### PR TITLE
Expose Python authorization client

### DIFF
--- a/sdk/python/gestalt/__init__.py
+++ b/sdk/python/gestalt/__init__.py
@@ -168,11 +168,13 @@ _AUTHENTICATION_AUTHORED_EXPORTS = (
 _AUTHORIZATION_AUTHORED_EXPORTS = (
     "AddRelationshipRequest",
     "AddRelationshipResponse",
+    "Authorization",
     "AuthorizationAction",
     "AuthorizationModel",
     "AuthorizationModelRef",
     "AuthorizationModelResourceType",
     "AuthorizationModelResourceTypeFilter",
+    "AuthorizationProtocol",
     "AuthorizationResource",
     "AuthorizationSubject",
     "CheckAccessManyRequest",

--- a/sdk/python/gestalt/_api.py
+++ b/sdk/python/gestalt/_api.py
@@ -29,6 +29,7 @@ else:
 if TYPE_CHECKING:
     from ._agent import Agent, AgentToolRef
     from ._app_access import AppProtocol
+    from ._authorization import AuthorizationProtocol
     from ._workflow import Workflow, WorkflowRunContext
 
 FIELD_DESCRIPTION_KEY: Final[str] = "description"
@@ -129,6 +130,11 @@ class Request:
             self.invocation_token,
             idempotency_key=self.idempotency_key,
         )
+
+    def authorization(self) -> AuthorizationProtocol:
+        from ._authorization import _shared_authorization_client
+
+        return _shared_authorization_client()
 
     def workflow_run_context(self) -> "WorkflowRunContext":
         from ._workflow import parse_workflow_run_context

--- a/sdk/python/gestalt/_authorization.py
+++ b/sdk/python/gestalt/_authorization.py
@@ -1,11 +1,21 @@
 from __future__ import annotations
 
 import datetime as dt
+import os
+import threading
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Protocol
+
+from google.protobuf import empty_pb2 as _empty_pb2
 
 from ._gen.v1 import authorization_pb2 as _pb
+from ._gen.v1 import authorization_pb2_grpc as _pb_grpc
+from ._grpc_transport import (
+    ENV_HOST_SERVICE_SOCKET,
+    ENV_HOST_SERVICE_TOKEN,
+    host_service_channel,
+)
 from ._protocol import coerce_model as _coerce
 from ._protocol import copy_message as _copy
 from ._protocol import datetime_from_timestamp as _datetime_from_timestamp
@@ -16,6 +26,10 @@ from ._protocol import timestamp_from_datetime as _timestamp_from_datetime
 from ._protocol import which_oneof as _which_oneof
 
 pb: Any = _pb
+pb_grpc: Any = _pb_grpc
+
+_shared_authorization_transport: dict[str, Any] = {}
+_shared_authorization_lock = threading.Lock()
 
 RELATIONSHIP_TARGET_TYPE_UNSPECIFIED = _pb.RELATIONSHIP_TARGET_TYPE_UNSPECIFIED
 RELATIONSHIP_TARGET_TYPE_SUBJECT = _pb.RELATIONSHIP_TARGET_TYPE_SUBJECT
@@ -240,12 +254,258 @@ class ListActiveModelResourceTypesResponse:
     model_id: str = ""
 
 
+class AuthorizationProtocol(Protocol):
+    """Fakeable contract for host authorization calls."""
+
+    def __enter__(self) -> "AuthorizationProtocol":
+        """Return the client for ``with`` statements."""
+
+    def __exit__(self, *args: Any) -> None:
+        """Close the client at the end of a context manager block."""
+
+    def close(self) -> None:
+        """Close the client."""
+
+    def check_access(self, request: CheckAccessRequest) -> CheckAccessResponse:
+        """Return whether one authorization request is allowed."""
+
+    def check_access_many(
+        self, request: CheckAccessManyRequest
+    ) -> CheckAccessManyResponse:
+        """Return decisions for a batch of authorization requests."""
+
+    def list_relationships(
+        self, request: ListRelationshipsRequest
+    ) -> ListRelationshipsResponse:
+        """List relationships matching a filter."""
+
+    def add_relationship(
+        self, request: AddRelationshipRequest
+    ) -> AddRelationshipResponse:
+        """Add one relationship."""
+
+    def delete_relationship(
+        self, request: DeleteRelationshipRequest
+    ) -> DeleteRelationshipResponse:
+        """Delete one relationship tuple."""
+
+    def set_authorization_state(
+        self, request: SetAuthorizationStateRequest
+    ) -> SetAuthorizationStateResponse:
+        """Atomically replace authorization state."""
+
+    def get_active_model_ref(self) -> GetActiveModelRefResponse:
+        """Return the active authorization model reference."""
+
+    def set_active_model(self, request: SetActiveModelRequest) -> SetActiveModelResponse:
+        """Set the active authorization model."""
+
+    def list_active_model_resource_types(
+        self, request: ListActiveModelResourceTypesRequest
+    ) -> ListActiveModelResourceTypesResponse:
+        """List resource types in the active authorization model."""
+
+
+class Authorization:
+    """Transport-backed implementation for host authorization calls."""
+
+    def __new__(
+        cls,
+        socket_target: str | None = None,
+        relay_token: str | None = None,
+        *,
+        _shared: bool = False,
+    ) -> "Authorization":
+        if not _shared and socket_target is None and relay_token is None:
+            return _shared_authorization_client()
+        return super().__new__(cls)
+
+    def __init__(
+        self,
+        socket_target: str | None = None,
+        relay_token: str | None = None,
+        *,
+        _shared: bool = False,
+    ) -> None:
+        if getattr(self, "_authorization_initialized", False):
+            return
+        target = _resolve_authorization_socket_target(socket_target)
+        token = (
+            relay_token
+            if relay_token is not None
+            else os.environ.get(ENV_HOST_SERVICE_TOKEN, "")
+        ).strip()
+        self._channel = host_service_channel("authorization", target, token=token)
+        self._stub = pb_grpc.AuthorizationProviderStub(self._channel)
+        self._closed = False
+        self._shared = _shared
+        self._authorization_initialized = True
+
+    def close(self) -> None:
+        """Close the underlying gRPC channel."""
+
+        if self._shared:
+            return
+        self._close_channel()
+
+    def _close_channel(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._channel.close()
+
+    def check_access(self, request: CheckAccessRequest) -> CheckAccessResponse:
+        """Return whether one authorization request is allowed."""
+
+        return check_access_response_from_proto(
+            self._stub.CheckAccess(check_access_request_to_proto(request))
+        )
+
+    def check_access_many(
+        self, request: CheckAccessManyRequest
+    ) -> CheckAccessManyResponse:
+        """Return decisions for a batch of authorization requests."""
+
+        return check_access_many_response_from_proto(
+            self._stub.CheckAccessMany(check_access_many_request_to_proto(request))
+        )
+
+    def list_relationships(
+        self, request: ListRelationshipsRequest
+    ) -> ListRelationshipsResponse:
+        """List relationships matching a filter."""
+
+        return list_relationships_response_from_proto(
+            self._stub.ListRelationships(list_relationships_request_to_proto(request))
+        )
+
+    def add_relationship(
+        self, request: AddRelationshipRequest
+    ) -> AddRelationshipResponse:
+        """Add one relationship."""
+
+        return add_relationship_response_from_proto(
+            self._stub.AddRelationship(add_relationship_request_to_proto(request))
+        )
+
+    def delete_relationship(
+        self, request: DeleteRelationshipRequest
+    ) -> DeleteRelationshipResponse:
+        """Delete one relationship tuple."""
+
+        return delete_relationship_response_from_proto(
+            self._stub.DeleteRelationship(delete_relationship_request_to_proto(request))
+        )
+
+    def set_authorization_state(
+        self, request: SetAuthorizationStateRequest
+    ) -> SetAuthorizationStateResponse:
+        """Atomically replace authorization state."""
+
+        return set_authorization_state_response_from_proto(
+            self._stub.SetAuthorizationState(
+                set_authorization_state_request_to_proto(request)
+            )
+        )
+
+    def get_active_model_ref(self) -> GetActiveModelRefResponse:
+        """Return the active authorization model reference."""
+
+        return get_active_model_ref_response_from_proto(
+            self._stub.GetActiveModelRef(getattr(_empty_pb2, "Empty")())
+        )
+
+    def set_active_model(self, request: SetActiveModelRequest) -> SetActiveModelResponse:
+        """Set the active authorization model."""
+
+        return set_active_model_response_from_proto(
+            self._stub.SetActiveModel(set_active_model_request_to_proto(request))
+        )
+
+    def list_active_model_resource_types(
+        self, request: ListActiveModelResourceTypesRequest
+    ) -> ListActiveModelResourceTypesResponse:
+        """List resource types in the active authorization model."""
+
+        return list_active_model_resource_types_response_from_proto(
+            self._stub.ListActiveModelResourceTypes(
+                list_active_model_resource_types_request_to_proto(request)
+            )
+        )
+
+    def __enter__(self) -> "Authorization":
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.close()
+
+
+def _shared_authorization_client() -> Authorization:
+    target = _resolve_authorization_socket_target()
+    token = os.environ.get(ENV_HOST_SERVICE_TOKEN, "").strip()
+    with _shared_authorization_lock:
+        client = _shared_authorization_transport.get("client")
+        if (
+            client is not None
+            and _shared_authorization_transport.get("target") == target
+            and _shared_authorization_transport.get("token") == token
+        ):
+            return client
+
+        client = Authorization(target, token, _shared=True)
+        stale = _shared_authorization_transport.get("client")
+        _shared_authorization_transport["target"] = target
+        _shared_authorization_transport["token"] = token
+        _shared_authorization_transport["client"] = client
+        if stale is not None:
+            stale._close_channel()
+        return client
+
+
+def _resolve_authorization_socket_target(socket_target: str | None = None) -> str:
+    target = (
+        socket_target
+        if socket_target is not None
+        else os.environ.get(ENV_HOST_SERVICE_SOCKET, "")
+    ).strip()
+    if not target:
+        raise RuntimeError(f"authorization: {ENV_HOST_SERVICE_SOCKET} is not set")
+    return target
+
+
+def check_access_request_to_proto(value: Any) -> Any:
+    if isinstance(value, pb.CheckAccessRequest):
+        return _copy(value)
+    request = _coerce(value, CheckAccessRequest, "CheckAccessRequest")
+    return pb.CheckAccessRequest(
+        subject=(
+            _subject_to_proto(request.subject)
+            if request.subject is not None
+            else None
+        ),
+        action=(
+            _action_to_proto(request.action)
+            if request.action is not None
+            else None
+        ),
+        resource=(
+            _resource_to_proto(request.resource)
+            if request.resource is not None
+            else None
+        ),
+    )
+
+
 def check_access_request_from_proto(value: Any) -> CheckAccessRequest:
     return CheckAccessRequest(
         subject=_subject_from_proto(value.subject) if _has_field(value, "subject") else None,
         action=_action_from_proto(value.action) if _has_field(value, "action") else None,
         resource=_resource_from_proto(value.resource) if _has_field(value, "resource") else None,
     )
+
+
+def check_access_response_from_proto(value: Any) -> CheckAccessResponse:
+    return CheckAccessResponse(allowed=value.allowed, model_id=value.model_id)
 
 
 def check_access_response_to_proto(value: Any) -> Any:
@@ -258,9 +518,24 @@ def check_access_response_to_proto(value: Any) -> Any:
     )
 
 
+def check_access_many_request_to_proto(value: Any) -> Any:
+    if isinstance(value, pb.CheckAccessManyRequest):
+        return _copy(value)
+    request = _coerce(value, CheckAccessManyRequest, "CheckAccessManyRequest")
+    return pb.CheckAccessManyRequest(
+        requests=[check_access_request_to_proto(item) for item in request.requests]
+    )
+
+
 def check_access_many_request_from_proto(value: Any) -> CheckAccessManyRequest:
     return CheckAccessManyRequest(
         requests=[check_access_request_from_proto(request) for request in value.requests]
+    )
+
+
+def check_access_many_response_from_proto(value: Any) -> CheckAccessManyResponse:
+    return CheckAccessManyResponse(
+        decisions=[check_access_response_from_proto(item) for item in value.decisions]
     )
 
 
@@ -270,6 +545,21 @@ def check_access_many_response_to_proto(value: Any) -> Any:
     response = _coerce(value, CheckAccessManyResponse, "CheckAccessManyResponse")
     return pb.CheckAccessManyResponse(
         decisions=[check_access_response_to_proto(decision) for decision in response.decisions]
+    )
+
+
+def list_relationships_request_to_proto(value: Any) -> Any:
+    if isinstance(value, pb.ListRelationshipsRequest):
+        return _copy(value)
+    request = _coerce(value, ListRelationshipsRequest, "ListRelationshipsRequest")
+    return pb.ListRelationshipsRequest(
+        filter=(
+            relationship_filter_to_proto(request.filter)
+            if request.filter is not None
+            else None
+        ),
+        page_size=request.page_size,
+        page_token=request.page_token,
     )
 
 
@@ -285,6 +575,13 @@ def list_relationships_request_from_proto(value: Any) -> ListRelationshipsReques
     )
 
 
