### PR TITLE
Delete legacy catalog tool source compatibility

### DIFF
--- a/gestaltd/internal/bootstrap/agent_runtime.go
+++ b/gestaltd/internal/bootstrap/agent_runtime.go
@@ -1029,7 +1029,7 @@ func executeUnavailableAgentTool(target coreagent.ToolTarget) (*coreagent.Execut
 
 func normalizeAgentToolSource(source coreagent.ToolSourceMode) coreagent.ToolSourceMode {
 	source = coreagent.ToolSourceMode(strings.TrimSpace(string(source)))
-	if source == "" || string(source) == "mcp_catalog" {
+	if source == "" {
 		return coreagent.ToolSourceModeCatalog
 	}
 	return source

--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -66,7 +66,6 @@ const (
 	agentSessionToolScopeMetadataKey           = "__gestalt.lifecycle.agent.tools"
 	agentSessionToolScopeMetadataSourceCatalog = "catalog"
 	agentSessionToolScopeMetadataSourceNone    = "none"
-	legacyAgentToolSourceCatalog               = "mcp_catalog"
 )
 
 type AgentProviderNotAvailableError struct {
@@ -2735,9 +2734,6 @@ func normalizeAgentToolSource(source coreagent.ToolSourceMode) coreagent.ToolSou
 	if source == "" {
 		return coreagent.ToolSourceModeUnspecified
 	}
-	if string(source) == legacyAgentToolSourceCatalog {
-		return coreagent.ToolSourceModeCatalog
-	}
 	return source
 }
 
@@ -4133,9 +4129,6 @@ func shouldUseResolvedUserToolScope(ctx context.Context, p *principal.Principal,
 func normalizeToolSource(source coreagent.ToolSourceMode) coreagent.ToolSourceMode {
 	source = coreagent.ToolSourceMode(strings.TrimSpace(string(source)))
 	if source == "" {
-		return coreagent.ToolSourceModeCatalog
-	}
-	if string(source) == legacyAgentToolSourceCatalog {
 		return coreagent.ToolSourceModeCatalog
 	}
 	return source


### PR DESCRIPTION
## Summary
- Remove the temporary `mcp_catalog` normalization path from agent tool source handling.
- Keep the current `catalog` source spelling and existing empty/default source behavior.
- This should merge only after valon-technologies/toolshed#2375 is merged and deployed, so valon-tools has moved to the post-#2343 runtime and post-#979 provider snapshots.

## Test plan
- [x] `go test ./gestaltd/internal/bootstrap ./gestaltd/services/agents/agentmanager ./gestaltd/internal/server ./gestaltd/core/agent`
- [x] `git diff --check`
- [x] Targeted scan for remaining `mcp_catalog` runtime references outside generated/reserved proto exclusions
