### PR TITLE
Move workflow agent tools to session creation

### DIFF
--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -33,6 +33,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	gproto "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 var (
@@ -61,6 +62,12 @@ const (
 	agentDefaultToolNarrowingK   = 200
 	AgentListSummaryDefaultLimit = 100
 	AgentListMaxLimit            = 500
+)
+
+const (
+	agentSessionToolScopeMetadataKey           = "__gestalt.lifecycle.agent.tools"
+	agentSessionToolScopeMetadataSourceCatalog = "catalog"
+	agentSessionToolScopeMetadataSourceNone    = "none"
 )
 
 type AgentProviderNotAvailableError struct {
@@ -504,25 +511,54 @@ func (m *Manager) CreateSession(ctx context.Context, p *principal.Principal, req
 	if err != nil {
 		return nil, err
 	}
+	callerKind, callerName := agentCaller(ctx, req.GetContext(), providerName)
+	if callerKind != "" && callerName != "" {
+		ctx = invocation.WithCallerProvider(ctx, callerKind, callerName)
+	}
+	if _, _, err := workflowTurnScope(ctx, req.GetContext(), callerKind, providerName); err != nil {
+		return nil, err
+	}
+	ctx, providerReqContext, err := agentProviderRequestContext(ctx, p, req.GetContext(), providerName)
+	if err != nil {
+		return nil, err
+	}
+	sessionTools, err := m.agentSessionTools(ctx, p, providerName, provider, req.GetTools())
+	if err != nil {
+		return nil, err
+	}
 	idempotencyKey := strings.TrimSpace(req.GetIdempotencyKey())
 	sessionID := newAgentSessionID(providerName, subjectID, idempotencyKey, workspace != nil)
+	deterministicSession := workspace != nil && idempotencyKey != ""
+	if deterministicSession && sessionTools.set {
+		if err := m.validateExistingSessionToolScope(ctx, p, providerName, provider, sessionID, providerReqContext, sessionTools); err != nil {
+			return nil, err
+		}
+	} else if deterministicSession {
+		if err := m.validateExistingSessionWithoutSessionTools(ctx, p, providerName, provider, sessionID, providerReqContext); err != nil {
+			return nil, err
+		}
+	}
+	providerMetadata := req.GetMetadata()
+	if sessionTools.set {
+		providerMetadata, err = agentSessionMetadataWithToolScope(metadata, sessionTools)
+		if err != nil {
+			return nil, err
+		}
+	}
 	providerReq := cloneAgentRequest(req, &proto.CreateAgentProviderSessionRequest{})
 	providerReq.SessionId = sessionID
 	providerReq.IdempotencyKey = idempotencyKey
 	providerReq.ProviderName = providerName
 	providerReq.Model = strings.TrimSpace(req.GetModel())
 	providerReq.ClientRef = strings.TrimSpace(req.GetClientRef())
-	providerReq.Metadata = req.GetMetadata()
+	providerReq.Metadata = providerMetadata
 	providerReq.CreatedBySubjectId = agentSubjectIDFromPrincipal(p)
 	providerReq.Subject = agentSubjectToProto(agentSubjectFromPrincipal(p))
 	providerReq.SessionStart = sessionStartConfigToProto(sessionStart)
 	providerReq.Workspace = agentWorkspaceToProto(workspace)
 	providerReq.PreparedWorkspace = nil
-	providerReq.Tools = nil
-	ctx, providerReq.Context, err = agentProviderRequestContext(ctx, p, req.GetContext(), providerName)
-	if err != nil {
-		return nil, err
-	}
+	providerReq.Tools = sessionTools.config
+	providerReq.Context = providerReqContext
 	session, err = provider.CreateSession(ctx, providerReq)
 	if err != nil {
 		if sessionStart != nil || workspace != nil {
@@ -542,6 +578,25 @@ func (m *Manager) CreateSession(ctx context.Context, p *principal.Principal, req
 	}
 	if !providerSessionOwnedBy(normalized, p) {
 		return nil, core.ErrNotFound
+	}
+	if sessionTools.set {
+		if persistedScope, ok, err := agentSessionScopeFromMetadata(providerName, normalized); err != nil {
+			return nil, err
+		} else if !ok {
+			return nil, fmt.Errorf("%w: existing agent session is missing tool scope metadata", invocation.ErrInvalidInvocation)
+		} else if !agentSessionScopeMatchesTools(persistedScope, sessionTools) {
+			return nil, fmt.Errorf("%w: agent session tool scope does not match existing session", invocation.ErrInvalidInvocation)
+		}
+		if err := m.storeSessionScope(ctx, req.GetContext(), p, providerName, normalized.ID, callerKind, callerName, sessionTools.refs, sessionTools.listed, sessionTools.toolSource); err != nil {
+			return nil, err
+		}
+	} else {
+		if _, ok, err := agentSessionScopeFromMetadata(providerName, normalized); err != nil {
+			return nil, err
+		} else if ok {
+			return nil, fmt.Errorf("%w: existing agent session has tool scope metadata", invocation.ErrInvalidInvocation)
+		}
+		m.deleteSessionScope(providerName, normalized.ID)
 	}
 	return normalized, nil
 }
@@ -749,6 +804,9 @@ func (m *Manager) UpdateSession(ctx context.Context, p *principal.Principal, req
 	if !providerSessionOwnedBy(normalized, p) {
 		return nil, core.ErrNotFound
 	}
+	if normalized.State == coreagent.SessionStateArchived {
+		m.deleteSessionScope(owned.providerName, normalized.ID)
+	}
 	return normalized, nil
 }
 
@@ -784,14 +842,24 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req *p
 	if err != nil {
 		return nil, err
 	}
-	if toolSource == coreagent.ToolSourceModeUnspecified && len(toolRefs) > 0 {
-		toolSource = coreagent.ToolSourceModeMCPCatalog
-	}
-	if toolSource == coreagent.ToolSourceModeUnspecified && len(toolRefs) == 0 && !req.GetToolRefsSet() && defaultAgentTurnToolSource(ctx, ownedSession.provider) == coreagent.ToolSourceModeMCPCatalog {
-		toolSource = coreagent.ToolSourceModeMCPCatalog
-		toolRefs = m.defaultAgentTurnToolRefs(ctx, p, callerKind, callerName, agentwire.MessagesFromProto(req.GetMessages()))
-	}
 	toolRefsSet := req.GetToolRefsSet() || len(toolRefs) > 0
+	if sessionScope, ok, err := m.sessionScopeForSession(ownedSession.providerName, ownedSession.session); err != nil {
+		return nil, err
+	} else if ok {
+		toolSource, toolRefs, toolRefsSet, err = agentTurnToolsFromSessionScope(sessionScope, toolSource, toolRefs, toolRefsSet)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		if toolSource == coreagent.ToolSourceModeUnspecified && len(toolRefs) > 0 {
+			toolSource = coreagent.ToolSourceModeMCPCatalog
+		}
+		if toolSource == coreagent.ToolSourceModeUnspecified && len(toolRefs) == 0 && !toolRefsSet && defaultAgentTurnToolSource(ctx, ownedSession.provider) == coreagent.ToolSourceModeMCPCatalog {
+			toolSource = coreagent.ToolSourceModeMCPCatalog
+			toolRefs = m.defaultAgentTurnToolRefs(ctx, p, callerKind, callerName, agentwire.MessagesFromProto(req.GetMessages()))
+			toolRefsSet = len(toolRefs) > 0
+		}
+	}
 	requestedOutput := agentOutputFromProto(req.GetOutput())
 	if err := validateAgentOutput(requestedOutput); err != nil {
 		return nil, err
@@ -1176,6 +1244,35 @@ type accessibleAgentTurn struct {
 	turn         *coreagent.Turn
 	session      *coreagent.Session
 	sessionOwned bool
+}
+
+type agentSessionTools struct {
+	config     *proto.AgentToolConfig
+	refs       []coreagent.ToolRef
+	listed     []coreagent.ListedTool
+	toolSource coreagent.ToolSourceMode
+	set        bool
+}
+
+type agentSessionToolScopeMetadata struct {
+	Version int                           `json:"version"`
+	Source  string                        `json:"source"`
+	Refs    []agentSessionToolRefMetadata `json:"refs,omitempty"`
+}
+
+type agentSessionToolRefMetadata struct {
+	System         string                     `json:"system,omitempty"`
+	App            string                     `json:"app,omitempty"`
+	Operation      string                     `json:"operation,omitempty"`
+	Connection     string                     `json:"connection,omitempty"`
+	Instance       string                     `json:"instance,omitempty"`
+	CredentialMode string                     `json:"credentialMode,omitempty"`
+	RunAs          *agentSessionRunAsMetadata `json:"runAs,omitempty"`
+}
+
+type agentSessionRunAsMetadata struct {
+	SubjectID           string `json:"subjectId,omitempty"`
+	CredentialSubjectID string `json:"credentialSubjectId,omitempty"`
 }
 
 func (m *Manager) providerCandidates(ctx context.Context, providerName string) ([]namedAgentProvider, error) {
@@ -1586,6 +1683,137 @@ func (m *Manager) storeTurnScope(ctx context.Context, reqContext *proto.RequestC
 	})
 }
 
+func (m *Manager) storeSessionScope(ctx context.Context, reqContext *proto.RequestContext, p *principal.Principal, providerName, sessionID string, callerKind invocation.ProviderKind, callerName string, toolRefs []coreagent.ToolRef, listedTools []coreagent.ListedTool, toolSource coreagent.ToolSourceMode) error {
+	if m == nil || m.turnScopes == nil {
+		return fmt.Errorf("%w: agent turn scopes are not configured", invocation.ErrInternal)
+	}
+	workflowRunID, workflowStepID, err := workflowTurnScope(ctx, reqContext, callerKind, providerName)
+	if err != nil {
+		return err
+	}
+	subject := agentSubjectFromPrincipal(p)
+	permissions := agentTurnPermissions(ctx, p, callerKind, callerName, toolRefs)
+	connections := m.agentConnectionBindings(providerName)
+	if toolSource == coreagent.ToolSourceModeNone {
+		connections = nil
+	}
+	return m.turnScopes.PutSession(agentturnscope.Scope{
+		ProviderName:        providerName,
+		SessionID:           sessionID,
+		CallerKind:          callerKind,
+		CallerName:          callerName,
+		WorkflowRunID:       workflowRunID,
+		WorkflowStepID:      workflowStepID,
+		SubjectID:           subject.SubjectID,
+		CredentialSubjectID: subject.CredentialSubjectID,
+		Permissions:         permissions,
+		ToolRefs:            append([]coreagent.ToolRef(nil), toolRefs...),
+		ToolRefsSet:         true,
+		ListedTools:         append([]coreagent.ListedTool(nil), listedTools...),
+		ToolSource:          toolSource,
+		Connections:         connections,
+	})
+}
+
+func (m *Manager) sessionScope(providerName, sessionID string) (agentturnscope.Scope, bool) {
+	if m == nil || m.turnScopes == nil {
+		return agentturnscope.Scope{}, false
+	}
+	return m.turnScopes.GetSession(providerName, sessionID)
+}
+
+func (m *Manager) sessionScopeForSession(providerName string, session *coreagent.Session) (agentturnscope.Scope, bool, error) {
+	if session == nil {
+		return agentturnscope.Scope{}, false, nil
+	}
+	sessionID := strings.TrimSpace(session.ID)
+	if scope, ok := m.sessionScope(providerName, sessionID); ok {
+		return scope, true, nil
+	}
+	scope, ok, err := agentSessionScopeFromMetadata(providerName, session)
+	if err != nil || !ok {
+		return agentturnscope.Scope{}, ok, err
+	}
+	if m != nil && m.turnScopes != nil {
+		_ = m.turnScopes.PutSession(scope)
+	}
+	return scope, true, nil
+}
+
+func (m *Manager) validateExistingSessionToolScope(ctx context.Context, p *principal.Principal, providerName string, provider coreagent.Provider, sessionID string, reqContext *proto.RequestContext, tools agentSessionTools) error {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return nil
+	}
+	existing, err := provider.GetSession(ctx, &proto.GetAgentProviderSessionRequest{
+		SessionId: sessionID,
+		Subject:   agentSubjectToProto(agentSubjectFromPrincipal(p)),
+		Context:   reqContext,
+	})
+	if err != nil {
+		if agentProviderReturnedNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	normalized, err := normalizeProviderSession(providerName, sessionID, existing)
+	if err != nil {
+		return err
+	}
+	if !providerSessionOwnedBy(normalized, p) {
+		return core.ErrNotFound
+	}
+	persistedScope, ok, err := agentSessionScopeFromMetadata(providerName, normalized)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("%w: existing agent session is missing tool scope metadata", invocation.ErrInvalidInvocation)
+	}
+	if !agentSessionScopeMatchesTools(persistedScope, tools) {
+		return fmt.Errorf("%w: agent session tool scope does not match existing session", invocation.ErrInvalidInvocation)
+	}
+	return nil
+}
+
+func (m *Manager) validateExistingSessionWithoutSessionTools(ctx context.Context, p *principal.Principal, providerName string, provider coreagent.Provider, sessionID string, reqContext *proto.RequestContext) error {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return nil
+	}
+	existing, err := provider.GetSession(ctx, &proto.GetAgentProviderSessionRequest{
+		SessionId: sessionID,
+		Subject:   agentSubjectToProto(agentSubjectFromPrincipal(p)),
+		Context:   reqContext,
+	})
+	if err != nil {
+		if agentProviderReturnedNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	normalized, err := normalizeProviderSession(providerName, sessionID, existing)
+	if err != nil {
+		return err
+	}
+	if !providerSessionOwnedBy(normalized, p) {
+		return core.ErrNotFound
+	}
+	if _, ok, err := agentSessionScopeFromMetadata(providerName, normalized); err != nil {
+		return err
+	} else if ok {
+		return fmt.Errorf("%w: existing agent session has tool scope metadata", invocation.ErrInvalidInvocation)
+	}
+	return nil
+}
+
+func (m *Manager) deleteSessionScope(providerName, sessionID string) {
+	if m == nil || m.turnScopes == nil {
+		return
+	}
+	m.turnScopes.DeleteSession(providerName, sessionID)
+}
+
 func workflowTurnScope(ctx context.Context, reqContext *proto.RequestContext, callerKind invocation.ProviderKind, providerName string) (string, string, error) {
 	if callerKind != invocation.ProviderKindWorkflow {
 		return "", "", nil
@@ -1798,6 +2026,287 @@ func (m *Manager) listTools(ctx context.Context, p *principal.Principal, req cor
 		Tools:         tools,
 		NextPageToken: nextPageToken,
 	}, nil
+}
+
+func (m *Manager) agentSessionTools(ctx context.Context, p *principal.Principal, providerName string, provider coreagent.Provider, config *proto.AgentToolConfig) (agentSessionTools, error) {
+	if config == nil {
+		return agentSessionTools{}, nil
+	}
+	switch source := config.GetSource().(type) {
+	case *proto.AgentToolConfig_None:
+		if supported, err := agentProviderSupportsToolSource(ctx, provider, coreagent.ToolSourceModeNone); err != nil {
+			return agentSessionTools{}, err
+		} else if !supported {
+			return agentSessionTools{}, fmt.Errorf("agent provider %q does not support tool source %q", providerName, coreagent.ToolSourceModeNone)
+		}
+		return agentSessionTools{
+			config:     &proto.AgentToolConfig{Source: &proto.AgentToolConfig_None{None: &proto.AgentNoTools{}}},
+			toolSource: coreagent.ToolSourceModeNone,
+			set:        true,
+		}, nil
+	case *proto.AgentToolConfig_Catalog:
+		if supported, err := agentProviderSupportsToolSource(ctx, provider, coreagent.ToolSourceModeMCPCatalog); err != nil {
+			return agentSessionTools{}, err
+		} else if !supported {
+			return agentSessionTools{}, fmt.Errorf("agent provider %q does not support tool source %q", providerName, coreagent.ToolSourceModeMCPCatalog)
+		}
+		catalog := source.Catalog
+		if catalog == nil {
+			catalog = &proto.AgentCatalogToolConfig{}
+		}
+		refs, err := normalizeToolRefs(agentwire.ToolRefsFromProto(catalog.GetRefs()))
+		if err != nil {
+			return agentSessionTools{}, err
+		}
+		if err := validateMCPCatalogToolRefs(refs); err != nil {
+			return agentSessionTools{}, err
+		}
+		if err := m.authorizeToolRefs(ctx, p, refs); err != nil {
+			return agentSessionTools{}, err
+		}
+		var listed []coreagent.ListedTool
+		if len(refs) > 0 {
+			listResp, err := m.listTools(ctx, p, coreagent.ListToolsRequest{
+				ProviderName: providerName,
+				PageSize:     agentToolListMaxPageSize,
+				ToolRefs:     refs,
+				ToolSource:   coreagent.ToolSourceModeMCPCatalog,
+			})
+			if err != nil {
+				return agentSessionTools{}, err
+			}
+			if listResp != nil {
+				listed = append([]coreagent.ListedTool(nil), listResp.Tools...)
+			}
+		}
+		return agentSessionTools{
+			config: &proto.AgentToolConfig{Source: &proto.AgentToolConfig_Catalog{Catalog: &proto.AgentCatalogToolConfig{
+				Refs:  agentwire.ToolRefsToProto(refs),
+				Tools: listedAgentToolsToProto(listed),
+			}}},
+			refs:       refs,
+			listed:     listed,
+			toolSource: coreagent.ToolSourceModeMCPCatalog,
+			set:        true,
+		}, nil
+	default:
+		return agentSessionTools{}, fmt.Errorf("%w: agent session tools source is required", invocation.ErrInvalidInvocation)
+	}
+}
+
+func agentSessionMetadataWithToolScope(metadata map[string]any, tools agentSessionTools) (*structpb.Struct, error) {
+	withScope := maps.Clone(metadata)
+	if withScope == nil {
+		withScope = map[string]any{}
+	}
+	scope, err := agentSessionToolScopeMetadataFromTools(tools)
+	if err != nil {
+		return nil, err
+	}
+	scopeValue, err := agentSessionToolScopeMetadataValue(scope)
+	if err != nil {
+		return nil, err
+	}
+	withScope[agentSessionToolScopeMetadataKey] = scopeValue
+	return protoutil.StructFromMap(withScope)
+}
+
+func agentSessionToolScopeMetadataValue(scope agentSessionToolScopeMetadata) (map[string]any, error) {
+	encoded, err := json.Marshal(scope)
+	if err != nil {
+		return nil, err
+	}
+	var out map[string]any
+	if err := json.Unmarshal(encoded, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func agentSessionToolScopeMetadataFromTools(tools agentSessionTools) (agentSessionToolScopeMetadata, error) {
+	source, err := agentSessionToolScopeMetadataSource(tools.toolSource)
+	if err != nil {
+		return agentSessionToolScopeMetadata{}, err
+	}
+	return agentSessionToolScopeMetadata{
+		Version: 1,
+		Source:  source,
+		Refs:    agentSessionToolRefsMetadataFromCore(tools.refs),
+	}, nil
+}
+
+func agentSessionScopeFromMetadata(providerName string, session *coreagent.Session) (agentturnscope.Scope, bool, error) {
+	if session == nil || session.Metadata == nil {
+		return agentturnscope.Scope{}, false, nil
+	}
+	value, ok := session.Metadata[agentSessionToolScopeMetadataKey]
+	if !ok {
+		return agentturnscope.Scope{}, false, nil
+	}
+	var metadata agentSessionToolScopeMetadata
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return agentturnscope.Scope{}, true, fmt.Errorf("%w: invalid agent session tool metadata", invocation.ErrInvalidInvocation)
+	}
+	if err := json.Unmarshal(encoded, &metadata); err != nil {
+		return agentturnscope.Scope{}, true, fmt.Errorf("%w: invalid agent session tool metadata", invocation.ErrInvalidInvocation)
+	}
+	source, err := agentSessionToolScopeMetadataCoreSource(metadata.Source)
+	if err != nil {
+		return agentturnscope.Scope{}, true, err
+	}
+	refs := agentSessionToolRefsMetadataToCore(metadata.Refs)
+	if source == coreagent.ToolSourceModeNone {
+		refs = nil
+	}
+	if source == coreagent.ToolSourceModeMCPCatalog {
+		if err := validateMCPCatalogToolRefs(refs); err != nil {
+			return agentturnscope.Scope{}, true, err
+		}
+	}
+	return agentturnscope.Scope{
+		ProviderName: strings.TrimSpace(providerName),
+		SessionID:    strings.TrimSpace(session.ID),
+		ToolRefs:     refs,
+		ToolRefsSet:  true,
+		ToolSource:   source,
+	}, true, nil
+}
+
+func agentSessionToolScopeMetadataSource(source coreagent.ToolSourceMode) (string, error) {
+	switch normalizeAgentToolSource(source) {
+	case coreagent.ToolSourceModeMCPCatalog:
+		return agentSessionToolScopeMetadataSourceCatalog, nil
+	case coreagent.ToolSourceModeNone:
+		return agentSessionToolScopeMetadataSourceNone, nil
+	default:
+		return "", fmt.Errorf("%w: unsupported agent session tool source %q", invocation.ErrInvalidInvocation, source)
+	}
+}
+
+func agentSessionToolScopeMetadataCoreSource(source string) (coreagent.ToolSourceMode, error) {
+	switch strings.TrimSpace(source) {
+	case agentSessionToolScopeMetadataSourceCatalog:
+		return coreagent.ToolSourceModeMCPCatalog, nil
+	case agentSessionToolScopeMetadataSourceNone:
+		return coreagent.ToolSourceModeNone, nil
+	default:
+		return "", fmt.Errorf("%w: unsupported agent session tool source %q", invocation.ErrInvalidInvocation, source)
+	}
+}
+
+func agentSessionToolRefsMetadataFromCore(refs []coreagent.ToolRef) []agentSessionToolRefMetadata {
+	if len(refs) == 0 {
+		return nil
+	}
+	out := make([]agentSessionToolRefMetadata, 0, len(refs))
+	for i := range refs {
+		ref := normalizeToolRefForCompare(refs[i])
+		out = append(out, agentSessionToolRefMetadata{
+			System:         ref.System,
+			App:            ref.App,
+			Operation:      ref.Operation,
+			Connection:     ref.Connection,
+			Instance:       ref.Instance,
+			CredentialMode: string(ref.CredentialMode),
+			RunAs:          agentSessionRunAsMetadataFromCore(ref.RunAs),
+		})
+	}
+	return out
+}
+
+func agentSessionToolRefsMetadataToCore(refs []agentSessionToolRefMetadata) []coreagent.ToolRef {
+	if len(refs) == 0 {
+		return nil
+	}
+	out := make([]coreagent.ToolRef, 0, len(refs))
+	for i := range refs {
+		out = append(out, normalizeToolRefForCompare(coreagent.ToolRef{
+			System:         refs[i].System,
+			App:            refs[i].App,
+			Operation:      refs[i].Operation,
+			Connection:     refs[i].Connection,
+			Instance:       refs[i].Instance,
+			CredentialMode: core.ConnectionMode(refs[i].CredentialMode),
+			RunAs:          agentSessionRunAsMetadataToCore(refs[i].RunAs),
+		}))
+	}
+	return out
+}
+
+func agentSessionRunAsMetadataFromCore(runAs *core.RunAsSubject) *agentSessionRunAsMetadata {
+	normalized := core.NormalizeRunAsSubject(runAs)
+	if normalized == nil {
+		return nil
+	}
+	return &agentSessionRunAsMetadata{
+		SubjectID:           normalized.SubjectID,
+		CredentialSubjectID: normalized.CredentialSubjectID,
+	}
+}
+
+func agentSessionRunAsMetadataToCore(runAs *agentSessionRunAsMetadata) *core.RunAsSubject {
+	if runAs == nil {
+		return nil
+	}
+	return core.NormalizeRunAsSubject(&core.RunAsSubject{
+		SubjectID:           runAs.SubjectID,
+		CredentialSubjectID: runAs.CredentialSubjectID,
+	})
+}
+
+func agentSessionScopeMatchesTools(scope agentturnscope.Scope, tools agentSessionTools) bool {
+	if normalizeAgentToolSource(scope.ToolSource) != normalizeAgentToolSource(tools.toolSource) {
+		return false
+	}
+	return agentToolRefsEqual(scope.ToolRefs, tools.refs)
+}
+
+func agentToolRefsEqual(left, right []coreagent.ToolRef) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	counts := make(map[agentToolRefCompareKey]int, len(left))
+	for i := range left {
+		counts[agentToolRefCompareKeyFromRef(left[i])]++
+	}
+	for i := range right {
+		key := agentToolRefCompareKeyFromRef(right[i])
+		if counts[key] == 0 {
+			return false
+		}
+		counts[key]--
+	}
+	return true
+}
+
+type agentToolRefCompareKey struct {
+	System          string
+	App             string
+	Operation       string
+	Connection      string
+	Instance        string
+	CredentialMode  core.ConnectionMode
+	RunAsSubject    string
+	RunAsCredential string
+}
+
+func agentToolRefCompareKeyFromRef(ref coreagent.ToolRef) agentToolRefCompareKey {
+	normalized := normalizeToolRefForCompare(ref)
+	runAs := core.NormalizeRunAsSubject(normalized.RunAs)
+	key := agentToolRefCompareKey{
+		System:         normalized.System,
+		App:            normalized.App,
+		Operation:      normalized.Operation,
+		Connection:     normalized.Connection,
+		Instance:       normalized.Instance,
+		CredentialMode: normalized.CredentialMode,
+	}
+	if runAs != nil {
+		key.RunAsSubject = runAs.SubjectID
+		key.RunAsCredential = runAs.CredentialSubjectID
+	}
+	return key
 }
 
 func (m *Manager) searchWorkflowSystemTools(ctx context.Context, p *principal.Principal, refs []coreagent.ToolRef) ([]coreagent.Tool, error) {
@@ -2230,6 +2739,145 @@ func unavailableAgentToolCandidate(ref coreagent.ToolRef, err error) agentToolUn
 
 func listedAgentToolUnavailable(tool coreagent.ListedTool) bool {
 	return tool.Target.Unavailable != nil
+}
+
+func listedAgentToolsToProto(tools []coreagent.ListedTool) []*proto.ListedAgentTool {
+	if len(tools) == 0 {
+		return nil
+	}
+	out := make([]*proto.ListedAgentTool, 0, len(tools))
+	for i := range tools {
+		out = append(out, listedAgentToolToProto(tools[i]))
+	}
+	return out
+}
+
+func listedAgentToolToProto(tool coreagent.ListedTool) *proto.ListedAgentTool {
+	return &proto.ListedAgentTool{
+		Id:           strings.TrimSpace(tool.ToolID),
+		McpName:      strings.TrimSpace(tool.MCPName),
+		Title:        strings.TrimSpace(tool.Title),
+		Description:  strings.TrimSpace(tool.Description),
+		InputSchema:  strings.TrimSpace(tool.InputSchemaJSON),
+		OutputSchema: strings.TrimSpace(tool.OutputSchemaJSON),
+		Annotations:  operationAnnotationsToProto(tool.Annotations),
+		Ref:          agentwire.ToolRefToProto(tool.Ref),
+		Tags:         append([]string(nil), tool.Tags...),
+		SearchText:   strings.TrimSpace(tool.SearchText),
+	}
+}
+
+func operationAnnotationsToProto(annotations core.CapabilityAnnotations) *proto.OperationAnnotations {
+	if annotations.ReadOnlyHint == nil &&
+		annotations.IdempotentHint == nil &&
+		annotations.DestructiveHint == nil &&
+		annotations.OpenWorldHint == nil {
+		return nil
+	}
+	return &proto.OperationAnnotations{
+		ReadOnlyHint:    annotations.ReadOnlyHint,
+		IdempotentHint:  annotations.IdempotentHint,
+		DestructiveHint: annotations.DestructiveHint,
+		OpenWorldHint:   annotations.OpenWorldHint,
+	}
+}
+
+func agentTurnToolsFromSessionScope(scope agentturnscope.Scope, requestedSource coreagent.ToolSourceMode, requestedRefs []coreagent.ToolRef, requestedRefsSet bool) (coreagent.ToolSourceMode, []coreagent.ToolRef, bool, error) {
+	sessionSource := normalizeAgentToolSource(scope.ToolSource)
+	if requestedSource != coreagent.ToolSourceModeUnspecified && requestedSource != sessionSource {
+		return "", nil, false, fmt.Errorf("%w: agent turn tool source %q does not match session tool source %q", invocation.ErrInvalidInvocation, requestedSource, sessionSource)
+	}
+	if requestedRefsSet {
+		if sessionSource == coreagent.ToolSourceModeNone && len(requestedRefs) > 0 {
+			return "", nil, false, fmt.Errorf("%w: toolRefs are not supported with agent tool source %q", invocation.ErrInvalidInvocation, sessionSource)
+		}
+		if !agentToolRefsWithinSessionScope(requestedRefs, scope.ToolRefs) {
+			return "", nil, false, fmt.Errorf("%w: agent turn toolRefs must be a subset of session toolRefs", invocation.ErrAuthorizationDenied)
+		}
+		return sessionSource, append([]coreagent.ToolRef(nil), requestedRefs...), true, nil
+	}
+	return sessionSource, append([]coreagent.ToolRef(nil), scope.ToolRefs...), true, nil
+}
+
+func agentToolRefsWithinSessionScope(requested, allowed []coreagent.ToolRef) bool {
+	if len(requested) == 0 {
+		return true
+	}
+	if len(allowed) == 0 {
+		return false
+	}
+	for i := range requested {
+		ok := false
+		for j := range allowed {
+			if agentToolRefAllowsSessionRef(allowed[j], requested[i]) {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func agentToolRefAllowsSessionRef(allowed, requested coreagent.ToolRef) bool {
+	allowed = normalizeToolRefForCompare(allowed)
+	requested = normalizeToolRefForCompare(requested)
+	if allowed.System != "" || requested.System != "" {
+		return allowed.System != "" &&
+			allowed.System == requested.System &&
+			agentOptionalScopeFieldAllows(allowed.Operation, requested.Operation) &&
+			agentOptionalScopeFieldAllows(allowed.App, requested.App)
+	}
+	if allowed.App != agentToolSearchAllApp && allowed.App != requested.App {
+		return false
+	}
+	if !agentOptionalScopeFieldAllows(allowed.Operation, requested.Operation) {
+		return false
+	}
+	if !agentOptionalScopeFieldAllows(allowed.Connection, requested.Connection) {
+		return false
+	}
+	if !agentOptionalScopeFieldAllows(allowed.Instance, requested.Instance) {
+		return false
+	}
+	if allowed.CredentialMode != "" && allowed.CredentialMode != requested.CredentialMode {
+		return false
+	}
+	if allowed.RunAs != nil {
+		if requested.RunAs == nil {
+			return false
+		}
+		return allowed.RunAs.SubjectID == requested.RunAs.SubjectID &&
+			allowed.RunAs.CredentialSubjectID == requested.RunAs.CredentialSubjectID
+	}
+	return true
+}
+
+func normalizeToolRefForCompare(ref coreagent.ToolRef) coreagent.ToolRef {
+	ref.System = strings.TrimSpace(ref.System)
+	ref.App = strings.TrimSpace(ref.App)
+	ref.Operation = strings.TrimSpace(ref.Operation)
+	ref.Connection = strings.TrimSpace(ref.Connection)
+	ref.Instance = strings.TrimSpace(ref.Instance)
+	ref.CredentialMode = core.NormalizeOptionalConnectionMode(ref.CredentialMode)
+	ref.RunAs = core.NormalizeRunAsSubject(ref.RunAs)
+	return ref
+}
+
+func agentOptionalScopeFieldAllows(allowed, requested string) bool {
+	allowed = strings.TrimSpace(allowed)
+	requested = strings.TrimSpace(requested)
+	return allowed == "" || allowed == requested
+}
+
+func normalizeAgentToolSource(source coreagent.ToolSourceMode) coreagent.ToolSourceMode {
+	source = coreagent.ToolSourceMode(strings.TrimSpace(string(source)))
+	if source == "" {
+		return coreagent.ToolSourceModeUnspecified
+	}
+	return source
 }
 
 func unavailableAgentToolReason(err error) string {

--- a/gestaltd/services/agents/agentmanager/manager_test.go
+++ b/gestaltd/services/agents/agentmanager/manager_test.go
@@ -707,12 +707,14 @@ func TestCreateSessionUsesStableWorkspaceSessionIDWithIdempotencyKey(t *testing.
 	}
 }
 
-func TestCreateSessionClearsCallerPreparedWorkspaceAndTools(t *testing.T) {
+func TestCreateSessionClearsCallerPreparedWorkspaceAndSanitizesTools(t *testing.T) {
 	t.Parallel()
 
 	provider := newRouteCountingAgentProvider("alpha")
 	provider.supportsWorkspace = true
+	slack := agentCatalogTestProvider("slack", "Slack", "chat.postMessage")
 	manager := newTestManager(t, Config{
+		Providers: testutil.NewProviderRegistry(t, slack),
 		Agent: &routeCountingAgentControl{
 			defaultName: "alpha",
 			names:       []string{"alpha"},
@@ -744,8 +746,521 @@ func TestCreateSessionClearsCallerPreparedWorkspaceAndTools(t *testing.T) {
 	if got := provider.createSessionReqs[0].GetPreparedWorkspace(); got != nil {
 		t.Fatalf("PreparedWorkspace = %#v, want nil", got)
 	}
-	if got := provider.createSessionReqs[0].GetTools(); got != nil {
-		t.Fatalf("Tools = %#v, want nil", got)
+	tools := provider.createSessionReqs[0].GetTools().GetCatalog().GetTools()
+	if len(tools) != 1 {
+		t.Fatalf("Tools = %#v, want one hydrated listed tool", tools)
+	}
+	if got := tools[0].GetId(); got == "tool-spoofed" {
+		t.Fatalf("Tools[0].id = %q, want manager-hydrated tool id", got)
+	}
+	if got := tools[0].GetRef().GetOperation(); got != "chat.postMessage" {
+		t.Fatalf("Tools[0] operation = %q, want chat.postMessage", got)
+	}
+}
+
+func TestCreateSessionRejectsInvalidWorkflowScopeBeforeProviderCreate(t *testing.T) {
+	t.Parallel()
+
+	provider := newRouteCountingAgentProvider("alpha")
+	manager := newTestManager(t, Config{
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers:   map[string]*routeCountingAgentProvider{"alpha": provider},
+		},
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("runner")}
+
+	_, err := manager.CreateSession(context.Background(), p, &proto.CreateAgentProviderSessionRequest{
+		Context:      workflowAgentRequestContext(t, "run-1", "review", "beta", "test-model"),
+		ProviderName: "alpha",
+		Model:        "test-model",
+	})
+	if !errors.Is(err, invocation.ErrAuthorizationDenied) {
+		t.Fatalf("CreateSession error = %v, want authorization denied", err)
+	}
+	if len(provider.createSessionReqs) != 0 {
+		t.Fatalf("CreateSession calls = %d, want 0", len(provider.createSessionReqs))
+	}
+}
+
+func TestCreateSessionHydratesAndStoresSessionTools(t *testing.T) {
+	t.Parallel()
+
+	slack := agentCatalogTestProvider("slack", "Slack", "chat.postMessage")
+	alpha := newRouteCountingAgentProvider("alpha")
+	scopes := newAgentManagerTestTurnScopes()
+	manager := newTestManager(t, Config{
+		Providers: testutil.NewProviderRegistry(t, slack),
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers:   map[string]*routeCountingAgentProvider{"alpha": alpha},
+		},
+		TurnScopes: scopes,
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+
+	session, err := manager.CreateSession(context.Background(), p, &proto.CreateAgentProviderSessionRequest{
+		ProviderName: "alpha",
+		Model:        "test-model",
+		Tools: &proto.AgentToolConfig{Source: &proto.AgentToolConfig_Catalog{Catalog: &proto.AgentCatalogToolConfig{
+			Refs: []*proto.AgentToolRef{{
+				App:       "slack",
+				Operation: "chat.postMessage",
+			}},
+		}}},
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if len(alpha.createSessionReqs) != 1 {
+		t.Fatalf("CreateSession calls = %d, want 1", len(alpha.createSessionReqs))
+	}
+	catalogTools := alpha.createSessionReqs[0].GetTools().GetCatalog()
+	if catalogTools == nil {
+		t.Fatalf("provider session tools = %#v, want catalog", alpha.createSessionReqs[0].GetTools())
+	}
+	if got := catalogTools.GetRefs()[0].GetOperation(); got != "chat.postMessage" {
+		t.Fatalf("provider session tool ref operation = %q, want chat.postMessage", got)
+	}
+	if got := catalogTools.GetTools()[0].GetRef().GetOperation(); got != "chat.postMessage" {
+		t.Fatalf("provider listed tool operation = %q, want chat.postMessage", got)
+	}
+	scope, ok := scopes.GetSession("alpha", session.ID)
+	if !ok {
+		t.Fatal("session scope was not stored")
+	}
+	if scope.ToolSource != coreagent.ToolSourceModeMCPCatalog {
+		t.Fatalf("session scope tool source = %q, want mcp catalog", scope.ToolSource)
+	}
+	if len(scope.ToolRefs) != 1 || scope.ToolRefs[0].Operation != "chat.postMessage" {
+		t.Fatalf("session scope refs = %#v, want slack chat.postMessage", scope.ToolRefs)
+	}
+	if len(scope.ListedTools) != 1 || scope.ListedTools[0].Ref.Operation != "chat.postMessage" {
+		t.Fatalf("session scope listed tools = %#v, want chat.postMessage", scope.ListedTools)
+	}
+	if _, err := manager.UpdateSession(context.Background(), p, &proto.UpdateAgentProviderSessionRequest{
+		SessionId: session.ID,
+		State:     proto.AgentSessionState_AGENT_SESSION_STATE_ARCHIVED,
+	}); err != nil {
+		t.Fatalf("UpdateSession archive: %v", err)
+	}
+	if _, ok := scopes.GetSession("alpha", session.ID); ok {
+		t.Fatal("archived session scope was not deleted")
+	}
+}
+
+func TestCreateSessionRejectsIdempotentToolScopeMismatchBeforeProviderCreate(t *testing.T) {
+	t.Parallel()
+
+	slack := agentCatalogTestProvider("slack", "Slack", "chat.postMessage")
+	github := agentCatalogTestProvider("github", "GitHub", "issues.create")
+	alpha := newRouteCountingAgentProvider("alpha")
+	alpha.supportsWorkspace = true
+	scopes := newAgentManagerTestTurnScopes()
+	manager := newTestManager(t, Config{
+		Providers: testutil.NewProviderRegistry(t, slack, github),
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers:   map[string]*routeCountingAgentProvider{"alpha": alpha},
+		},
+		TurnScopes: scopes,
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+	workspace := &proto.AgentWorkspace{
+		Checkouts: []*proto.AgentWorkspaceGitCheckout{{
+			Url:  "https://github.com/valon-technologies/gestalt.git",
+			Ref:  "main",
+			Path: "repo",
+		}},
+		Cwd: "repo",
+	}
+
+	session, err := manager.CreateSession(context.Background(), p, &proto.CreateAgentProviderSessionRequest{
+		ProviderName:   "alpha",
+		Model:          "test-model",
+		IdempotencyKey: "workspace-review",
+		Workspace:      workspace,
+		Tools: &proto.AgentToolConfig{Source: &proto.AgentToolConfig_Catalog{Catalog: &proto.AgentCatalogToolConfig{
+			Refs: []*proto.AgentToolRef{{
+				App:       "slack",
+				Operation: "chat.postMessage",
+			}},
+		}}},
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	scopes.DeleteSession("alpha", session.ID)
+
+	_, err = manager.CreateSession(context.Background(), p, &proto.CreateAgentProviderSessionRequest{
+		ProviderName:   "alpha",
+		Model:          "test-model",
+		IdempotencyKey: "workspace-review",
+		Workspace:      workspace,
+		Tools: &proto.AgentToolConfig{Source: &proto.AgentToolConfig_Catalog{Catalog: &proto.AgentCatalogToolConfig{
+			Refs: []*proto.AgentToolRef{{
+				App:       "github",
+				Operation: "issues.create",
+			}},
+		}}},
+	})
+	if !errors.Is(err, invocation.ErrInvalidInvocation) {
+		t.Fatalf("CreateSession error = %v, want invalid invocation", err)
+	}
+	if len(alpha.createSessionReqs) != 1 {
+		t.Fatalf("CreateSession calls = %d, want only the initial create", len(alpha.createSessionReqs))
+	}
+}
+
+func TestCreateSessionRejectsExistingSessionMissingToolScopeMetadata(t *testing.T) {
+	t.Parallel()
+
+	slack := agentCatalogTestProvider("slack", "Slack", "chat.postMessage")
+	alpha := newRouteCountingAgentProvider("alpha")
+	alpha.supportsWorkspace = true
+	scopes := newAgentManagerTestTurnScopes()
+	manager := newTestManager(t, Config{
+		Providers: testutil.NewProviderRegistry(t, slack),
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers:   map[string]*routeCountingAgentProvider{"alpha": alpha},
+		},
+		TurnScopes: scopes,
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+	workspace := &proto.AgentWorkspace{
+		Checkouts: []*proto.AgentWorkspaceGitCheckout{{
+			Url:  "https://github.com/valon-technologies/gestalt.git",
+			Ref:  "main",
+			Path: "repo",
+		}},
+		Cwd: "repo",
+	}
+	tools := &proto.AgentToolConfig{Source: &proto.AgentToolConfig_Catalog{Catalog: &proto.AgentCatalogToolConfig{
+		Refs: []*proto.AgentToolRef{{
+			App:       "slack",
+			Operation: "chat.postMessage",
+		}},
+	}}}
+
+	session, err := manager.CreateSession(context.Background(), p, &proto.CreateAgentProviderSessionRequest{
+		ProviderName:   "alpha",
+		Model:          "test-model",
+		IdempotencyKey: "workspace-review",
+		Workspace:      workspace,
+		Tools:          tools,
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	alpha.sessions[session.ID].Metadata = nil
+	scopes.DeleteSession("alpha", session.ID)
+
+	_, err = manager.CreateSession(context.Background(), p, &proto.CreateAgentProviderSessionRequest{
+		ProviderName:   "alpha",
+		Model:          "test-model",
+		IdempotencyKey: "workspace-review",
+		Workspace:      workspace,
+		Tools:          tools,
+	})
+	if !errors.Is(err, invocation.ErrInvalidInvocation) {
+		t.Fatalf("CreateSession error = %v, want invalid invocation", err)
+	}
+	if len(alpha.createSessionReqs) != 1 {
+		t.Fatalf("CreateSession calls = %d, want only the initial create", len(alpha.createSessionReqs))
+	}
+}
+
+func TestCreateSessionWithoutToolsClearsStaleSessionScope(t *testing.T) {
+	t.Parallel()
+
+	slack := agentCatalogTestProvider("slack", "Slack", "chat.postMessage")
+	alpha := newRouteCountingAgentProvider("alpha")
+	alpha.supportsWorkspace = true
+	scopes := newAgentManagerTestTurnScopes()
+	manager := newTestManager(t, Config{
+		Providers: testutil.NewProviderRegistry(t, slack),
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers:   map[string]*routeCountingAgentProvider{"alpha": alpha},
+		},
+		TurnScopes: scopes,
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+	workspace := &proto.AgentWorkspace{
+		Checkouts: []*proto.AgentWorkspaceGitCheckout{{
+			Url:  "https://github.com/valon-technologies/gestalt.git",
+			Ref:  "main",
+			Path: "repo",
+		}},
+		Cwd: "repo",
+	}
+
+	session, err := manager.CreateSession(context.Background(), p, &proto.CreateAgentProviderSessionRequest{
+		ProviderName:   "alpha",
+		Model:          "test-model",
+		IdempotencyKey: "workspace-review",
+		Workspace:      workspace,
+		Tools: &proto.AgentToolConfig{Source: &proto.AgentToolConfig_Catalog{Catalog: &proto.AgentCatalogToolConfig{
+			Refs: []*proto.AgentToolRef{{
+				App:       "slack",
+				Operation: "chat.postMessage",
+			}},
+		}}},
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if _, ok := scopes.GetSession("alpha", session.ID); !ok {
+		t.Fatal("session scope was not stored")
+	}
+	alpha.sessions[session.ID].Metadata = nil
+
+	if _, err := manager.CreateSession(context.Background(), p, &proto.CreateAgentProviderSessionRequest{
+		ProviderName:   "alpha",
+		Model:          "test-model",
+		IdempotencyKey: "workspace-review",
+		Workspace:      workspace,
+	}); err != nil {
+		t.Fatalf("CreateSession without tools: %v", err)
+	}
+	if _, ok := scopes.GetSession("alpha", session.ID); ok {
+		t.Fatal("stale session scope was not deleted")
+	}
+}
+
+func TestCreateSessionIgnoresStaleSessionScopeWhenDurableMetadataMatches(t *testing.T) {
+	t.Parallel()
+
+	slack := agentCatalogTestProvider("slack", "Slack", "chat.postMessage")
+	github := agentCatalogTestProvider("github", "GitHub", "issues.create")
+	alpha := newRouteCountingAgentProvider("alpha")
+	alpha.supportsWorkspace = true
+	scopes := newAgentManagerTestTurnScopes()
+	manager := newTestManager(t, Config{
+		Providers: testutil.NewProviderRegistry(t, slack, github),
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers:   map[string]*routeCountingAgentProvider{"alpha": alpha},
+		},
+		TurnScopes: scopes,
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+	workspace := &proto.AgentWorkspace{
+		Checkouts: []*proto.AgentWorkspaceGitCheckout{{
+			Url:  "https://github.com/valon-technologies/gestalt.git",
+			Ref:  "main",
+			Path: "repo",
+		}},
+		Cwd: "repo",
+	}
+	tools := &proto.AgentToolConfig{Source: &proto.AgentToolConfig_Catalog{Catalog: &proto.AgentCatalogToolConfig{
+		Refs: []*proto.AgentToolRef{{
+			App:       "slack",
+			Operation: "chat.postMessage",
+		}},
+	}}}
+
+	session, err := manager.CreateSession(context.Background(), p, &proto.CreateAgentProviderSessionRequest{
+		ProviderName:   "alpha",
+		Model:          "test-model",
+		IdempotencyKey: "workspace-review",
+		Workspace:      workspace,
+		Tools:          tools,
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if err := scopes.PutSession(agentturnscope.Scope{
+		ProviderName: "alpha",
+		SessionID:    session.ID,
+		ToolRefs: []coreagent.ToolRef{{
+			App:       "github",
+			Operation: "issues.create",
+		}},
+		ToolRefsSet: true,
+		ToolSource:  coreagent.ToolSourceModeMCPCatalog,
+	}); err != nil {
+		t.Fatalf("PutSession stale scope: %v", err)
+	}
+
+	if _, err := manager.CreateSession(context.Background(), p, &proto.CreateAgentProviderSessionRequest{
+		ProviderName:   "alpha",
+		Model:          "test-model",
+		IdempotencyKey: "workspace-review",
+		Workspace:      workspace,
+		Tools:          tools,
+	}); err != nil {
+		t.Fatalf("CreateSession replay: %v", err)
+	}
+	if len(alpha.createSessionReqs) != 2 {
+		t.Fatalf("CreateSession calls = %d, want replay create", len(alpha.createSessionReqs))
+	}
+	scope, ok := scopes.GetSession("alpha", session.ID)
+	if !ok {
+		t.Fatal("session scope was not stored after replay")
+	}
+	if len(scope.ToolRefs) != 1 || scope.ToolRefs[0].App != "slack" {
+		t.Fatalf("session scope refs = %#v, want durable slack scope", scope.ToolRefs)
+	}
+}
+
+func TestCreateSessionWithoutToolsRejectsExistingScopedSession(t *testing.T) {
+	t.Parallel()
+
+	slack := agentCatalogTestProvider("slack", "Slack", "chat.postMessage")
+	alpha := newRouteCountingAgentProvider("alpha")
+	alpha.supportsWorkspace = true
+	scopes := newAgentManagerTestTurnScopes()
+	manager := newTestManager(t, Config{
+		Providers: testutil.NewProviderRegistry(t, slack),
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers:   map[string]*routeCountingAgentProvider{"alpha": alpha},
+		},
+		TurnScopes: scopes,
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+	workspace := &proto.AgentWorkspace{
+		Checkouts: []*proto.AgentWorkspaceGitCheckout{{
+			Url:  "https://github.com/valon-technologies/gestalt.git",
+			Ref:  "main",
+			Path: "repo",
+		}},
+		Cwd: "repo",
+	}
+
+	session, err := manager.CreateSession(context.Background(), p, &proto.CreateAgentProviderSessionRequest{
+		ProviderName:   "alpha",
+		Model:          "test-model",
+		IdempotencyKey: "workspace-review",
+		Workspace:      workspace,
+		Tools: &proto.AgentToolConfig{Source: &proto.AgentToolConfig_Catalog{Catalog: &proto.AgentCatalogToolConfig{
+			Refs: []*proto.AgentToolRef{{
+				App:       "slack",
+				Operation: "chat.postMessage",
+			}},
+		}}},
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	_, err = manager.CreateSession(context.Background(), p, &proto.CreateAgentProviderSessionRequest{
+		ProviderName:   "alpha",
+		Model:          "test-model",
+		IdempotencyKey: "workspace-review",
+		Workspace:      workspace,
+	})
+	if !errors.Is(err, invocation.ErrInvalidInvocation) {
+		t.Fatalf("CreateSession without tools error = %v, want invalid invocation", err)
+	}
+	if len(alpha.createSessionReqs) != 1 {
+		t.Fatalf("CreateSession calls = %d, want only the initial create", len(alpha.createSessionReqs))
+	}
+	if _, ok := scopes.GetSession("alpha", session.ID); !ok {
+		t.Fatal("existing scoped session scope was deleted")
+	}
+}
+
+func TestCreateTurnInheritsSessionToolScope(t *testing.T) {
+	t.Parallel()
+
+	slack := agentCatalogTestProvider("slack", "Slack", "chat.postMessage")
+	alpha := newRouteCountingAgentProvider("alpha")
+	scopes := newAgentManagerTestTurnScopes()
+	manager := newTestManager(t, Config{
+		Providers: testutil.NewProviderRegistry(t, slack),
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers:   map[string]*routeCountingAgentProvider{"alpha": alpha},
+		},
+		TurnScopes: scopes,
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+
+	session, err := manager.CreateSession(context.Background(), p, &proto.CreateAgentProviderSessionRequest{
+		ProviderName: "alpha",
+		Model:        "test-model",
+		Tools: &proto.AgentToolConfig{Source: &proto.AgentToolConfig_Catalog{Catalog: &proto.AgentCatalogToolConfig{
+			Refs: []*proto.AgentToolRef{{App: "slack"}},
+		}}},
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	turn, err := manager.CreateTurn(context.Background(), p, &proto.CreateAgentProviderTurnRequest{
+		SessionId:      session.ID,
+		Model:          "test-model",
+		Output:         agentTextOutputProto(),
+		TimeoutSeconds: 1,
+	})
+	if err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	if got := alpha.createTurnReqs[0].GetToolSource(); got != proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_CATALOG {
+		t.Fatalf("provider turn tool source = %s, want MCP catalog", got)
+	}
+	if len(alpha.createTurnReqs[0].GetToolRefs()) != 1 || alpha.createTurnReqs[0].GetToolRefs()[0].GetApp() != "slack" {
+		t.Fatalf("provider turn refs = %#v, want inherited slack ref", alpha.createTurnReqs[0].GetToolRefs())
+	}
+	scope := requireAgentManagerTurnScope(t, scopes, "alpha", session.ID, turn.ID)
+	if len(scope.ToolRefs) != 1 || scope.ToolRefs[0].App != "slack" {
+		t.Fatalf("turn scope refs = %#v, want inherited slack ref", scope.ToolRefs)
+	}
+}
+
+func TestCreateTurnRejectsToolsOutsideSessionScope(t *testing.T) {
+	t.Parallel()
+
+	slack := agentCatalogTestProvider("slack", "Slack", "chat.postMessage")
+	github := agentCatalogTestProvider("github", "GitHub", "issues.create")
+	alpha := newRouteCountingAgentProvider("alpha")
+	manager := newTestManager(t, Config{
+		Providers: testutil.NewProviderRegistry(t, slack, github),
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers:   map[string]*routeCountingAgentProvider{"alpha": alpha},
+		},
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+
+	session, err := manager.CreateSession(context.Background(), p, &proto.CreateAgentProviderSessionRequest{
+		ProviderName: "alpha",
+		Model:        "test-model",
+		Tools: &proto.AgentToolConfig{Source: &proto.AgentToolConfig_Catalog{Catalog: &proto.AgentCatalogToolConfig{
+			Refs: []*proto.AgentToolRef{{
+				App:       "slack",
+				Operation: "chat.postMessage",
+			}},
+		}}},
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	manager.turnScopes.DeleteSession("alpha", session.ID)
+	_, err = manager.CreateTurn(context.Background(), p, &proto.CreateAgentProviderTurnRequest{
+		SessionId:      session.ID,
+		Model:          "test-model",
+		Output:         agentTextOutputProto(),
+		TimeoutSeconds: 1,
+		ToolRefs: []*proto.AgentToolRef{{
+			App:       "github",
+			Operation: "issues.create",
+		}},
+		ToolSource: proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_CATALOG,
+	})
+	if !errors.Is(err, invocation.ErrAuthorizationDenied) {
+		t.Fatalf("CreateTurn error = %v, want authorization denied", err)
 	}
 }
 
@@ -2364,6 +2879,30 @@ func TestAgentTurnPermissionsCompactsExactRefsAfterAuthorization(t *testing.T) {
 	want := []core.AccessPermission{{App: "linear", Operations: []string{"viewer"}}}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("agentTurnPermissions = %#v, want %#v", got, want)
+	}
+}
+
+func TestAgentToolRefsEqualIgnoresOrder(t *testing.T) {
+	t.Parallel()
+
+	left := []coreagent.ToolRef{
+		{App: "slack", Operation: "chat.postMessage"},
+		{App: "github", Operation: "issues.create"},
+	}
+	right := []coreagent.ToolRef{
+		{App: "github", Operation: "issues.create"},
+		{App: "slack", Operation: "chat.postMessage"},
+	}
+	withDuplicate := []coreagent.ToolRef{
+		{App: "slack", Operation: "chat.postMessage"},
+		{App: "slack", Operation: "chat.postMessage"},
+	}
+
+	if !agentToolRefsEqual(left, right) {
+		t.Fatalf("agentToolRefsEqual(%#v, %#v) = false, want true", left, right)
+	}
+	if agentToolRefsEqual(left, withDuplicate) {
+		t.Fatalf("agentToolRefsEqual(%#v, %#v) = true, want false", left, withDuplicate)
 	}
 }
 

--- a/gestaltd/services/agents/agentturnscope/store.go
+++ b/gestaltd/services/agents/agentturnscope/store.go
@@ -28,6 +28,7 @@ type Scope struct {
 	Permissions         []core.AccessPermission
 	ToolRefs            []coreagent.ToolRef
 	ToolRefsSet         bool
+	ListedTools         []coreagent.ListedTool
 	Tools               []coreagent.Tool
 	ToolSource          coreagent.ToolSourceMode
 	Connections         []ConnectionBinding
@@ -35,12 +36,16 @@ type Scope struct {
 }
 
 type Store struct {
-	mu     sync.RWMutex
-	scopes map[string]*Scope
+	mu            sync.RWMutex
+	scopes        map[string]*Scope
+	sessionScopes map[string]*Scope
 }
 
 func NewStore() *Store {
-	return &Store{scopes: map[string]*Scope{}}
+	return &Store{
+		scopes:        map[string]*Scope{},
+		sessionScopes: map[string]*Scope{},
+	}
 }
 
 func (s *Store) Put(scope Scope) error {
@@ -58,6 +63,25 @@ func (s *Store) Put(scope Scope) error {
 		s.scopes = map[string]*Scope{}
 	}
 	s.scopes[key] = &scope
+	return nil
+}
+
+func (s *Store) PutSession(scope Scope) error {
+	scope = cloneScope(scope)
+	key := sessionScopeKey(scope.ProviderName, scope.SessionID)
+	if key == "" {
+		return fmt.Errorf("agent session scope requires provider and session")
+	}
+	scope.TurnID = ""
+	if scope.ToolRefsSet || len(scope.ToolRefs) > 0 {
+		scope.ToolRefsSet = true
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.sessionScopes == nil {
+		s.sessionScopes = map[string]*Scope{}
+	}
+	s.sessionScopes[key] = &scope
 	return nil
 }
 
@@ -92,6 +116,16 @@ func (s *Store) Delete(providerName, sessionID, turnID string) {
 	}
 }
 
+func (s *Store) DeleteSession(providerName, sessionID string) {
+	key := sessionScopeKey(providerName, sessionID)
+	if key == "" || s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.sessionScopes, key)
+}
+
 func (s *Store) Revoke(providerName, sessionID, turnID string) {
 	key := scopeKey(providerName, sessionID, turnID)
 	if key == "" || s == nil {
@@ -118,6 +152,20 @@ func (s *Store) Get(providerName, sessionID, turnID string) (Scope, bool) {
 	return cloneScope(*scope), true
 }
 
+func (s *Store) GetSession(providerName, sessionID string) (Scope, bool) {
+	key := sessionScopeKey(providerName, sessionID)
+	if key == "" || s == nil {
+		return Scope{}, false
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	scope := s.sessionScopes[key]
+	if scope == nil {
+		return Scope{}, false
+	}
+	return cloneScope(*scope), true
+}
+
 func scopeKey(providerName, sessionID, turnID string) string {
 	providerName = strings.TrimSpace(providerName)
 	sessionID = strings.TrimSpace(sessionID)
@@ -126,6 +174,15 @@ func scopeKey(providerName, sessionID, turnID string) string {
 		return ""
 	}
 	return providerName + "\x00" + sessionID + "\x00" + turnID
+}
+
+func sessionScopeKey(providerName, sessionID string) string {
+	providerName = strings.TrimSpace(providerName)
+	sessionID = strings.TrimSpace(sessionID)
+	if providerName == "" || sessionID == "" {
+		return ""
+	}
+	return providerName + "\x00" + sessionID
 }
 
 func cloneScope(src Scope) Scope {
@@ -144,6 +201,7 @@ func cloneScope(src Scope) Scope {
 		Permissions:         clonePermissions(src.Permissions),
 		ToolRefs:            cloneToolRefs(src.ToolRefs),
 		ToolRefsSet:         src.ToolRefsSet || len(src.ToolRefs) > 0,
+		ListedTools:         cloneListedTools(src.ListedTools),
 		Tools:               cloneTools(src.Tools),
 		ToolSource:          src.ToolSource,
 		Connections:         cloneConnectionBindings(src.Connections),
@@ -181,6 +239,30 @@ func cloneToolRefs(src []coreagent.ToolRef) []coreagent.ToolRef {
 			RunAs:          core.NormalizeRunAsSubject(src[i].RunAs),
 			Title:          strings.TrimSpace(src[i].Title),
 			Description:    strings.TrimSpace(src[i].Description),
+		})
+	}
+	return out
+}
+
+func cloneListedTools(src []coreagent.ListedTool) []coreagent.ListedTool {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make([]coreagent.ListedTool, 0, len(src))
+	for i := range src {
+		out = append(out, coreagent.ListedTool{
+			ToolID:           strings.TrimSpace(src[i].ToolID),
+			MCPName:          strings.TrimSpace(src[i].MCPName),
+			Title:            strings.TrimSpace(src[i].Title),
+			Description:      strings.TrimSpace(src[i].Description),
+			Tags:             append([]string(nil), src[i].Tags...),
+			SearchText:       strings.TrimSpace(src[i].SearchText),
+			InputSchemaJSON:  strings.TrimSpace(src[i].InputSchemaJSON),
+			OutputSchemaJSON: strings.TrimSpace(src[i].OutputSchemaJSON),
+			Annotations:      src[i].Annotations,
+			Ref:              cloneToolRefs([]coreagent.ToolRef{src[i].Ref})[0],
+			Target:           cloneToolTarget(src[i].Target),
+			Hidden:           src[i].Hidden,
 		})
 	}
 	return out

--- a/sdk/go/workflow/executor.go
+++ b/sdk/go/workflow/executor.go
@@ -345,10 +345,11 @@ func workflowAgentSessionsFromOutputs(target *gestalt.BoundWorkflowTarget, stepI
 		providerName := strings.TrimSpace(step.Agent.Provider)
 		model := strings.TrimSpace(step.Agent.Model)
 		optionsKey := stableJSON(step.Agent.ModelOptions)
+		toolsKey := workflowAgentSessionToolsKey(step.Agent.Tools)
 		state, exists := sessions[sessionKey]
 		if exists {
-			if state.providerName != providerName || state.model != model || state.options != optionsKey {
-				return nil, fmt.Errorf("workflow agent session_key %q uses incompatible provider, model, or model_options", sessionKey)
+			if state.providerName != providerName || state.model != model || state.options != optionsKey || state.tools != toolsKey {
+				return nil, fmt.Errorf("workflow agent session_key %q uses incompatible provider, model, model_options, or tools", sessionKey)
 			}
 			continue
 		}
@@ -357,6 +358,7 @@ func workflowAgentSessionsFromOutputs(target *gestalt.BoundWorkflowTarget, stepI
 			providerName: providerName,
 			model:        model,
 			options:      optionsKey,
+			tools:        toolsKey,
 		}
 	}
 	return sessions, nil

--- a/sdk/go/workflow/steps.go
+++ b/sdk/go/workflow/steps.go
@@ -121,15 +121,17 @@ func (e *Executor) invokeAgentStep(ctx context.Context, req Request, stepIndex i
 		sessionKey = stepID
 	}
 	optionsKey := stableJSON(agent.ModelOptions)
+	toolsKey := workflowAgentSessionToolsKey(agent.Tools)
 	state, ok := sessions[sessionKey]
 	if ok {
-		if state.providerName != providerName || state.model != model || state.options != optionsKey {
-			return nil, "", fmt.Errorf("workflow agent session_key %q uses incompatible provider, model, or model_options", sessionKey)
+		if state.providerName != providerName || state.model != model || state.options != optionsKey || state.tools != toolsKey {
+			return nil, "", fmt.Errorf("workflow agent session_key %q uses incompatible provider, model, model_options, or tools", sessionKey)
 		}
 	} else {
 		session, err := client.CreateSession(ctx, gestalt.AgentCreateSession{
 			ProviderName: providerName,
 			Model:        model,
+			Tools:        workflowAgentSessionTools(agent.Tools),
 			Metadata: map[string]any{
 				"workflow":       workflowContext,
 				"workflowStepId": stepID,
@@ -139,7 +141,7 @@ func (e *Executor) invokeAgentStep(ctx context.Context, req Request, stepIndex i
 		if err != nil {
 			return nil, "", err
 		}
-		state = workflowAgentSessionState{session: session, providerName: providerName, model: model, options: optionsKey}
+		state = workflowAgentSessionState{session: session, providerName: providerName, model: model, options: optionsKey, tools: toolsKey}
 		sessions[sessionKey] = state
 	}
 	messages, err := workflowAgentTurnMessages(agent, req, outputs, stepInputs)
@@ -150,8 +152,6 @@ func (e *Executor) invokeAgentStep(ctx context.Context, req Request, stepIndex i
 		SessionID:      state.session.ID,
 		Model:          model,
 		Messages:       messages,
-		ToolRefs:       append([]gestalt.AgentToolRef(nil), agent.Tools...),
-		ToolRefsSet:    true,
 		Output:         agent.Output,
 		Metadata:       stepMetadata,
 		ModelOptions:   agent.ModelOptions,
@@ -244,11 +244,26 @@ func workflowAgentTurnID(turn *gestalt.AgentTurn) string {
 	return strings.TrimSpace(turn.ID)
 }
 
+func workflowAgentSessionTools(refs []gestalt.AgentToolRef) gestalt.AgentToolConfig {
+	if len(refs) == 0 {
+		return &gestalt.AgentNoTools{}
+	}
+	return &gestalt.AgentCatalogToolConfig{Refs: append([]gestalt.AgentToolRef(nil), refs...)}
+}
+
+func workflowAgentSessionToolsKey(refs []gestalt.AgentToolRef) string {
+	if len(refs) == 0 {
+		return "[]"
+	}
+	return stableJSON(refs)
+}
+
 type workflowAgentSessionState struct {
 	session      *gestalt.AgentSession
 	providerName string
 	model        string
 	options      string
+	tools        string
 }
 
 type workflowStepResult struct {

--- a/sdk/go/workflow/workflow_test.go
+++ b/sdk/go/workflow/workflow_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	gestalt "github.com/valon-technologies/gestalt/sdk/go"
@@ -248,6 +249,10 @@ func TestExecutorInvokesAgentStepWithWorkflowRunAs(t *testing.T) {
 				Provider: "claude",
 				Model:    "default",
 				Prompt:   gestalt.WorkflowText{Template: "review ${{ input.name }}"},
+				Tools: []gestalt.AgentToolRef{{
+					App:       "slack",
+					Operation: "chat.postMessage",
+				}},
 			},
 		}}},
 		Input: map[string]any{"name": "Ada"},
@@ -261,8 +266,18 @@ func TestExecutorInvokesAgentStepWithWorkflowRunAs(t *testing.T) {
 	if agent.session.ProviderName != "claude" || agent.session.Model != "default" {
 		t.Fatalf("session = %#v", agent.session)
 	}
+	sessionTools, ok := agent.session.Tools.(*gestalt.AgentCatalogToolConfig)
+	if !ok {
+		t.Fatalf("session tools = %#v, want catalog config", agent.session.Tools)
+	}
+	if len(sessionTools.Refs) != 1 || sessionTools.Refs[0].App != "slack" || sessionTools.Refs[0].Operation != "chat.postMessage" {
+		t.Fatalf("session tool refs = %#v, want slack chat.postMessage", sessionTools.Refs)
+	}
 	if agent.turn.SessionID != "session-1" || agent.turn.Messages[0].Text != "review Ada" {
 		t.Fatalf("turn = %#v", agent.turn)
+	}
+	if len(agent.turn.ToolRefs) != 0 || agent.turn.ToolRefsSet {
+		t.Fatalf("turn tools = refs %#v set %v, want inherited session tools", agent.turn.ToolRefs, agent.turn.ToolRefsSet)
 	}
 	if agent.turn.TimeoutSeconds != 45 {
 		t.Fatalf("turn timeout = %d, want 45", agent.turn.TimeoutSeconds)
@@ -279,6 +294,250 @@ func TestExecutorInvokesAgentStepWithWorkflowRunAs(t *testing.T) {
 	}
 	if agent.request.WorkflowContext["currentStepId"] != "review" {
 		t.Fatalf("agent request workflow context = %#v, want currentStepId=review", agent.request.WorkflowContext)
+	}
+}
+
+func TestExecutorCreatesNoToolsAgentSessionWhenWorkflowToolsEmpty(t *testing.T) {
+	t.Parallel()
+
+	agent := &recordingAgentClient{}
+	executor := New(Config{
+		NewAgent: func(req gestalt.Request) (AgentClient, error) {
+			agent.request = req
+			return agent, nil
+		},
+		AgentPollInterval: 0,
+	})
+	resp, err := executor.ExecuteStep(context.Background(), StepRequest{Request: Request{
+		ProviderName:         "indexeddb",
+		RunID:                "run-1",
+		DefinitionID:         "definition-1",
+		DefinitionGeneration: 1,
+		RunAs: &gestalt.Subject{
+			ID:                  "service_account:workflow-runner",
+			CredentialSubjectID: "service_account:workflow-runner",
+		},
+		Target: &gestalt.BoundWorkflowTarget{Steps: []gestalt.WorkflowStep{{
+			ID: "review",
+			Agent: &gestalt.WorkflowStepAgentTurn{
+				Provider: "claude",
+				Model:    "default",
+				Prompt:   gestalt.WorkflowText{Template: "review"},
+			},
+		}}},
+	}})
+	if err != nil {
+		t.Fatalf("ExecuteStep: %v", err)
+	}
+	if resp.Status != 200 {
+		t.Fatalf("status = %d, want 200; step = %#v", resp.Status, resp.Step)
+	}
+	if _, ok := agent.session.Tools.(*gestalt.AgentNoTools); !ok {
+		t.Fatalf("session = %#v, want no tools config", agent.session)
+	}
+	if len(agent.turn.ToolRefs) != 0 || agent.turn.ToolRefsSet {
+		t.Fatalf("turn tools = refs %#v set %v, want inherited no-tools session", agent.turn.ToolRefs, agent.turn.ToolRefsSet)
+	}
+}
+
+func TestExecutorRejectsLiveSharedAgentSessionWithIncompatibleTools(t *testing.T) {
+	t.Parallel()
+
+	agent := &recordingAgentClient{}
+	executor := New(Config{
+		NewAgent: func(req gestalt.Request) (AgentClient, error) {
+			agent.request = req
+			return agent, nil
+		},
+		AgentPollInterval: 0,
+	})
+	resp, err := executor.Execute(context.Background(), Request{
+		ProviderName:         "indexeddb",
+		RunID:                "run-1",
+		DefinitionID:         "definition-1",
+		DefinitionGeneration: 1,
+		RunAs: &gestalt.Subject{
+			ID:                  "service_account:workflow-runner",
+			CredentialSubjectID: "service_account:workflow-runner",
+		},
+		Target: &gestalt.BoundWorkflowTarget{Steps: []gestalt.WorkflowStep{
+			{
+				ID: "review-a",
+				Agent: &gestalt.WorkflowStepAgentTurn{
+					Provider:   "claude",
+					Model:      "default",
+					SessionKey: "review",
+					Prompt:     gestalt.WorkflowText{Template: "review a"},
+					Tools: []gestalt.AgentToolRef{{
+						App:       "slack",
+						Operation: "chat.postMessage",
+					}},
+				},
+			},
+			{
+				ID: "review-b",
+				Agent: &gestalt.WorkflowStepAgentTurn{
+					Provider:   "claude",
+					Model:      "default",
+					SessionKey: "review",
+					Prompt:     gestalt.WorkflowText{Template: "review b"},
+					Tools: []gestalt.AgentToolRef{{
+						App:       "github",
+						Operation: "issues.create",
+					}},
+				},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if resp.Status == 200 || !strings.Contains(resp.Body, "tools") {
+		t.Fatalf("response = %#v, want incompatible tools failure", resp)
+	}
+}
+
+func TestExecutorAllowsLiveSharedAgentSessionWithNilAndEmptyTools(t *testing.T) {
+	t.Parallel()
+
+	agent := &recordingAgentClient{}
+	executor := New(Config{
+		NewAgent: func(req gestalt.Request) (AgentClient, error) {
+			agent.request = req
+			return agent, nil
+		},
+		AgentPollInterval: 0,
+	})
+	resp, err := executor.Execute(context.Background(), Request{
+		ProviderName:         "indexeddb",
+		RunID:                "run-1",
+		DefinitionID:         "definition-1",
+		DefinitionGeneration: 1,
+		RunAs: &gestalt.Subject{
+			ID:                  "service_account:workflow-runner",
+			CredentialSubjectID: "service_account:workflow-runner",
+		},
+		Target: &gestalt.BoundWorkflowTarget{Steps: []gestalt.WorkflowStep{
+			{
+				ID: "review-a",
+				Agent: &gestalt.WorkflowStepAgentTurn{
+					Provider:   "claude",
+					Model:      "default",
+					SessionKey: "review",
+					Prompt:     gestalt.WorkflowText{Template: "review a"},
+				},
+			},
+			{
+				ID: "review-b",
+				Agent: &gestalt.WorkflowStepAgentTurn{
+					Provider:   "claude",
+					Model:      "default",
+					SessionKey: "review",
+					Prompt:     gestalt.WorkflowText{Template: "review b"},
+					Tools:      []gestalt.AgentToolRef{},
+				},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if resp.Status != 200 {
+		t.Fatalf("response = %#v, want success", resp)
+	}
+}
+
+func TestWorkflowAgentSessionsFromOutputsRejectsIncompatibleTools(t *testing.T) {
+	t.Parallel()
+
+	target := &gestalt.BoundWorkflowTarget{Steps: []gestalt.WorkflowStep{
+		{
+			ID: "review-a",
+			Agent: &gestalt.WorkflowStepAgentTurn{
+				Provider:   "claude",
+				Model:      "default",
+				SessionKey: "review",
+				Tools: []gestalt.AgentToolRef{{
+					App:       "slack",
+					Operation: "chat.postMessage",
+				}},
+			},
+		},
+		{
+			ID: "review-b",
+			Agent: &gestalt.WorkflowStepAgentTurn{
+				Provider:   "claude",
+				Model:      "default",
+				SessionKey: "review",
+				Tools: []gestalt.AgentToolRef{{
+					App:       "github",
+					Operation: "issues.create",
+				}},
+			},
+		},
+	}}
+
+	_, err := workflowAgentSessionsFromOutputs(target, 2, map[string]any{
+		"review-a": map[string]any{
+			"kind": "agent",
+			"agent": map[string]any{
+				"sessionId": "session-1",
+			},
+		},
+		"review-b": map[string]any{
+			"kind": "agent",
+			"agent": map[string]any{
+				"sessionId": "session-1",
+			},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "tools") {
+		t.Fatalf("workflowAgentSessionsFromOutputs error = %v, want incompatible tools", err)
+	}
+}
+
+func TestWorkflowAgentSessionsFromOutputsAllowsNilAndEmptyTools(t *testing.T) {
+	t.Parallel()
+
+	target := &gestalt.BoundWorkflowTarget{Steps: []gestalt.WorkflowStep{
+		{
+			ID: "review-a",
+			Agent: &gestalt.WorkflowStepAgentTurn{
+				Provider:   "claude",
+				Model:      "default",
+				SessionKey: "review",
+			},
+		},
+		{
+			ID: "review-b",
+			Agent: &gestalt.WorkflowStepAgentTurn{
+				Provider:   "claude",
+				Model:      "default",
+				SessionKey: "review",
+				Tools:      []gestalt.AgentToolRef{},
+			},
+		},
+	}}
+
+	sessions, err := workflowAgentSessionsFromOutputs(target, 2, map[string]any{
+		"review-a": map[string]any{
+			"kind": "agent",
+			"agent": map[string]any{
+				"sessionId": "session-1",
+			},
+		},
+		"review-b": map[string]any{
+			"kind": "agent",
+			"agent": map[string]any{
+				"sessionId": "session-1",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("workflowAgentSessionsFromOutputs: %v", err)
+	}
+	if len(sessions) != 1 || sessions["review"].session.ID != "session-1" {
+		t.Fatalf("sessions = %#v, want shared review session", sessions)
 	}
 }
 

--- a/sdk/rust/tests/agent_transport.rs
+++ b/sdk/rust/tests/agent_transport.rs
@@ -713,6 +713,14 @@ async fn agent_runtime_and_server_round_trip_over_unix_socket() {
         AgentExecutionStatus::WaitingForInput
     );
     assert_eq!(created_turn.messages[0].parts.len(), 1);
+    assert_eq!(
+        provider
+            .turn_request_context_subjects
+            .lock()
+            .expect("turn request contexts")
+            .as_slice(),
+        ["user:turn"]
+    );
 
     let listed_turns = client
         .list_turns(pb::ListAgentProviderTurnsRequest {


### PR DESCRIPTION
## Summary

Moves workflow agent step tools to agent session creation so workflow turns use the same session-scoped contract as direct agent callers.

Workflow agent turns now leave legacy turn-level `ToolRefs` unset and inherit the tool scope configured on `AgentCreateSession`. Empty workflow tool lists become explicit `tools.none` so no-tools workflow steps do not accidentally receive provider default tools.

Shared `session_key` compatibility now includes the workflow agent tool configuration during both live execution and resume reconstruction, preventing incompatible steps from reusing the same provider session.

## Interfaces

```go
workflow.Agent("triage", workflow.AgentOptions{
  Tools: []workflow.AgentToolRef{{App: "github", Operation: "pulls.list"}},
  SessionKey: "review-thread",
})
```

```go
AgentCreateSession{
  Tools: &AgentToolConfig{Catalog: refsFromStepTools},
}

AgentCreateTurn{
  ToolRefs: nil, // inherited from the session
}
```

The workflow SDK keeps the authored workflow step shape stable while changing where the tool scope is applied at runtime.

## Architecture

```mermaid
flowchart LR
  Step[Workflow agent step] --> Tools[step Tools]
  Tools --> SessionKey[session_key compatibility hash]
  SessionKey --> CreateSession[AgentCreateSession.tools]
  CreateSession --> ProviderSession[provider session]
  ProviderSession --> CreateTurn[AgentCreateTurn without ToolRefs]
  CreateTurn --> Inherit[manager/provider session-scope inheritance]
  Resume[resume reconstruction] --> SessionKey
```

## Runtime

The workflow executor configures the provider session with the step's tool scope before the first turn. Subsequent turns for that session inherit the configured scope.

If two workflow agent steps try to share a `session_key` with different tool configurations, execution fails instead of silently reusing a session with the wrong tool scope. Resume uses the same compatibility data, so restarted workflow runs preserve the live execution behavior.

## Test plan

- [x] `(cd sdk/go && go test ./...)`
- [x] `cargo test --manifest-path sdk/rust/Cargo.toml --test agent_transport --test agent_access_transport`
- [x] `git diff --check`
