### PR TITLE
Expose workflow definition HTTP controls

### DIFF
--- a/gestaltd/internal/server/handlers_workflow_definitions.go
+++ b/gestaltd/internal/server/handlers_workflow_definitions.go
@@ -1,0 +1,282 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/valon-technologies/gestalt/server/core"
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
+	"github.com/valon-technologies/gestalt/server/services/workflows/workflowmanager"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+)
+
+type workflowDefinitionInfo struct {
+	ID                 string                     `json:"id"`
+	Provider           string                     `json:"provider"`
+	Generation         int64                      `json:"generation"`
+	Target             workflowScheduleTargetInfo `json:"target"`
+	Activations        []workflowActivationInfo   `json:"activations"`
+	Paused             bool                       `json:"paused"`
+	CreatedBySubjectID string                     `json:"createdBySubjectId,omitempty"`
+	CreatedAt          *time.Time                 `json:"createdAt,omitempty"`
+	UpdatedAt          *time.Time                 `json:"updatedAt,omitempty"`
+	RunAs              *workflowRunAsInfo         `json:"runAs,omitempty"`
+}
+
+type workflowRunAsInfo struct {
+	SubjectID           string `json:"subjectId,omitempty"`
+	CredentialSubjectID string `json:"credentialSubjectId,omitempty"`
+}
+
+type workflowActivationInfo struct {
+	ID       string                          `json:"id"`
+	Input    any                             `json:"input,omitempty"`
+	Paused   bool                            `json:"paused"`
+	Schedule *workflowScheduleActivationInfo `json:"schedule,omitempty"`
+	Event    *workflowEventActivationInfo    `json:"event,omitempty"`
+}
+
+type workflowScheduleActivationInfo struct {
+	Cron     string `json:"cron"`
+	Timezone string `json:"timezone,omitempty"`
+}
+
+type workflowEventActivationInfo struct {
+	Match workflowEventMatchInfo `json:"match"`
+}
+
+type workflowEventMatchInfo struct {
+	Type    string `json:"type"`
+	Source  string `json:"source,omitempty"`
+	Subject string `json:"subject,omitempty"`
+}
+
+type workflowDefinitionListResponse struct {
+	Definitions []workflowDefinitionInfo `json:"definitions"`
+}
+
+type workflowDefinitionPauseRequest struct {
+	Paused *bool `json:"paused"`
+}
+
+func (s *Server) listGlobalWorkflowDefinitions(w http.ResponseWriter, r *http.Request) {
+	p, ok := s.resolveWorkflowActor(w, r)
+	if !ok {
+		return
+	}
+	resp, err := s.workflowSchedules.ListDefinitions(r.Context(), p)
+	if err != nil {
+		s.writeWorkflowDefinitionManagerError(w, r, "", err)
+		return
+	}
+	if resp == nil {
+		resp = &workflowmanager.ListDefinitionsResponse{}
+	}
+	out := make([]workflowDefinitionInfo, 0, len(resp.Definitions))
+	for _, managed := range resp.Definitions {
+		if managed == nil || managed.Definition == nil {
+			continue
+		}
+		out = append(out, workflowDefinitionInfoFromManaged(managed))
+	}
+	writeJSON(w, http.StatusOK, workflowDefinitionListResponse{Definitions: out})
+}
+
+func (s *Server) getGlobalWorkflowDefinition(w http.ResponseWriter, r *http.Request) {
+	p, ok := s.resolveWorkflowActor(w, r)
+	if !ok {
+		return
+	}
+	definitionID := chi.URLParam(r, "definitionID")
+	managed, err := s.workflowSchedules.GetDefinition(r.Context(), p, definitionID)
+	if err != nil {
+		s.writeWorkflowDefinitionManagerError(w, r, definitionID, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, workflowDefinitionInfoFromManaged(managed))
+}
+
+func (s *Server) setGlobalWorkflowDefinitionPaused(w http.ResponseWriter, r *http.Request) {
+	p, ok := s.resolveWorkflowActor(w, r)
+	if !ok {
+		return
+	}
+	req, ok := workflowDefinitionPauseRequestFromBody(w, r)
+	if !ok {
+		return
+	}
+	definitionID := chi.URLParam(r, "definitionID")
+	managed, err := s.workflowSchedules.SetDefinitionPaused(r.Context(), p, definitionID, *req.Paused)
+	if err != nil {
+		s.writeWorkflowDefinitionManagerError(w, r, definitionID, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, workflowDefinitionInfoFromManaged(managed))
+}
+
+func (s *Server) setGlobalWorkflowActivationPaused(w http.ResponseWriter, r *http.Request) {
+	p, ok := s.resolveWorkflowActor(w, r)
+	if !ok {
+		return
+	}
+	req, ok := workflowDefinitionPauseRequestFromBody(w, r)
+	if !ok {
+		return
+	}
+	definitionID := chi.URLParam(r, "definitionID")
+	managed, err := s.workflowSchedules.SetActivationPaused(r.Context(), p, definitionID, chi.URLParam(r, "activationID"), *req.Paused)
+	if err != nil {
+		s.writeWorkflowDefinitionManagerError(w, r, definitionID, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, workflowDefinitionInfoFromManaged(managed))
+}
+
+func (s *Server) deleteGlobalWorkflowDefinition(w http.ResponseWriter, r *http.Request) {
+	p, ok := s.resolveWorkflowActor(w, r)
+	if !ok {
+		return
+	}
+	definitionID := chi.URLParam(r, "definitionID")
+	if err := s.workflowSchedules.DeleteDefinition(r.Context(), p, definitionID); err != nil {
+		s.writeWorkflowDefinitionManagerError(w, r, definitionID, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func workflowDefinitionPauseRequestFromBody(w http.ResponseWriter, r *http.Request) (workflowDefinitionPauseRequest, bool) {
+	var req workflowDefinitionPauseRequest
+	if r.Body != nil {
+		defer func() { _ = r.Body.Close() }()
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+			writeError(w, http.StatusBadRequest, "invalid JSON body")
+			return workflowDefinitionPauseRequest{}, false
+		}
+	}
+	if req.Paused == nil {
+		writeError(w, http.StatusBadRequest, "paused is required")
+		return workflowDefinitionPauseRequest{}, false
+	}
+	return req, true
+}
+
+func workflowDefinitionInfoFromManaged(managed *workflowmanager.ManagedDefinition) workflowDefinitionInfo {
+	if managed == nil {
+		return workflowDefinitionInfo{}
+	}
+	return workflowDefinitionInfoFromCore(managed.Definition, strings.TrimSpace(managed.ProviderName))
+}
+
+func workflowDefinitionInfoFromCore(definition *coreworkflow.Definition, providerName string) workflowDefinitionInfo {
+	info := workflowDefinitionInfo{Provider: providerName}
+	if definition == nil {
+		return info
+	}
+	info.ID = strings.TrimSpace(definition.ID)
+	info.Generation = definition.Generation
+	info.Target = workflowScheduleTargetInfoFromCore(definition.Target)
+	info.Activations = workflowActivationsInfoFromCore(definition.Activations)
+	info.Paused = definition.Paused
+	info.CreatedBySubjectID = strings.TrimSpace(definition.CreatedBySubjectID)
+	info.CreatedAt = definition.CreatedAt
+	info.UpdatedAt = definition.UpdatedAt
+	info.RunAs = workflowRunAsInfoFromCore(definition.RunAs)
+	return info
+}
+
+func workflowRunAsInfoFromCore(runAs *core.RunAsSubject) *workflowRunAsInfo {
+	runAs = core.NormalizeRunAsSubject(runAs)
+	if runAs == nil {
+		return nil
+	}
+	return &workflowRunAsInfo{
+		SubjectID:           runAs.SubjectID,
+		CredentialSubjectID: runAs.CredentialSubjectID,
+	}
+}
+
+func workflowActivationsInfoFromCore(activations []coreworkflow.Activation) []workflowActivationInfo {
+	if len(activations) == 0 {
+		return []workflowActivationInfo{}
+	}
+	out := make([]workflowActivationInfo, 0, len(activations))
+	for i := range activations {
+		activation := activations[i]
+		out = append(out, workflowActivationInfo{
+			ID:       strings.TrimSpace(activation.ID),
+			Input:    workflowValueInfoFromCore(activation.Input),
+			Paused:   activation.Paused,
+			Schedule: workflowScheduleActivationInfoFromCore(activation.Schedule),
+			Event:    workflowEventActivationInfoFromCore(activation.Event),
+		})
+	}
+	return out
+}
+
+func workflowScheduleActivationInfoFromCore(schedule *coreworkflow.ScheduleActivation) *workflowScheduleActivationInfo {
+	if schedule == nil {
+		return nil
+	}
+	return &workflowScheduleActivationInfo{
+		Cron:     strings.TrimSpace(schedule.Cron),
+		Timezone: strings.TrimSpace(schedule.Timezone),
+	}
+}
+
+func workflowEventActivationInfoFromCore(event *coreworkflow.EventActivation) *workflowEventActivationInfo {
+	if event == nil {
+		return nil
+	}
+	return &workflowEventActivationInfo{Match: workflowEventMatchInfoFromCore(event.Match)}
+}
+
+func workflowEventMatchInfoFromCore(match coreworkflow.EventMatch) workflowEventMatchInfo {
+	return workflowEventMatchInfo{
+		Type:    strings.TrimSpace(match.Type),
+		Source:  strings.TrimSpace(match.Source),
+		Subject: strings.TrimSpace(match.Subject),
+	}
+}
+
+func (s *Server) writeWorkflowDefinitionManagerError(w http.ResponseWriter, r *http.Request, definitionID string, err error) {
+	switch {
+	case errors.Is(err, workflowmanager.ErrWorkflowNotConfigured):
+		writeError(w, http.StatusPreconditionFailed, err.Error())
+	case errors.Is(err, workflowmanager.ErrWorkflowSubjectRequired):
+		writeError(w, http.StatusUnauthorized, err.Error())
+	case errors.Is(err, invocation.ErrInvalidInvocation):
+		writeError(w, http.StatusBadRequest, err.Error())
+	case errors.Is(err, core.ErrNotFound):
+		s.writeWorkflowDefinitionProviderError(r.Context(), w, definitionID, err)
+	default:
+		s.writeWorkflowDefinitionProviderError(r.Context(), w, definitionID, err)
+	}
+}
+
+func (s *Server) writeWorkflowDefinitionProviderError(ctx context.Context, w http.ResponseWriter, definitionID string, err error) {
+	switch {
+	case errors.Is(err, core.ErrNotFound):
+		writeError(w, http.StatusNotFound, fmt.Sprintf("workflow definition %q not found", definitionID))
+	case grpcstatus.Code(err) == codes.NotFound:
+		writeError(w, http.StatusNotFound, fmt.Sprintf("workflow definition %q not found", definitionID))
+	case grpcstatus.Code(err) == codes.InvalidArgument:
+		writeError(w, http.StatusBadRequest, grpcstatus.Convert(err).Message())
+	default:
+		slog.ErrorContext(ctx, "workflow definition provider error",
+			"definition_id", definitionID,
+			"error", err,
+		)
+		writeError(w, http.StatusInternalServerError, "workflow definition request failed")
+	}
+}

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -19,6 +19,14 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 		r.Delete("/apps/{name}", s.disconnectIntegration)
 
 		r.Post("/workflow/events", s.deliverWorkflowEvent)
+		r.Get("/workflow/definitions", s.listGlobalWorkflowDefinitions)
+		r.Route("/workflow/definitions", func(r chi.Router) {
+			r.Get("/", s.listGlobalWorkflowDefinitions)
+			r.Get("/{definitionID}", s.getGlobalWorkflowDefinition)
+			r.Patch("/{definitionID}", s.setGlobalWorkflowDefinitionPaused)
+			r.Delete("/{definitionID}", s.deleteGlobalWorkflowDefinition)
+			r.Patch("/{definitionID}/activations/{activationID}", s.setGlobalWorkflowActivationPaused)
+		})
 		r.Get("/workflow/runs", s.listGlobalWorkflowRuns)
 		r.Route("/workflow/runs", func(r chi.Router) {
 			r.Get("/", s.listGlobalWorkflowRuns)

--- a/gestaltd/internal/server/workflow_definition_test.go
+++ b/gestaltd/internal/server/workflow_definition_test.go
@@ -1,0 +1,361 @@
+package server_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+	"github.com/valon-technologies/gestalt/server/internal/server"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type workflowDefinitionHTTPResponse struct {
+	ID                 string `json:"id"`
+	Provider           string `json:"provider"`
+	Generation         int64  `json:"generation"`
+	Paused             bool   `json:"paused"`
+	CreatedBySubjectID string `json:"createdBySubjectId"`
+	Target             struct {
+		Steps []struct {
+			ID  string `json:"id"`
+			App *struct {
+				Name      string `json:"name"`
+				Operation string `json:"operation"`
+			} `json:"app"`
+		} `json:"steps"`
+	} `json:"target"`
+	Activations []struct {
+		ID       string         `json:"id"`
+		Input    map[string]any `json:"input"`
+		Paused   bool           `json:"paused"`
+		Schedule *struct {
+			Cron     string `json:"cron"`
+			Timezone string `json:"timezone"`
+		} `json:"schedule"`
+		Event *struct {
+			Match struct {
+				Type    string `json:"type"`
+				Source  string `json:"source"`
+				Subject string `json:"subject"`
+			} `json:"match"`
+		} `json:"event"`
+	} `json:"activations"`
+	RunAs *struct {
+		SubjectID           string `json:"subjectId"`
+		CredentialSubjectID string `json:"credentialSubjectId"`
+	} `json:"runAs"`
+}
+
+type workflowDefinitionHTTPListResponse struct {
+	Definitions []workflowDefinitionHTTPResponse `json:"definitions"`
+}
+
+func TestGlobalWorkflowDefinitionInspectionAndPause(t *testing.T) {
+	t.Parallel()
+
+	services := testutil.NewStubServices(t)
+	user := seedUser(t, services, "ada@example.test")
+	provider := newMemoryWorkflowProvider()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	provider.definitions["cfg_roadmap_sync"] = &coreworkflow.Definition{
+		ID:                 "cfg_roadmap_sync",
+		Generation:         7,
+		Target:             workflowAppStepTarget("roadmap", "sync"),
+		Paused:             false,
+		CreatedBySubjectID: principal.UserSubjectID(user.ID),
+		CreatedAt:          &now,
+		UpdatedAt:          &now,
+		RunAs: &core.RunAsSubject{
+			SubjectID:           "service_account:workflow:roadmap",
+			CredentialSubjectID: "service_account:credential:roadmap",
+		},
+		Activations: []coreworkflow.Activation{{
+			ID: "nightly",
+			Input: coreworkflow.Value{Object: map[string]coreworkflow.Value{
+				"item": {Literal: "roadmap", LiteralSet: true},
+			}},
+			Schedule: &coreworkflow.ScheduleActivation{Cron: "0 3 * * *", Timezone: "America/New_York"},
+		}, {
+			ID:     "task_updated",
+			Paused: true,
+			Event: &coreworkflow.EventActivation{Match: coreworkflow.EventMatch{
+				Type:    "task.updated",
+				Source:  "roadmap",
+				Subject: "workspace:planning",
+			}},
+		}},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "ada-session" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: user.Email, DisplayName: "Ada"}, nil
+			},
+		}
+		cfg.Services = services
+		cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+			N:        "roadmap",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{
+				Name:       "roadmap",
+				Operations: []catalog.CatalogOperation{{ID: "sync", Method: http.MethodPost}},
+			},
+		})
+		cfg.Workflow = &stubWorkflowControl{
+			defaultProviderName: "basic",
+			provider:            provider,
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	listReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/workflow/definitions/", nil)
+	listReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	listResp, err := http.DefaultClient.Do(listReq)
+	if err != nil {
+		t.Fatalf("list request: %v", err)
+	}
+	defer func() { _ = listResp.Body.Close() }()
+	if listResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected list 200, got %d", listResp.StatusCode)
+	}
+	var listed workflowDefinitionHTTPListResponse
+	if err := json.NewDecoder(listResp.Body).Decode(&listed); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if len(listed.Definitions) != 1 || listed.Definitions[0].ID != "cfg_roadmap_sync" || listed.Definitions[0].Provider != "basic" {
+		t.Fatalf("listed definitions = %#v", listed.Definitions)
+	}
+
+	getReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/workflow/definitions/cfg_roadmap_sync", nil)
+	getReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	getResp, err := http.DefaultClient.Do(getReq)
+	if err != nil {
+		t.Fatalf("get request: %v", err)
+	}
+	defer func() { _ = getResp.Body.Close() }()
+	if getResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected get 200, got %d", getResp.StatusCode)
+	}
+	var got workflowDefinitionHTTPResponse
+	if err := json.NewDecoder(getResp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode get response: %v", err)
+	}
+	if got.Generation != 7 || got.CreatedBySubjectID != principal.UserSubjectID(user.ID) {
+		t.Fatalf("definition identity fields = %#v", got)
+	}
+	if got.RunAs == nil || got.RunAs.SubjectID != "service_account:workflow:roadmap" || got.RunAs.CredentialSubjectID != "service_account:credential:roadmap" {
+		t.Fatalf("runAs = %#v", got.RunAs)
+	}
+	if len(got.Target.Steps) != 1 || got.Target.Steps[0].ID != "app" || got.Target.Steps[0].App.Name != "roadmap" || got.Target.Steps[0].App.Operation != "sync" {
+		t.Fatalf("target = %#v", got.Target)
+	}
+	if len(got.Activations) != 2 || got.Activations[0].Schedule == nil || got.Activations[1].Event == nil {
+		t.Fatalf("activations = %#v", got.Activations)
+	}
+	if got.Activations[0].Schedule.Cron != "0 3 * * *" || got.Activations[1].Event.Match.Type != "task.updated" {
+		t.Fatalf("activation details = %#v", got.Activations)
+	}
+
+	pauseReq, _ := http.NewRequest(http.MethodPatch, ts.URL+"/api/v1/workflow/definitions/cfg_roadmap_sync", bytes.NewBufferString(`{"paused":true}`))
+	pauseReq.Header.Set("Content-Type", "application/json")
+	pauseReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	pauseResp, err := http.DefaultClient.Do(pauseReq)
+	if err != nil {
+		t.Fatalf("pause request: %v", err)
+	}
+	defer func() { _ = pauseResp.Body.Close() }()
+	if pauseResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected pause 200, got %d", pauseResp.StatusCode)
+	}
+	if len(provider.definitionPauseReqs) != 1 || !provider.definitionPauseReqs[0].GetPaused() || provider.definitionPauseReqs[0].GetRequestedBySubjectId() != principal.UserSubjectID(user.ID) {
+		t.Fatalf("definition pause requests = %#v", provider.definitionPauseReqs)
+	}
+
+	activationReq, _ := http.NewRequest(http.MethodPatch, ts.URL+"/api/v1/workflow/definitions/cfg_roadmap_sync/activations/task_updated", bytes.NewBufferString(`{"paused":false}`))
+	activationReq.Header.Set("Content-Type", "application/json")
+	activationReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	activationResp, err := http.DefaultClient.Do(activationReq)
+	if err != nil {
+		t.Fatalf("activation pause request: %v", err)
+	}
+	defer func() { _ = activationResp.Body.Close() }()
+	if activationResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected activation pause 200, got %d", activationResp.StatusCode)
+	}
+	if len(provider.activationPauseReqs) != 1 || provider.activationPauseReqs[0].GetActivationId() != "task_updated" || provider.activationPauseReqs[0].GetPaused() {
+		t.Fatalf("activation pause requests = %#v", provider.activationPauseReqs)
+	}
+
+	deleteReq, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/workflow/definitions/cfg_roadmap_sync", nil)
+	deleteReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	deleteResp, err := http.DefaultClient.Do(deleteReq)
+	if err != nil {
+		t.Fatalf("delete request: %v", err)
+	}
+	defer func() { _ = deleteResp.Body.Close() }()
+	if deleteResp.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected delete 204, got %d", deleteResp.StatusCode)
+	}
+	if len(provider.deletedDefinitions) != 1 || provider.deletedDefinitions[0] != "cfg_roadmap_sync" {
+		t.Fatalf("deleted definitions = %#v", provider.deletedDefinitions)
+	}
+}
+
+func TestGlobalWorkflowDefinitionPauseRequiresPaused(t *testing.T) {
+	t.Parallel()
+
+	services := testutil.NewStubServices(t)
+	user := seedUser(t, services, "ada@example.test")
+	provider := newMemoryWorkflowProvider()
+	provider.definitions["cfg_roadmap_sync"] = &coreworkflow.Definition{
+		ID:                 "cfg_roadmap_sync",
+		Target:             workflowAppStepTarget("roadmap", "sync"),
+		CreatedBySubjectID: principal.UserSubjectID(user.ID),
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "ada-session" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: user.Email, DisplayName: "Ada"}, nil
+			},
+		}
+		cfg.Services = services
+		cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+			N:        "roadmap",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{
+				Name:       "roadmap",
+				Operations: []catalog.CatalogOperation{{ID: "sync", Method: http.MethodPost}},
+			},
+		})
+		cfg.Workflow = &stubWorkflowControl{
+			defaultProviderName: "basic",
+			provider:            provider,
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	getReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/workflow/definitions/cfg_roadmap_sync", nil)
+	getReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	getResp, err := http.DefaultClient.Do(getReq)
+	if err != nil {
+		t.Fatalf("get request: %v", err)
+	}
+	defer func() { _ = getResp.Body.Close() }()
+	if getResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected get 200, got %d", getResp.StatusCode)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.NewDecoder(getResp.Body).Decode(&raw); err != nil {
+		t.Fatalf("decode get response: %v", err)
+	}
+	if string(raw["activations"]) != "[]" {
+		t.Fatalf("activations JSON = %s, want []", raw["activations"])
+	}
+
+	req, _ := http.NewRequest(http.MethodPatch, ts.URL+"/api/v1/workflow/definitions/cfg_roadmap_sync", bytes.NewBufferString(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("pause request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestGlobalWorkflowDefinitionProviderNotFoundMapsToHTTPNotFound(t *testing.T) {
+	t.Parallel()
+
+	services := testutil.NewStubServices(t)
+	user := seedUser(t, services, "ada@example.test")
+	provider := newMemoryWorkflowProvider()
+	provider.definitions["cfg_roadmap_sync"] = &coreworkflow.Definition{
+		ID: "cfg_roadmap_sync",
+		Target: coreworkflow.Target{Steps: []coreworkflow.Step{{
+			ID: "sync",
+			App: &coreworkflow.AppCall{
+				Name:      "roadmap",
+				Operation: "sync",
+			},
+		}}},
+		CreatedBySubjectID: principal.UserSubjectID(user.ID),
+		Activations: []coreworkflow.Activation{{
+			ID:       "nightly",
+			Schedule: &coreworkflow.ScheduleActivation{Cron: "0 3 * * *"},
+		}},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "ada-session" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: user.Email, DisplayName: "Ada"}, nil
+			},
+		}
+		cfg.Services = services
+		cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+			N:        "roadmap",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{
+				Name:       "roadmap",
+				Operations: []catalog.CatalogOperation{{ID: "sync", Method: http.MethodPost}},
+			},
+		})
+		cfg.Workflow = &stubWorkflowControl{
+			defaultProviderName: "basic",
+			provider:            provider,
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	provider.activationPauseErr = status.Error(codes.NotFound, "activation not found")
+	activationReq, _ := http.NewRequest(http.MethodPatch, ts.URL+"/api/v1/workflow/definitions/cfg_roadmap_sync/activations/nightly", bytes.NewBufferString(`{"paused":true}`))
+	activationReq.Header.Set("Content-Type", "application/json")
+	activationReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	activationResp, err := http.DefaultClient.Do(activationReq)
+	if err != nil {
+		t.Fatalf("activation pause request: %v", err)
+	}
+	defer func() { _ = activationResp.Body.Close() }()
+	if activationResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected activation pause 404, got %d", activationResp.StatusCode)
+	}
+
+	provider.activationPauseErr = nil
+	provider.deleteDefinitionErr = status.Error(codes.NotFound, "definition not found")
+	deleteReq, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/workflow/definitions/cfg_roadmap_sync", nil)
+	deleteReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	deleteResp, err := http.DefaultClient.Do(deleteReq)
+	if err != nil {
+		t.Fatalf("delete request: %v", err)
+	}
+	defer func() { _ = deleteResp.Body.Close() }()
+	if deleteResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected delete 404, got %d", deleteResp.StatusCode)
+	}
+}

