### PR TITLE
Use fake time in selected Go tests

### DIFF
--- a/gestaltd/internal/bootstrap/agent_runtime_test.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -834,22 +835,24 @@ func TestAgentRuntimePingChecksConfiguredProviders(t *testing.T) {
 func TestAgentRuntimePingChecksConfiguredProvidersInParallel(t *testing.T) {
 	t.Parallel()
 
-	runtime := &agentRuntime{
-		defaultProviderName: "simple",
-		configuredProviders: map[string]struct{}{
-			"canary": {},
-			"simple": {},
-		},
-		providers: map[string]coreagent.Provider{
-			"canary": &pingAgentProvider{delay: 100 * time.Millisecond},
-			"simple": &pingAgentProvider{delay: 100 * time.Millisecond},
-		},
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
-	defer cancel()
-	if err := runtime.Ping(ctx); err != nil {
-		t.Fatalf("Ping: %v", err)
-	}
+	synctest.Test(t, func(t *testing.T) {
+		runtime := &agentRuntime{
+			defaultProviderName: "simple",
+			configuredProviders: map[string]struct{}{
+				"canary": {},
+				"simple": {},
+			},
+			providers: map[string]coreagent.Provider{
+				"canary": &pingAgentProvider{delay: 100 * time.Millisecond},
+				"simple": &pingAgentProvider{delay: 100 * time.Millisecond},
+			},
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+		defer cancel()
+		if err := runtime.Ping(ctx); err != nil {
+			t.Fatalf("Ping: %v", err)
+		}
+	})
 }
 
 func TestAgentRuntimeConfigSelectedProviderStartsSessionWithRuntimeFields(t *testing.T) {
@@ -1094,13 +1097,8 @@ func TestAgentRuntimeConfigStartsHostedAgentWarmPool(t *testing.T) {
 	if resolved == nil || resolved.Status != coreagent.ExecutionStatusSucceeded {
 		t.Fatalf("GetTurn(after ResolveInteraction) = %#v, want succeeded turn", resolved)
 	}
-	select {
-	case err := <-drainDone:
-		if err != nil {
-			t.Fatalf("drainAndCloseBackend: %v", err)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("drainAndCloseBackend did not finish after live turn completed")
+	if err := <-drainDone; err != nil {
+		t.Fatalf("drainAndCloseBackend: %v", err)
 	}
 }
 
@@ -1498,21 +1496,17 @@ func TestAgentRuntimeConfigKeepsHostedAgentServingWhenProactiveReplacementStartF
 func TestAgentRuntimeConfigProactiveReplacementRespectsMaxReadyInstances(t *testing.T) {
 	bin := buildAgentProviderBinary(t)
 	runtimeProvider := newCapturingRuntime()
+	runtimeProvider.getSessionRequests = make(chan runtimeprovider.GetSessionRequest, 64)
 	releaseReplacement := make(chan struct{})
 	replacementStarted := make(chan struct{})
 	var replacementStartedOnce sync.Once
 	runtimeProvider.lifecycleForSession = func(index int) *runtimeprovider.SessionLifecycle {
 		startedAt := time.Now().UTC()
 		expiresAt := startedAt.Add(time.Hour)
-		lifecycle := &runtimeprovider.SessionLifecycle{
+		return &runtimeprovider.SessionLifecycle{
 			StartedAt: &startedAt,
 			ExpiresAt: &expiresAt,
 		}
-		if index <= 2 {
-			recommendedDrainAt := startedAt.Add(500 * time.Millisecond)
-			lifecycle.RecommendedDrainAt = &recommendedDrainAt
-		}
-		return lifecycle
 	}
 	runtimeProvider.startErrForSession = func(index int) error {
 		if index <= 2 {
@@ -1572,15 +1566,14 @@ func TestAgentRuntimeConfigProactiveReplacementRespectsMaxReadyInstances(t *test
 	}()
 
 	pool := hostedAgentProviderPoolForTest(t, agents[0])
-	if ready := pool.readyBackends(); len(ready) != 2 {
+	ready := pool.readyBackends()
+	if len(ready) != 2 {
 		t.Fatalf("ready backends = %d, want 2", len(ready))
 	}
-	select {
-	case <-replacementStarted:
-	case <-time.After(2 * time.Second):
-		t.Fatal("proactive replacement did not start")
-	}
-	time.Sleep(150 * time.Millisecond)
+	markCapturingRuntimeBackendsDrainingSoon(runtimeProvider, ready, 250*time.Millisecond)
+	<-replacementStarted
+	drainRuntimeGetSessionRequests(runtimeProvider.getSessionRequests)
+	<-runtimeProvider.getSessionRequests
 	if got := len(runtimeProvider.startSessionRequests()); got != 3 {
 		t.Fatalf("start session requests while one replacement is starting = %d, want 3", got)
 	}
@@ -1589,6 +1582,36 @@ func TestAgentRuntimeConfigProactiveReplacementRespectsMaxReadyInstances(t *test
 	pool.mu.Unlock()
 	if starting != 1 {
 		t.Fatalf("starting instances = %d, want 1", starting)
+	}
+}
+
+func markCapturingRuntimeBackendsDrainingSoon(runtimeProvider *capturingRuntime, backends []*hostedAgentPoolBackend, delay time.Duration) {
+	drainAt := time.Now().UTC().Add(delay)
+	runtimeProvider.mu.Lock()
+	defer runtimeProvider.mu.Unlock()
+	if runtimeProvider.sessionLifecycles == nil {
+		runtimeProvider.sessionLifecycles = map[string]*runtimeprovider.SessionLifecycle{}
+	}
+	for _, backend := range backends {
+		if backend == nil || backend.runtimeSessionID == "" {
+			continue
+		}
+		lifecycle := cloneRuntimeSessionLifecycle(runtimeProvider.sessionLifecycles[backend.runtimeSessionID])
+		if lifecycle == nil {
+			lifecycle = &runtimeprovider.SessionLifecycle{}
+		}
+		lifecycle.RecommendedDrainAt = &drainAt
+		runtimeProvider.sessionLifecycles[backend.runtimeSessionID] = lifecycle
+	}
+}
+
+func drainRuntimeGetSessionRequests(ch <-chan runtimeprovider.GetSessionRequest) {
+	for {
+		select {
+		case <-ch:
+		default:
+			return
+		}
 	}
 }
 
@@ -1740,26 +1763,28 @@ func TestAgentRuntimeConfigReplacesExpiresOnlyRuntimeBeforeExpiry(t *testing.T) 
 func TestHostedAgentProviderPoolPingChecksReadyBackendsInParallel(t *testing.T) {
 	t.Parallel()
 
-	pool := &hostedAgentProviderPool{
-		name: "simple",
-		backends: []*hostedAgentPoolBackend{
-			{
-				id:        1,
-				provider:  &pingAgentProvider{delay: 100 * time.Millisecond},
-				liveTurns: map[string]struct{}{},
+	synctest.Test(t, func(t *testing.T) {
+		pool := &hostedAgentProviderPool{
+			name: "simple",
+			backends: []*hostedAgentPoolBackend{
+				{
+					id:        1,
+					provider:  &pingAgentProvider{delay: 100 * time.Millisecond},
+					liveTurns: map[string]struct{}{},
+				},
+				{
+					id:        2,
+					provider:  &pingAgentProvider{delay: 100 * time.Millisecond},
+					liveTurns: map[string]struct{}{},
+				},
 			},
-			{
-				id:        2,
-				provider:  &pingAgentProvider{delay: 100 * time.Millisecond},
-				liveTurns: map[string]struct{}{},
-			},
-		},
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
-	defer cancel()
-	if err := pool.Ping(ctx); err != nil {
-		t.Fatalf("Ping: %v", err)
-	}
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+		defer cancel()
+		if err := pool.Ping(ctx); err != nil {
+			t.Fatalf("Ping: %v", err)
+		}
+	})
 }
 
 func TestHostedAgentProviderPoolListSessionsDeduplicatesSharedStoreSessions(t *testing.T) {

--- a/gestaltd/internal/bootstrap/executable_app_test.go
+++ b/gestaltd/internal/bootstrap/executable_app_test.go
@@ -205,6 +205,7 @@ type capturingRuntime struct {
 	startRequests       []runtimeprovider.StartSessionRequest
 	startAppRequests    []runtimeprovider.StartAppRequest
 	startTimes          []time.Time
+	getSessionRequests  chan runtimeprovider.GetSessionRequest
 	sessionLifecycles   map[string]*runtimeprovider.SessionLifecycle
 	lifecycleForSession func(index int) *runtimeprovider.SessionLifecycle
 	startErrForSession  func(index int) error
@@ -271,6 +272,12 @@ func (r *capturingRuntime) GetSession(ctx context.Context, req runtimeprovider.G
 		return nil, err
 	}
 	r.attachSessionLifecycle(session)
+	if r.getSessionRequests != nil {
+		select {
+		case r.getSessionRequests <- req:
+		default:
+		}
+	}
 	return session, nil
 }
 

--- a/gestaltd/internal/bootstrap/hosted_workflow_provider_test.go
+++ b/gestaltd/internal/bootstrap/hosted_workflow_provider_test.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -125,62 +126,62 @@ func TestHostedWorkflowProviderPoolStartsWorkersFromWorkflowProviderStartup(t *t
 func TestHostedWorkflowProviderPoolStartupDoesNotBlockWorkflowReadiness(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-	runtimeProvider := &blockingStartSessionWorkflowRuntime{
-		recordingHostedWorkflowRuntime: newRecordingHostedWorkflowRuntime(t),
-		started:                        make(chan struct{}),
-	}
-	t.Cleanup(func() { _ = runtimeProvider.Close() })
-	deps := Deps{
-		BaseURL:            "http://127.0.0.1:8080",
-		EncryptionKey:      []byte("0123456789abcdef0123456789abcdef"),
-		Runtime:            runtimeProvider,
-		PublicHostServices: runtimehost.NewPublicHostServiceRegistry(),
-	}
-	entry := &config.ProviderEntry{
-		Runtime: &config.RuntimePlacementConfig{
-			Provider: "gke",
-			Pool: &config.RuntimePlacementPoolConfig{
-				MinReadyInstances:   1,
-				MaxReadyInstances:   1,
-				StartupTimeout:      "5s",
-				HealthCheckInterval: "1m",
-				RestartPolicy:       config.RuntimePlacementRestartPolicyNever,
-				DrainTimeout:        "50ms",
-			},
-		},
-	}
-
-	workers, err := buildHostedWorkflowWorkerPool(ctx, "temporal", entry, mustNode(t, map[string]any{
-		"command": "/bin/temporal-provider",
-	}), []runtimehost.HostService{{
-		Name:           "indexeddb",
-		MethodPrefixes: []string{grpcMethodPrefix(proto.IndexedDB_ServiceDesc.ServiceName)},
-	}}, deps)
-	if err != nil {
-		t.Fatalf("buildHostedWorkflowWorkerPool: %v", err)
-	}
-	provider := wrapWorkflowProviderWithRuntimeWorkers(&recordingWorkflowControlProvider{}, workers)
-	result := &Result{ExtraWorkflows: []workflow.Provider{provider}}
-	t.Cleanup(func() { _ = provider.Close() })
-
-	done := make(chan error, 1)
-	go func() {
-		done <- result.StartWorkflowProviders(ctx)
-	}()
-	select {
-	case err := <-done:
-		if err != nil {
-			t.Fatalf("StartWorkflowProviders: %v", err)
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		runtimeProvider := &blockingStartSessionWorkflowRuntime{
+			recordingHostedWorkflowRuntime: newRecordingHostedWorkflowRuntime(t),
+			started:                        make(chan struct{}),
 		}
-	case <-time.After(200 * time.Millisecond):
-		t.Fatal("StartWorkflowProviders blocked on runtime worker startup")
-	}
-	select {
-	case <-runtimeProvider.started:
-	case <-time.After(2 * time.Second):
-		t.Fatal("runtime worker startup did not begin")
-	}
+		defer func() { _ = runtimeProvider.Close() }()
+		deps := Deps{
+			BaseURL:            "http://127.0.0.1:8080",
+			EncryptionKey:      []byte("0123456789abcdef0123456789abcdef"),
+			Runtime:            runtimeProvider,
+			PublicHostServices: runtimehost.NewPublicHostServiceRegistry(),
+		}
+		entry := &config.ProviderEntry{
+			Runtime: &config.RuntimePlacementConfig{
+				Provider: "gke",
+				Pool: &config.RuntimePlacementPoolConfig{
+					MinReadyInstances:   1,
+					MaxReadyInstances:   1,
+					StartupTimeout:      "5s",
+					HealthCheckInterval: "1m",
+					RestartPolicy:       config.RuntimePlacementRestartPolicyNever,
+					DrainTimeout:        "50ms",
+				},
+			},
+		}
+
+		workers, err := buildHostedWorkflowWorkerPool(ctx, "temporal", entry, mustNode(t, map[string]any{
+			"command": "/bin/temporal-provider",
+		}), []runtimehost.HostService{{
+			Name:           "indexeddb",
+			MethodPrefixes: []string{grpcMethodPrefix(proto.IndexedDB_ServiceDesc.ServiceName)},
+		}}, deps)
+		if err != nil {
+			t.Fatalf("buildHostedWorkflowWorkerPool: %v", err)
+		}
+		provider := wrapWorkflowProviderWithRuntimeWorkers(&recordingWorkflowControlProvider{}, workers)
+		defer func() { _ = provider.Close() }()
+		result := &Result{ExtraWorkflows: []workflow.Provider{provider}}
+
+		done := make(chan error, 1)
+		go func() {
+			done <- result.StartWorkflowProviders(ctx)
+		}()
+		synctest.Wait()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("StartWorkflowProviders: %v", err)
+			}
+		default:
+			t.Fatal("StartWorkflowProviders blocked on runtime worker startup")
+		}
+		<-runtimeProvider.started
+	})
 }
 
 func TestWorkflowConfigReconciliationWaitsForRuntimeWorkers(t *testing.T) {
@@ -226,11 +227,16 @@ func TestWorkflowConfigReconciliationWaitsForRuntimeWorkers(t *testing.T) {
 	}
 	workflowRuntime.PublishProvider("temporal", provider)
 	reconciled := make(chan struct{})
+	readinessWaitStarted := make(chan struct{})
+	var readinessWaitStartedOnce sync.Once
 	result := &Result{
 		ExtraWorkflows: []workflow.Provider{provider},
 		workflowConfigReconcileTasks: []workflowConfigReconcileTask{{
 			name: "temporal",
 			reconcile: func(context.Context) error {
+				readinessWaitStartedOnce.Do(func() {
+					close(readinessWaitStarted)
+				})
 				if err := waitRuntimeWorkflowProviderReady(ctx, workflowRuntime, "temporal"); err != nil {
 					return err
 				}
@@ -242,19 +248,16 @@ func TestWorkflowConfigReconciliationWaitsForRuntimeWorkers(t *testing.T) {
 	t.Cleanup(func() { _ = provider.Close() })
 
 	result.StartWorkflowConfigReconciliation(ctx)
+	<-readinessWaitStarted
 	select {
 	case <-reconciled:
 		t.Fatal("workflow config reconciliation ran before runtime workers were started")
-	case <-time.After(50 * time.Millisecond):
+	default:
 	}
 	if err := result.StartWorkflowProviders(ctx); err != nil {
 		t.Fatalf("StartWorkflowProviders: %v", err)
 	}
-	select {
-	case <-reconciled:
-	case <-time.After(2 * time.Second):
-		t.Fatal("workflow config reconciliation did not run after runtime workers became ready")
-	}
+	<-reconciled
 }
 
 func TestWorkflowConfigReconciliationReconcilesReadyRuntimeProvidersIndependently(t *testing.T) {
@@ -330,16 +333,8 @@ func TestWorkflowConfigReconciliationReconcilesReadyRuntimeProvidersIndependentl
 	}
 
 	result.StartWorkflowConfigReconciliation(ctx)
-	select {
-	case <-stuckProvider.waitStarted:
-	case <-time.After(2 * time.Second):
-		t.Fatal("stuck provider readiness wait did not start")
-	}
-	select {
-	case <-readyProvider.upsertedSchedule:
-	case <-time.After(2 * time.Second):
-		t.Fatalf("ready provider schedules = %d, want 1 while another provider is stuck", len(readyProvider.upsertedSchedules))
-	}
+	<-stuckProvider.waitStarted
+	<-readyProvider.upsertedSchedule
 	if got := len(stuckProvider.upsertedSchedules); got != 0 {
 		t.Fatalf("stuck provider schedules = %d, want 0 before readiness", got)
 	}
@@ -351,6 +346,7 @@ func TestHostedWorkflowProviderPoolRejectsIncompatibleStartupSession(t *testing.
 	ctx := context.Background()
 	runtimeProvider := &staleSessionWorkflowRuntime{
 		recordingHostedWorkflowRuntime: newRecordingHostedWorkflowRuntime(t),
+		started:                        make(chan struct{}),
 	}
 	t.Cleanup(func() { _ = runtimeProvider.Close() })
 	deps := Deps{
@@ -386,14 +382,19 @@ func TestHostedWorkflowProviderPoolRejectsIncompatibleStartupSession(t *testing.
 	if err := pool.Start(ctx); err != nil {
 		t.Fatalf("pool.Start: %v", err)
 	}
-	waitForHostedWorkflowRuntimeStartSessionRequests(t, runtimeProvider.recordingHostedWorkflowRuntime, 1)
+	<-runtimeProvider.started
 	if got := len(runtimeProvider.startAppRequestsCopy()); got != 0 {
 		t.Fatalf("StartApp requests = %d, want 0 for incompatible runtime session", got)
 	}
-	waitCtx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
-	defer cancel()
-	if err := pool.WaitReady(waitCtx); err == nil {
-		t.Fatal("pool.WaitReady: expected timeout for incompatible runtime session")
+	select {
+	case <-pool.ready:
+		t.Fatal("pool marked ready for incompatible runtime session")
+	default:
+	}
+	waitCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	if err := pool.WaitReady(waitCtx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("pool.WaitReady canceled error = %v, want %v", err, context.Canceled)
 	}
 	if got := len(pool.readyWorkers()); got != 0 {
 		t.Fatalf("ready workers = %d, want 0 for incompatible runtime session", got)
@@ -403,82 +404,78 @@ func TestHostedWorkflowProviderPoolRejectsIncompatibleStartupSession(t *testing.
 func TestHostedWorkflowProviderPoolClosedStartLoopDoesNotMarkReady(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	pool := &hostedWorkflowWorkerPool{
-		name:   "temporal",
-		ctx:    ctx,
-		cancel: cancel,
-		ready:  make(chan struct{}),
-		policy: config.RuntimePlacementLifecyclePolicy{
-			MinReadyInstances:   1,
-			HealthCheckInterval: time.Hour,
-			RestartPolicy:       config.RuntimePlacementRestartPolicyNever,
-		},
-	}
-	pool.mu.Lock()
-	pool.closed = true
-	pool.mu.Unlock()
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		pool := &hostedWorkflowWorkerPool{
+			name:   "temporal",
+			ctx:    ctx,
+			cancel: cancel,
+			ready:  make(chan struct{}),
+			policy: config.RuntimePlacementLifecyclePolicy{
+				MinReadyInstances:   1,
+				HealthCheckInterval: time.Hour,
+				RestartPolicy:       config.RuntimePlacementRestartPolicyNever,
+			},
+		}
+		pool.mu.Lock()
+		pool.closed = true
+		pool.mu.Unlock()
 
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		pool.startLoop()
-	}()
-	select {
-	case <-done:
-	case <-time.After(200 * time.Millisecond):
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			pool.startLoop()
+		}()
+		synctest.Wait()
+		select {
+		case <-done:
+		default:
+			t.Fatal("startLoop did not exit after pool closed")
+		}
 		select {
 		case <-pool.ready:
 			t.Fatal("pool marked ready after it was closed")
 		default:
 		}
-		t.Fatal("startLoop did not exit after pool closed")
-	}
-	select {
-	case <-pool.ready:
-		t.Fatal("pool marked ready after it was closed")
-	default:
-	}
+	})
 }
 
 func TestHostedWorkflowProviderPoolCloseUnblocksWaitReady(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	pool := &hostedWorkflowWorkerPool{
-		name:   "temporal",
-		ctx:    ctx,
-		cancel: cancel,
-		ready:  make(chan struct{}),
-		policy: config.RuntimePlacementLifecyclePolicy{
-			MinReadyInstances:   1,
-			HealthCheckInterval: time.Hour,
-			RestartPolicy:       config.RuntimePlacementRestartPolicyNever,
-		},
-	}
-	t.Cleanup(func() { _ = pool.Close() })
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		pool := &hostedWorkflowWorkerPool{
+			name:   "temporal",
+			ctx:    ctx,
+			cancel: cancel,
+			ready:  make(chan struct{}),
+			policy: config.RuntimePlacementLifecyclePolicy{
+				MinReadyInstances:   1,
+				HealthCheckInterval: time.Hour,
+				RestartPolicy:       config.RuntimePlacementRestartPolicyNever,
+			},
+		}
 
-	waitDone := make(chan error, 1)
-	go func() {
-		waitDone <- pool.WaitReady(context.Background())
-	}()
-	select {
-	case err := <-waitDone:
-		t.Fatalf("WaitReady returned before pool close: %v", err)
-	case <-time.After(25 * time.Millisecond):
-	}
-	if err := pool.Close(); err != nil {
-		t.Fatalf("pool.Close: %v", err)
-	}
-	select {
-	case err := <-waitDone:
+		waitDone := make(chan error, 1)
+		go func() {
+			waitDone <- pool.WaitReady(context.Background())
+		}()
+		synctest.Wait()
+		select {
+		case err := <-waitDone:
+			t.Fatalf("WaitReady returned before pool close: %v", err)
+		default:
+		}
+		if err := pool.Close(); err != nil {
+			t.Fatalf("pool.Close: %v", err)
+		}
+		err := <-waitDone
 		if !errors.Is(err, errHostedWorkflowWorkerPoolClosed) {
 			t.Fatalf("WaitReady error = %v, want hosted workflow worker pool closed", err)
 		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("WaitReady did not unblock after pool close")
-	}
+	})
 }
 
 func TestWorkflowConfigReconciliationFiltersRuntimePlacedProviders(t *testing.T) {
@@ -655,73 +652,47 @@ func TestHostedWorkflowProviderKeepsSharedRuntimeOpen(t *testing.T) {
 func TestHostedWorkflowProviderPoolDrainWaitsBeforeClosingWorker(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-	runtimeProvider := newRecordingHostedWorkflowRuntime(t)
-	t.Cleanup(func() { _ = runtimeProvider.Close() })
-	deps := Deps{
-		BaseURL:            "http://127.0.0.1:8080",
-		EncryptionKey:      []byte("0123456789abcdef0123456789abcdef"),
-		Runtime:            runtimeProvider,
-		PublicHostServices: runtimehost.NewPublicHostServiceRegistry(),
-	}
-	entry := &config.ProviderEntry{
-		Runtime: &config.RuntimePlacementConfig{
-			Provider: "gke",
-			Pool: &config.RuntimePlacementPoolConfig{
-				MinReadyInstances:   1,
-				MaxReadyInstances:   1,
-				StartupTimeout:      "5s",
-				HealthCheckInterval: "1m",
-				RestartPolicy:       config.RuntimePlacementRestartPolicyNever,
-				DrainTimeout:        "150ms",
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		worker := &hostedWorkflowWorker{
+			id:       1,
+			provider: &noopWorkflowProvider{},
+			active:   1,
+		}
+		pool := &hostedWorkflowWorkerPool{
+			name:    "temporal",
+			ctx:     ctx,
+			cancel:  cancel,
+			ready:   make(chan struct{}),
+			workers: []*hostedWorkflowWorker{worker},
+			policy: config.RuntimePlacementLifecyclePolicy{
+				DrainTimeout: 150 * time.Millisecond,
 			},
-		},
-	}
+		}
 
-	pool, err := buildHostedWorkflowWorkerPool(ctx, "temporal", entry, mustNode(t, map[string]any{
-		"command": "/bin/temporal-provider",
-	}), []runtimehost.HostService{{
-		Name:           "indexeddb",
-		MethodPrefixes: []string{grpcMethodPrefix(proto.IndexedDB_ServiceDesc.ServiceName)},
-	}}, deps)
-	if err != nil {
-		t.Fatalf("buildHostedWorkflowWorkerPool: %v", err)
-	}
-	t.Cleanup(func() { _ = pool.Close() })
-	if err := pool.Start(ctx); err != nil {
-		t.Fatalf("pool.Start: %v", err)
-	}
-	if err := pool.WaitReady(ctx); err != nil {
-		t.Fatalf("pool.WaitReady: %v", err)
-	}
-	workers := pool.readyWorkers()
-	if len(workers) != 1 {
-		t.Fatalf("ready workers = %d, want 1", len(workers))
-	}
-	pool.mu.Lock()
-	workers[0].active = 1
-	pool.mu.Unlock()
-
-	done := make(chan error, 1)
-	go func() {
-		done <- pool.drainAndCloseWorker(workers[0])
-	}()
-	select {
-	case err := <-done:
-		t.Fatalf("drainAndCloseWorker finished before drain timeout with error %v", err)
-	case <-time.After(30 * time.Millisecond):
-	}
-	pool.mu.Lock()
-	workers[0].active = 0
-	pool.mu.Unlock()
-	select {
-	case err := <-done:
+		done := make(chan error, 1)
+		go func() {
+			done <- pool.drainAndCloseWorker(worker)
+		}()
+		time.Sleep(30 * time.Millisecond)
+		select {
+		case err := <-done:
+			t.Fatalf("drainAndCloseWorker finished while worker was active: %v", err)
+		default:
+		}
+		pool.mu.Lock()
+		worker.active = 0
+		pool.mu.Unlock()
+		releasedAt := time.Now()
+		err := <-done
 		if err != nil {
 			t.Fatalf("drainAndCloseWorker: %v", err)
 		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("drainAndCloseWorker did not finish after drain timeout")
-	}
+		if elapsed := time.Since(releasedAt); elapsed > 25*time.Millisecond {
+			t.Fatalf("drainAndCloseWorker elapsed after worker release = %v, want at most one poll interval", elapsed)
+		}
+	})
 }
 
 const providermanifestKindWorkflow = "workflow"
@@ -753,6 +724,18 @@ func (r *blockingStartSessionWorkflowRuntime) StartSession(ctx context.Context, 
 
 type staleSessionWorkflowRuntime struct {
 	*recordingHostedWorkflowRuntime
+	started chan struct{}
+	once    sync.Once
+}
+
+func (r *staleSessionWorkflowRuntime) StartSession(ctx context.Context, req runtimeprovider.StartSessionRequest) (*runtimeprovider.Session, error) {
+	session, err := r.recordingHostedWorkflowRuntime.StartSession(ctx, req)
+	if err == nil {
+		r.once.Do(func() {
+			close(r.started)
+		})
+	}
+	return session, err
 }
 
 func (r *staleSessionWorkflowRuntime) GetSession(ctx context.Context, req runtimeprovider.GetSessionRequest) (*runtimeprovider.Session, error) {
@@ -1041,18 +1024,6 @@ func (r *recordingHostedWorkflowRuntime) startProviderCalls() int32 {
 		total += server.startProviderCalls.Load()
 	}
 	return total
-}
-
-func waitForHostedWorkflowRuntimeStartSessionRequests(t *testing.T, runtimeProvider *recordingHostedWorkflowRuntime, want int) {
-	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if got := len(runtimeProvider.startSessionRequestsCopy()); got >= want {
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	t.Fatalf("StartSession requests = %d, want at least %d", len(runtimeProvider.startSessionRequestsCopy()), want)
 }
 
 func (r *recordingHostedWorkflowRuntime) cleanupServer(sessionID string) {

--- a/gestaltd/internal/operator/path_domain_scheduler_test.go
+++ b/gestaltd/internal/operator/path_domain_scheduler_test.go
@@ -7,156 +7,164 @@ import (
 	"runtime"
 	"sync/atomic"
 	"testing"
-	"time"
+	"testing/synctest"
 )
 
 func TestRunPathDomainTasksHonorsWorkerCap(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
-	started := make(chan struct{}, 4)
-	release := make(chan struct{})
-	var active int32
-	var maxActive int32
+	synctest.Test(t, func(t *testing.T) {
+		dir := t.TempDir()
+		started := make(chan struct{}, 4)
+		release := make(chan struct{})
+		var active int32
+		var maxActive int32
 
-	var tasks []pathDomainTask
-	for _, name := range []string{"a", "b", "c", "d"} {
-		name := name
-		tasks = append(tasks, pathDomainTask{
-			name:    name,
-			domains: mustNormalizePathDomains(t, filepath.Join(dir, name)),
-			run: func() error {
-				now := atomic.AddInt32(&active, 1)
-				for {
-					max := atomic.LoadInt32(&maxActive)
-					if now <= max || atomic.CompareAndSwapInt32(&maxActive, max, now) {
-						break
+		var tasks []pathDomainTask
+		for _, name := range []string{"a", "b", "c", "d"} {
+			name := name
+			tasks = append(tasks, pathDomainTask{
+				name:    name,
+				domains: mustNormalizePathDomains(t, filepath.Join(dir, name)),
+				run: func() error {
+					now := atomic.AddInt32(&active, 1)
+					for {
+						max := atomic.LoadInt32(&maxActive)
+						if now <= max || atomic.CompareAndSwapInt32(&maxActive, max, now) {
+							break
+						}
 					}
-				}
-				started <- struct{}{}
-				<-release
-				atomic.AddInt32(&active, -1)
-				return nil
-			},
-		})
-	}
+					started <- struct{}{}
+					<-release
+					atomic.AddInt32(&active, -1)
+					return nil
+				},
+			})
+		}
 
-	done := make(chan error, 1)
-	go func() { done <- runPathDomainTasks(tasks, 2) }()
+		done := make(chan error, 1)
+		go func() { done <- runPathDomainTasks(tasks, 2) }()
 
-	waitForStarts(t, started, 2)
-	select {
-	case <-started:
-		t.Fatal("third task started before worker cap allowed it")
-	case <-time.After(50 * time.Millisecond):
-	}
-	close(release)
-	if err := waitForScheduler(t, done); err != nil {
-		t.Fatalf("runPathDomainTasks: %v", err)
-	}
-	if got := atomic.LoadInt32(&maxActive); got != 2 {
-		t.Fatalf("max active tasks = %d, want 2", got)
-	}
+		waitForStarts(t, started, 2)
+		synctest.Wait()
+		select {
+		case <-started:
+			t.Fatal("third task started before worker cap allowed it")
+		default:
+		}
+		close(release)
+		if err := waitForScheduler(t, done); err != nil {
+			t.Fatalf("runPathDomainTasks: %v", err)
+		}
+		if got := atomic.LoadInt32(&maxActive); got != 2 {
+			t.Fatalf("max active tasks = %d, want 2", got)
+		}
+	})
 }
 
 func TestRunPathDomainTasksSerializesAncestorDescendantDomains(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
-	parent := filepath.Join(dir, "project")
-	child := filepath.Join(parent, "ui")
-	started := make(chan string, 2)
-	releaseA := make(chan struct{})
+	synctest.Test(t, func(t *testing.T) {
+		dir := t.TempDir()
+		parent := filepath.Join(dir, "project")
+		child := filepath.Join(parent, "ui")
+		started := make(chan string, 2)
+		releaseA := make(chan struct{})
 
-	tasks := []pathDomainTask{
-		{
-			name:    "a",
-			domains: mustNormalizePathDomains(t, parent),
-			run: func() error {
-				started <- "a"
-				<-releaseA
-				return nil
+		tasks := []pathDomainTask{
+			{
+				name:    "a",
+				domains: mustNormalizePathDomains(t, parent),
+				run: func() error {
+					started <- "a"
+					<-releaseA
+					return nil
+				},
 			},
-		},
-		{
-			name:    "b",
-			domains: mustNormalizePathDomains(t, child),
-			run: func() error {
-				started <- "b"
-				return nil
+			{
+				name:    "b",
+				domains: mustNormalizePathDomains(t, child),
+				run: func() error {
+					started <- "b"
+					return nil
+				},
 			},
-		},
-	}
+		}
 
-	done := make(chan error, 1)
-	go func() { done <- runPathDomainTasks(tasks, 2) }()
-	if got := waitForStart(t, started); got != "a" {
-		t.Fatalf("first started task = %q, want a", got)
-	}
-	select {
-	case got := <-started:
-		t.Fatalf("task %q started while ancestor domain was active", got)
-	case <-time.After(50 * time.Millisecond):
-	}
-	close(releaseA)
-	if got := waitForStart(t, started); got != "b" {
-		t.Fatalf("second started task = %q, want b", got)
-	}
-	if err := waitForScheduler(t, done); err != nil {
-		t.Fatalf("runPathDomainTasks: %v", err)
-	}
+		done := make(chan error, 1)
+		go func() { done <- runPathDomainTasks(tasks, 2) }()
+		if got := waitForStart(t, started); got != "a" {
+			t.Fatalf("first started task = %q, want a", got)
+		}
+		synctest.Wait()
+		select {
+		case got := <-started:
+			t.Fatalf("task %q started while ancestor domain was active", got)
+		default:
+		}
+		close(releaseA)
+		if got := waitForStart(t, started); got != "b" {
+			t.Fatalf("second started task = %q, want b", got)
+		}
+		if err := waitForScheduler(t, done); err != nil {
+			t.Fatalf("runPathDomainTasks: %v", err)
+		}
+	})
 }
 
 func TestRunPathDomainTasksDoesNotRunBlockedTaskAfterFailure(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
-	shared := filepath.Join(dir, "shared")
-	aStarted := make(chan struct{})
-	cStarted := make(chan struct{})
-	releaseA := make(chan struct{})
-	var bRan atomic.Bool
-	errC := errors.New("c failed")
+	synctest.Test(t, func(t *testing.T) {
+		dir := t.TempDir()
+		shared := filepath.Join(dir, "shared")
+		aStarted := make(chan struct{})
+		cStarted := make(chan struct{})
+		releaseA := make(chan struct{})
+		var bRan atomic.Bool
+		errC := errors.New("c failed")
 
-	tasks := []pathDomainTask{
-		{
-			name:    "a",
-			domains: mustNormalizePathDomains(t, shared),
-			run: func() error {
-				close(aStarted)
-				<-releaseA
-				return nil
+		tasks := []pathDomainTask{
+			{
+				name:    "a",
+				domains: mustNormalizePathDomains(t, shared),
+				run: func() error {
+					close(aStarted)
+					<-releaseA
+					return nil
+				},
 			},
-		},
-		{
-			name:    "b",
-			domains: mustNormalizePathDomains(t, shared),
-			run: func() error {
-				bRan.Store(true)
-				return nil
+			{
+				name:    "b",
+				domains: mustNormalizePathDomains(t, shared),
+				run: func() error {
+					bRan.Store(true)
+					return nil
+				},
 			},
-		},
-		{
-			name:    "c",
-			domains: mustNormalizePathDomains(t, filepath.Join(dir, "c")),
-			run: func() error {
-				close(cStarted)
-				return errC
+			{
+				name:    "c",
+				domains: mustNormalizePathDomains(t, filepath.Join(dir, "c")),
+				run: func() error {
+					close(cStarted)
+					return errC
+				},
 			},
-		},
-	}
+		}
 
-	done := make(chan error, 1)
-	go func() { done <- runPathDomainTasks(tasks, 2) }()
-	<-aStarted
-	<-cStarted
-	close(releaseA)
-	if err := waitForScheduler(t, done); !errors.Is(err, errC) {
-		t.Fatalf("runPathDomainTasks error = %v, want %v", err, errC)
-	}
-	if bRan.Load() {
-		t.Fatal("blocked task ran after scheduler failure")
-	}
+		done := make(chan error, 1)
+		go func() { done <- runPathDomainTasks(tasks, 2) }()
+		<-aStarted
+		<-cStarted
+		close(releaseA)
+		if err := waitForScheduler(t, done); !errors.Is(err, errC) {
+			t.Fatalf("runPathDomainTasks error = %v, want %v", err, errC)
+		}
+		if bRan.Load() {
+			t.Fatal("blocked task ran after scheduler failure")
+		}
+	})
 }
 
 func TestCanonicalPathDomainResolvesExistingSymlinkPrefixForMissingPath(t *testing.T) {
@@ -200,32 +208,16 @@ func mustNormalizePathDomains(t *testing.T, paths ...string) []string {
 func waitForStarts(t *testing.T, started <-chan struct{}, count int) {
 	t.Helper()
 	for range count {
-		select {
-		case <-started:
-		case <-time.After(2 * time.Second):
-			t.Fatalf("timed out waiting for %d task starts", count)
-		}
+		<-started
 	}
 }
 
 func waitForStart(t *testing.T, started <-chan string) string {
 	t.Helper()
-	select {
-	case got := <-started:
-		return got
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for task start")
-		return ""
-	}
+	return <-started
 }
 
 func waitForScheduler(t *testing.T, done <-chan error) error {
 	t.Helper()
-	select {
-	case err := <-done:
-		return err
-	case <-time.After(2 * time.Second):
-		t.Fatal("scheduler timed out")
-		return nil
-	}
+	return <-done
 }

--- a/gestaltd/services/apps/apiexec/apiexec_test.go
+++ b/gestaltd/services/apps/apiexec/apiexec_test.go
@@ -5,15 +5,40 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func newRetryTestClient(t *testing.T, handle func(*http.Request) (int, http.Header, string)) *http.Client {
+	t.Helper()
+	return &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		status, headers, body := handle(req)
+		if headers == nil {
+			headers = http.Header{}
+		}
+		return &http.Response{
+			StatusCode: status,
+			Status:     fmt.Sprintf("%d %s", status, http.StatusText(status)),
+			Header:     headers,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    req,
+		}, nil
+	})}
+}
 
 func TestSubstitutePath_MissingParam(t *testing.T) {
 	t.Parallel()
@@ -424,76 +449,132 @@ func TestRetryOn429ThenSuccess(t *testing.T) {
 func TestRetryOn503WithBackoff(t *testing.T) {
 	t.Parallel()
 
-	var attempts atomic.Int32
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		if attempts.Add(1) <= 2 {
-			w.WriteHeader(http.StatusServiceUnavailable)
-			_, _ = w.Write([]byte("unavailable"))
-			return
+	synctest.Test(t, func(t *testing.T) {
+		var attempts atomic.Int32
+		client := newRetryTestClient(t, func(*http.Request) (int, http.Header, string) {
+			if attempts.Add(1) <= 2 {
+				return http.StatusServiceUnavailable, nil, "unavailable"
+			}
+			return http.StatusOK, nil, `{"status":"recovered"}`
+		})
+
+		done := make(chan error, 1)
+		var resultStatus int
+		go func() {
+			result, err := Do(context.Background(), client, Request{
+				Method:     http.MethodGet,
+				BaseURL:    "https://api.example.test",
+				Path:       "/test",
+				MaxRetries: 3,
+			})
+			if result != nil {
+				resultStatus = result.Status
+			}
+			done <- err
+		}()
+
+		synctest.Wait()
+		if got := attempts.Load(); got != 1 {
+			t.Fatalf("attempts before first backoff = %d, want 1", got)
 		}
-		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(map[string]string{"status": "recovered"})
-	}))
-	testutil.CloseOnCleanup(t, srv)
+		select {
+		case err := <-done:
+			t.Fatalf("Do returned before first backoff elapsed: %v", err)
+		default:
+		}
 
-	start := time.Now()
-	result, err := Do(context.Background(), srv.Client(), Request{
-		Method:     http.MethodGet,
-		BaseURL:    srv.URL,
-		Path:       "/test",
-		MaxRetries: 3,
+		time.Sleep(time.Second - time.Nanosecond)
+		synctest.Wait()
+		if got := attempts.Load(); got != 1 {
+			t.Fatalf("attempts before first backoff completes = %d, want 1", got)
+		}
+		time.Sleep(time.Nanosecond)
+		synctest.Wait()
+		if got := attempts.Load(); got != 2 {
+			t.Fatalf("attempts after first backoff = %d, want 2", got)
+		}
+
+		time.Sleep(2*time.Second - time.Nanosecond)
+		synctest.Wait()
+		if got := attempts.Load(); got != 2 {
+			t.Fatalf("attempts before second backoff completes = %d, want 2", got)
+		}
+		time.Sleep(time.Nanosecond)
+		synctest.Wait()
+		if got := attempts.Load(); got != 3 {
+			t.Fatalf("attempts after second backoff = %d, want 3", got)
+		}
+
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("expected success after retries, got: %v", err)
+			}
+		default:
+			t.Fatal("Do did not return after successful retry")
+		}
+		if resultStatus != http.StatusOK {
+			t.Fatalf("status = %d, want %d", resultStatus, http.StatusOK)
+		}
 	})
-	elapsed := time.Since(start)
-
-	if err != nil {
-		t.Fatalf("expected success after retries, got: %v", err)
-	}
-	if result.Status != http.StatusOK {
-		t.Fatalf("status = %d, want %d", result.Status, http.StatusOK)
-	}
-	if got := attempts.Load(); got != 3 {
-		t.Fatalf("attempts = %d, want 3", got)
-	}
-	// Two retries: 1s + 2s = 3s minimum backoff
-	if elapsed < 3*time.Second {
-		t.Fatalf("elapsed = %v, expected at least 3s of backoff", elapsed)
-	}
 }
 
 func TestRetryAfterHeaderRespected(t *testing.T) {
 	t.Parallel()
 
-	var attempts atomic.Int32
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		if attempts.Add(1) == 1 {
-			w.Header().Set("Retry-After", "2")
-			w.WriteHeader(http.StatusTooManyRequests)
-			_, _ = w.Write([]byte("rate limited"))
-			return
+	synctest.Test(t, func(t *testing.T) {
+		var attempts atomic.Int32
+		client := newRetryTestClient(t, func(*http.Request) (int, http.Header, string) {
+			if attempts.Add(1) == 1 {
+				headers := http.Header{}
+				headers.Set("Retry-After", "2")
+				return http.StatusTooManyRequests, headers, "rate limited"
+			}
+			return http.StatusOK, nil, `{"status":"ok"}`
+		})
+
+		done := make(chan error, 1)
+		var resultStatus int
+		go func() {
+			result, err := Do(context.Background(), client, Request{
+				Method:     http.MethodGet,
+				BaseURL:    "https://api.example.test",
+				Path:       "/test",
+				MaxRetries: 2,
+			})
+			if result != nil {
+				resultStatus = result.Status
+			}
+			done <- err
+		}()
+
+		synctest.Wait()
+		if got := attempts.Load(); got != 1 {
+			t.Fatalf("attempts before Retry-After delay = %d, want 1", got)
 		}
-		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
-	}))
-	testutil.CloseOnCleanup(t, srv)
+		time.Sleep(2*time.Second - time.Nanosecond)
+		synctest.Wait()
+		if got := attempts.Load(); got != 1 {
+			t.Fatalf("attempts before Retry-After delay completes = %d, want 1", got)
+		}
+		time.Sleep(time.Nanosecond)
+		synctest.Wait()
+		if got := attempts.Load(); got != 2 {
+			t.Fatalf("attempts after Retry-After delay = %d, want 2", got)
+		}
 
-	start := time.Now()
-	result, err := Do(context.Background(), srv.Client(), Request{
-		Method:     http.MethodGet,
-		BaseURL:    srv.URL,
-		Path:       "/test",
-		MaxRetries: 2,
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("expected success, got: %v", err)
+			}
+		default:
+			t.Fatal("Do did not return after Retry-After retry")
+		}
+		if resultStatus != http.StatusOK {
+			t.Fatalf("status = %d, want %d", resultStatus, http.StatusOK)
+		}
 	})
-	elapsed := time.Since(start)
-
-	if err != nil {
-		t.Fatalf("expected success, got: %v", err)
-	}
-	if result.Status != http.StatusOK {
-		t.Fatalf("status = %d, want %d", result.Status, http.StatusOK)
-	}
-	if elapsed < 2*time.Second {
-		t.Fatalf("elapsed = %v, expected at least 2s from Retry-After", elapsed)
-	}
 }
 
 func TestNoRetryDisablesRetry(t *testing.T) {
@@ -550,35 +631,49 @@ func TestRetriesStopAfterMaxRetries(t *testing.T) {
 func TestContextCancellationStopsRetries(t *testing.T) {
 	t.Parallel()
 
-	var attempts atomic.Int32
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		attempts.Add(1)
-		w.WriteHeader(http.StatusServiceUnavailable)
-		_, _ = w.Write([]byte("unavailable"))
-	}))
-	testutil.CloseOnCleanup(t, srv)
+	synctest.Test(t, func(t *testing.T) {
+		var attempts atomic.Int32
+		client := newRetryTestClient(t, func(*http.Request) (int, http.Header, string) {
+			attempts.Add(1)
+			return http.StatusServiceUnavailable, nil, "unavailable"
+		})
 
-	ctx, cancel := context.WithCancel(context.Background())
-	go func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		done := make(chan error, 1)
+		go func() {
+			_, err := Do(ctx, client, Request{
+				Method:     http.MethodGet,
+				BaseURL:    "https://api.example.test",
+				Path:       "/test",
+				MaxRetries: 5,
+			})
+			done <- err
+		}()
+
+		synctest.Wait()
+		if got := attempts.Load(); got != 1 {
+			t.Fatalf("attempts before cancellation = %d, want 1", got)
+		}
 		time.Sleep(500 * time.Millisecond)
 		cancel()
-	}()
+		synctest.Wait()
 
-	_, err := Do(ctx, srv.Client(), Request{
-		Method:     http.MethodGet,
-		BaseURL:    srv.URL,
-		Path:       "/test",
-		MaxRetries: 5,
+		select {
+		case err := <-done:
+			if err == nil {
+				t.Fatal("expected error from context cancellation")
+			}
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("err = %v, want context.Canceled", err)
+			}
+		default:
+			t.Fatal("Do did not return after context cancellation")
+		}
+		if got := attempts.Load(); got != 1 {
+			t.Fatalf("attempts = %d, want 1", got)
+		}
 	})
-	if err == nil {
-		t.Fatal("expected error from context cancellation")
-	}
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("err = %v, want context.Canceled", err)
-	}
-	if got := attempts.Load(); got > 2 {
-		t.Fatalf("attempts = %d, want at most 2", got)
-	}
 }
 
 func TestNonRetryableErrorsNotRetried(t *testing.T) {


### PR DESCRIPTION
## Summary

Converts selected Go tests that were asserting elapsed wall-clock time into deterministic fake-time tests using Go's `testing/synctest` package and explicit channel synchronization.

The retry, path-domain scheduler, hosted workflow pool, and hosted agent pool tests now advance fake time inside their test bubbles instead of waiting on real sleeps, timeout guards, or elapsed-time measurements. The helper runtime used by hosted agent tests also exposes a test-only `GetSession` signal so the proactive replacement cap assertion waits for a real health-loop refresh before checking the max-ready guard.

This keeps the tested behavior intact while making the affected tests faster and less sensitive to package load, scheduler delays, or machine timing variance.

## Interfaces

No production interfaces are added or changed.

The only helper surface added is test-only: `capturingRuntime` can optionally publish runtime `GetSession` requests to a channel so tests can synchronize on health-loop progress without sleeping.

## Runtime

Production runtime behavior is unchanged.

Local validation run from the PR worktree:

```sh
go test ./gestaltd/services/apps/apiexec
go test ./gestaltd/internal/operator
go test ./gestaltd/internal/bootstrap
git diff --check
```