### PR TITLE
Add provider artifact publishing

### DIFF
--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -523,6 +523,46 @@ writes `provider-release.yaml` next to the archives. It does not run source
 build commands and can run after multiple platform-specific package jobs have
 collected their archives into one dist directory.
 
+CI systems that publish commit-addressed artifacts can use `provider publish`
+instead of writing release metadata into the source dist directory:
+
+```sh
+gestaltd provider publish \
+  --config gestaltd.yaml \
+  --repo valon \
+  --manifest manifest.yaml \
+  --version 0.0.0-snapshot.g651a5c30feb995c9364c38f63d0d5c3880bc2055 \
+  --ref 651a5c30feb995c9364c38f63d0d5c3880bc2055 \
+  --dist-dir dist/linux \
+  --dist-dir dist/darwin
+```
+
+Use `--dry-run --format json` in CI when a later step needs the exact artifact,
+checksums, and metadata URLs that publish would write:
+
+```sh
+gestaltd provider publish \
+  --config gestaltd.yaml \
+  --repo valon \
+  --manifest manifest.yaml \
+  --version 0.0.0-snapshot.g651a5c30feb995c9364c38f63d0d5c3880bc2055 \
+  --ref 651a5c30feb995c9364c38f63d0d5c3880bc2055 \
+  --dist-dir dist/linux \
+  --dist-dir dist/darwin \
+  --dry-run \
+  --format json
+```
+
+The JSON plan includes the publish repository key, source repository, source
+ref, manifest path, provider directory, and URL entries for `metadata`,
+`checksums`, `artifacts`, and `files`.
+
+The repository's `providerSnapshotRepositories.<name>.publish` config controls
+the storage backend and path layout. With `pathLayout: sourceRef`, Gestalt uses
+the source checkout's GitHub origin, the full `--ref`, and the manifest path
+relative to the git root. The resulting metadata URL is the same deterministic
+location that `source.git` snapshot materialization resolves.
+
 For source manifests that declare object-form `build.command`, package runs
 that command, verifies that the declared output exists, strips `build` and
 `run` metadata from the packaged manifest, and records released artifacts. The

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -61,6 +61,7 @@ import { Callout } from 'nextra/components'
 | `gestaltd provider package --version VERSION` | Build provider release archives from a source directory. Executable source providers use SDK-native source packages or `build.command` and default to the host platform; UI and declarative providers default to a generic archive. Pass `--platform ...` with `os/arch` targets or `--platform all` for multi-platform builds. |
 | `gestaltd provider package --output DIR` | Output directory for the release archives. Defaults to `dist/`. |
 | `gestaltd provider release --dist-dir DIR` | Finalize already-built release archives by validating them and writing `checksums.txt` and `provider-release.yaml` into the dist directory. |
+| `gestaltd provider publish --repo NAME --manifest PATH --version VERSION --ref SHA --dist-dir DIR` | Validate one release bundle from one or more dist directories, write release metadata in a temporary directory, and publish archives plus metadata to a configured artifact repository. Pass `--dry-run --format json` to emit the exact publish plan for CI. |
 
 For config-free local development, inferred UI mount paths use the manifest
 `source` slug rather than the API-safe provider key. A source ending in

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -140,12 +140,22 @@ providerSnapshotRepositories:
   valon:
     url: https://storage.googleapis.com/valon-gestalt-provider-snapshots
     gestaltRef: 651a5c30feb995c9364c38f63d0d5c3880bc2055
+    publish:
+      pathLayout: sourceRef
+      immutable: true
+      storage:
+        kind: objectStore
+        url: gs://valon-gestalt-provider-snapshots
 ```
 
 | Field | Description |
 | --- | --- |
 | `providerSnapshotRepositories.<name>.url` | HTTP(S) root containing deterministic snapshot `provider-release.yaml` files and archives. |
 | `providerSnapshotRepositories.<name>.gestaltRef` | Optional full Gestalt commit SHA expected for snapshots from this repository. |
+| `providerSnapshotRepositories.<name>.publish.pathLayout` | Publish path layout. `sourceRef` writes `github.com/<owner>/<repo>/<ref>/<provider-dir>/provider-release.yaml`, deriving `<owner>/<repo>` from the source checkout's GitHub origin and `<provider-dir>` from the manifest path relative to the git root. |
+| `providerSnapshotRepositories.<name>.publish.immutable` | Must be `true`; published artifacts are write-once. |
+| `providerSnapshotRepositories.<name>.publish.storage.kind` | Write backend kind. `objectStore` publishes files to an object-store URL. |
+| `providerSnapshotRepositories.<name>.publish.storage.url` | Authenticated write root for published artifacts. The current object-store writer supports `gs://` paths. |
 
 ## `server`
 

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -65,8 +65,20 @@ type ProviderRepositoryConfig struct {
 }
 
 type ProviderSnapshotRepositoryConfig struct {
-	URL        string `yaml:"url,omitempty"`
-	GestaltRef string `yaml:"gestaltRef,omitempty"`
+	URL        string                                  `yaml:"url,omitempty"`
+	GestaltRef string                                  `yaml:"gestaltRef,omitempty"`
+	Publish    ProviderSnapshotRepositoryPublishConfig `yaml:"publish,omitempty"`
+}
+
+type ProviderSnapshotRepositoryPublishConfig struct {
+	PathLayout string                                  `yaml:"pathLayout,omitempty"`
+	Immutable  bool                                    `yaml:"immutable,omitempty"`
+	Storage    ProviderSnapshotRepositoryStorageConfig `yaml:"storage,omitempty"`
+}
+
+type ProviderSnapshotRepositoryStorageConfig struct {
+	Kind string `yaml:"kind,omitempty"`
+	URL  string `yaml:"url,omitempty"`
 }
 
 type ProvidersConfig struct {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -5028,6 +5028,65 @@ apps:
 	}
 }
 
