### PR TITLE
Use self-contained provider release metadata

### DIFF
--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -518,8 +518,8 @@ gestaltd provider release --dist-dir dist --version 0.0.1-alpha.1
 ```
 
 The release step validates the packaged archives, writes `provider-release.yaml`
-plus validation sidecars next to the archives, and records archive hashes in the
-release metadata. It does not run source build commands and can run after
+next to the archives, and records archive hashes plus static validation metadata
+in that file. It does not run source build commands and can run after
 multiple platform-specific package jobs have collected their archives into one
 dist directory.
 

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -61,7 +61,7 @@ the platform where they run.
 | `gestaltd provider validate --config PATH` | Validate the target provider together with selected supporting providers and `null` deletions from layered config overlays. |
 | `gestaltd provider package --version VERSION` | Build provider release archives from a source directory. Executable source providers use SDK-native source packages or `build.command` and default to the host platform; UI and declarative providers default to a generic archive. Pass `--platform ...` with `os/arch` targets or `--platform all` for multi-platform builds. |
 | `gestaltd provider package --output DIR` | Output directory for the release archives. Defaults to `dist/`. |
-| `gestaltd provider release --dist-dir DIR` | Finalize already-built release archives by validating them and writing `provider-release.yaml` plus validation sidecars into the dist directory. |
+| `gestaltd provider release --dist-dir DIR` | Finalize already-built release archives by validating them and writing `provider-release.yaml` into the dist directory. |
 
 For config-free local development, inferred UI mount paths use the manifest
 `source` slug rather than the API-safe provider key. A source ending in

--- a/gestaltd/internal/daemon/provider_lifecycle_test.go
+++ b/gestaltd/internal/daemon/provider_lifecycle_test.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/operator"
 	"github.com/valon-technologies/gestalt/server/internal/providerrelease"
@@ -493,24 +494,30 @@ func writeProviderLifecycleRelease(t *testing.T, dir, pkg, version string) strin
 	if err != nil {
 		t.Fatalf("ProjectManifest: %v", err)
 	}
-	manifestData, err = yaml.Marshal(staticManifest)
-	if err != nil {
-		t.Fatalf("Marshal validation manifest: %v", err)
+	var staticCatalog catalog.Catalog
+	if err := yaml.Unmarshal(catalogData, &staticCatalog); err != nil {
+		t.Fatalf("Unmarshal static catalog: %v", err)
 	}
-	manifestSHA := sha256.Sum256(manifestData)
-	catalogSHA := sha256.Sum256(catalogData)
-	metadata := map[string]any{
-		"package":                  pkg,
-		"kind":                     providermanifestv1.KindApp,
-		"version":                  version,
-		"validationManifestSHA256": fmt.Sprintf("%x", manifestSHA[:]),
-		"validationCatalogSHA256":  fmt.Sprintf("%x", catalogSHA[:]),
-		"artifacts": map[string]any{
-			providerpkg.CurrentPlatformString(): map[string]any{
-				"path":   archiveName,
-				"sha256": archiveDigest,
+	metadata := providerrelease.Metadata{
+		Schema:        providerrelease.SchemaName,
+		SchemaVersion: providerrelease.SchemaVersion,
+		Package:       pkg,
+		Kind:          providermanifestv1.KindApp,
+		Version:       version,
+		Runtime:       providerrelease.RuntimeForManifest(providermanifestv1.KindApp, staticManifest),
+		Artifacts: providerrelease.Artifacts{
+			providerpkg.CurrentPlatformString(): {
+				Path:   archiveName,
+				SHA256: archiveDigest,
 			},
 		},
+		StaticValidation: &providerrelease.StaticValidation{
+			Manifest: staticManifest,
+			Catalog:  &staticCatalog,
+		},
+	}
+	if err := providerrelease.ValidateMetadata(&metadata); err != nil {
+		t.Fatalf("ValidateMetadata: %v", err)
 	}
 	metadataData, err := yaml.Marshal(metadata)
 	if err != nil {
@@ -519,8 +526,6 @@ func writeProviderLifecycleRelease(t *testing.T, dir, pkg, version string) strin
 	metadataRel := filepath.ToSlash(filepath.Join("releases", version, "provider-release.yaml"))
 	metadataPath := filepath.Join(dir, filepath.FromSlash(metadataRel))
 	writeProviderLifecycleTestFile(t, metadataPath, string(metadataData))
-	writeProviderLifecycleTestFile(t, filepath.Join(filepath.Dir(metadataPath), providerrelease.ValidationManifestFile), string(manifestData))
-	writeProviderLifecycleTestFile(t, filepath.Join(filepath.Dir(metadataPath), providerrelease.ValidationCatalogFile), string(catalogData))
 	return metadataRel
 }
 

--- a/gestaltd/internal/daemon/provider_package.go
+++ b/gestaltd/internal/daemon/provider_package.go
@@ -116,11 +116,9 @@ func runProviderPackage(args []string) (err error) {
 }
 
 func removeStaleReleaseFinalizationFiles(outputDir string) error {
-	for _, name := range []string{providerrelease.MetadataFile, providerrelease.ValidationManifestFile, providerrelease.ValidationCatalogFile} {
-		p := filepath.Join(outputDir, name)
-		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("remove stale %s: %w", name, err)
-		}
+	p := filepath.Join(outputDir, providerrelease.MetadataFile)
+	if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove stale %s: %w", providerrelease.MetadataFile, err)
 	}
 	return nil
 }

--- a/gestaltd/internal/daemon/provider_package_edge_test.go
+++ b/gestaltd/internal/daemon/provider_package_edge_test.go
@@ -492,24 +492,16 @@ func TestRun_ProviderPackageDoesNotWriteReleaseFinalizationFiles(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(outputDir, providerrelease.MetadataFile), []byte("stale\n"), 0o644); err != nil {
 		t.Fatalf("write stale metadata: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(outputDir, providerrelease.ValidationManifestFile), []byte("stale\n"), 0o644); err != nil {
-		t.Fatalf("write stale validation manifest: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(outputDir, providerrelease.ValidationCatalogFile), []byte("stale\n"), 0o644); err != nil {
-		t.Fatalf("write stale validation catalog: %v", err)
-	}
 
 	runProviderPackageCommand(t, pluginDir,
 		"--version", "1.0.0",
 		"--output", outputDir,
 	)
 
-	for _, name := range []string{providerrelease.MetadataFile, providerrelease.ValidationManifestFile, providerrelease.ValidationCatalogFile} {
-		if _, err := os.Stat(filepath.Join(outputDir, name)); err == nil {
-			t.Fatalf("provider package unexpectedly wrote %s", name)
-		} else if !os.IsNotExist(err) {
-			t.Fatalf("stat %s: %v", name, err)
-		}
+	if _, err := os.Stat(filepath.Join(outputDir, providerrelease.MetadataFile)); err == nil {
+		t.Fatalf("provider package unexpectedly wrote %s", providerrelease.MetadataFile)
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("stat %s: %v", providerrelease.MetadataFile, err)
 	}
 }
 

--- a/gestaltd/internal/daemon/provider_publish.go
+++ b/gestaltd/internal/daemon/provider_publish.go
@@ -27,7 +27,6 @@ import (
 
 const providerPublishPlanSchema = "gestaltd.provider.publish.plan.v1"
 const providerPublishFileKindArchive = "archive"
-const providerPublishFileKindValidation = "validation"
 const providerPublishFileKindMetadata = "metadata"
 const providerPublishFormatText = "text"
 const providerPublishFormatJSON = "json"
@@ -70,7 +69,6 @@ type providerPublishPlan struct {
 	ManifestPath      string                `json:"manifestPath"`
 	Version           string                `json:"version"`
 	Metadata          providerPublishFile   `json:"metadata"`
-	Validation        []providerPublishFile `json:"validation"`
 	Artifacts         []providerPublishFile `json:"artifacts"`
 	Files             []providerPublishFile `json:"files"`
 }
@@ -226,22 +224,9 @@ func providerPublishFiles(repo config.ProviderSnapshotRepositoryConfig, manifest
 	sort.Slice(sortedArchives, func(i, j int) bool {
 		return filepath.Base(sortedArchives[i].Path) < filepath.Base(sortedArchives[j].Path)
 	})
-	files := make([]providerPublishFile, 0, len(sortedArchives)+3)
+	files := make([]providerPublishFile, 0, len(sortedArchives)+1)
 	for _, archive := range sortedArchives {
 		file, err := newProviderPublishFile(providerPublishFileKindArchive, archive.Target, archive.Path, storageRoot, publicRoot, sourceInfo.RelRoot, filepath.Base(archive.Path))
-		if err != nil {
-			return nil, providerPublishSourceRefInfo{}, err
-		}
-		files = append(files, file)
-	}
-	for _, name := range []string{providerrelease.ValidationManifestFile, providerrelease.ValidationCatalogFile} {
-		localPath := filepath.Join(metadataDir, name)
-		if _, err := os.Stat(localPath); os.IsNotExist(err) {
-			continue
-		} else if err != nil {
-			return nil, providerPublishSourceRefInfo{}, fmt.Errorf("stat %s: %w", localPath, err)
-		}
-		file, err := newProviderPublishFile(providerPublishFileKindValidation, "", localPath, storageRoot, publicRoot, sourceInfo.RelRoot, name)
 		if err != nil {
 			return nil, providerPublishSourceRefInfo{}, err
 		}
@@ -358,7 +343,6 @@ func newProviderPublishPlan(publishRepository string, sourceInfo providerPublish
 		ManifestPath:      sourceInfo.ManifestPath,
 		Version:           version,
 		Artifacts:         []providerPublishFile{},
-		Validation:        []providerPublishFile{},
 		Files:             make([]providerPublishFile, 0, len(files)),
 	}
 	for _, file := range files {
@@ -366,8 +350,6 @@ func newProviderPublishPlan(publishRepository string, sourceInfo providerPublish
 		switch file.Kind {
 		case providerPublishFileKindArchive:
 			plan.Artifacts = append(plan.Artifacts, file)
-		case providerPublishFileKindValidation:
-			plan.Validation = append(plan.Validation, file)
 		case providerPublishFileKindMetadata:
 			plan.Metadata = file
 		}
@@ -375,19 +357,7 @@ func newProviderPublishPlan(publishRepository string, sourceInfo providerPublish
 	if plan.Metadata.PublicURL == "" {
 		return providerPublishPlan{}, fmt.Errorf("provider publish plan is missing %s", providerrelease.MetadataFile)
 	}
-	if !providerPublishPlanHasFile(plan.Validation, providerrelease.ValidationManifestFile) {
-		return providerPublishPlan{}, fmt.Errorf("provider publish plan is missing %s", providerrelease.ValidationManifestFile)
-	}
 	return plan, nil
-}
-
-func providerPublishPlanHasFile(files []providerPublishFile, name string) bool {
-	for _, file := range files {
-		if filepath.Base(file.LocalPath) == name {
-			return true
-		}
-	}
-	return false
 }
 
 func preflightProviderPublishFiles(files []providerPublishFile) error {
@@ -410,14 +380,14 @@ func validateProviderPublishMetadataFile(file providerPublishFile) error {
 	if file.Kind != providerPublishFileKindMetadata {
 		return nil
 	}
-	if err := providerrelease.ValidateLocalBundle(file.LocalPath); err != nil {
+	if err := providerrelease.ValidateLocalMetadata(file.LocalPath); err != nil {
 		return fmt.Errorf("provider release metadata %s: %w", file.LocalPath, err)
 	}
 	return nil
 }
 
 func uploadProviderPublishFiles(files []providerPublishFile, sourceRef string) error {
-	for _, kind := range []string{providerPublishFileKindArchive, providerPublishFileKindValidation, providerPublishFileKindMetadata} {
+	for _, kind := range []string{providerPublishFileKindArchive, providerPublishFileKindMetadata} {
 		for _, file := range files {
 			if file.Kind != kind {
 				continue
@@ -500,8 +470,8 @@ func printProviderPublishUsage(w io.Writer) {
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Publish finalized provider release artifacts to a configured artifact repository.")
 	writeUsageLine(w, "Reads .tar.gz archives from each --dist-dir, validates one release bundle,")
-	writeUsageLine(w, "generates provider-release.yaml and validation sidecars, then uploads archives")
-	writeUsageLine(w, "and sidecars before provider-release.yaml. Destination paths use the configured repository")
+	writeUsageLine(w, "generates provider-release.yaml, then uploads archives before provider-release.yaml.")
+	writeUsageLine(w, "Destination paths use the configured repository")
 	writeUsageLine(w, "publish.pathLayout and the manifest source plus --ref.")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Flags:")

--- a/gestaltd/internal/daemon/provider_publish_test.go
+++ b/gestaltd/internal/daemon/provider_publish_test.go
@@ -123,12 +123,6 @@ providerSnapshotRepositories:
 	if plan.Metadata.PublicURL != "https://storage.example.test/providers/github.com/testowner/apps/"+ref+"/ui-test/provider-release.yaml" {
 		t.Fatalf("metadata public URL = %q", plan.Metadata.PublicURL)
 	}
-	if len(plan.Validation) != 1 {
-		t.Fatalf("validation len = %d, want 1: %#v", len(plan.Validation), plan.Validation)
-	}
-	if plan.Validation[0].PublicURL != "https://storage.example.test/providers/github.com/testowner/apps/"+ref+"/ui-test/"+providerrelease.ValidationManifestFile {
-		t.Fatalf("validation manifest public URL = %q", plan.Validation[0].PublicURL)
-	}
 	if len(plan.Artifacts) != 1 {
 		t.Fatalf("artifacts len = %d, want 1: %#v", len(plan.Artifacts), plan.Artifacts)
 	}
@@ -139,8 +133,8 @@ providerSnapshotRepositories:
 	if artifact.PublicURL != "https://storage.example.test/providers/github.com/testowner/apps/"+ref+"/ui-test/gestalt-app-ui-test_v"+version+".tar.gz" {
 		t.Fatalf("artifact public URL = %q", artifact.PublicURL)
 	}
-	if len(plan.Files) != 3 {
-		t.Fatalf("files len = %d, want 3: %#v", len(plan.Files), plan.Files)
+	if len(plan.Files) != 2 {
+		t.Fatalf("files len = %d, want 2: %#v", len(plan.Files), plan.Files)
 	}
 }
 
@@ -398,13 +392,12 @@ exit 1
 	}
 	got := string(calls)
 	archiveUpload := strings.Index(got, "gestalt-app-ui-test_v"+version+".tar.gz gs://provider-snapshots")
-	validationUpload := strings.Index(got, providerrelease.ValidationManifestFile+" gs://provider-snapshots")
 	metadataUpload := strings.Index(got, "provider-release.yaml gs://provider-snapshots")
-	if archiveUpload < 0 || validationUpload < 0 || metadataUpload < 0 {
+	if archiveUpload < 0 || metadataUpload < 0 {
 		t.Fatalf("missing expected upload calls:\n%s", got)
 	}
-	if archiveUpload >= validationUpload || validationUpload >= metadataUpload {
-		t.Fatalf("uploads are not phased archive -> validation -> metadata:\n%s", got)
+	if archiveUpload >= metadataUpload {
+		t.Fatalf("uploads are not phased archive -> metadata:\n%s", got)
 	}
 }
 

--- a/gestaltd/internal/daemon/provider_release_finalize.go
+++ b/gestaltd/internal/daemon/provider_release_finalize.go
@@ -215,17 +215,9 @@ func releaseArchiveTargetFromManifest(manifest *providermanifestv1.Manifest) (st
 }
 
 func writeProviderReleaseMetadata(dir string, manifest *providermanifestv1.Manifest, version string, archives []releaseArchive, verbose bool) error {
-	metadata, manifestData, catalogData, err := buildProviderReleaseMetadataAndSidecars(manifest, version, archives)
+	metadata, err := buildProviderReleaseMetadata(manifest, version, archives)
 	if err != nil {
 		return err
-	}
-	if err := writeProviderReleaseSidecar(dir, providerrelease.ValidationManifestFile, manifestData, verbose); err != nil {
-		return err
-	}
-	if len(catalogData) != 0 {
-		if err := writeProviderReleaseSidecar(dir, providerrelease.ValidationCatalogFile, catalogData, verbose); err != nil {
-			return err
-		}
 	}
 	data, err := yaml.Marshal(metadata)
 	if err != nil {
@@ -241,50 +233,34 @@ func writeProviderReleaseMetadata(dir string, manifest *providermanifestv1.Manif
 	return nil
 }
 
-func writeProviderReleaseSidecar(dir, name string, data []byte, verbose bool) error {
-	path := filepath.Join(dir, name)
-	if err := os.WriteFile(path, data, 0o644); err != nil {
-		return err
-	}
-	if verbose {
-		_, _ = fmt.Fprintf(os.Stdout, "created %s\n", path)
-	}
-	return nil
-}
-
-func buildProviderReleaseMetadataAndSidecars(manifest *providermanifestv1.Manifest, version string, archives []releaseArchive) (*providerrelease.Metadata, []byte, []byte, error) {
+func buildProviderReleaseMetadata(manifest *providermanifestv1.Manifest, version string, archives []releaseArchive) (*providerrelease.Metadata, error) {
 	if manifest == nil {
-		return nil, nil, nil, fmt.Errorf("manifest is required")
+		return nil, fmt.Errorf("manifest is required")
 	}
 	staticManifest, err := staticvalidation.ProjectManifest(manifest, "", true)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("project static validation manifest: %w", err)
+		return nil, fmt.Errorf("project static validation manifest: %w", err)
 	}
 	staticCatalog, err := staticValidationCatalogForRelease(manifest, archives)
 	if err != nil {
-		return nil, nil, nil, err
-	}
-	manifestData, err := yaml.Marshal(staticManifest)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("encode %s: %w", providerrelease.ValidationManifestFile, err)
-	}
-	var catalogData []byte
-	var catalogSHA string
-	if staticCatalog != nil {
-		catalogData, err = yaml.Marshal(staticCatalog)
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("encode %s: %w", providerrelease.ValidationCatalogFile, err)
-		}
-		catalogSHA = providerrelease.SHA256Hex(catalogData)
+		return nil, err
 	}
 
 	metadata := &providerrelease.Metadata{
-		Package:                  manifest.Source,
-		Kind:                     manifest.Kind,
-		Version:                  version,
-		Artifacts:                providerrelease.Artifacts{},
-		ValidationManifestSHA256: providerrelease.SHA256Hex(manifestData),
-		ValidationCatalogSHA256:  catalogSHA,
+		Schema:        providerrelease.SchemaName,
+		SchemaVersion: providerrelease.SchemaVersion,
+		Package:       manifest.Source,
+		Kind:          manifest.Kind,
+		Version:       version,
+		Runtime:       providerrelease.RuntimeForManifest(manifest.Kind, staticManifest),
+		Artifacts:     providerrelease.Artifacts{},
+		StaticValidation: &providerrelease.StaticValidation{
+			Manifest: staticManifest,
+			Catalog:  staticCatalog,
+		},
+	}
+	if staticCatalog == nil && providerrelease.CatalogSessionModeAllowed(manifest.Kind, staticManifest) {
+		metadata.StaticValidation.CatalogSessionOnly = true
 	}
 	for _, archive := range archives {
 		target := strings.TrimSpace(archive.Target)
@@ -293,10 +269,10 @@ func buildProviderReleaseMetadataAndSidecars(manifest *providermanifestv1.Manife
 		}
 		metadata.Artifacts[target] = providerrelease.Artifact{Path: filepath.Base(archive.Path), SHA256: archive.SHA256}
 	}
-	if err := providerrelease.ValidateBundle(metadata, staticManifest, staticCatalog); err != nil {
-		return nil, nil, nil, fmt.Errorf("validate provider release metadata: %w", err)
+	if err := providerrelease.ValidateMetadata(metadata); err != nil {
+		return nil, fmt.Errorf("validate provider release metadata: %w", err)
 	}
-	return metadata, manifestData, catalogData, nil
+	return metadata, nil
 }
 
 func staticValidationCatalogForRelease(manifest *providermanifestv1.Manifest, archives []releaseArchive) (*catalog.Catalog, error) {
@@ -368,7 +344,7 @@ func printProviderReleaseUsage(w io.Writer) {
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Finalize provider release metadata from already-built archives.")
 	writeUsageLine(w, "Reads all .tar.gz archives in --dist-dir, validates package contents, and")
-	writeUsageLine(w, "writes provider-release.yaml plus validation sidecars in the same directory.")
+	writeUsageLine(w, "writes provider-release.yaml in the same directory.")
 	writeUsageLine(w, "Run this after one or more provider package jobs have produced archives.")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Flags:")

--- a/gestaltd/internal/daemon/provider_release_finalize_test.go
+++ b/gestaltd/internal/daemon/provider_release_finalize_test.go
@@ -154,12 +154,18 @@ func TestProviderReleaseMetadataAllowsMCPOnlyWithoutCatalog(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildProviderReleaseMetadata: %v", err)
 	}
-	if metadata.ValidationCatalogSHA256 != "" {
-		t.Fatalf("catalog sha256 = %q, want empty for MCP-only release", metadata.ValidationCatalogSHA256)
+	if metadata.StaticValidation == nil {
+		t.Fatal("static validation metadata missing")
+	}
+	if metadata.StaticValidation.Catalog != nil {
+		t.Fatalf("catalog = %#v, want nil for MCP-only release", metadata.StaticValidation.Catalog)
+	}
+	if !metadata.StaticValidation.CatalogSessionOnly {
+		t.Fatal("catalogSessionOnly = false, want true for MCP-only release")
 	}
 }
 
-func TestProviderReleaseMetadataBuildsOpenAPICatalogSidecar(t *testing.T) {
+func TestProviderReleaseMetadataBuildsOpenAPICatalog(t *testing.T) {
 	t.Parallel()
 
 	manifest := &providermanifestv1.Manifest{
@@ -180,7 +186,7 @@ func TestProviderReleaseMetadataBuildsOpenAPICatalogSidecar(t *testing.T) {
 			},
 		},
 	}
-	metadata, manifestData, catalogData, err := buildProviderReleaseBundleForManifest(t, manifest, map[string]string{
+	metadata, err := buildProviderReleaseMetadataForManifest(t, manifest, map[string]string{
 		"assets/icon.svg": "<svg/>",
 		"openapi.yaml": `openapi: 3.0.0
 info:
