### PR TITLE
[codex] update dependabot schedule and cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,62 +3,98 @@ updates:
   - package-ecosystem: docker
     directory: /gestaltd
     schedule:
-      interval: daily
+      interval: "cron"
+      cronjob: "0 9 1,15 * *"
+      timezone: "America/New_York"
+    cooldown:
+      default-days: 14
     commit-message:
       prefix: build
 
   - package-ecosystem: docker
     directory: /gestalt
     schedule:
-      interval: daily
+      interval: "cron"
+      cronjob: "0 9 1,15 * *"
+      timezone: "America/New_York"
+    cooldown:
+      default-days: 14
     commit-message:
       prefix: build
 
   - package-ecosystem: docker
     directory: /docs
     schedule:
-      interval: daily
+      interval: "cron"
+      cronjob: "0 9 1,15 * *"
+      timezone: "America/New_York"
+    cooldown:
+      default-days: 14
     commit-message:
       prefix: build
 
   - package-ecosystem: cargo
     directory: /gestalt
     schedule:
-      interval: daily
+      interval: "cron"
+      cronjob: "0 9 1,15 * *"
+      timezone: "America/New_York"
+    cooldown:
+      default-days: 14
     commit-message:
       prefix: build
 
   - package-ecosystem: cargo
     directory: /sdk/rust
     schedule:
-      interval: daily
+      interval: "cron"
+      cronjob: "0 9 1,15 * *"
+      timezone: "America/New_York"
+    cooldown:
+      default-days: 14
     commit-message:
       prefix: build
 
   - package-ecosystem: gomod
     directory: /gestaltd
     schedule:
-      interval: daily
+      interval: "cron"
+      cronjob: "0 9 1,15 * *"
+      timezone: "America/New_York"
+    cooldown:
+      default-days: 14
     commit-message:
       prefix: build
 
   - package-ecosystem: gomod
     directory: /sdk/go
     schedule:
-      interval: daily
+      interval: "cron"
+      cronjob: "0 9 1,15 * *"
+      timezone: "America/New_York"
+    cooldown:
+      default-days: 14
     commit-message:
       prefix: build
 
   - package-ecosystem: npm
     directory: /docs
     schedule:
-      interval: daily
+      interval: "cron"
+      cronjob: "0 9 1,15 * *"
+      timezone: "America/New_York"
+    cooldown:
+      default-days: 14
     commit-message:
       prefix: build
 
   - package-ecosystem: pip
     directory: /sdk/python
     schedule:
-      interval: daily
+      interval: "cron"
+      cronjob: "0 9 1,15 * *"
+      timezone: "America/New_York"
+    cooldown:
+      default-days: 14
     commit-message:
       prefix: build


### PR DESCRIPTION
## What changed

- Switch Dependabot version update schedules from daily to cron-based runs on the 1st and 15th of each month at 09:00 America/New_York.
- Add a 14-day Dependabot cooldown for all configured ecosystems.

## Impact

Dependabot version update PRs should be less frequent and should avoid new releases until they are at least 14 days old. Security updates are still handled by Dependabot outside this version update cooldown behavior.

## Validation

- Parsed `.github/dependabot.yml` with Ruby YAML.
- Checked every Dependabot update entry has the expected cron schedule and `cooldown.default-days: 14`.