+def list_relationships_response_from_proto(value: Any) -> ListRelationshipsResponse:
+    return ListRelationshipsResponse(
+        relationships=[relationship_from_proto(item) for item in value.relationships],
+        next_page_token=value.next_page_token,
+    )
+
+
 def list_relationships_response_to_proto(value: Any) -> Any:
     if isinstance(value, pb.ListRelationshipsResponse):
         return _copy(value)
@@ -295,8 +592,31 @@ def list_relationships_response_to_proto(value: Any) -> Any:
     )
 
 
+def add_relationship_request_to_proto(value: Any) -> Any:
+    if isinstance(value, pb.AddRelationshipRequest):
+        return _copy(value)
+    request = _coerce(value, AddRelationshipRequest, "AddRelationshipRequest")
+    return pb.AddRelationshipRequest(
+        relationship=(
+            relationship_to_proto(request.relationship)
+            if request.relationship is not None
+            else None
+        )
+    )
+
+
 def add_relationship_request_from_proto(value: Any) -> AddRelationshipRequest:
     return AddRelationshipRequest(
+        relationship=(
+            relationship_from_proto(value.relationship)
+            if _has_field(value, "relationship")
+            else None
+        )
+    )
+
+
+def add_relationship_response_from_proto(value: Any) -> AddRelationshipResponse:
+    return AddRelationshipResponse(
         relationship=(
             relationship_from_proto(value.relationship)
             if _has_field(value, "relationship")
@@ -318,6 +638,19 @@ def add_relationship_response_to_proto(value: Any) -> Any:
     )
 
 
+def delete_relationship_request_to_proto(value: Any) -> Any:
+    if isinstance(value, pb.DeleteRelationshipRequest):
+        return _copy(value)
+    request = _coerce(value, DeleteRelationshipRequest, "DeleteRelationshipRequest")
+    return pb.DeleteRelationshipRequest(
+        relationship_tuple=(
+            relationship_tuple_to_proto(request.relationship_tuple)
+            if request.relationship_tuple is not None
+            else None
+        )
+    )
+
+
 def delete_relationship_request_from_proto(value: Any) -> DeleteRelationshipRequest:
     return DeleteRelationshipRequest(
         relationship_tuple=(
@@ -328,10 +661,30 @@ def delete_relationship_request_from_proto(value: Any) -> DeleteRelationshipRequ
     )
 
 
+def delete_relationship_response_from_proto(_value: Any) -> DeleteRelationshipResponse:
+    return DeleteRelationshipResponse()
+
+
 def delete_relationship_response_to_proto(value: Any) -> Any:
     if isinstance(value, pb.DeleteRelationshipResponse):
         return _copy(value)
     return pb.DeleteRelationshipResponse()
+
+
+def set_authorization_state_request_to_proto(value: Any) -> Any:
+    if isinstance(value, pb.SetAuthorizationStateRequest):
+        return _copy(value)
+    request = _coerce(
+        value, SetAuthorizationStateRequest, "SetAuthorizationStateRequest"
+    )
+    return pb.SetAuthorizationStateRequest(
+        model=(
+            authorization_model_to_proto(request.model)
+            if request.model is not None
+            else None
+        ),
+        relationships=[relationship_to_proto(item) for item in request.relationships],
+    )
 
 
 def set_authorization_state_request_from_proto(
@@ -342,6 +695,18 @@ def set_authorization_state_request_from_proto(
         if _has_field(value, "model")
         else None,
         relationships=[relationship_from_proto(item) for item in value.relationships]
+    )
+
+
+def set_authorization_state_response_from_proto(
+    value: Any,
+) -> SetAuthorizationStateResponse:
+    return SetAuthorizationStateResponse(
+        active_model=(
+            _authorization_model_ref_from_proto(value.active_model)
+            if _has_field(value, "active_model")
+            else None
+        )
     )
 
 
@@ -362,6 +727,16 @@ def set_authorization_state_response_to_proto(value: Any) -> Any:
     )
 
 
+def get_active_model_ref_response_from_proto(value: Any) -> GetActiveModelRefResponse:
+    return GetActiveModelRefResponse(
+        model=(
+            _authorization_model_ref_from_proto(value.model)
+            if _has_field(value, "model")
+            else None
+        )
+    )
+
+
 def get_active_model_ref_response_to_proto(value: Any) -> Any:
     if isinstance(value, pb.GetActiveModelRefResponse):
         return _copy(value)
@@ -375,9 +750,32 @@ def get_active_model_ref_response_to_proto(value: Any) -> Any:
     )
 
 
+def set_active_model_request_to_proto(value: Any) -> Any:
+    if isinstance(value, pb.SetActiveModelRequest):
+        return _copy(value)
+    request = _coerce(value, SetActiveModelRequest, "SetActiveModelRequest")
+    return pb.SetActiveModelRequest(
+        model=(
+            authorization_model_to_proto(request.model)
+            if request.model is not None
+            else None
+        )
+    )
+
+
 def set_active_model_request_from_proto(value: Any) -> SetActiveModelRequest:
     return SetActiveModelRequest(
         model=authorization_model_from_proto(value.model) if _has_field(value, "model") else None
+    )
+
+
+def set_active_model_response_from_proto(value: Any) -> SetActiveModelResponse:
+    return SetActiveModelResponse(
+        model=(
+            _authorization_model_ref_from_proto(value.model)
+            if _has_field(value, "model")
+            else None
+        )
     )
 
 
@@ -391,6 +789,28 @@ def set_active_model_response_to_proto(value: Any) -> Any:
             if response.model is not None
             else None
         )
