### PR TITLE
Move gestaltd exit policy into daemon.Main so cmd stays a bootstrap shell.

### DIFF
--- a/gestaltd/cmd/gestaltd/main.go
+++ b/gestaltd/cmd/gestaltd/main.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"errors"
-	"flag"
-	"log/slog"
 	"os"
 	_ "time/tzdata"
 
@@ -13,17 +10,8 @@ import (
 var version = "dev"
 
 func main() {
-	if err := daemon.Run(daemon.Options{
+	os.Exit(daemon.Main(daemon.Options{
 		Version: version,
 		Args:    os.Args[1:],
-	}); err != nil {
-		if errors.Is(err, flag.ErrHelp) {
-			return
-		}
-		if code, ok := daemon.ExitCode(err); ok {
-			os.Exit(code)
-		}
-		slog.Error("gestaltd exited", "error", err)
-		os.Exit(1)
-	}
+	}))
 }

--- a/gestaltd/internal/daemon/agent_local.go
+++ b/gestaltd/internal/daemon/agent_local.go
@@ -2,7 +2,6 @@ package daemon
 
 import (
 	"encoding/json"
-	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -16,24 +15,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/operator"
 )
-
-type exitCodeError struct {
-	code int
-}
-
-func (e exitCodeError) Error() string {
-	return fmt.Sprintf("process exited with status %d", e.code)
-}
-
-// ExitCode extracts a daemon command exit code that intentionally mirrors a
-// child process status.
-func ExitCode(err error) (int, bool) {
-	var exitErr exitCodeError
-	if errors.As(err, &exitErr) {
-		return exitErr.code, true
-	}
-	return 0, false
-}
 
 type localAgentCommandOptions struct {
 	ConfigPaths []string

--- a/gestaltd/internal/daemon/exit.go
+++ b/gestaltd/internal/daemon/exit.go
@@ -36,6 +36,10 @@ func Main(opts Options) int {
 }
 
 func mainExitCode(err error) int {
+	return mainExitCodeWithLogger(err, slog.Default())
+}
+
+func mainExitCodeWithLogger(err error, logger *slog.Logger) int {
 	if err == nil {
 		return 0
 	}
@@ -45,6 +49,6 @@ func mainExitCode(err error) int {
 	if code, ok := exitCode(err); ok {
 		return code
 	}
-	slog.Error("gestaltd exited", "error", err)
+	logger.Error("gestaltd exited", "error", err)
 	return 1
 }

--- a/gestaltd/internal/daemon/exit.go
+++ b/gestaltd/internal/daemon/exit.go
@@ -1,0 +1,50 @@
+package daemon
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"log/slog"
+)
+
+type exitCodeError struct {
+	code int
+}
+
+func (e exitCodeError) Error() string {
+	return fmt.Sprintf("process exited with status %d", e.code)
+}
+
+func exitCode(err error) (int, bool) {
+	var exitErr exitCodeError
+	if errors.As(err, &exitErr) {
+		return exitErr.code, true
+	}
+	return 0, false
+}
+
+// Main is the gestaltd process entrypoint. It runs the CLI and returns the
+// process exit code. Callers should typically invoke it from main via os.Exit.
+//
+// Exit policy:
+//   - Run succeeds: 0
+//   - flag.ErrHelp: 0 without logging
+//   - exitCodeError (intentional child process exit passthrough): child code without logging
+//   - all other errors: log "gestaltd exited" and return 1
+func Main(opts Options) int {
+	return mainExitCode(Run(opts))
+}
+
+func mainExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	if errors.Is(err, flag.ErrHelp) {
+		return 0
+	}
+	if code, ok := exitCode(err); ok {
+		return code
+	}
+	slog.Error("gestaltd exited", "error", err)
+	return 1
+}

--- a/gestaltd/internal/daemon/exit_test.go
+++ b/gestaltd/internal/daemon/exit_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 )
 
