### PR TITLE
[codex] Preserve workflow provider invocation context

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1843,6 +1843,9 @@ func buildWorkflow(ctx context.Context, name string, entry *config.ProviderEntry
 			proto.RegisterWorkflowHostServer(srv, workflowservice.NewHostServer(name, deps.WorkflowRuntime.Invoke))
 		},
 	}}
+	if deps.AuthorizationProvider != nil {
+		hostServices = append(hostServices, buildPluginAuthorizationHostService(deps.AuthorizationProvider))
+	}
 	var cleanup func()
 	defer func() {
 		if cleanup != nil {

--- a/gestaltd/internal/bootstrap/workflow_startup_test.go
+++ b/gestaltd/internal/bootstrap/workflow_startup_test.go
@@ -169,6 +169,46 @@ func TestBuildWorkflowRegistersExecutableWorkflowHostPublicRelay(t *testing.T) {
 	}
 }
 
+func TestBuildWorkflowPassesAuthorizationHostService(t *testing.T) {
+	t.Parallel()
+
+	var hostServiceNames []string
+	factories := NewFactoryRegistry()
+	factories.Workflow = func(_ context.Context, _ string, _ yaml.Node, hostServices []runtimehost.HostService, _ Deps) (coreworkflow.Provider, error) {
+		for _, hostService := range hostServices {
+			hostServiceNames = append(hostServiceNames, hostService.Name)
+		}
+		return startupTestWorkflowProvider{}, nil
+	}
+	provider, err := buildWorkflow(context.Background(), "local", &config.ProviderEntry{
+		Config: mustNode(t, map[string]any{"command": "/bin/workflow-provider"}),
+	}, factories, Deps{
+		AuthorizationProvider: &hostedHTTPAuthorizationProvider{},
+	})
+	if err != nil {
+		t.Fatalf("buildWorkflow: %v", err)
+	}
+	if err := provider.Close(); err != nil {
+		t.Fatalf("provider.Close: %v", err)
+	}
+
+	if !hasHostServiceName(hostServiceNames, "workflow_host") {
+		t.Fatalf("workflow host services = %v, want workflow_host", hostServiceNames)
+	}
+	if !hasHostServiceName(hostServiceNames, "authorization") {
+		t.Fatalf("workflow host services = %v, want authorization", hostServiceNames)
+	}
+}
+
+func hasHostServiceName(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
 func (noopTelemetryProvider) Logger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(os.Stderr, nil))
 }

