### PR TITLE
Emit app targets for TypeScript provider builds

### DIFF
--- a/gestaltd/services/apps/providerpkg/typescript_provider.go
+++ b/gestaltd/services/apps/providerpkg/typescript_provider.go
@@ -398,7 +398,7 @@ func normalizeTypeScriptProviderKind(value string) string {
 
 func formatTypeScriptRuntimeTarget(kind, target string) string {
 	if kind == "integration" {
-		return "plugin:" + strings.TrimSpace(target)
+		return "app:" + strings.TrimSpace(target)
 	}
 	return kind + ":" + strings.TrimSpace(target)
 }

--- a/gestaltd/services/apps/providerpkg/typescript_provider_test.go
+++ b/gestaltd/services/apps/providerpkg/typescript_provider_test.go
@@ -1,0 +1,29 @@
+package providerpkg
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestDetectTypeScriptProviderTargetFormatsAppsAsAppTargets(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "package.json"), []byte(`{
+  "gestalt": {
+    "provider": {
+      "kind": "app",
+      "target": "./provider.ts#provider"
+    }
+  }
+}
+`), 0o644)
+
+	target, err := DetectTypeScriptProviderTarget(root)
+	if err != nil {
+		t.Fatalf("DetectTypeScriptProviderTarget() error = %v", err)
+	}
+	if target != "app:./provider.ts#provider" {
+		t.Fatalf("DetectTypeScriptProviderTarget() = %q, want %q", target, "app:./provider.ts#provider")
+	}
+}


### PR DESCRIPTION
## Interface Changes
TypeScript source app packages now emit `app:./provider.ts#provider` for release builds instead of the removed `plugin:./provider.ts#provider` target. This keeps `gestaltd provider package --platform linux/amd64` aligned with `kind: app` manifests so Toolshed can cut real `apps/...` release artifacts.