### PR TITLE
Add wire helpers for gestalt CLI agent protocol strings

### DIFF
--- a/gestalt/cli/src/commands/agents/driver.rs
+++ b/gestalt/cli/src/commands/agents/driver.rs
@@ -6,12 +6,14 @@ use crate::api::ApiClient;
 use super::requests::{get_turn_info, list_interactions_info};
 use super::stream::EVENT_POLL_INTERVAL;
 use super::types::{AgentInteractionInfo, AgentTurnInfo};
+use super::wire::{is_live_turn_status, is_terminal_turn_status};
 
 pub(crate) struct TurnLoopContext<'a> {
     pub client: &'a ApiClient,
     pub turn_id: &'a str,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TurnLoopOutcome {
     Continue,
     Cancelled,
@@ -39,14 +41,18 @@ pub(crate) fn run_turn_status_loop<S: TurnDriverSink>(
         }
         let latest = get_turn_info(ctx.client, ctx.turn_id)?;
         sink.on_turn_snapshot(&latest)?;
-        match latest.status.as_str() {
-            "waiting_for_input" => match sink.handle_waiting_for_input(ctx, &latest)? {
+        let status = latest.status.as_str();
+        if status == "waiting_for_input" {
+            match sink.handle_waiting_for_input(ctx, &latest)? {
                 TurnLoopOutcome::Continue => {}
                 TurnLoopOutcome::Cancelled => return Ok(()),
-            },
-            "pending" | "running" => thread::sleep(EVENT_POLL_INTERVAL),
-            "succeeded" | "failed" | "canceled" => return Ok(()),
-            other => bail!("agent turn {} has unsupported status {}", latest.id, other),
+            }
+        } else if is_live_turn_status(status) {
+            thread::sleep(EVENT_POLL_INTERVAL);
+        } else if is_terminal_turn_status(status) {
+            return Ok(());
+        } else {
+            bail!("agent turn {} has unsupported status {}", latest.id, status);
         }
     }
 }

--- a/gestalt/cli/src/commands/agents/events.rs
+++ b/gestalt/cli/src/commands/agents/events.rs
@@ -5,6 +5,7 @@ use super::fields::{
     string_any_field, string_field, turn_event_display, value_any_field,
 };
 use super::types::{AgentTurnDisplayInfo, AgentTurnEventInfo};
