### PR TITLE
[codex] Bump default UI provider

### DIFF
--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -39,7 +39,7 @@ const (
 	DefaultExternalCredentialsProvider = DefaultProviderRepo + "/externalcredentials/default"
 	DefaultExternalCredentialsVersion  = "0.0.1-alpha.1"
 	DefaultUIProvider                  = DefaultProviderRepo + "/ui/default"
-	DefaultUIVersion                   = "0.0.1"
+	DefaultUIVersion                   = "0.0.2-alpha.1"
 	DefaultProviderInstance            = "default"
 )
 


### PR DESCRIPTION
## Summary

Bump the generated no-config `gestaltd` default UI provider from `0.0.1` to the latest published `0.0.2-alpha.1` release.

This only affects newly generated `~/.gestaltd/config.yaml` files. Existing configs keep their pinned UI provider source.

## Validation

- `go test ./internal/operator -run 'TestDefault.*Config|TestResolveStartConfigPathsGeneratesDefaultLocalSourceConfig'`
- `go test ./internal/config -run 'TestLoadConfigSelectsDefaultProvidersFromNamedMaps|Test.*UI'`