+func TestLoadConfigProviderSnapshotRepositoryPublish(t *testing.T) {
+	t.Parallel()
+
+	path := mustWriteRawConfigFile(t, `
+apiVersion: gestaltd.config/v6
+providerSnapshotRepositories:
+  valon:
+    url: https://storage.example.test/providers
+    gestaltRef: 651a5c30feb995c9364c38f63d0d5c3880bc2055
+    publish:
+      pathLayout: sourceRef
+      immutable: true
+      storage:
+        kind: objectStore
+        url: gs://provider-snapshots
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	repo := cfg.ProviderSnapshotRepositories["valon"]
+	if got := repo.Publish.PathLayout; got != "sourceRef" {
+		t.Fatalf("Publish.PathLayout = %q, want sourceRef", got)
+	}
+	if !repo.Publish.Immutable {
+		t.Fatal("Publish.Immutable = false, want true")
+	}
+	if got := repo.Publish.Storage.Kind; got != "objectStore" {
+		t.Fatalf("Publish.Storage.Kind = %q, want objectStore", got)
+	}
+	if got := repo.Publish.Storage.URL; got != "gs://provider-snapshots" {
+		t.Fatalf("Publish.Storage.URL = %q", got)
+	}
+}
+
+func TestLoadConfigProviderSnapshotRepositoryPublishRejectsUnsupportedStorageURL(t *testing.T) {
+	t.Parallel()
+
+	path := mustWriteRawConfigFile(t, `
+apiVersion: gestaltd.config/v6
+providerSnapshotRepositories:
+  valon:
+    url: https://storage.example.test/providers
+    publish:
+      pathLayout: sourceRef
+      immutable: true
+      storage:
+        kind: objectStore
+        url: s3://provider-snapshots
+`)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("Load: expected unsupported storage URL error, got nil")
+	}
+	if !strings.Contains(err.Error(), "publish.storage.url currently supports gs:// object store URLs") {
+		t.Fatalf("Load error = %v", err)
+	}
+}
+
 func TestLoadConfigProviderPackageSourcesDoNotGetBuiltinDefaults(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -238,6 +238,31 @@ func validateProviderSnapshotRepositories(cfg *Config) error {
 		if ref := strings.TrimSpace(repo.GestaltRef); ref != "" && !isFullGitSHA(ref) {
 			return fmt.Errorf("config validation: providerSnapshotRepositories.%s.gestaltRef must be a 40-character commit SHA", name)
 		}
+		if err := validateProviderSnapshotRepositoryPublish(name, repo.Publish); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateProviderSnapshotRepositoryPublish(name string, publish ProviderSnapshotRepositoryPublishConfig) error {
+	if publish.PathLayout == "" && !publish.Immutable && publish.Storage.Kind == "" && publish.Storage.URL == "" {
+		return nil
+	}
+	if strings.TrimSpace(publish.PathLayout) != "sourceRef" {
+		return fmt.Errorf("config validation: providerSnapshotRepositories.%s.publish.pathLayout must be sourceRef", name)
+	}
+	if !publish.Immutable {
+		return fmt.Errorf("config validation: providerSnapshotRepositories.%s.publish.immutable must be true", name)
+	}
+	if strings.TrimSpace(publish.Storage.Kind) != "objectStore" {
+		return fmt.Errorf("config validation: providerSnapshotRepositories.%s.publish.storage.kind must be objectStore", name)
+	}
+	if strings.TrimSpace(publish.Storage.URL) == "" {
+		return fmt.Errorf("config validation: providerSnapshotRepositories.%s.publish.storage.url is required", name)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(publish.Storage.URL), "gs://") {
+		return fmt.Errorf("config validation: providerSnapshotRepositories.%s.publish.storage.url currently supports gs:// object store URLs", name)
 	}
 	return nil
 }

--- a/gestaltd/internal/daemon/provider.go
+++ b/gestaltd/internal/daemon/provider.go
@@ -27,6 +27,8 @@ func runProvider(args []string) error {
 		return runProviderList(args[1:])
 	case "package":
 		return runProviderPackage(args[1:])
+	case "publish":
+		return runProviderPublish(args[1:])
 	case "remove":
 		return runProviderRemove(args[1:])
 	case "repo":
@@ -54,6 +56,7 @@ func printProviderUsage(w io.Writer) {
 	writeUsageLine(w, "  info        Show provider package metadata from configured repositories")
 	writeUsageLine(w, "  list        List configured providers and lock status")
 	writeUsageLine(w, "  package     Build provider release archives")
+	writeUsageLine(w, "  publish     Publish provider release artifacts")
 	writeUsageLine(w, "  release     Finalize provider release metadata from archives")
 	writeUsageLine(w, "  remove      Remove a provider entry from config and update lock state")
 	writeUsageLine(w, "  repo        Manage provider package repositories")

--- a/gestaltd/internal/daemon/provider_publish.go
+++ b/gestaltd/internal/daemon/provider_publish.go
@@ -1,0 +1,528 @@
+package daemon
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/operator"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/apps/providerpkg"
+	"github.com/valon-technologies/gestalt/server/services/apps/source"
+)
+
+const providerPublishPlanSchema = "gestaltd.provider.publish.plan.v1"
+const providerPublishFileKindArchive = "archive"
+const providerPublishFileKindChecksums = "checksums"
+const providerPublishFileKindMetadata = "metadata"
+const providerPublishFormatText = "text"
+const providerPublishFormatJSON = "json"
+
+var fullGitSHARe = regexp.MustCompile(`^[0-9a-fA-F]{40}$`)
+
+type providerPublishSourceRefInfo = operator.SnapshotSourceRefPath
+
+type providerPublishDistDirs []string
+
+func (d *providerPublishDistDirs) String() string {
+	return strings.Join(*d, ",")
+}
+
+func (d *providerPublishDistDirs) Set(value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fmt.Errorf("--dist-dir requires a value")
+	}
+	*d = append(*d, value)
+	return nil
+}
+
+type providerPublishFile struct {
+	Kind       string `json:"kind"`
+	Target     string `json:"target,omitempty"`
+	LocalPath  string `json:"localPath"`
+	StorageURL string `json:"storageUrl"`
+	PublicURL  string `json:"publicUrl"`
+	SHA256     string `json:"sha256"`
+}
+
+type providerPublishPlan struct {
+	Schema            string                `json:"schema"`
+	PublishRepository string                `json:"publishRepository"`
+	SourceRepository  string                `json:"sourceRepository"`
+	SourceRef         string                `json:"sourceRef"`
+	ProviderDir       string                `json:"providerDir"`
+	ManifestPath      string                `json:"manifestPath"`
+	Version           string                `json:"version"`
+	Metadata          providerPublishFile   `json:"metadata"`
+	Checksums         providerPublishFile   `json:"checksums"`
+	Artifacts         []providerPublishFile `json:"artifacts"`
+	Files             []providerPublishFile `json:"files"`
+}
+
+func runProviderPublish(args []string) (err error) {
+	fs := flag.NewFlagSet("gestaltd provider publish", flag.ContinueOnError)
+	fs.Usage = func() { printProviderPublishUsage(fs.Output()) }
+	repoName := fs.String("repo", "", "provider snapshot repository name")
+	manifestPath := fs.String("manifest", "", "source manifest path")
+	version := fs.String("version", "", "semantic version guard")
+	ref := fs.String("ref", "", "full source commit SHA")
+	dryRun := fs.Bool("dry-run", false, "print the publish plan without uploading")
+	format := fs.String("format", providerPublishFormatText, "dry-run output format: text or json")
+	var distDirs providerPublishDistDirs
+	var configPaths repeatedStringFlag
+	fs.Var(&distDirs, "dist-dir", "directory containing release archives (repeatable)")
+	fs.Var(&configPaths, "config", "path to config file (repeat to layer overrides)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() > 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	if strings.TrimSpace(*repoName) == "" {
+		return fmt.Errorf("--repo is required")
+	}
+	if err := validateProviderPublishFormat(*format, *dryRun); err != nil {
+		return err
+	}
+	if strings.TrimSpace(*manifestPath) == "" {
+		return fmt.Errorf("--manifest is required")
+	}
+	if len(distDirs) == 0 {
+		return fmt.Errorf("--dist-dir is required")
+	}
+	if strings.TrimSpace(*version) == "" {
+		return fmt.Errorf("--version is required")
+	}
+	if err := source.ValidateVersion(*version); err != nil {
+		return fmt.Errorf("invalid --version: %w", err)
+	}
+	sourceRef := strings.ToLower(strings.TrimSpace(*ref))
+	if !fullGitSHARe.MatchString(sourceRef) {
+		return fmt.Errorf("--ref must be a 40-character commit SHA")
+	}
+
+	cfg, err := config.LoadAllowMissingEnvPaths(operator.ResolveConfigPaths(configPaths))
+	if err != nil {
+		return err
+	}
+	repo, err := providerPublishRepository(cfg, *repoName)
+	if err != nil {
+		return err
+	}
+	_, sourceManifest, err := providerpkg.ReadSourceManifestFile(*manifestPath)
+	if err != nil {
+		return fmt.Errorf("read --manifest: %w", err)
+	}
+	releaseManifest, releaseVersion, releaseArchives, err := collectReleaseArchivesFromDirs([]string(distDirs), *version)
+	if err != nil {
+		return err
+	}
+	if err := validateProviderPublishManifest(sourceManifest, releaseManifest, releaseVersion, *version); err != nil {
+		return err
+	}
+
+	tmpDir, err := os.MkdirTemp("", "gestalt-provider-publish-*")
+	if err != nil {
+		return fmt.Errorf("create publish temp dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+	if err := writeChecksumsQuiet(tmpDir, releaseArchives); err != nil {
+		return fmt.Errorf("write checksums: %w", err)
+	}
+	if err := writeProviderReleaseMetadataQuiet(tmpDir, releaseManifest, releaseVersion, releaseArchives); err != nil {
+		return fmt.Errorf("write release metadata: %w", err)
+	}
+
+	files, sourceInfo, err := providerPublishFiles(repo, *manifestPath, sourceRef, releaseArchives, tmpDir)
+	if err != nil {
+		return err
+	}
+	if *dryRun {
+		if *format == providerPublishFormatJSON {
+			return printProviderPublishPlanJSON(*repoName, sourceInfo, *version, files)
+		}
+		printProviderPublishPlan(files)
+		return nil
+	}
+	existingFiles, err := preflightProviderPublishFiles(files)
+	if err != nil {
+		return err
+	}
+	return uploadProviderPublishFiles(files, sourceRef, existingFiles)
+}
+
+func validateProviderPublishFormat(format string, dryRun bool) error {
+	switch strings.TrimSpace(format) {
+	case providerPublishFormatText:
+		return nil
+	case providerPublishFormatJSON:
+		if !dryRun {
+			return fmt.Errorf("--format json requires --dry-run")
+		}
+		return nil
+	default:
+		return fmt.Errorf("--format must be %q or %q", providerPublishFormatText, providerPublishFormatJSON)
+	}
+}
+
+func providerPublishRepository(cfg *config.Config, name string) (config.ProviderSnapshotRepositoryConfig, error) {
+	if cfg == nil {
+		return config.ProviderSnapshotRepositoryConfig{}, fmt.Errorf("config did not load provider snapshot repositories")
+	}
+	repo, ok := cfg.ProviderSnapshotRepositories[strings.TrimSpace(name)]
+	if !ok {
+		return config.ProviderSnapshotRepositoryConfig{}, fmt.Errorf("providerSnapshotRepositories.%s is not configured", name)
+	}
+	publish := repo.Publish
+	if publish.PathLayout == "" && !publish.Immutable && publish.Storage.Kind == "" && publish.Storage.URL == "" {
+		return config.ProviderSnapshotRepositoryConfig{}, fmt.Errorf("providerSnapshotRepositories.%s.publish is required", name)
+	}
+	return repo, nil
+}
+
+func validateProviderPublishManifest(sourceManifest, releaseManifest *providermanifestv1.Manifest, releaseVersion, versionGuard string) error {
+	if sourceManifest == nil {
+		return fmt.Errorf("--manifest is required")
+	}
+	if releaseManifest == nil {
+		return fmt.Errorf("release manifest is required")
+	}
+	if sourceManifest.Source != releaseManifest.Source {
+		return fmt.Errorf("--manifest package %q does not match release package %q", sourceManifest.Source, releaseManifest.Source)
+	}
+	if sourceManifest.Kind != releaseManifest.Kind {
+		return fmt.Errorf("--manifest kind %q does not match release kind %q", sourceManifest.Kind, releaseManifest.Kind)
+	}
+	if releaseVersion != versionGuard {
+		return fmt.Errorf("release version %q does not match --version %q", releaseVersion, versionGuard)
+	}
+	return nil
+}
+
+func providerPublishFiles(repo config.ProviderSnapshotRepositoryConfig, manifestPath, sourceRef string, archives []releaseArchive, metadataDir string) ([]providerPublishFile, providerPublishSourceRefInfo, error) {
+	sourceInfo, err := providerPublishSourceRef(manifestPath, sourceRef)
+	if err != nil {
+		return nil, providerPublishSourceRefInfo{}, err
+	}
+	storageRoot := strings.TrimRight(strings.TrimSpace(repo.Publish.Storage.URL), "/")
+	publicRoot := strings.TrimRight(strings.TrimSpace(repo.URL), "/")
+	if publicRoot == "" {
+		return nil, providerPublishSourceRefInfo{}, fmt.Errorf("provider snapshot repository url is required")
+	}
+
+	sortedArchives := append([]releaseArchive(nil), archives...)
+	sort.Slice(sortedArchives, func(i, j int) bool {
+		return filepath.Base(sortedArchives[i].Path) < filepath.Base(sortedArchives[j].Path)
+	})
+	files := make([]providerPublishFile, 0, len(sortedArchives)+2)
+	for _, archive := range sortedArchives {
+		file, err := newProviderPublishFile(providerPublishFileKindArchive, archive.Target, archive.Path, storageRoot, publicRoot, sourceInfo.RelRoot, filepath.Base(archive.Path))
+		if err != nil {
+			return nil, providerPublishSourceRefInfo{}, err
+		}
+		files = append(files, file)
+	}
+	for _, item := range []struct {
+		kind string
+		name string
+	}{
+		{kind: providerPublishFileKindChecksums, name: "checksums.txt"},
+		{kind: providerPublishFileKindMetadata, name: providerReleaseMetadataFile},
+	} {
+		file, err := newProviderPublishFile(item.kind, "", filepath.Join(metadataDir, item.name), storageRoot, publicRoot, sourceInfo.RelRoot, item.name)
+		if err != nil {
+			return nil, providerPublishSourceRefInfo{}, err
+		}
+		files = append(files, file)
+	}
+	return files, sourceInfo, nil
+}
+
+func providerPublishSourceRef(manifestPath, sourceRef string) (providerPublishSourceRefInfo, error) {
+	absManifestPath, err := filepath.Abs(manifestPath)
+	if err != nil {
+		return providerPublishSourceRefInfo{}, fmt.Errorf("resolve --manifest: %w", err)
+	}
+	if evaluatedManifestPath, err := filepath.EvalSymlinks(absManifestPath); err == nil {
+		absManifestPath = evaluatedManifestPath
+	}
+	manifestDir := filepath.Dir(absManifestPath)
+	rootOut, err := runProviderPublishCommand("git", "-C", manifestDir, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return providerPublishSourceRefInfo{}, fmt.Errorf("resolve git root for --manifest: %w", err)
+	}
+	gitRoot := strings.TrimSpace(rootOut)
+	if absGitRoot, err := filepath.Abs(gitRoot); err == nil {
+		gitRoot = absGitRoot
+	}
+	if evaluatedGitRoot, err := filepath.EvalSymlinks(gitRoot); err == nil {
+		gitRoot = evaluatedGitRoot
+	}
+	relManifestPath, err := filepath.Rel(gitRoot, absManifestPath)
+	if err != nil {
+		return providerPublishSourceRefInfo{}, fmt.Errorf("resolve manifest path relative to git root: %w", err)
+	}
+	if relManifestPath == "." || strings.HasPrefix(relManifestPath, ".."+string(filepath.Separator)) || filepath.IsAbs(relManifestPath) {
+		return providerPublishSourceRefInfo{}, fmt.Errorf("--manifest must be inside the current git checkout")
+	}
+	providerDir := path.Dir(filepath.ToSlash(relManifestPath))
+	if providerDir == "." {
+		providerDir = ""
+	}
+	remoteOut, err := runProviderPublishCommand("git", "-C", gitRoot, "remote", "get-url", "origin")
+	if err != nil {
+		return providerPublishSourceRefInfo{}, fmt.Errorf("resolve git origin for --manifest: %w", err)
+	}
+	sourceInfo, err := operator.NewSnapshotSourceRefPath(strings.TrimSpace(remoteOut), sourceRef, filepath.ToSlash(relManifestPath))
+	if err != nil {
+		return providerPublishSourceRefInfo{}, err
+	}
+	if sourceInfo.ProviderDir != providerDir || sourceInfo.ManifestPath != filepath.ToSlash(relManifestPath) {
+		return providerPublishSourceRefInfo{}, fmt.Errorf("resolved snapshot path does not match --manifest")
+	}
+	return sourceInfo, nil
+}
+
+func newProviderPublishFile(kind, target, localPath, storageRoot, publicRoot, relRoot, filename string) (providerPublishFile, error) {
+	digest, err := sha256File(localPath)
+	if err != nil {
+		return providerPublishFile{}, err
+	}
+	rel := path.Join(relRoot, filename)
+	return providerPublishFile{
+		Kind:       kind,
+		Target:     target,
+		LocalPath:  localPath,
+		StorageURL: storageRoot + "/" + rel,
+		PublicURL:  publicRoot + "/" + rel,
+		SHA256:     digest,
+	}, nil
+}
+
+func sha256File(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("open %s: %w", path, err)
+	}
+	defer func() { _ = file.Close() }()
+	digest := sha256.New()
+	if _, err := io.Copy(digest, file); err != nil {
+		return "", fmt.Errorf("hash %s: %w", path, err)
+	}
+	return hex.EncodeToString(digest.Sum(nil)), nil
+}
+
+func printProviderPublishPlan(files []providerPublishFile) {
+	for _, file := range files {
+		_, _ = fmt.Fprintf(os.Stdout, "dry-run upload %s -> %s sha256=%s\n", file.LocalPath, file.StorageURL, file.SHA256)
+	}
+	if len(files) > 0 {
+		_, _ = fmt.Fprintf(os.Stdout, "provider-release metadata: %s\n", files[len(files)-1].PublicURL)
+	}
+}
+
+func printProviderPublishPlanJSON(publishRepository string, sourceInfo providerPublishSourceRefInfo, version string, files []providerPublishFile) error {
+	plan, err := newProviderPublishPlan(publishRepository, sourceInfo, version, files)
+	if err != nil {
+		return err
+	}
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(plan)
+}
+
+func newProviderPublishPlan(publishRepository string, sourceInfo providerPublishSourceRefInfo, version string, files []providerPublishFile) (providerPublishPlan, error) {
+	plan := providerPublishPlan{
+		Schema:            providerPublishPlanSchema,
+		PublishRepository: publishRepository,
+		SourceRepository:  sourceInfo.SourceRepository,
+		SourceRef:         sourceInfo.SourceRef,
+		ProviderDir:       sourceInfo.ProviderDir,
+		ManifestPath:      sourceInfo.ManifestPath,
+		Version:           version,
+		Artifacts:         []providerPublishFile{},
+		Files:             make([]providerPublishFile, 0, len(files)),
+	}
+	for _, file := range files {
+		plan.Files = append(plan.Files, file)
+		switch file.Kind {
+		case providerPublishFileKindArchive:
+			plan.Artifacts = append(plan.Artifacts, file)
+		case providerPublishFileKindChecksums:
+			plan.Checksums = file
+		case providerPublishFileKindMetadata:
+			plan.Metadata = file
+		}
+	}
+	if plan.Metadata.PublicURL == "" {
+		return providerPublishPlan{}, fmt.Errorf("provider publish plan is missing %s", providerReleaseMetadataFile)
+	}
+	if plan.Checksums.PublicURL == "" {
+		return providerPublishPlan{}, fmt.Errorf("provider publish plan is missing checksums.txt")
+	}
+	return plan, nil
+}
+
+func preflightProviderPublishFiles(files []providerPublishFile) (map[string]bool, error) {
+	existingFiles := make(map[string]bool, len(files))
+	for _, file := range files {
+		existingSHA, exists, err := providerPublishObjectSHA256(file.StorageURL)
+		if err != nil {
+			return nil, err
+		}
+		if !exists {
+			continue
+		}
+		if existingSHA != file.SHA256 {
+			return nil, fmt.Errorf("%s already exists with different sha256 metadata", file.StorageURL)
+		}
+		existingFiles[file.StorageURL] = true
+	}
+	return existingFiles, nil
+}
+
+func uploadProviderPublishFile(file providerPublishFile, sourceRef string, alreadyExists bool) error {
+	if alreadyExists {
+		_, _ = fmt.Fprintf(os.Stdout, "exists byte-identical %s\n", file.StorageURL)
+		return nil
+	}
+	return uploadProviderPublishFileCreateOnly(file, sourceRef)
+}
+
+func uploadProviderPublishFiles(files []providerPublishFile, sourceRef string, existingFiles map[string]bool) error {
+	for _, kind := range []string{providerPublishFileKindArchive, providerPublishFileKindChecksums, providerPublishFileKindMetadata} {
+		for _, file := range files {
+			if file.Kind != kind {
+				continue
+			}
+			if err := uploadProviderPublishFile(file, sourceRef, existingFiles[file.StorageURL]); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func uploadProviderPublishFileCreateOnly(file providerPublishFile, sourceRef string) error {
+	metadata := fmt.Sprintf("source-ref=%s,sha256=%s", sourceRef, file.SHA256)
+	if _, err := runProviderPublishCommand("gcloud", "storage", "cp", "--if-generation-match=0", "--custom-metadata="+metadata, file.LocalPath, file.StorageURL); err != nil {
+		return acceptProviderPublishUploadRace(file, err)
+	}
+	_, _ = fmt.Fprintf(os.Stdout, "uploaded %s\n", file.StorageURL)
+	return nil
+}
+
+func acceptProviderPublishUploadRace(file providerPublishFile, uploadErr error) error {
+	existingSHA, exists, err := providerPublishObjectSHA256(file.StorageURL)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return uploadErr
+	}
+	if existingSHA == file.SHA256 {
+		_, _ = fmt.Fprintf(os.Stdout, "exists byte-identical %s\n", file.StorageURL)
+		return nil
+	}
+	return fmt.Errorf("%s already exists with different sha256 metadata", file.StorageURL)
+}
+
+func providerPublishObjectSHA256(storageURL string) (string, bool, error) {
+	out, err := runProviderPublishCommand("gcloud", "storage", "objects", "describe", storageURL, "--format=json")
+	if err != nil {
+		if providerPublishObjectNotFound(err) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	var describe struct {
+		Metadata map[string]string `json:"metadata"`
+	}
+	if err := json.Unmarshal([]byte(out), &describe); err != nil {
+		return "", false, fmt.Errorf("parse gcloud describe %s: %w", storageURL, err)
+	}
+	sha := strings.TrimSpace(describe.Metadata["sha256"])
+	if sha == "" {
+		return "", true, fmt.Errorf("%s exists without sha256 custom metadata", storageURL)
+	}
+	return sha, true, nil
+}
+
+func providerPublishObjectNotFound(err error) bool {
+	var cmdErr *providerPublishCommandError
+	if !errors.As(err, &cmdErr) {
+		return false
+	}
+	text := strings.ToLower(cmdErr.Stdout + "\n" + cmdErr.Stderr + "\n" + cmdErr.Err.Error())
+	return strings.Contains(text, "not found") ||
+		strings.Contains(text, "no urls matched") ||
+		strings.Contains(text, "404")
+}
+
+type providerPublishCommandError struct {
+	Name   string
+	Args   []string
+	Err    error
+	Stdout string
+	Stderr string
+}
+
+func (e *providerPublishCommandError) Error() string {
+	return fmt.Sprintf("%s %s failed: %v\n%s%s", e.Name, strings.Join(e.Args, " "), e.Err, e.Stdout, e.Stderr)
+}
+
+func (e *providerPublishCommandError) Unwrap() error {
+	return e.Err
+}
+
+func runProviderPublishCommand(name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", &providerPublishCommandError{
+			Name:   name,
+			Args:   append([]string(nil), args...),
+			Err:    err,
+			Stdout: stdout.String(),
+			Stderr: stderr.String(),
+		}
+	}
+	return stdout.String(), nil
+}
+
+func printProviderPublishUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd provider publish --repo NAME --manifest PATH --version VERSION --ref SHA --dist-dir DIR [--dist-dir DIR...]")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Publish finalized provider release artifacts to a configured artifact repository.")
+	writeUsageLine(w, "Reads .tar.gz archives from each --dist-dir, validates one release bundle,")
+	writeUsageLine(w, "generates checksums.txt and provider-release.yaml, then uploads archives first")
+	writeUsageLine(w, "and provider-release.yaml last. Destination paths use the configured repository")
+	writeUsageLine(w, "publish.pathLayout and the manifest source plus --ref.")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Flags:")
+	writeUsageLine(w, "  --config    Path to config file (repeat to layer overrides)")
+	writeUsageLine(w, "  --dist-dir  Directory containing release archives (repeatable)")
+	writeUsageLine(w, "  --dry-run   Print the upload plan without writing")
+	writeUsageLine(w, "  --format    Dry-run output format: text or json (default: text)")
+	writeUsageLine(w, "  --manifest  Source manifest path")
+	writeUsageLine(w, "  --ref       Full source commit SHA")
+	writeUsageLine(w, "  --repo      providerSnapshotRepositories entry with publish settings")
+	writeUsageLine(w, "  --version   Semantic version guard")
+}

--- a/gestaltd/internal/daemon/provider_publish_test.go
+++ b/gestaltd/internal/daemon/provider_publish_test.go
@@ -1,0 +1,418 @@
+package daemon
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRun_ProviderPublishDryRunPlansSourceRefUploads(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	pluginDir := newUIReleaseFixture(t, rootDir)
+	initProviderPublishGitRepo(t, rootDir, "https://github.com/testowner/apps.git")
+	outputDir := t.TempDir()
+	const version = "0.0.0-snapshot.g651a5c30feb995c9364c38f63d0d5c3880bc2055"
+	const ref = "651a5c30feb995c9364c38f63d0d5c3880bc2055"
+	runProviderPackageCommand(t, pluginDir,
+		"--version", version,
+		"--output", outputDir,
+	)
+	configPath := filepath.Join(t.TempDir(), "gestaltd.yaml")
+	if err := os.WriteFile(configPath, []byte(`
+apiVersion: gestaltd.config/v6
+providerSnapshotRepositories:
+  valon:
+    url: https://storage.example.test/providers
+    publish:
+      pathLayout: sourceRef
+      immutable: true
+      storage:
+        kind: objectStore
+        url: gs://provider-snapshots
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	out, err := runProviderCommandResult(pluginDir,
+		"publish",
+		"--config", configPath,
+		"--repo", "valon",
+		"--manifest", filepath.Join(pluginDir, "manifest.json"),
+		"--version", version,
+		"--ref", ref,
+		"--dist-dir", outputDir,
+		"--dry-run",
+	)
+	if err != nil {
+		t.Fatalf("provider publish failed: %v\n%s", err, out)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"dry-run upload",
+		"gs://provider-snapshots/github.com/testowner/apps/" + ref + "/ui-test/gestalt-app-ui-test_v" + version + ".tar.gz",
+		"provider-release metadata: https://storage.example.test/providers/github.com/testowner/apps/" + ref + "/ui-test/provider-release.yaml",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("provider publish output missing %q\n%s", want, got)
+		}
+	}
+}
+
+func TestRun_ProviderPublishDryRunJSONPlansSourceRefUploads(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	pluginDir := newUIReleaseFixture(t, rootDir)
+	initProviderPublishGitRepo(t, rootDir, "git@github.com:testowner/apps.git")
+	outputDir := t.TempDir()
+	const version = "0.0.0-snapshot.g651a5c30feb995c9364c38f63d0d5c3880bc2055"
+	const ref = "651a5c30feb995c9364c38f63d0d5c3880bc2055"
+	runProviderPackageCommand(t, pluginDir,
+		"--version", version,
+		"--output", outputDir,
+	)
+	configPath := filepath.Join(t.TempDir(), "gestaltd.yaml")
+	if err := os.WriteFile(configPath, []byte(`
+apiVersion: gestaltd.config/v6
+providerSnapshotRepositories:
+  valon:
+    url: https://storage.example.test/providers
+    publish:
+      pathLayout: sourceRef
+      immutable: true
+      storage:
+        kind: objectStore
+        url: gs://provider-snapshots
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	out, err := runProviderCommandResult(pluginDir,
+		"publish",
+		"--config", configPath,
+		"--repo", "valon",
+		"--manifest", filepath.Join(pluginDir, "manifest.json"),
+		"--version", version,
+		"--ref", strings.ToUpper(ref),
+		"--dist-dir", outputDir,
+		"--dry-run",
+		"--format", "json",
+	)
+	if err != nil {
+		t.Fatalf("provider publish failed: %v\n%s", err, out)
+	}
+	var plan providerPublishPlan
+	if err := json.Unmarshal(out, &plan); err != nil {
+		t.Fatalf("dry-run JSON did not parse: %v\n%s", err, out)
+	}
+	if plan.Schema != providerPublishPlanSchema {
+		t.Fatalf("schema = %q, want %q", plan.Schema, providerPublishPlanSchema)
+	}
+	if plan.PublishRepository != "valon" || plan.SourceRepository != "github.com/testowner/apps" || plan.SourceRef != ref || plan.Version != version {
+		t.Fatalf("unexpected plan identity: %#v", plan)
+	}
+	if plan.ProviderDir != "ui-test" || plan.ManifestPath != "ui-test/manifest.json" {
+		t.Fatalf("unexpected source paths: %#v", plan)
+	}
+	if plan.Metadata.PublicURL != "https://storage.example.test/providers/github.com/testowner/apps/"+ref+"/ui-test/provider-release.yaml" {
+		t.Fatalf("metadata public URL = %q", plan.Metadata.PublicURL)
+	}
+	if plan.Checksums.PublicURL != "https://storage.example.test/providers/github.com/testowner/apps/"+ref+"/ui-test/checksums.txt" {
+		t.Fatalf("checksums public URL = %q", plan.Checksums.PublicURL)
+	}
+	if len(plan.Artifacts) != 1 {
+		t.Fatalf("artifacts len = %d, want 1: %#v", len(plan.Artifacts), plan.Artifacts)
+	}
+	artifact := plan.Artifacts[0]
+	if artifact.Kind != providerPublishFileKindArchive || artifact.Target != providerReleaseGenericTarget {
+		t.Fatalf("unexpected artifact identity: %#v", artifact)
+	}
+	if artifact.PublicURL != "https://storage.example.test/providers/github.com/testowner/apps/"+ref+"/ui-test/gestalt-app-ui-test_v"+version+".tar.gz" {
+		t.Fatalf("artifact public URL = %q", artifact.PublicURL)
+	}
+	if len(plan.Files) != 3 {
+		t.Fatalf("files len = %d, want 3: %#v", len(plan.Files), plan.Files)
+	}
+}
+
+func TestRun_ProviderPublishRejectsShortRef(t *testing.T) {
+	t.Parallel()
+
+	pluginDir := newUIReleaseFixture(t, t.TempDir())
+	out, err := runProviderCommandResult(pluginDir,
+		"publish",
+		"--repo", "valon",
+		"--manifest", filepath.Join(pluginDir, "manifest.json"),
+		"--version", "1.0.0",
+		"--ref", "abc123",
+		"--dist-dir", t.TempDir(),
+		"--dry-run",
+	)
+	if err == nil {
+		t.Fatalf("expected provider publish to reject short ref\n%s", out)
+	}
+	if !strings.Contains(string(out), "--ref must be a 40-character commit SHA") {
+		t.Fatalf("unexpected output: %s", out)
+	}
+}
+
+func TestRun_ProviderPublishRejectsJSONFormatWithoutDryRun(t *testing.T) {
+	t.Parallel()
+
+	out, err := runProviderCommandResult(t.TempDir(),
+		"publish",
+		"--repo", "valon",
+		"--format", "json",
+	)
+	if err == nil {
+		t.Fatalf("expected provider publish to reject JSON format without dry-run\n%s", out)
+	}
+	if !strings.Contains(string(out), "--format json requires --dry-run") {
+		t.Fatalf("unexpected output: %s", out)
+	}
+}
+
+func TestRun_ProviderPublishPreflightsConflictsBeforeUploading(t *testing.T) {
+	rootDir := t.TempDir()
+	pluginDir := newUIReleaseFixture(t, rootDir)
+	initProviderPublishGitRepo(t, rootDir, "https://github.com/testowner/apps.git")
+	outputDir := t.TempDir()
+	const version = "0.0.0-snapshot.g651a5c30feb995c9364c38f63d0d5c3880bc2055"
+	const ref = "651a5c30feb995c9364c38f63d0d5c3880bc2055"
+	runProviderPackageCommand(t, pluginDir,
+		"--version", version,
+		"--output", outputDir,
+	)
+	configPath := filepath.Join(t.TempDir(), "gestaltd.yaml")
+	if err := os.WriteFile(configPath, []byte(`
+apiVersion: gestaltd.config/v6
+providerSnapshotRepositories:
+  valon:
+    url: https://storage.example.test/providers
+    publish:
+      pathLayout: sourceRef
+      immutable: true
+      storage:
+        kind: objectStore
+        url: gs://provider-snapshots
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	binDir := t.TempDir()
+	callsPath := filepath.Join(t.TempDir(), "gcloud.calls")
+	fakeGcloud := filepath.Join(binDir, "gcloud")
+	if err := os.WriteFile(fakeGcloud, []byte(`#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${GCLOUD_CALLS}"
+if [ "$1" = "storage" ] && [ "$2" = "objects" ] && [ "$3" = "describe" ]; then
+  case "$4" in
+    *provider-release.yaml)
+      printf '{"metadata":{"sha256":"stale"}}\n'
+      exit 0
+      ;;
+    *)
+      echo "not found" >&2
+      exit 1
+      ;;
+  esac
+fi
+if [ "$1" = "storage" ] && [ "$2" = "cp" ]; then
+  printf 'upload attempted\n' >> "${GCLOUD_CALLS}"
+  exit 0
+fi
+exit 1
+`), 0o755); err != nil {
+		t.Fatalf("write fake gcloud: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GCLOUD_CALLS", callsPath)
+
+	out, err := runProviderCommandResult(pluginDir,
+		"publish",
+		"--config", configPath,
+		"--repo", "valon",
+		"--manifest", filepath.Join(pluginDir, "manifest.json"),
+		"--version", version,
+		"--ref", ref,
+		"--dist-dir", outputDir,
+	)
+	if err == nil {
+		t.Fatalf("expected provider publish to reject stale metadata before upload\n%s", out)
+	}
+	if !strings.Contains(string(out), "provider-release.yaml already exists with different sha256 metadata") {
+		t.Fatalf("unexpected output: %s", out)
+	}
+	calls, err := os.ReadFile(callsPath)
+	if err != nil {
+		t.Fatalf("read fake gcloud calls: %v", err)
+	}
+	if strings.Contains(string(calls), "upload attempted") {
+		t.Fatalf("provider publish attempted upload before preflight completed:\n%s", calls)
+	}
+}
+
+func TestRun_ProviderPublishDoesNotTreatDescribeErrorsAsMissing(t *testing.T) {
+	rootDir := t.TempDir()
+	pluginDir := newUIReleaseFixture(t, rootDir)
+	initProviderPublishGitRepo(t, rootDir, "https://github.com/testowner/apps.git")
+	outputDir := t.TempDir()
+	const version = "0.0.0-snapshot.g651a5c30feb995c9364c38f63d0d5c3880bc2055"
+	const ref = "651a5c30feb995c9364c38f63d0d5c3880bc2055"
+	runProviderPackageCommand(t, pluginDir,
+		"--version", version,
+		"--output", outputDir,
+	)
+	configPath := filepath.Join(t.TempDir(), "gestaltd.yaml")
+	if err := os.WriteFile(configPath, []byte(`
+apiVersion: gestaltd.config/v6
+providerSnapshotRepositories:
+  valon:
+    url: https://storage.example.test/providers
+    publish:
+      pathLayout: sourceRef
+      immutable: true
+      storage:
+        kind: objectStore
+        url: gs://provider-snapshots
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	binDir := t.TempDir()
+	callsPath := filepath.Join(t.TempDir(), "gcloud.calls")
+	fakeGcloud := filepath.Join(binDir, "gcloud")
+	if err := os.WriteFile(fakeGcloud, []byte(`#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${GCLOUD_CALLS}"
+if [ "$1" = "storage" ] && [ "$2" = "objects" ] && [ "$3" = "describe" ]; then
+  echo "permission denied" >&2
+  exit 1
+fi
+if [ "$1" = "storage" ] && [ "$2" = "cp" ]; then
+  printf 'upload attempted\n' >> "${GCLOUD_CALLS}"
+  exit 0
+fi
+exit 1
+`), 0o755); err != nil {
+		t.Fatalf("write fake gcloud: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GCLOUD_CALLS", callsPath)
+
+	out, err := runProviderCommandResult(pluginDir,
+		"publish",
+		"--config", configPath,
+		"--repo", "valon",
+		"--manifest", filepath.Join(pluginDir, "manifest.json"),
+		"--version", version,
+		"--ref", ref,
+		"--dist-dir", outputDir,
+	)
+	if err == nil {
+		t.Fatalf("expected provider publish to reject describe error before upload\n%s", out)
+	}
+	if !strings.Contains(string(out), "permission denied") {
+		t.Fatalf("unexpected output: %s", out)
+	}
+	calls, err := os.ReadFile(callsPath)
+	if err != nil {
+		t.Fatalf("read fake gcloud calls: %v", err)
+	}
+	if strings.Contains(string(calls), "upload attempted") {
+		t.Fatalf("provider publish attempted upload after describe error:\n%s", calls)
+	}
+}
+
+func TestRun_ProviderPublishUploadsArchivesBeforeMetadata(t *testing.T) {
+	rootDir := t.TempDir()
+	pluginDir := newUIReleaseFixture(t, rootDir)
+	initProviderPublishGitRepo(t, rootDir, "https://github.com/testowner/apps.git")
+	outputDir := t.TempDir()
+	const version = "0.0.0-snapshot.g651a5c30feb995c9364c38f63d0d5c3880bc2055"
+	const ref = "651a5c30feb995c9364c38f63d0d5c3880bc2055"
+	runProviderPackageCommand(t, pluginDir,
+		"--version", version,
+		"--output", outputDir,
+	)
+	configPath := filepath.Join(t.TempDir(), "gestaltd.yaml")
+	if err := os.WriteFile(configPath, []byte(`
+apiVersion: gestaltd.config/v6
+providerSnapshotRepositories:
+  valon:
+    url: https://storage.example.test/providers
+    publish:
+      pathLayout: sourceRef
+      immutable: true
+      storage:
+        kind: objectStore
+        url: gs://provider-snapshots
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	binDir := t.TempDir()
+	callsPath := filepath.Join(t.TempDir(), "gcloud.calls")
+	fakeGcloud := filepath.Join(binDir, "gcloud")
+	if err := os.WriteFile(fakeGcloud, []byte(`#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${GCLOUD_CALLS}"
+if [ "$1" = "storage" ] && [ "$2" = "objects" ] && [ "$3" = "describe" ]; then
+  echo "not found" >&2
+  exit 1
+fi
+if [ "$1" = "storage" ] && [ "$2" = "cp" ]; then
+  exit 0
+fi
+exit 1
+`), 0o755); err != nil {
+		t.Fatalf("write fake gcloud: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GCLOUD_CALLS", callsPath)
+
+	out, err := runProviderCommandResult(pluginDir,
+		"publish",
+		"--config", configPath,
+		"--repo", "valon",
+		"--manifest", filepath.Join(pluginDir, "manifest.json"),
+		"--version", version,
+		"--ref", ref,
+		"--dist-dir", outputDir,
+	)
+	if err != nil {
+		t.Fatalf("provider publish failed: %v\n%s", err, out)
+	}
+	calls, err := os.ReadFile(callsPath)
+	if err != nil {
+		t.Fatalf("read fake gcloud calls: %v", err)
+	}
+	got := string(calls)
+	archiveUpload := strings.Index(got, "gestalt-app-ui-test_v"+version+".tar.gz gs://provider-snapshots")
+	checksumUpload := strings.Index(got, "checksums.txt gs://provider-snapshots")
+	metadataUpload := strings.Index(got, "provider-release.yaml gs://provider-snapshots")
+	if archiveUpload < 0 || checksumUpload < 0 || metadataUpload < 0 {
+		t.Fatalf("missing expected upload calls:\n%s", got)
+	}
+	if archiveUpload >= checksumUpload || checksumUpload >= metadataUpload {
+		t.Fatalf("uploads are not phased archive -> checksums -> metadata:\n%s", got)
+	}
+}
+
+func initProviderPublishGitRepo(t *testing.T, dir, remote string) {
+	t.Helper()
+
+	for _, args := range [][]string{
+		{"init"},
+		{"remote", "add", "origin", remote},
+	} {
+		out, err := runProviderPublishCommand("git", append([]string{"-C", dir}, args...)...)
+		if err != nil {
+			t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, out)
+		}
+	}
+}

--- a/gestaltd/internal/daemon/provider_release_finalize.go
+++ b/gestaltd/internal/daemon/provider_release_finalize.go
@@ -50,6 +50,14 @@ func runProviderRelease(args []string) (err error) {
 }
 
 func writeChecksums(dir string, archives []releaseArchive) error {
+	return writeChecksumsWithOutput(dir, archives, true)
+}
+
+func writeChecksumsQuiet(dir string, archives []releaseArchive) error {
+	return writeChecksumsWithOutput(dir, archives, false)
+}
+
+func writeChecksumsWithOutput(dir string, archives []releaseArchive, verbose bool) error {
 	sortedArchives := append([]releaseArchive(nil), archives...)
 	sort.Slice(sortedArchives, func(i, j int) bool {
 		return filepath.Base(sortedArchives[i].Path) < filepath.Base(sortedArchives[j].Path)
@@ -68,7 +76,9 @@ func writeChecksums(dir string, archives []releaseArchive) error {
 	if err := os.WriteFile(checksumPath, []byte(content), 0644); err != nil {
 		return err
 	}
-	_, _ = fmt.Fprintf(os.Stdout, "created %s\n", checksumPath)
+	if verbose {
+		_, _ = fmt.Fprintf(os.Stdout, "created %s\n", checksumPath)
+	}
 	return nil
 }
 
@@ -85,9 +95,29 @@ func describeReleaseArchive(path, target string) (releaseArchive, error) {
 }
 
 func collectReleaseArchives(distDir, versionGuard string) (*providermanifestv1.Manifest, string, []releaseArchive, error) {
+	return collectReleaseArchivesFromDirs([]string{distDir}, versionGuard)
+}
+
+func collectReleaseArchivesFromDirs(distDirs []string, versionGuard string) (*providermanifestv1.Manifest, string, []releaseArchive, error) {
+	var archivePaths []string
+	for _, distDir := range distDirs {
+		paths, err := releaseArchivePathsInDir(distDir)
+		if err != nil {
+			return nil, "", nil, err
+		}
+		archivePaths = append(archivePaths, paths...)
+	}
+	sort.Strings(archivePaths)
+	if len(archivePaths) == 0 {
+		return nil, "", nil, fmt.Errorf("no .tar.gz release archives found in %s", strings.Join(distDirs, ", "))
+	}
+	return collectReleaseArchivePaths(archivePaths, versionGuard)
+}
+
+func releaseArchivePathsInDir(distDir string) ([]string, error) {
 	entries, err := os.ReadDir(distDir)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("read dist dir: %w", err)
+		return nil, fmt.Errorf("read dist dir %s: %w", distDir, err)
 	}
 	var archivePaths []string
 	for _, entry := range entries {
@@ -96,18 +126,23 @@ func collectReleaseArchives(distDir, versionGuard string) (*providermanifestv1.M
 		}
 		archivePaths = append(archivePaths, filepath.Join(distDir, entry.Name()))
 	}
-	sort.Strings(archivePaths)
-	if len(archivePaths) == 0 {
-		return nil, "", nil, fmt.Errorf("no .tar.gz release archives found in %s", distDir)
-	}
+	return archivePaths, nil
+}
 
+func collectReleaseArchivePaths(archivePaths []string, versionGuard string) (*providermanifestv1.Manifest, string, []releaseArchive, error) {
 	var releaseManifest *providermanifestv1.Manifest
 	var comparableReleaseManifest []byte
 	releaseVersion := ""
+	seenArchiveNames := map[string]string{}
 	seenTargets := map[string]string{}
 	var hasGeneric, hasPlatform bool
 	archives := make([]releaseArchive, 0, len(archivePaths))
 	for _, archivePath := range archivePaths {
+		archiveName := filepath.Base(archivePath)
+		if existingPath, ok := seenArchiveNames[archiveName]; ok {
+			return nil, "", nil, fmt.Errorf("multiple release archives have filename %s: %s and %s", archiveName, existingPath, archivePath)
+		}
+		seenArchiveNames[archiveName] = archivePath
 		manifest, target, err := inspectReleaseArchive(archivePath)
 		if err != nil {
 			return nil, "", nil, err
@@ -211,6 +246,14 @@ func releaseArchiveTargetFromManifest(manifest *providermanifestv1.Manifest) (st
 }
 
 func writeProviderReleaseMetadata(dir string, manifest *providermanifestv1.Manifest, version string, archives []releaseArchive) error {
+	return writeProviderReleaseMetadataWithOutput(dir, manifest, version, archives, true)
+}
+
+func writeProviderReleaseMetadataQuiet(dir string, manifest *providermanifestv1.Manifest, version string, archives []releaseArchive) error {
+	return writeProviderReleaseMetadataWithOutput(dir, manifest, version, archives, false)
+}
+
+func writeProviderReleaseMetadataWithOutput(dir string, manifest *providermanifestv1.Manifest, version string, archives []releaseArchive, verbose bool) error {
 	metadata, err := buildProviderReleaseMetadata(manifest, version, archives)
 	if err != nil {
 		return err
@@ -223,7 +266,9 @@ func writeProviderReleaseMetadata(dir string, manifest *providermanifestv1.Manif
 	if err := os.WriteFile(path, data, 0o644); err != nil {
 		return err
 	}
-	_, _ = fmt.Fprintf(os.Stdout, "created %s\n", path)
+	if verbose {
+		_, _ = fmt.Fprintf(os.Stdout, "created %s\n", path)
+	}
 	return nil
 }
 

--- a/gestaltd/internal/daemon/provider_release_finalize_test.go
+++ b/gestaltd/internal/daemon/provider_release_finalize_test.go
@@ -69,6 +69,35 @@ func TestRun_ProviderReleaseRejectsDuplicateArchiveTargets(t *testing.T) {
 	}
 }
 
+func TestCollectReleaseArchivesRejectsDuplicateArchiveFilenamesAcrossDirs(t *testing.T) {
+	t.Parallel()
+
+	pluginDir := newUIReleaseFixture(t, t.TempDir())
+	leftDir := t.TempDir()
+	rightDir := t.TempDir()
+	const testVersion = "0.0.4-duplicate-name.1"
+	runProviderPackageCommand(t, pluginDir,
+		"--version", testVersion,
+		"--output", leftDir,
+	)
+	archiveName := "gestalt-app-" + uiTestAppName + "_v" + testVersion + ".tar.gz"
+	data, err := os.ReadFile(filepath.Join(leftDir, archiveName))
+	if err != nil {
+		t.Fatalf("read archive: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rightDir, archiveName), data, 0o644); err != nil {
+		t.Fatalf("write duplicate archive: %v", err)
+	}
+
+	_, _, _, err = collectReleaseArchivesFromDirs([]string{leftDir, rightDir}, testVersion)
+	if err == nil {
+		t.Fatal("collectReleaseArchivesFromDirs: expected duplicate filename error")
+	}
+	if !strings.Contains(err.Error(), "multiple release archives have filename") {
+		t.Fatalf("collectReleaseArchivesFromDirs error = %v", err)
+	}
+}
+
 func TestRun_ProviderReleaseRejectsMismatchedArchiveManifests(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/operator/git_source.go
+++ b/gestaltd/internal/operator/git_source.go
@@ -28,6 +28,46 @@ type gitSnapshotSource struct {
 	GestaltRef  string
 }
 
+type SnapshotSourceRefPath struct {
+	RelRoot          string
+	SourceRepository string
+	SourceRef        string
+	ProviderDir      string
+	ManifestPath     string
+}
+
+func NewSnapshotSourceRefPath(repoURL, ref, manifestPath string) (SnapshotSourceRefPath, error) {
+	host, owner, name, err := githubRepoPath(repoURL)
+	if err != nil {
+		return SnapshotSourceRefPath{}, err
+	}
+	sourceRef := strings.ToLower(strings.TrimSpace(ref))
+	manifestPath = path.Clean(filepath.ToSlash(strings.TrimSpace(manifestPath)))
+	if manifestPath == "" || manifestPath == "." || strings.HasPrefix(manifestPath, "../") || path.IsAbs(manifestPath) {
+		return SnapshotSourceRefPath{}, fmt.Errorf("source.git.path must be a clean relative path")
+	}
+	providerDir := path.Dir(manifestPath)
+	if providerDir == "." {
+		providerDir = ""
+	}
+	sourceRepository := path.Join(host, owner, name)
+	parts := []string{sourceRepository, sourceRef}
+	if providerDir != "" {
+		parts = append(parts, strings.Split(providerDir, "/")...)
+	}
+	return SnapshotSourceRefPath{
+		RelRoot:          path.Join(parts...),
+		SourceRepository: sourceRepository,
+		SourceRef:        sourceRef,
+		ProviderDir:      providerDir,
+		ManifestPath:     manifestPath,
+	}, nil
+}
+
+func (p SnapshotSourceRefPath) FileRelPath(filename string) string {
+	return path.Join(p.RelRoot, filename)
+}
+
 func gitSourceDef(entry *config.ProviderEntry) *config.GitSourceDef {
 	if entry == nil {
 		return nil
@@ -111,41 +151,40 @@ func resolveGitSnapshotSource(cfg *config.Config, entry *config.ProviderEntry) (
 	if !ok {
 		return gitSnapshotSource{}, fmt.Errorf("providerSnapshotRepositories.%s is not configured", repoName)
 	}
-	owner, name, err := githubRepoPath(git.Repo)
+	base := strings.TrimRight(strings.TrimSpace(repo.URL), "/")
+	_, ref, manifestPath := git.NormalizedLocationParts()
+	snapshotPath, err := NewSnapshotSourceRefPath(git.Repo, ref, manifestPath)
 	if err != nil {
 		return gitSnapshotSource{}, err
 	}
-	base := strings.TrimRight(strings.TrimSpace(repo.URL), "/")
-	_, ref, manifestPath := git.NormalizedLocationParts()
-	providerDir := path.Dir(manifestPath)
-	if providerDir == "." {
-		providerDir = ""
-	}
-	parts := []string{base, "github.com", owner, name, ref}
-	if providerDir != "" {
-		parts = append(parts, strings.Split(providerDir, "/")...)
-	}
-	parts = append(parts, "provider-release.yaml")
 	return gitSnapshotSource{
-		MetadataURL: strings.Join(parts, "/"),
+		MetadataURL: base + "/" + snapshotPath.FileRelPath("provider-release.yaml"),
 		GestaltRef:  strings.TrimSpace(repo.GestaltRef),
 	}, nil
 }
 
-func githubRepoPath(raw string) (string, string, error) {
+func githubRepoPath(raw string) (string, string, string, error) {
+	raw = strings.TrimSpace(raw)
+	const sshPrefix = "git@github.com:"
+	if strings.HasPrefix(raw, sshPrefix) {
+		owner, repo, ok := strings.Cut(strings.TrimPrefix(raw, sshPrefix), "/")
+		if ok && owner != "" && repo != "" {
+			return "github.com", owner, strings.TrimSuffix(repo, ".git"), nil
+		}
+	}
 	parsed, err := url.Parse(strings.TrimSpace(raw))
 	if err != nil {
-		return "", "", fmt.Errorf("parse source.git.repo: %w", err)
+		return "", "", "", fmt.Errorf("parse source.git.repo: %w", err)
 	}
 	if parsed.Scheme != "https" || !strings.EqualFold(parsed.Host, "github.com") {
-		return "", "", fmt.Errorf("source.git snapshots require https://github.com/<owner>/<repo>[.git]")
+		return "", "", "", fmt.Errorf("source.git snapshots require https://github.com/<owner>/<repo>[.git]")
 	}
 	clean := strings.Trim(path.Clean(parsed.Path), "/")
 	parts := strings.Split(clean, "/")
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return "", "", fmt.Errorf("source.git snapshots require https://github.com/<owner>/<repo>[.git]")
+		return "", "", "", fmt.Errorf("source.git snapshots require https://github.com/<owner>/<repo>[.git]")
 	}
-	return parts[0], strings.TrimSuffix(parts[1], ".git"), nil
+	return "github.com", parts[0], strings.TrimSuffix(parts[1], ".git"), nil
 }
 
 func (l *Lifecycle) gitSourceManifestPath(ctx context.Context, paths lifecyclePaths, entry *config.ProviderEntry) (string, error) {
@@ -248,7 +287,6 @@ func (l *Lifecycle) lockGitSnapshotSource(ctx context.Context, cfg *config.Confi
 	}
 	metadataProvider := *app
 	metadataProvider.Source = config.NewMetadataSource(snapshot.MetadataURL)
-	metadataProvider.Source.Auth = app.Source.Auth
 	installed, entry, err := l.installMetadataSourcePackage(ctx, expectedKind, name, subject, destDir, &metadataProvider, paths.configDir)
 	if err != nil {
 		return LockEntry{}, nil, fmt.Errorf("%s source.git snapshot %s: %w", subject, snapshot.MetadataURL, err)

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -4475,7 +4475,7 @@ func (l *Lifecycle) installLockedArchiveForStaticValidation(ctx context.Context,
 	if archive.SHA256 == "" && archiveReferenceNeedsIntegrityHash(archiveLocation) {
 		return nil, nil, fmt.Errorf("no verified hash for platform %s for %s %q; run `%s --platform %s`", platform, kind, name, formatLockCommand(paths), platform)
 	}
-	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), sourceAuthToken(provider), archiveLocation)
+	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), lockedReleaseArchiveAuthToken(provider), archiveLocation)
 	if err != nil {
 		return nil, nil, staticArchiveUnavailableError{
 			err: fmt.Errorf("download locked source provider for %s %q: %w", kind, name, err),
@@ -5333,7 +5333,7 @@ func (l *Lifecycle) materializeLockedProvider(ctx context.Context, paths lifecyc
 	if archive.SHA256 == "" && archiveReferenceNeedsIntegrityHash(archiveLocation) {
 		return fmt.Errorf("no verified hash for platform %s for provider %q; run `%s --platform %s`", platform, name, formatLockCommand(paths), platform)
 	}
-	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), sourceAuthToken(app), archiveLocation)
+	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), lockedReleaseArchiveAuthToken(app), archiveLocation)
 	if err != nil {
 		return fmt.Errorf("download locked source provider for provider %q: %w", name, err)
 	}
@@ -5389,7 +5389,7 @@ func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths lifecy
 	if archive.SHA256 == "" && archiveReferenceNeedsIntegrityHash(archiveLocation) {
 		return fmt.Errorf("no verified hash for platform %s for %s %q; run `%s --platform %s`", platform, kind, name, formatLockCommand(paths), platform)
 	}
-	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), sourceAuthToken(app), archiveLocation)
+	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), lockedReleaseArchiveAuthToken(app), archiveLocation)
 	if err != nil {
 		return fmt.Errorf("download locked source provider for %s %q: %w", kind, name, err)
 	}
@@ -5450,7 +5450,7 @@ func (l *Lifecycle) materializeLockedUIProvider(ctx context.Context, paths lifec
 	if archive.SHA256 == "" && archiveReferenceNeedsIntegrityHash(archiveLocation) {
 		return fmt.Errorf("no verified hash for platform %s for ui provider; run `%s --platform %s`", platform, formatLockCommand(paths), platform)
 	}
-	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), sourceAuthToken(app), archiveLocation)
+	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), lockedReleaseArchiveAuthToken(app), archiveLocation)
 	if err != nil {
 		return fmt.Errorf("download locked source for ui provider: %w", err)
 	}

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -1280,10 +1280,32 @@ func TestLifecycleGitSourceSnapshotRequireContract(t *testing.T) {
 	}
 	var metadataCount atomic.Int64
 	var archiveCount atomic.Int64
+	handlerErrs := make(chan error, 2)
+	nextHandlerErr := func() error {
+		t.Helper()
+		select {
+		case err := <-handlerErrs:
+			return err
+		default:
+			return nil
+		}
+	}
+	rejectAuth := func(w http.ResponseWriter, r *http.Request, subject string) bool {
+		t.Helper()
+		if got := r.Header.Get("Authorization"); got != "" {
+			handlerErrs <- fmt.Errorf("%s authorization = %q, want empty", subject, got)
+			http.Error(w, "unexpected authorization", http.StatusBadRequest)
+			return false
+		}
+		return true
+	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/snapshots/github.com/acme/providers/" + ref + "/apps/alpha/provider-release.yaml":
 			metadataCount.Add(1)
+			if !rejectAuth(w, r, "metadata") {
+				return
+			}
 			metadata := providerReleaseMetadata{
 				Schema:        providerReleaseSchemaName,
 				SchemaVersion: providerReleaseSchemaVersion,
@@ -1305,6 +1327,9 @@ func TestLifecycleGitSourceSnapshotRequireContract(t *testing.T) {
 			_, _ = w.Write(data)
 		case "/snapshots/github.com/acme/providers/" + ref + "/apps/alpha/alpha.tar.gz":
 			archiveCount.Add(1)
+			if !rejectAuth(w, r, "archive") {
+				return
+			}
 			_, _ = w.Write(archiveData)
 		default:
 			http.NotFound(w, r)
@@ -1335,6 +1360,8 @@ apps:
         path: apps/alpha/manifest.yaml
         artifactRepository: valon
         materialization: snapshot
+      auth:
+        token: git-source-token
 `, srv.URL, gestaltRef, requiredComponentConfigYAML(t, dir, filepath.Join(dir, "snapshot.db")), filepath.ToSlash(artifactsDir), ref)
 	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
@@ -1342,7 +1369,13 @@ apps:
 
 	lock, err := NewLifecycle().WithHTTPClient(srv.Client()).LockAtPathsWithStatePaths([]string{configPath}, StatePaths{})
 	if err != nil {
+		if handlerErr := nextHandlerErr(); handlerErr != nil {
+			t.Fatal(handlerErr)
+		}
 		t.Fatalf("LockAtPathsWithStatePaths: %v", err)
+	}
+	if handlerErr := nextHandlerErr(); handlerErr != nil {
+		t.Fatal(handlerErr)
 	}
 	entry := lock.Providers["alpha"]
 	if entry.SourceRef == nil {
@@ -1365,6 +1398,31 @@ apps:
 	}
 	if got := archiveCount.Load(); got != 1 {
 		t.Fatalf("archive count = %d, want 1", got)
+	}
+
+	if err := WriteLockfile(filepath.Join(dir, LockfileName), lock); err != nil {
+		t.Fatalf("WriteLockfile: %v", err)
+	}
+	appRoot := filepath.Join(artifactsDir, filepath.FromSlash(PreparedProvidersDir), "alpha")
+	if err := os.RemoveAll(appRoot); err != nil {
+		t.Fatalf("RemoveAll app root: %v", err)
+	}
+	metadataBefore := metadataCount.Load()
+	archiveBefore := archiveCount.Load()
+	if err := NewLifecycle().WithHTTPClient(srv.Client()).SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
+		if handlerErr := nextHandlerErr(); handlerErr != nil {
+			t.Fatal(handlerErr)
+		}
+		t.Fatalf("SyncAtPathsWithStatePaths: %v", err)
+	}
+	if handlerErr := nextHandlerErr(); handlerErr != nil {
+		t.Fatal(handlerErr)
+	}
+	if got := metadataCount.Load(); got != metadataBefore {
+		t.Fatalf("metadata count after locked sync = %d, want %d", got, metadataBefore)
+	}
+	if got := archiveCount.Load(); got != archiveBefore+1 {
+		t.Fatalf("archive count after locked sync = %d, want %d", got, archiveBefore+1)
 	}
 }
 

--- a/gestaltd/internal/operator/release_metadata.go
+++ b/gestaltd/internal/operator/release_metadata.go
@@ -81,6 +81,13 @@ func sourceAuthToken(entry *config.ProviderEntry) string {
 	return strings.TrimSpace(entry.Source.Auth.Token)
 }
 
+func lockedReleaseArchiveAuthToken(entry *config.ProviderEntry) string {
+	if entry == nil || entry.Source.IsGit() {
+		return ""
+	}
+	return sourceAuthToken(entry)
+}
+
 func decodeProviderReleaseMetadata(data []byte) (*providerReleaseMetadata, error) {
 	var metadata providerReleaseMetadata
 	decoder := yaml.NewDecoder(bytes.NewReader(data))

--- a/gestaltd/internal/operator/release_metadata_test.go
+++ b/gestaltd/internal/operator/release_metadata_test.go
@@ -1,0 +1,30 @@
+package operator
+
+import (
+	"testing"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+func TestDecodeProviderReleaseMetadataNormalizesLegacyPluginKind(t *testing.T) {
+	t.Parallel()
+
+	metadata, err := decodeProviderReleaseMetadata([]byte(`
+schema: gestaltd-provider-release
+schemaVersion: 1
+package: github.com/valon-technologies/token-pile/tokenpile
+kind: plugin
+version: 0.2.2
+runtime: executable
+artifacts:
+  linux/amd64:
+    path: token-pile_linux_amd64.tar.gz
+    sha256: abc123
+`))
+	if err != nil {
+		t.Fatalf("decodeProviderReleaseMetadata: %v", err)
+	}
+	if metadata.Kind != providermanifestv1.KindApp {
+		t.Fatalf("Kind = %q, want %q", metadata.Kind, providermanifestv1.KindApp)
+	}
+}

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -38,6 +38,8 @@ func NormalizeKind(kind string) string {
 		return KindAuthentication
 	case KindApp:
 		return KindApp
+	case "plugin":
+		return KindApp
 	case KindAuthorization:
 		return KindAuthorization
 	case KindIndexedDB:

--- a/gestaltd/sdk/providermanifest/v1/types_test.go
+++ b/gestaltd/sdk/providermanifest/v1/types_test.go
@@ -1,0 +1,11 @@
+package providermanifestv1
+
+import "testing"
+
+func TestNormalizeKindMapsLegacyPluginToApp(t *testing.T) {
+	t.Parallel()
+
+	if got := NormalizeKind("plugin"); got != KindApp {
+		t.Fatalf("NormalizeKind(\"plugin\") = %q, want %q", got, KindApp)
+	}
+}


### PR DESCRIPTION
## Interface

This adds configured artifact publishing to the provider CLI:

```sh
gestaltd provider publish \
  --config gestaltd.yaml \
  --repo valon \
  --manifest manifest.yaml \
  --version 0.0.0-snapshot.g<source-sha> \
  --ref <source-sha> \
  --dist-dir dist/linux \
  --dist-dir dist/darwin
```

The command validates one release bundle assembled from one or more dist directories, writes release metadata in a temporary location, and publishes archives, checksums, and `provider-release.yaml` to the configured repository path.

CI can ask Gestalt for the exact upload contract without publishing:

```sh
gestaltd provider publish \
  --config gestaltd.yaml \
  --repo valon \
  --manifest manifest.yaml \
  --version 0.0.0-snapshot.g<source-sha> \
  --ref <source-sha> \
  --dist-dir dist/linux \
  --dry-run \
  --format json
```

The JSON dry-run output uses schema `gestaltd.provider.publish.plan.v1` and includes `publishRepository`, `sourceRepository`, `sourceRef`, `providerDir`, `manifestPath`, `version`, `metadata`, `checksums`, `artifacts`, and `files`.

## Behavior

`provider publish` uses `providerSnapshotRepositories.<name>.publish` from config. The initial supported repository shape is immutable object-store publishing with `pathLayout: sourceRef`, which keeps storage details in config instead of requiring CI to construct repository-specific URLs.

Publish now uses the same source-ref path helper as `source.git` snapshot materialization, so the uploaded `provider-release.yaml` path is the same path the deploy resolver reads later. It also trusts config-load validation for publish repository shape instead of revalidating the same fields in the CLI layer.

Before uploading, publish preflights every planned destination by reading object metadata and comparing the planned SHA256 with the object's `sha256` custom metadata. Missing objects proceed to upload, byte-identical existing objects are accepted, and non-not-found describe errors fail before any upload is attempted. Upload order is explicit: archives first, checksums second, metadata last.

## Validation

The focused provider publish tests cover text dry-run output, pure JSON dry-run output, source-ref URL planning, uppercase ref normalization, invalid refs, invalid JSON format usage, conflict preflight before upload, describe permission errors, and archive/checksum/metadata upload order. I also ran the relevant operator/config tests and built `gestaltd` locally.
