### PR TITLE
[external-credentials] rename credential endpoints

### DIFF
--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -20,7 +20,8 @@ Authenticated routes accept a `session_token` cookie or an `Authorization: Beare
 | `GET` | `/api/v1/auth/login/callback` | Completes platform login. |
 | `POST` | `/api/v1/auth/logout` | Clears the current platform session. |
 | `GET` | `/api/v1/auth/callback` | Completes app OAuth. |
-| `POST` | `/api/v1/auth/pending-connection` | Render or finalize a multi-candidate connection choice using a pending connection token. |
+| `POST` | `/api/v1/external-credentials/pending-connection` | Render or finalize a multi-candidate connection choice using a pending connection token. |
+| `POST` | `/api/v1/auth/pending-connection` | Legacy alias for `/api/v1/external-credentials/pending-connection`. |
 | `GET`, `POST`, `PUT`, `PATCH`, or `DELETE` | `/api/v1/{app}/{hostedPath}` | Invoke a app-hosted HTTP binding declared by `spec.http` or `apps.<name>.http`. The route is verified by the binding's `security` scheme, not by Gestalt session authentication. |
 
 ## Authenticated User Routes
@@ -60,8 +61,10 @@ Authenticated routes accept a `session_token` cookie or an `Authorization: Beare
 
 | Method | Path | Purpose |
 | --- | --- | --- |
-| `POST` | `/api/v1/auth/start-oauth` | Start a app OAuth flow. |
-| `POST` | `/api/v1/auth/connect-manual` | Submit manual app credentials. |
+| `POST` | `/api/v1/external-credentials/start-oauth` | Start a app OAuth flow. |
+| `POST` | `/api/v1/external-credentials/connect-manual` | Submit manual app credentials. |
+| `POST` | `/api/v1/auth/start-oauth` | Legacy alias for `/api/v1/external-credentials/start-oauth`. |
+| `POST` | `/api/v1/auth/connect-manual` | Legacy alias for `/api/v1/external-credentials/connect-manual`. |
 
 Both app connection endpoints resolve the credential owner from the authenticated
 caller by default. To provision the credential for a managed service account
@@ -69,10 +72,10 @@ instead, include `serviceAccountId`. The value may be either the local service
 account ID, such as `nightly-sync`, or the canonical subject ID,
 `service_account:nightly-sync`. The invoking principal must be allowed by the
 authorization provider to perform `manages` on that `service_account` resource.
-The same `manages` check is applied when completing `/api/v1/auth/pending-connection`
+The same `manages` check is applied when completing `/api/v1/external-credentials/pending-connection`
 for a service-account credential.
 
-`POST /api/v1/auth/start-oauth` accepts:
+`POST /api/v1/external-credentials/start-oauth` accepts:
 
 ```json
 {
@@ -85,7 +88,7 @@ for a service-account credential.
 }
 ```
 
