### PR TITLE
Remove duplicate workflow runAs bootstrap validation

### DIFF
--- a/gestaltd/internal/bootstrap/workflow_config_event_triggers.go
+++ b/gestaltd/internal/bootstrap/workflow_config_event_triggers.go
@@ -60,10 +60,7 @@ func reconcileWorkflowConfigEventTriggers(ctx context.Context, cfg *config.Confi
 		default:
 			return fmt.Errorf("bootstrap: get workflow event trigger %q for app %q: %w", desiredEntry.TriggerID, appName, err)
 		}
-		runAs, err := workflowConfigRunAsSubject("workflows.eventTriggers."+desiredEntry.TriggerKey+".runAs", trigger.RunAs)
-		if err != nil {
-			return fmt.Errorf("bootstrap: workflow event trigger %q for app %q: %w", desiredEntry.TriggerKey, appName, err)
-		}
+		runAs := trigger.RunAs.SubjectRef()
 		if err := workflowConfigValidateExecutionTarget(cfg, target, runAs); err != nil {
 			return fmt.Errorf("bootstrap: workflow event trigger %q for app %q: %w", desiredEntry.TriggerKey, appName, err)
 		}

--- a/gestaltd/internal/bootstrap/workflow_config_schedules.go
+++ b/gestaltd/internal/bootstrap/workflow_config_schedules.go
@@ -68,10 +68,7 @@ func reconcileWorkflowConfigSchedules(ctx context.Context, cfg *config.Config, r
 		default:
 			return fmt.Errorf("bootstrap: get workflow schedule %q for app %q: %w", desiredEntry.ScheduleID, appName, err)
 		}
-		runAs, err := workflowConfigRunAsSubject("workflows.schedules."+desiredEntry.ScheduleKey+".runAs", schedule.RunAs)
-		if err != nil {
-			return fmt.Errorf("bootstrap: workflow schedule %q for app %q: %w", desiredEntry.ScheduleKey, appName, err)
-		}
+		runAs := schedule.RunAs.SubjectRef()
 		if err := workflowConfigValidateExecutionTarget(cfg, target, runAs); err != nil {
 			return fmt.Errorf("bootstrap: workflow schedule %q for app %q: %w", desiredEntry.ScheduleKey, appName, err)
 		}
@@ -217,20 +214,6 @@ func workflowConfigTargetLabel(target coreworkflow.Target) string {
 
 func workflowConfigTarget(target *config.WorkflowTargetConfig) coreworkflow.Target {
 	return config.WorkflowTargetToCore(target)
-}
-
-func workflowConfigRunAsSubject(path string, runAs *config.WorkflowRunAsConfig) (*core.RunAsSubject, error) {
-	if runAs == nil {
-		return nil, fmt.Errorf("config validation: %s is required", path)
-	}
-	subject := runAs.SubjectRef()
-	if subject == nil || strings.TrimSpace(subject.SubjectID) == "" {
-		return nil, fmt.Errorf("config validation: %s.subject is required", path)
-	}
-	if subject.AuthSource == "" {
-		subject.AuthSource = "config"
-	}
-	return subject, nil
 }
 
 func workflowConfigActor() coreworkflow.Actor {

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -818,11 +818,15 @@ func (r *WorkflowRunAsConfig) SubjectRef() *core.RunAsSubject {
 	if r == nil || r.Subject == nil {
 		return nil
 	}
+	authSource := r.Subject.AuthSource
+	if authSource == "" {
+		authSource = "config"
+	}
 	return core.NormalizeRunAsSubject(&core.RunAsSubject{
 		SubjectID:   r.Subject.ID,
 		SubjectKind: r.Subject.Kind,
 		DisplayName: r.Subject.DisplayName,
-		AuthSource:  r.Subject.AuthSource,
+		AuthSource:  authSource,
 	})
 }
 


### PR DESCRIPTION
## Summary

- Remove the bootstrap-only runAs parser now that config normalization owns required runAs validation.
- Default config-derived runAs authSource in `WorkflowRunAsConfig.SubjectRef()` so direct config consumers get the same normalized subject.

## Interfaces

No API, proto, or config schema changes.

## Runtime

Schedules and event triggers now pass their normalized config subject directly into target validation and provider upserts. This keeps runtime behavior the same while removing duplicate validation in bootstrap.

Tested with:

`go test ./gestaltd/internal/bootstrap ./gestaltd/internal/config ./gestaltd/services/appaccess ./gestaltd/services/agents ./gestaltd/services/workflows/workflowrunauth`