--- a/gestaltd/services/appaccess/app_test.go
+++ b/gestaltd/services/appaccess/app_test.go
@@ -18,6 +18,7 @@ import (
 type recordingAppInvocation struct {
 	idempotencyKey        string
 	internalConnection    bool
+	workflowContext       map[string]any
 	providerName          string
 	instance              string
 	operation             string
@@ -32,11 +33,68 @@ type recordingAppInvocation struct {
 func (i *recordingAppInvocation) Invoke(ctx context.Context, _ *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error) {
 	i.idempotencyKey = invocation.IdempotencyKeyFromContext(ctx)
 	i.internalConnection = invocation.InternalConnectionAccessFromContext(ctx)
+	i.workflowContext = invocation.WorkflowContextFromContext(ctx)
 	i.providerName = providerName
 	i.instance = instance
 	i.operation = operation
 	i.params = params
 	return &core.OperationResult{Status: 202, Body: "accepted"}, nil
+}
+
+func TestAppServerInvokeRestoresWorkflowContext(t *testing.T) {
+	t.Parallel()
+
+	tokens, err := NewInvocationTokenManager([]byte("plugin-invoker-workflow-context-secret"))
+	if err != nil {
+		t.Fatalf("NewInvocationTokenManager: %v", err)
+	}
+	ctx := principal.WithPrincipal(context.Background(), &principal.Principal{
+		SubjectID: "service_account:workflow",
+		Kind:      principal.Kind("service_account"),
+		Source:    principal.SourceAPIToken,
+	})
+	ctx = invocation.WithWorkflowContext(ctx, map[string]any{
+		"providerName": "temporal",
+		"runId":        "run-123",
+		"step": map[string]any{
+			"id": "notify",
+		},
+	})
+	rootToken, err := tokens.MintRootToken(ctx, "workflow-provider", InvocationGrants{
+		"slack": {Operations: map[string]core.ConnectionMode{"chat.postMessage": ""}},
+	})
+	if err != nil {
+		t.Fatalf("MintRootToken: %v", err)
+	}
+
+	invoker := &recordingAppInvocation{}
+	server := NewAppServer(
+		"workflow-provider",
+		[]invocation.AppInvocationDependency{{App: "slack", Operation: "chat.postMessage"}},
+		invoker,
+		tokens,
+	)
+	client := proto.NewAppClient(newBufconnConn(t, func(srv *grpc.Server) {
+		proto.RegisterAppServer(srv, server)
+	}))
+	if _, err := client.Invoke(context.Background(), &proto.AppInvokeRequest{
+		InvocationToken: rootToken,
+		App:             "slack",
+		Operation:       "chat.postMessage",
+	}); err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+
+	if got := invocation.WorkflowContextString(invoker.workflowContext, "providerName"); got != "temporal" {
+		t.Fatalf("providerName = %q, want temporal", got)
+	}
+	if got := invocation.WorkflowContextString(invoker.workflowContext, "runId"); got != "run-123" {
+		t.Fatalf("runId = %q, want run-123", got)
+	}
+	step := invocation.WorkflowContextMap(invoker.workflowContext, "step")
+	if got := invocation.WorkflowContextString(step, "id"); got != "notify" {
+		t.Fatalf("step.id = %q, want notify", got)
+	}
 }
 
 func TestAppServerInvokePropagatesInternalConnectionAccess(t *testing.T) {

--- a/gestaltd/services/appaccess/invocation_token.go
+++ b/gestaltd/services/appaccess/invocation_token.go
@@ -78,6 +78,7 @@ type workflowGrantClaims struct {
 }
 
 type invocationTokenContext struct {
+	token                  string
 	principal              *principal.Principal
 	requestMeta            invocation.RequestMeta
 	credential             invocation.CredentialContext
@@ -167,6 +168,7 @@ func (m *InvocationTokenManager) resolveToken(token, appName string) (invocation
 		return invocationTokenContext{}, fmt.Errorf("app invocation token is not valid for %q", appName)
 	}
 	return invocationTokenContext{
+		token:     strings.TrimSpace(token),
 		principal: principalFromInvocationClaims(claims),
 		requestMeta: invocation.RequestMeta{
 			ClientIP:   claims.RequestMeta.ClientIP,
@@ -378,6 +380,9 @@ func restoreInvocationTokenContext(ctx context.Context, tokenCtx invocationToken
 	}
 	if tokenCtx.workflow != nil {
 		ctx = invocation.WithWorkflowContext(ctx, cloneInvocationTokenMap(tokenCtx.workflow))
+	}
+	if token := strings.TrimSpace(tokenCtx.token); token != "" {
+		ctx = WithInvocationToken(ctx, token)
 	}
 
 	connection := strings.TrimSpace(connectionOverride)

--- a/gestaltd/services/appaccess/invocation_token.go
+++ b/gestaltd/services/appaccess/invocation_token.go
@@ -45,6 +45,7 @@ type invocationTokenClaims struct {
 	TokenPermissions    map[string][]string              `json:"token_permissions,omitempty"`
 	Grants              map[string]invocationGrantClaims `json:"grants,omitempty"`
 	WorkflowGrants      *workflowGrantClaims             `json:"workflow_grants,omitempty"`
+	Workflow            map[string]any                   `json:"workflow,omitempty"`
 	RequestMeta         requestMetaClaims                `json:"request_meta,omitempty"`
 	Credential          credentialClaims                 `json:"credential,omitempty"`
 	Invocation          invocationClaims                 `json:"invocation,omitempty"`
@@ -87,6 +88,7 @@ type invocationTokenContext struct {
 	connection             string
 	grants                 InvocationGrants
 	workflowGrants         workflowgrants.Grants
+	workflow               map[string]any
 }
 
 func NewInvocationTokenManager(secret []byte) (*InvocationTokenManager, error) {
@@ -187,6 +189,7 @@ func (m *InvocationTokenManager) resolveToken(token, appName string) (invocation
 		connection:         strings.TrimSpace(claims.Connection),
 		grants:             decodeInvocationGrantClaims(claims.Grants),
 		workflowGrants:     decodeWorkflowGrantClaims(claims.WorkflowGrants),
+		workflow:           cloneInvocationTokenMap(claims.Workflow),
 	}, nil
 }
 
@@ -303,6 +306,7 @@ func claimsFromContext(ctx context.Context, appName string, grants InvocationGra
 		TokenPermissions:    encodePermissionSet(tokenPermissionsForInvocationClaims(p)),
 		Grants:              encodeInvocationGrantClaims(grants),
 		WorkflowGrants:      encodeWorkflowGrantClaims(workflowGrants),
+		Workflow:            cloneInvocationTokenMap(invocation.WorkflowContextFromContext(ctx)),
 		RequestMeta: requestMetaClaims{
 			ClientIP:   reqMeta.ClientIP,
 			RemoteAddr: reqMeta.RemoteAddr,
@@ -372,6 +376,9 @@ func restoreInvocationTokenContext(ctx context.Context, tokenCtx invocationToken
 	if tokenCtx.internalConnection {
 		ctx = invocation.WithInternalConnectionAccess(ctx)
 	}
+	if tokenCtx.workflow != nil {
+		ctx = invocation.WithWorkflowContext(ctx, cloneInvocationTokenMap(tokenCtx.workflow))
+	}
 
 	connection := strings.TrimSpace(connectionOverride)
 	if connection == "" {
@@ -384,6 +391,39 @@ func restoreInvocationTokenContext(ctx context.Context, tokenCtx invocationToken
 		ctx = invocation.WithConnection(ctx, connection)
 	}
 	return ctx
+}
+
+func cloneInvocationTokenMap(src map[string]any) map[string]any {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(src))
+	for key, value := range src {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		out[key] = cloneInvocationTokenValue(value)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func cloneInvocationTokenValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		return cloneInvocationTokenMap(typed)
+	case []any:
+		out := make([]any, len(typed))
+		for i := range typed {
+			out[i] = cloneInvocationTokenValue(typed[i])
+		}
+		return out
+	default:
+		return typed
+	}
 }
 
 func RestoreTokenContext(ctx context.Context, tokenCtx TokenContext, connectionOverride string) context.Context {

--- a/gestaltd/services/appaccess/invocation_token_test.go
+++ b/gestaltd/services/appaccess/invocation_token_test.go
@@ -273,6 +273,9 @@ func TestInvocationTokenRestoresWorkflowContext(t *testing.T) {
 		t.Fatalf("ResolveToken: %v", err)
 	}
 	restored := RestoreTokenContext(context.Background(), tokenCtx, "")
+	if got := InvocationTokenFromContext(restored); got != token {
+		t.Fatalf("restored invocation token = %q, want original token", got)
+	}
 	workflow := invocation.WorkflowContextFromContext(restored)
 	if got := invocation.WorkflowContextString(workflow, "providerName"); got != "temporal" {
 		t.Fatalf("providerName = %q, want temporal", got)

--- a/gestaltd/services/appaccess/invocation_token_test.go
+++ b/gestaltd/services/appaccess/invocation_token_test.go
@@ -234,6 +234,114 @@ func TestInvocationTokenResolvePreservesEmailOnlyPrincipals(t *testing.T) {
 	}
 }
 
+func TestInvocationTokenRestoresWorkflowContext(t *testing.T) {
+	t.Parallel()
+
+	manager, err := NewInvocationTokenManager([]byte("invocation-token-workflow-context-secret"))
+	if err != nil {
+		t.Fatalf("NewInvocationTokenManager: %v", err)
+	}
+
+	ctx := principal.WithPrincipal(
+		context.Background(),
+		&principal.Principal{
+			SubjectID: "user:test-user",
+			UserID:    "test-user",
+			Kind:      principal.KindUser,
+			Source:    principal.SourceSession,
+		},
+	)
+	ctx = invocation.WithWorkflowContext(ctx, map[string]any{
+		"providerName":       "temporal",
+		"runId":              "run-123",
+		"definitionId":       "def-123",
+		"definitionRevision": "7",
+		"activationId":       "webhook",
+		"step": map[string]any{
+			"id": "notify",
+		},
+	})
+	token, err := manager.MintRootToken(ctx, "caller", InvocationGrants{
+		"slack": {Operations: map[string]core.ConnectionMode{"chat.postMessage": ""}},
+	})
+	if err != nil {
+		t.Fatalf("MintRootToken: %v", err)
+	}
+
+	tokenCtx, err := manager.ResolveToken(token, "caller")
+	if err != nil {
+		t.Fatalf("ResolveToken: %v", err)
+	}
+	restored := RestoreTokenContext(context.Background(), tokenCtx, "")
+	workflow := invocation.WorkflowContextFromContext(restored)
+	if got := invocation.WorkflowContextString(workflow, "providerName"); got != "temporal" {
+		t.Fatalf("providerName = %q, want temporal", got)
+	}
+	if got := invocation.WorkflowContextString(workflow, "runId"); got != "run-123" {
+		t.Fatalf("runId = %q, want run-123", got)
+	}
+	step := invocation.WorkflowContextMap(workflow, "step")
+	if got := invocation.WorkflowContextString(step, "id"); got != "notify" {
+		t.Fatalf("step.id = %q, want notify", got)
+	}
+}
+
+func TestInvocationTokenExchangePreservesWorkflowContext(t *testing.T) {
+	t.Parallel()
+
+	manager, err := NewInvocationTokenManager([]byte("invocation-token-workflow-context-exchange-secret"))
+	if err != nil {
+		t.Fatalf("NewInvocationTokenManager: %v", err)
+	}
+
+	ctx := principal.WithPrincipal(
+		context.Background(),
+		&principal.Principal{
+			SubjectID: "user:test-user",
+			UserID:    "test-user",
+			Kind:      principal.KindUser,
+			Source:    principal.SourceSession,
+		},
+	)
+	ctx = invocation.WithWorkflowContext(ctx, map[string]any{
+		"providerName": "temporal",
+		"runId":        "run-123",
+		"step": map[string]any{
+			"id": "notify",
+		},
+	})
+	rootToken, err := manager.MintRootToken(ctx, "caller", InvocationGrants{
+		"slack":  {Operations: map[string]core.ConnectionMode{"chat.postMessage": ""}},
+		"github": {Operations: map[string]core.ConnectionMode{"issues.create": ""}},
+	})
+	if err != nil {
+		t.Fatalf("MintRootToken: %v", err)
+	}
+	childToken, err := manager.ExchangeToken(rootToken, "caller", InvocationGrants{
+		"slack": {Operations: map[string]core.ConnectionMode{"chat.postMessage": ""}},
+	}, time.Minute)
+	if err != nil {
+		t.Fatalf("ExchangeToken: %v", err)
+	}
+
+	tokenCtx, err := manager.ResolveToken(childToken, "caller")
+	if err != nil {
+		t.Fatalf("ResolveToken(child): %v", err)
+	}
+	restored := RestoreTokenContext(context.Background(), tokenCtx, "")
+	workflow := invocation.WorkflowContextFromContext(restored)
+	if got := invocation.WorkflowContextString(workflow, "providerName"); got != "temporal" {
+		t.Fatalf("providerName = %q, want temporal", got)
+	}
+	if got := invocation.WorkflowContextString(workflow, "runId"); got != "run-123" {
+		t.Fatalf("runId = %q, want run-123", got)
+	}
+	step := invocation.WorkflowContextMap(workflow, "step")
+	if got := invocation.WorkflowContextString(step, "id"); got != "notify" {
+		t.Fatalf("step.id = %q, want notify", got)
+	}
+}
+
 func TestDecodeInvocationGrantClaimsIgnoresModesForUndeclaredOperations(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/workflows/client.go
+++ b/gestaltd/services/workflows/client.go
@@ -9,6 +9,7 @@ import (
 
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	appaccessservice "github.com/valon-technologies/gestalt/server/services/appaccess"
 	"github.com/valon-technologies/gestalt/server/services/egress"
 	"github.com/valon-technologies/gestalt/server/services/observability"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
@@ -100,6 +101,7 @@ func (r *remoteWorkflow) StartRun(ctx context.Context, req coreworkflow.StartRun
 		targetKind:  workflowTargetKind(req.Target),
 	})
 	defer func() { end(err) }()
+	invocationToken := workflowProviderInvocationToken(ctx)
 	ctx, cancel := runtimehost.ProviderCallContext(ctx)
 	defer cancel()
 	target, err := workflowTargetToProto(req.Target)
@@ -107,11 +109,12 @@ func (r *remoteWorkflow) StartRun(ctx context.Context, req coreworkflow.StartRun
 		return nil, err
 	}
 	resp, err := r.client.StartRun(ctx, &proto.StartWorkflowProviderRunRequest{
-		Target:         target,
-		IdempotencyKey: req.IdempotencyKey,
-		CreatedBy:      workflowActorToProto(req.CreatedBy),
-		ExecutionRef:   req.ExecutionRef,
-		WorkflowKey:    req.WorkflowKey,
+		Target:          target,
+		IdempotencyKey:  req.IdempotencyKey,
+		CreatedBy:       workflowActorToProto(req.CreatedBy),
+		ExecutionRef:    req.ExecutionRef,
+		WorkflowKey:     req.WorkflowKey,
+		InvocationToken: invocationToken,
 	})
 	if err != nil {
 		return nil, err
@@ -130,10 +133,12 @@ func (r *remoteWorkflow) StartRun(ctx context.Context, req coreworkflow.StartRun
 func (r *remoteWorkflow) GetRun(ctx context.Context, req coreworkflow.GetRunRequest) (run *coreworkflow.Run, err error) {
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationGetRun, workflowDims{})
 	defer func() { end(err) }()
+	invocationToken := workflowProviderInvocationToken(ctx)
 	ctx, cancel := runtimehost.ProviderCallContext(ctx)
 	defer cancel()
 	resp, err := r.client.GetRun(ctx, &proto.GetWorkflowProviderRunRequest{
-		RunId: req.RunID,
+		RunId:           req.RunID,
+		InvocationToken: invocationToken,
 	})
 	if err != nil {
 		return nil, err
@@ -144,13 +149,15 @@ func (r *remoteWorkflow) GetRun(ctx context.Context, req coreworkflow.GetRunRequ
 func (r *remoteWorkflow) ListRuns(ctx context.Context, req coreworkflow.ListRunsRequest) (out *coreworkflow.ListRunsResponse, err error) {
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationListRuns, workflowDims{})
 	defer func() { end(err) }()
+	invocationToken := workflowProviderInvocationToken(ctx)
 	ctx, cancel := runtimehost.ProviderCallContext(ctx)
 	defer cancel()
 	resp, err := r.client.ListRuns(ctx, &proto.ListWorkflowProviderRunsRequest{
-		PageSize:  int32(req.PageSize),
-		PageToken: strings.TrimSpace(req.PageToken),
-		Status:    workflowRunStatusToProto(req.Status),
-		TargetApp: strings.TrimSpace(req.TargetApp),
+		PageSize:        int32(req.PageSize),
+		PageToken:       strings.TrimSpace(req.PageToken),
+		Status:          workflowRunStatusToProto(req.Status),
+		InvocationToken: invocationToken,
+		TargetApp:       strings.TrimSpace(req.TargetApp),
 	})
 	if err != nil {
 		return nil, err
@@ -172,11 +179,13 @@ func (r *remoteWorkflow) ListRuns(ctx context.Context, req coreworkflow.ListRuns
 func (r *remoteWorkflow) CancelRun(ctx context.Context, req coreworkflow.CancelRunRequest) (run *coreworkflow.Run, err error) {
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationCancelRun, workflowDims{})
 	defer func() { end(err) }()
+	invocationToken := workflowProviderInvocationToken(ctx)
 	ctx, cancel := runtimehost.ProviderCallContext(ctx)
 	defer cancel()
 	resp, err := r.client.CancelRun(ctx, &proto.CancelWorkflowProviderRunRequest{
-		RunId:  req.RunID,
-		Reason: req.Reason,
+		RunId:           req.RunID,
+		Reason:          req.Reason,
+		InvocationToken: invocationToken,
 	})
 	if err != nil {
 		return nil, err
@@ -187,6 +196,7 @@ func (r *remoteWorkflow) CancelRun(ctx context.Context, req coreworkflow.CancelR
 func (r *remoteWorkflow) SignalRun(ctx context.Context, req coreworkflow.SignalRunRequest) (out *coreworkflow.SignalRunResponse, err error) {
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationSignalRun, workflowDims{triggerKind: observability.WorkflowTriggerKindSignal})
 	defer func() { end(err) }()
+	invocationToken := workflowProviderInvocationToken(ctx)
 	ctx, cancel := runtimehost.ProviderCallContext(ctx)
 	defer cancel()
 	signal, err := workflowSignalToProto(req.Signal)
@@ -194,8 +204,9 @@ func (r *remoteWorkflow) SignalRun(ctx context.Context, req coreworkflow.SignalR
 		return nil, err
 	}
 	resp, err := r.client.SignalRun(ctx, &proto.SignalWorkflowProviderRunRequest{
-		RunId:  req.RunID,
-		Signal: signal,
+		RunId:           req.RunID,
+		Signal:          signal,
+		InvocationToken: invocationToken,
 	})
 	if err != nil {
 		return nil, err
@@ -209,6 +220,7 @@ func (r *remoteWorkflow) SignalOrStartRun(ctx context.Context, req coreworkflow.
 		targetKind:  workflowTargetKind(req.Target),
 	})
 	defer func() { end(err) }()
+	invocationToken := workflowProviderInvocationToken(ctx)
 	ctx, cancel := runtimehost.ProviderCallContext(ctx)
 	defer cancel()
 	target, err := workflowTargetToProto(req.Target)
@@ -220,12 +232,13 @@ func (r *remoteWorkflow) SignalOrStartRun(ctx context.Context, req coreworkflow.
 		return nil, err
 	}
 	resp, err := r.client.SignalOrStartRun(ctx, &proto.SignalOrStartWorkflowProviderRunRequest{
-		WorkflowKey:    req.WorkflowKey,
-		Target:         target,
-		IdempotencyKey: req.IdempotencyKey,
-		CreatedBy:      workflowActorToProto(req.CreatedBy),
-		ExecutionRef:   req.ExecutionRef,
-		Signal:         signal,
+		WorkflowKey:     req.WorkflowKey,
+		Target:          target,
+		IdempotencyKey:  req.IdempotencyKey,
+		CreatedBy:       workflowActorToProto(req.CreatedBy),
+		ExecutionRef:    req.ExecutionRef,
+		Signal:          signal,
+		InvocationToken: invocationToken,
 	})
 	if err != nil {
 		return nil, err
@@ -248,6 +261,7 @@ func (r *remoteWorkflow) UpsertSchedule(ctx context.Context, req coreworkflow.Up
 		targetKind:  workflowTargetKind(req.Target),
 	})
 	defer func() { end(err) }()
+	invocationToken := workflowProviderInvocationToken(ctx)
 	ctx, cancel := runtimehost.ProviderCallContext(ctx)
 	defer cancel()
 	target, err := workflowTargetToProto(req.Target)
@@ -255,13 +269,14 @@ func (r *remoteWorkflow) UpsertSchedule(ctx context.Context, req coreworkflow.Up
 		return nil, err
 	}
 	resp, err := r.client.UpsertSchedule(ctx, &proto.UpsertWorkflowProviderScheduleRequest{
-		ScheduleId:   req.ScheduleID,
-		Cron:         req.Cron,
-		Timezone:     req.Timezone,
-		Target:       target,
-		Paused:       req.Paused,
-		RequestedBy:  workflowActorToProto(req.RequestedBy),
-		ExecutionRef: req.ExecutionRef,
+		ScheduleId:      req.ScheduleID,
+		Cron:            req.Cron,
+		Timezone:        req.Timezone,
+		Target:          target,
+		Paused:          req.Paused,
+		RequestedBy:     workflowActorToProto(req.RequestedBy),
+		ExecutionRef:    req.ExecutionRef,
+		InvocationToken: invocationToken,
 	})
 	if err != nil {
 		return nil, err
@@ -272,10 +287,12 @@ func (r *remoteWorkflow) UpsertSchedule(ctx context.Context, req coreworkflow.Up
 func (r *remoteWorkflow) GetSchedule(ctx context.Context, req coreworkflow.GetScheduleRequest) (schedule *coreworkflow.Schedule, err error) {
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationGetSchedule, workflowDims{triggerKind: observability.WorkflowTriggerKindSchedule})
 	defer func() { end(err) }()
+	invocationToken := workflowProviderInvocationToken(ctx)
 	ctx, cancel := runtimehost.ProviderCallContext(ctx)
 	defer cancel()
 	resp, err := r.client.GetSchedule(ctx, &proto.GetWorkflowProviderScheduleRequest{
-		ScheduleId: req.ScheduleID,
+		ScheduleId:      req.ScheduleID,
+		InvocationToken: invocationToken,
 	})
 	if err != nil {
 		return nil, err
@@ -286,9 +303,10 @@ func (r *remoteWorkflow) GetSchedule(ctx context.Context, req coreworkflow.GetSc
 func (r *remoteWorkflow) ListSchedules(ctx context.Context, req coreworkflow.ListSchedulesRequest) (schedules []*coreworkflow.Schedule, err error) {
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationListSchedules, workflowDims{triggerKind: observability.WorkflowTriggerKindSchedule})
 	defer func() { end(err) }()
+	invocationToken := workflowProviderInvocationToken(ctx)
 	ctx, cancel := runtimehost.ProviderCallContext(ctx)
 	defer cancel()
-	resp, err := r.client.ListSchedules(ctx, &proto.ListWorkflowProviderSchedulesRequest{})
+	resp, err := r.client.ListSchedules(ctx, &proto.ListWorkflowProviderSchedulesRequest{InvocationToken: invocationToken})
 	if err != nil {
 		return nil, err
 	}
@@ -306,10 +324,12 @@ func (r *remoteWorkflow) ListSchedules(ctx context.Context, req coreworkflow.Lis
 func (r *remoteWorkflow) DeleteSchedule(ctx context.Context, req coreworkflow.DeleteScheduleRequest) (err error) {
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationDeleteSchedule, workflowDims{triggerKind: observability.WorkflowTriggerKindSchedule})
 	defer func() { end(err) }()
+	invocationToken := workflowProviderInvocationToken(ctx)
 	ctx, cancel := runtimehost.ProviderCallContext(ctx)
 	defer cancel()
 	_, err = r.client.DeleteSchedule(ctx, &proto.DeleteWorkflowProviderScheduleRequest{
-		ScheduleId: req.ScheduleID,
+		ScheduleId:      req.ScheduleID,
+		InvocationToken: invocationToken,
 	})
 	return err
 }
@@ -317,10 +337,12 @@ func (r *remoteWorkflow) DeleteSchedule(ctx context.Context, req coreworkflow.De
 func (r *remoteWorkflow) PauseSchedule(ctx context.Context, req coreworkflow.PauseScheduleRequest) (schedule *coreworkflow.Schedule, err error) {
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationPauseSchedule, workflowDims{triggerKind: observability.WorkflowTriggerKindSchedule})
 	defer func() { end(err) }()
+	invocationToken := workflowProviderInvocationToken(ctx)
 	ctx, cancel := runtimehost.ProviderCallContext(ctx)
 	defer cancel()
 	resp, err := r.client.PauseSchedule(ctx, &proto.PauseWorkflowProviderScheduleRequest{
-		ScheduleId: req.ScheduleID,
+		ScheduleId:      req.ScheduleID,
+		InvocationToken: invocationToken,
 	})
 	if err != nil {
 		return nil, err
@@ -331,10 +353,12 @@ func (r *remoteWorkflow) PauseSchedule(ctx context.Context, req coreworkflow.Pau
 func (r *remoteWorkflow) ResumeSchedule(ctx context.Context, req coreworkflow.ResumeScheduleRequest) (schedule *coreworkflow.Schedule, err error) {
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationResumeSchedule, workflowDims{triggerKind: observability.WorkflowTriggerKindSchedule})
 	defer func() { end(err) }()
+	invocationToken := workflowProviderInvocationToken(ctx)
 	ctx, cancel := runtimehost.ProviderCallContext(ctx)
 	defer cancel()
 	resp, err := r.client.ResumeSchedule(ctx, &proto.ResumeWorkflowProviderScheduleRequest{
-		ScheduleId: req.ScheduleID,
+		ScheduleId:      req.ScheduleID,
+		InvocationToken: invocationToken,
 	})
 	if err != nil {
 		return nil, err
@@ -348,6 +372,7 @@ func (r *remoteWorkflow) UpsertEventTrigger(ctx context.Context, req coreworkflo
 		targetKind:  workflowTargetKind(req.Target),
 	})
 	defer func() { end(err) }()
+	invocationToken := workflowProviderInvocationToken(ctx)
 	ctx, cancel := runtimehost.ProviderCallContext(ctx)
 	defer cancel()
 	target, err := workflowTargetToProto(req.Target)
@@ -355,12 +380,13 @@ func (r *remoteWorkflow) UpsertEventTrigger(ctx context.Context, req coreworkflo
 		return nil, err
 	}
 	resp, err := r.client.UpsertEventTrigger(ctx, &proto.UpsertWorkflowProviderEventTriggerRequest{
-		TriggerId:    req.TriggerID,
-		Match:        workflowEventMatchToProto(req.Match),
-		Target:       target,
-		Paused:       req.Paused,
-		RequestedBy:  workflowActorToProto(req.RequestedBy),
-		ExecutionRef: req.ExecutionRef,
+		TriggerId:       req.TriggerID,
+		Match:           workflowEventMatchToProto(req.Match),
+		Target:          target,
+		Paused:          req.Paused,
+		RequestedBy:     workflowActorToProto(req.RequestedBy),
+		ExecutionRef:    req.ExecutionRef,
+		InvocationToken: invocationToken,
 	})
 	if err != nil {
 		return nil, err
@@ -371,10 +397,12 @@ func (r *remoteWorkflow) UpsertEventTrigger(ctx context.Context, req coreworkflo
 func (r *remoteWorkflow) GetEventTrigger(ctx context.Context, req coreworkflow.GetEventTriggerRequest) (trigger *coreworkflow.EventTrigger, err error) {
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationGetEventTrigger, workflowDims{triggerKind: observability.WorkflowTriggerKindEvent})
 	defer func() { end(err) }()
+	invocationToken := workflowProviderInvocationToken(ctx)
 	ctx, cancel := runtimehost.ProviderCallContext(ctx)
 	defer cancel()
 	resp, err := r.client.GetEventTrigger(ctx, &proto.GetWorkflowProviderEventTriggerRequest{
-		TriggerId: req.TriggerID,
+		TriggerId:       req.TriggerID,
+		InvocationToken: invocationToken,
 	})
 	if err != nil {
 		return nil, err
@@ -385,9 +413,10 @@ func (r *remoteWorkflow) GetEventTrigger(ctx context.Context, req coreworkflow.G
 func (r *remoteWorkflow) ListEventTriggers(ctx context.Context, req coreworkflow.ListEventTriggersRequest) (triggers []*coreworkflow.EventTrigger, err error) {
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationListEventTriggers, workflowDims{triggerKind: observability.WorkflowTriggerKindEvent})
 	defer func() { end(err) }()
+	invocationToken := workflowProviderInvocationToken(ctx)
 	ctx, cancel := runtimehost.ProviderCallContext(ctx)
 	defer cancel()
-	resp, err := r.client.ListEventTriggers(ctx, &proto.ListWorkflowProviderEventTriggersRequest{})
+	resp, err := r.client.ListEventTriggers(ctx, &proto.ListWorkflowProviderEventTriggersRequest{InvocationToken: invocationToken})
 	if err != nil {
 		return nil, err
 	}
@@ -405,10 +434,12 @@ func (r *remoteWorkflow) ListEventTriggers(ctx context.Context, req coreworkflow
 func (r *remoteWorkflow) DeleteEventTrigger(ctx context.Context, req coreworkflow.DeleteEventTriggerRequest) (err error) {
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationDeleteEventTrigger, workflowDims{triggerKind: observability.WorkflowTriggerKindEvent})
 	defer func() { end(err) }()
+	invocationToken := workflowProviderInvocationToken(ctx)
 	ctx, cancel := runtimehost.ProviderCallContext(ctx)
 	defer cancel()
 	_, err = r.client.DeleteEventTrigger(ctx, &proto.DeleteWorkflowProviderEventTriggerRequest{
-		TriggerId: req.TriggerID,
+		TriggerId:       req.TriggerID,
+		InvocationToken: invocationToken,
 	})
 	return err
 }
@@ -416,10 +447,12 @@ func (r *remoteWorkflow) DeleteEventTrigger(ctx context.Context, req coreworkflo
 func (r *remoteWorkflow) PauseEventTrigger(ctx context.Context, req coreworkflow.PauseEventTriggerRequest) (trigger *coreworkflow.EventTrigger, err error) {
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationPauseEventTrigger, workflowDims{triggerKind: observability.WorkflowTriggerKindEvent})
 	defer func() { end(err) }()
+	invocationToken := workflowProviderInvocationToken(ctx)
 	ctx, cancel := runtimehost.ProviderCallContext(ctx)
 	defer cancel()
 	resp, err := r.client.PauseEventTrigger(ctx, &proto.PauseWorkflowProviderEventTriggerRequest{
-		TriggerId: req.TriggerID,
+		TriggerId:       req.TriggerID,
+		InvocationToken: invocationToken,
 	})
 	if err != nil {
 		return nil, err
@@ -430,10 +463,12 @@ func (r *remoteWorkflow) PauseEventTrigger(ctx context.Context, req coreworkflow
 func (r *remoteWorkflow) ResumeEventTrigger(ctx context.Context, req coreworkflow.ResumeEventTriggerRequest) (trigger *coreworkflow.EventTrigger, err error) {
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationResumeEventTrigger, workflowDims{triggerKind: observability.WorkflowTriggerKindEvent})
 	defer func() { end(err) }()
+	invocationToken := workflowProviderInvocationToken(ctx)
 	ctx, cancel := runtimehost.ProviderCallContext(ctx)
 	defer cancel()
 	resp, err := r.client.ResumeEventTrigger(ctx, &proto.ResumeWorkflowProviderEventTriggerRequest{
-		TriggerId: req.TriggerID,
+		TriggerId:       req.TriggerID,
+		InvocationToken: invocationToken,
 	})
 	if err != nil {
 		return nil, err
@@ -448,6 +483,7 @@ func (r *remoteWorkflow) PublishEvent(ctx context.Context, req coreworkflow.Publ
 		end(err)
 		observability.RecordWorkflowEventPublished(metricCtx, err, r.workflowMetricDims(observability.WorkflowOperationPublishEvent, workflowDims{triggerKind: observability.WorkflowTriggerKindEvent}))
 	}()
+	invocationToken := workflowProviderInvocationToken(ctx)
 	ctx, cancel := runtimehost.ProviderCallContext(ctx)
 	defer cancel()
 	pbEvent, err := workflowEventToProto(req.Event)
@@ -455,9 +491,10 @@ func (r *remoteWorkflow) PublishEvent(ctx context.Context, req coreworkflow.Publ
 		return nil, err
 	}
 	resp, err := r.client.PublishEvent(ctx, &proto.PublishWorkflowProviderEventRequest{
-		AppName:     req.AppName,
-		Event:       pbEvent,
-		PublishedBy: workflowActorToProto(req.PublishedBy),
+		AppName:         req.AppName,
+		Event:           pbEvent,
+		PublishedBy:     workflowActorToProto(req.PublishedBy),
+		InvocationToken: invocationToken,
 	})
 	if err != nil {
 		return nil, err
@@ -573,6 +610,10 @@ func workflowTargetKind(target coreworkflow.Target) string {
 		return observability.WorkflowTargetKindSteps
 	}
 	return observability.WorkflowTargetKindUnknown
+}
+
+func workflowProviderInvocationToken(ctx context.Context) string {
+	return strings.TrimSpace(appaccessservice.InvocationTokenFromContext(ctx))
 }
 
 func workflowExecutionReferenceTarget(ref *coreworkflow.ExecutionReference) coreworkflow.Target {

--- a/gestaltd/services/workflows/client.go
+++ b/gestaltd/services/workflows/client.go
@@ -13,6 +13,8 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/egress"
 	"github.com/valon-technologies/gestalt/server/services/observability"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
+	gproto "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -101,21 +103,20 @@ func (r *remoteWorkflow) StartRun(ctx context.Context, req coreworkflow.StartRun
 		targetKind:  workflowTargetKind(req.Target),
 	})
 	defer func() { end(err) }()
-	invocationToken := workflowProviderInvocationToken(ctx)
-	ctx, cancel := runtimehost.ProviderCallContext(ctx)
-	defer cancel()
 	target, err := workflowTargetToProto(req.Target)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := r.client.StartRun(ctx, &proto.StartWorkflowProviderRunRequest{
-		Target:          target,
-		IdempotencyKey:  req.IdempotencyKey,
-		CreatedBy:       workflowActorToProto(req.CreatedBy),
-		ExecutionRef:    req.ExecutionRef,
-		WorkflowKey:     req.WorkflowKey,
-		InvocationToken: invocationToken,
-	})
+	pbReq := &proto.StartWorkflowProviderRunRequest{
+		Target:         target,
+		IdempotencyKey: req.IdempotencyKey,
+		CreatedBy:      workflowActorToProto(req.CreatedBy),
+		ExecutionRef:   req.ExecutionRef,
+		WorkflowKey:    req.WorkflowKey,
+	}
+	ctx, cancel := workflowProviderRequestContext(ctx, pbReq)
+	defer cancel()
+	resp, err := r.client.StartRun(ctx, pbReq)
 	if err != nil {
 		return nil, err
 	}
@@ -133,13 +134,10 @@ func (r *remoteWorkflow) StartRun(ctx context.Context, req coreworkflow.StartRun
 func (r *remoteWorkflow) GetRun(ctx context.Context, req coreworkflow.GetRunRequest) (run *coreworkflow.Run, err error) {
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationGetRun, workflowDims{})
 	defer func() { end(err) }()
-	invocationToken := workflowProviderInvocationToken(ctx)
-	ctx, cancel := runtimehost.ProviderCallContext(ctx)
+	pbReq := &proto.GetWorkflowProviderRunRequest{RunId: req.RunID}
+	ctx, cancel := workflowProviderRequestContext(ctx, pbReq)
 	defer cancel()
-	resp, err := r.client.GetRun(ctx, &proto.GetWorkflowProviderRunRequest{
-		RunId:           req.RunID,
-		InvocationToken: invocationToken,
-	})
+	resp, err := r.client.GetRun(ctx, pbReq)
 	if err != nil {
 		return nil, err
 	}
@@ -149,16 +147,15 @@ func (r *remoteWorkflow) GetRun(ctx context.Context, req coreworkflow.GetRunRequ
 func (r *remoteWorkflow) ListRuns(ctx context.Context, req coreworkflow.ListRunsRequest) (out *coreworkflow.ListRunsResponse, err error) {
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationListRuns, workflowDims{})
 	defer func() { end(err) }()
-	invocationToken := workflowProviderInvocationToken(ctx)
-	ctx, cancel := runtimehost.ProviderCallContext(ctx)
+	pbReq := &proto.ListWorkflowProviderRunsRequest{
+		PageSize:  int32(req.PageSize),
+		PageToken: strings.TrimSpace(req.PageToken),
+		Status:    workflowRunStatusToProto(req.Status),
+		TargetApp: strings.TrimSpace(req.TargetApp),
+	}
+	ctx, cancel := workflowProviderRequestContext(ctx, pbReq)
 	defer cancel()
-	resp, err := r.client.ListRuns(ctx, &proto.ListWorkflowProviderRunsRequest{
-		PageSize:        int32(req.PageSize),
-		PageToken:       strings.TrimSpace(req.PageToken),
-		Status:          workflowRunStatusToProto(req.Status),
-		InvocationToken: invocationToken,
-		TargetApp:       strings.TrimSpace(req.TargetApp),
-	})
+	resp, err := r.client.ListRuns(ctx, pbReq)
 	if err != nil {
 		return nil, err
 	}
@@ -179,14 +176,13 @@ func (r *remoteWorkflow) ListRuns(ctx context.Context, req coreworkflow.ListRuns
 func (r *remoteWorkflow) CancelRun(ctx context.Context, req coreworkflow.CancelRunRequest) (run *coreworkflow.Run, err error) {
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationCancelRun, workflowDims{})
 	defer func() { end(err) }()
-	invocationToken := workflowProviderInvocationToken(ctx)
-	ctx, cancel := runtimehost.ProviderCallContext(ctx)
+	pbReq := &proto.CancelWorkflowProviderRunRequest{
+		RunId:  req.RunID,
+		Reason: req.Reason,
+	}
+	ctx, cancel := workflowProviderRequestContext(ctx, pbReq)
 	defer cancel()
-	resp, err := r.client.CancelRun(ctx, &proto.CancelWorkflowProviderRunRequest{
-		RunId:           req.RunID,
-		Reason:          req.Reason,
-		InvocationToken: invocationToken,
-	})
+	resp, err := r.client.CancelRun(ctx, pbReq)
 	if err != nil {
 		return nil, err
 	}
@@ -196,18 +192,17 @@ func (r *remoteWorkflow) CancelRun(ctx context.Context, req coreworkflow.CancelR
 func (r *remoteWorkflow) SignalRun(ctx context.Context, req coreworkflow.SignalRunRequest) (out *coreworkflow.SignalRunResponse, err error) {
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationSignalRun, workflowDims{triggerKind: observability.WorkflowTriggerKindSignal})
 	defer func() { end(err) }()
-	invocationToken := workflowProviderInvocationToken(ctx)
-	ctx, cancel := runtimehost.ProviderCallContext(ctx)
-	defer cancel()
 	signal, err := workflowSignalToProto(req.Signal)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := r.client.SignalRun(ctx, &proto.SignalWorkflowProviderRunRequest{
-		RunId:           req.RunID,
-		Signal:          signal,
-		InvocationToken: invocationToken,
-	})
+	pbReq := &proto.SignalWorkflowProviderRunRequest{
+		RunId:  req.RunID,
+		Signal: signal,
+	}
+	ctx, cancel := workflowProviderRequestContext(ctx, pbReq)
+	defer cancel()
+	resp, err := r.client.SignalRun(ctx, pbReq)
 	if err != nil {
 		return nil, err
 	}
@@ -220,9 +215,6 @@ func (r *remoteWorkflow) SignalOrStartRun(ctx context.Context, req coreworkflow.
 		targetKind:  workflowTargetKind(req.Target),
 	})
 	defer func() { end(err) }()
-	invocationToken := workflowProviderInvocationToken(ctx)
-	ctx, cancel := runtimehost.ProviderCallContext(ctx)
-	defer cancel()
 	target, err := workflowTargetToProto(req.Target)
 	if err != nil {
 		return nil, err
@@ -231,15 +223,17 @@ func (r *remoteWorkflow) SignalOrStartRun(ctx context.Context, req coreworkflow.
 	if err != nil {
 		return nil, err
 	}
-	resp, err := r.client.SignalOrStartRun(ctx, &proto.SignalOrStartWorkflowProviderRunRequest{
-		WorkflowKey:     req.WorkflowKey,
-		Target:          target,
-		IdempotencyKey:  req.IdempotencyKey,
-		CreatedBy:       workflowActorToProto(req.CreatedBy),
-		ExecutionRef:    req.ExecutionRef,
-		Signal:          signal,
-		InvocationToken: invocationToken,
-	})
+	pbReq := &proto.SignalOrStartWorkflowProviderRunRequest{
+		WorkflowKey:    req.WorkflowKey,
+		Target:         target,
+		IdempotencyKey: req.IdempotencyKey,
+		CreatedBy:      workflowActorToProto(req.CreatedBy),
+		ExecutionRef:   req.ExecutionRef,
+		Signal:         signal,
+	}
+	ctx, cancel := workflowProviderRequestContext(ctx, pbReq)
+	defer cancel()
+	resp, err := r.client.SignalOrStartRun(ctx, pbReq)
 	if err != nil {
 		return nil, err
 	}
@@ -261,23 +255,22 @@ func (r *remoteWorkflow) UpsertSchedule(ctx context.Context, req coreworkflow.Up
 		targetKind:  workflowTargetKind(req.Target),
 	})
 	defer func() { end(err) }()
-	invocationToken := workflowProviderInvocationToken(ctx)
-	ctx, cancel := runtimehost.ProviderCallContext(ctx)
-	defer cancel()
 	target, err := workflowTargetToProto(req.Target)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := r.client.UpsertSchedule(ctx, &proto.UpsertWorkflowProviderScheduleRequest{
-		ScheduleId:      req.ScheduleID,
-		Cron:            req.Cron,
-		Timezone:        req.Timezone,
-		Target:          target,
-		Paused:          req.Paused,
-		RequestedBy:     workflowActorToProto(req.RequestedBy),
-		ExecutionRef:    req.ExecutionRef,
-		InvocationToken: invocationToken,
-	})
+	pbReq := &proto.UpsertWorkflowProviderScheduleRequest{
+		ScheduleId:   req.ScheduleID,
+		Cron:         req.Cron,
+		Timezone:     req.Timezone,
+		Target:       target,
+		Paused:       req.Paused,
+		RequestedBy:  workflowActorToProto(req.RequestedBy),
+		ExecutionRef: req.ExecutionRef,
+	}
+	ctx, cancel := workflowProviderRequestContext(ctx, pbReq)
+	defer cancel()
+	resp, err := r.client.UpsertSchedule(ctx, pbReq)
 	if err != nil {
 		return nil, err
 	}
@@ -287,13 +280,10 @@ func (r *remoteWorkflow) UpsertSchedule(ctx context.Context, req coreworkflow.Up
 func (r *remoteWorkflow) GetSchedule(ctx context.Context, req coreworkflow.GetScheduleRequest) (schedule *coreworkflow.Schedule, err error) {
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationGetSchedule, workflowDims{triggerKind: observability.WorkflowTriggerKindSchedule})
 	defer func() { end(err) }()
-	invocationToken := workflowProviderInvocationToken(ctx)
-	ctx, cancel := runtimehost.ProviderCallContext(ctx)
+	pbReq := &proto.GetWorkflowProviderScheduleRequest{ScheduleId: req.ScheduleID}
+	ctx, cancel := workflowProviderRequestContext(ctx, pbReq)
 	defer cancel()
-	resp, err := r.client.GetSchedule(ctx, &proto.GetWorkflowProviderScheduleRequest{
-		ScheduleId:      req.ScheduleID,
-		InvocationToken: invocationToken,
-	})
+	resp, err := r.client.GetSchedule(ctx, pbReq)
 	if err != nil {
 		return nil, err
 	}
@@ -303,10 +293,10 @@ func (r *remoteWorkflow) GetSchedule(ctx context.Context, req coreworkflow.GetSc
 func (r *remoteWorkflow) ListSchedules(ctx context.Context, req coreworkflow.ListSchedulesRequest) (schedules []*coreworkflow.Schedule, err error) {
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationListSchedules, workflowDims{triggerKind: observability.WorkflowTriggerKindSchedule})
 	defer func() { end(err) }()
-	invocationToken := workflowProviderInvocationToken(ctx)
-	ctx, cancel := runtimehost.ProviderCallContext(ctx)
+	pbReq := &proto.ListWorkflowProviderSchedulesRequest{}
+	ctx, cancel := workflowProviderRequestContext(ctx, pbReq)
 	defer cancel()
-	resp, err := r.client.ListSchedules(ctx, &proto.ListWorkflowProviderSchedulesRequest{InvocationToken: invocationToken})
+	resp, err := r.client.ListSchedules(ctx, pbReq)
 	if err != nil {
 		return nil, err
 	}
@@ -324,26 +314,20 @@ func (r *remoteWorkflow) ListSchedules(ctx context.Context, req coreworkflow.Lis
 func (r *remoteWorkflow) DeleteSchedule(ctx context.Context, req coreworkflow.DeleteScheduleRequest) (err error) {
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationDeleteSchedule, workflowDims{triggerKind: observability.WorkflowTriggerKindSchedule})
 	defer func() { end(err) }()
-	invocationToken := workflowProviderInvocationToken(ctx)
-	ctx, cancel := runtimehost.ProviderCallContext(ctx)
+	pbReq := &proto.DeleteWorkflowProviderScheduleRequest{ScheduleId: req.ScheduleID}
+	ctx, cancel := workflowProviderRequestContext(ctx, pbReq)
 	defer cancel()
-	_, err = r.client.DeleteSchedule(ctx, &proto.DeleteWorkflowProviderScheduleRequest{
-		ScheduleId:      req.ScheduleID,
-		InvocationToken: invocationToken,
-	})
+	_, err = r.client.DeleteSchedule(ctx, pbReq)
 	return err
 }
 
 func (r *remoteWorkflow) PauseSchedule(ctx context.Context, req coreworkflow.PauseScheduleRequest) (schedule *coreworkflow.Schedule, err error) {
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationPauseSchedule, workflowDims{triggerKind: observability.WorkflowTriggerKindSchedule})
 	defer func() { end(err) }()
-	invocationToken := workflowProviderInvocationToken(ctx)
-	ctx, cancel := runtimehost.ProviderCallContext(ctx)
+	pbReq := &proto.PauseWorkflowProviderScheduleRequest{ScheduleId: req.ScheduleID}
+	ctx, cancel := workflowProviderRequestContext(ctx, pbReq)
 	defer cancel()
-	resp, err := r.client.PauseSchedule(ctx, &proto.PauseWorkflowProviderScheduleRequest{
-		ScheduleId:      req.ScheduleID,
-		InvocationToken: invocationToken,
-	})
+	resp, err := r.client.PauseSchedule(ctx, pbReq)
 	if err != nil {
 		return nil, err
 	}
@@ -353,13 +337,10 @@ func (r *remoteWorkflow) PauseSchedule(ctx context.Context, req coreworkflow.Pau
 func (r *remoteWorkflow) ResumeSchedule(ctx context.Context, req coreworkflow.ResumeScheduleRequest) (schedule *coreworkflow.Schedule, err error) {
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationResumeSchedule, workflowDims{triggerKind: observability.WorkflowTriggerKindSchedule})
 	defer func() { end(err) }()
-	invocationToken := workflowProviderInvocationToken(ctx)
-	ctx, cancel := runtimehost.ProviderCallContext(ctx)
+	pbReq := &proto.ResumeWorkflowProviderScheduleRequest{ScheduleId: req.ScheduleID}
+	ctx, cancel := workflowProviderRequestContext(ctx, pbReq)
 	defer cancel()
-	resp, err := r.client.ResumeSchedule(ctx, &proto.ResumeWorkflowProviderScheduleRequest{
-		ScheduleId:      req.ScheduleID,
-		InvocationToken: invocationToken,
-	})
+	resp, err := r.client.ResumeSchedule(ctx, pbReq)
 	if err != nil {
 		return nil, err
 	}
@@ -372,22 +353,21 @@ func (r *remoteWorkflow) UpsertEventTrigger(ctx context.Context, req coreworkflo
 		targetKind:  workflowTargetKind(req.Target),
 	})
 	defer func() { end(err) }()
-	invocationToken := workflowProviderInvocationToken(ctx)
-	ctx, cancel := runtimehost.ProviderCallContext(ctx)
-	defer cancel()
 	target, err := workflowTargetToProto(req.Target)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := r.client.UpsertEventTrigger(ctx, &proto.UpsertWorkflowProviderEventTriggerRequest{
-		TriggerId:       req.TriggerID,
-		Match:           workflowEventMatchToProto(req.Match),
-		Target:          target,
-		Paused:          req.Paused,
-		RequestedBy:     workflowActorToProto(req.RequestedBy),
-		ExecutionRef:    req.ExecutionRef,
-		InvocationToken: invocationToken,
-	})
+	pbReq := &proto.UpsertWorkflowProviderEventTriggerRequest{
+		TriggerId:    req.TriggerID,
+		Match:        workflowEventMatchToProto(req.Match),
+		Target:       target,
+		Paused:       req.Paused,
+		RequestedBy:  workflowActorToProto(req.RequestedBy),
+		ExecutionRef: req.ExecutionRef,
+	}
+	ctx, cancel := workflowProviderRequestContext(ctx, pbReq)
+	defer cancel()
+	resp, err := r.client.UpsertEventTrigger(ctx, pbReq)
 	if err != nil {
 		return nil, err
 	}
@@ -397,13 +377,10 @@ func (r *remoteWorkflow) UpsertEventTrigger(ctx context.Context, req coreworkflo
 func (r *remoteWorkflow) GetEventTrigger(ctx context.Context, req coreworkflow.GetEventTriggerRequest) (trigger *coreworkflow.EventTrigger, err error) {
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationGetEventTrigger, workflowDims{triggerKind: observability.WorkflowTriggerKindEvent})
 	defer func() { end(err) }()
-	invocationToken := workflowProviderInvocationToken(ctx)
-	ctx, cancel := runtimehost.ProviderCallContext(ctx)
+	pbReq := &proto.GetWorkflowProviderEventTriggerRequest{TriggerId: req.TriggerID}
+	ctx, cancel := workflowProviderRequestContext(ctx, pbReq)
 	defer cancel()
-	resp, err := r.client.GetEventTrigger(ctx, &proto.GetWorkflowProviderEventTriggerRequest{
-		TriggerId:       req.TriggerID,
-		InvocationToken: invocationToken,
-	})
+	resp, err := r.client.GetEventTrigger(ctx, pbReq)
 	if err != nil {
 		return nil, err
 	}
@@ -413,10 +390,10 @@ func (r *remoteWorkflow) GetEventTrigger(ctx context.Context, req coreworkflow.G
 func (r *remoteWorkflow) ListEventTriggers(ctx context.Context, req coreworkflow.ListEventTriggersRequest) (triggers []*coreworkflow.EventTrigger, err error) {
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationListEventTriggers, workflowDims{triggerKind: observability.WorkflowTriggerKindEvent})
 	defer func() { end(err) }()
-	invocationToken := workflowProviderInvocationToken(ctx)
-	ctx, cancel := runtimehost.ProviderCallContext(ctx)
+	pbReq := &proto.ListWorkflowProviderEventTriggersRequest{}
+	ctx, cancel := workflowProviderRequestContext(ctx, pbReq)
 	defer cancel()
-	resp, err := r.client.ListEventTriggers(ctx, &proto.ListWorkflowProviderEventTriggersRequest{InvocationToken: invocationToken})
+	resp, err := r.client.ListEventTriggers(ctx, pbReq)
 	if err != nil {
 		return nil, err
 	}
@@ -434,26 +411,20 @@ func (r *remoteWorkflow) ListEventTriggers(ctx context.Context, req coreworkflow
 func (r *remoteWorkflow) DeleteEventTrigger(ctx context.Context, req coreworkflow.DeleteEventTriggerRequest) (err error) {
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationDeleteEventTrigger, workflowDims{triggerKind: observability.WorkflowTriggerKindEvent})
 	defer func() { end(err) }()
-	invocationToken := workflowProviderInvocationToken(ctx)
-	ctx, cancel := runtimehost.ProviderCallContext(ctx)
+	pbReq := &proto.DeleteWorkflowProviderEventTriggerRequest{TriggerId: req.TriggerID}
+	ctx, cancel := workflowProviderRequestContext(ctx, pbReq)
 	defer cancel()
-	_, err = r.client.DeleteEventTrigger(ctx, &proto.DeleteWorkflowProviderEventTriggerRequest{
-		TriggerId:       req.TriggerID,
-		InvocationToken: invocationToken,
-	})
+	_, err = r.client.DeleteEventTrigger(ctx, pbReq)
 	return err
 }
 
 func (r *remoteWorkflow) PauseEventTrigger(ctx context.Context, req coreworkflow.PauseEventTriggerRequest) (trigger *coreworkflow.EventTrigger, err error) {
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationPauseEventTrigger, workflowDims{triggerKind: observability.WorkflowTriggerKindEvent})
 	defer func() { end(err) }()
-	invocationToken := workflowProviderInvocationToken(ctx)
-	ctx, cancel := runtimehost.ProviderCallContext(ctx)
+	pbReq := &proto.PauseWorkflowProviderEventTriggerRequest{TriggerId: req.TriggerID}
+	ctx, cancel := workflowProviderRequestContext(ctx, pbReq)
 	defer cancel()
-	resp, err := r.client.PauseEventTrigger(ctx, &proto.PauseWorkflowProviderEventTriggerRequest{
-		TriggerId:       req.TriggerID,
-		InvocationToken: invocationToken,
-	})
+	resp, err := r.client.PauseEventTrigger(ctx, pbReq)
 	if err != nil {
 		return nil, err
 	}
@@ -463,13 +434,10 @@ func (r *remoteWorkflow) PauseEventTrigger(ctx context.Context, req coreworkflow
 func (r *remoteWorkflow) ResumeEventTrigger(ctx context.Context, req coreworkflow.ResumeEventTriggerRequest) (trigger *coreworkflow.EventTrigger, err error) {
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationResumeEventTrigger, workflowDims{triggerKind: observability.WorkflowTriggerKindEvent})
 	defer func() { end(err) }()
-	invocationToken := workflowProviderInvocationToken(ctx)
-	ctx, cancel := runtimehost.ProviderCallContext(ctx)
+	pbReq := &proto.ResumeWorkflowProviderEventTriggerRequest{TriggerId: req.TriggerID}
+	ctx, cancel := workflowProviderRequestContext(ctx, pbReq)
 	defer cancel()
-	resp, err := r.client.ResumeEventTrigger(ctx, &proto.ResumeWorkflowProviderEventTriggerRequest{
-		TriggerId:       req.TriggerID,
-		InvocationToken: invocationToken,
-	})
+	resp, err := r.client.ResumeEventTrigger(ctx, pbReq)
 	if err != nil {
 		return nil, err
 	}
@@ -483,19 +451,18 @@ func (r *remoteWorkflow) PublishEvent(ctx context.Context, req coreworkflow.Publ
 		end(err)
 		observability.RecordWorkflowEventPublished(metricCtx, err, r.workflowMetricDims(observability.WorkflowOperationPublishEvent, workflowDims{triggerKind: observability.WorkflowTriggerKindEvent}))
 	}()
-	invocationToken := workflowProviderInvocationToken(ctx)
-	ctx, cancel := runtimehost.ProviderCallContext(ctx)
-	defer cancel()
 	pbEvent, err := workflowEventToProto(req.Event)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := r.client.PublishEvent(ctx, &proto.PublishWorkflowProviderEventRequest{
-		AppName:         req.AppName,
-		Event:           pbEvent,
-		PublishedBy:     workflowActorToProto(req.PublishedBy),
-		InvocationToken: invocationToken,
-	})
+	pbReq := &proto.PublishWorkflowProviderEventRequest{
+		AppName:     req.AppName,
+		Event:       pbEvent,
+		PublishedBy: workflowActorToProto(req.PublishedBy),
+	}
+	ctx, cancel := workflowProviderRequestContext(ctx, pbReq)
+	defer cancel()
+	resp, err := r.client.PublishEvent(ctx, pbReq)
 	if err != nil {
 		return nil, err
 	}
@@ -612,8 +579,25 @@ func workflowTargetKind(target coreworkflow.Target) string {
 	return observability.WorkflowTargetKindUnknown
 }
 
-func workflowProviderInvocationToken(ctx context.Context) string {
-	return strings.TrimSpace(appaccessservice.InvocationTokenFromContext(ctx))
+func workflowProviderRequestContext(ctx context.Context, req gproto.Message) (context.Context, context.CancelFunc) {
+	attachWorkflowProviderInvocationToken(ctx, req)
+	return runtimehost.ProviderCallContext(ctx)
+}
+
+func attachWorkflowProviderInvocationToken(ctx context.Context, req gproto.Message) {
+	if req == nil {
+		return
+	}
+	token := strings.TrimSpace(appaccessservice.InvocationTokenFromContext(ctx))
+	if token == "" {
+		return
+	}
+	msg := req.ProtoReflect()
+	field := msg.Descriptor().Fields().ByName(protoreflect.Name("invocation_token"))
+	if field == nil || field.Kind() != protoreflect.StringKind {
+		return
+	}
+	msg.Set(field, protoreflect.ValueOfString(token))
 }
 
 func workflowExecutionReferenceTarget(ref *coreworkflow.ExecutionReference) coreworkflow.Target {

--- a/gestaltd/services/workflows/client_invocation_token_test.go
+++ b/gestaltd/services/workflows/client_invocation_token_test.go
@@ -46,89 +46,9 @@ func (s *recordingWorkflowProviderServer) StartRun(_ context.Context, req *proto
 	return &proto.BoundWorkflowRun{Id: "run-1", Status: proto.WorkflowRunStatus_WORKFLOW_RUN_STATUS_PENDING}, nil
 }
 
-func (s *recordingWorkflowProviderServer) GetRun(_ context.Context, req *proto.GetWorkflowProviderRunRequest) (*proto.BoundWorkflowRun, error) {
-	s.record("GetRun", req.GetInvocationToken())
-	return &proto.BoundWorkflowRun{Id: req.GetRunId(), Status: proto.WorkflowRunStatus_WORKFLOW_RUN_STATUS_SUCCEEDED}, nil
-}
-
-func (s *recordingWorkflowProviderServer) ListRuns(_ context.Context, req *proto.ListWorkflowProviderRunsRequest) (*proto.ListWorkflowProviderRunsResponse, error) {
-	s.record("ListRuns", req.GetInvocationToken())
-	return &proto.ListWorkflowProviderRunsResponse{}, nil
-}
-
-func (s *recordingWorkflowProviderServer) CancelRun(_ context.Context, req *proto.CancelWorkflowProviderRunRequest) (*proto.BoundWorkflowRun, error) {
-	s.record("CancelRun", req.GetInvocationToken())
-	return &proto.BoundWorkflowRun{Id: req.GetRunId(), Status: proto.WorkflowRunStatus_WORKFLOW_RUN_STATUS_CANCELED}, nil
-}
-
-func (s *recordingWorkflowProviderServer) SignalRun(_ context.Context, req *proto.SignalWorkflowProviderRunRequest) (*proto.SignalWorkflowRunResponse, error) {
-	s.record("SignalRun", req.GetInvocationToken())
-	return &proto.SignalWorkflowRunResponse{Run: &proto.BoundWorkflowRun{Id: req.GetRunId()}}, nil
-}
-
-func (s *recordingWorkflowProviderServer) SignalOrStartRun(_ context.Context, req *proto.SignalOrStartWorkflowProviderRunRequest) (*proto.SignalWorkflowRunResponse, error) {
-	s.record("SignalOrStartRun", req.GetInvocationToken())
-	return &proto.SignalWorkflowRunResponse{Run: &proto.BoundWorkflowRun{Id: "run-1"}}, nil
-}
-
-func (s *recordingWorkflowProviderServer) UpsertSchedule(_ context.Context, req *proto.UpsertWorkflowProviderScheduleRequest) (*proto.BoundWorkflowSchedule, error) {
-	s.record("UpsertSchedule", req.GetInvocationToken())
-	return &proto.BoundWorkflowSchedule{Id: "schedule-1"}, nil
-}
-
-func (s *recordingWorkflowProviderServer) GetSchedule(_ context.Context, req *proto.GetWorkflowProviderScheduleRequest) (*proto.BoundWorkflowSchedule, error) {
-	s.record("GetSchedule", req.GetInvocationToken())
-	return &proto.BoundWorkflowSchedule{Id: req.GetScheduleId()}, nil
-}
-
 func (s *recordingWorkflowProviderServer) ListSchedules(_ context.Context, req *proto.ListWorkflowProviderSchedulesRequest) (*proto.ListWorkflowProviderSchedulesResponse, error) {
 	s.record("ListSchedules", req.GetInvocationToken())
 	return &proto.ListWorkflowProviderSchedulesResponse{}, nil
-}
-
-func (s *recordingWorkflowProviderServer) DeleteSchedule(_ context.Context, req *proto.DeleteWorkflowProviderScheduleRequest) (*emptypb.Empty, error) {
-	s.record("DeleteSchedule", req.GetInvocationToken())
-	return &emptypb.Empty{}, nil
-}
-
-func (s *recordingWorkflowProviderServer) PauseSchedule(_ context.Context, req *proto.PauseWorkflowProviderScheduleRequest) (*proto.BoundWorkflowSchedule, error) {
-	s.record("PauseSchedule", req.GetInvocationToken())
-	return &proto.BoundWorkflowSchedule{Id: req.GetScheduleId()}, nil
-}
-
-func (s *recordingWorkflowProviderServer) ResumeSchedule(_ context.Context, req *proto.ResumeWorkflowProviderScheduleRequest) (*proto.BoundWorkflowSchedule, error) {
-	s.record("ResumeSchedule", req.GetInvocationToken())
-	return &proto.BoundWorkflowSchedule{Id: req.GetScheduleId()}, nil
-}
-
-func (s *recordingWorkflowProviderServer) UpsertEventTrigger(_ context.Context, req *proto.UpsertWorkflowProviderEventTriggerRequest) (*proto.BoundWorkflowEventTrigger, error) {
-	s.record("UpsertEventTrigger", req.GetInvocationToken())
-	return &proto.BoundWorkflowEventTrigger{Id: "trigger-1"}, nil
-}
-
-func (s *recordingWorkflowProviderServer) GetEventTrigger(_ context.Context, req *proto.GetWorkflowProviderEventTriggerRequest) (*proto.BoundWorkflowEventTrigger, error) {
-	s.record("GetEventTrigger", req.GetInvocationToken())
-	return &proto.BoundWorkflowEventTrigger{Id: req.GetTriggerId()}, nil
-}
-
-func (s *recordingWorkflowProviderServer) ListEventTriggers(_ context.Context, req *proto.ListWorkflowProviderEventTriggersRequest) (*proto.ListWorkflowProviderEventTriggersResponse, error) {
-	s.record("ListEventTriggers", req.GetInvocationToken())
-	return &proto.ListWorkflowProviderEventTriggersResponse{}, nil
-}
-
-func (s *recordingWorkflowProviderServer) DeleteEventTrigger(_ context.Context, req *proto.DeleteWorkflowProviderEventTriggerRequest) (*emptypb.Empty, error) {
-	s.record("DeleteEventTrigger", req.GetInvocationToken())
-	return &emptypb.Empty{}, nil
-}
-
-func (s *recordingWorkflowProviderServer) PauseEventTrigger(_ context.Context, req *proto.PauseWorkflowProviderEventTriggerRequest) (*proto.BoundWorkflowEventTrigger, error) {
-	s.record("PauseEventTrigger", req.GetInvocationToken())
-	return &proto.BoundWorkflowEventTrigger{Id: req.GetTriggerId()}, nil
-}
-
-func (s *recordingWorkflowProviderServer) ResumeEventTrigger(_ context.Context, req *proto.ResumeWorkflowProviderEventTriggerRequest) (*proto.BoundWorkflowEventTrigger, error) {
-	s.record("ResumeEventTrigger", req.GetInvocationToken())
-	return &proto.BoundWorkflowEventTrigger{Id: req.GetTriggerId()}, nil
 }
 
 func (s *recordingWorkflowProviderServer) PublishEvent(_ context.Context, req *proto.PublishWorkflowProviderEventRequest) (*proto.WorkflowEvent, error) {
@@ -136,11 +56,24 @@ func (s *recordingWorkflowProviderServer) PublishEvent(_ context.Context, req *p
 	return &proto.WorkflowEvent{Id: "event-1", Type: req.GetEvent().GetType()}, nil
 }
 
-func TestRemoteWorkflowForwardsInvocationToken(t *testing.T) {
+func TestRemoteWorkflowForwardsRestoredInvocationToken(t *testing.T) {
 	t.Parallel()
 
+	manager, err := appaccessservice.NewInvocationTokenManager([]byte("workflow-provider-token-test-secret"))
+	if err != nil {
+		t.Fatalf("NewInvocationTokenManager: %v", err)
+	}
+	token, err := manager.MintRootToken(context.Background(), "caller", nil)
+	if err != nil {
+		t.Fatalf("MintRootToken: %v", err)
+	}
+	tokenCtx, err := manager.ResolveToken(token, "caller")
+	if err != nil {
+		t.Fatalf("ResolveToken: %v", err)
+	}
+	ctx := appaccessservice.RestoreTokenContext(context.Background(), tokenCtx, "")
+
 	workflow, server := newRecordingRemoteWorkflow(t)
-	ctx := appaccessservice.WithInvocationToken(context.Background(), "workflow-provider-token")
 	target := coreworkflow.Target{Steps: []coreworkflow.Step{{
 		ID:  "call_app",
 		App: &coreworkflow.AppCall{Name: "slack", Operation: "chat.postMessage"},
@@ -151,70 +84,8 @@ func TestRemoteWorkflowForwardsInvocationToken(t *testing.T) {
 			_, err := workflow.StartRun(ctx, coreworkflow.StartRunRequest{Target: target})
 			return err
 		},
-		"GetRun": func() error {
-			_, err := workflow.GetRun(ctx, coreworkflow.GetRunRequest{RunID: "run-1"})
-			return err
-		},
-		"ListRuns": func() error {
-			_, err := workflow.ListRuns(ctx, coreworkflow.ListRunsRequest{})
-			return err
-		},
-		"CancelRun": func() error {
-			_, err := workflow.CancelRun(ctx, coreworkflow.CancelRunRequest{RunID: "run-1"})
-			return err
-		},
-		"SignalRun": func() error {
-			_, err := workflow.SignalRun(ctx, coreworkflow.SignalRunRequest{RunID: "run-1", Signal: coreworkflow.Signal{Name: "wake"}})
-			return err
-		},
-		"SignalOrStartRun": func() error {
-			_, err := workflow.SignalOrStartRun(ctx, coreworkflow.SignalOrStartRunRequest{Target: target, Signal: coreworkflow.Signal{Name: "wake"}})
-			return err
-		},
-		"UpsertSchedule": func() error {
-			_, err := workflow.UpsertSchedule(ctx, coreworkflow.UpsertScheduleRequest{Target: target})
-			return err
-		},
-		"GetSchedule": func() error {
-			_, err := workflow.GetSchedule(ctx, coreworkflow.GetScheduleRequest{ScheduleID: "schedule-1"})
-			return err
-		},
 		"ListSchedules": func() error {
 			_, err := workflow.ListSchedules(ctx, coreworkflow.ListSchedulesRequest{})
-			return err
-		},
-		"DeleteSchedule": func() error {
-			return workflow.DeleteSchedule(ctx, coreworkflow.DeleteScheduleRequest{ScheduleID: "schedule-1"})
-		},
-		"PauseSchedule": func() error {
-			_, err := workflow.PauseSchedule(ctx, coreworkflow.PauseScheduleRequest{ScheduleID: "schedule-1"})
-			return err
-		},
-		"ResumeSchedule": func() error {
-			_, err := workflow.ResumeSchedule(ctx, coreworkflow.ResumeScheduleRequest{ScheduleID: "schedule-1"})
-			return err
-		},
-		"UpsertEventTrigger": func() error {
-			_, err := workflow.UpsertEventTrigger(ctx, coreworkflow.UpsertEventTriggerRequest{Target: target})
-			return err
-		},
-		"GetEventTrigger": func() error {
-			_, err := workflow.GetEventTrigger(ctx, coreworkflow.GetEventTriggerRequest{TriggerID: "trigger-1"})
-			return err
-		},
-		"ListEventTriggers": func() error {
-			_, err := workflow.ListEventTriggers(ctx, coreworkflow.ListEventTriggersRequest{})
-			return err
-		},
-		"DeleteEventTrigger": func() error {
-			return workflow.DeleteEventTrigger(ctx, coreworkflow.DeleteEventTriggerRequest{TriggerID: "trigger-1"})
-		},
-		"PauseEventTrigger": func() error {
-			_, err := workflow.PauseEventTrigger(ctx, coreworkflow.PauseEventTriggerRequest{TriggerID: "trigger-1"})
-			return err
-		},
-		"ResumeEventTrigger": func() error {
-			_, err := workflow.ResumeEventTrigger(ctx, coreworkflow.ResumeEventTriggerRequest{TriggerID: "trigger-1"})
 			return err
 		},
 		"PublishEvent": func() error {
@@ -229,8 +100,8 @@ func TestRemoteWorkflowForwardsInvocationToken(t *testing.T) {
 		}
 	}
 	for name := range calls {
-		if got := server.tokens[name]; got != "workflow-provider-token" {
-			t.Fatalf("%s invocation token = %q, want workflow-provider-token", name, got)
+		if got := server.tokens[name]; got != token {
+			t.Fatalf("%s invocation token = %q, want restored token", name, got)
 		}
 	}
 }

--- a/gestaltd/services/workflows/client_invocation_token_test.go
+++ b/gestaltd/services/workflows/client_invocation_token_test.go
@@ -1,0 +1,275 @@
+package workflows
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	appaccessservice "github.com/valon-technologies/gestalt/server/services/appaccess"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+type recordingWorkflowProviderServer struct {
+	proto.UnimplementedWorkflowProviderServer
+	proto.UnimplementedProviderLifecycleServer
+
+	tokens map[string]string
+}
+
+func (s *recordingWorkflowProviderServer) record(name, token string) {
+	if s.tokens == nil {
+		s.tokens = map[string]string{}
+	}
+	s.tokens[name] = token
+}
+
+func (s *recordingWorkflowProviderServer) GetProviderIdentity(context.Context, *emptypb.Empty) (*proto.ProviderIdentity, error) {
+	return &proto.ProviderIdentity{
+		Kind:               proto.ProviderKind_PROVIDER_KIND_WORKFLOW,
+		Name:               "recording",
+		MinProtocolVersion: proto.CurrentProtocolVersion,
+		MaxProtocolVersion: proto.CurrentProtocolVersion,
+	}, nil
+}
+
+func (s *recordingWorkflowProviderServer) ConfigureProvider(context.Context, *proto.ConfigureProviderRequest) (*proto.ConfigureProviderResponse, error) {
+	return &proto.ConfigureProviderResponse{ProtocolVersion: proto.CurrentProtocolVersion}, nil
+}
+
+func (s *recordingWorkflowProviderServer) StartRun(_ context.Context, req *proto.StartWorkflowProviderRunRequest) (*proto.BoundWorkflowRun, error) {
+	s.record("StartRun", req.GetInvocationToken())
+	return &proto.BoundWorkflowRun{Id: "run-1", Status: proto.WorkflowRunStatus_WORKFLOW_RUN_STATUS_PENDING}, nil
+}
+
+func (s *recordingWorkflowProviderServer) GetRun(_ context.Context, req *proto.GetWorkflowProviderRunRequest) (*proto.BoundWorkflowRun, error) {
+	s.record("GetRun", req.GetInvocationToken())
+	return &proto.BoundWorkflowRun{Id: req.GetRunId(), Status: proto.WorkflowRunStatus_WORKFLOW_RUN_STATUS_SUCCEEDED}, nil
+}
+
+func (s *recordingWorkflowProviderServer) ListRuns(_ context.Context, req *proto.ListWorkflowProviderRunsRequest) (*proto.ListWorkflowProviderRunsResponse, error) {
+	s.record("ListRuns", req.GetInvocationToken())
+	return &proto.ListWorkflowProviderRunsResponse{}, nil
+}
+
+func (s *recordingWorkflowProviderServer) CancelRun(_ context.Context, req *proto.CancelWorkflowProviderRunRequest) (*proto.BoundWorkflowRun, error) {
+	s.record("CancelRun", req.GetInvocationToken())
+	return &proto.BoundWorkflowRun{Id: req.GetRunId(), Status: proto.WorkflowRunStatus_WORKFLOW_RUN_STATUS_CANCELED}, nil
+}
+
+func (s *recordingWorkflowProviderServer) SignalRun(_ context.Context, req *proto.SignalWorkflowProviderRunRequest) (*proto.SignalWorkflowRunResponse, error) {
+	s.record("SignalRun", req.GetInvocationToken())
+	return &proto.SignalWorkflowRunResponse{Run: &proto.BoundWorkflowRun{Id: req.GetRunId()}}, nil
+}
+
+func (s *recordingWorkflowProviderServer) SignalOrStartRun(_ context.Context, req *proto.SignalOrStartWorkflowProviderRunRequest) (*proto.SignalWorkflowRunResponse, error) {
+	s.record("SignalOrStartRun", req.GetInvocationToken())
+	return &proto.SignalWorkflowRunResponse{Run: &proto.BoundWorkflowRun{Id: "run-1"}}, nil
+}
+
+func (s *recordingWorkflowProviderServer) UpsertSchedule(_ context.Context, req *proto.UpsertWorkflowProviderScheduleRequest) (*proto.BoundWorkflowSchedule, error) {
+	s.record("UpsertSchedule", req.GetInvocationToken())
+	return &proto.BoundWorkflowSchedule{Id: "schedule-1"}, nil
+}
+
+func (s *recordingWorkflowProviderServer) GetSchedule(_ context.Context, req *proto.GetWorkflowProviderScheduleRequest) (*proto.BoundWorkflowSchedule, error) {
+	s.record("GetSchedule", req.GetInvocationToken())
+	return &proto.BoundWorkflowSchedule{Id: req.GetScheduleId()}, nil
+}
+
+func (s *recordingWorkflowProviderServer) ListSchedules(_ context.Context, req *proto.ListWorkflowProviderSchedulesRequest) (*proto.ListWorkflowProviderSchedulesResponse, error) {
+	s.record("ListSchedules", req.GetInvocationToken())
+	return &proto.ListWorkflowProviderSchedulesResponse{}, nil
+}
+
+func (s *recordingWorkflowProviderServer) DeleteSchedule(_ context.Context, req *proto.DeleteWorkflowProviderScheduleRequest) (*emptypb.Empty, error) {
+	s.record("DeleteSchedule", req.GetInvocationToken())
+	return &emptypb.Empty{}, nil
+}
+
+func (s *recordingWorkflowProviderServer) PauseSchedule(_ context.Context, req *proto.PauseWorkflowProviderScheduleRequest) (*proto.BoundWorkflowSchedule, error) {
+	s.record("PauseSchedule", req.GetInvocationToken())
+	return &proto.BoundWorkflowSchedule{Id: req.GetScheduleId()}, nil
+}
+
+func (s *recordingWorkflowProviderServer) ResumeSchedule(_ context.Context, req *proto.ResumeWorkflowProviderScheduleRequest) (*proto.BoundWorkflowSchedule, error) {
+	s.record("ResumeSchedule", req.GetInvocationToken())
+	return &proto.BoundWorkflowSchedule{Id: req.GetScheduleId()}, nil
+}
+
+func (s *recordingWorkflowProviderServer) UpsertEventTrigger(_ context.Context, req *proto.UpsertWorkflowProviderEventTriggerRequest) (*proto.BoundWorkflowEventTrigger, error) {
+	s.record("UpsertEventTrigger", req.GetInvocationToken())
+	return &proto.BoundWorkflowEventTrigger{Id: "trigger-1"}, nil
+}
+
+func (s *recordingWorkflowProviderServer) GetEventTrigger(_ context.Context, req *proto.GetWorkflowProviderEventTriggerRequest) (*proto.BoundWorkflowEventTrigger, error) {
+	s.record("GetEventTrigger", req.GetInvocationToken())
+	return &proto.BoundWorkflowEventTrigger{Id: req.GetTriggerId()}, nil
+}
+
+func (s *recordingWorkflowProviderServer) ListEventTriggers(_ context.Context, req *proto.ListWorkflowProviderEventTriggersRequest) (*proto.ListWorkflowProviderEventTriggersResponse, error) {
+	s.record("ListEventTriggers", req.GetInvocationToken())
+	return &proto.ListWorkflowProviderEventTriggersResponse{}, nil
+}
+
+func (s *recordingWorkflowProviderServer) DeleteEventTrigger(_ context.Context, req *proto.DeleteWorkflowProviderEventTriggerRequest) (*emptypb.Empty, error) {
+	s.record("DeleteEventTrigger", req.GetInvocationToken())
+	return &emptypb.Empty{}, nil
+}
+
+func (s *recordingWorkflowProviderServer) PauseEventTrigger(_ context.Context, req *proto.PauseWorkflowProviderEventTriggerRequest) (*proto.BoundWorkflowEventTrigger, error) {
+	s.record("PauseEventTrigger", req.GetInvocationToken())
+	return &proto.BoundWorkflowEventTrigger{Id: req.GetTriggerId()}, nil
+}
+
+func (s *recordingWorkflowProviderServer) ResumeEventTrigger(_ context.Context, req *proto.ResumeWorkflowProviderEventTriggerRequest) (*proto.BoundWorkflowEventTrigger, error) {
+	s.record("ResumeEventTrigger", req.GetInvocationToken())
+	return &proto.BoundWorkflowEventTrigger{Id: req.GetTriggerId()}, nil
+}
+
+func (s *recordingWorkflowProviderServer) PublishEvent(_ context.Context, req *proto.PublishWorkflowProviderEventRequest) (*proto.WorkflowEvent, error) {
+	s.record("PublishEvent", req.GetInvocationToken())
+	return &proto.WorkflowEvent{Id: "event-1", Type: req.GetEvent().GetType()}, nil
+}
+
+func TestRemoteWorkflowForwardsInvocationToken(t *testing.T) {
+	t.Parallel()
+
+	workflow, server := newRecordingRemoteWorkflow(t)
+	ctx := appaccessservice.WithInvocationToken(context.Background(), "workflow-provider-token")
+	target := coreworkflow.Target{Steps: []coreworkflow.Step{{
+		ID:  "call_app",
+		App: &coreworkflow.AppCall{Name: "slack", Operation: "chat.postMessage"},
+	}}}
+
+	calls := map[string]func() error{
+		"StartRun": func() error {
+			_, err := workflow.StartRun(ctx, coreworkflow.StartRunRequest{Target: target})
+			return err
+		},
+		"GetRun": func() error {
+			_, err := workflow.GetRun(ctx, coreworkflow.GetRunRequest{RunID: "run-1"})
+			return err
+		},
+		"ListRuns": func() error {
+			_, err := workflow.ListRuns(ctx, coreworkflow.ListRunsRequest{})
+			return err
+		},
+		"CancelRun": func() error {
+			_, err := workflow.CancelRun(ctx, coreworkflow.CancelRunRequest{RunID: "run-1"})
+			return err
+		},
+		"SignalRun": func() error {
+			_, err := workflow.SignalRun(ctx, coreworkflow.SignalRunRequest{RunID: "run-1", Signal: coreworkflow.Signal{Name: "wake"}})
+			return err
+		},
+		"SignalOrStartRun": func() error {
+			_, err := workflow.SignalOrStartRun(ctx, coreworkflow.SignalOrStartRunRequest{Target: target, Signal: coreworkflow.Signal{Name: "wake"}})
+			return err
+		},
+		"UpsertSchedule": func() error {
+			_, err := workflow.UpsertSchedule(ctx, coreworkflow.UpsertScheduleRequest{Target: target})
+			return err
+		},
+		"GetSchedule": func() error {
+			_, err := workflow.GetSchedule(ctx, coreworkflow.GetScheduleRequest{ScheduleID: "schedule-1"})
+			return err
+		},
+		"ListSchedules": func() error {
+			_, err := workflow.ListSchedules(ctx, coreworkflow.ListSchedulesRequest{})
+			return err
+		},
+		"DeleteSchedule": func() error {
+			return workflow.DeleteSchedule(ctx, coreworkflow.DeleteScheduleRequest{ScheduleID: "schedule-1"})
+		},
+		"PauseSchedule": func() error {
+			_, err := workflow.PauseSchedule(ctx, coreworkflow.PauseScheduleRequest{ScheduleID: "schedule-1"})
+			return err
+		},
+		"ResumeSchedule": func() error {
+			_, err := workflow.ResumeSchedule(ctx, coreworkflow.ResumeScheduleRequest{ScheduleID: "schedule-1"})
+			return err
+		},
+		"UpsertEventTrigger": func() error {
+			_, err := workflow.UpsertEventTrigger(ctx, coreworkflow.UpsertEventTriggerRequest{Target: target})
+			return err
+		},
+		"GetEventTrigger": func() error {
+			_, err := workflow.GetEventTrigger(ctx, coreworkflow.GetEventTriggerRequest{TriggerID: "trigger-1"})
+			return err
+		},
+		"ListEventTriggers": func() error {
+			_, err := workflow.ListEventTriggers(ctx, coreworkflow.ListEventTriggersRequest{})
+			return err
+		},
+		"DeleteEventTrigger": func() error {
+			return workflow.DeleteEventTrigger(ctx, coreworkflow.DeleteEventTriggerRequest{TriggerID: "trigger-1"})
+		},
+		"PauseEventTrigger": func() error {
+			_, err := workflow.PauseEventTrigger(ctx, coreworkflow.PauseEventTriggerRequest{TriggerID: "trigger-1"})
+			return err
+		},
+		"ResumeEventTrigger": func() error {
+			_, err := workflow.ResumeEventTrigger(ctx, coreworkflow.ResumeEventTriggerRequest{TriggerID: "trigger-1"})
+			return err
+		},
+		"PublishEvent": func() error {
+			_, err := workflow.PublishEvent(ctx, coreworkflow.PublishEventRequest{Event: coreworkflow.Event{Type: "issue.created"}})
+			return err
+		},
+	}
+
+	for name, call := range calls {
+		if err := call(); err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+	}
+	for name := range calls {
+		if got := server.tokens[name]; got != "workflow-provider-token" {
+			t.Fatalf("%s invocation token = %q, want workflow-provider-token", name, got)
+		}
+	}
+}
+
+func newRecordingRemoteWorkflow(t *testing.T) (coreworkflow.Provider, *recordingWorkflowProviderServer) {
+	t.Helper()
+
+	lis := bufconn.Listen(1024 * 1024)
+	srv := grpc.NewServer()
+	provider := &recordingWorkflowProviderServer{}
+	proto.RegisterWorkflowProviderServer(srv, provider)
+	proto.RegisterProviderLifecycleServer(srv, provider)
+	go func() {
+		_ = srv.Serve(lis)
+	}()
+	t.Cleanup(func() {
+		srv.Stop()
+		_ = lis.Close()
+	})
+
+	conn, err := grpc.NewClient("passthrough:///workflow-provider",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return lis.Dial()
+		}),
+	)
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	workflow, err := NewRemote(context.Background(), RemoteConfig{
+		Client:  proto.NewWorkflowProviderClient(conn),
+		Runtime: proto.NewProviderLifecycleClient(conn),
+		Closer:  noopCloser{},
+		Name:    "recording",
+	})
+	if err != nil {
+		t.Fatalf("NewRemote: %v", err)
+	}
+	return workflow, provider
+}

--- a/sdk/go/serve.go
+++ b/sdk/go/serve.go
@@ -65,7 +65,7 @@ func withProviderCloser(ctx context.Context, provider any) context.Context {
 	return ctx
 }
 
-func serveProvider(ctx context.Context, register func(*grpc.Server)) error {
+func serveProvider(ctx context.Context, register func(*grpc.Server), opts ...grpc.ServerOption) error {
 	socket := os.Getenv(proto.EnvProviderSocket)
 	if socket == "" {
 		return fmt.Errorf("%s is required", proto.EnvProviderSocket)
@@ -90,7 +90,7 @@ func serveProvider(ctx context.Context, register func(*grpc.Server)) error {
 		_ = os.Remove(socket)
 	}()
 
-	srv := grpc.NewServer()
+	srv := grpc.NewServer(opts...)
 	register(srv)
 
 	closer, _ := ctx.Value(providerCloserContextKey{}).(Closer)

--- a/sdk/go/serve_workflow.go
+++ b/sdk/go/serve_workflow.go
@@ -14,7 +14,7 @@ func ServeWorkflowProvider(ctx context.Context, provider WorkflowProvider) error
 	return serveProvider(withProviderCloser(ctx, provider), func(srv *grpc.Server) {
 		proto.RegisterProviderLifecycleServer(srv, newRuntimeServer(ProviderKindWorkflow, provider))
 		proto.RegisterWorkflowProviderServer(srv, workflowProviderServer{provider: provider})
-	})
+	}, grpc.UnaryInterceptor(workflowProviderInvocationUnaryInterceptor))
 }
 
 type workflowProviderServer struct {
@@ -22,8 +22,18 @@ type workflowProviderServer struct {
 	provider WorkflowProvider
 }
 
+type workflowProviderInvocationTokenRequest interface {
+	GetInvocationToken() string
+}
+
+func workflowProviderInvocationUnaryInterceptor(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+	if tokenReq, ok := req.(workflowProviderInvocationTokenRequest); ok {
+		ctx = workflowProviderInvocationContext(ctx, tokenReq.GetInvocationToken())
+	}
+	return handler(ctx, req)
+}
+
 func (s workflowProviderServer) CreateDefinition(ctx context.Context, req *proto.CreateWorkflowProviderDefinitionRequest) (*proto.BoundWorkflowDefinition, error) {
-	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	definition, err := s.provider.CreateDefinition(ctx, createWorkflowProviderDefinitionRequestFromProto(req))
 	if err != nil {
 		return nil, providerRPCError("workflow create definition", err)
@@ -33,7 +43,6 @@ func (s workflowProviderServer) CreateDefinition(ctx context.Context, req *proto
 }
 
 func (s workflowProviderServer) GetDefinition(ctx context.Context, req *proto.GetWorkflowProviderDefinitionRequest) (*proto.BoundWorkflowDefinition, error) {
-	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	definition, err := s.provider.GetDefinition(ctx, &GetWorkflowProviderDefinitionRequest{DefinitionID: req.GetDefinitionId()})
 	if err != nil {
 		return nil, providerRPCError("workflow get definition", err)
@@ -43,7 +52,6 @@ func (s workflowProviderServer) GetDefinition(ctx context.Context, req *proto.Ge
 }
 
 func (s workflowProviderServer) UpdateDefinition(ctx context.Context, req *proto.UpdateWorkflowProviderDefinitionRequest) (*proto.BoundWorkflowDefinition, error) {
-	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	definition, err := s.provider.UpdateDefinition(ctx, updateWorkflowProviderDefinitionRequestFromProto(req))
 	if err != nil {
 		return nil, providerRPCError("workflow update definition", err)
@@ -53,12 +61,10 @@ func (s workflowProviderServer) UpdateDefinition(ctx context.Context, req *proto
 }
 
 func (s workflowProviderServer) DeleteDefinition(ctx context.Context, req *proto.DeleteWorkflowProviderDefinitionRequest) (*emptypb.Empty, error) {
-	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	return &emptypb.Empty{}, providerRPCError("workflow delete definition", s.provider.DeleteDefinition(ctx, &DeleteWorkflowProviderDefinitionRequest{DefinitionID: req.GetDefinitionId()}))
 }
 
 func (s workflowProviderServer) StartRun(ctx context.Context, req *proto.StartWorkflowProviderRunRequest) (*proto.BoundWorkflowRun, error) {
-	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	run, err := s.provider.StartRun(ctx, startWorkflowProviderRunRequestFromProto(req))
 	if err != nil {
 		return nil, providerRPCError("workflow start run", err)
@@ -68,7 +74,6 @@ func (s workflowProviderServer) StartRun(ctx context.Context, req *proto.StartWo
 }
 
 func (s workflowProviderServer) GetRun(ctx context.Context, req *proto.GetWorkflowProviderRunRequest) (*proto.BoundWorkflowRun, error) {
-	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	run, err := s.provider.GetRun(ctx, &GetWorkflowProviderRunRequest{RunID: req.GetRunId()})
 	if err != nil {
 		return nil, providerRPCError("workflow get run", err)
@@ -78,7 +83,6 @@ func (s workflowProviderServer) GetRun(ctx context.Context, req *proto.GetWorkfl
 }
 
 func (s workflowProviderServer) ListRuns(ctx context.Context, req *proto.ListWorkflowProviderRunsRequest) (*proto.ListWorkflowProviderRunsResponse, error) {
-	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	resp, err := s.provider.ListRuns(ctx, &ListWorkflowProviderRunsRequest{
 		PageSize:  int(req.GetPageSize()),
 		PageToken: req.GetPageToken(),
@@ -99,7 +103,6 @@ func (s workflowProviderServer) ListRuns(ctx context.Context, req *proto.ListWor
 }
 
 func (s workflowProviderServer) CancelRun(ctx context.Context, req *proto.CancelWorkflowProviderRunRequest) (*proto.BoundWorkflowRun, error) {
-	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	run, err := s.provider.CancelRun(ctx, &CancelWorkflowProviderRunRequest{RunID: req.GetRunId(), Reason: req.GetReason()})
 	if err != nil {
 		return nil, providerRPCError("workflow cancel run", err)
@@ -109,7 +112,6 @@ func (s workflowProviderServer) CancelRun(ctx context.Context, req *proto.Cancel
 }
 
 func (s workflowProviderServer) SignalRun(ctx context.Context, req *proto.SignalWorkflowProviderRunRequest) (*proto.SignalWorkflowRunResponse, error) {
-	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	resp, err := s.provider.SignalRun(ctx, signalWorkflowProviderRunRequestFromProto(req))
 	if err != nil {
 		return nil, providerRPCError("workflow signal run", err)
@@ -119,7 +121,6 @@ func (s workflowProviderServer) SignalRun(ctx context.Context, req *proto.Signal
 }
 
 func (s workflowProviderServer) SignalOrStartRun(ctx context.Context, req *proto.SignalOrStartWorkflowProviderRunRequest) (*proto.SignalWorkflowRunResponse, error) {
-	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	resp, err := s.provider.SignalOrStartRun(ctx, signalOrStartWorkflowProviderRunRequestFromProto(req))
 	if err != nil {
 		return nil, providerRPCError("workflow signal or start run", err)
@@ -129,7 +130,6 @@ func (s workflowProviderServer) SignalOrStartRun(ctx context.Context, req *proto
 }
 
 func (s workflowProviderServer) UpsertSchedule(ctx context.Context, req *proto.UpsertWorkflowProviderScheduleRequest) (*proto.BoundWorkflowSchedule, error) {
-	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	schedule, err := s.provider.UpsertSchedule(ctx, upsertWorkflowProviderScheduleRequestFromProto(req))
 	if err != nil {
 		return nil, providerRPCError("workflow upsert schedule", err)
@@ -139,7 +139,6 @@ func (s workflowProviderServer) UpsertSchedule(ctx context.Context, req *proto.U
 }
 
 func (s workflowProviderServer) GetSchedule(ctx context.Context, req *proto.GetWorkflowProviderScheduleRequest) (*proto.BoundWorkflowSchedule, error) {
-	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	schedule, err := s.provider.GetSchedule(ctx, &GetWorkflowProviderScheduleRequest{ScheduleID: req.GetScheduleId()})
 	if err != nil {
 		return nil, providerRPCError("workflow get schedule", err)
@@ -149,7 +148,6 @@ func (s workflowProviderServer) GetSchedule(ctx context.Context, req *proto.GetW
 }
 
 func (s workflowProviderServer) ListSchedules(ctx context.Context, req *proto.ListWorkflowProviderSchedulesRequest) (*proto.ListWorkflowProviderSchedulesResponse, error) {
-	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	resp, err := s.provider.ListSchedules(ctx, &ListWorkflowProviderSchedulesRequest{})
 	if err != nil {
 		return nil, providerRPCError("workflow list schedules", err)
@@ -162,12 +160,10 @@ func (s workflowProviderServer) ListSchedules(ctx context.Context, req *proto.Li
 }
 
 func (s workflowProviderServer) DeleteSchedule(ctx context.Context, req *proto.DeleteWorkflowProviderScheduleRequest) (*emptypb.Empty, error) {
-	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	return &emptypb.Empty{}, providerRPCError("workflow delete schedule", s.provider.DeleteSchedule(ctx, &DeleteWorkflowProviderScheduleRequest{ScheduleID: req.GetScheduleId()}))
 }
 
 func (s workflowProviderServer) PauseSchedule(ctx context.Context, req *proto.PauseWorkflowProviderScheduleRequest) (*proto.BoundWorkflowSchedule, error) {
-	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	schedule, err := s.provider.PauseSchedule(ctx, &PauseWorkflowProviderScheduleRequest{ScheduleID: req.GetScheduleId()})
 	if err != nil {
 		return nil, providerRPCError("workflow pause schedule", err)
@@ -177,7 +173,6 @@ func (s workflowProviderServer) PauseSchedule(ctx context.Context, req *proto.Pa
 }
 
 func (s workflowProviderServer) ResumeSchedule(ctx context.Context, req *proto.ResumeWorkflowProviderScheduleRequest) (*proto.BoundWorkflowSchedule, error) {
-	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	schedule, err := s.provider.ResumeSchedule(ctx, &ResumeWorkflowProviderScheduleRequest{ScheduleID: req.GetScheduleId()})
 	if err != nil {
 		return nil, providerRPCError("workflow resume schedule", err)
@@ -187,7 +182,6 @@ func (s workflowProviderServer) ResumeSchedule(ctx context.Context, req *proto.R
 }
 
 func (s workflowProviderServer) UpsertEventTrigger(ctx context.Context, req *proto.UpsertWorkflowProviderEventTriggerRequest) (*proto.BoundWorkflowEventTrigger, error) {
-	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	trigger, err := s.provider.UpsertEventTrigger(ctx, upsertWorkflowProviderEventTriggerRequestFromProto(req))
 	if err != nil {
 		return nil, providerRPCError("workflow upsert event trigger", err)
@@ -197,7 +191,6 @@ func (s workflowProviderServer) UpsertEventTrigger(ctx context.Context, req *pro
 }
 
 func (s workflowProviderServer) GetEventTrigger(ctx context.Context, req *proto.GetWorkflowProviderEventTriggerRequest) (*proto.BoundWorkflowEventTrigger, error) {
-	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	trigger, err := s.provider.GetEventTrigger(ctx, &GetWorkflowProviderEventTriggerRequest{TriggerID: req.GetTriggerId()})
 	if err != nil {
 		return nil, providerRPCError("workflow get event trigger", err)
@@ -207,7 +200,6 @@ func (s workflowProviderServer) GetEventTrigger(ctx context.Context, req *proto.
 }
 
 func (s workflowProviderServer) ListEventTriggers(ctx context.Context, req *proto.ListWorkflowProviderEventTriggersRequest) (*proto.ListWorkflowProviderEventTriggersResponse, error) {
-	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	resp, err := s.provider.ListEventTriggers(ctx, &ListWorkflowProviderEventTriggersRequest{})
 	if err != nil {
 		return nil, providerRPCError("workflow list event triggers", err)
@@ -220,12 +212,10 @@ func (s workflowProviderServer) ListEventTriggers(ctx context.Context, req *prot
 }
 
 func (s workflowProviderServer) DeleteEventTrigger(ctx context.Context, req *proto.DeleteWorkflowProviderEventTriggerRequest) (*emptypb.Empty, error) {
-	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	return &emptypb.Empty{}, providerRPCError("workflow delete event trigger", s.provider.DeleteEventTrigger(ctx, &DeleteWorkflowProviderEventTriggerRequest{TriggerID: req.GetTriggerId()}))
 }
 
 func (s workflowProviderServer) PauseEventTrigger(ctx context.Context, req *proto.PauseWorkflowProviderEventTriggerRequest) (*proto.BoundWorkflowEventTrigger, error) {
-	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	trigger, err := s.provider.PauseEventTrigger(ctx, &PauseWorkflowProviderEventTriggerRequest{TriggerID: req.GetTriggerId()})
 	if err != nil {
 		return nil, providerRPCError("workflow pause event trigger", err)
@@ -235,7 +225,6 @@ func (s workflowProviderServer) PauseEventTrigger(ctx context.Context, req *prot
 }
 
 func (s workflowProviderServer) ResumeEventTrigger(ctx context.Context, req *proto.ResumeWorkflowProviderEventTriggerRequest) (*proto.BoundWorkflowEventTrigger, error) {
-	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	trigger, err := s.provider.ResumeEventTrigger(ctx, &ResumeWorkflowProviderEventTriggerRequest{TriggerID: req.GetTriggerId()})
 	if err != nil {
 		return nil, providerRPCError("workflow resume event trigger", err)
@@ -279,7 +268,6 @@ func (s workflowProviderServer) ListExecutionReferences(ctx context.Context, req
 }
 
 func (s workflowProviderServer) PublishEvent(ctx context.Context, req *proto.PublishWorkflowProviderEventRequest) (*proto.WorkflowEvent, error) {
-	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	input := publishWorkflowProviderEventRequestFromProto(req)
 	eventInput, err := s.provider.PublishEvent(ctx, input)
 	if err != nil {

--- a/sdk/go/serve_workflow.go
+++ b/sdk/go/serve_workflow.go
@@ -2,6 +2,7 @@ package gestalt
 
 import (
 	"context"
+	"strings"
 
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"google.golang.org/grpc"
@@ -22,6 +23,7 @@ type workflowProviderServer struct {
 }
 
 func (s workflowProviderServer) CreateDefinition(ctx context.Context, req *proto.CreateWorkflowProviderDefinitionRequest) (*proto.BoundWorkflowDefinition, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	definition, err := s.provider.CreateDefinition(ctx, createWorkflowProviderDefinitionRequestFromProto(req))
 	if err != nil {
 		return nil, providerRPCError("workflow create definition", err)
@@ -31,6 +33,7 @@ func (s workflowProviderServer) CreateDefinition(ctx context.Context, req *proto
 }
 
 func (s workflowProviderServer) GetDefinition(ctx context.Context, req *proto.GetWorkflowProviderDefinitionRequest) (*proto.BoundWorkflowDefinition, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	definition, err := s.provider.GetDefinition(ctx, &GetWorkflowProviderDefinitionRequest{DefinitionID: req.GetDefinitionId()})
 	if err != nil {
 		return nil, providerRPCError("workflow get definition", err)
@@ -40,6 +43,7 @@ func (s workflowProviderServer) GetDefinition(ctx context.Context, req *proto.Ge
 }
 
 func (s workflowProviderServer) UpdateDefinition(ctx context.Context, req *proto.UpdateWorkflowProviderDefinitionRequest) (*proto.BoundWorkflowDefinition, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	definition, err := s.provider.UpdateDefinition(ctx, updateWorkflowProviderDefinitionRequestFromProto(req))
 	if err != nil {
 		return nil, providerRPCError("workflow update definition", err)
@@ -49,10 +53,12 @@ func (s workflowProviderServer) UpdateDefinition(ctx context.Context, req *proto
 }
 
 func (s workflowProviderServer) DeleteDefinition(ctx context.Context, req *proto.DeleteWorkflowProviderDefinitionRequest) (*emptypb.Empty, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	return &emptypb.Empty{}, providerRPCError("workflow delete definition", s.provider.DeleteDefinition(ctx, &DeleteWorkflowProviderDefinitionRequest{DefinitionID: req.GetDefinitionId()}))
 }
 
 func (s workflowProviderServer) StartRun(ctx context.Context, req *proto.StartWorkflowProviderRunRequest) (*proto.BoundWorkflowRun, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	run, err := s.provider.StartRun(ctx, startWorkflowProviderRunRequestFromProto(req))
 	if err != nil {
 		return nil, providerRPCError("workflow start run", err)
@@ -62,6 +68,7 @@ func (s workflowProviderServer) StartRun(ctx context.Context, req *proto.StartWo
 }
 
 func (s workflowProviderServer) GetRun(ctx context.Context, req *proto.GetWorkflowProviderRunRequest) (*proto.BoundWorkflowRun, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	run, err := s.provider.GetRun(ctx, &GetWorkflowProviderRunRequest{RunID: req.GetRunId()})
 	if err != nil {
 		return nil, providerRPCError("workflow get run", err)
@@ -71,10 +78,11 @@ func (s workflowProviderServer) GetRun(ctx context.Context, req *proto.GetWorkfl
 }
 
 func (s workflowProviderServer) ListRuns(ctx context.Context, req *proto.ListWorkflowProviderRunsRequest) (*proto.ListWorkflowProviderRunsResponse, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	resp, err := s.provider.ListRuns(ctx, &ListWorkflowProviderRunsRequest{
-		PageSize:     int(req.GetPageSize()),
-		PageToken:    req.GetPageToken(),
-		Status:       WorkflowRunStatus(req.GetStatus()),
+		PageSize:  int(req.GetPageSize()),
+		PageToken: req.GetPageToken(),
+		Status:    WorkflowRunStatus(req.GetStatus()),
 		TargetApp: req.GetTargetApp(),
 	})
 	if err != nil {
@@ -91,6 +99,7 @@ func (s workflowProviderServer) ListRuns(ctx context.Context, req *proto.ListWor
 }
 
 func (s workflowProviderServer) CancelRun(ctx context.Context, req *proto.CancelWorkflowProviderRunRequest) (*proto.BoundWorkflowRun, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	run, err := s.provider.CancelRun(ctx, &CancelWorkflowProviderRunRequest{RunID: req.GetRunId(), Reason: req.GetReason()})
 	if err != nil {
 		return nil, providerRPCError("workflow cancel run", err)
@@ -100,6 +109,7 @@ func (s workflowProviderServer) CancelRun(ctx context.Context, req *proto.Cancel
 }
 
 func (s workflowProviderServer) SignalRun(ctx context.Context, req *proto.SignalWorkflowProviderRunRequest) (*proto.SignalWorkflowRunResponse, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	resp, err := s.provider.SignalRun(ctx, signalWorkflowProviderRunRequestFromProto(req))
 	if err != nil {
 		return nil, providerRPCError("workflow signal run", err)
@@ -109,6 +119,7 @@ func (s workflowProviderServer) SignalRun(ctx context.Context, req *proto.Signal
 }
 
 func (s workflowProviderServer) SignalOrStartRun(ctx context.Context, req *proto.SignalOrStartWorkflowProviderRunRequest) (*proto.SignalWorkflowRunResponse, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	resp, err := s.provider.SignalOrStartRun(ctx, signalOrStartWorkflowProviderRunRequestFromProto(req))
 	if err != nil {
 		return nil, providerRPCError("workflow signal or start run", err)
@@ -118,6 +129,7 @@ func (s workflowProviderServer) SignalOrStartRun(ctx context.Context, req *proto
 }
 
 func (s workflowProviderServer) UpsertSchedule(ctx context.Context, req *proto.UpsertWorkflowProviderScheduleRequest) (*proto.BoundWorkflowSchedule, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	schedule, err := s.provider.UpsertSchedule(ctx, upsertWorkflowProviderScheduleRequestFromProto(req))
 	if err != nil {
 		return nil, providerRPCError("workflow upsert schedule", err)
@@ -127,6 +139,7 @@ func (s workflowProviderServer) UpsertSchedule(ctx context.Context, req *proto.U
 }
 
 func (s workflowProviderServer) GetSchedule(ctx context.Context, req *proto.GetWorkflowProviderScheduleRequest) (*proto.BoundWorkflowSchedule, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	schedule, err := s.provider.GetSchedule(ctx, &GetWorkflowProviderScheduleRequest{ScheduleID: req.GetScheduleId()})
 	if err != nil {
 		return nil, providerRPCError("workflow get schedule", err)
@@ -136,6 +149,7 @@ func (s workflowProviderServer) GetSchedule(ctx context.Context, req *proto.GetW
 }
 
 func (s workflowProviderServer) ListSchedules(ctx context.Context, req *proto.ListWorkflowProviderSchedulesRequest) (*proto.ListWorkflowProviderSchedulesResponse, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	resp, err := s.provider.ListSchedules(ctx, &ListWorkflowProviderSchedulesRequest{})
 	if err != nil {
 		return nil, providerRPCError("workflow list schedules", err)
@@ -148,10 +162,12 @@ func (s workflowProviderServer) ListSchedules(ctx context.Context, req *proto.Li
 }
 
 func (s workflowProviderServer) DeleteSchedule(ctx context.Context, req *proto.DeleteWorkflowProviderScheduleRequest) (*emptypb.Empty, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	return &emptypb.Empty{}, providerRPCError("workflow delete schedule", s.provider.DeleteSchedule(ctx, &DeleteWorkflowProviderScheduleRequest{ScheduleID: req.GetScheduleId()}))
 }
 
 func (s workflowProviderServer) PauseSchedule(ctx context.Context, req *proto.PauseWorkflowProviderScheduleRequest) (*proto.BoundWorkflowSchedule, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	schedule, err := s.provider.PauseSchedule(ctx, &PauseWorkflowProviderScheduleRequest{ScheduleID: req.GetScheduleId()})
 	if err != nil {
 		return nil, providerRPCError("workflow pause schedule", err)
@@ -161,6 +177,7 @@ func (s workflowProviderServer) PauseSchedule(ctx context.Context, req *proto.Pa
 }
 
 func (s workflowProviderServer) ResumeSchedule(ctx context.Context, req *proto.ResumeWorkflowProviderScheduleRequest) (*proto.BoundWorkflowSchedule, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	schedule, err := s.provider.ResumeSchedule(ctx, &ResumeWorkflowProviderScheduleRequest{ScheduleID: req.GetScheduleId()})
 	if err != nil {
 		return nil, providerRPCError("workflow resume schedule", err)
@@ -170,6 +187,7 @@ func (s workflowProviderServer) ResumeSchedule(ctx context.Context, req *proto.R
 }
 
 func (s workflowProviderServer) UpsertEventTrigger(ctx context.Context, req *proto.UpsertWorkflowProviderEventTriggerRequest) (*proto.BoundWorkflowEventTrigger, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	trigger, err := s.provider.UpsertEventTrigger(ctx, upsertWorkflowProviderEventTriggerRequestFromProto(req))
 	if err != nil {
 		return nil, providerRPCError("workflow upsert event trigger", err)
@@ -179,6 +197,7 @@ func (s workflowProviderServer) UpsertEventTrigger(ctx context.Context, req *pro
 }
 
 func (s workflowProviderServer) GetEventTrigger(ctx context.Context, req *proto.GetWorkflowProviderEventTriggerRequest) (*proto.BoundWorkflowEventTrigger, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	trigger, err := s.provider.GetEventTrigger(ctx, &GetWorkflowProviderEventTriggerRequest{TriggerID: req.GetTriggerId()})
 	if err != nil {
 		return nil, providerRPCError("workflow get event trigger", err)
@@ -188,6 +207,7 @@ func (s workflowProviderServer) GetEventTrigger(ctx context.Context, req *proto.
 }
 
 func (s workflowProviderServer) ListEventTriggers(ctx context.Context, req *proto.ListWorkflowProviderEventTriggersRequest) (*proto.ListWorkflowProviderEventTriggersResponse, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	resp, err := s.provider.ListEventTriggers(ctx, &ListWorkflowProviderEventTriggersRequest{})
 	if err != nil {
 		return nil, providerRPCError("workflow list event triggers", err)
@@ -200,10 +220,12 @@ func (s workflowProviderServer) ListEventTriggers(ctx context.Context, req *prot
 }
 
 func (s workflowProviderServer) DeleteEventTrigger(ctx context.Context, req *proto.DeleteWorkflowProviderEventTriggerRequest) (*emptypb.Empty, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	return &emptypb.Empty{}, providerRPCError("workflow delete event trigger", s.provider.DeleteEventTrigger(ctx, &DeleteWorkflowProviderEventTriggerRequest{TriggerID: req.GetTriggerId()}))
 }
 
 func (s workflowProviderServer) PauseEventTrigger(ctx context.Context, req *proto.PauseWorkflowProviderEventTriggerRequest) (*proto.BoundWorkflowEventTrigger, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	trigger, err := s.provider.PauseEventTrigger(ctx, &PauseWorkflowProviderEventTriggerRequest{TriggerID: req.GetTriggerId()})
 	if err != nil {
 		return nil, providerRPCError("workflow pause event trigger", err)
@@ -213,6 +235,7 @@ func (s workflowProviderServer) PauseEventTrigger(ctx context.Context, req *prot
 }
 
 func (s workflowProviderServer) ResumeEventTrigger(ctx context.Context, req *proto.ResumeWorkflowProviderEventTriggerRequest) (*proto.BoundWorkflowEventTrigger, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	trigger, err := s.provider.ResumeEventTrigger(ctx, &ResumeWorkflowProviderEventTriggerRequest{TriggerID: req.GetTriggerId()})
 	if err != nil {
 		return nil, providerRPCError("workflow resume event trigger", err)
@@ -256,6 +279,7 @@ func (s workflowProviderServer) ListExecutionReferences(ctx context.Context, req
 }
 
 func (s workflowProviderServer) PublishEvent(ctx context.Context, req *proto.PublishWorkflowProviderEventRequest) (*proto.WorkflowEvent, error) {
+	ctx = workflowProviderInvocationContext(ctx, req.GetInvocationToken())
 	input := publishWorkflowProviderEventRequestFromProto(req)
 	eventInput, err := s.provider.PublishEvent(ctx, input)
 	if err != nil {
@@ -269,6 +293,13 @@ func (s workflowProviderServer) PublishEvent(ctx context.Context, req *proto.Pub
 	}
 	event, err := workflowEventToProto(*eventInput)
 	return event, providerRPCError("workflow publish event", err)
+}
+
+func workflowProviderInvocationContext(ctx context.Context, token string) context.Context {
+	if strings.TrimSpace(token) == "" {
+		return ctx
+	}
+	return withInvocationToken(ctx, token)
 }
 
 func createWorkflowProviderDefinitionRequestFromProto(req *proto.CreateWorkflowProviderDefinitionRequest) *CreateWorkflowProviderDefinitionRequest {
@@ -383,7 +414,7 @@ func publishWorkflowProviderEventRequestFromProto(req *proto.PublishWorkflowProv
 		event = &input
 	}
 	return &PublishWorkflowProviderEventRequest{
-		AppName:  req.GetAppName(),
+		AppName:     req.GetAppName(),
 		Event:       event,
 		PublishedBy: workflowActorInputPtrFromActor(req.GetPublishedBy()),
 	}

--- a/sdk/go/workflow_provider_transport_test.go
+++ b/sdk/go/workflow_provider_transport_test.go
@@ -14,8 +14,11 @@ import (
 type fullWorkflowProvider struct {
 	gestalt.UnimplementedWorkflowProvider
 	closeTracker
-	configuredName  string
-	publishedEvents []string
+	configuredName          string
+	startRunInvocationToken string
+	definitionToken         string
+	publishEventToken       string
+	publishedEvents         []string
 }
 
 func (p *fullWorkflowProvider) Configure(_ context.Context, name string, _ map[string]any) error {
@@ -32,7 +35,8 @@ func (p *fullWorkflowProvider) Metadata() gestalt.ProviderMetadata {
 	}
 }
 
-func (p *fullWorkflowProvider) StartRun(_ context.Context, req *gestalt.StartWorkflowProviderRunRequest) (*gestalt.BoundWorkflowRun, error) {
+func (p *fullWorkflowProvider) StartRun(ctx context.Context, req *gestalt.StartWorkflowProviderRunRequest) (*gestalt.BoundWorkflowRun, error) {
+	p.startRunInvocationToken = gestalt.InvocationTokenFromContext(ctx)
 	return &gestalt.BoundWorkflowRun{
 		ID:     req.IdempotencyKey,
 		Status: gestalt.WorkflowRunStatusValuePending,
@@ -40,14 +44,16 @@ func (p *fullWorkflowProvider) StartRun(_ context.Context, req *gestalt.StartWor
 	}, nil
 }
 
-func (p *fullWorkflowProvider) CreateDefinition(_ context.Context, req *gestalt.CreateWorkflowProviderDefinitionRequest) (*gestalt.BoundWorkflowDefinition, error) {
+func (p *fullWorkflowProvider) CreateDefinition(ctx context.Context, req *gestalt.CreateWorkflowProviderDefinitionRequest) (*gestalt.BoundWorkflowDefinition, error) {
+	p.definitionToken = gestalt.InvocationTokenFromContext(ctx)
 	return &gestalt.BoundWorkflowDefinition{
 		ID:     req.IdempotencyKey,
 		Target: req.Target,
 	}, nil
 }
 
-func (p *fullWorkflowProvider) PublishEvent(_ context.Context, req *gestalt.PublishWorkflowProviderEventRequest) (*gestalt.WorkflowEvent, error) {
+func (p *fullWorkflowProvider) PublishEvent(ctx context.Context, req *gestalt.PublishWorkflowProviderEventRequest) (*gestalt.WorkflowEvent, error) {
+	p.publishEventToken = gestalt.InvocationTokenFromContext(ctx)
 	if req.Event != nil {
 		p.publishedEvents = append(p.publishedEvents, req.Event.Type)
 		return &gestalt.WorkflowEvent{ID: "published-go", Type: req.Event.Type}, nil
@@ -90,7 +96,8 @@ func TestWorkflowProviderTypedTransportRoundTrip(t *testing.T) {
 	}
 
 	run, err := workflowClient.StartRun(rpcCtx, &proto.StartWorkflowProviderRunRequest{
-		IdempotencyKey: "run-1",
+		IdempotencyKey:  "run-1",
+		InvocationToken: "workflow-run-token",
 		Target: &proto.BoundWorkflowTarget{
 			Steps: []*proto.WorkflowStep{{
 				Id: "create_issue",
@@ -107,9 +114,13 @@ func TestWorkflowProviderTypedTransportRoundTrip(t *testing.T) {
 	if run.GetId() != "run-1" || run.GetStatus() != proto.WorkflowRunStatus_WORKFLOW_RUN_STATUS_PENDING {
 		t.Fatalf("StartRun = %+v, want pending run", run)
 	}
+	if provider.startRunInvocationToken != "workflow-run-token" {
+		t.Fatalf("StartRun invocation token = %q, want workflow-run-token", provider.startRunInvocationToken)
+	}
 
 	definition, err := workflowClient.CreateDefinition(rpcCtx, &proto.CreateWorkflowProviderDefinitionRequest{
-		IdempotencyKey: "definition-1",
+		IdempotencyKey:  "definition-1",
+		InvocationToken: "workflow-definition-token",
 		Target: &proto.BoundWorkflowTarget{
 			Steps: []*proto.WorkflowStep{{
 				Id: "search_issues",
@@ -126,9 +137,13 @@ func TestWorkflowProviderTypedTransportRoundTrip(t *testing.T) {
 	if definition.GetId() != "definition-1" {
 		t.Fatalf("CreateDefinition id = %q, want definition-1", definition.GetId())
 	}
+	if provider.definitionToken != "workflow-definition-token" {
+		t.Fatalf("CreateDefinition invocation token = %q, want workflow-definition-token", provider.definitionToken)
+	}
 
 	published, err := workflowClient.PublishEvent(rpcCtx, &proto.PublishWorkflowProviderEventRequest{
-		Event: &proto.WorkflowEvent{Type: "issue.created"},
+		Event:           &proto.WorkflowEvent{Type: "issue.created"},
+		InvocationToken: "workflow-event-token",
 	})
 	if err != nil {
 		t.Fatalf("PublishEvent: %v", err)
@@ -138,5 +153,8 @@ func TestWorkflowProviderTypedTransportRoundTrip(t *testing.T) {
 	}
 	if len(provider.publishedEvents) != 1 || provider.publishedEvents[0] != "issue.created" {
 		t.Fatalf("published events = %v, want [issue.created]", provider.publishedEvents)
+	}
+	if provider.publishEventToken != "workflow-event-token" {
+		t.Fatalf("PublishEvent invocation token = %q, want workflow-event-token", provider.publishEventToken)
 	}
 }


### PR DESCRIPTION
## Summary

Workflow-provider SDK calls now keep the trusted workflow metadata and invocation token that gestaltd restored while dispatching workflow provider RPCs.

Invocation tokens carry workflow context in signed claims, child token exchange preserves that context, and host services restore it before invoking downstream apps.

Gestaltd now forwards the current invocation token to remote workflow providers, and the Go workflow provider adapter attaches that token to provider method contexts so provider implementations can use `AppFromContext` and `AgentFromContext` from the normal context-token path. Authorization remains available through the normal `Authorization()` host-service capability.

## Interfaces

```go
ctx = invocation.WithWorkflowContext(ctx, map[string]any{
    "providerName": "temporal",
    "runId":        "run-123",
    "definitionId": "definition-123",
    "activationId": "activation-123",
})

token, err := tokens.MintRootToken(ctx, "workflow-provider", grants)
restored := appinvoker.RestoreTokenContext(context.Background(), tokenCtx, "")
workflow := invocation.WorkflowContextFromContext(restored)
```

```go
func (p *WorkflowProvider) StartRun(ctx context.Context, req *gestalt.StartWorkflowProviderRunRequest) (*gestalt.BoundWorkflowRun, error) {
    apps, err := gestalt.AppFromContext(ctx)
    agents, err := gestalt.AgentFromContext(ctx)
    authz, err := gestalt.Authorization()
    _ = apps
    _ = agents
    _ = authz
    return p.start(ctx, req)
}
```

## Runtime

The token handoff stays inside existing SDK and host-service transports. App calls into gestaltd restore the signed token context, daemon workflow-provider clients forward the current `invocation_token`, Go provider transports attach it to `context.Context`, and downstream host-service clients read it from the normal SDK context.

Workflow provider processes receive the `authorization` host service whenever authorization is configured, so provider implementations can evaluate authorization through the same host-service path as other SDK clients.