### PR TITLE
Speed up remote materialized cache writes

### DIFF
--- a/gestaltd/internal/daemon/sync_output.go
+++ b/gestaltd/internal/daemon/sync_output.go
@@ -96,6 +96,18 @@ func writeSyncText(w io.Writer, metrics operator.SyncMetrics, verbose bool) erro
 		); err != nil {
 			return err
 		}
+		if metrics.Cache.Put.Successes > 0 || metrics.Cache.Put.Failures > 0 {
+			if _, err := fmt.Fprintf(w, "Cache put timing: inspect %.3fs, local write %.3fs, remote exists %.3fs, archive %.3fs, upload %.3fs, skipped existing %d.\n",
+				metrics.Cache.Put.LocalInspectSeconds,
+				metrics.Cache.Put.LocalWriteSeconds,
+				metrics.Cache.Put.RemoteExistsSeconds,
+				metrics.Cache.Put.RemoteArchiveSeconds,
+				metrics.Cache.Put.RemoteUploadSeconds,
+				metrics.Cache.Put.RemoteSkippedExisting,
+			); err != nil {
+				return err
+			}
+		}
 		if _, err := fmt.Fprintf(w, "Downloads: %d archives, %s, cumulative download time %.3fs.\n", metrics.Archives.Downloads.Count, formatIECBytes(metrics.Archives.Downloads.Bytes), metrics.Archives.Downloads.DurationSeconds); err != nil {
 			return err
 		}

