### PR TITLE
[codex] Preserve locked validation catalogs during sync

### DIFF
--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -3228,9 +3228,7 @@ func (l *Lifecycle) resolveLockedProvider(ctx context.Context, cfg *config.Confi
 		entry.InputDigest = fingerprint
 		provider.ResolvedManifest = entry.ValidationManifest
 		provider.ResolvedManifestPath = ""
-		provider.ResolvedCatalog = catalogFromValidationManifest(entry.ValidationManifest, entry.CatalogAvailable)
-		provider.ResolvedCatalogAvailable = entry.CatalogAvailable
-		provider.ResolvedCatalogSessionOnly = entry.CatalogSessionOnly
+		bindLockValidationCatalog(provider, entry)
 		return entry, nil
 	}
 	if err := providerpkg.ValidateConfigForManifest(installed.ManifestPath, installed.Manifest, kind, configMap); err != nil {
@@ -3674,9 +3672,7 @@ func attachStaticValidationMetadata(lock *Lockfile, cfg *config.Config, catalogs
 			lockEntry.CatalogFingerprint = fingerprint
 		}
 		lock.Providers.App[name] = lockEntry
-		entry.ResolvedCatalog = catalogFromValidationManifest(lockEntry.ValidationManifest, lockEntry.CatalogAvailable)
-		entry.ResolvedCatalogAvailable = lockEntry.CatalogAvailable
-		entry.ResolvedCatalogSessionOnly = lockEntry.CatalogSessionOnly
+		bindLockValidationCatalog(entry, lockEntry)
 	}
 	for _, collection := range hostProviderCollections(cfg) {
 		entries := lockEntriesForKind(lock, collection.kind)
@@ -3841,6 +3837,15 @@ func catalogFromValidationManifest(manifest *providermanifestv1.Manifest, availa
 		cat.Operations = append(cat.Operations, catalog.CatalogOperation{ID: id})
 	}
 	return cat
+}
+
+func bindLockValidationCatalog(provider *config.ProviderEntry, entry LockEntry) {
+	if provider == nil {
+		return
+	}
+	provider.ResolvedCatalog = catalogFromValidationManifest(entry.ValidationManifest, entry.CatalogAvailable)
+	provider.ResolvedCatalogAvailable = entry.CatalogAvailable
+	provider.ResolvedCatalogSessionOnly = entry.CatalogSessionOnly
 }
 
 func staticCatalogInputFingerprint(entry *config.ProviderEntry) (string, error) {
@@ -4072,9 +4077,7 @@ func (l *Lifecycle) applyStaticValidationEntry(ctx context.Context, paths lifecy
 					return lockMetadataStaleError(paths, "lock entry for %s %q is stale", kind, name)
 				}
 			}
-			provider.ResolvedCatalog = catalogFromValidationManifest(entry.ValidationManifest, entry.CatalogAvailable)
-			provider.ResolvedCatalogAvailable = entry.CatalogAvailable
-			provider.ResolvedCatalogSessionOnly = entry.CatalogSessionOnly
+			bindLockValidationCatalog(provider, entry)
 			return bind("", entry.ValidationManifest)
 		}
 	}
@@ -4864,7 +4867,13 @@ func (l *Lifecycle) applyLockedProviderEntry(paths lifecyclePaths, lock *Lockfil
 	if !needMaterialize {
 		recordSyncArtifact(paths, providermanifestv1.KindApp, name, fmt.Sprintf("provider %q", name), destDir, syncArtifactArchiveSourceKind(paths, entry), syncArtifactResultReused, syncArtifactReasonFresh, start, 0, 0)
 	}
-	return bindPreparedProviderInstall(paths, name, app, configMap, install)
+	if err := bindPreparedProviderInstall(paths, name, app, configMap, install); err != nil {
+		return err
+	}
+	if lockEntryHasCompleteStaticValidation(providermanifestv1.KindApp, entry) {
+		bindLockValidationCatalog(app, entry)
+	}
+	return nil
 }
 
 func (l *Lifecycle) applyLockedComponentEntry(paths lifecyclePaths, entry *LockEntry, kind, name string, app *config.ProviderEntry, configMap map[string]any, destDir string, mode artifactMode) error {

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -1670,6 +1670,62 @@ server:
 	}
 }
 
