### PR TITLE
Add provider release static validation schema

### DIFF
--- a/gestaltd/internal/daemon/provider_release_types.go
+++ b/gestaltd/internal/daemon/provider_release_types.go
@@ -1,5 +1,10 @@
 package daemon
 
+import (
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
 const defaultPlatforms = "darwin/amd64,darwin/arm64,linux/amd64,linux/arm64"
 const allPlatformsValue = "all"
 const defaultReleaseOutputDir = "dist/"
@@ -29,16 +34,23 @@ type releaseArchive struct {
 }
 
 type providerReleaseMetadata struct {
-	Schema        string                             `yaml:"schema"`
-	SchemaVersion int                                `yaml:"schemaVersion"`
-	Package       string                             `yaml:"package"`
-	Kind          string                             `yaml:"kind"`
-	Version       string                             `yaml:"version"`
-	Runtime       string                             `yaml:"runtime"`
-	Artifacts     map[string]providerReleaseArtifact `yaml:"artifacts,omitempty"`
+	Schema           string                               `yaml:"schema"`
+	SchemaVersion    int                                  `yaml:"schemaVersion"`
+	Package          string                               `yaml:"package"`
+	Kind             string                               `yaml:"kind"`
+	Version          string                               `yaml:"version"`
+	Runtime          string                               `yaml:"runtime"`
+	Artifacts        map[string]providerReleaseArtifact   `yaml:"artifacts,omitempty"`
+	StaticValidation *providerReleaseStaticValidationData `yaml:"staticValidation,omitempty"`
 }
 
 type providerReleaseArtifact struct {
 	Path   string `yaml:"path"`
 	SHA256 string `yaml:"sha256"`
+}
+
+type providerReleaseStaticValidationData struct {
+	Manifest           *providermanifestv1.Manifest `yaml:"manifest,omitempty"`
+	Catalog            *catalog.Catalog             `yaml:"catalog,omitempty"`
+	CatalogSessionOnly bool                         `yaml:"catalogSessionOnly,omitempty"`
 }

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -23,9 +23,9 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/providerregistry"
+	"github.com/valon-technologies/gestalt/server/internal/staticvalidation"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	appservice "github.com/valon-technologies/gestalt/server/services/apps"
-	"github.com/valon-technologies/gestalt/server/services/apps/packageio"
 	"github.com/valon-technologies/gestalt/server/services/apps/providerpkg"
 	"gopkg.in/yaml.v3"
 )
