### PR TITLE
[credentials] allow service account external credential provisioning

### DIFF
--- a/docs/content/client/cli/index.mdx
+++ b/docs/content/client/cli/index.mdx
@@ -63,7 +63,12 @@ The CLI searches the current directory and then parent directories until it find
 
 ## App connect flags
 
-`gestalt app connect NAME` accepts `--connection` and `--instance`. When the selected connection uses manual authentication instead of OAuth, the CLI prompts for the required credential fields and connection parameters.
+`gestalt app connect NAME` accepts `--connection`, `--instance`, and
+`--service-account-id`. Pass `--service-account-id` to store the connected
+external credential under a service account subject instead of the invoking
+user, after server-side authorization. When the selected connection uses manual
+authentication instead of OAuth, the CLI prompts for the required credential
+fields and connection parameters.
 
 ## App disconnect flags
 
@@ -88,6 +93,7 @@ This resolves to `chat.postMessage`. If the segments match a prefix shared by mu
 ```sh
 gestalt app list
 gestalt app connect notion --connection MCP
+gestalt app connect github --service-account-id nightly-sync
 gestalt app describe slack chat.postMessage
 gestalt app invoke slack chat postMessage \
   --connection app \

--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -63,6 +63,45 @@ Authenticated routes accept a `session_token` cookie or an `Authorization: Beare
 | `POST` | `/api/v1/auth/start-oauth` | Start a app OAuth flow. |
 | `POST` | `/api/v1/auth/connect-manual` | Submit manual app credentials. |
 
+Both app connection endpoints resolve the credential owner from the authenticated
+caller by default. To provision the credential for a managed service account
+instead, include `serviceAccountId`. The value may be either the local service
+account ID, such as `nightly-sync`, or the canonical subject ID,
+`service_account:nightly-sync`. The invoking principal must be allowed by the
+authorization provider to perform `manages` on that `service_account` resource.
+The same `manages` check is applied when completing `/api/v1/auth/pending-connection`
+for a service-account credential.
+
+`POST /api/v1/auth/start-oauth` accepts:
+
+```json
+{
+  "integration": "github",
+  "connection": "default",
+  "instance": "automation",
+  "serviceAccountId": "nightly-sync",
+  "scopes": ["repo"],
+  "connectionParams": {}
+}
+```
+
+`POST /api/v1/auth/connect-manual` accepts:
+
+```json
+{
+  "integration": "model-api",
+  "connection": "default",
+  "instance": "automation",
+  "serviceAccountId": "service_account:nightly-sync",
+  "credential": "api-token",
+  "credentials": {
+    "client_id": "id-123",
+    "client_secret": "secret-456"
+  },
+  "connectionParams": {}
+}
+```
+
 ### Workflows
 
 | Method | Path | Purpose |

--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -115,6 +115,10 @@ pub enum AppCommands {
         /// Instance name to create or refresh
         #[arg(long)]
         instance: Option<String>,
+
+        /// Store the connection credential under this service account subject
+        #[arg(long = "service-account-id")]
+        service_account_id: Option<String>,
     },
     /// Describe an app operation
     Describe(DescribeArgs),

--- a/gestalt/cli/src/commands/apps/connect.rs
+++ b/gestalt/cli/src/commands/apps/connect.rs
@@ -86,6 +86,8 @@ struct StartOAuthRequest<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     instance: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    service_account_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     connection_params: Option<&'a BTreeMap<String, String>>,
 }
 
@@ -99,6 +101,8 @@ struct ConnectManualRequest<'a> {
     connection: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     instance: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    service_account_id: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     connection_params: Option<&'a BTreeMap<String, String>>,
 }
@@ -251,10 +255,16 @@ pub fn connect(
     name: &str,
     connection: Option<&str>,
     instance: Option<&str>,
+    service_account_id: Option<&str>,
 ) -> Result<()> {
-    connect_with_browser_opener(client, name, connection, instance, |url| {
-        open::that(url).map(|_| ()).map_err(Into::into)
-    })
+    connect_with_browser_opener(
+        client,
+        name,
+        connection,
+        instance,
+        service_account_id,
+        |url| open::that(url).map(|_| ()).map_err(Into::into),
+    )
 }
 
 pub fn connect_with_browser_opener<F>(
@@ -262,6 +272,7 @@ pub fn connect_with_browser_opener<F>(
     name: &str,
     connection: Option<&str>,
     instance: Option<&str>,
+    service_account_id: Option<&str>,
     open_browser: F,
 ) -> Result<()>
 where
@@ -271,8 +282,10 @@ where
     let flow = ResolvedConnectFlow::resolve(&integration, connection)?;
 
     match flow.mode {
-        ConnectMode::OAuth => start_oauth(client, &flow, instance, open_browser),
-        ConnectMode::Manual => connect_manual(client, &flow, instance),
+        ConnectMode::OAuth => {
+            start_oauth(client, &flow, instance, service_account_id, open_browser)
+        }
+        ConnectMode::Manual => connect_manual(client, &flow, instance, service_account_id),
     }
 }
 
@@ -280,6 +293,7 @@ fn start_oauth<F>(
     client: &ApiClient,
     flow: &ResolvedConnectFlow<'_>,
     instance: Option<&str>,
+    service_account_id: Option<&str>,
     open_browser: F,
 ) -> Result<()>
 where
