### PR TITLE
[authorization] revert app host service

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -169,7 +169,6 @@ type Deps struct {
 	AgentRunGrants              *agentgrant.Manager
 	WorkflowManager             workflowmanager.Service
 	AgentManager                agentmanager.Service
-	AuthorizationProvider       core.AuthorizationProvider
 	Egress                      EgressDeps
 	AppInvocation               invocation.Invoker
 	WorkflowAppInvocationGrants map[string]appaccessservice.InvocationGrants
@@ -982,12 +981,6 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 		_ = closeAuthProviders(authProviders)
 		return nil, err
 	}
-	_, authorizationProvider, err := selectedAuthorizationProviderInstance(cfg, authorizationProviders)
-	if err != nil {
-		_ = closeAuthProviders(authProviders)
-		return nil, err
-	}
-	deps.AuthorizationProvider = authorizationProvider
 	closeExternalCredentialsOnError := true
 	defer func() {
 		if closeExternalCredentialsOnError {

--- a/gestaltd/internal/bootstrap/host_service_bootstrap.go
+++ b/gestaltd/internal/bootstrap/host_service_bootstrap.go
@@ -26,9 +26,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/s3"
 	workflowservice "github.com/valon-technologies/gestalt/server/services/workflows"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 const (
@@ -54,7 +51,6 @@ func buildProviderHostServices(name string, deps Deps, extraHostServices ...runt
 		hostServices = append(hostServices, s3HostService)
 	}
 	hostServices = append(hostServices,
-		buildPluginAuthorizationHostService(deps.AuthorizationProvider),
 		buildAppInvocationHostService(deps, invTokens),
 		buildWorkflowProviderHostService(name, deps, invTokens),
 		buildPluginAgentProviderHostService(name, deps, invTokens),
@@ -484,72 +480,6 @@ func buildPluginExternalCredentialsHostService(provider core.ExternalCredentialP
 			proto.RegisterExternalCredentialProviderServer(srv, externalcredentialsservice.NewProviderServer(provider))
 		},
 	}
-}
-
-func buildPluginAuthorizationHostService(provider core.AuthorizationProvider) runtimehost.HostService {
-	return runtimehost.HostService{
-		Name:           "authorization",
-		MethodPrefixes: []string{grpcMethodPrefix(proto.AuthorizationProvider_ServiceDesc.ServiceName)},
-		Register: func(srv *grpc.Server) {
-			proto.RegisterAuthorizationProviderServer(srv, appAuthorizationHostService{provider: provider})
-		},
-	}
-}
-
-type appAuthorizationHostService struct {
-	proto.UnimplementedAuthorizationProviderServer
-	provider core.AuthorizationProvider
-}
-
-func (s appAuthorizationHostService) CheckAccess(ctx context.Context, req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
-	if s.provider == nil {
-		return nil, status.Error(codes.Unavailable, "authorization provider is not configured")
-	}
-	return s.provider.CheckAccess(ctx, req)
-}
-
-func (s appAuthorizationHostService) CheckAccessMany(ctx context.Context, req *proto.CheckAccessManyRequest) (*proto.CheckAccessManyResponse, error) {
-	if s.provider == nil {
-		return nil, status.Error(codes.Unavailable, "authorization provider is not configured")
-	}
-	return s.provider.CheckAccessMany(ctx, req)
-}
-
-func (s appAuthorizationHostService) ListRelationships(ctx context.Context, req *proto.ListRelationshipsRequest) (*proto.ListRelationshipsResponse, error) {
-	if s.provider == nil {
-		return nil, status.Error(codes.Unavailable, "authorization provider is not configured")
-	}
-	return s.provider.ListRelationships(ctx, req)
-}
-
-func (s appAuthorizationHostService) GetActiveModelRef(ctx context.Context, _ *emptypb.Empty) (*proto.GetActiveModelRefResponse, error) {
-	if s.provider == nil {
-		return nil, status.Error(codes.Unavailable, "authorization provider is not configured")
-	}
-	return s.provider.GetActiveModelRef(ctx)
-}
-
-func (s appAuthorizationHostService) ListActiveModelResourceTypes(ctx context.Context, req *proto.ListActiveModelResourceTypesRequest) (*proto.ListActiveModelResourceTypesResponse, error) {
-	if s.provider == nil {
-		return nil, status.Error(codes.Unavailable, "authorization provider is not configured")
-	}
-	return s.provider.ListActiveModelResourceTypes(ctx, req)
-}
-
-func (appAuthorizationHostService) AddRelationship(context.Context, *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {
-	return nil, status.Error(codes.PermissionDenied, "authorization relationship mutations are not available to apps")
-}
-
-func (appAuthorizationHostService) DeleteRelationship(context.Context, *proto.DeleteRelationshipRequest) (*proto.DeleteRelationshipResponse, error) {
-	return nil, status.Error(codes.PermissionDenied, "authorization relationship mutations are not available to apps")
-}
-
-func (appAuthorizationHostService) SetAuthorizationState(context.Context, *proto.SetAuthorizationStateRequest) (*proto.SetAuthorizationStateResponse, error) {
-	return nil, status.Error(codes.PermissionDenied, "authorization state mutations are not available to apps")
-}
-
-func (appAuthorizationHostService) SetActiveModel(context.Context, *proto.SetActiveModelRequest) (*proto.SetActiveModelResponse, error) {
-	return nil, status.Error(codes.PermissionDenied, "authorization model mutations are not available to apps")
 }
 
 func buildAppInvocationHostService(deps Deps, tokens *appaccessservice.InvocationTokenManager) runtimehost.HostService {

--- a/gestaltd/internal/bootstrap/workflow_startup_test.go
+++ b/gestaltd/internal/bootstrap/workflow_startup_test.go
@@ -14,14 +14,11 @@ import (
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
-	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"go.opentelemetry.io/otel/metric"
 	metricnoop "go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/trace"
 	tracenoop "go.opentelemetry.io/otel/trace/noop"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"gopkg.in/yaml.v3"
 )
 
@@ -90,7 +87,6 @@ func TestBuildProviderHostServicesDoesNotRequireConfiguredEncryptionKey(t *testi
 	t.Parallel()
 
 	hostServices, invTokens, err := buildProviderHostServices("metadata", Deps{
-		AuthorizationProvider: &recordingAuthorizationProvider{},
 		Services: &coredata.Services{
 			ExternalCredentials: coretesting.NewStubExternalCredentialProvider(),
 		},
@@ -103,32 +99,10 @@ func TestBuildProviderHostServicesDoesNotRequireConfiguredEncryptionKey(t *testi
 	}
 
 	names := hostServiceNames(hostServices)
-	for _, want := range []string{"authorization", "app", "workflow_provider", "agent_provider", "external_credentials"} {
+	for _, want := range []string{"app", "workflow_provider", "agent_provider", "external_credentials"} {
 		if !hasHostServiceName(names, want) {
 			t.Fatalf("provider host services missing %q: %v", want, names)
 		}
-	}
-}
-
-func TestAppAuthorizationHostServiceIsReadOnly(t *testing.T) {
-	t.Parallel()
-
-	provider := &recordingAuthorizationProvider{}
-	service := appAuthorizationHostService{provider: provider}
-
-	_, err := service.ListRelationships(context.Background(), &proto.ListRelationshipsRequest{
-		Filter: &proto.RelationshipFilter{ResourceType: "workplaceHub"},
-	})
-	if err != nil {
-		t.Fatalf("ListRelationships: %v", err)
-	}
-	if len(provider.listRequests) != 1 || provider.listRequests[0].GetFilter().GetResourceType() != "workplaceHub" {
-		t.Fatalf("ListRelationships requests = %#v", provider.listRequests)
-	}
-
-	_, err = service.AddRelationship(context.Background(), &proto.AddRelationshipRequest{})
-	if status.Code(err) != codes.PermissionDenied {
-		t.Fatalf("AddRelationship error = %v, want PermissionDenied", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Revert the authorization app host-service wiring that landed directly on main
- Restore the previous app host-service surface while the change is reviewed separately

## Test plan
- [x] go test ./gestaltd/internal/bootstrap ./gestaltd/services/runtimehost ./gestaltd/services/invocation