### PR TITLE
[auth] hydrate subject email for canonical users

### DIFF
--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -87,6 +87,7 @@ type CapabilityLister interface {
 // UserStore is the user persistence surface the broker needs to canonicalize
 // session identities before resolving user-scoped credentials.
 type UserStore interface {
+	GetUser(ctx context.Context, id string) (*core.User, error)
 	FindOrCreateUser(ctx context.Context, email string) (*core.User, error)
 }
 
@@ -740,7 +741,40 @@ func (b *Broker) ResolveRuntimeConnectionCredential(ctx context.Context, p *prin
 
 func (b *Broker) resolveUserPrincipal(ctx context.Context, p *principal.Principal) error {
 	p = principal.Canonicalize(p)
-	if p == nil || p.UserID != "" || principal.IsNonUserPrincipal(p) || p.Identity == nil || p.Identity.Email == "" {
+	if p == nil || principal.IsNonUserPrincipal(p) {
+		return nil
+	}
+	if p.UserID != "" {
+		if b.users == nil {
+			return nil
+		}
+		dbUser, err := b.users.GetUser(ctx, p.UserID)
+		if err != nil {
+			if errors.Is(err, core.ErrNotFound) {
+				return nil
+			}
+			return fmt.Errorf("%w: %v", ErrUserResolution, err)
+		}
+		if dbUser == nil || dbUser.ID == "" {
+			return fmt.Errorf("%w: no user record returned", ErrUserResolution)
+		}
+		p.UserID = dbUser.ID
+		if p.Identity == nil {
+			p.Identity = &core.UserIdentity{}
+		}
+		if p.Identity.Email == "" {
+			p.Identity.Email = dbUser.Email
+		}
+		if p.Identity.DisplayName == "" {
+			p.Identity.DisplayName = dbUser.DisplayName
+		}
+		if p.Kind == "" {
+			p.Kind = principal.KindUser
+		}
+		principal.Canonicalize(p)
+		return nil
+	}
+	if p.Identity == nil || p.Identity.Email == "" {
 		return nil
 	}
 	if b.users == nil {

--- a/gestaltd/services/invocation/broker_test.go
+++ b/gestaltd/services/invocation/broker_test.go
@@ -53,6 +53,36 @@ func TestBrokerResolveToken_ConnectionModeNoneResolvesSessionUserSubject(t *test
 	}
 }
 
+func TestBrokerResolveUserPrincipalHydratesKnownUserIdentity(t *testing.T) {
+	t.Parallel()
+
+	svc := testutil.NewStubServices(t)
+	user, err := svc.Users.FindOrCreateUser(context.Background(), "abc@valon.com")
+	if err != nil {
+		t.Fatalf("FindOrCreateUser: %v", err)
+	}
+	broker := NewBroker(testutil.NewProviderRegistry(t), svc.Users, svc.ExternalCredentials)
+	p := &principal.Principal{
+		UserID:    user.ID,
+		SubjectID: principal.UserSubjectID(user.ID),
+		Kind:      principal.KindUser,
+		Source:    principal.SourceAPIToken,
+	}
+
+	if err := broker.resolveUserPrincipal(context.Background(), p); err != nil {
+		t.Fatalf("resolveUserPrincipal: %v", err)
+	}
+	if p.Identity == nil {
+		t.Fatal("identity was not hydrated")
+	}
+	if got := p.Identity.Email; got != "abc@valon.com" {
+		t.Fatalf("identity email = %q, want abc@valon.com", got)
+	}
+	if got := p.SubjectID; got != principal.UserSubjectID(user.ID) {
+		t.Fatalf("subject ID = %q, want %q", got, principal.UserSubjectID(user.ID))
+	}
+}
+
 func TestBrokerResolveToken_NonUserSubjectUsesOwnExternalCredential(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Description
Hydrates broker user principals from the user store when a request already has a canonical user subject but lacks identity email, so app provider request contexts include `subject.email` for user API/session principals.

Tested with `go test ./gestaltd/services/invocation`.