+func TestSyncAtPathsUsesLockedStaticValidationCatalogForOpenAPIProvider(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	artifactsDir := filepath.Join(dir, "artifacts")
+	packageSource := "github.com/acme/tools/static-openapi"
+	version := "1.2.3"
+	archivePath := buildExecutableArchiveDataWithSpec(t, dir, "static-openapi-src", packageSource, version, providermanifestv1.KindApp, "static-openapi", []byte("static-openapi-binary"), withNoAuthDefaultConnection(&providermanifestv1.Spec{
+		Surfaces: &providermanifestv1.ProviderSurfaces{
+			OpenAPI: &providermanifestv1.OpenAPISurface{Document: "http://127.0.0.1:1/openapi.yaml"},
+		},
+	}))
+	archiveSHA, err := providerpkg.ArchiveDigest(archivePath)
+	if err != nil {
+		t.Fatalf("ArchiveDigest: %v", err)
+	}
+
+	metadataPath := filepath.Join(dir, "provider-release.yaml")
+	writeProviderReleaseMetadataFileWithStaticValidation(t, metadataPath, providerReleaseMetadataFixture{
+		Package:     packageSource,
+		Kind:        providermanifestv1.KindApp,
+		Version:     version,
+		ArchivePath: archivePath,
+		Artifacts: map[string]providerrelease.Artifact{
+			providerpkg.CurrentPlatformString(): {
+				Path:   filepath.Base(archivePath),
+				SHA256: archiveSHA,
+			},
+		},
+	})
+
+	configPath := filepath.Join(dir, "gestaltd.yaml")
+	configYAML := fmt.Sprintf(`
+apiVersion: %s
+%sapps:
+  static-openapi:
+    source: %s
+server:
+  providers:
+    indexeddb: sqlite
+  artifactsDir: %s
+  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`, config.ConfigAPIVersion, requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")), filepath.ToSlash(metadataPath), filepath.ToSlash(artifactsDir))
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	lc := NewLifecycle()
+	if _, err := lc.LockAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
+		t.Fatalf("LockAtPathsWithStatePaths: %v", err)
+	}
+	if err := lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{Parallelism: 1}); err != nil {
+		t.Fatalf("SyncAtPathsWithStatePathsOptions: %v", err)
+	}
+}
+
 func TestLockAtPathsRejectsProviderReleaseWhenStaticValidationCatalogMissing(t *testing.T) {
 	t.Parallel()
 
@@ -1850,6 +1906,12 @@ func buildExecutableArchiveFromBinaryPath(t *testing.T, dir, srcDirName, source,
 func buildExecutableArchiveData(t *testing.T, dir, srcDirName, source, version, kind, binaryName string, binaryData []byte) string {
 	t.Helper()
 
+	return buildExecutableArchiveDataWithSpec(t, dir, srcDirName, source, version, kind, binaryName, binaryData, &providermanifestv1.Spec{})
+}
+
+func buildExecutableArchiveDataWithSpec(t *testing.T, dir, srcDirName, source, version, kind, binaryName string, binaryData []byte, spec *providermanifestv1.Spec) string {
+	t.Helper()
+
 	artPath := artifactRelPath(binaryName)
 	srcDir := filepath.Join(dir, srcDirName)
 	if err := os.MkdirAll(filepath.Join(srcDir, filepath.Dir(filepath.FromSlash(artPath))), 0755); err != nil {
@@ -1871,7 +1933,7 @@ func buildExecutableArchiveData(t *testing.T, dir, srcDirName, source, version, 
 		},
 	}
 	manifest.Kind = kind
-	manifest.Spec = &providermanifestv1.Spec{}
+	manifest.Spec = spec
 	manifest.Entrypoint = &providermanifestv1.Entrypoint{ArtifactPath: artPath}
 
 	manifestBytes, err := providerpkg.EncodeManifest(manifest)


### PR DESCRIPTION
## Summary
- Preserve static validation catalog metadata from locked provider entries after sync binds a prepared provider install.
- Reuse the existing lock catalog binding helper everywhere lifecycle restores catalog fields.
- Add a regression for locked sync of an executable OpenAPI provider whose live OpenAPI URL is unreachable, proving sync uses the lock metadata instead of fetching the remote document.

## Test plan
- [x] go test ./gestaltd/internal/operator -run TestSyncAtPathsUsesLockedStaticValidationCatalogForOpenAPIProvider -count=1
- [x] go test ./gestaltd/internal/operator -run 'Test(LockAtPathsUsesProviderReleaseStaticValidationWithoutUnpackingArchive|LockAtPathsRejectsProviderReleaseWhenStaticValidationCatalogMissing|LockAtPathsRejectsPackageLocalStaticValidationSurfaceAsSelfContained|SyncAtPathsUsesLockedStaticValidationCatalogForOpenAPIProvider)$' -count=1