### PR TITLE
Allow TS host clients to use workflow run context

### DIFF
--- a/sdk/typescript/src/agent-access.ts
+++ b/sdk/typescript/src/agent-access.ts
@@ -38,6 +38,7 @@ import {
   dateFromTimestamp,
   type JsonObjectInput,
 } from "./protocol.ts";
+import { hostInvocationContext } from "./invocation-context.ts";
 import {
   optionalObjectFromStruct,
   optionalStruct,
@@ -171,12 +172,12 @@ export interface Agent {
  */
 class AgentImpl implements Agent {
   private readonly client: Client<typeof AgentProviderService>;
-  private readonly invocationToken: string;
+  private readonly invocationContext: ReturnType<typeof hostInvocationContext>;
 
   constructor(request: Request);
   constructor(invocationToken: string);
   constructor(requestOrToken: Request | string) {
-    this.invocationToken = normalizeInvocationToken(requestOrToken);
+    this.invocationContext = hostInvocationContext(requestOrToken);
 
     const target = process.env[ENV_HOST_SERVICE_SOCKET]?.trim();
     if (!target) {
@@ -203,7 +204,7 @@ class AgentImpl implements Agent {
         clientRef: request.clientRef ?? "",
         metadata: optionalStruct(request.metadata),
         idempotencyKey: request.idempotencyKey ?? "",
-        invocationToken: this.invocationToken,
+        ...this.invocationContext,
         workspace: workspaceToProto(request.workspace),
       }),
     );
@@ -214,7 +215,7 @@ class AgentImpl implements Agent {
     return agentSessionFromProto(
       await this.client.getSession({
         sessionId: request.sessionId,
-        invocationToken: this.invocationToken,
+        ...this.invocationContext,
       }),
     );
   }
@@ -225,7 +226,7 @@ class AgentImpl implements Agent {
   ): Promise<AgentSession[]> {
     const response = await this.client.listSessions({
       providerName: request.providerName ?? "",
-      invocationToken: this.invocationToken,
+      ...this.invocationContext,
       state: request.state ?? AgentSessionState.UNSPECIFIED,
       limit: request.limit ?? 0,
       summaryOnly: request.summaryOnly ?? false,
@@ -243,7 +244,7 @@ class AgentImpl implements Agent {
         clientRef: request.clientRef ?? "",
         state: request.state ?? AgentSessionState.UNSPECIFIED,
         metadata: optionalStruct(request.metadata),
-        invocationToken: this.invocationToken,
+        ...this.invocationContext,
       }),
     );
   }
@@ -260,7 +261,7 @@ class AgentImpl implements Agent {
         output: agentOutputToProto(request.output),
         metadata: optionalStruct(request.metadata),
         idempotencyKey: request.idempotencyKey ?? "",
-        invocationToken: this.invocationToken,
+        ...this.invocationContext,
         modelOptions: optionalStruct(request.modelOptions),
         timeoutSeconds: request.timeoutSeconds ?? 0,
       }),
@@ -272,7 +273,7 @@ class AgentImpl implements Agent {
     return agentTurnFromProto(
       await this.client.getTurn({
         turnId: request.turnId,
-        invocationToken: this.invocationToken,
+        ...this.invocationContext,
       }),
     );
   }
@@ -281,7 +282,7 @@ class AgentImpl implements Agent {
   async listTurns(request: AgentListTurns): Promise<AgentTurn[]> {
     const response = await this.client.listTurns({
       sessionId: request.sessionId,
-      invocationToken: this.invocationToken,
+      ...this.invocationContext,
       status: request.status ?? AgentExecutionStatus.UNSPECIFIED,
       limit: request.limit ?? 0,
       summaryOnly: request.summaryOnly ?? false,
@@ -295,7 +296,7 @@ class AgentImpl implements Agent {
       await this.client.cancelTurn({
         turnId: request.turnId,
         reason: request.reason ?? "",
-        invocationToken: this.invocationToken,
+        ...this.invocationContext,
       }),
     );
   }
@@ -308,7 +309,7 @@ class AgentImpl implements Agent {
       turnId: request.turnId,
       afterSeq: BigInt(request.afterSeq ?? 0),
       limit: request.limit ?? 0,
-      invocationToken: this.invocationToken,
+      ...this.invocationContext,
     });
     return response.events.map(agentTurnEventFromProto);
   }
@@ -319,7 +320,7 @@ class AgentImpl implements Agent {
   ): Promise<AgentInteraction[]> {
     const response = await this.client.listInteractions({
       turnId: request.turnId,
-      invocationToken: this.invocationToken,
+      ...this.invocationContext,
     });
     return response.interactions.map(agentInteractionFromProto);
   }
@@ -333,22 +334,10 @@ class AgentImpl implements Agent {
         turnId: request.turnId,
         interactionId: request.interactionId,
         resolution: optionalStruct(request.resolution),
-        invocationToken: this.invocationToken,
+        ...this.invocationContext,
       }),
     );
   }