+use super::wire::is_private_event_visibility;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ToolPhase {
@@ -54,7 +55,7 @@ pub(crate) fn classify_turn_event(event: &AgentTurnEventInfo) -> ClassifiedTurnE
     if let Some(effect) = classify_data_event(event) {
         return ClassifiedTurnEvent::Data(effect);
     }
-    if event.visibility == "private" {
+    if is_private_event_visibility(&event.visibility) {
         return ClassifiedTurnEvent::Private;
     }
     ClassifiedTurnEvent::Unknown(event)

--- a/gestalt/cli/src/commands/agents/fields.rs
+++ b/gestalt/cli/src/commands/agents/fields.rs
@@ -6,6 +6,7 @@ use super::display_markdown;
 use super::types::{
     AgentMessageInfo, AgentMessagePartInfo, AgentTurnDisplayInfo, AgentTurnEventInfo,
 };
+use super::wire::is_private_event_visibility;
 
 pub(crate) fn decode_json<T>(value: Value) -> Result<T>
 where
@@ -40,7 +41,7 @@ pub(crate) fn turn_event_display(event: &AgentTurnEventInfo) -> Option<&AgentTur
     if display.kind.trim().is_empty() {
         return None;
     }
-    if event.visibility == "private" && !known_turn_event_type(&event.event_type) {
+    if is_private_event_visibility(&event.visibility) && !known_turn_event_type(&event.event_type) {
         return None;
     }
     Some(display)

--- a/gestalt/cli/src/commands/agents/format/transcript.rs
+++ b/gestalt/cli/src/commands/agents/format/transcript.rs
@@ -9,16 +9,20 @@ use crate::commands::agents::fields::{
     turn_event_display,
 };
 use crate::commands::agents::types::{AgentTurnDisplayInfo, AgentTurnEventInfo};
+use crate::commands::agents::wire::is_private_event_visibility;
 
 pub(crate) fn fallback_turn_event_data_summary(value: &Value) -> String {
     if let Ok(event) = serde_json::from_value::<AgentTurnEventInfo>(value.clone()) {
         if let Some(summary) = turn_event_data_summary(&event) {
             return summary;
         }
-        if event.visibility == "private" {
+        if is_private_event_visibility(&event.visibility) {
             return String::new();
         }
-    } else if value["visibility"].as_str() == Some("private") {
+    } else if value["visibility"]
+        .as_str()
+        .is_some_and(is_private_event_visibility)
+    {
         return String::new();
     }
     serde_json::to_string(&value["data"]).unwrap_or_else(|_| "-".to_string())

--- a/gestalt/cli/src/commands/agents/mod.rs
+++ b/gestalt/cli/src/commands/agents/mod.rs
@@ -10,6 +10,7 @@ mod shell;
 mod stream;
 mod tui;
 mod types;
+mod wire;
 
 pub use harness::{doctor_local, launch_local};
 pub use requests::{

--- a/gestalt/cli/src/commands/agents/tui.rs
+++ b/gestalt/cli/src/commands/agents/tui.rs
@@ -29,6 +29,7 @@ mod worker;
 use state::{AgentUiState, ToolDetailMode, TranscriptItem, turn_status_label};
 use worker::{TurnWorker, WorkerCommand, WorkerEvent, spawn_turn_worker};
 
+use super::wire::is_text_input_interaction;
 use super::{
     AgentInteractionInfo, AgentShell, INTERRUPT_CANCEL_REASON, agent_model_lines,
     agent_session_lines, agent_tui_help_lines, cancel_turn_silent, compact_json, display_markdown,
@@ -318,7 +319,7 @@ impl TuiApp {
             area,
         );
 
-        if interaction.interaction_type != "approval" && area.height > 4 {
+        if is_text_input_interaction(&interaction.interaction_type) && area.height > 4 {
             let input_area = Rect {
                 x: area.x + 1,
                 y: area.y + area.height.saturating_sub(3),

--- a/gestalt/cli/src/commands/agents/tui/state.rs
+++ b/gestalt/cli/src/commands/agents/tui/state.rs
@@ -17,6 +17,7 @@ use crate::commands::agents::fields::{
 use crate::commands::agents::types::{
     AgentInteractionInfo, AgentSessionInfo, AgentTurnDisplayInfo, AgentTurnEventInfo, AgentTurnInfo,
 };
+use crate::commands::agents::wire::is_terminal_turn_status;
 
 const MAX_TRANSCRIPT_ITEMS: usize = 500;
 const TOOL_PREVIEW_MAX_WIDTH: usize = 120;
@@ -296,7 +297,7 @@ impl AgentUiState {
     }
 
     pub(super) fn finish_turn(&mut self, turn: &AgentTurnInfo) {
-        let terminal = matches!(turn.status.as_str(), "succeeded" | "failed" | "canceled");
+        let terminal = is_terminal_turn_status(turn.status.as_str());
         match turn.status.as_str() {
             "succeeded" if !turn.output_text.is_empty() => {
                 if !self.assistant_buffer.is_empty() {

--- a/gestalt/cli/src/commands/agents/wire.rs
+++ b/gestalt/cli/src/commands/agents/wire.rs
@@ -1,0 +1,15 @@
+pub(crate) fn is_live_turn_status(status: &str) -> bool {
+    matches!(status, "pending" | "running" | "")
+}
+
+pub(crate) fn is_terminal_turn_status(status: &str) -> bool {
+    matches!(status, "succeeded" | "failed" | "canceled")
+}
+
+pub(crate) fn is_private_event_visibility(visibility: &str) -> bool {
+    visibility == "private"
+}
+
+pub(crate) fn is_text_input_interaction(interaction_type: &str) -> bool {
+    matches!(interaction_type, "clarification" | "input")
+}


### PR DESCRIPTION
This PR adds a small `wire` module with helpers for the agent protocol string comparisons scattered through the CLI. Wire types stay as plain strings from JSON; the helpers group live vs terminal turn status in the driver loop, private event visibility in event classification and transcript formatting, and text-input interaction detection in the TUI.

There are no user-facing CLI changes.