### PR TITLE
Use catalog agent tool source values

### DIFF
--- a/gestaltd/core/agent/types.go
+++ b/gestaltd/core/agent/types.go
@@ -128,7 +128,7 @@ type ToolSourceMode string
 
 const (
 	ToolSourceModeUnspecified ToolSourceMode = ""
-	ToolSourceModeCatalog     ToolSourceMode = "mcp_catalog"
+	ToolSourceModeCatalog     ToolSourceMode = "catalog"
 	ToolSourceModeNone        ToolSourceMode = "none"
 )
 

--- a/gestaltd/internal/bootstrap/agent_runtime.go
+++ b/gestaltd/internal/bootstrap/agent_runtime.go
@@ -1028,7 +1028,8 @@ func executeUnavailableAgentTool(target coreagent.ToolTarget) (*coreagent.Execut
 }
 
 func normalizeAgentToolSource(source coreagent.ToolSourceMode) coreagent.ToolSourceMode {
-	if strings.TrimSpace(string(source)) == "" {
+	source = coreagent.ToolSourceMode(strings.TrimSpace(string(source)))
+	if source == "" || string(source) == "mcp_catalog" {
 		return coreagent.ToolSourceModeCatalog
 	}
 	return source

--- a/gestaltd/internal/server/agent_session_turn_test.go
+++ b/gestaltd/internal/server/agent_session_turn_test.go
@@ -909,10 +909,6 @@ func TestAgentSessionsAndTurnsRoundTrip(t *testing.T) {
 	if !gotProvider.Capabilities.StreamingText || !gotProvider.Capabilities.BoundedListHydration {
 		t.Fatalf("provider capabilities = %#v, want streaming text and catalog listing", gotProvider.Capabilities)
 	}
-	if got := gotProvider.Capabilities.SupportedToolSources; strings.Join(got, ",") != "mcp_catalog" {
-		t.Fatalf("supported tool sources = %#v, want mcp_catalog", got)
-	}
-
 	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(`{"output":{"text":{}},"messages":[{"role":"user","text":"hello"}]}`))
 	turnReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
 	turnResp, err := http.DefaultClient.Do(turnReq)

--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -66,6 +66,7 @@ const (
 	agentSessionToolScopeMetadataKey           = "__gestalt.lifecycle.agent.tools"
 	agentSessionToolScopeMetadataSourceCatalog = "catalog"
 	agentSessionToolScopeMetadataSourceNone    = "none"
+	legacyAgentToolSourceCatalog               = "mcp_catalog"
 )
 
 type AgentProviderNotAvailableError struct {
@@ -2734,6 +2735,9 @@ func normalizeAgentToolSource(source coreagent.ToolSourceMode) coreagent.ToolSou
 	if source == "" {
 		return coreagent.ToolSourceModeUnspecified
 	}
+	if string(source) == legacyAgentToolSourceCatalog {
+		return coreagent.ToolSourceModeCatalog
+	}
 	return source
 }
 
@@ -4127,7 +4131,11 @@ func shouldUseResolvedUserToolScope(ctx context.Context, p *principal.Principal,
 }
 
 func normalizeToolSource(source coreagent.ToolSourceMode) coreagent.ToolSourceMode {
-	if strings.TrimSpace(string(source)) == "" {
+	source = coreagent.ToolSourceMode(strings.TrimSpace(string(source)))
+	if source == "" {
+		return coreagent.ToolSourceModeCatalog
+	}
+	if string(source) == legacyAgentToolSourceCatalog {
 		return coreagent.ToolSourceModeCatalog
 	}
 	return source
@@ -4225,7 +4233,7 @@ func agentProviderCapabilitiesSupportToolSource(caps *coreagent.ProviderCapabili
 		return false
 	}
 	for _, supported := range caps.SupportedToolSources {
-		if coreagent.ToolSourceMode(strings.TrimSpace(string(supported))) == source {
+		if normalizeAgentToolSource(supported) == source {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary

Switches the runtime catalog agent tool source value from the legacy `mcp_catalog` string to the canonical `catalog` string introduced by the provider and SDK cleanup stack.

The manager and bootstrap runtime still normalize old `mcp_catalog` values on read, so already persisted provider/session metadata remains accepted while new capability surfaces and metadata use `catalog`.

This finishes the runtime side of the catalog rename after the public MCP catalog aliases were removed from the SDKs and providers.

## Interfaces

`coreagent.ToolSourceModeCatalog` now serializes as `catalog`. Existing legacy `mcp_catalog` inputs are normalized to `catalog` before validation and capability matching.

## Runtime

Agent provider capability checks compare normalized source values, so providers that have not yet rotated any persisted legacy metadata continue to match catalog-backed sessions. The agent session round-trip test now asserts the canonical `catalog` capability value.

## Test plan
- [x] `go test ./gestaltd/core/agent ./gestaltd/internal/bootstrap ./gestaltd/internal/server ./gestaltd/services/agents/agentmanager`
- [x] `git diff --check`