### PR TITLE
Replace serve watch E2E with focused reload test

### DIFF
--- a/gestaltd/internal/daemon/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e_test.go
@@ -2457,51 +2457,6 @@ func e2eLoopbackBaseURL(port int) string {
 	}).String()
 }
 
-func TestE2EServeConfigWatchReloadsAndKeepsLastGoodOnFailedPreflight(t *testing.T) {
-	t.Parallel()
-
-	if testing.Short() {
-		t.Skip("skipping serve --watch config test in short mode")
-	}
-
-	dir := t.TempDir()
-	appDir := setupAppDir(t, dir)
-	manifestPath := componentProviderManifestPath(t, appDir)
-	port, holder := reservePort(t)
-	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
-	cfgPath := writeE2EConfig(t, dir, appDir, port)
-	originalConfig, err := os.ReadFile(cfgPath)
-	if err != nil {
-		t.Fatalf("read config: %v", err)
-	}
-
-	cmd := exec.Command(gestaltdBin, "serve", "--config", cfgPath, "--app", "example", "--watch")
-	cmd.Env = append(os.Environ(), "GOTELEMETRY=off")
-	startCommandAfterReleasingPort(t, holder, cmd, baseURL)
-
-	client := &http.Client{Timeout: 2 * time.Second}
-	_ = waitForHTTPBody(t, client, baseURL+"/api/v1/apps", "Example Provider")
-
-	setAppManifestDisplayName(t, manifestPath, "Config Watch Provider")
-	_ = waitForHTTPBody(t, client, baseURL+"/api/v1/apps", "Config Watch Provider")
-
-	invalidConfig := strings.Replace(string(originalConfig), manifestPath, filepath.Join(dir, "missing", "manifest.yaml"), 1)
-	if invalidConfig == string(originalConfig) {
-		t.Fatalf("test config did not contain manifest path %s", manifestPath)
-	}
-	if err := os.WriteFile(cfgPath, []byte(invalidConfig), 0o644); err != nil {
-		t.Fatalf("write invalid config: %v", err)
-	}
-	time.Sleep(750 * time.Millisecond)
-	_ = waitForHTTPBody(t, client, baseURL+"/api/v1/apps", "Config Watch Provider")
-
-	if err := os.WriteFile(cfgPath, originalConfig, 0o644); err != nil {
-		t.Fatalf("restore config: %v", err)
-	}
-	setAppManifestDisplayName(t, manifestPath, "Recovered Config Watch Provider")
-	_ = waitForHTTPBody(t, client, baseURL+"/api/v1/apps", "Recovered Config Watch Provider")
-}
-
 func TestE2EServeSplitManagementRoutes(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/daemon/serve_watch.go
+++ b/gestaltd/internal/daemon/serve_watch.go
@@ -48,6 +48,7 @@ func runServeWatch(configPaths []string, state operator.StatePaths) error {
 	if !timer.Stop() {
 		<-timer.C
 	}
+	defer timer.Stop()
 	var timerC <-chan time.Time
 	scheduleReload := func() {
 		if timerC == nil {
@@ -92,31 +93,36 @@ func runServeWatch(configPaths []string, state operator.StatePaths) error {
 			}
 		case <-timerC:
 			timerC = nil
-			next, err := prepareServeWatchCandidate(ctx, configPaths, state)
-			if err != nil {
-				slog.Error("watch reload failed; keeping current server", "error", err)
-				continue
-			}
-			nextWatcher, err := newProviderLocalFSWatcher(next.plan)
-			if err != nil {
-				next.close()
-				slog.Error("watch reload failed; keeping current server", "error", err)
-				continue
-			}
-			if err := active.stop(); err != nil {
-				slog.Warn("watch reload replacing exited server", "error", err)
-			}
-			next.start()
-			_ = watcher.Close()
-			watcher = nextWatcher
-			active = next
-			slog.Info("watch reload complete",
-				"files", len(active.plan.Files),
-				"roots", len(active.plan.Roots),
-				"watch_dirs", len(active.plan.WatchDirs),
-			)
+			active, watcher = reloadServeWatchCandidate(ctx, configPaths, state, active, watcher)
 		}
 	}
+}
+
+func reloadServeWatchCandidate(ctx context.Context, configPaths []string, state operator.StatePaths, active *serveWatchCandidate, watcher *fsnotify.Watcher) (*serveWatchCandidate, *fsnotify.Watcher) {
+	next, err := prepareServeWatchCandidate(ctx, configPaths, state)
+	if err != nil {
+		slog.Error("watch reload failed; keeping current server", "error", err)
+		return active, watcher
+	}
+	nextWatcher, err := newProviderLocalFSWatcher(next.plan)
+	if err != nil {
+		next.close()
+		slog.Error("watch reload failed; keeping current server", "error", err)
+		return active, watcher
+	}
+	if err := active.stop(); err != nil {
+		slog.Warn("watch reload replacing exited server", "error", err)
+	}
+	next.start()
+	if watcher != nil {
+		_ = watcher.Close()
+	}
+	slog.Info("watch reload complete",
+		"files", len(next.plan.Files),
+		"roots", len(next.plan.Roots),
+		"watch_dirs", len(next.plan.WatchDirs),
+	)
+	return next, nextWatcher
 }
 
 func prepareServeWatchCandidate(parent context.Context, configPaths []string, state operator.StatePaths) (*serveWatchCandidate, error) {

--- a/gestaltd/internal/daemon/serve_watch_test.go
+++ b/gestaltd/internal/daemon/serve_watch_test.go
@@ -1,0 +1,24 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/operator"
+)
+
+func TestReloadServeWatchCandidateKeepsActiveWhenPrepareFails(t *testing.T) {
+	t.Parallel()
+
+	active := &serveWatchCandidate{}
+	missingConfigPath := filepath.Join(t.TempDir(), "missing.yaml")
+
+	gotActive, gotWatcher := reloadServeWatchCandidate(context.Background(), []string{missingConfigPath}, operator.StatePaths{}, active, nil)
+	if gotActive != active {
+		t.Fatal("reload replaced active candidate after prepare failure")
+	}
+	if gotWatcher != nil {
+		t.Fatalf("reload created watcher after prepare failure: %v", gotWatcher)
+	}
+}


### PR DESCRIPTION
## Summary
- Delete the slow subprocess E2E `TestE2EServeConfigWatchReloadsAndKeepsLastGoodOnFailedPreflight`.
- Extract the reload step from the `serve --watch` loop.
- Add a focused unit test that verifies failed reload preparation keeps the active candidate/watcher instead of replacing the running server.

## Timing
Before, on current `main` after #2226:
- `go test ./gestaltd/internal/daemon -count=1 -timeout=300s`: `real 36.37s`
- Slow removed test in that run: `24.780s TestE2EServeConfigWatchReloadsAndKeepsLastGoodOnFailedPreflight`

After this revised change:
- `go test ./gestaltd/internal/daemon -count=1 -timeout=300s`: `real 31.25s`
- `go test ./gestaltd/internal/daemon -run '^$' -count=1 -timeout=120s`: `real 9.08s`
- Replacement test: `go test ./gestaltd/internal/daemon -run 'TestReloadServeWatchCandidateKeepsActiveWhenPrepareFails' -count=1 -timeout=120s`: package `8.167s` including daemon `TestMain` setup

Net full-package wall-time savings in this run: about `5.12s`. The removed E2E is gone from the per-test list; package wall time is now led by `TestE2EHostedHTTPSubjectResolutionUsesAuthorizationAndInheritedInvocation` and `TestE2EServeSplitManagementRoutes`.

## Tests
- `go test ./gestaltd/internal/daemon -run 'TestReloadServeWatchCandidateKeepsActiveWhenPrepareFails' -count=1 -timeout=120s`
- `/usr/bin/time -p go test ./gestaltd/internal/daemon -run '^$' -count=1 -timeout=120s`
- `/usr/bin/time -p go test -json ./gestaltd/internal/daemon -count=1 -timeout=300s`
