### PR TITLE
Add gestaltd sync observability

### DIFF
--- a/docs/content/deploy/docker.mdx
+++ b/docs/content/deploy/docker.mdx
@@ -59,6 +59,28 @@ gestaltd lock --config deploy/config.yaml
 gestaltd sync --locked --config deploy/config.yaml --artifacts-dir deploy
 ```
 
+Successful `gestaltd sync --locked` stays quiet by default. In CI, use
+`--output-format=json` when you want machine-readable sync timing and cache
+metrics. Stdout contains only the JSON document on success, while build output
+and errors remain on stderr:
+
+```sh
+gestaltd sync \
+  --locked \
+  --verbose \
+  --output-format=json \
+  --config deploy/config.yaml \
+  --artifacts-dir deploy \
+  --cache-dir /cache/gestaltd-archives \
+  > gestaltd-sync.json
+```
+
+The archive cache is content-addressed by the locked archive SHA-256. A
+lockfile bump misses only for archives whose SHA changes; unchanged remote
+release archives can still be reused from the cache. Omitting `--cache-dir`
+disables the archive cache, and `sync --locked --check` remains read-only and
+does not populate it.
+
 If the deployment builds local source providers during `sync`, you can opt into
 the generic Gestalt build cache during the build stage:
 

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -29,6 +29,8 @@ the platform where they run.
 | `gestaltd lock --check --config PATH` | Verify that the checked-in lockfile matches the current config without rewriting it. |
 | `gestaltd sync --locked --config PATH` | Materialize prepared provider artifacts from an existing lockfile. Local source UI preparation uses bounded parallelism by default. |
 | `gestaltd sync --locked --cache-dir DIR --config PATH` | Reuse verified remote release archives across sync runs. `DIR` resolves like a normal CLI path. |
+| `gestaltd sync --locked --verbose --config PATH` | Emit detailed cache, archive download, timing, and output-size diagnostics while syncing. |
+| `gestaltd sync --locked --output-format=json --config PATH` | Emit one compact JSON metrics document to stdout on successful sync. |
 | `gestaltd sync --locked --check --config PATH` | Verify that prepared artifacts exist and match the lockfile without rewriting them. |
 | `gestaltd validate --config PATH` | Validate config without serving. Repeat `--config` to layer overrides. |
 | `gestaltd validate --lockfile PATH` | Accept the same explicit lockfile path used by `lock`, `sync`, and `serve` without mutating it. |
@@ -88,6 +90,70 @@ artifact directories, local source builds, local archive paths, or metadata
 responses. `sync --locked --check` remains read-only and does not populate the
 cache.
 
+`gestaltd sync --locked -v` and `gestaltd sync --locked --verbose` add
+human-readable diagnostics for archive cache behavior, archive downloads,
+phase timings, prepared output size, and the slowest archive fetches. There is
+one verbosity level; `-vv` is not supported. The top-level `gestaltd -v` still
+prints the server version. Without `-v` or `--output-format=json`, successful
+`gestaltd sync --locked` remains quiet.
+
+`gestaltd sync --locked --output-format=json` writes one compact JSON metrics
+document to stdout on success. Child source-build output and errors go to
+stderr so CI can redirect stdout to a JSON file safely. On failure, stdout is
+empty and the error is written to stderr. `--output-format` defaults to `text`;
+supported values are `text` and `json`.
+
+```sh
+gestaltd sync \
+  --locked \
+  --config ./deploy/config.yaml \
+  --artifacts-dir ./deploy
+
+gestaltd sync \
+  --locked \
+  --verbose \
+  --config ./deploy/config.yaml \
+  --artifacts-dir ./deploy \
+  --cache-dir ./.gestaltd-archive-cache
+
+gestaltd sync \
+  --locked \
+  --output-format=json \
+  --config ./deploy/config.yaml \
+  --artifacts-dir ./deploy \
+  > gestaltd-sync.json
+
+gestaltd sync \
+  --locked \
+  --verbose \
+  --output-format=json \
+  --config ./deploy/config.yaml \
+  --artifacts-dir ./deploy \
+  --cache-dir ./.gestaltd-archive-cache \
+  > gestaltd-sync.json
+```
+
+The JSON schema starts at version `1` and reports the sync action, inputs,
+artifact count, archive cache counters, archive download counters, phase
+timings, prepared output size, and the five slowest archive fetches. In
+`--check` mode, the action is `check`, archive cache writes remain zero, and
+`output.measured` is `false`.
+
+| JSON field | Meaning |
+| --- | --- |
+| `schema.version` | Metrics schema version. Starts at `1`. |
+| `sync.action` | `materialize` for normal sync or `check` for `--check`. |
+| `sync.duration_seconds` | Total successful sync duration. |
+| `inputs.config_paths` | Config files passed to sync after CLI path resolution. |
+| `artifacts.considered` | Prepared artifact entries in the effective config. |
+| `archives.requests` | Current-platform archive acquisition attempts made by this run. |
+| `archives.unique_sha256` | Unique canonical expected SHA-256 values among archive requests. |
+| `archives.cache.*` | Cache configuration, eligibility, hit/miss, invalid, rejected, put, and put-failure counters. |
+| `archives.downloads.*` | Successful remote archive download count, bytes, and cumulative download time. |
+| `archives.slowest_fetches` | Up to five slowest archive acquisitions, including cache result and download status. |
+| `phases.*_seconds` | Major lifecycle phase timings. Download time is cumulative and may not sum to wall-clock time under parallelism. |
+| `output.*` | Prepared output measurement over known prepared artifact roots, not the entire artifacts directory. |
+
 ## Config Watch Mode
 
 Use `gestaltd serve --watch` for config-based local development when your
@@ -117,6 +183,8 @@ gestaltd
 gestaltd lock --config ./config.yaml
 gestaltd sync --locked --config ./config.yaml
 gestaltd sync --locked --config ./config.yaml --cache-dir ./.gestaltd-archive-cache
+gestaltd sync --locked --config ./config.yaml --verbose
+gestaltd sync --locked --config ./config.yaml --output-format=json > gestaltd-sync.json
 gestaltd sync --locked --config ./config.yaml --parallelism 2
 gestaltd serve --locked --config ./config.yaml
 gestaltd validate --config ./config.yaml

--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -100,6 +100,24 @@ For deterministic production deployments, run `gestaltd lock` and
 `gestaltd sync --locked` before runtime, then bake the lockfile and prepared
 artifacts into a derived image:
 
+```sh
+gestaltd sync \
+  --locked \
+  --verbose \
+  --output-format=json \
+  --config deploy/config.yaml \
+  --artifacts-dir deploy \
+  --cache-dir /cache/gestaltd-archives \
+  > gestaltd-sync.json
+```
+
+`--output-format=json` writes one compact metrics document to stdout on
+successful sync, while source-build output and errors go to stderr. Without
+`--verbose` or `--output-format=json`, successful `gestaltd sync --locked`
+stays quiet.
+`--cache-dir` enables a content-addressed cache for verified remote release
+archives keyed by their locked SHA-256.
+
 ```dockerfile
 FROM valontechnologies/gestaltd:latest-alpine
 COPY deploy/ /app/

