### PR TITLE
Detect GraphQL errors before envelope unwrap

### DIFF
--- a/sdk/go/app_decode.go
+++ b/sdk/go/app_decode.go
@@ -21,25 +21,41 @@ func decodeAppGraphQLResult(app string, result *OperationResult) (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	object, ok := decoded.(map[string]any)
-	if !ok {
+	if result == nil {
 		return decoded, nil
+	}
+	parsed, parseErr := parseOperationResultJSON(result.Body)
+	if parseErr == nil {
+		if err := graphQLErrors(app, result.Body, parsed); err != nil {
+			return nil, err
+		}
+	}
+	if err := graphQLErrors(app, result.Body, decoded); err != nil {
+		return nil, err
+	}
+	return decoded, nil
+}
+
+func graphQLErrors(app, rawBody string, value any) error {
+	object, ok := value.(map[string]any)
+	if !ok {
+		return nil
 	}
 	errorsValue, ok := object["errors"]
 	if !ok {
-		return decoded, nil
+		return nil
 	}
 	errors, ok := errorsValue.([]any)
 	if !ok || len(errors) == 0 {
-		return decoded, nil
+		return nil
 	}
-	return nil, &InvokeError{
+	return &InvokeError{
 		App:       app,
 		Operation: "graphql",
 		Code:      "graphql_errors",
 		Message:   graphqlErrorMessage(errors),
 		Body:      object,
-		RawBody:   result.Body,
+		RawBody:   rawBody,
 	}
 }
 

--- a/sdk/go/app_decode_test.go
+++ b/sdk/go/app_decode_test.go
@@ -74,14 +74,18 @@ func TestDecodeAppResultErrors(t *testing.T) {
 }
 
 func TestDecodeGraphQLResultErrors(t *testing.T) {
-	body, err := os.ReadFile(filepath.Join("..", "testdata", "app_invoke", "graphql_errors.json"))
-	if err != nil {
-		t.Fatalf("read fixture: %v", err)
-	}
-	_, err = decodeAppGraphQLResult("linear", &OperationResult{Status: 200, Body: string(body)})
-	var invokeErr *InvokeError
-	if !errors.As(err, &invokeErr) || invokeErr.Code != "graphql_errors" {
-		t.Fatalf("GraphQL error = %+v err=%v", invokeErr, err)
+	for _, name := range []string{"graphql_errors.json", "graphql_success_envelope_errors.json"} {
+		t.Run(name, func(t *testing.T) {
+			body, err := os.ReadFile(filepath.Join("..", "testdata", "app_invoke", name))
+			if err != nil {
+				t.Fatalf("read fixture: %v", err)
+			}
+			_, err = decodeAppGraphQLResult("linear", &OperationResult{Status: 200, Body: string(body)})
+			var invokeErr *InvokeError
+			if !errors.As(err, &invokeErr) || invokeErr.Code != "graphql_errors" {
+				t.Fatalf("GraphQL error = %+v err=%v", invokeErr, err)
+			}
+		})
 	}
 }
 

--- a/sdk/python/gestalt/_app_decode.py
+++ b/sdk/python/gestalt/_app_decode.py
@@ -36,18 +36,27 @@ def decode_app_result(app: str, operation: str, result: Response[str]) -> JsonVa
 
 def decode_graphql_result(app: str, result: Response[str]) -> JsonValue:
     decoded = decode_app_result(app, "graphql", result)
-    if isinstance(decoded, dict):
-        errors = decoded.get("errors")
-        if isinstance(errors, list) and errors:
-            raise InvokeError(
-                _graphql_error_message(errors),
-                app=app,
-                operation="graphql",
-                code="graphql_errors",
-                body=decoded,
-                raw_body=result.body,
-            )
+    try:
+        _raise_graphql_errors(app, result.body, parse_operation_result_json(result.body))
+    except ValueError:
+        pass
+    _raise_graphql_errors(app, result.body, decoded)
     return decoded
+
+
+def _raise_graphql_errors(app: str, raw_body: str, value: JsonValue) -> None:
+    if not isinstance(value, dict):
+        return
+    errors = value.get("errors")
+    if isinstance(errors, list) and errors:
+        raise InvokeError(
+            _graphql_error_message(errors),
+            app=app,
+            operation="graphql",
+            code="graphql_errors",
+            body=value,
+            raw_body=raw_body,
+        )
 
 
 def decode_app_body(app: str, operation: str, status: int, body: str) -> JsonValue:

--- a/sdk/python/tests/test_app_decode.py
+++ b/sdk/python/tests/test_app_decode.py
@@ -80,6 +80,9 @@ class AppDecodeTests(unittest.TestCase):
         with self.assertRaises(InvokeError) as error:
             decode_graphql_result("linear", self.result("graphql_errors.json"))
         self.assertEqual(error.exception.code, "graphql_errors")
+        with self.assertRaises(InvokeError) as envelope_error:
+            decode_graphql_result("linear", self.result("graphql_success_envelope_errors.json"))
+        self.assertEqual(envelope_error.exception.code, "graphql_errors")
 
 
 if __name__ == "__main__":

--- a/sdk/rust/src/app_decode.rs
+++ b/sdk/rust/src/app_decode.rs
@@ -28,7 +28,15 @@ pub(crate) fn decode_graphql_result(
     result: &OperationResult,
 ) -> Result<Value, Box<InvokeError>> {
     let decoded = decode_app_result(app, "graphql", result)?;
-    if let Value::Object(object) = &decoded {
+    if let Ok(parsed) = parse_operation_result_json(&result.body) {
+        raise_graphql_errors(app, &result.body, &parsed)?;
+    }
+    raise_graphql_errors(app, &result.body, &decoded)?;
+    Ok(decoded)
+}
+
+fn raise_graphql_errors(app: &str, raw_body: &str, value: &Value) -> Result<(), Box<InvokeError>> {
+    if let Value::Object(object) = value {
         if let Some(Value::Array(errors)) = object.get("errors") {
             if !errors.is_empty() {
                 return Err(Box::new(InvokeError {
@@ -37,13 +45,13 @@ pub(crate) fn decode_graphql_result(
                     status: None,
                     code: Some("graphql_errors".to_string()),
                     message: graphql_error_message(errors),
-                    body: Some(Box::new(decoded)),
-                    raw_body: result.body.clone(),
+                    body: Some(Box::new(value.clone())),
+                    raw_body: raw_body.to_string(),
                 }));
             }
         }
     }
-    Ok(decoded)
+    Ok(())
 }
 
 pub(crate) fn parse_operation_result_json(body: &str) -> Result<Value, serde_json::Error> {
@@ -336,5 +344,14 @@ mod tests {
         )
         .expect_err("graphql errors");
         assert_eq!(err.code.as_deref(), Some("graphql_errors"));
+        let envelope_err = decode_graphql_result(
+            "linear",
+            &result(
+                include_str!("../../testdata/app_invoke/graphql_success_envelope_errors.json"),
+                200,
+            ),
+        )
+        .expect_err("enveloped graphql errors");
+        assert_eq!(envelope_err.code.as_deref(), Some("graphql_errors"));
     }
 }

--- a/sdk/testdata/app_invoke/graphql_success_envelope_errors.json
+++ b/sdk/testdata/app_invoke/graphql_success_envelope_errors.json
@@ -1,0 +1,11 @@
+{
+  "status": "success",
+  "data": {
+    "viewer": null
+  },
+  "errors": [
+    {
+      "message": "viewer failed"
+    }
+  ]
+}

--- a/sdk/typescript/src/app-decode.ts
+++ b/sdk/typescript/src/app-decode.ts
@@ -25,20 +25,26 @@ export function decodeGraphQLResult<T = unknown>(
   result: OperationResult,
 ): T {
   const decoded = decodeAppResult<unknown>(app, "graphql", result);
-  if (isRecord(decoded)) {
-    const errors = decoded.errors;
-    if (Array.isArray(errors) && errors.length > 0) {
-      throw new InvokeError({
-        app,
-        operation: "graphql",
-        code: "graphql_errors",
-        message: graphqlErrorMessage(errors),
-        body: decoded,
-        rawBody: result.body,
-      });
-    }
-  }
+  throwGraphQLErrors(app, result.body, parseOperationResultJson(result.body));
+  throwGraphQLErrors(app, result.body, decoded);
   return decoded as T;
+}
+
+function throwGraphQLErrors(app: string, rawBody: string, value: unknown): void {
+  if (!isRecord(value)) {
+    return;
+  }
+  const errors = value.errors;
+  if (Array.isArray(errors) && errors.length > 0) {
+    throw new InvokeError({
+      app,
+      operation: "graphql",
+      code: "graphql_errors",
+      message: graphqlErrorMessage(errors),
+      body: value,
+      rawBody,
+    });
+  }
 }
 
 function decodeAppBody(

--- a/sdk/typescript/tests/app-decode.test.ts
+++ b/sdk/typescript/tests/app-decode.test.ts
@@ -56,6 +56,9 @@ test("app decode fixture behavior", () => {
     errors: { message: "not an array" },
   });
   expect(() => decodeGraphQLResult("linear", result("graphql_errors.json"))).toThrow(InvokeError);
+  expect(() => decodeGraphQLResult("linear", result("graphql_success_envelope_errors.json"))).toThrow(
+    InvokeError,
+  );
 });
 
 test("OperationResult json helper does not unwrap envelopes", () => {


### PR DESCRIPTION
## Summary
- Check GraphQL `errors` on the parsed raw response before SDK envelope unwrapping returns `data`.
- Add a shared fixture covering `{ status: "success", data, errors }` so all SDKs reject GraphQL field errors consistently.

## Test plan
- [x] `go test ./...` in `sdk/go`
- [x] `bun run check` in `sdk/typescript`
- [x] `uv run pytest` in `sdk/python`
- [x] `cargo test` in `sdk/rust`