### PR TITLE
Expose Rust agent turn request context

### DIFF
--- a/sdk/rust/src/agent.rs
+++ b/sdk/rust/src/agent.rs
@@ -662,6 +662,7 @@ pub struct CreateAgentProviderTurnRequest {
     pub subject: Option<Subject>,
     pub model_options: Option<AgentJson>,
     pub timeout_seconds: i32,
+    pub context: Option<pb::RequestContext>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -1731,6 +1732,7 @@ fn create_turn_request_from_proto(
         subject: agent_subject_from_proto(value.subject),
         model_options: json_from_struct(value.model_options),
         timeout_seconds: value.timeout_seconds,
+        context: value.context,
     })
 }
 

--- a/sdk/rust/tests/agent_transport.rs
+++ b/sdk/rust/tests/agent_transport.rs
@@ -55,6 +55,7 @@ struct TestAgentProvider {
     configured_name: Mutex<String>,
     session_context_subjects: Mutex<Vec<String>>,
     turn_context_subjects: Mutex<Vec<String>>,
+    turn_request_context_subjects: Mutex<Vec<String>>,
 }
 
 #[derive(Default, Clone)]
@@ -208,6 +209,10 @@ impl AgentProvider for TestAgentProvider {
             .push(request_context_subject_id(
                 gestalt::current_request_context().as_ref(),
             ));
+        self.turn_request_context_subjects
+            .lock()
+            .expect("turn_request_context_subjects lock")
+            .push(request_context_subject_id(request.context.as_ref()));
         Ok(AgentTurn {
             id: request.turn_id,
             session_id: request.session_id,
@@ -780,6 +785,13 @@ async fn agent_runtime_and_server_round_trip_over_unix_socket() {
             .turn_context_subjects
             .lock()
             .expect("turn_context_subjects lock"),
+        vec!["user:turn".to_string()]
+    );
+    assert_eq!(
+        *provider
+            .turn_request_context_subjects
+            .lock()
+            .expect("turn_request_context_subjects lock"),
         vec!["user:turn".to_string()]
     );
 


### PR DESCRIPTION
## Summary
- Expose `CreateAgentProviderTurnRequest.context` on the Rust provider-native SDK wrapper so Rust agent providers can read the trusted request context directly from the turn request.
- Preserve the existing wire-to-provider mapping while carrying the already-present proto `RequestContext` through `create_turn_request_from_proto`.
- Add a Rust agent transport assertion that the typed provider request carries the same context subject as the scoped provider context.

## Architecture

```mermaid
flowchart LR
  Daemon[gestaltd AgentProvider CreateTurn] --> Wire[CreateAgentProviderTurnRequest.context]
  Wire --> RustServer[Rust ProviderServer]
  RustServer --> Wrapper[gestalt::CreateAgentProviderTurnRequest.context]
  Wrapper --> Provider[Rust agent provider CreateTurn]
  Provider --> Persist[Provider stores/passes explicit request context]
```

## Test plan
- [x] `cargo fmt --check` from `sdk/rust`
- [x] `cargo test --test agent_transport` from `sdk/rust`
- [x] `git diff --check`
