### PR TITLE
Prepare gestalt CLI 0.0.2-alpha.1 release

### DIFF
--- a/gestalt/Cargo.toml
+++ b/gestalt/Cargo.toml
@@ -3,5 +3,5 @@ resolver = "2"
 members = ["cli"]
 
 [workspace.package]
-version = "0.0.1"
+version = "0.0.2-alpha.1"
 edition = "2024"


### PR DESCRIPTION
## Summary
- Bump the Gestalt CLI workspace package version to `0.0.2-alpha.1` so the `gestalt/v0.0.2-alpha.1` release tag can publish the selector UX changes from #2073 as an alpha release.
- This intentionally does not prepare a stable `0.0.2` release or a `gestalt/v0.0.2` tag.

## Interface

Rust package metadata:

```toml
[workspace.package]
version = "0.0.2-alpha.1"
```

Release tag after merge:

```bash
git tag -a gestalt/v0.0.2-alpha.1 <merge-sha> -m "gestalt v0.0.2-alpha.1"
git push origin gestalt/v0.0.2-alpha.1
```

The release workflow verifies the Cargo package version against the alpha tag:

```bash
cargo metadata --format-version 1 --no-deps \
  | jq -r '.packages[] | select(.name=="gestalt") | .version'
# 0.0.2-alpha.1
```

## Test plan
- [x] `cargo metadata --manifest-path gestalt/Cargo.toml --format-version 1 --no-deps | jq -r '.packages[] | select(.name=="gestalt") | .version'`
- [x] `cargo fmt --manifest-path gestalt/Cargo.toml --check`
- [x] `git diff --check`