### PR TITLE
[codex] Fix session catalog connection routing

### DIFF
--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -774,10 +774,13 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusForbidden, "operation access denied")
 		return
 	}
-	operationConnection, err := invocation.ResolveOperationConnection(surfaceProv, opMeta.ID, params)
-	if err != nil {
-		s.writeInvocationError(w, r, providerName, operationName, err)
-		return
+	operationConnection := resolvedConnection
+	if operationConnection == "" {
+		operationConnection, err = invocation.ResolveOperationConnection(surfaceProv, opMeta.ID, params)
+		if err != nil {
+			s.writeInvocationError(w, r, providerName, operationName, err)
+			return
+		}
 	}
 	explicitConnection := connectionInput
 	if explicitConnection != "" {
@@ -803,9 +806,6 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 	ctx = invocation.WithCatalogOperation(ctx, providerName, opMeta)
 	if connection == "" {
 		connection = operationConnection
-		if connection == "" {
-			connection = resolvedConnection
-		}
 	}
 	if connection != "" {
 		if !safeParamValue.MatchString(connection) {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -13026,6 +13026,63 @@ func TestExecuteOperation_RejectsExplicitConnectionForStaticOperation(t *testing
 	}
 }
 
+func TestExecuteOperation_UsesResolvedConnectionForSessionCatalogOperation(t *testing.T) {
+	t.Parallel()
+
+	const (
+		integration = "sample-svc"
+		operation   = "session_graphql"
+	)
+
+	executed := false
+	prov := &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{
+				N:        integration,
+				ConnMode: core.ConnectionModeNone,
+				ExecuteFn: func(_ context.Context, gotOperation string, _ map[string]any, _ string) (*core.OperationResult, error) {
+					executed = true
+					if gotOperation != operation {
+						t.Fatalf("operation = %q, want %q", gotOperation, operation)
+					}
+					return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+				},
+			},
+		},
+		operationConnection: config.PluginConnectionName,
+		catalog: &catalog.Catalog{
+			Name: integration,
+			Operations: []catalog.CatalogOperation{{
+				ID:        operation,
+				Method:    http.MethodPost,
+				Transport: "graphql",
+			}},
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, prov)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := strings.NewReader(`{"_connection":"prod"}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/"+integration+"/"+operation, body)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	if !executed {
+		t.Fatal("expected provider execution")
+	}
+}
+
 func TestExecuteOperation_AllowsExplicitConnectionAliasForStaticOperation(t *testing.T) {
 	t.Parallel()
 
@@ -18609,12 +18666,17 @@ func (s *stubIntegrationWithCatalog) Catalog() *catalog.Catalog {
 type stubIntegrationWithSessionCatalog struct {
 	stubIntegrationWithOps
 	catalog             *catalog.Catalog
+	operationConnection string
 	catalogForRequestFn func(context.Context, string) (*catalog.Catalog, error)
 	callFn              func(ctx context.Context, name string, args map[string]any) (*mcpgo.CallToolResult, error)
 }
 
 func (s *stubIntegrationWithSessionCatalog) Catalog() *catalog.Catalog {
 	return s.catalog
+}
+
+func (s *stubIntegrationWithSessionCatalog) ConnectionForOperation(string) string {
+	return s.operationConnection
 }
 
 func (s *stubIntegrationWithSessionCatalog) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {

--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -291,10 +291,13 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 		return fail(core.ErrMCPOnly)
 	}
 
+	operationConnection := resolvedConnection
 	if strings.TrimSpace(conn) != "" {
-		operationConnection, err := ResolveOperationConnection(execProv, opMeta.ID, params)
-		if err != nil {
-			return fail(err)
+		if operationConnection == "" {
+			operationConnection, err = ResolveOperationConnection(execProv, opMeta.ID, params)
+			if err != nil {
+				return fail(err)
+			}
 		}
 		operationConnection = core.ResolveConnectionAlias(operationConnection)
 		explicitConnection := core.ResolveConnectionAlias(conn)
@@ -312,18 +315,17 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 		}
 	}
 	if conn == "" {
-		conn = resolvedConnection
+		conn = operationConnection
 	}
-	if conn == "" {
-		if transport == catalog.TransportMCPPassthrough {
-			conn = b.mcpConnection(providerName)
-		} else {
-			var err error
-			conn, err = ResolveOperationConnection(execProv, opMeta.ID, params)
-			if err != nil {
-				return fail(err)
-			}
+	if conn == "" && transport == catalog.TransportMCPPassthrough {
+		conn = b.mcpConnection(providerName)
+	}
+	if conn == "" && transport != catalog.TransportMCPPassthrough {
+		operationConnection, err = ResolveOperationConnection(execProv, opMeta.ID, params)
+		if err != nil {
+			return fail(err)
 		}
+		conn = operationConnection
 	}
 	if conn == "" && b.connMapper != nil {
 		conn = b.connMapper.ConnectionForProvider(providerName)

--- a/gestaltd/services/invocation/catalog.go
+++ b/gestaltd/services/invocation/catalog.go
@@ -120,7 +120,7 @@ func ResolveOperation(ctx context.Context, prov core.Provider, provName string, 
 
 	if op, ok := CatalogOperationFromContext(ctx, provName, operation); ok {
 		catalogSource = "context"
-		return op, OperationTransport(op), "", nil
+		return op, OperationTransport(op), ConnectionFromContext(ctx), nil
 	}
 
 	staticOp, staticOK := CatalogOperation(providerCatalog(prov), operation)


### PR DESCRIPTION
## Summary
- Preserve the connection used to resolve a session-catalog operation so execution routes through the same credential.
- Use that resolved connection before falling back to provider-declared operation connections in both HTTP and broker invocation paths.
- Cover the Front Porch-shaped case where a session GraphQL operation is discovered through `prod/default` while the provider fallback still reports `_plugin`.

## Test plan
- [x] `go test ./internal/server -run 'TestExecuteOperation_(UsesResolvedConnectionForSessionCatalogOperation|RejectsExplicitConnectionForStaticOperation)'`
- [x] `go test ./services/invocation`
- [x] `go test ./internal/server`