### PR TITLE
Carry workflow step request authority explicitly

### DIFF
--- a/gestaltd/internal/bootstrap/startup_app_proxy.go
+++ b/gestaltd/internal/bootstrap/startup_app_proxy.go
@@ -240,7 +240,7 @@ func (p *startupProviderProxy) beginCallerWait(ctx context.Context) (func(), err
 	}
 	target := newStartupProviderNode(invocation.ProviderKindApp, p.spec.Name)
 	workflow := invocation.WorkflowContextFromContext(ctx)
-	if providerName, _ := workflow["provider"].(string); strings.TrimSpace(providerName) != "" {
+	if providerName, _ := workflow["providerName"].(string); strings.TrimSpace(providerName) != "" {
 		return p.tracker.beginWait(newStartupProviderNode(invocation.ProviderKindWorkflow, providerName), target)
 	}
 	if done, ok, err := p.tracker.beginCallerProviderWait(ctx, target); ok || err != nil {

--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -827,7 +827,7 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req *p
 	}
 	idempotencyKey := strings.TrimSpace(req.GetIdempotencyKey())
 	turnID := newAgentTurnID(ownedSession.session.ID, idempotencyKey)
-	if err := m.storeTurnScope(ctx, p, ownedSession.providerName, ownedSession.session.ID, turnID, callerKind, callerName, toolRefs, toolRefsSet, tools, toolSource); err != nil {
+	if err := m.storeTurnScope(ctx, req.GetContext(), p, ownedSession.providerName, ownedSession.session.ID, turnID, callerKind, callerName, toolRefs, toolRefsSet, tools, toolSource); err != nil {
 		return nil, err
 	}
 	scopeCommitted := false
@@ -887,6 +887,9 @@ func (m *Manager) GetTurn(ctx context.Context, p *principal.Principal, req *prot
 		return nil, err
 	}
 	observability.SetSpanAttributes(ctx, observability.AttrAgentProvider.String(owned.providerName))
+	if err := m.authorizeWorkflowTurnAccess(ctx, owned, req.GetContext()); err != nil {
+		return nil, err
+	}
 	return owned.turn, nil
 }
 
@@ -976,6 +979,9 @@ func (m *Manager) CancelTurn(ctx context.Context, p *principal.Principal, req *p
 	if !owned.sessionOwned {
 		return nil, core.ErrNotFound
 	}
+	if err := m.authorizeWorkflowTurnAccess(ctx, owned, req.GetContext()); err != nil {
+		return nil, err
+	}
 	observability.SetSpanAttributes(ctx, observability.AttrAgentProvider.String(owned.providerName))
 	providerReq := cloneAgentRequest(req, &proto.CancelAgentProviderTurnRequest{})
 	providerReq.TurnId = strings.TrimSpace(req.GetTurnId())
@@ -1017,6 +1023,9 @@ func (m *Manager) ListTurnEvents(ctx context.Context, p *principal.Principal, re
 		return nil, err
 	}
 	observability.SetSpanAttributes(ctx, observability.AttrAgentProvider.String(owned.providerName))
+	if err := m.authorizeWorkflowTurnAccess(ctx, owned, req.GetContext()); err != nil {
+		return nil, err
+	}
 	callCtx, providerReqContext, err := agentProviderRequestContext(ctx, p, req.GetContext(), owned.providerName)
 	if err != nil {
 		return nil, err
@@ -1046,6 +1055,9 @@ func (m *Manager) ListInteractions(ctx context.Context, p *principal.Principal, 
 		return nil, err
 	}
 	observability.SetSpanAttributes(ctx, observability.AttrAgentProvider.String(owned.providerName))
+	if err := m.authorizeWorkflowTurnAccess(ctx, owned, req.GetContext()); err != nil {
+		return nil, err
+	}
 	callCtx, providerReqContext, err := agentProviderRequestContext(ctx, p, req.GetContext(), owned.providerName)
 	if err != nil {
 		return nil, err
@@ -1087,6 +1099,9 @@ func (m *Manager) ResolveInteraction(ctx context.Context, p *principal.Principal
 	}
 	if !owned.sessionOwned {
 		return nil, core.ErrNotFound
+	}
+	if err := m.authorizeWorkflowTurnAccess(ctx, owned, req.GetContext()); err != nil {
+		return nil, err
 	}
 	observability.SetSpanAttributes(ctx, observability.AttrAgentProvider.String(owned.providerName))
 	interactionID := strings.TrimSpace(req.GetInteractionId())
@@ -1537,9 +1552,13 @@ func agentProviderReadFallbackAllowed(err error) bool {
 	return false
 }
 
-func (m *Manager) storeTurnScope(ctx context.Context, p *principal.Principal, providerName, sessionID, turnID string, callerKind invocation.ProviderKind, callerName string, toolRefs []coreagent.ToolRef, toolRefsSet bool, tools []coreagent.Tool, toolSource coreagent.ToolSourceMode) error {
+func (m *Manager) storeTurnScope(ctx context.Context, reqContext *proto.RequestContext, p *principal.Principal, providerName, sessionID, turnID string, callerKind invocation.ProviderKind, callerName string, toolRefs []coreagent.ToolRef, toolRefsSet bool, tools []coreagent.Tool, toolSource coreagent.ToolSourceMode) error {
 	if m == nil || m.turnScopes == nil {
 		return fmt.Errorf("%w: agent turn scopes are not configured", invocation.ErrInternal)
+	}
+	workflowRunID, workflowStepID, err := workflowTurnScope(ctx, reqContext, callerKind, providerName)
+	if err != nil {
+		return err
 	}
 	subject := agentSubjectFromPrincipal(p)
 	permissions := agentTurnPermissions(ctx, p, callerKind, callerName, toolRefs)
@@ -1553,6 +1572,8 @@ func (m *Manager) storeTurnScope(ctx context.Context, p *principal.Principal, pr
 		TurnID:              turnID,
 		CallerKind:          callerKind,
 		CallerName:          callerName,
+		WorkflowRunID:       workflowRunID,
+		WorkflowStepID:      workflowStepID,
 		SubjectID:           subject.SubjectID,
 		CredentialSubjectID: subject.CredentialSubjectID,
 		Permissions:         permissions,
@@ -1562,6 +1583,75 @@ func (m *Manager) storeTurnScope(ctx context.Context, p *principal.Principal, pr
 		ToolSource:          toolSource,
 		Connections:         connections,
 	})
+}
+
+func workflowTurnScope(ctx context.Context, reqContext *proto.RequestContext, callerKind invocation.ProviderKind, providerName string) (string, string, error) {
+	if callerKind != invocation.ProviderKindWorkflow {
+		return "", "", nil
+	}
+	step, err := appaccessservice.WorkflowStepInvocationFromContext(agentWorkflowContext(ctx, reqContext))
+	if err != nil {
+		return "", "", err
+	}
+	if step.Kind != "agent" {
+		return "", "", fmt.Errorf("%w: workflow step %q is not an agent step", invocation.ErrAuthorizationDenied, step.ID)
+	}
+	if step.AgentProvider != strings.TrimSpace(providerName) {
+		return "", "", fmt.Errorf("%w: workflow step %q may not invoke agent provider %q", invocation.ErrAuthorizationDenied, step.ID, strings.TrimSpace(providerName))
+	}
+	return step.RunID, step.ID, nil
+}
+
+func (m *Manager) authorizeWorkflowTurnAccess(ctx context.Context, owned *accessibleAgentTurn, reqContext *proto.RequestContext) error {
+	caller := reqContext.GetCaller()
+	if invocation.ProviderKind(strings.TrimSpace(caller.GetKind())) != invocation.ProviderKindWorkflow {
+		return nil
+	}
+	callerName := strings.TrimSpace(caller.GetName())
+	step, err := appaccessservice.WorkflowStepInvocationFromContext(agentWorkflowContext(ctx, reqContext))
+	if err != nil {
+		return err
+	}
+	if callerName == "" || step.ProviderName != callerName {
+		return fmt.Errorf("%w: workflow caller %q does not match workflow context provider %q", invocation.ErrAuthorizationDenied, callerName, step.ProviderName)
+	}
+	if step.Kind != "agent" || step.AgentProvider != owned.providerName {
+		return fmt.Errorf("%w: workflow %q step %q may not access agent turn %q", invocation.ErrAuthorizationDenied, callerName, step.ID, strings.TrimSpace(owned.turn.ID))
+	}
+	if model := strings.TrimSpace(step.Model); model != "" {
+		turnModel := strings.TrimSpace(owned.turn.Model)
+		sessionModel := strings.TrimSpace(owned.session.Model)
+		if turnModel != "" && turnModel != model {
+			return fmt.Errorf("%w: workflow %q step %q may not access agent model %q", invocation.ErrAuthorizationDenied, callerName, step.ID, turnModel)
+		}
+		if sessionModel != "" && sessionModel != model {
+			return fmt.Errorf("%w: workflow %q step %q may not access agent model %q", invocation.ErrAuthorizationDenied, callerName, step.ID, sessionModel)
+		}
+	}
+	if m == nil || m.turnScopes == nil {
+		return fmt.Errorf("%w: agent turn scopes are not configured", invocation.ErrInternal)
+	}
+	scope, ok := m.turnScopes.Get(owned.providerName, owned.turn.SessionID, owned.turn.ID)
+	if !ok {
+		return fmt.Errorf("%w: workflow %q step %q may not access agent turn %q", invocation.ErrAuthorizationDenied, callerName, step.ID, strings.TrimSpace(owned.turn.ID))
+	}
+	if scope.CallerKind != invocation.ProviderKindWorkflow ||
+		strings.TrimSpace(scope.CallerName) != callerName ||
+		strings.TrimSpace(scope.WorkflowRunID) != step.RunID ||
+		strings.TrimSpace(scope.WorkflowStepID) != step.ID {
+		return fmt.Errorf("%w: workflow %q step %q may not access agent turn %q", invocation.ErrAuthorizationDenied, callerName, step.ID, strings.TrimSpace(owned.turn.ID))
+	}
+	return nil
+}
+
+func agentWorkflowContext(ctx context.Context, reqContext *proto.RequestContext) map[string]any {
+	if workflow := invocation.WorkflowContextFromContext(ctx); workflow != nil {
+		return workflow
+	}
+	if workflow := reqContext.GetWorkflow(); workflow != nil {
+		return workflow.AsMap()
+	}
+	return nil
 }
 
 func (m *Manager) deleteTurnScope(providerName, sessionID, turnID string) {

--- a/gestaltd/services/agents/agentmanager/manager_test.go
+++ b/gestaltd/services/agents/agentmanager/manager_test.go
@@ -124,6 +124,43 @@ func mustProtoStruct(t testing.TB, values map[string]any) *structpb.Struct {
 	return out
 }
 
+func workflowAgentRequestContext(t testing.TB, runID, stepID, providerName, model string) *proto.RequestContext {
+	t.Helper()
+	return &proto.RequestContext{
+		Caller: &proto.ProviderContext{
+			Kind: string(invocation.ProviderKindWorkflow),
+			Name: "temporal",
+		},
+		Subject: &proto.SubjectContext{
+			Id:                  principal.UserSubjectID("runner"),
+			CredentialSubjectId: principal.UserSubjectID("runner"),
+		},
+		Workflow: mustProtoStruct(t, map[string]any{
+			"providerName":         "temporal",
+			"runId":                runID,
+			"definitionId":         "agent_review",
+			"definitionGeneration": 1,
+			"workflowKey":          "review:123",
+			"currentStepId":        stepID,
+			"currentStep": map[string]any{
+				"id":    stepID,
+				"index": 0,
+			},
+			"target": map[string]any{
+				"kind": "steps",
+				"steps": []any{
+					map[string]any{
+						"id":            stepID,
+						"kind":          "agent",
+						"agentProvider": providerName,
+						"model":         model,
+					},
+				},
+			},
+		}),
+	}
+}
+
 func mustAgentMessages(t testing.TB, messages []coreagent.Message) []*proto.AgentMessage {
 	t.Helper()
 	out, err := agentwire.MessagesToProto(messages)
@@ -910,6 +947,65 @@ func TestManagerVisibleNonOwnedSessionReadsButCannotWrite(t *testing.T) {
 		Resolution:    mustProtoStruct(t, map[string]any{"value": true}),
 	}); !errors.Is(err, core.ErrNotFound) {
 		t.Fatalf("ResolveInteraction as visible non-owner error = %v, want not found", err)
+	}
+}
+
+func TestManagerWorkflowTurnAccessRequiresSameRunAndStepScope(t *testing.T) {
+	t.Parallel()
+
+	alpha := newRouteCountingAgentProvider("alpha")
+	scopes := newAgentManagerTestTurnScopes()
+	manager := newTestManager(t, Config{
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers: map[string]*routeCountingAgentProvider{
+				"alpha": alpha,
+			},
+		},
+		TurnScopes: scopes,
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("runner")}
+	run1 := workflowAgentRequestContext(t, "run-1", "review", "alpha", "test-model")
+	run2 := workflowAgentRequestContext(t, "run-2", "review", "alpha", "test-model")
+
+	session, err := manager.CreateSession(context.Background(), p, &proto.CreateAgentProviderSessionRequest{
+		Context:      run1,
+		ProviderName: "alpha",
+		Model:        "test-model",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	turn, err := manager.CreateTurn(context.Background(), p, &proto.CreateAgentProviderTurnRequest{
+		Context:        run1,
+		TimeoutSeconds: 1,
+		SessionId:      session.ID,
+		Model:          "test-model",
+		Output:         agentTextOutputProto(),
+	})
+	if err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	scope := requireAgentManagerTurnScope(t, scopes, "alpha", session.ID, turn.ID)
+	if scope.CallerKind != invocation.ProviderKindWorkflow || scope.CallerName != "temporal" || scope.WorkflowRunID != "run-1" || scope.WorkflowStepID != "review" {
+		t.Fatalf("turn scope = %#v, want workflow temporal run-1/review", scope)
+	}
+
+	if _, err := manager.GetTurn(context.Background(), p, &proto.GetAgentProviderTurnRequest{Context: run1, TurnId: turn.ID}); err != nil {
+		t.Fatalf("GetTurn same workflow run: %v", err)
+	}
+	if _, err := manager.GetTurn(context.Background(), p, &proto.GetAgentProviderTurnRequest{Context: run2, TurnId: turn.ID}); !errors.Is(err, invocation.ErrAuthorizationDenied) {
+		t.Fatalf("GetTurn different workflow run error = %v, want authorization denied", err)
+	}
+	if _, err := manager.CancelTurn(context.Background(), p, &proto.CancelAgentProviderTurnRequest{Context: run2, TurnId: turn.ID, Reason: "wrong run"}); !errors.Is(err, invocation.ErrAuthorizationDenied) {
+		t.Fatalf("CancelTurn different workflow run error = %v, want authorization denied", err)
+	}
+	if got := alpha.turns[turn.ID].Status; got != coreagent.ExecutionStatusRunning {
+		t.Fatalf("turn status after denied cancel = %q, want running", got)
+	}
+	if _, err := manager.CancelTurn(context.Background(), p, &proto.CancelAgentProviderTurnRequest{Context: run1, TurnId: turn.ID, Reason: "done"}); err != nil {
+		t.Fatalf("CancelTurn same workflow run: %v", err)
 	}
 }
 

--- a/gestaltd/services/agents/agentturnscope/store.go
+++ b/gestaltd/services/agents/agentturnscope/store.go
@@ -21,6 +21,8 @@ type Scope struct {
 	TurnID              string
 	CallerKind          invocation.ProviderKind
 	CallerName          string
+	WorkflowRunID       string
+	WorkflowStepID      string
 	SubjectID           string
 	CredentialSubjectID string
 	Permissions         []core.AccessPermission
@@ -135,6 +137,8 @@ func cloneScope(src Scope) Scope {
 		TurnID:              strings.TrimSpace(src.TurnID),
 		CallerKind:          callerKind,
 		CallerName:          callerName,
+		WorkflowRunID:       strings.TrimSpace(src.WorkflowRunID),
+		WorkflowStepID:      strings.TrimSpace(src.WorkflowStepID),
 		SubjectID:           strings.TrimSpace(src.SubjectID),
 		CredentialSubjectID: strings.TrimSpace(src.CredentialSubjectID),
 		Permissions:         clonePermissions(src.Permissions),

--- a/gestaltd/services/agents/manager_server.go
+++ b/gestaltd/services/agents/manager_server.go
@@ -60,6 +60,9 @@ func (s *ProviderServer) CreateSession(ctx context.Context, req *proto.CreateAge
 	if err != nil {
 		return nil, err
 	}
+	if err := s.authorizeWorkflowAgentRequest(reqCtx, req.GetProviderName(), req.GetModel()); err != nil {
+		return nil, err
+	}
 	session, err := s.manager.CreateSession(s.restoreRequestContext(ctx, reqCtx), reqCtx.Principal(), req)
 	if err != nil {
 		return nil, agentManagerStatusError(err)
@@ -79,6 +82,9 @@ func (s *ProviderServer) GetSession(ctx context.Context, req *proto.GetAgentProv
 	if sessionID == "" {
 		return nil, status.Error(codes.InvalidArgument, "session_id is required")
 	}
+	if err := rejectWorkflowAgentRequest(reqCtx, "get agent sessions"); err != nil {
+		return nil, err
+	}
 	session, err := s.manager.GetSession(s.restoreRequestContext(ctx, reqCtx), reqCtx.Principal(), req)
 	if err != nil {
 		return nil, agentManagerStatusError(err)
@@ -96,6 +102,9 @@ func (s *ProviderServer) ListSessions(ctx context.Context, req *proto.ListAgentP
 	}
 	if req.GetLimit() < 0 {
 		return nil, status.Error(codes.InvalidArgument, "limit must be non-negative")
+	}
+	if err := rejectWorkflowAgentRequest(reqCtx, "list agent sessions"); err != nil {
+		return nil, err
 	}
 	sessions, err := s.manager.ListSessions(s.restoreRequestContext(ctx, reqCtx), reqCtx.Principal(), req)
 	if err != nil {
@@ -124,6 +133,9 @@ func (s *ProviderServer) UpdateSession(ctx context.Context, req *proto.UpdateAge
 	if sessionID == "" {
 		return nil, status.Error(codes.InvalidArgument, "session_id is required")
 	}
+	if err := rejectWorkflowAgentRequest(reqCtx, "update agent sessions"); err != nil {
+		return nil, err
+	}
 	session, err := s.manager.UpdateSession(s.restoreRequestContext(ctx, reqCtx), reqCtx.Principal(), req)
 	if err != nil {
 		return nil, agentManagerStatusError(err)
@@ -143,6 +155,9 @@ func (s *ProviderServer) CreateTurn(ctx context.Context, req *proto.CreateAgentP
 	if sessionID == "" {
 		return nil, status.Error(codes.InvalidArgument, "session_id is required")
 	}
+	if err := s.authorizeWorkflowAgentRequest(reqCtx, "", req.GetModel()); err != nil {
+		return nil, err
+	}
 	turn, err := s.manager.CreateTurn(s.restoreRequestContext(ctx, reqCtx), reqCtx.Principal(), req)
 	if err != nil {
 		return nil, agentManagerStatusError(err)
@@ -161,6 +176,9 @@ func (s *ProviderServer) GetTurn(ctx context.Context, req *proto.GetAgentProvide
 	turnID := strings.TrimSpace(req.GetTurnId())
 	if turnID == "" {
 		return nil, status.Error(codes.InvalidArgument, "turn_id is required")
+	}
+	if err := s.authorizeWorkflowAgentRequest(reqCtx, "", ""); err != nil {
+		return nil, err
 	}
 	turn, err := s.manager.GetTurn(s.restoreRequestContext(ctx, reqCtx), reqCtx.Principal(), req)
 	if err != nil {
@@ -183,6 +201,9 @@ func (s *ProviderServer) ListTurns(ctx context.Context, req *proto.ListAgentProv
 	}
 	if req.GetLimit() < 0 {
 		return nil, status.Error(codes.InvalidArgument, "limit must be non-negative")
+	}
+	if err := rejectWorkflowAgentRequest(reqCtx, "list agent turns"); err != nil {
+		return nil, err
 	}
 	turns, err := s.manager.ListTurns(s.restoreRequestContext(ctx, reqCtx), reqCtx.Principal(), req)
 	if err != nil {
@@ -211,6 +232,9 @@ func (s *ProviderServer) CancelTurn(ctx context.Context, req *proto.CancelAgentP
 	if turnID == "" {
 		return nil, status.Error(codes.InvalidArgument, "turn_id is required")
 	}
+	if err := s.authorizeWorkflowAgentRequest(reqCtx, "", ""); err != nil {
+		return nil, err
+	}
 	turn, err := s.manager.CancelTurn(s.restoreRequestContext(ctx, reqCtx), reqCtx.Principal(), req)
 	if err != nil {
 		return nil, agentManagerStatusError(err)
@@ -229,6 +253,9 @@ func (s *ProviderServer) ListTurnEvents(ctx context.Context, req *proto.ListAgen
 	turnID := strings.TrimSpace(req.GetTurnId())
 	if turnID == "" {
 		return nil, status.Error(codes.InvalidArgument, "turn_id is required")
+	}
+	if err := rejectWorkflowAgentRequest(reqCtx, "list agent turn events"); err != nil {
+		return nil, err
 	}
 	events, err := s.manager.ListTurnEvents(s.restoreRequestContext(ctx, reqCtx), reqCtx.Principal(), req)
 	if err != nil {
@@ -253,6 +280,9 @@ func (s *ProviderServer) ListInteractions(ctx context.Context, req *proto.ListAg
 	if turnID == "" {
 		return nil, status.Error(codes.InvalidArgument, "turn_id is required")
 	}
+	if err := rejectWorkflowAgentRequest(reqCtx, "list agent interactions"); err != nil {
+		return nil, err
+	}
 	interactions, err := s.manager.ListInteractions(s.restoreRequestContext(ctx, reqCtx), reqCtx.Principal(), req)
 	if err != nil {
 		return nil, agentManagerStatusError(err)
@@ -276,6 +306,9 @@ func (s *ProviderServer) ResolveInteraction(ctx context.Context, req *proto.Reso
 	if interactionID == "" {
 		return nil, status.Error(codes.InvalidArgument, "interaction_id is required")
 	}
+	if err := rejectWorkflowAgentRequest(reqCtx, "resolve agent interactions"); err != nil {
+		return nil, err
+	}
 	interaction, err := s.manager.ResolveInteraction(s.restoreRequestContext(ctx, reqCtx), reqCtx.Principal(), req)
 	if err != nil {
 		return nil, agentManagerStatusError(err)
@@ -288,11 +321,50 @@ func (s *ProviderServer) GetCapabilities(context.Context, *proto.GetAgentProvide
 }
 
 func (s *ProviderServer) requestContext(reqCtx *proto.RequestContext) (appaccessservice.ProviderRequestContext, error) {
-	return appaccessservice.ProviderRequestContextFromProto(reqCtx, invocation.ProviderKindApp, s.pluginName)
+	out, err := appaccessservice.ProviderRequestContextFromProto(reqCtx, "", s.pluginName)
+	if err != nil {
+		return out, err
+	}
+	switch out.CallerKind() {
+	case invocation.ProviderKindApp, invocation.ProviderKindWorkflow:
+		return out, nil
+	default:
+		return out, status.Errorf(codes.FailedPrecondition, "%s caller context is not supported for agent provider invocation", out.CallerKind())
+	}
 }
 
 func (s *ProviderServer) restoreRequestContext(ctx context.Context, reqCtx appaccessservice.ProviderRequestContext) context.Context {
 	return reqCtx.Restore(ctx, "")
+}
+
+func (s *ProviderServer) authorizeWorkflowAgentRequest(reqCtx appaccessservice.ProviderRequestContext, providerName, model string) error {
+	if reqCtx.CallerKind() != invocation.ProviderKindWorkflow {
+		return nil
+	}
+	step, err := appaccessservice.WorkflowStepInvocationFromContext(reqCtx.Workflow())
+	if err != nil {
+		return err
+	}
+	if step.ProviderName != reqCtx.CallerName() {
+		return status.Errorf(codes.PermissionDenied, "workflow caller %q does not match workflow context provider %q", reqCtx.CallerName(), step.ProviderName)
+	}
+	if step.Kind != "agent" {
+		return status.Errorf(codes.PermissionDenied, "workflow %q step %q may not invoke agent provider", reqCtx.CallerName(), step.ID)
+	}
+	if providerName = strings.TrimSpace(providerName); providerName != "" && step.AgentProvider != providerName {
+		return status.Errorf(codes.PermissionDenied, "workflow %q step %q may not invoke agent provider %q", reqCtx.CallerName(), step.ID, providerName)
+	}
+	if model = strings.TrimSpace(model); model != "" && step.Model != model {
+		return status.Errorf(codes.PermissionDenied, "workflow %q step %q may not invoke agent model %q", reqCtx.CallerName(), step.ID, model)
+	}
+	return nil
+}
+
+func rejectWorkflowAgentRequest(reqCtx appaccessservice.ProviderRequestContext, operation string) error {
+	if reqCtx.CallerKind() != invocation.ProviderKindWorkflow {
+		return nil
+	}
+	return status.Errorf(codes.PermissionDenied, "workflow callers may not %s", operation)
 }
 
 func agentManagerStatusError(err error) error {

--- a/gestaltd/services/agents/manager_server_test.go
+++ b/gestaltd/services/agents/manager_server_test.go
@@ -18,6 +18,8 @@ import (
 type recordingManagerService struct {
 	createSession func(context.Context, *principal.Principal, *proto.CreateAgentProviderSessionRequest) (*coreagent.Session, error)
 	createTurn    func(context.Context, *principal.Principal, *proto.CreateAgentProviderTurnRequest) (*coreagent.Turn, error)
+	getTurn       func(context.Context, *principal.Principal, *proto.GetAgentProviderTurnRequest) (*coreagent.Turn, error)
+	cancelTurn    func(context.Context, *principal.Principal, *proto.CancelAgentProviderTurnRequest) (*coreagent.Turn, error)
 	listSessions  func(context.Context, *principal.Principal, *proto.ListAgentProviderSessionsRequest) ([]*coreagent.Session, error)
 	listTurns     func(context.Context, *principal.Principal, *proto.ListAgentProviderTurnsRequest) ([]*coreagent.Turn, error)
 }
@@ -51,7 +53,10 @@ func (s *recordingManagerService) CreateTurn(ctx context.Context, p *principal.P
 	return nil, errors.New("unexpected CreateTurn call")
 }
 
-func (s *recordingManagerService) GetTurn(context.Context, *principal.Principal, *proto.GetAgentProviderTurnRequest) (*coreagent.Turn, error) {
+func (s *recordingManagerService) GetTurn(ctx context.Context, p *principal.Principal, req *proto.GetAgentProviderTurnRequest) (*coreagent.Turn, error) {
+	if s.getTurn != nil {
+		return s.getTurn(ctx, p, req)
+	}
 	return nil, errors.New("unexpected GetTurn call")
 }
 
@@ -62,7 +67,10 @@ func (s *recordingManagerService) ListTurns(ctx context.Context, p *principal.Pr
 	return nil, errors.New("unexpected ListTurns call")
 }
 
-func (s *recordingManagerService) CancelTurn(context.Context, *principal.Principal, *proto.CancelAgentProviderTurnRequest) (*coreagent.Turn, error) {
+func (s *recordingManagerService) CancelTurn(ctx context.Context, p *principal.Principal, req *proto.CancelAgentProviderTurnRequest) (*coreagent.Turn, error) {
+	if s.cancelTurn != nil {
+		return s.cancelTurn(ctx, p, req)
+	}
 	return nil, errors.New("unexpected CancelTurn call")
 }
 
@@ -164,6 +172,89 @@ func TestManagerServerCreateTurnForwardsStructuredOutputInputs(t *testing.T) {
 	}
 }
 
+func TestManagerServerAuthorizesWorkflowAgentStep(t *testing.T) {
+	t.Parallel()
+
+	workflow := map[string]any{
+		"providerName":         "temporal",
+		"runId":                "run-123",
+		"definitionId":         "agent_review",
+		"definitionGeneration": 2,
+		"workflowKey":          "review:123",
+		"currentStepId":        "review",
+		"currentStep": map[string]any{
+			"id":    "review",
+			"index": 0,
+		},
+		"target": map[string]any{
+			"kind": "steps",
+			"steps": []any{
+				map[string]any{
+					"id":            "review",
+					"kind":          "agent",
+					"agentProvider": "claude",
+					"model":         "default",
+				},
+			},
+		},
+	}
+	service := &recordingManagerService{
+		createSession: func(ctx context.Context, p *principal.Principal, req *proto.CreateAgentProviderSessionRequest) (*coreagent.Session, error) {
+			if got := invocation.WorkflowContextString(invocation.WorkflowContextFromContext(ctx), "currentStepId"); got != "review" {
+				t.Fatalf("workflow currentStepId = %q, want review", got)
+			}
+			return &coreagent.Session{ID: "session-1", ProviderName: req.GetProviderName(), Model: req.GetModel(), State: coreagent.SessionStateActive}, nil
+		},
+		createTurn: func(context.Context, *principal.Principal, *proto.CreateAgentProviderTurnRequest) (*coreagent.Turn, error) {
+			return &coreagent.Turn{ID: "turn-1", SessionID: "session-1", Status: coreagent.ExecutionStatusRunning}, nil
+		},
+		getTurn: func(context.Context, *principal.Principal, *proto.GetAgentProviderTurnRequest) (*coreagent.Turn, error) {
+			return &coreagent.Turn{ID: "turn-1", SessionID: "session-1", Status: coreagent.ExecutionStatusSucceeded}, nil
+		},
+		cancelTurn: func(context.Context, *principal.Principal, *proto.CancelAgentProviderTurnRequest) (*coreagent.Turn, error) {
+			return &coreagent.Turn{ID: "turn-1", SessionID: "session-1", Status: coreagent.ExecutionStatusCanceled}, nil
+		},
+	}
+	server := NewProviderServer("temporal", service)
+	ctx := agentManagerRequestContextWithCallerKind("workflow", "temporal", "user-1", workflow)
+
+	if _, err := server.CreateSession(context.Background(), &proto.CreateAgentProviderSessionRequest{
+		Context:      ctx,
+		ProviderName: "claude",
+		Model:        "default",
+	}); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if _, err := server.CreateTurn(context.Background(), &proto.CreateAgentProviderTurnRequest{
+		Context:   ctx,
+		SessionId: "session-1",
+		Model:     "default",
+	}); err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	if _, err := server.GetTurn(context.Background(), &proto.GetAgentProviderTurnRequest{
+		Context: ctx,
+		TurnId:  "turn-1",
+	}); err != nil {
+		t.Fatalf("GetTurn: %v", err)
+	}
+	if _, err := server.CancelTurn(context.Background(), &proto.CancelAgentProviderTurnRequest{
+		Context: ctx,
+		TurnId:  "turn-1",
+	}); err != nil {
+		t.Fatalf("CancelTurn: %v", err)
+	}
+
+	_, err := server.CreateSession(context.Background(), &proto.CreateAgentProviderSessionRequest{
+		Context:      ctx,
+		ProviderName: "openai",
+		Model:        "default",
+	})
+	if got := status.Code(err); got != codes.PermissionDenied {
+		t.Fatalf("CreateSession mismatched provider status = %s, want %s (err=%v)", got, codes.PermissionDenied, err)
+	}
+}
+
 func TestManagerServerForwardsBoundedListRequests(t *testing.T) {
 	t.Parallel()
 
@@ -258,9 +349,13 @@ func TestManagerServerForwardsBoundedListRequests(t *testing.T) {
 }
 
 func agentManagerRequestContext(callerApp, subjectID string, workflow map[string]any) *proto.RequestContext {
+	return agentManagerRequestContextWithCallerKind("app", callerApp, subjectID, workflow)
+}
+
+func agentManagerRequestContextWithCallerKind(callerKind, callerApp, subjectID string, workflow map[string]any) *proto.RequestContext {
 	ctx := &proto.RequestContext{
 		Caller: &proto.ProviderContext{
-			Kind: string(invocation.ProviderKindApp),
+			Kind: callerKind,
 			Name: callerApp,
 		},
 		Subject: &proto.SubjectContext{

--- a/gestaltd/services/appaccess/app_server.go
+++ b/gestaltd/services/appaccess/app_server.go
@@ -28,7 +28,7 @@ type AppServer struct {
 
 	invoker        invocation.Invoker
 	authorization  core.AuthorizationProvider
-	callerApp      string
+	callerName     string
 	accessProfiles AppAccessProfiles
 }
 
@@ -42,7 +42,7 @@ func WithAuthorizationProvider(provider core.AuthorizationProvider) AppServerOpt
 
 func WithCallerApp(callerApp string, profiles AppAccessProfiles) AppServerOption {
 	return func(s *AppServer) {
-		s.callerApp = strings.TrimSpace(callerApp)
+		s.callerName = strings.TrimSpace(callerApp)
 		s.accessProfiles = CloneAppAccessProfiles(profiles)
 	}
 }
@@ -76,7 +76,7 @@ func (s *AppServer) Invoke(ctx context.Context, req *proto.AppInvokeRequest) (*p
 	if targetOperation == "" {
 		return nil, status.Error(codes.InvalidArgument, "operation is required")
 	}
-	callCtx, err := s.requestContextForInvoke(ctx, req.GetContext(), targetApp, targetOperation, req.GetCredentialMode())
+	callCtx, err := s.requestContextForInvoke(ctx, req.GetContext(), targetApp, targetOperation, req.GetConnection(), req.GetInstance(), req.GetCredentialMode())
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +143,7 @@ func (s *AppServer) InvokeGraphQL(ctx context.Context, req *proto.AppInvokeGraph
 }
 
 type requestInvocationContext struct {
-	callerApp              string
+	callerName             string
 	callerProviderKind     invocation.ProviderKind
 	principal              *principal.Principal
 	credential             invocation.CredentialContext
@@ -153,25 +153,34 @@ type requestInvocationContext struct {
 	requestContext         *proto.RequestContext
 }
 
-func (s *AppServer) requestContextForInvoke(ctx context.Context, reqCtx *proto.RequestContext, targetApp, targetOperation, rawCredentialMode string) (requestInvocationContext, error) {
+func (s *AppServer) requestContextForInvoke(ctx context.Context, reqCtx *proto.RequestContext, targetApp, targetOperation, rawConnection, rawInstance, rawCredentialMode string) (requestInvocationContext, error) {
 	callCtx, err := s.requestContext(reqCtx)
 	if err != nil {
 		return requestInvocationContext{}, err
+	}
+	credentialMode, err := appInvokeCredentialMode(rawCredentialMode)
+	if err != nil {
+		return requestInvocationContext{}, err
+	}
+	if callCtx.callerProviderKind == invocation.ProviderKindWorkflow {
+		if err := authorizeWorkflowAppInvocation(callCtx, targetApp, targetOperation, rawConnection, rawInstance, credentialMode); err != nil {
+			return requestInvocationContext{}, err
+		}
+		if credentialMode != "" {
+			callCtx.credentialModeOverride = credentialMode
+		}
+		return callCtx, nil
 	}
 	if err := s.authorizeAppInvocation(ctx, callCtx, appInvocationAuthorizationResourceTypeOperation, appInvocationOperationResourceID(targetApp, targetOperation), targetApp, targetOperation); err != nil {
 		return requestInvocationContext{}, err
 	}
 	profile, profileOK := EffectiveAppOperationProfile(s.accessProfiles, targetApp, targetOperation)
-	credentialMode, err := appInvokeCredentialMode(rawCredentialMode)
-	if err != nil {
-		return requestInvocationContext{}, err
-	}
 	if credentialMode != "" {
 		if !profileOK {
-			return requestInvocationContext{}, status.Errorf(codes.PermissionDenied, "plugin %q may not invoke %s.%s with credential_mode %q", callCtx.callerApp, targetApp, targetOperation, credentialMode)
+			return requestInvocationContext{}, status.Errorf(codes.PermissionDenied, "plugin %q may not invoke %s.%s with credential_mode %q", callCtx.callerName, targetApp, targetOperation, credentialMode)
 		}
 		if profileOK && !appInvokeCredentialModeAllowed(credentialMode, profile) {
-			return requestInvocationContext{}, status.Errorf(codes.PermissionDenied, "plugin %q may not invoke %s.%s with credential_mode %q", callCtx.callerApp, targetApp, targetOperation, credentialMode)
+			return requestInvocationContext{}, status.Errorf(codes.PermissionDenied, "plugin %q may not invoke %s.%s with credential_mode %q", callCtx.callerName, targetApp, targetOperation, credentialMode)
 		}
 		callCtx.credentialModeOverride = credentialMode
 		callCtx.operationProfile = profile
@@ -206,15 +215,18 @@ func (s *AppServer) requestContext(reqCtx *proto.RequestContext) (requestInvocat
 	}
 	caller := reqCtx.GetCaller()
 	callerKind := invocation.ProviderKind(strings.TrimSpace(caller.GetKind()))
-	callerApp := strings.TrimSpace(caller.GetName())
-	if callerKind != invocation.ProviderKindApp || callerApp == "" {
-		return requestInvocationContext{}, status.Error(codes.FailedPrecondition, "app caller context is required")
+	callerName := strings.TrimSpace(caller.GetName())
+	if callerName == "" {
+		return requestInvocationContext{}, status.Error(codes.FailedPrecondition, "provider caller context is required")
 	}
-	if expected := strings.TrimSpace(s.callerApp); expected != "" && callerApp != expected {
-		return requestInvocationContext{}, status.Errorf(codes.PermissionDenied, "app caller context %q does not match host service caller %q", callerApp, expected)
+	if callerKind != invocation.ProviderKindApp && callerKind != invocation.ProviderKindWorkflow {
+		return requestInvocationContext{}, status.Errorf(codes.FailedPrecondition, "%s caller context is not supported for app invocation", callerKind)
+	}
+	if expected := strings.TrimSpace(s.callerName); expected != "" && callerName != expected {
+		return requestInvocationContext{}, status.Errorf(codes.PermissionDenied, "provider caller context %q does not match host service caller %q", callerName, expected)
 	}
 	return requestInvocationContext{
-		callerApp:          callerApp,
+		callerName:         callerName,
 		callerProviderKind: callerKind,
 		principal:          PrincipalFromSubjectContext(reqCtx.GetSubject()),
 		credential:         credentialFromRequestContext(reqCtx),
@@ -224,13 +236,16 @@ func (s *AppServer) requestContext(reqCtx *proto.RequestContext) (requestInvocat
 }
 
 func (s *AppServer) authorizeAppInvocation(ctx context.Context, callCtx requestInvocationContext, resourceType, resourceID, targetApp, target string) error {
+	if callCtx.callerProviderKind == invocation.ProviderKindWorkflow {
+		return status.Error(codes.PermissionDenied, "workflow callers may only invoke workflow target app operations")
+	}
 	if s == nil || s.authorization == nil {
 		return status.Error(codes.FailedPrecondition, "authorization provider is required for app invocation")
 	}
 	resp, err := s.authorization.CheckAccess(ctx, &proto.CheckAccessRequest{
 		Subject: &proto.Subject{
 			Type: appInvocationAuthorizationSubjectTypeApp,
-			Id:   callCtx.callerApp,
+			Id:   callCtx.callerName,
 		},
 		Action: &proto.Action{Name: appInvocationAuthorizationActionInvoke},
 		Resource: &proto.Resource{
@@ -239,10 +254,37 @@ func (s *AppServer) authorizeAppInvocation(ctx context.Context, callCtx requestI
 		},
 	})
 	if err != nil {
-		return status.Errorf(codes.PermissionDenied, "plugin %q may not invoke %s.%s: %v", callCtx.callerApp, targetApp, target, err)
+		return status.Errorf(codes.PermissionDenied, "plugin %q may not invoke %s.%s: %v", callCtx.callerName, targetApp, target, err)
 	}
 	if resp == nil || !resp.GetAllowed() {
-		return status.Errorf(codes.PermissionDenied, "plugin %q may not invoke %s.%s", callCtx.callerApp, targetApp, target)
+		return status.Errorf(codes.PermissionDenied, "plugin %q may not invoke %s.%s", callCtx.callerName, targetApp, target)
+	}
+	return nil
+}
+
+func authorizeWorkflowAppInvocation(callCtx requestInvocationContext, targetApp, targetOperation, rawConnection, rawInstance string, credentialMode core.ConnectionMode) error {
+	step, err := WorkflowStepInvocationFromContext(callCtx.workflow)
+	if err != nil {
+		return err
+	}
+	if step.ProviderName != callCtx.callerName {
+		return status.Errorf(codes.PermissionDenied, "workflow caller %q does not match workflow context provider %q", callCtx.callerName, step.ProviderName)
+	}
+	if step.Kind != "app" || step.App != targetApp || step.Operation != targetOperation {
+		return status.Errorf(codes.PermissionDenied, "workflow %q step %q may not invoke %s.%s", callCtx.callerName, step.ID, targetApp, targetOperation)
+	}
+	if strings.TrimSpace(rawConnection) != step.Connection {
+		return status.Errorf(codes.PermissionDenied, "workflow %q step %q may not invoke %s.%s with connection %q", callCtx.callerName, step.ID, targetApp, targetOperation, strings.TrimSpace(rawConnection))
+	}
+	if strings.TrimSpace(rawInstance) != step.Instance {
+		return status.Errorf(codes.PermissionDenied, "workflow %q step %q may not invoke %s.%s with instance %q", callCtx.callerName, step.ID, targetApp, targetOperation, strings.TrimSpace(rawInstance))
+	}
+	stepCredentialMode, err := appInvokeCredentialMode(step.CredentialMode)
+	if err != nil {
+		return err
+	}
+	if stepCredentialMode != credentialMode {
+		return status.Errorf(codes.PermissionDenied, "workflow %q step %q may not invoke %s.%s with credential_mode %q", callCtx.callerName, step.ID, targetApp, targetOperation, credentialMode)
 	}
 	return nil
 }
@@ -292,8 +334,8 @@ func restoreRequestInvocationContext(ctx context.Context, callCtx requestInvocat
 	if callCtx.principal != nil {
 		ctx = principal.WithPrincipal(ctx, principal.Canonicalized(callCtx.principal))
 	}
-	if callCtx.callerApp != "" && callCtx.callerProviderKind != "" {
-		ctx = invocation.WithCallerProvider(ctx, callCtx.callerProviderKind, callCtx.callerApp)
+	if callCtx.callerName != "" && callCtx.callerProviderKind != "" {
+		ctx = invocation.WithCallerProvider(ctx, callCtx.callerProviderKind, callCtx.callerName)
 	}
 	if meta := invocationMetaFromRequestContext(callCtx.requestContext); meta != nil {
 		ctx = invocation.ContextWithMeta(ctx, meta)

--- a/gestaltd/services/appaccess/app_test.go
+++ b/gestaltd/services/appaccess/app_test.go
@@ -235,6 +235,76 @@ func TestAppServerInvokeGraphQLAuthorizesSurface(t *testing.T) {
 	}
 }
 
+func TestAppServerInvokeAuthorizesWorkflowCurrentAppStep(t *testing.T) {
+	t.Parallel()
+
+	authz := &recordingAuthorizationProvider{allowed: false}
+	invoker := &recordingAppInvocation{}
+	server := NewAppServer(invoker, WithAuthorizationProvider(authz), WithCallerApp("temporal", nil))
+	client := proto.NewAppClient(newBufconnConn(t, func(srv *grpc.Server) {
+		proto.RegisterAppServer(srv, server)
+	}))
+	workflow := map[string]any{
+		"providerName":         "temporal",
+		"runId":                "run-123",
+		"definitionId":         "slack_reactions",
+		"definitionGeneration": 3,
+		"workflowKey":          "thread:123",
+		"currentStepId":        "react",
+		"currentStep": map[string]any{
+			"id":    "react",
+			"index": 0,
+		},
+		"target": map[string]any{
+			"kind": "steps",
+			"steps": []any{
+				map[string]any{
+					"id":             "react",
+					"kind":           "app",
+					"app":            "slack",
+					"operation":      "events.addReaction",
+					"connection":     "team-primary",
+					"credentialMode": "subject",
+				},
+			},
+		},
+	}
+
+	resp, err := client.Invoke(context.Background(), &proto.AppInvokeRequest{
+		App:            "slack",
+		Operation:      "events.addReaction",
+		Connection:     "team-primary",
+		CredentialMode: "subject",
+		Context:        requestContextWithCallerKind(t, "workflow", "temporal", workflow),
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if resp.GetStatus() != 202 || resp.GetBody() != "accepted" {
+		t.Fatalf("Invoke response = %+v, want accepted", resp)
+	}
+	if len(authz.requests) != 0 {
+		t.Fatalf("authorization requests = %d, want 0 for workflow caller", len(authz.requests))
+	}
+	if invoker.subjectID != "user:test-user" || invoker.credentialMode != core.ConnectionModeSubject {
+		t.Fatalf("invocation principal/mode = %s/%q, want workflow subject/subject", invoker.subjectID, invoker.credentialMode)
+	}
+	if got := invocation.WorkflowContextString(invoker.workflowContext, "currentStepId"); got != "react" {
+		t.Fatalf("workflow currentStepId = %q, want react", got)
+	}
+
+	_, err = client.Invoke(context.Background(), &proto.AppInvokeRequest{
+		App:            "slack",
+		Operation:      "chat.postMessage",
+		Connection:     "team-primary",
+		CredentialMode: "subject",
+		Context:        requestContextWithCallerKind(t, "workflow", "temporal", workflow),
+	})
+	if got := status.Code(err); got != codes.PermissionDenied {
+		t.Fatalf("Invoke mismatched operation status = %s, want %s (err=%v)", got, codes.PermissionDenied, err)
+	}
+}
+
 func TestAppServerInvokeFailsClosedWithoutAuthorizedCaller(t *testing.T) {
 	t.Parallel()
 
@@ -272,6 +342,10 @@ func TestAppServerInvokeFailsClosedWithoutAuthorizedCaller(t *testing.T) {
 }
 
 func requestContext(t *testing.T, caller string, workflow map[string]any) *proto.RequestContext {
+	return requestContextWithCallerKind(t, "app", caller, workflow)
+}
+
+func requestContextWithCallerKind(t *testing.T, callerKind, caller string, workflow map[string]any) *proto.RequestContext {
 	t.Helper()
 
 	var workflowStruct *structpb.Struct
@@ -296,7 +370,7 @@ func requestContext(t *testing.T, caller string, workflow map[string]any) *proto
 		},
 		Workflow: workflowStruct,
 		Caller: &proto.ProviderContext{
-			Kind: "app",
+			Kind: callerKind,
 			Name: caller,
 		},
 		Invocation: &proto.InvocationContext{

--- a/gestaltd/services/appaccess/workflow_authority.go
+++ b/gestaltd/services/appaccess/workflow_authority.go
@@ -1,0 +1,135 @@
+package appaccess
+
+import (
+	"math"
+	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type WorkflowStepInvocation struct {
+	ID                   string
+	Index                int
+	ProviderName         string
+	RunID                string
+	DefinitionID         string
+	DefinitionGeneration int64
+	WorkflowKey          string
+	WorkflowKeySet       bool
+	Kind                 string
+	App                  string
+	Operation            string
+	AgentProvider        string
+	Model                string
+	Connection           string
+	Instance             string
+	CredentialMode       string
+}
+
+func WorkflowStepInvocationFromContext(workflow map[string]any) (WorkflowStepInvocation, error) {
+	providerName := workflowString(workflow["providerName"])
+	runID := workflowString(workflow["runId"])
+	definitionID := workflowString(workflow["definitionId"])
+	definitionGeneration, ok := workflowInt64(workflow["definitionGeneration"])
+	if providerName == "" || runID == "" || definitionID == "" || !ok || definitionGeneration <= 0 {
+		return WorkflowStepInvocation{}, status.Error(codes.FailedPrecondition, "workflow run identity context is required")
+	}
+	workflowKey, workflowKeySet := workflow["workflowKey"]
+	if !workflowKeySet {
+		return WorkflowStepInvocation{}, status.Error(codes.FailedPrecondition, "workflow key context is required")
+	}
+	currentStep, ok := workflowMap(workflow["currentStep"])
+	if !ok {
+		return WorkflowStepInvocation{}, status.Error(codes.FailedPrecondition, "workflow current step context is required")
+	}
+	stepID := workflowString(currentStep["id"])
+	stepIndex, ok := workflowIndex(currentStep["index"])
+	if stepID == "" || !ok {
+		return WorkflowStepInvocation{}, status.Error(codes.FailedPrecondition, "workflow current step id and index are required")
+	}
+	target, ok := workflowMap(workflow["target"])
+	if !ok {
+		return WorkflowStepInvocation{}, status.Error(codes.FailedPrecondition, "workflow target context is required")
+	}
+	steps, ok := workflowSteps(target["steps"])
+	if !ok || stepIndex < 0 || stepIndex >= len(steps) {
+		return WorkflowStepInvocation{}, status.Error(codes.FailedPrecondition, "workflow current step index is outside the target")
+	}
+	step, ok := workflowMap(steps[stepIndex])
+	if !ok {
+		return WorkflowStepInvocation{}, status.Error(codes.FailedPrecondition, "workflow target step context is invalid")
+	}
+	if targetStepID := workflowString(step["id"]); targetStepID != stepID {
+		return WorkflowStepInvocation{}, status.Error(codes.FailedPrecondition, "workflow current step does not match the target")
+	}
+	return WorkflowStepInvocation{
+		ID:                   stepID,
+		Index:                stepIndex,
+		ProviderName:         providerName,
+		RunID:                runID,
+		DefinitionID:         definitionID,
+		DefinitionGeneration: definitionGeneration,
+		WorkflowKey:          workflowString(workflowKey),
+		WorkflowKeySet:       true,
+		Kind:                 workflowString(step["kind"]),
+		App:                  workflowString(step["app"]),
+		Operation:            workflowString(step["operation"]),
+		AgentProvider:        workflowString(step["agentProvider"]),
+		Model:                workflowString(step["model"]),
+		Connection:           workflowString(step["connection"]),
+		Instance:             workflowString(step["instance"]),
+		CredentialMode:       workflowString(step["credentialMode"]),
+	}, nil
+}
+
+func workflowMap(value any) (map[string]any, bool) {
+	m, ok := value.(map[string]any)
+	return m, ok
+}
+
+func workflowSteps(value any) ([]any, bool) {
+	switch typed := value.(type) {
+	case []any:
+		return typed, true
+	case []map[string]any:
+		out := make([]any, 0, len(typed))
+		for i := range typed {
+			out = append(out, typed[i])
+		}
+		return out, true
+	default:
+		return nil, false
+	}
+}
+
+func workflowString(value any) string {
+	text, _ := value.(string)
+	return strings.TrimSpace(text)
+}
+
+func workflowIndex(value any) (int, bool) {
+	index, ok := workflowInt64(value)
+	if !ok || index < 0 || index > int64(int(index)) {
+		return 0, false
+	}
+	return int(index), true
+}
+
+func workflowInt64(value any) (int64, bool) {
+	switch typed := value.(type) {
+	case int:
+		return int64(typed), true
+	case int32:
+		return int64(typed), true
+	case int64:
+		return typed, true
+	case float64:
+		if math.Trunc(typed) != typed {
+			return 0, false
+		}
+		return int64(typed), true
+	default:
+		return 0, false
+	}
+}

--- a/sdk/go/agent.go
+++ b/sdk/go/agent.go
@@ -33,7 +33,11 @@ var sharedAgentTransport sharedManagerTransport[proto.AgentProviderClient]
 
 // NewAgent returns an agent capability for the current provider request.
 func NewAgent(req Request) (Agent, error) {
-	return newAgent(requestContextForRequest(req))
+	reqCtx, err := requestContextForRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	return newAgent(reqCtx)
 }
 
 // NewAgentFromRequest returns an agent capability for the current provider request.

--- a/sdk/go/agent_transport_test.go
+++ b/sdk/go/agent_transport_test.go
@@ -255,6 +255,70 @@ func TestTransport_AgentWorkflowContext(t *testing.T) {
 	}
 }
 
+func TestTransport_AgentRequestBuilderCallerAndWorkflowContext(t *testing.T) {
+	address := reserveTCPAddress()
+	lis, err := net.Listen("tcp", address)
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	t.Cleanup(func() { _ = lis.Close() })
+
+	harness := &agentTransportHarness{}
+	srv := grpc.NewServer()
+	proto.RegisterAgentProviderServer(srv, harness)
+	go func() {
+		_ = srv.Serve(lis)
+	}()
+	t.Cleanup(srv.Stop)
+
+	t.Setenv(gestalt.EnvHostServiceSocket, "tcp://"+address)
+	t.Setenv(gestalt.EnvHostServiceToken, "relay-token-go")
+
+	req, err := gestalt.NewRequest(gestalt.RequestInput{
+		Subject: gestalt.Subject{ID: "service_account:workflow-runner", CredentialSubjectID: "service_account:workflow-runner"},
+		Caller:  gestalt.RequestCaller{Kind: gestalt.RequestCallerKindWorkflow, Name: "temporal"},
+		WorkflowContext: map[string]any{
+			"providerName":  "temporal",
+			"runId":         "run-1",
+			"currentStepId": "review",
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	client, err := gestalt.NewAgentFromRequest(req)
+	if err != nil {
+		t.Fatalf("Agent: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	if _, err := client.CreateSession(context.Background(), gestalt.AgentCreateSession{
+		ProviderName: "claude",
+		Model:        "default",
+	}); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if _, err := client.GetTurn(context.Background(), gestalt.AgentGetTurn{TurnID: "turn-1"}); err != nil {
+		t.Fatalf("GetTurn: %v", err)
+	}
+
+	harness.mu.Lock()
+	defer harness.mu.Unlock()
+	if len(harness.sessionRequests) != 1 || len(harness.getTurnRequests) != 1 {
+		t.Fatalf("requests = sessions:%d get:%d", len(harness.sessionRequests), len(harness.getTurnRequests))
+	}
+	got := harness.sessionRequests[0].GetContext()
+	if got.GetCaller().GetKind() != "workflow" || got.GetCaller().GetName() != "temporal" {
+		t.Fatalf("caller = %#v, want workflow temporal", got.GetCaller())
+	}
+	if got.GetWorkflow().AsMap()["currentStepId"] != "review" {
+		t.Fatalf("workflow context = %#v, want currentStepId=review", got.GetWorkflow().AsMap())
+	}
+	if got := harness.getTurnRequests[0].GetContext().GetWorkflow().AsMap()["currentStepId"]; got != "review" {
+		t.Fatalf("get workflow currentStepId = %#v, want review", got)
+	}
+}
+
 func TestTransport_AgentCreateTurnNativeValues(t *testing.T) {
 	address := reserveTCPAddress()
 	lis, err := net.Listen("tcp", address)

--- a/sdk/go/app_invocation.go
+++ b/sdk/go/app_invocation.go
@@ -50,7 +50,11 @@ var sharedAppTransport sharedManagerTransport[proto.AppClient]
 
 // NewApp returns an app invocation capability for the current provider request.
 func NewApp(req Request) (App, error) {
-	return newApp(requestContextForRequest(req))
+	reqCtx, err := requestContextForRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	return newApp(reqCtx)
 }
 
 // NewAppFromRequest returns an app invocation capability for the current

--- a/sdk/go/app_invocation_transport_test.go
+++ b/sdk/go/app_invocation_transport_test.go
@@ -223,6 +223,62 @@ func TestTransport_AppTCPTargetTokenEnv(t *testing.T) {
 	}
 }
 
+func TestTransport_AppRequestBuilderCallerAndWorkflowContext(t *testing.T) {
+	address := reserveTCPAddress()
+	lis, err := net.Listen("tcp", address)
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	t.Cleanup(func() { _ = lis.Close() })
+
+	harness := &pluginAppTransportHarness{}
+	srv := grpc.NewServer()
+	proto.RegisterAppServer(srv, harness)
+	go func() {
+		_ = srv.Serve(lis)
+	}()
+	t.Cleanup(srv.Stop)
+
+	t.Setenv(gestalt.EnvHostServiceSocket, "tcp://"+address)
+	t.Setenv(gestalt.EnvHostServiceToken, "relay-token-go")
+
+	req, err := gestalt.NewRequest(gestalt.RequestInput{
+		Subject: gestalt.Subject{ID: "service_account:workflow-runner", CredentialSubjectID: "service_account:workflow-runner"},
+		Caller:  gestalt.RequestCaller{Kind: gestalt.RequestCallerKindWorkflow, Name: "temporal"},
+		WorkflowContext: map[string]any{
+			"providerName":  "temporal",
+			"runId":         "run-1",
+			"currentStepId": "react",
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	client, err := gestalt.NewAppFromRequest(req)
+	if err != nil {
+		t.Fatalf("App: %v", err)
+	}
+	if _, err := client.Invoke(context.Background(), "slack", "events.addReaction", map[string]any{}, nil); err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+
+	harness.mu.Lock()
+	defer harness.mu.Unlock()
+	if len(harness.requests) != 1 {
+		t.Fatalf("invoke requests len = %d, want 1", len(harness.requests))
+	}
+	got := harness.requests[0].GetContext()
+	if got.GetCaller().GetKind() != "workflow" || got.GetCaller().GetName() != "temporal" {
+		t.Fatalf("caller = %#v, want workflow temporal", got.GetCaller())
+	}
+	if got.GetSubject().GetId() != "service_account:workflow-runner" {
+		t.Fatalf("subject = %q, want workflow runner", got.GetSubject().GetId())
+	}
+	if got.GetWorkflow().AsMap()["currentStepId"] != "react" {
+		t.Fatalf("workflow context = %#v, want currentStepId=react", got.GetWorkflow().AsMap())
+	}
+}
+
 func appTransportRequest() gestalt.Request {
 	return gestalt.Request{
 		Subject: gestalt.Subject{

--- a/sdk/go/router.go
+++ b/sdk/go/router.go
@@ -21,10 +21,84 @@ type Request struct {
 	Credential       Credential
 	Access           Access
 	Host             Host
+	Caller           RequestCaller
+	WorkflowContext  map[string]any
 	IdempotencyKey   string
 	ToolRefs         []AgentToolRef
 	ToolRefsSet      bool
 	requestContext   *proto.RequestContext
+}
+
+// RequestCallerKind identifies the trusted provider surface making a host
+// service request. These values match the daemon invocation caller kinds.
+type RequestCallerKind string
+
+const (
+	RequestCallerKindApp      RequestCallerKind = "app"
+	RequestCallerKindWorkflow RequestCallerKind = "workflow"
+	RequestCallerKindAgent    RequestCallerKind = "agent"
+)
+
+// RequestCaller identifies the trusted provider making a host service request.
+type RequestCaller struct {
+	Kind RequestCallerKind
+	Name string
+}
+
+// RequestInput contains the public request authority fields used to construct
+// an SDK Request and its wire RequestContext together.
+type RequestInput struct {
+	Token            string
+	ConnectionParams map[string]string
+	Subject          Subject
+	AgentSubject     Subject
+	Credential       Credential
+	Access           Access
+	Host             Host
+	Caller           RequestCaller
+	WorkflowContext  map[string]any
+	IdempotencyKey   string
+	ToolRefs         []AgentToolRef
+	ToolRefsSet      bool
+}
+
+// NewRequest builds a Request with a canonical host-service RequestContext.
+func NewRequest(input RequestInput) (Request, error) {
+	req := Request{
+		Token:            input.Token,
+		ConnectionParams: cloneStringMap(input.ConnectionParams),
+		Subject:          input.Subject,
+		AgentSubject:     input.AgentSubject,
+		Credential:       input.Credential,
+		Access:           input.Access,
+		Host:             input.Host,
+		Caller:           RequestCaller{Kind: RequestCallerKind(strings.TrimSpace(string(input.Caller.Kind))), Name: strings.TrimSpace(input.Caller.Name)},
+		IdempotencyKey:   input.IdempotencyKey,
+		ToolRefs:         copyAgentToolRefs(input.ToolRefs),
+		ToolRefsSet:      input.ToolRefsSet,
+	}
+	reqCtx, err := requestContextForRequest(req)
+	if err != nil {
+		return Request{}, err
+	}
+	if input.WorkflowContext != nil {
+		workflow, err := structFromAny(input.WorkflowContext)
+		if err != nil {
+			return Request{}, fmt.Errorf("request: encode workflow context: %w", err)
+		}
+		if workflow != nil {
+			if reqCtx == nil {
+				reqCtx = &proto.RequestContext{}
+			}
+			reqCtx.Workflow = workflow
+			req.WorkflowContext = mapFromStruct(workflow)
+		}
+	}
+	if emptyRequestContext(reqCtx) {
+		reqCtx = nil
+	}
+	req.requestContext = reqCtx
+	return req, nil
 }
 
 // ConnectionParam returns one resolved connection parameter by name and whether
@@ -42,7 +116,11 @@ func (r Request) App() (App, error) {
 }
 
 func (r Request) Workflow() (Workflow, error) {
-	client, err := newWorkflow(requestContextForRequest(r))
+	reqCtx, err := requestContextForRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	client, err := newWorkflow(reqCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -56,21 +134,35 @@ func (r Request) Agent() (Agent, error) {
 
 // RequestFromContext reconstructs the current provider request from ctx.
 func RequestFromContext(ctx context.Context) Request {
+	reqCtx := requestContextFromContext(ctx)
+	caller := RequestCaller{}
+	if protoCaller := reqCtx.GetCaller(); protoCaller != nil {
+		caller = RequestCaller{
+			Kind: RequestCallerKind(strings.TrimSpace(protoCaller.GetKind())),
+			Name: strings.TrimSpace(protoCaller.GetName()),
+		}
+	}
+	workflow := WorkflowContextFromContext(ctx)
+	if workflow == nil && reqCtx.GetWorkflow() != nil {
+		workflow = reqCtx.GetWorkflow().AsMap()
+	}
 	return Request{
-		ConnectionParams: ConnectionParams(ctx),
+		ConnectionParams: cloneStringMap(ConnectionParams(ctx)),
 		Subject:          SubjectFromContext(ctx),
 		AgentSubject:     AgentSubjectFromContext(ctx),
 		Credential:       CredentialFromContext(ctx),
 		Access:           AccessFromContext(ctx),
 		Host:             HostContextFromContext(ctx),
+		Caller:           caller,
+		WorkflowContext:  cloneWorkflowContextMap(workflow),
 		IdempotencyKey:   IdempotencyKeyFromContext(ctx),
 		ToolRefs:         ToolRefsFromContext(ctx),
 		ToolRefsSet:      ToolRefsSetFromContext(ctx),
-		requestContext:   requestContextFromContext(ctx),
+		requestContext:   reqCtx,
 	}
 }
 
-func requestContextForRequest(req Request) *proto.RequestContext {
+func requestContextForRequest(req Request) (*proto.RequestContext, error) {
 	reqCtx := cloneRequestContext(req.requestContext)
 	if reqCtx == nil {
 		reqCtx = &proto.RequestContext{}
@@ -95,14 +187,31 @@ func requestContextForRequest(req Request) *proto.RequestContext {
 	if reqCtx.Host == nil && req.Host.PublicBaseURL != "" {
 		reqCtx.Host = &proto.HostContext{PublicBaseUrl: req.Host.PublicBaseURL}
 	}
+	if reqCtx.Caller == nil {
+		callerKind := strings.TrimSpace(string(req.Caller.Kind))
+		callerName := strings.TrimSpace(req.Caller.Name)
+		if callerKind != "" || callerName != "" {
+			if callerKind == "" || callerName == "" {
+				return nil, fmt.Errorf("request: caller kind and name are required together")
+			}
+			reqCtx.Caller = &proto.ProviderContext{Kind: callerKind, Name: callerName}
+		}
+	}
+	if reqCtx.Workflow == nil && req.WorkflowContext != nil {
+		workflow, err := structFromAny(req.WorkflowContext)
+		if err != nil {
+			return nil, fmt.Errorf("request: encode workflow context: %w", err)
+		}
+		reqCtx.Workflow = workflow
+	}
 	if !reqCtx.ToolRefsSet && req.ToolRefsSet {
 		reqCtx.ToolRefsSet = true
 		reqCtx.ToolRefs = agentToolRefsToProto(req.ToolRefs)
 	}
 	if emptyRequestContext(reqCtx) {
-		return nil
+		return nil, nil
 	}
-	return reqCtx
+	return reqCtx, nil
 }
 
 func subjectContextFromSubject(subject Subject) *proto.SubjectContext {
@@ -169,6 +278,17 @@ func emptyCredential(credential Credential) bool {
 
 func emptyAccess(access Access) bool {
 	return access.Policy == "" && access.Role == ""
+}
+
+func cloneWorkflowContextMap(values map[string]any) map[string]any {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(values))
+	for key, value := range values {
+		out[key] = value
+	}
+	return out
 }
 
 func emptyRequestContext(reqCtx *proto.RequestContext) bool {

--- a/sdk/go/workflow.go
+++ b/sdk/go/workflow.go
@@ -37,7 +37,11 @@ var sharedWorkflowTransport sharedManagerTransport[proto.WorkflowProviderClient]
 
 // NewWorkflow returns a workflow capability for the current provider request.
 func NewWorkflow(req Request) (Workflow, error) {
-	return newWorkflow(requestContextForRequest(req))
+	reqCtx, err := requestContextForRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	return newWorkflow(reqCtx)
 }
 
 // NewWorkflowFromRequest returns a workflow capability for the current

--- a/sdk/go/workflow/context.go
+++ b/sdk/go/workflow/context.go
@@ -72,8 +72,15 @@ func WorkflowRunContext(req Request) map[string]any {
 		ctxValue["runId"] = runID
 	}
 	if providerName := strings.TrimSpace(req.ProviderName); providerName != "" {
-		ctxValue["provider"] = providerName
+		ctxValue["providerName"] = providerName
 	}
+	if definitionID := strings.TrimSpace(req.DefinitionID); definitionID != "" {
+		ctxValue["definitionId"] = definitionID
+	}
+	if req.DefinitionGeneration != 0 {
+		ctxValue["definitionGeneration"] = req.DefinitionGeneration
+	}
+	ctxValue["workflowKey"] = strings.TrimSpace(req.WorkflowKey)
 	if target := WorkflowTargetContext(req.Target); len(target) > 0 {
 		ctxValue["target"] = target
 	}
@@ -96,6 +103,47 @@ func WorkflowRunContext(req Request) map[string]any {
 		ctxValue["runAs"] = runAs
 	}
 	return ctxValue
+}
+
+func WorkflowStepContext(req Request, stepIndex int, stepID string) map[string]any {
+	ctxValue := WorkflowRunContext(req)
+	stepID = strings.TrimSpace(stepID)
+	ctxValue["currentStep"] = map[string]any{
+		"id":    stepID,
+		"index": stepIndex,
+	}
+	if stepID != "" {
+		ctxValue["currentStepId"] = stepID
+	}
+	return ctxValue
+}
+
+func StepInvocationRequest(req Request, stepIndex int, stepID, idempotencyKey string) (gestalt.Request, error) {
+	providerName := strings.TrimSpace(req.ProviderName)
+	if providerName == "" {
+		return gestalt.Request{}, fmt.Errorf("workflow provider name is required for step invocation")
+	}
+	if strings.TrimSpace(req.RunID) == "" {
+		return gestalt.Request{}, fmt.Errorf("workflow run id is required for step invocation")
+	}
+	if strings.TrimSpace(req.DefinitionID) == "" {
+		return gestalt.Request{}, fmt.Errorf("workflow definition id is required for step invocation")
+	}
+	if req.DefinitionGeneration <= 0 {
+		return gestalt.Request{}, fmt.Errorf("workflow definition generation is required for step invocation")
+	}
+	if req.RunAs == nil || strings.TrimSpace(req.RunAs.ID) == "" {
+		return gestalt.Request{}, fmt.Errorf("workflow runAs subject is required for step invocation")
+	}
+	return gestalt.NewRequest(gestalt.RequestInput{
+		Subject: *req.RunAs,
+		Caller: gestalt.RequestCaller{
+			Kind: gestalt.RequestCallerKindWorkflow,
+			Name: providerName,
+		},
+		WorkflowContext: WorkflowStepContext(req, stepIndex, stepID),
+		IdempotencyKey:  strings.TrimSpace(idempotencyKey),
+	})
 }
 
 func WorkflowTargetContext(target *gestalt.BoundWorkflowTarget) map[string]any {

--- a/sdk/go/workflow/executor.go
+++ b/sdk/go/workflow/executor.go
@@ -15,15 +15,18 @@ import (
 const workflowStepOutputBodyMaxBytes = 64 * 1024
 
 type Request struct {
-	ProviderName       string
-	RunID              string
-	Target             *gestalt.BoundWorkflowTarget
-	Trigger            *gestalt.WorkflowRunTrigger
-	Input              map[string]any
-	Metadata           map[string]any
-	CreatedBySubjectID string
-	RunAs              *gestalt.Subject
-	Signals            []gestalt.WorkflowSignal
+	ProviderName         string
+	RunID                string
+	DefinitionID         string
+	DefinitionGeneration int64
+	WorkflowKey          string
+	Target               *gestalt.BoundWorkflowTarget
+	Trigger              *gestalt.WorkflowRunTrigger
+	Input                map[string]any
+	Metadata             map[string]any
+	CreatedBySubjectID   string
+	RunAs                *gestalt.Subject
+	Signals              []gestalt.WorkflowSignal
 }
 
 type Response struct {
@@ -65,6 +68,7 @@ type AppInvocation struct {
 	CredentialMode  string
 	IdempotencyKey  string
 	WorkflowContext map[string]any
+	Request         gestalt.Request
 }
 
 type AppResult struct {
@@ -243,9 +247,9 @@ func (e *Executor) ExecuteStep(ctx context.Context, stepReq StepRequest) (*StepR
 		cancelStep()
 		return failedStepResponse(stepID, "invalid_step", "workflow step cannot set both app and agent", "", inputs, outputs, stepInputs), nil
 	case step.App != nil:
-		output, err = e.invokeAppStep(stepCtx, req, step.App, inputs, outputs, stepInputs, scope, stepID)
+		output, err = e.invokeAppStep(stepCtx, req, stepReq.StepIndex, step.App, inputs, outputs, stepInputs, scope, stepID)
 	case step.Agent != nil:
-		output, turnID, err = e.invokeAgentStep(stepCtx, req, step.Agent, inputs, outputs, stepInputs, sessions, scope, stepID, step.TimeoutSeconds, step.Metadata)
+		output, turnID, err = e.invokeAgentStep(stepCtx, req, stepReq.StepIndex, step.Agent, inputs, outputs, stepInputs, sessions, scope, stepID, step.TimeoutSeconds, step.Metadata)
 	default:
 		err = fmt.Errorf("workflow step must set app or agent")
 	}

--- a/sdk/go/workflow/steps.go
+++ b/sdk/go/workflow/steps.go
@@ -17,7 +17,7 @@ type appClientInvoker struct {
 }
 
 func (i appClientInvoker) InvokeWorkflowApp(ctx context.Context, call AppInvocation) (*AppResult, error) {
-	client, err := i.newApp(gestalt.RequestFromContext(ctx))
+	client, err := i.newApp(call.Request)
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +42,7 @@ func (i appClientInvoker) InvokeWorkflowApp(ctx context.Context, call AppInvocat
 	return out, nil
 }
 
-func (e *Executor) invokeAppStep(ctx context.Context, req Request, app *gestalt.WorkflowStepAppCall, inputs map[string]any, outputs map[string]any, stepInputs map[string]any, invocationScope, stepID string) (any, error) {
+func (e *Executor) invokeAppStep(ctx context.Context, req Request, stepIndex int, app *gestalt.WorkflowStepAppCall, inputs map[string]any, outputs map[string]any, stepInputs map[string]any, invocationScope, stepID string) (any, error) {
 	appName := strings.TrimSpace(app.Name)
 	operation := strings.TrimSpace(app.Operation)
 	if appName == "" || operation == "" {
@@ -70,6 +70,12 @@ func (e *Executor) invokeAppStep(ctx context.Context, req Request, app *gestalt.
 			params[key] = value
 		}
 	}
+	idempotencyKey := WorkflowStepIdempotencyKey(req, invocationScope, stepID, "step")
+	workflowContext := WorkflowStepContext(req, stepIndex, stepID)
+	request, err := StepInvocationRequest(req, stepIndex, stepID, idempotencyKey)
+	if err != nil {
+		return nil, err
+	}
 	result, err := e.appInvoker.InvokeWorkflowApp(ctx, AppInvocation{
 		App:             appName,
 		Operation:       operation,
@@ -77,8 +83,9 @@ func (e *Executor) invokeAppStep(ctx context.Context, req Request, app *gestalt.
 		Connection:      strings.TrimSpace(app.Connection),
 		Instance:        strings.TrimSpace(app.Instance),
 		CredentialMode:  strings.TrimSpace(app.CredentialMode),
-		IdempotencyKey:  WorkflowStepIdempotencyKey(req, invocationScope, stepID, "step"),
-		WorkflowContext: WorkflowRunContext(req),
+		IdempotencyKey:  idempotencyKey,
+		WorkflowContext: workflowContext,
+		Request:         request,
 	})
 	if err != nil {
 		return nil, err
@@ -90,8 +97,12 @@ func (e *Executor) invokeAppStep(ctx context.Context, req Request, app *gestalt.
 	return output, nil
 }
 
-func (e *Executor) invokeAgentStep(ctx context.Context, req Request, agent *gestalt.WorkflowStepAgentTurn, inputs map[string]any, outputs map[string]any, stepInputs map[string]any, sessions map[string]workflowAgentSessionState, invocationScope, stepID string, timeoutSeconds int32, stepMetadata any) (any, string, error) {
-	client, err := e.newAgent(gestalt.RequestFromContext(ctx))
+func (e *Executor) invokeAgentStep(ctx context.Context, req Request, stepIndex int, agent *gestalt.WorkflowStepAgentTurn, inputs map[string]any, outputs map[string]any, stepInputs map[string]any, sessions map[string]workflowAgentSessionState, invocationScope, stepID string, timeoutSeconds int32, stepMetadata any) (any, string, error) {
+	request, err := StepInvocationRequest(req, stepIndex, stepID, WorkflowStepIdempotencyKey(req, invocationScope, stepID, "agent"))
+	if err != nil {
+		return nil, "", err
+	}
+	client, err := e.newAgent(request)
 	if err != nil {
 		return nil, "", err
 	}
@@ -103,7 +114,7 @@ func (e *Executor) invokeAgentStep(ctx context.Context, req Request, agent *gest
 	if providerName == "" {
 		return nil, "", fmt.Errorf("workflow agent provider is required")
 	}
-	workflowContext := WorkflowRunContext(req)
+	workflowContext := WorkflowStepContext(req, stepIndex, stepID)
 	ctx = gestalt.WithWorkflowContext(ctx, workflowContext)
 	sessionKey := strings.TrimSpace(agent.SessionKey)
 	if sessionKey == "" {

--- a/sdk/go/workflow/workflow_test.go
+++ b/sdk/go/workflow/workflow_test.go
@@ -51,8 +51,11 @@ func TestExecutorInvokesAppStep(t *testing.T) {
 	invoker := &recordingAppInvoker{}
 	executor := New(Config{AppInvoker: invoker})
 	resp, err := executor.Execute(context.Background(), Request{
-		ProviderName: "indexeddb",
-		RunID:        "run-1",
+		ProviderName:         "indexeddb",
+		RunID:                "run-1",
+		DefinitionID:         "definition-1",
+		DefinitionGeneration: 1,
+		WorkflowKey:          "customer:ada",
 		RunAs: &gestalt.Subject{
 			ID:                  "service_account:workflow-runner",
 			CredentialSubjectID: "service_account:workflow-runner",
@@ -81,6 +84,19 @@ func TestExecutorInvokesAppStep(t *testing.T) {
 	if invoker.call.Params["text"] != "hello Ada" || invoker.call.Params["name"] != "Ada" {
 		t.Fatalf("params = %#v", invoker.call.Params)
 	}
+	if invoker.call.Request.Caller.Kind != gestalt.RequestCallerKindWorkflow || invoker.call.Request.Caller.Name != "indexeddb" {
+		t.Fatalf("request caller = %#v, want indexeddb workflow", invoker.call.Request.Caller)
+	}
+	if invoker.call.Request.Subject.ID != "service_account:workflow-runner" {
+		t.Fatalf("request subject = %#v, want workflow runner", invoker.call.Request.Subject)
+	}
+	if invoker.call.Request.WorkflowContext["definitionId"] != "definition-1" || invoker.call.Request.WorkflowContext["workflowKey"] != "customer:ada" {
+		t.Fatalf("request workflow context = %#v", invoker.call.Request.WorkflowContext)
+	}
+	currentStep := invoker.call.Request.WorkflowContext["currentStep"].(map[string]any)
+	if currentStep["id"] != "send" || currentStep["index"] != float64(0) {
+		t.Fatalf("current step = %#v, want send/0", currentStep)
+	}
 	runAs := invoker.call.WorkflowContext["runAs"].(map[string]any)
 	if runAs["id"] != "service_account:workflow-runner" {
 		t.Fatalf("workflow runAs = %#v", runAs)
@@ -105,8 +121,14 @@ func TestExecutorExecuteStepUsesPriorOutput(t *testing.T) {
 	executor := New(Config{AppInvoker: invoker})
 	resp, err := executor.ExecuteStep(context.Background(), StepRequest{
 		Request: Request{
-			ProviderName: "indexeddb",
-			RunID:        "run-1",
+			ProviderName:         "indexeddb",
+			RunID:                "run-1",
+			DefinitionID:         "definition-1",
+			DefinitionGeneration: 1,
+			RunAs: &gestalt.Subject{
+				ID:                  "service_account:workflow-runner",
+				CredentialSubjectID: "service_account:workflow-runner",
+			},
 			Target: &gestalt.BoundWorkflowTarget{Steps: []gestalt.WorkflowStep{
 				{
 					ID: "collect",
@@ -211,8 +233,10 @@ func TestExecutorInvokesAgentStepWithWorkflowRunAs(t *testing.T) {
 		AgentPollInterval: 0,
 	})
 	resp, err := executor.Execute(context.Background(), Request{
-		ProviderName: "indexeddb",
-		RunID:        "run-1",
+		ProviderName:         "indexeddb",
+		RunID:                "run-1",
+		DefinitionID:         "definition-1",
+		DefinitionGeneration: 1,
 		RunAs: &gestalt.Subject{
 			ID:                  "service_account:workflow-runner",
 			CredentialSubjectID: "service_account:workflow-runner",
@@ -249,6 +273,12 @@ func TestExecutorInvokesAgentStepWithWorkflowRunAs(t *testing.T) {
 	}
 	if agent.getTurnWorkflow["runId"] != "run-1" {
 		t.Fatalf("get turn workflow context = %#v", agent.getTurnWorkflow)
+	}
+	if agent.request.Caller.Kind != gestalt.RequestCallerKindWorkflow || agent.request.Caller.Name != "indexeddb" {
+		t.Fatalf("agent request caller = %#v, want indexeddb workflow", agent.request.Caller)
+	}
+	if agent.request.WorkflowContext["currentStepId"] != "review" {
+		t.Fatalf("agent request workflow context = %#v, want currentStepId=review", agent.request.WorkflowContext)
 	}
 }
 


### PR DESCRIPTION
## Summary

Carry workflow step authority as an explicit SDK request instead of relying on ambient context inside workflow workers.

The SDK adds `gestalt.NewRequest(...)`, `gestalt.RequestInput`, and `gestalt.RequestCaller`. Workflow app steps now carry a concrete `gestalt.Request` on `workflow.AppInvocation`, and app/agent host services accept workflow callers as first-class callers.

This lets a workflow step derive downstream app or agent authority from persisted workflow run state: provider name, run ID, definition ID/generation, workflow key, target, current step, idempotency key, created-by subject, and persisted `runAs`.

## Architecture

```mermaid
flowchart LR
  Run[(Persisted workflow run state)] --> StepReq[workflow.StepInvocationRequest]
  StepReq --> Request[gestalt.Request]
  Request --> AppInvocation[workflow.AppInvocation]
  Request --> AgentInvocation[workflow.AgentInvocation]
  AppInvocation --> AppClient[SDK app client]
  AgentInvocation --> AgentClient[SDK agent client]
  AppClient --> AppHost[gestaltd app host service]
  AgentClient --> AgentHost[gestaltd agent host service]
  AppHost --> WorkflowAuth[Workflow caller authorization]
  AgentHost --> WorkflowAuth
  WorkflowAuth --> Run
  WorkflowAuth --> Target[Current target step]
  Target --> Downstream[Allowed app or agent operation]
```

Workflow step authority now flows from persisted workflow run state into an explicit SDK request. App and agent clients no longer depend on `gestalt.RequestFromContext(ctx)` when running inside Temporal or another async worker. The host service sees a first-class workflow caller, resolves the workflow run context, and authorizes only the current target step instead of accepting broad invocation-token fallback.

## Interfaces

```go
req, err := gestalt.NewRequest(gestalt.RequestInput{
  Caller: gestalt.RequestCaller{Kind: gestalt.RequestCallerKindWorkflow, Name: providerName},
  Subject: runAs,
  WorkflowContext: map[string]any{
    "providerName": providerName,
    "runId": runID,
    "definitionId": definitionID,
    "definitionGeneration": definitionGeneration,
    "workflowKey": workflowKey,
    "currentStepId": stepID,
  },
})
```

```go
type AppInvocation struct {
  App     string
  Op      string
  Request gestalt.Request
}
```

```go
type RequestCaller struct {
  Kind RequestCallerKind
  Name string
}
```

## Runtime

`workflow.Executor` builds downstream app and agent clients from the explicit per-step request carried by the invocation. `gestaltd` app and agent host services accept workflow callers as first-class callers and authorize them against the persisted workflow run, current step, target app/agent operation, connection, instance, credential mode, and run subject.

Agent turns created by workflow steps store their workflow run and step scope, so follow-up workflow operations like polling and cancellation are bound to the same workflow step that created the turn.

## Test plan

- [x] `go test ./sdk/go/... ./gestaltd/services/appaccess ./gestaltd/services/agents ./gestaltd/services/agents/agentmanager ./gestaltd/internal/bootstrap`
- [x] `go test ./gestaltd/internal/bootstrap ./gestaltd/internal/server ./gestaltd/services/workflows/...`
- [x] `go test ./gestaltd/...`
- [x] `git diff --check`