### PR TITLE
Accept legacy plugin kind in provider manifests

### DIFF
--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -38,6 +38,8 @@ func NormalizeKind(kind string) string {
 		return KindAuthentication
 	case KindApp:
 		return KindApp
+	case "plugin":
+		return KindApp
 	case KindAuthorization:
 		return KindAuthorization
 	case KindIndexedDB:


### PR DESCRIPTION
Provider release metadata may still declare `kind: plugin` while repositories and deploy configs finish the rename to apps. This normalizes that legacy kind to the app kind so older tarball manifests keep loading through the cutover without requiring every published artifact to be rebuilt first.


Made with [Cursor](https://cursor.com)