### PR TITLE
Remove duplicated transport, bootstrap, and proto conversion layers

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1649,15 +1649,7 @@ func buildExternalCredentialsHostServices(name string, deps Deps) ([]runtimehost
 }
 
 func externalCredentialsIndexedDBHostService(envVar, providerName string, ds indexeddb.IndexedDB) runtimehost.HostService {
-	return runtimehost.HostService{
-		Name:   "indexeddb",
-		EnvVar: envVar,
-		Register: func(srv *grpc.Server) {
-			proto.RegisterIndexedDBServer(srv, indexeddbservice.NewServer(ds, providerName, indexeddbservice.ServerOptions{
-				AllowedStores: []string{"external_credentials"},
-			}))
-		},
-	}
+	return newIndexedDBHostService(envVar, providerName, ds, []string{"external_credentials"})
 }
 
 func closeAuth(provider core.AuthenticationProvider) error {
@@ -1835,13 +1827,7 @@ func buildHostIndexedDBHostServices(selectedName string, indexeddbs map[string]i
 }
 
 func indexedDBHostService(envVar, name string, ds indexeddb.IndexedDB) runtimehost.HostService {
-	return runtimehost.HostService{
-		Name:   "indexeddb",
-		EnvVar: envVar,
-		Register: func(srv *grpc.Server) {
-			proto.RegisterIndexedDBServer(srv, indexeddbservice.NewServer(ds, name, indexeddbservice.ServerOptions{}))
-		},
-	}
+	return newIndexedDBHostService(envVar, name, ds, nil)
 }
 
 func buildCache(entry *config.ProviderEntry, factories *FactoryRegistry) (corecache.Cache, error) {
@@ -1918,7 +1904,7 @@ func buildWorkflow(ctx context.Context, name string, entry *config.ProviderEntry
 		return nil, fmt.Errorf("workflow provider: %w", err)
 	}
 	if effectiveIndexedDB.Enabled {
-		indexedDBHostServices, indexedDBCleanup, err := buildWorkflowIndexedDBHostServices(name, effectiveIndexedDB, deps)
+		indexedDBHostServices, indexedDBCleanup, err := buildIndexedDBHostServices(name, name, effectiveIndexedDB, deps)
 		if err != nil {
 			return nil, fmt.Errorf("workflow provider: %w", err)
 		}
@@ -1995,7 +1981,7 @@ func buildAgent(ctx context.Context, name string, entry *config.ProviderEntry, f
 		return nil, fmt.Errorf("agent provider: %w", err)
 	}
 	if effectiveIndexedDB.Enabled {
-		indexedDBHostServices, indexedDBCleanup, err := buildAgentIndexedDBHostServices(name, effectiveIndexedDB, deps)
+		indexedDBHostServices, indexedDBCleanup, err := buildIndexedDBHostServices(name, name, effectiveIndexedDB, deps)
 		if err != nil {
 			return nil, fmt.Errorf("agent provider: %w", err)
 		}

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -1715,7 +1715,7 @@ func buildPluginRuntimeHostServices(name string, entry *config.ProviderEntry, de
 		return fail(err)
 	}
 	if effectiveIndexedDB.Enabled {
-		services, indexedDBCleanup, err := buildPluginIndexedDBHostServices(name, effectiveIndexedDB, deps)
+		services, indexedDBCleanup, err := buildIndexedDBHostServices(name, effectiveIndexedDB.ProviderName, effectiveIndexedDB, deps)
 		if err != nil {
 			return fail(err)
 		}
@@ -2179,28 +2179,34 @@ func isLoopbackAllowedHost(host string) bool {
 	return ip != nil && ip.IsLoopback()
 }
 
-func buildPluginIndexedDBHostServices(pluginName string, effective config.EffectiveHostIndexedDBBinding, deps Deps) ([]runtimehost.HostService, func(), error) {
+func buildIndexedDBHostServices(serverLabel, metricsName string, effective config.EffectiveHostIndexedDBBinding, deps Deps) ([]runtimehost.HostService, func(), error) {
 	if deps.IndexedDBFactory == nil || len(deps.IndexedDBDefs) == 0 {
 		return nil, nil, fmt.Errorf("indexeddb host services are not available")
 	}
 
-	ds, err := buildPluginScopedIndexedDB(pluginName, effective, deps)
+	ds, err := buildHostScopedIndexedDB(metricsName, effective, deps)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	hostServices := []runtimehost.HostService{{
-		Name:   "indexeddb",
-		EnvVar: indexeddbservice.DefaultSocketEnv,
-		Register: func(srv *grpc.Server) {
-			proto.RegisterIndexedDBServer(srv, indexeddbservice.NewServer(ds, pluginName, indexeddbservice.ServerOptions{
-				AllowedStores: effective.ObjectStores,
-			}))
-		},
-	}}
+	hostServices := []runtimehost.HostService{
+		newIndexedDBHostService(indexeddbservice.DefaultSocketEnv, serverLabel, ds, effective.ObjectStores),
+	}
 	return hostServices, func() {
 		_ = closeIndexedDBs(ds)
 	}, nil
+}
+
+func newIndexedDBHostService(envVar, serverLabel string, ds indexeddb.IndexedDB, allowedStores []string) runtimehost.HostService {
+	return runtimehost.HostService{
+		Name:   "indexeddb",
+		EnvVar: envVar,
+		Register: func(srv *grpc.Server) {
+			proto.RegisterIndexedDBServer(srv, indexeddbservice.NewServer(ds, serverLabel, indexeddbservice.ServerOptions{
+				AllowedStores: allowedStores,
+			}))
+		},
+	}
 }
 
 func buildPluginCacheHostServices(pluginName string, entry *config.ProviderEntry, deps Deps) ([]runtimehost.HostService, func(), error) {
@@ -2297,54 +2303,6 @@ func buildPluginS3HostServices(pluginName string, entry *config.ProviderEntry, d
 		})
 	}
 	return hostServices, nil
-}
-
-func buildWorkflowIndexedDBHostServices(name string, effective config.EffectiveHostIndexedDBBinding, deps Deps) ([]runtimehost.HostService, func(), error) {
-	if deps.IndexedDBFactory == nil || len(deps.IndexedDBDefs) == 0 {
-		return nil, nil, fmt.Errorf("indexeddb host services are not available")
-	}
-
-	ds, err := buildWorkflowScopedIndexedDB(name, effective, deps)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	hostServices := []runtimehost.HostService{{
-		Name:   "indexeddb",
-		EnvVar: indexeddbservice.DefaultSocketEnv,
-		Register: func(srv *grpc.Server) {
-			proto.RegisterIndexedDBServer(srv, indexeddbservice.NewServer(ds, name, indexeddbservice.ServerOptions{
-				AllowedStores: effective.ObjectStores,
-			}))
-		},
-	}}
-	return hostServices, func() {
-		_ = closeIndexedDBs(ds)
-	}, nil
-}
-
-func buildAgentIndexedDBHostServices(name string, effective config.EffectiveHostIndexedDBBinding, deps Deps) ([]runtimehost.HostService, func(), error) {
-	if deps.IndexedDBFactory == nil || len(deps.IndexedDBDefs) == 0 {
-		return nil, nil, fmt.Errorf("indexeddb host services are not available")
-	}
-
-	ds, err := buildAgentScopedIndexedDB(name, effective, deps)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	hostServices := []runtimehost.HostService{{
-		Name:   "indexeddb",
-		EnvVar: indexeddbservice.DefaultSocketEnv,
-		Register: func(srv *grpc.Server) {
-			proto.RegisterIndexedDBServer(srv, indexeddbservice.NewServer(ds, name, indexeddbservice.ServerOptions{
-				AllowedStores: effective.ObjectStores,
-			}))
-		},
-	}}
-	return hostServices, func() {
-		_ = closeIndexedDBs(ds)
-	}, nil
 }
 
 func buildPluginWorkflowProviderHostService(pluginName string, deps Deps, tokens *plugininvokerservice.InvocationTokenManager) runtimehost.HostService {
@@ -2578,27 +2536,9 @@ func (unavailableAgentManager) ResolveInteraction(context.Context, *principal.Pr
 	return nil, fmt.Errorf("agent manager is not available")
 }
 
-func buildPluginScopedIndexedDB(_ string, effective config.EffectiveHostIndexedDBBinding, deps Deps) (indexeddb.IndexedDB, error) {
+func buildHostScopedIndexedDB(metricsName string, effective config.EffectiveHostIndexedDBBinding, deps Deps) (indexeddb.IndexedDB, error) {
 	return buildScopedIndexedDB(scopedIndexedDBBuildOptions{
-		MetricsName:   effective.ProviderName,
-		ProviderName:  effective.ProviderName,
-		DB:            effective.DB,
-		AllowedStores: effective.ObjectStores,
-	}, deps)
-}
-
-func buildWorkflowScopedIndexedDB(name string, effective config.EffectiveHostIndexedDBBinding, deps Deps) (indexeddb.IndexedDB, error) {
-	return buildScopedIndexedDB(scopedIndexedDBBuildOptions{
-		MetricsName:   name,
-		ProviderName:  effective.ProviderName,
-		DB:            effective.DB,
-		AllowedStores: effective.ObjectStores,
-	}, deps)
-}
-
-func buildAgentScopedIndexedDB(name string, effective config.EffectiveHostIndexedDBBinding, deps Deps) (indexeddb.IndexedDB, error) {
-	return buildScopedIndexedDB(scopedIndexedDBBuildOptions{
-		MetricsName:   name,
+		MetricsName:   metricsName,
 		ProviderName:  effective.ProviderName,
 		DB:            effective.DB,
 		AllowedStores: effective.ObjectStores,

--- a/gestaltd/services/plugins/convert.go
+++ b/gestaltd/services/plugins/convert.go
@@ -2,33 +2,13 @@ package plugins
 
 import (
 	"encoding/json"
-	"fmt"
-	"reflect"
-	"time"
 
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	proto "github.com/valon-technologies/gestalt/server/internal/gen/v1"
+	"github.com/valon-technologies/gestalt/server/services/internal/protoutil"
 
 	"google.golang.org/protobuf/types/known/structpb"
 )
-
-func structFromMap(values map[string]any) (*structpb.Struct, error) {
-	if len(values) == 0 {
-		return nil, nil
-	}
-	normalized, err := normalizeStructMap(values)
-	if err != nil {
-		return nil, err
-	}
-	return structpb.NewStruct(normalized)
-}
-
-func mapFromStruct(s *structpb.Struct) map[string]any {
-	if s == nil {
-		return nil
-	}
-	return s.AsMap()
-}
 
 func catalogFromProto(src *proto.Catalog) (*catalog.Catalog, error) {
 	if src == nil {
@@ -70,7 +50,7 @@ func catalogFromProto(src *proto.Catalog) (*catalog.Catalog, error) {
 				Type:        p.GetType(),
 				Description: p.GetDescription(),
 				Required:    p.GetRequired(),
-				Default:     protoValueToAny(p.GetDefault()),
+				Default:     protoutil.ValueToAny(p.GetDefault()),
 			})
 		}
 		cat.Operations = append(cat.Operations, catOp)
@@ -141,79 +121,4 @@ func jsonRawFromString(s string) json.RawMessage {
 		return nil
 	}
 	return json.RawMessage(s)
-}
-
-func protoValueToAny(v *structpb.Value) any {
-	if v == nil {
-		return nil
-	}
-	return v.AsInterface()
-}
-
-func normalizeStructMap(values map[string]any) (map[string]any, error) {
-	normalized := make(map[string]any, len(values))
-	for key, value := range values {
-		out, err := normalizeStructValue(value)
-		if err != nil {
-			return nil, fmt.Errorf("%s: %w", key, err)
-		}
-		normalized[key] = out
-	}
-	return normalized, nil
-}
-
-func normalizeStructValue(value any) (any, error) {
-	switch v := value.(type) {
-	case nil:
-		return nil, nil
-	case time.Time:
-		return v.UTC().Format(time.RFC3339Nano), nil
-	case *time.Time:
-		if v == nil {
-			return nil, nil
-		}
-		return v.UTC().Format(time.RFC3339Nano), nil
-	case map[string]any:
-		return normalizeStructMap(v)
-	}
-
-	rv := reflect.ValueOf(value)
-	if !rv.IsValid() {
-		return nil, nil
-	}
-
-	switch rv.Kind() {
-	case reflect.Map:
-		if rv.IsNil() {
-			return nil, nil
-		}
-		if rv.Type().Key().Kind() != reflect.String {
-			return value, nil
-		}
-		normalized := make(map[string]any, rv.Len())
-		iter := rv.MapRange()
-		for iter.Next() {
-			out, err := normalizeStructValue(iter.Value().Interface())
-			if err != nil {
-				return nil, fmt.Errorf("%s: %w", iter.Key().String(), err)
-			}
-			normalized[iter.Key().String()] = out
-		}
-		return normalized, nil
-	case reflect.Slice, reflect.Array:
-		if rv.Kind() == reflect.Slice && rv.IsNil() {
-			return nil, nil
-		}
-		normalized := make([]any, rv.Len())
-		for i := 0; i < rv.Len(); i++ {
-			out, err := normalizeStructValue(rv.Index(i).Interface())
-			if err != nil {
-				return nil, fmt.Errorf("[%d]: %w", i, err)
-			}
-			normalized[i] = out
-		}
-		return normalized, nil
-	default:
-		return value, nil
-	}
 }

--- a/gestaltd/services/plugins/http_subject_client.go
+++ b/gestaltd/services/plugins/http_subject_client.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	proto "github.com/valon-technologies/gestalt/server/internal/gen/v1"
+	"github.com/valon-technologies/gestalt/server/services/internal/protoutil"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -61,7 +62,7 @@ func httpSubjectRequestProto(req *core.HTTPSubjectResolveRequest) (*proto.HTTPSu
 		return nil, nil
 	}
 
-	params, err := structFromMap(req.Params)
+	params, err := protoutil.StructFromMap(req.Params)
 	if err != nil {
 		return nil, err
 	}

--- a/gestaltd/services/plugins/provider_client.go
+++ b/gestaltd/services/plugins/provider_client.go
@@ -13,6 +13,7 @@ import (
 	proto "github.com/valon-technologies/gestalt/server/internal/gen/v1"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/internal/agentwire"
+	"github.com/valon-technologies/gestalt/server/services/internal/protoutil"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	plugininvokerservice "github.com/valon-technologies/gestalt/server/services/plugininvoker"
 	"github.com/valon-technologies/gestalt/server/services/workflows/workflowgrants"
@@ -177,7 +178,7 @@ func (p *remoteProviderBase) ConnectionMode() core.ConnectionMode {
 }
 
 func (p *remoteProviderBase) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {
-	msg, err := structFromMap(params)
+	msg, err := protoutil.StructFromMap(params)
 	if err != nil {
 		return nil, err
 	}
@@ -323,7 +324,7 @@ func (p *remoteProviderBase) decorateCatalog(cat *catalog.Catalog) *catalog.Cata
 }
 
 func callStartProvider(ctx context.Context, client proto.IntegrationProviderClient, name string, config map[string]any) error {
-	cfgStruct, err := structFromMap(config)
+	cfgStruct, err := protoutil.StructFromMap(config)
 	if err != nil {
 		return fmt.Errorf("encode provider config: %w", err)
 	}
@@ -389,7 +390,7 @@ func requestContextProto(ctx context.Context, publicBaseURL string) (*proto.Requ
 		}
 	}
 	if workflow := invocation.WorkflowContextFromContext(ctx); workflow != nil {
-		value, err := structFromMap(workflow)
+		value, err := protoutil.StructFromMap(workflow)
 		if err != nil {
 			return nil, fmt.Errorf("workflow request context: %w", err)
 		}

--- a/gestaltd/services/plugins/provider_server.go
+++ b/gestaltd/services/plugins/provider_server.go
@@ -10,6 +10,7 @@ import (
 	proto "github.com/valon-technologies/gestalt/server/internal/gen/v1"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/internal/agentwire"
+	"github.com/valon-technologies/gestalt/server/services/internal/protoutil"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	plugininvokerservice "github.com/valon-technologies/gestalt/server/services/plugininvoker"
 	"google.golang.org/grpc/codes"
@@ -47,7 +48,7 @@ func (s *ProviderServer) Execute(ctx context.Context, req *proto.ExecuteRequest)
 	if len(req.GetConnectionParams()) > 0 {
 		ctx = core.WithConnectionParams(ctx, req.GetConnectionParams())
 	}
-	result, err := s.provider.Execute(ctx, req.GetOperation(), mapFromStruct(req.GetParams()), req.GetToken())
+	result, err := s.provider.Execute(ctx, req.GetOperation(), protoutil.MapFromStruct(req.GetParams()), req.GetToken())
 	if err != nil {
 		return nil, status.Errorf(codes.Unknown, "execute: %v", err)
 	}
@@ -126,7 +127,7 @@ func httpSubjectRequestFromProto(req *proto.HTTPSubjectRequest) *core.HTTPSubjec
 		ContentType:     req.GetContentType(),
 		Headers:         mapStringLists(req.GetHeaders()),
 		Query:           mapStringLists(req.GetQuery()),
-		Params:          mapFromStruct(req.GetParams()),
+		Params:          protoutil.MapFromStruct(req.GetParams()),
 		RawBody:         append([]byte(nil), req.GetRawBody()...),
 		SecurityScheme:  req.GetSecurityScheme(),
 		VerifiedSubject: req.GetVerifiedSubject(),

--- a/sdk/go/authorization_client.go
+++ b/sdk/go/authorization_client.go
@@ -3,18 +3,12 @@ package gestalt
 import (
 	"context"
 	"fmt"
-	"net"
-	"net/url"
 	"os"
-	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/internal/gen/v1"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -68,50 +62,7 @@ func sharedAuthorizationClient(ctx context.Context, target, token string) (proto
 	}
 	sharedAuthorizationTransport.mu.Unlock()
 
-	network, address, err := parseAuthorizationTarget(target)
-	if err != nil {
-		return nil, err
-	}
-	opts := authorizationDialOptions(token)
-	var conn *grpc.ClientConn
-	switch network {
-	case "unix":
-		conn, err = grpc.DialContext(ctx, "passthrough:///localhost",
-			append(internalHostServiceBaseDialOptions(
-				grpc.WithTransportCredentials(insecure.NewCredentials()),
-				grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
-					var d net.Dialer
-					return d.DialContext(ctx, "unix", address)
-				}),
-				grpc.WithAuthority("localhost"),
-				grpc.WithBlock(),
-			), opts...)...,
-		)
-	case "tcp":
-		conn, err = grpc.DialContext(ctx, address,
-			append(internalHostServiceBaseDialOptions(
-				grpc.WithTransportCredentials(insecure.NewCredentials()),
-				grpc.WithBlock(),
-			), opts...)...,
-		)
-	case "tls":
-		host, _, splitErr := net.SplitHostPort(address)
-		if splitErr != nil {
-			return nil, fmt.Errorf("authorization: parse tls target %q: %w", address, splitErr)
-		}
-		tlsConfig, tlsErr := hostServiceTLSConfig("authorization", host)
-		if tlsErr != nil {
-			return nil, tlsErr
-		}
-		conn, err = grpc.DialContext(ctx, address,
-			append(internalHostServiceBaseDialOptions(
-				grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
-				grpc.WithBlock(),
-			), opts...)...,
-		)
-	default:
-		return nil, fmt.Errorf("authorization: unsupported transport network %q", network)
-	}
+	conn, err := dialHostServiceRelay(ctx, "authorization", target, token)
 	if err != nil {
 		return nil, fmt.Errorf("authorization: connect to host: %w", err)
 	}
@@ -134,61 +85,6 @@ func sharedAuthorizationClient(ctx context.Context, target, token string) (proto
 	sharedAuthorizationTransport.conn = conn
 	sharedAuthorizationTransport.client = client
 	return client, nil
-}
-
-func authorizationDialOptions(token string) []grpc.DialOption {
-	token = strings.TrimSpace(token)
-	if token == "" {
-		return nil
-	}
-	return []grpc.DialOption{grpc.WithPerRPCCredentials(authorizationRelayPerRPCCredentials{token: token})}
-}
-
-type authorizationRelayPerRPCCredentials struct {
-	token string
-}
-
-func (c authorizationRelayPerRPCCredentials) GetRequestMetadata(context.Context, ...string) (map[string]string, error) {
-	return map[string]string{
-		"x-gestalt-host-service-relay-token": c.token,
-	}, nil
-}
-
-func (authorizationRelayPerRPCCredentials) RequireTransportSecurity() bool { return false }
-
-func parseAuthorizationTarget(raw string) (network string, address string, err error) {
-	target := strings.TrimSpace(raw)
-	if target == "" {
-		return "", "", fmt.Errorf("authorization: transport target is required")
-	}
-	switch {
-	case strings.HasPrefix(target, "tcp://"):
-		address = strings.TrimSpace(strings.TrimPrefix(target, "tcp://"))
-		if address == "" {
-			return "", "", fmt.Errorf("authorization: tcp target %q is missing host:port", raw)
-		}
-		return "tcp", address, nil
-	case strings.HasPrefix(target, "tls://"):
-		address = strings.TrimSpace(strings.TrimPrefix(target, "tls://"))
-		if address == "" {
-			return "", "", fmt.Errorf("authorization: tls target %q is missing host:port", raw)
-		}
-		return "tls", address, nil
-	case strings.HasPrefix(target, "unix://"):
-		address = strings.TrimSpace(strings.TrimPrefix(target, "unix://"))
-		if address == "" {
-			return "", "", fmt.Errorf("authorization: unix target %q is missing a socket path", raw)
-		}
-		return "unix", address, nil
-	case strings.Contains(target, "://"):
-		parsed, parseErr := url.Parse(target)
-		if parseErr != nil {
-			return "", "", fmt.Errorf("authorization: parse target %q: %w", raw, parseErr)
-		}
-		return "", "", fmt.Errorf("authorization: unsupported target scheme %q", parsed.Scheme)
-	default:
-		return "unix", filepath.Clean(target), nil
-	}
 }
 
 // Close is a no-op compatibility method because this client uses shared transport.

--- a/sdk/go/cache.go
+++ b/sdk/go/cache.go
@@ -3,17 +3,12 @@ package gestalt
 import (
 	"context"
 	"fmt"
-	"net"
-	"net/url"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/internal/gen/v1"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
@@ -80,53 +75,10 @@ func Cache(name ...string) (*CacheClient, error) {
 	if target == "" {
 		return nil, fmt.Errorf("cache: %s is not set", envName)
 	}
-	network, address, err := parseCacheTarget(target)
-	if err != nil {
-		return nil, err
-	}
 	token := os.Getenv(CacheSocketTokenEnv(firstCacheName(name)))
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	var conn *grpc.ClientConn
-	opts := cacheDialOptions(token)
-	switch network {
-	case "unix":
-		conn, err = grpc.DialContext(ctx, "passthrough:///localhost",
-			append(internalHostServiceBaseDialOptions(
-				grpc.WithTransportCredentials(insecure.NewCredentials()),
-				grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
-					var d net.Dialer
-					return d.DialContext(ctx, "unix", address)
-				}),
-				grpc.WithAuthority("localhost"),
-				grpc.WithBlock(),
-			), opts...)...,
-		)
-	case "tcp":
-		conn, err = grpc.DialContext(ctx, address,
-			append(internalHostServiceBaseDialOptions(
-				grpc.WithTransportCredentials(insecure.NewCredentials()),
-				grpc.WithBlock(),
-			), opts...)...,
-		)
-	case "tls":
-		host, _, splitErr := net.SplitHostPort(address)
-		if splitErr != nil {
-			return nil, fmt.Errorf("cache: parse tls target %q: %w", address, splitErr)
-		}
-		tlsConfig, tlsErr := hostServiceTLSConfig("cache", host)
-		if tlsErr != nil {
-			return nil, tlsErr
-		}
-		conn, err = grpc.DialContext(ctx, address,
-			append(internalHostServiceBaseDialOptions(
-				grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
-				grpc.WithBlock(),
-			), opts...)...,
-		)
-	default:
-		return nil, fmt.Errorf("cache: unsupported transport network %q", network)
-	}
+	conn, err := dialHostServiceRelay(ctx, "cache", target, token)
 	if err != nil {
 		return nil, fmt.Errorf("cache: connect to host: %w", err)
 	}
@@ -232,64 +184,9 @@ func cacheTTLToProto(ttl time.Duration) *durationpb.Duration {
 	return durationpb.New(ttl)
 }
 
-func cacheDialOptions(token string) []grpc.DialOption {
-	token = strings.TrimSpace(token)
-	if token == "" {
-		return nil
-	}
-	return []grpc.DialOption{grpc.WithPerRPCCredentials(cacheRelayPerRPCCredentials{token: token})}
-}
-
 func firstCacheName(name []string) string {
 	if len(name) == 0 {
 		return ""
 	}
 	return name[0]
-}
-
-type cacheRelayPerRPCCredentials struct {
-	token string
-}
-
-func (c cacheRelayPerRPCCredentials) GetRequestMetadata(context.Context, ...string) (map[string]string, error) {
-	return map[string]string{
-		"x-gestalt-host-service-relay-token": c.token,
-	}, nil
-}
-
-func (cacheRelayPerRPCCredentials) RequireTransportSecurity() bool { return false }
-
-func parseCacheTarget(raw string) (network string, address string, err error) {
-	target := strings.TrimSpace(raw)
-	if target == "" {
-		return "", "", fmt.Errorf("cache: transport target is required")
-	}
-	switch {
-	case strings.HasPrefix(target, "tcp://"):
-		address = strings.TrimSpace(strings.TrimPrefix(target, "tcp://"))
-		if address == "" {
-			return "", "", fmt.Errorf("cache: tcp target %q is missing host:port", raw)
-		}
-		return "tcp", address, nil
-	case strings.HasPrefix(target, "tls://"):
-		address = strings.TrimSpace(strings.TrimPrefix(target, "tls://"))
-		if address == "" {
-			return "", "", fmt.Errorf("cache: tls target %q is missing host:port", raw)
-		}
-		return "tls", address, nil
-	case strings.HasPrefix(target, "unix://"):
-		address = strings.TrimSpace(strings.TrimPrefix(target, "unix://"))
-		if address == "" {
-			return "", "", fmt.Errorf("cache: unix target %q is missing a socket path", raw)
-		}
-		return "unix", address, nil
-	case strings.Contains(target, "://"):
-		parsed, parseErr := url.Parse(target)
-		if parseErr != nil {
-			return "", "", fmt.Errorf("cache: parse target %q: %w", raw, parseErr)
-		}
-		return "", "", fmt.Errorf("cache: unsupported target scheme %q", parsed.Scheme)
-	default:
-		return "unix", filepath.Clean(target), nil
-	}
 }

--- a/sdk/go/indexeddb.go
+++ b/sdk/go/indexeddb.go
@@ -3,10 +3,7 @@ package gestalt
 import (
 	"context"
 	"fmt"
-	"net"
-	"net/url"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -15,8 +12,6 @@ import (
 	rpcstatus "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 )
 
@@ -181,53 +176,10 @@ func IndexedDB(name ...string) (*IndexedDBClient, error) {
 	if target == "" {
 		return nil, fmt.Errorf("indexeddb: %s is not set", envName)
 	}
-	network, address, err := parseIndexedDBTarget(target)
-	if err != nil {
-		return nil, err
-	}
 	token := os.Getenv(IndexedDBSocketTokenEnv(firstIndex(name)))
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	var conn *grpc.ClientConn
-	opts := indexedDBDialOptions(token)
-	switch network {
-	case "unix":
-		conn, err = grpc.DialContext(ctx, "passthrough:///localhost",
-			append(internalHostServiceBaseDialOptions(
-				grpc.WithTransportCredentials(insecure.NewCredentials()),
-				grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
-					var d net.Dialer
-					return d.DialContext(ctx, "unix", address)
-				}),
-				grpc.WithAuthority("localhost"),
-				grpc.WithBlock(),
-			), opts...)...,
-		)
-	case "tcp":
-		conn, err = grpc.DialContext(ctx, address,
-			append(internalHostServiceBaseDialOptions(
-				grpc.WithTransportCredentials(insecure.NewCredentials()),
-				grpc.WithBlock(),
-			), opts...)...,
-		)
-	case "tls":
-		host, _, splitErr := net.SplitHostPort(address)
-		if splitErr != nil {
-			return nil, fmt.Errorf("indexeddb: parse tls target %q: %w", address, splitErr)
-		}
-		tlsConfig, tlsErr := hostServiceTLSConfig("indexeddb", host)
-		if tlsErr != nil {
-			return nil, tlsErr
-		}
-		conn, err = grpc.DialContext(ctx, address,
-			append(internalHostServiceBaseDialOptions(
-				grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
-				grpc.WithBlock(),
-			), opts...)...,
-		)
-	default:
-		return nil, fmt.Errorf("indexeddb: unsupported transport network %q", network)
-	}
+	conn, err := dialHostServiceRelay(ctx, "indexeddb", target, token)
 	if err != nil {
 		return nil, fmt.Errorf("indexeddb: connect to host: %w", err)
 	}
@@ -237,66 +189,11 @@ func IndexedDB(name ...string) (*IndexedDBClient, error) {
 	}, nil
 }
 
-func indexedDBDialOptions(token string) []grpc.DialOption {
-	token = strings.TrimSpace(token)
-	if token == "" {
-		return nil
-	}
-	return []grpc.DialOption{grpc.WithPerRPCCredentials(indexedDBRelayPerRPCCredentials{token: token})}
-}
-
 func firstIndex(name []string) string {
 	if len(name) == 0 {
 		return ""
 	}
 	return name[0]
-}
-
-type indexedDBRelayPerRPCCredentials struct {
-	token string
-}
-
-func (c indexedDBRelayPerRPCCredentials) GetRequestMetadata(context.Context, ...string) (map[string]string, error) {
-	return map[string]string{
-		"x-gestalt-host-service-relay-token": c.token,
-	}, nil
-}
-
-func (indexedDBRelayPerRPCCredentials) RequireTransportSecurity() bool { return false }
-
-func parseIndexedDBTarget(raw string) (network string, address string, err error) {
-	target := strings.TrimSpace(raw)
-	if target == "" {
-		return "", "", fmt.Errorf("indexeddb: transport target is required")
-	}
-	switch {
-	case strings.HasPrefix(target, "tcp://"):
-		address = strings.TrimSpace(strings.TrimPrefix(target, "tcp://"))
-		if address == "" {
-			return "", "", fmt.Errorf("indexeddb: tcp target %q is missing host:port", raw)
-		}
-		return "tcp", address, nil
-	case strings.HasPrefix(target, "tls://"):
-		address = strings.TrimSpace(strings.TrimPrefix(target, "tls://"))
-		if address == "" {
-			return "", "", fmt.Errorf("indexeddb: tls target %q is missing host:port", raw)
-		}
-		return "tls", address, nil
-	case strings.HasPrefix(target, "unix://"):
-		address = strings.TrimSpace(strings.TrimPrefix(target, "unix://"))
-		if address == "" {
-			return "", "", fmt.Errorf("indexeddb: unix target %q is missing a socket path", raw)
-		}
-		return "unix", address, nil
-	case strings.Contains(target, "://"):
-		parsed, parseErr := url.Parse(target)
-		if parseErr != nil {
-			return "", "", fmt.Errorf("indexeddb: parse target %q: %w", raw, parseErr)
-		}
-		return "", "", fmt.Errorf("indexeddb: unsupported target scheme %q", parsed.Scheme)
-	default:
-		return "unix", filepath.Clean(target), nil
-	}
 }
 
 // Close closes the underlying gRPC transport.

--- a/sdk/go/invoker.go
+++ b/sdk/go/invoker.go
@@ -3,18 +3,13 @@ package gestalt
 import (
 	"context"
 	"fmt"
-	"net"
-	"net/url"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/internal/gen/v1"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -96,50 +91,7 @@ func sharedPluginInvokerClient(ctx context.Context, target, token string) (proto
 	}
 	sharedInvokerTransport.mu.Unlock()
 
-	network, address, err := parsePluginInvokerTarget(target)
-	if err != nil {
-		return nil, err
-	}
-	opts := pluginInvokerDialOptions(token)
-	var conn *grpc.ClientConn
-	switch network {
-	case "unix":
-		conn, err = grpc.DialContext(ctx, "passthrough:///localhost",
-			append(internalHostServiceBaseDialOptions(
-				grpc.WithTransportCredentials(insecure.NewCredentials()),
-				grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
-					var d net.Dialer
-					return d.DialContext(ctx, "unix", address)
-				}),
-				grpc.WithAuthority("localhost"),
-				grpc.WithBlock(),
-			), opts...)...,
-		)
-	case "tcp":
-		conn, err = grpc.DialContext(ctx, address,
-			append(internalHostServiceBaseDialOptions(
-				grpc.WithTransportCredentials(insecure.NewCredentials()),
-				grpc.WithBlock(),
-			), opts...)...,
-		)
-	case "tls":
-		host, _, splitErr := net.SplitHostPort(address)
-		if splitErr != nil {
-			return nil, fmt.Errorf("plugin invoker: parse tls target %q: %w", address, splitErr)
-		}
-		tlsConfig, tlsErr := hostServiceTLSConfig("plugin invoker", host)
-		if tlsErr != nil {
-			return nil, tlsErr
-		}
-		conn, err = grpc.DialContext(ctx, address,
-			append(internalHostServiceBaseDialOptions(
-				grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
-				grpc.WithBlock(),
-			), opts...)...,
-		)
-	default:
-		return nil, fmt.Errorf("plugin invoker: unsupported transport network %q", network)
-	}
+	conn, err := dialHostServiceRelay(ctx, "plugin invoker", target, token)
 	if err != nil {
 		return nil, fmt.Errorf("plugin invoker: connect to host: %w", err)
 	}
@@ -162,61 +114,6 @@ func sharedPluginInvokerClient(ctx context.Context, target, token string) (proto
 	sharedInvokerTransport.conn = conn
 	sharedInvokerTransport.client = client
 	return client, nil
-}
-
-func pluginInvokerDialOptions(token string) []grpc.DialOption {
-	token = strings.TrimSpace(token)
-	if token == "" {
-		return nil
-	}
-	return []grpc.DialOption{grpc.WithPerRPCCredentials(pluginInvokerRelayPerRPCCredentials{token: token})}
-}
-
-type pluginInvokerRelayPerRPCCredentials struct {
-	token string
-}
-
-func (c pluginInvokerRelayPerRPCCredentials) GetRequestMetadata(context.Context, ...string) (map[string]string, error) {
-	return map[string]string{
-		"x-gestalt-host-service-relay-token": c.token,
-	}, nil
-}
-
-func (pluginInvokerRelayPerRPCCredentials) RequireTransportSecurity() bool { return false }
-
-func parsePluginInvokerTarget(raw string) (network string, address string, err error) {
-	target := strings.TrimSpace(raw)
-	if target == "" {
-		return "", "", fmt.Errorf("plugin invoker: transport target is required")
-	}
-	switch {
-	case strings.HasPrefix(target, "tcp://"):
-		address = strings.TrimSpace(strings.TrimPrefix(target, "tcp://"))
-		if address == "" {
-			return "", "", fmt.Errorf("plugin invoker: tcp target %q is missing host:port", raw)
-		}
-		return "tcp", address, nil
-	case strings.HasPrefix(target, "tls://"):
-		address = strings.TrimSpace(strings.TrimPrefix(target, "tls://"))
-		if address == "" {
-			return "", "", fmt.Errorf("plugin invoker: tls target %q is missing host:port", raw)
-		}
-		return "tls", address, nil
-	case strings.HasPrefix(target, "unix://"):
-		address = strings.TrimSpace(strings.TrimPrefix(target, "unix://"))
-		if address == "" {
-			return "", "", fmt.Errorf("plugin invoker: unix target %q is missing a socket path", raw)
-		}
-		return "unix", address, nil
-	case strings.Contains(target, "://"):
-		parsed, parseErr := url.Parse(target)
-		if parseErr != nil {
-			return "", "", fmt.Errorf("plugin invoker: parse target %q: %w", raw, parseErr)
-		}
-		return "", "", fmt.Errorf("plugin invoker: unsupported target scheme %q", parsed.Scheme)
-	default:
-		return "unix", filepath.Clean(target), nil
-	}
 }
 
 // InvokerFromContext returns an Invoker using the context invocation token.

--- a/sdk/go/manager_transport.go
+++ b/sdk/go/manager_transport.go
@@ -36,7 +36,7 @@ func managerTransportClient[C any](ctx context.Context, serviceName, target, tok
 	}
 	transport.mu.Unlock()
 
-	conn, err := dialManagerTransport(ctx, serviceName, target, token)
+	conn, err := dialHostServiceRelay(ctx, serviceName, target, token)
 	if err != nil {
 		return zero, err
 	}
@@ -60,12 +60,15 @@ func managerTransportClient[C any](ctx context.Context, serviceName, target, tok
 	return client, nil
 }
 
-func dialManagerTransport(ctx context.Context, serviceName, target, token string) (*grpc.ClientConn, error) {
+func dialHostServiceRelay(ctx context.Context, serviceName, target, token string) (*grpc.ClientConn, error) {
+	return dialManagerTransport(ctx, serviceName, target, managerRelayDialOptions(token)...)
+}
+
+func dialManagerTransport(ctx context.Context, serviceName, target string, extraOpts ...grpc.DialOption) (*grpc.ClientConn, error) {
 	network, address, err := parseManagerTransportTarget(serviceName, target)
 	if err != nil {
 		return nil, err
 	}
-	opts := managerRelayDialOptions(token)
 	switch network {
 	case "unix":
 		return grpc.DialContext(ctx, "passthrough:///localhost",
@@ -77,14 +80,14 @@ func dialManagerTransport(ctx context.Context, serviceName, target, token string
 				}),
 				grpc.WithAuthority("localhost"),
 				grpc.WithBlock(),
-			), opts...)...,
+			), extraOpts...)...,
 		)
 	case "tcp":
 		return grpc.DialContext(ctx, address,
 			append(internalHostServiceBaseDialOptions(
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
 				grpc.WithBlock(),
-			), opts...)...,
+			), extraOpts...)...,
 		)
 	case "tls":
 		host, _, err := net.SplitHostPort(address)
@@ -99,7 +102,7 @@ func dialManagerTransport(ctx context.Context, serviceName, target, token string
 			append(internalHostServiceBaseDialOptions(
 				grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
 				grpc.WithBlock(),
-			), opts...)...,
+			), extraOpts...)...,
 		)
 	default:
 		return nil, fmt.Errorf("%s: unsupported transport network %q", serviceName, network)

--- a/sdk/go/s3.go
+++ b/sdk/go/s3.go
@@ -6,18 +6,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net"
-	"net/url"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/internal/gen/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -190,53 +185,10 @@ func S3(name ...string) (*S3Client, error) {
 	if target == "" {
 		return nil, fmt.Errorf("s3: %s is not set", envName)
 	}
-	network, address, err := parseS3Target(target)
-	if err != nil {
-		return nil, err
-	}
 	token := os.Getenv(S3SocketTokenEnv(firstS3Name(name)))
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	var conn *grpc.ClientConn
-	opts := s3DialOptions(token)
-	switch network {
-	case "unix":
-		conn, err = grpc.DialContext(ctx, "passthrough:///localhost",
-			append(internalHostServiceBaseDialOptions(
-				grpc.WithTransportCredentials(insecure.NewCredentials()),
-				grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
-					var d net.Dialer
-					return d.DialContext(ctx, "unix", address)
-				}),
-				grpc.WithAuthority("localhost"),
-				grpc.WithBlock(),
-			), opts...)...,
-		)
-	case "tcp":
-		conn, err = grpc.DialContext(ctx, address,
-			append(internalHostServiceBaseDialOptions(
-				grpc.WithTransportCredentials(insecure.NewCredentials()),
-				grpc.WithBlock(),
-			), opts...)...,
-		)
-	case "tls":
-		host, _, splitErr := net.SplitHostPort(address)
-		if splitErr != nil {
-			return nil, fmt.Errorf("s3: parse tls target %q: %w", address, splitErr)
-		}
-		tlsConfig, tlsErr := hostServiceTLSConfig("s3", host)
-		if tlsErr != nil {
-			return nil, tlsErr
-		}
-		conn, err = grpc.DialContext(ctx, address,
-			append(internalHostServiceBaseDialOptions(
-				grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
-				grpc.WithBlock(),
-			), opts...)...,
-		)
-	default:
-		return nil, fmt.Errorf("s3: unsupported transport network %q", network)
-	}
+	conn, err := dialHostServiceRelay(ctx, "s3", target, token)
 	if err != nil {
 		return nil, fmt.Errorf("s3: connect to host: %w", err)
 	}
