### PR TITLE
[authorization] omit mounted ui path from apps response

### DIFF
--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -216,7 +216,7 @@ For the conceptual model and setup flow, see
 | `GET` | `/admin/api/v1/authorization/provider` | Inspect the configured authorization provider, capabilities, and active model. |
 | `GET` | `/admin/api/v1/authorization/models` | List authorization provider models. Supports `pageSize` and `pageToken`. |
 | `GET` | `/admin/api/v1/authorization/relationships` | List authorization provider relationships for debugging. Supports `modelId`, subject, relation, resource, `pageSize`, and `pageToken` filters. |
-| `GET` | `/admin/api/v1/authorization/apps` | List apps that declare `authorizationPolicy`, including the bound policy name and mounted UI path when present. |
+| `GET` | `/admin/api/v1/authorization/apps` | List apps that declare `authorizationPolicy`, including the bound policy name. |
 | `GET` | `/admin/api/v1/authorization/apps/{app}/members` | List merged static and dynamic subject membership rows for one app. Rows include `source`, `effective`, `mutable`, and selector metadata. |
 | `PUT` | `/admin/api/v1/authorization/apps/{app}/members` | Upsert one dynamic subject membership row for a app by canonical `subjectId` or by user-only `email` alias and role. Rejects subjects who already have static authorization on that app. |
 | `DELETE` | `/admin/api/v1/authorization/apps/{app}/members/{subjectID}` | Remove one dynamic subject membership row for a app. Static rows are read-only and cannot be deleted through the API. |

--- a/gestaltd/internal/server/handlers_admin_authorization.go
+++ b/gestaltd/internal/server/handlers_admin_authorization.go
@@ -23,7 +23,6 @@ import (
 type adminAuthorizationPluginInfo struct {
 	Name                string `json:"name"`
 	AuthorizationPolicy string `json:"authorizationPolicy"`
-	MountedUIPath       string `json:"mountedUiPath,omitempty"`
 }
 
 type adminAuthorizationMemberRow struct {
@@ -214,7 +213,6 @@ func (s *Server) listAdminAuthorizationPlugins(w http.ResponseWriter, r *http.Re
 		out = append(out, adminAuthorizationPluginInfo{
 			Name:                name,
 			AuthorizationPolicy: strings.TrimSpace(entry.AuthorizationPolicy),
-			MountedUIPath:       strings.TrimSpace(entry.MountPath),
 		})
 	}
 	writeJSON(w, http.StatusOK, out)

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -5243,6 +5243,22 @@ func TestAdminAPI_PluginAuthorizationCRUD(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("plugins status = %d, want 200", resp.StatusCode)
 	}
+	var apps []map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&apps); err != nil {
+		t.Fatalf("decode apps: %v", err)
+	}
+	if len(apps) != 1 {
+		t.Fatalf("apps len = %d, want 1", len(apps))
+	}
+	if apps[0]["name"] != "sample_plugin" {
+		t.Fatalf("app name = %v, want sample_plugin", apps[0]["name"])
+	}
+	if apps[0]["authorizationPolicy"] != "sample_policy" {
+		t.Fatalf("app authorizationPolicy = %v, want sample_policy", apps[0]["authorizationPolicy"])
+	}
+	if _, ok := apps[0]["mountedUiPath"]; ok {
+		t.Fatalf("apps response unexpectedly included mountedUiPath: %#v", apps[0])
+	}
 
 	dynamicEmail := "dynamic@example.test"
 	body := bytes.NewBufferString(fmt.Sprintf(`{"email":%q,"role":"viewer"}`, dynamicEmail))


### PR DESCRIPTION
## Description

Removes mountedUiPath from the authorization apps endpoint response and updates the HTTP API docs.