### PR TITLE
Stop forwarding session tools on agent turns

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -701,6 +701,7 @@ type callbackAgentProvider struct {
 	*recordingAgentProvider
 	started                *runtimehost.StartedHostServices
 	socketPath             string
+	catalogSessions        map[string]bool
 	listRequests           []*proto.ListAgentToolsRequest
 	listResponses          []*proto.ListAgentToolsResponse
 	toolBodies             []string
@@ -737,7 +738,21 @@ func newCallbackAgentProvider(started *runtimehost.StartedHostServices) (*callba
 		recordingAgentProvider: newRecordingAgentProvider(),
 		started:                started,
 		socketPath:             socketPath,
+		catalogSessions:        map[string]bool{},
 	}, nil
+}
+
+func (p *callbackAgentProvider) CreateSession(ctx context.Context, req *proto.CreateAgentProviderSessionRequest) (*coreagent.Session, error) {
+	session, err := p.recordingAgentProvider.CreateSession(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if req.GetTools().GetCatalog() != nil {
+		p.mu.Lock()
+		p.catalogSessions[session.ID] = true
+		p.mu.Unlock()
+	}
+	return session, nil
 }
 
 func (p *callbackAgentProvider) CreateTurn(ctx context.Context, req *proto.CreateAgentProviderTurnRequest) (*coreagent.Turn, error) {
@@ -800,7 +815,10 @@ func (p *callbackAgentProvider) CreateTurn(ctx context.Context, req *proto.Creat
 	}
 
 	outputBody := ""
-	if req.GetToolSource() == proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_CATALOG || len(req.GetTools()) > 0 {
+	p.mu.Lock()
+	catalogSession := p.catalogSessions[strings.TrimSpace(req.GetSessionId())]
+	p.mu.Unlock()
+	if catalogSession || len(req.GetTools()) > 0 {
 		conn, err := grpc.NewClient(
 			"passthrough:///localhost",
 			grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
@@ -816,7 +834,7 @@ func (p *callbackAgentProvider) CreateTurn(ctx context.Context, req *proto.Creat
 		defer func() { _ = conn.Close() }()
 		client := proto.NewAgentHostClient(conn)
 		tools := bootstrapAgentToolsFromProto(req.GetTools())
-		if len(tools) == 0 && req.GetToolSource() == proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_CATALOG {
+		if len(tools) == 0 && catalogSession {
 			listReq := &proto.ListAgentToolsRequest{
 				SessionId: req.GetSessionId(),
 				TurnId:    turnID,
@@ -2368,11 +2386,11 @@ func TestBootstrapAgentManagerCreateTurnPersistsMetadataForToolCallbacks(t *test
 	if len(createTurnReq.GetTools()) != 0 {
 		t.Fatalf("CreateTurn tools = %#v, want no preloaded tools", createTurnReq.GetTools())
 	}
-	if createTurnReq.GetToolSource() != proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_CATALOG {
-		t.Fatalf("CreateTurn tool source = %q, want mcp_catalog", createTurnReq.GetToolSource())
+	if createTurnReq.GetToolSource() != proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_UNSPECIFIED {
+		t.Fatalf("CreateTurn tool source = %q, want unspecified", createTurnReq.GetToolSource())
 	}
-	if len(createTurnReq.GetToolRefs()) != 1 || createTurnReq.GetToolRefs()[0].GetApp() != "roadmap" || createTurnReq.GetToolRefs()[0].GetOperation() != "sync" {
-		t.Fatalf("CreateTurn tool refs = %#v", createTurnReq.GetToolRefs())
+	if len(createTurnReq.GetToolRefs()) != 0 {
+		t.Fatalf("CreateTurn tool refs = %#v, want none", createTurnReq.GetToolRefs())
 	}
 	if createTurnReq.GetContext() == nil {
 		t.Fatal("CreateTurn context is empty")

--- a/gestaltd/internal/bootstrap/executable_app_test.go
+++ b/gestaltd/internal/bootstrap/executable_app_test.go
@@ -3894,11 +3894,11 @@ func TestPluginAgentManagerTurnUsesInheritedInvokesAndRequestContext(t *testing.
 	if len(turnReq.Tools) != 0 {
 		t.Fatalf("CreateTurn tools = %#v, want no preloaded tools", turnReq.Tools)
 	}
-	if turnReq.GetToolSource() != proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_CATALOG {
-		t.Fatalf("CreateTurn tool source = %q, want mcp_catalog", turnReq.GetToolSource())
+	if turnReq.GetToolSource() != proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_UNSPECIFIED {
+		t.Fatalf("CreateTurn tool source = %q, want unspecified", turnReq.GetToolSource())
 	}
-	if len(turnReq.GetToolRefs()) != 1 || turnReq.GetToolRefs()[0].GetApp() != "roadmap" || turnReq.GetToolRefs()[0].GetOperation() != "sync" {
-		t.Fatalf("CreateTurn tool refs = %#v", turnReq.GetToolRefs())
+	if len(turnReq.GetToolRefs()) != 0 {
+		t.Fatalf("CreateTurn tool refs = %#v, want none", turnReq.GetToolRefs())
 	}
 }
 

--- a/gestaltd/internal/server/agent_session_turn_test.go
+++ b/gestaltd/internal/server/agent_session_turn_test.go
@@ -935,11 +935,11 @@ func TestAgentSessionsAndTurnsRoundTrip(t *testing.T) {
 	if got := turnRequests[0].GetTools(); len(got) != 0 {
 		t.Fatalf("provider turn tools = %#v, want no preloaded tools", got)
 	}
-	if turnRequests[0].GetToolSource() != proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_CATALOG {
-		t.Fatalf("provider turn tool source = %q, want mcp_catalog", turnRequests[0].GetToolSource())
+	if turnRequests[0].GetToolSource() != proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_UNSPECIFIED {
+		t.Fatalf("provider turn tool source = %q, want unspecified", turnRequests[0].GetToolSource())
 	}
-	if got := turnRequests[0].GetToolRefs(); len(got) != 1 || got[0].GetApp() != "docs" || got[0].GetOperation() != "search" {
-		t.Fatalf("provider turn tool refs = %#v, want docs.search", got)
+	if got := turnRequests[0].GetToolRefs(); len(got) != 0 {
+		t.Fatalf("provider turn tool refs = %#v, want none", got)
 	}
 
 	eventsReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/agent/turns/"+turnID+"/events?after=0&limit=10", nil)
@@ -1262,8 +1262,8 @@ func TestAgentTurnOmittedToolsDefaultToNone(t *testing.T) {
 	if got := turnRequests[0].ToolRefs; len(got) != 0 {
 		t.Fatalf("omitted toolRefs provider refs = %#v, want none", got)
 	}
-	if got := turnRequests[0].GetToolSource(); got != proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_NONE {
-		t.Fatalf("omitted tool source = %q, want none", got)
+	if got := turnRequests[0].GetToolSource(); got != proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_UNSPECIFIED {
+		t.Fatalf("omitted tool source = %q, want unspecified", got)
 	}
 }
 
@@ -1342,8 +1342,8 @@ func TestAgentCreateTurnUsesNoToolsWithStructuredOutput(t *testing.T) {
 		t.Fatalf("provider turn requests len = %d, want 1", len(turnRequests))
 	}
 	req := turnRequests[0]
-	if req.GetToolSource() != proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_NONE {
-		t.Fatalf("provider turn tool source = %q, want none", req.GetToolSource())
+	if req.GetToolSource() != proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_UNSPECIFIED {
+		t.Fatalf("provider turn tool source = %q, want unspecified", req.GetToolSource())
 	}
 	if len(req.GetToolRefs()) != 0 || len(req.GetTools()) != 0 {
 		t.Fatalf("provider turn tools = refs:%#v resolved:%#v, want none", req.GetToolRefs(), req.GetTools())
@@ -1406,8 +1406,8 @@ func TestAgentTurnOmittedToolsDoNotForceCatalogForUnsupportedProvider(t *testing
 	if len(turnRequests) != 1 {
 		t.Fatalf("provider turn requests len = %d, want 1", len(turnRequests))
 	}
-	if got := turnRequests[0].GetToolSource(); got != proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_NONE {
-		t.Fatalf("provider turn tool source = %q, want none", got)
+	if got := turnRequests[0].GetToolSource(); got != proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_UNSPECIFIED {
+		t.Fatalf("provider turn tool source = %q, want unspecified", got)
 	}
 	if got := turnRequests[0].GetToolRefs(); len(got) != 0 {
 		t.Fatalf("provider turn tool refs = %#v, want none", got)

--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -857,9 +857,6 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req *p
 	providerReq.SessionId = ownedSession.session.ID
 	providerReq.IdempotencyKey = idempotencyKey
 	providerReq.Model = strings.TrimSpace(req.GetModel())
-	providerReq.ToolRefs = agentwire.ToolRefsToProto(toolRefs)
-	providerReq.ToolRefsSet = toolRefsSet
-	providerReq.ToolSource = agentwire.ToolSourceModeToProto(toolSource)
 	providerReq.Tools = nil
 	providerReq.CreatedBySubjectId = agentSubjectIDFromPrincipal(p)
 	providerReq.ExecutionRef = turnID

--- a/gestaltd/services/agents/agentmanager/manager_test.go
+++ b/gestaltd/services/agents/agentmanager/manager_test.go
@@ -1261,11 +1261,11 @@ func TestCreateTurnInheritsSessionToolScope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateTurn: %v", err)
 	}
-	if got := alpha.createTurnReqs[0].GetToolSource(); got != proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_CATALOG {
-		t.Fatalf("provider turn tool source = %s, want MCP catalog", got)
+	if got := alpha.createTurnReqs[0].GetToolSource(); got != proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_UNSPECIFIED {
+		t.Fatalf("provider turn tool source = %s, want unspecified", got)
 	}
-	if len(alpha.createTurnReqs[0].GetToolRefs()) != 1 || alpha.createTurnReqs[0].GetToolRefs()[0].GetApp() != "slack" {
-		t.Fatalf("provider turn refs = %#v, want inherited slack ref", alpha.createTurnReqs[0].GetToolRefs())
+	if got := alpha.createTurnReqs[0].GetToolRefs(); len(got) != 0 {
+		t.Fatalf("provider turn refs = %#v, want none", got)
 	}
 	scope := requireAgentManagerTurnScope(t, scopes, "alpha", session.ID, turn.ID)
 	if len(scope.ToolRefs) != 1 || scope.ToolRefs[0].App != "slack" {
@@ -1312,8 +1312,12 @@ func TestCreateTurnRejectsToolsOutsideSessionScope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateTurn: %v", err)
 	}
-	if got := alpha.createTurnReqs[0].GetToolRefs(); len(got) != 1 || got[0].GetApp() != "slack" {
-		t.Fatalf("CreateTurn tool refs = %#v, want durable slack scope", got)
+	if got := alpha.createTurnReqs[0].GetToolRefs(); len(got) != 0 {
+		t.Fatalf("CreateTurn tool refs = %#v, want none", got)
+	}
+	scope := requireAgentManagerTurnScope(t, manager.turnScopes, "alpha", session.ID, alpha.createTurnReqs[0].GetTurnId())
+	if len(scope.ToolRefs) != 1 || scope.ToolRefs[0].App != "slack" {
+		t.Fatalf("turn scope refs = %#v, want durable slack scope", scope.ToolRefs)
 	}
 }
 
@@ -1862,8 +1866,8 @@ func TestManagerCreateTurnUsesNoToolsWhenSessionToolsAreOmitted(t *testing.T) {
 		t.Fatalf("CreateTurn requests = %d, want 1", len(alpha.createTurnReqs))
 	}
 	req := alpha.createTurnReqs[0]
-	if got := req.GetToolSource(); got != proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_NONE {
-		t.Fatalf("CreateTurn tool source = %q, want none", got)
+	if got := req.GetToolSource(); got != proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_UNSPECIFIED {
+		t.Fatalf("CreateTurn tool source = %q, want unspecified", got)
 	}
 	if len(req.GetToolRefs()) != 0 || len(req.GetTools()) != 0 {
 		t.Fatalf("CreateTurn tools = refs:%#v resolved:%#v, want none", req.GetToolRefs(), req.GetTools())

--- a/gestaltd/services/agents/manager_server_test.go
+++ b/gestaltd/services/agents/manager_server_test.go
@@ -137,8 +137,8 @@ func TestManagerServerCreateTurnForwardsStructuredOutputInputs(t *testing.T) {
 			if got := invocation.WorkflowContextString(invocation.WorkflowContextFromContext(ctx), "runId"); got != "run-123" {
 				t.Fatalf("workflow run id = %q, want run-123", got)
 			}
-			if req.GetToolSource() != proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_NONE {
-				t.Fatalf("tool source = %q, want none", req.GetToolSource())
+			if req.GetToolSource() != proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_UNSPECIFIED {
+				t.Fatalf("tool source = %q, want unspecified", req.GetToolSource())
 			}
 			if req.GetOutput().GetStructured() == nil {
 				t.Fatal("output.structured = nil, want structured output request")
@@ -162,7 +162,6 @@ func TestManagerServerCreateTurnForwardsStructuredOutputInputs(t *testing.T) {
 		Context:        agentManagerRequestContext("caller-plugin", "user-1", workflow),
 		TimeoutSeconds: 1,
 		SessionId:      "session-1",
-		ToolSource:     proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_NONE,
 		Output: &proto.AgentOutput{Kind: &proto.AgentOutput_Structured{
 			Structured: &proto.AgentStructuredOutput{Schema: schema},
 		}},


### PR DESCRIPTION
## Summary

Stops gestaltd from copying session-derived tool source and tool refs back onto provider `CreateTurn` requests.

The manager still resolves, authorizes, and stores session tool scope for each turn so `AgentHost` callbacks remain scoped correctly. The provider wire request now reflects the directionally correct contract: tools are configured on the session and turns do not carry their own tool selection.

This is stacked after valon-technologies/gestalt-providers#974, which makes all agent providers reject turn-level tool fields and inherit tools from session state.

## Interfaces

```go
providerReq := cloneAgentRequest(req, &proto.CreateAgentProviderTurnRequest{})
providerReq.TurnId = turnID
providerReq.SessionId = ownedSession.session.ID
providerReq.Tools = nil
// providerReq.ToolRefs, ToolRefsSet, and ToolSource are intentionally unset.
```

```proto
message CreateAgentProviderTurnRequest {
  // Legacy tool_refs/tool_source fields remain on the wire for compatibility,
  // but gestaltd no longer populates them for provider turns.
}
```

## Runtime

`AgentManager.CreateTurn` continues to derive the effective tool scope from the session, validate provider support, authorize catalog refs, and persist the turn scope used by `AgentHost.ListTools` and `AgentHost.ExecuteTool`.

Bootstrap test providers were updated to model session-scoped tools: they remember whether a session was created with a catalog and call `AgentHost` from that session state rather than using turn-level `ToolSource` as the signal.

## Test plan

- [x] `go test ./gestaltd/services/agents/agentmanager`
- [x] `go test ./gestaltd/services/agents`
- [x] `go test ./gestaltd/internal/server -run 'TestAgent'`
- [x] `go test ./gestaltd/internal/bootstrap -run 'TestBootstrap.*Agent|TestAgent'`