### PR TITLE
Add opt-in sync archive caching

### DIFF
--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -25,6 +25,7 @@ import { Callout } from 'nextra/components'
 | `gestaltd lock --config PATH` | Resolve published provider sources and write canonical lock metadata. Repeat `--config` to layer overrides. |
 | `gestaltd lock --check --config PATH` | Verify that the checked-in lockfile matches the current config without rewriting it. |
 | `gestaltd sync --locked --config PATH` | Materialize prepared provider artifacts from an existing lockfile. Local source UI preparation uses bounded parallelism by default. |
+| `gestaltd sync --locked --cache-dir DIR --config PATH` | Reuse verified remote release archives across sync runs. `DIR` resolves like a normal CLI path. |
 | `gestaltd sync --locked --check --config PATH` | Verify that prepared artifacts exist and match the lockfile without rewriting them. |
 | `gestaltd validate --config PATH` | Validate config without serving. Repeat `--config` to layer overrides. |
 | `gestaltd validate --lockfile PATH` | Accept the same explicit lockfile path used by `lock`, `sync`, and `serve` without mutating it. |
@@ -77,6 +78,13 @@ update the lockfile by default. `provider add` and `provider remove` accept
 `GOMAXPROCS`; `--parallelism 1` forces sequential preparation. Other provider
 types and `sync --locked --check` remain sequential.
 
+`gestaltd sync --locked --cache-dir DIR` enables an opt-in cache for verified
+remote release archives. The cache key is the locked archive SHA-256, and
+cached archives are rehashed before use. The cache does not store prepared
+artifact directories, local source builds, local archive paths, or metadata
+responses. `sync --locked --check` remains read-only and does not populate the
+cache.
+
 ## Config Watch Mode
 
 Use `gestaltd serve --watch` for config-based local development when your
@@ -105,6 +113,7 @@ Watch mode applies only to config-based serve. It cannot be combined with
 gestaltd
 gestaltd lock --config ./config.yaml
 gestaltd sync --locked --config ./config.yaml
+gestaltd sync --locked --config ./config.yaml --cache-dir ./.gestaltd-archive-cache
 gestaltd sync --locked --config ./config.yaml --parallelism 2
 gestaltd serve --locked --config ./config.yaml
 gestaltd validate --config ./config.yaml

