### PR TITLE
Use workflow owner identities

### DIFF
--- a/gestaltd/core/subjects.go
+++ b/gestaltd/core/subjects.go
@@ -1,6 +1,11 @@
 package core
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
+
+const SubjectKindServiceAccount = "service_account"
 
 // Actor identifies who performed an action without credential-scoping fields.
 type Actor struct {
@@ -48,6 +53,32 @@ func NormalizeRunAsSubject(subject *RunAsSubject) *RunAsSubject {
 		out.CredentialSubjectID = out.SubjectID
 	}
 	return out
+}
+
+func NormalizeServiceAccountSubject(subject *RunAsSubject, path string) (*RunAsSubject, error) {
+	out := NormalizeRunAsSubject(subject)
+	if out == nil {
+		return nil, fmt.Errorf("%s is required", path)
+	}
+	if out.AuthSource == "" {
+		out.AuthSource = "config"
+	}
+	if out.SubjectID == "" {
+		return nil, fmt.Errorf("%s.id is required", path)
+	}
+	kind, _, ok := ParseSubjectID(out.SubjectID)
+	if !ok {
+		return nil, fmt.Errorf("%s.id %q must be a fully-qualified service_account subject", path, out.SubjectID)
+	}
+	if kind != SubjectKindServiceAccount {
+		return nil, fmt.Errorf("%s.id %q must identify a service_account subject", path, out.SubjectID)
+	}
+	if out.SubjectKind == "" {
+		out.SubjectKind = kind
+	} else if out.SubjectKind != kind {
+		return nil, fmt.Errorf("%s.kind %q must match subject.id kind %q", path, out.SubjectKind, kind)
+	}
+	return out, nil
 }
 
 func RunAsSubjectsEqual(left, right *RunAsSubject) bool {

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -5087,7 +5087,7 @@ func TestBootstrapAllowsConfiguredWorkflowScheduleCredentialModeNoneForUserCrede
 	}
 }
 
-func TestBootstrapConfiguredWorkflowScheduleRunAsAllowsUserCredentialedTarget(t *testing.T) {
+func TestBootstrapConfiguredWorkflowScheduleOwnerAllowsUserCredentialedTarget(t *testing.T) {
 	t.Parallel()
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
@@ -5103,8 +5103,8 @@ func TestBootstrapConfiguredWorkflowScheduleRunAsAllowsUserCredentialedTarget(t 
 		},
 	})
 	nightly := cfg.Workflows.Schedules["nightly_sync"]
