### PR TITLE
Preserve provider credential errors across app RPC

### DIFF
--- a/gestaltd/services/apps/provider_client.go
+++ b/gestaltd/services/apps/provider_client.go
@@ -199,7 +199,7 @@ func (p *remoteProviderBase) Execute(ctx context.Context, operation string, para
 		Context:          reqCtx,
 	})
 	if err != nil {
-		return nil, err
+		return nil, remoteProviderExecuteError(err)
 	}
 	return &core.OperationResult{
 		Status:  int(resp.GetStatus()),

--- a/gestaltd/services/apps/provider_errors.go
+++ b/gestaltd/services/apps/provider_errors.go
@@ -1,0 +1,37 @@
+package plugins
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/services/invocation"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func providerExecuteError(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, invocation.ErrNoCredential), errors.Is(err, invocation.ErrReconnectRequired):
+		return status.Error(codes.FailedPrecondition, err.Error())
+	default:
+		return status.Errorf(codes.Unknown, "execute: %v", err)
+	}
+}
+
+func remoteProviderExecuteError(err error) error {
+	if status.Code(err) != codes.FailedPrecondition {
+		return err
+	}
+	message := status.Convert(err).Message()
+	switch {
+	case strings.Contains(message, invocation.ErrNoCredential.Error()):
+		return fmt.Errorf("%w: %s", invocation.ErrNoCredential, message)
+	case strings.Contains(message, invocation.ErrReconnectRequired.Error()):
+		return fmt.Errorf("%w: %s", invocation.ErrReconnectRequired, message)
+	default:
+		return err
+	}
+}

--- a/gestaltd/services/apps/provider_server.go
+++ b/gestaltd/services/apps/provider_server.go
@@ -48,7 +48,7 @@ func (s *ProviderServer) Execute(ctx context.Context, req *proto.ExecuteRequest)
 	}
 	result, err := s.provider.Execute(ctx, req.GetOperation(), protoutil.MapFromStruct(req.GetParams()), req.GetToken())
 	if err != nil {
-		return nil, status.Errorf(codes.Unknown, "execute: %v", err)
+		return nil, providerExecuteError(err)
 	}
 	return &proto.OperationResult{
 		Status:  int32(result.Status),

--- a/gestaltd/services/apps/provider_test.go
+++ b/gestaltd/services/apps/provider_test.go
@@ -42,6 +42,9 @@ func (p *roundTripProvider) DiscoveryConfig() *core.DiscoveryConfig      { retur
 func (p *roundTripProvider) ConnectionForOperation(string) string        { return "" }
 
 func (p *roundTripProvider) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {
+	if operation == "missing_credential" {
+		return nil, fmt.Errorf("%w: no external credential stored for integration %q", invocation.ErrNoCredential, "roundtrip")
+	}
 	subjectID := ""
 	subjectKind := ""
 	authSource := ""
@@ -301,6 +304,15 @@ func TestRemoteProviderRoundTrip(t *testing.T) {
 
 		if _, err := prov.Execute(ctx, "echo", map[string]any{"message": "hi"}, "secret-token"); err == nil {
 			t.Fatal("expected Execute to fail for unserializable workflow context")
+		}
+	})
+
+	t.Run("missing credential error", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := prov.Execute(context.Background(), "missing_credential", nil, "")
+		if !errors.Is(err, invocation.ErrNoCredential) {
+			t.Fatalf("Execute error = %v, want ErrNoCredential", err)
 		}
 	})
 


### PR DESCRIPTION
## Summary

- Preserves `ErrNoCredential` and `ErrReconnectRequired` when a remote provider returns those errors from `Execute`.
- Maps those sentinel errors back on the remote provider client so appaccess can return them as operation results instead of opaque RPC failures.
- Adds remote provider round-trip coverage for missing credential errors.

## Runtime

Hosted provider execution no longer erases credential sentinel errors at the provider RPC boundary. App-to-app calls that target hosted providers can now receive the existing 412 operation-result behavior added for missing credentials, instead of seeing `rpc error: code = Internal desc = internal error`.

This is the generic path needed for Oncall to degrade missing PagerDuty credentials during `get_me`.

## Test plan

- [x] `go test ./gestaltd/services/apps -run 'TestRemoteProviderRoundTrip'`
- [x] `go test ./gestaltd/services/appaccess ./gestaltd/services/invocation`
- [x] `go test ./gestaltd/internal/bootstrap -run 'TestPluginInvokesRejectInvalidTargetRequests'`
- [x] `git diff --check`
