### PR TITLE
Trim provider release test builds

### DIFF
--- a/gestaltd/internal/daemon/provider_package_edge_test.go
+++ b/gestaltd/internal/daemon/provider_package_edge_test.go
@@ -470,48 +470,6 @@ func TestRun_ProviderPackageAndReleasePreservesYAMLManifestFormatAndConnectionDe
 	}
 }
 
-func TestRun_ProviderPackageAndReleaseSupportsSourcePackageManifestFile(t *testing.T) {
-	t.Parallel()
-
-	pluginDir := newSourceProviderReleaseFixture(t, t.TempDir())
-	if err := os.Remove(filepath.Join(pluginDir, providerpkg.ManifestFile)); err != nil {
-		t.Fatalf("remove %s: %v", providerpkg.ManifestFile, err)
-	}
-	writeReleaseTestManifestFormat(t, pluginDir, "manifest.yaml", &providermanifestv1.Manifest{
-		Kind:        providermanifestv1.KindApp,
-		Source:      "github.com/testowner/apps/source-manifest",
-		Version:     "0.0.1",
-		DisplayName: "Source Manifest",
-		Spec: &providermanifestv1.Spec{
-			ConfigSchemaPath: releaseProviderSchemaPath,
-			MCP:              true,
-		},
-		Build: &providermanifestv1.SourceBuild{
-			Command: []string{"sh", "./build.sh"},
-			Inputs:  []string{"go.mod", "go.sum", "provider.go", "cmd", "build.sh"},
-		},
-		Entrypoint: &providermanifestv1.Entrypoint{ArtifactPath: ".gestalt/build/provider"},
-	})
-
-	outputDir := t.TempDir()
-	const testVersion = "0.0.4-source.1"
-
-	runProviderPackageAndReleaseCommand(t, pluginDir,
-		"--version", testVersion,
-		"--output", outputDir,
-	)
-
-	archiveName := "gestalt-app-source-manifest_v" + testVersion + "_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
-	extractDir := extractReleasedArchive(t, outputDir, archiveName)
-	manifestPath, manifest := readManifestFromDir(t, extractDir)
-	if filepath.Base(manifestPath) != "manifest.yaml" {
-		t.Fatalf("released manifest = %q, want manifest.yaml", filepath.Base(manifestPath))
-	}
-	if manifest.Source != "github.com/testowner/apps/source-manifest" {
-		t.Fatalf("manifest source = %q, want %q", manifest.Source, "github.com/testowner/apps/source-manifest")
-	}
-}
-
 func TestRun_ProviderPackageRemovesStaleArchivesForSameApp(t *testing.T) {
 	t.Parallel()
 
@@ -569,35 +527,24 @@ func TestRun_ProviderPackageDoesNotWriteReleaseFinalizationFiles(t *testing.T) {
 	}
 }
 
