### PR TITLE
Apply named connection auth mappings for declarative providers

### DIFF
--- a/gestaltd/services/apps/declarative/auth_mapping.go
+++ b/gestaltd/services/apps/declarative/auth_mapping.go
@@ -4,11 +4,20 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+
+	"github.com/valon-technologies/gestalt/server/services/egress"
 )
+
+func AuthMappingTokenParser(mapping *AuthMappingDef) egress.TokenParser {
+	if mapping == nil || (len(mapping.Headers) == 0 && mapping.Basic == nil) {
+		return nil
+	}
+	return MappedCredentialParser(mapping)
+}
 
 // MappedCredentialParser maps a structured credential JSON token into request
 // auth material according to an authMapping definition.
-func MappedCredentialParser(mapping *AuthMappingDef) func(string) (string, map[string]string, error) {
+func MappedCredentialParser(mapping *AuthMappingDef) egress.TokenParser {
 	return func(token string) (string, map[string]string, error) {
 		var (
 			tokenData map[string]any

--- a/gestaltd/services/apps/declarative/build.go
+++ b/gestaltd/services/apps/declarative/build.go
@@ -122,20 +122,19 @@ func Build(def *Definition, conn ConnectionDef, opts ...BuildOption) (core.Provi
 		}
 	}
 
-	switch {
-	case def.AuthMapping != nil && (len(def.AuthMapping.Headers) > 0 || def.AuthMapping.Basic != nil):
+	if parser := AuthMappingTokenParser(def.AuthMapping); parser != nil {
 		if base.AuthStyle != AuthStyleBasic {
 			if def.AuthMapping.Basic != nil {
 				return nil, fmt.Errorf("%s: authMapping.basic requires authStyle basic", def.Provider)
 			}
 		}
-		base.TokenParser = MappedCredentialParser(def.AuthMapping)
-	case def.AuthHeader != "":
+		base.TokenParser = parser
+	} else if def.AuthHeader != "" {
 		headerName := def.AuthHeader
 		base.TokenParser = func(token string) (string, map[string]string, error) {
 			return "", map[string]string{headerName: token}, nil
 		}
-	case def.TokenPrefix != "":
+	} else if def.TokenPrefix != "" {
 		prefix := def.TokenPrefix
 		base.TokenParser = func(token string) (string, map[string]string, error) {
 			return prefix + token, nil, nil

--- a/gestaltd/services/apps/declarative_provider.go
+++ b/gestaltd/services/apps/declarative_provider.go
@@ -13,10 +13,13 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	integration "github.com/valon-technologies/gestalt/server/services/apps/declarative"
+	"github.com/valon-technologies/gestalt/server/services/egress"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
 )
 
 const declarativeHTTPTimeout = 30 * time.Second
 const declarativeJSONContentType = "application/json; charset=utf-8"
+const declarativeDefaultConnection = "default"
 
 type declarativeOptions struct {
 	displayName          string
@@ -70,6 +73,7 @@ type DeclarativeProvider struct {
 	operationConnections map[string]string
 	connectionSelectors  map[string]core.OperationConnectionSelector
 	operationLocks       map[string]bool
+	tokenParsers         map[string]egress.TokenParser
 }
 
 func NewDeclarativeProvider(manifest *providermanifestv1.Manifest, httpClient *http.Client, opts ...DeclarativeProviderOption) (*DeclarativeProvider, error) {
@@ -120,9 +124,6 @@ func NewDeclarativeProvider(manifest *providermanifestv1.Manifest, httpClient *h
 	if auth != nil {
 		authType = auth.Type
 		authorizationURL = auth.AuthorizationURL
-		if auth.AuthMapping != nil && (len(auth.AuthMapping.Headers) > 0 || auth.AuthMapping.Basic != nil) {
-			base.TokenParser = integration.MappedCredentialParser(auth.AuthMapping)
-		}
 	}
 	base.SetCatalog(cat)
 
@@ -133,6 +134,7 @@ func NewDeclarativeProvider(manifest *providermanifestv1.Manifest, httpClient *h
 		operationConnections: maps.Clone(options.operationConnections),
 		connectionSelectors:  cloneOperationConnectionSelectors(options.connectionSelectors),
 		operationLocks:       maps.Clone(options.operationLocks),
+		tokenParsers:         connectionTokenParsers(manifest.Spec.Connections),
 	}, nil
 }
 
@@ -144,7 +146,11 @@ func (p *DeclarativeProvider) Execute(ctx context.Context, operation string, par
 	if !declarativeHasOperation(p.Base.Catalog(), operation) {
 		return &core.OperationResult{Status: http.StatusNotFound, Body: `{"error":"unknown operation"}`}, nil
 	}
-	return p.Base.Execute(ctx, operation, params, token)
+	base, err := p.baseForConnection(ctx, operation, params)
+	if err != nil {
+		return nil, err
+	}
+	return base.Execute(ctx, operation, params, token)
 }
 
 func (p *DeclarativeProvider) ConnectionForOperation(operation string) string {
@@ -169,6 +175,68 @@ func (p *DeclarativeProvider) OperationConnectionOverrideAllowed(operation strin
 		}
 	}
 	return !p.operationLocks[operation]
+}
+
+func (p *DeclarativeProvider) baseForConnection(ctx context.Context, operation string, params map[string]any) (*integration.Base, error) {
+	connection, resolved, err := p.connectionForExecution(ctx, operation, params)
+	if err != nil {
+		return nil, err
+	}
+	if !resolved {
+		connection = declarativeDefaultConnection
+	}
+	base := *p.Base
+	if parser, ok := p.tokenParsers[connection]; ok {
+		base.TokenParser = parser
+	}
+	return &base, nil
+}
+
+func (p *DeclarativeProvider) connectionForExecution(ctx context.Context, operation string, params map[string]any) (string, bool, error) {
+	for _, connection := range []string{
+		invocation.CredentialContextFromContext(ctx).Connection,
+		invocation.ConnectionFromContext(ctx),
+	} {
+		connection = core.ResolveConnectionAlias(strings.TrimSpace(connection))
+		if connection == "" {
+			continue
+		}
+		return connection, true, nil
+	}
+	connection, err := p.ResolveConnectionForOperation(operation, params)
+	if err != nil {
+		return "", false, err
+	}
+	connection = core.ResolveConnectionAlias(strings.TrimSpace(connection))
+	if connection == "" {
+		return "", false, nil
+	}
+	return connection, true, nil
+}
+
+func connectionTokenParsers(connections map[string]*providermanifestv1.ManifestConnectionDef) map[string]egress.TokenParser {
+	if len(connections) == 0 {
+		return nil
+	}
+	parsers := make(map[string]egress.TokenParser)
+	for name, conn := range connections {
+		if conn == nil {
+			continue
+		}
+		name = core.ResolveConnectionAlias(strings.TrimSpace(name))
+		if name == "" {
+			continue
+		}
+		if conn.Auth != nil {
+			parsers[name] = integration.AuthMappingTokenParser(conn.Auth.AuthMapping)
+		} else {
+			parsers[name] = nil
+		}
+	}
+	if len(parsers) == 0 {
+		return nil
+	}
+	return parsers
 }
 
 func selectorConnection(selector core.OperationConnectionSelector, params map[string]any) (string, bool, error) {

--- a/gestaltd/services/apps/declarative_provider_test.go
+++ b/gestaltd/services/apps/declarative_provider_test.go
@@ -7,79 +7,268 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
 )
 
-func TestDeclarativeProvider_POSTUsesExplicitJSONContentType(t *testing.T) {
+func TestDeclarativeProvider_HTTPRequestMaterialization(t *testing.T) {
 	t.Parallel()
 
-	var gotContentType string
-	var gotHeader string
-	var gotBody map[string]any
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotContentType = r.Header.Get("Content-Type")
-		gotHeader = r.Header.Get("X-Test")
-		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+	t.Run("post uses explicit JSON content type", func(t *testing.T) {
+		var gotContentType string
+		var gotHeader string
+		var gotBody map[string]any
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotContentType = r.Header.Get("Content-Type")
+			gotHeader = r.Header.Get("X-Test")
+			_ = json.NewDecoder(r.Body).Decode(&gotBody)
 
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
-	}))
-	testutil.CloseOnCleanup(t, srv)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		}))
+		testutil.CloseOnCleanup(t, srv)
 
-	manifest := &providermanifestv1.Manifest{
-		Kind:    providermanifestv1.KindApp,
-		Source:  "github.com/test/declarative",
-		Version: "0.0.1-alpha.1",
-		Spec: &providermanifestv1.Spec{
-			Headers: map[string]string{
-				"Content-Type": "text/plain",
-				"X-Test":       "kept",
-			},
-			Surfaces: &providermanifestv1.ProviderSurfaces{
-				REST: &providermanifestv1.RESTSurface{
-					BaseURL: srv.URL,
-					Operations: []providermanifestv1.ProviderOperation{{
-						Name:   "chat.postMessage",
-						Method: http.MethodPost,
-						Path:   "/api/chat.postMessage",
-						Tags:   []string{"chat", "message"},
-						Parameters: []providermanifestv1.ProviderParameter{
-							{Name: "channel", Type: "string", In: "body", Required: true},
-							{Name: "text", Type: "string", In: "body", Required: true},
-						},
-					}},
+		manifest := &providermanifestv1.Manifest{
+			Kind:    providermanifestv1.KindApp,
+			Source:  "github.com/test/declarative",
+			Version: "0.0.1-alpha.1",
+			Spec: &providermanifestv1.Spec{
+				Headers: map[string]string{
+					"Content-Type": "text/plain",
+					"X-Test":       "kept",
+				},
+				Surfaces: &providermanifestv1.ProviderSurfaces{
+					REST: &providermanifestv1.RESTSurface{
+						BaseURL: srv.URL,
+						Operations: []providermanifestv1.ProviderOperation{{
+							Name:   "chat.postMessage",
+							Method: http.MethodPost,
+							Path:   "/api/chat.postMessage",
+							Tags:   []string{"chat", "message"},
+							Parameters: []providermanifestv1.ProviderParameter{
+								{Name: "channel", Type: "string", In: "body", Required: true},
+								{Name: "text", Type: "string", In: "body", Required: true},
+							},
+						}},
+					},
 				},
 			},
-		},
-	}
+		}
 
-	prov, err := NewDeclarativeProvider(manifest, srv.Client())
-	if err != nil {
-		t.Fatalf("NewDeclarativeProvider: %v", err)
-	}
+		prov, err := NewDeclarativeProvider(manifest, srv.Client())
+		if err != nil {
+			t.Fatalf("NewDeclarativeProvider: %v", err)
+		}
 
-	_, err = prov.Execute(context.Background(), "chat.postMessage", map[string]any{
-		"channel": "D024BGTKK33",
-		"text":    "hello",
-	}, "")
-	if err != nil {
-		t.Fatalf("Execute: %v", err)
-	}
+		_, err = prov.Execute(context.Background(), "chat.postMessage", map[string]any{
+			"channel": "D024BGTKK33",
+			"text":    "hello",
+		}, "")
+		if err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
 
-	if gotContentType != declarativeJSONContentType {
-		t.Fatalf("Content-Type = %q, want %q", gotContentType, declarativeJSONContentType)
-	}
-	if gotHeader != "kept" {
-		t.Fatalf("X-Test = %q, want kept", gotHeader)
-	}
-	if gotBody["channel"] != "D024BGTKK33" {
-		t.Fatalf("body[channel] = %v, want D024BGTKK33", gotBody["channel"])
-	}
-	if gotBody["text"] != "hello" {
-		t.Fatalf("body[text] = %v, want hello", gotBody["text"])
-	}
-	if got := prov.Catalog().Operations[0].Tags; len(got) != 2 || got[0] != "chat" || got[1] != "message" {
-		t.Fatalf("catalog operation tags = %#v, want chat/message", got)
-	}
+		if gotContentType != declarativeJSONContentType {
+			t.Fatalf("Content-Type = %q, want %q", gotContentType, declarativeJSONContentType)
+		}
+		if gotHeader != "kept" {
+			t.Fatalf("X-Test = %q, want kept", gotHeader)
+		}
+		if gotBody["channel"] != "D024BGTKK33" {
+			t.Fatalf("body[channel] = %v, want D024BGTKK33", gotBody["channel"])
+		}
+		if gotBody["text"] != "hello" {
+			t.Fatalf("body[text] = %v, want hello", gotBody["text"])
+		}
+		if got := prov.Catalog().Operations[0].Tags; len(got) != 2 || got[0] != "chat" || got[1] != "message" {
+			t.Fatalf("catalog operation tags = %#v, want chat/message", got)
+		}
+	})
+
+	t.Run("named connection auth mapping", func(t *testing.T) {
+		var gotAPIKey string
+		var gotDefaultKey string
+		var gotAuthorization string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotAPIKey = r.Header.Get("X-API-Key")
+			gotDefaultKey = r.Header.Get("X-Default-Key")
+			gotAuthorization = r.Header.Get("Authorization")
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		}))
+		testutil.CloseOnCleanup(t, srv)
+
+		manifest := &providermanifestv1.Manifest{
+			Kind:    providermanifestv1.KindApp,
+			Source:  "github.com/test/declarative",
+			Version: "0.0.1-alpha.1",
+			Spec: &providermanifestv1.Spec{
+				Connections: map[string]*providermanifestv1.ManifestConnectionDef{
+					"default": {
+						Mode: providermanifestv1.ConnectionModeSubject,
+						Auth: &providermanifestv1.ProviderAuth{
+							Type: providermanifestv1.AuthTypeManual,
+							Credentials: []providermanifestv1.CredentialField{{
+								Name:  "api_key",
+								Label: "API Key",
+							}},
+							AuthMapping: &providermanifestv1.AuthMapping{
+								Headers: map[string]providermanifestv1.AuthValue{
+									"X-Default-Key": {
+										ValueFrom: &providermanifestv1.AuthValueFrom{
+											CredentialFieldRef: &providermanifestv1.CredentialFieldRef{Name: "api_key"},
+										},
+									},
+								},
+							},
+						},
+					},
+					"plain": {
+						Mode: providermanifestv1.ConnectionModeSubject,
+						Auth: &providermanifestv1.ProviderAuth{
+							Type: providermanifestv1.AuthTypeBearer,
+						},
+					},
+					"prod": {
+						Mode: providermanifestv1.ConnectionModeSubject,
+						Auth: &providermanifestv1.ProviderAuth{
+							Type: providermanifestv1.AuthTypeManual,
+							Credentials: []providermanifestv1.CredentialField{{
+								Name:  "api_key",
+								Label: "API Key",
+							}},
+							AuthMapping: &providermanifestv1.AuthMapping{
+								Headers: map[string]providermanifestv1.AuthValue{
+									"X-API-Key": {
+										ValueFrom: &providermanifestv1.AuthValueFrom{
+											CredentialFieldRef: &providermanifestv1.CredentialFieldRef{Name: "api_key"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Surfaces: &providermanifestv1.ProviderSurfaces{
+					REST: &providermanifestv1.RESTSurface{
+						BaseURL: srv.URL,
+						Operations: []providermanifestv1.ProviderOperation{{
+							Name:   "schema.versions",
+							Method: http.MethodGet,
+							Path:   "/v1/schema/versions",
+						}},
+					},
+				},
+			},
+		}
+		token := `{"api_key":"prod-key"}`
+
+		t.Run("default connection fallback", func(t *testing.T) {
+			gotAPIKey = ""
+			gotDefaultKey = ""
+			gotAuthorization = ""
+			prov, err := NewDeclarativeProvider(manifest, srv.Client())
+			if err != nil {
+				t.Fatalf("NewDeclarativeProvider: %v", err)
+			}
+
+			if _, err := prov.Execute(context.Background(), "schema.versions", nil, `{"api_key":"default-key"}`); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+
+			if gotDefaultKey != "default-key" {
+				t.Fatalf("X-Default-Key = %q, want default-key", gotDefaultKey)
+			}
+			if gotAPIKey != "" {
+				t.Fatalf("X-API-Key = %q, want empty", gotAPIKey)
+			}
+			if gotAuthorization != "" {
+				t.Fatalf("Authorization = %q, want empty", gotAuthorization)
+			}
+		})
+
+		t.Run("credential context", func(t *testing.T) {
+			gotAPIKey = ""
+			gotDefaultKey = ""
+			gotAuthorization = ""
+			prov, err := NewDeclarativeProvider(manifest, srv.Client())
+			if err != nil {
+				t.Fatalf("NewDeclarativeProvider: %v", err)
+			}
+			ctx := invocation.WithCredentialContext(context.Background(), invocation.CredentialContext{
+				Mode:       core.ConnectionModeSubject,
+				SubjectID:  "service_account:data-schema-explorer",
+				Connection: "prod",
+				Instance:   "default",
+			})
+
+			if _, err := prov.Execute(ctx, "schema.versions", nil, token); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+
+			if gotAPIKey != "prod-key" {
+				t.Fatalf("X-API-Key = %q, want prod-key", gotAPIKey)
+			}
+			if gotDefaultKey != "" {
+				t.Fatalf("X-Default-Key = %q, want empty", gotDefaultKey)
+			}
+		})
+
+		t.Run("operation connection fallback", func(t *testing.T) {
+			gotAPIKey = ""
+			gotDefaultKey = ""
+			gotAuthorization = ""
+			prov, err := NewDeclarativeProvider(
+				manifest,
+				srv.Client(),
+				WithDeclarativeOperationConnections(map[string]string{"schema.versions": "prod"}, nil, nil),
+			)
+			if err != nil {
+				t.Fatalf("NewDeclarativeProvider: %v", err)
+			}
+
+			if _, err := prov.Execute(context.Background(), "schema.versions", nil, token); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+
+			if gotAPIKey != "prod-key" {
+				t.Fatalf("X-API-Key = %q, want prod-key", gotAPIKey)
+			}
+			if gotDefaultKey != "" {
+				t.Fatalf("X-Default-Key = %q, want empty", gotDefaultKey)
+			}
+		})
+
+		t.Run("unmapped connection uses generic credential materialization", func(t *testing.T) {
+			gotAPIKey = ""
+			gotDefaultKey = ""
+			gotAuthorization = ""
+			prov, err := NewDeclarativeProvider(manifest, srv.Client())
+			if err != nil {
+				t.Fatalf("NewDeclarativeProvider: %v", err)
+			}
+			ctx := invocation.WithCredentialContext(context.Background(), invocation.CredentialContext{
+				Mode:       core.ConnectionModeSubject,
+				SubjectID:  "service_account:data-schema-explorer",
+				Connection: "plain",
+				Instance:   "default",
+			})
+
+			if _, err := prov.Execute(ctx, "schema.versions", nil, "plain-token"); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+
+			if gotAuthorization != "Bearer plain-token" {
+				t.Fatalf("Authorization = %q, want Bearer plain-token", gotAuthorization)
+			}
+			if gotDefaultKey != "" {
+				t.Fatalf("X-Default-Key = %q, want empty", gotDefaultKey)
+			}
+			if gotAPIKey != "" {
+				t.Fatalf("X-API-Key = %q, want empty", gotAPIKey)
+			}
+		})
+	})
 }


### PR DESCRIPTION
## Summary

Manifest-backed declarative providers now apply the selected named connection's `authMapping` when materializing stored credentials.

Previously, declarative providers only installed a token parser from the default connection. Apps that used named connections without a default connection could therefore resolve the correct stored credential, but still send the raw stored manual credential JSON through the generic credential materialization path instead of rendering the header shape declared by the connection.

This lets apps such as Data Schema Explorer invoke the Front Porch REST API through a configured `prod` connection and have the stored `api_key` credential sent as the configured `X-API-Key` header.

## Runtime

Declarative provider construction now builds a connection-keyed parser registry using the shared declarative `authMapping` parser helper. Execution selects the effective connection from the credential context, explicit invocation connection, or configured operation connection, then applies that connection's parser to a per-call copy of the shared declarative executor.

Default-connection behavior is preserved through an explicit `default` fallback when no connection is resolved. If a connection is resolved but has no `authMapping`, execution uses the generic credential materialization path instead of borrowing the default connection's mapping.
