### PR TITLE
Add detailed gestaltd sync observability

### DIFF
--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -92,7 +92,7 @@ cache.
 
 `gestaltd sync --locked -v` and `gestaltd sync --locked --verbose` add
 human-readable diagnostics for archive cache behavior, archive downloads,
-phase timings, prepared output size, and the slowest archive fetches. There is
+phase timings, prepared output size, and archive fetches. There is
 one verbosity level; `-vv` is not supported. The top-level `gestaltd -v` still
 prints the server version. Without `-v` or `--output-format=json`, successful
 `gestaltd sync --locked` remains quiet.
@@ -134,8 +134,8 @@ gestaltd sync \
 ```
 
 The JSON schema starts at version `1` and reports the sync action, inputs,
-artifact count, archive cache counters, archive download counters, phase
-timings, prepared output size, and the five slowest archive fetches. In
+artifact count and decisions, archive cache counters, archive download counters,
+archive fetches, phase timings, and prepared output size. In
 `--check` mode, the action is `check`, archive cache writes remain zero, and
 `output.measured` is `false`.
 
@@ -146,13 +146,15 @@ timings, prepared output size, and the five slowest archive fetches. In
 | `sync.duration_seconds` | Total successful sync duration. |
 | `inputs.config_paths` | Config files passed to sync after CLI path resolution. |
 | `artifacts.considered` | Prepared artifact entries in the effective config. |
+| `artifacts.items` | All prepared artifact decisions recorded by the run, sorted by duration descending. |
 | `archives.requests` | Current-platform archive acquisition attempts made by this run. |
 | `archives.unique_sha256` | Unique canonical expected SHA-256 values among archive requests. |
 | `archives.cache.*` | Cache configuration, eligibility, hit/miss, invalid, rejected, put, and put-failure counters. |
 | `archives.downloads.*` | Successful remote archive download count, bytes, and cumulative download time. |
-| `archives.slowest_fetches` | Up to five slowest archive acquisitions, including cache result and download status. |
+| `archives.fetches` | All archive acquisitions recorded by the run, sorted by duration descending. |
 | `phases.*_seconds` | Major lifecycle phase timings. Download time is cumulative and may not sum to wall-clock time under parallelism. |
-| `output.*` | Prepared output measurement over known prepared artifact roots, not the entire artifacts directory. |
+| `output.files`, `output.bytes` | Aggregate prepared output measurement over known prepared artifact roots, not the entire artifacts directory. |
+| `output.roots` | All measured prepared output roots, sorted by bytes descending. |
 
 ## Config Watch Mode
 

--- a/gestaltd/internal/daemon/main_test.go
+++ b/gestaltd/internal/daemon/main_test.go
@@ -286,6 +286,14 @@ func TestE2ESyncDefaultSuccessIsQuiet(t *testing.T) {
 
 	dir := t.TempDir()
 	appDir := setupAppDir(t, dir)
+	buildScriptPath := filepath.Join(appDir, "build.sh")
+	buildScript, err := os.ReadFile(buildScriptPath)
+	if err != nil {
+		t.Fatalf("read build script: %v", err)
+	}
+	if err := os.WriteFile(buildScriptPath, []byte("printf 'DEFAULT_SYNC_STDOUT_SENTINEL\\n'\nprintf 'DEFAULT_SYNC_STDERR_SENTINEL\\n' >&2\n"+string(buildScript)), 0o755); err != nil {
+		t.Fatalf("write build script: %v", err)
+	}
 	configPath := writeE2EConfig(t, dir, appDir, 18080)
 
 	out, err := exec.Command(gestaltdBin, "lock", "--config", configPath).CombinedOutput()

--- a/gestaltd/internal/daemon/run.go
+++ b/gestaltd/internal/daemon/run.go
@@ -307,7 +307,8 @@ func runSync(args []string) error {
 		metrics = operator.NewSyncMetricsRecorder()
 		observability.Recorder = metrics
 	}
-	if *outputFormat == syncOutputFormatJSON {
+	observability.BuildOutput = providerpkg.CommandOutput{Stdout: io.Discard, Stderr: io.Discard}
+	if *outputFormat == syncOutputFormatJSON || verbose {
 		observability.BuildOutput = providerpkg.CommandOutput{Stdout: os.Stderr, Stderr: os.Stderr}
 	}
 	opts := operator.SyncOptions{

--- a/gestaltd/internal/daemon/sync_output.go
+++ b/gestaltd/internal/daemon/sync_output.go
@@ -33,6 +33,7 @@ func validateSyncOutputFormat(format string) error {
 }
 
 func writeSyncJSON(w io.Writer, metrics operator.SyncMetrics) error {
+	metrics = normalizeSyncMetricsForJSON(metrics)
 	doc := syncOutputDocument{
 		Schema:      syncOutputSchema{Version: "1"},
 		Command:     "sync",
@@ -40,6 +41,19 @@ func writeSyncJSON(w io.Writer, metrics operator.SyncMetrics) error {
 	}
 	encoder := json.NewEncoder(w)
 	return encoder.Encode(doc)
+}
+
+func normalizeSyncMetricsForJSON(metrics operator.SyncMetrics) operator.SyncMetrics {
+	if metrics.Archives.Fetches == nil {
+		metrics.Archives.Fetches = []operator.SyncMetricsArchiveFetch{}
+	}
+	if metrics.Artifacts.Items == nil {
+		metrics.Artifacts.Items = []operator.SyncMetricsArtifactRecord{}
+	}
+	if metrics.Output.Roots == nil {
+		metrics.Output.Roots = []operator.SyncMetricsOutputRoot{}
+	}
+	return metrics
 }
 
 func writeSyncText(w io.Writer, metrics operator.SyncMetrics, verbose bool) error {
@@ -95,12 +109,33 @@ func writeSyncText(w io.Writer, metrics operator.SyncMetrics, verbose bool) erro
 				return err
 			}
 		}
-		if len(metrics.Archives.SlowestFetches) > 0 {
-			if _, err := fmt.Fprintln(w, "Slowest archive fetches:"); err != nil {
+		if len(metrics.Archives.Fetches) > 0 {
+			if _, err := fmt.Fprintln(w, "Archive fetches:"); err != nil {
 				return err
 			}
-			for _, fetch := range metrics.Archives.SlowestFetches {
+			for _, fetch := range metrics.Archives.Fetches {
 				if _, err := fmt.Fprintf(w, "  %s: %s, downloaded=%t, %s, %.3fs\n", fetch.Subject, fetch.CacheResult, fetch.Downloaded, formatIECBytes(fetch.Bytes), fetch.DurationSeconds); err != nil {
+					return err
+				}
+			}
+		}
+		if len(metrics.Artifacts.Items) > 0 {
+			if _, err := fmt.Fprintln(w, "Artifacts:"); err != nil {
+				return err
+			}
+			for i := range metrics.Artifacts.Items {
+				artifact := &metrics.Artifacts.Items[i]
+				if _, err := fmt.Fprintf(w, "  %s: %s %s, reason=%s, prepare %.3fs, activate %.3fs, total %.3fs\n", artifact.Subject, artifact.SourceKind, artifact.Result, artifact.Reason, artifact.PrepareDurationSeconds, artifact.ActivateDurationSeconds, artifact.DurationSeconds); err != nil {
+					return err
+				}
+			}
+		}
+		if len(metrics.Output.Roots) > 0 {
+			if _, err := fmt.Fprintln(w, "Prepared output roots:"); err != nil {
+				return err
+			}
+			for _, root := range metrics.Output.Roots {
+				if _, err := fmt.Fprintf(w, "  %s: %d files, %s, %s\n", root.Subject, root.Files, formatIECBytes(root.Bytes), root.RelativePath); err != nil {
 					return err
 				}
 			}

--- a/gestaltd/internal/daemon/sync_output_test.go
+++ b/gestaltd/internal/daemon/sync_output_test.go
@@ -25,7 +25,35 @@ func TestWriteSyncJSON(t *testing.T) {
 			Check:       false,
 			Parallelism: 4,
 		},
-		Artifacts: operator.SyncMetricsArtifacts{Considered: 2},
+		Artifacts: operator.SyncMetricsArtifacts{
+			Considered: 2,
+			Items: []operator.SyncMetricsArtifactRecord{{
+				Subject:         "provider \"alpha\"",
+				Kind:            "app",
+				Name:            "alpha",
+				SourceKind:      "local_source",
+				Result:          "materialized",
+				Reason:          "prepared_missing",
+				DurationSeconds: 1.0,
+			}},
+		},
+		Archives: operator.SyncMetricsArchives{
+			Fetches: []operator.SyncMetricsArchiveFetch{{
+				Subject:         "provider \"alpha\"",
+				SourceKind:      "remote_release_metadata",
+				CacheResult:     "hit",
+				DurationSeconds: 0.5,
+			}},
+		},
+		Output: operator.SyncMetricsOutput{
+			Measured: true,
+			Roots: []operator.SyncMetricsOutputRoot{{
+				Subject:      "provider \"alpha\"",
+				Kind:         "app",
+				Name:         "alpha",
+				RelativePath: "providers/alpha",
+			}},
+		},
 	}
 
 	var out bytes.Buffer
@@ -51,6 +79,59 @@ func TestWriteSyncJSON(t *testing.T) {
 	}
 	if doc.Artifacts.Considered != 2 {
 		t.Fatalf("artifacts.considered = %d, want 2", doc.Artifacts.Considered)
+	}
+	if len(doc.Archives.Fetches) != 1 {
+		t.Fatalf("archives.fetches len = %d, want 1", len(doc.Archives.Fetches))
+	}
+	if len(doc.Artifacts.Items) != 1 {
+		t.Fatalf("artifacts.items len = %d, want 1", len(doc.Artifacts.Items))
+	}
+	if len(doc.Output.Roots) != 1 {
+		t.Fatalf("output.roots len = %d, want 1", len(doc.Output.Roots))
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(out.Bytes(), &raw); err != nil {
+		t.Fatalf("unmarshal sync JSON map: %v", err)
+	}
+	archives, ok := raw["archives"].(map[string]any)
+	if !ok {
+		t.Fatalf("archives missing from JSON: %s", out.String())
+	}
+	if _, ok := archives["slowest_fetches"]; ok {
+		t.Fatalf("archives.slowest_fetches should not be serialized: %s", out.String())
+	}
+}
+
+func TestWriteSyncJSONIncludesEmptyMetricArrays(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	if err := writeSyncJSON(&out, operator.SyncMetrics{}); err != nil {
+		t.Fatalf("writeSyncJSON: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(out.Bytes(), &raw); err != nil {
+		t.Fatalf("unmarshal sync JSON map: %v", err)
+	}
+	archives := raw["archives"].(map[string]any)
+	if _, ok := archives["slowest_fetches"]; ok {
+		t.Fatalf("archives.slowest_fetches should not be serialized: %s", out.String())
+	}
+	for parent, keys := range map[string][]string{
+		"archives":  {"fetches"},
+		"artifacts": {"items"},
+		"output":    {"roots"},
+	} {
+		obj := raw[parent].(map[string]any)
+		for _, key := range keys {
+			array, ok := obj[key].([]any)
+			if !ok {
+				t.Fatalf("%s.%s = %#v, want empty array", parent, key, obj[key])
+			}
+			if len(array) != 0 {
+				t.Fatalf("%s.%s len = %d, want 0", parent, key, len(array))
+			}
+		}
 	}
 }
 

--- a/gestaltd/internal/operator/archive_cache_test.go
+++ b/gestaltd/internal/operator/archive_cache_test.go
@@ -306,11 +306,11 @@ func TestDownloadArchiveWithCacheRecordsMetrics(t *testing.T) {
 	if cold.Archives.Requests != 1 || cold.Archives.Cache.Eligible != 1 || cold.Archives.Cache.Misses != 1 || cold.Archives.Downloads.Count != 1 || cold.Archives.Cache.Puts != 1 {
 		t.Fatalf("cold metrics = %+v, want one eligible miss, download, and put", cold.Archives)
 	}
-	if len(cold.Archives.SlowestFetches) != 1 {
-		t.Fatalf("cold slowest fetches len = %d, want 1", len(cold.Archives.SlowestFetches))
+	if len(cold.Archives.Fetches) != 1 {
+		t.Fatalf("cold fetches len = %d, want 1", len(cold.Archives.Fetches))
 	}
-	if got := cold.Archives.SlowestFetches[0]; got.Subject != "provider alpha" || got.CacheResult != syncArchiveCacheResultMiss || !got.Downloaded || got.Bytes != int64(len(data)) {
-		t.Fatalf("cold slowest fetch = %+v, want miss/downloaded/%d bytes", got, len(data))
+	if got := cold.Archives.Fetches[0]; got.Subject != "provider alpha" || got.CacheResult != syncArchiveCacheResultMiss || !got.Downloaded || got.Bytes != int64(len(data)) {
+		t.Fatalf("cold fetch = %+v, want miss/downloaded/%d bytes", got, len(data))
 	}
 
 	warmMetrics := NewSyncMetricsRecorder()

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -1125,7 +1125,7 @@ func (l *Lifecycle) syncAtPathsWithStatePaths(configPaths []string, state StateP
 	}
 	if recorder != nil {
 		recorder.FinishValidatePhase()
-		recorder.RecordOutputStats(mode == artifactModeMaterialize, preparedArtifactDestDirs(paths, cfg))
+		recorder.RecordOutputStats(mode == artifactModeMaterialize, paths.artifactsDir, preparedArtifactRoots(paths, cfg))
 		recorder.Finish()
 	}
 	return nil
@@ -1136,6 +1136,31 @@ func syncActionForArtifactMode(mode artifactMode) string {
 		return syncActionCheck
 	}
 	return syncActionMaterialize
+}
+
+func recordSyncArtifact(paths lifecyclePaths, kind, name, subject, destDir, sourceKind, result, reason string, start time.Time, prepareDuration, activateDuration time.Duration) {
+	if paths.syncMetrics == nil {
+		return
+	}
+	paths.syncMetrics.RecordArtifact(syncArtifactMetricsEvent{
+		Subject:          subject,
+		Kind:             kind,
+		Name:             name,
+		SourceKind:       sourceKind,
+		Result:           result,
+		Reason:           reason,
+		RelativePath:     relativeArtifactPath(paths.artifactsDir, destDir),
+		Duration:         time.Since(start),
+		PrepareDuration:  prepareDuration,
+		ActivateDuration: activateDuration,
+	})
+}
+
+func syncArtifactArchiveSourceKind(paths lifecyclePaths, entry LockEntry) string {
+	if isRemoteReleaseMetadataLocation(entry.Source) {
+		return syncArtifactSourceRemoteArchive
+	}
+	return syncArtifactSourceLocalArchive
 }
 
 func (l *Lifecycle) resolveConfigSecrets(ctx context.Context, cfg *config.Config) error {
@@ -3450,7 +3475,7 @@ func (l *Lifecycle) applyPreparedProviders(paths lifecyclePaths, lock *Lockfile,
 		return err
 	}
 	if paths.syncMetrics != nil {
-		paths.syncMetrics.SetArtifactCount(len(preparedArtifactDestDirs(paths, cfg)))
+		paths.syncMetrics.SetArtifactRoots(preparedArtifactRoots(paths, cfg))
 	}
 	for _, collection := range hostProviderCollections(cfg) {
 		lockEntries := lockEntriesForKind(lock, collection.kind)
@@ -4773,21 +4798,27 @@ func (l *Lifecycle) ensureLocalPreparedInstall(paths lifecyclePaths, kind, name 
 	if provider == nil || !provider.HasLocalSource() {
 		return nil, fmt.Errorf("%s requires local source configuration", subject)
 	}
+	start := time.Now()
 	install, err := inspectPreparedInstall(destDir)
 	needMaterialize := err != nil
+	reason := syncArtifactReasonPreparedMissing
 	if !needMaterialize {
 		switch inspectPreparedLockMetadata(paths, install, kind, name, provider, mode) {
 		case preparedLockMetadataMatch:
 			needMaterialize = false
+			reason = syncArtifactReasonFresh
 		default:
 			needMaterialize = true
+			reason = syncArtifactReasonMetadataStale
 		}
 	}
 	if needMaterialize {
 		if !mode.canMaterialize() {
 			return nil, preparedArtifactStaleError(paths, "prepared artifact for %s is missing or stale", subject)
 		}
+		prepareStart := time.Now()
 		stagedInstall, cleanupStaged, commitStaged, err := stageLocalSourceInstall(kind, name, provider.SourcePath(), destDir, paths.stageOptions())
+		prepareDuration := time.Since(prepareStart)
 		if cleanupStaged != nil {
 			defer func() { _ = cleanupStaged() }()
 		}
@@ -4803,16 +4834,22 @@ func (l *Lifecycle) ensureLocalPreparedInstall(paths lifecyclePaths, kind, name 
 		if err := writePreparedLockMetadata(paths, stagedInstall, kind, name, provider); err != nil {
 			return nil, err
 		}
+		activateStart := time.Now()
 		if err := commitStaged(); err != nil {
 			return nil, err
 		}
+		activateDuration := time.Since(activateStart)
 		install, err = inspectPreparedInstall(destDir)
 		if err != nil {
 			return nil, fmt.Errorf("read prepared manifest for %s: %w", subject, err)
 		}
+		recordSyncArtifact(paths, kind, name, subject, destDir, syncArtifactSourceLocalSource, syncArtifactResultMaterialized, reason, start, prepareDuration, activateDuration)
 	}
 	if inspectPreparedLockMetadata(paths, install, kind, name, provider, mode) != preparedLockMetadataMatch {
 		return nil, preparedArtifactStaleError(paths, "prepared artifact for %s is missing or stale", subject)
+	}
+	if !needMaterialize {
+		recordSyncArtifact(paths, kind, name, subject, destDir, syncArtifactSourceLocalSource, syncArtifactResultReused, syncArtifactReasonFresh, start, 0, 0)
 	}
 	return install, nil
 }
@@ -4906,7 +4943,12 @@ func (l *Lifecycle) applyConfiguredUIProvider(paths lifecyclePaths, lockEntry *L
 	case sourceBacked(provider):
 		if provider.HasLocalSource() {
 			if pathWithinRoot(filepath.Join(paths.artifactsDir, ".gestaltd"), provider.SourcePath()) {
-				return bindPathBackedUIManifest(provider, configMap)
+				start := time.Now()
+				assetRoot, err := bindPathBackedUIManifest(provider, configMap)
+				if err == nil {
+					recordSyncArtifact(paths, providermanifestv1.KindUI, logicalName, subject, assetRoot, syncArtifactSourcePathBacked, syncArtifactResultPathBacked, syncArtifactReasonSourcePathBacked, start, 0, 0)
+				}
+				return assetRoot, err
 			}
 			return l.applyLocalUIProvider(paths, provider, logicalName, subject, destDir, configMap, mode)
 		}
@@ -4931,14 +4973,21 @@ func (l *Lifecycle) applyConfiguredUIProvider(paths lifecyclePaths, lockEntry *L
 		if !fingerprintMatches {
 			return "", lockMetadataStaleError(paths, "lock entry for %s is stale", subject)
 		}
+		start := time.Now()
 		install, err := inspectPreparedInstall(destDir)
 		needMaterialize := err != nil || !preparedInstallMatchesLockForMode(providermanifestv1.KindUI, logicalName, provider, *lockEntry, install, mode)
+		reason := syncArtifactReasonPreparedMissing
+		if err == nil && needMaterialize {
+			reason = syncArtifactReasonManifestStale
+		}
 		if !needMaterialize && install.assetRootPath == "" {
 			needMaterialize = true
+			reason = syncArtifactReasonAssetRootMissing
 		}
 		if !needMaterialize {
 			if _, err := os.Stat(install.assetRootPath); err != nil {
 				needMaterialize = true
+				reason = syncArtifactReasonAssetRootMissing
 			}
 		}
 		if needMaterialize {
@@ -4949,12 +4998,15 @@ func (l *Lifecycle) applyConfiguredUIProvider(paths lifecyclePaths, lockEntry *L
 				if !provider.HasLocalSource() && !provider.HasGitSource() {
 					return "", preparedArtifactStaleError(paths, "prepared artifact for %s is missing or stale", subject)
 				}
+				var prepareDuration time.Duration
 				if stagedInstall == nil {
+					prepareStart := time.Now()
 					if provider.HasGitSource() {
 						stagedInstall, cleanupStaged, commitStaged, err = l.stageGitSourceInstall(context.Background(), paths, providermanifestv1.KindUI, logicalName, destDir, provider, paths.stageOptions())
 					} else {
 						stagedInstall, cleanupStaged, commitStaged, err = stageLocalSourceInstall(providermanifestv1.KindUI, logicalName, provider.SourcePath(), destDir, paths.stageOptions())
 					}
+					prepareDuration = time.Since(prepareStart)
 					if err != nil {
 						return "", err
 					}
@@ -4969,11 +5021,17 @@ func (l *Lifecycle) applyConfiguredUIProvider(paths lifecyclePaths, lockEntry *L
 				if !preparedManifestMatchesLock(*lockEntry, stagedInstall.manifest) {
 					return "", lockMetadataStaleError(paths, "lock entry for %s is stale", subject)
 				}
+				activateStart := time.Now()
 				if err := commitStaged(); err != nil {
 					return "", err
 				}
+				sourceKind := syncArtifactSourceLocalSource
+				if provider.HasGitSource() {
+					sourceKind = syncArtifactSourceGitSource
+				}
+				recordSyncArtifact(paths, providermanifestv1.KindUI, logicalName, subject, destDir, sourceKind, syncArtifactResultMaterialized, reason, start, prepareDuration, time.Since(activateStart))
 			} else {
-				if err := l.materializeLockedUIProvider(context.Background(), paths, provider, *lockEntry, destDir); err != nil {
+				if err := l.materializeLockedUIProvider(context.Background(), paths, logicalName, subject, provider, *lockEntry, destDir, reason); err != nil {
 					return "", err
 				}
 			}
@@ -4981,6 +5039,9 @@ func (l *Lifecycle) applyConfiguredUIProvider(paths lifecyclePaths, lockEntry *L
 			if err != nil {
 				return "", fmt.Errorf("read prepared manifest for %s: %w", subject, err)
 			}
+		}
+		if !needMaterialize {
+			recordSyncArtifact(paths, providermanifestv1.KindUI, logicalName, subject, destDir, syncArtifactArchiveSourceKind(paths, *lockEntry), syncArtifactResultReused, syncArtifactReasonFresh, start, 0, 0)
 		}
 		return bindPreparedUIInstall(provider, subject, destDir, configMap, install)
 	default:
@@ -5058,8 +5119,13 @@ func (l *Lifecycle) applyLockedProviderEntry(paths lifecyclePaths, lock *Lockfil
 		return lockMetadataStaleError(paths, "lock entry for provider %q is stale", name)
 	}
 
+	start := time.Now()
 	install, err := inspectPreparedInstall(destDir)
 	needMaterialize := err != nil || !preparedInstallMatchesLockForMode(providermanifestv1.KindApp, name, app, entry, install, mode)
+	reason := syncArtifactReasonPreparedMissing
+	if err == nil && needMaterialize {
+		reason = syncArtifactReasonManifestStale
+	}
 	if err == nil && !needMaterialize {
 		platform := providerpkg.CurrentPlatformString()
 		if _, resolvedKey, ok := resolveArchiveForPlatform(entry, platform); ok {
@@ -5071,6 +5137,7 @@ func (l *Lifecycle) applyLockedProviderEntry(paths lifecyclePaths, lock *Lockfil
 	if !needMaterialize && install.executablePath != "" {
 		if _, err := os.Stat(install.executablePath); err != nil {
 			needMaterialize = true
+			reason = syncArtifactReasonExecutableMissing
 		}
 	}
 	if needMaterialize {
@@ -5081,12 +5148,15 @@ func (l *Lifecycle) applyLockedProviderEntry(paths lifecyclePaths, lock *Lockfil
 			if !app.HasLocalSource() && !app.HasGitSource() {
 				return preparedArtifactStaleError(paths, "prepared artifact for provider %q is missing or stale", name)
 			}
+			var prepareDuration time.Duration
 			if stagedInstall == nil {
+				prepareStart := time.Now()
 				if app.HasGitSource() {
 					stagedInstall, cleanupStaged, commitStaged, err = l.stageGitSourceInstall(context.Background(), paths, providermanifestv1.KindApp, name, destDir, app, paths.stageOptions())
 				} else {
 					stagedInstall, cleanupStaged, commitStaged, err = stageLocalSourceInstall(providermanifestv1.KindApp, name, app.SourcePath(), destDir, paths.stageOptions())
 				}
+				prepareDuration = time.Since(prepareStart)
 				if err != nil {
 					return err
 				}
@@ -5101,11 +5171,17 @@ func (l *Lifecycle) applyLockedProviderEntry(paths lifecyclePaths, lock *Lockfil
 			if !preparedManifestMatchesLock(entry, stagedInstall.manifest) {
 				return lockMetadataStaleError(paths, "lock entry for provider %q is stale", name)
 			}
+			activateStart := time.Now()
 			if err := commitStaged(); err != nil {
 				return err
 			}
+			sourceKind := syncArtifactSourceLocalSource
+			if app.HasGitSource() {
+				sourceKind = syncArtifactSourceGitSource
+			}
+			recordSyncArtifact(paths, providermanifestv1.KindApp, name, fmt.Sprintf("provider %q", name), destDir, sourceKind, syncArtifactResultMaterialized, reason, start, prepareDuration, time.Since(activateStart))
 		} else {
-			if err := l.materializeLockedProvider(context.Background(), paths, name, app, entry); err != nil {
+			if err := l.materializeLockedProvider(context.Background(), paths, name, app, entry, reason); err != nil {
 				return err
 			}
 		}
@@ -5113,6 +5189,9 @@ func (l *Lifecycle) applyLockedProviderEntry(paths lifecyclePaths, lock *Lockfil
 		if err != nil {
 			return fmt.Errorf("read prepared manifest for provider %q: %w", name, err)
 		}
+	}
+	if !needMaterialize {
+		recordSyncArtifact(paths, providermanifestv1.KindApp, name, fmt.Sprintf("provider %q", name), destDir, syncArtifactArchiveSourceKind(paths, entry), syncArtifactResultReused, syncArtifactReasonFresh, start, 0, 0)
 	}
 	return bindPreparedProviderInstall(paths, name, app, configMap, install)
 }
@@ -5144,8 +5223,13 @@ func (l *Lifecycle) applyLockedComponentEntry(paths lifecyclePaths, entry *LockE
 		return lockMetadataStaleError(paths, "lock entry for %s %q is stale", kind, name)
 	}
 
+	start := time.Now()
 	install, err := inspectPreparedInstall(destDir)
 	needMaterialize := err != nil || !preparedInstallMatchesLockForMode(kind, name, app, *entry, install, mode)
+	reason := syncArtifactReasonPreparedMissing
+	if err == nil && needMaterialize {
+		reason = syncArtifactReasonManifestStale
+	}
 	if err == nil && !needMaterialize {
 		platform := providerpkg.CurrentPlatformString()
 		if _, resolvedKey, ok := resolveArchiveForPlatform(*entry, platform); ok {
@@ -5156,10 +5240,12 @@ func (l *Lifecycle) applyLockedComponentEntry(paths lifecyclePaths, entry *LockE
 	}
 	if !needMaterialize && install.executablePath == "" {
 		needMaterialize = true
+		reason = syncArtifactReasonExecutableMissing
 	}
 	if !needMaterialize {
 		if _, err := os.Stat(install.executablePath); err != nil {
 			needMaterialize = true
+			reason = syncArtifactReasonExecutableMissing
 		}
 	}
 	if needMaterialize {
@@ -5170,12 +5256,15 @@ func (l *Lifecycle) applyLockedComponentEntry(paths lifecyclePaths, entry *LockE
 			if !app.HasLocalSource() && !app.HasGitSource() {
 				return preparedArtifactStaleError(paths, "prepared artifact for %s %q is missing or stale", kind, name)
 			}
+			var prepareDuration time.Duration
 			if stagedInstall == nil {
+				prepareStart := time.Now()
 				if app.HasGitSource() {
 					stagedInstall, cleanupStaged, commitStaged, err = l.stageGitSourceInstall(context.Background(), paths, kind, name, destDir, app, paths.stageOptions())
 				} else {
 					stagedInstall, cleanupStaged, commitStaged, err = stageLocalSourceInstall(kind, name, app.SourcePath(), destDir, paths.stageOptions())
 				}
+				prepareDuration = time.Since(prepareStart)
 				if err != nil {
 					return err
 				}
@@ -5190,11 +5279,17 @@ func (l *Lifecycle) applyLockedComponentEntry(paths lifecyclePaths, entry *LockE
 			if !preparedManifestMatchesLock(*entry, stagedInstall.manifest) {
 				return lockMetadataStaleError(paths, "lock entry for %s %q is stale", kind, name)
 			}
+			activateStart := time.Now()
 			if err := commitStaged(); err != nil {
 				return err
 			}
+			sourceKind := syncArtifactSourceLocalSource
+			if app.HasGitSource() {
+				sourceKind = syncArtifactSourceGitSource
+			}
+			recordSyncArtifact(paths, kind, name, fmt.Sprintf("%s %q", kind, name), destDir, sourceKind, syncArtifactResultMaterialized, reason, start, prepareDuration, time.Since(activateStart))
 		} else {
-			if err := l.materializeLockedComponent(context.Background(), paths, kind, name, app, *entry, destDir); err != nil {
+			if err := l.materializeLockedComponent(context.Background(), paths, kind, name, app, *entry, destDir, reason); err != nil {
 				return err
 			}
 		}
@@ -5202,6 +5297,9 @@ func (l *Lifecycle) applyLockedComponentEntry(paths lifecyclePaths, entry *LockE
 		if err != nil {
 			return fmt.Errorf("read prepared manifest for %s %q: %w", kind, name, err)
 		}
+	}
+	if !needMaterialize {
+		recordSyncArtifact(paths, kind, name, fmt.Sprintf("%s %q", kind, name), destDir, syncArtifactArchiveSourceKind(paths, *entry), syncArtifactResultReused, syncArtifactReasonFresh, start, 0, 0)
 	}
 	return bindPreparedComponentInstall(paths, kind, name, app, configMap, destDir, install)
 }
@@ -5272,7 +5370,8 @@ func bindPathBackedUIManifest(app *config.ProviderEntry, configMap map[string]an
 	return assetRoot, nil
 }
 
-func (l *Lifecycle) materializeLockedProvider(ctx context.Context, paths lifecyclePaths, name string, app *config.ProviderEntry, entry LockEntry) error {
+func (l *Lifecycle) materializeLockedProvider(ctx context.Context, paths lifecyclePaths, name string, app *config.ProviderEntry, entry LockEntry, reason string) error {
+	start := time.Now()
 	platform := providerpkg.CurrentPlatformString()
 	download, resolvedKey, cleanupDownload, err := l.downloadLockedArchive(ctx, paths, app, entry, platform, fmt.Sprintf("provider %q", name), paths.archiveCacheDir)
 	if err != nil {
@@ -5281,7 +5380,9 @@ func (l *Lifecycle) materializeLockedProvider(ctx context.Context, paths lifecyc
 	defer cleanupDownload()
 
 	destDir := providerDestDir(paths, name)
+	prepareStart := time.Now()
 	installed, cleanupInstall, commitInstall, err := installLockedPackageAtomic(download.LocalPath, destDir)
+	prepareDuration := time.Since(prepareStart)
 	if err != nil {
 		return fmt.Errorf("install locked source provider for provider %q: %w", name, err)
 	}
@@ -5295,13 +5396,16 @@ func (l *Lifecycle) materializeLockedProvider(ctx context.Context, paths lifecyc
 	if err := validateLockedArchivePolicy(fmt.Sprintf("provider %q", name), providermanifestv1.KindApp, installed.Manifest, entry, platform, resolvedKey); err != nil {
 		return err
 	}
+	activateStart := time.Now()
 	if err := commitInstall(); err != nil {
 		return fmt.Errorf("activate locked source provider for provider %q: %w", name, err)
 	}
+	recordSyncArtifact(paths, providermanifestv1.KindApp, name, fmt.Sprintf("provider %q", name), destDir, syncArtifactArchiveSourceKind(paths, entry), syncArtifactResultMaterialized, reason, start, prepareDuration, time.Since(activateStart))
 	return nil
 }
 
-func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths lifecyclePaths, kind, name string, app *config.ProviderEntry, entry LockEntry, destDir string) error {
+func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths lifecyclePaths, kind, name string, app *config.ProviderEntry, entry LockEntry, destDir, reason string) error {
+	start := time.Now()
 	platform := providerpkg.CurrentPlatformString()
 	download, resolvedKey, cleanupDownload, err := l.downloadLockedArchive(ctx, paths, app, entry, platform, fmt.Sprintf("%s %q", kind, name), paths.archiveCacheDir)
 	if err != nil {
@@ -5312,7 +5416,9 @@ func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths lifecy
 	if destDir == "" {
 		return fmt.Errorf("unsupported component %q", name)
 	}
+	prepareStart := time.Now()
 	installed, cleanupInstall, commitInstall, err := installLockedPackageAtomic(download.LocalPath, destDir)
+	prepareDuration := time.Since(prepareStart)
 	if err != nil {
 		return fmt.Errorf("install locked source provider for %s %q: %w", kind, name, err)
 	}
@@ -5329,15 +5435,18 @@ func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths lifecy
 	if err := validateLockedArchivePolicy(fmt.Sprintf("%s %q", kind, name), archivePolicyKind(kind), installed.Manifest, entry, platform, resolvedKey); err != nil {
 		return err
 	}
+	activateStart := time.Now()
 	if err := commitInstall(); err != nil {
 		return fmt.Errorf("activate locked source provider for %s %q: %w", kind, name, err)
 	}
+	recordSyncArtifact(paths, kind, name, fmt.Sprintf("%s %q", kind, name), destDir, syncArtifactArchiveSourceKind(paths, entry), syncArtifactResultMaterialized, reason, start, prepareDuration, time.Since(activateStart))
 	return nil
 }
 
-func (l *Lifecycle) materializeLockedUIProvider(ctx context.Context, paths lifecyclePaths, app *config.ProviderEntry, entry LockEntry, destDir string) error {
+func (l *Lifecycle) materializeLockedUIProvider(ctx context.Context, paths lifecyclePaths, name, subject string, app *config.ProviderEntry, entry LockEntry, destDir, reason string) error {
+	start := time.Now()
 	platform := providerpkg.CurrentPlatformString()
-	download, _, cleanupDownload, err := l.downloadLockedArchive(ctx, paths, app, entry, platform, "ui provider", paths.archiveCacheDir)
+	download, _, cleanupDownload, err := l.downloadLockedArchive(ctx, paths, app, entry, platform, subject, paths.archiveCacheDir)
 	if err != nil {
 		return err
 	}
@@ -5346,7 +5455,9 @@ func (l *Lifecycle) materializeLockedUIProvider(ctx context.Context, paths lifec
 	if err := os.RemoveAll(destDir); err != nil {
 		return fmt.Errorf("remove stale cache for ui provider: %w", err)
 	}
+	prepareStart := time.Now()
 	installed, err := installPackage(download.LocalPath, destDir)
+	prepareDuration := time.Since(prepareStart)
 	if err != nil {
 		return fmt.Errorf("install locked source for ui provider: %w", err)
 	}
@@ -5359,6 +5470,7 @@ func (l *Lifecycle) materializeLockedUIProvider(ctx context.Context, paths lifec
 	if installed.Manifest.Version != entry.Version {
 		return fmt.Errorf("locked source manifest version mismatch for ui provider: got %q, want %q", installed.Manifest.Version, entry.Version)
 	}
+	recordSyncArtifact(paths, providermanifestv1.KindUI, name, subject, destDir, syncArtifactArchiveSourceKind(paths, entry), syncArtifactResultMaterialized, reason, start, prepareDuration, 0)
 	return nil
 }
 

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -4510,7 +4510,7 @@ func TestMaterializeLockedComponent_AllowsGenericDeclarativeTelemetryAndAuditPac
 				Source: config.NewMetadataSource("https://example.invalid/github-com-acme-providers-declarative/v1.0.0/provider-release.yaml"),
 			}
 			destDir := filepath.Join(dir, kind)
-			if err := lc.materializeLockedComponent(context.Background(), lifecyclePaths{}, kind, "default", providerEntry, entry, destDir); err != nil {
+			if err := lc.materializeLockedComponent(context.Background(), lifecyclePaths{}, kind, "default", providerEntry, entry, destDir, syncArtifactReasonPreparedMissing); err != nil {
 				t.Fatalf("materializeLockedComponent: %v", err)
 			}
 			install, err := inspectPreparedInstall(destDir)

--- a/gestaltd/internal/operator/sync_metrics.go
+++ b/gestaltd/internal/operator/sync_metrics.go
@@ -1,10 +1,12 @@
 package operator
 
 import (
+	"cmp"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 )
@@ -23,7 +25,25 @@ const (
 	syncArchiveCacheResultDisabled    = "disabled"
 	syncArchiveCacheResultUncacheable = "uncacheable"
 
-	syncMetricsMaxSlowFetches = 5
+	syncArtifactSourceRemoteArchive = "remote_archive"
+	syncArtifactSourceLocalArchive  = "local_archive"
+	syncArtifactSourceLocalSource   = "local_source"
+	syncArtifactSourceGitSource     = "git_source"
+	syncArtifactSourcePathBacked    = "path_backed"
+
+	syncArtifactResultReused       = "reused"
+	syncArtifactResultMaterialized = "materialized"
+	syncArtifactResultPathBacked   = "path_backed"
+
+	syncArtifactReasonFresh             = "fresh"
+	syncArtifactReasonPreparedMissing   = "prepared_missing"
+	syncArtifactReasonMetadataMissing   = "metadata_missing"
+	syncArtifactReasonMetadataStale     = "metadata_stale"
+	syncArtifactReasonFingerprintStale  = "fingerprint_stale"
+	syncArtifactReasonManifestStale     = "manifest_stale"
+	syncArtifactReasonAssetRootMissing  = "asset_root_missing"
+	syncArtifactReasonExecutableMissing = "executable_missing"
+	syncArtifactReasonSourcePathBacked  = "source_path_backed"
 )
 
 type SyncMetrics struct {
@@ -50,15 +70,29 @@ type SyncMetricsInputs struct {
 }
 
 type SyncMetricsArtifacts struct {
-	Considered int `json:"considered"`
+	Considered int                         `json:"considered"`
+	Items      []SyncMetricsArtifactRecord `json:"items"`
+}
+
+type SyncMetricsArtifactRecord struct {
+	Subject                 string  `json:"subject"`
+	Kind                    string  `json:"kind"`
+	Name                    string  `json:"name"`
+	SourceKind              string  `json:"source_kind"`
+	Result                  string  `json:"result"`
+	Reason                  string  `json:"reason,omitempty"`
+	RelativePath            string  `json:"relative_path,omitempty"`
+	DurationSeconds         float64 `json:"duration_seconds"`
+	PrepareDurationSeconds  float64 `json:"prepare_duration_seconds,omitempty"`
+	ActivateDurationSeconds float64 `json:"activate_duration_seconds,omitempty"`
 }
 
 type SyncMetricsArchives struct {
-	Requests       int                       `json:"requests"`
-	UniqueSHA256   int                       `json:"unique_sha256"`
-	Cache          SyncMetricsArchiveCache   `json:"cache"`
-	Downloads      SyncMetricsDownloads      `json:"downloads"`
-	SlowestFetches []SyncMetricsArchiveFetch `json:"slowest_fetches"`
+	Requests     int                       `json:"requests"`
+	UniqueSHA256 int                       `json:"unique_sha256"`
+	Cache        SyncMetricsArchiveCache   `json:"cache"`
+	Downloads    SyncMetricsDownloads      `json:"downloads"`
+	Fetches      []SyncMetricsArchiveFetch `json:"fetches"`
 }
 
 type SyncMetricsArchiveCache struct {
@@ -101,9 +135,19 @@ type SyncMetricsPhases struct {
 }
 
 type SyncMetricsOutput struct {
-	Measured bool  `json:"measured"`
-	Files    int   `json:"files,omitempty"`
-	Bytes    int64 `json:"bytes,omitempty"`
+	Measured bool                    `json:"measured"`
+	Files    int                     `json:"files,omitempty"`
+	Bytes    int64                   `json:"bytes,omitempty"`
+	Roots    []SyncMetricsOutputRoot `json:"roots"`
+}
+
+type SyncMetricsOutputRoot struct {
+	Subject      string `json:"subject"`
+	Kind         string `json:"kind"`
+	Name         string `json:"name"`
+	RelativePath string `json:"relative_path,omitempty"`
+	Files        int    `json:"files,omitempty"`
+	Bytes        int64  `json:"bytes,omitempty"`
 }
 
 type SyncMetricsRecorder struct {
@@ -111,8 +155,22 @@ type SyncMetricsRecorder struct {
 	metrics    SyncMetrics
 	seenSHA    map[string]struct{}
 	fetches    []SyncMetricsArchiveFetch
+	artifacts  []SyncMetricsArtifactRecord
 	totalStart time.Time
 	phaseStart time.Time
+}
+
+type syncArtifactMetricsEvent struct {
+	Subject          string
+	Kind             string
+	Name             string
+	SourceKind       string
+	Result           string
+	Reason           string
+	RelativePath     string
+	Duration         time.Duration
+	PrepareDuration  time.Duration
+	ActivateDuration time.Duration
 }
 
 type syncArchiveMetricsEvent struct {
@@ -299,13 +357,13 @@ func (r *SyncMetricsRecorder) FinishLoadPhase() {
 	r.phaseStart = now
 }
 
-func (r *SyncMetricsRecorder) SetArtifactCount(artifactCount int) {
+func (r *SyncMetricsRecorder) SetArtifactRoots(roots []PreparedArtifactRoot) {
 	if r == nil {
 		return
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.metrics.Artifacts.Considered = artifactCount
+	r.metrics.Artifacts.Considered = len(roots)
 }
 
 func (r *SyncMetricsRecorder) FinishMaterializePhase() {
@@ -330,20 +388,21 @@ func (r *SyncMetricsRecorder) FinishValidatePhase() {
 	r.phaseStart = now
 }
 
-func (r *SyncMetricsRecorder) RecordOutputStats(measure bool, roots []string) {
+func (r *SyncMetricsRecorder) RecordOutputStats(measure bool, artifactsDir string, roots []PreparedArtifactRoot) {
 	if r == nil {
 		return
 	}
 	if !measure {
-		r.SetOutputStats(false, 0, 0)
+		r.SetOutputStats(false, 0, 0, nil)
 		return
 	}
 	outputStart := time.Now()
-	measured, files, bytes, err := measurePreparedOutputRoots(roots)
+	measured, files, bytes, outputRoots, err := measurePreparedOutputRoots(artifactsDir, roots)
 	if err != nil {
 		measured = false
 		files = 0
 		bytes = 0
+		outputRoots = nil
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -351,6 +410,7 @@ func (r *SyncMetricsRecorder) RecordOutputStats(measure bool, roots []string) {
 		Measured: measured,
 		Files:    files,
 		Bytes:    bytes,
+		Roots:    outputRoots,
 	}
 	r.metrics.Phases.OutputMeasureSeconds = roundedSeconds(time.Since(outputStart))
 }
@@ -417,15 +477,41 @@ func (r *SyncMetricsRecorder) RecordArchiveFetch(event syncArchiveMetricsEvent) 
 		case a.DurationSeconds < b.DurationSeconds:
 			return 1
 		default:
-			return 0
+			if n := cmp.Compare(a.Subject, b.Subject); n != 0 {
+				return n
+			}
+			if n := cmp.Compare(a.SourceKind, b.SourceKind); n != 0 {
+				return n
+			}
+			return cmp.Compare(a.SHA256, b.SHA256)
 		}
 	})
-	if len(r.fetches) > syncMetricsMaxSlowFetches {
-		r.fetches = r.fetches[:syncMetricsMaxSlowFetches]
-	}
 }
 
-func (r *SyncMetricsRecorder) SetOutputStats(measured bool, files int, bytes int64) {
+func (r *SyncMetricsRecorder) RecordArtifact(event syncArtifactMetricsEvent) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	record := SyncMetricsArtifactRecord{
+		Subject:                 event.Subject,
+		Kind:                    event.Kind,
+		Name:                    event.Name,
+		SourceKind:              event.SourceKind,
+		Result:                  event.Result,
+		Reason:                  event.Reason,
+		RelativePath:            event.RelativePath,
+		DurationSeconds:         roundedSeconds(event.Duration),
+		PrepareDurationSeconds:  roundedSeconds(event.PrepareDuration),
+		ActivateDurationSeconds: roundedSeconds(event.ActivateDuration),
+	}
+	r.artifacts = append(r.artifacts, record)
+	sortArtifactRecords(r.artifacts)
+	r.metrics.Artifacts.Items = append([]SyncMetricsArtifactRecord(nil), r.artifacts...)
+}
+
+func (r *SyncMetricsRecorder) SetOutputStats(measured bool, files int, bytes int64, roots []SyncMetricsOutputRoot) {
 	if r == nil {
 		return
 	}
@@ -435,6 +521,7 @@ func (r *SyncMetricsRecorder) SetOutputStats(measured bool, files int, bytes int
 		Measured: measured,
 		Files:    files,
 		Bytes:    bytes,
+		Roots:    append([]SyncMetricsOutputRoot(nil), roots...),
 	}
 }
 
@@ -456,7 +543,18 @@ func (r *SyncMetricsRecorder) Snapshot() SyncMetrics {
 	metrics := r.metrics
 	metrics.Inputs.ConfigPaths = append([]string(nil), r.metrics.Inputs.ConfigPaths...)
 	fetches := append([]SyncMetricsArchiveFetch(nil), r.fetches...)
-	metrics.Archives.SlowestFetches = fetches
+	metrics.Archives.Fetches = fetches
+	metrics.Artifacts.Items = append([]SyncMetricsArtifactRecord(nil), r.metrics.Artifacts.Items...)
+	metrics.Output.Roots = append([]SyncMetricsOutputRoot(nil), r.metrics.Output.Roots...)
+	if metrics.Archives.Fetches == nil {
+		metrics.Archives.Fetches = []SyncMetricsArchiveFetch{}
+	}
+	if metrics.Artifacts.Items == nil {
+		metrics.Artifacts.Items = []SyncMetricsArtifactRecord{}
+	}
+	if metrics.Output.Roots == nil {
+		metrics.Output.Roots = []SyncMetricsOutputRoot{}
+	}
 	return metrics
 }
 
@@ -468,17 +566,22 @@ func secondsDuration(seconds float64) time.Duration {
 	return time.Duration(seconds * float64(time.Second))
 }
 
-func measurePreparedOutputRoots(roots []string) (bool, int, int64, error) {
-	roots = dedupeCleanPaths(roots)
+func measurePreparedOutputRoots(artifactsDir string, roots []PreparedArtifactRoot) (bool, int, int64, []SyncMetricsOutputRoot, error) {
+	roots = dedupePreparedArtifactRoots(roots)
 	if len(roots) == 0 {
-		return false, 0, 0, nil
+		return false, 0, 0, nil, nil
 	}
 	var files int
 	var bytes int64
+	var outputRoots []SyncMetricsOutputRoot
 	for _, root := range roots {
-		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		var rootFiles int
+		var rootBytes int64
+		rootExists := true
+		err := filepath.WalkDir(root.DestDir, func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
-				if path == root && os.IsNotExist(err) {
+				if path == root.DestDir && os.IsNotExist(err) {
+					rootExists = false
 					return nil
 				}
 				return err
@@ -491,32 +594,101 @@ func measurePreparedOutputRoots(roots []string) (bool, int, int64, error) {
 				return err
 			}
 			if info.Mode().IsRegular() {
-				files++
-				bytes += info.Size()
+				rootFiles++
+				rootBytes += info.Size()
 			}
 			return nil
 		})
 		if err != nil {
-			return false, 0, 0, err
+			return false, 0, 0, nil, err
 		}
+		if !rootExists {
+			continue
+		}
+		files += rootFiles
+		bytes += rootBytes
+		outputRoots = append(outputRoots, SyncMetricsOutputRoot{
+			Subject:      root.Subject,
+			Kind:         root.Kind,
+			Name:         root.Name,
+			RelativePath: relativeArtifactPath(artifactsDir, root.DestDir),
+			Files:        rootFiles,
+			Bytes:        rootBytes,
+		})
 	}
-	return true, files, bytes, nil
+	sortOutputRoots(outputRoots)
+	return true, files, bytes, outputRoots, nil
 }
 
-func dedupeCleanPaths(paths []string) []string {
-	seen := make(map[string]struct{}, len(paths))
-	var cleaned []string
-	for _, path := range paths {
-		if path == "" {
+func dedupePreparedArtifactRoots(roots []PreparedArtifactRoot) []PreparedArtifactRoot {
+	seen := make(map[string]struct{}, len(roots))
+	var cleaned []PreparedArtifactRoot
+	for _, root := range roots {
+		if root.DestDir == "" {
 			continue
 		}
-		path = filepath.Clean(path)
-		if _, ok := seen[path]; ok {
+		root.DestDir = filepath.Clean(root.DestDir)
+		if _, ok := seen[root.DestDir]; ok {
 			continue
 		}
-		seen[path] = struct{}{}
-		cleaned = append(cleaned, path)
+		seen[root.DestDir] = struct{}{}
+		cleaned = append(cleaned, root)
 	}
-	slices.Sort(cleaned)
+	slices.SortFunc(cleaned, func(a, b PreparedArtifactRoot) int {
+		if n := cmp.Compare(a.Kind, b.Kind); n != 0 {
+			return n
+		}
+		if n := cmp.Compare(a.Name, b.Name); n != 0 {
+			return n
+		}
+		return cmp.Compare(a.Subject, b.Subject)
+	})
 	return cleaned
+}
+
+func sortArtifactRecords(records []SyncMetricsArtifactRecord) {
+	slices.SortFunc(records, func(a, b SyncMetricsArtifactRecord) int {
+		switch {
+		case a.DurationSeconds > b.DurationSeconds:
+			return -1
+		case a.DurationSeconds < b.DurationSeconds:
+			return 1
+		}
+		if n := cmp.Compare(a.Kind, b.Kind); n != 0 {
+			return n
+		}
+		if n := cmp.Compare(a.Name, b.Name); n != 0 {
+			return n
+		}
+		return cmp.Compare(a.Subject, b.Subject)
+	})
+}
+
+func sortOutputRoots(roots []SyncMetricsOutputRoot) {
+	slices.SortFunc(roots, func(a, b SyncMetricsOutputRoot) int {
+		switch {
+		case a.Bytes > b.Bytes:
+			return -1
+		case a.Bytes < b.Bytes:
+			return 1
+		}
+		if n := cmp.Compare(a.Kind, b.Kind); n != 0 {
+			return n
+		}
+		if n := cmp.Compare(a.Name, b.Name); n != 0 {
+			return n
+		}
+		return cmp.Compare(a.Subject, b.Subject)
+	})
+}
+
+func relativeArtifactPath(artifactsDir, path string) string {
+	if artifactsDir == "" || path == "" {
+		return ""
+	}
+	rel, err := filepath.Rel(artifactsDir, path)
+	if err != nil || rel == "." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
+		return ""
+	}
+	return filepath.ToSlash(rel)
 }

--- a/gestaltd/internal/operator/sync_metrics_test.go
+++ b/gestaltd/internal/operator/sync_metrics_test.go
@@ -1,30 +1,102 @@
 package operator
 
 import (
-	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
 
-func TestSyncMetricsRecorderKeepsOnlySlowestFetches(t *testing.T) {
+func TestSyncMetricsRecorderKeepsAllArchiveFetchesSorted(t *testing.T) {
 	t.Parallel()
 
 	recorder := NewSyncMetricsRecorder()
-	for i := 0; i < syncMetricsMaxSlowFetches+3; i++ {
+	for i := 0; i < 8; i++ {
 		recorder.RecordArchiveFetch(syncArchiveMetricsEvent{
-			Subject:  fmt.Sprintf("fetch-%d", i),
+			Subject:  "fetch-" + string(rune('a'+i)),
 			Duration: time.Duration(i) * time.Second,
 		})
 	}
 
-	got := recorder.Snapshot().Archives.SlowestFetches
-	if len(got) != syncMetricsMaxSlowFetches {
-		t.Fatalf("slowest fetches len = %d, want %d", len(got), syncMetricsMaxSlowFetches)
+	got := recorder.Snapshot().Archives.Fetches
+	if len(got) != 8 {
+		t.Fatalf("fetches len = %d, want 8", len(got))
 	}
 	for i, fetch := range got {
-		want := fmt.Sprintf("fetch-%d", syncMetricsMaxSlowFetches+2-i)
+		want := "fetch-" + string(rune('a'+7-i))
 		if fetch.Subject != want {
-			t.Fatalf("slowest fetches[%d].subject = %q, want %q", i, fetch.Subject, want)
+			t.Fatalf("fetches[%d].subject = %q, want %q", i, fetch.Subject, want)
 		}
+	}
+}
+
+func TestSyncMetricsRecorderKeepsAllArtifactItemsSorted(t *testing.T) {
+	t.Parallel()
+
+	recorder := NewSyncMetricsRecorder()
+	for i := 0; i < 8; i++ {
+		sourceKind := syncArtifactSourceRemoteArchive
+		result := syncArtifactResultMaterialized
+		if i%2 == 0 {
+			sourceKind = syncArtifactSourceLocalSource
+			result = syncArtifactResultReused
+		}
+		recorder.RecordArtifact(syncArtifactMetricsEvent{
+			Subject:    "artifact-" + string(rune('a'+i)),
+			Kind:       "app",
+			Name:       "artifact-" + string(rune('a'+i)),
+			SourceKind: sourceKind,
+			Result:     result,
+			Reason:     syncArtifactReasonFresh,
+			Duration:   time.Duration(i) * time.Second,
+		})
+	}
+
+	metrics := recorder.Snapshot()
+	if len(metrics.Artifacts.Items) != 8 {
+		t.Fatalf("artifact items len = %d, want 8", len(metrics.Artifacts.Items))
+	}
+	if metrics.Artifacts.Items[0].Name != "artifact-h" {
+		t.Fatalf("first artifact item = %q, want artifact-h", metrics.Artifacts.Items[0].Name)
+	}
+}
+
+func TestRecordOutputStatsRecordsAllRoots(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	alpha := filepath.Join(dir, "providers", "alpha")
+	beta := filepath.Join(dir, "providers", "beta")
+	if err := os.MkdirAll(alpha, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(beta, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(alpha, "a.txt"), []byte("alpha"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beta, "b.txt"), []byte("beta-beta"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	recorder := NewSyncMetricsRecorder()
+	recorder.RecordOutputStats(true, dir, []PreparedArtifactRoot{
+		{Subject: "provider \"alpha\"", Kind: "app", Name: "alpha", DestDir: alpha},
+		{Subject: "provider \"beta\"", Kind: "app", Name: "beta", DestDir: beta},
+	})
+
+	output := recorder.Snapshot().Output
+	if !output.Measured {
+		t.Fatalf("output measured = false, want true")
+	}
+	if output.Files != 2 || output.Bytes != 14 {
+		t.Fatalf("output aggregate = %d files/%d bytes, want 2 files/14 bytes", output.Files, output.Bytes)
+	}
+	if len(output.Roots) != 2 {
+		t.Fatalf("output roots len = %d, want 2", len(output.Roots))
+	}
+	if output.Roots[0].Name != "beta" || output.Roots[0].RelativePath != "providers/beta" {
+		t.Fatalf("first output root = %+v, want beta sorted by bytes", output.Roots[0])
 	}
 }

--- a/gestaltd/internal/operator/sync_observability.go
+++ b/gestaltd/internal/operator/sync_observability.go
@@ -1,7 +1,11 @@
 package operator
 
 import (
+	"fmt"
+	"strconv"
+
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/apps/providerpkg"
 )
 
@@ -16,42 +20,80 @@ func (paths lifecyclePaths) stageOptions() providerpkg.StageSourcePreparedInstal
 	}
 }
 
-func preparedArtifactDestDirs(paths lifecyclePaths, cfg *config.Config) []string {
+type PreparedArtifactRoot struct {
+	Subject string
+	Kind    string
+	Name    string
+	DestDir string
+}
+
+func preparedArtifactRoots(paths lifecyclePaths, cfg *config.Config) []PreparedArtifactRoot {
 	if cfg == nil {
 		return nil
 	}
-	var roots []string
+	var roots []PreparedArtifactRoot
 	for name, entry := range cfg.Apps {
 		if entry != nil {
-			roots = append(roots, providerDestDir(paths, name))
+			roots = append(roots, PreparedArtifactRoot{
+				Subject: "provider " + strconv.Quote(name),
+				Kind:    providermanifestv1.KindApp,
+				Name:    name,
+				DestDir: providerDestDir(paths, name),
+			})
 		}
 	}
 	for _, collection := range hostProviderCollections(cfg) {
+		kind := providerManifestKind(collection.kind)
 		for name, entry := range collection.entries {
 			if entry != nil {
-				roots = append(roots, componentDestDir(paths, collection.kind, name))
+				roots = append(roots, PreparedArtifactRoot{
+					Subject: fmt.Sprintf("%s %q", kind, name),
+					Kind:    kind,
+					Name:    name,
+					DestDir: componentDestDir(paths, collection.kind, name),
+				})
 			}
 		}
 	}
 	for name, entry := range cfg.Runtime.Providers {
 		if entry != nil {
-			roots = append(roots, runtimeDestDir(paths, name))
+			roots = append(roots, PreparedArtifactRoot{
+				Subject: fmt.Sprintf("%s %q", providermanifestv1.KindRuntime, name),
+				Kind:    providermanifestv1.KindRuntime,
+				Name:    name,
+				DestDir: runtimeDestDir(paths, name),
+			})
 		}
 	}
 	for name, entry := range cfg.Providers.IndexedDB {
 		if entry != nil {
-			roots = append(roots, indexeddbDestDir(paths, name))
+			roots = append(roots, PreparedArtifactRoot{
+				Subject: fmt.Sprintf("%s %q", providermanifestv1.KindIndexedDB, name),
+				Kind:    providermanifestv1.KindIndexedDB,
+				Name:    name,
+				DestDir: indexeddbDestDir(paths, name),
+			})
 		}
 	}
 	for name, entry := range cfg.Providers.S3 {
 		if entry != nil {
-			roots = append(roots, s3DestDir(paths, name))
+			roots = append(roots, PreparedArtifactRoot{
+				Subject: fmt.Sprintf("%s %q", providermanifestv1.KindS3, name),
+				Kind:    providermanifestv1.KindS3,
+				Name:    name,
+				DestDir: s3DestDir(paths, name),
+			})
 		}
 	}
 	for name, entry := range cfg.Providers.UI {
 		if entry != nil {
-			roots = append(roots, uiDestDir(paths, name))
+			roots = append(roots, PreparedArtifactRoot{
+				Subject: "ui " + strconv.Quote(name),
+				Kind:    providermanifestv1.KindUI,
+				Name:    name,
+				DestDir: uiDestDir(paths, name),
+			})
 		}
 	}
-	return dedupeCleanPaths(roots)
+	return dedupePreparedArtifactRoots(roots)
 }


### PR DESCRIPTION
## Summary

Expands `gestaltd sync` observability so successful verbose and JSON sync runs report every archive fetch, every prepared artifact decision, grouped artifact timing, and every measured prepared output root.

The JSON schema removes the capped `archives.slowest_fetches` field entirely and replaces it with the full `archives.fetches` array. Artifact metrics now include `artifacts.items`, `artifacts.by_source_kind`, and `artifacts.by_result`, while output measurement now includes `output.roots` in addition to aggregate file and byte counts.

Default successful `gestaltd sync --locked` remains quiet. Source-build child output is discarded unless the caller explicitly asks for observability with `-v`, `--verbose`, or `--output-format=json`; JSON mode still keeps stdout clean and routes build output to stderr.

## Interfaces

```json
{
  "archives": {
    "fetches": [
      {
        "subject": "provider \"example\"",
        "source_kind": "remote_release_metadata",
        "sha256": "...",
        "cache_result": "hit",
        "downloaded": false,
        "cache_put_failed": false,
        "bytes": 12345,
        "duration_seconds": 0.123
      }
    ]
  },
  "artifacts": {
    "considered": 1,
    "by_source_kind": [
      {
        "source_kind": "remote_archive",
        "count": 1,
        "duration_seconds": 1.234
      }
    ],
    "by_result": [
      {
        "result": "materialized",
        "count": 1,
        "duration_seconds": 1.234
      }
    ],
    "items": [
      {
        "subject": "provider \"example\"",
        "kind": "app",
        "name": "example",
        "source_kind": "remote_archive",
        "result": "materialized",
        "reason": "prepared_missing",
        "relative_path": ".gestaltd/providers/example",
        "duration_seconds": 1.234,
        "prepare_duration_seconds": 1.2,
        "activate_duration_seconds": 0.034
      }
    ]
  },
  "output": {
    "measured": true,
    "files": 10,
    "bytes": 123456,
    "roots": [
      {
        "subject": "provider \"example\"",
        "kind": "app",
        "name": "example",
        "relative_path": ".gestaltd/providers/example",
        "files": 10,
        "bytes": 123456
      }
    ]
  }
}
```

`archives.fetches`, `artifacts.by_source_kind`, `artifacts.by_result`, `artifacts.items`, and `output.roots` are emitted as arrays in JSON output, including empty arrays when no rows are recorded. Verbose text output prints the same recorded rows without truncation.

```sh
gestaltd sync --locked --output-format=json --config deploy/config.yaml > gestaltd-sync.json

gestaltd sync --locked -v --config deploy/config.yaml
```

## Runtime

The sync lifecycle records artifact decisions from the existing materialization paths: local source preparation, git source staging, archive-backed provider/component/UI installation, path-backed UI binding, and prepared artifact reuse. The recorder remains sync-scoped and is still only created for explicit verbose or JSON observability.

Prepared output measurement now uses typed prepared roots so `artifacts.considered`, artifact relative paths, and `output.roots` are derived from the same root enumeration. Missing static roots are skipped during output measurement instead of being reported as zero-byte roots.

Verification passed locally with `go test ./gestaltd/internal/operator ./gestaltd/internal/daemon` and `go test ./gestaltd/...`.
