### PR TITLE
Honor agent turn create timeouts

### DIFF
--- a/gestaltd/services/agents/client.go
+++ b/gestaltd/services/agents/client.go
@@ -145,7 +145,7 @@ func (r *remoteAgent) UpdateSession(ctx context.Context, req *proto.UpdateAgentP
 }
 
 func (r *remoteAgent) CreateTurn(ctx context.Context, req *proto.CreateAgentProviderTurnRequest) (*coreagent.Turn, error) {
-	ctx, cancel := runtimehost.ProviderWorkflowAgentCallContext(ctx)
+	ctx, cancel := runtimehost.ProviderAgentTurnCreateContext(ctx, req.GetTimeoutSeconds())
 	defer cancel()
 	providerReq := cloneAgentRequest(req, &proto.CreateAgentProviderTurnRequest{})
 	providerReq.InvocationToken = appaccess.InvocationTokenFromContext(ctx)

--- a/gestaltd/services/agents/client_test.go
+++ b/gestaltd/services/agents/client_test.go
@@ -246,8 +246,10 @@ func TestRemoteAgentWorkflowAgentTurnCallsPreserveMarkedDeadline(t *testing.T) {
 func TestRemoteAgentTurnCallsKeepProviderTimeoutWithoutWorkflowMarker(t *testing.T) {
 	t.Parallel()
 
+	const requestTimeoutSeconds int32 = 120
 	parentDeadline := time.Now().Add(2 * runtimehost.ProviderSessionCreateTimeout)
 	var createTurnRemaining time.Duration
+	var createTurnWithTimeoutRemaining time.Duration
 	var getTurnRemaining time.Duration
 	var getSessionRemaining time.Duration
 	agent := &remoteAgent{
@@ -257,7 +259,14 @@ func TestRemoteAgentTurnCallsKeepProviderTimeoutWithoutWorkflowMarker(t *testing
 				if !ok {
 					t.Fatal("CreateTurn context has no deadline")
 				}
-				createTurnRemaining = time.Until(deadline)
+				if req.GetTimeoutSeconds() > 0 {
+					if req.GetTimeoutSeconds() != requestTimeoutSeconds {
+						t.Fatalf("CreateTurn timeout_seconds = %d, want %d", req.GetTimeoutSeconds(), requestTimeoutSeconds)
+					}
+					createTurnWithTimeoutRemaining = time.Until(deadline)
+				} else {
+					createTurnRemaining = time.Until(deadline)
+				}
 				return &proto.AgentTurn{Id: "turn-1", SessionId: req.GetSessionId()}, nil
 			},
 			getTurn: func(ctx context.Context, req *proto.GetAgentProviderTurnRequest, _ ...grpc.CallOption) (*proto.AgentTurn, error) {
@@ -284,6 +293,12 @@ func TestRemoteAgentTurnCallsKeepProviderTimeoutWithoutWorkflowMarker(t *testing
 	if _, err := agent.CreateTurn(parent, &proto.CreateAgentProviderTurnRequest{SessionId: "session-1"}); err != nil {
 		t.Fatalf("CreateTurn: %v", err)
 	}
+	if _, err := agent.CreateTurn(parent, &proto.CreateAgentProviderTurnRequest{
+		SessionId:      "session-2",
+		TimeoutSeconds: requestTimeoutSeconds,
+	}); err != nil {
+		t.Fatalf("CreateTurn with timeout: %v", err)
+	}
 	if _, err := agent.GetTurn(parent, &proto.GetAgentProviderTurnRequest{TurnId: "turn-1"}); err != nil {
 		t.Fatalf("GetTurn: %v", err)
 	}
@@ -299,6 +314,13 @@ func TestRemoteAgentTurnCallsKeepProviderTimeoutWithoutWorkflowMarker(t *testing
 		if remaining > runtimehost.ProviderRPCTimeout {
 			t.Fatalf("%s remaining deadline = %s, want at most provider RPC timeout %s", name, remaining, runtimehost.ProviderRPCTimeout)
 		}
+	}
+	if createTurnWithTimeoutRemaining <= runtimehost.ProviderRPCTimeout {
+		t.Fatalf("CreateTurn with timeout remaining deadline = %s, want above provider RPC timeout %s", createTurnWithTimeoutRemaining, runtimehost.ProviderRPCTimeout)
+	}
+	requestTimeout := time.Duration(requestTimeoutSeconds) * time.Second
+	if createTurnWithTimeoutRemaining > requestTimeout {
+		t.Fatalf("CreateTurn with timeout remaining deadline = %s, want at most request timeout %s", createTurnWithTimeoutRemaining, requestTimeout)
 	}
 }
 

--- a/gestaltd/services/runtimehost/runtime_client.go
+++ b/gestaltd/services/runtimehost/runtime_client.go
@@ -184,6 +184,25 @@ func ProviderWorkflowAgentCallContext(parent context.Context) (context.Context, 
 	return ProviderCallContext(parent)
 }
 
+// ProviderAgentTurnCreateContext returns a context for agent turn creation RPCs.
+// Workflow-owned calls keep the workflow deadline; direct app calls may opt into
+// a longer turn deadline through CreateTurn.timeout_seconds.
+func ProviderAgentTurnCreateContext(parent context.Context, timeoutSeconds int32) (context.Context, context.CancelFunc) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	if marked, _ := parent.Value(workflowAgentProviderDeadlineKey{}).(bool); marked {
+		if _, ok := parent.Deadline(); ok {
+			return context.WithCancel(parent)
+		}
+		return ProviderCallContext(parent)
+	}
+	if timeoutSeconds > 0 {
+		return context.WithTimeout(parent, time.Duration(timeoutSeconds)*time.Second)
+	}
+	return ProviderCallContext(parent)
+}
+
 // ProviderSessionCreateContext returns a child context for agent CreateSession RPCs.
 // It preserves caller deadlines when present and otherwise applies a bounded fallback.
 func ProviderSessionCreateContext(parent context.Context) (context.Context, context.CancelFunc) {

--- a/gestaltd/services/runtimehost/runtime_client_test.go
+++ b/gestaltd/services/runtimehost/runtime_client_test.go
@@ -277,6 +277,15 @@ func TestProviderWorkflowAgentCallContextRequiresMarkerForParentDeadline(t *test
 	if !markedDeadline.Equal(parentDeadline) {
 		t.Fatalf("marked deadline = %s, want parent deadline %s", markedDeadline, parentDeadline)
 	}
+	markedTurn, markedTurnCancel := ProviderAgentTurnCreateContext(markedParent, int32((2 * ProviderRPCTimeout).Seconds()))
+	defer markedTurnCancel()
+	markedTurnDeadline, ok := markedTurn.Deadline()
+	if !ok {
+		t.Fatal("marked turn create context has no deadline")
+	}
+	if !markedTurnDeadline.Equal(parentDeadline) {
+		t.Fatalf("marked turn create deadline = %s, want parent deadline %s", markedTurnDeadline, parentDeadline)
+	}
 	parentCancel()
 	select {
 	case <-marked.Done():
@@ -296,6 +305,16 @@ func TestProviderWorkflowAgentCallContextFallsBackWithoutParentDeadline(t *testi
 	}
 	if remaining := time.Until(deadline); remaining > ProviderRPCTimeout {
 		t.Fatalf("remaining deadline = %s, want at most provider RPC timeout %s", remaining, ProviderRPCTimeout)
+	}
+
+	markedNoDeadline, markedNoDeadlineCancel := ProviderAgentTurnCreateContext(WithWorkflowAgentProviderDeadline(context.Background()), int32((2 * ProviderRPCTimeout).Seconds()))
+	defer markedNoDeadlineCancel()
+	markedNoDeadlineDeadline, ok := markedNoDeadline.Deadline()
+	if !ok {
+		t.Fatal("marked without parent deadline turn create context has no deadline")
+	}
+	if remaining := time.Until(markedNoDeadlineDeadline); remaining > ProviderRPCTimeout {
+		t.Fatalf("marked without parent deadline remaining = %s, want at most provider RPC timeout %s", remaining, ProviderRPCTimeout)
 	}
 }
 

--- a/sdk/go/workflow/workflow_test.go
+++ b/sdk/go/workflow/workflow_test.go
@@ -122,7 +122,8 @@ func TestExecutorInvokesAgentStepWithWorkflowRunAs(t *testing.T) {
 			AuthSource:          "config",
 		},
 		Target: &gestalt.BoundWorkflowTarget{Steps: []gestalt.WorkflowStep{{
-			ID: "review",
+			ID:             "review",
+			TimeoutSeconds: 90,
 			Agent: &gestalt.WorkflowStepAgentTurn{
 				Provider: "claude",
 				Model:    "default",
@@ -145,6 +146,9 @@ func TestExecutorInvokesAgentStepWithWorkflowRunAs(t *testing.T) {
 	}
 	if agent.turn.SessionID != "session-1" || agent.turn.Messages[0].Text != "review Ada" {
 		t.Fatalf("turn = %#v", agent.turn)
+	}
+	if agent.turn.TimeoutSeconds != 90 {
+		t.Fatalf("turn timeout seconds = %d, want 90", agent.turn.TimeoutSeconds)
 	}
 	runAs := agent.turnWorkflow["runAs"].(map[string]any)
 	if runAs["id"] != "service_account:workflow-runner" {


### PR DESCRIPTION
## Summary

Agent turn creation now uses the existing `CreateAgentProviderTurnRequest.timeout_seconds` budget when deciding how long a direct provider `CreateTurn` RPC may run.

Workflow-marked agent calls keep their existing deadline behavior: marked calls with a parent deadline preserve that parent deadline, and marked calls without one fall back to the generic provider RPC timeout.

This replaces the closed `hugh/agent-turn-create-timeout` branch from a clean `origin/main` base, keeping the already-published timeout interface and tightening the helper and workflow coverage around it.

## Interfaces

```proto
message CreateAgentProviderTurnRequest {
  int32 timeout_seconds = 18;
}
```

```go
func ProviderAgentTurnCreateContext(parent context.Context, timeoutSeconds int32) (context.Context, context.CancelFunc)
```

## Runtime

`remoteAgent.CreateTurn` now builds its provider call context with `ProviderAgentTurnCreateContext`, passing the request timeout through to the runtime helper.

The helper applies positive request timeouts only for unmarked direct turn creation. Workflow-marked calls continue to use the existing workflow-agent deadline semantics so workflow execution remains bounded by the workflow context rather than by a second request-derived deadline.

The existing Go workflow executor test now also asserts that workflow step `timeoutSeconds` is passed into `AgentCreateTurn`, which covers the SDK step invocation path without adding app-specific fixtures.

## Test plan

- [x] `go test ./gestaltd/services/runtimehost ./gestaltd/services/agents ./sdk/go/workflow`