### PR TITLE
[codex] Allow exact invokes for session catalog operations

### DIFF
--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -1134,7 +1134,7 @@ server:
 	}
 }
 
-func TestPrepareAtPath_RejectsSessionCatalogOnlyInvokesTarget(t *testing.T) {
+func TestPrepareAtPath_AllowsSessionCatalogOnlyInvokesTarget(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -1149,6 +1149,11 @@ func TestPrepareAtPath_RejectsSessionCatalogOnlyInvokesTarget(t *testing.T) {
       invokes:
         - plugin: target
           operation: private_search
+          runAs:
+            subject:
+              id: service_account:agent
+              kind: service_account
+            applyByDefault: false
     target:
       source:
         path: %q
@@ -1159,9 +1164,8 @@ server:
 		t.Fatalf("WriteFile config: %v", err)
 	}
 
-	_, err := NewLifecycle().PrepareAtPath(cfgPath)
-	if err == nil || !strings.Contains(err.Error(), `session-catalog-only operation "private_search" on plugin "target"`) {
-		t.Fatalf("PrepareAtPath error = %v, want session catalog invokes error", err)
+	if _, err := NewLifecycle().PrepareAtPath(cfgPath); err != nil {
+		t.Fatalf("PrepareAtPath: %v", err)
 	}
 }
 

--- a/gestaltd/services/plugins/validation.go
+++ b/gestaltd/services/plugins/validation.go
@@ -152,7 +152,10 @@ func validateDependencies(ctx context.Context, cfg *ValidationConfig, cache *cat
 				continue
 			}
 			if resolved.sessionOnly {
-				return fmt.Errorf("config validation: plugins.%s.invokes[%d] references session-catalog-only operation %q on plugin %q, which is unsupported during init/validate", callerName, i, dependency.Operation, dependency.Plugin)
+				// Static validation cannot prove session-catalog-only operations,
+				// but runtime resolution still enforces that the operation exists
+				// for the effective subject before invocation.
+				continue
 			}
 			return fmt.Errorf("config validation: plugins.%s.invokes[%d] references unknown effective operation %q on plugin %q", callerName, i, dependency.Operation, dependency.Plugin)
 		}


### PR DESCRIPTION
## Summary
- Reapply the exact invoke validation fix on top of current main, which already includes static GraphQL argument support.
- Keep init-time validation permissive only for operations known to be session-catalog-only, while leaving normal static catalog validation unchanged.
- This lets downstream configs keep exact `runAs` invoke declarations for GraphQL operations until the static catalog is available during runtime/provider resolution.

## Test plan
- [x] `go test ./services/plugins ./internal/operator` from `gestaltd/`