### PR TITLE
[authorization] update CLI authz endpoints

### DIFF
--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -216,6 +216,11 @@ pub enum AuthorizationCommands {
         #[command(subcommand)]
         command: AuthorizationAppCommands,
     },
+    /// Manage dynamic authorization grant sources
+    Grants {
+        #[command(subcommand)]
+        command: AuthorizationGrantCommands,
+    },
     /// Inspect authorization models
     Models {
         #[command(subcommand)]
@@ -281,6 +286,34 @@ pub enum AuthorizationSubjectCommands {
     },
     /// Update a service-account subject
     Update(AuthorizationSubjectUpdateArgs),
+}
+
+#[derive(Subcommand)]
+pub enum AuthorizationGrantCommands {
+    /// Delete a dynamic authorization grant source
+    Delete {
+        /// Grant source ID, for example app/github
+        grant_id: String,
+    },
+    /// Show a dynamic authorization grant source
+    Get {
+        /// Grant source ID, for example app/github
+        grant_id: String,
+    },
+    /// List dynamic authorization grant sources
+    List,
+    /// Create or replace a dynamic authorization grant source from JSON
+    Put(AuthorizationGrantPutArgs),
+}
+
+#[derive(Args)]
+pub struct AuthorizationGrantPutArgs {
+    /// Grant source ID, for example app/github
+    pub grant_id: String,
+
+    /// JSON file containing the grant source body, or - for stdin
+    #[arg(long)]
+    pub file: String,
 }
 
 #[derive(Args)]

--- a/gestalt/cli/src/commands/authorization.rs
+++ b/gestalt/cli/src/commands/authorization.rs
@@ -7,14 +7,14 @@ use serde_json::{Map, Value, json};
 use crate::api::{ApiClient, encode_path_segment};
 use crate::cli::{
     AuthorizationAdminCommands, AuthorizationAdminMemberCommands, AuthorizationAppCommands,
-    AuthorizationAppMemberCommands, AuthorizationCommands, AuthorizationManagedSubjectRole,
-    AuthorizationModelCommands, AuthorizationPageArgs, AuthorizationProviderCommands,
-    AuthorizationRelationshipCommands, AuthorizationRelationshipListArgs,
-    AuthorizationSubjectCommands, AuthorizationSubjectCreateArgs,
-    AuthorizationSubjectExternalIdentityCommands, AuthorizationSubjectGrantCommands,
-    AuthorizationSubjectIntegrationCommands, AuthorizationSubjectMemberCommands,
-    AuthorizationSubjectTokenCommands, AuthorizationSubjectTokenCreateArgs,
-    AuthorizationSubjectUpdateArgs,
+    AuthorizationAppMemberCommands, AuthorizationCommands, AuthorizationGrantCommands,
+    AuthorizationGrantPutArgs, AuthorizationManagedSubjectRole, AuthorizationModelCommands,
+    AuthorizationPageArgs, AuthorizationProviderCommands, AuthorizationRelationshipCommands,
+    AuthorizationRelationshipListArgs, AuthorizationSubjectCommands,
+    AuthorizationSubjectCreateArgs, AuthorizationSubjectExternalIdentityCommands,
+    AuthorizationSubjectGrantCommands, AuthorizationSubjectIntegrationCommands,
+    AuthorizationSubjectMemberCommands, AuthorizationSubjectTokenCommands,
+    AuthorizationSubjectTokenCreateArgs, AuthorizationSubjectUpdateArgs,
 };
 use crate::commands::apps;
 use crate::output::{self, Format};
@@ -146,6 +146,16 @@ pub fn dispatch(client: &ApiClient, command: AuthorizationCommands, format: Form
                     remove_app_member(client, &app, &subject_id, format)
                 }
             },
