### PR TITLE
[authorization] expose dynamic grants endpoint

### DIFF
--- a/gestaltd/internal/server/authz_dynamic_fragments.go
+++ b/gestaltd/internal/server/authz_dynamic_fragments.go
@@ -22,31 +22,31 @@ type putAuthorizationDynamicFragmentRequest struct {
 	ExpectedVersion *int64                                              `json:"expectedVersion"`
 }
 
-func (s *Server) listAdminAuthorizationFragments(w http.ResponseWriter, r *http.Request) {
+func (s *Server) listAdminAuthorizationGrants(w http.ResponseWriter, r *http.Request) {
 	if !s.ensureAuthorizationDynamicFragmentStore(w) {
 		return
 	}
 	if err := s.ensureAuthorizationDynamicFragmentsBackfilled(r.Context()); err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to backfill authorization fragments")
+		writeError(w, http.StatusInternalServerError, "failed to backfill authorization grants")
 		return
 	}
-	fragments, err := s.authzFragments.ListFragments(r.Context())
+	grants, err := s.authzFragments.ListFragments(r.Context())
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to list authorization fragments")
+		writeError(w, http.StatusInternalServerError, "failed to list authorization grants")
 		return
 	}
-	writeJSON(w, http.StatusOK, fragments)
+	writeJSON(w, http.StatusOK, grants)
 }
 
