### PR TITLE
Use sync.OnceValues for lazy daemon test fixtures

### DIFF
--- a/gestaltd/internal/daemon/agent_local_test.go
+++ b/gestaltd/internal/daemon/agent_local_test.go
@@ -40,7 +40,7 @@ providers:
 		t.Fatalf("write config: %v", err)
 	}
 
-	out, err := exec.Command(gestaltdBin, "agent", "launch", "--config", cfgPath, "--dry-run").CombinedOutput()
+	out, err := gestaltdCommand(t, "agent", "launch", "--config", cfgPath, "--dry-run").CombinedOutput()
 	if err != nil {
 		t.Fatalf("agent launch --dry-run failed: %v\n%s", err, out)
 	}
@@ -115,7 +115,7 @@ providers:
 		t.Fatalf("write config: %v", err)
 	}
 
-	out, err := exec.Command(gestaltdBin, "agent", "launch", "--config", cfgPath).CombinedOutput()
+	out, err := gestaltdCommand(t, "agent", "launch", "--config", cfgPath).CombinedOutput()
 	var exitErr *exec.ExitError
 	if !errors.As(err, &exitErr) {
 		t.Fatalf("agent launch err = %v, want exit status 7\n%s", err, out)
@@ -159,7 +159,7 @@ providers:
 		t.Fatalf("write config: %v", err)
 	}
 
-	out, err := exec.Command(gestaltdBin, "agent", "doctor", "--config", cfgPath).CombinedOutput()
+	out, err := gestaltdCommand(t, "agent", "doctor", "--config", cfgPath).CombinedOutput()
 	if err == nil {
 		t.Fatalf("agent doctor unexpectedly succeeded:\n%s", out)
 	}
@@ -197,7 +197,7 @@ providers:
 		t.Fatalf("write config: %v", err)
 	}
 
-	cmd := exec.Command(gestaltdBin, "agent", "launch", "--config", cfgPath, "--dry-run")
+	cmd := gestaltdCommand(t, "agent", "launch", "--config", cfgPath, "--dry-run")
 	cmd.Env = withoutEnv(os.Environ(), missingEnv, "GESTALT_TEST_MISSING_UNSELECTED_HARNESS_ENV")
 	out, err := cmd.CombinedOutput()
 	if err == nil {

--- a/gestaltd/internal/daemon/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e_test.go
@@ -48,7 +48,7 @@ apps:
 		t.Fatalf("write config audit: %v", err)
 	}
 
-	out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+	out, err := gestaltdCommand(t, "validate", "--config", cfgPath).CombinedOutput()
 	if err == nil {
 		t.Fatalf("expected gestaltd validate to fail, got success\n%s", out)
 	}
@@ -106,7 +106,7 @@ func TestE2EValidateRejectsInvalidAuditSettings(t *testing.T) {
 				t.Fatalf("write config audit: %v", err)
 			}
 
-			out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+			out, err := gestaltdCommand(t, "validate", "--config", cfgPath).CombinedOutput()
 			if err == nil {
 				t.Fatalf("expected gestaltd validate to fail, got success\n%s", out)
 			}
@@ -181,7 +181,7 @@ apps:
 				t.Fatalf("write config: %v", err)
 			}
 
-			out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+			out, err := gestaltdCommand(t, "validate", "--config", cfgPath).CombinedOutput()
 			if err != nil {
 				t.Fatalf("gestaltd validate failed: %v\noutput: %s", err, out)
 			}
@@ -300,7 +300,7 @@ workflows:
 		t.Fatalf("write config: %v", err)
 	}
 
-	out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+	out, err := gestaltdCommand(t, "validate", "--config", cfgPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("gestaltd validate failed: %v\noutput: %s", err, out)
 	}
@@ -370,7 +370,7 @@ apps:
 				t.Fatalf("write invalid config: %v", err)
 			}
 
-			out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+			out, err := gestaltdCommand(t, "validate", "--config", cfgPath).CombinedOutput()
 			if err == nil {
 				t.Fatalf("expected gestaltd validate to fail, got success\n%s", out)
 			}
