### PR TITLE
Remove legacy agent grant seal support

### DIFF
--- a/gestaltd/services/agents/agentgrant/grant.go
+++ b/gestaltd/services/agents/agentgrant/grant.go
@@ -154,7 +154,7 @@ func (m *Manager) Resolve(token string) (Grant, error) {
 		return Grant{}, fmt.Errorf("agent run grant is invalid or expired")
 	}
 	var scope toolScope
-	if err := m.openValueAny([]string{sealPurposeToolScope, legacySealPurposeToolScope}, strings.TrimSpace(decoded.ToolScope), &scope); err != nil {
+	if err := m.openValue(sealPurposeToolScope, strings.TrimSpace(decoded.ToolScope), &scope); err != nil {
 		return Grant{}, fmt.Errorf("agent run grant is invalid or expired")
 	}
 	grant := Grant{

--- a/gestaltd/services/agents/agentgrant/seal.go
+++ b/gestaltd/services/agents/agentgrant/seal.go
@@ -16,12 +16,10 @@ import (
 )
 
 const (
-	sealVersion                = "v1"
-	sealPurposeToolID          = "agent-tool-id-v2"
-	sealPurposeToolScope       = "agent-tool-scope-v2"
-	legacySealPurposeToolID    = "agent-tool-id"
-	legacySealPurposeToolScope = "agent-tool-scope"
-	toolIDPrefix               = "agt_tool_"
+	sealVersion          = "v1"
+	sealPurposeToolID    = "agent-tool-id-v2"
+	sealPurposeToolScope = "agent-tool-scope-v2"
+	toolIDPrefix         = "agt_tool_"
 )
 
 type toolBinding struct {
@@ -69,7 +67,7 @@ func (m *Manager) ResolveToolID(id string) (coreagent.ToolTarget, error) {
 		return coreagent.ToolTarget{}, fmt.Errorf("agent tool id is invalid")
 	}
 	var binding toolBinding
-	if err := m.openValueAny([]string{sealPurposeToolID, legacySealPurposeToolID}, strings.TrimPrefix(id, toolIDPrefix), &binding); err != nil {
+	if err := m.openValue(sealPurposeToolID, strings.TrimPrefix(id, toolIDPrefix), &binding); err != nil {
 		return coreagent.ToolTarget{}, fmt.Errorf("agent tool id is invalid")
 	}
 	target := binding.Target
@@ -152,24 +150,6 @@ func (m *Manager) openValue(purpose, token string, value any) error {
 		return fmt.Errorf("decode agent grant payload: %w", err)
 	}
 	return nil
-}
-
-func (m *Manager) openValueAny(purposes []string, token string, value any) error {
-	var lastErr error
-	for _, purpose := range purposes {
-		if strings.TrimSpace(purpose) == "" {
-			continue
-		}
-		if err := m.openValue(purpose, token, value); err == nil {
-			return nil
-		} else {
-			lastErr = err
-		}
-	}
-	if lastErr != nil {
-		return lastErr
-	}
-	return fmt.Errorf("agent grant payload purpose is invalid")
 }
 
 func (m *Manager) sealer(purpose string) (cipher.AEAD, error) {


### PR DESCRIPTION
## Summary

Removes the compatibility path that let agent run grants and sealed agent tool IDs resolve with the old seal purposes.

Agent grants now open only the current `agent-tool-scope-v2` payload, and agent tool IDs now open only the current `agent-tool-id-v2` payload. The alternate-purpose resolver helper is deleted instead of preserving a fallback branch for stale sealed values.

This keeps the agent grant manager on a single sealed payload contract and makes old grant/tool tokens fail resolution rather than being accepted through backwards-compatible purpose probing.

## Interfaces

Removed:

```go
const legacySealPurposeToolID = "agent-tool-id"
const legacySealPurposeToolScope = "agent-tool-scope"

func (m *Manager) openValueAny(purposes []string, token string, value any) error
```

Supported:

```go
const sealPurposeToolID = "agent-tool-id-v2"
const sealPurposeToolScope = "agent-tool-scope-v2"

func (m *Manager) openValue(purpose string, token string, value any) error
```

## Runtime

Newly minted agent run grants and tool IDs are unchanged.

Values sealed with the old `agent-tool-id` or `agent-tool-scope` purposes now fail as invalid instead of being retried with a legacy purpose. Agent tool execution, tool listing, connection resolution, and grant validation continue to use the same current-purpose grants produced by the manager.