### PR TITLE
Update gestaltd formula and chart to v0.0.2-alpha.10

### DIFF
--- a/Formula/gestaltd.rb
+++ b/Formula/gestaltd.rb
@@ -3,30 +3,30 @@
 class Gestaltd < Formula
   desc "Gestalt server daemon"
   homepage "https://github.com/valon-technologies/gestalt"
-  version "0.0.2-alpha.9"
+  version "0.0.2-alpha.10"
   license "Apache-2.0"
 
   on_macos do
     on_arm do
-      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.9/gestaltd-macos-arm64.tar.gz"
-      sha256 "c4a5f7cfa2c3b5d54151a0bd9b96f5ead6905fe62468c9c1dbe31317558279e6"
+      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.10/gestaltd-macos-arm64.tar.gz"
+      sha256 "9bb040589cf5ebe6843a51b2c1a9ca677a9ce34709703979d0bd51573572abb1"
     end
 
     on_intel do
-      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.9/gestaltd-macos-x86_64.tar.gz"
-      sha256 "ded925a36cede25ae0a92405d044cd02213a70a8a0c929a3ae584482ad5847d0"
+      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.10/gestaltd-macos-x86_64.tar.gz"
+      sha256 "ba2405a7f9fa2777d0cfd5f2208f3950b2664ab9a2a5102e3f0c1303d7ab9b49"
     end
   end
 
   on_linux do
     on_arm do
-      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.9/gestaltd-linux-arm64.tar.gz"
-      sha256 "0d423e65e3d0dfd713e419c8126b616c68826ce8ac098c804d0352eaba1cbe55"
+      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.10/gestaltd-linux-arm64.tar.gz"
+      sha256 "88fc9d3171f1210969644d80f5e5a80931ea3390d011107832b5966c600010b6"
     end
 
     on_intel do
-      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.9/gestaltd-linux-x86_64.tar.gz"
-      sha256 "e53e696d5b98e0fc027d835962ca696924b86b926a70c1c0e1d11b9b6bd98a86"
+      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.10/gestaltd-linux-x86_64.tar.gz"
+      sha256 "6cd0877e817f90937f6479b75f1aac09232ac45ea0227e131f82772b07f2209c"
     end
   end
 

--- a/gestaltd/deploy/helm/gestaltd/Chart.yaml
+++ b/gestaltd/deploy/helm/gestaltd/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: gestaltd
 description: gestaltd - OAuth token management proxy with pluggable integrations
 type: application
-version: 0.0.2-alpha.9
-appVersion: "0.0.2-alpha.9"
+version: 0.0.2-alpha.10
+appVersion: "0.0.2-alpha.10"


### PR DESCRIPTION
## Summary
- Updates the checked-in gestaltd Homebrew formula to `0.0.2-alpha.10` with release asset checksums.
- Updates the gestaltd Helm chart version and appVersion to `0.0.2-alpha.10`.
- Carries the repository update that the release workflow could not push directly because `main` is protected.

## Test plan
- [x] Verified GitHub release `gestaltd/v0.0.2-alpha.10` assets exist
- [x] Verified `docker run --rm --platform linux/amd64 valontechnologies/gestaltd:0.0.2-alpha.10 version` reports `0.0.2-alpha.10`


Made with [Cursor](https://cursor.com)