### PR TITLE
[authorization] remove stale interface references

### DIFF
--- a/docs/content/applications.mdx
+++ b/docs/content/applications.mdx
@@ -15,7 +15,7 @@ Gestalt can be used to build applications. At a minimum, an application is a
 single [app](/providers/apps), or optionally a composition of
 [apps](/providers/apps) and [UIs](/providers/ui), using existing
 primitives for [authentication](/providers/authentication),
-[authorization](/providers/authorization),
+[authorization configuration](/reference/config-file#authorization),
 [IndexedDB](/providers/indexeddb)/[Cache](/providers/cache)/[S3](/providers/s3),
 [workflows](/providers/workflow), and [agents](/providers/agent).
 

--- a/docs/content/architecture/data-model.mdx
+++ b/docs/content/architecture/data-model.mdx
@@ -34,12 +34,11 @@ Emails and display names are plaintext. If you need encrypted PII at rest, handl
 
 ### `managed_subjects`
 
-Metadata for [service account](/service-accounts) identities managed through
-`/api/v1/authorization/subjects`. The canonical subject ID is always
-`service_account:<id>`. Authorization relationships for who can manage the
-subject live in the configured authorization provider as `managed_subject`
-resource relationships; runtime grants live as provider-backed dynamic
-plugin relationships.
+Metadata for [service account](/service-accounts) identities. The canonical
+subject ID is always `service_account:<id>`. Authorization relationships for
+who can manage the subject live in the configured authorization provider as
+`managed_subject` resource relationships; runtime grants live as
+provider-backed app relationships.
 
 | Field | Type | Notes |
 | --- | --- | --- |

--- a/docs/content/client/cli/index.mdx
+++ b/docs/content/client/cli/index.mdx
@@ -33,7 +33,6 @@ asIndexPage: true
 | `gestalt agent sessions ...` | Create, list, inspect, and update agent sessions. |
 | `gestalt agent turns ...` | Create, list, inspect, cancel, and stream agent turns. |
 | `gestalt tokens create\|list\|revoke` | Manage Gestalt API tokens. |
-| `gestalt authorization ...` | Manage service account subjects, subject grants and tokens, dynamic authorization members, and authorization provider debug views. |
 
 ## URL resolution
 
@@ -224,74 +223,6 @@ server-sent event stream to stdout.
 Interactive sessions use `GET /api/v1/agent/turns/{turnID}/events/stream`
 with `until=blocked_or_terminal`, which lets the CLI switch immediately from
 streaming output to interaction prompts when a provider requests input.
-
-## Authorization
-
-`gestalt authorization` covers service account subjects and the dynamic
-authorization admin surface. Built-in Gestalt admins can manage all dynamic
-grants. App admins can manage members for the specific apps they
-administer, so they can grant users or service accounts access without being
-global Gestalt admins. Admin subcommands may require `--url` pointing at the
-management base URL when public and management listeners are split.
-
-```sh
-gestalt authorization subjects list
-gestalt authorization subjects create release-bot \
-  --display-name "Release Bot"
-gestalt authorization subjects get service_account:release-bot
-gestalt authorization subjects update service_account:release-bot \
-  --description "Release automation"
-gestalt authorization subjects delete service_account:release-bot
-
-gestalt authorization subjects members list service_account:release-bot
-gestalt authorization subjects members set service_account:release-bot \
-  --email operator@example.com \
-  --role editor
-gestalt authorization subjects members remove service_account:release-bot \
-  user:user_123
-
-gestalt authorization subjects grants list service_account:release-bot
-gestalt authorization subjects grants set service_account:release-bot github \
-  --role viewer
-gestalt authorization subjects grants remove service_account:release-bot github
-
-gestalt authorization subjects integrations list service_account:release-bot
-gestalt authorization subjects integrations connect service_account:release-bot github
-gestalt authorization subjects integrations disconnect service_account:release-bot github
-
-gestalt authorization subjects tokens list service_account:release-bot
-gestalt authorization subjects tokens create service_account:release-bot \
-  --name release-bot \
-  --permission github:issues.list
-gestalt authorization subjects tokens revoke service_account:release-bot <token-id>
-gestalt authorization subjects tokens revoke-all service_account:release-bot
-
-gestalt authorization apps list
-gestalt authorization apps members list github
-gestalt authorization apps members set github \
-  --subject-id service_account:release-bot \
-  --role viewer
-gestalt authorization apps members set github \
-  --email operator@example.com \
-  --role admin
-gestalt authorization apps members remove github service_account:release-bot
-
-gestalt authorization admins members list
-gestalt authorization admins members set \
-  --email admin@example.com \
-  --role admin
-gestalt authorization admins members remove user:user_123
-
-gestalt authorization provider get
-gestalt authorization models list
-gestalt authorization relationships list \
-  --resource-type app_dynamic \
-  --resource-id github
-```
-
-Subject token creation accepts `--permission app:operation`, `--scopes`, or
-`--permissions-file` with a raw JSON permissions array. These inputs are
-mutually exclusive except repeated `--permission` flags, which can be combined.
 
 ### Local Quickstart
 

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -42,7 +42,7 @@ When you need production controls, add them through the [provider](/providers) e
 
 - Plug-and-play [providers](/providers), inspired by [Terraform providers](https://developer.hashicorp.com/terraform/language/providers), so you add only what you need.
 - A [unified tool surface](/providers/apps) over MCP, HTTP, and CLI, usable by cloud agents, local coding assistants, and human operators.
-- [Authentication](/providers/authentication) flows, [credential storage](/providers/external-credentials), encryption at rest, token refresh, and [RBAC](/providers/authorization) on infrastructure you control.
+- [Authentication](/providers/authentication) flows, [credential storage](/providers/external-credentials), encryption at rest, token refresh, and [RBAC](/reference/config-file#authorization) on infrastructure you control.
 - [OpenTelemetry](https://opentelemetry.io/) compatible [observability](/observability) and [audit logging](/audit-logging).
 - [Runtimes](/providers/runtime) for agent and code sandboxing.<sup><a href="#runtimes-alpha-note">*</a></sup>
 - [Workflows](/providers/workflow) and [agents](/providers/agent) with durable state, retries, and delegated invocations.<sup><a href="#workflows-agents-alpha-note">†</a></sup>

--- a/docs/content/providers/apps.mdx
+++ b/docs/content/providers/apps.mdx
@@ -26,7 +26,7 @@ server's `/mcp` endpoint.
 ## How app invocation uses authorization
 
 Gestalt resolves every app request to a canonical subject, then
-[authorization](/providers/authorization) decides whether that subject may use
+[authorization configuration](/reference/config-file#authorization) decides whether that subject may use
 the app or operation.
 
 When executable
@@ -1059,4 +1059,4 @@ For application composition, see [Applications](/applications).
 For configuration, see [Configuration](/reference/configuration). For operation
 invocation, see [HTTP API](/reference/http-api). For manifest fields, see
 [Provider Manifests](/reference/app-manifests). For authorization behavior,
-see [Authorization](/providers/authorization).
+see [Authorization configuration](/reference/config-file#authorization).

--- a/docs/content/providers/authentication.mdx
+++ b/docs/content/providers/authentication.mdx
@@ -3,7 +3,7 @@ import { Tabs } from 'nextra/components'
 # Authentication
 
 Authentication providers handle platform login for the Gestalt server.
-Authentication is separate from [Authorization](/providers/authorization), which
+Authentication is separate from [authorization configuration](/reference/config-file#authorization), which
 decides what the caller may access, and
 [External Credentials](/providers/external-credentials), which provide upstream
 credentials for configured connections.

--- a/docs/content/providers/external-credentials.mdx
+++ b/docs/content/providers/external-credentials.mdx
@@ -8,7 +8,7 @@ and resolve the runtime credential for that connection.
 
 External credentials are separate from Gestalt
 [authentication](/providers/authentication), which identifies the caller, and
-[authorization](/providers/authorization), which decides what the caller may
+[authorization configuration](/reference/config-file#authorization), which decides what the caller may
 access. An external credential is the credential Gestalt uses to call an
 upstream API for a configured connection.
 
@@ -17,7 +17,7 @@ upstream API for a configured connection.
 ### Subject scoping
 
 External credentials are scoped to a canonical
-[subject](/providers/authorization#subjects). Connections resolve credentials
+subject. Connections resolve credentials
 for the effective credential subject of the current request.
 
 ### Integration and connection

--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -25,7 +25,6 @@ examples, and custom provider contract for that kind:
 
 <Cards num={6} className="provider-kind-cards">
   <Cards.Card title="Authentication" href="/providers/authentication" />
-  <Cards.Card title="Authorization" href="/providers/authorization" />
   <Cards.Card title="External Credentials" href="/providers/external-credentials" />
   <Cards.Card title="Agent" href="/providers/agent" />
   <Cards.Card title="Cache" href="/providers/cache" />

--- a/docs/content/providers/ui.mdx
+++ b/docs/content/providers/ui.mdx
@@ -153,4 +153,4 @@ build and release behavior, see
 - [Applications](/applications): recommended app plus sibling UI layout
 - [Config File](/reference/config-file#providersui): exact `providers.ui` fields
 - [App Manifests](/reference/app-manifests#ui-metadata): UI manifest schema
-- [Authorization](/providers/authorization): route and role semantics
+- [Authorization configuration](/reference/config-file#authorization): route and role semantics

--- a/docs/content/reference/configuration.mdx
+++ b/docs/content/reference/configuration.mdx
@@ -77,7 +77,7 @@ the field reference:
 | --- | --- |
 | App setup, operation filtering, connections, and app-backed UIs | [Apps](/providers/apps) |
 | Platform login | [Authentication](/providers/authentication) |
-| RBAC, policies, and dynamic grants | [Authorization](/providers/authorization) |
+| RBAC, policies, and static grants | [Authorization configuration](/reference/config-file#authorization) |
 | Service accounts, subject-owned API tokens, and `runAs` | [Service Accounts](/service-accounts) |
 | Credential storage and upstream credentials | [External Credentials](/providers/external-credentials) |
 | Persistent state providers | [IndexedDB](/providers/indexeddb) |

--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -153,42 +153,6 @@ still honor each event's `visibility`.
 | `DELETE` | `/api/v1/tokens/{id}` | Revoke an API token. |
 | `DELETE` | `/api/v1/tokens` | Revoke all API tokens for the current user. |
 
-### Managed Subjects
-
-Managed subjects are the API representation of
-[service accounts](/service-accounts). Their canonical subject ID is always
-`service_account:<id>`, and their upstream credentials and subject-owned API
-tokens use that same subject ID. These management routes require a browser
-session or an unscoped user-owned API token; scoped API tokens and subject-owned
-API tokens cannot manage managed subjects.
-
-| Method | Path | Purpose |
-| --- | --- | --- |
-| `GET` | `/api/v1/authorization/subjects` | List managed subjects the current user can view. |
-| `POST` | `/api/v1/authorization/subjects` | Create a managed subject. The creator becomes an `admin` of that managed subject. |
-| `GET` | `/api/v1/authorization/subjects/{subjectID}` | Inspect one managed subject. |
-| `PATCH` | `/api/v1/authorization/subjects/{subjectID}` | Update display metadata. Requires managed subject `admin`. |
-| `DELETE` | `/api/v1/authorization/subjects/{subjectID}` | Delete one managed subject, revoke its API tokens, remove its external credentials, and delete its authorization relationships. Requires managed subject `admin`. |
-| `GET` | `/api/v1/authorization/subjects/{subjectID}/members` | List users or subjects that can manage the managed subject. |
-| `PUT` | `/api/v1/authorization/subjects/{subjectID}/members` | Upsert a managed subject member by canonical `subjectId` or user `email`; role must be `viewer`, `editor`, or `admin`. Requires managed subject `admin`. |
-| `DELETE` | `/api/v1/authorization/subjects/{subjectID}/members/{memberSubjectID}` | Remove a managed subject member. Requires managed subject `admin`. |
-| `GET` | `/api/v1/authorization/subjects/{subjectID}/grants` | List app authorization grants for the managed subject. |
-| `PUT` | `/api/v1/authorization/subjects/{subjectID}/grants/{app}` | Grant a app role to the managed subject. Requires managed subject `admin` and the caller must already hold the requested app role, or app `admin`. |
-| `DELETE` | `/api/v1/authorization/subjects/{subjectID}/grants/{app}` | Remove a app authorization grant from the managed subject. Requires managed subject `admin`. |
-| `GET` | `/api/v1/authorization/subjects/{subjectID}/integrations` | List apps with connection state resolved against the managed subject's credential subject. Requires managed subject `viewer`. |
-| `POST` | `/api/v1/authorization/subjects/{subjectID}/auth/start-oauth` | Start a app OAuth flow that stores credentials on the managed subject. Requires managed subject `editor`. |
-| `POST` | `/api/v1/authorization/subjects/{subjectID}/auth/connect-manual` | Submit manual app credentials for the managed subject. Requires managed subject `editor`. |
-| `DELETE` | `/api/v1/authorization/subjects/{subjectID}/integrations/{name}` | Disconnect one app credential from the managed subject. Requires managed subject `editor`. |
-| `GET` | `/api/v1/authorization/subjects/{subjectID}/tokens` | List API tokens owned by the managed subject. |
-| `POST` | `/api/v1/authorization/subjects/{subjectID}/tokens` | Create a subject-owned API token. Plaintext is returned once. Requires managed subject `admin`. |
-| `DELETE` | `/api/v1/authorization/subjects/{subjectID}/tokens/{id}` | Revoke one subject-owned API token. Requires managed subject `admin`. |
-| `DELETE` | `/api/v1/authorization/subjects/{subjectID}/tokens` | Revoke all API tokens owned by the managed subject. Requires managed subject `admin`. |
-
-The authorization provider stores managed-subject management as relationships on the `managed_subject` resource type. App runtime access is separate: a managed subject can only invoke an app after it has an explicit app grant, which is stored as the same provider-backed dynamic app relationship used by the admin authorization API. Policy `default: allow` applies to user callers, not to managed subjects. Credential connection management is also subject-scoped: OAuth, manual credentials, pending connection selection, and disconnects store or remove credentials under the managed subject's canonical subject ID.
-
-For the conceptual model and setup flow, see
-[Service Accounts](/service-accounts).
-
 ### Operator Surfaces
 
 | Method | Path | Purpose |
@@ -196,22 +160,6 @@ For the conceptual model and setup flow, see
 | `GET` | `/metrics` | Prometheus scrape endpoint for emitted metrics. Requires Gestalt authentication only when served on the public listener. The recommended production pattern is to move it to `server.management` and protect that listener at the network or proxy layer. |
 | `GET` | `/admin/api/v1/runtime/providers` | List configured runtime providers. When support inspection succeeds, loaded providers include a derived `profile` with `advertised` behavior reported by the runtime and `effective` behavior resolved for this host deployment. `error` explains any current inspection failure. |
 | `GET` | `/admin/api/v1/runtime/providers/{provider}/sessions` | List active sessions for one runtime provider, including session `id`, lifecycle `state`, and the hosted `app` when known. Supports `pageSize` and `pageToken`, and returns `sessions` plus `nextPageToken` when more sessions are available. |
-| `GET` | `/admin/api/v1/authorization/provider` | Inspect the configured authorization provider, capabilities, and active model. |
-| `GET` | `/admin/api/v1/authorization/models` | List authorization provider models. Supports `pageSize` and `pageToken`. |
-| `GET` | `/admin/api/v1/authorization/relationships` | List authorization provider relationships for debugging. Supports `modelId`, subject, relation, resource, `pageSize`, and `pageToken` filters. |
-| `GET` | `/admin/api/v1/authorization/apps` | List apps that declare `authorizationPolicy`, including the bound policy name. |
-| `GET` | `/admin/api/v1/authorization/apps/{app}/members` | List merged static and dynamic subject membership rows for one app. Rows include `source`, `effective`, and selector metadata. |
-| `PUT` | `/admin/api/v1/authorization/apps/{app}/members` | Upsert one dynamic subject membership row for a app by canonical `subjectId` or by user-only `email` alias and role. Rejects subjects who already have static authorization on that app. |
-| `DELETE` | `/admin/api/v1/authorization/apps/{app}/members/{subjectID}` | Remove one dynamic subject membership row for a app. Static rows are read-only and cannot be deleted through the API. |
-| `GET` | `/admin/api/v1/authorization/admins/members` | List merged static and dynamic built-in admin membership rows. |
-| `PUT` | `/admin/api/v1/authorization/admins/members` | Upsert one dynamic built-in admin membership row by canonical `subjectId` or by user-only `email` alias and role. Rejects subjects who already have static built-in admin authorization. |
-| `DELETE` | `/admin/api/v1/authorization/admins/members/{subjectID}` | Remove one dynamic built-in admin membership row. Static rows are read-only and cannot be deleted through the API. |
-
-`/admin/api/v1/...` mirrors the built-in `/admin` protection model for global admin and debug routes: when `server.admin.authorizationPolicy` is unset, the routes are open wherever `/admin` is open; when it is set, they require the same browser session and role checks as `/admin`, but return JSON `401`/`403` instead of browser redirects. App member routes also accept callers with role `admin` on the specific target app, so app admins can manage dynamic grants for their own app without being built-in Gestalt admins.
-
-Mutable membership APIs still list and delete by canonical `subjectId`. User-backed rows use `user:<user_id>` and non-human rows can use `service_account:<id>` or another canonical non-system subject ID. Dynamic membership writes accept either a canonical `subjectId` or an `email` alias. When `email` is used, Gestalt resolves it to the canonical user subject and creates the user record if needed before persisting the provider-backed grant.
-
-`PUT` and `DELETE` may return `202 Accepted` with `status: "persisted_pending_reload"` when the dynamic grant was written successfully but the local in-memory authorization snapshot has not reloaded yet. In that case, retry access checks only after the local snapshot converges.
 
 ## MCP
 
@@ -437,32 +385,4 @@ curl -X POST http://localhost:8080/api/v1/agent/turns/turn-123/cancel \
 #   }
 # ]
 
-# Add a dynamic app member from the management/admin surface by email alias
-curl -X PUT http://localhost:9090/admin/api/v1/authorization/apps/sample_app/members \
-  -H 'Content-Type: application/json' \
-  -d '{"email":"user@example.com","role":"viewer"}'
-
-# Create a managed subject and grant it viewer access to a app
-curl -X POST http://localhost:8080/api/v1/authorization/subjects \
-  -H 'Authorization: Bearer gst_api_...' \
-  -H 'Content-Type: application/json' \
-  -d '{"id":"release-bot","displayName":"Release Bot"}'
-
-curl -X PUT http://localhost:8080/api/v1/authorization/subjects/service_account:release-bot/grants/github \
-  -H 'Authorization: Bearer gst_api_...' \
-  -H 'Content-Type: application/json' \
-  -d '{"role":"viewer"}'
-
-curl -X POST http://localhost:8080/api/v1/authorization/subjects/service_account:release-bot/auth/connect-manual \
-  -H 'Authorization: Bearer gst_api_...' \
-  -H 'Content-Type: application/json' \
-  -d '{"integration":"github","credential":"ghp_..."}'
-
-curl http://localhost:8080/api/v1/authorization/subjects/service_account:release-bot/integrations \
-  -H 'Authorization: Bearer gst_api_...'
-
-curl -X POST http://localhost:8080/api/v1/authorization/subjects/service_account:release-bot/tokens \
-  -H 'Authorization: Bearer gst_api_...' \
-  -H 'Content-Type: application/json' \
-  -d '{"name":"release-bot","permissions":[{"app":"github","operations":["issues.list"]}]}'
 ```

--- a/docs/content/service-accounts.mdx
+++ b/docs/content/service-accounts.mdx
@@ -11,40 +11,18 @@ service_account:<id>
 ```
 
 Service accounts participate in the same
-[authorization](/providers/authorization) and
+[authorization configuration](/reference/config-file#authorization) and
 [external credential](/providers/external-credentials) systems as user subjects.
 
 ## Setup Flow
 
-1. Create the managed subject through the
-   [managed subjects API](/reference/http-api#managed-subjects).
+1. Declare the service-account subject in configuration where it is used.
 2. Grant users or groups permission to manage it.
 3. Grant app roles to the service account through
-   [authorization](/providers/authorization).
+   [authorization configuration](/reference/config-file#authorization).
 4. Connect upstream credentials for the service account through
    [external credentials](/providers/external-credentials).
-5. Use the service account through a subject-owned API token or `runAs`.
-
-## CLI Setup
-
-Use a subject-owned API token when automation calls Gestalt over HTTP, CLI, or
-MCP as the service account. The token owner is the service account subject, so
-normal app authorization and credential lookup use that subject.
-
-```sh
-gestalt authorization subjects create release-bot \
-  --display-name "Release Bot"
-
-gestalt authorization subjects grants set service_account:release-bot github \
-  --role viewer
-
-gestalt authorization subjects integrations connect service_account:release-bot github
-
-gestalt authorization subjects tokens create service_account:release-bot \
-  --name release-bot
-```
-
-The plaintext token is returned once. Store it like any other secret.
+5. Use the service account through `runAs`.
 
 ## runAs
 
@@ -89,13 +67,11 @@ execution explicit and auditable.
 
 ## Related Docs
 
-- [Authorization](/providers/authorization) explains subjects, resources,
-  relations, and grants.
+- [Configuration](/reference/config-file#authorization) explains subjects,
+  resources, relations, and grants.
 - [External Credentials](/providers/external-credentials) explains where
   upstream credentials are stored and resolved.
 - [Workflow](/providers/workflow) explains schedules, triggers, and workflow
   execution identity.
-- [HTTP API](/reference/http-api#managed-subjects) lists the managed subject,
-  credential, grant, and token routes.
 - [Data Model](/architecture/data-model) describes the
   underlying managed-subject records.

--- a/gestalt/cli/src/commands/apps.rs
+++ b/gestalt/cli/src/commands/apps.rs
@@ -5,10 +5,7 @@ use anyhow::{Context, Result};
 use crate::api::ApiClient;
 use crate::output::{self, Format};
 
-pub use connect::{
-    connect, connect_managed_subject, connect_managed_subject_with_browser_opener,
-    connect_with_browser_opener,
-};
+pub use connect::{connect, connect_with_browser_opener};
 
 const APP_CONNECTION_NAME: &str = "_app";
 const APP_CONNECTION_ALIAS: &str = "app";

--- a/gestalt/cli/src/commands/apps/connect.rs
+++ b/gestalt/cli/src/commands/apps/connect.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 
-use crate::api::{ApiClient, ApiError, encode_path_segment};
+use crate::api::{ApiClient, ApiError};
 use crate::interactive::{InputPrompt, PromptOption, prompt_input, prompt_select};
 use crate::output;
 
@@ -267,115 +267,17 @@ pub fn connect_with_browser_opener<F>(
 where
     F: FnOnce(&str) -> Result<()>,
 {
-    connect_with_scope_and_browser_opener(
-        client,
-        ConnectScope::User,
-        name,
-        connection,
-        instance,
-        open_browser,
-    )
-}
-
-pub fn connect_managed_subject(
-    client: &ApiClient,
-    subject_id: &str,
-    name: &str,
-    connection: Option<&str>,
-    instance: Option<&str>,
-) -> Result<()> {
-    connect_managed_subject_with_browser_opener(
-        client,
-        subject_id,
-        name,
-        connection,
-        instance,
-        |url| open::that(url).map(|_| ()).map_err(Into::into),
-    )
-}
-
-pub fn connect_managed_subject_with_browser_opener<F>(
-    client: &ApiClient,
-    subject_id: &str,
-    name: &str,
-    connection: Option<&str>,
-    instance: Option<&str>,
-    open_browser: F,
-) -> Result<()>
-where
-    F: FnOnce(&str) -> Result<()>,
-{
-    connect_with_scope_and_browser_opener(
-        client,
-        ConnectScope::ManagedSubject { subject_id },
-        name,
-        connection,
-        instance,
-        open_browser,
-    )
-}
-
-fn connect_with_scope_and_browser_opener<F>(
-    client: &ApiClient,
-    scope: ConnectScope<'_>,
-    name: &str,
-    connection: Option<&str>,
-    instance: Option<&str>,
-    open_browser: F,
-) -> Result<()>
-where
-    F: FnOnce(&str) -> Result<()>,
-{
-    let integration = fetch_app(client, scope, name)?;
+    let integration = fetch_app(client, name)?;
     let flow = ResolvedConnectFlow::resolve(&integration, connection)?;
 
     match flow.mode {
-        ConnectMode::OAuth => start_oauth(client, scope, &flow, instance, open_browser),
-        ConnectMode::Manual => connect_manual(client, scope, &flow, instance),
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ConnectScope<'a> {
-    User,
-    ManagedSubject { subject_id: &'a str },
-}
-
-impl ConnectScope<'_> {
-    fn integrations_path(self) -> String {
-        match self {
-            Self::User => "/api/v1/apps".to_string(),
-            Self::ManagedSubject { subject_id } => format!(
-                "/api/v1/authorization/subjects/{}/apps",
-                encode_path_segment(subject_id)
-            ),
-        }
-    }
-
-    fn start_oauth_path(self) -> String {
-        match self {
-            Self::User => "/api/v1/auth/start-oauth".to_string(),
-            Self::ManagedSubject { subject_id } => format!(
-                "/api/v1/authorization/subjects/{}/auth/start-oauth",
-                encode_path_segment(subject_id)
-            ),
-        }
-    }
-
-    fn connect_manual_path(self) -> String {
-        match self {
-            Self::User => "/api/v1/auth/connect-manual".to_string(),
-            Self::ManagedSubject { subject_id } => format!(
-                "/api/v1/authorization/subjects/{}/auth/connect-manual",
-                encode_path_segment(subject_id)
-            ),
-        }
+        ConnectMode::OAuth => start_oauth(client, &flow, instance, open_browser),
+        ConnectMode::Manual => connect_manual(client, &flow, instance),
     }
 }
 
 fn start_oauth<F>(
     client: &ApiClient,
-    scope: ConnectScope<'_>,
     flow: &ResolvedConnectFlow<'_>,
     instance: Option<&str>,
     open_browser: F,
@@ -386,7 +288,7 @@ where
     let connection_params = prompt_connection_params(flow.connection_param_defs())?;
     let resp = client
         .post(
-            &scope.start_oauth_path(),
+            "/api/v1/auth/start-oauth",
             &StartOAuthRequest {
                 integration: flow.integration_name(),
                 connection: flow.connection_name(),
@@ -412,7 +314,6 @@ where
 
 fn connect_manual(
     client: &ApiClient,
-    scope: ConnectScope<'_>,
     flow: &ResolvedConnectFlow<'_>,
     instance: Option<&str>,
 ) -> Result<()> {
@@ -432,7 +333,7 @@ fn connect_manual(
     let response: ConnectManualResponse = serde_json::from_value(
         client
             .post(
-                &scope.connect_manual_path(),
+                "/api/v1/auth/connect-manual",
                 &ConnectManualRequest {
                     integration: flow.integration_name(),
                     credentials: credentials.request(),
@@ -521,13 +422,10 @@ fn complete_pending_selection(
     Ok(())
 }
 
-fn fetch_app(client: &ApiClient, scope: ConnectScope<'_>, name: &str) -> Result<IntegrationInfo> {
-    let apps: Vec<IntegrationInfo> = serde_json::from_value(
-        client
-            .get(&scope.integrations_path())
-            .context("failed to load apps")?,
-    )
-    .context("failed to parse apps")?;
+fn fetch_app(client: &ApiClient, name: &str) -> Result<IntegrationInfo> {
+    let apps: Vec<IntegrationInfo> =
+        serde_json::from_value(client.get("/api/v1/apps").context("failed to load apps")?)
+            .context("failed to parse apps")?;
 
     apps.into_iter()
         .find(|app| app.name == name)

--- a/gestalt/cli/tests/apps_connect.rs
+++ b/gestalt/cli/tests/apps_connect.rs
@@ -55,46 +55,6 @@ fn test_connect_includes_connection_and_instance() {
 }
 
 #[test]
-fn test_connect_managed_subject_uses_subject_scoped_oauth_routes() {
-    let mut server = Server::new();
-    let _integrations = authed_json_mock!(
-        server,
-        Method::GET,
-        "/api/v1/authorization/subjects/service_account%3Arelease-bot/apps",
-        StatusCode::OK
-    )
-    .with_body(
-        r#"[{"name":"acme_crm","connections":[{"name":"workspace","authTypes":["oauth"]}]}]"#,
-    )
-    .create();
-    let mock = authed_json_mock!(
-        server,
-        Method::POST,
-        "/api/v1/authorization/subjects/service_account%3Arelease-bot/auth/start-oauth",
-        StatusCode::OK
-    )
-    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
-    .match_body(Matcher::JsonString(
-        r#"{"connection":"workspace","instance":"team-a","integration":"acme_crm"}"#.to_string(),
-    ))
-    .with_body(r#"{"url":"https://example.com/oauth","state":"abc123"}"#)
-    .create();
-
-    let client = create_client(&server);
-    let result = gestalt::commands::apps::connect_managed_subject_with_browser_opener(
-        &client,
-        "service_account:release-bot",
-        "acme_crm",
-        Some("workspace"),
-        Some("team-a"),
-        |_| Ok(()),
-    );
-
-    mock.assert();
-    assert!(result.is_ok());
-}
-
-#[test]
 fn test_connect_prefers_oauth_when_manual_also_exists_and_omits_null_instance() {
     let mut server = Server::new();
     let _integrations = authed_json_mock!(

--- a/sdk/typescript/tests/public-api-contract.ts
+++ b/sdk/typescript/tests/public-api-contract.ts
@@ -14,9 +14,7 @@ import { StructSchema as RootStructSchema } from "@valon-technologies/gestalt";
 // @ts-expect-error Root package must not expose protocol helper types.
 import type { Struct as RootStruct } from "@valon-technologies/gestalt";
 // @ts-expect-error Root package must not expose generated protocol schemas.
-import { AccessEvaluationRequestSchema as RootAccessEvaluationRequestSchema } from "@valon-technologies/gestalt";
-// @ts-expect-error Root package must not expose generated protocol message types.
-import type { AccessEvaluationRequest as RootAccessEvaluationRequest } from "@valon-technologies/gestalt";
+import { CheckAccessRequestSchema as RootCheckAccessRequestSchema } from "@valon-technologies/gestalt";
 // @ts-expect-error Root package must not expose runtime-log generated request schemas.
 import { AppendRuntimeLogsRequestSchema as RootAppendRuntimeLogsRequestSchema } from "@valon-technologies/gestalt";
 // @ts-expect-error Root package must not expose runtime-log generated enums.
@@ -30,7 +28,7 @@ import { connectionParamToProto } from "@valon-technologies/gestalt";
 // @ts-expect-error Protocol helper subpath is not public.
 import type { Struct as ProtocolStruct } from "@valon-technologies/gestalt/protocol";
 // @ts-expect-error Generated protocol subpath is not public.
-import type { AccessEvaluationRequest as ProtocolRequest } from "@valon-technologies/gestalt/protocol/v1";
+import type { CheckAccessRequest as ProtocolRequest } from "@valon-technologies/gestalt/protocol/v1";
 // @ts-expect-error Generated agent contract helpers are not public.
 import type { agentContractSchemas } from "@valon-technologies/gestalt/test/agent-contract";
 


### PR DESCRIPTION
## Description

Removes stale references to the pre-migration authorization interface from docs, CLI dead code, and the TypeScript public API contract.