### PR TITLE
[authorization] pass host services to authz providers

### DIFF
--- a/gestaltd/internal/bootstrap/authorization_bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/authorization_bootstrap_test.go
@@ -8,9 +8,13 @@ import (
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	gproto "google.golang.org/protobuf/proto"
+	"gopkg.in/yaml.v3"
 )
 
 func TestBootstrapAuthorizationProviderStatePreservesRuntimeRelationships(t *testing.T) {
@@ -181,6 +185,60 @@ func TestStaticAuthorizationModelCarriesResourceTypeDefaultAccessPolicy(t *testi
 	if got := policies["team"]; got != proto.DefaultAccessPolicy_DEFAULT_ACCESS_POLICY_DENY {
 		t.Fatalf("team default policy = %v, want deny", got)
 	}
+}
+
+func TestBuildAuthorizationProviderPassesIndexedDBHostService(t *testing.T) {
+	t.Parallel()
+
+	var runtimeConfig yaml.Node
+	if err := yaml.Unmarshal([]byte(`
+command: /bin/true
+config:
+  indexeddb: main-db
+`), &runtimeConfig); err != nil {
+		t.Fatalf("decode runtime config: %v", err)
+	}
+	var capturedName string
+	var capturedHostServices []runtimehost.HostService
+	factories := &FactoryRegistry{
+		Authorization: func(_ context.Context, name string, _ yaml.Node, hostServices []runtimehost.HostService) (core.AuthorizationProvider, error) {
+			capturedName = name
+			capturedHostServices = append([]runtimehost.HostService(nil), hostServices...)
+			return &recordingAuthorizationProvider{}, nil
+		},
+	}
+	cfg := &config.Config{
+		Server: config.ServerConfig{Providers: config.ServerProvidersConfig{Authorization: "indexeddb"}},
+		Providers: config.ProvidersConfig{
+			Authorization: map[string]*config.ProviderEntry{
+				"indexeddb": {Config: *runtimeConfig.Content[0]},
+			},
+		},
+	}
+	deps := Deps{
+		EncryptionKey:         []byte("0123456789abcdef0123456789abcdef"),
+		SelectedIndexedDBName: "main-db",
+		IndexedDBs: map[string]indexeddb.IndexedDB{
+			"main-db": &coretesting.StubIndexedDB{},
+		},
+	}
+
+	providers, err := buildAuthorizationProviders(context.Background(), cfg, factories, deps)
+	if err != nil {
+		t.Fatalf("buildAuthorizationProviders: %v", err)
+	}
+	if providers["indexeddb"] == nil {
+		t.Fatal("authorization provider was not built")
+	}
+	if capturedName != "indexeddb" {
+		t.Fatalf("authorization provider name = %q, want indexeddb", capturedName)
+	}
+	for _, hostService := range capturedHostServices {
+		if hostService.Name == "indexeddb" {
+			return
+		}
+	}
+	t.Fatalf("authorization host services = %#v, want indexeddb host service", capturedHostServices)
 }
 
 type recordingAuthorizationProvider struct {

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -183,7 +183,7 @@ type Deps struct {
 }
 
 type AuthFactory func(node yaml.Node, deps Deps) (core.AuthenticationProvider, error)
-type AuthorizationFactory func(node yaml.Node) (core.AuthorizationProvider, error)
+type AuthorizationFactory func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService) (core.AuthorizationProvider, error)
 type ExternalCredentialFactory func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps Deps) (core.ExternalCredentialProvider, error)
 type SecretManagerFactory func(node yaml.Node) (core.SecretManager, error)
 type IndexedDBFactory func(node yaml.Node) (indexeddb.IndexedDB, error)
@@ -966,7 +966,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	deps.SelectedIndexedDBName = selectedIndexedDBName
 	deps.Caches = hostCaches
 	deps.S3 = hostS3s
