### PR TITLE
Migrate authz dynamic fragments to app schema

### DIFF
--- a/gestaltd/internal/coredata/authz_dynamic_fragments_migration.go
+++ b/gestaltd/internal/coredata/authz_dynamic_fragments_migration.go
@@ -1,0 +1,184 @@
+package coredata
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	legacyAuthorizationFragmentOwnerKindPlugin = "plugin"
+	legacyAuthorizationFragmentScopePlugin     = "plugin"
+	legacyProviderResourceTypePluginDynamic    = "plugin_dynamic"
+	providerResourceTypeAppDynamic             = "app_dynamic"
+)
+
+var legacyAuthorizationDynamicFragmentsPluginSchema = indexeddb.ObjectStoreSchema{
+	Indexes: []indexeddb.IndexSchema{
+		{Name: "by_owner", KeyPath: []string{"owner_kind", "owner_id"}, Unique: true},
+		{Name: "by_scope", KeyPath: []string{"scope"}},
+		{Name: "by_plugin", KeyPath: []string{"plugin"}},
+		{Name: "by_status", KeyPath: []string{"status"}},
+	},
+	Columns: []indexeddb.ColumnDef{
+		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
+		{Name: "owner_kind", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "owner_id", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "scope", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "plugin", Type: indexeddb.TypeString},
+		{Name: "version", Type: indexeddb.TypeInt},
+		{Name: "status", Type: indexeddb.TypeString},
+		{Name: "resource_types_json", Type: indexeddb.TypeString},
+		{Name: "relationships_json", Type: indexeddb.TypeString},
+		{Name: "audit_json", Type: indexeddb.TypeString},
+		{Name: "created_at", Type: indexeddb.TypeTime},
+		{Name: "updated_at", Type: indexeddb.TypeTime},
+	},
+}
+
+func ensureAuthorizationDynamicFragmentsStore(ctx context.Context, ds indexeddb.IndexedDB) error {
+	if err := ds.CreateObjectStore(ctx, StoreAuthorizationDynamicFragments, AuthorizationDynamicFragmentsSchema); err != nil {
+		if status.Code(err) != codes.FailedPrecondition {
+			return err
+		}
+		if legacyErr := ds.CreateObjectStore(ctx, StoreAuthorizationDynamicFragments, legacyAuthorizationDynamicFragmentsPluginSchema); legacyErr != nil {
+			return err
+		}
+		if err := migrateAuthorizationDynamicFragmentsPluginSchema(ctx, ds); err != nil {
+			return fmt.Errorf("migrate authz_dynamic_fragments plugin schema: %w", err)
+		}
+	}
+	return nil
+}
+
+func migrateAuthorizationDynamicFragmentsPluginSchema(ctx context.Context, ds indexeddb.IndexedDB) error {
+	store := ds.ObjectStore(StoreAuthorizationDynamicFragments)
+	records, err := store.GetAll(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("read legacy records: %w", err)
+	}
+	migrated := make([]indexeddb.Record, 0, len(records))
+	for _, record := range records {
+		next, err := migrateAuthorizationDynamicFragmentPluginRecord(record)
+		if err != nil {
+			return err
+		}
+		migrated = append(migrated, next)
+	}
+
+	if err := ds.DeleteObjectStore(ctx, StoreAuthorizationDynamicFragments); err != nil {
+		return fmt.Errorf("delete legacy store: %w", err)
+	}
+	if err := ds.CreateObjectStore(ctx, StoreAuthorizationDynamicFragments, AuthorizationDynamicFragmentsSchema); err != nil {
+		return fmt.Errorf("create app schema store: %w", err)
+	}
+	store = ds.ObjectStore(StoreAuthorizationDynamicFragments)
+	for _, record := range migrated {
+		if err := store.Add(ctx, record); err != nil {
+			return fmt.Errorf("write migrated record %q: %w", recString(record, "id"), err)
+		}
+	}
+	return nil
+}
+
+func migrateAuthorizationDynamicFragmentPluginRecord(record indexeddb.Record) (indexeddb.Record, error) {
+	next := make(indexeddb.Record, len(record)+1)
+	for key, value := range record {
+		next[key] = value
+	}
+
+	ownerKind := recString(next, "owner_kind")
+	ownerID := recString(next, "owner_id")
+	plugin := recString(next, "plugin")
+	if plugin == "" && ownerKind == legacyAuthorizationFragmentOwnerKindPlugin {
+		plugin = ownerID
+	}
+	if ownerKind == legacyAuthorizationFragmentOwnerKindPlugin {
+		next["owner_kind"] = AuthorizationFragmentOwnerKindApp
+	}
+	if recString(next, "scope") == legacyAuthorizationFragmentScopePlugin {
+		next["scope"] = AuthorizationFragmentScopeApp
+	}
+	if plugin != "" {
+		next["app"] = plugin
+	}
+	if id := recString(next, "id"); strings.HasPrefix(id, "plugin/") {
+		next["id"] = "app/" + strings.TrimPrefix(id, "plugin/")
+	} else if ownerKind == legacyAuthorizationFragmentOwnerKindPlugin && ownerID != "" {
+		next["id"] = "app/" + ownerID
+	}
+	delete(next, "plugin")
+
+	resourceTypesJSON, err := migrateAuthorizationFragmentResourceTypesJSON(recString(next, "resource_types_json"))
+	if err != nil {
+		return nil, err
+	}
+	next["resource_types_json"] = resourceTypesJSON
+	relationshipsJSON, err := migrateAuthorizationFragmentRelationshipsJSON(recString(next, "relationships_json"))
+	if err != nil {
+		return nil, err
+	}
+	next["relationships_json"] = relationshipsJSON
+	return next, nil
+}
+
+func migrateAuthorizationFragmentResourceTypesJSON(raw string) (string, error) {
+	if strings.TrimSpace(raw) == "" {
+		return raw, nil
+	}
+	var resourceTypes map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &resourceTypes); err != nil {
+		return "", fmt.Errorf("decode legacy resource types: %w", err)
+	}
+	if value, ok := resourceTypes[legacyProviderResourceTypePluginDynamic]; ok {
+		delete(resourceTypes, legacyProviderResourceTypePluginDynamic)
+		resourceTypes[providerResourceTypeAppDynamic] = value
+	}
+	data, err := json.Marshal(resourceTypes)
+	if err != nil {
+		return "", fmt.Errorf("encode migrated resource types: %w", err)
+	}
+	return string(data), nil
+}
+
+func migrateAuthorizationFragmentRelationshipsJSON(raw string) (string, error) {
+	if strings.TrimSpace(raw) == "" {
+		return raw, nil
+	}
+	var relationships []AuthorizationDynamicFragmentRelationship
+	if err := json.Unmarshal([]byte(raw), &relationships); err != nil {
+		return "", fmt.Errorf("decode legacy relationships: %w", err)
+	}
+	for i := range relationships {
+		migrateAuthorizationFragmentRelationshipResource(&relationships[i].Resource)
+		migrateAuthorizationFragmentRelationshipTarget(&relationships[i].Target)
+	}
+	data, err := json.Marshal(relationships)
+	if err != nil {
+		return "", fmt.Errorf("encode migrated relationships: %w", err)
+	}
+	return string(data), nil
+}
+
+func migrateAuthorizationFragmentRelationshipTarget(target *AuthorizationDynamicFragmentTarget) {
+	if target == nil {
+		return
+	}
+	if target.Resource != nil {
+		migrateAuthorizationFragmentRelationshipResource(target.Resource)
+	}
+	if target.SubjectSet != nil {
+		migrateAuthorizationFragmentRelationshipResource(&target.SubjectSet.Resource)
+	}
+}
+
+func migrateAuthorizationFragmentRelationshipResource(resource *AuthorizationDynamicFragmentResource) {
+	if resource != nil && resource.Type == legacyProviderResourceTypePluginDynamic {
+		resource.Type = providerResourceTypeAppDynamic
+	}
+}

