### PR TITLE
[codex] Simplify source provider run commands

### DIFF
--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -277,12 +277,14 @@ See [Provider Manifests](/reference/plugin-manifests) for the full field referen
   </Tabs.Tab>
   <Tabs.Tab>
     You need the package manager and TypeScript runtime or compiler used by
-    your `build.command`, plus a running `gestaltd` instance for testing.
+    your `run` and `build.command`, plus a running `gestaltd` instance for
+    testing.
 
     ```sh
     mkdir slack && cd slack
     npm init -y
     npm install @valon-technologies/gestalt
+    npm install --save-dev tsx
     ```
 
     Recommended layout:
@@ -306,10 +308,14 @@ See [Provider Manifests](/reference/plugin-manifests) for the full field referen
       "private": true,
       "type": "module",
       "scripts": {
-        "build": "node ./scripts/build-provider.mjs"
+        "build": "node ./scripts/build-provider.mjs",
+        "dev:provider": "tsx ./provider.ts"
       },
       "dependencies": {
         "@valon-technologies/gestalt": "latest"
+      },
+      "devDependencies": {
+        "tsx": "latest"
       }
     }
     ```
@@ -325,6 +331,10 @@ See [Provider Manifests](/reference/plugin-manifests) for the full field referen
         - package-lock.json
         - provider.ts
         - scripts
+    run:
+      - npm
+      - run
+      - dev:provider
     entrypoint:
       artifactPath: .gestalt/build/slack
     ```
@@ -333,7 +343,7 @@ See [Provider Manifests](/reference/plugin-manifests) for the full field referen
 
 ### Defining operations
 
-Operations are the callable units of a plugin. Each operation has an ID, an HTTP method, input and output types, and a handler function. Executable source plugins can use SDK-native source package metadata, or declare `build.command` and `entrypoint.artifactPath` when they need a custom build.
+Operations are the callable units of a plugin. Each operation has an ID, an HTTP method, input and output types, and a handler function. Executable source plugins can use SDK-native source package metadata, declare `run` for local source execution, or declare `build.command` and `entrypoint.artifactPath` when they need a compiled release artifact.
 
 The following example defines a `conversations.getMessage` operation that fetches a single Slack message by channel and timestamp. The handler uses the resolved runtime token from the request context to call the Slack API.
 
@@ -495,9 +505,9 @@ The following example defines a `conversations.getMessage` operation that fetche
     });
     ```
 
-    The manifest `build.command` packages this source into the executable file
-    declared by `entrypoint.artifactPath`; Gestalt starts that artifact for
-    local source execution and release packaging.
+    The manifest `run` command starts this source locally. Object-form
+    `build.command` packages the release executable declared by
+    `entrypoint.artifactPath`.
   </Tabs.Tab>
 </Tabs>
 

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -1440,12 +1440,11 @@ same action. API tokens must carry `permissions[].actions:
 operation permissions do not grant attach, and the attach action does not grant
 operation invocation.
 
-Source-backed executable plugins must declare how to build the runnable
-artifact and where that artifact will appear. Gestalt runs `build.command`
-before local execution or release packaging, then starts
-`entrypoint.artifactPath`. The command can call any runtime or compiler
-available in the preparation environment; Gestalt does not infer the provider
-language or synthesize executable wrappers.
+Source-backed executable plugins can declare a local source command with
+top-level `run`. Gestalt runs that argv from the manifest directory when
+serving local source. Use object-form `build.command` with
+`entrypoint.artifactPath` when the same source package also needs a compiled
+release artifact.
 
 ```yaml
 kind: plugin
@@ -1458,6 +1457,10 @@ build:
     - scripts
     - src
     - package.json
+run:
+  - npm
+  - run
+  - dev:provider
 entrypoint:
   artifactPath: .gestalt/build/provider
 spec:

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -44,6 +44,7 @@ These fields appear at the top level of every manifest regardless of kind.
 | `artifacts`   | Artifact[] | no       | Prepared or released executable artifacts keyed by platform. Source manifests must omit this field.                                                        |
 | `entrypoint`  | Entrypoint | no       | Executable entrypoint metadata for the provider.                                                                                                                                                     |
 | `build`       | SourceBuild | no       | Source-only command that prepares the declared runtime output. Prepared and released manifests strip this field.                                                                                     |
+| `run`         | string[] | no       | Source-only command argv for local source execution. Prepared and released manifests strip this field.                                                                                              |
 | `spec`        | object     | no       | Kind-specific configuration block.                                                                                                                                                                   |
 
 ## Entrypoint
@@ -61,10 +62,11 @@ entrypoint:
   args: ["--verbose"]
 ```
 
-For executable source manifests, `entrypoint.artifactPath` is also the build
-output path. When `build` is present, Gestalt runs `build.command` before
-preparing, serving, or releasing the package, and the command must produce that
-file.
+For executable source manifests, `entrypoint.artifactPath` is the packaged
+executable path. When object-form `build.command` is present, Gestalt runs it
+before release packaging and requires the command to produce that file. If a
+source manifest also declares `run`, local source execution uses `run` instead
+of `entrypoint`.
 
 ```yaml
 kind: indexeddb
@@ -573,12 +575,32 @@ spec:
 Top-level `build` is source-only and supported for UI and executable source
 manifests. It is the recommended form for new UI packages authored from
 TypeScript, React, Next.js static export, Vite, or similar frontend source.
+For executable source manifests, `build` can be a sequence that prepares local
+source dependencies. As an object, `build.command` must produce the output declared by
+`entrypoint.artifactPath` for executables or `spec.assetRoot` for UI bundles.
 
 | Build field | Type     | Required | Purpose                                                                                           |
 | ----------- | -------- | -------- | ------------------------------------------------------------------------------------------------- |
 | `command`   | string[] | yes      | Command argv to run before preparing the static assets.                                           |
 | `workdir`   | string   | no       | Manifest-relative directory where `command` runs. Defaults to the manifest directory.             |
 | `inputs`    | string[] | no       | Literal manifest-relative files or directories used to fingerprint local source builds. Glob syntax is not supported. |
+
+## Run
+
+Top-level `run` is source-only and starts an executable provider from local
+source. It is an argv array, not a shell string. Gestalt runs it from the
+manifest directory, so project-local executables should usually include `./`.
+
+```yaml
+build: [uv, sync, --frozen, --no-install-project]
+run: [uv, run, --frozen, ./provider.py, --serve]
+```
+
+`run` is never included in prepared or released manifests. Use
+`entrypoint.artifactPath` and `artifacts` for the compiled package command.
+A manifest that only declares `run` is local-only; add SDK-native provider
+metadata or object-form `build.command` with `entrypoint.artifactPath` before
+using it with lock, sync, or release packaging.
 
 ## Artifacts
 
@@ -810,11 +832,11 @@ and MCP may be added alongside either or both.
 A connection using `mcp_oauth` auth requires the plugin to declare an MCP surface (via `spec.surfaces.mcp` or an equivalent). Manifests that set `auth.type: mcp_oauth` without an MCP surface fail validation.
 
 Executable source providers may either use the SDK-native Go, Rust, Python, or
-TypeScript source-package metadata, or declare top-level `build.command` with
-`entrypoint.artifactPath`. When `build.command` is present, Gestalt runs it
-before source-manifest preparation and requires the command to produce that
-artifact path. Source manifests must not include `artifacts`; prepared and
-released manifests include `artifacts` and omit `build`.
+TypeScript source-package metadata, or declare top-level `run` for local source
+execution. Use object-form `build.command` with `entrypoint.artifactPath` when
+the source package needs to produce a compiled release artifact. Source
+manifests must not include `artifacts`; prepared and released manifests include
+`artifacts` and omit `build` and `run`.
 
 ```yaml
 kind: indexeddb
