### PR TITLE
Remove static validation entrypoint placeholder

### DIFF
--- a/gestaltd/internal/daemon/provider_lifecycle_test.go
+++ b/gestaltd/internal/daemon/provider_lifecycle_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/operator"
-	"github.com/valon-technologies/gestalt/server/internal/staticvalidation"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/apps/providerpkg"
 	"gopkg.in/yaml.v3"
@@ -504,10 +503,7 @@ func writeProviderLifecycleRelease(t *testing.T, dir, pkg, version string) strin
 				"kind":    providermanifestv1.KindApp,
 				"source":  pkg,
 				"version": version,
-				"entrypoint": map[string]any{
-					"artifactPath": staticvalidation.EntrypointPlaceholder,
-				},
-				"spec": map[string]any{},
+				"spec":    map[string]any{},
 			},
 			"catalog": map[string]any{
 				"name": "alpha",

--- a/gestaltd/internal/daemon/testmain_test.go
+++ b/gestaltd/internal/daemon/testmain_test.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/valon-technologies/gestalt/server/internal/staticvalidation"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/apps/providerpkg"
@@ -379,10 +378,7 @@ func writeLocalProviderReleaseMetadata(dir string) error {
 				"kind":    manifest.Kind,
 				"source":  manifest.Source,
 				"version": manifest.Version,
-				"entrypoint": map[string]any{
-					"artifactPath": staticvalidation.EntrypointPlaceholder,
-				},
-				"spec": map[string]any{},
+				"spec":    map[string]any{},
 			},
 		},
 	}

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -44,8 +44,7 @@ const (
 	PreparedRuntimeDir             = ".gestaltd/runtime"
 	PreparedUIDir                  = ".gestaltd/ui"
 
-	platformKeyGeneric                    = "generic"
-	staticValidationEntrypointPlaceholder = staticvalidation.EntrypointPlaceholder
+	platformKeyGeneric = "generic"
 )
 
 type Lockfile struct {

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -906,8 +906,8 @@ server:
 		t.Fatalf("LockAtPathsWithStatePaths: %v", err)
 	}
 	callerStatic := lock.Providers["caller"].StaticManifest