--- a/gestaltd/internal/daemon/sync_output_test.go
+++ b/gestaltd/internal/daemon/sync_output_test.go
@@ -51,7 +51,15 @@ func TestWriteSyncJSON(t *testing.T) {
 			Mode:          "materialized",
 			BucketVersion: "materialized/v1",
 			Hits:          1,
-			Put:           operator.SyncMetricsCachePut{Successes: 1},
+			Put: operator.SyncMetricsCachePut{
+				Successes:             1,
+				LocalInspectSeconds:   1.1,
+				LocalWriteSeconds:     2.2,
+				RemoteExistsSeconds:   0.3,
+				RemoteArchiveSeconds:  4.4,
+				RemoteUploadSeconds:   5.5,
+				RemoteSkippedExisting: 1,
+			},
 			Entries: []operator.SyncMetricsCacheEntry{{
 				Subject:         "provider \"alpha\"",
 				SourceKind:      "remote_archive",
@@ -129,6 +137,11 @@ func TestWriteSyncJSON(t *testing.T) {
 	if !ok || put["successes"] == nil || put["failures"] == nil {
 		t.Fatalf("cache.put missing successes/failures: %#v", cache["put"])
 	}
+	for _, key := range []string{"local_inspect_seconds", "local_write_seconds", "remote_exists_seconds", "remote_archive_seconds", "remote_upload_seconds", "remote_skipped_existing"} {
+		if _, ok := put[key]; !ok {
+			t.Fatalf("cache.put.%s missing from JSON: %#v", key, put)
+		}
+	}
 }
 
 func TestWriteSyncJSONIncludesEmptyMetricArrays(t *testing.T) {
@@ -180,7 +193,15 @@ func TestWriteSyncText(t *testing.T) {
 			Enabled:    true,
 			Dir:        "/cache",
 			Hits:       1,
-			Put:        operator.SyncMetricsCachePut{Successes: 1},
+			Put: operator.SyncMetricsCachePut{
+				Successes:             1,
+				LocalInspectSeconds:   1.1,
+				LocalWriteSeconds:     2.2,
+				RemoteExistsSeconds:   0.3,
+				RemoteArchiveSeconds:  4.4,
+				RemoteUploadSeconds:   5.5,
+				RemoteSkippedExisting: 1,
+			},
 		},
 		Archives: operator.SyncMetricsArchives{
 			Requests: 3,
@@ -201,6 +222,7 @@ func TestWriteSyncText(t *testing.T) {
 		"Loaded 2 prepared artifacts from lock/config.",
 		"Fetched 3 archives: 2 downloads.",
 		"Cache:",
+		"Cache put timing: inspect 1.100s, local write 2.200s, remote exists 0.300s, archive 4.400s, upload 5.500s, skipped existing 1.",
 		"Downloads: 2 archives",
 		"Prepared output: 4 files",
 		"Prepared artifacts in /prepared in 1.234s.",

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -5175,19 +5175,20 @@ func (l *Lifecycle) materializeLockedArchive(ctx context.Context, paths lifecycl
 	}
 	if cache.dir != "" && cacheEligible {
 		cacheStart := time.Now()
-		key, files, bytes, putErr := cache.Put(ctx, cacheReq, installed.Root)
+		putResult, putErr := cache.Put(ctx, cacheReq, installed.Root)
 		recordSyncCacheEntry(paths, syncCacheMetricsEvent{
 			Subject:    subject,
 			SourceKind: cacheReq.SourceKind,
-			Key:        key.Display,
-			SHA256:     key.ArchiveSHA256,
+			Key:        putResult.Key.Display,
+			SHA256:     putResult.Key.ArchiveSHA256,
 			Platform:   platform,
 			Result:     cacheResult,
 			Put:        true,
 			PutFailed:  putErr != nil,
-			Bytes:      bytes,
-			Files:      files,
+			Bytes:      putResult.Bytes,
+			Files:      putResult.Files,
 			Duration:   time.Since(cacheStart),
+			PutTimings: putResult.Timings,
 		})
 	}
 	activateStart := time.Now()

--- a/gestaltd/internal/operator/materialized_cache.go
+++ b/gestaltd/internal/operator/materialized_cache.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"time"
 )
 
 const (
@@ -91,6 +92,22 @@ type materializedCacheRestore struct {
 
 	cleanup func() error
 	commit  func() error
+}
+
+type materializedCachePutResult struct {
+	Key     materializedCacheKey
+	Files   int
+	Bytes   int64
+	Timings materializedCachePutTimings
+}
+
+type materializedCachePutTimings struct {
+	LocalInspect          time.Duration
+	LocalWrite            time.Duration
+	RemoteExists          time.Duration
+	RemoteArchive         time.Duration
+	RemoteUpload          time.Duration
+	RemoteSkippedExisting bool
 }
 
 func materializedCacheKeyForRequest(req materializedCacheRequest) (materializedCacheKey, bool, error) {
@@ -193,17 +210,22 @@ func materializedCacheRestoreResult(key materializedCacheKey, result materialize
 	return &materializedCacheRestore{Result: result, Key: key}, nil
 }
 
-func (c materializedCache) Put(ctx context.Context, req materializedCacheRequest, sourceDir string) (materializedCacheKey, int, int64, error) {
+func (c materializedCache) Put(ctx context.Context, req materializedCacheRequest, sourceDir string) (materializedCachePutResult, error) {
 	key, eligible, err := materializedCacheKeyForRequest(req)
+	result := materializedCachePutResult{Key: key}
 	if err != nil {
-		return key, 0, 0, err
+		return result, err
 	}
 	if !eligible {
-		return key, 0, 0, nil
+		return result, nil
 	}
+	inspectStart := time.Now()
 	files, bytes, digest, err := inspectMaterializedCacheFiles(sourceDir)
+	result.Timings.LocalInspect = time.Since(inspectStart)
+	result.Files = len(files)
+	result.Bytes = bytes
 	if err != nil {
-		return key, 0, 0, err
+		return result, err
 	}
 	entry := materializedCacheEntry{
 		Schema:              materializedCacheSchema,
@@ -222,14 +244,17 @@ func (c materializedCache) Put(ctx context.Context, req materializedCacheRequest
 		Files:               files,
 	}
 
+	writeStart := time.Now()
 	entryDir := c.entryDir(key)
 	parentDir := filepath.Dir(entryDir)
 	if err := os.MkdirAll(parentDir, 0o755); err != nil {
-		return key, 0, 0, fmt.Errorf("create materialized cache parent: %w", err)
+		result.Timings.LocalWrite = time.Since(writeStart)
+		return result, fmt.Errorf("create materialized cache parent: %w", err)
 	}
 	tmpDir, err := os.MkdirTemp(parentDir, "."+filepath.Base(entryDir)+".tmp-*")
 	if err != nil {
-		return key, 0, 0, fmt.Errorf("create materialized cache temp entry: %w", err)
+		result.Timings.LocalWrite = time.Since(writeStart)
+		return result, fmt.Errorf("create materialized cache temp entry: %w", err)
 	}
 	keepTmp := false
 	defer func() {
@@ -239,41 +264,63 @@ func (c materializedCache) Put(ctx context.Context, req materializedCacheRequest
 	}()
 	rootDir := filepath.Join(tmpDir, materializedCacheRootDir)
 	if err := copyMaterializedFiles(sourceDir, rootDir, files); err != nil {
-		return key, 0, 0, err
+		result.Timings.LocalWrite = time.Since(writeStart)
+		return result, err
 	}
 	data, err := json.MarshalIndent(entry, "", "  ")
 	if err != nil {
-		return key, 0, 0, err
+		result.Timings.LocalWrite = time.Since(writeStart)
+		return result, err
 	}
 	if err := os.WriteFile(filepath.Join(tmpDir, materializedCacheEntryFile), append(data, '\n'), 0o644); err != nil {
-		return key, 0, 0, fmt.Errorf("write materialized cache entry metadata: %w", err)
+		result.Timings.LocalWrite = time.Since(writeStart)
+		return result, fmt.Errorf("write materialized cache entry metadata: %w", err)
 	}
 	if err := os.RemoveAll(entryDir); err != nil {
-		return key, 0, 0, fmt.Errorf("remove stale materialized cache entry: %w", err)
+		result.Timings.LocalWrite = time.Since(writeStart)
+		return result, fmt.Errorf("remove stale materialized cache entry: %w", err)
 	}
 	if err := os.Rename(tmpDir, entryDir); err != nil {
-		return key, 0, 0, fmt.Errorf("commit materialized cache entry: %w", err)
+		result.Timings.LocalWrite = time.Since(writeStart)
+		return result, fmt.Errorf("commit materialized cache entry: %w", err)
 	}
 	keepTmp = true
+	result.Timings.LocalWrite = time.Since(writeStart)
 	if c.remote != nil {
-		archivePath, err := os.CreateTemp(parentDir, "."+filepath.Base(entryDir)+".archive-*.tar.gz")
+		existsStart := time.Now()
+		exists, err := c.remote.Exists(ctx, key)
+		result.Timings.RemoteExists = time.Since(existsStart)
 		if err != nil {
-			return key, len(files), bytes, fmt.Errorf("create materialized cache archive temp file: %w", err)
+			return result, fmt.Errorf("check materialized cache remote object: %w", err)
+		}
+		if exists {
+			result.Timings.RemoteSkippedExisting = true
+			return result, nil
+		}
+		archivePath, err := os.CreateTemp(parentDir, "."+filepath.Base(entryDir)+".archive-*.tar")
+		if err != nil {
+			return result, fmt.Errorf("create materialized cache archive temp file: %w", err)
 		}
 		archiveName := archivePath.Name()
 		if err := archivePath.Close(); err != nil {
 			_ = os.Remove(archiveName)
-			return key, len(files), bytes, fmt.Errorf("close materialized cache archive temp file: %w", err)
+			return result, fmt.Errorf("close materialized cache archive temp file: %w", err)
 		}
 		defer func() { _ = os.Remove(archiveName) }()
+		archiveStart := time.Now()
 		if err := writeMaterializedCacheEntryArchive(entryDir, archiveName); err != nil {
-			return key, len(files), bytes, err
+			result.Timings.RemoteArchive = time.Since(archiveStart)
+			return result, err
 		}
+		result.Timings.RemoteArchive = time.Since(archiveStart)
+		uploadStart := time.Now()
 		if err := c.remote.Put(ctx, key, archiveName); err != nil {
-			return key, len(files), bytes, err
+			result.Timings.RemoteUpload = time.Since(uploadStart)
+			return result, err
 		}
+		result.Timings.RemoteUpload = time.Since(uploadStart)
 	}
-	return key, len(files), bytes, nil
+	return result, nil
 }
 
 func (c materializedCache) entryDir(key materializedCacheKey) string {

--- a/gestaltd/internal/operator/materialized_cache_archive.go
+++ b/gestaltd/internal/operator/materialized_cache_archive.go
@@ -2,7 +2,6 @@ package operator
 
 import (
 	"archive/tar"
-	"compress/gzip"
 	"fmt"
 	"io"
 	"os"
@@ -19,11 +18,7 @@ func writeMaterializedCacheEntryArchive(entryDir, outputPath string) error {
 	}
 	defer func() { _ = out.Close() }()
 
-	gzw := gzip.NewWriter(out)
-	gzw.ModTime = time.Unix(0, 0)
-	defer func() { _ = gzw.Close() }()
-
-	tw := tar.NewWriter(gzw)
+	tw := tar.NewWriter(out)
 	defer func() { _ = tw.Close() }()
 
 	if err := filepath.WalkDir(entryDir, func(absPath string, d os.DirEntry, err error) error {
@@ -87,9 +82,6 @@ func writeMaterializedCacheEntryArchive(entryDir, outputPath string) error {
 	if err := tw.Close(); err != nil {
 		return fmt.Errorf("close materialized cache tar stream: %w", err)
 	}
-	if err := gzw.Close(); err != nil {
-		return fmt.Errorf("close materialized cache gzip stream: %w", err)
-	}
 	if err := out.Close(); err != nil {
 		return fmt.Errorf("close materialized cache archive: %w", err)
 	}
@@ -97,13 +89,7 @@ func writeMaterializedCacheEntryArchive(entryDir, outputPath string) error {
 }
 
 func extractMaterializedCacheEntryArchive(reader io.Reader, destDir string) error {
-	gzr, err := gzip.NewReader(reader)
-	if err != nil {
-		return fmt.Errorf("open materialized cache gzip stream: %w", err)
-	}
-	defer func() { _ = gzr.Close() }()
-
-	tr := tar.NewReader(gzr)
+	tr := tar.NewReader(reader)
 	seen := map[string]struct{}{}
 	for {
 		hdr, err := tr.Next()
@@ -159,9 +145,6 @@ func extractMaterializedCacheEntryArchive(reader io.Reader, destDir string) erro
 	}
 	if _, ok := seen[materializedCacheEntryFile]; !ok {
 		return fmt.Errorf("materialized cache archive missing %s", materializedCacheEntryFile)
-	}
-	if err := gzr.Close(); err != nil {
-		return fmt.Errorf("close materialized cache gzip stream: %w", err)
 	}
 	return nil
 }

--- a/gestaltd/internal/operator/materialized_cache_remote.go
+++ b/gestaltd/internal/operator/materialized_cache_remote.go
@@ -19,6 +19,7 @@ const materializedCacheRemoteScope = "https://www.googleapis.com/auth/devstorage
 
 type materializedCacheRemote interface {
 	Get(context.Context, materializedCacheKey) (io.ReadCloser, bool, error)
+	Exists(context.Context, materializedCacheKey) (bool, error)
 	Put(context.Context, materializedCacheKey, string) error
 }
 
@@ -93,6 +94,30 @@ func (r *gcsMaterializedCacheRemote) Get(ctx context.Context, key materializedCa
 	return resp.Body, true, nil
 }
 
+func (r *gcsMaterializedCacheRemote) Exists(ctx context.Context, key materializedCacheKey) (bool, error) {
+	object := r.objectName(key)
+	client, err := r.httpClient(ctx)
+	if err != nil {
+		return false, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.metadataURL(object), nil)
+	if err != nil {
+		return false, fmt.Errorf("build materialized cache remote metadata request: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("read materialized cache remote object metadata %s: %w", object, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusNotFound {
+		return false, nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return false, gcsMaterializedCacheStatusError("read metadata for", object, resp)
+	}
+	return true, nil
+}
+
 func (r *gcsMaterializedCacheRemote) Put(ctx context.Context, key materializedCacheKey, archivePath string) error {
 	object := r.objectName(key)
 	client, err := r.httpClient(ctx)
@@ -109,7 +134,7 @@ func (r *gcsMaterializedCacheRemote) Put(ctx context.Context, key materializedCa
 	if err != nil {
 		return fmt.Errorf("build materialized cache remote upload request: %w", err)
 	}
-	req.Header.Set("Content-Type", "application/gzip")
+	req.Header.Set("Content-Type", "application/x-tar")
 	if info, err := file.Stat(); err == nil {
 		req.ContentLength = info.Size()
 	}
@@ -140,13 +165,17 @@ func (r *gcsMaterializedCacheRemote) httpClient(ctx context.Context) (*http.Clie
 
 func (r *gcsMaterializedCacheRemote) objectName(key materializedCacheKey) string {
 	if r.prefix == "" {
-		return key.Display + ".tar.gz"
+		return key.Display + ".tar"
 	}
-	return path.Join(r.prefix, key.Display+".tar.gz")
+	return path.Join(r.prefix, key.Display+".tar")
 }
 
 func (r *gcsMaterializedCacheRemote) downloadURL(object string) string {
-	return "https://storage.googleapis.com/storage/v1/b/" + url.PathEscape(r.bucket) + "/o/" + escapeGCSPathSegment(object) + "?alt=media"
+	return r.metadataURL(object) + "?alt=media"
+}
+
+func (r *gcsMaterializedCacheRemote) metadataURL(object string) string {
+	return "https://storage.googleapis.com/storage/v1/b/" + url.PathEscape(r.bucket) + "/o/" + escapeGCSPathSegment(object)
 }
 
 func (r *gcsMaterializedCacheRemote) uploadURL(object string) string {

--- a/gestaltd/internal/operator/materialized_cache_remote_test.go
+++ b/gestaltd/internal/operator/materialized_cache_remote_test.go
@@ -19,13 +19,21 @@ func TestGCSMaterializedCacheRemoteHTTPContracts(t *testing.T) {
 		t.Fatalf("materializedCacheKeyForRequest eligible=%t err=%v", eligible, err)
 	}
 
-	objectName := "prefix/" + key.Display + ".tar.gz"
+	objectName := "prefix/" + key.Display + ".tar"
 	var sawDownload bool
+	var sawExists bool
 	var sawUpload bool
 	remote := &gcsMaterializedCacheRemote{
 		client: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 			switch r.Method {
 			case http.MethodGet:
+				if r.URL.Query().Get("alt") == "" {
+					sawExists = true
+					if got := r.URL.EscapedPath(); got != "/storage/v1/b/cache-bucket/o/"+escapeGCSPathSegment(objectName) {
+						t.Fatalf("exists escaped path = %q, want encoded object path", got)
+					}
+					return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(http.NoBody)}, nil
+				}
 				sawDownload = true
 				if got := r.URL.Query().Get("alt"); got != "media" {
 					t.Fatalf("download alt query = %q, want media", got)
@@ -45,8 +53,8 @@ func TestGCSMaterializedCacheRemoteHTTPContracts(t *testing.T) {
 				if got := r.URL.Query().Get("name"); got != objectName {
 					t.Fatalf("upload name = %q, want %q", got, objectName)
 				}
-				if got := r.Header.Get("Content-Type"); got != "application/gzip" {
-					t.Fatalf("upload content type = %q, want application/gzip", got)
+				if got := r.Header.Get("Content-Type"); got != "application/x-tar" {
+					t.Fatalf("upload content type = %q, want application/x-tar", got)
 				}
 				return &http.Response{StatusCode: http.StatusPreconditionFailed, Body: io.NopCloser(http.NoBody)}, nil
 			default:
@@ -65,16 +73,23 @@ func TestGCSMaterializedCacheRemoteHTTPContracts(t *testing.T) {
 	if reader != nil || hit {
 		t.Fatalf("Get hit=%t reader=%v, want 404 miss", hit, reader)
 	}
+	exists, err := remote.Exists(context.Background(), key)
+	if err != nil {
+		t.Fatalf("Exists: %v", err)
+	}
+	if exists {
+		t.Fatal("Exists = true, want 404 miss")
+	}
 
-	archivePath := filepath.Join(dir, "entry.tar.gz")
+	archivePath := filepath.Join(dir, "entry.tar")
 	if err := os.WriteFile(archivePath, []byte("archive"), 0o644); err != nil {
 		t.Fatalf("write archive: %v", err)
 	}
 	if err := remote.Put(context.Background(), key, archivePath); err != nil {
 		t.Fatalf("Put: %v", err)
 	}
-	if !sawDownload || !sawUpload {
-		t.Fatalf("saw download/upload = %t/%t, want both", sawDownload, sawUpload)
+	if !sawDownload || !sawExists || !sawUpload {
+		t.Fatalf("saw download/exists/upload = %t/%t/%t, want all", sawDownload, sawExists, sawUpload)
 	}
 }
 

--- a/gestaltd/internal/operator/materialized_cache_test.go
+++ b/gestaltd/internal/operator/materialized_cache_test.go
@@ -3,7 +3,6 @@ package operator
 import (
 	"archive/tar"
 	"bytes"
-	"compress/gzip"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -26,7 +25,7 @@ func TestMaterializedCachePreservesEmptyDirectories(t *testing.T) {
 
 	req := materializedCacheUIRequest(dir, "alpha", "dest")
 	cache := materializedCache{dir: filepath.Join(dir, "cache")}
-	if _, _, _, err := cache.Put(context.Background(), req, source); err != nil {
+	if _, err := cache.Put(context.Background(), req, source); err != nil {
 		t.Fatalf("Put: %v", err)
 	}
 	restore, err := cache.Restore(context.Background(), req)
@@ -52,7 +51,7 @@ func TestMaterializedCacheRestoresSharedArchiveForDifferentSubjects(t *testing.T
 	source := writeMaterializedCacheUISource(t, dir, "source")
 	cache := materializedCache{dir: filepath.Join(dir, "cache")}
 	req := materializedCacheUIRequest(dir, "alpha", "dest-alpha")
-	if _, _, _, err := cache.Put(context.Background(), req, source); err != nil {
+	if _, err := cache.Put(context.Background(), req, source); err != nil {
 		t.Fatalf("Put: %v", err)
 	}
 
@@ -75,7 +74,7 @@ func TestMaterializedCacheRestoresRemoteEntry(t *testing.T) {
 	source := writeMaterializedCacheUISource(t, dir, "source")
 	req := materializedCacheUIRequest(dir, "alpha", "dest")
 
-	if _, _, _, err := (materializedCache{dir: filepath.Join(dir, "cold"), remote: remote}).Put(context.Background(), req, source); err != nil {
+	if _, err := (materializedCache{dir: filepath.Join(dir, "cold"), remote: remote}).Put(context.Background(), req, source); err != nil {
 		t.Fatalf("Put: %v", err)
 	}
 	if remote.puts != 1 {
@@ -127,6 +126,64 @@ func TestMaterializedCacheTreatsUnsafeRemoteArchiveAsInvalid(t *testing.T) {
 	if restore == nil || restore.Result != materializedCacheInvalid {
 		t.Fatalf("Restore unsafe remote archive = %#v, want invalid", restore)
 	}
+}
+
+func TestMaterializedCachePutSkipsRemoteArchiveWhenObjectExists(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	remote := newFakeMaterializedCacheRemote()
+	remote.exists = true
+	source := writeMaterializedCacheUISource(t, dir, "source")
+	req := materializedCacheUIRequest(dir, "alpha", "dest")
+	cache := materializedCache{dir: filepath.Join(dir, "cache"), remote: remote}
+
+	result, err := cache.Put(context.Background(), req, source)
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if remote.existsCalls != 1 {
+		t.Fatalf("remote exists calls = %d, want 1", remote.existsCalls)
+	}
+	if remote.puts != 0 {
+		t.Fatalf("remote puts = %d, want 0", remote.puts)
+	}
+	if !result.Timings.RemoteSkippedExisting {
+		t.Fatal("RemoteSkippedExisting = false, want true")
+	}
+	if result.Timings.RemoteArchive != 0 || result.Timings.RemoteUpload != 0 {
+		t.Fatalf("remote archive/upload timings = %s/%s, want zero", result.Timings.RemoteArchive, result.Timings.RemoteUpload)
+	}
+	assertNoMaterializedCacheArchiveTemps(t, filepath.Join(dir, "cache"), result.Key)
+}
+
+func TestMaterializedCachePutRemoteExistsErrorSkipsArchive(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	remote := newFakeMaterializedCacheRemote()
+	remote.existsErr = errors.New("metadata unavailable")
+	source := writeMaterializedCacheUISource(t, dir, "source")
+	req := materializedCacheUIRequest(dir, "alpha", "dest")
+	cache := materializedCache{dir: filepath.Join(dir, "cache"), remote: remote}
+
+	result, err := cache.Put(context.Background(), req, source)
+	if err == nil {
+		t.Fatal("Put error = nil, want remote exists error")
+	}
+	if remote.existsCalls != 1 {
+		t.Fatalf("remote exists calls = %d, want 1", remote.existsCalls)
+	}
+	if remote.puts != 0 {
+		t.Fatalf("remote puts = %d, want 0", remote.puts)
+	}
+	if result.Files == 0 || result.Bytes == 0 {
+		t.Fatalf("put result files/bytes = %d/%d, want populated result", result.Files, result.Bytes)
+	}
+	if result.Timings.RemoteArchive != 0 || result.Timings.RemoteUpload != 0 {
+		t.Fatalf("remote archive/upload timings = %s/%s, want zero", result.Timings.RemoteArchive, result.Timings.RemoteUpload)
+	}
+	assertNoMaterializedCacheArchiveTemps(t, filepath.Join(dir, "cache"), result.Key)
 }
 
 func writeMaterializedCacheUISource(t *testing.T, dir, name string) string {
@@ -218,10 +275,13 @@ func materializedCacheTestSHA256Hex(data []byte) string {
 }
 
 type fakeMaterializedCacheRemote struct {
-	objects map[string][]byte
-	gets    int
-	puts    int
-	getErr  error
+	objects     map[string][]byte
+	gets        int
+	existsCalls int
+	puts        int
+	exists      bool
+	getErr      error
+	existsErr   error
 }
 
 func newFakeMaterializedCacheRemote() *fakeMaterializedCacheRemote {
@@ -240,6 +300,14 @@ func (r *fakeMaterializedCacheRemote) Get(_ context.Context, key materializedCac
 	return io.NopCloser(bytes.NewReader(data)), true, nil
 }
 
+func (r *fakeMaterializedCacheRemote) Exists(_ context.Context, _ materializedCacheKey) (bool, error) {
+	r.existsCalls++
+	if r.existsErr != nil {
+		return false, r.existsErr
+	}
+	return r.exists, nil
+}
+
 func (r *fakeMaterializedCacheRemote) Put(_ context.Context, key materializedCacheKey, archivePath string) error {
 	r.puts++
 	data, err := os.ReadFile(archivePath)
@@ -254,8 +322,7 @@ func materializedCacheUnsafeArchive(t *testing.T) []byte {
 	t.Helper()
 
 	var buf bytes.Buffer
-	gzw := gzip.NewWriter(&buf)
-	tw := tar.NewWriter(gzw)
+	tw := tar.NewWriter(&buf)
 	if err := tw.WriteHeader(&tar.Header{
 		Name:     materializedCacheRootDir + "/link",
 		Typeflag: tar.TypeSymlink,
@@ -267,8 +334,17 @@ func materializedCacheUnsafeArchive(t *testing.T) []byte {
 	if err := tw.Close(); err != nil {
 		t.Fatalf("close unsafe archive tar: %v", err)
 	}
-	if err := gzw.Close(); err != nil {
-		t.Fatalf("close unsafe archive gzip: %v", err)
-	}
 	return buf.Bytes()
+}
+
+func assertNoMaterializedCacheArchiveTemps(t *testing.T, cacheDir string, key materializedCacheKey) {
+	t.Helper()
+
+	matches, err := filepath.Glob(filepath.Join(filepath.Dir((materializedCache{dir: cacheDir}).entryDir(key)), ".*.archive-*.tar"))
+	if err != nil {
+		t.Fatalf("glob archive temp files: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("archive temp files = %v, want none", matches)
+	}
 }

--- a/gestaltd/internal/operator/sync_metrics.go
+++ b/gestaltd/internal/operator/sync_metrics.go
@@ -114,8 +114,14 @@ type SyncMetricsCache struct {
 }
 
 type SyncMetricsCachePut struct {
-	Successes int `json:"successes"`
-	Failures  int `json:"failures"`
+	Successes             int     `json:"successes"`
+	Failures              int     `json:"failures"`
+	LocalInspectSeconds   float64 `json:"local_inspect_seconds"`
+	LocalWriteSeconds     float64 `json:"local_write_seconds"`
+	RemoteExistsSeconds   float64 `json:"remote_exists_seconds"`
+	RemoteArchiveSeconds  float64 `json:"remote_archive_seconds"`
+	RemoteUploadSeconds   float64 `json:"remote_upload_seconds"`
+	RemoteSkippedExisting int     `json:"remote_skipped_existing"`
 }
 
 type SyncMetricsCacheEntry struct {
@@ -216,6 +222,7 @@ type syncCacheMetricsEvent struct {
 	Bytes      int64
 	Files      int
 	Duration   time.Duration
+	PutTimings materializedCachePutTimings
 }
 
 func NewSyncMetricsRecorder() *SyncMetricsRecorder {
@@ -403,6 +410,14 @@ func (r *SyncMetricsRecorder) RecordCacheEntry(event syncCacheMetricsEvent) {
 		} else {
 			r.metrics.Cache.Put.Successes++
 			put = syncCachePutSuccess
+		}
+		r.metrics.Cache.Put.LocalInspectSeconds = roundedSeconds(secondsDuration(r.metrics.Cache.Put.LocalInspectSeconds) + event.PutTimings.LocalInspect)
+		r.metrics.Cache.Put.LocalWriteSeconds = roundedSeconds(secondsDuration(r.metrics.Cache.Put.LocalWriteSeconds) + event.PutTimings.LocalWrite)
+		r.metrics.Cache.Put.RemoteExistsSeconds = roundedSeconds(secondsDuration(r.metrics.Cache.Put.RemoteExistsSeconds) + event.PutTimings.RemoteExists)
+		r.metrics.Cache.Put.RemoteArchiveSeconds = roundedSeconds(secondsDuration(r.metrics.Cache.Put.RemoteArchiveSeconds) + event.PutTimings.RemoteArchive)
+		r.metrics.Cache.Put.RemoteUploadSeconds = roundedSeconds(secondsDuration(r.metrics.Cache.Put.RemoteUploadSeconds) + event.PutTimings.RemoteUpload)
+		if event.PutTimings.RemoteSkippedExisting {
+			r.metrics.Cache.Put.RemoteSkippedExisting++
 		}
 	}
 	entry := SyncMetricsCacheEntry{

--- a/gestaltd/internal/operator/sync_metrics_test.go
+++ b/gestaltd/internal/operator/sync_metrics_test.go
@@ -76,11 +76,27 @@ func TestSyncMetricsRecorderCountsCacheLookupAndPutSeparately(t *testing.T) {
 		SourceKind: syncArtifactSourceRemoteArchive,
 		Result:     syncCacheResultMiss,
 		Put:        true,
+		PutTimings: materializedCachePutTimings{
+			LocalInspect:          1100 * time.Millisecond,
+			LocalWrite:            2200 * time.Millisecond,
+			RemoteExists:          300 * time.Millisecond,
+			RemoteArchive:         4400 * time.Millisecond,
+			RemoteUpload:          5500 * time.Millisecond,
+			RemoteSkippedExisting: true,
+		},
 	})
 
 	cache := recorder.Snapshot().Cache
 	if cache.Eligible != 1 || cache.Misses != 1 || cache.Put.Successes != 1 {
 		t.Fatalf("cache counts = eligible %d, misses %d, put successes %d; want 1, 1, 1", cache.Eligible, cache.Misses, cache.Put.Successes)
+	}
+	if cache.Put.LocalInspectSeconds != 1.1 ||
+		cache.Put.LocalWriteSeconds != 2.2 ||
+		cache.Put.RemoteExistsSeconds != 0.3 ||
+		cache.Put.RemoteArchiveSeconds != 4.4 ||
+		cache.Put.RemoteUploadSeconds != 5.5 ||
+		cache.Put.RemoteSkippedExisting != 1 {
+		t.Fatalf("cache put timings = %+v, want aggregated timing fields", cache.Put)
 	}
 	if len(cache.Entries) != 2 {
 		t.Fatalf("cache entries len = %d, want 2", len(cache.Entries))


### PR DESCRIPTION
## Summary

Speeds up `gestaltd sync` remote materialized cache writes by removing gzip compression from remote cache entries and by checking whether a remote entry already exists before building an upload archive.

Remote materialized cache objects now use plain tar archives with `.tar` names and `application/x-tar` uploads. There is intentionally no fallback for old `.tar.gz` remote cache objects; those entries cold-miss and are repopulated in the new format.

The sync metrics now expose aggregate `cache.put.*` timing so deploy profiling can separate local cache inspection, local cache writes, remote existence checks, archive creation, uploads, and skipped-existing entries.

## Interfaces

The CLI surface stays the same:

```bash
GESTALTD_SYNC_CACHE_REMOTE=gs://bucket/prefix \
  gestaltd sync --locked --cache-dir /cache/gestaltd-materialized --output-format=json
```

Remote cache objects use the same materialized cache key, but with a plain tar suffix:

```text
gs://bucket/prefix/materialized/v1/linux_amd64/sha256/ab/<archive-sha>/<resolved-key-hash>.tar
```

Sync JSON includes the new aggregate put timing fields under `cache.put`:

```json
{
  "cache": {
    "put": {
      "successes": 111,
      "failures": 0,
      "local_inspect_seconds": 12.43,
      "local_write_seconds": 48.221,
      "remote_exists_seconds": 3.104,
      "remote_archive_seconds": 71.552,
      "remote_upload_seconds": 32.918,
      "remote_skipped_existing": 8
    }
  }
}
```

## Runtime

The materialized cache still writes the local entry directory first so a sync can reuse the entry within the same run and preserve the existing non-fatal remote write behavior. When a remote cache is configured, `gestaltd` now performs a GCS metadata read for the target object before creating the upload tar.

If the object exists, archive creation and upload are skipped. If the object is missing, `gestaltd` writes an uncompressed tar and uploads it with the existing `ifGenerationMatch=0` create-only guard. If another writer wins that race, GCS returns `412 Precondition Failed` and the cache put still counts as successful.

Remote metadata errors are recorded as cache put failures without failing the sync, which keeps remote cache writes best-effort while making the failure visible through `cache.put.failures` and the new timing metrics.
