### PR TITLE
Preserve workflow authority for provider SDK calls

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1843,6 +1843,9 @@ func buildWorkflow(ctx context.Context, name string, entry *config.ProviderEntry
 			proto.RegisterWorkflowHostServer(srv, workflowservice.NewHostServer(name, deps.WorkflowRuntime.Invoke))
 		},
 	}}
+	if deps.AuthorizationProvider != nil {
+		hostServices = append(hostServices, buildPluginAuthorizationHostService(deps.AuthorizationProvider))
+	}
 	var cleanup func()
 	defer func() {
 		if cleanup != nil {

--- a/gestaltd/internal/bootstrap/workflow_startup_test.go
+++ b/gestaltd/internal/bootstrap/workflow_startup_test.go
@@ -169,6 +169,46 @@ func TestBuildWorkflowRegistersExecutableWorkflowHostPublicRelay(t *testing.T) {
 	}
 }
 
+func TestBuildWorkflowPassesAuthorizationHostService(t *testing.T) {
+	t.Parallel()
+
+	var hostServiceNames []string
+	factories := NewFactoryRegistry()
+	factories.Workflow = func(_ context.Context, _ string, _ yaml.Node, hostServices []runtimehost.HostService, _ Deps) (coreworkflow.Provider, error) {
+		for _, hostService := range hostServices {
+			hostServiceNames = append(hostServiceNames, hostService.Name)
+		}
+		return startupTestWorkflowProvider{}, nil
+	}
+	provider, err := buildWorkflow(context.Background(), "local", &config.ProviderEntry{
+		Config: mustNode(t, map[string]any{"command": "/bin/workflow-provider"}),
+	}, factories, Deps{
+		AuthorizationProvider: &hostedHTTPAuthorizationProvider{},
+	})
+	if err != nil {
+		t.Fatalf("buildWorkflow: %v", err)
+	}
+	if err := provider.Close(); err != nil {
+		t.Fatalf("provider.Close: %v", err)
+	}
+
+	if !hasHostServiceName(hostServiceNames, "workflow_host") {
+		t.Fatalf("workflow host services = %v, want workflow_host", hostServiceNames)
+	}
+	if !hasHostServiceName(hostServiceNames, "authorization") {
+		t.Fatalf("workflow host services = %v, want authorization", hostServiceNames)
+	}
+}
+
+func hasHostServiceName(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
 func (noopTelemetryProvider) Logger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(os.Stderr, nil))
 }