@@ -293,6 +307,7 @@ where
                 integration: flow.integration_name(),
                 connection: flow.connection_name(),
                 instance,
+                service_account_id,
                 connection_params: connection_params.as_ref(),
             },
         )
@@ -316,6 +331,7 @@ fn connect_manual(
     client: &ApiClient,
     flow: &ResolvedConnectFlow<'_>,
     instance: Option<&str>,
+    service_account_id: Option<&str>,
 ) -> Result<()> {
     eprintln!(
         "Connecting {} with manual auth.",
@@ -339,6 +355,7 @@ fn connect_manual(
                     credentials: credentials.request(),
                     connection: flow.connection_name(),
                     instance,
+                    service_account_id,
                     connection_params: connection_params.as_ref(),
                 },
             )

--- a/gestalt/cli/src/main.rs
+++ b/gestalt/cli/src/main.rs
@@ -260,7 +260,14 @@ fn dispatch_app_command(
             name,
             connection,
             instance,
-        } => commands::apps::connect(&client, &name, connection.as_deref(), instance.as_deref()),
+            service_account_id,
+        } => commands::apps::connect(
+            &client,
+            &name,
+            connection.as_deref(),
+            instance.as_deref(),
+            service_account_id.as_deref(),
+        ),
         AppCommands::Disconnect {
             name,
             connection,

--- a/gestalt/cli/tests/agents_cli.rs
+++ b/gestalt/cli/tests/agents_cli.rs
@@ -5,7 +5,7 @@ use std::collections::VecDeque;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::path::Path;
-use std::sync::{Arc, Mutex, mpsc};
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock, mpsc};
 use std::time::{Duration, Instant};
 use support::*;
 
@@ -1725,7 +1725,7 @@ fn test_cli_tty_scrolls_multiline_help_rows() {
     session.write("\x1b[6~\x0c");
     session.wait_for(&mut output, "Ctrl-C");
     session.write("\x03");
-    session.wait_for_exit();
+    session.wait_for_exit_after_interrupt();
 
     server.assert_finished();
 }
@@ -3411,6 +3411,7 @@ struct TtyCliSession {
     rows: u16,
     cols: u16,
     cursor_query_buffer: Vec<u8>,
+    _tty_lock: MutexGuard<'static, ()>,
 }
 
 #[cfg(unix)]