--- a/gestaltd/internal/server/workflow_test_helpers_test.go
+++ b/gestaltd/internal/server/workflow_test_helpers_test.go
@@ -63,17 +63,24 @@ func (c *stubWorkflowControl) ProviderNames() []string {
 }
 
 type memoryWorkflowProvider struct {
-	mu               sync.Mutex
-	runs             map[string]*coreworkflow.Run
-	listRunReqs      []coreworkflow.ListRunsRequest
-	listRunsNextPage string
-	cancelReqs       []*proto.CancelWorkflowProviderRunRequest
-	deliveredEvents  []*proto.DeliverWorkflowProviderEventRequest
+	mu                  sync.Mutex
+	definitions         map[string]*coreworkflow.Definition
+	runs                map[string]*coreworkflow.Run
+	definitionPauseReqs []*proto.SetWorkflowProviderDefinitionPausedRequest
+	activationPauseReqs []*proto.SetWorkflowProviderActivationPausedRequest
+	deletedDefinitions  []string
+	activationPauseErr  error
+	deleteDefinitionErr error
+	listRunReqs         []coreworkflow.ListRunsRequest
+	listRunsNextPage    string
+	cancelReqs          []*proto.CancelWorkflowProviderRunRequest
+	deliveredEvents     []*proto.DeliverWorkflowProviderEventRequest
 }
 
 func newMemoryWorkflowProvider() *memoryWorkflowProvider {
 	return &memoryWorkflowProvider{
-		runs: map[string]*coreworkflow.Run{},
+		definitions: map[string]*coreworkflow.Definition{},
+		runs:        map[string]*coreworkflow.Run{},
 	}
 }
 
