### PR TITLE
Require workflow event publisher source

### DIFF
--- a/gestaltd/internal/server/handlers_workflow_events.go
+++ b/gestaltd/internal/server/handlers_workflow_events.go
@@ -92,7 +92,8 @@ func (s *Server) writeWorkflowPublishEventError(w http.ResponseWriter, r *http.R
 	case errors.Is(err, workflowmanager.ErrWorkflowSubjectRequired),
 		errors.Is(err, workflowmanager.ErrWorkflowScheduleSubject):
 		writeError(w, http.StatusUnauthorized, err.Error())
-	case errors.Is(err, workflowmanager.ErrWorkflowEventTypeRequired):
+	case errors.Is(err, workflowmanager.ErrWorkflowEventSourceRequired),
+		errors.Is(err, workflowmanager.ErrWorkflowEventTypeRequired):
 		writeError(w, http.StatusBadRequest, err.Error())
 	default:
 		s.writeWorkflowPublishEventProviderError(r.Context(), w, err)

--- a/gestaltd/internal/server/workflow_schedule_test.go
+++ b/gestaltd/internal/server/workflow_schedule_test.go
@@ -2707,7 +2707,7 @@ func TestWorkflowEventTriggerCreateRequiresMatchType(t *testing.T) {
 	}
 }
 
