### PR TITLE
Restore optional agent timeout documentation

### DIFF
--- a/docs/content/client/cli/index.mdx
+++ b/docs/content/client/cli/index.mdx
@@ -207,7 +207,11 @@ with `\` to continue the same user message on the next prompt.
 
 `gestalt agent turns create` is the non-interactive equivalent. It supports
 repeated `--system`, repeated `--message`, repeated `--tool app:operation`,
-`--idempotency-key`, and `--input`. `gestalt agent turns transcript` renders a
+`--idempotency-key`, and `--input`. Use `--timeout-seconds` on interactive
+`gestalt agent`, `gestalt agent resume`, and `gestalt agent turns create` to set
+an optional per-turn execution budget for server-backed sessions; see
+[Agent — Turn timeouts (optional)](/providers/agent#turn-timeouts-optional).
+`gestalt agent turns transcript` renders a
 stored turn by combining the turn's messages from
 `GET /api/v1/agent/turns/{turnID}` with stored display-projected events from
 `GET /api/v1/agent/turns/{turnID}/events`. `gestalt agent turns events list`

--- a/docs/content/providers/agent.mdx
+++ b/docs/content/providers/agent.mdx
@@ -162,6 +162,40 @@ Each `messages[]` entry accepts `role`, optional `text`, optional `parts`, and
 optional `metadata`. `parts[]` supports `type: text | json | tool_call |
 tool_result | image_ref`.
 
+### Turn timeouts (optional)
+
+`timeoutSeconds` is an optional positive execution budget for a provider-owned
+turn. When omitted or zero, the provider chooses its own execution timeout,
+usually by delegating to the upstream model SDK default. The field does not
+extend the `CreateTurn` HTTP or RPC deadline: `CreateTurn` still returns quickly
+while model and tool work continues in the background.
+
+You can set the budget on these surfaces:
+
+- **HTTP/JSON:** `timeoutSeconds` on `POST /api/v1/agent/sessions/{sessionID}/turns`
+- **SDK:** `TimeoutSeconds` (Go), `timeout_seconds` (Python), `timeout_seconds`
+  (Rust), or `timeoutSeconds` (TypeScript) on `AgentCreateTurn`
+- **CLI:** `--timeout-seconds` on `gestalt agent`, `gestalt agent resume`, and
+  `gestalt agent turns create` for server-backed sessions (`--cloud`). Local
+  `gestalt agent` does not accept `--timeout-seconds`; use `--cloud` when you need
+  an explicit turn budget from the CLI.
+- **Workflow steps:** optional per-step `timeout` in YAML (for example `120s`) or
+  `timeoutSeconds` in programmatic targets. See [Workflow](/providers/workflow)
+  and [Config File — `workflows`](/reference/config-file#workflows).
+
+`timeoutSeconds` under `providers.agent.<name>.config` in the example above is
+provider-specific configuration passed into the agent provider, not the Gestalt
+turn API field on `CreateTurn`.
+
+```json
+{
+  "model": "fast",
+  "timeoutSeconds": 120,
+  "messages": [{ "role": "user", "text": "Summarize the roadmap risk." }],
+  "output": { "text": {} }
+}
+```
+
 ## Invoking agents
 
 Use `gestalt agent` for an interactive session:
@@ -432,6 +466,7 @@ provider.
 
 `CreateTurn` should persist the turn and return quickly, usually in `RUNNING` or
 `PENDING`. Long-running model and tool work should continue in the background.
+For an optional per-turn execution budget, see [Turn timeouts (optional)](#turn-timeouts-optional).
 Callers use `GetTurn`, `ListTurnEvents`, and `ListInteractions` to observe
 progress or resolve pending human input.
 
@@ -447,5 +482,5 @@ raw event `type` and `data` remain the source of truth.
 - [HTTP API](/reference/http-api): session, turn, interaction, and event routes
 - [CLI](/client/cli): `gestalt agent`, `gestalt agent sessions`, and `gestalt agent turns`
 - [Runtime](/providers/runtime): sandboxing hosted agent providers
-- [Workflow](/providers/workflow): schedules, triggers, and workflow steps
+- [Workflow](/providers/workflow): definitions, activations, and workflow steps
 - [SDK](/reference/sdk): provider and host-service helpers by language

--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -120,7 +120,10 @@ prepared checkouts.
 
 Turn creation accepts `model`, `messages`, required `output`, optional
 `toolRefs`, optional `toolSource`, optional `metadata`, optional
-`modelOptions`, and optional `idempotencyKey`. `output` must contain exactly one
+`modelOptions`, optional `timeoutSeconds`, and optional `idempotencyKey`.
+`timeoutSeconds` is a provider-owned turn execution budget in seconds; omit it
+or set it to `0` to use the provider default. It does not extend the `CreateTurn`
+request deadline. `output` must contain exactly one
 of `text` or `structured`. Missing `toolRefs[].app` or
 `toolRefs[].operation` returns `400`. Conflicting header/body idempotency keys
 also return `400`, an in-progress idempotent create returns `409`, and an


### PR DESCRIPTION
PR #2288 accidentally removed agent turn timeout documentation during a merge conflict. This change restores a dedicated optional-timeout section in the agent provider guide, plus brief cross-references in the HTTP API and CLI docs, without adding timeout fields to every tutorial example.

Workflow and config-file references for step timeouts were already adequate and are left unchanged.