@@ -3445,10 +3446,25 @@ impl TtyCliSession {
     }
 
     fn wait_for_exit(&mut self) {
+        self.wait_for_exit_matching(|status| status.success(), "TTY CLI exited");
+    }
+
+    fn wait_for_exit_after_interrupt(&mut self) {
+        self.wait_for_exit_matching(
+            |status| status.success() || (status.signal().is_none() && status.exit_code() == 1),
+            "TTY CLI exited after interrupt",
+        );
+    }
+
+    fn wait_for_exit_matching(
+        &mut self,
+        accepted: impl Fn(&portable_pty::ExitStatus) -> bool,
+        message: &str,
+    ) {
         let deadline = Instant::now() + Duration::from_secs(10);
         loop {
             if let Some(status) = self.child.try_wait().unwrap() {
-                assert!(status.success(), "TTY CLI exited with {status:?}");
+                assert!(accepted(&status), "{message} with {status:?}");
                 if let Some(reader) = self.reader.take() {
                     let _ = reader.join();
                 }
@@ -3535,6 +3551,9 @@ fn spawn_tty_cli_with_size_and_env(
 ) -> TtyCliSession {
     use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 
+    let tty_lock = tty_test_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     std::fs::create_dir_all(home).unwrap();
     let pty_system = native_pty_system();
     let pair = pty_system
@@ -3589,7 +3608,14 @@ fn spawn_tty_cli_with_size_and_env(
         rows,
         cols,
         cursor_query_buffer: Vec::new(),
+        _tty_lock: tty_lock,
     }
+}
+
+#[cfg(unix)]
+fn tty_test_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
 }
 
 fn read_scripted_http_request(stream: &mut TcpStream) -> ScriptedHttpRequest {

--- a/gestalt/cli/tests/apps_connect.rs
+++ b/gestalt/cli/tests/apps_connect.rs
@@ -47,6 +47,42 @@ fn test_connect_includes_connection_and_instance() {
         "acme_crm",
         Some("workspace"),
         Some("team-a"),
+        None,
+        |_| Ok(()),
+    );
+
+    mock.assert();
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_connect_oauth_includes_service_account_id() {
+    let mut server = Server::new();
+    let _integrations = authed_json_mock!(server, Method::GET, "/api/v1/apps", StatusCode::OK)
+        .with_body(
+            r#"[{"name":"acme_crm","connections":[{"name":"workspace","authTypes":["oauth"]}]}]"#,
+        )
+        .create();
+    let mock = authed_json_mock!(
+        server,
+        Method::POST,
+        "/api/v1/auth/start-oauth",
+        StatusCode::OK
+    )
+    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+    .match_body(Matcher::JsonString(
+        r#"{"connection":"workspace","integration":"acme_crm","serviceAccountId":"service_account:nightly-sync"}"#.to_string(),
+    ))
+    .with_body(r#"{"url":"https://example.com/oauth","state":"abc123"}"#)
+    .create();
+
+    let client = create_client(&server);
+    let result = gestalt::commands::apps::connect_with_browser_opener(
+        &client,
+        "acme_crm",
+        Some("workspace"),
+        None,
+        Some("service_account:nightly-sync"),
         |_| Ok(()),
     );
 
@@ -86,6 +122,7 @@ fn test_connect_prefers_oauth_when_manual_also_exists_and_omits_null_instance() 
     let result = gestalt::commands::apps::connect_with_browser_opener(
         &client,
         "acme_crm",
+        None,
         None,
         None,
         move |url| {
@@ -131,6 +168,7 @@ fn test_connect_uses_user_facing_app_connection_name_on_the_wire() {
         &client,
         "acme_crm",
         Some("app"),
+        None,
         None,
         |_| Ok(()),
     );
@@ -237,6 +275,50 @@ fn test_manual_connect_uses_prompted_credentials_and_connection_params() {
         .success()
         .stderr(predicate::str::contains("API region"))
         .stderr(predicate::str::contains("API key"))
+        .stderr(predicate::str::contains("Connected widget_metrics."));
+}
+
+#[test]
+fn test_manual_connect_includes_service_account_id_flag() {
+    let mut server = Server::new();
+    let _integrations = authed_json_mock!(server, Method::GET, "/api/v1/apps", StatusCode::OK)
+        .with_body(
+            r#"[{
+                "name":"widget_metrics",
+                "displayName":"Widget Metrics",
+                "connections":[{
+                    "name":"app",
+                    "authTypes":["manual"],
+                    "credentialFields":[{"name":"api_key","label":"API key"}]
+                }]
+            }]"#,
+        )
+        .create();
+    let _connect = authed_json_mock!(
+        server,
+        Method::POST,
+        "/api/v1/auth/connect-manual",
+        StatusCode::OK
+    )
+    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+    .match_body(Matcher::JsonString(
+        r#"{"connection":"app","credential":"wm-key","integration":"widget_metrics","serviceAccountId":"nightly-sync"}"#.to_string(),
+    ))
+    .with_body(r#"{"status":"connected","integration":"widget_metrics"}"#)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "app",
+            "connect",
+            "widget_metrics",
+            "--service-account-id",
+            "nightly-sync",
+        ])
+        .write_stdin("wm-key\n")
+        .assert()
+        .success()
         .stderr(predicate::str::contains("Connected widget_metrics."));
 }
 

--- a/gestaltd/internal/server/access_context.go
+++ b/gestaltd/internal/server/access_context.go
@@ -17,14 +17,6 @@ func requireUserCaller(w http.ResponseWriter, p *principal.Principal) error {
 	return errUserRequired
 }
 
-func managedSubjectCallerIsUnscoped(p *principal.Principal) bool {
-	p = principal.Canonicalized(p)
-	if p == nil || p.Source != principal.SourceAPIToken {
-		return true
-	}
-	return p.TokenPermissions == nil && len(p.Scopes) == 0
-}
-
 func canonicalServiceAccountSubjectID(subjectID string) (string, error) {
 	kind, id, ok := core.ParseSubjectID(subjectID)
 	if !ok || kind != coredata.ManagedSubjectKindServiceAccount || !validManagedSubjectLocalID(id) {

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -178,8 +178,7 @@ func (s *Server) authorizeServiceAccountCredentialManagement(ctx context.Context
 	if s == nil || s.authorization == nil {
 		return fmt.Errorf("authorization provider is required")
 	}
-	p = principal.Canonicalized(p)
-	subjectID := strings.TrimSpace(principal.EffectiveCredentialSubjectID(p))
+	subjectID := invokingPrincipalSubjectID(p)
 	if subjectID == "" {
 		return fmt.Errorf("not authenticated")
 	}
@@ -201,6 +200,20 @@ func (s *Server) authorizeServiceAccountCredentialManagement(ctx context.Context
 		return fmt.Errorf("service account credential management denied")
 	}
 	return nil
+}
+
+func invokingPrincipalSubjectID(p *principal.Principal) string {
+	p = principal.Canonicalized(p)
+	if p == nil {
+		return ""
+	}
+	if subjectID := strings.TrimSpace(p.SubjectID); subjectID != "" {
+		return subjectID
+	}
+	if userID := strings.TrimSpace(p.UserID); userID != "" {
+		return principal.UserSubjectID(userID)
+	}
+	return ""
 }
 
 func (s *Server) healthCheck(w http.ResponseWriter, _ *http.Request) {

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/apps/apiexec"
 	"github.com/valon-technologies/gestalt/server/services/apps/mcphttp"
@@ -123,7 +124,10 @@ func (s *Server) resolveUserID(w http.ResponseWriter, r *http.Request) (string, 
 	return dbUser.ID, nil
 }
 
-func (s *Server) resolveCredentialSubjectID(w http.ResponseWriter, r *http.Request) (string, error) {
+func (s *Server) resolveCredentialSubjectID(w http.ResponseWriter, r *http.Request, serviceAccountID string) (string, error) {
+	if strings.TrimSpace(serviceAccountID) != "" {
+		return s.resolveServiceAccountCredentialSubjectID(w, r, serviceAccountID)
+	}
 	p := PrincipalFromContext(r.Context())
 	if p != nil {
 		if subjectID := strings.TrimSpace(p.CredentialSubjectID); subjectID != "" {
@@ -143,6 +147,60 @@ func (s *Server) resolveCredentialSubjectID(w http.ResponseWriter, r *http.Reque
 		return "", err
 	}
 	return principal.UserSubjectID(userID), nil
+}
+
+func (s *Server) resolveServiceAccountCredentialSubjectID(w http.ResponseWriter, r *http.Request, serviceAccountID string) (string, error) {
+	subjectID, err := canonicalServiceAccountCredentialSubjectID(serviceAccountID)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return "", err
+	}
+	if err := s.authorizeServiceAccountCredentialManagement(r.Context(), PrincipalFromContext(r.Context()), subjectID); err != nil {
+		writeError(w, http.StatusForbidden, err.Error())
+		return "", err
+	}
+	return subjectID, nil
+}
+
+func canonicalServiceAccountCredentialSubjectID(serviceAccountID string) (string, error) {
+	value := strings.TrimSpace(serviceAccountID)
+	if !strings.Contains(value, ":") {
+		value = "service_account:" + value
+	}
+	subjectID, err := canonicalServiceAccountSubjectID(value)
+	if err != nil {
+		return "", fmt.Errorf("serviceAccountId must be a service account id or canonical service_account:<id> subject ID")
+	}
+	return subjectID, nil
+}
+
+func (s *Server) authorizeServiceAccountCredentialManagement(ctx context.Context, p *principal.Principal, serviceAccountSubjectID string) error {
+	if s == nil || s.authorization == nil {
+		return fmt.Errorf("authorization provider is required")
+	}
+	p = principal.Canonicalized(p)
+	subjectID := strings.TrimSpace(principal.EffectiveCredentialSubjectID(p))
+	if subjectID == "" {
+		return fmt.Errorf("not authenticated")
+	}
+	resp, err := s.authorization.CheckAccess(ctx, &proto.CheckAccessRequest{
+		Subject: &proto.Subject{
+			Type: "subject",
+			Id:   subjectID,
+		},
+		Action: &proto.Action{Name: "manages"},
+		Resource: &proto.Resource{
+			Type: "service_account",
+			Id:   serviceAccountSubjectID,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("service account credential management denied: %w", err)
+	}
+	if resp == nil || !resp.GetAllowed() {
+		return fmt.Errorf("service account credential management denied")
+	}
+	return nil
 }
 
 func (s *Server) healthCheck(w http.ResponseWriter, _ *http.Request) {
@@ -331,7 +389,7 @@ func (s *Server) disconnectIntegration(w http.ResponseWriter, r *http.Request) {
 		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), name, "connection.disconnect", auditAllowed, auditErr, auditTarget)
 	}()
 
-	subjectID, err := s.resolveCredentialSubjectID(w, r)
+	subjectID, err := s.resolveCredentialSubjectID(w, r, "")
 	if err != nil {
 		auditErr = err
 		return

--- a/gestaltd/internal/server/handlers_connect.go
+++ b/gestaltd/internal/server/handlers_connect.go
@@ -24,6 +24,7 @@ type connectManualRequest struct {
 	Integration      string            `json:"integration"`
 	Connection       string            `json:"connection"`
 	Instance         string            `json:"instance"`
+	ServiceAccountID string            `json:"serviceAccountId"`
 	Credential       string            `json:"credential"`
 	Credentials      map[string]string `json:"credentials"`
 	ConnectionParams map[string]string `json:"connectionParams"`
@@ -78,7 +79,7 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	subjectID, manualInstance, err := s.resolveCredentialConnectionSetup(w, r, req.Instance)
+	subjectID, manualInstance, err := s.resolveCredentialConnectionSetup(w, r, req.Instance, req.ServiceAccountID)
 	if err != nil {
 		auditErr = err
 		return
@@ -210,8 +211,8 @@ func (s *Server) resolveConnectionProvider(w http.ResponseWriter, integration, r
 	return prov, connection, nil
 }
 
-func (s *Server) resolveCredentialConnectionSetup(w http.ResponseWriter, r *http.Request, requestedInstance string) (string, string, error) {
-	subjectID, err := s.resolveCredentialSubjectID(w, r)
+func (s *Server) resolveCredentialConnectionSetup(w http.ResponseWriter, r *http.Request, requestedInstance, serviceAccountID string) (string, string, error) {
+	subjectID, err := s.resolveCredentialSubjectID(w, r, serviceAccountID)
 	if err != nil {
 		return "", "", err
 	}

--- a/gestaltd/internal/server/handlers_oauth.go
+++ b/gestaltd/internal/server/handlers_oauth.go
@@ -19,6 +19,7 @@ type startOAuthRequest struct {
 	Integration      string            `json:"integration"`
 	Connection       string            `json:"connection"`
 	Instance         string            `json:"instance"`
+	ServiceAccountID string            `json:"serviceAccountId"`
 	Scopes           []string          `json:"scopes"`
 	ConnectionParams map[string]string `json:"connectionParams"`
 }
@@ -72,7 +73,7 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	subjectID, instance, err := s.resolveCredentialConnectionSetup(w, r, req.Instance)
+	subjectID, instance, err := s.resolveCredentialConnectionSetup(w, r, req.Instance, req.ServiceAccountID)
 	if err != nil {
 		auditErr = err
 		return

--- a/gestaltd/internal/server/pending_connection.go
+++ b/gestaltd/internal/server/pending_connection.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"html/template"
@@ -308,7 +307,12 @@ func (s *Server) authorizePendingConnection(w http.ResponseWriter, r *http.Reque
 			subjectID = principal.UserSubjectID(p.UserID)
 		}
 		if subjectID != state.Credential.SubjectID {
-			if !s.authorizeManagedSubjectPendingConnection(r.Context(), p, state.Credential.SubjectID) {
+			if _, err := canonicalServiceAccountSubjectID(state.Credential.SubjectID); err == nil {
+				if err := s.authorizeServiceAccountCredentialManagement(r.Context(), p, state.Credential.SubjectID); err != nil {
+					writeError(w, http.StatusForbidden, err.Error())
+					return nil, false
+				}
+			} else {
 				writeError(w, http.StatusNotFound, "pending connection not found")
 				return nil, false
 			}
@@ -326,22 +330,6 @@ func (s *Server) authorizePendingConnection(w http.ResponseWriter, r *http.Reque
 		}
 	}
 	return nil, true
-}
-
-func (s *Server) authorizeManagedSubjectPendingConnection(ctx context.Context, p *principal.Principal, subjectID string) bool {
-	if _, err := canonicalServiceAccountSubjectID(subjectID); err != nil {
-		return false
-	}
-	if !managedSubjectCallerIsUnscoped(p) {
-		return false
-	}
-	if s.managedSubjects == nil {
-		return false
-	}
-	if _, err := s.managedSubjects.GetManagedSubject(ctx, subjectID); err != nil {
-		return false
-	}
-	return true
 }
 
 func (s *Server) selectPendingConnection(w http.ResponseWriter, r *http.Request) {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -8692,6 +8692,13 @@ func TestStartIntegrationOAuth_ServiceAccountIDStoresCredentialForServiceAccount
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
 		cfg.DefaultConnection = map[string]string{"oauth-service-account": testDefaultConnection}
+		cfg.AppDefs = map[string]*config.ProviderEntry{
+			"oauth-service-account": {
+				Connections: map[string]*config.ConnectionDef{
+					testDefaultConnection: oauthConnectionDef(nil),
+				},
+			},
+		}
 		cfg.ConnectionAuth = testConnectionAuth("oauth-service-account", handler)
 		cfg.Authorization = authz
 		cfg.Services = svc
@@ -13126,6 +13133,11 @@ func TestConnectManual_ServiceAccountIDStoresCredentialForServiceAccount(t *test
 			StubIntegration: coretesting.StubIntegration{N: "manual-service-account"},
 		})
 		cfg.DefaultConnection = map[string]string{"manual-service-account": config.AppConnectionName}
+		cfg.AppDefs = map[string]*config.ProviderEntry{
+			"manual-service-account": {
+				Auth: &config.ConnectionAuthDef{Type: providermanifestv1.AuthTypeManual},
+			},
+		}
 		cfg.Authorization = authz
 		cfg.Services = svc
 	})
@@ -13210,6 +13222,11 @@ func TestConnectManual_ServiceAccountIDAuthorizesInvokingSubjectNotCredentialSub
 			StubIntegration: coretesting.StubIntegration{N: "manual-service-account-invoker"},
 		})
 		cfg.DefaultConnection = map[string]string{"manual-service-account-invoker": config.AppConnectionName}
+		cfg.AppDefs = map[string]*config.ProviderEntry{
+			"manual-service-account-invoker": {
+				Auth: &config.ConnectionAuthDef{Type: providermanifestv1.AuthTypeManual},
+			},
+		}
 		cfg.Authorization = authz
 		cfg.Services = svc
 	})
@@ -13255,6 +13272,11 @@ func TestConnectManual_ServiceAccountIDRequiresManagesAuthorization(t *testing.T
 			StubIntegration: coretesting.StubIntegration{N: "manual-service-account-denied"},
 		})
 		cfg.DefaultConnection = map[string]string{"manual-service-account-denied": config.AppConnectionName}
+		cfg.AppDefs = map[string]*config.ProviderEntry{
+			"manual-service-account-denied": {
+				Auth: &config.ConnectionAuthDef{Type: providermanifestv1.AuthTypeManual},
+			},
+		}
 		cfg.Authorization = authz
 		cfg.Services = svc
 	})
@@ -13326,6 +13348,14 @@ func TestSelectPendingConnection_ServiceAccountIDRequiresManagesAuthorization(t 
 			},
 		})
 		cfg.DefaultConnection = map[string]string{"manual-service-account-pending": config.AppConnectionName}
+		cfg.AppDefs = map[string]*config.ProviderEntry{
+			"manual-service-account-pending": {
+				Auth: &config.ConnectionAuthDef{Type: providermanifestv1.AuthTypeManual},
+				ConnectionParams: map[string]config.ConnectionParamDef{
+					"workspace": {From: "selection", Field: "workspace"},
+				},
+			},
+		}
 		cfg.Authorization = authz
 		cfg.Services = svc
 	})

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -2503,6 +2503,18 @@ func (p *serverTestAuthorizationProvider) ListRelationships(_ context.Context, r
 	return &proto.ListRelationshipsResponse{Relationships: out}, nil
 }
 
+type serviceAccountCredentialAuthorizationProvider struct {
+	core.AuthorizationProvider
+
+	allowed  bool
+	requests []*proto.CheckAccessRequest
+}
+
+func (p *serviceAccountCredentialAuthorizationProvider) CheckAccess(_ context.Context, req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
+	p.requests = append(p.requests, req)
+	return &proto.CheckAccessResponse{Allowed: p.allowed}, nil
+}
+
 func (p *serverTestAuthorizationProvider) ListActiveModelResourceTypes(_ context.Context, req *proto.ListActiveModelResourceTypesRequest) (*proto.ListActiveModelResourceTypesResponse, error) {
 	name := strings.TrimSpace(req.GetFilter().GetName())
 	out := []*proto.AuthorizationModelResourceType{}
@@ -8655,6 +8667,94 @@ func TestStartIntegrationOAuth(t *testing.T) {
 	}
 }
 
+func TestStartIntegrationOAuth_ServiceAccountIDStoresCredentialForServiceAccount(t *testing.T) {
+	t.Parallel()
+
+	const serviceAccountSubjectID = "service_account:oauth-bot"
+
+	svc := testutil.NewStubServices(t)
+	authz := &serviceAccountCredentialAuthorizationProvider{allowed: true}
+
+	handler := &testOAuthHandler{
+		authorizationBaseURLVal: "https://auth.example.com/oauth/authorize",
+		exchangeCodeFn: func(_ context.Context, code string) (*core.TokenResponse, error) {
+			if code != "good-code" {
+				return nil, fmt.Errorf("bad code")
+			}
+			return &core.TokenResponse{AccessToken: "service-account-oauth-token"}, nil
+		},
+	}
+	stub := &stubIntegrationWithAuthURL{
+		StubIntegration: coretesting.StubIntegration{N: "oauth-service-account"},
+		authURL:         "https://auth.example.com/oauth/authorize",
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.DefaultConnection = map[string]string{"oauth-service-account": testDefaultConnection}
+		cfg.ConnectionAuth = testConnectionAuth("oauth-service-account", handler)
+		cfg.Authorization = authz
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", bytes.NewBufferString(`{"integration":"oauth-service-account","serviceAccountId":"oauth-bot"}`))
+	startReq.Header.Set("Content-Type", "application/json")
+	startResp, err := http.DefaultClient.Do(startReq)
+	if err != nil {
+		t.Fatalf("start request: %v", err)
+	}
+	defer func() { _ = startResp.Body.Close() }()
+	if startResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(startResp.Body)
+		t.Fatalf("start status = %d, want 200: %s", startResp.StatusCode, body)
+	}
+	var startResult map[string]string
+	if err := json.NewDecoder(startResp.Body).Decode(&startResult); err != nil {
+		t.Fatalf("decode start response: %v", err)
+	}
+
+	noRedirect := &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	callbackReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=good-code&state="+url.QueryEscape(startResult["state"]), nil)
+	callbackResp, err := noRedirect.Do(callbackReq)
+	if err != nil {
+		t.Fatalf("callback request: %v", err)
+	}
+	defer func() { _ = callbackResp.Body.Close() }()
+	if callbackResp.StatusCode != http.StatusSeeOther {
+		body, _ := io.ReadAll(callbackResp.Body)
+		t.Fatalf("callback status = %d, want 303: %s", callbackResp.StatusCode, body)
+	}
+
+	tokens, err := svc.ExternalCredentials.ListCredentials(context.Background(), serviceAccountSubjectID)
+	if err != nil {
+		t.Fatalf("ListCredentials(service account): %v", err)
+	}
+	if len(tokens) != 1 {
+		t.Fatalf("service account tokens len = %d, want 1", len(tokens))
+	}
+	if got := tokens[0].AccessToken; got != "service-account-oauth-token" {
+		t.Fatalf("stored access token = %q, want service-account-oauth-token", got)
+	}
+	if len(authz.requests) != 1 {
+		t.Fatalf("authorization requests = %d, want 1", len(authz.requests))
+	}
+	authReq := authz.requests[0]
+	if authReq.GetSubject().GetType() != "subject" || !strings.HasPrefix(authReq.GetSubject().GetId(), "user:") {
+		t.Fatalf("authorization subject = %+v, want user subject", authReq.GetSubject())
+	}
+	if got := authReq.GetAction().GetName(); got != "manages" {
+		t.Fatalf("authorization action = %q, want manages", got)
+	}
+	if resource := authReq.GetResource(); resource.GetType() != "service_account" || resource.GetId() != serviceAccountSubjectID {
+		t.Fatalf("authorization resource = %+v, want service_account/%s", resource, serviceAccountSubjectID)
+	}
+}
+
 func TestIntegrationOAuthCallback(t *testing.T) {
 	t.Parallel()
 
@@ -13010,6 +13110,210 @@ func TestConnectManual_MultiCredential(t *testing.T) {
 				t.Fatalf("token data = %+v, want %+v", tokenData, tc.wantTokenData)
 			}
 		})
+	}
+}
+
+func TestConnectManual_ServiceAccountIDStoresCredentialForServiceAccount(t *testing.T) {
+	t.Parallel()
+
+	const serviceAccountSubjectID = "service_account:manual-bot"
+
+	svc := testutil.NewStubServices(t)
+	authz := &serviceAccountCredentialAuthorizationProvider{allowed: true}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, &stubManualProvider{
+			StubIntegration: coretesting.StubIntegration{N: "manual-service-account"},
+		})
+		cfg.DefaultConnection = map[string]string{"manual-service-account": config.AppConnectionName}
+		cfg.Authorization = authz
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", bytes.NewBufferString(`{"integration":"manual-service-account","serviceAccountId":"service_account:manual-bot","credential":"manual-service-account-token"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
+	}
+
+	tokens, err := svc.ExternalCredentials.ListCredentials(context.Background(), serviceAccountSubjectID)
+	if err != nil {
+		t.Fatalf("ListCredentials(service account): %v", err)
+	}
+	if len(tokens) != 1 {
+		t.Fatalf("service account tokens len = %d, want 1", len(tokens))
+	}
+	if got := tokens[0].AccessToken; got != "manual-service-account-token" {
+		t.Fatalf("stored access token = %q, want manual-service-account-token", got)
+	}
+	if len(authz.requests) != 1 {
+		t.Fatalf("authorization requests = %d, want 1", len(authz.requests))
+	}
+	authReq := authz.requests[0]
+	if authReq.GetSubject().GetType() != "subject" || !strings.HasPrefix(authReq.GetSubject().GetId(), "user:") {
+		t.Fatalf("authorization subject = %+v, want user subject", authReq.GetSubject())
+	}
+	if got := authReq.GetAction().GetName(); got != "manages" {
+		t.Fatalf("authorization action = %q, want manages", got)
+	}
+	if resource := authReq.GetResource(); resource.GetType() != "service_account" || resource.GetId() != serviceAccountSubjectID {
+		t.Fatalf("authorization resource = %+v, want service_account/%s", resource, serviceAccountSubjectID)
+	}
+}
+
+func TestConnectManual_ServiceAccountIDRequiresManagesAuthorization(t *testing.T) {
+	t.Parallel()
+
+	const serviceAccountSubjectID = "service_account:manual-bot"
+
+	svc := testutil.NewStubServices(t)
+	authz := &serviceAccountCredentialAuthorizationProvider{allowed: false}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, &stubManualProvider{
+			StubIntegration: coretesting.StubIntegration{N: "manual-service-account-denied"},
+		})
+		cfg.DefaultConnection = map[string]string{"manual-service-account-denied": config.AppConnectionName}
+		cfg.Authorization = authz
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", bytes.NewBufferString(`{"integration":"manual-service-account-denied","serviceAccountId":"manual-bot","credential":"manual-service-account-token"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 403: %s", resp.StatusCode, body)
+	}
+	if len(authz.requests) != 1 {
+		t.Fatalf("authorization requests = %d, want 1", len(authz.requests))
+	}
+	authReq := authz.requests[0]
+	if got := authReq.GetAction().GetName(); got != "manages" {
+		t.Fatalf("authorization action = %q, want manages", got)
+	}
+	if resource := authReq.GetResource(); resource.GetType() != "service_account" || resource.GetId() != serviceAccountSubjectID {
+		t.Fatalf("authorization resource = %+v, want service_account/%s", resource, serviceAccountSubjectID)
+	}
+	tokens, err := svc.ExternalCredentials.ListCredentials(context.Background(), serviceAccountSubjectID)
+	if err != nil {
+		t.Fatalf("ListCredentials(service account): %v", err)
+	}
+	if len(tokens) != 0 {
+		t.Fatalf("service account tokens len = %d, want 0", len(tokens))
+	}
+}
+
+func TestSelectPendingConnection_ServiceAccountIDRequiresManagesAuthorization(t *testing.T) {
+	t.Parallel()
+
+	const serviceAccountSubjectID = "service_account:manual-bot"
+
+	discoverySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[{"id":"site-a","name":"Site A","workspace":"alpha"},{"id":"site-b","name":"Site B","workspace":"beta"}]`)
+	}))
+	testutil.CloseOnCleanup(t, discoverySrv)
+
+	svc := testutil.NewStubServices(t)
+	authz := &serviceAccountCredentialAuthorizationProvider{allowed: true}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "session-token" {
+					return nil, fmt.Errorf("bad token")
+				}
+				return &core.UserIdentity{Email: "service-account-manager@test.local"}, nil
+			},
+		}
+		cfg.Providers = testutil.NewProviderRegistry(t, &stubManualProviderWithCapabilities{
+			stubManualProvider: stubManualProvider{
+				StubIntegration: coretesting.StubIntegration{N: "manual-service-account-pending"},
+			},
+			discovery: &core.DiscoveryConfig{
+				URL:      discoverySrv.URL,
+				IDPath:   "id",
+				NamePath: "name",
+				Metadata: map[string]string{"workspace": "workspace"},
+			},
+		})
+		cfg.DefaultConnection = map[string]string{"manual-service-account-pending": config.AppConnectionName}
+		cfg.Authorization = authz
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", bytes.NewBufferString(`{"integration":"manual-service-account-pending","serviceAccountId":"manual-bot","credential":"manual-service-account-token"}`))
+	req.Header.Set("Authorization", "Bearer session-token")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("connect request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("connect status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	var connectResp struct {
+		Status       string `json:"status"`
+		PendingToken string `json:"pendingToken"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&connectResp); err != nil {
+		t.Fatalf("decode connect response: %v", err)
+	}
+	if connectResp.Status != "selection_required" || connectResp.PendingToken == "" {
+		t.Fatalf("connect response = %+v, want selection_required with pending token", connectResp)
+	}
+
+	authz.allowed = false
+	form := url.Values{
+		"pending_token":   {connectResp.PendingToken},
+		"candidate_index": {"0"},
+	}
+	selectReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/pending-connection", strings.NewReader(form.Encode()))
+	selectReq.Header.Set("Authorization", "Bearer session-token")
+	selectReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	selectResp, err := http.DefaultClient.Do(selectReq)
+	if err != nil {
+		t.Fatalf("select request: %v", err)
+	}
+	defer func() { _ = selectResp.Body.Close() }()
+	if selectResp.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(selectResp.Body)
+		t.Fatalf("select status = %d, want 403: %s", selectResp.StatusCode, body)
+	}
+	if len(authz.requests) != 2 {
+		t.Fatalf("authorization requests = %d, want 2", len(authz.requests))
+	}
+	for idx, authReq := range authz.requests {
+		if got := authReq.GetAction().GetName(); got != "manages" {
+			t.Fatalf("authorization request %d action = %q, want manages", idx, got)
+		}
+		if resource := authReq.GetResource(); resource.GetType() != "service_account" || resource.GetId() != serviceAccountSubjectID {
+			t.Fatalf("authorization request %d resource = %+v, want service_account/%s", idx, resource, serviceAccountSubjectID)
+		}
+	}
+	tokens, err := svc.ExternalCredentials.ListCredentials(context.Background(), serviceAccountSubjectID)
+	if err != nil {
+		t.Fatalf("ListCredentials(service account): %v", err)
+	}
+	if len(tokens) != 0 {
+		t.Fatalf("service account tokens len = %d, want 0", len(tokens))
 	}
 }
 

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -13168,6 +13168,80 @@ func TestConnectManual_ServiceAccountIDStoresCredentialForServiceAccount(t *test
 	}
 }
 
