### PR TITLE
Handle omitted tool refs in TypeScript request context

### DIFF
--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -875,7 +875,7 @@ function providerRequest(
 function providerRequestToolRefs(
   requestContext?: ProtoRequestContext,
 ): AgentToolRef[] {
-  return requestContext?.toolRefs.map(agentToolRefFromProto) ?? [];
+  return requestContext?.toolRefs?.map(agentToolRefFromProto) ?? [];
 }
 
 function providerHTTPSubjectRequest(

--- a/sdk/typescript/tests/runtime.test.ts
+++ b/sdk/typescript/tests/runtime.test.ts
@@ -2306,6 +2306,27 @@ test("integration provider request context includes workflow metadata", async ()
       },
     ],
   });
+
+  const omittedToolRefs = await (service.execute as any)(
+    create(ExecuteRequestSchema, {
+      operation: "inspect",
+      params: {},
+      token: "token-123",
+      context: create(RequestContextSchema, {
+        host: create(HostContextSchema, {
+          publicBaseUrl: "https://gestalt.example.test",
+        }),
+      }),
+    }),
+  );
+
+  expect(JSON.parse(omittedToolRefs.body)).toMatchObject({
+    host: {
+      publicBaseUrl: "https://gestalt.example.test",
+    },
+    toolRefsSet: false,
+    toolRefs: [],
+  });
 });
 
 test("s3 writeObject closes unread request frames when provider returns early", async () => {


### PR DESCRIPTION
## Summary
- Default omitted TypeScript request-context tool refs to an empty array.
- Cover app execution when request context exists without tool refs.

## Test plan
- [x] `bun test tests/runtime.test.ts`
- [x] `bun run check`