### PR TITLE
Authorize agent app calls through request context

### DIFF
--- a/gestaltd/internal/bootstrap/agent_runtime.go
+++ b/gestaltd/internal/bootstrap/agent_runtime.go
@@ -782,12 +782,7 @@ func resolveAgentTurnScope(scopes *agentturnscope.Store, reqCtx *proto.RequestCo
 	if scope.Revoked {
 		return agentturnscope.Scope{}, appaccessservice.ProviderRequestContext{}, fmt.Errorf("%w: agent turn scope is revoked", invocation.ErrAuthorizationDenied)
 	}
-	expectedKind := scope.CallerKind
-	expectedName := strings.TrimSpace(scope.CallerName)
-	if expectedKind == "" || expectedName == "" {
-		return agentturnscope.Scope{}, appaccessservice.ProviderRequestContext{}, fmt.Errorf("%w: agent turn scope caller context is required", invocation.ErrInternal)
-	}
-	parsed, err := appaccessservice.ProviderRequestContextFromProto(reqCtx, expectedKind, expectedName)
+	parsed, err := appaccessservice.ProviderRequestContextFromProto(reqCtx, invocation.ProviderKindAgent, providerName)
 	if err != nil {
 		return agentturnscope.Scope{}, appaccessservice.ProviderRequestContext{}, err
 	}

--- a/gestaltd/internal/bootstrap/agent_runtime_test.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_test.go
@@ -78,8 +78,8 @@ func putAgentRuntimeTurnScope(scopes *agentturnscope.Store, scope agentturnscope
 	}
 	return &proto.RequestContext{
 		Caller: &proto.ProviderContext{
-			Kind: string(scope.CallerKind),
-			Name: scope.CallerName,
+			Kind: string(invocation.ProviderKindAgent),
+			Name: scope.ProviderName,
 		},
 		Subject: &proto.SubjectContext{
 			Id:                  scope.SubjectID,
@@ -2925,8 +2925,8 @@ func TestAgentRuntimeAcceptsProviderOwnedTurnIDWithExecutionRefScope(t *testing.
 	if err != nil {
 		t.Fatalf("Put turn scope: %v", err)
 	}
-	if err := turnScopes.Alias("simple", "session-1", "requested-turn-1", "provider-turn-1"); err != nil {
-		t.Fatalf("Alias provider-owned turn scope: %v", err)
+	if err := turnScopes.BindProviderTurnID("simple", "session-1", "requested-turn-1", "provider-turn-1"); err != nil {
+		t.Fatalf("Bind provider-owned turn scope: %v", err)
 	}
 	listResp, err := runtime.ListTools(context.Background(), coreagent.ListToolsRequest{
 		ProviderName: "simple",

--- a/gestaltd/internal/bootstrap/host_service_bootstrap.go
+++ b/gestaltd/internal/bootstrap/host_service_bootstrap.go
@@ -498,11 +498,14 @@ func buildAppInvocationHostService(appName string, deps Deps) runtimehost.HostSe
 		Name:           "app",
 		MethodPrefixes: []string{grpcMethodPrefix(proto.App_ServiceDesc.ServiceName)},
 		Register: func(srv *grpc.Server) {
-			proto.RegisterAppServer(srv, appaccessservice.NewServer(
-				invoker,
+			opts := []appaccessservice.AppServerOption{
 				appaccessservice.WithAuthorizationProvider(deps.Authorization),
 				appaccessservice.WithCallerApp(appName, deps.AppAccessProfiles[strings.TrimSpace(appName)]),
-			))
+			}
+			if manager, ok := deps.AgentManager.(*lazyAgentManager); ok {
+				opts = append(opts, appaccessservice.WithAgentAppInvocationAuthorizer(manager.AuthorizeAgentAppInvocation))
+			}
+			proto.RegisterAppServer(srv, appaccessservice.NewServer(invoker, opts...))
 		},
 	}
 }

--- a/gestaltd/internal/bootstrap/lazy_agent_manager.go
+++ b/gestaltd/internal/bootstrap/lazy_agent_manager.go
@@ -8,19 +8,20 @@ import (
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"github.com/valon-technologies/gestalt/server/services/agents/agentmanager"
+	"github.com/valon-technologies/gestalt/server/services/agents/agentturnscope"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 )
 
 type lazyAgentManager struct {
 	mu     sync.RWMutex
-	target agentmanager.Service
+	target *agentmanager.Manager
 }
 
 func newLazyAgentManager() *lazyAgentManager {
 	return &lazyAgentManager{}
 }
 
-func (l *lazyAgentManager) SetTarget(target agentmanager.Service) {
+func (l *lazyAgentManager) SetTarget(target *agentmanager.Manager) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	l.target = target
@@ -146,7 +147,15 @@ func (l *lazyAgentManager) ResolveInteraction(ctx context.Context, p *principal.
 	return target.ResolveInteraction(ctx, p, req)
 }
 
-func (l *lazyAgentManager) current() (agentmanager.Service, error) {
+func (l *lazyAgentManager) AuthorizeAgentAppInvocation(ctx context.Context, providerName, turnID string, requestPrincipal *principal.Principal, targetTool coreagent.ToolTarget, reqCtx *proto.RequestContext) (*principal.Principal, agentturnscope.Scope, coreagent.ListedTool, error) {
+	target, err := l.current()
+	if err != nil {
+		return nil, agentturnscope.Scope{}, coreagent.ListedTool{}, err
+	}
+	return target.AuthorizeAgentAppInvocation(ctx, providerName, turnID, requestPrincipal, targetTool, reqCtx)
+}
+
+func (l *lazyAgentManager) current() (*agentmanager.Manager, error) {
 	l.mu.RLock()
 	target := l.target
 	l.mu.RUnlock()

--- a/gestaltd/services/agents/agentmanager/agent_app_authority.go
+++ b/gestaltd/services/agents/agentmanager/agent_app_authority.go
@@ -1,0 +1,210 @@
+package agentmanager
+
+import (
+	"context"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/agents/agentturnscope"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func (m *Manager) AuthorizeAgentAppInvocation(ctx context.Context, providerName, turnID string, requestPrincipal *principal.Principal, target coreagent.ToolTarget, reqCtx *proto.RequestContext) (*principal.Principal, agentturnscope.Scope, coreagent.ListedTool, error) {
+	if m == nil || m.turnScopes == nil {
+		return nil, agentturnscope.Scope{}, coreagent.ListedTool{}, status.Error(codes.FailedPrecondition, "agent turn scopes are not configured")
+	}
+	providerName = strings.TrimSpace(providerName)
+	turnID = strings.TrimSpace(turnID)
+	if providerName == "" || turnID == "" {
+		return nil, agentturnscope.Scope{}, coreagent.ListedTool{}, status.Error(codes.FailedPrecondition, "agent turn request context is required")
+	}
+	_, provider, err := m.resolveProvider(ctx, providerName)
+	if err != nil {
+		return nil, agentturnscope.Scope{}, coreagent.ListedTool{}, status.Errorf(codes.PermissionDenied, "agent provider %q is not available for turn scope", providerName)
+	}
+	scope, scopeFound := m.scopeForAgentInvocationRequest(providerName, turnID)
+	if scopeFound {
+		if err := validateAgentInvocationScope(scope, providerName, requestPrincipal); err != nil {
+			return nil, agentturnscope.Scope{}, coreagent.ListedTool{}, err
+		}
+	}
+	providerTurnID := turnID
+	if scopeFound {
+		if scopedProviderTurnID := strings.TrimSpace(scope.ProviderTurnID); scopedProviderTurnID != "" {
+			providerTurnID = scopedProviderTurnID
+		}
+	}
+	turn, err := getAgentInvocationTurn(ctx, provider, providerTurnID, turnID, reqCtx, requestPrincipal)
+	if err != nil {
+		return nil, agentturnscope.Scope{}, coreagent.ListedTool{}, err
+	}
+	if !scopeFound {
+		var ok bool
+		scope, ok = m.scopeForAgentInvocationTurn(providerName, turnID, turn)
+		if !ok {
+			return nil, agentturnscope.Scope{}, coreagent.ListedTool{}, status.Error(codes.PermissionDenied, "agent turn scope was not found")
+		}
+		if err := validateAgentInvocationScope(scope, providerName, requestPrincipal); err != nil {
+			return nil, agentturnscope.Scope{}, coreagent.ListedTool{}, err
+		}
+	}
+	if err := validateAgentInvocationReturnedTurn(scope, turnID, turn); err != nil {
+		return nil, agentturnscope.Scope{}, coreagent.ListedTool{}, err
+	}
+	tool, ok := matchingAgentAppInvocationTool(scope.ListedTools, target)
+	if !ok {
+		return nil, agentturnscope.Scope{}, coreagent.ListedTool{}, status.Errorf(codes.PermissionDenied, "agent turn may not invoke %s.%s", strings.TrimSpace(target.App), strings.TrimSpace(target.Operation))
+	}
+	p := agentScopePrincipal(scope)
+	if p == nil || strings.TrimSpace(p.SubjectID) == "" {
+		return nil, agentturnscope.Scope{}, coreagent.ListedTool{}, status.Error(codes.FailedPrecondition, "agent turn scope subject is required")
+	}
+	return p, scope, tool, nil
+}
+
+func (m *Manager) scopeForAgentInvocationRequest(providerName, requestedTurnID string) (agentturnscope.Scope, bool) {
+	if m == nil || m.turnScopes == nil {
+		return agentturnscope.Scope{}, false
+	}
+	return m.turnScopes.GetByTurnID(providerName, requestedTurnID)
+}
+
+func (m *Manager) scopeForAgentInvocationTurn(providerName, requestedTurnID string, turn *coreagent.Turn) (agentturnscope.Scope, bool) {
+	if m == nil || m.turnScopes == nil || turn == nil {
+		return agentturnscope.Scope{}, false
+	}
+	sessionID := strings.TrimSpace(turn.SessionID)
+	if sessionID == "" {
+		return agentturnscope.Scope{}, false
+	}
+	for _, candidate := range []string{requestedTurnID, turn.ID, turn.ExecutionRef} {
+		scope, ok := m.turnScopes.Get(providerName, sessionID, candidate)
+		if ok {
+			return scope, true
+		}
+	}
+	return agentturnscope.Scope{}, false
+}
+
+func validateAgentInvocationScope(scope agentturnscope.Scope, providerName string, p *principal.Principal) error {
+	if scope.Revoked {
+		return status.Error(codes.PermissionDenied, "agent turn scope is revoked")
+	}
+	if strings.TrimSpace(providerName) != strings.TrimSpace(scope.ProviderName) {
+		return status.Error(codes.PermissionDenied, "agent invocation provider does not match turn scope")
+	}
+	return validateAgentInvocationSubject(scope, p)
+}
+
+func validateAgentInvocationSubject(scope agentturnscope.Scope, p *principal.Principal) error {
+	p = principal.Canonicalized(p)
+	if p == nil || strings.TrimSpace(p.SubjectID) == "" {
+		return status.Error(codes.PermissionDenied, "agent request context subject is required")
+	}
+	if strings.TrimSpace(p.SubjectID) != strings.TrimSpace(scope.SubjectID) {
+		return status.Error(codes.PermissionDenied, "agent request context subject does not match turn scope")
+	}
+	if credentialSubjectID := strings.TrimSpace(scope.CredentialSubjectID); credentialSubjectID != "" && strings.TrimSpace(principal.EffectiveCredentialSubjectID(p)) != credentialSubjectID {
+		return status.Error(codes.PermissionDenied, "agent request context credential subject does not match turn scope")
+	}
+	return nil
+}
+
+func getAgentInvocationTurn(ctx context.Context, provider coreagent.Provider, providerTurnID, requestedTurnID string, reqCtx *proto.RequestContext, p *principal.Principal) (*coreagent.Turn, error) {
+	turn, err := provider.GetTurn(ctx, &proto.GetAgentProviderTurnRequest{
+		TurnId:  strings.TrimSpace(providerTurnID),
+		Context: reqCtx,
+		Subject: &proto.SubjectContext{
+			Id:                  strings.TrimSpace(principalSubjectID(p)),
+			CredentialSubjectId: strings.TrimSpace(principal.EffectiveCredentialSubjectID(p)),
+		},
+	})
+	if err != nil {
+		if agentProviderReturnedNotFound(err) {
+			return nil, status.Errorf(codes.PermissionDenied, "agent turn %q was not found", strings.TrimSpace(requestedTurnID))
+		}
+		return nil, err
+	}
+	return turn, nil
+}
+
+func validateAgentInvocationReturnedTurn(scope agentturnscope.Scope, requestedTurnID string, turn *coreagent.Turn) error {
+	scopeTurnID := strings.TrimSpace(scope.TurnID)
+	requestedTurnID = strings.TrimSpace(requestedTurnID)
+	returnedTurnID := strings.TrimSpace(turn.ID)
+	executionRef := strings.TrimSpace(turn.ExecutionRef)
+	if !agentInvocationTurnIDMatches(returnedTurnID, scopeTurnID, requestedTurnID) && !agentInvocationTurnIDMatches(executionRef, scopeTurnID, requestedTurnID) {
+		return status.Errorf(codes.PermissionDenied, "agent provider returned turn %q for requested turn %q", returnedTurnID, requestedTurnID)
+	}
+	if strings.TrimSpace(turn.SessionID) != strings.TrimSpace(scope.SessionID) {
+		return status.Errorf(codes.PermissionDenied, "agent turn scope is not valid for session %q", strings.TrimSpace(scope.SessionID))
+	}
+	if !coreagent.ExecutionStatusIsLive(turn.Status) {
+		return status.Errorf(codes.PermissionDenied, "agent turn %q is not active", scopeTurnID)
+	}
+	return nil
+}
+
+func agentInvocationTurnIDMatches(value, scopeTurnID, requestedTurnID string) bool {
+	value = strings.TrimSpace(value)
+	return value != "" && (value == strings.TrimSpace(scopeTurnID) || value == strings.TrimSpace(requestedTurnID))
+}
+
+func matchingAgentAppInvocationTool(tools []coreagent.ListedTool, target coreagent.ToolTarget) (coreagent.ListedTool, bool) {
+	targetApp := strings.TrimSpace(target.App)
+	targetOperation := strings.TrimSpace(target.Operation)
+	targetConnection := core.ResolveConnectionAlias(strings.TrimSpace(target.Connection))
+	targetInstance := strings.TrimSpace(target.Instance)
+	targetCredentialMode := core.NormalizeOptionalConnectionMode(target.CredentialMode)
+	var matched coreagent.ListedTool
+	var found bool
+	for i := range tools {
+		tool := tools[i]
+		target := tool.Target
+		if target.Unavailable != nil || strings.TrimSpace(target.System) != "" {
+			continue
+		}
+		if strings.TrimSpace(target.App) != targetApp || strings.TrimSpace(target.Operation) != targetOperation {
+			continue
+		}
+		if targetConnection != "" && core.ResolveConnectionAlias(strings.TrimSpace(target.Connection)) != targetConnection {
+			continue
+		}
+		if targetInstance != "" && strings.TrimSpace(target.Instance) != targetInstance {
+			continue
+		}
+		if targetCredentialMode != "" && core.NormalizeOptionalConnectionMode(target.CredentialMode) != targetCredentialMode {
+			continue
+		}
+		if found {
+			return coreagent.ListedTool{}, false
+		}
+		matched = tool
+		found = true
+	}
+	if found {
+		return matched, true
+	}
+	return coreagent.ListedTool{}, false
+}
+
+func agentScopePrincipal(scope agentturnscope.Scope) *principal.Principal {
+	compiled := principal.CompilePermissions(scope.Permissions)
+	value := &principal.Principal{
+		SubjectID:           strings.TrimSpace(scope.SubjectID),
+		CredentialSubjectID: strings.TrimSpace(scope.CredentialSubjectID),
+		Scopes:              principal.PermissionApps(compiled),
+		TokenPermissions:    compiled,
+	}
+	if kind, _, ok := core.ParseSubjectID(value.SubjectID); ok {
+		value.Kind = principal.Kind(kind)
+	}
+	if value.CredentialSubjectID == "" && principal.IsSystemSubjectID(value.SubjectID) {
+		value.CredentialSubjectID = value.SubjectID
+	}
+	return principal.Canonicalize(value)
+}

--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -279,6 +279,20 @@ func agentProviderRequestContext(ctx context.Context, p *principal.Principal, ex
 	return ctx, reqCtx, err
 }
 
+func setAgentTurnRequestContext(reqCtx *proto.RequestContext, providerName, turnID string) {
+	if reqCtx == nil {
+		return
+	}
+	reqCtx.Caller = &proto.ProviderContext{
+		Kind: string(invocation.ProviderKindAgent),
+		Name: strings.TrimSpace(providerName),
+	}
+	if reqCtx.Invocation == nil {
+		reqCtx.Invocation = &proto.InvocationContext{}
+	}
+	reqCtx.Invocation.RequestId = strings.TrimSpace(turnID)
+}
+
 func agentSubjectToProto(subject core.RunAsSubject) *proto.SubjectContext {
 	return agentwire.RunAsSubjectToProto(&subject)
 }
@@ -802,12 +816,16 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req *p
 	}
 	toolSource := coreagent.ToolSourceModeNone
 	var toolRefs []coreagent.ToolRef
+	var tools []coreagent.Tool
+	var listedTools []coreagent.ListedTool
 	toolRefsSet := true
-	if sessionScope, ok, err := m.sessionScopeForSession(ownedSession.providerName, ownedSession.session); err != nil {
+	if sessionScope, ok, err := m.sessionScopeForSession(ctx, p, ownedSession.providerName, ownedSession.session); err != nil {
 		return nil, err
 	} else if ok {
 		toolSource = normalizeAgentToolSource(sessionScope.ToolSource)
 		toolRefs = append([]coreagent.ToolRef(nil), sessionScope.ToolRefs...)
+		tools = append([]coreagent.Tool(nil), sessionScope.Tools...)
+		listedTools = append([]coreagent.ListedTool(nil), sessionScope.ListedTools...)
 	}
 	requestedOutput := agentOutputFromProto(req.GetOutput())
 	if err := validateAgentOutput(requestedOutput); err != nil {
@@ -816,7 +834,6 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req *p
 	if req.GetTimeoutSeconds() < 0 {
 		return nil, fmt.Errorf("%w: timeout_seconds must not be negative", invocation.ErrInvalidInvocation)
 	}
-	var tools []coreagent.Tool
 	switch toolSource {
 	case coreagent.ToolSourceModeCatalog:
 		if err := validateCatalogToolRefs(toolRefs); err != nil {
@@ -840,7 +857,7 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req *p
 	}
 	idempotencyKey := strings.TrimSpace(req.GetIdempotencyKey())
 	turnID := newAgentTurnID(ownedSession.session.ID, idempotencyKey)
-	if err := m.storeTurnScope(ctx, req.GetContext(), p, ownedSession.providerName, ownedSession.session.ID, turnID, callerKind, callerName, toolRefs, toolRefsSet, tools, toolSource); err != nil {
+	if err := m.storeTurnScope(ctx, req.GetContext(), p, ownedSession.providerName, ownedSession.session.ID, turnID, callerKind, callerName, toolRefs, toolRefsSet, tools, listedTools, toolSource); err != nil {
 		return nil, err
 	}
 	scopeCommitted := false
@@ -858,10 +875,11 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req *p
 	providerReq.CreatedBySubjectId = agentSubjectIDFromPrincipal(p)
 	providerReq.ExecutionRef = turnID
 	providerReq.Subject = agentSubjectToProto(agentSubjectFromPrincipal(p))
-	providerReq.Context, err = agentRequestContext(ctx, p, req.GetContext(), callerKind, callerName)
+	providerReq.Context, err = agentRequestContext(ctx, p, req.GetContext(), invocation.ProviderKindAgent, ownedSession.providerName)
 	if err != nil {
 		return nil, err
 	}
+	setAgentTurnRequestContext(providerReq.Context, ownedSession.providerName, turnID)
 	turn, err = ownedSession.provider.CreateTurn(ctx, providerReq)
 	if err != nil {
 		return nil, err
@@ -876,9 +894,9 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req *p
 	if err := validateAgentTurnOutput(requestedOutput, normalized); err != nil {
 		return nil, err
 	}
-	if executionRef := strings.TrimSpace(normalized.ExecutionRef); executionRef != "" && executionRef != strings.TrimSpace(normalized.ID) {
-		if err := m.turnScopes.Alias(ownedSession.providerName, normalized.SessionID, executionRef, normalized.ID); err != nil {
-			return nil, fmt.Errorf("%w: alias agent turn scope: %v", invocation.ErrInternal, err)
+	if executionRef := strings.TrimSpace(normalized.ExecutionRef); executionRef != "" {
+		if err := m.turnScopes.BindProviderTurnID(ownedSession.providerName, normalized.SessionID, executionRef, normalized.ID); err != nil {
+			return nil, fmt.Errorf("%w: bind agent provider turn scope: %v", invocation.ErrInternal, err)
 		}
 	}
 	scopeCommitted = true
@@ -1591,7 +1609,7 @@ func agentProviderReadFallbackAllowed(err error) bool {
 	return false
 }
 
-func (m *Manager) storeTurnScope(ctx context.Context, reqContext *proto.RequestContext, p *principal.Principal, providerName, sessionID, turnID string, callerKind invocation.ProviderKind, callerName string, toolRefs []coreagent.ToolRef, toolRefsSet bool, tools []coreagent.Tool, toolSource coreagent.ToolSourceMode) error {
+func (m *Manager) storeTurnScope(ctx context.Context, reqContext *proto.RequestContext, p *principal.Principal, providerName, sessionID, turnID string, callerKind invocation.ProviderKind, callerName string, toolRefs []coreagent.ToolRef, toolRefsSet bool, tools []coreagent.Tool, listedTools []coreagent.ListedTool, toolSource coreagent.ToolSourceMode) error {
 	if m == nil || m.turnScopes == nil {
 		return fmt.Errorf("%w: agent turn scopes are not configured", invocation.ErrInternal)
 	}
@@ -1609,6 +1627,7 @@ func (m *Manager) storeTurnScope(ctx context.Context, reqContext *proto.RequestC
 		ProviderName:        providerName,
 		SessionID:           sessionID,
 		TurnID:              turnID,
+		ProviderTurnID:      turnID,
 		CallerKind:          callerKind,
 		CallerName:          callerName,
 		WorkflowRunID:       workflowRunID,
@@ -1619,6 +1638,7 @@ func (m *Manager) storeTurnScope(ctx context.Context, reqContext *proto.RequestC
 		ToolRefs:            append([]coreagent.ToolRef(nil), toolRefs...),
 		ToolRefsSet:         toolRefsSet,
 		Tools:               append([]coreagent.Tool(nil), tools...),
+		ListedTools:         append([]coreagent.ListedTool(nil), listedTools...),
 		ToolSource:          toolSource,
 		Connections:         connections,
 	})
@@ -1663,22 +1683,46 @@ func (m *Manager) sessionScope(providerName, sessionID string) (agentturnscope.S
 	return m.turnScopes.GetSession(providerName, sessionID)
 }
 
-func (m *Manager) sessionScopeForSession(providerName string, session *coreagent.Session) (agentturnscope.Scope, bool, error) {
+func (m *Manager) sessionScopeForSession(ctx context.Context, p *principal.Principal, providerName string, session *coreagent.Session) (agentturnscope.Scope, bool, error) {
 	if session == nil {
 		return agentturnscope.Scope{}, false, nil
 	}
 	sessionID := strings.TrimSpace(session.ID)
 	if scope, ok := m.sessionScope(providerName, sessionID); ok {
+		var err error
+		scope, err = m.hydrateSessionScopeListedTools(ctx, p, providerName, scope)
+		if err != nil {
+			return agentturnscope.Scope{}, true, err
+		}
+		if m != nil && m.turnScopes != nil {
+			_ = m.turnScopes.PutSession(scope)
+		}
 		return scope, true, nil
 	}
 	scope, ok, err := agentSessionScopeFromMetadata(providerName, session)
 	if err != nil || !ok {
 		return agentturnscope.Scope{}, ok, err
 	}
+	scope, err = m.hydrateSessionScopeListedTools(ctx, p, providerName, scope)
+	if err != nil {
+		return agentturnscope.Scope{}, true, err
+	}
 	if m != nil && m.turnScopes != nil {
 		_ = m.turnScopes.PutSession(scope)
 	}
 	return scope, true, nil
+}
+
+func (m *Manager) hydrateSessionScopeListedTools(ctx context.Context, p *principal.Principal, providerName string, scope agentturnscope.Scope) (agentturnscope.Scope, error) {
+	if normalizeAgentToolSource(scope.ToolSource) != coreagent.ToolSourceModeCatalog || len(scope.ToolRefs) == 0 || len(scope.ListedTools) > 0 {
+		return scope, nil
+	}
+	listed, err := m.listAllCatalogTools(ctx, p, providerName, scope.ToolRefs)
+	if err != nil {
+		return agentturnscope.Scope{}, err
+	}
+	scope.ListedTools = listed
+	return scope, nil
 }
 
 func (m *Manager) validateExistingSessionToolScope(ctx context.Context, p *principal.Principal, providerName string, provider coreagent.Provider, sessionID string, reqContext *proto.RequestContext, tools agentSessionTools) error {
@@ -1998,18 +2042,11 @@ func (m *Manager) agentSessionTools(ctx context.Context, p *principal.Principal,
 		}
 		var listed []coreagent.ListedTool
 		if len(refs) > 0 {
-			listResp, err := m.listTools(ctx, p, coreagent.ListToolsRequest{
-				ProviderName: providerName,
-				PageSize:     agentToolListMaxPageSize,
-				ToolRefs:     refs,
-				ToolSource:   coreagent.ToolSourceModeCatalog,
-			})
+			resolved, err := m.listAllCatalogTools(ctx, p, providerName, refs)
 			if err != nil {
 				return agentSessionTools{}, err
 			}
-			if listResp != nil {
-				listed = append([]coreagent.ListedTool(nil), listResp.Tools...)
-			}
+			listed = executableListedTools(resolved)
 		}
 		return agentSessionTools{
 			config: &proto.AgentToolConfig{Source: &proto.AgentToolConfig_Catalog{Catalog: &proto.AgentCatalogToolConfig{
@@ -2024,6 +2061,49 @@ func (m *Manager) agentSessionTools(ctx context.Context, p *principal.Principal,
 	default:
 		return agentSessionTools{}, fmt.Errorf("%w: agent session tools source is required", invocation.ErrInvalidInvocation)
 	}
+}
+
+func (m *Manager) listAllCatalogTools(ctx context.Context, p *principal.Principal, providerName string, refs []coreagent.ToolRef) ([]coreagent.ListedTool, error) {
+	var tools []coreagent.ListedTool
+	pageToken := ""
+	for {
+		listResp, err := m.listTools(ctx, p, coreagent.ListToolsRequest{
+			ProviderName: providerName,
+			PageSize:     agentToolListMaxPageSize,
+			PageToken:    pageToken,
+			ToolRefs:     refs,
+			ToolSource:   coreagent.ToolSourceModeCatalog,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if listResp == nil {
+			return tools, nil
+		}
+		tools = append(tools, listResp.Tools...)
+		nextPageToken := strings.TrimSpace(listResp.NextPageToken)
+		if nextPageToken == "" {
+			return tools, nil
+		}
+		if nextPageToken == pageToken {
+			return nil, fmt.Errorf("%w: agent tool listing returned duplicate next page token", invocation.ErrInternal)
+		}
+		pageToken = nextPageToken
+	}
+}
+
+func executableListedTools(tools []coreagent.ListedTool) []coreagent.ListedTool {
+	if len(tools) == 0 {
+		return nil
+	}
+	out := make([]coreagent.ListedTool, 0, len(tools))
+	for i := range tools {
+		if tools[i].Target.Unavailable != nil {
+			continue
+		}
+		out = append(out, tools[i])
+	}
+	return out
 }
 
 func agentSessionMetadataWithToolScope(metadata map[string]any, tools agentSessionTools) (*structpb.Struct, error) {

--- a/gestaltd/services/agents/agentmanager/manager_test.go
+++ b/gestaltd/services/agents/agentmanager/manager_test.go
@@ -779,11 +779,16 @@ func TestCreateSessionRejectsInvalidWorkflowScopeBeforeProviderCreate(t *testing
 func TestCreateSessionHydratesAndStoresSessionTools(t *testing.T) {
 	t.Parallel()
 
-	slack := agentCatalogTestProvider("slack", "Slack", "chat.postMessage")
+	const toolCount = agentToolListMaxPageSize + 7
+	operations := make([]string, toolCount)
+	for i := range operations {
+		operations[i] = fmt.Sprintf("fetch_%04d", i+1)
+	}
+	docs := agentCatalogTestProvider("docs", "Docs", operations...)
 	alpha := newRouteCountingAgentProvider("alpha")
 	scopes := newAgentManagerTestTurnScopes()
 	manager := newTestManager(t, Config{
-		Providers: testutil.NewProviderRegistry(t, slack),
+		Providers: testutil.NewProviderRegistry(t, docs),
 		Agent: &routeCountingAgentControl{
 			defaultName: "alpha",
 			names:       []string{"alpha"},
@@ -798,8 +803,7 @@ func TestCreateSessionHydratesAndStoresSessionTools(t *testing.T) {
 		Model:        "test-model",
 		Tools: &proto.AgentToolConfig{Source: &proto.AgentToolConfig_Catalog{Catalog: &proto.AgentCatalogToolConfig{
 			Refs: []*proto.AgentToolRef{{
-				App:       "slack",
-				Operation: "chat.postMessage",
+				App: "docs",
 			}},
 		}}},
 	})
@@ -813,11 +817,11 @@ func TestCreateSessionHydratesAndStoresSessionTools(t *testing.T) {
 	if catalogTools == nil {
 		t.Fatalf("provider session tools = %#v, want catalog", alpha.createSessionReqs[0].GetTools())
 	}
-	if got := catalogTools.GetRefs()[0].GetOperation(); got != "chat.postMessage" {
-		t.Fatalf("provider session tool ref operation = %q, want chat.postMessage", got)
+	if got := catalogTools.GetRefs()[0].GetApp(); got != "docs" {
+		t.Fatalf("provider session tool ref app = %q, want docs", got)
 	}
-	if got := catalogTools.GetTools()[0].GetRef().GetOperation(); got != "chat.postMessage" {
-		t.Fatalf("provider listed tool operation = %q, want chat.postMessage", got)
+	if len(catalogTools.GetTools()) != toolCount {
+		t.Fatalf("provider listed tools = %d, want %d", len(catalogTools.GetTools()), toolCount)
 	}
 	scope, ok := scopes.GetSession("alpha", session.ID)
 	if !ok {
@@ -826,11 +830,11 @@ func TestCreateSessionHydratesAndStoresSessionTools(t *testing.T) {
 	if scope.ToolSource != coreagent.ToolSourceModeCatalog {
 		t.Fatalf("session scope tool source = %q, want catalog", scope.ToolSource)
 	}
-	if len(scope.ToolRefs) != 1 || scope.ToolRefs[0].Operation != "chat.postMessage" {
-		t.Fatalf("session scope refs = %#v, want slack chat.postMessage", scope.ToolRefs)
+	if len(scope.ToolRefs) != 1 || scope.ToolRefs[0].App != "docs" {
+		t.Fatalf("session scope refs = %#v, want docs", scope.ToolRefs)
 	}
-	if len(scope.ListedTools) != 1 || scope.ListedTools[0].Ref.Operation != "chat.postMessage" {
-		t.Fatalf("session scope listed tools = %#v, want chat.postMessage", scope.ListedTools)
+	if len(scope.ListedTools) != toolCount {
+		t.Fatalf("session scope listed tools = %d, want %d", len(scope.ListedTools), toolCount)
 	}
 	if _, err := manager.UpdateSession(context.Background(), p, &proto.UpdateAgentProviderSessionRequest{
 		SessionId: session.ID,
@@ -1267,14 +1271,264 @@ func TestCreateTurnInheritsSessionToolScope(t *testing.T) {
 	}
 }
 
-func TestCreateTurnRejectsToolsOutsideSessionScope(t *testing.T) {
+func TestAuthorizeAgentAppInvocationUsesPersistedTurnScope(t *testing.T) {
 	t.Parallel()
 
 	slack := agentCatalogTestProvider("slack", "Slack", "chat.postMessage")
-	github := agentCatalogTestProvider("github", "GitHub", "issues.create")
+	slack.ConnMode = core.ConnectionModeSubject
+	alpha := newRouteCountingAgentProvider("alpha")
+	scopes := newAgentManagerTestTurnScopes()
+	manager := newTestManager(t, Config{
+		Providers: testutil.NewProviderRegistry(t, slack),
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers:   map[string]*routeCountingAgentProvider{"alpha": alpha},
+		},
+		TurnScopes: scopes,
+	})
+	p := &principal.Principal{
+		SubjectID:           principal.UserSubjectID("user-1"),
+		CredentialSubjectID: principal.UserSubjectID("user-1"),
+	}
+	ctx := invocation.WithCallerProvider(context.Background(), invocation.ProviderKindApp, "sats")
+
+	session, err := manager.CreateSession(ctx, p, &proto.CreateAgentProviderSessionRequest{
+		ProviderName: "alpha",
+		Model:        "test-model",
+		Tools: &proto.AgentToolConfig{Source: &proto.AgentToolConfig_Catalog{Catalog: &proto.AgentCatalogToolConfig{
+			Refs: []*proto.AgentToolRef{{
+				App:            "slack",
+				Operation:      "chat.postMessage",
+				Connection:     "team-primary",
+				CredentialMode: string(core.ConnectionModeSubject),
+			}},
+		}}},
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	turn, err := manager.CreateTurn(ctx, p, &proto.CreateAgentProviderTurnRequest{
+		SessionId:      session.ID,
+		Model:          "test-model",
+		Output:         agentTextOutputProto(),
+		TimeoutSeconds: 1,
+	})
+	if err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	if len(alpha.createTurnReqs) != 1 {
+		t.Fatalf("CreateTurn calls = %d, want 1", len(alpha.createTurnReqs))
+	}
+	providerReqCtx := alpha.createTurnReqs[0].GetContext()
+	requireAgentManagerRequestContextCaller(t, providerReqCtx, invocation.ProviderKindAgent, "alpha")
+	if got := providerReqCtx.GetInvocation().GetRequestId(); got != turn.ID {
+		t.Fatalf("provider request id = %q, want turn id %q", got, turn.ID)
+	}
+	scope := requireAgentManagerTurnScope(t, scopes, "alpha", session.ID, turn.ID)
+	if len(scope.ListedTools) != 1 || scope.ListedTools[0].Target.App != "slack" || scope.ListedTools[0].Target.Operation != "chat.postMessage" {
+		t.Fatalf("turn listed tools = %#v, want slack chat.postMessage", scope.ListedTools)
+	}
+	runAs := &core.RunAsSubject{
+		SubjectID:           "service_account:automation",
+		CredentialSubjectID: "service_account:automation",
+	}
+	scope.ListedTools[0].Target.RunAs = runAs
+	if err := scopes.Put(scope); err != nil {
+		t.Fatalf("Put delegated turn scope: %v", err)
+	}
+
+	target := coreagent.ToolTarget{
+		App:       "slack",
+		Operation: "chat.postMessage",
+	}
+	authorized, authorizedScope, authorizedTool, err := manager.AuthorizeAgentAppInvocation(context.Background(), "alpha", turn.ID, p, target, providerReqCtx)
+	if err != nil {
+		t.Fatalf("AuthorizeAgentAppInvocation: %v", err)
+	}
+	if authorized == nil || authorized.SubjectID != p.SubjectID || authorized.CredentialSubjectID != p.CredentialSubjectID {
+		t.Fatalf("authorized principal = %#v, want %s/%s", authorized, p.SubjectID, p.CredentialSubjectID)
+	}
+	if _, ok := authorized.TokenPermissions["slack"]["chat.postMessage"]; !ok {
+		t.Fatalf("authorized permissions = %#v, want only persisted slack chat.postMessage scope", authorized.TokenPermissions)
+	}
+	if authorizedTool.Target.CredentialMode != core.ConnectionModeSubject {
+		t.Fatalf("credential mode = %q, want subject", authorizedTool.Target.CredentialMode)
+	}
+	if authorizedTool.Target.Connection != "team-primary" {
+		t.Fatalf("connection = %q, want team-primary", authorizedTool.Target.Connection)
+	}
+	if !core.RunAsSubjectsEqual(authorizedTool.Target.RunAs, runAs) {
+		t.Fatalf("runAs = %#v, want %#v", authorizedTool.Target.RunAs, runAs)
+	}
+	if !authorizedScope.ToolRefsSet || len(authorizedScope.ToolRefs) != 1 || authorizedScope.ToolRefs[0].App != "slack" || authorizedScope.ToolRefs[0].Operation != "chat.postMessage" {
+		t.Fatalf("authorized tool refs = %#v, set=%v; want persisted slack chat.postMessage refs", authorizedScope.ToolRefs, authorizedScope.ToolRefsSet)
+	}
+	if alpha.getTurnCalls != 1 {
+		t.Fatalf("GetTurn calls = %d, want 1 live-turn validation", alpha.getTurnCalls)
+	}
+
+	target.Operation = "chat.delete"
+	_, _, _, err = manager.AuthorizeAgentAppInvocation(context.Background(), "alpha", turn.ID, p, target, providerReqCtx)
+	if got := status.Code(err); got != codes.PermissionDenied {
+		t.Fatalf("AuthorizeAgentAppInvocation unlisted operation status = %s, want %s (err=%v)", got, codes.PermissionDenied, err)
+	}
+	target.Operation = "chat.postMessage"
+	_, _, _, err = manager.AuthorizeAgentAppInvocation(context.Background(), "beta", turn.ID, p, target, providerReqCtx)
+	if got := status.Code(err); got != codes.PermissionDenied {
+		t.Fatalf("AuthorizeAgentAppInvocation wrong provider status = %s, want %s (err=%v)", got, codes.PermissionDenied, err)
+	}
+}
+
+func TestMatchingAgentAppInvocationToolUsesOptionalSelectors(t *testing.T) {
+	t.Parallel()
+
+	tools := []coreagent.ListedTool{{
+		Target: coreagent.ToolTarget{
+			App:            "slack",
+			Operation:      "chat.postMessage",
+			Connection:     "team-primary",
+			Instance:       "workspace-1",
+			CredentialMode: core.ConnectionModeSubject,
+		},
+	}, {
+		Target: coreagent.ToolTarget{
+			App:            "github",
+			Operation:      "issues.create",
+			Connection:     "org-primary",
+			CredentialMode: core.ConnectionModeSubject,
+		},
+	}}
+
+	tool, ok := matchingAgentAppInvocationTool(tools, coreagent.ToolTarget{
+		App:       "slack",
+		Operation: "chat.postMessage",
+	})
+	if !ok {
+		t.Fatal("matchingAgentAppInvocationTool without selectors failed")
+	}
+	if got := tool.Target.Connection; got != "team-primary" {
+		t.Fatalf("connection = %q, want persisted team-primary", got)
+	}
+
+	tools = append(tools, coreagent.ListedTool{Target: coreagent.ToolTarget{
+		App:            "slack",
+		Operation:      "chat.postMessage",
+		Connection:     "team-secondary",
+		Instance:       "workspace-2",
+		CredentialMode: core.ConnectionModeSubject,
+	}})
+	if _, ok := matchingAgentAppInvocationTool(tools, coreagent.ToolTarget{
+		App:       "slack",
+		Operation: "chat.postMessage",
+	}); ok {
+		t.Fatal("matchingAgentAppInvocationTool without selectors matched ambiguous tools")
+	}
+	tool, ok = matchingAgentAppInvocationTool(tools, coreagent.ToolTarget{
+		App:        "slack",
+		Operation:  "chat.postMessage",
+		Connection: "team-secondary",
+	})
+	if !ok {
+		t.Fatal("matchingAgentAppInvocationTool with connection selector failed")
+	}
+	if got := tool.Target.Instance; got != "workspace-2" {
+		t.Fatalf("instance = %q, want workspace-2", got)
+	}
+}
+
+func TestAuthorizeAgentAppInvocationAcceptsProviderOwnedTurnID(t *testing.T) {
+	t.Parallel()
+
+	slack := agentCatalogTestProvider("slack", "Slack", "chat.postMessage")
+	alpha := newRouteCountingAgentProvider("alpha")
+	alpha.turnIDOverride = "provider-turn-1"
+	scopes := newAgentManagerTestTurnScopes()
+	manager := newTestManager(t, Config{
+		Providers: testutil.NewProviderRegistry(t, slack),
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers:   map[string]*routeCountingAgentProvider{"alpha": alpha},
+		},
+		TurnScopes: scopes,
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+	ctx := invocation.WithCallerProvider(context.Background(), invocation.ProviderKindApp, "sats")
+
+	session, err := manager.CreateSession(ctx, p, &proto.CreateAgentProviderSessionRequest{
+		ProviderName: "alpha",
+		Model:        "test-model",
+		Tools: &proto.AgentToolConfig{Source: &proto.AgentToolConfig_Catalog{Catalog: &proto.AgentCatalogToolConfig{
+			Refs: []*proto.AgentToolRef{{
+				App:       "slack",
+				Operation: "chat.postMessage",
+			}},
+		}}},
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	turn, err := manager.CreateTurn(ctx, p, &proto.CreateAgentProviderTurnRequest{
+		SessionId:      session.ID,
+		IdempotencyKey: "provider-owned-turn",
+		Model:          "test-model",
+		Output:         agentTextOutputProto(),
+		TimeoutSeconds: 1,
+	})
+	if err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	if turn.ID != "provider-turn-1" {
+		t.Fatalf("CreateTurn ID = %q, want provider-turn-1", turn.ID)
+	}
+	if strings.TrimSpace(turn.ExecutionRef) == "" || turn.ExecutionRef == turn.ID {
+		t.Fatalf("CreateTurn ExecutionRef = %q, want generated execution ref distinct from provider turn ID", turn.ExecutionRef)
+	}
+	if _, ok := scopes.Get("alpha", session.ID, turn.ID); !ok {
+		t.Fatalf("provider-owned turn scope alias %q was not stored", turn.ID)
+	}
+	providerReqCtx := alpha.createTurnReqs[0].GetContext()
+	target := coreagent.ToolTarget{
+		App:       "slack",
+		Operation: "chat.postMessage",
+	}
+
+	authorized, _, _, err := manager.AuthorizeAgentAppInvocation(context.Background(), "alpha", turn.ExecutionRef, p, target, providerReqCtx)
+	if err != nil {
+		t.Fatalf("AuthorizeAgentAppInvocation with execution ref: %v", err)
+	}
+	if authorized == nil || authorized.SubjectID != p.SubjectID {
+		t.Fatalf("authorized principal = %#v, want %s", authorized, p.SubjectID)
+	}
+
+	providerOwnedReqCtx := cloneAgentRequest(providerReqCtx, &proto.RequestContext{})
+	providerOwnedReqCtx.Invocation.RequestId = turn.ID
+
+	authorized, _, _, err = manager.AuthorizeAgentAppInvocation(context.Background(), "alpha", turn.ID, p, target, providerOwnedReqCtx)
+	if err != nil {
+		t.Fatalf("AuthorizeAgentAppInvocation with provider turn id: %v", err)
+	}
+	if authorized == nil || authorized.SubjectID != p.SubjectID {
+		t.Fatalf("authorized principal = %#v, want %s", authorized, p.SubjectID)
+	}
+	if alpha.getTurnCalls != 2 {
+		t.Fatalf("GetTurn calls = %d, want 2 provider-owned turn lookups", alpha.getTurnCalls)
+	}
+}
+
+func TestCreateTurnRejectsToolsOutsideSessionScope(t *testing.T) {
+	t.Parallel()
+
+	const toolCount = agentToolListMaxPageSize + 7
+	operations := make([]string, toolCount)
+	for i := range operations {
+		operations[i] = fmt.Sprintf("fetch_%04d", i+1)
+	}
+	docs := agentCatalogTestProvider("docs", "Docs", operations...)
 	alpha := newRouteCountingAgentProvider("alpha")
 	manager := newTestManager(t, Config{
-		Providers: testutil.NewProviderRegistry(t, slack, github),
+		Providers: testutil.NewProviderRegistry(t, docs),
 		Agent: &routeCountingAgentControl{
 			defaultName: "alpha",
 			names:       []string{"alpha"},
@@ -1288,8 +1542,7 @@ func TestCreateTurnRejectsToolsOutsideSessionScope(t *testing.T) {
 		Model:        "test-model",
 		Tools: &proto.AgentToolConfig{Source: &proto.AgentToolConfig_Catalog{Catalog: &proto.AgentCatalogToolConfig{
 			Refs: []*proto.AgentToolRef{{
-				App:       "slack",
-				Operation: "chat.postMessage",
+				App: "docs",
 			}},
 		}}},
 	})
@@ -1307,8 +1560,11 @@ func TestCreateTurnRejectsToolsOutsideSessionScope(t *testing.T) {
 		t.Fatalf("CreateTurn: %v", err)
 	}
 	scope := requireAgentManagerTurnScope(t, manager.turnScopes, "alpha", session.ID, alpha.createTurnReqs[0].GetTurnId())
-	if len(scope.ToolRefs) != 1 || scope.ToolRefs[0].App != "slack" {
-		t.Fatalf("turn scope refs = %#v, want durable slack scope", scope.ToolRefs)
+	if len(scope.ToolRefs) != 1 || scope.ToolRefs[0].App != "docs" {
+		t.Fatalf("turn scope refs = %#v, want durable docs scope", scope.ToolRefs)
+	}
+	if len(scope.ListedTools) != toolCount {
+		t.Fatalf("turn listed tools = %d, want %d", len(scope.ListedTools), toolCount)
 	}
 }
 

--- a/gestaltd/services/agents/agentturnscope/store.go
+++ b/gestaltd/services/agents/agentturnscope/store.go
@@ -19,6 +19,7 @@ type Scope struct {
 	ProviderName        string
 	SessionID           string
 	TurnID              string
+	ProviderTurnID      string
 	CallerKind          invocation.ProviderKind
 	CallerName          string
 	WorkflowRunID       string
@@ -63,6 +64,9 @@ func (s *Store) Put(scope Scope) error {
 		s.scopes = map[string]*Scope{}
 	}
 	s.scopes[key] = &scope
+	if providerKey := scopeKey(scope.ProviderName, scope.SessionID, scope.ProviderTurnID); providerKey != "" && providerKey != key {
+		s.scopes[providerKey] = &scope
+	}
 	return nil
 }
 
@@ -73,6 +77,7 @@ func (s *Store) PutSession(scope Scope) error {
 		return fmt.Errorf("agent session scope requires provider and session")
 	}
 	scope.TurnID = ""
+	scope.ProviderTurnID = ""
 	if scope.ToolRefsSet || len(scope.ToolRefs) > 0 {
 		scope.ToolRefsSet = true
 	}
@@ -85,10 +90,10 @@ func (s *Store) PutSession(scope Scope) error {
 	return nil
 }
 
-func (s *Store) Alias(providerName, sessionID, turnID, aliasTurnID string) error {
+func (s *Store) BindProviderTurnID(providerName, sessionID, turnID, providerTurnID string) error {
 	key := scopeKey(providerName, sessionID, turnID)
-	aliasKey := scopeKey(providerName, sessionID, aliasTurnID)
-	if key == "" || aliasKey == "" || key == aliasKey {
+	providerKey := scopeKey(providerName, sessionID, providerTurnID)
+	if key == "" || providerKey == "" {
 		return nil
 	}
 	s.mu.Lock()
@@ -97,7 +102,10 @@ func (s *Store) Alias(providerName, sessionID, turnID, aliasTurnID string) error
 	if scope == nil {
 		return fmt.Errorf("agent turn scope not found")
 	}
-	s.scopes[aliasKey] = scope
+	scope.ProviderTurnID = strings.TrimSpace(providerTurnID)
+	if key != providerKey {
+		s.scopes[providerKey] = scope
+	}
 	return nil
 }
 
@@ -152,6 +160,34 @@ func (s *Store) Get(providerName, sessionID, turnID string) (Scope, bool) {
 	return cloneScope(*scope), true
 }
 
+func (s *Store) GetByTurnID(providerName, turnID string) (Scope, bool) {
+	providerName = strings.TrimSpace(providerName)
+	turnID = strings.TrimSpace(turnID)
+	if providerName == "" || turnID == "" || s == nil {
+		return Scope{}, false
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var found *Scope
+	for key, scope := range s.scopes {
+		if scope == nil {
+			continue
+		}
+		keyProvider, keyTurnID, ok := scopeKeyProviderAndTurn(key)
+		if !ok || keyProvider != providerName || keyTurnID != turnID {
+			continue
+		}
+		if found != nil && found != scope {
+			return Scope{}, false
+		}
+		found = scope
+	}
+	if found == nil {
+		return Scope{}, false
+	}
+	return cloneScope(*found), true
+}
+
 func (s *Store) GetSession(providerName, sessionID string) (Scope, bool) {
 	key := sessionScopeKey(providerName, sessionID)
 	if key == "" || s == nil {
@@ -185,13 +221,31 @@ func sessionScopeKey(providerName, sessionID string) string {
 	return providerName + "\x00" + sessionID
 }
 
+func scopeKeyProviderAndTurn(key string) (string, string, bool) {
+	providerName, rest, ok := strings.Cut(key, "\x00")
+	if !ok {
+		return "", "", false
+	}
+	_, turnID, ok := strings.Cut(rest, "\x00")
+	if !ok {
+		return "", "", false
+	}
+	return providerName, turnID, true
+}
+
 func cloneScope(src Scope) Scope {
 	callerKind := invocation.ProviderKind(strings.TrimSpace(string(src.CallerKind)))
 	callerName := strings.TrimSpace(src.CallerName)
+	turnID := strings.TrimSpace(src.TurnID)
+	providerTurnID := strings.TrimSpace(src.ProviderTurnID)
+	if providerTurnID == "" {
+		providerTurnID = turnID
+	}
 	return Scope{
 		ProviderName:        strings.TrimSpace(src.ProviderName),
 		SessionID:           strings.TrimSpace(src.SessionID),
-		TurnID:              strings.TrimSpace(src.TurnID),
+		TurnID:              turnID,
+		ProviderTurnID:      providerTurnID,
 		CallerKind:          callerKind,
 		CallerName:          callerName,
 		WorkflowRunID:       strings.TrimSpace(src.WorkflowRunID),

--- a/gestaltd/services/appaccess/app_server.go
+++ b/gestaltd/services/appaccess/app_server.go
@@ -7,9 +7,11 @@ import (
 	"strings"
 
 	"github.com/valon-technologies/gestalt/server/core"
+	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
 	"github.com/valon-technologies/gestalt/server/internal/agentwire"
 	"github.com/valon-technologies/gestalt/server/internal/protoutil"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/agents/agentturnscope"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"google.golang.org/grpc/codes"
@@ -30,6 +32,7 @@ type AppServer struct {
 	authorization  core.AuthorizationProvider
 	callerName     string
 	accessProfiles AppAccessProfiles
+	agentAppAuth   func(context.Context, string, string, *principal.Principal, coreagent.ToolTarget, *proto.RequestContext) (*principal.Principal, agentturnscope.Scope, coreagent.ListedTool, error)
 }
 
 type AppServerOption func(*AppServer)
@@ -37,6 +40,12 @@ type AppServerOption func(*AppServer)
 func WithAuthorizationProvider(provider core.AuthorizationProvider) AppServerOption {
 	return func(s *AppServer) {
 		s.authorization = provider
+	}
+}
+
+func WithAgentAppInvocationAuthorizer(authorizer func(context.Context, string, string, *principal.Principal, coreagent.ToolTarget, *proto.RequestContext) (*principal.Principal, agentturnscope.Scope, coreagent.ListedTool, error)) AppServerOption {
+	return func(s *AppServer) {
+		s.agentAppAuth = authorizer
 	}
 }
 
@@ -150,6 +159,11 @@ type requestInvocationContext struct {
 	credentialModeOverride core.ConnectionMode
 	operationProfile       AppOperationProfile
 	workflow               map[string]any
+	agentToolRefs          []coreagent.ToolRef
+	agentToolRefsSet       bool
+	authorizedConnection   string
+	authorizedInstance     string
+	authorizedSelectors    bool
 	requestContext         *proto.RequestContext
 }
 
@@ -161,6 +175,29 @@ func (s *AppServer) requestContextForInvoke(ctx context.Context, reqCtx *proto.R
 	credentialMode, err := appInvokeCredentialMode(rawCredentialMode)
 	if err != nil {
 		return requestInvocationContext{}, err
+	}
+	if callCtx.callerProviderKind == invocation.ProviderKindAgent {
+		authorizedPrincipal, scope, tool, err := s.authorizeAgentAppInvocation(ctx, callCtx, targetApp, targetOperation, rawConnection, rawInstance, credentialMode)
+		if err != nil {
+			return requestInvocationContext{}, err
+		}
+		if authorizedPrincipal != nil {
+			callCtx.principal = authorizedPrincipal
+		}
+		if mode := core.NormalizeOptionalConnectionMode(tool.Target.CredentialMode); mode != "" {
+			callCtx.credentialModeOverride = mode
+		}
+		callCtx.authorizedConnection = core.ResolveConnectionAlias(strings.TrimSpace(tool.Target.Connection))
+		callCtx.authorizedInstance = strings.TrimSpace(tool.Target.Instance)
+		callCtx.authorizedSelectors = true
+		if runAs := core.NormalizeRunAsSubject(tool.Target.RunAs); runAs != nil {
+			callCtx.operationProfile.Delegation.RunAs = runAs
+		}
+		if scope.ToolRefsSet {
+			callCtx.agentToolRefs = append([]coreagent.ToolRef(nil), scope.ToolRefs...)
+			callCtx.agentToolRefsSet = true
+		}
+		return callCtx, nil
 	}
 	if callCtx.callerProviderKind == invocation.ProviderKindWorkflow {
 		if err := authorizeWorkflowAppInvocation(callCtx, targetApp, targetOperation, rawConnection, rawInstance, credentialMode); err != nil {
@@ -198,6 +235,9 @@ func (s *AppServer) requestContextForSurfaceInvoke(ctx context.Context, reqCtx *
 	if err != nil {
 		return requestInvocationContext{}, err
 	}
+	if callCtx.callerProviderKind == invocation.ProviderKindAgent {
+		return requestInvocationContext{}, status.Error(codes.PermissionDenied, "agent callers may only invoke listed app operations")
+	}
 	if err := s.authorizeAppInvocation(ctx, callCtx, appInvocationAuthorizationResourceTypeSurface, appInvocationSurfaceResourceID(targetApp, surface), targetApp, surface); err != nil {
 		return requestInvocationContext{}, err
 	}
@@ -219,7 +259,7 @@ func (s *AppServer) requestContext(reqCtx *proto.RequestContext) (requestInvocat
 	if callerName == "" {
 		return requestInvocationContext{}, status.Error(codes.FailedPrecondition, "provider caller context is required")
 	}
-	if callerKind != invocation.ProviderKindApp && callerKind != invocation.ProviderKindWorkflow {
+	if callerKind != invocation.ProviderKindApp && callerKind != invocation.ProviderKindWorkflow && callerKind != invocation.ProviderKindAgent {
 		return requestInvocationContext{}, status.Errorf(codes.FailedPrecondition, "%s caller context is not supported for app invocation", callerKind)
 	}
 	if expected := strings.TrimSpace(s.callerName); expected != "" && callerName != expected {
@@ -236,8 +276,8 @@ func (s *AppServer) requestContext(reqCtx *proto.RequestContext) (requestInvocat
 }
 
 func (s *AppServer) authorizeAppInvocation(ctx context.Context, callCtx requestInvocationContext, resourceType, resourceID, targetApp, target string) error {
-	if callCtx.callerProviderKind == invocation.ProviderKindWorkflow {
-		return status.Error(codes.PermissionDenied, "workflow callers may only invoke workflow target app operations")
+	if callCtx.callerProviderKind == invocation.ProviderKindWorkflow || callCtx.callerProviderKind == invocation.ProviderKindAgent {
+		return status.Errorf(codes.PermissionDenied, "%s callers may only invoke authorized target app operations", callCtx.callerProviderKind)
 	}
 	if s == nil || s.authorization == nil {
 		return status.Error(codes.FailedPrecondition, "authorization provider is required for app invocation")
@@ -260,6 +300,26 @@ func (s *AppServer) authorizeAppInvocation(ctx context.Context, callCtx requestI
 		return status.Errorf(codes.PermissionDenied, "plugin %q may not invoke %s.%s", callCtx.callerName, targetApp, target)
 	}
 	return nil
+}
+
+func (s *AppServer) authorizeAgentAppInvocation(ctx context.Context, callCtx requestInvocationContext, targetApp, targetOperation, rawConnection, rawInstance string, credentialMode core.ConnectionMode) (*principal.Principal, agentturnscope.Scope, coreagent.ListedTool, error) {
+	if s == nil || s.agentAppAuth == nil {
+		return nil, agentturnscope.Scope{}, coreagent.ListedTool{}, status.Error(codes.FailedPrecondition, "agent app invocation authorizer is required")
+	}
+	turnID := ""
+	if meta := invocationMetaFromRequestContext(callCtx.requestContext); meta != nil {
+		turnID = strings.TrimSpace(meta.RequestID)
+	}
+	if turnID == "" {
+		return nil, agentturnscope.Scope{}, coreagent.ListedTool{}, status.Error(codes.FailedPrecondition, "agent turn request context is required")
+	}
+	return s.agentAppAuth(ctx, strings.TrimSpace(callCtx.callerName), turnID, callCtx.principal, coreagent.ToolTarget{
+		App:            targetApp,
+		Operation:      targetOperation,
+		Connection:     strings.TrimSpace(rawConnection),
+		Instance:       strings.TrimSpace(rawInstance),
+		CredentialMode: core.NormalizeOptionalConnectionMode(credentialMode),
+	}, callCtx.requestContext)
 }
 
 func authorizeWorkflowAppInvocation(callCtx requestInvocationContext, targetApp, targetOperation, rawConnection, rawInstance string, credentialMode core.ConnectionMode) error {
@@ -319,6 +379,9 @@ func appInvokeCredentialModeAllowed(mode core.ConnectionMode, profile AppOperati
 }
 
 func prepareInvocationSelectors(ctx context.Context, callCtx requestInvocationContext, rawConnection, rawInstance string) (context.Context, string, error) {
+	if callCtx.authorizedSelectors {
+		return restoreRequestInvocationContext(ctx, callCtx, callCtx.authorizedConnection), callCtx.authorizedInstance, nil
+	}
 	connection := strings.TrimSpace(rawConnection)
 	instance := strings.TrimSpace(rawInstance)
 	if instance == "" && connection == "" {
@@ -353,7 +416,7 @@ func restoreRequestInvocationContext(ctx context.Context, callCtx requestInvocat
 		if surface := invocation.InvocationSurface(strings.TrimSpace(inv.GetSurface())); surface != "" {
 			ctx = invocation.WithInvocationSurface(ctx, surface)
 		}
-		if inv.GetInternalConnectionAccess() {
+		if inv.GetInternalConnectionAccess() && !callCtx.authorizedSelectors {
 			ctx = invocation.WithInternalConnectionAccess(ctx)
 		}
 	}
@@ -361,12 +424,15 @@ func restoreRequestInvocationContext(ctx context.Context, callCtx requestInvocat
 		ctx = invocation.WithWorkflowContext(ctx, invocation.CloneWorkflowContext(callCtx.workflow))
 	}
 	ctx = applyInheritedRequestContext(ctx, callCtx.requestContext)
+	if callCtx.agentToolRefsSet {
+		ctx = invocation.WithToolRefsContext(ctx, callCtx.agentToolRefs)
+	}
 
 	connection := strings.TrimSpace(connectionOverride)
-	if connection == "" && callCtx.requestContext.GetInvocation() != nil {
+	if !callCtx.authorizedSelectors && connection == "" && callCtx.requestContext.GetInvocation() != nil {
 		connection = strings.TrimSpace(callCtx.requestContext.GetInvocation().GetConnection())
 	}
-	if connection == "" {
+	if !callCtx.authorizedSelectors && connection == "" {
 		connection = strings.TrimSpace(callCtx.credential.Connection)
 	}
 	if connection != "" {

--- a/gestaltd/services/appaccess/app_test.go
+++ b/gestaltd/services/appaccess/app_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/core"
+	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/agents/agentturnscope"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"google.golang.org/grpc"
@@ -33,6 +35,7 @@ type recordingAppInvocation struct {
 	instance            string
 	operation           string
 	credentialMode      core.ConnectionMode
+	toolRefs            []coreagent.ToolRef
 	params              map[string]any
 	graphQLProviderName string
 	graphQLDocument     string
@@ -65,6 +68,9 @@ func (i *recordingAppInvocation) Invoke(ctx context.Context, p *principal.Princi
 	i.instance = instance
 	i.operation = operation
 	i.credentialMode = invocation.CredentialModeOverrideFromContext(ctx)
+	if refs := invocation.ToolRefsContextFromContext(ctx); refs.Set {
+		i.toolRefs = append([]coreagent.ToolRef(nil), refs.Refs...)
+	}
 	i.params = params
 	return &core.OperationResult{Status: 202, Body: "accepted"}, nil
 }
@@ -113,6 +119,27 @@ func (p *recordingAuthorizationProvider) ListActiveModelResourceTypes(context.Co
 }
 func (p *recordingAuthorizationProvider) Ping(context.Context) error { return nil }
 func (p *recordingAuthorizationProvider) Close() error               { return nil }
+
+type recordingAgentAppAuthorizer struct {
+	providerName string
+	turnID       string
+	principal    *principal.Principal
+	target       coreagent.ToolTarget
+	reqCtx       *proto.RequestContext
+	principalOut *principal.Principal
+	scope        agentturnscope.Scope
+	tool         coreagent.ListedTool
+	err          error
+}
+
+func (a *recordingAgentAppAuthorizer) Authorize(_ context.Context, providerName, turnID string, p *principal.Principal, target coreagent.ToolTarget, reqCtx *proto.RequestContext) (*principal.Principal, agentturnscope.Scope, coreagent.ListedTool, error) {
+	a.providerName = providerName
+	a.turnID = turnID
+	a.principal = p
+	a.target = target
+	a.reqCtx = reqCtx
+	return a.principalOut, a.scope, a.tool, a.err
+}
 
 func TestAppServerInvokeUsesRequestContextAndAuthorization(t *testing.T) {
 	t.Parallel()
@@ -191,6 +218,97 @@ func TestAppServerInvokeUsesRequestContextAndAuthorization(t *testing.T) {
 	}
 	if invoker.idempotencyKey != "call-123" || invoker.params["title"] != "hello" {
 		t.Fatalf("request propagation idempotency=%q params=%v", invoker.idempotencyKey, invoker.params)
+	}
+}
+
+func TestAppServerInvokeAuthorizesAgentTurnAppOperation(t *testing.T) {
+	t.Parallel()
+
+	authz := &recordingAuthorizationProvider{allowed: false}
+	invoker := &recordingAppInvocation{}
+	agentAuth := &recordingAgentAppAuthorizer{
+		principalOut: &principal.Principal{
+			SubjectID:           "user:runner",
+			CredentialSubjectID: "user:runner",
+		},
+		scope: agentturnscope.Scope{
+			ToolRefs: []coreagent.ToolRef{{
+				App:            "slack",
+				Operation:      "chat.postMessage",
+				Connection:     "team-primary",
+				CredentialMode: core.ConnectionModeSubject,
+			}},
+			ToolRefsSet: true,
+		},
+		tool: coreagent.ListedTool{Target: coreagent.ToolTarget{
+			App:            "slack",
+			Operation:      "chat.postMessage",
+			Connection:     "team-primary",
+			Instance:       "workspace-1",
+			CredentialMode: core.ConnectionModeSubject,
+			RunAs: &core.RunAsSubject{
+				SubjectID:           "service_account:automation",
+				CredentialSubjectID: "service_account:automation",
+			},
+		}},
+	}
+	server := NewAppServer(
+		invoker,
+		WithAuthorizationProvider(authz),
+		WithAgentAppInvocationAuthorizer(agentAuth.Authorize),
+		WithCallerApp("alpha", nil),
+	)
+	client := proto.NewAppClient(newBufconnConn(t, func(srv *grpc.Server) {
+		proto.RegisterAppServer(srv, server)
+	}))
+	reqCtx := requestContextWithCallerKind(t, "agent", "alpha", nil)
+	reqCtx.Invocation.RequestId = "turn-1"
+	reqCtx.ToolRefsSet = true
+	reqCtx.ToolRefs = []*proto.AgentToolRef{{
+		App:       "github",
+		Operation: "issues.create",
+	}}
+
+	resp, err := client.Invoke(context.Background(), &proto.AppInvokeRequest{
+		App:            "slack",
+		Operation:      "chat.postMessage",
+		Connection:     "forged-request-connection",
+		Instance:       "forged-request-instance",
+		CredentialMode: "subject",
+		Context:        reqCtx,
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if resp.GetStatus() != 202 || resp.GetBody() != "accepted" {
+		t.Fatalf("Invoke response = %+v, want accepted", resp)
+	}
+	if len(authz.requests) != 0 {
+		t.Fatalf("authorization requests = %d, want 0 for agent turn", len(authz.requests))
+	}
+	if agentAuth.providerName != "alpha" || agentAuth.turnID != "turn-1" {
+		t.Fatalf("agent authorization turn = %s/%s, want alpha/turn-1", agentAuth.providerName, agentAuth.turnID)
+	}
+	if agentAuth.target.App != "slack" || agentAuth.target.Operation != "chat.postMessage" || agentAuth.target.Connection != "forged-request-connection" || agentAuth.target.CredentialMode != core.ConnectionModeSubject {
+		t.Fatalf("agent authorization target = %s.%s/%s/%s", agentAuth.target.App, agentAuth.target.Operation, agentAuth.target.Connection, agentAuth.target.CredentialMode)
+	}
+	if invoker.subjectID != "service_account:automation" || invoker.credentialSubjectID != "service_account:automation" {
+		t.Fatalf("invocation principal = %s/%s, want delegated automation subject", invoker.subjectID, invoker.credentialSubjectID)
+	}
+	if invoker.agentSubjectID != "user:runner" || invoker.runAsSubjectID != "service_account:automation" {
+		t.Fatalf("run-as audit = %s/%s, want user:runner/service_account:automation", invoker.agentSubjectID, invoker.runAsSubjectID)
+	}
+	if invoker.providerName != "slack" || invoker.operation != "chat.postMessage" || invoker.connection != "team-primary" || invoker.instance != "workspace-1" {
+		t.Fatalf("invocation target = %s.%s/%s/%s", invoker.providerName, invoker.operation, invoker.connection, invoker.instance)
+	}
+	if invoker.internalConnection {
+		t.Fatal("internal connection access = true, want false for agent-authorized invocation")
+	}
+	if invoker.credentialMode != core.ConnectionModeSubject {
+		t.Fatalf("credential mode = %q, want subject", invoker.credentialMode)
+	}
+	if len(invoker.toolRefs) != 1 || invoker.toolRefs[0].App != "slack" || invoker.toolRefs[0].Operation != "chat.postMessage" {
+		t.Fatalf("tool refs = %#v, want authorized slack chat.postMessage refs", invoker.toolRefs)
 	}
 }
 


### PR DESCRIPTION
## Summary

Authorizes agent-originated app invocations from the persisted agent turn scope rather than invocation tokens, run grants, AgentHost state, or a new public request-context field. Agent provider callbacks use the existing provider caller context (`caller=agent/<provider>`) plus the existing invocation request id (`Invocation.RequestId`) to identify the turn that produced the call.

The stored turn scope remains authoritative for the original app/workflow caller, subject, permissions, tool refs, and listed tool targets. When an agent calls an app host service, appaccess asks the agent manager to validate the live turn and match the requested app operation against the listed tools stored on that scope. The downstream app invocation then uses the matched target selector, credential mode, and runAs settings instead of trusting request-supplied selectors or inherited internal connection access.

This keeps the public wire/API surface unchanged: there is no `RequestContext.agent`, no `AgentInvocationContext`, no Python SDK signature change, no new method on the broad `agentmanager.Service` interface, and no new turn-scope store API.

## Internal Touchpoints

```go
func WithAgentAppInvocationAuthorizer(
    authorizer func(
        context.Context,
        string, // agent provider name from RequestContext.caller.name
        string, // turn id from RequestContext.invocation.request_id
        *principal.Principal,
        coreagent.ToolTarget,
        *proto.RequestContext,
    ) (*principal.Principal, agentturnscope.Scope, coreagent.ListedTool, error),
) AppServerOption
```

```go
func (m *Manager) AuthorizeAgentAppInvocation(
    ctx context.Context,
    providerName string,
    turnID string,
    requestPrincipal *principal.Principal,
    target coreagent.ToolTarget,
    reqCtx *proto.RequestContext,
) (*principal.Principal, agentturnscope.Scope, coreagent.ListedTool, error)
```

## Runtime

Agent provider `CreateTurn` requests are sent with `RequestContext.caller` set to the agent provider and `RequestContext.invocation.request_id` set to the generated turn id. The original logical caller is still kept in the turn scope, so app/workflow provenance is preserved without requiring the agent provider to echo it back later.

Hosted agent callbacks validate as `agent/<provider>` against the existing provider request-context machinery. For app calls, appaccess rejects ambient widening and delegates authorization to the agent manager. The manager validates the provider turn, resolves the stored turn scope through the existing provider/session/turn key, matches the requested tool target against persisted listed tools, and returns existing primitives for appaccess to restore before invoking the target app.