### PR TITLE
[authorization] add config model fragments and relationships

### DIFF
--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -208,7 +208,7 @@ authorization:
 
 `authorization.policies` configures shared subject access policies. Each policy resolves a caller to exactly one role by matching canonical `subjectID` values such as `user:<id>` or `service_account:<id>`, then applies a `default` fallback (`allow` or `deny`) when no member matches. Plugins opt into a policy explicitly through `authorizationPolicy`.
 
-`authorization.models` defines deployment-owned authorization model fragments as generic resource types, relations, actions, rewrites, and allowed targets. `authorization.relationships` defines static relationship tuples against those resource types. These fields are parsed and validated alongside existing `authorization.policies`; provider reconciliation continues to consume the compatibility policy inputs until the authorization composer is enabled.
+`authorization.models` defines deployment-owned authorization model fragments as generic resource types, relations, actions, and allowed targets. `authorization.relationships` defines static relationship tuples against those resource types. These fields are parsed and validated alongside existing `authorization.policies`; provider reconciliation consumes both the compatibility policy inputs and the generic model fragments when the authorization composer is enabled.
 
 ```yaml
 authorization:
@@ -219,8 +219,6 @@ authorization:
           relations:
             member:
               subjectTypes: [subject]
-              rewrite:
-                this: {}
             admin:
               subjectTypes: [subject]
           actions:
@@ -295,7 +293,7 @@ Plugins without `authorizationPolicy` are open to any authenticated subject. Bin
 | `admin.allowedRoles` | `[admin]` | Roles allowed to load the built-in `/admin` route when `admin.authorizationPolicy` is set. |
 | `admin.ui` | | Optional named `providers.ui` bundle whose `admin/` assets should back `/admin`. When omitted, Gestalt auto-discovers `admin/` assets from the root UI bundle before using the built-in fallback. |
 | `authorization.policies` | | Shared subject access policies resolved by canonical `subjectID`. |
-| `authorization.models` | | Static authorization model fragments keyed by model name. Each fragment defines `resourceTypes`, relation `subjectTypes` or `allowedTargets`, actions, and optional rewrites. |
+| `authorization.models` | | Static authorization model fragments keyed by model name. Each fragment defines `resourceTypes`, relation `subjectTypes` or `allowedTargets`, and actions. |
 | `authorization.relationships` | | Static relationship tuples with `subject`, `relation`, and `resource` fields. |
 | `authorization.resourceTypes.<type>.dynamic.allowAdditionalRelationships` | `false` | Allows later dynamic source state to add relationship tuples for a static resource type. Dynamic override/removal of static relationships is not supported. |
 

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -208,6 +208,67 @@ authorization:
 
 `authorization.policies` configures shared subject access policies. Each policy resolves a caller to exactly one role by matching canonical `subjectID` values such as `user:<id>` or `service_account:<id>`, then applies a `default` fallback (`allow` or `deny`) when no member matches. Plugins opt into a policy explicitly through `authorizationPolicy`.
 
+`authorization.models` defines deployment-owned authorization model fragments as generic resource types, relations, actions, rewrites, and allowed targets. `authorization.relationships` defines static relationship tuples against those resource types. These fields are parsed and validated alongside existing `authorization.policies`; provider reconciliation continues to consume the compatibility policy inputs until the authorization composer is enabled.
+
+```yaml
+authorization:
+  models:
+    default:
+      resourceTypes:
+        team:
+          relations:
+            member:
+              subjectTypes: [subject]
+              rewrite:
+                this: {}
+            admin:
+              subjectTypes: [subject]
+          actions:
+            view:
+              relations: [member, admin]
+            manage:
+              relations: [admin]
+          dynamic:
+            allowAdditionalRelationships: true
+        managed_subject:
+          relations:
+            viewer:
+              subjectTypes: [subject]
+            editor:
+              subjectTypes: [subject]
+            admin:
+              subjectTypes: [subject]
+          actions:
+            view:
+              relations: [viewer, editor, admin]
+            manage:
+              relations: [admin]
+        plugin/github/repository:
+          relations:
+            reader:
+              allowedTargets:
+                - subjectType: subject
+            maintainer:
+              allowedTargets:
+                - subjectType: subject
+          actions:
+            read:
+              relations: [reader, maintainer]
+            administer:
+              relations: [maintainer]
+  relationships:
+    - subject:
+        type: subject
+        id: user:alice
+      relation: admin
+      resource:
+        type: team
+        id: servicing
+      source:
+        layer: static_config
+        id: authorization.relationships[0]
+```
+
 Dynamic grants are plugin-scoped, not policy-scoped. When a plugin sets `authorizationPolicy`, built-in Gestalt admins can manage additional dynamic members from the admin UI at `/admin/?tab=members`, and callers with role `admin` on a specific plugin can manage dynamic members for that plugin through `/admin/api/v1/authorization/plugins/{plugin}/members` or `gestalt authorization plugins members ...`. Static policy members always win over dynamic grants, and Gestalt rejects dynamic writes for subjects that already have static authorization on that plugin. The `email` write field is a user-only convenience alias; `subjectId` accepts any canonical non-system subject ID, such as `user:<id>`, `service_account:<id>`, or another deployment-defined subject kind.
 
 Non-human callers are modeled as [service account subjects](/service-accounts), typically `service_account:<id>`. Grant plugin access with `authorization.policies` or provider-backed dynamic memberships using the canonical subject ID, and store third-party credentials through the configured external credentials provider under the same subject ID.
@@ -234,6 +295,9 @@ Plugins without `authorizationPolicy` are open to any authenticated subject. Bin
 | `admin.allowedRoles` | `[admin]` | Roles allowed to load the built-in `/admin` route when `admin.authorizationPolicy` is set. |
 | `admin.ui` | | Optional named `providers.ui` bundle whose `admin/` assets should back `/admin`. When omitted, Gestalt auto-discovers `admin/` assets from the root UI bundle before using the built-in fallback. |
 | `authorization.policies` | | Shared subject access policies resolved by canonical `subjectID`. |
+| `authorization.models` | | Static authorization model fragments keyed by model name. Each fragment defines `resourceTypes`, relation `subjectTypes` or `allowedTargets`, actions, and optional rewrites. |
+| `authorization.relationships` | | Static relationship tuples with `subject`, `relation`, and `resource` fields. |
+| `authorization.resourceTypes.<type>.dynamic.allowAdditionalRelationships` | `false` | Allows later dynamic source state to add relationship tuples for a static resource type. Dynamic override/removal of static relationships is not supported. |
 
 When `server.management` is configured, Gestalt serves `/`, `/api/v1/*`, auth routes, and `/mcp` on the public listener, while `/admin`, `/admin/api/v1/*`, `/metrics`, `/health`, and `/ready` move to the management listener. The management listener can also serve token-authenticated hosted-runtime host-service relay and egress proxy callbacks when `server.runtime.relayBaseUrl` points at that origin.
 

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1896,8 +1896,7 @@ type AuthorizationResourcePolicyDef struct {
 }
 
 type AuthorizationResourceDynamicPolicyDef struct {
-	AllowAdditionalRelationships     bool `yaml:"allowAdditionalRelationships,omitempty"`
-	AllowStaticRelationshipOverrides bool `yaml:"allowStaticRelationshipOverrides,omitempty"`
+	AllowAdditionalRelationships bool `yaml:"allowAdditionalRelationships,omitempty"`
 }
 
 type ListenerConfig struct {
@@ -3830,8 +3829,10 @@ func normalizedAuthorizationRelationshipTargetDef(def AuthorizationRelationshipT
 		def.Resource = &resource
 	}
 	if def.SubjectSet != nil {
-		def.SubjectSet.Resource = normalizedAuthorizationResourceDef(def.SubjectSet.Resource)
-		def.SubjectSet.Relation = strings.TrimSpace(def.SubjectSet.Relation)
+		subjectSet := *def.SubjectSet
+		subjectSet.Resource = normalizedAuthorizationResourceDef(subjectSet.Resource)
+		subjectSet.Relation = strings.TrimSpace(subjectSet.Relation)
+		def.SubjectSet = &subjectSet
 	}
 	return def
 }

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1802,7 +1802,10 @@ type EgressConfig struct {
 }
 
 type AuthorizationConfig struct {
-	Policies map[string]SubjectPolicyDef `yaml:"policies,omitempty"`
+	Policies      map[string]SubjectPolicyDef               `yaml:"policies,omitempty"`
+	Models        map[string]AuthorizationModelDef          `yaml:"models,omitempty"`
+	Relationships []AuthorizationRelationshipDef            `yaml:"relationships,omitempty"`
+	ResourceTypes map[string]AuthorizationResourcePolicyDef `yaml:"resourceTypes,omitempty"`
 }
 
 type SubjectPolicyDef struct {
@@ -1813,6 +1816,108 @@ type SubjectPolicyDef struct {
 type SubjectPolicyMemberDef struct {
 	SubjectID string `yaml:"subjectID,omitempty"`
 	Role      string `yaml:"role"`
+}
+
+type AuthorizationModelDef struct {
+	ResourceTypes map[string]AuthorizationResourceTypeDef `yaml:"resourceTypes,omitempty"`
+	Source        AuthorizationSourceMetadataDef          `yaml:"source,omitempty"`
+}
+
+type AuthorizationResourceTypeDef struct {
+	Relations map[string]AuthorizationRelationDef   `yaml:"relations,omitempty"`
+	Actions   map[string]AuthorizationActionDef     `yaml:"actions,omitempty"`
+	Dynamic   AuthorizationResourceDynamicPolicyDef `yaml:"dynamic,omitempty"`
+	Source    AuthorizationSourceMetadataDef        `yaml:"source,omitempty"`
+}
+
+type AuthorizationRelationDef struct {
+	SubjectTypes   []string                        `yaml:"subjectTypes,omitempty"`
+	AllowedTargets []AuthorizationAllowedTargetDef `yaml:"allowedTargets,omitempty"`
+	Rewrite        *AuthorizationRewriteDef        `yaml:"rewrite,omitempty"`
+	Source         AuthorizationSourceMetadataDef  `yaml:"source,omitempty"`
+}
+
+type AuthorizationActionDef struct {
+	Relations []string                       `yaml:"relations,omitempty"`
+	Rewrite   *AuthorizationRewriteDef       `yaml:"rewrite,omitempty"`
+	Source    AuthorizationSourceMetadataDef `yaml:"source,omitempty"`
+}
+
+type AuthorizationAllowedTargetDef struct {
+	SubjectType  string                            `yaml:"subjectType,omitempty"`
+	ResourceType string                            `yaml:"resourceType,omitempty"`
+	SubjectSet   *AuthorizationSubjectSetTargetDef `yaml:"subjectSet,omitempty"`
+}
+
+type AuthorizationSubjectSetTargetDef struct {
+	ResourceType string `yaml:"resourceType,omitempty"`
+	Relation     string `yaml:"relation,omitempty"`
+}
+
+type AuthorizationRewriteDef struct {
+	This            *AuthorizationRewriteThisDef     `yaml:"this,omitempty"`
+	ComputedUserset *AuthorizationComputedUsersetDef `yaml:"computedUserset,omitempty"`
+	TupleToUserset  *AuthorizationTupleToUsersetDef  `yaml:"tupleToUserset,omitempty"`
+	Union           []AuthorizationRewriteDef        `yaml:"union,omitempty"`
+}
+
+type AuthorizationRewriteThisDef struct{}
+
+type AuthorizationComputedUsersetDef struct {
+	Relation string `yaml:"relation,omitempty"`
+}
+
+type AuthorizationTupleToUsersetDef struct {
+	TuplesetRelation string `yaml:"tuplesetRelation,omitempty"`
+	ComputedRelation string `yaml:"computedRelation,omitempty"`
+}
+
+type AuthorizationRelationshipDef struct {
+	Subject    AuthorizationSubjectDef            `yaml:"subject,omitempty"`
+	Target     AuthorizationRelationshipTargetDef `yaml:"target,omitempty"`
+	Relation   string                             `yaml:"relation,omitempty"`
+	Resource   AuthorizationResourceDef           `yaml:"resource,omitempty"`
+	Source     AuthorizationSourceMetadataDef     `yaml:"source,omitempty"`
+	Properties map[string]string                  `yaml:"properties,omitempty"`
+}
+
+type AuthorizationSubjectDef struct {
+	Type       string            `yaml:"type,omitempty"`
+	ID         string            `yaml:"id,omitempty"`
+	Properties map[string]string `yaml:"properties,omitempty"`
+}
+
+type AuthorizationResourceDef struct {
+	Type       string            `yaml:"type,omitempty"`
+	ID         string            `yaml:"id,omitempty"`
+	Properties map[string]string `yaml:"properties,omitempty"`
+}
+
+type AuthorizationRelationshipTargetDef struct {
+	Subject    *AuthorizationSubjectDef    `yaml:"subject,omitempty"`
+	Resource   *AuthorizationResourceDef   `yaml:"resource,omitempty"`
+	SubjectSet *AuthorizationSubjectSetDef `yaml:"subjectSet,omitempty"`
+}
+
+type AuthorizationSubjectSetDef struct {
+	Resource AuthorizationResourceDef `yaml:"resource,omitempty"`
+	Relation string                   `yaml:"relation,omitempty"`
+}
+
+type AuthorizationSourceMetadataDef struct {
+	Layer     string `yaml:"layer,omitempty"`
+	ID        string `yaml:"id,omitempty"`
+	OwnerKind string `yaml:"ownerKind,omitempty"`
+	OwnerID   string `yaml:"ownerId,omitempty"`
+}
+
+type AuthorizationResourcePolicyDef struct {
+	Dynamic AuthorizationResourceDynamicPolicyDef `yaml:"dynamic,omitempty"`
+}
+
+type AuthorizationResourceDynamicPolicyDef struct {
+	AllowAdditionalRelationships     bool `yaml:"allowAdditionalRelationships,omitempty"`
+	AllowStaticRelationshipOverrides bool `yaml:"allowStaticRelationshipOverrides,omitempty"`
 }
 
 type ListenerConfig struct {
@@ -3602,7 +3707,194 @@ func normalizedAuthorizationConfig(cfg AuthorizationConfig) AuthorizationConfig 
 		}
 		cfg.Policies = policies
 	}
+	if len(cfg.Models) == 0 {
+		cfg.Models = nil
+	} else {
+		models := make(map[string]AuthorizationModelDef, len(cfg.Models))
+		for name, model := range cfg.Models {
+			models[name] = normalizedAuthorizationModelDef(model)
+		}
+		cfg.Models = models
+	}
+	if len(cfg.Relationships) == 0 {
+		cfg.Relationships = nil
+	} else {
+		for i := range cfg.Relationships {
+			cfg.Relationships[i] = normalizedAuthorizationRelationshipDef(cfg.Relationships[i])
+		}
+	}
+	if len(cfg.ResourceTypes) == 0 {
+		cfg.ResourceTypes = nil
+	} else {
+		resourceTypes := make(map[string]AuthorizationResourcePolicyDef, len(cfg.ResourceTypes))
+		for name, policy := range cfg.ResourceTypes {
+			resourceTypes[name] = policy
+		}
+		cfg.ResourceTypes = resourceTypes
+	}
 	return cfg
+}
+
+func normalizedAuthorizationModelDef(def AuthorizationModelDef) AuthorizationModelDef {
+	def.Source = normalizedAuthorizationSourceMetadataDef(def.Source)
+	if len(def.ResourceTypes) == 0 {
+		def.ResourceTypes = nil
+		return def
+	}
+	resourceTypes := make(map[string]AuthorizationResourceTypeDef, len(def.ResourceTypes))
+	for name, resourceType := range def.ResourceTypes {
+		resourceTypes[name] = normalizedAuthorizationResourceTypeDef(resourceType)
+	}
+	def.ResourceTypes = resourceTypes
+	return def
+}
+
+func normalizedAuthorizationResourceTypeDef(def AuthorizationResourceTypeDef) AuthorizationResourceTypeDef {
+	def.Source = normalizedAuthorizationSourceMetadataDef(def.Source)
+	if len(def.Relations) == 0 {
+		def.Relations = nil
+	} else {
+		relations := make(map[string]AuthorizationRelationDef, len(def.Relations))
+		for name, relation := range def.Relations {
+			relations[name] = normalizedAuthorizationRelationDef(relation)
+		}
+		def.Relations = relations
+	}
+	if len(def.Actions) == 0 {
+		def.Actions = nil
+	} else {
+		actions := make(map[string]AuthorizationActionDef, len(def.Actions))
+		for name, action := range def.Actions {
+			actions[name] = normalizedAuthorizationActionDef(action)
+		}
+		def.Actions = actions
+	}
+	return def
+}
+
+func normalizedAuthorizationRelationDef(def AuthorizationRelationDef) AuthorizationRelationDef {
+	def.SubjectTypes = trimAuthorizationStringSlice(def.SubjectTypes)
+	for i := range def.AllowedTargets {
+		def.AllowedTargets[i].SubjectType = strings.TrimSpace(def.AllowedTargets[i].SubjectType)
+		def.AllowedTargets[i].ResourceType = strings.TrimSpace(def.AllowedTargets[i].ResourceType)
+		if def.AllowedTargets[i].SubjectSet != nil {
+			def.AllowedTargets[i].SubjectSet.ResourceType = strings.TrimSpace(def.AllowedTargets[i].SubjectSet.ResourceType)
+			def.AllowedTargets[i].SubjectSet.Relation = strings.TrimSpace(def.AllowedTargets[i].SubjectSet.Relation)
+		}
+	}
+	def.Rewrite = normalizedAuthorizationRewriteDef(def.Rewrite)
+	def.Source = normalizedAuthorizationSourceMetadataDef(def.Source)
+	return def
+}
+
+func normalizedAuthorizationActionDef(def AuthorizationActionDef) AuthorizationActionDef {
+	def.Relations = trimAuthorizationStringSlice(def.Relations)
+	def.Rewrite = normalizedAuthorizationRewriteDef(def.Rewrite)
+	def.Source = normalizedAuthorizationSourceMetadataDef(def.Source)
+	return def
+}
+
+func normalizedAuthorizationRewriteDef(def *AuthorizationRewriteDef) *AuthorizationRewriteDef {
+	if def == nil {
+		return nil
+	}
+	if def.ComputedUserset != nil {
+		def.ComputedUserset.Relation = strings.TrimSpace(def.ComputedUserset.Relation)
+	}
+	if def.TupleToUserset != nil {
+		def.TupleToUserset.TuplesetRelation = strings.TrimSpace(def.TupleToUserset.TuplesetRelation)
+		def.TupleToUserset.ComputedRelation = strings.TrimSpace(def.TupleToUserset.ComputedRelation)
+	}
+	for i := range def.Union {
+		child := normalizedAuthorizationRewriteDef(&def.Union[i])
+		if child != nil {
+			def.Union[i] = *child
+		}
+	}
+	return def
+}
+
+func normalizedAuthorizationRelationshipDef(def AuthorizationRelationshipDef) AuthorizationRelationshipDef {
+	def.Subject = normalizedAuthorizationSubjectDef(def.Subject)
+	def.Relation = strings.TrimSpace(def.Relation)
+	def.Resource = normalizedAuthorizationResourceDef(def.Resource)
+	def.Target = normalizedAuthorizationRelationshipTargetDef(def.Target)
+	def.Source = normalizedAuthorizationSourceMetadataDef(def.Source)
+	if len(def.Properties) == 0 {
+		def.Properties = nil
+	} else {
+		properties := make(map[string]string, len(def.Properties))
+		for key, value := range def.Properties {
+			properties[strings.TrimSpace(key)] = strings.TrimSpace(value)
+		}
+		def.Properties = properties
+	}
+	return def
+}
+
+func normalizedAuthorizationSubjectDef(def AuthorizationSubjectDef) AuthorizationSubjectDef {
+	def.Type = strings.TrimSpace(def.Type)
+	def.ID = strings.TrimSpace(def.ID)
+	if len(def.Properties) == 0 {
+		def.Properties = nil
+	} else {
+		properties := make(map[string]string, len(def.Properties))
+		for key, value := range def.Properties {
+			properties[strings.TrimSpace(key)] = strings.TrimSpace(value)
+		}
+		def.Properties = properties
+	}
+	return def
+}
+
+func normalizedAuthorizationResourceDef(def AuthorizationResourceDef) AuthorizationResourceDef {
+	def.Type = strings.TrimSpace(def.Type)
+	def.ID = strings.TrimSpace(def.ID)
+	if len(def.Properties) == 0 {
+		def.Properties = nil
+	} else {
+		properties := make(map[string]string, len(def.Properties))
+		for key, value := range def.Properties {
+			properties[strings.TrimSpace(key)] = strings.TrimSpace(value)
+		}
+		def.Properties = properties
+	}
+	return def
+}
+
+func normalizedAuthorizationRelationshipTargetDef(def AuthorizationRelationshipTargetDef) AuthorizationRelationshipTargetDef {
+	if def.Subject != nil {
+		subject := normalizedAuthorizationSubjectDef(*def.Subject)
+		def.Subject = &subject
+	}
+	if def.Resource != nil {
+		resource := normalizedAuthorizationResourceDef(*def.Resource)
+		def.Resource = &resource
+	}
+	if def.SubjectSet != nil {
+		def.SubjectSet.Resource = normalizedAuthorizationResourceDef(def.SubjectSet.Resource)
+		def.SubjectSet.Relation = strings.TrimSpace(def.SubjectSet.Relation)
+	}
+	return def
+}
+
+func normalizedAuthorizationSourceMetadataDef(def AuthorizationSourceMetadataDef) AuthorizationSourceMetadataDef {
+	def.Layer = strings.TrimSpace(def.Layer)
+	def.ID = strings.TrimSpace(def.ID)
+	def.OwnerKind = strings.TrimSpace(def.OwnerKind)
+	def.OwnerID = strings.TrimSpace(def.OwnerID)
+	return def
+}
+
+func trimAuthorizationStringSlice(values []string) []string {
+	if values == nil {
+		return nil
+	}
+	out := make([]string, len(values))
+	for i, value := range values {
+		out[i] = strings.TrimSpace(value)
+	}
+	return out
 }
 
 func normalizeAdminConfig(cfg *Config) error {

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1833,13 +1833,11 @@ type AuthorizationResourceTypeDef struct {
 type AuthorizationRelationDef struct {
 	SubjectTypes   []string                        `yaml:"subjectTypes,omitempty"`
 	AllowedTargets []AuthorizationAllowedTargetDef `yaml:"allowedTargets,omitempty"`
-	Rewrite        *AuthorizationRewriteDef        `yaml:"rewrite,omitempty"`
 	Source         AuthorizationSourceMetadataDef  `yaml:"source,omitempty"`
 }
 
 type AuthorizationActionDef struct {
 	Relations []string                       `yaml:"relations,omitempty"`
-	Rewrite   *AuthorizationRewriteDef       `yaml:"rewrite,omitempty"`
 	Source    AuthorizationSourceMetadataDef `yaml:"source,omitempty"`
 }
 
@@ -1852,24 +1850,6 @@ type AuthorizationAllowedTargetDef struct {
 type AuthorizationSubjectSetTargetDef struct {
 	ResourceType string `yaml:"resourceType,omitempty"`
 	Relation     string `yaml:"relation,omitempty"`
-}
-
-type AuthorizationRewriteDef struct {
-	This            *AuthorizationRewriteThisDef     `yaml:"this,omitempty"`
-	ComputedUserset *AuthorizationComputedUsersetDef `yaml:"computedUserset,omitempty"`
-	TupleToUserset  *AuthorizationTupleToUsersetDef  `yaml:"tupleToUserset,omitempty"`
-	Union           []AuthorizationRewriteDef        `yaml:"union,omitempty"`
-}
-
-type AuthorizationRewriteThisDef struct{}
-
-type AuthorizationComputedUsersetDef struct {
-	Relation string `yaml:"relation,omitempty"`
-}
-
-type AuthorizationTupleToUsersetDef struct {
-	TuplesetRelation string `yaml:"tuplesetRelation,omitempty"`
-	ComputedRelation string `yaml:"computedRelation,omitempty"`
 }
 
 type AuthorizationRelationshipDef struct {
@@ -3782,35 +3762,13 @@ func normalizedAuthorizationRelationDef(def AuthorizationRelationDef) Authorizat
 			def.AllowedTargets[i].SubjectSet.Relation = strings.TrimSpace(def.AllowedTargets[i].SubjectSet.Relation)
 		}
 	}
-	def.Rewrite = normalizedAuthorizationRewriteDef(def.Rewrite)
 	def.Source = normalizedAuthorizationSourceMetadataDef(def.Source)
 	return def
 }
 
 func normalizedAuthorizationActionDef(def AuthorizationActionDef) AuthorizationActionDef {
 	def.Relations = trimAuthorizationStringSlice(def.Relations)
-	def.Rewrite = normalizedAuthorizationRewriteDef(def.Rewrite)
 	def.Source = normalizedAuthorizationSourceMetadataDef(def.Source)
-	return def
-}
-
-func normalizedAuthorizationRewriteDef(def *AuthorizationRewriteDef) *AuthorizationRewriteDef {
-	if def == nil {
-		return nil
-	}
-	if def.ComputedUserset != nil {
-		def.ComputedUserset.Relation = strings.TrimSpace(def.ComputedUserset.Relation)
-	}
-	if def.TupleToUserset != nil {
-		def.TupleToUserset.TuplesetRelation = strings.TrimSpace(def.TupleToUserset.TuplesetRelation)
-		def.TupleToUserset.ComputedRelation = strings.TrimSpace(def.TupleToUserset.ComputedRelation)
-	}
-	for i := range def.Union {
-		child := normalizedAuthorizationRewriteDef(&def.Union[i])
-		if child != nil {
-			def.Union[i] = *child
-		}
-	}
 	return def
 }
 

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -945,8 +945,6 @@ authorization:
           relations:
             member:
               subjectTypes: [subject]
-              rewrite:
-                this: {}
             admin:
               subjectTypes: [subject]
           actions:
@@ -1017,7 +1015,6 @@ func TestValidateAuthorizationModelFragments(t *testing.T) {
 	model := func(resourceTypes map[string]AuthorizationResourceTypeDef) AuthorizationModelDef {
 		return AuthorizationModelDef{ResourceTypes: resourceTypes}
 	}
-
 	tests := []struct {
 		name    string
 		authz   AuthorizationConfig
@@ -1055,21 +1052,6 @@ func TestValidateAuthorizationModelFragments(t *testing.T) {
 				}),
 			}},
 			wantErr: `authorization.models key " default " must not have surrounding whitespace`,
-		},
-		{
-			name: "invalid rewrite relation",
-			authz: AuthorizationConfig{Models: map[string]AuthorizationModelDef{
-				"default": model(map[string]AuthorizationResourceTypeDef{
-					"team": resourceType(
-						map[string]AuthorizationRelationDef{"member": {
-							SubjectTypes: []string{"subject"},
-							Rewrite:      &AuthorizationRewriteDef{ComputedUserset: &AuthorizationComputedUsersetDef{Relation: "admin"}},
-						}},
-						nil,
-					),
-				}),
-			}},
-			wantErr: `computedUserset.relation references unknown relation "admin"`,
 		},
 		{
 			name: "invalid allowed target resource type",

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -1083,6 +1083,25 @@ func TestValidateAuthorizationModelFragments(t *testing.T) {
 			wantErr: `resource.type references unknown resource type "missing"`,
 		},
 		{
+			name: "malformed relationship subject set target relation",
+			authz: AuthorizationConfig{
+				Models: map[string]AuthorizationModelDef{
+					"default": model(map[string]AuthorizationResourceTypeDef{
+						"team": resourceType(map[string]AuthorizationRelationDef{"member": subjectRelation("subject")}, nil),
+					}),
+				},
+				Relationships: []AuthorizationRelationshipDef{{
+					Subject:  AuthorizationSubjectDef{Type: "subject", ID: "user:alice"},
+					Relation: "member",
+					Resource: AuthorizationResourceDef{Type: "team", ID: "servicing"},
+					Target: AuthorizationRelationshipTargetDef{SubjectSet: &AuthorizationSubjectSetDef{
+						Resource: AuthorizationResourceDef{Type: "team", ID: "servicing"},
+					}},
+				}},
+			},
+			wantErr: `target.subjectSet.relation is required`,
+		},
+		{
 			name: "relationship without model resource type",
 			authz: AuthorizationConfig{
 				Relationships: []AuthorizationRelationshipDef{{

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -1038,7 +1038,7 @@ func TestValidateAuthorizationModelFragments(t *testing.T) {
 				"default": model(map[string]AuthorizationResourceTypeDef{
 					"team": resourceType(
 						map[string]AuthorizationRelationDef{"member": subjectRelation("subject")},
-						map[string]AuthorizationActionDef{"manage": AuthorizationActionDef{Relations: []string{"admin"}}},
+						map[string]AuthorizationActionDef{"manage": {Relations: []string{"admin"}}},
 					),
 				}),
 			}},
@@ -1065,6 +1065,37 @@ func TestValidateAuthorizationModelFragments(t *testing.T) {
 				}),
 			}},
 			wantErr: `allowedTargets[0].resourceType references unknown resource type "missing"`,
+		},
+		{
+			name: "invalid allowed subject set relation",
+			authz: AuthorizationConfig{Models: map[string]AuthorizationModelDef{
+				"default": model(map[string]AuthorizationResourceTypeDef{
+					"team": resourceType(map[string]AuthorizationRelationDef{
+						"member": subjectRelation("subject"),
+						"parent": {
+							AllowedTargets: []AuthorizationAllowedTargetDef{{SubjectSet: &AuthorizationSubjectSetTargetDef{
+								ResourceType: "team",
+								Relation:     "missing",
+							}}},
+						},
+					}, nil),
+				}),
+			}},
+			wantErr: `allowedTargets[0].subjectSet.relation references unknown relation "missing"`,
+		},
+		{
+			name: "unknown dynamic resource policy type",
+			authz: AuthorizationConfig{
+				Models: map[string]AuthorizationModelDef{
+					"default": model(map[string]AuthorizationResourceTypeDef{
+						"team": resourceType(map[string]AuthorizationRelationDef{"admin": subjectRelation("subject")}, nil),
+					}),
+				},
+				ResourceTypes: map[string]AuthorizationResourcePolicyDef{
+					"missing": {Dynamic: AuthorizationResourceDynamicPolicyDef{AllowAdditionalRelationships: true}},
+				},
+			},
+			wantErr: `authorization.resourceTypes.missing references unknown resource type "missing"`,
 		},
 		{
 			name: "malformed relationship resource",
@@ -1112,13 +1143,6 @@ func TestValidateAuthorizationModelFragments(t *testing.T) {
 			},
 			wantErr: `resource.type references unknown resource type "team"`,
 		},
-		{
-			name: "unsupported static override flag",
-			authz: AuthorizationConfig{ResourceTypes: map[string]AuthorizationResourcePolicyDef{
-				"team": {Dynamic: AuthorizationResourceDynamicPolicyDef{AllowStaticRelationshipOverrides: true}},
-			}},
-			wantErr: "allowStaticRelationshipOverrides is not supported",
-		},
 	}
 
 	for _, tc := range tests {
@@ -1134,6 +1158,36 @@ func TestValidateAuthorizationModelFragments(t *testing.T) {
 				t.Fatalf("ValidateStructure error = %v, want substring %q", err, tc.wantErr)
 			}
 		})
+	}
+}
+
+func TestNormalizedAuthorizationRelationshipTargetDefCopiesSubjectSet(t *testing.T) {
+	t.Parallel()
+
+	subjectSet := &AuthorizationSubjectSetDef{
+		Resource: AuthorizationResourceDef{
+			Type:       " team ",
+			ID:         " servicing ",
+			Properties: map[string]string{" role ": " owner "},
+		},
+		Relation: " member ",
+	}
+
+	normalized := normalizedAuthorizationRelationshipTargetDef(AuthorizationRelationshipTargetDef{
+		SubjectSet: subjectSet,
+	})
+
+	if normalized.SubjectSet == subjectSet {
+		t.Fatal("normalized subject set reused original pointer")
+	}
+	if subjectSet.Resource.Type != " team " || subjectSet.Resource.ID != " servicing " || subjectSet.Relation != " member " {
+		t.Fatalf("original subject set mutated: %#v", subjectSet)
+	}
+	if normalized.SubjectSet.Resource.Type != "team" ||
+		normalized.SubjectSet.Resource.ID != "servicing" ||
+		normalized.SubjectSet.Resource.Properties["role"] != "owner" ||
+		normalized.SubjectSet.Relation != "member" {
+		t.Fatalf("normalized subject set = %#v", normalized.SubjectSet)
 	}
 }
 

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -927,6 +927,215 @@ func TestValidateStructureRejectsDuplicateAuthorizationPolicyMembers(t *testing.
 	}
 }
 
+func TestLoadAuthorizationModelFragments(t *testing.T) {
+	t.Parallel()
+
+	path := mustWriteConfigFile(t, `
+authorization:
+  policies:
+    legacy_admins:
+      default: deny
+      members:
+        - subjectID: user:legacy
+          role: admin
+  models:
+    default:
+      resourceTypes:
+        team:
+          relations:
+            member:
+              subjectTypes: [subject]
+              rewrite:
+                this: {}
+            admin:
+              subjectTypes: [subject]
+          actions:
+            view:
+              relations: [member, admin]
+            manage:
+              relations: [admin]
+          dynamic:
+            allowAdditionalRelationships: true
+        plugin/github/repository:
+          relations:
+            maintainer:
+              allowedTargets:
+                - subjectType: subject
+          actions:
+            administer:
+              relations: [maintainer]
+  resourceTypes:
+    team:
+      dynamic:
+        allowAdditionalRelationships: true
+  relationships:
+    - subject:
+        type: subject
+        id: user:alice
+      relation: admin
+      resource:
+        type: team
+        id: servicing
+      source:
+        layer: static_config
+        id: authorization.relationships[0]
+`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := cfg.Authorization.Policies["legacy_admins"].Members[0].SubjectID; got != "user:legacy" {
+		t.Fatalf("legacy policy subjectID = %q, want user:legacy", got)
+	}
+	team := cfg.Authorization.Models["default"].ResourceTypes["team"]
+	if !team.Dynamic.AllowAdditionalRelationships {
+		t.Fatal("team dynamic allowAdditionalRelationships = false, want true")
+	}
+	if got := team.Actions["view"].Relations; !reflect.DeepEqual(got, []string{"member", "admin"}) {
+		t.Fatalf("team view relations = %#v, want member/admin", got)
+	}
+	repository := cfg.Authorization.Models["default"].ResourceTypes["plugin/github/repository"]
+	if got := repository.Relations["maintainer"].AllowedTargets[0].SubjectType; got != "subject" {
+		t.Fatalf("repository maintainer allowed target = %q, want subject", got)
+	}
+	relationship := cfg.Authorization.Relationships[0]
+	if relationship.Subject.ID != "user:alice" || relationship.Resource.Type != "team" || relationship.Relation != "admin" {
+		t.Fatalf("relationship parsed as %#v", relationship)
+	}
+}
+
+func TestValidateAuthorizationModelFragments(t *testing.T) {
+	t.Parallel()
+
+	subjectRelation := func(subjectTypes ...string) AuthorizationRelationDef {
+		return AuthorizationRelationDef{SubjectTypes: subjectTypes}
+	}
+	resourceType := func(relations map[string]AuthorizationRelationDef, actions map[string]AuthorizationActionDef) AuthorizationResourceTypeDef {
+		return AuthorizationResourceTypeDef{Relations: relations, Actions: actions}
+	}
+	model := func(resourceTypes map[string]AuthorizationResourceTypeDef) AuthorizationModelDef {
+		return AuthorizationModelDef{ResourceTypes: resourceTypes}
+	}
+
+	tests := []struct {
+		name    string
+		authz   AuthorizationConfig
+		wantErr string
+	}{
+		{
+			name: "duplicate resource type across models",
+			authz: AuthorizationConfig{Models: map[string]AuthorizationModelDef{
+				"base": model(map[string]AuthorizationResourceTypeDef{
+					"team": resourceType(map[string]AuthorizationRelationDef{"member": subjectRelation("subject")}, nil),
+				}),
+				"extra": model(map[string]AuthorizationResourceTypeDef{
+					"team": resourceType(map[string]AuthorizationRelationDef{"admin": subjectRelation("subject")}, nil),
+				}),
+			}},
+			wantErr: "duplicates resource type",
+		},
+		{
+			name: "unknown action relation",
+			authz: AuthorizationConfig{Models: map[string]AuthorizationModelDef{
+				"default": model(map[string]AuthorizationResourceTypeDef{
+					"team": resourceType(
+						map[string]AuthorizationRelationDef{"member": subjectRelation("subject")},
+						map[string]AuthorizationActionDef{"manage": AuthorizationActionDef{Relations: []string{"admin"}}},
+					),
+				}),
+			}},
+			wantErr: `references unknown relation "admin"`,
+		},
+		{
+			name: "model key has surrounding whitespace",
+			authz: AuthorizationConfig{Models: map[string]AuthorizationModelDef{
+				" default ": model(map[string]AuthorizationResourceTypeDef{
+					"team": resourceType(map[string]AuthorizationRelationDef{"member": subjectRelation("subject")}, nil),
+				}),
+			}},
+			wantErr: `authorization.models key " default " must not have surrounding whitespace`,
+		},
+		{
+			name: "invalid rewrite relation",
+			authz: AuthorizationConfig{Models: map[string]AuthorizationModelDef{
+				"default": model(map[string]AuthorizationResourceTypeDef{
+					"team": resourceType(
+						map[string]AuthorizationRelationDef{"member": {
+							SubjectTypes: []string{"subject"},
+							Rewrite:      &AuthorizationRewriteDef{ComputedUserset: &AuthorizationComputedUsersetDef{Relation: "admin"}},
+						}},
+						nil,
+					),
+				}),
+			}},
+			wantErr: `computedUserset.relation references unknown relation "admin"`,
+		},
+		{
+			name: "invalid allowed target resource type",
+			authz: AuthorizationConfig{Models: map[string]AuthorizationModelDef{
+				"default": model(map[string]AuthorizationResourceTypeDef{
+					"agent_session": resourceType(map[string]AuthorizationRelationDef{
+						"parent": {
+							AllowedTargets: []AuthorizationAllowedTargetDef{{ResourceType: "missing"}},
+						},
+					}, nil),
+				}),
+			}},
+			wantErr: `allowedTargets[0].resourceType references unknown resource type "missing"`,
+		},
+		{
+			name: "malformed relationship resource",
+			authz: AuthorizationConfig{
+				Models: map[string]AuthorizationModelDef{
+					"default": model(map[string]AuthorizationResourceTypeDef{
+						"team": resourceType(map[string]AuthorizationRelationDef{"admin": subjectRelation("subject")}, nil),
+					}),
+				},
+				Relationships: []AuthorizationRelationshipDef{{
+					Subject:  AuthorizationSubjectDef{Type: "subject", ID: "user:alice"},
+					Relation: "admin",
+					Resource: AuthorizationResourceDef{Type: "missing", ID: "servicing"},
+				}},
+			},
+			wantErr: `resource.type references unknown resource type "missing"`,
+		},
+		{
+			name: "relationship without model resource type",
+			authz: AuthorizationConfig{
+				Relationships: []AuthorizationRelationshipDef{{
+					Subject:  AuthorizationSubjectDef{Type: "subject", ID: "user:alice"},
+					Relation: "admin",
+					Resource: AuthorizationResourceDef{Type: "team", ID: "servicing"},
+				}},
+			},
+			wantErr: `resource.type references unknown resource type "team"`,
+		},
+		{
+			name: "unsupported static override flag",
+			authz: AuthorizationConfig{ResourceTypes: map[string]AuthorizationResourcePolicyDef{
+				"team": {Dynamic: AuthorizationResourceDynamicPolicyDef{AllowStaticRelationshipOverrides: true}},
+			}},
+			wantErr: "allowStaticRelationshipOverrides is not supported",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateStructure(&Config{
+				APIVersion:    ConfigAPIVersion,
+				Authorization: tc.authz,
+			})
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("ValidateStructure error = %v, want substring %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestExpandEnvVariablesPreservesMissingPlaceholder(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -1696,9 +1696,6 @@ func validateAuthorizationResourceTypeDef(path, name string, def AuthorizationRe
 				return err
 			}
 		}
-		if err := validateAuthorizationRewriteDef(relationPath+".rewrite", relation.Rewrite, def.Relations); err != nil {
-			return err
-		}
 		if err := validateAuthorizationSourceMetadata(relationPath+".source", relation.Source); err != nil {
 			return err
 		}
@@ -1711,16 +1708,13 @@ func validateAuthorizationResourceTypeDef(path, name string, def AuthorizationRe
 		if err := validateStringList(actionPath+".relations", action.Relations); err != nil {
 			return err
 		}
-		if len(action.Relations) == 0 && action.Rewrite == nil {
-			return fmt.Errorf("config validation: %s must set relations or rewrite", actionPath)
+		if len(action.Relations) == 0 {
+			return fmt.Errorf("config validation: %s.relations must contain at least one value", actionPath)
 		}
 		for _, relation := range action.Relations {
 			if _, ok := def.Relations[relation]; !ok {
 				return fmt.Errorf("config validation: %s.relations references unknown relation %q", actionPath, relation)
 			}
-		}
-		if err := validateAuthorizationRewriteDef(actionPath+".rewrite", action.Rewrite, def.Relations); err != nil {
-			return err
 		}
 		if err := validateAuthorizationSourceMetadata(actionPath+".source", action.Source); err != nil {
 			return err
@@ -1748,52 +1742,6 @@ func validateAuthorizationAllowedTargetDef(path string, target AuthorizationAllo
 	}
 	if set != 1 {
 		return fmt.Errorf("config validation: %s must set exactly one of subjectType, resourceType, or subjectSet", path)
-	}
-	return nil
-}
-
-func validateAuthorizationRewriteDef(path string, rewrite *AuthorizationRewriteDef, relations map[string]AuthorizationRelationDef) error {
-	if rewrite == nil {
-		return nil
-	}
-	set := 0
-	if rewrite.This != nil {
-		set++
-	}
-	if rewrite.ComputedUserset != nil {
-		set++
-		relation := strings.TrimSpace(rewrite.ComputedUserset.Relation)
-		if relation == "" {
-			return fmt.Errorf("config validation: %s.computedUserset.relation is required", path)
-		}
-		if _, ok := relations[relation]; !ok {
-			return fmt.Errorf("config validation: %s.computedUserset.relation references unknown relation %q", path, relation)
-		}
-	}
-	if rewrite.TupleToUserset != nil {
-		set++
-		tupleset := strings.TrimSpace(rewrite.TupleToUserset.TuplesetRelation)
-		computed := strings.TrimSpace(rewrite.TupleToUserset.ComputedRelation)
-		if tupleset == "" {
-			return fmt.Errorf("config validation: %s.tupleToUserset.tuplesetRelation is required", path)
-		}
-		if computed == "" {
-			return fmt.Errorf("config validation: %s.tupleToUserset.computedRelation is required", path)
-		}
-		if _, ok := relations[tupleset]; !ok {
-			return fmt.Errorf("config validation: %s.tupleToUserset.tuplesetRelation references unknown relation %q", path, tupleset)
-		}
-	}
-	if len(rewrite.Union) > 0 {
-		set++
-		for i := range rewrite.Union {
-			if err := validateAuthorizationRewriteDef(fmt.Sprintf("%s.union[%d]", path, i), &rewrite.Union[i], relations); err != nil {
-				return err
-			}
-		}
-	}
-	if set != 1 {
-		return fmt.Errorf("config validation: %s must set exactly one of this, computedUserset, tupleToUserset, or union", path)
 	}
 	return nil
 }

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -1610,7 +1610,7 @@ func validateAuthorizationModelConfig(cfg *Config) error {
 		}
 		for resourceTypeName, resourceType := range model.ResourceTypes {
 			resourcePath := fmt.Sprintf("authorization.models.%s.resourceTypes.%s", modelName, resourceTypeName)
-			if err := validateAuthorizationResourceTypeDef(resourcePath, resourceTypeName, resourceType); err != nil {
+			if err := validateAuthorizationResourceTypeDef(fmt.Sprintf("authorization.models.%s.resourceTypes", modelName), resourceTypeName, resourcePath, resourceType); err != nil {
 				return err
 			}
 			if prev, exists := definedResourceTypes[resourceTypeName]; exists {
@@ -1623,29 +1623,30 @@ func validateAuthorizationModelConfig(cfg *Config) error {
 	for modelName, model := range cfg.Authorization.Models {
 		for resourceTypeName, resourceType := range model.ResourceTypes {
 			resourcePath := fmt.Sprintf("authorization.models.%s.resourceTypes.%s", modelName, resourceTypeName)
-			if err := validateAuthorizationResourceTypeReferences(resourcePath, resourceType, definedResourceTypes); err != nil {
+			if err := validateAuthorizationResourceTypeReferences(resourcePath, resourceType, resourceTypeRelations); err != nil {
 				return err
 			}
 		}
 	}
-	for resourceTypeName, policy := range cfg.Authorization.ResourceTypes {
+	for resourceTypeName := range cfg.Authorization.ResourceTypes {
 		if err := validateAuthorizationMapKey("authorization.resourceTypes", resourceTypeName); err != nil {
 			return err
 		}
-		if policy.Dynamic.AllowStaticRelationshipOverrides {
-			return fmt.Errorf("config validation: authorization.resourceTypes.%s.dynamic.allowStaticRelationshipOverrides is not supported", resourceTypeName)
+		if _, ok := definedResourceTypes[resourceTypeName]; !ok {
+			return fmt.Errorf("config validation: authorization.resourceTypes.%s references unknown resource type %q", resourceTypeName, resourceTypeName)
 		}
 	}
-	for i, relationship := range cfg.Authorization.Relationships {
+	for i := range cfg.Authorization.Relationships {
+		relationship := &cfg.Authorization.Relationships[i]
 		path := fmt.Sprintf("authorization.relationships[%d]", i)
-		if err := validateAuthorizationRelationshipDef(path, relationship, resourceTypeRelations); err != nil {
+		if err := validateAuthorizationRelationshipDef(path, *relationship, resourceTypeRelations); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func validateAuthorizationResourceTypeReferences(path string, def AuthorizationResourceTypeDef, resourceTypes map[string]string) error {
+func validateAuthorizationResourceTypeReferences(path string, def AuthorizationResourceTypeDef, resourceTypes map[string]map[string]AuthorizationRelationDef) error {
 	for relationName, relation := range def.Relations {
 		relationPath := path + ".relations." + relationName
 		for i := range relation.AllowedTargets {
@@ -1658,8 +1659,13 @@ func validateAuthorizationResourceTypeReferences(path string, def AuthorizationR
 			}
 			if target.SubjectSet != nil {
 				resourceType := strings.TrimSpace(target.SubjectSet.ResourceType)
-				if _, ok := resourceTypes[resourceType]; !ok {
+				relations, ok := resourceTypes[resourceType]
+				if !ok {
 					return fmt.Errorf("config validation: %s.subjectSet.resourceType references unknown resource type %q", targetPath, resourceType)
+				}
+				relation := strings.TrimSpace(target.SubjectSet.Relation)
+				if _, ok := relations[relation]; !ok {
+					return fmt.Errorf("config validation: %s.subjectSet.relation references unknown relation %q for resource type %q", targetPath, relation, resourceType)
 				}
 			}
 		}
@@ -1667,8 +1673,8 @@ func validateAuthorizationResourceTypeReferences(path string, def AuthorizationR
 	return nil
 }
 
-func validateAuthorizationResourceTypeDef(path, name string, def AuthorizationResourceTypeDef) error {
-	if err := validateAuthorizationMapKey(path, name); err != nil {
+func validateAuthorizationResourceTypeDef(parentPath, name, path string, def AuthorizationResourceTypeDef) error {
+	if err := validateAuthorizationMapKey(parentPath, name); err != nil {
 		return err
 	}
 	if len(def.Relations) == 0 {
@@ -1677,12 +1683,9 @@ func validateAuthorizationResourceTypeDef(path, name string, def AuthorizationRe
 	if err := validateAuthorizationSourceMetadata(path+".source", def.Source); err != nil {
 		return err
 	}
-	if def.Dynamic.AllowStaticRelationshipOverrides {
-		return fmt.Errorf("config validation: %s.dynamic.allowStaticRelationshipOverrides is not supported", path)
-	}
 	for relationName, relation := range def.Relations {
 		relationPath := path + ".relations." + relationName
-		if err := validateAuthorizationMapKey(relationPath, relationName); err != nil {
+		if err := validateAuthorizationMapKey(path+".relations", relationName); err != nil {
 			return err
 		}
 		if err := validateStringList(relationPath+".subjectTypes", relation.SubjectTypes); err != nil {
@@ -1702,7 +1705,7 @@ func validateAuthorizationResourceTypeDef(path, name string, def AuthorizationRe
 	}
 	for actionName, action := range def.Actions {
 		actionPath := path + ".actions." + actionName
-		if err := validateAuthorizationMapKey(actionPath, actionName); err != nil {
+		if err := validateAuthorizationMapKey(path+".actions", actionName); err != nil {
 			return err
 		}
 		if err := validateStringList(actionPath+".relations", action.Relations); err != nil {

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -62,6 +62,9 @@ func ValidateCanonicalStructure(cfg *Config) error {
 	if err := validateAuthorizationPolicies(cfg); err != nil {
 		return err
 	}
+	if err := validateAuthorizationModelConfig(cfg); err != nil {
+		return err
+	}
 	if err := validateServerListeners(cfg.Server); err != nil {
 		return err
 	}
@@ -1591,6 +1594,333 @@ func validateAuthorizationPolicies(cfg *Config) error {
 			}
 			seenSubjectIDs[subjectID] = i
 		}
+	}
+	return nil
+}
+
+func validateAuthorizationModelConfig(cfg *Config) error {
+	definedResourceTypes := make(map[string]string)
+	resourceTypeRelations := make(map[string]map[string]AuthorizationRelationDef)
+	for modelName, model := range cfg.Authorization.Models {
+		if err := validateAuthorizationMapKey("authorization.models", modelName); err != nil {
+			return err
+		}
+		if err := validateAuthorizationSourceMetadata("authorization.models."+modelName+".source", model.Source); err != nil {
+			return err
+		}
+		for resourceTypeName, resourceType := range model.ResourceTypes {
+			resourcePath := fmt.Sprintf("authorization.models.%s.resourceTypes.%s", modelName, resourceTypeName)
+			if err := validateAuthorizationResourceTypeDef(resourcePath, resourceTypeName, resourceType); err != nil {
+				return err
+			}
+			if prev, exists := definedResourceTypes[resourceTypeName]; exists {
+				return fmt.Errorf("config validation: %s duplicates resource type already defined at %s", resourcePath, prev)
+			}
+			definedResourceTypes[resourceTypeName] = resourcePath
+			resourceTypeRelations[resourceTypeName] = resourceType.Relations
+		}
+	}
+	for modelName, model := range cfg.Authorization.Models {
+		for resourceTypeName, resourceType := range model.ResourceTypes {
+			resourcePath := fmt.Sprintf("authorization.models.%s.resourceTypes.%s", modelName, resourceTypeName)
+			if err := validateAuthorizationResourceTypeReferences(resourcePath, resourceType, definedResourceTypes); err != nil {
+				return err
+			}
+		}
+	}
+	for resourceTypeName, policy := range cfg.Authorization.ResourceTypes {
+		if err := validateAuthorizationMapKey("authorization.resourceTypes", resourceTypeName); err != nil {
+			return err
+		}
+		if policy.Dynamic.AllowStaticRelationshipOverrides {
+			return fmt.Errorf("config validation: authorization.resourceTypes.%s.dynamic.allowStaticRelationshipOverrides is not supported", resourceTypeName)
+		}
+	}
+	for i, relationship := range cfg.Authorization.Relationships {
+		path := fmt.Sprintf("authorization.relationships[%d]", i)
+		if err := validateAuthorizationRelationshipDef(path, relationship, resourceTypeRelations); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateAuthorizationResourceTypeReferences(path string, def AuthorizationResourceTypeDef, resourceTypes map[string]string) error {
+	for relationName, relation := range def.Relations {
+		relationPath := path + ".relations." + relationName
+		for i := range relation.AllowedTargets {
+			target := &relation.AllowedTargets[i]
+			targetPath := fmt.Sprintf("%s.allowedTargets[%d]", relationPath, i)
+			if resourceType := strings.TrimSpace(target.ResourceType); resourceType != "" {
+				if _, ok := resourceTypes[resourceType]; !ok {
+					return fmt.Errorf("config validation: %s.resourceType references unknown resource type %q", targetPath, resourceType)
+				}
+			}
+			if target.SubjectSet != nil {
+				resourceType := strings.TrimSpace(target.SubjectSet.ResourceType)
+				if _, ok := resourceTypes[resourceType]; !ok {
+					return fmt.Errorf("config validation: %s.subjectSet.resourceType references unknown resource type %q", targetPath, resourceType)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func validateAuthorizationResourceTypeDef(path, name string, def AuthorizationResourceTypeDef) error {
+	if err := validateAuthorizationMapKey(path, name); err != nil {
+		return err
+	}
+	if len(def.Relations) == 0 {
+		return fmt.Errorf("config validation: %s.relations must define at least one relation", path)
+	}
+	if err := validateAuthorizationSourceMetadata(path+".source", def.Source); err != nil {
+		return err
+	}
+	if def.Dynamic.AllowStaticRelationshipOverrides {
+		return fmt.Errorf("config validation: %s.dynamic.allowStaticRelationshipOverrides is not supported", path)
+	}
+	for relationName, relation := range def.Relations {
+		relationPath := path + ".relations." + relationName
+		if err := validateAuthorizationMapKey(relationPath, relationName); err != nil {
+			return err
+		}
+		if err := validateStringList(relationPath+".subjectTypes", relation.SubjectTypes); err != nil {
+			return err
+		}
+		if len(relation.SubjectTypes) == 0 && len(relation.AllowedTargets) == 0 {
+			return fmt.Errorf("config validation: %s must set subjectTypes or allowedTargets", relationPath)
+		}
+		for i, target := range relation.AllowedTargets {
+			if err := validateAuthorizationAllowedTargetDef(fmt.Sprintf("%s.allowedTargets[%d]", relationPath, i), target); err != nil {
+				return err
+			}
+		}
+		if err := validateAuthorizationRewriteDef(relationPath+".rewrite", relation.Rewrite, def.Relations); err != nil {
+			return err
+		}
+		if err := validateAuthorizationSourceMetadata(relationPath+".source", relation.Source); err != nil {
+			return err
+		}
+	}
+	for actionName, action := range def.Actions {
+		actionPath := path + ".actions." + actionName
+		if err := validateAuthorizationMapKey(actionPath, actionName); err != nil {
+			return err
+		}
+		if err := validateStringList(actionPath+".relations", action.Relations); err != nil {
+			return err
+		}
+		if len(action.Relations) == 0 && action.Rewrite == nil {
+			return fmt.Errorf("config validation: %s must set relations or rewrite", actionPath)
+		}
+		for _, relation := range action.Relations {
+			if _, ok := def.Relations[relation]; !ok {
+				return fmt.Errorf("config validation: %s.relations references unknown relation %q", actionPath, relation)
+			}
+		}
+		if err := validateAuthorizationRewriteDef(actionPath+".rewrite", action.Rewrite, def.Relations); err != nil {
+			return err
+		}
+		if err := validateAuthorizationSourceMetadata(actionPath+".source", action.Source); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateAuthorizationAllowedTargetDef(path string, target AuthorizationAllowedTargetDef) error {
+	set := 0
+	if strings.TrimSpace(target.SubjectType) != "" {
+		set++
+	}
+	if strings.TrimSpace(target.ResourceType) != "" {
+		set++
+	}
+	if target.SubjectSet != nil {
+		set++
+		if strings.TrimSpace(target.SubjectSet.ResourceType) == "" {
+			return fmt.Errorf("config validation: %s.subjectSet.resourceType is required", path)
+		}
+		if strings.TrimSpace(target.SubjectSet.Relation) == "" {
+			return fmt.Errorf("config validation: %s.subjectSet.relation is required", path)
+		}
+	}
+	if set != 1 {
+		return fmt.Errorf("config validation: %s must set exactly one of subjectType, resourceType, or subjectSet", path)
+	}
+	return nil
+}
+
+func validateAuthorizationRewriteDef(path string, rewrite *AuthorizationRewriteDef, relations map[string]AuthorizationRelationDef) error {
+	if rewrite == nil {
+		return nil
+	}
+	set := 0
+	if rewrite.This != nil {
+		set++
+	}
+	if rewrite.ComputedUserset != nil {
+		set++
+		relation := strings.TrimSpace(rewrite.ComputedUserset.Relation)
+		if relation == "" {
+			return fmt.Errorf("config validation: %s.computedUserset.relation is required", path)
+		}
+		if _, ok := relations[relation]; !ok {
+			return fmt.Errorf("config validation: %s.computedUserset.relation references unknown relation %q", path, relation)
+		}
+	}
+	if rewrite.TupleToUserset != nil {
+		set++
+		tupleset := strings.TrimSpace(rewrite.TupleToUserset.TuplesetRelation)
+		computed := strings.TrimSpace(rewrite.TupleToUserset.ComputedRelation)
+		if tupleset == "" {
+			return fmt.Errorf("config validation: %s.tupleToUserset.tuplesetRelation is required", path)
+		}
+		if computed == "" {
+			return fmt.Errorf("config validation: %s.tupleToUserset.computedRelation is required", path)
+		}
+		if _, ok := relations[tupleset]; !ok {
+			return fmt.Errorf("config validation: %s.tupleToUserset.tuplesetRelation references unknown relation %q", path, tupleset)
+		}
+	}
+	if len(rewrite.Union) > 0 {
+		set++
+		for i := range rewrite.Union {
+			if err := validateAuthorizationRewriteDef(fmt.Sprintf("%s.union[%d]", path, i), &rewrite.Union[i], relations); err != nil {
+				return err
+			}
+		}
+	}
+	if set != 1 {
+		return fmt.Errorf("config validation: %s must set exactly one of this, computedUserset, tupleToUserset, or union", path)
+	}
+	return nil
+}
+
+func validateAuthorizationRelationshipDef(path string, relationship AuthorizationRelationshipDef, resourceTypes map[string]map[string]AuthorizationRelationDef) error {
+	if err := validateAuthorizationSubjectDef(path+".subject", relationship.Subject); err != nil {
+		return err
+	}
+	if strings.TrimSpace(relationship.Relation) == "" {
+		return fmt.Errorf("config validation: %s.relation is required", path)
+	}
+	if err := validateAuthorizationResourceDef(path+".resource", relationship.Resource); err != nil {
+		return err
+	}
+	resourceType := strings.TrimSpace(relationship.Resource.Type)
+	relations, ok := resourceTypes[resourceType]
+	if !ok {
+		return fmt.Errorf("config validation: %s.resource.type references unknown resource type %q", path, resourceType)
+	}
+	if _, ok := relations[strings.TrimSpace(relationship.Relation)]; !ok {
+		return fmt.Errorf("config validation: %s.relation references unknown relation %q for resource type %q", path, relationship.Relation, resourceType)
+	}
+	if err := validateAuthorizationRelationshipTargetDef(path+".target", relationship.Target, resourceTypes); err != nil {
+		return err
+	}
+	if err := validateAuthorizationSourceMetadata(path+".source", relationship.Source); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateAuthorizationMapKey(path, key string) error {
+	if strings.TrimSpace(key) == "" {
+		return fmt.Errorf("config validation: %s keys must be non-empty", path)
+	}
+	if key != strings.TrimSpace(key) {
+		return fmt.Errorf("config validation: %s key %q must not have surrounding whitespace", path, key)
+	}
+	return nil
+}
+
+func validateAuthorizationSubjectDef(path string, subject AuthorizationSubjectDef) error {
+	if strings.TrimSpace(subject.Type) == "" {
+		return fmt.Errorf("config validation: %s.type is required", path)
+	}
+	if strings.TrimSpace(subject.ID) == "" {
+		return fmt.Errorf("config validation: %s.id is required", path)
+	}
+	return nil
+}
+
+func validateAuthorizationResourceDef(path string, resource AuthorizationResourceDef) error {
+	if strings.TrimSpace(resource.Type) == "" {
+		return fmt.Errorf("config validation: %s.type is required", path)
+	}
+	if strings.TrimSpace(resource.ID) == "" {
+		return fmt.Errorf("config validation: %s.id is required", path)
+	}
+	return nil
+}
+
+func validateAuthorizationRelationshipTargetDef(path string, target AuthorizationRelationshipTargetDef, resourceTypes map[string]map[string]AuthorizationRelationDef) error {
+	set := 0
+	if target.Subject != nil {
+		set++
+		if err := validateAuthorizationSubjectDef(path+".subject", *target.Subject); err != nil {
+			return err
+		}
+	}
+	if target.Resource != nil {
+		set++
+		if err := validateAuthorizationResourceDef(path+".resource", *target.Resource); err != nil {
+			return err
+		}
+		if len(resourceTypes) > 0 {
+			if _, ok := resourceTypes[strings.TrimSpace(target.Resource.Type)]; !ok {
+				return fmt.Errorf("config validation: %s.resource.type references unknown resource type %q", path, target.Resource.Type)
+			}
+		}
+	}
+	if target.SubjectSet != nil {
+		set++
+		if err := validateAuthorizationResourceDef(path+".subjectSet.resource", target.SubjectSet.Resource); err != nil {
+			return err
+		}
+		if len(resourceTypes) > 0 {
+			relations, ok := resourceTypes[strings.TrimSpace(target.SubjectSet.Resource.Type)]
+			if !ok {
+				return fmt.Errorf("config validation: %s.subjectSet.resource.type references unknown resource type %q", path, target.SubjectSet.Resource.Type)
+			}
+			if _, ok := relations[strings.TrimSpace(target.SubjectSet.Relation)]; !ok {
+				return fmt.Errorf("config validation: %s.subjectSet.relation references unknown relation %q for resource type %q", path, target.SubjectSet.Relation, target.SubjectSet.Resource.Type)
+			}
+		}
+		if strings.TrimSpace(target.SubjectSet.Relation) == "" {
+			return fmt.Errorf("config validation: %s.subjectSet.relation is required", path)
+		}
+	}
+	if set > 1 {
+		return fmt.Errorf("config validation: %s must set at most one of subject, resource, or subjectSet", path)
+	}
+	return nil
+}
+
+func validateAuthorizationSourceMetadata(path string, source AuthorizationSourceMetadataDef) error {
+	ownerKind := strings.TrimSpace(source.OwnerKind)
+	ownerID := strings.TrimSpace(source.OwnerID)
+	if ownerKind == "" && ownerID != "" {
+		return fmt.Errorf("config validation: %s.ownerKind is required when ownerId is set", path)
+	}
+	if ownerKind != "" && ownerID == "" {
+		return fmt.Errorf("config validation: %s.ownerId is required when ownerKind is set", path)
+	}
+	return nil
+}
+
+func validateStringList(path string, values []string) error {
+	seen := make(map[string]int, len(values))
+	for i, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			return fmt.Errorf("config validation: %s[%d] is required", path, i)
+		}
+		if prev, exists := seen[trimmed]; exists {
+			return fmt.Errorf("config validation: %s[%d] duplicates [%d]", path, i, prev)
+		}
+		seen[trimmed] = i
 	}
 	return nil
 }

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -1827,6 +1827,9 @@ func validateAuthorizationRelationshipTargetDef(path string, target Authorizatio
 		if err := validateAuthorizationResourceDef(path+".subjectSet.resource", target.SubjectSet.Resource); err != nil {
 			return err
 		}
+		if strings.TrimSpace(target.SubjectSet.Relation) == "" {
+			return fmt.Errorf("config validation: %s.subjectSet.relation is required", path)
+		}
 		if len(resourceTypes) > 0 {
 			relations, ok := resourceTypes[strings.TrimSpace(target.SubjectSet.Resource.Type)]
 			if !ok {
@@ -1835,9 +1838,6 @@ func validateAuthorizationRelationshipTargetDef(path string, target Authorizatio
 			if _, ok := relations[strings.TrimSpace(target.SubjectSet.Relation)]; !ok {
 				return fmt.Errorf("config validation: %s.subjectSet.relation references unknown relation %q for resource type %q", path, target.SubjectSet.Relation, target.SubjectSet.Resource.Type)
 			}
-		}
-		if strings.TrimSpace(target.SubjectSet.Relation) == "" {
-			return fmt.Errorf("config validation: %s.subjectSet.relation is required", path)
 		}
 	}
 	if set > 1 {

--- a/gestaltd/services/authorization/provider_schema.go
+++ b/gestaltd/services/authorization/provider_schema.go
@@ -195,25 +195,11 @@ func membershipResourceType(name string) *core.AuthorizationModelResourceType {
 			AllowedTargets: []*core.AuthorizationModelAllowedTarget{{
 				Kind: &proto.AuthorizationModelAllowedTarget_SubjectType{SubjectType: subjectTypeSubject},
 			}},
-			Rewrite: rewriteThis(),
 		}},
 		Actions: []*core.AuthorizationModelAction{{
 			Name:      relationMember,
 			Relations: []string{relationMember},
-			Rewrite:   rewriteComputedUserset(relationMember),
 		}},
-	}
-}
-
-func rewriteThis() *core.AuthorizationModelRewrite {
-	return &core.AuthorizationModelRewrite{
-		Kind: &proto.AuthorizationModelRewrite_This{This: &core.AuthorizationModelRewriteThis{}},
-	}
-}
-
-func rewriteComputedUserset(relation string) *core.AuthorizationModelRewrite {
-	return &core.AuthorizationModelRewrite{
-		Kind: &proto.AuthorizationModelRewrite_ComputedUserset{ComputedUserset: &core.AuthorizationModelComputedUserset{Relation: relation}},
 	}
 }
 


### PR DESCRIPTION
## Description

Adds the config-only foundation for expressing deployment-owned authorization intent as generic authorization model data. The `gestaltd.config/v5` schema now accepts `authorization.models`, `authorization.relationships`, dynamic extension metadata, and source metadata while preserving the existing `authorization.policies` compatibility path.

This PR only parses, normalizes, validates, tests, and documents the new config surface; runtime reconciliation and provider writes are handled by later PRs in the stack.

## config.yaml

```yaml
authorization:
  models:
    default:
      resourceTypes:
        team:
          relations:
            member:
              subjectTypes: [subject]
            admin:
              subjectTypes: [subject]
          actions:
            view:
              relations: [member, admin]
            manage:
              relations: [admin]
          dynamic:
            allowAdditionalRelationships: true
        managed_subject:
          relations:
            viewer:
              subjectTypes: [subject]
            editor:
              subjectTypes: [subject]
            admin:
              subjectTypes: [subject]
          actions:
            view:
              relations: [viewer, editor, admin]
            manage:
              relations: [admin]
        plugin/github/repository:
          relations:
            reader:
              allowedTargets:
                - subjectType: subject
            maintainer:
              allowedTargets:
                - subjectType: subject
          actions:
            read:
              relations: [reader, maintainer]
            administer:
              relations: [maintainer]
  relationships:
    - subject:
        type: subject
        id: user:alice
      relation: admin
      resource:
        type: team
        id: servicing
      source:
        layer: static_config
        id: authorization.relationships[0]
```
