### PR TITLE
[codex] Map IndexedDB object-store errors

### DIFF
--- a/sdk/typescript/src/indexeddb.ts
+++ b/sdk/typescript/src/indexeddb.ts
@@ -927,23 +927,25 @@ class IndexedDBImpl implements IndexedDB {
     name: string,
     schema?: ObjectStoreSchema,
   ): Promise<ObjectStore> {
-    await this.client.createObjectStore({
-      name,
-      schema: {
-        indexes: (schema?.indexes ?? []).map((idx) => ({
-          name: idx.name,
-          keyPath: idx.keyPath,
-          unique: idx.unique ?? false,
-        })),
-        columns: (schema?.columns ?? []).map((col) => ({
-          name: col.name,
-          type: col.type ?? ColumnType.String,
-          primaryKey: col.primaryKey ?? false,
-          notNull: col.notNull ?? false,
-          unique: col.unique ?? false,
-        })),
-      },
-    });
+    await rpc(() =>
+      this.client.createObjectStore({
+        name,
+        schema: {
+          indexes: (schema?.indexes ?? []).map((idx) => ({
+            name: idx.name,
+            keyPath: idx.keyPath,
+            unique: idx.unique ?? false,
+          })),
+          columns: (schema?.columns ?? []).map((col) => ({
+            name: col.name,
+            type: col.type ?? ColumnType.String,
+            primaryKey: col.primaryKey ?? false,
+            notNull: col.notNull ?? false,
+            unique: col.unique ?? false,
+          })),
+        },
+      }),
+    );
     return this.objectStore(name);
   }
 
@@ -951,7 +953,7 @@ class IndexedDBImpl implements IndexedDB {
    * Deletes an object store.
    */
   async deleteObjectStore(name: string): Promise<void> {
-    await this.client.deleteObjectStore({ name });
+    await rpc(() => this.client.deleteObjectStore({ name }));
   }
 
   /**

--- a/sdk/typescript/tests/indexeddb.transport.test.ts
+++ b/sdk/typescript/tests/indexeddb.transport.test.ts
@@ -564,4 +564,26 @@ describe("IndexedDB transport", () => {
     await os.add({ id: "dup-1", data: "first" });
     await expect(os.add({ id: "dup-1", data: "second" })).rejects.toThrow(AlreadyExistsError);
   });
+
+  test("error mapping: duplicate object store throws AlreadyExistsError", async () => {
+    const local = new IndexedDB("schema");
+    (local as any).client = {
+      createObjectStore: async () => {
+        throw Object.assign(new Error("store already exists"), { code: 6 });
+      },
+    };
+
+    await expect(local.createObjectStore("dupe")).rejects.toThrow(AlreadyExistsError);
+  });
+
+  test("error mapping: deleting missing object store throws NotFoundError", async () => {
+    const local = new IndexedDB("schema");
+    (local as any).client = {
+      deleteObjectStore: async () => {
+        throw Object.assign(new Error("store not found"), { code: 5 });
+      },
+    };
+
+    await expect(local.deleteObjectStore("missing")).rejects.toThrow(NotFoundError);
+  });
 });


### PR DESCRIPTION
## Summary

Wrap TypeScript SDK `IndexedDB.createObjectStore` and `deleteObjectStore` calls with the existing `rpc()` error mapper.

This makes hosted IndexedDB `code: 5` / `code: 6` transport errors map to the SDK's exported `NotFoundError` and `AlreadyExistsError`, matching the behavior already used by object-store record operations like `get`, `add`, `put`, and `delete`.

## Root Cause

`ObjectStoreImpl` methods already call through `rpc()`, so consumers can catch typed SDK errors. `IndexedDBImpl.createObjectStore` and `deleteObjectStore` bypassed that wrapper and surfaced raw host transport errors instead. That forced apps like the PA Configuration Registry to defensively match hosted error wrappers in application code.

## Validation

- `bun test tests/indexeddb.transport.test.ts`
- `bun run typecheck`
- `bun run check`