### PR TITLE
[authorization] add composer and reconciler

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1166,7 +1166,9 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	}()
 	var authz authorization.RuntimeAuthorizer = baseAuthz
 	if prepared.AuthorizationProvider != nil {
-		authz, err = authorization.NewProviderBacked(baseAuthz, prepared.AuthorizationProvider)
+		authz, err = authorization.NewProviderBacked(baseAuthz, prepared.AuthorizationProvider,
+			authorization.WithDynamicFragmentSource(prepared.Services.AuthzFragments),
+		)
 		if err != nil {
 			prepared.Deps.WorkflowRuntime.FailPendingProviders(err)
 			return nil, err

--- a/gestaltd/internal/config/authorization.go
+++ b/gestaltd/internal/config/authorization.go
@@ -1,6 +1,11 @@
 package config
 
-import "github.com/valon-technologies/gestalt/server/services/authorization"
+import (
+	"github.com/valon-technologies/gestalt/server/core"
+	proto "github.com/valon-technologies/gestalt/server/internal/gen/v1"
+	"github.com/valon-technologies/gestalt/server/services/authorization"
+	"google.golang.org/protobuf/types/known/structpb"
+)
 
 // AuthorizationStaticConfig adapts parsed config into the service-owned
 // authorization static policy model.
@@ -8,6 +13,8 @@ func AuthorizationStaticConfig(cfg AuthorizationConfig, pluginDefs map[string]*P
 	out := authorization.StaticConfig{
 		Policies:         make(map[string]authorization.StaticSubjectPolicy, len(cfg.Policies)),
 		ProviderPolicies: make(map[string]string, len(pluginDefs)),
+		ModelFragments:   authorizationModelFragments(cfg),
+		Relationships:    authorizationRelationships(cfg),
 	}
 	for policyID, def := range cfg.Policies {
 		policy := authorization.StaticSubjectPolicy{
@@ -27,5 +34,141 @@ func AuthorizationStaticConfig(cfg AuthorizationConfig, pluginDefs map[string]*P
 			out.ProviderPolicies[providerName] = entry.AuthorizationPolicy
 		}
 	}
+	return out
+}
+
+func authorizationModelFragments(cfg AuthorizationConfig) []*core.AuthorizationModelResourceType {
+	var out []*core.AuthorizationModelResourceType
+	for _, model := range cfg.Models {
+		for name, resourceType := range model.ResourceTypes {
+			out = append(out, authorizationModelResourceType(name, resourceType))
+		}
+	}
+	return out
+}
+
+func authorizationModelResourceType(name string, def AuthorizationResourceTypeDef) *core.AuthorizationModelResourceType {
+	resourceType := &core.AuthorizationModelResourceType{Name: name}
+	for relationName, relation := range def.Relations {
+		resourceType.Relations = append(resourceType.Relations, &core.AuthorizationModelRelation{
+			Name:           relationName,
+			SubjectTypes:   append([]string(nil), relation.SubjectTypes...),
+			AllowedTargets: authorizationAllowedTargets(relation.AllowedTargets),
+			Rewrite:        authorizationRewrite(relation.Rewrite),
+		})
+	}
+	for actionName, action := range def.Actions {
+		resourceType.Actions = append(resourceType.Actions, &core.AuthorizationModelAction{
+			Name:      actionName,
+			Relations: append([]string(nil), action.Relations...),
+			Rewrite:   authorizationRewrite(action.Rewrite),
+		})
+	}
+	return resourceType
+}
+
+func authorizationAllowedTargets(targets []AuthorizationAllowedTargetDef) []*core.AuthorizationModelAllowedTarget {
+	out := make([]*core.AuthorizationModelAllowedTarget, 0, len(targets))
+	for _, target := range targets {
+		switch {
+		case target.SubjectType != "":
+			out = append(out, &core.AuthorizationModelAllowedTarget{
+				Kind: &proto.AuthorizationModelAllowedTarget_SubjectType{SubjectType: target.SubjectType},
+			})
+		case target.ResourceType != "":
+			out = append(out, &core.AuthorizationModelAllowedTarget{
+				Kind: &proto.AuthorizationModelAllowedTarget_ResourceType{ResourceType: target.ResourceType},
+			})
+		case target.SubjectSet != nil:
+			out = append(out, &core.AuthorizationModelAllowedTarget{
+				Kind: &proto.AuthorizationModelAllowedTarget_SubjectSet{SubjectSet: &core.AuthorizationModelSubjectSetTarget{
+					ResourceType: target.SubjectSet.ResourceType,
+					Relation:     target.SubjectSet.Relation,
+				}},
+			})
+		}
+	}
+	return out
+}
+
+func authorizationRewrite(def *AuthorizationRewriteDef) *core.AuthorizationModelRewrite {
+	if def == nil {
+		return nil
+	}
+	switch {
+	case def.This != nil:
+		return &core.AuthorizationModelRewrite{Kind: &proto.AuthorizationModelRewrite_This{This: &core.AuthorizationModelRewriteThis{}}}
+	case def.ComputedUserset != nil:
+		return &core.AuthorizationModelRewrite{Kind: &proto.AuthorizationModelRewrite_ComputedUserset{ComputedUserset: &core.AuthorizationModelComputedUserset{Relation: def.ComputedUserset.Relation}}}
+	case def.TupleToUserset != nil:
+		return &core.AuthorizationModelRewrite{Kind: &proto.AuthorizationModelRewrite_TupleToUserset{TupleToUserset: &core.AuthorizationModelTupleToUserset{
+			TuplesetRelation: def.TupleToUserset.TuplesetRelation,
+			ComputedRelation: def.TupleToUserset.ComputedRelation,
+		}}}
+	case len(def.Union) > 0:
+		children := make([]*core.AuthorizationModelRewrite, 0, len(def.Union))
+		for i := range def.Union {
+			children = append(children, authorizationRewrite(&def.Union[i]))
+		}
+		return &core.AuthorizationModelRewrite{Kind: &proto.AuthorizationModelRewrite_Union{Union: &core.AuthorizationModelRewriteUnion{Children: children}}}
+	default:
+		return nil
+	}
+}
+
+func authorizationRelationships(cfg AuthorizationConfig) []*core.Relationship {
+	out := make([]*core.Relationship, 0, len(cfg.Relationships))
+	for i := range cfg.Relationships {
+		relationship := &cfg.Relationships[i]
+		out = append(out, &core.Relationship{
+			Subject:    authorizationSubject(relationship.Subject),
+			Relation:   relationship.Relation,
+			Resource:   authorizationResource(relationship.Resource),
+			Target:     authorizationRelationshipTarget(relationship.Target),
+			Properties: authorizationStringProperties(relationship.Properties),
+		})
+	}
+	return out
+}
+
+func authorizationSubject(def AuthorizationSubjectDef) *core.SubjectRef {
+	if def.Type == "" && def.ID == "" {
+		return nil
+	}
+	return &core.SubjectRef{Type: def.Type, Id: def.ID}
+}
+
+func authorizationResource(def AuthorizationResourceDef) *core.ResourceRef {
+	if def.Type == "" && def.ID == "" {
+		return nil
+	}
+	return &core.ResourceRef{Type: def.Type, Id: def.ID}
+}
+
+func authorizationRelationshipTarget(def AuthorizationRelationshipTargetDef) *core.RelationshipTargetRef {
+	switch {
+	case def.Subject != nil:
+		return &core.RelationshipTargetRef{Kind: &proto.RelationshipTarget_Subject{Subject: authorizationSubject(*def.Subject)}}
+	case def.Resource != nil:
+		return &core.RelationshipTargetRef{Kind: &proto.RelationshipTarget_Resource{Resource: authorizationResource(*def.Resource)}}
+	case def.SubjectSet != nil:
+		return &core.RelationshipTargetRef{Kind: &proto.RelationshipTarget_SubjectSet{SubjectSet: &core.SubjectSetRef{
+			Resource: authorizationResource(def.SubjectSet.Resource),
+			Relation: def.SubjectSet.Relation,
+		}}}
+	default:
+		return nil
+	}
+}
+
+func authorizationStringProperties(properties map[string]string) *structpb.Struct {
+	if len(properties) == 0 {
+		return nil
+	}
+	values := make(map[string]any, len(properties))
+	for key, value := range properties {
+		values[key] = value
+	}
+	out, _ := structpb.NewStruct(values)
 	return out
 }

--- a/gestaltd/internal/config/authorization.go
+++ b/gestaltd/internal/config/authorization.go
@@ -11,10 +11,11 @@ import (
 // authorization static policy model.
 func AuthorizationStaticConfig(cfg AuthorizationConfig, pluginDefs map[string]*ProviderEntry) authorization.StaticConfig {
 	out := authorization.StaticConfig{
-		Policies:         make(map[string]authorization.StaticSubjectPolicy, len(cfg.Policies)),
-		ProviderPolicies: make(map[string]string, len(pluginDefs)),
-		ModelFragments:   authorizationModelFragments(cfg),
-		Relationships:    authorizationRelationships(cfg),
+		Policies:                make(map[string]authorization.StaticSubjectPolicy, len(cfg.Policies)),
+		ProviderPolicies:        make(map[string]string, len(pluginDefs)),
+		ModelFragments:          authorizationModelFragments(cfg),
+		Relationships:           authorizationRelationships(cfg),
+		ResourceDynamicPolicies: authorizationResourceDynamicPolicies(cfg),
 	}
 	for policyID, def := range cfg.Policies {
 		policy := authorization.StaticSubjectPolicy{
@@ -37,6 +38,26 @@ func AuthorizationStaticConfig(cfg AuthorizationConfig, pluginDefs map[string]*P
 	return out
 }
 
+func authorizationResourceDynamicPolicies(cfg AuthorizationConfig) map[string]authorization.StaticResourceDynamicPolicy {
+	out := map[string]authorization.StaticResourceDynamicPolicy{}
+	for name, resourceType := range cfg.ResourceTypes {
+		if resourceType.Dynamic.AllowAdditionalRelationships {
+			out[name] = authorization.StaticResourceDynamicPolicy{AllowAdditionalRelationships: true}
+		}
+	}
+	for _, model := range cfg.Models {
+		for name, resourceType := range model.ResourceTypes {
+			if resourceType.Dynamic.AllowAdditionalRelationships {
+				out[name] = authorization.StaticResourceDynamicPolicy{AllowAdditionalRelationships: true}
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 func authorizationModelFragments(cfg AuthorizationConfig) []*core.AuthorizationModelResourceType {
 	var out []*core.AuthorizationModelResourceType
 	for _, model := range cfg.Models {
@@ -54,14 +75,12 @@ func authorizationModelResourceType(name string, def AuthorizationResourceTypeDe
 			Name:           relationName,
 			SubjectTypes:   append([]string(nil), relation.SubjectTypes...),
 			AllowedTargets: authorizationAllowedTargets(relation.AllowedTargets),
-			Rewrite:        authorizationRewrite(relation.Rewrite),
 		})
 	}
 	for actionName, action := range def.Actions {
 		resourceType.Actions = append(resourceType.Actions, &core.AuthorizationModelAction{
 			Name:      actionName,
 			Relations: append([]string(nil), action.Relations...),
-			Rewrite:   authorizationRewrite(action.Rewrite),
 		})
 	}
 	return resourceType
@@ -89,31 +108,6 @@ func authorizationAllowedTargets(targets []AuthorizationAllowedTargetDef) []*cor
 		}
 	}
 	return out
-}
-
-func authorizationRewrite(def *AuthorizationRewriteDef) *core.AuthorizationModelRewrite {
-	if def == nil {
-		return nil
-	}
-	switch {
-	case def.This != nil:
-		return &core.AuthorizationModelRewrite{Kind: &proto.AuthorizationModelRewrite_This{This: &core.AuthorizationModelRewriteThis{}}}
-	case def.ComputedUserset != nil:
-		return &core.AuthorizationModelRewrite{Kind: &proto.AuthorizationModelRewrite_ComputedUserset{ComputedUserset: &core.AuthorizationModelComputedUserset{Relation: def.ComputedUserset.Relation}}}
-	case def.TupleToUserset != nil:
-		return &core.AuthorizationModelRewrite{Kind: &proto.AuthorizationModelRewrite_TupleToUserset{TupleToUserset: &core.AuthorizationModelTupleToUserset{
-			TuplesetRelation: def.TupleToUserset.TuplesetRelation,
-			ComputedRelation: def.TupleToUserset.ComputedRelation,
-		}}}
-	case len(def.Union) > 0:
-		children := make([]*core.AuthorizationModelRewrite, 0, len(def.Union))
-		for i := range def.Union {
-			children = append(children, authorizationRewrite(&def.Union[i]))
-		}
-		return &core.AuthorizationModelRewrite{Kind: &proto.AuthorizationModelRewrite_Union{Union: &core.AuthorizationModelRewriteUnion{Children: children}}}
-	default:
-		return nil
-	}
 }
 
 func authorizationRelationships(cfg AuthorizationConfig) []*core.Relationship {

--- a/gestaltd/services/authorization/authorizer.go
+++ b/gestaltd/services/authorization/authorizer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+	gproto "google.golang.org/protobuf/proto"
 )
 
 const (
@@ -32,6 +33,8 @@ type StaticSubjectMember struct {
 type StaticConfig struct {
 	Policies         map[string]StaticSubjectPolicy
 	ProviderPolicies map[string]string
+	ModelFragments   []*core.AuthorizationModelResourceType
+	Relationships    []*core.Relationship
 }
 
 type StaticSubjectPolicy struct {
@@ -42,12 +45,16 @@ type StaticSubjectPolicy struct {
 type Authorizer struct {
 	policies         map[string]*SubjectPolicy
 	providerPolicies map[string]string
+	modelFragments   []*core.AuthorizationModelResourceType
+	relationships    []*core.Relationship
 }
 
 func New(cfg StaticConfig) (*Authorizer, error) {
 	a := &Authorizer{
 		policies:         map[string]*SubjectPolicy{},
 		providerPolicies: map[string]string{},
+		modelFragments:   cloneModelResourceTypes(cfg.ModelFragments),
+		relationships:    cloneRelationships(cfg.Relationships),
 	}
 
 	for policyID, def := range cfg.Policies {
@@ -71,6 +78,34 @@ func New(cfg StaticConfig) (*Authorizer, error) {
 	}
 
 	return a, nil
+}
+
+func cloneModelResourceTypes(in []*core.AuthorizationModelResourceType) []*core.AuthorizationModelResourceType {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]*core.AuthorizationModelResourceType, 0, len(in))
+	for _, resourceType := range in {
+		if resourceType == nil {
+			continue
+		}
+		out = append(out, gproto.Clone(resourceType).(*core.AuthorizationModelResourceType))
+	}
+	return out
+}
+
+func cloneRelationships(in []*core.Relationship) []*core.Relationship {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]*core.Relationship, 0, len(in))
+	for _, relationship := range in {
+		if relationship == nil {
+			continue
+		}
+		out = append(out, gproto.Clone(relationship).(*core.Relationship))
+	}
+	return out
 }
 
 func (a *Authorizer) Start(ctx context.Context) error {

--- a/gestaltd/services/authorization/authorizer.go
+++ b/gestaltd/services/authorization/authorizer.go
@@ -31,10 +31,15 @@ type StaticSubjectMember struct {
 }
 
 type StaticConfig struct {
-	Policies         map[string]StaticSubjectPolicy
-	ProviderPolicies map[string]string
-	ModelFragments   []*core.AuthorizationModelResourceType
-	Relationships    []*core.Relationship
+	Policies                map[string]StaticSubjectPolicy
+	ProviderPolicies        map[string]string
+	ModelFragments          []*core.AuthorizationModelResourceType
+	Relationships           []*core.Relationship
+	ResourceDynamicPolicies map[string]StaticResourceDynamicPolicy
+}
+
+type StaticResourceDynamicPolicy struct {
+	AllowAdditionalRelationships bool
 }
 
 type StaticSubjectPolicy struct {
@@ -43,18 +48,20 @@ type StaticSubjectPolicy struct {
 }
 
 type Authorizer struct {
-	policies         map[string]*SubjectPolicy
-	providerPolicies map[string]string
-	modelFragments   []*core.AuthorizationModelResourceType
-	relationships    []*core.Relationship
+	policies                map[string]*SubjectPolicy
+	providerPolicies        map[string]string
+	modelFragments          []*core.AuthorizationModelResourceType
+	relationships           []*core.Relationship
+	resourceDynamicPolicies map[string]StaticResourceDynamicPolicy
 }
 
 func New(cfg StaticConfig) (*Authorizer, error) {
 	a := &Authorizer{
-		policies:         map[string]*SubjectPolicy{},
-		providerPolicies: map[string]string{},
-		modelFragments:   cloneModelResourceTypes(cfg.ModelFragments),
-		relationships:    cloneRelationships(cfg.Relationships),
+		policies:                map[string]*SubjectPolicy{},
+		providerPolicies:        map[string]string{},
+		modelFragments:          cloneModelResourceTypes(cfg.ModelFragments),
+		relationships:           cloneRelationships(cfg.Relationships),
+		resourceDynamicPolicies: cloneResourceDynamicPolicies(cfg.ResourceDynamicPolicies),
 	}
 
 	for policyID, def := range cfg.Policies {
@@ -104,6 +111,19 @@ func cloneRelationships(in []*core.Relationship) []*core.Relationship {
 			continue
 		}
 		out = append(out, gproto.Clone(relationship).(*core.Relationship))
+	}
+	return out
+}
+
+func cloneResourceDynamicPolicies(in map[string]StaticResourceDynamicPolicy) map[string]StaticResourceDynamicPolicy {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]StaticResourceDynamicPolicy, len(in))
+	for name, policy := range in {
+		if name = strings.TrimSpace(name); name != "" {
+			out[name] = policy
+		}
 	}
 	return out
 }

--- a/gestaltd/services/authorization/provider_backed.go
+++ b/gestaltd/services/authorization/provider_backed.go
@@ -623,7 +623,14 @@ func (a *ProviderBackedAuthorizer) readAllRelationships(ctx context.Context, mod
 	}
 }
 
-func (a *ProviderBackedAuthorizer) buildDesiredRelationships(existing map[string]*core.Relationship, fragmentRelationships []*core.Relationship) (map[string]*core.Relationship, providerBackedRoleState, error) {
+type dynamicFragmentRelationship struct {
+	Relationship *core.Relationship
+	SourceID     string
+	OwnerKind    string
+	OwnerID      string
+}
+
+func (a *ProviderBackedAuthorizer) buildDesiredRelationships(existing map[string]*core.Relationship, fragmentRelationships []dynamicFragmentRelationship) (map[string]*core.Relationship, providerBackedRoleState, error) {
 	desired := map[string]*core.Relationship{}
 	state := providerBackedRoleState{
 		policyStaticRoles:  map[string][]string{},
@@ -684,11 +691,6 @@ func (a *ProviderBackedAuthorizer) buildDesiredRelationships(existing map[string
 				continue
 			}
 			addDesiredRelationship(desired, synthesizedRelationship(rel, "provider_existing", "managed_subject", "", ""))
-		case resourceTypeAgentSession:
-			if !validManagedAgentSessionRelationship(rel) {
-				continue
-			}
-			addDesiredRelationship(desired, synthesizedRelationship(rel, "provider_existing", "agent_session", "", ""))
 		case resourceTypeEveryone, resourceTypeTeam, resourceTypeSlackChannel:
 			if !validManagedMembershipRelationship(rel) {
 				continue
@@ -697,9 +699,14 @@ func (a *ProviderBackedAuthorizer) buildDesiredRelationships(existing map[string
 		}
 	}
 
-	for _, rel := range fragmentRelationships {
+	for _, fragmentRel := range fragmentRelationships {
+		rel := fragmentRel.Relationship
 		if rel == nil || rel.GetResource() == nil {
 			continue
+		}
+		sourceID := strings.TrimSpace(fragmentRel.SourceID)
+		if sourceID == "" {
+			sourceID = "dynamic_fragment"
 		}
 		switch strings.TrimSpace(rel.GetResource().GetType()) {
 		case resourceTypePluginDynamic:
@@ -708,7 +715,7 @@ func (a *ProviderBackedAuthorizer) buildDesiredRelationships(existing map[string
 			if resourceID == "" || relation == "" {
 				continue
 			}
-			addDesiredRelationship(desired, synthesizedRelationship(rel, "dynamic_fragment", "plugin/"+resourceID, "plugin", resourceID))
+			addDesiredRelationship(desired, synthesizedRelationship(rel, "dynamic_fragment", sourceID, "plugin", resourceID))
 			ensureRoleSet(pluginDynamicRoles, resourceID)[relation] = struct{}{}
 		case resourceTypeAdminDynamic:
 			resourceID := strings.TrimSpace(rel.GetResource().GetId())
@@ -716,8 +723,10 @@ func (a *ProviderBackedAuthorizer) buildDesiredRelationships(existing map[string
 			if resourceID != resourceIDAdminDynamicGlobal || relation == "" {
 				continue
 			}
-			addDesiredRelationship(desired, synthesizedRelationship(rel, "dynamic_fragment", "global", "global", resourceIDAdminDynamicGlobal))
+			addDesiredRelationship(desired, synthesizedRelationship(rel, "dynamic_fragment", sourceID, "global", resourceIDAdminDynamicGlobal))
 			adminDynamicRoles[relation] = struct{}{}
+		default:
+			addDesiredRelationship(desired, synthesizedRelationship(rel, "dynamic_fragment", sourceID, fragmentRel.OwnerKind, fragmentRel.OwnerID))
 		}
 	}
 
@@ -782,7 +791,7 @@ func (a *ProviderBackedAuthorizer) buildDesiredRelationships(existing map[string
 	return desired, state, nil
 }
 
-func (a *ProviderBackedAuthorizer) dynamicFragmentState(ctx context.Context, existing map[string]*core.Relationship) ([]*core.Relationship, []*core.AuthorizationModelResourceType, error) {
+func (a *ProviderBackedAuthorizer) dynamicFragmentState(ctx context.Context, existing map[string]*core.Relationship) ([]dynamicFragmentRelationship, []*core.AuthorizationModelResourceType, error) {
 	if a.fragmentSource == nil {
 		return nil, nil, nil
 	}
@@ -793,25 +802,91 @@ func (a *ProviderBackedAuthorizer) dynamicFragmentState(ctx context.Context, exi
 	if err != nil {
 		return nil, nil, fmt.Errorf("list dynamic authorization fragments: %w", err)
 	}
-	var relationships []*core.Relationship
+	var relationships []dynamicFragmentRelationship
 	var modelFragments []*core.AuthorizationModelResourceType
+	staticResourceTypes, resourceRelations := a.staticResourceTypeState(dynamicFragmentRoleState(fragments))
+	seenOwners := map[string]string{}
 	for _, fragment := range fragments {
 		if fragment == nil || strings.TrimSpace(fragment.Status) != coredata.AuthorizationFragmentStatusActive {
 			continue
 		}
+		ownerKey := dynamicFragmentOwnerKey(fragment.Owner)
+		if existingID, ok := seenOwners[ownerKey]; ok {
+			slog.WarnContext(ctx, "authorization: removing duplicate dynamic authorization fragment owner", "fragment", fragment.ID, "existing_fragment", existingID, "owner", ownerKey)
+			if err := a.fragmentSource.DeleteFragment(ctx, fragment.ID); err != nil {
+				return nil, nil, fmt.Errorf("delete duplicate dynamic authorization fragment %q: %w", fragment.ID, err)
+			}
+			continue
+		}
+		seenOwners[ownerKey] = fragment.ID
+		localResourceTypes := dynamicFragmentLocalResourceTypes(fragment)
+		fragmentRelationshipsStart := len(relationships)
+		fragmentModelsStart := len(modelFragments)
+		fragmentResourceNames := []string{}
+		fragmentValid := true
 		for resourceTypeName, raw := range fragment.ResourceTypes {
-			resourceType, err := dynamicFragmentModelResourceType(resourceTypeName, raw)
+			canonicalName, err := dynamicFragmentCanonicalResourceType(fragment.Owner, resourceTypeName, localResourceTypes)
 			if err != nil {
-				return nil, nil, fmt.Errorf("dynamic authorization fragment %q resource type %q: %w", fragment.ID, resourceTypeName, err)
+				slog.WarnContext(ctx, "authorization: removing invalid dynamic authorization fragment resource type", "fragment", fragment.ID, "resource_type", resourceTypeName, "error", err)
+				fragmentValid = false
+				break
+			}
+			if _, ok := staticResourceTypes[canonicalName]; ok {
+				slog.WarnContext(ctx, "authorization: removing conflicting dynamic authorization fragment resource type", "fragment", fragment.ID, "resource_type", canonicalName)
+				fragmentValid = false
+				break
+			}
+			resourceType, err := dynamicFragmentModelResourceType(fragment.Owner, resourceTypeName, raw, localResourceTypes)
+			if err != nil {
+				slog.WarnContext(ctx, "authorization: removing invalid dynamic authorization fragment model", "fragment", fragment.ID, "resource_type", resourceTypeName, "error", err)
+				fragmentValid = false
+				break
 			}
 			modelFragments = append(modelFragments, resourceType)
+			resourceRelations[canonicalName] = modelResourceTypeRelations(resourceType)
+			fragmentResourceNames = append(fragmentResourceNames, canonicalName)
+		}
+		if !fragmentValid {
+			if err := a.fragmentSource.DeleteFragment(ctx, fragment.ID); err != nil {
+				return nil, nil, fmt.Errorf("delete invalid dynamic authorization fragment %q: %w", fragment.ID, err)
+			}
+			modelFragments = modelFragments[:fragmentModelsStart]
+			for _, resourceType := range fragmentResourceNames {
+				delete(resourceRelations, resourceType)
+			}
+			continue
 		}
 		for _, relationship := range fragment.Relationships {
-			rel := relationshipFromDynamicFragment(relationship)
+			rel, err := relationshipFromDynamicFragment(fragment.Owner, relationship, localResourceTypes)
+			if err != nil {
+				slog.WarnContext(ctx, "authorization: removing invalid dynamic authorization fragment relationship", "fragment", fragment.ID, "error", err)
+				fragmentValid = false
+				break
+			}
 			if rel == nil {
 				continue
 			}
-			relationships = append(relationships, rel)
+			if err := a.validateDynamicRelationship(rel, resourceRelations, staticResourceTypes); err != nil {
+				slog.WarnContext(ctx, "authorization: removing invalid dynamic authorization fragment relationship", "fragment", fragment.ID, "resource_type", rel.GetResource().GetType(), "relation", rel.GetRelation(), "error", err)
+				fragmentValid = false
+				break
+			}
+			relationships = append(relationships, dynamicFragmentRelationship{
+				Relationship: rel,
+				SourceID:     fragment.ID,
+				OwnerKind:    strings.TrimSpace(fragment.Owner.Kind),
+				OwnerID:      dynamicFragmentOwnerID(fragment.Owner),
+			})
+		}
+		if !fragmentValid {
+			if err := a.fragmentSource.DeleteFragment(ctx, fragment.ID); err != nil {
+				return nil, nil, fmt.Errorf("delete invalid dynamic authorization fragment %q: %w", fragment.ID, err)
+			}
+			relationships = relationships[:fragmentRelationshipsStart]
+			modelFragments = modelFragments[:fragmentModelsStart]
+			for _, resourceType := range fragmentResourceNames {
+				delete(resourceRelations, resourceType)
+			}
 		}
 	}
 	return relationships, modelFragments, nil
@@ -843,17 +918,174 @@ func (a *ProviderBackedAuthorizer) backfillDynamicFragments(ctx context.Context,
 	return nil
 }
 
-func relationshipFromDynamicFragment(relationship coredata.AuthorizationDynamicFragmentRelationship) *core.Relationship {
+func (a *ProviderBackedAuthorizer) staticResourceTypeState(roles providerBackedRoleState) (map[string]struct{}, map[string]map[string]struct{}) {
+	names := map[string]struct{}{}
+	relations := map[string]map[string]struct{}{}
+	addResourceTypes := func(resourceTypes []*core.AuthorizationModelResourceType) {
+		for _, resourceType := range resourceTypes {
+			name := strings.TrimSpace(resourceType.GetName())
+			if name == "" {
+				continue
+			}
+			names[name] = struct{}{}
+			relations[name] = modelResourceTypeRelations(resourceType)
+		}
+	}
+	addResourceTypes(buildProviderAuthorizationModel(roles).GetResourceTypes())
+	addResourceTypes(a.base.modelFragments)
+	for _, resourceType := range providerAuthorizationResourceTypes {
+		if name := strings.TrimSpace(resourceType); name != "" {
+			names[name] = struct{}{}
+		}
+	}
+	return names, relations
+}
+
+func dynamicFragmentRoleState(fragments []*coredata.AuthorizationDynamicFragment) providerBackedRoleState {
+	state := providerBackedRoleState{
+		pluginDynamicRoles: map[string][]string{},
+	}
+	pluginRoles := map[string]map[string]struct{}{}
+	adminRoles := map[string]struct{}{}
+	for _, fragment := range fragments {
+		if fragment == nil || strings.TrimSpace(fragment.Status) != coredata.AuthorizationFragmentStatusActive {
+			continue
+		}
+		localResourceTypes := dynamicFragmentLocalResourceTypes(fragment)
+		for _, relationship := range fragment.Relationships {
+			resourceType, err := dynamicFragmentCanonicalResourceType(fragment.Owner, relationship.Resource.Type, localResourceTypes)
+			if err != nil {
+				continue
+			}
+			relation := strings.TrimSpace(relationship.Relation)
+			if relation == "" {
+				continue
+			}
+			switch resourceType {
+			case resourceTypePluginDynamic:
+				resourceID := strings.TrimSpace(relationship.Resource.ID)
+				if resourceID != "" {
+					ensureRoleSet(pluginRoles, resourceID)[relation] = struct{}{}
+				}
+			case resourceTypeAdminDynamic:
+				if strings.TrimSpace(relationship.Resource.ID) == resourceIDAdminDynamicGlobal {
+					adminRoles[relation] = struct{}{}
+				}
+			}
+		}
+	}
+	for resourceID, roles := range pluginRoles {
+		state.pluginDynamicRoles[resourceID] = normalizeRoleList(roles)
+	}
+	state.adminDynamicRoles = normalizeRoleList(adminRoles)
+	return state
+}
+
+func modelResourceTypeRelations(resourceType *core.AuthorizationModelResourceType) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, relation := range resourceType.GetRelations() {
+		if name := strings.TrimSpace(relation.GetName()); name != "" {
+			out[name] = struct{}{}
+		}
+	}
+	return out
+}
+
+func dynamicFragmentLocalResourceTypes(fragment *coredata.AuthorizationDynamicFragment) map[string]struct{} {
+	out := map[string]struct{}{}
+	if fragment == nil {
+		return out
+	}
+	for name := range fragment.ResourceTypes {
+		if name = strings.TrimSpace(name); name != "" {
+			out[name] = struct{}{}
+		}
+	}
+	return out
+}
+
+func dynamicFragmentCanonicalResourceType(owner coredata.AuthorizationFragmentOwner, resourceType string, localResourceTypes map[string]struct{}) (string, error) {
+	resourceType = strings.TrimSpace(resourceType)
+	if resourceType == "" {
+		return "", fmt.Errorf("resource type is required")
+	}
+	if strings.TrimSpace(owner.Kind) != coredata.AuthorizationFragmentOwnerKindPlugin {
+		return resourceType, nil
+	}
+	plugin := strings.TrimSpace(owner.Plugin)
+	if plugin == "" {
+		return "", fmt.Errorf("plugin owner requires plugin")
+	}
+	prefix := "plugin/" + plugin + "/"
+	if strings.HasPrefix(resourceType, "plugin/") {
+		if !strings.HasPrefix(resourceType, prefix) {
+			return "", fmt.Errorf("plugin fragment cannot reference resource type %q outside %q", resourceType, prefix)
+		}
+		return resourceType, nil
+	}
+	if _, ok := localResourceTypes[resourceType]; ok {
+		return prefix + resourceType, nil
+	}
+	switch resourceType {
+	case resourceTypePluginDynamic:
+		return resourceType, nil
+	default:
+		return "", fmt.Errorf("plugin fragment cannot reference non-local resource type %q", resourceType)
+	}
+}
+
+func dynamicFragmentOwnerKey(owner coredata.AuthorizationFragmentOwner) string {
+	return strings.TrimSpace(owner.Kind) + "\x00" + dynamicFragmentOwnerID(owner)
+}
+
+func dynamicFragmentOwnerID(owner coredata.AuthorizationFragmentOwner) string {
+	if strings.TrimSpace(owner.Kind) == coredata.AuthorizationFragmentOwnerKindPlugin {
+		return strings.TrimSpace(owner.Plugin)
+	}
+	return coredata.AuthorizationFragmentOwnerKindGlobal
+}
+
+func (a *ProviderBackedAuthorizer) validateDynamicRelationship(rel *core.Relationship, resourceRelations map[string]map[string]struct{}, staticResourceTypes map[string]struct{}) error {
+	resourceType := strings.TrimSpace(rel.GetResource().GetType())
+	relation := strings.TrimSpace(rel.GetRelation())
+	if resourceType == "" || relation == "" {
+		return fmt.Errorf("resource type and relation are required")
+	}
+	relations := resourceRelations[resourceType]
+	if len(relations) == 0 {
+		return fmt.Errorf("resource type %q is not defined by the composed model", resourceType)
+	}
+	if _, ok := relations[relation]; !ok {
+		return fmt.Errorf("relation %q is not defined on resource type %q", relation, resourceType)
+	}
+	if _, static := staticResourceTypes[resourceType]; static &&
+		resourceType != resourceTypePluginDynamic &&
+		resourceType != resourceTypeAdminDynamic &&
+		!a.base.resourceDynamicPolicies[resourceType].AllowAdditionalRelationships {
+		return fmt.Errorf("static resource type %q does not allow dynamic relationships", resourceType)
+	}
+	return nil
+}
+
+func relationshipFromDynamicFragment(owner coredata.AuthorizationFragmentOwner, relationship coredata.AuthorizationDynamicFragmentRelationship, localResourceTypes map[string]struct{}) (*core.Relationship, error) {
 	subject := &core.SubjectRef{Type: strings.TrimSpace(relationship.Subject.Type), Id: strings.TrimSpace(relationship.Subject.ID)}
-	resource := &core.ResourceRef{Type: strings.TrimSpace(relationship.Resource.Type), Id: strings.TrimSpace(relationship.Resource.ID)}
+	resourceType, err := dynamicFragmentCanonicalResourceType(owner, relationship.Resource.Type, localResourceTypes)
+	if err != nil {
+		return nil, err
+	}
+	resource := &core.ResourceRef{Type: resourceType, Id: strings.TrimSpace(relationship.Resource.ID)}
 	if subject.GetType() == "" || subject.GetId() == "" || resource.GetType() == "" || resource.GetId() == "" || strings.TrimSpace(relationship.Relation) == "" {
-		return nil
+		return nil, nil
+	}
+	target, err := dynamicFragmentRelationshipTarget(owner, relationship.Target, localResourceTypes)
+	if err != nil {
+		return nil, err
 	}
 	rel := &core.Relationship{
 		Subject:  subject,
 		Relation: strings.TrimSpace(relationship.Relation),
 		Resource: resource,
-		Target:   dynamicFragmentRelationshipTarget(relationship.Target),
+		Target:   target,
 	}
 	if len(relationship.Properties) > 0 {
 		properties := make(map[string]any, len(relationship.Properties))
@@ -862,7 +1094,7 @@ func relationshipFromDynamicFragment(relationship coredata.AuthorizationDynamicF
 		}
 		rel.Properties, _ = structpb.NewStruct(properties)
 	}
-	return rel
+	return rel, nil
 }
 
 func dynamicFragmentRelationshipFromProvider(rel *core.Relationship) (coredata.AuthorizationDynamicFragmentRelationship, coredata.AuthorizationFragmentOwner, bool) {
@@ -970,141 +1202,94 @@ func (a *ProviderBackedAuthorizer) buildComposedAuthorizationModel(roles provide
 	return model
 }
 
-type dynamicFragmentResourceTypeDef struct {
-	Relations map[string]dynamicFragmentRelationDef `json:"relations,omitempty"`
-	Actions   map[string]dynamicFragmentActionDef   `json:"actions,omitempty"`
-}
-
-type dynamicFragmentRelationDef struct {
-	SubjectTypes   []string                          `json:"subjectTypes,omitempty"`
-	AllowedTargets []dynamicFragmentAllowedTargetDef `json:"allowedTargets,omitempty"`
-	Rewrite        *dynamicFragmentRewriteDef        `json:"rewrite,omitempty"`
-}
-
-type dynamicFragmentActionDef struct {
-	Relations []string                   `json:"relations,omitempty"`
-	Rewrite   *dynamicFragmentRewriteDef `json:"rewrite,omitempty"`
-}
-
-type dynamicFragmentAllowedTargetDef struct {
-	SubjectType  string                            `json:"subjectType,omitempty"`
-	ResourceType string                            `json:"resourceType,omitempty"`
-	SubjectSet   *dynamicFragmentSubjectSetTypeDef `json:"subjectSet,omitempty"`
-}
-
-type dynamicFragmentSubjectSetTypeDef struct {
-	ResourceType string `json:"resourceType,omitempty"`
-	Relation     string `json:"relation,omitempty"`
-}
-
-type dynamicFragmentRewriteDef struct {
-	This            *struct{}                      `json:"this,omitempty"`
-	ComputedUserset *dynamicFragmentRelationRef    `json:"computedUserset,omitempty"`
-	TupleToUserset  *dynamicFragmentTupleToUserset `json:"tupleToUserset,omitempty"`
-	Union           []dynamicFragmentRewriteDef    `json:"union,omitempty"`
-}
-
-type dynamicFragmentRelationRef struct {
-	Relation string `json:"relation,omitempty"`
-}
-
-type dynamicFragmentTupleToUserset struct {
-	TuplesetRelation string `json:"tuplesetRelation,omitempty"`
-	ComputedRelation string `json:"computedRelation,omitempty"`
-}
-
-func dynamicFragmentModelResourceType(name string, raw json.RawMessage) (*core.AuthorizationModelResourceType, error) {
-	name = strings.TrimSpace(name)
-	if name == "" {
+func dynamicFragmentModelResourceType(owner coredata.AuthorizationFragmentOwner, name string, raw json.RawMessage, localResourceTypes map[string]struct{}) (*core.AuthorizationModelResourceType, error) {
+	canonicalName, err := dynamicFragmentCanonicalResourceType(owner, name, localResourceTypes)
+	if err != nil {
+		return nil, err
+	}
+	if canonicalName == "" {
 		return nil, fmt.Errorf("name is required")
 	}
-	var def dynamicFragmentResourceTypeDef
+	var def coredata.AuthorizationDynamicFragmentResourceTypeDef
 	if len(raw) > 0 {
 		if err := json.Unmarshal(raw, &def); err != nil {
 			return nil, err
 		}
 	}
-	resourceType := &core.AuthorizationModelResourceType{Name: name}
+	resourceType := &core.AuthorizationModelResourceType{Name: canonicalName}
 	for relationName, relation := range def.Relations {
+		allowedTargets, err := dynamicFragmentAllowedTargets(owner, relation.AllowedTargets, localResourceTypes)
+		if err != nil {
+			return nil, fmt.Errorf("relations.%s.allowedTargets: %w", relationName, err)
+		}
 		resourceType.Relations = append(resourceType.Relations, &core.AuthorizationModelRelation{
 			Name:           relationName,
 			SubjectTypes:   append([]string(nil), relation.SubjectTypes...),
-			AllowedTargets: dynamicFragmentAllowedTargets(relation.AllowedTargets),
-			Rewrite:        dynamicFragmentRewrite(relation.Rewrite),
+			AllowedTargets: allowedTargets,
 		})
 	}
 	for actionName, action := range def.Actions {
 		resourceType.Actions = append(resourceType.Actions, &core.AuthorizationModelAction{
 			Name:      actionName,
 			Relations: append([]string(nil), action.Relations...),
-			Rewrite:   dynamicFragmentRewrite(action.Rewrite),
 		})
 	}
 	return resourceType, nil
 }
 
-func dynamicFragmentAllowedTargets(targets []dynamicFragmentAllowedTargetDef) []*core.AuthorizationModelAllowedTarget {
+func dynamicFragmentAllowedTargets(owner coredata.AuthorizationFragmentOwner, targets []coredata.AuthorizationDynamicFragmentAllowedTarget, localResourceTypes map[string]struct{}) ([]*core.AuthorizationModelAllowedTarget, error) {
 	out := make([]*core.AuthorizationModelAllowedTarget, 0, len(targets))
-	for _, target := range targets {
+	for i, target := range targets {
 		switch {
 		case strings.TrimSpace(target.SubjectType) != "":
 			out = append(out, &core.AuthorizationModelAllowedTarget{
 				Kind: &proto.AuthorizationModelAllowedTarget_SubjectType{SubjectType: strings.TrimSpace(target.SubjectType)},
 			})
 		case strings.TrimSpace(target.ResourceType) != "":
+			resourceType, err := dynamicFragmentCanonicalResourceType(owner, target.ResourceType, localResourceTypes)
+			if err != nil {
+				return nil, fmt.Errorf("[%d]: %w", i, err)
+			}
 			out = append(out, &core.AuthorizationModelAllowedTarget{
-				Kind: &proto.AuthorizationModelAllowedTarget_ResourceType{ResourceType: strings.TrimSpace(target.ResourceType)},
+				Kind: &proto.AuthorizationModelAllowedTarget_ResourceType{ResourceType: resourceType},
 			})
 		case target.SubjectSet != nil:
+			resourceType, err := dynamicFragmentCanonicalResourceType(owner, target.SubjectSet.ResourceType, localResourceTypes)
+			if err != nil {
+				return nil, fmt.Errorf("[%d]: %w", i, err)
+			}
 			out = append(out, &core.AuthorizationModelAllowedTarget{
 				Kind: &proto.AuthorizationModelAllowedTarget_SubjectSet{SubjectSet: &core.AuthorizationModelSubjectSetTarget{
-					ResourceType: strings.TrimSpace(target.SubjectSet.ResourceType),
+					ResourceType: resourceType,
 					Relation:     strings.TrimSpace(target.SubjectSet.Relation),
 				}},
 			})
 		}
 	}
-	return out
+	return out, nil
 }
 
-func dynamicFragmentRewrite(def *dynamicFragmentRewriteDef) *core.AuthorizationModelRewrite {
-	if def == nil {
-		return nil
-	}
-	switch {
-	case def.This != nil:
-		return &core.AuthorizationModelRewrite{Kind: &proto.AuthorizationModelRewrite_This{This: &core.AuthorizationModelRewriteThis{}}}
-	case def.ComputedUserset != nil:
-		return &core.AuthorizationModelRewrite{Kind: &proto.AuthorizationModelRewrite_ComputedUserset{ComputedUserset: &core.AuthorizationModelComputedUserset{Relation: strings.TrimSpace(def.ComputedUserset.Relation)}}}
-	case def.TupleToUserset != nil:
-		return &core.AuthorizationModelRewrite{Kind: &proto.AuthorizationModelRewrite_TupleToUserset{TupleToUserset: &core.AuthorizationModelTupleToUserset{
-			TuplesetRelation: strings.TrimSpace(def.TupleToUserset.TuplesetRelation),
-			ComputedRelation: strings.TrimSpace(def.TupleToUserset.ComputedRelation),
-		}}}
-	case len(def.Union) > 0:
-		children := make([]*core.AuthorizationModelRewrite, 0, len(def.Union))
-		for i := range def.Union {
-			children = append(children, dynamicFragmentRewrite(&def.Union[i]))
-		}
-		return &core.AuthorizationModelRewrite{Kind: &proto.AuthorizationModelRewrite_Union{Union: &core.AuthorizationModelRewriteUnion{Children: children}}}
-	default:
-		return nil
-	}
-}
-
-func dynamicFragmentRelationshipTarget(target coredata.AuthorizationDynamicFragmentTarget) *core.RelationshipTargetRef {
+func dynamicFragmentRelationshipTarget(owner coredata.AuthorizationFragmentOwner, target coredata.AuthorizationDynamicFragmentTarget, localResourceTypes map[string]struct{}) (*core.RelationshipTargetRef, error) {
 	switch {
 	case target.Subject != nil:
-		return &core.RelationshipTargetRef{Kind: &proto.RelationshipTarget_Subject{Subject: &core.SubjectRef{Type: strings.TrimSpace(target.Subject.Type), Id: strings.TrimSpace(target.Subject.ID)}}}
+		return &core.RelationshipTargetRef{Kind: &proto.RelationshipTarget_Subject{Subject: &core.SubjectRef{Type: strings.TrimSpace(target.Subject.Type), Id: strings.TrimSpace(target.Subject.ID)}}}, nil
 	case target.Resource != nil:
-		return &core.RelationshipTargetRef{Kind: &proto.RelationshipTarget_Resource{Resource: &core.ResourceRef{Type: strings.TrimSpace(target.Resource.Type), Id: strings.TrimSpace(target.Resource.ID)}}}
+		resourceType, err := dynamicFragmentCanonicalResourceType(owner, target.Resource.Type, localResourceTypes)
+		if err != nil {
+			return nil, err
+		}
+		return &core.RelationshipTargetRef{Kind: &proto.RelationshipTarget_Resource{Resource: &core.ResourceRef{Type: resourceType, Id: strings.TrimSpace(target.Resource.ID)}}}, nil
 	case target.SubjectSet != nil:
+		resourceType, err := dynamicFragmentCanonicalResourceType(owner, target.SubjectSet.Resource.Type, localResourceTypes)
+		if err != nil {
+			return nil, err
+		}
 		return &core.RelationshipTargetRef{Kind: &proto.RelationshipTarget_SubjectSet{SubjectSet: &core.SubjectSetRef{
-			Resource: &core.ResourceRef{Type: strings.TrimSpace(target.SubjectSet.Resource.Type), Id: strings.TrimSpace(target.SubjectSet.Resource.ID)},
+			Resource: &core.ResourceRef{Type: resourceType, Id: strings.TrimSpace(target.SubjectSet.Resource.ID)},
 			Relation: strings.TrimSpace(target.SubjectSet.Relation),
-		}}}
+		}}}, nil
 	default:
-		return nil
+		return nil, nil
 	}
 }
 

--- a/gestaltd/services/authorization/provider_backed.go
+++ b/gestaltd/services/authorization/provider_backed.go
@@ -2,6 +2,7 @@ package authorization
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -12,8 +13,10 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	proto "github.com/valon-technologies/gestalt/server/internal/gen/v1"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 type providerBackedRoleState struct {
@@ -27,7 +30,10 @@ type providerBackedRoleState struct {
 type ProviderBackedAuthorizer struct {
 	base *Authorizer
 
-	provider core.AuthorizationProvider
+	provider       core.AuthorizationProvider
+	fragmentSource *coredata.AuthorizationDynamicFragmentService
+	backfillMu     sync.Mutex
+	backfilled     bool
 
 	lifecycleMu sync.Mutex
 	started     bool
@@ -45,14 +51,22 @@ var _ RuntimeAuthorizer = (*ProviderBackedAuthorizer)(nil)
 
 const providerBackedReloadInterval = 5 * time.Second
 
-func NewProviderBacked(base *Authorizer, provider core.AuthorizationProvider) (*ProviderBackedAuthorizer, error) {
+type ProviderBackedOption func(*ProviderBackedAuthorizer)
+
+func WithDynamicFragmentSource(source *coredata.AuthorizationDynamicFragmentService) ProviderBackedOption {
+	return func(a *ProviderBackedAuthorizer) {
+		a.fragmentSource = source
+	}
+}
+
+func NewProviderBacked(base *Authorizer, provider core.AuthorizationProvider, opts ...ProviderBackedOption) (*ProviderBackedAuthorizer, error) {
 	if base == nil {
 		return nil, errors.New("base authorizer is required")
 	}
 	if provider == nil {
 		return nil, errors.New("authorization provider is required")
 	}
-	return &ProviderBackedAuthorizer{
+	a := &ProviderBackedAuthorizer{
 		base:     base,
 		provider: provider,
 		state: providerBackedRoleState{
@@ -60,7 +74,13 @@ func NewProviderBacked(base *Authorizer, provider core.AuthorizationProvider) (*
 			pluginStaticRoles:  map[string][]string{},
 			pluginDynamicRoles: map[string][]string{},
 		},
-	}, nil
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(a)
+		}
+	}
+	return a, nil
 }
 
 func (a *ProviderBackedAuthorizer) Start(ctx context.Context) error {
@@ -172,7 +192,11 @@ func (a *ProviderBackedAuthorizer) reloadAuthorizationStateLocked(ctx context.Co
 			return "", err
 		}
 	}
-	desired, roles, err := a.buildDesiredRelationships(sourceExisting)
+	fragmentRelationships, fragmentModelFragments, err := a.dynamicFragmentState(ctx, sourceExisting)
+	if err != nil {
+		return "", err
+	}
+	desired, roles, err := a.buildDesiredRelationships(sourceExisting, fragmentRelationships)
 	if err != nil {
 		return "", err
 	}
@@ -181,7 +205,7 @@ func (a *ProviderBackedAuthorizer) reloadAuthorizationStateLocked(ctx context.Co
 			return "", err
 		}
 	}
-	model, err := a.provider.WriteModel(ctx, &core.WriteModelRequest{Model: buildProviderAuthorizationModel(roles)})
+	model, err := a.provider.WriteModel(ctx, &core.WriteModelRequest{Model: a.buildComposedAuthorizationModel(roles, fragmentModelFragments)})
 	if err != nil {
 		return "", fmt.Errorf("write authorization model: %w", err)
 	}
@@ -599,7 +623,7 @@ func (a *ProviderBackedAuthorizer) readAllRelationships(ctx context.Context, mod
 	}
 }
 
-func (a *ProviderBackedAuthorizer) buildDesiredRelationships(existing map[string]*core.Relationship) (map[string]*core.Relationship, providerBackedRoleState, error) {
+func (a *ProviderBackedAuthorizer) buildDesiredRelationships(existing map[string]*core.Relationship, fragmentRelationships []*core.Relationship) (map[string]*core.Relationship, providerBackedRoleState, error) {
 	desired := map[string]*core.Relationship{}
 	state := providerBackedRoleState{
 		policyStaticRoles:  map[string][]string{},
@@ -617,20 +641,26 @@ func (a *ProviderBackedAuthorizer) buildDesiredRelationships(existing map[string
 		}
 		switch strings.TrimSpace(rel.GetResource().GetType()) {
 		case resourceTypePluginDynamic:
+			if a.fragmentSource != nil {
+				continue
+			}
 			resourceID := strings.TrimSpace(rel.GetResource().GetId())
 			relation := strings.TrimSpace(rel.GetRelation())
 			if resourceID == "" || relation == "" {
 				continue
 			}
-			addDesiredRelationship(desired, rel)
+			addDesiredRelationship(desired, synthesizedRelationship(rel, "provider_dynamic", "legacy_plugin_dynamic", "plugin", resourceID))
 			ensureRoleSet(pluginDynamicRoles, resourceID)[relation] = struct{}{}
 		case resourceTypeAdminDynamic:
+			if a.fragmentSource != nil {
+				continue
+			}
 			resourceID := strings.TrimSpace(rel.GetResource().GetId())
 			relation := strings.TrimSpace(rel.GetRelation())
 			if resourceID != resourceIDAdminDynamicGlobal || relation == "" {
 				continue
 			}
-			addDesiredRelationship(desired, rel)
+			addDesiredRelationship(desired, synthesizedRelationship(rel, "provider_dynamic", "legacy_admin_dynamic", "global", resourceIDAdminDynamicGlobal))
 			adminDynamicRoles[relation] = struct{}{}
 		case resourceTypeExternalIdentity:
 			relation := strings.TrimSpace(rel.GetRelation())
@@ -643,7 +673,7 @@ func (a *ProviderBackedAuthorizer) buildDesiredRelationships(existing map[string
 			default:
 				continue
 			}
-			addDesiredRelationship(desired, rel)
+			addDesiredRelationship(desired, synthesizedRelationship(rel, "provider_existing", "external_identity", "", ""))
 		case resourceTypeManagedSubject:
 			relation := strings.TrimSpace(rel.GetRelation())
 			subject := relationshipTargetSubject(rel)
@@ -653,12 +683,41 @@ func (a *ProviderBackedAuthorizer) buildDesiredRelationships(existing map[string
 			if strings.TrimSpace(subject.GetType()) != subjectTypeSubject {
 				continue
 			}
-			addDesiredRelationship(desired, rel)
+			addDesiredRelationship(desired, synthesizedRelationship(rel, "provider_existing", "managed_subject", "", ""))
+		case resourceTypeAgentSession:
+			if !validManagedAgentSessionRelationship(rel) {
+				continue
+			}
+			addDesiredRelationship(desired, synthesizedRelationship(rel, "provider_existing", "agent_session", "", ""))
 		case resourceTypeEveryone, resourceTypeTeam, resourceTypeSlackChannel:
 			if !validManagedMembershipRelationship(rel) {
 				continue
 			}
-			addDesiredRelationship(desired, rel)
+			addDesiredRelationship(desired, synthesizedRelationship(rel, "provider_existing", "membership", "", ""))
+		}
+	}
+
+	for _, rel := range fragmentRelationships {
+		if rel == nil || rel.GetResource() == nil {
+			continue
+		}
+		switch strings.TrimSpace(rel.GetResource().GetType()) {
+		case resourceTypePluginDynamic:
+			resourceID := strings.TrimSpace(rel.GetResource().GetId())
+			relation := strings.TrimSpace(rel.GetRelation())
+			if resourceID == "" || relation == "" {
+				continue
+			}
+			addDesiredRelationship(desired, synthesizedRelationship(rel, "dynamic_fragment", "plugin/"+resourceID, "plugin", resourceID))
+			ensureRoleSet(pluginDynamicRoles, resourceID)[relation] = struct{}{}
+		case resourceTypeAdminDynamic:
+			resourceID := strings.TrimSpace(rel.GetResource().GetId())
+			relation := strings.TrimSpace(rel.GetRelation())
+			if resourceID != resourceIDAdminDynamicGlobal || relation == "" {
+				continue
+			}
+			addDesiredRelationship(desired, synthesizedRelationship(rel, "dynamic_fragment", "global", "global", resourceIDAdminDynamicGlobal))
+			adminDynamicRoles[relation] = struct{}{}
 		}
 	}
 
@@ -682,25 +741,32 @@ func (a *ProviderBackedAuthorizer) buildDesiredRelationships(existing map[string
 				continue
 			}
 			policyRoleSet[role] = struct{}{}
-			addDesiredRelationship(desired, &core.Relationship{
+			addDesiredRelationship(desired, synthesizedRelationship(&core.Relationship{
 				Subject:  &core.SubjectRef{Type: subjectTypeSubject, Id: subjectID},
 				Relation: role,
 				Resource: &core.ResourceRef{Type: resourceTypePolicyStatic, Id: policyName},
-			})
-			addDesiredRelationship(desired, &core.Relationship{
+			}, "static_config", "authorization.policies."+policyName, "policy", policyName))
+			addDesiredRelationship(desired, synthesizedRelationship(&core.Relationship{
 				Subject:  &core.SubjectRef{Type: subjectTypeSubject, Id: subjectID},
 				Relation: role,
 				Resource: &core.ResourceRef{Type: resourceTypeAdminPolicyStatic, Id: policyName},
-			})
+			}, "static_config", "authorization.policies."+policyName, "policy", policyName))
 			for _, providerName := range providersByPolicy[policyName] {
 				ensureRoleSet(pluginStaticRoles, providerName)[role] = struct{}{}
-				addDesiredRelationship(desired, &core.Relationship{
+				addDesiredRelationship(desired, synthesizedRelationship(&core.Relationship{
 					Subject:  &core.SubjectRef{Type: subjectTypeSubject, Id: subjectID},
 					Relation: role,
 					Resource: &core.ResourceRef{Type: resourceTypePluginStatic, Id: providerName},
-				})
+				}, "static_config", "authorization.policies."+policyName, "plugin", providerName))
 			}
 		}
+	}
+
+	for i, rel := range a.base.relationships {
+		if rel == nil {
+			continue
+		}
+		addDesiredRelationship(desired, synthesizedRelationship(rel, "static_config", fmt.Sprintf("authorization.relationships[%d]", i), "", ""))
 	}
 
 	for name, roles := range policyStaticRoles {
@@ -714,6 +780,372 @@ func (a *ProviderBackedAuthorizer) buildDesiredRelationships(existing map[string
 	}
 	state.adminDynamicRoles = normalizeRoleList(adminDynamicRoles)
 	return desired, state, nil
+}
+
+func (a *ProviderBackedAuthorizer) dynamicFragmentState(ctx context.Context, existing map[string]*core.Relationship) ([]*core.Relationship, []*core.AuthorizationModelResourceType, error) {
+	if a.fragmentSource == nil {
+		return nil, nil, nil
+	}
+	if err := a.ensureDynamicFragmentsBackfilled(ctx, existing); err != nil {
+		return nil, nil, err
+	}
+	fragments, err := a.fragmentSource.ListFragments(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("list dynamic authorization fragments: %w", err)
+	}
+	var relationships []*core.Relationship
+	var modelFragments []*core.AuthorizationModelResourceType
+	for _, fragment := range fragments {
+		if fragment == nil || strings.TrimSpace(fragment.Status) != coredata.AuthorizationFragmentStatusActive {
+			continue
+		}
+		for resourceTypeName, raw := range fragment.ResourceTypes {
+			resourceType, err := dynamicFragmentModelResourceType(resourceTypeName, raw)
+			if err != nil {
+				return nil, nil, fmt.Errorf("dynamic authorization fragment %q resource type %q: %w", fragment.ID, resourceTypeName, err)
+			}
+			modelFragments = append(modelFragments, resourceType)
+		}
+		for _, relationship := range fragment.Relationships {
+			rel := relationshipFromDynamicFragment(relationship)
+			if rel == nil {
+				continue
+			}
+			relationships = append(relationships, rel)
+		}
+	}
+	return relationships, modelFragments, nil
+}
+
+func (a *ProviderBackedAuthorizer) ensureDynamicFragmentsBackfilled(ctx context.Context, existing map[string]*core.Relationship) error {
+	a.backfillMu.Lock()
+	defer a.backfillMu.Unlock()
+	if a.backfilled {
+		return nil
+	}
+	if err := a.backfillDynamicFragments(ctx, existing); err != nil {
+		return err
+	}
+	a.backfilled = true
+	return nil
+}
+
+func (a *ProviderBackedAuthorizer) backfillDynamicFragments(ctx context.Context, existing map[string]*core.Relationship) error {
+	for _, rel := range existing {
+		fragmentRelationship, owner, ok := dynamicFragmentRelationshipFromProvider(rel)
+		if !ok {
+			continue
+		}
+		if _, err := a.fragmentSource.UpsertRelationship(ctx, owner, fragmentRelationship, coredata.AuthorizationDynamicFragmentAuditMetadata{Reason: "provider_backed_reload_backfill"}); err != nil {
+			return fmt.Errorf("backfill dynamic authorization fragment: %w", err)
+		}
+	}
+	return nil
+}
+
+func relationshipFromDynamicFragment(relationship coredata.AuthorizationDynamicFragmentRelationship) *core.Relationship {
+	subject := &core.SubjectRef{Type: strings.TrimSpace(relationship.Subject.Type), Id: strings.TrimSpace(relationship.Subject.ID)}
+	resource := &core.ResourceRef{Type: strings.TrimSpace(relationship.Resource.Type), Id: strings.TrimSpace(relationship.Resource.ID)}
+	if subject.GetType() == "" || subject.GetId() == "" || resource.GetType() == "" || resource.GetId() == "" || strings.TrimSpace(relationship.Relation) == "" {
+		return nil
+	}
+	rel := &core.Relationship{
+		Subject:  subject,
+		Relation: strings.TrimSpace(relationship.Relation),
+		Resource: resource,
+		Target:   dynamicFragmentRelationshipTarget(relationship.Target),
+	}
+	if len(relationship.Properties) > 0 {
+		properties := make(map[string]any, len(relationship.Properties))
+		for key, value := range relationship.Properties {
+			properties[key] = value
+		}
+		rel.Properties, _ = structpb.NewStruct(properties)
+	}
+	return rel
+}
+
+func dynamicFragmentRelationshipFromProvider(rel *core.Relationship) (coredata.AuthorizationDynamicFragmentRelationship, coredata.AuthorizationFragmentOwner, bool) {
+	if rel == nil || relationshipTargetSubject(rel) == nil || rel.GetResource() == nil {
+		return coredata.AuthorizationDynamicFragmentRelationship{}, coredata.AuthorizationFragmentOwner{}, false
+	}
+	resource := rel.GetResource()
+	switch strings.TrimSpace(resource.GetType()) {
+	case resourceTypePluginDynamic:
+		plugin := strings.TrimSpace(resource.GetId())
+		if plugin == "" {
+			return coredata.AuthorizationDynamicFragmentRelationship{}, coredata.AuthorizationFragmentOwner{}, false
+		}
+		return dynamicFragmentRelationshipFromCore(rel), coredata.AuthorizationPluginFragmentOwner(plugin), true
+	case resourceTypeAdminDynamic:
+		if strings.TrimSpace(resource.GetId()) != resourceIDAdminDynamicGlobal {
+			return coredata.AuthorizationDynamicFragmentRelationship{}, coredata.AuthorizationFragmentOwner{}, false
+		}
+		return dynamicFragmentRelationshipFromCore(rel), coredata.AuthorizationGlobalFragmentOwner(), true
+	default:
+		return coredata.AuthorizationDynamicFragmentRelationship{}, coredata.AuthorizationFragmentOwner{}, false
+	}
+}
+
+func dynamicFragmentRelationshipFromCore(rel *core.Relationship) coredata.AuthorizationDynamicFragmentRelationship {
+	subject := relationshipTargetSubject(rel)
+	relationship := coredata.AuthorizationDynamicFragmentRelationship{
+		Subject: coredata.AuthorizationDynamicFragmentSubject{
+			Type: strings.TrimSpace(subject.GetType()),
+			ID:   strings.TrimSpace(subject.GetId()),
+		},
+		Relation: strings.TrimSpace(rel.GetRelation()),
+		Resource: coredata.AuthorizationDynamicFragmentResource{
+			Type: strings.TrimSpace(rel.GetResource().GetType()),
+			ID:   strings.TrimSpace(rel.GetResource().GetId()),
+		},
+		Target: dynamicFragmentTargetFromCore(rel.GetTarget()),
+	}
+	if len(rel.GetProperties().GetFields()) > 0 {
+		relationship.Properties = map[string]string{}
+		for key, value := range rel.GetProperties().GetFields() {
+			if stringValue := value.GetStringValue(); stringValue != "" {
+				relationship.Properties[key] = stringValue
+			}
+		}
+		if len(relationship.Properties) == 0 {
+			relationship.Properties = nil
+		}
+	}
+	return relationship
+}
+
+func dynamicFragmentTargetFromCore(target *core.RelationshipTargetRef) coredata.AuthorizationDynamicFragmentTarget {
+	if target == nil {
+		return coredata.AuthorizationDynamicFragmentTarget{}
+	}
+	if subject := target.GetSubject(); subject != nil {
+		return coredata.AuthorizationDynamicFragmentTarget{Subject: &coredata.AuthorizationDynamicFragmentSubject{
+			Type: strings.TrimSpace(subject.GetType()),
+			ID:   strings.TrimSpace(subject.GetId()),
+		}}
+	}
+	if resource := target.GetResource(); resource != nil {
+		return coredata.AuthorizationDynamicFragmentTarget{Resource: &coredata.AuthorizationDynamicFragmentResource{
+			Type: strings.TrimSpace(resource.GetType()),
+			ID:   strings.TrimSpace(resource.GetId()),
+		}}
+	}
+	if subjectSet := target.GetSubjectSet(); subjectSet != nil {
+		resource := subjectSet.GetResource()
+		return coredata.AuthorizationDynamicFragmentTarget{SubjectSet: &coredata.AuthorizationDynamicFragmentSubjectSet{
+			Resource: coredata.AuthorizationDynamicFragmentResource{
+				Type: strings.TrimSpace(resource.GetType()),
+				ID:   strings.TrimSpace(resource.GetId()),
+			},
+			Relation: strings.TrimSpace(subjectSet.GetRelation()),
+		}}
+	}
+	return coredata.AuthorizationDynamicFragmentTarget{}
+}
+
+func (a *ProviderBackedAuthorizer) buildComposedAuthorizationModel(roles providerBackedRoleState, dynamicFragments []*core.AuthorizationModelResourceType) *core.AuthorizationModel {
+	model := buildProviderAuthorizationModel(roles)
+	seen := make(map[string]struct{}, len(model.GetResourceTypes())+len(a.base.modelFragments)+len(dynamicFragments))
+	for _, resourceType := range model.GetResourceTypes() {
+		seen[strings.TrimSpace(resourceType.GetName())] = struct{}{}
+	}
+	appendResourceTypes := func(resourceTypes []*core.AuthorizationModelResourceType) {
+		for _, resourceType := range resourceTypes {
+			if resourceType == nil || strings.TrimSpace(resourceType.GetName()) == "" {
+				continue
+			}
+			if _, ok := seen[strings.TrimSpace(resourceType.GetName())]; ok {
+				continue
+			}
+			model.ResourceTypes = append(model.ResourceTypes, cloneModelResourceTypes([]*core.AuthorizationModelResourceType{resourceType})...)
+			seen[strings.TrimSpace(resourceType.GetName())] = struct{}{}
+		}
+	}
+	appendResourceTypes(a.base.modelFragments)
+	appendResourceTypes(dynamicFragments)
+	sort.Slice(model.ResourceTypes, func(i, j int) bool {
+		return strings.Compare(model.ResourceTypes[i].GetName(), model.ResourceTypes[j].GetName()) < 0
+	})
+	return model
+}
+
+type dynamicFragmentResourceTypeDef struct {
+	Relations map[string]dynamicFragmentRelationDef `json:"relations,omitempty"`
+	Actions   map[string]dynamicFragmentActionDef   `json:"actions,omitempty"`
+}
+
+type dynamicFragmentRelationDef struct {
+	SubjectTypes   []string                          `json:"subjectTypes,omitempty"`
+	AllowedTargets []dynamicFragmentAllowedTargetDef `json:"allowedTargets,omitempty"`
+	Rewrite        *dynamicFragmentRewriteDef        `json:"rewrite,omitempty"`
+}
+
+type dynamicFragmentActionDef struct {
+	Relations []string                   `json:"relations,omitempty"`
+	Rewrite   *dynamicFragmentRewriteDef `json:"rewrite,omitempty"`
+}
+
+type dynamicFragmentAllowedTargetDef struct {
+	SubjectType  string                            `json:"subjectType,omitempty"`
+	ResourceType string                            `json:"resourceType,omitempty"`
+	SubjectSet   *dynamicFragmentSubjectSetTypeDef `json:"subjectSet,omitempty"`
+}
+
+type dynamicFragmentSubjectSetTypeDef struct {
+	ResourceType string `json:"resourceType,omitempty"`
+	Relation     string `json:"relation,omitempty"`
+}
+
+type dynamicFragmentRewriteDef struct {
+	This            *struct{}                      `json:"this,omitempty"`
+	ComputedUserset *dynamicFragmentRelationRef    `json:"computedUserset,omitempty"`
+	TupleToUserset  *dynamicFragmentTupleToUserset `json:"tupleToUserset,omitempty"`
+	Union           []dynamicFragmentRewriteDef    `json:"union,omitempty"`
+}
+
+type dynamicFragmentRelationRef struct {
+	Relation string `json:"relation,omitempty"`
+}
+
+type dynamicFragmentTupleToUserset struct {
+	TuplesetRelation string `json:"tuplesetRelation,omitempty"`
+	ComputedRelation string `json:"computedRelation,omitempty"`
+}
+
+func dynamicFragmentModelResourceType(name string, raw json.RawMessage) (*core.AuthorizationModelResourceType, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+	var def dynamicFragmentResourceTypeDef
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &def); err != nil {
+			return nil, err
+		}
+	}
+	resourceType := &core.AuthorizationModelResourceType{Name: name}
+	for relationName, relation := range def.Relations {
+		resourceType.Relations = append(resourceType.Relations, &core.AuthorizationModelRelation{
+			Name:           relationName,
+			SubjectTypes:   append([]string(nil), relation.SubjectTypes...),
+			AllowedTargets: dynamicFragmentAllowedTargets(relation.AllowedTargets),
+			Rewrite:        dynamicFragmentRewrite(relation.Rewrite),
+		})
+	}
+	for actionName, action := range def.Actions {
+		resourceType.Actions = append(resourceType.Actions, &core.AuthorizationModelAction{
+			Name:      actionName,
+			Relations: append([]string(nil), action.Relations...),
+			Rewrite:   dynamicFragmentRewrite(action.Rewrite),
+		})
+	}
+	return resourceType, nil
+}
+
+func dynamicFragmentAllowedTargets(targets []dynamicFragmentAllowedTargetDef) []*core.AuthorizationModelAllowedTarget {
+	out := make([]*core.AuthorizationModelAllowedTarget, 0, len(targets))
+	for _, target := range targets {
+		switch {
+		case strings.TrimSpace(target.SubjectType) != "":
+			out = append(out, &core.AuthorizationModelAllowedTarget{
+				Kind: &proto.AuthorizationModelAllowedTarget_SubjectType{SubjectType: strings.TrimSpace(target.SubjectType)},
+			})
+		case strings.TrimSpace(target.ResourceType) != "":
+			out = append(out, &core.AuthorizationModelAllowedTarget{
+				Kind: &proto.AuthorizationModelAllowedTarget_ResourceType{ResourceType: strings.TrimSpace(target.ResourceType)},
+			})
+		case target.SubjectSet != nil:
+			out = append(out, &core.AuthorizationModelAllowedTarget{
+				Kind: &proto.AuthorizationModelAllowedTarget_SubjectSet{SubjectSet: &core.AuthorizationModelSubjectSetTarget{
+					ResourceType: strings.TrimSpace(target.SubjectSet.ResourceType),
+					Relation:     strings.TrimSpace(target.SubjectSet.Relation),
+				}},
+			})
+		}
+	}
+	return out
+}
+
+func dynamicFragmentRewrite(def *dynamicFragmentRewriteDef) *core.AuthorizationModelRewrite {
+	if def == nil {
+		return nil
+	}
+	switch {
+	case def.This != nil:
+		return &core.AuthorizationModelRewrite{Kind: &proto.AuthorizationModelRewrite_This{This: &core.AuthorizationModelRewriteThis{}}}
+	case def.ComputedUserset != nil:
+		return &core.AuthorizationModelRewrite{Kind: &proto.AuthorizationModelRewrite_ComputedUserset{ComputedUserset: &core.AuthorizationModelComputedUserset{Relation: strings.TrimSpace(def.ComputedUserset.Relation)}}}
+	case def.TupleToUserset != nil:
+		return &core.AuthorizationModelRewrite{Kind: &proto.AuthorizationModelRewrite_TupleToUserset{TupleToUserset: &core.AuthorizationModelTupleToUserset{
+			TuplesetRelation: strings.TrimSpace(def.TupleToUserset.TuplesetRelation),
+			ComputedRelation: strings.TrimSpace(def.TupleToUserset.ComputedRelation),
+		}}}
+	case len(def.Union) > 0:
+		children := make([]*core.AuthorizationModelRewrite, 0, len(def.Union))
+		for i := range def.Union {
+			children = append(children, dynamicFragmentRewrite(&def.Union[i]))
+		}
+		return &core.AuthorizationModelRewrite{Kind: &proto.AuthorizationModelRewrite_Union{Union: &core.AuthorizationModelRewriteUnion{Children: children}}}
+	default:
+		return nil
+	}
+}
+
+func dynamicFragmentRelationshipTarget(target coredata.AuthorizationDynamicFragmentTarget) *core.RelationshipTargetRef {
+	switch {
+	case target.Subject != nil:
+		return &core.RelationshipTargetRef{Kind: &proto.RelationshipTarget_Subject{Subject: &core.SubjectRef{Type: strings.TrimSpace(target.Subject.Type), Id: strings.TrimSpace(target.Subject.ID)}}}
+	case target.Resource != nil:
+		return &core.RelationshipTargetRef{Kind: &proto.RelationshipTarget_Resource{Resource: &core.ResourceRef{Type: strings.TrimSpace(target.Resource.Type), Id: strings.TrimSpace(target.Resource.ID)}}}
+	case target.SubjectSet != nil:
+		return &core.RelationshipTargetRef{Kind: &proto.RelationshipTarget_SubjectSet{SubjectSet: &core.SubjectSetRef{
+			Resource: &core.ResourceRef{Type: strings.TrimSpace(target.SubjectSet.Resource.Type), Id: strings.TrimSpace(target.SubjectSet.Resource.ID)},
+			Relation: strings.TrimSpace(target.SubjectSet.Relation),
+		}}}
+	default:
+		return nil
+	}
+}
+
+func synthesizedRelationship(rel *core.Relationship, sourceLayer, sourceID, ownerKind, ownerID string) *core.Relationship {
+	if rel == nil {
+		return nil
+	}
+	out := cloneRelationships([]*core.Relationship{rel})[0]
+	properties := map[string]any{}
+	for key, value := range rel.GetProperties().GetFields() {
+		properties[key] = value.AsInterface()
+	}
+	properties["gestalt.authz.synthesized"] = true
+	if strings.TrimSpace(sourceLayer) != "" {
+		properties["gestalt.authz.source_layer"] = strings.TrimSpace(sourceLayer)
+	}
+	if strings.TrimSpace(sourceID) != "" {
+		properties["gestalt.authz.source_id"] = strings.TrimSpace(sourceID)
+	}
+	if strings.TrimSpace(ownerKind) != "" {
+		properties["gestalt.authz.owner_kind"] = strings.TrimSpace(ownerKind)
+	}
+	if strings.TrimSpace(ownerID) != "" {
+		properties["gestalt.authz.owner_id"] = strings.TrimSpace(ownerID)
+	}
+	props, err := structpb.NewStruct(properties)
+	if err == nil {
+		out.Properties = props
+	}
+	return out
+}
+
+func synthesizedProviderRelationship(rel *core.Relationship) bool {
+	if rel == nil {
+		return false
+	}
+	return rel.GetProperties().GetFields()["gestalt.authz.synthesized"].GetBoolValue()
+}
+
+func managedRelationship(rel *core.Relationship) bool {
+	return IsManagedProviderRelationship(rel) || synthesizedProviderRelationship(rel)
 }
 
 func addDesiredRelationship(target map[string]*core.Relationship, rel *core.Relationship) {
@@ -1007,8 +1439,4 @@ func (a *ProviderBackedAuthorizer) currentState() providerBackedRoleState {
 	a.stateMu.RLock()
 	defer a.stateMu.RUnlock()
 	return a.state
-}
-
-func managedRelationship(rel *core.Relationship) bool {
-	return IsManagedProviderRelationship(rel)
 }

--- a/gestaltd/services/authorization/provider_backed_test.go
+++ b/gestaltd/services/authorization/provider_backed_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -152,8 +153,26 @@ func TestProviderBackedReloadComposesConfigAndDynamicFragmentSources(t *testing.
 		ResourceTypes: map[string]json.RawMessage{
 			"project": json.RawMessage(`{"relations":{"viewer":{"subjectTypes":["subject"]}},"actions":{"view":{"relations":["viewer"]}}}`),
 		},
+		Relationships: []coredata.AuthorizationDynamicFragmentRelationship{{
+			Subject:  coredata.AuthorizationDynamicFragmentSubject{Type: subjectTypeSubject, ID: "user:carol"},
+			Relation: "viewer",
+			Resource: coredata.AuthorizationDynamicFragmentResource{Type: "project", ID: "proj-1"},
+		}},
 	}, coredata.AuthorizationDynamicFragmentUpdate{Audit: coredata.AuthorizationDynamicFragmentAuditMetadata{Reason: "test_dynamic_model"}}); err != nil {
 		t.Fatalf("PutFragment: %v", err)
+	}
+	if _, err := services.AuthzFragments.PutFragment(ctx, &coredata.AuthorizationDynamicFragment{
+		Owner: coredata.AuthorizationPluginFragmentOwner("github"),
+		ResourceTypes: map[string]json.RawMessage{
+			"repository": json.RawMessage(`{"relations":{"maintainer":{"subjectTypes":["subject"]}},"actions":{"administer":{"relations":["maintainer"]}}}`),
+		},
+		Relationships: []coredata.AuthorizationDynamicFragmentRelationship{{
+			Subject:  coredata.AuthorizationDynamicFragmentSubject{Type: subjectTypeSubject, ID: "user:dana"},
+			Relation: "maintainer",
+			Resource: coredata.AuthorizationDynamicFragmentResource{Type: "repository", ID: "valon-tools"},
+		}},
+	}, coredata.AuthorizationDynamicFragmentUpdate{Audit: coredata.AuthorizationDynamicFragmentAuditMetadata{Reason: "test_plugin_model"}}); err != nil {
+		t.Fatalf("PutFragment plugin: %v", err)
 	}
 	base, err := New(StaticConfig{
 		ModelFragments: []*core.AuthorizationModelResourceType{{
@@ -181,6 +200,15 @@ func TestProviderBackedReloadComposesConfigAndDynamicFragmentSources(t *testing.
 	}
 	if authorizationModelResourceType(provider.lastModel, "project") == nil {
 		t.Fatalf("composed model resource types = %#v, want project fragment", provider.lastModel.GetResourceTypes())
+	}
+	if authorizationModelResourceType(provider.lastModel, "plugin/github/repository") == nil {
+		t.Fatalf("composed model resource types = %#v, want plugin/github/repository fragment", provider.lastModel.GetResourceTypes())
+	}
+	if !provider.hasRelationship(providerBackedRoleTestRelationship("user:carol", "project", "proj-1", "viewer")) {
+		t.Fatal("provider is missing generic dynamic fragment relationship")
+	}
+	if !provider.hasRelationship(providerBackedRoleTestRelationship("user:dana", "plugin/github/repository", "valon-tools", "maintainer")) {
+		t.Fatal("provider is missing plugin-qualified dynamic fragment relationship")
 	}
 	if !provider.hasRelationship(legacyDynamic) {
 		t.Fatal("provider is missing backfilled plugin dynamic relationship")
@@ -214,6 +242,158 @@ func TestProviderBackedReloadComposesConfigAndDynamicFragmentSources(t *testing.
 	}
 	if provider.hasRelationship(legacyDynamic) {
 		t.Fatal("provider still has plugin dynamic relationship after source fragment deletion")
+	}
+}
+
+func TestProviderBackedReloadRemovesInvalidDynamicFragmentAndContinues(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	services, err := coredata.New(&coretesting.StubIndexedDB{})
+	if err != nil {
+		t.Fatalf("coredata.New: %v", err)
+	}
+	if _, err := services.AuthzFragments.PutFragment(ctx, &coredata.AuthorizationDynamicFragment{
+		Owner: coredata.AuthorizationGlobalFragmentOwner(),
+		ResourceTypes: map[string]json.RawMessage{
+			"workspace": json.RawMessage(`{"relations":{"viewer":{"subjectTypes":["subject"]}}}`),
+		},
+	}, coredata.AuthorizationDynamicFragmentUpdate{Audit: coredata.AuthorizationDynamicFragmentAuditMetadata{Reason: "test_conflict"}}); err != nil {
+		t.Fatalf("PutFragment invalid: %v", err)
+	}
+	base, err := New(StaticConfig{
+		ModelFragments: []*core.AuthorizationModelResourceType{{
+			Name: "workspace",
+			Relations: []*core.AuthorizationModelRelation{{
+				Name:         "member",
+				SubjectTypes: []string{subjectTypeSubject},
+			}},
+		}},
+		Relationships: []*core.Relationship{providerBackedRoleTestRelationship("user:bob", "workspace", "ws-1", "member")},
+	})
+	if err != nil {
+		t.Fatalf("New authorizer: %v", err)
+	}
+	provider := newProviderBackedComposerTestProvider("model-0")
+	authorizer, err := NewProviderBacked(base, provider, WithDynamicFragmentSource(services.AuthzFragments))
+	if err != nil {
+		t.Fatalf("NewProviderBacked: %v", err)
+	}
+	if err := authorizer.ReloadAuthorizationState(ctx); err != nil {
+		t.Fatalf("ReloadAuthorizationState: %v", err)
+	}
+	if _, err := services.AuthzFragments.GetFragmentByOwner(ctx, coredata.AuthorizationGlobalFragmentOwner()); !errors.Is(err, core.ErrNotFound) {
+		t.Fatalf("GetFragmentByOwner invalid err = %v, want not found", err)
+	}
+	if !provider.hasRelationship(providerBackedRoleTestRelationship("user:bob", "workspace", "ws-1", "member")) {
+		t.Fatal("provider is missing static relationship after invalid dynamic fragment cleanup")
+	}
+}
+
+func TestProviderBackedReloadRemovesDynamicFragmentRedefiningProviderResourceType(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	services, err := coredata.New(&coretesting.StubIndexedDB{})
+	if err != nil {
+		t.Fatalf("coredata.New: %v", err)
+	}
+	if _, err := services.AuthzFragments.PutFragment(ctx, &coredata.AuthorizationDynamicFragment{
+		Owner: coredata.AuthorizationGlobalFragmentOwner(),
+		ResourceTypes: map[string]json.RawMessage{
+			resourceTypePluginStatic: json.RawMessage(`{"relations":{"viewer":{"subjectTypes":["subject"]}}}`),
+		},
+	}, coredata.AuthorizationDynamicFragmentUpdate{Audit: coredata.AuthorizationDynamicFragmentAuditMetadata{Reason: "test_builtin_conflict"}}); err != nil {
+		t.Fatalf("PutFragment invalid: %v", err)
+	}
+	base, err := New(StaticConfig{})
+	if err != nil {
+		t.Fatalf("New authorizer: %v", err)
+	}
+	provider := newProviderBackedComposerTestProvider("model-0")
+	authorizer, err := NewProviderBacked(base, provider, WithDynamicFragmentSource(services.AuthzFragments))
+	if err != nil {
+		t.Fatalf("NewProviderBacked: %v", err)
+	}
+
+	if err := authorizer.ReloadAuthorizationState(ctx); err != nil {
+		t.Fatalf("ReloadAuthorizationState: %v", err)
+	}
+	if _, err := services.AuthzFragments.GetFragmentByOwner(ctx, coredata.AuthorizationGlobalFragmentOwner()); !errors.Is(err, core.ErrNotFound) {
+		t.Fatalf("GetFragmentByOwner invalid err = %v, want not found", err)
+	}
+}
+
+func TestProviderBackedReloadRemovesDynamicFragmentWithInvalidRelationshipTarget(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	services, err := coredata.New(&coretesting.StubIndexedDB{})
+	if err != nil {
+		t.Fatalf("coredata.New: %v", err)
+	}
+	if _, err := services.AuthzFragments.PutFragment(ctx, &coredata.AuthorizationDynamicFragment{
+		Owner: coredata.AuthorizationPluginFragmentOwner("github"),
+		ResourceTypes: map[string]json.RawMessage{
+			"repository": json.RawMessage(`{"relations":{"maintainer":{"subjectTypes":["subject"]}}}`),
+		},
+		Relationships: []coredata.AuthorizationDynamicFragmentRelationship{{
+			Subject:  coredata.AuthorizationDynamicFragmentSubject{Type: subjectTypeSubject, ID: "user:dana"},
+			Relation: "maintainer",
+			Resource: coredata.AuthorizationDynamicFragmentResource{Type: "repository", ID: "valon-tools"},
+			Target: coredata.AuthorizationDynamicFragmentTarget{
+				Resource: &coredata.AuthorizationDynamicFragmentResource{Type: "workspace", ID: "ws-1"},
+			},
+		}},
+	}, coredata.AuthorizationDynamicFragmentUpdate{Audit: coredata.AuthorizationDynamicFragmentAuditMetadata{Reason: "test_invalid_target"}}); err != nil {
+		t.Fatalf("PutFragment invalid target: %v", err)
+	}
+	base, err := New(StaticConfig{})
+	if err != nil {
+		t.Fatalf("New authorizer: %v", err)
+	}
+	provider := newProviderBackedComposerTestProvider("model-0")
+	authorizer, err := NewProviderBacked(base, provider, WithDynamicFragmentSource(services.AuthzFragments))
+	if err != nil {
+		t.Fatalf("NewProviderBacked: %v", err)
+	}
+
+	if err := authorizer.ReloadAuthorizationState(ctx); err != nil {
+		t.Fatalf("ReloadAuthorizationState: %v", err)
+	}
+	if _, err := services.AuthzFragments.GetFragmentByOwner(ctx, coredata.AuthorizationPluginFragmentOwner("github")); !errors.Is(err, core.ErrNotFound) {
+		t.Fatalf("GetFragmentByOwner invalid target err = %v, want not found", err)
+	}
+	if provider.hasRelationship(providerBackedRoleTestRelationship("user:dana", "plugin/github/repository", "valon-tools", "maintainer")) {
+		t.Fatal("provider has relationship from invalid dynamic fragment target")
+	}
+}
+
+func TestProviderBackedValidateDynamicRelationshipChecksCompatibilityDynamicRelations(t *testing.T) {
+	t.Parallel()
+
+	base, err := New(StaticConfig{})
+	if err != nil {
+		t.Fatalf("New authorizer: %v", err)
+	}
+	authorizer := &ProviderBackedAuthorizer{base: base}
+	fragments := []*coredata.AuthorizationDynamicFragment{{
+		Owner:  coredata.AuthorizationPluginFragmentOwner("github"),
+		Status: coredata.AuthorizationFragmentStatusActive,
+		Relationships: []coredata.AuthorizationDynamicFragmentRelationship{{
+			Subject:  coredata.AuthorizationDynamicFragmentSubject{Type: subjectTypeSubject, ID: "user:alice"},
+			Relation: "viewer",
+			Resource: coredata.AuthorizationDynamicFragmentResource{Type: resourceTypePluginDynamic, ID: "github"},
+		}},
+	}}
+	staticResourceTypes, resourceRelations := authorizer.staticResourceTypeState(dynamicFragmentRoleState(fragments))
+
+	if err := authorizer.validateDynamicRelationship(providerBackedRoleTestRelationship("user:alice", resourceTypePluginDynamic, "github", "viewer"), resourceRelations, staticResourceTypes); err != nil {
+		t.Fatalf("validateDynamicRelationship viewer: %v", err)
+	}
+	err = authorizer.validateDynamicRelationship(providerBackedRoleTestRelationship("user:alice", resourceTypePluginDynamic, "github", "owner"), resourceRelations, staticResourceTypes)
+	if err == nil || !strings.Contains(err.Error(), `relation "owner" is not defined`) {
+		t.Fatalf("validateDynamicRelationship owner error = %v, want undefined relation", err)
 	}
 }
 
@@ -269,6 +449,15 @@ func mustStruct(t *testing.T, fields map[string]any) *structpb.Struct {
 		t.Fatalf("structpb.NewStruct: %v", err)
 	}
 	return out
+}
+
+func authorizationModelResourceType(model *core.AuthorizationModel, name string) *core.AuthorizationModelResourceType {
+	for _, resourceType := range model.GetResourceTypes() {
+		if resourceType.GetName() == name {
+			return resourceType
+		}
+	}
+	return nil
 }
 
 type providerBackedComposerTestProvider struct {

--- a/gestaltd/services/authorization/provider_backed_test.go
+++ b/gestaltd/services/authorization/provider_backed_test.go
@@ -2,11 +2,17 @@ package authorization
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/core"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
+	proto "github.com/valon-technologies/gestalt/server/internal/gen/v1"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func TestExternalIdentityAssumptionSubjectRefsIncludesLegacyUserSubjectType(t *testing.T) {
@@ -123,6 +129,94 @@ func TestProviderBackedResolveAccessDeniesMismatchedReadRelationshipsModel(t *te
 	}
 }
 
+func TestProviderBackedReloadComposesConfigAndDynamicFragmentSources(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	services, err := coredata.New(&coretesting.StubIndexedDB{})
+	if err != nil {
+		t.Fatalf("coredata.New: %v", err)
+	}
+	legacyDynamic := &core.Relationship{
+		Target: &core.RelationshipTargetRef{Kind: &proto.RelationshipTarget_Subject{Subject: &core.SubjectRef{
+			Type: subjectTypeSubject,
+			Id:   "user:alice",
+		}}},
+		Relation:   "editor",
+		Resource:   &core.ResourceRef{Type: resourceTypePluginDynamic, Id: "slack"},
+		Properties: mustStruct(t, map[string]any{"source": "provider"}),
+	}
+	provider := newProviderBackedComposerTestProvider("model-0", legacyDynamic)
+	if _, err := services.AuthzFragments.PutFragment(ctx, &coredata.AuthorizationDynamicFragment{
+		Owner: coredata.AuthorizationGlobalFragmentOwner(),
+		ResourceTypes: map[string]json.RawMessage{
+			"project": json.RawMessage(`{"relations":{"viewer":{"subjectTypes":["subject"]}},"actions":{"view":{"relations":["viewer"]}}}`),
+		},
+	}, coredata.AuthorizationDynamicFragmentUpdate{Audit: coredata.AuthorizationDynamicFragmentAuditMetadata{Reason: "test_dynamic_model"}}); err != nil {
+		t.Fatalf("PutFragment: %v", err)
+	}
+	base, err := New(StaticConfig{
+		ModelFragments: []*core.AuthorizationModelResourceType{{
+			Name: "workspace",
+			Relations: []*core.AuthorizationModelRelation{{
+				Name:         "member",
+				SubjectTypes: []string{subjectTypeSubject},
+			}},
+		}},
+		Relationships: []*core.Relationship{providerBackedRoleTestRelationship("user:bob", "workspace", "ws-1", "member")},
+	})
+	if err != nil {
+		t.Fatalf("New authorizer: %v", err)
+	}
+	authorizer, err := NewProviderBacked(base, provider, WithDynamicFragmentSource(services.AuthzFragments))
+	if err != nil {
+		t.Fatalf("NewProviderBacked: %v", err)
+	}
+
+	if err := authorizer.ReloadAuthorizationState(ctx); err != nil {
+		t.Fatalf("ReloadAuthorizationState: %v", err)
+	}
+	if authorizationModelResourceType(provider.lastModel, "workspace") == nil {
+		t.Fatalf("composed model resource types = %#v, want workspace fragment", provider.lastModel.GetResourceTypes())
+	}
+	if authorizationModelResourceType(provider.lastModel, "project") == nil {
+		t.Fatalf("composed model resource types = %#v, want project fragment", provider.lastModel.GetResourceTypes())
+	}
+	if !provider.hasRelationship(legacyDynamic) {
+		t.Fatal("provider is missing backfilled plugin dynamic relationship")
+	}
+	if !provider.hasRelationship(providerBackedRoleTestRelationship("user:bob", "workspace", "ws-1", "member")) {
+		t.Fatal("provider is missing static config relationship")
+	}
+	fragment, err := services.AuthzFragments.GetFragmentByOwner(ctx, coredata.AuthorizationPluginFragmentOwner("slack"))
+	if err != nil {
+		t.Fatalf("GetFragmentByOwner: %v", err)
+	}
+	if len(fragment.Relationships) != 1 || fragment.Relationships[0].Subject.ID != "user:alice" {
+		t.Fatalf("backfilled fragment relationships = %#v", fragment.Relationships)
+	}
+	if fragment.Relationships[0].Target.Subject == nil || fragment.Relationships[0].Target.Subject.ID != "user:alice" {
+		t.Fatalf("backfilled fragment target = %#v, want subject target", fragment.Relationships[0].Target)
+	}
+	if fragment.Relationships[0].Properties["source"] != "provider" {
+		t.Fatalf("backfilled fragment properties = %#v, want provider source", fragment.Relationships[0].Properties)
+	}
+
+	deleted, _, err := services.AuthzFragments.DeleteRelationship(ctx, coredata.AuthorizationPluginFragmentOwner("slack"), fragment.Relationships[0], coredata.AuthorizationDynamicFragmentAuditMetadata{Reason: "test_delete"})
+	if err != nil {
+		t.Fatalf("DeleteRelationship: %v", err)
+	}
+	if !deleted {
+		t.Fatal("DeleteRelationship deleted = false, want true")
+	}
+	if err := authorizer.ReloadAuthorizationState(ctx); err != nil {
+		t.Fatalf("ReloadAuthorizationState after delete: %v", err)
+	}
+	if provider.hasRelationship(legacyDynamic) {
+		t.Fatal("provider still has plugin dynamic relationship after source fragment deletion")
+	}
+}
+
 func newProviderBackedRoleTestAuthorizer(t *testing.T, provider *providerBackedRoleContractProvider, roles []string, modelID string) *ProviderBackedAuthorizer {
 	t.Helper()
 
@@ -166,6 +260,120 @@ func providerBackedRoleTestRelationship(subjectID, resourceType, resourceID, rel
 		Relation: relation,
 		Resource: &core.ResourceRef{Type: resourceType, Id: resourceID},
 	}
+}
+
+func mustStruct(t *testing.T, fields map[string]any) *structpb.Struct {
+	t.Helper()
+	out, err := structpb.NewStruct(fields)
+	if err != nil {
+		t.Fatalf("structpb.NewStruct: %v", err)
+	}
+	return out
+}
+
+type providerBackedComposerTestProvider struct {
+	activeModelID          string
+	lastModel              *core.AuthorizationModel
+	nextModel              int
+	relationshipsByModelID map[string]map[string]*core.Relationship
+}
+
+func newProviderBackedComposerTestProvider(activeModelID string, relationships ...*core.Relationship) *providerBackedComposerTestProvider {
+	p := &providerBackedComposerTestProvider{
+		activeModelID:          activeModelID,
+		relationshipsByModelID: map[string]map[string]*core.Relationship{},
+	}
+	if activeModelID != "" {
+		p.relationshipsByModelID[activeModelID] = map[string]*core.Relationship{}
+		for _, rel := range relationships {
+			p.relationshipsByModelID[activeModelID][relationshipMapKey(rel)] = rel
+		}
+	}
+	return p
+}
+
+func (p *providerBackedComposerTestProvider) Name() string { return "composer-test" }
+
+func (p *providerBackedComposerTestProvider) Evaluate(context.Context, *core.AccessEvaluationRequest) (*core.AccessDecision, error) {
+	return &core.AccessDecision{}, nil
+}
+
+func (p *providerBackedComposerTestProvider) EvaluateMany(context.Context, *core.AccessEvaluationsRequest) (*core.AccessEvaluationsResponse, error) {
+	return &core.AccessEvaluationsResponse{}, nil
+}
+
+func (p *providerBackedComposerTestProvider) SearchResources(context.Context, *core.ResourceSearchRequest) (*core.ResourceSearchResponse, error) {
+	return nil, errors.New("SearchResources not implemented")
+}
+
+func (p *providerBackedComposerTestProvider) SearchSubjects(context.Context, *core.SubjectSearchRequest) (*core.SubjectSearchResponse, error) {
+	return nil, errors.New("SearchSubjects not implemented")
+}
+
+func (p *providerBackedComposerTestProvider) SearchActions(context.Context, *core.ActionSearchRequest) (*core.ActionSearchResponse, error) {
+	return nil, errors.New("SearchActions not implemented")
+}
+
+func (p *providerBackedComposerTestProvider) GetMetadata(context.Context) (*core.AuthorizationMetadata, error) {
+	return &core.AuthorizationMetadata{}, nil
+}
+
+func (p *providerBackedComposerTestProvider) ReadRelationships(_ context.Context, req *core.ReadRelationshipsRequest) (*core.ReadRelationshipsResponse, error) {
+	modelID := req.GetModelId()
+	if modelID == "" {
+		modelID = p.activeModelID
+	}
+	out := []*core.Relationship{}
+	for _, rel := range p.relationshipsByModelID[modelID] {
+		if !providerBackedRoleRelationshipMatches(rel, req) {
+			continue
+		}
+		out = append(out, rel)
+	}
+	return &core.ReadRelationshipsResponse{Relationships: out, ModelId: modelID}, nil
+}
+
+func (p *providerBackedComposerTestProvider) WriteRelationships(_ context.Context, req *core.WriteRelationshipsRequest) error {
+	modelID := req.GetModelId()
+	if modelID == "" {
+		modelID = p.activeModelID
+	}
+	if p.relationshipsByModelID[modelID] == nil {
+		p.relationshipsByModelID[modelID] = map[string]*core.Relationship{}
+	}
+	for _, key := range req.GetDeletes() {
+		delete(p.relationshipsByModelID[modelID], relationshipKeyMapKey(key))
+	}
+	for _, rel := range req.GetWrites() {
+		p.relationshipsByModelID[modelID][relationshipMapKey(rel)] = rel
+	}
+	return nil
+}
+
+func (p *providerBackedComposerTestProvider) GetActiveModel(context.Context) (*core.GetActiveModelResponse, error) {
+	return &core.GetActiveModelResponse{Model: &core.AuthorizationModelRef{Id: p.activeModelID}}, nil
+}
+
+func (p *providerBackedComposerTestProvider) ListModels(context.Context, *core.ListModelsRequest) (*core.ListModelsResponse, error) {
+	return &core.ListModelsResponse{}, nil
+}
+
+func (p *providerBackedComposerTestProvider) WriteModel(_ context.Context, req *core.WriteModelRequest) (*core.AuthorizationModelRef, error) {
+	p.nextModel++
+	modelID := fmt.Sprintf("model-%d", p.nextModel)
+	if p.activeModelID != "" {
+		p.relationshipsByModelID[modelID] = map[string]*core.Relationship{}
+		for key, rel := range p.relationshipsByModelID[p.activeModelID] {
+			p.relationshipsByModelID[modelID][key] = rel
+		}
+	}
+	p.activeModelID = modelID
+	p.lastModel = req.GetModel()
+	return &core.AuthorizationModelRef{Id: modelID}, nil
+}
+
+func (p *providerBackedComposerTestProvider) hasRelationship(rel *core.Relationship) bool {
+	return p.relationshipsByModelID[p.activeModelID][relationshipMapKey(rel)] != nil
 }
 
 type providerBackedRoleContractProvider struct {

--- a/gestaltd/services/authorization/provider_schema.go
+++ b/gestaltd/services/authorization/provider_schema.go
@@ -60,25 +60,30 @@ const (
 	subjectTypeUser    = ProviderSubjectTypeUser
 )
 
+var providerAuthorizationResourceTypes = []string{
+	ProviderResourceTypePolicyStatic,
+	ProviderResourceTypePluginStatic,
+	ProviderResourceTypePluginDynamic,
+	ProviderResourceTypeAdminPolicyStatic,
+	ProviderResourceTypeAdminDynamic,
+	ProviderResourceTypeExternalIdentity,
+	ProviderResourceTypeManagedSubject,
+	ProviderResourceTypeEveryone,
+	ProviderResourceTypeTeam,
+	ProviderResourceTypeSlackChannel,
+}
+
 func IsManagedProviderRelationship(rel *core.Relationship) bool {
 	if rel == nil || rel.GetResource() == nil {
 		return false
 	}
-	switch rel.GetResource().GetType() {
-	case ProviderResourceTypePolicyStatic,
-		ProviderResourceTypePluginStatic,
-		ProviderResourceTypePluginDynamic,
-		ProviderResourceTypeAdminPolicyStatic,
-		ProviderResourceTypeAdminDynamic,
-		ProviderResourceTypeExternalIdentity,
-		ProviderResourceTypeManagedSubject,
-		ProviderResourceTypeEveryone,
-		ProviderResourceTypeTeam,
-		ProviderResourceTypeSlackChannel:
-		return true
-	default:
-		return false
+	resourceType := strings.TrimSpace(rel.GetResource().GetType())
+	for _, managedResourceType := range providerAuthorizationResourceTypes {
+		if resourceType == managedResourceType {
+			return true
+		}
 	}
+	return false
 }
 
 func ProviderAuthorizationModelForRoles(policyRoles, pluginStaticRoles, pluginDynamicRoles, adminDynamicRoles []string) *core.AuthorizationModel {


### PR DESCRIPTION
## Description

Composes configured and dynamic authorization fragments into the provider-backed model, reconciles synthesized relationships, and backfills legacy provider dynamic tuples into the IndexedDB fragment source before treating that source as authoritative.