-`POST /api/v1/auth/connect-manual` accepts:
+`POST /api/v1/external-credentials/connect-manual` accepts:
 
 ```json
 {

--- a/gestalt/cli/src/commands/apps/connect.rs
+++ b/gestalt/cli/src/commands/apps/connect.rs
@@ -302,7 +302,7 @@ where
     let connection_params = prompt_connection_params(flow.connection_param_defs())?;
     let resp = client
         .post(
-            "/api/v1/auth/start-oauth",
+            "/api/v1/external-credentials/start-oauth",
             &StartOAuthRequest {
                 integration: flow.integration_name(),
                 connection: flow.connection_name(),
@@ -349,7 +349,7 @@ fn connect_manual(
     let response: ConnectManualResponse = serde_json::from_value(
         client
             .post(
-                "/api/v1/auth/connect-manual",
+                "/api/v1/external-credentials/connect-manual",
                 &ConnectManualRequest {
                     integration: flow.integration_name(),
                     credentials: credentials.request(),

--- a/gestalt/cli/tests/apps_connect.rs
+++ b/gestalt/cli/tests/apps_connect.rs
@@ -31,7 +31,7 @@ fn test_connect_includes_connection_and_instance() {
     let mock = authed_json_mock!(
         server,
         Method::POST,
-        "/api/v1/auth/start-oauth",
+        "/api/v1/external-credentials/start-oauth",
         StatusCode::OK
     )
     .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
@@ -66,7 +66,7 @@ fn test_connect_oauth_includes_service_account_id() {
     let mock = authed_json_mock!(
         server,
         Method::POST,
-        "/api/v1/auth/start-oauth",
+        "/api/v1/external-credentials/start-oauth",
         StatusCode::OK
     )
     .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
@@ -106,7 +106,7 @@ fn test_connect_prefers_oauth_when_manual_also_exists_and_omits_null_instance() 
     let mock = authed_json_mock!(
         server,
         Method::POST,
-        "/api/v1/auth/start-oauth",
+        "/api/v1/external-credentials/start-oauth",
         StatusCode::OK
     )
     .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
@@ -153,7 +153,7 @@ fn test_connect_uses_user_facing_app_connection_name_on_the_wire() {
     let mock = authed_json_mock!(
         server,
         Method::POST,
-        "/api/v1/auth/start-oauth",
+        "/api/v1/external-credentials/start-oauth",
         StatusCode::OK
     )
     .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
@@ -257,7 +257,7 @@ fn test_manual_connect_uses_prompted_credentials_and_connection_params() {
     let _connect = authed_json_mock!(
         server,
         Method::POST,
-        "/api/v1/auth/connect-manual",
+        "/api/v1/external-credentials/connect-manual",
         StatusCode::OK
     )
 		.match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
@@ -297,7 +297,7 @@ fn test_manual_connect_includes_service_account_id_flag() {
     let _connect = authed_json_mock!(
         server,
         Method::POST,
-        "/api/v1/auth/connect-manual",
+        "/api/v1/external-credentials/connect-manual",
         StatusCode::OK
     )
     .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
@@ -341,7 +341,7 @@ fn test_manual_connect_prompts_for_connection_and_finishes_candidate_selection()
     let _connect = authed_json_mock!(
         server,
         Method::POST,
-        "/api/v1/auth/connect-manual",
+        "/api/v1/external-credentials/connect-manual",
         StatusCode::OK
     )
     .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
@@ -353,7 +353,7 @@ fn test_manual_connect_prompts_for_connection_and_finishes_candidate_selection()
         r#"{
                 "status":"selection_required",
                 "integration":"manual-svc",
-                "selectionUrl":"/api/v1/auth/pending-connection",
+                "selectionUrl":"/api/v1/external-credentials/pending-connection",
                 "pendingToken":"pending-123",
                 "candidates":[
                     {"id":"site-a","name":"Site A"},
@@ -363,7 +363,10 @@ fn test_manual_connect_prompts_for_connection_and_finishes_candidate_selection()
     )
     .create();
     let _select = server
-        .mock(Method::POST.as_str(), "/api/v1/auth/pending-connection")
+        .mock(
+            Method::POST.as_str(),
+            "/api/v1/external-credentials/pending-connection",
+        )
         .match_header(
             header::AUTHORIZATION.as_str(),
             Matcher::Exact(test_bearer()),
@@ -417,7 +420,7 @@ fn test_connection_selection_uses_selected_connection_auth_type() {
     let _oauth = authed_json_mock!(
         server,
         Method::POST,
-        "/api/v1/auth/start-oauth",
+        "/api/v1/external-credentials/start-oauth",
         StatusCode::OK
     )
     .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
@@ -459,7 +462,7 @@ fn test_connect_auto_selects_single_connection_and_uses_its_auth_type() {
     let _oauth = authed_json_mock!(
         server,
         Method::POST,
-        "/api/v1/auth/start-oauth",
+        "/api/v1/external-credentials/start-oauth",
         StatusCode::OK
     )
     .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
@@ -528,7 +531,7 @@ fn test_manual_connect_uses_credentials_object_for_multi_field_auth() {
     let _connect = authed_json_mock!(
         server,
         Method::POST,
-        "/api/v1/auth/connect-manual",
+        "/api/v1/external-credentials/connect-manual",
         StatusCode::OK
     )
 		.match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
@@ -560,7 +563,7 @@ fn test_manual_connect_falls_back_to_generic_credential_prompt() {
     let _connect = authed_json_mock!(
         server,
         Method::POST,
-        "/api/v1/auth/connect-manual",
+        "/api/v1/external-credentials/connect-manual",
         StatusCode::OK
     )
     .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)

--- a/gestalt/cli/tests/auth_flow.rs
+++ b/gestalt/cli/tests/auth_flow.rs
@@ -10,7 +10,7 @@ fn test_start_oauth() {
     let mock = authed_json_mock!(
         server,
         Method::POST,
-        "/api/v1/auth/start-oauth",
+        "/api/v1/external-credentials/start-oauth",
         StatusCode::OK
     )
     .with_body(r#"{"url":"https://example.com/oauth","state":"abc123"}"#)
@@ -18,7 +18,9 @@ fn test_start_oauth() {
 
     let client = create_client(&server);
     let body = serde_json::json!({"integration": "acme_crm"});
-    let resp = client.post("/api/v1/auth/start-oauth", &body).unwrap();
+    let resp = client
+        .post("/api/v1/external-credentials/start-oauth", &body)
+        .unwrap();
 
     mock.assert();
     assert_eq!(resp["url"], "https://example.com/oauth");

--- a/gestaltd/internal/server/metrics_test.go
+++ b/gestaltd/internal/server/metrics_test.go
@@ -174,7 +174,7 @@ func TestConnectionAuthMetrics(t *testing.T) {
 		t.Helper()
 
 		body := bytes.NewBufferString(`{"integration":"` + providerName + `"}`)
-		startReq, _ := http.NewRequest(http.MethodPost, oauthServer.URL+"/api/v1/auth/start-oauth", body)
+		startReq, _ := http.NewRequest(http.MethodPost, oauthServer.URL+"/api/v1/external-credentials/start-oauth", body)
 		startReq.Header.Set("Content-Type", "application/json")
 		startResp, err := http.DefaultClient.Do(startReq)
 		if err != nil {
@@ -508,7 +508,7 @@ func TestManualConnectionMetrics(t *testing.T) {
 	testutil.CloseOnCleanup(t, srv)
 
 	body := bytes.NewBufferString(`{"integration":"` + providerName + `","credentials":{"api_key":"secret"}}`)
-	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/auth/connect-manual", body)
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/external-credentials/connect-manual", body)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -538,7 +538,7 @@ func TestConnectionAuthMetricsUseUnknownProviderForMissingIntegration(t *testing
 	testutil.CloseOnCleanup(t, srv)
 
 	startBody := bytes.NewBufferString(`{"integration":"typo-oauth"}`)
-	startReq, _ := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/auth/start-oauth", startBody)
+	startReq, _ := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/external-credentials/start-oauth", startBody)
 	startReq.Header.Set("Content-Type", "application/json")
 	startResp, err := http.DefaultClient.Do(startReq)
 	if err != nil {
@@ -550,7 +550,7 @@ func TestConnectionAuthMetricsUseUnknownProviderForMissingIntegration(t *testing
 	}
 
 	manualBody := bytes.NewBufferString(`{"integration":"typo-manual","credential":"secret"}`)
-	manualReq, _ := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/auth/connect-manual", manualBody)
+	manualReq, _ := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/external-credentials/connect-manual", manualBody)
 	manualReq.Header.Set("Content-Type", "application/json")
 	manualResp, err := http.DefaultClient.Do(manualReq)
 	if err != nil {

--- a/gestaltd/internal/server/pending_connection.go
+++ b/gestaltd/internal/server/pending_connection.go
@@ -15,7 +15,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 )
 
-const pendingConnectionPath = "/api/v1/auth/pending-connection"
+const pendingConnectionPath = "/api/v1/external-credentials/pending-connection"
 const pendingConnectionCookieName = "pending_connection_state"
 
 var pendingConnectionSelectionPage = template.Must(template.New("pending-connection-selection").Parse(`<!doctype html>

