### PR TITLE
[authorization] fix service account authz provider state

### DIFF
--- a/gestaltd/internal/coredata/authz_dynamic_fragments.go
+++ b/gestaltd/internal/coredata/authz_dynamic_fragments.go
@@ -266,17 +266,7 @@ func (s *AuthorizationDynamicFragmentService) ReplaceSubjectResourceRelationship
 		if err := validateAuthorizationFragmentRelationship(relationship); err != nil {
 			return err
 		}
-		out := make([]AuthorizationDynamicFragmentRelationship, 0, len(fragment.Relationships)+1)
-		for _, existing := range fragment.Relationships {
-			existing = normalizeAuthorizationFragmentRelationship(existing)
-			if existing.Subject.Type == relationship.Subject.Type &&
-				existing.Subject.ID == relationship.Subject.ID &&
-				existing.Resource.Type == relationship.Resource.Type &&
-				existing.Resource.ID == relationship.Resource.ID {
-				continue
-			}
-			out = append(out, existing)
-		}
+		out, _ := removeAuthorizationFragmentRelationshipsForSubjectResource(fragment.Relationships, relationship.Subject, relationship.Resource)
 		out = append(out, relationship)
 		fragment.Relationships = out
 		sortAuthorizationFragmentRelationships(fragment.Relationships)
@@ -306,7 +296,75 @@ func (s *AuthorizationDynamicFragmentService) DeleteRelationship(ctx context.Con
 		fragment.Relationships = out
 		return nil
 	})
