### PR TITLE
Trim agent invocation authorizer plumbing

### DIFF
--- a/gestaltd/internal/bootstrap/lazy_agent_manager.go
+++ b/gestaltd/internal/bootstrap/lazy_agent_manager.go
@@ -8,8 +8,8 @@ import (
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"github.com/valon-technologies/gestalt/server/services/agents/agentmanager"
-	appaccessservice "github.com/valon-technologies/gestalt/server/services/appaccess"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
 )
 
 type lazyAgentManager struct {
@@ -147,20 +147,20 @@ func (l *lazyAgentManager) ResolveInteraction(ctx context.Context, p *principal.
 	return target.ResolveInteraction(ctx, p, req)
 }
 
-func (l *lazyAgentManager) AuthorizeAgentAppInvocation(ctx context.Context, req appaccessservice.AgentAppInvocationAuthorizationRequest) (appaccessservice.AgentAppInvocationAuthorization, error) {
+func (l *lazyAgentManager) AuthorizeAppInvocation(ctx context.Context, req invocation.AgentAppAuthorizationRequest) (invocation.AgentAppAuthorization, error) {
 	target, err := l.current()
 	if err != nil {
-		return appaccessservice.AgentAppInvocationAuthorization{}, err
+		return invocation.AgentAppAuthorization{}, err
 	}
-	return target.AuthorizeAgentAppInvocation(ctx, req)
+	return target.AuthorizeAppInvocation(ctx, req)
 }
 
-func (l *lazyAgentManager) AuthorizeAgentWorkflowInvocation(ctx context.Context, req appaccessservice.AgentWorkflowInvocationAuthorizationRequest) (appaccessservice.AgentWorkflowInvocationAuthorization, error) {
+func (l *lazyAgentManager) AuthorizeWorkflowInvocation(ctx context.Context, req invocation.AgentWorkflowAuthorizationRequest) (invocation.AgentWorkflowAuthorization, error) {
 	target, err := l.current()
 	if err != nil {
-		return appaccessservice.AgentWorkflowInvocationAuthorization{}, err
+		return invocation.AgentWorkflowAuthorization{}, err
 	}
-	return target.AuthorizeAgentWorkflowInvocation(ctx, req)
+	return target.AuthorizeWorkflowInvocation(ctx, req)
 }
 
 func (l *lazyAgentManager) current() (*agentmanager.Manager, error) {

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -24,7 +24,6 @@ import (
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	agentservice "github.com/valon-technologies/gestalt/server/services/agents"
-	appaccessservice "github.com/valon-technologies/gestalt/server/services/appaccess"
 	appservice "github.com/valon-technologies/gestalt/server/services/apps"
 	"github.com/valon-technologies/gestalt/server/services/apps/composite"
 	"github.com/valon-technologies/gestalt/server/services/apps/declarative"
@@ -1780,12 +1779,12 @@ func (unavailableAgentManager) ResolveInteraction(context.Context, *principal.Pr
 	return nil, fmt.Errorf("agent manager is not available")
 }
 
-func (unavailableAgentManager) AuthorizeAgentAppInvocation(context.Context, appaccessservice.AgentAppInvocationAuthorizationRequest) (appaccessservice.AgentAppInvocationAuthorization, error) {
-	return appaccessservice.AgentAppInvocationAuthorization{}, fmt.Errorf("agent manager is not available")
+func (unavailableAgentManager) AuthorizeAppInvocation(context.Context, invocation.AgentAppAuthorizationRequest) (invocation.AgentAppAuthorization, error) {
+	return invocation.AgentAppAuthorization{}, fmt.Errorf("agent manager is not available")
 }
 
-func (unavailableAgentManager) AuthorizeAgentWorkflowInvocation(context.Context, appaccessservice.AgentWorkflowInvocationAuthorizationRequest) (appaccessservice.AgentWorkflowInvocationAuthorization, error) {
-	return appaccessservice.AgentWorkflowInvocationAuthorization{}, fmt.Errorf("agent manager is not available")
+func (unavailableAgentManager) AuthorizeWorkflowInvocation(context.Context, invocation.AgentWorkflowAuthorizationRequest) (invocation.AgentWorkflowAuthorization, error) {
+	return invocation.AgentWorkflowAuthorization{}, fmt.Errorf("agent manager is not available")
 }
 
 func mapToYAMLNode(value map[string]any) (yaml.Node, error) {

--- a/gestaltd/services/agents/agentmanager/agent_app_authority.go
+++ b/gestaltd/services/agents/agentmanager/agent_app_authority.go
@@ -10,7 +10,6 @@ import (
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"github.com/valon-technologies/gestalt/server/services/agents/agentturnscope"
-	appaccessservice "github.com/valon-technologies/gestalt/server/services/appaccess"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"google.golang.org/grpc/codes"
@@ -26,7 +25,7 @@ type agentInvocationScopeRequest struct {
 	RequestContext    *proto.RequestContext
 }
 
-func (m *Manager) AuthorizeAgentAppInvocation(ctx context.Context, req appaccessservice.AgentAppInvocationAuthorizationRequest) (appaccessservice.AgentAppInvocationAuthorization, error) {
+func (m *Manager) AuthorizeAppInvocation(ctx context.Context, req invocation.AgentAppAuthorizationRequest) (invocation.AgentAppAuthorization, error) {
 	scope, err := m.authorizeAgentInvocationScope(ctx, agentInvocationScopeRequest{
 		AgentProviderName: req.AgentProviderName,
 		CallerKind:        req.CallerKind,
@@ -36,17 +35,17 @@ func (m *Manager) AuthorizeAgentAppInvocation(ctx context.Context, req appaccess
 		RequestContext:    req.RequestContext,
 	})
 	if err != nil {
-		return appaccessservice.AgentAppInvocationAuthorization{}, err
+		return invocation.AgentAppAuthorization{}, err
 	}
 	tool, ok := matchingAgentAppInvocationTool(scope.ListedTools, req)
 	if !ok {
-		return appaccessservice.AgentAppInvocationAuthorization{}, status.Errorf(codes.PermissionDenied, "agent turn may not invoke %s.%s", strings.TrimSpace(req.App), strings.TrimSpace(req.Operation))
+		return invocation.AgentAppAuthorization{}, status.Errorf(codes.PermissionDenied, "agent turn may not invoke %s.%s", strings.TrimSpace(req.App), strings.TrimSpace(req.Operation))
 	}
 	p := agentScopePrincipal(scope)
 	if p == nil || strings.TrimSpace(p.SubjectID) == "" {
-		return appaccessservice.AgentAppInvocationAuthorization{}, status.Error(codes.FailedPrecondition, "agent turn scope subject is required")
+		return invocation.AgentAppAuthorization{}, status.Error(codes.FailedPrecondition, "agent turn scope subject is required")
 	}
-	return appaccessservice.AgentAppInvocationAuthorization{
+	return invocation.AgentAppAuthorization{
 		Principal:      p,
 		CredentialMode: core.NormalizeOptionalConnectionMode(tool.Target.CredentialMode),
 		Connection:     core.ResolveConnectionAlias(strings.TrimSpace(tool.Target.Connection)),
@@ -57,7 +56,7 @@ func (m *Manager) AuthorizeAgentAppInvocation(ctx context.Context, req appaccess
 	}, nil
 }
 
-func (m *Manager) AuthorizeAgentWorkflowInvocation(ctx context.Context, req appaccessservice.AgentWorkflowInvocationAuthorizationRequest) (appaccessservice.AgentWorkflowInvocationAuthorization, error) {
+func (m *Manager) AuthorizeWorkflowInvocation(ctx context.Context, req invocation.AgentWorkflowAuthorizationRequest) (invocation.AgentWorkflowAuthorization, error) {
 	scope, err := m.authorizeAgentInvocationScope(ctx, agentInvocationScopeRequest{
 		AgentProviderName: req.AgentProviderName,
 		CallerKind:        req.CallerKind,
@@ -67,27 +66,27 @@ func (m *Manager) AuthorizeAgentWorkflowInvocation(ctx context.Context, req appa
 		RequestContext:    req.RequestContext,
 	})
 	if err != nil {
-		return appaccessservice.AgentWorkflowInvocationAuthorization{}, err
+		return invocation.AgentWorkflowAuthorization{}, err
 	}
 	if operation := strings.TrimSpace(req.Operation); operation != "" && !agentWorkflowOperationAllowed(scope, operation) {
-		return appaccessservice.AgentWorkflowInvocationAuthorization{}, status.Errorf(codes.PermissionDenied, "agent turn may not invoke workflow.%s", operation)
+		return invocation.AgentWorkflowAuthorization{}, status.Errorf(codes.PermissionDenied, "agent turn may not invoke workflow.%s", operation)
 	}
 	var target *coreworkflow.Target
 	if req.Target != nil {
 		copied := *req.Target
 		target = &copied
 		if err := validateAgentWorkflowTargetScope(scope, copied); err != nil {
-			return appaccessservice.AgentWorkflowInvocationAuthorization{}, err
+			return invocation.AgentWorkflowAuthorization{}, err
 		}
 	}
 	p := agentScopePrincipal(scope)
 	if p == nil || strings.TrimSpace(p.SubjectID) == "" {
-		return appaccessservice.AgentWorkflowInvocationAuthorization{}, status.Error(codes.FailedPrecondition, "agent turn scope subject is required")
+		return invocation.AgentWorkflowAuthorization{}, status.Error(codes.FailedPrecondition, "agent turn scope subject is required")
 	}
 	if target != nil {
 		p = agentWorkflowPrincipalForTarget(p, scope, *target)
 	}
-	return appaccessservice.AgentWorkflowInvocationAuthorization{Principal: p}, nil
+	return invocation.AgentWorkflowAuthorization{Principal: p}, nil
 }
 
 func (m *Manager) authorizeAgentInvocationScope(ctx context.Context, req agentInvocationScopeRequest) (agentturnscope.Scope, error) {
@@ -224,7 +223,7 @@ func agentInvocationTurnIDMatches(value, scopeTurnID, requestedTurnID string) bo
 	return value != "" && (value == strings.TrimSpace(scopeTurnID) || value == strings.TrimSpace(requestedTurnID))
 }
 
-func matchingAgentAppInvocationTool(tools []coreagent.ListedTool, req appaccessservice.AgentAppInvocationAuthorizationRequest) (coreagent.ListedTool, bool) {
+func matchingAgentAppInvocationTool(tools []coreagent.ListedTool, req invocation.AgentAppAuthorizationRequest) (coreagent.ListedTool, bool) {
 	targetApp := strings.TrimSpace(req.App)
 	targetOperation := strings.TrimSpace(req.Operation)
 	targetConnection := core.ResolveConnectionAlias(strings.TrimSpace(req.Connection))

--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -116,8 +116,8 @@ type Service interface {
 	ListTurnEvents(ctx context.Context, p *principal.Principal, req *proto.ListAgentProviderTurnEventsRequest) ([]*coreagent.TurnEvent, error)
 	ListInteractions(ctx context.Context, p *principal.Principal, req *proto.ListAgentProviderInteractionsRequest) ([]*coreagent.Interaction, error)
 	ResolveInteraction(ctx context.Context, p *principal.Principal, req *proto.ResolveAgentProviderInteractionRequest) (*coreagent.Interaction, error)
-	AuthorizeAgentAppInvocation(context.Context, appaccessservice.AgentAppInvocationAuthorizationRequest) (appaccessservice.AgentAppInvocationAuthorization, error)
-	AuthorizeAgentWorkflowInvocation(context.Context, appaccessservice.AgentWorkflowInvocationAuthorizationRequest) (appaccessservice.AgentWorkflowInvocationAuthorization, error)
+	AuthorizeAppInvocation(context.Context, invocation.AgentAppAuthorizationRequest) (invocation.AgentAppAuthorization, error)
+	AuthorizeWorkflowInvocation(context.Context, invocation.AgentWorkflowAuthorizationRequest) (invocation.AgentWorkflowAuthorization, error)
 }
 
 type Config struct {

--- a/gestaltd/services/agents/agentmanager/manager_test.go
+++ b/gestaltd/services/agents/agentmanager/manager_test.go
@@ -1275,7 +1275,7 @@ func TestCreateTurnInheritsSessionToolScope(t *testing.T) {
 	}
 }
 
-func TestAuthorizeAgentAppInvocationUsesPersistedTurnScope(t *testing.T) {
+func TestAuthorizeAppInvocationUsesPersistedTurnScope(t *testing.T) {
 	t.Parallel()
 
 	slack := agentCatalogTestProvider("slack", "Slack", "chat.postMessage")
@@ -1343,7 +1343,7 @@ func TestAuthorizeAgentAppInvocationUsesPersistedTurnScope(t *testing.T) {
 		t.Fatalf("Put delegated turn scope: %v", err)
 	}
 
-	req := appaccessservice.AgentAppInvocationAuthorizationRequest{
+	req := invocation.AgentAppAuthorizationRequest{
 		AgentProviderName: "alpha",
 		CallerKind:        invocation.ProviderKindApp,
 		CallerName:        "sats",
@@ -1357,9 +1357,9 @@ func TestAuthorizeAgentAppInvocationUsesPersistedTurnScope(t *testing.T) {
 		Operation:      "chat.postMessage",
 		RequestContext: providerReqCtx,
 	}
-	authorized, err := manager.AuthorizeAgentAppInvocation(context.Background(), req)
+	authorized, err := manager.AuthorizeAppInvocation(context.Background(), req)
 	if err != nil {
-		t.Fatalf("AuthorizeAgentAppInvocation: %v", err)
+		t.Fatalf("AuthorizeAppInvocation: %v", err)
 	}
 	if authorized.Principal == nil || authorized.Principal.SubjectID != p.SubjectID || authorized.Principal.CredentialSubjectID != p.CredentialSubjectID {
 		t.Fatalf("authorized principal = %#v, want %s/%s", authorized.Principal, p.SubjectID, p.CredentialSubjectID)
@@ -1384,15 +1384,15 @@ func TestAuthorizeAgentAppInvocationUsesPersistedTurnScope(t *testing.T) {
 	}
 
 	req.Operation = "chat.delete"
-	_, err = manager.AuthorizeAgentAppInvocation(context.Background(), req)
+	_, err = manager.AuthorizeAppInvocation(context.Background(), req)
 	if got := status.Code(err); got != codes.PermissionDenied {
-		t.Fatalf("AuthorizeAgentAppInvocation unlisted operation status = %s, want %s (err=%v)", got, codes.PermissionDenied, err)
+		t.Fatalf("AuthorizeAppInvocation unlisted operation status = %s, want %s (err=%v)", got, codes.PermissionDenied, err)
 	}
 	req.Operation = "chat.postMessage"
 	req.AgentProviderName = "beta"
-	_, err = manager.AuthorizeAgentAppInvocation(context.Background(), req)
+	_, err = manager.AuthorizeAppInvocation(context.Background(), req)
 	if got := status.Code(err); got != codes.PermissionDenied {
-		t.Fatalf("AuthorizeAgentAppInvocation wrong provider status = %s, want %s (err=%v)", got, codes.PermissionDenied, err)
+		t.Fatalf("AuthorizeAppInvocation wrong provider status = %s, want %s (err=%v)", got, codes.PermissionDenied, err)
 	}
 }
 
@@ -1416,7 +1416,7 @@ func TestMatchingAgentAppInvocationToolUsesOptionalSelectors(t *testing.T) {
 		},
 	}}
 
-	tool, ok := matchingAgentAppInvocationTool(tools, appaccessservice.AgentAppInvocationAuthorizationRequest{
+	tool, ok := matchingAgentAppInvocationTool(tools, invocation.AgentAppAuthorizationRequest{
 		App:       "slack",
 		Operation: "chat.postMessage",
 	})
@@ -1434,13 +1434,13 @@ func TestMatchingAgentAppInvocationToolUsesOptionalSelectors(t *testing.T) {
 		Instance:       "workspace-2",
 		CredentialMode: core.ConnectionModeSubject,
 	}})
-	if _, ok := matchingAgentAppInvocationTool(tools, appaccessservice.AgentAppInvocationAuthorizationRequest{
+	if _, ok := matchingAgentAppInvocationTool(tools, invocation.AgentAppAuthorizationRequest{
 		App:       "slack",
 		Operation: "chat.postMessage",
 	}); ok {
 		t.Fatal("matchingAgentAppInvocationTool without selectors matched ambiguous tools")
 	}
-	tool, ok = matchingAgentAppInvocationTool(tools, appaccessservice.AgentAppInvocationAuthorizationRequest{
+	tool, ok = matchingAgentAppInvocationTool(tools, invocation.AgentAppAuthorizationRequest{
 		App:        "slack",
 		Operation:  "chat.postMessage",
 		Connection: "team-secondary",
@@ -1453,7 +1453,7 @@ func TestMatchingAgentAppInvocationToolUsesOptionalSelectors(t *testing.T) {
 	}
 }
 
-func TestAuthorizeAgentWorkflowInvocationUsesPersistedTurnScope(t *testing.T) {
+func TestAuthorizeWorkflowInvocationUsesPersistedTurnScope(t *testing.T) {
 	t.Parallel()
 
 	slack := agentCatalogTestProvider("slack", "Slack", "chat.postMessage")
@@ -1535,7 +1535,7 @@ func TestAuthorizeAgentWorkflowInvocationUsesPersistedTurnScope(t *testing.T) {
 			},
 		},
 	}}
-	req := appaccessservice.AgentWorkflowInvocationAuthorizationRequest{
+	req := invocation.AgentWorkflowAuthorizationRequest{
 		AgentProviderName: "alpha",
 		CallerKind:        invocation.ProviderKindApp,
 		CallerName:        "sats",
@@ -1549,9 +1549,9 @@ func TestAuthorizeAgentWorkflowInvocationUsesPersistedTurnScope(t *testing.T) {
 		Target:         &target,
 		RequestContext: providerReqCtx,
 	}
-	authorized, err := manager.AuthorizeAgentWorkflowInvocation(context.Background(), req)
+	authorized, err := manager.AuthorizeWorkflowInvocation(context.Background(), req)
 	if err != nil {
-		t.Fatalf("AuthorizeAgentWorkflowInvocation: %v", err)
+		t.Fatalf("AuthorizeWorkflowInvocation: %v", err)
 	}
 	if authorized.Principal == nil || authorized.Principal.SubjectID != p.SubjectID || authorized.Principal.CredentialSubjectID != p.CredentialSubjectID {
 		t.Fatalf("authorized principal = %#v, want %s/%s", authorized.Principal, p.SubjectID, p.CredentialSubjectID)
@@ -1567,28 +1567,28 @@ func TestAuthorizeAgentWorkflowInvocationUsesPersistedTurnScope(t *testing.T) {
 	}
 
 	req.Operation = "runs.start"
-	_, err = manager.AuthorizeAgentWorkflowInvocation(context.Background(), req)
+	_, err = manager.AuthorizeWorkflowInvocation(context.Background(), req)
 	if got := status.Code(err); got != codes.PermissionDenied {
-		t.Fatalf("AuthorizeAgentWorkflowInvocation unlisted operation status = %s, want %s (err=%v)", got, codes.PermissionDenied, err)
+		t.Fatalf("AuthorizeWorkflowInvocation unlisted operation status = %s, want %s (err=%v)", got, codes.PermissionDenied, err)
 	}
 	req.Operation = "definitions.apply"
 	outsideTarget := target
 	outsideTarget.Steps = append([]coreworkflow.Step(nil), target.Steps...)
 	outsideTarget.Steps[0].App = &coreworkflow.AppCall{Name: "slack", Operation: "chat.delete"}
 	req.Target = &outsideTarget
-	_, err = manager.AuthorizeAgentWorkflowInvocation(context.Background(), req)
+	_, err = manager.AuthorizeWorkflowInvocation(context.Background(), req)
 	if got := status.Code(err); got != codes.PermissionDenied {
-		t.Fatalf("AuthorizeAgentWorkflowInvocation unlisted target status = %s, want %s (err=%v)", got, codes.PermissionDenied, err)
+		t.Fatalf("AuthorizeWorkflowInvocation unlisted target status = %s, want %s (err=%v)", got, codes.PermissionDenied, err)
 	}
 	req.Target = &target
 	req.AgentProviderName = "beta"
-	_, err = manager.AuthorizeAgentWorkflowInvocation(context.Background(), req)
+	_, err = manager.AuthorizeWorkflowInvocation(context.Background(), req)
 	if got := status.Code(err); got != codes.PermissionDenied {
-		t.Fatalf("AuthorizeAgentWorkflowInvocation wrong provider status = %s, want %s (err=%v)", got, codes.PermissionDenied, err)
+		t.Fatalf("AuthorizeWorkflowInvocation wrong provider status = %s, want %s (err=%v)", got, codes.PermissionDenied, err)
 	}
 }
 
-func TestAuthorizeAgentAppInvocationAcceptsProviderOwnedTurnID(t *testing.T) {
+func TestAuthorizeAppInvocationAcceptsProviderOwnedTurnID(t *testing.T) {
 	t.Parallel()
 
 	slack := agentCatalogTestProvider("slack", "Slack", "chat.postMessage")
@@ -1644,7 +1644,7 @@ func TestAuthorizeAgentAppInvocationAcceptsProviderOwnedTurnID(t *testing.T) {
 	executionRefReqCtx := cloneAgentRequest(providerReqCtx, &proto.RequestContext{})
 	executionRefReqCtx.Agent.TurnId = turn.ExecutionRef
 
-	authorized, err := manager.AuthorizeAgentAppInvocation(context.Background(), appaccessservice.AgentAppInvocationAuthorizationRequest{
+	authorized, err := manager.AuthorizeAppInvocation(context.Background(), invocation.AgentAppAuthorizationRequest{
 		AgentProviderName: "alpha",
 		CallerKind:        invocation.ProviderKindApp,
 		CallerName:        "sats",
@@ -1659,7 +1659,7 @@ func TestAuthorizeAgentAppInvocationAcceptsProviderOwnedTurnID(t *testing.T) {
 		RequestContext: executionRefReqCtx,
 	})
 	if err != nil {
-		t.Fatalf("AuthorizeAgentAppInvocation with execution ref: %v", err)
+		t.Fatalf("AuthorizeAppInvocation with execution ref: %v", err)
 	}
 	if authorized.Principal == nil || authorized.Principal.SubjectID != p.SubjectID {
 		t.Fatalf("authorized principal = %#v, want %s", authorized.Principal, p.SubjectID)
@@ -1668,7 +1668,7 @@ func TestAuthorizeAgentAppInvocationAcceptsProviderOwnedTurnID(t *testing.T) {
 	providerOwnedReqCtx := cloneAgentRequest(providerReqCtx, &proto.RequestContext{})
 	providerOwnedReqCtx.Agent.TurnId = turn.ID
 
-	authorized, err = manager.AuthorizeAgentAppInvocation(context.Background(), appaccessservice.AgentAppInvocationAuthorizationRequest{
+	authorized, err = manager.AuthorizeAppInvocation(context.Background(), invocation.AgentAppAuthorizationRequest{
 		AgentProviderName: "alpha",
 		CallerKind:        invocation.ProviderKindApp,
 		CallerName:        "sats",
@@ -1683,7 +1683,7 @@ func TestAuthorizeAgentAppInvocationAcceptsProviderOwnedTurnID(t *testing.T) {
 		RequestContext: providerOwnedReqCtx,
 	})
 	if err != nil {
-		t.Fatalf("AuthorizeAgentAppInvocation with provider turn id: %v", err)
+		t.Fatalf("AuthorizeAppInvocation with provider turn id: %v", err)
 	}
 	if authorized.Principal == nil || authorized.Principal.SubjectID != p.SubjectID {
 		t.Fatalf("authorized principal = %#v, want %s", authorized.Principal, p.SubjectID)

--- a/gestaltd/services/appaccess/app_server.go
+++ b/gestaltd/services/appaccess/app_server.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
-	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/internal/agentwire"
 	"github.com/valon-technologies/gestalt/server/internal/protoutil"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
@@ -32,57 +31,12 @@ type AppServer struct {
 	authorization  core.AuthorizationProvider
 	callerName     string
 	accessProfiles AppAccessProfiles
-	agentAppAuth   AgentAppInvocationAuthorizer
+	agentAppAuth   interface {
+		AuthorizeAppInvocation(context.Context, invocation.AgentAppAuthorizationRequest) (invocation.AgentAppAuthorization, error)
+	}
 }
 
 type AppServerOption func(*AppServer)
-
-type AgentAppInvocationAuthorizer interface {
-	AuthorizeAgentAppInvocation(context.Context, AgentAppInvocationAuthorizationRequest) (AgentAppInvocationAuthorization, error)
-}
-
-type AgentWorkflowInvocationAuthorizer interface {
-	AuthorizeAgentWorkflowInvocation(context.Context, AgentWorkflowInvocationAuthorizationRequest) (AgentWorkflowInvocationAuthorization, error)
-}
-
-type AgentAppInvocationAuthorizationRequest struct {
-	AgentProviderName string
-	CallerKind        invocation.ProviderKind
-	CallerName        string
-	Agent             invocation.AgentInvocationContext
-	Principal         *principal.Principal
-	App               string
-	Operation         string
-	Connection        string
-	Instance          string
-	CredentialMode    core.ConnectionMode
-	RequestContext    *proto.RequestContext
-}
-
-type AgentAppInvocationAuthorization struct {
-	Principal      *principal.Principal
-	CredentialMode core.ConnectionMode
-	Connection     string
-	Instance       string
-	RunAs          *core.RunAsSubject
-	ToolRefs       []coreagent.ToolRef
-	ToolRefsSet    bool
-}
-
-type AgentWorkflowInvocationAuthorizationRequest struct {
-	AgentProviderName string
-	CallerKind        invocation.ProviderKind
-	CallerName        string
-	Agent             invocation.AgentInvocationContext
-	Principal         *principal.Principal
-	Operation         string
-	Target            *coreworkflow.Target
-	RequestContext    *proto.RequestContext
-}
-
-type AgentWorkflowInvocationAuthorization struct {
-	Principal *principal.Principal
-}
 
 func WithAuthorizationProvider(provider core.AuthorizationProvider) AppServerOption {
 	return func(s *AppServer) {
@@ -90,7 +44,9 @@ func WithAuthorizationProvider(provider core.AuthorizationProvider) AppServerOpt
 	}
 }
 
-func WithAgentAppInvocationAuthorizer(authorizer AgentAppInvocationAuthorizer) AppServerOption {
+func WithAgentAppInvocationAuthorizer(authorizer interface {
+	AuthorizeAppInvocation(context.Context, invocation.AgentAppAuthorizationRequest) (invocation.AgentAppAuthorization, error)
+}) AppServerOption {
 	return func(s *AppServer) {
 		s.agentAppAuth = authorizer
 	}
@@ -361,11 +317,11 @@ func (s *AppServer) authorizeAppInvocation(ctx context.Context, callCtx requestI
 	return nil
 }
 
-func (s *AppServer) authorizeAgentAppInvocation(ctx context.Context, callCtx requestInvocationContext, targetApp, targetOperation, rawConnection, rawInstance string, credentialMode core.ConnectionMode) (AgentAppInvocationAuthorization, error) {
+func (s *AppServer) authorizeAgentAppInvocation(ctx context.Context, callCtx requestInvocationContext, targetApp, targetOperation, rawConnection, rawInstance string, credentialMode core.ConnectionMode) (invocation.AgentAppAuthorization, error) {
 	if s == nil || s.agentAppAuth == nil {
-		return AgentAppInvocationAuthorization{}, status.Error(codes.FailedPrecondition, "agent app invocation authorizer is required")
+		return invocation.AgentAppAuthorization{}, status.Error(codes.FailedPrecondition, "agent app invocation authorizer is required")
 	}
-	return s.agentAppAuth.AuthorizeAgentAppInvocation(ctx, AgentAppInvocationAuthorizationRequest{
+	return s.agentAppAuth.AuthorizeAppInvocation(ctx, invocation.AgentAppAuthorizationRequest{
 		AgentProviderName: strings.TrimSpace(s.callerName),
 		CallerKind:        callCtx.callerProviderKind,
 		CallerName:        callCtx.callerName,

--- a/gestaltd/services/appaccess/app_test.go
+++ b/gestaltd/services/appaccess/app_test.go
@@ -120,12 +120,12 @@ func (p *recordingAuthorizationProvider) Ping(context.Context) error { return ni
 func (p *recordingAuthorizationProvider) Close() error               { return nil }
 
 type recordingAgentAppAuthorizer struct {
-	requests []AgentAppInvocationAuthorizationRequest
-	response AgentAppInvocationAuthorization
+	requests []invocation.AgentAppAuthorizationRequest
+	response invocation.AgentAppAuthorization
 	err      error
 }
 
-func (a *recordingAgentAppAuthorizer) AuthorizeAgentAppInvocation(_ context.Context, req AgentAppInvocationAuthorizationRequest) (AgentAppInvocationAuthorization, error) {
+func (a *recordingAgentAppAuthorizer) AuthorizeAppInvocation(_ context.Context, req invocation.AgentAppAuthorizationRequest) (invocation.AgentAppAuthorization, error) {
 	a.requests = append(a.requests, req)
 	return a.response, a.err
 }
@@ -216,7 +216,7 @@ func TestAppServerInvokeAuthorizesAgentTurnAppOperation(t *testing.T) {
 	authz := &recordingAuthorizationProvider{allowed: false}
 	invoker := &recordingAppInvocation{}
 	agentAuth := &recordingAgentAppAuthorizer{
-		response: AgentAppInvocationAuthorization{
+		response: invocation.AgentAppAuthorization{
 			Principal: &principal.Principal{
 				SubjectID:           "user:runner",
 				CredentialSubjectID: "user:runner",
@@ -315,7 +315,7 @@ func TestAppServerInvokeRejectsAgentContextOnWrongHostService(t *testing.T) {
 	t.Parallel()
 
 	agentAuth := &recordingAgentAppAuthorizer{
-		response: AgentAppInvocationAuthorization{
+		response: invocation.AgentAppAuthorization{
 			Principal: &principal.Principal{SubjectID: "user:runner"},
 		},
 	}

--- a/gestaltd/services/invocation/agent_authorization.go
+++ b/gestaltd/services/invocation/agent_authorization.go
@@ -1,0 +1,48 @@
+package invocation
+
+import (
+	"github.com/valon-technologies/gestalt/server/core"
+	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+)
+
+type AgentAppAuthorizationRequest struct {
+	AgentProviderName string
+	CallerKind        ProviderKind
+	CallerName        string
+	Agent             AgentInvocationContext
+	Principal         *principal.Principal
+	App               string
+	Operation         string
+	Connection        string
+	Instance          string
+	CredentialMode    core.ConnectionMode
+	RequestContext    *proto.RequestContext
+}
+
+type AgentAppAuthorization struct {
+	Principal      *principal.Principal
+	CredentialMode core.ConnectionMode
+	Connection     string
+	Instance       string
+	RunAs          *core.RunAsSubject
+	ToolRefs       []coreagent.ToolRef
+	ToolRefsSet    bool
+}
+
+type AgentWorkflowAuthorizationRequest struct {
+	AgentProviderName string
+	CallerKind        ProviderKind
+	CallerName        string
+	Agent             AgentInvocationContext
+	Principal         *principal.Principal
+	Operation         string
+	Target            *coreworkflow.Target
+	RequestContext    *proto.RequestContext
+}
+
+type AgentWorkflowAuthorization struct {
+	Principal *principal.Principal
+}

--- a/gestaltd/services/workflows/manager_server.go
+++ b/gestaltd/services/workflows/manager_server.go
@@ -30,12 +30,16 @@ type ProviderServer struct {
 	appName       string
 	manager       ManagerService
 	authorization core.AuthorizationProvider
-	agentAuth     appaccessservice.AgentWorkflowInvocationAuthorizer
+	agentAuth     interface {
+		AuthorizeWorkflowInvocation(context.Context, invocation.AgentWorkflowAuthorizationRequest) (invocation.AgentWorkflowAuthorization, error)
+	}
 }
 
 type ProviderServerOption func(*ProviderServer)
 
-func WithAgentWorkflowInvocationAuthorizer(authorizer appaccessservice.AgentWorkflowInvocationAuthorizer) ProviderServerOption {
+func WithAgentWorkflowInvocationAuthorizer(authorizer interface {
+	AuthorizeWorkflowInvocation(context.Context, invocation.AgentWorkflowAuthorizationRequest) (invocation.AgentWorkflowAuthorization, error)
+}) ProviderServerOption {
 	return func(s *ProviderServer) {
 		s.agentAuth = authorizer
 	}
@@ -565,7 +569,7 @@ func (s *ProviderServer) authorizeWorkflowAccess(ctx context.Context, authCtx wo
 		if s == nil || s.agentAuth == nil {
 			return nil, status.Error(codes.FailedPrecondition, "agent workflow invocation authorizer is required")
 		}
-		authorized, err := s.agentAuth.AuthorizeAgentWorkflowInvocation(ctx, appaccessservice.AgentWorkflowInvocationAuthorizationRequest{
+		authorized, err := s.agentAuth.AuthorizeWorkflowInvocation(ctx, invocation.AgentWorkflowAuthorizationRequest{
 			AgentProviderName: strings.TrimSpace(s.appName),
 			CallerKind:        authCtx.Caller().Kind,
 			CallerName:        authCtx.Caller().Name,

--- a/gestaltd/services/workflows/workflowmanager/manager_agent_authority.go
+++ b/gestaltd/services/workflows/workflowmanager/manager_agent_authority.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
-	appaccessservice "github.com/valon-technologies/gestalt/server/services/appaccess"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/workflows/workflowauth"
@@ -33,7 +32,7 @@ func (m *Manager) authorizeAgentWorkflowTarget(ctx context.Context, p *principal
 	if err != nil {
 		return nil, err
 	}
-	authorized, err := m.agentManager.AuthorizeAgentWorkflowInvocation(ctx, appaccessservice.AgentWorkflowInvocationAuthorizationRequest{
+	authorized, err := m.agentManager.AuthorizeWorkflowInvocation(ctx, invocation.AgentWorkflowAuthorizationRequest{
 		AgentProviderName: strings.TrimSpace(agent.ProviderName),
 		CallerKind:        caller.Kind,
 		CallerName:        caller.Name,


### PR DESCRIPTION
## Summary

Moves agent invocation authorization request and response shapes out of `appaccess` so app access no longer owns the agent execution authority contract.

The authorization behavior remains in `agentmanager`, where the active turn scope, provider ownership, caller context, subject, and listed tool scope are validated before app or workflow follow-up calls proceed. App and workflow services now depend only on the narrow structural authorizer method they call.

This trims the server-side plumbing without changing the provider API, proto schema, or turn-scope validation model.

## Interfaces

```go
package invocation

type AgentAppAuthorizationRequest struct { ... }
type AgentAppAuthorization struct { ... }

type AgentWorkflowAuthorizationRequest struct { ... }
type AgentWorkflowAuthorization struct { ... }
```

```go
AuthorizeAppInvocation(context.Context, invocation.AgentAppAuthorizationRequest) (invocation.AgentAppAuthorization, error)
AuthorizeWorkflowInvocation(context.Context, invocation.AgentWorkflowAuthorizationRequest) (invocation.AgentWorkflowAuthorization, error)
```

No new exported authorizer interface is introduced; app and workflow host services wire the methods above structurally at their option boundaries.

### Deleted Interfaces

```go
type appaccess.AgentAppInvocationAuthorizer interface { ... }
type appaccess.AgentWorkflowInvocationAuthorizer interface { ... }
```

`appaccess.AgentAppInvocationAuthorization*` and `appaccess.AgentWorkflowInvocationAuthorization*` are also deleted. Their request/result shapes now live in `invocation`, next to the agent invocation context and caller-provider primitives they carry.

## Runtime

App and workflow host services still reject agent follow-up calls unless the request context carries a live agent invocation context and `agentmanager` can match that context to the persisted turn scope.

Matching listed app tools still provides the effective principal, credential mode, connection, instance, runAs delegation, and inherited tool refs for nested calls. Workflow follow-ups still validate workflow operations and nested targets against the current agent tool scope.