### PR TITLE
Retry stale GCS release metadata with cache busting

### DIFF
--- a/gestaltd/internal/operator/release_metadata.go
+++ b/gestaltd/internal/operator/release_metadata.go
@@ -238,9 +238,57 @@ func fetchProviderReleaseMetadata(ctx context.Context, client *http.Client, meta
 	}
 	metadata, err := decodeProviderReleaseMetadata(data)
 	if err != nil {
+		if shouldRetryProviderReleaseMetadataWithCacheBust(resolvedMetadataLocation, err) {
+			cacheBustedLocation := providerReleaseMetadataCacheBustLocation(resolvedMetadataLocation)
+			resp, fetchErr := doProviderReleaseHTTPRequestWithRetry(ctx, client, func(ctx context.Context) (*http.Request, error) {
+				return newAuthenticatedFetchRequest(ctx, cacheBustedLocation, token)
+			})
+			if fetchErr != nil {
+				return nil, "", nil, fmt.Errorf("fetch provider release metadata cache-bust retry: %w", fetchErr)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusOK {
+				return nil, "", nil, fmt.Errorf("unexpected status %d fetching provider release metadata from %s", resp.StatusCode, cacheBustedLocation)
+			}
+			data, fetchErr = io.ReadAll(io.LimitReader(resp.Body, providerReleaseMetadataMaxBytes+1))
+			if fetchErr != nil {
+				return nil, "", nil, fmt.Errorf("read provider release metadata cache-bust retry: %w", fetchErr)
+			}
+			if len(data) > providerReleaseMetadataMaxBytes {
+				return nil, "", nil, fmt.Errorf("provider release metadata exceeds %d byte limit", providerReleaseMetadataMaxBytes)
+			}
+			metadata, fetchErr = decodeProviderReleaseMetadata(data)
+			if fetchErr == nil {
+				return metadata, resolvedMetadataLocation, gitHubReleaseAssets, nil
+			}
+		}
 		return nil, "", nil, err
 	}
 	return metadata, resolvedMetadataLocation, gitHubReleaseAssets, nil
+}
+
+func shouldRetryProviderReleaseMetadataWithCacheBust(metadataLocation string, err error) bool {
+	if err == nil || !strings.Contains(err.Error(), "provider release staticValidation is required") {
+		return false
+	}
+	parsed, parseErr := url.Parse(metadataLocation)
+	if parseErr != nil {
+		return false
+	}
+	return parsed.Scheme == "https" &&
+		parsed.Host == "storage.googleapis.com" &&
+		strings.HasSuffix(parsed.Path, "/provider-release.yaml")
+}
+
+func providerReleaseMetadataCacheBustLocation(metadataLocation string) string {
+	parsed, err := url.Parse(metadataLocation)
+	if err != nil {
+		return metadataLocation
+	}
+	query := parsed.Query()
+	query.Set("gestaltdCacheBust", fmt.Sprintf("%d", time.Now().UnixNano()))
+	parsed.RawQuery = query.Encode()
+	return parsed.String()
 }
 
 func doProviderReleaseHTTPRequestWithRetry(ctx context.Context, client *http.Client, newRequest func(context.Context) (*http.Request, error)) (*http.Response, error) {

--- a/gestaltd/internal/operator/release_metadata_test.go
+++ b/gestaltd/internal/operator/release_metadata_test.go
@@ -118,6 +118,37 @@ artifacts:
 	}
 }
 
+func TestProviderReleaseMetadataCacheBustRetryPredicate(t *testing.T) {
+	t.Parallel()
+
+	_, err := decodeProviderReleaseMetadata([]byte(`
+schema: gestaltd-provider-release
+schemaVersion: 1
+package: github.com/acme/providers/provider
+kind: app
+version: 1.2.3
+runtime: executable
+artifacts:
+  linux/amd64:
+    path: provider-linux-amd64.tar.gz
+    sha256: linux-sha
+`))
+	if err == nil {
+		t.Fatal("decodeProviderReleaseMetadata error = nil, want missing staticValidation")
+	}
+	location := "https://storage.googleapis.com/gitlab-peach-street-gestalt-provider-snapshots/github.com/acme/providers/main/app/provider/provider-release.yaml"
+	if !shouldRetryProviderReleaseMetadataWithCacheBust(location, err) {
+		t.Fatal("shouldRetryProviderReleaseMetadataWithCacheBust = false, want true for GCS stale metadata")
+	}
+	if shouldRetryProviderReleaseMetadataWithCacheBust("https://example.com/provider-release.yaml", err) {
+		t.Fatal("shouldRetryProviderReleaseMetadataWithCacheBust = true, want false for non-GCS metadata")
+	}
+	cacheBusted := providerReleaseMetadataCacheBustLocation(location)
+	if !strings.HasPrefix(cacheBusted, location+"?gestaltdCacheBust=") {
+		t.Fatalf("cache-busted location = %q, want query appended to original location", cacheBusted)
+	}
+}
+
 func staticValidationBlock(block *string) string {
 	if block == nil {
 		return ""


### PR DESCRIPTION
## Summary
- Retries public GCS `provider-release.yaml` fetches with a cache-busting query only when the first response is stale metadata missing required `staticValidation`.
- Keeps strict `staticValidation` validation for non-GCS metadata and other decode errors.

## Test plan
- [x] `TMPDIR=/tmp go test ./gestaltd/internal/staticvalidation ./gestaltd/internal/operator ./gestaltd/internal/daemon`