### PR TITLE
Preserve agent created-by subjects in Python SDK

### DIFF
--- a/sdk/python/gestalt/_agent.py
+++ b/sdk/python/gestalt/_agent.py
@@ -638,9 +638,7 @@ def create_agent_provider_session_request_from_proto(
         metadata=struct_to_dict(request.metadata)
         if has_field(request, "metadata")
         else None,
-        created_by_subject_id=request.created_by_subject_id.strip()
-        if has_field(request, "created_by_subject_id")
-        else "",
+        created_by_subject_id=request.created_by_subject_id.strip(),
         subject=subject_from_proto(request.subject)
         if has_field(request, "subject")
         else None,
@@ -713,9 +711,7 @@ def create_agent_provider_turn_request_from_proto(
         metadata=struct_to_dict(request.metadata)
         if has_field(request, "metadata")
         else None,
-        created_by_subject_id=request.created_by_subject_id.strip()
-        if has_field(request, "created_by_subject_id")
-        else "",
+        created_by_subject_id=request.created_by_subject_id.strip(),
         execution_ref=request.execution_ref,
         tool_refs=[agent_tool_ref_from_proto(ref) for ref in request.tool_refs],
         tool_source=request.tool_source,
@@ -1282,9 +1278,7 @@ def agent_session_from_proto(value: Any) -> AgentSession:
         metadata=struct_to_dict(value.metadata)
         if has_field(value, "metadata")
         else None,
-        created_by_subject_id=value.created_by_subject_id.strip()
-        if has_field(value, "created_by_subject_id")
-        else "",
+        created_by_subject_id=value.created_by_subject_id.strip(),
         created_at=datetime_from_timestamp(value.created_at)
         if has_field(value, "created_at")
         else None,
@@ -1315,9 +1309,7 @@ def agent_turn_from_proto(value: Any) -> AgentTurn:
         messages=[agent_message_from_proto(message) for message in value.messages],
         output=_agent_turn_output_from_proto(value),
         status_message=value.status_message,
-        created_by_subject_id=value.created_by_subject_id.strip()
-        if has_field(value, "created_by_subject_id")
-        else "",
+        created_by_subject_id=value.created_by_subject_id.strip(),
         created_at=datetime_from_timestamp(value.created_at)
         if has_field(value, "created_at")
         else None,

--- a/sdk/python/tests/test_agent_transport.py
+++ b/sdk/python/tests/test_agent_transport.py
@@ -935,6 +935,7 @@ class AgentTransportTests(unittest.TestCase):
             idempotency_key="session-req-1",
             model="gpt-5.1",
             client_ref="cli-session-1",
+            created_by_subject_id="user:session-owner",
         )
         create_session_metadata = struct_pb2.Struct()
         create_session_metadata.update({"source": "py-test"})
@@ -975,6 +976,7 @@ class AgentTransportTests(unittest.TestCase):
                         ],
                     )
                 ],
+                created_by_subject_id="user:turn-owner",
                 execution_ref="exec-turn-1",
                 output=agent_pb2.AgentOutput(
                     text=agent_pb2.AgentTextOutput(),
@@ -1020,12 +1022,14 @@ class AgentTransportTests(unittest.TestCase):
         self.assertEqual(_provider.configured, [("agent-runtime", {"tenant": "acme"})])
         self.assertEqual(created_session.id, "session-1")
         self.assertEqual(created_session.state, agent_pb2.AGENT_SESSION_STATE_ACTIVE)
+        self.assertEqual(created_session.created_by_subject_id, "user:session-owner")
         self.assertEqual(
             [session.id for session in listed_sessions.sessions], ["session-1"]
         )
         self.assertEqual(fetched_session.state, agent_pb2.AGENT_SESSION_STATE_ARCHIVED)
         self.assertEqual(updated_session.client_ref, "cli-session-2")
         self.assertEqual(created_turn.id, "turn-1")
+        self.assertEqual(created_turn.created_by_subject_id, "user:turn-owner")
         self.assertEqual(
             created_turn.status,
             agent_pb2.AGENT_EXECUTION_STATUS_WAITING_FOR_INPUT,


### PR DESCRIPTION
## Summary
- Preserve scalar `created_by_subject_id` values when converting agent provider requests, sessions, and turns from proto in the Python SDK.
- Extend the agent transport roundtrip test to assert session and turn owner subjects survive the runtime boundary.

## Interfaces
- Keeps the current `created_by_subject_id` contract; no `AgentActor` compatibility path is reintroduced.

## Runtime
- Fixes provider/runtime conversions where proto3 scalar presence checks dropped owner IDs before agent providers could persist them.

## Verification
- `uv run --no-sync --group dev ruff check .`
- `uv run --no-sync --group dev ty check --exclude 'gestalt/_gen/**' gestalt scripts tests`\n- `uv run --no-sync --group dev vulture --config pyproject.toml`\n- `uv run --no-sync --group dev python -m unittest discover -s tests -p 'test*.py'`