+    )
+
+
+def list_active_model_resource_types_request_to_proto(value: Any) -> Any:
+    if isinstance(value, pb.ListActiveModelResourceTypesRequest):
+        return _copy(value)
+    request = _coerce(
+        value,
+        ListActiveModelResourceTypesRequest,
+        "ListActiveModelResourceTypesRequest",
+    )
+    return pb.ListActiveModelResourceTypesRequest(
+        filter=(
+            pb.AuthorizationModelResourceTypeFilter(
+                name=request.filter.name,
+                source_layer=request.filter.source_layer,
+            )
+            if request.filter is not None
+            else None
+        ),
+        page_size=request.page_size,
+        page_token=request.page_token,
     )
 
 
@@ -411,6 +831,19 @@ def list_active_model_resource_types_request_from_proto(
     )
 
 
+def list_active_model_resource_types_response_from_proto(
+    value: Any,
+) -> ListActiveModelResourceTypesResponse:
+    return ListActiveModelResourceTypesResponse(
+        resource_types=[
+            authorization_model_resource_type_from_proto(item)
+            for item in value.resource_types
+        ],
+        next_page_token=value.next_page_token,
+        model_id=value.model_id,
+    )
+
+
 def list_active_model_resource_types_response_to_proto(value: Any) -> Any:
     if isinstance(value, pb.ListActiveModelResourceTypesResponse):
         return _copy(value)
