### PR TITLE
Remove legacy agent local harness support

### DIFF
--- a/gestaltd/internal/config/agent_harness.go
+++ b/gestaltd/internal/config/agent_harness.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 )
 
-// DefaultAgentHarnessName is the conventional harness name selected when a
-// provider has a single legacy localHarness or an explicit default harness.
+// DefaultAgentHarnessName is the conventional harness name selected when an
+// agent provider defines a default harness entry.
 const DefaultAgentHarnessName = "default"
 
 // EffectiveAgentHarness is the resolved provider and harness launch
@@ -42,9 +42,6 @@ func ResolveProviderEntryAgentHarness(providerName string, entry *ProviderEntry,
 			selectedName = strings.TrimSpace(name)
 		}
 	}
-	if selectedName == "" && entry.LocalHarness != nil {
-		selectedName = DefaultAgentHarnessName
-	}
 	if selectedName == "" {
 		return EffectiveAgentHarness{}, fmt.Errorf("providers.agent.%s.harnesses is required for agent harness launch", providerName)
 	}
@@ -52,9 +49,6 @@ func ResolveProviderEntryAgentHarness(providerName string, entry *ProviderEntry,
 	var harness *ProviderEntryHarnessConfig
 	if entry.Harnesses != nil {
 		harness = entry.Harnesses[selectedName]
-	}
-	if harness == nil && selectedName == DefaultAgentHarnessName && entry.LocalHarness != nil {
-		harness = entry.LocalHarness
 	}
 	if harness == nil {
 		return EffectiveAgentHarness{}, fmt.Errorf("providers.agent.%s.harnesses.%s is not configured", providerName, selectedName)

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -498,7 +498,6 @@ type ProviderEntry struct {
 	IconFile        string                                 `yaml:"iconFile,omitempty"`
 	DefaultHarness  string                                 `yaml:"defaultHarness,omitempty"`
 	Harnesses       map[string]*ProviderEntryHarnessConfig `yaml:"harnesses,omitempty"`
-	LocalHarness    *ProviderEntryHarnessConfig            `yaml:"localHarness,omitempty"`
 	Lifecycle       *AgentProviderLifecycleConfig          `yaml:"lifecycle,omitempty"`
 	RouteAuth       *RouteAuthDef                          `yaml:"-"`
 	SecuritySchemes map[string]*HTTPSecurityScheme         `yaml:"securitySchemes,omitempty"`
@@ -553,10 +552,6 @@ type ProviderEntryHarnessConfig struct {
 	RequiredCommands []string                           `yaml:"requiredCommands,omitempty"`
 	Install          *ProviderEntryHarnessInstallConfig `yaml:"install,omitempty"`
 }
-
-// ProviderEntryLocalHarnessConfig is kept as a compatibility alias for configs
-// that still use providers.agent.<name>.localHarness.
-type ProviderEntryLocalHarnessConfig = ProviderEntryHarnessConfig
 
 // ProviderEntryHarnessInstallConfig describes optional local install guidance
 // for commands required by an agent harness.
@@ -1209,7 +1204,6 @@ func providerEntryFieldsFromEntry(e ProviderEntry) providerEntryFields {
 	e.Runtime = cloneRuntimePlacementConfig(e.Runtime)
 	e.Dev = cloneProviderEntryDevConfig(e.Dev)
 	e.Harnesses = cloneProviderEntryHarnessConfigMap(e.Harnesses)
-	e.LocalHarness = cloneProviderEntryHarnessConfig(e.LocalHarness)
 	e.Lifecycle = cloneAgentProviderLifecycleConfig(e.Lifecycle)
 	normalizeProviderEntryAliases(&e)
 	return providerEntryFields(e)
@@ -1291,7 +1285,6 @@ func normalizeProviderEntryAliases(entry *ProviderEntry) {
 	}
 	normalizeAgentProviderLifecycle(entry.Lifecycle)
 	entry.DefaultHarness = strings.TrimSpace(entry.DefaultHarness)
-	normalizeProviderEntryHarness(entry.LocalHarness)
 	for name, harness := range entry.Harnesses {
 		trimmed := strings.TrimSpace(name)
 		if trimmed != name {
@@ -2718,11 +2711,6 @@ func ValidateSelectedAgentHarnessEnvPaths(paths []string, providerName string, h
 	return nil
 }
 
-// ValidateSelectedAgentLocalHarnessEnvPaths preserves the old helper API.
-func ValidateSelectedAgentLocalHarnessEnvPaths(paths []string, providerName string) error {
-	return ValidateSelectedAgentHarnessEnvPaths(paths, providerName, "")
-}
-
 func selectedAgentHarnessNode(entry *yaml.Node, harnessName string) *yaml.Node {
 	if entry == nil {
 		return nil
@@ -2746,9 +2734,6 @@ func selectedAgentHarnessNode(entry *yaml.Node, harnessName string) *yaml.Node {
 		if harness := mappingValueNode(harnesses, harnessName); harness != nil {
 			return harness
 		}
-	}
-	if harnessName == "" || harnessName == DefaultAgentHarnessName {
-		return mappingValueNode(entry, "localHarness")
 	}
 	return nil
 }
@@ -4113,9 +4098,6 @@ func resolveRelativePathsInEntry(kind string, entry map[string]any, baseDir stri
 		return
 	}
 	resolveRelativeStringField(entry, "iconFile", baseDir)
-	if localHarness, ok := entry["localHarness"].(map[string]any); ok {
-		resolveRelativeStringField(localHarness, "workingDirectory", baseDir)
-	}
 	if harnesses, ok := entry["harnesses"].(map[string]any); ok {
 		for _, harness := range mapValues(harnesses) {
 			resolveRelativeStringField(harness, "workingDirectory", baseDir)
@@ -4192,9 +4174,6 @@ func resolveRelativePaths(configPath string, cfg *Config) {
 		entry.IconFile = resolveRelativePath(baseDir, entry.IconFile)
 		entry.Source.Path = resolveRelativePath(baseDir, entry.Source.Path)
 		entry.Source.metadataPath = resolveRelativePath(baseDir, entry.Source.metadataPath)
-		if entry.LocalHarness != nil {
-			entry.LocalHarness.WorkingDirectory = resolveRelativePath(baseDir, entry.LocalHarness.WorkingDirectory)
-		}
 		for _, harness := range entry.Harnesses {
 			if harness != nil {
 				harness.WorkingDirectory = resolveRelativePath(baseDir, harness.WorkingDirectory)

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -5162,6 +5162,7 @@ apps:
 func TestLoadRejectsUnknownProviderFields(t *testing.T) {
 	t.Parallel()
 
+	legacyAgentHarnessKey := "local" + "Harness"
 	cases := []struct {
 		name    string
 		yaml    string
@@ -5186,6 +5187,17 @@ providers:
       builtin: stdout
 `,
 			wantErr: `field builtin not found`,
+		},
+		{
+			name: "agent legacy harness field is rejected",
+			yaml: fmt.Sprintf(`
+providers:
+  agent:
+    primary:
+      %s:
+        command: /bin/sh
+`, legacyAgentHarnessKey),
+			wantErr: fmt.Sprintf(`field %s not found`, legacyAgentHarnessKey),
 		},
 	}
 

--- a/gestaltd/internal/daemon/agent_local.go
+++ b/gestaltd/internal/daemon/agent_local.go
@@ -26,7 +26,7 @@ type localAgentCommandOptions struct {
 type localAgentHarnessPlan struct {
 	ProviderName    string
 	HarnessName     string
-	Harness         config.ProviderEntryLocalHarnessConfig
+	Harness         config.ProviderEntryHarnessConfig
 	WorkingDir      string
 	Env             map[string]string
 	ResolvedCommand string
@@ -341,9 +341,8 @@ func printAgentLaunchUsage(w io.Writer) {
 	writeUsageLine(w, "  gestaltd agent launch [--config PATH]... [--provider NAME] [--harness NAME] [--dry-run]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Start the selected provider's configured agent harness.")
-	writeUsageLine(w, "Only providers.agent.<name>.harnesses is used; legacy localHarness")
-	writeUsageLine(w, "is also accepted. No server, session,")
-	writeUsageLine(w, "persistence, runtime, tool grant, or AgentProvider RPC stack is started.")
+	writeUsageLine(w, "No server, session, persistence, runtime, tool grant,")
+	writeUsageLine(w, "or AgentProvider RPC stack is started.")
 }
 
 func printAgentDoctorUsage(w io.Writer) {

--- a/gestaltd/internal/daemon/agent_local_test.go
+++ b/gestaltd/internal/daemon/agent_local_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-func TestE2EAgentLaunchDryRunUsesLocalHarnessOnly(t *testing.T) {
+func TestE2EAgentLaunchDryRunUsesHarnessesDefault(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -24,13 +24,14 @@ providers:
   agent:
     local:
       default: true
-      localHarness:
-        command: /bin/sh
-        args: ["-c", "echo hi"]
-        workingDirectory: work
-        env:
-          OPENAI_API_KEY: secret
-          PLAIN: visible
+      harnesses:
+        default:
+          command: /bin/sh
+          args: ["-c", "echo hi"]
+          workingDirectory: work
+          env:
+            OPENAI_API_KEY: secret
+            PLAIN: visible
     deployment_only:
       runtime:
         provider: missing
@@ -103,11 +104,12 @@ providers:
   agent:
     local:
       default: true
-      localHarness:
-        command: ./harness.sh
-        workingDirectory: work
-        env:
-          HARNESS_VALUE: from-config
+      harnesses:
+        default:
+          command: ./harness.sh
+          workingDirectory: work
+          env:
+            HARNESS_VALUE: from-config
 `
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
@@ -147,10 +149,11 @@ providers:
   agent:
     local:
       default: true
-      localHarness:
-        command: /bin/sh
-        requiredCommands:
-          - definitely-missing-gestalt-agent-command
+      harnesses:
+        default:
+          command: /bin/sh
+          requiredCommands:
+            - definitely-missing-gestalt-agent-command
 `
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
@@ -178,15 +181,17 @@ providers:
   agent:
     local:
       default: true
-      localHarness:
-        command: /bin/sh
-        env:
-          OPENAI_API_KEY: ${GESTALT_TEST_MISSING_SELECTED_HARNESS_ENV}
+      harnesses:
+        default:
+          command: /bin/sh
+          env:
+            OPENAI_API_KEY: ${GESTALT_TEST_MISSING_SELECTED_HARNESS_ENV}
     unselected:
-      localHarness:
-        command: /bin/sh
-        env:
-          OTHER: ${GESTALT_TEST_MISSING_UNSELECTED_HARNESS_ENV}
+      harnesses:
+        default:
+          command: /bin/sh
+          env:
+            OTHER: ${GESTALT_TEST_MISSING_UNSELECTED_HARNESS_ENV}
 `
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)


### PR DESCRIPTION
## Summary

Removes the legacy `providers.agent.<name>.localHarness` configuration path instead of preserving it as a compatibility alias for `harnesses.default`.

Agent harness launch, doctor, config validation, relative path resolution, and selected-harness env validation now use the supported `harnesses` map exclusively. The resolver still supports the intended harness selection paths: an explicit harness name, `defaultHarness`, the conventional `harnesses.default` entry, and the single configured harness fallback.

This deletes the old compatibility Go surface and makes stale configs fail config decoding as unknown fields instead of silently mapping into a default harness.

## Interfaces

Removed:

```yaml
providers:
  agent:
    <name>:
      localHarness: ...
```

```go
type ProviderEntryLocalHarnessConfig = ProviderEntryHarnessConfig

func ValidateSelectedAgentLocalHarnessEnvPaths(paths []string, providerName string) error
```

Supported:

```yaml
providers:
  agent:
    <name>:
      defaultHarness: default
      harnesses:
        default:
          command: ...
```

## Runtime

`gestaltd agent launch`, `gestaltd agent doctor`, and `/api/v1/agent/harnesses/resolve` no longer branch for legacy local harness configs.

Supported harness configs keep the same runtime behavior and precedence: explicit harness, `defaultHarness`, `harnesses.default`, then the single configured harness. Legacy `localHarness` configs now fail during config decode instead of being normalized, path-resolved, env-validated, or launched.