--- a/gestaltd/internal/coredata/authz_dynamic_fragments_migration_test.go
+++ b/gestaltd/internal/coredata/authz_dynamic_fragments_migration_test.go
@@ -1,0 +1,145 @@
+package coredata
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type strictSchemaIndexedDB struct {
+	inner   indexeddb.IndexedDB
+	schemas map[string]indexeddb.ObjectStoreSchema
+}
+
+func newStrictSchemaIndexedDB(inner indexeddb.IndexedDB) *strictSchemaIndexedDB {
+	return &strictSchemaIndexedDB{
+		inner:   inner,
+		schemas: map[string]indexeddb.ObjectStoreSchema{},
+	}
+}
+
+func (d *strictSchemaIndexedDB) ObjectStore(name string) indexeddb.ObjectStore {
+	return d.inner.ObjectStore(name)
+}
+
+func (d *strictSchemaIndexedDB) Transaction(ctx context.Context, stores []string, mode indexeddb.TransactionMode, opts indexeddb.TransactionOptions) (indexeddb.Transaction, error) {
+	return d.inner.Transaction(ctx, stores, mode, opts)
+}
+
+func (d *strictSchemaIndexedDB) CreateObjectStore(ctx context.Context, name string, schema indexeddb.ObjectStoreSchema) error {
+	if existing, ok := d.schemas[name]; ok {
+		if reflect.DeepEqual(existing, schema) {
+			return nil
+		}
+		return status.Errorf(codes.FailedPrecondition, "object store %q schema does not match", name)
+	}
+	d.schemas[name] = schema
+	return d.inner.CreateObjectStore(ctx, name, schema)
+}
+
+func (d *strictSchemaIndexedDB) DeleteObjectStore(ctx context.Context, name string) error {
+	delete(d.schemas, name)
+	return d.inner.DeleteObjectStore(ctx, name)
+}
+
+func (d *strictSchemaIndexedDB) Ping(ctx context.Context) error {
+	return d.inner.Ping(ctx)
+}
+
+func (d *strictSchemaIndexedDB) Close() error {
+	return d.inner.Close()
+}
+
+func (d *strictSchemaIndexedDB) schema(name string) indexeddb.ObjectStoreSchema {
+	return d.schemas[name]
+}
+
+func TestNewMigratesLegacyAuthorizationDynamicFragmentsPluginSchema(t *testing.T) {
+	ctx := context.Background()
+	db := newStrictSchemaIndexedDB(&coretesting.StubIndexedDB{})
+	if err := db.CreateObjectStore(ctx, StoreAuthorizationDynamicFragments, legacyAuthorizationDynamicFragmentsPluginSchema); err != nil {
+		t.Fatalf("CreateObjectStore(legacy): %v", err)
+	}
+
+	now := time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)
+	relationshipsJSON, err := json.Marshal([]AuthorizationDynamicFragmentRelationship{{
+		Subject:  AuthorizationDynamicFragmentSubject{Type: "subject", ID: "user:alice"},
+		Relation: "admin",
+		Resource: AuthorizationDynamicFragmentResource{Type: legacyProviderResourceTypePluginDynamic, ID: "github"},
+		Target: AuthorizationDynamicFragmentTarget{
+			Resource: &AuthorizationDynamicFragmentResource{Type: legacyProviderResourceTypePluginDynamic, ID: "github"},
+		},
+	}})
+	if err != nil {
+		t.Fatalf("Marshal relationships: %v", err)
+	}
+	if err := db.ObjectStore(StoreAuthorizationDynamicFragments).Add(ctx, indexeddb.Record{
+		"id":                  "plugin/github",
+		"owner_kind":          legacyAuthorizationFragmentOwnerKindPlugin,
+		"owner_id":            "github",
+		"scope":               legacyAuthorizationFragmentScopePlugin,
+		"plugin":              "github",
+		"version":             int64(2),
+		"status":              AuthorizationFragmentStatusActive,
+		"resource_types_json": `{"plugin_dynamic":{"relations":{"admin":{"subjectTypes":["subject"]}}}}`,
+		"relationships_json":  string(relationshipsJSON),
+		"audit_json":          `{"reason":"legacy"}`,
+		"created_at":          now,
+		"updated_at":          now,
+	}); err != nil {
+		t.Fatalf("Add legacy fragment: %v", err)
+	}
+
+	svc, err := NewWithContext(ctx, db)
+	if err != nil {
+		t.Fatalf("NewWithContext: %v", err)
+	}
+	if got := db.schema(StoreAuthorizationDynamicFragments); !reflect.DeepEqual(got, AuthorizationDynamicFragmentsSchema) {
+		t.Fatalf("authz_dynamic_fragments schema was not migrated")
+	}
+
+	fragment, err := svc.AuthzFragments.GetFragmentByOwner(ctx, AuthorizationAppFragmentOwner("github"))
+	if err != nil {
+		t.Fatalf("GetFragmentByOwner(app github): %v", err)
+	}
+	if fragment.ID != "app/github" || fragment.Owner.Kind != AuthorizationFragmentOwnerKindApp || fragment.Owner.App != "github" || fragment.App != "github" || fragment.Scope != AuthorizationFragmentScopeApp {
+		t.Fatalf("migrated fragment = %+v", fragment)
+	}
+	if len(fragment.Relationships) != 1 {
+		t.Fatalf("relationships len = %d, want 1", len(fragment.Relationships))
+	}
+	if got := fragment.Relationships[0].Resource.Type; got != providerResourceTypeAppDynamic {
+		t.Fatalf("relationship resource type = %q, want %q", got, providerResourceTypeAppDynamic)
+	}
+	if fragment.Relationships[0].Target.Resource == nil || fragment.Relationships[0].Target.Resource.Type != providerResourceTypeAppDynamic {
+		t.Fatalf("relationship target resource = %+v", fragment.Relationships[0].Target.Resource)
+	}
+	if _, ok := fragment.ResourceTypes[providerResourceTypeAppDynamic]; !ok {
+		t.Fatalf("migrated resource types missing %q: %+v", providerResourceTypeAppDynamic, fragment.ResourceTypes)
+	}
+	if _, ok := fragment.ResourceTypes[legacyProviderResourceTypePluginDynamic]; ok {
+		t.Fatalf("migrated resource types still contain %q", legacyProviderResourceTypePluginDynamic)
+	}
+
+	record, err := svc.DB.ObjectStore(StoreAuthorizationDynamicFragments).Get(ctx, "app/github")
+	if err != nil {
+		t.Fatalf("Get(app/github): %v", err)
+	}
+	if _, ok := record["plugin"]; ok {
+		t.Fatalf("migrated record still has legacy plugin field: %+v", record)
+	}
+	if got := record["app"]; got != "github" {
+		t.Fatalf("record app = %v, want github", got)
+	}
+	if _, err := svc.DB.ObjectStore(StoreAuthorizationDynamicFragments).Get(ctx, "plugin/github"); !errors.Is(err, indexeddb.ErrNotFound) {
+		t.Fatalf("Get(plugin/github) error = %v, want ErrNotFound", err)
+	}
+}

