### PR TITLE
Simplify provider-dev remote attach startup

### DIFF
--- a/gestaltd/internal/daemon/provider_local.go
+++ b/gestaltd/internal/daemon/provider_local.go
@@ -26,6 +26,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/operator"
+	"github.com/valon-technologies/gestalt/server/internal/protoutil"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/apps/providerpkg"
@@ -267,6 +268,9 @@ func runProviderRemoteDev(opts providerLocalCommandOptions) error {
 			return err
 		}
 		processes = append(processes, process)
+		if err := startRemoteDevProvider(ctx, process.Integration(), sessionProvider.Name, sessionProvider.Config); err != nil {
+			return fmt.Errorf("start local provider apps.%s for remote attach: %w", target.Name, err)
+		}
 		providerClients[target.Name] = process.Integration()
 	}
 
@@ -278,6 +282,25 @@ func runProviderRemoteDev(opts providerLocalCommandOptions) error {
 		"config_files", configPaths,
 	)
 	return client.RunDispatcher(ctx, attachID, providerClients, providerdev.WithUIHandlers(localUIHandlers))
+}
+
+func startRemoteDevProvider(ctx context.Context, client proto.AppProviderClient, name string, config map[string]any) error {
+	cfg, err := protoutil.StructFromMap(config)
+	if err != nil {
+		return fmt.Errorf("encode provider config: %w", err)
+	}
+	resp, err := client.StartProvider(ctx, &proto.StartProviderRequest{
+		Name:            name,
+		Config:          cfg,
+		ProtocolVersion: proto.CurrentProtocolVersion,
+	})
+	if err != nil {
+		return err
+	}
+	if v := resp.GetProtocolVersion(); v != proto.CurrentProtocolVersion {
+		return fmt.Errorf("provider responded with protocol version %d, host requires %d", v, proto.CurrentProtocolVersion)
+	}
+	return nil
 }
 
 func resolveProviderRemoteAttachToken(opts providerLocalCommandOptions) string {

--- a/gestaltd/services/apps/provider_client.go
+++ b/gestaltd/services/apps/provider_client.go
@@ -432,6 +432,12 @@ func requestContextProto(ctx context.Context, publicBaseURL string) (*proto.Requ
 	return &out, nil
 }
 
+// RequestContextProto converts the invocation context used by app providers into
+// the protobuf request context carried on Execute requests.
+func RequestContextProto(ctx context.Context, publicBaseURL string) (*proto.RequestContext, error) {
+	return requestContextProto(ctx, publicBaseURL)
+}
+
 func normalizePublicBaseURL(baseURL string) string {
 	return strings.TrimRight(strings.TrimSpace(baseURL), "/")
 }

--- a/gestaltd/services/providerdev/indexeddb_store.go
+++ b/gestaltd/services/providerdev/indexeddb_store.go
@@ -107,13 +107,11 @@ type indexedDBSessionRecord struct {
 }
 
 type storedTarget struct {
-	Name      string                        `json:"name"`
-	Source    string                        `json:"source,omitempty"`
-	Spec      appservice.StaticProviderSpec `json:"spec"`
-	Config    map[string]any                `json:"config,omitempty"`
-	ConfigSet bool                          `json:"configSet,omitempty"`
-	UI        bool                          `json:"ui,omitempty"`
-	UIPath    string                        `json:"uiPath,omitempty"`
+	Name   string                        `json:"name"`
+	Source string                        `json:"source,omitempty"`
+	Spec   appservice.StaticProviderSpec `json:"spec"`
+	UI     bool                          `json:"ui,omitempty"`
+	UIPath string                        `json:"uiPath,omitempty"`
 }
 
 type indexedDBCallRecord struct {
@@ -192,18 +190,12 @@ func (s *indexedDBSessionStore) createSession(ctx context.Context, owner, id, di
 	stored := make([]storedTarget, 0, len(targets))
 	for i := range targets {
 		target := targets[i]
-		var storedConfig map[string]any
-		if target.ConfigSet {
-			storedConfig = cloneAnyMap(target.Config)
-		}
 		stored = append(stored, storedTarget{
-			Name:      target.Name,
-			Source:    target.Source,
-			Spec:      target.Spec,
-			Config:    storedConfig,
-			ConfigSet: target.ConfigSet,
-			UI:        target.UI,
-			UIPath:    target.UIPath,
+			Name:   target.Name,
+			Source: target.Source,
+			Spec:   target.Spec,
+			UI:     target.UI,
+			UIPath: target.UIPath,
 		})
 	}
 	targetsJSON, err := json.Marshal(stored)
@@ -1172,13 +1164,11 @@ func (r indexedDBSessionRecord) attachmentInfo() AttachmentInfo {
 
 func (t storedTarget) target() Target {
 	return Target{
-		Name:      t.Name,
-		Source:    t.Source,
-		Spec:      t.Spec,
-		Config:    cloneAnyMap(t.Config),
-		ConfigSet: t.ConfigSet,
-		UI:        t.UI,
-		UIPath:    t.UIPath,
+		Name:   t.Name,
+		Source: t.Source,
+		Spec:   t.Spec,
+		UI:     t.UI,
+		UIPath: t.UIPath,
 	}
 }
 

--- a/gestaltd/services/providerdev/session.go
+++ b/gestaltd/services/providerdev/session.go
@@ -26,14 +26,14 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/internal/protoutil"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	appservice "github.com/valon-technologies/gestalt/server/services/apps"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
-	"google.golang.org/grpc"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	gproto "google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 const (
@@ -61,7 +61,6 @@ type Target struct {
 	Source     string
 	Spec       appservice.StaticProviderSpec
 	Config     map[string]any
-	ConfigSet  bool
 	UI         bool
 	UIPath     string
 	RuntimeEnv RuntimeEnvBuilder
@@ -103,6 +102,7 @@ type CreateSessionProvider struct {
 	Source string            `json:"source,omitempty"`
 	UI     bool              `json:"ui,omitempty"`
 	UIPath string            `json:"uiPath,omitempty"`
+	Config map[string]any    `json:"config,omitempty"`
 }
 
 type CreateAttachAuthorizationResponse struct {
@@ -343,6 +343,7 @@ func (m *Manager) CreateSession(ctx context.Context, p *principal.Principal, req
 			Source: target.Source,
 			UI:     target.UI,
 			UIPath: target.UIPath,
+			Config: cloneAnyMap(target.Config),
 		})
 	}
 
@@ -396,6 +397,7 @@ func (m *Manager) createSharedSession(ctx context.Context, owner, sessionID, dis
 			Source: target.Source,
 			UI:     target.UI,
 			UIPath: target.UIPath,
+			Config: cloneAnyMap(target.Config),
 		})
 	}
 	if err := m.shared.createSession(ctx, owner, sessionID, dispatcherSecretHash, targets, time.Now()); err != nil {
@@ -647,7 +649,6 @@ func (m *Manager) resolveAttachTargets(requestedProviders []AttachProvider) ([]T
 		target.Spec = buildAttachSpec(remoteTarget.Spec, requested.Spec)
 		if requested.Config != nil {
 			target.Config = cloneAnyMap(*requested.Config)
-			target.ConfigSet = true
 		}
 		target.UI = requested.UI
 		targets = append(targets, target)
@@ -899,7 +900,6 @@ func (m *Manager) ResolveProviderOverride(ctx context.Context, p *principal.Prin
 		if !ok {
 			return nil, false, nil
 		}
-		target = m.hydrateSharedTarget(target)
 		attached := m.sharedTarget(session.id, target)
 		prov, err := attached.providerForSession(ctx, &sharedSession{id: session.id, owner: owner, store: m.shared}, providerName)
 		if err != nil {
@@ -926,28 +926,6 @@ func (m *Manager) ResolveProviderOverride(ctx context.Context, p *principal.Prin
 		return prov, true, nil
 	}
 	return nil, false, nil
-}
-
-func (m *Manager) hydrateSharedTarget(target Target) Target {
-	if m == nil {
-		return target
-	}
-	m.mu.RLock()
-	base, ok := m.targets[target.Name]
-	m.mu.RUnlock()
-	if !ok {
-		return target
-	}
-	if target.Source == "" {
-		target.Source = base.Source
-	}
-	if target.UIPath == "" {
-		target.UIPath = base.UIPath
-	}
-	if !target.ConfigSet {
-		target.Config = cloneAnyMap(base.Config)
-	}
-	return target
 }
 
 func (m *Manager) ServeUIAsset(ctx context.Context, p *principal.Principal, providerName string, req UIAssetRequest) (*UIAssetResponse, bool, error) {
@@ -1516,7 +1494,7 @@ type providerDevSession interface {
 	invoke(ctx context.Context, providerName, method string, req gproto.Message, resp gproto.Message) error
 }
 
-func (t *attachedTarget) providerForSession(ctx context.Context, session providerDevSession, providerName string) (core.Provider, error) {
+func (t *attachedTarget) providerForSession(_ context.Context, session providerDevSession, providerName string) (core.Provider, error) {
 	t.providerMu.Lock()
 	defer t.providerMu.Unlock()
 	if t.closed {
@@ -1526,83 +1504,95 @@ func (t *attachedTarget) providerForSession(ctx context.Context, session provide
 		return t.provider, nil
 	}
 
-	client := &sessionProviderClient{session: session, provider: providerName}
-	prov, err := appservice.NewRemote(ctx, client, t.target.Spec, t.target.Config)
-	if err != nil {
-		return nil, err
-	}
-	t.provider = &attachProvider{Provider: prov, policyCatalog: t.target.Spec.Catalog}
+	t.provider = &devTunnelProvider{session: session, provider: providerName, spec: t.target.Spec}
 	return t.provider, nil
 }
 
-type attachProvider struct {
-	core.Provider
-	policyCatalog *catalog.Catalog
+type devTunnelProvider struct {
+	session  providerDevSession
+	provider string
+	spec     appservice.StaticProviderSpec
 }
 
-func (p *attachProvider) Catalog() *catalog.Catalog {
-	if p == nil || p.Provider == nil {
+func (p *devTunnelProvider) Name() string        { return p.spec.Name }
+func (p *devTunnelProvider) DisplayName() string { return p.spec.DisplayName }
+func (p *devTunnelProvider) Description() string { return p.spec.Description }
+
+func (p *devTunnelProvider) ConnectionMode() core.ConnectionMode {
+	if p.spec.ConnectionMode == "" {
+		return core.ConnectionModeSubject
+	}
+	return core.NormalizeConnectionMode(p.spec.ConnectionMode)
+}
+
+func (p *devTunnelProvider) AuthTypes() []string { return p.spec.AuthTypes }
+
+func (p *devTunnelProvider) ConnectionParamDefs() map[string]core.ConnectionParamDef {
+	return p.spec.ConnectionParams
+}
+
+func (p *devTunnelProvider) CredentialFields() []core.CredentialFieldDef {
+	return p.spec.CredentialFields
+}
+
+func (p *devTunnelProvider) DiscoveryConfig() *core.DiscoveryConfig { return p.spec.DiscoveryConfig }
+
+func (p *devTunnelProvider) ConnectionForOperation(string) string { return "" }
+
+func (p *devTunnelProvider) Catalog() *catalog.Catalog {
+	if p.spec.Catalog == nil {
 		return nil
 	}
-	return buildAttachCatalog(p.policyCatalog, p.Provider.Catalog())
+	cat := p.spec.Catalog.Clone()
+	if cat.Name == "" {
+		cat.Name = p.spec.Name
+	}
+	if cat.DisplayName == "" {
+		cat.DisplayName = p.spec.DisplayName
+	}
+	if cat.Description == "" {
+		cat.Description = p.spec.Description
+	}
+	if p.spec.IconSVG != "" {
+		cat.IconSVG = p.spec.IconSVG
+	}
+	for i := range cat.Operations {
+		if cat.Operations[i].Transport == "" {
+			cat.Operations[i].Transport = catalog.TransportApp
+		}
+	}
+	return cat
 }
 
-func (p *attachProvider) SupportsSessionCatalog() bool {
-	return p != nil && p.Provider != nil && core.SupportsSessionCatalog(p.Provider)
-}
-
-func (p *attachProvider) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
-	if p == nil || p.Provider == nil {
-		return nil, core.ErrSessionCatalogUnsupported
-	}
-	cat, scoped, err := core.CatalogForRequest(ctx, p.Provider, token)
-	if !scoped {
-		return nil, core.WrapSessionCatalogUnsupported(core.ErrSessionCatalogUnsupported)
-	}
+func (p *devTunnelProvider) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {
+	msg, err := protoutil.StructFromMap(params)
 	if err != nil {
 		return nil, err
 	}
-	if cat == nil {
-		return nil, nil
+	reqCtx, err := appservice.RequestContextProto(ctx, "")
+	if err != nil {
+		return nil, err
 	}
-	return buildAttachCatalog(p.policyCatalog, cat), nil
-}
-
-func (p *attachProvider) SupportsPostConnect() bool {
-	return p != nil && p.Provider != nil && core.SupportsPostConnect(p.Provider)
-}
-
-func (p *attachProvider) PostConnect(ctx context.Context, token *core.ExternalCredential) (map[string]string, error) {
-	if p == nil || p.Provider == nil {
-		return nil, core.ErrPostConnectUnsupported
+	req := &proto.ExecuteRequest{
+		Operation:        operation,
+		Params:           msg,
+		Token:            token,
+		ConnectionParams: core.ConnectionParams(ctx),
+		IdempotencyKey:   invocation.IdempotencyKeyFromContext(ctx),
+		Context:          reqCtx,
 	}
-	metadata, supported, err := core.PostConnect(ctx, p.Provider, token)
-	if !supported {
-		return nil, core.ErrPostConnectUnsupported
+	if meta := invocation.MetaFromContext(ctx); meta != nil {
+		req.InvocationId = meta.RequestID
 	}
-	return metadata, err
-}
-
-func (p *attachProvider) SupportsHTTPSubject() bool {
-	return p != nil && p.Provider != nil && core.SupportsHTTPSubject(p.Provider)
-}
-
-func (p *attachProvider) ResolveHTTPSubject(ctx context.Context, req *core.HTTPSubjectResolveRequest) (*core.HTTPResolvedSubject, error) {
-	if p == nil || p.Provider == nil {
-		return nil, nil
+	resp := &proto.OperationResult{}
+	if err := p.session.invoke(ctx, p.provider, "Execute", req, resp); err != nil {
+		return nil, err
 	}
-	subject, _, err := core.ResolveHTTPSubject(ctx, p.Provider, req)
-	return subject, err
-}
-
-func (p *attachProvider) Close() error {
-	if p == nil || p.Provider == nil {
-		return nil
-	}
-	if c, ok := p.Provider.(interface{ Close() error }); ok {
-		return c.Close()
-	}
-	return nil
+	return &core.OperationResult{
+		Status:  int(resp.GetStatus()),
+		Headers: protoutil.StringListsFromProto(resp.GetHeaders()),
+		Body:    resp.GetBody(),
+	}, nil
 }
 
 func (t *attachedTarget) close() error {
@@ -1623,47 +1613,6 @@ func (t *attachedTarget) close() error {
 		t.env.Cleanup()
 	}
 	return errors.Join(errs...)
-}
-
-type sessionProviderClient struct {
-	session  providerDevSession
-	provider string
-}
-
-func (c *sessionProviderClient) GetMetadata(ctx context.Context, req *emptypb.Empty, _ ...grpc.CallOption) (*proto.ProviderMetadata, error) {
-	resp := &proto.ProviderMetadata{}
-	err := c.session.invoke(ctx, c.provider, "GetMetadata", req, resp)
-	return resp, err
-}
-
-func (c *sessionProviderClient) StartProvider(ctx context.Context, req *proto.StartProviderRequest, _ ...grpc.CallOption) (*proto.StartProviderResponse, error) {
-	resp := &proto.StartProviderResponse{}
-	err := c.session.invoke(ctx, c.provider, "StartProvider", req, resp)
-	return resp, err
-}
-
-func (c *sessionProviderClient) Execute(ctx context.Context, req *proto.ExecuteRequest, _ ...grpc.CallOption) (*proto.OperationResult, error) {
-	resp := &proto.OperationResult{}
-	err := c.session.invoke(ctx, c.provider, "Execute", req, resp)
-	return resp, err
-}
-
-func (c *sessionProviderClient) ResolveHTTPSubject(ctx context.Context, req *proto.ResolveHTTPSubjectRequest, _ ...grpc.CallOption) (*proto.ResolveHTTPSubjectResponse, error) {
-	resp := &proto.ResolveHTTPSubjectResponse{}
-	err := c.session.invoke(ctx, c.provider, "ResolveHTTPSubject", req, resp)
-	return resp, err
-}
-
-func (c *sessionProviderClient) GetSessionCatalog(ctx context.Context, req *proto.GetSessionCatalogRequest, _ ...grpc.CallOption) (*proto.GetSessionCatalogResponse, error) {
-	resp := &proto.GetSessionCatalogResponse{}
-	err := c.session.invoke(ctx, c.provider, "GetSessionCatalog", req, resp)
-	return resp, err
-}
-
-func (c *sessionProviderClient) PostConnect(ctx context.Context, req *proto.PostConnectRequest, _ ...grpc.CallOption) (*proto.PostConnectResponse, error) {
-	resp := &proto.PostConnectResponse{}
-	err := c.session.invoke(ctx, c.provider, "PostConnect", req, resp)
-	return resp, err
 }
 
 type Client struct {
@@ -1771,7 +1720,7 @@ func (c Client) GetAttachment(ctx context.Context, attachID string) (*Attachment
 	return &out, nil
 }
 
-func (c Client) Poll(ctx context.Context, sessionID string) (*PollResponse, bool, error) {
+func (c Client) poll(ctx context.Context, sessionID string) (*PollResponse, bool, error) {
 	path := PathAttachments + "/" + url.PathEscape(sessionID) + "/poll"
 	var out PollResponse
 	statusCode, err := c.doJSONStatus(ctx, http.MethodGet, path, nil, &out)
@@ -1784,7 +1733,7 @@ func (c Client) Poll(ctx context.Context, sessionID string) (*PollResponse, bool
 	return &out, true, nil
 }
 
-func (c Client) Complete(ctx context.Context, sessionID, callID string, req CompleteCallRequest) error {
+func (c Client) complete(ctx context.Context, sessionID, callID string, req CompleteCallRequest) error {
 	path := PathAttachments + "/" + url.PathEscape(sessionID) + "/calls/" + url.PathEscape(callID)
 	return c.doJSON(ctx, http.MethodPost, path, req, nil)
 }
@@ -1805,7 +1754,7 @@ func (c Client) RunDispatcher(ctx context.Context, sessionID string, providers m
 	retryAttempt := 0
 	var retryStarted time.Time
 	for {
-		call, ok, err := c.Poll(ctx, sessionID)
+		call, ok, err := c.poll(ctx, sessionID)
 		if err != nil {
 			if dispatcherContextDone(ctx) {
 				return nil
@@ -1842,7 +1791,7 @@ func (c Client) RunDispatcher(ctx context.Context, sessionID string, providers m
 			continue
 		}
 		req := c.dispatchCall(ctx, call, providers, cfg)
-		if err := c.Complete(ctx, sessionID, call.CallID, req); err != nil {
+		if err := c.complete(ctx, sessionID, call.CallID, req); err != nil {
 			if dispatcherContextDone(ctx) {
 				return nil
 			}
@@ -2012,70 +1961,18 @@ func dispatchProviderDevUIRequest(ctx context.Context, handler http.Handler, pay
 }
 
 func dispatchProviderRPC(ctx context.Context, client proto.AppProviderClient, method string, payload []byte) ([]byte, error) {
-	switch method {
-	case "GetMetadata":
-		req := &emptypb.Empty{}
-		if err := gproto.Unmarshal(payload, req); err != nil {
-			return nil, err
-		}
-		resp, err := client.GetMetadata(ctx, req)
-		if err != nil {
-			return nil, err
-		}
-		return gproto.Marshal(resp)
-	case "StartProvider":
-		req := &proto.StartProviderRequest{}
-		if err := gproto.Unmarshal(payload, req); err != nil {
-			return nil, err
-		}
-		resp, err := client.StartProvider(ctx, req)
-		if err != nil {
-			return nil, err
-		}
-		return gproto.Marshal(resp)
-	case "Execute":
-		req := &proto.ExecuteRequest{}
-		if err := gproto.Unmarshal(payload, req); err != nil {
-			return nil, err
-		}
-		resp, err := client.Execute(ctx, req)
-		if err != nil {
-			return nil, err
-		}
-		return gproto.Marshal(resp)
-	case "ResolveHTTPSubject":
-		req := &proto.ResolveHTTPSubjectRequest{}
-		if err := gproto.Unmarshal(payload, req); err != nil {
-			return nil, err
-		}
-		resp, err := client.ResolveHTTPSubject(ctx, req)
-		if err != nil {
-			return nil, err
-		}
-		return gproto.Marshal(resp)
-	case "GetSessionCatalog":
-		req := &proto.GetSessionCatalogRequest{}
-		if err := gproto.Unmarshal(payload, req); err != nil {
-			return nil, err
-		}
-		resp, err := client.GetSessionCatalog(ctx, req)
-		if err != nil {
-			return nil, err
-		}
-		return gproto.Marshal(resp)
-	case "PostConnect":
-		req := &proto.PostConnectRequest{}
-		if err := gproto.Unmarshal(payload, req); err != nil {
-			return nil, err
-		}
-		resp, err := client.PostConnect(ctx, req)
-		if err != nil {
-			return nil, err
-		}
-		return gproto.Marshal(resp)
-	default:
+	if method != "Execute" {
 		return nil, status.Errorf(codes.Unimplemented, "provider dev method %q is not supported", method)
 	}
+	req := &proto.ExecuteRequest{}
+	if err := gproto.Unmarshal(payload, req); err != nil {
+		return nil, err
+	}
+	resp, err := client.Execute(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return gproto.Marshal(resp)
 }
 
 func (c Client) doJSON(ctx context.Context, method, path string, in any, out any) error {

--- a/gestaltd/services/providerdev/session_test.go
+++ b/gestaltd/services/providerdev/session_test.go
@@ -20,9 +20,11 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/protoutil"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	appservice "github.com/valon-technologies/gestalt/server/services/apps"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -34,18 +36,7 @@ import (
 func TestHTTPTransportDispatchesProviderRPCs(t *testing.T) {
 	t.Parallel()
 
-	local := &recordingIntegrationClient{
-		supportsSessionCatalog: true,
-		sessionCatalog: &proto.Catalog{
-			Name: "roadmap",
-			Operations: []*proto.CatalogOperation{{
-				Id:             "echo",
-				Transport:      catalog.TransportApp,
-				AllowedRoles:   []string{"viewer"},
-				RequiredScopes: []string{"local.session.scope"},
-			}},
-		},
-	}
+	local := &recordingIntegrationClient{}
 	spec := appservice.StaticProviderSpec{
 		Name:           "roadmap",
 		DisplayName:    "Roadmap",
@@ -114,6 +105,7 @@ func TestHTTPTransportDispatchesProviderRPCs(t *testing.T) {
 	if got := session.Providers[0].Env["CUSTOM_PROVIDER_ENV"]; got != "tls://gestalt.example.test:443" {
 		t.Fatalf("runtime env = %q, want relay target", got)
 	}
+	startRecordingIntegrationClient(t, local, session.Providers[0].Name, session.Providers[0].Config)
 
 	dispatchCtx, dispatchCancel := context.WithCancel(context.Background())
 	defer dispatchCancel()
@@ -126,6 +118,8 @@ func TestHTTPTransportDispatchesProviderRPCs(t *testing.T) {
 
 	resolveCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
+	resolveCtx = principal.WithPrincipal(resolveCtx, p)
+	resolveCtx = invocation.WithAccessContext(resolveCtx, invocation.AccessContext{Policy: "remote.policy", Role: "admin"})
 	prov, ok, err := manager.ResolveProviderOverride(resolveCtx, p, "roadmap")
 	if err != nil {
 		t.Fatalf("ResolveProviderOverride: %v", err)
@@ -146,26 +140,21 @@ func TestHTTPTransportDispatchesProviderRPCs(t *testing.T) {
 	if got := cat.Operations[0].RequiredScopes; len(got) != 1 || got[0] != "remote.scope" {
 		t.Fatalf("Catalog RequiredScopes = %#v, want remote [remote.scope]", got)
 	}
-	sessionCat, attempted, err := core.CatalogForRequest(resolveCtx, prov, "remote-token")
-	if err != nil {
-		t.Fatalf("CatalogForRequest: %v", err)
-	}
-	if !attempted {
-		t.Fatal("CatalogForRequest attempted = false, want true")
-	}
-	if got := sessionCat.Operations[0].AllowedRoles; len(got) != 1 || got[0] != "admin" {
-		t.Fatalf("session Catalog AllowedRoles = %#v, want remote [admin]", got)
-	}
-	if got := sessionCat.Operations[0].RequiredScopes; len(got) != 1 || got[0] != "remote.scope" {
-		t.Fatalf("session Catalog RequiredScopes = %#v, want remote [remote.scope]", got)
-	}
-
 	result, err := prov.Execute(resolveCtx, "echo", map[string]any{"message": "hello"}, "remote-token")
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
 	if result.Body != `{"message":"hello","operation":"echo","token":"remote-token"}` {
 		t.Fatalf("Execute body = %s", result.Body)
+	}
+	local.mu.Lock()
+	executeCtx := local.lastExecuteContext
+	local.mu.Unlock()
+	if executeCtx.GetSubject().GetId() != "user:user-123" {
+		t.Fatalf("Execute context subject = %#v, want user:user-123", executeCtx.GetSubject())
+	}
+	if executeCtx.GetAccess().GetRole() != "admin" || executeCtx.GetAccess().GetPolicy() != "remote.policy" {
+		t.Fatalf("Execute context access = %#v, want admin remote.policy", executeCtx.GetAccess())
 	}
 
 	uiResp, ok, err := manager.ServeUIAsset(resolveCtx, p, "roadmap", UIAssetRequest{
@@ -230,9 +219,17 @@ func TestHTTPTransportDispatchesProviderRPCs(t *testing.T) {
 	}
 
 	local.mu.Lock()
+	metadataCalls := local.metadataCalls
+	startCalls := local.startCalls
 	startName := local.startName
 	startConfig := fmt.Sprint(local.startConfig)
 	local.mu.Unlock()
+	if metadataCalls != 0 {
+		t.Fatalf("GetMetadata calls = %d, want 0", metadataCalls)
+	}
+	if startCalls != 1 {
+		t.Fatalf("StartProvider calls = %d, want exactly local startup call", startCalls)
+	}
 	if startName != "roadmap" {
 		t.Fatalf("StartProvider name = %q, want roadmap", startName)
 	}
@@ -248,61 +245,6 @@ func TestHTTPTransportDispatchesProviderRPCs(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("dispatcher did not stop")
-	}
-}
-
-func TestAttachProviderSkipsSessionCatalogWhenRemoteMetadataReportsNoSupport(t *testing.T) {
-	t.Parallel()
-
-	local := &recordingIntegrationClient{
-		sessionCatalog: &proto.Catalog{
-			Name: "roadmap",
-			Operations: []*proto.CatalogOperation{{
-				Id:        "echo",
-				Transport: catalog.TransportApp,
-			}},
-		},
-	}
-	spec := appservice.StaticProviderSpec{
-		Name:           "roadmap",
-		DisplayName:    "Roadmap",
-		ConnectionMode: core.ConnectionModeUser,
-		Catalog: &catalog.Catalog{
-			Name: "roadmap",
-			Operations: []catalog.CatalogOperation{{
-				ID:        "echo",
-				Transport: catalog.TransportApp,
-			}},
-		},
-	}
-	remote, err := appservice.NewRemote(context.Background(), local, spec, nil)
-	if err != nil {
-		t.Fatalf("NewRemote: %v", err)
-	}
-	prov := &attachProvider{
-		Provider:      remote,
-		policyCatalog: spec.Catalog,
-	}
-
-	if core.SupportsSessionCatalog(prov) {
-		t.Fatal("expected attach provider to report no session catalog support")
-	}
-	cat, attempted, err := core.CatalogForRequest(context.Background(), prov, "tok")
-	if err != nil {
-		t.Fatalf("CatalogForRequest: %v", err)
-	}
-	if attempted {
-		t.Fatal("expected core.CatalogForRequest to report no attempt")
-	}
-	if cat != nil {
-		t.Fatalf("CatalogForRequest catalog = %#v, want nil", cat)
-	}
-
-	local.mu.Lock()
-	calls := local.sessionCatalogCalls
-	local.mu.Unlock()
-	if calls != 0 {
-		t.Fatalf("GetSessionCatalog calls = %d, want 0", calls)
 	}
 }
 
@@ -391,6 +333,12 @@ func TestIndexedDBAttachmentStateDispatchesAcrossManagers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
+	if len(session.Providers) != 1 {
+		t.Fatalf("session providers = %#v, want start payload", session.Providers)
+	}
+	local := &recordingIntegrationClient{}
+	startRecordingIntegrationClient(t, local, session.Providers[0].Name, session.Providers[0].Config)
+	dispatchClient.DispatcherSecret = session.DispatcherSecret
 	record, err := db.ObjectStore(indexedDBAttachmentStore).Get(ctx, session.AttachID)
 	if err != nil {
 		t.Fatalf("load shared attachment: %v", err)
@@ -420,8 +368,6 @@ func TestIndexedDBAttachmentStateDispatchesAcrossManagers(t *testing.T) {
 	dispatchCtx, dispatchCancel := context.WithCancel(context.Background())
 	defer dispatchCancel()
 	dispatchDone := make(chan error, 1)
-	local := &recordingIntegrationClient{}
-	dispatchClient.DispatcherSecret = session.DispatcherSecret
 	go func() {
 		dispatchDone <- dispatchClient.RunDispatcher(dispatchCtx, session.AttachID, map[string]proto.AppProviderClient{
 			"roadmap": local,
@@ -459,7 +405,7 @@ func TestIndexedDBAttachmentStateDispatchesAcrossManagers(t *testing.T) {
 		t.Fatalf("StartProvider calls = %d, want 1 cached shared provider", startCalls)
 	}
 	if !strings.Contains(startConfig, "remote:true") {
-		t.Fatalf("StartProvider config = %s, want remote:true rehydrated from replica config", startConfig)
+		t.Fatalf("StartProvider config = %s, want remote:true from start payload", startConfig)
 	}
 
 	dispatchCancel()
@@ -1786,22 +1732,39 @@ func writeProviderDevTestError(w http.ResponseWriter, err error) {
 	http.Error(w, err.Error(), code)
 }
 
+func startRecordingIntegrationClient(t *testing.T, client *recordingIntegrationClient, name string, config map[string]any) {
+	t.Helper()
+	cfg, err := protoutil.StructFromMap(config)
+	if err != nil {
+		t.Fatalf("encode provider config: %v", err)
+	}
+	resp, err := client.StartProvider(context.Background(), &proto.StartProviderRequest{
+		Name:            name,
+		Config:          cfg,
+		ProtocolVersion: proto.CurrentProtocolVersion,
+	})
+	if err != nil {
+		t.Fatalf("StartProvider: %v", err)
+	}
+	if v := resp.GetProtocolVersion(); v != proto.CurrentProtocolVersion {
+		t.Fatalf("StartProvider protocol = %d, want %d", v, proto.CurrentProtocolVersion)
+	}
+}
+
 type recordingIntegrationClient struct {
-	mu                     sync.Mutex
-	metadataCalls          int
-	startCalls             int
-	sessionCatalogCalls    int
-	startName              string
-	startConfig            map[string]any
-	supportsSessionCatalog bool
-	sessionCatalog         *proto.Catalog
+	mu                 sync.Mutex
+	metadataCalls      int
+	startCalls         int
+	startName          string
+	startConfig        map[string]any
+	lastExecuteContext *proto.RequestContext
 }
 
 func (c *recordingIntegrationClient) GetMetadata(context.Context, *emptypb.Empty, ...grpc.CallOption) (*proto.ProviderMetadata, error) {
 	c.mu.Lock()
 	c.metadataCalls++
 	c.mu.Unlock()
-	return &proto.ProviderMetadata{SupportsSessionCatalog: c.supportsSessionCatalog}, nil
+	return &proto.ProviderMetadata{}, nil
 }
 
 func (c *recordingIntegrationClient) StartProvider(_ context.Context, req *proto.StartProviderRequest, _ ...grpc.CallOption) (*proto.StartProviderResponse, error) {
@@ -1816,6 +1779,9 @@ func (c *recordingIntegrationClient) StartProvider(_ context.Context, req *proto
 }
 
 func (c *recordingIntegrationClient) Execute(_ context.Context, req *proto.ExecuteRequest, _ ...grpc.CallOption) (*proto.OperationResult, error) {
+	c.mu.Lock()
+	c.lastExecuteContext = req.GetContext()
+	c.mu.Unlock()
 	params := req.GetParams().AsMap()
 	body := fmt.Sprintf(`{"message":%q,"operation":%q,"token":%q}`, params["message"], req.GetOperation(), req.GetToken())
 	return &proto.OperationResult{Status: http.StatusOK, Body: body}, nil
@@ -1826,13 +1792,7 @@ func (c *recordingIntegrationClient) ResolveHTTPSubject(context.Context, *proto.
 }
 
 func (c *recordingIntegrationClient) GetSessionCatalog(context.Context, *proto.GetSessionCatalogRequest, ...grpc.CallOption) (*proto.GetSessionCatalogResponse, error) {
-	c.mu.Lock()
-	c.sessionCatalogCalls++
-	c.mu.Unlock()
-	if !c.supportsSessionCatalog {
-		return nil, status.Error(codes.Unimplemented, "session catalog is not implemented")
-	}
-	return &proto.GetSessionCatalogResponse{Catalog: c.sessionCatalog}, nil
+	return nil, status.Error(codes.Unimplemented, "session catalog is not implemented")
 }
 
 func (c *recordingIntegrationClient) PostConnect(context.Context, *proto.PostConnectRequest, ...grpc.CallOption) (*proto.PostConnectResponse, error) {


### PR DESCRIPTION
## Summary

Simplifies provider-dev remote attach by replacing the fake provider-client layer with a direct provider-dev override on the remote host.

The remote broker now gets static provider metadata from the attach request, while the local CLI starts the local provider process once during attach setup. Only `Execute` calls cross from the remote host to the developer machine through provider-dev.

This removes the tunneled startup, metadata discovery, session catalog, post-connect, HTTP-subject, readiness, and persisted attach-config compatibility paths from remote attach.

## Interfaces

```go
type CreateSessionProvider struct {
  Name   string            `json:"name"`
  Env    map[string]string `json:"env,omitempty"`
  Source string            `json:"source,omitempty"`
  UI     bool              `json:"ui,omitempty"`
  UIPath string            `json:"uiPath,omitempty"`
  Config map[string]any    `json:"config,omitempty"`
}
```

```go
func RequestContextProto(
  ctx context.Context,
  publicBaseURL string,
) (*proto.RequestContext, error)
```

```text
provider-dev dispatch: Execute only
```

## Runtime

Remote attach creation returns the provider config that the local CLI needs to start the local dev provider. `gestaltd serve --remote` launches the provider process, calls `StartProvider` directly on the real local gRPC client, then starts the provider-dev loop.

The remote broker resolves an attached provider with `devTunnelProvider` instead of `appservice.NewRemote(sessionProviderClient)`. The provider-dev override serves static metadata locally and turns `core.Provider.Execute` into a pending provider-dev call for the local CLI.

The local CLI claims pending Execute calls, invokes the real local provider Execute RPC, and posts the result back. Execute requests still carry the normal app-provider request context through `RequestContextProto`.