@@ -426,6 +859,29 @@ def list_active_model_resource_types_response_to_proto(value: Any) -> Any:
         ],
         next_page_token=response.next_page_token,
         model_id=response.model_id,
+    )
+
+
+def relationship_filter_to_proto(value: Any) -> Any:
+    if isinstance(value, pb.RelationshipFilter):
+        return _copy(value)
+    relationship_filter = _coerce(value, RelationshipFilter, "RelationshipFilter")
+    return pb.RelationshipFilter(
+        target=(
+            relationship_target_to_proto(relationship_filter.target)
+            if relationship_filter.target is not None
+            else None
+        ),
+        relation=relationship_filter.relation,
+        resource=(
+            _resource_to_proto(relationship_filter.resource)
+            if relationship_filter.resource is not None
+            else None
+        ),
+        target_type=relationship_filter.target_type,
+        target_entity_type=relationship_filter.target_entity_type,
+        resource_type=relationship_filter.resource_type,
+        source_layer=relationship_filter.source_layer,
     )
 
 
@@ -548,6 +1004,20 @@ def subject_set_to_proto(value: Any) -> Any:
             else None
         ),
         relation=subject_set.relation,
+    )
+
+
+def authorization_model_to_proto(value: Any) -> Any:
+    if isinstance(value, pb.AuthorizationModel):
+        return _copy(value)
+    model = _coerce(value, AuthorizationModel, "AuthorizationModel")
+    return pb.AuthorizationModel(
+        id=model.id,
+        version=model.version,
+        resource_types=[
+            authorization_model_resource_type_to_proto(item)
+            for item in model.resource_types
+        ],
     )
 
 
