### PR TITLE
Allow static GraphQL operations to use selected connections

### DIFF
--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -3438,6 +3438,35 @@ func TestBuildStartupProviderSpecPreservesStaticCatalogConnectionRouting(t *test
 	if got := operationRouting.connections["echo"]; got != config.PluginConnectionName {
 		t.Fatalf("echo connection = %q, want %q", got, config.PluginConnectionName)
 	}
+
+	manifestRoot = writeStaticCatalog(t, &catalog.Catalog{
+		Name: "schema",
+		Operations: []catalog.CatalogOperation{
+			{ID: "versions.list", Method: http.MethodPost, Transport: "graphql"},
+		},
+	})
+	manifest = newExecutableManifest("Schema", "GraphQL startup routing")
+	manifest.Spec.Connections = map[string]*providermanifestv1.ManifestConnectionDef{
+		"dev":  {Mode: providermanifestv1.ConnectionModeUser},
+		"prod": {Mode: providermanifestv1.ConnectionModeUser},
+	}
+	manifest.Spec.Surfaces = &providermanifestv1.ProviderSurfaces{
+		GraphQL: &providermanifestv1.GraphQLSurface{URL: "https://{graphql_host}/graphql"},
+	}
+
+	spec, operationRouting, err = buildStartupProviderSpec("schema", &config.ProviderEntry{
+		ResolvedManifest:     manifest,
+		ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+	})
+	if err != nil {
+		t.Fatalf("buildStartupProviderSpec ambiguous graphql: %v", err)
+	}
+	if spec.Catalog == nil || len(spec.Catalog.Operations) != 1 {
+		t.Fatalf("unexpected ambiguous graphql startup catalog: %+v", spec.Catalog)
+	}
+	if got, ok := operationRouting.connections["versions.list"]; ok {
+		t.Fatalf("versions.list connection = %q, want no static connection so the selected connection can apply", got)
+	}
 }
 
 func TestStartupProviderProxyResolvesDeclarativeConnectionSelectorBeforeProviderReady(t *testing.T) {

--- a/gestaltd/internal/config/connection_plan.go
+++ b/gestaltd/internal/config/connection_plan.go
@@ -423,18 +423,7 @@ func (plan StaticConnectionPlan) resolveSurfaceConnectionName(raw string) string
 	if name := ResolveConnectionAlias(raw); name != "" {
 		return name
 	}
-	if plan.defaultConnection != "" {
-		return plan.defaultConnection
-	}
-	if _, ok := plan.namedConnections["default"]; ok {
-		return "default"
-	}
-	if len(plan.namedConnections) == 1 {
-		for name := range plan.namedConnections {
-			return name
-		}
-	}
-	return PluginConnectionName
+	return plan.fallbackConnection()
 }
 
 func (plan StaticConnectionPlan) shouldAdvertisePluginConnection() bool {


### PR DESCRIPTION
## Summary
- Reuses the connection plan fallback semantics for spec surfaces, leaving operations unpinned when an integration has multiple named connections and no default surface connection.
- Keeps explicit surface connections, named `default` connections, single named connections, and explicit `_plugin` defaults on the existing routing path.
- Augments the existing startup provider routing coverage with a static GraphQL operation that must be routed by the caller-selected connection.

## Test plan
- [x] `go test ./internal/bootstrap -run 'TestBuildStartupProviderSpecPreservesStaticCatalogConnectionRouting|TestBootstrapAllowsPluginConfiguredWithBothOpenAPIAndGraphQLAPISurfaces'`\n- [x] `go test ./internal/bootstrap ./internal/config`