### PR TITLE
Use selected connection definitions during auth setup

### DIFF
--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -192,7 +192,7 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 			info.MountedPath = strings.TrimSpace(entry.MountPath)
 		}
 		instances := connected[name]
-		authTypes := s.populateIntegrationSettings(&info, prov, instances, p)
+		authTypes := s.populateIntegrationSettings(&info, instances, p)
 		s.applyIntegrationConnectionStatus(&info, prov, instances, authTypes, p)
 		info.MountedPath = s.integrationMountedPathForPrincipalContext(r.Context(), p, name, info.MountedPath)
 		if !s.integrationHasUsableSurfaceContext(r.Context(), p, name, prov, info) {
@@ -514,8 +514,8 @@ func resolveRequestedInstance(w http.ResponseWriter, requested string) (string, 
 	return instance, true
 }
 
-func resolveConnectionParams(w http.ResponseWriter, prov core.Provider, provided map[string]string) (map[string]string, bool) {
-	connParams, err := validateConnectionParams(prov.ConnectionParamDefs(), provided)
+func resolveConnectionParams(w http.ResponseWriter, defs map[string]core.ConnectionParamDef, provided map[string]string) (map[string]string, bool) {
+	connParams, err := validateConnectionParams(defs, provided)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return nil, false

--- a/gestaltd/internal/server/handlers_connect.go
+++ b/gestaltd/internal/server/handlers_connect.go
@@ -62,14 +62,17 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 	}
 	metricProviderName = req.Integration
 	connectionMode = metricutil.NormalizeConnectionMode(prov.ConnectionMode())
-	conn, hasConnectionDef := s.effectiveConnectionDef(req.Integration, manualConnection)
-	if hasConnectionDef {
-		mode := config.ConnectionModeForConnection(conn)
-		connectionMode = metricutil.NormalizeConnectionMode(mode)
-	}
 	p := PrincipalFromContext(r.Context())
+
+	selected, ok := s.requireConfiguredConnection(w, req.Integration, manualConnection)
+	if !ok {
+		auditErr = errors.New("connection is not configured")
+		return
+	}
+	conn := selected.Def
+	connectionMode = metricutil.NormalizeConnectionMode(selected.Mode)
 	auth := conn.Auth
-	if !manualConnectionAllowed(prov, conn, hasConnectionDef) {
+	if !manualConnectionAllowed(conn) {
 		auditErr = errors.New("integration does not support manual auth")
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("integration %q does not support manual auth; use OAuth connect instead", req.Integration))
 		return
@@ -84,7 +87,7 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 
 	tokenExchange := manualTokenExchangeConfigured(auth)
 
-	effectiveCredential, credErr := buildEffectiveManualCredential(req, manualCredentialAuth(auth, prov, tokenExchange), tokenExchange)
+	effectiveCredential, credErr := buildEffectiveManualCredential(req, auth, tokenExchange)
 	if credErr != nil {
 		auditErr = credErr
 		writeError(w, http.StatusBadRequest, credErr.Error())
@@ -96,7 +99,7 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	connParams, ok := resolveConnectionParams(w, prov, req.ConnectionParams)
+	connParams, ok := resolveConnectionParams(w, selected.ParamDefs, req.ConnectionParams)
 	if !ok {
 		auditErr = errors.New("invalid connection parameters")
 		return
@@ -110,7 +113,7 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	manualMeta, metaErr := buildConnectionMetadata(prov, connParams, tokenResp)
+	manualMeta, metaErr := buildConnectionMetadata(selected.ParamDefs, connParams, tokenResp)
 	if metaErr != nil {
 		auditErr = errors.New(metaErr.Error())
 		writeError(w, http.StatusBadRequest, metaErr.Error())
@@ -155,20 +158,6 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 	auditAllowed = true
 	auditErr = nil
 	writeJSON(w, http.StatusOK, result)
-}
-
-func manualCredentialAuth(auth config.ConnectionAuthDef, prov core.Provider, tokenExchange bool) config.ConnectionAuthDef {
-	if !tokenExchange || len(auth.Credentials) > 0 {
-		return auth
-	}
-	for _, field := range prov.CredentialFields() {
-		auth.Credentials = append(auth.Credentials, config.CredentialFieldDef{
-			Name:        field.Name,
-			Label:       field.Label,
-			Description: field.Description,
-		})
-	}
-	return auth
 }
 
 func manualTokenExchangeConfigured(auth config.ConnectionAuthDef) bool {
@@ -261,32 +250,33 @@ func validateConnectionParams(defs map[string]core.ConnectionParamDef, provided 
 	return result, nil
 }
 
-func buildConnectionMetadata(prov core.Provider, userParams map[string]string, tokenResp *core.TokenResponse) (string, error) {
+func buildConnectionMetadata(defs map[string]core.ConnectionParamDef, userParams map[string]string, tokenResp *core.TokenResponse) (string, error) {
 	metadata := make(map[string]string)
 	for k, v := range userParams {
 		metadata[k] = v
 	}
 
-	if defs := prov.ConnectionParamDefs(); tokenResp != nil && tokenResp.Extra != nil {
-		for name, def := range defs {
-			if def.From == "token_response" {
-				field := def.Field
-				if field == "" {
-					field = name
-				}
-				val, ok := apiexec.ExtractJSONPath(tokenResp.Extra, field)
-				if !ok {
-					if def.Required {
-						return "", fmt.Errorf("token response missing required field %q for connection param %q", field, name)
-					}
-					continue
-				}
-				s := fmt.Sprintf("%v", val)
-				if !safeTokenResponseValue.MatchString(s) {
-					return "", fmt.Errorf("token response field %q for connection param %q contains invalid characters", field, name)
-				}
-				metadata[name] = s
+	for name, def := range defs {
+		if def.From == "token_response" {
+			if tokenResp == nil {
+				continue
 			}
+			field := def.Field
+			if field == "" {
+				field = name
+			}
+			val, ok := apiexec.ExtractJSONPath(tokenResp.Extra, field)
+			if !ok {
+				if def.Required {
+					return "", fmt.Errorf("token response missing required field %q for connection param %q", field, name)
+				}
+				continue
+			}
+			s := fmt.Sprintf("%v", val)
+			if !safeTokenResponseValue.MatchString(s) {
+				return "", fmt.Errorf("token response field %q for connection param %q contains invalid characters", field, name)
+			}
+			metadata[name] = s
 		}
 	}
 
@@ -504,11 +494,52 @@ func (s *Server) completeConnection(ctx context.Context, _ core.Provider, tm cre
 	return &connectionSetupResult{Status: "connected", Integration: tm.Integration}, nil
 }
 
-func manualConnectionAllowed(prov core.Provider, conn config.ConnectionDef, hasConnectionDef bool) bool {
-	if hasConnectionDef && authTypesContain(connectionAuthTypes(conn.Auth, nil), "manual") {
-		return true
+func manualConnectionAllowed(conn config.ConnectionDef) bool {
+	return authTypesContain(connectionAuthTypes(conn.Auth, nil), "manual")
+}
+
+type configuredConnectionInfo struct {
+	Def       config.ConnectionDef
+	Mode      core.ConnectionMode
+	ParamDefs map[string]core.ConnectionParamDef
+}
+
+func (s *Server) configuredConnectionInfo(integration, connection string) (configuredConnectionInfo, error) {
+	conn, ok := s.effectiveConnectionDef(integration, connection)
+	if !ok {
+		return configuredConnectionInfo{}, fmt.Errorf("connection %q is not configured for integration %q", connection, integration)
 	}
-	return authTypesContain(userFacingAuthTypes(prov.AuthTypes()), "manual")
+	return configuredConnectionInfo{
+		Def:       conn,
+		Mode:      config.ConnectionModeForConnection(conn),
+		ParamDefs: connectionParamDefsFromConfig(conn.ConnectionParams),
+	}, nil
+}
+
+func connectionParamDefsFromConfig(defs map[string]config.ConnectionParamDef) map[string]core.ConnectionParamDef {
+	if len(defs) == 0 {
+		return nil
+	}
+	out := make(map[string]core.ConnectionParamDef, len(defs))
+	for name, def := range defs {
+		out[name] = core.ConnectionParamDef{
+			Required:    def.Required,
+			Description: def.Description,
+			Default:     def.Default,
+			From:        def.From,
+			Field:       def.Field,
+		}
+	}
+	return out
+}
+
+func (s *Server) requireConfiguredConnection(w http.ResponseWriter, integration, connection string) (configuredConnectionInfo, bool) {
+	info, err := s.configuredConnectionInfo(integration, connection)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return configuredConnectionInfo{}, false
+	}
+	return info, true
 }
 
 func discoveryCandidateInfos(candidates []core.DiscoveryCandidate) []discoveryCandidateInfo {

--- a/gestaltd/internal/server/handlers_oauth.go
+++ b/gestaltd/internal/server/handlers_oauth.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
-	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/services/apps/oauth"
 	"github.com/valon-technologies/gestalt/server/services/apps/paraminterp"
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
@@ -51,10 +50,14 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 	}
 	metricProviderName = req.Integration
 	connectionMode = metricutil.NormalizeConnectionMode(prov.ConnectionMode())
-	if conn, ok := s.effectiveConnectionDef(req.Integration, connection); ok {
-		if mode := config.ConnectionModeForConnection(conn); mode != "" {
-			connectionMode = metricutil.NormalizeConnectionMode(mode)
-		}
+	p := PrincipalFromContext(r.Context())
+	selected, ok := s.requireConfiguredConnection(w, req.Integration, connection)
+	if !ok {
+		auditErr = errors.New("connection is not configured")
+		return
+	}
+	if selected.Mode != "" {
+		connectionMode = metricutil.NormalizeConnectionMode(selected.Mode)
 	}
 
 	handler, ok := s.requireOAuthHandler(w, req.Integration, connection)
@@ -76,7 +79,7 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 	}
 	auditTarget = connectionAuditTarget(req.Integration, connection, instance)
 
-	connParams, ok := resolveConnectionParams(w, prov, req.ConnectionParams)
+	connParams, ok := resolveConnectionParams(w, selected.ParamDefs, req.ConnectionParams)
 	if !ok {
 		auditErr = errors.New("invalid connection parameters")
 		return
@@ -95,7 +98,6 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 		authURL, verifier = handler.StartOAuth("_", req.Scopes)
 	}
 
-	p := PrincipalFromContext(r.Context())
 	authSource := ""
 	if p != nil {
 		authSource = p.AuthSource()
@@ -212,6 +214,20 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 	if prov != nil {
 		connectionMode = metricutil.NormalizeConnectionMode(prov.ConnectionMode())
 	}
+	selected, connErr := s.configuredConnectionInfo(providerName, state.Connection)
+	if connErr != nil {
+		auditErr = errors.New("connection is not configured")
+		writeCallbackError(
+			http.StatusBadRequest,
+			connErr.Error(),
+			providerName+" connection failed",
+			"Gestalt could not finish saving this connection. Start the connection again from Integrations.",
+		)
+		return
+	}
+	if selected.Mode != "" {
+		connectionMode = metricutil.NormalizeConnectionMode(selected.Mode)
+	}
 
 	var exchangeOpts []oauth.ExchangeOption
 	connParams := state.ConnectionParams
@@ -237,7 +253,7 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	metadata, metaErr := buildConnectionMetadata(prov, connParams, tokenResp)
+	metadata, metaErr := buildConnectionMetadata(selected.ParamDefs, connParams, tokenResp)
 	if metaErr != nil {
 		auditErr = errors.New("failed to extract connection metadata from token response")
 		slog.ErrorContext(r.Context(), "connection metadata extraction failed", "provider", providerName, "error", metaErr)
@@ -272,9 +288,7 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 		TokenExpiresAt: tokenExpiresAt,
 		MetadataJSON:   metadata,
 	}
-	if conn, ok := s.effectiveConnectionDef(providerName, state.Connection); ok {
-		tm.ConnectionID = conn.ConnectionID
-	}
+	tm.ConnectionID = selected.Def.ConnectionID
 	tm.ActorSubjectID = state.ActorSubjectID
 	tm.ActorUserID = state.ActorUserID
 	tm.ActorAuthSource = state.ActorAuthSource

--- a/gestaltd/internal/server/handlers_tokens.go
+++ b/gestaltd/internal/server/handlers_tokens.go
@@ -240,7 +240,7 @@ func (s *Server) revokeAllAPITokens(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"status": "revoked", "count": count})
 }
 
-func (s *Server) connectionInfosForPlugin(integration string, app *config.ProviderEntry, instances []instanceInfo, integrationAuthTypes []string, defaultCredentialFields []credentialFieldInfo, defaultConnectionParams map[string]connectionParamInfo, p *principal.Principal) []connectionDefInfo {
+func (s *Server) connectionInfosForPlugin(integration string, app *config.ProviderEntry, instances []instanceInfo, integrationAuthTypes []string, p *principal.Principal) []connectionDefInfo {
 	if app == nil {
 		return []connectionDefInfo{}
 	}
@@ -259,7 +259,7 @@ func (s *Server) connectionInfosForPlugin(integration string, app *config.Provid
 		if name == config.AppConnectionName {
 			conn = displayAppConnectionDef(app, manifestSpec, conn)
 		}
-		if info, ok := s.connectionInfoFromAuth(integration, name, userFacingConnectionName(name), name, conn, instances, integrationAuthTypes, defaultCredentialFields, defaultConnectionParams, name != config.AppConnectionName, p); ok {
+		if info, ok := s.connectionInfoFromAuth(integration, userFacingConnectionName(name), name, conn, instances, integrationAuthTypes, name != config.AppConnectionName, p); ok {
 			infos = append(infos, info)
 		}
 	}
@@ -297,64 +297,14 @@ func userFacingConnectionName(name string) string {
 	return name
 }
 
-func (s *Server) populateIntegrationSettings(info *integrationInfo, prov core.Provider, instances []instanceInfo, p *principal.Principal) []string {
-	authTypes := userFacingAuthTypes(prov.AuthTypes())
-	defaultConnectionParams := connectionParamInfosFromProvider(prov)
-	defaultCredentialFields := credentialFieldInfosFromProvider(prov, authTypes)
-	info.Connections = s.connectionInfosForPlugin(info.Name, s.pluginDefs[info.Name], instances, authTypes, defaultCredentialFields, defaultConnectionParams, p)
-	resolvedAuthTypes := resolvedIntegrationAuthTypes(prov, authTypes, info.Connections)
+func (s *Server) populateIntegrationSettings(info *integrationInfo, instances []instanceInfo, p *principal.Principal) []string {
+	authTypes := []string{}
+	info.Connections = s.connectionInfosForPlugin(info.Name, s.pluginDefs[info.Name], instances, authTypes, p)
+	resolvedAuthTypes := resolvedIntegrationAuthTypes(info.Connections)
 	if len(authTypes) == 0 && len(resolvedAuthTypes) > 0 {
-		info.Connections = s.connectionInfosForPlugin(info.Name, s.pluginDefs[info.Name], instances, resolvedAuthTypes, defaultCredentialFields, defaultConnectionParams, p)
+		info.Connections = s.connectionInfosForPlugin(info.Name, s.pluginDefs[info.Name], instances, resolvedAuthTypes, p)
 	}
-	if len(info.Connections) == 0 && shouldExposeProviderConnectionFallback(prov, resolvedAuthTypes, defaultCredentialFields, defaultConnectionParams) {
-		if fallback, ok := s.providerConnectionInfo(info.Name, prov, instances, resolvedAuthTypes, defaultCredentialFields, defaultConnectionParams, p); ok {
-			info.Connections = []connectionDefInfo{fallback}
-		}
-	}
-	return resolvedIntegrationAuthTypes(prov, resolvedAuthTypes, info.Connections)
-}
-
-func shouldExposeProviderConnectionFallback(prov core.Provider, authTypes []string, credentialFields []credentialFieldInfo, connectionParams map[string]connectionParamInfo) bool {
-	if prov == nil {
-		return false
-	}
-	if core.NormalizeConnectionMode(prov.ConnectionMode()) == core.ConnectionModeNone {
-		return false
-	}
-	return len(authTypes) > 0 || len(credentialFields) > 0 || len(connectionParams) > 0
-}
-
-func credentialFieldInfosFromProvider(prov core.Provider, authTypes []string) []credentialFieldInfo {
-	if fields := prov.CredentialFields(); len(fields) > 0 {
-		if fields := credentialFieldInfos(fields, func(field core.CredentialFieldDef) credentialFieldInfo {
-			return credentialFieldInfo{
-				Name:        field.Name,
-				Label:       field.Label,
-				Description: field.Description,
-			}
-		}); len(fields) > 0 {
-			return fields
-		}
-	}
-	if authTypesContain(authTypes, "manual") {
-		return defaultManualCredentialFieldInfos()
-	}
-	return []credentialFieldInfo{}
-}
-
-func connectionParamInfosFromProvider(prov core.Provider) map[string]connectionParamInfo {
-	infos := map[string]connectionParamInfo{}
-	for name, def := range prov.ConnectionParamDefs() {
-		if def.From != "" {
-			continue
-		}
-		infos[name] = connectionParamInfo{
-			Required:    def.Required,
-			Description: def.Description,
-			Default:     def.Default,
-		}
-	}
-	return infos
+	return resolvedIntegrationAuthTypes(info.Connections)
 }
 
 func connectionParamInfosFromConnection(conn config.ConnectionDef) map[string]connectionParamInfo {
@@ -386,21 +336,11 @@ func credentialFieldInfos[T any](fields []T, mapField func(T) credentialFieldInf
 	return infos
 }
 
-func (s *Server) providerConnectionInfo(integration string, prov core.Provider, instances []instanceInfo, integrationAuthTypes []string, defaultCredentialFields []credentialFieldInfo, defaultConnectionParams map[string]connectionParamInfo, p *principal.Principal) (connectionDefInfo, bool) {
-	conn := config.ConnectionDef{
-		Mode: providermanifestv1.ConnectionMode(core.NormalizeConnectionMode(prov.ConnectionMode())),
-	}
-	return s.connectionInfoFromAuth(integration, config.AppConnectionName, config.AppConnectionAlias, "", conn, instances, integrationAuthTypes, defaultCredentialFields, defaultConnectionParams, true, p)
-}
-
-func (s *Server) connectionInfoFromAuth(integration, _ string, name, instanceConnection string, conn config.ConnectionDef, instances []instanceInfo, integrationAuthTypes []string, defaultCredentialFields []credentialFieldInfo, defaultConnectionParams map[string]connectionParamInfo, includeWithoutAuth bool, p *principal.Principal) (connectionDefInfo, bool) {
+func (s *Server) connectionInfoFromAuth(integration, name, instanceConnection string, conn config.ConnectionDef, instances []instanceInfo, integrationAuthTypes []string, includeWithoutAuth bool, p *principal.Principal) (connectionDefInfo, bool) {
 	mode := config.ConnectionModeForConnection(conn)
 	connectionInstances := groupInstancesForConnection(instances, instanceConnection)
 	connectionParams := connectionParamInfosFromConnection(conn)
-	if len(connectionParams) == 0 && config.ResolveConnectionAlias(name) == config.AppConnectionName {
-		connectionParams = cloneConnectionParamInfos(defaultConnectionParams)
-	}
-	authTypes := connectionAuthTypes(conn.Auth, integrationAuthTypes)
+	authTypes := connectionAuthTypes(conn.Auth, nil)
 	authTypes = s.supportedConnectionAuthTypes(integration, name, authTypes)
 	if len(authTypes) == 0 && !includeWithoutAuth {
 		return connectionDefInfo{}, false
@@ -445,23 +385,10 @@ func (s *Server) connectionInfoFromAuth(integration, _ string, name, instanceCon
 		}
 	}); len(fields) > 0 {
 		info.CredentialFields = fields
-	} else if authTypesContain(authTypes, "manual") && len(defaultCredentialFields) > 0 {
-		info.CredentialFields = append([]credentialFieldInfo(nil), defaultCredentialFields...)
 	} else if authTypesContain(authTypes, "manual") {
 		info.CredentialFields = defaultManualCredentialFieldInfos()
 	}
 	return info, true
-}
-
-func cloneConnectionParamInfos(params map[string]connectionParamInfo) map[string]connectionParamInfo {
-	if len(params) == 0 {
-		return map[string]connectionParamInfo{}
-	}
-	out := make(map[string]connectionParamInfo, len(params))
-	for key, value := range params {
-		out[key] = value
-	}
-	return out
 }
 
 func (s *Server) invocationConnectionMode(prov core.Provider, integration, connection string) core.ConnectionMode {
@@ -501,7 +428,7 @@ func shouldHidePassiveNamedConnection(plan config.StaticConnectionPlan, name str
 	if strings.TrimSpace(conn.DisplayName) != "" {
 		return false
 	}
-	if len(connectionAuthTypes(conn.Auth, integrationAuthTypes)) != 0 {
+	if len(connectionAuthTypes(conn.Auth, nil)) != 0 {
 		return false
 	}
 	if len(conn.Auth.Credentials) != 0 {
@@ -555,20 +482,14 @@ func connectionDisplayName(name, configured string) string {
 	return userFacingConnectionName(name)
 }
 
-func resolvedIntegrationAuthTypes(prov core.Provider, authTypes []string, connections []connectionDefInfo) []string {
-	if len(authTypes) > 0 {
-		return authTypes
-	}
+func resolvedIntegrationAuthTypes(connections []connectionDefInfo) []string {
 	combined := make([]string, 0, 2)
 	for i := range connections {
 		connection := &connections[i]
 		combined = append(combined, connection.AuthTypes...)
 	}
-	if authTypes = userFacingAuthTypes(combined); len(authTypes) > 0 {
+	if authTypes := userFacingAuthTypes(combined); len(authTypes) > 0 {
 		return authTypes
-	}
-	if _, ok := prov.(core.OAuthProvider); ok {
-		return []string{"oauth"}
 	}
 	return []string{}
 }

--- a/gestaltd/internal/server/metrics_test.go
+++ b/gestaltd/internal/server/metrics_test.go
@@ -152,6 +152,19 @@ func TestConnectionAuthMetrics(t *testing.T) {
 			authURL:         "https://idp.example.test/authorize",
 		})
 		cfg.DefaultConnection = map[string]string{providerName: testDefaultConnection}
+		cfg.AppDefs = map[string]*config.ProviderEntry{
+			providerName: {
+				Connections: map[string]*config.ConnectionDef{
+					testDefaultConnection: {
+						Auth: config.ConnectionAuthDef{
+							Type:             providermanifestv1.AuthTypeOAuth2,
+							AuthorizationURL: "https://idp.example.test/authorize",
+							TokenURL:         "https://idp.example.test/token",
+						},
+					},
+				},
+			},
+		}
 		cfg.ConnectionAuth = testConnectionAuth(providerName, handler)
 		cfg.Services = testutil.NewStubServices(t)
 	})
@@ -482,6 +495,15 @@ func TestManualConnectionMetrics(t *testing.T) {
 		cfg.Services = testutil.NewStubServices(t)
 		cfg.Providers = testutil.NewProviderRegistry(t, &manualMetricsProvider{name: providerName})
 		cfg.DefaultConnection = map[string]string{providerName: testDefaultConnection}
+		cfg.AppDefs = map[string]*config.ProviderEntry{
+			providerName: {
+				Connections: map[string]*config.ConnectionDef{
+					testDefaultConnection: {
+						Auth: config.ConnectionAuthDef{Type: providermanifestv1.AuthTypeManual},
+					},
+				},
+			},
+		}
 	})
 	testutil.CloseOnCleanup(t, srv)
 

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -1966,6 +1966,18 @@ func testConnectionAuth(integration string, handler bootstrap.OAuthHandler) func
 	return func() map[string]map[string]bootstrap.OAuthHandler { return m }
 }
 
+func oauthConnectionDef(params map[string]config.ConnectionParamDef) *config.ConnectionDef {
+	return &config.ConnectionDef{
+		Mode: providermanifestv1.ConnectionModeSubject,
+		Auth: config.ConnectionAuthDef{
+			Type:             providermanifestv1.AuthTypeOAuth2,
+			AuthorizationURL: "https://provider.example/oauth/authorize",
+			TokenURL:         "https://provider.example/oauth/token",
+		},
+		ConnectionParams: params,
+	}
+}
+
 func oauthRefreshConnectionAuth(integration string, refreshFn func(context.Context, string) (*core.TokenResponse, error)) func() map[string]map[string]bootstrap.OAuthHandler {
 	return testConnectionAuth(integration, &testOAuthHandler{refreshTokenFn: refreshFn})
 }
@@ -2102,6 +2114,9 @@ func testPluginDefsForConnections(plugin string, connections ...string) map[stri
 		entry.Connections[connection] = &config.ConnectionDef{
 			ConnectionID: plugin + ":" + connection,
 			Mode:         providermanifestv1.ConnectionModeSubject,
+			Auth: config.ConnectionAuthDef{
+				Type: providermanifestv1.AuthTypeManual,
+			},
 		}
 	}
 	return map[string]*config.ProviderEntry{plugin: entry}
@@ -3933,6 +3948,7 @@ func TestListIntegrations(t *testing.T) {
 	stub := &coretesting.StubIntegration{N: "slack", DN: "Slack", Desc: "Team messaging"}
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.AppDefs = testPluginDefsForConnections("slack", "default")
 		cfg.Services = testutil.NewStubServices(t)
 	})
 	testutil.CloseOnCleanup(t, ts)
@@ -4087,11 +4103,25 @@ func TestListIntegrations_ConnectionStatusContract(t *testing.T) {
 		&stubManualProvider{StubIntegration: coretesting.StubIntegration{N: "manual-multi", DN: "Manual Multi"}},
 	)
 	pluginDefs := map[string]*config.ProviderEntry{
+		"manual-disconnected": {
+			Connections: map[string]*config.ConnectionDef{
+				testDefaultConnection: {
+					ConnectionID: "manual-disconnected:" + testDefaultConnection,
+					Mode:         providermanifestv1.ConnectionModeSubject,
+					Auth: config.ConnectionAuthDef{
+						Type: providermanifestv1.AuthTypeManual,
+					},
+				},
+			},
+		},
 		"manual-connected": {
 			Connections: map[string]*config.ConnectionDef{
 				testDefaultConnection: {
 					ConnectionID: "manual-connected:" + testDefaultConnection,
 					Mode:         providermanifestv1.ConnectionModeSubject,
+					Auth: config.ConnectionAuthDef{
+						Type: providermanifestv1.AuthTypeManual,
+					},
 				},
 			},
 		},
@@ -4100,6 +4130,9 @@ func TestListIntegrations_ConnectionStatusContract(t *testing.T) {
 				testDefaultConnection: {
 					ConnectionID: "manual-multi:" + testDefaultConnection,
 					Mode:         providermanifestv1.ConnectionModeSubject,
+					Auth: config.ConnectionAuthDef{
+						Type: providermanifestv1.AuthTypeManual,
+					},
 				},
 			},
 		},
@@ -4238,10 +4271,16 @@ func TestListIntegrations_StaleRefreshFailuresRequireReconnect(t *testing.T) {
 			testDefaultConnection: {
 				ConnectionID: "named-stale:" + testDefaultConnection,
 				Mode:         providermanifestv1.ConnectionModeSubject,
+				Auth: config.ConnectionAuthDef{
+					Type: providermanifestv1.AuthTypeManual,
+				},
 			},
 			"archive": {
 				ConnectionID: "named-stale:archive",
 				Mode:         providermanifestv1.ConnectionModeSubject,
+				Auth: config.ConnectionAuthDef{
+					Type: providermanifestv1.AuthTypeManual,
+				},
 			},
 		},
 	}
@@ -4351,6 +4390,31 @@ func TestListIntegrations_AuthTypes(t *testing.T) {
 	}
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, oauthStub, manualStub, mcpStub)
+		cfg.AppDefs = map[string]*config.ProviderEntry{
+			"oauth-svc": {
+				Connections: map[string]*config.ConnectionDef{
+					"default": {
+						ConnectionID: "oauth-svc:default",
+						Mode:         providermanifestv1.ConnectionModeSubject,
+						Auth: config.ConnectionAuthDef{
+							Type: providermanifestv1.AuthTypeOAuth2,
+						},
+					},
+				},
+			},
+			"manual-svc": {
+				Connections: map[string]*config.ConnectionDef{
+					"default": {
+						ConnectionID: "manual-svc:default",
+						Mode:         providermanifestv1.ConnectionModeSubject,
+						Auth: config.ConnectionAuthDef{
+							Type: providermanifestv1.AuthTypeManual,
+						},
+					},
+				},
+			},
+			"clickhouse": {},
+		}
 		cfg.Services = testutil.NewStubServices(t)
 	})
 	testutil.CloseOnCleanup(t, ts)
@@ -4527,14 +4591,11 @@ func TestListIntegrations_ShowsCredentialedConnectionsInUserFacingMetadata(t *te
 	if len(integrations) != 1 {
 		t.Fatalf("expected 1 integration, got %d", len(integrations))
 	}
-	if len(integrations[0].Connections) != 2 {
-		t.Fatalf("connections = %+v, want app and default user-facing connections", integrations[0].Connections)
+	if len(integrations[0].Connections) != 1 {
+		t.Fatalf("connections = %+v, want one declared default connection", integrations[0].Connections)
 	}
-	if integrations[0].Connections[0].Name != "app" {
-		t.Fatalf("first connection name = %q, want %q", integrations[0].Connections[0].Name, "app")
-	}
-	if integrations[0].Connections[1].Name != "default" {
-		t.Fatalf("second connection name = %q, want %q", integrations[0].Connections[1].Name, "default")
+	if integrations[0].Connections[0].Name != "default" {
+		t.Fatalf("connection name = %q, want %q", integrations[0].Connections[0].Name, "default")
 	}
 	for _, conn := range integrations[0].Connections {
 		if !reflect.DeepEqual(conn.AuthTypes, []string{"manual"}) {
@@ -4553,7 +4614,11 @@ func TestListIntegrations_ManualProvidersWithoutDeclaredCredentialsExposeGeneric
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
 		cfg.AppDefs = map[string]*config.ProviderEntry{
-			"linear": {},
+			"linear": {
+				Auth: &config.ConnectionAuthDef{
+					Type: providermanifestv1.AuthTypeManual,
+				},
+			},
 		}
 		cfg.Services = testutil.NewStubServices(t)
 	})
@@ -4852,100 +4917,6 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 		}
 	})
 
-	t.Run("composite wrappers preserve API metadata", func(t *testing.T) {
-		t.Parallel()
-
-		apiProv := &stubManualProviderWithCapabilities{
-			stubManualProvider: stubManualProvider{
-				StubIntegration: coretesting.StubIntegration{N: "docs", DN: "Docs"},
-			},
-			credentialFields: []core.CredentialFieldDef{
-				{Name: "api_key", Label: "API Key", Description: "Docs API key"},
-			},
-			connectionParams: map[string]core.ConnectionParamDef{
-				"tenant": {
-					Required:    true,
-					Description: "Tenant slug",
-					Default:     "acme",
-				},
-			},
-		}
-		prov := composite.New("docs", apiProv, &stubIntegrationWithSessionCatalog{
-			stubIntegrationWithOps: stubIntegrationWithOps{
-				StubIntegration: coretesting.StubIntegration{N: "docs-mcp", ConnMode: core.ConnectionModeNone},
-			},
-		})
-
-		ts := newTestServer(t, func(cfg *server.Config) {
-			cfg.Providers = testutil.NewProviderRegistry(t, prov)
-			cfg.AppDefs = map[string]*config.ProviderEntry{
-				"docs": {},
-			}
-			cfg.Services = testutil.NewStubServices(t)
-		})
-		testutil.CloseOnCleanup(t, ts)
-
-		req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps", nil)
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			t.Fatalf("request: %v", err)
-		}
-		defer func() { _ = resp.Body.Close() }()
-
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("expected 200, got %d", resp.StatusCode)
-		}
-
-		type credentialField struct {
-			Name        string `json:"name"`
-			Label       string `json:"label"`
-			Description string `json:"description"`
-		}
-		type connectionParam struct {
-			Required    bool   `json:"required"`
-			Description string `json:"description"`
-			Default     string `json:"default"`
-		}
-		var integrations []struct {
-			Name        string `json:"name"`
-			Connections []struct {
-				Name             string                     `json:"name"`
-				AuthTypes        []string                   `json:"authTypes"`
-				CredentialFields []credentialField          `json:"credentialFields"`
-				ConnectionParams map[string]connectionParam `json:"connectionParams"`
-			} `json:"connections"`
-		}
-		if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
-			t.Fatalf("decoding: %v", err)
-		}
-		if len(integrations) != 1 {
-			t.Fatalf("expected 1 integration, got %d", len(integrations))
-		}
-
-		wantFields := []credentialField{{Name: "api_key", Label: "API Key", Description: "Docs API key"}}
-		if len(integrations[0].Connections) != 1 {
-			t.Fatalf("connections = %+v, want one default connection", integrations[0].Connections)
-		}
-		if integrations[0].Connections[0].Name != config.AppConnectionAlias {
-			t.Fatalf("connection name = %q, want %q", integrations[0].Connections[0].Name, config.AppConnectionAlias)
-		}
-		if !reflect.DeepEqual(integrations[0].Connections[0].AuthTypes, []string{"manual"}) {
-			t.Fatalf("connection auth types = %v, want [manual]", integrations[0].Connections[0].AuthTypes)
-		}
-		if !reflect.DeepEqual(integrations[0].Connections[0].CredentialFields, wantFields) {
-			t.Fatalf("connection credential fields = %+v, want %+v", integrations[0].Connections[0].CredentialFields, wantFields)
-		}
-		if !reflect.DeepEqual(integrations[0].Connections[0].ConnectionParams, map[string]connectionParam{
-			"tenant": {
-				Required:    true,
-				Description: "Tenant slug",
-				Default:     "acme",
-			},
-		}) {
-			t.Fatalf("connection params = %+v", integrations[0].Connections[0].ConnectionParams)
-		}
-	})
-
 	t.Run("manifest-backed MCP passthrough without declared auth exposes no synthetic connection", func(t *testing.T) {
 		t.Parallel()
 
@@ -5140,7 +5111,11 @@ func TestListIntegrations_ConnectionInfosHideOAuthConnectionsWithoutHandler(t *t
 	plugin := &config.ProviderEntry{
 		Source: config.NewMetadataSource("https://example.invalid/github-com-acme-plugins-slack/v1.0.0/provider-release.yaml"),
 		Connections: map[string]*config.ConnectionDef{
-			"default": {},
+			"default": {
+				Auth: config.ConnectionAuthDef{
+					Type: providermanifestv1.AuthTypeOAuth2,
+				},
+			},
 		},
 	}
 
@@ -5228,60 +5203,6 @@ func TestListIntegrations_ConnectionInfosIncludeProviderManualAuth(t *testing.T)
 				Name  string `json:"name"`
 				Label string `json:"label"`
 			}{},
-		},
-		{
-			name: "empty auth type still exposes oauth",
-			provider: func(t *testing.T) core.Provider {
-				t.Helper()
-				return &stubDualAuthProvider{
-					StubIntegration: coretesting.StubIntegration{N: "example", DN: "Example"},
-				}
-			},
-			plugin: &config.ProviderEntry{
-				Auth: &config.ConnectionAuthDef{
-					Type:             "",
-					AuthorizationURL: "https://example.com/oauth/authorize",
-					TokenURL:         "https://example.com/oauth/token",
-				},
-			},
-			wantAuth: []string{"oauth", "manual"},
-			wantFields: []struct {
-				Name  string `json:"name"`
-				Label string `json:"label"`
-			}{
-				{Name: "api_token", Label: "API Token"},
-			},
-		},
-		{
-			name: "plugin auth unset uses provider auth types",
-			provider: func(t *testing.T) core.Provider {
-				t.Helper()
-				prov, err := declarative.Build(&declarative.Definition{
-					Provider:    "example",
-					DisplayName: "Example",
-					Auth:        declarative.AuthDef{Type: "manual"},
-					CredentialFields: []declarative.CredentialFieldDef{
-						{Name: "primary_token", Label: "Primary Token"},
-						{Name: "secondary_token", Label: "Secondary Token"},
-					},
-					Operations: map[string]declarative.OperationDef{
-						"list_items": {Method: http.MethodGet, Path: "/items"},
-					},
-				}, declarative.ConnectionDef{})
-				if err != nil {
-					t.Fatalf("Build: %v", err)
-				}
-				return prov
-			},
-			plugin:   &config.ProviderEntry{},
-			wantAuth: []string{"manual"},
-			wantFields: []struct {
-				Name  string `json:"name"`
-				Label string `json:"label"`
-			}{
-				{Name: "primary_token", Label: "Primary Token"},
-				{Name: "secondary_token", Label: "Secondary Token"},
-			},
 		},
 		{
 			name: "declared manual credential fields are exposed without synthetic auth inputs",
@@ -5469,7 +5390,17 @@ func TestListIntegrations_ShowsConnectedStatus(t *testing.T) {
 			},
 		}
 		cfg.Providers = testutil.NewProviderRegistry(t, stub, stub2)
-		cfg.AppDefs = testPluginDefsForConnections("slack", "default")
+		cfg.AppDefs = map[string]*config.ProviderEntry{
+			"slack": testPluginDefsForConnections("slack", "default")["slack"],
+			"github": {
+				Connections: map[string]*config.ConnectionDef{
+					testDefaultConnection: {
+						ConnectionID: "github:" + testDefaultConnection,
+						Mode:         providermanifestv1.ConnectionModeSubject,
+					},
+				},
+			},
+		}
 		cfg.Services = svc
 	})
 	testutil.CloseOnCleanup(t, ts)
@@ -6973,7 +6904,10 @@ func TestExecuteOperation_DeclarativeRESTConnectionSelectorRoutesCredentialAndOm
 		Spec: &providermanifestv1.Spec{
 			DefaultConnection: "default",
 			Connections: map[string]*providermanifestv1.ManifestConnectionDef{
-				"default": {Mode: providermanifestv1.ConnectionModeSubject},
+				"default": {
+					Mode: providermanifestv1.ConnectionModeSubject,
+					Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeBearer},
+				},
 				"bot": {
 					Mode: providermanifestv1.ConnectionModeSubject,
 					Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeBearer},
@@ -7054,6 +6988,9 @@ func TestExecuteOperation_DeclarativeRESTConnectionSelectorRoutesCredentialAndOm
 		Connections: map[string]*config.ConnectionDef{
 			"bot": {
 				Mode: providermanifestv1.ConnectionModeSubject,
+				Auth: config.ConnectionAuthDef{
+					Type: providermanifestv1.AuthTypeBearer,
+				},
 			},
 		},
 	}
@@ -8619,6 +8556,13 @@ func TestStartIntegrationOAuth(t *testing.T) {
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
 		cfg.DefaultConnection = map[string]string{"slack": testDefaultConnection}
+		cfg.AppDefs = map[string]*config.ProviderEntry{
+			"slack": {
+				Connections: map[string]*config.ConnectionDef{
+					testDefaultConnection: oauthConnectionDef(nil),
+				},
+			},
+		}
 		cfg.ConnectionAuth = testConnectionAuth("slack", handler)
 		cfg.AuditSink = invocation.NewSlogAuditSink(&auditBuf)
 		cfg.Services = testutil.NewStubServices(t)
@@ -8675,6 +8619,13 @@ func TestStartIntegrationOAuth(t *testing.T) {
 	invalidTS := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
 		cfg.DefaultConnection = map[string]string{"slack": testDefaultConnection}
+		cfg.AppDefs = map[string]*config.ProviderEntry{
+			"slack": {
+				Connections: map[string]*config.ConnectionDef{
+					testDefaultConnection: oauthConnectionDef(nil),
+				},
+			},
+		}
 		cfg.ConnectionAuth = testConnectionAuth("slack", handler)
 		cfg.AuditSink = invocation.NewSlogAuditSink(&invalidAuditBuf)
 		cfg.Services = testutil.NewStubServices(t)
@@ -8762,6 +8713,16 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 			}
 			cfg.Providers = testutil.NewProviderRegistry(t, stub)
 			cfg.DefaultConnection = map[string]string{"oauth-svc": testDefaultConnection}
+			cfg.AppDefs = map[string]*config.ProviderEntry{
+				"oauth-svc": {
+					Connections: map[string]*config.ConnectionDef{
+						testDefaultConnection: oauthConnectionDef(map[string]config.ConnectionParamDef{
+							"tenant_id":  {Required: true, From: "token_response", Field: "tenant.id"},
+							"account_id": {Required: true, From: "token_response", Field: "account.id"},
+						}),
+					},
+				},
+			}
 			cfg.ConnectionAuth = testConnectionAuth("oauth-svc", handler)
 			cfg.Services = svc
 			cfg.AuditSink = invocation.NewSlogAuditSink(&auditBuf)
@@ -8920,6 +8881,16 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 			}
 			cfg.Providers = testutil.NewProviderRegistry(t, stub)
 			cfg.DefaultConnection = map[string]string{"oauth-svc": testDefaultConnection}
+			cfg.AppDefs = map[string]*config.ProviderEntry{
+				"oauth-svc": {
+					Connections: map[string]*config.ConnectionDef{
+						testDefaultConnection: oauthConnectionDef(map[string]config.ConnectionParamDef{
+							"tenant_id":  {Required: true, From: "token_response", Field: "tenant.id"},
+							"account_id": {Required: true, From: "token_response", Field: "account.id"},
+						}),
+					},
+				},
+			}
 			cfg.ConnectionAuth = testConnectionAuth("oauth-svc", handler)
 			cfg.Services = svc
 		})
@@ -10232,6 +10203,13 @@ func TestIntegrationOAuthCallback_PKCEUsesVerifier(t *testing.T) {
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
 		cfg.DefaultConnection = map[string]string{"gitlab": testDefaultConnection}
+		cfg.AppDefs = map[string]*config.ProviderEntry{
+			"gitlab": {
+				Connections: map[string]*config.ConnectionDef{
+					testDefaultConnection: oauthConnectionDef(nil),
+				},
+			},
+		}
 		cfg.ConnectionAuth = testConnectionAuth("gitlab", handler)
 		cfg.Services = testutil.NewStubServices(t)
 	})
@@ -11313,6 +11291,14 @@ func TestStartOAuth_MultiConnection_SelectsByConnectionName(t *testing.T) {
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
 		cfg.DefaultConnection = map[string]string{"multi": "conn-a"}
+		cfg.AppDefs = map[string]*config.ProviderEntry{
+			"multi": {
+				Connections: map[string]*config.ConnectionDef{
+					"conn-a": oauthConnectionDef(nil),
+					"conn-b": oauthConnectionDef(nil),
+				},
+			},
+		}
 		cfg.ConnectionAuth = func() map[string]map[string]bootstrap.OAuthHandler {
 			return map[string]map[string]bootstrap.OAuthHandler{
 				"multi": {
@@ -11454,6 +11440,14 @@ func TestOAuthCallback_UsesStateConnection(t *testing.T) {
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
 		cfg.DefaultConnection = map[string]string{"multi": "conn-a"}
+		cfg.AppDefs = map[string]*config.ProviderEntry{
+			"multi": {
+				Connections: map[string]*config.ConnectionDef{
+					"conn-a": oauthConnectionDef(nil),
+					"conn-b": oauthConnectionDef(nil),
+				},
+			},
+		}
 		cfg.ConnectionAuth = func() map[string]map[string]bootstrap.OAuthHandler {
 			return map[string]map[string]bootstrap.OAuthHandler{
 				"multi": {
@@ -12901,6 +12895,17 @@ func TestConnectManual_MultiCredential(t *testing.T) {
 					StubIntegration: coretesting.StubIntegration{N: "multi-key-svc"},
 				}
 			},
+			pluginDefs: map[string]*config.ProviderEntry{
+				"multi-key-svc": {
+					Auth: &config.ConnectionAuthDef{
+						Type: providermanifestv1.AuthTypeManual,
+						Credentials: []config.CredentialFieldDef{
+							{Name: "api_key", Label: "API Key"},
+							{Name: "app_key", Label: "App Key"},
+						},
+					},
+				},
+			},
 			wantTokenData: map[string]string{
 				"api_key": "k1",
 				"app_key": "k2",
@@ -13057,6 +13062,9 @@ func TestConnectManual_TokenExchange(t *testing.T) {
 							{Name: "client_id", Label: "Client ID"},
 							{Name: "client_secret", Label: "Client Secret"},
 						},
+					},
+					ConnectionParams: map[string]config.ConnectionParamDef{
+						"account_id": {From: "token_response", Field: "account.id", Required: true},
 					},
 				},
 			}


### PR DESCRIPTION
## Summary

Use the selected configured connection definition as the source of truth for manual and OAuth auth setup instead of falling back to provider-wide auth metadata.

Manual connect, OAuth start, OAuth callback, and list-integrations now agree on which connections are actually configurable. A connection must be declared in the app or manifest connection plan before the server validates manual credentials, connection params, token exchange metadata, callback metadata, auth types, or top-level integration status.

This removes the stale provider-default path that could advertise a connectable integration or connection even though the setup endpoints would reject it. Tests now model explicit selected connection definitions and drop compatibility coverage for provider-default fallback behavior.

## Interfaces

```go
selected, ok := s.requireConfiguredConnection(w, integration, connection)
if !ok {
  return
}

connParams, ok := resolveConnectionParams(w, selected.ParamDefs, req.ConnectionParams)
```

```json
{
  "connections": [
    {
      "name": "default",
      "authTypes": ["manual"],
      "credentialFields": [{"name": "credential", "label": "Credential"}]
    }
  ]
}
```

## Runtime

The connect and OAuth handlers resolve the request connection through the static connection plan before accepting credential material. Provider-level `AuthTypes`, credential fields, and connection params no longer synthesize an app connection or supply params for an otherwise unconfigured selected connection.

List-integrations now uses the same configured connection definitions for auth metadata and status. That keeps UI actions aligned with the setup endpoints: if a selected connection is not configured for manual or OAuth auth, the list endpoint no longer advertises manual or OAuth connect actions for it.

## Test plan

- [x] `go test -count=1 ./gestaltd/internal/server -run 'TestConnectManual|TestStartOAuth|TestOAuthCallback|TestIntegrationOAuthCallback|TestConnectionAuthMetrics|TestListIntegrations_ConnectionInfos'`
- [x] `go test -count=1 ./gestaltd/internal/server -run 'TestListIntegrations_ConnectionStatusContract|TestListIntegrations_StaleRefreshFailuresRequireReconnect|TestListIntegrations_ShowsCredentialedConnectionsInUserFacingMetadata|TestListIntegrations_ManualProvidersWithoutDeclaredCredentialsExposeGenericField|TestExecuteOperation_DeclarativeRESTConnectionSelectorRoutesCredentialAndOmitsInternalParam|TestListIntegrations_AuthTypes|TestListIntegrations_ConnectionInfos'`
- [x] `go test ./gestaltd/internal/server`
