### PR TITLE
Export combined host-service gRPC registration helpers for tests

### DIFF
--- a/sdk/go/serve_host_service.go
+++ b/sdk/go/serve_host_service.go
@@ -1,0 +1,65 @@
+package gestalt
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+
+	proto "github.com/valon-technologies/gestalt/sdk/go/internal/gen/v1"
+	"google.golang.org/grpc"
+)
+
+// RegisterIndexedDBHostService registers an IndexedDB host service on srv.
+func RegisterIndexedDBHostService(srv *grpc.Server, datastore IndexedDBProvider) {
+	proto.RegisterIndexedDBServer(srv, indexedDBProviderServer{provider: datastore})
+}
+
+// RegisterExternalCredentialHostService registers an external credential host
+// service on srv.
+func RegisterExternalCredentialHostService(srv *grpc.Server, provider ExternalCredentialProvider) {
+	proto.RegisterExternalCredentialProviderServer(srv, newExternalCredentialProviderServer(provider))
+}
+
+// ServeHostServiceGRPC serves host-service gRPC handlers on a unix socket until
+// ctx is cancelled. The register callback should register one or more host
+// services on the server.
+func ServeHostServiceGRPC(ctx context.Context, socketPath string, register func(*grpc.Server)) error {
+	socketPath = strings.TrimSpace(socketPath)
+	if socketPath == "" {
+		return fmt.Errorf("host service socket path is required")
+	}
+	if register == nil {
+		return fmt.Errorf("host service register callback is required")
+	}
+	if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove stale socket %q: %w", socketPath, err)
+	}
+
+	lis, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return fmt.Errorf("listen on host service socket %q: %w", socketPath, err)
+	}
+	defer func() {
+		_ = lis.Close()
+		_ = os.Remove(socketPath)
+	}()
+
+	srv := grpc.NewServer()
+	register(srv)
+
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		<-ctx.Done()
+		srv.GracefulStop()
+	}()
+
+	err = srv.Serve(lis)
+	if ctx.Err() != nil {
+		<-stopped
+		return nil
+	}
+	return err
+}


### PR DESCRIPTION
## Summary
- Add `ServeHostServiceGRPC` to run multiple host-service gRPC handlers on one unix socket until context cancellation.
- Add `RegisterIndexedDBHostService` and `RegisterExternalCredentialHostService` so tests can register providers on a shared server without separate `Serve*` processes per service.
- Unblocks gestalt-providers PR #879, which consolidates external-credentials tests onto a single host-service socket instead of env-swapping between two servers.

## Architecture

**The socket is generic; services are typed gRPC APIs on the same listener.** Production gestaltd already does this (`runtimehost/process.go`: one `grpc.Server`, loop `Register()` for each host service, one `GESTALT_HOST_SERVICE_SOCKET`). Existing `ServeIndexedDBProvider` / `ServeExternalCredentialProvider` each bind their own listener — fine for standalone provider binaries, but tests that mirror production need multi-service registration on one socket.

### Unified model (what clients use)

```mermaid
flowchart LR
  subgraph Plugin["Plugin / provider process"]
    P[Provider code]
  end

  subgraph Env["Environment"]
    E[GESTALT_HOST_SERVICE_SOCKET]
    T[GESTALT_HOST_SERVICE_TOKEN optional]
  end

  subgraph OneSocket["Single host-service listener"]
    HS[(host.sock)]
    subgraph GRPC["gRPC services on same server"]
      IDB[IndexedDB]
      EC[ExternalCredential]
      Cache[Cache]
      S3[S3]
    end
  end

  P --> E --> HS
  P -->|gestalt.IndexedDB| IDB
  P -->|gestalt.ExternalCredentials| EC
  P -->|gestalt.Cache| Cache
```

`gestalt.IndexedDB()` and `gestalt.ExternalCredentials()` dial the **same** env var; they differ only in which gRPC stub they use. “IndexedDB host service” names a capability, not a separate socket type.

### Why this PR exists (test harness gap)

**Before:** each `Serve*` helper starts its own exclusive server → tests with one env var had to swap sockets.

```mermaid
sequenceDiagram
  participant Test
  participant Env as GESTALT_HOST_SERVICE_SOCKET
  participant IDB as indexeddb.sock
  participant EC as ext-cred.sock

  Test->>IDB: start ServeIndexedDBProvider
  Test->>Env: set unix://indexeddb.sock
  Test->>Test: provider.Configure

  Test->>EC: start ServeExternalCredentialProvider
  Test->>Env: overwrite unix://ext-cred.sock

  Test->>Env: swap back for gestalt.IndexedDB()
```

**After (with this PR):** one listener, multiple registrations — matches gestaltd.

```mermaid
flowchart TB
  subgraph TestHarness["Test: startTestHostService"]
    HS[(host-service.sock)]
    Reg[ServeHostServiceGRPC]
    Reg --> HS
    Reg --> IDBReg[RegisterIndexedDBHostService]
    Reg --> ECReg[RegisterExternalCredentialHostService]
  end

  Env[GESTALT_HOST_SERVICE_SOCKET]

  TestHarness --> Env
  Client1[gestalt.IndexedDB] --> HS
  Client2[gestalt.ExternalCredentials] --> HS
```

## Merge order

```mermaid
flowchart LR
  G2116["gestalt #2116<br/>ServeHostServiceGRPC"] --> P879["gestalt-providers #879"]
  G2106["gestalt #2106 merged<br/>unified env vars"] --> P879
```

## Test plan
- [x] `GOWORK=off go test -count=1 .` in `gestalt-providers/externalcredentials/default` (via local replace)
- [ ] Merge this PR, then re-run CI on https://github.com/valon-technologies/gestalt-providers/pull/879