### PR TITLE
[codex] Document local development features

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -84,6 +84,10 @@ server {
         try_files $uri =404;
     }
 
+    location ~ ^/(dev|latest|versions/v[^/]+)/_pagefind/(.*)$ {
+        try_files /_pagefind/$2 =404;
+    }
+
     location /dev/ {
         try_files $uri $uri.html $uri/ =404;
     }

--- a/docs/content/applications.mdx
+++ b/docs/content/applications.mdx
@@ -62,17 +62,18 @@ spec:
 ```
 
 The UI bundle should be authored from source. Check in the UI source and
-dependency lockfile, declare a `build` command and `output` directory, and leave
-the generated `out/` or `dist/` directory out of source control. Gestalt builds
-the static assets during preparation and serves the prepared output at runtime.
+dependency lockfile, declare a `build` command and `spec.assetRoot` output
+directory, and leave the generated `out/` or `dist/` directory out of source
+control. Gestalt builds the static assets during preparation and serves the
+prepared output at runtime.
 Route rules are required when the mounted plugin binds an `authorizationPolicy`.
 For UI package details, see [Providers > UI](/providers/ui).
 
 <Callout type="info">
   Source-built UI packages are the recommended shape for new applications, but
   the workflow is still alpha. Current manifests need explicit build commands,
-  output paths, and build tools in the preparation environment; improving those
-  ergonomics is on the radar.
+  `spec.assetRoot` paths, and build tools in the preparation environment;
+  improving those ergonomics is on the radar.
 </Callout>
 
 ```yaml
@@ -875,6 +876,13 @@ bindings in a development config file:
 ```sh
 gestaltd provider validate --path ./workspace-review/plugin --config ./dev.yaml
 gestaltd serve --path ./workspace-review/plugin --config ./dev.yaml
+```
+
+When `dev.yaml` already points at the local application plugin source, use a
+config-scoped serve to skip unrelated configured providers during iteration:
+
+```sh
+gestaltd serve --plugin workspace_review --config ./dev.yaml --watch
 ```
 
 For local UI detection, config overlays, and remote attach workflows, see

--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -248,11 +248,6 @@ See [Provider Manifests](/reference/plugin-manifests) for the full field referen
       artifactPath: .gestalt/build/slack
     ```
 
-    For repeated Python source builds, set `GESTALT_BUILD_CACHE_DIR` to a
-    writable directory before running `gestaltd sync`, `gestaltd serve`, or
-    `gestaltd provider release`. The cache stores SDK-internal packaging
-    accelerators only; deleting it or unsetting the variable restores clean
-    temporary builds.
   </Tabs.Tab>
   <Tabs.Tab>
     You need the current stable Rust toolchain, Cargo, and a running `gestaltd` instance for testing.

--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -247,6 +247,12 @@ See [Provider Manifests](/reference/plugin-manifests) for the full field referen
     entrypoint:
       artifactPath: .gestalt/build/slack
     ```
+
+    For repeated Python source builds, set `GESTALT_BUILD_CACHE_DIR` to a
+    writable directory before running `gestaltd sync`, `gestaltd serve`, or
+    `gestaltd provider release`. The cache stores SDK-internal packaging
+    accelerators only; deleting it or unsetting the variable restores clean
+    temporary builds.
   </Tabs.Tab>
   <Tabs.Tab>
     You need the current stable Rust toolchain, Cargo, and a running `gestaltd` instance for testing.
@@ -334,6 +340,26 @@ See [Provider Manifests](/reference/plugin-manifests) for the full field referen
 ### Defining operations
 
 Operations are the callable units of a plugin. Each operation has an ID, an HTTP method, input and output types, and a handler function. Executable source plugins can use SDK-native source package metadata, or declare `build.command` and `entrypoint.artifactPath` when they need a custom build.
