### PR TITLE
[authorization] remove mutable from admin member rows

### DIFF
--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -217,7 +217,7 @@ For the conceptual model and setup flow, see
 | `GET` | `/admin/api/v1/authorization/models` | List authorization provider models. Supports `pageSize` and `pageToken`. |
 | `GET` | `/admin/api/v1/authorization/relationships` | List authorization provider relationships for debugging. Supports `modelId`, subject, relation, resource, `pageSize`, and `pageToken` filters. |
 | `GET` | `/admin/api/v1/authorization/apps` | List apps that declare `authorizationPolicy`, including the bound policy name. |
-| `GET` | `/admin/api/v1/authorization/apps/{app}/members` | List merged static and dynamic subject membership rows for one app. Rows include `source`, `effective`, `mutable`, and selector metadata. |
+| `GET` | `/admin/api/v1/authorization/apps/{app}/members` | List merged static and dynamic subject membership rows for one app. Rows include `source`, `effective`, and selector metadata. |
 | `PUT` | `/admin/api/v1/authorization/apps/{app}/members` | Upsert one dynamic subject membership row for a app by canonical `subjectId` or by user-only `email` alias and role. Rejects subjects who already have static authorization on that app. |
 | `DELETE` | `/admin/api/v1/authorization/apps/{app}/members/{subjectID}` | Remove one dynamic subject membership row for a app. Static rows are read-only and cannot be deleted through the API. |
 | `GET` | `/admin/api/v1/authorization/admins/members` | List merged static and dynamic built-in admin membership rows. |

--- a/gestalt/cli/src/commands/authorization.rs
+++ b/gestalt/cli/src/commands/authorization.rs
@@ -544,7 +544,7 @@ pub fn list_app_members(client: &ApiClient, app: &str, format: Format) -> Result
     print_array_response(
         &resp,
         format,
-        &["Subject", "Role", "Source", "Effective", "Mutable"],
+        &["Subject", "Role", "Source", "Effective"],
         admin_member_row,
     )
 }
@@ -595,7 +595,7 @@ pub fn list_admin_members(client: &ApiClient, format: Format) -> Result<()> {
     print_array_response(
         &resp,
         format,
-        &["Subject", "Role", "Source", "Effective", "Mutable"],
+        &["Subject", "Role", "Source", "Effective"],
         admin_member_row,
     )
 }
@@ -956,7 +956,7 @@ fn print_admin_write_response(resp: &Value, format: Format) -> Result<()> {
                 print_single_response(
                     membership,
                     Format::Table,
-                    &["Subject", "Role", "Source", "Effective", "Mutable"],
+                    &["Subject", "Role", "Source", "Effective"],
                     admin_member_row,
                 )?;
             } else {
@@ -1124,7 +1124,6 @@ fn admin_member_row(item: &Value) -> Vec<String> {
         string_cell(item, "role"),
         string_cell(item, "source"),
         bool_cell(item, "effective"),
-        bool_cell(item, "mutable"),
     ]
 }
 

--- a/gestalt/cli/tests/authorization_cli.rs
+++ b/gestalt/cli/tests/authorization_cli.rs
@@ -263,7 +263,7 @@ fn test_cli_authorization_apps_members_set_uses_management_api() {
         r#"{"role":"triage","subjectId":"service_account:release-bot"}"#.to_string(),
     ))
     .with_body(
-        r#"{"status":"ok","persisted":true,"reloaded":true,"membership":{"role":"triage","source":"dynamic","effective":true,"mutable":true,"selectorKind":"subject_id","selectorValue":"service_account:release-bot"}}"#,
+        r#"{"status":"ok","persisted":true,"reloaded":true,"membership":{"role":"triage","source":"dynamic","effective":true,"selectorKind":"subject_id","selectorValue":"service_account:release-bot"}}"#,
     )
     .create();
 