--- a/gestaltd/services/appinvoker/app_invoker_test.go
+++ b/gestaltd/services/appinvoker/app_invoker_test.go
@@ -18,6 +18,7 @@ import (
 type recordingAppInvoker struct {
 	idempotencyKey        string
 	internalConnection    bool
+	workflowContext       map[string]any
 	providerName          string
 	instance              string
 	operation             string
@@ -32,11 +33,68 @@ type recordingAppInvoker struct {
 func (i *recordingAppInvoker) Invoke(ctx context.Context, _ *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error) {
 	i.idempotencyKey = invocation.IdempotencyKeyFromContext(ctx)
 	i.internalConnection = invocation.InternalConnectionAccessFromContext(ctx)
+	i.workflowContext = invocation.WorkflowContextFromContext(ctx)
 	i.providerName = providerName
 	i.instance = instance
 	i.operation = operation
 	i.params = params
 	return &core.OperationResult{Status: 202, Body: "accepted"}, nil
+}
+
+func TestAppInvokerServerInvokeRestoresWorkflowContext(t *testing.T) {
+	t.Parallel()
+
+	tokens, err := NewInvocationTokenManager([]byte("plugin-invoker-workflow-context-secret"))
+	if err != nil {
+		t.Fatalf("NewInvocationTokenManager: %v", err)
+	}
+	ctx := principal.WithPrincipal(context.Background(), &principal.Principal{
+		SubjectID: "service_account:workflow",
+		Kind:      principal.Kind("service_account"),
+		Source:    principal.SourceAPIToken,
+	})
+	ctx = invocation.WithWorkflowContext(ctx, map[string]any{
+		"providerName": "temporal",
+		"runId":        "run-123",
+		"step": map[string]any{
+			"id": "notify",
+		},
+	})
+	rootToken, err := tokens.MintRootToken(ctx, "workflow-provider", InvocationGrants{
+		"slack": {Operations: map[string]core.ConnectionMode{"chat.postMessage": ""}},
+	})
+	if err != nil {
+		t.Fatalf("MintRootToken: %v", err)
+	}
+
+	invoker := &recordingAppInvoker{}
+	server := NewAppInvokerServer(
+		"workflow-provider",
+		[]invocation.AppInvocationDependency{{App: "slack", Operation: "chat.postMessage"}},
+		invoker,
+		tokens,
+	)
+	client := proto.NewAppInvokerClient(newBufconnConn(t, func(srv *grpc.Server) {
+		proto.RegisterAppInvokerServer(srv, server)
+	}))
+	if _, err := client.Invoke(context.Background(), &proto.AppInvokeRequest{
+		InvocationToken: rootToken,
+		App:             "slack",
+		Operation:       "chat.postMessage",
+	}); err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+
+	if got := invocation.WorkflowContextString(invoker.workflowContext, "providerName"); got != "temporal" {
+		t.Fatalf("providerName = %q, want temporal", got)
+	}
+	if got := invocation.WorkflowContextString(invoker.workflowContext, "runId"); got != "run-123" {
+		t.Fatalf("runId = %q, want run-123", got)
+	}
+	step := invocation.WorkflowContextMap(invoker.workflowContext, "step")
+	if got := invocation.WorkflowContextString(step, "id"); got != "notify" {
+		t.Fatalf("step.id = %q, want notify", got)
+	}
 }
 
 func TestAppInvokerServerInvokePropagatesInternalConnectionAccess(t *testing.T) {

--- a/gestaltd/services/appinvoker/invocation_token.go
+++ b/gestaltd/services/appinvoker/invocation_token.go
@@ -45,6 +45,7 @@ type invocationTokenClaims struct {
 	TokenPermissions    map[string][]string              `json:"token_permissions,omitempty"`
 	Grants              map[string]invocationGrantClaims `json:"grants,omitempty"`
 	WorkflowGrants      *workflowGrantClaims             `json:"workflow_grants,omitempty"`
+	Workflow            map[string]any                   `json:"workflow,omitempty"`
 	RequestMeta         requestMetaClaims                `json:"request_meta,omitempty"`
 	Credential          credentialClaims                 `json:"credential,omitempty"`
 	Invocation          invocationClaims                 `json:"invocation,omitempty"`
@@ -87,6 +88,7 @@ type invocationTokenContext struct {
 	connection             string
 	grants                 InvocationGrants
 	workflowGrants         workflowgrants.Grants
+	workflow               map[string]any
 }
 
 func NewInvocationTokenManager(secret []byte) (*InvocationTokenManager, error) {
@@ -187,6 +189,7 @@ func (m *InvocationTokenManager) resolveToken(token, appName string) (invocation
 		connection:         strings.TrimSpace(claims.Connection),
 		grants:             decodeInvocationGrantClaims(claims.Grants),
 		workflowGrants:     decodeWorkflowGrantClaims(claims.WorkflowGrants),
+		workflow:           cloneInvocationTokenMap(claims.Workflow),
 	}, nil
 }
 
@@ -303,6 +306,7 @@ func claimsFromContext(ctx context.Context, appName string, grants InvocationGra
 		TokenPermissions:    encodePermissionSet(tokenPermissionsForInvocationClaims(p)),
 		Grants:              encodeInvocationGrantClaims(grants),
 		WorkflowGrants:      encodeWorkflowGrantClaims(workflowGrants),
+		Workflow:            cloneInvocationTokenMap(invocation.WorkflowContextFromContext(ctx)),
 		RequestMeta: requestMetaClaims{
 			ClientIP:   reqMeta.ClientIP,
 			RemoteAddr: reqMeta.RemoteAddr,
@@ -372,6 +376,9 @@ func restoreInvocationTokenContext(ctx context.Context, tokenCtx invocationToken
 	if tokenCtx.internalConnection {
 		ctx = invocation.WithInternalConnectionAccess(ctx)
 	}
+	if tokenCtx.workflow != nil {
+		ctx = invocation.WithWorkflowContext(ctx, cloneInvocationTokenMap(tokenCtx.workflow))
+	}
 
 	connection := strings.TrimSpace(connectionOverride)
 	if connection == "" {
@@ -384,6 +391,39 @@ func restoreInvocationTokenContext(ctx context.Context, tokenCtx invocationToken
 		ctx = invocation.WithConnection(ctx, connection)
 	}
 	return ctx
+}
+
+func cloneInvocationTokenMap(src map[string]any) map[string]any {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(src))
+	for key, value := range src {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		out[key] = cloneInvocationTokenValue(value)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func cloneInvocationTokenValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		return cloneInvocationTokenMap(typed)
+	case []any:
+		out := make([]any, len(typed))
+		for i := range typed {
+			out[i] = cloneInvocationTokenValue(typed[i])
+		}
+		return out
+	default:
+		return typed
+	}
 }
 
 func RestoreTokenContext(ctx context.Context, tokenCtx TokenContext, connectionOverride string) context.Context {

--- a/gestaltd/services/appinvoker/invocation_token_test.go
+++ b/gestaltd/services/appinvoker/invocation_token_test.go
@@ -234,6 +234,114 @@ func TestInvocationTokenResolvePreservesEmailOnlyPrincipals(t *testing.T) {
 	}
 }
 
+func TestInvocationTokenRestoresWorkflowContext(t *testing.T) {
+	t.Parallel()
+
+	manager, err := NewInvocationTokenManager([]byte("invocation-token-workflow-context-secret"))
+	if err != nil {
+		t.Fatalf("NewInvocationTokenManager: %v", err)
+	}
+
+	ctx := principal.WithPrincipal(
+		context.Background(),
+		&principal.Principal{
+			SubjectID: "user:test-user",
+			UserID:    "test-user",
+			Kind:      principal.KindUser,
+			Source:    principal.SourceSession,
+		},
+	)
+	ctx = invocation.WithWorkflowContext(ctx, map[string]any{
+		"providerName":       "temporal",
+		"runId":              "run-123",
+		"definitionId":       "def-123",
+		"definitionRevision": "7",
+		"activationId":       "webhook",
+		"step": map[string]any{
+			"id": "notify",
+		},
+	})
+	token, err := manager.MintRootToken(ctx, "caller", InvocationGrants{
+		"slack": {Operations: map[string]core.ConnectionMode{"chat.postMessage": ""}},
+	})
+	if err != nil {
+		t.Fatalf("MintRootToken: %v", err)
+	}
+
+	tokenCtx, err := manager.ResolveToken(token, "caller")
+	if err != nil {
+		t.Fatalf("ResolveToken: %v", err)
+	}
+	restored := RestoreTokenContext(context.Background(), tokenCtx, "")
+	workflow := invocation.WorkflowContextFromContext(restored)
+	if got := invocation.WorkflowContextString(workflow, "providerName"); got != "temporal" {
+		t.Fatalf("providerName = %q, want temporal", got)
+	}
+	if got := invocation.WorkflowContextString(workflow, "runId"); got != "run-123" {
+		t.Fatalf("runId = %q, want run-123", got)
+	}
+	step := invocation.WorkflowContextMap(workflow, "step")
+	if got := invocation.WorkflowContextString(step, "id"); got != "notify" {
+		t.Fatalf("step.id = %q, want notify", got)
+	}
+}
+
+func TestInvocationTokenExchangePreservesWorkflowContext(t *testing.T) {
+	t.Parallel()
+
+	manager, err := NewInvocationTokenManager([]byte("invocation-token-workflow-context-exchange-secret"))
+	if err != nil {
+		t.Fatalf("NewInvocationTokenManager: %v", err)
+	}
+
+	ctx := principal.WithPrincipal(
+		context.Background(),
+		&principal.Principal{
+			SubjectID: "user:test-user",
+			UserID:    "test-user",
+			Kind:      principal.KindUser,
+			Source:    principal.SourceSession,
+		},
+	)
+	ctx = invocation.WithWorkflowContext(ctx, map[string]any{
+		"providerName": "temporal",
+		"runId":        "run-123",
+		"step": map[string]any{
+			"id": "notify",
+		},
+	})
+	rootToken, err := manager.MintRootToken(ctx, "caller", InvocationGrants{
+		"slack":  {Operations: map[string]core.ConnectionMode{"chat.postMessage": ""}},
+		"github": {Operations: map[string]core.ConnectionMode{"issues.create": ""}},
+	})
+	if err != nil {
+		t.Fatalf("MintRootToken: %v", err)
+	}
+	childToken, err := manager.ExchangeToken(rootToken, "caller", InvocationGrants{
+		"slack": {Operations: map[string]core.ConnectionMode{"chat.postMessage": ""}},
+	}, time.Minute)
+	if err != nil {
+		t.Fatalf("ExchangeToken: %v", err)
+	}
+
+	tokenCtx, err := manager.ResolveToken(childToken, "caller")
+	if err != nil {
+		t.Fatalf("ResolveToken(child): %v", err)
+	}
+	restored := RestoreTokenContext(context.Background(), tokenCtx, "")
+	workflow := invocation.WorkflowContextFromContext(restored)
+	if got := invocation.WorkflowContextString(workflow, "providerName"); got != "temporal" {
+		t.Fatalf("providerName = %q, want temporal", got)
+	}
+	if got := invocation.WorkflowContextString(workflow, "runId"); got != "run-123" {
+		t.Fatalf("runId = %q, want run-123", got)
+	}
+	step := invocation.WorkflowContextMap(workflow, "step")
+	if got := invocation.WorkflowContextString(step, "id"); got != "notify" {
+		t.Fatalf("step.id = %q, want notify", got)
+	}
+}
+
 func TestDecodeInvocationGrantClaimsIgnoresModesForUndeclaredOperations(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/go/serve_workflow.go
+++ b/sdk/go/serve_workflow.go
@@ -2,6 +2,7 @@ package gestalt
 
 import (
 	"context"
+	"strings"
 
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"google.golang.org/grpc"
@@ -22,6 +23,7 @@ type workflowProviderServer struct {
 }
 
 func (s workflowProviderServer) CreateDefinition(ctx context.Context, req *proto.CreateWorkflowProviderDefinitionRequest) (*proto.BoundWorkflowDefinition, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	definition, err := s.provider.CreateDefinition(ctx, createWorkflowProviderDefinitionRequestFromProto(req))
 	if err != nil {
 		return nil, providerRPCError("workflow create definition", err)
@@ -31,6 +33,7 @@ func (s workflowProviderServer) CreateDefinition(ctx context.Context, req *proto
 }
 
 func (s workflowProviderServer) GetDefinition(ctx context.Context, req *proto.GetWorkflowProviderDefinitionRequest) (*proto.BoundWorkflowDefinition, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	definition, err := s.provider.GetDefinition(ctx, &GetWorkflowProviderDefinitionRequest{DefinitionID: req.GetDefinitionId()})
 	if err != nil {
 		return nil, providerRPCError("workflow get definition", err)
@@ -40,6 +43,7 @@ func (s workflowProviderServer) GetDefinition(ctx context.Context, req *proto.Ge
 }
 
 func (s workflowProviderServer) UpdateDefinition(ctx context.Context, req *proto.UpdateWorkflowProviderDefinitionRequest) (*proto.BoundWorkflowDefinition, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	definition, err := s.provider.UpdateDefinition(ctx, updateWorkflowProviderDefinitionRequestFromProto(req))
 	if err != nil {
 		return nil, providerRPCError("workflow update definition", err)
@@ -49,10 +53,12 @@ func (s workflowProviderServer) UpdateDefinition(ctx context.Context, req *proto
 }
 
 func (s workflowProviderServer) DeleteDefinition(ctx context.Context, req *proto.DeleteWorkflowProviderDefinitionRequest) (*emptypb.Empty, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	return &emptypb.Empty{}, providerRPCError("workflow delete definition", s.provider.DeleteDefinition(ctx, &DeleteWorkflowProviderDefinitionRequest{DefinitionID: req.GetDefinitionId()}))
 }
 
 func (s workflowProviderServer) StartRun(ctx context.Context, req *proto.StartWorkflowProviderRunRequest) (*proto.BoundWorkflowRun, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	run, err := s.provider.StartRun(ctx, startWorkflowProviderRunRequestFromProto(req))
 	if err != nil {
 		return nil, providerRPCError("workflow start run", err)
@@ -62,6 +68,7 @@ func (s workflowProviderServer) StartRun(ctx context.Context, req *proto.StartWo
 }
 
 func (s workflowProviderServer) GetRun(ctx context.Context, req *proto.GetWorkflowProviderRunRequest) (*proto.BoundWorkflowRun, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	run, err := s.provider.GetRun(ctx, &GetWorkflowProviderRunRequest{RunID: req.GetRunId()})
 	if err != nil {
 		return nil, providerRPCError("workflow get run", err)
@@ -71,10 +78,11 @@ func (s workflowProviderServer) GetRun(ctx context.Context, req *proto.GetWorkfl
 }
 
 func (s workflowProviderServer) ListRuns(ctx context.Context, req *proto.ListWorkflowProviderRunsRequest) (*proto.ListWorkflowProviderRunsResponse, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	resp, err := s.provider.ListRuns(ctx, &ListWorkflowProviderRunsRequest{
-		PageSize:     int(req.GetPageSize()),
-		PageToken:    req.GetPageToken(),
-		Status:       WorkflowRunStatus(req.GetStatus()),
+		PageSize:  int(req.GetPageSize()),
+		PageToken: req.GetPageToken(),
+		Status:    WorkflowRunStatus(req.GetStatus()),
 		TargetApp: req.GetTargetApp(),
 	})
 	if err != nil {
@@ -91,6 +99,7 @@ func (s workflowProviderServer) ListRuns(ctx context.Context, req *proto.ListWor
 }
 
 func (s workflowProviderServer) CancelRun(ctx context.Context, req *proto.CancelWorkflowProviderRunRequest) (*proto.BoundWorkflowRun, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	run, err := s.provider.CancelRun(ctx, &CancelWorkflowProviderRunRequest{RunID: req.GetRunId(), Reason: req.GetReason()})
 	if err != nil {
 		return nil, providerRPCError("workflow cancel run", err)
@@ -100,6 +109,7 @@ func (s workflowProviderServer) CancelRun(ctx context.Context, req *proto.Cancel
 }
 
 func (s workflowProviderServer) SignalRun(ctx context.Context, req *proto.SignalWorkflowProviderRunRequest) (*proto.SignalWorkflowRunResponse, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	resp, err := s.provider.SignalRun(ctx, signalWorkflowProviderRunRequestFromProto(req))
 	if err != nil {
 		return nil, providerRPCError("workflow signal run", err)
@@ -109,6 +119,7 @@ func (s workflowProviderServer) SignalRun(ctx context.Context, req *proto.Signal
 }
 
 func (s workflowProviderServer) SignalOrStartRun(ctx context.Context, req *proto.SignalOrStartWorkflowProviderRunRequest) (*proto.SignalWorkflowRunResponse, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	resp, err := s.provider.SignalOrStartRun(ctx, signalOrStartWorkflowProviderRunRequestFromProto(req))
 	if err != nil {
 		return nil, providerRPCError("workflow signal or start run", err)
@@ -118,6 +129,7 @@ func (s workflowProviderServer) SignalOrStartRun(ctx context.Context, req *proto
 }
 
 func (s workflowProviderServer) UpsertSchedule(ctx context.Context, req *proto.UpsertWorkflowProviderScheduleRequest) (*proto.BoundWorkflowSchedule, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	schedule, err := s.provider.UpsertSchedule(ctx, upsertWorkflowProviderScheduleRequestFromProto(req))
 	if err != nil {
 		return nil, providerRPCError("workflow upsert schedule", err)
@@ -127,6 +139,7 @@ func (s workflowProviderServer) UpsertSchedule(ctx context.Context, req *proto.U
 }
 
 func (s workflowProviderServer) GetSchedule(ctx context.Context, req *proto.GetWorkflowProviderScheduleRequest) (*proto.BoundWorkflowSchedule, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	schedule, err := s.provider.GetSchedule(ctx, &GetWorkflowProviderScheduleRequest{ScheduleID: req.GetScheduleId()})
 	if err != nil {
 		return nil, providerRPCError("workflow get schedule", err)
@@ -136,6 +149,7 @@ func (s workflowProviderServer) GetSchedule(ctx context.Context, req *proto.GetW
 }
 
 func (s workflowProviderServer) ListSchedules(ctx context.Context, req *proto.ListWorkflowProviderSchedulesRequest) (*proto.ListWorkflowProviderSchedulesResponse, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	resp, err := s.provider.ListSchedules(ctx, &ListWorkflowProviderSchedulesRequest{})
 	if err != nil {
 		return nil, providerRPCError("workflow list schedules", err)
@@ -148,10 +162,12 @@ func (s workflowProviderServer) ListSchedules(ctx context.Context, req *proto.Li
 }
 
 func (s workflowProviderServer) DeleteSchedule(ctx context.Context, req *proto.DeleteWorkflowProviderScheduleRequest) (*emptypb.Empty, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	return &emptypb.Empty{}, providerRPCError("workflow delete schedule", s.provider.DeleteSchedule(ctx, &DeleteWorkflowProviderScheduleRequest{ScheduleID: req.GetScheduleId()}))
 }
 
 func (s workflowProviderServer) PauseSchedule(ctx context.Context, req *proto.PauseWorkflowProviderScheduleRequest) (*proto.BoundWorkflowSchedule, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	schedule, err := s.provider.PauseSchedule(ctx, &PauseWorkflowProviderScheduleRequest{ScheduleID: req.GetScheduleId()})
 	if err != nil {
 		return nil, providerRPCError("workflow pause schedule", err)
@@ -161,6 +177,7 @@ func (s workflowProviderServer) PauseSchedule(ctx context.Context, req *proto.Pa
 }
 
 func (s workflowProviderServer) ResumeSchedule(ctx context.Context, req *proto.ResumeWorkflowProviderScheduleRequest) (*proto.BoundWorkflowSchedule, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	schedule, err := s.provider.ResumeSchedule(ctx, &ResumeWorkflowProviderScheduleRequest{ScheduleID: req.GetScheduleId()})
 	if err != nil {
 		return nil, providerRPCError("workflow resume schedule", err)
@@ -170,6 +187,7 @@ func (s workflowProviderServer) ResumeSchedule(ctx context.Context, req *proto.R
 }
 
 func (s workflowProviderServer) UpsertEventTrigger(ctx context.Context, req *proto.UpsertWorkflowProviderEventTriggerRequest) (*proto.BoundWorkflowEventTrigger, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	trigger, err := s.provider.UpsertEventTrigger(ctx, upsertWorkflowProviderEventTriggerRequestFromProto(req))
 	if err != nil {
 		return nil, providerRPCError("workflow upsert event trigger", err)
@@ -179,6 +197,7 @@ func (s workflowProviderServer) UpsertEventTrigger(ctx context.Context, req *pro
 }
 
 func (s workflowProviderServer) GetEventTrigger(ctx context.Context, req *proto.GetWorkflowProviderEventTriggerRequest) (*proto.BoundWorkflowEventTrigger, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	trigger, err := s.provider.GetEventTrigger(ctx, &GetWorkflowProviderEventTriggerRequest{TriggerID: req.GetTriggerId()})
 	if err != nil {
 		return nil, providerRPCError("workflow get event trigger", err)
@@ -188,6 +207,7 @@ func (s workflowProviderServer) GetEventTrigger(ctx context.Context, req *proto.
 }
 
 func (s workflowProviderServer) ListEventTriggers(ctx context.Context, req *proto.ListWorkflowProviderEventTriggersRequest) (*proto.ListWorkflowProviderEventTriggersResponse, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	resp, err := s.provider.ListEventTriggers(ctx, &ListWorkflowProviderEventTriggersRequest{})
 	if err != nil {
 		return nil, providerRPCError("workflow list event triggers", err)
@@ -200,10 +220,12 @@ func (s workflowProviderServer) ListEventTriggers(ctx context.Context, req *prot
 }
 
 func (s workflowProviderServer) DeleteEventTrigger(ctx context.Context, req *proto.DeleteWorkflowProviderEventTriggerRequest) (*emptypb.Empty, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	return &emptypb.Empty{}, providerRPCError("workflow delete event trigger", s.provider.DeleteEventTrigger(ctx, &DeleteWorkflowProviderEventTriggerRequest{TriggerID: req.GetTriggerId()}))
 }
 
 func (s workflowProviderServer) PauseEventTrigger(ctx context.Context, req *proto.PauseWorkflowProviderEventTriggerRequest) (*proto.BoundWorkflowEventTrigger, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	trigger, err := s.provider.PauseEventTrigger(ctx, &PauseWorkflowProviderEventTriggerRequest{TriggerID: req.GetTriggerId()})
 	if err != nil {
 		return nil, providerRPCError("workflow pause event trigger", err)
@@ -213,6 +235,7 @@ func (s workflowProviderServer) PauseEventTrigger(ctx context.Context, req *prot
 }
 
 func (s workflowProviderServer) ResumeEventTrigger(ctx context.Context, req *proto.ResumeWorkflowProviderEventTriggerRequest) (*proto.BoundWorkflowEventTrigger, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	trigger, err := s.provider.ResumeEventTrigger(ctx, &ResumeWorkflowProviderEventTriggerRequest{TriggerID: req.GetTriggerId()})
 	if err != nil {
 		return nil, providerRPCError("workflow resume event trigger", err)
@@ -256,6 +279,7 @@ func (s workflowProviderServer) ListExecutionReferences(ctx context.Context, req
 }
 
 func (s workflowProviderServer) PublishEvent(ctx context.Context, req *proto.PublishWorkflowProviderEventRequest) (*proto.WorkflowEvent, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	input := publishWorkflowProviderEventRequestFromProto(req)
 	eventInput, err := s.provider.PublishEvent(ctx, input)
 	if err != nil {
@@ -269,6 +293,13 @@ func (s workflowProviderServer) PublishEvent(ctx context.Context, req *proto.Pub
 	}
 	event, err := workflowEventToProto(*eventInput)
 	return event, providerRPCError("workflow publish event", err)
+}
+
+func workflowProviderInvocationContext(ctx context.Context, token string) context.Context {
+	if strings.TrimSpace(token) == "" {
+		return ctx
+	}
+	return withInvocationToken(ctx, token)
 }
 
 func createWorkflowProviderDefinitionRequestFromProto(req *proto.CreateWorkflowProviderDefinitionRequest) *CreateWorkflowProviderDefinitionRequest {
@@ -383,7 +414,7 @@ func publishWorkflowProviderEventRequestFromProto(req *proto.PublishWorkflowProv
 		event = &input
 	}
 	return &PublishWorkflowProviderEventRequest{
-		AppName:  req.GetAppName(),
+		AppName:     req.GetAppName(),
 		Event:       event,
 		PublishedBy: workflowActorInputPtrFromActor(req.GetPublishedBy()),
 	}

--- a/sdk/go/workflow_provider_transport_test.go
+++ b/sdk/go/workflow_provider_transport_test.go
@@ -14,8 +14,11 @@ import (
 type fullWorkflowProvider struct {
 	gestalt.UnimplementedWorkflowProvider
 	closeTracker
-	configuredName  string
-	publishedEvents []string
+	configuredName          string
+	startRunInvocationToken string
+	definitionToken         string
+	publishEventToken       string
+	publishedEvents         []string
 }
 
 func (p *fullWorkflowProvider) Configure(_ context.Context, name string, _ map[string]any) error {
@@ -32,7 +35,8 @@ func (p *fullWorkflowProvider) Metadata() gestalt.ProviderMetadata {
 	}
 }
 
-func (p *fullWorkflowProvider) StartRun(_ context.Context, req *gestalt.StartWorkflowProviderRunRequest) (*gestalt.BoundWorkflowRun, error) {
+func (p *fullWorkflowProvider) StartRun(ctx context.Context, req *gestalt.StartWorkflowProviderRunRequest) (*gestalt.BoundWorkflowRun, error) {
+	p.startRunInvocationToken = gestalt.InvocationTokenFromContext(ctx)
 	return &gestalt.BoundWorkflowRun{
 		ID:     req.IdempotencyKey,
 		Status: gestalt.WorkflowRunStatusValuePending,
@@ -40,14 +44,16 @@ func (p *fullWorkflowProvider) StartRun(_ context.Context, req *gestalt.StartWor
 	}, nil
 }
 
-func (p *fullWorkflowProvider) CreateDefinition(_ context.Context, req *gestalt.CreateWorkflowProviderDefinitionRequest) (*gestalt.BoundWorkflowDefinition, error) {
+func (p *fullWorkflowProvider) CreateDefinition(ctx context.Context, req *gestalt.CreateWorkflowProviderDefinitionRequest) (*gestalt.BoundWorkflowDefinition, error) {
+	p.definitionToken = gestalt.InvocationTokenFromContext(ctx)
 	return &gestalt.BoundWorkflowDefinition{
 		ID:     req.IdempotencyKey,
 		Target: req.Target,
 	}, nil
 }
 
-func (p *fullWorkflowProvider) PublishEvent(_ context.Context, req *gestalt.PublishWorkflowProviderEventRequest) (*gestalt.WorkflowEvent, error) {
+func (p *fullWorkflowProvider) PublishEvent(ctx context.Context, req *gestalt.PublishWorkflowProviderEventRequest) (*gestalt.WorkflowEvent, error) {
+	p.publishEventToken = gestalt.InvocationTokenFromContext(ctx)
 	if req.Event != nil {
 		p.publishedEvents = append(p.publishedEvents, req.Event.Type)
 		return &gestalt.WorkflowEvent{ID: "published-go", Type: req.Event.Type}, nil
@@ -90,7 +96,8 @@ func TestWorkflowProviderTypedTransportRoundTrip(t *testing.T) {
 	}
 
 	run, err := workflowClient.StartRun(rpcCtx, &proto.StartWorkflowProviderRunRequest{
-		IdempotencyKey: "run-1",
+		IdempotencyKey:  "run-1",
+		InvocationToken: "workflow-run-token",
 		Target: &proto.BoundWorkflowTarget{
 			Steps: []*proto.WorkflowStep{{
 				Id: "create_issue",
@@ -107,9 +114,13 @@ func TestWorkflowProviderTypedTransportRoundTrip(t *testing.T) {
 	if run.GetId() != "run-1" || run.GetStatus() != proto.WorkflowRunStatus_WORKFLOW_RUN_STATUS_PENDING {
 		t.Fatalf("StartRun = %+v, want pending run", run)
 	}
+	if provider.startRunInvocationToken != "workflow-run-token" {
+		t.Fatalf("StartRun invocation token = %q, want workflow-run-token", provider.startRunInvocationToken)
+	}
 
 	definition, err := workflowClient.CreateDefinition(rpcCtx, &proto.CreateWorkflowProviderDefinitionRequest{
-		IdempotencyKey: "definition-1",
+		IdempotencyKey:  "definition-1",
+		InvocationToken: "workflow-definition-token",
 		Target: &proto.BoundWorkflowTarget{
 			Steps: []*proto.WorkflowStep{{
 				Id: "search_issues",
@@ -126,9 +137,13 @@ func TestWorkflowProviderTypedTransportRoundTrip(t *testing.T) {
 	if definition.GetId() != "definition-1" {
 		t.Fatalf("CreateDefinition id = %q, want definition-1", definition.GetId())
 	}
+	if provider.definitionToken != "workflow-definition-token" {
+		t.Fatalf("CreateDefinition invocation token = %q, want workflow-definition-token", provider.definitionToken)
+	}
 
 	published, err := workflowClient.PublishEvent(rpcCtx, &proto.PublishWorkflowProviderEventRequest{
-		Event: &proto.WorkflowEvent{Type: "issue.created"},
+		Event:           &proto.WorkflowEvent{Type: "issue.created"},
+		InvocationToken: "workflow-event-token",
 	})
 	if err != nil {
 		t.Fatalf("PublishEvent: %v", err)
@@ -138,5 +153,8 @@ func TestWorkflowProviderTypedTransportRoundTrip(t *testing.T) {
 	}
 	if len(provider.publishedEvents) != 1 || provider.publishedEvents[0] != "issue.created" {
 		t.Fatalf("published events = %v, want [issue.created]", provider.publishedEvents)
+	}
+	if provider.publishEventToken != "workflow-event-token" {
+		t.Fatalf("PublishEvent invocation token = %q, want workflow-event-token", provider.publishEventToken)
 	}
 }


### PR DESCRIPTION
## Summary

Workflow-provider SDK calls now keep the trusted workflow metadata that gestaltd attached when it minted the provider invocation token.

Invocation tokens carry workflow context in signed claims, child token exchange preserves that context, and host services restore it before invoking downstream apps. Workflow providers can use the normal SDK host capabilities instead of a separate workflow control channel.

Go workflow providers now receive their `invocation_token` request field in the provider method context, so `AppFromContext`, `AgentFromContext`, and `AuthorizationFromContext` work from provider implementations.

## Interfaces

```go
ctx = invocation.WithWorkflowContext(ctx, map[string]any{
  "providerName": "temporal",
  "runId": "run-123",
  "definitionId": "definition-123",
  "activationId": "activation-123",
})

token, err := tokens.MintRootToken(ctx, "workflow-provider", grants)
restored := appinvoker.RestoreTokenContext(context.Background(), tokenCtx, "")
workflow := invocation.WorkflowContextFromContext(restored)
```

```go
func (p *WorkflowProvider) StartRun(ctx context.Context, req *gestalt.StartWorkflowProviderRunRequest) (*gestalt.BoundWorkflowRun, error) {
  apps, err := gestalt.AppFromContext(ctx)
  authz, err := gestalt.AuthorizationFromContext(ctx)
  agents, err := gestalt.AgentFromContext(ctx)
  // The host-service clients use the workflow provider invocation token from ctx.
}
```

## Runtime

Workflow provider processes now receive the existing `authorization` host service when authorization is configured, alongside the existing app and agent host-service surfaces.

The token handoff stays inside the existing SDK and host-service transports: provider RPCs attach the invocation token to the provider context, SDK host clients use that token, and gestaltd restores signed workflow context when resolving the token.