+
+Executable source providers can also declare a prepare-only build when a local
+dependency step must run before SDK-native source execution, but that step does
+not produce a release artifact. Use array-form `build` for that case, and use
+`run.commandPrefix` when the generated provider command should be launched
+through another runtime command:
+
+```yaml
+build:
+  - uv
+  - sync
+run:
+  commandPrefix:
+    - uv
+    - run
+```
+
+Prepare-only builds are for executable source providers. Source UI manifests
+must use object-form `build` plus `spec.assetRoot` so Gestalt can verify and
+serve the generated static asset directory.
 
 The following example defines a `conversations.getMessage` operation that fetches a single Slack message by channel and timestamp. The handler uses the resolved runtime token from the request context to call the Slack API.
 
@@ -1123,8 +1149,18 @@ entries. That makes it possible to boot some supporting providers while
 suppressing others for a local session.
 
 When your config already points at local provider source paths, use config-based
-serve with `--watch` to restart after local config, source provider, or local
-release metadata changes:
+serve with `--plugin NAME` to prepare and run only that configured plugin and
+the supporting providers it needs:
+
+```sh
+gestaltd serve \
+  --plugin slack \
+  --config ./base.yaml \
+  --config ./dev/local.yaml
+```
+
+Add `--watch` to restart after local config, source provider, or local release
+metadata changes:
 
 ```sh
 gestaltd serve \

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -24,7 +24,7 @@ import { Callout } from 'nextra/components'
 | `gestaltd serve --lockfile PATH` | Override the lockfile location. `PATH` resolves like a normal CLI path. |
 | `gestaltd lock --config PATH` | Resolve published provider sources and write canonical lock metadata. Repeat `--config` to layer overrides. |
 | `gestaltd lock --check --config PATH` | Verify that the checked-in lockfile matches the current config without rewriting it. |
-| `gestaltd sync --locked --config PATH` | Materialize prepared provider artifacts from an existing lockfile. Local source UI preparation uses bounded parallelism by default. |
+| `gestaltd sync --locked --config PATH` | Materialize prepared provider artifacts from an existing lockfile. Local source plugin and UI preparation uses bounded parallelism by default. |
 | `gestaltd sync --locked --check --config PATH` | Verify that prepared artifacts exist and match the lockfile without rewriting them. |
 | `gestaltd validate --config PATH` | Validate config without serving. Repeat `--config` to layer overrides. |
 | `gestaltd validate --lockfile PATH` | Accept the same explicit lockfile path used by `lock`, `sync`, and `serve` without mutating it. |
@@ -77,9 +77,10 @@ update the lockfile by default. `provider add` and `provider remove` accept
 `--no-lock` when you need to edit config only.
 
 `gestaltd sync --locked --parallelism N` caps concurrent preparation for local
-`source.path` UI bundles. The default is up to four workers, capped by
-`GOMAXPROCS`; `--parallelism 1` forces sequential preparation. Other provider
-types and `sync --locked --check` remain sequential.
+source plugins and UI bundles, including plugin-owned and plugin-bound local
+UIs. The default is up to four workers, capped by `GOMAXPROCS`;
+`--parallelism 1` forces sequential preparation. Non-local providers and
+`sync --locked --check` remain sequential and read-only.
 
 ## Config Watch Mode
 
@@ -154,9 +155,12 @@ gestaltd provider release --version 0.0.1-alpha.1 --platform linux/amd64,linux/a
 
 When repeated, `--config` files merge left-to-right. Maps deep-merge, later
 scalar values win, lists replace inherited lists, and `null` deletes inherited
-keys. By default, lockfiles and artifact paths stay rooted at the leftmost
-config file. `--lockfile` overrides only the lockfile path. `--artifacts-dir`
-keeps the same config-relative resolution used by `sync` and `serve`.
+keys. By default, lockfiles and config-declared artifact paths stay rooted at
+the leftmost config file. `--lockfile` overrides only the lockfile path.
+`--artifacts-dir` follows normal CLI path resolution, so relative values resolve
+from the current working directory.
+
+## Provider Development
 
 `gestaltd serve --remote` is environment-agnostic: the URL is just the remote
 `gestaltd` instance to attach to. The local command only replaces source-backed

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -1476,7 +1476,8 @@ spec:
 
 Executable source providers that use SDK-native source-package metadata can use
 array-form `build` for prepare-only dependency setup, and `run.commandPrefix`
-to launch the resolved provider command through another local runtime command:
+to launch the command Gestalt would normally use to start the provider through
+another local runtime command:
 
 ```yaml
 kind: plugin

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -1381,6 +1381,14 @@ For local development with a source provider package:
 source: ./manifest.yaml
 ```
 
+Configured local source providers are omitted from canonical `gestalt.lock.json`
+metadata during `gestaltd lock` and `gestaltd lock --check`. They are prepared
+from source during `gestaltd sync --locked`, unlocked `gestaltd serve`, scoped
+`gestaltd serve --plugin`, `gestaltd serve --path`, and
+`gestaltd provider validate --path`.
+
+### Provider development
+
 When a remote `gestaltd` instance is running the provider-dev endpoints,
 authenticated developers can attach a local implementation for configured
 plugins that are registered on the remote server and that they are authorized to
@@ -1440,12 +1448,11 @@ same action. API tokens must carry `permissions[].actions:
 operation permissions do not grant attach, and the attach action does not grant
 operation invocation.
 
