### PR TITLE
[codex] Rename CLI plugin terminology to app

### DIFF
--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -110,7 +110,7 @@ pub enum ConfigCommands {
 
 #[derive(Subcommand)]
 pub enum AppCommands {
-    /// List available plugins
+    /// List available apps
     List,
     /// Connect an app via OAuth or interactive manual auth
     Connect {
@@ -125,7 +125,7 @@ pub enum AppCommands {
         #[arg(long)]
         instance: Option<String>,
     },
-    /// Disconnect a plugin
+    /// Disconnect an app
     Disconnect {
         /// App name (e.g., github, slack)
         name: String,
@@ -478,11 +478,11 @@ pub struct AuthorizationSubjectTokenCreateArgs {
     #[arg(long, conflicts_with_all = ["permission", "action", "permissions_file"])]
     pub scopes: Option<String>,
 
-    /// Operation permission in plugin:operation form
+    /// Operation permission in app:operation form
     #[arg(long = "permission", conflicts_with = "permissions_file")]
     pub permission: Vec<String>,
 
-    /// Action permission in plugin:action form
+    /// Action permission in app:action form
     #[arg(long = "action", conflicts_with = "permissions_file")]
     pub action: Vec<String>,
 
@@ -498,19 +498,19 @@ pub enum AuthorizationAppCommands {
     /// Manage app members
     Members {
         #[command(subcommand)]
-        command: AuthorizationPluginMemberCommands,
+        command: AuthorizationAppMemberCommands,
     },
 }
 
 #[derive(Subcommand)]
-pub enum AuthorizationPluginMemberCommands {
+pub enum AuthorizationAppMemberCommands {
     /// List app members
     List {
         /// App name
         app: String,
     },
     /// Add or update an app member
-    Set(AuthorizationPluginMemberSetArgs),
+    Set(AuthorizationAppMemberSetArgs),
     /// Remove an app member
     Remove {
         /// App name
@@ -521,7 +521,7 @@ pub enum AuthorizationPluginMemberCommands {
 }
 
 #[derive(Args)]
-pub struct AuthorizationPluginMemberSetArgs {
+pub struct AuthorizationAppMemberSetArgs {
     /// App name
     pub app: String,
 
@@ -696,7 +696,7 @@ pub struct AgentArgs {
     #[arg(long = "message")]
     pub messages: Vec<String>,
 
-    /// Add a tool in plugin:operation form to each turn
+    /// Add a tool in app:operation form to each turn
     #[arg(long = "tool", value_parser = AgentToolArg::parse)]
     pub tools: Vec<AgentToolArg>,
 }
@@ -751,7 +751,7 @@ pub struct AgentResumeArgs {
     #[arg(long = "message")]
     pub messages: Vec<String>,
 
-    /// Add a tool in plugin:operation form to each turn
+    /// Add a tool in app:operation form to each turn
     #[arg(long = "tool", value_parser = AgentToolArg::parse)]
     pub tools: Vec<AgentToolArg>,
 }
@@ -1064,7 +1064,7 @@ pub struct AgentTurnCreateArgs {
     #[arg(long = "message")]
     pub messages: Vec<String>,
 
-    /// Add a tool in plugin:operation form
+    /// Add a tool in app:operation form
     #[arg(long = "tool", value_parser = AgentToolArg::parse)]
     pub tools: Vec<AgentToolArg>,
 

--- a/gestalt/cli/src/commands/apps.rs
+++ b/gestalt/cli/src/commands/apps.rs
@@ -56,9 +56,7 @@ pub fn canonical_connection_name(name: &str) -> &str {
 }
 
 pub fn list(client: &ApiClient, format: Format) -> Result<()> {
-    let resp = client
-        .get("/api/v1/apps")
-        .context("failed to list plugins")?;
+    let resp = client.get("/api/v1/apps").context("failed to list apps")?;
 
     match format {
         Format::Json => output::print_json(&resp),
@@ -112,7 +110,7 @@ fn expand_app_group_divider_line(line: &str) -> String {
     )
 }
 
-fn plugin_status(item: &serde_json::Value) -> String {
+fn app_status(item: &serde_json::Value) -> String {
     item["status"]
         .as_str()
         .map(str::to_string)
@@ -120,9 +118,9 @@ fn plugin_status(item: &serde_json::Value) -> String {
 }
 
 fn app_rows(item: &serde_json::Value) -> Vec<Vec<String>> {
-    let mut connections = plugin_connection_rows(item);
+    let mut connections = app_connection_rows(item);
     if connections.is_empty() {
-        connections.push((plugin_status(item), "-".to_string(), "-".to_string()));
+        connections.push((app_status(item), "-".to_string(), "-".to_string()));
     }
 
     connections
@@ -158,7 +156,7 @@ fn app_group_divider_row() -> Vec<String> {
     ]
 }
 
-fn plugin_connection_rows(item: &serde_json::Value) -> Vec<(String, String, String)> {
+fn app_connection_rows(item: &serde_json::Value) -> Vec<(String, String, String)> {
     item["connections"]
         .as_array()
         .map(|connections| connections.iter().flat_map(connection_rows).collect())

--- a/gestalt/cli/src/commands/apps/connect.rs
+++ b/gestalt/cli/src/commands/apps/connect.rs
@@ -326,7 +326,7 @@ fn connect_with_scope_and_browser_opener<F>(
 where
     F: FnOnce(&str) -> Result<()>,
 {
-    let integration = fetch_plugin(client, scope, name)?;
+    let integration = fetch_app(client, scope, name)?;
     let flow = ResolvedConnectFlow::resolve(&integration, connection)?;
 
     match flow.mode {
@@ -442,7 +442,7 @@ fn connect_manual(
                 },
             )
             .map_err(rewrite_connect_api_error)
-            .context("failed to connect plugin")?,
+            .context("failed to connect app")?,
     )
     .context("failed to parse manual connect response")?;
 
@@ -521,21 +521,17 @@ fn complete_pending_selection(
     Ok(())
 }
 
-fn fetch_plugin(
-    client: &ApiClient,
-    scope: ConnectScope<'_>,
-    name: &str,
-) -> Result<IntegrationInfo> {
+fn fetch_app(client: &ApiClient, scope: ConnectScope<'_>, name: &str) -> Result<IntegrationInfo> {
     let apps: Vec<IntegrationInfo> = serde_json::from_value(
         client
             .get(&scope.integrations_path())
-            .context("failed to load plugins")?,
+            .context("failed to load apps")?,
     )
-    .context("failed to parse plugins")?;
+    .context("failed to parse apps")?;
 
     apps.into_iter()
         .find(|app| app.name == name)
-        .with_context(|| format!("plugin '{}' not found", name))
+        .with_context(|| format!("app '{}' not found", name))
 }
 
 fn resolve_connection<'a>(
@@ -598,7 +594,7 @@ fn resolve_connect_mode(integration: &str, auth_types: &[String]) -> Result<Conn
     }
 
     bail!(
-        "plugin '{}' does not expose a supported connection flow in the CLI",
+        "app '{}' does not expose a supported connection flow in the CLI",
         integration
     );
 }
@@ -611,7 +607,7 @@ fn validate_user_connectable(
         && let Some("none") = definition.credential_mode.as_deref()
     {
         bail!(
-            "plugin '{}' connection '{}' does not require a user connection",
+            "app '{}' connection '{}' does not require a user connection",
             integration.name,
             definition.display_name()
         );

--- a/gestalt/cli/src/commands/authorization.rs
+++ b/gestalt/cli/src/commands/authorization.rs
@@ -7,8 +7,8 @@ use serde_json::{Map, Value, json};
 use crate::api::{ApiClient, encode_path_segment};
 use crate::cli::{
     AuthorizationAdminCommands, AuthorizationAdminMemberCommands, AuthorizationAppCommands,
-    AuthorizationCommands, AuthorizationManagedSubjectRole, AuthorizationModelCommands,
-    AuthorizationPageArgs, AuthorizationPluginMemberCommands, AuthorizationProviderCommands,
+    AuthorizationAppMemberCommands, AuthorizationCommands, AuthorizationManagedSubjectRole,
+    AuthorizationModelCommands, AuthorizationPageArgs, AuthorizationProviderCommands,
     AuthorizationRelationshipCommands, AuthorizationRelationshipListArgs,
     AuthorizationSubjectCommands, AuthorizationSubjectCreateArgs,
     AuthorizationSubjectExternalIdentityCommands, AuthorizationSubjectGrantCommands,
@@ -129,12 +129,12 @@ pub fn dispatch(client: &ApiClient, command: AuthorizationCommands, format: Form
             },
         },
         AuthorizationCommands::Apps { command } => match command {
-            AuthorizationAppCommands::List => list_plugins(client, format),
+            AuthorizationAppCommands::List => list_apps(client, format),
             AuthorizationAppCommands::Members { command } => match command {
-                AuthorizationPluginMemberCommands::List { app } => {
-                    list_plugin_members(client, &app, format)
+                AuthorizationAppMemberCommands::List { app } => {
+                    list_app_members(client, &app, format)
                 }
-                AuthorizationPluginMemberCommands::Set(args) => set_plugin_member(
+                AuthorizationAppMemberCommands::Set(args) => set_app_member(
                     client,
                     &args.app,
                     args.subject_id.as_deref(),
@@ -142,8 +142,8 @@ pub fn dispatch(client: &ApiClient, command: AuthorizationCommands, format: Form
                     &args.role,
                     format,
                 ),
-                AuthorizationPluginMemberCommands::Remove { app, subject_id } => {
-                    remove_plugin_member(client, &app, &subject_id, format)
+                AuthorizationAppMemberCommands::Remove { app, subject_id } => {
+                    remove_app_member(client, &app, &subject_id, format)
                 }
             },
         },
@@ -305,7 +305,7 @@ pub fn list_subject_grants(client: &ApiClient, subject: &str, format: Format) ->
     print_array_response(
         &resp,
         format,
-        &["Plugin", "Role", "Source", "Mutable"],
+        &["App", "Role", "Source", "Mutable"],
         grant_row,
     )
 }
@@ -313,7 +313,7 @@ pub fn list_subject_grants(client: &ApiClient, subject: &str, format: Format) ->
 pub fn set_subject_grant(
     client: &ApiClient,
     subject: &str,
-    plugin: &str,
+    app: &str,
     role: &str,
     format: Format,
 ) -> Result<()> {
@@ -323,7 +323,7 @@ pub fn set_subject_grant(
             &format!(
                 "{}/grants/{}",
                 subject_path(subject)?,
-                encode_path_segment(plugin)
+                encode_path_segment(app)
             ),
             &json!({ "role": role }),
         )
@@ -334,20 +334,20 @@ pub fn set_subject_grant(
 pub fn remove_subject_grant(
     client: &ApiClient,
     subject: &str,
-    plugin: &str,
+    app: &str,
     format: Format,
 ) -> Result<()> {
     let resp = client
         .delete(&format!(
             "{}/grants/{}",
             subject_path(subject)?,
-            encode_path_segment(plugin)
+            encode_path_segment(app)
         ))
         .context("failed to remove service account grant")?;
     print_status(
         &resp,
         format,
-        &format!("Removed {plugin} grant from {subject}."),
+        &format!("Removed {app} grant from {subject}."),
     )
 }
 
@@ -522,23 +522,23 @@ pub fn revoke_all_subject_tokens(client: &ApiClient, subject: &str, format: Form
     print_status(&resp, format, "Revoked all service account tokens.")
 }
 
-pub fn list_plugins(client: &ApiClient, format: Format) -> Result<()> {
+pub fn list_apps(client: &ApiClient, format: Format) -> Result<()> {
     let resp = client
         .get("/admin/api/v1/authorization/apps")
-        .context("failed to list authorization plugins")?;
+        .context("failed to list authorization apps")?;
     print_array_response(
         &resp,
         format,
         &["Name", "Policy", "Mounted UI"],
-        authorization_plugin_row,
+        authorization_app_row,
     )
 }
 
-pub fn list_plugin_members(client: &ApiClient, plugin: &str, format: Format) -> Result<()> {
+pub fn list_app_members(client: &ApiClient, app: &str, format: Format) -> Result<()> {
     let resp = client
         .get(&format!(
             "/admin/api/v1/authorization/apps/{}/members",
-            encode_path_segment(plugin)
+            encode_path_segment(app)
         ))
         .context("failed to list app members")?;
     print_array_response(
@@ -549,9 +549,9 @@ pub fn list_plugin_members(client: &ApiClient, plugin: &str, format: Format) -> 
     )
 }
 
-pub fn set_plugin_member(
+pub fn set_app_member(
     client: &ApiClient,
-    plugin: &str,
+    app: &str,
     subject_id: Option<&str>,
     email: Option<&str>,
     role: &str,
@@ -563,7 +563,7 @@ pub fn set_plugin_member(
         .put(
             &format!(
                 "/admin/api/v1/authorization/apps/{}/members",
-                encode_path_segment(plugin)
+                encode_path_segment(app)
             ),
             &body,
         )
@@ -571,9 +571,9 @@ pub fn set_plugin_member(
     print_admin_write_response(&resp, format)
 }
 
-pub fn remove_plugin_member(
+pub fn remove_app_member(
     client: &ApiClient,
-    plugin: &str,
+    app: &str,
     subject_id: &str,
     format: Format,
 ) -> Result<()> {
@@ -581,15 +581,11 @@ pub fn remove_plugin_member(
     let resp = client
         .delete(&format!(
             "/admin/api/v1/authorization/apps/{}/members/{}",
-            encode_path_segment(plugin),
+            encode_path_segment(app),
             encode_path_segment(&subject_id)
         ))
         .context("failed to remove app member")?;
-    print_status(
-        &resp,
-        format,
-        &format!("Removed {subject_id} from {plugin}."),
-    )
+    print_status(&resp, format, &format!("Removed {subject_id} from {app}."))
 }
 
 pub fn list_admin_members(client: &ApiClient, format: Format) -> Result<()> {
@@ -847,19 +843,19 @@ fn token_permissions(args: &AuthorizationSubjectTokenCreateArgs) -> Result<Optio
 
     let mut by_app: BTreeMap<String, (Vec<String>, Vec<String>)> = BTreeMap::new();
     for value in &args.permission {
-        let (plugin, operation) = parse_scoped_value(value, "permission")?;
-        by_app.entry(plugin).or_default().0.push(operation);
+        let (app, operation) = parse_scoped_value(value, "permission")?;
+        by_app.entry(app).or_default().0.push(operation);
     }
     for value in &args.action {
-        let (plugin, action) = parse_scoped_value(value, "action")?;
-        by_app.entry(plugin).or_default().1.push(action);
+        let (app, action) = parse_scoped_value(value, "action")?;
+        by_app.entry(app).or_default().1.push(action);
     }
 
     let permissions = by_app
         .into_iter()
-        .map(|(plugin, (operations, actions))| {
+        .map(|(app, (operations, actions))| {
             let mut permission = object();
-            permission.insert("app".to_string(), json!(plugin));
+            permission.insert("app".to_string(), json!(app));
             if !operations.is_empty() {
                 permission.insert("operations".to_string(), json!(operations));
             }
@@ -873,11 +869,11 @@ fn token_permissions(args: &AuthorizationSubjectTokenCreateArgs) -> Result<Optio
 }
 
 fn parse_scoped_value(value: &str, label: &str) -> Result<(String, String)> {
-    let Some((plugin, name)) = value.split_once(':') else {
-        bail!("--{label} must use plugin:name form");
+    let Some((app, name)) = value.split_once(':') else {
+        bail!("--{label} must use app:name form");
     };
     Ok((
-        non_empty("app", plugin)?.to_string(),
+        non_empty("app", app)?.to_string(),
         non_empty(label, name)?.to_string(),
     ))
 }
@@ -984,14 +980,14 @@ fn print_grant_write_response(resp: &Value, format: Format) -> Result<()> {
                 print_single_response(
                     grant,
                     Format::Table,
-                    &["Plugin", "Role", "Source", "Mutable"],
+                    &["App", "Role", "Source", "Mutable"],
                     grant_row,
                 )?;
             } else {
                 print_single_response(
                     resp,
                     Format::Table,
-                    &["Plugin", "Role", "Source", "Mutable"],
+                    &["App", "Role", "Source", "Mutable"],
                     grant_row,
                 )?;
             }
@@ -1114,7 +1110,7 @@ fn permission_cell(item: &Value) -> String {
     }
 }
 
-fn authorization_plugin_row(item: &Value) -> Vec<String> {
+fn authorization_app_row(item: &Value) -> Vec<String> {
     vec![
         string_cell(item, "name"),
         string_cell(item, "authorizationPolicy"),

--- a/gestalt/cli/tests/apps_connect.rs
+++ b/gestalt/cli/tests/apps_connect.rs
@@ -5,12 +5,10 @@ use std::sync::{Arc, Mutex};
 use support::*;
 
 #[test]
-fn test_list_plugins() {
+fn test_list_apps() {
     let mut server = Server::new();
     let mock = authed_json_mock!(server, Method::GET, "/api/v1/apps", StatusCode::OK)
-        .with_body(
-            r#"[{"name":"acme_crm","displayName":"Acme CRM","description":"Acme CRM plugin"}]"#,
-        )
+        .with_body(r#"[{"name":"acme_crm","displayName":"Acme CRM","description":"Acme CRM app"}]"#)
         .create();
 
     let client = create_client(&server);
@@ -145,7 +143,7 @@ fn test_connect_prefers_oauth_when_manual_also_exists_and_omits_null_instance() 
 }
 
 #[test]
-fn test_connect_uses_user_facing_plugin_connection_name_on_the_wire() {
+fn test_connect_uses_user_facing_app_connection_name_on_the_wire() {
     let mut server = Server::new();
     let _integrations = authed_json_mock!(server, Method::GET, "/api/v1/apps", StatusCode::OK)
         .with_body(
@@ -202,7 +200,7 @@ fn test_disconnect_sends_delete_with_connection_and_instance() {
 }
 
 #[test]
-fn test_disconnect_normalizes_plugin_connection_name() {
+fn test_disconnect_normalizes_app_connection_name() {
     let mut server = Server::new();
     let mock = authed_json_mock!(
         server,
@@ -561,7 +559,7 @@ fn test_manual_connect_fails_when_stdin_closes_during_prompt() {
 }
 
 #[test]
-fn test_cli_plugins_list_table_output() {
+fn test_cli_apps_list_table_output() {
     let mut server = Server::new();
     let home = TempDir::new().unwrap();
     write_credentials(

--- a/gestalt/cli/tests/authorization_cli.rs
+++ b/gestalt/cli/tests/authorization_cli.rs
@@ -250,7 +250,7 @@ fn test_cli_authorization_subjects_tokens_list_table_shows_permissions() {
 }
 
 #[test]
-fn test_cli_authorization_plugins_members_set_uses_management_api() {
+fn test_cli_authorization_apps_members_set_uses_management_api() {
     let mut server = Server::new();
     let mock = authed_json_mock!(
         server,

--- a/gestalt/cli/tests/invoke_contract.rs
+++ b/gestalt/cli/tests/invoke_contract.rs
@@ -224,7 +224,7 @@ fn test_list_operations_infers_only_connected_instance_before_catalog_resolution
         .stdout(predicate::str::contains("Connection: prod"))
         .stdout(predicate::str::contains("Instance:   default"))
         .stdout(predicate::str::contains("healthcheck"))
-        .stderr(predicate::str::contains("plugin \"frontPorch\" is not connected").not());
+        .stderr(predicate::str::contains("app \"frontPorch\" is not connected").not());
 
     integrations_mock.assert();
     catalog_mock.assert();
@@ -680,7 +680,7 @@ fn test_invoke_retries_without_catalog_when_preflight_masks_surface_error() {
         .stderr(predicate::str::contains(
             "operation \"api_get_resource\" on integration \"sample_svc\" uses connection \"api-conn\"",
         ))
-        .stderr(predicate::str::contains("plugin \"sample_svc\" is not connected").not());
+        .stderr(predicate::str::contains("app \"sample_svc\" is not connected").not());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Update CLI help, table headers, and user-facing error/context messages from plugin terminology to app terminology.
- Rename authorization app member command types/helpers internally where the old plugin name leaked into the CLI path.
- Add regression coverage that `gestalt help app` stays app-oriented.

## Test plan
- [x] `cargo test`