-	if callerStatic == nil || callerStatic.Entrypoint == nil || callerStatic.Entrypoint.ArtifactPath != staticValidationEntrypointPlaceholder {
-		t.Fatalf("caller static manifest entrypoint = %+v, want placeholder", callerStatic)
+	if callerStatic == nil || callerStatic.Entrypoint != nil {
+		t.Fatalf("caller static manifest entrypoint = %+v, want nil", callerStatic)
 	}
 
 	writeConfig(`
@@ -5874,8 +5874,8 @@ func TestManagedCacheSourcesLockRecordsReleaseMetadataArchives(t *testing.T) {
 			if len(entry.StaticManifest.Artifacts) != 0 {
 				t.Fatalf("lock static manifest artifacts = %+v, want nil", entry.StaticManifest.Artifacts)
 			}
-			if entry.StaticManifest.Entrypoint == nil || entry.StaticManifest.Entrypoint.ArtifactPath != staticValidationEntrypointPlaceholder {
-				t.Fatalf("lock static manifest entrypoint = %+v, want placeholder", entry.StaticManifest.Entrypoint)
+			if entry.StaticManifest.Entrypoint != nil {
+				t.Fatalf("lock static manifest entrypoint = %+v, want nil", entry.StaticManifest.Entrypoint)
 			}
 			wantCurrentSHA := hex.EncodeToString(currentArchiveSum[:])
 			wantExtraSHA := hex.EncodeToString(extraArchiveSum[:])
@@ -5903,8 +5903,8 @@ func TestManagedCacheSourcesLockRecordsReleaseMetadataArchives(t *testing.T) {
 			if len(readBackManifest.Artifacts) != 0 {
 				t.Fatalf("readBack static manifest artifacts = %+v, want nil", readBackManifest.Artifacts)
 			}
-			if readBackManifest.Entrypoint == nil || readBackManifest.Entrypoint.ArtifactPath != staticValidationEntrypointPlaceholder {
-				t.Fatalf("readBack static manifest entrypoint = %+v, want placeholder", readBackManifest.Entrypoint)
+			if readBackManifest.Entrypoint != nil {
+				t.Fatalf("readBack static manifest entrypoint = %+v, want nil", readBackManifest.Entrypoint)
 			}
 			if got := readBack.Caches["session"].Archives[providerpkg.CurrentPlatformString()].SHA256; got != wantCurrentSHA {
 				t.Fatalf("readBack current-platform SHA256 = %q, want %q", got, wantCurrentSHA)

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -3402,11 +3402,8 @@ func TestPortableStaticValidationManifestProjectsPlatformNeutralRuntimeFields(t 
 	if len(darwinProjected.Artifacts) != 0 {
 		t.Fatalf("projected artifacts = %+v, want nil", darwinProjected.Artifacts)
 	}
-	if darwinProjected.Entrypoint == nil || darwinProjected.Entrypoint.ArtifactPath != staticValidationEntrypointPlaceholder {
-		t.Fatalf("projected entrypoint = %+v, want placeholder", darwinProjected.Entrypoint)
-	}
-	if len(darwinProjected.Entrypoint.Args) != 0 {
-		t.Fatalf("projected entrypoint args = %+v, want nil", darwinProjected.Entrypoint.Args)
+	if darwinProjected.Entrypoint != nil {
+		t.Fatalf("projected entrypoint = %+v, want nil", darwinProjected.Entrypoint)
 	}
 	if darwinProjected.Spec.Surfaces.OpenAPI.Document != "openapi.yaml" {
 		t.Fatalf("projected OpenAPI document = %q, want openapi.yaml", darwinProjected.Spec.Surfaces.OpenAPI.Document)
@@ -3422,7 +3419,7 @@ func TestPortableStaticValidationManifestProjectsPlatformNeutralRuntimeFields(t 
 	if !bytes.Equal(darwinJSON, linuxJSON) {
 		t.Fatalf("projected manifests differ:\ndarwin: %s\nlinux: %s", darwinJSON, linuxJSON)
 	}
-	if darwinManifest.Entrypoint.ArtifactPath == staticValidationEntrypointPlaceholder || len(darwinManifest.Artifacts) == 0 {
+	if len(darwinManifest.Artifacts) == 0 {
 		t.Fatal("portableStaticValidationManifest mutated source manifest")
 	}
 
@@ -3568,24 +3565,24 @@ func TestAttachStaticValidationMetadataProjectsPortableArchiveBackedSources(t *t
 		if len(staticManifest.Artifacts) != 0 {
 			t.Fatalf("%s artifacts = %+v, want nil", name, staticManifest.Artifacts)
 		}
-		if staticManifest.Entrypoint == nil || staticManifest.Entrypoint.ArtifactPath != staticValidationEntrypointPlaceholder {
-			t.Fatalf("%s entrypoint = %+v, want placeholder", name, staticManifest.Entrypoint)
+		if staticManifest.Entrypoint != nil {
+			t.Fatalf("%s entrypoint = %+v, want nil", name, staticManifest.Entrypoint)
 		}
 	}
 	agentManifest := lock.Agents["agentSnapshot"].StaticManifest
 	if len(agentManifest.Artifacts) != 0 {
 		t.Fatalf("agentSnapshot artifacts = %+v, want nil", agentManifest.Artifacts)
 	}
-	if agentManifest.Entrypoint == nil || agentManifest.Entrypoint.ArtifactPath != staticValidationEntrypointPlaceholder {
-		t.Fatalf("agentSnapshot entrypoint = %+v, want placeholder", agentManifest.Entrypoint)
+	if agentManifest.Entrypoint != nil {
+		t.Fatalf("agentSnapshot entrypoint = %+v, want nil", agentManifest.Entrypoint)
 	}
 	for _, name := range []string{"local", "gitSource", "gitSnapshotMissingSourceRef", "gitSnapshotSourceMaterialization", "gitSnapshotNoArchives", "gitSnapshotWrongSourceRefType"} {
 		staticManifest := lock.Providers[name].StaticManifest
 		if len(staticManifest.Artifacts) != 1 {
 			t.Fatalf("%s artifacts = %+v, want preserved runtime artifact", name, staticManifest.Artifacts)
 		}
-		if staticManifest.Entrypoint == nil || staticManifest.Entrypoint.ArtifactPath == staticValidationEntrypointPlaceholder {
-			t.Fatalf("%s entrypoint = %+v, want original entrypoint", name, staticManifest.Entrypoint)
+		if staticManifest.Entrypoint == nil {
+			t.Fatalf("%s entrypoint = nil, want original entrypoint", name)
 		}
 	}
 }
@@ -3668,8 +3665,8 @@ func TestArchiveBackedGitSnapshotStaticProjectionAvoidsAgentPlatformDrift(t *tes
 	if entry.StaticManifest == nil || len(entry.StaticManifest.Artifacts) != 0 {
 		t.Fatalf("static manifest artifacts = %+v, want nil", entry.StaticManifest)
 	}
-	if entry.StaticManifest.Entrypoint == nil || entry.StaticManifest.Entrypoint.ArtifactPath != staticValidationEntrypointPlaceholder {
-		t.Fatalf("static manifest entrypoint = %+v, want placeholder", entry.StaticManifest.Entrypoint)
+	if entry.StaticManifest.Entrypoint != nil {
+		t.Fatalf("static manifest entrypoint = %+v, want nil", entry.StaticManifest.Entrypoint)
 	}
 
 	lockPath := filepath.Join(t.TempDir(), LockfileName)
@@ -3684,8 +3681,8 @@ func TestArchiveBackedGitSnapshotStaticProjectionAvoidsAgentPlatformDrift(t *tes
 	if readBackManifest == nil || len(readBackManifest.Artifacts) != 0 {
 		t.Fatalf("read-back static manifest artifacts = %+v, want nil", readBackManifest)
 	}
-	if readBackManifest.Entrypoint == nil || readBackManifest.Entrypoint.ArtifactPath != staticValidationEntrypointPlaceholder {
-		t.Fatalf("read-back static manifest entrypoint = %+v, want placeholder", readBackManifest.Entrypoint)
+	if readBackManifest.Entrypoint != nil {
+		t.Fatalf("read-back static manifest entrypoint = %+v, want nil", readBackManifest.Entrypoint)
 	}
 }
 

--- a/gestaltd/internal/operator/release_metadata.go
+++ b/gestaltd/internal/operator/release_metadata.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/internal/config"
-	"github.com/valon-technologies/gestalt/server/internal/staticvalidation"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/apps/providerpkg"
 	"github.com/valon-technologies/gestalt/server/services/apps/source"
@@ -188,8 +187,8 @@ func validateProviderReleaseStaticValidation(metadata *providerReleaseMetadata) 
 		if len(static.Manifest.Artifacts) != 0 {
 			return fmt.Errorf("provider release staticValidation.manifest must not include platform artifacts")
 		}
-		if static.Manifest.Entrypoint != nil && static.Manifest.Entrypoint.ArtifactPath != staticvalidation.EntrypointPlaceholder {
-			return fmt.Errorf("provider release staticValidation.manifest entrypoint artifactPath must be %q", staticvalidation.EntrypointPlaceholder)
+		if static.Manifest.Entrypoint != nil {
+			return fmt.Errorf("provider release staticValidation.manifest must not include entrypoint")
 		}
 	}
 	if static.Catalog != nil {

--- a/gestaltd/internal/operator/release_metadata_test.go
+++ b/gestaltd/internal/operator/release_metadata_test.go
@@ -84,18 +84,6 @@ func TestDecodeProviderReleaseMetadataRejectsInvalidStaticValidation(t *testing.
 			wantErr: "staticValidation.manifest must not include platform artifacts",
 		},
 		{
-			name: "static manifest entrypoint placeholder",
-			block: ptr(`
-  manifest:
-    kind: app
-    source: github.com/acme/providers/provider
-    version: 1.2.3
-    entrypoint:
-      artifactPath: static-validation-placeholder
-    spec: {}`),
-			wantErr: "staticValidation.manifest must not include entrypoint",
-		},
-		{
 			name: "static manifest entrypoint",
 			block: ptr(`
   manifest:

--- a/gestaltd/internal/operator/release_metadata_test.go
+++ b/gestaltd/internal/operator/release_metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/valon-technologies/gestalt/server/internal/staticvalidation"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 )
 
@@ -27,8 +26,6 @@ staticValidation:
     kind: app
     source: github.com/acme/providers/provider
     version: 1.2.3
-    entrypoint:
-      artifactPath: static-validation-placeholder
     spec: {}
   catalog:
     name: provider
@@ -44,11 +41,11 @@ staticValidation:
 	if metadata.StaticValidation == nil {
 		t.Fatal("StaticValidation = nil, want decoded metadata")
 	}
-	if metadata.StaticValidation.Manifest == nil || metadata.StaticValidation.Manifest.Entrypoint == nil {
-		t.Fatalf("static manifest = %+v, want entrypoint", metadata.StaticValidation.Manifest)
+	if metadata.StaticValidation.Manifest == nil {
+		t.Fatalf("static manifest = %+v, want manifest", metadata.StaticValidation.Manifest)
 	}
-	if got := metadata.StaticValidation.Manifest.Entrypoint.ArtifactPath; got != staticvalidation.EntrypointPlaceholder {
-		t.Fatalf("static entrypoint artifactPath = %q, want %q", got, staticvalidation.EntrypointPlaceholder)
+	if metadata.StaticValidation.Manifest.Entrypoint != nil {
+		t.Fatalf("static manifest entrypoint = %+v, want nil", metadata.StaticValidation.Manifest.Entrypoint)
 	}
 	if metadata.StaticValidation.Catalog == nil || len(metadata.StaticValidation.Catalog.Operations) != 1 {
 		t.Fatalf("static catalog = %+v, want one operation", metadata.StaticValidation.Catalog)
@@ -85,6 +82,30 @@ func TestDecodeProviderReleaseMetadataRejectsInvalidStaticValidation(t *testing.
       artifactPath: bin/provider
     spec: {}`),
 			wantErr: "staticValidation.manifest must not include platform artifacts",
+		},
+		{
+			name: "static manifest entrypoint placeholder",
+			block: ptr(`
+  manifest:
+    kind: app
+    source: github.com/acme/providers/provider
+    version: 1.2.3
+    entrypoint:
+      artifactPath: static-validation-placeholder
+    spec: {}`),
+			wantErr: "staticValidation.manifest must not include entrypoint",
+		},
+		{
+			name: "static manifest entrypoint",
+			block: ptr(`
+  manifest:
+    kind: app
+    source: github.com/acme/providers/provider
+    version: 1.2.3
+    entrypoint:
+      artifactPath: bin/provider
+    spec: {}`),
+			wantErr: "staticValidation.manifest must not include entrypoint",
 		},
 		{
 			name: "session-only flag without metadata",
@@ -147,9 +168,6 @@ func defaultProviderReleaseStaticValidationForTest(metadata *providerReleaseMeta
 		Source:  strings.TrimSpace(metadata.Package),
 		Version: strings.TrimSpace(metadata.Version),
 		Spec:    &providermanifestv1.Spec{},
-	}
-	if metadata.Runtime == providerReleaseRuntimeExecutable {
-		manifest.Entrypoint = &providermanifestv1.Entrypoint{ArtifactPath: staticvalidation.EntrypointPlaceholder}
 	}
 	return &providerReleaseStaticValidationData{Manifest: manifest}
 }

--- a/gestaltd/internal/operator/testmain_test.go
+++ b/gestaltd/internal/operator/testmain_test.go
@@ -200,10 +200,7 @@ func writeProviderReleaseMetadata(dir string, manifest *providermanifestv1.Manif
 				"kind":    manifest.Kind,
 				"source":  manifest.Source,
 				"version": manifest.Version,
-				"entrypoint": map[string]any{
-					"artifactPath": staticValidationEntrypointPlaceholder,
-				},
-				"spec": map[string]any{},
+				"spec":    map[string]any{},
 			},
 		},
 	}

--- a/gestaltd/internal/staticvalidation/manifest.go
+++ b/gestaltd/internal/staticvalidation/manifest.go
@@ -8,8 +8,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/apps/packageio"
 )
 
-const EntrypointPlaceholder = "static-validation-placeholder"
-
 func ProjectManifest(manifest *providermanifestv1.Manifest, manifestPath string, platformNeutral bool) (*providermanifestv1.Manifest, error) {
 	if manifest == nil {
 		return nil, nil
@@ -20,9 +18,7 @@ func ProjectManifest(manifest *providermanifestv1.Manifest, manifestPath string,
 			return nil, err
 		}
 		cloned.Artifacts = nil
-		if cloned.Entrypoint != nil {
-			cloned.Entrypoint = &providermanifestv1.Entrypoint{ArtifactPath: EntrypointPlaceholder}
-		}
+		cloned.Entrypoint = nil
 		return RelativizeManifest(cloned, manifestPath), nil
 	}
 	return RelativizeManifest(manifest, manifestPath), nil


### PR DESCRIPTION
## Summary

Removes the `static-validation-placeholder` sentinel from platform-neutral static manifests and release metadata.

`staticvalidation.ProjectManifest` now clears `entrypoint` when projecting archive-backed providers for locks and `provider release`, instead of writing a fake `artifactPath`. Release metadata validation rejects any `staticValidation.manifest.entrypoint`, including legacy placeholder values, so static metadata cannot carry platform-specific binary paths.

Committed lock `manifest` entries will drop `entrypoint` the next time downstream repos run `gestaltd lock`. Republishing existing `provider-release.yaml` assets and refreshing those lockfiles is a separate follow-up.

## Runtime

`gestaltd provider release` embeds a platform-neutral static manifest with no `entrypoint`. Decode of remote `provider-release.yaml` fails if `staticValidation.manifest` includes `entrypoint` (real path or placeholder).

`gestaltd lock` writes the same shape into committed lock `manifest` fields for archive-backed and git-snapshot providers. Static config and catalog validation still use that manifest plus lock `archives`; install continues to resolve binaries from per-platform archive digests.


Made with [Cursor](https://cursor.com)