### PR TITLE
Thread declarative connection token parsers without copying Base

### DIFF
--- a/gestaltd/services/apps/declarative/base.go
+++ b/gestaltd/services/apps/declarative/base.go
@@ -149,6 +149,10 @@ func (b *Base) httpClient() *http.Client {
 }
 
 func (b *Base) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {
+	return b.ExecuteWithTokenParser(ctx, operation, params, token, b.TokenParser)
+}
+
+func (b *Base) ExecuteWithTokenParser(ctx context.Context, operation string, params map[string]any, token string, parser egress.TokenParser) (*core.OperationResult, error) {
 	if b.ExecuteFunc != nil {
 		return b.ExecuteFunc(ctx, operation, params, token)
 	}
@@ -158,9 +162,9 @@ func (b *Base) Execute(ctx context.Context, operation string, params map[string]
 		return nil, fmt.Errorf("unknown operation: %s", operation)
 	}
 	if catOp.Query != "" {
-		return b.executeGraphQL(ctx, operation, catOp.Query, catOp.OperationName, params, token)
+		return b.executeGraphQL(ctx, operation, catOp.Query, catOp.OperationName, params, token, parser)
 	}
-	return b.executeREST(ctx, operation, catOp, params, token)
+	return b.executeREST(ctx, operation, catOp, params, token, parser)
 }
 
 func (b *Base) InvokeGraphQL(ctx context.Context, request core.GraphQLRequest, token string) (*core.OperationResult, error) {
@@ -168,7 +172,7 @@ func (b *Base) InvokeGraphQL(ctx context.Context, request core.GraphQLRequest, t
 	if document == "" {
 		return nil, fmt.Errorf("graphql document is required")
 	}
-	return b.executeGraphQL(ctx, "graphql", document, request.OperationName, request.Variables, token)
+	return b.executeGraphQL(ctx, "graphql", document, request.OperationName, request.Variables, token, b.TokenParser)
 }
 
 func (b *Base) egressAuthStyle() egress.AuthStyle {
@@ -184,6 +188,6 @@ func (b *Base) egressAuthStyle() egress.AuthStyle {
 	}
 }
 
-func (b *Base) materializeCredential(token string) (egress.CredentialMaterialization, error) {
-	return egress.MaterializeCredential(token, b.egressAuthStyle(), b.TokenParser)
+func (b *Base) materializeCredential(token string, parser egress.TokenParser) (egress.CredentialMaterialization, error) {
+	return egress.MaterializeCredential(token, b.egressAuthStyle(), parser)
 }

--- a/gestaltd/services/apps/declarative/egress_adapter.go
+++ b/gestaltd/services/apps/declarative/egress_adapter.go
@@ -13,7 +13,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/egress"
 )
 
-func (b *Base) executeREST(ctx context.Context, operation string, catOp *catalog.CatalogOperation, params map[string]any, token string) (*core.OperationResult, error) {
+func (b *Base) executeREST(ctx context.Context, operation string, catOp *catalog.CatalogOperation, params map[string]any, token string, parser egress.TokenParser) (*core.OperationResult, error) {
 	if catOp == nil {
 		return nil, fmt.Errorf("unknown operation: %s", operation)
 	}
@@ -38,7 +38,7 @@ func (b *Base) executeREST(ctx context.Context, operation string, catOp *catalog
 		return nil, err
 	}
 
-	credential, err := b.materializeCredential(token)
+	credential, err := b.materializeCredential(token, parser)
 	if err != nil {
 		return nil, err
 	}
@@ -73,14 +73,14 @@ func (b *Base) executeREST(ctx context.Context, operation string, catOp *catalog
 	return result, nil
 }
 
-func (b *Base) executeGraphQL(ctx context.Context, operation string, query string, operationName string, params map[string]any, token string) (*core.OperationResult, error) {
+func (b *Base) executeGraphQL(ctx context.Context, operation string, query string, operationName string, params map[string]any, token string, parser egress.TokenParser) (*core.OperationResult, error) {
 	gqlURL, headers := b.resolvedURLAndHeaders(ctx)
 
 	if err := b.checkEgressHost(gqlURL); err != nil {
 		return nil, err
 	}
 
-	credential, err := b.materializeCredential(token)
+	credential, err := b.materializeCredential(token, parser)
 	if err != nil {
 		return nil, err
 	}

--- a/gestaltd/services/apps/declarative_provider.go
+++ b/gestaltd/services/apps/declarative_provider.go
@@ -146,11 +146,11 @@ func (p *DeclarativeProvider) Execute(ctx context.Context, operation string, par
 	if !declarativeHasOperation(p.Base.Catalog(), operation) {
 		return &core.OperationResult{Status: http.StatusNotFound, Body: `{"error":"unknown operation"}`}, nil
 	}
-	base, err := p.baseForConnection(ctx, operation, params)
+	parser, err := p.tokenParserForExecution(ctx, operation, params)
 	if err != nil {
 		return nil, err
 	}
-	return base.Execute(ctx, operation, params, token)
+	return p.ExecuteWithTokenParser(ctx, operation, params, token, parser)
 }
 
 func (p *DeclarativeProvider) ConnectionForOperation(operation string) string {
@@ -177,7 +177,7 @@ func (p *DeclarativeProvider) OperationConnectionOverrideAllowed(operation strin
 	return !p.operationLocks[operation]
 }
 
-func (p *DeclarativeProvider) baseForConnection(ctx context.Context, operation string, params map[string]any) (*integration.Base, error) {
+func (p *DeclarativeProvider) tokenParserForExecution(ctx context.Context, operation string, params map[string]any) (egress.TokenParser, error) {
 	connection, resolved, err := p.connectionForExecution(ctx, operation, params)
 	if err != nil {
 		return nil, err
@@ -185,11 +185,10 @@ func (p *DeclarativeProvider) baseForConnection(ctx context.Context, operation s
 	if !resolved {
 		connection = declarativeDefaultConnection
 	}
-	base := *p.Base
 	if parser, ok := p.tokenParsers[connection]; ok {
-		base.TokenParser = parser
+		return parser, nil
 	}
-	return &base, nil
+	return p.TokenParser, nil
 }
 
 func (p *DeclarativeProvider) connectionForExecution(ctx context.Context, operation string, params map[string]any) (string, bool, error) {


### PR DESCRIPTION
## Summary

- Follow-up to #2255: apply named-connection `authMapping` by passing the resolved `egress.TokenParser` into execution instead of shallow-copying the full declarative `Base` on every `Execute`.
- Add `Base.ExecuteWithTokenParser` and thread the parser through REST/GraphQL credential materialization.

## Test plan

- [x] `go test ./services/apps/... ./services/apps/declarative/...`
- [ ] Existing integration/functional coverage for connection resolution

Made with [Cursor](https://cursor.com)