-Source-backed executable plugins must declare how to build the runnable
-artifact and where that artifact will appear. Gestalt runs `build.command`
-before local execution or release packaging, then starts
-`entrypoint.artifactPath`. The command can call any runtime or compiler
-available in the preparation environment; Gestalt does not infer the provider
-language or synthesize executable wrappers.
+When source-backed executable plugins declare object-form `build`, they must
+declare how to build the runnable artifact and where that artifact will appear.
+Gestalt runs `build.command` before local execution or release packaging, then
+starts `entrypoint.artifactPath`. The command can call any runtime or compiler
+available in the preparation environment.
 
 ```yaml
 kind: plugin
@@ -1460,6 +1467,28 @@ build:
     - package.json
 entrypoint:
   artifactPath: .gestalt/build/provider
+spec:
+  connections:
+    default:
+      auth:
+        type: none
+```
+
+Executable source providers that use SDK-native source-package metadata can use
+array-form `build` for prepare-only dependency setup, and `run.commandPrefix`
+to launch the resolved provider command through another local runtime command:
+
+```yaml
+kind: plugin
+source: github.com/acme/plugins/my-python-plugin
+version: 1.0.0
+build:
+  - uv
+  - sync
+run:
+  commandPrefix:
+    - uv
+    - run
 spec:
   connections:
     default:

--- a/docs/content/reference/configuration.mdx
+++ b/docs/content/reference/configuration.mdx
@@ -175,6 +175,11 @@ For deterministic production deployments:
    artifacts.
 3. Run `gestaltd serve --locked --config ./config.yaml` at runtime.
 
+Configured local source providers are intentionally omitted from canonical lock
+metadata. Keep them in local overlays for development, then let
+`gestaltd sync --locked` or unlocked/scoped local serve prepare them from source
+when those overlays are active.
+
 See [Deploy](/deploy), [Docker](/deploy/docker), [Helm](/deploy/helm), and the
 [Server CLI](/reference/cli) for deployment-specific workflows.
 

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -43,7 +43,8 @@ These fields appear at the top level of every manifest regardless of kind.
 | `iconFile`    | string     | no       | Relative path to an SVG icon bundled with the package.                                                                                                                                               |
 | `artifacts`   | Artifact[] | no       | Prepared or released executable artifacts keyed by platform. Source manifests must omit this field.                                                        |
 | `entrypoint`  | Entrypoint | no       | Executable entrypoint metadata for the provider.                                                                                                                                                     |
-| `build`       | SourceBuild | no       | Source-only command that prepares the declared runtime output. Prepared and released manifests strip this field.                                                                                     |
+| `build`       | SourceBuild | no       | Source-only command. Object form prepares a declared runtime output; array form is prepare-only for executable source providers. Prepared and released manifests strip this field.                  |
+| `run`         | SourceRun   | no       | Source-only runtime launch metadata. Prepared and released manifests strip this field.                                                                                                               |
 | `spec`        | object     | no       | Kind-specific configuration block.                                                                                                                                                                   |
 
 ## Entrypoint
@@ -61,10 +62,10 @@ entrypoint:
   args: ["--verbose"]
 ```
 