--- a/gestaltd/internal/daemon/main_test.go
+++ b/gestaltd/internal/daemon/main_test.go
@@ -1,6 +1,8 @@
 package daemon
 
 import (
+	"bytes"
+	"encoding/json"
 	"net/url"
 	"os"
 	"os/exec"
@@ -9,6 +11,8 @@ import (
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/apps/providerpkg"
 )
 
 func TestE2ECLIHelp(t *testing.T) {
@@ -40,7 +44,7 @@ func TestE2ECLIHelp(t *testing.T) {
 		{
 			name:      "sync",
 			args:      []string{"sync", "--help"},
-			wantParts: []string{"gestaltd sync --locked", "Materialize prepared artifacts", "--artifacts-dir", "--parallelism", "--cache-dir", "--check"},
+			wantParts: []string{"gestaltd sync --locked", "Materialize prepared artifacts", "--artifacts-dir", "--parallelism", "--cache-dir", "--output-format", "-v, --verbose", "--check"},
 		},
 		{
 			name:      "provider",
@@ -100,6 +104,18 @@ func TestRunLockRejectsPlatformFlag(t *testing.T) {
 	}
 }
 
+func TestE2ECLITopLevelVersionShortFlag(t *testing.T) {
+	t.Parallel()
+
+	out, err := exec.Command(gestaltdBin, "-v").CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd -v: %v\n%s", err, out)
+	}
+	if got := strings.TrimSpace(string(out)); got == "" {
+		t.Fatalf("gestaltd -v output is empty")
+	}
+}
+
 func TestRunSyncParallelismValidation(t *testing.T) {
 	t.Parallel()
 
@@ -133,6 +149,41 @@ func TestRunSyncParallelismValidation(t *testing.T) {
 			args:      []string{"--cache-dir", filepath.Join(t.TempDir(), "cache")},
 			wantError: "gestaltd sync currently requires --locked",
 		},
+		{
+			name:      "verbose long accepted",
+			args:      []string{"--verbose"},
+			wantError: "gestaltd sync currently requires --locked",
+		},
+		{
+			name:      "verbose short accepted",
+			args:      []string{"-v"},
+			wantError: "gestaltd sync currently requires --locked",
+		},
+		{
+			name:      "repeated verbose short accepted",
+			args:      []string{"-v", "-v"},
+			wantError: "gestaltd sync currently requires --locked",
+		},
+		{
+			name:      "condensed verbose short rejected",
+			args:      []string{"-vv"},
+			wantError: "flag provided but not defined: -vv",
+		},
+		{
+			name:      "output format text accepted",
+			args:      []string{"--output-format", "text"},
+			wantError: "gestaltd sync currently requires --locked",
+		},
+		{
+			name:      "output format json accepted",
+			args:      []string{"--output-format=json"},
+			wantError: "gestaltd sync currently requires --locked",
+		},
+		{
+			name:      "output format invalid",
+			args:      []string{"--output-format", "yaml"},
+			wantError: `invalid --output-format "yaml"; expected "text" or "json"`,
+		},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
@@ -143,6 +194,180 @@ func TestRunSyncParallelismValidation(t *testing.T) {
 				t.Fatalf("runSync(%v) error = %v, want %q", tc.args, err, tc.wantError)
 			}
 		})
+	}
+}
+
+func TestE2ESyncJSONStdoutCleanWithSourceBuildOutput(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	appDir := setupAppDir(t, dir)
+	buildScriptPath := filepath.Join(appDir, "build.sh")
+	buildScript, err := os.ReadFile(buildScriptPath)
+	if err != nil {
+		t.Fatalf("read build script: %v", err)
+	}
+	if err := os.WriteFile(buildScriptPath, []byte("printf 'BUILD_STDOUT_SENTINEL\\n'\n"+string(buildScript)), 0o755); err != nil {
+		t.Fatalf("write build script: %v", err)
+	}
+	configPath := writeE2EConfig(t, dir, appDir, 18080)
+	unrelated, err := os.Create(filepath.Join(dir, "unrelated-large.bin"))
+	if err != nil {
+		t.Fatalf("create unrelated sparse file: %v", err)
+	}
+	if err := unrelated.Truncate(1 << 30); err != nil {
+		_ = unrelated.Close()
+		t.Fatalf("truncate unrelated sparse file: %v", err)
+	}
+	if err := unrelated.Close(); err != nil {
+		t.Fatalf("close unrelated sparse file: %v", err)
+	}
+
+	out, err := exec.Command(gestaltdBin, "lock", "--config", configPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd lock: %v\n%s", err, out)
+	}
+	if err := os.RemoveAll(filepath.Join(dir, ".gestaltd", "providers", "example")); err != nil {
+		t.Fatalf("remove prepared provider: %v", err)
+	}
+
+	cmd := exec.Command(gestaltdBin, "sync", "--locked", "--verbose", "--output-format=json", "--config", configPath)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("gestaltd sync json: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	}
+	if strings.Contains(stdout.String(), "BUILD_STDOUT_SENTINEL") {
+		t.Fatalf("JSON stdout contained source build output:\n%s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "BUILD_STDOUT_SENTINEL") {
+		t.Fatalf("stderr missing source build output sentinel:\nstdout:\n%s\nstderr:\n%s", stdout.String(), stderr.String())
+	}
+	var doc syncOutputDocument
+	if err := json.Unmarshal(stdout.Bytes(), &doc); err != nil {
+		t.Fatalf("sync stdout is not JSON: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	}
+	if doc.Command != "sync" || doc.Sync.Action != "materialize" {
+		t.Fatalf("sync JSON command/action = %q/%q, want sync/materialize", doc.Command, doc.Sync.Action)
+	}
+	if !doc.Output.Measured {
+		t.Fatalf("sync JSON output.measured = false, want true")
+	}
+	if doc.Output.Bytes >= 1<<30 {
+		t.Fatalf("sync JSON output bytes = %d, want unrelated artifacts-dir file excluded", doc.Output.Bytes)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	cmd = exec.Command(gestaltdBin, "sync", "--locked", "--check", "--output-format=json", "--config", configPath)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("gestaltd sync check json: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	}
+	doc = syncOutputDocument{}
+	if err := json.Unmarshal(stdout.Bytes(), &doc); err != nil {
+		t.Fatalf("sync check stdout is not JSON: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	}
+	if doc.Sync.Action != "check" || !doc.Inputs.Check {
+		t.Fatalf("sync check JSON action/check = %q/%t, want check/true", doc.Sync.Action, doc.Inputs.Check)
+	}
+	if doc.Output.Measured {
+		t.Fatalf("sync check JSON output.measured = true, want false")
+	}
+	if doc.Archives.Cache.Puts != 0 || doc.Archives.Cache.PutFailures != 0 {
+		t.Fatalf("sync check JSON cache puts/failures = %d/%d, want 0/0", doc.Archives.Cache.Puts, doc.Archives.Cache.PutFailures)
+	}
+}
+
+func TestE2ESyncDefaultSuccessIsQuiet(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	appDir := setupAppDir(t, dir)
+	configPath := writeE2EConfig(t, dir, appDir, 18080)
+
+	out, err := exec.Command(gestaltdBin, "lock", "--config", configPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd lock: %v\n%s", err, out)
+	}
+	if err := os.RemoveAll(filepath.Join(dir, ".gestaltd", "providers", "example")); err != nil {
+		t.Fatalf("remove prepared provider: %v", err)
+	}
+
+	cmd := exec.Command(gestaltdBin, "sync", "--locked", "--config", configPath)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("gestaltd sync: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	}
+	if got := stdout.String(); got != "" {
+		t.Fatalf("default sync stdout = %q, want empty", got)
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("default sync stderr = %q, want empty", got)
+	}
+}
+
+func TestE2ESyncJSONFailureLeavesStdoutEmpty(t *testing.T) {
+	t.Parallel()
+
+	missingConfig := filepath.Join(t.TempDir(), "missing.yaml")
+	cmd := exec.Command(gestaltdBin, "sync", "--locked", "--output-format=json", "--config", missingConfig)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err == nil {
+		t.Fatalf("gestaltd sync json with missing config unexpectedly succeeded\nstdout:\n%s\nstderr:\n%s", stdout.String(), stderr.String())
+	}
+	if got := strings.TrimSpace(stdout.String()); got != "" {
+		t.Fatalf("failed JSON sync stdout = %q, want empty\nstderr:\n%s", got, stderr.String())
+	}
+}
+
+func TestE2ESyncJSONStdoutCleanWithPrepareOnlyBuildOutput(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	appDir := setupPrebuiltAppDir(t, dir)
+	manifestPath := componentProviderManifestPath(t, appDir)
+	_, manifest, err := providerpkg.ReadSourceManifestFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read source manifest: %v", err)
+	}
+	manifest.Build = &providermanifestv1.SourceBuild{
+		Command:     []string{"sh", "-c", "printf 'PREPARE_ONLY_STDOUT_SENTINEL\\n'"},
+		PrepareOnly: true,
+	}
+	writeManifestFile(t, appDir, manifest)
+	configPath := writeE2EConfig(t, dir, appDir, 18080)
+
+	out, err := exec.Command(gestaltdBin, "lock", "--config", configPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd lock: %v\n%s", err, out)
+	}
+	if err := os.RemoveAll(filepath.Join(dir, ".gestaltd", "providers", "example")); err != nil {
+		t.Fatalf("remove prepared provider: %v", err)
+	}
+
+	cmd := exec.Command(gestaltdBin, "sync", "--locked", "--output-format=json", "--config", configPath)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("gestaltd sync json: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	}
+	if strings.Contains(stdout.String(), "PREPARE_ONLY_STDOUT_SENTINEL") {
+		t.Fatalf("JSON stdout contained prepare-only build output:\n%s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "PREPARE_ONLY_STDOUT_SENTINEL") {
+		t.Fatalf("stderr missing prepare-only build output sentinel:\nstdout:\n%s\nstderr:\n%s", stdout.String(), stderr.String())
+	}
+	var doc syncOutputDocument
+	if err := json.Unmarshal(stdout.Bytes(), &doc); err != nil {
+		t.Fatalf("sync stdout is not JSON: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
 	}
 }
 

--- a/gestaltd/internal/daemon/run.go
+++ b/gestaltd/internal/daemon/run.go
@@ -280,6 +280,9 @@ func runSync(args []string) error {
 	check := fs.Bool("check", false, "fail if artifacts would need to be materialized")
 	parallelism := fs.Int("parallelism", defaultSyncParallelism(), "maximum concurrent local UI source preparations")
 	cacheDir := fs.String("cache-dir", "", "path to opt-in remote archive cache")
+	verboseLong := fs.Bool("verbose", false, "emit detailed sync diagnostics")
+	verboseShort := fs.Bool("v", false, "emit detailed sync diagnostics")
+	outputFormat := fs.String("output-format", syncOutputFormatText, "output format: text or json")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -289,14 +292,45 @@ func runSync(args []string) error {
 	if *parallelism < 1 {
 		return fmt.Errorf("invalid --parallelism %d: must be at least 1", *parallelism)
 	}
+	if err := validateSyncOutputFormat(*outputFormat); err != nil {
+		return err
+	}
 	if !*locked {
 		return fmt.Errorf("gestaltd sync currently requires --locked")
 	}
 
-	return syncConfigWithStatePathsOptions(configPaths, operator.StatePaths{
+	verbose := *verboseLong || *verboseShort
+	observabilityRequested := verbose || *outputFormat == syncOutputFormatJSON
+	var metrics *operator.SyncMetricsRecorder
+	observability := operator.SyncObservability{}
+	if observabilityRequested {
+		metrics = operator.NewSyncMetricsRecorder()
+		observability.Recorder = metrics
+	}
+	if *outputFormat == syncOutputFormatJSON {
+		observability.BuildOutput = providerpkg.CommandOutput{Stdout: os.Stderr, Stderr: os.Stderr}
+	}
+	opts := operator.SyncOptions{
+		Parallelism:     *parallelism,
+		ArchiveCacheDir: *cacheDir,
+		Observability:   observability,
+	}
+
+	if err := syncConfigWithStatePathsOptions(configPaths, operator.StatePaths{
 		ArtifactsDir: *artifactsDir,
 		LockfilePath: *lockfilePath,
-	}, *check, operator.SyncOptions{Parallelism: *parallelism, ArchiveCacheDir: *cacheDir})
+	}, *check, opts); err != nil {
+		return err
+	}
+
+	switch {
+	case *outputFormat == syncOutputFormatJSON:
+		return writeSyncJSON(os.Stdout, metrics.Snapshot())
+	case verbose:
+		return writeSyncText(os.Stderr, metrics.Snapshot(), true)
+	default:
+		return nil
+	}
 }
 
 func defaultSyncParallelism() int {
@@ -434,7 +468,7 @@ func printMainUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
 	writeUsageLine(w, "  gestaltd [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH]")
 	writeUsageLine(w, "  gestaltd lock [--config PATH]... [--lockfile PATH] [--check]")
-	writeUsageLine(w, "  gestaltd sync --locked [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--parallelism N] [--cache-dir PATH] [--check]")
+	writeUsageLine(w, "  gestaltd sync --locked [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--parallelism N] [--cache-dir PATH] [--output-format text|json] [-v|--verbose] [--check]")
 	writeUsageLine(w, "  gestaltd serve [--app NAME] [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--locked] [--watch]")
 	writeUsageLine(w, "  gestaltd serve --path PATH [--config PATH]... [--name NAME] [--port PORT]")
 	writeUsageLine(w, "  gestaltd agent <command> [flags]")
@@ -489,12 +523,14 @@ func printLockUsage(w io.Writer) {
 
 func printSyncUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
-	writeUsageLine(w, "  gestaltd sync --locked [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--parallelism N] [--cache-dir PATH] [--check]")
+	writeUsageLine(w, "  gestaltd sync --locked [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--parallelism N] [--cache-dir PATH] [--output-format text|json] [-v|--verbose] [--check]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Materialize prepared artifacts from the existing lockfile.")
 	writeUsageLine(w, "Does not resolve new metadata or rewrite the lockfile.")
 	writeUsageLine(w, "--cache-dir reuses verified remote release archives; --check remains read-only.")
 	writeUsageLine(w, "--parallelism caps concurrent local source UI preparation.")
+	writeUsageLine(w, "--output-format=json writes one machine-readable metrics document to stdout on success.")
+	writeUsageLine(w, "-v/--verbose adds cache, download, timing, and output-size diagnostics.")
 	writeUsageLine(w, "When repeated, --config files merge left-to-right.")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Flags:")
@@ -504,6 +540,8 @@ func printSyncUsage(w io.Writer) {
 	writeUsageLine(w, "  --locked          Require an existing lockfile")
 	writeUsageLine(w, "  --parallelism     Maximum concurrent local source UI preparations")
 	writeUsageLine(w, "  --cache-dir       Opt-in cache for verified remote release archives; relative paths use the current working directory")
+	writeUsageLine(w, "  --output-format   Output format: text or json")
+	writeUsageLine(w, "  -v, --verbose     Emit detailed sync diagnostics")
 	writeUsageLine(w, "  --check           Fail if artifacts would need to be materialized")
 }
 

--- a/gestaltd/internal/daemon/sync_output.go
+++ b/gestaltd/internal/daemon/sync_output.go
@@ -1,0 +1,125 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/valon-technologies/gestalt/server/internal/operator"
+)
+
+const (
+	syncOutputFormatText = "text"
+	syncOutputFormatJSON = "json"
+)
+
+type syncOutputDocument struct {
+	Schema  syncOutputSchema `json:"schema"`
+	Command string           `json:"command"`
+	operator.SyncMetrics
+}
+
+type syncOutputSchema struct {
+	Version string `json:"version"`
+}
+
+func validateSyncOutputFormat(format string) error {
+	switch format {
+	case syncOutputFormatText, syncOutputFormatJSON:
+		return nil
+	default:
+		return fmt.Errorf("invalid --output-format %q; expected %q or %q", format, syncOutputFormatText, syncOutputFormatJSON)
+	}
+}
+
+func writeSyncJSON(w io.Writer, metrics operator.SyncMetrics) error {
+	doc := syncOutputDocument{
+		Schema:      syncOutputSchema{Version: "1"},
+		Command:     "sync",
+		SyncMetrics: metrics,
+	}
+	encoder := json.NewEncoder(w)
+	return encoder.Encode(doc)
+}
+
+func writeSyncText(w io.Writer, metrics operator.SyncMetrics, verbose bool) error {
+	action := "Prepared"
+	if metrics.Sync.Action == "check" {
+		action = "Checked"
+	}
+	if _, err := fmt.Fprintf(w, "Loaded %d prepared artifacts from lock/config.\n", metrics.Artifacts.Considered); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "Fetched %d archives: %d cache hits, %d downloads.\n", metrics.Archives.Requests, metrics.Archives.Cache.Hits, metrics.Archives.Downloads.Count); err != nil {
+		return err
+	}
+	if verbose {
+		cacheState := "disabled"
+		if metrics.Archives.Cache.Enabled {
+			cacheState = "enabled"
+		}
+		if metrics.Archives.Cache.Configured {
+			if _, err := fmt.Fprintf(w, "Archive cache: %s at %s.\n", cacheState, metrics.Archives.Cache.Dir); err != nil {
+				return err
+			}
+		} else {
+			if _, err := fmt.Fprintln(w, "Archive cache: disabled."); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintf(w, "Archive cache: %d eligible, %d disabled, %d uncacheable, %d hits, %d misses, %d invalid, %d rejected, %d puts, %d put failures.\n",
+			metrics.Archives.Cache.Eligible,
+			metrics.Archives.Cache.Disabled,
+			metrics.Archives.Cache.Uncacheable,
+			metrics.Archives.Cache.Hits,
+			metrics.Archives.Cache.Misses,
+			metrics.Archives.Cache.Invalid,
+			metrics.Archives.Cache.Rejected,
+			metrics.Archives.Cache.Puts,
+			metrics.Archives.Cache.PutFailures,
+		); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(w, "Downloads: %d archives, %s, cumulative download time %.3fs.\n", metrics.Archives.Downloads.Count, formatIECBytes(metrics.Archives.Downloads.Bytes), metrics.Archives.Downloads.DurationSeconds); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(w, "Phases: load %.3fs, materialize %.3fs, validate %.3fs, output measure %.3fs.\n", metrics.Phases.LoadSeconds, metrics.Phases.MaterializeSeconds, metrics.Phases.ValidateSeconds, metrics.Phases.OutputMeasureSeconds); err != nil {
+			return err
+		}
+		if metrics.Output.Measured {
+			if _, err := fmt.Fprintf(w, "Prepared output: %d files, %s.\n", metrics.Output.Files, formatIECBytes(metrics.Output.Bytes)); err != nil {
+				return err
+			}
+		} else {
+			if _, err := fmt.Fprintln(w, "Prepared output: not measured."); err != nil {
+				return err
+			}
+		}
+		if len(metrics.Archives.SlowestFetches) > 0 {
+			if _, err := fmt.Fprintln(w, "Slowest archive fetches:"); err != nil {
+				return err
+			}
+			for _, fetch := range metrics.Archives.SlowestFetches {
+				if _, err := fmt.Fprintf(w, "  %s: %s, downloaded=%t, %s, %.3fs\n", fetch.Subject, fetch.CacheResult, fetch.Downloaded, formatIECBytes(fetch.Bytes), fetch.DurationSeconds); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	_, err := fmt.Fprintf(w, "%s artifacts in %s in %.3fs.\n", action, metrics.Sync.ArtifactsDir, metrics.Sync.DurationSeconds)
+	return err
+}
+
+func formatIECBytes(bytes int64) string {
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	div := int64(unit)
+	exp := 0
+	for n := bytes / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(bytes)/float64(div), "KMGTPE"[exp])
+}

--- a/gestaltd/internal/daemon/sync_output_test.go
+++ b/gestaltd/internal/daemon/sync_output_test.go
@@ -1,0 +1,95 @@
+package daemon
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/operator"
+)
+
+func TestWriteSyncJSON(t *testing.T) {
+	t.Parallel()
+
+	metrics := operator.SyncMetrics{
+		Sync: operator.SyncMetricsSync{
+			Action:          "materialize",
+			DurationSeconds: 1.234,
+			ArtifactsDir:    "/prepared",
+			LockfilePath:    "/app/gestalt.lock.json",
+		},
+		Inputs: operator.SyncMetricsInputs{
+			ConfigPaths: []string{"/app/config.yaml"},
+			Locked:      true,
+			Check:       false,
+			Parallelism: 4,
+		},
+		Artifacts: operator.SyncMetricsArtifacts{Considered: 2},
+	}
+
+	var out bytes.Buffer
+	if err := writeSyncJSON(&out, metrics); err != nil {
+		t.Fatalf("writeSyncJSON: %v", err)
+	}
+	if strings.Contains(out.String(), "\n{") {
+		t.Fatalf("writeSyncJSON output should be compact single-document JSON, got %q", out.String())
+	}
+
+	var doc syncOutputDocument
+	if err := json.Unmarshal(out.Bytes(), &doc); err != nil {
+		t.Fatalf("unmarshal sync JSON: %v\n%s", err, out.String())
+	}
+	if doc.Schema.Version != "1" {
+		t.Fatalf("schema.version = %q, want 1", doc.Schema.Version)
+	}
+	if doc.Command != "sync" {
+		t.Fatalf("command = %q, want sync", doc.Command)
+	}
+	if doc.Sync.Action != "materialize" {
+		t.Fatalf("sync.action = %q, want materialize", doc.Sync.Action)
+	}
+	if doc.Artifacts.Considered != 2 {
+		t.Fatalf("artifacts.considered = %d, want 2", doc.Artifacts.Considered)
+	}
+}
+
+func TestWriteSyncText(t *testing.T) {
+	t.Parallel()
+
+	metrics := operator.SyncMetrics{
+		Sync: operator.SyncMetricsSync{
+			Action:          "materialize",
+			DurationSeconds: 1.234,
+			ArtifactsDir:    "/prepared",
+		},
+		Artifacts: operator.SyncMetricsArtifacts{Considered: 2},
+		Archives: operator.SyncMetricsArchives{
+			Requests: 3,
+			Cache:    operator.SyncMetricsArchiveCache{Hits: 1},
+			Downloads: operator.SyncMetricsDownloads{
+				Count: 2,
+				Bytes: 4096,
+			},
+		},
+		Output: operator.SyncMetricsOutput{Measured: true, Files: 4, Bytes: 8192},
+	}
+
+	var out bytes.Buffer
+	if err := writeSyncText(&out, metrics, true); err != nil {
+		t.Fatalf("writeSyncText: %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{
+		"Loaded 2 prepared artifacts from lock/config.",
+		"Fetched 3 archives: 1 cache hits, 2 downloads.",
+		"Archive cache:",
+		"Downloads: 2 archives",
+		"Prepared output: 4 files",
+		"Prepared artifacts in /prepared in 1.234s.",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("writeSyncText output missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/gestaltd/internal/operator/archive_cache.go
+++ b/gestaltd/internal/operator/archive_cache.go
@@ -46,41 +46,74 @@ const (
 	archiveCacheRejected
 )
 
-func downloadArchiveForSourceWithCache(ctx context.Context, client *http.Client, token, archiveURL, expectedSHA, cacheDir string) (*providerpkg.DownloadResult, error) {
+type archiveDownloadObserver interface {
+	beginArchiveFetch(sourceKind, sha string, cacheEligible, useCache bool) *archiveFetchTracker
+}
+
+func downloadArchiveForSourceWithCache(ctx context.Context, client *http.Client, token, archiveURL, expectedSHA, cacheDir string, observer archiveDownloadObserver) (*providerpkg.DownloadResult, error) {
 	sha, hasExpectedSHA, err := normalizeArchiveSHA256(expectedSHA)
 	if err != nil {
 		return nil, err
 	}
 
-	useCache := cacheDir != "" && hasExpectedSHA && isRemoteReleaseMetadataLocation(archiveURL)
+	remoteArchive := isRemoteReleaseMetadataLocation(archiveURL)
+	sourceKind := syncArchiveSourceLocal
+	if remoteArchive {
+		sourceKind = syncArchiveSourceRemoteReleaseMetadata
+	}
+	cacheConfigured := cacheDir != ""
+	cacheEligible := hasExpectedSHA && remoteArchive
+	useCache := cacheConfigured && cacheEligible
+	var tracker *archiveFetchTracker
+	if observer != nil {
+		tracker = observer.beginArchiveFetch(sourceKind, sha, cacheEligible, useCache)
+	}
+	defer tracker.record()
 	if useCache {
 		cache := archiveCache{dir: cacheDir}
 		cached, result, err := cache.Get(sha)
 		if err != nil {
+			tracker.setCacheLookupResult(archiveCacheRejected)
 			return nil, fmt.Errorf("read archive cache: %w", err)
 		}
 		switch result {
 		case archiveCacheHit:
+			tracker.setCacheLookupResult(result)
+			tracker.setBytesFromPath(cached.LocalPath)
 			return cached, nil
 		case archiveCacheMiss, archiveCacheInvalid:
+			tracker.setCacheLookupResult(result)
 		case archiveCacheRejected:
+			tracker.setCacheLookupResult(result)
 			return nil, fmt.Errorf("read archive cache: rejected cached archive")
 		}
 	}
 
+	tracker.startDownload()
 	download, err := downloadArchiveForSource(ctx, client, token, archiveURL)
 	if err != nil {
+		tracker.cancel()
 		return nil, err
 	}
 	if err := verifyArchiveSHA256(download.SHA256Hex, sha); err != nil {
 		download.Cleanup()
+		tracker.cancel()
 		return nil, err
 	}
 	if useCache {
 		// The verified temp download is still usable; a write-only cache miss should not fail sync.
-		_ = (archiveCache{dir: cacheDir}).Put(download.LocalPath, sha)
+		tracker.setCachePut((archiveCache{dir: cacheDir}).Put(download.LocalPath, sha) != nil)
 	}
+	tracker.finishDownload(remoteArchive, download.LocalPath)
 	return download, nil
+}
+
+func archiveFileSize(path string) int64 {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	return info.Size()
 }
 
 func normalizeArchiveSHA256(raw string) (string, bool, error) {

--- a/gestaltd/internal/operator/archive_cache_test.go
+++ b/gestaltd/internal/operator/archive_cache_test.go
@@ -220,7 +220,7 @@ func TestDownloadArchiveWithCacheFallsBackWhenStoreFails(t *testing.T) {
 	}
 	defer func() { _ = os.Chmod(shardDir, 0o755) }()
 
-	download, err := downloadArchiveForSourceWithCache(context.Background(), srv.Client(), "", srv.URL, sha, cache.dir)
+	download, err := downloadArchiveForSourceWithCache(context.Background(), srv.Client(), "", srv.URL, sha, cache.dir, nil)
 	if err != nil {
 		t.Fatalf("downloadArchiveForSourceWithCache: %v", err)
 	}
@@ -254,7 +254,7 @@ func TestDownloadArchiveWithCacheVerifiesExpectedSHA(t *testing.T) {
 	defer srv.Close()
 
 	cache := archiveCache{dir: filepath.Join(dir, "cache")}
-	download, err := downloadArchiveForSourceWithCache(context.Background(), srv.Client(), "", srv.URL, wrongSHA, cache.dir)
+	download, err := downloadArchiveForSourceWithCache(context.Background(), srv.Client(), "", srv.URL, wrongSHA, cache.dir, nil)
 	if err == nil {
 		if download != nil {
 			download.Cleanup()
@@ -272,12 +272,98 @@ func TestDownloadArchiveWithCacheVerifiesExpectedSHA(t *testing.T) {
 		t.Fatalf("matching cache archive stat err = %v, want not exist", err)
 	}
 
-	_, err = downloadArchiveForSourceWithCache(context.Background(), srv.Client(), "", srv.URL, "abc123", cache.dir)
+	_, err = downloadArchiveForSourceWithCache(context.Background(), srv.Client(), "", srv.URL, "abc123", cache.dir, nil)
 	if err == nil || !strings.Contains(err.Error(), "invalid archive sha256") {
 		t.Fatalf("downloadArchiveForSourceWithCache invalid digest error = %v, want invalid archive sha256", err)
 	}
 	if got := requests.Load(); got != 1 {
 		t.Fatalf("request count after invalid digest = %d, want 1", got)
+	}
+}
+
+func TestDownloadArchiveWithCacheRecordsMetrics(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	data := []byte("archive bytes")
+	sha := testSHA256Hex(data)
+	var requests atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		_, _ = w.Write(data)
+	}))
+	defer srv.Close()
+
+	cacheDir := filepath.Join(dir, "cache")
+	coldMetrics := NewSyncMetricsRecorder()
+	coldMetrics.SetPaths("", "", cacheDir, true, true)
+	download, err := downloadArchiveForSourceWithCache(context.Background(), srv.Client(), "", srv.URL, sha, cacheDir, newSyncArchiveDownloadObserver(coldMetrics, "provider alpha"))
+	if err != nil {
+		t.Fatalf("cold downloadArchiveForSourceWithCache: %v", err)
+	}
+	download.Cleanup()
+	cold := coldMetrics.Snapshot()
+	if cold.Archives.Requests != 1 || cold.Archives.Cache.Eligible != 1 || cold.Archives.Cache.Misses != 1 || cold.Archives.Downloads.Count != 1 || cold.Archives.Cache.Puts != 1 {
+		t.Fatalf("cold metrics = %+v, want one eligible miss, download, and put", cold.Archives)
+	}
+	if len(cold.Archives.SlowestFetches) != 1 {
+		t.Fatalf("cold slowest fetches len = %d, want 1", len(cold.Archives.SlowestFetches))
+	}
+	if got := cold.Archives.SlowestFetches[0]; got.Subject != "provider alpha" || got.CacheResult != syncArchiveCacheResultMiss || !got.Downloaded || got.Bytes != int64(len(data)) {
+		t.Fatalf("cold slowest fetch = %+v, want miss/downloaded/%d bytes", got, len(data))
+	}
+
+	warmMetrics := NewSyncMetricsRecorder()
+	warmMetrics.SetPaths("", "", cacheDir, true, true)
+	download, err = downloadArchiveForSourceWithCache(context.Background(), srv.Client(), "", srv.URL, sha, cacheDir, newSyncArchiveDownloadObserver(warmMetrics, "provider alpha"))
+	if err != nil {
+		t.Fatalf("warm downloadArchiveForSourceWithCache: %v", err)
+	}
+	download.Cleanup()
+	warm := warmMetrics.Snapshot()
+	if warm.Archives.Requests != 1 || warm.Archives.Cache.Eligible != 1 || warm.Archives.Cache.Hits != 1 || warm.Archives.Downloads.Count != 0 {
+		t.Fatalf("warm metrics = %+v, want one eligible hit and no download", warm.Archives)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("request count = %d, want only cold download to hit server", got)
+	}
+}
+
+func TestDownloadArchiveMetricsClassifiesDisabledAndUncacheable(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	data := []byte("archive bytes")
+	sha := testSHA256Hex(data)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(data)
+	}))
+	defer srv.Close()
+
+	disabledMetrics := NewSyncMetricsRecorder()
+	download, err := downloadArchiveForSourceWithCache(context.Background(), srv.Client(), "", srv.URL, sha, "", newSyncArchiveDownloadObserver(disabledMetrics, "provider alpha"))
+	if err != nil {
+		t.Fatalf("disabled cache downloadArchiveForSourceWithCache: %v", err)
+	}
+	download.Cleanup()
+	disabled := disabledMetrics.Snapshot()
+	if disabled.Archives.Cache.Eligible != 1 || disabled.Archives.Cache.Disabled != 1 || disabled.Archives.Cache.Uncacheable != 0 || disabled.Archives.Downloads.Count != 1 {
+		t.Fatalf("disabled cache metrics = %+v, want eligible disabled remote download", disabled.Archives)
+	}
+
+	localPath := filepath.Join(dir, "local.tar.gz")
+	if err := os.WriteFile(localPath, data, 0o644); err != nil {
+		t.Fatalf("write local archive: %v", err)
+	}
+	localMetrics := NewSyncMetricsRecorder()
+	download, err = downloadArchiveForSourceWithCache(context.Background(), nil, "", localPath, sha, filepath.Join(dir, "cache"), newSyncArchiveDownloadObserver(localMetrics, "provider alpha"))
+	if err != nil {
+		t.Fatalf("local downloadArchiveForSourceWithCache: %v", err)
+	}
+	download.Cleanup()
+	local := localMetrics.Snapshot()
+	if local.Archives.Cache.Eligible != 0 || local.Archives.Cache.Uncacheable != 1 || local.Archives.Downloads.Count != 0 {
+		t.Fatalf("local metrics = %+v, want uncacheable local copy with no remote download", local.Archives)
 	}
 }
 

--- a/gestaltd/internal/operator/git_source.go
+++ b/gestaltd/internal/operator/git_source.go
@@ -312,12 +312,12 @@ func (l *Lifecycle) prepareGitSourceInstall(ctx context.Context, paths lifecycle
 	return install, nil
 }
 
-func (l *Lifecycle) stageGitSourceInstall(ctx context.Context, paths lifecyclePaths, kind, name, destDir string, app *config.ProviderEntry) (*preparedInstall, func() error, func() error, error) {
+func (l *Lifecycle) stageGitSourceInstall(ctx context.Context, paths lifecyclePaths, kind, name, destDir string, app *config.ProviderEntry, opts providerpkg.StageSourcePreparedInstallOptions) (*preparedInstall, func() error, func() error, error) {
 	manifestPath, err := l.gitSourceManifestPath(ctx, paths, app)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	return stageLocalSourceInstall(kind, name, manifestPath, destDir)
+	return stageLocalSourceInstall(kind, name, manifestPath, destDir, opts)
 }
 
 func gitLocalLockEntryFromPreparedInstall(paths lifecyclePaths, kind, fingerprintName string, app *config.ProviderEntry, install *preparedInstall, ui bool) (LockEntry, error) {

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -121,6 +121,7 @@ type StatePaths struct {
 type SyncOptions struct {
 	Parallelism     int
 	ArchiveCacheDir string
+	Observability   SyncObservability
 }
 
 func DefaultSyncParallelism() int {
@@ -1058,6 +1059,10 @@ func (l *Lifecycle) LoadForStaticValidationAtPathsWithStatePaths(configPaths []s
 
 func (l *Lifecycle) syncAtPathsWithStatePaths(configPaths []string, state StatePaths, mode artifactMode, opts SyncOptions) error {
 	opts = normalizeSyncOptions(opts)
+	recorder := opts.Observability.Recorder
+	if recorder != nil {
+		recorder.Begin(syncActionForArtifactMode(mode), configPaths, mode == artifactModeCheck, opts.Parallelism)
+	}
 	cfg, err := loadConfigForLifecycle(configPaths, state, true)
 	if err != nil {
 		return fmt.Errorf("loading config: %v", err)
@@ -1071,6 +1076,11 @@ func (l *Lifecycle) syncAtPathsWithStatePaths(configPaths []string, state StateP
 	paths := resolveLifecyclePaths(configPaths, cfg, state)
 	if mode == artifactModeMaterialize && opts.ArchiveCacheDir != "" {
 		paths.archiveCacheDir = resolveCLIArtifactsDir(opts.ArchiveCacheDir)
+	}
+	paths.syncMetrics = recorder
+	paths.syncBuildOutput = opts.Observability.BuildOutput
+	if recorder != nil {
+		recorder.SetPaths(paths.artifactsDir, paths.lockfilePath, paths.archiveCacheDir, opts.ArchiveCacheDir != "", mode == artifactModeMaterialize && paths.archiveCacheDir != "")
 	}
 	lock, err := ReadLockfile(paths.lockfilePath)
 	if err != nil {
@@ -1098,8 +1108,14 @@ func (l *Lifecycle) syncAtPathsWithStatePaths(configPaths []string, state StateP
 	if err := config.ValidateRuntime(cfg); err != nil {
 		return err
 	}
+	if recorder != nil {
+		recorder.FinishLoadPhase()
+	}
 	if err := l.applyPreparedProviders(paths, lock, cfg, mode, opts); err != nil {
 		return err
+	}
+	if recorder != nil {
+		recorder.FinishMaterializePhase()
 	}
 	if err := config.ValidateResolvedStructure(cfg); err != nil {
 		return err
@@ -1107,7 +1123,19 @@ func (l *Lifecycle) syncAtPathsWithStatePaths(configPaths []string, state StateP
 	if err := appservice.ValidateEffectiveCatalogsAndDependencies(context.Background(), config.AppValidationConfig(cfg)); err != nil {
 		return err
 	}
+	if recorder != nil {
+		recorder.FinishValidatePhase()
+		recorder.RecordOutputStats(mode == artifactModeMaterialize, preparedArtifactDestDirs(paths, cfg))
+		recorder.Finish()
+	}
 	return nil
+}
+
+func syncActionForArtifactMode(mode artifactMode) string {
+	if mode == artifactModeCheck {
+		return syncActionCheck
+	}
+	return syncActionMaterialize
 }
 
 func (l *Lifecycle) resolveConfigSecrets(ctx context.Context, cfg *config.Config) error {
@@ -1512,6 +1540,8 @@ type lifecyclePaths struct {
 	runtimeDir             string
 	uiDir                  string
 	archiveCacheDir        string
+	syncMetrics            *SyncMetricsRecorder
+	syncBuildOutput        providerpkg.CommandOutput
 }
 
 func primaryConfigPath(paths []string) string {
@@ -2933,7 +2963,7 @@ func resolveArchiveForPlatform(entry LockEntry, platform string) (LockArchive, s
 }
 
 func prepareLocalSourceInstall(kind, name, manifestPath, destDir string) (*preparedInstall, error) {
-	_, cleanupInstall, commitInstall, err := stageLocalSourceInstall(kind, name, manifestPath, destDir)
+	_, cleanupInstall, commitInstall, err := stageLocalSourceInstall(kind, name, manifestPath, destDir, providerpkg.StageSourcePreparedInstallOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -2948,7 +2978,7 @@ func prepareLocalSourceInstall(kind, name, manifestPath, destDir string) (*prepa
 	return install, nil
 }
 
-func stageLocalSourceInstall(kind, name, manifestPath, destDir string) (*preparedInstall, func() error, func() error, error) {
+func stageLocalSourceInstall(kind, name, manifestPath, destDir string, opts providerpkg.StageSourcePreparedInstallOptions) (*preparedInstall, func() error, func() error, error) {
 	if strings.TrimSpace(manifestPath) == "" {
 		return nil, nil, nil, fmt.Errorf("manifest path for %s %q is required", kind, name)
 	}
@@ -2978,10 +3008,11 @@ func stageLocalSourceInstall(kind, name, manifestPath, destDir string) (*prepare
 		stageKind = providermanifestv1.KindApp
 	}
 	if _, err := providerpkg.StageSourcePreparedInstallDir(manifestPath, tempDir, providerpkg.StageSourcePreparedInstallOptions{
-		Kind:    stageKind,
-		AppName: name,
-		GOOS:    runtime.GOOS,
-		GOARCH:  runtime.GOARCH,
+		Kind:        stageKind,
+		AppName:     name,
+		GOOS:        runtime.GOOS,
+		GOARCH:      runtime.GOARCH,
+		BuildOutput: opts.BuildOutput,
 	}); err != nil {
 		_ = cleanupInstall()
 		return nil, nil, nil, fmt.Errorf("prepare manifest for %s %q: %w", kind, name, err)
@@ -3143,7 +3174,7 @@ func (l *Lifecycle) installMetadataSourcePackage(ctx context.Context, expectedKi
 	if err != nil {
 		return nil, LockEntry{}, fmt.Errorf("resolve archive for %s: %w", subject, err)
 	}
-	download, err := downloadArchiveForSourceWithCache(ctx, l.metadataHTTPClient(), sourceAuthToken(app), archiveLocation, archive.SHA256, "")
+	download, err := downloadArchiveForSourceWithCache(ctx, l.metadataHTTPClient(), sourceAuthToken(app), archiveLocation, archive.SHA256, "", nil)
 	if err != nil {
 		return nil, LockEntry{}, fmt.Errorf("download metadata source package for %s: %w", subject, err)
 	}
@@ -3417,6 +3448,9 @@ func (l *Lifecycle) applyPreparedProviders(paths lifecyclePaths, lock *Lockfile,
 	}
 	if err := synthesizePluginOwnedUIEntries(cfg); err != nil {
 		return err
+	}
+	if paths.syncMetrics != nil {
+		paths.syncMetrics.SetArtifactCount(len(preparedArtifactDestDirs(paths, cfg)))
 	}
 	for _, collection := range hostProviderCollections(cfg) {
 		lockEntries := lockEntriesForKind(lock, collection.kind)
@@ -4159,7 +4193,7 @@ func (l *Lifecycle) applyStaticValidationEntry(ctx context.Context, paths lifecy
 		return nil
 	}
 	if provider.HasLocalSource() {
-		install, cleanup, _, err := stageLocalSourceInstall(kind, name, provider.SourcePath(), destDir)
+		install, cleanup, _, err := stageLocalSourceInstall(kind, name, provider.SourcePath(), destDir, providerpkg.StageSourcePreparedInstallOptions{})
 		if err != nil {
 			if cleanup != nil {
 				_ = cleanup()
@@ -4213,7 +4247,7 @@ func (l *Lifecycle) applyStaticValidationEntry(ctx context.Context, paths lifecy
 		}
 	}
 	if provider.HasGitSource() && found && len(entry.Archives) == 0 {
-		install, cleanup, _, err := l.stageGitSourceInstall(ctx, paths, kind, name, destDir, provider)
+		install, cleanup, _, err := l.stageGitSourceInstall(ctx, paths, kind, name, destDir, provider, providerpkg.StageSourcePreparedInstallOptions{})
 		if err != nil {
 			if cleanup != nil {
 				_ = cleanup()
@@ -4753,7 +4787,7 @@ func (l *Lifecycle) ensureLocalPreparedInstall(paths lifecyclePaths, kind, name 
 		if !mode.canMaterialize() {
 			return nil, preparedArtifactStaleError(paths, "prepared artifact for %s is missing or stale", subject)
 		}
-		stagedInstall, cleanupStaged, commitStaged, err := stageLocalSourceInstall(kind, name, provider.SourcePath(), destDir)
+		stagedInstall, cleanupStaged, commitStaged, err := stageLocalSourceInstall(kind, name, provider.SourcePath(), destDir, paths.stageOptions())
 		if cleanupStaged != nil {
 			defer func() { _ = cleanupStaged() }()
 		}
@@ -4917,9 +4951,9 @@ func (l *Lifecycle) applyConfiguredUIProvider(paths lifecyclePaths, lockEntry *L
 				}
 				if stagedInstall == nil {
 					if provider.HasGitSource() {
-						stagedInstall, cleanupStaged, commitStaged, err = l.stageGitSourceInstall(context.Background(), paths, providermanifestv1.KindUI, logicalName, destDir, provider)
+						stagedInstall, cleanupStaged, commitStaged, err = l.stageGitSourceInstall(context.Background(), paths, providermanifestv1.KindUI, logicalName, destDir, provider, paths.stageOptions())
 					} else {
-						stagedInstall, cleanupStaged, commitStaged, err = stageLocalSourceInstall(providermanifestv1.KindUI, logicalName, provider.SourcePath(), destDir)
+						stagedInstall, cleanupStaged, commitStaged, err = stageLocalSourceInstall(providermanifestv1.KindUI, logicalName, provider.SourcePath(), destDir, paths.stageOptions())
 					}
 					if err != nil {
 						return "", err
@@ -5049,9 +5083,9 @@ func (l *Lifecycle) applyLockedProviderEntry(paths lifecyclePaths, lock *Lockfil
 			}
 			if stagedInstall == nil {
 				if app.HasGitSource() {
-					stagedInstall, cleanupStaged, commitStaged, err = l.stageGitSourceInstall(context.Background(), paths, providermanifestv1.KindApp, name, destDir, app)
+					stagedInstall, cleanupStaged, commitStaged, err = l.stageGitSourceInstall(context.Background(), paths, providermanifestv1.KindApp, name, destDir, app, paths.stageOptions())
 				} else {
-					stagedInstall, cleanupStaged, commitStaged, err = stageLocalSourceInstall(providermanifestv1.KindApp, name, app.SourcePath(), destDir)
+					stagedInstall, cleanupStaged, commitStaged, err = stageLocalSourceInstall(providermanifestv1.KindApp, name, app.SourcePath(), destDir, paths.stageOptions())
 				}
 				if err != nil {
 					return err
@@ -5138,9 +5172,9 @@ func (l *Lifecycle) applyLockedComponentEntry(paths lifecyclePaths, entry *LockE
 			}
 			if stagedInstall == nil {
 				if app.HasGitSource() {
-					stagedInstall, cleanupStaged, commitStaged, err = l.stageGitSourceInstall(context.Background(), paths, kind, name, destDir, app)
+					stagedInstall, cleanupStaged, commitStaged, err = l.stageGitSourceInstall(context.Background(), paths, kind, name, destDir, app, paths.stageOptions())
 				} else {
-					stagedInstall, cleanupStaged, commitStaged, err = stageLocalSourceInstall(kind, name, app.SourcePath(), destDir)
+					stagedInstall, cleanupStaged, commitStaged, err = stageLocalSourceInstall(kind, name, app.SourcePath(), destDir, paths.stageOptions())
 				}
 				if err != nil {
 					return err
@@ -5344,7 +5378,11 @@ func (l *Lifecycle) downloadLockedArchive(ctx context.Context, paths lifecyclePa
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("resolve locked archive digest for %s: %w", subject, err)
 	}
-	download, err := downloadArchiveForSourceWithCache(ctx, l.metadataHTTPClient(), sourceAuthToken(app), archiveLocation, expectedSHA, cacheDir)
+	var observer archiveDownloadObserver
+	if paths.syncMetrics != nil {
+		observer = newSyncArchiveDownloadObserver(paths.syncMetrics, subject)
+	}
+	download, err := downloadArchiveForSourceWithCache(ctx, l.metadataHTTPClient(), sourceAuthToken(app), archiveLocation, expectedSHA, cacheDir, observer)
 	if err != nil {
 		return nil, "", nil, lockedArchiveDownloadError{err: fmt.Errorf("download locked source archive for %s: %w", subject, err)}
 	}

--- a/gestaltd/internal/operator/sync_metrics.go
+++ b/gestaltd/internal/operator/sync_metrics.go
@@ -1,0 +1,522 @@
+package operator
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"sync"
+	"time"
+)
+
+const (
+	syncActionMaterialize = "materialize"
+	syncActionCheck       = "check"
+
+	syncArchiveSourceRemoteReleaseMetadata = "remote_release_metadata"
+	syncArchiveSourceLocal                 = "local"
+
+	syncArchiveCacheResultHit         = "hit"
+	syncArchiveCacheResultMiss        = "miss"
+	syncArchiveCacheResultInvalid     = "invalid"
+	syncArchiveCacheResultRejected    = "rejected"
+	syncArchiveCacheResultDisabled    = "disabled"
+	syncArchiveCacheResultUncacheable = "uncacheable"
+
+	syncMetricsMaxSlowFetches = 5
+)
+
+type SyncMetrics struct {
+	Sync      SyncMetricsSync      `json:"sync"`
+	Inputs    SyncMetricsInputs    `json:"inputs"`
+	Artifacts SyncMetricsArtifacts `json:"artifacts"`
+	Archives  SyncMetricsArchives  `json:"archives"`
+	Phases    SyncMetricsPhases    `json:"phases"`
+	Output    SyncMetricsOutput    `json:"output"`
+}
+
+type SyncMetricsSync struct {
+	Action          string  `json:"action"`
+	DurationSeconds float64 `json:"duration_seconds"`
+	ArtifactsDir    string  `json:"artifacts_dir"`
+	LockfilePath    string  `json:"lockfile_path"`
+}
+
+type SyncMetricsInputs struct {
+	ConfigPaths []string `json:"config_paths"`
+	Locked      bool     `json:"locked"`
+	Check       bool     `json:"check"`
+	Parallelism int      `json:"parallelism"`
+}
+
+type SyncMetricsArtifacts struct {
+	Considered int `json:"considered"`
+}
+
+type SyncMetricsArchives struct {
+	Requests       int                       `json:"requests"`
+	UniqueSHA256   int                       `json:"unique_sha256"`
+	Cache          SyncMetricsArchiveCache   `json:"cache"`
+	Downloads      SyncMetricsDownloads      `json:"downloads"`
+	SlowestFetches []SyncMetricsArchiveFetch `json:"slowest_fetches"`
+}
+
+type SyncMetricsArchiveCache struct {
+	Configured  bool   `json:"configured"`
+	Enabled     bool   `json:"enabled"`
+	Dir         string `json:"dir"`
+	Eligible    int    `json:"eligible"`
+	Disabled    int    `json:"disabled"`
+	Uncacheable int    `json:"uncacheable"`
+	Hits        int    `json:"hits"`
+	Misses      int    `json:"misses"`
+	Invalid     int    `json:"invalid"`
+	Rejected    int    `json:"rejected"`
+	Puts        int    `json:"puts"`
+	PutFailures int    `json:"put_failures"`
+}
+
+type SyncMetricsDownloads struct {
+	Count           int     `json:"count"`
+	Bytes           int64   `json:"bytes"`
+	DurationSeconds float64 `json:"duration_seconds"`
+}
+
+type SyncMetricsArchiveFetch struct {
+	Subject         string  `json:"subject"`
+	SourceKind      string  `json:"source_kind"`
+	SHA256          string  `json:"sha256,omitempty"`
+	CacheResult     string  `json:"cache_result"`
+	Downloaded      bool    `json:"downloaded"`
+	CachePutFailed  bool    `json:"cache_put_failed"`
+	Bytes           int64   `json:"bytes"`
+	DurationSeconds float64 `json:"duration_seconds"`
+}
+
+type SyncMetricsPhases struct {
+	LoadSeconds          float64 `json:"load_seconds"`
+	MaterializeSeconds   float64 `json:"materialize_seconds"`
+	ValidateSeconds      float64 `json:"validate_seconds"`
+	OutputMeasureSeconds float64 `json:"output_measure_seconds"`
+}
+
+type SyncMetricsOutput struct {
+	Measured bool  `json:"measured"`
+	Files    int   `json:"files,omitempty"`
+	Bytes    int64 `json:"bytes,omitempty"`
+}
+
+type SyncMetricsRecorder struct {
+	mu         sync.Mutex
+	metrics    SyncMetrics
+	seenSHA    map[string]struct{}
+	fetches    []SyncMetricsArchiveFetch
+	totalStart time.Time
+	phaseStart time.Time
+}
+
+type syncArchiveMetricsEvent struct {
+	Subject          string
+	SourceKind       string
+	SHA256           string
+	Eligible         bool
+	Disabled         bool
+	Uncacheable      bool
+	CacheResult      string
+	Downloaded       bool
+	CachePut         bool
+	CachePutFailed   bool
+	Bytes            int64
+	Duration         time.Duration
+	DownloadDuration time.Duration
+}
+
+type syncArchiveDownloadObserver struct {
+	metrics *SyncMetricsRecorder
+	subject string
+}
+
+func newSyncArchiveDownloadObserver(metrics *SyncMetricsRecorder, subject string) syncArchiveDownloadObserver {
+	return syncArchiveDownloadObserver{
+		metrics: metrics,
+		subject: subject,
+	}
+}
+
+func (o syncArchiveDownloadObserver) beginArchiveFetch(sourceKind, sha string, cacheEligible, useCache bool) *archiveFetchTracker {
+	return newArchiveFetchTracker(o.metrics, o.subject, sourceKind, sha, cacheEligible, useCache)
+}
+
+type archiveFetchTracker struct {
+	metrics       *SyncMetricsRecorder
+	event         syncArchiveMetricsEvent
+	start         time.Time
+	downloadStart time.Time
+	canceled      bool
+}
+
+func newArchiveFetchTracker(metrics *SyncMetricsRecorder, subject, sourceKind, sha string, cacheEligible, useCache bool) *archiveFetchTracker {
+	if metrics == nil {
+		return nil
+	}
+	tracker := &archiveFetchTracker{
+		metrics: metrics,
+		start:   time.Now(),
+		event: syncArchiveMetricsEvent{
+			Subject:     subject,
+			SourceKind:  sourceKind,
+			SHA256:      sha,
+			Eligible:    cacheEligible,
+			Disabled:    cacheEligible && !useCache,
+			Uncacheable: !cacheEligible,
+		},
+	}
+	switch {
+	case useCache:
+		tracker.event.CacheResult = syncArchiveCacheResultMiss
+	case tracker.event.Disabled:
+		tracker.event.CacheResult = syncArchiveCacheResultDisabled
+	default:
+		tracker.event.CacheResult = syncArchiveCacheResultUncacheable
+	}
+	return tracker
+}
+
+func (t *archiveFetchTracker) setCacheResult(result string) {
+	if t == nil {
+		return
+	}
+	t.event.CacheResult = result
+}
+
+func (t *archiveFetchTracker) setCacheLookupResult(result archiveCacheLookupResult) {
+	if t == nil {
+		return
+	}
+	switch result {
+	case archiveCacheHit:
+		t.setCacheResult(syncArchiveCacheResultHit)
+	case archiveCacheMiss:
+		t.setCacheResult(syncArchiveCacheResultMiss)
+	case archiveCacheInvalid:
+		t.setCacheResult(syncArchiveCacheResultInvalid)
+	case archiveCacheRejected:
+		t.setCacheResult(syncArchiveCacheResultRejected)
+	}
+}
+
+func (t *archiveFetchTracker) setCachePut(failed bool) {
+	if t == nil {
+		return
+	}
+	t.event.CachePut = true
+	t.event.CachePutFailed = failed
+}
+
+func (t *archiveFetchTracker) setBytesFromPath(path string) {
+	if t == nil {
+		return
+	}
+	t.event.Bytes = archiveFileSize(path)
+}
+
+func (t *archiveFetchTracker) startDownload() {
+	if t == nil {
+		return
+	}
+	t.downloadStart = time.Now()
+}
+
+func (t *archiveFetchTracker) finishDownload(remote bool, path string) {
+	if t == nil {
+		return
+	}
+	t.event.Downloaded = remote
+	t.event.Bytes = archiveFileSize(path)
+	if remote && !t.downloadStart.IsZero() {
+		t.event.DownloadDuration = time.Since(t.downloadStart)
+	}
+}
+
+func (t *archiveFetchTracker) cancel() {
+	if t == nil {
+		return
+	}
+	t.canceled = true
+}
+
+func (t *archiveFetchTracker) record() {
+	if t == nil || t.canceled {
+		return
+	}
+	t.event.Duration = time.Since(t.start)
+	t.metrics.RecordArchiveFetch(t.event)
+}
+
+func NewSyncMetricsRecorder() *SyncMetricsRecorder {
+	return &SyncMetricsRecorder{
+		seenSHA: make(map[string]struct{}),
+	}
+}
+
+func (r *SyncMetricsRecorder) Begin(action string, configPaths []string, check bool, parallelism int) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	now := time.Now()
+	r.totalStart = now
+	r.phaseStart = now
+	r.metrics.Sync.Action = action
+	r.metrics.Inputs.ConfigPaths = append([]string(nil), configPaths...)
+	r.metrics.Inputs.Locked = true
+	r.metrics.Inputs.Check = check
+	r.metrics.Inputs.Parallelism = parallelism
+}
+
+func (r *SyncMetricsRecorder) SetPaths(artifactsDir, lockfilePath, cacheDir string, cacheConfigured, cacheEnabled bool) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.metrics.Sync.ArtifactsDir = artifactsDir
+	r.metrics.Sync.LockfilePath = lockfilePath
+	r.metrics.Archives.Cache.Configured = cacheConfigured
+	r.metrics.Archives.Cache.Enabled = cacheEnabled
+	r.metrics.Archives.Cache.Dir = cacheDir
+}
+
+func (r *SyncMetricsRecorder) FinishLoadPhase() {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	now := time.Now()
+	r.metrics.Phases.LoadSeconds = roundedSeconds(now.Sub(r.phaseStart))
+	r.phaseStart = now
+}
+
+func (r *SyncMetricsRecorder) SetArtifactCount(artifactCount int) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.metrics.Artifacts.Considered = artifactCount
+}
+
+func (r *SyncMetricsRecorder) FinishMaterializePhase() {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	now := time.Now()
+	r.metrics.Phases.MaterializeSeconds = roundedSeconds(now.Sub(r.phaseStart))
+	r.phaseStart = now
+}
+
+func (r *SyncMetricsRecorder) FinishValidatePhase() {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	now := time.Now()
+	r.metrics.Phases.ValidateSeconds = roundedSeconds(now.Sub(r.phaseStart))
+	r.phaseStart = now
+}
+
+func (r *SyncMetricsRecorder) RecordOutputStats(measure bool, roots []string) {
+	if r == nil {
+		return
+	}
+	if !measure {
+		r.SetOutputStats(false, 0, 0)
+		return
+	}
+	outputStart := time.Now()
+	measured, files, bytes, err := measurePreparedOutputRoots(roots)
+	if err != nil {
+		measured = false
+		files = 0
+		bytes = 0
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.metrics.Output = SyncMetricsOutput{
+		Measured: measured,
+		Files:    files,
+		Bytes:    bytes,
+	}
+	r.metrics.Phases.OutputMeasureSeconds = roundedSeconds(time.Since(outputStart))
+}
+
+func (r *SyncMetricsRecorder) RecordArchiveFetch(event syncArchiveMetricsEvent) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.metrics.Archives.Requests++
+	if event.SHA256 != "" {
+		r.seenSHA[event.SHA256] = struct{}{}
+		r.metrics.Archives.UniqueSHA256 = len(r.seenSHA)
+	}
+	if event.Eligible {
+		r.metrics.Archives.Cache.Eligible++
+	}
+	if event.Disabled {
+		r.metrics.Archives.Cache.Disabled++
+	}
+	if event.Uncacheable {
+		r.metrics.Archives.Cache.Uncacheable++
+	}
+	switch event.CacheResult {
+	case syncArchiveCacheResultHit:
+		r.metrics.Archives.Cache.Hits++
+	case syncArchiveCacheResultMiss:
+		r.metrics.Archives.Cache.Misses++
+	case syncArchiveCacheResultInvalid:
+		r.metrics.Archives.Cache.Invalid++
+	case syncArchiveCacheResultRejected:
+		r.metrics.Archives.Cache.Rejected++
+	}
+	if event.CachePut {
+		if event.CachePutFailed {
+			r.metrics.Archives.Cache.PutFailures++
+		} else {
+			r.metrics.Archives.Cache.Puts++
+		}
+	}
+	if event.Downloaded {
+		r.metrics.Archives.Downloads.Count++
+		r.metrics.Archives.Downloads.Bytes += event.Bytes
+		r.metrics.Archives.Downloads.DurationSeconds = roundedSeconds(secondsDuration(r.metrics.Archives.Downloads.DurationSeconds) + event.DownloadDuration)
+	}
+
+	fetch := SyncMetricsArchiveFetch{
+		Subject:         event.Subject,
+		SourceKind:      event.SourceKind,
+		SHA256:          event.SHA256,
+		CacheResult:     event.CacheResult,
+		Downloaded:      event.Downloaded,
+		CachePutFailed:  event.CachePutFailed,
+		Bytes:           event.Bytes,
+		DurationSeconds: roundedSeconds(event.Duration),
+	}
+	r.fetches = append(r.fetches, fetch)
+	slices.SortFunc(r.fetches, func(a, b SyncMetricsArchiveFetch) int {
+		switch {
+		case a.DurationSeconds > b.DurationSeconds:
+			return -1
+		case a.DurationSeconds < b.DurationSeconds:
+			return 1
+		default:
+			return 0
+		}
+	})
+	if len(r.fetches) > syncMetricsMaxSlowFetches {
+		r.fetches = r.fetches[:syncMetricsMaxSlowFetches]
+	}
+}
+
+func (r *SyncMetricsRecorder) SetOutputStats(measured bool, files int, bytes int64) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.metrics.Output = SyncMetricsOutput{
+		Measured: measured,
+		Files:    files,
+		Bytes:    bytes,
+	}
+}
+
+func (r *SyncMetricsRecorder) Finish() {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.metrics.Sync.DurationSeconds = roundedSeconds(time.Since(r.totalStart))
+}
+
+func (r *SyncMetricsRecorder) Snapshot() SyncMetrics {
+	if r == nil {
+		return SyncMetrics{}
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	metrics := r.metrics
+	metrics.Inputs.ConfigPaths = append([]string(nil), r.metrics.Inputs.ConfigPaths...)
+	fetches := append([]SyncMetricsArchiveFetch(nil), r.fetches...)
+	metrics.Archives.SlowestFetches = fetches
+	return metrics
+}
+
+func roundedSeconds(d time.Duration) float64 {
+	return float64((d + 500*time.Microsecond).Milliseconds()) / 1000
+}
+
+func secondsDuration(seconds float64) time.Duration {
+	return time.Duration(seconds * float64(time.Second))
+}
+
+func measurePreparedOutputRoots(roots []string) (bool, int, int64, error) {
+	roots = dedupeCleanPaths(roots)
+	if len(roots) == 0 {
+		return false, 0, 0, nil
+	}
+	var files int
+	var bytes int64
+	for _, root := range roots {
+		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				if path == root && os.IsNotExist(err) {
+					return nil
+				}
+				return err
+			}
+			if d.IsDir() {
+				return nil
+			}
+			info, err := d.Info()
+			if err != nil {
+				return err
+			}
+			if info.Mode().IsRegular() {
+				files++
+				bytes += info.Size()
+			}
+			return nil
+		})
+		if err != nil {
+			return false, 0, 0, err
+		}
+	}
+	return true, files, bytes, nil
+}
+
+func dedupeCleanPaths(paths []string) []string {
+	seen := make(map[string]struct{}, len(paths))
+	var cleaned []string
+	for _, path := range paths {
+		if path == "" {
+			continue
+		}
+		path = filepath.Clean(path)
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		cleaned = append(cleaned, path)
+	}
+	slices.Sort(cleaned)
+	return cleaned
+}

--- a/gestaltd/internal/operator/sync_metrics_test.go
+++ b/gestaltd/internal/operator/sync_metrics_test.go
@@ -1,0 +1,30 @@
+package operator
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestSyncMetricsRecorderKeepsOnlySlowestFetches(t *testing.T) {
+	t.Parallel()
+
+	recorder := NewSyncMetricsRecorder()
+	for i := 0; i < syncMetricsMaxSlowFetches+3; i++ {
+		recorder.RecordArchiveFetch(syncArchiveMetricsEvent{
+			Subject:  fmt.Sprintf("fetch-%d", i),
+			Duration: time.Duration(i) * time.Second,
+		})
+	}
+
+	got := recorder.Snapshot().Archives.SlowestFetches
+	if len(got) != syncMetricsMaxSlowFetches {
+		t.Fatalf("slowest fetches len = %d, want %d", len(got), syncMetricsMaxSlowFetches)
+	}
+	for i, fetch := range got {
+		want := fmt.Sprintf("fetch-%d", syncMetricsMaxSlowFetches+2-i)
+		if fetch.Subject != want {
+			t.Fatalf("slowest fetches[%d].subject = %q, want %q", i, fetch.Subject, want)
+		}
+	}
+}

--- a/gestaltd/internal/operator/sync_observability.go
+++ b/gestaltd/internal/operator/sync_observability.go
@@ -1,0 +1,57 @@
+package operator
+
+import (
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/services/apps/providerpkg"
+)
+
+type SyncObservability struct {
+	Recorder    *SyncMetricsRecorder
+	BuildOutput providerpkg.CommandOutput
+}
+
+func (paths lifecyclePaths) stageOptions() providerpkg.StageSourcePreparedInstallOptions {
+	return providerpkg.StageSourcePreparedInstallOptions{
+		BuildOutput: paths.syncBuildOutput,
+	}
+}
+
+func preparedArtifactDestDirs(paths lifecyclePaths, cfg *config.Config) []string {
+	if cfg == nil {
+		return nil
+	}
+	var roots []string
+	for name, entry := range cfg.Apps {
+		if entry != nil {
+			roots = append(roots, providerDestDir(paths, name))
+		}
+	}
+	for _, collection := range hostProviderCollections(cfg) {
+		for name, entry := range collection.entries {
+			if entry != nil {
+				roots = append(roots, componentDestDir(paths, collection.kind, name))
+			}
+		}
+	}
+	for name, entry := range cfg.Runtime.Providers {
+		if entry != nil {
+			roots = append(roots, runtimeDestDir(paths, name))
+		}
+	}
+	for name, entry := range cfg.Providers.IndexedDB {
+		if entry != nil {
+			roots = append(roots, indexeddbDestDir(paths, name))
+		}
+	}
+	for name, entry := range cfg.Providers.S3 {
+		if entry != nil {
+			roots = append(roots, s3DestDir(paths, name))
+		}
+	}
+	for name, entry := range cfg.Providers.UI {
+		if entry != nil {
+			roots = append(roots, uiDestDir(paths, name))
+		}
+	}
+	return dedupeCleanPaths(roots)
+}

--- a/gestaltd/services/apps/providerpkg/command_output.go
+++ b/gestaltd/services/apps/providerpkg/command_output.go
@@ -1,0 +1,25 @@
+package providerpkg
+
+import (
+	"io"
+	"os"
+)
+
+type CommandOutput struct {
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+func commandStdout(output CommandOutput) io.Writer {
+	if output.Stdout != nil {
+		return output.Stdout
+	}
+	return os.Stdout
+}
+
+func commandStderr(output CommandOutput) io.Writer {
+	if output.Stderr != nil {
+		return output.Stderr
+	}
+	return os.Stderr
+}

--- a/gestaltd/services/apps/providerpkg/go_provider.go
+++ b/gestaltd/services/apps/providerpkg/go_provider.go
@@ -48,12 +48,16 @@ func BuildGoProviderTempBinary(root, goos, goarch string) (string, func(), error
 }
 
 func BuildGoProviderBinary(root, outputPath, pluginName, goos, goarch string) error {
+	return buildGoProviderBinary(root, outputPath, pluginName, goos, goarch, CommandOutput{})
+}
+
+func buildGoProviderBinary(root, outputPath, pluginName, goos, goarch string, output CommandOutput) error {
 	return buildGoSourceBinary(root, outputPath, goos, goarch, ErrNoGoProviderPackage, goProviderSourceExists, "gestalt-go-provider-*.go", "Go provider wrapper", func(importPath string) (goExecutableWrapperData, error) {
 		return goExecutableWrapperData{
 			ImportPath: importPath,
 			ServeCall:  fmt.Sprintf("gestalt.ServeProvider(ctx, providerpkg.New(), providerpkg.Router.WithName(%q))", pluginName),
 		}, nil
-	})
+	}, output)
 }
 
 func DetectGoComponentImportPath(root, kind, goos, goarch string) (string, error) {
@@ -70,6 +74,10 @@ func BuildGoComponentTempBinary(root, kind, goos, goarch string) (string, func()
 }
 
 func BuildGoComponentBinary(root, outputPath, kind, goos, goarch string) error {
+	return buildGoComponentBinary(root, outputPath, kind, goos, goarch, CommandOutput{})
+}
+
+func buildGoComponentBinary(root, outputPath, kind, goos, goarch string, output CommandOutput) error {
 	if err := validateSourceComponentKind(kind); err != nil {
 		return err
 	}
@@ -82,7 +90,7 @@ func BuildGoComponentBinary(root, outputPath, kind, goos, goarch string) error {
 			ImportPath: importPath,
 			ServeCall:  serveCall,
 		}, nil
-	})
+	}, output)
 }
 
 func SourceComponentExecutionCommand(root, kind, goos, goarch string) (string, []string, func(), error) {
@@ -146,24 +154,28 @@ func ValidateSourceComponentRelease(root, kind, goos, goarch string) error {
 }
 
 func BuildSourceComponentReleaseBinary(root, outputPath, kind, goos, goarch string) (string, error) {
+	return buildSourceComponentReleaseBinary(root, outputPath, kind, goos, goarch, CommandOutput{})
+}
+
+func buildSourceComponentReleaseBinary(root, outputPath, kind, goos, goarch string, output CommandOutput) (string, error) {
 	sourceKind, target, err := detectSourceComponent(root, kind, goos, goarch)
 	if err != nil {
 		return "", err
 	}
 	switch sourceKind {
 	case sourceProviderKindGo:
-		return "", BuildGoComponentBinary(root, outputPath, kind, goos, goarch)
+		return "", buildGoComponentBinary(root, outputPath, kind, goos, goarch, output)
 	case sourceProviderKindRust:
-		return BuildRustComponentBinary(root, outputPath, kind, goos, goarch)
+		return buildRustComponentBinary(root, outputPath, kind, goos, goarch, output)
 	case sourceProviderKindPython:
 		runtimeKind, err := pythonRuntimeKind(kind)
 		if err != nil {
 			return "", err
 		}
 		pluginName := sourceAppName(root)
-		return BuildPythonComponentBinary(root, outputPath, pluginName, target, runtimeKind, goos, goarch)
+		return buildPythonComponentBinary(root, outputPath, pluginName, target, runtimeKind, goos, goarch, output)
 	case sourceProviderKindTypeScript:
-		return BuildTypeScriptComponentBinary(root, outputPath, kind, target, goos, goarch)
+		return buildTypeScriptComponentBinary(root, outputPath, kind, target, goos, goarch, output)
 	default:
 		return "", ErrNoSourceComponentPackage
 	}
@@ -311,14 +323,14 @@ func newGoSourceWrapper(root, goos, goarch string, noSourceErr error, sourceExis
 	return newGoWrapper(tempPattern, description, goExecutableWrapperTemplate, data)
 }
 
-func buildGoSourceBinary(root, outputPath, goos, goarch string, noSourceErr error, sourceExists func(string) bool, tempPattern, description string, wrapperData func(string) (goExecutableWrapperData, error)) error {
+func buildGoSourceBinary(root, outputPath, goos, goarch string, noSourceErr error, sourceExists func(string) bool, tempPattern, description string, wrapperData func(string) (goExecutableWrapperData, error), output CommandOutput) error {
 	wrapperPath, cleanup, err := newGoSourceWrapper(root, goos, goarch, noSourceErr, sourceExists, tempPattern, description, wrapperData)
 	if err != nil {
 		return err
 	}
 	defer cleanup()
 
-	return buildGoWrapperBinary(root, outputPath, wrapperPath, goos, goarch)
+	return buildGoWrapperBinary(root, outputPath, wrapperPath, goos, goarch, output)
 }
 
 func newGoWrapper(tempPattern, description string, tmpl *template.Template, data any) (string, func(), error) {
@@ -366,11 +378,11 @@ func buildGoTempBinary(tempDirPattern, binaryBaseName, goos string, build func(o
 	return binaryPath, cleanup, nil
 }
 
-func buildGoWrapperBinary(root, outputPath, wrapperPath, goos, goarch string) error {
+func buildGoWrapperBinary(root, outputPath, wrapperPath, goos, goarch string, output CommandOutput) error {
 	cmd := exec.Command("go", "-C", root, "build", goReadonlyFlag, "-trimpath", "-ldflags", "-s -w", "-o", outputPath, wrapperPath)
 	cmd.Env = append(os.Environ(), "CGO_ENABLED=0", "GOOS="+goos, "GOARCH="+goarch)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = commandStdout(output)
+	cmd.Stderr = commandStderr(output)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("go build: %w", err)
 	}

--- a/gestaltd/services/apps/providerpkg/prepared_stage.go
+++ b/gestaltd/services/apps/providerpkg/prepared_stage.go
@@ -27,6 +27,7 @@ type StagePreparedInstallOptions struct {
 	AppName         string
 	GOOS            string
 	GOARCH          string
+	BuildOutput     CommandOutput
 }
 
 type StageSourcePreparedInstallOptions struct {
@@ -35,6 +36,7 @@ type StageSourcePreparedInstallOptions struct {
 	AppName         string
 	GOOS            string
 	GOARCH          string
+	BuildOutput     CommandOutput
 }
 
 type StagedPreparedInstall struct {
@@ -69,12 +71,12 @@ func StageSourcePreparedInstallDir(manifestPath, stagingDir string, opts StageSo
 	if err := ValidateExplicitRunPackaging(filepath.Dir(manifestPath), manifest); err != nil {
 		return nil, err
 	}
-	targetOpts := SourceBuildOptions{GOOS: opts.GOOS, GOARCH: opts.GOARCH}
-	hostBuiltForCatalog, err := ensureHostBuildForSourceStaticCatalog(manifestPath, manifest)
+	targetOpts := SourceBuildOptions{GOOS: opts.GOOS, GOARCH: opts.GOARCH, Output: opts.BuildOutput}
+	hostBuiltForCatalog, err := ensureHostBuildForSourceStaticCatalog(manifestPath, manifest, SourceBuildOptions{Output: opts.BuildOutput})
 	if err != nil {
 		return nil, err
 	}
-	_, srcManifest, err := prepareSourceManifestForPreparedInstall(manifestPath)
+	_, srcManifest, err := prepareSourceManifestForPreparedInstallWithOptions(manifestPath, SourceBuildOptions{Output: opts.BuildOutput})
 	if err != nil {
 		return nil, fmt.Errorf("prepare %s: %w", manifestPath, err)
 	}
@@ -88,10 +90,11 @@ func StageSourcePreparedInstallDir(manifestPath, stagingDir string, opts StageSo
 		AppName:         opts.AppName,
 		GOOS:            opts.GOOS,
 		GOARCH:          opts.GOARCH,
+		BuildOutput:     opts.BuildOutput,
 	})
 }
 
-func ensureHostBuildForSourceStaticCatalog(manifestPath string, manifest *providermanifestv1.Manifest) (bool, error) {
+func ensureHostBuildForSourceStaticCatalog(manifestPath string, manifest *providermanifestv1.Manifest, opts SourceBuildOptions) (bool, error) {
 	shouldPrepare, err := sourceStaticCatalogShouldBePreparedForPackaging(manifestPath, manifest)
 	if err != nil {
 		return false, err
@@ -99,7 +102,7 @@ func ensureHostBuildForSourceStaticCatalog(manifestPath string, manifest *provid
 	if !SourceBuildProducesOutput(manifest) || !shouldPrepare {
 		return false, nil
 	}
-	if err := EnsureSourceBuildOutput(manifestPath, manifest, SourceBuildOptions{}); err != nil {
+	if err := EnsureSourceBuildOutput(manifestPath, manifest, opts); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -152,7 +155,7 @@ func StagePreparedInstallDir(manifestPath, stagingDir string, opts StagePrepared
 	if err := ValidateExplicitRunPackaging(filepath.Dir(manifestPath), manifest); err != nil {
 		return nil, err
 	}
-	_, srcManifest, err := prepareSourceManifestForPreparedInstall(manifestPath)
+	_, srcManifest, err := prepareSourceManifestForPreparedInstallWithOptions(manifestPath, SourceBuildOptions{Output: opts.BuildOutput})
 	if err != nil {
 		return nil, fmt.Errorf("prepare %s: %w", manifestPath, err)
 	}
@@ -200,7 +203,7 @@ func stagePreparedInstallDir(manifestPath, stagingDir string, srcManifest *provi
 	if buildKind != "" {
 		binaryName := stagedReleaseBinaryName(pluginName, goos)
 		binaryPath := filepath.Join(stagingDir, binaryName)
-		if _, err := buildPreparedInstallBinary(sourceDir, binaryPath, pluginName, buildKind, goos, goarch); err != nil {
+		if _, err := buildPreparedInstallBinary(sourceDir, binaryPath, pluginName, buildKind, goos, goarch, opts.BuildOutput); err != nil {
 			return nil, err
 		}
 		digest, digestErr := FileSHA256(binaryPath)
@@ -333,12 +336,12 @@ func artifactExistsForEntrypoint(root string, entry *providermanifestv1.Entrypoi
 	return err == nil
 }
 
-func buildPreparedInstallBinary(root, outputPath, pluginName, kind, goos, goarch string) (string, error) {
+func buildPreparedInstallBinary(root, outputPath, pluginName, kind, goos, goarch string, output CommandOutput) (string, error) {
 	switch kind {
 	case providermanifestv1.KindApp:
-		return BuildSourceProviderReleaseBinary(root, outputPath, pluginName, goos, goarch)
+		return buildSourceProviderReleaseBinary(root, outputPath, pluginName, goos, goarch, output)
 	case providermanifestv1.KindAuthentication, providermanifestv1.KindAuthorization, providermanifestv1.KindExternalCredentials, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindAgent, providermanifestv1.KindSecrets, providermanifestv1.KindRuntime:
-		return BuildSourceComponentReleaseBinary(root, outputPath, kind, goos, goarch)
+		return buildSourceComponentReleaseBinary(root, outputPath, kind, goos, goarch, output)
 	default:
 		return "", fmt.Errorf("unsupported release build target kind %q", kind)
 	}

--- a/gestaltd/services/apps/providerpkg/python_provider.go
+++ b/gestaltd/services/apps/providerpkg/python_provider.go
@@ -102,10 +102,18 @@ func pythonExecutionCommand(root, target, runtimeKind string) (string, []string,
 }
 
 func BuildPythonProviderBinary(sourceDir, binaryPath, pluginName, target, goos, goarch string) (string, error) {
-	return BuildPythonComponentBinary(sourceDir, binaryPath, pluginName, target, pythonRuntimeKindIntegration, goos, goarch)
+	return buildPythonProviderBinary(sourceDir, binaryPath, pluginName, target, goos, goarch, CommandOutput{})
+}
+
+func buildPythonProviderBinary(sourceDir, binaryPath, pluginName, target, goos, goarch string, output CommandOutput) (string, error) {
+	return buildPythonComponentBinary(sourceDir, binaryPath, pluginName, target, pythonRuntimeKindIntegration, goos, goarch, output)
 }
 
 func BuildPythonComponentBinary(sourceDir, binaryPath, pluginName, target, runtimeKind, goos, goarch string) (string, error) {
+	return buildPythonComponentBinary(sourceDir, binaryPath, pluginName, target, runtimeKind, goos, goarch, CommandOutput{})
+}
+
+func buildPythonComponentBinary(sourceDir, binaryPath, pluginName, target, runtimeKind, goos, goarch string, output CommandOutput) (string, error) {
 	interpreter, err := DetectPythonInterpreter(sourceDir, goos, goarch)
 	if err != nil {
 		return "", fmt.Errorf("detect Python release interpreter for %s/%s: %w", goos, goarch, err)
@@ -118,8 +126,8 @@ func BuildPythonComponentBinary(sourceDir, binaryPath, pluginName, target, runti
 		return "", fmt.Errorf("prepare Python release build environment: %w", err)
 	}
 	cmd.Env = env
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = commandStdout(output)
+	cmd.Stderr = commandStderr(output)
 	if err := cmd.Run(); err != nil {
 		return "", fmt.Errorf("python release build: %w (ensure gestalt and PyInstaller are installed in the selected Python environment)", err)
 	}

--- a/gestaltd/services/apps/providerpkg/rust_provider.go
+++ b/gestaltd/services/apps/providerpkg/rust_provider.go
@@ -123,7 +123,7 @@ func BuildRustComponentTempBinary(root, kind, goos, goarch string) (string, func
 
 func buildRustTempBinary(root, pluginName, kind, goos, goarch string) (string, func(), error) {
 	return buildGoTempBinary("gestalt-rust-provider-bin-*", rustBinaryName(kind), goos, func(outputPath string) error {
-		_, err := buildRustBinary(root, outputPath, pluginName, kind, goos, goarch)
+		_, err := buildRustBinary(root, outputPath, pluginName, kind, goos, goarch, CommandOutput{})
 		return err
 	})
 }
@@ -152,21 +152,29 @@ func ValidateRustComponentRelease(root, kind, goos, goarch string) error {
 }
 
 func BuildRustProviderBinary(root, outputPath, pluginName, goos, goarch string) (string, error) {
-	return buildRustBinary(root, outputPath, pluginName, providermanifestv1.KindApp, goos, goarch)
+	return buildRustProviderBinary(root, outputPath, pluginName, goos, goarch, CommandOutput{})
+}
+
+func buildRustProviderBinary(root, outputPath, pluginName, goos, goarch string, output CommandOutput) (string, error) {
+	return buildRustBinary(root, outputPath, pluginName, providermanifestv1.KindApp, goos, goarch, output)
 }
 
 func BuildRustComponentBinary(root, outputPath, kind, goos, goarch string) (string, error) {
+	return buildRustComponentBinary(root, outputPath, kind, goos, goarch, CommandOutput{})
+}
+
+func buildRustComponentBinary(root, outputPath, kind, goos, goarch string, output CommandOutput) (string, error) {
 	if err := validateRustComponentKind(kind); err != nil {
 		return "", err
 	}
-	return buildRustBinary(root, outputPath, sourceAppName(root), kind, goos, goarch)
+	return buildRustBinary(root, outputPath, sourceAppName(root), kind, goos, goarch, output)
 }
 
 func validateRustComponentKind(kind string) error {
 	return validateSourceComponentKind(kind)
 }
 
-func buildRustBinary(root, outputPath, pluginName, kind, goos, goarch string) (string, error) {
+func buildRustBinary(root, outputPath, pluginName, kind, goos, goarch string, output CommandOutput) (string, error) {
 	target, err := detectRustPackage(root)
 	if err != nil {
 		return "", err
@@ -197,8 +205,8 @@ func buildRustBinary(root, outputPath, pluginName, kind, goos, goarch string) (s
 		"--target-dir", targetDir,
 	)
 	cmd.Env = os.Environ()
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = commandStdout(output)
+	cmd.Stderr = commandStderr(output)
 	if err := cmd.Run(); err != nil {
 		return "", fmt.Errorf("cargo build: %w", err)
 	}

--- a/gestaltd/services/apps/providerpkg/source_build.go
+++ b/gestaltd/services/apps/providerpkg/source_build.go
@@ -23,6 +23,7 @@ type SourceBuildOptions struct {
 	GOOS   string
 	GOARCH string
 	LibC   string
+	Output CommandOutput
 }
 
 type SourceExecutionIntent int
@@ -105,8 +106,8 @@ func RunSourceBuild(manifestPath string, manifest *providermanifestv1.Manifest, 
 	cmd := exec.Command(build.Command[0], build.Command[1:]...)
 	cmd.Dir = workdir
 	cmd.Env = sourceBuildEnv(os.Environ(), opts)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = commandStdout(opts.Output)
+	cmd.Stderr = commandStderr(opts.Output)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("run %s.command: %w", build.Label, err)
 	}

--- a/gestaltd/services/apps/providerpkg/source_prepare.go
+++ b/gestaltd/services/apps/providerpkg/source_prepare.go
@@ -20,11 +20,11 @@ type sourceCatalogOptions struct {
 }
 
 func PrepareSourceManifest(manifestPath string) ([]byte, *providermanifestv1.Manifest, error) {
-	return prepareSourceManifest(manifestPath, false)
+	return prepareSourceManifest(manifestPath, false, SourceBuildOptions{})
 }
 
-func prepareSourceManifestForPreparedInstall(manifestPath string) ([]byte, *providermanifestv1.Manifest, error) {
-	return prepareSourceManifest(manifestPath, true)
+func prepareSourceManifestForPreparedInstallWithOptions(manifestPath string, opts SourceBuildOptions) ([]byte, *providermanifestv1.Manifest, error) {
+	return prepareSourceManifest(manifestPath, true, opts)
 }
 
 // Local prepare may create catalog.yaml from run; packaging must regenerate it
@@ -33,7 +33,7 @@ func explicitRunStaleCatalog(manifest *providermanifestv1.Manifest) bool {
 	return HasExplicitSourceRun(manifest)
 }
 
-func prepareSourceManifest(manifestPath string, packaging bool) ([]byte, *providermanifestv1.Manifest, error) {
+func prepareSourceManifest(manifestPath string, packaging bool, buildOpts SourceBuildOptions) ([]byte, *providermanifestv1.Manifest, error) {
 	absoluteManifestPath, err := filepath.Abs(manifestPath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("resolve manifest path: %w", err)
@@ -53,7 +53,7 @@ func prepareSourceManifest(manifestPath string, packaging bool) ([]byte, *provid
 	if err != nil {
 		return nil, nil, err
 	}
-	if err := ensurePrepareOnlyBuild(manifestPath, manifest, SourceBuildOptions{}); err != nil {
+	if err := ensurePrepareOnlyBuild(manifestPath, manifest, buildOpts); err != nil {
 		return nil, nil, err
 	}
 	catalogOptions := sourceCatalogOptions{SkipExplicitRun: packaging}

--- a/gestaltd/services/apps/providerpkg/source_provider.go
+++ b/gestaltd/services/apps/providerpkg/source_provider.go
@@ -105,19 +105,23 @@ func ValidateSourceProviderRelease(root, goos, goarch string) error {
 }
 
 func BuildSourceProviderReleaseBinary(root, outputPath, pluginName, goos, goarch string) (string, error) {
+	return buildSourceProviderReleaseBinary(root, outputPath, pluginName, goos, goarch, CommandOutput{})
+}
+
+func buildSourceProviderReleaseBinary(root, outputPath, pluginName, goos, goarch string, output CommandOutput) (string, error) {
 	kind, target, err := detectSourceProvider(root, goos, goarch)
 	if err != nil {
 		return "", err
 	}
 	switch kind {
 	case sourceProviderKindGo:
-		return "", BuildGoProviderBinary(root, outputPath, pluginName, goos, goarch)
+		return "", buildGoProviderBinary(root, outputPath, pluginName, goos, goarch, output)
 	case sourceProviderKindRust:
-		return BuildRustProviderBinary(root, outputPath, pluginName, goos, goarch)
+		return buildRustProviderBinary(root, outputPath, pluginName, goos, goarch, output)
 	case sourceProviderKindPython:
-		return BuildPythonProviderBinary(root, outputPath, pluginName, target, goos, goarch)
+		return buildPythonProviderBinary(root, outputPath, pluginName, target, goos, goarch, output)
 	case sourceProviderKindTypeScript:
-		return BuildTypeScriptProviderBinary(root, outputPath, pluginName, target, goos, goarch)
+		return buildTypeScriptProviderBinary(root, outputPath, pluginName, target, goos, goarch, output)
 	default:
 		return "", ErrNoSourceProviderPackage
 	}

--- a/gestaltd/services/apps/providerpkg/typescript_provider.go
+++ b/gestaltd/services/apps/providerpkg/typescript_provider.go
@@ -81,10 +81,10 @@ func typeScriptExecutionCommand(root, target string) (string, []string, func(), 
 	if err != nil {
 		return "", nil, nil, err
 	}
-	if err := ensureTypeScriptProjectDependencies(bunPath, root); err != nil {
+	if err := ensureTypeScriptProjectDependencies(bunPath, root, CommandOutput{}); err != nil {
 		return "", nil, nil, err
 	}
-	sdkPath, err := prepareLocalTypeScriptSDK(bunPath)
+	sdkPath, err := prepareLocalTypeScriptSDK(bunPath, CommandOutput{})
 	if err != nil {
 		return "", nil, nil, err
 	}
@@ -108,27 +108,35 @@ func typeScriptExecutionCommand(root, target string) (string, []string, func(), 
 }
 
 func BuildTypeScriptProviderBinary(sourceDir, binaryPath, pluginName, target, goos, goarch string) (string, error) {
-	return buildTypeScriptBinary(sourceDir, binaryPath, pluginName, target, goos, goarch)
+	return buildTypeScriptProviderBinary(sourceDir, binaryPath, pluginName, target, goos, goarch, CommandOutput{})
+}
+
+func buildTypeScriptProviderBinary(sourceDir, binaryPath, pluginName, target, goos, goarch string, output CommandOutput) (string, error) {
+	return buildTypeScriptBinary(sourceDir, binaryPath, pluginName, target, goos, goarch, output)
 }
 
 func BuildTypeScriptComponentBinary(sourceDir, binaryPath, kind, target, goos, goarch string) (string, error) {
+	return buildTypeScriptComponentBinary(sourceDir, binaryPath, kind, target, goos, goarch, CommandOutput{})
+}
+
+func buildTypeScriptComponentBinary(sourceDir, binaryPath, kind, target, goos, goarch string, output CommandOutput) (string, error) {
 	if err := validateSourceComponentKind(kind); err != nil {
 		return "", err
 	}
-	return buildTypeScriptBinary(sourceDir, binaryPath, sourceAppName(sourceDir), target, goos, goarch)
+	return buildTypeScriptBinary(sourceDir, binaryPath, sourceAppName(sourceDir), target, goos, goarch, output)
 }
 
-func buildTypeScriptBinary(sourceDir, binaryPath, pluginName, target, goos, goarch string) (string, error) {
+func buildTypeScriptBinary(sourceDir, binaryPath, pluginName, target, goos, goarch string, output CommandOutput) (string, error) {
 	bunPath, err := DetectBunExecutable()
 	if err != nil {
 		return "", fmt.Errorf("detect Bun executable: %w", err)
 	}
-	if err := ensureTypeScriptProjectDependencies(bunPath, sourceDir); err != nil {
+	if err := ensureTypeScriptProjectDependencies(bunPath, sourceDir, output); err != nil {
 		return "", fmt.Errorf("prepare TypeScript provider dependencies: %w", err)
 	}
 
 	var args []string
-	sdkPath, err := prepareLocalTypeScriptSDK(bunPath)
+	sdkPath, err := prepareLocalTypeScriptSDK(bunPath, output)
 	if err != nil {
 		return "", fmt.Errorf("prepare local TypeScript SDK: %w", err)
 	}
@@ -161,8 +169,8 @@ func buildTypeScriptBinary(sourceDir, binaryPath, pluginName, target, goos, goar
 
 	cmd := exec.Command(bunPath, args...)
 	cmd.Dir = sourceDir
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = commandStdout(output)
+	cmd.Stderr = commandStderr(output)
 	if err := cmd.Run(); err != nil {
 		return "", fmt.Errorf("TypeScript release build: %w (ensure Bun and @valon-technologies/gestalt are available)", err)
 	}
@@ -224,26 +232,26 @@ func bunExecutableCandidates() []string {
 	return candidates
 }
 
-func prepareLocalTypeScriptSDK(bunPath string) (string, error) {
+func prepareLocalTypeScriptSDK(bunPath string, output CommandOutput) (string, error) {
 	sdkPath := localTypeScriptSDKPath()
 	if sdkPath == "" {
 		return "", nil
 	}
-	if err := ensureLocalTypeScriptSDKDependencies(bunPath, sdkPath); err != nil {
+	if err := ensureLocalTypeScriptSDKDependencies(bunPath, sdkPath, output); err != nil {
 		return "", err
 	}
 	return sdkPath, nil
 }
 
-func ensureTypeScriptProjectDependencies(bunPath, root string) error {
-	return ensureTypeScriptDependencies(bunPath, root, "TypeScript provider")
+func ensureTypeScriptProjectDependencies(bunPath, root string, output CommandOutput) error {
+	return ensureTypeScriptDependencies(bunPath, root, "TypeScript provider", output)
 }
 
-func ensureLocalTypeScriptSDKDependencies(bunPath, sdkPath string) error {
-	return ensureTypeScriptDependencies(bunPath, sdkPath, "local TypeScript SDK")
+func ensureLocalTypeScriptSDKDependencies(bunPath, sdkPath string, output CommandOutput) error {
+	return ensureTypeScriptDependencies(bunPath, sdkPath, "local TypeScript SDK", output)
 }
 
-func ensureTypeScriptDependencies(bunPath, root, label string) error {
+func ensureTypeScriptDependencies(bunPath, root, label string, output CommandOutput) error {
 	nodeModulesPath := filepath.Join(root, "node_modules")
 	if info, err := os.Stat(nodeModulesPath); err == nil {
 		if info.IsDir() {
@@ -264,8 +272,8 @@ func ensureTypeScriptDependencies(bunPath, root, label string) error {
 
 	cmd := exec.Command(bunPath, args...)
 	cmd.Dir = root
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = commandStdout(output)
+	cmd.Stderr = commandStderr(output)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("bun install for %s: %w", label, err)
 	}


### PR DESCRIPTION
## Summary

Adds a `uv`-style observability surface for locked artifact preparation in `gestaltd sync`.

`gestaltd sync` now accepts `-v` / `--verbose` for human diagnostics and `--output-format text|json` for machine-readable CI instrumentation. Text remains the default output format and successful default sync remains quiet. JSON mode writes a single schema v1 metrics document to stdout on successful sync, leaves stdout empty on failure, and routes source-build child output to stderr so CI can safely redirect stdout into a metrics file.

The metrics report the effective sync action, config and lock inputs, prepared artifact count, archive cache eligibility and hit/miss behavior, archive download count and bytes, lifecycle phase timings, prepared output size over known artifact roots, and the five slowest archive fetches.

## Interfaces

```sh
gestaltd sync \
  --locked \
  --verbose \
  --output-format=json \
  --config deploy/config.yaml \
  --artifacts-dir deploy \
  --cache-dir /cache/gestaltd-archives \
  > gestaltd-sync.json
```

```json
{
  "schema": {"version": "1"},
  "command": "sync",
  "sync": {"action": "materialize", "duration_seconds": 113.6},
  "archives": {
    "cache": {"enabled": true, "hits": 12, "misses": 6},
    "downloads": {"count": 6, "bytes": 883216384}
  }
}
```

`gestaltd sync -v -v` is accepted as the same single verbose level, while `gestaltd sync -vv` remains unsupported by the Go flag parser. Top-level `gestaltd -v` still prints the server version.

## Runtime

The operator records sync metrics through a thread-safe `SyncMetricsRecorder` wired into the sync lifecycle and locked archive download/cache path only when sync observability is requested. Archive cache writes remain best-effort; put failures are counted but do not fail sync. Prepared output measurement is also best-effort and only scans known prepared artifact roots, not the entire artifacts directory.

Provider source preparation gains explicit child-output routing for sync JSON mode through one shared provider command-output option. Normal callers keep the existing stdout/stderr defaults, while `gestaltd sync --output-format=json` passes stderr as the child stdout/stderr writer so build logs do not corrupt the JSON metrics document.

Docs now cover the new sync flags, quiet default success behavior, JSON stdout/stderr contract, JSON field meanings, and Docker/CI usage with `--cache-dir`.