### PR TITLE
[authorization] expose authorization host access

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -164,6 +164,7 @@ type Deps struct {
 	CacheDefs                   map[string]*config.ProviderEntry
 	CacheFactory                CacheFactory
 	S3                          map[string]s3sdk.S3
+	Authorization               core.AuthorizationProvider
 	WorkflowRuntime             *workflowRuntime
 	AgentRuntime                *agentRuntime
 	AgentRunGrants              *agentgrant.Manager
@@ -980,6 +981,12 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	if err := bootstrapAuthorizationProviderState(ctx, cfg, authorizationProviders); err != nil {
 		_ = closeAuthProviders(authProviders)
 		return nil, err
+	}
+	if _, authorizationProvider, err := selectedAuthorizationProviderInstance(cfg, authorizationProviders); err != nil {
+		_ = closeAuthProviders(authProviders)
+		return nil, err
+	} else {
+		deps.Authorization = authorizationProvider
 	}
 	closeExternalCredentialsOnError := true
 	defer func() {

--- a/gestaltd/internal/bootstrap/host_service_bootstrap.go
+++ b/gestaltd/internal/bootstrap/host_service_bootstrap.go
@@ -18,6 +18,7 @@ import (
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	agentservice "github.com/valon-technologies/gestalt/server/services/agents"
 	appaccessservice "github.com/valon-technologies/gestalt/server/services/appaccess"
+	authorizationservice "github.com/valon-technologies/gestalt/server/services/authorization"
 	cacheservice "github.com/valon-technologies/gestalt/server/services/cache"
 	externalcredentialsservice "github.com/valon-technologies/gestalt/server/services/externalcredentials"
 	indexeddbservice "github.com/valon-technologies/gestalt/server/services/indexeddb"
@@ -50,6 +51,9 @@ func buildProviderHostServices(name string, deps Deps, extraHostServices ...runt
 	} else if ok {
 		hostServices = append(hostServices, s3HostService)
 	}
+	if authorizationHostService, ok := authorizationHostServiceFromDeps(deps); ok {
+		hostServices = append(hostServices, authorizationHostService)
+	}
 	hostServices = append(hostServices,
 		buildAppInvocationHostService(deps, invTokens),
 		buildWorkflowProviderHostService(name, deps, invTokens),
@@ -69,6 +73,19 @@ func appProviderHostServiceDeps(entry *config.ProviderEntry, deps Deps) Deps {
 	deps.Caches = scopedCacheBindings(entry.Cache, deps.Caches)
 	deps.S3 = scopedS3Bindings(entry.S3, deps.S3)
 	return deps
+}
+
+func authorizationHostServiceFromDeps(deps Deps) (runtimehost.HostService, bool) {
+	if deps.Authorization == nil {
+		return runtimehost.HostService{}, false
+	}
+	return runtimehost.HostService{
+		Name:           "authorization",
+		MethodPrefixes: []string{grpcMethodPrefix(proto.AuthorizationProvider_ServiceDesc.ServiceName)},
+		Register: func(srv *grpc.Server) {
+			proto.RegisterAuthorizationProviderServer(srv, authorizationservice.NewProviderServer(deps.Authorization))
+		},
+	}, true
 }
 
 func scopedCacheBindings(names []string, bindings map[string]corecache.Cache) map[string]corecache.Cache {

--- a/gestaltd/internal/bootstrap/workflow_startup_test.go
+++ b/gestaltd/internal/bootstrap/workflow_startup_test.go
@@ -87,6 +87,7 @@ func TestBuildProviderHostServicesDoesNotRequireConfiguredEncryptionKey(t *testi
 	t.Parallel()
 
 	hostServices, invTokens, err := buildProviderHostServices("metadata", Deps{
+		Authorization: &recordingAuthorizationProvider{},
 		Services: &coredata.Services{
 			ExternalCredentials: coretesting.NewStubExternalCredentialProvider(),
 		},
@@ -99,7 +100,7 @@ func TestBuildProviderHostServicesDoesNotRequireConfiguredEncryptionKey(t *testi
 	}
 
 	names := hostServiceNames(hostServices)
-	for _, want := range []string{"app", "workflow_provider", "agent_provider", "external_credentials"} {
+	for _, want := range []string{"app", "workflow_provider", "agent_provider", "external_credentials", "authorization"} {
 		if !hasHostServiceName(names, want) {
 			t.Fatalf("provider host services missing %q: %v", want, names)
 		}

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -3775,9 +3775,6 @@ func normalizeAdminConfig(cfg *Config) error {
 
 	roles, err := packageio.NormalizeUIAllowedRoles("server.admin.allowedRoles", admin.AllowedRoles)
 	if err != nil {
-		if admin.AuthorizationPolicy == "" {
-			return fmt.Errorf("normalize admin config: server.admin.allowedRoles requires server.admin.authorizationPolicy")
-		}
 		return fmt.Errorf("normalize admin config: %w", err)
 	}
 	admin.AllowedRoles = roles

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -1310,12 +1310,14 @@ server:
   providers:
     authentication: sample
     indexeddb: sqlite
+    authorization: indexeddb
   management:
     host: 127.0.0.1
     port: 9090
     baseUrl: https://gestalt.example.test:9090
   admin:
     authorizationPolicy: admin_policy
+    allowedRoles: [admin]
 providers:
   authentication:
     sample:
@@ -1325,6 +1327,10 @@ providers:
     sqlite:
       source:
         path: ./providers/datastore/sqlite
+  authorization:
+    indexeddb:
+      source:
+        path: ./providers/authorization/indexeddb
 `)
 
 		_, err := Load(path)
@@ -1346,12 +1352,14 @@ server:
   providers:
     authentication: sample
     indexeddb: sqlite
+    authorization: indexeddb
   management:
     host: 127.0.0.1
     port: 9090
     baseUrl: not a url
   admin:
     authorizationPolicy: admin_policy
+    allowedRoles: [admin]
 providers:
   authentication:
     sample:
@@ -1361,6 +1369,10 @@ providers:
     sqlite:
       source:
         path: ./providers/datastore/sqlite
+  authorization:
+    indexeddb:
+      source:
+        path: ./providers/authorization/indexeddb
 `)
 
 		_, err := Load(path)
@@ -1382,10 +1394,12 @@ server:
   providers:
     authentication: sample
     indexeddb: sqlite
+    authorization: indexeddb
   management:
     baseUrl: https://gestalt.example.test:9090
   admin:
     authorizationPolicy: admin_policy
+    allowedRoles: [admin]
 providers:
   authentication:
     sample:
@@ -1395,6 +1409,10 @@ providers:
     sqlite:
       source:
         path: ./providers/datastore/sqlite
+  authorization:
+    indexeddb:
+      source:
+        path: ./providers/authorization/indexeddb
 `)
 
 		_, err := Load(path)
@@ -1438,6 +1456,7 @@ providers:
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
+
 }
 
 func TestLoadSucceedsWithoutRuntimeFields(t *testing.T) {

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -1840,19 +1840,22 @@ func validateAdminConfig(cfg *Config) error {
 			return fmt.Errorf("config validation: server.admin.ui references unknown ui %q", adminUI)
 		}
 	}
-	if policy == "" {
-		if len(admin.AllowedRoles) > 0 {
-			return fmt.Errorf("config validation: server.admin.allowedRoles requires server.admin.authorizationPolicy")
-		}
-	} else {
+	if policy != "" || len(admin.AllowedRoles) > 0 {
 		_, authProvider, err := cfg.SelectedAuthenticationProvider()
 		if err != nil {
 			return err
 		}
 		if authProvider == nil {
-			return fmt.Errorf("config validation: server.admin.authorizationPolicy requires providers.authentication to be configured")
+			return fmt.Errorf("config validation: server.admin authorization requires providers.authentication to be configured")
 		}
-		if len(admin.AllowedRoles) == 0 {
+		_, authorizationProvider, err := cfg.SelectedAuthorizationProvider()
+		if err != nil {
+			return err
+		}
+		if authorizationProvider == nil {
+			return fmt.Errorf("config validation: server.admin authorization requires providers.authorization to be configured")
+		}
+		if policy != "" && len(admin.AllowedRoles) == 0 {
 			return fmt.Errorf("config validation: server.admin.allowedRoles must not be empty when server.admin.authorizationPolicy is set")
 		}
 	}

--- a/gestaltd/internal/server/integration_visibility.go
+++ b/gestaltd/internal/server/integration_visibility.go
@@ -69,16 +69,16 @@ func (s *Server) mountedUIForProvider(provider, mountedPath string) (MountedUI, 
 }
 
 func (s *Server) mountedUIRootAccessibleContext(ctx context.Context, p *principal.Principal, mounted MountedUI) bool {
-	if mounted.AuthorizationPolicy == "" {
+	if !mountedUIRequiresAuthorization(mounted) {
 		return true
 	}
 	if p == nil || principal.IsNonUserPrincipal(p) {
 		return false
 	}
 
-	access := invocation.AccessContext{}
 	route, matched := mounted.routeForRequestPath(mountedUIRootRequestPath(mounted))
-	return matched && len(route.AllowedRoles) > 0 && mountedUIRoleAllowed(access.Role, route.AllowedRoles)
+	_, allowed, err := s.authorizeMountedUIRoute(ctx, p, mounted, route, matched)
+	return err == nil && allowed
 }
 
 func mountedUIRootRequestPath(mounted MountedUI) string {

--- a/gestaltd/internal/server/mounted_ui.go
+++ b/gestaltd/internal/server/mounted_ui.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"github.com/valon-technologies/gestalt/server/services/apps/providerpkg"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
@@ -23,6 +24,7 @@ import (
 
 const browserLoginPath = "/api/v1/auth/login"
 const adminUIDirEnv = "GESTALTD_ADMIN_UI_DIR"
+const defaultAdminAuthorizationResource = "gestaltAdmin"
 
 type mountedUINavigationPathResolver interface {
 	NavigationPathForRequest(string) (string, bool)
@@ -30,8 +32,11 @@ type mountedUINavigationPathResolver interface {
 
 type protectedUILoginRedirect func(http.ResponseWriter, *http.Request) error
 
-func normalizeAdminRouteConfig(admin AdminRouteConfig) (AdminRouteConfig, error) {
+func normalizeAdminRouteConfig(admin AdminRouteConfig, defaultAuthorizationResource string) (AdminRouteConfig, error) {
 	admin.AuthorizationPolicy = strings.TrimSpace(admin.AuthorizationPolicy)
+	if admin.AuthorizationPolicy == "" {
+		admin.AuthorizationPolicy = strings.TrimSpace(defaultAuthorizationResource)
+	}
 	if admin.AuthorizationPolicy == "" {
 		if len(admin.AllowedRoles) > 0 {
 			return AdminRouteConfig{}, fmt.Errorf("admin allowedRoles requires AuthorizationPolicy")
@@ -296,11 +301,11 @@ func normalizeMountedUIRoutes(routes []MountedUIRoute) ([]MountedUIRoute, error)
 }
 
 func validatePolicyBoundMountedUIRoutes(mounted MountedUI) error {
-	if mounted.AuthorizationPolicy == "" {
+	if !mountedUIRequiresAuthorization(mounted) {
 		return nil
 	}
 	if len(mounted.Routes) == 0 {
-		return fmt.Errorf("policy-bound UIs must declare at least one route")
+		return fmt.Errorf("authorization-bound UIs must declare at least one route")
 	}
 	coversRoot := false
 	for i := range mounted.Routes {
@@ -312,7 +317,7 @@ func validatePolicyBoundMountedUIRoutes(mounted MountedUI) error {
 		}
 	}
 	if !coversRoot {
-		return fmt.Errorf("policy-bound UIs must declare a route covering /")
+		return fmt.Errorf("authorization-bound UIs must declare a route covering /")
 	}
 	return nil
 }
@@ -352,7 +357,7 @@ func (s *Server) adminMountedUI() MountedUI {
 }
 
 func (s *Server) protectedUIHandler(mounted MountedUI, inner http.Handler, redirectLogin protectedUILoginRedirect) http.Handler {
-	if mounted.AuthorizationPolicy == "" {
+	if !mountedUIRequiresAuthorization(mounted) {
 		return inner
 	}
 
@@ -394,9 +399,13 @@ func (s *Server) authorizeProtectedUIRequest(w http.ResponseWriter, r *http.Requ
 		return nil, false
 	}
 
-	access := invocation.AccessContext{}
 	route, matched := mounted.routeForRequestPath(r.URL.Path)
-	if !matched || len(route.AllowedRoles) == 0 || !mountedUIRoleAllowed(access.Role, route.AllowedRoles) {
+	access, allowed, err := s.authorizeMountedUIRoute(r.Context(), p, mounted, route, matched)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to authorize app access")
+		return nil, false
+	}
+	if !allowed {
 		writeError(w, http.StatusForbidden, "app access denied")
 		return nil, false
 	}
@@ -409,6 +418,114 @@ func (s *Server) authorizeProtectedUIRequest(w http.ResponseWriter, r *http.Requ
 		ctx = invocation.WithAccessContext(ctx, access)
 	}
 	return ctx, true
+}
+
+func (s *Server) authorizeMountedUIRoute(ctx context.Context, p *principal.Principal, mounted MountedUI, route MountedUIRoute, matched bool) (invocation.AccessContext, bool, error) {
+	if !matched || len(route.AllowedRoles) == 0 {
+		return invocation.AccessContext{}, false, nil
+	}
+	if !mountedUIRequiresAuthorization(mounted) {
+		return invocation.AccessContext{}, true, nil
+	}
+	if s.authorization == nil {
+		return invocation.AccessContext{}, false, nil
+	}
+	resourceName := mountedUIAuthorizationResourceName(mounted)
+	if resourceName == "" {
+		return invocation.AccessContext{}, false, nil
+	}
+	subjectID := principal.EffectiveCredentialSubjectID(principal.Canonicalized(p))
+	if strings.TrimSpace(subjectID) == "" {
+		return invocation.AccessContext{}, false, nil
+	}
+
+	roles, err := s.mountedUIAuthorizationRoles(ctx, subjectID, resourceName)
+	if err != nil {
+		return invocation.AccessContext{}, false, err
+	}
+	for _, allowedRole := range route.AllowedRoles {
+		if _, ok := roles[strings.TrimSpace(allowedRole)]; ok {
+			return invocation.AccessContext{Policy: resourceName, Role: strings.TrimSpace(allowedRole)}, true, nil
+		}
+	}
+
+	defaultAllow, err := s.mountedUIResourceDefaultAllows(ctx, resourceName)
+	if err != nil {
+		return invocation.AccessContext{}, false, err
+	}
+	if defaultAllow && mountedUIRoleAllowed("viewer", route.AllowedRoles) {
+		return invocation.AccessContext{Policy: resourceName, Role: "viewer"}, true, nil
+	}
+	return invocation.AccessContext{}, false, nil
+}
+
+func mountedUIAuthorizationResourceName(mounted MountedUI) string {
+	if name := strings.TrimSpace(mounted.AuthorizationPolicy); name != "" {
+		return name
+	}
+	return strings.TrimSpace(mounted.AppName)
+}
+
+func mountedUIRequiresAuthorization(mounted MountedUI) bool {
+	if strings.TrimSpace(mounted.AuthorizationPolicy) != "" {
+		return true
+	}
+	if mounted.builtInAdmin {
+		return false
+	}
+	return strings.TrimSpace(mounted.AppName) != "" && len(mounted.Routes) > 0
+}
+
+func (s *Server) mountedUIAuthorizationRoles(ctx context.Context, subjectID, resourceName string) (map[string]struct{}, error) {
+	roles := map[string]struct{}{}
+	pageToken := ""
+	for {
+		resp, err := s.authorization.ListRelationships(ctx, &proto.ListRelationshipsRequest{
+			Filter: &proto.RelationshipFilter{
+				Target: &proto.RelationshipTarget{
+					Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{
+						Type: "subject",
+						Id:   strings.TrimSpace(subjectID),
+					}},
+				},
+				Resource: &proto.Resource{
+					Type: strings.TrimSpace(resourceName),
+					Id:   strings.TrimSpace(resourceName),
+				},
+			},
+			PageSize:  500,
+			PageToken: pageToken,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, relationship := range resp.GetRelationships() {
+			relation := strings.TrimSpace(relationship.GetTuple().GetRelation())
+			if relation != "" {
+				roles[relation] = struct{}{}
+			}
+		}
+		pageToken = strings.TrimSpace(resp.GetNextPageToken())
+		if pageToken == "" {
+			return roles, nil
+		}
+	}
+}
+
+func (s *Server) mountedUIResourceDefaultAllows(ctx context.Context, resourceName string) (bool, error) {
+	resp, err := s.authorization.ListActiveModelResourceTypes(ctx, &proto.ListActiveModelResourceTypesRequest{
+		Filter:   &proto.AuthorizationModelResourceTypeFilter{Name: strings.TrimSpace(resourceName)},
+		PageSize: 1,
+	})
+	if err != nil {
+		return false, err
+	}
+	for _, resourceType := range resp.GetResourceTypes() {
+		if strings.TrimSpace(resourceType.GetName()) == strings.TrimSpace(resourceName) {
+			return resourceType.GetDefaultAccessPolicy() == proto.DefaultAccessPolicy_DEFAULT_ACCESS_POLICY_ALLOW, nil
+		}
+	}
+	return false, nil
 }
 
 func (s *Server) resolveMountedUIPrincipal(r *http.Request, mounted MountedUI) (*principal.Principal, bool, error) {

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -68,10 +68,19 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 	managementAddr := cfg.Server.ManagementAddr()
 	mcpSlot := &switchableHandler{}
 	workflowProvidersReady := make(chan struct{})
+	authorizationName, authorizationEntry, err := cfg.SelectedAuthorizationProvider()
+	if err != nil {
+		return err
+	}
+	var authorizationProvider core.AuthorizationProvider
+	if authorizationEntry != nil {
+		authorizationProvider = result.Authorization[authorizationName]
+	}
 	baseConfig := Config{
 		Auth:                 result.Auth,
 		SelectedAuthProvider: result.SelectedAuthProvider,
 		AuthProviders:        result.AuthProviders,
+		Authorization:        authorizationProvider,
 		AuditSink:            result.AuditSink,
 		Services:             result.Services,
 		Providers:            result.Providers,

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -84,6 +84,7 @@ type Server struct {
 	auth                   core.AuthenticationProvider
 	authProviders          map[string]core.AuthenticationProvider
 	serverAuthProvider     string
+	authorization          core.AuthorizationProvider
 	auditSink              core.AuditSink
 	users                  *coredata.UserService
 	externalCredentials    core.ExternalCredentialProvider
@@ -147,6 +148,7 @@ type Config struct {
 	Auth                 core.AuthenticationProvider
 	SelectedAuthProvider string
 	AuthProviders        map[string]core.AuthenticationProvider
+	Authorization        core.AuthorizationProvider
 	AuditSink            core.AuditSink
 	Services             *coredata.Services
 	Providers            *registry.ProviderMap[core.Provider]
@@ -231,7 +233,11 @@ func New(cfg Config) (*Server, error) {
 	if agentStreamHeartbeat <= 0 {
 		agentStreamHeartbeat = defaultAgentTurnEventStreamHeartbeatInterval
 	}
-	adminRoute, err := normalizeAdminRouteConfig(cfg.Admin)
+	defaultAdminResource := ""
+	if !noAuth && cfg.Authorization != nil {
+		defaultAdminResource = defaultAdminAuthorizationResource
+	}
+	adminRoute, err := normalizeAdminRouteConfig(cfg.Admin, defaultAdminResource)
 	if err != nil {
 		return nil, fmt.Errorf("normalize admin route: %w", err)
 	}
@@ -333,6 +339,7 @@ func New(cfg Config) (*Server, error) {
 		auth:                   cfg.Auth,
 		authProviders:          authProviders,
 		serverAuthProvider:     serverAuthProvider,
+		authorization:          cfg.Authorization,
 		auditSink:              cfg.AuditSink,
 		users:                  users,
 		externalCredentials:    externalCredentials,

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -2167,6 +2167,10 @@ func TestMountedUIRoutes(t *testing.T) {
 		cfg.MountedUIs = []server.MountedUI{{
 			Path:    "/sample-portal",
 			Handler: handler,
+			Routes: []server.MountedUIRoute{{
+				Path:         "/*",
+				AllowedRoles: []string{"viewer"},
+			}},
 		}}
 	})
 	testutil.CloseOnCleanup(t, ts)
@@ -2296,6 +2300,234 @@ func TestMountedUIRoutes_PrefersNestedMount(t *testing.T) {
 	}
 	if !strings.Contains(string(body), "parent-shell") {
 		t.Fatalf("body = %q, want parent shell", body)
+	}
+}
+
+func TestPolicyBoundMountedUIUsesAuthorizationRelationships(t *testing.T) {
+	t.Parallel()
+
+	svc := testutil.NewStubServices(t)
+	user := seedUserRecord(t, svc, "ui-user", "ui-user@example.test", time.Now())
+	authz := &serverTestAuthorizationProvider{
+		resourceTypes: []*proto.AuthorizationModelResourceType{
+			{
+				Name:                "dealHub",
+				DefaultAccessPolicy: proto.DefaultAccessPolicy_DEFAULT_ACCESS_POLICY_DENY,
+			},
+			{
+				Name:                "brainPolicy",
+				DefaultAccessPolicy: proto.DefaultAccessPolicy_DEFAULT_ACCESS_POLICY_ALLOW,
+			},
+			{
+				Name:                "gestaltAdmin",
+				DefaultAccessPolicy: proto.DefaultAccessPolicy_DEFAULT_ACCESS_POLICY_DENY,
+			},
+		},
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(
+				principal.UserSubjectID(user.ID),
+				"admin",
+				"dealHub",
+				"dealHub",
+			),
+			testAuthorizationRelationship(
+				principal.UserSubjectID(user.ID),
+				"admin",
+				"gestaltAdmin",
+				"gestaltAdmin",
+			),
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "session-token" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: "ui-user@example.test"}, nil
+			},
+		}
+		cfg.Services = svc
+		cfg.Authorization = authz
+		cfg.MountedUIs = []server.MountedUI{
+			{
+				Name:    "deal-hub-ui",
+				Path:    "/deal-hub",
+				AppName: "dealHub",
+				Routes: []server.MountedUIRoute{{
+					Path:         "/*",
+					AllowedRoles: []string{"admin"},
+				}},
+				Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					_, _ = w.Write([]byte("deal-hub-shell"))
+				}),
+			},
+			{
+				Name:                "brain-ui",
+				Path:                "/brain",
+				AppName:             "brain",
+				AuthorizationPolicy: "brainPolicy",
+				Routes: []server.MountedUIRoute{
+					{Path: "/admin/*", AllowedRoles: []string{"admin"}},
+					{Path: "/*", AllowedRoles: []string{"viewer"}},
+				},
+				Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					_, _ = w.Write([]byte("brain-shell"))
+				}),
+			},
+		}
+		cfg.AdminUI = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("admin-shell"))
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/deal-hub/", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "session-token"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET protected mounted UI: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("protected mounted UI status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	if !bytes.Contains(body, []byte("deal-hub-shell")) {
+		t.Fatalf("protected mounted UI body = %q, want shell", body)
+	}
+	if len(authz.listRelationshipRequests) == 0 {
+		t.Fatal("authorization ListRelationships was not called")
+	}
+	if got := authz.listRelationshipRequests[0].GetFilter().GetResource().GetType(); got != "dealHub" {
+		t.Fatalf("relationship resource type = %q, want app resource type dealHub", got)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/brain/", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "session-token"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET viewer mounted UI: %v", err)
+	}
+	body, _ = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("viewer mounted UI status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	if !bytes.Contains(body, []byte("brain-shell")) {
+		t.Fatalf("viewer mounted UI body = %q, want shell", body)
+	}
+	if got := authz.listRelationshipRequests[len(authz.listRelationshipRequests)-1].GetFilter().GetResource().GetType(); got != "brainPolicy" {
+		t.Fatalf("relationship resource type = %q, want explicit AuthorizationPolicy brainPolicy", got)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/brain/admin/settings", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "session-token"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET admin mounted UI: %v", err)
+	}
+	body, _ = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("admin mounted UI status = %d, want 403: %s", resp.StatusCode, body)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "session-token"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET admin UI: %v", err)
+	}
+	body, _ = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("admin UI status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	if !bytes.Contains(body, []byte("admin-shell")) {
+		t.Fatalf("admin UI body = %q, want shell", body)
+	}
+	if len(authz.listRelationshipRequests) < 2 {
+		t.Fatalf("authorization ListRelationships calls = %d, want at least 2", len(authz.listRelationshipRequests))
+	}
+	if got := authz.listRelationshipRequests[len(authz.listRelationshipRequests)-1].GetFilter().GetResource().GetType(); got != "gestaltAdmin" {
+		t.Fatalf("relationship resource type = %q, want gestaltAdmin", got)
+	}
+}
+
+type serverTestAuthorizationProvider struct {
+	core.AuthorizationProvider
+
+	resourceTypes            []*proto.AuthorizationModelResourceType
+	relationships            []*proto.Relationship
+	listRelationshipRequests []*proto.ListRelationshipsRequest
+}
+
+func (p *serverTestAuthorizationProvider) ListRelationships(_ context.Context, req *proto.ListRelationshipsRequest) (*proto.ListRelationshipsResponse, error) {
+	p.listRelationshipRequests = append(p.listRelationshipRequests, req)
+	filter := req.GetFilter()
+	out := []*proto.Relationship{}
+	for _, relationship := range p.relationships {
+		if !relationshipMatchesFilter(relationship, filter) {
+			continue
+		}
+		out = append(out, relationship)
+	}
+	return &proto.ListRelationshipsResponse{Relationships: out}, nil
+}
+
+func (p *serverTestAuthorizationProvider) ListActiveModelResourceTypes(_ context.Context, req *proto.ListActiveModelResourceTypesRequest) (*proto.ListActiveModelResourceTypesResponse, error) {
+	name := strings.TrimSpace(req.GetFilter().GetName())
+	out := []*proto.AuthorizationModelResourceType{}
+	for _, resourceType := range p.resourceTypes {
+		if name != "" && strings.TrimSpace(resourceType.GetName()) != name {
+			continue
+		}
+		out = append(out, resourceType)
+	}
+	return &proto.ListActiveModelResourceTypesResponse{ResourceTypes: out}, nil
+}
+
+func relationshipMatchesFilter(relationship *proto.Relationship, filter *proto.RelationshipFilter) bool {
+	if relationship == nil || filter == nil {
+		return false
+	}
+	tuple := relationship.GetTuple()
+	if resource := filter.GetResource(); resource != nil {
+		if tuple.GetResource().GetType() != resource.GetType() || tuple.GetResource().GetId() != resource.GetId() {
+			return false
+		}
+	}
+	if relation := strings.TrimSpace(filter.GetRelation()); relation != "" && tuple.GetRelation() != relation {
+		return false
+	}
+	if target := filter.GetTarget().GetSubject(); target != nil {
+		subject := tuple.GetTarget().GetSubject()
+		if subject.GetType() != target.GetType() || subject.GetId() != target.GetId() {
+			return false
+		}
+	}
+	return true
+}
+
+func testAuthorizationRelationship(subjectID, relation, resourceType, resourceID string) *proto.Relationship {
+	return &proto.Relationship{
+		Tuple: &proto.RelationshipTuple{
+			Target: &proto.RelationshipTarget{
+				Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{
+					Type: "subject",
+					Id:   subjectID,
+				}},
+			},
+			Relation: relation,
+			Resource: &proto.Resource{
+				Type: resourceType,
+				Id:   resourceID,
+			},
+		},
+		SourceLayer: proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG,
 	}
 }
 

--- a/gestaltd/services/authorization/server.go
+++ b/gestaltd/services/authorization/server.go
@@ -1,0 +1,90 @@
+package authorization
+
+import (
+	"context"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+type providerServer struct {
+	proto.UnimplementedAuthorizationProviderServer
+	provider core.AuthorizationProvider
+}
+
+func NewProviderServer(provider core.AuthorizationProvider) proto.AuthorizationProviderServer {
+	return &providerServer{provider: provider}
+}
+
+func (s *providerServer) CheckAccess(ctx context.Context, req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
+	if err := s.requireProvider(); err != nil {
+		return nil, err
+	}
+	return s.provider.CheckAccess(ctx, req)
+}
+
+func (s *providerServer) CheckAccessMany(ctx context.Context, req *proto.CheckAccessManyRequest) (*proto.CheckAccessManyResponse, error) {
+	if err := s.requireProvider(); err != nil {
+		return nil, err
+	}
+	return s.provider.CheckAccessMany(ctx, req)
+}
+
+func (s *providerServer) ListRelationships(ctx context.Context, req *proto.ListRelationshipsRequest) (*proto.ListRelationshipsResponse, error) {
+	if err := s.requireProvider(); err != nil {
+		return nil, err
+	}
+	return s.provider.ListRelationships(ctx, req)
+}
+
+func (s *providerServer) AddRelationship(ctx context.Context, req *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {
+	if err := s.requireProvider(); err != nil {
+		return nil, err
+	}
+	return s.provider.AddRelationship(ctx, req)
+}
+
+func (s *providerServer) DeleteRelationship(ctx context.Context, req *proto.DeleteRelationshipRequest) (*proto.DeleteRelationshipResponse, error) {
+	if err := s.requireProvider(); err != nil {
+		return nil, err
+	}
+	return s.provider.DeleteRelationship(ctx, req)
+}
+
+func (s *providerServer) SetAuthorizationState(ctx context.Context, req *proto.SetAuthorizationStateRequest) (*proto.SetAuthorizationStateResponse, error) {
+	if err := s.requireProvider(); err != nil {
+		return nil, err
+	}
+	return s.provider.SetAuthorizationState(ctx, req)
+}
+
+func (s *providerServer) GetActiveModelRef(ctx context.Context, _ *emptypb.Empty) (*proto.GetActiveModelRefResponse, error) {
+	if err := s.requireProvider(); err != nil {
+		return nil, err
+	}
+	return s.provider.GetActiveModelRef(ctx)
+}
+
+func (s *providerServer) SetActiveModel(ctx context.Context, req *proto.SetActiveModelRequest) (*proto.SetActiveModelResponse, error) {
+	if err := s.requireProvider(); err != nil {
+		return nil, err
+	}
+	return s.provider.SetActiveModel(ctx, req)
+}
+
+func (s *providerServer) ListActiveModelResourceTypes(ctx context.Context, req *proto.ListActiveModelResourceTypesRequest) (*proto.ListActiveModelResourceTypesResponse, error) {
+	if err := s.requireProvider(); err != nil {
+		return nil, err
+	}
+	return s.provider.ListActiveModelResourceTypes(ctx, req)
+}
+
+func (s *providerServer) requireProvider() error {
+	if s == nil || s.provider == nil {
+		return status.Error(codes.FailedPrecondition, "authorization provider is not configured")
+	}
+	return nil
+}

--- a/sdk/typescript/src/api.ts
+++ b/sdk/typescript/src/api.ts
@@ -7,6 +7,9 @@ export interface Subject {
   id: string;
   credentialSubjectId: string;
   email: string;
+  kind?: string | undefined;
+  displayName?: string | undefined;
+  authSource?: string | undefined;
 }
 
 /**
@@ -169,11 +172,17 @@ export function request(
       id: subject.id ?? "",
       credentialSubjectId: subject.credentialSubjectId ?? "",
       email: subject.email ?? "",
+      kind: subject.kind,
+      displayName: subject.displayName,
+      authSource: subject.authSource,
     },
     agentSubject: {
       id: agentSubject.id ?? "",
       credentialSubjectId: agentSubject.credentialSubjectId ?? "",
       email: agentSubject.email ?? "",
+      kind: agentSubject.kind,
+      displayName: agentSubject.displayName,
+      authSource: agentSubject.authSource,
     },
     credential: {
       mode: credential.mode ?? "",

--- a/sdk/typescript/src/authorization.ts
+++ b/sdk/typescript/src/authorization.ts
@@ -6,16 +6,25 @@ import {
   type Client,
   type ServiceImpl,
 } from "@connectrpc/connect";
+import { EmptySchema } from "@bufbuild/protobuf/wkt";
 
 import {
+  ActionSchema,
+  AddRelationshipRequestSchema,
   AddRelationshipResponseSchema,
+  AuthorizationModelSchema,
+  AuthorizationModelResourceTypeFilterSchema,
   AuthorizationModelRefSchema,
   AuthorizationModelResourceTypeSchema,
+  CheckAccessManyRequestSchema,
   CheckAccessManyResponseSchema,
+  CheckAccessRequestSchema,
   CheckAccessResponseSchema,
   DefaultAccessPolicy as ProtoDefaultAccessPolicy,
+  DeleteRelationshipRequestSchema,
   DeleteRelationshipResponseSchema,
   GetActiveModelRefResponseSchema,
+  ListActiveModelResourceTypesRequestSchema,
   ListRelationshipsRequestSchema,
   ListActiveModelResourceTypesResponseSchema,
   ListRelationshipsResponseSchema,
@@ -27,7 +36,9 @@ import {
   RelationshipTargetType as ProtoRelationshipTargetType,
   RelationshipTupleSchema,
   ResourceSchema,
+  SetActiveModelRequestSchema,
   SetActiveModelResponseSchema,
+  SetAuthorizationStateRequestSchema,
   SetAuthorizationStateResponseSchema,
   SourceLayer as ProtoSourceLayer,
   SubjectSchema,
@@ -35,12 +46,18 @@ import {
   SubjectSetTypeSchema,
   AuthorizationProvider as AuthorizationProviderService,
   type AddRelationshipRequest as ProtoAddRelationshipRequest,
+  type AddRelationshipResponse as ProtoAddRelationshipResponse,
   type AuthorizationModel as ProtoAuthorizationModel,
   type AuthorizationModelResourceType as ProtoAuthorizationModelResourceType,
   type CheckAccessManyRequest as ProtoCheckAccessManyRequest,
+  type CheckAccessManyResponse as ProtoCheckAccessManyResponse,
   type CheckAccessRequest as ProtoCheckAccessRequest,
+  type CheckAccessResponse as ProtoCheckAccessResponse,
   type DeleteRelationshipRequest as ProtoDeleteRelationshipRequest,
+  type DeleteRelationshipResponse as ProtoDeleteRelationshipResponse,
+  type GetActiveModelRefResponse as ProtoGetActiveModelRefResponse,
   type ListActiveModelResourceTypesRequest as ProtoListActiveModelResourceTypesRequest,
+  type ListActiveModelResourceTypesResponse as ProtoListActiveModelResourceTypesResponse,
   type ListRelationshipsRequest as ProtoListRelationshipsRequest,
   type ListRelationshipsResponse as ProtoListRelationshipsResponse,
   type ModelAllowedTarget as ProtoModelAllowedTarget,
@@ -48,13 +65,16 @@ import {
   type RelationshipFilter as ProtoRelationshipFilter,
   type RelationshipTarget as ProtoRelationshipTarget,
   type RelationshipTuple as ProtoRelationshipTuple,
+  type SetActiveModelResponse as ProtoSetActiveModelResponse,
   type SetActiveModelRequest as ProtoSetActiveModelRequest,
+  type SetAuthorizationStateResponse as ProtoSetAuthorizationStateResponse,
   type SetAuthorizationStateRequest as ProtoSetAuthorizationStateRequest,
   type SubjectSet as ProtoSubjectSet,
 } from "./internal/gen/v1/authorization_pb.ts";
 import { errorMessage, type MaybePromise } from "./api.ts";
 import { ProviderBase, type ProviderBaseOptions } from "./provider.ts";
 import {
+  dateFromTimestamp,
   jsonObjectFromStruct,
   structFromObject,
   timestampFromDate,
@@ -264,9 +284,29 @@ export interface ListActiveModelResourceTypesResponse {
 }
 
 export interface Authorization {
+  checkAccess(request: CheckAccessRequest): Promise<CheckAccessResponse>;
+  checkAccessMany(
+    request: CheckAccessManyRequest,
+  ): Promise<CheckAccessManyResponse>;
   listRelationships(
     request: ListRelationshipsRequest,
   ): Promise<ListRelationshipsResponse>;
+  addRelationship(
+    request: AddRelationshipRequest,
+  ): Promise<AddRelationshipResponse>;
+  deleteRelationship(
+    request: DeleteRelationshipRequest,
+  ): Promise<DeleteRelationshipResponse>;
+  setAuthorizationState(
+    request: SetAuthorizationStateRequest,
+  ): Promise<SetAuthorizationStateResponse>;
+  getActiveModelRef(): Promise<GetActiveModelRefResponse>;
+  setActiveModel(
+    request: SetActiveModelRequest,
+  ): Promise<SetActiveModelResponse>;
+  listActiveModelResourceTypes(
+    request: ListActiveModelResourceTypesRequest,
+  ): Promise<ListActiveModelResourceTypesResponse>;
 }
 
 class AuthorizationImpl implements Authorization {
@@ -283,11 +323,75 @@ class AuthorizationImpl implements Authorization {
     this.client = createClient(AuthorizationProviderService, transport);
   }
 
+  async checkAccess(request: CheckAccessRequest): Promise<CheckAccessResponse> {
+    return checkAccessResponseFromProto(
+      await this.client.checkAccess(checkAccessRequestToProto(request)),
+    );
+  }
+
+  async checkAccessMany(
+    request: CheckAccessManyRequest,
+  ): Promise<CheckAccessManyResponse> {
+    return checkAccessManyResponseFromProto(
+      await this.client.checkAccessMany(checkAccessManyRequestToProto(request)),
+    );
+  }
+
   async listRelationships(
     request: ListRelationshipsRequest,
   ): Promise<ListRelationshipsResponse> {
     return listRelationshipsResponseFromProto(
       await this.client.listRelationships(listRelationshipsRequestToProto(request)),
+    );
+  }
+
+  async addRelationship(
+    request: AddRelationshipRequest,
+  ): Promise<AddRelationshipResponse> {
+    return addRelationshipResponseFromProto(
+      await this.client.addRelationship(addRelationshipRequestToProto(request)),
+    );
+  }
+
+  async deleteRelationship(
+    request: DeleteRelationshipRequest,
+  ): Promise<DeleteRelationshipResponse> {
+    return deleteRelationshipResponseFromProto(
+      await this.client.deleteRelationship(deleteRelationshipRequestToProto(request)),
+    );
+  }
+
+  async setAuthorizationState(
+    request: SetAuthorizationStateRequest,
+  ): Promise<SetAuthorizationStateResponse> {
+    return setAuthorizationStateResponseFromProto(
+      await this.client.setAuthorizationState(
+        setAuthorizationStateRequestToProto(request),
+      ),
+    );
+  }
+
+  async getActiveModelRef(): Promise<GetActiveModelRefResponse> {
+    return getActiveModelRefResponseFromProto(
+      await this.client.getActiveModelRef(create(EmptySchema)),
+    );
+  }
+
+  async setActiveModel(
+    request: SetActiveModelRequest,
+  ): Promise<SetActiveModelResponse> {
+    return setActiveModelResponseFromProto(
+      await this.client.setActiveModel(setActiveModelRequestToProto(request)),
+    );
+  }
+
+  async listActiveModelResourceTypes(
+    request: ListActiveModelResourceTypesRequest,
+  ): Promise<ListActiveModelResourceTypesResponse> {
+    return listActiveModelResourceTypesResponseFromProto(
+      await this.client.listActiveModelResourceTypes(
+        listActiveModelResourceTypesRequestToProto(request),
+      ),
     );
   }
 }
@@ -529,6 +633,30 @@ function checkAccessRequestFromProto(
   };
 }
 
+function checkAccessRequestToProto(value: CheckAccessRequest) {
+  return create(CheckAccessRequestSchema, {
+    subject: subjectToProto(value.subject),
+    action: value.action
+      ? create(ActionSchema, {
+          name: value.action.name ?? "",
+          properties: value.action.properties === undefined
+            ? undefined
+            : structFromObject(value.action.properties),
+        })
+      : undefined,
+    resource: resourceToProto(value.resource),
+  });
+}
+
+function checkAccessResponseFromProto(
+  value: ProtoCheckAccessResponse,
+): CheckAccessResponse {
+  return {
+    allowed: value.allowed,
+    modelId: value.modelId,
+  };
+}
+
 function checkAccessResponseToProto(value: CheckAccessResponse | undefined) {
   if (!value) {
     throw new ConnectError(
@@ -547,6 +675,20 @@ function checkAccessManyRequestFromProto(
 ): CheckAccessManyRequest {
   return {
     requests: value.requests.map(checkAccessRequestFromProto),
+  };
+}
+
+function checkAccessManyRequestToProto(value: CheckAccessManyRequest) {
+  return create(CheckAccessManyRequestSchema, {
+    requests: (value.requests ?? []).map(checkAccessRequestToProto),
+  });
+}
+
+function checkAccessManyResponseFromProto(
+  value: ProtoCheckAccessManyResponse,
+): CheckAccessManyResponse {
+  return {
+    decisions: value.decisions.map(checkAccessResponseFromProto),
   };
 }
 
@@ -616,6 +758,20 @@ function addRelationshipRequestFromProto(
   };
 }
 
+function addRelationshipRequestToProto(value: AddRelationshipRequest) {
+  return create(AddRelationshipRequestSchema, {
+    relationship: relationshipToProto(value.relationship),
+  });
+}
+
+function addRelationshipResponseFromProto(
+  value: ProtoAddRelationshipResponse,
+): AddRelationshipResponse {
+  return {
+    relationship: relationshipFromProto(value.relationship),
+  };
+}
+
 function addRelationshipResponseToProto(
   value: AddRelationshipResponse | undefined,
 ) {
@@ -640,12 +796,41 @@ function deleteRelationshipRequestFromProto(
   };
 }
 
+function deleteRelationshipRequestToProto(value: DeleteRelationshipRequest) {
+  return create(DeleteRelationshipRequestSchema, {
+    relationshipTuple: relationshipTupleToProto(value.relationshipTuple),
+  });
+}
+
+function deleteRelationshipResponseFromProto(
+  _value: ProtoDeleteRelationshipResponse,
+): DeleteRelationshipResponse {
+  return {};
+}
+
 function setAuthorizationStateRequestFromProto(
   value: ProtoSetAuthorizationStateRequest,
 ): SetAuthorizationStateRequest {
   return {
     model: authorizationModelFromProto(value.model),
     relationships: value.relationships.map(relationshipFromProtoRequired),
+  };
+}
+
+function setAuthorizationStateRequestToProto(
+  value: SetAuthorizationStateRequest,
+) {
+  return create(SetAuthorizationStateRequestSchema, {
+    model: authorizationModelToProto(value.model),
+    relationships: (value.relationships ?? []).map(relationshipToProtoRequired),
+  });
+}
+
+function setAuthorizationStateResponseFromProto(
+  value: ProtoSetAuthorizationStateResponse,
+): SetAuthorizationStateResponse {
+  return {
+    activeModel: authorizationModelRefFromProto(value.activeModel),
   };
 }
 
@@ -663,6 +848,14 @@ function setAuthorizationStateResponseToProto(
       ? authorizationModelRefToProto(value.activeModel)
       : undefined,
   });
+}
+
+function getActiveModelRefResponseFromProto(
+  value: ProtoGetActiveModelRefResponse,
+): GetActiveModelRefResponse {
+  return {
+    model: authorizationModelRefFromProto(value.model),
+  };
 }
 
 function getActiveModelRefResponseToProto(
@@ -684,6 +877,20 @@ function setActiveModelRequestFromProto(
 ): SetActiveModelRequest {
   return {
     model: authorizationModelFromProto(value.model),
+  };
+}
+
+function setActiveModelRequestToProto(value: SetActiveModelRequest) {
+  return create(SetActiveModelRequestSchema, {
+    model: authorizationModelToProto(value.model),
+  });
+}
+
+function setActiveModelResponseFromProto(
+  value: ProtoSetActiveModelResponse,
+): SetActiveModelResponse {
+  return {
+    model: authorizationModelRefFromProto(value.model),
   };
 }
 
@@ -711,6 +918,31 @@ function listActiveModelResourceTypesRequestFromProto(
       : undefined,
     pageSize: value.pageSize,
     pageToken: value.pageToken,
+  };
+}
+
+function listActiveModelResourceTypesRequestToProto(
+  value: ListActiveModelResourceTypesRequest,
+) {
+  return create(ListActiveModelResourceTypesRequestSchema, {
+    filter: value.filter
+      ? create(AuthorizationModelResourceTypeFilterSchema, {
+          name: value.filter.name ?? "",
+          sourceLayer: value.filter.sourceLayer ?? SourceLayer.UNSPECIFIED,
+        })
+      : undefined,
+    pageSize: value.pageSize ?? 0,
+    pageToken: value.pageToken ?? "",
+  });
+}
+
+function listActiveModelResourceTypesResponseFromProto(
+  value: ProtoListActiveModelResourceTypesResponse,
+): ListActiveModelResourceTypesResponse {
+  return {
+    resourceTypes: value.resourceTypes.map(authorizationModelResourceTypeFromProto),
+    nextPageToken: value.nextPageToken,
+    modelId: value.modelId,
   };
 }
 
@@ -940,6 +1172,19 @@ function authorizationModelFromProto(
   };
 }
 
+function authorizationModelToProto(value: AuthorizationModel | undefined) {
+  if (!value) {
+    return undefined;
+  }
+  return create(AuthorizationModelSchema, {
+    id: value.id ?? "",
+    version: value.version ?? "",
+    resourceTypes: (value.resourceTypes ?? []).map(
+      authorizationModelResourceTypeToProto,
+    ),
+  });
+}
+
 function authorizationModelResourceTypeFromProto(
   value: ProtoAuthorizationModelResourceType,
 ): AuthorizationModelResourceType {
@@ -1025,6 +1270,19 @@ function modelAllowedTargetToProto(value: ModelAllowedTarget) {
     });
   }
   return create(ModelAllowedTargetSchema);
+}
+
+function authorizationModelRefFromProto(
+  value: ProtoGetActiveModelRefResponse["model"] | undefined,
+): AuthorizationModelRef | undefined {
+  if (!value) {
+    return undefined;
+  }
+  return {
+    id: value.id,
+    version: value.version,
+    createdAt: value.createdAt ? dateFromTimestamp(value.createdAt) : undefined,
+  };
 }
 
 function authorizationModelRefToProto(value: AuthorizationModelRef) {

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -75,7 +75,7 @@ import {
 } from "./internal/gen/v1/runtime_pb.ts";
 import { S3 as S3Service } from "./internal/gen/v1/s3_pb.ts";
 import { WorkflowProvider as WorkflowProviderService } from "./internal/gen/v1/workflow_pb.ts";
-import { errorMessage, type OperationResult, type Request } from "./api.ts";
+import { errorMessage, parseSubjectId, type OperationResult, type Request } from "./api.ts";
 import {
   AgentProvider,
   createAgentProviderService,
@@ -835,11 +835,13 @@ function providerRequest(
       id: subject?.id ?? "",
       credentialSubjectId: subject?.credentialSubjectId ?? "",
       email: subject?.email ?? "",
+      kind: subjectKind(subject?.id ?? ""),
     },
     agentSubject: {
       id: agentSubject?.id ?? "",
       credentialSubjectId: agentSubject?.credentialSubjectId ?? "",
       email: agentSubject?.email ?? "",
+      kind: subjectKind(agentSubject?.id ?? ""),
     },
     credential: {
       mode: credential?.mode ?? "",
@@ -862,6 +864,10 @@ function providerRequest(
     invocationToken,
     idempotencyKey: idempotencyKey.trim(),
   };
+}
+
+function subjectKind(subjectID: string): string {
+  return parseSubjectId(subjectID)?.kind ?? "";
 }
 
 function providerRequestToolRefs(

--- a/sdk/typescript/tests/runtime.test.ts
+++ b/sdk/typescript/tests/runtime.test.ts
@@ -773,6 +773,7 @@ test("integration provider service resolves hosted HTTP subjects through the app
       id: "system:http_binding:agent:command",
       credentialSubjectId: "",
       email: "",
+      kind: "system",
     },
     credential: {
       mode: "none",


### PR DESCRIPTION
## Summary

- Expose the selected `core.AuthorizationProvider` to provider processes as an unscoped `authorization` host service when authorization is configured.
- Expand the TypeScript SDK Authorization client to the full RPC-shaped surface (`checkAccess`, `checkAccessMany`, `listRelationships`, `addRelationship`, `deleteRelationship`, `setAuthorizationState`, `getActiveModelRef`, `setActiveModel`, `listActiveModelResourceTypes`).
- Gate mounted app/admin UIs through authorization relationships and default-allow resource policy instead of legacy `request.access.role`.

## Interfaces

Provider processes now use the same authorization provider surface as gestaltd; there is no per-app `authorizationAccess` YAML:

```ts
const decision = await Authorization().checkAccess({
  subject: { type: "subject", id: "user:..." },
  action: { name: "read" },
  resource: { type: "deal_hub.matter", id: "matter-123" },
});

await Authorization().addRelationship({
  relationship: {
    tuple: {
      target: { subject: { type: "subject", id: "user:..." } },
      relation: "viewer",
      resource: { type: "deal_hub.matter", id: "matter-123" },
    },
  },
});
```

Gestaltd registers the host service from `deps.Authorization` and forwards all AuthorizationProvider RPCs directly to the configured provider.

## Test plan

- [x] `go test ./gestaltd/internal/config ./gestaltd/services/authorization ./gestaltd/internal/bootstrap ./gestaltd/internal/server`
- [x] `cd sdk/typescript && bun run check`