### PR TITLE
Move token commands under auth

### DIFF
--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -52,12 +52,6 @@ pub enum Commands {
     /// Describe an app operation
     Describe(DescribeArgs),
 
-    /// Manage API tokens
-    Tokens {
-        #[command(subcommand)]
-        command: TokenCommands,
-    },
-
     /// Manage authorization resources
     Authorization {
         #[command(subcommand)]
@@ -83,6 +77,11 @@ pub enum AuthCommands {
     Logout,
     /// Show authentication status
     Status,
+    /// Manage API tokens
+    Token {
+        #[command(subcommand)]
+        command: TokenCommands,
+    },
 }
 
 #[derive(Subcommand)]

--- a/gestalt/cli/src/main.rs
+++ b/gestalt/cli/src/main.rs
@@ -24,6 +24,7 @@ fn run() -> anyhow::Result<()> {
             AuthCommands::Login => commands::auth::login(url),
             AuthCommands::Logout => commands::auth::logout(),
             AuthCommands::Status => commands::auth::status(url, format),
+            AuthCommands::Token { command } => dispatch_token_command(command, url, format),
         },
         Commands::Init => commands::init::run(url),
         Commands::Config { command } => match command {
@@ -35,16 +36,6 @@ fn run() -> anyhow::Result<()> {
         Commands::App { command } => dispatch_app_command(command, url, format),
         Commands::Invoke(args) => dispatch_app_command(AppCommands::Invoke(args), url, format),
         Commands::Describe(args) => dispatch_app_command(AppCommands::Describe(args), url, format),
-        Commands::Tokens { command } => {
-            let client = ApiClient::from_env(url)?;
-            match command {
-                TokenCommands::Create { name } => {
-                    commands::tokens::create(&client, name.as_deref(), format)
-                }
-                TokenCommands::List => commands::tokens::list(&client, format),
-                TokenCommands::Revoke { id } => commands::tokens::revoke(&client, &id, format),
-            }
-        }
         Commands::Authorization { command } => {
             let client = ApiClient::from_env(url)?;
             commands::authorization::dispatch(&client, command, format)
@@ -54,6 +45,21 @@ fn run() -> anyhow::Result<()> {
             commands::workflows::dispatch(&client, command, format)
         }
         Commands::Agent(args) => dispatch_agent(args, url, url_was_explicit, format),
+    }
+}
+
+fn dispatch_token_command(
+    command: TokenCommands,
+    url: Option<&str>,
+    format: gestalt::output::Format,
+) -> anyhow::Result<()> {
+    let client = ApiClient::from_env(url)?;
+    match command {
+        TokenCommands::Create { name } => {
+            commands::tokens::create(&client, name.as_deref(), format)
+        }
+        TokenCommands::List => commands::tokens::list(&client, format),
+        TokenCommands::Revoke { id } => commands::tokens::revoke(&client, &id, format),
     }
 }
 

--- a/gestalt/cli/tests/config_resolution.rs
+++ b/gestalt/cli/tests/config_resolution.rs
@@ -20,7 +20,7 @@ fn test_cli_reuses_stored_credentials_api_url() {
     );
 
     cli_command(home.path())
-        .args(["tokens", "list"])
+        .args(["auth", "token", "list"])
         .assert()
         .success();
 }
@@ -37,7 +37,7 @@ fn test_cli_ignores_blank_stored_credentials_api_url() {
     );
 
     cli_command(home.path())
-        .args(["tokens", "list"])
+        .args(["auth", "token", "list"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("no URL configured"));


### PR DESCRIPTION
## Summary
Move token commands under auth.

## Test plan
- [ ] Token subcommands live under auth