### PR TITLE
Show config locations for provider source failures

### DIFF
--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -2442,7 +2442,8 @@ func Load(path string) (*Config, error) {
 }
 
 func LoadPaths(paths []string) (*Config, error) {
-	return loadWithLookupPaths(paths, os.LookupEnv, false)
+	cfg, err := loadWithLookupPaths(paths, os.LookupEnv, false)
+	return cfg, RenderDiagnosticError(paths, err)
 }
 
 func LoadWithLookup(path string, lookup func(string) (string, bool)) (*Config, error) {
@@ -2450,7 +2451,8 @@ func LoadWithLookup(path string, lookup func(string) (string, bool)) (*Config, e
 }
 
 func LoadWithLookupPaths(paths []string, lookup func(string) (string, bool)) (*Config, error) {
-	return loadWithLookupPaths(paths, lookup, false)
+	cfg, err := loadWithLookupPaths(paths, lookup, false)
+	return cfg, RenderDiagnosticError(paths, err)
 }
 
 func LoadAllowMissingEnv(path string) (*Config, error) {
@@ -2458,7 +2460,8 @@ func LoadAllowMissingEnv(path string) (*Config, error) {
 }
 
 func LoadAllowMissingEnvPaths(paths []string) (*Config, error) {
-	return loadWithLookupPaths(paths, os.LookupEnv, true)
+	cfg, err := loadWithLookupPaths(paths, os.LookupEnv, true)
+	return cfg, RenderDiagnosticError(paths, err)
 }
 
 // LoadPartialAllowMissingEnvPaths loads config for commands that inspect a
@@ -2467,14 +2470,16 @@ func LoadAllowMissingEnvPaths(paths []string) (*Config, error) {
 // structural validation so unrelated deployment-only entries with missing
 // local env vars do not block the caller.
 func LoadPartialAllowMissingEnvPaths(paths []string) (*Config, error) {
-	return loadWithLookupPathsValidation(paths, os.LookupEnv, true, false)
+	cfg, err := loadWithLookupPathsValidation(paths, os.LookupEnv, true, false)
+	return cfg, RenderDiagnosticError(paths, err)
 }
 
 // LoadPartialPreserveMissingEnvPaths is like LoadPartialAllowMissingEnvPaths,
 // but preserves unresolved environment placeholders so callers can project a
 // local subset first, then reject missing env only in the retained config.
 func LoadPartialPreserveMissingEnvPaths(paths []string) (*Config, error) {
-	return loadWithLookupPathsMode(paths, os.LookupEnv, envMissingPreserve, "", false, false, false)
+	cfg, err := loadWithLookupPathsMode(paths, os.LookupEnv, envMissingPreserve, "", false, false, false)
+	return cfg, RenderDiagnosticError(paths, err)
 }
 
 // LoadAppScopePreserveMissingEnvPaths projects the merged YAML before typed
@@ -2483,18 +2488,19 @@ func LoadPartialPreserveMissingEnvPaths(paths []string) (*Config, error) {
 func LoadAppScopePreserveMissingEnvPaths(paths []string, apps []string) (*Config, error) {
 	root, err := loadMergedConfigRoot(paths, os.LookupEnv, envMissingPreserve, "")
 	if err != nil {
-		return nil, err
+		return nil, RenderDiagnosticError(paths, err)
 	}
 	if err := NormalizeConfigSecretRefs(&root); err != nil {
-		return nil, err
+		return nil, RenderDiagnosticError(paths, err)
 	}
 	if err := applyAppScopeNode(&root, apps); err != nil {
-		return nil, err
+		return nil, RenderDiagnosticError(paths, err)
 	}
 	if err := validateNoMissingEnvRefsInNode(&root); err != nil {
-		return nil, err
+		return nil, RenderDiagnosticError(paths, err)
 	}
-	return loadConfigFromRoot(paths, root, false, false)
+	cfg, err := loadConfigFromRoot(paths, root, false, false)
+	return cfg, RenderDiagnosticError(paths, err)
 }
 
 func validateNoMissingEnvRefsInNode(node *yaml.Node) error {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -5422,6 +5422,110 @@ apps:
 	}
 }
 
+func TestLoadRendersSourceAuthTokenDiagnosticSnippet(t *testing.T) {
+	t.Parallel()
+
+	configPath := mustWriteRawConfigFile(t, `
+apiVersion: gestaltd.config/v6
+providers:
+apps:
+  external:
+    source:
+      url: https://example.com/providers/external/provider-release.yaml
+      auth:
+        token: ${GESTALT_EMPTY_SOURCE_AUTH_TOKEN:-}
+`)
+
+	_, err := Load(configPath)
+	if err == nil {
+		t.Fatal("Load: expected error, got nil")
+	}
+	for _, want := range []string{
+		"config validation: apps.external.source.auth.token: source.auth.token is empty",
+		configPath + ":9:",
+		">  9 |         token: ${GESTALT_EMPTY_SOURCE_AUTH_TOKEN:-}",
+		"|                ^",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("Load error = %v, want substring %q", err, want)
+		}
+	}
+}
+
+func TestLoadRendersDiagnosticFromLastOverlay(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "base.yaml")
+	overridePath := filepath.Join(dir, "override.yaml")
+	if err := os.WriteFile(basePath, []byte(`
+apiVersion: gestaltd.config/v6
+providers:
+apps:
+  external:
+    source:
+      url: https://example.com/providers/external/provider-release.yaml
+`), 0o644); err != nil {
+		t.Fatalf("write base config: %v", err)
+	}
+	if err := os.WriteFile(overridePath, []byte(`
+apiVersion: gestaltd.config/v6
+apps:
+  external:
+    source:
+      auth:
+        token: ${GESTALT_EMPTY_SOURCE_AUTH_TOKEN:-}
+`), 0o644); err != nil {
+		t.Fatalf("write override config: %v", err)
+	}
+
+	_, err := LoadPaths([]string{basePath, overridePath})
+	if err == nil {
+		t.Fatal("LoadPaths: expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), overridePath+":7:") {
+		t.Fatalf("LoadPaths error = %v, want override snippet", err)
+	}
+	if strings.Contains(err.Error(), basePath+":") {
+		t.Fatalf("LoadPaths error = %v, did not expect base snippet", err)
+	}
+}
+
+func TestTransformSourceAuthTokensReturnsDiagnosticPath(t *testing.T) {
+	configPath := mustWriteRawConfigFile(t, `
+apiVersion: gestaltd.config/v6
+providers:
+apps:
+  external:
+    source:
+      url: https://example.com/providers/external/provider-release.yaml
+      auth:
+        token: ${SOURCE_TOKEN}
+`)
+	t.Setenv("SOURCE_TOKEN", "placeholder")
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	err = TransformSourceAuthTokens(cfg, func(string) (string, error) {
+		return "", fmt.Errorf("resolved to empty value")
+	})
+	if err == nil {
+		t.Fatal("TransformSourceAuthTokens: expected error, got nil")
+	}
+	err = RenderDiagnosticError([]string{configPath}, err)
+	for _, want := range []string{
+		"apps.external.source.auth.token: source.auth.token could not be resolved: resolved to empty value",
+		configPath + ":9:",
+		">  9 |         token: ${SOURCE_TOKEN}",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("TransformSourceAuthTokens error = %v, want substring %q", err, want)
+		}
+	}
+}
+
 func TestLoadConfigRequiresAPIVersion(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -614,17 +614,17 @@ func validateProviderEntrySource(kind, name string, entry *ProviderEntry) error 
 		release := src.GitHubReleaseSource()
 		switch {
 		case release == nil:
-			return fmt.Errorf("config validation: %s %q githubRelease source is required", kind, name)
+			return newConfigValidationDiagnostic(ProviderSourceFieldPath(kind, name, "githubRelease"), "source.githubRelease is required")
 		case strings.TrimSpace(release.Repo) == "":
-			return fmt.Errorf("config validation: %s %q source.githubRelease.repo is required", kind, name)
+			return newConfigValidationDiagnostic(ProviderSourceFieldPath(kind, name, "githubRelease", "repo"), "source.githubRelease.repo is required")
 		case strings.TrimSpace(release.Tag) == "":
-			return fmt.Errorf("config validation: %s %q source.githubRelease.tag is required", kind, name)
+			return newConfigValidationDiagnostic(ProviderSourceFieldPath(kind, name, "githubRelease", "tag"), "source.githubRelease.tag is required")
 		case strings.TrimSpace(release.Asset) == "":
-			return fmt.Errorf("config validation: %s %q source.githubRelease.asset is required", kind, name)
+			return newConfigValidationDiagnostic(ProviderSourceFieldPath(kind, name, "githubRelease", "asset"), "source.githubRelease.asset is required")
 		}
 		repoParts := strings.Split(strings.TrimSpace(release.Repo), "/")
 		if len(repoParts) != 2 || strings.TrimSpace(repoParts[0]) == "" || strings.TrimSpace(repoParts[1]) == "" {
-			return fmt.Errorf("config validation: %s %q source.githubRelease.repo must be owner/name", kind, name)
+			return newConfigValidationDiagnostic(ProviderSourceFieldPath(kind, name, "githubRelease", "repo"), "source.githubRelease.repo must be owner/name")
 		}
 	}
 	if src.IsGit() {
@@ -694,7 +694,7 @@ func validateProviderEntrySource(kind, name string, entry *ProviderEntry) error 
 			return fmt.Errorf("config validation: %s %q auth is only valid with provider-release metadata sources", kind, name)
 		}
 		if strings.TrimSpace(auth.Token) == "" {
-			return fmt.Errorf("config validation: %s %q auth.token is required when auth is set", kind, name)
+			return newConfigValidationDiagnostic(ProviderSourceFieldPath(kind, name, "auth", "token"), "source.auth.token is empty; source.auth is configured for provider source access, so token must resolve to a non-empty value or source.auth must be removed when the source does not require authentication")
 		}
 	}
 	return nil

