### PR TITLE
[authorization] route member writes through source fragments

### DIFF
--- a/gestaltd/internal/server/handlers_admin_authorization.go
+++ b/gestaltd/internal/server/handlers_admin_authorization.go
@@ -263,11 +263,11 @@ func (s *Server) putAdminAuthorizationPluginMember(w http.ResponseWriter, r *htt
 		return
 	}
 	if access, ok := s.authorizer.StaticRoleForProviderIdentity(plugin, subject.SubjectID); ok && access.Role != "" {
-		writeError(w, http.StatusConflict, "subject already has static authorization for this plugin")
+		writeError(w, http.StatusConflict, "subject already has static authorization for this app")
 		return
 	}
 
-	membership, err := s.upsertProviderPluginAuthorization(r.Context(), subject, plugin, req.Role)
+	membership, err := s.upsertSourceAppAuthorization(r.Context(), subject, plugin, req.Role)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to persist authorization member")
 		return
@@ -320,7 +320,7 @@ func (s *Server) deleteAdminAuthorizationPluginMember(w http.ResponseWriter, r *
 		return
 	}
 
-	deleteErr := s.deleteProviderPluginAuthorization(r.Context(), plugin, subjectID)
+	deleteErr := s.deleteSourceAppAuthorization(r.Context(), plugin, subjectID)
 	if deleteErr != nil {
 		if errors.Is(deleteErr, core.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "authorization member not found")
@@ -387,7 +387,7 @@ func (s *Server) putAdminAuthorizationAdminMember(w http.ResponseWriter, r *http
 		return
 	}
 
-	membership, err := s.upsertProviderAdminAuthorization(r.Context(), subject, req.Role)
+	membership, err := s.upsertSourceAdminAuthorization(r.Context(), subject, req.Role)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to persist admin member")
 		return
@@ -437,7 +437,7 @@ func (s *Server) deleteAdminAuthorizationAdminMember(w http.ResponseWriter, r *h
 		return
 	}
 
-	deleteErr := s.deleteProviderAdminAuthorization(r.Context(), subjectID)
+	deleteErr := s.deleteSourceAdminAuthorization(r.Context(), subjectID)
 	if deleteErr != nil {
 		if errors.Is(deleteErr, core.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "admin member not found")
@@ -482,11 +482,11 @@ func (s *Server) writeAdminAuthorizationPluginError(w http.ResponseWriter, err e
 	case errAdminAuthorizationAppMissing:
 		writeError(w, http.StatusBadRequest, "app is required")
 	case errAdminAuthorizationPluginUnknown:
-		writeError(w, http.StatusNotFound, "plugin not found")
+		writeError(w, http.StatusNotFound, "app not found")
 	case errAdminAuthorizationPluginUnbound:
-		writeError(w, http.StatusBadRequest, "plugin does not declare authorizationPolicy")
+		writeError(w, http.StatusBadRequest, "app does not declare authorizationPolicy")
 	default:
-		writeError(w, http.StatusInternalServerError, "plugin authorization failed")
+		writeError(w, http.StatusInternalServerError, "app authorization failed")
 	}
 }
 
@@ -687,14 +687,18 @@ func adminAuthorizationValidSubjectID(subjectID string) bool {
 
 var (
 	errAdminAuthorizationAppMissing    = errors.New("app is required")
-	errAdminAuthorizationPluginUnknown = errors.New("plugin not found")
-	errAdminAuthorizationPluginUnbound = errors.New("plugin does not declare authorizationPolicy")
+	errAdminAuthorizationPluginUnknown = errors.New("app not found")
+	errAdminAuthorizationPluginUnbound = errors.New("app does not declare authorizationPolicy")
 	errAdminAuthorizationUnavailable   = errors.New("dynamic authorization is unavailable")
 )
 
 func (s *Server) ensureAdminDynamicAuthorizationAvailable(w http.ResponseWriter) bool {
 	if s.authorizer == nil || s.authorizationProvider == nil {
 		writeError(w, http.StatusServiceUnavailable, "dynamic authorization requires an authorization provider")
+		return false
+	}
+	if s.authzFragments == nil {
+		writeError(w, http.StatusServiceUnavailable, "dynamic authorization requires indexeddb source state")
 		return false
 	}
 	return true
@@ -711,6 +715,10 @@ func (s *Server) ensureAdminDynamicAdminAvailable(w http.ResponseWriter) bool {
 	}
 	if s.authorizationProvider == nil {
 		writeError(w, http.StatusServiceUnavailable, "dynamic admin authorization requires an authorization provider")
+		return false
+	}
+	if s.authzFragments == nil {
+		writeError(w, http.StatusServiceUnavailable, "dynamic admin authorization requires indexeddb source state")
 		return false
 	}
 	members, ok := s.authorizer.StaticMembersForPolicy(s.adminRoute.AuthorizationPolicy)

--- a/gestaltd/internal/server/handlers_admin_authorization_provider_write.go
+++ b/gestaltd/internal/server/handlers_admin_authorization_provider_write.go
@@ -64,8 +64,52 @@ func (s *Server) deleteProviderPluginAuthorization(ctx context.Context, plugin, 
 	return s.deleteProviderDynamicFragmentMembership(ctx, coredata.AuthorizationAppFragmentOwner(plugin), resource, subjectID, "app_member_delete")
 }
 
-func (s *Server) upsertProviderAdminAuthorization(ctx context.Context, subject *adminAuthorizationWriteSubject, role string) (*providerAdminAuthorizationMembership, error) {
-	if s.authorizationProvider == nil {
+func (s *Server) upsertSourceAppAuthorization(ctx context.Context, subject *adminAuthorizationWriteSubject, app, role string) (*providerPluginAuthorizationMembership, error) {
+	if s.authzFragments == nil {
+		return nil, errAdminAuthorizationUnavailable
+	}
+	if subject == nil || strings.TrimSpace(subject.SubjectID) == "" {
+		return nil, fmt.Errorf("subject is required")
+	}
+	resource := &core.ResourceRef{
+		Type: authorization.ProviderResourceTypeAppDynamic,
+		Id:   strings.TrimSpace(app),
+	}
+	fragmentRel := coredata.AuthorizationDynamicFragmentRelationship{
+		Subject:  coredata.AuthorizationDynamicFragmentSubject{Type: authorization.ProviderSubjectTypeSubject, ID: strings.TrimSpace(subject.SubjectID)},
+		Relation: strings.TrimSpace(role),
+		Resource: coredata.AuthorizationDynamicFragmentResource{Type: resource.GetType(), ID: resource.GetId()},
+	}
+	if _, err := s.upsertAuthorizationDynamicFragmentRelationship(ctx, coredata.AuthorizationAppFragmentOwner(app), fragmentRel, "app_member_upsert"); err != nil {
+		return nil, err
+	}
+	return &providerPluginAuthorizationMembership{
+		App:       app,
+		SubjectID: strings.TrimSpace(subject.SubjectID),
+		Role:      strings.TrimSpace(role),
+	}, nil
+}
+
+func (s *Server) deleteSourceAppAuthorization(ctx context.Context, app, subjectID string) error {
+	if s.authzFragments == nil {
+		return errAdminAuthorizationUnavailable
+	}
+	resource := &core.ResourceRef{
+		Type: authorization.ProviderResourceTypeAppDynamic,
+		Id:   strings.TrimSpace(app),
+	}
+	deleted, _, err := s.deleteDynamicFragmentMembership(ctx, coredata.AuthorizationAppFragmentOwner(app), resource, subjectID, "app_member_delete")
+	if err != nil {
+		return err
+	}
+	if !deleted {
+		return core.ErrNotFound
+	}
+	return nil
+}
+
+func (s *Server) upsertSourceAdminAuthorization(ctx context.Context, subject *adminAuthorizationWriteSubject, role string) (*providerAdminAuthorizationMembership, error) {
+	if s.authzFragments == nil {
 		return nil, errAdminAuthorizationUnavailable
 	}
 	if subject == nil || strings.TrimSpace(subject.SubjectID) == "" {
@@ -80,28 +124,31 @@ func (s *Server) upsertProviderAdminAuthorization(ctx context.Context, subject *
 		Relation: strings.TrimSpace(role),
 		Resource: coredata.AuthorizationDynamicFragmentResource{Type: resource.GetType(), ID: resource.GetId()},
 	}
-	_, _, err := s.replaceProviderDynamicMembership(ctx, resource, subject.SubjectID, strings.TrimSpace(role))
-	if err != nil {
-		return nil, err
-	}
 	if _, err := s.upsertAuthorizationDynamicFragmentRelationship(ctx, coredata.AuthorizationGlobalFragmentOwner(), fragmentRel, "admin_member_upsert"); err != nil {
 		return nil, err
 	}
 	return &providerAdminAuthorizationMembership{
 		SubjectID: strings.TrimSpace(subject.SubjectID),
-		Role:      role,
+		Role:      strings.TrimSpace(role),
 	}, nil
 }
 
-func (s *Server) deleteProviderAdminAuthorization(ctx context.Context, subjectID string) error {
-	if s.authorizationProvider == nil {
+func (s *Server) deleteSourceAdminAuthorization(ctx context.Context, subjectID string) error {
+	if s.authzFragments == nil {
 		return errAdminAuthorizationUnavailable
 	}
 	resource := &core.ResourceRef{
 		Type: authorization.ProviderResourceTypeAdminDynamic,
 		Id:   authorization.ProviderResourceIDAdminDynamicGlobal,
 	}
-	return s.deleteProviderDynamicFragmentMembership(ctx, coredata.AuthorizationGlobalFragmentOwner(), resource, subjectID, "admin_member_delete")
+	deleted, _, err := s.deleteDynamicFragmentMembership(ctx, coredata.AuthorizationGlobalFragmentOwner(), resource, subjectID, "admin_member_delete")
+	if err != nil {
+		return err
+	}
+	if !deleted {
+		return core.ErrNotFound
+	}
+	return nil
 }
 
 func (s *Server) deleteProviderDynamicFragmentMembership(ctx context.Context, owner coredata.AuthorizationFragmentOwner, resource *core.ResourceRef, subjectID, reason string) error {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -2630,9 +2630,9 @@ func newTestAuthorizer(cfg config.AuthorizationConfig, pluginDefs map[string]*co
 	return authorization.New(config.AuthorizationStaticConfig(cfg, pluginDefs))
 }
 
-func mustProviderBackedAuthorizer(t *testing.T, base *authorization.Authorizer, provider *memoryAuthorizationProvider) *authorization.ProviderBackedAuthorizer {
+func mustProviderBackedAuthorizer(t *testing.T, base *authorization.Authorizer, provider *memoryAuthorizationProvider, opts ...authorization.ProviderBackedOption) *authorization.ProviderBackedAuthorizer {
 	t.Helper()
-	authz, err := authorization.NewProviderBacked(base, provider)
+	authz, err := authorization.NewProviderBacked(base, provider, opts...)
 	if err != nil {
 		t.Fatalf("NewProviderBacked: %v", err)
 	}
@@ -2709,6 +2709,9 @@ func seedProviderDynamicAdminMembership(t *testing.T, svc *coredata.Services, au
 		Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeSubject, Id: principal.UserSubjectID(user.ID)},
 		Relation: role,
 		Resource: &core.ResourceRef{Type: authorization.ProviderResourceTypeAdminDynamic, Id: authorization.ProviderResourceIDAdminDynamicGlobal},
+		Target: &core.RelationshipTargetRef{Kind: &proto.RelationshipTarget_Subject{
+			Subject: &core.SubjectRef{Type: authorization.ProviderSubjectTypeSubject, Id: principal.UserSubjectID(user.ID)},
+		}},
 	})
 	if err := authz.ReloadAuthorizationState(context.Background()); err != nil {
 		t.Fatalf("seedProviderDynamicAdminMembership authorization state reload after write: %v", err)
@@ -2731,6 +2734,9 @@ func seedProviderPluginAuthorization(t *testing.T, svc *coredata.Services, authz
 		Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeSubject, Id: principal.UserSubjectID(user.ID)},
 		Relation: role,
 		Resource: &core.ResourceRef{Type: authorization.ProviderResourceTypeAppDynamic, Id: plugin},
+		Target: &core.RelationshipTargetRef{Kind: &proto.RelationshipTarget_Subject{
+			Subject: &core.SubjectRef{Type: authorization.ProviderSubjectTypeSubject, Id: principal.UserSubjectID(user.ID)},
+		}},
 	})
 	if err := authz.ReloadAuthorizationState(context.Background()); err != nil {
 		t.Fatalf("seedProviderPluginAuthorization authorization state reload after write: %v", err)
@@ -5220,7 +5226,7 @@ func TestAdminAPI_PluginAuthorizationCRUD(t *testing.T) {
 		t.Fatalf("authorization.New: %v", err)
 	}
 	provider := newMemoryAuthorizationProvider("memory-authorization")
-	authz := mustProviderBackedAuthorizer(t, baseAuthz, provider)
+	authz := mustProviderBackedAuthorizer(t, baseAuthz, provider, authorization.WithDynamicFragmentSource(svc.AuthzFragments))
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Services = svc
@@ -6066,13 +6072,7 @@ func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 	if err != nil {
 		t.Fatalf("authorization.New: %v", err)
 	}
-	authz, err := authorization.NewProviderBacked(baseAuthz, provider, authorization.WithDynamicFragmentSource(svc.AuthzFragments))
-	if err != nil {
-		t.Fatalf("NewProviderBacked: %v", err)
-	}
-	if err := authz.ReloadAuthorizationState(context.Background()); err != nil {
-		t.Fatalf("ReloadAuthorizationState: %v", err)
-	}
+	authz := mustProviderBackedAuthorizer(t, baseAuthz, provider, authorization.WithDynamicFragmentSource(svc.AuthzFragments))
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{
@@ -6418,7 +6418,7 @@ func TestAdminAPI_AuthorizationProviderDebugRequiresAdminPolicy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("authorization.New: %v", err)
 	}
-	authz := mustProviderBackedAuthorizer(t, baseAuthz, provider)
+	authz := mustProviderBackedAuthorizer(t, baseAuthz, provider, authorization.WithDynamicFragmentSource(svc.AuthzFragments))
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Services = svc
@@ -6470,7 +6470,7 @@ func TestAdminAPI_AdminAuthorizationCRUD(t *testing.T) {
 	}, nil)
 
 	provider := newMemoryAuthorizationProvider("memory-authorization")
-	authz := mustProviderBackedAuthorizer(t, baseAuthz, provider)
+	authz := mustProviderBackedAuthorizer(t, baseAuthz, provider, authorization.WithDynamicFragmentSource(svc.AuthzFragments))
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{
@@ -6686,7 +6686,7 @@ func TestAdminAPI_AdminAuthorizationProviderBackedReads(t *testing.T) {
 		},
 	}, nil)
 
-	authz := mustProviderBackedAuthorizer(t, baseAuthz, provider)
+	authz := mustProviderBackedAuthorizer(t, baseAuthz, provider, authorization.WithDynamicFragmentSource(svc.AuthzFragments))
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{
@@ -6751,7 +6751,7 @@ func TestAdminAPI_AdminAuthorizationProviderBackedReads(t *testing.T) {
 	}
 }
 
-func TestAdminAPI_ProviderBackedWritesUseAuthorizationProvider(t *testing.T) {
+func TestAdminAPI_ProviderBackedWritesUseDynamicFragmentSource(t *testing.T) {
 	t.Parallel()
 
 	t.Run("plugin members", func(t *testing.T) {
@@ -6775,7 +6775,7 @@ func TestAdminAPI_ProviderBackedWritesUseAuthorizationProvider(t *testing.T) {
 		if err != nil {
 			t.Fatalf("authorization.New: %v", err)
 		}
-		authz := mustProviderBackedAuthorizer(t, baseAuthz, provider)
+		authz := mustProviderBackedAuthorizer(t, baseAuthz, provider, authorization.WithDynamicFragmentSource(svc.AuthzFragments))
 
 		ts := newTestServer(t, func(cfg *server.Config) {
 			cfg.Auth = &coretesting.StubAuthProvider{
@@ -6836,7 +6836,7 @@ func TestAdminAPI_ProviderBackedWritesUseAuthorizationProvider(t *testing.T) {
 			},
 		}, nil)
 
-		authz := mustProviderBackedAuthorizer(t, baseAuthz, provider)
+		authz := mustProviderBackedAuthorizer(t, baseAuthz, provider, authorization.WithDynamicFragmentSource(svc.AuthzFragments))
 
 		ts := newTestServer(t, func(cfg *server.Config) {
 			cfg.Auth = &coretesting.StubAuthProvider{
@@ -6897,7 +6897,7 @@ func TestAdminAPI_AdminAuthorizationWriteUsesAllowedAdminRoles(t *testing.T) {
 		},
 	}, nil)
 
-	authz := mustProviderBackedAuthorizer(t, baseAuthz, provider)
+	authz := mustProviderBackedAuthorizer(t, baseAuthz, provider, authorization.WithDynamicFragmentSource(svc.AuthzFragments))
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{
@@ -7163,7 +7163,7 @@ func TestAdminAPI_AdminAuthorizationUnavailable(t *testing.T) {
 
 }
 
-func TestAdminAPI_PluginAuthorizationPutFailureReturnsServerError(t *testing.T) {
+func TestAdminAPI_PluginAuthorizationReloadFailureReturnsAccepted(t *testing.T) {
 	t.Parallel()
 
 	svc := testutil.NewStubServices(t)
@@ -7179,7 +7179,7 @@ func TestAdminAPI_PluginAuthorizationPutFailureReturnsServerError(t *testing.T) 
 	if err != nil {
 		t.Fatalf("authorization.New: %v", err)
 	}
-	authz := mustProviderBackedAuthorizer(t, baseAuthz, provider)
+	authz := mustProviderBackedAuthorizer(t, baseAuthz, provider, authorization.WithDynamicFragmentSource(svc.AuthzFragments))
 	provider.writeErr = fmt.Errorf("provider write failed")
 
 	ts := newTestServer(t, func(cfg *server.Config) {
@@ -7204,13 +7204,20 @@ func TestAdminAPI_PluginAuthorizationPutFailureReturnsServerError(t *testing.T) 
 		t.Fatalf("PUT dynamic member: %v", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusInternalServerError {
+	if resp.StatusCode != http.StatusAccepted {
 		respBody, _ := io.ReadAll(resp.Body)
-		t.Fatalf("put dynamic member status = %d, want 500: %s", resp.StatusCode, respBody)
+		t.Fatalf("put dynamic member status = %d, want 202: %s", resp.StatusCode, respBody)
+	}
+	fragment, err := svc.AuthzFragments.GetFragmentByOwner(context.Background(), coredata.AuthorizationAppFragmentOwner("sample_plugin"))
+	if err != nil {
+		t.Fatalf("GetFragmentByOwner plugin after accepted reload failure: %v", err)
+	}
+	if len(fragment.Relationships) != 1 || fragment.Relationships[0].Subject.ID != principal.UserSubjectID(dynamicUser.ID) {
+		t.Fatalf("plugin fragment relationships = %#v, want persisted source-layer member", fragment.Relationships)
 	}
 }
 
-func TestAdminAPI_AdminAuthorizationPutFailureReturnsServerError(t *testing.T) {
+func TestAdminAPI_AdminAuthorizationReloadFailureReturnsAccepted(t *testing.T) {
 	t.Parallel()
 
 	svc := testutil.NewStubServices(t)
@@ -7227,7 +7234,7 @@ func TestAdminAPI_AdminAuthorizationPutFailureReturnsServerError(t *testing.T) {
 		},
 	}, nil)
 
-	authz := mustProviderBackedAuthorizer(t, baseAuthz, provider)
+	authz := mustProviderBackedAuthorizer(t, baseAuthz, provider, authorization.WithDynamicFragmentSource(svc.AuthzFragments))
 	provider.writeErr = fmt.Errorf("provider write failed")
 
 	ts := newTestServer(t, func(cfg *server.Config) {
@@ -7263,9 +7270,16 @@ func TestAdminAPI_AdminAuthorizationPutFailureReturnsServerError(t *testing.T) {
 		t.Fatalf("PUT admin member: %v", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusInternalServerError {
+	if resp.StatusCode != http.StatusAccepted {
 		respBody, _ := io.ReadAll(resp.Body)
-		t.Fatalf("put admin member status = %d, want 500: %s", resp.StatusCode, respBody)
+		t.Fatalf("put admin member status = %d, want 202: %s", resp.StatusCode, respBody)
+	}
+	fragment, err := svc.AuthzFragments.GetFragmentByOwner(context.Background(), coredata.AuthorizationGlobalFragmentOwner())
+	if err != nil {
+		t.Fatalf("GetFragmentByOwner global after accepted reload failure: %v", err)
+	}
+	if len(fragment.Relationships) != 1 || fragment.Relationships[0].Subject.ID != principal.UserSubjectID(dynamicAdmin.ID) {
+		t.Fatalf("admin fragment relationships = %#v, want persisted source-layer member", fragment.Relationships)
 	}
 }
 

--- a/gestaltd/services/ui/adminui/out/index.html
+++ b/gestaltd/services/ui/adminui/out/index.html
@@ -644,7 +644,7 @@
           Inspect live Prometheus telemetry, manage app-scoped human
           authorization, and maintain built-in Gestalt admins from the same
           protected surface. Static policy members remain authoritative;
-          dynamic grants only extend access where the plugin or admin surface
+          dynamic grants only extend access where the app or admin surface
           already declares an authorization policy.
         </p>
       </section>
@@ -752,7 +752,7 @@
         <section class="card controls animate-fade-in-up" style="animation-delay:80ms">
           <div class="control-cluster">
             <label class="control-group" for="authorization-app-select">
-              <span class="label-text">Plugin</span>
+              <span class="label-text">App</span>
               <select class="control-select" id="authorization-app-select"></select>
             </label>
 
@@ -763,7 +763,7 @@
             Dynamic grants are app-scoped and evaluated only after static
             policy members. Writes accept a user email, resolve it to a
             canonical user subject ID, and are blocked when that subject
-            already has static authorization on the selected plugin.
+            already has static authorization on the selected app.
           </p>
         </section>
 
@@ -781,7 +781,7 @@
           <article class="card summary-card">
             <span class="label-text">Dynamic rows</span>
             <div class="metric-value" id="authorization-dynamic-count">--</div>
-            <p class="metric-note">Persisted plugin grants from the admin API.</p>
+            <p class="metric-note">Persisted app grants from the admin API.</p>
           </article>
           <article class="card summary-card">
             <span class="label-text">Shadowed grants</span>
@@ -796,7 +796,7 @@
             <h2>Add or update a dynamic member</h2>
             <p class="metric-note auth-form-copy">
               Roles are stored as opaque strings and checked against the
-              plugin's existing <code>allowedRoles</code> rules.
+              app's existing <code>allowedRoles</code> rules.
             </p>
 
             <form id="authorization-form" class="auth-form">
@@ -820,7 +820,7 @@
 
           <article class="card panel-card">
             <span class="label-text">Effective access</span>
-            <h2>Plugin members</h2>
+            <h2>App members</h2>
             <div class="member-table-wrap">
               <table class="member-table">
                 <thead>
@@ -1052,7 +1052,7 @@
               : "overview";
         }
 
-        function normalizePluginName(value) {
+        function normalizeAppName(value) {
           return typeof value === "string" ? value.trim() : "";
         }
 
@@ -1101,7 +1101,7 @@
             }
           });
           if (activeTabKey === "authorization" && !authLoaded && !authLoading) {
-            loadAuthorizationPlugins();
+            loadAuthorizationApps();
           }
           if (activeTabKey === "admins" && !adminLoaded && !adminLoading) {
             loadAdminMembers();
@@ -1431,25 +1431,25 @@
           const roleInput = byId("authorization-role-input");
           const submitButton = byId("authorization-submit-button");
           const formNote = byId("authorization-form-note");
-          const pluginSelect = byId("authorization-app-select");
-          const hasPlugin = !!selectedAppName;
-          pluginSelect.disabled = authLoading || authSaving;
-          emailInput.disabled = !hasPlugin || authLoading || authSaving;
-          roleInput.disabled = !hasPlugin || authLoading || authSaving;
+          const appSelect = byId("authorization-app-select");
+          const hasApp = !!selectedAppName;
+          appSelect.disabled = authLoading || authSaving;
+          emailInput.disabled = !hasApp || authLoading || authSaving;
+          roleInput.disabled = !hasApp || authLoading || authSaving;
 
           const email = normalizeEmailInput(emailInput.value);
           const role = String(roleInput.value || "").trim();
-          submitButton.disabled = !hasPlugin || !email || !role || authLoading || authSaving;
+          submitButton.disabled = !hasApp || !email || !role || authLoading || authSaving;
           submitButton.textContent = authSaving ? "Saving..." : "Save dynamic grant";
 
-          if (!hasPlugin) {
+          if (!hasApp) {
             formNote.textContent = "Pick an app with an authorization policy to manage members.";
           } else {
             formNote.textContent = "Enter a user email. The server resolves it to a canonical user subject ID before writing the dynamic grant.";
           }
         }
 
-        function renderAuthorizationPluginSelect() {
+        function renderAuthorizationAppSelect() {
           const select = byId("authorization-app-select");
           select.textContent = "";
           if (authApps.length === 0) {
@@ -1475,7 +1475,7 @@
         }
 
         function renderAuthorization() {
-          renderAuthorizationPluginSelect();
+          renderAuthorizationAppSelect();
           renderAuthorizationSummary();
           renderAuthorizationMembers();
           updateAuthorizationFormState();
@@ -1659,13 +1659,13 @@
           const appName = selectedAppName;
           try {
             const result = await fetchJSON("/admin/api/v1/authorization/apps/" + encodeURIComponent(appName) + "/members");
-            if (requestToken !== authMembersRequestToken || plugin !== selectedAppName) return;
+            if (requestToken !== authMembersRequestToken || appName !== selectedAppName) return;
             authMembers = Array.isArray(result.payload) ? result.payload : [];
-            setAuthStatus("Loaded " + authMembers.length + " rows for " + plugin + ".", "ok");
+            setAuthStatus("Loaded " + authMembers.length + " rows for " + appName + ".", "ok");
           } catch (error) {
-            if (requestToken !== authMembersRequestToken || plugin !== selectedAppName) return;
+            if (requestToken !== authMembersRequestToken || appName !== selectedAppName) return;
             authMembers = [];
-            setAuthStatus(error instanceof Error ? error.message : "Failed to load plugin members.", "error");
+            setAuthStatus(error instanceof Error ? error.message : "Failed to load app members.", "error");
           } finally {
             if (requestToken === authMembersRequestToken) {
               authLoading = false;
@@ -1674,15 +1674,15 @@
           }
         }
 
-        async function loadAuthorizationPlugins() {
+        async function loadAuthorizationApps() {
           authLoading = true;
           renderAuthorization();
           setAuthStatus("Loading authorization apps...", "");
           try {
-            const result = await fetchJSON("/admin/api/v1/authorization/plugins");
+            const result = await fetchJSON("/admin/api/v1/authorization/apps");
             authApps = Array.isArray(result.payload) ? result.payload : [];
             authLoaded = true;
-            renderAuthorizationPluginSelect();
+            renderAuthorizationAppSelect();
             updateURLState();
             if (authApps.length === 0) {
               authMembers = [];
@@ -1742,7 +1742,7 @@
             const target = event.target;
             if (!target || typeof target.value !== "string") return;
             clearAuthPendingReload();
-            selectedAppName = normalizePluginName(target.value);
+            selectedAppName = normalizeAppName(target.value);
             updateURLState();
             loadAuthorizationMembers();
           });
@@ -1750,7 +1750,7 @@
           byId("authorization-refresh-button").addEventListener("click", function () {
             if (authLoading || authSaving) return;
             clearAuthPendingReload();
-            loadAuthorizationPlugins();
+            loadAuthorizationApps();
           });
 
           byId("authorization-email-input").addEventListener("input", updateAuthorizationFormState);


### PR DESCRIPTION
## Description

Routes plugin/admin member compatibility writes through authz_dynamic_fragments and lets gestaltd reconciliation update provider relationships.