@@ -836,6 +858,21 @@ entrypoint:
   artifactPath: .gestalt/build/indexeddb
 spec:
   configSchemaPath: schemas/config.schema.yaml
+```
+
+For local-only source execution, `run` can start the provider directly:
+
+```yaml
+kind: plugin
+source: github.com/acme/plugins/slack
+version: 1.0.0
+build: [uv, sync, --frozen, --no-install-project]
+run: [uv, run, --frozen, ./provider.py, --serve]
+spec:
+  connections:
+    default:
+      auth:
+        type: none
 ```
 
 Declarative plugin manifests that only describe hosted HTTP, GraphQL, MCP, or
@@ -882,18 +919,19 @@ gestaltd provider release --version 1.2.3
 
 `gestaltd provider release` preserves the source manifest format, so
 `manifest.yaml` stays YAML and `manifest.json` stays JSON in the release archive.
-For source manifests with `build.command`, release runs the command before
-packaging. Executable providers must produce `entrypoint.artifactPath`; UI
-providers must produce `spec.assetRoot`. Released manifests strip `build` and
-record the prepared `artifacts` metadata. Hosted HTTP/security metadata is read
-from manifest `spec.securitySchemes` / `spec.http` and preserved in the
-packaged manifest.
+For source manifests with object-form `build.command`, release runs the command
+before packaging. Executable providers must produce
+`entrypoint.artifactPath`; UI providers must produce `spec.assetRoot`. Released
+manifests strip `build` and `run`, then record the prepared `artifacts`
+metadata. Hosted HTTP/security metadata is read from manifest
+`spec.securitySchemes` / `spec.http` and preserved in the packaged manifest.
 
-Executable source packages require `build.command` for release packaging and
-build the host-platform artifact by default. Platform-neutral packages, such as
-UI and declarative providers, produce a generic archive by default. Pass
-`--platform` for an explicit `os/arch[/libc]` target list, or `--platform all`
-in CI to build the full supported release matrix. For explicit platforms,
-Gestalt sets target environment variables such as `GOOS`, `GOARCH`,
-`GESTALT_TARGET_OS`, `GESTALT_TARGET_ARCH`, and `GESTALT_TARGET_LIBC` for build
-scripts that need them.
+Executable source packages that are not SDK-native require `build.command` for
+release packaging and build the host-platform artifact by default.
+Platform-neutral packages, such as UI and declarative providers, produce a
+generic archive by default. Pass `--platform` for an explicit
+`os/arch[/libc]` target list, or `--platform all` in CI to build the full
+supported release matrix. For explicit platforms, Gestalt sets target
+environment variables such as `GOOS`, `GOARCH`, `GESTALT_TARGET_OS`,
+`GESTALT_TARGET_ARCH`, and `GESTALT_TARGET_LIBC` for build scripts that need
+them.

--- a/gestaltd/internal/daemon/provider.go
+++ b/gestaltd/internal/daemon/provider.go
@@ -270,6 +270,9 @@ func resolveReleaseBuildTarget(root string, manifest *providermanifestv1.Manifes
 	if kind == providermanifestv1.KindUI {
 		return nil, nil
 	}
+	if err := providerpkg.ValidateExplicitRunPackaging(root, manifest); err != nil {
+		return nil, err
+	}
 	if providerpkg.EffectiveSourceBuild(manifest) != nil {
 		entry := providerpkg.EntrypointForKind(manifest, kind)
 		if entry == nil || strings.TrimSpace(entry.ArtifactPath) == "" {

--- a/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
@@ -104,20 +104,11 @@
       ]
     },
     "sourceRun": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "commandPrefix"
-      ],
-      "properties": {
-        "commandPrefix": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "type": "string",
-            "minLength": 1
-          }
-        }
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
       }
     },
     "spec": {

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -69,7 +69,7 @@ type Manifest struct {
 	Description string       `json:"description,omitempty" yaml:"description,omitempty"`
 	IconFile    string       `json:"iconFile,omitempty" yaml:"iconFile,omitempty"`
 	Build       *SourceBuild `json:"build,omitempty" yaml:"build,omitempty"`
-	Run         *SourceRun   `json:"run,omitempty" yaml:"run,omitempty"`
+	Run         []string     `json:"run,omitempty" yaml:"run,omitempty"`
 	Artifacts   []Artifact   `json:"artifacts,omitempty" yaml:"artifacts,omitempty"`
 	Entrypoint  *Entrypoint  `json:"entrypoint,omitempty" yaml:"entrypoint,omitempty"`
 	Spec        *Spec        `json:"spec,omitempty" yaml:"spec,omitempty"`
@@ -80,10 +80,6 @@ type SourceBuild struct {
 	Command     []string `json:"command" yaml:"command"`
 	Inputs      []string `json:"inputs,omitempty" yaml:"inputs,omitempty"`
 	PrepareOnly bool     `json:"-" yaml:"-"`
-}
-
-type SourceRun struct {
-	CommandPrefix []string `json:"commandPrefix,omitempty" yaml:"commandPrefix,omitempty"`
 }
 
 type sourceBuildWire struct {

--- a/gestaltd/services/plugins/packageio/manifest.go
+++ b/gestaltd/services/plugins/packageio/manifest.go
@@ -163,6 +163,9 @@ func validateManifest(manifest *providermanifestv1.Manifest, sourceMode bool) er
 		if !sourceMode {
 			return fmt.Errorf("run metadata is only allowed in source manifests")
 		}
+		if kind == providermanifestv1.KindUI {
+			return fmt.Errorf("run metadata is not supported for ui manifests")
+		}
 		if err := validateSourceRun(manifest.Run); err != nil {
 			return err
 		}
@@ -479,16 +482,16 @@ func validateSourceBuild(build *providermanifestv1.SourceBuild) error {
 	return nil
 }
 
-func validateSourceRun(run *providermanifestv1.SourceRun) error {
+func validateSourceRun(run []string) error {
 	if run == nil {
 		return nil
 	}
-	if len(run.CommandPrefix) == 0 {
-		return fmt.Errorf("run.commandPrefix is required")
+	if len(run) == 0 {
+		return fmt.Errorf("run command is required")
 	}
-	for i, arg := range run.CommandPrefix {
+	for i, arg := range run {
 		if strings.TrimSpace(arg) == "" {
-			return fmt.Errorf("run.commandPrefix[%d] is required", i)
+			return fmt.Errorf("run[%d] is required", i)
 		}
 	}
 	return nil

--- a/gestaltd/services/plugins/providerpkg/manifest_source_run_test.go
+++ b/gestaltd/services/plugins/providerpkg/manifest_source_run_test.go
@@ -1,0 +1,62 @@
+package providerpkg
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSourceManifestPrepareBuildAndRunCommand(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	manifestPath := mustWriteManifestData(t, dir, "manifest.yaml", []byte(`
+kind: plugin
+source: github.com/acme/plugins/uv-source
+version: 0.0.1-alpha.1
+build: [uv, sync, --frozen, --no-install-project]
+run: [uv, run, --frozen, provider.py, --serve]
+spec:
+  connections:
+    default:
+      auth:
+        type: none
+`))
+
+	_, manifest, err := ReadSourceManifestFile(manifestPath)
+	if err != nil {
+		t.Fatalf("ReadSourceManifestFile: %v", err)
+	}
+	if manifest.Build == nil || !manifest.Build.PrepareOnly {
+		t.Fatalf("build = %#v, want prepare-only build", manifest.Build)
+	}
+	if got := strings.Join(manifest.Build.Command, " "); got != "uv sync --frozen --no-install-project" {
+		t.Fatalf("build.command = %q", got)
+	}
+	if strings.Join(manifest.Run, " ") != "uv run --frozen provider.py --serve" {
+		t.Fatalf("run = %#v", manifest.Run)
+	}
+
+	cloned, err := cloneManifest(manifest)
+	if err != nil {
+		t.Fatalf("cloneManifest: %v", err)
+	}
+	if cloned.Build == nil || !cloned.Build.PrepareOnly {
+		t.Fatalf("cloned build = %#v, want prepare-only build", cloned.Build)
+	}
+
+	encoded, err := EncodeSourceManifestFormat(cloned, ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("EncodeSourceManifestFormat: %v", err)
+	}
+	roundTripped, err := DecodeSourceManifestFormat(encoded, ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("DecodeSourceManifestFormat(round trip): %v\n%s", err, encoded)
+	}
+	if roundTripped.Build == nil || !roundTripped.Build.PrepareOnly {
+		t.Fatalf("round-tripped build = %#v, want prepare-only build", roundTripped.Build)
+	}
+
+	if _, _, err := ReadManifestFile(manifestPath); err == nil || !strings.Contains(err.Error(), "build metadata is only allowed in source manifests") {
+		t.Fatalf("ReadManifestFile error = %v, want package build rejection", err)
+	}
+}

--- a/gestaltd/services/plugins/providerpkg/manifest_workflow_test.go
+++ b/gestaltd/services/plugins/providerpkg/manifest_workflow_test.go
@@ -189,63 +189,6 @@ func TestManifestWorkflow_SourceExecutableDeclaresEntrypointNotArtifacts(t *test
 	}
 }
 
-func TestManifestWorkflow_SourcePrepareBuildAndRunPrefix(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	manifestPath := mustWriteManifestData(t, dir, "manifest.yaml", []byte(`
-kind: plugin
-source: github.com/acme/plugins/uv-source
-version: 0.0.1-alpha.1
-build: [uv, sync, --frozen, --no-install-project]
-run:
-  commandPrefix: [uv, run, --frozen]
-spec:
-  connections:
-    default:
-      auth:
-        type: none
-`))
-
-	_, manifest, err := ReadSourceManifestFile(manifestPath)
-	if err != nil {
-		t.Fatalf("ReadSourceManifestFile: %v", err)
-	}
-	if manifest.Build == nil || !manifest.Build.PrepareOnly {
-		t.Fatalf("build = %#v, want prepare-only build", manifest.Build)
-	}
-	if got := strings.Join(manifest.Build.Command, " "); got != "uv sync --frozen --no-install-project" {
-		t.Fatalf("build.command = %q", got)
-	}
-	if manifest.Run == nil || strings.Join(manifest.Run.CommandPrefix, " ") != "uv run --frozen" {
-		t.Fatalf("run = %#v", manifest.Run)
-	}
-
-	cloned, err := cloneManifest(manifest)
-	if err != nil {
-		t.Fatalf("cloneManifest: %v", err)
-	}
-	if cloned.Build == nil || !cloned.Build.PrepareOnly {
-		t.Fatalf("cloned build = %#v, want prepare-only build", cloned.Build)
-	}
-
-	encoded, err := EncodeSourceManifestFormat(cloned, ManifestFormatYAML)
-	if err != nil {
-		t.Fatalf("EncodeSourceManifestFormat: %v", err)
-	}
-	roundTripped, err := DecodeSourceManifestFormat(encoded, ManifestFormatYAML)
-	if err != nil {
-		t.Fatalf("DecodeSourceManifestFormat(round trip): %v\n%s", err, encoded)
-	}
-	if roundTripped.Build == nil || !roundTripped.Build.PrepareOnly {
-		t.Fatalf("round-tripped build = %#v, want prepare-only build", roundTripped.Build)
-	}
-
-	if _, _, err := ReadManifestFile(manifestPath); err == nil || !strings.Contains(err.Error(), "build metadata is only allowed in source manifests") {
-		t.Fatalf("ReadManifestFile error = %v, want package build rejection", err)
-	}
-}
-
 func TestLoadManifestFromPath_PrefersManifestFileOrder(t *testing.T) {
 	t.Parallel()
 
@@ -485,14 +428,13 @@ spec:
 			wantError:  "build.typo is not supported",
 		},
 		{
-			name: "rejects empty source run prefix",
+			name: "rejects empty source run command",
 			buildData: func(t *testing.T, dir string) string {
 				return mustWriteManifestData(t, dir, "manifest.yaml", []byte(`
 kind: plugin
