### PR TITLE
Honor agent turn create timeouts

### DIFF
--- a/gestaltd/services/agents/client.go
+++ b/gestaltd/services/agents/client.go
@@ -145,7 +145,7 @@ func (r *remoteAgent) UpdateSession(ctx context.Context, req *proto.UpdateAgentP
 }
 
 func (r *remoteAgent) CreateTurn(ctx context.Context, req *proto.CreateAgentProviderTurnRequest) (*coreagent.Turn, error) {
-	ctx, cancel := runtimehost.ProviderWorkflowAgentCallContext(ctx)
+	ctx, cancel := runtimehost.ProviderAgentTurnCreateContext(ctx, req.GetTimeoutSeconds())
 	defer cancel()
 	providerReq := cloneAgentRequest(req, &proto.CreateAgentProviderTurnRequest{})
 	providerReq.InvocationToken = appaccess.InvocationTokenFromContext(ctx)

--- a/gestaltd/services/agents/client_test.go
+++ b/gestaltd/services/agents/client_test.go
@@ -246,8 +246,10 @@ func TestRemoteAgentWorkflowAgentTurnCallsPreserveMarkedDeadline(t *testing.T) {
 func TestRemoteAgentTurnCallsKeepProviderTimeoutWithoutWorkflowMarker(t *testing.T) {
 	t.Parallel()
 
+	const requestTimeoutSeconds int32 = 120
 	parentDeadline := time.Now().Add(2 * runtimehost.ProviderSessionCreateTimeout)
 	var createTurnRemaining time.Duration
+	var createTurnWithTimeoutRemaining time.Duration
 	var getTurnRemaining time.Duration
 	var getSessionRemaining time.Duration
 	agent := &remoteAgent{
@@ -257,7 +259,11 @@ func TestRemoteAgentTurnCallsKeepProviderTimeoutWithoutWorkflowMarker(t *testing
 				if !ok {
 					t.Fatal("CreateTurn context has no deadline")
 				}
-				createTurnRemaining = time.Until(deadline)
+				if req.GetTimeoutSeconds() > 0 {
+					createTurnWithTimeoutRemaining = time.Until(deadline)
+				} else {
+					createTurnRemaining = time.Until(deadline)
+				}
 				return &proto.AgentTurn{Id: "turn-1", SessionId: req.GetSessionId()}, nil
 			},
 			getTurn: func(ctx context.Context, req *proto.GetAgentProviderTurnRequest, _ ...grpc.CallOption) (*proto.AgentTurn, error) {
@@ -284,6 +290,12 @@ func TestRemoteAgentTurnCallsKeepProviderTimeoutWithoutWorkflowMarker(t *testing
 	if _, err := agent.CreateTurn(parent, &proto.CreateAgentProviderTurnRequest{SessionId: "session-1"}); err != nil {
 		t.Fatalf("CreateTurn: %v", err)
 	}
+	if _, err := agent.CreateTurn(parent, &proto.CreateAgentProviderTurnRequest{
+		SessionId:      "session-2",
+		TimeoutSeconds: requestTimeoutSeconds,
+	}); err != nil {
+		t.Fatalf("CreateTurn with timeout: %v", err)
+	}
 	if _, err := agent.GetTurn(parent, &proto.GetAgentProviderTurnRequest{TurnId: "turn-1"}); err != nil {
 		t.Fatalf("GetTurn: %v", err)
 	}
@@ -299,6 +311,13 @@ func TestRemoteAgentTurnCallsKeepProviderTimeoutWithoutWorkflowMarker(t *testing
 		if remaining > runtimehost.ProviderRPCTimeout {
 			t.Fatalf("%s remaining deadline = %s, want at most provider RPC timeout %s", name, remaining, runtimehost.ProviderRPCTimeout)
 		}
+	}
+	if createTurnWithTimeoutRemaining <= runtimehost.ProviderRPCTimeout {
+		t.Fatalf("CreateTurn with timeout remaining deadline = %s, want above provider RPC timeout %s", createTurnWithTimeoutRemaining, runtimehost.ProviderRPCTimeout)
+	}
+	requestTimeout := time.Duration(requestTimeoutSeconds) * time.Second
+	if createTurnWithTimeoutRemaining > requestTimeout {
+		t.Fatalf("CreateTurn with timeout remaining deadline = %s, want at most request timeout %s", createTurnWithTimeoutRemaining, requestTimeout)
 	}
 }
 

--- a/gestaltd/services/runtimehost/runtime_client.go
+++ b/gestaltd/services/runtimehost/runtime_client.go
@@ -184,6 +184,25 @@ func ProviderWorkflowAgentCallContext(parent context.Context) (context.Context, 
 	return ProviderCallContext(parent)
 }
 
+// ProviderAgentTurnCreateContext returns a context for agent turn creation RPCs.
+// Workflow-owned calls keep the workflow deadline; direct app calls may opt into
+// a longer turn deadline through CreateTurn.timeout_seconds.
+func ProviderAgentTurnCreateContext(parent context.Context, timeoutSeconds int32) (context.Context, context.CancelFunc) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	if marked, _ := parent.Value(workflowAgentProviderDeadlineKey{}).(bool); marked {
+		if _, ok := parent.Deadline(); ok {
+			return context.WithCancel(parent)
+		}
+		return ProviderCallContext(parent)
+	}
+	if timeoutSeconds > 0 {
+		return context.WithTimeout(parent, time.Duration(timeoutSeconds)*time.Second)
+	}
+	return ProviderCallContext(parent)
+}
+
 // ProviderSessionCreateContext returns a child context for agent CreateSession RPCs.
 // It preserves caller deadlines when present and otherwise applies a bounded fallback.
 func ProviderSessionCreateContext(parent context.Context) (context.Context, context.CancelFunc) {

--- a/gestaltd/services/runtimehost/runtime_client_test.go
+++ b/gestaltd/services/runtimehost/runtime_client_test.go
@@ -288,7 +288,8 @@ func TestProviderWorkflowAgentCallContextRequiresMarkerForParentDeadline(t *test
 func TestProviderWorkflowAgentCallContextFallsBackWithoutParentDeadline(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := ProviderWorkflowAgentCallContext(WithWorkflowAgentProviderDeadline(context.Background()))
+	markedParent := WithWorkflowAgentProviderDeadline(context.Background())
+	ctx, cancel := ProviderWorkflowAgentCallContext(markedParent)
 	defer cancel()
 	deadline, ok := ctx.Deadline()
 	if !ok {
@@ -296,6 +297,16 @@ func TestProviderWorkflowAgentCallContextFallsBackWithoutParentDeadline(t *testi
 	}
 	if remaining := time.Until(deadline); remaining > ProviderRPCTimeout {
 		t.Fatalf("remaining deadline = %s, want at most provider RPC timeout %s", remaining, ProviderRPCTimeout)
+	}
+
+	turnCtx, turnCancel := ProviderAgentTurnCreateContext(markedParent, int32((2 * ProviderRPCTimeout).Seconds()))
+	defer turnCancel()
+	turnDeadline, ok := turnCtx.Deadline()
+	if !ok {
+		t.Fatal("workflow agent turn create context has no deadline")
+	}
+	if remaining := time.Until(turnDeadline); remaining > ProviderRPCTimeout {
+		t.Fatalf("turn create remaining deadline = %s, want at most provider RPC timeout %s", remaining, ProviderRPCTimeout)
 	}
 }
 


### PR DESCRIPTION
## Summary

Agent turn creation now uses the caller's explicit turn timeout when deciding how long the provider RPC may run, instead of always falling back to the generic provider RPC timeout for app-originated turns.

Workflow-owned agent turns keep the existing marked workflow deadline behavior. Unmarked turn creation without an explicit timeout still uses the normal provider RPC timeout, so short provider calls remain bounded by the existing default.

This lets direct app calls and workflow agent steps share the same timeout contract through `CreateAgentProviderTurnRequest.timeout_seconds`.

## Interfaces

```proto
message CreateAgentProviderTurnRequest {
  int32 timeout_seconds = 18;
}
```

```go
func ProviderAgentTurnCreateContext(parent context.Context, timeoutSeconds int32) (context.Context, context.CancelFunc)
```

## Runtime

`remoteAgent.CreateTurn` now builds its provider call context with `ProviderAgentTurnCreateContext`, passing through the request timeout. The helper preserves marked workflow deadlines first, applies a positive request timeout for direct turn creation, and otherwise falls back to `ProviderCallContext`.

The existing unmarked provider timeout test now also verifies the request-timeout path, so the behavior is covered without adding a separate test case.

## Test plan

- [x] `go test ./gestaltd/services/runtimehost ./gestaltd/services/agents`
