### PR TITLE
[codex] Use Impl names for TypeScript SDK implementations

### DIFF
--- a/sdk/typescript/src/agent-access.ts
+++ b/sdk/typescript/src/agent-access.ts
@@ -167,7 +167,7 @@ export interface Agent {
  * The constructor accepts either a Gestalt request or an invocation token. Each
  * agent call forwards that token to the agent-provider facade.
  */
-class HostAgent implements Agent {
+class AgentImpl implements Agent {
   private readonly client: Client<typeof AgentProviderService>;
   private readonly invocationToken: string;
 
@@ -364,7 +364,7 @@ function workspaceToProto(workspace?: AgentWorkspace | undefined) {
   };
 }
 
-export const Agent = HostAgent;
+export const Agent = AgentImpl;
 
 function agentSessionFromProto(session: ProtoAgentSession): AgentSession {
   return {

--- a/sdk/typescript/src/agent.ts
+++ b/sdk/typescript/src/agent.ts
@@ -1156,7 +1156,7 @@ export function isAgentProvider(value: unknown): value is AgentProvider {
 }
 
 /** Client for the agent host service available inside agent providers. */
-class HostAgentHost implements AgentHost {
+class AgentHostImpl implements AgentHost {
   private readonly client: Client<typeof AgentHostService>;
 
   constructor() {
@@ -1406,7 +1406,7 @@ function listInteractionsResult(
   return "interactions" in value ? value.interactions : value;
 }
 
-export const AgentHost = HostAgentHost;
+export const AgentHost = AgentHostImpl;
 
 async function requireAgentProviderHandler<Request, Response>(
   action: string,

--- a/sdk/typescript/src/app-access.ts
+++ b/sdk/typescript/src/app-access.ts
@@ -62,7 +62,7 @@ export interface App {
  * The constructor accepts either a Gestalt request or an invocation token. The
  * token is attached to every operation, GraphQL, and token-exchange request.
  */
-class RemoteApp implements App {
+class AppImpl implements App {
   private readonly client: Client<typeof AppService>;
   private readonly invocationToken: string;
 
@@ -156,7 +156,7 @@ class RemoteApp implements App {
   }
 }
 
-export const App = RemoteApp;
+export const App = AppImpl;
 
 function normalizeInvocationToken(requestOrToken: Request | string): string {
   const invocationToken =

--- a/sdk/typescript/src/authorization.ts
+++ b/sdk/typescript/src/authorization.ts
@@ -377,7 +377,7 @@ export interface AuthorizationWriteModelInput {
 const sharedAuthorizationTransport: {
   target: string;
   token: string;
-  client: HostAuthorization | undefined;
+  client: AuthorizationImpl | undefined;
 } = {
   target: "",
   token: "",
@@ -385,7 +385,7 @@ const sharedAuthorizationTransport: {
 };
 
 /**
- * Fakeable client contract for host authorization calls.
+ * Fakeable contract for authorization calls.
  */
 export interface Authorization {
   evaluate(request: AuthorizationEvaluateInput): Promise<AuthorizationDecision>;
@@ -425,12 +425,12 @@ export interface Authorization {
 }
 
 /**
- * Client for the host-configured authorization provider.
+ * Client for the configured authorization provider.
  *
  * The client accepts plain SDK request objects and keeps transport message
  * construction inside the SDK.
  */
-class HostAuthorization implements Authorization {
+class AuthorizationImpl implements Authorization {
   private readonly client: Client<typeof AuthorizationProviderService>;
 
   constructor(
@@ -849,7 +849,7 @@ function requiredAuthorizationResponse<T>(
 }
 
 /**
- * Returns a shared host authorization client for authored providers.
+ * Returns a shared authorization capability for authored providers.
  */
 export function Authorization(): Authorization {
   const target = resolveAuthorizationSocketTarget();
@@ -862,7 +862,7 @@ export function Authorization(): Authorization {
     return sharedAuthorizationTransport.client;
   }
 
-  const client = new HostAuthorization(target, token);
+  const client = new AuthorizationImpl(target, token);
   sharedAuthorizationTransport.target = target;
   sharedAuthorizationTransport.token = token;
   sharedAuthorizationTransport.client = client;

--- a/sdk/typescript/src/cache.ts
+++ b/sdk/typescript/src/cache.ts
@@ -26,7 +26,7 @@ export interface CacheSetOptions {
 }
 
 /**
- * Fakeable cache client contract shared by host clients and tests.
+ * Fakeable cache contract shared by SDK callers and tests.
  */
 export interface Cache {
   get(key: string): Promise<Uint8Array | undefined>;
@@ -76,7 +76,7 @@ export interface CacheProviderOptions extends ProviderBaseOptions {
  * await cache.set("session", new TextEncoder().encode("hello"));
  * ```
  */
-class RemoteCache implements Cache {
+class CacheImpl implements Cache {
   private readonly client: ConnectClient<typeof CacheService>;
 
   constructor(name?: string) {
@@ -160,7 +160,7 @@ class RemoteCache implements Cache {
   }
 }
 
-export const Cache = RemoteCache;
+export const Cache = CacheImpl;
 
 /**
  * Cache provider implementation consumed by the Gestalt runtime.

--- a/sdk/typescript/src/indexeddb.ts
+++ b/sdk/typescript/src/indexeddb.ts
@@ -210,7 +210,7 @@ export interface Cursor {
 /**
  * Streaming cursor over an object store or secondary index.
  */
-class RemoteCursor implements Cursor {
+class CursorImpl implements Cursor {
   private sendQueue: AsyncQueue<any>;
   private responseIterator: AsyncIterator<any>;
   private _key: unknown = undefined;
@@ -265,7 +265,7 @@ class RemoteCursor implements Cursor {
     const responseIterator = responses[Symbol.asyncIterator]();
 
     const isIndex = !!options?.index;
-    const cursor = new RemoteCursor(sendQueue, responseIterator, isIndex);
+    const cursor = new CursorImpl(sendQueue, responseIterator, isIndex);
     // Read the open ack to surface creation errors synchronously.
     await cursor.recvOpenAck();
     return cursor;
@@ -900,7 +900,7 @@ function compareBytes(left: Uint8Array, right: Uint8Array): number {
  * const todos = db.objectStore("todos");
  * ```
  */
-class RemoteIndexedDB implements IndexedDB {
+class IndexedDBImpl implements IndexedDB {
   private client: Client<typeof IndexedDBService>;
 
   constructor(name?: string) {
@@ -956,7 +956,7 @@ class RemoteIndexedDB implements IndexedDB {
    * Returns a client bound to a single object store.
    */
   objectStore(name: string): ObjectStore {
-    return new RemoteObjectStore(this.client, name);
+    return new ObjectStoreImpl(this.client, name);
   }
 
   /**
@@ -967,14 +967,14 @@ class RemoteIndexedDB implements IndexedDB {
     mode: TransactionMode = "readonly",
     options?: TransactionOptions,
   ): Promise<Transaction> {
-    return RemoteTransaction.open(this.client, stores, mode, options);
+    return TransactionImpl.open(this.client, stores, mode, options);
   }
 }
 
 /**
  * Explicit transaction over one or more object stores.
  */
-class RemoteTransaction implements Transaction {
+class TransactionImpl implements Transaction {
   private sendQueue: AsyncQueue<any>;
   private responseIterator: AsyncIterator<any>;
   private closed = false;
@@ -1013,7 +1013,7 @@ class RemoteTransaction implements Transaction {
     });
     const responses = client.transaction(sendQueue);
     const responseIterator = responses[Symbol.asyncIterator]();
-    const tx = new RemoteTransaction(sendQueue, responseIterator);
+    const tx = new TransactionImpl(sendQueue, responseIterator);
     try {
       const { value: resp, done } = await responseIterator.next();
       if (done || !resp) {
@@ -1035,7 +1035,7 @@ class RemoteTransaction implements Transaction {
    * Returns a transaction-scoped object store.
    */
   objectStore(name: string): TransactionObjectStore {
-    return new RemoteTransactionObjectStore(this, name);
+    return new TransactionObjectStoreImpl(this, name);
   }
 
   /**
@@ -1160,12 +1160,12 @@ class RemoteTransaction implements Transaction {
 /**
  * Transaction-scoped object-store client.
  */
-class RemoteTransactionObjectStore implements TransactionObjectStore {
+class TransactionObjectStoreImpl implements TransactionObjectStore {
   /**
    * @internal
    */
   constructor(
-    private tx: RemoteTransaction,
+    private tx: TransactionImpl,
     private store: string,
   ) {}
 
@@ -1288,19 +1288,19 @@ class RemoteTransactionObjectStore implements TransactionObjectStore {
    * Returns a transaction-scoped secondary index.
    */
   index(name: string): TransactionIndex {
-    return new RemoteTransactionIndex(this.tx, this.store, name);
+    return new TransactionIndexImpl(this.tx, this.store, name);
   }
 }
 
 /**
  * Transaction-scoped secondary-index client.
  */
-class RemoteTransactionIndex implements TransactionIndex {
+class TransactionIndexImpl implements TransactionIndex {
   /**
    * @internal
    */
   constructor(
-    private tx: RemoteTransaction,
+    private tx: TransactionImpl,
     private store: string,
     private indexName: string,
   ) {}
@@ -1398,7 +1398,7 @@ class RemoteTransactionIndex implements TransactionIndex {
 /**
  * Object store client used for primary-key operations.
  */
-class RemoteObjectStore implements ObjectStore {
+class ObjectStoreImpl implements ObjectStore {
   /**
    * @internal
    */
@@ -1503,14 +1503,14 @@ class RemoteObjectStore implements ObjectStore {
    * Opens a cursor over the object store.
    */
   async openCursor(options?: OpenCursorOptions): Promise<Cursor | null> {
-    return RemoteCursor.open(this.client, this.store, options);
+    return CursorImpl.open(this.client, this.store, options);
   }
 
   /**
    * Opens a key-only cursor over the object store.
    */
   async openKeyCursor(options?: OpenCursorOptions): Promise<Cursor | null> {
-    return RemoteCursor.open(this.client, this.store, {
+    return CursorImpl.open(this.client, this.store, {
       ...options,
       keysOnly: true,
     });
@@ -1520,14 +1520,14 @@ class RemoteObjectStore implements ObjectStore {
    * Returns a client bound to a secondary index.
    */
   index(name: string): Index {
-    return new RemoteIndex(this.client, this.store, name);
+    return new IndexImpl(this.client, this.store, name);
   }
 }
 
 /**
  * Secondary-index client used for lookup and cursor operations.
  */
-class RemoteIndex implements Index {
+class IndexImpl implements Index {
   /**
    * @internal
    */
@@ -1639,7 +1639,7 @@ class RemoteIndex implements Index {
     options?: OpenCursorOptions,
     ...values: unknown[]
   ): Promise<Cursor | null> {
-    return RemoteCursor.open(this.client, this.store, {
+    return CursorImpl.open(this.client, this.store, {
       ...options,
       index: this.indexName,
       indexValues: values,
@@ -1653,7 +1653,7 @@ class RemoteIndex implements Index {
     options?: OpenCursorOptions,
     ...values: unknown[]
   ): Promise<Cursor | null> {
-    return RemoteCursor.open(this.client, this.store, {
+    return CursorImpl.open(this.client, this.store, {
       ...options,
       keysOnly: true,
       index: this.indexName,
@@ -1895,4 +1895,4 @@ function mapTransactionTransportError(err: any): never {
   throw err;
 }
 
-export const IndexedDB = RemoteIndexedDB;
+export const IndexedDB = IndexedDBImpl;

--- a/sdk/typescript/src/s3.ts
+++ b/sdk/typescript/src/s3.ts
@@ -583,7 +583,7 @@ export function createS3Service(
  * await s3.object("example-bucket", "hello.json").writeJSON({ ok: true });
  * ```
  */
-class RemoteS3 implements S3 {
+class S3Impl implements S3 {
   private readonly transport: Transport;
   private readonly client: Client<typeof S3Service>;
   private objectAccessClient?: Client<typeof S3ObjectAccessService>;
@@ -603,12 +603,12 @@ class RemoteS3 implements S3 {
 
   /** Returns a convenience helper for the latest version of an object. */
   object(bucket: string, key: string): S3Object {
-    return new RemoteS3Object(this, { bucket, key });
+    return new S3ObjectImpl(this, { bucket, key });
   }
 
   /** Returns a convenience helper pinned to a specific object version. */
   objectVersion(bucket: string, key: string, versionId: string): S3Object {
-    return new RemoteS3Object(this, { bucket, key, versionId });
+    return new S3ObjectImpl(this, { bucket, key, versionId });
   }
 
   /** Fetches object metadata without reading the object body. */
@@ -791,7 +791,7 @@ class RemoteS3 implements S3 {
 /**
  * Convenience wrapper for working with a single S3 object reference.
  */
-class RemoteS3Object implements S3Object {
+class S3ObjectImpl implements S3Object {
   constructor(
     private readonly client: S3,
     readonly ref: ObjectRef,
@@ -1388,4 +1388,4 @@ function messageFromError(error: unknown): string {
   return errorMessage(error);
 }
 
-export const S3 = RemoteS3;
+export const S3 = S3Impl;

--- a/sdk/typescript/src/workflow-access.ts
+++ b/sdk/typescript/src/workflow-access.ts
@@ -241,7 +241,7 @@ export interface Workflow {
  * constructed from a request, create operations reuse the request idempotency
  * key unless the call provides one explicitly.
  */
-class HostWorkflow implements Workflow {
+class WorkflowImpl implements Workflow {
   private readonly client: Client<typeof WorkflowProviderService>;
   private readonly invocationToken: string;
   private readonly idempotencyKey: string;
@@ -544,7 +544,7 @@ class HostWorkflow implements Workflow {
   }
 }
 
-export const Workflow = HostWorkflow;
+export const Workflow = WorkflowImpl;
 
 function normalizeInvocationToken(requestOrToken: Request | string): string {
   const invocationToken =

--- a/sdk/typescript/src/workflow.ts
+++ b/sdk/typescript/src/workflow.ts
@@ -1655,7 +1655,7 @@ export function isWorkflowProvider(value: unknown): value is WorkflowProvider {
 }
 
 /** Client for invoking operations from workflow provider code. */
-class HostWorkflowHost implements WorkflowHost {
+class WorkflowHostImpl implements WorkflowHost {
   private readonly client: Client<typeof WorkflowHostService>;
 
   constructor() {
@@ -3023,7 +3023,7 @@ function listRunsResult(
   return "runs" in value ? value : { runs: value };
 }
 
-export const WorkflowHost = HostWorkflowHost;
+export const WorkflowHost = WorkflowHostImpl;
 
 async function invokeWorkflowProvider<T>(
   action: string,


### PR DESCRIPTION
## Summary

The TypeScript SDK now uses private `*Impl` class names for transport-backed implementations instead of `Remote*` or capability-specific `Host*` names, while preserving the public `App`, `Cache`, `S3`, `IndexedDB`, `Authorization`, `Agent`, `AgentHost`, `Workflow`, and `WorkflowHost` exports.

## Interfaces

```ts
export interface Cache { /* fakeable contract */ }
class CacheImpl implements Cache { /* transport-backed implementation */ }
export const Cache = CacheImpl;
```

## Validation

Ran `bun run typecheck` and the affected TypeScript transport tests.