@@ -200,25 +206,21 @@ paths:
 	if err != nil {
 		t.Fatalf("buildProviderReleaseMetadata: %v", err)
 	}
-	if metadata.ValidationCatalogSHA256 == "" || len(catalogData) == 0 {
-		t.Fatalf("catalog sidecar missing: sha=%q bytes=%d", metadata.ValidationCatalogSHA256, len(catalogData))
+	if metadata.StaticValidation == nil || metadata.StaticValidation.Catalog == nil {
+		t.Fatalf("catalog metadata missing: %#v", metadata.StaticValidation)
 	}
-	if strings.Contains(string(manifestData), "openapi.yaml") || strings.Contains(string(manifestData), "assets/icon.svg") {
-		t.Fatalf("validation manifest retained package-local references:\n%s", manifestData)
+	if providerrelease.ManifestReferencesPackageFiles(metadata.StaticValidation.Manifest) {
+		t.Fatalf("validation manifest retained package-local references: %#v", metadata.StaticValidation.Manifest)
 	}
-	cat, err := providerrelease.DecodeCatalog(catalogData)
-	if err != nil {
-		t.Fatalf("DecodeCatalog: %v", err)
-	}
-	if _, ok := catalog.OperationByID(cat, "listPets"); !ok {
-		t.Fatalf("catalog operations = %#v, want listPets", cat.Operations)
+	if _, ok := catalog.OperationByID(metadata.StaticValidation.Catalog, "listPets"); !ok {
+		t.Fatalf("catalog operations = %#v, want listPets", metadata.StaticValidation.Catalog.Operations)
 	}
 }
 
 func TestProviderReleaseMetadataMergesExecutableStaticAndAPICatalogs(t *testing.T) {
 	t.Parallel()
 
-	metadata, _, catalogData, err := buildProviderReleaseBundleForRawManifest(t, `kind: app
+	metadata, err := buildProviderReleaseMetadataForRawManifest(t, `kind: app
 source: github.com/testowner/apps/catalog/release-test
 version: 1.0.0
 displayName: Mixed App
@@ -254,12 +256,9 @@ operations:
 	if err != nil {
 		t.Fatalf("buildProviderReleaseMetadata: %v", err)
 	}
-	if metadata.ValidationCatalogSHA256 == "" || len(catalogData) == 0 {
-		t.Fatalf("catalog sidecar missing: sha=%q bytes=%d", metadata.ValidationCatalogSHA256, len(catalogData))
-	}
-	cat, err := providerrelease.DecodeCatalog(catalogData)
-	if err != nil {
-		t.Fatalf("DecodeCatalog: %v", err)
+	cat := metadata.StaticValidation.Catalog
+	if cat == nil {
+		t.Fatalf("catalog metadata missing: %#v", metadata.StaticValidation)
 	}
 	if _, ok := catalog.OperationByID(cat, "pluginOp"); !ok {
 		t.Fatalf("catalog operations = %#v, want pluginOp", cat.Operations)
@@ -272,7 +271,7 @@ operations:
 func TestProviderReleaseMetadataMergesExecutableStaticAndOpenAPICatalogs(t *testing.T) {
 	t.Parallel()
 
-	metadata, _, catalogData, err := buildProviderReleaseBundleForRawManifest(t, `kind: app
+	metadata, err := buildProviderReleaseMetadataForRawManifest(t, `kind: app
 source: github.com/testowner/apps/catalog/release-test
 version: 1.0.0
 displayName: Mixed OpenAPI App
@@ -316,12 +315,9 @@ paths:
 	if err != nil {
 		t.Fatalf("buildProviderReleaseMetadata: %v", err)
 	}
-	if metadata.ValidationCatalogSHA256 == "" || len(catalogData) == 0 {
-		t.Fatalf("catalog sidecar missing: sha=%q bytes=%d", metadata.ValidationCatalogSHA256, len(catalogData))
-	}
-	cat, err := providerrelease.DecodeCatalog(catalogData)
-	if err != nil {
-		t.Fatalf("DecodeCatalog: %v", err)
+	cat := metadata.StaticValidation.Catalog
+	if cat == nil {
+		t.Fatalf("catalog metadata missing: %#v", metadata.StaticValidation)
 	}
 	if _, ok := catalog.OperationByID(cat, "pluginOp"); !ok {
 		t.Fatalf("catalog operations = %#v, want pluginOp", cat.Operations)
@@ -331,7 +327,7 @@ paths:
 	}
 }
 
-func TestProviderReleaseMetadataBuildsGraphQLMCPCatalogSidecar(t *testing.T) {
+func TestProviderReleaseMetadataBuildsGraphQLMCPCatalog(t *testing.T) {
 	t.Parallel()
 
 	manifest := &providermanifestv1.Manifest{
@@ -357,19 +353,15 @@ func TestProviderReleaseMetadataBuildsGraphQLMCPCatalogSidecar(t *testing.T) {
 			},
 		},
 	}
-	metadata, _, catalogData, err := buildProviderReleaseBundleForManifest(t, manifest, nil)
+	metadata, err := buildProviderReleaseMetadataForManifest(t, manifest, nil)
 	if err != nil {
 		t.Fatalf("buildProviderReleaseMetadata: %v", err)
 	}
-	if metadata.ValidationCatalogSHA256 == "" || len(catalogData) == 0 {
-		t.Fatalf("catalog sidecar missing: sha=%q bytes=%d", metadata.ValidationCatalogSHA256, len(catalogData))
+	if metadata.StaticValidation == nil || metadata.StaticValidation.Catalog == nil {
+		t.Fatalf("catalog metadata missing: %#v", metadata.StaticValidation)
 	}
-	cat, err := providerrelease.DecodeCatalog(catalogData)
-	if err != nil {
-		t.Fatalf("DecodeCatalog: %v", err)
-	}
-	if _, ok := catalog.OperationByID(cat, "viewer"); !ok {
-		t.Fatalf("catalog operations = %#v, want viewer", cat.Operations)
+	if _, ok := catalog.OperationByID(metadata.StaticValidation.Catalog, "viewer"); !ok {
+		t.Fatalf("catalog operations = %#v, want viewer", metadata.StaticValidation.Catalog.Operations)
 	}
 }
 
@@ -393,7 +385,7 @@ func TestProviderReleaseMetadataRejectsMCPAppWithoutStaticCatalog(t *testing.T) 
 	}
 }
 
-func buildProviderReleaseBundleForManifest(t *testing.T, manifest *providermanifestv1.Manifest, files map[string]string) (*providerrelease.Metadata, []byte, []byte, error) {
+func buildProviderReleaseMetadataForManifest(t *testing.T, manifest *providermanifestv1.Manifest, files map[string]string) (*providerrelease.Metadata, error) {
 	t.Helper()
 
 	packageDir := t.TempDir()
@@ -423,14 +415,14 @@ func buildProviderReleaseBundleForManifest(t *testing.T, manifest *providermanif
 		t.Fatalf("ArchiveDigest: %v", err)
 	}
 
-	return buildProviderReleaseMetadataAndSidecars(
+	return buildProviderReleaseMetadata(
 		manifest,
 		"1.0.0",
 		[]releaseArchive{{Path: archive, SHA256: archiveSHA, Target: providerpkg.CurrentPlatformString()}},
 	)
 }
 
-func buildProviderReleaseBundleForRawManifest(t *testing.T, rawManifest string, files map[string]string) (*providerrelease.Metadata, []byte, []byte, error) {
+func buildProviderReleaseMetadataForRawManifest(t *testing.T, rawManifest string, files map[string]string) (*providerrelease.Metadata, error) {
 	t.Helper()
 
 	packageDir := t.TempDir()
@@ -460,18 +452,11 @@ func buildProviderReleaseBundleForRawManifest(t *testing.T, rawManifest string, 
 		t.Fatalf("ArchiveDigest: %v", err)
 	}
 
-	return buildProviderReleaseMetadataAndSidecars(
+	return buildProviderReleaseMetadata(
 		manifest,
 		"1.0.0",
 		[]releaseArchive{{Path: archive, SHA256: archiveSHA, Target: providerpkg.CurrentPlatformString()}},
 	)
-}
-
-func buildProviderReleaseMetadataForManifest(t *testing.T, manifest *providermanifestv1.Manifest, files map[string]string) (*providerrelease.Metadata, error) {
-	t.Helper()
-
-	metadata, _, _, err := buildProviderReleaseBundleForManifest(t, manifest, files)
-	return metadata, err
 }
 
 func providerReleaseManifestForTest(version, displayName, goos, goarch string) *providermanifestv1.Manifest {

--- a/gestaltd/internal/daemon/testmain_test.go
+++ b/gestaltd/internal/daemon/testmain_test.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/internal/providerrelease"
 	"github.com/valon-technologies/gestalt/server/internal/staticvalidation"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
@@ -366,39 +367,42 @@ func writeLocalProviderReleaseMetadata(dir string) error {
 	if err != nil {
 		return err
 	}
-	manifestSidecar, err := yaml.Marshal(staticManifest)
-	if err != nil {
-		return err
-	}
-	if err := os.WriteFile(filepath.Join(dir, providerrelease.ValidationManifestFile), manifestSidecar, 0o644); err != nil {
-		return err
-	}
-	manifestSHA := sha256.Sum256(manifestSidecar)
-	var catalogSHA string
+	var staticCatalog *catalog.Catalog
 	if catalogData, err := os.ReadFile(filepath.Join(dir, providerpkg.StaticCatalogFile)); err == nil {
-		if err := os.WriteFile(filepath.Join(dir, providerrelease.ValidationCatalogFile), catalogData, 0o644); err != nil {
+		var cat catalog.Catalog
+		if err := yaml.Unmarshal(catalogData, &cat); err != nil {
 			return err
 		}
-		sum := sha256.Sum256(catalogData)
-		catalogSHA = fmt.Sprintf("%x", sum[:])
+		staticCatalog = &cat
 	}
 
-	metadata := map[string]any{
-		"package":                  manifest.Source,
-		"kind":                     manifest.Kind,
-		"version":                  manifest.Version,
-		"validationManifestSHA256": fmt.Sprintf("%x", manifestSHA[:]),
-		"validationCatalogSHA256":  catalogSHA,
-		"artifacts": map[string]any{
-			providerpkg.CurrentPlatformString(): map[string]any{
-				"path":   filepath.ToSlash(filepath.Join("..", filepath.Base(archivePath))),
-				"sha256": digest,
+	metadata := providerrelease.Metadata{
+		Schema:        providerrelease.SchemaName,
+		SchemaVersion: providerrelease.SchemaVersion,
+		Package:       manifest.Source,
+		Kind:          manifest.Kind,
+		Version:       manifest.Version,
+		Runtime:       providerrelease.RuntimeForManifest(manifest.Kind, staticManifest),
+		Artifacts: providerrelease.Artifacts{
+			providerpkg.CurrentPlatformString(): {
+				Path:   filepath.ToSlash(filepath.Join("..", filepath.Base(archivePath))),
+				SHA256: digest,
 			},
 		},
+		StaticValidation: &providerrelease.StaticValidation{
+			Manifest: staticManifest,
+			Catalog:  staticCatalog,
+		},
+	}
+	if staticCatalog == nil && providerrelease.CatalogSessionModeAllowed(manifest.Kind, staticManifest) {
+		metadata.StaticValidation.CatalogSessionOnly = true
+	}
+	if err := providerrelease.ValidateMetadata(&metadata); err != nil {
+		return err
 	}
 	data, err := yaml.Marshal(metadata)
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(dir, "provider-release.yaml"), data, 0o644)
+	return os.WriteFile(filepath.Join(dir, providerrelease.MetadataFile), data, 0o644)
 }

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -1013,7 +1013,7 @@ func TestLifecycleGitSourceSnapshotRequireContract(t *testing.T) {
 	metadataPath := "/snapshots/github.com/acme/providers/" + ref + "/apps/alpha/provider-release.yaml"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case metadataPath, providerReleaseManifestSidecarPath(metadataPath), providerReleaseCatalogSidecarPath(metadataPath):
+		case metadataPath:
 			metadata := providerReleaseMetadataFixture{
 				Package:     packageSource,
 				Kind:        providermanifestv1.KindApp,
@@ -1128,7 +1128,7 @@ func TestLifecycleGitSourceSnapshotRequirePrimesSecretsProvider(t *testing.T) {
 	metadataPath := "/snapshots/github.com/acme/providers/" + ref + "/secrets/google/provider-release.yaml"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case metadataPath, providerReleaseManifestSidecarPath(metadataPath), providerReleaseCatalogSidecarPath(metadataPath):
+		case metadataPath:
 			metadata := providerReleaseMetadataFixture{
 				Package:     packageSource,
 				Kind:        providermanifestv1.KindSecrets,
@@ -2191,7 +2191,7 @@ func TestSourceAppMetadataURLPrepareAndLockedLoad(t *testing.T) {
 			} else {
 				srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					switch r.URL.Path {
-					case metadataPath, providerReleaseManifestSidecarPath(metadataPath), providerReleaseCatalogSidecarPath(metadataPath):
+					case metadataPath:
 						if r.URL.Path == metadataPath {
 							metadataCount.Add(1)
 						}
@@ -2579,7 +2579,7 @@ packages:
 `, version, providerpkg.CurrentPlatformString())
 			w.Header().Set("Content-Type", "application/yaml")
 			_, _ = w.Write([]byte(index))
-		case metadataPath, providerReleaseManifestSidecarPath(metadataPath), providerReleaseCatalogSidecarPath(metadataPath):
+		case metadataPath:
 			if r.URL.Path == metadataPath {
 				metadataCount.Add(1)
 			}
@@ -2821,7 +2821,7 @@ func TestSourceProviderPackagesResolveIndexedDBAndS3(t *testing.T) {
 		}
 		for _, rel := range releases {
 			switch r.URL.Path {
-			case rel.metadataPath, providerReleaseManifestSidecarPath(rel.metadataPath), providerReleaseCatalogSidecarPath(rel.metadataPath):
+			case rel.metadataPath:
 				if r.URL.Path == rel.metadataPath {
 					metadataCount.Add(1)
 				}
@@ -2959,7 +2959,7 @@ func TestSourceWorkflowMetadataURLPrepareAndLockedLoad(t *testing.T) {
 	archivePathURL := "/providers/workflow/workflow-runner.tar.gz"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case metadataPath, providerReleaseManifestSidecarPath(metadataPath), providerReleaseCatalogSidecarPath(metadataPath):
+		case metadataPath:
 			if r.URL.Path == metadataPath {
 				metadataCount.Add(1)
 			}
@@ -3129,7 +3129,7 @@ func TestSourceExternalCredentialsMetadataURLPrepareAndLockedLoad(t *testing.T) 
 	archivePathURL := "/providers/external-credentials/external-credentials-runner.tar.gz"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case metadataPath, providerReleaseManifestSidecarPath(metadataPath), providerReleaseCatalogSidecarPath(metadataPath):
+		case metadataPath:
 			if r.URL.Path == metadataPath {
 				metadataCount.Add(1)
 			}
@@ -3303,7 +3303,7 @@ func TestSourceUIMetadataURLPrepareAndLockedLoad(t *testing.T) {
 	archivePathURL := "/providers/roadmap/roadmap-ui.tar.gz"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case metadataPath, providerReleaseManifestSidecarPath(metadataPath), providerReleaseCatalogSidecarPath(metadataPath):
+		case metadataPath:
 			if r.URL.Path == metadataPath {
 				metadataCount.Add(1)
 			}
@@ -3468,7 +3468,7 @@ func TestSourceAppPrepareRejectsMetadataSourceManifestMismatch(t *testing.T) {
 	archivePathURL := "/providers/gadget/gadget-current.tar.gz"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case metadataPath, providerReleaseManifestSidecarPath(metadataPath), providerReleaseCatalogSidecarPath(metadataPath):
+		case metadataPath:
 			metadata := providerReleaseMetadataFixture{
 				Package:      packageSource,
 				Kind:         providermanifestv1.KindApp,
@@ -3518,8 +3518,8 @@ func TestSourceAppPrepareRejectsMetadataSourceManifestMismatch(t *testing.T) {
 		t.Fatal("PrepareAtPath unexpectedly succeeded")
 		return
 	}
-	if !strings.Contains(err.Error(), `provider release validation manifest package "github.com/acme/tools/other-gadget" does not match "github.com/acme/tools/gadget"`) {
-		t.Fatalf("PrepareAtPath error = %v, want release validation manifest package mismatch", err)
+	if !strings.Contains(err.Error(), `provider "gadget" manifest source "github.com/acme/tools/other-gadget" does not match metadata package "github.com/acme/tools/gadget"`) {
+		t.Fatalf("PrepareAtPath error = %v, want installed manifest package mismatch", err)
 	}
 }
 
@@ -3558,7 +3558,7 @@ func TestSourceAppMetadataURLUsesGenericAuthenticatedFetch(t *testing.T) {
 	var currentMu sync.RWMutex
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case metadataPath, providerReleaseManifestSidecarPath(metadataPath), providerReleaseCatalogSidecarPath(metadataPath):
+		case metadataPath:
 			if r.URL.Path == metadataPath {
 				metadataCount.Add(1)
 			}
@@ -3706,13 +3706,9 @@ func TestSourceAppGitHubReleaseSourceUsesResolvedAssetURL(t *testing.T) {
 		repo         = "valon-technologies/toolshed"
 		tag          = "apps/workplace-hub/v0.0.1-alpha.1"
 		metadataID   = int64(101)
-		manifestID   = int64(102)
-		catalogID    = int64(103)
 		archiveID    = int64(202)
 		metadataName = "provider-release.yaml"
 		archiveName  = "alpha-current.tar.gz"
-		manifestName = providerrelease.ValidationManifestFile
-		catalogName  = providerrelease.ValidationCatalogFile
 	)
 
 	archiveAssetURL := fmt.Sprintf("https://api.github.com/repos/%s/releases/assets/%d", repo, archiveID)
@@ -3762,10 +3758,8 @@ func TestSourceAppGitHubReleaseSourceUsesResolvedAssetURL(t *testing.T) {
 				return
 			}
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = fmt.Fprintf(w, `{"assets":[{"id":%d,"name":"%s"},{"id":%d,"name":"%s"},{"id":%d,"name":"%s"},{"id":%d,"name":"%s"}]}`,
+			_, _ = fmt.Fprintf(w, `{"assets":[{"id":%d,"name":"%s"},{"id":%d,"name":"%s"}]}`,
 				metadataID, metadataName,
-				manifestID, manifestName,
-				catalogID, catalogName,
 				archiveID, archiveName,
 			)
 		case escapedPath == fmt.Sprintf("/repos/%s/releases/assets/%d", repo, metadataID):
@@ -3782,17 +3776,6 @@ func TestSourceAppGitHubReleaseSourceUsesResolvedAssetURL(t *testing.T) {
 			}
 			setYAMLContentType(w)
 			_, _ = w.Write(releaseFixture().Metadata)
-		case escapedPath == fmt.Sprintf("/repos/%s/releases/assets/%d", repo, manifestID):
-			setYAMLContentType(w)
-			_, _ = w.Write(releaseFixture().Manifest)
-		case escapedPath == fmt.Sprintf("/repos/%s/releases/assets/%d", repo, catalogID):
-			files := releaseFixture()
-			if len(files.Catalog) == 0 {
-				http.NotFound(w, r)
-				return
-			}
-			setYAMLContentType(w)
-			_, _ = w.Write(files.Catalog)
 		case escapedPath == fmt.Sprintf("/repos/%s/releases/assets/%d", repo, archiveID):
 			archiveCount.Add(1)
 			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
@@ -3908,7 +3891,7 @@ func TestSourceAppMetadataURLRetriesTransientRemoteMetadataFailure(t *testing.T)
 	const archivePathURL = "/providers/alpha/alpha-current.tar.gz"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case metadataPath, providerReleaseManifestSidecarPath(metadataPath), providerReleaseCatalogSidecarPath(metadataPath):
+		case metadataPath:
 			count := metadataCount.Load()
 			if r.URL.Path == metadataPath {
 				count = metadataCount.Add(1)
@@ -4109,7 +4092,7 @@ func TestSourceAppMetadataURLUnlockedLoadRefreshesMutableMetadata(t *testing.T) 
 	currentArchivePathURL := "/providers/alpha/alpha-current.tar.gz"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case metadataPath, providerReleaseManifestSidecarPath(metadataPath), providerReleaseCatalogSidecarPath(metadataPath):
+		case metadataPath:
 			if r.URL.Path == metadataPath {
 				metadataCount.Add(1)
 			}
@@ -4325,7 +4308,7 @@ func TestSourceAppLoadForExecution_RehydratesWhenCachedManifestVersionMismatches
 	archivePathURL := "/providers/gadget/gadget-current.tar.gz"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case metadataPath, providerReleaseManifestSidecarPath(metadataPath), providerReleaseCatalogSidecarPath(metadataPath):
+		case metadataPath:
 			metadata := providerReleaseMetadataFixture{
 				Package:     source,
 				Kind:        providermanifestv1.KindApp,
@@ -4451,7 +4434,7 @@ func TestSourceAuthAppLoadForExecution(t *testing.T) {
 	archivePathURL := "/providers/auth/auth-current.tar.gz"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case metadataPath, providerReleaseManifestSidecarPath(metadataPath), providerReleaseCatalogSidecarPath(metadataPath):
+		case metadataPath:
 			if r.URL.Path == metadataPath {
 				metadataCount.Add(1)
 			}
@@ -4626,7 +4609,7 @@ func TestSourceAuthAppPrepareAllowsMissingEnvPlaceholderInNonStringField(t *test
 	archivePathURL := "/providers/auth/auth-current.tar.gz"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case metadataPath, providerReleaseManifestSidecarPath(metadataPath), providerReleaseCatalogSidecarPath(metadataPath):
+		case metadataPath:
 			if r.URL.Path == metadataPath {
 				metadataCount.Add(1)
 			}
@@ -4993,7 +4976,7 @@ packages:
 `, secretsSource, secretsVersion, strings.TrimPrefix(secretsMetadataPath, "/"), providerpkg.CurrentPlatformString())
 			w.Header().Set("Content-Type", "application/yaml")
 			_, _ = w.Write([]byte(index))
-		case secretsMetadataPath, providerReleaseManifestSidecarPath(secretsMetadataPath), providerReleaseCatalogSidecarPath(secretsMetadataPath):
+		case secretsMetadataPath:
 			if r.URL.Path == secretsMetadataPath {
 				secretsMetadataCount.Add(1)
 			}
@@ -5016,7 +4999,7 @@ packages:
 			secretsArchiveCount.Add(1)
 			w.Header().Set("Content-Type", "application/octet-stream")
 			_, _ = w.Write(secretsArchiveData)
-		case appMetadataPath, providerReleaseManifestSidecarPath(appMetadataPath), providerReleaseCatalogSidecarPath(appMetadataPath):
+		case appMetadataPath:
 			if r.URL.Path == appMetadataPath {
 				appMetadataCount.Add(1)
 			}
@@ -5546,7 +5529,7 @@ func TestManagedCacheSourcesLockRecordsReleaseMetadataArchives(t *testing.T) {
 			} else {
 				srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					switch r.URL.Path {
-					case metadataPath, providerReleaseManifestSidecarPath(metadataPath), providerReleaseCatalogSidecarPath(metadataPath):
+					case metadataPath:
 						metadata := providerReleaseMetadataFixture{
 							Package:     cacheSource,
 							Kind:        providermanifestv1.KindCache,
@@ -5751,7 +5734,7 @@ func TestSourceSecretsAppBootstrapsManagedAuthSourceToken(t *testing.T) {
 	authArchivePathURL := "/providers/auth/auth.tar.gz"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case secretsMetadataPath, providerReleaseManifestSidecarPath(secretsMetadataPath), providerReleaseCatalogSidecarPath(secretsMetadataPath):
+		case secretsMetadataPath:
 			if r.URL.Path == secretsMetadataPath {
 				secretsMetadataCount.Add(1)
 			}
@@ -5782,7 +5765,7 @@ func TestSourceSecretsAppBootstrapsManagedAuthSourceToken(t *testing.T) {
 			}
 			w.Header().Set("Content-Type", "application/octet-stream")
 			_, _ = w.Write(secretsArchiveData)
-		case authMetadataPath, providerReleaseManifestSidecarPath(authMetadataPath), providerReleaseCatalogSidecarPath(authMetadataPath):
+		case authMetadataPath:
 			if r.URL.Path == authMetadataPath {
 				authMetadataCount.Add(1)
 			}
@@ -6016,7 +5999,7 @@ func TestLoadForExecutionAtPath_UnlockedBootstrapMetadataPreparesOnce(t *testing
 	archivePathURL := "/providers/auth/auth-current.tar.gz"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case metadataPath, providerReleaseManifestSidecarPath(metadataPath), providerReleaseCatalogSidecarPath(metadataPath):
+		case metadataPath:
 			if r.URL.Path == metadataPath {
 				metadataCount.Add(1)
 			}
@@ -6154,7 +6137,7 @@ func TestLoadForExecutionAtPath_UnlockedMetadataSecretsProviderResolvesConfigSec
 	archivePathURL := "/providers/secrets/secrets-current.tar.gz"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case metadataPath, providerReleaseManifestSidecarPath(metadataPath), providerReleaseCatalogSidecarPath(metadataPath):
+		case metadataPath:
 			if r.URL.Path == metadataPath {
 				metadataCount.Add(1)
 			}

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -13,7 +13,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -286,18 +285,6 @@ func newManagedMetadataServer(t *testing.T, releases []managedMetadataRelease) *
 			contentType: "application/yaml",
 			token:       release.token,
 			body:        fixture.Metadata,
-		}
-		routes[path.Dir(release.metadataPath)+"/"+providerrelease.ValidationManifestFile] = response{
-			contentType: "application/yaml",
-			token:       release.token,
-			body:        fixture.Manifest,
-		}
-		if len(fixture.Catalog) != 0 {
-			routes[path.Dir(release.metadataPath)+"/"+providerrelease.ValidationCatalogFile] = response{
-				contentType: "application/yaml",
-				token:       release.token,
-				body:        fixture.Catalog,
-			}
 		}
 		routes[release.archiveURLPath] = response{
 			contentType: "application/octet-stream",
@@ -2457,7 +2444,7 @@ server:
 		t.Fatal("expected provider kind validation error")
 		return
 	}
-	if !strings.Contains(err.Error(), `provider release validation manifest kind "authentication" does not match "app"`) {
+	if !strings.Contains(err.Error(), `app "example" manifest has kind "authentication", want "app"`) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/gestaltd/internal/operator/release_metadata.go
+++ b/gestaltd/internal/operator/release_metadata.go
@@ -102,83 +102,11 @@ func fetchProviderReleaseBundle(ctx context.Context, client *http.Client, metada
 	if err != nil {
 		return providerReleaseValidationBundle{}, "", nil, err
 	}
-	manifest, cat, err := fetchProviderReleaseSidecars(ctx, client, resolvedMetadataLocation, token, metadata, gitHubReleaseAssets)
-	if err != nil {
-		return providerReleaseValidationBundle{}, "", nil, err
-	}
-	if err := providerrelease.ValidateBundle(metadata, manifest, cat); err != nil {
-		return providerReleaseValidationBundle{}, "", nil, err
-	}
-	return providerReleaseValidationBundle{Metadata: metadata, Manifest: manifest, Catalog: cat}, resolvedMetadataLocation, gitHubReleaseAssets, nil
-}
-
-func fetchProviderReleaseSidecars(ctx context.Context, client *http.Client, metadataLocation, token string, metadata *providerrelease.Metadata, gitHubReleaseAssets map[string]string) (*providermanifestv1.Manifest, *catalog.Catalog, error) {
-	if metadata == nil {
-		return nil, nil, fmt.Errorf("provider release metadata is required")
-	}
-	manifestData, err := fetchProviderReleaseSidecar(ctx, client, metadataLocation, token, gitHubReleaseAssets, providerrelease.ValidationManifestFile, metadata.ValidationManifestSHA256)
-	if err != nil {
-		return nil, nil, err
-	}
-	manifest, err := providerrelease.DecodeManifest(manifestData)
-	if err != nil {
-		return nil, nil, fmt.Errorf("decode %s: %w", providerrelease.ValidationManifestFile, err)
-	}
-	var staticCatalog *catalog.Catalog
-	if metadata.ValidationCatalogSHA256 != "" {
-		catalogData, err := fetchProviderReleaseSidecar(ctx, client, metadataLocation, token, gitHubReleaseAssets, providerrelease.ValidationCatalogFile, metadata.ValidationCatalogSHA256)
-		if err != nil {
-			return nil, nil, err
-		}
-		cat, err := providerrelease.DecodeCatalog(catalogData)
-		if err != nil {
-			return nil, nil, fmt.Errorf("decode %s: %w", providerrelease.ValidationCatalogFile, err)
-		}
-		staticCatalog = cat
-	}
-	return manifest, staticCatalog, nil
-}
-
-func fetchProviderReleaseSidecar(ctx context.Context, client *http.Client, metadataLocation, token string, gitHubReleaseAssets map[string]string, name, wantSHA string) ([]byte, error) {
-	sidecarLocation, err := resolveArchiveSourceLocation(metadataLocation, name, gitHubReleaseAssets)
-	if err != nil {
-		return nil, fmt.Errorf("resolve provider release validation sidecar %s: %w", name, err)
-	}
-	data, err := readProviderReleaseSidecar(ctx, client, token, sidecarLocation)
-	if err != nil {
-		return nil, err
-	}
-	if got := providerrelease.SHA256Hex(data); got != strings.TrimSpace(wantSHA) {
-		return nil, fmt.Errorf("provider release validation sidecar %s sha256 %q does not match %q", name, got, strings.TrimSpace(wantSHA))
-	}
-	return data, nil
-}
-
-func readProviderReleaseSidecar(ctx context.Context, client *http.Client, token, location string) ([]byte, error) {
-	if !isRemoteReleaseMetadataLocation(location) {
-		return providerrelease.ReadLocalFile(location)
-	}
-	if client == nil {
-		client = http.DefaultClient
-	}
-	resp, err := doProviderReleaseHTTPRequestWithRetry(ctx, client, func(ctx context.Context) (*http.Request, error) {
-		return newAuthenticatedFetchRequest(ctx, location, token)
-	})
-	if err != nil {
-		return nil, fmt.Errorf("fetch provider release validation sidecar %s: %w", location, err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status %d fetching provider release validation sidecar from %s", resp.StatusCode, location)
-	}
-	data, err := io.ReadAll(io.LimitReader(resp.Body, providerrelease.MaxBytes+1))
-	if err != nil {
-		return nil, fmt.Errorf("read provider release validation sidecar: %w", err)
-	}
-	if len(data) > providerrelease.MaxBytes {
-		return nil, fmt.Errorf("provider release validation sidecar exceeds %d byte limit", providerrelease.MaxBytes)
-	}
-	return data, nil
+	return providerReleaseValidationBundle{
+		Metadata: metadata,
+		Manifest: metadata.StaticValidation.Manifest,
+		Catalog:  metadata.StaticValidation.Catalog,
+	}, resolvedMetadataLocation, gitHubReleaseAssets, nil
 }
 
 func doProviderReleaseHTTPRequestWithRetry(ctx context.Context, client *http.Client, newRequest func(context.Context) (*http.Request, error)) (*http.Response, error) {

--- a/gestaltd/internal/operator/release_metadata_test.go
+++ b/gestaltd/internal/operator/release_metadata_test.go
@@ -7,13 +7,13 @@ func TestResolveArchiveSourceLocationPreservesMetadataQueryForRelativeRefs(t *te
 
 	got, err := resolveArchiveSourceLocation(
 		"https://storage.googleapis.com/snapshots/github.com/acme/providers/ref/app/demo/provider-release.yaml?sourceRef=ref",
-		"validation-catalog.yaml",
+		"app-linux-amd64.tar.gz",
 		nil,
 	)
 	if err != nil {
 		t.Fatalf("resolveArchiveSourceLocation: %v", err)
 	}
-	want := "https://storage.googleapis.com/snapshots/github.com/acme/providers/ref/app/demo/validation-catalog.yaml?sourceRef=ref"
+	want := "https://storage.googleapis.com/snapshots/github.com/acme/providers/ref/app/demo/app-linux-amd64.tar.gz?sourceRef=ref"
 	if got != want {
 		t.Fatalf("resolveArchiveSourceLocation = %q, want %q", got, want)
 	}
@@ -24,13 +24,13 @@ func TestResolveArchiveSourceLocationDoesNotOverrideExplicitQuery(t *testing.T) 
 
 	got, err := resolveArchiveSourceLocation(
 		"https://storage.googleapis.com/snapshots/github.com/acme/providers/ref/app/demo/provider-release.yaml?sourceRef=ref",
-		"validation-catalog.yaml?generation=1",
+		"app-linux-amd64.tar.gz?generation=1",
 		nil,
 	)
 	if err != nil {
 		t.Fatalf("resolveArchiveSourceLocation: %v", err)
 	}
-	want := "https://storage.googleapis.com/snapshots/github.com/acme/providers/ref/app/demo/validation-catalog.yaml?generation=1"
+	want := "https://storage.googleapis.com/snapshots/github.com/acme/providers/ref/app/demo/app-linux-amd64.tar.gz?generation=1"
 	if got != want {
 		t.Fatalf("resolveArchiveSourceLocation = %q, want %q", got, want)
 	}

--- a/gestaltd/internal/operator/release_metadata_test_helpers_test.go
+++ b/gestaltd/internal/operator/release_metadata_test_helpers_test.go
@@ -3,7 +3,6 @@ package operator
 import (
 	"net/http"
 	"os"
-	"path"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -32,8 +31,6 @@ type providerReleaseMetadataFixture struct {
 
 type providerReleaseFixtureFiles struct {
 	Metadata []byte
-	Manifest []byte
-	Catalog  []byte
 }
 
 func newProviderReleaseFixtureFiles(t *testing.T, fixture providerReleaseMetadataFixture) providerReleaseFixtureFiles {
@@ -51,11 +48,6 @@ func newProviderReleaseFixtureFiles(t *testing.T, fixture providerReleaseMetadat
 			Spec:    &providermanifestv1.Spec{},
 		}
 	}
-	manifestData, err := yaml.Marshal(manifest)
-	if err != nil {
-		t.Fatalf("encode validation manifest: %v", err)
-	}
-
 	staticCatalog := fixture.Catalog
 	if staticCatalog == nil && !fixture.NoCatalog && providerrelease.CatalogRequired(fixture.Kind, manifest) && !providerrelease.CatalogSessionModeAllowed(fixture.Kind, manifest) {
 		staticCatalog = &catalog.Catalog{
@@ -65,36 +57,34 @@ func newProviderReleaseFixtureFiles(t *testing.T, fixture providerReleaseMetadat
 			},
 		}
 	}
-	var catalogData []byte
-	if staticCatalog != nil {
-		catalogData, err = yaml.Marshal(staticCatalog)
-		if err != nil {
-			t.Fatalf("encode validation catalog: %v", err)
-		}
-	}
 
 	metadata := &providerrelease.Metadata{
-		Package:                  fixture.Package,
-		Kind:                     fixture.Kind,
-		Version:                  fixture.Version,
-		Artifacts:                providerrelease.Artifacts{},
-		ValidationManifestSHA256: providerrelease.SHA256Hex(manifestData),
+		Schema:        providerrelease.SchemaName,
+		SchemaVersion: providerrelease.SchemaVersion,
+		Package:       fixture.Package,
+		Kind:          fixture.Kind,
+		Version:       fixture.Version,
+		Runtime:       providerrelease.RuntimeForManifest(fixture.Kind, manifest),
+		Artifacts:     providerrelease.Artifacts{},
+		StaticValidation: &providerrelease.StaticValidation{
+			Manifest: manifest,
+			Catalog:  staticCatalog,
+		},
 	}
 	for target, artifact := range fixture.Artifacts {
 		metadata.Artifacts[strings.TrimSpace(target)] = artifact
 	}
-	switch {
-	case staticCatalog != nil:
-		metadata.ValidationCatalogSHA256 = providerrelease.SHA256Hex(catalogData)
+	if staticCatalog == nil && providerrelease.CatalogSessionModeAllowed(fixture.Kind, manifest) {
+		metadata.StaticValidation.CatalogSessionOnly = true
 	}
-	if err := providerrelease.ValidateBundle(metadata, manifest, staticCatalog); err != nil && !fixture.AllowInvalid {
+	if err := providerrelease.ValidateMetadata(metadata); err != nil && !fixture.AllowInvalid {
 		t.Fatalf("validate provider release fixture: %v", err)
 	}
 	metadataData, err := yaml.Marshal(metadata)
 	if err != nil {
 		t.Fatalf("encode provider release metadata: %v", err)
 	}
-	return providerReleaseFixtureFiles{Metadata: metadataData, Manifest: manifestData, Catalog: catalogData}
+	return providerReleaseFixtureFiles{Metadata: metadataData}
 }
 
 func writeProviderReleaseMetadataFileWithStaticValidation(t *testing.T, metadataPath string, fixture providerReleaseMetadataFixture) {
@@ -106,10 +96,6 @@ func writeProviderReleaseMetadataFileWithStaticValidation(t *testing.T, metadata
 		t.Fatalf("create metadata dir: %v", err)
 	}
 	writeProviderReleaseFile(t, metadataPath, files.Metadata)
-	writeProviderReleaseFile(t, filepath.Join(filepath.Dir(metadataPath), providerrelease.ValidationManifestFile), files.Manifest)
-	if len(files.Catalog) != 0 {
-		writeProviderReleaseFile(t, filepath.Join(filepath.Dir(metadataPath), providerrelease.ValidationCatalogFile), files.Catalog)
-	}
 }
 
 func deriveProviderReleaseFixtureFromArchive(t *testing.T, metadataPath string, fixture *providerReleaseMetadataFixture) {
@@ -149,11 +135,14 @@ func deriveProviderReleaseFixtureFromArchive(t *testing.T, metadataPath string, 
 		if err != nil {
 			return
 		}
-		staticCatalog, err := providerrelease.DecodeCatalog(data)
-		if err != nil {
+		var staticCatalog catalog.Catalog
+		if err := yaml.Unmarshal(data, &staticCatalog); err != nil {
 			t.Fatalf("decode fixture archive catalog: %v", err)
 		}
-		fixture.Catalog = staticCatalog
+		if err := staticCatalog.Validate(); err != nil {
+			t.Fatalf("validate fixture archive catalog: %v", err)
+		}
+		fixture.Catalog = &staticCatalog
 	}
 }
 
@@ -165,11 +154,11 @@ func readInvalidFixtureArchiveManifest(t *testing.T, archivePath string) *provid
 		if err != nil {
 			continue
 		}
-		manifest, err := providerrelease.DecodeManifest(data)
-		if err != nil {
+		var manifest providermanifestv1.Manifest
+		if err := yaml.Unmarshal(data, &manifest); err != nil {
 			t.Fatalf("decode invalid fixture archive manifest %s: %v", name, err)
 		}
-		return manifest
+		return &manifest
 	}
 	t.Fatalf("read invalid fixture archive manifest: no root manifest found")
 	return nil
@@ -188,22 +177,10 @@ func serveProviderReleaseFixture(t *testing.T, w httpResponseWriter, requestPath
 
 	deriveProviderReleaseFixtureFromArchive(t, metadataPath, &fixture)
 	files := newProviderReleaseFixtureFiles(t, fixture)
-	base := path.Dir(metadataPath)
 	switch requestPath {
 	case metadataPath:
 		setYAMLContentType(w)
 		_, _ = w.Write(files.Metadata)
-		return true
-	case base + "/" + providerrelease.ValidationManifestFile:
-		setYAMLContentType(w)
-		_, _ = w.Write(files.Manifest)
-		return true
-	case base + "/" + providerrelease.ValidationCatalogFile:
-		if len(files.Catalog) == 0 {
-			return false
-		}
-		setYAMLContentType(w)
-		_, _ = w.Write(files.Catalog)
 		return true
 	default:
 		return false
@@ -213,11 +190,7 @@ func serveProviderReleaseFixture(t *testing.T, w httpResponseWriter, requestPath
 func serveProviderReleaseFixtureForRequest(t *testing.T, w httpResponseWriter, requestPath string, fixture providerReleaseMetadataFixture) bool {
 	t.Helper()
 
-	metadataPath := requestPath
-	if strings.HasSuffix(requestPath, "/"+providerrelease.ValidationManifestFile) || strings.HasSuffix(requestPath, "/"+providerrelease.ValidationCatalogFile) {
-		metadataPath = path.Dir(requestPath) + "/" + providerrelease.MetadataFile
-	}
-	return serveProviderReleaseFixture(t, w, requestPath, metadataPath, fixture)
+	return serveProviderReleaseFixture(t, w, requestPath, requestPath, fixture)
 }
 
 type httpResponseWriter interface {
@@ -227,12 +200,4 @@ type httpResponseWriter interface {
 
 func setYAMLContentType(w httpResponseWriter) {
 	w.Header()["Content-Type"] = []string{"application/yaml"}
-}
-
-func providerReleaseManifestSidecarPath(metadataPath string) string {
-	return path.Dir(metadataPath) + "/" + providerrelease.ValidationManifestFile
-}
-
-func providerReleaseCatalogSidecarPath(metadataPath string) string {
-	return path.Dir(metadataPath) + "/" + providerrelease.ValidationCatalogFile
 }

--- a/gestaltd/internal/operator/testmain_test.go
+++ b/gestaltd/internal/operator/testmain_test.go
@@ -188,24 +188,23 @@ func writeProviderReleaseMetadata(dir string, manifest *providermanifestv1.Manif
 	if err != nil {
 		return err
 	}
-	staticManifestData, err := yaml.Marshal(staticManifest)
-	if err != nil {
-		return err
-	}
-	if err := os.WriteFile(filepath.Join(dir, providerrelease.ValidationManifestFile), staticManifestData, 0o644); err != nil {
-		return err
-	}
 	metadata := providerrelease.Metadata{
-		Package:                  manifest.Source,
-		Kind:                     manifest.Kind,
-		Version:                  manifest.Version,
-		ValidationManifestSHA256: providerrelease.SHA256Hex(staticManifestData),
+		Schema:        providerrelease.SchemaName,
+		SchemaVersion: providerrelease.SchemaVersion,
+		Package:       manifest.Source,
+		Kind:          manifest.Kind,
+		Version:       manifest.Version,
+		Runtime:       providerrelease.RuntimeForManifest(manifest.Kind, staticManifest),
 		Artifacts: providerrelease.Artifacts{
 			providerpkg.CurrentPlatformString(): {
 				Path:   filepath.ToSlash(filepath.Join("..", filepath.Base(archivePath))),
 				SHA256: digest,
 			},
 		},
+		StaticValidation: &providerrelease.StaticValidation{Manifest: staticManifest},
+	}
+	if err := providerrelease.ValidateMetadata(&metadata); err != nil {
+		return err
 	}
 	data, err := yaml.Marshal(metadata)
 	if err != nil {

--- a/gestaltd/internal/providerrelease/release.go
+++ b/gestaltd/internal/providerrelease/release.go
@@ -2,11 +2,8 @@ package providerrelease
 
 import (
 	"bytes"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/valon-technologies/gestalt/server/core/catalog"
@@ -18,23 +15,25 @@ import (
 )
 
 const (
-	MetadataFile           = "provider-release.yaml"
-	ValidationManifestFile = "validation-manifest.yaml"
-	ValidationCatalogFile  = "validation-catalog.yaml"
-	RuntimeExecutable      = "executable"
-	RuntimeDeclarative     = "declarative"
-	RuntimeUI              = "ui"
-	GenericTarget          = "generic"
-	MaxBytes               = 4 << 20
+	MetadataFile       = "provider-release.yaml"
+	SchemaName         = "gestaltd-provider-release"
+	SchemaVersion      = 1
+	RuntimeExecutable  = "executable"
+	RuntimeDeclarative = "declarative"
+	RuntimeUI          = "ui"
+	GenericTarget      = "generic"
+	MaxBytes           = 16 << 20 // One file carries descriptor, validation manifest, and optional catalog.
 )
 
 type Metadata struct {
-	Package                  string    `yaml:"package"`
-	Kind                     string    `yaml:"kind"`
-	Version                  string    `yaml:"version"`
-	Artifacts                Artifacts `yaml:"artifacts"`
-	ValidationManifestSHA256 string    `yaml:"validationManifestSHA256"`
-	ValidationCatalogSHA256  string    `yaml:"validationCatalogSHA256,omitempty"`
+	Schema           string            `yaml:"schema"`
+	SchemaVersion    int               `yaml:"schemaVersion"`
+	Package          string            `yaml:"package"`
+	Kind             string            `yaml:"kind"`
+	Version          string            `yaml:"version"`
+	Runtime          string            `yaml:"runtime"`
+	Artifacts        Artifacts         `yaml:"artifacts"`
+	StaticValidation *StaticValidation `yaml:"staticValidation,omitempty"`
 }
 
 type Artifacts map[string]Artifact
@@ -44,9 +43,27 @@ type Artifact struct {
 	SHA256 string `yaml:"sha256"`
 }
 
-func SHA256Hex(data []byte) string {
-	sum := sha256.Sum256(data)
-	return hex.EncodeToString(sum[:])
+type StaticValidation struct {
+	Manifest           *providermanifestv1.Manifest `yaml:"manifest,omitempty"`
+	Catalog            *catalog.Catalog             `yaml:"catalog,omitempty"`
+	CatalogSessionOnly bool                         `yaml:"catalogSessionOnly,omitempty"`
+}
+
+type staticValidationYAML struct {
+	Manifest           *staticValidationManifestYAML `yaml:"manifest,omitempty"`
+	Catalog            *catalog.Catalog              `yaml:"catalog,omitempty"`
+	CatalogSessionOnly bool                          `yaml:"catalogSessionOnly,omitempty"`
+}
+
+type staticValidationManifestYAML struct {
+	DisplayName string                          `yaml:"displayName,omitempty"`
+	Description string                          `yaml:"description,omitempty"`
+	IconFile    string                          `yaml:"iconFile,omitempty"`
+	Build       *providermanifestv1.SourceBuild `yaml:"build,omitempty"`
+	Run         []string                        `yaml:"run,omitempty"`
+	Artifacts   []providermanifestv1.Artifact   `yaml:"artifacts,omitempty"`
+	Entrypoint  *providermanifestv1.Entrypoint  `yaml:"entrypoint,omitempty"`
+	Spec        *providermanifestv1.Spec        `yaml:"spec,omitempty"`
 }
 
 func Decode(data []byte) (*Metadata, error) {
@@ -56,84 +73,43 @@ func Decode(data []byte) (*Metadata, error) {
 	if err := decoder.Decode(&metadata); err != nil {
 		return nil, fmt.Errorf("decode provider release metadata: %w", err)
 	}
-	if err := validateDescriptor(&metadata); err != nil {
+	if err := ValidateMetadata(&metadata); err != nil {
 		return nil, err
 	}
 	return &metadata, nil
 }
 
-func DecodeManifest(data []byte) (*providermanifestv1.Manifest, error) {
-	var manifest providermanifestv1.Manifest
-	decoder := yaml.NewDecoder(bytes.NewReader(data))
-	decoder.KnownFields(true)
-	if err := decoder.Decode(&manifest); err != nil {
-		return nil, err
-	}
-	return &manifest, nil
+func (s StaticValidation) MarshalYAML() (any, error) {
+	return staticValidationYAML{
+		Manifest:           staticValidationManifestForYAML(s.Manifest),
+		Catalog:            s.Catalog,
+		CatalogSessionOnly: s.CatalogSessionOnly,
+	}, nil
 }
 
-func DecodeCatalog(data []byte) (*catalog.Catalog, error) {
-	var cat catalog.Catalog
-	decoder := yaml.NewDecoder(bytes.NewReader(data))
-	decoder.KnownFields(true)
-	if err := decoder.Decode(&cat); err != nil {
-		return nil, err
+func staticValidationManifestForYAML(manifest *providermanifestv1.Manifest) *staticValidationManifestYAML {
+	if manifest == nil {
+		return nil
 	}
-	return &cat, nil
+	return &staticValidationManifestYAML{
+		DisplayName: manifest.DisplayName,
+		Description: manifest.Description,
+		IconFile:    manifest.IconFile,
+		Build:       manifest.Build,
+		Run:         manifest.Run,
+		Artifacts:   manifest.Artifacts,
+		Entrypoint:  manifest.Entrypoint,
+		Spec:        manifest.Spec,
+	}
 }
 
-func ValidateLocalBundle(metadataPath string) error {
-	metadata, manifestData, catalogData, err := readLocalValidationFiles(metadataPath)
+func ValidateLocalMetadata(metadataPath string) error {
+	data, err := ReadLocalFile(metadataPath)
 	if err != nil {
 		return err
 	}
-	manifest, err := DecodeManifest(manifestData)
-	if err != nil {
-		return fmt.Errorf("decode %s: %w", ValidationManifestFile, err)
-	}
-	var staticCatalog *catalog.Catalog
-	if len(catalogData) != 0 {
-		staticCatalog, err = DecodeCatalog(catalogData)
-		if err != nil {
-			return fmt.Errorf("decode %s: %w", ValidationCatalogFile, err)
-		}
-	}
-	return ValidateBundle(metadata, manifest, staticCatalog)
-}
-
-func readLocalValidationFiles(metadataPath string) (*Metadata, []byte, []byte, error) {
-	data, err := ReadLocalFile(metadataPath)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	metadata, err := Decode(data)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	dir := filepath.Dir(metadataPath)
-	manifestData, err := readVerifiedLocalSidecar(filepath.Join(dir, ValidationManifestFile), metadata.ValidationManifestSHA256)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	var catalogData []byte
-	if metadata.ValidationCatalogSHA256 != "" {
-		catalogData, err = readVerifiedLocalSidecar(filepath.Join(dir, ValidationCatalogFile), metadata.ValidationCatalogSHA256)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-	}
-	return metadata, manifestData, catalogData, nil
-}
-
-func readVerifiedLocalSidecar(path, wantSHA string) ([]byte, error) {
-	data, err := ReadLocalFile(path)
-	if err != nil {
-		return nil, err
-	}
-	if got := SHA256Hex(data); got != strings.TrimSpace(wantSHA) {
-		return nil, fmt.Errorf("provider release validation sidecar %s sha256 %q does not match %q", filepath.Base(path), got, strings.TrimSpace(wantSHA))
-	}
-	return data, nil
+	_, err = Decode(data)
+	return err
 }
 
 func ReadLocalFile(path string) ([]byte, error) {
@@ -147,11 +123,17 @@ func ReadLocalFile(path string) ([]byte, error) {
 	return data, nil
 }
 
-func validateDescriptor(metadata *Metadata) error {
+func ValidateMetadata(metadata *Metadata) error {
 	if metadata == nil {
 		return fmt.Errorf("provider release metadata is required")
 	}
 	metadata.Kind = providermanifestv1.NormalizeKind(metadata.Kind)
+	if metadata.Schema != SchemaName {
+		return fmt.Errorf("unsupported provider release schema %q", metadata.Schema)
+	}
+	if metadata.SchemaVersion != SchemaVersion {
+		return fmt.Errorf("unsupported provider release schema version %d", metadata.SchemaVersion)
+	}
 	if _, err := source.Parse(strings.TrimSpace(metadata.Package)); err != nil {
 		return fmt.Errorf("provider release package: %w", err)
 	}
@@ -166,10 +148,83 @@ func validateDescriptor(metadata *Metadata) error {
 	if _, err := ArtifactsByTarget(metadata.Artifacts); err != nil {
 		return err
 	}
-	if strings.TrimSpace(metadata.ValidationManifestSHA256) == "" {
-		return fmt.Errorf("provider release validation manifest sha256 is required")
+	switch metadata.Runtime {
+	case RuntimeExecutable:
+		if metadata.Kind == providermanifestv1.KindUI {
+			return fmt.Errorf("provider release runtime %q is invalid for kind %q", metadata.Runtime, metadata.Kind)
+		}
+	case RuntimeDeclarative:
+		if metadata.Kind != providermanifestv1.KindApp {
+			return fmt.Errorf("provider release runtime %q is only valid for kind %q", metadata.Runtime, providermanifestv1.KindApp)
+		}
+	case RuntimeUI:
+		if metadata.Kind != providermanifestv1.KindUI {
+			return fmt.Errorf("provider release runtime %q is only valid for kind %q", metadata.Runtime, providermanifestv1.KindUI)
+		}
+	default:
+		return fmt.Errorf("provider release runtime %q is not supported", metadata.Runtime)
+	}
+	if metadata.StaticValidation == nil || metadata.StaticValidation.Manifest == nil {
+		return fmt.Errorf("provider release validation manifest is required")
+	}
+	manifest := metadata.StaticValidation.Manifest
+	inheritValidationManifestIdentity(metadata, manifest)
+	staticCatalog := metadata.StaticValidation.Catalog
+	metadataKind := providermanifestv1.NormalizeKind(metadata.Kind)
+	manifestKind := providermanifestv1.NormalizeKind(manifest.Kind)
+	if manifestKind != metadataKind {
+		return fmt.Errorf("provider release validation manifest kind %q does not match %q", manifestKind, metadataKind)
+	}
+	if source := strings.TrimSpace(manifest.Source); source != "" && source != strings.TrimSpace(metadata.Package) {
+		return fmt.Errorf("provider release validation manifest package %q does not match %q", source, metadata.Package)
+	}
+	if version := strings.TrimSpace(manifest.Version); version != "" && version != strings.TrimSpace(metadata.Version) {
+		return fmt.Errorf("provider release validation manifest version %q does not match %q", version, metadata.Version)
+	}
+	if runtime := RuntimeForManifest(metadataKind, manifest); metadata.Runtime != runtime {
+		return fmt.Errorf("provider release runtime %q does not match validation manifest runtime %q", metadata.Runtime, runtime)
+	}
+	if len(manifest.Artifacts) != 0 {
+		return fmt.Errorf("provider release validation manifest must not include platform artifacts")
+	}
+	if manifest.Entrypoint != nil {
+		return fmt.Errorf("provider release validation manifest must not include entrypoint")
+	}
+	if ManifestReferencesPackageFiles(manifest) {
+		return fmt.Errorf("provider release validation manifest must be self-contained")
+	}
+	if staticCatalog != nil {
+		if err := staticCatalog.Validate(); err != nil {
+			return fmt.Errorf("provider release validation catalog: %w", err)
+		}
+	}
+	switch {
+	case staticCatalog != nil && metadata.StaticValidation.CatalogSessionOnly:
+		return fmt.Errorf("provider release staticValidation.catalogSessionOnly must not be set when catalog metadata is present")
+	case staticCatalog == nil && metadata.StaticValidation.CatalogSessionOnly && !CatalogSessionModeAllowed(metadataKind, manifest):
+		return fmt.Errorf("provider release staticValidation.catalogSessionOnly is only valid for MCP-only validation manifests")
+	case CatalogRequired(metadataKind, manifest) && staticCatalog == nil && !metadata.StaticValidation.CatalogSessionOnly && !CatalogSessionModeAllowed(metadataKind, manifest):
+		return fmt.Errorf("provider release validation for package %q must include catalog metadata unless the validation manifest is MCP-only", metadata.Package)
+	}
+	if _, ok := metadata.Artifacts[GenericTarget]; ok && metadataKind == providermanifestv1.KindApp && RuntimeForManifest(metadataKind, manifest) != RuntimeDeclarative {
+		return fmt.Errorf("provider release generic app artifact requires declarative-only validation manifest")
 	}
 	return nil
+}
+
+func inheritValidationManifestIdentity(metadata *Metadata, manifest *providermanifestv1.Manifest) {
+	if metadata == nil || manifest == nil {
+		return
+	}
+	if strings.TrimSpace(manifest.Kind) == "" {
+		manifest.Kind = metadata.Kind
+	}
+	if strings.TrimSpace(manifest.Source) == "" {
+		manifest.Source = strings.TrimSpace(metadata.Package)
+	}
+	if strings.TrimSpace(manifest.Version) == "" {
+		manifest.Version = strings.TrimSpace(metadata.Version)
+	}
 }
 
 func ArtifactsByTarget(artifacts Artifacts) (map[string]Artifact, error) {
@@ -207,52 +262,6 @@ func ArtifactsByTarget(artifacts Artifacts) (map[string]Artifact, error) {
 		return nil, fmt.Errorf("provider release generic artifact must not be mixed with platform artifacts")
 	}
 	return byTarget, nil
-}
-
-func ValidateBundle(metadata *Metadata, manifest *providermanifestv1.Manifest, staticCatalog *catalog.Catalog) error {
-	if err := validateDescriptor(metadata); err != nil {
-		return err
-	}
-	if manifest == nil {
-		return fmt.Errorf("provider release validation manifest is required")
-	}
-	metadataKind := providermanifestv1.NormalizeKind(metadata.Kind)
-	manifestKind := providermanifestv1.NormalizeKind(manifest.Kind)
-	if manifestKind != metadataKind {
-		return fmt.Errorf("provider release validation manifest kind %q does not match %q", manifestKind, metadataKind)
-	}
-	if source := strings.TrimSpace(manifest.Source); source != "" && source != strings.TrimSpace(metadata.Package) {
-		return fmt.Errorf("provider release validation manifest package %q does not match %q", source, metadata.Package)
-	}
-	if version := strings.TrimSpace(manifest.Version); version != "" && version != strings.TrimSpace(metadata.Version) {
-		return fmt.Errorf("provider release validation manifest version %q does not match %q", version, metadata.Version)
-	}
-	if len(manifest.Artifacts) != 0 {
-		return fmt.Errorf("provider release validation manifest must not include platform artifacts")
-	}
-	if manifest.Entrypoint != nil {
-		return fmt.Errorf("provider release validation manifest must not include entrypoint")
-	}
-	if ManifestReferencesPackageFiles(manifest) {
-		return fmt.Errorf("provider release validation manifest must be self-contained")
-	}
-	if staticCatalog != nil {
-		if err := staticCatalog.Validate(); err != nil {
-			return fmt.Errorf("provider release validation catalog: %w", err)
-		}
-	}
-	switch {
-	case strings.TrimSpace(metadata.ValidationCatalogSHA256) != "" && staticCatalog == nil:
-		return fmt.Errorf("provider release validation catalog sidecar is required")
-	case strings.TrimSpace(metadata.ValidationCatalogSHA256) == "" && staticCatalog != nil:
-		return fmt.Errorf("provider release validation catalog sha256 is required")
-	case CatalogRequired(metadataKind, manifest) && staticCatalog == nil && !CatalogSessionModeAllowed(metadataKind, manifest):
-		return fmt.Errorf("provider release validation for package %q must include catalog metadata unless the validation manifest is MCP-only", metadata.Package)
-	}
-	if _, ok := metadata.Artifacts[GenericTarget]; ok && metadataKind == providermanifestv1.KindApp && RuntimeForManifest(metadataKind, manifest) != RuntimeDeclarative {
-		return fmt.Errorf("provider release generic app artifact requires declarative-only validation manifest")
-	}
-	return nil
 }
 
 func RuntimeForManifest(kind string, manifest *providermanifestv1.Manifest) string {

--- a/gestaltd/internal/providerrelease/release_test.go
+++ b/gestaltd/internal/providerrelease/release_test.go
@@ -1,0 +1,117 @@
+package providerrelease
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"gopkg.in/yaml.v3"
+)
+
+const releaseMetadataWithoutManifestIdentityYAML = `schema: gestaltd-provider-release
+schemaVersion: 1
+package: github.com/acme/providers/app
+kind: app
+version: 1.0.0
+runtime: executable
+artifacts:
+  linux/amd64:
+    path: app-linux-amd64.tar.gz
+    sha256: abc123
+staticValidation:
+  manifest:
+    spec: {}
+  catalog:
+    name: app
+    operations:
+      - id: echo
+        method: POST
+`
+
+func TestMarshalMetadataOmitsStaticValidationManifestIdentity(t *testing.T) {
+	t.Parallel()
+
+	data, err := yaml.Marshal(validReleaseMetadataForTest())
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var raw map[string]any
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	staticValidation := raw["staticValidation"].(map[string]any)
+	manifest := staticValidation["manifest"].(map[string]any)
+	for _, key := range []string{"kind", "source", "version"} {
+		if _, ok := manifest[key]; ok {
+			t.Fatalf("staticValidation.manifest contains duplicated %q in:\n%s", key, data)
+		}
+	}
+}
+
+func TestDecodeMetadataInheritsStaticValidationManifestIdentity(t *testing.T) {
+	t.Parallel()
+
+	metadata, err := Decode([]byte(releaseMetadataWithoutManifestIdentityYAML))
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	manifest := metadata.StaticValidation.Manifest
+	if manifest.Kind != providermanifestv1.KindApp || manifest.Source != metadata.Package || manifest.Version != metadata.Version {
+		t.Fatalf("manifest identity = kind %q source %q version %q, want inherited top-level identity", manifest.Kind, manifest.Source, manifest.Version)
+	}
+}
+
+func TestValidateMetadataRejectsRuntimeMismatch(t *testing.T) {
+	t.Parallel()
+
+	metadata := validReleaseMetadataForTest()
+	metadata.Runtime = RuntimeDeclarative
+
+	err := ValidateMetadata(metadata)
+	if err == nil || !strings.Contains(err.Error(), `runtime "declarative" does not match validation manifest runtime "executable"`) {
+		t.Fatalf("ValidateMetadata error = %v, want runtime mismatch", err)
+	}
+}
+
+func TestValidateMetadataRejectsInvalidCatalogSessionOnly(t *testing.T) {
+	t.Parallel()
+
+	metadata := validReleaseMetadataForTest()
+	metadata.StaticValidation.Catalog = nil
+	metadata.StaticValidation.CatalogSessionOnly = true
+
+	err := ValidateMetadata(metadata)
+	if err == nil || !strings.Contains(err.Error(), "catalogSessionOnly is only valid for MCP-only validation manifests") {
+		t.Fatalf("ValidateMetadata error = %v, want catalogSessionOnly validation failure", err)
+	}
+}
+
+func validReleaseMetadataForTest() *Metadata {
+	return &Metadata{
+		Schema:        SchemaName,
+		SchemaVersion: SchemaVersion,
+		Package:       "github.com/acme/providers/app",
+		Kind:          providermanifestv1.KindApp,
+		Version:       "1.0.0",
+		Runtime:       RuntimeExecutable,
+		Artifacts: Artifacts{
+			"linux/amd64": {Path: "app-linux-amd64.tar.gz", SHA256: "abc123"},
+		},
+		StaticValidation: &StaticValidation{
+			Manifest: &providermanifestv1.Manifest{
+				Kind:    providermanifestv1.KindApp,
+				Source:  "github.com/acme/providers/app",
+				Version: "1.0.0",
+				Spec:    &providermanifestv1.Spec{},
+			},
+			Catalog: &catalog.Catalog{
+				Name: "app",
+				Operations: []catalog.CatalogOperation{{
+					ID:     "echo",
+					Method: "POST",
+				}},
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Summary

Provider releases now use one self-contained `provider-release.yaml` again instead of publishing sibling validation sidecars. The file embeds static validation metadata directly with the release descriptor, so release metadata is the single source of truth for locking and syncing.

This keeps `gestaltd lock` and `gestaltd sync` able to validate released providers from metadata alone without unpacking archives, while matching the one-file release assets already used by toolshed. It also deletes the sidecar fetch, sidecar generation, sidecar upload planning, and sidecar fixture plumbing that became unnecessary.

Provider publish now uploads release archives first and then `provider-release.yaml`. The package command only clears stale finalized metadata, and the docs describe `provider-release.yaml` as the one release metadata artifact.

## Interfaces

```yaml
schema: gestaltd-provider-release
schemaVersion: 1
package: github.com/example/providers/app
kind: app
version: 1.0.0
runtime: executable
artifacts:
  linux/amd64:
    path: app-linux-amd64.tar.gz
    sha256: ...
staticValidation:
  manifest:
    spec:
      allowedOperations: {}
  catalog:
    name: app
    operations: []
```

```sh
gestaltd provider release --dist-dir dist --version 1.0.0
gestaltd provider publish --repo valon --manifest manifest.yaml --version 1.0.0 --ref <sha> --dist-dir dist
```

## Runtime

Provider release resolution decodes static validation directly from `provider-release.yaml`. Local metadata paths, HTTP metadata URLs, and GitHub release metadata assets all use the same single-file decode path.

Lock and sync still verify the selected archive digest before materializing the release. Archive downloads remain separate from metadata downloads, but validation no longer requires extra requests for `validation-manifest.yaml` or `validation-catalog.yaml`.