@@ -686,6 +1156,16 @@ def _action_from_proto(value: Any) -> AuthorizationAction:
         properties=_struct_to_dict(value.properties)
         if _has_field(value, "properties")
         else {},
+    )
+
+
+def _action_to_proto(value: Any) -> Any:
+    if isinstance(value, pb.Action):
+        return _copy(value)
+    action = _coerce(value, AuthorizationAction, "AuthorizationAction")
+    return pb.Action(
+        name=action.name,
+        properties=_struct_from_dict(action.properties),
     )
 
 

--- a/sdk/python/tests/test_runtime.py
+++ b/sdk/python/tests/test_runtime.py
@@ -1,6 +1,7 @@
 import datetime as dt
 import importlib
 import json
+import os
 import pathlib
 import socket
 import sys
@@ -318,6 +319,15 @@ class RequestTests(unittest.TestCase):
         self.assertEqual(request.workflow, {})
         self.assertEqual(request.idempotency_key, "")
         self.assertEqual(request.invocation_token, "")
+
+    def test_authorization_requires_host_service_socket(self) -> None:
+        request = Request()
+
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with self.assertRaisesRegex(
+                RuntimeError, "authorization: GESTALT_HOST_SERVICE_SOCKET is not set"
+            ):
+                request.authorization()
 
 
 class MainEntrypointTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