@@ -46,7 +46,7 @@ const (
 	PreparedUIDir                  = ".gestaltd/ui"
 
 	platformKeyGeneric                    = "generic"
-	staticValidationEntrypointPlaceholder = "static-validation-placeholder"
+	staticValidationEntrypointPlaceholder = staticvalidation.EntrypointPlaceholder
 )
 
 type Lockfile struct {
@@ -3898,94 +3898,7 @@ func synthesizedCommittedOwnedUIEntry(paths lifecyclePaths, cfg *config.Config, 
 }
 
 func portableStaticValidationManifest(manifest *providermanifestv1.Manifest, manifestPath string, platformNeutral bool) (*providermanifestv1.Manifest, error) {
-	if manifest == nil {
-		return nil, nil
-	}
-	if platformNeutral {
-		cloned, err := packageio.CloneManifest(manifest)
-		if err != nil {
-			return nil, err
-		}
-		cloned.Artifacts = nil
-		if cloned.Entrypoint != nil {
-			cloned.Entrypoint = &providermanifestv1.Entrypoint{ArtifactPath: staticValidationEntrypointPlaceholder}
-		}
-		return relativizeStaticValidationManifest(cloned, manifestPath), nil
-	}
-	return relativizeStaticValidationManifest(manifest, manifestPath), nil
-}
-
-func relativizeStaticValidationManifest(manifest *providermanifestv1.Manifest, manifestPath string) *providermanifestv1.Manifest {
-	if manifest == nil || manifest.Spec == nil || manifest.Spec.Surfaces == nil || strings.TrimSpace(manifestPath) == "" {
-		return manifest
-	}
-	manifestDir := filepath.Dir(manifestPath)
-	relativize := func(raw string) string {
-		if raw == "" {
-			return raw
-		}
-		if strings.HasPrefix(raw, "file://") {
-			path := strings.TrimPrefix(raw, "file://")
-			if rel, ok := relativePathWithin(manifestDir, path); ok {
-				return "file://" + rel
-			}
-			return raw
-		}
-		if strings.Contains(raw, "://") {
-			return raw
-		}
-		if rel, ok := relativePathWithin(manifestDir, raw); ok {
-			return rel
-		}
-		return raw
-	}
-
-	surfaces := *manifest.Spec.Surfaces
-	changed := false
-	if surfaces.OpenAPI != nil {
-		openapi := *surfaces.OpenAPI
-		if next := relativize(openapi.Document); next != openapi.Document {
-			openapi.Document = next
-			surfaces.OpenAPI = &openapi
-			changed = true
-		}
-	}
-	if surfaces.GraphQL != nil {
-		graphql := *surfaces.GraphQL
-		if next := relativize(graphql.URL); next != graphql.URL {
-			graphql.URL = next
-			surfaces.GraphQL = &graphql
-			changed = true
-		}
-	}
-	if surfaces.MCP != nil {
-		mcp := *surfaces.MCP
-		if next := relativize(mcp.URL); next != mcp.URL {
-			mcp.URL = next
-			surfaces.MCP = &mcp
-			changed = true
-		}
-	}
-	if !changed {
-		return manifest
-	}
-
-	spec := *manifest.Spec
-	spec.Surfaces = &surfaces
-	cloned := *manifest
-	cloned.Spec = &spec
-	return &cloned
-}
-
-func relativePathWithin(baseDir, path string) (string, bool) {
-	if !filepath.IsAbs(path) {
-		return filepath.ToSlash(filepath.Clean(path)), false
-	}
-	rel, err := filepath.Rel(baseDir, path)
-	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return "", false
-	}
-	return filepath.ToSlash(rel), true
+	return staticvalidation.ProjectManifest(manifest, manifestPath, platformNeutral)
 }
 
 func staticCatalogOperationIDs(cat *catalog.Catalog) []string {

--- a/gestaltd/internal/operator/release_metadata.go
+++ b/gestaltd/internal/operator/release_metadata.go
@@ -16,7 +16,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/staticvalidation"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/apps/providerpkg"
 	"github.com/valon-technologies/gestalt/server/services/apps/source"
@@ -60,18 +62,25 @@ type gitHubReleaseByTagResponse struct {
 }
 
 type providerReleaseMetadata struct {
-	Schema        string                             `yaml:"schema"`
-	SchemaVersion int                                `yaml:"schemaVersion"`
-	Package       string                             `yaml:"package"`
-	Kind          string                             `yaml:"kind"`
-	Version       string                             `yaml:"version"`
-	Runtime       string                             `yaml:"runtime"`
-	Artifacts     map[string]providerReleaseArtifact `yaml:"artifacts,omitempty"`
+	Schema           string                               `yaml:"schema"`
+	SchemaVersion    int                                  `yaml:"schemaVersion"`
+	Package          string                               `yaml:"package"`
+	Kind             string                               `yaml:"kind"`
+	Version          string                               `yaml:"version"`
+	Runtime          string                               `yaml:"runtime"`
+	Artifacts        map[string]providerReleaseArtifact   `yaml:"artifacts,omitempty"`
+	StaticValidation *providerReleaseStaticValidationData `yaml:"staticValidation,omitempty"`
 }
 
 type providerReleaseArtifact struct {
 	Path   string `yaml:"path"`
 	SHA256 string `yaml:"sha256"`
+}
+
+type providerReleaseStaticValidationData struct {
+	Manifest           *providermanifestv1.Manifest `yaml:"manifest,omitempty"`
+	Catalog            *catalog.Catalog             `yaml:"catalog,omitempty"`
+	CatalogSessionOnly bool                         `yaml:"catalogSessionOnly,omitempty"`
 }
 
 func sourceAuthToken(entry *config.ProviderEntry) string {
@@ -149,6 +158,43 @@ func validateProviderReleaseMetadata(metadata *providerReleaseMetadata) error {
 		}
 		if strings.TrimSpace(artifact.SHA256) == "" {
 			return fmt.Errorf("provider release artifact sha256 is required for target %q", target)
+		}
+	}
+	if err := validateProviderReleaseStaticValidation(metadata); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateProviderReleaseStaticValidation(metadata *providerReleaseMetadata) error {
+	static := metadata.StaticValidation
+	if static == nil {
+		return nil
+	}
+	if static.Manifest == nil && static.Catalog == nil && !static.CatalogSessionOnly {
+		return fmt.Errorf("provider release staticValidation must include manifest or catalog metadata")
+	}
+	if static.Manifest != nil {
+		manifestKind := providermanifestv1.NormalizeKind(static.Manifest.Kind)
+		if manifestKind != metadata.Kind {
+			return fmt.Errorf("provider release staticValidation.manifest kind %q does not match %q", manifestKind, metadata.Kind)
+		}
+		if source := strings.TrimSpace(static.Manifest.Source); source != "" && source != strings.TrimSpace(metadata.Package) {
+			return fmt.Errorf("provider release staticValidation.manifest package %q does not match %q", source, metadata.Package)
+		}
+		if version := strings.TrimSpace(static.Manifest.Version); version != "" && version != strings.TrimSpace(metadata.Version) {
+			return fmt.Errorf("provider release staticValidation.manifest version %q does not match %q", version, metadata.Version)
+		}
+		if len(static.Manifest.Artifacts) != 0 {
+			return fmt.Errorf("provider release staticValidation.manifest must not include platform artifacts")
+		}
+		if static.Manifest.Entrypoint != nil && static.Manifest.Entrypoint.ArtifactPath != staticvalidation.EntrypointPlaceholder {
+			return fmt.Errorf("provider release staticValidation.manifest entrypoint artifactPath must be %q", staticvalidation.EntrypointPlaceholder)
+		}
+	}
+	if static.Catalog != nil {
+		if err := static.Catalog.Validate(); err != nil {
+			return fmt.Errorf("provider release staticValidation.catalog: %w", err)
 		}
 	}
 	return nil

--- a/gestaltd/internal/operator/release_metadata.go
+++ b/gestaltd/internal/operator/release_metadata.go
@@ -171,7 +171,7 @@ func validateProviderReleaseStaticValidation(metadata *providerReleaseMetadata) 
 	if static == nil {
 		return nil
 	}
-	if static.Manifest == nil && static.Catalog == nil && !static.CatalogSessionOnly {
+	if static.Manifest == nil && static.Catalog == nil {
 		return fmt.Errorf("provider release staticValidation must include manifest or catalog metadata")
 	}
 	if static.Manifest != nil {

--- a/gestaltd/internal/operator/release_metadata_test.go
+++ b/gestaltd/internal/operator/release_metadata_test.go
@@ -1,0 +1,90 @@
+package operator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/staticvalidation"
+)
+
+func TestDecodeProviderReleaseMetadataAcceptsStaticValidation(t *testing.T) {
+	t.Parallel()
+
+	metadata, err := decodeProviderReleaseMetadata([]byte(`
+schema: gestaltd-provider-release
+schemaVersion: 1
+package: github.com/acme/providers/provider
+kind: app
+version: 1.2.3
+runtime: executable
+artifacts:
+  linux/amd64:
+    path: provider-linux-amd64.tar.gz
+    sha256: linux-sha
+staticValidation:
+  manifest:
+    kind: app
+    source: github.com/acme/providers/provider
+    version: 1.2.3
+    entrypoint:
+      artifactPath: static-validation-placeholder
+    spec: {}
+  catalog:
+    name: provider
+    operations:
+      - id: echo
+        method: POST
+        path: /echo
+  catalogSessionOnly: true
+`))
+	if err != nil {
+		t.Fatalf("decodeProviderReleaseMetadata: %v", err)
+	}
+	if metadata.StaticValidation == nil {
+		t.Fatal("StaticValidation = nil, want decoded metadata")
+	}
+	if metadata.StaticValidation.Manifest == nil || metadata.StaticValidation.Manifest.Entrypoint == nil {
+		t.Fatalf("static manifest = %+v, want entrypoint", metadata.StaticValidation.Manifest)
+	}
+	if got := metadata.StaticValidation.Manifest.Entrypoint.ArtifactPath; got != staticvalidation.EntrypointPlaceholder {
+		t.Fatalf("static entrypoint artifactPath = %q, want %q", got, staticvalidation.EntrypointPlaceholder)
+	}
+	if metadata.StaticValidation.Catalog == nil || len(metadata.StaticValidation.Catalog.Operations) != 1 {
+		t.Fatalf("static catalog = %+v, want one operation", metadata.StaticValidation.Catalog)
+	}
+	if !metadata.StaticValidation.CatalogSessionOnly {
+		t.Fatal("CatalogSessionOnly = false, want true")
+	}
+}
+
+func TestDecodeProviderReleaseMetadataRejectsPlatformSpecificStaticManifest(t *testing.T) {
+	t.Parallel()
+
+	_, err := decodeProviderReleaseMetadata([]byte(`
+schema: gestaltd-provider-release
+schemaVersion: 1
+package: github.com/acme/providers/provider
+kind: app
+version: 1.2.3
+runtime: executable
+artifacts:
+  linux/amd64:
+    path: provider-linux-amd64.tar.gz
+    sha256: linux-sha
+staticValidation:
+  manifest:
+    kind: app
+    source: github.com/acme/providers/provider
+    version: 1.2.3
+    artifacts:
+      - os: linux
+        arch: amd64
+        path: bin/provider
+    entrypoint:
+      artifactPath: bin/provider
+    spec: {}
+`))
+	if err == nil || !strings.Contains(err.Error(), "staticValidation.manifest must not include platform artifacts") {
+		t.Fatalf("decodeProviderReleaseMetadata error = %v, want platform artifact rejection", err)
+	}
+}

--- a/gestaltd/internal/operator/release_metadata_test.go
+++ b/gestaltd/internal/operator/release_metadata_test.go
@@ -57,21 +57,17 @@ staticValidation:
 	}
 }
 
-func TestDecodeProviderReleaseMetadataRejectsPlatformSpecificStaticManifest(t *testing.T) {
+func TestDecodeProviderReleaseMetadataRejectsInvalidStaticValidation(t *testing.T) {
 	t.Parallel()
 
-	_, err := decodeProviderReleaseMetadata([]byte(`
-schema: gestaltd-provider-release
-schemaVersion: 1
-package: github.com/acme/providers/provider
-kind: app
-version: 1.2.3
-runtime: executable
-artifacts:
-  linux/amd64:
-    path: provider-linux-amd64.tar.gz
-    sha256: linux-sha
-staticValidation:
+	cases := []struct {
+		name    string
+		block   string
+		wantErr string
+	}{
+		{
+			name: "platform-specific static manifest",
+			block: `
   manifest:
     kind: app
     source: github.com/acme/providers/provider
@@ -82,9 +78,38 @@ staticValidation:
         path: bin/provider
     entrypoint:
       artifactPath: bin/provider
-    spec: {}
+    spec: {}`,
+			wantErr: "staticValidation.manifest must not include platform artifacts",
+		},
+		{
+			name: "session-only flag without metadata",
+			block: `
+  catalogSessionOnly: true`,
+			wantErr: "staticValidation must include manifest or catalog metadata",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := decodeProviderReleaseMetadata([]byte(`
+schema: gestaltd-provider-release
+schemaVersion: 1
+package: github.com/acme/providers/provider
+kind: app
+version: 1.2.3
+runtime: executable
+artifacts:
+  linux/amd64:
+    path: provider-linux-amd64.tar.gz
+    sha256: linux-sha
+staticValidation:` + tc.block + `
 `))
-	if err == nil || !strings.Contains(err.Error(), "staticValidation.manifest must not include platform artifacts") {
-		t.Fatalf("decodeProviderReleaseMetadata error = %v, want platform artifact rejection", err)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("decodeProviderReleaseMetadata error = %v, want %q", err, tc.wantErr)
+			}
+		})
 	}
 }

--- a/gestaltd/internal/staticvalidation/manifest.go
+++ b/gestaltd/internal/staticvalidation/manifest.go
@@ -1,0 +1,102 @@
+package staticvalidation
+
+import (
+	"path/filepath"
+	"strings"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/apps/packageio"
+)
+
+const EntrypointPlaceholder = "static-validation-placeholder"
+
+func ProjectManifest(manifest *providermanifestv1.Manifest, manifestPath string, platformNeutral bool) (*providermanifestv1.Manifest, error) {
+	if manifest == nil {
+		return nil, nil
+	}
+	if platformNeutral {
+		cloned, err := packageio.CloneManifest(manifest)
+		if err != nil {
+			return nil, err
+		}
+		cloned.Artifacts = nil
+		if cloned.Entrypoint != nil {
+			cloned.Entrypoint = &providermanifestv1.Entrypoint{ArtifactPath: EntrypointPlaceholder}
+		}
+		return RelativizeManifest(cloned, manifestPath), nil
+	}
+	return RelativizeManifest(manifest, manifestPath), nil
+}
+
+func RelativizeManifest(manifest *providermanifestv1.Manifest, manifestPath string) *providermanifestv1.Manifest {
+	if manifest == nil || manifest.Spec == nil || manifest.Spec.Surfaces == nil || strings.TrimSpace(manifestPath) == "" {
+		return manifest
+	}
+	manifestDir := filepath.Dir(manifestPath)
+	relativize := func(raw string) string {
+		if raw == "" {
+			return raw
+		}
+		if strings.HasPrefix(raw, "file://") {
+			path := strings.TrimPrefix(raw, "file://")
+			if rel, ok := relativePathWithin(manifestDir, path); ok {
+				return "file://" + rel
+			}
+			return raw
+		}
+		if strings.Contains(raw, "://") {
+			return raw
+		}
+		if rel, ok := relativePathWithin(manifestDir, raw); ok {
+			return rel
+		}
+		return raw
+	}
+
+	surfaces := *manifest.Spec.Surfaces
+	changed := false
+	if surfaces.OpenAPI != nil {
+		openapi := *surfaces.OpenAPI
+		if next := relativize(openapi.Document); next != openapi.Document {
+			openapi.Document = next
+			surfaces.OpenAPI = &openapi
+			changed = true
+		}
+	}
+	if surfaces.GraphQL != nil {
+		graphql := *surfaces.GraphQL
+		if next := relativize(graphql.URL); next != graphql.URL {
+			graphql.URL = next
+			surfaces.GraphQL = &graphql
+			changed = true
+		}
+	}
+	if surfaces.MCP != nil {
+		mcp := *surfaces.MCP
+		if next := relativize(mcp.URL); next != mcp.URL {
+			mcp.URL = next
+			surfaces.MCP = &mcp
+			changed = true
+		}
+	}
+	if !changed {
+		return manifest
+	}
+
+	spec := *manifest.Spec
+	spec.Surfaces = &surfaces
+	cloned := *manifest
+	cloned.Spec = &spec
+	return &cloned
+}
+
+func relativePathWithin(baseDir, path string) (string, bool) {
+	if !filepath.IsAbs(path) {
+		return filepath.ToSlash(filepath.Clean(path)), false
+	}
+	rel, err := filepath.Rel(baseDir, path)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return filepath.ToSlash(rel), true
+}


### PR DESCRIPTION
## Summary
- Adds `staticValidation` metadata to `provider-release.yaml` and validates embedded manifest/catalog data.
- Centralizes static validation manifest projection so release metadata and lock metadata use the same portable shape.
- Replaces closed PR #2273.

## Test plan
- [x] go test ./gestaltd/internal/staticvalidation ./gestaltd/internal/operator ./gestaltd/internal/daemon