@@ -81,24 +88,85 @@ func (p *memoryWorkflowProvider) ApplyDefinition(context.Context, *proto.ApplyWo
 	return nil, core.ErrNotFound
 }
 
-func (p *memoryWorkflowProvider) GetDefinition(context.Context, *proto.GetWorkflowProviderDefinitionRequest) (*proto.WorkflowDefinition, error) {
-	return nil, core.ErrNotFound
+func (p *memoryWorkflowProvider) GetDefinition(_ context.Context, req *proto.GetWorkflowProviderDefinitionRequest) (*proto.WorkflowDefinition, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	definition := p.definitions[strings.TrimSpace(req.GetDefinitionId())]
+	if definition == nil {
+		return nil, core.ErrNotFound
+	}
+	return workflowwire.DefinitionToProto(cloneWorkflowDefinition(definition))
 }
 
 func (p *memoryWorkflowProvider) ListDefinitions(context.Context, *proto.ListWorkflowProviderDefinitionsRequest) (*proto.ListWorkflowProviderDefinitionsResponse, error) {
-	return &proto.ListWorkflowProviderDefinitionsResponse{}, nil
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	resp := &proto.ListWorkflowProviderDefinitionsResponse{}
+	for _, definition := range p.definitions {
+		pb, err := workflowwire.DefinitionToProto(cloneWorkflowDefinition(definition))
+		if err != nil {
+			return nil, err
+		}
+		resp.Definitions = append(resp.Definitions, pb)
+	}
+	return resp, nil
 }
 
-func (p *memoryWorkflowProvider) SetDefinitionPaused(context.Context, *proto.SetWorkflowProviderDefinitionPausedRequest) (*proto.WorkflowDefinition, error) {
+func (p *memoryWorkflowProvider) SetDefinitionPaused(_ context.Context, req *proto.SetWorkflowProviderDefinitionPausedRequest) (*proto.WorkflowDefinition, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	definition := p.definitions[strings.TrimSpace(req.GetDefinitionId())]
+	if definition == nil {
+		return nil, core.ErrNotFound
+	}
+	p.definitionPauseReqs = append(p.definitionPauseReqs, &proto.SetWorkflowProviderDefinitionPausedRequest{
+		DefinitionId:         strings.TrimSpace(req.GetDefinitionId()),
+		Paused:               req.GetPaused(),
+		RequestedBySubjectId: strings.TrimSpace(req.GetRequestedBySubjectId()),
+	})
+	definition.Paused = req.GetPaused()
+	return workflowwire.DefinitionToProto(cloneWorkflowDefinition(definition))
+}
+
+func (p *memoryWorkflowProvider) SetActivationPaused(_ context.Context, req *proto.SetWorkflowProviderActivationPausedRequest) (*proto.WorkflowDefinition, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.activationPauseErr != nil {
+		return nil, p.activationPauseErr
+	}
+	definition := p.definitions[strings.TrimSpace(req.GetDefinitionId())]
+	if definition == nil {
+		return nil, core.ErrNotFound
+	}
+	activationID := strings.TrimSpace(req.GetActivationId())
+	for i := range definition.Activations {
+		if strings.TrimSpace(definition.Activations[i].ID) == activationID {
+			p.activationPauseReqs = append(p.activationPauseReqs, &proto.SetWorkflowProviderActivationPausedRequest{
+				DefinitionId:         strings.TrimSpace(req.GetDefinitionId()),
+				ActivationId:         activationID,
+				Paused:               req.GetPaused(),
+				RequestedBySubjectId: strings.TrimSpace(req.GetRequestedBySubjectId()),
+			})
+			definition.Activations[i].Paused = req.GetPaused()
+			return workflowwire.DefinitionToProto(cloneWorkflowDefinition(definition))
+		}
+	}
 	return nil, core.ErrNotFound
 }
 
-func (p *memoryWorkflowProvider) SetActivationPaused(context.Context, *proto.SetWorkflowProviderActivationPausedRequest) (*proto.WorkflowDefinition, error) {
-	return nil, core.ErrNotFound
-}
-
-func (p *memoryWorkflowProvider) DeleteDefinition(context.Context, *proto.DeleteWorkflowProviderDefinitionRequest) error {
-	return core.ErrNotFound
+func (p *memoryWorkflowProvider) DeleteDefinition(_ context.Context, req *proto.DeleteWorkflowProviderDefinitionRequest) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.deleteDefinitionErr != nil {
+		return p.deleteDefinitionErr
+	}
+	definitionID := strings.TrimSpace(req.GetDefinitionId())
+	if p.definitions[definitionID] == nil {
+		return core.ErrNotFound
+	}
+	delete(p.definitions, definitionID)
+	p.deletedDefinitions = append(p.deletedDefinitions, definitionID)
+	return nil
 }
 
 func (p *memoryWorkflowProvider) StartRun(context.Context, *proto.StartWorkflowProviderRunRequest) (*proto.WorkflowRun, error) {
@@ -193,6 +261,35 @@ func cloneWorkflowRun(src *coreworkflow.Run) *coreworkflow.Run {
 	dst := *src
 	dst.Target = cloneWorkflowTarget(src.Target)
 	dst.Input = cloneMap(src.Input)
+	return &dst
+}
+
+func cloneWorkflowDefinition(src *coreworkflow.Definition) *coreworkflow.Definition {
+	if src == nil {
+		return nil
+	}
+	dst := *src
+	dst.Target = cloneWorkflowTarget(src.Target)
+	if src.Activations != nil {
+		dst.Activations = make([]coreworkflow.Activation, len(src.Activations))
+		for i := range src.Activations {
+			activation := src.Activations[i]
+			activation.Input = coreworkflow.CloneValue(activation.Input)
+			if activation.Schedule != nil {
+				schedule := *activation.Schedule
+				activation.Schedule = &schedule
+			}
+			if activation.Event != nil {
+				event := *activation.Event
+				activation.Event = &event
+			}
+			dst.Activations[i] = activation
+		}
+	}
+	if src.RunAs != nil {
+		runAs := *src.RunAs
+		dst.RunAs = &runAs
+	}
 	return &dst
 }
 


### PR DESCRIPTION
## Summary

Closes #2090.
- Add authenticated workflow definition HTTP endpoints for list, get, definition pause, activation pause, and delete.
- Reuse the workflow manager/provider contract so ownership and stored-target authorization stay centralized.
- Example: `PATCH /api/v1/workflow/definitions/cfg_roadmap_sync/activations/nightly` with `{ "paused": true }`.

## Test plan
- [x] Run `go test ./gestaltd/internal/server -run 'WorkflowDefinition|WorkflowRun'`.\n- [x] Run `go test ./gestaltd/internal/server`.\n- [x] Verify provider `NotFound` maps to HTTP 404 and empty activations render as `[]`.\n