### PR TITLE
Update gestaltd formula and chart to v0.0.2-alpha.9

### DIFF
--- a/Formula/gestaltd.rb
+++ b/Formula/gestaltd.rb
@@ -3,30 +3,30 @@
 class Gestaltd < Formula
   desc "Gestalt server daemon"
   homepage "https://github.com/valon-technologies/gestalt"
-  version "0.0.2-alpha.8"
+  version "0.0.2-alpha.9"
   license "Apache-2.0"
 
   on_macos do
     on_arm do
-      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.8/gestaltd-macos-arm64.tar.gz"
-      sha256 "a969f24142a6266cdde28db266b6e19948f2f25be68adbbacecc28387215255f"
+      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.9/gestaltd-macos-arm64.tar.gz"
+      sha256 "c4a5f7cfa2c3b5d54151a0bd9b96f5ead6905fe62468c9c1dbe31317558279e6"
     end
 
     on_intel do
-      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.8/gestaltd-macos-x86_64.tar.gz"
-      sha256 "c68c4b81a6abb76335d740928819454b744879a96b1d5fd9be45ea9f9a2e4c56"
+      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.9/gestaltd-macos-x86_64.tar.gz"
+      sha256 "ded925a36cede25ae0a92405d044cd02213a70a8a0c929a3ae584482ad5847d0"
     end
   end
 
   on_linux do
     on_arm do
-      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.8/gestaltd-linux-arm64.tar.gz"
-      sha256 "061fd3af8135db46c305ca2889977b7a7a11d6db217ce9e4c73ad0b8994032d0"
+      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.9/gestaltd-linux-arm64.tar.gz"
+      sha256 "0d423e65e3d0dfd713e419c8126b616c68826ce8ac098c804d0352eaba1cbe55"
     end
 
     on_intel do
-      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.8/gestaltd-linux-x86_64.tar.gz"
-      sha256 "d665d3257e46b7ab9d47a32f3f48014ef47d2fafb04a6821b10fac7cf7faac58"
+      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.9/gestaltd-linux-x86_64.tar.gz"
+      sha256 "e53e696d5b98e0fc027d835962ca696924b86b926a70c1c0e1d11b9b6bd98a86"
     end
   end
 

--- a/gestaltd/deploy/helm/gestaltd/Chart.yaml
+++ b/gestaltd/deploy/helm/gestaltd/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: gestaltd
 description: gestaltd - OAuth token management proxy with pluggable integrations
 type: application
-version: 0.0.2-alpha.8
-appVersion: "0.0.2-alpha.8"
+version: 0.0.2-alpha.9
+appVersion: "0.0.2-alpha.9"


### PR DESCRIPTION
## Summary

- Updates the checked-in gestaltd Homebrew formula to `0.0.2-alpha.9` using the published release asset checksums.
- Updates the gestaltd Helm chart `version` and `appVersion` to `0.0.2-alpha.9`.

## Context

The `gestaltd/v0.0.2-alpha.9` release was published successfully, including release assets, Docker images, and OCI Helm chart publication. The release workflow failed only when it attempted to push these repository updates directly to protected `main`, so this PR carries that blocked repository diff.