--- a/gestaltd/internal/config/diagnostic.go
+++ b/gestaltd/internal/config/diagnostic.go
@@ -1,0 +1,266 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// diagnosticError carries a logical config path so command-facing callers can
+// render the original YAML location without threading yaml.Node through config.
+type diagnosticError struct {
+	prefix  string
+	path    []string
+	message string
+	cause   error
+}
+
+func newConfigValidationDiagnostic(path []string, message string) *diagnosticError {
+	return &diagnosticError{prefix: "config validation", path: clonePath(path), message: strings.TrimSpace(message)}
+}
+
+func WrapDiagnosticError(path []string, message string, cause error) error {
+	return &diagnosticError{path: clonePath(path), message: strings.TrimSpace(message), cause: cause}
+}
+
+func (e *diagnosticError) Error() string {
+	if e == nil {
+		return ""
+	}
+	message := strings.TrimSpace(e.message)
+	if message == "" && e.cause != nil {
+		message = e.cause.Error()
+	} else if message != "" && e.cause != nil {
+		message += ": " + e.cause.Error()
+	}
+	if path := strings.Join(e.path, "."); path != "" {
+		message = path + ": " + message
+	}
+	if prefix := strings.TrimSpace(e.prefix); prefix != "" {
+		message = prefix + ": " + message
+	}
+	return message
+}
+
+func (e *diagnosticError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+type renderedDiagnosticError struct {
+	message string
+	cause   error
+}
+
+func (e renderedDiagnosticError) Error() string {
+	return e.message
+}
+
+func (e renderedDiagnosticError) Unwrap() error {
+	return e.cause
+}
+
+func ProviderSourcePath(kind, name string) []string {
+	kind = strings.TrimSpace(kind)
+	name = strings.TrimSpace(name)
+	switch kind {
+	case "app":
+		return []string{"apps", name, "source"}
+	case "runtime":
+		return []string{"runtime", "providers", name, "source"}
+	case "ui":
+		return []string{"providers", "ui", name, "source"}
+	default:
+		return []string{"providers", kind, name, "source"}
+	}
+}
+
+func ProviderSourceFieldPath(kind, name string, fields ...string) []string {
+	path := ProviderSourcePath(kind, name)
+	for _, field := range fields {
+		if field = strings.TrimSpace(field); field != "" {
+			path = append(path, field)
+		}
+	}
+	return path
+}
+
+func clonePath(path []string) []string {
+	if len(path) == 0 {
+		return nil
+	}
+	out := make([]string, len(path))
+	copy(out, path)
+	return out
+}
+
+func RenderDiagnosticError(paths []string, err error) error {
+	if err == nil {
+		return nil
+	}
+	var rendered renderedDiagnosticError
+	if errors.As(err, &rendered) {
+		return err
+	}
+	var diagnostic *diagnosticError
+	if !errors.As(err, &diagnostic) {
+		return err
+	}
+	if diagnostic == nil || len(diagnostic.path) == 0 {
+		return err
+	}
+	snippet, ok := renderDiagnosticSnippet(paths, diagnostic.path)
+	if !ok {
+		return err
+	}
+	message := strings.TrimRight(err.Error(), "\n") + "\n\n" + snippet
+	return renderedDiagnosticError{message: message, cause: err}
+}
+
+type diagnosticLocation struct {
+	path   string
+	line   int
+	column int
+	lines  []string
+}
+
+func renderDiagnosticSnippet(paths []string, diagnosticPath []string) (string, bool) {
+	location, ok := findDiagnosticLocation(paths, diagnosticPath)
+	if !ok {
+		return "", false
+	}
+	if location.line <= 0 || location.line > len(location.lines) {
+		return "", false
+	}
+	column := location.column
+	if column <= 0 {
+		column = 1
+	}
+	start := location.line - 2
+	if start < 1 {
+		start = 1
+	}
+	end := location.line + 2
+	if end > len(location.lines) {
+		end = len(location.lines)
+	}
+	width := len(fmt.Sprintf("%d", end))
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "%s:%d:%d\n", location.path, location.line, column)
+	for lineNo := start; lineNo <= end; lineNo++ {
+		marker := " "
+		if lineNo == location.line {
+			marker = ">"
+		}
+		fmt.Fprintf(&builder, "%s %*d | %s\n", marker, width, lineNo, location.lines[lineNo-1])
+		if lineNo == location.line {
+			fmt.Fprintf(&builder, "  %*s | %s^\n", width, "", strings.Repeat(" ", column-1))
+		}
+	}
+	return strings.TrimRight(builder.String(), "\n"), true
+}
+
+func findDiagnosticLocation(paths []string, diagnosticPath []string) (diagnosticLocation, bool) {
+	var best diagnosticLocation
+	bestDepth := 0
+	bestExact := false
+	found := false
+	for i := len(paths) - 1; i >= 0; i-- {
+		path := strings.TrimSpace(paths[i])
+		if path == "" {
+			continue
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var root yaml.Node
+		if err := yaml.Unmarshal(data, &root); err != nil {
+			continue
+		}
+		node, depth, exact := locateDiagnosticNode(&root, diagnosticPath)
+		if node == nil || depth == 0 || depth < bestDepth {
+			continue
+		}
+		line, column := nodePosition(node)
+		if line <= 0 {
+			continue
+		}
+		candidate := diagnosticLocation{
+			path:   path,
+			line:   line,
+			column: column,
+			lines:  strings.Split(string(data), "\n"),
+		}
+		if !found || depth > bestDepth || (exact && !bestExact) {
+			best = candidate
+			bestDepth = depth
+			bestExact = exact
+			found = true
+			if exact {
+				break
+			}
+		}
+	}
+	return best, found
+}
+
+func locateDiagnosticNode(root *yaml.Node, diagnosticPath []string) (*yaml.Node, int, bool) {
+	node := documentValueNode(root)
+	if node == nil {
+		return nil, 0, false
+	}
+	best := node
+	var lastMatchedKey *yaml.Node
+	depth := 0
+	for _, segment := range diagnosticPath {
+		if node.Kind != yaml.MappingNode {
+			return best, depth, false
+		}
+		key, value := mappingEntryNode(node, segment)
+		if value == nil {
+			if lastMatchedKey != nil {
+				return lastMatchedKey, depth, false
+			}
+			return nil, 0, false
+		}
+		lastMatchedKey = key
+		node = value
+		best = node
+		depth++
+	}
+	return node, depth, true
+}
+
+func mappingEntryNode(node *yaml.Node, key string) (*yaml.Node, *yaml.Node) {
+	node = documentValueNode(node)
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil, nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i], node.Content[i+1]
+		}
+	}
+	return nil, nil
+}
+
+func nodePosition(node *yaml.Node) (int, int) {
+	if node == nil {
+		return 0, 0
+	}
+	if node.Line > 0 {
+		return node.Line, node.Column
+	}
+	for _, child := range node.Content {
+		if line, column := nodePosition(child); line > 0 {
+			return line, column
+		}
+	}
+	return 0, 0
+}

--- a/gestaltd/internal/config/secret_refs.go
+++ b/gestaltd/internal/config/secret_refs.go
@@ -235,54 +235,57 @@ func TransformSourceAuthTokens(cfg *Config, transform ConfigStringTransformer) e
 	if cfg == nil {
 		return nil
 	}
