### PR TITLE
Type authorization SDK surfaces

### DIFF
--- a/sdk/python/gestalt/__init__.py
+++ b/sdk/python/gestalt/__init__.py
@@ -161,6 +161,56 @@ _AUTHENTICATION_AUTHORED_EXPORTS = (
     "CompleteLoginRequest",
 )
 
+_PROTOCOL_TYPE_EXPORTS = (
+    "JsonObject",
+    "JsonValue",
+)
+
+_AUTHORIZATION_AUTHORED_EXPORTS = (
+    "AccessDecision",
+    "AccessEvaluationRequest",
+    "AccessEvaluationsRequest",
+    "AccessEvaluationsResponse",
+    "ActionSearchRequest",
+    "ActionSearchResponse",
+    "AuthorizationAction",
+    "AuthorizationMetadata",
+    "AuthorizationModel",
+    "AuthorizationModelAction",
+    "AuthorizationModelAllowedTarget",
+    "AuthorizationModelComputedUserset",
+    "AuthorizationModelRef",
+    "AuthorizationModelRelation",
+    "AuthorizationModelResourceType",
+    "AuthorizationModelRewrite",
+    "AuthorizationModelRewriteThis",
+    "AuthorizationModelRewriteUnion",
+    "AuthorizationModelSubjectSetTarget",
+    "AuthorizationModelTupleToUserset",
+    "AuthorizationRelationshipTarget",
+    "AuthorizationResource",
+    "AuthorizationSubject",
+    "AuthorizationSubjectSet",
+    "EffectiveSubjectSearchRequest",
+    "EffectiveSubjectSearchResponse",
+    "ExpandNode",
+    "ExpandRequest",
+    "ExpandResponse",
+    "GetActiveModelResponse",
+    "ListModelsRequest",
+    "ListModelsResponse",
+    "ReadRelationshipsRequest",
+    "ReadRelationshipsResponse",
+    "Relationship",
+    "RelationshipKey",
+    "ResourceSearchRequest",
+    "ResourceSearchResponse",
+    "SubjectSearchRequest",
+    "SubjectSearchResponse",
+    "WriteModelRequest",
+    "WriteRelationshipsRequest",
+)
+
 _AUTHORIZATION_HELPER_EXPORTS = ("AUTHORIZATION_SUBJECT_TYPE_SUBJECT",)
 
 _RUNTIME_PROVIDER_AUTHORED_EXPORTS = (
@@ -457,6 +507,10 @@ _LAZY_EXPORTS.update({name: ("._agent", name) for name in _AGENT_HELPER_EXPORTS}
 _LAZY_EXPORTS.update(
     {name: ("._authentication", name) for name in _AUTHENTICATION_AUTHORED_EXPORTS}
 )
+_LAZY_EXPORTS.update({name: ("._protocol", name) for name in _PROTOCOL_TYPE_EXPORTS})
+_LAZY_EXPORTS.update(
+    {name: ("._authorization", name) for name in _AUTHORIZATION_AUTHORED_EXPORTS}
+)
 _LAZY_EXPORTS.update(
     {name: ("._authorization", name) for name in _AUTHORIZATION_HELPER_EXPORTS}
 )
@@ -495,6 +549,8 @@ __all__ = [
     *_AGENT_PROTOCOL_EXPORTS,
     *_AGENT_HELPER_EXPORTS,
     *_AUTHENTICATION_AUTHORED_EXPORTS,
+    *_PROTOCOL_TYPE_EXPORTS,
+    *_AUTHORIZATION_AUTHORED_EXPORTS,
     *_AUTHORIZATION_HELPER_EXPORTS,
     *_RUNTIME_PROVIDER_AUTHORED_EXPORTS,
     *_WORKFLOW_AUTHORED_EXPORTS,

--- a/sdk/python/gestalt/_api.py
+++ b/sdk/python/gestalt/_api.py
@@ -7,6 +7,8 @@ from dataclasses import MISSING
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, Final, Generic, TypeVar
 
+from ._protocol import JsonObject
+
 if TYPE_CHECKING:
     from typing_extensions import dataclass_transform
 else:
@@ -93,7 +95,7 @@ class Request:
     invocation_token: str = ""
     # Workflow callback metadata uses a JSON-style lowerCamelCase object such
     # as runId, target.steps, trigger.scheduleId, and trigger.event.specVersion.
-    workflow: dict[str, Any] = dataclasses.field(default_factory=dict)
+    workflow: JsonObject = dataclasses.field(default_factory=dict)
     tool_refs: list[AgentToolRef] = dataclasses.field(default_factory=list)
     tool_refs_set: bool = False
     idempotency_key: str = ""

--- a/sdk/python/gestalt/_authorization.py
+++ b/sdk/python/gestalt/_authorization.py
@@ -23,6 +23,7 @@ from ._grpc_transport import (
     internal_channel_target,
     secure_internal_channel,
 )
+from ._protocol import JsonObject
 from ._protocol import dataclass_mapping as _dataclass_mapping
 
 empty_pb2: Any = _empty_pb2
@@ -44,106 +45,114 @@ _shared_authorization_lock = threading.Lock()
 class AuthorizationSubject:
     type: str = ""
     id: str = ""
-    properties: Mapping[str, Any] | None = None
+    properties: JsonObject | None = None
 
 
 @_dataclasses.dataclass(slots=True)
 class AuthorizationResource:
     type: str = ""
     id: str = ""
-    properties: Mapping[str, Any] | None = None
+    properties: JsonObject | None = None
 
 
 @_dataclasses.dataclass(slots=True)
 class AuthorizationSubjectSet:
-    resource: Any | None = None
+    resource: AuthorizationResource | None = None
     relation: str = ""
 
 
 @_dataclasses.dataclass(slots=True)
 class AuthorizationRelationshipTarget:
-    subject: Any | None = None
-    resource: Any | None = None
-    subject_set: Any | None = None
+    subject: AuthorizationSubject | None = None
+    resource: AuthorizationResource | None = None
+    subject_set: AuthorizationSubjectSet | None = None
 
 
 @_dataclasses.dataclass(slots=True)
 class AuthorizationAction:
     name: str = ""
-    properties: Mapping[str, Any] | None = None
+    properties: JsonObject | None = None
 
 
 @_dataclasses.dataclass(slots=True)
 class AccessEvaluationRequest:
-    subject: Any | None = None
-    action: Any | None = None
-    resource: Any | None = None
-    context: Mapping[str, Any] | None = None
+    subject: AuthorizationSubject | None = None
+    action: AuthorizationAction | None = None
+    resource: AuthorizationResource | None = None
+    context: JsonObject | None = None
 
 
 @_dataclasses.dataclass(slots=True)
 class AccessDecision:
     allowed: bool = False
-    context: Mapping[str, Any] | None = None
+    context: JsonObject | None = None
     model_id: str = ""
 
 
 @_dataclasses.dataclass(slots=True)
 class AccessEvaluationsRequest:
-    requests: Sequence[Any] | None = None
+    requests: Sequence[AccessEvaluationRequest] = _dataclasses.field(
+        default_factory=tuple
+    )
 
 
 @_dataclasses.dataclass(slots=True)
 class AccessEvaluationsResponse:
-    decisions: Sequence[Any] | None = None
+    decisions: Sequence[AccessDecision] = _dataclasses.field(default_factory=tuple)
 
 
 @_dataclasses.dataclass(slots=True)
 class ResourceSearchRequest:
-    subject: Any | None = None
-    action: Any | None = None
+    subject: AuthorizationSubject | None = None
+    action: AuthorizationAction | None = None
     resource_type: str = ""
-    context: Mapping[str, Any] | None = None
+    context: JsonObject | None = None
     page_size: int = 0
     page_token: str = ""
 
 
 @_dataclasses.dataclass(slots=True)
 class ResourceSearchResponse:
-    resources: Sequence[Any] | None = None
+    resources: Sequence[AuthorizationResource] = _dataclasses.field(
+        default_factory=tuple
+    )
     next_page_token: str = ""
     model_id: str = ""
 
 
 @_dataclasses.dataclass(slots=True)
 class SubjectSearchRequest:
-    resource: Any | None = None
-    action: Any | None = None
+    resource: AuthorizationResource | None = None
+    action: AuthorizationAction | None = None
     subject_type: str = ""
-    context: Mapping[str, Any] | None = None
+    context: JsonObject | None = None
     page_size: int = 0
     page_token: str = ""
 
 
 @_dataclasses.dataclass(slots=True)
 class SubjectSearchResponse:
-    subjects: Sequence[Any] | None = None
+    subjects: Sequence[AuthorizationSubject] = _dataclasses.field(
+        default_factory=tuple
+    )
     next_page_token: str = ""
     model_id: str = ""
 
 
 @_dataclasses.dataclass(slots=True)
 class EffectiveSubjectSearchRequest:
-    resource: Any | None = None
-    action: Any | None = None
-    context: Mapping[str, Any] | None = None
+    resource: AuthorizationResource | None = None
+    action: AuthorizationAction | None = None
+    context: JsonObject | None = None
     page_size: int = 0
     page_token: str = ""
 
 
 @_dataclasses.dataclass(slots=True)
 class EffectiveSubjectSearchResponse:
-    targets: Sequence[Any] | None = None
+    targets: Sequence[AuthorizationRelationshipTarget] = _dataclasses.field(
+        default_factory=tuple
+    )
     next_page_token: str = ""
     model_id: str = ""
     truncated: bool = False
@@ -151,101 +160,109 @@ class EffectiveSubjectSearchResponse:
 
 @_dataclasses.dataclass(slots=True)
 class ActionSearchRequest:
-    subject: Any | None = None
-    resource: Any | None = None
-    context: Mapping[str, Any] | None = None
+    subject: AuthorizationSubject | None = None
+    resource: AuthorizationResource | None = None
+    context: JsonObject | None = None
     page_size: int = 0
     page_token: str = ""
 
 
 @_dataclasses.dataclass(slots=True)
 class ActionSearchResponse:
-    actions: Sequence[Any] | None = None
+    actions: Sequence[AuthorizationAction] = _dataclasses.field(default_factory=tuple)
     next_page_token: str = ""
     model_id: str = ""
 
 
 @_dataclasses.dataclass(slots=True)
 class AuthorizationMetadata:
-    capabilities: Sequence[str] | None = None
+    capabilities: Sequence[str] = _dataclasses.field(default_factory=tuple)
     active_model_id: str = ""
 
 
 @_dataclasses.dataclass(slots=True)
 class Relationship:
-    subject: Any | None = None
+    subject: AuthorizationSubject | None = None
     relation: str = ""
-    resource: Any | None = None
-    properties: Mapping[str, Any] | None = None
-    target: Any | None = None
+    resource: AuthorizationResource | None = None
+    properties: JsonObject | None = None
+    target: AuthorizationRelationshipTarget | None = None
 
 
 @_dataclasses.dataclass(slots=True)
 class RelationshipKey:
-    subject: Any | None = None
+    subject: AuthorizationSubject | None = None
     relation: str = ""
-    resource: Any | None = None
-    target: Any | None = None
+    resource: AuthorizationResource | None = None
+    target: AuthorizationRelationshipTarget | None = None
 
 
 @_dataclasses.dataclass(slots=True)
 class ReadRelationshipsRequest:
-    subject: Any | None = None
+    subject: AuthorizationSubject | None = None
     relation: str = ""
-    resource: Any | None = None
+    resource: AuthorizationResource | None = None
     page_size: int = 0
     page_token: str = ""
     model_id: str = ""
-    target: Any | None = None
+    target: AuthorizationRelationshipTarget | None = None
 
 
 @_dataclasses.dataclass(slots=True)
 class ReadRelationshipsResponse:
-    relationships: Sequence[Any] | None = None
+    relationships: Sequence[Relationship] = _dataclasses.field(default_factory=tuple)
     next_page_token: str = ""
     model_id: str = ""
 
 
 @_dataclasses.dataclass(slots=True)
 class WriteRelationshipsRequest:
-    writes: Sequence[Any] | None = None
-    deletes: Sequence[Any] | None = None
+    writes: Sequence[Relationship] = _dataclasses.field(default_factory=tuple)
+    deletes: Sequence[RelationshipKey] = _dataclasses.field(default_factory=tuple)
     model_id: str = ""
 
 
 @_dataclasses.dataclass(slots=True)
 class AuthorizationModel:
     version: int = 0
-    resource_types: Sequence[Any] | None = None
+    resource_types: Sequence[AuthorizationModelResourceType] = _dataclasses.field(
+        default_factory=tuple
+    )
 
 
 @_dataclasses.dataclass(slots=True)
 class AuthorizationModelResourceType:
     name: str = ""
-    relations: Sequence[Any] | None = None
-    actions: Sequence[Any] | None = None
+    relations: Sequence[AuthorizationModelRelation] = _dataclasses.field(
+        default_factory=tuple
+    )
+    actions: Sequence[AuthorizationModelAction] = _dataclasses.field(
+        default_factory=tuple
+    )
 
 
 @_dataclasses.dataclass(slots=True)
 class AuthorizationModelRelation:
     name: str = ""
-    subject_types: Sequence[str] | None = None
-    allowed_targets: Sequence[Any] | None = None
-    rewrite: Any | None = None
+    subject_types: Sequence[str] = _dataclasses.field(default_factory=tuple)
+    allowed_targets: Sequence[AuthorizationModelAllowedTarget] = _dataclasses.field(
+        default_factory=tuple
+    )
+    rewrite: AuthorizationModelRewrite | None = None
 
 
 @_dataclasses.dataclass(slots=True)
 class AuthorizationModelAction:
     name: str = ""
-    relations: Sequence[str] | None = None
-    rewrite: Any | None = None
+    relations: Sequence[str] = _dataclasses.field(default_factory=tuple)
+    rewrite: AuthorizationModelRewrite | None = None
 
 
 @_dataclasses.dataclass(slots=True)
 class AuthorizationModelAllowedTarget:
     subject_type: str = ""
     resource_type: str = ""
-    subject_set: Any | None = None
+    subject_set: AuthorizationModelSubjectSetTarget | None = None
 
 
 @_dataclasses.dataclass(slots=True)
@@ -256,10 +273,10 @@ class AuthorizationModelSubjectSetTarget:
 
 @_dataclasses.dataclass(slots=True)
 class AuthorizationModelRewrite:
-    this: Any | None = None
-    computed_userset: Any | None = None
-    tuple_to_userset: Any | None = None
-    union: Any | None = None
+    this: AuthorizationModelRewriteThis | None = None
+    computed_userset: AuthorizationModelComputedUserset | None = None
+    tuple_to_userset: AuthorizationModelTupleToUserset | None = None
+    union: AuthorizationModelRewriteUnion | None = None
 
 
 @_dataclasses.dataclass(slots=True)
@@ -280,7 +297,9 @@ class AuthorizationModelTupleToUserset:
 
 @_dataclasses.dataclass(slots=True)
 class AuthorizationModelRewriteUnion:
-    children: Sequence[Any] | None = None
+    children: Sequence[AuthorizationModelRewrite] = _dataclasses.field(
+        default_factory=tuple
+    )
 
 
 @_dataclasses.dataclass(slots=True)
@@ -296,7 +315,7 @@ class AuthorizationModelRef:
 
 @_dataclasses.dataclass(slots=True)
 class GetActiveModelResponse:
-    model: Any | None = None
+    model: AuthorizationModelRef | None = None
 
 
 @_dataclasses.dataclass(slots=True)
@@ -307,34 +326,34 @@ class ListModelsRequest:
 
 @_dataclasses.dataclass(slots=True)
 class ListModelsResponse:
-    models: Sequence[Any] | None = None
+    models: Sequence[AuthorizationModelRef] = _dataclasses.field(default_factory=tuple)
     next_page_token: str = ""
 
 
 @_dataclasses.dataclass(slots=True)
 class WriteModelRequest:
-    model: Any | None = None
+    model: AuthorizationModel | None = None
 
 
 @_dataclasses.dataclass(slots=True)
 class ExpandRequest:
-    resource: Any | None = None
+    resource: AuthorizationResource | None = None
     relation: str = ""
-    context: Mapping[str, Any] | None = None
+    context: JsonObject | None = None
     max_depth: int = 0
     model_id: str = ""
 
 
 @_dataclasses.dataclass(slots=True)
 class ExpandNode:
-    target: Any | None = None
+    target: AuthorizationRelationshipTarget | None = None
     relation: str = ""
-    children: Sequence[Any] | None = None
+    children: Sequence[ExpandNode] = _dataclasses.field(default_factory=tuple)
 
 
 @_dataclasses.dataclass(slots=True)
 class ExpandResponse:
-    root: Any | None = None
+    root: ExpandNode | None = None
     truncated: bool = False
     cycle_detected: bool = False
     max_depth_reached: bool = False
@@ -692,97 +711,169 @@ class Authorization:
         self._closed = True
         self._channel.close()
 
-    def evaluate(self, request: Any) -> Any:
+    def evaluate(
+        self,
+        request: AccessEvaluationRequest,
+    ) -> AccessDecision:
         """Evaluate one authorization request."""
 
-        return _authorization_from_message(self._stub.Evaluate(
-            _authorization_message(
-                request,
-                authorization_pb2.AccessEvaluationRequest,
-            )
-        ))
+        return cast(
+            AccessDecision,
+            _authorization_from_message(
+                self._stub.Evaluate(
+                    _authorization_message(
+                        request,
+                        authorization_pb2.AccessEvaluationRequest,
+                    )
+                )
+            ),
+        )
 
-    def evaluate_many(self, request: Any) -> Any:
+    def evaluate_many(
+        self,
+        request: AccessEvaluationsRequest,
+    ) -> AccessEvaluationsResponse:
         """Evaluate multiple authorization requests."""
 
-        return _authorization_from_message(self._stub.EvaluateMany(
-            _authorization_message(
-                request,
-                authorization_pb2.AccessEvaluationsRequest,
-            )
-        ))
+        return cast(
+            AccessEvaluationsResponse,
+            _authorization_from_message(
+                self._stub.EvaluateMany(
+                    _authorization_message(
+                        request,
+                        authorization_pb2.AccessEvaluationsRequest,
+                    )
+                )
+            ),
+        )
 
-    def search_resources(self, request: Any) -> Any:
+    def search_resources(
+        self,
+        request: ResourceSearchRequest,
+    ) -> ResourceSearchResponse:
         """Search resources visible to a subject for an action."""
 
-        return _authorization_from_message(self._stub.SearchResources(
-            _authorization_message(
-                request,
-                authorization_pb2.ResourceSearchRequest,
-            )
-        ))
+        return cast(
+            ResourceSearchResponse,
+            _authorization_from_message(
+                self._stub.SearchResources(
+                    _authorization_message(
+                        request,
+                        authorization_pb2.ResourceSearchRequest,
+                    )
+                )
+            ),
+        )
 
-    def search_subjects(self, request: Any) -> Any:
+    def search_subjects(
+        self,
+        request: SubjectSearchRequest,
+    ) -> SubjectSearchResponse:
         """Search subjects related to a resource and action."""
 
-        return _authorization_from_message(self._stub.SearchSubjects(
-            _authorization_message(
-                request,
-                authorization_pb2.SubjectSearchRequest,
-            )
-        ))
+        return cast(
+            SubjectSearchResponse,
+            _authorization_from_message(
+                self._stub.SearchSubjects(
+                    _authorization_message(
+                        request,
+                        authorization_pb2.SubjectSearchRequest,
+                    )
+                )
+            ),
+        )
 
-    def effective_search_resources(self, request: Any) -> Any:
+    def effective_search_resources(
+        self,
+        request: ResourceSearchRequest,
+    ) -> ResourceSearchResponse:
         """Search effective resources visible through inherited relationships."""
 
-        return _authorization_from_message(self._stub.EffectiveSearchResources(
-            _authorization_message(
-                request,
-                authorization_pb2.ResourceSearchRequest,
-            )
-        ))
+        return cast(
+            ResourceSearchResponse,
+            _authorization_from_message(
+                self._stub.EffectiveSearchResources(
+                    _authorization_message(
+                        request,
+                        authorization_pb2.ResourceSearchRequest,
+                    )
+                )
+            ),
+        )
 
-    def effective_search_subjects(self, request: Any) -> Any:
+    def effective_search_subjects(
+        self,
+        request: EffectiveSubjectSearchRequest,
+    ) -> EffectiveSubjectSearchResponse:
         """Search effective subjects or subject sets for a resource and action."""
 
-        return _authorization_from_message(self._stub.EffectiveSearchSubjects(
-            _authorization_message(
-                request,
-                authorization_pb2.EffectiveSubjectSearchRequest,
-            )
-        ))
+        return cast(
+            EffectiveSubjectSearchResponse,
+            _authorization_from_message(
+                self._stub.EffectiveSearchSubjects(
+                    _authorization_message(
+                        request,
+                        authorization_pb2.EffectiveSubjectSearchRequest,
+                    )
+                )
+            ),
+        )
 
-    def search_actions(self, request: Any) -> Any:
+    def search_actions(
+        self,
+        request: ActionSearchRequest,
+    ) -> ActionSearchResponse:
         """Search actions available between a subject and resource."""
 
-        return _authorization_from_message(self._stub.SearchActions(
-            _authorization_message(
-                request,
-                authorization_pb2.ActionSearchRequest,
-            )
-        ))
+        return cast(
+            ActionSearchResponse,
+            _authorization_from_message(
+                self._stub.SearchActions(
+                    _authorization_message(
+                        request,
+                        authorization_pb2.ActionSearchRequest,
+                    )
+                )
+            ),
+        )
 
-    def expand(self, request: Any) -> Any:
+    def expand(self, request: ExpandRequest) -> ExpandResponse:
         """Expand one resource relation into contributing relationship targets."""
 
-        return _authorization_from_message(self._stub.Expand(
-            _authorization_message(
-                request,
-                authorization_pb2.ExpandRequest,
-            )
-        ))
+        return cast(
+            ExpandResponse,
+            _authorization_from_message(
+                self._stub.Expand(
+                    _authorization_message(
+                        request,
+                        authorization_pb2.ExpandRequest,
+                    )
+                )
+            ),
+        )
 
-    def read_relationships(self, request: Any) -> Any:
+    def read_relationships(
+        self,
+        request: ReadRelationshipsRequest,
+    ) -> ReadRelationshipsResponse:
         """Read authorization relationships matching a request."""
 
-        return _authorization_from_message(self._stub.ReadRelationships(
-            _authorization_message(
-                request,
-                authorization_pb2.ReadRelationshipsRequest,
-            )
-        ))
+        return cast(
+            ReadRelationshipsResponse,
+            _authorization_from_message(
+                self._stub.ReadRelationships(
+                    _authorization_message(
+                        request,
+                        authorization_pb2.ReadRelationshipsRequest,
+                    )
+                )
+            ),
+        )
 
-    def write_relationships(self, request: Any) -> None:
+    def write_relationships(
+        self,
+        request: WriteRelationshipsRequest,
+    ) -> None:
         """Write authorization relationships."""
 
         self._stub.WriteRelationships(
@@ -792,35 +883,57 @@ class Authorization:
             )
         )
 
-    def get_metadata(self) -> Any:
+    def get_metadata(self) -> AuthorizationMetadata:
         """Return host authorization provider metadata."""
 
-        return _authorization_from_message(self._stub.GetMetadata(empty_pb2.Empty()))
+        return cast(
+            AuthorizationMetadata,
+            _authorization_from_message(self._stub.GetMetadata(empty_pb2.Empty())),
+        )
 
-    def get_active_model(self) -> Any:
+    def get_active_model(self) -> GetActiveModelResponse:
         """Return the active authorization model."""
 
-        return _authorization_from_message(self._stub.GetActiveModel(empty_pb2.Empty()))
+        return cast(
+            GetActiveModelResponse,
+            _authorization_from_message(self._stub.GetActiveModel(empty_pb2.Empty())),
+        )
 
-    def list_models(self, request: Any) -> Any:
+    def list_models(
+        self,
+        request: ListModelsRequest,
+    ) -> ListModelsResponse:
         """List authorization model references."""
 
-        return _authorization_from_message(self._stub.ListModels(
-            _authorization_message(
-                request,
-                authorization_pb2.ListModelsRequest,
-            )
-        ))
+        return cast(
+            ListModelsResponse,
+            _authorization_from_message(
+                self._stub.ListModels(
+                    _authorization_message(
+                        request,
+                        authorization_pb2.ListModelsRequest,
+                    )
+                )
+            ),
+        )
 
-    def write_model(self, request: Any) -> Any:
+    def write_model(
+        self,
+        request: WriteModelRequest,
+    ) -> AuthorizationModelRef:
         """Write an authorization model."""
 
-        return _authorization_from_message(self._stub.WriteModel(
-            _authorization_message(
-                request,
-                authorization_pb2.WriteModelRequest,
-            )
-        ))
+        return cast(
+            AuthorizationModelRef,
+            _authorization_from_message(
+                self._stub.WriteModel(
+                    _authorization_message(
+                        request,
+                        authorization_pb2.WriteModelRequest,
+                    )
+                )
+            ),
+        )
 
     def __enter__(self) -> Authorization:
         return self

--- a/sdk/python/gestalt/_providers.py
+++ b/sdk/python/gestalt/_providers.py
@@ -19,6 +19,32 @@ from typing import (
     runtime_checkable,
 )
 
+from ._authorization import (
+    AccessDecision,
+    AccessEvaluationRequest,
+    AccessEvaluationsRequest,
+    AccessEvaluationsResponse,
+    ActionSearchRequest,
+    ActionSearchResponse,
+    AuthorizationMetadata,
+    AuthorizationModelRef,
+    EffectiveSubjectSearchRequest,
+    EffectiveSubjectSearchResponse,
+    ExpandRequest,
+    ExpandResponse,
+    GetActiveModelResponse,
+    ListModelsRequest,
+    ListModelsResponse,
+    ReadRelationshipsRequest,
+    ReadRelationshipsResponse,
+    ResourceSearchRequest,
+    ResourceSearchResponse,
+    SubjectSearchRequest,
+    SubjectSearchResponse,
+    WriteModelRequest,
+    WriteRelationshipsRequest,
+)
+
 if TYPE_CHECKING:
     from ._agent import (
         AgentInteraction,
@@ -51,31 +77,6 @@ if TYPE_CHECKING:
         CompleteLoginRequest,
     )
     from ._cache import CacheEntry
-    from ._gen.v1.authorization_pb2 import (
-        AccessDecision,
-        AccessEvaluationRequest,
-        AccessEvaluationsRequest,
-        AccessEvaluationsResponse,
-        ActionSearchRequest,
-        ActionSearchResponse,
-        AuthorizationMetadata,
-        AuthorizationModelRef,
-        EffectiveSubjectSearchRequest,
-        EffectiveSubjectSearchResponse,
-        ExpandRequest,
-        ExpandResponse,
-        GetActiveModelResponse,
-        ListModelsRequest,
-        ListModelsResponse,
-        ReadRelationshipsRequest,
-        ReadRelationshipsResponse,
-        ResourceSearchRequest,
-        ResourceSearchResponse,
-        SubjectSearchRequest,
-        SubjectSearchResponse,
-        WriteModelRequest,
-        WriteRelationshipsRequest,
-    )
     from ._runtime_provider import (
         GetRuntimeSessionRequest,
         GetRuntimeSupportRequest,

--- a/sdk/python/gestalt/_runtime.py
+++ b/sdk/python/gestalt/_runtime.py
@@ -18,6 +18,7 @@ from typing import Any, Final, cast
 
 from . import _agent as _agent_native
 from . import _authentication as _auth_native
+from . import _authorization as _authorization_native
 from . import _runtime_provider as _runtime_provider_native
 from . import _s3 as _s3_native
 from . import _telemetry
@@ -1824,7 +1825,12 @@ def _authorization_servicer(*, provider: AppProvider) -> Any:
         @_grpc_handler("authorization evaluate")
         def Evaluate(self, request: Any, context: Any) -> Any:
             return _authorization_response(
-                authz_provider.evaluate(request),
+                authz_provider.evaluate(
+                    _authorization_native._authorization_from_message(
+                        request,
+                        _authorization_native.AccessEvaluationRequest,
+                    )
+                ),
                 authorization_pb2.AccessDecision,
                 context,
                 "evaluate",
@@ -1833,7 +1839,12 @@ def _authorization_servicer(*, provider: AppProvider) -> Any:
         @_grpc_handler("authorization evaluate many")
         def EvaluateMany(self, request: Any, context: Any) -> Any:
             return _authorization_response(
-                authz_provider.evaluate_many(request),
+                authz_provider.evaluate_many(
+                    _authorization_native._authorization_from_message(
+                        request,
+                        _authorization_native.AccessEvaluationsRequest,
+                    )
+                ),
                 authorization_pb2.AccessEvaluationsResponse,
                 context,
                 "evaluate many",
@@ -1842,7 +1853,12 @@ def _authorization_servicer(*, provider: AppProvider) -> Any:
         @_grpc_handler("authorization search resources")
         def SearchResources(self, request: Any, context: Any) -> Any:
             return _authorization_response(
-                authz_provider.search_resources(request),
+                authz_provider.search_resources(
+                    _authorization_native._authorization_from_message(
+                        request,
+                        _authorization_native.ResourceSearchRequest,
+                    )
+                ),
                 authorization_pb2.ResourceSearchResponse,
                 context,
                 "search resources",
@@ -1851,7 +1867,12 @@ def _authorization_servicer(*, provider: AppProvider) -> Any:
         @_grpc_handler("authorization search subjects")
         def SearchSubjects(self, request: Any, context: Any) -> Any:
             return _authorization_response(
-                authz_provider.search_subjects(request),
+                authz_provider.search_subjects(
+                    _authorization_native._authorization_from_message(
+                        request,
+                        _authorization_native.SubjectSearchRequest,
+                    )
+                ),
                 authorization_pb2.SubjectSearchResponse,
                 context,
                 "search subjects",
@@ -1865,7 +1886,12 @@ def _authorization_servicer(*, provider: AppProvider) -> Any:
                     "authorization provider does not support effective search",
                 )
             return _authorization_response(
-                authz_provider.effective_search_resources(request),
+                authz_provider.effective_search_resources(
+                    _authorization_native._authorization_from_message(
+                        request,
+                        _authorization_native.ResourceSearchRequest,
+                    )
+                ),
                 authorization_pb2.ResourceSearchResponse,
                 context,
                 "effective search resources",
@@ -1879,7 +1905,12 @@ def _authorization_servicer(*, provider: AppProvider) -> Any:
                     "authorization provider does not support effective search",
                 )
             return _authorization_response(
-                authz_provider.effective_search_subjects(request),
+                authz_provider.effective_search_subjects(
+                    _authorization_native._authorization_from_message(
+                        request,
+                        _authorization_native.EffectiveSubjectSearchRequest,
+                    )
+                ),
                 authorization_pb2.EffectiveSubjectSearchResponse,
                 context,
                 "effective search subjects",
@@ -1888,7 +1919,12 @@ def _authorization_servicer(*, provider: AppProvider) -> Any:
         @_grpc_handler("authorization search actions")
         def SearchActions(self, request: Any, context: Any) -> Any:
             return _authorization_response(
-                authz_provider.search_actions(request),
+                authz_provider.search_actions(
+                    _authorization_native._authorization_from_message(
+                        request,
+                        _authorization_native.ActionSearchRequest,
+                    )
+                ),
                 authorization_pb2.ActionSearchResponse,
                 context,
                 "search actions",
@@ -1902,7 +1938,12 @@ def _authorization_servicer(*, provider: AppProvider) -> Any:
                     "authorization provider does not support expansion",
                 )
             return _authorization_response(
-                authz_provider.expand(request),
+                authz_provider.expand(
+                    _authorization_native._authorization_from_message(
+                        request,
+                        _authorization_native.ExpandRequest,
+                    )
+                ),
                 authorization_pb2.ExpandResponse,
                 context,
                 "expand",
@@ -1931,7 +1972,12 @@ def _authorization_servicer(*, provider: AppProvider) -> Any:
         @_grpc_handler("authorization read relationships")
         def ReadRelationships(self, request: Any, context: Any) -> Any:
             return _authorization_response(
-                authz_provider.read_relationships(request),
+                authz_provider.read_relationships(
+                    _authorization_native._authorization_from_message(
+                        request,
+                        _authorization_native.ReadRelationshipsRequest,
+                    )
+                ),
                 authorization_pb2.ReadRelationshipsResponse,
                 context,
                 "read relationships",
@@ -1939,7 +1985,12 @@ def _authorization_servicer(*, provider: AppProvider) -> Any:
 
         @_grpc_handler("authorization write relationships")
         def WriteRelationships(self, request: Any, _context: Any) -> Any:
-            authz_provider.write_relationships(request)
+            authz_provider.write_relationships(
+                _authorization_native._authorization_from_message(
+                    request,
+                    _authorization_native.WriteRelationshipsRequest,
+                )
+            )
             return empty_pb2.Empty()
 
         @_grpc_handler("authorization get active model")
@@ -1954,7 +2005,12 @@ def _authorization_servicer(*, provider: AppProvider) -> Any:
         @_grpc_handler("authorization list models")
         def ListModels(self, request: Any, context: Any) -> Any:
             return _authorization_response(
-                authz_provider.list_models(request),
+                authz_provider.list_models(
+                    _authorization_native._authorization_from_message(
+                        request,
+                        _authorization_native.ListModelsRequest,
+                    )
+                ),
                 authorization_pb2.ListModelsResponse,
                 context,
                 "list models",
@@ -1963,7 +2019,12 @@ def _authorization_servicer(*, provider: AppProvider) -> Any:
         @_grpc_handler("authorization write model")
         def WriteModel(self, request: Any, context: Any) -> Any:
             return _authorization_response(
-                authz_provider.write_model(request),
+                authz_provider.write_model(
+                    _authorization_native._authorization_from_message(
+                        request,
+                        _authorization_native.WriteModelRequest,
+                    )
+                ),
                 authorization_pb2.AuthorizationModelRef,
                 context,
                 "write model",
@@ -1986,13 +2047,17 @@ def _authorization_response(
     if isinstance(value, message_type):
         return value
     if isinstance(value, dict):
-        message = message_type()
-        json_format.ParseDict(value, message)
-        return message
-    raise TypeError(
-        f"authorization provider returned {type(value).__name__} for {label}, "
-        f"want {message_type.__name__} or dict"
-    )
+        raise TypeError(
+            f"authorization provider returned dict for {label}, "
+            f"want {message_type.__name__} or dataclass"
+        )
+    try:
+        return _authorization_native._authorization_message(value, message_type)
+    except Exception as error:
+        raise TypeError(
+            f"authorization provider returned {type(value).__name__} for {label}, "
+            f"want {message_type.__name__} or dataclass"
+        ) from error
 
 
 def _authorization_supports_effective_search(provider: AuthorizationProvider) -> bool:

--- a/sdk/python/tests/test_authorization_transport.py
+++ b/sdk/python/tests/test_authorization_transport.py
@@ -10,11 +10,8 @@ from typing import Any
 import grpc
 from google.protobuf import empty_pb2 as _empty_pb2
 
-from gestalt import (
-    Authorization,
-    AuthorizationProvider,
-    _runtime,
-)
+import gestalt
+from gestalt import _runtime
 from gestalt._gen.v1 import (
     authorization_pb2,
     authorization_pb2_grpc,
@@ -23,28 +20,6 @@ from gestalt._gen.v1 import (
 )
 
 empty_pb2: Any = _empty_pb2
-AccessDecision = authorization_pb2.AccessDecision
-AccessEvaluationRequest = authorization_pb2.AccessEvaluationRequest
-AccessEvaluationsResponse = authorization_pb2.AccessEvaluationsResponse
-ActionSearchResponse = authorization_pb2.ActionSearchResponse
-AuthorizationAction = authorization_pb2.Action
-AuthorizationMetadata = authorization_pb2.AuthorizationMetadata
-AuthorizationModel = authorization_pb2.AuthorizationModel
-AuthorizationModelRef = authorization_pb2.AuthorizationModelRef
-AuthorizationRelationshipTarget = authorization_pb2.RelationshipTarget
-AuthorizationResource = authorization_pb2.Resource
-AuthorizationSubject = authorization_pb2.Subject
-AuthorizationSubjectSet = authorization_pb2.SubjectSet
-EffectiveSubjectSearchRequest = authorization_pb2.EffectiveSubjectSearchRequest
-ExpandRequest = authorization_pb2.ExpandRequest
-GetActiveModelResponse = authorization_pb2.GetActiveModelResponse
-ListModelsResponse = authorization_pb2.ListModelsResponse
-ReadRelationshipsResponse = authorization_pb2.ReadRelationshipsResponse
-Relationship = authorization_pb2.Relationship
-ResourceSearchRequest = authorization_pb2.ResourceSearchRequest
-ResourceSearchResponse = authorization_pb2.ResourceSearchResponse
-SubjectSearchResponse = authorization_pb2.SubjectSearchResponse
-WriteRelationshipsRequest = authorization_pb2.WriteRelationshipsRequest
 
 
 class _AuthorizationProvider(authorization_pb2_grpc.AuthorizationProviderServicer):
@@ -99,25 +74,38 @@ class _AuthorizationProvider(authorization_pb2_grpc.AuthorizationProviderService
         return empty_pb2.Empty()
 
 
-class _SDKAuthorizationProvider(AuthorizationProvider):
+class _SDKAuthorizationProvider(gestalt.AuthorizationProvider):
     def __init__(self) -> None:
+        self.requests: dict[str, Any] = {}
         self.writes: list[Any] = []
 
-    def evaluate(self, request: Any) -> Any:
-        return AccessDecision(
-            allowed=request.subject.id == "user:1",
+    def evaluate(
+        self,
+        request: gestalt.AccessEvaluationRequest,
+    ) -> gestalt.AccessDecision:
+        self.requests["evaluate"] = request
+        return gestalt.AccessDecision(
+            allowed=request.subject is not None and request.subject.id == "user:1",
             model_id="model-1",
         )
 
-    def evaluate_many(self, request: Any) -> Any:
-        return AccessEvaluationsResponse(
+    def evaluate_many(
+        self,
+        request: gestalt.AccessEvaluationsRequest,
+    ) -> gestalt.AccessEvaluationsResponse:
+        self.requests["evaluate_many"] = request
+        return gestalt.AccessEvaluationsResponse(
             decisions=[self.evaluate(item) for item in request.requests],
         )
 
-    def search_resources(self, request: Any) -> Any:
-        return ResourceSearchResponse(
+    def search_resources(
+        self,
+        request: gestalt.ResourceSearchRequest,
+    ) -> gestalt.ResourceSearchResponse:
+        self.requests["search_resources"] = request
+        return gestalt.ResourceSearchResponse(
             resources=[
-                AuthorizationResource(
+                gestalt.AuthorizationResource(
                     type=request.resource_type,
                     id="doc-1",
                 )
@@ -125,10 +113,14 @@ class _SDKAuthorizationProvider(AuthorizationProvider):
             model_id="model-1",
         )
 
-    def search_subjects(self, request: Any) -> Any:
-        return SubjectSearchResponse(
+    def search_subjects(
+        self,
+        request: gestalt.SubjectSearchRequest,
+    ) -> gestalt.SubjectSearchResponse:
+        self.requests["search_subjects"] = request
+        return gestalt.SubjectSearchResponse(
             subjects=[
-                AuthorizationSubject(
+                gestalt.AuthorizationSubject(
                     type=request.subject_type,
                     id="user:1",
                 )
@@ -136,38 +128,55 @@ class _SDKAuthorizationProvider(AuthorizationProvider):
             model_id="model-1",
         )
 
-    def search_actions(self, request: Any) -> Any:
-        return ActionSearchResponse(
-            actions=[AuthorizationAction(name="view")],
+    def search_actions(
+        self,
+        request: gestalt.ActionSearchRequest,
+    ) -> gestalt.ActionSearchResponse:
+        self.requests["search_actions"] = request
+        return gestalt.ActionSearchResponse(
+            actions=[gestalt.AuthorizationAction(name="view")],
             model_id="model-1",
         )
 
-    def get_metadata(self) -> Any:
-        return AuthorizationMetadata(
+    def get_metadata(self) -> gestalt.AuthorizationMetadata:
+        return gestalt.AuthorizationMetadata(
             capabilities=["evaluate"],
             active_model_id="model-1",
         )
 
-    def read_relationships(self, request: Any) -> Any:
-        return ReadRelationshipsResponse(model_id="model-1")
+    def read_relationships(
+        self,
+        request: gestalt.ReadRelationshipsRequest,
+    ) -> gestalt.ReadRelationshipsResponse:
+        self.requests["read_relationships"] = request
+        return gestalt.ReadRelationshipsResponse(model_id="model-1")
 
-    def write_relationships(self, request: Any) -> None:
+    def write_relationships(self, request: gestalt.WriteRelationshipsRequest) -> None:
+        self.requests["write_relationships"] = request
         self.writes.append(request)
 
-    def get_active_model(self) -> Any:
-        return GetActiveModelResponse(
-            model=AuthorizationModelRef(id="model-1", version="1"),
+    def get_active_model(self) -> gestalt.GetActiveModelResponse:
+        return gestalt.GetActiveModelResponse(
+            model=gestalt.AuthorizationModelRef(id="model-1", version="1"),
         )
 
-    def list_models(self, request: Any) -> Any:
-        return ListModelsResponse(
-            models=[AuthorizationModelRef(id="model-1", version="1")],
+    def list_models(
+        self,
+        request: gestalt.ListModelsRequest,
+    ) -> gestalt.ListModelsResponse:
+        self.requests["list_models"] = request
+        return gestalt.ListModelsResponse(
+            models=[gestalt.AuthorizationModelRef(id="model-1", version="1")],
         )
 
-    def write_model(self, request: Any) -> Any:
-        return AuthorizationModelRef(
+    def write_model(
+        self,
+        request: gestalt.WriteModelRequest,
+    ) -> gestalt.AuthorizationModelRef:
+        self.requests["write_model"] = request
+        return gestalt.AuthorizationModelRef(
             id="model-2",
-            version=str(request.model.version),
+            version=str(request.model.version if request.model is not None else 0),
         )
 
 
@@ -184,37 +193,43 @@ class AuthorizationTransportTest(unittest.TestCase):
             server.add_insecure_port(f"unix:{socket_path}")
             server.start()
             try:
-                client = Authorization(f"unix://{socket_path}")
+                client = gestalt.Authorization(f"unix://{socket_path}")
                 resource_response = client.effective_search_resources(
-                    ResourceSearchRequest(
-                        subject=AuthorizationSubject(
+                    gestalt.ResourceSearchRequest(
+                        subject=gestalt.AuthorizationSubject(
                             type="subject",
                             id="user:shared",
                         ),
-                        action=AuthorizationAction(name="edit"),
+                        action=gestalt.AuthorizationAction(name="edit"),
                         resource_type="agent_session",
                     )
                 )
                 self.assertEqual(resource_response.resources[0].id, "session-1")
 
                 subject_response = client.effective_search_subjects(
-                    EffectiveSubjectSearchRequest(
-                        resource=AuthorizationResource(
+                    gestalt.EffectiveSubjectSearchRequest(
+                        resource=gestalt.AuthorizationResource(
                             type="agent_session",
                             id="session-1",
                         ),
-                        action=AuthorizationAction(name="edit"),
+                        action=gestalt.AuthorizationAction(name="edit"),
                     )
                 )
                 self.assertTrue(subject_response.truncated)
                 self.assertEqual(
-                    subject_response.targets[0].subject_set.relation,
-                    "member",
+                    subject_response.targets[0].subject_set,
+                    gestalt.AuthorizationSubjectSet(
+                        resource=gestalt.AuthorizationResource(
+                            type="slack_channel",
+                            id="C123",
+                        ),
+                        relation="member",
+                    ),
                 )
 
                 expand_response = client.expand(
-                    ExpandRequest(
-                        resource=AuthorizationResource(
+                    gestalt.ExpandRequest(
+                        resource=gestalt.AuthorizationResource(
                             type="agent_session",
                             id="session-1",
                         ),
@@ -223,15 +238,19 @@ class AuthorizationTransportTest(unittest.TestCase):
                     )
                 )
                 self.assertTrue(expand_response.max_depth_reached)
-                self.assertEqual(expand_response.root.target.resource.id, "session-1")
+                root = expand_response.root
+                self.assertIsNotNone(root)
+                self.assertIsNotNone(root.target)
+                self.assertIsNotNone(root.target.resource)
+                self.assertEqual(root.target.resource.id, "session-1")
 
                 client.write_relationships(
-                    WriteRelationshipsRequest(
+                    gestalt.WriteRelationshipsRequest(
                         writes=[
-                            Relationship(
-                                target=AuthorizationRelationshipTarget(
-                                    subject_set=AuthorizationSubjectSet(
-                                        resource=AuthorizationResource(
+                            gestalt.Relationship(
+                                target=gestalt.AuthorizationRelationshipTarget(
+                                    subject_set=gestalt.AuthorizationSubjectSet(
+                                        resource=gestalt.AuthorizationResource(
                                             type="slack_channel",
                                             id="C123",
                                         ),
@@ -239,7 +258,7 @@ class AuthorizationTransportTest(unittest.TestCase):
                                     )
                                 ),
                                 relation="editor",
-                                resource=AuthorizationResource(
+                                resource=gestalt.AuthorizationResource(
                                     type="agent_session",
                                     id="session-1",
                                 ),
@@ -291,25 +310,35 @@ class AuthorizationTransportTest(unittest.TestCase):
 
                 stub = authorization_pb2_grpc.AuthorizationProviderStub(channel)
                 decision = stub.Evaluate(
-                    AccessEvaluationRequest(
-                        subject=AuthorizationSubject(type="subject", id="user:1"),
-                        action=AuthorizationAction(name="view"),
-                        resource=AuthorizationResource(type="doc", id="doc-1"),
+                    authorization_pb2.AccessEvaluationRequest(
+                        subject=authorization_pb2.Subject(
+                            type="subject",
+                            id="user:1",
+                        ),
+                        action=authorization_pb2.Action(name="view"),
+                        resource=authorization_pb2.Resource(
+                            type="doc",
+                            id="doc-1",
+                        ),
                     ),
                     timeout=5,
                 )
                 self.assertTrue(decision.allowed)
+                self.assertIsInstance(
+                    provider.requests["evaluate"],
+                    gestalt.AccessEvaluationRequest,
+                )
 
                 batch = stub.EvaluateMany(
                     authorization_pb2.AccessEvaluationsRequest(
                         requests=[
-                            AccessEvaluationRequest(
-                                subject=AuthorizationSubject(
+                            authorization_pb2.AccessEvaluationRequest(
+                                subject=authorization_pb2.Subject(
                                     type="subject",
                                     id="user:1",
                                 ),
-                                action=AuthorizationAction(name="view"),
-                                resource=AuthorizationResource(
+                                action=authorization_pb2.Action(name="view"),
+                                resource=authorization_pb2.Resource(
                                     type="doc",
                                     id="doc-1",
                                 ),
@@ -319,20 +348,63 @@ class AuthorizationTransportTest(unittest.TestCase):
                     timeout=5,
                 )
                 self.assertTrue(batch.decisions[0].allowed)
+                self.assertIsInstance(
+                    provider.requests["evaluate_many"],
+                    gestalt.AccessEvaluationsRequest,
+                )
+
+                empty_batch = stub.EvaluateMany(
+                    authorization_pb2.AccessEvaluationsRequest(),
+                    timeout=5,
+                )
+                self.assertEqual(list(empty_batch.decisions), [])
+                self.assertEqual(
+                    provider.requests["evaluate_many"].requests,
+                    (),
+                )
 
                 metadata = stub.GetMetadata(empty_pb2.Empty(), timeout=5)
                 self.assertEqual(list(metadata.capabilities), ["evaluate"])
 
+                subjects = stub.SearchSubjects(
+                    authorization_pb2.SubjectSearchRequest(
+                        resource=authorization_pb2.Resource(
+                            type="doc",
+                            id="doc-1",
+                        ),
+                        action=authorization_pb2.Action(name="view"),
+                        subject_type="subject",
+                    ),
+                    timeout=5,
+                )
+                self.assertEqual(subjects.subjects[0].id, "user:1")
+                self.assertIsInstance(
+                    provider.requests["search_subjects"],
+                    gestalt.SubjectSearchRequest,
+                )
+
                 model_ref = stub.WriteModel(
                     authorization_pb2.WriteModelRequest(
-                        model=AuthorizationModel(version=2),
+                        model=authorization_pb2.AuthorizationModel(version=2),
                     ),
                     timeout=5,
                 )
                 self.assertEqual(model_ref.version, "2")
+                self.assertIsInstance(
+                    provider.requests["write_model"],
+                    gestalt.WriteModelRequest,
+                )
+
+                stub.WriteRelationships(
+                    authorization_pb2.WriteRelationshipsRequest(),
+                    timeout=5,
+                )
+                write_request = provider.requests["write_relationships"]
+                self.assertEqual(write_request.writes, ())
+                self.assertEqual(write_request.deletes, ())
 
                 with self.assertRaises(grpc.RpcError) as failure:
-                    stub.Expand(ExpandRequest(), timeout=5)
+                    stub.Expand(authorization_pb2.ExpandRequest(), timeout=5)
                 rpc_error: Any = failure.exception
                 self.assertEqual(
                     rpc_error.code(),
@@ -342,7 +414,7 @@ class AuthorizationTransportTest(unittest.TestCase):
                 server.stop(grace=0)
 
     def test_sdk_authorization_provider_write_relationships_unimplemented(self) -> None:
-        provider = AuthorizationProvider()
+        provider = gestalt.AuthorizationProvider()
         server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
         _runtime._register_authorization_services(server, provider)
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -354,7 +426,10 @@ class AuthorizationTransportTest(unittest.TestCase):
                 stub = authorization_pb2_grpc.AuthorizationProviderStub(channel)
 
                 with self.assertRaises(grpc.RpcError) as failure:
-                    stub.WriteRelationships(WriteRelationshipsRequest(), timeout=5)
+                    stub.WriteRelationships(
+                        authorization_pb2.WriteRelationshipsRequest(),
+                        timeout=5,
+                    )
                 rpc_error: Any = failure.exception
                 self.assertEqual(
                     rpc_error.code(),

--- a/sdk/python/tests/test_protocol_helpers.py
+++ b/sdk/python/tests/test_protocol_helpers.py
@@ -1,4 +1,5 @@
 import unittest
+from typing import get_type_hints
 
 import gestalt
 from gestalt import testing
@@ -12,6 +13,19 @@ class ProtocolHelperTests(unittest.TestCase):
 
         self.assertEqual(message_dict["role"], "user")
 
+    def test_authorization_provider_methods_are_annotated_with_native_types(
+        self,
+    ) -> None:
+        evaluate_hints = get_type_hints(gestalt.AuthorizationProvider.evaluate)
+        search_subjects_hints = get_type_hints(
+            gestalt.AuthorizationProvider.search_subjects
+        )
+
+        self.assertIs(evaluate_hints["request"], gestalt.AccessEvaluationRequest)
+        self.assertIs(evaluate_hints["return"], gestalt.AccessDecision)
+        self.assertIs(search_subjects_hints["request"], gestalt.SubjectSearchRequest)
+        self.assertIs(search_subjects_hints["return"], gestalt.SubjectSearchResponse)
+
     def test_public_low_level_imports_fail(self) -> None:
         with self.assertRaises(ImportError):
             exec("from gestalt import protocol", {})
@@ -22,7 +36,6 @@ class ProtocolHelperTests(unittest.TestCase):
         for name in (
             "struct_from_dict",
             "indexeddb_record_to_proto",
-            "AuthorizationResource",
         ):
             with self.subTest(name=name):
                 with self.assertRaises(ImportError):

--- a/sdk/python/tests/test_runtime.py
+++ b/sdk/python/tests/test_runtime.py
@@ -368,6 +368,12 @@ class MainEntrypointTests(unittest.TestCase):
 
         @app.operation
         def whoami(request: Request) -> dict[str, Any]:
+            workflow_trigger = request.workflow.get("trigger")
+            workflow_trigger_kind = (
+                workflow_trigger.get("kind", "")
+                if isinstance(workflow_trigger, dict)
+                else ""
+            )
             return {
                 "token": request.token,
                 "subject_id": request.subject.id,
@@ -387,9 +393,7 @@ class MainEntrypointTests(unittest.TestCase):
                 "idempotency_key": request.idempotency_key,
                 "invocation_token": request.invocation_token,
                 "workflow_run_id": str(request.workflow.get("runId", "")),
-                "workflow_trigger_kind": str(
-                    request.workflow.get("trigger", {}).get("kind", "")
-                ),
+                "workflow_trigger_kind": str(workflow_trigger_kind),
                 "workflow": request.workflow,
                 "tool_refs_set": request.tool_refs_set,
                 "tool_ref_app": request.tool_refs[0].app if request.tool_refs else "",

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -110,6 +110,7 @@ export {
   type Subject,
   type SubjectInput,
 } from "./api.ts";
+export { type JsonObject, type JsonValue } from "./protocol.ts";
 export {
   type HTTPSubjectRequest,
   type HTTPSubjectResolutionContext,

--- a/sdk/typescript/src/protocol.ts
+++ b/sdk/typescript/src/protocol.ts
@@ -14,6 +14,8 @@ import {
   type Value,
 } from "@bufbuild/protobuf/wkt";
 
+export type { JsonObject, JsonValue };
+
 const MIN_TIMESTAMP_SECONDS = -62_135_596_800n;
 const MAX_TIMESTAMP_SECONDS = 253_402_300_799n;
 const MIN_TIMESTAMP_SECONDS_NUMBER = Number(MIN_TIMESTAMP_SECONDS);

--- a/sdk/typescript/tests/public-api-contract.ts
+++ b/sdk/typescript/tests/public-api-contract.ts
@@ -5,6 +5,8 @@ import {
   WorkflowRunStatus,
   type AuthorizationEvaluateInput,
   type AgentWorkspace,
+  type JsonObject,
+  type JsonValue,
   type RuntimeLogAppendResponse,
   type WorkflowEvent,
 } from "@valon-technologies/gestalt";
@@ -45,6 +47,8 @@ const workspace: AgentWorkspace = {
   cwd: "/workspace",
   checkouts: [{ url: "https://example.test/repo.git", ref: "main" }],
 };
+const jsonObject: JsonObject = { ok: true };
+const jsonValue: JsonValue = { nested: ["value"] };
 const egressMode: RuntimeEgressMode = RuntimeEgressMode.NONE;
 
 void Authorization;
@@ -54,6 +58,8 @@ void evaluateInput;
 void appendResponse;
 void event;
 void workspace;
+void jsonObject;
+void jsonValue;
 void egressMode;
 void (undefined as unknown as ProtocolStruct);
 void (undefined as unknown as ProtocolRequest);


### PR DESCRIPTION
## Summary
- expose Python authorization dataclasses plus JSON type aliases from the public SDK surface
- tighten Python authorization request/response dataclass fields and client method signatures
- convert authorization provider runtime callbacks to native request dataclasses and serialize native dataclass responses back to protobuf
- expose TypeScript `JsonObject` and `JsonValue` type aliases from the root package while keeping protocol schemas/generated types private

## Test plan
- `cd sdk/python && uv run ruff check .`
- `cd sdk/python && uv run ty check --exclude 'gestalt/_gen/**' gestalt scripts tests`
- `cd sdk/python && uv run python -m unittest discover -s tests`
- `cd sdk/typescript && bun run typecheck`
- `cd sdk/typescript && bun test --max-concurrency 1`
- `git diff --check`