### PR TITLE
Default IndexedDB pin to relationaldb v0.0.1-alpha.2

### DIFF
--- a/docs/content/deploy/index.mdx
+++ b/docs/content/deploy/index.mdx
@@ -47,7 +47,7 @@ The lock file is a JSON document that records resolved apps and host-scoped prov
         "package": "github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb",
         "kind": "indexeddb",
         "runtime": "executable",
-        "source": "https://github.com/valon-technologies/gestalt-providers/releases/download/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml",
+        "source": "https://github.com/valon-technologies/gestalt-providers/releases/download/indexeddb/relationaldb/v0.0.1-alpha.2/provider-release.yaml",
         "version": "0.0.1-alpha.1"
       }
     }

--- a/docs/content/providers/indexeddb.mdx
+++ b/docs/content/providers/indexeddb.mdx
@@ -25,13 +25,13 @@ providers:
     main:
       source:
         package: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.1
+        version: 0.0.1-alpha.2
       config:
         dsn: ${SYSTEM_DATABASE_URL}
     workplaceHub:
       source:
         package: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.1
+        version: 0.0.1-alpha.2
       config:
         dsn: ${APP_DATABASE_URL}
 
@@ -544,7 +544,7 @@ providers:
     main:
       source:
         package: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.1
+        version: 0.0.1-alpha.2
       config:
         dsn: ${DATABASE_URL}
 ```
@@ -598,7 +598,7 @@ An IndexedDB provider manifest declares `kind: indexeddb`:
 ```yaml
 kind: indexeddb
 source: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-version: 0.0.1-alpha.1
+version: 0.0.1-alpha.2
 displayName: RelationalDB
 description: IndexedDB provider supporting PostgreSQL, MySQL, SQLite, and SQL Server.
 spec:

--- a/docs/content/reference/built-in-providers.mdx
+++ b/docs/content/reference/built-in-providers.mdx
@@ -54,7 +54,7 @@ providers:
     main:
       source:
         package: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.1
+        version: 0.0.1-alpha.2
       config:
         dsn: ${DATABASE_URL}
 
@@ -85,7 +85,7 @@ providers:
     main:
       source:
         package: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.1
+        version: 0.0.1-alpha.2
       config:
         dsn: ${DATABASE_URL}
 ```
@@ -138,7 +138,7 @@ providers:
     workflow_state:
       source:
         package: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.1
+        version: 0.0.1-alpha.2
       config:
         dsn: ${DATABASE_URL}
 

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -479,7 +479,7 @@ providers:
     main:
       source:
         package: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.1
+        version: 0.0.1-alpha.2
       config:
         dsn: ${DATABASE_URL}
 ```
@@ -514,7 +514,7 @@ providers:
     main:
       source:
         package: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.1
+        version: 0.0.1-alpha.2
       config:
         dsn: ${DATABASE_URL}
 
@@ -567,7 +567,7 @@ providers:
     workflow_state:
       source:
         package: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.1
+        version: 0.0.1-alpha.2
       config:
         dsn: ${DATABASE_URL}
 

--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -69,7 +69,7 @@ server:
 providers:
   indexeddb:
     main:
-      source: https://github.com/valon-technologies/gestalt-providers/releases/download/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
+      source: https://github.com/valon-technologies/gestalt-providers/releases/download/indexeddb/relationaldb/v0.0.1-alpha.2/provider-release.yaml
       config:
         dsn: sqlite:///data/gestalt.db
 

--- a/gestaltd/deploy/helm/gestaltd/values.yaml
+++ b/gestaltd/deploy/helm/gestaltd/values.yaml
@@ -106,7 +106,7 @@ config:
       main:
         # SQLite is appropriate for local development or single-instance
         # deployments with mounted persistent storage at /data.