--- a/gestaltd/internal/daemon/main_test.go
+++ b/gestaltd/internal/daemon/main_test.go
@@ -39,7 +39,7 @@ func TestE2ECLIHelp(t *testing.T) {
 		{
 			name:      "sync",
 			args:      []string{"sync", "--help"},
-			wantParts: []string{"gestaltd sync --locked", "Materialize prepared artifacts", "--artifacts-dir", "--parallelism", "--check"},
+			wantParts: []string{"gestaltd sync --locked", "Materialize prepared artifacts", "--artifacts-dir", "--parallelism", "--cache-dir", "--check"},
 		},
 		{
 			name:      "provider",
@@ -113,6 +113,11 @@ func TestRunSyncParallelismValidation(t *testing.T) {
 		{
 			name:      "two accepted",
 			args:      []string{"--parallelism", "2"},
+			wantError: "gestaltd sync currently requires --locked",
+		},
+		{
+			name:      "cache dir accepted",
+			args:      []string{"--cache-dir", filepath.Join(t.TempDir(), "cache")},
 			wantError: "gestaltd sync currently requires --locked",
 		},
 	} {

--- a/gestaltd/internal/daemon/run.go
+++ b/gestaltd/internal/daemon/run.go
@@ -280,6 +280,7 @@ func runSync(args []string) error {
 	locked := fs.Bool("locked", false, "require an existing lockfile; do not resolve new metadata")
 	check := fs.Bool("check", false, "fail if artifacts would need to be materialized")
 	parallelism := fs.Int("parallelism", defaultSyncParallelism(), "maximum concurrent local UI source preparations")
+	cacheDir := fs.String("cache-dir", "", "path to opt-in remote archive cache")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -296,7 +297,7 @@ func runSync(args []string) error {
 	return syncConfigWithStatePathsOptions(configPaths, operator.StatePaths{
 		ArtifactsDir: *artifactsDir,
 		LockfilePath: *lockfilePath,
-	}, *check, operator.SyncOptions{Parallelism: *parallelism})
+	}, *check, operator.SyncOptions{Parallelism: *parallelism, ArchiveCacheDir: *cacheDir})
 }
 
 func defaultSyncParallelism() int {
@@ -434,7 +435,7 @@ func printMainUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
 	writeUsageLine(w, "  gestaltd [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH]")
 	writeUsageLine(w, "  gestaltd lock [--config PATH]... [--lockfile PATH] [--platform PLATFORMS] [--check]")
-	writeUsageLine(w, "  gestaltd sync --locked [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--parallelism N] [--check]")
+	writeUsageLine(w, "  gestaltd sync --locked [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--parallelism N] [--cache-dir PATH] [--check]")
 	writeUsageLine(w, "  gestaltd serve [--app NAME] [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--locked] [--watch]")
 	writeUsageLine(w, "  gestaltd serve --path PATH [--config PATH]... [--name NAME] [--port PORT]")
 	writeUsageLine(w, "  gestaltd agent <command> [flags]")
@@ -490,11 +491,12 @@ func printLockUsage(w io.Writer) {
 
 func printSyncUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
-	writeUsageLine(w, "  gestaltd sync --locked [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--parallelism N] [--check]")
+	writeUsageLine(w, "  gestaltd sync --locked [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--parallelism N] [--cache-dir PATH] [--check]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Materialize prepared artifacts from the existing lockfile.")
 	writeUsageLine(w, "Does not resolve new metadata or rewrite the lockfile.")
-	writeUsageLine(w, "--parallelism caps concurrent local source UI preparation; --check remains read-only.")
+	writeUsageLine(w, "--cache-dir reuses verified remote release archives; --check remains read-only.")
+	writeUsageLine(w, "--parallelism caps concurrent local source UI preparation.")
 	writeUsageLine(w, "When repeated, --config files merge left-to-right.")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Flags:")
@@ -503,6 +505,7 @@ func printSyncUsage(w io.Writer) {
 	writeUsageLine(w, "  --lockfile        Path to lockfile; defaults to gestalt.lock.json next to the primary config")
 	writeUsageLine(w, "  --locked          Require an existing lockfile")
 	writeUsageLine(w, "  --parallelism     Maximum concurrent local source UI preparations")
+	writeUsageLine(w, "  --cache-dir       Opt-in cache for verified remote release archives; relative paths use the current working directory")
 	writeUsageLine(w, "  --check           Fail if artifacts would need to be materialized")
 }
 

--- a/gestaltd/internal/operator/archive_cache.go
+++ b/gestaltd/internal/operator/archive_cache.go
@@ -1,0 +1,323 @@
+package operator
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/services/apps/providerpkg"
+)
+
+type archiveCache struct {
+	dir string
+}
+
+type archiveDigestMismatchError struct {
+	actual   string
+	expected string
+}
+
+func (e archiveDigestMismatchError) Error() string {
+	return fmt.Sprintf("archive digest mismatch: got %s, want %s", e.actual, e.expected)
+}
+
+type archiveSizeLimitError struct {
+	subject  string
+	maxBytes int64
+}
+
+func (e archiveSizeLimitError) Error() string {
+	return fmt.Sprintf("%s exceeds %d byte limit", e.subject, e.maxBytes)
+}
+
+type archiveCacheLookupResult int
+
+const (
+	archiveCacheMiss archiveCacheLookupResult = iota
+	archiveCacheHit
+	archiveCacheInvalid
+	archiveCacheRejected
+)
+
+func downloadArchiveForSourceWithCache(ctx context.Context, client *http.Client, token, archiveURL, expectedSHA, cacheDir string) (*providerpkg.DownloadResult, error) {
+	sha, hasExpectedSHA, err := normalizeArchiveSHA256(expectedSHA)
+	if err != nil {
+		return nil, err
+	}
+
+	useCache := cacheDir != "" && hasExpectedSHA && isRemoteReleaseMetadataLocation(archiveURL)
+	if useCache {
+		cache := archiveCache{dir: cacheDir}
+		cached, result, err := cache.Get(sha)
+		if err != nil {
+			return nil, fmt.Errorf("read archive cache: %w", err)
+		}
+		switch result {
+		case archiveCacheHit:
+			return cached, nil
+		case archiveCacheMiss, archiveCacheInvalid:
+		case archiveCacheRejected:
+			return nil, fmt.Errorf("read archive cache: rejected cached archive")
+		}
+	}
+
+	download, err := downloadArchiveForSource(ctx, client, token, archiveURL)
+	if err != nil {
+		return nil, err
+	}
+	if err := verifyArchiveSHA256(download.SHA256Hex, sha); err != nil {
+		download.Cleanup()
+		return nil, err
+	}
+	if useCache {
+		// The verified temp download is still usable; a write-only cache miss should not fail sync.
+		_ = (archiveCache{dir: cacheDir}).Put(download.LocalPath, sha)
+	}
+	return download, nil
+}
+
+func normalizeArchiveSHA256(raw string) (string, bool, error) {
+	if strings.TrimSpace(raw) == "" {
+		return "", false, nil
+	}
+	sha, ok := canonicalArchiveCacheSHA(raw)
+	if !ok {
+		return "", false, fmt.Errorf("invalid archive sha256 %q", raw)
+	}
+	return sha, true, nil
+}
+
+func verifyArchiveSHA256(actual, expected string) error {
+	expectedSHA, hasExpectedSHA, err := normalizeArchiveSHA256(expected)
+	if err != nil || !hasExpectedSHA {
+		return err
+	}
+	actualSHA, ok := canonicalArchiveCacheSHA(actual)
+	if !ok {
+		return fmt.Errorf("invalid downloaded archive sha256 %q", actual)
+	}
+	if actualSHA != expectedSHA {
+		return archiveDigestMismatchError{actual: actualSHA, expected: expectedSHA}
+	}
+	return nil
+}
+
+func canonicalArchiveCacheSHA(raw string) (string, bool) {
+	raw = strings.TrimSpace(raw)
+	if len(raw) != 64 {
+		return "", false
+	}
+	normalized := strings.ToLower(raw)
+	for _, r := range normalized {
+		switch {
+		case r >= '0' && r <= '9':
+		case r >= 'a' && r <= 'f':
+		default:
+			return "", false
+		}
+	}
+	return normalized, true
+}
+
+func (c archiveCache) Get(expectedSHA string) (*providerpkg.DownloadResult, archiveCacheLookupResult, error) {
+	sha, ok := canonicalArchiveCacheSHA(expectedSHA)
+	if !ok {
+		return nil, archiveCacheRejected, fmt.Errorf("invalid archive cache sha %q", expectedSHA)
+	}
+	path := c.pathForSHA(sha)
+	cached, valid, err := copyCachedArchiveToTemp(path, sha)
+	if os.IsNotExist(err) {
+		return nil, archiveCacheMiss, nil
+	}
+	if err != nil {
+		return nil, archiveCacheRejected, err
+	}
+	if !valid {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return nil, archiveCacheRejected, fmt.Errorf("remove invalid cached archive: %w", err)
+		}
+		return nil, archiveCacheInvalid, nil
+	}
+	return cached, archiveCacheHit, nil
+}
+
+func (c archiveCache) Put(sourcePath, expectedSHA string) error {
+	sha, ok := canonicalArchiveCacheSHA(expectedSHA)
+	if !ok {
+		return fmt.Errorf("invalid archive cache sha %q", expectedSHA)
+	}
+
+	targetPath := c.pathForSHA(sha)
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		return fmt.Errorf("create archive cache directory: %w", err)
+	}
+	if valid, err := validateCachedArchive(targetPath, sha); err == nil {
+		if valid {
+			return nil
+		}
+		if err := os.Remove(targetPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove invalid cached archive: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
+		if err := os.Remove(targetPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove invalid cached archive: %w", err)
+		}
+	}
+
+	tmpPath, digest, cleanupTmp, err := copyRegularArchiveToTempWithDigest(
+		sourcePath,
+		"downloaded archive",
+		filepath.Dir(targetPath),
+		"."+filepath.Base(targetPath)+".tmp-*",
+		providerpkg.MaxPackageBytes,
+	)
+	if err != nil {
+		return err
+	}
+	keepTmp := false
+	defer func() {
+		if !keepTmp {
+			cleanupTmp()
+		}
+	}()
+	if digest != sha {
+		return fmt.Errorf("archive cache temp file digest mismatch: got %s, want %s", digest, sha)
+	}
+	if err := os.Rename(tmpPath, targetPath); err != nil {
+		if valid, validateErr := validateCachedArchive(targetPath, sha); validateErr == nil && valid {
+			return nil
+		}
+		return fmt.Errorf("commit archive cache file: %w", err)
+	}
+	keepTmp = true
+	return nil
+}
+
+func (c archiveCache) pathForSHA(sha string) string {
+	return filepath.Join(c.dir, "sha256", sha[:2], sha+".tar.gz")
+}
+
+func validateCachedArchive(path, expectedSHA string) (bool, error) {
+	_, digest, cleanup, err := copyRegularArchiveToTempWithDigest(
+		path,
+		"cached archive "+path,
+		"",
+		"gestalt-archive-cache-validate-*.tar.gz",
+		providerpkg.MaxPackageBytes,
+	)
+	if err != nil {
+		var sizeErr archiveSizeLimitError
+		if errors.As(err, &sizeErr) {
+			return false, nil
+		}
+		return false, err
+	}
+	cleanup()
+	return digest == expectedSHA, nil
+}
+
+func copyCachedArchiveToTemp(path, expectedSHA string) (*providerpkg.DownloadResult, bool, error) {
+	tmpPath, digest, cleanup, err := copyRegularArchiveToTempWithDigest(
+		path,
+		"cached archive "+path,
+		"",
+		"gestalt-archive-cache-*.tar.gz",
+		providerpkg.MaxPackageBytes,
+	)
+	if err != nil {
+		var sizeErr archiveSizeLimitError
+		if errors.As(err, &sizeErr) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	if digest != expectedSHA {
+		cleanup()
+		return nil, false, nil
+	}
+	return &providerpkg.DownloadResult{
+		LocalPath: tmpPath,
+		Cleanup:   cleanup,
+		SHA256Hex: digest,
+	}, true, nil
+}
+
+func copyRegularArchiveToTempWithDigest(sourcePath, subject, tempDir, tempPattern string, maxBytes int64) (string, string, func(), error) {
+	info, err := statRegularArchiveFile(sourcePath, subject)
+	if err != nil {
+		return "", "", nil, err
+	}
+	if info.Size() > maxBytes {
+		return "", "", nil, archiveSizeLimitError{subject: subject, maxBytes: maxBytes}
+	}
+
+	src, err := os.Open(sourcePath)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("open %s: %w", subject, err)
+	}
+	defer func() {
+		if src != nil {
+			_ = src.Close()
+		}
+	}()
+	openedInfo, err := src.Stat()
+	if err != nil {
+		return "", "", nil, fmt.Errorf("stat opened %s: %w", subject, err)
+	}
+	if !os.SameFile(info, openedInfo) {
+		return "", "", nil, fmt.Errorf("%s %s changed during validation", subject, sourcePath)
+	}
+
+	tmp, err := os.CreateTemp(tempDir, tempPattern)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("create archive temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	cleanupTmp := func() { _ = os.Remove(tmpPath) }
+
+	h := sha256.New()
+	n, err := io.Copy(io.MultiWriter(tmp, h), io.LimitReader(src, maxBytes+1))
+	if err != nil {
+		_ = tmp.Close()
+		cleanupTmp()
+		return "", "", nil, fmt.Errorf("copy %s: %w", subject, err)
+	}
+	if n > maxBytes {
+		_ = tmp.Close()
+		cleanupTmp()
+		return "", "", nil, archiveSizeLimitError{subject: subject, maxBytes: maxBytes}
+	}
+	if err := src.Close(); err != nil {
+		src = nil
+		_ = tmp.Close()
+		cleanupTmp()
+		return "", "", nil, fmt.Errorf("close %s: %w", subject, err)
+	}
+	src = nil
+	if err := tmp.Close(); err != nil {
+		cleanupTmp()
+		return "", "", nil, fmt.Errorf("close archive temp file: %w", err)
+	}
+	return tmpPath, hex.EncodeToString(h.Sum(nil)), cleanupTmp, nil
+}
+
+func statRegularArchiveFile(path, subject string) (os.FileInfo, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("%s is a symlink", subject)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("%s is not a regular file", subject)
+	}
+	return info, nil
+}

--- a/gestaltd/internal/operator/archive_cache_integration_test.go
+++ b/gestaltd/internal/operator/archive_cache_integration_test.go
@@ -1,0 +1,110 @@
+package operator
+
+import (
+	"os"
+	"sync/atomic"
+	"testing"
+)
+
+func assertCheckSyncDoesNotPopulateArchiveCache(t *testing.T, lc *Lifecycle, configPath, cacheDir string, resetArtifacts func() error) {
+	t.Helper()
+
+	if err := resetArtifacts(); err != nil {
+		t.Fatalf("reset artifacts before check sync: %v", err)
+	}
+	if err := lc.CheckSyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{ArchiveCacheDir: cacheDir}); err == nil {
+		t.Fatal("CheckSyncAtPathsWithStatePathsOptions with cache dir error = nil, want stale artifact error")
+	}
+	if _, err := os.Stat(cacheDir); !os.IsNotExist(err) {
+		t.Fatalf("cache dir after check sync stat err = %v, want not exist", err)
+	}
+}
+
+func assertRemoteArchiveCacheRoundTrip(
+	t *testing.T,
+	lc *Lifecycle,
+	configPath string,
+	cacheDir string,
+	archiveSHAHex string,
+	archiveCount *atomic.Int64,
+	resetArtifacts func() error,
+	afterMiss func(),
+) {
+	t.Helper()
+
+	if err := resetArtifacts(); err != nil {
+		t.Fatalf("reset artifacts before cache miss: %v", err)
+	}
+	archiveBeforeCacheMiss := archiveCount.Load()
+	if err := lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{ArchiveCacheDir: cacheDir}); err != nil {
+		if afterMiss != nil {
+			afterMiss()
+		}
+		t.Fatalf("SyncAtPathsWithStatePathsOptions cache miss: %v", err)
+	}
+	if afterMiss != nil {
+		afterMiss()
+	}
+	if got := archiveCount.Load(); got != archiveBeforeCacheMiss+1 {
+		t.Fatalf("archive request count after cache miss = %d, want %d", got, archiveBeforeCacheMiss+1)
+	}
+	cachePath := archiveCachePathForTest(t, cacheDir, archiveSHAHex)
+	if _, err := os.Stat(cachePath); err != nil {
+		t.Fatalf("cache archive stat: %v", err)
+	}
+
+	if err := resetArtifacts(); err != nil {
+		t.Fatalf("reset artifacts before cache hit: %v", err)
+	}
+	archiveBeforeCacheHit := archiveCount.Load()
+	if err := lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{ArchiveCacheDir: cacheDir}); err != nil {
+		t.Fatalf("SyncAtPathsWithStatePathsOptions cache hit: %v", err)
+	}
+	if got := archiveCount.Load(); got != archiveBeforeCacheHit {
+		t.Fatalf("archive request count after cache hit = %d, want %d", got, archiveBeforeCacheHit)
+	}
+}
+
+func assertRemoteArchiveCacheRepair(
+	t *testing.T,
+	lc *Lifecycle,
+	configPath string,
+	cacheDir string,
+	archiveSHAHex string,
+	archiveCount *atomic.Int64,
+	resetArtifacts func() error,
+	afterRepair func(),
+) {
+	t.Helper()
+
+	cachePath := archiveCachePathForTest(t, cacheDir, archiveSHAHex)
+	if err := os.WriteFile(cachePath, []byte("corrupt cached archive"), 0o644); err != nil {
+		t.Fatalf("write corrupt cache archive: %v", err)
+	}
+	if err := resetArtifacts(); err != nil {
+		t.Fatalf("reset artifacts before cache repair: %v", err)
+	}
+	archiveBeforeCacheRepair := archiveCount.Load()
+	if err := lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{ArchiveCacheDir: cacheDir}); err != nil {
+		if afterRepair != nil {
+			afterRepair()
+		}
+		t.Fatalf("SyncAtPathsWithStatePathsOptions cache repair: %v", err)
+	}
+	if afterRepair != nil {
+		afterRepair()
+	}
+	if got := archiveCount.Load(); got != archiveBeforeCacheRepair+1 {
+		t.Fatalf("archive request count after cache repair = %d, want %d", got, archiveBeforeCacheRepair+1)
+	}
+}
+
+func archiveCachePathForTest(t *testing.T, cacheDir, archiveSHAHex string) string {
+	t.Helper()
+
+	sha, ok := canonicalArchiveCacheSHA(archiveSHAHex)
+	if !ok {
+		t.Fatalf("archive SHA %q is not cacheable", archiveSHAHex)
+	}
+	return archiveCache{dir: cacheDir}.pathForSHA(sha)
+}