+func TestConnectManual_ServiceAccountIDAuthorizesInvokingSubjectNotCredentialSubject(t *testing.T) {
+	t.Parallel()
+
+	const (
+		serviceAccountSubjectID = "service_account:manual-bot"
+		credentialSubjectID     = "service_account:reports"
+	)
+
+	svc := testutil.NewStubServices(t)
+	user, err := svc.Users.FindOrCreateUser(context.Background(), "api-user@test.local")
+	if err != nil {
+		t.Fatalf("FindOrCreateUser: %v", err)
+	}
+	apiToken, hashed, err := principal.GenerateToken(principal.TokenTypeAPI)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	exp := time.Now().Add(24 * time.Hour)
+	if err := svc.APITokens.StoreAPIToken(context.Background(), &core.APIToken{
+		ID:                  "api-tok-service-account-credential-subject",
+		OwnerKind:           core.APITokenOwnerKindUser,
+		OwnerID:             user.ID,
+		CredentialSubjectID: credentialSubjectID,
+		Name:                "service account credential subject",
+		HashedToken:         hashed,
+		ExpiresAt:           &exp,
+	}); err != nil {
+		t.Fatalf("StoreAPIToken: %v", err)
+	}
+	authz := &serviceAccountCredentialAuthorizationProvider{allowed: true}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, _ string) (*core.UserIdentity, error) {
+				return nil, fmt.Errorf("not a session token")
+			},
+		}
+		cfg.Providers = testutil.NewProviderRegistry(t, &stubManualProvider{
+			StubIntegration: coretesting.StubIntegration{N: "manual-service-account-invoker"},
+		})
+		cfg.DefaultConnection = map[string]string{"manual-service-account-invoker": config.AppConnectionName}
+		cfg.Authorization = authz
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", bytes.NewBufferString(`{"integration":"manual-service-account-invoker","serviceAccountId":"manual-bot","credential":"manual-service-account-token"}`))
+	req.Header.Set("Authorization", "Bearer "+apiToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	if len(authz.requests) != 1 {
+		t.Fatalf("authorization requests = %d, want 1", len(authz.requests))
+	}
+	authReq := authz.requests[0]
+	if got, want := authReq.GetSubject().GetId(), principal.UserSubjectID(user.ID); got != want {
+		t.Fatalf("authorization subject id = %q, want invoking subject %q", got, want)
+	}
+	if got := authReq.GetSubject().GetId(); got == credentialSubjectID {
+		t.Fatalf("authorization subject id = %q, must not use credential subject", got)
+	}
+	if resource := authReq.GetResource(); resource.GetType() != "service_account" || resource.GetId() != serviceAccountSubjectID {
+		t.Fatalf("authorization resource = %+v, want service_account/%s", resource, serviceAccountSubjectID)
+	}
+}
+
 func TestConnectManual_ServiceAccountIDRequiresManagesAuthorization(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Description

Adds serviceAccountId support to OAuth and manual connection flows so external credentials can be stored under a managed service account subject.