### PR TITLE
Allow omitted agent provider names in TypeScript SDK

### DIFF
--- a/sdk/typescript/src/agent-access.ts
+++ b/sdk/typescript/src/agent-access.ts
@@ -63,7 +63,7 @@ export interface AgentWorkspace {
 
 /** Shape accepted when creating an agent session through the agent facade. */
 export interface AgentCreateSession {
-  providerName: string;
+  providerName?: string | undefined;
   model?: string | undefined;
   clientRef?: string | undefined;
   metadata?: JsonObjectInput | undefined;
@@ -198,7 +198,7 @@ class AgentImpl implements Agent {
   ): Promise<AgentSession> {
     return agentSessionFromProto(
       await this.client.createSession({
-        providerName: request.providerName,
+        providerName: request.providerName ?? "",
         model: request.model ?? "",
         clientRef: request.clientRef ?? "",
         metadata: optionalStruct(request.metadata),

--- a/sdk/typescript/tests/agent-access.transport.test.ts
+++ b/sdk/typescript/tests/agent-access.transport.test.ts
@@ -263,7 +263,6 @@ test("Agent forwards invocation tokens across session, turn, and interaction cal
 
     const fromHandle = new Agent("invocation-token-123");
     const session = await fromHandle.createSession({
-      providerName: "basic",
       model: "gpt-test",
       clientRef: "cli-session-1",
       metadata: {
@@ -344,7 +343,7 @@ test("Agent forwards invocation tokens across session, turn, and interaction cal
       {
         method: "createSession",
         invocationToken: "invocation-token-123",
-        providerName: "basic",
+        providerName: "",
       },
       {
         method: "getSession",


### PR DESCRIPTION
## Summary

- Makes `AgentCreateSession.providerName` optional in the TypeScript SDK facade.
- Defaults omitted provider names to the existing empty-string sentinel before forwarding to the agent host service.
- Updates the existing agent transport test to exercise create-session calls without an explicit provider name.

## Test plan

- [x] `cd sdk/typescript && bun run check`