--- a/gestaltd/internal/server/routes_auth.go
+++ b/gestaltd/internal/server/routes_auth.go
@@ -9,5 +9,7 @@ func (s *Server) mountAuthRoutes(r chi.Router) {
 	r.Get("/auth/login/callback", s.loginCallback)
 	r.Post("/auth/logout", s.logout)
 	r.Get("/auth/callback", s.integrationOAuthCallback)
+	r.Post("/external-credentials/pending-connection", s.selectPendingConnection)
+	// Deprecated: keep this auth route as a backwards-compatible alias while clients migrate to /external-credentials.
 	r.Post("/auth/pending-connection", s.selectPendingConnection)
 }

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -46,6 +46,9 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 			r.Post("/{turnID}/interactions/{interactionID}/resolve", s.resolveAgentInteraction)
 		})
 
+		r.Post("/external-credentials/start-oauth", s.startIntegrationOAuth)
+		r.Post("/external-credentials/connect-manual", s.connectManual)
+		// Deprecated: keep these auth routes as backwards-compatible aliases while clients migrate to /external-credentials.
 		r.Post("/auth/start-oauth", s.startIntegrationOAuth)
 		r.Post("/auth/connect-manual", s.connectManual)
 

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -8581,7 +8581,7 @@ func TestStartIntegrationOAuth(t *testing.T) {
 	testutil.CloseOnCleanup(t, ts)
 
 	body := bytes.NewBufferString(`{"integration":"slack","scopes":["channels:read"]}`)
-	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", body)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/external-credentials/start-oauth", body)
 	req.Header.Set("Authorization", "Bearer ignored")
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
@@ -8644,7 +8644,7 @@ func TestStartIntegrationOAuth(t *testing.T) {
 	testutil.CloseOnCleanup(t, invalidTS)
 
 	invalidBody := bytes.NewBufferString(`{"integration":"slack","connectionParams":{"unknown":"nope"}}`)
-	invalidReq, _ := http.NewRequest(http.MethodPost, invalidTS.URL+"/api/v1/auth/start-oauth", invalidBody)
+	invalidReq, _ := http.NewRequest(http.MethodPost, invalidTS.URL+"/api/v1/external-credentials/start-oauth", invalidBody)
 	invalidReq.Header.Set("Content-Type", "application/json")
 	invalidResp, err := http.DefaultClient.Do(invalidReq)
 	if err != nil {
@@ -8663,6 +8663,58 @@ func TestStartIntegrationOAuth(t *testing.T) {
 	}
 	if invalidAuditRecord["target_id"] != "slack/default/default" {
 		t.Fatalf("expected invalid audit target_id slack/default/default, got %v", invalidAuditRecord["target_id"])
+	}
+}
+
+func TestExternalCredentialLegacyAuthRoutes(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {})
+	testutil.CloseOnCleanup(t, ts)
+
+	tests := []struct {
+		name string
+		path string
+		body string
+		want int
+	}{
+		{
+			name: "start oauth",
+			path: "/api/v1/auth/start-oauth",
+			body: `{`,
+			want: http.StatusBadRequest,
+		},
+		{
+			name: "connect manual",
+			path: "/api/v1/auth/connect-manual",
+			body: `{`,
+			want: http.StatusBadRequest,
+		},
+		{
+			name: "pending connection",
+			path: "/api/v1/auth/pending-connection",
+			body: ``,
+			want: http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			req, _ := http.NewRequest(http.MethodPost, ts.URL+tc.path, strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("request: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != tc.want {
+				t.Fatalf("legacy route %s status = %d, want %d", tc.path, resp.StatusCode, tc.want)
+			}
+		})
 	}
 }
 