@@ -388,7 +388,7 @@ func TestE2EProviderValidateIsolatedSourceApp(t *testing.T) {
 	providersDir := setupDefaultLocalProvidersDir(t, dir)
 	appDir := setupAppDir(t, dir)
 
-	cmd := exec.Command(gestaltdBin, "provider", "validate", "--path", appDir)
+	cmd := gestaltdCommand(t, "provider", "validate", "--path", appDir)
 	cmd.Env = append(os.Environ(),
 		"GESTALT_PROVIDERS_DIR="+providersDir,
 		"GOTELEMETRY=off",
@@ -413,7 +413,7 @@ func TestE2EProviderValidateSourceUI(t *testing.T) {
 	mountedUI := setupMountedUIDir(t, dir)
 	setUIManifestSource(t, mountedUI.ManifestPath, "github.com/test/ui/roadmap.review")
 
-	cmd := exec.Command(gestaltdBin, "provider", "validate", "--path", mountedUI.ManifestPath)
+	cmd := gestaltdCommand(t, "provider", "validate", "--path", mountedUI.ManifestPath)
 	cmd.Env = append(os.Environ(),
 		"GESTALT_PROVIDERS_DIR="+providersDir,
 		"GOTELEMETRY=off",
@@ -449,7 +449,7 @@ apps:
 		t.Fatalf("write config: %v", err)
 	}
 
-	cmd := exec.Command(gestaltdBin, "provider", "validate", "--path", appDir, "--config", cfgPath, "--name", "provider_go")
+	cmd := gestaltdCommand(t, "provider", "validate", "--path", appDir, "--config", cfgPath, "--name", "provider_go")
 	cmd.Env = append(os.Environ(),
 		"GESTALT_PROVIDERS_DIR="+providersDir,
 		"GOTELEMETRY=off",
@@ -469,7 +469,7 @@ func TestE2EProviderValidateRejectsNonAppManifest(t *testing.T) {
 	dir := t.TempDir()
 	manifestPath := componentProviderManifestPath(t, setupIndexedDBProviderDir(t, dir))
 
-	out, err := exec.Command(gestaltdBin, "provider", "validate", "--path", manifestPath).CombinedOutput()
+	out, err := gestaltdCommand(t, "provider", "validate", "--path", manifestPath).CombinedOutput()
 	if err == nil {
 		t.Fatalf("expected gestaltd provider validate to fail for non-app manifest\n%s", out)
 	}
@@ -530,7 +530,7 @@ apps:
 		t.Fatalf("write support override: %v", err)
 	}
 
-	failingCmd := exec.Command(gestaltdBin, "provider", "validate", "--path", targetDir, "--config", baseCfgPath)
+	failingCmd := gestaltdCommand(t, "provider", "validate", "--path", targetDir, "--config", baseCfgPath)
 	failingCmd.Env = append(os.Environ(),
 		"GESTALT_PROVIDERS_DIR="+providersDir,
 		"GOTELEMETRY=off",
@@ -543,7 +543,7 @@ apps:
 		t.Fatalf("expected mount collision error, got: %s", failingOut)
 	}
 
-	successCmd := exec.Command(gestaltdBin, "provider", "validate", "--path", targetDir, "--config", baseCfgPath, "--config", overrideCfgPath)
+	successCmd := gestaltdCommand(t, "provider", "validate", "--path", targetDir, "--config", baseCfgPath, "--config", overrideCfgPath)
 	successCmd.Env = append(os.Environ(),
 		"GESTALT_PROVIDERS_DIR="+providersDir,
 		"GOTELEMETRY=off",
@@ -645,7 +645,7 @@ func TestE2EValidateConfigPathPrecedence(t *testing.T) {
 				args = append(args, tc.before(t, root, home, workdir)...)
 			}
 
-			cmd := exec.Command(gestaltdBin, args...)
+			cmd := gestaltdCommand(t, args...)
 			cmd.Dir = workdir
 			cmd.Env = append(os.Environ(),
 				"HOME="+home,
@@ -715,7 +715,7 @@ apps:
 		t.Fatalf("WriteFile override config: %v", err)
 	}
 
-	out, err := exec.Command(gestaltdBin, "validate", "--config", baseConfigPath).CombinedOutput()
+	out, err := gestaltdCommand(t, "validate", "--config", baseConfigPath).CombinedOutput()
 	if err == nil {
 		t.Fatalf("expected base config validate to fail, output: %s", out)
 	}
@@ -723,7 +723,7 @@ apps:
 		t.Fatalf("expected base config failure to mention missing manifest, got: %s", out)
 	}
 
-	out, err = exec.Command(gestaltdBin, "validate", "--config", baseConfigPath, "--config", overrideConfigPath).CombinedOutput()
+	out, err = gestaltdCommand(t, "validate", "--config", baseConfigPath, "--config", overrideConfigPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("expected layered config validate to succeed: %v\n%s", err, out)
 	}
@@ -763,7 +763,7 @@ apps:
 		t.Fatalf("WriteFile config: %v", err)
 	}
 
-	out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+	out, err := gestaltdCommand(t, "validate", "--config", cfgPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("expected validate to succeed: %v\n%s", err, out)
 	}
@@ -777,7 +777,7 @@ apps:
 		t.Fatalf("validate should not leave prepared artifacts in config dir, got err=%v", err)
 	}
 	overrideLockfilePath := filepath.Join(dir, "state", "validate", operator.LockfileName)
-	out, err = exec.Command(gestaltdBin, "validate", "--config", cfgPath, "--lockfile", overrideLockfilePath).CombinedOutput()
+	out, err = gestaltdCommand(t, "validate", "--config", cfgPath, "--lockfile", overrideLockfilePath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("expected validate with --lockfile to succeed: %v\n%s", err, out)
 	}
@@ -786,7 +786,7 @@ apps:
 	}
 
 	providedArtifactsDir := filepath.Join(dir, "artifacts", "validate")
-	out, err = exec.Command(gestaltdBin, "validate", "--config", cfgPath, "--artifacts-dir", providedArtifactsDir).CombinedOutput()
+	out, err = gestaltdCommand(t, "validate", "--config", cfgPath, "--artifacts-dir", providedArtifactsDir).CombinedOutput()
 	if err == nil {
 		t.Fatalf("expected validate with --artifacts-dir to fail, got success:\n%s", out)
 	}
@@ -809,7 +809,7 @@ func TestE2EValidateStaticAcceptsMissingRuntimeEnvPlaceholder(t *testing.T) {
 		t.Fatalf("write config: %v", err)
 	}
 
-	out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+	out, err := gestaltdCommand(t, "validate", "--config", cfgPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("expected static validate to succeed with missing runtime env placeholder: %v\n%s", err, out)
 	}
@@ -853,7 +853,7 @@ apps:
 		t.Fatalf("write config: %v", err)
 	}
 	lockPath := filepath.Join(dir, "gestalt.lock.json")
-	out, err := exec.Command(gestaltdBin, "lock", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
+	out, err := gestaltdCommand(t, "lock", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("gestaltd lock failed: %v\n%s", err, out)
 	}
@@ -891,7 +891,7 @@ apps:
 		t.Fatalf("write lockfile: %v", err)
 	}
 
-	out, err = exec.Command(gestaltdBin, "validate", "--platform", "linux/amd64", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
+	out, err = gestaltdCommand(t, "validate", "--platform", "linux/amd64", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("expected platform validate to use locked static metadata: %v\n%s", err, out)
 	}
@@ -949,13 +949,13 @@ apps:
 		}
 	}
 	writeConfig("echo")
-	out, err := exec.Command(gestaltdBin, "lock", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
+	out, err := gestaltdCommand(t, "lock", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("gestaltd lock failed: %v\n%s", err, out)
 	}
 
 	writeConfig("greet")
-	out, err = exec.Command(gestaltdBin, "validate", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
+	out, err = gestaltdCommand(t, "validate", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
 	if err == nil {
 		t.Fatalf("expected stale static catalog metadata to fail validation:\n%s", out)
 	}
@@ -995,7 +995,7 @@ apps:
 		t.Fatalf("write config: %v", err)
 	}
 	lockPath := filepath.Join(dir, "missing.lock.json")
-	out, err := exec.Command(gestaltdBin, "validate", "--platform", runtime.GOOS+"/"+runtime.GOARCH, "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
+	out, err := gestaltdCommand(t, "validate", "--platform", runtime.GOOS+"/"+runtime.GOARCH, "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
 	if err == nil {
 		t.Fatalf("expected explicit missing lockfile to fail:\n%s", out)
 	}
@@ -1092,7 +1092,7 @@ authorization:
 		t.Fatalf("write lockfile: %v", err)
 	}
 
-	out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
+	out, err := gestaltdCommand(t, "validate", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("expected static validate to tolerate unavailable legacy ui metadata: %v\n%s", err, out)
 	}
@@ -1187,7 +1187,7 @@ apps:
 		t.Fatalf("write lockfile: %v", err)
 	}
 
-	out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
+	out, err := gestaltdCommand(t, "validate", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("expected static validate to tolerate unavailable legacy target catalog: %v\n%s", err, out)
 	}
@@ -1233,7 +1233,7 @@ apps:
 		t.Fatalf("WriteFile config: %v", err)
 	}
 
-	out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+	out, err := gestaltdCommand(t, "validate", "--config", cfgPath).CombinedOutput()
 	if err == nil {
 		t.Fatalf("expected validate to fail, got success:\n%s", out)
 	}
@@ -1301,7 +1301,7 @@ apps:
 		t.Fatalf("WriteFile config: %v", err)
 	}
 
-	out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+	out, err := gestaltdCommand(t, "validate", "--config", cfgPath).CombinedOutput()
 	if err == nil {
 		t.Fatalf("expected validate to fail, got success:\n%s", out)
 	}