-func TestMainExitPolicy(t *testing.T) {
-	for _, tc := range []struct {
+func TestMainExitPolicy(t *testing.T) { //nolint:paralleltest // mutates slog.Default
+	for _, tc := range []struct { //nolint:paralleltest // subtests mutate slog.Default
 		name     string
 		err      error
 		wantCode int

--- a/gestaltd/internal/daemon/exit_test.go
+++ b/gestaltd/internal/daemon/exit_test.go
@@ -9,8 +9,10 @@ import (
 	"testing"
 )
 
-func TestMainExitPolicy(t *testing.T) { //nolint:paralleltest // mutates slog.Default
-	for _, tc := range []struct { //nolint:paralleltest // subtests mutate slog.Default
+func TestMainExitPolicy(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
 		name     string
 		err      error
 		wantCode int
@@ -40,13 +42,13 @@ func TestMainExitPolicy(t *testing.T) { //nolint:paralleltest // mutates slog.De
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			var logs []string
-			origDefault := slog.Default()
-			t.Cleanup(func() { slog.SetDefault(origDefault) })
-			slog.SetDefault(slog.New(&testLogHandler{logs: &logs}))
+			t.Parallel()
 
-			if got := mainExitCode(tc.err); got != tc.wantCode {
-				t.Fatalf("mainExitCode() = %d, want %d", got, tc.wantCode)
+			var logs []string
+			logger := slog.New(&testLogHandler{logs: &logs})
+
+			if got := mainExitCodeWithLogger(tc.err, logger); got != tc.wantCode {
+				t.Fatalf("mainExitCodeWithLogger() = %d, want %d", got, tc.wantCode)
 			}
 			if tc.wantLog {
 				if len(logs) != 1 {

--- a/gestaltd/internal/daemon/exit_test.go
+++ b/gestaltd/internal/daemon/exit_test.go
@@ -1,0 +1,107 @@
+package daemon
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestMainExitPolicy(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		err      error
+		wantCode int
+		wantLog  bool
+	}{
+		{
+			name:     "success",
+			err:      nil,
+			wantCode: 0,
+		},
+		{
+			name:     "help",
+			err:      flag.ErrHelp,
+			wantCode: 0,
+		},
+		{
+			name:     "child exit",
+			err:      exitCodeError{code: 7},
+			wantCode: 7,
+		},
+		{
+			name:     "failure",
+			err:      fmt.Errorf("boom"),
+			wantCode: 1,
+			wantLog:  true,
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			var logs []string
+			origDefault := slog.Default()
+			t.Cleanup(func() { slog.SetDefault(origDefault) })
+			slog.SetDefault(slog.New(&testLogHandler{logs: &logs}))
+
+			if got := mainExitCode(tc.err); got != tc.wantCode {
+				t.Fatalf("mainExitCode() = %d, want %d", got, tc.wantCode)
+			}
+			if tc.wantLog {
+				if len(logs) != 1 {
+					t.Fatalf("log count = %d, want 1", len(logs))
+				}
+				if logs[0] != "gestaltd exited error=boom" {
+					t.Fatalf("log = %q, want gestaltd exited error=boom", logs[0])
+				}
+				return
+			}
+			if len(logs) != 0 {
+				t.Fatalf("unexpected logs: %v", logs)
+			}
+		})
+	}
+}
+
+func TestExitCode(t *testing.T) {
+	t.Parallel()
+
+	if code, ok := exitCode(exitCodeError{code: 7}); !ok || code != 7 {
+		t.Fatalf("exitCode(exitCodeError{7}) = (%d, %v), want (7, true)", code, ok)
+	}
+	if code, ok := exitCode(fmt.Errorf("other")); ok {
+		t.Fatalf("exitCode(generic) = (%d, true), want (_, false)", code)
+	}
+}
+
+type testLogHandler struct {
+	logs *[]string
+}
+
+func (h *testLogHandler) Enabled(_ context.Context, _ slog.Level) bool {
+	return true
+}
+
+func (h *testLogHandler) Handle(_ context.Context, r slog.Record) error {
+	var buf strings.Builder
+	r.Attrs(func(a slog.Attr) bool {
+		if buf.Len() > 0 {
+			buf.WriteByte(' ')
+		}
+		buf.WriteString(a.Key)
+		buf.WriteByte('=')
+		buf.WriteString(a.Value.String())
+		return true
+	})
+	*h.logs = append(*h.logs, r.Message+" "+buf.String())
+	return nil
+}
+
+func (h *testLogHandler) WithAttrs(_ []slog.Attr) slog.Handler {
+	return h
+}
+
+func (h *testLogHandler) WithGroup(_ string) slog.Handler {
+	return h
+}


### PR DESCRIPTION
## Summary
- Add `daemon.Main(opts) int` as the canonical gestaltd process exit policy.
- Move `exitCodeError` / exit-code extraction into `internal/daemon/exit.go`.
- Simplify `cmd/gestaltd/main.go` to `os.Exit(daemon.Main(...))`.
- Example: `os.Exit(daemon.Main(daemon.Options{Version: version, Args: os.Args[1:]}))`

## Test plan
- [x] `go test ./internal/daemon/... -run TestMainExitPolicy`
- [x] `go test ./internal/daemon/... -run TestE2EAgentLaunchRunsHarnessWithInheritedStdioAndExitCode`
- [x] `go test ./internal/daemon/... -run 'TestE2ECLIHelp|TestE2ECLIRejectsBadArgs'`

Made with [Cursor](https://cursor.com)