### PR TITLE
Finalize static release sidecars from manifest packages

### DIFF
--- a/gestaltd/internal/daemon/provider_release_finalize.go
+++ b/gestaltd/internal/daemon/provider_release_finalize.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -15,6 +16,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/providerrelease"
 	"github.com/valon-technologies/gestalt/server/internal/staticvalidation"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	appservice "github.com/valon-technologies/gestalt/server/services/apps"
 	"github.com/valon-technologies/gestalt/server/services/apps/packageio"
 	"github.com/valon-technologies/gestalt/server/services/apps/providerpkg"
 	"github.com/valon-technologies/gestalt/server/services/apps/source"
@@ -306,22 +308,35 @@ func staticValidationCatalogForRelease(manifest *providermanifestv1.Manifest, ar
 	}
 	var firstCatalog *catalog.Catalog
 	var firstData []byte
-	for i, archive := range archives {
+	firstPath := ""
+	found := false
+	for _, archive := range archives {
 		cat, err := staticValidationCatalogFromArchive(manifest, archive)
 		if err != nil {
 			return nil, err
+		}
+		if cat == nil {
+			cat, err = staticValidationCatalogFromArchiveManifest(archive)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if cat == nil {
+			continue
 		}
 		data, err := yaml.Marshal(cat)
 		if err != nil {
 			return nil, fmt.Errorf("encode static validation catalog from %s: %w", filepath.Base(archive.Path), err)
 		}
-		if i == 0 {
+		if !found {
 			firstData = data
 			firstCatalog = cat
+			firstPath = archive.Path
+			found = true
 			continue
 		}
 		if !bytes.Equal(bytes.TrimSpace(firstData), bytes.TrimSpace(data)) {
-			return nil, fmt.Errorf("static validation catalog in %s does not match %s", filepath.Base(archive.Path), filepath.Base(archives[0].Path))
+			return nil, fmt.Errorf("static validation catalog in %s does not match %s", filepath.Base(archive.Path), filepath.Base(firstPath))
 		}
 	}
 	return firstCatalog, nil
@@ -348,6 +363,32 @@ func staticValidationCatalogFromArchive(manifest *providermanifestv1.Manifest, a
 		return nil, fmt.Errorf("validate static validation catalog from %s: %w", filepath.Base(archive.Path), err)
 	}
 	return &cat, nil
+}
+
+func staticValidationCatalogFromArchiveManifest(archive releaseArchive) (*catalog.Catalog, error) {
+	tmpDir, err := os.MkdirTemp("", "gestalt-provider-release-catalog-*")
+	if err != nil {
+		return nil, fmt.Errorf("create static validation catalog temp dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+	if err := packageio.ExtractPackage(archive.Path, tmpDir); err != nil {
+		return nil, fmt.Errorf("extract static validation catalog source from %s: %w", filepath.Base(archive.Path), err)
+	}
+	_, manifest, manifestPath, err := packageio.LoadManifestFromPath(tmpDir)
+	if err != nil {
+		return nil, fmt.Errorf("read static validation catalog manifest from %s: %w", filepath.Base(archive.Path), err)
+	}
+	if providermanifestv1.NormalizeKind(manifest.Kind) != providermanifestv1.KindApp || manifest.Spec == nil || !manifest.Spec.IsManifestBacked() {
+		return nil, nil
+	}
+	cat, sessionOnly, err := appservice.EffectiveCatalog(context.Background(), manifest.Source, appservice.ValidationAppFromManifest(manifestPath, manifest))
+	if err != nil {
+		return nil, fmt.Errorf("derive static validation catalog from %s: %w", filepath.Base(archive.Path), err)
+	}
+	if sessionOnly {
+		return nil, nil
+	}
+	return cat, nil
 }
 
 func printProviderReleaseUsage(w io.Writer) {

--- a/gestaltd/internal/daemon/provider_release_finalize_test.go
+++ b/gestaltd/internal/daemon/provider_release_finalize_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/internal/providerrelease"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/apps/providerpkg"
@@ -158,6 +159,104 @@ func TestProviderReleaseMetadataAllowsMCPOnlyWithoutCatalog(t *testing.T) {
 	}
 }
 
+func TestProviderReleaseMetadataBuildsOpenAPICatalogSidecar(t *testing.T) {
+	t.Parallel()
+
+	manifest := &providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindApp,
+		Source:      releaseTestSource,
+		Version:     "1.0.0",
+		DisplayName: "OpenAPI App",
+		IconFile:    "assets/icon.svg",
+		Spec: &providermanifestv1.Spec{
+			Surfaces: &providermanifestv1.ProviderSurfaces{
+				OpenAPI: &providermanifestv1.OpenAPISurface{
+					Connection: "default",
+					Document:   "openapi.yaml",
+				},
+			},
+			Connections: map[string]*providermanifestv1.ManifestConnectionDef{
+				"default": {Mode: providermanifestv1.ConnectionModeNone, Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone}},
+			},
+		},
+	}
+	metadata, manifestData, catalogData, err := buildProviderReleaseBundleForManifest(t, manifest, map[string]string{
+		"assets/icon.svg": "<svg/>",
+		"openapi.yaml": `openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+servers:
+  - url: https://api.example.test
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: ok
+`,
+	})
+	if err != nil {
+		t.Fatalf("buildProviderReleaseMetadata: %v", err)
+	}
+	if metadata.ValidationCatalogSHA256 == "" || len(catalogData) == 0 {
+		t.Fatalf("catalog sidecar missing: sha=%q bytes=%d", metadata.ValidationCatalogSHA256, len(catalogData))
+	}
+	if strings.Contains(string(manifestData), "openapi.yaml") || strings.Contains(string(manifestData), "assets/icon.svg") {
+		t.Fatalf("validation manifest retained package-local references:\n%s", manifestData)
+	}
+	cat, err := providerrelease.DecodeCatalog(catalogData)
+	if err != nil {
+		t.Fatalf("DecodeCatalog: %v", err)
+	}
+	if _, ok := catalog.OperationByID(cat, "listPets"); !ok {
+		t.Fatalf("catalog operations = %#v, want listPets", cat.Operations)
+	}
+}
+
+func TestProviderReleaseMetadataBuildsGraphQLMCPCatalogSidecar(t *testing.T) {
+	t.Parallel()
+
+	manifest := &providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindApp,
+		Source:      releaseTestSource,
+		Version:     "1.0.0",
+		DisplayName: "GraphQL MCP",
+		Spec: &providermanifestv1.Spec{
+			Surfaces: &providermanifestv1.ProviderSurfaces{
+				GraphQL: &providermanifestv1.GraphQLSurface{Connection: "default", URL: "https://graphql.example.test/graphql"},
+				MCP:     &providermanifestv1.MCPSurface{Connection: "default", URL: "https://mcp.example.test/mcp"},
+			},
+			Connections: map[string]*providermanifestv1.ManifestConnectionDef{
+				"default": {Mode: providermanifestv1.ConnectionModeNone, Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone}},
+			},
+			AllowedOperations: map[string]*providermanifestv1.ManifestOperationOverride{
+				"viewer": {
+					GraphQL: &providermanifestv1.ManifestGraphQLOperation{
+						OperationName: "Viewer",
+						Document:      "query Viewer { viewer { id } }",
+					},
+				},
+			},
+		},
+	}
+	metadata, _, catalogData, err := buildProviderReleaseBundleForManifest(t, manifest, nil)
+	if err != nil {
+		t.Fatalf("buildProviderReleaseMetadata: %v", err)
+	}
+	if metadata.ValidationCatalogSHA256 == "" || len(catalogData) == 0 {
+		t.Fatalf("catalog sidecar missing: sha=%q bytes=%d", metadata.ValidationCatalogSHA256, len(catalogData))
+	}
+	cat, err := providerrelease.DecodeCatalog(catalogData)
+	if err != nil {
+		t.Fatalf("DecodeCatalog: %v", err)
+	}
+	if _, ok := catalog.OperationByID(cat, "viewer"); !ok {
+		t.Fatalf("catalog operations = %#v, want viewer", cat.Operations)
+	}
+}
+
 func TestProviderReleaseMetadataRejectsMCPAppWithoutStaticCatalog(t *testing.T) {
 	t.Parallel()
 
@@ -178,7 +277,7 @@ func TestProviderReleaseMetadataRejectsMCPAppWithoutStaticCatalog(t *testing.T) 
 	}
 }
 