Exposes a current-contract Python SDK authorization client from `gestalt.Request.authorization()` so app providers can call the host authorization provider after the authorization API rewrite.

The SDK adds `Authorization` and `AuthorizationProtocol` around the new provider RPCs: `CheckAccess`, `ListRelationships`, `AddRelationship`, relationship deletion, active model calls, and authorization state updates. The client uses the same host-service socket and relay token transport as the app, agent, and workflow clients.

This lets Python providers migrate off the removed resource-search and relationship-write helpers without losing runtime access to authorization relationships.

## Interfaces

```python
authorization = request.authorization()
allowed = authorization.check_access(
    gestalt.CheckAccessRequest(
        subject=gestalt.AuthorizationSubject(type="subject", id=subject_id),
        action=gestalt.AuthorizationAction(name="bot"),
        resource=gestalt.AuthorizationResource(type="github/repository", id=repo_id),
    )
)
```

```python
authorization.add_relationship(
    gestalt.AddRelationshipRequest(
        relationship=gestalt.Relationship(
            tuple=gestalt.RelationshipTuple(
                target=gestalt.RelationshipTarget(subject=subject),
                relation="linked",
                resource=resource,
            ),
            source_layer=gestalt.SOURCE_LAYER_RUNTIME,
        )
    )
)
```

## Runtime

`Request.authorization()` returns a shared authorization client bound to `GESTALT_HOST_SERVICE_SOCKET` and `GESTALT_HOST_SERVICE_TOKEN`. Client requests convert Python dataclasses into the current authorization protobuf messages, and responses convert back into the SDK dataclasses already used by authorization providers.

A runtime test covers the request hook and host-service socket requirement. Existing provider-side authorization dataclasses and RPC handlers remain on the same protobuf contract.