### PR TITLE
[cli] release gestalt CLI v0.0.2-alpha.4

### DIFF
--- a/gestalt/Cargo.toml
+++ b/gestalt/Cargo.toml
@@ -3,5 +3,5 @@ resolver = "2"
 members = ["cli"]
 
 [workspace.package]
-version = "0.0.2-alpha.3"
+version = "0.0.2-alpha.4"
 edition = "2024"


### PR DESCRIPTION
## Description

Bumps the Gestalt CLI package version to 0.0.2-alpha.4 so the release tag can publish the merged service-account credential CLI changes.