### PR TITLE
Fix Python agent output proto construction

### DIFF
--- a/sdk/python/gestalt/_agent.py
+++ b/sdk/python/gestalt/_agent.py
@@ -873,13 +873,13 @@ def _agent_output_to_proto(value: AgentOutput | Mapping[str, Any] | None) -> Any
     if text_set == structured_set:
         raise ValueError("exactly one of output.text or output.structured is required")
     if text_set:
-        return pb.AgentOutput(text=pb.AgentTextOutput())
+        return pb.AgentOutput(text={})
     structured = _coerce(
         output.structured, AgentStructuredOutput, "AgentStructuredOutput"
     )
     if structured.schema is None:
         raise ValueError("output.structured.schema is required")
-    proto = pb.AgentOutput(structured=pb.AgentStructuredOutput())
+    proto = pb.AgentOutput(structured={})
     proto.structured.schema.CopyFrom(struct_from_dict(structured.schema))
     return proto
 

--- a/sdk/python/tests/test_agent_transport.py
+++ b/sdk/python/tests/test_agent_transport.py
@@ -978,9 +978,7 @@ class AgentTransportTests(unittest.TestCase):
                 ],
                 created_by_subject_id="user:turn-owner",
                 execution_ref="exec-turn-1",
-                output=agent_pb2.AgentOutput(
-                    text=agent_pb2.AgentTextOutput(),
-                ),
+                output=agent_pb2.AgentOutput(text={}),
             )
         )
         listed_turns = provider_client.ListTurns(
@@ -1231,9 +1229,7 @@ class AgentTransportTests(unittest.TestCase):
                     ],
                     tool_source=agent_pb2.AGENT_TOOL_SOURCE_MODE_NONE,
                     output=agent_pb2.AgentOutput(
-                        structured=agent_pb2.AgentStructuredOutput(
-                            schema={"type": "object"},
-                        ),
+                        structured={"schema": {"type": "object"}},
                     ),
                 )
             )


### PR DESCRIPTION
Closes #2215.

## Summary\n- construct Python AgentOutput protos using mapping values for oneof fields\n- update raw agent transport proto fixtures to match the generated protobuf API\n\n## Testing\n- cd sdk/python && uv run pytest tests/test_agent_transport.py -q\n- cd sdk/python && uv run pytest -q\n\n## Context\nThe codeReview workflow created the agent session, then crashed locally while serializing a structured AgentOutput for CreateTurn. That prevented CreateTurn from reaching the provider, so the GitHub check run failed before review execution.