--- a/gestaltd/internal/operator/archive_cache_test.go
+++ b/gestaltd/internal/operator/archive_cache_test.go
@@ -1,0 +1,317 @@
+package operator
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/services/apps/providerpkg"
+)
+
+func TestArchiveCacheGetPutRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	data := []byte("archive bytes")
+	sha := testSHA256Hex(data)
+	sourcePath := filepath.Join(dir, "source.tar.gz")
+	if err := os.WriteFile(sourcePath, data, 0o644); err != nil {
+		t.Fatalf("write source archive: %v", err)
+	}
+
+	cache := archiveCache{dir: filepath.Join(dir, "cache")}
+	if err := cache.Put(sourcePath, sha); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if err := cache.Put(sourcePath, strings.ToUpper(sha)); err != nil {
+		t.Fatalf("second Put with uppercase digest: %v", err)
+	}
+	got, result, err := cache.Get(sha)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if result != archiveCacheHit {
+		t.Fatalf("Get result = %v, want %v", result, archiveCacheHit)
+	}
+	if got.LocalPath == cache.pathForSHA(sha) {
+		t.Fatalf("LocalPath = cache path %q, want private temp copy", got.LocalPath)
+	}
+	if got.SHA256Hex != sha {
+		t.Fatalf("SHA256Hex = %q, want %q", got.SHA256Hex, sha)
+	}
+	if gotData, err := os.ReadFile(got.LocalPath); err != nil || string(gotData) != string(data) {
+		t.Fatalf("read temp cache hit data = %q, %v; want %q", gotData, err, data)
+	}
+	got.Cleanup()
+	if _, err := os.Stat(got.LocalPath); !os.IsNotExist(err) {
+		t.Fatalf("temp cache hit after cleanup stat err = %v, want not exist", err)
+	}
+
+	got, result, err = cache.Get(strings.ToUpper(sha))
+	if err != nil {
+		t.Fatalf("Get uppercase: %v", err)
+	}
+	if result != archiveCacheHit {
+		t.Fatalf("Get uppercase result = %v, want %v", result, archiveCacheHit)
+	}
+	if got.SHA256Hex != sha {
+		t.Fatalf("uppercase SHA256Hex = %q, want %q", got.SHA256Hex, sha)
+	}
+	got.Cleanup()
+}
+
+func TestArchiveCacheRejectsInvalidDigest(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	data := []byte("archive bytes")
+	sha := testSHA256Hex(data)
+	sourcePath := filepath.Join(dir, "source.tar.gz")
+	if err := os.WriteFile(sourcePath, data, 0o644); err != nil {
+		t.Fatalf("write source archive: %v", err)
+	}
+	cache := archiveCache{dir: filepath.Join(dir, "cache")}
+
+	for _, digest := range []string{"", sha[:63], strings.Repeat("g", 64)} {
+		if _, result, err := cache.Get(digest); err == nil || result != archiveCacheRejected {
+			t.Fatalf("Get(%q) error = nil, want invalid digest error", digest)
+		}
+		if err := cache.Put(sourcePath, digest); err == nil {
+			t.Fatalf("Put(%q) error = nil, want invalid digest error", digest)
+		}
+	}
+}
+
+func TestArchiveCacheInvalidatesCorruptAndOversizedEntries(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cache := archiveCache{dir: filepath.Join(dir, "cache")}
+	sha := testSHA256Hex([]byte("expected archive"))
+
+	corruptPath := cache.pathForSHA(sha)
+	if err := os.MkdirAll(filepath.Dir(corruptPath), 0o755); err != nil {
+		t.Fatalf("create corrupt parent: %v", err)
+	}
+	if err := os.WriteFile(corruptPath, []byte("wrong archive"), 0o644); err != nil {
+		t.Fatalf("write corrupt cache entry: %v", err)
+	}
+	if _, result, err := cache.Get(sha); err != nil || result != archiveCacheInvalid {
+		t.Fatalf("Get corrupt entry result=%v err=%v, want invalid without error", result, err)
+	}
+	if _, err := os.Stat(corruptPath); !os.IsNotExist(err) {
+		t.Fatalf("corrupt cache entry still exists, stat err = %v", err)
+	}
+
+	oversizedSHA := testSHA256Hex([]byte("oversized archive"))
+	oversizedPath := cache.pathForSHA(oversizedSHA)
+	if err := os.MkdirAll(filepath.Dir(oversizedPath), 0o755); err != nil {
+		t.Fatalf("create oversized parent: %v", err)
+	}
+	f, err := os.Create(oversizedPath)
+	if err != nil {
+		t.Fatalf("create oversized cache entry: %v", err)
+	}
+	if err := f.Truncate(int64(providerpkg.MaxPackageBytes) + 1); err != nil {
+		_ = f.Close()
+		t.Fatalf("truncate oversized cache entry: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close oversized cache entry: %v", err)
+	}
+	if _, result, err := cache.Get(oversizedSHA); err != nil || result != archiveCacheInvalid {
+		t.Fatalf("Get oversized entry result=%v err=%v, want invalid without error", result, err)
+	}
+	if _, err := os.Stat(oversizedPath); !os.IsNotExist(err) {
+		t.Fatalf("oversized cache entry still exists, stat err = %v", err)
+	}
+}
+
+func TestArchiveCacheRejectsSymlinkAndNonRegularEntries(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cache := archiveCache{dir: filepath.Join(dir, "cache")}
+	sha := testSHA256Hex([]byte("expected archive"))
+	targetPath := cache.pathForSHA(sha)
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		t.Fatalf("create target parent: %v", err)
+	}
+
+	linkTarget := filepath.Join(dir, "link-target.tar.gz")
+	if err := os.WriteFile(linkTarget, []byte("expected archive"), 0o644); err != nil {
+		t.Fatalf("write link target: %v", err)
+	}
+	if err := os.Symlink(linkTarget, targetPath); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	if _, result, err := cache.Get(sha); err == nil || result != archiveCacheRejected || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("Get symlink result=%v error=%v, want rejected symlink error", result, err)
+	}
+	if err := os.Remove(targetPath); err != nil {
+		t.Fatalf("remove symlink: %v", err)
+	}
+	if err := os.Mkdir(targetPath, 0o755); err != nil {
+		t.Fatalf("create directory cache entry: %v", err)
+	}
+	if _, result, err := cache.Get(sha); err == nil || result != archiveCacheRejected || !strings.Contains(err.Error(), "not a regular file") {
+		t.Fatalf("Get directory result=%v error=%v, want rejected non-regular error", result, err)
+	}
+}
+
+func TestArchiveCachePutReplacesInvalidTarget(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cache := archiveCache{dir: filepath.Join(dir, "cache")}
+	data := []byte("archive bytes")
+	sha := testSHA256Hex(data)
+	sourcePath := filepath.Join(dir, "source.tar.gz")
+	if err := os.WriteFile(sourcePath, data, 0o644); err != nil {
+		t.Fatalf("write source archive: %v", err)
+	}
+	targetPath := cache.pathForSHA(sha)
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		t.Fatalf("create target parent: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte("wrong archive"), 0o644); err != nil {
+		t.Fatalf("write invalid target: %v", err)
+	}
+	if err := cache.Put(sourcePath, sha); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	got, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(got) != string(data) {
+		t.Fatalf("target data = %q, want %q", got, data)
+	}
+}
+
+func TestDownloadArchiveWithCacheFallsBackWhenStoreFails(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	data := []byte("archive bytes")
+	sha := testSHA256Hex(data)
+	var requests atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		_, _ = w.Write(data)
+	}))
+	defer srv.Close()
+
+	cache := archiveCache{dir: filepath.Join(dir, "cache")}
+	shardDir := filepath.Dir(cache.pathForSHA(sha))
+	if err := os.MkdirAll(shardDir, 0o755); err != nil {
+		t.Fatalf("create shard dir: %v", err)
+	}
+	if err := os.Chmod(shardDir, 0o555); err != nil {
+		t.Fatalf("chmod shard dir readonly: %v", err)
+	}
+	defer func() { _ = os.Chmod(shardDir, 0o755) }()
+
+	download, err := downloadArchiveForSourceWithCache(context.Background(), srv.Client(), "", srv.URL, sha, cache.dir)
+	if err != nil {
+		t.Fatalf("downloadArchiveForSourceWithCache: %v", err)
+	}
+	defer download.Cleanup()
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("request count = %d, want 1", got)
+	}
+	if download.SHA256Hex != sha {
+		t.Fatalf("SHA256Hex = %q, want %q", download.SHA256Hex, sha)
+	}
+	if _, err := os.Stat(download.LocalPath); err != nil {
+		t.Fatalf("download local path stat: %v", err)
+	}
+	if _, err := os.Stat(cache.pathForSHA(sha)); !os.IsNotExist(err) {
+		t.Fatalf("cache archive stat err = %v, want not exist", err)
+	}
+}
+
+func TestDownloadArchiveWithCacheVerifiesExpectedSHA(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	data := []byte("archive bytes")
+	sha := testSHA256Hex(data)
+	wrongSHA := testSHA256Hex([]byte("wrong archive bytes"))
+	var requests atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		_, _ = w.Write(data)
+	}))
+	defer srv.Close()
+
+	cache := archiveCache{dir: filepath.Join(dir, "cache")}
+	download, err := downloadArchiveForSourceWithCache(context.Background(), srv.Client(), "", srv.URL, wrongSHA, cache.dir)
+	if err == nil {
+		if download != nil {
+			download.Cleanup()
+		}
+		t.Fatal("downloadArchiveForSourceWithCache mismatch error = nil")
+	}
+	var mismatch archiveDigestMismatchError
+	if !errors.As(err, &mismatch) {
+		t.Fatalf("downloadArchiveForSourceWithCache mismatch error = %v, want archiveDigestMismatchError", err)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("request count = %d, want 1", got)
+	}
+	if _, err := os.Stat(cache.pathForSHA(sha)); !os.IsNotExist(err) {
+		t.Fatalf("matching cache archive stat err = %v, want not exist", err)
+	}
+
+	_, err = downloadArchiveForSourceWithCache(context.Background(), srv.Client(), "", srv.URL, "abc123", cache.dir)
+	if err == nil || !strings.Contains(err.Error(), "invalid archive sha256") {
+		t.Fatalf("downloadArchiveForSourceWithCache invalid digest error = %v, want invalid archive sha256", err)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("request count after invalid digest = %d, want 1", got)
+	}
+}
+
+func TestLockfileNormalizesArchiveSHA256(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, LockfileName)
+	sha := testSHA256Hex([]byte("archive bytes"))
+	lock := &Lockfile{
+		Providers: map[string]LockEntry{
+			"alpha": {
+				Package: "github.com/acme/tools/alpha",
+				Kind:    "app",
+				Runtime: providerReleaseRuntimeExecutable,
+				Archives: map[string]LockArchive{
+					"generic": {URL: "https://example.com/alpha.tar.gz", SHA256: strings.ToUpper(sha)},
+				},
+			},
+		},
+	}
+	if err := WriteLockfile(lockPath, lock); err != nil {
+		t.Fatalf("WriteLockfile: %v", err)
+	}
+	written, err := ReadLockfile(lockPath)
+	if err != nil {
+		t.Fatalf("ReadLockfile: %v", err)
+	}
+	if got := written.Providers["alpha"].Archives["generic"].SHA256; got != sha {
+		t.Fatalf("read archive SHA256 = %q, want %q", got, sha)
+	}
+}
+
+func testSHA256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -117,7 +117,8 @@ type StatePaths struct {
 }
 
 type SyncOptions struct {
-	Parallelism int
+	Parallelism     int
+	ArchiveCacheDir string
 }
 
 func DefaultSyncParallelism() int {
@@ -1152,6 +1153,9 @@ func (l *Lifecycle) syncAtPathsWithStatePaths(configPaths []string, state StateP
 		return err
 	}
 	paths := resolveLifecyclePaths(configPaths, cfg, state)
+	if mode == artifactModeMaterialize && opts.ArchiveCacheDir != "" {
+		paths.archiveCacheDir = resolveCLIArtifactsDir(opts.ArchiveCacheDir)
+	}
 	lock, err := ReadLockfile(paths.lockfilePath)
 	if err != nil {
 		if os.IsNotExist(err) && !configRequiresCommittedLock(cfg) {
@@ -1591,6 +1595,7 @@ type lifecyclePaths struct {
 	agentDir               string
 	runtimeDir             string
 	uiDir                  string
+	archiveCacheDir        string
 }
 
 func primaryConfigPath(paths []string) string {
@@ -3251,14 +3256,11 @@ func (l *Lifecycle) installMetadataSourcePackage(ctx context.Context, expectedKi
 	if err != nil {
 		return nil, LockEntry{}, fmt.Errorf("resolve archive for %s: %w", subject, err)
 	}
-	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), sourceAuthToken(app), archiveLocation)
+	download, err := downloadArchiveForSourceWithCache(ctx, l.metadataHTTPClient(), sourceAuthToken(app), archiveLocation, archive.SHA256, "")
 	if err != nil {
 		return nil, LockEntry{}, fmt.Errorf("download metadata source package for %s: %w", subject, err)
 	}
 	defer download.Cleanup()
-	if archive.SHA256 != "" && download.SHA256Hex != archive.SHA256 {
-		return nil, LockEntry{}, fmt.Errorf("metadata source digest mismatch for %s: got %s, want %s", subject, download.SHA256Hex, archive.SHA256)
-	}
 
 	installed, err := installPackage(download.LocalPath, destDir)
 	if err != nil {
@@ -4442,6 +4444,18 @@ func (e staticArchiveUnavailableError) Unwrap() error {
 	return e.err
 }
 
+type lockedArchiveDownloadError struct {
+	err error
+}
+
+func (e lockedArchiveDownloadError) Error() string {
+	return e.err.Error()
+}
+
+func (e lockedArchiveDownloadError) Unwrap() error {
+	return e.err
+}
+
 func isStaticArchiveUnavailable(err error) bool {
 	var unavailable staticArchiveUnavailableError
 	return errors.As(err, &unavailable)
@@ -4468,41 +4482,19 @@ func fallbackStaticValidationManifest(kind string, entry LockEntry) *providerman
 }
 
 func (l *Lifecycle) installLockedArchiveForStaticValidation(ctx context.Context, paths lifecyclePaths, kind, name string, provider *config.ProviderEntry, entry LockEntry, destDir, platform string) (*preparedInstall, func(), error) {
-	archive, resolvedKey, ok := resolveArchiveForPlatform(entry, platform)
-	if !ok || archive.URL == "" {
-		return nil, nil, fmt.Errorf("no archive for platform %s for %s %q; run `%s --platform %s`", platform, kind, name, formatLockCommand(paths), platform)
-	}
-	archiveLocation, err := resolveLockedArchiveLocation(paths.configDir, entry.Source, archive.URL)
+	subject := fmt.Sprintf("%s %q", kind, name)
+	download, resolvedKey, cleanup, err := l.downloadLockedArchive(ctx, paths, provider, entry, platform, subject, "")
 	if err != nil {
-		return nil, nil, fmt.Errorf("resolve locked source provider for %s %q: %w", kind, name, err)
-	}
-	if archive.SHA256 == "" && archiveReferenceNeedsIntegrityHash(archiveLocation) {
-		return nil, nil, fmt.Errorf("no verified hash for platform %s for %s %q; run `%s --platform %s`", platform, kind, name, formatLockCommand(paths), platform)
-	}
-	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), sourceAuthToken(provider), archiveLocation)
-	if err != nil {
+		var downloadErr lockedArchiveDownloadError
+		if !errors.As(err, &downloadErr) {
+			return nil, nil, err
+		}
+		var mismatch archiveDigestMismatchError
+		if errors.As(err, &mismatch) {
+			return nil, nil, fmt.Errorf("locked source provider digest mismatch for %s %q: %w", kind, name, err)
+		}
 		return nil, nil, staticArchiveUnavailableError{
-			err: fmt.Errorf("download locked source provider for %s %q: %w", kind, name, err),
-		}
-	}
-	cleanup := download.Cleanup
-	if archive.SHA256 != "" && download.SHA256Hex != archive.SHA256 {
-		cleanup()
-		return nil, nil, fmt.Errorf("locked source provider digest mismatch for %s %q: got %s, want %s", kind, name, download.SHA256Hex, archive.SHA256)
-	}
-	if archive.SHA256 == "" {
-		sourceLocation := entry.Source
-		if !isRemoteReleaseMetadataLocation(sourceLocation) {
-			sourceLocation = resolveLockPath(paths.configDir, sourceLocation)
-		}
-		expectedSHA, err := localReleaseArchiveExpectedSHA(sourceLocation, resolvedKey, archiveLocation)
-		if err != nil {
-			cleanup()
-			return nil, nil, fmt.Errorf("load local archive metadata for %s %q: %w", kind, name, err)
-		}
-		if expectedSHA != "" && download.SHA256Hex != expectedSHA {
-			cleanup()
-			return nil, nil, fmt.Errorf("locked source provider digest mismatch for %s %q: got %s, want %s", kind, name, download.SHA256Hex, expectedSHA)
+			err: err,
 		}
 	}
 	if err := os.RemoveAll(destDir); err != nil {
@@ -5326,38 +5318,11 @@ func bindPathBackedUIManifest(app *config.ProviderEntry, configMap map[string]an
 
 func (l *Lifecycle) materializeLockedProvider(ctx context.Context, paths lifecyclePaths, name string, app *config.ProviderEntry, entry LockEntry) error {
 	platform := providerpkg.CurrentPlatformString()
-	archive, resolvedKey, ok := resolveArchiveForPlatform(entry, platform)
-	if !ok || archive.URL == "" {
-		return fmt.Errorf("no archive for platform %s for provider %q; run `%s --platform %s`", platform, name, formatLockCommand(paths), platform)
-	}
-	archiveLocation, err := resolveLockedArchiveLocation(paths.configDir, entry.Source, archive.URL)
+	download, resolvedKey, cleanupDownload, err := l.downloadLockedArchive(ctx, paths, app, entry, platform, fmt.Sprintf("provider %q", name), paths.archiveCacheDir)
 	if err != nil {
-		return fmt.Errorf("resolve locked source provider for provider %q: %w", name, err)
+		return err
 	}
-	if archive.SHA256 == "" && archiveReferenceNeedsIntegrityHash(archiveLocation) {
-		return fmt.Errorf("no verified hash for platform %s for provider %q; run `%s --platform %s`", platform, name, formatLockCommand(paths), platform)
-	}
-	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), sourceAuthToken(app), archiveLocation)
-	if err != nil {
-		return fmt.Errorf("download locked source provider for provider %q: %w", name, err)
-	}
-	defer download.Cleanup()
-	if archive.SHA256 != "" && download.SHA256Hex != archive.SHA256 {
-		return fmt.Errorf("locked source provider digest mismatch for provider %q: got %s, want %s", name, download.SHA256Hex, archive.SHA256)
-	}
-	if archive.SHA256 == "" {
-		sourceLocation := entry.Source
-		if !isRemoteReleaseMetadataLocation(sourceLocation) {
-			sourceLocation = resolveLockPath(paths.configDir, sourceLocation)
-		}
-		expectedSHA, err := localReleaseArchiveExpectedSHA(sourceLocation, resolvedKey, archiveLocation)
-		if err != nil {
-			return fmt.Errorf("load local archive metadata for provider %q: %w", name, err)
-		}
-		if expectedSHA != "" && download.SHA256Hex != expectedSHA {
-			return fmt.Errorf("locked source provider digest mismatch for provider %q: got %s, want %s", name, download.SHA256Hex, expectedSHA)
-		}
-	}
+	defer cleanupDownload()
 
 	destDir := providerDestDir(paths, name)
 	installed, cleanupInstall, commitInstall, err := installLockedPackageAtomic(download.LocalPath, destDir)
@@ -5382,38 +5347,11 @@ func (l *Lifecycle) materializeLockedProvider(ctx context.Context, paths lifecyc
 
 func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths lifecyclePaths, kind, name string, app *config.ProviderEntry, entry LockEntry, destDir string) error {
 	platform := providerpkg.CurrentPlatformString()
-	archive, resolvedKey, ok := resolveArchiveForPlatform(entry, platform)
-	if !ok || archive.URL == "" {
-		return fmt.Errorf("no archive for platform %s for %s %q; run `%s --platform %s`", platform, kind, name, formatLockCommand(paths), platform)
-	}
-	archiveLocation, err := resolveLockedArchiveLocation(paths.configDir, entry.Source, archive.URL)
+	download, resolvedKey, cleanupDownload, err := l.downloadLockedArchive(ctx, paths, app, entry, platform, fmt.Sprintf("%s %q", kind, name), paths.archiveCacheDir)
 	if err != nil {
-		return fmt.Errorf("resolve locked source provider for %s %q: %w", kind, name, err)
+		return err
 	}
-	if archive.SHA256 == "" && archiveReferenceNeedsIntegrityHash(archiveLocation) {
-		return fmt.Errorf("no verified hash for platform %s for %s %q; run `%s --platform %s`", platform, kind, name, formatLockCommand(paths), platform)
-	}
-	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), sourceAuthToken(app), archiveLocation)
-	if err != nil {
-		return fmt.Errorf("download locked source provider for %s %q: %w", kind, name, err)
-	}
-	defer download.Cleanup()
-	if archive.SHA256 != "" && download.SHA256Hex != archive.SHA256 {
-		return fmt.Errorf("locked source provider digest mismatch for %s %q: got %s, want %s", kind, name, download.SHA256Hex, archive.SHA256)
-	}
-	if archive.SHA256 == "" {
-		sourceLocation := entry.Source
-		if !isRemoteReleaseMetadataLocation(sourceLocation) {
-			sourceLocation = resolveLockPath(paths.configDir, sourceLocation)
-		}
-		expectedSHA, err := localReleaseArchiveExpectedSHA(sourceLocation, resolvedKey, archiveLocation)
-		if err != nil {
-			return fmt.Errorf("load local archive metadata for %s %q: %w", kind, name, err)
-		}
-		if expectedSHA != "" && download.SHA256Hex != expectedSHA {
-			return fmt.Errorf("locked source provider digest mismatch for %s %q: got %s, want %s", kind, name, download.SHA256Hex, expectedSHA)
-		}
-	}
+	defer cleanupDownload()
 
 	if destDir == "" {
 		return fmt.Errorf("unsupported component %q", name)
@@ -5443,38 +5381,11 @@ func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths lifecy
 
 func (l *Lifecycle) materializeLockedUIProvider(ctx context.Context, paths lifecyclePaths, app *config.ProviderEntry, entry LockEntry, destDir string) error {
 	platform := providerpkg.CurrentPlatformString()
-	archive, resolvedKey, ok := resolveArchiveForPlatform(entry, platform)
-	if !ok || archive.URL == "" {
-		return fmt.Errorf("no archive for platform %s for ui provider; run `%s --platform %s`", platform, formatLockCommand(paths), platform)
-	}
-	archiveLocation, err := resolveLockedArchiveLocation(paths.configDir, entry.Source, archive.URL)
+	download, _, cleanupDownload, err := l.downloadLockedArchive(ctx, paths, app, entry, platform, "ui provider", paths.archiveCacheDir)
 	if err != nil {
-		return fmt.Errorf("resolve locked source for ui provider: %w", err)
+		return err
 	}
-	if archive.SHA256 == "" && archiveReferenceNeedsIntegrityHash(archiveLocation) {
-		return fmt.Errorf("no verified hash for platform %s for ui provider; run `%s --platform %s`", platform, formatLockCommand(paths), platform)
-	}
-	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), sourceAuthToken(app), archiveLocation)
-	if err != nil {
-		return fmt.Errorf("download locked source for ui provider: %w", err)
-	}
-	defer download.Cleanup()
-	if archive.SHA256 != "" && download.SHA256Hex != archive.SHA256 {
-		return fmt.Errorf("locked source digest mismatch for ui provider: got %s, want %s", download.SHA256Hex, archive.SHA256)
-	}
-	if archive.SHA256 == "" {
-		sourceLocation := entry.Source
-		if !isRemoteReleaseMetadataLocation(sourceLocation) {
-			sourceLocation = resolveLockPath(paths.configDir, sourceLocation)
-		}
-		expectedSHA, err := localReleaseArchiveExpectedSHA(sourceLocation, resolvedKey, archiveLocation)
-		if err != nil {
-			return fmt.Errorf("load local archive metadata for ui provider: %w", err)
-		}
-		if expectedSHA != "" && download.SHA256Hex != expectedSHA {
-			return fmt.Errorf("locked source digest mismatch for ui provider: got %s, want %s", download.SHA256Hex, expectedSHA)
-		}
-	}
+	defer cleanupDownload()
 
 	if err := os.RemoveAll(destDir); err != nil {
 		return fmt.Errorf("remove stale cache for ui provider: %w", err)
@@ -5493,6 +5404,55 @@ func (l *Lifecycle) materializeLockedUIProvider(ctx context.Context, paths lifec
 		return fmt.Errorf("locked source manifest version mismatch for ui provider: got %q, want %q", installed.Manifest.Version, entry.Version)
 	}
 	return nil
+}
+
+func (l *Lifecycle) downloadLockedArchive(ctx context.Context, paths lifecyclePaths, app *config.ProviderEntry, entry LockEntry, platform, subject, cacheDir string) (*providerpkg.DownloadResult, string, func(), error) {
+	archive, resolvedKey, ok := resolveArchiveForPlatform(entry, platform)
+	if !ok || archive.URL == "" {
+		return nil, "", nil, fmt.Errorf("no archive for platform %s for %s; run `%s --platform %s`", platform, subject, formatLockCommand(paths), platform)
+	}
+	archiveLocation, err := resolveLockedArchiveLocation(paths.configDir, entry.Source, archive.URL)
+	if err != nil {
+		return nil, "", nil, fmt.Errorf("resolve locked source archive for %s: %w", subject, err)
+	}
+	if archive.SHA256 == "" && archiveReferenceNeedsIntegrityHash(archiveLocation) {
+		return nil, "", nil, fmt.Errorf("no verified hash for platform %s for %s; run `%s --platform %s`", platform, subject, formatLockCommand(paths), platform)
+	}
+	expectedSHA, err := expectedSHAForLockedArchive(paths, entry, resolvedKey, archiveLocation, archive)
+	if err != nil {
+		return nil, "", nil, fmt.Errorf("resolve locked archive digest for %s: %w", subject, err)
+	}
+	download, err := downloadArchiveForSourceWithCache(ctx, l.metadataHTTPClient(), sourceAuthToken(app), archiveLocation, expectedSHA, cacheDir)
+	if err != nil {
+		return nil, "", nil, lockedArchiveDownloadError{err: fmt.Errorf("download locked source archive for %s: %w", subject, err)}
+	}
+	return download, resolvedKey, download.Cleanup, nil
+}
+
+func expectedSHAForLockedArchive(paths lifecyclePaths, entry LockEntry, resolvedKey, archiveLocation string, archive LockArchive) (string, error) {
+	if strings.TrimSpace(archive.SHA256) != "" {
+		sha, _, err := normalizeArchiveSHA256(archive.SHA256)
+		if err != nil {
+			return "", fmt.Errorf("lock archive sha256: %w", err)
+		}
+		return sha, nil
+	}
+	sourceLocation := entry.Source
+	if !isRemoteReleaseMetadataLocation(sourceLocation) {
+		sourceLocation = resolveLockPath(paths.configDir, sourceLocation)
+	}
+	expectedSHA, err := localReleaseArchiveExpectedSHA(sourceLocation, resolvedKey, archiveLocation)
+	if err != nil {
+		return "", fmt.Errorf("load local archive metadata: %w", err)
+	}
+	sha, hasSHA, err := normalizeArchiveSHA256(expectedSHA)
+	if err != nil {
+		return "", fmt.Errorf("local archive metadata sha256: %w", err)
+	}
+	if !hasSHA {
+		return "", nil
+	}
+	return sha, nil
 }
 
 func (l *Lifecycle) downloadPlatformArchives(ctx context.Context, lock *Lockfile, paths lifecyclePaths, platforms []struct{ GOOS, GOARCH string }, tokenForSource map[string]string) error {

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -2632,6 +2632,16 @@ func TestSourceAppMetadataURLPrepareAndLockedLoad(t *testing.T) {
 					t.Fatalf("extra archive request count after sync = %d, want 0", got)
 				}
 			}
+			if tc.localSource && tc.remoteArchives {
+				cacheDir := filepath.Join(dir, "archive-cache-local-metadata")
+				assertRemoteArchiveCacheRoundTrip(t, lc, configPath, cacheDir, wantCurrentSHA, &currentArchiveCount, func() error {
+					return os.RemoveAll(appRoot)
+				}, func() {
+					if handlerErr := nextHandlerErr(); handlerErr != nil {
+						t.Fatal(handlerErr)
+					}
+				})
+			}
 			cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
 			if err != nil {
 				t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
@@ -2887,6 +2897,17 @@ packages:
 		t.Fatalf("archive request count after sync = %d, want %d", got, archiveBefore+1)
 	}
 
+	cacheDir := filepath.Join(dir, "archive-cache")
+	resetAppRoot := func() error { return os.RemoveAll(appRoot) }
+	drainHandlerErr := func() {
+		if handlerErr := nextHandlerErr(); handlerErr != nil {
+			t.Fatal(handlerErr)
+		}
+	}
+	assertCheckSyncDoesNotPopulateArchiveCache(t, lc, configPath, cacheDir, resetAppRoot)
+	assertRemoteArchiveCacheRoundTrip(t, lc, configPath, cacheDir, currentArchiveSHAHex, &archiveCount, resetAppRoot, drainHandlerErr)
+	assertRemoteArchiveCacheRepair(t, lc, configPath, cacheDir, currentArchiveSHAHex, &archiveCount, resetAppRoot, drainHandlerErr)
+
 	archiveBeforeLoad := archiveCount.Load()
 	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
 	if err != nil {
@@ -3104,6 +3125,7 @@ func TestSourceWorkflowMetadataURLPrepareAndLockedLoad(t *testing.T) {
 		t.Fatalf("read workflow archive: %v", err)
 	}
 	archiveSHA := sha256.Sum256(archiveData)
+	archiveSHAHex := hex.EncodeToString(archiveSHA[:])
 
 	var metadataCount atomic.Int64
 	var archiveCount atomic.Int64
@@ -3139,7 +3161,7 @@ func TestSourceWorkflowMetadataURLPrepareAndLockedLoad(t *testing.T) {
 				Artifacts: map[string]providerReleaseArtifact{
 					providerpkg.CurrentPlatformString(): {
 						Path:   filepath.Base(archivePathURL),
-						SHA256: hex.EncodeToString(archiveSHA[:]),
+						SHA256: archiveSHAHex,
 					},
 				},
 			}
@@ -3242,6 +3264,14 @@ func TestSourceWorkflowMetadataURLPrepareAndLockedLoad(t *testing.T) {
 	if got := archiveCount.Load() - archiveBefore; got != 1 {
 		t.Fatalf("archive request count during sync = %d, want 1", got)
 	}
+	cacheDir := filepath.Join(dir, "archive-cache")
+	assertRemoteArchiveCacheRoundTrip(t, lc, configPath, cacheDir, archiveSHAHex, &archiveCount, func() error {
+		return os.RemoveAll(workflowRoot)
+	}, func() {
+		if handlerErr := nextHandlerErr(); handlerErr != nil {
+			t.Fatal(handlerErr)
+		}
+	})
 	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
 	if err != nil {
 		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
@@ -3449,6 +3479,7 @@ func TestSourceUIMetadataURLPrepareAndLockedLoad(t *testing.T) {
 		t.Fatalf("read ui archive: %v", err)
 	}
 	archiveSHA := sha256.Sum256(archiveData)
+	archiveSHAHex := hex.EncodeToString(archiveSHA[:])
 
 	var metadataCount atomic.Int64
 	var archiveCount atomic.Int64
@@ -3484,7 +3515,7 @@ func TestSourceUIMetadataURLPrepareAndLockedLoad(t *testing.T) {
 				Artifacts: map[string]providerReleaseArtifact{
 					providerpkg.CurrentPlatformString(): {
 						Path:   filepath.Base(archivePathURL),
-						SHA256: hex.EncodeToString(archiveSHA[:]),
+						SHA256: archiveSHAHex,
 					},
 				},
 			}
@@ -3591,6 +3622,14 @@ func TestSourceUIMetadataURLPrepareAndLockedLoad(t *testing.T) {
 	if got := archiveCount.Load() - archiveBefore; got != 1 {
 		t.Fatalf("archive request count during sync = %d, want 1", got)
 	}
+	cacheDir := filepath.Join(dir, "archive-cache")
+	assertRemoteArchiveCacheRoundTrip(t, lc, configPath, cacheDir, archiveSHAHex, &archiveCount, func() error {
+		return os.RemoveAll(uiRoot)
+	}, func() {
+		if handlerErr := nextHandlerErr(); handlerErr != nil {
+			t.Fatal(handlerErr)
+		}
+	})
 	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
 	if err != nil {
 		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)

--- a/gestaltd/internal/operator/lockschema.go
+++ b/gestaltd/internal/operator/lockschema.go
@@ -2,7 +2,6 @@ package operator
 
 import (
 	"fmt"
-	"maps"
 	"slices"
 	"strings"
 
@@ -269,7 +268,7 @@ func portableEntriesFromLockEntries(entries map[string]LockEntry, kind string) m
 			Source:             source,
 			SourceRef:          cloneLockSourceRef(entry.SourceRef),
 			Version:            entry.Version,
-			Archives:           maps.Clone(entry.Archives),
+			Archives:           normalizeLockArchives(entry.Archives),
 			Manifest:           entry.StaticManifest,
 			CatalogAvailable:   entry.StaticCatalogAvailable,
 			CatalogFingerprint: entry.StaticCatalogFingerprint,
@@ -299,7 +298,7 @@ func lockEntriesFromPortableEntries(entries map[string]portableLockEntry) map[st
 			Source:                   source,
 			SourceRef:                cloneLockSourceRef(entry.SourceRef),
 			Version:                  entry.Version,
-			Archives:                 maps.Clone(entry.Archives),
+			Archives:                 normalizeLockArchives(entry.Archives),
 			StaticManifest:           entry.Manifest,
 			StaticCatalogAvailable:   entry.CatalogAvailable,
 			StaticCatalogFingerprint: entry.CatalogFingerprint,
@@ -308,6 +307,23 @@ func lockEntriesFromPortableEntries(entries map[string]portableLockEntry) map[st
 		}
 	}
 	return runtimeEntries
+}
+
+func normalizeLockArchives(archives map[string]LockArchive) map[string]LockArchive {
+	if len(archives) == 0 {
+		return nil
+	}
+	normalized := make(map[string]LockArchive, len(archives))
+	for platform := range archives {
+		archive := archives[platform]
+		if sha, ok := canonicalArchiveCacheSHA(archive.SHA256); ok {
+			archive.SHA256 = sha
+		} else {
+			archive.SHA256 = strings.TrimSpace(archive.SHA256)
+		}
+		normalized[platform] = archive
+	}
+	return normalized
 }
 
 func cloneLockSourceRef(src *LockSourceRef) *LockSourceRef {


### PR DESCRIPTION
## Summary

Adds an opt-in archive cache for locked sync materialization through `gestaltd sync --locked --cache-dir PATH`.

The cache reuses verified remote release archives across sync runs without changing lockfile contents, config schemas, prepared artifact layout, or default sync behavior. Calls that do not pass `--cache-dir` continue to download archives into per-run temp files, and `sync --locked --check` remains read-only.

This gives deploy builds a simple way to keep the expensive remote tarball downloads out of repeated `gestaltd sync` runs while still treating the lockfile SHA-256 as the source of truth for every cached byte.

## Interfaces

```sh
gestaltd sync --locked [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--parallelism N] [--cache-dir PATH] [--check]
```

```sh
gestaltd sync \
  --locked \
  --config ./config.yaml \
  --cache-dir ./.gestaltd-archive-cache
```

`--cache-dir` is flag-only. Relative paths resolve from the current working directory, matching other CLI path overrides. There is no config-file field, environment variable, default cache directory, pruning command, TTL, or lockfile schema change.

## Runtime

Locked sync now passes the resolved archive cache directory through lifecycle state only for materializing syncs. The provider, component, and UI locked materializers use it when the resolved archive location is remote HTTP(S) and the lock entry has a canonical SHA-256.

Archives are stored under the cache directory by SHA-256. Cache hits are checked for regular-file shape and size, copied into a private temp file while hashing, and installed from that temp file only if the computed digest still matches the lock. Corrupt or oversized regular cache files are removed and redownloaded; suspicious non-regular cache entries fail sync with context.

The cache does not store prepared artifact directories, local source builds, local archive paths, provider metadata, or repository indexes. Source-auth secret resolution still runs before materialization, so a warm cache skips archive HTTP downloads but does not bypass the existing auth-resolution flow.
