### PR TITLE
Restore remote materialized cache before sync

### DIFF
--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -119,8 +119,8 @@ stays quiet.
 artifacts keyed by locked archive identity. Cache hits restore prepared outputs
 without re-downloading or reinstalling the package.
 Set `GESTALTD_SYNC_CACHE_REMOTE=gs://bucket/prefix` with `--cache-dir` to back
-that local cache with sparse per-artifact GCS objects. `gestaltd sync` checks
-the local cache first, downloads only missing remote entries, and uploads only
+that local cache with sparse per-artifact GCS objects. `gestaltd sync` restores
+the remote cache into the local cache before materialization, then uploads only
 entries materialized during the current sync.
 Use a private cache location because cache writers can influence restored
 prepared artifacts.

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -1080,6 +1080,12 @@ func (l *Lifecycle) syncAtPathsWithStatePaths(configPaths []string, state StateP
 	if recorder != nil {
 		recorder.FinishLoadPhase()
 	}
+	if paths.syncCache.remote != nil {
+		restoreStats := paths.syncCache.HydrateRemote(context.Background(), opts.Parallelism)
+		if recorder != nil {
+			recorder.RecordCacheRestore(restoreStats)
+		}
+	}
 	if err := l.applyPreparedProviders(paths, lock, cfg, mode, opts); err != nil {
 		return err
 	}
@@ -5094,7 +5100,7 @@ func (l *Lifecycle) materializeLockedArchive(ctx context.Context, paths lifecycl
 	cache := paths.syncCache
 	if cache.dir != "" {
 		cacheStart := time.Now()
-		restore, err := cache.Restore(ctx, cacheReq)
+		restore, err := cache.Restore(cacheReq)
 		if restore != nil {
 			cacheResult = string(restore.Result)
 		}

--- a/gestaltd/internal/operator/materialized_cache.go
+++ b/gestaltd/internal/operator/materialized_cache.go
@@ -120,25 +120,50 @@ func materializedCacheKeyForRequest(req materializedCacheRequest) (materializedC
 	}
 	resolvedHash := sha256Hex([]byte(req.ResolvedKey))
 	platformPath := strings.ReplaceAll(req.Platform, "/", "_")
-	display := strings.Join([]string{materializedCacheBucketVersion, platformPath, "sha256", sha[:2], sha, resolvedHash}, "/")
-	return materializedCacheKey{
-		Path:                filepath.Join(platformPath, "sha256", sha[:2], sha, resolvedHash),
-		Display:             display,
-		ArchiveSHA256:       sha,
-		ResolvedKeyHash:     resolvedHash,
-		Platform:            req.Platform,
-		MaterializerVersion: materializedCacheVersion,
-	}, true, nil
+	return materializedCacheKeyForParts(req.Platform, platformPath, sha, resolvedHash), true, nil
 }
 
-func (c materializedCache) Restore(ctx context.Context, req materializedCacheRequest) (*materializedCacheRestore, error) {
+func materializedCacheKeyFromDisplay(display string) (materializedCacheKey, bool) {
+	display = strings.TrimSpace(filepath.ToSlash(display))
+	parts := strings.Split(display, "/")
+	if len(parts) != 7 || parts[0]+"/"+parts[1] != materializedCacheBucketVersion || parts[3] != "sha256" {
+		return materializedCacheKey{}, false
+	}
+	platformPath := parts[2]
+	sha, ok := canonicalArchiveSHA256(parts[5])
+	if !ok || parts[4] != sha[:2] {
+		return materializedCacheKey{}, false
+	}
+	resolvedHash, ok := canonicalArchiveSHA256(parts[6])
+	if !ok {
+		return materializedCacheKey{}, false
+	}
+	key := materializedCacheKeyForParts(strings.ReplaceAll(platformPath, "_", "/"), platformPath, sha, resolvedHash)
+	if clean, err := validateMaterializedCachePath(filepath.ToSlash(key.Path)); err != nil || clean != filepath.ToSlash(key.Path) || key.Display != strings.Join(parts, "/") {
+		return materializedCacheKey{}, false
+	}
+	return key, true
+}
+
+func materializedCacheKeyForParts(platform, platformPath, sha, resolvedHash string) materializedCacheKey {
+	return materializedCacheKey{
+		Path:                filepath.Join(platformPath, "sha256", sha[:2], sha, resolvedHash),
+		Display:             strings.Join([]string{materializedCacheBucketVersion, platformPath, "sha256", sha[:2], sha, resolvedHash}, "/"),
+		ArchiveSHA256:       sha,
+		ResolvedKeyHash:     resolvedHash,
+		Platform:            platform,
+		MaterializerVersion: materializedCacheVersion,
+	}
+}
+
+func (c materializedCache) Restore(req materializedCacheRequest) (*materializedCacheRestore, error) {
 	key, eligible, err := materializedCacheKeyForRequest(req)
 	if err != nil || !eligible {
 		return nil, err
 	}
 	entryDir := c.entryDir(key)
 	fallback := materializedCacheMiss
-	entry, err := c.readEntry(entryDir, req, key)
+	entry, err := c.readEntryForKey(entryDir, key)
 	if err == nil {
 		restore, err := c.stageRestore(entryDir, req.DestinationDir, entry)
 		if err == nil {
@@ -150,60 +175,7 @@ func (c materializedCache) Restore(ctx context.Context, req materializedCacheReq
 	} else if !os.IsNotExist(err) {
 		fallback = materializedCacheInvalid
 	}
-	if c.remote != nil {
-		return c.restoreFromRemote(ctx, req, key, fallback)
-	}
 	return materializedCacheRestoreResult(key, fallback)
-}
-
-func (c materializedCache) restoreFromRemote(ctx context.Context, req materializedCacheRequest, key materializedCacheKey, fallback materializedCacheLookupResult) (*materializedCacheRestore, error) {
-	entryDir := c.entryDir(key)
-	parentDir := filepath.Dir(entryDir)
-	if err := os.MkdirAll(parentDir, 0o755); err != nil {
-		return nil, fmt.Errorf("create materialized cache parent: %w", err)
-	}
-	archiveReader, hit, err := c.remote.Get(ctx, key)
-	if err != nil {
-		return materializedCacheRestoreResult(key, fallback)
-	}
-	if !hit {
-		return materializedCacheRestoreResult(key, fallback)
-	}
-	defer func() { _ = archiveReader.Close() }()
-
-	tmpDir, err := os.MkdirTemp(parentDir, "."+filepath.Base(entryDir)+".remote-*")
-	if err != nil {
-		return nil, fmt.Errorf("create remote materialized cache temp entry: %w", err)
-	}
-	keepTmp := false
-	defer func() {
-		if !keepTmp {
-			_ = os.RemoveAll(tmpDir)
-		}
-	}()
-	if err := extractMaterializedCacheEntryArchive(archiveReader, tmpDir); err != nil {
-		return materializedCacheRestoreResult(key, materializedCacheInvalid)
-	}
-	entry, err := c.readEntry(tmpDir, req, key)
-	if err != nil {
-		return materializedCacheRestoreResult(key, materializedCacheInvalid)
-	}
-	restore, err := c.stageRestore(tmpDir, req.DestinationDir, entry)
-	if err != nil {
-		return materializedCacheRestoreResult(key, materializedCacheInvalid)
-	}
-	if err := os.RemoveAll(entryDir); err != nil {
-		_ = restore.cleanup()
-		return nil, fmt.Errorf("remove stale materialized cache entry: %w", err)
-	}
-	if err := os.Rename(tmpDir, entryDir); err != nil {
-		_ = restore.cleanup()
-		return nil, fmt.Errorf("commit remote materialized cache entry: %w", err)
-	}
-	keepTmp = true
-	restore.Result = materializedCacheHit
-	restore.Key = key
-	return restore, nil
 }
 
 func materializedCacheRestoreResult(key materializedCacheKey, result materializedCacheLookupResult) (*materializedCacheRestore, error) {
@@ -327,7 +299,7 @@ func (c materializedCache) entryDir(key materializedCacheKey) string {
 	return filepath.Join(c.dir, materializedCacheBucketVersion, key.Path)
 }
 
-func (c materializedCache) readEntry(entryDir string, req materializedCacheRequest, key materializedCacheKey) (*materializedCacheEntry, error) {
+func (c materializedCache) readEntryForKey(entryDir string, key materializedCacheKey) (*materializedCacheEntry, error) {
 	data, err := os.ReadFile(filepath.Join(entryDir, materializedCacheEntryFile))
 	if err != nil {
 		return nil, err
@@ -344,8 +316,12 @@ func (c materializedCache) readEntry(entryDir string, req materializedCacheReque
 		entry.ResolvedKeyHash != key.ResolvedKeyHash {
 		return nil, fmt.Errorf("materialized cache entry metadata mismatch")
 	}
-	if _, _, err := materializedCacheOutputDigest(entry.Files); err != nil {
+	_, digest, err := materializedCacheOutputDigest(entry.Files)
+	if err != nil {
 		return nil, err
+	}
+	if entry.OutputDigest != digest {
+		return nil, fmt.Errorf("materialized cache entry output digest mismatch")
 	}
 	return &entry, nil
 }
@@ -513,22 +489,34 @@ func copyMaterializedFiles(sourceRoot, destRoot string, files []materializedCach
 	return nil
 }
 
-func copyMaterializedFile(source, dest string, file materializedCacheFile) error {
-	if file.Type != "file" {
-		return fmt.Errorf("materialized cache entry %s is %q, want file", file.Path, file.Type)
+func validateMaterializedCacheEntryFiles(entryDir string, entry *materializedCacheEntry) error {
+	for _, file := range entry.Files {
+		rel, err := validateMaterializedCachePath(file.Path)
+		if err != nil {
+			return err
+		}
+		source := filepath.Join(entryDir, materializedCacheRootDir, filepath.FromSlash(rel))
+		if file.Type == "dir" {
+			info, err := os.Lstat(source)
+			if err != nil {
+				return err
+			}
+			if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+				return fmt.Errorf("materialized cache directory %s is invalid", file.Path)
+			}
+			continue
+		}
+		if err := validateMaterializedFile(source, file); err != nil {
+			return err
+		}
 	}
-	info, err := os.Lstat(source)
+	return nil
+}
+
+func copyMaterializedFile(source, dest string, file materializedCacheFile) error {
+	want, err := validateMaterializedFileMetadata(source, file)
 	if err != nil {
 		return err
-	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("materialized cache file %s is a symlink", file.Path)
-	}
-	if !info.Mode().IsRegular() {
-		return fmt.Errorf("materialized cache file %s is not regular", file.Path)
-	}
-	if info.Size() != file.Size {
-		return fmt.Errorf("materialized cache file %s size mismatch", file.Path)
 	}
 	in, err := os.Open(source)
 	if err != nil {
@@ -549,10 +537,6 @@ func copyMaterializedFile(source, dest string, file materializedCacheFile) error
 		return closeErr
 	}
 	got := hex.EncodeToString(h.Sum(nil))
-	want, ok := canonicalArchiveSHA256(file.SHA256)
-	if !ok {
-		return fmt.Errorf("invalid materialized cache file sha256 for %s", file.Path)
-	}
 	if got != want {
 		return fmt.Errorf("materialized cache file %s digest mismatch", file.Path)
 	}
@@ -560,6 +544,45 @@ func copyMaterializedFile(source, dest string, file materializedCacheFile) error
 		return err
 	}
 	return nil
+}
+
+func validateMaterializedFile(source string, file materializedCacheFile) error {
+	want, err := validateMaterializedFileMetadata(source, file)
+	if err != nil {
+		return err
+	}
+	got, err := fileSHA256Hex(source)
+	if err != nil {
+		return err
+	}
+	if got != want {
+		return fmt.Errorf("materialized cache file %s digest mismatch", file.Path)
+	}
+	return nil
+}
+
+func validateMaterializedFileMetadata(source string, file materializedCacheFile) (string, error) {
+	if file.Type != "file" {
+		return "", fmt.Errorf("materialized cache entry %s is %q, want file", file.Path, file.Type)
+	}
+	info, err := os.Lstat(source)
+	if err != nil {
+		return "", err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("materialized cache file %s is a symlink", file.Path)
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("materialized cache file %s is not regular", file.Path)
+	}
+	if info.Size() != file.Size {
+		return "", fmt.Errorf("materialized cache file %s size mismatch", file.Path)
+	}
+	want, ok := canonicalArchiveSHA256(file.SHA256)
+	if !ok {
+		return "", fmt.Errorf("invalid materialized cache file sha256 for %s", file.Path)
+	}
+	return want, nil
 }
 
 func validateMaterializedCachePath(path string) (string, error) {

--- a/gestaltd/internal/operator/materialized_cache_hydrate.go
+++ b/gestaltd/internal/operator/materialized_cache_hydrate.go
@@ -1,0 +1,154 @@
+package operator
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+type materializedCacheHydrateStats struct {
+	Duration time.Duration
+	List     time.Duration
+	Entries  int
+	Restored int
+	Failures int
+	Bytes    int64
+}
+
+func (c materializedCache) HydrateRemote(ctx context.Context, parallelism int) materializedCacheHydrateStats {
+	var stats materializedCacheHydrateStats
+	start := time.Now()
+	defer func() {
+		stats.Duration = time.Since(start)
+	}()
+	if c.dir == "" || c.remote == nil {
+		return stats
+	}
+
+	listStart := time.Now()
+	objects, err := c.remote.List(ctx)
+	stats.List = time.Since(listStart)
+	stats.Entries = len(objects)
+	if err != nil {
+		stats.Failures++
+		return stats
+	}
+	if len(objects) == 0 {
+		return stats
+	}
+	if parallelism < 1 {
+		parallelism = 1
+	}
+
+	var mu sync.Mutex
+	jobs := make(chan string)
+	var wg sync.WaitGroup
+	for i := 0; i < parallelism; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for object := range jobs {
+				result := c.hydrateRemoteObject(ctx, object)
+				mu.Lock()
+				stats.Bytes += result.Bytes
+				if result.Restored {
+					stats.Restored++
+				}
+				if result.Failed {
+					stats.Failures++
+				}
+				mu.Unlock()
+			}
+		}()
+	}
+sendJobs:
+	for _, object := range objects {
+		select {
+		case jobs <- object:
+		case <-ctx.Done():
+			break sendJobs
+		}
+	}
+	close(jobs)
+	wg.Wait()
+	return stats
+}
+
+type materializedCacheHydrateObjectResult struct {
+	Bytes    int64
+	Restored bool
+	Failed   bool
+}
+
+func (c materializedCache) hydrateRemoteObject(ctx context.Context, display string) materializedCacheHydrateObjectResult {
+	result := materializedCacheHydrateObjectResult{}
+	key, ok := materializedCacheKeyFromDisplay(display)
+	if !ok {
+		result.Failed = true
+		return result
+	}
+	entryDir := c.entryDir(key)
+	if entry, err := c.readEntryForKey(entryDir, key); err == nil && validateMaterializedCacheEntryFiles(entryDir, entry) == nil {
+		result.Restored = true
+		return result
+	}
+	parentDir := filepath.Dir(entryDir)
+	if err := os.MkdirAll(parentDir, 0o755); err != nil {
+		result.Failed = true
+		return result
+	}
+	reader, err := c.remote.Get(ctx, display)
+	if err != nil {
+		result.Failed = true
+		return result
+	}
+	defer func() { _ = reader.Close() }()
+
+	tmpDir, err := os.MkdirTemp(parentDir, "."+filepath.Base(entryDir)+".remote-*")
+	if err != nil {
+		result.Failed = true
+		return result
+	}
+	keepTmp := false
+	defer func() {
+		if !keepTmp {
+			_ = os.RemoveAll(tmpDir)
+		}
+	}()
+	counter := &countingReader{reader: reader}
+	if err := extractMaterializedCacheEntryArchive(counter, tmpDir); err != nil {
+		result.Failed = true
+		return result
+	}
+	result.Bytes = counter.bytes
+	entry, err := c.readEntryForKey(tmpDir, key)
+	if err != nil || validateMaterializedCacheEntryFiles(tmpDir, entry) != nil {
+		result.Failed = true
+		return result
+	}
+	if err := os.RemoveAll(entryDir); err != nil {
+		result.Failed = true
+		return result
+	}
+	if err := os.Rename(tmpDir, entryDir); err != nil {
+		result.Failed = true
+		return result
+	}
+	keepTmp = true
+	result.Restored = true
+	return result
+}
+
+type countingReader struct {
+	reader io.Reader
+	bytes  int64
+}
+
+func (r *countingReader) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	r.bytes += int64(n)
+	return n, err
+}

--- a/gestaltd/internal/operator/materialized_cache_remote.go
+++ b/gestaltd/internal/operator/materialized_cache_remote.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -18,7 +19,8 @@ const materializedCacheRemoteEnv = "GESTALTD_SYNC_CACHE_REMOTE"
 const materializedCacheRemoteScope = "https://www.googleapis.com/auth/devstorage.read_write"
 
 type materializedCacheRemote interface {
-	Get(context.Context, materializedCacheKey) (io.ReadCloser, bool, error)
+	List(context.Context) ([]string, error)
+	Get(context.Context, string) (io.ReadCloser, error)
 	Exists(context.Context, materializedCacheKey) (bool, error)
 	Put(context.Context, materializedCacheKey, string) error
 }
@@ -68,30 +70,71 @@ func newGCSMaterializedCacheRemote(raw string) (materializedCacheRemote, error) 
 	}, nil
 }
 
-func (r *gcsMaterializedCacheRemote) Get(ctx context.Context, key materializedCacheKey) (io.ReadCloser, bool, error) {
-	object := r.objectName(key)
+func (r *gcsMaterializedCacheRemote) List(ctx context.Context) ([]string, error) {
 	client, err := r.httpClient(ctx)
 	if err != nil {
-		return nil, false, err
+		return nil, err
+	}
+	var objects []string
+	pageToken := ""
+	for {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.listURL(pageToken), nil)
+		if err != nil {
+			return nil, fmt.Errorf("build materialized cache remote list request: %w", err)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("list materialized cache remote objects: %w", err)
+		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			err := gcsMaterializedCacheStatusError("list", r.listPrefix(), resp)
+			_ = resp.Body.Close()
+			return nil, err
+		}
+		var page struct {
+			Items []struct {
+				Name string `json:"name"`
+			} `json:"items"`
+			NextPageToken string `json:"nextPageToken"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&page); err != nil {
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("decode materialized cache remote list response: %w", err)
+		}
+		_ = resp.Body.Close()
+		for _, item := range page.Items {
+			display, ok := r.displayName(item.Name)
+			if ok {
+				objects = append(objects, display)
+			}
+		}
+		if page.NextPageToken == "" {
+			return objects, nil
+		}
+		pageToken = page.NextPageToken
+	}
+}
+
+func (r *gcsMaterializedCacheRemote) Get(ctx context.Context, display string) (io.ReadCloser, error) {
+	object := r.displayObjectName(display)
+	client, err := r.httpClient(ctx)
+	if err != nil {
+		return nil, err
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.downloadURL(object), nil)
 	if err != nil {
-		return nil, false, fmt.Errorf("build materialized cache remote read request: %w", err)
+		return nil, fmt.Errorf("build materialized cache remote read request: %w", err)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, false, fmt.Errorf("read materialized cache remote object %s: %w", object, err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
-		_ = resp.Body.Close()
-		return nil, false, nil
+		return nil, fmt.Errorf("read materialized cache remote object %s: %w", object, err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		err := gcsMaterializedCacheStatusError("read", object, resp)
 		_ = resp.Body.Close()
-		return nil, false, err
+		return nil, err
 	}
-	return resp.Body, true, nil
+	return resp.Body, nil
 }
 
 func (r *gcsMaterializedCacheRemote) Exists(ctx context.Context, key materializedCacheKey) (bool, error) {
@@ -164,10 +207,52 @@ func (r *gcsMaterializedCacheRemote) httpClient(ctx context.Context) (*http.Clie
 }
 
 func (r *gcsMaterializedCacheRemote) objectName(key materializedCacheKey) string {
+	return r.displayObjectName(key.Display)
+}
+
+func (r *gcsMaterializedCacheRemote) displayObjectName(display string) string {
 	if r.prefix == "" {
-		return key.Display + ".tar"
+		return display + ".tar"
 	}
-	return path.Join(r.prefix, key.Display+".tar")
+	return path.Join(r.prefix, display+".tar")
+}
+
+func (r *gcsMaterializedCacheRemote) listPrefix() string {
+	if r.prefix == "" {
+		return materializedCacheBucketVersion + "/"
+	}
+	return path.Join(r.prefix, materializedCacheBucketVersion) + "/"
+}
+
+func (r *gcsMaterializedCacheRemote) displayName(object string) (string, bool) {
+	prefix := strings.TrimSuffix(r.prefix, "/")
+	if prefix != "" {
+		prefix += "/"
+		if !strings.HasPrefix(object, prefix) {
+			return "", false
+		}
+		object = strings.TrimPrefix(object, prefix)
+	}
+	if !strings.HasPrefix(object, materializedCacheBucketVersion+"/") || !strings.HasSuffix(object, ".tar") {
+		return "", false
+	}
+	return strings.TrimSuffix(object, ".tar"), true
+}
+
+func (r *gcsMaterializedCacheRemote) listURL(pageToken string) string {
+	u := url.URL{
+		Scheme: "https",
+		Host:   "storage.googleapis.com",
+		Path:   "/storage/v1/b/" + url.PathEscape(r.bucket) + "/o",
+	}
+	q := u.Query()
+	q.Set("prefix", r.listPrefix())
+	q.Set("fields", "nextPageToken,items/name")
+	if pageToken != "" {
+		q.Set("pageToken", pageToken)
+	}
+	u.RawQuery = q.Encode()
+	return u.String()
 }
 
 func (r *gcsMaterializedCacheRemote) downloadURL(object string) string {

--- a/gestaltd/internal/operator/materialized_cache_remote_test.go
+++ b/gestaltd/internal/operator/materialized_cache_remote_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -20,6 +21,7 @@ func TestGCSMaterializedCacheRemoteHTTPContracts(t *testing.T) {
 	}
 
 	objectName := "prefix/" + key.Display + ".tar"
+	var sawList bool
 	var sawDownload bool
 	var sawExists bool
 	var sawUpload bool
@@ -27,6 +29,19 @@ func TestGCSMaterializedCacheRemoteHTTPContracts(t *testing.T) {
 		client: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 			switch r.Method {
 			case http.MethodGet:
+				if r.URL.EscapedPath() == "/storage/v1/b/cache-bucket/o" {
+					sawList = true
+					if got := r.URL.Query().Get("prefix"); got != "prefix/materialized/v1/" {
+						t.Fatalf("list prefix = %q, want materialized cache prefix", got)
+					}
+					if got := r.URL.Query().Get("fields"); got != "nextPageToken,items/name" {
+						t.Fatalf("list fields = %q, want narrow object projection", got)
+					}
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(`{"items":[{"name":"` + objectName + `"}]}`)),
+					}, nil
+				}
 				if r.URL.Query().Get("alt") == "" {
 					sawExists = true
 					if got := r.URL.EscapedPath(); got != "/storage/v1/b/cache-bucket/o/"+escapeGCSPathSegment(objectName) {
@@ -41,7 +56,7 @@ func TestGCSMaterializedCacheRemoteHTTPContracts(t *testing.T) {
 				if got := r.URL.EscapedPath(); got != "/storage/v1/b/cache-bucket/o/"+escapeGCSPathSegment(objectName) {
 					t.Fatalf("download escaped path = %q, want encoded object path", got)
 				}
-				return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(http.NoBody)}, nil
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("archive"))}, nil
 			case http.MethodPost:
 				sawUpload = true
 				if got := r.URL.Query().Get("uploadType"); got != "media" {
@@ -66,13 +81,18 @@ func TestGCSMaterializedCacheRemoteHTTPContracts(t *testing.T) {
 		prefix: "prefix",
 	}
 
-	reader, hit, err := remote.Get(context.Background(), key)
+	objects, err := remote.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(objects) != 1 || objects[0] != key.Display {
+		t.Fatalf("List objects = %#v, want listed cache object", objects)
+	}
+	reader, err := remote.Get(context.Background(), objects[0])
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if reader != nil || hit {
-		t.Fatalf("Get hit=%t reader=%v, want 404 miss", hit, reader)
-	}
+	_ = reader.Close()
 	exists, err := remote.Exists(context.Background(), key)
 	if err != nil {
 		t.Fatalf("Exists: %v", err)
@@ -88,8 +108,8 @@ func TestGCSMaterializedCacheRemoteHTTPContracts(t *testing.T) {
 	if err := remote.Put(context.Background(), key, archivePath); err != nil {
 		t.Fatalf("Put: %v", err)
 	}
-	if !sawDownload || !sawExists || !sawUpload {
-		t.Fatalf("saw download/exists/upload = %t/%t/%t, want all", sawDownload, sawExists, sawUpload)
+	if !sawList || !sawDownload || !sawExists || !sawUpload {
+		t.Fatalf("saw list/download/exists/upload = %t/%t/%t/%t, want all", sawList, sawDownload, sawExists, sawUpload)
 	}
 }
 

--- a/gestaltd/internal/operator/materialized_cache_test.go
+++ b/gestaltd/internal/operator/materialized_cache_test.go
@@ -28,7 +28,7 @@ func TestMaterializedCachePreservesEmptyDirectories(t *testing.T) {
 	if _, err := cache.Put(context.Background(), req, source); err != nil {
 		t.Fatalf("Put: %v", err)
 	}
-	restore, err := cache.Restore(context.Background(), req)
+	restore, err := cache.Restore(req)
 	if err != nil {
 		t.Fatalf("Restore: %v", err)
 	}
@@ -56,7 +56,7 @@ func TestMaterializedCacheRestoresSharedArchiveForDifferentSubjects(t *testing.T
 	}
 
 	sharedReq := materializedCacheUIRequest(dir, "beta", "dest-beta")
-	restore, err := cache.Restore(context.Background(), sharedReq)
+	restore, err := cache.Restore(sharedReq)
 	if err != nil {
 		t.Fatalf("Restore shared archive: %v", err)
 	}
@@ -66,7 +66,7 @@ func TestMaterializedCacheRestoresSharedArchiveForDifferentSubjects(t *testing.T
 	defer func() { _ = restore.cleanup() }()
 }
 
-func TestMaterializedCacheRestoresRemoteEntry(t *testing.T) {
+func TestMaterializedCacheHydratesRemoteEntriesBeforeRestore(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -81,32 +81,41 @@ func TestMaterializedCacheRestoresRemoteEntry(t *testing.T) {
 		t.Fatalf("remote puts = %d, want 1", remote.puts)
 	}
 
-	restore, err := (materializedCache{dir: filepath.Join(dir, "warm"), remote: remote}).Restore(context.Background(), req)
+	warm := materializedCache{dir: filepath.Join(dir, "warm"), remote: remote}
+	stats := warm.HydrateRemote(context.Background(), 2)
+	if stats.Entries != 1 || stats.Restored != 1 || stats.Failures != 0 || stats.Bytes == 0 {
+		t.Fatalf("HydrateRemote stats = %+v, want one restored entry", stats)
+	}
+	if remote.listCalls != 1 || remote.gets != 1 {
+		t.Fatalf("remote list/get calls = %d/%d, want 1/1", remote.listCalls, remote.gets)
+	}
+
+	remote.getErr = errors.New("remote cache unavailable")
+	stats = warm.HydrateRemote(context.Background(), 2)
+	if stats.Entries != 1 || stats.Restored != 1 || stats.Failures != 0 || stats.Bytes != 0 {
+		t.Fatalf("HydrateRemote local-hit stats = %+v, want one local restore without bytes", stats)
+	}
+	if remote.listCalls != 2 || remote.gets != 1 {
+		t.Fatalf("remote list/get calls after local hydrate = %d/%d, want 2/1", remote.listCalls, remote.gets)
+	}
+
+	restore, err := warm.Restore(req)
 	if err != nil {
-		t.Fatalf("Restore remote entry: %v", err)
+		t.Fatalf("Restore hydrated entry: %v", err)
 	}
 	if restore == nil || restore.Result != materializedCacheHit {
-		t.Fatalf("remote Restore result = %#v, want hit", restore)
+		t.Fatalf("hydrated Restore result = %#v, want hit", restore)
 	}
 	defer func() { _ = restore.cleanup() }()
 	if err := restore.commit(); err != nil {
-		t.Fatalf("commit remote restore: %v", err)
+		t.Fatalf("commit hydrated restore: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(req.DestinationDir, "manifest.yaml")); err != nil {
 		t.Fatalf("restored manifest stat: %v", err)
 	}
-
-	remote.getErr = errors.New("remote cache unavailable")
-	fallback, err := (materializedCache{dir: filepath.Join(dir, "fallback"), remote: remote}).Restore(context.Background(), req)
-	if err != nil {
-		t.Fatalf("Restore remote read error: %v", err)
-	}
-	if fallback == nil || fallback.Result != materializedCacheMiss {
-		t.Fatalf("remote read error Restore result = %#v, want miss", fallback)
-	}
 }
 
-func TestMaterializedCacheTreatsUnsafeRemoteArchiveAsInvalid(t *testing.T) {
+func TestMaterializedCacheSkipsUnsafeRemoteArchiveDuringHydrate(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -119,12 +128,16 @@ func TestMaterializedCacheTreatsUnsafeRemoteArchiveAsInvalid(t *testing.T) {
 	remote.objects[key.Display] = materializedCacheUnsafeArchive(t)
 
 	cache := materializedCache{dir: filepath.Join(dir, "cache"), remote: remote}
-	restore, err := cache.Restore(context.Background(), req)
-	if err != nil {
-		t.Fatalf("Restore unsafe remote archive error = %v, want repairable invalid result", err)
+	stats := cache.HydrateRemote(context.Background(), 1)
+	if stats.Entries != 1 || stats.Restored != 0 || stats.Failures != 1 {
+		t.Fatalf("HydrateRemote unsafe stats = %+v, want one failure", stats)
 	}
-	if restore == nil || restore.Result != materializedCacheInvalid {
-		t.Fatalf("Restore unsafe remote archive = %#v, want invalid", restore)
+	restore, err := cache.Restore(req)
+	if err != nil {
+		t.Fatalf("Restore after unsafe hydrate: %v", err)
+	}
+	if restore == nil || restore.Result != materializedCacheMiss {
+		t.Fatalf("Restore unsafe remote archive = %#v, want miss", restore)
 	}
 }
 
@@ -260,7 +273,7 @@ func TestMaterializedCacheTreatsUnsafeMetadataAsInvalid(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(entryDir, materializedCacheEntryFile), data, 0o644); err != nil {
 		t.Fatalf("write entry: %v", err)
 	}
-	restore, err := cache.Restore(context.Background(), req)
+	restore, err := cache.Restore(req)
 	if err != nil {
 		t.Fatalf("Restore unsafe entry error = %v, want repairable invalid result", err)
 	}
@@ -276,10 +289,12 @@ func materializedCacheTestSHA256Hex(data []byte) string {
 
 type fakeMaterializedCacheRemote struct {
 	objects     map[string][]byte
+	listCalls   int
 	gets        int
 	existsCalls int
 	puts        int
 	exists      bool
+	listErr     error
 	getErr      error
 	existsErr   error
 }
@@ -288,16 +303,28 @@ func newFakeMaterializedCacheRemote() *fakeMaterializedCacheRemote {
 	return &fakeMaterializedCacheRemote{objects: map[string][]byte{}}
 }
 
-func (r *fakeMaterializedCacheRemote) Get(_ context.Context, key materializedCacheKey) (io.ReadCloser, bool, error) {
+func (r *fakeMaterializedCacheRemote) List(_ context.Context) ([]string, error) {
+	r.listCalls++
+	if r.listErr != nil {
+		return nil, r.listErr
+	}
+	objects := make([]string, 0, len(r.objects))
+	for display := range r.objects {
+		objects = append(objects, display)
+	}
+	return objects, nil
+}
+
+func (r *fakeMaterializedCacheRemote) Get(_ context.Context, display string) (io.ReadCloser, error) {
 	r.gets++
 	if r.getErr != nil {
-		return nil, false, r.getErr
+		return nil, r.getErr
 	}
-	data := r.objects[key.Display]
+	data := r.objects[display]
 	if data == nil {
-		return nil, false, nil
+		return nil, os.ErrNotExist
 	}
-	return io.NopCloser(bytes.NewReader(data)), true, nil
+	return io.NopCloser(bytes.NewReader(data)), nil
 }
 
 func (r *fakeMaterializedCacheRemote) Exists(_ context.Context, _ materializedCacheKey) (bool, error) {

--- a/gestaltd/internal/operator/sync_metrics.go
+++ b/gestaltd/internal/operator/sync_metrics.go
@@ -109,8 +109,18 @@ type SyncMetricsCache struct {
 	Hits          int                     `json:"hits"`
 	Misses        int                     `json:"misses"`
 	Invalid       int                     `json:"invalid"`
+	Restore       SyncMetricsCacheRestore `json:"restore"`
 	Put           SyncMetricsCachePut     `json:"put"`
 	Entries       []SyncMetricsCacheEntry `json:"entries"`
+}
+
+type SyncMetricsCacheRestore struct {
+	DurationSeconds float64 `json:"duration_seconds"`
+	ListSeconds     float64 `json:"list_seconds"`
+	Entries         int     `json:"entries"`
+	Restored        int     `json:"restored"`
+	Failures        int     `json:"failures"`
+	Bytes           int64   `json:"bytes"`
 }
 
 type SyncMetricsCachePut struct {
@@ -443,6 +453,22 @@ func (r *SyncMetricsRecorder) RecordCacheEntry(event syncCacheMetricsEvent) {
 		return cmp.Compare(a.Key, b.Key)
 	})
 	r.metrics.Cache.Entries = append([]SyncMetricsCacheEntry(nil), r.cache...)
+}
+
+func (r *SyncMetricsRecorder) RecordCacheRestore(stats materializedCacheHydrateStats) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.metrics.Cache.Restore = SyncMetricsCacheRestore{
+		DurationSeconds: roundedSeconds(stats.Duration),
+		ListSeconds:     roundedSeconds(stats.List),
+		Entries:         stats.Entries,
+		Restored:        stats.Restored,
+		Failures:        stats.Failures,
+		Bytes:           stats.Bytes,
+	}
 }
 
 func (r *SyncMetricsRecorder) RecordArtifact(event syncArtifactMetricsEvent) {


### PR DESCRIPTION
## Summary

Restores the remote materialized cache into the local `--cache-dir` before sync materialization instead of fetching individual cache entries from GCS during each artifact restore.

The existing sparse upload behavior stays in place: entries materialized during the current sync are still written to the local cache, checked against the remote object key, and uploaded only when the corresponding remote object does not already exist.

This keeps Valon Tools-style image builds on a local-cache hot path after the initial restore, while preserving the per-entry remote cache layout that lets future runs upload only changed prepared artifacts.

## Interfaces

```sh
GESTALTD_SYNC_CACHE_REMOTE=gs://bucket/prefix \
  gestaltd sync \
    --locked \
    --cache-dir /cache/gestaltd-materialized \
    --output-format=json
```

The CLI and environment variable surface stay unchanged. With `--output-format=json`, sync output includes aggregate remote restore metrics under `cache.restore`:

```json
{
  "cache": {
    "restore": {
      "duration_seconds": 12.345,
      "list_seconds": 0.123,
      "entries": 120,
      "restored": 120,
      "failures": 0,
      "bytes": 3364853264
    }
  }
}
```

## Runtime

During locked materializing sync, gestaltd hydrates the configured remote materialized cache immediately after config, lock, and runtime validation finish and before prepared providers are applied. Hydration lists GCS objects under the materialized cache prefix, keeps valid local entries in place, and downloads only entries that are missing or invalid locally. Downloaded entries are extracted in parallel, validated, and committed into the local cache directory.

Per-artifact cache lookup is local-only after hydration. If a cache entry is missing or invalid locally, gestaltd falls back to the existing package download/install path and then sparsely writes the resulting materialized output back to the remote cache when needed.