### PR TITLE
Make release locks platform independent

### DIFF
--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -11,6 +11,9 @@ import { Callout } from 'nextra/components'
 </Callout>
 
 `gestaltd` manages server lifecycle and provider releases.
+For release-backed providers, `gestaltd lock` writes platform-independent static
+metadata while `sync --locked` and locked serve select the runtime archive for
+the platform where they run.
 
 ## Server commands
 

--- a/gestaltd/internal/daemon/lifecycle.go
+++ b/gestaltd/internal/daemon/lifecycle.go
@@ -16,34 +16,12 @@ func operatorLifecycle() *operator.Lifecycle {
 	})
 }
 
-func lockConfigWithStatePaths(configFlags []string, state operator.StatePaths, platformFlag string, check bool) error {
+func lockConfigWithStatePaths(configFlags []string, state operator.StatePaths, check bool) error {
 	configPaths := operator.ResolveConfigPaths(configFlags)
-	if platformFlag == "" && check {
-		return operatorLifecycle().CheckLockAtPathsWithStatePaths(configPaths, state, nil)
-	}
-	if platformFlag == "" {
-		_, err := operatorLifecycle().LockAtPathsWithStatePaths(configPaths, state)
-		return err
-	}
-
-	value, err := expandReleasePlatformValue(platformFlag)
-	if err != nil {
-		return err
-	}
-	platforms, err := parseReleasePlatforms(value)
-	if err != nil {
-		return err
-	}
-
-	platArgs := make([]struct{ GOOS, GOARCH string }, len(platforms))
-	for i, p := range platforms {
-		platArgs[i] = struct{ GOOS, GOARCH string }{p.GOOS, p.GOARCH}
-	}
-
 	if check {
-		return operatorLifecycle().CheckLockAtPathsWithStatePaths(configPaths, state, platArgs)
+		return operatorLifecycle().CheckLockAtPathsWithStatePaths(configPaths, state)
 	}
-	_, err = operatorLifecycle().LockAtPathsWithPlatforms(configPaths, state, platArgs)
+	_, err := operatorLifecycle().LockAtPathsWithStatePaths(configPaths, state)
 	return err
 }
 

--- a/gestaltd/internal/daemon/main_test.go
+++ b/gestaltd/internal/daemon/main_test.go
@@ -24,17 +24,18 @@ func TestE2ECLIHelp(t *testing.T) {
 			name:      "root",
 			args:      []string{"--help"},
 			wantParts: []string{"gestaltd validate", "gestaltd lock", "gestaltd sync --locked", "gestaltd agent <command> [flags]", "gestaltd provider <command> [flags]", "gestaltd serve", "--locked", "[--config PATH]...", "--lockfile PATH"},
-			notWant:   []string{"gestaltd bundle", "gestaltd dev", "gestaltd init", "\n  init"},
+			notWant:   []string{"gestaltd lock [--config PATH]... [--lockfile PATH] [--platform", "gestaltd bundle", "gestaltd dev", "gestaltd init", "\n  init"},
 		},
 		{
 			name:      "validate",
 			args:      []string{"validate", "--help"},
-			wantParts: []string{"gestaltd validate", "scoped validation of one app closure", "--app NAME", "--lockfile PATH"},
+			wantParts: []string{"gestaltd validate", "scoped validation of one app closure", "--app NAME", "--lockfile PATH", "--platform os/arch"},
 		},
 		{
 			name:      "lock",
 			args:      []string{"lock", "--help"},
-			wantParts: []string{"gestaltd lock", "write canonical lock metadata", "--platform", "--check"},
+			wantParts: []string{"gestaltd lock", "write canonical lock metadata", "--check"},
+			notWant:   []string{"--platform"},
 		},
 		{
 			name:      "sync",
@@ -84,6 +85,18 @@ func TestE2ECLIHelp(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestRunLockRejectsPlatformFlag(t *testing.T) {
+	t.Parallel()
+
+	out, err := exec.Command(gestaltdBin, "lock", "--platform", "linux/amd64").CombinedOutput()
+	if err == nil {
+		t.Fatalf("gestaltd lock --platform unexpectedly succeeded:\n%s", out)
+	}
+	if !strings.Contains(string(out), "flag provided but not defined: -platform") {
+		t.Fatalf("gestaltd lock --platform output = %s, want unknown flag error", out)
 	}
 }
 

--- a/gestaltd/internal/daemon/provider_registry.go
+++ b/gestaltd/internal/daemon/provider_registry.go
@@ -492,7 +492,7 @@ func runProviderUpgrade(args []string) error {
 		}
 		return nil
 	}
-	if err := lockConfigWithStatePaths(configPaths, operator.StatePaths{LockfilePath: *lockfilePath}, "", false); err != nil {
+	if err := lockConfigWithStatePaths(configPaths, operator.StatePaths{LockfilePath: *lockfilePath}, false); err != nil {
 		return err
 	}
 	fmt.Println("Refreshed provider lock state")

--- a/gestaltd/internal/daemon/run.go
+++ b/gestaltd/internal/daemon/run.go
@@ -256,7 +256,6 @@ func runLock(args []string) error {
 	var configPaths repeatedStringFlag
 	fs.Var(&configPaths, "config", "path to config file (repeat to layer overrides)")
 	lockfilePath := fs.String("lockfile", "", "path to lockfile; defaults to gestalt.lock.json next to the primary config")
-	platformFlag := fs.String("platform", "", "additional platforms to verify hashes for (comma-separated os/arch or \"all\")")
 	check := fs.Bool("check", false, "fail if the lockfile would change")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -267,7 +266,7 @@ func runLock(args []string) error {
 
 	return lockConfigWithStatePaths(configPaths, operator.StatePaths{
 		LockfilePath: *lockfilePath,
-	}, *platformFlag, *check)
+	}, *check)
 }
 
 func runSync(args []string) error {
@@ -434,7 +433,7 @@ func maskEmpty(s string) string {
 func printMainUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
 	writeUsageLine(w, "  gestaltd [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH]")
-	writeUsageLine(w, "  gestaltd lock [--config PATH]... [--lockfile PATH] [--platform PLATFORMS] [--check]")
+	writeUsageLine(w, "  gestaltd lock [--config PATH]... [--lockfile PATH] [--check]")
 	writeUsageLine(w, "  gestaltd sync --locked [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--parallelism N] [--cache-dir PATH] [--check]")
 	writeUsageLine(w, "  gestaltd serve [--app NAME] [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--locked] [--watch]")
 	writeUsageLine(w, "  gestaltd serve --path PATH [--config PATH]... [--name NAME] [--port PORT]")
@@ -476,7 +475,7 @@ func printServeUsage(w io.Writer) {
 
 func printLockUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
-	writeUsageLine(w, "  gestaltd lock [--config PATH]... [--lockfile PATH] [--platform PLATFORMS] [--check]")
+	writeUsageLine(w, "  gestaltd lock [--config PATH]... [--lockfile PATH] [--check]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Resolve provider metadata, validate config against staged scratch artifacts,")
 	writeUsageLine(w, "and write canonical lock metadata without preparing final artifacts.")
@@ -485,7 +484,6 @@ func printLockUsage(w io.Writer) {
 	writeUsageLine(w, "Flags:")
 	writeUsageLine(w, "  --config          Path to a config file; repeat to layer left-to-right")
 	writeUsageLine(w, "  --lockfile        Path to lockfile; defaults to gestalt.lock.json next to the primary config")
-	writeUsageLine(w, "  --platform        Additional platforms to verify (comma-separated os/arch or \"all\")")
 	writeUsageLine(w, "  --check           Fail if the lockfile would change")
 }
 

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -25,6 +25,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/providerregistry"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	appservice "github.com/valon-technologies/gestalt/server/services/apps"
+	"github.com/valon-technologies/gestalt/server/services/apps/packageio"
 	"github.com/valon-technologies/gestalt/server/services/apps/providerpkg"
 	"gopkg.in/yaml.v3"
 )
@@ -44,7 +45,8 @@ const (
 	PreparedRuntimeDir             = ".gestaltd/runtime"
 	PreparedUIDir                  = ".gestaltd/ui"
 
-	platformKeyGeneric = "generic"
+	platformKeyGeneric                    = "generic"
+	staticValidationEntrypointPlaceholder = "static-validation-placeholder"
 )
 
 type Lockfile struct {
@@ -215,22 +217,12 @@ func (l *Lifecycle) PrepareAtPathsWithStatePaths(configPaths []string, state Sta
 }
 
 func (l *Lifecycle) LockAtPathsWithStatePaths(configPaths []string, state StatePaths) (*Lockfile, error) {
-	return l.LockAtPathsWithPlatforms(configPaths, state, nil)
-}
-
-func (l *Lifecycle) LockAtPathsWithPlatforms(configPaths []string, state StatePaths, platforms []struct{ GOOS, GOARCH string }) (*Lockfile, error) {
-	lock, cfg, paths, cleanup, err := l.prepareCommittedLockAtPathsInScratch(configPaths, state)
+	lock, _, paths, cleanup, err := l.prepareCommittedLockAtPathsInScratch(configPaths, state)
 	if cleanup != nil {
 		defer cleanup()
 	}
 	if err != nil {
 		return nil, err
-	}
-	if len(platforms) > 0 {
-		tokenForSource := buildSourceTokenMap(cfg)
-		if err := l.downloadPlatformArchives(context.Background(), lock, paths, platforms, tokenForSource); err != nil {
-			return nil, err
-		}
 	}
 	if err := WriteLockfile(paths.lockfilePath, lock); err != nil {
 		return nil, err
@@ -239,19 +231,13 @@ func (l *Lifecycle) LockAtPathsWithPlatforms(configPaths []string, state StatePa
 	return providerLockfileFromLockfile(lock).toLockfile(), nil
 }
 
-func (l *Lifecycle) CheckLockAtPathsWithStatePaths(configPaths []string, state StatePaths, platforms []struct{ GOOS, GOARCH string }) error {
+func (l *Lifecycle) CheckLockAtPathsWithStatePaths(configPaths []string, state StatePaths) error {
 	lock, cfg, paths, cleanup, err := l.prepareCommittedLockAtPathsInScratch(configPaths, state)
 	if cleanup != nil {
 		defer cleanup()
 	}
 	if err != nil {
 		return err
-	}
-	if len(platforms) > 0 {
-		tokenForSource := buildSourceTokenMap(cfg)
-		if err := l.downloadPlatformArchives(context.Background(), lock, paths, platforms, tokenForSource); err != nil {
-			return err
-		}
 	}
 	expected, err := canonicalLockfileJSON(lock)
 	if err != nil {
@@ -292,34 +278,6 @@ func (l *Lifecycle) SyncAtPathsWithStatePathsOptions(configPaths []string, state
 
 func (l *Lifecycle) CheckSyncAtPathsWithStatePathsOptions(configPaths []string, state StatePaths, opts SyncOptions) error {
 	return l.syncAtPathsWithStatePaths(configPaths, state, artifactModeCheck, opts)
-}
-
-// PrepareAtPathWithPlatforms runs preparation and additionally downloads and hashes
-// archives for the specified extra platforms.
-func (l *Lifecycle) PrepareAtPathWithPlatforms(configPath, artifactsDir string, platforms []struct{ GOOS, GOARCH string }) (*Lockfile, error) {
-	return l.PrepareAtPathsWithPlatforms([]string{configPath}, StatePaths{ArtifactsDir: artifactsDir}, platforms)
-}
-
-// PrepareAtPathsWithPlatforms runs preparation and additionally downloads and hashes
-// archives for the specified extra platforms.
-func (l *Lifecycle) PrepareAtPathsWithPlatforms(configPaths []string, state StatePaths, platforms []struct{ GOOS, GOARCH string }) (*Lockfile, error) {
-	lock, cfg, paths, err := l.prepareAtPathsAndWriteLock(configPaths, state)
-	if err != nil {
-		return nil, err
-	}
-	if len(platforms) == 0 {
-		return lock, nil
-	}
-
-	tokenForSource := buildSourceTokenMap(cfg)
-	if err := l.downloadPlatformArchives(context.Background(), lock, paths, platforms, tokenForSource); err != nil {
-		return nil, err
-	}
-
-	if err := WriteLockfile(paths.lockfilePath, lock); err != nil {
-		return nil, err
-	}
-	return lock, nil
 }
 
 func (l *Lifecycle) prepareAtPathsAndWriteLock(configPaths []string, state StatePaths) (*Lockfile, *config.Config, lifecyclePaths, error) {
@@ -899,48 +857,6 @@ func cloneProviderRepositories(repos []providerregistry.NamedRepository) []provi
 		return nil
 	}
 	return append([]providerregistry.NamedRepository(nil), repos...)
-}
-
-func buildSourceTokenMap(cfg *config.Config) map[string]string {
-	tokens := make(map[string]string)
-	addEntry := func(entry *config.ProviderEntry) {
-		if entry == nil || entry.Source.Auth == nil {
-			return
-		}
-		location := strings.TrimSpace(entry.SourceRemoteLocation())
-		if location == "" {
-			return
-		}
-		tokens[location] = entry.Source.Auth.Token
-		if entry.Source.IsGit() {
-			if snapshot, err := resolveGitSnapshotSource(cfg, entry); err == nil && snapshot.MetadataURL != "" {
-				tokens[snapshot.MetadataURL] = entry.Source.Auth.Token
-			}
-		}
-	}
-	for _, entry := range cfg.Apps {
-		addEntry(entry)
-	}
-	for _, entry := range cfg.Runtime.Providers {
-		if entry != nil {
-			addEntry(&entry.ProviderEntry)
-		}
-	}
-	for _, collection := range hostProviderCollections(cfg) {
-		for _, entry := range collection.entries {
-			addEntry(entry)
-		}
-	}
-	for _, def := range cfg.Providers.IndexedDB {
-		addEntry(def)
-	}
-	for _, def := range cfg.Providers.S3 {
-		addEntry(def)
-	}
-	for _, entry := range cfg.Providers.UI {
-		addEntry(&entry.ProviderEntry)
-	}
-	return tokens
 }
 
 func defaultLockfilePath(configPath string) string {
@@ -2870,35 +2786,6 @@ func archivePolicySubject(kind, name string) string {
 	}
 }
 
-func lockEntryDestDir(paths lifecyclePaths, kind, name string) string {
-	switch kind {
-	case providermanifestv1.KindApp:
-		return providerDestDir(paths, name)
-	case providermanifestv1.KindAuthentication:
-		return authDestDir(paths, name)
-	case providermanifestv1.KindAuthorization:
-		return authorizationDestDir(paths, name)
-	case providermanifestv1.KindSecrets:
-		return secretsDestDir(paths, name)
-	case providermanifestv1.KindCache:
-		return cacheDestDir(paths, name)
-	case providermanifestv1.KindIndexedDB:
-		return indexeddbDestDir(paths, name)
-	case providermanifestv1.KindS3:
-		return s3DestDir(paths, name)
-	case providermanifestv1.KindWorkflow:
-		return workflowDestDir(paths, name)
-	case providerLockKindTelemetry:
-		return telemetryDestDir(paths, name)
-	case providerLockKindAudit:
-		return auditDestDir(paths, name)
-	case providermanifestv1.KindUI:
-		return uiDestDir(paths, name)
-	default:
-		return ""
-	}
-}
-
 func readLockEntryManifest(paths lifecyclePaths, entry LockEntry, destDir string) (*providermanifestv1.Manifest, error) {
 	if strings.TrimSpace(entry.Manifest) != "" {
 		manifestPath := resolveLockPath(paths.artifactsDir, entry.Manifest)
@@ -3801,19 +3688,26 @@ func attachStaticValidationMetadata(lock *Lockfile, cfg *config.Config, catalogs
 	if lock == nil || cfg == nil {
 		return nil
 	}
-	attach := func(entries map[string]LockEntry, name string, entry *config.ProviderEntry) {
+	attach := func(entries map[string]LockEntry, name string, entry *config.ProviderEntry) error {
 		if entries == nil || entry == nil || entry.ResolvedManifest == nil {
-			return
+			return nil
 		}
 		lockEntry, ok := entries[name]
 		if !ok {
-			return
+			return nil
 		}
-		lockEntry.StaticManifest = portableStaticValidationManifest(entry.ResolvedManifest, entry.ResolvedManifestPath)
+		staticManifest, err := portableStaticValidationManifest(entry.ResolvedManifest, entry.ResolvedManifestPath, entry.HasReleaseMetadataSource())
+		if err != nil {
+			return fmt.Errorf("project static validation manifest for %s: %w", name, err)
+		}
+		lockEntry.StaticManifest = staticManifest
 		entries[name] = lockEntry
+		return nil
 	}
 	for name, entry := range cfg.Apps {
-		attach(lock.Providers, name, entry)
+		if err := attach(lock.Providers, name, entry); err != nil {
+			return err
+		}
 		if entry == nil || entry.ResolvedManifest == nil {
 			continue
 		}
@@ -3838,23 +3732,33 @@ func attachStaticValidationMetadata(lock *Lockfile, cfg *config.Config, catalogs
 	for _, collection := range hostProviderCollections(cfg) {
 		entries := lockEntriesForKind(lock, collection.kind)
 		for name, entry := range collection.entries {
-			attach(entries, name, entry)
+			if err := attach(entries, name, entry); err != nil {
+				return err
+			}
 		}
 	}
 	for name, entry := range cfg.Runtime.Providers {
 		if entry != nil {
-			attach(lock.Runtimes, name, &entry.ProviderEntry)
+			if err := attach(lock.Runtimes, name, &entry.ProviderEntry); err != nil {
+				return err
+			}
 		}
 	}
 	for name, entry := range cfg.Providers.IndexedDB {
-		attach(lock.IndexedDBs, name, entry)
+		if err := attach(lock.IndexedDBs, name, entry); err != nil {
+			return err
+		}
 	}
 	for name, entry := range cfg.Providers.S3 {
-		attach(lock.S3, name, entry)
+		if err := attach(lock.S3, name, entry); err != nil {
+			return err
+		}
 	}
 	for name, entry := range cfg.Providers.UI {
 		if entry != nil {
-			attach(lock.UIs, name, &entry.ProviderEntry)
+			if err := attach(lock.UIs, name, &entry.ProviderEntry); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -3934,7 +3838,25 @@ func synthesizedCommittedOwnedUIEntry(paths lifecyclePaths, cfg *config.Config, 
 	return providerRequiresCommittedLock(cfg.Apps[owner])
 }
 
-func portableStaticValidationManifest(manifest *providermanifestv1.Manifest, manifestPath string) *providermanifestv1.Manifest {
+func portableStaticValidationManifest(manifest *providermanifestv1.Manifest, manifestPath string, releaseBacked bool) (*providermanifestv1.Manifest, error) {
+	if manifest == nil {
+		return nil, nil
+	}
+	if releaseBacked {
+		cloned, err := packageio.CloneManifest(manifest)
+		if err != nil {
+			return nil, err
+		}
+		cloned.Artifacts = nil
+		if cloned.Entrypoint != nil {
+			cloned.Entrypoint = &providermanifestv1.Entrypoint{ArtifactPath: staticValidationEntrypointPlaceholder}
+		}
+		return relativizeStaticValidationManifest(cloned, manifestPath), nil
+	}
+	return relativizeStaticValidationManifest(manifest, manifestPath), nil
+}
+
+func relativizeStaticValidationManifest(manifest *providermanifestv1.Manifest, manifestPath string) *providermanifestv1.Manifest {
 	if manifest == nil || manifest.Spec == nil || manifest.Spec.Surfaces == nil || strings.TrimSpace(manifestPath) == "" {
 		return manifest
 	}
@@ -4268,7 +4190,7 @@ func (l *Lifecycle) applyStaticValidationEntry(ctx context.Context, paths lifecy
 		if len(entry.Archives) > 0 {
 			_, resolvedKey, ok := resolveArchiveForPlatform(entry, platform)
 			if !ok {
-				return fmt.Errorf("no archive for platform %s for %s %q; run `%s --platform %s`", platform, kind, name, formatLockCommand(paths), platform)
+				return fmt.Errorf("no archive for platform %s for %s %q; publish an explicit %s archive with `gestaltd provider package --platform %s` or use a generic package where allowed", platform, kind, name, platform, platform)
 			}
 			if err := validateStaticLockedArchivePolicy(archivePolicySubject(kind, name), archivePolicyKind(kind), entry, platform, resolvedKey); err != nil {
 				return err
@@ -4476,7 +4398,7 @@ func fallbackStaticValidationManifest(kind string, entry LockEntry) *providerman
 		Spec:    &providermanifestv1.Spec{},
 	}
 	if lockEntryRuntime(entry, kind) == providerReleaseRuntimeExecutable {
-		manifest.Entrypoint = &providermanifestv1.Entrypoint{ArtifactPath: "static-validation-placeholder"}
+		manifest.Entrypoint = &providermanifestv1.Entrypoint{ArtifactPath: staticValidationEntrypointPlaceholder}
 	}
 	return manifest
 }
@@ -5409,14 +5331,14 @@ func (l *Lifecycle) materializeLockedUIProvider(ctx context.Context, paths lifec
 func (l *Lifecycle) downloadLockedArchive(ctx context.Context, paths lifecyclePaths, app *config.ProviderEntry, entry LockEntry, platform, subject, cacheDir string) (*providerpkg.DownloadResult, string, func(), error) {
 	archive, resolvedKey, ok := resolveArchiveForPlatform(entry, platform)
 	if !ok || archive.URL == "" {
-		return nil, "", nil, fmt.Errorf("no archive for platform %s for %s; run `%s --platform %s`", platform, subject, formatLockCommand(paths), platform)
+		return nil, "", nil, fmt.Errorf("no archive for platform %s for %s; publish an explicit %s archive with `gestaltd provider package --platform %s` or use a generic package where allowed", platform, subject, platform, platform)
 	}
 	archiveLocation, err := resolveLockedArchiveLocation(paths.configDir, entry.Source, archive.URL)
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("resolve locked source archive for %s: %w", subject, err)
 	}
 	if archive.SHA256 == "" && archiveReferenceNeedsIntegrityHash(archiveLocation) {
-		return nil, "", nil, fmt.Errorf("no verified hash for platform %s for %s; run `%s --platform %s`", platform, subject, formatLockCommand(paths), platform)
+		return nil, "", nil, fmt.Errorf("no verified hash for platform %s for %s; publish release metadata with a sha256 for that archive before locking", platform, subject)
 	}
 	expectedSHA, err := expectedSHAForLockedArchive(paths, entry, resolvedKey, archiveLocation, archive)
 	if err != nil {
@@ -5453,68 +5375,6 @@ func expectedSHAForLockedArchive(paths lifecyclePaths, entry LockEntry, resolved
 		return "", nil
 	}
 	return sha, nil
-}
-
-func (l *Lifecycle) downloadPlatformArchives(ctx context.Context, lock *Lockfile, paths lifecyclePaths, platforms []struct{ GOOS, GOARCH string }, tokenForSource map[string]string) error {
-	for _, plat := range platforms {
-		platformKey := providerpkg.PlatformString(plat.GOOS, plat.GOARCH)
-		if err := l.hashPlatformInEntries(ctx, lock, paths, platformKey, tokenForSource); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (l *Lifecycle) hashPlatformInEntries(ctx context.Context, lock *Lockfile, paths lifecyclePaths, platformKey string, tokenForSource map[string]string) error {
-	for _, kind := range providerLockKinds() {
-		lockEntries := lockEntriesForProviderKind(lock, kind)
-		for name := range lockEntries {
-			entry := lockEntries[name]
-			if err := l.hashArchiveEntry(ctx, kind, name, &entry, paths, platformKey, tokenForSource); err != nil {
-				return err
-			}
-			lockEntries[name] = entry
-		}
-	}
-	return nil
-}
-
-func (l *Lifecycle) hashArchiveEntry(ctx context.Context, kind, name string, entry *LockEntry, paths lifecyclePaths, platformKey string, tokenForSource map[string]string) error {
-	if entry.Archives == nil {
-		return nil
-	}
-	archive, resolvedKey, ok := resolveArchiveForPlatform(*entry, platformKey)
-	if !ok || archive.URL == "" || archive.SHA256 != "" {
-		return nil
-	}
-	policyKind := archivePolicyKind(kind)
-	var manifest *providermanifestv1.Manifest
-	if policyKind == providermanifestv1.KindApp {
-		var manifestErr error
-		manifest, manifestErr = readLockEntryManifest(paths, *entry, lockEntryDestDir(paths, kind, name))
-		if manifestErr != nil {
-			return fmt.Errorf("load manifest for %s: %w", archivePolicySubject(kind, name), manifestErr)
-		}
-	}
-	if err := validateLockedArchivePolicy(archivePolicySubject(kind, name), policyKind, manifest, *entry, platformKey, resolvedKey); err != nil {
-		return err
-	}
-	archiveLocation, err := resolveLockedArchiveLocation(paths.configDir, entry.Source, archive.URL)
-	if err != nil {
-		return fmt.Errorf("resolve archive for platform %s, source %s: %w", platformKey, entry.Source, err)
-	}
-	if !archiveReferenceNeedsIntegrityHash(archiveLocation) {
-		return nil
-	}
-	token := tokenForSource[entry.Source]
-	dl, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), token, archiveLocation)
-	if err != nil {
-		return fmt.Errorf("download archive for platform %s, source %s: %w", platformKey, entry.Source, err)
-	}
-	archive.SHA256 = dl.SHA256Hex
-	dl.Cleanup()
-	entry.Archives[resolvedKey] = archive
-	return nil
 }
 
 func resolveProviderIcon(manifest *providermanifestv1.Manifest, manifestPath string, app *config.ProviderEntry) {

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -879,26 +879,44 @@ func TestLockAtPathsValidatesCommittedProviderInvokes(t *testing.T) {
 	callerSource := writeLocalRelease("caller", "github.com/acme/tools/caller", "1.0.0")
 	targetSource := writeLocalRelease("target", "github.com/acme/tools/target", "1.0.0")
 	configPath := filepath.Join(dir, "gestaltd.yaml")
-	configYAML := fmt.Sprintf(`
+	writeConfig := func(callerInvokes string) {
+		t.Helper()
+
+		configYAML := fmt.Sprintf(`
 apiVersion: gestaltd.config/v6
 %sapps:
   target:
     source: %s
   caller:
-    source: %s
-    invokes:
-      - app: target
-        operation: missing
+    source: %s%s
 server:
   providers:
     indexeddb: sqlite
   artifactsDir: %s
   encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-`, requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")), targetSource, callerSource, filepath.ToSlash(filepath.Join(dir, "artifacts")))
-	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
-		t.Fatalf("write config: %v", err)
+`, requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")), targetSource, callerSource, callerInvokes, filepath.ToSlash(filepath.Join(dir, "artifacts")))
+		if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+	}
+	writeConfig("")
+
+	lock, err := NewLifecycle().LockAtPathsWithStatePaths([]string{configPath}, StatePaths{})
+	if err != nil {
+		t.Fatalf("LockAtPathsWithStatePaths: %v", err)
+	}
+	callerStatic := lock.Providers["caller"].StaticManifest
+	if callerStatic == nil || callerStatic.Entrypoint == nil || callerStatic.Entrypoint.ArtifactPath != staticValidationEntrypointPlaceholder {
+		t.Fatalf("caller static manifest entrypoint = %+v, want placeholder", callerStatic)
 	}
 
+	writeConfig(`
+    invokes:
+      - app: target
+        operation: missing`)
+	if _, err := NewLifecycle().LoadForStaticValidationAtPathsWithStatePaths([]string{configPath}, StatePaths{}, StaticValidationOptions{}); err == nil || !strings.Contains(err.Error(), "unknown effective operation") || strings.Contains(err.Error(), "invokes is only supported") {
+		t.Fatalf("LoadForStaticValidationAtPathsWithStatePaths error = %v, want executable committed provider invokes validation error", err)
+	}
 	if _, err := NewLifecycle().LockAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err == nil || !strings.Contains(err.Error(), "unknown effective operation") {
 		t.Fatalf("LockAtPathsWithStatePaths error = %v, want committed provider invokes validation error", err)
 	}
@@ -967,7 +985,7 @@ server:
 		t.Fatalf("write stale lockfile: %v", err)
 	}
 
-	err = lc.CheckLockAtPathsWithStatePaths([]string{configPath}, StatePaths{}, nil)
+	err = lc.CheckLockAtPathsWithStatePaths([]string{configPath}, StatePaths{})
 	if err == nil {
 		t.Fatal("CheckLockAtPathsWithStatePaths unexpectedly succeeded")
 	}
@@ -1109,7 +1127,7 @@ apps:
 	if err := os.Remove(scopedLockPath); err != nil {
 		t.Fatalf("remove empty scoped lockfile: %v", err)
 	}
-	if err := lc.CheckLockAtPathsWithStatePaths([]string{configPath}, StatePaths{AppScope: []string{"alpha"}}, nil); err != nil {
+	if err := lc.CheckLockAtPathsWithStatePaths([]string{configPath}, StatePaths{AppScope: []string{"alpha"}}); err != nil {
 		t.Fatalf("CheckLockAtPathsWithStatePaths should allow missing local-only scoped lockfile: %v", err)
 	}
 
@@ -2499,16 +2517,14 @@ func TestSourceAppMetadataURLPrepareAndLockedLoad(t *testing.T) {
 			}
 
 			lc := NewLifecycle()
-			lock, err := lc.PrepareAtPathWithPlatforms(configPath, "", []struct{ GOOS, GOARCH string }{
-				{GOOS: extraPlatform.goos, GOARCH: extraPlatform.goarch},
-			})
+			lock, err := lc.LockAtPathsWithStatePaths([]string{configPath}, StatePaths{})
 			if err == nil {
 				if handlerErr := nextHandlerErr(); handlerErr != nil {
 					t.Fatal(handlerErr)
 				}
 			}
 			if err != nil {
-				t.Fatalf("PrepareAtPathWithPlatforms: %v", err)
+				t.Fatalf("LockAtPathsWithStatePaths: %v", err)
 			}
 			if handlerErr := nextHandlerErr(); handlerErr != nil {
 				t.Fatal(handlerErr)
@@ -2657,7 +2673,7 @@ func TestSourceAppMetadataURLPrepareAndLockedLoad(t *testing.T) {
 			if cfg.Apps["alpha"].ResolvedManifest.Source != packageSource {
 				t.Fatalf("ResolvedManifest.Source = %q, want %q", cfg.Apps["alpha"].ResolvedManifest.Source, packageSource)
 			}
-			executablePath := resolveLockPath(artifactsDir, entry.Executable)
+			executablePath := filepath.Join(artifactsDir, PreparedProvidersDir, "alpha", filepath.FromSlash(artifactRelPath("provider")))
 			if cfg.Apps["alpha"].Command != executablePath {
 				t.Fatalf("app command = %q, want %q", cfg.Apps["alpha"].Command, executablePath)
 			}
@@ -4995,7 +5011,7 @@ func TestLockAndSyncSkipRuntimeOnlySecretRefs(t *testing.T) {
 	if _, err := lc.LockAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
 		t.Fatalf("LockAtPathsWithStatePaths: %v", err)
 	}
-	if err := lc.CheckLockAtPathsWithStatePaths([]string{configPath}, StatePaths{}, nil); err != nil {
+	if err := lc.CheckLockAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
 		t.Fatalf("CheckLockAtPathsWithStatePaths: %v", err)
 	}
 	if err := lc.SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
@@ -5437,7 +5453,7 @@ packages:
 		t.Fatalf("app archive request count = %d, want 1", got)
 	}
 
-	if err := lc.CheckLockAtPathsWithStatePaths([]string{configPath}, StatePaths{}, nil); err != nil {
+	if err := lc.CheckLockAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
 		if handlerErr := nextHandlerErr(); handlerErr != nil {
 			t.Fatal(handlerErr)
 		}
@@ -5778,7 +5794,7 @@ func TestManagedCacheSourcesLoadForExecutionWithMultipleBindings(t *testing.T) {
 	}
 }
 
-func TestManagedCacheSourcesPrepareAtPathWithPlatformsHashesExtraPlatformArchives(t *testing.T) {
+func TestManagedCacheSourcesLockRecordsReleaseMetadataArchives(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
@@ -5926,9 +5942,9 @@ func TestManagedCacheSourcesPrepareAtPathWithPlatformsHashesExtraPlatformArchive
 			if client != nil {
 				lc = lc.WithHTTPClient(client)
 			}
-			lock, err := lc.PrepareAtPathWithPlatforms(configPath, "", []struct{ GOOS, GOARCH string }{extraPlatform})
+			lock, err := lc.LockAtPathsWithStatePaths([]string{configPath}, StatePaths{})
 			if err != nil {
-				t.Fatalf("PrepareAtPathWithPlatforms: %v", err)
+				t.Fatalf("LockAtPathsWithStatePaths: %v", err)
 			}
 
 			entry, ok := lock.Caches["session"]
@@ -5937,6 +5953,15 @@ func TestManagedCacheSourcesPrepareAtPathWithPlatformsHashesExtraPlatformArchive
 			}
 			if entry.Source != wantSource {
 				t.Fatalf("lock source = %q, want %q", entry.Source, wantSource)
+			}
+			if entry.StaticManifest == nil {
+				t.Fatal("lock static manifest is nil")
+			}
+			if len(entry.StaticManifest.Artifacts) != 0 {
+				t.Fatalf("lock static manifest artifacts = %+v, want nil", entry.StaticManifest.Artifacts)
+			}
+			if entry.StaticManifest.Entrypoint == nil || entry.StaticManifest.Entrypoint.ArtifactPath != staticValidationEntrypointPlaceholder {
+				t.Fatalf("lock static manifest entrypoint = %+v, want placeholder", entry.StaticManifest.Entrypoint)
 			}
 			wantCurrentSHA := hex.EncodeToString(currentArchiveSum[:])
 			wantExtraSHA := hex.EncodeToString(extraArchiveSum[:])
@@ -5956,6 +5981,16 @@ func TestManagedCacheSourcesPrepareAtPathWithPlatformsHashesExtraPlatformArchive
 			}
 			if got := readBack.Caches["session"].Source; got != wantSource {
 				t.Fatalf("readBack source = %q, want %q", got, wantSource)
+			}
+			readBackManifest := readBack.Caches["session"].StaticManifest
+			if readBackManifest == nil {
+				t.Fatal("readBack static manifest is nil")
+			}
+			if len(readBackManifest.Artifacts) != 0 {
+				t.Fatalf("readBack static manifest artifacts = %+v, want nil", readBackManifest.Artifacts)
+			}
+			if readBackManifest.Entrypoint == nil || readBackManifest.Entrypoint.ArtifactPath != staticValidationEntrypointPlaceholder {
+				t.Fatalf("readBack static manifest entrypoint = %+v, want placeholder", readBackManifest.Entrypoint)
 			}
 			if got := readBack.Caches["session"].Archives[providerpkg.CurrentPlatformString()].SHA256; got != wantCurrentSHA {
 				t.Fatalf("readBack current-platform SHA256 = %q, want %q", got, wantCurrentSHA)

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -2,9 +2,9 @@ package operator
 
 import (
 	"archive/tar"
+	"bytes"
 	"cmp"
 	"compress/gzip"
-	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -2493,60 +2493,6 @@ server:
 	}
 }
 
-func TestHashPlatformInEntries_HashesMountedUIAndProviderArchives(t *testing.T) {
-	t.Parallel()
-
-	archiveBytes := []byte("mounted-ui-archive")
-	sum := sha256.Sum256(archiveBytes)
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write(archiveBytes)
-	}))
-	defer srv.Close()
-
-	lock := &Lockfile{
-		Caches: map[string]LockEntry{
-			"session": {
-				Source: "github.com/testowner/cache/session",
-				Archives: map[string]LockArchive{
-					providerpkg.CurrentPlatformString(): {URL: srv.URL},
-				},
-			},
-		},
-		S3: map[string]LockEntry{
-			"assets": {
-				Source: "github.com/testowner/providers/s3",
-				Archives: map[string]LockArchive{
-					providerpkg.CurrentPlatformString(): {URL: srv.URL},
-				},
-			},
-		},
-		UIs: map[string]LockEntry{
-			"roadmap": {
-				Source: "github.com/testowner/web/roadmap",
-				Archives: map[string]LockArchive{
-					platformKeyGeneric: {URL: srv.URL},
-				},
-			},
-		},
-	}
-
-	if err := NewLifecycle().hashPlatformInEntries(context.Background(), lock, lifecyclePaths{}, providerpkg.CurrentPlatformString(), map[string]string{}); err != nil {
-		t.Fatalf("hashPlatformInEntries: %v", err)
-	}
-
-	got := lock.UIs["roadmap"].Archives[platformKeyGeneric].SHA256
-	want := hex.EncodeToString(sum[:])
-	if got != want {
-		t.Fatalf("ui SHA256 = %q, want %q", got, want)
-	}
-	if got := lock.Caches["session"].Archives[providerpkg.CurrentPlatformString()].SHA256; got != want {
-		t.Fatalf("cache SHA256 = %q, want %q", got, want)
-	}
-	if got := lock.S3["assets"].Archives[providerpkg.CurrentPlatformString()].SHA256; got != want {
-		t.Fatalf("S3 SHA256 = %q, want %q", got, want)
-	}
-}
-
 func TestLoadForExecutionAtPath_ResolvesLocalTopLevelPluginsWithoutLockfile(t *testing.T) {
 	t.Parallel()
 
@@ -3376,7 +3322,10 @@ func TestPortableStaticValidationManifestRelativizesLocalSurfaces(t *testing.T) 
 		},
 	}
 
-	got := portableStaticValidationManifest(manifest, manifestPath)
+	got, err := portableStaticValidationManifest(manifest, manifestPath, false)
+	if err != nil {
+		t.Fatalf("portableStaticValidationManifest: %v", err)
+	}
 	if got == manifest {
 		t.Fatal("portableStaticValidationManifest returned original manifest after changing local references")
 	}
@@ -3391,6 +3340,179 @@ func TestPortableStaticValidationManifestRelativizesLocalSurfaces(t *testing.T) 
 	}
 	if manifest.Spec.Surfaces.OpenAPI.Document == "openapi.yaml" {
 		t.Fatal("portableStaticValidationManifest mutated original manifest")
+	}
+}
+
+func TestPortableStaticValidationManifestProjectsReleaseRuntimeFields(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "manifest.yaml")
+	baseManifest := func(artifactPath string, args []string, artifacts []providermanifestv1.Artifact) *providermanifestv1.Manifest {
+		return &providermanifestv1.Manifest{
+			Kind:      providermanifestv1.KindApp,
+			Source:    "github.com/acme/provider",
+			Version:   "1.2.3",
+			Artifacts: artifacts,
+			Entrypoint: &providermanifestv1.Entrypoint{
+				ArtifactPath: artifactPath,
+				Args:         args,
+			},
+			Spec: &providermanifestv1.Spec{
+				Surfaces: &providermanifestv1.ProviderSurfaces{
+					OpenAPI: &providermanifestv1.OpenAPISurface{
+						Document: filepath.Join(dir, "openapi.yaml"),
+					},
+				},
+			},
+		}
+	}
+
+	darwinManifest := baseManifest(
+		"artifacts/darwin/arm64/provider",
+		[]string{"serve-darwin"},
+		[]providermanifestv1.Artifact{{
+			OS:     "darwin",
+			Arch:   "arm64",
+			Path:   "artifacts/darwin/arm64/provider",
+			SHA256: "darwin-sha",
+		}},
+	)
+	linuxManifest := baseManifest(
+		"artifacts/linux/amd64/provider",
+		[]string{"serve-linux"},
+		[]providermanifestv1.Artifact{{
+			OS:     "linux",
+			Arch:   "amd64",
+			Path:   "artifacts/linux/amd64/provider",
+			SHA256: "linux-sha",
+		}},
+	)
+
+	darwinProjected, err := portableStaticValidationManifest(darwinManifest, manifestPath, true)
+	if err != nil {
+		t.Fatalf("project darwin manifest: %v", err)
+	}
+	linuxProjected, err := portableStaticValidationManifest(linuxManifest, manifestPath, true)
+	if err != nil {
+		t.Fatalf("project linux manifest: %v", err)
+	}
+	if len(darwinProjected.Artifacts) != 0 {
+		t.Fatalf("projected artifacts = %+v, want nil", darwinProjected.Artifacts)
+	}
+	if darwinProjected.Entrypoint == nil || darwinProjected.Entrypoint.ArtifactPath != staticValidationEntrypointPlaceholder {
+		t.Fatalf("projected entrypoint = %+v, want placeholder", darwinProjected.Entrypoint)
+	}
+	if len(darwinProjected.Entrypoint.Args) != 0 {
+		t.Fatalf("projected entrypoint args = %+v, want nil", darwinProjected.Entrypoint.Args)
+	}
+	if darwinProjected.Spec.Surfaces.OpenAPI.Document != "openapi.yaml" {
+		t.Fatalf("projected OpenAPI document = %q, want openapi.yaml", darwinProjected.Spec.Surfaces.OpenAPI.Document)
+	}
+	darwinJSON, err := json.Marshal(darwinProjected)
+	if err != nil {
+		t.Fatalf("marshal darwin projection: %v", err)
+	}
+	linuxJSON, err := json.Marshal(linuxProjected)
+	if err != nil {
+		t.Fatalf("marshal linux projection: %v", err)
+	}
+	if !bytes.Equal(darwinJSON, linuxJSON) {
+		t.Fatalf("projected manifests differ:\ndarwin: %s\nlinux: %s", darwinJSON, linuxJSON)
+	}
+	if darwinManifest.Entrypoint.ArtifactPath == staticValidationEntrypointPlaceholder || len(darwinManifest.Artifacts) == 0 {
+		t.Fatal("portableStaticValidationManifest mutated source manifest")
+	}
+
+	localProjected, err := portableStaticValidationManifest(darwinManifest, manifestPath, false)
+	if err != nil {
+		t.Fatalf("project local manifest: %v", err)
+	}
+	if len(localProjected.Artifacts) != 1 {
+		t.Fatalf("local artifacts = %+v, want preserved runtime artifacts", localProjected.Artifacts)
+	}
+	if localProjected.Entrypoint == nil || localProjected.Entrypoint.ArtifactPath != "artifacts/darwin/arm64/provider" || len(localProjected.Entrypoint.Args) != 1 {
+		t.Fatalf("local entrypoint = %+v, want original entrypoint", localProjected.Entrypoint)
+	}
+
+	declarative := &providermanifestv1.Manifest{
+		Kind:      providermanifestv1.KindApp,
+		Version:   "1.2.3",
+		Artifacts: []providermanifestv1.Artifact{{Path: "generic.tar.gz", SHA256: "generic-sha"}},
+		Spec:      &providermanifestv1.Spec{},
+	}
+	declarativeProjected, err := portableStaticValidationManifest(declarative, "", true)
+	if err != nil {
+		t.Fatalf("project declarative manifest: %v", err)
+	}
+	if declarativeProjected.Entrypoint != nil {
+		t.Fatalf("declarative entrypoint = %+v, want nil", declarativeProjected.Entrypoint)
+	}
+	if len(declarativeProjected.Artifacts) != 0 {
+		t.Fatalf("declarative artifacts = %+v, want nil", declarativeProjected.Artifacts)
+	}
+}
+
+func TestAttachStaticValidationMetadataProjectsOnlyReleaseSources(t *testing.T) {
+	t.Parallel()
+
+	manifest := func(binary string) *providermanifestv1.Manifest {
+		return &providermanifestv1.Manifest{
+			Kind:    providermanifestv1.KindApp,
+			Version: "1.2.3",
+			Artifacts: []providermanifestv1.Artifact{{
+				OS:     runtime.GOOS,
+				Arch:   runtime.GOARCH,
+				Path:   binary,
+				SHA256: "sha",
+			}},
+			Entrypoint: &providermanifestv1.Entrypoint{ArtifactPath: binary},
+			Spec:       &providermanifestv1.Spec{},
+		}
+	}
+	cfg := &config.Config{
+		Apps: map[string]*config.ProviderEntry{
+			"release": {
+				Source:           config.NewMetadataSource("https://example.invalid/provider-release.yaml"),
+				ResolvedManifest: manifest("release-provider"),
+			},
+			"local": {
+				Source:           config.ProviderSource{Path: "./local"},
+				ResolvedManifest: manifest("local-provider"),
+			},
+			"git": {
+				Source:           config.NewGitSource(config.GitSourceDef{Repo: "github.com/acme/provider", Ref: "main"}),
+				ResolvedManifest: manifest("git-provider"),
+			},
+		},
+	}
+	lock := &Lockfile{
+		Providers: map[string]LockEntry{
+			"release": {},
+			"local":   {},
+			"git":     {},
+		},
+	}
+
+	if err := attachStaticValidationMetadata(lock, cfg, nil); err != nil {
+		t.Fatalf("attachStaticValidationMetadata: %v", err)
+	}
+
+	releaseManifest := lock.Providers["release"].StaticManifest
+	if len(releaseManifest.Artifacts) != 0 {
+		t.Fatalf("release artifacts = %+v, want nil", releaseManifest.Artifacts)
+	}
+	if releaseManifest.Entrypoint == nil || releaseManifest.Entrypoint.ArtifactPath != staticValidationEntrypointPlaceholder {
+		t.Fatalf("release entrypoint = %+v, want placeholder", releaseManifest.Entrypoint)
+	}
+	for _, name := range []string{"local", "git"} {
+		staticManifest := lock.Providers[name].StaticManifest
+		if len(staticManifest.Artifacts) != 1 {
+			t.Fatalf("%s artifacts = %+v, want preserved runtime artifact", name, staticManifest.Artifacts)
+		}
+		if staticManifest.Entrypoint == nil || staticManifest.Entrypoint.ArtifactPath != name+"-provider" {
+			t.Fatalf("%s entrypoint = %+v, want original entrypoint", name, staticManifest.Entrypoint)
+		}
 	}
 }
 
@@ -3873,6 +3995,22 @@ func TestReadWriteLockfile_RoundTrip(t *testing.T) {
 	if diskLock.SchemaVersion != providerLockSchemaVersion {
 		t.Fatalf("lock schemaVersion = %d, want %d", diskLock.SchemaVersion, providerLockSchemaVersion)
 	}
+	if diskLock.SchemaVersion != 9 {
+		t.Fatalf("lock schemaVersion = %d, want explicit v9 schema", diskLock.SchemaVersion)
+	}
+	diskLock.SchemaVersion = 8
+	oldLockData, err := json.Marshal(diskLock)
+	if err != nil {
+		t.Fatalf("Marshal old schema lock: %v", err)
+	}
+	oldLockPath := filepath.Join(dir, "old-schema.lock.json")
+	if err := os.WriteFile(oldLockPath, oldLockData, 0o644); err != nil {
+		t.Fatalf("write old schema lock: %v", err)
+	}
+	if _, err := ReadLockfile(oldLockPath); err == nil || !strings.Contains(err.Error(), "unsupported lockfile schema version 8") {
+		t.Fatalf("ReadLockfile old schema error = %v, want schema version rejection", err)
+	}
+	diskLock.SchemaVersion = providerLockSchemaVersion
 	providerEntry, ok := diskLock.Providers.App["example"]
 	if !ok {
 		t.Fatal(`disk lock providers.plugin["example"] not found`)
@@ -3990,35 +4128,5 @@ func TestReadWriteLockfile_RoundTrip(t *testing.T) {
 	}
 	if got.Providers["example"].Manifest != "" || got.UIs["roadmap"].AssetRoot != "" {
 		t.Fatal("portable lock schema should not populate local path fields on read")
-	}
-}
-
-func TestHashArchiveEntry_HashesFallbackArchive(t *testing.T) {
-	t.Parallel()
-
-	const payload = "generic app archive"
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(payload))
-	}))
-	defer server.Close()
-
-	entry := LockEntry{
-		Source: server.URL,
-		Archives: map[string]LockArchive{
-			platformKeyGeneric: {URL: server.URL},
-		},
-	}
-
-	if err := NewLifecycle().hashArchiveEntry(context.Background(), providermanifestv1.KindUI, "roadmap", &entry, lifecyclePaths{}, "linux/amd64", nil); err != nil {
-		t.Fatalf("hashArchiveEntry: %v", err)
-	}
-
-	got := entry.Archives[platformKeyGeneric]
-	if got.URL != server.URL {
-		t.Fatalf("generic URL = %q, want %q", got.URL, server.URL)
-	}
-	want := sha256.Sum256([]byte(payload))
-	if got.SHA256 != hex.EncodeToString(want[:]) {
-		t.Fatalf("generic SHA256 = %q, want %q", got.SHA256, hex.EncodeToString(want[:]))
 	}
 }

--- a/gestaltd/internal/operator/lockschema.go
+++ b/gestaltd/internal/operator/lockschema.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	providerLockSchemaName         = "gestaltd-provider-lock"
-	providerLockSchemaVersion      = 8
+	providerLockSchemaVersion      = 9
 	providerLockRevision           = 0
 	providerLockKindWorkflow       = "workflow"
 	providerLockKindTelemetry      = "telemetry"
@@ -192,14 +192,6 @@ func normalizeLockfile(lock *Lockfile) *Lockfile {
 		lock.UIs = make(map[string]LockEntry)
 	}
 	return lock
-}
-
-func providerLockKinds() []string {
-	kinds := make([]string, 0, len(providerLockBucketSpecs))
-	for _, bucket := range providerLockBucketSpecs {
-		kinds = append(kinds, bucket.kind)
-	}
-	return kinds
 }
 
 func lockEntriesForProviderKind(lock *Lockfile, kind string) map[string]LockEntry {


### PR DESCRIPTION
## Summary

Makes release-backed provider lockfiles platform-independent instead of preserving the target-materialization architecture from PR 2249.

`gestaltd lock` now writes canonical static validation metadata that is stable across platforms for release metadata sources, while still pinning every archive URL and SHA from the release metadata. Local source and git source lock behavior stays tied to their existing prepared output path.

This removes the confusing cross-platform lock command surface: lock generation no longer accepts target platform arguments, and runtime archive selection remains the responsibility of `sync --locked`, locked serve, and validation on the platform where they run.

## Interfaces

Deleted CLI:

```sh
gestaltd lock --platform PLATFORMS
gestaltd lock --check --platform PLATFORMS
```

Changed CLI:

```sh
gestaltd lock [--config PATH]... [--lockfile PATH] [--check]
gestaltd lock --check [--config PATH]... [--lockfile PATH]
```

Unchanged CLI:

```sh
gestaltd provider package --platform PLATFORMS
gestaltd validate --platform os/arch
gestaltd sync --locked
gestaltd sync --locked --check
```

Lock schema moves from v8 to v9. Release-backed static manifests in the portable lock schema now omit runtime `artifacts`; executable and hybrid manifests keep executable semantics through a static-validation placeholder entrypoint instead of a platform-specific artifact path.

No new commands or arguments are added.

## Runtime

Locking no longer materializes or hashes additional target platforms after the host lock pass. The deleted platformful lifecycle helpers and extra-platform hash-writing path are removed.

Release metadata remains the integrity source for archive URLs and SHA values. `sync --locked` and locked load still resolve the archive for the current platform and fail if the locked release does not publish a supported explicit or generic archive.

Test coverage exercises the deleted lock flag, the v9 schema break, platform-neutral release manifest projection, unchanged local/git source projection behavior, locked static invokes validation, and multi-platform release metadata archive pinning.