@@ -8704,7 +8756,7 @@ func TestStartIntegrationOAuth_ServiceAccountIDStoresCredentialForServiceAccount
 	})
 	testutil.CloseOnCleanup(t, ts)
 
-	startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", bytes.NewBufferString(`{"integration":"oauth-service-account","serviceAccountId":"oauth-bot"}`))
+	startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/external-credentials/start-oauth", bytes.NewBufferString(`{"integration":"oauth-service-account","serviceAccountId":"oauth-bot"}`))
 	startReq.Header.Set("Content-Type", "application/json")
 	startResp, err := http.DefaultClient.Do(startReq)
 	if err != nil {
@@ -8764,7 +8816,7 @@ func TestStartIntegrationOAuth_ServiceAccountIDStoresCredentialForServiceAccount
 func TestIntegrationOAuthCallback(t *testing.T) {
 	t.Parallel()
 
-	const pendingSelectionPath = "/api/v1/auth/pending-connection"
+	const pendingSelectionPath = "/api/v1/external-credentials/pending-connection"
 
 	t.Run("connected", func(t *testing.T) {
 		t.Parallel()
@@ -8836,7 +8888,7 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 		testutil.CloseOnCleanup(t, ts)
 
 		startBody := bytes.NewBufferString(`{"integration":"oauth-svc"}`)
-		startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", startBody)
+		startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/external-credentials/start-oauth", startBody)
 		startReq.Header.Set("Content-Type", "application/json")
 		startReq.Header.Set("Authorization", "Bearer session-token")
 		startResp, err := http.DefaultClient.Do(startReq)
@@ -9003,7 +9055,7 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 		testutil.CloseOnCleanup(t, ts)
 
 		startBody := bytes.NewBufferString(`{"integration":"oauth-svc"}`)
-		startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", startBody)
+		startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/external-credentials/start-oauth", startBody)
 		startReq.Header.Set("Content-Type", "application/json")
 		startReq.Header.Set("Authorization", "Bearer cli-api-token")
 		startResp, err := http.DefaultClient.Do(startReq)
@@ -10322,7 +10374,7 @@ func TestIntegrationOAuthCallback_PKCEUsesVerifier(t *testing.T) {
 	testutil.CloseOnCleanup(t, ts)
 
 	startBody := bytes.NewBufferString(`{"integration":"gitlab"}`)
-	startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", startBody)
+	startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/external-credentials/start-oauth", startBody)
 	startReq.Header.Set("Content-Type", "application/json")
 	startResp, err := http.DefaultClient.Do(startReq)
 	if err != nil {
@@ -11304,7 +11356,7 @@ func TestConnectManual_OAuthProviderRejected(t *testing.T) {
 	testutil.CloseOnCleanup(t, ts)
 
 	body := bytes.NewBufferString(`{"integration":"oauth-svc","credential":"some-key"}`)
-	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", body)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/external-credentials/connect-manual", body)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -11325,7 +11377,7 @@ func TestConnectManual_MissingFields(t *testing.T) {
 	testutil.CloseOnCleanup(t, ts)
 
 	body := bytes.NewBufferString(`{}`)
-	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", body)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/external-credentials/connect-manual", body)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -11346,7 +11398,7 @@ func TestConnectManual_UnknownIntegration(t *testing.T) {
 	testutil.CloseOnCleanup(t, ts)
 
 	body := bytes.NewBufferString(`{"integration":"nonexistent","credential":"key"}`)
-	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", body)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/external-credentials/connect-manual", body)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -11370,7 +11422,7 @@ func TestStartOAuth_ManualProviderRejected(t *testing.T) {
 	testutil.CloseOnCleanup(t, ts)
 
 	body := bytes.NewBufferString(`{"integration":"manual-svc","scopes":[]}`)
-	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", body)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/external-credentials/start-oauth", body)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -11430,7 +11482,7 @@ func TestStartOAuth_MultiConnection_SelectsByConnectionName(t *testing.T) {
 	testutil.CloseOnCleanup(t, ts)
 
 	body := bytes.NewBufferString(`{"integration":"multi","connection":"conn-b"}`)
-	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", body)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/external-credentials/start-oauth", body)
 	req.Header.Set("X-Dev-User-Email", "dev@example.com")
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
@@ -11475,7 +11527,7 @@ func TestStartOAuth_MultiConnectionWithoutDefaultRequiresExplicitConnection(t *t
 	testutil.CloseOnCleanup(t, ts)
 
 	body := bytes.NewBufferString(`{"integration":"multi"}`)
-	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", body)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/external-credentials/start-oauth", body)
 	req.Header.Set("X-Dev-User-Email", "dev@example.com")
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
@@ -11517,7 +11569,7 @@ func TestStartOAuth_MissingConnection_FailsCleanly(t *testing.T) {
 	testutil.CloseOnCleanup(t, ts)
 
 	body := bytes.NewBufferString(`{"integration":"myint","connection":"nonexistent"}`)
-	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", body)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/external-credentials/start-oauth", body)
 	req.Header.Set("X-Dev-User-Email", "dev@example.com")
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
@@ -11579,7 +11631,7 @@ func TestOAuthCallback_UsesStateConnection(t *testing.T) {
 	testutil.CloseOnCleanup(t, ts)
 
 	startBody := bytes.NewBufferString(`{"integration":"multi","connection":"conn-b"}`)
-	startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", startBody)
+	startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/external-credentials/start-oauth", startBody)
 	startReq.Header.Set("X-Dev-User-Email", "dev@example.com")
 	startReq.Header.Set("Content-Type", "application/json")
 	startResp, err := http.DefaultClient.Do(startReq)
@@ -13677,7 +13729,7 @@ func TestConnectManual_MultiCredential(t *testing.T) {
 			})
 			testutil.CloseOnCleanup(t, ts)
 
-			req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", bytes.NewBufferString(tc.requestBody))
+			req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/external-credentials/connect-manual", bytes.NewBufferString(tc.requestBody))
 			req.Header.Set("Content-Type", "application/json")
 			resp, err := http.DefaultClient.Do(req)
 			if err != nil {
@@ -13730,7 +13782,7 @@ func TestConnectManual_ServiceAccountIDStoresCredentialForServiceAccount(t *test
 	})
 	testutil.CloseOnCleanup(t, ts)
 
-	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", bytes.NewBufferString(`{"integration":"manual-service-account","serviceAccountId":"service_account:manual-bot","credential":"manual-service-account-token"}`))
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/external-credentials/connect-manual", bytes.NewBufferString(`{"integration":"manual-service-account","serviceAccountId":"service_account:manual-bot","credential":"manual-service-account-token"}`))
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -13819,7 +13871,7 @@ func TestConnectManual_ServiceAccountIDAuthorizesInvokingSubjectNotCredentialSub
 	})
 	testutil.CloseOnCleanup(t, ts)
 
-	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", bytes.NewBufferString(`{"integration":"manual-service-account-invoker","serviceAccountId":"manual-bot","credential":"manual-service-account-token"}`))
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/external-credentials/connect-manual", bytes.NewBufferString(`{"integration":"manual-service-account-invoker","serviceAccountId":"manual-bot","credential":"manual-service-account-token"}`))
 	req.Header.Set("Authorization", "Bearer "+apiToken)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
@@ -13869,7 +13921,7 @@ func TestConnectManual_ServiceAccountIDRequiresManagesAuthorization(t *testing.T
 	})
 	testutil.CloseOnCleanup(t, ts)
 
-	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", bytes.NewBufferString(`{"integration":"manual-service-account-denied","serviceAccountId":"manual-bot","credential":"manual-service-account-token"}`))
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/external-credentials/connect-manual", bytes.NewBufferString(`{"integration":"manual-service-account-denied","serviceAccountId":"manual-bot","credential":"manual-service-account-token"}`))
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -13948,7 +14000,7 @@ func TestSelectPendingConnection_ServiceAccountIDRequiresManagesAuthorization(t 
 	})
 	testutil.CloseOnCleanup(t, ts)
 
-	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", bytes.NewBufferString(`{"integration":"manual-service-account-pending","serviceAccountId":"manual-bot","credential":"manual-service-account-token"}`))
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/external-credentials/connect-manual", bytes.NewBufferString(`{"integration":"manual-service-account-pending","serviceAccountId":"manual-bot","credential":"manual-service-account-token"}`))
 	req.Header.Set("Authorization", "Bearer session-token")
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
@@ -13976,7 +14028,7 @@ func TestSelectPendingConnection_ServiceAccountIDRequiresManagesAuthorization(t 
 		"pending_token":   {connectResp.PendingToken},
 		"candidate_index": {"0"},
 	}
-	selectReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/pending-connection", strings.NewReader(form.Encode()))
+	selectReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/external-credentials/pending-connection", strings.NewReader(form.Encode()))
 	selectReq.Header.Set("Authorization", "Bearer session-token")
 	selectReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	selectResp, err := http.DefaultClient.Do(selectReq)
@@ -14068,7 +14120,7 @@ func TestConnectManual_TokenExchange(t *testing.T) {
 		})
 		testutil.CloseOnCleanup(t, ts)
 
-		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", bytes.NewBufferString(`{"integration":"looker-like","credentials":{"client_id":"id-123","client_secret":"secret-456"}}`))
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/external-credentials/connect-manual", bytes.NewBufferString(`{"integration":"looker-like","credentials":{"client_id":"id-123","client_secret":"secret-456"}}`))
 		req.Header.Set("Content-Type", "application/json")
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
@@ -14165,7 +14217,7 @@ func TestConnectManual_TokenExchange(t *testing.T) {
 		})
 		testutil.CloseOnCleanup(t, ts)
 