@@ -1415,7 +1415,7 @@ func setupExecutableProviderDir(t *testing.T, baseDir, kind, name string) string
 			t.Fatalf("build agent provider fixture: %v", err)
 		}
 	default:
-		binData, err := os.ReadFile(appBin)
+		binData, err := os.ReadFile(providerAppBinary(t))
 		if err != nil {
 			t.Fatalf("read provider binary: %v", err)
 		}
@@ -1631,6 +1631,7 @@ func setupIndexedDBProviderDir(t *testing.T, baseDir string) string {
 		t.Fatalf("MkdirAll(%s): %v", providerDir, err)
 	}
 
+	indexedDBBin := indexedDBProviderBinary(t)
 	binDest := filepath.Join(providerDir, filepath.Base(indexedDBBin))
 	data, err := os.ReadFile(indexedDBBin)
 	if err != nil {
@@ -1660,6 +1661,7 @@ func setupExternalCredentialsProviderDir(t *testing.T, baseDir string) string {
 		t.Fatalf("MkdirAll(%s): %v", providerDir, err)
 	}
 
+	externalCredentialsBin := externalCredentialsProviderBinary(t)
 	binDest := filepath.Join(providerDir, filepath.Base(externalCredentialsBin))
 	data, err := os.ReadFile(externalCredentialsBin)
 	if err != nil {
@@ -1690,7 +1692,7 @@ func setupPrebuiltAppDir(t *testing.T, baseDir string) string {
 	}
 
 	binDest := filepath.Join(providerDir, "gestalt-app-example")
-	binData, err := os.ReadFile(appBin)
+	binData, err := os.ReadFile(providerAppBinary(t))
 	if err != nil {
 		t.Fatalf("read app binary: %v", err)
 	}
@@ -1813,6 +1815,7 @@ func setupDefaultLocalProvidersDir(t *testing.T, baseDir string) string {
 		t.Fatalf("MkdirAll(%s): %v", indexedDBDir, err)
 	}
 
+	indexedDBBin := indexedDBProviderBinary(t)
 	indexedDBBinDest := filepath.Join(indexedDBDir, filepath.Base(indexedDBBin))
 	indexedDBData, err := os.ReadFile(indexedDBBin)
 	if err != nil {
@@ -1834,6 +1837,7 @@ func setupDefaultLocalProvidersDir(t *testing.T, baseDir string) string {
 	if err := os.MkdirAll(externalCredentialsDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll(%s): %v", externalCredentialsDir, err)
 	}
+	externalCredentialsBin := externalCredentialsProviderBinary(t)
 	externalCredentialsBinDest := filepath.Join(externalCredentialsDir, filepath.Base(externalCredentialsBin))
 	externalCredentialsData, err := os.ReadFile(externalCredentialsBin)
 	if err != nil {
@@ -1886,6 +1890,7 @@ func setupDefaultLocalProvidersDir(t *testing.T, baseDir string) string {
 func writeServeConfig(t *testing.T, dir string, port int, mountedUI *mountedUITestConfig) string {
 	t.Helper()
 
+	_ = defaultProvidersDir(t)
 	indexedDBDir := setupIndexedDBProviderDir(t, dir)
 	indexedDBManifest := componentProviderManifestPath(t, indexedDBDir)
 	appDir := setupPrebuiltAppDir(t, dir)
@@ -1932,6 +1937,7 @@ providers:
 func writeServeConfigWithManagement(t *testing.T, dir string, publicPort, managementPort int, mountedUI *mountedUITestConfig) string {
 	t.Helper()
 
+	_ = defaultProvidersDir(t)
 	indexedDBDir := setupIndexedDBProviderDir(t, dir)
 	indexedDBManifest := componentProviderManifestPath(t, indexedDBDir)
 	appDir := setupPrebuiltAppDir(t, dir)
@@ -2072,7 +2078,7 @@ func TestE2EServeSplitManagementRoutes(t *testing.T) {
 	managementURL := fmt.Sprintf("http://127.0.0.1:%d", managementPort)
 	cfgPath := writeServeConfigWithManagement(t, dir, publicPort, managementPort, mountedUI)
 
-	cmd := exec.Command(gestaltdBin, "serve", "--config", cfgPath)
+	cmd := gestaltdCommand(t, "serve", "--config", cfgPath)
 	releasePortHoldersAndStart(t, []net.Listener{publicHolder, managementHolder}, func() {
 		startCommandAndWaitReadyForURLs(t, cmd, []string{publicURL, managementURL})
 	})
@@ -2163,7 +2169,7 @@ func TestE2ELockLocalProviders(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := writeServeConfig(t, dir, 0, nil)
 
-	out, err := exec.Command(gestaltdBin, "lock", "--config", cfgPath).CombinedOutput()
+	out, err := gestaltdCommand(t, "lock", "--config", cfgPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("gestaltd lock failed: %v\noutput: %s", err, out)
 	}
@@ -2227,15 +2233,15 @@ providers:
 	}
 
 	lockPath := filepath.Join(dir, "gestalt.lock.json")
-	out, err := exec.Command(gestaltdBin, "lock", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
+	out, err := gestaltdCommand(t, "lock", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("gestaltd lock should not resolve runtime secret refs: %v\n%s", err, out)
 	}
-	out, err = exec.Command(gestaltdBin, "sync", "--locked", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
+	out, err = gestaltdCommand(t, "sync", "--locked", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("gestaltd sync should not resolve runtime secret refs: %v\n%s", err, out)
 	}
-	out, err = exec.Command(gestaltdBin, "validate", "--runtime", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
+	out, err = gestaltdCommand(t, "validate", "--runtime", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
 	if err == nil {
 		t.Fatalf("gestaltd validate --runtime unexpectedly succeeded without runtime secret:\n%s", out)
 	}

--- a/gestaltd/internal/daemon/main_test.go
+++ b/gestaltd/internal/daemon/main_test.go
@@ -74,7 +74,7 @@ func TestE2ECLIHelp(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			out, err := exec.Command(gestaltdBin, tc.args...).CombinedOutput()
+			out, err := exec.Command(gestaltdBinary(t), tc.args...).CombinedOutput()
 			if err != nil {
 				t.Fatalf("gestaltd %s: %v\n%s", strings.Join(tc.args, " "), err, out)
 			}
@@ -159,11 +159,11 @@ packages:
 	}
 	indexURL := (&url.URL{Scheme: "file", Path: indexPath}).String()
 
-	out, err := exec.Command(gestaltdBin, "provider", "repo", "add", "local", indexURL, "--config", cfgPath).CombinedOutput()
+	out, err := exec.Command(gestaltdBinary(t), "provider", "repo", "add", "local", indexURL, "--config", cfgPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("provider repo add failed: %v\n%s", err, out)
 	}
-	out, err = exec.Command(gestaltdBin, "provider", "add", "github.com/acme/providers/alpha", "--config", cfgPath, "--repo", "local", "--name", "alpha", "--no-lock").CombinedOutput()
+	out, err = exec.Command(gestaltdBinary(t), "provider", "add", "github.com/acme/providers/alpha", "--config", cfgPath, "--repo", "local", "--name", "alpha", "--no-lock").CombinedOutput()
 	if err != nil {
 		t.Fatalf("provider add failed: %v\n%s", err, out)
 	}
@@ -260,7 +260,7 @@ func TestE2ECLIRejectsBadArgs(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			out, err := exec.Command(gestaltdBin, tc.args...).CombinedOutput()
+			out, err := exec.Command(gestaltdBinary(t), tc.args...).CombinedOutput()
 			if err == nil {
 				t.Fatalf("expected gestaltd %s to fail, output: %s", strings.Join(tc.args, " "), out)
 			}

--- a/gestaltd/internal/daemon/provider_lifecycle_test.go
+++ b/gestaltd/internal/daemon/provider_lifecycle_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -164,7 +163,7 @@ func TestE2EProviderAddExactSourceAndRejectsRepeatedConfig(t *testing.T) {
 		t.Fatalf("MetadataURL = %q", got)
 	}
 
-	out, err = runGestaltdResult("provider", "add", "github.com/acme/providers/alpha", "--config", cfgPath, "--config", otherCfgPath, "--repo", "local", "--name", "beta", "--no-lock")
+	out, err = runGestaltdResult(t, "provider", "add", "github.com/acme/providers/alpha", "--config", cfgPath, "--config", otherCfgPath, "--repo", "local", "--name", "beta", "--no-lock")
 	if err == nil {
 		t.Fatalf("provider add with repeated --config succeeded: %s", out)
 	}
@@ -180,7 +179,7 @@ func TestE2EProviderAddRejectsExistingName(t *testing.T) {
 	indexURL := writeProviderLifecycleIndex(t, dir)
 
 	runGestaltd(t, "provider", "repo", "add", "local", indexURL, "--config", cfgPath)
-	out, err := runGestaltdResult("provider", "add", "github.com/acme/providers/alpha", "--config", cfgPath, "--repo", "local", "--name", "alpha", "--no-lock")
+	out, err := runGestaltdResult(t, "provider", "add", "github.com/acme/providers/alpha", "--config", cfgPath, "--repo", "local", "--name", "alpha", "--no-lock")
 	if err == nil {
 		t.Fatalf("provider add duplicate succeeded: %s", out)
 	}
@@ -349,7 +348,7 @@ providers:
 	}
 
 	writeProviderLifecycleTestFile(t, filepath.Join(dir, operator.LockfileName), "not json")
-	out, err = runGestaltdResult("provider", "list", "--config", cfgPath)
+	out, err = runGestaltdResult(t, "provider", "list", "--config", cfgPath)
 	if err == nil {
 		t.Fatalf("provider list with corrupt lockfile succeeded: %s", out)
 	}
@@ -374,7 +373,7 @@ providers:
     secretstore:
       source: env
 `)
-	out, err := runGestaltdResult("provider", "remove", "alpha", "--config", cfgPath, "--no-lock")
+	out, err := runGestaltdResult(t, "provider", "remove", "alpha", "--config", cfgPath, "--no-lock")
 	if err == nil {
 		t.Fatalf("ambiguous provider remove succeeded: %s", out)
 	}
@@ -411,13 +410,13 @@ providers:
 `)
 	writeProviderLifecycleTestFile(t, otherCfgPath, "apiVersion: gestaltd.config/v6\n")
 
-	out, err := runGestaltdResult("provider", "upgrade", "alpha", "--version", "1.2.3", "--config", cfgPath, "--config", otherCfgPath)
+	out, err := runGestaltdResult(t, "provider", "upgrade", "alpha", "--version", "1.2.3", "--config", cfgPath, "--config", otherCfgPath)
 	if err == nil {
 		t.Fatalf("provider upgrade with repeated --config succeeded: %s", out)
 	}
 	assertContains(t, out, "only one --config")
 
-	out, err = runGestaltdResult("provider", "upgrade", "alpha", "--version", "1.2.3", "--config", cfgPath)
+	out, err = runGestaltdResult(t, "provider", "upgrade", "alpha", "--version", "1.2.3", "--config", cfgPath)
 	if err == nil {
 		t.Fatalf("ambiguous provider upgrade succeeded: %s", out)
 	}
@@ -520,7 +519,7 @@ func writeProviderLifecycleTestFile(t *testing.T, path, data string) {
 
 func runGestaltd(t *testing.T, args ...string) string {
 	t.Helper()
-	out, err := runGestaltdResult(args...)
+	out, err := runGestaltdResult(t, args...)
 	if err != nil {
 		t.Fatalf("gestaltd %s failed: %v\n%s", strings.Join(args, " "), err, out)
 	}
@@ -529,21 +528,23 @@ func runGestaltd(t *testing.T, args ...string) string {
 
 func runGestaltdWithEnv(t *testing.T, env []string, args ...string) string {
 	t.Helper()
-	out, err := runGestaltdResultWithEnv(env, args...)
+	out, err := runGestaltdResultWithEnv(t, env, args...)
 	if err != nil {
 		t.Fatalf("gestaltd %s failed: %v\n%s", strings.Join(args, " "), err, out)
 	}
 	return out
 }
 
-func runGestaltdResult(args ...string) (string, error) {
-	return runGestaltdResultWithEnv(nil, args...)
+func runGestaltdResult(t testing.TB, args ...string) (string, error) {
+	t.Helper()
+	return runGestaltdResultWithEnv(t, nil, args...)
 }
 
-func runGestaltdResultWithEnv(env []string, args ...string) (string, error) {
-	cmd := exec.Command(gestaltdBin, args...)
+func runGestaltdResultWithEnv(t testing.TB, env []string, args ...string) (string, error) {
+	t.Helper()
+	cmd := gestaltdCommand(t, args...)
 	if len(env) > 0 {
-		cmd.Env = append(os.Environ(), env...)
+		cmd.Env = append(cmd.Env, env...)
 	}
 	out, err := cmd.CombinedOutput()
 	return string(out), err

--- a/gestaltd/internal/daemon/provider_local_session_test.go
+++ b/gestaltd/internal/daemon/provider_local_session_test.go
@@ -12,6 +12,7 @@ import (
 func TestPrepareProviderLocalSessionSupportsDirectUITarget(t *testing.T) {
 	t.Parallel()
 
+	_ = defaultProvidersDir(t)
 	dir := t.TempDir()
 	mountedUI := setupMountedUIDir(t, dir)
 	setUIManifestSource(t, mountedUI.ManifestPath, "github.com/test/ui/roadmap.review")
@@ -58,6 +59,7 @@ func TestPrepareProviderLocalSessionSupportsDirectUITarget(t *testing.T) {
 func TestPrepareProviderLocalSessionAutoMountsSiblingUI(t *testing.T) {
 	t.Parallel()
 
+	_ = defaultProvidersDir(t)
 	dir := t.TempDir()
 	rootDir := filepath.Join(dir, "package")
 	appDir := setupAppDir(t, filepath.Join(rootDir, "app"))
@@ -114,6 +116,7 @@ func TestPrepareProviderLocalSessionAutoMountsSiblingUI(t *testing.T) {
 func TestPrepareProviderLocalSessionLeavesAppWithoutUIUnmounted(t *testing.T) {
 	t.Parallel()
 
+	_ = defaultProvidersDir(t)
 	dir := t.TempDir()
 	appDir := setupAppDir(t, dir)
 	setAppManifestSource(t, appDir, "github.com/test/apps/api-only")

--- a/gestaltd/internal/daemon/provider_package_edge_test.go
+++ b/gestaltd/internal/daemon/provider_package_edge_test.go
@@ -199,7 +199,7 @@ func TestRun_ProviderPackageRejectsDeletedBuild(t *testing.T) {
 	}
 
 	pluginDir := newBuiltUIReleaseFixture(t, t.TempDir())
-	out, err := runProviderPackageAndReleaseCommandResult(pluginDir,
+	out, err := runProviderPackageAndReleaseCommandResult(t, pluginDir,
 		"--version", "0.0.3-legacy-build-ui",
 		"--output", t.TempDir(),
 	)
@@ -554,7 +554,7 @@ func TestRun_ProviderPackageRejectsOutputInsideUIAssetRoot(t *testing.T) {
 	pluginDir := newUIReleaseFixtureWithAssetRoot(t, t.TempDir(), "release-output")
 	outputDir := filepath.Join(pluginDir, "release-output", "nested")
 
-	out, err := runProviderPackageAndReleaseCommandResult(pluginDir, "--version", "1.0.0", "--output", outputDir)
+	out, err := runProviderPackageAndReleaseCommandResult(t, pluginDir, "--version", "1.0.0", "--output", outputDir)
 	if err == nil {
 		t.Fatalf("expected provider release to fail, got output: %s", out)
 	}
@@ -601,7 +601,7 @@ paths:
 	}
 	writeTestFile(t, pluginDir, providerpkg.StaticCatalogFile, []byte("name: release-test\noperations:\n  - id: generated_op\n    method: GET\n"), 0o644)
 
-	out, err := runProviderPackageAndReleaseCommandResult(pluginDir, "--version", "0.0.4-source.1", "--platform", runtime.GOOS+"/"+runtime.GOARCH, "--output", t.TempDir())
+	out, err := runProviderPackageAndReleaseCommandResult(t, pluginDir, "--version", "0.0.4-source.1", "--platform", runtime.GOOS+"/"+runtime.GOARCH, "--output", t.TempDir())
 	if err == nil {
 		t.Fatalf("expected provider release to fail, got output: %s", out)
 	}
@@ -700,7 +700,7 @@ func TestRun_ProviderPackageRejectsPrebuiltExecutableProvider(t *testing.T) {
 	outputDir := t.TempDir()
 	const testVersion = "0.0.5-test"
 
-	out, err := runProviderPackageAndReleaseCommandResult(pluginDir,
+	out, err := runProviderPackageAndReleaseCommandResult(t, pluginDir,
 		"--version", testVersion,
 		"--output", outputDir,
 	)
@@ -718,7 +718,7 @@ func TestRun_ProviderPackageRejectsExplicitPlatformForPrebuiltProvider(t *testin
 	pluginDir := newPrebuiltProviderReleaseFixture(t, t.TempDir())
 	outputDir := t.TempDir()
 
-	out, err := runProviderPackageAndReleaseCommandResult(pluginDir,
+	out, err := runProviderPackageAndReleaseCommandResult(t, pluginDir,
 		"--version", "0.0.5-platform-test",
 		"--platform", runtime.GOOS+"/"+runtime.GOARCH,
 		"--output", outputDir,
@@ -740,7 +740,7 @@ func TestRun_ProviderPackageRejectsGoModuleWithoutBuildCommand(t *testing.T) {
 	outputDir := t.TempDir()
 	const testVersion = "0.0.6-test"
 
-	out, err := runProviderPackageAndReleaseCommandResult(pluginDir,
+	out, err := runProviderPackageAndReleaseCommandResult(t, pluginDir,
 		"--version", testVersion,
 		"--output", outputDir,
 	)

--- a/gestaltd/internal/daemon/provider_package_test.go
+++ b/gestaltd/internal/daemon/provider_package_test.go
@@ -28,7 +28,7 @@ func TestRun_ProviderPackageRequiresVersion(t *testing.T) {
 	t.Parallel()
 
 	pluginDir := newSourceProviderReleaseFixture(t, t.TempDir())
-	out, err := runProviderCommandResult(pluginDir, "package")
+	out, err := runProviderCommandResult(t, pluginDir, "package")
 	if err == nil {
 		t.Fatal("expected error when --version missing")
 	}
@@ -45,7 +45,7 @@ func TestRun_ProviderReleaseRejectsPackageOnlyFlags(t *testing.T) {
 		t.Run(flagName, func(t *testing.T) {
 			t.Parallel()
 
-			out, err := runProviderCommandResult(t.TempDir(), "release", flagName, "value")
+			out, err := runProviderCommandResult(t, t.TempDir(), "release", flagName, "value")
 			if err == nil {
 				t.Fatalf("expected %s rejection, got output: %s", flagName, out)
 			}
@@ -105,7 +105,7 @@ entrypoint:
 			}
 			writeTestFile(t, pluginDir, "manifest.yaml", []byte(tc.manifestYAML), 0644)
 
-			out, err := runProviderPackageAndReleaseCommandResult(pluginDir, "--version", "0.0.1-test")
+			out, err := runProviderPackageAndReleaseCommandResult(t, pluginDir, "--version", "0.0.1-test")
 			if err == nil {
 				t.Fatal("expected invalid manifest error")
 			}
@@ -129,7 +129,7 @@ func TestE2EProviderPackageAndReleaseBigquery(t *testing.T) {
 	const testVersion = "0.0.1-test"
 	const testPlatform = "linux/amd64"
 
-	cmd := exec.Command(gestaltdBin, "provider", "package",
+	cmd := exec.Command(gestaltdBinary(t), "provider", "package",
 		"--version", testVersion,
 		"--platform", testPlatform,
 		"--output", outputDir,
@@ -139,7 +139,7 @@ func TestE2EProviderPackageAndReleaseBigquery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("provider package failed: %v\n%s", err, out)
 	}
-	cmd = exec.Command(gestaltdBin, "provider", "release",
+	cmd = exec.Command(gestaltdBinary(t), "provider", "release",
 		"--version", testVersion,
 		"--dist-dir", outputDir,
 	)

--- a/gestaltd/internal/daemon/provider_publish_test.go
+++ b/gestaltd/internal/daemon/provider_publish_test.go
@@ -37,7 +37,7 @@ providerSnapshotRepositories:
 		t.Fatalf("write config: %v", err)
 	}
 
-	out, err := runProviderCommandResult(pluginDir,
+	out, err := runProviderCommandResult(t, pluginDir,
 		"publish",
 		"--config", configPath,
 		"--repo", "valon",
@@ -91,7 +91,7 @@ providerSnapshotRepositories:
 		t.Fatalf("write config: %v", err)
 	}
 
-	out, err := runProviderCommandResult(pluginDir,
+	out, err := runProviderCommandResult(t, pluginDir,
 		"publish",
 		"--config", configPath,
 		"--repo", "valon",
@@ -143,7 +143,7 @@ func TestRun_ProviderPublishRejectsShortRef(t *testing.T) {
 	t.Parallel()
 
 	pluginDir := newUIReleaseFixture(t, t.TempDir())
-	out, err := runProviderCommandResult(pluginDir,
+	out, err := runProviderCommandResult(t, pluginDir,
 		"publish",
 		"--repo", "valon",
 		"--manifest", filepath.Join(pluginDir, "manifest.json"),
@@ -163,7 +163,7 @@ func TestRun_ProviderPublishRejectsShortRef(t *testing.T) {
 func TestRun_ProviderPublishRejectsJSONFormatWithoutDryRun(t *testing.T) {
 	t.Parallel()
 
-	out, err := runProviderCommandResult(t.TempDir(),
+	out, err := runProviderCommandResult(t, t.TempDir(),
 		"publish",
 		"--repo", "valon",
 		"--format", "json",
@@ -232,7 +232,7 @@ exit 1
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Setenv("GCLOUD_CALLS", callsPath)
 
-	out, err := runProviderCommandResult(pluginDir,
+	out, err := runProviderCommandResult(t, pluginDir,
 		"publish",
 		"--config", configPath,
 		"--repo", "valon",
@@ -304,7 +304,7 @@ exit 1
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Setenv("GCLOUD_CALLS", callsPath)
 
-	out, err := runProviderCommandResult(pluginDir,
+	out, err := runProviderCommandResult(t, pluginDir,
 		"publish",
 		"--config", configPath,
 		"--repo", "valon",
@@ -375,7 +375,7 @@ exit 1
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Setenv("GCLOUD_CALLS", callsPath)
 
-	out, err := runProviderCommandResult(pluginDir,
+	out, err := runProviderCommandResult(t, pluginDir,
 		"publish",
 		"--config", configPath,
 		"--repo", "valon",

--- a/gestaltd/internal/daemon/provider_release_finalize_test.go
+++ b/gestaltd/internal/daemon/provider_release_finalize_test.go
@@ -19,7 +19,7 @@ func TestRun_ProviderReleaseFinalizesArchivesWithoutSourceTree(t *testing.T) {
 	archiveName := platformArchiveNameForTest(releaseTestAppName, testVersion, runtime.GOOS, runtime.GOARCH)
 	writeProviderReleaseArchiveForTest(t, outputDir, archiveName, providerReleaseManifestForTest(testVersion, "Release Test", runtime.GOOS, runtime.GOARCH))
 
-	out, err := runProviderCommandResult(t.TempDir(), "release", "--dist-dir", outputDir, "--version", testVersion)
+	out, err := runProviderCommandResult(t, t.TempDir(), "release", "--dist-dir", outputDir, "--version", testVersion)
 	if err != nil {
 		t.Fatalf("provider release failed: %v\n%s", err, out)
 	}

--- a/gestaltd/internal/daemon/provider_release_helpers_test.go
+++ b/gestaltd/internal/daemon/provider_release_helpers_test.go
@@ -53,7 +53,7 @@ func assertArtifactPlatform(t *testing.T, artifact providermanifestv1.Artifact, 
 func runProviderPackageAndReleaseCommand(t *testing.T, pluginDir string, args ...string) string {
 	t.Helper()
 
-	out, err := runProviderPackageAndReleaseCommandResult(pluginDir, args...)
+	out, err := runProviderPackageAndReleaseCommandResult(t, pluginDir, args...)
 	if err != nil {
 		t.Fatalf("provider package+release failed: %v\n%s", err, out)
 	}
@@ -63,24 +63,26 @@ func runProviderPackageAndReleaseCommand(t *testing.T, pluginDir string, args ..
 func runProviderPackageCommand(t *testing.T, pluginDir string, args ...string) string {
 	t.Helper()
 
-	out, err := runProviderPackageCommandResult(pluginDir, args...)
+	out, err := runProviderPackageCommandResult(t, pluginDir, args...)
 	if err != nil {
 		t.Fatalf("provider package failed: %v\n%s", err, out)
 	}
 	return string(out)
 }
 
-func runProviderCommandResult(pluginDir string, args ...string) ([]byte, error) {
+func runProviderCommandResult(t testing.TB, pluginDir string, args ...string) ([]byte, error) {
+	t.Helper()
 	cmdArgs := append([]string{"provider"}, args...)
-	cmd := exec.Command(gestaltdBin, cmdArgs...)
+	cmd := exec.Command(gestaltdBinary(t), cmdArgs...)
 	cmd.Dir = pluginDir
 	return cmd.CombinedOutput()
 }
 
 // runProviderPackageAndReleaseCommandResult keeps archive-creation tests focused
 // on their historical assertions while exercising the new two-step CLI.
-func runProviderPackageAndReleaseCommandResult(pluginDir string, args ...string) ([]byte, error) {
-	packageOut, err := runProviderPackageCommandResult(pluginDir, args...)
+func runProviderPackageAndReleaseCommandResult(t testing.TB, pluginDir string, args ...string) ([]byte, error) {
+	t.Helper()
+	packageOut, err := runProviderPackageCommandResult(t, pluginDir, args...)
 	if err != nil {
 		return packageOut, err
 	}
@@ -89,12 +91,13 @@ func runProviderPackageAndReleaseCommandResult(pluginDir string, args ...string)
 	if version != "" {
 		releaseArgs = append(releaseArgs, "--version", version)
 	}
-	releaseOut, err := runProviderCommandResult(pluginDir, releaseArgs...)
+	releaseOut, err := runProviderCommandResult(t, pluginDir, releaseArgs...)
 	return append(packageOut, releaseOut...), err
 }
 
-func runProviderPackageCommandResult(pluginDir string, args ...string) ([]byte, error) {
-	return runProviderCommandResult(pluginDir, append([]string{"package"}, args...)...)
+func runProviderPackageCommandResult(t testing.TB, pluginDir string, args ...string) ([]byte, error) {
+	t.Helper()
+	return runProviderCommandResult(t, pluginDir, append([]string{"package"}, args...)...)
 }
 
 func providerReleaseTestVersionAndOutput(args []string) (string, string) {

--- a/gestaltd/internal/daemon/provider_test.go
+++ b/gestaltd/internal/daemon/provider_test.go
@@ -278,7 +278,7 @@ func TestProviderAttachCommandsUseOwnerAttachmentRoutes(t *testing.T) {
 	defer ts.Close()
 	remote := ts.URL + "/team-a"
 
-	listOut, err := runProviderCommandResult("", "attach", "list", "--remote", remote, "--remote-token", "owner-token")
+	listOut, err := runProviderCommandResult(t, "", "attach", "list", "--remote", remote, "--remote-token", "owner-token")
 	if err != nil {
 		t.Fatalf("provider attach list: %v\n%s", err, listOut)
 	}
@@ -288,7 +288,7 @@ func TestProviderAttachCommandsUseOwnerAttachmentRoutes(t *testing.T) {
 		}
 	}
 
-	showOut, err := runProviderCommandResult("", "attach", "show", "--remote", remote, "--remote-token", "owner-token", "attach-1")
+	showOut, err := runProviderCommandResult(t, "", "attach", "show", "--remote", remote, "--remote-token", "owner-token", "attach-1")
 	if err != nil {
 		t.Fatalf("provider attach show: %v\n%s", err, showOut)
 	}
@@ -298,7 +298,7 @@ func TestProviderAttachCommandsUseOwnerAttachmentRoutes(t *testing.T) {
 		}
 	}
 
-	detachOut, err := runProviderCommandResult("", "attach", "detach", "--remote", remote, "--remote-token", "owner-token", "attach-1")
+	detachOut, err := runProviderCommandResult(t, "", "attach", "detach", "--remote", remote, "--remote-token", "owner-token", "attach-1")
 	if err != nil {
 		t.Fatalf("provider attach detach: %v\n%s", err, detachOut)
 	}
@@ -400,7 +400,7 @@ func TestRun_ProviderCLIUsageAndErrors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			out, err := runProviderCommandResult("", tc.args...)
+			out, err := runProviderCommandResult(t, "", tc.args...)
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("expected error for provider %v, got output: %s", tc.args, out)

--- a/gestaltd/internal/daemon/testmain_test.go
+++ b/gestaltd/internal/daemon/testmain_test.go
@@ -18,11 +18,44 @@ import (
 )
 
 var (
-	gestaltdBin            string
-	appBin                 string
-	indexedDBBin           string
-	externalCredentialsBin string
+	testTmpDir string
+
+	gestaltdBinaryFixture = sync.OnceValues(func() (string, error) {
+		path := filepath.Join(testTmpDir, "gestaltd")
+		return path, buildTarget(".", "github.com/valon-technologies/gestalt/server/cmd/gestaltd", path)
+	})
+	providerAppBinaryFixture = sync.OnceValues(func() (string, error) {
+		path := filepath.Join(testTmpDir, "provider")
+		return path, buildGoFixtureBinary(testutil.MustExampleProviderAppPath(), path, "github.com/valon-technologies/gestalt/testdata/provider-go", `gestalt.ServeProvider(ctx, providerpkg.New(), providerpkg.Router.WithName("provider-go"))`)
+	})
+	indexedDBProviderBinaryFixture = sync.OnceValues(func() (string, error) {
+		path := filepath.Join(testTmpDir, "indexeddb-provider")
+		indexedDBSrcDir := filepath.Join(filepath.Dir(testutil.MustExampleProviderAppPath()), "provider-go-indexeddb")
+		return path, buildGoFixtureBinary(indexedDBSrcDir, path, "github.com/valon-technologies/gestalt/testdata/provider-go-indexeddb", "gestalt.ServeIndexedDBProvider(ctx, providerpkg.New())")
+	})
+	externalCredentialsProviderBinaryFixture = sync.OnceValues(func() (string, error) {
+		path := filepath.Join(testTmpDir, "external-credentials-provider")
+		externalCredentialsSrcDir, err := writeExternalCredentialsProviderFixture(testTmpDir)
+		if err != nil {
+			return path, fmt.Errorf("write external credentials fixture: %w", err)
+		}
+		return path, buildGoFixtureBinary(externalCredentialsSrcDir, path, "github.com/valon-technologies/gestalt/testdata/provider-go-externalcredentials", "gestalt.ServeExternalCredentialProvider(ctx, providerpkg.New())")
+	})
+	defaultProvidersDirFixture = sync.OnceValues(func() (string, error) {
+		path := filepath.Join(testTmpDir, "providers")
+		indexedDBBin, err := indexedDBProviderBinaryFixture()
+		if err != nil {
+			return path, fmt.Errorf("indexeddb provider: %w", err)
+		}
+		externalCredentialsBin, err := externalCredentialsProviderBinaryFixture()
+		if err != nil {
+			return path, fmt.Errorf("external credentials provider: %w", err)
+		}
+		return path, writeDefaultProvidersDir(testTmpDir, indexedDBBin, externalCredentialsBin)
+	})
 )
+
+type stringFixture func() (string, error)
 
 func TestMain(m *testing.M) {
 	tmpDir, err := os.MkdirTemp("", "gestaltd-e2e-*")
@@ -31,54 +64,9 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	gestaltdBin = filepath.Join(tmpDir, "gestaltd")
-	appBin = filepath.Join(tmpDir, "provider")
-	indexedDBBin = filepath.Join(tmpDir, "indexeddb-provider")
-	externalCredentialsBin = filepath.Join(tmpDir, "external-credentials-provider")
-	indexedDBSrcDir := filepath.Join(filepath.Dir(testutil.MustExampleProviderAppPath()), "provider-go-indexeddb")
-	externalCredentialsSrcDir, err := writeExternalCredentialsProviderFixture(tmpDir)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "write external credentials fixture: %v\n", err)
-		_ = os.RemoveAll(tmpDir)
-		os.Exit(1)
-	}
+	testTmpDir = tmpDir
 
-	var wg sync.WaitGroup
-	errs := make([]error, 4)
-	wg.Add(4)
-	go func() {
-		defer wg.Done()
-		errs[0] = buildTarget(".", "github.com/valon-technologies/gestalt/server/cmd/gestaltd", gestaltdBin)
-	}()
-	go func() {
-		defer wg.Done()
-		errs[1] = buildGoFixtureBinary(testutil.MustExampleProviderAppPath(), appBin, "github.com/valon-technologies/gestalt/testdata/provider-go", `gestalt.ServeProvider(ctx, providerpkg.New(), providerpkg.Router.WithName("provider-go"))`)
-	}()
-	go func() {
-		defer wg.Done()
-		errs[2] = buildGoFixtureBinary(indexedDBSrcDir, indexedDBBin, "github.com/valon-technologies/gestalt/testdata/provider-go-indexeddb", "gestalt.ServeIndexedDBProvider(ctx, providerpkg.New())")
-	}()
-	go func() {
-		defer wg.Done()
-		errs[3] = buildGoFixtureBinary(externalCredentialsSrcDir, externalCredentialsBin, "github.com/valon-technologies/gestalt/testdata/provider-go-externalcredentials", "gestalt.ServeExternalCredentialProvider(ctx, providerpkg.New())")
-	}()
-	wg.Wait()
-
-	for i, err := range errs {
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "build %d: %v\n", i, err)
-			_ = os.RemoveAll(tmpDir)
-			os.Exit(1)
-		}
-	}
-
-	defaultProvidersDir, err := writeDefaultProvidersDir(tmpDir)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "write default providers dir: %v\n", err)
-		_ = os.RemoveAll(tmpDir)
-		os.Exit(1)
-	}
-	if err := os.Setenv("GESTALT_PROVIDERS_DIR", defaultProvidersDir); err != nil {
+	if err := os.Setenv("GESTALT_PROVIDERS_DIR", filepath.Join(testTmpDir, "providers")); err != nil {
 		fmt.Fprintf(os.Stderr, "set GESTALT_PROVIDERS_DIR: %v\n", err)
 		_ = os.RemoveAll(tmpDir)
 		os.Exit(1)
@@ -87,6 +75,48 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 	_ = os.RemoveAll(tmpDir)
 	os.Exit(code)
+}
+
+func gestaltdBinary(t testing.TB) string {
+	t.Helper()
+	return mustFixture(t, "gestaltd", gestaltdBinaryFixture)
+}
+
+func gestaltdCommand(t testing.TB, args ...string) *exec.Cmd {
+	t.Helper()
+	cmd := exec.Command(gestaltdBinary(t), args...)
+	providersDir := defaultProvidersDir(t)
+	cmd.Env = append(os.Environ(), "GESTALT_PROVIDERS_DIR="+providersDir)
+	return cmd
+}
+
+func providerAppBinary(t testing.TB) string {
+	t.Helper()
+	return mustFixture(t, "provider app", providerAppBinaryFixture)
+}
+
+func indexedDBProviderBinary(t testing.TB) string {
+	t.Helper()
+	return mustFixture(t, "indexeddb provider", indexedDBProviderBinaryFixture)
+}
+
+func externalCredentialsProviderBinary(t testing.TB) string {
+	t.Helper()
+	return mustFixture(t, "external credentials provider", externalCredentialsProviderBinaryFixture)
+}
+
+func defaultProvidersDir(t testing.TB) string {
+	t.Helper()
+	return mustFixture(t, "default providers", defaultProvidersDirFixture)
+}
+
+func mustFixture(t testing.TB, name string, fixture stringFixture) string {
+	t.Helper()
+	path, err := fixture()
+	if err != nil {
+		t.Fatalf("build %s fixture: %v", name, err)
+	}
+	return path
 }
 
 func buildTarget(dir, target, output string) error {
@@ -213,10 +243,10 @@ func writeExternalCredentialsProviderFixture(baseDir string) (string, error) {
 	return fixtureDir, nil
 }
 
-func writeDefaultProvidersDir(baseDir string) (string, error) {
+func writeDefaultProvidersDir(baseDir, indexedDBBin, externalCredentialsBin string) error {
 	providersDir := filepath.Join(baseDir, "providers")
 	if err := os.MkdirAll(providersDir, 0o755); err != nil {
-		return "", err
+		return err
 	}
 
 	if err := writeComponentProviderDir(filepath.Join(providersDir, "indexeddb", "relationaldb"), indexedDBBin, &providermanifestv1.Manifest{
@@ -226,7 +256,7 @@ func writeDefaultProvidersDir(baseDir string) (string, error) {
 		DisplayName: "Relational IndexedDB",
 		Spec:        &providermanifestv1.Spec{},
 	}); err != nil {
-		return "", err
+		return err
 	}
 
 	if err := writeComponentProviderDir(filepath.Join(providersDir, "externalcredentials", "default"), externalCredentialsBin, &providermanifestv1.Manifest{
@@ -236,16 +266,16 @@ func writeDefaultProvidersDir(baseDir string) (string, error) {
 		DisplayName: "Default External Credentials",
 		Spec:        &providermanifestv1.Spec{},
 	}); err != nil {
-		return "", err
+		return err
 	}
 	if err := writeLocalProviderReleaseMetadata(filepath.Join(providersDir, "externalcredentials", "default")); err != nil {
-		return "", err
+		return err
 	}
 
 	uiDir := filepath.Join(providersDir, "ui", "default")
 	distDir := filepath.Join(uiDir, "dist")
 	if err := os.MkdirAll(distDir, 0o755); err != nil {
-		return "", err
+		return err
 	}
 	if err := os.WriteFile(filepath.Join(distDir, "index.html"), []byte(`<!doctype html>
 <html>
@@ -258,10 +288,10 @@ func writeDefaultProvidersDir(baseDir string) (string, error) {
   </body>
 </html>
 `), 0o644); err != nil {
-		return "", err
+		return err
 	}
 	if err := os.WriteFile(filepath.Join(uiDir, "build.sh"), []byte("mkdir -p dist\nprintf '<html>Default Gestalt UI</html>\\n' > dist/index.html\n"), 0o755); err != nil {
-		return "", err
+		return err
 	}
 	if err := writeManifest(filepath.Join(uiDir, "manifest.yaml"), &providermanifestv1.Manifest{
 		Kind:        providermanifestv1.KindUI,
@@ -274,10 +304,10 @@ func writeDefaultProvidersDir(baseDir string) (string, error) {
 		},
 		Spec: &providermanifestv1.Spec{AssetRoot: "dist"},
 	}); err != nil {
-		return "", err
+		return err
 	}
 
-	return providersDir, nil
+	return nil
 }
 
 func writeComponentProviderDir(dir, binaryPath string, manifest *providermanifestv1.Manifest) error {


### PR DESCRIPTION
## Summary
- Replace eager daemon `TestMain` fixture builds with idiomatic `sync.OnceValues` lazy fixtures.
- Keep each expensive fixture independently lazy: `gestaltd`, provider app, IndexedDB provider, external credentials provider, and the default providers directory.
- Materialize default providers only at helpers that rely on the default provider env, and do it before config helpers can observe default source selection to avoid parallel-test races.
- Thread `testing.TB` through shared CLI helpers so lazy build failures report from the calling test.

## Timing
Local `origin/main` no-test package run:

```sh
/usr/bin/time -p go test ./gestaltd/internal/daemon -run '^$' -count=1 -timeout=120s
# real 14.53
```

This branch after rebasing onto current `origin/main`:

```sh
/usr/bin/time -p go test ./gestaltd/internal/daemon -run '^$' -count=1 -timeout=120s
# real 2.07
```

Full package runtime is intentionally not the claimed win; it is dominated by actual subprocess/package flows and now uses simpler sequential first-use fixture construction:

```sh
go test ./gestaltd/internal/daemon -count=1 -timeout=300s
# real 22.47
```

## Tests
```sh
go test ./gestaltd/internal/daemon -run '^$' -count=1 -timeout=120s
go test ./gestaltd/internal/daemon -run 'TestE2EValidateAcceptsLayeredConfigs|TestE2EValidateUsesScratchPreparedInstallsForLocalSourceConfigs|TestE2EValidateRejectsInvalidAppInvokesDependency|TestE2EValidateRejectsHybridExecutableDuplicateEffectiveOperation|TestRunServeLockedUsesOverrideLockfile' -count=1 -timeout=180s
go test ./gestaltd/internal/daemon -count=1 -timeout=300s
```
