### PR TITLE
Add provider snapshot publish command

### DIFF
--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -65,8 +65,20 @@ type ProviderRepositoryConfig struct {
 }
 
 type ProviderSnapshotRepositoryConfig struct {
-	URL        string `yaml:"url,omitempty"`
-	GestaltRef string `yaml:"gestaltRef,omitempty"`
+	URL        string                                  `yaml:"url,omitempty"`
+	GestaltRef string                                  `yaml:"gestaltRef,omitempty"`
+	Publish    ProviderSnapshotRepositoryPublishConfig `yaml:"publish,omitempty"`
+}
+
+type ProviderSnapshotRepositoryPublishConfig struct {
+	PathLayout string                                  `yaml:"pathLayout,omitempty"`
+	Immutable  bool                                    `yaml:"immutable,omitempty"`
+	Storage    ProviderSnapshotRepositoryStorageConfig `yaml:"storage,omitempty"`
+}
+
+type ProviderSnapshotRepositoryStorageConfig struct {
+	Kind string `yaml:"kind,omitempty"`
+	URL  string `yaml:"url,omitempty"`
 }
 
 type ProvidersConfig struct {

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -238,6 +238,31 @@ func validateProviderSnapshotRepositories(cfg *Config) error {
 		if ref := strings.TrimSpace(repo.GestaltRef); ref != "" && !isFullGitSHA(ref) {
 			return fmt.Errorf("config validation: providerSnapshotRepositories.%s.gestaltRef must be a 40-character commit SHA", name)
 		}
+		if err := validateProviderSnapshotRepositoryPublish(name, repo.Publish); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateProviderSnapshotRepositoryPublish(name string, publish ProviderSnapshotRepositoryPublishConfig) error {
+	if publish.PathLayout == "" && !publish.Immutable && publish.Storage.Kind == "" && publish.Storage.URL == "" {
+		return nil
+	}
+	if strings.TrimSpace(publish.PathLayout) != "sourceRef" {
+		return fmt.Errorf("config validation: providerSnapshotRepositories.%s.publish.pathLayout must be sourceRef", name)
+	}
+	if !publish.Immutable {
+		return fmt.Errorf("config validation: providerSnapshotRepositories.%s.publish.immutable must be true", name)
+	}
+	if strings.TrimSpace(publish.Storage.Kind) != "objectStore" {
+		return fmt.Errorf("config validation: providerSnapshotRepositories.%s.publish.storage.kind must be objectStore", name)
+	}
+	if strings.TrimSpace(publish.Storage.URL) == "" {
+		return fmt.Errorf("config validation: providerSnapshotRepositories.%s.publish.storage.url is required", name)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(publish.Storage.URL), "gs://") {
+		return fmt.Errorf("config validation: providerSnapshotRepositories.%s.publish.storage.url currently supports gs:// object store URLs", name)
 	}
 	return nil
 }

--- a/gestaltd/internal/daemon/provider.go
+++ b/gestaltd/internal/daemon/provider.go
@@ -27,6 +27,8 @@ func runProvider(args []string) error {
 		return runProviderList(args[1:])
 	case "package":
 		return runProviderPackage(args[1:])
+	case "publish":
+		return runProviderPublish(args[1:])
 	case "remove":
 		return runProviderRemove(args[1:])
 	case "repo":
@@ -54,6 +56,7 @@ func printProviderUsage(w io.Writer) {
 	writeUsageLine(w, "  info        Show provider package metadata from configured repositories")
 	writeUsageLine(w, "  list        List configured providers and lock status")
 	writeUsageLine(w, "  package     Build provider release archives")
+	writeUsageLine(w, "  publish     Publish provider release artifacts")
 	writeUsageLine(w, "  release     Finalize provider release metadata from archives")
 	writeUsageLine(w, "  remove      Remove a provider entry from config and update lock state")
 	writeUsageLine(w, "  repo        Manage provider package repositories")

--- a/gestaltd/internal/daemon/provider_publish.go
+++ b/gestaltd/internal/daemon/provider_publish.go
@@ -1,0 +1,528 @@
+package daemon
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/operator"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/apps/providerpkg"
+	"github.com/valon-technologies/gestalt/server/services/apps/source"
+)
+
+const providerPublishPlanSchema = "gestaltd.provider.publish.plan.v1"
+const providerPublishFileKindArchive = "archive"
+const providerPublishFileKindChecksums = "checksums"
+const providerPublishFileKindMetadata = "metadata"
+const providerPublishFormatText = "text"
+const providerPublishFormatJSON = "json"
+
+var fullGitSHARe = regexp.MustCompile(`^[0-9a-fA-F]{40}$`)
+
+type providerPublishSourceRefInfo = operator.SnapshotSourceRefPath
+
+type providerPublishDistDirs []string
+
+func (d *providerPublishDistDirs) String() string {
+	return strings.Join(*d, ",")
+}
+
+func (d *providerPublishDistDirs) Set(value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fmt.Errorf("--dist-dir requires a value")
+	}
+	*d = append(*d, value)
+	return nil
+}
+
+type providerPublishFile struct {
+	Kind       string `json:"kind"`
+	Target     string `json:"target,omitempty"`
+	LocalPath  string `json:"localPath"`
+	StorageURL string `json:"storageUrl"`
+	PublicURL  string `json:"publicUrl"`
+	SHA256     string `json:"sha256"`
+}
+
+type providerPublishPlan struct {
+	Schema            string                `json:"schema"`
+	PublishRepository string                `json:"publishRepository"`
+	SourceRepository  string                `json:"sourceRepository"`
+	SourceRef         string                `json:"sourceRef"`
+	ProviderDir       string                `json:"providerDir"`
+	ManifestPath      string                `json:"manifestPath"`
+	Version           string                `json:"version"`
+	Metadata          providerPublishFile   `json:"metadata"`
+	Checksums         providerPublishFile   `json:"checksums"`
+	Artifacts         []providerPublishFile `json:"artifacts"`
+	Files             []providerPublishFile `json:"files"`
+}
+
+func runProviderPublish(args []string) (err error) {
+	fs := flag.NewFlagSet("gestaltd provider publish", flag.ContinueOnError)
+	fs.Usage = func() { printProviderPublishUsage(fs.Output()) }
+	repoName := fs.String("repo", "", "provider snapshot repository name")
+	manifestPath := fs.String("manifest", "", "source manifest path")
+	version := fs.String("version", "", "semantic version guard")
+	ref := fs.String("ref", "", "full source commit SHA")
+	dryRun := fs.Bool("dry-run", false, "print the publish plan without uploading")
+	format := fs.String("format", providerPublishFormatText, "dry-run output format: text or json")
+	var distDirs providerPublishDistDirs
+	var configPaths repeatedStringFlag
+	fs.Var(&distDirs, "dist-dir", "directory containing release archives (repeatable)")
+	fs.Var(&configPaths, "config", "path to config file (repeat to layer overrides)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() > 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	if strings.TrimSpace(*repoName) == "" {
+		return fmt.Errorf("--repo is required")
+	}
+	if err := validateProviderPublishFormat(*format, *dryRun); err != nil {
+		return err
+	}
+	if strings.TrimSpace(*manifestPath) == "" {
+		return fmt.Errorf("--manifest is required")
+	}
+	if len(distDirs) == 0 {
+		return fmt.Errorf("--dist-dir is required")
+	}
+	if strings.TrimSpace(*version) == "" {
+		return fmt.Errorf("--version is required")
+	}
+	if err := source.ValidateVersion(*version); err != nil {
+		return fmt.Errorf("invalid --version: %w", err)
+	}
+	sourceRef := strings.ToLower(strings.TrimSpace(*ref))
+	if !fullGitSHARe.MatchString(sourceRef) {
+		return fmt.Errorf("--ref must be a 40-character commit SHA")
+	}
+
+	cfg, err := config.LoadAllowMissingEnvPaths(operator.ResolveConfigPaths(configPaths))
+	if err != nil {
+		return err
+	}
+	repo, err := providerPublishRepository(cfg, *repoName)
+	if err != nil {
+		return err
+	}
+	_, sourceManifest, err := providerpkg.ReadSourceManifestFile(*manifestPath)
+	if err != nil {
+		return fmt.Errorf("read --manifest: %w", err)
+	}
+	releaseManifest, releaseVersion, releaseArchives, err := collectReleaseArchivesFromDirs([]string(distDirs), *version)
+	if err != nil {
+		return err
+	}
+	if err := validateProviderPublishManifest(sourceManifest, releaseManifest, releaseVersion, *version); err != nil {
+		return err
+	}
+
+	tmpDir, err := os.MkdirTemp("", "gestalt-provider-publish-*")
+	if err != nil {
+		return fmt.Errorf("create publish temp dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+	if err := writeChecksumsQuiet(tmpDir, releaseArchives); err != nil {
+		return fmt.Errorf("write checksums: %w", err)
+	}
+	if err := writeProviderReleaseMetadataQuiet(tmpDir, releaseManifest, releaseVersion, releaseArchives); err != nil {
+		return fmt.Errorf("write release metadata: %w", err)
+	}
+
+	files, sourceInfo, err := providerPublishFiles(repo, *manifestPath, sourceRef, releaseArchives, tmpDir)
+	if err != nil {
+		return err
+	}
+	if *dryRun {
+		if *format == providerPublishFormatJSON {
+			return printProviderPublishPlanJSON(*repoName, sourceInfo, *version, files)
+		}
+		printProviderPublishPlan(files)
+		return nil
+	}
+	existingFiles, err := preflightProviderPublishFiles(files)
+	if err != nil {
+		return err
+	}
+	return uploadProviderPublishFiles(files, sourceRef, existingFiles)
+}
+
+func validateProviderPublishFormat(format string, dryRun bool) error {
+	switch strings.TrimSpace(format) {
+	case providerPublishFormatText:
+		return nil
+	case providerPublishFormatJSON:
+		if !dryRun {
+			return fmt.Errorf("--format json requires --dry-run")
+		}
+		return nil
+	default:
+		return fmt.Errorf("--format must be %q or %q", providerPublishFormatText, providerPublishFormatJSON)
+	}
+}
+
+func providerPublishRepository(cfg *config.Config, name string) (config.ProviderSnapshotRepositoryConfig, error) {
+	if cfg == nil {
+		return config.ProviderSnapshotRepositoryConfig{}, fmt.Errorf("config did not load provider snapshot repositories")
+	}
+	repo, ok := cfg.ProviderSnapshotRepositories[strings.TrimSpace(name)]
+	if !ok {
+		return config.ProviderSnapshotRepositoryConfig{}, fmt.Errorf("providerSnapshotRepositories.%s is not configured", name)
+	}
+	publish := repo.Publish
+	if publish.PathLayout == "" && !publish.Immutable && publish.Storage.Kind == "" && publish.Storage.URL == "" {
+		return config.ProviderSnapshotRepositoryConfig{}, fmt.Errorf("providerSnapshotRepositories.%s.publish is required", name)
+	}
+	return repo, nil
+}
+
+func validateProviderPublishManifest(sourceManifest, releaseManifest *providermanifestv1.Manifest, releaseVersion, versionGuard string) error {
+	if sourceManifest == nil {
+		return fmt.Errorf("--manifest is required")
+	}
+	if releaseManifest == nil {
+		return fmt.Errorf("release manifest is required")
+	}
+	if sourceManifest.Source != releaseManifest.Source {
+		return fmt.Errorf("--manifest package %q does not match release package %q", sourceManifest.Source, releaseManifest.Source)
+	}
+	if sourceManifest.Kind != releaseManifest.Kind {
+		return fmt.Errorf("--manifest kind %q does not match release kind %q", sourceManifest.Kind, releaseManifest.Kind)
+	}
+	if releaseVersion != versionGuard {
+		return fmt.Errorf("release version %q does not match --version %q", releaseVersion, versionGuard)
+	}
+	return nil
+}
+
+func providerPublishFiles(repo config.ProviderSnapshotRepositoryConfig, manifestPath, sourceRef string, archives []releaseArchive, metadataDir string) ([]providerPublishFile, providerPublishSourceRefInfo, error) {
+	sourceInfo, err := providerPublishSourceRef(manifestPath, sourceRef)
+	if err != nil {
+		return nil, providerPublishSourceRefInfo{}, err
+	}
+	storageRoot := strings.TrimRight(strings.TrimSpace(repo.Publish.Storage.URL), "/")
+	publicRoot := strings.TrimRight(strings.TrimSpace(repo.URL), "/")
+	if publicRoot == "" {
+		return nil, providerPublishSourceRefInfo{}, fmt.Errorf("provider snapshot repository url is required")
+	}
+
+	sortedArchives := append([]releaseArchive(nil), archives...)
+	sort.Slice(sortedArchives, func(i, j int) bool {
+		return filepath.Base(sortedArchives[i].Path) < filepath.Base(sortedArchives[j].Path)
+	})
+	files := make([]providerPublishFile, 0, len(sortedArchives)+2)
+	for _, archive := range sortedArchives {
+		file, err := newProviderPublishFile(providerPublishFileKindArchive, archive.Target, archive.Path, storageRoot, publicRoot, sourceInfo.RelRoot, filepath.Base(archive.Path))
+		if err != nil {
+			return nil, providerPublishSourceRefInfo{}, err
+		}
+		files = append(files, file)
+	}
+	for _, item := range []struct {
+		kind string
+		name string
+	}{
+		{kind: providerPublishFileKindChecksums, name: "checksums.txt"},
+		{kind: providerPublishFileKindMetadata, name: providerReleaseMetadataFile},
+	} {
+		file, err := newProviderPublishFile(item.kind, "", filepath.Join(metadataDir, item.name), storageRoot, publicRoot, sourceInfo.RelRoot, item.name)
+		if err != nil {
+			return nil, providerPublishSourceRefInfo{}, err
+		}
+		files = append(files, file)
+	}
+	return files, sourceInfo, nil
+}
+
+func providerPublishSourceRef(manifestPath, sourceRef string) (providerPublishSourceRefInfo, error) {
+	absManifestPath, err := filepath.Abs(manifestPath)
+	if err != nil {
+		return providerPublishSourceRefInfo{}, fmt.Errorf("resolve --manifest: %w", err)
+	}
+	if evaluatedManifestPath, err := filepath.EvalSymlinks(absManifestPath); err == nil {
+		absManifestPath = evaluatedManifestPath
+	}
+	manifestDir := filepath.Dir(absManifestPath)
+	rootOut, err := runProviderPublishCommand("git", "-C", manifestDir, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return providerPublishSourceRefInfo{}, fmt.Errorf("resolve git root for --manifest: %w", err)
+	}
+	gitRoot := strings.TrimSpace(rootOut)
+	if absGitRoot, err := filepath.Abs(gitRoot); err == nil {
+		gitRoot = absGitRoot
+	}
+	if evaluatedGitRoot, err := filepath.EvalSymlinks(gitRoot); err == nil {
+		gitRoot = evaluatedGitRoot
+	}
+	relManifestPath, err := filepath.Rel(gitRoot, absManifestPath)
+	if err != nil {
+		return providerPublishSourceRefInfo{}, fmt.Errorf("resolve manifest path relative to git root: %w", err)
+	}
+	if relManifestPath == "." || strings.HasPrefix(relManifestPath, ".."+string(filepath.Separator)) || filepath.IsAbs(relManifestPath) {
+		return providerPublishSourceRefInfo{}, fmt.Errorf("--manifest must be inside the current git checkout")
+	}
+	providerDir := path.Dir(filepath.ToSlash(relManifestPath))
+	if providerDir == "." {
+		providerDir = ""
+	}
+	remoteOut, err := runProviderPublishCommand("git", "-C", gitRoot, "remote", "get-url", "origin")
+	if err != nil {
+		return providerPublishSourceRefInfo{}, fmt.Errorf("resolve git origin for --manifest: %w", err)
+	}
+	sourceInfo, err := operator.NewSnapshotSourceRefPath(strings.TrimSpace(remoteOut), sourceRef, filepath.ToSlash(relManifestPath))
+	if err != nil {
+		return providerPublishSourceRefInfo{}, err
+	}
+	if sourceInfo.ProviderDir != providerDir || sourceInfo.ManifestPath != filepath.ToSlash(relManifestPath) {
+		return providerPublishSourceRefInfo{}, fmt.Errorf("resolved snapshot path does not match --manifest")
+	}
+	return sourceInfo, nil
+}
+
+func newProviderPublishFile(kind, target, localPath, storageRoot, publicRoot, relRoot, filename string) (providerPublishFile, error) {
+	digest, err := sha256File(localPath)
+	if err != nil {
+		return providerPublishFile{}, err
+	}
+	rel := path.Join(relRoot, filename)
+	return providerPublishFile{
+		Kind:       kind,
+		Target:     target,
+		LocalPath:  localPath,
+		StorageURL: storageRoot + "/" + rel,
+		PublicURL:  publicRoot + "/" + rel,
+		SHA256:     digest,
+	}, nil
+}
+
+func sha256File(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("open %s: %w", path, err)
+	}
+	defer func() { _ = file.Close() }()
+	digest := sha256.New()
+	if _, err := io.Copy(digest, file); err != nil {
+		return "", fmt.Errorf("hash %s: %w", path, err)
+	}
+	return hex.EncodeToString(digest.Sum(nil)), nil
+}
+
+func printProviderPublishPlan(files []providerPublishFile) {
+	for _, file := range files {
+		_, _ = fmt.Fprintf(os.Stdout, "dry-run upload %s -> %s sha256=%s\n", file.LocalPath, file.StorageURL, file.SHA256)
+	}
+	if len(files) > 0 {
+		_, _ = fmt.Fprintf(os.Stdout, "provider-release metadata: %s\n", files[len(files)-1].PublicURL)
+	}
+}
+
+func printProviderPublishPlanJSON(publishRepository string, sourceInfo providerPublishSourceRefInfo, version string, files []providerPublishFile) error {
+	plan, err := newProviderPublishPlan(publishRepository, sourceInfo, version, files)
+	if err != nil {
+		return err
+	}
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(plan)
+}
+
+func newProviderPublishPlan(publishRepository string, sourceInfo providerPublishSourceRefInfo, version string, files []providerPublishFile) (providerPublishPlan, error) {
+	plan := providerPublishPlan{
+		Schema:            providerPublishPlanSchema,
+		PublishRepository: publishRepository,
+		SourceRepository:  sourceInfo.SourceRepository,
+		SourceRef:         sourceInfo.SourceRef,
+		ProviderDir:       sourceInfo.ProviderDir,
+		ManifestPath:      sourceInfo.ManifestPath,
+		Version:           version,
+		Artifacts:         []providerPublishFile{},
+		Files:             make([]providerPublishFile, 0, len(files)),
+	}
+	for _, file := range files {
+		plan.Files = append(plan.Files, file)
+		switch file.Kind {
+		case providerPublishFileKindArchive:
+			plan.Artifacts = append(plan.Artifacts, file)
+		case providerPublishFileKindChecksums:
+			plan.Checksums = file
+		case providerPublishFileKindMetadata:
+			plan.Metadata = file
+		}
+	}
+	if plan.Metadata.PublicURL == "" {
+		return providerPublishPlan{}, fmt.Errorf("provider publish plan is missing %s", providerReleaseMetadataFile)
+	}
+	if plan.Checksums.PublicURL == "" {
+		return providerPublishPlan{}, fmt.Errorf("provider publish plan is missing checksums.txt")
+	}
+	return plan, nil
+}
+
+func preflightProviderPublishFiles(files []providerPublishFile) (map[string]bool, error) {
+	existingFiles := make(map[string]bool, len(files))
+	for _, file := range files {
+		existingSHA, exists, err := providerPublishObjectSHA256(file.StorageURL)
+		if err != nil {
+			return nil, err
+		}
+		if !exists {
+			continue
+		}
+		if existingSHA != file.SHA256 {
+			return nil, fmt.Errorf("%s already exists with different sha256 metadata", file.StorageURL)
+		}
+		existingFiles[file.StorageURL] = true
+	}
+	return existingFiles, nil
+}
+
+func uploadProviderPublishFile(file providerPublishFile, sourceRef string, alreadyExists bool) error {
+	if alreadyExists {
+		_, _ = fmt.Fprintf(os.Stdout, "exists byte-identical %s\n", file.StorageURL)
+		return nil
+	}
+	return uploadProviderPublishFileCreateOnly(file, sourceRef)
+}
+
+func uploadProviderPublishFiles(files []providerPublishFile, sourceRef string, existingFiles map[string]bool) error {
+	for _, kind := range []string{providerPublishFileKindArchive, providerPublishFileKindChecksums, providerPublishFileKindMetadata} {
+		for _, file := range files {
+			if file.Kind != kind {
+				continue
+			}
+			if err := uploadProviderPublishFile(file, sourceRef, existingFiles[file.StorageURL]); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func uploadProviderPublishFileCreateOnly(file providerPublishFile, sourceRef string) error {
+	metadata := fmt.Sprintf("source-ref=%s,sha256=%s", sourceRef, file.SHA256)
+	if _, err := runProviderPublishCommand("gcloud", "storage", "cp", "--if-generation-match=0", "--custom-metadata="+metadata, file.LocalPath, file.StorageURL); err != nil {
+		return acceptProviderPublishUploadRace(file, err)
+	}
+	_, _ = fmt.Fprintf(os.Stdout, "uploaded %s\n", file.StorageURL)
+	return nil
+}
+
+func acceptProviderPublishUploadRace(file providerPublishFile, uploadErr error) error {
+	existingSHA, exists, err := providerPublishObjectSHA256(file.StorageURL)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return uploadErr
+	}
+	if existingSHA == file.SHA256 {
+		_, _ = fmt.Fprintf(os.Stdout, "exists byte-identical %s\n", file.StorageURL)
+		return nil
+	}
+	return fmt.Errorf("%s already exists with different sha256 metadata", file.StorageURL)
+}
+
+func providerPublishObjectSHA256(storageURL string) (string, bool, error) {
+	out, err := runProviderPublishCommand("gcloud", "storage", "objects", "describe", storageURL, "--format=json")
+	if err != nil {
+		if providerPublishObjectNotFound(err) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	var describe struct {
+		Metadata map[string]string `json:"metadata"`
+	}
+	if err := json.Unmarshal([]byte(out), &describe); err != nil {
+		return "", false, fmt.Errorf("parse gcloud describe %s: %w", storageURL, err)
+	}
+	sha := strings.TrimSpace(describe.Metadata["sha256"])
+	if sha == "" {
+		return "", true, fmt.Errorf("%s exists without sha256 custom metadata", storageURL)
+	}
+	return sha, true, nil
+}
+
+func providerPublishObjectNotFound(err error) bool {
+	var cmdErr *providerPublishCommandError
+	if !errors.As(err, &cmdErr) {
+		return false
+	}
+	text := strings.ToLower(cmdErr.Stdout + "\n" + cmdErr.Stderr + "\n" + cmdErr.Err.Error())
+	return strings.Contains(text, "not found") ||
+		strings.Contains(text, "no urls matched") ||
+		strings.Contains(text, "404")
+}
+
+type providerPublishCommandError struct {
+	Name   string
+	Args   []string
+	Err    error
+	Stdout string
+	Stderr string
+}
+
+func (e *providerPublishCommandError) Error() string {
+	return fmt.Sprintf("%s %s failed: %v\n%s%s", e.Name, strings.Join(e.Args, " "), e.Err, e.Stdout, e.Stderr)
+}
+
+func (e *providerPublishCommandError) Unwrap() error {
+	return e.Err
+}
+
+func runProviderPublishCommand(name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", &providerPublishCommandError{
+			Name:   name,
+			Args:   append([]string(nil), args...),
+			Err:    err,
+			Stdout: stdout.String(),
+			Stderr: stderr.String(),
+		}
+	}
+	return stdout.String(), nil
+}
+
+func printProviderPublishUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd provider publish --repo NAME --manifest PATH --version VERSION --ref SHA --dist-dir DIR [--dist-dir DIR...]")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Publish finalized provider release artifacts to a configured artifact repository.")
+	writeUsageLine(w, "Reads .tar.gz archives from each --dist-dir, validates one release bundle,")
+	writeUsageLine(w, "generates checksums.txt and provider-release.yaml, then uploads archives first")
+	writeUsageLine(w, "and provider-release.yaml last. Destination paths use the configured repository")
+	writeUsageLine(w, "publish.pathLayout and the manifest source plus --ref.")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Flags:")
+	writeUsageLine(w, "  --config    Path to config file (repeat to layer overrides)")
+	writeUsageLine(w, "  --dist-dir  Directory containing release archives (repeatable)")
+	writeUsageLine(w, "  --dry-run   Print the upload plan without writing")
+	writeUsageLine(w, "  --format    Dry-run output format: text or json (default: text)")
+	writeUsageLine(w, "  --manifest  Source manifest path")
+	writeUsageLine(w, "  --ref       Full source commit SHA")
+	writeUsageLine(w, "  --repo      providerSnapshotRepositories entry with publish settings")
+	writeUsageLine(w, "  --version   Semantic version guard")
+}

--- a/gestaltd/internal/daemon/provider_publish_test.go
+++ b/gestaltd/internal/daemon/provider_publish_test.go
@@ -1,0 +1,418 @@
+package daemon
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRun_ProviderPublishDryRunPlansSourceRefUploads(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	pluginDir := newUIReleaseFixture(t, rootDir)
+	initProviderPublishGitRepo(t, rootDir, "https://github.com/testowner/apps.git")
+	outputDir := t.TempDir()
+	const version = "0.0.0-snapshot.g651a5c30feb995c9364c38f63d0d5c3880bc2055"
+	const ref = "651a5c30feb995c9364c38f63d0d5c3880bc2055"
+	runProviderPackageCommand(t, pluginDir,
+		"--version", version,
+		"--output", outputDir,
+	)
+	configPath := filepath.Join(t.TempDir(), "gestaltd.yaml")
+	if err := os.WriteFile(configPath, []byte(`
+apiVersion: gestaltd.config/v6
+providerSnapshotRepositories:
+  valon:
+    url: https://storage.example.test/providers
+    publish:
+      pathLayout: sourceRef
+      immutable: true
+      storage:
+        kind: objectStore
+        url: gs://provider-snapshots
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	out, err := runProviderCommandResult(pluginDir,
+		"publish",
+		"--config", configPath,
+		"--repo", "valon",
+		"--manifest", filepath.Join(pluginDir, "manifest.json"),
+		"--version", version,
+		"--ref", ref,
+		"--dist-dir", outputDir,
+		"--dry-run",
+	)
+	if err != nil {
+		t.Fatalf("provider publish failed: %v\n%s", err, out)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"dry-run upload",
+		"gs://provider-snapshots/github.com/testowner/apps/" + ref + "/ui-test/gestalt-app-ui-test_v" + version + ".tar.gz",
+		"provider-release metadata: https://storage.example.test/providers/github.com/testowner/apps/" + ref + "/ui-test/provider-release.yaml",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("provider publish output missing %q\n%s", want, got)
+		}
+	}
+}
+
+func TestRun_ProviderPublishDryRunJSONPlansSourceRefUploads(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	pluginDir := newUIReleaseFixture(t, rootDir)
+	initProviderPublishGitRepo(t, rootDir, "git@github.com:testowner/apps.git")
+	outputDir := t.TempDir()
+	const version = "0.0.0-snapshot.g651a5c30feb995c9364c38f63d0d5c3880bc2055"
+	const ref = "651a5c30feb995c9364c38f63d0d5c3880bc2055"
+	runProviderPackageCommand(t, pluginDir,
+		"--version", version,
+		"--output", outputDir,
+	)
+	configPath := filepath.Join(t.TempDir(), "gestaltd.yaml")
+	if err := os.WriteFile(configPath, []byte(`
+apiVersion: gestaltd.config/v6
+providerSnapshotRepositories:
+  valon:
+    url: https://storage.example.test/providers
+    publish:
+      pathLayout: sourceRef
+      immutable: true
+      storage:
+        kind: objectStore
+        url: gs://provider-snapshots
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	out, err := runProviderCommandResult(pluginDir,
+		"publish",
+		"--config", configPath,
+		"--repo", "valon",
+		"--manifest", filepath.Join(pluginDir, "manifest.json"),
+		"--version", version,
+		"--ref", strings.ToUpper(ref),
+		"--dist-dir", outputDir,
+		"--dry-run",
+		"--format", "json",
+	)
+	if err != nil {
+		t.Fatalf("provider publish failed: %v\n%s", err, out)
+	}
+	var plan providerPublishPlan
+	if err := json.Unmarshal(out, &plan); err != nil {
+		t.Fatalf("dry-run JSON did not parse: %v\n%s", err, out)
+	}
+	if plan.Schema != providerPublishPlanSchema {
+		t.Fatalf("schema = %q, want %q", plan.Schema, providerPublishPlanSchema)
+	}
+	if plan.PublishRepository != "valon" || plan.SourceRepository != "github.com/testowner/apps" || plan.SourceRef != ref || plan.Version != version {
+		t.Fatalf("unexpected plan identity: %#v", plan)
+	}
+	if plan.ProviderDir != "ui-test" || plan.ManifestPath != "ui-test/manifest.json" {
+		t.Fatalf("unexpected source paths: %#v", plan)
+	}
+	if plan.Metadata.PublicURL != "https://storage.example.test/providers/github.com/testowner/apps/"+ref+"/ui-test/provider-release.yaml" {
+		t.Fatalf("metadata public URL = %q", plan.Metadata.PublicURL)
+	}
+	if plan.Checksums.PublicURL != "https://storage.example.test/providers/github.com/testowner/apps/"+ref+"/ui-test/checksums.txt" {
+		t.Fatalf("checksums public URL = %q", plan.Checksums.PublicURL)
+	}
+	if len(plan.Artifacts) != 1 {
+		t.Fatalf("artifacts len = %d, want 1: %#v", len(plan.Artifacts), plan.Artifacts)
+	}
+	artifact := plan.Artifacts[0]
+	if artifact.Kind != providerPublishFileKindArchive || artifact.Target != providerReleaseGenericTarget {
+		t.Fatalf("unexpected artifact identity: %#v", artifact)
+	}
+	if artifact.PublicURL != "https://storage.example.test/providers/github.com/testowner/apps/"+ref+"/ui-test/gestalt-app-ui-test_v"+version+".tar.gz" {
+		t.Fatalf("artifact public URL = %q", artifact.PublicURL)
+	}
+	if len(plan.Files) != 3 {
+		t.Fatalf("files len = %d, want 3: %#v", len(plan.Files), plan.Files)
+	}
+}
+
+func TestRun_ProviderPublishRejectsShortRef(t *testing.T) {
+	t.Parallel()
+
+	pluginDir := newUIReleaseFixture(t, t.TempDir())
+	out, err := runProviderCommandResult(pluginDir,
+		"publish",
+		"--repo", "valon",
+		"--manifest", filepath.Join(pluginDir, "manifest.json"),
+		"--version", "1.0.0",
+		"--ref", "abc123",
+		"--dist-dir", t.TempDir(),
+		"--dry-run",
+	)
+	if err == nil {
+		t.Fatalf("expected provider publish to reject short ref\n%s", out)
+	}
+	if !strings.Contains(string(out), "--ref must be a 40-character commit SHA") {
+		t.Fatalf("unexpected output: %s", out)
+	}
+}
+
+func TestRun_ProviderPublishRejectsJSONFormatWithoutDryRun(t *testing.T) {
+	t.Parallel()
+
+	out, err := runProviderCommandResult(t.TempDir(),
+		"publish",
+		"--repo", "valon",
+		"--format", "json",
+	)
+	if err == nil {
+		t.Fatalf("expected provider publish to reject JSON format without dry-run\n%s", out)
+	}
+	if !strings.Contains(string(out), "--format json requires --dry-run") {
+		t.Fatalf("unexpected output: %s", out)
+	}
+}
+
+func TestRun_ProviderPublishPreflightsConflictsBeforeUploading(t *testing.T) {
+	rootDir := t.TempDir()
+	pluginDir := newUIReleaseFixture(t, rootDir)
+	initProviderPublishGitRepo(t, rootDir, "https://github.com/testowner/apps.git")
+	outputDir := t.TempDir()
+	const version = "0.0.0-snapshot.g651a5c30feb995c9364c38f63d0d5c3880bc2055"
+	const ref = "651a5c30feb995c9364c38f63d0d5c3880bc2055"
+	runProviderPackageCommand(t, pluginDir,
+		"--version", version,
+		"--output", outputDir,
+	)
+	configPath := filepath.Join(t.TempDir(), "gestaltd.yaml")
+	if err := os.WriteFile(configPath, []byte(`
+apiVersion: gestaltd.config/v6
+providerSnapshotRepositories:
+  valon:
+    url: https://storage.example.test/providers
+    publish:
+      pathLayout: sourceRef
+      immutable: true
+      storage:
+        kind: objectStore
+        url: gs://provider-snapshots
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	binDir := t.TempDir()
+	callsPath := filepath.Join(t.TempDir(), "gcloud.calls")
+	fakeGcloud := filepath.Join(binDir, "gcloud")
+	if err := os.WriteFile(fakeGcloud, []byte(`#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${GCLOUD_CALLS}"
+if [ "$1" = "storage" ] && [ "$2" = "objects" ] && [ "$3" = "describe" ]; then
+  case "$4" in
+    *provider-release.yaml)
+      printf '{"metadata":{"sha256":"stale"}}\n'
+      exit 0
+      ;;
+    *)
+      echo "not found" >&2
+      exit 1
+      ;;
+  esac
+fi
+if [ "$1" = "storage" ] && [ "$2" = "cp" ]; then
+  printf 'upload attempted\n' >> "${GCLOUD_CALLS}"
+  exit 0
+fi
+exit 1
+`), 0o755); err != nil {
+		t.Fatalf("write fake gcloud: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GCLOUD_CALLS", callsPath)
+
+	out, err := runProviderCommandResult(pluginDir,
+		"publish",
+		"--config", configPath,
+		"--repo", "valon",
+		"--manifest", filepath.Join(pluginDir, "manifest.json"),
+		"--version", version,
+		"--ref", ref,
+		"--dist-dir", outputDir,
+	)
+	if err == nil {
+		t.Fatalf("expected provider publish to reject stale metadata before upload\n%s", out)
+	}
+	if !strings.Contains(string(out), "provider-release.yaml already exists with different sha256 metadata") {
+		t.Fatalf("unexpected output: %s", out)
+	}
+	calls, err := os.ReadFile(callsPath)
+	if err != nil {
+		t.Fatalf("read fake gcloud calls: %v", err)
+	}
+	if strings.Contains(string(calls), "upload attempted") {
+		t.Fatalf("provider publish attempted upload before preflight completed:\n%s", calls)
+	}
+}
+
+func TestRun_ProviderPublishDoesNotTreatDescribeErrorsAsMissing(t *testing.T) {
+	rootDir := t.TempDir()
+	pluginDir := newUIReleaseFixture(t, rootDir)
+	initProviderPublishGitRepo(t, rootDir, "https://github.com/testowner/apps.git")
+	outputDir := t.TempDir()
+	const version = "0.0.0-snapshot.g651a5c30feb995c9364c38f63d0d5c3880bc2055"
+	const ref = "651a5c30feb995c9364c38f63d0d5c3880bc2055"
+	runProviderPackageCommand(t, pluginDir,
+		"--version", version,
+		"--output", outputDir,
+	)
+	configPath := filepath.Join(t.TempDir(), "gestaltd.yaml")
+	if err := os.WriteFile(configPath, []byte(`
+apiVersion: gestaltd.config/v6
+providerSnapshotRepositories:
+  valon:
+    url: https://storage.example.test/providers
+    publish:
+      pathLayout: sourceRef
+      immutable: true
+      storage:
+        kind: objectStore
+        url: gs://provider-snapshots
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	binDir := t.TempDir()
+	callsPath := filepath.Join(t.TempDir(), "gcloud.calls")
+	fakeGcloud := filepath.Join(binDir, "gcloud")
+	if err := os.WriteFile(fakeGcloud, []byte(`#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${GCLOUD_CALLS}"
+if [ "$1" = "storage" ] && [ "$2" = "objects" ] && [ "$3" = "describe" ]; then
+  echo "permission denied" >&2
+  exit 1
+fi
+if [ "$1" = "storage" ] && [ "$2" = "cp" ]; then
+  printf 'upload attempted\n' >> "${GCLOUD_CALLS}"
+  exit 0
+fi
+exit 1
+`), 0o755); err != nil {
+		t.Fatalf("write fake gcloud: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GCLOUD_CALLS", callsPath)
+
+	out, err := runProviderCommandResult(pluginDir,
+		"publish",
+		"--config", configPath,
+		"--repo", "valon",
+		"--manifest", filepath.Join(pluginDir, "manifest.json"),
+		"--version", version,
+		"--ref", ref,
+		"--dist-dir", outputDir,
+	)
+	if err == nil {
+		t.Fatalf("expected provider publish to reject describe error before upload\n%s", out)
+	}
+	if !strings.Contains(string(out), "permission denied") {
+		t.Fatalf("unexpected output: %s", out)
+	}
+	calls, err := os.ReadFile(callsPath)
+	if err != nil {
+		t.Fatalf("read fake gcloud calls: %v", err)
+	}
+	if strings.Contains(string(calls), "upload attempted") {
+		t.Fatalf("provider publish attempted upload after describe error:\n%s", calls)
+	}
+}
+
+func TestRun_ProviderPublishUploadsArchivesBeforeMetadata(t *testing.T) {
+	rootDir := t.TempDir()
+	pluginDir := newUIReleaseFixture(t, rootDir)
+	initProviderPublishGitRepo(t, rootDir, "https://github.com/testowner/apps.git")
+	outputDir := t.TempDir()
+	const version = "0.0.0-snapshot.g651a5c30feb995c9364c38f63d0d5c3880bc2055"
+	const ref = "651a5c30feb995c9364c38f63d0d5c3880bc2055"
+	runProviderPackageCommand(t, pluginDir,
+		"--version", version,
+		"--output", outputDir,
+	)
+	configPath := filepath.Join(t.TempDir(), "gestaltd.yaml")
+	if err := os.WriteFile(configPath, []byte(`
+apiVersion: gestaltd.config/v6
+providerSnapshotRepositories:
+  valon:
+    url: https://storage.example.test/providers
+    publish:
+      pathLayout: sourceRef
+      immutable: true
+      storage:
+        kind: objectStore
+        url: gs://provider-snapshots
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	binDir := t.TempDir()
+	callsPath := filepath.Join(t.TempDir(), "gcloud.calls")
+	fakeGcloud := filepath.Join(binDir, "gcloud")
+	if err := os.WriteFile(fakeGcloud, []byte(`#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${GCLOUD_CALLS}"
+if [ "$1" = "storage" ] && [ "$2" = "objects" ] && [ "$3" = "describe" ]; then
+  echo "not found" >&2
+  exit 1
+fi
+if [ "$1" = "storage" ] && [ "$2" = "cp" ]; then
+  exit 0
+fi
+exit 1
+`), 0o755); err != nil {
+		t.Fatalf("write fake gcloud: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GCLOUD_CALLS", callsPath)
+
+	out, err := runProviderCommandResult(pluginDir,
+		"publish",
+		"--config", configPath,
+		"--repo", "valon",
+		"--manifest", filepath.Join(pluginDir, "manifest.json"),
+		"--version", version,
+		"--ref", ref,
+		"--dist-dir", outputDir,
+	)
+	if err != nil {
+		t.Fatalf("provider publish failed: %v\n%s", err, out)
+	}
+	calls, err := os.ReadFile(callsPath)
+	if err != nil {
+		t.Fatalf("read fake gcloud calls: %v", err)
+	}
+	got := string(calls)
+	archiveUpload := strings.Index(got, "gestalt-app-ui-test_v"+version+".tar.gz gs://provider-snapshots")
+	checksumUpload := strings.Index(got, "checksums.txt gs://provider-snapshots")
+	metadataUpload := strings.Index(got, "provider-release.yaml gs://provider-snapshots")
+	if archiveUpload < 0 || checksumUpload < 0 || metadataUpload < 0 {
+		t.Fatalf("missing expected upload calls:\n%s", got)
+	}
+	if archiveUpload >= checksumUpload || checksumUpload >= metadataUpload {
+		t.Fatalf("uploads are not phased archive -> checksums -> metadata:\n%s", got)
+	}
+}
+
+func initProviderPublishGitRepo(t *testing.T, dir, remote string) {
+	t.Helper()
+
+	for _, args := range [][]string{
+		{"init"},
+		{"remote", "add", "origin", remote},
+	} {
+		out, err := runProviderPublishCommand("git", append([]string{"-C", dir}, args...)...)
+		if err != nil {
+			t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, out)
+		}
+	}
+}

--- a/gestaltd/internal/daemon/provider_release_finalize.go
+++ b/gestaltd/internal/daemon/provider_release_finalize.go
@@ -50,6 +50,14 @@ func runProviderRelease(args []string) (err error) {
 }
 
 func writeChecksums(dir string, archives []releaseArchive) error {
+	return writeChecksumsWithOutput(dir, archives, true)
+}
+
+func writeChecksumsQuiet(dir string, archives []releaseArchive) error {
+	return writeChecksumsWithOutput(dir, archives, false)
+}
+
+func writeChecksumsWithOutput(dir string, archives []releaseArchive, verbose bool) error {
 	sortedArchives := append([]releaseArchive(nil), archives...)
 	sort.Slice(sortedArchives, func(i, j int) bool {
 		return filepath.Base(sortedArchives[i].Path) < filepath.Base(sortedArchives[j].Path)
@@ -68,7 +76,9 @@ func writeChecksums(dir string, archives []releaseArchive) error {
 	if err := os.WriteFile(checksumPath, []byte(content), 0644); err != nil {
 		return err
 	}
-	_, _ = fmt.Fprintf(os.Stdout, "created %s\n", checksumPath)
+	if verbose {
+		_, _ = fmt.Fprintf(os.Stdout, "created %s\n", checksumPath)
+	}
 	return nil
 }
 
@@ -85,9 +95,29 @@ func describeReleaseArchive(path, target string) (releaseArchive, error) {
 }
 
 func collectReleaseArchives(distDir, versionGuard string) (*providermanifestv1.Manifest, string, []releaseArchive, error) {
+	return collectReleaseArchivesFromDirs([]string{distDir}, versionGuard)
+}
+
+func collectReleaseArchivesFromDirs(distDirs []string, versionGuard string) (*providermanifestv1.Manifest, string, []releaseArchive, error) {
+	var archivePaths []string
+	for _, distDir := range distDirs {
+		paths, err := releaseArchivePathsInDir(distDir)
+		if err != nil {
+			return nil, "", nil, err
+		}
+		archivePaths = append(archivePaths, paths...)
+	}
+	sort.Strings(archivePaths)
+	if len(archivePaths) == 0 {
+		return nil, "", nil, fmt.Errorf("no .tar.gz release archives found in %s", strings.Join(distDirs, ", "))
+	}
+	return collectReleaseArchivePaths(archivePaths, versionGuard)
+}
+
+func releaseArchivePathsInDir(distDir string) ([]string, error) {
 	entries, err := os.ReadDir(distDir)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("read dist dir: %w", err)
+		return nil, fmt.Errorf("read dist dir %s: %w", distDir, err)
 	}
 	var archivePaths []string
 	for _, entry := range entries {
@@ -96,18 +126,23 @@ func collectReleaseArchives(distDir, versionGuard string) (*providermanifestv1.M
 		}
 		archivePaths = append(archivePaths, filepath.Join(distDir, entry.Name()))
 	}
-	sort.Strings(archivePaths)
-	if len(archivePaths) == 0 {
-		return nil, "", nil, fmt.Errorf("no .tar.gz release archives found in %s", distDir)
-	}
+	return archivePaths, nil
+}
 
+func collectReleaseArchivePaths(archivePaths []string, versionGuard string) (*providermanifestv1.Manifest, string, []releaseArchive, error) {
 	var releaseManifest *providermanifestv1.Manifest
 	var comparableReleaseManifest []byte
 	releaseVersion := ""
+	seenArchiveNames := map[string]string{}
 	seenTargets := map[string]string{}
 	var hasGeneric, hasPlatform bool
 	archives := make([]releaseArchive, 0, len(archivePaths))
 	for _, archivePath := range archivePaths {
+		archiveName := filepath.Base(archivePath)
+		if existingPath, ok := seenArchiveNames[archiveName]; ok {
+			return nil, "", nil, fmt.Errorf("multiple release archives have filename %s: %s and %s", archiveName, existingPath, archivePath)
+		}
+		seenArchiveNames[archiveName] = archivePath
 		manifest, target, err := inspectReleaseArchive(archivePath)
 		if err != nil {
 			return nil, "", nil, err
@@ -211,6 +246,14 @@ func releaseArchiveTargetFromManifest(manifest *providermanifestv1.Manifest) (st
 }
 
 func writeProviderReleaseMetadata(dir string, manifest *providermanifestv1.Manifest, version string, archives []releaseArchive) error {
+	return writeProviderReleaseMetadataWithOutput(dir, manifest, version, archives, true)
+}
+
+func writeProviderReleaseMetadataQuiet(dir string, manifest *providermanifestv1.Manifest, version string, archives []releaseArchive) error {
+	return writeProviderReleaseMetadataWithOutput(dir, manifest, version, archives, false)
+}
+
+func writeProviderReleaseMetadataWithOutput(dir string, manifest *providermanifestv1.Manifest, version string, archives []releaseArchive, verbose bool) error {
 	metadata, err := buildProviderReleaseMetadata(manifest, version, archives)
 	if err != nil {
 		return err
@@ -223,7 +266,9 @@ func writeProviderReleaseMetadata(dir string, manifest *providermanifestv1.Manif
 	if err := os.WriteFile(path, data, 0o644); err != nil {
 		return err
 	}
-	_, _ = fmt.Fprintf(os.Stdout, "created %s\n", path)
+	if verbose {
+		_, _ = fmt.Fprintf(os.Stdout, "created %s\n", path)
+	}
 	return nil
 }
 

--- a/gestaltd/internal/operator/git_source.go
+++ b/gestaltd/internal/operator/git_source.go
@@ -28,6 +28,46 @@ type gitSnapshotSource struct {
 	GestaltRef  string
 }
 
+type SnapshotSourceRefPath struct {
+	RelRoot          string
+	SourceRepository string
+	SourceRef        string
+	ProviderDir      string
+	ManifestPath     string
+}
+
+func NewSnapshotSourceRefPath(repoURL, ref, manifestPath string) (SnapshotSourceRefPath, error) {
+	host, owner, name, err := githubRepoPath(repoURL)
+	if err != nil {
+		return SnapshotSourceRefPath{}, err
+	}
+	sourceRef := strings.ToLower(strings.TrimSpace(ref))
+	manifestPath = path.Clean(filepath.ToSlash(strings.TrimSpace(manifestPath)))
+	if manifestPath == "" || manifestPath == "." || strings.HasPrefix(manifestPath, "../") || path.IsAbs(manifestPath) {
+		return SnapshotSourceRefPath{}, fmt.Errorf("source.git.path must be a clean relative path")
+	}
+	providerDir := path.Dir(manifestPath)
+	if providerDir == "." {
+		providerDir = ""
+	}
+	sourceRepository := path.Join(host, owner, name)
+	parts := []string{sourceRepository, sourceRef}
+	if providerDir != "" {
+		parts = append(parts, strings.Split(providerDir, "/")...)
+	}
+	return SnapshotSourceRefPath{
+		RelRoot:          path.Join(parts...),
+		SourceRepository: sourceRepository,
+		SourceRef:        sourceRef,
+		ProviderDir:      providerDir,
+		ManifestPath:     manifestPath,
+	}, nil
+}
+
+func (p SnapshotSourceRefPath) FileRelPath(filename string) string {
+	return path.Join(p.RelRoot, filename)
+}
+
 func gitSourceDef(entry *config.ProviderEntry) *config.GitSourceDef {
 	if entry == nil {
 		return nil
@@ -111,41 +151,40 @@ func resolveGitSnapshotSource(cfg *config.Config, entry *config.ProviderEntry) (
 	if !ok {
 		return gitSnapshotSource{}, fmt.Errorf("providerSnapshotRepositories.%s is not configured", repoName)
 	}
-	owner, name, err := githubRepoPath(git.Repo)
+	base := strings.TrimRight(strings.TrimSpace(repo.URL), "/")
+	_, ref, manifestPath := git.NormalizedLocationParts()
+	snapshotPath, err := NewSnapshotSourceRefPath(git.Repo, ref, manifestPath)
 	if err != nil {
 		return gitSnapshotSource{}, err
 	}
-	base := strings.TrimRight(strings.TrimSpace(repo.URL), "/")
-	_, ref, manifestPath := git.NormalizedLocationParts()
-	providerDir := path.Dir(manifestPath)
-	if providerDir == "." {
-		providerDir = ""
-	}
-	parts := []string{base, "github.com", owner, name, ref}
-	if providerDir != "" {
-		parts = append(parts, strings.Split(providerDir, "/")...)
-	}
-	parts = append(parts, "provider-release.yaml")
 	return gitSnapshotSource{
-		MetadataURL: strings.Join(parts, "/"),
+		MetadataURL: base + "/" + snapshotPath.FileRelPath("provider-release.yaml"),
 		GestaltRef:  strings.TrimSpace(repo.GestaltRef),
 	}, nil
 }
 
-func githubRepoPath(raw string) (string, string, error) {
+func githubRepoPath(raw string) (string, string, string, error) {
+	raw = strings.TrimSpace(raw)
+	const sshPrefix = "git@github.com:"
+	if strings.HasPrefix(raw, sshPrefix) {
+		owner, repo, ok := strings.Cut(strings.TrimPrefix(raw, sshPrefix), "/")
+		if ok && owner != "" && repo != "" {
+			return "github.com", owner, strings.TrimSuffix(repo, ".git"), nil
+		}
+	}
 	parsed, err := url.Parse(strings.TrimSpace(raw))
 	if err != nil {
-		return "", "", fmt.Errorf("parse source.git.repo: %w", err)
+		return "", "", "", fmt.Errorf("parse source.git.repo: %w", err)
 	}
 	if parsed.Scheme != "https" || !strings.EqualFold(parsed.Host, "github.com") {
-		return "", "", fmt.Errorf("source.git snapshots require https://github.com/<owner>/<repo>[.git]")
+		return "", "", "", fmt.Errorf("source.git snapshots require https://github.com/<owner>/<repo>[.git]")
 	}
 	clean := strings.Trim(path.Clean(parsed.Path), "/")
 	parts := strings.Split(clean, "/")
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return "", "", fmt.Errorf("source.git snapshots require https://github.com/<owner>/<repo>[.git]")
+		return "", "", "", fmt.Errorf("source.git snapshots require https://github.com/<owner>/<repo>[.git]")
 	}
-	return parts[0], strings.TrimSuffix(parts[1], ".git"), nil
+	return "github.com", parts[0], strings.TrimSuffix(parts[1], ".git"), nil
 }
 
 func (l *Lifecycle) gitSourceManifestPath(ctx context.Context, paths lifecyclePaths, entry *config.ProviderEntry) (string, error) {


### PR DESCRIPTION
## Summary
- add `gestaltd provider publish` for immutable provider snapshot uploads
- teach snapshot repository config about publish storage settings
- share release archive collection/metadata helpers so publish can emit checksums and provider-release metadata without rebuilding artifacts

## Tests
- `go test ./internal/daemon ./internal/operator ./internal/config`
- `go test ./internal/daemon -run TestRun_ProviderPublish`