### PR TITLE
Expose RegisterS3HostService for unified host-service test harnesses

### DIFF
--- a/sdk/go/serve_s3.go
+++ b/sdk/go/serve_s3.go
@@ -12,11 +12,16 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
+// RegisterS3HostService registers an S3 host service on srv.
+func RegisterS3HostService(srv *grpc.Server, provider S3Provider) {
+	proto.RegisterS3Server(srv, s3ProviderServer{provider: provider})
+}
+
 // ServeS3Provider starts a gRPC server for an [S3Provider].
 func ServeS3Provider(ctx context.Context, provider S3Provider) error {
 	return serveProvider(withProviderCloser(ctx, provider), func(srv *grpc.Server) {
 		proto.RegisterProviderLifecycleServer(srv, newRuntimeServer(ProviderKindS3, provider))
-		proto.RegisterS3Server(srv, s3ProviderServer{provider: provider})
+		RegisterS3HostService(srv, provider)
 	})
 }
 


### PR DESCRIPTION
## Summary
- Add `RegisterS3HostService` so tests can register S3 on `ServeHostServiceGRPC` alongside other host services.
- Refactor `ServeS3Provider` to call the shared registration helper.

## Context
Companion to gestalt-providers #879, which deletes duplicate S3 test harness code that previously called `ServeS3Provider` with `GESTALT_PLUGIN_SOCKET`.

## Test plan
- [x] `go test ./sdk/go/...` (S3 registration is compile-time only; no new tests in this PR)


Made with [Cursor](https://cursor.com)