-source: github.com/acme/plugins/empty-source-run-prefix
+source: github.com/acme/plugins/empty-source-run-command
 version: 1.0.0
-run:
-  commandPrefix: []
+run: []
 entrypoint:
   artifactPath: provider
 spec:
@@ -503,7 +445,65 @@ spec:
 `))
 			},
 			readSource: true,
-			wantError:  "run.commandPrefix is required",
+			wantError:  "run command is required",
+		},
+		{
+			name: "rejects empty source run arg",
+			buildData: func(t *testing.T, dir string) string {
+				return mustWriteManifestData(t, dir, "manifest.yaml", []byte(`
+kind: plugin
+source: github.com/acme/plugins/empty-source-run-arg
+version: 1.0.0
+run: [uv, ""]
+entrypoint:
+  artifactPath: provider
+spec:
+  connections:
+    default:
+      auth:
+        type: none
+`))
+			},
+			readSource: true,
+			wantError:  "run[1] is required",
+		},
+		{
+			name: "rejects legacy source run prefix object",
+			buildData: func(t *testing.T, dir string) string {
+				return mustWriteManifestData(t, dir, "manifest.yaml", []byte(`
+kind: plugin
+source: github.com/acme/plugins/legacy-source-run-prefix
+version: 1.0.0
+run:
+  commandPrefix: [uv, run, --frozen]
+entrypoint:
+  artifactPath: provider
+spec:
+  connections:
+    default:
+      auth:
+        type: none
+`))
+			},
+			readSource: true,
+			wantError:  "cannot unmarshal",
+		},
+		{
+			name: "rejects source ui run metadata",
+			buildData: func(t *testing.T, dir string) string {
+				return mustWriteManifestData(t, dir, "manifest.yaml", []byte(`
+kind: ui
+source: github.com/acme/plugins/source-ui-run
+version: 1.0.0
+build:
+  command: [npm, run, build]
+run: [npm, run, dev]
+spec:
+  assetRoot: dist
+`))
+			},
+			readSource: true,
+			wantError:  "run metadata is not supported for ui manifests",
 		},
 		{
 			name: "released package rejects run metadata",
@@ -512,8 +512,7 @@ spec:
 kind: plugin
 source: github.com/acme/plugins/released-run-metadata
 version: 1.0.0
-run:
-  commandPrefix: [uv, run, --frozen]
+run: [uv, run, --frozen, provider.py]
 spec:
   connections:
     default:

--- a/gestaltd/services/plugins/providerpkg/prepared_stage.go
+++ b/gestaltd/services/plugins/providerpkg/prepared_stage.go
@@ -66,12 +66,15 @@ func StageSourcePreparedInstallDir(manifestPath, stagingDir string, opts StageSo
 			return nil, err
 		}
 	}
+	if err := ValidateExplicitRunPackaging(filepath.Dir(manifestPath), manifest); err != nil {
+		return nil, err
+	}
 	targetOpts := SourceBuildOptions{GOOS: opts.GOOS, GOARCH: opts.GOARCH}
 	hostBuiltForCatalog, err := ensureHostBuildForSourceStaticCatalog(manifestPath, manifest)
 	if err != nil {
 		return nil, err
 	}
-	_, srcManifest, err := PrepareSourceManifest(manifestPath)
+	_, srcManifest, err := prepareSourceManifestForPreparedInstall(manifestPath)
 	if err != nil {
 		return nil, fmt.Errorf("prepare %s: %w", manifestPath, err)
 	}
@@ -89,11 +92,11 @@ func StageSourcePreparedInstallDir(manifestPath, stagingDir string, opts StageSo
 }
 
 func ensureHostBuildForSourceStaticCatalog(manifestPath string, manifest *providermanifestv1.Manifest) (bool, error) {
-	mayGenerate, err := sourceStaticCatalogMayBeGenerated(manifestPath, manifest)
+	shouldPrepare, err := sourceStaticCatalogShouldBePreparedForPackaging(manifestPath, manifest)
 	if err != nil {
 		return false, err
 	}
-	if !SourceBuildProducesOutput(manifest) || !mayGenerate {
+	if !SourceBuildProducesOutput(manifest) || !shouldPrepare {
 		return false, nil
 	}
 	if err := EnsureSourceBuildOutput(manifestPath, manifest, SourceBuildOptions{}); err != nil {
@@ -102,13 +105,16 @@ func ensureHostBuildForSourceStaticCatalog(manifestPath string, manifest *provid
 	return true, nil
 }
 
-func sourceStaticCatalogMayBeGenerated(manifestPath string, manifest *providermanifestv1.Manifest) (bool, error) {
+func sourceStaticCatalogShouldBePreparedForPackaging(manifestPath string, manifest *providermanifestv1.Manifest) (bool, error) {
 	if manifest == nil || manifest.Kind != providermanifestv1.KindPlugin {
 		return false, nil
 	}
 	entry := EntrypointForKind(manifest, providermanifestv1.KindPlugin)
 	if entry == nil || strings.TrimSpace(entry.ArtifactPath) == "" {
 		return false, nil
+	}
+	if explicitRunStaleCatalog(manifest) {
+		return true, nil
 	}
 	if _, err := os.Stat(StaticCatalogPath(filepath.Dir(manifestPath))); err == nil {
 		return false, nil
@@ -139,11 +145,14 @@ func StagePreparedInstallDir(manifestPath, stagingDir string, opts StagePrepared
 	}
 	manifestPath = absoluteManifestPath
 
-	_, _, err = ReadSourceManifestFile(manifestPath)
+	_, manifest, err := ReadSourceManifestFile(manifestPath)
 	if err != nil {
 		return nil, fmt.Errorf("read %s: %w", manifestPath, err)
 	}
-	_, srcManifest, err := PrepareSourceManifest(manifestPath)
+	if err := ValidateExplicitRunPackaging(filepath.Dir(manifestPath), manifest); err != nil {
+		return nil, err
+	}
+	_, srcManifest, err := prepareSourceManifestForPreparedInstall(manifestPath)
 	if err != nil {
 		return nil, fmt.Errorf("prepare %s: %w", manifestPath, err)
 	}
@@ -263,21 +272,10 @@ func resolvePreparedInstallBuildKind(root string, manifest *providermanifestv1.M
 		return "", nil
 	}
 
-	if preparedInstallRequiresBuild(manifest, kind) {
+	if releaseRequiresBuildForKind(manifest, kind) {
 		return "", missingPreparedInstallBuildTargetError(kind)
 	}
 	return "", nil
-}
-
-func preparedInstallRequiresBuild(manifest *providermanifestv1.Manifest, kind string) bool {
-	switch kind {
-	case providermanifestv1.KindPlugin:
-		return manifest != nil && manifest.Entrypoint == nil && (manifest.Spec == nil || !manifest.Spec.IsManifestBacked())
-	case providermanifestv1.KindAuthentication, providermanifestv1.KindAuthorization, providermanifestv1.KindExternalCredentials, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindAgent, providermanifestv1.KindSecrets, providermanifestv1.KindRuntime:
-		return EntrypointForKind(manifest, kind) == nil
-	default:
-		return false
-	}
 }
 
 func resolvePreparedInstallBuildTarget(root, kind string) (string, error) {

--- a/gestaltd/services/plugins/providerpkg/prepared_stage_test.go
+++ b/gestaltd/services/plugins/providerpkg/prepared_stage_test.go
@@ -26,8 +26,12 @@ SH
 chmod +x .gestalt/build/provider
 `
 	mustWriteFile(t, filepath.Join(root, "build.sh"), []byte(buildScript), 0o755)