-	authorizationProviders, err := buildAuthorizationProviders(cfg, factories)
+	authorizationProviders, err := buildAuthorizationProviders(ctx, cfg, factories, deps)
 	if err != nil {
 		_ = closeAuthProviders(authProviders)
 		return nil, err
@@ -1820,7 +1820,7 @@ func buildNamedAuthProvider(name string, authEntry *config.ProviderEntry, factor
 	return auth, nil
 }
 
-func buildAuthorizationProviders(cfg *config.Config, factories *FactoryRegistry) (map[string]core.AuthorizationProvider, error) {
+func buildAuthorizationProviders(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, deps Deps) (map[string]core.AuthorizationProvider, error) {
 	if len(cfg.Providers.Authorization) == 0 {
 		return nil, nil
 	}
@@ -1834,14 +1834,14 @@ func buildAuthorizationProviders(cfg *config.Config, factories *FactoryRegistry)
 	if entry == nil {
 		return nil, nil
 	}
-	provider, err := buildNamedAuthorizationProvider(name, entry, factories)
+	provider, err := buildNamedAuthorizationProvider(ctx, name, entry, factories, deps)
 	if err != nil {
 		return nil, err
 	}
 	return map[string]core.AuthorizationProvider{name: provider}, nil
 }
 
-func buildNamedAuthorizationProvider(name string, entry *config.ProviderEntry, factories *FactoryRegistry) (core.AuthorizationProvider, error) {
+func buildNamedAuthorizationProvider(ctx context.Context, name string, entry *config.ProviderEntry, factories *FactoryRegistry, deps Deps) (core.AuthorizationProvider, error) {
 	logicalName := strings.TrimSpace(name)
 	if logicalName == "" {
 		logicalName = "authorization"
@@ -1857,7 +1857,11 @@ func buildNamedAuthorizationProvider(name string, entry *config.ProviderEntry, f
 			return nil, fmt.Errorf("bootstrap: authorization provider %q: %w", logicalName, err)
 		}
 	}
-	provider, err := factories.Authorization(node)
+	hostServices, _, err := buildProviderHostServices(logicalName, deps)
+	if err != nil {
+		return nil, fmt.Errorf("bootstrap: authorization provider %q: %w", logicalName, err)
+	}
+	provider, err := factories.Authorization(ctx, logicalName, node, hostServices)
 	if err != nil {
 		return nil, fmt.Errorf("bootstrap: authorization provider %q: %w", logicalName, err)
 	}

--- a/gestaltd/services/authorization/client.go
+++ b/gestaltd/services/authorization/client.go
@@ -13,15 +13,16 @@ import (
 )
 
 type ExecConfig struct {
-	Command    string
-	Args       []string
-	Workdir    string
-	Env        map[string]string
-	Config     map[string]any
-	Egress     egress.Policy
-	HostBinary string
-	Cleanup    func()
-	Name       string
+	Command      string
+	Args         []string
+	Workdir      string
+	Env          map[string]string
+	Config       map[string]any
+	Egress       egress.Policy
+	HostBinary   string
+	Cleanup      func()
+	HostServices []runtimehost.HostService
+	Name         string
 }
 
 type remoteAuthorizationProvider struct {
@@ -39,6 +40,7 @@ func NewExecutable(ctx context.Context, cfg ExecConfig) (core.AuthorizationProvi
 		Egress:       cfg.Egress,
 		HostBinary:   cfg.HostBinary,
 		Cleanup:      cfg.Cleanup,
+		HostServices: cfg.HostServices,
 		ProviderName: cfg.Name,
 	})
 	if err != nil {

--- a/gestaltd/services/providerdrivers/authorization.go
+++ b/gestaltd/services/providerdrivers/authorization.go
@@ -8,10 +8,11 @@ import (
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	authorizationservice "github.com/valon-technologies/gestalt/server/services/authorization"
 	"github.com/valon-technologies/gestalt/server/services/providerdrivers/componentprovider"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"gopkg.in/yaml.v3"
 )
 
-func AuthorizationFactory(node yaml.Node) (core.AuthorizationProvider, error) {
+func AuthorizationFactory(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService) (core.AuthorizationProvider, error) {
 	var cfg componentprovider.YAMLConfig
 	if err := node.Decode(&cfg); err != nil {
 		return nil, fmt.Errorf("authorization provider: parsing config: %w", err)
@@ -27,15 +28,16 @@ func AuthorizationFactory(node yaml.Node) (core.AuthorizationProvider, error) {
 	}
 	cfg = prepared.YAMLConfig
 
-	return authorizationservice.NewExecutable(context.Background(), authorizationservice.ExecConfig{
-		Command:    cfg.Command,
-		Args:       cfg.Args,
-		Workdir:    cfg.Workdir,
-		Env:        cfg.Env,
-		Config:     cfg.Config,
-		Egress:     cfg.EgressPolicy(""),
-		HostBinary: cfg.HostBinary,
-		Cleanup:    prepared.Cleanup,
-		Name:       cfg.Name,
+	return authorizationservice.NewExecutable(ctx, authorizationservice.ExecConfig{
+		Command:      cfg.Command,
+		Args:         cfg.Args,
+		Workdir:      cfg.Workdir,
+		Env:          cfg.Env,
+		Config:       cfg.Config,
+		Egress:       cfg.EgressPolicy(""),
+		HostBinary:   cfg.HostBinary,
+		Cleanup:      prepared.Cleanup,
+		HostServices: hostServices,
+		Name:         name,
 	})
 }


### PR DESCRIPTION
## Description
Threads provider host services into executable authorization providers so IndexedDB-backed authorization can reach the host IndexedDB service during bootstrap.