-For executable source manifests, `entrypoint.artifactPath` is also the build
-output path. When `build` is present, Gestalt runs `build.command` before
-preparing, serving, or releasing the package, and the command must produce that
-file.
+For output-producing executable source manifests, `entrypoint.artifactPath` is
+also the build output path. When object-form `build` is present, Gestalt runs
+`build.command` before preparing, serving, or releasing the package, and the
+command must produce that file.
 
 ```yaml
 kind: indexeddb
@@ -530,9 +531,10 @@ artifacts:
 ## UI Metadata
 
 The `spec` block for a `kind: ui` manifest describes a static UI package.
-Source UI manifests must declare top-level `build.command` and `spec.assetRoot`.
-Generated assets should stay out of source control. Released and prepared UI
-manifests always contain `spec.assetRoot` and do not contain top-level `build`.
+Source UI manifests must declare object-form top-level `build.command` and
+`spec.assetRoot`. Generated assets should stay out of source control. Released
+and prepared UI manifests always contain `spec.assetRoot` and do not contain
+top-level `build`.
 
 | Field       | Type         | Required | Purpose                                                                                                                     |
 | ----------- | ------------ | -------- | --------------------------------------------------------------------------------------------------------------------------- |
@@ -570,15 +572,43 @@ spec:
       allowedRoles: [admin]
 ```
 
-Top-level `build` is source-only and supported for UI and executable source
-manifests. It is the recommended form for new UI packages authored from
-TypeScript, React, Next.js static export, Vite, or similar frontend source.
+Object-form top-level `build` is source-only and supported for UI and
+executable source manifests. It is the recommended form for new UI packages
+authored from TypeScript, React, Next.js static export, Vite, or similar
+frontend source.
 
 | Build field | Type     | Required | Purpose                                                                                           |
 | ----------- | -------- | -------- | ------------------------------------------------------------------------------------------------- |
 | `command`   | string[] | yes      | Command argv to run before preparing the static assets.                                           |
 | `workdir`   | string   | no       | Manifest-relative directory where `command` runs. Defaults to the manifest directory.             |
 | `inputs`    | string[] | no       | Literal manifest-relative files or directories used to fingerprint local source builds. Glob syntax is not supported. |
+
+Executable source providers may also use array-form `build` for prepare-only
+steps that do not produce a declared output. This is useful for dependency
+preparation before SDK-native source execution:
+
+```yaml
+build:
+  - uv
+  - sync
+```
+
+Prepare-only builds are not valid for source UI manifests, because UI packages
+must produce the directory declared by `spec.assetRoot`.
+
+Top-level `run` is source-only. `run.commandPrefix` wraps the resolved provider
+command when Gestalt launches the local source provider:
+
+```yaml
+run:
+  commandPrefix:
+    - uv
+    - run
+```
+
+| Run field | Type | Required | Purpose |
+| --- | --- | --- | --- |
+| `commandPrefix` | string[] | yes | Command argv prepended to the resolved provider command. |
 
 ## Artifacts
 
@@ -810,11 +840,12 @@ and MCP may be added alongside either or both.
 A connection using `mcp_oauth` auth requires the plugin to declare an MCP surface (via `spec.surfaces.mcp` or an equivalent). Manifests that set `auth.type: mcp_oauth` without an MCP surface fail validation.
 
 Executable source providers may either use the SDK-native Go, Rust, Python, or
-TypeScript source-package metadata, or declare top-level `build.command` with
-`entrypoint.artifactPath`. When `build.command` is present, Gestalt runs it
-before source-manifest preparation and requires the command to produce that
-artifact path. Source manifests must not include `artifacts`; prepared and
-released manifests include `artifacts` and omit `build`.
+TypeScript source-package metadata, declare object-form top-level
+`build.command` with `entrypoint.artifactPath`, or declare array-form `build`
+for prepare-only dependency setup. When object-form `build.command` is present,
+Gestalt runs it before source-manifest preparation and requires the command to
+produce that artifact path. Source manifests must not include `artifacts`;
+prepared and released manifests include `artifacts` and omit `build` and `run`.
 
 ```yaml
 kind: indexeddb
@@ -842,9 +873,9 @@ Declarative plugin manifests that only describe hosted HTTP, GraphQL, MCP, or
 spec-loaded surfaces may omit `entrypoint` and `build`. See
 [Plugins](/providers/plugins) for the end-to-end authoring flow.
 
-Source UI build steps must be declared with top-level `build`. Gestalt runs
-that command before source-manifest preparation during lock, sync, dev, and
-release packaging. This lets UI packages generate static bundles without
+Source UI build steps must be declared with object-form top-level `build`.
+Gestalt runs that command before source-manifest preparation during sync, dev,
+and release packaging. This lets UI packages generate static bundles without
 checking built artifacts into source control.
 
 ```yaml