-	prefixScriptPath := filepath.Join(root, "prefix.sh")
-	mustWriteFile(t, prefixScriptPath, []byte("#!/bin/sh\nexec \"$@\"\n"), 0o755)
+	mustWriteFile(t, filepath.Join(root, "catalog.sh"), []byte(`#!/bin/sh
+set -eu
+if [ -n "${GESTALT_PLUGIN_WRITE_CATALOG:-}" ]; then
+  printf 'name: provider\noperations:\n  - id: run_catalog\n    method: POST\n' > "$GESTALT_PLUGIN_WRITE_CATALOG"
+fi
+`), 0o755)
 	manifestPath := mustWriteManifestData(t, root, "manifest.yaml", mustManifestYAML(t, &providermanifestv1.Manifest{
 		Kind:        providermanifestv1.KindPlugin,
 		Source:      "github.com/test/plugins/provider",
@@ -38,7 +42,7 @@ chmod +x .gestalt/build/provider
 			Command: []string{"sh", "./build.sh"},
 			Inputs:  []string{"build.sh"},
 		},
-		Run:        &providermanifestv1.SourceRun{CommandPrefix: []string{prefixScriptPath}},
+		Run:        []string{"./catalog.sh"},
 		Entrypoint: &providermanifestv1.Entrypoint{ArtifactPath: artifactPath},
 	}))
 
@@ -77,12 +81,105 @@ chmod +x .gestalt/build/provider
 	if err != nil {
 		t.Fatalf("ReadFile(%s): %v", filepath.Join(stagingDir, StaticCatalogFile), err)
 	}
-	if len(catalogData) == 0 {
-		t.Fatal("staged catalog.yaml is empty")
+	if !strings.Contains(string(catalogData), "echo") || strings.Contains(string(catalogData), "run_catalog") {
+		t.Fatalf("staged catalog should come from packaged entrypoint, got: %s", catalogData)
 	}
 }
 