-func (s *Server) getAdminAuthorizationFragment(w http.ResponseWriter, r *http.Request) {
+func (s *Server) getAdminAuthorizationGrant(w http.ResponseWriter, r *http.Request) {
 	if !s.ensureAuthorizationDynamicFragmentStore(w) {
 		return
 	}
 	if err := s.ensureAuthorizationDynamicFragmentsBackfilled(r.Context()); err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to backfill authorization fragments")
+		writeError(w, http.StatusInternalServerError, "failed to backfill authorization grants")
 		return
 	}
-	id, err := decodedURLParam(r, "fragmentID")
+	id, err := decodedURLParam(r, "grantID")
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
@@ -54,24 +54,24 @@ func (s *Server) getAdminAuthorizationFragment(w http.ResponseWriter, r *http.Re
 	fragment, err := s.authzFragments.GetFragment(r.Context(), id)
 	if err != nil {
 		if errors.Is(err, core.ErrNotFound) {
-			writeError(w, http.StatusNotFound, "authorization fragment not found")
+			writeError(w, http.StatusNotFound, "authorization grant not found")
 			return
 		}
-		writeError(w, http.StatusInternalServerError, "failed to read authorization fragment")
+		writeError(w, http.StatusInternalServerError, "failed to read authorization grant")
 		return
 	}
 	writeJSON(w, http.StatusOK, fragment)
 }
 
-func (s *Server) putAdminAuthorizationFragment(w http.ResponseWriter, r *http.Request) {
+func (s *Server) putAdminAuthorizationGrant(w http.ResponseWriter, r *http.Request) {
 	if !s.ensureAuthorizationDynamicFragmentStore(w) {
 		return
 	}
 	if err := s.ensureAuthorizationDynamicFragmentsBackfilled(r.Context()); err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to backfill authorization fragments")
+		writeError(w, http.StatusInternalServerError, "failed to backfill authorization grants")
 		return
 	}
-	id, err := decodedURLParam(r, "fragmentID")
+	id, err := decodedURLParam(r, "grantID")
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
@@ -124,15 +124,15 @@ func (s *Server) putAdminAuthorizationFragment(w http.ResponseWriter, r *http.Re
 	writeJSON(w, http.StatusOK, fragment)
 }
 
-func (s *Server) deleteAdminAuthorizationFragment(w http.ResponseWriter, r *http.Request) {
+func (s *Server) deleteAdminAuthorizationGrant(w http.ResponseWriter, r *http.Request) {
 	if !s.ensureAuthorizationDynamicFragmentStore(w) {
 		return
 	}
 	if err := s.ensureAuthorizationDynamicFragmentsBackfilled(r.Context()); err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to backfill authorization fragments")
+		writeError(w, http.StatusInternalServerError, "failed to backfill authorization grants")
 		return
 	}
-	id, err := decodedURLParam(r, "fragmentID")
+	id, err := decodedURLParam(r, "grantID")
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
@@ -144,14 +144,14 @@ func (s *Server) deleteAdminAuthorizationFragment(w http.ResponseWriter, r *http
 	fragment, getErr := s.authzFragments.GetFragment(r.Context(), id)
 	if getErr != nil {
 		if errors.Is(getErr, core.ErrNotFound) {
-			writeError(w, http.StatusNotFound, "authorization fragment not found")
+			writeError(w, http.StatusNotFound, "authorization grant not found")
 			return
 		}
-		writeError(w, http.StatusInternalServerError, "failed to read authorization fragment")
+		writeError(w, http.StatusInternalServerError, "failed to read authorization grant")
 		return
 	}
 	if err := s.authzFragments.DeleteFragment(r.Context(), id); err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to delete authorization fragment")
+		writeError(w, http.StatusInternalServerError, "failed to delete authorization grant")
 		return
 	}
 	s.auditAuthorizationFragmentMutation(r.Context(), "authorization.fragment.delete", fragment, nil)
@@ -184,13 +184,13 @@ func (s *Server) ensureAuthorizationFragmentWriteAccess(w http.ResponseWriter, r
 			return true
 		}
 	}
-	writeError(w, http.StatusForbidden, "authorization fragment changes require admin access or app admin access")
+	writeError(w, http.StatusForbidden, "authorization grant changes require admin access or app admin access")
 	return false
 }
 
 func (s *Server) ensureAuthorizationDynamicFragmentStore(w http.ResponseWriter) bool {
 	if s.authzFragments == nil {
-		writeError(w, http.StatusServiceUnavailable, "dynamic authorization fragments require indexeddb source state")
+		writeError(w, http.StatusServiceUnavailable, "dynamic authorization grants require indexeddb source state")
 		return false
 	}
 	return true

--- a/gestaltd/internal/server/handlers_admin_authorization.go
+++ b/gestaltd/internal/server/handlers_admin_authorization.go
@@ -54,10 +54,10 @@ func (s *Server) mountAdminAuthorizationRoutes(r chi.Router) {
 	r.Get("/authorization/provider", s.getAdminAuthorizationProvider)
 	r.Get("/authorization/models", s.listAdminAuthorizationModels)
 	r.Get("/authorization/relationships", s.listAdminAuthorizationRelationships)
-	r.Get("/authorization/fragments", s.listAdminAuthorizationFragments)
-	r.Get("/authorization/fragments/{fragmentID}", s.getAdminAuthorizationFragment)
-	r.Put("/authorization/fragments/{fragmentID}", s.putAdminAuthorizationFragment)
-	r.Delete("/authorization/fragments/{fragmentID}", s.deleteAdminAuthorizationFragment)
+	r.Get("/authorization/grants", s.listAdminAuthorizationGrants)
+	r.Get("/authorization/grants/{grantID}", s.getAdminAuthorizationGrant)
+	r.Put("/authorization/grants/{grantID}", s.putAdminAuthorizationGrant)
+	r.Delete("/authorization/grants/{grantID}", s.deleteAdminAuthorizationGrant)
 	r.Get("/authorization/admins/members", s.listAdminAuthorizationAdminMembers)
 	r.Put("/authorization/admins/members", s.putAdminAuthorizationAdminMember)
 	r.Delete("/authorization/admins/members/{subjectID}", s.deleteAdminAuthorizationAdminMember)
@@ -124,7 +124,7 @@ func appScopedAdminAuthorizationRoutePlugin(r *http.Request) (string, bool) {
 		return "", false
 	}
 	path := adminAuthorizationRoutePath(r)
-	if plugin, ok := adminAuthorizationFragmentRoutePlugin(path); ok {
+	if plugin, ok := adminAuthorizationGrantRoutePlugin(path); ok {
 		return plugin, true
 	}
 	var rest string
@@ -157,13 +157,13 @@ func appScopedAdminAuthorizationRoutePlugin(r *http.Request) (string, bool) {
 	return app, true
 }
 
-func adminAuthorizationFragmentRoutePlugin(path string) (string, bool) {
+func adminAuthorizationGrantRoutePlugin(path string) (string, bool) {
 	var rest string
 	switch {
-	case strings.HasPrefix(path, "/authorization/fragments/"):
-		rest = strings.TrimPrefix(path, "/authorization/fragments/")
-	case strings.HasPrefix(path, "/admin/api/v1/authorization/fragments/"):
-		rest = strings.TrimPrefix(path, "/admin/api/v1/authorization/fragments/")
+	case strings.HasPrefix(path, "/authorization/grants/"):
+		rest = strings.TrimPrefix(path, "/authorization/grants/")
+	case strings.HasPrefix(path, "/admin/api/v1/authorization/grants/"):
+		rest = strings.TrimPrefix(path, "/admin/api/v1/authorization/grants/")
 	default:
 		return "", false
 	}

--- a/gestaltd/internal/server/handlers_admin_authorization_test.go
+++ b/gestaltd/internal/server/handlers_admin_authorization_test.go
@@ -6,12 +6,12 @@ import (
 	"testing"
 )
 
-func TestAppScopedAdminAuthorizationRoutePluginAllowsEncodedPluginFragmentID(t *testing.T) {
+func TestAppScopedAdminAuthorizationRoutePluginAllowsEncodedAppGrantID(t *testing.T) {
 	t.Parallel()
 
 	req := &http.Request{URL: &url.URL{
-		Path:    "/admin/api/v1/authorization/fragments/app/github",
-		RawPath: "/admin/api/v1/authorization/fragments/app%2Fgithub",
+		Path:    "/admin/api/v1/authorization/grants/app/github",
+		RawPath: "/admin/api/v1/authorization/grants/app%2Fgithub",
 	}}
 
 	appName, ok := appScopedAdminAuthorizationRoutePlugin(req)

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -6128,7 +6128,7 @@ func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 		}},
 		Properties: mustStruct(t, map[string]any{"source": "provider"}),
 	})
-	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/fragments/"+url.PathEscape("app/sample_plugin"), nil)
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/grants/"+url.PathEscape("app/sample_plugin"), nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -6151,6 +6151,25 @@ func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 	}
 	if pluginFragmentResp.Relationships[0].Properties["source"] != "provider" {
 		t.Fatalf("plugin fragment properties = %#v, want provider source", pluginFragmentResp.Relationships[0].Properties)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/grants", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET grants: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("grants status = %d, want 200: %s", resp.StatusCode, respBody)
+	}
+	var grantsResp []coredata.AuthorizationDynamicFragment
+	if err := json.NewDecoder(resp.Body).Decode(&grantsResp); err != nil {
+		t.Fatalf("decoding grants response: %v", err)
+	}
+	if len(grantsResp) != 1 || grantsResp[0].ID != "app/sample_plugin" {
+		t.Fatalf("grants response = %#v, want dynamic app grant source only", grantsResp)
 	}
 
 	dynamicUser := seedUser(t, svc, "dynamic@example.test")
@@ -6326,7 +6345,7 @@ func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal fragment PUT body: %v", err)
 	}
-	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/fragments/"+url.PathEscape("app/sample_plugin"), bytes.NewReader(fragmentPutBody))
+	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/grants/"+url.PathEscape("app/sample_plugin"), bytes.NewReader(fragmentPutBody))
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 	resp, err = http.DefaultClient.Do(req)
@@ -6370,7 +6389,7 @@ func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 		t.Fatalf("expected 3 provider relationships after fragment PUT, got %d", len(relationshipsResp.Relationships))
 	}
 
-	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/admin/api/v1/authorization/fragments/"+url.PathEscape("app/sample_plugin"), nil)
+	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/admin/api/v1/authorization/grants/"+url.PathEscape("app/sample_plugin"), nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
## Description

Renames the dynamic authorization fragment APIs to `/admin/api/v1/authorization/grants`, keeping the response and writes scoped to dynamic grant source state.