### PR TITLE
Prefer workflow runAs for host-service calls

### DIFF
--- a/sdk/typescript/src/invocation-context.ts
+++ b/sdk/typescript/src/invocation-context.ts
@@ -8,7 +8,7 @@ export function hostInvocationContext(requestOrToken: Request | string) {
   const providerName = stringValue(requestOrToken.workflow.providerName) || stringValue(requestOrToken.workflow.provider);
   const runId = stringValue(requestOrToken.workflow.runId);
   return providerName && runId
-    ? { invocationToken, workflow: { provider: providerName, providerName, runId } }
+    ? { invocationToken: "", workflow: { provider: providerName, providerName, runId } }
     : { invocationToken };
 }
 


### PR DESCRIPTION
## Summary
- Use workflow provider/run metadata instead of forwarding short-lived invocation tokens for workflow-originated TypeScript SDK host-service calls.
- Preserve explicit string-token behavior for non-request callers.
- Unblock long-running workflow steps from losing agent/app access after the root invocation token TTL.

## Test plan
- [x] bun run typecheck in sdk/typescript