-func TestWorkflowEventPublishFansOutAcrossWorkflowProviders(t *testing.T) {
+func TestWorkflowEventPublishRequiresCallerAppSource(t *testing.T) {
 	t.Parallel()
 
 	services := testutil.NewStubServices(t)
@@ -2762,66 +2762,16 @@ func TestWorkflowEventPublishFansOutAcrossWorkflowProviders(t *testing.T) {
 		t.Fatalf("publish request: %v", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusAccepted {
+	if resp.StatusCode != http.StatusBadRequest {
 		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("expected 202, got %d: %s", resp.StatusCode, body)
+		t.Fatalf("expected 400, got %d: %s", resp.StatusCode, body)
 	}
-
-	var body struct {
-		Status string `json:"status"`
-		Event  struct {
-			ID          string         `json:"id"`
-			Type        string         `json:"type"`
-			Source      string         `json:"source"`
-			Subject     string         `json:"subject"`
-			SpecVersion string         `json:"specVersion"`
-			Time        *time.Time     `json:"time"`
-			Data        map[string]any `json:"data"`
-			Extensions  map[string]any `json:"extensions"`
-		} `json:"event"`
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "workflow event source is required") {
+		t.Fatalf("response body = %s, want workflow event source error", body)
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
-		t.Fatalf("decode publish response: %v", err)
-	}
-	if body.Status != "published" {
-		t.Fatalf("publish response status = %q, want published", body.Status)
-	}
-	if body.Event.ID == "" || body.Event.SpecVersion != "1.0" || body.Event.Time == nil {
-		t.Fatalf("published event = %#v", body.Event)
-	}
-	if body.Event.Type != "roadmap.item.updated" || body.Event.Source != "roadmap" || body.Event.Subject != "item" {
-		t.Fatalf("published event = %#v", body.Event)
-	}
-	if got := body.Event.Data["id"]; got != "item-1" {
-		t.Fatalf("published event data = %#v", body.Event.Data)
-	}
-	if got := body.Event.Extensions["traceId"]; got != "trace-1" {
-		t.Fatalf("published event extensions = %#v", body.Event.Extensions)
-	}
-
-	for name, provider := range map[string]*memoryWorkflowProvider{
-		"basic":    basicProvider,
-		"advanced": advancedProvider,
-	} {
-		if len(provider.publishEventReqs) != 1 {
-			t.Fatalf("%s publish requests = %d, want 1", name, len(provider.publishEventReqs))
-		}
-		if got := provider.publishEventReqs[0].GetAppName(); got != "" {
-			t.Fatalf("%s publish app = %q, want empty global publish", name, got)
-		}
-		for _, publishReq := range provider.publishEventReqs {
-			publishedAt := publishReq.GetEvent().GetTime().AsTime()
-			if publishReq.GetEvent().GetId() != body.Event.ID || publishReq.GetEvent().GetSpecVersion() != "1.0" || publishReq.GetEvent().GetTime() == nil || !publishedAt.Equal(*body.Event.Time) {
-				t.Fatalf("%s publish event = %#v, response = %#v", name, publishReq.GetEvent(), body.Event)
-			}
-			publishedBy := publishReq.GetPublishedBy()
-			if publishedBy.GetSubjectId() != principal.UserSubjectID(user.ID) ||
-				publishedBy.GetSubjectKind() != "user" ||
-				publishedBy.GetDisplayName() != "Ada" ||
-				publishedBy.GetAuthSource() != "session" {
-				t.Fatalf("%s published_by = %#v, want publishing user actor", name, publishedBy)
-			}
-		}
+	if len(basicProvider.publishEventReqs) != 0 || len(advancedProvider.publishEventReqs) != 0 {
+		t.Fatalf("publish requests basic=%d advanced=%d, want none", len(basicProvider.publishEventReqs), len(advancedProvider.publishEventReqs))
 	}
 }
 

--- a/gestaltd/services/workflows/manager_server.go
+++ b/gestaltd/services/workflows/manager_server.go
@@ -729,7 +729,7 @@ func workflowManagerStatusError(err error) error {
 	switch {
 	case errors.Is(err, workflowmanager.ErrWorkflowNotConfigured), errors.Is(err, invocation.ErrNoCredential), errors.Is(err, invocation.ErrAmbiguousInstance), errors.Is(err, invocation.ErrUserResolution):
 		return status.Error(codes.FailedPrecondition, err.Error())
-	case errors.Is(err, workflowmanager.ErrWorkflowEventMatchRequired), errors.Is(err, workflowmanager.ErrWorkflowEventTypeRequired), errors.Is(err, workflowmanager.ErrWorkflowKeyRequired), errors.Is(err, workflowmanager.ErrWorkflowSignalNameRequired), errors.Is(err, invocation.ErrInvalidInvocation):
+	case errors.Is(err, workflowmanager.ErrWorkflowEventMatchRequired), errors.Is(err, workflowmanager.ErrWorkflowEventSourceRequired), errors.Is(err, workflowmanager.ErrWorkflowEventTypeRequired), errors.Is(err, workflowmanager.ErrWorkflowKeyRequired), errors.Is(err, workflowmanager.ErrWorkflowSignalNameRequired), errors.Is(err, invocation.ErrInvalidInvocation):
 		return status.Error(codes.InvalidArgument, err.Error())
 	case errors.Is(err, workflowmanager.ErrWorkflowScheduleSubject), errors.Is(err, invocation.ErrNotAuthenticated):
 		return status.Error(codes.Unauthenticated, err.Error())

--- a/gestaltd/services/workflows/manager_server_test.go
+++ b/gestaltd/services/workflows/manager_server_test.go
@@ -107,7 +107,7 @@ func TestManagerServerPublishEventThreadsCallerAppToSelectedProvider(t *testing.
 	published, err := server.PublishEvent(context.Background(), &proto.PublishWorkflowProviderEventRequest{
 		ProviderName:    "selected",
 		InvocationToken: token,
-		Event:           &proto.WorkflowEvent{Type: "valon_sats.attempt.submitted"},
+		Event:           &proto.WorkflowEvent{Type: "valon_sats.attempt.submitted", Source: "slack"},
 	})
 	if err != nil {
 		t.Fatalf("PublishEvent: %v", err)
@@ -120,6 +120,9 @@ func TestManagerServerPublishEventThreadsCallerAppToSelectedProvider(t *testing.
 	}
 	if got := selected.publishReqs[0].GetAppName(); got != "valonSats" {
 		t.Fatalf("selected publish app = %q, want valonSats", got)
+	}
+	if got := selected.publishReqs[0].GetEvent().GetSource(); got != "valonSats" {
+		t.Fatalf("selected publish source = %q, want valonSats", got)
 	}
 	if len(other.publishReqs) != 0 {
 		t.Fatalf("other publish requests = %d, want 0", len(other.publishReqs))
@@ -181,6 +184,9 @@ func TestManagerServerPublishEventThreadsCallerAppToFanoutProviders(t *testing.T
 		if got := provider.publishReqs[0].GetAppName(); got != "valonSats" {
 			t.Fatalf("%s publish app = %q, want valonSats", name, got)
 		}
+		if got := provider.publishReqs[0].GetEvent().GetSource(); got != "valonSats" {
+			t.Fatalf("%s publish source = %q, want valonSats", name, got)
+		}
 	}
 	for _, providerName := range []string{"first", "second"} {
 		assertManagerServerWorkflowAudit(t, auditBuf.String(), map[string]any{
@@ -200,7 +206,7 @@ func TestManagerServerPublishEventThreadsCallerAppToFanoutProviders(t *testing.T
 	}
 }
 
-func TestWorkflowManagerPublishEventSelectedProviderPreservesBlankApp(t *testing.T) {
+func TestWorkflowManagerPublishEventSelectedProviderRequiresCallerApp(t *testing.T) {
 	t.Parallel()
 
 	selected := &recordingWorkflowProvider{}
@@ -219,14 +225,11 @@ func TestWorkflowManagerPublishEventSelectedProviderPreservesBlankApp(t *testing
 		AppName:      "   ",
 		Event:        coreworkflow.Event{Type: "valon_sats.attempt.submitted"},
 	})
-	if err != nil {
-		t.Fatalf("PublishEvent: %v", err)
+	if !errors.Is(err, workflowmanager.ErrWorkflowEventSourceRequired) {
+		t.Fatalf("PublishEvent error = %v, want ErrWorkflowEventSourceRequired", err)
 	}
-	if len(selected.publishReqs) != 1 {
-		t.Fatalf("selected publish requests = %d, want 1", len(selected.publishReqs))
-	}
-	if got := selected.publishReqs[0].GetAppName(); got != "" {
-		t.Fatalf("selected publish app = %q, want empty", got)
+	if len(selected.publishReqs) != 0 {
+		t.Fatalf("selected publish requests = %d, want 0", len(selected.publishReqs))
 	}
 }
 

--- a/gestaltd/services/workflows/workflowmanager/manager.go
+++ b/gestaltd/services/workflows/workflowmanager/manager.go
@@ -27,14 +27,15 @@ import (
 )
 
 var (
-	ErrWorkflowNotConfigured      = errors.New("workflow is not configured")
-	ErrWorkflowSubjectRequired    = errors.New("workflow subject is required")
-	ErrWorkflowScheduleSubject    = ErrWorkflowSubjectRequired
-	ErrDuplicateWorkflowObjects   = errors.New("workflow object matched multiple providers")
-	ErrWorkflowEventMatchRequired = errors.New("workflow trigger match.type is required")
-	ErrWorkflowEventTypeRequired  = errors.New("workflow event type is required")
-	ErrWorkflowKeyRequired        = errors.New("workflow key is required")
-	ErrWorkflowSignalNameRequired = errors.New("workflow signal name is required")
+	ErrWorkflowNotConfigured       = errors.New("workflow is not configured")
+	ErrWorkflowSubjectRequired     = errors.New("workflow subject is required")
+	ErrWorkflowScheduleSubject     = ErrWorkflowSubjectRequired
+	ErrDuplicateWorkflowObjects    = errors.New("workflow object matched multiple providers")
+	ErrWorkflowEventMatchRequired  = errors.New("workflow trigger match.type is required")
+	ErrWorkflowEventSourceRequired = errors.New("workflow event source is required")
+	ErrWorkflowEventTypeRequired   = errors.New("workflow event type is required")
+	ErrWorkflowKeyRequired         = errors.New("workflow key is required")
+	ErrWorkflowSignalNameRequired  = errors.New("workflow signal name is required")
 )
 
 const defaultWorkflowEventSpecVersion = "1.0"
@@ -871,7 +872,8 @@ func workflowTargetHasApp(target coreworkflow.Target, appName string) bool {
 func (m *Manager) PublishEvent(ctx context.Context, p *principal.Principal, req EventPublish) (out coreworkflow.Event, err error) {
 	p = principal.Canonicalized(p)
 	ctx, audit := m.beginWorkflowAudit(ctx, p, workflowAuditOperationEventPublish)
-	audit.setCallerApp(req.AppName)
+	appName := strings.TrimSpace(req.AppName)
+	audit.setCallerApp(appName)
 	finishAudit := true
 	defer func() {
 		eventType := out.Type
@@ -891,8 +893,11 @@ func (m *Manager) PublishEvent(ctx context.Context, p *principal.Principal, req 
 	}
 
 	providerSelection := strings.TrimSpace(req.ProviderName)
-	appName := strings.TrimSpace(req.AppName)
+	if appName == "" {
+		return coreworkflow.Event{}, ErrWorkflowEventSourceRequired
+	}
 	event := req.Event
+	event.Source = appName
 	event = normalizePublishedEvent(event, m.now())
 	if strings.TrimSpace(event.Type) == "" {
 		return coreworkflow.Event{}, ErrWorkflowEventTypeRequired

--- a/gestaltd/services/workflows/workflowmanager/manager_runs.go
+++ b/gestaltd/services/workflows/workflowmanager/manager_runs.go
@@ -300,6 +300,8 @@ func workflowManagerErrorType(err error) string {
 		return "duplicate_workflow_objects"
 	case errors.Is(err, ErrWorkflowEventMatchRequired):
 		return "workflow_event_match_required"
+	case errors.Is(err, ErrWorkflowEventSourceRequired):
+		return "workflow_event_source_required"
 	case errors.Is(err, ErrWorkflowEventTypeRequired):
 		return "workflow_event_type_required"
 	case errors.Is(err, ErrWorkflowKeyRequired):

--- a/gestaltd/services/workflows/workflowmanager/manager_test.go
+++ b/gestaltd/services/workflows/workflowmanager/manager_test.go
@@ -165,7 +165,7 @@ func TestPublishEventPreservesCallerAppName(t *testing.T) {
 	if _, err := manager.PublishEvent(context.Background(), caller, EventPublish{
 		ProviderName: "local",
 		AppName:      " github ",
-		Event:        coreworkflow.Event{Type: "issue.created"},
+		Event:        coreworkflow.Event{Type: "issue.created", Source: "slack"},
 	}); err != nil {
 		t.Fatalf("PublishEvent selected provider: %v", err)
 	}
@@ -182,6 +182,15 @@ func TestPublishEventPreservesCallerAppName(t *testing.T) {
 		if req.GetAppName() != "github" {
 			t.Fatalf("publishedEvents[%d].AppName = %q, want github", i, req.GetAppName())
 		}
+		if req.GetEvent().GetSource() != "github" {
+			t.Fatalf("publishedEvents[%d].Event.Source = %q, want github", i, req.GetEvent().GetSource())
+		}
+	}
+
+	if _, err := manager.PublishEvent(context.Background(), caller, EventPublish{
+		Event: coreworkflow.Event{Type: "issue.deleted"},
+	}); !errors.Is(err, ErrWorkflowEventSourceRequired) {
+		t.Fatalf("PublishEvent without caller app error = %v, want ErrWorkflowEventSourceRequired", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Workflow event publishing now treats the publishing app as the authoritative event source instead of trusting event payloads. The manager rejects publishes that do not carry a caller app and overwrites the event source with that app before handing the event to providers.

This makes event-trigger routing source-scoped without introducing a separate listener key or preserving legacy target-owner publish behavior.

## Contract

App and provider publish paths must identify the publishing app. Body-provided `source` values are ignored, so a caller cannot spoof another source by shaping the CloudEvents payload.

Triggers keep the existing `match.source` field: when set it filters to that source, and when omitted the trigger matches events from any source.

## Runtime

HTTP and workflow-provider APIs surface missing publisher source as an invalid publish request. Provider publish requests receive the normalized event with `source` set to the caller app, so downstream workflow providers can route consistently by event type, optional source, and optional subject.