+        },
+        AuthorizationCommands::Grants { command } => match command {
+            AuthorizationGrantCommands::List => list_authorization_grants(client, format),
+            AuthorizationGrantCommands::Get { grant_id } => {
+                get_authorization_grant(client, &grant_id, format)
+            }
+            AuthorizationGrantCommands::Put(args) => put_authorization_grant(client, &args, format),
+            AuthorizationGrantCommands::Delete { grant_id } => {
+                delete_authorization_grant(client, &grant_id, format)
+            }
         },
         AuthorizationCommands::Admins { command } => match command {
             AuthorizationAdminCommands::Members { command } => match command {
@@ -522,9 +532,78 @@ pub fn revoke_all_subject_tokens(client: &ApiClient, subject: &str, format: Form
     print_status(&resp, format, "Revoked all service account tokens.")
 }
 
+pub fn list_authorization_grants(client: &ApiClient, format: Format) -> Result<()> {
+    let resp = client
+        .get("/api/v1/authorization/grants")
+        .context("failed to list authorization grants")?;
+    print_array_response(
+        &resp,
+        format,
+        &["ID", "Owner", "Version", "Relationships"],
+        authorization_grant_source_row,
+    )
+}
+
+pub fn get_authorization_grant(client: &ApiClient, grant_id: &str, format: Format) -> Result<()> {
+    let resp = client
+        .get(&format!(
+            "/api/v1/authorization/grants/{}",
+            encode_path_segment(non_empty("grant_id", grant_id)?)
+        ))
+        .context("failed to get authorization grant")?;
+    print_single_response(
+        &resp,
+        format,
+        &["ID", "Owner", "Version", "Relationships"],
+        authorization_grant_source_row,
+    )
+}
+
+pub fn put_authorization_grant(
+    client: &ApiClient,
+    args: &AuthorizationGrantPutArgs,
+    format: Format,
+) -> Result<()> {
+    let body: Value = serde_json::from_str(&read_input(&args.file)?)
+        .with_context(|| format!("failed to parse grant JSON from {}", args.file))?;
+    let resp = client
+        .put(
+            &format!(
+                "/api/v1/authorization/grants/{}",
+                encode_path_segment(non_empty("grant_id", &args.grant_id)?)
+            ),
+            &body,
+        )
+        .context("failed to put authorization grant")?;
+    print_single_response(
+        &resp,
+        format,
+        &["ID", "Owner", "Version", "Relationships"],
+        authorization_grant_source_row,
+    )
+}
+
+pub fn delete_authorization_grant(
+    client: &ApiClient,
+    grant_id: &str,
+    format: Format,
+) -> Result<()> {
+    let resp = client
+        .delete(&format!(
+            "/api/v1/authorization/grants/{}",
+            encode_path_segment(non_empty("grant_id", grant_id)?)
+        ))
+        .context("failed to delete authorization grant")?;
+    print_status(
+        &resp,
+        format,
+        &format!("Deleted authorization grant {grant_id}."),
+    )
+}
+
 pub fn list_apps(client: &ApiClient, format: Format) -> Result<()> {
     let resp = client
-        .get("/admin/api/v1/authorization/apps")
+        .get("/api/v1/authorization/apps")
         .context("failed to list authorization apps")?;
     print_array_response(
         &resp,
@@ -537,7 +616,7 @@ pub fn list_apps(client: &ApiClient, format: Format) -> Result<()> {
 pub fn list_app_members(client: &ApiClient, app: &str, format: Format) -> Result<()> {
     let resp = client
         .get(&format!(
-            "/admin/api/v1/authorization/apps/{}/members",
+            "/api/v1/authorization/apps/{}/members",
             encode_path_segment(app)
         ))
         .context("failed to list app members")?;
@@ -562,7 +641,7 @@ pub fn set_app_member(
     let resp = client
         .put(
             &format!(
-                "/admin/api/v1/authorization/apps/{}/members",
+                "/api/v1/authorization/apps/{}/members",
                 encode_path_segment(app)
             ),
             &body,
@@ -580,7 +659,7 @@ pub fn remove_app_member(
     let subject_id = canonical_non_system_subject(subject_id)?;
     let resp = client
         .delete(&format!(
-            "/admin/api/v1/authorization/apps/{}/members/{}",
+            "/api/v1/authorization/apps/{}/members/{}",
             encode_path_segment(app),
             encode_path_segment(&subject_id)
         ))
@@ -590,7 +669,7 @@ pub fn remove_app_member(
 
 pub fn list_admin_members(client: &ApiClient, format: Format) -> Result<()> {
     let resp = client
-        .get("/admin/api/v1/authorization/admins/members")
+        .get("/api/v1/authorization/admins/members")
         .context("failed to list admin members")?;
     print_array_response(
         &resp,
@@ -610,7 +689,7 @@ pub fn set_admin_member(
     let mut body = subject_selector_body(subject_id, email)?;
     body.insert("role".to_string(), json!(non_empty("role", role)?));
     let resp = client
-        .put("/admin/api/v1/authorization/admins/members", &body)
+        .put("/api/v1/authorization/admins/members", &body)
         .context("failed to set admin member")?;
     print_admin_write_response(&resp, format)
 }
@@ -619,7 +698,7 @@ pub fn remove_admin_member(client: &ApiClient, subject_id: &str, format: Format)
     let subject_id = canonical_non_system_subject(subject_id)?;
     let resp = client
         .delete(&format!(
-            "/admin/api/v1/authorization/admins/members/{}",
+            "/api/v1/authorization/admins/members/{}",
             encode_path_segment(&subject_id)
         ))
         .context("failed to remove admin member")?;
@@ -632,14 +711,14 @@ pub fn remove_admin_member(client: &ApiClient, subject_id: &str, format: Format)
 
 pub fn get_provider(client: &ApiClient, format: Format) -> Result<()> {
     let resp = client
-        .get("/admin/api/v1/authorization/provider")
+        .get("/api/v1/authorization/provider")
         .context("failed to get authorization provider")?;
     print_response(&resp, format)
 }
 
 pub fn list_models(client: &ApiClient, args: &AuthorizationPageArgs, format: Format) -> Result<()> {
     let path = query::append_query(
-        "/admin/api/v1/authorization/models",
+        "/api/v1/authorization/models",
         &query::page_params(args.page_size, args.page_token.as_deref()),
     )?;
     let resp = client
@@ -676,7 +755,7 @@ pub fn list_relationships(
     query::push_opt_param(&mut params, "resourceType", args.resource_type.as_deref());
     query::push_opt_param(&mut params, "resourceId", args.resource_id.as_deref());
     query::push_opt_param(&mut params, "modelId", args.model_id.as_deref());
-    let path = query::append_query("/admin/api/v1/authorization/relationships", &params)?;
+    let path = query::append_query("/api/v1/authorization/relationships", &params)?;
     let resp = client
         .get(&path)
         .context("failed to list authorization relationships")?;
@@ -883,7 +962,7 @@ fn read_input(path: &str) -> Result<String> {
         let mut input = String::new();
         std::io::stdin()
             .read_to_string(&mut input)
-            .context("failed to read permissions from stdin")?;
+            .context("failed to read stdin")?;
         return Ok(input);
     }
     std::fs::read_to_string(path).with_context(|| format!("failed to read {path}"))
@@ -1027,6 +1106,31 @@ fn grant_row(item: &Value) -> Vec<String> {
         string_cell(item, "source"),
         bool_cell(item, "mutable"),
     ]
+}
+
+fn authorization_grant_source_row(item: &Value) -> Vec<String> {
+    vec![
+        string_cell(item, "id"),
+        authorization_grant_owner_cell(item.get("owner")),
+        number_cell(item, "version"),
+        item["relationships"]
+            .as_array()
+            .map(|items| items.len().to_string())
+            .unwrap_or_else(|| "-".to_string()),
+    ]
+}
+
+fn authorization_grant_owner_cell(value: Option<&Value>) -> String {
+    let Some(value) = value else {
+        return "-".to_string();
+    };
+    let kind = string_cell(value, "kind");
+    match kind.as_str() {
+        "app" => format!("app:{}", string_cell(value, "app")),
+        "global" => "global".to_string(),
+        "-" => "-".to_string(),
+        _ => kind,
+    }
 }
 
 fn external_identity_row(item: &Value) -> Vec<String> {
@@ -1186,5 +1290,14 @@ fn bool_cell(item: &Value, key: &str) -> String {
     item.get(key)
         .and_then(Value::as_bool)
         .map(|value| value.to_string())
+        .unwrap_or_else(|| "-".to_string())
+}
+
+fn number_cell(item: &Value, key: &str) -> String {
+    item[key]
+        .as_i64()
+        .map(|value| value.to_string())
+        .or_else(|| item[key].as_u64().map(|value| value.to_string()))
+        .or_else(|| item[key].as_f64().map(|value| value.to_string()))
         .unwrap_or_else(|| "-".to_string())
 }

--- a/gestalt/cli/src/commands/authorization.rs
+++ b/gestalt/cli/src/commands/authorization.rs
@@ -575,12 +575,7 @@ pub fn put_authorization_grant(
             &body,
         )
         .context("failed to put authorization grant")?;
-    print_single_response(
-        &resp,
-        format,
-        &["ID", "Owner", "Version", "Relationships"],
-        authorization_grant_source_row,
-    )
+    print_authorization_grant_write_response(&resp, format)
 }
 
 pub fn delete_authorization_grant(
@@ -1068,6 +1063,35 @@ fn print_grant_write_response(resp: &Value, format: Format) -> Result<()> {
                     Format::Table,
                     &["App", "Role", "Source", "Mutable"],
                     grant_row,
+                )?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn print_authorization_grant_write_response(resp: &Value, format: Format) -> Result<()> {
+    match format {
+        Format::Json => output::print_json(resp),
+        Format::Table => {
+            if resp["reloaded"].as_bool() == Some(false) {
+                output::print_warning(
+                    "Grant persisted, but the local authorization snapshot has not reloaded yet.",
+                );
+            }
+            if let Some(fragment) = resp.get("fragment") {
+                print_single_response(
+                    fragment,
+                    Format::Table,
+                    &["ID", "Owner", "Version", "Relationships"],
+                    authorization_grant_source_row,
+                )?;
+            } else {
+                print_single_response(
+                    resp,
+                    Format::Table,
+                    &["ID", "Owner", "Version", "Relationships"],
+                    authorization_grant_source_row,
                 )?;
             }
         }

--- a/gestalt/cli/tests/authorization_cli.rs
+++ b/gestalt/cli/tests/authorization_cli.rs
@@ -314,6 +314,50 @@ fn test_cli_authorization_grants_put_reads_json_file() {
 }
 
 #[test]
+fn test_cli_authorization_grants_put_surfaces_pending_reload_fragment() {
+    let mut server = Server::new();
+    let mock = authed_json_mock!(
+        server,
+        Method::PUT,
+        "/api/v1/authorization/grants/app%2Fgithub",
+        StatusCode::ACCEPTED
+    )
+    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+    .match_body(Matcher::JsonString(
+        r#"{"id":"app/github","owner":{"kind":"app","app":"github"},"version":4,"resourceTypes":{},"relationships":[]}"#.to_string(),
+    ))
+    .with_body(
+        r#"{"status":"persisted_pending_reload","persisted":true,"reloaded":false,"fragment":{"id":"app/github","owner":{"kind":"app","app":"github"},"version":4,"relationships":[],"resourceTypes":{}}}"#,
+    )
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    let grant_file = home.path().join("grant.json");
+    std::fs::write(
+        &grant_file,
+        r#"{"id":"app/github","owner":{"kind":"app","app":"github"},"version":4,"resourceTypes":{},"relationships":[]}"#,
+    )
+    .unwrap();
+
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "authz",
+            "grants",
+            "put",
+            "app/github",
+            "--file",
+            grant_file.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("app/github"))
+        .stdout(predicate::str::contains("app:github"))
+        .stderr(predicate::str::contains("snapshot has not reloaded"));
+
+    mock.assert();
+}
+
+#[test]
 fn test_cli_authorization_grants_delete_encodes_grant_id() {
     let mut server = Server::new();
     let mock = authed_json_mock!(

--- a/gestalt/cli/tests/authorization_cli.rs
+++ b/gestalt/cli/tests/authorization_cli.rs
@@ -224,6 +224,125 @@ fn test_cli_authorization_subjects_grants_set_surfaces_pending_reload() {
 }
 
 #[test]
+fn test_cli_authorization_grants_list_uses_public_api() {
+    let mut server = Server::new();
+    let mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/authorization/grants",
+        StatusCode::OK
+    )
+    .with_body(
+        r#"[{"id":"app/github","owner":{"kind":"app","app":"github"},"version":3,"relationships":[],"resourceTypes":{}}]"#,
+    )
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args(["authz", "grants", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("app/github"));
+
+    mock.assert();
+}
+
+#[test]
+fn test_cli_authorization_grants_get_encodes_grant_id() {
+    let mut server = Server::new();
+    let mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/authorization/grants/app%2Fgithub",
+        StatusCode::OK
+    )
+    .with_body(
+        r#"{"id":"app/github","owner":{"kind":"app","app":"github"},"version":3,"relationships":[],"resourceTypes":{}}"#,
+    )
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args(["authz", "grants", "get", "app/github"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("app/github"));
+
+    mock.assert();
+}
+
+#[test]
+fn test_cli_authorization_grants_put_reads_json_file() {
+    let mut server = Server::new();
+    let mock = authed_json_mock!(
+        server,
+        Method::PUT,
+        "/api/v1/authorization/grants/app%2Fgithub",
+        StatusCode::OK
+    )
+    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+    .match_body(Matcher::JsonString(
+        r#"{"id":"app/github","owner":{"kind":"app","app":"github"},"version":4,"resourceTypes":{},"relationships":[]}"#.to_string(),
+    ))
+    .with_body(
+        r#"{"id":"app/github","owner":{"kind":"app","app":"github"},"version":4,"relationships":[],"resourceTypes":{}}"#,
+    )
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    let grant_file = home.path().join("grant.json");
+    std::fs::write(
+        &grant_file,
+        r#"{"id":"app/github","owner":{"kind":"app","app":"github"},"version":4,"resourceTypes":{},"relationships":[]}"#,
+    )
+    .unwrap();
+
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "authz",
+            "grants",
+            "put",
+            "app/github",
+            "--file",
+            grant_file.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("app/github"));
+
+    mock.assert();
+}
+
+#[test]
+fn test_cli_authorization_grants_delete_encodes_grant_id() {
+    let mut server = Server::new();
+    let mock = authed_json_mock!(
+        server,
+        Method::DELETE,
+        "/api/v1/authorization/grants/app%2Fgithub",
+        StatusCode::OK
+    )
+    .with_body(r#"{"status":"deleted","persisted":true,"reloaded":true}"#)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "--format",
+            "json",
+            "authz",
+            "grants",
+            "delete",
+            "app/github",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("deleted"));
+
+    mock.assert();
+}
+
+#[test]
 fn test_cli_authorization_subjects_tokens_list_table_shows_permissions() {
     let mut server = Server::new();
     let mock = authed_json_mock!(
@@ -255,7 +374,7 @@ fn test_cli_authorization_apps_members_set_uses_management_api() {
     let mock = authed_json_mock!(
         server,
         Method::PUT,
-        "/admin/api/v1/authorization/apps/github/members",
+        "/api/v1/authorization/apps/github/members",
         StatusCode::OK
     )
     .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
@@ -295,7 +414,7 @@ fn test_cli_authorization_relationships_list_maps_debug_filters() {
     let mock = authed_json_mock!(
         server,
         Method::GET,
-        "/admin/api/v1/authorization/relationships?pageSize=10&pageToken=next&subjectType=subject&subjectId=user%3Aalice&relation=viewer&resourceType=app_dynamic&resourceId=github&modelId=model-1",
+        "/api/v1/authorization/relationships?pageSize=10&pageToken=next&subjectType=subject&subjectId=user%3Aalice&relation=viewer&resourceType=app_dynamic&resourceId=github&modelId=model-1",
         StatusCode::OK
     )
     .with_body(

--- a/gestaltd/internal/server/handlers_admin_authorization.go
+++ b/gestaltd/internal/server/handlers_admin_authorization.go
@@ -131,8 +131,8 @@ func appScopedAdminAuthorizationRoutePlugin(r *http.Request) (string, bool) {
 	switch {
 	case strings.HasPrefix(path, "/authorization/apps/"):
 		rest = strings.TrimPrefix(path, "/authorization/apps/")
-	case strings.HasPrefix(path, "/admin/api/v1/authorization/apps/"):
-		rest = strings.TrimPrefix(path, "/admin/api/v1/authorization/apps/")
+	case strings.HasPrefix(path, "/api/v1/authorization/apps/"):
+		rest = strings.TrimPrefix(path, "/api/v1/authorization/apps/")
 	default:
 		return "", false
 	}
@@ -162,8 +162,8 @@ func adminAuthorizationGrantRoutePlugin(path string) (string, bool) {
 	switch {
 	case strings.HasPrefix(path, "/authorization/grants/"):
 		rest = strings.TrimPrefix(path, "/authorization/grants/")
-	case strings.HasPrefix(path, "/admin/api/v1/authorization/grants/"):
-		rest = strings.TrimPrefix(path, "/admin/api/v1/authorization/grants/")
+	case strings.HasPrefix(path, "/api/v1/authorization/grants/"):
+		rest = strings.TrimPrefix(path, "/api/v1/authorization/grants/")
 	default:
 		return "", false
 	}

--- a/gestaltd/internal/server/handlers_admin_authorization_provider_write_test.go
+++ b/gestaltd/internal/server/handlers_admin_authorization_provider_write_test.go
@@ -113,7 +113,7 @@ func TestAdminAPI_DeletePluginMemberRemovesPersistedDynamicFragmentAcrossReload(
 	assertSubjectStatus("before grant", http.StatusForbidden)
 
 	body := bytes.NewBufferString(fmt.Sprintf(`{"subjectId":%q,"role":"viewer"}`, subjectID))
-	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/apps/sample_plugin/members", body)
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/api/v1/authorization/apps/sample_plugin/members", body)
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 	resp, err := http.DefaultClient.Do(req)
@@ -135,7 +135,7 @@ func TestAdminAPI_DeletePluginMemberRemovesPersistedDynamicFragmentAcrossReload(
 		t.Fatalf("fragment after grant = %#v, want one dynamic candidate relationship", fragment.Relationships)
 	}
 
-	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/admin/api/v1/authorization/apps/sample_plugin/members/"+url.PathEscape(subjectID), nil)
+	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/authorization/apps/sample_plugin/members/"+url.PathEscape(subjectID), nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {

--- a/gestaltd/internal/server/handlers_admin_authorization_test.go
+++ b/gestaltd/internal/server/handlers_admin_authorization_test.go
@@ -10,8 +10,8 @@ func TestAppScopedAdminAuthorizationRoutePluginAllowsEncodedAppGrantID(t *testin
 	t.Parallel()
 
 	req := &http.Request{URL: &url.URL{
-		Path:    "/admin/api/v1/authorization/grants/app/github",
-		RawPath: "/admin/api/v1/authorization/grants/app%2Fgithub",
+		Path:    "/api/v1/authorization/grants/app/github",
+		RawPath: "/api/v1/authorization/grants/app%2Fgithub",
 	}}
 
 	appName, ok := appScopedAdminAuthorizationRoutePlugin(req)

--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -31,6 +31,7 @@ func (s *Server) routes() {
 	case RouteProfileManagement:
 		s.mountCoreRoutes(r, metricsUnauthenticated)
 		s.mountManagementRootRedirect(r)
+		s.mountAdminAuthorizationAPIRoutes(r)
 		s.mountAdminAPIRoutes(r)
 		s.mountAdminUIRoutes(r)
 	default:
@@ -95,7 +96,6 @@ func (s *Server) mountAdminAPIRoutes(r chi.Router) {
 			r.Use(s.adminAPIAuthMiddleware)
 		}
 		s.mountAdminRuntimeRoutes(r)
-		s.mountAdminAuthorizationRoutes(r)
 	})
 }
 
@@ -175,8 +175,25 @@ func (s *Server) mountAPIRoutes(r chi.Router) {
 			s.mountProviderDevPublicRoutes(r)
 			s.mountAuthenticatedRoutes(r)
 		})
+		s.mountAdminAuthorizationAPIRoutesInGroup(r)
 		r.NotFound(apiNotFound)
 		r.MethodNotAllowed(apiMethodNotAllowed)
+	})
+}
+
+func (s *Server) mountAdminAuthorizationAPIRoutes(r chi.Router) {
+	r.Route("/api/v1", func(r chi.Router) {
+		s.mountAdminAuthorizationAPIRoutesInGroup(r)
+	})
+}
+
+func (s *Server) mountAdminAuthorizationAPIRoutesInGroup(r chi.Router) {
+	r.Group(func(r chi.Router) {
+		r.Use(middleware.Timeout(60 * time.Second))
+		if s.adminRoute.AuthorizationPolicy != "" {
+			r.Use(s.adminAPIAuthMiddleware)
+		}
+		s.mountAdminAuthorizationRoutes(r)
 	})
 }
 

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -4082,8 +4082,8 @@ func TestBuiltInAdminRoute_EmbeddedAdminUIIncludesAuthorizationWorkspace(t *test
 		`data-tab-panel="authorization"`,
 		`data-tab="admins"`,
 		`data-tab-panel="admins"`,
-		"/admin/api/v1/authorization/apps",
-		"/admin/api/v1/authorization/admins/members",
+		"/api/v1/authorization/apps",
+		"/api/v1/authorization/admins/members",
 		`window.__gestaltAdminShell.loginBase = "/api/v1/auth/login"`,
 		"Save dynamic grant",
 		"Save admin grant",
@@ -4387,7 +4387,7 @@ func TestAdminAPI_HumanAuthorization(t *testing.T) {
 	})
 	testutil.CloseOnCleanup(t, ts)
 
-	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/apps", nil)
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/authorization/apps", nil)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("GET admin api without auth: %v", err)
@@ -4397,7 +4397,7 @@ func TestAdminAPI_HumanAuthorization(t *testing.T) {
 		t.Fatalf("unauthenticated admin api status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
 	}
 
-	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/apps", nil)
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/authorization/apps", nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "viewer-session"})
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
@@ -4408,7 +4408,7 @@ func TestAdminAPI_HumanAuthorization(t *testing.T) {
 		t.Fatalf("viewer admin api status = %d, want %d", resp.StatusCode, http.StatusForbidden)
 	}
 
-	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/admins/members", nil)
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/authorization/admins/members", nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "dynamic-admin-session"})
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
@@ -4423,7 +4423,7 @@ func TestAdminAPI_HumanAuthorization(t *testing.T) {
 		t.Fatalf("dynamic admin can-write header = %q, want true", got)
 	}
 
-	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/apps", nil)
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/authorization/apps", nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
@@ -4443,7 +4443,7 @@ func TestAdminAPI_HumanAuthorization(t *testing.T) {
 		t.Fatalf("apps = %+v, want double escaped, escaped, slash, other_plugin, and sample_plugin", apps)
 	}
 
-	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/apps/sample_plugin/members", nil)
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/authorization/apps/sample_plugin/members", nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "plugin-admin-session"})
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
@@ -4456,7 +4456,7 @@ func TestAdminAPI_HumanAuthorization(t *testing.T) {
 	}
 
 	body := bytes.NewBufferString(fmt.Sprintf(`{"subjectId":%q,"role":"viewer"}`, principal.UserSubjectID(dynamicUser.ID)))
-	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/apps/sample_plugin/members", body)
+	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/api/v1/authorization/apps/sample_plugin/members", body)
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "plugin-admin-session"})
 	resp, err = http.DefaultClient.Do(req)
@@ -4469,7 +4469,7 @@ func TestAdminAPI_HumanAuthorization(t *testing.T) {
 		t.Fatalf("plugin admin put app member status = %d, want 200: %s", resp.StatusCode, respBody)
 	}
 
-	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/admin/api/v1/authorization/apps/sample_plugin/members/"+url.PathEscape(principal.UserSubjectID(dynamicUser.ID)), nil)
+	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/authorization/apps/sample_plugin/members/"+url.PathEscape(principal.UserSubjectID(dynamicUser.ID)), nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "plugin-admin-session"})
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
@@ -4481,7 +4481,7 @@ func TestAdminAPI_HumanAuthorization(t *testing.T) {
 		t.Fatalf("plugin admin delete app member status = %d, want 200: %s", resp.StatusCode, respBody)
 	}
 
-	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/apps/a%252Fb/members", nil)
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/authorization/apps/a%252Fb/members", nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "escaped-plugin-admin-session"})
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
@@ -4498,11 +4498,11 @@ func TestAdminAPI_HumanAuthorization(t *testing.T) {
 		session string
 		path    string
 	}{
-		{name: "plugin admin cannot manage other plugin", session: "plugin-admin-session", path: "/admin/api/v1/authorization/apps/other_plugin/members"},
-		{name: "plugin viewer cannot manage plugin", session: "plugin-viewer-session", path: "/admin/api/v1/authorization/apps/sample_plugin/members"},
-		{name: "escaped slash path does not authorize slash plugin", session: "slash-plugin-admin-session", path: "/admin/api/v1/authorization/apps/a%2Fb/members"},
-		{name: "double escaped app admin cannot manage escaped plugin", session: "double-escaped-plugin-admin-session", path: "/admin/api/v1/authorization/apps/a%252Fb/members"},
-		{name: "plugin admin cannot manage gestaltd admins", session: "plugin-admin-session", path: "/admin/api/v1/authorization/admins/members"},
+		{name: "plugin admin cannot manage other plugin", session: "plugin-admin-session", path: "/api/v1/authorization/apps/other_plugin/members"},
+		{name: "plugin viewer cannot manage plugin", session: "plugin-viewer-session", path: "/api/v1/authorization/apps/sample_plugin/members"},
+		{name: "escaped slash path does not authorize slash plugin", session: "slash-plugin-admin-session", path: "/api/v1/authorization/apps/a%2Fb/members"},
+		{name: "double escaped app admin cannot manage escaped plugin", session: "double-escaped-plugin-admin-session", path: "/api/v1/authorization/apps/a%252Fb/members"},
+		{name: "plugin admin cannot manage gestaltd admins", session: "plugin-admin-session", path: "/api/v1/authorization/admins/members"},
 	} {
 		req, _ = http.NewRequest(http.MethodGet, ts.URL+tc.path, nil)
 		req.AddCookie(&http.Cookie{Name: "session_token", Value: tc.session})
@@ -4529,7 +4529,7 @@ func TestAdminAPI_RoutesMountedWithoutAdminUI(t *testing.T) {
 	})
 	testutil.CloseOnCleanup(t, ts)
 
-	resp, err := http.Get(ts.URL + "/admin/api/v1/authorization/apps")
+	resp, err := http.Get(ts.URL + "/api/v1/authorization/apps")
 	if err != nil {
 		t.Fatalf("GET admin api without admin ui: %v", err)
 	}
@@ -5095,7 +5095,7 @@ func TestAdminAPI_HumanAuthorizationOnManagementProfile(t *testing.T) {
 	})
 	testutil.CloseOnCleanup(t, ts)
 
-	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/admins/members", nil)
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/authorization/admins/members", nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "dynamic-admin-session"})
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -5107,7 +5107,7 @@ func TestAdminAPI_HumanAuthorizationOnManagementProfile(t *testing.T) {
 		t.Fatalf("management dynamic admin api status = %d, want 200: %s", resp.StatusCode, body)
 	}
 
-	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/apps", nil)
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/authorization/apps", nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
@@ -5168,7 +5168,7 @@ func TestAdminAPI_HumanAuthorization_UserResolutionFailure(t *testing.T) {
 	stubDB.Err = fmt.Errorf("database unavailable")
 	defer func() { stubDB.Err = nil }()
 
-	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/apps", nil)
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/authorization/apps", nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -5181,7 +5181,7 @@ func TestAdminAPI_HumanAuthorization_UserResolutionFailure(t *testing.T) {
 	}
 }
 
-func TestAdminAPIRoutes_HiddenOnPublicProfile(t *testing.T) {
+func TestAdminAPIRoutes_OldAdminPrefixHiddenOnPublicProfile(t *testing.T) {
 	t.Parallel()
 
 	ts := newTestServer(t, func(cfg *server.Config) {
@@ -5197,11 +5197,11 @@ func TestAdminAPIRoutes_HiddenOnPublicProfile(t *testing.T) {
 
 	resp, err := http.Get(ts.URL + "/admin/api/v1/authorization/apps")
 	if err != nil {
-		t.Fatalf("GET public admin api: %v", err)
+		t.Fatalf("GET old public admin api: %v", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusNotFound {
-		t.Fatalf("public admin api status = %d, want %d", resp.StatusCode, http.StatusNotFound)
+		t.Fatalf("old public admin api status = %d, want %d", resp.StatusCode, http.StatusNotFound)
 	}
 }
 
@@ -5241,7 +5241,7 @@ func TestAdminAPI_PluginAuthorizationCRUD(t *testing.T) {
 	})
 	testutil.CloseOnCleanup(t, ts)
 
-	resp, err := http.Get(ts.URL + "/admin/api/v1/authorization/apps")
+	resp, err := http.Get(ts.URL + "/api/v1/authorization/apps")
 	if err != nil {
 		t.Fatalf("GET apps: %v", err)
 	}
@@ -5268,7 +5268,7 @@ func TestAdminAPI_PluginAuthorizationCRUD(t *testing.T) {
 
 	dynamicEmail := "dynamic@example.test"
 	body := bytes.NewBufferString(fmt.Sprintf(`{"email":%q,"role":"viewer"}`, dynamicEmail))
-	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/apps/sample_plugin/members", body)
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/api/v1/authorization/apps/sample_plugin/members", body)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
@@ -5306,7 +5306,7 @@ func TestAdminAPI_PluginAuthorizationCRUD(t *testing.T) {
 
 	serviceAccountSubjectID := "service_account:reporting-bot"
 	body = bytes.NewBufferString(fmt.Sprintf(`{"subjectId":%q,"role":"viewer"}`, serviceAccountSubjectID))
-	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/apps/sample_plugin/members", body)
+	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/api/v1/authorization/apps/sample_plugin/members", body)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
@@ -5338,7 +5338,7 @@ func TestAdminAPI_PluginAuthorizationCRUD(t *testing.T) {
 		t.Fatalf("service account membership email = %q, want empty", putServiceAccountMembershipResp.Membership.Email)
 	}
 
-	resp, err = http.Get(ts.URL + "/admin/api/v1/authorization/apps/sample_plugin/members")
+	resp, err = http.Get(ts.URL + "/api/v1/authorization/apps/sample_plugin/members")
 	if err != nil {
 		t.Fatalf("GET members: %v", err)
 	}
@@ -5390,7 +5390,7 @@ func TestAdminAPI_PluginAuthorizationCRUD(t *testing.T) {
 	}
 
 	body = bytes.NewBufferString(`{"email":"static@example.test","role":"viewer"}`)
-	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/apps/sample_plugin/members", body)
+	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/api/v1/authorization/apps/sample_plugin/members", body)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
@@ -5402,7 +5402,7 @@ func TestAdminAPI_PluginAuthorizationCRUD(t *testing.T) {
 		t.Fatalf("put static-conflict status = %d, want 409: %s", resp.StatusCode, respBody)
 	}
 
-	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/admin/api/v1/authorization/apps/sample_plugin/members/"+url.PathEscape(principal.UserSubjectID(dynamicUser.ID)), nil)
+	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/authorization/apps/sample_plugin/members/"+url.PathEscape(principal.UserSubjectID(dynamicUser.ID)), nil)
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("DELETE dynamic member: %v", err)
@@ -5413,7 +5413,7 @@ func TestAdminAPI_PluginAuthorizationCRUD(t *testing.T) {
 		t.Fatalf("delete dynamic member status = %d, want 200: %s", resp.StatusCode, respBody)
 	}
 
-	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/admin/api/v1/authorization/apps/sample_plugin/members/"+url.PathEscape(serviceAccountSubjectID), nil)
+	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/authorization/apps/sample_plugin/members/"+url.PathEscape(serviceAccountSubjectID), nil)
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("DELETE service account member: %v", err)
@@ -5424,7 +5424,7 @@ func TestAdminAPI_PluginAuthorizationCRUD(t *testing.T) {
 		t.Fatalf("delete service account member status = %d, want 200: %s", resp.StatusCode, respBody)
 	}
 
-	resp, err = http.Get(ts.URL + "/admin/api/v1/authorization/apps/sample_plugin/members")
+	resp, err = http.Get(ts.URL + "/api/v1/authorization/apps/sample_plugin/members")
 	if err != nil {
 		t.Fatalf("GET members after delete: %v", err)
 	}
@@ -6128,7 +6128,7 @@ func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 		}},
 		Properties: mustStruct(t, map[string]any{"source": "provider"}),
 	})
-	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/grants/"+url.PathEscape("app/sample_plugin"), nil)
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/authorization/grants/"+url.PathEscape("app/sample_plugin"), nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -6153,7 +6153,7 @@ func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 		t.Fatalf("plugin fragment properties = %#v, want provider source", pluginFragmentResp.Relationships[0].Properties)
 	}
 
-	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/grants", nil)
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/authorization/grants", nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
@@ -6174,7 +6174,7 @@ func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 
 	dynamicUser := seedUser(t, svc, "dynamic@example.test")
 	body := bytes.NewBufferString(fmt.Sprintf(`{"subjectId":%q,"role":"viewer"}`, principal.UserSubjectID(dynamicUser.ID)))
-	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/apps/sample_plugin/members", body)
+	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/api/v1/authorization/apps/sample_plugin/members", body)
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 	resp, err = http.DefaultClient.Do(req)
@@ -6208,7 +6208,7 @@ func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 		t.Fatalf("ReloadAuthorizationState after provider-backed app write: %v", err)
 	}
 
-	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/apps/sample_plugin/members", nil)
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/authorization/apps/sample_plugin/members", nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
@@ -6237,7 +6237,7 @@ func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 		t.Fatalf("members = %+v, want target-only direct subject %q", members, rawSubjectID)
 	}
 
-	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/provider", nil)
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/authorization/provider", nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
@@ -6262,7 +6262,7 @@ func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 		t.Fatal("expected active model id")
 	}
 
-	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/models", nil)
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/authorization/models", nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
@@ -6295,7 +6295,7 @@ func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 		t.Fatalf("models response = %+v, want active model %q to be listed", modelsResp.Models, providerSummary.ActiveModelID)
 	}
 
-	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/relationships?resourceType=app_dynamic&resourceId=sample_plugin", nil)
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/authorization/relationships?resourceType=app_dynamic&resourceId=sample_plugin", nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
@@ -6345,7 +6345,7 @@ func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal fragment PUT body: %v", err)
 	}
-	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/grants/"+url.PathEscape("app/sample_plugin"), bytes.NewReader(fragmentPutBody))
+	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/api/v1/authorization/grants/"+url.PathEscape("app/sample_plugin"), bytes.NewReader(fragmentPutBody))
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 	resp, err = http.DefaultClient.Do(req)
@@ -6365,7 +6365,7 @@ func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 		t.Fatalf("plugin fragment PUT response has %d relationships, want 3", len(fragmentPutResp.Relationships))
 	}
 
-	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/relationships?resourceType=app_dynamic&resourceId=sample_plugin", nil)
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/authorization/relationships?resourceType=app_dynamic&resourceId=sample_plugin", nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
@@ -6389,7 +6389,7 @@ func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 		t.Fatalf("expected 3 provider relationships after fragment PUT, got %d", len(relationshipsResp.Relationships))
 	}
 
-	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/admin/api/v1/authorization/grants/"+url.PathEscape("app/sample_plugin"), nil)
+	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/authorization/grants/"+url.PathEscape("app/sample_plugin"), nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
@@ -6410,7 +6410,7 @@ func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 		t.Fatal("plugin fragment DELETE response reloaded = false, want true")
 	}
 
-	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/relationships?resourceType=app_dynamic&resourceId=sample_plugin", nil)
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/authorization/relationships?resourceType=app_dynamic&resourceId=sample_plugin", nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
@@ -6472,9 +6472,9 @@ func TestAdminAPI_AuthorizationProviderDebugRequiresAdminPolicy(t *testing.T) {
 	testutil.CloseOnCleanup(t, ts)
 
 	paths := []string{
-		"/admin/api/v1/authorization/provider",
-		"/admin/api/v1/authorization/models",
-		"/admin/api/v1/authorization/relationships",
+		"/api/v1/authorization/provider",
+		"/api/v1/authorization/models",
+		"/api/v1/authorization/relationships",
 	}
 	for _, path := range paths {
 		resp, err := http.Get(ts.URL + path)
@@ -6533,7 +6533,7 @@ func TestAdminAPI_AdminAuthorizationCRUD(t *testing.T) {
 	})
 	testutil.CloseOnCleanup(t, ts)
 
-	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/admins/members", nil)
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/authorization/admins/members", nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -6555,7 +6555,7 @@ func TestAdminAPI_AdminAuthorizationCRUD(t *testing.T) {
 
 	dynamicAdminEmail := "dynamic-admin@example.test"
 	body := bytes.NewBufferString(fmt.Sprintf(`{"email":%q,"role":"owner"}`, dynamicAdminEmail))
-	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/admins/members", body)
+	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/api/v1/authorization/admins/members", body)
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 	resp, err = http.DefaultClient.Do(req)
@@ -6602,7 +6602,7 @@ func TestAdminAPI_AdminAuthorizationCRUD(t *testing.T) {
 		t.Fatalf("admin fragment role = %q, want owner", got)
 	}
 
-	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/admins/members", nil)
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/authorization/admins/members", nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
@@ -6640,7 +6640,7 @@ func TestAdminAPI_AdminAuthorizationCRUD(t *testing.T) {
 	}
 
 	body = bytes.NewBufferString(`{"email":"static-admin@example.test","role":"owner"}`)
-	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/admins/members", body)
+	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/api/v1/authorization/admins/members", body)
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 	resp, err = http.DefaultClient.Do(req)
@@ -6654,7 +6654,7 @@ func TestAdminAPI_AdminAuthorizationCRUD(t *testing.T) {
 	}
 
 	body = bytes.NewBufferString(fmt.Sprintf(`{"subjectId":%q,"role":"operator"}`, principal.UserSubjectID(dynamicAdmin.ID)))
-	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/admins/members", body)
+	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/api/v1/authorization/admins/members", body)
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 	resp, err = http.DefaultClient.Do(req)
@@ -6674,7 +6674,7 @@ func TestAdminAPI_AdminAuthorizationCRUD(t *testing.T) {
 		t.Fatalf("admin fragment after role change = %#v, want single operator relationship", adminFragment.Relationships)
 	}
 
-	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/admin/api/v1/authorization/admins/members/"+url.PathEscape(principal.UserSubjectID(dynamicAdmin.ID)), nil)
+	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/authorization/admins/members/"+url.PathEscape(principal.UserSubjectID(dynamicAdmin.ID)), nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
@@ -6686,7 +6686,7 @@ func TestAdminAPI_AdminAuthorizationCRUD(t *testing.T) {
 		t.Fatalf("delete admin member status = %d, want 200: %s", resp.StatusCode, respBody)
 	}
 
-	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/admins/members", nil)
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/authorization/admins/members", nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
@@ -6751,7 +6751,7 @@ func TestAdminAPI_AdminAuthorizationProviderBackedReads(t *testing.T) {
 
 	dynamicAdmin := seedUser(t, svc, "dynamic-admin@example.test")
 	body := bytes.NewBufferString(fmt.Sprintf(`{"subjectId":%q,"role":"owner"}`, principal.UserSubjectID(dynamicAdmin.ID)))
-	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/admins/members", body)
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/api/v1/authorization/admins/members", body)
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 	resp, err := http.DefaultClient.Do(req)
@@ -6768,7 +6768,7 @@ func TestAdminAPI_AdminAuthorizationProviderBackedReads(t *testing.T) {
 		t.Fatalf("ReloadAuthorizationState after provider-backed admin write: %v", err)
 	}
 
-	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/admins/members", nil)
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/authorization/admins/members", nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
@@ -6843,7 +6843,7 @@ func TestAdminAPI_ProviderBackedWritesUseDynamicFragmentSource(t *testing.T) {
 
 		dynamicUser := seedUser(t, svc, "dynamic@example.test")
 		body := bytes.NewBufferString(fmt.Sprintf(`{"subjectId":%q,"role":"viewer"}`, principal.UserSubjectID(dynamicUser.ID)))
-		req, _ := http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/apps/sample_plugin/members", body)
+		req, _ := http.NewRequest(http.MethodPut, ts.URL+"/api/v1/authorization/apps/sample_plugin/members", body)
 		req.Header.Set("Content-Type", "application/json")
 		req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 		resp, err := http.DefaultClient.Do(req)
@@ -6901,7 +6901,7 @@ func TestAdminAPI_ProviderBackedWritesUseDynamicFragmentSource(t *testing.T) {
 
 		dynamicAdmin := seedUser(t, svc, "dynamic-admin@example.test")
 		body := bytes.NewBufferString(fmt.Sprintf(`{"subjectId":%q,"role":"operator"}`, principal.UserSubjectID(dynamicAdmin.ID)))
-		req, _ := http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/admins/members", body)
+		req, _ := http.NewRequest(http.MethodPut, ts.URL+"/api/v1/authorization/admins/members", body)
 		req.Header.Set("Content-Type", "application/json")
 		req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 		resp, err := http.DefaultClient.Do(req)
@@ -6964,7 +6964,7 @@ func TestAdminAPI_AdminAuthorizationWriteUsesAllowedAdminRoles(t *testing.T) {
 	})
 	testutil.CloseOnCleanup(t, ts)
 
-	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/admins/members", nil)
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/authorization/admins/members", nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "ops-admin-session"})
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -6981,7 +6981,7 @@ func TestAdminAPI_AdminAuthorizationWriteUsesAllowedAdminRoles(t *testing.T) {
 
 	viewer := seedUser(t, svc, "viewer@example.test")
 	body := bytes.NewBufferString(fmt.Sprintf(`{"subjectId":%q,"role":"ops-admin"}`, principal.UserSubjectID(viewer.ID)))
-	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/admins/members", body)
+	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/api/v1/authorization/admins/members", body)
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "ops-admin-session"})
 	resp, err = http.DefaultClient.Do(req)
@@ -6994,7 +6994,7 @@ func TestAdminAPI_AdminAuthorizationWriteUsesAllowedAdminRoles(t *testing.T) {
 		t.Fatalf("ops-admin put admin member status = %d, want 200: %s", resp.StatusCode, respBody)
 	}
 
-	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/admin/api/v1/authorization/admins/members/"+url.PathEscape(principal.UserSubjectID(viewer.ID)), nil)
+	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/authorization/admins/members/"+url.PathEscape(principal.UserSubjectID(viewer.ID)), nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "ops-admin-session"})
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
@@ -7060,9 +7060,9 @@ func TestAdminAPI_PluginAuthorizationUnavailable(t *testing.T) {
 		path   string
 		body   string
 	}{
-		{name: "list", method: http.MethodGet, path: "/admin/api/v1/authorization/apps/sample_plugin/members"},
-		{name: "put", method: http.MethodPut, path: "/admin/api/v1/authorization/apps/sample_plugin/members", body: fmt.Sprintf(`{"subjectId":%q,"role":"viewer"}`, principal.UserSubjectID(dynamicUser.ID))},
-		{name: "delete", method: http.MethodDelete, path: "/admin/api/v1/authorization/apps/sample_plugin/members/" + url.PathEscape(principal.UserSubjectID(dynamicUser.ID))},
+		{name: "list", method: http.MethodGet, path: "/api/v1/authorization/apps/sample_plugin/members"},
+		{name: "put", method: http.MethodPut, path: "/api/v1/authorization/apps/sample_plugin/members", body: fmt.Sprintf(`{"subjectId":%q,"role":"viewer"}`, principal.UserSubjectID(dynamicUser.ID))},
+		{name: "delete", method: http.MethodDelete, path: "/api/v1/authorization/apps/sample_plugin/members/" + url.PathEscape(principal.UserSubjectID(dynamicUser.ID))},
 	} {
 		reqBody := io.Reader(nil)
 		if tc.body != "" {
@@ -7137,9 +7137,9 @@ func TestAdminAPI_AdminAuthorizationUnavailable(t *testing.T) {
 			path   string
 			body   string
 		}{
-			{name: "list", method: http.MethodGet, path: "/admin/api/v1/authorization/admins/members"},
-			{name: "put", method: http.MethodPut, path: "/admin/api/v1/authorization/admins/members", body: fmt.Sprintf(`{"subjectId":%q,"role":"operator"}`, principal.UserSubjectID(user.ID))},
-			{name: "delete", method: http.MethodDelete, path: "/admin/api/v1/authorization/admins/members/" + url.PathEscape(principal.UserSubjectID(user.ID))},
+			{name: "list", method: http.MethodGet, path: "/api/v1/authorization/admins/members"},
+			{name: "put", method: http.MethodPut, path: "/api/v1/authorization/admins/members", body: fmt.Sprintf(`{"subjectId":%q,"role":"operator"}`, principal.UserSubjectID(user.ID))},
+			{name: "delete", method: http.MethodDelete, path: "/api/v1/authorization/admins/members/" + url.PathEscape(principal.UserSubjectID(user.ID))},
 		} {
 			reqBody := io.Reader(nil)
 			if tc.body != "" {
@@ -7186,7 +7186,7 @@ func TestAdminAPI_AdminAuthorizationUnavailable(t *testing.T) {
 		})
 		testutil.CloseOnCleanup(t, ts)
 
-		req, _ := http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/admins/members", nil)
+		req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/authorization/admins/members", nil)
 		req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
@@ -7235,7 +7235,7 @@ func TestAdminAPI_PluginAuthorizationReloadFailureReturnsAccepted(t *testing.T) 
 
 	dynamicUser := seedUser(t, svc, "dynamic@example.test")
 	body := bytes.NewBufferString(fmt.Sprintf(`{"subjectId":%q,"role":"viewer"}`, principal.UserSubjectID(dynamicUser.ID)))
-	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/apps/sample_plugin/members", body)
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/api/v1/authorization/apps/sample_plugin/members", body)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -7300,7 +7300,7 @@ func TestAdminAPI_AdminAuthorizationReloadFailureReturnsAccepted(t *testing.T) {
 
 	dynamicAdmin := seedUser(t, svc, "dynamic-admin@example.test")
 	body := bytes.NewBufferString(fmt.Sprintf(`{"subjectId":%q,"role":"admin"}`, principal.UserSubjectID(dynamicAdmin.ID)))
-	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/admins/members", body)
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/api/v1/authorization/admins/members", body)
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 	resp, err := http.DefaultClient.Do(req)

--- a/gestaltd/services/ui/adminui/out/index.html
+++ b/gestaltd/services/ui/adminui/out/index.html
@@ -1660,7 +1660,7 @@
           setAuthStatus("Loading app members...", "");
           const appName = selectedAppName;
           try {
-            const result = await fetchJSON("/admin/api/v1/authorization/apps/" + encodeURIComponent(appName) + "/members");
+            const result = await fetchJSON("/api/v1/authorization/apps/" + encodeURIComponent(appName) + "/members");
             if (requestToken !== authMembersRequestToken || appName !== selectedAppName) return;
             authMembers = Array.isArray(result.payload) ? result.payload : [];
             setAuthStatus("Loaded " + authMembers.length + " rows for " + appName + ".", "ok");
@@ -1681,7 +1681,7 @@
           renderAuthorization();
           setAuthStatus("Loading authorization apps...", "");
           try {
-            const result = await fetchJSON("/admin/api/v1/authorization/apps");
+            const result = await fetchJSON("/api/v1/authorization/apps");
             authApps = Array.isArray(result.payload) ? result.payload : [];
             authLoaded = true;
             renderAuthorizationAppSelect();
@@ -1712,7 +1712,7 @@
           renderAdminMembersWorkspace();
           setAdminMembersStatus("Loading Gestalt admins...", "");
           try {
-            const result = await fetchJSON("/admin/api/v1/authorization/admins/members");
+            const result = await fetchJSON("/api/v1/authorization/admins/members");
             if (requestToken !== adminMembersRequestToken) return;
             adminMembers = Array.isArray(result.payload) ? result.payload : [];
             adminAvailable = true;
@@ -1776,7 +1776,7 @@
             setAuthStatus("Saving dynamic grant...", "");
             try {
               const result = await fetchJSON(
-                "/admin/api/v1/authorization/apps/" + encodeURIComponent(selectedAppName) + "/members",
+                "/api/v1/authorization/apps/" + encodeURIComponent(selectedAppName) + "/members",
                 {
                   method: "PUT",
                   headers: {
@@ -1816,7 +1816,7 @@
             setAuthStatus("Removing dynamic grant...", "");
             try {
               const result = await fetchJSON(
-                "/admin/api/v1/authorization/apps/" + encodeURIComponent(selectedAppName) + "/members/" + encodeURIComponent(subjectID),
+                "/api/v1/authorization/apps/" + encodeURIComponent(selectedAppName) + "/members/" + encodeURIComponent(subjectID),
                 {
                   method: "DELETE",
                 },
@@ -1864,7 +1864,7 @@
             updateAdminMembersFormState();
             setAdminMembersStatus("Saving built-in admin grant...", "");
             try {
-              const result = await fetchJSON("/admin/api/v1/authorization/admins/members", {
+              const result = await fetchJSON("/api/v1/authorization/admins/members", {
                 method: "PUT",
                 headers: {
                   Accept: "application/json",
@@ -1904,7 +1904,7 @@
             setAdminMembersStatus("Removing built-in admin grant...", "");
             try {
               const result = await fetchJSON(
-                "/admin/api/v1/authorization/admins/members/" + encodeURIComponent(subjectID),
+                "/api/v1/authorization/admins/members/" + encodeURIComponent(subjectID),
                 {
                   method: "DELETE",
                 },


### PR DESCRIPTION
## Description

Updates the Gestalt CLI authz commands to call the current `/api/v1/authorization` endpoints and adds CLI entrypoints for top-level dynamic authorization grant source CRUD.