### PR TITLE
Expose materialized cache restore errors

### DIFF
--- a/gestaltd/internal/operator/materialized_cache_hydrate.go
+++ b/gestaltd/internal/operator/materialized_cache_hydrate.go
@@ -16,10 +16,10 @@ type materializedCacheHydrateStats struct {
 	Restored int
 	Failures int
 	Bytes    int64
+	Error    string
 }
 
-func (c materializedCache) HydrateRemote(ctx context.Context, parallelism int) materializedCacheHydrateStats {
-	var stats materializedCacheHydrateStats
+func (c materializedCache) HydrateRemote(ctx context.Context, parallelism int) (stats materializedCacheHydrateStats) {
 	start := time.Now()
 	defer func() {
 		stats.Duration = time.Since(start)
@@ -34,6 +34,7 @@ func (c materializedCache) HydrateRemote(ctx context.Context, parallelism int) m
 	stats.Entries = len(objects)
 	if err != nil {
 		stats.Failures++
+		stats.Error = err.Error()
 		return stats
 	}
 	if len(objects) == 0 {

--- a/gestaltd/internal/operator/materialized_cache_test.go
+++ b/gestaltd/internal/operator/materialized_cache_test.go
@@ -99,6 +99,13 @@ func TestMaterializedCacheHydratesRemoteEntriesBeforeRestore(t *testing.T) {
 		t.Fatalf("remote list/get calls after local hydrate = %d/%d, want 2/1", remote.listCalls, remote.gets)
 	}
 
+	remote.listErr = errors.New("remote list unavailable")
+	stats = warm.HydrateRemote(context.Background(), 2)
+	if stats.Failures != 1 || stats.Error != "remote list unavailable" || stats.Duration <= 0 {
+		t.Fatalf("HydrateRemote list error stats = %+v, want failure, error, and duration", stats)
+	}
+	remote.listErr = nil
+
 	restore, err := warm.Restore(req)
 	if err != nil {
 		t.Fatalf("Restore hydrated entry: %v", err)

--- a/gestaltd/internal/operator/sync_metrics.go
+++ b/gestaltd/internal/operator/sync_metrics.go
@@ -121,6 +121,7 @@ type SyncMetricsCacheRestore struct {
 	Restored        int     `json:"restored"`
 	Failures        int     `json:"failures"`
 	Bytes           int64   `json:"bytes"`
+	Error           string  `json:"error,omitempty"`
 }
 
 type SyncMetricsCachePut struct {
@@ -468,6 +469,7 @@ func (r *SyncMetricsRecorder) RecordCacheRestore(stats materializedCacheHydrateS
 		Restored:        stats.Restored,
 		Failures:        stats.Failures,
 		Bytes:           stats.Bytes,
+		Error:           stats.Error,
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fix materialized remote cache hydrate duration reporting so `cache.restore.duration_seconds` includes list time.
- Include the bulk restore error message in `cache.restore.error` when remote restore setup fails.
- Extend the existing materialized cache hydrate test to cover list failures without adding another test file.

## Test plan
- [x] `go test ./gestaltd/internal/operator`
- [x] `go test ./gestaltd/internal/daemon`