### PR TITLE
Expose Python app invoke options

### DIFF
--- a/sdk/python/gestalt/_app_access.py
+++ b/sdk/python/gestalt/_app_access.py
@@ -53,6 +53,8 @@ class AppProtocol(Protocol):
         connection: str = "",
         instance: str = "",
         idempotency_key: str = "",
+        credential_mode: str = "",
+        timeout_seconds: float | None = None,
     ) -> JsonValue:
         """Invoke one operation on another app."""
 
@@ -65,6 +67,8 @@ class AppProtocol(Protocol):
         connection: str = "",
         instance: str = "",
         idempotency_key: str = "",
+        credential_mode: str = "",
+        timeout_seconds: float | None = None,
     ) -> Response[bytes]:
         """Invoke one operation on another app and return the raw transport result."""
 
@@ -122,6 +126,8 @@ class _AppClient:
         connection: str = "",
         instance: str = "",
         idempotency_key: str = "",
+        credential_mode: str = "",
+        timeout_seconds: float | None = None,
     ) -> JsonValue:
         """Invoke one operation on another app.
 
@@ -140,6 +146,8 @@ class _AppClient:
                 connection=connection,
                 instance=instance,
                 idempotency_key=idempotency_key,
+                credential_mode=credential_mode,
+                timeout_seconds=timeout_seconds,
             ),
         )
 
@@ -152,6 +160,8 @@ class _AppClient:
         connection: str = "",
         instance: str = "",
         idempotency_key: str = "",
+        credential_mode: str = "",
+        timeout_seconds: float | None = None,
     ) -> Response[bytes]:
         """Invoke one operation on another app and return the raw transport result."""
 
@@ -161,6 +171,7 @@ class _AppClient:
             connection=connection,
             instance=instance,
             idempotency_key=idempotency_key.strip(),
+            credential_mode=credential_mode.strip(),
         )
         message = _struct_from_dict(params)
         if message is not None:
@@ -168,7 +179,9 @@ class _AppClient:
         if self._context is not None:
             request.context.CopyFrom(self._context)
 
-        return _response_from_proto(self._stub.Invoke(request))
+        return _response_from_proto(
+            self._stub.Invoke(request, timeout=_positive_float(timeout_seconds))
+        )
 
     def invoke_graphql(
         self,
@@ -260,6 +273,13 @@ def _struct_from_dict_optional(
         return None
 
     return _struct_from_normalized_object(normalized)
+
+
+def _positive_float(value: float | None) -> float | None:
+    if value is None:
+        return None
+    timeout = float(value)
+    return timeout if timeout > 0 else None
 
 
 def _app_channel(raw_target: str, *, token: str = "") -> grpc.Channel:

--- a/sdk/python/tests/test_app_transport.py
+++ b/sdk/python/tests/test_app_transport.py
@@ -71,6 +71,18 @@ class _AppServicer(app_pb2_grpc.AppServicer):
             else {}
         )
         _invoke_contexts.append(request_context)
+        body = {
+            "app": request.app,
+            "operation": request.operation,
+            "params": params,
+            "params_present": request.HasField("params"),
+            "connection": request.connection,
+            "instance": request.instance,
+            "idempotency_key": request.idempotency_key,
+            "context": request_context,
+        }
+        if request.credential_mode:
+            body["credential_mode"] = request.credential_mode
         return app_pb2.OperationResult(
             status=200,
             headers={
@@ -78,18 +90,7 @@ class _AppServicer(app_pb2_grpc.AppServicer):
                     values=["https://example.test/created"]
                 )
             },
-            body=json.dumps(
-                {
-                    "app": request.app,
-                    "operation": request.operation,
-                    "params": params,
-                    "params_present": request.HasField("params"),
-                    "connection": request.connection,
-                    "instance": request.instance,
-                    "idempotency_key": request.idempotency_key,
-                    "context": request_context,
-                }
-            ).encode("utf-8"),
+            body=json.dumps(body).encode("utf-8"),
         )
 
     def InvokeGraphQL(self, request, context):
@@ -197,6 +198,8 @@ class AppTransportTests(unittest.TestCase):
                 connection="work",
                 instance="prod",
                 idempotency_key=" issue-1026-create ",
+                credential_mode="subject",
+                timeout_seconds=5,
             )
 
         self.assertEqual(response.status, 200)
@@ -217,6 +220,7 @@ class AppTransportTests(unittest.TestCase):
                 "connection": "work",
                 "instance": "prod",
                 "idempotency_key": "issue-1026-create",
+                "credential_mode": "subject",
                 "context": {
                     "subject": {
                         "id": "user:ada",


### PR DESCRIPTION
## Summary

This updates the Python SDK app invocation client so raw and typed app invokes can pass the same host invocation options already carried by the underlying proto.

## Interfaces

`Request.app().invoke(...)` and `invoke_raw(...)` now accept `credential_mode` and `timeout_seconds`. The credential mode is serialized onto `AppInvokeRequest.credential_mode`; the timeout is passed as the gRPC deadline for the invoke call.

## Runtime

Agent bridge providers can keep using raw app invocation without dropping credential scoping or timeout behavior. Existing callers that omit the new keyword arguments keep the current request shape.

## Test plan

- [x] `uv run ruff check gestalt/_app_access.py tests/test_app_transport.py`
- [x] `uv run ty check gestalt/_app_access.py tests/test_app_transport.py`
- [x] `uv run --with pytest pytest tests/test_app_transport.py -q`
- [x] `git diff --check`