-	return deleted, fragment, err
+	if err != nil || !deleted {
+		return deleted, fragment, err
+	}
+	fragment, err = s.maybeDeleteEmptyFragment(ctx, fragment)
+	return true, fragment, err
+}
+
+func (s *AuthorizationDynamicFragmentService) DeleteSubjectResourceRelationships(ctx context.Context, owner AuthorizationFragmentOwner, subject AuthorizationDynamicFragmentSubject, resource AuthorizationDynamicFragmentResource, audit AuthorizationDynamicFragmentAuditMetadata) (bool, *AuthorizationDynamicFragment, error) {
+	existing, err := s.GetFragmentByOwner(ctx, owner)
+	if err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			return false, nil, nil
+		}
+		return false, nil, err
+	}
+	subject.Type = strings.TrimSpace(subject.Type)
+	subject.ID = strings.TrimSpace(subject.ID)
+	resource.Type = strings.TrimSpace(resource.Type)
+	resource.ID = strings.TrimSpace(resource.ID)
+	if subject.Type == "" || subject.ID == "" || resource.Type == "" || resource.ID == "" {
+		return false, existing, fmt.Errorf("subject and resource are required")
+	}
+
+	deleted := false
+	fragment, err := s.UpdateFragment(ctx, owner, AuthorizationDynamicFragmentUpdate{Audit: audit}, func(fragment *AuthorizationDynamicFragment) error {
+		out, removed := removeAuthorizationFragmentRelationshipsForSubjectResource(fragment.Relationships, subject, resource)
+		deleted = removed
+		fragment.Relationships = out
+		return nil
+	})
+	if err != nil || !deleted {
+		return deleted, fragment, err
+	}
+	fragment, err = s.maybeDeleteEmptyFragment(ctx, fragment)
+	return true, fragment, err
+}
+
+func (s *AuthorizationDynamicFragmentService) maybeDeleteEmptyFragment(ctx context.Context, fragment *AuthorizationDynamicFragment) (*AuthorizationDynamicFragment, error) {
+	if fragment == nil {
+		return nil, nil
+	}
+	if len(fragment.Relationships) == 0 && len(fragment.ResourceTypes) == 0 {
+		if err := s.DeleteFragment(ctx, fragment.ID); err != nil {
+			return fragment, err
+		}
+		return nil, nil
+	}
+	return fragment, nil
+}
+
+func removeAuthorizationFragmentRelationshipsForSubjectResource(relationships []AuthorizationDynamicFragmentRelationship, subject AuthorizationDynamicFragmentSubject, resource AuthorizationDynamicFragmentResource) ([]AuthorizationDynamicFragmentRelationship, bool) {
+	out := relationships[:0]
+	removed := false
+	for _, relationship := range relationships {
+		relationship = normalizeAuthorizationFragmentRelationship(relationship)
+		if authorizationFragmentRelationshipMatchesSubjectResource(relationship, subject, resource) {
+			removed = true
+			continue
+		}
+		out = append(out, relationship)
+	}
+	return out, removed
+}
+
+func authorizationFragmentRelationshipMatchesSubjectResource(relationship AuthorizationDynamicFragmentRelationship, subject AuthorizationDynamicFragmentSubject, resource AuthorizationDynamicFragmentResource) bool {
+	return relationship.Subject.Type == subject.Type &&
+		relationship.Subject.ID == subject.ID &&
+		relationship.Resource.Type == resource.Type &&
+		relationship.Resource.ID == resource.ID
 }
 
 func normalizeAuthorizationFragmentOwner(owner AuthorizationFragmentOwner) AuthorizationFragmentOwner {

--- a/gestaltd/internal/coredata/authz_dynamic_fragments_test.go
+++ b/gestaltd/internal/coredata/authz_dynamic_fragments_test.go
@@ -55,8 +55,11 @@ func TestAuthorizationDynamicFragmentServiceUpsertsOwnerRecord(t *testing.T) {
 	if !deleted {
 		t.Fatal("DeleteRelationship deleted = false, want true")
 	}
-	if updated.Version != 3 {
-		t.Fatalf("version after delete = %d, want 3", updated.Version)
+	if updated != nil {
+		t.Fatalf("fragment after deleting only relationship = %#v, want deleted fragment", updated)
+	}
+	if _, err := svc.AuthzFragments.GetFragmentByOwner(ctx, coredata.AuthorizationPluginFragmentOwner("github")); err != core.ErrNotFound {
+		t.Fatalf("GetFragmentByOwner after delete err = %v, want ErrNotFound", err)
 	}
 }
 
@@ -81,6 +84,45 @@ func TestAuthorizationDynamicFragmentServiceDeleteMissingOwnerDoesNotCreateFragm
 	}
 	if _, err := svc.AuthzFragments.GetFragmentByOwner(ctx, coredata.AuthorizationPluginFragmentOwner("github")); err != core.ErrNotFound {
 		t.Fatalf("GetFragmentByOwner err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestAuthorizationDynamicFragmentServiceDeleteSubjectResourceRelationships(t *testing.T) {
+	t.Parallel()
+
+	svc, err := coredata.New(&coretesting.StubIndexedDB{})
+	if err != nil {
+		t.Fatalf("coredata.New: %v", err)
+	}
+	ctx := context.Background()
+	owner := coredata.AuthorizationPluginFragmentOwner("github")
+	directMember := coredata.AuthorizationDynamicFragmentRelationship{
+		Subject:  coredata.AuthorizationDynamicFragmentSubject{Type: "subject", ID: "service_account:bot"},
+		Relation: "viewer",
+		Resource: coredata.AuthorizationDynamicFragmentResource{Type: "plugin_dynamic", ID: "github"},
+	}
+	targetedMember := directMember
+	targetedMember.Relation = "editor"
+	targetedMember.Target.Subject = &coredata.AuthorizationDynamicFragmentSubject{Type: "subject", ID: "service_account:bot"}
+	if _, err := svc.AuthzFragments.UpsertRelationship(ctx, owner, directMember, coredata.AuthorizationDynamicFragmentAuditMetadata{Reason: "direct"}); err != nil {
+		t.Fatalf("UpsertRelationship direct: %v", err)
+	}
+	if _, err := svc.AuthzFragments.UpsertRelationship(ctx, owner, targetedMember, coredata.AuthorizationDynamicFragmentAuditMetadata{Reason: "targeted"}); err != nil {
+		t.Fatalf("UpsertRelationship targeted: %v", err)
+	}
+
+	deleted, fragment, err := svc.AuthzFragments.DeleteSubjectResourceRelationships(ctx, owner, directMember.Subject, directMember.Resource, coredata.AuthorizationDynamicFragmentAuditMetadata{Reason: "delete_member"})
+	if err != nil {
+		t.Fatalf("DeleteSubjectResourceRelationships: %v", err)
+	}
+	if !deleted {
+		t.Fatal("DeleteSubjectResourceRelationships deleted = false, want true")
+	}
+	if fragment != nil {
+		t.Fatalf("fragment after deleting only member relationships = %#v, want deleted fragment", fragment)
+	}
+	if _, err := svc.AuthzFragments.GetFragmentByOwner(ctx, owner); err != core.ErrNotFound {
+		t.Fatalf("GetFragmentByOwner after delete err = %v, want ErrNotFound", err)
 	}
 }
 

--- a/gestaltd/internal/server/authz_dynamic_fragments.go
+++ b/gestaltd/internal/server/authz_dynamic_fragments.go
@@ -225,19 +225,22 @@ func (s *Server) upsertAuthorizationDynamicFragmentRelationship(ctx context.Cont
 	return fragment, nil
 }
 
-func (s *Server) deleteAuthorizationDynamicFragmentRelationship(ctx context.Context, owner coredata.AuthorizationFragmentOwner, relationship coredata.AuthorizationDynamicFragmentRelationship, reason string) (bool, *coredata.AuthorizationDynamicFragment, error) {
+func (s *Server) deleteAuthorizationDynamicFragmentSubjectResourceRelationships(ctx context.Context, owner coredata.AuthorizationFragmentOwner, subject coredata.AuthorizationDynamicFragmentSubject, resource coredata.AuthorizationDynamicFragmentResource, reason string) (bool, *coredata.AuthorizationDynamicFragment, error) {
 	if s.authzFragments == nil {
 		return false, nil, nil
 	}
 	if err := s.ensureAuthorizationDynamicFragmentsBackfilled(ctx); err != nil {
 		return false, nil, err
 	}
-	deleted, fragment, err := s.authzFragments.DeleteRelationship(ctx, owner, relationship, s.authorizationFragmentAuditMetadata(ctx, reason))
+	deleted, fragment, err := s.authzFragments.DeleteSubjectResourceRelationships(ctx, owner, subject, resource, s.authorizationFragmentAuditMetadata(ctx, reason))
 	if err != nil {
 		return false, nil, err
 	}
 	if deleted {
-		s.auditAuthorizationFragmentMutation(ctx, "authorization.fragment.relationship.delete", fragment, &relationship)
+		s.auditAuthorizationFragmentMutation(ctx, "authorization.fragment.relationship.delete", fragment, &coredata.AuthorizationDynamicFragmentRelationship{
+			Subject:  subject,
+			Resource: resource,
+		})
 	}
 	return deleted, fragment, nil
 }

--- a/gestaltd/internal/server/handlers_admin_authorization_provider_write.go
+++ b/gestaltd/internal/server/handlers_admin_authorization_provider_write.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -60,21 +61,7 @@ func (s *Server) deleteProviderPluginAuthorization(ctx context.Context, plugin, 
 		Type: authorization.ProviderResourceTypePluginDynamic,
 		Id:   strings.TrimSpace(plugin),
 	}
-	existing, _, err := s.deleteProviderDynamicMembership(ctx, resource, subjectID)
-	if err != nil {
-		return err
-	}
-	if len(existing) == 0 {
-		return core.ErrNotFound
-	}
-	for _, rel := range existing {
-		fragmentRel := authorizationDynamicFragmentRelationshipFromCore(rel)
-		_, _, err := s.deleteAuthorizationDynamicFragmentRelationship(ctx, coredata.AuthorizationPluginFragmentOwner(plugin), fragmentRel, "plugin_member_delete")
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	return s.deleteProviderDynamicFragmentMembership(ctx, coredata.AuthorizationPluginFragmentOwner(plugin), resource, subjectID, "plugin_member_delete")
 }
 
 func (s *Server) upsertProviderAdminAuthorization(ctx context.Context, subject *adminAuthorizationWriteSubject, role string) (*providerAdminAuthorizationMembership, error) {
@@ -114,6 +101,10 @@ func (s *Server) deleteProviderAdminAuthorization(ctx context.Context, subjectID
 		Type: authorization.ProviderResourceTypeAdminDynamic,
 		Id:   authorization.ProviderResourceIDAdminDynamicGlobal,
 	}
+	return s.deleteProviderDynamicFragmentMembership(ctx, coredata.AuthorizationGlobalFragmentOwner(), resource, subjectID, "admin_member_delete")
+}
+
+func (s *Server) deleteProviderDynamicFragmentMembership(ctx context.Context, owner coredata.AuthorizationFragmentOwner, resource *core.ResourceRef, subjectID, reason string) error {
 	existing, _, err := s.deleteProviderDynamicMembership(ctx, resource, subjectID)
 	if err != nil {
 		return err
@@ -121,14 +112,30 @@ func (s *Server) deleteProviderAdminAuthorization(ctx context.Context, subjectID
 	if len(existing) == 0 {
 		return core.ErrNotFound
 	}
-	for _, rel := range existing {
-		fragmentRel := authorizationDynamicFragmentRelationshipFromCore(rel)
-		_, _, err := s.deleteAuthorizationDynamicFragmentRelationship(ctx, coredata.AuthorizationGlobalFragmentOwner(), fragmentRel, "admin_member_delete")
-		if err != nil {
-			return err
-		}
+	deleted, _, err := s.deleteDynamicFragmentMembership(ctx, owner, resource, subjectID, reason)
+	if err != nil {
+		return err
+	}
+	if !deleted {
+		slog.WarnContext(ctx, "provider authorization membership deleted without matching dynamic fragment relationship",
+			"owner_kind", owner.Kind,
+			"owner_plugin", owner.Plugin,
+			"resource_type", resource.GetType(),
+			"resource_id", resource.GetId(),
+			"subject_id", strings.TrimSpace(subjectID),
+		)
 	}
 	return nil
+}
+
+func (s *Server) deleteDynamicFragmentMembership(ctx context.Context, owner coredata.AuthorizationFragmentOwner, resource *core.ResourceRef, subjectID, reason string) (bool, *coredata.AuthorizationDynamicFragment, error) {
+	return s.deleteAuthorizationDynamicFragmentSubjectResourceRelationships(ctx, owner, coredata.AuthorizationDynamicFragmentSubject{
+		Type: authorization.ProviderSubjectTypeSubject,
+		ID:   strings.TrimSpace(subjectID),
+	}, coredata.AuthorizationDynamicFragmentResource{
+		Type: resource.GetType(),
+		ID:   resource.GetId(),
+	}, reason)
 }
 
 func (s *Server) upsertManagedSubjectExternalIdentity(ctx context.Context, subjectID string, ref externalIdentityRef) error {

--- a/gestaltd/internal/server/handlers_admin_authorization_provider_write_test.go
+++ b/gestaltd/internal/server/handlers_admin_authorization_provider_write_test.go
@@ -1,0 +1,161 @@
+package server_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
+	"github.com/valon-technologies/gestalt/server/internal/server"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	"github.com/valon-technologies/gestalt/server/services/authorization"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+)
+
+func TestAdminAPI_DeletePluginMemberRemovesPersistedDynamicFragmentAcrossReload(t *testing.T) {
+	t.Parallel()
+
+	subjectToken, subjectTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
+	if err != nil {
+		t.Fatalf("GenerateToken subject: %v", err)
+	}
+	subjectID := "service_account:authz-dynamic-candidate"
+	svc := testutil.NewStubServices(t)
+	seedSubjectAPIToken(t, svc, subjectTokenHash, subjectID, "authz dynamic candidate")
+
+	stub := &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{StubIntegration: coretesting.StubIntegration{
+			N:        "sample_plugin",
+			ConnMode: core.ConnectionModeNone,
+			ExecuteFn: func(context.Context, string, map[string]any, string) (*core.OperationResult, error) {
+				return &core.OperationResult{Status: http.StatusOK, Body: `{}`}, nil
+			},
+		}},
+		catalog: &catalog.Catalog{
+			Name:       "sample_plugin",
+			Operations: []catalog.CatalogOperation{{ID: "run", Method: http.MethodGet, Transport: catalog.TransportREST, AllowedRoles: []string{"viewer"}}},
+		},
+	}
+	pluginDefs := map[string]*config.ProviderEntry{
+		"sample_plugin": {AuthorizationPolicy: "sample_policy"},
+	}
+	baseAuthz, err := newTestAuthorizer(config.AuthorizationConfig{
+		Policies: map[string]config.SubjectPolicyDef{
+			"sample_policy": {Default: "deny"},
+			"admin_policy": {
+				Default: "deny",
+				Members: []config.SubjectPolicyMemberDef{
+					staticPolicyUserMember(t, svc, "static-admin@example.test", "admin"),
+				},
+			},
+		},
+	}, pluginDefs)
+	if err != nil {
+		t.Fatalf("authorization.New: %v", err)
+	}
+	provider := newMemoryAuthorizationProvider("memory-authorization")
+	authz, err := authorization.NewProviderBacked(baseAuthz, provider, authorization.WithDynamicFragmentSource(svc.AuthzFragments))
+	if err != nil {
+		t.Fatalf("NewProviderBacked: %v", err)
+	}
+	if err := authz.ReloadAuthorizationState(context.Background()); err != nil {
+		t.Fatalf("ReloadAuthorizationState: %v", err)
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "admin-session" {
+					return nil, fmt.Errorf("invalid token")
+				}
+				return &core.UserIdentity{Email: "static-admin@example.test"}, nil
+			},
+		}
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.AuthorizationProvider = provider
+		cfg.PluginDefs = pluginDefs
+		cfg.Admin = server.AdminRouteConfig{
+			AuthorizationPolicy: "admin_policy",
+			AllowedRoles:        []string{"admin"},
+		}
+		cfg.AdminUI = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("admin"))
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	assertSubjectStatus := func(label string, want int) {
+		t.Helper()
+		req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/sample_plugin/run", nil)
+		req.Header.Set("Authorization", "Bearer "+subjectToken)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("%s request: %v", label, err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != want {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("%s status = %d, want %d: %s", label, resp.StatusCode, want, body)
+		}
+	}
+	assertSubjectStatus("before grant", http.StatusForbidden)
+
+	body := bytes.NewBufferString(fmt.Sprintf(`{"subjectId":%q,"role":"viewer"}`, subjectID))
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT dynamic member: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("put dynamic member status = %d, want 200: %s", resp.StatusCode, respBody)
+	}
+	assertSubjectStatus("after grant", http.StatusOK)
+
+	fragment, err := svc.AuthzFragments.GetFragmentByOwner(context.Background(), coredata.AuthorizationPluginFragmentOwner("sample_plugin"))
+	if err != nil {
+		t.Fatalf("GetFragmentByOwner after grant: %v", err)
+	}
+	if len(fragment.Relationships) != 1 || fragment.Relationships[0].Subject.ID != subjectID {
+		t.Fatalf("fragment after grant = %#v, want one dynamic candidate relationship", fragment.Relationships)
+	}
+
+	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members/"+url.PathEscape(subjectID), nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE dynamic member: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("delete dynamic member status = %d, want 200: %s", resp.StatusCode, respBody)
+	}
+	assertSubjectStatus("after delete", http.StatusForbidden)
+	if _, err := svc.AuthzFragments.GetFragmentByOwner(context.Background(), coredata.AuthorizationPluginFragmentOwner("sample_plugin")); !errors.Is(err, core.ErrNotFound) {
+		t.Fatalf("GetFragmentByOwner after delete err = %v, want ErrNotFound", err)
+	}
+
+	if err := authz.ReloadAuthorizationState(context.Background()); err != nil {
+		t.Fatalf("ReloadAuthorizationState after delete: %v", err)
+	}
+	assertSubjectStatus("after reload", http.StatusForbidden)
+	if _, err := svc.AuthzFragments.GetFragmentByOwner(context.Background(), coredata.AuthorizationPluginFragmentOwner("sample_plugin")); !errors.Is(err, core.ErrNotFound) {
+		t.Fatalf("GetFragmentByOwner after reload err = %v, want ErrNotFound", err)
+	}
+}

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -5817,10 +5817,10 @@ func TestAuthorizationManagedSubjectsAPI(t *testing.T) {
 	if err != nil {
 		t.Fatalf("invoke default-allow plugin without managed subject grant: %v", err)
 	}
-	if resp.StatusCode != http.StatusForbidden {
+	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		_ = resp.Body.Close()
-		t.Fatalf("default-allow invocation without grant status = %d, want 403: %s", resp.StatusCode, body)
+		t.Fatalf("default-allow invocation without grant status = %d, want 200: %s", resp.StatusCode, body)
 	}
 	_ = resp.Body.Close()
 

--- a/gestaltd/services/authorization/authorizer.go
+++ b/gestaltd/services/authorization/authorizer.go
@@ -11,7 +11,8 @@ import (
 )
 
 const (
-	defaultSubjectRole = "viewer"
+	defaultSubjectRole        = "viewer"
+	serviceAccountSubjectKind = principal.Kind("service_account")
 )
 
 type AccessContext struct {
@@ -343,7 +344,14 @@ func (p *SubjectPolicy) roleForPrincipal(pr *principal.Principal) (string, bool)
 }
 
 func defaultAllowAppliesToPrincipal(p *principal.Principal) bool {
-	return !principal.IsNonUserPrincipal(p)
+	p = principal.Canonicalized(p)
+	if p == nil || strings.TrimSpace(p.SubjectID) == "" {
+		return false
+	}
+	// Static default-allow grants the baseline viewer role only to authenticated
+	// user and service-account callers. Other managed subject kinds still need
+	// explicit policy membership.
+	return p.Kind == principal.KindUser || p.Kind == serviceAccountSubjectKind
 }
 
 func (p *SubjectPolicy) staticRoleForIdentity(subjectID string) (string, bool) {

--- a/gestaltd/services/authorization/authorizer_test.go
+++ b/gestaltd/services/authorization/authorizer_test.go
@@ -1,0 +1,69 @@
+package authorization
+
+import (
+	"context"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+)
+
+func TestDefaultAllowAppliesToUsersAndServiceAccounts(t *testing.T) {
+	t.Parallel()
+
+	authz, err := New(StaticConfig{
+		Policies: map[string]StaticSubjectPolicy{
+			"default_allow": {Default: "allow"},
+		},
+		ProviderPolicies: map[string]string{
+			"svc": "default_allow",
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name      string
+		principal *principal.Principal
+		wantAllow bool
+	}{
+		{
+			name:      "user subject",
+			principal: &principal.Principal{SubjectID: "user:u-123"},
+			wantAllow: true,
+		},
+		{
+			name:      "service account subject",
+			principal: &principal.Principal{SubjectID: "service_account:triage-bot"},
+			wantAllow: true,
+		},
+		{
+			name:      "managed subject",
+			principal: &principal.Principal{SubjectID: "subject:deploy-managed-bot"},
+			wantAllow: false,
+		},
+		{
+			name:      "system subject",
+			principal: &principal.Principal{SubjectID: "system:workflow"},
+			wantAllow: false,
+		},
+		{
+			name:      "empty subject",
+			principal: &principal.Principal{},
+			wantAllow: false,
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			access, allowed := authz.ResolvePolicyAccess(context.Background(), tc.principal, "default_allow")
+			if allowed != tc.wantAllow {
+				t.Fatalf("ResolveAccess allowed = %v, want %v", allowed, tc.wantAllow)
+			}
+			if tc.wantAllow && access.Role != defaultSubjectRole {
+				t.Fatalf("ResolveAccess role = %q, want %q", access.Role, defaultSubjectRole)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Allows default-allow policies to grant viewer access to authenticated users and service-account subjects only, and makes dynamic plugin/admin member deletion remove persisted fragment state so reloads do not resurrect removed members.