-		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", bytes.NewBufferString(`{"integration":"json-token","credentials":{"client_id":"json-id","client_secret":"json-secret"}}`))
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/external-credentials/connect-manual", bytes.NewBufferString(`{"integration":"json-token","credentials":{"client_id":"json-id","client_secret":"json-secret"}}`))
 		req.Header.Set("Content-Type", "application/json")
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
@@ -14242,7 +14294,7 @@ func TestConnectManual_TokenExchange(t *testing.T) {
 		})
 		testutil.CloseOnCleanup(t, ts)
 
-		rawReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", bytes.NewBufferString(`{"integration":"fallback-token","credential":"raw-token"}`))
+		rawReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/external-credentials/connect-manual", bytes.NewBufferString(`{"integration":"fallback-token","credential":"raw-token"}`))
 		rawReq.Header.Set("Content-Type", "application/json")
 		rawResp, err := http.DefaultClient.Do(rawReq)
 		if err != nil {
@@ -14257,7 +14309,7 @@ func TestConnectManual_TokenExchange(t *testing.T) {
 			t.Fatalf("token endpoint calls after raw credential = %d, want 0", calls.Load())
 		}
 
-		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", bytes.NewBufferString(`{"integration":"fallback-token","credentials":{"client_id":"fallback-id","client_secret":"fallback-secret"}}`))
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/external-credentials/connect-manual", bytes.NewBufferString(`{"integration":"fallback-token","credentials":{"client_id":"fallback-id","client_secret":"fallback-secret"}}`))
 		req.Header.Set("Content-Type", "application/json")
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
@@ -14329,7 +14381,7 @@ func TestConnectManual_TokenExchange(t *testing.T) {
 				})
 				testutil.CloseOnCleanup(t, ts)
 
-				req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", bytes.NewBufferString(body))
+				req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/external-credentials/connect-manual", bytes.NewBufferString(body))
 				req.Header.Set("Content-Type", "application/json")
 				resp, err := http.DefaultClient.Do(req)
 				if err != nil {


### PR DESCRIPTION
## Description

Moves the external credential connection endpoints from `/api/v1/auth/*` to `/api/v1/external-credentials/*` while keeping the existing `/api/v1/auth/*` endpoints as legacy aliases. Updates CLI callers, docs, and tests.