### PR TITLE
Compile workflow scalar expressions

### DIFF
--- a/gestaltd/core/workflow/validate.go
+++ b/gestaltd/core/workflow/validate.go
@@ -52,6 +52,11 @@ func ValidateValueMapRefs(path string, values map[string]Value, previousSteps ma
 
 // ValidateValueRefs validates step references in a value tree.
 func ValidateValueRefs(path string, value Value, previousSteps map[string]struct{}) error {
+	if value.Template != nil {
+		if err := ValidateTemplateRefs(path+".template", value.Template.Template, previousSteps); err != nil {
+			return err
+		}
+	}
 	if value.StepOutput != nil {
 		stepID := strings.TrimSpace(value.StepOutput.StepID)
 		if stepID == "" {
@@ -59,9 +64,6 @@ func ValidateValueRefs(path string, value Value, previousSteps map[string]struct
 		}
 		if _, ok := previousSteps[stepID]; !ok {
 			return fmt.Errorf("%s.step_output.step_id %q must reference an earlier step", path, stepID)
-		}
-		if strings.TrimSpace(value.StepOutput.Path) == "" {
-			return fmt.Errorf("%s.step_output.path is required", path)
 		}
 	}
 	if value.StepInput != nil {
@@ -71,9 +73,6 @@ func ValidateValueRefs(path string, value Value, previousSteps map[string]struct
 		}
 		if _, ok := previousSteps[stepID]; !ok {
 			return fmt.Errorf("%s.step_input.step_id %q must reference an earlier step", path, stepID)
-		}
-		if strings.TrimSpace(value.StepInput.Path) == "" {
-			return fmt.Errorf("%s.step_input.path is required", path)
 		}
 	}
 	for key := range value.Object {
@@ -87,6 +86,96 @@ func ValidateValueRefs(path string, value Value, previousSteps map[string]struct
 		}
 	}
 	return nil
+}
+
+// TemplateExpressions returns the unescaped ${{ ... }} expressions in a
+// workflow template. A leading extra dollar escapes the marker.
+func TemplateExpressions(template string) ([]string, error) {
+	var out []string
+	for i := 0; i < len(template); {
+		if strings.HasPrefix(template[i:], "$${{") {
+			i += 4
+			continue
+		}
+		if !strings.HasPrefix(template[i:], "${{") {
+			i++
+			continue
+		}
+		end := strings.Index(template[i+3:], "}}")
+		if end < 0 {
+			return nil, fmt.Errorf("unterminated template expression")
+		}
+		expr := strings.TrimSpace(template[i+3 : i+3+end])
+		if expr == "" {
+			return nil, fmt.Errorf("empty template expression")
+		}
+		out = append(out, expr)
+		i += 3 + end + 2
+	}
+	return out, nil
+}
+
+// ValidateTemplateRefs validates workflow template expression roots and step
+// references without evaluating the template.
+func ValidateTemplateRefs(path string, template string, previousSteps map[string]struct{}) error {
+	expressions, err := TemplateExpressions(template)
+	if err != nil {
+		return fmt.Errorf("%s: %w", path, err)
+	}
+	for _, expr := range expressions {
+		if err := validateTemplateExpressionRef(expr, previousSteps); err != nil {
+			return fmt.Errorf("%s expression %q: %w", path, expr, err)
+		}
+	}
+	return nil
+}
+
+func validateTemplateExpressionRef(expr string, previousSteps map[string]struct{}) error {
+	switch {
+	case strings.HasPrefix(expr, "input."):
+		if strings.TrimSpace(strings.TrimPrefix(expr, "input.")) == "" {
+			return fmt.Errorf("input path is required")
+		}
+		return nil
+	case strings.HasPrefix(expr, "signal."):
+		if strings.TrimSpace(strings.TrimPrefix(expr, "signal.")) == "" {
+			return fmt.Errorf("signal path is required")
+		}
+		return nil
+	case strings.HasPrefix(expr, "steps."):
+		return validateTemplateStepExpression(strings.TrimPrefix(expr, "steps."), previousSteps)
+	default:
+		return fmt.Errorf("unsupported root; expected input.*, signal.*, steps.<step>.outputs, or steps.<step>.inputs")
+	}
+}
+
+func validateTemplateStepExpression(expr string, previousSteps map[string]struct{}) error {
+	stepID, tail, ok := strings.Cut(expr, ".")
+	stepID = strings.TrimSpace(stepID)
+	if !ok || stepID == "" {
+		return fmt.Errorf("step id is required")
+	}
+	if _, ok := previousSteps[stepID]; !ok {
+		return fmt.Errorf("step %q must reference an earlier step", stepID)
+	}
+	switch {
+	case tail == "outputs":
+		return nil
+	case strings.HasPrefix(tail, "outputs."):
+		if strings.TrimSpace(strings.TrimPrefix(tail, "outputs.")) == "" {
+			return fmt.Errorf("step output path is required")
+		}
+		return nil
+	case tail == "inputs":
+		return nil
+	case strings.HasPrefix(tail, "inputs."):
+		if strings.TrimSpace(strings.TrimPrefix(tail, "inputs.")) == "" {
+			return fmt.Errorf("step input path is required")
+		}
+		return nil
+	default:
+		return fmt.Errorf("expected outputs or inputs")
+	}
 }
 
 // ValidateStepWhen validates a step when clause and its value references.

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/apps/packageio"
 	"gopkg.in/yaml.v3"
@@ -1026,6 +1027,14 @@ func (c *WorkflowValueConfig) UnmarshalYAML(value *yaml.Node) error {
 		c.Array = out
 		return nil
 	default:
+		if value.Kind == yaml.ScalarNode && value.Tag == "!!str" {
+			var out string
+			if err := value.Decode(&out); err != nil {
+				return err
+			}
+			*c = workflowValueConfigFromScalarString(out)
+			return nil
+		}
 		var out any
 		if err := value.Decode(&out); err != nil {
 			return err
@@ -1033,6 +1042,87 @@ func (c *WorkflowValueConfig) UnmarshalYAML(value *yaml.Node) error {
 		c.Literal = out
 		c.LiteralSet = true
 		return nil
+	}
+}
+
+func workflowValueConfigFromScalarString(value string) WorkflowValueConfig {
+	if !strings.Contains(value, "${{") {
+		return WorkflowValueConfig{Literal: value, LiteralSet: true}
+	}
+	expressions, err := coreworkflow.TemplateExpressions(value)
+	if err == nil && len(expressions) == 1 {
+		if expr, ok := exactWorkflowTemplateExpression(value); ok {
+			if compiled, ok := workflowValueConfigFromExpression(expr); ok {
+				return compiled
+			}
+		}
+	}
+	return WorkflowValueConfig{Template: &WorkflowTextConfig{Template: value}}
+}
+
+func exactWorkflowTemplateExpression(value string) (string, bool) {
+	trimmed := strings.TrimSpace(value)
+	if !strings.HasPrefix(trimmed, "${{") {
+		return "", false
+	}
+	end := strings.Index(trimmed[3:], "}}")
+	if end < 0 {
+		return "", false
+	}
+	exprEnd := 3 + end
+	if strings.TrimSpace(trimmed[exprEnd+2:]) != "" {
+		return "", false
+	}
+	return strings.TrimSpace(trimmed[3:exprEnd]), true
+}
+
+func workflowValueConfigFromExpression(expr string) (WorkflowValueConfig, bool) {
+	expr = strings.TrimSpace(expr)
+	switch {
+	case strings.HasPrefix(expr, "input."):
+		path := strings.TrimSpace(strings.TrimPrefix(expr, "input."))
+		if path == "" {
+			return WorkflowValueConfig{}, false
+		}
+		return WorkflowValueConfig{Input: path}, true
+	case strings.HasPrefix(expr, "signal."):
+		path := strings.TrimSpace(strings.TrimPrefix(expr, "signal."))
+		if path == "" {
+			return WorkflowValueConfig{}, false
+		}
+		return WorkflowValueConfig{Signal: path}, true
+	case strings.HasPrefix(expr, "steps."):
+		return workflowValueConfigFromStepExpression(strings.TrimPrefix(expr, "steps."))
+	default:
+		return WorkflowValueConfig{}, false
+	}
+}
+
+func workflowValueConfigFromStepExpression(expr string) (WorkflowValueConfig, bool) {
+	stepID, tail, ok := strings.Cut(expr, ".")
+	stepID = strings.TrimSpace(stepID)
+	if !ok || stepID == "" {
+		return WorkflowValueConfig{}, false
+	}
+	switch {
+	case tail == "outputs":
+		return WorkflowValueConfig{StepOutput: &WorkflowStepOutputSourceConfig{StepID: stepID}}, true
+	case strings.HasPrefix(tail, "outputs."):
+		path := strings.TrimSpace(strings.TrimPrefix(tail, "outputs."))
+		if path == "" {
+			return WorkflowValueConfig{}, false
+		}
+		return WorkflowValueConfig{StepOutput: &WorkflowStepOutputSourceConfig{StepID: stepID, Path: path}}, true
+	case tail == "inputs":
+		return WorkflowValueConfig{StepInput: &WorkflowStepInputSourceConfig{StepID: stepID}}, true
+	case strings.HasPrefix(tail, "inputs."):
+		path := strings.TrimSpace(strings.TrimPrefix(tail, "inputs."))
+		if path == "" {
+			return WorkflowValueConfig{}, false
+		}
+		return WorkflowValueConfig{StepInput: &WorkflowStepInputSourceConfig{StepID: stepID, Path: path}}, true
+	default:
+		return WorkflowValueConfig{}, false
 	}
 }
 
@@ -3086,78 +3176,153 @@ func parseEnvPlaceholder(key string) (name string, allowEmptyDefault bool, err e
 }
 
 func expandEnvVariables(input string, lookup func(string) (string, bool), preserveMissing bool) (string, string, error) {
-	var expandErr error
 	var firstMissing string
-	resolved := os.Expand(input, func(key string) string {
-		if expandErr != nil {
-			return ""
-		}
+	resolved, err := expandConfigEnvPlaceholders(input, func(key string) (string, error) {
 		name, allowEmptyDefault, err := parseEnvPlaceholder(key)
 		if err != nil {
-			expandErr = err
-			return ""
+			return "", err
 		}
 		if val, ok := lookup(name); ok {
-			return val
+			return val, nil
 		}
 		filePath, ok := lookup(name + "_FILE")
 		if !ok || filePath == "" {
 			if allowEmptyDefault {
-				return ""
+				return "", nil
 			}
 			if preserveMissing {
 				if firstMissing == "" {
 					firstMissing = name
 				}
-				return "${" + key + "}"
+				return "${" + key + "}", nil
 			}
-			return ""
+			return "", nil
 		}
 		data, err := os.ReadFile(filePath)
 		if err != nil {
-			expandErr = fmt.Errorf("resolving %s_FILE: %w", name, err)
-			return ""
+			return "", fmt.Errorf("resolving %s_FILE: %w", name, err)
 		}
-		return strings.TrimRight(string(data), "\r\n")
+		return strings.TrimRight(string(data), "\r\n"), nil
 	})
-	if expandErr != nil {
-		return "", "", fmt.Errorf("expanding config environment variables: %w", expandErr)
+	if err != nil {
+		return "", "", fmt.Errorf("expanding config environment variables: %w", err)
 	}
 	return resolved, firstMissing, nil
 }
 
 func expandEnvVariablesWithMissingSentinels(input string, lookup func(string) (string, bool), sentinelPrefix string) (string, error) {
-	var expandErr error
-	resolved := os.Expand(input, func(key string) string {
-		if expandErr != nil {
-			return ""
-		}
+	resolved, err := expandConfigEnvPlaceholders(input, func(key string) (string, error) {
 		name, allowEmptyDefault, err := parseEnvPlaceholder(key)
 		if err != nil {
-			expandErr = err
-			return ""
+			return "", err
 		}
 		if val, ok := lookup(name); ok {
-			return val
+			return val, nil
 		}
 		filePath, ok := lookup(name + "_FILE")
 		if !ok || filePath == "" {
 			if allowEmptyDefault {
-				return ""
+				return "", nil
 			}
-			return sentinelPrefix + base64.RawURLEncoding.EncodeToString([]byte(name)) + missingEnvSentinelSuffix
+			return sentinelPrefix + base64.RawURLEncoding.EncodeToString([]byte(name)) + missingEnvSentinelSuffix, nil
 		}
 		data, err := os.ReadFile(filePath)
 		if err != nil {
-			expandErr = fmt.Errorf("resolving %s_FILE: %w", name, err)
-			return ""
+			return "", fmt.Errorf("resolving %s_FILE: %w", name, err)
 		}
-		return strings.TrimRight(string(data), "\r\n")
+		return strings.TrimRight(string(data), "\r\n"), nil
 	})
-	if expandErr != nil {
-		return "", fmt.Errorf("expanding config environment variables: %w", expandErr)
+	if err != nil {
+		return "", fmt.Errorf("expanding config environment variables: %w", err)
 	}
 	return resolved, nil
+}
+
+func expandConfigEnvPlaceholders(input string, resolve func(string) (string, error)) (string, error) {
+	var b strings.Builder
+	for i := 0; i < len(input); {
+		if input[i] != '$' {
+			next := strings.IndexByte(input[i:], '$')
+			if next < 0 {
+				b.WriteString(input[i:])
+				break
+			}
+			b.WriteString(input[i : i+next])
+			i += next
+			continue
+		}
+		if i+1 >= len(input) {
+			b.WriteByte(input[i])
+			i++
+			continue
+		}
+		if input[i+1] == '{' {
+			end := strings.IndexByte(input[i+2:], '}')
+			if end < 0 {
+				b.WriteByte(input[i])
+				i++
+				continue
+			}
+			keyEnd := i + 2 + end
+			key := input[i+2 : keyEnd]
+			if !isConfigEnvPlaceholderKey(key) {
+				b.WriteByte(input[i])
+				i++
+				continue
+			}
+			resolved, err := resolve(key)
+			if err != nil {
+				return "", err
+			}
+			b.WriteString(resolved)
+			i = keyEnd + 1
+			continue
+		}
+		if !isConfigEnvNameStart(input[i+1]) {
+			b.WriteByte(input[i])
+			i++
+			continue
+		}
+		keyEnd := i + 2
+		for keyEnd < len(input) && isConfigEnvNameChar(input[keyEnd]) {
+			keyEnd++
+		}
+		resolved, err := resolve(input[i+1 : keyEnd])
+		if err != nil {
+			return "", err
+		}
+		b.WriteString(resolved)
+		i = keyEnd
+	}
+	return b.String(), nil
+}
+
+func isConfigEnvPlaceholderKey(key string) bool {
+	name, _, hasDefault := strings.Cut(key, ":-")
+	if !isConfigEnvName(name) {
+		return false
+	}
+	return hasDefault || name == key
+}
+
+func isConfigEnvName(name string) bool {
+	if name == "" || !isConfigEnvNameStart(name[0]) {
+		return false
+	}
+	for i := 1; i < len(name); i++ {
+		if !isConfigEnvNameChar(name[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func isConfigEnvNameStart(ch byte) bool {
+	return ch == '_' || (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z')
+}
+
+func isConfigEnvNameChar(ch byte) bool {
+	return isConfigEnvNameStart(ch) || (ch >= '0' && ch <= '9')
 }
 
 func overlayEnvIntoNode(node yaml.Node, lookup func(string) (string, bool), preserveMissing bool) (yaml.Node, error) {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -1111,6 +1111,47 @@ func TestExpandEnvVariablesPreservesMissingPlaceholder(t *testing.T) {
 	}
 }
 
+func TestExpandEnvVariablesPreservesWorkflowExpressions(t *testing.T) {
+	t.Parallel()
+
+	got, firstMissing, err := expandEnvVariables(
+		"value: ${{ signal.data.github }} env: ${NAME} short: $SHORT escaped: $${{ literal }} other: ${json.path}",
+		func(key string) (string, bool) {
+			if key == "NAME" {
+				return "resolved", true
+			}
+			if key == "SHORT" {
+				return "short-resolved", true
+			}
+			return "", false
+		},
+		false,
+	)
+	if err != nil {
+		t.Fatalf("expandEnvVariables: %v", err)
+	}
+	if firstMissing != "" {
+		t.Fatalf("expandEnvVariables firstMissing = %q, want empty", firstMissing)
+	}
+	want := "value: ${{ signal.data.github }} env: resolved short: short-resolved escaped: $${{ literal }} other: ${json.path}"
+	if got != want {
+		t.Fatalf("expandEnvVariables = %q, want %q", got, want)
+	}
+
+	got, firstMissing, err = expandEnvVariables("other: ${json.path}", func(string) (string, bool) {
+		return "", false
+	}, true)
+	if err != nil {
+		t.Fatalf("expandEnvVariables preserve missing: %v", err)
+	}
+	if firstMissing != "" {
+		t.Fatalf("expandEnvVariables preserve missing firstMissing = %q, want empty", firstMissing)
+	}
+	if got != "other: ${json.path}" {
+		t.Fatalf("expandEnvVariables preserve missing = %q, want other: ${json.path}", got)
+	}
+}
+
 func TestExpandEnvVariablesRejectsNonEmptyDefault(t *testing.T) {
 	t.Parallel()
 
@@ -3035,6 +3076,79 @@ server:
 		}
 	})
 
+	t.Run("workflow scalar expressions compile to value refs", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+apps:
+  roadmap:
+    source:
+      path: ./app/manifest.yaml
+workflows:
+  definitions:
+    review:
+      provider: temporal
+      runAs:
+        subject:
+          id: service_account:roadmap-events
+      steps:
+        - id: collect
+          app:
+              name: roadmap
+              operation: collect
+              input:
+                repo: "${{ input.github.repository }}"
+        - id: notify
+          app:
+              name: roadmap
+              operation: notify
+              input:
+                previous: "${{ steps.collect.outputs }}"
+                text: "repo=${{ input.github.repository }} status=${{ steps.collect.outputs.status }}"
+      on:
+        github_pr:
+          event:
+            type: github.pull_request
+            source: github
+          input:
+            github: "${{ signal.data.github }}"
+            raw: "${{ signal.data.raw }}"
+providers:
+  workflow:
+    temporal:
+      source:
+        path: ./providers/workflow/temporal
+server:
+  encryptionKey: server-key
+`)
+
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		definition := cfg.Workflows.Definitions["review"]
+		activationInput := definition.On["github_pr"].Input.Object
+		if got := activationInput["github"].Signal; got != "data.github" {
+			t.Fatalf("activation github signal = %q, want data.github", got)
+		}
+		if got := activationInput["raw"].Signal; got != "data.raw" {
+			t.Fatalf("activation raw signal = %q, want data.raw", got)
+		}
+		collectInput := definition.Steps[0].App.Input.Object
+		if got := collectInput["repo"].Input; got != "github.repository" {
+			t.Fatalf("collect repo input = %q, want github.repository", got)
+		}
+		notifyInput := definition.Steps[1].App.Input.Object
+		previous := notifyInput["previous"].StepOutput
+		if previous == nil || previous.StepID != "collect" || previous.Path != "" {
+			t.Fatalf("notify previous step output = %#v, want collect whole output", previous)
+		}
+		text := notifyInput["text"].Template
+		if text == nil || text.Template != "repo=${{ input.github.repository }} status=${{ steps.collect.outputs.status }}" {
+			t.Fatalf("notify text template = %#v", text)
+		}
+	})
+
 	t.Run("workflow target validation errors use canonical paths", func(t *testing.T) {
 		t.Parallel()
 
@@ -3249,6 +3363,41 @@ server:
   encryptionKey: server-key
 `,
 				want: `workflows.definitions.nightly.steps[0].inputs.source.step_output.step_id "pr_fix" must reference an earlier step`,
+			},
+			{
+				name: "app input template rejects future reference",
+				yaml: `
+apps:
+  roadmap:
+    source:
+      path: ./app/manifest.yaml
+workflows:
+  definitions:
+    nightly:
+      provider: temporal
+      runAs:
+        subject:
+          id: service_account:roadmap-workflow
+      steps:
+        - id: diagnosis
+          app:
+              name: roadmap
+              operation: diagnose
+              input:
+                message: "fix ${{ steps.pr_fix.outputs.text }}"
+        - id: pr_fix
+          app:
+              name: roadmap
+              operation: fix
+providers:
+  workflow:
+    temporal:
+      source:
+        path: ./providers/workflow/temporal
+server:
+  encryptionKey: server-key
+`,
+				want: `workflows.definitions.nightly.steps[0].app.input.message.template expression "steps.pr_fix.outputs.text": step "pr_fix" must reference an earlier step`,
 			},
 			{
 				name: "agent step when requires equals",

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -2143,7 +2143,7 @@ func normalizeWorkflowSteps(cfg *Config, path string, steps []WorkflowStepConfig
 			if step.Timeout != "" && parsedTimeout < 0 {
 				return fmt.Errorf("config validation: %s.timeout must not be negative for agent steps", stepPath)
 			}
-			if err := validateWorkflowStepAgentConfig(cfg, stepPath+".agent", step.Agent); err != nil {
+			if err := validateWorkflowStepAgentConfig(cfg, stepPath+".agent", step.Agent, seen); err != nil {
 				return err
 			}
 		}
@@ -2206,7 +2206,7 @@ func normalizeWorkflowStepAppCallConfig(path string, app *WorkflowStepAppCallCon
 	return nil
 }
 
-func validateWorkflowStepAgentConfig(cfg *Config, path string, agent *WorkflowStepAgentConfig) error {
+func validateWorkflowStepAgentConfig(cfg *Config, path string, agent *WorkflowStepAgentConfig, previousSteps map[string]struct{}) error {
 	if agent == nil {
 		return fmt.Errorf("config validation: %s is required", path)
 	}
@@ -2222,9 +2222,15 @@ func validateWorkflowStepAgentConfig(cfg *Config, path string, agent *WorkflowSt
 	agent.Model = strings.TrimSpace(agent.Model)
 	agent.SessionKey = strings.TrimSpace(agent.SessionKey)
 	agent.Prompt.Template = strings.TrimSpace(agent.Prompt.Template)
+	if err := coreworkflow.ValidateTemplateRefs(path+".prompt", agent.Prompt.Template, previousSteps); err != nil {
+		return fmt.Errorf("config validation: %w", err)
+	}
 	for i := range agent.Messages {
 		agent.Messages[i].Role = strings.TrimSpace(agent.Messages[i].Role)
 		agent.Messages[i].Text.Template = strings.TrimSpace(agent.Messages[i].Text.Template)
+		if err := coreworkflow.ValidateTemplateRefs(fmt.Sprintf("%s.messages[%d].text", path, i), agent.Messages[i].Text.Template, previousSteps); err != nil {
+			return fmt.Errorf("config validation: %w", err)
+		}
 	}
 	if agent.Prompt.Template == "" && len(agent.Messages) == 0 {
 		return fmt.Errorf("config validation: %s.prompt or messages is required", path)

--- a/sdk/go/workflow/executor.go
+++ b/sdk/go/workflow/executor.go
@@ -15,16 +15,16 @@ import (
 const workflowStepOutputBodyMaxBytes = 64 * 1024
 
 type Request struct {
-	ProviderName    string
-	RunID           string
-	Target          *gestalt.BoundWorkflowTarget
-	Trigger         *gestalt.WorkflowRunTrigger
-	Input           map[string]any
-	Metadata        map[string]any
+	ProviderName       string
+	RunID              string
+	Target             *gestalt.BoundWorkflowTarget
+	Trigger            *gestalt.WorkflowRunTrigger
+	Input              map[string]any
+	Metadata           map[string]any
 	CreatedBySubjectID string
-	RunAs           *gestalt.Subject
-	InvocationToken string
-	Signals         []gestalt.WorkflowSignal
+	RunAs              *gestalt.Subject
+	InvocationToken    string
+	Signals            []gestalt.WorkflowSignal
 }
 
 type Response struct {
@@ -34,7 +34,27 @@ type Response struct {
 
 type StepExecutor interface {
 	Execute(context.Context, Request) (*Response, error)
+	ExecuteStep(context.Context, StepRequest) (*StepResponse, error)
 	Close() error
+}
+
+type StepRequest struct {
+	Request        Request
+	StepIndex      int
+	Outputs        map[string]any
+	StepInputs     map[string]any
+	SkippedStepIDs []string
+}
+
+type StepResponse struct {
+	Status      int
+	Step        StepResult
+	Input       map[string]any
+	Output      any
+	Outputs     map[string]any
+	StepInputs  map[string]any
+	FinalStepID string
+	FinalOutput any
 }
 
 type AppInvocation struct {
@@ -108,7 +128,6 @@ func (e *Executor) Execute(ctx context.Context, req Request) (*Response, error) 
 	if req.Target == nil || len(req.Target.Steps) == 0 {
 		return nil, fmt.Errorf("workflow target steps are required")
 	}
-	token := strings.TrimSpace(req.InvocationToken)
 	result := workflowStepsResult{
 		Version: 1,
 		Status:  "succeeded",
@@ -117,60 +136,247 @@ func (e *Executor) Execute(ctx context.Context, req Request) (*Response, error) 
 	}
 	skipped := map[string]struct{}{}
 	stepInputs := map[string]any{}
-	sessions := map[string]workflowAgentSessionState{}
-	scope := WorkflowStepInvocationScope(req)
 	for i := range req.Target.Steps {
-		step := req.Target.Steps[i]
-		stepID := strings.TrimSpace(step.ID)
-		if stepID == "" {
-			return workflowFailedStepResponse(result, stepID, "invalid_step", "workflow step id is required")
-		}
-		runStep, skipReason, err := workflowStepWhenMatches(step.When, req, result.Outputs, skipped)
+		stepResp, err := e.ExecuteStep(ctx, StepRequest{
+			Request:        req,
+			StepIndex:      i,
+			Outputs:        result.Outputs,
+			StepInputs:     stepInputs,
+			SkippedStepIDs: skippedStepIDs(skipped),
+		})
 		if err != nil {
-			return workflowFailedStepResponse(result, stepID, "invalid_when", err.Error())
+			return nil, err
 		}
-		if !runStep {
-			result.Steps = append(result.Steps, workflowStepResult{ID: stepID, Status: "skipped", SkippedReason: skipReason})
+		result.Outputs = stepResp.Outputs
+		if result.Outputs == nil {
+			result.Outputs = map[string]any{}
+		}
+		stepInputs = stepResp.StepInputs
+		if stepInputs == nil {
+			stepInputs = map[string]any{}
+		}
+		stepID := strings.TrimSpace(stepResp.Step.ID)
+		result.Steps = append(result.Steps, stepResp.Step)
+		switch strings.ToLower(strings.TrimSpace(stepResp.Step.Status)) {
+		case "skipped":
 			skipped[stepID] = struct{}{}
-			continue
-		}
-		inputs, err := (EvalContext{Request: req, Outputs: result.Outputs, StepInputs: stepInputs}).EvaluateStepInputs(step.Inputs)
-		if err != nil {
-			return workflowFailedStepResponse(result, stepID, "invalid_input", WorkflowEvalError(err).Error())
-		}
-		stepInputs[stepID] = inputs
-		stepCtx := ctx
-		cancelStep := func() {}
-		if step.TimeoutSeconds > 0 {
-			stepCtx, cancelStep = context.WithTimeout(ctx, time.Duration(step.TimeoutSeconds)*time.Second)
-		}
-		var output any
-		var turnID string
-		switch {
-		case step.App != nil && step.Agent != nil:
-			cancelStep()
-			return workflowFailedStepResponse(result, stepID, "invalid_step", "workflow step cannot set both app and agent")
-		case step.App != nil:
-			output, err = e.invokeAppStep(stepCtx, req, token, step.App, inputs, result.Outputs, stepInputs, scope, stepID)
-		case step.Agent != nil:
-			output, turnID, err = e.invokeAgentStep(stepCtx, req, token, step.Agent, inputs, result.Outputs, stepInputs, sessions, scope, stepID, step.TimeoutSeconds, step.Metadata)
+		case "succeeded":
+			result.FinalStepID = stepResp.FinalStepID
+			result.FinalOutput = stepResp.FinalOutput
+		case "failed":
+			result.Status = "failed"
+			result.Error = stepResp.Step.Error
+			body, err := json.Marshal(result)
+			if err != nil {
+				return nil, err
+			}
+			status := stepResp.Status
+			if status == 0 {
+				status = http.StatusInternalServerError
+			}
+			return &Response{Status: status, Body: string(body)}, nil
 		default:
-			err = fmt.Errorf("workflow step must set app or agent")
+			return workflowFailedStepResponse(result, stepID, "invalid_step_result", "workflow step returned invalid status")
 		}
-		cancelStep()
-		if err != nil {
-			return workflowFailedStepResponse(result, stepID, "step_failed", err.Error())
-		}
-		result.Outputs[stepID] = output
-		result.FinalStepID = stepID
-		result.FinalOutput = output
-		result.Steps = append(result.Steps, workflowStepResult{ID: stepID, Status: "succeeded", TurnID: turnID})
 	}
 	body, err := json.Marshal(result)
 	if err != nil {
 		return nil, err
 	}
 	return &Response{Status: http.StatusOK, Body: string(body)}, nil
+}
+
+func (e *Executor) ExecuteStep(ctx context.Context, stepReq StepRequest) (*StepResponse, error) {
+	if e == nil {
+		return nil, fmt.Errorf("workflow executor is not configured")
+	}
+	req := stepReq.Request
+	if req.Target == nil || len(req.Target.Steps) == 0 {
+		return nil, fmt.Errorf("workflow target steps are required")
+	}
+	if stepReq.StepIndex < 0 || stepReq.StepIndex >= len(req.Target.Steps) {
+		return nil, fmt.Errorf("workflow step index %d is out of range", stepReq.StepIndex)
+	}
+	outputs := cloneWorkflowMap(stepReq.Outputs)
+	if outputs == nil {
+		outputs = map[string]any{}
+	}
+	stepInputs := cloneWorkflowMap(stepReq.StepInputs)
+	if stepInputs == nil {
+		stepInputs = map[string]any{}
+	}
+	skipped := skippedStepIDMap(stepReq.SkippedStepIDs)
+	step := req.Target.Steps[stepReq.StepIndex]
+	stepID := strings.TrimSpace(step.ID)
+	if stepID == "" {
+		return failedStepResponse(stepID, "invalid_step", "workflow step id is required", "", nil, outputs, stepInputs), nil
+	}
+	runStep, skipReason, err := workflowStepWhenMatches(step.When, req, outputs, skipped)
+	if err != nil {
+		return failedStepResponse(stepID, "invalid_when", err.Error(), "", nil, outputs, stepInputs), nil
+	}
+	if !runStep {
+		return &StepResponse{
+			Status:     http.StatusOK,
+			Step:       workflowStepResult{ID: stepID, Status: "skipped", SkippedReason: skipReason},
+			Outputs:    outputs,
+			StepInputs: stepInputs,
+		}, nil
+	}
+	inputs, err := (EvalContext{Request: req, Outputs: outputs, StepInputs: stepInputs}).EvaluateStepInputs(step.Inputs)
+	if err != nil {
+		return failedStepResponse(stepID, "invalid_input", WorkflowEvalError(err).Error(), "", nil, outputs, stepInputs), nil
+	}
+	stepInputs[stepID] = inputs
+	sessions, err := workflowAgentSessionsFromOutputs(req.Target, stepReq.StepIndex, outputs)
+	if err != nil {
+		return failedStepResponse(stepID, "invalid_agent_session", err.Error(), "", inputs, outputs, stepInputs), nil
+	}
+	stepCtx := ctx
+	cancelStep := func() {}
+	if step.TimeoutSeconds > 0 {
+		stepCtx, cancelStep = context.WithTimeout(ctx, time.Duration(step.TimeoutSeconds)*time.Second)
+	}
+	token := strings.TrimSpace(req.InvocationToken)
+	scope := WorkflowStepInvocationScope(req)
+	var output any
+	var turnID string
+	switch {
+	case step.App != nil && step.Agent != nil:
+		cancelStep()
+		return failedStepResponse(stepID, "invalid_step", "workflow step cannot set both app and agent", "", inputs, outputs, stepInputs), nil
+	case step.App != nil:
+		output, err = e.invokeAppStep(stepCtx, req, token, step.App, inputs, outputs, stepInputs, scope, stepID)
+	case step.Agent != nil:
+		output, turnID, err = e.invokeAgentStep(stepCtx, req, token, step.Agent, inputs, outputs, stepInputs, sessions, scope, stepID, step.TimeoutSeconds, step.Metadata)
+	default:
+		err = fmt.Errorf("workflow step must set app or agent")
+	}
+	cancelStep()
+	if err != nil {
+		return failedStepResponse(stepID, "step_failed", err.Error(), turnID, inputs, outputs, stepInputs), nil
+	}
+	outputs[stepID] = output
+	return &StepResponse{
+		Status:      http.StatusOK,
+		Step:        workflowStepResult{ID: stepID, Status: "succeeded", TurnID: turnID},
+		Input:       inputs,
+		Output:      output,
+		Outputs:     outputs,
+		StepInputs:  stepInputs,
+		FinalStepID: stepID,
+		FinalOutput: output,
+	}, nil
+}
+
+func failedStepResponse(stepID, code, message, turnID string, input map[string]any, outputs map[string]any, stepInputs map[string]any) *StepResponse {
+	errValue := &workflowStepError{StepID: stepID, Code: code, Message: message}
+	return &StepResponse{
+		Status:     http.StatusInternalServerError,
+		Step:       workflowStepResult{ID: stepID, Status: "failed", TurnID: turnID, Error: errValue},
+		Input:      input,
+		Outputs:    outputs,
+		StepInputs: stepInputs,
+	}
+}
+
+func skippedStepIDs(values map[string]struct{}) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(values))
+	for value := range values {
+		out = append(out, value)
+	}
+	return out
+}
+
+func skippedStepIDMap(values []string) map[string]struct{} {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			out[value] = struct{}{}
+		}
+	}
+	return out
+}
+
+func cloneWorkflowMap(input map[string]any) map[string]any {
+	if input == nil {
+		return nil
+	}
+	out := make(map[string]any, len(input))
+	for key, value := range input {
+		out[key] = value
+	}
+	return out
+}
+
+func workflowAgentSessionsFromOutputs(target *gestalt.BoundWorkflowTarget, stepIndex int, outputs map[string]any) (map[string]workflowAgentSessionState, error) {
+	sessions := map[string]workflowAgentSessionState{}
+	if target == nil || stepIndex <= 0 {
+		return sessions, nil
+	}
+	if stepIndex > len(target.Steps) {
+		stepIndex = len(target.Steps)
+	}
+	for i := 0; i < stepIndex; i++ {
+		step := target.Steps[i]
+		if step.Agent == nil {
+			continue
+		}
+		stepID := strings.TrimSpace(step.ID)
+		output, ok := outputs[stepID]
+		if !ok {
+			continue
+		}
+		sessionID, ok := workflowAgentSessionIDFromOutput(output)
+		if !ok {
+			return nil, fmt.Errorf("workflow agent step %q output is missing agent.sessionId", stepID)
+		}
+		sessionKey := strings.TrimSpace(step.Agent.SessionKey)
+		if sessionKey == "" {
+			sessionKey = stepID
+		}
+		providerName := strings.TrimSpace(step.Agent.Provider)
+		model := strings.TrimSpace(step.Agent.Model)
+		optionsKey := stableJSON(step.Agent.ModelOptions)
+		state, exists := sessions[sessionKey]
+		if exists {
+			if state.providerName != providerName || state.model != model || state.options != optionsKey {
+				return nil, fmt.Errorf("workflow agent session_key %q uses incompatible provider, model, or model_options", sessionKey)
+			}
+			continue
+		}
+		sessions[sessionKey] = workflowAgentSessionState{
+			session:      &gestalt.AgentSession{ID: sessionID, ProviderName: providerName, Model: model},
+			providerName: providerName,
+			model:        model,
+			options:      optionsKey,
+		}
+	}
+	return sessions, nil
+}
+
+func workflowAgentSessionIDFromOutput(output any) (string, bool) {
+	object, ok := output.(map[string]any)
+	if !ok {
+		return "", false
+	}
+	kind, _ := object["kind"].(string)
+	if strings.TrimSpace(kind) != "agent" {
+		return "", false
+	}
+	agent, ok := object["agent"].(map[string]any)
+	if !ok {
+		return "", false
+	}
+	sessionID, ok := agent["sessionId"].(string)
+	sessionID = strings.TrimSpace(sessionID)
+	return sessionID, ok && sessionID != ""
 }
 
 func WorkflowEvalError(err error) error {

--- a/sdk/go/workflow/workflow_test.go
+++ b/sdk/go/workflow/workflow_test.go
@@ -101,6 +101,107 @@ func TestExecutorInvokesAppStep(t *testing.T) {
 	}
 }
 
+func TestExecutorExecuteStepUsesPriorOutput(t *testing.T) {
+	t.Parallel()
+
+	invoker := &recordingAppInvoker{}
+	executor := New(Config{AppInvoker: invoker})
+	resp, err := executor.ExecuteStep(context.Background(), StepRequest{
+		Request: Request{
+			ProviderName: "indexeddb",
+			RunID:        "run-1",
+			Target: &gestalt.BoundWorkflowTarget{Steps: []gestalt.WorkflowStep{
+				{
+					ID: "collect",
+					App: &gestalt.WorkflowStepAppCall{
+						Name:      "github",
+						Operation: "pullRequests.get",
+					},
+				},
+				{
+					ID: "notify",
+					Inputs: map[string]gestalt.WorkflowValue{
+						"summary": {StepOutput: &gestalt.WorkflowStepOutputSource{StepID: "collect", Path: "summary"}},
+					},
+					App: &gestalt.WorkflowStepAppCall{
+						Name:      "slack",
+						Operation: "chat.postMessage",
+						Input: gestalt.WorkflowValue{Object: map[string]gestalt.WorkflowValue{
+							"text": {Template: &gestalt.WorkflowText{Template: "summary=${{ steps.collect.outputs.summary }}"}},
+						}},
+					},
+				},
+			}},
+		},
+		StepIndex: 1,
+		Outputs: map[string]any{
+			"collect": map[string]any{"summary": "ready"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStep: %v", err)
+	}
+	if resp.Status != 200 || resp.Step.ID != "notify" || resp.Step.Status != "succeeded" {
+		t.Fatalf("response = %#v", resp)
+	}
+	if invoker.call.Params["text"] != "summary=ready" {
+		t.Fatalf("params = %#v", invoker.call.Params)
+	}
+	if resp.StepInputs["notify"].(map[string]any)["summary"] != "ready" {
+		t.Fatalf("step inputs = %#v", resp.StepInputs)
+	}
+	if _, ok := resp.Outputs["collect"]; !ok {
+		t.Fatalf("prior output was not preserved: %#v", resp.Outputs)
+	}
+	if _, ok := resp.Outputs["notify"]; !ok {
+		t.Fatalf("current output was not recorded: %#v", resp.Outputs)
+	}
+}
+
+func TestExecutorExecuteStepSkipsMissingDependency(t *testing.T) {
+	t.Parallel()
+
+	invoker := &recordingAppInvoker{}
+	executor := New(Config{AppInvoker: invoker})
+	resp, err := executor.ExecuteStep(context.Background(), StepRequest{
+		Request: Request{
+			ProviderName: "indexeddb",
+			RunID:        "run-1",
+			Target: &gestalt.BoundWorkflowTarget{Steps: []gestalt.WorkflowStep{
+				{
+					ID: "collect",
+					App: &gestalt.WorkflowStepAppCall{
+						Name:      "github",
+						Operation: "pullRequests.get",
+					},
+				},
+				{
+					ID: "notify",
+					When: &gestalt.WorkflowStepWhen{
+						Value:  gestalt.WorkflowValue{StepOutput: &gestalt.WorkflowStepOutputSource{StepID: "collect", Path: "ok"}},
+						Equals: true,
+					},
+					App: &gestalt.WorkflowStepAppCall{
+						Name:      "slack",
+						Operation: "chat.postMessage",
+					},
+				},
+			}},
+		},
+		StepIndex:      1,
+		SkippedStepIDs: []string{"collect"},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStep: %v", err)
+	}
+	if resp.Status != 200 || resp.Step.ID != "notify" || resp.Step.Status != "skipped" || resp.Step.SkippedReason != "missing_dependency" {
+		t.Fatalf("response = %#v", resp)
+	}
+	if invoker.call.App != "" {
+		t.Fatalf("app was invoked: %#v", invoker.call)
+	}
+}
+
 func TestExecutorInvokesAgentStepWithWorkflowRunAs(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/typescript/src/workflow.ts
+++ b/sdk/typescript/src/workflow.ts
@@ -1766,11 +1766,11 @@ export function evaluateWorkflowValue(ctx: WorkflowEvalContext, input: WorkflowV
 }
 
 export function renderWorkflowTemplate(ctx: WorkflowEvalContext, template: string): string {
-  return template.replace(/\$\$\{/g, "\u0000{").replace(/\$\{([^{}]+)\}/g, (_match, expr: string) => {
+  return template.replace(/\$\$\{\{/g, "\u0000{{").replace(/\$\{\{([^{}]+)\}\}/g, (_match, expr: string) => {
     const resolved = templateExpressionValue(ctx, expr.trim());
     if (!resolved.ok) throw new WorkflowValueError(`template expression "${expr.trim()}" did not resolve`);
     return renderTemplateValue(resolved.value);
-  }).replace(/\u0000\{/g, "${");
+  }).replace(/\u0000\{\{/g, "${{");
 }
 
 export function pathValue(value: unknown, path: string): { value: unknown; ok: boolean } {

--- a/sdk/typescript/tests/workflow-helpers.test.ts
+++ b/sdk/typescript/tests/workflow-helpers.test.ts
@@ -24,9 +24,9 @@ test("workflow execution helpers evaluate templates and paths", () => {
   expect(
     renderWorkflowTemplate(
       ctx,
-      "customer=${input.customer.id}; thread=${signal.payload.thread.ts}; input=${inputs.thread}; literal=$${x}",
+      "customer=${{ input.customer.id }}; thread=${{ signal.payload.thread.ts }}; input=${{ inputs.thread }}; literal=$${{ x }}",
     ),
-  ).toBe("customer=cust_1; thread=123.456; input=123.456; literal=${x}");
+  ).toBe("customer=cust_1; thread=123.456; input=123.456; literal=${{ x }}");
 
   expect(evaluateWorkflowValue(ctx, { input: "customer.id" })).toEqual({
     value: "cust_1",


### PR DESCRIPTION
## Summary

Compiles workflow authoring expressions in YAML scalar strings into typed workflow value refs instead of leaving them as opaque strings.

Config authors can write `${{ input.* }}`, `${{ signal.* }}`, `${{ steps.<id>.outputs.* }}`, and `${{ steps.<id>.inputs.* }}` in step app inputs, agent prompts, and agent message templates. Lone scalar expressions become structured refs, while mixed strings become templates that preserve literal text around embedded refs.

The config loader now uses Gestalt-owned environment placeholder scanning instead of `os.Expand`, so only the declared env forms are expanded and embedded declarative languages such as workflow templates are not mistaken for host environment placeholders. Go and TypeScript workflow template evaluation now use the same `${{ ... }}` marker and `$${{ ... }}` escape.

## Interfaces

```yaml
steps:
  - id: diagnose
    app:
      name: datadog
      operation: monitors.get
      input:
        monitor_id: "${{ input.monitor_id }}"
  - id: summarize
    agent:
      provider: claude
      prompt: "Summarize ${{ steps.diagnose.outputs.body }}"
```

```go
input.alert_id
signal.data.github
steps.ensure_check_run.outputs.id
steps.review.inputs.pull_request
```

```ts
renderWorkflowTemplate(ctx, "Review ${{ signal.data.pull_request.title }}")
```

```yaml
env: "${GESTALT_ENV}"
workflow: "${{ signal.data }}"
foreign: "${json.path}"
```

## Runtime

Config scalar expressions compile into the same `WorkflowValue` tree used by the executor. The shared workflow validator walks compiled values and templates so app inputs and agent prompt/message templates enforce root names, path shape, and prior-step-only references.

Executor evaluation continues to consume typed refs, so the runtime path stays the same whether a value was authored as structured YAML or compiled from a scalar expression.