-func TestSourcePrepareOnlyBuildAndRunPrefix(t *testing.T) {
+func TestStageSourcePreparedInstallDir_ReplacesRunGeneratedCatalog(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	artifactPath := ".gestalt/build/provider"
+	buildScript := `mkdir -p .gestalt/build
+cat > .gestalt/build/provider <<'SH'
+#!/bin/sh
+if [ -n "$GESTALT_PLUGIN_WRITE_CATALOG" ]; then
+  printf 'name: provider\noperations:\n  - id: packaged_catalog\n    method: POST\n' > "$GESTALT_PLUGIN_WRITE_CATALOG"
+fi
+SH
+chmod +x .gestalt/build/provider
+`
+	mustWriteFile(t, filepath.Join(root, "build.sh"), []byte(buildScript), 0o755)
+	mustWriteFile(t, filepath.Join(root, "run.sh"), []byte(`#!/bin/sh
+set -eu
+if [ -n "${GESTALT_PLUGIN_WRITE_CATALOG:-}" ]; then
+  printf 'name: provider\noperations:\n  - id: run_catalog\n    method: POST\n' > "$GESTALT_PLUGIN_WRITE_CATALOG"
+fi
+`), 0o755)
+	manifestPath := mustWriteManifestData(t, root, "manifest.yaml", mustManifestYAML(t, &providermanifestv1.Manifest{
+		Kind:    providermanifestv1.KindPlugin,
+		Source:  "github.com/test/plugins/provider",
+		Version: "0.0.1-alpha.1",
+		Spec:    &providermanifestv1.Spec{},
+		Build: &providermanifestv1.SourceBuild{
+			Command: []string{"sh", "./build.sh"},
+			Inputs:  []string{"build.sh"},
+		},
+		Run:        []string{"./run.sh"},
+		Entrypoint: &providermanifestv1.Entrypoint{ArtifactPath: artifactPath},
+	}))
+
+	if _, _, err := PrepareSourceManifest(manifestPath); err != nil {
+		t.Fatalf("PrepareSourceManifest: %v", err)
+	}
+	sourceCatalog, err := os.ReadFile(filepath.Join(root, StaticCatalogFile))
+	if err != nil {
+		t.Fatalf("ReadFile(source catalog): %v", err)
+	}
+	if !strings.Contains(string(sourceCatalog), "run_catalog") {
+		t.Fatalf("source catalog = %s, want run-generated catalog", sourceCatalog)
+	}
+
+	stagingDir := filepath.Join(t.TempDir(), "prepared")
+	if _, err := StageSourcePreparedInstallDir(manifestPath, stagingDir, StageSourcePreparedInstallOptions{
+		Kind:       providermanifestv1.KindPlugin,
+		PluginName: "prepared-stage-test",
+		GOOS:       runtime.GOOS,
+		GOARCH:     runtime.GOARCH,
+	}); err != nil {
+		t.Fatalf("StageSourcePreparedInstallDir: %v", err)
+	}
+
+	stagedCatalog, err := os.ReadFile(filepath.Join(stagingDir, StaticCatalogFile))
+	if err != nil {
+		t.Fatalf("ReadFile(staged catalog): %v", err)
+	}
+	if !strings.Contains(string(stagedCatalog), "packaged_catalog") || strings.Contains(string(stagedCatalog), "run_catalog") {
+		t.Fatalf("staged catalog should be regenerated from packaged entrypoint, got: %s", stagedCatalog)
+	}
+}
+
+func TestValidateExplicitRunPackaging_AllowsManifestBackedRunOnlyPlugin(t *testing.T) {
+	t.Parallel()
+
+	manifest := &providermanifestv1.Manifest{
+		Kind:    providermanifestv1.KindPlugin,
+		Source:  "github.com/test/plugins/manifest-backed",
+		Version: "0.0.1-alpha.1",
+		Run:     []string{"npm", "run", "dev"},
+		Spec: &providermanifestv1.Spec{
+			Surfaces: &providermanifestv1.ProviderSurfaces{
+				REST: &providermanifestv1.RESTSurface{
+					BaseURL: "https://api.example.com",
+					Operations: []providermanifestv1.ProviderOperation{{
+						Name:   "get_status",
+						Method: "GET",
+						Path:   "/status",
+					}},
+				},
+			},
+		},
+	}
+	if ReleaseRequiresBuild(manifest) {
+		t.Fatal("manifest-backed plugin should not require a release build")
+	}
+	if err := ValidateExplicitRunPackaging(t.TempDir(), manifest); err != nil {
+		t.Fatalf("ValidateExplicitRunPackaging: %v", err)
+	}
+}
+
+func TestSourceRunCommand(t *testing.T) {
 	t.Parallel()
 
 	if runtime.GOOS == windowsOS {
@@ -94,7 +191,7 @@ func TestSourcePrepareOnlyBuildAndRunPrefix(t *testing.T) {
 		run  func(t *testing.T, root, fakeUVPath, logPath string)
 	}{
 		{
-			name: "source execution wraps entrypoint",
+			name: "source execution uses run instead of entrypoint",
 			run: func(t *testing.T, root, fakeUVPath, logPath string) {
 				mustWriteFile(t, filepath.Join(root, "provider.sh"), []byte("#!/bin/sh\nexit 0\n"), 0o755)
 				manifestPath := mustWriteManifestData(t, root, "manifest.yaml", mustManifestYAML(t, &providermanifestv1.Manifest{
@@ -105,7 +202,7 @@ func TestSourcePrepareOnlyBuildAndRunPrefix(t *testing.T) {
 						Command:     []string{fakeUVPath, "sync", "--frozen", "--no-install-project"},
 						PrepareOnly: true,
 					},
-					Run:        &providermanifestv1.SourceRun{CommandPrefix: []string{fakeUVPath, "run", "--frozen"}},
+					Run:        []string{fakeUVPath, "run", "--frozen", "./provider.sh", "--dev"},
 					Entrypoint: &providermanifestv1.Entrypoint{ArtifactPath: "provider.sh", Args: []string{"--serve"}},
 					Spec:       &providermanifestv1.Spec{},
 				}))
@@ -117,7 +214,7 @@ func TestSourcePrepareOnlyBuildAndRunPrefix(t *testing.T) {
 				if execution.Command != fakeUVPath {
 					t.Fatalf("execution.Command = %q, want %q", execution.Command, fakeUVPath)
 				}
-				wantArgs := []string{"run", "--frozen", filepath.Join(root, "provider.sh"), "--serve"}
+				wantArgs := []string{"run", "--frozen", "./provider.sh", "--dev"}
 				if !slices.Equal(execution.Args, wantArgs) {
 					t.Fatalf("execution.Args = %#v, want %#v", execution.Args, wantArgs)
 				}
@@ -144,7 +241,7 @@ fi
 						Command:     []string{fakeUVPath, "sync", "--frozen", "--no-install-project"},
 						PrepareOnly: true,
 					},
-					Run:        &providermanifestv1.SourceRun{CommandPrefix: []string{fakeUVPath, "run", "--frozen"}},
+					Run:        []string{fakeUVPath, "run", "--frozen", "./provider.sh"},
 					Entrypoint: &providermanifestv1.Entrypoint{ArtifactPath: "provider.sh"},
 					Spec:       &providermanifestv1.Spec{},
 				}))
@@ -163,11 +260,94 @@ fi
 
 				logText := readLog(t, logPath)
 				syncLine := root + "|sync --frozen --no-install-project"
-				runLine := root + "|run --frozen " + filepath.Join(root, "provider.sh")
+				runLine := root + "|run --frozen ./provider.sh"
 				syncIdx := strings.Index(logText, syncLine)
 				runIdx := strings.Index(logText, runLine)
 				if syncIdx < 0 || runIdx < 0 || syncIdx > runIdx {
 					t.Fatalf("uv log = %q, want sync before catalog run", logText)
+				}
+			},
+		},
+		{
+			name: "local execution skips output build",
+			run: func(t *testing.T, root, fakeUVPath, logPath string) {
+				mustWriteFile(t, filepath.Join(root, "provider.sh"), []byte("#!/bin/sh\nexit 0\n"), 0o755)
+				mustWriteFile(t, filepath.Join(root, "fail-build.sh"), []byte("#!/bin/sh\nexit 42\n"), 0o755)
+				manifestPath := mustWriteManifestData(t, root, "manifest.yaml", mustManifestYAML(t, &providermanifestv1.Manifest{
+					Kind:    providermanifestv1.KindPlugin,
+					Source:  "github.com/test/plugins/uv-provider",
+					Version: "0.0.1-alpha.1",
+					Build: &providermanifestv1.SourceBuild{
+						Command: []string{"./fail-build.sh"},
+					},
+					Run:        []string{"./provider.sh"},
+					Entrypoint: &providermanifestv1.Entrypoint{ArtifactPath: ".gestalt/build/provider"},
+					Spec:       &providermanifestv1.Spec{},
+				}))
+
+				execution, err := SourceManifestExecution(manifestPath, providermanifestv1.KindPlugin, SourceBuildOptions{})
+				if err != nil {
+					t.Fatalf("SourceManifestExecution: %v", err)
+				}
+				if execution.Command != "./provider.sh" || len(execution.Args) != 0 {
+					t.Fatalf("execution = %#v, want explicit run command", execution)
+				}
+				if _, err := os.Stat(logPath); err == nil {
+					t.Fatalf("unexpected fake uv log; output build or prep command ran")
+				} else if !os.IsNotExist(err) {
+					t.Fatalf("stat fake uv log: %v", err)
+				}
+			},
+		},
+		{
+			name: "run-only plugin does not need SDK metadata",
+			run: func(t *testing.T, root, fakeUVPath, logPath string) {
+				mustWriteFile(t, filepath.Join(root, "provider.sh"), []byte("#!/bin/sh\nexit 0\n"), 0o755)
+				manifestPath := mustWriteManifestData(t, root, "manifest.yaml", mustManifestYAML(t, &providermanifestv1.Manifest{
+					Kind:    providermanifestv1.KindPlugin,
+					Source:  "github.com/test/plugins/run-only",
+					Version: "0.0.1-alpha.1",
+					Run:     []string{"./provider.sh"},
+					Spec:    &providermanifestv1.Spec{},
+				}))
+
+				execution, err := SourceManifestExecution(manifestPath, providermanifestv1.KindPlugin, SourceBuildOptions{})
+				if err != nil {
+					t.Fatalf("SourceManifestExecution: %v", err)
+				}
+				if execution.Command != "./provider.sh" || len(execution.Args) != 0 {
+					t.Fatalf("execution = %#v, want explicit run command", execution)
+				}
+				if _, err := os.Stat(logPath); err == nil {
+					t.Fatalf("unexpected fake uv log; SDK detection should not run commands")
+				} else if !os.IsNotExist(err) {
+					t.Fatalf("stat fake uv log: %v", err)
+				}
+			},
+		},
+		{
+			name: "run-only component provider",
+			run: func(t *testing.T, root, fakeUVPath, logPath string) {
+				mustWriteFile(t, filepath.Join(root, "auth.sh"), []byte("#!/bin/sh\nexit 0\n"), 0o755)
+				manifestPath := mustWriteManifestData(t, root, "manifest.yaml", mustManifestYAML(t, &providermanifestv1.Manifest{
+					Kind:    providermanifestv1.KindAuthentication,
+					Source:  "github.com/test/providers/auth",
+					Version: "0.0.1-alpha.1",
+					Run:     []string{"./auth.sh", "--serve"},
+					Spec:    &providermanifestv1.Spec{},
+				}))
+
+				execution, err := SourceManifestExecution(manifestPath, providermanifestv1.KindAuthentication, SourceBuildOptions{})
+				if err != nil {
+					t.Fatalf("SourceManifestExecution: %v", err)
+				}
+				if execution.Command != "./auth.sh" || !slices.Equal(execution.Args, []string{"--serve"}) {
+					t.Fatalf("execution = %#v, want explicit run command", execution)
+				}
+				if _, err := os.Stat(logPath); err == nil {
+					t.Fatalf("unexpected fake uv log; SDK detection should not run commands")
+				} else if !os.IsNotExist(err) {
+					t.Fatalf("stat fake uv log: %v", err)
 				}
 			},
 		},
@@ -256,6 +436,35 @@ chmod +x .gestalt/build/provider
 	}
 	if !strings.Contains(string(stagedBinary), "target artifact") {
 		t.Fatalf("staged binary did not come from target build: %s", stagedBinary)
+	}
+}
+
+func TestStageSourcePreparedInstallDir_RunOnlyFailsReleasePackaging(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "provider.sh"), []byte(`#!/bin/sh
+set -eu
+if [ -n "${GESTALT_PLUGIN_WRITE_CATALOG:-}" ]; then
+  printf 'name: provider\noperations:\n  - id: local_only\n    method: POST\n' > "$GESTALT_PLUGIN_WRITE_CATALOG"
+fi
+`), 0o755)
+	manifestPath := mustWriteManifestData(t, root, "manifest.yaml", mustManifestYAML(t, &providermanifestv1.Manifest{
+		Kind:    providermanifestv1.KindPlugin,
+		Source:  "github.com/test/plugins/run-only",
+		Version: "0.0.1-alpha.1",
+		Run:     []string{"./provider.sh"},
+		Spec:    &providermanifestv1.Spec{},
+	}))
+
+	_, err := StageSourcePreparedInstallDir(manifestPath, filepath.Join(t.TempDir(), "prepared"), StageSourcePreparedInstallOptions{
+		Kind:       providermanifestv1.KindPlugin,
+		PluginName: "run-only",
+		GOOS:       runtime.GOOS,
+		GOARCH:     runtime.GOARCH,
+	})
+	if err == nil || !strings.Contains(err.Error(), "run is local-only and cannot be packaged") {
+		t.Fatalf("StageSourcePreparedInstallDir error = %v, want local-only run release error", err)
 	}
 }
 