--- a/gestaltd/internal/server/handlers_admin_authorization.go
+++ b/gestaltd/internal/server/handlers_admin_authorization.go
@@ -30,7 +30,6 @@ type adminAuthorizationMemberRow struct {
 	Role          string `json:"role"`
 	Source        string `json:"source"`
 	Effective     bool   `json:"effective"`
-	Mutable       bool   `json:"mutable"`
 	SelectorKind  string `json:"selectorKind"`
 	SelectorValue string `json:"selectorValue"`
 	Email         string `json:"email,omitempty"`
@@ -276,7 +275,6 @@ func (s *Server) putAdminAuthorizationPluginMember(w http.ResponseWriter, r *htt
 		Role:          membership.Role,
 		Source:        "dynamic",
 		Effective:     true,
-		Mutable:       true,
 		SelectorKind:  "subject_id",
 		SelectorValue: strings.TrimSpace(membership.SubjectID),
 		Email:         adminAuthorizationSubjectEmail(subject),
@@ -395,7 +393,6 @@ func (s *Server) putAdminAuthorizationAdminMember(w http.ResponseWriter, r *http
 		Role:          membership.Role,
 		Source:        "dynamic",
 		Effective:     true,
-		Mutable:       true,
 		SelectorKind:  "subject_id",
 		SelectorValue: strings.TrimSpace(membership.SubjectID),
 		Email:         adminAuthorizationSubjectEmail(subject),
@@ -536,7 +533,6 @@ func (s *Server) adminAuthorizationRowsFromStaticMembers(ctx context.Context, ap
 			Role:          member.Role,
 			Source:        "static",
 			Effective:     true,
-			Mutable:       false,
 			SelectorKind:  "subject_id",
 			SelectorValue: member.SubjectID,
 			Email:         s.adminAuthorizationEmailForSubjectID(ctx, member.SubjectID),

--- a/gestaltd/internal/server/handlers_admin_authorization_provider.go
+++ b/gestaltd/internal/server/handlers_admin_authorization_provider.go
@@ -223,7 +223,6 @@ func (s *Server) adminAuthorizationDynamicRowFromProviderRelationship(ctx contex
 		Role:      strings.TrimSpace(rel.GetRelation()),
 		Source:    "dynamic",
 		Effective: true,
-		Mutable:   true,
 	}
 	if row.Role == "" {
 		return adminAuthorizationMemberRow{}, false, nil

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -5357,6 +5357,9 @@ func TestAdminAPI_PluginAuthorizationCRUD(t *testing.T) {
 	foundDynamicPluginMember := false
 	foundDynamicServiceAccountMember := false
 	for _, member := range members {
+		if _, ok := member["mutable"]; ok {
+			t.Fatalf("member unexpectedly included mutable: %+v", member)
+		}
 		if member["source"] != "dynamic" {
 			continue
 		}

--- a/gestaltd/services/ui/adminui/out/index.html
+++ b/gestaltd/services/ui/adminui/out/index.html
@@ -1378,15 +1378,16 @@
           authMembers.forEach(function (row) {
             const tr = document.createElement("tr");
             const sourceClass = row.source === "static" ? "source-static" : "source-dynamic";
+            const rowMutable = row.source === "dynamic";
             const stateClass = row.effective ? "state-effective" : "state-shadowed";
             const stateLabel = row.effective ? "Effective" : "Shadowed";
-            const mutableLabel = row.mutable ? "Mutable" : "Locked";
+            const mutableLabel = rowMutable ? "Mutable" : "Locked";
             const subjectID = rowSubjectID(row);
-            const actionDisabled = !row.mutable || !subjectID || authDeletingSubjectID === subjectID;
+            const actionDisabled = !rowMutable || !subjectID || authDeletingSubjectID === subjectID;
             tr.innerHTML =
               '<td><div class="principal-value"></div><div class="principal-meta"></div></td>' +
               '<td><code></code></td>' +
-              '<td><div class="pill-row"><span class="pill ' + sourceClass + '"></span><span class="pill ' + (row.mutable ? "" : "locked") + '"></span></div></td>' +
+              '<td><div class="pill-row"><span class="pill ' + sourceClass + '"></span><span class="pill ' + (rowMutable ? "" : "locked") + '"></span></div></td>' +
               '<td><div class="pill-row"><span class="pill ' + stateClass + '"></span></div><div class="principal-meta state-copy"></div></td>' +
               '<td><button class="danger-btn" type="button">Remove</button></td>';
             tr.querySelector(".principal-value").textContent = principalLabel(row);
@@ -1403,10 +1404,10 @@
             if (actionDisabled) {
               button.disabled = true;
             }
-            if (row.mutable && subjectID) {
+            if (rowMutable && subjectID) {
               button.dataset.subjectId = subjectID;
             }
-            if (!row.mutable) {
+            if (!rowMutable) {
               button.textContent = "Static";
             } else if (authDeletingSubjectID === subjectID) {
               button.textContent = "Removing...";
@@ -1554,12 +1555,13 @@
           adminMembers.forEach(function (row) {
             const tr = document.createElement("tr");
             const sourceClass = row.source === "static" ? "source-static" : "source-dynamic";
+            const rowMutable = row.source === "dynamic";
             const stateClass = row.effective ? "state-effective" : "state-shadowed";
             const stateLabel = row.effective ? "Effective" : "Shadowed";
-            const mutableLabel = row.mutable ? "Mutable" : "Locked";
+            const mutableLabel = rowMutable ? "Mutable" : "Locked";
             const subjectID = rowSubjectID(row);
             const actionDisabled =
-              !row.mutable ||
+              !rowMutable ||
               !subjectID ||
               adminDeletingSubjectID === subjectID ||
               !adminCanWrite ||
@@ -1568,7 +1570,7 @@
             tr.innerHTML =
               '<td><div class="principal-value"></div><div class="principal-meta"></div></td>' +
               '<td><code></code></td>' +
-              '<td><div class="pill-row"><span class="pill ' + sourceClass + '"></span><span class="pill ' + (row.mutable ? "" : "locked") + '"></span></div></td>' +
+              '<td><div class="pill-row"><span class="pill ' + sourceClass + '"></span><span class="pill ' + (rowMutable ? "" : "locked") + '"></span></div></td>' +
               '<td><div class="pill-row"><span class="pill ' + stateClass + '"></span></div><div class="principal-meta state-copy"></div></td>' +
               '<td><button class="danger-btn" type="button">Remove</button></td>';
             tr.querySelector(".principal-value").textContent = principalLabel(row);
@@ -1585,10 +1587,10 @@
             if (actionDisabled) {
               button.disabled = true;
             }
-            if (row.mutable && subjectID) {
+            if (rowMutable && subjectID) {
               button.dataset.subjectId = subjectID;
             }
-            if (!row.mutable) {
+            if (!rowMutable) {
               button.textContent = "Static";
             } else if (adminDeletingSubjectID === subjectID) {
               button.textContent = "Removing...";


### PR DESCRIPTION
## Description

Removes the mutable field from admin authorization member responses and updates the admin UI/CLI to derive mutability from dynamic source rows.