@@ -882,18 +913,19 @@ gestaltd provider release --version 1.2.3
 
 `gestaltd provider release` preserves the source manifest format, so
 `manifest.yaml` stays YAML and `manifest.json` stays JSON in the release archive.
-For source manifests with `build.command`, release runs the command before
-packaging. Executable providers must produce `entrypoint.artifactPath`; UI
-providers must produce `spec.assetRoot`. Released manifests strip `build` and
-record the prepared `artifacts` metadata. Hosted HTTP/security metadata is read
-from manifest `spec.securitySchemes` / `spec.http` and preserved in the
-packaged manifest.
+For source manifests with object-form `build.command`, release runs the command
+before packaging. Executable providers must produce `entrypoint.artifactPath`;
+UI providers must produce `spec.assetRoot`. Released manifests strip `build`
+and `run`, then record the prepared `artifacts` metadata. Hosted HTTP/security
+metadata is read from manifest `spec.securitySchemes` / `spec.http` and
+preserved in the packaged manifest.
 
-Executable source packages require `build.command` for release packaging and
-build the host-platform artifact by default. Platform-neutral packages, such as
-UI and declarative providers, produce a generic archive by default. Pass
-`--platform` for an explicit `os/arch[/libc]` target list, or `--platform all`
-in CI to build the full supported release matrix. For explicit platforms,
-Gestalt sets target environment variables such as `GOOS`, `GOARCH`,
-`GESTALT_TARGET_OS`, `GESTALT_TARGET_ARCH`, and `GESTALT_TARGET_LIBC` for build
-scripts that need them.
+Executable source packages build the host-platform artifact by default. They
+can use SDK-native source-package metadata, or object-form `build.command` when
+they need a custom build step. Platform-neutral packages, such as UI and
+declarative providers, produce a generic archive by default. Pass `--platform`
+for an explicit `os/arch[/libc]` target list, or `--platform all` in CI to
+build the full supported release matrix. For explicit platforms, Gestalt sets
+target environment variables such as `GOOS`, `GOARCH`, `GESTALT_TARGET_OS`,
+`GESTALT_TARGET_ARCH`, and `GESTALT_TARGET_LIBC` for build scripts that need
+them.

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -596,8 +596,8 @@ build:
 Prepare-only builds are not valid for source UI manifests, because UI packages
 must produce the directory declared by `spec.assetRoot`.
 
-Top-level `run` is source-only. `run.commandPrefix` wraps the resolved provider
-command when Gestalt launches the local source provider:
+Top-level `run` is source-only. `run.commandPrefix` is prepended to the command
+Gestalt would normally use to start the local source provider:
 
 ```yaml
 run:
@@ -608,7 +608,7 @@ run:
 
 | Run field | Type | Required | Purpose |
 | --- | --- | --- | --- |
-| `commandPrefix` | string[] | yes | Command argv prepended to the resolved provider command. |
+| `commandPrefix` | string[] | yes | Command argv prepended to the command Gestalt would normally use to start the local source provider. |
 
 ## Artifacts
 

--- a/docs/scripts/check-nginx-routing.mjs
+++ b/docs/scripts/check-nginx-routing.mjs
@@ -27,6 +27,7 @@ try {
   const baseUrl = `http://127.0.0.1:${port}`;
   const devAssetPath = findStaticAssetPath("dev/_next/static");
   const latestAssetPath = findStaticAssetPath("latest/_next/static");
