### PR TITLE
Remove redundant serve health E2E

### DIFF
--- a/gestaltd/internal/daemon/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e_test.go
@@ -2492,67 +2492,6 @@ func e2eLoopbackBaseURL(port int) string {
 	}).String()
 }
 
-func TestE2EServeAndHealthCheck(t *testing.T) {
-	t.Parallel()
-
-	if testing.Short() {
-		t.Skip("skipping E2E serve test in short mode")
-	}
-
-	dir := t.TempDir()
-	baseURL := startGestaltd(t, dir, nil)
-
-	client := &http.Client{Timeout: 2 * time.Second}
-	for _, tc := range []struct {
-		path string
-		want string
-	}{
-		{path: "/health", want: "ok"},
-		{path: "/ready", want: "ok"},
-	} {
-		tc := tc
-		t.Run(tc.path, func(t *testing.T) {
-			t.Parallel()
-
-			resp, err := client.Get(baseURL + tc.path)
-			if err != nil {
-				t.Fatalf("GET %s: %v", tc.path, err)
-			}
-			defer func() { _ = resp.Body.Close() }()
-			if resp.StatusCode != http.StatusOK {
-				body, _ := io.ReadAll(resp.Body)
-				t.Fatalf("expected %s 200, got %d: %s", tc.path, resp.StatusCode, body)
-			}
-
-			var body map[string]string
-			if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
-				t.Fatalf("decode %s response: %v", tc.path, err)
-			}
-			if body["status"] != tc.want {
-				t.Fatalf("%s status = %q, want %q", tc.path, body["status"], tc.want)
-			}
-		})
-	}
-
-	intResp, err := client.Get(baseURL + "/api/v1/apps")
-	if err != nil {
-		t.Fatalf("GET /api/v1/apps: %v", err)
-	}
-	defer func() { _ = intResp.Body.Close() }()
-	body, _ := io.ReadAll(intResp.Body)
-	if intResp.StatusCode != http.StatusOK {
-		t.Fatalf("expected /api/v1/apps 200, got %d: %s", intResp.StatusCode, body)
-	}
-
-	var apps []json.RawMessage
-	if err := json.Unmarshal(body, &apps); err != nil {
-		t.Fatalf("decode apps response: %v (body: %s)", err, body)
-	}
-	if len(apps) == 0 {
-		t.Fatal("expected /api/v1/apps to return at least one app")
-	}
-}
-
 func TestE2EServePathServesAdminWithoutInjectingRootUI(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Delete `TestE2EServeAndHealthCheck`, a broad subprocess serve smoke test that duplicated lower-level health/readiness coverage and more specific daemon serve coverage.
- Keep the more targeted serve E2Es that still exercise real `gestaltd serve` startup, mounted UI, split management routes, app-owned UI, cache provider wiring, and `/api/v1/apps` behavior.
- No new skipped tests or `paralleltest` suppressions.

## Runtime
- Removed test isolated runtime before deletion: `real 10.57s` (`go test ./gestaltd/internal/daemon -run '^TestE2EServeAndHealthCheck$' -count=1`).
- Full daemon package after deletion: `real 40.87s`, package time `39.403s` (`go test ./gestaltd/internal/daemon -count=1`).
- I am treating the speedup as the removed isolated subprocess cost; package wall time is noisy because these E2Es run in parallel and contend for builds/process startup.

## Verification
- `go test ./gestaltd/internal/server -run 'TestReadinessCheck|TestSecurityHeaders|TestMountedRootUIRoutesHiddenOnManagementProfile' -count=1 -timeout=300s`
- `go test ./gestaltd/internal/daemon -run 'TestE2EServePathServesAdminWithoutInjectingRootUI|TestE2EServePathAutoMountsOwnedUI|TestE2EServeConfigWatchReloadsAndKeepsLastGoodOnFailedPreflight|TestE2EServeSplitManagementRoutes|TestE2EServeAppOwnedUIWiring|TestE2EServeStartsWithAppBoundCacheProvider' -count=1 -timeout=300s`
- `go test ./gestaltd/internal/daemon -count=1 -timeout=300s`
- `golangci-lint run ./gestaltd/internal/daemon`