-	nightly.RunAs = &config.WorkflowRunAsConfig{
-		Subject: &config.WorkflowRunAsSubjectConfig{
+	nightly.Owner = &config.WorkflowOwnerConfig{
+		Subject: &config.WorkflowOwnerSubjectConfig{
 			ID:          " service_account:roadmap-sync ",
 			DisplayName: " Roadmap sync ",
 		},
@@ -5132,12 +5132,12 @@ func TestBootstrapConfiguredWorkflowScheduleRunAsAllowsUserCredentialedTarget(t 
 	}
 	got := recorder.upsertedSchedules[0]
 	requestedBy := workflowwire.ActorFromProto(got.GetRequestedBy())
-	if requestedBy.SubjectID != "system:config" || requestedBy.SubjectKind != "system" || requestedBy.AuthSource != "config" {
+	if requestedBy.SubjectID != "service_account:roadmap-sync" || requestedBy.SubjectKind != "service_account" || requestedBy.DisplayName != "Roadmap sync" || requestedBy.AuthSource != "config" {
 		t.Fatalf("requestedBy = %#v", requestedBy)
 	}
 }
 
-func TestBootstrapRejectsConfiguredWorkflowScheduleRunAsUserSubject(t *testing.T) {
+func TestBootstrapConfiguredWorkflowScheduleOwnerChangeUpdatesManagedSchedule(t *testing.T) {
 	t.Parallel()
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
@@ -5152,8 +5152,62 @@ func TestBootstrapRejectsConfiguredWorkflowScheduleRunAsUserSubject(t *testing.T
 		},
 	})
 	nightly := cfg.Workflows.Schedules["nightly_sync"]
-	nightly.RunAs = &config.WorkflowRunAsConfig{
-		Subject: &config.WorkflowRunAsSubjectConfig{ID: "user:ada"},
+	nightly.Owner = &config.WorkflowOwnerConfig{
+		Subject: &config.WorkflowOwnerSubjectConfig{ID: "service_account:roadmap-new"},
+	}
+	cfg.Workflows.Schedules["nightly_sync"] = nightly
+
+	recorder := &recordingWorkflowProvider{
+		getSchedule: &coreworkflow.Schedule{
+			ID:       workflowConfigScheduleID("nightly_sync"),
+			Cron:     "0 2 * * *",
+			Timezone: "UTC",
+			Target:   coreWorkflowAppStepTarget("roadmap", "sync"),
+			CreatedBy: coreworkflow.Actor{
+				SubjectID:   "service_account:roadmap-old",
+				SubjectKind: core.SubjectKindServiceAccount,
+				AuthSource:  "config",
+			},
+		},
+	}
+	factories := validFactories()
+	factories.Workflow = func(_ context.Context, _ string, _ yaml.Node, _ []runtimehost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		return recorder, nil
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	if len(recorder.upsertedSchedules) != 1 {
+		t.Fatalf("upserted schedules = %d, want 1", len(recorder.upsertedSchedules))
+	}
+	requestedBy := workflowwire.ActorFromProto(recorder.upsertedSchedules[0].GetRequestedBy())
+	if requestedBy.SubjectID != "service_account:roadmap-new" || requestedBy.SubjectKind != core.SubjectKindServiceAccount || requestedBy.AuthSource != "config" {
+		t.Fatalf("requestedBy = %#v", requestedBy)
+	}
+}
+
+func TestBootstrapRejectsConfiguredWorkflowScheduleOwnerUserSubject(t *testing.T) {
+	t.Parallel()
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
+		Provider: "temporal",
+		Schedules: map[string]workflowFixtureSchedule{
+			"nightly_sync": {
+				Cron:      "0 2 * * *",
+				Timezone:  "UTC",
+				Operation: "sync",
+			},
+		},
+	})
+	nightly := cfg.Workflows.Schedules["nightly_sync"]
+	nightly.Owner = &config.WorkflowOwnerConfig{
+		Subject: &config.WorkflowOwnerSubjectConfig{ID: "user:ada"},
 	}
 	cfg.Workflows.Schedules["nightly_sync"] = nightly
 
@@ -5164,14 +5218,14 @@ func TestBootstrapRejectsConfiguredWorkflowScheduleRunAsUserSubject(t *testing.T
 
 	_, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
 	if err == nil {
-		t.Fatal("expected Bootstrap to reject user runAs subject")
+		t.Fatal("expected Bootstrap to reject user owner subject")
 	}
-	if !strings.Contains(err.Error(), `workflows.schedules.nightly_sync.runAs.subject.id "user:ada" must identify a service_account subject`) {
+	if !strings.Contains(err.Error(), `workflows.schedules.nightly_sync.owner.subject.id "user:ada" must identify a service_account subject`) {
 		t.Fatalf("Bootstrap error = %v", err)
 	}
 }
 
-func TestBootstrapAppliesConfiguredWorkflowSchedulesForRunAsConnectionOnUserDefaultApp(t *testing.T) {
+func TestBootstrapAppliesConfiguredWorkflowSchedulesForOwnerConnectionOnUserDefaultApp(t *testing.T) {
 	t.Parallel()
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
@@ -5193,8 +5247,8 @@ func TestBootstrapAppliesConfiguredWorkflowSchedulesForRunAsConnectionOnUserDefa
 	})
 	nightly := cfg.Workflows.Schedules["nightly_sync"]
 	nightly.Target.Steps[0].App.Connection = "bot"
-	nightly.RunAs = &config.WorkflowRunAsConfig{
-		Subject: &config.WorkflowRunAsSubjectConfig{ID: "service_account:roadmap-sync"},
+	nightly.Owner = &config.WorkflowOwnerConfig{
+		Subject: &config.WorkflowOwnerSubjectConfig{ID: "service_account:roadmap-sync"},
 	}
 	cfg.Workflows.Schedules["nightly_sync"] = nightly
 
@@ -5896,7 +5950,7 @@ func TestBootstrapAppliesConfiguredWorkflowEventTriggers(t *testing.T) {
 	assertWorkflowConfigTokenAllowsAppInvoke(t, workflowEncryptionKey, recorder.upsertedEventTriggerTokens[0], "slack", "conversations.history")
 }
 
-func TestBootstrapConfiguredWorkflowEventTriggerRunAsAllowsUserCredentialedTarget(t *testing.T) {
+func TestBootstrapConfiguredWorkflowEventTriggerOwnerAllowsUserCredentialedTarget(t *testing.T) {
 	t.Parallel()
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
@@ -5914,8 +5968,8 @@ func TestBootstrapConfiguredWorkflowEventTriggerRunAsAllowsUserCredentialedTarge
 		},
 	})
 	trigger := cfg.Workflows.EventTriggers["task_updated"]
-	trigger.RunAs = &config.WorkflowRunAsConfig{
-		Subject: &config.WorkflowRunAsSubjectConfig{
+	trigger.Owner = &config.WorkflowOwnerConfig{
+		Subject: &config.WorkflowOwnerSubjectConfig{
 			ID:   "service_account:roadmap-events",
 			Kind: "service_account",
 		},
@@ -5945,7 +5999,7 @@ func TestBootstrapConfiguredWorkflowEventTriggerRunAsAllowsUserCredentialedTarge
 	}
 	got := recorder.upsertedEventTriggers[0]
 	requestedBy := workflowwire.ActorFromProto(got.GetRequestedBy())
-	if requestedBy.SubjectID != "system:config" || requestedBy.SubjectKind != "system" || requestedBy.AuthSource != "config" {
+	if requestedBy.SubjectID != "service_account:roadmap-events" || requestedBy.SubjectKind != "service_account" || requestedBy.AuthSource != "config" {
 		t.Fatalf("requestedBy = %#v", requestedBy)
 	}
 	if len(recorder.upsertedEventTriggerTokens) != 1 {
@@ -5954,6 +6008,64 @@ func TestBootstrapConfiguredWorkflowEventTriggerRunAsAllowsUserCredentialedTarge
 	tokenPrincipal := requireWorkflowConfigTokenContext(t, workflowEncryptionKey, recorder.upsertedEventTriggerTokens[0]).Principal()
 	if tokenPrincipal == nil || tokenPrincipal.SubjectID != "service_account:roadmap-events" || tokenPrincipal.Kind != "service_account" || tokenPrincipal.CredentialSubjectID != "service_account:roadmap-events" || tokenPrincipal.AuthSource() != "config" {
 		t.Fatalf("token principal = %#v", tokenPrincipal)
+	}
+}
+
+func TestBootstrapConfiguredWorkflowEventTriggerOwnerChangeUpdatesManagedTrigger(t *testing.T) {
+	t.Parallel()
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
+		Provider: "temporal",
+		EventTriggers: map[string]workflowFixtureEventTrigger{
+			"task_updated": {
+				Match: workflowFixtureEventMatch{
+					Type:   "task.updated",
+					Source: "roadmap",
+				},
+				Operation: "sync",
+			},
+		},
+	})
+	trigger := cfg.Workflows.EventTriggers["task_updated"]
+	trigger.Owner = &config.WorkflowOwnerConfig{
+		Subject: &config.WorkflowOwnerSubjectConfig{ID: "service_account:roadmap-events-new"},
+	}
+	cfg.Workflows.EventTriggers["task_updated"] = trigger
+
+	recorder := &recordingWorkflowProvider{
+		getEventTrigger: &coreworkflow.EventTrigger{
+			ID: workflowConfigEventTriggerID("task_updated"),
+			Match: coreworkflow.EventMatch{
+				Type:   "task.updated",
+				Source: "roadmap",
+			},
+			Target: coreWorkflowAppStepTarget("roadmap", "sync"),
+			CreatedBy: coreworkflow.Actor{
+				SubjectID:   "service_account:roadmap-events-old",
+				SubjectKind: core.SubjectKindServiceAccount,
+				AuthSource:  "config",
+			},
+		},
+	}
+	factories := validFactories()
+	factories.Workflow = func(_ context.Context, _ string, _ yaml.Node, _ []runtimehost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		return recorder, nil
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	if len(recorder.upsertedEventTriggers) != 1 {
+		t.Fatalf("upserted event triggers = %d, want 1", len(recorder.upsertedEventTriggers))
+	}
+	requestedBy := workflowwire.ActorFromProto(recorder.upsertedEventTriggers[0].GetRequestedBy())
+	if requestedBy.SubjectID != "service_account:roadmap-events-new" || requestedBy.SubjectKind != core.SubjectKindServiceAccount || requestedBy.AuthSource != "config" {
+		t.Fatalf("requestedBy = %#v", requestedBy)
 	}
 }
 

--- a/gestaltd/internal/bootstrap/workflow_config_event_triggers.go
+++ b/gestaltd/internal/bootstrap/workflow_config_event_triggers.go
@@ -41,6 +41,10 @@ func reconcileWorkflowConfigEventTriggers(ctx context.Context, cfg *config.Confi
 		trigger := desiredEntry.trigger
 		target := workflowConfigTarget(trigger.Target)
 		appName := workflowConfigTargetLabel(target)
+		owner, err := workflowConfigOwnerSubject("workflows.eventTriggers."+desiredEntry.TriggerKey+".owner", trigger.Owner)
+		if err != nil {
+			return fmt.Errorf("bootstrap: workflow event trigger %q for app %q: %w", desiredEntry.TriggerKey, appName, err)
+		}
 		_, provider, err := runtime.ResolveProvider(ctx, trigger.Provider)
 		if err != nil {
 			return fmt.Errorf("bootstrap: workflow event trigger %q for app %q: %w", desiredEntry.TriggerKey, appName, err)
@@ -60,19 +64,15 @@ func reconcileWorkflowConfigEventTriggers(ctx context.Context, cfg *config.Confi
 		default:
 			return fmt.Errorf("bootstrap: get workflow event trigger %q for app %q: %w", desiredEntry.TriggerID, appName, err)
 		}
-		runAs, err := workflowConfigRunAsSubject("workflows.eventTriggers."+desiredEntry.TriggerKey+".runAs", trigger.RunAs)
-		if err != nil {
-			return fmt.Errorf("bootstrap: workflow event trigger %q for app %q: %w", desiredEntry.TriggerKey, appName, err)
-		}
 		permissions, err := workflowConfigExecutionPermissions(cfg, "workflows.eventTriggers."+desiredEntry.TriggerKey, trigger.Invokes)
 		if err != nil {
 			return fmt.Errorf("bootstrap: workflow event trigger %q for app %q: %w", desiredEntry.TriggerKey, appName, err)
 		}
-		if err := workflowConfigValidateExecutionTarget(cfg, target, runAs, permissions); err != nil {
+		if err := workflowConfigValidateExecutionTarget(cfg, target, owner, permissions); err != nil {
 			return fmt.Errorf("bootstrap: workflow event trigger %q for app %q: %w", desiredEntry.TriggerKey, appName, err)
 		}
 		executionPermissions := workflowConfigExecutionPermissionsForTarget(target, permissions)
-		providerCtx, err = workflowConfigInvocationContext(providerCtx, tokens, runAs, executionPermissions)
+		providerCtx, err = workflowConfigInvocationContext(providerCtx, tokens, owner, executionPermissions)
 		if err != nil {
 			return fmt.Errorf("bootstrap: workflow event trigger %q for app %q: %w", desiredEntry.TriggerKey, appName, err)
 		}
@@ -85,7 +85,7 @@ func reconcileWorkflowConfigEventTriggers(ctx context.Context, cfg *config.Confi
 			Match:       workflowwire.EventMatchToProto(workflowConfigEventTriggerMatch(trigger)),
 			Target:      targetProto,
 			Paused:      trigger.Paused,
-			RequestedBy: workflowwire.ActorToProto(workflowConfigActor()),
+			RequestedBy: workflowwire.ActorToProto(workflowConfigOwnerActor(owner)),
 		}); err != nil {
 			return fmt.Errorf("bootstrap: workflow event trigger %q for app %q: %w", desiredEntry.TriggerKey, appName, err)
 		}
@@ -146,7 +146,7 @@ func cleanupRemovedWorkflowConfigEventTriggers(ctx context.Context, runtime *wor
 			if err != nil {
 				return fmt.Errorf("bootstrap: decode workflow event trigger from provider %q: %w", providerName, err)
 			}
-			if trigger == nil || !isWorkflowConfigOwnedEventTrigger(trigger, workflowConfigTargetLabel(trigger.Target), trigger.ID) {
+			if trigger == nil || !isWorkflowConfigManagedEventTrigger(trigger, workflowConfigTargetLabel(trigger.Target)) {
 				continue
 			}
 			if _, ok := desiredByProviderTrigger[workflowConfigProviderObjectKey(providerName, trigger.ID)]; ok {
@@ -166,12 +166,18 @@ func isWorkflowConfigOwnedEventTrigger(existing *coreworkflow.EventTrigger, appN
 	if existing == nil {
 		return false
 	}
-	actor := workflowConfigActor()
 	return existing.ID == triggerID &&
 		workflowConfigTargetLabel(existing.Target) == appName &&
-		existing.CreatedBy.SubjectID == actor.SubjectID &&
-		existing.CreatedBy.SubjectKind == actor.SubjectKind &&
-		existing.CreatedBy.AuthSource == actor.AuthSource
+		isWorkflowConfigManagedActor(existing.CreatedBy)
+}
+
+func isWorkflowConfigManagedEventTrigger(existing *coreworkflow.EventTrigger, appName string) bool {
+	if existing == nil {
+		return false
+	}
+	return strings.HasPrefix(strings.TrimSpace(existing.ID), coreworkflow.ConfigManagedSchedulePrefix) &&
+		workflowConfigTargetLabel(existing.Target) == appName &&
+		isWorkflowConfigManagedActor(existing.CreatedBy)
 }
 
 func workflowConfigEventTriggerMatch(trigger config.WorkflowEventTriggerConfig) coreworkflow.EventMatch {

--- a/gestaltd/internal/bootstrap/workflow_config_schedules.go
+++ b/gestaltd/internal/bootstrap/workflow_config_schedules.go
@@ -50,6 +50,10 @@ func reconcileWorkflowConfigSchedules(ctx context.Context, cfg *config.Config, r
 		schedule := desiredEntry.schedule
 		target := workflowConfigTarget(schedule.Target)
 		appName := workflowConfigTargetLabel(target)
+		owner, err := workflowConfigOwnerSubject("workflows.schedules."+desiredEntry.ScheduleKey+".owner", schedule.Owner)
+		if err != nil {
+			return fmt.Errorf("bootstrap: workflow schedule %q for app %q: %w", desiredEntry.ScheduleKey, appName, err)
+		}
 		_, provider, err := runtime.ResolveProvider(ctx, schedule.Provider)
 		if err != nil {
 			return fmt.Errorf("bootstrap: workflow schedule %q for app %q: %w", desiredEntry.ScheduleKey, appName, err)
@@ -69,19 +73,15 @@ func reconcileWorkflowConfigSchedules(ctx context.Context, cfg *config.Config, r
 		default:
 			return fmt.Errorf("bootstrap: get workflow schedule %q for app %q: %w", desiredEntry.ScheduleID, appName, err)
 		}
-		runAs, err := workflowConfigRunAsSubject("workflows.schedules."+desiredEntry.ScheduleKey+".runAs", schedule.RunAs)
-		if err != nil {
-			return fmt.Errorf("bootstrap: workflow schedule %q for app %q: %w", desiredEntry.ScheduleKey, appName, err)
-		}
 		permissions, err := workflowConfigExecutionPermissions(cfg, "workflows.schedules."+desiredEntry.ScheduleKey, schedule.Invokes)
 		if err != nil {
 			return fmt.Errorf("bootstrap: workflow schedule %q for app %q: %w", desiredEntry.ScheduleKey, appName, err)
 		}
-		if err := workflowConfigValidateExecutionTarget(cfg, target, runAs, permissions); err != nil {
+		if err := workflowConfigValidateExecutionTarget(cfg, target, owner, permissions); err != nil {
 			return fmt.Errorf("bootstrap: workflow schedule %q for app %q: %w", desiredEntry.ScheduleKey, appName, err)
 		}
 		executionPermissions := workflowConfigExecutionPermissionsForTarget(target, permissions)
-		providerCtx, err = workflowConfigInvocationContext(providerCtx, tokens, runAs, executionPermissions)
+		providerCtx, err = workflowConfigInvocationContext(providerCtx, tokens, owner, executionPermissions)
 		if err != nil {
 			return fmt.Errorf("bootstrap: workflow schedule %q for app %q: %w", desiredEntry.ScheduleKey, appName, err)
 		}
@@ -95,7 +95,7 @@ func reconcileWorkflowConfigSchedules(ctx context.Context, cfg *config.Config, r
 			Timezone:    schedule.Timezone,
 			Target:      targetProto,
 			Paused:      schedule.Paused,
-			RequestedBy: workflowwire.ActorToProto(workflowConfigActor()),
+			RequestedBy: workflowwire.ActorToProto(workflowConfigOwnerActor(owner)),
 		}); err != nil {
 			return fmt.Errorf("bootstrap: workflow schedule %q for app %q: %w", desiredEntry.ScheduleKey, appName, err)
 		}
@@ -167,7 +167,7 @@ func cleanupRemovedWorkflowConfigSchedules(ctx context.Context, runtime *workflo
 			if err != nil {
 				return fmt.Errorf("bootstrap: decode workflow schedule from provider %q: %w", providerName, err)
 			}
-			if schedule == nil || !isWorkflowConfigOwnedSchedule(schedule, workflowConfigTargetLabel(schedule.Target), schedule.ID) {
+			if schedule == nil || !isWorkflowConfigManagedSchedule(schedule, workflowConfigTargetLabel(schedule.Target)) {
 				continue
 			}
 			if _, ok := desiredByProviderSchedule[workflowConfigProviderObjectKey(providerName, schedule.ID)]; ok {
@@ -199,12 +199,18 @@ func isWorkflowConfigOwnedSchedule(existing *coreworkflow.Schedule, appName, sch
 	if existing == nil {
 		return false
 	}
-	actor := workflowConfigActor()
 	return existing.ID == scheduleID &&
 		workflowConfigTargetLabel(existing.Target) == appName &&
-		existing.CreatedBy.SubjectID == actor.SubjectID &&
-		existing.CreatedBy.SubjectKind == actor.SubjectKind &&
-		existing.CreatedBy.AuthSource == actor.AuthSource
+		isWorkflowConfigManagedActor(existing.CreatedBy)
+}
+
+func isWorkflowConfigManagedSchedule(existing *coreworkflow.Schedule, appName string) bool {
+	if existing == nil {
+		return false
+	}
+	return strings.HasPrefix(strings.TrimSpace(existing.ID), coreworkflow.ConfigManagedSchedulePrefix) &&
+		workflowConfigTargetLabel(existing.Target) == appName &&
+		isWorkflowConfigManagedActor(existing.CreatedBy)
 }
 
 func workflowConfigTargetLabel(target coreworkflow.Target) string {
@@ -228,26 +234,13 @@ func workflowConfigTarget(target *config.WorkflowTargetConfig) coreworkflow.Targ
 	return config.WorkflowTargetToCore(target)
 }
 
-func workflowConfigRunAsSubject(path string, runAs *config.WorkflowRunAsConfig) (*core.RunAsSubject, error) {
-	if runAs == nil {
+func workflowConfigOwnerSubject(path string, owner *config.WorkflowOwnerConfig) (*core.RunAsSubject, error) {
+	if owner == nil {
 		return nil, nil
 	}
-	subject := runAs.SubjectRef()
-	if subject == nil {
-		return nil, fmt.Errorf("config validation: %s.subject is required", path)
-	}
-	kind, _, ok := core.ParseSubjectID(subject.SubjectID)
-	if !ok {
-		return nil, fmt.Errorf("config validation: %s.subject.id %q must be a fully-qualified service_account subject", path, subject.SubjectID)
-	}
-	if kind != "service_account" {
-		return nil, fmt.Errorf("config validation: %s.subject.id %q must identify a service_account subject", path, subject.SubjectID)
-	}
-	if subject.SubjectKind != kind {
-		return nil, fmt.Errorf("config validation: %s.subject.kind %q must match subject.id kind %q", path, subject.SubjectKind, kind)
-	}
-	if subject.AuthSource == "" {
-		subject.AuthSource = "config"
+	subject, err := core.NormalizeServiceAccountSubject(owner.SubjectRef(), path+".subject")
+	if err != nil {
+		return nil, fmt.Errorf("config validation: %w", err)
 	}
 	return subject, nil
 }
@@ -370,11 +363,11 @@ func workflowMergeExecutionPermissions(groups ...[]core.AccessPermission) []core
 	return out
 }
 
-func workflowConfigInvocationContext(ctx context.Context, tokens *appaccessservice.InvocationTokenManager, runAs *core.RunAsSubject, permissions []core.AccessPermission) (context.Context, error) {
+func workflowConfigInvocationContext(ctx context.Context, tokens *appaccessservice.InvocationTokenManager, owner *core.RunAsSubject, permissions []core.AccessPermission) (context.Context, error) {
 	if tokens == nil {
 		return ctx, nil
 	}
-	tokenCtx := principal.WithPrincipal(ctx, workflowConfigPrincipal(runAs, permissions))
+	tokenCtx := principal.WithPrincipal(ctx, workflowConfigPrincipal(owner, permissions))
 	token, err := tokens.MintRootToken(tokenCtx, workflowConfigOwnerSubjectID(), workflowConfigInvocationGrants(permissions))
 	if err != nil {
 		return nil, fmt.Errorf("workflow config invocation token: %w", err)
@@ -382,19 +375,19 @@ func workflowConfigInvocationContext(ctx context.Context, tokens *appaccessservi
 	return appaccessservice.WithInvocationToken(ctx, token), nil
 }
 
-func workflowConfigPrincipal(runAs *core.RunAsSubject, permissions []core.AccessPermission) *principal.Principal {
+func workflowConfigPrincipal(owner *core.RunAsSubject, permissions []core.AccessPermission) *principal.Principal {
 	actor := workflowConfigActor()
 	subjectID := strings.TrimSpace(actor.SubjectID)
 	subjectKind := strings.TrimSpace(actor.SubjectKind)
 	credentialSubjectID := subjectID
 	displayName := strings.TrimSpace(actor.DisplayName)
 	authSource := strings.TrimSpace(actor.AuthSource)
-	if runAs := core.NormalizeRunAsSubject(runAs); runAs != nil {
-		subjectID = strings.TrimSpace(runAs.SubjectID)
-		subjectKind = strings.TrimSpace(runAs.SubjectKind)
-		credentialSubjectID = strings.TrimSpace(runAs.CredentialSubjectID)
-		displayName = strings.TrimSpace(runAs.DisplayName)
-		authSource = strings.TrimSpace(runAs.AuthSource)
+	if owner := core.NormalizeRunAsSubject(owner); owner != nil {
+		subjectID = strings.TrimSpace(owner.SubjectID)
+		subjectKind = strings.TrimSpace(owner.SubjectKind)
+		credentialSubjectID = strings.TrimSpace(owner.CredentialSubjectID)
+		displayName = strings.TrimSpace(owner.DisplayName)
+		authSource = strings.TrimSpace(owner.AuthSource)
 	}
 	compiled := principal.CompilePermissions(permissions)
 	value := &principal.Principal{
@@ -452,18 +445,44 @@ func workflowConfigActor() coreworkflow.Actor {
 	}
 }
 
+func workflowConfigOwnerActor(owner *core.RunAsSubject) coreworkflow.Actor {
+	owner = core.NormalizeRunAsSubject(owner)
+	if owner == nil {
+		return workflowConfigActor()
+	}
+	return coreworkflow.Actor{
+		SubjectID:   owner.SubjectID,
+		SubjectKind: owner.SubjectKind,
+		DisplayName: owner.DisplayName,
+		AuthSource:  owner.AuthSource,
+	}
+}
+
+func isWorkflowConfigManagedActor(actor coreworkflow.Actor) bool {
+	if actor.SubjectID == workflowConfigOwnerSubjectID() &&
+		actor.SubjectKind == "system" &&
+		actor.AuthSource == "config" {
+		return true
+	}
+	if actor.SubjectKind != core.SubjectKindServiceAccount || actor.AuthSource != "config" {
+		return false
+	}
+	kind, _, ok := core.ParseSubjectID(actor.SubjectID)
+	return ok && kind == core.SubjectKindServiceAccount
+}
+
 func workflowConfigScheduleID(scheduleKey string) string {
 	sum := sha256.Sum256([]byte(strings.TrimSpace(scheduleKey)))
 	return coreworkflow.ConfigManagedSchedulePrefix + hex.EncodeToString(sum[:])
 }
 
-func workflowConfigValidateExecutionTarget(cfg *config.Config, target coreworkflow.Target, runAs *core.RunAsSubject, _ []core.AccessPermission) error {
-	runAs = core.NormalizeRunAsSubject(runAs)
-	hasRunAs := runAs != nil
+func workflowConfigValidateExecutionTarget(cfg *config.Config, target coreworkflow.Target, owner *core.RunAsSubject, _ []core.AccessPermission) error {
+	owner = core.NormalizeRunAsSubject(owner)
+	hasOwner := owner != nil
 	for i := range target.Steps {
 		step := target.Steps[i]
 		if step.App != nil {
-			if err := workflowConfigValidateNoUserCredentialTarget(cfg, *step.App, hasRunAs); err != nil {
+			if err := workflowConfigValidateNoUserCredentialTarget(cfg, *step.App, hasOwner); err != nil {
 				return err
 			}
 		}
@@ -478,7 +497,7 @@ func workflowConfigValidateExecutionTarget(cfg *config.Config, target coreworkfl
 					Operation:  strings.TrimSpace(tool.Operation),
 					Connection: strings.TrimSpace(tool.Connection),
 					Instance:   strings.TrimSpace(tool.Instance),
-				}, hasRunAs); err != nil {
+				}, hasOwner); err != nil {
 					return err
 				}
 			}
@@ -487,14 +506,14 @@ func workflowConfigValidateExecutionTarget(cfg *config.Config, target coreworkfl
 	return nil
 }
 
-func workflowConfigValidateNoUserCredentialTarget(cfg *config.Config, target coreworkflow.AppCall, hasRunAs bool) error {
+func workflowConfigValidateNoUserCredentialTarget(cfg *config.Config, target coreworkflow.AppCall, hasOwner bool) error {
 	modeOverride := core.NormalizeOptionalConnectionMode(target.CredentialMode)
 	switch modeOverride {
 	case "":
 	case core.ConnectionModeNone:
 		return nil
 	case core.ConnectionModeUser:
-		if hasRunAs {
+		if hasOwner {
 			return nil
 		}
 		return fmt.Errorf("config-managed workflows do not support user-credentialed app %q", strings.TrimSpace(target.Name))
@@ -510,7 +529,7 @@ func workflowConfigValidateNoUserCredentialTarget(cfg *config.Config, target cor
 	case core.ConnectionModeNone:
 		return nil
 	case core.ConnectionModeUser:
-		if hasRunAs {
+		if hasOwner {
 			return nil
 		}
 		return fmt.Errorf("config-managed workflows do not support user-credentialed app %q", appName)

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -798,7 +798,7 @@ type WorkflowsConfig struct {
 type WorkflowScheduleConfig struct {
 	Provider string                 `yaml:"provider,omitempty"`
 	Target   *WorkflowTargetConfig  `yaml:"target,omitempty"`
-	RunAs    *WorkflowRunAsConfig   `yaml:"runAs,omitempty"`
+	Owner    *WorkflowOwnerConfig   `yaml:"owner,omitempty"`
 	Invokes  []WorkflowInvokeConfig `yaml:"invokes,omitempty"`
 	Cron     string                 `yaml:"cron,omitempty"`
 	Timezone string                 `yaml:"timezone,omitempty"`
@@ -808,32 +808,32 @@ type WorkflowScheduleConfig struct {
 type WorkflowEventTriggerConfig struct {
 	Provider string                 `yaml:"provider,omitempty"`
 	Target   *WorkflowTargetConfig  `yaml:"target,omitempty"`
-	RunAs    *WorkflowRunAsConfig   `yaml:"runAs,omitempty"`
+	Owner    *WorkflowOwnerConfig   `yaml:"owner,omitempty"`
 	Invokes  []WorkflowInvokeConfig `yaml:"invokes,omitempty"`
 	Match    WorkflowEventMatch     `yaml:"match,omitempty"`
 	Paused   bool                   `yaml:"paused,omitempty"`
 }
 
-type WorkflowRunAsConfig struct {
-	Subject *WorkflowRunAsSubjectConfig `yaml:"subject,omitempty"`
+type WorkflowOwnerConfig struct {
+	Subject *WorkflowOwnerSubjectConfig `yaml:"subject,omitempty"`
 }
 
-type WorkflowRunAsSubjectConfig struct {
+type WorkflowOwnerSubjectConfig struct {
 	ID          string `yaml:"id,omitempty"`
 	Kind        string `yaml:"kind,omitempty"`
 	DisplayName string `yaml:"displayName,omitempty"`
 	AuthSource  string `yaml:"authSource,omitempty"`
 }
 
-func (r *WorkflowRunAsConfig) SubjectRef() *core.RunAsSubject {
-	if r == nil || r.Subject == nil {
+func (o *WorkflowOwnerConfig) SubjectRef() *core.RunAsSubject {
+	if o == nil || o.Subject == nil {
 		return nil
 	}
 	return core.NormalizeRunAsSubject(&core.RunAsSubject{
-		SubjectID:   r.Subject.ID,
-		SubjectKind: r.Subject.Kind,
-		DisplayName: r.Subject.DisplayName,
-		AuthSource:  r.Subject.AuthSource,
+		SubjectID:   o.Subject.ID,
+		SubjectKind: o.Subject.Kind,
+		DisplayName: o.Subject.DisplayName,
+		AuthSource:  o.Subject.AuthSource,
 	})
 }
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -2062,11 +2062,11 @@ func validateWorkflowsConfig(cfg *Config) error {
 			if err := validateWorkflowScheduleTarget(cfg, key, &schedule); err != nil {
 				return err
 			}
-			runAs, err := normalizeWorkflowRunAs("workflows.schedules."+key+".runAs", schedule.RunAs)
+			owner, err := normalizeWorkflowOwner("workflows.schedules."+key+".owner", schedule.Owner)
 			if err != nil {
 				return err
 			}
-			schedule.RunAs = runAs
+			schedule.Owner = owner
 			invokes, _, err := normalizeWorkflowExecutionInvokes(cfg, "workflows.schedules."+key+".invokes", schedule.Invokes)
 			if err != nil {
 				return err
@@ -2113,11 +2113,11 @@ func validateWorkflowsConfig(cfg *Config) error {
 			if err := validateWorkflowEventTriggerTarget(cfg, key, &trigger); err != nil {
 				return err
 			}
-			runAs, err := normalizeWorkflowRunAs("workflows.eventTriggers."+key+".runAs", trigger.RunAs)
+			owner, err := normalizeWorkflowOwner("workflows.eventTriggers."+key+".owner", trigger.Owner)
 			if err != nil {
 				return err
 			}
-			trigger.RunAs = runAs
+			trigger.Owner = owner
 			invokes, _, err := normalizeWorkflowExecutionInvokes(cfg, "workflows.eventTriggers."+key+".invokes", trigger.Invokes)
 			if err != nil {
 				return err
@@ -2179,37 +2179,28 @@ func validateWorkflowTargetApps(cfg *Config, path string, target *WorkflowTarget
 	return nil
 }
 
-func normalizeWorkflowRunAs(path string, runAs *WorkflowRunAsConfig) (*WorkflowRunAsConfig, error) {
-	if runAs == nil {
+func normalizeWorkflowOwner(path string, owner *WorkflowOwnerConfig) (*WorkflowOwnerConfig, error) {
+	if owner == nil {
 		return nil, nil
 	}
-	if runAs.Subject == nil {
+	if owner.Subject == nil {
 		return nil, fmt.Errorf("config validation: %s.subject is required", path)
 	}
-	subject := *runAs.Subject
-	subject.ID = strings.TrimSpace(subject.ID)
-	subject.Kind = strings.TrimSpace(subject.Kind)
-	subject.DisplayName = strings.TrimSpace(subject.DisplayName)
-	subject.AuthSource = strings.TrimSpace(subject.AuthSource)
-	if subject.AuthSource == "" {
-		subject.AuthSource = "config"
+	subject, err := core.NormalizeServiceAccountSubject(&core.RunAsSubject{
+		SubjectID:   owner.Subject.ID,
+		SubjectKind: owner.Subject.Kind,
+		DisplayName: owner.Subject.DisplayName,
+		AuthSource:  owner.Subject.AuthSource,
+	}, path+".subject")
+	if err != nil {
+		return nil, fmt.Errorf("config validation: %w", err)
 	}
-	if subject.ID == "" {
-		return nil, fmt.Errorf("config validation: %s.subject.id is required", path)
-	}
-	kind, _, ok := core.ParseSubjectID(subject.ID)
-	if !ok {
-		return nil, fmt.Errorf("config validation: %s.subject.id %q must be a fully-qualified service_account subject", path, subject.ID)
-	}
-	if kind != "service_account" {
-		return nil, fmt.Errorf("config validation: %s.subject.id %q must identify a service_account subject", path, subject.ID)
-	}
-	if subject.Kind == "" {
-		subject.Kind = kind
-	} else if subject.Kind != kind {
-		return nil, fmt.Errorf("config validation: %s.subject.kind %q must match subject.id kind %q", path, subject.Kind, kind)
-	}
-	return &WorkflowRunAsConfig{Subject: &subject}, nil
+	return &WorkflowOwnerConfig{Subject: &WorkflowOwnerSubjectConfig{
+		ID:          subject.SubjectID,
+		Kind:        subject.SubjectKind,
+		DisplayName: subject.DisplayName,
+		AuthSource:  subject.AuthSource,
+	}}, nil
 }
 
 func normalizeWorkflowExecutionInvokes(cfg *Config, path string, values []WorkflowInvokeConfig) ([]WorkflowInvokeConfig, []core.AccessPermission, error) {

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -968,7 +968,7 @@ workflows:
               operation: ping
       cron: "* * * * *"
       paused: ${GESTALT_SCOPED_APP_DROPPED_WORKFLOW_BOOL_MISSING_ENV}
-      runAs:
+      owner:
         subject:
           id: test
           kind: test

--- a/gestaltd/internal/workflowwire/target.go
+++ b/gestaltd/internal/workflowwire/target.go
@@ -159,7 +159,7 @@ func parseAgentTurn(value any, path string) (*coreworkflow.AgentTurn, error) {
 	if err != nil {
 		return nil, err
 	}
-	tools, err := parseToolRefs(agentMap["tools"])
+	tools, err := parseToolRefs(agentMap["tools"], path+".tools")
 	if err != nil {
 		return nil, err
 	}
@@ -295,22 +295,22 @@ func parseMessages(value any, path string) ([]coreworkflow.AgentMessage, error) 
 	return out, nil
 }
 
-func parseToolRefs(value any) ([]coreagent.ToolRef, error) {
+func parseToolRefs(value any, path string) ([]coreagent.ToolRef, error) {
 	if value == nil {
 		return nil, nil
 	}
-	items, ok := value.([]any)
+	items, ok := asArray(value)
 	if !ok {
-		return nil, fmt.Errorf("%w: agent tools must be an array", ErrInvalid)
+		return nil, fmt.Errorf("%w: %s must be an array", ErrInvalid, path)
 	}
 	out := make([]coreagent.ToolRef, 0, len(items))
 	for i, item := range items {
 		refMap, ok := asMap(item)
 		if !ok {
-			return nil, fmt.Errorf("%w: agent tools[%d] must be an object", ErrInvalid, i)
+			return nil, fmt.Errorf("%w: %s[%d] must be an object", ErrInvalid, path, i)
 		}
-		path := fmt.Sprintf("agent tools[%d]", i)
-		if err := rejectUnknownKeys(refMap, path, "system", "app", "operation", "connection", "instance", "title", "description"); err != nil {
+		refPath := fmt.Sprintf("%s[%d]", path, i)
+		if err := rejectUnknownKeys(refMap, refPath, "system", "app", "operation", "connection", "instance", "title", "description"); err != nil {
 			return nil, err
 		}
 		out = append(out, coreagent.ToolRef{


### PR DESCRIPTION
Summary:
- Replace config-managed workflow `runAs` with an explicit `owner` subject on schedules and event triggers.
- Use the workflow owner as the execution identity when minting workflow invocation tokens and upserting config-managed workflow objects.
- Keep workflow agent tool refs from carrying per-tool runAs delegation, with improved target path errors.

Test plan:
- `go test ./gestaltd/core ./gestaltd/internal/workflowwire`
- `go test ./gestaltd/internal/config ./gestaltd/services/workflows/workflowmanager`
- Focused `gestaltd/internal/bootstrap` owner/tool-ref tests
- Focused `gestaltd/internal/operator` scoped-load tests

Note:
- Full `go test ./gestaltd/internal/bootstrap` still has unrelated hosted-agent git clone failures in this local environment.