### PR TITLE
Allow shared external identity links

### DIFF
--- a/gestaltd/internal/server/external_identity_sync.go
+++ b/gestaltd/internal/server/external_identity_sync.go
@@ -10,7 +10,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/authorization"
 )
 
-var errExternalIdentityAlreadyLinked = errors.New("external identity already linked")
 var errDuplicateExternalIdentityCredential = errors.New("duplicate external identity credential")
 
 type duplicateExternalIdentityCredentialError struct {
@@ -164,23 +163,13 @@ func (s *Server) ensureExternalIdentityLink(ctx context.Context, subjectID strin
 		return err
 	}
 
-	currentSubjectLinked := false
-	otherSubjectLinked := false
 	for _, rel := range relationships {
 		if rel == nil || rel.GetSubject() == nil {
 			continue
 		}
 		if externalIdentityRelationshipSubjectMatches(rel.GetSubject(), subjectID) {
-			currentSubjectLinked = true
-			continue
+			return nil
 		}
-		otherSubjectLinked = true
-	}
-	if currentSubjectLinked {
-		return nil
-	}
-	if otherSubjectLinked {
-		return errExternalIdentityAlreadyLinked
 	}
 
 	modelID, err := s.managedAuthorizationModelID(ctx)

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -16567,7 +16567,7 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 		}
 	})
 
