### PR TITLE
Merge release catalogs from manifests

### DIFF
--- a/gestaltd/internal/daemon/provider_release_finalize.go
+++ b/gestaltd/internal/daemon/provider_release_finalize.go
@@ -311,15 +311,9 @@ func staticValidationCatalogForRelease(manifest *providermanifestv1.Manifest, ar
 	firstPath := ""
 	found := false
 	for _, archive := range archives {
-		cat, err := staticValidationCatalogFromArchive(manifest, archive)
+		cat, err := staticValidationCatalogFromArchiveManifest(archive)
 		if err != nil {
 			return nil, err
-		}
-		if cat == nil {
-			cat, err = staticValidationCatalogFromArchiveManifest(archive)
-			if err != nil {
-				return nil, err
-			}
 		}
 		if cat == nil {
 			continue
@@ -342,29 +336,6 @@ func staticValidationCatalogForRelease(manifest *providermanifestv1.Manifest, ar
 	return firstCatalog, nil
 }
 
-func staticValidationCatalogFromArchive(manifest *providermanifestv1.Manifest, archive releaseArchive) (*catalog.Catalog, error) {
-	data, err := packageio.ReadArchiveEntry(archive.Path, packageio.StaticCatalogFile)
-	if err != nil {
-		if !packageio.StaticCatalogRequired(manifest) && strings.Contains(err.Error(), "does not contain") {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("read static validation catalog from %s: %w", filepath.Base(archive.Path), err)
-	}
-	var cat catalog.Catalog
-	decoder := yaml.NewDecoder(bytes.NewReader(data))
-	decoder.KnownFields(true)
-	if err := decoder.Decode(&cat); err != nil {
-		return nil, fmt.Errorf("decode static validation catalog from %s: %w", filepath.Base(archive.Path), err)
-	}
-	if strings.TrimSpace(cat.Name) == "" {
-		cat.Name = manifest.Source
-	}
-	if err := cat.Validate(); err != nil {
-		return nil, fmt.Errorf("validate static validation catalog from %s: %w", filepath.Base(archive.Path), err)
-	}
-	return &cat, nil
-}
-
 func staticValidationCatalogFromArchiveManifest(archive releaseArchive) (*catalog.Catalog, error) {
 	tmpDir, err := os.MkdirTemp("", "gestalt-provider-release-catalog-*")
 	if err != nil {
@@ -378,7 +349,7 @@ func staticValidationCatalogFromArchiveManifest(archive releaseArchive) (*catalo
 	if err != nil {
 		return nil, fmt.Errorf("read static validation catalog manifest from %s: %w", filepath.Base(archive.Path), err)
 	}
-	if providermanifestv1.NormalizeKind(manifest.Kind) != providermanifestv1.KindApp || manifest.Spec == nil || !manifest.Spec.IsManifestBacked() {
+	if providermanifestv1.NormalizeKind(manifest.Kind) != providermanifestv1.KindApp || manifest.Spec == nil {
 		return nil, nil
 	}
 	cat, sessionOnly, err := appservice.EffectiveCatalog(context.Background(), manifest.Source, appservice.ValidationAppFromManifest(manifestPath, manifest))

--- a/gestaltd/internal/daemon/provider_release_finalize_test.go
+++ b/gestaltd/internal/daemon/provider_release_finalize_test.go
@@ -215,6 +215,122 @@ paths:
 	}
 }
 
+func TestProviderReleaseMetadataMergesExecutableStaticAndAPICatalogs(t *testing.T) {
+	t.Parallel()
+
+	metadata, _, catalogData, err := buildProviderReleaseBundleForRawManifest(t, `kind: app
+source: github.com/testowner/apps/catalog/release-test
+version: 1.0.0
+displayName: Mixed App
+artifacts:
+  - os: test
+    arch: test
+    path: provider
+    sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+entrypoint:
+  artifactPath: provider
+spec:
+  surfaces:
+    rest:
+      connection: default
+      baseUrl: https://api.example.test
+      operations:
+        - name: createThing
+          method: POST
+          path: /things
+  connections:
+    default:
+      auth:
+        type: none
+`, map[string]string{
+		"provider": "",
+		"catalog.yaml": `name: test
+operations:
+  - id: pluginOp
+    method: POST
+    description: Static plugin operation
+`,
+	})
+	if err != nil {
+		t.Fatalf("buildProviderReleaseMetadata: %v", err)
+	}
+	if metadata.ValidationCatalogSHA256 == "" || len(catalogData) == 0 {
+		t.Fatalf("catalog sidecar missing: sha=%q bytes=%d", metadata.ValidationCatalogSHA256, len(catalogData))
+	}
+	cat, err := providerrelease.DecodeCatalog(catalogData)
+	if err != nil {
+		t.Fatalf("DecodeCatalog: %v", err)
+	}
+	if _, ok := catalog.OperationByID(cat, "pluginOp"); !ok {
+		t.Fatalf("catalog operations = %#v, want pluginOp", cat.Operations)
+	}
+	if _, ok := catalog.OperationByID(cat, "createThing"); !ok {
+		t.Fatalf("catalog operations = %#v, want createThing", cat.Operations)
+	}
+}
+
+func TestProviderReleaseMetadataMergesExecutableStaticAndOpenAPICatalogs(t *testing.T) {
+	t.Parallel()
+
+	metadata, _, catalogData, err := buildProviderReleaseBundleForRawManifest(t, `kind: app
+source: github.com/testowner/apps/catalog/release-test
+version: 1.0.0
+displayName: Mixed OpenAPI App
+artifacts:
+  - os: test
+    arch: test
+    path: provider
+    sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+entrypoint:
+  artifactPath: provider
+spec:
+  surfaces:
+    openapi:
+      connection: default
+      document: openapi.yaml
+  connections:
+    default:
+      auth:
+        type: none
+`, map[string]string{
+		"provider": "",
+		"catalog.yaml": `name: test
+operations:
+  - id: pluginOp
+    method: POST
+    description: Static plugin operation
+`,
+		"openapi.yaml": `openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /teams:
+    get:
+      operationId: getTeams
+      responses:
+        "200":
+          description: ok
+`,
+	})
+	if err != nil {
+		t.Fatalf("buildProviderReleaseMetadata: %v", err)
+	}
+	if metadata.ValidationCatalogSHA256 == "" || len(catalogData) == 0 {
+		t.Fatalf("catalog sidecar missing: sha=%q bytes=%d", metadata.ValidationCatalogSHA256, len(catalogData))
+	}
+	cat, err := providerrelease.DecodeCatalog(catalogData)
+	if err != nil {
+		t.Fatalf("DecodeCatalog: %v", err)
+	}
+	if _, ok := catalog.OperationByID(cat, "pluginOp"); !ok {
+		t.Fatalf("catalog operations = %#v, want pluginOp", cat.Operations)
+	}
+	if _, ok := catalog.OperationByID(cat, "getTeams"); !ok {
+		t.Fatalf("catalog operations = %#v, want getTeams", cat.Operations)
+	}
+}
+
 func TestProviderReleaseMetadataBuildsGraphQLMCPCatalogSidecar(t *testing.T) {
 	t.Parallel()
 
@@ -296,6 +412,43 @@ func buildProviderReleaseBundleForManifest(t *testing.T, manifest *providermanif
 		if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
 			t.Fatalf("write %s: %v", name, err)
 		}
+	}
+	outputDir := t.TempDir()
+	archive := filepath.Join(outputDir, "gestalt-app-release-test_v1.0.0.tar.gz")
+	if err := providerpkg.CreatePackageFromDir(packageDir, archive); err != nil {
+		t.Fatalf("CreatePackageFromDir: %v", err)
+	}
+	archiveSHA, err := providerpkg.ArchiveDigest(archive)
+	if err != nil {
+		t.Fatalf("ArchiveDigest: %v", err)
+	}
+
+	return buildProviderReleaseMetadataAndSidecars(
+		manifest,
+		"1.0.0",
+		[]releaseArchive{{Path: archive, SHA256: archiveSHA, Target: providerpkg.CurrentPlatformString()}},
+	)
+}
+
+func buildProviderReleaseBundleForRawManifest(t *testing.T, rawManifest string, files map[string]string) (*providerrelease.Metadata, []byte, []byte, error) {
+	t.Helper()
+
+	packageDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(packageDir, "manifest.yaml"), []byte(rawManifest), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	for name, contents := range files {
+		path := filepath.Join(packageDir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("create %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	_, manifest, _, err := providerpkg.LoadManifestFromPath(packageDir)
+	if err != nil {
+		t.Fatalf("LoadManifestFromPath: %v", err)
 	}
 	outputDir := t.TempDir()
 	archive := filepath.Join(outputDir, "gestalt-app-release-test_v1.0.0.tar.gz")

--- a/gestaltd/internal/operator/git_source.go
+++ b/gestaltd/internal/operator/git_source.go
@@ -158,10 +158,25 @@ func resolveGitSnapshotSource(cfg *config.Config, entry *config.ProviderEntry) (
 	if err != nil {
 		return gitSnapshotSource{}, err
 	}
+	metadataURL, err := snapshotSourceFileURL(base, snapshotPath, providerrelease.MetadataFile)
+	if err != nil {
+		return gitSnapshotSource{}, err
+	}
 	return gitSnapshotSource{
-		MetadataURL: base + "/" + snapshotPath.FileRelPath("provider-release.yaml"),
+		MetadataURL: metadataURL,
 		GestaltRef:  strings.TrimSpace(repo.GestaltRef),
 	}, nil
+}
+
+func snapshotSourceFileURL(base string, snapshotPath SnapshotSourceRefPath, filename string) (string, error) {
+	parsed, err := url.Parse(strings.TrimRight(strings.TrimSpace(base), "/") + "/" + snapshotPath.FileRelPath(filename))
+	if err != nil {
+		return "", fmt.Errorf("parse snapshot URL: %w", err)
+	}
+	query := parsed.Query()
+	query.Set("sourceRef", snapshotPath.SourceRef)
+	parsed.RawQuery = query.Encode()
+	return parsed.String(), nil
 }
 
 func githubRepoPath(raw string) (string, string, string, error) {

--- a/gestaltd/internal/operator/git_source_test.go
+++ b/gestaltd/internal/operator/git_source_test.go
@@ -1,0 +1,29 @@
+package operator
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSnapshotSourceFileURLAddsSourceRefQuery(t *testing.T) {
+	t.Parallel()
+
+	snapshotPath, err := NewSnapshotSourceRefPath(
+		"https://github.com/valon-technologies/gestalt-providers.git",
+		"CBF01DE477C362F96AACB814F7246F07C7ADB3A0",
+		"app/vercel/manifest.yaml",
+	)
+	if err != nil {
+		t.Fatalf("NewSnapshotSourceRefPath: %v", err)
+	}
+	got, err := snapshotSourceFileURL("https://storage.googleapis.com/snapshots", snapshotPath, "provider-release.yaml")
+	if err != nil {
+		t.Fatalf("snapshotSourceFileURL: %v", err)
+	}
+	if !strings.HasPrefix(got, "https://storage.googleapis.com/snapshots/github.com/valon-technologies/gestalt-providers/cbf01de477c362f96aacb814f7246f07c7adb3a0/app/vercel/provider-release.yaml?") {
+		t.Fatalf("snapshot URL = %q", got)
+	}
+	if !strings.Contains(got, "sourceRef=cbf01de477c362f96aacb814f7246f07c7adb3a0") {
+		t.Fatalf("snapshot URL = %q, want sourceRef query", got)
+	}
+}

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -1083,7 +1083,7 @@ apps:
 	if entry.SourceRef.ResolvedGestaltRef != gestaltRef {
 		t.Fatalf("resolvedGestaltRef = %q, want %q", entry.SourceRef.ResolvedGestaltRef, gestaltRef)
 	}
-	if entry.Source != srv.URL+"/snapshots/github.com/acme/providers/"+ref+"/apps/alpha/provider-release.yaml" {
+	if entry.Source != srv.URL+"/snapshots/github.com/acme/providers/"+ref+"/apps/alpha/provider-release.yaml?sourceRef="+ref {
 		t.Fatalf("source = %q", entry.Source)
 	}
 	if entry.Version != version {

--- a/gestaltd/internal/operator/release_metadata.go
+++ b/gestaltd/internal/operator/release_metadata.go
@@ -438,7 +438,11 @@ func resolveArchiveSourceLocation(metadataLocation, archiveRef string, gitHubRel
 		if err != nil {
 			return "", fmt.Errorf("parse provider release artifact path: %w", err)
 		}
-		return baseURL.ResolveReference(artifactURL).String(), nil
+		resolved := baseURL.ResolveReference(artifactURL)
+		if inheritReleaseMetadataQuery(baseURL, archiveRef, artifactURL) {
+			resolved.RawQuery = baseURL.RawQuery
+		}
+		return resolved.String(), nil
 	}
 	if isRemoteReleaseMetadataLocation(archiveRef) {
 		return archiveRef, nil
@@ -448,6 +452,16 @@ func resolveArchiveSourceLocation(metadataLocation, archiveRef string, gitHubRel
 		return filepath.Clean(archiveRef), nil
 	}
 	return filepath.Clean(filepath.Join(baseDir, filepath.FromSlash(archiveRef))), nil
+}
+
+func inheritReleaseMetadataQuery(base *url.URL, rawRef string, ref *url.URL) bool {
+	return base != nil &&
+		base.Query().Get("sourceRef") != "" &&
+		ref != nil &&
+		ref.Scheme == "" &&
+		ref.Host == "" &&
+		ref.RawQuery == "" &&
+		!strings.HasPrefix(strings.TrimSpace(rawRef), "/")
 }
 
 func copyLocalArchiveForSource(path string) (*providerpkg.DownloadResult, error) {

--- a/gestaltd/internal/operator/release_metadata_test.go
+++ b/gestaltd/internal/operator/release_metadata_test.go
@@ -1,0 +1,37 @@
+package operator
+
+import "testing"
+
+func TestResolveArchiveSourceLocationPreservesMetadataQueryForRelativeRefs(t *testing.T) {
+	t.Parallel()
+
+	got, err := resolveArchiveSourceLocation(
+		"https://storage.googleapis.com/snapshots/github.com/acme/providers/ref/app/demo/provider-release.yaml?sourceRef=ref",
+		"validation-catalog.yaml",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("resolveArchiveSourceLocation: %v", err)
+	}
+	want := "https://storage.googleapis.com/snapshots/github.com/acme/providers/ref/app/demo/validation-catalog.yaml?sourceRef=ref"
+	if got != want {
+		t.Fatalf("resolveArchiveSourceLocation = %q, want %q", got, want)
+	}
+}
+
+func TestResolveArchiveSourceLocationDoesNotOverrideExplicitQuery(t *testing.T) {
+	t.Parallel()
+
+	got, err := resolveArchiveSourceLocation(
+		"https://storage.googleapis.com/snapshots/github.com/acme/providers/ref/app/demo/provider-release.yaml?sourceRef=ref",
+		"validation-catalog.yaml?generation=1",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("resolveArchiveSourceLocation: %v", err)
+	}
+	want := "https://storage.googleapis.com/snapshots/github.com/acme/providers/ref/app/demo/validation-catalog.yaml?generation=1"
+	if got != want {
+		t.Fatalf("resolveArchiveSourceLocation = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Derive release validation catalogs from the effective manifest catalog, so executable static catalogs merge with REST/OpenAPI operations instead of replacing them.
- Add stable sourceRef cache-busting to git snapshot metadata URLs and preserve it for relative sidecars/archives.
- Cover mixed static/API release sidecars and snapshot URL query propagation.

## Test plan
- [x] go test ./internal/daemon -run 'TestProviderReleaseMetadataMergesExecutableStaticAnd(OpenAPI|API)Catalogs|TestProviderReleaseMetadataBuildsOpenAPICatalogSidecar' -count=1\n- [x] go test ./internal/operator -run 'TestSnapshotSourceFileURLAddsSourceRefQuery|TestResolveArchiveSourceLocation|TestLifecycleGitSourceSnapshotRequireContract|TestSourceAppMetadataURLPrepareAndLockedLoad' -count=1\n- [x] go test ./internal/daemon ./internal/operator\n- [x] /tmp/gestaltd-rest-catalog lock --lockfile valon-tools/deploy/gestalt.lock.json --config valon-tools/deploy/config.yaml\n- [x] /tmp/gestaltd-rest-catalog lock --check --lockfile valon-tools/deploy/gestalt.lock.json --config valon-tools/deploy/config.yaml