-	transformEntry := func(entry *ProviderEntry) error {
+	transformEntry := func(path []string, entry *ProviderEntry) error {
 		if entry == nil || entry.Source.Auth == nil {
 			return nil
 		}
 		next, err := transform(entry.Source.Auth.Token)
 		if err != nil {
-			return err
+			return WrapDiagnosticError(path, "source.auth.token could not be resolved", err)
 		}
 		entry.Source.Auth.Token = next
 		return nil
 	}
-	for _, entry := range cfg.Apps {
-		if err := transformEntry(entry); err != nil {
+	for name, entry := range cfg.Apps {
+		if err := transformEntry(ProviderSourceFieldPath("app", name, "auth", "token"), entry); err != nil {
 			return err
 		}
 	}
-	for _, entry := range cfg.Runtime.Providers {
+	for name, entry := range cfg.Runtime.Providers {
 		if entry == nil {
 			continue
 		}
-		if err := transformEntry(&entry.ProviderEntry); err != nil {
+		if err := transformEntry(ProviderSourceFieldPath("runtime", name, "auth", "token"), &entry.ProviderEntry); err != nil {
 			return err
 		}
 	}
-	for _, entries := range []map[string]*ProviderEntry{
-		cfg.Providers.Authentication,
-		cfg.Providers.Authorization,
-		cfg.Providers.ExternalCredentials,
-		cfg.Providers.Secrets,
-		cfg.Providers.Telemetry,
-		cfg.Providers.Audit,
-		cfg.Providers.IndexedDB,
-		cfg.Providers.Cache,
-		cfg.Providers.S3,
-		cfg.Providers.Workflow,
-		cfg.Providers.Agent,
+	for _, group := range []struct {
+		kind    string
+		entries map[string]*ProviderEntry
+	}{
+		{"authentication", cfg.Providers.Authentication},
+		{"authorization", cfg.Providers.Authorization},
+		{"externalCredentials", cfg.Providers.ExternalCredentials},
+		{"secrets", cfg.Providers.Secrets},
+		{"telemetry", cfg.Providers.Telemetry},
+		{"audit", cfg.Providers.Audit},
+		{"indexeddb", cfg.Providers.IndexedDB},
+		{"cache", cfg.Providers.Cache},
+		{"s3", cfg.Providers.S3},
+		{"workflow", cfg.Providers.Workflow},
+		{"agent", cfg.Providers.Agent},
 	} {
-		for _, entry := range entries {
-			if err := transformEntry(entry); err != nil {
+		for name, entry := range group.entries {
+			if err := transformEntry(ProviderSourceFieldPath(group.kind, name, "auth", "token"), entry); err != nil {
 				return err
 			}
 		}
 	}
-	for _, entry := range cfg.Providers.UI {
+	for name, entry := range cfg.Providers.UI {
 		if entry == nil {
 			continue
 		}
-		if err := transformEntry(&entry.ProviderEntry); err != nil {
+		if err := transformEntry(ProviderSourceFieldPath("ui", name, "auth", "token"), &entry.ProviderEntry); err != nil {
 			return err
 		}
 	}

--- a/gestaltd/internal/operator/git_source.go
+++ b/gestaltd/internal/operator/git_source.go
@@ -212,7 +212,7 @@ func (l *Lifecycle) gitSourceManifestPath(ctx context.Context, paths lifecyclePa
 func (l *Lifecycle) lockGitProviderEntryForSource(ctx context.Context, cfg *config.Config, paths lifecyclePaths, name string, app *config.ProviderEntry, configMap map[string]any) (LockEntry, error) {
 	destDir := providerDestDir(paths, name)
 	if gitSourceMaterialization(gitSourceDef(app)) == gitMaterializationSnapshot {
-		entry, installed, err := l.lockGitSnapshotSource(ctx, cfg, paths, providermanifestv1.KindApp, name, fmt.Sprintf("provider %q", name), destDir, app)
+		entry, installed, err := l.lockGitSnapshotSource(ctx, cfg, paths, providermanifestv1.KindApp, name, fmt.Sprintf("provider %q", name), destDir, app, config.ProviderSourcePath("app", name))
 		if err != nil {
 			return LockEntry{}, err
 		}
@@ -232,10 +232,10 @@ func (l *Lifecycle) lockGitProviderEntryForSource(ctx context.Context, cfg *conf
 	return gitLocalLockEntryFromPreparedInstall(paths, providermanifestv1.KindApp, name, app, install, false)
 }
 
-func (l *Lifecycle) lockGitComponentEntryForSource(ctx context.Context, cfg *config.Config, paths lifecyclePaths, kind, name, destDir string, app *config.ProviderEntry, configMap map[string]any) (LockEntry, error) {
+func (l *Lifecycle) lockGitComponentEntryForSource(ctx context.Context, cfg *config.Config, paths lifecyclePaths, kind, name, destDir string, app *config.ProviderEntry, configMap map[string]any, sourcePath []string) (LockEntry, error) {
 	subject := fmt.Sprintf("%s %q", kind, name)
 	if gitSourceMaterialization(gitSourceDef(app)) == gitMaterializationSnapshot {
-		entry, installed, err := l.lockGitSnapshotSource(ctx, cfg, paths, kind, name, subject, destDir, app)
+		entry, installed, err := l.lockGitSnapshotSource(ctx, cfg, paths, kind, name, subject, destDir, app, sourcePath)
 		if err != nil {
 			return LockEntry{}, err
 		}
@@ -257,7 +257,7 @@ func (l *Lifecycle) lockGitComponentEntryForSource(ctx context.Context, cfg *con
 
 func (l *Lifecycle) lockGitUIEntryForSource(ctx context.Context, cfg *config.Config, paths lifecyclePaths, name string, app *config.ProviderEntry, destDir, subject string, configMap map[string]any) (LockEntry, error) {
 	if gitSourceMaterialization(gitSourceDef(app)) == gitMaterializationSnapshot {
-		entry, installed, err := l.lockGitSnapshotSource(ctx, cfg, paths, providermanifestv1.KindUI, name, subject, destDir, app)
+		entry, installed, err := l.lockGitSnapshotSource(ctx, cfg, paths, providermanifestv1.KindUI, name, subject, destDir, app, config.ProviderSourcePath("ui", name))
 		if err != nil {
 			return LockEntry{}, err
 		}
@@ -277,7 +277,7 @@ func (l *Lifecycle) lockGitUIEntryForSource(ctx context.Context, cfg *config.Con
 	return gitLocalLockEntryFromPreparedInstall(paths, providermanifestv1.KindUI, "ui:"+name, app, install, true)
 }
 
-func (l *Lifecycle) lockGitSnapshotSource(ctx context.Context, cfg *config.Config, paths lifecyclePaths, expectedKind, name, subject, destDir string, app *config.ProviderEntry) (LockEntry, *installedPackage, error) {
+func (l *Lifecycle) lockGitSnapshotSource(ctx context.Context, cfg *config.Config, paths lifecyclePaths, expectedKind, name, subject, destDir string, app *config.ProviderEntry, sourcePath []string) (LockEntry, *installedPackage, error) {
 	if cfg == nil {
 		return LockEntry{}, nil, fmt.Errorf("%s source.git snapshot resolution requires loaded config", subject)
 	}
@@ -288,7 +288,7 @@ func (l *Lifecycle) lockGitSnapshotSource(ctx context.Context, cfg *config.Confi
 	metadataProvider := *app
 	metadataProvider.Source = config.NewMetadataSource(snapshot.MetadataURL)
 	metadataProvider.Source.Auth = app.Source.Auth
-	installed, entry, err := l.installMetadataSourcePackage(ctx, expectedKind, name, subject, destDir, &metadataProvider, paths.configDir)
+	installed, entry, err := l.installMetadataSourcePackage(ctx, expectedKind, name, subject, destDir, &metadataProvider, paths.configDir, sourcePath)
 	if err != nil {
 		return LockEntry{}, nil, fmt.Errorf("%s source.git snapshot %s: %w", subject, snapshot.MetadataURL, err)
 	}

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -210,7 +210,7 @@ func (l *Lifecycle) PrepareAtPaths(configPaths []string) (*Lockfile, error) {
 
 func (l *Lifecycle) PrepareAtPathsWithStatePaths(configPaths []string, state StatePaths) (*Lockfile, error) {
 	lock, _, _, err := l.prepareAtPathsAndWriteLock(configPaths, state)
-	return lock, err
+	return lock, config.RenderDiagnosticError(configPaths, err)
 }
 
 func (l *Lifecycle) LockAtPathsWithStatePaths(configPaths []string, state StatePaths) (*Lockfile, error) {
@@ -223,16 +223,16 @@ func (l *Lifecycle) LockAtPathsWithPlatforms(configPaths []string, state StatePa
 		defer cleanup()
 	}
 	if err != nil {
-		return nil, err
+		return nil, config.RenderDiagnosticError(configPaths, err)
 	}
 	if len(platforms) > 0 {
 		tokenForSource := buildSourceTokenMap(cfg)
 		if err := l.downloadPlatformArchives(context.Background(), lock, paths, platforms, tokenForSource); err != nil {
-			return nil, err
+			return nil, config.RenderDiagnosticError(configPaths, err)
 		}
 	}
 	if err := WriteLockfile(paths.lockfilePath, lock); err != nil {
-		return nil, err
+		return nil, config.RenderDiagnosticError(configPaths, err)
 	}
 	slog.Info("wrote lockfile", "path", paths.lockfilePath)
 	return providerLockfileFromLockfile(lock).toLockfile(), nil
@@ -244,12 +244,12 @@ func (l *Lifecycle) CheckLockAtPathsWithStatePaths(configPaths []string, state S
 		defer cleanup()
 	}
 	if err != nil {
-		return err
+		return config.RenderDiagnosticError(configPaths, err)
 	}
 	if len(platforms) > 0 {
 		tokenForSource := buildSourceTokenMap(cfg)
 		if err := l.downloadPlatformArchives(context.Background(), lock, paths, platforms, tokenForSource); err != nil {
-			return err
+			return config.RenderDiagnosticError(configPaths, err)
 		}
 	}
 	expected, err := canonicalLockfileJSON(lock)
@@ -282,11 +282,11 @@ func (l *Lifecycle) CheckSyncAtPathsWithStatePaths(configPaths []string, state S
 }
 
 func (l *Lifecycle) SyncAtPathsWithStatePathsOptions(configPaths []string, state StatePaths, opts SyncOptions) error {
-	return l.syncAtPathsWithStatePaths(configPaths, state, artifactModeMaterialize, opts)
+	return config.RenderDiagnosticError(configPaths, l.syncAtPathsWithStatePaths(configPaths, state, artifactModeMaterialize, opts))
 }
 
 func (l *Lifecycle) CheckSyncAtPathsWithStatePathsOptions(configPaths []string, state StatePaths, opts SyncOptions) error {
-	return l.syncAtPathsWithStatePaths(configPaths, state, artifactModeCheck, opts)
+	return config.RenderDiagnosticError(configPaths, l.syncAtPathsWithStatePaths(configPaths, state, artifactModeCheck, opts))
 }
 
 // PrepareAtPathWithPlatforms runs preparation and additionally downloads and hashes
@@ -300,7 +300,7 @@ func (l *Lifecycle) PrepareAtPathWithPlatforms(configPath, artifactsDir string, 
 func (l *Lifecycle) PrepareAtPathsWithPlatforms(configPaths []string, state StatePaths, platforms []struct{ GOOS, GOARCH string }) (*Lockfile, error) {
 	lock, cfg, paths, err := l.prepareAtPathsAndWriteLock(configPaths, state)
 	if err != nil {
-		return nil, err
+		return nil, config.RenderDiagnosticError(configPaths, err)
 	}
 	if len(platforms) == 0 {
 		return lock, nil
@@ -308,7 +308,7 @@ func (l *Lifecycle) PrepareAtPathsWithPlatforms(configPaths []string, state Stat
 
 	tokenForSource := buildSourceTokenMap(cfg)
 	if err := l.downloadPlatformArchives(context.Background(), lock, paths, platforms, tokenForSource); err != nil {
-		return nil, err
+		return nil, config.RenderDiagnosticError(configPaths, err)
 	}
 
 	if err := WriteLockfile(paths.lockfilePath, lock); err != nil {
@@ -370,10 +370,10 @@ func (l *Lifecycle) prepareCommittedLockAtPathsInScratch(configPaths []string, s
 func (l *Lifecycle) prepareCommittedLockAtPaths(configPaths []string, state StatePaths, displayState ...StatePaths) (*Lockfile, *config.Config, lifecyclePaths, error) {
 	cfg, err := loadConfigForLifecycle(configPaths, state, true)
 	if err != nil {
-		return nil, nil, lifecyclePaths{}, fmt.Errorf("loading config: %v", err)
+		return nil, nil, lifecyclePaths{}, fmt.Errorf("loading config: %w", err)
 	}
 	if err := config.OverlayRemotePluginConfigPaths(configPaths, cfg); err != nil {
-		return nil, nil, lifecyclePaths{}, fmt.Errorf("loading config: %v", err)
+		return nil, nil, lifecyclePaths{}, fmt.Errorf("loading config: %w", err)
 	}
 	if err := applyAppScope(cfg, state); err != nil {
 		return nil, nil, lifecyclePaths{}, err
@@ -410,10 +410,10 @@ func (l *Lifecycle) prepareCommittedLockAtPaths(configPaths []string, state Stat
 func (l *Lifecycle) prepareLockAtPaths(configPaths []string, state StatePaths, displayState ...StatePaths) (*Lockfile, *config.Config, lifecyclePaths, error) {
 	cfg, err := loadConfigForLifecycle(configPaths, state, true)
 	if err != nil {
-		return nil, nil, lifecyclePaths{}, fmt.Errorf("loading config: %v", err)
+		return nil, nil, lifecyclePaths{}, fmt.Errorf("loading config: %w", err)
 	}
 	if err := config.OverlayRemotePluginConfigPaths(configPaths, cfg); err != nil {
-		return nil, nil, lifecyclePaths{}, fmt.Errorf("loading config: %v", err)
+		return nil, nil, lifecyclePaths{}, fmt.Errorf("loading config: %w", err)
 	}
 	if err := applyAppScope(cfg, state); err != nil {
 		return nil, nil, lifecyclePaths{}, err
@@ -502,18 +502,18 @@ func (l *Lifecycle) prepareCommittedRuntimeLockFromLoadedConfig(ctx context.Cont
 					continue
 				}
 			}
-			kind := providerManifestKind(collection.kind)
-			destDir := componentDestDir(paths, collection.kind, name)
+			kind := collection.manifestKind()
+			destDir := collection.destDir(paths, name)
 			configMap, err := config.NodeToMap(entry.Config)
 			if err != nil {
 				return nil, fmt.Errorf("decode provider config for %s %q: %w", kind, name, err)
 			}
-			lockEntry, err := l.lockCommittedComponentEntryForSource(ctx, cfg, paths, kind, name, destDir, entry, configMap)
+			lockEntry, err := l.lockCommittedComponentEntryForSource(ctx, cfg, paths, kind, name, destDir, entry, configMap, collection.sourcePath(name))
 			if err != nil {
 				return nil, err
 			}
 			lockEntriesForKind(lock, collection.kind)[name] = lockEntry
-			if err := l.applyLockedComponentEntry(paths, &lockEntry, kind, name, entry, configMap, destDir, artifactModeCheck); err != nil {
+			if err := l.applyLockedComponentEntry(paths, &lockEntry, kind, name, entry, configMap, destDir, artifactModeCheck, collection.sourcePath(name)); err != nil {
 				return nil, err
 			}
 		}
@@ -528,12 +528,12 @@ func (l *Lifecycle) prepareCommittedRuntimeLockFromLoadedConfig(ctx context.Cont
 		if err != nil {
 			return nil, fmt.Errorf("decode provider config for %s %q: %w", kind, name, err)
 		}
-		lockEntry, err := l.lockCommittedComponentEntryForSource(ctx, cfg, paths, kind, name, destDir, &entry.ProviderEntry, configMap)
+		lockEntry, err := l.lockCommittedComponentEntryForSource(ctx, cfg, paths, kind, name, destDir, &entry.ProviderEntry, configMap, config.ProviderSourcePath("runtime", name))
 		if err != nil {
 			return nil, err
 		}
 		lock.Runtimes[name] = lockEntry
-		if err := l.applyLockedComponentEntry(paths, &lockEntry, kind, name, &entry.ProviderEntry, configMap, destDir, artifactModeCheck); err != nil {
+		if err := l.applyLockedComponentEntry(paths, &lockEntry, kind, name, &entry.ProviderEntry, configMap, destDir, artifactModeCheck, config.ProviderSourcePath("runtime", name)); err != nil {
 			return nil, err
 		}
 	}
@@ -547,12 +547,12 @@ func (l *Lifecycle) prepareCommittedRuntimeLockFromLoadedConfig(ctx context.Cont
 		if err != nil {
 			return nil, fmt.Errorf("decode provider config for %s %q: %w", kind, name, err)
 		}
-		lockEntry, err := l.lockCommittedComponentEntryForSource(ctx, cfg, paths, kind, name, destDir, def, configMap)
+		lockEntry, err := l.lockCommittedComponentEntryForSource(ctx, cfg, paths, kind, name, destDir, def, configMap, config.ProviderSourcePath("indexeddb", name))
 		if err != nil {
 			return nil, err
 		}
 		lock.IndexedDBs[name] = lockEntry
-		if err := l.applyLockedComponentEntry(paths, &lockEntry, kind, name, def, configMap, destDir, artifactModeCheck); err != nil {
+		if err := l.applyLockedComponentEntry(paths, &lockEntry, kind, name, def, configMap, destDir, artifactModeCheck, config.ProviderSourcePath("indexeddb", name)); err != nil {
 			return nil, err
 		}
 	}
@@ -566,12 +566,12 @@ func (l *Lifecycle) prepareCommittedRuntimeLockFromLoadedConfig(ctx context.Cont
 		if err != nil {
 			return nil, fmt.Errorf("decode provider config for %s %q: %w", kind, name, err)
 		}
-		lockEntry, err := l.lockCommittedComponentEntryForSource(ctx, cfg, paths, kind, name, destDir, def, configMap)
+		lockEntry, err := l.lockCommittedComponentEntryForSource(ctx, cfg, paths, kind, name, destDir, def, configMap, config.ProviderSourcePath("s3", name))
 		if err != nil {
 			return nil, err
 		}
 		lock.S3[name] = lockEntry
-		if err := l.applyLockedComponentEntry(paths, &lockEntry, kind, name, def, configMap, destDir, artifactModeCheck); err != nil {
+		if err := l.applyLockedComponentEntry(paths, &lockEntry, kind, name, def, configMap, destDir, artifactModeCheck, config.ProviderSourcePath("s3", name)); err != nil {
 			return nil, err
 		}
 	}
@@ -580,7 +580,7 @@ func (l *Lifecycle) prepareCommittedRuntimeLockFromLoadedConfig(ctx context.Cont
 			continue
 		}
 		if _, existed := existingUIEntries[name]; !existed && entry.HasLocalSource() && pathWithinRoot(filepath.Join(paths.artifactsDir, ".gestaltd"), entry.SourcePath()) {
-			if _, err := l.applyConfiguredUIProvider(paths, nil, &entry.ProviderEntry, name, "ui "+strconv.Quote(name), uiDestDir(paths, name), artifactModeCheck); err != nil {
+			if _, err := l.applyConfiguredUIProvider(paths, nil, &entry.ProviderEntry, name, "ui "+strconv.Quote(name), uiDestDir(paths, name), artifactModeCheck, config.ProviderSourcePath("ui", name)); err != nil {
 				return nil, err
 			}
 			continue
@@ -593,7 +593,7 @@ func (l *Lifecycle) prepareCommittedRuntimeLockFromLoadedConfig(ctx context.Cont
 			return nil, err
 		}
 		lock.UIs[name] = lockEntry
-		if _, err := l.applyConfiguredUIProvider(paths, &lockEntry, &entry.ProviderEntry, name, "ui "+strconv.Quote(name), uiDestDir(paths, name), artifactModeCheck); err != nil {
+		if _, err := l.applyConfiguredUIProvider(paths, &lockEntry, &entry.ProviderEntry, name, "ui "+strconv.Quote(name), uiDestDir(paths, name), artifactModeCheck, config.ProviderSourcePath("ui", name)); err != nil {
 			return nil, err
 		}
 	}
@@ -652,8 +652,8 @@ func (l *Lifecycle) prepareRuntimeLockFromLoadedConfigWithSecretMode(ctx context
 					continue
 				}
 			}
-			destDir := componentDestDir(paths, collection.kind, name)
-			lockEntry, err := l.writeComponentArtifact(ctx, cfg, paths, providerManifestKind(collection.kind), name, destDir, entry, entry.Config)
+			destDir := collection.destDir(paths, name)
+			lockEntry, err := l.writeComponentArtifact(ctx, cfg, paths, collection.manifestKind(), name, destDir, entry, entry.Config, collection.sourcePath(name))
 			if err != nil {
 				return nil, err
 			}
@@ -667,7 +667,7 @@ func (l *Lifecycle) prepareRuntimeLockFromLoadedConfigWithSecretMode(ctx context
 			continue
 		}
 		destDir := componentDestDir(paths, config.HostProviderKindRuntime, name)
-		lockEntry, err := l.writeComponentArtifact(ctx, cfg, paths, providerManifestKind(config.HostProviderKindRuntime), name, destDir, &entry.ProviderEntry, entry.Config)
+		lockEntry, err := l.writeComponentArtifact(ctx, cfg, paths, providerManifestKind(config.HostProviderKindRuntime), name, destDir, &entry.ProviderEntry, entry.Config, config.ProviderSourcePath("runtime", name))
 		if err != nil {
 			return nil, err
 		}
@@ -692,7 +692,7 @@ func (l *Lifecycle) prepareRuntimeLockFromLoadedConfigWithSecretMode(ctx context
 	}
 	for name, def := range cfg.Providers.IndexedDB {
 		if sourceBacked(def) {
-			entry, err := l.writeComponentArtifact(ctx, cfg, paths, providermanifestv1.KindIndexedDB, name, indexeddbDestDir(paths, name), def, def.Config)
+			entry, err := l.writeComponentArtifact(ctx, cfg, paths, providermanifestv1.KindIndexedDB, name, indexeddbDestDir(paths, name), def, def.Config, config.ProviderSourcePath("indexeddb", name))
 			if err != nil {
 				return nil, err
 			}
@@ -703,7 +703,7 @@ func (l *Lifecycle) prepareRuntimeLockFromLoadedConfigWithSecretMode(ctx context
 	}
 	for name, def := range cfg.Providers.S3 {
 		if sourceBacked(def) {
-			entry, err := l.writeComponentArtifact(ctx, cfg, paths, providermanifestv1.KindS3, name, s3DestDir(paths, name), def, def.Config)
+			entry, err := l.writeComponentArtifact(ctx, cfg, paths, providermanifestv1.KindS3, name, s3DestDir(paths, name), def, def.Config, config.ProviderSourcePath("s3", name))
 			if err != nil {
 				return nil, err
 			}
@@ -743,37 +743,37 @@ func (l *Lifecycle) resolvePackageSources(ctx context.Context, cfg *config.Confi
 		return err
 	}
 	for name, entry := range cfg.Apps {
-		if err := l.resolvePackageSourceEntry(ctx, "plugin "+strconv.Quote(name), entry, repos); err != nil {
+		if err := l.resolvePackageSourceEntry(ctx, "plugin "+strconv.Quote(name), entry, repos, config.ProviderSourcePath("app", name)); err != nil {
 			return err
 		}
 	}
 	for _, collection := range hostProviderCollections(cfg) {
 		for name, entry := range collection.entries {
-			if err := l.resolvePackageSourceEntry(ctx, string(collection.kind)+" "+strconv.Quote(name), entry, repos); err != nil {
+			if err := l.resolvePackageSourceEntry(ctx, string(collection.kind)+" "+strconv.Quote(name), entry, repos, collection.sourcePath(name)); err != nil {
 				return err
 			}
 		}
 	}
 	for name, entry := range cfg.Providers.IndexedDB {
-		if err := l.resolvePackageSourceEntry(ctx, string(config.HostProviderKindIndexedDB)+" "+strconv.Quote(name), entry, repos); err != nil {
+		if err := l.resolvePackageSourceEntry(ctx, string(config.HostProviderKindIndexedDB)+" "+strconv.Quote(name), entry, repos, config.ProviderSourcePath("indexeddb", name)); err != nil {
 			return err
 		}
 	}
 	for name, entry := range cfg.Providers.S3 {
-		if err := l.resolvePackageSourceEntry(ctx, providermanifestv1.KindS3+" "+strconv.Quote(name), entry, repos); err != nil {
+		if err := l.resolvePackageSourceEntry(ctx, providermanifestv1.KindS3+" "+strconv.Quote(name), entry, repos, config.ProviderSourcePath("s3", name)); err != nil {
 			return err
 		}
 	}
 	for name, entry := range cfg.Runtime.Providers {
 		if entry != nil {
-			if err := l.resolvePackageSourceEntry(ctx, "runtime "+strconv.Quote(name), &entry.ProviderEntry, repos); err != nil {
+			if err := l.resolvePackageSourceEntry(ctx, "runtime "+strconv.Quote(name), &entry.ProviderEntry, repos, config.ProviderSourcePath("runtime", name)); err != nil {
 				return err
 			}
 		}
 	}
 	for name, entry := range cfg.Providers.UI {
 		if entry != nil {
-			if err := l.resolvePackageSourceEntry(ctx, "ui "+strconv.Quote(name), &entry.ProviderEntry, repos); err != nil {
+			if err := l.resolvePackageSourceEntry(ctx, "ui "+strconv.Quote(name), &entry.ProviderEntry, repos, config.ProviderSourcePath("ui", name)); err != nil {
 				return err
 			}
 		}
@@ -781,7 +781,7 @@ func (l *Lifecycle) resolvePackageSources(ctx context.Context, cfg *config.Confi
 	return nil
 }
 
-func (l *Lifecycle) resolvePackageSourceEntry(ctx context.Context, subject string, entry *config.ProviderEntry, repos []providerregistry.NamedRepository) error {
+func (l *Lifecycle) resolvePackageSourceEntry(ctx context.Context, subject string, entry *config.ProviderEntry, repos []providerregistry.NamedRepository, sourcePath []string) error {
 	if entry == nil || !entry.Source.IsPackage() || entry.Source.ResolvedPackageMetadataURL() != "" {
 		return nil
 	}
@@ -800,10 +800,29 @@ func (l *Lifecycle) resolvePackageSourceEntry(ctx context.Context, subject strin
 		Repositories:      reqRepos,
 	})
 	if err != nil {
-		return fmt.Errorf("%s resolve provider package: %w", subject, err)
+		return fmt.Errorf("%s resolve provider package: %w", subject, config.WrapDiagnosticError(sourcePath, "provider package source could not be resolved", err))
 	}
 	entry.Source.SetResolvedPackage(resolved.MetadataURL, resolved.Version)
 	return nil
+}
+
+func providerLockSourcePath(kind, name string) []string {
+	switch kind {
+	case providermanifestv1.KindApp:
+		return config.ProviderSourcePath("app", name)
+	case providermanifestv1.KindExternalCredentials:
+		return config.ProviderSourcePath(string(config.HostProviderKindExternalCredentials), name)
+	case providermanifestv1.KindRuntime:
+		return config.ProviderSourcePath("runtime", name)
+	case providermanifestv1.KindUI:
+		return config.ProviderSourcePath("ui", name)
+	case providerLockKindTelemetry:
+		return config.ProviderSourcePath(string(config.HostProviderKindTelemetry), name)
+	case providerLockKindAudit:
+		return config.ProviderSourcePath(string(config.HostProviderKindAudit), name)
+	default:
+		return config.ProviderSourcePath(kind, name)
+	}
 }
 
 func configHasPackageSources(cfg *config.Config) bool {
@@ -1000,10 +1019,12 @@ func (l *Lifecycle) LoadForExecutionAtPaths(configPaths []string, locked bool) (
 	return l.LoadForExecutionAtPathsWithStatePaths(configPaths, StatePaths{}, locked)
 }
 
-func (l *Lifecycle) LoadForExecutionAtPathsWithStatePaths(configPaths []string, state StatePaths, locked bool) (*config.Config, map[string]string, error) {
-	cfg, err := loadConfigForLifecycle(configPaths, state, false)
+func (l *Lifecycle) LoadForExecutionAtPathsWithStatePaths(configPaths []string, state StatePaths, locked bool) (cfg *config.Config, fragments map[string]string, err error) {
+	defer func() { err = config.RenderDiagnosticError(configPaths, err) }()
+
+	cfg, err = loadConfigForLifecycle(configPaths, state, false)
 	if err != nil {
-		return nil, nil, fmt.Errorf("loading config: %v", err)
+		return nil, nil, fmt.Errorf("loading config: %w", err)
 	}
 	if err := applyAppScope(cfg, state); err != nil {
 		return nil, nil, err
@@ -1042,10 +1063,12 @@ func (l *Lifecycle) LoadForExecutionAtPathsWithStatePaths(configPaths []string, 
 	return cfg, nil, nil
 }
 
-func (l *Lifecycle) LoadForValidationAtPathsWithStatePaths(configPaths []string, state StatePaths) (*config.Config, error) {
-	cfg, err := loadConfigForLifecycle(configPaths, state, false)
+func (l *Lifecycle) LoadForValidationAtPathsWithStatePaths(configPaths []string, state StatePaths) (cfg *config.Config, err error) {
+	defer func() { err = config.RenderDiagnosticError(configPaths, err) }()
+
+	cfg, err = loadConfigForLifecycle(configPaths, state, false)
 	if err != nil {
-		return nil, fmt.Errorf("loading config: %v", err)
+		return nil, fmt.Errorf("loading config: %w", err)
 	}
 	if err := applyAppScope(cfg, state); err != nil {
 		return nil, err
@@ -1070,13 +1093,15 @@ func (l *Lifecycle) LoadForValidationAtPathsWithStatePaths(configPaths []string,
 	return cfg, nil
 }
 
-func (l *Lifecycle) LoadForStaticValidationAtPathsWithStatePaths(configPaths []string, state StatePaths, opts StaticValidationOptions) (*config.Config, error) {
-	cfg, err := loadConfigForLifecycle(configPaths, state, true)
+func (l *Lifecycle) LoadForStaticValidationAtPathsWithStatePaths(configPaths []string, state StatePaths, opts StaticValidationOptions) (cfg *config.Config, err error) {
+	defer func() { err = config.RenderDiagnosticError(configPaths, err) }()
+
+	cfg, err = loadConfigForLifecycle(configPaths, state, true)
 	if err != nil {
-		return nil, fmt.Errorf("loading config: %v", err)
+		return nil, fmt.Errorf("loading config: %w", err)
 	}
 	if err := config.OverlayRemotePluginConfigPaths(configPaths, cfg); err != nil {
-		return nil, fmt.Errorf("loading config: %v", err)
+		return nil, fmt.Errorf("loading config: %w", err)
 	}
 	if err := applyAppScope(cfg, state); err != nil {
 		return nil, err
@@ -1139,10 +1164,10 @@ func (l *Lifecycle) syncAtPathsWithStatePaths(configPaths []string, state StateP
 	opts = normalizeSyncOptions(opts)
 	cfg, err := loadConfigForLifecycle(configPaths, state, true)
 	if err != nil {
-		return fmt.Errorf("loading config: %v", err)
+		return fmt.Errorf("loading config: %w", err)
 	}
 	if err := config.OverlayRemotePluginConfigPaths(configPaths, cfg); err != nil {
-		return fmt.Errorf("loading config: %v", err)
+		return fmt.Errorf("loading config: %w", err)
 	}
 	if err := applyAppScope(cfg, state); err != nil {
 		return err
@@ -1467,7 +1492,7 @@ func (l *Lifecycle) primeSecretsProviderForConfigResolution(ctx context.Context,
 			}
 			packageReposLoaded = true
 		}
-		return l.resolvePackageSourceEntry(ctx, providermanifestv1.KindSecrets+" "+strconv.Quote(name), provider, packageRepos)
+		return l.resolvePackageSourceEntry(ctx, providermanifestv1.KindSecrets+" "+strconv.Quote(name), provider, packageRepos, config.ProviderSourcePath("secrets", name))
 	}
 	for len(pending) > 0 {
 		progress := false
@@ -1507,7 +1532,7 @@ func (l *Lifecycle) primeSecretsProviderForConfigResolution(ctx context.Context,
 				switch {
 				case provider.HasLocalSource():
 					if lock == nil {
-						entry, err := l.writeComponentArtifact(ctx, cfg, paths, providermanifestv1.KindSecrets, name, secretsDestDir(paths, name), provider, provider.Config)
+						entry, err := l.writeComponentArtifact(ctx, cfg, paths, providermanifestv1.KindSecrets, name, secretsDestDir(paths, name), provider, provider.Config, config.ProviderSourcePath("secrets", name))
 						if err != nil {
 							return nil, err
 						}
@@ -1521,15 +1546,15 @@ func (l *Lifecycle) primeSecretsProviderForConfigResolution(ctx context.Context,
 					if !ok {
 						return nil, lockMetadataStaleError(paths, "lock entry for %s %q is missing or stale", providermanifestv1.KindSecrets, name)
 					}
-					if err := l.applyLockedComponentEntry(paths, &lockEntry, providermanifestv1.KindSecrets, name, provider, configMap, secretsDestDir(paths, name), mode); err != nil {
+					if err := l.applyLockedComponentEntry(paths, &lockEntry, providermanifestv1.KindSecrets, name, provider, configMap, secretsDestDir(paths, name), mode, config.ProviderSourcePath("secrets", name)); err != nil {
 						return nil, err
 					}
 				default:
-					entry, err := l.writeComponentArtifact(ctx, cfg, paths, providermanifestv1.KindSecrets, name, secretsDestDir(paths, name), provider, provider.Config)
+					entry, err := l.writeComponentArtifact(ctx, cfg, paths, providermanifestv1.KindSecrets, name, secretsDestDir(paths, name), provider, provider.Config, config.ProviderSourcePath("secrets", name))
 					if err != nil {
 						return nil, err
 					}
-					if err := l.applyLockedComponentEntry(paths, &entry, providermanifestv1.KindSecrets, name, provider, configMap, secretsDestDir(paths, name), artifactModeMaterialize); err != nil {
+					if err := l.applyLockedComponentEntry(paths, &entry, providermanifestv1.KindSecrets, name, provider, configMap, secretsDestDir(paths, name), artifactModeMaterialize, config.ProviderSourcePath("secrets", name)); err != nil {
 						return nil, err
 					}
 					prepared[name] = entry
@@ -1683,14 +1708,25 @@ func runtimeRequiresCommittedLock(entry *config.RuntimeProviderEntry) bool {
 	return entry != nil && providerRequiresCommittedLock(&entry.ProviderEntry)
 }
 
-func hostProviderCollections(cfg *config.Config) []struct {
+type hostProviderCollection struct {
 	kind    config.HostProviderKind
 	entries map[string]*config.ProviderEntry
-} {
-	return []struct {
-		kind    config.HostProviderKind
-		entries map[string]*config.ProviderEntry
-	}{
+}
+
+func (c hostProviderCollection) manifestKind() string {
+	return providerManifestKind(c.kind)
+}
+
+func (c hostProviderCollection) destDir(paths lifecyclePaths, name string) string {
+	return componentDestDir(paths, c.kind, name)
+}
+
+func (c hostProviderCollection) sourcePath(name string) []string {
+	return config.ProviderSourcePath(string(c.kind), name)
+}
+
+func hostProviderCollections(cfg *config.Config) []hostProviderCollection {
+	return []hostProviderCollection{
 		{config.HostProviderKindAuthentication, cfg.Providers.Authentication},
 		{config.HostProviderKindAuthorization, cfg.Providers.Authorization},
 		{config.HostProviderKindExternalCredentials, cfg.Providers.ExternalCredentials},
@@ -2313,7 +2349,7 @@ func lockMatchesConfig(cfg *config.Config, paths lifecyclePaths, lock *Lockfile)
 				continue
 			}
 			lockEntry, found := lockEntries[name]
-			if !lockEntryMatches(paths, providerManifestKind(collection.kind), name, entry, lockEntry, found, componentDestDir(paths, collection.kind, name)) {
+			if !lockEntryMatches(paths, collection.manifestKind(), name, entry, lockEntry, found, collection.destDir(paths, name)) {
 				return false
 			}
 		}
@@ -2392,9 +2428,9 @@ func lockMetadataMatchesConfigForSync(cfg *config.Config, paths lifecyclePaths, 
 			if entry == nil || !providerRequiresCommittedLock(entry) {
 				continue
 			}
-			kind := providerManifestKind(collection.kind)
+			kind := collection.manifestKind()
 			lockEntry, found := lockEntries[name]
-			if !lockEntryMetadataMatchesForMode(paths, kind, name, entry, lockEntry, found, componentDestDir(paths, collection.kind, name), false) {
+			if !lockEntryMetadataMatchesForMode(paths, kind, name, entry, lockEntry, found, collection.destDir(paths, name), false) {
 				return false
 			}
 		}
@@ -3215,11 +3251,11 @@ func localUILockEntryFromPreparedInstall(paths lifecyclePaths, name string, app 
 	return entry, nil
 }
 
-func (l *Lifecycle) installMetadataSourcePackage(ctx context.Context, expectedKind, name, subject, destDir string, app *config.ProviderEntry, configDir string) (*installedPackage, LockEntry, error) {
+func (l *Lifecycle) installMetadataSourcePackage(ctx context.Context, expectedKind, name, subject, destDir string, app *config.ProviderEntry, configDir string, sourcePath []string) (*installedPackage, LockEntry, error) {
 	sourceLocation := app.SourceReleaseLocation()
 	metadata, resolvedMetadataLocation, gitHubReleaseAssets, err := fetchProviderReleaseMetadata(ctx, l.metadataHTTPClient(), sourceLocation, sourceAuthToken(app))
 	if err != nil {
-		return nil, LockEntry{}, fmt.Errorf("%s fetch metadata %q: %w", subject, sourceLocation, err)
+		return nil, LockEntry{}, fmt.Errorf("%s fetch metadata %q: %w", subject, sourceLocation, config.WrapDiagnosticError(sourcePath, "", err))
 	}
 	expectedManifestKind := archivePolicyKind(expectedKind)
 	if metadata.Kind != expectedManifestKind {
@@ -3249,7 +3285,7 @@ func (l *Lifecycle) installMetadataSourcePackage(ctx context.Context, expectedKi
 	}
 	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), sourceAuthToken(app), archiveLocation)
 	if err != nil {
-		return nil, LockEntry{}, fmt.Errorf("download metadata source package for %s: %w", subject, err)
+		return nil, LockEntry{}, fmt.Errorf("download metadata source package for %s: %w", subject, config.WrapDiagnosticError(sourcePath, "provider archive could not be downloaded", err))
 	}
 	defer download.Cleanup()
 	if archive.SHA256 != "" && download.SHA256Hex != archive.SHA256 {
@@ -3313,22 +3349,22 @@ func (l *Lifecycle) lockCommittedProviderEntryForSource(ctx context.Context, cfg
 	return l.lockProviderEntryForSource(ctx, cfg, paths, name, app, configMap)
 }
 
-func (l *Lifecycle) writeComponentArtifact(ctx context.Context, cfg *config.Config, paths lifecyclePaths, kind, name, destDir string, app *config.ProviderEntry, configNode yaml.Node) (LockEntry, error) {
+func (l *Lifecycle) writeComponentArtifact(ctx context.Context, cfg *config.Config, paths lifecyclePaths, kind, name, destDir string, app *config.ProviderEntry, configNode yaml.Node, sourcePath []string) (LockEntry, error) {
 	configMap, err := config.NodeToMap(configNode)
 	if err != nil {
 		return LockEntry{}, fmt.Errorf("decode provider config for %s %q: %w", kind, name, err)
 	}
-	return l.lockComponentEntryForSource(ctx, cfg, paths, kind, name, destDir, app, configMap)
+	return l.lockComponentEntryForSource(ctx, cfg, paths, kind, name, destDir, app, configMap, sourcePath)
 }
 
-func (l *Lifecycle) lockCommittedComponentEntryForSource(ctx context.Context, cfg *config.Config, paths lifecyclePaths, kind, name, destDir string, app *config.ProviderEntry, configMap map[string]any) (LockEntry, error) {
+func (l *Lifecycle) lockCommittedComponentEntryForSource(ctx context.Context, cfg *config.Config, paths lifecyclePaths, kind, name, destDir string, app *config.ProviderEntry, configMap map[string]any, sourcePath []string) (LockEntry, error) {
 	if !providerRequiresCommittedLock(app) {
 		return LockEntry{}, fmt.Errorf("%s %q does not require committed lock metadata", kind, name)
 	}
-	return l.lockComponentEntryForSource(ctx, cfg, paths, kind, name, destDir, app, configMap)
+	return l.lockComponentEntryForSource(ctx, cfg, paths, kind, name, destDir, app, configMap, sourcePath)
 }
 
-func (l *Lifecycle) lockComponentEntryForSource(ctx context.Context, cfg *config.Config, paths lifecyclePaths, kind, name, destDir string, app *config.ProviderEntry, configMap map[string]any) (LockEntry, error) {
+func (l *Lifecycle) lockComponentEntryForSource(ctx context.Context, cfg *config.Config, paths lifecyclePaths, kind, name, destDir string, app *config.ProviderEntry, configMap map[string]any, sourcePath []string) (LockEntry, error) {
 	if app != nil && app.HasLocalSource() {
 		install, err := prepareLocalSourceInstall(kind, name, app.SourcePath(), destDir)
 		if err != nil {
@@ -3343,7 +3379,7 @@ func (l *Lifecycle) lockComponentEntryForSource(ctx context.Context, cfg *config
 		return localLockEntryFromPreparedInstall(paths, kind, name, app, install)
 	}
 	if app != nil && app.HasGitSource() {
-		return l.lockGitComponentEntryForSource(ctx, cfg, paths, kind, name, destDir, app, configMap)
+		return l.lockGitComponentEntryForSource(ctx, cfg, paths, kind, name, destDir, app, configMap, sourcePath)
 	}
 
 	sourceLocation := app.SourceReleaseLocation()
@@ -3356,7 +3392,7 @@ func (l *Lifecycle) lockComponentEntryForSource(ctx context.Context, cfg *config
 	if !app.HasReleaseMetadataSource() {
 		return LockEntry{}, fmt.Errorf("%s %q source %q: only provider-release metadata sources and local manifest paths are supported", kind, name, sourceLocation)
 	}
-	installed, entry, err = l.installMetadataSourcePackage(ctx, kind, name, subject, destDir, app, paths.configDir)
+	installed, entry, err = l.installMetadataSourcePackage(ctx, kind, name, subject, destDir, app, paths.configDir, sourcePath)
 	if err != nil {
 		return LockEntry{}, err
 	}
@@ -3414,7 +3450,7 @@ func (l *Lifecycle) lockProviderEntryForSource(ctx context.Context, cfg *config.
 	if !app.HasReleaseMetadataSource() {
 		return LockEntry{}, fmt.Errorf("provider %q source %q: only provider-release metadata sources and local manifest paths are supported", name, sourceLocation)
 	}
-	installed, entry, err = l.installMetadataSourcePackage(ctx, providermanifestv1.KindApp, name, fmt.Sprintf("provider %q", name), destDir, app, paths.configDir)
+	installed, entry, err = l.installMetadataSourcePackage(ctx, providermanifestv1.KindApp, name, fmt.Sprintf("provider %q", name), destDir, app, paths.configDir, config.ProviderSourcePath("app", name))
 	if err != nil {
 		return LockEntry{}, err
 	}
@@ -3486,7 +3522,7 @@ func (l *Lifecycle) writeNamedUIProviderArtifact(ctx context.Context, cfg *confi
 	if !app.HasReleaseMetadataSource() {
 		return LockEntry{}, fmt.Errorf("%s source %q: only provider-release metadata sources and local manifest paths are supported", subject, expectedPackage)
 	}
-	installed, entry, opErr = l.installMetadataSourcePackage(ctx, providermanifestv1.KindUI, name, subject, destDir, app, paths.configDir)
+	installed, entry, opErr = l.installMetadataSourcePackage(ctx, providermanifestv1.KindUI, name, subject, destDir, app, paths.configDir, config.ProviderSourcePath("ui", name))
 	if opErr != nil {
 		return LockEntry{}, opErr
 	}
@@ -3531,7 +3567,7 @@ func (l *Lifecycle) applyPreparedProviders(paths lifecyclePaths, lock *Lockfile,
 			if entry == nil {
 				continue
 			}
-			if err := l.applyComponentProvider(paths, lockEntries, providerManifestKind(collection.kind), name, entry, entry.Config, &entry.Config, componentDestDir(paths, collection.kind, name), mode); err != nil {
+			if err := l.applyComponentProvider(paths, lockEntries, collection.manifestKind(), name, entry, entry.Config, &entry.Config, collection.destDir(paths, name), mode, collection.sourcePath(name)); err != nil {
 				return err
 			}
 		}
@@ -3544,7 +3580,7 @@ func (l *Lifecycle) applyPreparedProviders(paths lifecyclePaths, lock *Lockfile,
 		if entry == nil {
 			continue
 		}
-		if err := l.applyComponentProvider(paths, runtimeLocks, providermanifestv1.KindRuntime, name, &entry.ProviderEntry, entry.Config, &entry.Config, runtimeDestDir(paths, name), mode); err != nil {
+		if err := l.applyComponentProvider(paths, runtimeLocks, providermanifestv1.KindRuntime, name, &entry.ProviderEntry, entry.Config, &entry.Config, runtimeDestDir(paths, name), mode, config.ProviderSourcePath("runtime", name)); err != nil {
 			return err
 		}
 	}
@@ -3554,7 +3590,7 @@ func (l *Lifecycle) applyPreparedProviders(paths lifecyclePaths, lock *Lockfile,
 	}
 	for name, def := range cfg.Providers.IndexedDB {
 		if def != nil {
-			if err := l.applyComponentProvider(paths, indexedDBLocks, providermanifestv1.KindIndexedDB, name, def, def.Config, &def.Config, indexeddbDestDir(paths, name), mode); err != nil {
+			if err := l.applyComponentProvider(paths, indexedDBLocks, providermanifestv1.KindIndexedDB, name, def, def.Config, &def.Config, indexeddbDestDir(paths, name), mode, config.ProviderSourcePath("indexeddb", name)); err != nil {
 				return err
 			}
 		}
@@ -3565,7 +3601,7 @@ func (l *Lifecycle) applyPreparedProviders(paths lifecyclePaths, lock *Lockfile,
 	}
 	for name, def := range cfg.Providers.S3 {
 		if def != nil {
-			if err := l.applyComponentProvider(paths, s3Locks, providermanifestv1.KindS3, name, def, def.Config, &def.Config, s3DestDir(paths, name), mode); err != nil {
+			if err := l.applyComponentProvider(paths, s3Locks, providermanifestv1.KindS3, name, def, def.Config, &def.Config, s3DestDir(paths, name), mode, config.ProviderSourcePath("s3", name)); err != nil {
 				return err
 			}
 		}
@@ -3628,7 +3664,7 @@ func (l *Lifecycle) applyPreparedUIProviders(paths lifecyclePaths, lock *Lockfil
 			work.entry.ResolvedAssetRoot = resolvedAssetRoot
 			continue
 		}
-		resolvedAssetRoot, err := l.applyConfiguredUIProvider(paths, work.lockEntry, &work.entry.ProviderEntry, work.name, work.subject, work.destDir, mode)
+		resolvedAssetRoot, err := l.applyConfiguredUIProvider(paths, work.lockEntry, &work.entry.ProviderEntry, work.name, work.subject, work.destDir, mode, config.ProviderSourcePath("ui", work.name))
 		if err != nil {
 			return err
 		}
@@ -4135,7 +4171,7 @@ func (l *Lifecycle) applyStaticValidationProviders(ctx context.Context, paths li
 		if err != nil {
 			return fmt.Errorf("decode provider config for provider %q: %w", name, err)
 		}
-		if err := l.applyStaticValidationEntry(ctx, paths, lockEntriesForProviderKind(lock, providermanifestv1.KindApp), providermanifestv1.KindApp, name, entry, configMap, providerDestDir(paths, name), platform, false, func(manifestPath string, manifest *providermanifestv1.Manifest) error {
+		if err := l.applyStaticValidationEntry(ctx, paths, lockEntriesForProviderKind(lock, providermanifestv1.KindApp), providermanifestv1.KindApp, name, entry, configMap, providerDestDir(paths, name), platform, false, config.ProviderSourcePath("app", name), func(manifestPath string, manifest *providermanifestv1.Manifest) error {
 			return bindResolvedProviderManifest(name, entry, manifestPath, manifest, configMap)
 		}); err != nil {
 			return err
@@ -4151,7 +4187,7 @@ func (l *Lifecycle) applyStaticValidationProviders(ctx context.Context, paths li
 	}
 	for _, collection := range hostProviderCollections(cfg) {
 		lockEntries := lockEntriesForKind(lock, collection.kind)
-		kind := providerManifestKind(collection.kind)
+		kind := collection.manifestKind()
 		for name, entry := range collection.entries {
 			if entry == nil {
 				continue
@@ -4160,7 +4196,7 @@ func (l *Lifecycle) applyStaticValidationProviders(ctx context.Context, paths li
 			if err != nil {
 				return fmt.Errorf("decode provider config for %s %q: %w", kind, name, err)
 			}
-			if err := l.applyStaticValidationEntry(ctx, paths, lockEntries, kind, name, entry, configMap, componentDestDir(paths, collection.kind, name), platform, false, func(manifestPath string, manifest *providermanifestv1.Manifest) error {
+			if err := l.applyStaticValidationEntry(ctx, paths, lockEntries, kind, name, entry, configMap, collection.destDir(paths, name), platform, false, collection.sourcePath(name), func(manifestPath string, manifest *providermanifestv1.Manifest) error {
 				return bindResolvedComponentManifest(kind, name, entry, manifestPath, manifest, configMap)
 			}); err != nil {
 				return err
@@ -4175,7 +4211,7 @@ func (l *Lifecycle) applyStaticValidationProviders(ctx context.Context, paths li
 		if err != nil {
 			return fmt.Errorf("decode provider config for %s %q: %w", providermanifestv1.KindRuntime, name, err)
 		}
-		if err := l.applyStaticValidationEntry(ctx, paths, lockEntriesForProviderKind(lock, providermanifestv1.KindRuntime), providermanifestv1.KindRuntime, name, &entry.ProviderEntry, configMap, runtimeDestDir(paths, name), platform, false, func(manifestPath string, manifest *providermanifestv1.Manifest) error {
+		if err := l.applyStaticValidationEntry(ctx, paths, lockEntriesForProviderKind(lock, providermanifestv1.KindRuntime), providermanifestv1.KindRuntime, name, &entry.ProviderEntry, configMap, runtimeDestDir(paths, name), platform, false, config.ProviderSourcePath("runtime", name), func(manifestPath string, manifest *providermanifestv1.Manifest) error {
 			return bindResolvedComponentManifest(providermanifestv1.KindRuntime, name, &entry.ProviderEntry, manifestPath, manifest, configMap)
 		}); err != nil {
 			return err
@@ -4189,7 +4225,7 @@ func (l *Lifecycle) applyStaticValidationProviders(ctx context.Context, paths li
 		if err != nil {
 			return fmt.Errorf("decode provider config for %s %q: %w", providermanifestv1.KindIndexedDB, name, err)
 		}
-		if err := l.applyStaticValidationEntry(ctx, paths, lockEntriesForProviderKind(lock, providermanifestv1.KindIndexedDB), providermanifestv1.KindIndexedDB, name, entry, configMap, indexeddbDestDir(paths, name), platform, false, func(manifestPath string, manifest *providermanifestv1.Manifest) error {
+		if err := l.applyStaticValidationEntry(ctx, paths, lockEntriesForProviderKind(lock, providermanifestv1.KindIndexedDB), providermanifestv1.KindIndexedDB, name, entry, configMap, indexeddbDestDir(paths, name), platform, false, config.ProviderSourcePath("indexeddb", name), func(manifestPath string, manifest *providermanifestv1.Manifest) error {
 			return bindResolvedComponentManifest(providermanifestv1.KindIndexedDB, name, entry, manifestPath, manifest, configMap)
 		}); err != nil {
 			return err
@@ -4203,7 +4239,7 @@ func (l *Lifecycle) applyStaticValidationProviders(ctx context.Context, paths li
 		if err != nil {
 			return fmt.Errorf("decode provider config for %s %q: %w", providermanifestv1.KindS3, name, err)
 		}
-		if err := l.applyStaticValidationEntry(ctx, paths, lockEntriesForProviderKind(lock, providermanifestv1.KindS3), providermanifestv1.KindS3, name, entry, configMap, s3DestDir(paths, name), platform, false, func(manifestPath string, manifest *providermanifestv1.Manifest) error {
+		if err := l.applyStaticValidationEntry(ctx, paths, lockEntriesForProviderKind(lock, providermanifestv1.KindS3), providermanifestv1.KindS3, name, entry, configMap, s3DestDir(paths, name), platform, false, config.ProviderSourcePath("s3", name), func(manifestPath string, manifest *providermanifestv1.Manifest) error {
 			return bindResolvedComponentManifest(providermanifestv1.KindS3, name, entry, manifestPath, manifest, configMap)
 		}); err != nil {
 			return err
@@ -4217,7 +4253,7 @@ func (l *Lifecycle) applyStaticValidationProviders(ctx context.Context, paths li
 		if err != nil {
 			return fmt.Errorf("decode ui %q config: %w", name, err)
 		}
-		if err := l.applyStaticValidationEntry(ctx, paths, lockEntriesForProviderKind(lock, providermanifestv1.KindUI), providermanifestv1.KindUI, name, &entry.ProviderEntry, configMap, uiDestDir(paths, name), platform, true, func(manifestPath string, manifest *providermanifestv1.Manifest) error {
+		if err := l.applyStaticValidationEntry(ctx, paths, lockEntriesForProviderKind(lock, providermanifestv1.KindUI), providermanifestv1.KindUI, name, &entry.ProviderEntry, configMap, uiDestDir(paths, name), platform, true, config.ProviderSourcePath("ui", name), func(manifestPath string, manifest *providermanifestv1.Manifest) error {
 			return bindResolvedUIManifest(&entry.ProviderEntry, manifestPath, manifest, configMap)
 		}); err != nil {
 			return err
@@ -4226,7 +4262,7 @@ func (l *Lifecycle) applyStaticValidationProviders(ctx context.Context, paths li
 	return nil
 }
 
-func (l *Lifecycle) applyStaticValidationEntry(ctx context.Context, paths lifecyclePaths, lockEntries map[string]LockEntry, kind, name string, provider *config.ProviderEntry, configMap map[string]any, destDir, platform string, ui bool, bind func(string, *providermanifestv1.Manifest) error) error {
+func (l *Lifecycle) applyStaticValidationEntry(ctx context.Context, paths lifecyclePaths, lockEntries map[string]LockEntry, kind, name string, provider *config.ProviderEntry, configMap map[string]any, destDir, platform string, ui bool, sourcePath []string, bind func(string, *providermanifestv1.Manifest) error) error {
 	if provider == nil || !sourceBacked(provider) {
 		return nil
 	}
@@ -4309,7 +4345,7 @@ func (l *Lifecycle) applyStaticValidationEntry(ctx context.Context, paths lifecy
 	if !found {
 		return lockMetadataStaleError(paths, "lock entry for %s %q is missing or stale", kind, name)
 	}
-	install, cleanup, err := l.installLockedArchiveForStaticValidation(ctx, paths, kind, name, provider, entry, destDir, platform)
+	install, cleanup, err := l.installLockedArchiveForStaticValidation(ctx, paths, kind, name, provider, entry, destDir, platform, sourcePath)
 	if cleanup != nil {
 		defer func() { cleanup() }()
 	}
@@ -4340,7 +4376,7 @@ func staticValidationNeedsSourceAuthSecrets(paths lifecyclePaths, cfg *config.Co
 		}
 	}
 	for _, collection := range hostProviderCollections(cfg) {
-		kind := providerManifestKind(collection.kind)
+		kind := collection.manifestKind()
 		lockEntries := lockEntriesForKind(lock, collection.kind)
 		for name, entry := range collection.entries {
 			needs, err := check(lockEntries, kind, name, entry, false)
@@ -4463,7 +4499,7 @@ func fallbackStaticValidationManifest(kind string, entry LockEntry) *providerman
 	return manifest
 }
 
-func (l *Lifecycle) installLockedArchiveForStaticValidation(ctx context.Context, paths lifecyclePaths, kind, name string, provider *config.ProviderEntry, entry LockEntry, destDir, platform string) (*preparedInstall, func(), error) {
+func (l *Lifecycle) installLockedArchiveForStaticValidation(ctx context.Context, paths lifecyclePaths, kind, name string, provider *config.ProviderEntry, entry LockEntry, destDir, platform string, sourcePath []string) (*preparedInstall, func(), error) {
 	archive, resolvedKey, ok := resolveArchiveForPlatform(entry, platform)
 	if !ok || archive.URL == "" {
 		return nil, nil, fmt.Errorf("no archive for platform %s for %s %q; run `%s --platform %s`", platform, kind, name, formatLockCommand(paths), platform)
@@ -4478,7 +4514,7 @@ func (l *Lifecycle) installLockedArchiveForStaticValidation(ctx context.Context,
 	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), sourceAuthToken(provider), archiveLocation)
 	if err != nil {
 		return nil, nil, staticArchiveUnavailableError{
-			err: fmt.Errorf("download locked source provider for %s %q: %w", kind, name, err),
+			err: fmt.Errorf("download locked source provider for %s %q: %w", kind, name, config.WrapDiagnosticError(sourcePath, "provider archive could not be downloaded", err)),
 		}
 	}
 	cleanup := download.Cleanup
@@ -4942,7 +4978,7 @@ func (l *Lifecycle) applyLocalUIProvider(paths lifecyclePaths, provider *config.
 	return bindPreparedUIInstall(provider, subject, destDir, configMap, install)
 }
 
-func (l *Lifecycle) applyConfiguredUIProvider(paths lifecyclePaths, lockEntry *LockEntry, provider *config.ProviderEntry, logicalName, subject, destDir string, mode artifactMode) (string, error) {
+func (l *Lifecycle) applyConfiguredUIProvider(paths lifecyclePaths, lockEntry *LockEntry, provider *config.ProviderEntry, logicalName, subject, destDir string, mode artifactMode, sourcePath []string) (string, error) {
 	if provider == nil {
 		return "", nil
 	}
@@ -5021,7 +5057,7 @@ func (l *Lifecycle) applyConfiguredUIProvider(paths lifecyclePaths, lockEntry *L
 					return "", err
 				}
 			} else {
-				if err := l.materializeLockedUIProvider(context.Background(), paths, provider, *lockEntry, destDir); err != nil {
+				if err := l.materializeLockedUIProvider(context.Background(), paths, provider, *lockEntry, destDir, sourcePath); err != nil {
 					return "", err
 				}
 			}
@@ -5036,7 +5072,7 @@ func (l *Lifecycle) applyConfiguredUIProvider(paths lifecyclePaths, lockEntry *L
 	}
 }
 
-func (l *Lifecycle) applyComponentProvider(paths lifecyclePaths, lockEntries map[string]LockEntry, kind, name string, provider *config.ProviderEntry, providerConfig yaml.Node, targetNode *yaml.Node, destDir string, mode artifactMode) error {
+func (l *Lifecycle) applyComponentProvider(paths lifecyclePaths, lockEntries map[string]LockEntry, kind, name string, provider *config.ProviderEntry, providerConfig yaml.Node, targetNode *yaml.Node, destDir string, mode artifactMode, sourcePath []string) error {
 	if provider == nil {
 		return nil
 	}
@@ -5059,7 +5095,7 @@ func (l *Lifecycle) applyComponentProvider(paths lifecyclePaths, lockEntries map
 		if !ok {
 			return lockMetadataStaleError(paths, "lock entry for %s %q is missing or stale", kind, name)
 		}
-		if err := l.applyLockedComponentEntry(paths, &lockEntry, kind, name, provider, configMap, destDir, mode); err != nil {
+		if err := l.applyLockedComponentEntry(paths, &lockEntry, kind, name, provider, configMap, destDir, mode, sourcePath); err != nil {
 			return err
 		}
 	default:
@@ -5153,7 +5189,7 @@ func (l *Lifecycle) applyLockedProviderEntry(paths lifecyclePaths, lock *Lockfil
 				return err
 			}
 		} else {
-			if err := l.materializeLockedProvider(context.Background(), paths, name, app, entry); err != nil {
+			if err := l.materializeLockedProvider(context.Background(), paths, name, app, entry, config.ProviderSourcePath("app", name)); err != nil {
 				return err
 			}
 		}
@@ -5165,7 +5201,7 @@ func (l *Lifecycle) applyLockedProviderEntry(paths lifecyclePaths, lock *Lockfil
 	return bindPreparedProviderInstall(paths, name, app, configMap, install)
 }
 
-func (l *Lifecycle) applyLockedComponentEntry(paths lifecyclePaths, entry *LockEntry, kind, name string, app *config.ProviderEntry, configMap map[string]any, destDir string, mode artifactMode) error {
+func (l *Lifecycle) applyLockedComponentEntry(paths lifecyclePaths, entry *LockEntry, kind, name string, app *config.ProviderEntry, configMap map[string]any, destDir string, mode artifactMode, sourcePath []string) error {
 	if app != nil && app.HasLocalSource() {
 		return l.applyLocalComponentEntry(paths, kind, name, app, configMap, destDir, mode)
 	}
@@ -5242,7 +5278,7 @@ func (l *Lifecycle) applyLockedComponentEntry(paths lifecyclePaths, entry *LockE
 				return err
 			}
 		} else {
-			if err := l.materializeLockedComponent(context.Background(), paths, kind, name, app, *entry, destDir); err != nil {
+			if err := l.materializeLockedComponent(context.Background(), paths, kind, name, app, *entry, destDir, sourcePath); err != nil {
 				return err
 			}
 		}
@@ -5320,7 +5356,7 @@ func bindPathBackedUIManifest(app *config.ProviderEntry, configMap map[string]an
 	return assetRoot, nil
 }
 
-func (l *Lifecycle) materializeLockedProvider(ctx context.Context, paths lifecyclePaths, name string, app *config.ProviderEntry, entry LockEntry) error {
+func (l *Lifecycle) materializeLockedProvider(ctx context.Context, paths lifecyclePaths, name string, app *config.ProviderEntry, entry LockEntry, sourcePath []string) error {
 	platform := providerpkg.CurrentPlatformString()
 	archive, resolvedKey, ok := resolveArchiveForPlatform(entry, platform)
 	if !ok || archive.URL == "" {
@@ -5335,7 +5371,7 @@ func (l *Lifecycle) materializeLockedProvider(ctx context.Context, paths lifecyc
 	}
 	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), sourceAuthToken(app), archiveLocation)
 	if err != nil {
-		return fmt.Errorf("download locked source provider for provider %q: %w", name, err)
+		return fmt.Errorf("download locked source provider for provider %q: %w", name, config.WrapDiagnosticError(sourcePath, "provider archive could not be downloaded", err))
 	}
 	defer download.Cleanup()
 	if archive.SHA256 != "" && download.SHA256Hex != archive.SHA256 {
@@ -5376,7 +5412,7 @@ func (l *Lifecycle) materializeLockedProvider(ctx context.Context, paths lifecyc
 	return nil
 }
 
-func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths lifecyclePaths, kind, name string, app *config.ProviderEntry, entry LockEntry, destDir string) error {
+func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths lifecyclePaths, kind, name string, app *config.ProviderEntry, entry LockEntry, destDir string, sourcePath []string) error {
 	platform := providerpkg.CurrentPlatformString()
 	archive, resolvedKey, ok := resolveArchiveForPlatform(entry, platform)
 	if !ok || archive.URL == "" {
@@ -5391,7 +5427,7 @@ func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths lifecy
 	}
 	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), sourceAuthToken(app), archiveLocation)
 	if err != nil {
-		return fmt.Errorf("download locked source provider for %s %q: %w", kind, name, err)
+		return fmt.Errorf("download locked source provider for %s %q: %w", kind, name, config.WrapDiagnosticError(sourcePath, "provider archive could not be downloaded", err))
 	}
 	defer download.Cleanup()
 	if archive.SHA256 != "" && download.SHA256Hex != archive.SHA256 {
@@ -5437,7 +5473,7 @@ func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths lifecy
 	return nil
 }
 
-func (l *Lifecycle) materializeLockedUIProvider(ctx context.Context, paths lifecyclePaths, app *config.ProviderEntry, entry LockEntry, destDir string) error {
+func (l *Lifecycle) materializeLockedUIProvider(ctx context.Context, paths lifecyclePaths, app *config.ProviderEntry, entry LockEntry, destDir string, sourcePath []string) error {
 	platform := providerpkg.CurrentPlatformString()
 	archive, resolvedKey, ok := resolveArchiveForPlatform(entry, platform)
 	if !ok || archive.URL == "" {
@@ -5452,7 +5488,7 @@ func (l *Lifecycle) materializeLockedUIProvider(ctx context.Context, paths lifec
 	}
 	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), sourceAuthToken(app), archiveLocation)
 	if err != nil {
-		return fmt.Errorf("download locked source for ui provider: %w", err)
+		return fmt.Errorf("download locked source for ui provider: %w", config.WrapDiagnosticError(sourcePath, "provider archive could not be downloaded", err))
 	}
 	defer download.Cleanup()
 	if archive.SHA256 != "" && download.SHA256Hex != archive.SHA256 {
@@ -5506,7 +5542,7 @@ func (l *Lifecycle) hashPlatformInEntries(ctx context.Context, lock *Lockfile, p
 		lockEntries := lockEntriesForProviderKind(lock, kind)
 		for name := range lockEntries {
 			entry := lockEntries[name]
-			if err := l.hashArchiveEntry(ctx, kind, name, &entry, paths, platformKey, tokenForSource); err != nil {
+			if err := l.hashArchiveEntry(ctx, kind, name, &entry, paths, platformKey, tokenForSource, providerLockSourcePath(kind, name)); err != nil {
 				return err
 			}
 			lockEntries[name] = entry
@@ -5515,7 +5551,7 @@ func (l *Lifecycle) hashPlatformInEntries(ctx context.Context, lock *Lockfile, p
 	return nil
 }
 
-func (l *Lifecycle) hashArchiveEntry(ctx context.Context, kind, name string, entry *LockEntry, paths lifecyclePaths, platformKey string, tokenForSource map[string]string) error {
+func (l *Lifecycle) hashArchiveEntry(ctx context.Context, kind, name string, entry *LockEntry, paths lifecyclePaths, platformKey string, tokenForSource map[string]string, sourcePath []string) error {
 	if entry.Archives == nil {
 		return nil
 	}
@@ -5545,7 +5581,7 @@ func (l *Lifecycle) hashArchiveEntry(ctx context.Context, kind, name string, ent
 	token := tokenForSource[entry.Source]
 	dl, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), token, archiveLocation)
 	if err != nil {
-		return fmt.Errorf("download archive for platform %s, source %s: %w", platformKey, entry.Source, err)
+		return fmt.Errorf("download archive for platform %s, source %s: %w", platformKey, entry.Source, config.WrapDiagnosticError(sourcePath, "provider archive could not be downloaded", err))
 	}
 	archive.SHA256 = dl.SHA256Hex
 	dl.Cleanup()

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -4183,6 +4183,279 @@ func TestSourceAppMetadataURLRejectsOversizedRemoteMetadata(t *testing.T) {
 	}
 }
 
+func writeSourceDiagnosticConfig(t *testing.T, dir, artifactsDir string, lines ...string) string {
+	t.Helper()
+	if artifactsDir == "" {
+		artifactsDir = filepath.Join(dir, "prepared-artifacts")
+	}
+	configPath := filepath.Join(dir, "gestalt.yaml")
+	configYAML := "apiVersion: " + config.ConfigAPIVersion + "\n" +
+		requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) +
+		strings.Join(lines, "\n") + "\n" +
+		strings.Join([]string{
+			"server:",
+			"  providers:",
+			"    indexeddb: sqlite",
+			"  artifactsDir: " + artifactsDir,
+			"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		}, "\n") + "\n"
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return configPath
+}
+
+func requireDiagnosticError(t *testing.T, op string, err error, wants ...string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("%s: expected error, got nil", op)
+	}
+	for _, want := range wants {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("%s error = %v, want substring %q", op, err, want)
+		}
+	}
+}
+
+func TestPrepareAtPathRendersProviderReleaseMetadataStatusSnippet(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	metadataPath := "/providers/alpha/provider-release.yaml"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != metadataPath {
+			http.NotFound(w, r)
+			return
+		}
+		http.Error(w, "metadata unavailable", http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	configPath := writeSourceDiagnosticConfig(t, dir, "",
+		"apps:",
+		"  alpha:",
+		"    source: "+srv.URL+metadataPath,
+	)
+
+	_, err := NewLifecycle().PrepareAtPath(configPath)
+	requireDiagnosticError(t, "PrepareAtPath", err,
+		"provider-release metadata is not accessible",
+		"status 403",
+		"apps.alpha.source",
+		configPath+":",
+		"> ",
+		"source: "+srv.URL+metadataPath,
+	)
+}
+
+func TestPrepareAtPathRendersPackageIndexSourceSnippet(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	indexPath := "/provider-index.yaml"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != indexPath {
+			http.NotFound(w, r)
+			return
+		}
+		http.Error(w, "index unavailable", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	configPath := writeSourceDiagnosticConfig(t, dir, "",
+		"providerRepositories:",
+		"  mirror:",
+		"    url: "+srv.URL+indexPath,
+		"apps:",
+		"  alpha:",
+		"    source:",
+		"      repo: mirror",
+		"      package: github.com/acme/providers/apps/alpha",
+		"      version: ^1.0.0",
+	)
+
+	_, err := NewLifecycle().PrepareAtPath(configPath)
+	requireDiagnosticError(t, "PrepareAtPath", err,
+		"provider package source could not be resolved",
+		"unexpected status 404 fetching provider repository index",
+		"apps.alpha.source",
+		configPath+":",
+		"> ",
+		"source:",
+		"package: github.com/acme/providers/apps/alpha",
+	)
+}
+
+func TestSyncAtPathRendersLockedArchiveDownloadSnippet(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	const (
+		packageSource = "github.com/acme/providers/alpha"
+		version       = "1.2.3"
+	)
+	archiveFile := buildV2Archive(t, dir, packageSource, version, "alpha-binary")
+	archiveData, err := os.ReadFile(archiveFile)
+	if err != nil {
+		t.Fatalf("read archive: %v", err)
+	}
+	archiveSHA := sha256.Sum256(archiveData)
+	archiveAvailable := atomic.Bool{}
+	archiveAvailable.Store(true)
+
+	metadataPath := "/providers/alpha/provider-release.yaml"
+	archivePath := "/providers/alpha/alpha.tar.gz"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case metadataPath:
+			metadata := providerReleaseMetadata{
+				Schema:        providerReleaseSchemaName,
+				SchemaVersion: providerReleaseSchemaVersion,
+				Package:       packageSource,
+				Kind:          providermanifestv1.KindApp,
+				Runtime:       providerReleaseRuntimeExecutable,
+				Version:       version,
+				Artifacts: map[string]providerReleaseArtifact{
+					providerpkg.CurrentPlatformString(): {
+						Path:   strings.TrimPrefix(archivePath, "/providers/alpha/"),
+						SHA256: hex.EncodeToString(archiveSHA[:]),
+					},
+				},
+			}
+			data, err := yaml.Marshal(metadata)
+			if err != nil {
+				t.Errorf("marshal metadata: %v", err)
+				http.Error(w, "marshal metadata", http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/yaml")
+			_, _ = w.Write(data)
+		case archivePath:
+			if !archiveAvailable.Load() {
+				http.Error(w, "archive unavailable", http.StatusServiceUnavailable)
+				return
+			}
+			w.Header().Set("Content-Type", "application/gzip")
+			_, _ = w.Write(archiveData)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	configPath := writeSourceDiagnosticConfig(t, dir, artifactsDir,
+		"apps:",
+		"  alpha:",
+		"    source: "+srv.URL+metadataPath,
+	)
+
+	lc := NewLifecycle()
+	if _, err := lc.LockAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
+		t.Fatalf("LockAtPathsWithStatePaths: %v", err)
+	}
+	if err := os.RemoveAll(filepath.Join(artifactsDir, ".gestaltd", "providers", "alpha")); err != nil {
+		t.Fatalf("remove prepared provider: %v", err)
+	}
+	archiveAvailable.Store(false)
+
+	err = lc.SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{})
+	requireDiagnosticError(t, "SyncAtPathsWithStatePaths", err,
+		"provider archive could not be downloaded",
+		"status 503",
+		"apps.alpha.source",
+		configPath+":",
+		"> ",
+		"source: "+srv.URL+metadataPath,
+	)
+}
+
+func TestPrepareAtPathRendersHostProviderReleaseMetadataSnippet(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	metadataPath := "/providers/remote/provider-release.yaml"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != metadataPath {
+			http.NotFound(w, r)
+			return
+		}
+		http.Error(w, "metadata unavailable", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	source := srv.URL + metadataPath
+	configKey := string(config.HostProviderKindExternalCredentials)
+	configPath := writeSourceDiagnosticConfig(t, dir, "",
+		"  "+configKey+":",
+		"    remote:",
+		"      source: "+source,
+	)
+
+	_, err := NewLifecycle().PrepareAtPath(configPath)
+	requireDiagnosticError(t, "PrepareAtPath", err,
+		"provider-release metadata was not found",
+		"providers."+configKey+".remote.source",
+		configPath+":",
+		"> ",
+		"source: "+source,
+	)
+}
+
+func TestPrepareAtPathRendersReleaseMetadataSourceSnippet(t *testing.T) {
+	t.Parallel()
+
+	const (
+		repo  = "valon-technologies/toolshed"
+		tag   = "apps/alpha/v1.2.3"
+		asset = "provider-release.yaml"
+	)
+	dir := t.TempDir()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		escapedPath := r.URL.EscapedPath()
+		if escapedPath != "/repos/valon-technologies/toolshed/releases/tags/"+url.PathEscape(tag) && r.URL.Path != "/repos/valon-technologies/toolshed/releases/tags/"+tag {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"assets":[]}`))
+	}))
+	defer srv.Close()
+	baseURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse server url: %v", err)
+	}
+	serverClient := srv.Client()
+	client := &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			clone := req.Clone(req.Context())
+			clone.URL.Scheme = baseURL.Scheme
+			clone.URL.Host = baseURL.Host
+			clone.Host = baseURL.Host
+			return serverClient.Transport.RoundTrip(clone)
+		}),
+	}
+
+	configPath := writeSourceDiagnosticConfig(t, dir, "",
+		"apps:",
+		"  alpha:",
+		"    source:",
+		"      githubRelease:",
+		"        repo: "+repo,
+		"        tag: "+tag,
+		"        asset: "+asset,
+	)
+
+	_, err = NewLifecycle().WithHTTPClient(client).PrepareAtPath(configPath)
+	requireDiagnosticError(t, "PrepareAtPath", err,
+		`release metadata source is missing configured asset "provider-release.yaml"`,
+		"apps.alpha.source",
+		configPath+":",
+		"> ",
+		"githubRelease:",
+	)
+}
+
 func TestSourceAppMetadataURLUnlockedLoadRefreshesMutableMetadata(t *testing.T) {
 	t.Parallel()
 
@@ -4414,7 +4687,7 @@ func TestMaterializeLockedComponent_AllowsGenericDeclarativeTelemetryAndAuditPac
 				Source: config.NewMetadataSource("https://example.invalid/github-com-acme-providers-declarative/v1.0.0/provider-release.yaml"),
 			}
 			destDir := filepath.Join(dir, kind)
-			if err := lc.materializeLockedComponent(context.Background(), lifecyclePaths{}, kind, "default", providerEntry, entry, destDir); err != nil {
+			if err := lc.materializeLockedComponent(context.Background(), lifecyclePaths{}, kind, "default", providerEntry, entry, destDir, providerLockSourcePath(kind, "default")); err != nil {
 				t.Fatalf("materializeLockedComponent: %v", err)
 			}
 			install, err := inspectPreparedInstall(destDir)

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -4028,7 +4028,7 @@ func TestHashArchiveEntry_HashesFallbackArchive(t *testing.T) {
 		},
 	}
 
-	if err := NewLifecycle().hashArchiveEntry(context.Background(), providermanifestv1.KindUI, "roadmap", &entry, lifecyclePaths{}, "linux/amd64", nil); err != nil {
+	if err := NewLifecycle().hashArchiveEntry(context.Background(), providermanifestv1.KindUI, "roadmap", &entry, lifecyclePaths{}, "linux/amd64", nil, config.ProviderSourcePath("ui", "roadmap")); err != nil {
 		t.Fatalf("hashArchiveEntry: %v", err)
 	}
 

--- a/gestaltd/internal/operator/release_metadata.go
+++ b/gestaltd/internal/operator/release_metadata.go
@@ -181,7 +181,7 @@ func fetchProviderReleaseMetadata(ctx context.Context, client *http.Client, meta
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
-		return nil, "", nil, fmt.Errorf("unexpected status %d fetching provider release metadata from %s", resp.StatusCode, resolvedMetadataLocation)
+		return nil, "", nil, providerReleaseMetadataStatusError(metadataLocation, resp.StatusCode)
 	}
 	data, err := io.ReadAll(io.LimitReader(resp.Body, providerReleaseMetadataMaxBytes+1))
 	if err != nil {
@@ -275,7 +275,7 @@ func resolveProviderReleaseMetadataLocation(ctx context.Context, client *http.Cl
 func parseGitHubReleaseLocation(location string) (gitHubReleaseLocation, bool, error) {
 	parsed, err := url.Parse(strings.TrimSpace(location))
 	if err != nil {
-		return gitHubReleaseLocation{}, false, err
+		return gitHubReleaseLocation{}, false, fmt.Errorf("source.githubRelease is invalid: %w", err)
 	}
 	if parsed.Scheme != "github-release" {
 		return gitHubReleaseLocation{}, false, nil
@@ -286,12 +286,12 @@ func parseGitHubReleaseLocation(location string) (gitHubReleaseLocation, bool, e
 	}
 	repo, err = url.PathUnescape(repo)
 	if err != nil {
-		return gitHubReleaseLocation{}, false, fmt.Errorf("decode github release repo: %w", err)
+		return gitHubReleaseLocation{}, false, fmt.Errorf("source.githubRelease is invalid: %w", err)
 	}
 	tag := strings.TrimSpace(parsed.Query().Get("tag"))
 	asset := strings.TrimSpace(parsed.Query().Get("asset"))
 	if repo == "" || tag == "" || asset == "" {
-		return gitHubReleaseLocation{}, false, fmt.Errorf("github release source must include repo, tag, and asset")
+		return gitHubReleaseLocation{}, false, fmt.Errorf("source.githubRelease is invalid: repo, tag, and asset are required")
 	}
 	return gitHubReleaseLocation{
 		Repo:  repo,
@@ -318,15 +318,15 @@ func resolveGitHubReleaseAssetURL(ctx context.Context, client *http.Client, ref 
 		return req, nil
 	})
 	if err != nil {
-		return "", nil, fmt.Errorf("resolve github release %s@%s: %w", ref.Repo, ref.Tag, err)
+		return "", nil, fmt.Errorf("resolve release metadata source: source %s: %w", ref.location(), err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
-		return "", nil, fmt.Errorf("unexpected status %d resolving github release %s@%s", resp.StatusCode, ref.Repo, ref.Tag)
+		return "", nil, releaseMetadataSourceStatusError(ref.location(), resp.StatusCode)
 	}
 	var release gitHubReleaseByTagResponse
 	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
-		return "", nil, fmt.Errorf("decode github release %s@%s: %w", ref.Repo, ref.Tag, err)
+		return "", nil, fmt.Errorf("release metadata source response could not be decoded: source %s: %w", ref.location(), err)
 	}
 	assetURLs := make(map[string]string, len(release.Assets))
 	metadataAssetURL := ""
@@ -342,9 +342,41 @@ func resolveGitHubReleaseAssetURL(ctx context.Context, client *http.Client, ref 
 		}
 	}
 	if metadataAssetURL == "" {
-		return "", nil, fmt.Errorf("github release %s@%s does not contain asset %q", ref.Repo, ref.Tag, ref.Asset)
+		return "", nil, fmt.Errorf("release metadata source is missing configured asset %q: source %s; ensure the asset exists in the release", ref.Asset, ref.location())
 	}
 	return metadataAssetURL, assetURLs, nil
+}
+
+func (r gitHubReleaseLocation) location() string {
+	return (&url.URL{
+		Scheme: "github-release",
+		Host:   "github.com",
+		Path:   "/" + strings.TrimSpace(r.Repo),
+		RawQuery: url.Values{
+			"asset": []string{strings.TrimSpace(r.Asset)},
+			"tag":   []string{strings.TrimSpace(r.Tag)},
+		}.Encode(),
+	}).String()
+}
+
+func releaseMetadataSourceStatusError(source string, status int) error {
+	return metadataSourceStatusError("release metadata source", "lookup", source, status)
+}
+
+func providerReleaseMetadataStatusError(source string, status int) error {
+	return metadataSourceStatusError("provider-release metadata", "fetch", source, status)
+}
+
+func metadataSourceStatusError(subject, action, source string, status int) error {
+	source = strings.TrimSpace(source)
+	switch status {
+	case http.StatusNotFound:
+		return fmt.Errorf("%s was not found: source %s, status %d; ensure the configured source exists and is accessible", subject, source, status)
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return fmt.Errorf("%s is not accessible: source %s, status %d; ensure source.auth.token has access or use an accessible source", subject, source, status)
+	default:
+		return fmt.Errorf("%s %s failed: source %s, status %d", subject, action, source, status)
+	}
 }
 
 func providerReleaseArchives(metadataURL string, metadata *providerReleaseMetadata, gitHubReleaseAssets map[string]string) (map[string]LockArchive, error) {


### PR DESCRIPTION
## Summary

Adds path-aware config diagnostics for provider source failures so config and lifecycle entry points include the logical source path, original config file location, and caret-marked YAML snippet.

The renderer resolves diagnostics against config overlays by choosing the deepest matching path and falling back to the nearest parent key when a leaf is missing. It shows the original YAML text without redaction and preserves the underlying error chain for programmatic callers.

Provider-source failures use generic provider-release metadata and release metadata wording where the error is not inherently tied to a provider. GitHub-specific language remains limited to `source.githubRelease` schema validation and release lookup internals.

## Interfaces

```go
func RenderDiagnosticError(paths []string, err error) error
func WrapDiagnosticError(path []string, message string, cause error) error
func ProviderSourcePath(kind, name string) []string
func ProviderSourceFieldPath(kind, name string, fields ...string) []string
```

```text
config validation: apps.alpha.source.auth.token: source.auth.token is empty; source.auth is configured for provider source access, so token must resolve to a non-empty value or source.auth must be removed when the source does not require authentication

/path/to/gestalt.yaml:8:16
  6 |       url: https://example.com/providers/alpha/provider-release.yaml
  7 |       auth:
> 8 |         token: ${GESTALT_EMPTY_SOURCE_AUTH_TOKEN:-}
    |                ^
```

## Runtime

Config loaders render diagnostics for validation, source-auth, partial-load, and app-scope failures. `TransformSourceAuthTokens` attaches source-auth token paths when secret resolution fails.

Lifecycle prepare, lock, sync, execution load, validation load, and static validation load render path-aware diagnostics for source failures. Metadata, package, git snapshot, and archive paths carry the configured source path for app providers, host providers, runtime providers, and UI providers.

Release metadata fetches report status-specific generic messages for missing, inaccessible, and other failing metadata sources. `source.githubRelease` asset lookup reports release-source failures and missing configured assets without prescribing a credential command.