### PR TITLE
Use static GraphQL catalogs for explicit operations

### DIFF
--- a/gestaltd/internal/bootstrap/graphql_session_provider_test.go
+++ b/gestaltd/internal/bootstrap/graphql_session_provider_test.go
@@ -168,6 +168,8 @@ func TestConfiguredStaticGraphQLProviderSkipsSessionCatalog(t *testing.T) {
 			data = map[string]any{"record": map[string]any{"id": payload.Variables["id"]}}
 		} else if strings.Contains(payload.Query, "status") {
 			data = map[string]any{"status": "ok"}
+		} else if strings.Contains(payload.Query, "viewer") {
+			data = map[string]any{"viewer": map[string]any{"id": "user_123"}}
 		}
 		_ = json.NewEncoder(w).Encode(map[string]any{"data": data})
 	}))
@@ -189,7 +191,6 @@ func TestConfiguredStaticGraphQLProviderSkipsSessionCatalog(t *testing.T) {
 				"status": {
 					GraphQL: &providermanifestv1.ManifestGraphQLOperation{
 						OperationType: "query",
-						Arguments:     graphQLTestArgs(),
 					},
 				},
 				"record": {
@@ -223,6 +224,9 @@ func TestConfiguredStaticGraphQLProviderSkipsSessionCatalog(t *testing.T) {
 	)
 	if err != nil {
 		t.Fatalf("buildConfiguredSpecProvider: %v", err)
+	}
+	if core.SupportsSessionCatalog(prov) {
+		t.Fatal("static GraphQL provider reports session catalog support; want static catalog only")
 	}
 	if _, ok := prov.(core.SessionCatalogProvider); ok {
 		t.Fatal("static GraphQL provider implements SessionCatalogProvider; want static catalog only")
@@ -269,6 +273,55 @@ func TestConfiguredStaticGraphQLProviderSkipsSessionCatalog(t *testing.T) {
 	if result.Status != http.StatusOK {
 		t.Fatalf("status = %d, want %d", result.Status, http.StatusOK)
 	}
+
+	noArgProv, _, err := buildConfiguredSpecProvider(
+		context.Background(),
+		"exampleGraphQL",
+		config.ResolvedSpecSurface{
+			Surface: config.SpecSurfaceGraphQL,
+			URL:     srv.URL,
+			Connection: config.ConnectionDef{
+				Auth: config.ConnectionAuthDef{Type: providermanifestv1.AuthTypeNone},
+			},
+		},
+		providerMetadata{},
+		specProviderConfig{
+			allowedOperations: map[string]*config.OperationOverride{
+				"status": {
+					GraphQL: &providermanifestv1.ManifestGraphQLOperation{
+						OperationType: "query",
+					},
+				},
+				"viewer": {
+					GraphQL: &providermanifestv1.ManifestGraphQLOperation{
+						OperationType: "query",
+						SelectionSet:  "id",
+					},
+				},
+			},
+		},
+		Deps{},
+	)
+	if err != nil {
+		t.Fatalf("build no-arg provider: %v", err)
+	}
+	if core.SupportsSessionCatalog(noArgProv) {
+		t.Fatal("no-arg static GraphQL provider reports session catalog support; want static catalog only")
+	}
+	result, err = noArgProv.Execute(context.Background(), "status", nil, "")
+	if err != nil {
+		t.Fatalf("Execute(no-arg status): %v", err)
+	}
+	if result.Status != http.StatusOK {
+		t.Fatalf("status = %d, want %d", result.Status, http.StatusOK)
+	}
+	result, err = noArgProv.Execute(context.Background(), "viewer", nil, "")
+	if err != nil {
+		t.Fatalf("Execute(no-arg viewer): %v", err)
+	}
+	if result.Status != http.StatusOK {
+		t.Fatalf("status = %d, want %d", result.Status, http.StatusOK)
+	}
 	if got := introspectionCalls.Load(); got != 0 {
 		t.Fatalf("introspection calls = %d, want 0", got)
 	}
@@ -288,6 +341,10 @@ func TestConfiguredStaticGraphQLProviderSkipsSessionCatalog(t *testing.T) {
 		{
 			Query: "query { status }",
 		},
+		{
+			Query: "query { status }",
+		},
+		{Query: "query { viewer { id } }"},
 	}
 	if !reflect.DeepEqual(gotRequests, wantRequests) {
 		t.Fatalf("requests = %#v, want %#v", gotRequests, wantRequests)
@@ -302,22 +359,6 @@ func TestConfiguredStaticGraphQLProviderRejectsInvalidStaticConfig(t *testing.T)
 		operations map[string]*config.OperationOverride
 		wantErr    string
 	}{
-		{
-			name: "all graphql operations must opt in with arguments",
-			operations: map[string]*config.OperationOverride{
-				"status": {
-					GraphQL: &providermanifestv1.ManifestGraphQLOperation{
-						Arguments: graphQLTestArgs(),
-					},
-				},
-				"viewer": {
-					GraphQL: &providermanifestv1.ManifestGraphQLOperation{
-						SelectionSet: "id",
-					},
-				},
-			},
-			wantErr: `allowed operation "viewer" must set graphql.arguments`,
-		},
 		{
 			name: "invalid argument type",
 			operations: map[string]*config.OperationOverride{

--- a/gestaltd/services/plugins/graphql/static.go
+++ b/gestaltd/services/plugins/graphql/static.go
@@ -14,17 +14,13 @@ import (
 
 func StaticAllowedOperationsDefinition(name, endpoint string, allowedOps map[string]*operationexposure.OperationOverride, selectionOverrides map[string]string) (*declarative.Definition, error) {
 	graphQLNames := make([]string, 0)
-	hasStaticArgs := false
 	for opName, override := range allowedOps {
 		if override == nil || override.GraphQL == nil {
 			continue
 		}
 		graphQLNames = append(graphQLNames, opName)
-		if override.GraphQL.Arguments != nil {
-			hasStaticArgs = true
-		}
 	}
-	if !hasStaticArgs {
+	if len(graphQLNames) == 0 {
 		return nil, nil
 	}
 	if len(selectionOverrides) > 0 {
@@ -32,12 +28,6 @@ func StaticAllowedOperationsDefinition(name, endpoint string, allowedOps map[str
 	}
 
 	sort.Strings(graphQLNames)
-	for _, opName := range graphQLNames {
-		if allowedOps[opName].GraphQL.Arguments == nil {
-			return nil, fmt.Errorf("graphql %s: allowed operation %q must set graphql.arguments to use static GraphQL catalogs", name, opName)
-		}
-	}
-
 	def := StaticDefinition(name, endpoint)
 	for _, opName := range graphQLNames {
 		override := allowedOps[opName]
@@ -86,7 +76,11 @@ func staticOperationDefinition(name string, override *operationexposure.Operatio
 }
 
 func staticOperationQuery(operationType, fieldName string, graphQLOp *providermanifestv1.ManifestGraphQLOperation) (string, []declarative.ParameterDef, error) {
-	args, typeOverrides, err := staticInputValues(*graphQLOp.Arguments)
+	var rawArgs []providermanifestv1.ManifestGraphQLArgument
+	if graphQLOp.Arguments != nil {
+		rawArgs = *graphQLOp.Arguments
+	}
+	args, typeOverrides, err := staticInputValues(rawArgs)
 	if err != nil {
 		return "", nil, err
 	}


### PR DESCRIPTION
## Summary
- Treat an explicit `allowedOperations.<field>.graphql` entry with omitted `graphql.arguments` as a no-argument static GraphQL operation.
- Preserve typed static arguments for operations that declare `graphql.arguments`, so parameter metadata and generated GraphQL variables continue to work for mixed no-arg and arg-bearing operation catalogs.
- Keep legacy GraphQL filtering unchanged for allowed operations that do not use the explicit `graphql:` block; `operationSelections` remains incompatible with explicit static GraphQL allowed operations.
- Example manifest syntax: `status: { graphql: { operationType: query } }` now generates `query { status }`; `record: { graphql: { operationType: query, arguments: [{ name: id, type: String! }], selectionSet: "id" } }` still generates `query($id: String!) { record(id: $id) { id } }`.

## Test plan
- [x] `go test ./internal/bootstrap -run 'TestConfiguredStaticGraphQLProvider|TestGraphQLSessionCatalogProviderLoadsCatalogOnDemand'`
- [x] `go test ./services/plugins/graphql`
- [x] `rg -n "operationSelections" /Users/hugh/src/toolshed/valon-tools /Users/hugh/src/toolshed/marketplace -g 'manifest.yaml' -g '*.yaml' -g '*.yml'` returned no deployed Toolshed manifests using operation selections.