### PR TITLE
Make agent CreateTurn asynchronous

### DIFF
--- a/docs/content/providers/agent.mdx
+++ b/docs/content/providers/agent.mdx
@@ -128,6 +128,7 @@ Create a turn inside that session:
 ```json
 {
   "model": "fast",
+  "timeoutSeconds": 120,
   "messages": [
     {
       "role": "user",
@@ -167,8 +168,8 @@ tool_result | image_ref`.
 Use `gestalt agent` for an interactive session:
 
 ```sh
-gestalt agent
-gestalt agent resume <session-id>
+gestalt agent --timeout-seconds 120
+gestalt agent resume <session-id> --timeout-seconds 120
 ```
 
 Use the session and turn subcommands for automation:
@@ -180,6 +181,7 @@ gestalt agent sessions get <session-id>
 gestalt agent sessions update <session-id> --state archived
 
 gestalt agent turns create <session-id> \
+  --timeout-seconds 120 \
   --message "Summarize the latest roadmap risk."
 gestalt agent turns list <session-id> --status succeeded
 gestalt agent turns get <turn-id>
@@ -195,6 +197,7 @@ For structured input, pipe JSON into `--input -`:
 cat <<'JSON' | gestalt --format json agent turns create <session-id> --input -
 {
   "model": "fast",
+  "timeoutSeconds": 120,
   "messages": [
     {
       "role": "user",
@@ -238,6 +241,7 @@ Provider code can invoke agents through the SDK `Agent` capability:
 
         turn, err := agents.CreateTurn(ctx, gestalt.AgentCreateTurn{
             SessionID: session.GetId(),
+            TimeoutSeconds: 120,
             Messages: []gestalt.AgentMessage{{
                 Role: "user",
                 Text: "Summarize the latest roadmap risk.",
@@ -263,6 +267,7 @@ Provider code can invoke agents through the SDK `Agent` capability:
             turn = agents.create_turn(
                 AgentCreateTurn(
                     session_id=session.id,
+                    timeout_seconds=120,
                     messages=[
                         AgentMessage(
                             role="user",
@@ -290,6 +295,7 @@ Provider code can invoke agents through the SDK `Agent` capability:
 
         let turn = agents.create_turn(AgentCreateTurn {
             session_id: session.id,
+            timeout_seconds: 120,
             messages: vec![AgentMessage {
                 role: "user".into(),
                 text: "Summarize the latest roadmap risk.".into(),
@@ -313,6 +319,7 @@ Provider code can invoke agents through the SDK `Agent` capability:
       });
       const turn = await agents.createTurn({
         sessionId: session.id,
+        timeoutSeconds: 120,
         messages: [
           {
             role: "user",
@@ -343,6 +350,7 @@ workflows:
       target:
         steps:
           - id: summarize
+            timeout: 120s
             agent:
               provider: simple
               model: fast
@@ -368,6 +376,7 @@ gestalt workflow triggers create \
   "steps": [
     {
       "id": "summarize",
+      "timeoutSeconds": 120,
       "agent": {
         "provider": "simple",
         "model": "fast",
@@ -455,9 +464,11 @@ provider.
 ### Execution model
 
 `CreateTurn` should persist the turn and return quickly, usually in `RUNNING` or
-`PENDING`. Long-running model and tool work should continue in the background.
-Callers use `GetTurn`, `ListTurnEvents`, and `ListInteractions` to observe
-progress or resolve pending human input.
+`PENDING`. `timeoutSeconds` is a required positive execution budget for the
+provider-owned turn; it does not extend the `CreateTurn` RPC deadline.
+Long-running model and tool work should continue in the background. Callers use
+`GetTurn`, `ListTurnEvents`, and `ListInteractions` to observe progress or
+resolve pending human input.
 
 If your provider needs durable state, configure
 `providers.agent.<name>.indexeddb` and store canonical session and turn records

--- a/docs/content/providers/agent.mdx
+++ b/docs/content/providers/agent.mdx
@@ -464,8 +464,10 @@ provider.
 ### Execution model
 
 `CreateTurn` should persist the turn and return quickly, usually in `RUNNING` or
-`PENDING`. `timeoutSeconds` is a required positive execution budget for the
-provider-owned turn; it does not extend the `CreateTurn` RPC deadline.
+`PENDING`. `timeoutSeconds` is an optional positive execution budget for the
+provider-owned turn. When omitted or zero, the provider chooses its own
+execution timeout, usually by delegating to the upstream model SDK default. The
+field does not extend the `CreateTurn` RPC deadline.
 Long-running model and tool work should continue in the background. Callers use
 `GetTurn`, `ListTurnEvents`, and `ListInteractions` to observe progress or
 resolve pending human input.

--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -696,6 +696,10 @@ pub struct AgentArgs {
     /// Add a tool in app:operation form to each turn
     #[arg(long = "tool", value_parser = AgentToolArg::parse)]
     pub tools: Vec<AgentToolArg>,
+
+    /// Positive execution budget in seconds for each created turn
+    #[arg(long = "timeout-seconds", value_parser = clap::value_parser!(i32).range(1..))]
+    pub timeout_seconds: Option<i32>,
 }
 
 #[derive(Subcommand)]
@@ -751,6 +755,10 @@ pub struct AgentResumeArgs {
     /// Add a tool in app:operation form to each turn
     #[arg(long = "tool", value_parser = AgentToolArg::parse)]
     pub tools: Vec<AgentToolArg>,
+
+    /// Positive execution budget in seconds for each created turn
+    #[arg(long = "timeout-seconds", value_parser = clap::value_parser!(i32).range(1..))]
+    pub timeout_seconds: i32,
 }
 
 #[derive(Subcommand)]
@@ -1068,6 +1076,10 @@ pub struct AgentTurnCreateArgs {
     /// Idempotency key for safe retries
     #[arg(long = "idempotency-key")]
     pub idempotency_key: Option<String>,
+
+    /// Positive execution budget in seconds for the turn
+    #[arg(long = "timeout-seconds", value_parser = clap::value_parser!(i32).range(1..))]
+    pub timeout_seconds: Option<i32>,
 
     /// Load the JSON request body from a file (use "-" for stdin)
     #[arg(long = "input", alias = "request-file")]

--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -697,7 +697,7 @@ pub struct AgentArgs {
     #[arg(long = "tool", value_parser = AgentToolArg::parse)]
     pub tools: Vec<AgentToolArg>,
 
-    /// Positive execution budget in seconds for each created turn
+    /// Optional execution budget in seconds for each created turn
     #[arg(long = "timeout-seconds", value_parser = clap::value_parser!(i32).range(1..))]
     pub timeout_seconds: Option<i32>,
 }
@@ -756,9 +756,9 @@ pub struct AgentResumeArgs {
     #[arg(long = "tool", value_parser = AgentToolArg::parse)]
     pub tools: Vec<AgentToolArg>,
 
-    /// Positive execution budget in seconds for each created turn
+    /// Optional execution budget in seconds for each created turn
     #[arg(long = "timeout-seconds", value_parser = clap::value_parser!(i32).range(1..))]
-    pub timeout_seconds: i32,
+    pub timeout_seconds: Option<i32>,
 }
 
 #[derive(Subcommand)]
@@ -1077,7 +1077,7 @@ pub struct AgentTurnCreateArgs {
     #[arg(long = "idempotency-key")]
     pub idempotency_key: Option<String>,
 
-    /// Positive execution budget in seconds for the turn
+    /// Optional execution budget in seconds for the turn
     #[arg(long = "timeout-seconds", value_parser = clap::value_parser!(i32).range(1..))]
     pub timeout_seconds: Option<i32>,
 

--- a/gestalt/cli/src/commands/agents/requests.rs
+++ b/gestalt/cli/src/commands/agents/requests.rs
@@ -426,8 +426,6 @@ pub(crate) fn build_turn_create_body(args: &AgentTurnCreateArgs) -> Result<Value
             "timeoutSeconds".to_string(),
             Value::Number(timeout_seconds.into()),
         );
-    } else {
-        require_positive_timeout_seconds(&body)?;
     }
 
     let messages = build_messages(&args.system, &args.messages);
@@ -448,17 +446,17 @@ pub(crate) fn build_turn_create_body(args: &AgentTurnCreateArgs) -> Result<Value
     Ok(Value::Object(body))
 }
 
-fn require_positive_timeout_seconds(body: &Map<String, Value>) -> Result<()> {
-    let Some(value) = body.get("timeoutSeconds") else {
-        bail!("--timeout-seconds is required unless input sets timeoutSeconds");
-    };
-    if value.as_i64().is_some_and(|seconds| seconds > 0) {
-        return Ok(());
+fn validate_optional_timeout_seconds(body: &Map<String, Value>) -> Result<()> {
+    if let Some(value) = body.get("timeoutSeconds")
+        && !value.as_i64().is_some_and(|seconds| seconds >= 0)
+    {
+        bail!("timeoutSeconds must be a non-negative integer");
     }
-    bail!("timeoutSeconds must be a positive integer");
+    Ok(())
 }
 
 fn validate_turn_create_body(body: &Map<String, Value>) -> Result<()> {
+    validate_optional_timeout_seconds(body)?;
     let has_messages = body
         .get("messages")
         .and_then(Value::as_array)

--- a/gestalt/cli/src/commands/agents/requests.rs
+++ b/gestalt/cli/src/commands/agents/requests.rs
@@ -448,7 +448,7 @@ pub(crate) fn build_turn_create_body(args: &AgentTurnCreateArgs) -> Result<Value
 
 fn validate_optional_timeout_seconds(body: &Map<String, Value>) -> Result<()> {
     if let Some(value) = body.get("timeoutSeconds")
-        && !value.as_i64().is_some_and(|seconds| seconds >= 0)
+        && value.as_i64().is_none_or(|seconds| seconds < 0)
     {
         bail!("timeoutSeconds must be a non-negative integer");
     }

--- a/gestalt/cli/src/commands/agents/requests.rs
+++ b/gestalt/cli/src/commands/agents/requests.rs
@@ -421,6 +421,14 @@ pub(crate) fn build_turn_create_body(args: &AgentTurnCreateArgs) -> Result<Value
             Value::String(idempotency_key.to_string()),
         );
     }
+    if let Some(timeout_seconds) = args.timeout_seconds {
+        body.insert(
+            "timeoutSeconds".to_string(),
+            Value::Number(timeout_seconds.into()),
+        );
+    } else {
+        require_positive_timeout_seconds(&body)?;
+    }
 
     let messages = build_messages(&args.system, &args.messages);
     if !messages.is_empty() {
@@ -438,6 +446,16 @@ pub(crate) fn build_turn_create_body(args: &AgentTurnCreateArgs) -> Result<Value
 
     validate_turn_create_body(&body)?;
     Ok(Value::Object(body))
+}
+
+fn require_positive_timeout_seconds(body: &Map<String, Value>) -> Result<()> {
+    let Some(value) = body.get("timeoutSeconds") else {
+        bail!("--timeout-seconds is required unless input sets timeoutSeconds");
+    };
+    if value.as_i64().is_some_and(|seconds| seconds > 0) {
+        return Ok(());
+    }
+    bail!("timeoutSeconds must be a positive integer");
 }
 
 fn validate_turn_create_body(body: &Map<String, Value>) -> Result<()> {

--- a/gestalt/cli/src/commands/agents/shell.rs
+++ b/gestalt/cli/src/commands/agents/shell.rs
@@ -25,9 +25,6 @@ pub fn resume_interactive(client: &ApiClient, args: &AgentResumeArgs) -> Result<
 
 impl AgentShell {
     fn connect(client: &ApiClient, args: &AgentArgs) -> Result<Self> {
-        let timeout_seconds = args
-            .timeout_seconds
-            .context("--timeout-seconds is required for cloud agent turns")?;
         let session_args = AgentSessionCreateArgs {
             provider: args.provider.clone(),
             model: args.model.clone(),
@@ -42,7 +39,7 @@ impl AgentShell {
             model_override: args.model.clone(),
             system_messages: args.system.clone(),
             tools: args.tools.clone(),
-            timeout_seconds,
+            timeout_seconds: args.timeout_seconds,
             applied_system_messages: false,
         })
     }
@@ -111,7 +108,7 @@ impl AgentShell {
             messages,
             tools: self.tools.clone(),
             idempotency_key: None,
-            timeout_seconds: Some(self.timeout_seconds),
+            timeout_seconds: self.timeout_seconds,
             input: None,
         };
         let turn = super::requests::create_turn_info(client, &turn_args)?;
@@ -160,12 +157,15 @@ pub(crate) fn run_shell_interactive(
     }
 }
 
-fn print_resume_command(session_id: &str, timeout_seconds: i32) -> Result<()> {
+fn print_resume_command(session_id: &str, timeout_seconds: Option<i32>) -> Result<()> {
     let mut stdout = io::stdout().lock();
-    writeln!(
-        stdout,
-        "Resume with: gestalt agent resume {session_id} --timeout-seconds {timeout_seconds}"
-    )?;
+    match timeout_seconds {
+        Some(timeout_seconds) => writeln!(
+            stdout,
+            "Resume with: gestalt agent resume {session_id} --timeout-seconds {timeout_seconds}"
+        )?,
+        None => writeln!(stdout, "Resume with: gestalt agent resume {session_id}")?,
+    }
     Ok(())
 }
 
@@ -265,13 +265,14 @@ pub(crate) fn agent_tui_help_lines() -> Vec<String> {
 }
 
 pub(crate) fn agent_session_lines(shell: &AgentShell) -> Vec<String> {
-    vec![
-        format!("session {}", shell.session.id),
-        format!(
+    let resume_command = match shell.timeout_seconds {
+        Some(timeout_seconds) => format!(
             "resume command: gestalt agent resume {} --timeout-seconds {}",
-            shell.session.id, shell.timeout_seconds
+            shell.session.id, timeout_seconds
         ),
-    ]
+        None => format!("resume command: gestalt agent resume {}", shell.session.id),
+    };
+    vec![format!("session {}", shell.session.id), resume_command]
 }
 
 pub(crate) fn agent_model_lines(

--- a/gestalt/cli/src/commands/agents/shell.rs
+++ b/gestalt/cli/src/commands/agents/shell.rs
@@ -25,6 +25,9 @@ pub fn resume_interactive(client: &ApiClient, args: &AgentResumeArgs) -> Result<
 
 impl AgentShell {
     fn connect(client: &ApiClient, args: &AgentArgs) -> Result<Self> {
+        let timeout_seconds = args
+            .timeout_seconds
+            .context("--timeout-seconds is required for cloud agent turns")?;
         let session_args = AgentSessionCreateArgs {
             provider: args.provider.clone(),
             model: args.model.clone(),
@@ -39,6 +42,7 @@ impl AgentShell {
             model_override: args.model.clone(),
             system_messages: args.system.clone(),
             tools: args.tools.clone(),
+            timeout_seconds,
             applied_system_messages: false,
         })
     }
@@ -54,6 +58,7 @@ impl AgentShell {
             model_override: args.model.clone(),
             system_messages: args.system.clone(),
             tools: args.tools.clone(),
+            timeout_seconds: args.timeout_seconds,
             applied_system_messages: false,
         })
     }
@@ -106,6 +111,7 @@ impl AgentShell {
             messages,
             tools: self.tools.clone(),
             idempotency_key: None,
+            timeout_seconds: Some(self.timeout_seconds),
             input: None,
         };
         let turn = super::requests::create_turn_info(client, &turn_args)?;
@@ -121,10 +127,11 @@ pub(crate) fn run_shell_interactive(
     initial_messages: Vec<String>,
 ) -> Result<()> {
     let session_id = shell.session.id.clone();
+    let timeout_seconds = shell.timeout_seconds;
     if tui::can_run() {
         let result = tui::run_shell(client, shell, initial_messages);
         if result.is_ok() {
-            print_resume_command(&session_id)?;
+            print_resume_command(&session_id, timeout_seconds)?;
         }
         return result;
     }
@@ -139,7 +146,7 @@ pub(crate) fn run_shell_interactive(
 
     loop {
         let Some(line) = prompt_agent_message(&mut input)? else {
-            print_resume_command(&session_id)?;
+            print_resume_command(&session_id, timeout_seconds)?;
             return Ok(());
         };
         let trimmed = line.trim();
@@ -153,9 +160,12 @@ pub(crate) fn run_shell_interactive(
     }
 }
 
-fn print_resume_command(session_id: &str) -> Result<()> {
+fn print_resume_command(session_id: &str, timeout_seconds: i32) -> Result<()> {
     let mut stdout = io::stdout().lock();
-    writeln!(stdout, "Resume with: gestalt agent resume {session_id}")?;
+    writeln!(
+        stdout,
+        "Resume with: gestalt agent resume {session_id} --timeout-seconds {timeout_seconds}"
+    )?;
     Ok(())
 }
 
@@ -257,7 +267,10 @@ pub(crate) fn agent_tui_help_lines() -> Vec<String> {
 pub(crate) fn agent_session_lines(shell: &AgentShell) -> Vec<String> {
     vec![
         format!("session {}", shell.session.id),
-        format!("resume command: gestalt agent resume {}", shell.session.id),
+        format!(
+            "resume command: gestalt agent resume {} --timeout-seconds {}",
+            shell.session.id, shell.timeout_seconds
+        ),
     ]
 }
 

--- a/gestalt/cli/src/commands/agents/tui.rs
+++ b/gestalt/cli/src/commands/agents/tui.rs
@@ -641,6 +641,7 @@ impl TuiApp {
             messages,
             tools: self.shell.tools.clone(),
             idempotency_key: None,
+            timeout_seconds: Some(self.shell.timeout_seconds),
             input: None,
         };
         let (command_tx, command_rx) = mpsc::channel();

--- a/gestalt/cli/src/commands/agents/tui.rs
+++ b/gestalt/cli/src/commands/agents/tui.rs
@@ -641,7 +641,7 @@ impl TuiApp {
             messages,
             tools: self.shell.tools.clone(),
             idempotency_key: None,
-            timeout_seconds: Some(self.shell.timeout_seconds),
+            timeout_seconds: self.shell.timeout_seconds,
             input: None,
         };
         let (command_tx, command_rx) = mpsc::channel();

--- a/gestalt/cli/src/commands/agents/types.rs
+++ b/gestalt/cli/src/commands/agents/types.rs
@@ -265,6 +265,7 @@ pub(crate) struct AgentShell {
     pub(crate) model_override: Option<String>,
     pub(crate) system_messages: Vec<String>,
     pub(crate) tools: Vec<AgentToolArg>,
+    pub(crate) timeout_seconds: i32,
     pub(crate) applied_system_messages: bool,
 }
 

--- a/gestalt/cli/src/commands/agents/types.rs
+++ b/gestalt/cli/src/commands/agents/types.rs
@@ -265,7 +265,7 @@ pub(crate) struct AgentShell {
     pub(crate) model_override: Option<String>,
     pub(crate) system_messages: Vec<String>,
     pub(crate) tools: Vec<AgentToolArg>,
-    pub(crate) timeout_seconds: i32,
+    pub(crate) timeout_seconds: Option<i32>,
     pub(crate) applied_system_messages: bool,
 }
 

--- a/gestalt/cli/src/main.rs
+++ b/gestalt/cli/src/main.rs
@@ -138,6 +138,9 @@ fn reject_agent_doctor_root_options(args: &AgentArgs) -> anyhow::Result<()> {
     if !args.tools.is_empty() {
         anyhow::bail!("--tool is not supported with agent doctor");
     }
+    if args.timeout_seconds.is_some() {
+        anyhow::bail!("--timeout-seconds is not supported with agent doctor");
+    }
     Ok(())
 }
 
@@ -162,6 +165,11 @@ fn reject_local_agent_options(args: &AgentArgs) -> anyhow::Result<()> {
             "--tool is not supported in local agent mode; use --cloud for server-backed agent sessions"
         );
     }
+    if args.timeout_seconds.is_some() {
+        anyhow::bail!(
+            "--timeout-seconds is not supported in local agent mode; use --cloud for server-backed agent sessions"
+        );
+    }
     Ok(())
 }
 
@@ -180,6 +188,9 @@ fn reject_agent_interactive_options(args: &AgentArgs) -> anyhow::Result<()> {
     }
     if !args.tools.is_empty() {
         anyhow::bail!("--tool must be passed before a prompt or after `agent resume`");
+    }
+    if args.timeout_seconds.is_some() {
+        anyhow::bail!("--timeout-seconds must be passed before a prompt or after `agent resume`");
     }
     if args.provider.is_some() {
         anyhow::bail!("--provider must be passed before a prompt or after `agent resume`");

--- a/gestalt/cli/tests/agents_cli.rs
+++ b/gestalt/cli/tests/agents_cli.rs
@@ -284,6 +284,7 @@ fn test_cli_creates_agent_session() {
 fn test_cli_creates_agent_turn_from_input() {
     let request_json = r#"{
         "model":"gpt-5.4",
+        "timeoutSeconds":120,
         "toolSource":"mcp_catalog",
         "metadata":{"ticket":"TASK-123"},
         "modelOptions":{"temperature":0.2},
@@ -332,6 +333,8 @@ fn test_cli_creates_agent_turn_from_input() {
             "turns",
             "create",
             "session-1",
+            "--timeout-seconds",
+            "120",
             "--input",
             request_path.to_str().unwrap(),
         ])
@@ -354,7 +357,14 @@ fn test_cli_rejects_agent_turn_create_without_messages() {
 
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
-        .args(["agent", "turns", "create", "session-1"])
+        .args([
+            "agent",
+            "turns",
+            "create",
+            "session-1",
+            "--timeout-seconds",
+            "120",
+        ])
         .assert()
         .failure()
         .stderr(predicate::str::contains(
@@ -669,7 +679,7 @@ fn test_cli_runs_interactive_agent_session() {
     )
     .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
     .match_body(Matcher::JsonString(
-        r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"hello\nthere"}],"toolRefs":[{"app":"tracker","operation":"searchItems"}],"output":{"text":{}}}"#.to_string(),
+        r#"{"model":"gpt-5.4","timeoutSeconds":120,"messages":[{"role":"user","text":"hello\nthere"}],"toolRefs":[{"app":"tracker","operation":"searchItems"}],"output":{"text":{}}}"#.to_string(),
     ))
     .with_body(TURN_JSON)
     .create();
@@ -711,6 +721,8 @@ fn test_cli_runs_interactive_agent_session() {
         .args([
             "agent",
             "--cloud",
+            "--timeout-seconds",
+            "120",
             "--provider",
             "managed",
             "--model",
@@ -756,7 +768,7 @@ fn test_cli_runs_interactive_agent_session_with_display_events() {
     )
     .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
     .match_body(Matcher::JsonString(
-        r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"display events"}],"output":{"text":{}}}"#.to_string(),
+        r#"{"model":"gpt-5.4","timeoutSeconds":120,"messages":[{"role":"user","text":"display events"}],"output":{"text":{}}}"#.to_string(),
     ))
     .with_body(TURN_JSON)
     .create();
@@ -808,6 +820,8 @@ fn test_cli_runs_interactive_agent_session_with_display_events() {
         .args([
             "agent",
             "--cloud",
+            "--timeout-seconds",
+            "120",
             "--provider",
             "managed",
             "--model",
@@ -852,7 +866,7 @@ fn test_cli_runs_tty_agent_session_in_isolated_selectable_ui() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"hello tui"}]}"#,
+            r#"{"model":"gpt-5.4","timeoutSeconds":120,"messages":[{"role":"user","text":"hello tui"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -900,6 +914,8 @@ fn test_cli_runs_tty_agent_session_in_isolated_selectable_ui() {
         &[
             "agent",
             "--cloud",
+            "--timeout-seconds",
+            "120",
             "--provider",
             "managed",
             "--model",
@@ -914,7 +930,10 @@ fn test_cli_runs_tty_agent_session_in_isolated_selectable_ui() {
     session.wait_for(&mut output, "hello");
     session.wait_for(&mut output, "Brewed for");
     session.write("\x03");
-    session.wait_for(&mut output, "Resume with: gestalt agent resume session-1");
+    session.wait_for(
+        &mut output,
+        "Resume with: gestalt agent resume session-1 --timeout-seconds 120",
+    );
     session.wait_for_exit();
     session.drain_pending(&mut output);
 
@@ -978,6 +997,8 @@ fn test_cli_tty_can_disable_mouse_capture() {
         &[
             "agent",
             "--cloud",
+            "--timeout-seconds",
+            "120",
             "--provider",
             "managed",
             "--model",
@@ -990,7 +1011,10 @@ fn test_cli_tty_can_disable_mouse_capture() {
     let mut output = String::new();
     session.wait_for(&mut output, "Session");
     session.write("\x03");
-    session.wait_for(&mut output, "Resume with: gestalt agent resume session-1");
+    session.wait_for(
+        &mut output,
+        "Resume with: gestalt agent resume session-1 --timeout-seconds 120",
+    );
     session.wait_for_exit();
     session.drain_pending(&mut output);
 
@@ -1024,7 +1048,7 @@ fn test_cli_tty_resume_model_override_updates_visible_model_and_turn_payload() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.5","messages":[{"role":"user","text":"override model"}]}"#,
+            r#"{"model":"gpt-5.5","timeoutSeconds":120,"messages":[{"role":"user","text":"override model"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -1063,7 +1087,15 @@ fn test_cli_tty_resume_model_override_updates_visible_model_and_turn_payload() {
     let mut session = spawn_tty_cli(
         home.path(),
         server.url(),
-        &["agent", "resume", "session-1", "--model", "gpt-5.5"],
+        &[
+            "agent",
+            "resume",
+            "session-1",
+            "--timeout-seconds",
+            "120",
+            "--model",
+            "gpt-5.5",
+        ],
     );
     let mut output = String::new();
     session.wait_for(&mut output, "Session");
@@ -1072,7 +1104,10 @@ fn test_cli_tty_resume_model_override_updates_visible_model_and_turn_payload() {
     session.wait_for(&mut output, "override acknowledged");
     session.wait_for(&mut output, "Brewed for");
     session.write("\x03");
-    session.wait_for(&mut output, "Resume with: gestalt agent resume session-1");
+    session.wait_for(
+        &mut output,
+        "Resume with: gestalt agent resume session-1 --timeout-seconds 120",
+    );
     session.wait_for_exit();
 
     assert!(
@@ -1097,7 +1132,7 @@ fn test_cli_tty_renders_display_tool_activity_rows() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"display tools"}]}"#,
+            r#"{"model":"gpt-5.4","timeoutSeconds":120,"messages":[{"role":"user","text":"display tools"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -1148,6 +1183,8 @@ fn test_cli_tty_renders_display_tool_activity_rows() {
         &[
             "agent",
             "--cloud",
+            "--timeout-seconds",
+            "120",
             "--provider",
             "managed",
             "--model",
@@ -1237,7 +1274,7 @@ fn test_cli_tty_groups_tool_activity_rows() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"use tools"}]}"#,
+            r#"{"model":"gpt-5.4","timeoutSeconds":120,"messages":[{"role":"user","text":"use tools"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -1278,6 +1315,8 @@ fn test_cli_tty_groups_tool_activity_rows() {
         &[
             "agent",
             "--cloud",
+            "--timeout-seconds",
+            "120",
             "--provider",
             "managed",
             "--model",
@@ -1333,7 +1372,7 @@ fn test_cli_tty_reconciles_unmatched_tool_activity_rows() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"ambiguous tools"}]}"#,
+            r#"{"model":"gpt-5.4","timeoutSeconds":120,"messages":[{"role":"user","text":"ambiguous tools"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -1379,6 +1418,8 @@ fn test_cli_tty_reconciles_unmatched_tool_activity_rows() {
         &[
             "agent",
             "--cloud",
+            "--timeout-seconds",
+            "120",
             "--provider",
             "managed",
             "--model",
@@ -1417,7 +1458,7 @@ fn test_cli_tty_help_and_prompt_history() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"remember this"}]}"#,
+            r#"{"model":"gpt-5.4","timeoutSeconds":120,"messages":[{"role":"user","text":"remember this"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -1453,7 +1494,7 @@ fn test_cli_tty_help_and_prompt_history() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"remember this"}]}"#,
+            r#"{"model":"gpt-5.4","timeoutSeconds":120,"messages":[{"role":"user","text":"remember this"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -1489,7 +1530,7 @@ fn test_cli_tty_help_and_prompt_history() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"draft text"}]}"#,
+            r#"{"model":"gpt-5.4","timeoutSeconds":120,"messages":[{"role":"user","text":"draft text"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -1531,6 +1572,8 @@ fn test_cli_tty_help_and_prompt_history() {
         &[
             "agent",
             "--cloud",
+            "--timeout-seconds",
+            "120",
             "--provider",
             "managed",
             "--model",
@@ -1574,7 +1617,7 @@ fn test_cli_tty_ctrl_j_inserts_multiline_prompt() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"first\nsecond"}]}"#,
+            r#"{"model":"gpt-5.4","timeoutSeconds":120,"messages":[{"role":"user","text":"first\nsecond"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -1616,6 +1659,8 @@ fn test_cli_tty_ctrl_j_inserts_multiline_prompt() {
         &[
             "agent",
             "--cloud",
+            "--timeout-seconds",
+            "120",
             "--provider",
             "managed",
             "--model",
@@ -1651,6 +1696,8 @@ fn test_cli_tty_scrolls_multiline_help_rows() {
         &[
             "agent",
             "--cloud",
+            "--timeout-seconds",
+            "120",
             "--provider",
             "managed",
             "--model",
@@ -1702,6 +1749,8 @@ fn test_cli_tty_ctrl_d_exits_empty_prompt() {
         &[
             "agent",
             "--cloud",
+            "--timeout-seconds",
+            "120",
             "--provider",
             "managed",
             "--model",
@@ -1711,7 +1760,10 @@ fn test_cli_tty_ctrl_d_exits_empty_prompt() {
     let mut output = String::new();
     session.wait_for(&mut output, "Session");
     session.write("\x04");
-    session.wait_for(&mut output, "Resume with: gestalt agent resume session-1");
+    session.wait_for(
+        &mut output,
+        "Resume with: gestalt agent resume session-1 --timeout-seconds 120",
+    );
     session.wait_for_exit();
 
     server.assert_finished();
@@ -1732,7 +1784,7 @@ fn test_cli_tty_ctrl_l_redraw_preserves_transcript_and_input() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"draft input"}]}"#,
+            r#"{"model":"gpt-5.4","timeoutSeconds":120,"messages":[{"role":"user","text":"draft input"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -1774,6 +1826,8 @@ fn test_cli_tty_ctrl_l_redraw_preserves_transcript_and_input() {
         &[
             "agent",
             "--cloud",
+            "--timeout-seconds",
+            "120",
             "--provider",
             "managed",
             "--model",
@@ -1819,6 +1873,8 @@ fn test_cli_tty_resize_redraws_isolated_session() {
         &[
             "agent",
             "--cloud",
+            "--timeout-seconds",
+            "120",
             "--provider",
             "managed",
             "--model",
@@ -1866,7 +1922,7 @@ fn test_cli_tty_renders_markdown_like_assistant_content() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"render markdown"}]}"#,
+            r#"{"model":"gpt-5.4","timeoutSeconds":120,"messages":[{"role":"user","text":"render markdown"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -1908,6 +1964,8 @@ fn test_cli_tty_renders_markdown_like_assistant_content() {
         &[
             "agent",
             "--cloud",
+            "--timeout-seconds",
+            "120",
             "--provider",
             "managed",
             "--model",
@@ -1956,7 +2014,7 @@ fn test_cli_tty_wraps_wide_transcript_text_by_display_width() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"wide text"}]}"#,
+            r#"{"model":"gpt-5.4","timeoutSeconds":120,"messages":[{"role":"user","text":"wide text"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -1998,6 +2056,8 @@ fn test_cli_tty_wraps_wide_transcript_text_by_display_width() {
         &[
             "agent",
             "--cloud",
+            "--timeout-seconds",
+            "120",
             "--provider",
             "managed",
             "--model",
@@ -2031,7 +2091,7 @@ fn test_cli_tty_queues_prompt_while_turn_is_running() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"slow turn"}]}"#,
+            r#"{"model":"gpt-5.4","timeoutSeconds":120,"messages":[{"role":"user","text":"slow turn"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -2068,7 +2128,7 @@ fn test_cli_tty_queues_prompt_while_turn_is_running() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"pending turn"}]}"#,
+            r#"{"model":"gpt-5.4","timeoutSeconds":120,"messages":[{"role":"user","text":"pending turn"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -2110,6 +2170,8 @@ fn test_cli_tty_queues_prompt_while_turn_is_running() {
         &[
             "agent",
             "--cloud",
+            "--timeout-seconds",
+            "120",
             "--provider",
             "managed",
             "--model",
@@ -2179,7 +2241,7 @@ fn test_cli_tty_turn_boundary_stops_stale_streaming_transcript_item() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"first turn"}]}"#,
+            r#"{"model":"gpt-5.4","timeoutSeconds":120,"messages":[{"role":"user","text":"first turn"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -2214,7 +2276,7 @@ fn test_cli_tty_turn_boundary_stops_stale_streaming_transcript_item() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"second turn"}]}"#,
+            r#"{"model":"gpt-5.4","timeoutSeconds":120,"messages":[{"role":"user","text":"second turn"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -2256,6 +2318,8 @@ fn test_cli_tty_turn_boundary_stops_stale_streaming_transcript_item() {
         &[
             "agent",
             "--cloud",
+            "--timeout-seconds",
+            "120",
             "--provider",
             "managed",
             "--model",
@@ -2293,7 +2357,7 @@ fn test_cli_tty_secret_interaction_masks_and_requires_input() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"needs secret"}]}"#,
+            r#"{"model":"gpt-5.4","timeoutSeconds":120,"messages":[{"role":"user","text":"needs secret"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -2389,6 +2453,8 @@ fn test_cli_tty_secret_interaction_masks_and_requires_input() {
         &[
             "agent",
             "--cloud",
+            "--timeout-seconds",
+            "120",
             "--provider",
             "managed",
             "--model",
@@ -2446,7 +2512,7 @@ fn test_cli_resumes_latest_active_agent_session() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-new/turns",
-            r#"{"messages":[{"role":"user","text":"continue plan"}]}"#,
+            r#"{"timeoutSeconds":120,"messages":[{"role":"user","text":"continue plan"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -2489,6 +2555,8 @@ fn test_cli_resumes_latest_active_agent_session() {
         .args([
             "agent",
             "resume",
+            "--timeout-seconds",
+            "120",
             "--provider",
             "managed",
             "--message",
@@ -2498,7 +2566,7 @@ fn test_cli_resumes_latest_active_agent_session() {
         .success()
         .stdout(predicate::str::contains("assistant> continued"))
         .stdout(predicate::str::contains(
-            "Resume with: gestalt agent resume session-new",
+            "Resume with: gestalt agent resume session-new --timeout-seconds 120",
         ))
         .stderr(predicate::str::contains(
             "Session session-new [managed / gpt-5.4]",
@@ -2522,7 +2590,7 @@ fn test_cli_resume_fails_without_active_agent_session() {
         .env("GESTALT_API_KEY", TEST_TOKEN)
         .arg("--url")
         .arg(server.url())
-        .args(["agent", "resume"])
+        .args(["agent", "resume", "--timeout-seconds", "120"])
         .assert()
         .failure()
         .stderr(predicate::str::contains(
@@ -2821,6 +2889,8 @@ fn test_cli_agent_model_slash_lists_configured_providers() {
         .args([
             "agent",
             "--cloud",
+            "--timeout-seconds",
+            "120",
             "--provider",
             "managed",
             "--model",
@@ -2830,7 +2900,7 @@ fn test_cli_agent_model_slash_lists_configured_providers() {
         .assert()
         .success()
         .stdout(predicate::str::contains(
-            "Resume with: gestalt agent resume session-1",
+            "Resume with: gestalt agent resume session-1 --timeout-seconds 120",
         ))
         .stderr(predicate::str::contains("current provider: managed"))
         .stderr(predicate::str::contains("current model: gpt-5.4"))
@@ -2854,7 +2924,7 @@ fn test_cli_agent_model_slash_sets_future_turn_model() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.5","messages":[{"role":"user","text":"hello"}]}"#,
+            r#"{"model":"gpt-5.5","timeoutSeconds":120,"messages":[{"role":"user","text":"hello"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -2897,6 +2967,8 @@ fn test_cli_agent_model_slash_sets_future_turn_model() {
         .args([
             "agent",
             "--cloud",
+            "--timeout-seconds",
+            "120",
             "--provider",
             "managed",
             "--model",
@@ -2931,7 +3003,7 @@ fn test_cli_resumes_existing_agent_session_and_resolves_input_interaction() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-2/turns",
-            r#"{"messages":[{"role":"user","text":"need incident context"}]}"#,
+            r#"{"timeoutSeconds":120,"messages":[{"role":"user","text":"need incident context"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -3025,7 +3097,7 @@ fn test_cli_resumes_existing_agent_session_and_resolves_input_interaction() {
         .env("GESTALT_API_KEY", TEST_TOKEN)
         .arg("--url")
         .arg(server.url())
-        .args(["agent", "resume", "session-2"])
+        .args(["agent", "resume", "session-2", "--timeout-seconds", "120"])
         .write_stdin("need incident context\n\n")
         .assert()
         .success()
@@ -3064,7 +3136,7 @@ fn test_cli_resolves_agent_interaction_in_interactive_mode() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"approve deployment"}]}"#,
+            r#"{"model":"gpt-5.4","timeoutSeconds":120,"messages":[{"role":"user","text":"approve deployment"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -3161,6 +3233,8 @@ fn test_cli_resolves_agent_interaction_in_interactive_mode() {
         .args([
             "agent",
             "--cloud",
+            "--timeout-seconds",
+            "120",
             "--provider",
             "managed",
             "--model",

--- a/gestaltd/internal/bootstrap/agent_runtime_test.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_test.go
@@ -1138,10 +1138,11 @@ func TestAgentRuntimeConfigStartsHostedAgentWarmPool(t *testing.T) {
 		t.Fatal("session-1 backend was not recorded")
 	}
 	turn, err := agents[0].CreateTurn(context.Background(), &proto.CreateAgentProviderTurnRequest{
-		TurnId:    "turn-1",
-		SessionId: "session-1",
-		Model:     "gpt-test",
-		Output:    agentRuntimeTextOutput(),
+		TimeoutSeconds: 1,
+		TurnId:         "turn-1",
+		SessionId:      "session-1",
+		Model:          "gpt-test",
+		Output:         agentRuntimeTextOutput(),
 		Metadata: mustTestProtoStruct(t, map[string]any{
 			"requireInteraction": true,
 		}),
@@ -2023,9 +2024,10 @@ func TestHostedAgentProviderPoolSkipsPastDrainBackendForNewTurn(t *testing.T) {
 	}
 
 	turn, err := pool.CreateTurn(context.Background(), &proto.CreateAgentProviderTurnRequest{
-		TurnId:    "turn-1",
-		SessionId: "session-1",
-		Output:    agentRuntimeTextOutput(),
+		TimeoutSeconds: 1,
+		TurnId:         "turn-1",
+		SessionId:      "session-1",
+		Output:         agentRuntimeTextOutput(),
 	})
 	if err != nil {
 		t.Fatalf("CreateTurn: %v", err)
@@ -2320,9 +2322,10 @@ func TestAgentRuntimeConfigUsesPublicAgentHostBinding(t *testing.T) {
 	}
 
 	turn, err := agents[0].CreateTurn(context.Background(), &proto.CreateAgentProviderTurnRequest{
-		TurnId:    "turn-1",
-		SessionId: "session-1",
-		Model:     "gpt-test",
+		TimeoutSeconds: 1,
+		TurnId:         "turn-1",
+		SessionId:      "session-1",
+		Model:          "gpt-test",
 		Messages: []*proto.AgentMessage{{
 			Role: "user",
 			Text: "Plan it",
@@ -2412,6 +2415,7 @@ func TestAgentRuntimeConfigUsesPublicAgentHostBinding(t *testing.T) {
 		Model:              "gpt-test",
 		CreatedBySubjectId: "user:user-123",
 		Output:             agentRuntimeTextOutput(),
+		TimeoutSeconds:     1,
 		Metadata: mustTestProtoStruct(t, map[string]any{
 			"requireInteraction": true,
 		}),
@@ -3682,10 +3686,11 @@ func TestAgentRuntimeConfigUsesPublicAgentHostRelayBinding(t *testing.T) {
 	}
 
 	turn, err := agents[0].CreateTurn(context.Background(), &proto.CreateAgentProviderTurnRequest{
-		TurnId:    "turn-1",
-		SessionId: "session-1",
-		Model:     "gpt-test",
-		Output:    agentRuntimeTextOutput(),
+		TimeoutSeconds: 1,
+		TurnId:         "turn-1",
+		SessionId:      "session-1",
+		Model:          "gpt-test",
+		Output:         agentRuntimeTextOutput(),
 	})
 	if err != nil {
 		t.Fatalf("CreateTurn: %v", err)

--- a/gestaltd/internal/bootstrap/agent_workflow_tools_schema.go
+++ b/gestaltd/internal/bootstrap/agent_workflow_tools_schema.go
@@ -95,7 +95,7 @@ func workflowSystemToolStepSchema() map[string]any {
 		"app":            workflowSystemToolAppCallSchema("App name."),
 		"agent":          workflowSystemToolAgentTurnSchema(),
 		"when":           workflowSystemToolStepWhenSchema(),
-		"timeoutSeconds": map[string]any{"type": "integer", "minimum": 1, "description": "Execution budget in seconds. Required and positive for agent steps."},
+		"timeoutSeconds": map[string]any{"type": "integer", "minimum": 0, "description": "Optional execution budget in seconds. Providers choose their own timeout when omitted or zero."},
 		"metadata":       map[string]any{"type": "object"},
 	})
 	schema["oneOf"] = []any{
@@ -104,9 +104,9 @@ func workflowSystemToolStepSchema() map[string]any {
 			"not":      map[string]any{"required": []string{"agent"}},
 		},
 		map[string]any{
-			"required": []string{"agent", "timeoutSeconds"},
+			"required": []string{"agent"},
 			"properties": map[string]any{
-				"timeoutSeconds": map[string]any{"type": "integer", "minimum": 1},
+				"timeoutSeconds": map[string]any{"type": "integer", "minimum": 0},
 			},
 			"not": map[string]any{"required": []string{"app"}},
 		},

--- a/gestaltd/internal/bootstrap/agent_workflow_tools_schema.go
+++ b/gestaltd/internal/bootstrap/agent_workflow_tools_schema.go
@@ -89,15 +89,29 @@ func workflowSystemToolTargetSchema() map[string]any {
 }
 
 func workflowSystemToolStepSchema() map[string]any {
-	return workflowSystemToolObjectSchema([]string{"id"}, map[string]any{
+	schema := workflowSystemToolObjectSchema([]string{"id"}, map[string]any{
 		"id":             workflowSystemToolStringSchema("Stable step ID."),
 		"inputs":         map[string]any{"type": "object"},
 		"app":            workflowSystemToolAppCallSchema("App name."),
 		"agent":          workflowSystemToolAgentTurnSchema(),
 		"when":           workflowSystemToolStepWhenSchema(),
-		"timeoutSeconds": map[string]any{"type": "integer", "minimum": 0},
+		"timeoutSeconds": map[string]any{"type": "integer", "minimum": 0, "description": "Execution budget in seconds. Required and positive for agent steps."},
 		"metadata":       map[string]any{"type": "object"},
 	})
+	schema["oneOf"] = []any{
+		map[string]any{
+			"required": []string{"app"},
+			"not":      map[string]any{"required": []string{"agent"}},
+		},
+		map[string]any{
+			"required": []string{"agent", "timeoutSeconds"},
+			"properties": map[string]any{
+				"timeoutSeconds": map[string]any{"type": "integer", "minimum": 1},
+			},
+			"not": map[string]any{"required": []string{"app"}},
+		},
+	}
+	return schema
 }
 
 func workflowSystemToolAppCallSchema(nameDescription string) map[string]any {

--- a/gestaltd/internal/bootstrap/agent_workflow_tools_schema.go
+++ b/gestaltd/internal/bootstrap/agent_workflow_tools_schema.go
@@ -95,7 +95,7 @@ func workflowSystemToolStepSchema() map[string]any {
 		"app":            workflowSystemToolAppCallSchema("App name."),
 		"agent":          workflowSystemToolAgentTurnSchema(),
 		"when":           workflowSystemToolStepWhenSchema(),
-		"timeoutSeconds": map[string]any{"type": "integer", "minimum": 0, "description": "Execution budget in seconds. Required and positive for agent steps."},
+		"timeoutSeconds": map[string]any{"type": "integer", "minimum": 1, "description": "Execution budget in seconds. Required and positive for agent steps."},
 		"metadata":       map[string]any{"type": "object"},
 	})
 	schema["oneOf"] = []any{

--- a/gestaltd/internal/bootstrap/agent_workflow_tools_test.go
+++ b/gestaltd/internal/bootstrap/agent_workflow_tools_test.go
@@ -407,8 +407,8 @@ func TestWorkflowSystemToolStartRunSchemaMatchesV1Contract(t *testing.T) {
 		t.Fatalf("runs.start step properties = %#v", items["properties"])
 	}
 	stepTimeout, ok := stepProps["timeoutSeconds"].(map[string]any)
-	if !ok || stepTimeout["minimum"] != 1 {
-		t.Fatalf("runs.start step timeoutSeconds schema = %#v, want minimum 1", stepProps["timeoutSeconds"])
+	if !ok || stepTimeout["minimum"] != 0 {
+		t.Fatalf("runs.start step timeoutSeconds schema = %#v, want minimum 0", stepProps["timeoutSeconds"])
 	}
 	stepBranches, ok := items["oneOf"].([]any)
 	if !ok || len(stepBranches) != 2 {
@@ -419,16 +419,16 @@ func TestWorkflowSystemToolStartRunSchemaMatchesV1Contract(t *testing.T) {
 		t.Fatalf("runs.start agent step branch = %#v", stepBranches[1])
 	}
 	agentStepRequired, ok := agentStepBranch["required"].([]string)
-	if !ok || !stringSliceContains(agentStepRequired, "agent") || !stringSliceContains(agentStepRequired, "timeoutSeconds") {
-		t.Fatalf("runs.start agent step required = %#v, want agent and timeoutSeconds", agentStepBranch["required"])
+	if !ok || len(agentStepRequired) != 1 || agentStepRequired[0] != "agent" {
+		t.Fatalf("runs.start agent step required = %#v, want only agent", agentStepBranch["required"])
 	}
 	agentStepProps, ok := agentStepBranch["properties"].(map[string]any)
 	if !ok {
 		t.Fatalf("runs.start agent step properties = %#v", agentStepBranch["properties"])
 	}
 	agentStepTimeout, ok := agentStepProps["timeoutSeconds"].(map[string]any)
-	if !ok || agentStepTimeout["minimum"] != 1 {
-		t.Fatalf("runs.start agent step timeoutSeconds schema = %#v, want minimum 1", agentStepProps["timeoutSeconds"])
+	if !ok || agentStepTimeout["minimum"] != 0 {
+		t.Fatalf("runs.start agent step timeoutSeconds schema = %#v, want minimum 0", agentStepProps["timeoutSeconds"])
 	}
 	agent, ok := stepProps["agent"].(map[string]any)
 	if !ok {
@@ -2088,13 +2088,7 @@ func workflowSystemRunGrants(t *testing.T, runtime *agentRuntime) *agentgrant.Ma
 func workflowSystemToolTestTarget(steps ...map[string]any) map[string]any {
 	items := make([]any, 0, len(steps))
 	for _, step := range steps {
-		item := maps.Clone(step)
-		if _, hasAgent := item["agent"]; hasAgent {
-			if _, hasTimeout := item["timeoutSeconds"]; !hasTimeout {
-				item["timeoutSeconds"] = 1
-			}
-		}
-		items = append(items, item)
+		items = append(items, maps.Clone(step))
 	}
 	return map[string]any{"steps": items}
 }

--- a/gestaltd/internal/bootstrap/agent_workflow_tools_test.go
+++ b/gestaltd/internal/bootstrap/agent_workflow_tools_test.go
@@ -406,6 +406,26 @@ func TestWorkflowSystemToolStartRunSchemaMatchesV1Contract(t *testing.T) {
 	if !ok {
 		t.Fatalf("runs.start step properties = %#v", items["properties"])
 	}
+	stepBranches, ok := items["oneOf"].([]any)
+	if !ok || len(stepBranches) != 2 {
+		t.Fatalf("runs.start step oneOf = %#v, want app and agent branches", items["oneOf"])
+	}
+	agentStepBranch, ok := stepBranches[1].(map[string]any)
+	if !ok {
+		t.Fatalf("runs.start agent step branch = %#v", stepBranches[1])
+	}
+	agentStepRequired, ok := agentStepBranch["required"].([]string)
+	if !ok || !stringSliceContains(agentStepRequired, "agent") || !stringSliceContains(agentStepRequired, "timeoutSeconds") {
+		t.Fatalf("runs.start agent step required = %#v, want agent and timeoutSeconds", agentStepBranch["required"])
+	}
+	agentStepProps, ok := agentStepBranch["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("runs.start agent step properties = %#v", agentStepBranch["properties"])
+	}
+	agentStepTimeout, ok := agentStepProps["timeoutSeconds"].(map[string]any)
+	if !ok || agentStepTimeout["minimum"] != 1 {
+		t.Fatalf("runs.start agent step timeoutSeconds schema = %#v, want minimum 1", agentStepProps["timeoutSeconds"])
+	}
 	agent, ok := stepProps["agent"].(map[string]any)
 	if !ok {
 		t.Fatalf("runs.start step agent schema = %#v", stepProps["agent"])
@@ -2064,7 +2084,13 @@ func workflowSystemRunGrants(t *testing.T, runtime *agentRuntime) *agentgrant.Ma
 func workflowSystemToolTestTarget(steps ...map[string]any) map[string]any {
 	items := make([]any, 0, len(steps))
 	for _, step := range steps {
-		items = append(items, step)
+		item := maps.Clone(step)
+		if _, hasAgent := item["agent"]; hasAgent {
+			if _, hasTimeout := item["timeoutSeconds"]; !hasTimeout {
+				item["timeoutSeconds"] = 1
+			}
+		}
+		items = append(items, item)
 	}
 	return map[string]any{"steps": items}
 }
@@ -2081,4 +2107,13 @@ func mustWorkflowSystemTool(t *testing.T, runtime *agentRuntime, operation strin
 	}
 	tool.ID = mustMintAgentToolID(t, workflowSystemRunGrants(t, runtime), tool.Target)
 	return tool
+}
+
+func stringSliceContains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }

--- a/gestaltd/internal/bootstrap/agent_workflow_tools_test.go
+++ b/gestaltd/internal/bootstrap/agent_workflow_tools_test.go
@@ -2106,12 +2106,3 @@ func mustWorkflowSystemTool(t *testing.T, runtime *agentRuntime, operation strin
 	tool.ID = mustMintAgentToolID(t, workflowSystemRunGrants(t, runtime), tool.Target)
 	return tool
 }
-
-func stringSliceContains(values []string, want string) bool {
-	for _, value := range values {
-		if value == want {
-			return true
-		}
-	}
-	return false
-}

--- a/gestaltd/internal/bootstrap/agent_workflow_tools_test.go
+++ b/gestaltd/internal/bootstrap/agent_workflow_tools_test.go
@@ -406,6 +406,10 @@ func TestWorkflowSystemToolStartRunSchemaMatchesV1Contract(t *testing.T) {
 	if !ok {
 		t.Fatalf("runs.start step properties = %#v", items["properties"])
 	}
+	stepTimeout, ok := stepProps["timeoutSeconds"].(map[string]any)
+	if !ok || stepTimeout["minimum"] != 1 {
+		t.Fatalf("runs.start step timeoutSeconds schema = %#v, want minimum 1", stepProps["timeoutSeconds"])
+	}
 	stepBranches, ok := items["oneOf"].([]any)
 	if !ok || len(stepBranches) != 2 {
 		t.Fatalf("runs.start step oneOf = %#v, want app and agent branches", items["oneOf"])

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -2767,6 +2767,7 @@ func TestBootstrapAgentManagerCreateTurnPersistsMetadataForToolCallbacks(t *test
 		t.Fatalf("AgentManager.CreateSession: %v", err)
 	}
 	req := &proto.CreateAgentProviderTurnRequest{
+		TimeoutSeconds: 1,
 		SessionId:      session.ID,
 		IdempotencyKey: "demo-idempotency-key",
 		Model:          "gpt-test",
@@ -2832,6 +2833,7 @@ func TestBootstrapAgentManagerCreateTurnPersistsMetadataForToolCallbacks(t *test
 	}
 
 	_, err = result.AgentManager.CreateTurn(ctx, p, &proto.CreateAgentProviderTurnRequest{
+		TimeoutSeconds: 1,
 		SessionId:      session.ID,
 		IdempotencyKey: "global-search-idempotency-key",
 		Model:          "gpt-test",
@@ -2850,6 +2852,7 @@ func TestBootstrapAgentManagerCreateTurnPersistsMetadataForToolCallbacks(t *test
 	}
 
 	_, err = result.AgentManager.CreateTurn(ctx, p, &proto.CreateAgentProviderTurnRequest{
+		TimeoutSeconds: 1,
 		SessionId:      session.ID,
 		IdempotencyKey: "scoped-unavailable-idempotency-key",
 		Model:          "gpt-test",
@@ -3059,6 +3062,7 @@ func TestBootstrapAgentHostToolCatalogExecutesExactAppIssueTool(t *testing.T) {
 		t.Fatalf("AgentManager.CreateSession: %v", err)
 	}
 	turn, err := result.AgentManager.CreateTurn(ctx, p, &proto.CreateAgentProviderTurnRequest{
+		TimeoutSeconds: 1,
 		SessionId:      session.ID,
 		IdempotencyKey: "linear-search-idempotency-key",
 		Model:          "gpt-test",
@@ -3081,6 +3085,7 @@ func TestBootstrapAgentHostToolCatalogExecutesExactAppIssueTool(t *testing.T) {
 	}
 
 	second, err := result.AgentManager.CreateTurn(ctx, p, &proto.CreateAgentProviderTurnRequest{
+		TimeoutSeconds: 1,
 		SessionId:      session.ID,
 		IdempotencyKey: "linear-search-after-unavailable-idempotency-key",
 		Model:          "gpt-test",
@@ -3192,6 +3197,7 @@ func TestBootstrapAgentHostToolCatalogListsAndExecutesVisibleTools(t *testing.T)
 		t.Fatalf("AgentManager.CreateSession: %v", err)
 	}
 	turn, err := result.AgentManager.CreateTurn(ctx, p, &proto.CreateAgentProviderTurnRequest{
+		TimeoutSeconds: 1,
 		SessionId:      session.ID,
 		IdempotencyKey: "candidate-search-idempotency-key",
 		Model:          "gpt-test",
@@ -3252,6 +3258,7 @@ func TestBootstrapAgentHostToolCatalogListsAndExecutesVisibleTools(t *testing.T)
 		t.Fatalf("listed tools = %#v, want visible destructive epsilon_delete", listResp.GetTools())
 	}
 	exact, err := result.AgentManager.CreateTurn(ctx, p, &proto.CreateAgentProviderTurnRequest{
+		TimeoutSeconds: 1,
 		SessionId:      session.ID,
 		IdempotencyKey: "candidate-load-ref-idempotency-key",
 		Model:          "gpt-test",
@@ -3274,6 +3281,7 @@ func TestBootstrapAgentHostToolCatalogListsAndExecutesVisibleTools(t *testing.T)
 	}
 
 	mixed, err := result.AgentManager.CreateTurn(ctx, p, &proto.CreateAgentProviderTurnRequest{
+		TimeoutSeconds: 1,
 		SessionId:      session.ID,
 		IdempotencyKey: "candidate-mixed-global-exact-hidden-idempotency-key",
 		Model:          "gpt-test",
@@ -3423,6 +3431,7 @@ func TestBootstrapAgentDefaultToolNarrowingThresholdConfigNarrowsImplicitCatalog
 		t.Fatalf("AgentManager.CreateSession: %v", err)
 	}
 	turn, err := result.AgentManager.CreateTurn(ctx, p, &proto.CreateAgentProviderTurnRequest{
+		TimeoutSeconds: 1,
 		SessionId:      session.ID,
 		IdempotencyKey: "configured-narrowing-linear",
 		Model:          "gpt-test",
@@ -3539,6 +3548,7 @@ func TestBootstrapHTTPCallerWildcardCatalogToolRefsAreScopedByAuthorization(t *t
 		t.Fatalf("AgentManager.CreateSession: %v", err)
 	}
 	turn, err := result.AgentManager.CreateTurn(agentmanager.WithCallerAppName(ctx, "slack"), p, &proto.CreateAgentProviderTurnRequest{
+		TimeoutSeconds: 1,
 		SessionId:      session.ID,
 		IdempotencyKey: "http-slack-linear-search",
 		Model:          "gpt-test",
@@ -3671,6 +3681,7 @@ func TestBootstrapGlobalCatalogToolRefsSurfaceUnavailableProviders(t *testing.T)
 		t.Fatalf("AgentManager.CreateSession: %v", err)
 	}
 	turn, err := result.AgentManager.CreateTurn(agentmanager.WithCallerAppName(ctx, "slack"), p, &proto.CreateAgentProviderTurnRequest{
+		TimeoutSeconds: 1,
 		SessionId:      session.ID,
 		IdempotencyKey: "http-global-linear-search",
 		Model:          "gpt-test",
@@ -3759,6 +3770,7 @@ func TestBootstrapAgentProviderSupportsDirectTurnInteractionLifecycle(t *testing
 		Model:              "gpt-test",
 		CreatedBySubjectId: "system:config",
 		Output:             bootstrapTextAgentOutput(),
+		TimeoutSeconds:     1,
 		Messages: []*proto.AgentMessage{{
 			Role: "user",
 			Text: "request approval",
@@ -3868,9 +3880,10 @@ func TestBootstrapAgentManagerResolvesProviderOwnedInteractions(t *testing.T) {
 		t.Fatalf("AgentManager.CreateSession: %v", err)
 	}
 	turn, err := result.AgentManager.CreateTurn(startCtx, p, &proto.CreateAgentProviderTurnRequest{
-		SessionId: session.ID,
-		Model:     "gpt-test",
-		Output:    bootstrapTextAgentOutput(),
+		TimeoutSeconds: 1,
+		SessionId:      session.ID,
+		Model:          "gpt-test",
+		Output:         bootstrapTextAgentOutput(),
 		Messages: []*proto.AgentMessage{{
 			Role: "user",
 			Text: "request approval",
@@ -3969,9 +3982,10 @@ func TestBootstrapAgentManagerResolveInteractionReturnsNotFoundWhenProviderInter
 		t.Fatalf("AgentManager.CreateSession: %v", err)
 	}
 	turn, err := result.AgentManager.CreateTurn(startCtx, p, &proto.CreateAgentProviderTurnRequest{
-		SessionId: session.ID,
-		Model:     "gpt-test",
-		Output:    bootstrapTextAgentOutput(),
+		TimeoutSeconds: 1,
+		SessionId:      session.ID,
+		Model:          "gpt-test",
+		Output:         bootstrapTextAgentOutput(),
 		Messages: []*proto.AgentMessage{{
 			Role: "user",
 			Text: "request approval",
@@ -4053,9 +4067,10 @@ func TestBootstrapAgentManagerResolveInteractionReturnsNotFoundOnProviderInterac
 		t.Fatalf("AgentManager.CreateSession: %v", err)
 	}
 	turn, err := result.AgentManager.CreateTurn(startCtx, p, &proto.CreateAgentProviderTurnRequest{
-		SessionId: session.ID,
-		Model:     "gpt-test",
-		Output:    bootstrapTextAgentOutput(),
+		TimeoutSeconds: 1,
+		SessionId:      session.ID,
+		Model:          "gpt-test",
+		Output:         bootstrapTextAgentOutput(),
 		Messages: []*proto.AgentMessage{{
 			Role: "user",
 			Text: "request approval",
@@ -4138,9 +4153,10 @@ func TestBootstrapAgentManagerListInteractionsRejectsMissingSessionID(t *testing
 		t.Fatalf("AgentManager.CreateSession: %v", err)
 	}
 	turn, err := result.AgentManager.CreateTurn(startCtx, p, &proto.CreateAgentProviderTurnRequest{
-		SessionId: session.ID,
-		Model:     "gpt-test",
-		Output:    bootstrapTextAgentOutput(),
+		TimeoutSeconds: 1,
+		SessionId:      session.ID,
+		Model:          "gpt-test",
+		Output:         bootstrapTextAgentOutput(),
 		Messages: []*proto.AgentMessage{{
 			Role: "user",
 			Text: "request approval",
@@ -4207,9 +4223,10 @@ func TestBootstrapAgentManagerResolveInteractionRejectsMissingSessionID(t *testi
 		t.Fatalf("AgentManager.CreateSession: %v", err)
 	}
 	turn, err := result.AgentManager.CreateTurn(startCtx, p, &proto.CreateAgentProviderTurnRequest{
-		SessionId: session.ID,
-		Model:     "gpt-test",
-		Output:    bootstrapTextAgentOutput(),
+		TimeoutSeconds: 1,
+		SessionId:      session.ID,
+		Model:          "gpt-test",
+		Output:         bootstrapTextAgentOutput(),
 		Messages: []*proto.AgentMessage{{
 			Role: "user",
 			Text: "request approval",
@@ -4313,6 +4330,7 @@ func TestBootstrapAgentManagerIdempotentTurnReplayRequiresCurrentToolAccess(t *t
 	}
 
 	first, err := result.AgentManager.CreateTurn(fullCtx, full, &proto.CreateAgentProviderTurnRequest{
+		TimeoutSeconds: 1,
 		SessionId:      session.ID,
 		IdempotencyKey: "same-run",
 		Model:          "gpt-test",
@@ -4341,6 +4359,7 @@ func TestBootstrapAgentManagerIdempotentTurnReplayRequiresCurrentToolAccess(t *t
 	restrictedCtx := principal.WithPrincipal(context.Background(), restricted)
 
 	_, err = result.AgentManager.CreateTurn(restrictedCtx, restricted, &proto.CreateAgentProviderTurnRequest{
+		TimeoutSeconds: 1,
 		SessionId:      session.ID,
 		IdempotencyKey: "same-run",
 		Model:          "gpt-test",
@@ -6403,9 +6422,10 @@ func TestBootstrapStartsAgentProvidersAfterInvokerIsReady(t *testing.T) {
 		t.Fatalf("CreateSession: %v", err)
 	}
 	turn, err := result.AgentManager.CreateTurn(startCtx, systemPrincipal, &proto.CreateAgentProviderTurnRequest{
-		SessionId: session.ID,
-		Model:     "gpt-test",
-		Output:    bootstrapTextAgentOutput(),
+		TimeoutSeconds: 1,
+		SessionId:      session.ID,
+		Model:          "gpt-test",
+		Output:         bootstrapTextAgentOutput(),
 		ToolRefs: []*proto.AgentToolRef{{
 			App:       "roadmap",
 			Operation: "sync",
@@ -6593,9 +6613,10 @@ func TestBootstrapDoesNotRevokeAgentGrantWhenCancelReturnsLiveTurn(t *testing.T)
 		t.Fatalf("CreateSession: %v", err)
 	}
 	turn, err := result.AgentManager.CreateTurn(startCtx, systemPrincipal, &proto.CreateAgentProviderTurnRequest{
-		SessionId: session.ID,
-		Model:     "gpt-test",
-		Output:    bootstrapTextAgentOutput(),
+		TimeoutSeconds: 1,
+		SessionId:      session.ID,
+		Model:          "gpt-test",
+		Output:         bootstrapTextAgentOutput(),
 		ToolRefs: []*proto.AgentToolRef{{
 			App:       "roadmap",
 			Operation: "sync",
@@ -6746,6 +6767,7 @@ func TestBootstrapAgentProviderRejectsMismatchedRequestedSessionOrTurnID(t *test
 		CreatedBySubjectId: "system:config",
 		Output:             bootstrapTextAgentOutput(),
 		Tools:              bootstrapAgentToolsToProto([]coreagent.Tool{tool}),
+		TimeoutSeconds:     1,
 	}); err == nil {
 		t.Fatal("CreateTurn error = nil, want mismatched turn id failure")
 	} else if !strings.Contains(err.Error(), `returned turn id "generated-turn-1" for requested turn id "agent-turn-1"`) {
@@ -6771,6 +6793,7 @@ func TestBootstrapAgentProviderRejectsMismatchedRequestedSessionOrTurnID(t *test
 		CreatedBySubjectId: "system:config",
 		Output:             bootstrapTextAgentOutput(),
 		Tools:              bootstrapAgentToolsToProto([]coreagent.Tool{tool}),
+		TimeoutSeconds:     1,
 	})
 	if err != nil {
 		t.Fatalf("CreateTurn idempotent replay: %v", err)

--- a/gestaltd/internal/bootstrap/executable_app_test.go
+++ b/gestaltd/internal/bootstrap/executable_app_test.go
@@ -1113,6 +1113,7 @@ func fakeHostedAgentManagerRoundTrip(invocationToken string, env map[string]stri
 	}
 
 	turn, err := client.CreateTurn(ctx, &proto.CreateAgentProviderTurnRequest{
+		TimeoutSeconds:  1,
 		InvocationToken: invocationToken,
 		SessionId:       sessionID,
 		Model:           "gpt-test",

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -3124,6 +3124,7 @@ workflows:
       target:
         steps:
           - id: diagnosis
+            timeout: 1s
             agent:
               provider: simple
               prompt: "diagnose"
@@ -3163,6 +3164,7 @@ workflows:
       target:
         steps:
           - id: diagnosis
+            timeout: 1s
             inputs:
               source:
                 stepOutput:
@@ -3174,6 +3176,7 @@ workflows:
               output:
                 text: {}
           - id: pr_fix
+            timeout: 1s
             agent:
               provider: simple
               prompt: "fix"
@@ -3204,12 +3207,14 @@ workflows:
       target:
         steps:
           - id: diagnosis
+            timeout: 1s
             agent:
               provider: simple
               prompt: "diagnose"
               output:
                 text: {}
           - id: pr_fix
+            timeout: 1s
             agent:
               provider: simple
               prompt: "fix"
@@ -3245,12 +3250,14 @@ workflows:
       target:
         steps:
           - id: diagnosis
+            timeout: 1s
             agent:
               provider: simple
               prompt: "diagnose"
               output:
                 text: {}
           - id: pr_fix
+            timeout: 1s
             agent:
               provider: simple
               prompt: "fix"
@@ -3284,6 +3291,7 @@ workflows:
       target:
         steps:
           - id: run
+            timeout: 1s
             agent:
               model: gpt-5.5
 providers:

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -3111,6 +3111,40 @@ server:
 				want: `workflows.schedules.nightly.target.steps[0].app.credentialMode "unsupported-mode" is not supported`,
 			},
 			{
+				name: "agent step rejects sub-second negative timeout",
+				yaml: `
+workflows:
+  schedules:
+    nightly:
+      provider: temporal
+      runAs:
+        subject:
+          id: service_account:roadmap-workflow
+      cron: "0 2 * * *"
+      target:
+        steps:
+          - id: diagnosis
+            timeout: -500ms
+            agent:
+              provider: simple
+              prompt: "diagnose"
+              output:
+                text: {}
+providers:
+  agent:
+    simple:
+      source:
+        path: ./providers/agent/simple
+  workflow:
+    temporal:
+      source:
+        path: ./providers/workflow/temporal
+server:
+  encryptionKey: server-key
+`,
+				want: `workflows.schedules.nightly.target.steps[0].timeout must not be negative for agent steps`,
+			},
+			{
 				name: "agent step when rejects self reference",
 				yaml: `
 workflows:

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -2185,11 +2185,8 @@ func normalizeWorkflowTarget(cfg *Config, path string, target *WorkflowTargetCon
 			}
 		}
 		if step.Agent != nil {
-			if step.Timeout == "" {
-				return fmt.Errorf("config validation: %s.timeout is required for agent steps", stepPath)
-			}
-			if int(parsedTimeout.Seconds()) <= 0 {
-				return fmt.Errorf("config validation: %s.timeout must be at least 1s for agent steps", stepPath)
+			if step.Timeout != "" && int(parsedTimeout.Seconds()) < 0 {
+				return fmt.Errorf("config validation: %s.timeout must not be negative for agent steps", stepPath)
 			}
 			if err := validateWorkflowStepAgentConfig(cfg, stepPath+".agent", step.Agent); err != nil {
 				return err

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -2185,7 +2185,7 @@ func normalizeWorkflowTarget(cfg *Config, path string, target *WorkflowTargetCon
 			}
 		}
 		if step.Agent != nil {
-			if step.Timeout != "" && int(parsedTimeout.Seconds()) < 0 {
+			if step.Timeout != "" && parsedTimeout < 0 {
 				return fmt.Errorf("config validation: %s.timeout must not be negative for agent steps", stepPath)
 			}
 			if err := validateWorkflowStepAgentConfig(cfg, stepPath+".agent", step.Agent); err != nil {

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -2167,6 +2167,15 @@ func normalizeWorkflowTarget(cfg *Config, path string, target *WorkflowTargetCon
 		if (step.App == nil) == (step.Agent == nil) {
 			return fmt.Errorf("config validation: %s must set exactly one of app or agent", stepPath)
 		}
+		step.Timeout = strings.TrimSpace(step.Timeout)
+		var parsedTimeout time.Duration
+		if step.Timeout != "" {
+			var err error
+			parsedTimeout, err = time.ParseDuration(step.Timeout)
+			if err != nil {
+				return fmt.Errorf("config validation: %s.timeout %q is invalid: %w", stepPath, step.Timeout, err)
+			}
+		}
 		if step.App != nil {
 			if err := normalizeWorkflowStepAppCallConfig(stepPath+".app", step.App, true); err != nil {
 				return err
@@ -2176,14 +2185,14 @@ func normalizeWorkflowTarget(cfg *Config, path string, target *WorkflowTargetCon
 			}
 		}
 		if step.Agent != nil {
+			if step.Timeout == "" {
+				return fmt.Errorf("config validation: %s.timeout is required for agent steps", stepPath)
+			}
+			if int(parsedTimeout.Seconds()) <= 0 {
+				return fmt.Errorf("config validation: %s.timeout must be at least 1s for agent steps", stepPath)
+			}
 			if err := validateWorkflowStepAgentConfig(cfg, stepPath+".agent", step.Agent); err != nil {
 				return err
-			}
-		}
-		step.Timeout = strings.TrimSpace(step.Timeout)
-		if step.Timeout != "" {
-			if _, err := time.ParseDuration(step.Timeout); err != nil {
-				return fmt.Errorf("config validation: %s.timeout %q is invalid: %w", stepPath, step.Timeout, err)
 			}
 		}
 		if step.When != nil {

--- a/gestaltd/internal/daemon/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e_test.go
@@ -279,6 +279,7 @@ workflows:
       target:
         steps:
           - id: summarize
+            timeout: 120s
             agent:
               provider: simple
               model: fast

--- a/gestaltd/internal/server/agent_session_turn_test.go
+++ b/gestaltd/internal/server/agent_session_turn_test.go
@@ -193,7 +193,7 @@ func TestAgentTurnRechecksProviderAuthorization(t *testing.T) {
 	sessionID := session["id"].(string)
 
 	authz.allowed.Store(false)
-	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(`{"output":{"text":{}},"messages":[{"role":"user","text":"hello"}]}`))
+	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(`{"timeoutSeconds":120,"output":{"text":{}},"messages":[{"role":"user","text":"hello"}]}`))
 	turnReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
 	turnResp, err := http.DefaultClient.Do(turnReq)
 	if err != nil {
@@ -241,7 +241,7 @@ func TestAgentCreateTurnReportsMissingSession(t *testing.T) {
 	})
 	testutil.CloseOnCleanup(t, ts)
 
-	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/missing-session/turns", bytes.NewBufferString(`{"output":{"text":{}},"messages":[{"role":"user","text":"hello"}]}`))
+	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/missing-session/turns", bytes.NewBufferString(`{"timeoutSeconds":120,"output":{"text":{}},"messages":[{"role":"user","text":"hello"}]}`))
 	turnReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
 	turnResp, err := http.DefaultClient.Do(turnReq)
 	if err != nil {
@@ -302,7 +302,7 @@ func TestAgentCreateTurnReportsProviderDeadlineAsUnavailable(t *testing.T) {
 		t.Fatalf("decode session: %v", err)
 	}
 
-	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+session["id"].(string)+"/turns", bytes.NewBufferString(`{"output":{"text":{}},"messages":[{"role":"user","text":"hello"}]}`))
+	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+session["id"].(string)+"/turns", bytes.NewBufferString(`{"timeoutSeconds":120,"output":{"text":{}},"messages":[{"role":"user","text":"hello"}]}`))
 	turnReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
 	turnResp, err := http.DefaultClient.Do(turnReq)
 	if err != nil {
@@ -367,7 +367,7 @@ func TestAgentCreateTurnDoesNotReportSessionMissingAfterSessionResolved(t *testi
 	}
 	sessionID := session["id"].(string)
 
-	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(`{"output":{"text":{}},"messages":[{"role":"user","text":"hello"}]}`))
+	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(`{"timeoutSeconds":120,"output":{"text":{}},"messages":[{"role":"user","text":"hello"}]}`))
 	turnReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
 	turnResp, err := http.DefaultClient.Do(turnReq)
 	if err != nil {
@@ -448,7 +448,7 @@ func TestAgentRequestsRejectMissingProviderTokenPermission(t *testing.T) {
 	}
 	provider.mu.Unlock()
 
-	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/session-managed/turns", bytes.NewBufferString(`{"output":{"text":{}},"messages":[{"role":"user","text":"hello"}]}`))
+	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/session-managed/turns", bytes.NewBufferString(`{"timeoutSeconds":120,"output":{"text":{}},"messages":[{"role":"user","text":"hello"}]}`))
 	turnReq.Header.Set("Authorization", "Bearer "+plaintext)
 	turnResp, err := http.DefaultClient.Do(turnReq)
 	if err != nil {
@@ -1193,7 +1193,7 @@ func TestAgentSessionsAndTurnsRoundTrip(t *testing.T) {
 		t.Fatalf("supported tool sources = %#v, want mcp_catalog", got)
 	}
 
-	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(`{"output":{"text":{}},"messages":[{"role":"user","text":"hello"}],"toolSource":"mcp_catalog","toolRefs":[{"app":"docs","operation":"search"}]}`))
+	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(`{"timeoutSeconds":120,"output":{"text":{}},"messages":[{"role":"user","text":"hello"}],"toolSource":"mcp_catalog","toolRefs":[{"app":"docs","operation":"search"}]}`))
 	turnReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
 	turnResp, err := http.DefaultClient.Do(turnReq)
 	if err != nil {
@@ -1525,13 +1525,13 @@ func TestAgentTurnToolRefsDefaultBroadAndExplicitEmptyNone(t *testing.T) {
 		}
 	}
 
-	createTurn("omitted", `{"output":{"text":{}},"messages":[{"role":"user","text":"hello"}]}`, http.StatusCreated)
-	createTurn("explicit empty", `{"output":{"text":{}},"messages":[{"role":"user","text":"hello"}],"toolRefs":[]}`, http.StatusCreated)
-	createTurn("plugin broad", `{"output":{"text":{}},"messages":[{"role":"user","text":"hello"}],"toolRefs":[{"app":"docs"}]}`, http.StatusCreated)
+	createTurn("omitted", `{"timeoutSeconds":120,"output":{"text":{}},"messages":[{"role":"user","text":"hello"}]}`, http.StatusCreated)
+	createTurn("explicit empty", `{"timeoutSeconds":120,"output":{"text":{}},"messages":[{"role":"user","text":"hello"}],"toolRefs":[]}`, http.StatusCreated)
+	createTurn("plugin broad", `{"timeoutSeconds":120,"output":{"text":{}},"messages":[{"role":"user","text":"hello"}],"toolRefs":[{"app":"docs"}]}`, http.StatusCreated)
 	createTurn("missing output", `{"messages":[{"role":"user","text":"hello"}]}`, http.StatusBadRequest)
-	createTurn("null toolRefs", `{"output":{"text":{}},"messages":[{"role":"user","text":"hello"}],"toolRefs":null}`, http.StatusBadRequest)
-	createTurn("global credential mode", `{"output":{"text":{}},"messages":[{"role":"user","text":"hello"}],"toolRefs":[{"app":"*","credentialMode":"none"}]}`, http.StatusBadRequest)
-	createTurn("system title", `{"output":{"text":{}},"messages":[{"role":"user","text":"hello"}],"toolRefs":[{"system":"workflow","operation":"schedules.list","title":"Schedules"}]}`, http.StatusBadRequest)
+	createTurn("null toolRefs", `{"timeoutSeconds":120,"output":{"text":{}},"messages":[{"role":"user","text":"hello"}],"toolRefs":null}`, http.StatusBadRequest)
+	createTurn("global credential mode", `{"timeoutSeconds":120,"output":{"text":{}},"messages":[{"role":"user","text":"hello"}],"toolRefs":[{"app":"*","credentialMode":"none"}]}`, http.StatusBadRequest)
+	createTurn("system title", `{"timeoutSeconds":120,"output":{"text":{}},"messages":[{"role":"user","text":"hello"}],"toolRefs":[{"system":"workflow","operation":"schedules.list","title":"Schedules"}]}`, http.StatusBadRequest)
 
 	turnRequests := provider.capturedTurnRequests()
 	if len(turnRequests) != 3 {
@@ -1610,12 +1610,12 @@ func TestAgentCreateTurnAcceptsNoneToolSourceWithStructuredOutput(t *testing.T) 
 		}
 	}
 
-	createTurn("structured none", `{"messages":[{"role":"user","text":"grade"}],"toolSource":"none","output":{"structured":{"schema":{"type":"object","properties":{"score":{"type":"number"}}}}}}`, http.StatusCreated)
-	createTurn("null output", `{"messages":[{"role":"user","text":"grade"}],"toolSource":"none","output":null}`, http.StatusBadRequest)
-	createTurn("ambiguous output", `{"messages":[{"role":"user","text":"grade"}],"toolSource":"none","output":{"text":{},"structured":{"schema":{"type":"object"}}}}`, http.StatusBadRequest)
-	createTurn("ambiguous null text output", `{"messages":[{"role":"user","text":"grade"}],"toolSource":"none","output":{"text":null,"structured":{"schema":{"type":"object"}}}}`, http.StatusBadRequest)
-	createTurn("empty schema", `{"messages":[{"role":"user","text":"grade"}],"toolSource":"none","output":{"structured":{"schema":{}}}}`, http.StatusBadRequest)
-	createTurn("none with tools", `{"messages":[{"role":"user","text":"grade"}],"toolSource":"none","toolRefs":[{"app":"docs"}],"output":{"text":{}}}`, http.StatusBadRequest)
+	createTurn("structured none", `{"timeoutSeconds":120,"messages":[{"role":"user","text":"grade"}],"toolSource":"none","output":{"structured":{"schema":{"type":"object","properties":{"score":{"type":"number"}}}}}}`, http.StatusCreated)
+	createTurn("null output", `{"timeoutSeconds":120,"messages":[{"role":"user","text":"grade"}],"toolSource":"none","output":null}`, http.StatusBadRequest)
+	createTurn("ambiguous output", `{"timeoutSeconds":120,"messages":[{"role":"user","text":"grade"}],"toolSource":"none","output":{"text":{},"structured":{"schema":{"type":"object"}}}}`, http.StatusBadRequest)
+	createTurn("ambiguous null text output", `{"timeoutSeconds":120,"messages":[{"role":"user","text":"grade"}],"toolSource":"none","output":{"text":null,"structured":{"schema":{"type":"object"}}}}`, http.StatusBadRequest)
+	createTurn("empty schema", `{"timeoutSeconds":120,"messages":[{"role":"user","text":"grade"}],"toolSource":"none","output":{"structured":{"schema":{}}}}`, http.StatusBadRequest)
+	createTurn("none with tools", `{"timeoutSeconds":120,"messages":[{"role":"user","text":"grade"}],"toolSource":"none","toolRefs":[{"app":"docs"}],"output":{"text":{}}}`, http.StatusBadRequest)
 
 	turnRequests := provider.capturedTurnRequests()
 	if len(turnRequests) != 1 {
@@ -1670,7 +1670,7 @@ func TestAgentTurnOmittedToolsDoNotForceCatalogForUnsupportedProvider(t *testing
 	}
 	sessionID := session["id"].(string)
 
-	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(`{"output":{"text":{}},"messages":[{"role":"user","text":"hello"}]}`))
+	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(`{"timeoutSeconds":120,"output":{"text":{}},"messages":[{"role":"user","text":"hello"}]}`))
 	turnResp, err := http.DefaultClient.Do(turnReq)
 	if err != nil {
 		t.Fatalf("create turn: %v", err)
@@ -1720,7 +1720,7 @@ func TestAgentTurnEventsNormalizeToolPayloads(t *testing.T) {
 	}
 	sessionID := session["id"].(string)
 
-	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(`{"metadata":{"emitToolEvents":true,"nilDisplayAliases":true},"output":{"text":{}},"messages":[{"role":"user","text":"lookup"}]}`))
+	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(`{"timeoutSeconds":120,"metadata":{"emitToolEvents":true,"nilDisplayAliases":true},"output":{"text":{}},"messages":[{"role":"user","text":"lookup"}]}`))
 	turnResp, err := http.DefaultClient.Do(turnReq)
 	if err != nil {
 		t.Fatalf("create turn: %v", err)
@@ -1825,7 +1825,7 @@ func TestAgentSessionAndTurnMetrics(t *testing.T) {
 		t.Fatalf("session response missing id: %#v", session)
 	}
 
-	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(`{"output":{"text":{}},"messages":[{"role":"user","text":"hello"}]}`))
+	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(`{"timeoutSeconds":120,"output":{"text":{}},"messages":[{"role":"user","text":"hello"}]}`))
 	turnReq.AddCookie(&http.Cookie{Name: "session_token", Value: "metric-session"})
 	turnResp, err := http.DefaultClient.Do(turnReq)
 	if err != nil {
@@ -1881,7 +1881,7 @@ func TestAgentSessionsAndTurnsRoundTripWithoutAuth(t *testing.T) {
 	}
 	sessionID := session["id"].(string)
 
-	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(`{"output":{"text":{}},"messages":[{"role":"user","text":"hello"}]}`))
+	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(`{"timeoutSeconds":120,"output":{"text":{}},"messages":[{"role":"user","text":"hello"}]}`))
 	turnResp, err := http.DefaultClient.Do(turnReq)
 	if err != nil {
 		t.Fatalf("create turn: %v", err)
@@ -1942,7 +1942,7 @@ func TestAgentTurnEventStreamSendsHeartbeatBeforeEvents(t *testing.T) {
 	}
 	sessionID := session["id"].(string)
 
-	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(`{"output":{"text":{}},"messages":[{"role":"user","text":"wait"}]}`))
+	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(`{"timeoutSeconds":120,"output":{"text":{}},"messages":[{"role":"user","text":"wait"}]}`))
 	turnReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
 	turnResp, err := http.DefaultClient.Do(turnReq)
 	if err != nil {
@@ -2060,7 +2060,7 @@ func TestAgentTurnEventStreamReportsProviderContextErrorWhileRequestOpen(t *test
 	}
 	sessionID := session["id"].(string)
 
-	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(`{"output":{"text":{}},"messages":[{"role":"user","text":"wait"}]}`))
+	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(`{"timeoutSeconds":120,"output":{"text":{}},"messages":[{"role":"user","text":"wait"}]}`))
 	turnReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
 	turnResp, err := http.DefaultClient.Do(turnReq)
 	if err != nil {
@@ -2161,7 +2161,7 @@ func TestAgentInteractionResolutionAndEventStream(t *testing.T) {
 	_ = json.NewDecoder(sessionResp.Body).Decode(&session)
 	sessionID := session["id"].(string)
 
-	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(`{"metadata":{"requireInteraction":true},"output":{"text":{}},"messages":[{"role":"user","text":"proceed"}]}`))
+	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(`{"timeoutSeconds":120,"metadata":{"requireInteraction":true},"output":{"text":{}},"messages":[{"role":"user","text":"proceed"}]}`))
 	turnReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
 	turnResp, _ := http.DefaultClient.Do(turnReq)
 	defer func() { _ = turnResp.Body.Close() }()

--- a/gestaltd/internal/server/handlers_agent.go
+++ b/gestaltd/internal/server/handlers_agent.go
@@ -118,6 +118,7 @@ type agentTurnCreateRequest struct {
 	Metadata       map[string]any        `json:"metadata,omitempty"`
 	ModelOptions   map[string]any        `json:"modelOptions,omitempty"`
 	IdempotencyKey string                `json:"idempotencyKey,omitempty"`
+	TimeoutSeconds int32                 `json:"timeoutSeconds,omitempty"`
 }
 
 type agentOutputRequest struct {
@@ -612,6 +613,7 @@ func (s *Server) createAgentTurn(w http.ResponseWriter, r *http.Request) {
 		Output:         outputProto,
 		Metadata:       metadata,
 		ModelOptions:   modelOptions,
+		TimeoutSeconds: req.TimeoutSeconds,
 	})
 	if err != nil {
 		if errors.Is(err, agentmanager.ErrAgentSessionNotFound) {

--- a/gestaltd/internal/server/tracing_test.go
+++ b/gestaltd/internal/server/tracing_test.go
@@ -252,7 +252,7 @@ func TestTracing_AgentTurnTraceTree(t *testing.T) {
 		t.Fatalf("session response missing id: %#v", session)
 	}
 
-	turnBody := `{"output":{"text":{}},"messages":[{"role":"user","text":"search docs"}],"toolRefs":[{"app":"docs","operation":"search"}]}`
+	turnBody := `{"timeoutSeconds":120,"output":{"text":{}},"messages":[{"role":"user","text":"search docs"}],"toolRefs":[{"app":"docs","operation":"search"}]}`
 	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(turnBody))
 	turnReq.AddCookie(&http.Cookie{Name: "session_token", Value: "agent-session"})
 	turnResp, err := http.DefaultClient.Do(turnReq)

--- a/gestaltd/internal/server/workflow_schedule_test.go
+++ b/gestaltd/internal/server/workflow_schedule_test.go
@@ -981,7 +981,7 @@ func TestWorkflowScheduleAgentStepPreservesWorkflowSystemToolRefs(t *testing.T) 
 	})
 	testutil.CloseOnCleanup(t, ts)
 
-	createBody := bytes.NewBufferString(`{"cron":"*/5 * * * *","timezone":"UTC","target":{"steps":[{"id":"agent","agent":{"provider":"managed","model":"deep","prompt":"Manage schedules","output":{"text":{}},"tools":[{"system":"workflow","operation":"schedules.list"},{"app":"roadmap","operation":"sync"}]}}]}}`)
+	createBody := bytes.NewBufferString(`{"cron":"*/5 * * * *","timezone":"UTC","target":{"steps":[{"id":"agent","timeoutSeconds":90,"agent":{"provider":"managed","model":"deep","prompt":"Manage schedules","output":{"text":{}},"tools":[{"system":"workflow","operation":"schedules.list"},{"app":"roadmap","operation":"sync"}]}}]}}`)
 	createReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/workflow/schedules/", createBody)
 	createReq.Header.Set("Content-Type", "application/json")
 	createReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
@@ -2314,7 +2314,7 @@ func TestWorkflowEventTriggerAgentThenAppStepsCreateAndList(t *testing.T) {
 	createReq, _ := http.NewRequest(
 		http.MethodPost,
 		ts.URL+"/api/v1/workflow/event-triggers/",
-		bytes.NewBufferString(`{"provider":"basic","match":{"type":"slack.message.created","source":"slack","subject":"thread"},"target":{"steps":[{"id":"agent","agent":{"provider":"managed","model":"deep","prompt":"Reply to the Slack thread","output":{"text":{}}}},{"id":"reply","app":{"name":"roadmap","operation":"sync","input":{"object":{"format":{"literal":"final"},"text":{"stepOutput":{"stepId":"agent","path":"agent.output.text.text"}},"thread_ts":{"signalPayload":"extensions.slack_thread_ts"}}}}}]}}`),
+		bytes.NewBufferString(`{"provider":"basic","match":{"type":"slack.message.created","source":"slack","subject":"thread"},"target":{"steps":[{"id":"agent","timeoutSeconds":90,"agent":{"provider":"managed","model":"deep","prompt":"Reply to the Slack thread","output":{"text":{}}}},{"id":"reply","app":{"name":"roadmap","operation":"sync","input":{"object":{"format":{"literal":"final"},"text":{"stepOutput":{"stepId":"agent","path":"agent.output.text.text"}},"thread_ts":{"signalPayload":"extensions.slack_thread_ts"}}}}}]}}`),
 	)
 	createReq.Header.Set("Content-Type", "application/json")
 	createReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})

--- a/gestaltd/rpc/protov1/v1/agent.pb.go
+++ b/gestaltd/rpc/protov1/v1/agent.pb.go
@@ -2361,13 +2361,16 @@ type CreateAgentProviderTurnRequest struct {
 	Subject            *SubjectContext        `protobuf:"bytes,14,opt,name=subject,proto3" json:"subject,omitempty"`
 	ModelOptions       *structpb.Struct       `protobuf:"bytes,16,opt,name=model_options,json=modelOptions,proto3" json:"model_options,omitempty"`
 	RunGrant           string                 `protobuf:"bytes,17,opt,name=run_grant,json=runGrant,proto3" json:"run_grant,omitempty"`
-	TimeoutSeconds     int32                  `protobuf:"varint,18,opt,name=timeout_seconds,json=timeoutSeconds,proto3" json:"timeout_seconds,omitempty"`
-	InvocationToken    string                 `protobuf:"bytes,19,opt,name=invocation_token,json=invocationToken,proto3" json:"invocation_token,omitempty"`
-	ToolRefsSet        bool                   `protobuf:"varint,20,opt,name=tool_refs_set,json=toolRefsSet,proto3" json:"tool_refs_set,omitempty"`
-	Output             *AgentOutput           `protobuf:"bytes,21,opt,name=output,proto3" json:"output,omitempty"`
-	Workflow           *structpb.Struct       `protobuf:"bytes,22,opt,name=workflow,proto3" json:"workflow,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// Optional provider-owned turn execution budget, in seconds.
+	// If unset or zero, the provider chooses its own execution timeout. This does
+	// not control the CreateTurn RPC deadline.
+	TimeoutSeconds  int32            `protobuf:"varint,18,opt,name=timeout_seconds,json=timeoutSeconds,proto3" json:"timeout_seconds,omitempty"`
+	InvocationToken string           `protobuf:"bytes,19,opt,name=invocation_token,json=invocationToken,proto3" json:"invocation_token,omitempty"`
+	ToolRefsSet     bool             `protobuf:"varint,20,opt,name=tool_refs_set,json=toolRefsSet,proto3" json:"tool_refs_set,omitempty"`
+	Output          *AgentOutput     `protobuf:"bytes,21,opt,name=output,proto3" json:"output,omitempty"`
+	Workflow        *structpb.Struct `protobuf:"bytes,22,opt,name=workflow,proto3" json:"workflow,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *CreateAgentProviderTurnRequest) Reset() {

--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -752,8 +752,8 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req *p
 	if err := validateAgentOutput(requestedOutput); err != nil {
 		return nil, err
 	}
-	if req.GetTimeoutSeconds() <= 0 {
-		return nil, fmt.Errorf("%w: timeout_seconds must be positive", invocation.ErrInvalidInvocation)
+	if req.GetTimeoutSeconds() < 0 {
+		return nil, fmt.Errorf("%w: timeout_seconds must not be negative", invocation.ErrInvalidInvocation)
 	}
 	var tools []coreagent.Tool
 	switch toolSource {

--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -496,14 +496,10 @@ func (m *Manager) CreateSession(ctx context.Context, p *principal.Principal, req
 		if sessionStart != nil || workspace != nil {
 			return nil, err
 		}
-		fallback, getErr := provider.GetSession(ctx, &proto.GetAgentProviderSessionRequest{
-			SessionId: sessionID,
-			Subject:   agentSubjectToProto(agentSubjectFromPrincipal(p)),
-		})
-		if getErr != nil {
+		session, err = m.getCreatedSessionAfterCreateError(ctx, p, provider, sessionID)
+		if err != nil {
 			return nil, err
 		}
-		session = fallback
 	}
 	normalized, err := normalizeProviderSessionForCreate(providerName, sessionID, idempotencyKey, session)
 	if err != nil {
@@ -516,6 +512,13 @@ func (m *Manager) CreateSession(ctx context.Context, p *principal.Principal, req
 		return nil, core.ErrNotFound
 	}
 	return normalized, nil
+}
+
+func (m *Manager) getCreatedSessionAfterCreateError(ctx context.Context, p *principal.Principal, provider coreagent.Provider, sessionID string) (*coreagent.Session, error) {
+	return provider.GetSession(ctx, &proto.GetAgentProviderSessionRequest{
+		SessionId: sessionID,
+		Subject:   agentSubjectToProto(agentSubjectFromPrincipal(p)),
+	})
 }
 
 func (m *Manager) GetSession(ctx context.Context, p *principal.Principal, req *proto.GetAgentProviderSessionRequest) (session *coreagent.Session, err error) {
@@ -749,6 +752,9 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req *p
 	if err := validateAgentOutput(requestedOutput); err != nil {
 		return nil, err
 	}
+	if req.GetTimeoutSeconds() <= 0 {
+		return nil, fmt.Errorf("%w: timeout_seconds must be positive", invocation.ErrInvalidInvocation)
+	}
 	var tools []coreagent.Tool
 	switch toolSource {
 	case coreagent.ToolSourceModeMCPCatalog:
@@ -798,15 +804,7 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req *p
 	providerReq.InvocationToken = ""
 	turn, err = ownedSession.provider.CreateTurn(ctx, providerReq)
 	if err != nil {
-		fallback, getErr := ownedSession.provider.GetTurn(ctx, &proto.GetAgentProviderTurnRequest{
-			TurnId:  turnID,
-			Subject: agentSubjectToProto(agentSubjectFromPrincipal(p)),
-		})
-		if getErr == nil {
-			turn = fallback
-		} else {
-			return nil, err
-		}
+		return nil, err
 	}
 	normalized, err := normalizeProviderTurnForCreate(ownedSession.providerName, ownedSession.session.ID, turnID, idempotencyKey, turn)
 	if err != nil {

--- a/gestaltd/services/agents/agentmanager/manager_test.go
+++ b/gestaltd/services/agents/agentmanager/manager_test.go
@@ -1860,7 +1860,7 @@ func TestManagerCreateTurnValidatesStructuredOutputSchema(t *testing.T) {
 			wantCreated: true,
 		},
 		{
-			name: "turn execution budget is required",
+			name: "turn execution budget can be omitted",
 			caps: &coreagent.ProviderCapabilities{
 				SupportedToolSources: []coreagent.ToolSourceMode{
 					coreagent.ToolSourceModeNone,
@@ -1869,6 +1869,20 @@ func TestManagerCreateTurnValidatesStructuredOutputSchema(t *testing.T) {
 			req: &proto.CreateAgentProviderTurnRequest{
 				ToolSource: proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_NONE,
 				Output:     agentTextOutputProto(),
+			},
+			wantCreated: true,
+		},
+		{
+			name: "turn execution budget rejects negative values",
+			caps: &coreagent.ProviderCapabilities{
+				SupportedToolSources: []coreagent.ToolSourceMode{
+					coreagent.ToolSourceModeNone,
+				},
+			},
+			req: &proto.CreateAgentProviderTurnRequest{
+				TimeoutSeconds: -1,
+				ToolSource:     proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_NONE,
+				Output:         agentTextOutputProto(),
 			},
 			wantErr: invocation.ErrInvalidInvocation,
 		},

--- a/gestaltd/services/agents/agentmanager/manager_test.go
+++ b/gestaltd/services/agents/agentmanager/manager_test.go
@@ -840,9 +840,10 @@ func TestManagerVisibleNonOwnedSessionReadsButCannotWrite(t *testing.T) {
 		t.Fatalf("CreateSession: %v", err)
 	}
 	turn, err := manager.CreateTurn(context.Background(), owner, &proto.CreateAgentProviderTurnRequest{
-		SessionId: session.ID,
-		Model:     "test-model",
-		Output:    agentTextOutputProto(),
+		TimeoutSeconds: 1,
+		SessionId:      session.ID,
+		Model:          "test-model",
+		Output:         agentTextOutputProto(),
 	})
 	if err != nil {
 		t.Fatalf("CreateTurn: %v", err)
@@ -857,7 +858,12 @@ func TestManagerVisibleNonOwnedSessionReadsButCannotWrite(t *testing.T) {
 	if _, err := manager.UpdateSession(context.Background(), viewer, &proto.UpdateAgentProviderSessionRequest{SessionId: session.ID, ClientRef: "viewer-edit"}); !errors.Is(err, core.ErrNotFound) {
 		t.Fatalf("UpdateSession as visible non-owner error = %v, want not found", err)
 	}
-	if _, err := manager.CreateTurn(context.Background(), viewer, &proto.CreateAgentProviderTurnRequest{SessionId: session.ID, Model: "test-model", Output: agentTextOutputProto()}); !errors.Is(err, ErrAgentSessionNotFound) {
+	if _, err := manager.CreateTurn(context.Background(), viewer, &proto.CreateAgentProviderTurnRequest{
+		TimeoutSeconds: 1,
+		SessionId:      session.ID,
+		Model:          "test-model",
+		Output:         agentTextOutputProto(),
+	}); !errors.Is(err, ErrAgentSessionNotFound) {
 		t.Fatalf("CreateTurn as visible non-owner error = %v, want session not found", err)
 	}
 	if _, err := manager.CancelTurn(context.Background(), viewer, &proto.CancelAgentProviderTurnRequest{TurnId: turn.ID, Reason: "viewer-cancel"}); !errors.Is(err, core.ErrNotFound) {
@@ -900,6 +906,7 @@ func TestManagerCreateTurnAcceptsProviderOwnedIDForIdempotentReplay(t *testing.T
 		t.Fatalf("CreateSession: %v", err)
 	}
 	turn, err := manager.CreateTurn(context.Background(), p, &proto.CreateAgentProviderTurnRequest{
+		TimeoutSeconds: 1,
 		SessionId:      session.ID,
 		IdempotencyKey: "turn-replay",
 		Model:          "test-model",
@@ -1080,10 +1087,11 @@ func TestManagerListTurnsReturnsCapabilityErrorWhenCapabilityReadUnavailable(t *
 		t.Fatalf("CreateSession: %v", err)
 	}
 	if _, err := manager.CreateTurn(ctx, p, &proto.CreateAgentProviderTurnRequest{
-		SessionId: session.ID,
-		Model:     "test-model",
-		Messages:  mustAgentMessages(t, []coreagent.Message{{Role: "user", Text: "hello"}}),
-		Output:    agentTextOutputProto(),
+		TimeoutSeconds: 1,
+		SessionId:      session.ID,
+		Model:          "test-model",
+		Messages:       mustAgentMessages(t, []coreagent.Message{{Role: "user", Text: "hello"}}),
+		Output:         agentTextOutputProto(),
 	}); err != nil {
 		t.Fatalf("CreateTurn: %v", err)
 	}
@@ -1129,10 +1137,11 @@ func TestManagerCreateTurnLeavesToolSourceUnsetWhenNoToolsRequested(t *testing.T
 		t.Fatalf("CreateSession: %v", err)
 	}
 	_, err = manager.CreateTurn(context.Background(), p, &proto.CreateAgentProviderTurnRequest{
-		SessionId: session.ID,
-		Model:     "test-model",
-		Tools:     []*proto.ResolvedAgentTool{{Id: "spoofed-tool", Name: "spoofed_tool"}},
-		Output:    agentTextOutputProto(),
+		TimeoutSeconds: 1,
+		SessionId:      session.ID,
+		Model:          "test-model",
+		Tools:          []*proto.ResolvedAgentTool{{Id: "spoofed-tool", Name: "spoofed_tool"}},
+		Output:         agentTextOutputProto(),
 	})
 	if err != nil {
 		t.Fatalf("CreateTurn: %v", err)
@@ -1181,9 +1190,10 @@ func TestManagerCreateTurnDefaultsToCatalogToolsForCatalogOnlyProvider(t *testin
 		t.Fatalf("CreateSession: %v", err)
 	}
 	_, err = manager.CreateTurn(context.Background(), p, &proto.CreateAgentProviderTurnRequest{
-		SessionId: session.ID,
-		Model:     "test-model",
-		Output:    agentTextOutputProto(),
+		TimeoutSeconds: 1,
+		SessionId:      session.ID,
+		Model:          "test-model",
+		Output:         agentTextOutputProto(),
 	})
 	if err != nil {
 		t.Fatalf("CreateTurn: %v", err)
@@ -1243,10 +1253,11 @@ func TestManagerCreateTurnNarrowsImplicitDefaultCatalogRefsForLargeMentionedProv
 		t.Fatalf("CreateSession: %v", err)
 	}
 	_, err = manager.CreateTurn(context.Background(), p, &proto.CreateAgentProviderTurnRequest{
-		SessionId: session.ID,
-		Model:     "test-model",
-		Messages:  mustAgentMessages(t, []coreagent.Message{{Role: "user", Text: "show me my linear tickets"}}),
-		Output:    agentTextOutputProto(),
+		TimeoutSeconds: 1,
+		SessionId:      session.ID,
+		Model:          "test-model",
+		Messages:       mustAgentMessages(t, []coreagent.Message{{Role: "user", Text: "show me my linear tickets"}}),
+		Output:         agentTextOutputProto(),
 	})
 	if err != nil {
 		t.Fatalf("CreateTurn: %v", err)
@@ -1308,10 +1319,11 @@ func TestManagerCreateTurnKeepsImplicitWildcardForSmallCatalogs(t *testing.T) {
 		t.Fatalf("CreateSession: %v", err)
 	}
 	_, err = manager.CreateTurn(context.Background(), p, &proto.CreateAgentProviderTurnRequest{
-		SessionId: session.ID,
-		Model:     "test-model",
-		Messages:  mustAgentMessages(t, []coreagent.Message{{Role: "user", Text: "show me my linear tickets"}}),
-		Output:    agentTextOutputProto(),
+		TimeoutSeconds: 1,
+		SessionId:      session.ID,
+		Model:          "test-model",
+		Messages:       mustAgentMessages(t, []coreagent.Message{{Role: "user", Text: "show me my linear tickets"}}),
+		Output:         agentTextOutputProto(),
 	})
 	if err != nil {
 		t.Fatalf("CreateTurn: %v", err)
@@ -1348,10 +1360,11 @@ func TestManagerCreateTurnDoesNotEnumerateCatalogsWhenNoProviderMentionMatches(t
 		t.Fatalf("CreateSession: %v", err)
 	}
 	_, err = manager.CreateTurn(context.Background(), p, &proto.CreateAgentProviderTurnRequest{
-		SessionId: session.ID,
-		Model:     "test-model",
-		Messages:  mustAgentMessages(t, []coreagent.Message{{Role: "user", Text: "show me my tickets"}}),
-		Output:    agentTextOutputProto(),
+		TimeoutSeconds: 1,
+		SessionId:      session.ID,
+		Model:          "test-model",
+		Messages:       mustAgentMessages(t, []coreagent.Message{{Role: "user", Text: "show me my tickets"}}),
+		Output:         agentTextOutputProto(),
 	})
 	if err != nil {
 		t.Fatalf("CreateTurn: %v", err)
@@ -1391,10 +1404,11 @@ func TestManagerCreateTurnDoesNotStemProviderMentionsForImplicitNarrowing(t *tes
 		t.Fatalf("CreateSession: %v", err)
 	}
 	_, err = manager.CreateTurn(context.Background(), p, &proto.CreateAgentProviderTurnRequest{
-		SessionId: session.ID,
-		Model:     "test-model",
-		Messages:  mustAgentMessages(t, []coreagent.Message{{Role: "user", Text: "open a doc"}}),
-		Output:    agentTextOutputProto(),
+		TimeoutSeconds: 1,
+		SessionId:      session.ID,
+		Model:          "test-model",
+		Messages:       mustAgentMessages(t, []coreagent.Message{{Role: "user", Text: "open a doc"}}),
+		Output:         agentTextOutputProto(),
 	})
 	if err != nil {
 		t.Fatalf("CreateTurn: %v", err)
@@ -1437,10 +1451,11 @@ func TestManagerCreateTurnKeepsImplicitWildcardForCallerAppDefaults(t *testing.T
 	}
 	ctx := WithCallerAppName(context.Background(), "slack")
 	_, err = manager.CreateTurn(ctx, p, &proto.CreateAgentProviderTurnRequest{
-		SessionId: session.ID,
-		Model:     "test-model",
-		Messages:  mustAgentMessages(t, []coreagent.Message{{Role: "user", Text: "show me my linear tickets"}}),
-		Output:    agentTextOutputProto(),
+		TimeoutSeconds: 1,
+		SessionId:      session.ID,
+		Model:          "test-model",
+		Messages:       mustAgentMessages(t, []coreagent.Message{{Role: "user", Text: "show me my linear tickets"}}),
+		Output:         agentTextOutputProto(),
 	})
 	if err != nil {
 		t.Fatalf("CreateTurn: %v", err)
@@ -1488,8 +1503,9 @@ func TestManagerCreateTurnNarrowsFromLatestUserTextOnly(t *testing.T) {
 		t.Fatalf("CreateSession: %v", err)
 	}
 	_, err = manager.CreateTurn(context.Background(), p, &proto.CreateAgentProviderTurnRequest{
-		SessionId: session.ID,
-		Model:     "test-model",
+		TimeoutSeconds: 1,
+		SessionId:      session.ID,
+		Model:          "test-model",
 		Messages: mustAgentMessages(t, []coreagent.Message{
 			{Role: "user", Text: "linear was mentioned earlier"},
 			{Role: "assistant", Text: "linear is still in assistant text"},
@@ -1546,10 +1562,11 @@ func TestManagerCreateTurnKeepsImplicitWildcardWhenMentionedProviderCannotBeProb
 		t.Fatalf("CreateSession: %v", err)
 	}
 	_, err = manager.CreateTurn(context.Background(), p, &proto.CreateAgentProviderTurnRequest{
-		SessionId: session.ID,
-		Model:     "test-model",
-		Messages:  mustAgentMessages(t, []coreagent.Message{{Role: "user", Text: "show me my linear tickets"}}),
-		Output:    agentTextOutputProto(),
+		TimeoutSeconds: 1,
+		SessionId:      session.ID,
+		Model:          "test-model",
+		Messages:       mustAgentMessages(t, []coreagent.Message{{Role: "user", Text: "show me my linear tickets"}}),
+		Output:         agentTextOutputProto(),
 	})
 	if err != nil {
 		t.Fatalf("CreateTurn: %v", err)
@@ -1596,10 +1613,11 @@ func TestManagerCreateTurnKeepsImplicitWildcardWhenMentionedProviderUnavailable(
 		t.Fatalf("CreateSession: %v", err)
 	}
 	_, err = manager.CreateTurn(context.Background(), p, &proto.CreateAgentProviderTurnRequest{
-		SessionId: session.ID,
-		Model:     "test-model",
-		Messages:  mustAgentMessages(t, []coreagent.Message{{Role: "user", Text: "show me my linear tickets"}}),
-		Output:    agentTextOutputProto(),
+		TimeoutSeconds: 1,
+		SessionId:      session.ID,
+		Model:          "test-model",
+		Messages:       mustAgentMessages(t, []coreagent.Message{{Role: "user", Text: "show me my linear tickets"}}),
+		Output:         agentTextOutputProto(),
 	})
 	if err != nil {
 		t.Fatalf("CreateTurn: %v", err)
@@ -1648,10 +1666,11 @@ func TestManagerCreateTurnKeepsImplicitWildcardWhenMentionedProviderHasNoVisible
 		t.Fatalf("CreateSession: %v", err)
 	}
 	_, err = manager.CreateTurn(context.Background(), p, &proto.CreateAgentProviderTurnRequest{
-		SessionId: session.ID,
-		Model:     "test-model",
-		Messages:  mustAgentMessages(t, []coreagent.Message{{Role: "user", Text: "show me linear"}}),
-		Output:    agentTextOutputProto(),
+		TimeoutSeconds: 1,
+		SessionId:      session.ID,
+		Model:          "test-model",
+		Messages:       mustAgentMessages(t, []coreagent.Message{{Role: "user", Text: "show me linear"}}),
+		Output:         agentTextOutputProto(),
 	})
 	if err != nil {
 		t.Fatalf("CreateTurn: %v", err)
@@ -1684,10 +1703,11 @@ func TestManagerCreateTurnHonorsExplicitCatalogSourceWithNoToolRefs(t *testing.T
 		t.Fatalf("CreateSession: %v", err)
 	}
 	_, err = manager.CreateTurn(context.Background(), p, &proto.CreateAgentProviderTurnRequest{
-		SessionId:  session.ID,
-		Model:      "test-model",
-		ToolSource: proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_MCP_CATALOG,
-		Output:     agentTextOutputProto(),
+		TimeoutSeconds: 1,
+		SessionId:      session.ID,
+		Model:          "test-model",
+		ToolSource:     proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_MCP_CATALOG,
+		Output:         agentTextOutputProto(),
 	})
 	if err != nil {
 		t.Fatalf("CreateTurn: %v", err)
@@ -1738,10 +1758,11 @@ func TestManagerCreateTurnHonorsNoneToolSource(t *testing.T) {
 		t.Fatalf("CreateSession: %v", err)
 	}
 	_, err = manager.CreateTurn(context.Background(), p, &proto.CreateAgentProviderTurnRequest{
-		SessionId:  session.ID,
-		Model:      "test-model",
-		ToolSource: proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_NONE,
-		Output:     agentTextOutputProto(),
+		TimeoutSeconds: 1,
+		SessionId:      session.ID,
+		Model:          "test-model",
+		ToolSource:     proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_NONE,
+		Output:         agentTextOutputProto(),
 	})
 	if err != nil {
 		t.Fatalf("CreateTurn: %v", err)
@@ -1789,8 +1810,9 @@ func TestManagerCreateTurnValidatesStructuredOutputSchema(t *testing.T) {
 				},
 			},
 			req: &proto.CreateAgentProviderTurnRequest{
-				ToolSource: proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_NONE,
-				Output:     agentStructuredOutputProto(t, map[string]any{"type": "object"}),
+				TimeoutSeconds: 1,
+				ToolSource:     proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_NONE,
+				Output:         agentStructuredOutputProto(t, map[string]any{"type": "object"}),
 			},
 			wantCreated: true,
 		},
@@ -1802,8 +1824,9 @@ func TestManagerCreateTurnValidatesStructuredOutputSchema(t *testing.T) {
 				},
 			},
 			req: &proto.CreateAgentProviderTurnRequest{
-				ToolSource: proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_NONE,
-				Output:     agentStructuredOutputProto(t, map[string]any{}),
+				TimeoutSeconds: 1,
+				ToolSource:     proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_NONE,
+				Output:         agentStructuredOutputProto(t, map[string]any{}),
 			},
 			wantErr: invocation.ErrInvalidInvocation,
 		},
@@ -1815,9 +1838,10 @@ func TestManagerCreateTurnValidatesStructuredOutputSchema(t *testing.T) {
 				},
 			},
 			req: &proto.CreateAgentProviderTurnRequest{
-				ToolSource: proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_NONE,
-				ToolRefs:   []*proto.AgentToolRef{{App: "docs"}},
-				Output:     agentTextOutputProto(),
+				TimeoutSeconds: 1,
+				ToolSource:     proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_NONE,
+				ToolRefs:       []*proto.AgentToolRef{{App: "docs"}},
+				Output:         agentTextOutputProto(),
 			},
 			wantErr: invocation.ErrInvalidInvocation,
 		},
@@ -1829,10 +1853,24 @@ func TestManagerCreateTurnValidatesStructuredOutputSchema(t *testing.T) {
 				},
 			},
 			req: &proto.CreateAgentProviderTurnRequest{
+				TimeoutSeconds: 1,
+				ToolSource:     proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_NONE,
+				Output:         agentTextOutputProto(),
+			},
+			wantCreated: true,
+		},
+		{
+			name: "turn execution budget is required",
+			caps: &coreagent.ProviderCapabilities{
+				SupportedToolSources: []coreagent.ToolSourceMode{
+					coreagent.ToolSourceModeNone,
+				},
+			},
+			req: &proto.CreateAgentProviderTurnRequest{
 				ToolSource: proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_NONE,
 				Output:     agentTextOutputProto(),
 			},
-			wantCreated: true,
+			wantErr: invocation.ErrInvalidInvocation,
 		},
 	}
 	for _, tt := range tests {
@@ -1918,10 +1956,11 @@ func TestManagerCreateTurnHonorsExplicitEmptyToolRefsWithoutToolSource(t *testin
 		t.Fatalf("CreateSession: %v", err)
 	}
 	_, err = manager.CreateTurn(context.Background(), p, &proto.CreateAgentProviderTurnRequest{
-		SessionId:   session.ID,
-		Model:       "test-model",
-		ToolRefsSet: true,
-		Output:      agentTextOutputProto(),
+		TimeoutSeconds: 1,
+		SessionId:      session.ID,
+		Model:          "test-model",
+		ToolRefsSet:    true,
+		Output:         agentTextOutputProto(),
 	})
 	if err != nil {
 		t.Fatalf("CreateTurn: %v", err)
@@ -1992,10 +2031,11 @@ func TestManagerRejectsAmbiguousSuccessfulTurnOutput(t *testing.T) {
 	}
 
 	_, err = manager.CreateTurn(context.Background(), p, &proto.CreateAgentProviderTurnRequest{
-		SessionId:  session.ID,
-		Model:      "test-model",
-		ToolSource: proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_NONE,
-		Output:     agentTextOutputProto(),
+		TimeoutSeconds: 1,
+		SessionId:      session.ID,
+		Model:          "test-model",
+		ToolSource:     proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_NONE,
+		Output:         agentTextOutputProto(),
 	})
 	if err == nil {
 		t.Fatal("CreateTurn error = nil, want ambiguous successful output error")
@@ -2027,9 +2067,10 @@ func TestManagerCancelTurnRevokesRunGrantWithoutBootstrapWrapper(t *testing.T) {
 		t.Fatalf("CreateSession: %v", err)
 	}
 	turn, err := manager.CreateTurn(context.Background(), p, &proto.CreateAgentProviderTurnRequest{
-		SessionId: session.ID,
-		Model:     "test-model",
-		Output:    agentTextOutputProto(),
+		TimeoutSeconds: 1,
+		SessionId:      session.ID,
+		Model:          "test-model",
+		Output:         agentTextOutputProto(),
 	})
 	if err != nil {
 		t.Fatalf("CreateTurn: %v", err)
@@ -2083,6 +2124,7 @@ func TestManagerCancelTurnRevokesExecutionRefGrantWithoutBootstrapWrapper(t *tes
 		t.Fatalf("CreateSession: %v", err)
 	}
 	turn, err := manager.CreateTurn(context.Background(), p, &proto.CreateAgentProviderTurnRequest{
+		TimeoutSeconds: 1,
 		SessionId:      session.ID,
 		IdempotencyKey: "provider-owned-turn",
 		Model:          "test-model",

--- a/gestaltd/services/agents/client.go
+++ b/gestaltd/services/agents/client.go
@@ -145,7 +145,7 @@ func (r *remoteAgent) UpdateSession(ctx context.Context, req *proto.UpdateAgentP
 }
 
 func (r *remoteAgent) CreateTurn(ctx context.Context, req *proto.CreateAgentProviderTurnRequest) (*coreagent.Turn, error) {
-	ctx, cancel := runtimehost.ProviderWorkflowAgentCallContext(ctx)
+	ctx, cancel := runtimehost.ProviderCallContext(ctx)
 	defer cancel()
 	providerReq := cloneAgentRequest(req, &proto.CreateAgentProviderTurnRequest{})
 	providerReq.InvocationToken = appaccess.InvocationTokenFromContext(ctx)
@@ -157,7 +157,7 @@ func (r *remoteAgent) CreateTurn(ctx context.Context, req *proto.CreateAgentProv
 }
 
 func (r *remoteAgent) GetTurn(ctx context.Context, req *proto.GetAgentProviderTurnRequest) (*coreagent.Turn, error) {
-	ctx, cancel := runtimehost.ProviderWorkflowAgentCallContext(ctx)
+	ctx, cancel := runtimehost.ProviderCallContext(ctx)
 	defer cancel()
 	providerReq := cloneAgentRequest(req, &proto.GetAgentProviderTurnRequest{})
 	providerReq.InvocationToken = appaccess.InvocationTokenFromContext(ctx)

--- a/gestaltd/services/agents/client_test.go
+++ b/gestaltd/services/agents/client_test.go
@@ -187,63 +187,7 @@ func TestRemoteAgentCreateSessionPreservesWorkflowDeadline(t *testing.T) {
 	}
 }
 
-func TestRemoteAgentWorkflowAgentTurnCallsPreserveMarkedDeadline(t *testing.T) {
-	t.Parallel()
-
-	parentDeadline := time.Now().Add(2 * runtimehost.ProviderSessionCreateTimeout)
-	var createTurnRemaining time.Duration
-	var getTurnRemaining time.Duration
-	agent := &remoteAgent{
-		client: &fakeAgentProviderClient{
-			createTurn: func(ctx context.Context, req *proto.CreateAgentProviderTurnRequest, _ ...grpc.CallOption) (*proto.AgentTurn, error) {
-				deadline, ok := ctx.Deadline()
-				if !ok {
-					t.Fatal("CreateTurn context has no deadline")
-				}
-				createTurnRemaining = time.Until(deadline)
-				return &proto.AgentTurn{
-					Id:        "turn-1",
-					SessionId: req.GetSessionId(),
-					Status:    proto.AgentExecutionStatus_AGENT_EXECUTION_STATUS_RUNNING,
-				}, nil
-			},
-			getTurn: func(ctx context.Context, req *proto.GetAgentProviderTurnRequest, _ ...grpc.CallOption) (*proto.AgentTurn, error) {
-				deadline, ok := ctx.Deadline()
-				if !ok {
-					t.Fatal("GetTurn context has no deadline")
-				}
-				getTurnRemaining = time.Until(deadline)
-				return &proto.AgentTurn{
-					Id:     req.GetTurnId(),
-					Status: proto.AgentExecutionStatus_AGENT_EXECUTION_STATUS_RUNNING,
-				}, nil
-			},
-		},
-	}
-	parent, cancel := context.WithDeadline(context.Background(), parentDeadline)
-	defer cancel()
-	ctx := runtimehost.WithWorkflowAgentProviderDeadline(parent)
-
-	if _, err := agent.CreateTurn(ctx, &proto.CreateAgentProviderTurnRequest{SessionId: "session-1"}); err != nil {
-		t.Fatalf("CreateTurn: %v", err)
-	}
-	if _, err := agent.GetTurn(ctx, &proto.GetAgentProviderTurnRequest{TurnId: "turn-1"}); err != nil {
-		t.Fatalf("GetTurn: %v", err)
-	}
-	for name, remaining := range map[string]time.Duration{
-		"CreateTurn": createTurnRemaining,
-		"GetTurn":    getTurnRemaining,
-	} {
-		if remaining <= runtimehost.ProviderRPCTimeout {
-			t.Fatalf("%s remaining deadline = %s, want above provider RPC timeout %s", name, remaining, runtimehost.ProviderRPCTimeout)
-		}
-		if remaining > 2*runtimehost.ProviderSessionCreateTimeout {
-			t.Fatalf("%s remaining deadline = %s, want at most parent deadline %s", name, remaining, 2*runtimehost.ProviderSessionCreateTimeout)
-		}
-	}
-}
-
-func TestRemoteAgentTurnCallsKeepProviderTimeoutWithoutWorkflowMarker(t *testing.T) {
+func TestRemoteAgentTurnCallsUseProviderTimeout(t *testing.T) {
 	t.Parallel()
 
 	parentDeadline := time.Now().Add(2 * runtimehost.ProviderSessionCreateTimeout)
@@ -281,14 +225,13 @@ func TestRemoteAgentTurnCallsKeepProviderTimeoutWithoutWorkflowMarker(t *testing
 	parent, cancel := context.WithDeadline(context.Background(), parentDeadline)
 	defer cancel()
 
-	if _, err := agent.CreateTurn(parent, &proto.CreateAgentProviderTurnRequest{SessionId: "session-1"}); err != nil {
+	if _, err := agent.CreateTurn(parent, &proto.CreateAgentProviderTurnRequest{SessionId: "session-1", TimeoutSeconds: 300}); err != nil {
 		t.Fatalf("CreateTurn: %v", err)
 	}
 	if _, err := agent.GetTurn(parent, &proto.GetAgentProviderTurnRequest{TurnId: "turn-1"}); err != nil {
 		t.Fatalf("GetTurn: %v", err)
 	}
-	marked := runtimehost.WithWorkflowAgentProviderDeadline(parent)
-	if _, err := agent.GetSession(marked, &proto.GetAgentProviderSessionRequest{SessionId: "session-1"}); err != nil {
+	if _, err := agent.GetSession(parent, &proto.GetAgentProviderSessionRequest{SessionId: "session-1"}); err != nil {
 		t.Fatalf("GetSession: %v", err)
 	}
 	for name, remaining := range map[string]time.Duration{

--- a/gestaltd/services/agents/manager_server_test.go
+++ b/gestaltd/services/agents/manager_server_test.go
@@ -201,6 +201,7 @@ func TestManagerServerCreateTurnForwardsStructuredOutputInputs(t *testing.T) {
 		t.Fatalf("NewStruct: %v", err)
 	}
 	_, err = server.CreateTurn(context.Background(), &proto.CreateAgentProviderTurnRequest{
+		TimeoutSeconds:  1,
 		SessionId:       "session-1",
 		InvocationToken: token,
 		Workflow:        workflow,
@@ -298,8 +299,9 @@ func TestManagerServerCreateTurnUsesWorkflowRunAsWithoutInvocationTokenFromAppSt
 		t.Fatalf("CreateSession: %v", err)
 	}
 	if _, err := server.CreateTurn(context.Background(), &proto.CreateAgentProviderTurnRequest{
-		SessionId: "session-1",
-		Workflow:  workflow,
+		TimeoutSeconds: 1,
+		SessionId:      "session-1",
+		Workflow:       workflow,
 	}); err != nil {
 		t.Fatalf("CreateTurn: %v", err)
 	}
@@ -336,8 +338,9 @@ func TestManagerServerCreateTurnRequiresTokenOrPersistedWorkflowRunAs(t *testing
 				}
 			}
 			_, err := server.CreateTurn(context.Background(), &proto.CreateAgentProviderTurnRequest{
-				SessionId: "session-1",
-				Workflow:  workflow,
+				TimeoutSeconds: 1,
+				SessionId:      "session-1",
+				Workflow:       workflow,
 			})
 			if status.Code(err) != codes.FailedPrecondition {
 				t.Fatalf("CreateTurn code = %v, want %v (err=%v)", status.Code(err), codes.FailedPrecondition, err)
@@ -372,6 +375,7 @@ func TestManagerServerCreateTurnRequiresInvocationTokenCallerApp(t *testing.T) {
 	}, tokens)
 
 	if _, err := server.CreateTurn(context.Background(), &proto.CreateAgentProviderTurnRequest{
+		TimeoutSeconds:  1,
 		SessionId:       "session-1",
 		InvocationToken: token,
 	}); status.Code(err) != codes.FailedPrecondition {

--- a/gestaltd/services/runtimehost/runtime_client.go
+++ b/gestaltd/services/runtimehost/runtime_client.go
@@ -25,8 +25,6 @@ const (
 	providerStartTimeout         = 2 * time.Minute
 )
 
-type workflowAgentProviderDeadlineKey struct{}
-
 var providerConfigureTimeout = 30 * time.Second
 
 type RuntimeProviderMetadata struct {
@@ -158,30 +156,6 @@ func ProviderCallContext(parent context.Context) (context.Context, context.Cance
 		parent = context.Background()
 	}
 	return context.WithTimeout(parent, ProviderRPCTimeout)
-}
-
-// WithWorkflowAgentProviderDeadline marks provider RPCs that are part of a
-// workflow-owned agent run. Only workflow agent call helpers should observe it.
-func WithWorkflowAgentProviderDeadline(parent context.Context) context.Context {
-	if parent == nil {
-		parent = context.Background()
-	}
-	return context.WithValue(parent, workflowAgentProviderDeadlineKey{}, true)
-}
-
-// ProviderWorkflowAgentCallContext returns a context for workflow-owned agent
-// turn RPCs. It preserves the workflow run deadline only when explicitly marked;
-// otherwise it keeps the normal provider RPC timeout.
-func ProviderWorkflowAgentCallContext(parent context.Context) (context.Context, context.CancelFunc) {
-	if parent == nil {
-		parent = context.Background()
-	}
-	if marked, _ := parent.Value(workflowAgentProviderDeadlineKey{}).(bool); marked {
-		if _, ok := parent.Deadline(); ok {
-			return context.WithCancel(parent)
-		}
-	}
-	return ProviderCallContext(parent)
 }
 
 // ProviderSessionCreateContext returns a child context for agent CreateSession RPCs.

--- a/gestaltd/services/runtimehost/runtime_client_test.go
+++ b/gestaltd/services/runtimehost/runtime_client_test.go
@@ -247,58 +247,6 @@ func TestProviderSessionCreateContextPreservesShortParentDeadline(t *testing.T) 
 	}
 }
 
-func TestProviderWorkflowAgentCallContextRequiresMarkerForParentDeadline(t *testing.T) {
-	t.Parallel()
-
-	parentDeadline := time.Now().Add(2 * ProviderSessionCreateTimeout)
-	parent, parentCancel := context.WithDeadline(context.Background(), parentDeadline)
-	defer parentCancel()
-
-	unmarked, unmarkedCancel := ProviderWorkflowAgentCallContext(parent)
-	defer unmarkedCancel()
-	unmarkedDeadline, ok := unmarked.Deadline()
-	if !ok {
-		t.Fatal("unmarked workflow agent context has no deadline")
-	}
-	if unmarkedDeadline.Equal(parentDeadline) {
-		t.Fatal("unmarked workflow agent context preserved parent deadline")
-	}
-	if remaining := time.Until(unmarkedDeadline); remaining > ProviderRPCTimeout {
-		t.Fatalf("unmarked remaining deadline = %s, want at most provider RPC timeout %s", remaining, ProviderRPCTimeout)
-	}
-
-	markedParent := WithWorkflowAgentProviderDeadline(parent)
-	marked, markedCancel := ProviderWorkflowAgentCallContext(markedParent)
-	defer markedCancel()
-	markedDeadline, ok := marked.Deadline()
-	if !ok {
-		t.Fatal("marked workflow agent context has no deadline")
-	}
-	if !markedDeadline.Equal(parentDeadline) {
-		t.Fatalf("marked deadline = %s, want parent deadline %s", markedDeadline, parentDeadline)
-	}
-	parentCancel()
-	select {
-	case <-marked.Done():
-	case <-time.After(time.Second):
-		t.Fatal("marked workflow agent context did not observe parent cancellation")
-	}
-}
-
-func TestProviderWorkflowAgentCallContextFallsBackWithoutParentDeadline(t *testing.T) {
-	t.Parallel()
-
-	ctx, cancel := ProviderWorkflowAgentCallContext(WithWorkflowAgentProviderDeadline(context.Background()))
-	defer cancel()
-	deadline, ok := ctx.Deadline()
-	if !ok {
-		t.Fatal("workflow agent context has no deadline")
-	}
-	if remaining := time.Until(deadline); remaining > ProviderRPCTimeout {
-		t.Fatalf("remaining deadline = %s, want at most provider RPC timeout %s", remaining, ProviderRPCTimeout)
-	}
-}
-
 func TestStartRuntimeProviderValidatesProtocolVersion(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/workflows/telemetry_test.go
+++ b/gestaltd/services/workflows/telemetry_test.go
@@ -861,7 +861,7 @@ func telemetryCoreAppStepTarget() coreworkflow.Target {
 
 func telemetryCoreAgentStepTarget(tools []coreagent.ToolRef) coreworkflow.Target {
 	return coreworkflow.Target{
-		Steps: []coreworkflow.Step{{ID: "run", Agent: &coreworkflow.AgentTurn{
+		Steps: []coreworkflow.Step{{ID: "run", TimeoutSeconds: 1, Agent: &coreworkflow.AgentTurn{
 			ProviderName: "simple",
 			Prompt:       coreworkflow.Text{Template: "handle the Slack message"},
 			ToolRefs:     tools,
@@ -891,7 +891,8 @@ func telemetryProtoAppStepTarget(appName, operation string) *proto.BoundWorkflow
 func telemetryProtoAgentStepTarget(tools []*proto.AgentToolRef) *proto.BoundWorkflowTarget {
 	return &proto.BoundWorkflowTarget{
 		Steps: []*proto.WorkflowStep{{
-			Id: "run",
+			Id:             "run",
+			TimeoutSeconds: 1,
 			Action: &proto.WorkflowStep_Agent{Agent: &proto.WorkflowStepAgentTurn{
 				Provider: "simple",
 				Prompt:   &proto.WorkflowText{Template: "handle the Slack message"},

--- a/gestaltd/services/workflows/workflowmanager/manager_target.go
+++ b/gestaltd/services/workflows/workflowmanager/manager_target.go
@@ -97,6 +97,9 @@ func (m *Manager) resolveTarget(ctx context.Context, p *principal.Principal, tar
 			}
 			step.App = &app
 		case step.Agent != nil:
+			if step.TimeoutSeconds <= 0 {
+				return coreworkflow.Target{}, fmt.Errorf("%w: workflow target.steps[%d].timeout_seconds must be positive for agent steps", invocation.ErrInvalidInvocation, i)
+			}
 			agent, err := m.resolveWorkflowStepAgent(ctx, p, *step.Agent)
 			if err != nil {
 				return coreworkflow.Target{}, fmt.Errorf("workflow target.steps[%d].agent: %w", i, err)

--- a/gestaltd/services/workflows/workflowmanager/manager_target.go
+++ b/gestaltd/services/workflows/workflowmanager/manager_target.go
@@ -97,9 +97,6 @@ func (m *Manager) resolveTarget(ctx context.Context, p *principal.Principal, tar
 			}
 			step.App = &app
 		case step.Agent != nil:
-			if step.TimeoutSeconds <= 0 {
-				return coreworkflow.Target{}, fmt.Errorf("%w: workflow target.steps[%d].timeout_seconds must be positive for agent steps", invocation.ErrInvalidInvocation, i)
-			}
 			agent, err := m.resolveWorkflowStepAgent(ctx, p, *step.Agent)
 			if err != nil {
 				return coreworkflow.Target{}, fmt.Errorf("workflow target.steps[%d].agent: %w", i, err)

--- a/gestaltd/services/workflows/workflowmanager/manager_test.go
+++ b/gestaltd/services/workflows/workflowmanager/manager_test.go
@@ -69,8 +69,9 @@ func testWorkflowAppCall(appName, operation string, input map[string]any, creden
 
 func testWorkflowAgentStepTarget(agent coreworkflow.AgentTurn) coreworkflow.Target {
 	return coreworkflow.Target{Steps: []coreworkflow.Step{{
-		ID:    "run",
-		Agent: &agent,
+		ID:             "run",
+		TimeoutSeconds: 1,
+		Agent:          &agent,
 	}}}
 }
 
@@ -886,7 +887,8 @@ func TestSignalOrStartRunResolvesDeclaredAppCredentialModes(t *testing.T) {
 		CallerAppName: "github",
 		Target: coreworkflow.Target{Steps: []coreworkflow.Step{
 			{
-				ID: "run",
+				ID:             "run",
+				TimeoutSeconds: 1,
 				Agent: &coreworkflow.AgentTurn{
 					ProviderName: "simple",
 					Prompt:       coreworkflow.Text{Template: "Handle the webhook."},
@@ -985,7 +987,8 @@ func TestSignalOrStartRunRejectsStepWhenMissingEquals(t *testing.T) {
 		WorkflowKey:  "agent:steps:missing-equals",
 		Target: coreworkflow.Target{Steps: []coreworkflow.Step{
 			{
-				ID: "diagnosis",
+				ID:             "diagnosis",
+				TimeoutSeconds: 1,
 				Agent: &coreworkflow.AgentTurn{
 					ProviderName: "simple",
 					Prompt:       coreworkflow.Text{Template: "Diagnose the alert."},
@@ -993,7 +996,8 @@ func TestSignalOrStartRunRejectsStepWhenMissingEquals(t *testing.T) {
 				},
 			},
 			{
-				ID: "pr_fix",
+				ID:             "pr_fix",
+				TimeoutSeconds: 1,
 				Agent: &coreworkflow.AgentTurn{
 					ProviderName: "simple",
 					Prompt:       coreworkflow.Text{Template: "Open a PR."},
@@ -1041,7 +1045,8 @@ func TestSignalOrStartRunRejectsStepWhenMissingValue(t *testing.T) {
 		WorkflowKey:  "agent:steps:missing-when-value",
 		Target: coreworkflow.Target{Steps: []coreworkflow.Step{
 			{
-				ID: "diagnosis",
+				ID:             "diagnosis",
+				TimeoutSeconds: 1,
 				Agent: &coreworkflow.AgentTurn{
 					ProviderName: "simple",
 					Prompt:       coreworkflow.Text{Template: "Diagnose the alert."},
@@ -1049,7 +1054,8 @@ func TestSignalOrStartRunRejectsStepWhenMissingValue(t *testing.T) {
 				},
 			},
 			{
-				ID: "pr_fix",
+				ID:             "pr_fix",
+				TimeoutSeconds: 1,
 				Agent: &coreworkflow.AgentTurn{
 					ProviderName: "simple",
 					Prompt:       coreworkflow.Text{Template: "Open a PR."},
@@ -1178,7 +1184,8 @@ func TestSignalOrStartRunRejectsAgentStepWithoutPromptOrMessages(t *testing.T) {
 		ProviderName: "local",
 		WorkflowKey:  "agent:steps:empty-agent",
 		Target: coreworkflow.Target{Steps: []coreworkflow.Step{{
-			ID: "agent",
+			ID:             "agent",
+			TimeoutSeconds: 1,
 			Agent: &coreworkflow.AgentTurn{
 				ProviderName: "simple",
 				Output:       testWorkflowAgentTextOutput(),

--- a/sdk/go/agent_conversions.go
+++ b/sdk/go/agent_conversions.go
@@ -707,8 +707,8 @@ func createAgentProviderTurnRequestFromProto(req *proto.CreateAgentProviderTurnR
 	if req == nil {
 		return nil, InvalidArgument("agent create turn request is required")
 	}
-	if req.GetTimeoutSeconds() <= 0 {
-		return nil, InvalidArgument("agent create turn timeout_seconds must be positive")
+	if req.GetTimeoutSeconds() < 0 {
+		return nil, InvalidArgument("agent create turn timeout_seconds must not be negative")
 	}
 	return &CreateAgentProviderTurnRequest{
 		TurnID:         req.GetTurnId(),

--- a/sdk/go/agent_conversions.go
+++ b/sdk/go/agent_conversions.go
@@ -703,9 +703,12 @@ func listAgentTurnsResponseFromProto(value *proto.ListAgentProviderTurnsResponse
 	return &ListAgentTurnsResponse{Turns: agentTurnsFromProto(value.GetTurns())}
 }
 
-func createAgentProviderTurnRequestFromProto(req *proto.CreateAgentProviderTurnRequest) *CreateAgentProviderTurnRequest {
+func createAgentProviderTurnRequestFromProto(req *proto.CreateAgentProviderTurnRequest) (*CreateAgentProviderTurnRequest, error) {
 	if req == nil {
-		return &CreateAgentProviderTurnRequest{}
+		return nil, InvalidArgument("agent create turn request is required")
+	}
+	if req.GetTimeoutSeconds() <= 0 {
+		return nil, InvalidArgument("agent create turn timeout_seconds must be positive")
 	}
 	return &CreateAgentProviderTurnRequest{
 		TurnID:         req.GetTurnId(),
@@ -724,7 +727,7 @@ func createAgentProviderTurnRequestFromProto(req *proto.CreateAgentProviderTurnR
 		ModelOptions:   mapFromStruct(req.GetModelOptions()),
 		RunGrant:       req.GetRunGrant(),
 		TimeoutSeconds: req.GetTimeoutSeconds(),
-	}
+	}, nil
 }
 
 func getAgentProviderTurnRequestFromProto(req *proto.GetAgentProviderTurnRequest) *GetAgentProviderTurnRequest {

--- a/sdk/go/agent_inputs.go
+++ b/sdk/go/agent_inputs.go
@@ -137,8 +137,8 @@ func newAgentUpdateSessionRequest(input AgentUpdateSession) (*proto.UpdateAgentP
 }
 
 func newAgentCreateTurnRequest(input AgentCreateTurn) (*proto.CreateAgentProviderTurnRequest, error) {
-	if input.TimeoutSeconds <= 0 {
-		return nil, InvalidArgument("agent create turn timeout_seconds must be positive")
+	if input.TimeoutSeconds < 0 {
+		return nil, InvalidArgument("agent create turn timeout_seconds must not be negative")
 	}
 	messages, err := agentMessagesToProto(input.Messages)
 	if err != nil {

--- a/sdk/go/agent_inputs.go
+++ b/sdk/go/agent_inputs.go
@@ -137,6 +137,9 @@ func newAgentUpdateSessionRequest(input AgentUpdateSession) (*proto.UpdateAgentP
 }
 
 func newAgentCreateTurnRequest(input AgentCreateTurn) (*proto.CreateAgentProviderTurnRequest, error) {
+	if input.TimeoutSeconds <= 0 {
+		return nil, InvalidArgument("agent create turn timeout_seconds must be positive")
+	}
 	messages, err := agentMessagesToProto(input.Messages)
 	if err != nil {
 		return nil, err

--- a/sdk/go/agent_provider_transport_test.go
+++ b/sdk/go/agent_provider_transport_test.go
@@ -356,6 +356,7 @@ func TestAgentProviderTypedTransportRoundTrip(t *testing.T) {
 	}
 
 	turn, err := agentClient.CreateTurn(rpcCtx, &proto.CreateAgentProviderTurnRequest{
+		TimeoutSeconds: 1,
 		TurnId:         "turn-1",
 		SessionId:      "session-1",
 		IdempotencyKey: "turn-req-1",

--- a/sdk/go/agent_transport_test.go
+++ b/sdk/go/agent_transport_test.go
@@ -142,8 +142,9 @@ func TestTransport_AgentTCPTargetTokenEnv(t *testing.T) {
 	}
 
 	turn, err := client.CreateTurn(context.Background(), gestalt.AgentCreateTurn{
-		SessionID: "session-1",
-		Model:     "gpt-test",
+		SessionID:      "session-1",
+		Model:          "gpt-test",
+		TimeoutSeconds: 120,
 	})
 	if err != nil {
 		t.Fatalf("CreateTurn: %v", err)
@@ -225,8 +226,9 @@ func TestTransport_AgentWorkflowContextWithoutInvocationToken(t *testing.T) {
 		t.Fatalf("CreateSession: %v", err)
 	}
 	if _, err := client.CreateTurn(ctx, gestalt.AgentCreateTurn{
-		SessionID: "session-1",
-		Model:     "gpt-test",
+		SessionID:      "session-1",
+		Model:          "gpt-test",
+		TimeoutSeconds: 120,
 	}); err != nil {
 		t.Fatalf("CreateTurn: %v", err)
 	}
@@ -347,8 +349,9 @@ func TestTransport_AgentCreateTurnNativeValues(t *testing.T) {
 		Output: &gestalt.AgentOutput{
 			Structured: &gestalt.AgentStructuredOutput{Schema: map[string]any{"type": "object"}},
 		},
-		Metadata:     map[string]any{"request": "native"},
-		ModelOptions: map[string]any{"temperature": 0},
+		Metadata:       map[string]any{"request": "native"},
+		ModelOptions:   map[string]any{"temperature": 0},
+		TimeoutSeconds: 120,
 	})
 	if err != nil {
 		t.Fatalf("CreateTurn: %v", err)
@@ -377,5 +380,8 @@ func TestTransport_AgentCreateTurnNativeValues(t *testing.T) {
 	}
 	if schema := got.GetOutput().GetStructured().GetSchema().AsMap(); schema["type"] != "object" {
 		t.Fatalf("output schema = %#v", schema)
+	}
+	if got.GetTimeoutSeconds() != 120 {
+		t.Fatalf("timeout_seconds = %d, want 120", got.GetTimeoutSeconds())
 	}
 }

--- a/sdk/go/serve_agent.go
+++ b/sdk/go/serve_agent.go
@@ -57,7 +57,11 @@ func (s agentProviderServer) UpdateSession(ctx context.Context, req *proto.Updat
 }
 
 func (s agentProviderServer) CreateTurn(ctx context.Context, req *proto.CreateAgentProviderTurnRequest) (*proto.AgentTurn, error) {
-	turn, err := s.provider.CreateTurn(ctx, createAgentProviderTurnRequestFromProto(req))
+	providerReq, err := createAgentProviderTurnRequestFromProto(req)
+	if err != nil {
+		return nil, providerRPCError("agent create turn", err)
+	}
+	turn, err := s.provider.CreateTurn(ctx, providerReq)
 	if err != nil {
 		return nil, providerRPCError("agent create turn", err)
 	}

--- a/sdk/go/workflow/executor.go
+++ b/sdk/go/workflow/executor.go
@@ -151,10 +151,6 @@ func (e *Executor) Execute(ctx context.Context, req Request) (*Response, error) 
 		case step.App != nil:
 			output, err = e.invokeAppStep(stepCtx, req, token, step.App, inputs, result.Outputs, scope, stepID)
 		case step.Agent != nil:
-			if step.TimeoutSeconds <= 0 {
-				cancelStep()
-				return workflowFailedStepResponse(result, stepID, "invalid_step", "workflow agent step timeout_seconds must be positive")
-			}
 			output, turnID, err = e.invokeAgentStep(stepCtx, req, token, step.Agent, inputs, sessions, scope, stepID, step.TimeoutSeconds, step.Metadata)
 		default:
 			err = fmt.Errorf("workflow step must set app or agent")

--- a/sdk/go/workflow/executor.go
+++ b/sdk/go/workflow/executor.go
@@ -151,6 +151,10 @@ func (e *Executor) Execute(ctx context.Context, req Request) (*Response, error) 
 		case step.App != nil:
 			output, err = e.invokeAppStep(stepCtx, req, token, step.App, inputs, result.Outputs, scope, stepID)
 		case step.Agent != nil:
+			if step.TimeoutSeconds <= 0 {
+				cancelStep()
+				return workflowFailedStepResponse(result, stepID, "invalid_step", "workflow agent step timeout_seconds must be positive")
+			}
 			output, turnID, err = e.invokeAgentStep(stepCtx, req, token, step.Agent, inputs, sessions, scope, stepID, step.TimeoutSeconds, step.Metadata)
 		default:
 			err = fmt.Errorf("workflow step must set app or agent")

--- a/sdk/go/workflow/steps.go
+++ b/sdk/go/workflow/steps.go
@@ -92,9 +92,6 @@ func (e *Executor) invokeAppStep(ctx context.Context, req Request, token string,
 }
 
 func (e *Executor) invokeAgentStep(ctx context.Context, req Request, token string, agent *gestalt.WorkflowStepAgentTurn, inputs map[string]any, sessions map[string]workflowAgentSessionState, invocationScope, stepID string, timeoutSeconds int32, stepMetadata any) (any, string, error) {
-	if timeoutSeconds <= 0 {
-		return nil, "", fmt.Errorf("workflow agent step timeout_seconds must be positive")
-	}
 	client, err := e.newAgent(token)
 	if err != nil {
 		return nil, "", err

--- a/sdk/go/workflow/steps.go
+++ b/sdk/go/workflow/steps.go
@@ -92,6 +92,9 @@ func (e *Executor) invokeAppStep(ctx context.Context, req Request, token string,
 }
 
 func (e *Executor) invokeAgentStep(ctx context.Context, req Request, token string, agent *gestalt.WorkflowStepAgentTurn, inputs map[string]any, sessions map[string]workflowAgentSessionState, invocationScope, stepID string, timeoutSeconds int32, stepMetadata any) (any, string, error) {
+	if timeoutSeconds <= 0 {
+		return nil, "", fmt.Errorf("workflow agent step timeout_seconds must be positive")
+	}
 	client, err := e.newAgent(token)
 	if err != nil {
 		return nil, "", err

--- a/sdk/go/workflow/workflow_test.go
+++ b/sdk/go/workflow/workflow_test.go
@@ -116,7 +116,8 @@ func TestExecutorInvokesAgentStepWithWorkflowRunAs(t *testing.T) {
 			CredentialSubjectID: "service_account:workflow-runner",
 		},
 		Target: &gestalt.BoundWorkflowTarget{Steps: []gestalt.WorkflowStep{{
-			ID: "review",
+			ID:             "review",
+			TimeoutSeconds: 45,
 			Agent: &gestalt.WorkflowStepAgentTurn{
 				Provider: "claude",
 				Model:    "default",
@@ -139,6 +140,9 @@ func TestExecutorInvokesAgentStepWithWorkflowRunAs(t *testing.T) {
 	}
 	if agent.turn.SessionID != "session-1" || agent.turn.Messages[0].Text != "review Ada" {
 		t.Fatalf("turn = %#v", agent.turn)
+	}
+	if agent.turn.TimeoutSeconds != 45 {
+		t.Fatalf("turn timeout = %d, want 45", agent.turn.TimeoutSeconds)
 	}
 	runAs := agent.turnWorkflow["runAs"].(map[string]any)
 	if runAs["id"] != "service_account:workflow-runner" {

--- a/sdk/go/workflow_builders.go
+++ b/sdk/go/workflow_builders.go
@@ -164,9 +164,6 @@ func workflowStepToProto(step WorkflowStep) (*proto.WorkflowStep, error) {
 		}
 		out.Action = &proto.WorkflowStep_App{App: app}
 	case step.Agent != nil:
-		if step.TimeoutSeconds <= 0 {
-			return nil, fmt.Errorf("agent timeout_seconds must be positive")
-		}
 		agent, err := workflowStepAgentTurnToProto(step.Agent)
 		if err != nil {
 			return nil, fmt.Errorf("agent: %w", err)

--- a/sdk/go/workflow_builders.go
+++ b/sdk/go/workflow_builders.go
@@ -164,6 +164,9 @@ func workflowStepToProto(step WorkflowStep) (*proto.WorkflowStep, error) {
 		}
 		out.Action = &proto.WorkflowStep_App{App: app}
 	case step.Agent != nil:
+		if step.TimeoutSeconds <= 0 {
+			return nil, fmt.Errorf("agent timeout_seconds must be positive")
+		}
 		agent, err := workflowStepAgentTurnToProto(step.Agent)
 		if err != nil {
 			return nil, fmt.Errorf("agent: %w", err)

--- a/sdk/go/workflow_builders_test.go
+++ b/sdk/go/workflow_builders_test.go
@@ -196,6 +196,7 @@ func TestBoundWorkflowTargetAgentStepCopiesNativeFields(t *testing.T) {
 					},
 					Equals: true,
 				},
+				TimeoutSeconds: 45,
 			},
 		},
 	})

--- a/sdk/go/workflow_transport_test.go
+++ b/sdk/go/workflow_transport_test.go
@@ -152,7 +152,8 @@ func TestTransport_WorkflowSignalOrStartRunInjectsInvocationToken(t *testing.T) 
 		ProviderName: "local",
 		WorkflowKey:  "slack:T123:C123:1700000000.000001",
 		Target: &gestalt.BoundWorkflowTarget{Steps: []gestalt.WorkflowStep{{
-			ID: "respond",
+			ID:             "respond",
+			TimeoutSeconds: 120,
 			Agent: &gestalt.WorkflowStepAgentTurn{
 				Provider: "simple",
 				Model:    "gpt-5.5",
@@ -237,7 +238,8 @@ func TestTransport_WorkflowSignalOrStartRunNativeValues(t *testing.T) {
 		ProviderName: "local",
 		WorkflowKey:  "slack:T123:C123:1700000000.000001",
 		Target: &gestalt.BoundWorkflowTarget{Steps: []gestalt.WorkflowStep{{
-			ID: "respond",
+			ID:             "respond",
+			TimeoutSeconds: 120,
 			Agent: &gestalt.WorkflowStepAgentTurn{
 				Provider: "simple",
 				Model:    "gpt-5.5",

--- a/sdk/proto/v1/agent.proto
+++ b/sdk/proto/v1/agent.proto
@@ -295,6 +295,8 @@ message CreateAgentProviderTurnRequest {
   SubjectContext subject = 14;
   google.protobuf.Struct model_options = 16;
   string run_grant = 17;
+  // Required positive budget, in seconds, for provider-owned turn execution.
+  // This does not control the CreateTurn RPC deadline.
   int32 timeout_seconds = 18;
   string invocation_token = 19;
   bool tool_refs_set = 20;

--- a/sdk/proto/v1/agent.proto
+++ b/sdk/proto/v1/agent.proto
@@ -295,8 +295,9 @@ message CreateAgentProviderTurnRequest {
   SubjectContext subject = 14;
   google.protobuf.Struct model_options = 16;
   string run_grant = 17;
-  // Required positive budget, in seconds, for provider-owned turn execution.
-  // This does not control the CreateTurn RPC deadline.
+  // Optional provider-owned turn execution budget, in seconds.
+  // If unset or zero, the provider chooses its own execution timeout. This does
+  // not control the CreateTurn RPC deadline.
   int32 timeout_seconds = 18;
   string invocation_token = 19;
   bool tool_refs_set = 20;

--- a/sdk/python/gestalt/_agent.py
+++ b/sdk/python/gestalt/_agent.py
@@ -123,7 +123,6 @@ class AgentUpdateSession:
 
 @dataclass(slots=True)
 class AgentCreateTurn:
-    timeout_seconds: int
     session_id: str = ""
     model: str = ""
     messages: Sequence[Any] | None = None
@@ -133,6 +132,7 @@ class AgentCreateTurn:
     metadata: Any | None = None
     idempotency_key: str = ""
     model_options: Any | None = None
+    timeout_seconds: int = 0
 
 
 @dataclass(slots=True)
@@ -434,7 +434,6 @@ class ResolvedAgentTool:
 
 @dataclass(slots=True)
 class CreateAgentProviderTurnRequest:
-    timeout_seconds: int
     turn_id: str = ""
     session_id: str = ""
     idempotency_key: str = ""
@@ -450,6 +449,7 @@ class CreateAgentProviderTurnRequest:
     subject: Subject | None = None
     model_options: JsonObject | None = None
     run_grant: str = ""
+    timeout_seconds: int = 0
 
 
 @dataclass(slots=True)
@@ -699,8 +699,8 @@ def create_agent_provider_turn_request_from_proto(
 ) -> CreateAgentProviderTurnRequest:
     if not has_field(request, "output"):
         raise ValueError("create turn output is required")
-    if request.timeout_seconds <= 0:
-        raise ValueError("agent create turn timeout_seconds must be positive")
+    if request.timeout_seconds < 0:
+        raise ValueError("agent create turn timeout_seconds must not be negative")
     return CreateAgentProviderTurnRequest(
         timeout_seconds=request.timeout_seconds,
         turn_id=request.turn_id,
@@ -2056,13 +2056,13 @@ def _agent_create_turn_request(value: Any | None = None, **kwargs: Any) -> Any:
     if isinstance(value, pb.CreateAgentProviderTurnRequest):
         if not has_field(value, "output"):
             raise ValueError("create turn output is required")
-        if value.timeout_seconds <= 0:
-            raise ValueError("agent create turn timeout_seconds must be positive")
+        if value.timeout_seconds < 0:
+            raise ValueError("agent create turn timeout_seconds must not be negative")
         return _copy(value)
     data = _data(value, kwargs)
     timeout_seconds = data.get("timeout_seconds", 0)
-    if timeout_seconds <= 0:
-        raise ValueError("agent create turn timeout_seconds must be positive")
+    if timeout_seconds < 0:
+        raise ValueError("agent create turn timeout_seconds must not be negative")
     request = pb.CreateAgentProviderTurnRequest(
         session_id=data.get("session_id", ""),
         model=data.get("model", ""),

--- a/sdk/python/gestalt/_agent.py
+++ b/sdk/python/gestalt/_agent.py
@@ -123,6 +123,7 @@ class AgentUpdateSession:
 
 @dataclass(slots=True)
 class AgentCreateTurn:
+    timeout_seconds: int
     session_id: str = ""
     model: str = ""
     messages: Sequence[Any] | None = None
@@ -132,7 +133,6 @@ class AgentCreateTurn:
     metadata: Any | None = None
     idempotency_key: str = ""
     model_options: Any | None = None
-    timeout_seconds: int = 0
 
 
 @dataclass(slots=True)
@@ -434,6 +434,7 @@ class ResolvedAgentTool:
 
 @dataclass(slots=True)
 class CreateAgentProviderTurnRequest:
+    timeout_seconds: int
     turn_id: str = ""
     session_id: str = ""
     idempotency_key: str = ""
@@ -449,7 +450,6 @@ class CreateAgentProviderTurnRequest:
     subject: Subject | None = None
     model_options: JsonObject | None = None
     run_grant: str = ""
-    timeout_seconds: int = 0
 
 
 @dataclass(slots=True)
@@ -699,7 +699,10 @@ def create_agent_provider_turn_request_from_proto(
 ) -> CreateAgentProviderTurnRequest:
     if not has_field(request, "output"):
         raise ValueError("create turn output is required")
+    if request.timeout_seconds <= 0:
+        raise ValueError("agent create turn timeout_seconds must be positive")
     return CreateAgentProviderTurnRequest(
+        timeout_seconds=request.timeout_seconds,
         turn_id=request.turn_id,
         session_id=request.session_id,
         idempotency_key=request.idempotency_key,
@@ -723,7 +726,6 @@ def create_agent_provider_turn_request_from_proto(
         if has_field(request, "model_options")
         else None,
         run_grant=request.run_grant,
-        timeout_seconds=request.timeout_seconds,
     )
 
 
@@ -2054,8 +2056,13 @@ def _agent_create_turn_request(value: Any | None = None, **kwargs: Any) -> Any:
     if isinstance(value, pb.CreateAgentProviderTurnRequest):
         if not has_field(value, "output"):
             raise ValueError("create turn output is required")
+        if value.timeout_seconds <= 0:
+            raise ValueError("agent create turn timeout_seconds must be positive")
         return _copy(value)
     data = _data(value, kwargs)
+    timeout_seconds = data.get("timeout_seconds", 0)
+    if timeout_seconds <= 0:
+        raise ValueError("agent create turn timeout_seconds must be positive")
     request = pb.CreateAgentProviderTurnRequest(
         session_id=data.get("session_id", ""),
         model=data.get("model", ""),
@@ -2065,7 +2072,7 @@ def _agent_create_turn_request(value: Any | None = None, **kwargs: Any) -> Any:
         ],
         tool_source=data.get("tool_source", AGENT_TOOL_SOURCE_MODE_UNSPECIFIED),
         idempotency_key=data.get("idempotency_key", ""),
-        timeout_seconds=data.get("timeout_seconds", 0),
+        timeout_seconds=timeout_seconds,
     )
     request.output.CopyFrom(_agent_output_to_proto(data.get("output")))
     if data.get("metadata") is not None:

--- a/sdk/python/gestalt/_workflow.py
+++ b/sdk/python/gestalt/_workflow.py
@@ -998,19 +998,23 @@ def workflow_step(value: Any | None = None, **kwargs: Any) -> Any:
     """Create a workflow step."""
 
     if isinstance(value, pb.WorkflowStep):
+        _validate_workflow_step_timeout(value)
         return _copy(value)
     data = _data(value, kwargs)
     app = data.get("app")
     agent = data.get("agent")
     if app is not None and agent is not None:
         raise ValueError("workflow step must set either app or agent")
+    timeout_seconds = data.get("timeout_seconds", 0)
+    if agent is not None and timeout_seconds <= 0:
+        raise ValueError("workflow agent step timeout_seconds must be positive")
     step = pb.WorkflowStep(
         id=data.get("id", ""),
         inputs={
             key: _workflow_value_nested(item)
             for key, item in (data.get("inputs") or {}).items()
         },
-        timeout_seconds=data.get("timeout_seconds", 0),
+        timeout_seconds=timeout_seconds,
         metadata=_optional_struct(data.get("metadata")),
     )
     if app is not None:
@@ -1021,6 +1025,11 @@ def workflow_step(value: Any | None = None, **kwargs: Any) -> Any:
     if when is not None:
         step.when.CopyFrom(workflow_step_when(when))
     return step
+
+
+def _validate_workflow_step_timeout(value: Any) -> None:
+    if has_field(value, "agent") and value.timeout_seconds <= 0:
+        raise ValueError("workflow agent step timeout_seconds must be positive")
 
 
 def workflow_step_input_from_step(value: Any | None) -> WorkflowStep | None:
@@ -1054,6 +1063,8 @@ def bound_workflow_target(value: Any | None = None, **kwargs: Any) -> Any:
     """Create a bound workflow target."""
 
     if isinstance(value, pb.BoundWorkflowTarget):
+        for step in value.steps:
+            _validate_workflow_step_timeout(step)
         return _copy(value)
     data = _data(value, kwargs)
     return pb.BoundWorkflowTarget(

--- a/sdk/python/gestalt/_workflow.py
+++ b/sdk/python/gestalt/_workflow.py
@@ -1006,8 +1006,8 @@ def workflow_step(value: Any | None = None, **kwargs: Any) -> Any:
     if app is not None and agent is not None:
         raise ValueError("workflow step must set either app or agent")
     timeout_seconds = data.get("timeout_seconds", 0)
-    if agent is not None and timeout_seconds <= 0:
-        raise ValueError("workflow agent step timeout_seconds must be positive")
+    if timeout_seconds < 0:
+        raise ValueError("workflow step timeout_seconds must not be negative")
     step = pb.WorkflowStep(
         id=data.get("id", ""),
         inputs={
@@ -1028,8 +1028,8 @@ def workflow_step(value: Any | None = None, **kwargs: Any) -> Any:
 
 
 def _validate_workflow_step_timeout(value: Any) -> None:
-    if has_field(value, "agent") and value.timeout_seconds <= 0:
-        raise ValueError("workflow agent step timeout_seconds must be positive")
+    if value.timeout_seconds < 0:
+        raise ValueError("workflow step timeout_seconds must not be negative")
 
 
 def workflow_step_input_from_step(value: Any | None) -> WorkflowStep | None:

--- a/sdk/python/tests/test_agent_transport.py
+++ b/sdk/python/tests/test_agent_transport.py
@@ -962,6 +962,7 @@ class AgentTransportTests(unittest.TestCase):
                 turn_id="turn-1",
                 session_id="session-1",
                 model="gpt-5.1",
+                timeout_seconds=120,
                 messages=[
                     agent_pb2.AgentMessage(
                         role="user",
@@ -1211,6 +1212,7 @@ class AgentTransportTests(unittest.TestCase):
                 agent_pb2.CreateAgentProviderTurnRequest(
                     session_id="session-managed-1",
                     model="gpt-5.1",
+                    timeout_seconds=120,
                     messages=[
                         agent_pb2.AgentMessage(
                             role="user",
@@ -1325,7 +1327,7 @@ class AgentTransportTests(unittest.TestCase):
                     "reason": "",
                     "tool_source": agent_pb2.AGENT_TOOL_SOURCE_MODE_NONE,
                     "tool_ref_count": 0,
-                    "timeout_seconds": 0,
+                    "timeout_seconds": 120,
                     "output_kind": "structured",
                     "has_structured_schema": True,
                 },
@@ -1513,6 +1515,7 @@ class AgentTransportTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "agent output is required"):
                 manager.create_turn(
                     AgentCreateTurn(
+                        timeout_seconds=120,
                         session_id="session-managed-1",
                         messages=[AgentMessage(role="user", text="Summarize this")],
                     )
@@ -1523,6 +1526,7 @@ class AgentTransportTests(unittest.TestCase):
             ):
                 manager.create_turn(
                     AgentCreateTurn(
+                        timeout_seconds=120,
                         session_id="session-managed-1",
                         messages=[AgentMessage(role="user", text="Summarize this")],
                         output=AgentOutput(
@@ -1539,6 +1543,7 @@ class AgentTransportTests(unittest.TestCase):
             ):
                 manager.create_turn(
                     AgentCreateTurn(
+                        timeout_seconds=120,
                         session_id="session-managed-1",
                         messages=[AgentMessage(role="user", text="Summarize this")],
                         output=AgentOutput(

--- a/sdk/python/tests/test_workflow_helpers.py
+++ b/sdk/python/tests/test_workflow_helpers.py
@@ -207,6 +207,7 @@ class WorkflowHelperTests(unittest.TestCase):
                             )
                         ],
                     ),
+                    timeout_seconds=45,
                     when=gestalt.WorkflowStepWhen(
                         value=gestalt.WorkflowValue(
                             step_output=gestalt.WorkflowStepOutputSource(
@@ -280,6 +281,7 @@ class WorkflowHelperTests(unittest.TestCase):
                         output=gestalt.AgentOutput(text=gestalt.AgentTextOutput()),
                         model_options={"temperature": 0},
                     ),
+                    timeout_seconds=45,
                 )
             ]
         )

--- a/sdk/rust/src/agent.rs
+++ b/sdk/rust/src/agent.rs
@@ -1699,6 +1699,11 @@ fn create_session_request_from_proto(
 fn create_turn_request_from_proto(
     value: pb::CreateAgentProviderTurnRequest,
 ) -> ProviderResult<CreateAgentProviderTurnRequest> {
+    if value.timeout_seconds <= 0 {
+        return Err(crate::Error::bad_request(
+            "agent create turn timeout_seconds must be positive",
+        ));
+    }
     Ok(CreateAgentProviderTurnRequest {
         turn_id: value.turn_id,
         session_id: value.session_id,

--- a/sdk/rust/src/agent.rs
+++ b/sdk/rust/src/agent.rs
@@ -1699,9 +1699,9 @@ fn create_session_request_from_proto(
 fn create_turn_request_from_proto(
     value: pb::CreateAgentProviderTurnRequest,
 ) -> ProviderResult<CreateAgentProviderTurnRequest> {
-    if value.timeout_seconds <= 0 {
+    if value.timeout_seconds < 0 {
         return Err(crate::Error::bad_request(
-            "agent create turn timeout_seconds must be positive",
+            "agent create turn timeout_seconds must not be negative",
         ));
     }
     Ok(CreateAgentProviderTurnRequest {

--- a/sdk/rust/src/agent_access.rs
+++ b/sdk/rust/src/agent_access.rs
@@ -296,9 +296,9 @@ pub(crate) fn new_agent_update_session_request(
 pub(crate) fn new_agent_create_turn_request(
     input: AgentCreateTurn,
 ) -> crate::Result<pb::CreateAgentProviderTurnRequest> {
-    if input.timeout_seconds <= 0 {
+    if input.timeout_seconds < 0 {
         return Err(crate::Error::bad_request(
-            "agent create turn timeout_seconds must be positive",
+            "agent create turn timeout_seconds must not be negative",
         ));
     }
     Ok(pb::CreateAgentProviderTurnRequest {

--- a/sdk/rust/src/agent_access.rs
+++ b/sdk/rust/src/agent_access.rs
@@ -296,6 +296,11 @@ pub(crate) fn new_agent_update_session_request(
 pub(crate) fn new_agent_create_turn_request(
     input: AgentCreateTurn,
 ) -> crate::Result<pb::CreateAgentProviderTurnRequest> {
+    if input.timeout_seconds <= 0 {
+        return Err(crate::Error::bad_request(
+            "agent create turn timeout_seconds must be positive",
+        ));
+    }
     Ok(pb::CreateAgentProviderTurnRequest {
         session_id: input.session_id,
         model: input.model,

--- a/sdk/rust/src/generated/gestalt/provider/v1/gestalt.provider.v1.rs
+++ b/sdk/rust/src/generated/gestalt/provider/v1/gestalt.provider.v1.rs
@@ -816,6 +816,8 @@ pub struct CreateAgentProviderTurnRequest {
     pub model_options: ::core::option::Option<::prost_types::Struct>,
     #[prost(string, tag = "17")]
     pub run_grant: ::prost::alloc::string::String,
+    /// Required positive budget, in seconds, for provider-owned turn execution.
+    /// This does not control the CreateTurn RPC deadline.
     #[prost(int32, tag = "18")]
     pub timeout_seconds: i32,
     #[prost(string, tag = "19")]

--- a/sdk/rust/src/generated/gestalt/provider/v1/gestalt.provider.v1.rs
+++ b/sdk/rust/src/generated/gestalt/provider/v1/gestalt.provider.v1.rs
@@ -816,8 +816,9 @@ pub struct CreateAgentProviderTurnRequest {
     pub model_options: ::core::option::Option<::prost_types::Struct>,
     #[prost(string, tag = "17")]
     pub run_grant: ::prost::alloc::string::String,
-    /// Required positive budget, in seconds, for provider-owned turn execution.
-    /// This does not control the CreateTurn RPC deadline.
+    /// Optional provider-owned turn execution budget, in seconds.
+    /// If unset or zero, the provider chooses its own execution timeout. This does
+    /// not control the CreateTurn RPC deadline.
     #[prost(int32, tag = "18")]
     pub timeout_seconds: i32,
     #[prost(string, tag = "19")]

--- a/sdk/rust/src/workflow.rs
+++ b/sdk/rust/src/workflow.rs
@@ -873,9 +873,9 @@ fn workflow_step_when_from_proto(input: pb::WorkflowStepWhen) -> WorkflowStepWhe
 
 /// Creates a workflow step.
 pub fn new_workflow_step(input: WorkflowStep) -> ProviderResult<WorkflowStep> {
-    if matches!(input.action, WorkflowStepAction::Agent(_)) && input.timeout_seconds <= 0 {
+    if input.timeout_seconds < 0 {
         return Err(crate::Error::bad_request(
-            "workflow agent step timeout_seconds must be positive",
+            "workflow step timeout_seconds must not be negative",
         ));
     }
     Ok(WorkflowStep {
@@ -913,11 +913,6 @@ fn workflow_step_to_proto(input: WorkflowStep) -> ProviderResult<pb::WorkflowSte
             Some(Action::App(workflow_step_app_call_to_proto(value)?))
         }
         WorkflowStepAction::Agent(value) => {
-            if input.timeout_seconds <= 0 {
-                return Err(crate::Error::bad_request(
-                    "workflow agent step timeout_seconds must be positive",
-                ));
-            }
             Some(Action::Agent(workflow_step_agent_turn_to_proto(value)?))
         }
     };

--- a/sdk/rust/src/workflow.rs
+++ b/sdk/rust/src/workflow.rs
@@ -873,6 +873,11 @@ fn workflow_step_when_from_proto(input: pb::WorkflowStepWhen) -> WorkflowStepWhe
 
 /// Creates a workflow step.
 pub fn new_workflow_step(input: WorkflowStep) -> ProviderResult<WorkflowStep> {
+    if matches!(input.action, WorkflowStepAction::Agent(_)) && input.timeout_seconds <= 0 {
+        return Err(crate::Error::bad_request(
+            "workflow agent step timeout_seconds must be positive",
+        ));
+    }
     Ok(WorkflowStep {
         id: input.id,
         inputs: input
@@ -908,6 +913,11 @@ fn workflow_step_to_proto(input: WorkflowStep) -> ProviderResult<pb::WorkflowSte
             Some(Action::App(workflow_step_app_call_to_proto(value)?))
         }
         WorkflowStepAction::Agent(value) => {
+            if input.timeout_seconds <= 0 {
+                return Err(crate::Error::bad_request(
+                    "workflow agent step timeout_seconds must be positive",
+                ));
+            }
             Some(Action::Agent(workflow_step_agent_turn_to_proto(value)?))
         }
     };

--- a/sdk/rust/tests/agent_access_transport.rs
+++ b/sdk/rust/tests/agent_access_transport.rs
@@ -522,7 +522,7 @@ async fn agent_connects_over_unix_socket_and_sends_invocation_token() {
             metadata: None,
             idempotency_key: String::new(),
             model_options: None,
-            timeout_seconds: 0,
+            timeout_seconds: 120,
         })
         .await
         .expect("create turn");
@@ -744,7 +744,7 @@ async fn agent_create_turn_accepts_native_values() {
             metadata: Some(serde_json::json!({ "request": "native" })),
             idempotency_key: String::new(),
             model_options: Some(serde_json::json!({ "temperature": 0 })),
-            timeout_seconds: 0,
+            timeout_seconds: 120,
         })
         .await
         .expect("create turn");

--- a/sdk/rust/tests/agent_transport.rs
+++ b/sdk/rust/tests/agent_transport.rs
@@ -592,6 +592,7 @@ async fn agent_runtime_and_server_round_trip_over_unix_socket() {
             turn_id: "turn-1".to_string(),
             session_id: "session-1".to_string(),
             model: "gpt-5.1".to_string(),
+            timeout_seconds: 120,
             messages: vec![pb::AgentMessage {
                 role: "user".to_string(),
                 text: "Plan it".to_string(),

--- a/sdk/rust/tests/workflow_access_transport.rs
+++ b/sdk/rust/tests/workflow_access_transport.rs
@@ -1101,6 +1101,7 @@ async fn workflow_signal_or_start_accepts_native_values() {
                         tools: Vec::new(),
                         model_options: None,
                     }),
+                    timeout_seconds: 45,
                     ..Default::default()
                 }],
             }),

--- a/sdk/rust/tests/workflow_builders.rs
+++ b/sdk/rust/tests/workflow_builders.rs
@@ -158,6 +158,7 @@ fn workflow_steps_round_trip_through_copy_helpers() -> gestalt::Result<()> {
                     })),
                     equals: Some(json!(true)),
                 }),
+                timeout_seconds: 45,
                 ..Default::default()
             },
         ],

--- a/sdk/typescript/src/agent-access.ts
+++ b/sdk/typescript/src/agent-access.ts
@@ -103,7 +103,7 @@ export interface AgentCreateTurn {
   metadata?: JsonObjectInput | undefined;
   idempotencyKey?: string | undefined;
   modelOptions?: JsonObjectInput | undefined;
-  timeoutSeconds?: number | undefined;
+  timeoutSeconds: number;
 }
 
 /** Shape accepted when fetching an agent turn through the agent facade. */
@@ -250,6 +250,9 @@ class AgentImpl implements Agent {
 
   /** Creates an agent turn. */
   async createTurn(request: AgentCreateTurn): Promise<AgentTurn> {
+    if (!Number.isInteger(request.timeoutSeconds) || request.timeoutSeconds <= 0) {
+      throw new Error("agent create turn timeoutSeconds must be positive");
+    }
     return agentTurnFromProto(
       await this.client.createTurn({
         sessionId: request.sessionId,
@@ -262,7 +265,7 @@ class AgentImpl implements Agent {
         idempotencyKey: request.idempotencyKey ?? "",
         ...this.invocationContext,
         modelOptions: optionalStruct(request.modelOptions),
-        timeoutSeconds: request.timeoutSeconds ?? 0,
+        timeoutSeconds: request.timeoutSeconds,
       }),
     );
   }

--- a/sdk/typescript/src/agent-access.ts
+++ b/sdk/typescript/src/agent-access.ts
@@ -103,7 +103,7 @@ export interface AgentCreateTurn {
   metadata?: JsonObjectInput | undefined;
   idempotencyKey?: string | undefined;
   modelOptions?: JsonObjectInput | undefined;
-  timeoutSeconds: number;
+  timeoutSeconds?: number | undefined;
 }
 
 /** Shape accepted when fetching an agent turn through the agent facade. */
@@ -250,8 +250,9 @@ class AgentImpl implements Agent {
 
   /** Creates an agent turn. */
   async createTurn(request: AgentCreateTurn): Promise<AgentTurn> {
-    if (!Number.isInteger(request.timeoutSeconds) || request.timeoutSeconds <= 0) {
-      throw new Error("agent create turn timeoutSeconds must be positive");
+    const timeoutSeconds = request.timeoutSeconds ?? 0;
+    if (!Number.isInteger(timeoutSeconds) || timeoutSeconds < 0) {
+      throw new Error("agent create turn timeoutSeconds must not be negative");
     }
     return agentTurnFromProto(
       await this.client.createTurn({
@@ -265,7 +266,7 @@ class AgentImpl implements Agent {
         idempotencyKey: request.idempotencyKey ?? "",
         ...this.invocationContext,
         modelOptions: optionalStruct(request.modelOptions),
-        timeoutSeconds: request.timeoutSeconds,
+        timeoutSeconds,
       }),
     );
   }

--- a/sdk/typescript/src/agent.ts
+++ b/sdk/typescript/src/agent.ts
@@ -879,6 +879,12 @@ function createAgentProviderTurnRequestFromProto(
   if (output === undefined) {
     throw new ConnectError("create turn output is required", Code.InvalidArgument);
   }
+  if (!Number.isInteger(request.timeoutSeconds) || request.timeoutSeconds <= 0) {
+    throw new ConnectError(
+      "agent create turn timeoutSeconds must be positive",
+      Code.InvalidArgument,
+    );
+  }
   return {
     turnId: request.turnId,
     sessionId: request.sessionId,

--- a/sdk/typescript/src/agent.ts
+++ b/sdk/typescript/src/agent.ts
@@ -879,9 +879,9 @@ function createAgentProviderTurnRequestFromProto(
   if (output === undefined) {
     throw new ConnectError("create turn output is required", Code.InvalidArgument);
   }
-  if (!Number.isInteger(request.timeoutSeconds) || request.timeoutSeconds <= 0) {
+  if (!Number.isInteger(request.timeoutSeconds) || request.timeoutSeconds < 0) {
     throw new ConnectError(
-      "agent create turn timeoutSeconds must be positive",
+      "agent create turn timeoutSeconds must not be negative",
       Code.InvalidArgument,
     );
   }

--- a/sdk/typescript/src/internal/gen/v1/agent_pb.ts
+++ b/sdk/typescript/src/internal/gen/v1/agent_pb.ts
@@ -1074,6 +1074,9 @@ export type CreateAgentProviderTurnRequest = Message<"gestalt.provider.v1.Create
   runGrant: string;
 
   /**
+   * Required positive budget, in seconds, for provider-owned turn execution.
+   * This does not control the CreateTurn RPC deadline.
+   *
    * @generated from field: int32 timeout_seconds = 18;
    */
   timeoutSeconds: number;

--- a/sdk/typescript/src/internal/gen/v1/agent_pb.ts
+++ b/sdk/typescript/src/internal/gen/v1/agent_pb.ts
@@ -1074,8 +1074,9 @@ export type CreateAgentProviderTurnRequest = Message<"gestalt.provider.v1.Create
   runGrant: string;
 
   /**
-   * Required positive budget, in seconds, for provider-owned turn execution.
-   * This does not control the CreateTurn RPC deadline.
+   * Optional provider-owned turn execution budget, in seconds.
+   * If unset or zero, the provider chooses its own execution timeout. This does
+   * not control the CreateTurn RPC deadline.
    *
    * @generated from field: int32 timeout_seconds = 18;
    */
@@ -2173,4 +2174,3 @@ export const AgentHost: GenService<{
   },
 }> = /*@__PURE__*/
   serviceDesc(file_v1_agent, 1);
-

--- a/sdk/typescript/src/workflow.ts
+++ b/sdk/typescript/src/workflow.ts
@@ -742,10 +742,9 @@ export function workflowStep(input: WorkflowStep = {}): WorkflowStep {
   }
   const timeoutSeconds = input.timeoutSeconds ?? 0;
   if (
-    agent !== undefined
-    && (!Number.isInteger(timeoutSeconds) || timeoutSeconds <= 0)
+    !Number.isInteger(timeoutSeconds) || timeoutSeconds < 0
   ) {
-    throw new Error("workflow agent step timeoutSeconds must be positive");
+    throw new Error("workflow step timeoutSeconds must not be negative");
   }
   const action: WorkflowStepActionKind = app !== undefined
     ? { case: "app" as const, value: workflowStepAppCall(app) }

--- a/sdk/typescript/src/workflow.ts
+++ b/sdk/typescript/src/workflow.ts
@@ -740,6 +740,13 @@ export function workflowStep(input: WorkflowStep = {}): WorkflowStep {
   if (app !== undefined && agent !== undefined) {
     throw new Error("workflow step must set either app or agent");
   }
+  const timeoutSeconds = input.timeoutSeconds ?? 0;
+  if (
+    agent !== undefined
+    && (!Number.isInteger(timeoutSeconds) || timeoutSeconds <= 0)
+  ) {
+    throw new Error("workflow agent step timeoutSeconds must be positive");
+  }
   const action: WorkflowStepActionKind = app !== undefined
     ? { case: "app" as const, value: workflowStepAppCall(app) }
     : agent !== undefined
@@ -757,7 +764,7 @@ export function workflowStep(input: WorkflowStep = {}): WorkflowStep {
     agent: workflowStepAgentAction(action),
     action,
     when: input.when === undefined ? undefined : workflowStepWhen(input.when),
-    timeoutSeconds: input.timeoutSeconds ?? 0,
+    timeoutSeconds,
     metadata: input.metadata === undefined ? undefined : structFromObject(input.metadata),
   };
 }

--- a/sdk/typescript/tests/agent-access.transport.test.ts
+++ b/sdk/typescript/tests/agent-access.transport.test.ts
@@ -308,6 +308,7 @@ test("Agent forwards invocation tokens across session, turn, and interaction cal
       ],
       output: { text: {} },
       idempotencyKey: "turn-req-1",
+      timeoutSeconds: 120,
     });
     const fetchedTurn = await fromRequest.getTurn({ turnId: "turn-1" });
     const listedTurns = await fromRequest.listTurns({ sessionId: "session-1" });

--- a/sdk/typescript/tests/agent.transport.test.ts
+++ b/sdk/typescript/tests/agent.transport.test.ts
@@ -106,6 +106,7 @@ test("AgentProvider rejects structured output without a schema", async () => {
       create(CreateAgentProviderTurnRequestSchema, {
         turnId: "turn-1",
         sessionId: "session-1",
+        timeoutSeconds: 120,
         output: {
           kind: {
             case: "structured",
@@ -155,6 +156,7 @@ test("AgentProvider forwards invocation tokens to handlers", async () => {
       sessionId: "session-1",
       model: "gpt-test",
       output: { kind: { case: "text", value: {} } },
+      timeoutSeconds: 120,
       invocationToken: "turn-token",
     }),
   );

--- a/sdk/typescript/tests/build.test.ts
+++ b/sdk/typescript/tests/build.test.ts
@@ -969,6 +969,7 @@ test("buildProviderBinary compiles a runnable agent provider executable", async 
         turnId: "turn-1",
         sessionId: session.id,
         model: "gpt-test",
+        timeoutSeconds: 120,
         messages: [
           {
             role: "user",

--- a/sdk/typescript/tests/runtime.test.ts
+++ b/sdk/typescript/tests/runtime.test.ts
@@ -1923,6 +1923,7 @@ test("agent provider target resolves and serves runtime metadata plus agent oper
       sessionId: session.id,
       idempotencyKey: "turn-req-1",
       model: "gpt-test",
+      timeoutSeconds: 120,
       messages: [
         {
           role: "user",
@@ -2028,6 +2029,7 @@ test("agent provider target resolves and serves runtime metadata plus agent oper
       sessionId: session.id,
       idempotencyKey: "turn-req-2",
       model: "gpt-test",
+      timeoutSeconds: 120,
       messages: [
         {
           role: "user",

--- a/sdk/typescript/tests/workflow-access.transport.test.ts
+++ b/sdk/typescript/tests/workflow-access.transport.test.ts
@@ -35,7 +35,7 @@ function workflowAppStepTarget(name: string, operation: string) {
 
 function workflowAgentStepTarget(provider: string, prompt: string) {
   return {
-    steps: [{ id: "agent", agent: { provider, prompt, output: { text: {} } } }],
+    steps: [{ id: "agent", agent: { provider, prompt, output: { text: {} } }, timeoutSeconds: 45 }],
   };
 }
 

--- a/sdk/typescript/tests/workflow-builders.test.ts
+++ b/sdk/typescript/tests/workflow-builders.test.ts
@@ -161,6 +161,7 @@ test("agent and app workflow steps round-trip through copy helpers", () => {
           output: { text: {} },
           tools: [{ app: "github", operation: "createPullRequest" }],
         },
+        timeoutSeconds: 45,
         when: {
           value: {
             stepOutput: {


### PR DESCRIPTION
## Summary

Makes agent `CreateTurn` asynchronous while keeping the existing `timeout_seconds` field as an optional provider-owned execution budget instead of a long RPC deadline.

Gestaltd, the HTTP API, CLI, workflow validation, tool schemas, docs, and the Go, Python, Rust, and TypeScript SDK entry points now reject only negative timeout values. Omitted or zero timeout values are treated as unspecified, so each `AgentProvider` can use its own upstream SDK default instead of Gestalt forcing a budget.

Remote agent `CreateTurn` and `GetTurn` now use the normal provider RPC deadline. Providers are expected to persist the turn, return quickly, and expose progress through the existing turn polling and event APIs; failed `CreateTurn` calls no longer recover through `GetTurn`.

## Interfaces

```proto
message CreateAgentProviderTurnRequest {
  // Optional provider-owned turn execution budget, in seconds.
  // If unset or zero, the provider chooses its own execution timeout. This does
  // not control the CreateTurn RPC deadline.
  int32 timeout_seconds = 18;
}
```

```sh
gestalt agent --cloud
gestalt agent --cloud --timeout-seconds 120

gestalt agent resume <session-id>
gestalt agent resume <session-id> --timeout-seconds 120

gestalt agent turns create <session-id> \
  --message "Summarize the latest roadmap risk."

gestalt agent turns create <session-id> \
  --timeout-seconds 120 \
  --message "Summarize the latest roadmap risk."
```

```yaml
workflows:
  schedules:
    nightly:
      target:
        steps:
          - id: summarize
            agent:
              provider: simple
              output:
                text: {}
          - id: summarize-with-budget
            timeout: 120s
            agent:
              provider: simple
              output:
                text: {}
```

```json
{
  "steps": [
    {
      "id": "summarize",
      "agent": {
        "provider": "simple",
        "output": { "text": {} }
      }
    },
    {
      "id": "summarizeWithBudget",
      "timeoutSeconds": 120,
      "agent": {
        "provider": "simple",
        "output": { "text": {} }
      }
    }
  ]
}
```

## Runtime

Gestaltd forwards a positive `timeout_seconds` value as the provider-owned execution budget on provider turn requests, but does not use it to extend the provider RPC deadline. When the value is omitted or zero, Gestalt sends no explicit budget and the provider can delegate to its upstream SDK default.

The provider call should create durable turn state and return promptly, typically with `PENDING` or `RUNNING` status, while model and tool execution continues provider-side. Workflow execution no longer requires agent steps to declare a timeout; a positive timeout scopes provider-side execution and polling, and omitted or zero leaves the budget provider-owned.