-func TestRun_ProviderPackagePreservesOtherPlatformArchives(t *testing.T) {
+func TestProviderPackagePreservesOtherPlatformArchives(t *testing.T) {
 	t.Parallel()
 
-	pluginDir := newSourceProviderReleaseFixture(t, t.TempDir())
 	outputDir := t.TempDir()
 	linuxArchive := platformArchiveNameForTest(releaseTestAppName, "1.0.0", "linux", "amd64")
-	darwinArchive := platformArchiveNameForTest(releaseTestAppName, "1.0.0", "darwin", "arm64")
+	darwinArchive := platformArchiveNameForTest(releaseTestAppName, "0.9.0", "darwin", "arm64")
+	writeTestFile(t, outputDir, linuxArchive, []byte("linux archive"), 0o644)
+	writeTestFile(t, outputDir, darwinArchive, []byte("stale darwin archive"), 0o644)
 
-	runProviderPackageAndReleaseCommand(t, pluginDir,
-		"--version", "1.0.0",
-		"--output", outputDir,
-		"--platform", "linux/amd64",
-	)
-	runProviderPackageAndReleaseCommand(t, pluginDir,
-		"--version", "1.0.0",
-		"--output", outputDir,
-		"--platform", "darwin/arm64",
-	)
-
-	for _, archiveName := range []string{linuxArchive, darwinArchive} {
-		if _, err := os.Stat(filepath.Join(outputDir, archiveName)); err != nil {
-			t.Fatalf("expected archive %s to remain: %v", archiveName, err)
-		}
+	err := removeStalePackageArchives(outputDir, releaseTestAppName, releaseArchiveTargets([]releasePlatform{{GOOS: "darwin", GOARCH: "arm64"}}))
+	if err != nil {
+		t.Fatalf("removeStalePackageArchives: %v", err)
 	}
-	metadata := readProviderReleaseMetadata(t, outputDir)
-	for _, target := range []string{"linux/amd64", "darwin/arm64"} {
-		if _, ok := metadata.Artifacts[target]; !ok {
-			t.Fatalf("release metadata artifacts missing %s: %+v", target, metadata.Artifacts)
-		}
+	if _, err := os.Stat(filepath.Join(outputDir, linuxArchive)); err != nil {
+		t.Fatalf("expected other platform archive %s to remain: %v", linuxArchive, err)
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, darwinArchive)); !os.IsNotExist(err) {
+		t.Fatalf("expected same platform archive %s to be removed, got err=%v", darwinArchive, err)
 	}
 }
 
@@ -802,35 +749,5 @@ func TestRun_ProviderPackageRejectsGoModuleWithoutBuildCommand(t *testing.T) {
 	}
 	if !strings.Contains(string(out), "provider package requires build.command for executable source providers") {
 		t.Fatalf("unexpected output: %s", out)
-	}
-}
-
-func TestRun_ProviderPackageAndReleaseWindowsArtifactUsesExe(t *testing.T) {
-	t.Parallel()
-
-	pluginDir := newSourceProviderReleaseFixture(t, t.TempDir())
-	outputDir := t.TempDir()
-	const testVersion = "0.0.9-test"
-	const windowsPlatform = "windows/amd64"
-
-	runProviderPackageAndReleaseCommand(t, pluginDir,
-		"--version", testVersion,
-		"--platform", windowsPlatform,
-		"--output", outputDir,
-	)
-
-	archiveName := "gestalt-app-" + releaseTestAppName + "_v" + testVersion + "_windows_amd64.tar.gz"
-	extractDir := extractReleasedArchive(t, outputDir, archiveName)
-	manifest := readReleasedManifest(t, outputDir, archiveName)
-	binaryName := ".gestalt/build/provider"
-
-	if len(manifest.Artifacts) != 1 || manifest.Artifacts[0].Path != binaryName {
-		t.Fatalf("artifacts = %+v, want path %q", manifest.Artifacts, binaryName)
-	}
-	if manifest.Entrypoint == nil || manifest.Entrypoint.ArtifactPath != binaryName {
-		t.Fatalf("provider entrypoint = %+v, want artifact path %q", manifest.Entrypoint, binaryName)
-	}
-	if _, err := os.Stat(filepath.Join(extractDir, binaryName)); err != nil {
-		t.Fatalf("expected %s in archive: %v", binaryName, err)
 	}
 }

--- a/gestaltd/internal/daemon/provider_release_finalize_test.go
+++ b/gestaltd/internal/daemon/provider_release_finalize_test.go
@@ -7,28 +7,23 @@ import (
 	"strings"
 	"testing"
 
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/apps/providerpkg"
 )
 
 func TestRun_ProviderReleaseFinalizesArchivesWithoutSourceTree(t *testing.T) {
 	t.Parallel()
 
-	pluginDir := newSourceProviderReleaseFixture(t, t.TempDir())
 	outputDir := t.TempDir()
 	const testVersion = "0.0.4-finalize.1"
-	runProviderPackageCommand(t, pluginDir,
-		"--version", testVersion,
-		"--platform", runtime.GOOS+"/"+runtime.GOARCH,
-		"--output", outputDir,
-	)
-	writeReleaseBuildScript(t, pluginDir, "build.sh", "echo should-not-run >&2\nexit 42\n")
+	archiveName := platformArchiveNameForTest(releaseTestAppName, testVersion, runtime.GOOS, runtime.GOARCH)
+	writeProviderReleaseArchiveForTest(t, outputDir, archiveName, providerReleaseManifestForTest(testVersion, "Release Test", runtime.GOOS, runtime.GOARCH))
 
 	out, err := runProviderCommandResult(t.TempDir(), "release", "--dist-dir", outputDir, "--version", testVersion)
 	if err != nil {
 		t.Fatalf("provider release failed: %v\n%s", err, out)
 	}
 
-	archiveName := "gestalt-app-" + releaseTestAppName + "_v" + testVersion + "_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
 	metadata := readProviderReleaseMetadata(t, outputDir)
 	artifact, ok := metadata.Artifacts[providerpkg.CurrentPlatformString()]
 	if !ok {
@@ -39,40 +34,23 @@ func TestRun_ProviderReleaseFinalizesArchivesWithoutSourceTree(t *testing.T) {
 	}
 }
 
-func TestRun_ProviderReleaseRejectsDuplicateArchiveTargets(t *testing.T) {
+func TestProviderReleaseRejectsDuplicateArchiveTargets(t *testing.T) {
 	t.Parallel()
 
-	pluginDir := newSourceProviderReleaseFixture(t, t.TempDir())
 	outputDir := t.TempDir()
 	const testVersion = "0.0.4-duplicate.1"
-	runProviderPackageCommand(t, pluginDir,
-		"--version", testVersion,
-		"--platform", runtime.GOOS+"/"+runtime.GOARCH,
-		"--output", outputDir,
-	)
-	archiveName := "gestalt-app-" + releaseTestAppName + "_v" + testVersion + "_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
-	data, err := os.ReadFile(filepath.Join(outputDir, archiveName))
-	if err != nil {
-		t.Fatalf("read archive: %v", err)
-	}
-	duplicateName := "gestalt-app-" + releaseTestAppName + "_v" + testVersion + "_duplicate.tar.gz"
-	if err := os.WriteFile(filepath.Join(outputDir, duplicateName), data, 0o644); err != nil {
-		t.Fatalf("write duplicate archive: %v", err)
-	}
+	writeProviderReleaseArchiveForTest(t, outputDir, platformArchiveNameForTest(releaseTestAppName, testVersion, runtime.GOOS, runtime.GOARCH), providerReleaseManifestForTest(testVersion, "Release Test", runtime.GOOS, runtime.GOARCH))
+	writeProviderReleaseArchiveForTest(t, outputDir, "gestalt-app-"+releaseTestAppName+"_v"+testVersion+"_duplicate.tar.gz", providerReleaseManifestForTest(testVersion, "Release Test", runtime.GOOS, runtime.GOARCH))
 
-	out, err := runProviderCommandResult(pluginDir, "release", "--dist-dir", outputDir, "--version", testVersion)
-	if err == nil {
-		t.Fatalf("expected duplicate target failure, got output: %s", out)
-	}
-	if !strings.Contains(string(out), "multiple release archives map to target") {
-		t.Fatalf("unexpected output: %s", out)
+	_, _, _, err := collectReleaseArchives(outputDir, testVersion)
+	if err == nil || !strings.Contains(err.Error(), "multiple release archives map to target") {
+		t.Fatalf("collectReleaseArchives error = %v, want duplicate target failure", err)
 	}
 }
 
-func TestRun_ProviderReleaseRejectsMismatchedArchiveManifests(t *testing.T) {
+func TestProviderReleaseRejectsMismatchedArchiveManifests(t *testing.T) {
 	t.Parallel()
 
-	pluginDir := newSourceProviderReleaseFixture(t, t.TempDir())
 	outputDir := t.TempDir()
 	const testVersion = "0.0.4-mismatch.1"
 	alternatePlatform := releasePlatform{}
@@ -85,115 +63,131 @@ func TestRun_ProviderReleaseRejectsMismatchedArchiveManifests(t *testing.T) {
 	if alternatePlatform.GOOS == "" {
 		t.Fatal("no alternate release platform available")
 	}
-	runProviderPackageCommand(t, pluginDir,
-		"--version", testVersion,
-		"--platform", runtime.GOOS+"/"+runtime.GOARCH+","+providerpkg.PlatformString(alternatePlatform.GOOS, alternatePlatform.GOARCH),
-		"--output", outputDir,
-	)
-	archiveName := platformArchiveNameForTest(releaseTestAppName, testVersion, alternatePlatform.GOOS, alternatePlatform.GOARCH)
-	extractDir := extractReleasedArchive(t, outputDir, archiveName)
-	manifestPath, manifest := readManifestFromDir(t, extractDir)
-	manifest.DisplayName = "Different Release Test"
-	data, err := providerpkg.EncodeManifestFormat(manifest, providerpkg.ManifestFormatFromPath(manifestPath))
-	if err != nil {
-		t.Fatalf("encode manifest: %v", err)
-	}
-	if err := os.WriteFile(manifestPath, data, 0o644); err != nil {
-		t.Fatalf("write manifest: %v", err)
-	}
-	if err := providerpkg.CreatePackageFromDir(extractDir, filepath.Join(outputDir, archiveName)); err != nil {
-		t.Fatalf("rewrite archive: %v", err)
-	}
+	writeProviderReleaseArchiveForTest(t, outputDir, platformArchiveNameForTest(releaseTestAppName, testVersion, runtime.GOOS, runtime.GOARCH), providerReleaseManifestForTest(testVersion, "Release Test", runtime.GOOS, runtime.GOARCH))
+	writeProviderReleaseArchiveForTest(t, outputDir, platformArchiveNameForTest(releaseTestAppName, testVersion, alternatePlatform.GOOS, alternatePlatform.GOARCH), providerReleaseManifestForTest(testVersion, "Different Release Test", alternatePlatform.GOOS, alternatePlatform.GOARCH))
 
-	out, err := runProviderCommandResult(pluginDir, "release", "--dist-dir", outputDir, "--version", testVersion)
-	if err == nil {
-		t.Fatalf("expected mismatched manifest failure, got output: %s", out)
-	}
-	if !strings.Contains(string(out), "manifest does not match other release archives") {
-		t.Fatalf("unexpected output: %s", out)
+	_, _, _, err := collectReleaseArchives(outputDir, testVersion)
+	if err == nil || !strings.Contains(err.Error(), "manifest does not match other release archives") {
+		t.Fatalf("collectReleaseArchives error = %v, want mismatched manifest failure", err)
 	}
 }
 
-func TestRun_ProviderReleaseRejectsArchiveVersionMismatch(t *testing.T) {
+func TestProviderReleaseRejectsArchiveVersionMismatch(t *testing.T) {
 	t.Parallel()
 
-	pluginDir := newUIReleaseFixture(t, t.TempDir())
 	outputDir := t.TempDir()
-	runProviderPackageCommand(t, pluginDir,
-		"--version", "1.0.0",
-		"--output", outputDir,
-	)
+	writeProviderReleaseArchiveForTest(t, outputDir, "gestalt-app-"+uiTestAppName+"_v1.0.0.tar.gz", uiReleaseManifestForTest("1.0.0"))
 
-	out, err := runProviderCommandResult(pluginDir, "release", "--dist-dir", outputDir, "--version", "1.0.1")
-	if err == nil {
-		t.Fatalf("expected version mismatch failure, got output: %s", out)
-	}
-	if !strings.Contains(string(out), "does not match --version") {
-		t.Fatalf("unexpected output: %s", out)
+	_, _, _, err := collectReleaseArchives(outputDir, "1.0.1")
+	if err == nil || !strings.Contains(err.Error(), "does not match --version") {
+		t.Fatalf("collectReleaseArchives error = %v, want version mismatch failure", err)
 	}
 }
 
-func TestRun_ProviderReleaseRejectsNoArchives(t *testing.T) {
+func TestProviderReleaseRejectsNoArchives(t *testing.T) {
 	t.Parallel()
 
-	out, err := runProviderCommandResult(t.TempDir(), "release", "--dist-dir", t.TempDir())
-	if err == nil {
-		t.Fatalf("expected no archives failure, got output: %s", out)
-	}
-	if !strings.Contains(string(out), "no .tar.gz release archives found") {
-		t.Fatalf("unexpected output: %s", out)
+	_, _, _, err := collectReleaseArchives(t.TempDir(), "")
+	if err == nil || !strings.Contains(err.Error(), "no .tar.gz release archives found") {
+		t.Fatalf("collectReleaseArchives error = %v, want no archives failure", err)
 	}
 }
 
-func TestRun_ProviderReleaseRejectsMultipleRootManifests(t *testing.T) {
+func TestProviderReleaseRejectsMultipleRootManifests(t *testing.T) {
 	t.Parallel()
 
-	pluginDir := newUIReleaseFixture(t, t.TempDir())
 	outputDir := t.TempDir()
 	const testVersion = "1.0.0"
-	runProviderPackageCommand(t, pluginDir,
-		"--version", testVersion,
-		"--output", outputDir,
-	)
+	packageDir := t.TempDir()
+	writeProviderReleaseManifestSupportFilesForTest(t, packageDir, uiReleaseManifestForTest(testVersion))
+	writeReleasedManifestForArchiveTest(t, packageDir, uiReleaseManifestForTest(testVersion))
 	archiveName := "gestalt-app-" + uiTestAppName + "_v" + testVersion + ".tar.gz"
-	extractDir := extractReleasedArchive(t, outputDir, archiveName)
-	manifestData, err := os.ReadFile(filepath.Join(extractDir, providerpkg.ManifestFile))
+	manifestData, err := os.ReadFile(filepath.Join(packageDir, providerpkg.ManifestFile))
 	if err != nil {
 		t.Fatalf("read manifest: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(extractDir, "manifest.yml"), manifestData, 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(packageDir, "manifest.yml"), manifestData, 0o644); err != nil {
 		t.Fatalf("write second manifest: %v", err)
 	}
-	if err := providerpkg.CreatePackageFromDir(extractDir, filepath.Join(outputDir, archiveName)); err != nil {
-		t.Fatalf("rewrite archive: %v", err)
+	if err := providerpkg.CreatePackageFromDir(packageDir, filepath.Join(outputDir, archiveName)); err != nil {
+		t.Fatalf("CreatePackageFromDir(%s): %v", archiveName, err)
 	}
 
-	out, err := runProviderCommandResult(pluginDir, "release", "--dist-dir", outputDir, "--version", testVersion)
-	if err == nil {
-		t.Fatalf("expected multiple manifest failure, got output: %s", out)
-	}
-	if !strings.Contains(string(out), "contains multiple root provider manifests") {
-		t.Fatalf("unexpected output: %s", out)
+	_, _, _, err = collectReleaseArchives(outputDir, testVersion)
+	if err == nil || !strings.Contains(err.Error(), "contains multiple root provider manifests") {
+		t.Fatalf("collectReleaseArchives error = %v, want multiple manifest failure", err)
 	}
 }
 
-func TestRun_ProviderReleaseRejectsCorruptArchive(t *testing.T) {
+func TestProviderReleaseRejectsCorruptArchive(t *testing.T) {
 	t.Parallel()
 
-	pluginDir := newUIReleaseFixture(t, t.TempDir())
 	outputDir := t.TempDir()
 	const testVersion = "1.0.0"
-	runProviderPackageCommand(t, pluginDir,
-		"--version", testVersion,
-		"--output", outputDir,
-	)
 	archiveName := "gestalt-app-" + uiTestAppName + "_v" + testVersion + ".tar.gz"
 	if err := os.WriteFile(filepath.Join(outputDir, archiveName), []byte("not a gzip archive\n"), 0o644); err != nil {
 		t.Fatalf("rewrite corrupt archive: %v", err)
 	}
 
-	out, err := runProviderCommandResult(pluginDir, "release", "--dist-dir", outputDir, "--version", testVersion)
+	_, _, _, err := collectReleaseArchives(outputDir, testVersion)
 	if err == nil {
-		t.Fatalf("expected corrupt archive failure, got output: %s", out)
+		t.Fatal("expected corrupt archive failure")
+	}
+}
+
+func TestProviderReleaseMetadataIncludesPlatformArchives(t *testing.T) {
+	t.Parallel()
+
+	metadata, err := buildProviderReleaseMetadata(
+		providerReleaseManifestForTest("1.0.0", "Release Test", "linux", "amd64"),
+		"1.0.0",
+		[]releaseArchive{
+			{Path: "gestalt-app-release-test_v1.0.0_linux_amd64.tar.gz", SHA256: "linux-sha", Target: "linux/amd64"},
+			{Path: "gestalt-app-release-test_v1.0.0_darwin_arm64.tar.gz", SHA256: "darwin-sha", Target: "darwin/arm64"},
+		},
+	)
+	if err != nil {
+		t.Fatalf("buildProviderReleaseMetadata: %v", err)
+	}
+	for target, wantSHA := range map[string]string{
+		"linux/amd64":  "linux-sha",
+		"darwin/arm64": "darwin-sha",
+	} {
+		artifact, ok := metadata.Artifacts[target]
+		if !ok {
+			t.Fatalf("metadata artifacts missing %s: %+v", target, metadata.Artifacts)
+		}
+		if artifact.SHA256 != wantSHA {
+			t.Fatalf("metadata artifact %s sha = %q, want %q", target, artifact.SHA256, wantSHA)
+		}
+	}
+}
+
+func providerReleaseManifestForTest(version, displayName, goos, goarch string) *providermanifestv1.Manifest {
+	artifactPath := filepath.ToSlash(filepath.Join("bin", "provider-"+goos+"-"+goarch))
+	return &providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindApp,
+		Source:      releaseTestSource,
+		Version:     version,
+		DisplayName: displayName,
+		IconFile:    releaseTestIconPath,
+		Spec:        &providermanifestv1.Spec{},
+		Artifacts: []providermanifestv1.Artifact{{
+			OS:   goos,
+			Arch: goarch,
+			Path: artifactPath,
+		}},
+		Entrypoint: &providermanifestv1.Entrypoint{ArtifactPath: artifactPath},
+	}
+}
+
+func uiReleaseManifestForTest(version string) *providermanifestv1.Manifest {
+	return &providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindUI,
+		Source:      uiTestSource,
+		Version:     version,
+		DisplayName: "UI Test",
+		IconFile:    releaseTestIconPath,
+		Spec:        &providermanifestv1.Spec{AssetRoot: uiTestAssetRoot},
 	}
 }

--- a/gestaltd/internal/daemon/provider_release_helpers_test.go
+++ b/gestaltd/internal/daemon/provider_release_helpers_test.go
@@ -734,6 +734,59 @@ func readProviderReleaseMetadata(t *testing.T, outputDir string) *providerReleas
 	return &metadata
 }
 
+func writeProviderReleaseArchiveForTest(t *testing.T, outputDir, archiveName string, manifest *providermanifestv1.Manifest) string {
+	t.Helper()
+
+	packageDir := t.TempDir()
+	writeProviderReleaseManifestSupportFilesForTest(t, packageDir, manifest)
+	writeReleasedManifestForArchiveTest(t, packageDir, manifest)
+
+	archivePath := filepath.Join(outputDir, archiveName)
+	if err := providerpkg.CreatePackageFromDir(packageDir, archivePath); err != nil {
+		t.Fatalf("CreatePackageFromDir(%s): %v", archiveName, err)
+	}
+	return archivePath
+}
+
+func writeProviderReleaseManifestSupportFilesForTest(t *testing.T, dir string, manifest *providermanifestv1.Manifest) {
+	t.Helper()
+
+	if manifest == nil {
+		return
+	}
+	if manifest.IconFile != "" {
+		writeTestFile(t, dir, manifest.IconFile, []byte("<svg></svg>\n"), 0o644)
+	}
+	if manifest.Spec != nil {
+		if manifest.Spec.ConfigSchemaPath != "" {
+			writeTestFile(t, dir, manifest.Spec.ConfigSchemaPath, []byte(`{"type":"object"}`), 0o644)
+		}
+		if manifest.Spec.AssetRoot != "" {
+			writeTestFile(t, dir, filepath.Join(filepath.FromSlash(manifest.Spec.AssetRoot), "index.html"), []byte("<html></html>\n"), 0o644)
+		}
+	}
+	for _, artifact := range manifest.Artifacts {
+		if artifact.Path == "" {
+			continue
+		}
+		writeTestFile(t, dir, artifact.Path, []byte("artifact:"+artifact.Path), 0o755)
+	}
+}
+
+func writeReleasedManifestForArchiveTest(t *testing.T, dir string, manifest *providermanifestv1.Manifest) {
+	t.Helper()
+
+	populateMissingArtifactDigests(t, dir, manifest)
+	data, err := providerpkg.EncodeManifestFormat(manifest, providerpkg.ManifestFormatJSON)
+	if err != nil {
+		t.Fatalf("EncodeManifestFormat: %v", err)
+	}
+	writeTestFile(t, dir, providerpkg.ManifestFile, data, 0o644)
+	if manifest.Kind == providermanifestv1.KindApp && manifest.Spec != nil {
+		writeTestFile(t, dir, providerpkg.StaticCatalogFile, []byte("name: provider\noperations:\n  - id: echo\n    method: POST\n"), 0o644)
+	}
+}
+
 func readManifestFromDir(t *testing.T, dir string) (string, *providermanifestv1.Manifest) {
 	t.Helper()
 

--- a/gestaltd/services/apps/providerpkg/prepared_stage_test.go
+++ b/gestaltd/services/apps/providerpkg/prepared_stage_test.go
@@ -551,3 +551,14 @@ fi
 		t.Fatal("staged catalog.yaml is empty")
 	}
 }
+
+func TestStagedReleaseBinaryNameAddsWindowsSuffix(t *testing.T) {
+	t.Parallel()
+
+	if got := stagedReleaseBinaryName("release-test", "windows"); got != "gestalt-app-release-test.exe" {
+		t.Fatalf("windows binary name = %q, want %q", got, "gestalt-app-release-test.exe")
+	}
+	if got := stagedReleaseBinaryName("release-test", "linux"); got != "gestalt-app-release-test" {
+		t.Fatalf("linux binary name = %q, want %q", got, "gestalt-app-release-test")
+	}
+}


### PR DESCRIPTION
## Summary
- replace build-heavy provider release finalization tests with narrow fake-archive coverage
- replace the cross-platform archive preservation package+release test with a direct stale-archive check plus direct release metadata coverage
- remove redundant source-manifest and misleading Windows artifact package+release tests; keep a tiny providerpkg unit for Windows generated binary naming

## Timing
Provider/release slice on this machine:
- before: `real 37.53s`
- after: `real 18.73s`
- observed savings: ~18.8s

## Tests
- `go test ./gestaltd/internal/daemon ./gestaltd/services/apps/providerpkg -run '^(TestRun_ProviderReleaseFinalizesArchivesWithoutSourceTree|TestProviderReleaseRejectsDuplicateArchiveTargets|TestProviderReleaseRejectsMismatchedArchiveManifests|TestProviderReleaseRejectsArchiveVersionMismatch|TestProviderReleaseRejectsNoArchives|TestProviderReleaseRejectsMultipleRootManifests|TestProviderReleaseRejectsCorruptArchive|TestProviderReleaseMetadataIncludesPlatformArchives|TestProviderPackagePreservesOtherPlatformArchives|TestStagedReleaseBinaryNameAddsWindowsSuffix)$' -count=1`
- `go test ./gestaltd/internal/daemon ./gestaltd/services/apps/providerpkg -count=1 -timeout=300s`