@@ -873,66 +825,11 @@ func cloneStringMap(values map[string]string) map[string]string {
 	return out
 }
 
-func s3DialOptions(token string) []grpc.DialOption {
-	token = strings.TrimSpace(token)
-	if token == "" {
-		return nil
-	}
-	return []grpc.DialOption{grpc.WithPerRPCCredentials(s3RelayPerRPCCredentials{token: token})}
-}
-
 func firstS3Name(name []string) string {
 	if len(name) == 0 {
 		return ""
 	}
 	return name[0]
-}
-
-type s3RelayPerRPCCredentials struct {
-	token string
-}
-
-func (c s3RelayPerRPCCredentials) GetRequestMetadata(context.Context, ...string) (map[string]string, error) {
-	return map[string]string{
-		"x-gestalt-host-service-relay-token": c.token,
-	}, nil
-}
-
-func (s3RelayPerRPCCredentials) RequireTransportSecurity() bool { return false }
-
-func parseS3Target(raw string) (network string, address string, err error) {
-	target := strings.TrimSpace(raw)
-	if target == "" {
-		return "", "", fmt.Errorf("s3: transport target is required")
-	}
-	switch {
-	case strings.HasPrefix(target, "tcp://"):
-		address = strings.TrimSpace(strings.TrimPrefix(target, "tcp://"))
-		if address == "" {
-			return "", "", fmt.Errorf("s3: tcp target %q is missing host:port", raw)
-		}
-		return "tcp", address, nil
-	case strings.HasPrefix(target, "tls://"):
-		address = strings.TrimSpace(strings.TrimPrefix(target, "tls://"))
-		if address == "" {
-			return "", "", fmt.Errorf("s3: tls target %q is missing host:port", raw)
-		}
-		return "tls", address, nil
-	case strings.HasPrefix(target, "unix://"):
-		address = strings.TrimSpace(strings.TrimPrefix(target, "unix://"))
-		if address == "" {
-			return "", "", fmt.Errorf("s3: unix target %q is missing a socket path", raw)
-		}
-		return "unix", address, nil
-	case strings.Contains(target, "://"):
-		parsed, parseErr := url.Parse(target)
-		if parseErr != nil {
-			return "", "", fmt.Errorf("s3: parse target %q: %w", raw, parseErr)
-		}
-		return "", "", fmt.Errorf("s3: unsupported target scheme %q", parsed.Scheme)
-	default:
-		return "unix", filepath.Clean(target), nil
-	}
 }
 
 func grpcS3Err(err error) error {


### PR DESCRIPTION
## Summary
- Consolidate SDK host-service clients (cache, indexeddb, s3, authorization, plugin invoker) behind `dialHostServiceRelay`, deleting duplicate target parsers and dead per-service relay credential types (~527 lines).
- Collapse bootstrap IndexedDB scoped builders and host-service registration into `buildHostScopedIndexedDB`, `buildIndexedDBHostServices`, and `newIndexedDBHostService` (~74 lines).
- Route plugin struct/map conversions through shared `protoutil` helpers instead of local duplicates (~92 lines).

Deferred (out of scope): unified host-service env migration, shared indexeddbcodec module, IndexedDB transport stack unification.

Binding-header dedup was skipped on `main` because routing servers with local `hostServiceBindingHeader` constants are not present until the unified socket stack lands.

## Test plan
- [x] `go test ./sdk/go/... -run 'Transport|NamedSocket|TCPTarget|NamedBinding'`
- [x] `go test ./gestaltd/internal/bootstrap/... -run 'IndexedDB|HostService|Plugin.*Host|Workflow|Agent'`
- [x] `go test ./gestaltd/services/indexeddb/... -run Allowlist`
- [x] `go test ./gestaltd/services/plugins/... ./services/cache/... ./services/s3/...`


Made with [Cursor](https://cursor.com)