### PR TITLE
Add sparse remote materialized cache support

### DIFF
--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -118,6 +118,10 @@ stays quiet.
 `--cache-dir` enables a content-addressed cache for materialized prepared
 artifacts keyed by locked archive identity. Cache hits restore prepared outputs
 without re-downloading or reinstalling the package.
+Set `GESTALTD_SYNC_CACHE_REMOTE=gs://bucket/prefix` with `--cache-dir` to back
+that local cache with sparse per-artifact GCS objects. `gestaltd sync` checks
+the local cache first, downloads only missing remote entries, and uploads only
+entries materialized during the current sync.
 Use a private cache location because cache writers can influence restored
 prepared artifacts.
 

--- a/gestaltd/go.mod
+++ b/gestaltd/go.mod
@@ -36,6 +36,7 @@ require (
 	golang.org/x/crypto v0.51.0
 	golang.org/x/mod v0.36.0
 	golang.org/x/net v0.53.0
+	golang.org/x/oauth2 v0.36.0
 	golang.org/x/time v0.15.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260406210006-6f92a3bedf2d
 	google.golang.org/grpc v1.81.1
@@ -44,6 +45,7 @@ require (
 )
 
 require (
+	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	github.com/blevesearch/zapx/v17 v17.1.2 // indirect
 	github.com/wundergraph/go-arena v1.1.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect

--- a/gestaltd/go.sum
+++ b/gestaltd/go.sum
@@ -1,3 +1,5 @@
+cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
+cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/RoaringBitmap/roaring/v2 v2.14.5 h1:ckd0o545JqDPeVJDgeFoaM21eBixUnlWfYgjE5VnyWw=
@@ -208,6 +210,8 @@ golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
 golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/net v0.53.0 h1:d+qAbo5L0orcWAr0a9JweQpjXF19LMXJE8Ey7hwOdUA=
 golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
+golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
+golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -1033,6 +1033,10 @@ func (l *Lifecycle) LoadForStaticValidationAtPathsWithStatePaths(configPaths []s
 
 func (l *Lifecycle) syncAtPathsWithStatePaths(configPaths []string, state StatePaths, mode artifactMode, opts SyncOptions) error {
 	opts = normalizeSyncOptions(opts)
+	syncCache, err := materializedCacheFromSyncOptions(mode, opts)
+	if err != nil {
+		return err
+	}
 	recorder := opts.Observability.Recorder
 	if recorder != nil {
 		recorder.Begin(syncActionForArtifactMode(mode), configPaths, mode == artifactModeCheck, opts.Parallelism)
@@ -1045,13 +1049,11 @@ func (l *Lifecycle) syncAtPathsWithStatePaths(configPaths []string, state StateP
 		return fmt.Errorf("loading config: %v", err)
 	}
 	paths := resolveLifecyclePaths(configPaths, cfg, state)
-	if mode == artifactModeMaterialize && opts.CacheDir != "" {
-		paths.syncCacheDir = resolveCLIArtifactsDir(opts.CacheDir)
-	}
+	paths.syncCache = syncCache
 	paths.syncMetrics = recorder
 	paths.syncBuildOutput = opts.Observability.BuildOutput
 	if recorder != nil {
-		recorder.SetPaths(paths.artifactsDir, paths.lockfilePath, paths.syncCacheDir, opts.CacheDir != "", mode == artifactModeMaterialize && paths.syncCacheDir != "")
+		recorder.SetPaths(paths.artifactsDir, paths.lockfilePath, paths.syncCache.dir, opts.CacheDir != "", mode == artifactModeMaterialize && paths.syncCache.dir != "")
 	}
 	lock, err := ReadLockfile(paths.lockfilePath)
 	if err != nil {
@@ -1536,7 +1538,7 @@ type lifecyclePaths struct {
 	agentDir               string
 	runtimeDir             string
 	uiDir                  string
-	syncCacheDir           string
+	syncCache              materializedCache
 	syncMetrics            *SyncMetricsRecorder
 	syncBuildOutput        providerpkg.CommandOutput
 }
@@ -5120,9 +5122,10 @@ func (l *Lifecycle) materializeLockedArchive(ctx context.Context, paths lifecycl
 	}
 	cacheResult := syncCacheResultMiss
 	cacheEligible := true
-	if paths.syncCacheDir != "" {
+	cache := paths.syncCache
+	if cache.dir != "" {
 		cacheStart := time.Now()
-		restore, err := (materializedCache{dir: paths.syncCacheDir}).Restore(cacheReq)
+		restore, err := cache.Restore(ctx, cacheReq)
 		if restore != nil {
 			cacheResult = string(restore.Result)
 		}
@@ -5210,9 +5213,9 @@ func (l *Lifecycle) materializeLockedArchive(ctx context.Context, paths lifecycl
 	if err := validateLockedInstalledManifest(kind, name, subject, installed.Manifest, entry, platform, resolvedKey); err != nil {
 		return err
 	}
-	if paths.syncCacheDir != "" && cacheEligible {
+	if cache.dir != "" && cacheEligible {
 		cacheStart := time.Now()
-		key, files, bytes, putErr := (materializedCache{dir: paths.syncCacheDir}).Put(cacheReq, installed.Root)
+		key, files, bytes, putErr := cache.Put(ctx, cacheReq, installed.Root)
 		recordSyncCacheEntry(paths, syncCacheMetricsEvent{
 			Subject:    subject,
 			SourceKind: cacheReq.SourceKind,

--- a/gestaltd/internal/operator/materialized_cache.go
+++ b/gestaltd/internal/operator/materialized_cache.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -22,7 +23,8 @@ const (
 )
 
 type materializedCache struct {
-	dir string
+	dir    string
+	remote materializedCacheRemote
 }
 
 type materializedCacheLookupResult string
@@ -112,33 +114,86 @@ func materializedCacheKeyForRequest(req materializedCacheRequest) (materializedC
 	}, true, nil
 }
 
-func (c materializedCache) Restore(req materializedCacheRequest) (*materializedCacheRestore, error) {
+func (c materializedCache) Restore(ctx context.Context, req materializedCacheRequest) (*materializedCacheRestore, error) {
 	key, eligible, err := materializedCacheKeyForRequest(req)
 	if err != nil || !eligible {
 		return nil, err
 	}
 	entryDir := c.entryDir(key)
+	fallback := materializedCacheMiss
 	entry, err := c.readEntry(entryDir, req, key)
-	if os.IsNotExist(err) {
-		return &materializedCacheRestore{Result: materializedCacheMiss, Key: key}, nil
+	if err == nil {
+		restore, err := c.stageRestore(entryDir, req.DestinationDir, entry)
+		if err == nil {
+			restore.Result = materializedCacheHit
+			restore.Key = key
+			return restore, nil
+		}
+		fallback = materializedCacheInvalid
+	} else if !os.IsNotExist(err) {
+		fallback = materializedCacheInvalid
 	}
+	if c.remote != nil {
+		return c.restoreFromRemote(ctx, req, key, fallback)
+	}
+	return materializedCacheRestoreResult(key, fallback)
+}
+
+func (c materializedCache) restoreFromRemote(ctx context.Context, req materializedCacheRequest, key materializedCacheKey, fallback materializedCacheLookupResult) (*materializedCacheRestore, error) {
+	entryDir := c.entryDir(key)
+	parentDir := filepath.Dir(entryDir)
+	if err := os.MkdirAll(parentDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create materialized cache parent: %w", err)
+	}
+	archiveReader, hit, err := c.remote.Get(ctx, key)
 	if err != nil {
-		return invalidMaterializedCacheRestore(key)
+		return materializedCacheRestoreResult(key, fallback)
 	}
-	restore, err := c.stageRestore(entryDir, req.DestinationDir, entry)
+	if !hit {
+		return materializedCacheRestoreResult(key, fallback)
+	}
+	defer func() { _ = archiveReader.Close() }()
+
+	tmpDir, err := os.MkdirTemp(parentDir, "."+filepath.Base(entryDir)+".remote-*")
 	if err != nil {
-		return invalidMaterializedCacheRestore(key)
+		return nil, fmt.Errorf("create remote materialized cache temp entry: %w", err)
 	}
+	keepTmp := false
+	defer func() {
+		if !keepTmp {
+			_ = os.RemoveAll(tmpDir)
+		}
+	}()
+	if err := extractMaterializedCacheEntryArchive(archiveReader, tmpDir); err != nil {
+		return materializedCacheRestoreResult(key, materializedCacheInvalid)
+	}
+	entry, err := c.readEntry(tmpDir, req, key)
+	if err != nil {
+		return materializedCacheRestoreResult(key, materializedCacheInvalid)
+	}
+	restore, err := c.stageRestore(tmpDir, req.DestinationDir, entry)
+	if err != nil {
+		return materializedCacheRestoreResult(key, materializedCacheInvalid)
+	}
+	if err := os.RemoveAll(entryDir); err != nil {
+		_ = restore.cleanup()
+		return nil, fmt.Errorf("remove stale materialized cache entry: %w", err)
+	}
+	if err := os.Rename(tmpDir, entryDir); err != nil {
+		_ = restore.cleanup()
+		return nil, fmt.Errorf("commit remote materialized cache entry: %w", err)
+	}
+	keepTmp = true
 	restore.Result = materializedCacheHit
 	restore.Key = key
 	return restore, nil
 }
 
-func invalidMaterializedCacheRestore(key materializedCacheKey) (*materializedCacheRestore, error) {
-	return &materializedCacheRestore{Result: materializedCacheInvalid, Key: key}, nil
+func materializedCacheRestoreResult(key materializedCacheKey, result materializedCacheLookupResult) (*materializedCacheRestore, error) {
+	return &materializedCacheRestore{Result: result, Key: key}, nil
 }
 
-func (c materializedCache) Put(req materializedCacheRequest, sourceDir string) (materializedCacheKey, int, int64, error) {
+func (c materializedCache) Put(ctx context.Context, req materializedCacheRequest, sourceDir string) (materializedCacheKey, int, int64, error) {
 	key, eligible, err := materializedCacheKeyForRequest(req)
 	if err != nil {
 		return key, 0, 0, err
@@ -200,6 +255,24 @@ func (c materializedCache) Put(req materializedCacheRequest, sourceDir string) (
 		return key, 0, 0, fmt.Errorf("commit materialized cache entry: %w", err)
 	}
 	keepTmp = true
+	if c.remote != nil {
+		archivePath, err := os.CreateTemp(parentDir, "."+filepath.Base(entryDir)+".archive-*.tar.gz")
+		if err != nil {
+			return key, len(files), bytes, fmt.Errorf("create materialized cache archive temp file: %w", err)
+		}
+		archiveName := archivePath.Name()
+		if err := archivePath.Close(); err != nil {
+			_ = os.Remove(archiveName)
+			return key, len(files), bytes, fmt.Errorf("close materialized cache archive temp file: %w", err)
+		}
+		defer func() { _ = os.Remove(archiveName) }()
+		if err := writeMaterializedCacheEntryArchive(entryDir, archiveName); err != nil {
+			return key, len(files), bytes, err
+		}
+		if err := c.remote.Put(ctx, key, archiveName); err != nil {
+			return key, len(files), bytes, err
+		}
+	}
 	return key, len(files), bytes, nil
 }
 

--- a/gestaltd/internal/operator/materialized_cache_archive.go
+++ b/gestaltd/internal/operator/materialized_cache_archive.go
@@ -1,0 +1,192 @@
+package operator
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func writeMaterializedCacheEntryArchive(entryDir, outputPath string) error {
+	out, err := os.Create(outputPath)
+	if err != nil {
+		return fmt.Errorf("create materialized cache archive: %w", err)
+	}
+	defer func() { _ = out.Close() }()
+
+	gzw := gzip.NewWriter(out)
+	gzw.ModTime = time.Unix(0, 0)
+	defer func() { _ = gzw.Close() }()
+
+	tw := tar.NewWriter(gzw)
+	defer func() { _ = tw.Close() }()
+
+	if err := filepath.WalkDir(entryDir, func(absPath string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if absPath == entryDir {
+			return nil
+		}
+		rel, err := filepath.Rel(entryDir, absPath)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if _, err := validateMaterializedCacheArchivePath(rel); err != nil {
+			return err
+		}
+		if d.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("materialized cache archive does not support symlink %s", rel)
+		}
+		info, err := d.Info()
+		if err != nil {
+			return fmt.Errorf("stat materialized cache archive path %s: %w", rel, err)
+		}
+		if !info.IsDir() && !info.Mode().IsRegular() {
+			return fmt.Errorf("materialized cache archive does not support non-regular file %s", rel)
+		}
+		hdr, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return fmt.Errorf("build materialized cache archive header for %s: %w", rel, err)
+		}
+		hdr.Name = rel
+		hdr.ModTime = time.Unix(0, 0)
+		hdr.AccessTime = time.Unix(0, 0)
+		hdr.ChangeTime = time.Unix(0, 0)
+		hdr.Uid = 0
+		hdr.Gid = 0
+		hdr.Uname = ""
+		hdr.Gname = ""
+		if err := tw.WriteHeader(hdr); err != nil {
+			return fmt.Errorf("write materialized cache archive header for %s: %w", rel, err)
+		}
+		if info.IsDir() {
+			return nil
+		}
+		f, err := os.Open(absPath)
+		if err != nil {
+			return fmt.Errorf("open materialized cache archive path %s: %w", rel, err)
+		}
+		if _, err := io.Copy(tw, f); err != nil {
+			_ = f.Close()
+			return fmt.Errorf("write materialized cache archive path %s: %w", rel, err)
+		}
+		if err := f.Close(); err != nil {
+			return fmt.Errorf("close materialized cache archive path %s: %w", rel, err)
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("walk materialized cache entry: %w", err)
+	}
+	if err := tw.Close(); err != nil {
+		return fmt.Errorf("close materialized cache tar stream: %w", err)
+	}
+	if err := gzw.Close(); err != nil {
+		return fmt.Errorf("close materialized cache gzip stream: %w", err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("close materialized cache archive: %w", err)
+	}
+	return nil
+}
+
+func extractMaterializedCacheEntryArchive(reader io.Reader, destDir string) error {
+	gzr, err := gzip.NewReader(reader)
+	if err != nil {
+		return fmt.Errorf("open materialized cache gzip stream: %w", err)
+	}
+	defer func() { _ = gzr.Close() }()
+
+	tr := tar.NewReader(gzr)
+	seen := map[string]struct{}{}
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("read materialized cache tar stream: %w", err)
+		}
+		rel, err := validateMaterializedCacheArchivePath(hdr.Name)
+		if err != nil {
+			return err
+		}
+		if _, ok := seen[rel]; ok {
+			return fmt.Errorf("materialized cache archive path %q appears more than once", rel)
+		}
+		seen[rel] = struct{}{}
+
+		target := filepath.Join(destDir, filepath.FromSlash(rel))
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, os.FileMode(hdr.Mode)&0o777); err != nil {
+				return fmt.Errorf("create materialized cache archive directory %s: %w", rel, err)
+			}
+			if err := os.Chmod(target, os.FileMode(hdr.Mode)&0o777); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if hdr.Size < 0 {
+				return fmt.Errorf("materialized cache archive file %s has invalid size", rel)
+			}
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return fmt.Errorf("create parent for materialized cache archive file %s: %w", rel, err)
+			}
+			out, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(hdr.Mode)&0o777)
+			if err != nil {
+				return fmt.Errorf("create materialized cache archive file %s: %w", rel, err)
+			}
+			_, copyErr := io.CopyN(out, tr, hdr.Size)
+			closeErr := out.Close()
+			if copyErr != nil {
+				return fmt.Errorf("extract materialized cache archive file %s: %w", rel, copyErr)
+			}
+			if closeErr != nil {
+				return fmt.Errorf("close materialized cache archive file %s: %w", rel, closeErr)
+			}
+			if err := os.Chmod(target, os.FileMode(hdr.Mode)&0o777); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unsupported materialized cache archive entry type for %s", rel)
+		}
+	}
+	if _, ok := seen[materializedCacheEntryFile]; !ok {
+		return fmt.Errorf("materialized cache archive missing %s", materializedCacheEntryFile)
+	}
+	if err := gzr.Close(); err != nil {
+		return fmt.Errorf("close materialized cache gzip stream: %w", err)
+	}
+	return nil
+}
+
+func validateMaterializedCacheArchivePath(name string) (string, error) {
+	if name != strings.TrimSpace(name) || name == "" || strings.HasPrefix(name, "/") || strings.Contains(name, "\\") {
+		return "", fmt.Errorf("invalid materialized cache archive path %q", name)
+	}
+	name = strings.TrimSuffix(name, "/")
+	clean := path.Clean(name)
+	if clean == "." || clean != name || strings.HasPrefix(clean, "../") || clean == ".." {
+		return "", fmt.Errorf("invalid materialized cache archive path %q", name)
+	}
+	if clean == materializedCacheEntryFile {
+		return clean, nil
+	}
+	if clean == materializedCacheRootDir {
+		return clean, nil
+	}
+	if strings.HasPrefix(clean, materializedCacheRootDir+"/") {
+		rel, err := validateMaterializedCachePath(strings.TrimPrefix(clean, materializedCacheRootDir+"/"))
+		if err != nil {
+			return "", err
+		}
+		return materializedCacheRootDir + "/" + rel, nil
+	}
+	return "", fmt.Errorf("invalid materialized cache archive path %q", name)
+}

--- a/gestaltd/internal/operator/materialized_cache_remote.go
+++ b/gestaltd/internal/operator/materialized_cache_remote.go
@@ -1,0 +1,177 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"strings"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+const materializedCacheRemoteEnv = "GESTALTD_SYNC_CACHE_REMOTE"
+const materializedCacheRemoteScope = "https://www.googleapis.com/auth/devstorage.read_write"
+
+type materializedCacheRemote interface {
+	Get(context.Context, materializedCacheKey) (io.ReadCloser, bool, error)
+	Put(context.Context, materializedCacheKey, string) error
+}
+
+var newMaterializedCacheRemote = newGCSMaterializedCacheRemote
+
+type gcsMaterializedCacheRemote struct {
+	bucket string
+	prefix string
+	client *http.Client
+}
+
+func materializedCacheFromSyncOptions(mode artifactMode, opts SyncOptions) (materializedCache, error) {
+	if mode != artifactModeMaterialize {
+		return materializedCache{}, nil
+	}
+	remoteURL := strings.TrimSpace(os.Getenv(materializedCacheRemoteEnv))
+	if opts.CacheDir == "" {
+		if remoteURL != "" {
+			return materializedCache{}, fmt.Errorf("%s requires --cache-dir during gestaltd sync", materializedCacheRemoteEnv)
+		}
+		return materializedCache{}, nil
+	}
+	cache := materializedCache{dir: resolveCLIArtifactsDir(opts.CacheDir)}
+	if remoteURL == "" {
+		return cache, nil
+	}
+	remote, err := newMaterializedCacheRemote(remoteURL)
+	if err != nil {
+		return materializedCache{}, err
+	}
+	cache.remote = remote
+	return cache, nil
+}
+
+func newGCSMaterializedCacheRemote(raw string) (materializedCacheRemote, error) {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", materializedCacheRemoteEnv, err)
+	}
+	if u.Scheme != "gs" || u.Host == "" || u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+		return nil, fmt.Errorf("%s must be a gs://bucket/prefix URL", materializedCacheRemoteEnv)
+	}
+	return &gcsMaterializedCacheRemote{
+		bucket: u.Host,
+		prefix: strings.Trim(strings.TrimPrefix(u.Path, "/"), "/"),
+	}, nil
+}
+
+func (r *gcsMaterializedCacheRemote) Get(ctx context.Context, key materializedCacheKey) (io.ReadCloser, bool, error) {
+	object := r.objectName(key)
+	client, err := r.httpClient(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.downloadURL(object), nil)
+	if err != nil {
+		return nil, false, fmt.Errorf("build materialized cache remote read request: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, false, fmt.Errorf("read materialized cache remote object %s: %w", object, err)
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		_ = resp.Body.Close()
+		return nil, false, nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := gcsMaterializedCacheStatusError("read", object, resp)
+		_ = resp.Body.Close()
+		return nil, false, err
+	}
+	return resp.Body, true, nil
+}
+
+func (r *gcsMaterializedCacheRemote) Put(ctx context.Context, key materializedCacheKey, archivePath string) error {
+	object := r.objectName(key)
+	client, err := r.httpClient(ctx)
+	if err != nil {
+		return err
+	}
+	file, err := os.Open(archivePath)
+	if err != nil {
+		return fmt.Errorf("open materialized cache archive for upload: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, r.uploadURL(object), file)
+	if err != nil {
+		return fmt.Errorf("build materialized cache remote upload request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/gzip")
+	if info, err := file.Stat(); err == nil {
+		req.ContentLength = info.Size()
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("upload materialized cache remote object %s: %w", object, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusPreconditionFailed {
+		return nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return gcsMaterializedCacheStatusError("upload", object, resp)
+	}
+	return nil
+}
+
+func (r *gcsMaterializedCacheRemote) httpClient(ctx context.Context) (*http.Client, error) {
+	if r.client != nil {
+		return r.client, nil
+	}
+	tokenSource, err := google.DefaultTokenSource(ctx, materializedCacheRemoteScope)
+	if err != nil {
+		return nil, fmt.Errorf("create materialized cache GCS token source: %w", err)
+	}
+	return oauth2.NewClient(ctx, tokenSource), nil
+}
+
+func (r *gcsMaterializedCacheRemote) objectName(key materializedCacheKey) string {
+	if r.prefix == "" {
+		return key.Display + ".tar.gz"
+	}
+	return path.Join(r.prefix, key.Display+".tar.gz")
+}
+
+func (r *gcsMaterializedCacheRemote) downloadURL(object string) string {
+	return "https://storage.googleapis.com/storage/v1/b/" + url.PathEscape(r.bucket) + "/o/" + escapeGCSPathSegment(object) + "?alt=media"
+}
+
+func (r *gcsMaterializedCacheRemote) uploadURL(object string) string {
+	u := url.URL{
+		Scheme: "https",
+		Host:   "storage.googleapis.com",
+		Path:   "/upload/storage/v1/b/" + url.PathEscape(r.bucket) + "/o",
+	}
+	q := u.Query()
+	q.Set("uploadType", "media")
+	q.Set("ifGenerationMatch", "0")
+	q.Set("name", object)
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+func gcsMaterializedCacheStatusError(action, object string, resp *http.Response) error {
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	detail := strings.TrimSpace(string(body))
+	if detail == "" {
+		return fmt.Errorf("%s materialized cache remote object %s: status %s", action, object, resp.Status)
+	}
+	return fmt.Errorf("%s materialized cache remote object %s: status %s: %s", action, object, resp.Status, detail)
+}
+
+func escapeGCSPathSegment(value string) string {
+	return strings.ReplaceAll(url.PathEscape(value), "/", "%2F")
+}

--- a/gestaltd/internal/operator/materialized_cache_remote_test.go
+++ b/gestaltd/internal/operator/materialized_cache_remote_test.go
@@ -1,0 +1,85 @@
+package operator
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGCSMaterializedCacheRemoteHTTPContracts(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	req := materializedCacheUIRequest(dir, "alpha", "dest")
+	key, eligible, err := materializedCacheKeyForRequest(req)
+	if err != nil || !eligible {
+		t.Fatalf("materializedCacheKeyForRequest eligible=%t err=%v", eligible, err)
+	}
+
+	objectName := "prefix/" + key.Display + ".tar.gz"
+	var sawDownload bool
+	var sawUpload bool
+	remote := &gcsMaterializedCacheRemote{
+		client: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			switch r.Method {
+			case http.MethodGet:
+				sawDownload = true
+				if got := r.URL.Query().Get("alt"); got != "media" {
+					t.Fatalf("download alt query = %q, want media", got)
+				}
+				if got := r.URL.EscapedPath(); got != "/storage/v1/b/cache-bucket/o/"+escapeGCSPathSegment(objectName) {
+					t.Fatalf("download escaped path = %q, want encoded object path", got)
+				}
+				return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(http.NoBody)}, nil
+			case http.MethodPost:
+				sawUpload = true
+				if got := r.URL.Query().Get("uploadType"); got != "media" {
+					t.Fatalf("uploadType = %q, want media", got)
+				}
+				if got := r.URL.Query().Get("ifGenerationMatch"); got != "0" {
+					t.Fatalf("ifGenerationMatch = %q, want 0", got)
+				}
+				if got := r.URL.Query().Get("name"); got != objectName {
+					t.Fatalf("upload name = %q, want %q", got, objectName)
+				}
+				if got := r.Header.Get("Content-Type"); got != "application/gzip" {
+					t.Fatalf("upload content type = %q, want application/gzip", got)
+				}
+				return &http.Response{StatusCode: http.StatusPreconditionFailed, Body: io.NopCloser(http.NoBody)}, nil
+			default:
+				t.Fatalf("unexpected method %s", r.Method)
+				return nil, nil
+			}
+		})},
+		bucket: "cache-bucket",
+		prefix: "prefix",
+	}
+
+	reader, hit, err := remote.Get(context.Background(), key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if reader != nil || hit {
+		t.Fatalf("Get hit=%t reader=%v, want 404 miss", hit, reader)
+	}
+
+	archivePath := filepath.Join(dir, "entry.tar.gz")
+	if err := os.WriteFile(archivePath, []byte("archive"), 0o644); err != nil {
+		t.Fatalf("write archive: %v", err)
+	}
+	if err := remote.Put(context.Background(), key, archivePath); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if !sawDownload || !sawUpload {
+		t.Fatalf("saw download/upload = %t/%t, want both", sawDownload, sawUpload)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}

--- a/gestaltd/internal/operator/materialized_cache_test.go
+++ b/gestaltd/internal/operator/materialized_cache_test.go
@@ -1,9 +1,15 @@
 package operator
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -20,10 +26,10 @@ func TestMaterializedCachePreservesEmptyDirectories(t *testing.T) {
 
 	req := materializedCacheUIRequest(dir, "alpha", "dest")
 	cache := materializedCache{dir: filepath.Join(dir, "cache")}
-	if _, _, _, err := cache.Put(req, source); err != nil {
+	if _, _, _, err := cache.Put(context.Background(), req, source); err != nil {
 		t.Fatalf("Put: %v", err)
 	}
-	restore, err := cache.Restore(req)
+	restore, err := cache.Restore(context.Background(), req)
 	if err != nil {
 		t.Fatalf("Restore: %v", err)
 	}
@@ -46,12 +52,12 @@ func TestMaterializedCacheRestoresSharedArchiveForDifferentSubjects(t *testing.T
 	source := writeMaterializedCacheUISource(t, dir, "source")
 	cache := materializedCache{dir: filepath.Join(dir, "cache")}
 	req := materializedCacheUIRequest(dir, "alpha", "dest-alpha")
-	if _, _, _, err := cache.Put(req, source); err != nil {
+	if _, _, _, err := cache.Put(context.Background(), req, source); err != nil {
 		t.Fatalf("Put: %v", err)
 	}
 
 	sharedReq := materializedCacheUIRequest(dir, "beta", "dest-beta")
-	restore, err := cache.Restore(sharedReq)
+	restore, err := cache.Restore(context.Background(), sharedReq)
 	if err != nil {
 		t.Fatalf("Restore shared archive: %v", err)
 	}
@@ -59,6 +65,68 @@ func TestMaterializedCacheRestoresSharedArchiveForDifferentSubjects(t *testing.T
 		t.Fatalf("shared Restore result = %#v, want hit", restore)
 	}
 	defer func() { _ = restore.cleanup() }()
+}
+
+func TestMaterializedCacheRestoresRemoteEntry(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	remote := newFakeMaterializedCacheRemote()
+	source := writeMaterializedCacheUISource(t, dir, "source")
+	req := materializedCacheUIRequest(dir, "alpha", "dest")
+
+	if _, _, _, err := (materializedCache{dir: filepath.Join(dir, "cold"), remote: remote}).Put(context.Background(), req, source); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if remote.puts != 1 {
+		t.Fatalf("remote puts = %d, want 1", remote.puts)
+	}
+
+	restore, err := (materializedCache{dir: filepath.Join(dir, "warm"), remote: remote}).Restore(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Restore remote entry: %v", err)
+	}
+	if restore == nil || restore.Result != materializedCacheHit {
+		t.Fatalf("remote Restore result = %#v, want hit", restore)
+	}
+	defer func() { _ = restore.cleanup() }()
+	if err := restore.commit(); err != nil {
+		t.Fatalf("commit remote restore: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(req.DestinationDir, "manifest.yaml")); err != nil {
+		t.Fatalf("restored manifest stat: %v", err)
+	}
+
+	remote.getErr = errors.New("remote cache unavailable")
+	fallback, err := (materializedCache{dir: filepath.Join(dir, "fallback"), remote: remote}).Restore(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Restore remote read error: %v", err)
+	}
+	if fallback == nil || fallback.Result != materializedCacheMiss {
+		t.Fatalf("remote read error Restore result = %#v, want miss", fallback)
+	}
+}
+
+func TestMaterializedCacheTreatsUnsafeRemoteArchiveAsInvalid(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	remote := newFakeMaterializedCacheRemote()
+	req := materializedCacheUIRequest(dir, "alpha", "dest")
+	key, eligible, err := materializedCacheKeyForRequest(req)
+	if err != nil || !eligible {
+		t.Fatalf("materializedCacheKeyForRequest eligible=%t err=%v", eligible, err)
+	}
+	remote.objects[key.Display] = materializedCacheUnsafeArchive(t)
+
+	cache := materializedCache{dir: filepath.Join(dir, "cache"), remote: remote}
+	restore, err := cache.Restore(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Restore unsafe remote archive error = %v, want repairable invalid result", err)
+	}
+	if restore == nil || restore.Result != materializedCacheInvalid {
+		t.Fatalf("Restore unsafe remote archive = %#v, want invalid", restore)
+	}
 }
 
 func writeMaterializedCacheUISource(t *testing.T, dir, name string) string {
@@ -135,7 +203,7 @@ func TestMaterializedCacheTreatsUnsafeMetadataAsInvalid(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(entryDir, materializedCacheEntryFile), data, 0o644); err != nil {
 		t.Fatalf("write entry: %v", err)
 	}
-	restore, err := cache.Restore(req)
+	restore, err := cache.Restore(context.Background(), req)
 	if err != nil {
 		t.Fatalf("Restore unsafe entry error = %v, want repairable invalid result", err)
 	}
@@ -147,4 +215,60 @@ func TestMaterializedCacheTreatsUnsafeMetadataAsInvalid(t *testing.T) {
 func materializedCacheTestSHA256Hex(data []byte) string {
 	sum := sha256.Sum256(data)
 	return hex.EncodeToString(sum[:])
+}
+
+type fakeMaterializedCacheRemote struct {
+	objects map[string][]byte
+	gets    int
+	puts    int
+	getErr  error
+}
+
+func newFakeMaterializedCacheRemote() *fakeMaterializedCacheRemote {
+	return &fakeMaterializedCacheRemote{objects: map[string][]byte{}}
+}
+
+func (r *fakeMaterializedCacheRemote) Get(_ context.Context, key materializedCacheKey) (io.ReadCloser, bool, error) {
+	r.gets++
+	if r.getErr != nil {
+		return nil, false, r.getErr
+	}
+	data := r.objects[key.Display]
+	if data == nil {
+		return nil, false, nil
+	}
+	return io.NopCloser(bytes.NewReader(data)), true, nil
+}
+
+func (r *fakeMaterializedCacheRemote) Put(_ context.Context, key materializedCacheKey, archivePath string) error {
+	r.puts++
+	data, err := os.ReadFile(archivePath)
+	if err != nil {
+		return err
+	}
+	r.objects[key.Display] = data
+	return nil
+}
+
+func materializedCacheUnsafeArchive(t *testing.T) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gzw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gzw)
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     materializedCacheRootDir + "/link",
+		Typeflag: tar.TypeSymlink,
+		Linkname: materializedCacheEntryFile,
+		Mode:     0o777,
+	}); err != nil {
+		t.Fatalf("write unsafe archive header: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close unsafe archive tar: %v", err)
+	}
+	if err := gzw.Close(); err != nil {
+		t.Fatalf("close unsafe archive gzip: %v", err)
+	}
+	return buf.Bytes()
 }


### PR DESCRIPTION
## Summary

Adds sparse remote backing for the existing `gestaltd sync --cache-dir` materialized prepared-output cache. When `GESTALTD_SYNC_CACHE_REMOTE` points at a GCS prefix, sync still checks the local cache first, then downloads only the missing per-entry remote cache objects needed by the current lockfile.

Each remote object stores one validated materialized cache entry as a tar.gz keyed by the same content-addressed local cache path. Restored entries are unpacked into the local cache and pass through the existing metadata, platform, archive SHA, resolved-key, output digest, and prepared-install validation before activation.

This keeps cache writes best-effort for sync: local materialization succeeds even if a remote upload fails, and the failure is reported through the existing cache put-failure metrics. Check mode does not read or populate the cache.

## Interfaces

```sh
GESTALTD_SYNC_CACHE_REMOTE=gs://my-bucket/gestaltd-sync-cache \
  gestaltd sync \
  --locked \
  --lockfile deploy/gestalt.lock.json \
  --config deploy/config.yaml \
  --config deploy/prod/config.yaml \
  --artifacts-dir /prepared \
  --cache-dir /gestaltd-cache
```

`GESTALTD_SYNC_CACHE_REMOTE` requires `--cache-dir`; the remote cache is a backing store for the local materialized cache, not a standalone mode. Remote cache objects live below `materialized/v1/...tar.gz` under the configured GCS prefix.

## Runtime

The sync materialization path constructs the optional remote cache once, threads it through the existing lifecycle paths, and reuses the existing materialized cache restore/put flow. A local miss or invalid local entry can be repaired from the remote object; a remote miss falls through to normal archive download and materialization.

Remote objects are read and written through ADC-authenticated GCS JSON API requests, which keeps the dependency footprint small while still using the standard Google credential discovery path used by CI and GCP runtimes.