-	t.Run("slack identity already linked", func(t *testing.T) {
+	t.Run("slack identity can be linked to multiple subjects", func(t *testing.T) {
 		t.Parallel()
 
 		svc := testutil.NewStubServices(t)
@@ -16677,20 +16677,17 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 
 		viewerResp := runConnect("viewer-session")
 		defer func() { _ = viewerResp.Body.Close() }()
-		if viewerResp.StatusCode != http.StatusBadGateway {
+		if viewerResp.StatusCode != http.StatusSeeOther {
 			body, _ := io.ReadAll(viewerResp.Body)
-			t.Fatalf("viewer callback status = %d, want %d: %s", viewerResp.StatusCode, http.StatusBadGateway, strings.TrimSpace(string(body)))
+			t.Fatalf("viewer callback status = %d, want %d: %s", viewerResp.StatusCode, http.StatusSeeOther, strings.TrimSpace(string(body)))
 		}
 
 		admin, _ := svc.Users.FindOrCreateUser(context.Background(), "admin@example.test")
 		viewer, _ := svc.Users.FindOrCreateUser(context.Background(), "viewer@example.test")
 		adminTokens, _ := svc.ExternalCredentials.ListCredentials(context.Background(), principal.UserSubjectID(admin.ID))
-		if len(adminTokens) != 1 {
-			t.Fatalf("expected one admin token, got %d", len(adminTokens))
-		}
 		viewerTokens, _ := svc.ExternalCredentials.ListCredentials(context.Background(), principal.UserSubjectID(viewer.ID))
-		if len(viewerTokens) != 0 {
-			t.Fatalf("expected viewer token rollback, got %d", len(viewerTokens))
+		if len(adminTokens) != 1 || len(viewerTokens) != 1 {
+			t.Fatalf("expected one token per subject, got admin=%d viewer=%d", len(adminTokens), len(viewerTokens))
 		}
 
 		respAuthz, err := authzProvider.ReadRelationships(context.Background(), &core.ReadRelationshipsRequest{
@@ -16701,13 +16698,15 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 			},
 		})
 		if err != nil {
-			t.Fatalf("ReadRelationships after conflict: %v", err)
+			t.Fatalf("ReadRelationships after shared link: %v", err)
 		}
-		if len(respAuthz.GetRelationships()) != 1 {
-			t.Fatalf("relationships after conflict = %+v, want one", respAuthz.GetRelationships())
+		gotSubjects := map[string]bool{}
+		for _, rel := range respAuthz.GetRelationships() {
+			gotSubjects[rel.GetSubject().GetId()] = true
 		}
-		if got := respAuthz.GetRelationships()[0].GetSubject().GetId(); got != principal.UserSubjectID(admin.ID) {
-			t.Fatalf("linked subject after conflict = %q, want %q", got, principal.UserSubjectID(admin.ID))
+		adminSubjectID, viewerSubjectID := principal.UserSubjectID(admin.ID), principal.UserSubjectID(viewer.ID)
+		if len(gotSubjects) != 2 || !gotSubjects[adminSubjectID] || !gotSubjects[viewerSubjectID] {
+			t.Fatalf("relationships after shared link = %+v, want subjects %v", respAuthz.GetRelationships(), []string{adminSubjectID, viewerSubjectID})
 		}
 	})
 }
@@ -20120,23 +20119,28 @@ func TestConnectManual(t *testing.T) {
 		}
 	})
 
-	t.Run("service account external identity writes subject relationship", func(t *testing.T) {
+	t.Run("external identity can be linked to user and service account", func(t *testing.T) {
 		t.Parallel()
 
+		userToken, userTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
+		if err != nil {
+			t.Fatalf("GenerateToken user: %v", err)
+		}
 		subjectToken, subjectTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
 		if err != nil {
-			t.Fatalf("GenerateToken: %v", err)
+			t.Fatalf("GenerateToken subject: %v", err)
 		}
 		svc := testutil.NewStubServices(t)
+		user := seedAPITokenWithPermissions(t, svc, userToken, userTokenHash, "api-user", nil)
 		seedSubjectAPIToken(t, svc, subjectTokenHash, "service_account:triage-bot", "triage-bot")
 		authzProvider := newMemoryAuthorizationProvider("memory-authorization")
 		base, err := newTestAuthorizer(config.AuthorizationConfig{
 			Policies: map[string]config.SubjectPolicyDef{
 				"manual_policy": {
-					Members: []config.SubjectPolicyMemberDef{{
-						SubjectID: "service_account:triage-bot",
-						Role:      "viewer",
-					}},
+					Members: []config.SubjectPolicyMemberDef{
+						{SubjectID: principal.UserSubjectID(user.ID), Role: "viewer"},
+						{SubjectID: "service_account:triage-bot", Role: "viewer"},
+					},
 				},
 			},
 		}, map[string]*config.ProviderEntry{"manual-svc": {AuthorizationPolicy: "manual_policy"}})
@@ -20163,19 +20167,25 @@ func TestConnectManual(t *testing.T) {
 		})
 		testutil.CloseOnCleanup(t, ts)
 
-		body := bytes.NewBufferString(`{"integration":"manual-svc","credential":"my-api-key","connectionParams":{"team_id":"T123","user_id":"U456"}}`)
-		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", body)
-		req.Header.Set("Authorization", "Bearer "+subjectToken)
-		req.Header.Set("Content-Type", "application/json")
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			t.Fatalf("request: %v", err)
+		connect := func(token, credential string) {
+			t.Helper()
+			body := bytes.NewBufferString(fmt.Sprintf(`{"integration":"manual-svc","credential":%q,"connectionParams":{"team_id":"T123","user_id":"U456"}}`, credential))
+			req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", body)
+			req.Header.Set("Authorization", "Bearer "+token)
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("request: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusOK {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+			}
 		}
-		defer func() { _ = resp.Body.Close() }()
-		if resp.StatusCode != http.StatusOK {
-			body, _ := io.ReadAll(resp.Body)
-			t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
-		}
+
+		connect(userToken, "user-key")
+		connect(subjectToken, "subject-key")
 
 		relResp, err := authzProvider.ReadRelationships(context.Background(), &core.ReadRelationshipsRequest{
 			Relation: authorization.ProviderExternalIdentityRelationAssume,
@@ -20187,13 +20197,13 @@ func TestConnectManual(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ReadRelationships: %v", err)
 		}
-		relationships := relResp.GetRelationships()
-		if len(relationships) != 1 {
-			t.Fatalf("expected one external identity relationship, got %+v", relationships)
+		gotSubjects := map[string]bool{}
+		for _, rel := range relResp.GetRelationships() {
+			gotSubjects[rel.GetSubject().GetId()] = true
 		}
-		subject := relationships[0].GetSubject()
-		if subject.GetType() != authorization.ProviderSubjectTypeSubject || subject.GetId() != "service_account:triage-bot" {
-			t.Fatalf("expected subject service account relationship, got %+v", subject)
+		userSubjectID, serviceAccountSubjectID := principal.UserSubjectID(user.ID), "service_account:triage-bot"
+		if len(gotSubjects) != 2 || !gotSubjects[userSubjectID] || !gotSubjects[serviceAccountSubjectID] {
+			t.Fatalf("expected shared external identity relationships for %v, got %+v", []string{userSubjectID, serviceAccountSubjectID}, relResp.GetRelationships())
 		}
 	})
 


### PR DESCRIPTION
## Summary

Allows multiple Gestalt subjects to link to the same provider-owned external identity instead of treating the first link as an exclusive claim.

The host still keeps external identity relationship sync idempotent for the current subject, and it preserves same-subject duplicate credential protection so one subject cannot save the same external identity under multiple instances for the same connection.

This lets a human subject and a managed service account both save credentials for the same third-party identity, matching the run-as/shared-identity authorization model instead of blocking the later connection with a generic setup failure.

## Interfaces

```go
func (s *Server) ensureExternalIdentityLink(ctx context.Context, subjectID string, ref externalIdentityRef) error
```

```go
// External identity assume relationships are now many-subject:
subject:user:<id> -> assume -> external_identity:<provider identity>
subject:service_account:<id> -> assume -> external_identity:<same provider identity>
```

## Runtime

When a connection saves post-connect metadata with `gestalt.external_identity.*`, gestaltd now only skips writing the relationship if that same subject is already linked. Existing relationships from other subjects no longer cause connection setup to fail.

Disconnect still removes only relationships for the disconnecting subject, and same-subject duplicate credential protection remains in place for ambiguous multi-instance saves. Server tests cover OAuth and manual connection flows for shared user/user and user/service-account identity links.