### PR TITLE
Return missing credentials as app invoke results

### DIFF
--- a/gestaltd/internal/bootstrap/executable_app_test.go
+++ b/gestaltd/internal/bootstrap/executable_app_test.go
@@ -5165,6 +5165,51 @@ func TestPluginInvokesGraphQLSurface(t *testing.T) {
 	if variables["team"] != "eng" {
 		t.Fatalf("body.echo.variables.team = %#v, want %q", variables["team"], "eng")
 	}
+
+	missingUser := newNestedInvokeUser(t, harness, ctx, "nested-graphql-surface-missing@test.com")
+	storeNestedInvokeToken(t, harness, ctx, missingUser.ID, "caller", "work", "default")
+	missingResult, err := harness.invoker.Invoke(
+		invocation.WithConnection(context.Background(), "work"),
+		&principal.Principal{
+			UserID: missingUser.ID,
+			Kind:   principal.KindUser,
+			Source: principal.SourceSession,
+			Scopes: []string{"caller", "linear"},
+		},
+		"caller",
+		"",
+		"invoke_plugin_graphql",
+		map[string]any{
+			"app":      "linear",
+			"document": document,
+			"variables": map[string]any{
+				"team": "eng",
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("Invoke(caller.invoke_plugin_graphql missing credential): %v", err)
+	}
+	var missingGot struct {
+		OK     bool   `json:"ok"`
+		Status int    `json:"status"`
+		Body   any    `json:"body"`
+		Error  string `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(missingResult.Body), &missingGot); err != nil {
+		t.Fatalf("json.Unmarshal missing credential: %v", err)
+	}
+	if !missingGot.OK {
+		t.Fatalf("expected missing credential operation result, got error: %+v", missingGot)
+	}
+	if missingGot.Status != http.StatusPreconditionFailed {
+		t.Fatalf("missing credential nested status = %d, want %d", missingGot.Status, http.StatusPreconditionFailed)
+	}
+	body, ok := missingGot.Body.(string)
+	if !ok || !strings.Contains(body, `no external credential stored for integration "linear"`) {
+		t.Fatalf("missing credential body = %#v, want missing linear credential", missingGot.Body)
+	}
+
 	if got := introspectionCalls.Load(); got != 0 {
 		t.Fatalf("introspection calls = %d, want 0", got)
 	}
@@ -5317,11 +5362,13 @@ func TestPluginInvokesRejectInvalidTargetRequests(t *testing.T) {
 		instance   string
 	}
 	tests := []struct {
-		name      string
-		email     string
-		tokens    []tokenSpec
-		params    map[string]any
-		wantError string
+		name              string
+		email             string
+		tokens            []tokenSpec
+		params            map[string]any
+		wantStatus        int
+		wantBodySubstring string
+		wantError         string
 	}{
 		{
 			name:  "invalid invocation token",
@@ -5338,7 +5385,7 @@ func TestPluginInvokesRejectInvalidTargetRequests(t *testing.T) {
 			wantError: "invalid or expired",
 		},
 		{
-			name:  "missing target token",
+			name:  "missing target credential returns operation result",
 			email: "nested-no-target-token@test.com",
 			tokens: []tokenSpec{
 				{plugin: "caller", connection: "work", instance: "default"},
@@ -5347,7 +5394,8 @@ func TestPluginInvokesRejectInvalidTargetRequests(t *testing.T) {
 				"app":       "example",
 				"operation": "request_context",
 			},
-			wantError: "code = FailedPrecondition",
+			wantStatus:        http.StatusPreconditionFailed,
+			wantBodySubstring: `no external credential stored for integration "example"`,
 		},
 		{
 			name:  "ambiguous target instance",
@@ -5395,9 +5443,27 @@ func TestPluginInvokesRejectInvalidTargetRequests(t *testing.T) {
 				t.Fatalf("Invoke(caller.invoke_plugin): %v", err)
 			}
 
-			var got invokePluginEnvelope
+			var got struct {
+				OK     bool   `json:"ok"`
+				Status int    `json:"status"`
+				Body   any    `json:"body"`
+				Error  string `json:"error"`
+			}
 			if err := json.Unmarshal([]byte(result.Body), &got); err != nil {
 				t.Fatalf("json.Unmarshal: %v", err)
+			}
+			if tc.wantError == "" {
+				if !got.OK {
+					t.Fatalf("expected success envelope, got error: %+v", got)
+				}
+				if got.Status != tc.wantStatus {
+					t.Fatalf("nested status = %d, want %d", got.Status, tc.wantStatus)
+				}
+				body, ok := got.Body.(string)
+				if !ok || !strings.Contains(body, tc.wantBodySubstring) {
+					t.Fatalf("body = %#v, want substring %q", got.Body, tc.wantBodySubstring)
+				}
+				return
 			}
 			if got.OK {
 				t.Fatalf("expected error envelope, got success: %+v", got)

--- a/gestaltd/services/appaccess/app_server.go
+++ b/gestaltd/services/appaccess/app_server.go
@@ -94,18 +94,7 @@ func (s *AppServer) Invoke(ctx context.Context, req *proto.AppInvokeRequest) (*p
 	)
 
 	result, err := s.invoker.Invoke(invokeCtx, invokePrincipal, targetApp, instance, targetOperation, params)
-	if err != nil {
-		return nil, invocationStatusError(err)
-	}
-	if result == nil {
-		return nil, status.Error(codes.Internal, "plugin invocation returned no result")
-	}
-
-	return &proto.OperationResult{
-		Status:  int32(result.Status),
-		Headers: protoutil.StringSlicesToProto(result.Headers),
-		Body:    result.Body,
-	}, nil
+	return appOperationResult(result, err)
 }
 
 func (s *AppServer) InvokeGraphQL(ctx context.Context, req *proto.AppInvokeGraphQLRequest) (*proto.OperationResult, error) {
@@ -146,18 +135,7 @@ func (s *AppServer) InvokeGraphQL(ctx context.Context, req *proto.AppInvokeGraph
 		Document:  document,
 		Variables: variables,
 	})
-	if err != nil {
-		return nil, invocationStatusError(err)
-	}
-	if result == nil {
-		return nil, status.Error(codes.Internal, "plugin invocation returned no result")
-	}
-
-	return &proto.OperationResult{
-		Status:  int32(result.Status),
-		Headers: protoutil.StringSlicesToProto(result.Headers),
-		Body:    result.Body,
-	}, nil
+	return appOperationResult(result, err)
 }
 
 func (s *AppServer) tokenContextForInvoke(req *proto.AppInvokeRequest, targetApp, targetOperation string) (invocationTokenContext, error) {
@@ -239,6 +217,32 @@ func prepareInvocationSelectors(ctx context.Context, tokenCtx invocationTokenCon
 	return restoreInvocationTokenContext(ctx, tokenCtx, connection), instance, nil
 }
 
+func appOperationResult(result *core.OperationResult, err error) (*proto.OperationResult, error) {
+	if err != nil {
+		// Some target invocation errors are operation-level failures so SDK callers can
+		// inspect status/body; transport, authz, and malformed invoke errors remain RPC errors.
+		if statusCode, ok := invocation.OperationErrorResultStatus(err); ok {
+			return &proto.OperationResult{
+				Status: int32(statusCode),
+				Body:   err.Error(),
+			}, nil
+		}
+		return nil, invocationStatusError(err)
+	}
+	if result == nil {
+		return nil, status.Error(codes.Internal, "plugin invocation returned no result")
+	}
+	return coreOperationResultToProto(result), nil
+}
+
+func coreOperationResultToProto(result *core.OperationResult) *proto.OperationResult {
+	return &proto.OperationResult{
+		Status:  int32(result.Status),
+		Headers: protoutil.StringSlicesToProto(result.Headers),
+		Body:    result.Body,
+	}
+}
+
 func invocationStatusError(err error) error {
 	switch {
 	case err == nil:
@@ -251,7 +255,7 @@ func invocationStatusError(err error) error {
 		return status.Error(codes.NotFound, err.Error())
 	case errors.Is(err, invocation.ErrInvalidInvocation):
 		return status.Error(codes.InvalidArgument, err.Error())
-	case errors.Is(err, invocation.ErrNoCredential):
+	case errors.Is(err, invocation.ErrNoCredential), errors.Is(err, invocation.ErrReconnectRequired):
 		return status.Error(codes.FailedPrecondition, err.Error())
 	case errors.Is(err, invocation.ErrAmbiguousInstance):
 		return status.Error(codes.Aborted, err.Error())

--- a/gestaltd/services/invocation/metrics.go
+++ b/gestaltd/services/invocation/metrics.go
@@ -98,12 +98,15 @@ func operationResultStatus(result *core.OperationResult, err error) int {
 	if result != nil && validHTTPStatus(result.Status) {
 		return result.Status
 	}
-	if err == nil {
-		return 0
-	}
+	return OperationErrorHTTPStatus(err)
+}
 
+// OperationErrorHTTPStatus maps invocation sentinel errors to their HTTP-facing status.
+func OperationErrorHTTPStatus(err error) int {
 	var upstreamErr *apiexec.UpstreamHTTPError
 	switch {
+	case err == nil:
+		return 0
 	case errors.Is(err, ErrProviderNotFound), errors.Is(err, ErrOperationNotFound):
 		return http.StatusNotFound
 	case errors.Is(err, ErrNotAuthenticated):
@@ -122,6 +125,17 @@ func operationResultStatus(result *core.OperationResult, err error) int {
 		return upstreamErr.Status
 	default:
 		return http.StatusBadGateway
+	}
+}
+
+// OperationErrorResultStatus reports invocation errors that should be returned to
+// app SDK callers as operation results instead of transport errors.
+func OperationErrorResultStatus(err error) (int, bool) {
+	switch {
+	case errors.Is(err, ErrNoCredential), errors.Is(err, ErrReconnectRequired):
+		return OperationErrorHTTPStatus(err), true
+	default:
+		return 0, false
 	}
 }
 


### PR DESCRIPTION
## Summary

Returns target app credential-precondition failures through the app SDK as operation results instead of surfacing them as app-access transport errors.

When an app invokes another app and the target credential cannot be resolved because the subject has no credential or must reconnect, gestaltd now returns a `412` `OperationResult` with the original error body. Other invoke failures, including authorization denial, malformed invoke requests, missing providers, missing operations, recursion limits, and ambiguous instances, remain RPC errors.

This lets downstream apps degrade missing connections using the same status/body path they already use for ordinary operation results. The behavior stays generic and provider-agnostic, so apps like Oncall can handle missing Slack/GitHub/PagerDuty/Linear credentials without adding provider-specific logic to gestaltd.

## Interfaces

```go
func OperationErrorHTTPStatus(err error) int

func OperationErrorResultStatus(err error) (int, bool)
```

```go
func appOperationResult(result *core.OperationResult, err error) (*proto.OperationResult, error)
```

```proto
service App {
  rpc Invoke(AppInvokeRequest) returns (OperationResult);
  rpc InvokeGraphQL(AppInvokeGraphQLRequest) returns (OperationResult);
}
```

## Runtime

The app-access host now finalizes both `Invoke` and `InvokeGraphQL` through the same result conversion path.

`ErrNoCredential` and `ErrReconnectRequired` are classified as operation-level failures by `OperationErrorResultStatus`, then returned to SDK callers as `OperationResult` values. Transport, authorization, request-shape, provider lookup, and recursion failures continue to use the existing RPC error path.

The existing nested app-invocation functional tests now cover both REST operation invokes and GraphQL surface invokes where the target credential is missing.