+  const pagefindScriptPath = "/_pagefind/pagefind.js";
   await waitForNginx(baseUrl);
   const versionsManifest = await readVersionsManifest(
     `${baseUrl}/versions.json`,
@@ -87,6 +88,11 @@ try {
     cacheControlIncludes: "immutable",
   });
   await assertResponse({
+    url: `${baseUrl}/dev${pagefindScriptPath}`,
+    host: "gestaltd.ai",
+    status: 200,
+  });
+  await assertResponse({
     url: `${baseUrl}/dev/providers/`,
     host: "gestaltd.ai",
     status: 301,
@@ -129,10 +135,20 @@ try {
     cacheControlIncludes: "immutable",
   });
   await assertResponse({
+    url: `${baseUrl}/latest${pagefindScriptPath}`,
+    host: "gestaltd.ai",
+    status: 200,
+  });
+  await assertResponse({
     url: `${baseUrl}/latest/getting-started/`,
     host: "gestaltd.ai",
     status: 301,
     location: "/latest/getting-started",
+  });
+  await assertResponse({
+    url: `${baseUrl}${exactVersionPrefix}${pagefindScriptPath}`,
+    host: "gestaltd.ai",
+    status: 200,
   });
   await assertResponse({
     url: `${baseUrl}${exactVersionPrefix}/reference/cli`,

--- a/docs/scripts/check-registry-static.mjs
+++ b/docs/scripts/check-registry-static.mjs
@@ -54,6 +54,7 @@ try {
   const { port } = server.address();
   const baseUrl = `http://127.0.0.1:${port}`;
   const devAssetPath = findStaticAssetPath("dev/_next/static");
+  const pagefindScriptPath = "/_pagefind/pagefind.js";
   const versionsManifest = await readVersionsManifest(
     `${baseUrl}/versions.json`,
     "gestaltd.ai",
@@ -144,6 +145,11 @@ try {
     host: "gestaltd.ai",
     status: 200,
   });
+  await assertResponse({
+    url: `${baseUrl}/dev${pagefindScriptPath}`,
+    host: "gestaltd.ai",
+    status: 200,
+  });
   await assertRedirect({
     url: `${baseUrl}/dev/providers/`,
     host: "gestaltd.ai",
@@ -169,6 +175,11 @@ try {
     includes: "Getting Started",
     excludes: registryMarker,
   });
+  await assertResponse({
+    url: `${baseUrl}/latest${pagefindScriptPath}`,
+    host: "gestaltd.ai",
+    status: 200,
+  });
   await assertRedirect({
     url: `${baseUrl}/latest/getting-started/`,
     host: "gestaltd.ai",
@@ -192,6 +203,11 @@ try {
     status: 200,
     includes: "Server CLI",
     excludes: registryMarker,
+  });
+  await assertResponse({
+    url: `${baseUrl}${exactVersionPrefix}${pagefindScriptPath}`,
+    host: "gestaltd.ai",
+    status: 200,
   });
   await assertRedirect({
     url: `${baseUrl}${exactVersionPrefix}/reference/cli/`,
@@ -307,6 +323,12 @@ async function serveDocsHost(pathname, response) {
   const versionPageWithSlash = pathname.match(/^(\/versions\/v[^/]+\/.+)\/$/);
   if (versionPageWithSlash) {
     return redirect(response, versionPageWithSlash[1]);
+  }
+  const versionedPagefindPath = pathname.match(
+    /^\/(?:dev|latest|versions\/v[^/]+)(\/_pagefind\/.*)$/,
+  );
+  if (versionedPagefindPath) {
+    return serveFile(versionedPagefindPath[1], response, false);
   }
   if (
     pathname.startsWith("/dev/") ||


### PR DESCRIPTION
## Summary

- Document recently shipped local development paths for scoped serve, config watch, remote attach, local source lock behavior, and parallel local source preparation.
- Add manifest reference coverage for prepare-only source builds and `run.commandPrefix`.
- Correct app and CLI reference wording around `spec.assetRoot` and `--artifacts-dir`.

## Validation

- `npm run build:single`
- `npm run typecheck`
- Started a local docs server from the built output and verified edited pages return `200 OK`.
