### PR TITLE
Reduce real-time waits in async tests

### DIFF
--- a/gestaltd/internal/server/agent_session_turn_test.go
+++ b/gestaltd/internal/server/agent_session_turn_test.go
@@ -1828,7 +1828,7 @@ func TestAgentTurnEventStreamSendsHeartbeatBeforeEvents(t *testing.T) {
 			RunGrants: newServerTestAgentRunGrants(t),
 		})
 		cfg.APIRouteTimeout = 25 * time.Millisecond
-		cfg.AgentStreamHeartbeat = 10 * time.Millisecond
+		cfg.AgentStreamHeartbeat = time.Millisecond
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -1896,7 +1896,6 @@ func TestAgentTurnEventStreamSendsHeartbeatBeforeEvents(t *testing.T) {
 	if got := strings.TrimRight(line, "\r\n"); got != ": stream-open" {
 		t.Fatalf("first stream line = %q, want stream-open heartbeat", got)
 	}
-	time.Sleep(50 * time.Millisecond)
 	for {
 		line, err := reader.ReadString('\n')
 		if err != nil {

--- a/gestaltd/internal/server/handlers_agent.go
+++ b/gestaltd/internal/server/handlers_agent.go
@@ -677,7 +677,11 @@ func (s *Server) streamAgentTurnEvents(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("X-Accel-Buffering", "no")
-	ticker := time.NewTicker(250 * time.Millisecond)
+	tickInterval := 250 * time.Millisecond
+	if s.agentStreamHeartbeat > 0 && s.agentStreamHeartbeat < tickInterval {
+		tickInterval = s.agentStreamHeartbeat
+	}
+	ticker := time.NewTicker(tickInterval)
 	defer ticker.Stop()
 	lastWrite := time.Now()
 

--- a/gestaltd/services/providerdev/session_test.go
+++ b/gestaltd/services/providerdev/session_test.go
@@ -1076,7 +1076,7 @@ func TestPollSessionDropsCanceledQueuedCall(t *testing.T) {
 		id:                   "session-1",
 		dispatcherSecretHash: hashDispatcherSecret(dispatcherSecret),
 		owner:                p.SubjectID,
-		calls:                make(chan *rpcCall, 1),
+		calls:                make(chan *rpcCall, 2),
 		pending:              map[string]*rpcCall{},
 		done:                 make(chan struct{}),
 		closeDone:            make(chan struct{}),
@@ -1092,18 +1092,26 @@ func TestPollSessionDropsCanceledQueuedCall(t *testing.T) {
 		invokeDone <- session.invoke(invokeCtx, "roadmap", "Execute", &emptypb.Empty{}, &emptypb.Empty{})
 	}()
 
-	deadline := time.Now().Add(time.Second)
-	for len(session.calls) == 0 && time.Now().Before(deadline) {
-		time.Sleep(10 * time.Millisecond)
-	}
-	if len(session.calls) == 0 {
+	var canceledCall *rpcCall
+	select {
+	case canceledCall = <-session.calls:
+	case <-time.After(time.Second):
 		t.Fatal("invoke did not enqueue a call")
 	}
+	session.calls <- canceledCall
 
 	cancel()
 	if err := <-invokeDone; !errors.Is(err, context.Canceled) {
 		t.Fatalf("invoke error = %v, want %v", err, context.Canceled)
 	}
+	activeCall := &rpcCall{
+		id:       "call-active",
+		provider: "roadmap",
+		method:   "Execute",
+		request:  []byte("active"),
+		response: make(chan rpcResponse, 1),
+	}
+	session.calls <- activeCall
 
 	pollCtx, pollCancel := context.WithTimeout(context.Background(), time.Second)
 	defer pollCancel()
@@ -1111,11 +1119,17 @@ func TestPollSessionDropsCanceledQueuedCall(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PollSessionWithDispatcherSecretOnly: %v", err)
 	}
-	if ok || resp != nil {
-		t.Fatalf("PollSession = (%#v, %t), want no call", resp, ok)
+	if !ok || resp == nil {
+		t.Fatalf("PollSession = (%#v, %t), want active call", resp, ok)
 	}
-	if got := len(session.pending); got != 0 {
-		t.Fatalf("pending calls = %d, want 0", got)
+	if resp.CallID != activeCall.id {
+		t.Fatalf("PollSession call ID = %q, want %q", resp.CallID, activeCall.id)
+	}
+	if _, ok := session.pending[canceledCall.id]; ok {
+		t.Fatalf("canceled call %q is pending", canceledCall.id)
+	}
+	if got := len(session.pending); got != 1 {
+		t.Fatalf("pending calls = %d, want 1", got)
 	}
 	if got := len(session.calls); got != 0 {
 		t.Fatalf("queued calls = %d, want 0", got)

--- a/gestaltd/services/runtimehost/process_test.go
+++ b/gestaltd/services/runtimehost/process_test.go
@@ -168,11 +168,16 @@ func TestWaitForPluginConnReturnsProcessExitBeforeReady(t *testing.T) {
 		t.Fatalf("listen raw unix socket: %v", err)
 	}
 	t.Cleanup(func() { _ = rawLis.Close() })
+	rawAccepted := make(chan struct{}, 1)
 	go func() {
 		for {
 			conn, err := rawLis.Accept()
 			if err != nil {
 				return
+			}
+			select {
+			case rawAccepted <- struct{}{}:
+			default:
 			}
 			_ = conn.Close()
 		}
@@ -180,18 +185,24 @@ func TestWaitForPluginConnReturnsProcessExitBeforeReady(t *testing.T) {
 
 	exitErr := errors.New("provider crashed")
 	waitCh := make(chan error, 1)
-	go func() {
-		time.Sleep(75 * time.Millisecond)
-		waitCh <- exitErr
-		close(waitCh)
-	}()
-
+	result := make(chan error, 1)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	conn, err := waitForPluginConn(ctx, socket, waitCh, ProcessConfig{})
-	if conn != nil {
-		_ = conn.Close()
+	go func() {
+		conn, err := waitForPluginConn(ctx, socket, waitCh, ProcessConfig{})
+		if conn != nil {
+			_ = conn.Close()
+		}
+		result <- err
+	}()
+	select {
+	case <-rawAccepted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("waitForPluginConn() did not dial the raw socket")
 	}
+	waitCh <- exitErr
+	close(waitCh)
+	err = <-result
 	if err == nil {
 		t.Fatal("waitForPluginConn() error = nil, want provider exit error")
 	}


### PR DESCRIPTION
## Summary
- Remove success-path polling from the provider dev canceled-call test by synchronizing on the queued call directly and asserting the active call behind it is delivered.
- Remove the fixed runtimehost process-exit sleep by waiting until `waitForPluginConn` has actually dialed the raw socket before delivering the process exit error.
- Let agent event streams honor configured sub-250ms heartbeat intervals so the heartbeat test no longer needs an extra sleep before reading keepalives.

## Interfaces
No public API or CLI interfaces change. `server.Config.AgentStreamHeartbeat` now also lowers the event stream polling ticker when configured below the default 250ms stream poll interval.

## Runtime
This PR is primarily a determinism/flakiness cleanup. It does not produce an aggregate latency win in the targeted multi-package command: the measured targeted wall time was `2.64s` before and `3.22s` after. The reliable latency improvement is narrower, in `providerdev`, where the canceled queued-call test no longer waits for the poll timeout.

Before targeted run on `main`:
```bash
/usr/bin/time -p go test ./gestaltd/services/runtimehost ./gestaltd/services/providerdev ./gestaltd/internal/server -run 'TestWaitForPluginConn|TestPollSessionDropsCanceledQueuedCall|TestSessionCloseReturnsSameErrorToConcurrentCallers|TestAgentTurnEventStreamSendsHeartbeatBeforeEvents|TestStartedHostServicesCloseWaitsForInflightRPC' -count=1 -timeout=180s
# runtimehost 1.460s, providerdev 1.584s, server 1.042s, real 2.64s
```

After this change:
```bash
/usr/bin/time -p go test ./gestaltd/services/runtimehost ./gestaltd/services/providerdev ./gestaltd/internal/server -run 'TestWaitForPluginConn|TestPollSessionDropsCanceledQueuedCall|TestSessionCloseReturnsSameErrorToConcurrentCallers|TestAgentTurnEventStreamSendsHeartbeatBeforeEvents|TestStartedHostServicesCloseWaitsForInflightRPC' -count=1 -timeout=180s
# runtimehost 1.673s, providerdev 0.877s, server 0.788s, real 3.22s

/usr/bin/time -p go test ./gestaltd/services/runtimehost ./gestaltd/services/providerdev ./gestaltd/internal/server -count=1 -timeout=300s
# runtimehost 1.272s, providerdev 0.964s, server 1.035s, real 2.22s

/usr/bin/time -p go test ./gestaltd/internal/server -run 'TestAgentTurnEventStream|TestAgentInteractionResolutionAndEventStream|TestHostedHTTPBinding|TestHTTPBindingOperationMetricsIncludeBinding' -count=1 -timeout=300s
# server 0.922s, real 1.87s

/usr/bin/time -p go test -race ./gestaltd/services/runtimehost ./gestaltd/services/providerdev -run 'Test(WaitForPluginConn|PollSessionDropsCanceledQueuedCall|SessionCloseReturnsSameErrorToConcurrentCallers)' -count=1 -timeout=180s
# runtimehost 2.658s, providerdev 1.737s, real 3.95s
```

The reliable per-package saving is in `providerdev`: `TestPollSessionDropsCanceledQueuedCall` no longer waits for its one-second poll timeout and now reports `0.00s` in the targeted run.