--- a/gestaltd/services/plugins/providerpkg/release_target.go
+++ b/gestaltd/services/plugins/providerpkg/release_target.go
@@ -12,14 +12,43 @@ func ReleaseRequiresBuild(manifest *providermanifestv1.Manifest) bool {
 	if err != nil {
 		return false
 	}
+	return releaseRequiresBuildForKind(manifest, kind)
+}
+
+func releaseRequiresBuildForKind(manifest *providermanifestv1.Manifest, kind string) bool {
 	switch kind {
 	case providermanifestv1.KindPlugin:
-		return manifest.Entrypoint == nil && (manifest.Spec == nil || !manifest.Spec.IsManifestBacked())
+		return manifest != nil && manifest.Entrypoint == nil && (manifest.Spec == nil || !manifest.Spec.IsManifestBacked())
 	case providermanifestv1.KindAuthentication, providermanifestv1.KindAuthorization, providermanifestv1.KindExternalCredentials, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindAgent, providermanifestv1.KindSecrets, providermanifestv1.KindRuntime:
 		return EntrypointForKind(manifest, kind) == nil
 	default:
 		return false
 	}
+}
+
+func HasExplicitSourceRun(manifest *providermanifestv1.Manifest) bool {
+	return manifest != nil && len(manifest.Run) > 0
+}
+
+func ValidateExplicitRunPackaging(root string, manifest *providermanifestv1.Manifest) error {
+	if !HasExplicitSourceRun(manifest) {
+		return nil
+	}
+	kind, err := ManifestKind(manifest)
+	if err != nil {
+		return err
+	}
+	if kind == providermanifestv1.KindUI || !releaseRequiresBuildForKind(manifest, kind) {
+		return nil
+	}
+	hasSource, err := HasSourceReleaseTarget(root, kind)
+	if err != nil {
+		return fmt.Errorf("detect source %s package: %w", kind, err)
+	}
+	if hasSource {
+		return nil
+	}
+	return LocalOnlyRunReleaseError(kind)
 }
 
 func HasSourceReleaseTarget(root, kind string) (bool, error) {
@@ -84,5 +113,16 @@ func MissingSourceReleaseTargetError(kind string) error {
 		return fmt.Errorf("no Go runtime source package found")
 	default:
 		return fmt.Errorf("unsupported release build target kind %q", kind)
+	}
+}
+
+func LocalOnlyRunReleaseError(kind string) error {
+	switch kind {
+	case providermanifestv1.KindPlugin:
+		return fmt.Errorf("run is local-only and cannot be packaged; add SDK-native provider metadata or object-form build.command with entrypoint.artifactPath")
+	case providermanifestv1.KindAuthentication, providermanifestv1.KindAuthorization, providermanifestv1.KindExternalCredentials, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindAgent, providermanifestv1.KindSecrets, providermanifestv1.KindRuntime:
+		return fmt.Errorf("run is local-only and cannot be packaged; add SDK-native %s provider metadata or object-form build.command with entrypoint.artifactPath", kind)
+	default:
+		return fmt.Errorf("run is local-only and cannot be packaged for %q", kind)
 	}
 }

