### PR TITLE
Delete redundant workflow wire test coverage

### DIFF
--- a/gestaltd/internal/agentwire/convert_test.go
+++ b/gestaltd/internal/agentwire/convert_test.go
@@ -67,18 +67,3 @@ func TestToolRefFromProtoDropsMalformedRunAsExternalIdentity(t *testing.T) {
 		t.Fatalf("decoded malformed external identity = %#v, want nil", decoded.RunAsExternalIdentity)
 	}
 }
-
-func TestToolRefsFromProtoSkipsNilRefs(t *testing.T) {
-	t.Parallel()
-
-	decoded := ToolRefsFromProto([]*proto.AgentToolRef{
-		nil,
-		{App: "github", Operation: "search"},
-	})
-	if len(decoded) != 1 {
-		t.Fatalf("decoded refs = %#v, want one ref", decoded)
-	}
-	if decoded[0].App != "github" || decoded[0].Operation != "search" {
-		t.Fatalf("decoded ref = %#v, want github search", decoded[0])
-	}
-}

--- a/gestaltd/internal/workflowwire/entities.go
+++ b/gestaltd/internal/workflowwire/entities.go
@@ -40,9 +40,20 @@ func EventToProto(event coreworkflow.Event) (*proto.WorkflowEvent, error) {
 	if err != nil {
 		return nil, fmt.Errorf("workflow event data: %w", err)
 	}
-	extensions, err := workflowExtensionsToProto(event.Extensions)
-	if err != nil {
-		return nil, fmt.Errorf("workflow event extensions: %w", err)
+	extensions := make(map[string]*structpb.Value, len(event.Extensions))
+	for key, value := range event.Extensions {
+		if value == nil {
+			extensions[key] = structpb.NewNullValue()
+			continue
+		}
+		pbValue, err := protoutil.ValueFromAny(value)
+		if err != nil {
+			return nil, fmt.Errorf("workflow event extensions: %s: %w", key, err)
+		}
+		extensions[key] = pbValue
+	}
+	if len(extensions) == 0 {
+		extensions = nil
 	}
 	return &proto.WorkflowEvent{
 		Id:              event.ID,
@@ -61,10 +72,6 @@ func EventFromProto(event *proto.WorkflowEvent) (coreworkflow.Event, error) {
 	if event == nil {
 		return coreworkflow.Event{}, nil
 	}
-	extensions, err := workflowExtensionsFromProto(event.GetExtensions())
-	if err != nil {
-		return coreworkflow.Event{}, err
-	}
 	return coreworkflow.Event{
 		ID:              event.GetId(),
 		Source:          event.GetSource(),
@@ -74,7 +81,7 @@ func EventFromProto(event *proto.WorkflowEvent) (coreworkflow.Event, error) {
 		Time:            TimeFromProto(event.GetTime()),
 		DataContentType: event.GetDatacontenttype(),
 		Data:            protoutil.MapFromStruct(event.GetData()),
-		Extensions:      extensions,
+		Extensions:      workflowExtensionsFromProto(event.GetExtensions()),
 	}, nil
 }
 
@@ -437,28 +444,9 @@ func SignalRunResponseToProto(resp *coreworkflow.SignalRunResponse) (*proto.Sign
 	}, nil
 }
 
-func workflowExtensionsToProto(values map[string]any) (map[string]*structpb.Value, error) {
+func workflowExtensionsFromProto(values map[string]*structpb.Value) map[string]any {
 	if len(values) == 0 {
-		return nil, nil
-	}
-	out := make(map[string]*structpb.Value, len(values))
-	for key, value := range values {
-		if value == nil {
-			out[key] = structpb.NewNullValue()
-			continue
-		}
-		pbValue, err := protoutil.ValueFromAny(value)
-		if err != nil {
-			return nil, fmt.Errorf("%s: %w", key, err)
-		}
-		out[key] = pbValue
-	}
-	return out, nil
-}
-
-func workflowExtensionsFromProto(values map[string]*structpb.Value) (map[string]any, error) {
-	if len(values) == 0 {
-		return nil, nil
+		return nil
 	}
 	out := make(map[string]any, len(values))
 	for key, value := range values {
@@ -468,7 +456,7 @@ func workflowExtensionsFromProto(values map[string]*structpb.Value) (map[string]
 		}
 		out[key] = value.AsInterface()
 	}
-	return out, nil
+	return out
 }
 
 func TimeToProto(t *time.Time) *timestamppb.Timestamp {

--- a/gestaltd/internal/workflowwire/steps.go
+++ b/gestaltd/internal/workflowwire/steps.go
@@ -326,10 +326,6 @@ func workflowValueMapFromProto(values map[string]*proto.WorkflowValue) map[strin
 	if len(values) == 0 {
 		return nil
 	}
-	return workflowValueObjectMapFromProto(values)
-}
-
-func workflowValueObjectMapFromProto(values map[string]*proto.WorkflowValue) map[string]coreworkflow.Value {
 	out := make(map[string]coreworkflow.Value, len(values))
 	for key, value := range values {
 		out[key] = workflowValueFromProto(value)
@@ -413,7 +409,12 @@ func workflowValueFromProto(value *proto.WorkflowValue) coreworkflow.Value {
 	case *proto.WorkflowValue_Literal:
 		return coreworkflow.Value{Literal: protoutil.ValueToAny(typed.Literal), LiteralSet: true}
 	case *proto.WorkflowValue_Object:
-		return coreworkflow.Value{Object: workflowValueObjectMapFromProto(typed.Object.GetFields())}
+		fields := typed.Object.GetFields()
+		out := make(map[string]coreworkflow.Value, len(fields))
+		for key, value := range fields {
+			out[key] = workflowValueFromProto(value)
+		}
+		return coreworkflow.Value{Object: out}
 	case *proto.WorkflowValue_Array:
 		items := typed.Array.GetValues()
 		out := make([]coreworkflow.Value, 0, len(items))


### PR DESCRIPTION
## Summary

Deletes redundant follow-up coverage and small workflow wire indirection left after the workflow provider proto collapse.

The nil tool-ref slice test was too narrow for the behavior it guarded, and the existing agent wire tests still cover the meaningful run-as and external identity conversion behavior. Workflow event nil-extension coverage stays because it is the only test proving nil extensions encode as protobuf null and still marshal.

This also collapses private workflowwire helpers that did not add a useful boundary: workflow event extension encoding/decoding now happens at the only call sites, and object workflow values decode inline while preserving the existing empty-object round trip behavior.

## Interfaces

No public interfaces change.

```go
func EventFromProto(*proto.WorkflowEvent) (coreworkflow.Event, error)
```

## Runtime

Runtime behavior is unchanged. Provider proto requests, workflow event conversion, and workflow value decoding keep the same observable behavior; this only removes redundant test coverage and private helper indirection.