### PR TITLE
[codex] Document gestaltd watch mode

### DIFF
--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -1122,6 +1122,21 @@ Repeated `--config` flags merge left-to-right, and `null` deletes inherited
 entries. That makes it possible to boot some supporting providers while
 suppressing others for a local session.
 
+When your config already points at local provider source paths, use config-based
+serve with `--watch` to restart after local config, source provider, or local
+release metadata changes:
+
+```sh
+gestaltd serve \
+  --plugin slack \
+  --config ./base.yaml \
+  --config ./dev/local.yaml \
+  --watch
+```
+
+`--watch` is not supported with `--path`, `--remote`, or `--locked`; use it with
+`--config` files that reference the local sources you want to iterate on.
+
 #### Attaching local code to a remote server
 
 <ActiveDevelopmentCallout changeNote="Behavior, authorization requirements, and attach-session semantics may change between releases without warning.">Remote local serve</ActiveDevelopmentCallout>

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -18,6 +18,7 @@ import { Callout } from 'nextra/components'
 | --- | --- |
 | `gestaltd` | Local-friendly startup. Generates a config if needed and serves. |
 | `gestaltd serve --config PATH` | Start the server. Repeat `--config` to layer overrides. |
+| `gestaltd serve --config PATH --watch` | Start from layered config and restart after debounced local config, source provider, or local release metadata changes. |
 | `gestaltd serve --locked --config PATH` | Start read-only from an existing lockfile and prepared artifacts. Repeat `--config` to layer overrides. |
 | `gestaltd serve --artifacts-dir DIR` | Directory for prepared provider artifacts. |
 | `gestaltd serve --lockfile PATH` | Override the lockfile location. `PATH` resolves like a normal CLI path. |
@@ -80,6 +81,28 @@ update the lockfile by default. `provider add` and `provider remove` accept
 `GOMAXPROCS`; `--parallelism 1` forces sequential preparation. Other provider
 types and `sync --locked --check` remain sequential.
 
+## Config Watch Mode
+
+Use `gestaltd serve --watch` for config-based local development when your
+layered config points at local provider source paths or local
+`provider-release.yaml` metadata. Watch mode starts normally, then restarts the
+server after local file changes settle. If reload preparation fails, the current
+server keeps running and the failure is logged.
+
+For faster iteration on one configured plugin, combine `--watch` with
+`--plugin NAME` so unrelated configured plugins are not validated or prepared:
+
+```sh
+gestaltd serve \
+  --plugin support \
+  --config ./config.yaml \
+  --config ./local.yaml \
+  --watch
+```
+
+Watch mode applies only to config-based serve. It cannot be combined with
+`--locked`, `--path`, or `--remote`.
+
 ## Examples
 
 ```sh
@@ -92,6 +115,8 @@ gestaltd validate --config ./config.yaml
 gestaltd lock --config ./config.yaml --lockfile ./local/gestalt.lock.json
 gestaltd sync --locked --config ./config.yaml --lockfile ./local/gestalt.lock.json
 gestaltd serve --config ./config.yaml --lockfile ./local/gestalt.lock.json
+gestaltd serve --config ./config.yaml --watch
+gestaltd serve --plugin support --config ./config.yaml --config ./local.yaml --watch
 gestaltd serve --locked --config ./config.yaml --lockfile ./local/gestalt.lock.json
 gestaltd lock --config ./base.yaml --config ./overrides/prod.yaml
 gestaltd sync --locked --config ./base.yaml --config ./overrides/prod.yaml


### PR DESCRIPTION
## Summary

- Document `gestaltd serve --watch` in the CLI reference, including config-based usage, scoped `--plugin` usage, and unsupported flag combinations.
- Add provider-development guidance for using `--watch` with layered config files that already point at local source providers.

## Test plan

- [x] `cd docs && npm run typecheck`
- [x] `cd docs && npm run build:single`
- [x] `git diff --check`