### PR TITLE
[ci] fix Gestaltd skip check working directory

### DIFF
--- a/.github/workflows/build-gestaltd.yml
+++ b/.github/workflows/build-gestaltd.yml
@@ -139,6 +139,7 @@ jobs:
     steps:
       - name: Skip irrelevant changes
         if: ${{ needs.resolve-ref.outputs.should_validate == 'false' }}
+        working-directory: .
         run: echo "No Gestaltd-related changes detected; required check satisfied."
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -213,6 +214,7 @@ jobs:
     steps:
       - name: Skip irrelevant changes
         if: ${{ needs.resolve-ref.outputs.should_validate == 'false' }}
+        working-directory: .
         run: echo "No Gestaltd-related changes detected; required check satisfied."
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Description

Runs the Gestaltd fast-pass steps from the repository root so SDK-only PRs can satisfy required checks without checking out the Gestaltd directory.