--- a/gestaltd/internal/coredata/services.go
+++ b/gestaltd/internal/coredata/services.go
@@ -36,7 +36,7 @@ func NewWithContext(ctx context.Context, ds indexeddb.IndexedDB) (*Services, err
 	if err := ds.CreateObjectStore(ctx, StoreManagedSubjects, ManagedSubjectsSchema); err != nil {
 		return nil, fmt.Errorf("create managed_subjects store: %w", err)
 	}
-	if err := ds.CreateObjectStore(ctx, StoreAuthorizationDynamicFragments, AuthorizationDynamicFragmentsSchema); err != nil {
+	if err := ensureAuthorizationDynamicFragmentsStore(ctx, ds); err != nil {
 		return nil, fmt.Errorf("create authz_dynamic_fragments store: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
- migrate legacy `authz_dynamic_fragments` stores from the plugin schema to the app schema during coredata startup
- rewrite plugin-owned fragment records to app-owned records, including `plugin_dynamic` relationship/resource type references
- keep unknown schema mismatches failing instead of silently changing them

## Testing
- `go test ./internal/coredata`
- `go test ./internal/coredata ./internal/server -run 'TestNewMigratesLegacyAuthorizationDynamicFragmentsPluginSchema|AuthorizationDynamic|AdminAPI_DeletePluginMember|ProviderBackedReload'`\n- `go test ./services/authorization`\n\nContext: Valon Tools post-merge deploy is currently failing because production has the old `authz_dynamic_fragments` plugin schema and the alpha.24 server expects the app schema.