### PR TITLE
Percent-encode REST path parameters for declarative plugins

### DIFF
--- a/gestaltd/services/plugins/apiexec/apiexec.go
+++ b/gestaltd/services/plugins/apiexec/apiexec.go
@@ -455,7 +455,7 @@ func substitutePath(path string, params map[string]any) (string, error) {
 			return match
 		}
 		delete(params, key)
-		return fmt.Sprintf("%v", v)
+		return url.PathEscape(fmt.Sprintf("%v", v))
 	})
 	if missingErr != nil {
 		return "", missingErr

--- a/gestaltd/services/plugins/apiexec/apiexec_test.go
+++ b/gestaltd/services/plugins/apiexec/apiexec_test.go
@@ -40,6 +40,24 @@ func TestSubstitutePath_Success(t *testing.T) {
 	}
 }
 
+func TestSubstitutePath_EncodesSlashesInPathParams(t *testing.T) {
+	t.Parallel()
+	result, err := substitutePath(
+		"/storage/v1/b/{bucket}/o/{object}",
+		map[string]any{
+			"bucket": "my-bucket",
+			"object": "folder/sub/file.json",
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "/storage/v1/b/my-bucket/o/folder%2Fsub%2Ffile.json"
+	if result != want {
+		t.Errorf("got %q, want %q", result, want)
+	}
+}
+
 func TestDoGETWithQueryAndPathParams(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Encode declarative REST `in: path` substitutions with `url.PathEscape` in `apiexec.substitutePath`, fixing nested GCS object keys (and any other provider path segments containing `/`, spaces, etc.).
- Add `TestSubstitutePath_EncodesSlashesInPathParams` covering the GCS `/b/{bucket}/o/{object}` pattern.

## Context
`gcs.objects.get` / `objects.download` returned HTTP 404 for keys like `raw_pipe_cache/.../loan_batch/_loan_batch_split_meta.json` because `{object}` was inserted unencoded. GCS REST requires percent-encoded path segments.

Call-site encoding was added in toolshed [sdt-pipeline #1871](https://github.com/valon-technologies/toolshed/pull/1871) as a stopgap. After this ships, remove that client-side encoding to avoid double-encoding (`%2F` → `%252F`).

## Test plan
- [x] `go test ./...` in `gestaltd/services/plugins/apiexec`
- [ ] Deploy gestaltd; `gestalt plugin invoke gcs objects.get` with unencoded nested `object` succeeds
- [ ] Revert toolshed #1871 `_gcs_object_path_param` once server is live


Made with [Cursor](https://cursor.com)