-}
-
-function normalizeInvocationToken(requestOrToken: Request | string): string {
-  const invocationToken =
-    typeof requestOrToken === "string"
-      ? requestOrToken
-      : requestOrToken.invocationToken;
-  const trimmed = invocationToken.trim();
-  if (!trimmed) {
-    throw new Error("agent: invocation token is not available");
-  }
-  return trimmed;
 }
 
 function workspaceToProto(workspace?: AgentWorkspace | undefined) {

--- a/sdk/typescript/src/app-access.ts
+++ b/sdk/typescript/src/app-access.ts
@@ -8,6 +8,7 @@ import {
   structFromObject,
   type JsonObjectInput,
 } from "./protocol.ts";
+import { hostInvocationContext } from "./invocation-context.ts";
 import {
   createHostServiceGrpcTransport,
   hostServiceMetadataInterceptors,
@@ -72,12 +73,12 @@ export interface App {
  */
 class AppImpl implements App {
   private readonly client: Client<typeof AppService>;
-  private readonly invocationToken: string;
+  private readonly invocationContext: ReturnType<typeof hostInvocationContext>;
 
   constructor(request: Request);
   constructor(invocationToken: string);
   constructor(requestOrToken: Request | string) {
-    this.invocationToken = normalizeInvocationToken(requestOrToken);
+    this.invocationContext = hostInvocationContext(requestOrToken);
 
     const { target, token } = requireHostServiceTarget("app");
     const transport = createHostServiceGrpcTransport(
@@ -95,7 +96,7 @@ class AppImpl implements App {
     options?: AppInvokeOptions,
   ): Promise<OperationResult> {
     const response = await this.client.invoke({
-      invocationToken: this.invocationToken,
+      ...this.invocationContext,
       app,
       operation,
       params: structFromObject(params),
@@ -123,7 +124,7 @@ class AppImpl implements App {
     }
 
     const response = await this.client.invokeGraphQL({
-      invocationToken: this.invocationToken,
+      invocationToken: this.invocationContext.invocationToken,
       app,
       document: trimmedDocument,
       ...(options?.variables !== undefined
@@ -148,7 +149,7 @@ class AppImpl implements App {
     ttlSeconds?: number;
   }): Promise<string> {
     const response = await this.client.exchangeInvocationToken({
-      parentInvocationToken: this.invocationToken,
+      parentInvocationToken: this.invocationContext.invocationToken,
       grants: (options?.grants ?? [])
         .map((grant) => ({
           app: grant.app.trim(),
@@ -168,15 +169,3 @@ class AppImpl implements App {
 }
 
 export const App = AppImpl;
-
-function normalizeInvocationToken(requestOrToken: Request | string): string {
-  const invocationToken =
-    typeof requestOrToken === "string"
-      ? requestOrToken
-      : requestOrToken.invocationToken;
-  const trimmed = invocationToken.trim();
-  if (!trimmed) {
-    throw new Error("app: invocation token is not available");
-  }
-  return trimmed;
-}

--- a/sdk/typescript/src/invocation-context.ts
+++ b/sdk/typescript/src/invocation-context.ts
@@ -1,0 +1,15 @@
+import type { Request } from "./api.ts";
+
+export function hostInvocationContext(requestOrToken: Request | string) {
+  const invocationToken = (typeof requestOrToken === "string" ? requestOrToken : requestOrToken.invocationToken).trim();
+  if (typeof requestOrToken === "string") {
+    return { invocationToken };
+  }
+  const providerName = stringValue(requestOrToken.workflow.providerName) || stringValue(requestOrToken.workflow.provider);
+  const runId = stringValue(requestOrToken.workflow.runId);
+  return providerName && runId
+    ? { invocationToken, workflow: { provider: providerName, providerName, runId } }
+    : { invocationToken };
+}
+
+const stringValue = (value: unknown) => (typeof value === "string" ? value.trim() : "");

--- a/sdk/typescript/tests/agent-access.transport.test.ts
+++ b/sdk/typescript/tests/agent-access.transport.test.ts
@@ -44,6 +44,8 @@ test("Agent forwards invocation tokens across session, turn, and interaction cal
     turnId?: string;
     interactionId?: string;
     reason?: string;
+    workflowRunId?: string;
+    workflowKeys?: string[];
   }> = [];
 
   const handler = connectNodeAdapter({
@@ -57,6 +59,8 @@ test("Agent forwards invocation tokens across session, turn, and interaction cal
             method: "createSession",
             invocationToken: input.invocationToken,
             providerName: input.providerName,
+            ...(typeof input.workflow?.runId === "string" ? { workflowRunId: input.workflow.runId } : {}),
+            ...(input.workflow !== undefined ? { workflowKeys: Object.keys(input.workflow).sort() } : {}),
           });
           return create(AgentSessionSchema, {
             id: "session-1",
@@ -324,6 +328,19 @@ test("Agent forwards invocation tokens across session, turn, and interaction cal
       turnId: "turn-1",
       reason: "user requested cancellation",
     });
+    const fromWorkflow = new Agent(
+      request("", {}, {}, {}, {}, {
+        provider: "local",
+        runId: "run-123",
+        runAs: { id: "service_account:caller-supplied" },
+        trigger: { event: { data: { ignored: true } } },
+      }),
+    );
+    await fromWorkflow.createSession({
+      providerName: "workflow-agent",
+      model: "gpt-test",
+      clientRef: "workflow-session",
+    });
 
     expect(fetchedSession.metadata).toEqual({ source: "transport-test" });
     expect(listedSessions.map((entry) => entry.id)).toEqual(["session-1"]);
@@ -397,6 +414,13 @@ test("Agent forwards invocation tokens across session, turn, and interaction cal
         turnId: "turn-1",
         reason: "user requested cancellation",
       },
+      {
+        method: "createSession",
+        invocationToken: "",
+        providerName: "workflow-agent",
+        workflowRunId: "run-123",
+        workflowKeys: ["provider", "providerName", "runId"],
+      },
     ]);
   } finally {
     if (previousSocket === undefined) {
@@ -413,14 +437,12 @@ test("Agent forwards invocation tokens across session, turn, and interaction cal
   }
 });
 
-test("Agent prioritizes invocation-token validation over socket configuration", () => {
+test("Agent still requires host service socket configuration", () => {
   const previousSocket = process.env[ENV_HOST_SERVICE_SOCKET];
 
   try {
     delete process.env[ENV_HOST_SERVICE_SOCKET];
-    expect(() => new Agent("   ")).toThrow(
-      "agent: invocation token is not available",
-    );
+    expect(() => new Agent("   ")).toThrow("agent: GESTALT_HOST_SERVICE_SOCKET is not set");
   } finally {
     if (previousSocket === undefined) {
       delete process.env[ENV_HOST_SERVICE_SOCKET];

--- a/sdk/typescript/tests/app.transport.test.ts
+++ b/sdk/typescript/tests/app.transport.test.ts
@@ -38,6 +38,8 @@ test("App forwards invocation tokens from strings and Request objects", async ()
     connection: string;
     instance: string;
     idempotencyKey: string;
+    workflowRunId?: string;
+    workflowKeys?: string[];
   }> = [];
   const graphqlCalls: Array<{
     invocationToken: string;
@@ -92,6 +94,8 @@ test("App forwards invocation tokens from strings and Request objects", async ()
               connection: input.connection,
               instance: input.instance,
               idempotencyKey: input.idempotencyKey,
+              ...(typeof input.workflow?.runId === "string" ? { workflowRunId: input.workflow.runId } : {}),
+              ...(input.workflow !== undefined ? { workflowKeys: Object.keys(input.workflow).sort() } : {}),
             });
             return create(OperationResultSchema, {
               status: 207,
@@ -230,6 +234,16 @@ test("App forwards invocation tokens from strings and Request objects", async ()
       fromRequest.invoke("slack", "bad", { when: new Date() } as any),
     ).rejects.toThrow(TypeError);
 
+    const fromWorkflow = new App(
+      request("", {}, {}, {}, {}, {
+        provider: "local",
+        runId: "run-123",
+        runAs: { id: "service_account:caller-supplied" },
+        trigger: { event: { data: { ignored: true } } },
+      }),
+    );
+    await fromWorkflow.invoke("testApp", "runWorkflowStep");
+
     const graphql = await fromRequest.invokeGraphQL(
       "linear",
       "query Viewer($team: String!) { viewer(team: $team) { id } }",
@@ -305,6 +319,17 @@ test("App forwards invocation tokens from strings and Request objects", async ()
         instance: "",
         idempotencyKey: "",
       },
+      {
+        invocationToken: "",
+        app: "testApp",
+        operation: "runWorkflowStep",
+        params: {},
+        connection: "",
+        instance: "",
+        idempotencyKey: "",
+        workflowRunId: "run-123",
+        workflowKeys: ["provider", "providerName", "runId"],
+      },
     ]);
 
     expect(graphqlCalls).toEqual([
@@ -335,14 +360,12 @@ test("App forwards invocation tokens from strings and Request objects", async ()
   }
 });
 
-test("App prioritizes invocation-token validation over socket configuration", () => {
+test("App still requires host service socket configuration", () => {
   const previousSocket = process.env[ENV_HOST_SERVICE_SOCKET];
 
   try {
     delete process.env[ENV_HOST_SERVICE_SOCKET];
-    expect(() => new App("   ")).toThrow(
-      "app: invocation token is not available",
-    );
+    expect(() => new App("   ")).toThrow("app: GESTALT_HOST_SERVICE_SOCKET is not set");
   } finally {
     if (previousSocket === undefined) {
       delete process.env[ENV_HOST_SERVICE_SOCKET];


### PR DESCRIPTION
## Summary

- Allow TypeScript App and Agent host clients to be constructed without a minted invocation token.
- Forward only the persisted workflow run reference on nested host-service calls, so server-side workflow run state remains the source of runAs authorization.

## Interfaces

No proto or config schema changes. This loosens the TypeScript SDK App and Agent constructors to match the existing tokenless workflow-run path used by workflow hosts.

## Runtime

Workflow-triggered TypeScript app handlers can now call App and Agent host services with `workflow: { provider, providerName, runId }` instead of an invocation token. Caller-supplied `runAs`, trigger payloads, inputs, and other workflow metadata are not forwarded by these clients; gestaltd resolves persisted `runAs` and target grants from the stored run.

Tested with:

- [x] `bun test tests/app.transport.test.ts tests/agent-access.transport.test.ts`
- [x] `bun run test`
- [x] `bun run typecheck`
- [x] `bun run typecheck:loose`