### PR TITLE
Add typed workflow run context parsers

### DIFF
--- a/sdk/go/workflow/context.go
+++ b/sdk/go/workflow/context.go
@@ -66,7 +66,7 @@ func WorkflowStepIdempotencyKey(req Request, invocationScope, stepID, suffix str
 	return strings.Join(parts, ":")
 }
 
-func WorkflowInvocationContext(req Request) map[string]any {
+func WorkflowRunContext(req Request) map[string]any {
 	ctxValue := map[string]any{}
 	if runID := strings.TrimSpace(req.RunID); runID != "" {
 		ctxValue["runId"] = runID

--- a/sdk/go/workflow/steps.go
+++ b/sdk/go/workflow/steps.go
@@ -79,7 +79,7 @@ func (e *Executor) invokeAppStep(ctx context.Context, req Request, token string,
 		Instance:        strings.TrimSpace(app.Instance),
 		CredentialMode:  strings.TrimSpace(app.CredentialMode),
 		IdempotencyKey:  WorkflowStepIdempotencyKey(req, invocationScope, stepID, "step"),
-		WorkflowContext: WorkflowInvocationContext(req),
+		WorkflowContext: WorkflowRunContext(req),
 	})
 	if err != nil {
 		return nil, err
@@ -119,7 +119,7 @@ func (e *Executor) invokeAgentStep(ctx context.Context, req Request, token strin
 			ProviderName: providerName,
 			Model:        model,
 			Metadata: map[string]any{
-				"workflow":       WorkflowInvocationContext(req),
+				"workflow":       WorkflowRunContext(req),
 				"workflowStepId": stepID,
 			},
 			IdempotencyKey: WorkflowStepIdempotencyKey(req, invocationScope, stepID, "agent-session:"+sessionKey),

--- a/sdk/python/gestalt/__init__.py
+++ b/sdk/python/gestalt/__init__.py
@@ -371,14 +371,19 @@ _WORKFLOW_AUTHORED_EXPORTS = (
 _WORKFLOW_HELPER_EXPORTS = (
     "WorkflowEvalContext",
     "WorkflowExecutionRequest",
+    "WorkflowRunContextActor",
+    "WorkflowRunContext",
+    "WorkflowRunContextSignal",
+    "WorkflowRunContextTrigger",
     "WorkflowValueError",
     "evaluate_workflow_step_inputs",
     "evaluate_workflow_value",
     "latest_workflow_signal",
     "map_path_value",
+    "parse_workflow_run_context",
     "path_value",
     "render_workflow_template",
-    "workflow_invocation_context",
+    "workflow_run_context",
     "workflow_signals_context",
 )
 
@@ -554,6 +559,7 @@ __all__ = [
     *_AUTHORIZATION_HELPER_EXPORTS,
     *_RUNTIME_PROVIDER_AUTHORED_EXPORTS,
     *_WORKFLOW_AUTHORED_EXPORTS,
+    *_WORKFLOW_HELPER_EXPORTS,
     "AgentHost",
     "Agent",
     "AgentProvider",

--- a/sdk/python/gestalt/_api.py
+++ b/sdk/python/gestalt/_api.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from ._agent import Agent, AgentToolRef
     from ._app_access import AppProtocol
     from ._authorization import Authorization
-    from ._workflow import Workflow
+    from ._workflow import Workflow, WorkflowRunContext
 
 FIELD_DESCRIPTION_KEY: Final[str] = "description"
 FIELD_REQUIRED_KEY: Final[str] = "required"
@@ -130,6 +130,11 @@ class Request:
             self.invocation_token,
             idempotency_key=self.idempotency_key,
         )
+
+    def workflow_run_context(self) -> "WorkflowRunContext":
+        from ._workflow import parse_workflow_run_context
+
+        return parse_workflow_run_context(self.workflow)
 
     def authorization(self) -> "Authorization":
         from ._authorization import _shared_authorization_client

--- a/sdk/python/gestalt/_workflow.py
+++ b/sdk/python/gestalt/_workflow.py
@@ -4,6 +4,7 @@ import ast
 import dataclasses as _dataclasses
 import datetime as _dt
 import json
+import math
 import os
 from collections.abc import Mapping, Sequence
 from typing import Any, Protocol, TypeAlias, cast
@@ -2642,6 +2643,55 @@ class WorkflowExecutionRequest:
 
 
 @_dataclasses.dataclass(slots=True)
+class WorkflowRunContextActor:
+    subject_id: str = ""
+    subject_kind: str = ""
+    display_name: str = ""
+    auth_source: str = ""
+
+
+@_dataclasses.dataclass(slots=True)
+class WorkflowRunContextTrigger:
+    kind: str = ""
+    schedule_id: str = ""
+    scheduled_for: str = ""
+    trigger_id: str = ""
+    event: WorkflowJsonObject | None = None
+
+
+@_dataclasses.dataclass(slots=True)
+class WorkflowRunContextSignal:
+    id: str = ""
+    name: str = ""
+    payload: WorkflowJsonObject = _dataclasses.field(default_factory=dict)
+    metadata: WorkflowJsonObject = _dataclasses.field(default_factory=dict)
+    created_by: WorkflowRunContextActor | None = None
+    created_at: str = ""
+    idempotency_key: str = ""
+    sequence: int | None = None
+
+
+@_dataclasses.dataclass(slots=True)
+class WorkflowRunContext:
+    provider: str = ""
+    run_id: str = ""
+    target: WorkflowJsonObject | None = None
+    trigger: WorkflowRunContextTrigger = _dataclasses.field(
+        default_factory=WorkflowRunContextTrigger
+    )
+    input: WorkflowJsonObject = _dataclasses.field(default_factory=dict)
+    metadata: WorkflowJsonObject = _dataclasses.field(default_factory=dict)
+    signals: Sequence[WorkflowRunContextSignal] = _dataclasses.field(
+        default_factory=list
+    )
+    created_by: WorkflowRunContextActor | None = None
+
+    @property
+    def latest_signal(self) -> WorkflowRunContextSignal | None:
+        return self.signals[-1] if self.signals else None
+
+
+@_dataclasses.dataclass(slots=True)
 class WorkflowEvalContext:
     request: WorkflowExecutionRequest
     outputs: Mapping[str, Any] | None = None
@@ -2733,7 +2783,7 @@ def render_workflow_template(ctx: WorkflowEvalContext, template: str) -> str:
     return "".join(out)
 
 
-def workflow_invocation_context(req: WorkflowExecutionRequest) -> dict[str, Any]:
+def workflow_run_context(req: WorkflowExecutionRequest) -> dict[str, Any]:
     out: dict[str, Any] = {}
     if req.run_id.strip():
         out["runId"] = req.run_id.strip()
@@ -2756,6 +2806,102 @@ def workflow_invocation_context(req: WorkflowExecutionRequest) -> dict[str, Any]
     if created_by:
         out["createdBy"] = created_by
     return out
+
+
+def parse_workflow_run_context(
+    workflow: Mapping[str, Any] | None = None,
+) -> WorkflowRunContext:
+    data = workflow if isinstance(workflow, Mapping) else {}
+    return WorkflowRunContext(
+        provider=_workflow_context_str(data.get("provider")),
+        run_id=_workflow_context_str(data.get("runId")),
+        target=_workflow_context_optional_object(data.get("target")),
+        trigger=_workflow_run_trigger(data.get("trigger")),
+        input=_workflow_context_object(data.get("input")),
+        metadata=_workflow_context_object(data.get("metadata")),
+        signals=_workflow_run_signals(data.get("signals")),
+        created_by=_workflow_run_actor(data.get("createdBy")),
+    )
+
+
+def _workflow_run_trigger(value: Any) -> WorkflowRunContextTrigger:
+    data = value if isinstance(value, Mapping) else {}
+    return WorkflowRunContextTrigger(
+        kind=_workflow_context_str(data.get("kind")),
+        schedule_id=_workflow_context_str(data.get("scheduleId")),
+        scheduled_for=_workflow_context_str(data.get("scheduledFor")),
+        trigger_id=_workflow_context_str(data.get("triggerId")),
+        event=_workflow_context_optional_object(data.get("event")),
+    )
+
+
+def _workflow_run_signals(value: Any) -> list[WorkflowRunContextSignal]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    signals: list[WorkflowRunContextSignal] = []
+    for item in value:
+        signal = _workflow_run_signal(item)
+        if signal is not None:
+            signals.append(signal)
+    return signals
+
+
+def _workflow_run_signal(value: Any) -> WorkflowRunContextSignal | None:
+    if not isinstance(value, Mapping):
+        return None
+    return WorkflowRunContextSignal(
+        id=_workflow_context_str(value.get("id")),
+        name=_workflow_context_str(value.get("name")),
+        payload=_workflow_context_object(value.get("payload")),
+        metadata=_workflow_context_object(value.get("metadata")),
+        created_by=_workflow_run_actor(value.get("createdBy")),
+        created_at=_workflow_context_str(value.get("createdAt")),
+        idempotency_key=_workflow_context_str(value.get("idempotencyKey")),
+        sequence=_workflow_context_int(value.get("sequence")),
+    )
+
+
+def _workflow_run_actor(value: Any) -> WorkflowRunContextActor | None:
+    if not isinstance(value, Mapping):
+        return None
+    actor = WorkflowRunContextActor(
+        subject_id=_workflow_context_str(value.get("subjectId")),
+        subject_kind=_workflow_context_str(value.get("subjectKind")),
+        display_name=_workflow_context_str(value.get("displayName")),
+        auth_source=_workflow_context_str(value.get("authSource")),
+    )
+    if (
+        actor.subject_id
+        or actor.subject_kind
+        or actor.display_name
+        or actor.auth_source
+    ):
+        return actor
+    return None
+
+
+def _workflow_context_str(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _workflow_context_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, float) and math.isfinite(value) and value.is_integer():
+        return int(value)
+    return value if isinstance(value, int) else None
+
+
+def _workflow_context_object(value: Any) -> WorkflowJsonObject:
+    if not isinstance(value, Mapping):
+        return {}
+    return cast(WorkflowJsonObject, dict(value))
+
+
+def _workflow_context_optional_object(value: Any) -> WorkflowJsonObject | None:
+    if not isinstance(value, Mapping):
+        return None
+    return cast(WorkflowJsonObject, dict(value))
 
 
 def _workflow_target_context(target: BoundWorkflowTarget | Any | None) -> dict[str, Any]:

--- a/sdk/python/tests/test_workflow_helpers.py
+++ b/sdk/python/tests/test_workflow_helpers.py
@@ -2,6 +2,8 @@ import datetime as dt
 import unittest
 from collections.abc import Mapping
 
+from google.protobuf import json_format, struct_pb2
+
 import gestalt
 
 
@@ -233,7 +235,7 @@ class WorkflowHelperTests(unittest.TestCase):
         self.assertEqual(provider, "openai")
         self.assertEqual(model_options, {"temperature": 0})
 
-    def test_workflow_invocation_context_matches_runtime_shape(self) -> None:
+    def test_workflow_run_context_matches_runtime_shape(self) -> None:
         created_at = dt.datetime(2026, 5, 8, 12, 0, tzinfo=dt.timezone.utc)
         req = gestalt.WorkflowExecutionRequest(
             provider_name="indexeddb",
@@ -266,7 +268,7 @@ class WorkflowHelperTests(unittest.TestCase):
             ],
         )
 
-        ctx = gestalt.workflow_invocation_context(req)
+        ctx = gestalt.workflow_run_context(req)
 
         self.assertEqual(
             ctx["target"],
@@ -300,6 +302,123 @@ class WorkflowHelperTests(unittest.TestCase):
                 }
             ],
         )
+
+    def test_parse_workflow_run_context_from_request(self) -> None:
+        req = gestalt.Request(
+            workflow={
+                "provider": "github",
+                "runId": "run-1",
+                "target": {"kind": "steps", "steps": [{"id": "review"}]},
+                "trigger": {
+                    "kind": "schedule",
+                    "scheduleId": "sched-1",
+                    "scheduledFor": "2026-05-08T12:00:00Z",
+                },
+                "input": {"repository": "valon/app"},
+                "metadata": {"definitionId": "def-1"},
+                "createdBy": {"subjectId": "user-1", "subjectKind": "user"},
+                "signals": [
+                    "ignored",
+                    {"id": "sig-1", "name": "queued", "payload": {"state": "queued"}},
+                    {
+                        "id": "sig-2",
+                        "name": "github",
+                        "payload": {
+                            "github_event": "pull_request",
+                            "delivery_id": "delivery-1",
+                            "payloadOmitted": True,
+                        },
+                        "metadata": {"source": "webhook"},
+                        "createdBy": {"subjectId": "bot-1", "displayName": "GitHub"},
+                        "createdAt": "2026-05-08T12:01:00Z",
+                        "idempotencyKey": "idem-1",
+                        "sequence": 2,
+                    },
+                ],
+            }
+        )
+
+        ctx = req.workflow_run_context()
+
+        self.assertEqual(ctx.provider, "github")
+        self.assertEqual(ctx.run_id, "run-1")
+        self.assertEqual(ctx.target, {"kind": "steps", "steps": [{"id": "review"}]})
+        self.assertEqual(ctx.trigger.kind, "schedule")
+        self.assertEqual(ctx.trigger.schedule_id, "sched-1")
+        self.assertEqual(ctx.trigger.scheduled_for, "2026-05-08T12:00:00Z")
+        self.assertEqual(ctx.input, {"repository": "valon/app"})
+        self.assertEqual(ctx.metadata, {"definitionId": "def-1"})
+        assert ctx.created_by is not None
+        self.assertEqual(ctx.created_by.subject_id, "user-1")
+        self.assertEqual(len(ctx.signals), 2)
+        latest_signal = ctx.latest_signal
+        assert latest_signal is not None
+        self.assertEqual(latest_signal.id, "sig-2")
+        self.assertEqual(latest_signal.payload["github_event"], "pull_request")
+        self.assertEqual(latest_signal.metadata, {"source": "webhook"})
+        assert latest_signal.created_by is not None
+        self.assertEqual(latest_signal.created_by.display_name, "GitHub")
+        self.assertEqual(latest_signal.sequence, 2)
+
+    def test_parse_workflow_run_context_preserves_struct_sequence(self) -> None:
+        workflow = getattr(struct_pb2, "Struct")()
+        json_format.ParseDict({"signals": [{"sequence": 2}]}, workflow)
+        workflow_dict = json_format.MessageToDict(
+            workflow,
+            preserving_proto_field_name=True,
+        )
+
+        ctx = gestalt.parse_workflow_run_context(workflow_dict)
+
+        latest_signal = ctx.latest_signal
+        assert latest_signal is not None
+        self.assertEqual(latest_signal.sequence, 2)
+
+    def test_parse_workflow_run_context_tolerates_malformed_values(self) -> None:
+        ctx = gestalt.parse_workflow_run_context(
+            {
+                "provider": 123,
+                "runId": None,
+                "target": [],
+                "trigger": {
+                    "kind": "event",
+                    "triggerId": "trigger-1",
+                    "event": {
+                        "type": "github.pull_request",
+                        "specVersion": "1.0",
+                    },
+                },
+                "input": "bad",
+                "metadata": ["bad"],
+                "createdBy": {},
+                "signals": [
+                    {"sequence": True, "payload": "bad", "metadata": {"ok": True}},
+                    None,
+                ],
+            }
+        )
+
+        self.assertEqual(ctx.provider, "")
+        self.assertEqual(ctx.run_id, "")
+        self.assertIsNone(ctx.target)
+        self.assertEqual(ctx.trigger.kind, "event")
+        self.assertEqual(ctx.trigger.trigger_id, "trigger-1")
+        self.assertEqual(
+            ctx.trigger.event,
+            {"type": "github.pull_request", "specVersion": "1.0"},
+        )
+        self.assertEqual(ctx.input, {})
+        self.assertEqual(ctx.metadata, {})
+        self.assertIsNone(ctx.created_by)
+        self.assertEqual(len(ctx.signals), 1)
+        self.assertEqual(ctx.signals[0].payload, {})
+        self.assertEqual(ctx.signals[0].metadata, {"ok": True})
+        self.assertIsNone(ctx.signals[0].sequence)
+
+    def test_workflow_run_context_exports_public_helpers(self) -> None:
+        self.assertIn("WorkflowRunContext", gestalt.__all__)
+        self.assertIn("parse_workflow_run_context", gestalt.__all__)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -563,12 +563,17 @@ export {
   evaluateWorkflowValue,
   latestWorkflowSignal,
   mapPathValue,
+  parseWorkflowRunContext,
   pathValue,
   renderWorkflowTemplate,
-  workflowInvocationContext,
+  workflowRunContext,
   workflowSignalsContext,
   type WorkflowEvalContext,
   type WorkflowExecutionRequest,
+  type WorkflowRunContextActor,
+  type WorkflowRunContext,
+  type WorkflowRunContextSignal,
+  type WorkflowRunContextTrigger,
 } from "./workflow.ts";
 export {
   GENAI_OPERATION_CHAT,

--- a/sdk/typescript/src/workflow.ts
+++ b/sdk/typescript/src/workflow.ts
@@ -87,7 +87,7 @@ import {
   agentToolRefFromProto,
   agentToolRefToProto,
 } from "./agent-conversions.ts";
-import { errorMessage, type MaybePromise } from "./api.ts";
+import { errorMessage, type MaybePromise, type Request } from "./api.ts";
 import { ProviderBase, type ProviderBaseOptions } from "./provider.ts";
 import {
   dateFromTimestamp,
@@ -2652,6 +2652,44 @@ export interface WorkflowExecutionRequest {
   signals?: readonly WorkflowSignal[] | undefined;
 }
 
+export interface WorkflowRunContextActor {
+  subjectId: string;
+  subjectKind: string;
+  displayName: string;
+  authSource: string;
+}
+
+export interface WorkflowRunContextTrigger {
+  kind: string;
+  scheduleId: string;
+  scheduledFor: string;
+  triggerId: string;
+  event?: Record<string, JsonInput> | undefined;
+}
+
+export interface WorkflowRunContextSignal {
+  id: string;
+  name: string;
+  payload: Record<string, JsonInput>;
+  metadata: Record<string, JsonInput>;
+  createdBy?: WorkflowRunContextActor | undefined;
+  createdAt: string;
+  idempotencyKey: string;
+  sequence?: number | undefined;
+}
+
+export interface WorkflowRunContext {
+  provider: string;
+  runId: string;
+  target?: Record<string, JsonInput> | undefined;
+  trigger: WorkflowRunContextTrigger;
+  input: Record<string, JsonInput>;
+  metadata: Record<string, JsonInput>;
+  signals: readonly WorkflowRunContextSignal[];
+  createdBy?: WorkflowRunContextActor | undefined;
+  latestSignal?: WorkflowRunContextSignal | undefined;
+}
+
 export interface WorkflowEvalContext {
   request: WorkflowExecutionRequest;
   outputs?: Record<string, unknown> | undefined;
@@ -2772,7 +2810,7 @@ export function renderWorkflowTemplate(
   return out;
 }
 
-export function workflowInvocationContext(
+export function workflowRunContext(
   req: WorkflowExecutionRequest,
 ): Record<string, JsonInput> {
   const out: Record<string, JsonInput> = {};
@@ -2805,6 +2843,120 @@ export function workflowInvocationContext(
     out.createdBy = createdBy;
   }
   return out;
+}
+
+export function parseWorkflowRunContext(
+  value?: Request | Record<string, unknown> | null | undefined,
+): WorkflowRunContext {
+  const data = workflowRunContextData(value);
+  const target = workflowContextOptionalObject(data.target);
+  const signals = Array.isArray(data.signals)
+    ? data.signals
+      .map(workflowRunContextSignal)
+      .filter((signal): signal is WorkflowRunContextSignal => signal !== undefined)
+    : [];
+  const createdBy = workflowRunContextActor(data.createdBy);
+  const latestSignal = signals.at(-1);
+  const context: WorkflowRunContext = {
+    provider: workflowContextString(data.provider),
+    runId: workflowContextString(data.runId),
+    trigger: workflowRunContextTrigger(data.trigger),
+    input: workflowContextObject(data.input),
+    metadata: workflowContextObject(data.metadata),
+    signals,
+  };
+  if (target !== undefined) {
+    context.target = target;
+  }
+  if (createdBy !== undefined) {
+    context.createdBy = createdBy;
+  }
+  if (latestSignal !== undefined) {
+    context.latestSignal = latestSignal;
+  }
+  return context;
+}
+
+function workflowRunContextData(
+  value?: Request | Record<string, unknown> | null | undefined,
+): Record<string, unknown> {
+  if (!isWorkflowContextRecord(value)) {
+    return {};
+  }
+  return isWorkflowContextRecord(value.workflow) ? value.workflow : value;
+}
+
+function workflowRunContextTrigger(value: unknown): WorkflowRunContextTrigger {
+  const data = isWorkflowContextRecord(value) ? value : {};
+  const event = workflowContextOptionalObject(data.event);
+  const trigger: WorkflowRunContextTrigger = {
+    kind: workflowContextString(data.kind),
+    scheduleId: workflowContextString(data.scheduleId),
+    scheduledFor: workflowContextString(data.scheduledFor),
+    triggerId: workflowContextString(data.triggerId),
+  };
+  if (event !== undefined) {
+    trigger.event = event;
+  }
+  return trigger;
+}
+
+function workflowRunContextSignal(value: unknown): WorkflowRunContextSignal | undefined {
+  if (!isWorkflowContextRecord(value)) {
+    return undefined;
+  }
+  const signal: WorkflowRunContextSignal = {
+    id: workflowContextString(value.id),
+    name: workflowContextString(value.name),
+    payload: workflowContextObject(value.payload),
+    metadata: workflowContextObject(value.metadata),
+    createdAt: workflowContextString(value.createdAt),
+    idempotencyKey: workflowContextString(value.idempotencyKey),
+  };
+  const createdBy = workflowRunContextActor(value.createdBy);
+  if (createdBy !== undefined) {
+    signal.createdBy = createdBy;
+  }
+  const sequence = workflowContextNumber(value.sequence);
+  if (sequence !== undefined) {
+    signal.sequence = sequence;
+  }
+  return signal;
+}
+
+function workflowRunContextActor(value: unknown): WorkflowRunContextActor | undefined {
+  if (!isWorkflowContextRecord(value)) {
+    return undefined;
+  }
+  const actor: WorkflowRunContextActor = {
+    subjectId: workflowContextString(value.subjectId),
+    subjectKind: workflowContextString(value.subjectKind),
+    displayName: workflowContextString(value.displayName),
+    authSource: workflowContextString(value.authSource),
+  };
+  return actor.subjectId || actor.subjectKind || actor.displayName || actor.authSource
+    ? actor
+    : undefined;
+}
+
+function workflowContextString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function workflowContextNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function workflowContextObject(value: unknown): Record<string, JsonInput> {
+  return isWorkflowContextRecord(value) ? { ...(value as Record<string, JsonInput>) } : {};
+}
+
+function workflowContextOptionalObject(value: unknown): Record<string, JsonInput> | undefined {
+  return isWorkflowContextRecord(value) ? { ...(value as Record<string, JsonInput>) } : undefined;
+}
+
+function isWorkflowContextRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function workflowTargetContext(

--- a/sdk/typescript/tests/workflow-helpers.test.ts
+++ b/sdk/typescript/tests/workflow-helpers.test.ts
@@ -3,8 +3,9 @@ import { expect, test } from "bun:test";
 import {
   evaluateWorkflowValue,
   pathValue,
+  parseWorkflowRunContext,
   renderWorkflowTemplate,
-  workflowInvocationContext,
+  workflowRunContext,
   type WorkflowEvalContext,
 } from "../src/index.ts";
 
@@ -37,9 +38,9 @@ test("workflow execution helpers evaluate templates and paths", () => {
   });
 });
 
-test("workflow invocation context matches runtime shape", () => {
+test("workflow run context matches runtime shape", () => {
   const createdAt = new Date("2026-05-08T12:00:00.000Z");
-  const ctx = workflowInvocationContext({
+  const ctx = workflowRunContext({
     providerName: "indexeddb",
     runId: "run-1",
     target: {
@@ -88,4 +89,96 @@ test("workflow invocation context matches runtime shape", () => {
     },
     createdAt: "2026-05-08T12:00:00.000Z",
   }]);
+});
+
+test("workflow run context parses request workflow metadata", () => {
+  const ctx = parseWorkflowRunContext({
+    workflow: {
+      provider: "github",
+      runId: "run-1",
+      target: { kind: "steps", steps: [{ id: "review" }] },
+      trigger: {
+        kind: "schedule",
+        scheduleId: "sched-1",
+        scheduledFor: "2026-05-08T12:00:00Z",
+      },
+      input: { repository: "valon/app" },
+      metadata: { definitionId: "def-1" },
+      createdBy: { subjectId: "user-1", subjectKind: "user" },
+      signals: [
+        "ignored",
+        { id: "sig-1", name: "queued", payload: { state: "queued" } },
+        {
+          id: "sig-2",
+          name: "github",
+          payload: {
+            github_event: "pull_request",
+            delivery_id: "delivery-1",
+            payloadOmitted: true,
+          },
+          metadata: { source: "webhook" },
+          createdBy: { subjectId: "bot-1", displayName: "GitHub" },
+          createdAt: "2026-05-08T12:01:00Z",
+          idempotencyKey: "idem-1",
+          sequence: 2,
+        },
+      ],
+    },
+  });
+
+  expect(ctx.provider).toBe("github");
+  expect(ctx.runId).toBe("run-1");
+  expect(ctx.target).toEqual({ kind: "steps", steps: [{ id: "review" }] });
+  expect(ctx.trigger.kind).toBe("schedule");
+  expect(ctx.trigger.scheduleId).toBe("sched-1");
+  expect(ctx.trigger.scheduledFor).toBe("2026-05-08T12:00:00Z");
+  expect(ctx.input).toEqual({ repository: "valon/app" });
+  expect(ctx.metadata).toEqual({ definitionId: "def-1" });
+  expect(ctx.createdBy?.subjectId).toBe("user-1");
+  expect(ctx.signals).toHaveLength(2);
+  expect(ctx.latestSignal?.id).toBe("sig-2");
+  expect(ctx.latestSignal?.payload.github_event).toBe("pull_request");
+  expect(ctx.latestSignal?.metadata).toEqual({ source: "webhook" });
+  expect(ctx.latestSignal?.createdBy?.displayName).toBe("GitHub");
+  expect(ctx.latestSignal?.sequence).toBe(2);
+});
+
+test("workflow run context parser tolerates malformed values", () => {
+  const ctx = parseWorkflowRunContext({
+    provider: 123,
+    runId: null,
+    target: [],
+    trigger: {
+      kind: "event",
+      triggerId: "trigger-1",
+      event: {
+        type: "github.pull_request",
+        specVersion: "1.0",
+      },
+    },
+    input: "bad",
+    metadata: ["bad"],
+    createdBy: {},
+    signals: [
+      { sequence: true, payload: "bad", metadata: { ok: true } },
+      null,
+    ],
+  });
+
+  expect(ctx.provider).toBe("");
+  expect(ctx.runId).toBe("");
+  expect(ctx.target).toBeUndefined();
+  expect(ctx.trigger.kind).toBe("event");
+  expect(ctx.trigger.triggerId).toBe("trigger-1");
+  expect(ctx.trigger.event).toEqual({
+    type: "github.pull_request",
+    specVersion: "1.0",
+  });
+  expect(ctx.input).toEqual({});
+  expect(ctx.metadata).toEqual({});
+  expect(ctx.createdBy).toBeUndefined();
+  expect(ctx.signals).toHaveLength(1);
+  expect(ctx.signals[0]?.payload).toEqual({});
+  expect(ctx.signals[0]?.metadata).toEqual({ ok: true });
+  expect(ctx.signals[0]?.sequence).toBeUndefined();
 });


### PR DESCRIPTION
## Summary
- Add typed Python dataclasses plus `parse_workflow_run_context` and `Request.workflow_run_context()` for raw lowerCamel workflow run metadata.
- Add TypeScript `parseWorkflowRunContext` and exported workflow run context types.
- Rename the matching Go helper to `WorkflowRunContext` so SDK naming is aligned.
- Cover raw request parsing, malformed values, compacted signal payloads, protobuf `Struct` numeric sequence conversion, and public Python exports.

## Verification
- `uv run pytest tests/test_workflow_helpers.py` in `sdk/python`
- `uv run ty check gestalt/_api.py gestalt/_workflow.py tests/test_workflow_helpers.py` in `sdk/python`
- `uv run ruff check gestalt/_api.py gestalt/_workflow.py tests/test_workflow_helpers.py` in `sdk/python`
- `bun test tests/workflow-helpers.test.ts` in `sdk/typescript`
- `bun run typecheck` in `sdk/typescript`
- `bun run typecheck:loose` in `sdk/typescript`
- `go test ./sdk/go/...`
- `git diff --check`

Note: full `uv run ty check .` in `sdk/python` still reports existing generated protobuf stub diagnostics unrelated to this change.