--- a/gestaltd/services/plugins/providerpkg/source_build.go
+++ b/gestaltd/services/plugins/providerpkg/source_build.go
@@ -25,11 +25,24 @@ type SourceBuildOptions struct {
 	LibC   string
 }
 
+type SourceExecutionIntent int
+
+const (
+	SourceExecutionIntentLocalRun SourceExecutionIntent = iota
+	SourceExecutionIntentPackagedEntrypoint
+	SourceExecutionIntentSynthesizedSDK
+)
+
 type SourceExecution struct {
 	Command string
 	Args    []string
 	Workdir string
 	Cleanup func()
+}
+
+type ResolvedSourceExecution struct {
+	SourceExecution
+	Intent SourceExecutionIntent
 }
 
 func EffectiveSourceBuild(manifest *providermanifestv1.Manifest) *ResolvedSourceBuild {
@@ -205,6 +218,14 @@ func EnsureSourceBuildOutput(manifestPath string, manifest *providermanifestv1.M
 	return verifySourceBuildOutput(outputPath, outputRel, outputKind, opts)
 }
 
+func ensurePrepareOnlyBuild(manifestPath string, manifest *providermanifestv1.Manifest, opts SourceBuildOptions) error {
+	build := EffectiveSourceBuild(manifest)
+	if build == nil || !build.PrepareOnly {
+		return nil
+	}
+	return RunSourceBuild(manifestPath, manifest, opts)
+}
+
 func SourceBuildInputs(manifest *providermanifestv1.Manifest) []string {
 	build := EffectiveSourceBuild(manifest)
 	if build == nil {
@@ -223,26 +244,40 @@ func SourceManifestExecution(manifestPath, kind string, opts SourceBuildOptions)
 	if err != nil {
 		return SourceExecution{}, err
 	}
+	if HasExplicitSourceRun(manifest) {
+		if err := ensurePrepareOnlyBuild(manifestPath, manifest, opts); err != nil {
+			return SourceExecution{}, err
+		}
+		return explicitRunExecution(filepath.Dir(manifestPath), manifest).SourceExecution, nil
+	}
 	if err := EnsureSourceBuildOutput(manifestPath, manifest, opts); err != nil {
 		return SourceExecution{}, err
 	}
-	return sourceManifestExecution(manifestPath, manifest, kind, opts)
+	resolved, err := resolveSourceExecution(manifestPath, manifest, kind, opts, true)
+	if err != nil {
+		return SourceExecution{}, err
+	}
+	return resolved.SourceExecution, nil
 }
 
-func sourceManifestExecution(manifestPath string, manifest *providermanifestv1.Manifest, kind string, opts SourceBuildOptions) (SourceExecution, error) {
-	if strings.TrimSpace(kind) == "" {
-		var err error
-		kind, err = ManifestKind(manifest)
-		if err != nil {
-			return SourceExecution{}, err
-		}
-	}
+func resolveSourceExecution(manifestPath string, manifest *providermanifestv1.Manifest, kind string, opts SourceBuildOptions, skipExplicitRun bool) (ResolvedSourceExecution, error) {
 	rootDir := filepath.Dir(manifestPath)
+	if !skipExplicitRun && HasExplicitSourceRun(manifest) {
+		return explicitRunExecution(rootDir, manifest), nil
+	}
+	kind, err := sourceExecutionKind(manifest, kind)
+	if err != nil {
+		return ResolvedSourceExecution{}, err
+	}
 	exec := SourceExecution{Workdir: rootDir}
 	entry := EntrypointForKind(manifest, kind)
 	if entry != nil && strings.TrimSpace(entry.ArtifactPath) != "" {
 		exec.Command = filepath.Join(rootDir, filepath.FromSlash(entry.ArtifactPath))
 		exec.Args = append([]string(nil), entry.Args...)
+		return ResolvedSourceExecution{
+			SourceExecution: exec,
+			Intent:          SourceExecutionIntentPackagedEntrypoint,
+		}, nil
 	} else {
 		goos, goarch := SourceBuildTarget(opts)
 		var err error
@@ -252,22 +287,32 @@ func sourceManifestExecution(manifestPath string, manifest *providermanifestv1.M
 		case providermanifestv1.KindAuthentication, providermanifestv1.KindAuthorization, providermanifestv1.KindExternalCredentials, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindAgent, providermanifestv1.KindSecrets, providermanifestv1.KindRuntime:
 			exec.Command, exec.Args, exec.Cleanup, err = SourceComponentExecutionCommand(rootDir, kind, goos, goarch)
 		default:
-			return SourceExecution{}, fmt.Errorf("manifest does not define a %s entrypoint", kind)
+			return ResolvedSourceExecution{}, fmt.Errorf("manifest does not define a %s entrypoint", kind)
 		}
 		if err != nil {
-			return SourceExecution{}, err
+			return ResolvedSourceExecution{}, err
 		}
 	}
-	return applySourceRunCommandPrefix(exec, manifest), nil
+	return ResolvedSourceExecution{
+		SourceExecution: exec,
+		Intent:          SourceExecutionIntentSynthesizedSDK,
+	}, nil
 }
 
-func applySourceRunCommandPrefix(exec SourceExecution, manifest *providermanifestv1.Manifest) SourceExecution {
-	if manifest == nil || manifest.Run == nil || len(manifest.Run.CommandPrefix) == 0 || exec.Command == "" {
-		return exec
+func explicitRunExecution(rootDir string, manifest *providermanifestv1.Manifest) ResolvedSourceExecution {
+	return ResolvedSourceExecution{
+		SourceExecution: SourceExecution{
+			Command: manifest.Run[0],
+			Args:    append([]string(nil), manifest.Run[1:]...),
+			Workdir: rootDir,
+		},
+		Intent: SourceExecutionIntentLocalRun,
 	}
-	prefix := append([]string(nil), manifest.Run.CommandPrefix...)
-	original := append([]string{exec.Command}, exec.Args...)
-	exec.Command = prefix[0]
-	exec.Args = append(append([]string(nil), prefix[1:]...), original...)
-	return exec
+}
+
+func sourceExecutionKind(manifest *providermanifestv1.Manifest, kind string) (string, error) {
+	if strings.TrimSpace(kind) != "" {
+		return kind, nil
+	}
+	return ManifestKind(manifest)
 }

--- a/gestaltd/services/plugins/providerpkg/source_prepare.go
+++ b/gestaltd/services/plugins/providerpkg/source_prepare.go
@@ -14,7 +14,26 @@ import (
 
 const envWriteCatalog = "GESTALT_PLUGIN_WRITE_CATALOG"
 
+type sourceCatalogOptions struct {
+	SkipExplicitRun bool
+	RefreshExisting bool
+}
+
 func PrepareSourceManifest(manifestPath string) ([]byte, *providermanifestv1.Manifest, error) {
+	return prepareSourceManifest(manifestPath, false)
+}
+
+func prepareSourceManifestForPreparedInstall(manifestPath string) ([]byte, *providermanifestv1.Manifest, error) {
+	return prepareSourceManifest(manifestPath, true)
+}
+
+// Local prepare may create catalog.yaml from run; packaging must regenerate it
+// from the packaged entrypoint instead.
+func explicitRunStaleCatalog(manifest *providermanifestv1.Manifest) bool {
+	return HasExplicitSourceRun(manifest)
+}
+
+func prepareSourceManifest(manifestPath string, packaging bool) ([]byte, *providermanifestv1.Manifest, error) {
 	absoluteManifestPath, err := filepath.Abs(manifestPath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("resolve manifest path: %w", err)
@@ -34,12 +53,14 @@ func PrepareSourceManifest(manifestPath string) ([]byte, *providermanifestv1.Man
 	if err != nil {
 		return nil, nil, err
 	}
-	if build := EffectiveSourceBuild(manifest); build != nil && build.PrepareOnly {
-		if err := RunSourceBuild(manifestPath, manifest, SourceBuildOptions{}); err != nil {
-			return nil, nil, err
-		}
+	if err := ensurePrepareOnlyBuild(manifestPath, manifest, SourceBuildOptions{}); err != nil {
+		return nil, nil, err
 	}
-	if err := EnsureSourceStaticCatalog(manifestPath, manifest); err != nil {
+	catalogOptions := sourceCatalogOptions{SkipExplicitRun: packaging}
+	if packaging {
+		catalogOptions.RefreshExisting = explicitRunStaleCatalog(manifest)
+	}
+	if err := ensureSourceStaticCatalog(manifestPath, manifest, catalogOptions); err != nil {
 		return nil, nil, err
 	}
 	updatedEncoded, err := EncodeSourceManifestFormat(manifest, format)
@@ -53,6 +74,10 @@ func PrepareSourceManifest(manifestPath string) ([]byte, *providermanifestv1.Man
 }
 
 func EnsureSourceStaticCatalog(manifestPath string, manifest *providermanifestv1.Manifest) error {
+	return ensureSourceStaticCatalog(manifestPath, manifest, sourceCatalogOptions{})
+}
+
+func ensureSourceStaticCatalog(manifestPath string, manifest *providermanifestv1.Manifest, opts sourceCatalogOptions) error {
 	if manifest == nil || manifest.Kind != providermanifestv1.KindPlugin {
 		return nil
 	}
@@ -62,12 +87,17 @@ func EnsureSourceStaticCatalog(manifestPath string, manifest *providermanifestv1
 	if err != nil {
 		return fmt.Errorf("resolve static catalog path %q: %w", catalogPath, err)
 	}
-	if _, err := os.Stat(absoluteCatalogPath); err == nil {
+	if _, err := os.Stat(absoluteCatalogPath); err == nil && !opts.RefreshExisting {
 		return nil
 	} else if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("stat static catalog %q: %w", StaticCatalogFile, err)
 	}
-	if err := generateSourceStaticCatalog(manifestPath, rootDir, manifest, absoluteCatalogPath); err != nil {
+	if opts.RefreshExisting {
+		if err := os.Remove(absoluteCatalogPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove static catalog %q: %w", StaticCatalogFile, err)
+		}
+	}
+	if err := generateSourceStaticCatalog(manifestPath, rootDir, manifest, absoluteCatalogPath, opts); err != nil {
 		return err
 	}
 	if _, err := os.Stat(absoluteCatalogPath); err != nil {
@@ -79,21 +109,22 @@ func EnsureSourceStaticCatalog(manifestPath string, manifest *providermanifestv1
 	return nil
 }
 
-func generateSourceStaticCatalog(manifestPath, rootDir string, manifest *providermanifestv1.Manifest, catalogPath string) error {
+func generateSourceStaticCatalog(manifestPath, rootDir string, manifest *providermanifestv1.Manifest, catalogPath string, opts sourceCatalogOptions) error {
 	var execEnv map[string]string
-	execution, err := sourceManifestExecution(manifestPath, manifest, providermanifestv1.KindPlugin, SourceBuildOptions{})
+	resolved, err := resolveSourceExecution(manifestPath, manifest, providermanifestv1.KindPlugin, SourceBuildOptions{}, opts.SkipExplicitRun)
 	if err != nil {
 		if errors.Is(err, ErrNoSourceProviderPackage) {
 			return nil
 		}
 		return fmt.Errorf("prepare synthesized source provider for static catalog: %w", err)
 	}
-	if EntrypointForKind(manifest, providermanifestv1.KindPlugin) == nil {
+	if resolved.Intent == SourceExecutionIntentSynthesizedSDK {
 		execEnv, err = SourceProviderExecutionEnv(rootDir, runtime.GOOS, runtime.GOARCH)
 		if err != nil {
 			return fmt.Errorf("prepare synthesized source provider environment for static catalog: %w", err)
 		}
 	}
+	execution := resolved.SourceExecution
 	if execution.Cleanup != nil {
 		defer execution.Cleanup()
 	}


### PR DESCRIPTION
## Problem Statement

Source manifests currently model local provider startup as `run.commandPrefix`, which forces authors to understand and wrap Gestalt's internally resolved provider command. That is harder to explain than the build/run conventions used by common OSS tooling.

## Proposed Solution

Source manifests now use `run` as the complete local execution command. Old source-local startup wrapped a resolved provider command with `run.commandPrefix`:

```yaml
build: [uv, sync, --frozen, --no-install-project]
run:
  commandPrefix: [uv, run, --frozen]
entrypoint:
  artifactPath: provider.py
  args: [--serve]
```

New source-local startup declares the complete argv directly:

```yaml
build: [uv, sync, --frozen, --no-install-project]
run: [uv, run, --frozen, ./provider.py, --serve]
```

Compiled or released packages continue to use the existing package contract:

```yaml
artifacts:
  - os: linux
    arch: amd64
    path: artifacts/linux/amd64/provider
    sha256: ...
entrypoint:
  artifactPath: artifacts/linux/amd64/provider
```

## Implementation Detail

- Change provider manifest `run` from an object with `commandPrefix` to a non-empty string array.
- Resolve explicit `run` before `entrypoint` or SDK-native detection for local source execution.
- Keep prepare-only builds before local `run`; skip output-producing builds for local startup.
- Keep release/staging on SDK-native release targets or object-form `build.command` plus `entrypoint.artifactPath`.
- Add clear errors for run-only manifests that cannot be packaged.
- Update provider docs and examples to show `build`, `run`, and released `entrypoint`/`artifacts` as separate contracts.

## Test plan

- [x] `go test ./services/plugins/providerpkg`
- [x] `go test ./sdk/providermanifest/v1 ./services/plugins/packageio`
- [x] `go test ./services/providerdrivers/componentprovider`
- [x] `go test ./internal/operator`
- [x] `go test ./internal/daemon`
- [x] `go test ./internal/bootstrap -run '^$'`
- [x] `npm run typecheck`
- [x] `NODE_OPTIONS=--max-old-space-size=8192 npm run build:single`