-func buildProviderReleaseMetadataForManifest(t *testing.T, manifest *providermanifestv1.Manifest, files map[string]string) (*providerrelease.Metadata, error) {
+func buildProviderReleaseBundleForManifest(t *testing.T, manifest *providermanifestv1.Manifest, files map[string]string) (*providerrelease.Metadata, []byte, []byte, error) {
 	t.Helper()
 
 	packageDir := t.TempDir()
@@ -190,7 +289,11 @@ func buildProviderReleaseMetadataForManifest(t *testing.T, manifest *providerman
 		t.Fatalf("write manifest: %v", err)
 	}
 	for name, contents := range files {
-		if err := os.WriteFile(filepath.Join(packageDir, name), []byte(contents), 0o644); err != nil {
+		path := filepath.Join(packageDir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("create %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
 			t.Fatalf("write %s: %v", name, err)
 		}
 	}
@@ -204,11 +307,17 @@ func buildProviderReleaseMetadataForManifest(t *testing.T, manifest *providerman
 		t.Fatalf("ArchiveDigest: %v", err)
 	}
 
-	metadata, _, _, err := buildProviderReleaseMetadataAndSidecars(
+	return buildProviderReleaseMetadataAndSidecars(
 		manifest,
 		"1.0.0",
 		[]releaseArchive{{Path: archive, SHA256: archiveSHA, Target: providerpkg.CurrentPlatformString()}},
 	)
+}
+
+func buildProviderReleaseMetadataForManifest(t *testing.T, manifest *providermanifestv1.Manifest, files map[string]string) (*providerrelease.Metadata, error) {
+	t.Helper()
+
+	metadata, _, _, err := buildProviderReleaseBundleForManifest(t, manifest, files)
 	return metadata, err
 }
 

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -3374,8 +3374,8 @@ func TestPortableStaticValidationManifestProjectsPlatformNeutralRuntimeFields(t 
 	if darwinProjected.Entrypoint != nil {
 		t.Fatalf("projected entrypoint = %+v, want nil", darwinProjected.Entrypoint)
 	}
-	if darwinProjected.Spec.Surfaces.OpenAPI.Document != "openapi.yaml" {
-		t.Fatalf("projected OpenAPI document = %q, want openapi.yaml", darwinProjected.Spec.Surfaces.OpenAPI.Document)
+	if darwinProjected.Spec.Surfaces.OpenAPI.Document != "" {
+		t.Fatalf("projected OpenAPI document = %q, want package-local reference stripped", darwinProjected.Spec.Surfaces.OpenAPI.Document)
 	}
 	darwinJSON, err := json.Marshal(darwinProjected)
 	if err != nil {

--- a/gestaltd/internal/providerrelease/release.go
+++ b/gestaltd/internal/providerrelease/release.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/apps/packageio"
 	"github.com/valon-technologies/gestalt/server/services/apps/providerpkg"
 	"github.com/valon-technologies/gestalt/server/services/apps/source"
 	"gopkg.in/yaml.v3"
@@ -287,28 +288,23 @@ func ManifestReferencesPackageFiles(manifest *providermanifestv1.Manifest) bool 
 	if manifest == nil {
 		return false
 	}
-	if packageFileReference(manifest.IconFile) {
+	if packageio.IsLocalPackageReference(manifest.IconFile) {
 		return true
 	}
 	spec := manifest.Spec
 	if spec == nil {
 		return false
 	}
-	if packageFileReference(spec.ConfigSchemaPath) {
+	if packageio.IsLocalPackageReference(spec.ConfigSchemaPath) {
 		return true
 	}
-	if spec.UI != nil && packageFileReference(spec.UI.Path) {
+	if spec.UI != nil && packageio.IsLocalPackageReference(spec.UI.Path) {
 		return true
 	}
 	if spec.Surfaces == nil {
 		return false
 	}
-	return (spec.Surfaces.OpenAPI != nil && packageFileReference(spec.Surfaces.OpenAPI.Document)) ||
-		(spec.Surfaces.GraphQL != nil && packageFileReference(spec.Surfaces.GraphQL.URL)) ||
-		(spec.Surfaces.MCP != nil && packageFileReference(spec.Surfaces.MCP.URL))
-}
-
-func packageFileReference(raw string) bool {
-	value := strings.TrimSpace(raw)
-	return value != "" && (strings.HasPrefix(value, "file://") || !strings.Contains(value, "://"))
+	return (spec.Surfaces.OpenAPI != nil && packageio.IsLocalPackageReference(spec.Surfaces.OpenAPI.Document)) ||
+		(spec.Surfaces.GraphQL != nil && packageio.IsLocalPackageReference(spec.Surfaces.GraphQL.URL)) ||
+		(spec.Surfaces.MCP != nil && packageio.IsLocalPackageReference(spec.Surfaces.MCP.URL))
 }

--- a/gestaltd/internal/staticvalidation/manifest.go
+++ b/gestaltd/internal/staticvalidation/manifest.go
@@ -28,6 +28,25 @@ func ProjectManifest(manifest *providermanifestv1.Manifest, manifestPath string,
 				ui.Path = ""
 				spec.UI = &ui
 			}
+			if spec.Surfaces != nil {
+				surfaces := *spec.Surfaces
+				if surfaces.OpenAPI != nil && packageio.IsLocalPackageReference(surfaces.OpenAPI.Document) {
+					openapi := *surfaces.OpenAPI
+					openapi.Document = ""
+					surfaces.OpenAPI = &openapi
+				}
+				if surfaces.GraphQL != nil && packageio.IsLocalPackageReference(surfaces.GraphQL.URL) {
+					graphql := *surfaces.GraphQL
+					graphql.URL = ""
+					surfaces.GraphQL = &graphql
+				}
+				if surfaces.MCP != nil && packageio.IsLocalPackageReference(surfaces.MCP.URL) {
+					mcp := *surfaces.MCP
+					mcp.URL = ""
+					surfaces.MCP = &mcp
+				}
+				spec.Surfaces = &surfaces
+			}
 			cloned.Spec = &spec
 		}
 		return RelativizeManifest(cloned, manifestPath), nil

--- a/gestaltd/services/apps/packageio/references.go
+++ b/gestaltd/services/apps/packageio/references.go
@@ -35,18 +35,23 @@ func LocalPackageReferences(manifest *providermanifestv1.Manifest) []LocalPackag
 
 	if manifest.Spec != nil {
 		add(manifest.Spec.ConfigSchemaPath, "provider config schema")
-		if doc := manifest.Spec.OpenAPIDocument(); doc != "" && !strings.Contains(doc, "://") {
+		if doc := manifest.Spec.OpenAPIDocument(); IsLocalPackageReference(doc) {
 			add(doc, "provider openapi document")
 		}
-		if url := manifest.Spec.GraphQLURL(); url != "" && !strings.Contains(url, "://") {
+		if url := manifest.Spec.GraphQLURL(); IsLocalPackageReference(url) {
 			add(url, "provider graphql document")
 		}
-		if url := manifest.Spec.MCPURL(); url != "" && !strings.Contains(url, "://") {
+		if url := manifest.Spec.MCPURL(); IsLocalPackageReference(url) {
 			add(url, "provider mcp document")
 		}
 	}
 	add(manifest.IconFile, "icon_file")
 	return refs
+}
+
+func IsLocalPackageReference(value string) bool {
+	value = strings.TrimSpace(value)
+	return value != "" && (strings.HasPrefix(value, "file://") || !strings.Contains(value, "://"))
 }
 
 func ResolveManifestLocalReferences(manifest *providermanifestv1.Manifest, manifestPath string) *providermanifestv1.Manifest {


### PR DESCRIPTION
## Summary
- derive release validation catalog sidecars from manifest-backed OpenAPI and GraphQL provider archives
- strip package-local API/icon references from platform-neutral validation manifests
- share local package reference detection between package validation and release validation

## Test plan
- [x] go test ./internal/providerrelease ./internal/staticvalidation ./services/apps ./services/apps/packageio ./internal/daemon