-        source: https://github.com/valon-technologies/gestalt-providers/releases/download/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
+        source: https://github.com/valon-technologies/gestalt-providers/releases/download/indexeddb/relationaldb/v0.0.1-alpha.2/provider-release.yaml
         config:
           dsn: "sqlite:///data/gestalt.db"
     # Add providers.ui.<name> entries when you want to mount public static UI bundles.

--- a/gestaltd/internal/bootstrap/agent_runtime_test.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_test.go
@@ -60,7 +60,7 @@ func testHostedAgentRuntimeConfig() *config.RuntimePlacementConfig {
 func testAgentRuntimeIndexedDBDefs() map[string]*config.ProviderEntry {
 	return map[string]*config.ProviderEntry{
 		"agent_state": {
-			Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml"),
+			Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.2/provider-release.yaml"),
 		},
 	}
 }

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -1667,7 +1667,7 @@ func validConfig() *config.Config {
 				"default": {Source: config.ProviderSource{Builtin: "test-telemetry"}},
 			},
 			IndexedDB: map[string]*config.ProviderEntry{
-				"test": {Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml")},
+				"test": {Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.2/provider-release.yaml")},
 			},
 		},
 		Server: config.ServerConfig{
@@ -4192,7 +4192,7 @@ func TestBootstrapPassesIndexedDBHostSocketToWorkflowProviders(t *testing.T) {
 
 	cfg := validConfig()
 	cfg.Providers.IndexedDB["workflow_state"] = &config.ProviderEntry{
-		Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml"),
+		Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.2/provider-release.yaml"),
 	}
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"basic": {
@@ -4246,7 +4246,7 @@ func TestBootstrapPassesIndexedDBHostSocketToAgentProviders(t *testing.T) {
 
 	cfg := validConfig()
 	cfg.Providers.IndexedDB["agent_state"] = &config.ProviderEntry{
-		Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml"),
+		Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.2/provider-release.yaml"),
 		Config: mustYAMLNode(t, map[string]any{
 			"dsn": map[string]any{
 				"secret": map[string]any{
@@ -4385,7 +4385,7 @@ func TestBootstrapClosesWorkflowIndexedDBAndAppliesScopedConfig(t *testing.T) {
 
 	cfg := validConfig()
 	cfg.Providers.IndexedDB["workflow_state"] = &config.ProviderEntry{
-		Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml"),
+		Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.2/provider-release.yaml"),
 		Config: mustYAMLNode(t, map[string]any{
 			"dsn":          "sqlite://workflow.db",
 			"table_prefix": "host_",
@@ -4523,7 +4523,7 @@ func TestBootstrapRoutesWorkflowIndexedDBHostServices(t *testing.T) {
 
 	cfg := validConfig()
 	cfg.Providers.IndexedDB["workflow_state"] = &config.ProviderEntry{
-		Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml"),
+		Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.2/provider-release.yaml"),
 		Config: mustYAMLNode(t, map[string]any{"bucket": "workflow-state"}),
 	}
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{

--- a/gestaltd/internal/bootstrap/executable_app_test.go
+++ b/gestaltd/internal/bootstrap/executable_app_test.go
@@ -3784,11 +3784,11 @@ func TestPluginIndexedDBExposeHostSocketEnv(t *testing.T) {
 
 	indexedDBDefs := map[string]*config.ProviderEntry{
 		"main": {
-			Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml"),
+			Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.2/provider-release.yaml"),
 			Config: mustNode(t, map[string]any{"dsn": "postgres://main.example.test/gestalt"}),
 		},
 		"archive": {
-			Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml"),
+			Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.2/provider-release.yaml"),
 			Config: mustNode(t, map[string]any{"dsn": "sqlite://archive.db"}),
 		},
 	}
@@ -6598,7 +6598,7 @@ func TestRuntimeConfigUsesPublicIndexedDBRelayWithoutHostServiceTunnelCapability
 		SelectedIndexedDBName: "memory",
 		IndexedDBDefs: map[string]*config.ProviderEntry{
 			"memory": {
-				Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml"),
+				Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.2/provider-release.yaml"),
 				Config: mustNode(t, map[string]any{"bucket": "plugin-state"}),
 			},
 		},
@@ -6717,7 +6717,7 @@ func TestRuntimePublicIndexedDBRelayRoundTripsThroughHostedApp(t *testing.T) {
 		SelectedIndexedDBName: "memory",
 		IndexedDBDefs: map[string]*config.ProviderEntry{
 			"memory": {
-				Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml"),
+				Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.2/provider-release.yaml"),
 				Config: mustNode(t, map[string]any{"bucket": "plugin-state"}),
 			},
 		},
@@ -8639,7 +8639,7 @@ func TestPluginIndexedDBInheritsHostSelectionAndDefaultDBName(t *testing.T) {
 					SelectedIndexedDBName: "memory",
 					IndexedDBDefs: map[string]*config.ProviderEntry{
 						"memory": {
-							Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml"),
+							Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.2/provider-release.yaml"),
 							Config: mustNode(t, map[string]any{"bucket": "plugin-state"}),
 						},
 					},
@@ -8735,14 +8735,14 @@ func TestPluginIndexedDBBuildScopedConfig(t *testing.T) {
 
 	indexedDBDefs := map[string]*config.ProviderEntry{
 		"postgres": {
-			Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml"),
+			Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.2/provider-release.yaml"),
 			Config: mustNode(t, map[string]any{
 				"dsn":    "postgres://db.example.test/gestalt",
 				"schema": "host_schema",
 			}),
 		},
 		"sqlite": {
-			Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml"),
+			Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.2/provider-release.yaml"),
 			Config: mustNode(t, map[string]any{
 				"dsn":          "sqlite://plugin-state.db",
 				"table_prefix": "host_",
@@ -8758,7 +8758,7 @@ func TestPluginIndexedDBBuildScopedConfig(t *testing.T) {
 			}),
 		},
 		"mysql-secret": {
-			Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml"),
+			Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.2/provider-release.yaml"),
 			Config: mustNode(t, map[string]any{
 				"dsn": map[string]any{
 					"secret": map[string]any{
@@ -8929,7 +8929,7 @@ func TestPluginIndexedDBRouteObjectStores(t *testing.T) {
 				SelectedIndexedDBName: "memory",
 				IndexedDBDefs: map[string]*config.ProviderEntry{
 					"memory": {
-						Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml"),
+						Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.2/provider-release.yaml"),
 						Config: mustNode(t, map[string]any{"bucket": "plugin-state"}),
 					},
 				},
@@ -9057,11 +9057,11 @@ func TestPluginIndexedDBProviderOverrideUsesExplicitIndexedDB(t *testing.T) {
 		SelectedIndexedDBName: "main",
 		IndexedDBDefs: map[string]*config.ProviderEntry{
 			"main": {
-				Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml"),
+				Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.2/provider-release.yaml"),
 				Config: mustNode(t, map[string]any{"bucket": "main"}),
 			},
 			"archive": {
-				Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml"),
+				Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.2/provider-release.yaml"),
 				Config: mustNode(t, map[string]any{"bucket": "archive"}),
 			},
 		},
@@ -9142,7 +9142,7 @@ func TestPluginIndexedDBBindingsCleanupOnS3BindingFailure(t *testing.T) {
 		SelectedIndexedDBName: "main",
 		IndexedDBDefs: map[string]*config.ProviderEntry{
 			"main": {
-				Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml"),
+				Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.2/provider-release.yaml"),
 				Config: mustNode(t, map[string]any{"bucket": "main"}),
 			},
 		},

--- a/gestaltd/internal/bootstrap/host_service_tls_env_test.go
+++ b/gestaltd/internal/bootstrap/host_service_tls_env_test.go
@@ -52,7 +52,7 @@ func TestPrepareCoreLoadsHostServiceTLSCAFileForHostedRuntimeEnv(t *testing.T) {
 				"default": {Source: config.ProviderSource{Builtin: "noop"}},
 			},
 			IndexedDB: map[string]*config.ProviderEntry{
-				"main": {Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml")},
+				"main": {Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.2/provider-release.yaml")},
 			},
 		},
 		Server: config.ServerConfig{

--- a/gestaltd/internal/bootstrap/workflow_startup_test.go
+++ b/gestaltd/internal/bootstrap/workflow_startup_test.go
@@ -145,7 +145,7 @@ func TestBuildWorkflowRegistersIndexedDBPublicRelay(t *testing.T) {
 		EncryptionKey: []byte("0123456789abcdef0123456789abcdef"),
 		IndexedDBDefs: map[string]*config.ProviderEntry{
 			"main": {
-				Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml"),
+				Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.2/provider-release.yaml"),
 				Config: mustNode(t, map[string]any{"bucket": "workflow-state"}),
 			},
 		},

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -35,7 +35,7 @@ const (
 	DefaultProviderRepo = "github.com/valon-technologies/gestalt-providers"
 
 	DefaultIndexedDBProvider           = DefaultProviderRepo + "/indexeddb/relationaldb"
-	DefaultIndexedDBVersion            = "0.0.1-alpha.1"
+	DefaultIndexedDBVersion            = "0.0.1-alpha.2"
 	DefaultExternalCredentialsProvider = DefaultProviderRepo + "/externalcredentials/default"
 	DefaultExternalCredentialsVersion  = "0.0.1-alpha.1"
 	DefaultUIProvider                  = DefaultProviderRepo + "/ui/default"

--- a/gestaltd/internal/testutil/testdata/provider-go/config.yaml
+++ b/gestaltd/internal/testutil/testdata/provider-go/config.yaml
@@ -7,7 +7,7 @@ server:
 providers:
   indexeddb:
     main:
-      source: https://github.com/valon-technologies/gestalt-providers/releases/download/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
+      source: https://github.com/valon-technologies/gestalt-providers/releases/download/indexeddb/relationaldb/v0.0.1-alpha.2/provider-release.yaml
       config:
         dsn: sqlite://./example.db
 

--- a/gestaltd/internal/testutil/testdata/provider-rust/config.yaml
+++ b/gestaltd/internal/testutil/testdata/provider-rust/config.yaml
@@ -7,7 +7,7 @@ server:
 providers:
   indexeddb:
     main:
-      source: https://github.com/valon-technologies/gestalt-providers/releases/download/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
+      source: https://github.com/valon-technologies/gestalt-providers/releases/download/indexeddb/relationaldb/v0.0.1-alpha.2/provider-release.yaml
       config:
         dsn: sqlite://./example.db
 


### PR DESCRIPTION
## Summary

- Default IndexedDB metadata pin moves to published relationaldb `v0.0.1-alpha.2` (`GESTALT_PROVIDER_SOCKET`-compatible).
- Fixes `gestaltd serve --path` and local dev bootstrap failing with `GESTALT_PLUGIN_SOCKET is required` when using gestaltd 0.0.2-alpha.5+.

## Interfaces

- `DefaultIndexedDBVersion = "0.0.1-alpha.2"`
- Default URL: `https://github.com/valon-technologies/gestalt-providers/releases/download/indexeddb/relationaldb/v0.0.1-alpha.2/provider-release.yaml`

## Runtime

- `serve --path` and auto-generated `~/.gestaltd/config.yaml` fetch alpha.2 when `GESTALT_PROVIDERS_DIR` is unset.
- Requires gestalt-providers release `indexeddb/relationaldb/v0.0.1-alpha.2`.

## Test plan

- [x] `go test ./internal/config/... ./internal/operator/... ./internal/bootstrap/...`


Made with [Cursor](https://cursor.com)