### PR TITLE
[authorization] expose HTTP and CLI endpoints

### DIFF
--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -38,6 +38,12 @@ pub enum Commands {
         command: AuthCommands,
     },
 
+    /// Inspect and manage authorization state
+    Authorization {
+        #[command(subcommand)]
+        command: AuthorizationCommands,
+    },
+
     /// Manage persistent configuration
     Config {
         #[command(subcommand)]
@@ -199,6 +205,150 @@ pub enum TokenCommands {
         /// Token ID to revoke
         id: String,
     },
+}
+
+#[derive(Subcommand)]
+pub enum AuthorizationCommands {
+    /// Check whether a subject can perform an action on a resource
+    CheckAccess(AuthorizationCheckAccessArgs),
+    /// Inspect and manage authorization relationships
+    Relationships {
+        #[command(subcommand)]
+        command: AuthorizationRelationshipCommands,
+    },
+    /// Inspect authorization models
+    Models {
+        #[command(subcommand)]
+        command: AuthorizationModelCommands,
+    },
+}
+
+#[derive(Args)]
+pub struct AuthorizationCheckAccessArgs {
+    /// Subject identifier within the subject type
+    #[arg(long = "subject-id")]
+    pub subject_id: String,
+    /// Subject type/namespace, usually subject
+    #[arg(long = "subject-type")]
+    pub subject_type: String,
+    /// Action name to check
+    #[arg(long)]
+    pub action: String,
+    /// Resource identifier within the resource type
+    #[arg(long = "resource-id")]
+    pub resource_id: String,
+    /// Resource type on the relationship tuple
+    #[arg(long = "resource-type")]
+    pub resource_type: String,
+}
+
+#[derive(Subcommand)]
+pub enum AuthorizationRelationshipCommands {
+    /// List relationships
+    List(AuthorizationRelationshipListArgs),
+    /// Add a relationship from a JSON request file
+    Add(AuthorizationRelationshipAddArgs),
+    /// Delete a subject relationship
+    Delete(AuthorizationRelationshipDeleteArgs),
+}
+
+#[derive(Args)]
+pub struct AuthorizationRelationshipListArgs {
+    /// Filter by target subject id
+    #[arg(long = "subject-id")]
+    pub subject_id: Option<String>,
+    /// Filter by target subject type
+    #[arg(long = "subject-type")]
+    pub subject_type: Option<String>,
+    /// Filter to relationships with this relation name
+    #[arg(long)]
+    pub relation: Option<String>,
+    /// Resource type on the relationship tuple
+    #[arg(long = "resource-type")]
+    pub resource_type: Option<String>,
+    /// Filter to relationships whose resource has this id
+    #[arg(long = "resource-id")]
+    pub resource_id: Option<String>,
+    /// Filter by source layer, such as static_config or runtime
+    #[arg(long = "source-layer")]
+    pub source_layer: Option<String>,
+    /// Maximum number of relationships to return
+    #[arg(long = "page-size")]
+    pub page_size: Option<u32>,
+    /// Pagination cursor returned by a previous list response
+    #[arg(long = "page-token")]
+    pub page_token: Option<String>,
+    /// Optional path to a full ListRelationshipsRequest JSON file; use - to read from stdin
+    #[arg(long = "input-file")]
+    pub input_file: Option<String>,
+}
+
+#[derive(Args)]
+pub struct AuthorizationRelationshipAddArgs {
+    /// Required path to a full AddRelationshipRequest JSON file; use - to read from stdin
+    #[arg(long = "input-file")]
+    pub input_file: String,
+}
+
+#[derive(Args)]
+pub struct AuthorizationRelationshipDeleteArgs {
+    /// Target subject id
+    #[arg(long = "target-subject-id")]
+    pub target_subject_id: String,
+    /// Target subject type/namespace, usually subject
+    #[arg(long = "target-subject-type")]
+    pub target_subject_type: String,
+    /// Relation to delete from the resource
+    #[arg(long)]
+    pub relation: String,
+    /// Resource type on the relationship tuple
+    #[arg(long = "resource-type")]
+    pub resource_type: String,
+    /// Resource id on the relationship tuple
+    #[arg(long = "resource-id")]
+    pub resource_id: String,
+}
+
+#[derive(Subcommand)]
+pub enum AuthorizationModelCommands {
+    /// Inspect the active authorization model
+    Active {
+        #[command(subcommand)]
+        command: AuthorizationActiveModelCommands,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum AuthorizationActiveModelCommands {
+    /// Get the active model reference
+    Get,
+    /// List resource types in the active model
+    ResourceTypes {
+        #[command(subcommand)]
+        command: AuthorizationActiveModelResourceTypeCommands,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum AuthorizationActiveModelResourceTypeCommands {
+    /// List active model resource types
+    List(AuthorizationActiveModelResourceTypeListArgs),
+}
+
+#[derive(Args)]
+pub struct AuthorizationActiveModelResourceTypeListArgs {
+    /// Filter to one resource type name
+    #[arg(long)]
+    pub name: Option<String>,
+    /// Filter by source layer, such as static_config or runtime
+    #[arg(long = "source-layer")]
+    pub source_layer: Option<String>,
+    /// Maximum number of resource types to return
+    #[arg(long = "page-size")]
+    pub page_size: Option<u32>,
+    /// Pagination cursor returned by a previous list response
+    #[arg(long = "page-token")]
+    pub page_token: Option<String>,
 }
 #[derive(Subcommand)]
 pub enum WorkflowCommands {

--- a/gestalt/cli/src/commands/authorization.rs
+++ b/gestalt/cli/src/commands/authorization.rs
@@ -1,0 +1,222 @@
+use anyhow::{Context, Result};
+use serde_json::{Map, Value, json};
+
+use crate::api::ApiClient;
+use crate::cli::{
+    AuthorizationActiveModelCommands, AuthorizationActiveModelResourceTypeCommands,
+    AuthorizationCommands, AuthorizationModelCommands, AuthorizationRelationshipCommands,
+};
+use crate::output::{self, Format};
+use crate::params;
+use crate::query;
+
+const CHECK_ACCESS_PATH: &str = "/api/v1/authorization/check-access";
+const RELATIONSHIPS_PATH: &str = "/api/v1/authorization/relationships";
+const ACTIVE_MODEL_PATH: &str = "/api/v1/authorization/models/active";
+const ACTIVE_MODEL_RESOURCE_TYPES_PATH: &str = "/api/v1/authorization/models/active/resource-types";
+
+pub fn dispatch(client: &ApiClient, command: AuthorizationCommands, format: Format) -> Result<()> {
+    match command {
+        AuthorizationCommands::CheckAccess(args) => {
+            let body = json!({
+                "subject": {
+                    "type": args.subject_type,
+                    "id": args.subject_id,
+                },
+                "action": {
+                    "name": args.action,
+                },
+                "resource": {
+                    "type": args.resource_type,
+                    "id": args.resource_id,
+                },
+            });
+            let resp = client
+                .post(CHECK_ACCESS_PATH, &body)
+                .context("failed to check authorization access")?;
+            print_value(&resp, format);
+            Ok(())
+        }
+        AuthorizationCommands::Relationships { command } => match command {
+            AuthorizationRelationshipCommands::List(args) => {
+                let path = relationships_list_path(&args)?;
+                let resp = client
+                    .get(&path)
+                    .context("failed to list authorization relationships")?;
+                print_value(&resp, format);
+                Ok(())
+            }
+            AuthorizationRelationshipCommands::Add(args) => {
+                let body = Value::Object(params::load_input_file(&args.input_file)?);
+                let resp = client
+                    .post(RELATIONSHIPS_PATH, &body)
+                    .context("failed to add authorization relationship")?;
+                print_value(&resp, format);
+                Ok(())
+            }
+            AuthorizationRelationshipCommands::Delete(args) => {
+                let body = json!({
+                    "relationshipTuple": {
+                        "target": {
+                            "subject": {
+                                "type": args.target_subject_type,
+                                "id": args.target_subject_id,
+                            },
+                        },
+                        "relation": args.relation,
+                        "resource": {
+                            "type": args.resource_type,
+                            "id": args.resource_id,
+                        },
+                    },
+                });
+                let resp = client
+                    .delete_json(RELATIONSHIPS_PATH, &body)
+                    .context("failed to delete authorization relationship")?;
+                print_value(&resp, format);
+                Ok(())
+            }
+        },
+        AuthorizationCommands::Models { command } => match command {
+            AuthorizationModelCommands::Active { command } => match command {
+                AuthorizationActiveModelCommands::Get => {
+                    let resp = client
+                        .get(ACTIVE_MODEL_PATH)
+                        .context("failed to get active authorization model")?;
+                    print_value(&resp, format);
+                    Ok(())
+                }
+                AuthorizationActiveModelCommands::ResourceTypes { command } => match command {
+                    AuthorizationActiveModelResourceTypeCommands::List(args) => {
+                        let path = active_model_resource_types_path(
+                            args.name.as_deref(),
+                            args.source_layer.as_deref(),
+                            args.page_size,
+                            args.page_token.as_deref(),
+                        )?;
+                        let resp = client
+                            .get(&path)
+                            .context("failed to list active authorization model resource types")?;
+                        print_value(&resp, format);
+                        Ok(())
+                    }
+                },
+            },
+        },
+    }
+}
+
+fn relationships_list_path(args: &crate::cli::AuthorizationRelationshipListArgs) -> Result<String> {
+    let input = match args.input_file.as_deref() {
+        Some(path) => Some(Value::Object(params::load_input_file(path)?)),
+        None => None,
+    };
+    let mut params = Vec::new();
+    query::push_opt_param(
+        &mut params,
+        "subjectId",
+        args.subject_id
+            .as_deref()
+            .or_else(|| json_path_str(input.as_ref(), &["filter", "target", "subject", "id"])),
+    );
+    query::push_opt_param(
+        &mut params,
+        "subjectType",
+        args.subject_type
+            .as_deref()
+            .or_else(|| json_path_str(input.as_ref(), &["filter", "target", "subject", "type"])),
+    );
+    query::push_opt_param(
+        &mut params,
+        "relation",
+        args.relation
+            .as_deref()
+            .or_else(|| json_path_str(input.as_ref(), &["filter", "relation"])),
+    );
+    query::push_opt_param(
+        &mut params,
+        "resourceType",
+        args.resource_type
+            .as_deref()
+            .or_else(|| json_path_str(input.as_ref(), &["filter", "resourceType"]))
+            .or_else(|| json_path_str(input.as_ref(), &["filter", "resource", "type"])),
+    );
+    query::push_opt_param(
+        &mut params,
+        "resourceId",
+        args.resource_id
+            .as_deref()
+            .or_else(|| json_path_str(input.as_ref(), &["filter", "resource", "id"])),
+    );
+    query::push_opt_param(
+        &mut params,
+        "sourceLayer",
+        args.source_layer
+            .as_deref()
+            .or_else(|| json_path_str(input.as_ref(), &["filter", "sourceLayer"])),
+    );
+    query::push_opt_u32(
+        &mut params,
+        "pageSize",
+        args.page_size
+            .or_else(|| json_path_u32(input.as_ref(), &["pageSize"])),
+    );
+    query::push_opt_param(
+        &mut params,
+        "pageToken",
+        args.page_token
+            .as_deref()
+            .or_else(|| json_path_str(input.as_ref(), &["pageToken"])),
+    );
+    query::append_query(RELATIONSHIPS_PATH, &params)
+}
+
+fn active_model_resource_types_path(
+    name: Option<&str>,
+    source_layer: Option<&str>,
+    page_size: Option<u32>,
+    page_token: Option<&str>,
+) -> Result<String> {
+    let mut params = Vec::new();
+    query::push_opt_param(&mut params, "name", name);
+    query::push_opt_param(&mut params, "sourceLayer", source_layer);
+    query::push_opt_u32(&mut params, "pageSize", page_size);
+    query::push_opt_param(&mut params, "pageToken", page_token);
+    query::append_query(ACTIVE_MODEL_RESOURCE_TYPES_PATH, &params)
+}
+
+fn print_value(value: &Value, format: Format) {
+    match format {
+        Format::Json => output::print_json(value),
+        Format::Table => output::print_json_table(&table_value(value)),
+    }
+}
+
+fn table_value(value: &Value) -> Value {
+    if let Some(items) = value.get("relationships").and_then(Value::as_array) {
+        return Value::Array(items.clone());
+    }
+    if let Some(items) = value.get("resourceTypes").and_then(Value::as_array) {
+        return Value::Array(items.clone());
+    }
+    if let Some(model) = value.get("model").and_then(Value::as_object) {
+        return Value::Object(model.clone());
+    }
+    Value::Object(value.as_object().cloned().unwrap_or_else(Map::new))
+}
+
+fn json_path_str<'a>(value: Option<&'a Value>, path: &[&str]) -> Option<&'a str> {
+    let mut current = value?;
+    for segment in path {
+        current = current.get(*segment)?;
+    }
+    current.as_str()
+}
+
+fn json_path_u32(value: Option<&Value>, path: &[&str]) -> Option<u32> {
+    let mut current = value?;
+    for segment in path {
+        current = current.get(*segment)?;
+    }
+    current.as_u64().and_then(|value| u32::try_from(value).ok())
+}

--- a/gestalt/cli/src/commands/mod.rs
+++ b/gestalt/cli/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod agents;
 mod app_errors;
 pub mod apps;
 pub mod auth;
+pub mod authorization;
 pub mod config;
 pub mod describe;
 pub mod init;

--- a/gestalt/cli/src/main.rs
+++ b/gestalt/cli/src/main.rs
@@ -33,6 +33,10 @@ fn run() -> anyhow::Result<()> {
             ConfigCommands::Unset { key } => commands::config::unset(&key),
             ConfigCommands::List => commands::config::list(format),
         },
+        Commands::Authorization { command } => {
+            let client = ApiClient::from_env(url)?;
+            commands::authorization::dispatch(&client, command, format)
+        }
         Commands::App { command } => dispatch_app_command(command, url, format),
         Commands::Invoke(args) => dispatch_app_command(AppCommands::Invoke(args), url, format),
         Commands::Describe(args) => dispatch_app_command(AppCommands::Describe(args), url, format),

--- a/gestaltd/internal/server/authorization_api_test.go
+++ b/gestaltd/internal/server/authorization_api_test.go
@@ -1,0 +1,253 @@
+package server_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/server"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestAuthorizationAPICheckAccess(t *testing.T) {
+	authz := &authorizationAPITestProvider{}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Authorization = authz
+	})
+	defer ts.Close()
+
+	resp := doJSONRequest(t, http.MethodPost, ts.URL+"/api/v1/authorization/check-access", `{
+		"subject": {"type": "subject", "id": "user:alice"},
+		"action": {"name": "view"},
+		"resource": {"type": "group", "id": "engineering"}
+	}`)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	if got := authz.checkAccessRequest.GetSubject().GetId(); got != "user:alice" {
+		t.Fatalf("subject id = %q, want user:alice", got)
+	}
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["allowed"] != true || body["modelId"] != "model-1" {
+		t.Fatalf("response = %#v, want allowed true model-1", body)
+	}
+}
+
+func TestAuthorizationAPIListRelationships(t *testing.T) {
+	authz := &authorizationAPITestProvider{}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Authorization = authz
+	})
+	defer ts.Close()
+
+	resp := doJSONRequest(t, http.MethodGet, ts.URL+"/api/v1/authorization/relationships?subjectType=subject&subjectId=user%3Aalice&relation=member&resourceType=group&resourceId=engineering&sourceLayer=runtime&pageSize=25&pageToken=next", "")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	req := authz.listRelationshipsRequest
+	if req.GetPageSize() != 25 || req.GetPageToken() != "next" {
+		t.Fatalf("pagination = (%d, %q), want (25, next)", req.GetPageSize(), req.GetPageToken())
+	}
+	filter := req.GetFilter()
+	if filter.GetTarget().GetSubject().GetType() != "subject" || filter.GetTarget().GetSubject().GetId() != "user:alice" {
+		t.Fatalf("target subject = %#v", filter.GetTarget().GetSubject())
+	}
+	if filter.GetRelation() != "member" || filter.GetResource().GetType() != "group" || filter.GetResource().GetId() != "engineering" {
+		t.Fatalf("filter = %#v", filter)
+	}
+	if filter.GetSourceLayer() != proto.SourceLayer_SOURCE_LAYER_RUNTIME {
+		t.Fatalf("source layer = %v, want runtime", filter.GetSourceLayer())
+	}
+}
+
+func TestAuthorizationAPIAddRelationship(t *testing.T) {
+	authz := &authorizationAPITestProvider{}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Authorization = authz
+	})
+	defer ts.Close()
+
+	resp := doJSONRequest(t, http.MethodPost, ts.URL+"/api/v1/authorization/relationships", `{
+		"relationship": {
+			"tuple": {
+				"target": {"subject": {"type": "subject", "id": "user:alice"}},
+				"relation": "member",
+				"resource": {"type": "group", "id": "engineering"}
+			},
+			"sourceLayer": "SOURCE_LAYER_RUNTIME"
+		}
+	}`)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	if got := authz.addRelationshipRequest.GetRelationship().GetTuple().GetRelation(); got != "member" {
+		t.Fatalf("relation = %q, want member", got)
+	}
+}
+
+func TestAuthorizationAPIDeleteRelationship(t *testing.T) {
+	authz := &authorizationAPITestProvider{}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Authorization = authz
+	})
+	defer ts.Close()
+
+	resp := doJSONRequest(t, http.MethodDelete, ts.URL+"/api/v1/authorization/relationships", `{
+		"relationshipTuple": {
+			"target": {"subject": {"type": "subject", "id": "user:alice"}},
+			"relation": "member",
+			"resource": {"type": "group", "id": "engineering"}
+		}
+	}`)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	if got := authz.deleteRelationshipRequest.GetRelationshipTuple().GetResource().GetId(); got != "engineering" {
+		t.Fatalf("resource id = %q, want engineering", got)
+	}
+}
+
+func TestAuthorizationAPIGetActiveModelRef(t *testing.T) {
+	authz := &authorizationAPITestProvider{}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Authorization = authz
+	})
+	defer ts.Close()
+
+	resp := doJSONRequest(t, http.MethodGet, ts.URL+"/api/v1/authorization/models/active", "")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	var body map[string]map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["model"]["id"] != "model-1" || body["model"]["version"] != "v1" {
+		t.Fatalf("model = %#v, want model-1/v1", body["model"])
+	}
+}
+
+func TestAuthorizationAPIListActiveModelResourceTypes(t *testing.T) {
+	authz := &authorizationAPITestProvider{}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Authorization = authz
+	})
+	defer ts.Close()
+
+	resp := doJSONRequest(t, http.MethodGet, ts.URL+"/api/v1/authorization/models/active/resource-types?name=group&sourceLayer=static_config&pageSize=10&pageToken=next", "")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	req := authz.listResourceTypesRequest
+	if req.GetFilter().GetName() != "group" || req.GetFilter().GetSourceLayer() != proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG {
+		t.Fatalf("filter = %#v", req.GetFilter())
+	}
+	if req.GetPageSize() != 10 || req.GetPageToken() != "next" {
+		t.Fatalf("pagination = (%d, %q), want (10, next)", req.GetPageSize(), req.GetPageToken())
+	}
+}
+
+func doJSONRequest(t *testing.T, method, url, body string) *http.Response {
+	t.Helper()
+	var reader io.Reader
+	if strings.TrimSpace(body) != "" {
+		reader = bytes.NewBufferString(body)
+	}
+	req, err := http.NewRequest(method, url, reader)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if reader != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, url, err)
+	}
+	return resp
+}
+
+type authorizationAPITestProvider struct {
+	core.AuthorizationProvider
+
+	checkAccessRequest        *proto.CheckAccessRequest
+	listRelationshipsRequest  *proto.ListRelationshipsRequest
+	addRelationshipRequest    *proto.AddRelationshipRequest
+	deleteRelationshipRequest *proto.DeleteRelationshipRequest
+	listResourceTypesRequest  *proto.ListActiveModelResourceTypesRequest
+}
+
+func (p *authorizationAPITestProvider) CheckAccess(_ context.Context, req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
+	p.checkAccessRequest = req
+	return &proto.CheckAccessResponse{Allowed: true, ModelId: "model-1"}, nil
+}
+
+func (p *authorizationAPITestProvider) ListRelationships(_ context.Context, req *proto.ListRelationshipsRequest) (*proto.ListRelationshipsResponse, error) {
+	p.listRelationshipsRequest = req
+	return &proto.ListRelationshipsResponse{
+		Relationships: []*proto.Relationship{
+			{
+				Tuple: &proto.RelationshipTuple{
+					Target: &proto.RelationshipTarget{
+						Kind: &proto.RelationshipTarget_Subject{
+							Subject: &proto.Subject{Type: "subject", Id: "user:alice"},
+						},
+					},
+					Relation: "member",
+					Resource: &proto.Resource{Type: "group", Id: "engineering"},
+				},
+			},
+		},
+	}, nil
+}
+
+func (p *authorizationAPITestProvider) AddRelationship(_ context.Context, req *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {
+	p.addRelationshipRequest = req
+	return &proto.AddRelationshipResponse{Relationship: req.GetRelationship()}, nil
+}
+
+func (p *authorizationAPITestProvider) DeleteRelationship(_ context.Context, req *proto.DeleteRelationshipRequest) (*proto.DeleteRelationshipResponse, error) {
+	p.deleteRelationshipRequest = req
+	return &proto.DeleteRelationshipResponse{}, nil
+}
+
+func (p *authorizationAPITestProvider) GetActiveModelRef(context.Context) (*proto.GetActiveModelRefResponse, error) {
+	return &proto.GetActiveModelRefResponse{
+		Model: &proto.AuthorizationModelRef{
+			Id:        "model-1",
+			Version:   "v1",
+			CreatedAt: timestamppb.Now(),
+		},
+	}, nil
+}
+
+func (p *authorizationAPITestProvider) ListActiveModelResourceTypes(_ context.Context, req *proto.ListActiveModelResourceTypesRequest) (*proto.ListActiveModelResourceTypesResponse, error) {
+	p.listResourceTypesRequest = req
+	return &proto.ListActiveModelResourceTypesResponse{
+		ModelId: "model-1",
+		ResourceTypes: []*proto.AuthorizationModelResourceType{
+			{Name: "group", SourceLayer: proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG},
+		},
+	}, nil
+}

--- a/gestaltd/internal/server/handlers_authorization.go
+++ b/gestaltd/internal/server/handlers_authorization.go
@@ -1,0 +1,268 @@
+package server
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+	gproto "google.golang.org/protobuf/proto"
+)
+
+func (s *Server) checkAuthorizationAccess(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAuthorizationProvider(w) {
+		return
+	}
+	var req proto.CheckAccessRequest
+	if !decodeProtoJSONBody(w, r, &req) {
+		return
+	}
+	resp, err := s.authorization.CheckAccess(r.Context(), &req)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeProtoJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) listAuthorizationRelationships(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAuthorizationProvider(w) {
+		return
+	}
+	req, ok := listAuthorizationRelationshipsRequestFromQuery(w, r)
+	if !ok {
+		return
+	}
+	resp, err := s.authorization.ListRelationships(r.Context(), req)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeProtoJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) addAuthorizationRelationship(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAuthorizationProvider(w) {
+		return
+	}
+	var req proto.AddRelationshipRequest
+	if !decodeProtoJSONBody(w, r, &req) {
+		return
+	}
+	resp, err := s.authorization.AddRelationship(r.Context(), &req)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeProtoJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) deleteAuthorizationRelationship(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAuthorizationProvider(w) {
+		return
+	}
+	var req proto.DeleteRelationshipRequest
+	if !decodeProtoJSONBody(w, r, &req) {
+		return
+	}
+	resp, err := s.authorization.DeleteRelationship(r.Context(), &req)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeProtoJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) getAuthorizationActiveModelRef(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAuthorizationProvider(w) {
+		return
+	}
+	resp, err := s.authorization.GetActiveModelRef(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeProtoJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) listAuthorizationActiveModelResourceTypes(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAuthorizationProvider(w) {
+		return
+	}
+	req, ok := listAuthorizationActiveModelResourceTypesRequestFromQuery(w, r)
+	if !ok {
+		return
+	}
+	resp, err := s.authorization.ListActiveModelResourceTypes(r.Context(), req)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeProtoJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) requireAuthorizationProvider(w http.ResponseWriter) bool {
+	if s.authorization == nil {
+		writeError(w, http.StatusPreconditionFailed, "authorization provider is not configured")
+		return false
+	}
+	return true
+}
+
+func decodeProtoJSONBody(w http.ResponseWriter, r *http.Request, msg gproto.Message) bool {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "failed to read request body")
+		return false
+	}
+	if len(strings.TrimSpace(string(body))) == 0 {
+		writeError(w, http.StatusBadRequest, "request body is required")
+		return false
+	}
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: false}).Unmarshal(body, msg); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return false
+	}
+	return true
+}
+
+func writeProtoJSON(w http.ResponseWriter, status int, msg gproto.Message) {
+	body, err := protojson.MarshalOptions{EmitUnpopulated: false}.Marshal(msg)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to encode response")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write(body)
+	_, _ = w.Write([]byte("\n"))
+}
+
+func listAuthorizationRelationshipsRequestFromQuery(w http.ResponseWriter, r *http.Request) (*proto.ListRelationshipsRequest, bool) {
+	query := r.URL.Query()
+	pageSize, ok := parseOptionalInt32Query(w, queryValue(query, "pageSize", "page_size"), "pageSize")
+	if !ok {
+		return nil, false
+	}
+	targetType, ok := relationshipTargetTypeFromQuery(w, queryValue(query, "targetType", "target_type"))
+	if !ok {
+		return nil, false
+	}
+	sourceLayer, ok := sourceLayerFromQuery(w, queryValue(query, "sourceLayer", "source_layer"))
+	if !ok {
+		return nil, false
+	}
+
+	filter := &proto.RelationshipFilter{
+		Relation:         strings.TrimSpace(query.Get("relation")),
+		TargetType:       targetType,
+		TargetEntityType: strings.TrimSpace(queryValue(query, "targetEntityType", "target_entity_type")),
+		ResourceType:     strings.TrimSpace(queryValue(query, "resourceType", "resource_type")),
+		SourceLayer:      sourceLayer,
+	}
+	if subjectID := strings.TrimSpace(queryValue(query, "subjectId", "subject_id", "targetSubjectId", "target_subject_id")); subjectID != "" {
+		filter.Target = &proto.RelationshipTarget{
+			Kind: &proto.RelationshipTarget_Subject{
+				Subject: &proto.Subject{
+					Type: strings.TrimSpace(queryValue(query, "subjectType", "subject_type", "targetSubjectType", "target_subject_type")),
+					Id:   subjectID,
+				},
+			},
+		}
+	}
+	if resourceID := strings.TrimSpace(queryValue(query, "resourceId", "resource_id")); resourceID != "" || filter.ResourceType != "" {
+		filter.Resource = &proto.Resource{
+			Type: firstNonEmpty(filter.ResourceType, strings.TrimSpace(queryValue(query, "resourceType", "resource_type"))),
+			Id:   resourceID,
+		}
+	}
+
+	return &proto.ListRelationshipsRequest{
+		Filter:    filter,
+		PageSize:  pageSize,
+		PageToken: strings.TrimSpace(queryValue(query, "pageToken", "page_token")),
+	}, true
+}
+
+func listAuthorizationActiveModelResourceTypesRequestFromQuery(w http.ResponseWriter, r *http.Request) (*proto.ListActiveModelResourceTypesRequest, bool) {
+	query := r.URL.Query()
+	pageSize, ok := parseOptionalInt32Query(w, queryValue(query, "pageSize", "page_size"), "pageSize")
+	if !ok {
+		return nil, false
+	}
+	sourceLayer, ok := sourceLayerFromQuery(w, queryValue(query, "sourceLayer", "source_layer"))
+	if !ok {
+		return nil, false
+	}
+	return &proto.ListActiveModelResourceTypesRequest{
+		Filter: &proto.AuthorizationModelResourceTypeFilter{
+			Name:        strings.TrimSpace(query.Get("name")),
+			SourceLayer: sourceLayer,
+		},
+		PageSize:  pageSize,
+		PageToken: strings.TrimSpace(queryValue(query, "pageToken", "page_token")),
+	}, true
+}
+
+func parseOptionalInt32Query(w http.ResponseWriter, raw, name string) (int32, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0, true
+	}
+	value, err := strconv.ParseInt(raw, 10, 32)
+	if err != nil || value < 0 {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("%s must be a non-negative integer", name))
+		return 0, false
+	}
+	return int32(value), true
+}
+
+func relationshipTargetTypeFromQuery(w http.ResponseWriter, raw string) (proto.RelationshipTargetType, bool) {
+	switch normalizeEnumQuery(raw) {
+	case "":
+		return proto.RelationshipTargetType_RELATIONSHIP_TARGET_TYPE_UNSPECIFIED, true
+	case "subject":
+		return proto.RelationshipTargetType_RELATIONSHIP_TARGET_TYPE_SUBJECT, true
+	case "resource":
+		return proto.RelationshipTargetType_RELATIONSHIP_TARGET_TYPE_RESOURCE, true
+	case "subject_set", "subjectset":
+		return proto.RelationshipTargetType_RELATIONSHIP_TARGET_TYPE_SUBJECT_SET, true
+	default:
+		writeError(w, http.StatusBadRequest, "targetType must be subject, resource, or subject_set")
+		return proto.RelationshipTargetType_RELATIONSHIP_TARGET_TYPE_UNSPECIFIED, false
+	}
+}
+
+func sourceLayerFromQuery(w http.ResponseWriter, raw string) (proto.SourceLayer, bool) {
+	switch normalizeEnumQuery(raw) {
+	case "":
+		return proto.SourceLayer_SOURCE_LAYER_UNSPECIFIED, true
+	case "static_config", "staticconfig":
+		return proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG, true
+	case "runtime":
+		return proto.SourceLayer_SOURCE_LAYER_RUNTIME, true
+	default:
+		writeError(w, http.StatusBadRequest, "sourceLayer must be static_config or runtime")
+		return proto.SourceLayer_SOURCE_LAYER_UNSPECIFIED, false
+	}
+}
+
+func normalizeEnumQuery(raw string) string {
+	raw = strings.TrimSpace(strings.ToLower(raw))
+	raw = strings.TrimPrefix(raw, "relationship_target_type_")
+	raw = strings.TrimPrefix(raw, "source_layer_")
+	raw = strings.ReplaceAll(raw, "-", "_")
+	return raw
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -54,6 +54,12 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 		r.Delete("/tokens", s.revokeAllAPITokens)
 		r.Delete("/tokens/{id}", s.revokeAPIToken)
 
+		r.Post("/authorization/check-access", s.checkAuthorizationAccess)
+		r.Get("/authorization/relationships", s.listAuthorizationRelationships)
+		r.Post("/authorization/relationships", s.addAuthorizationRelationship)
+		r.Delete("/authorization/relationships", s.deleteAuthorizationRelationship)
+		r.Get("/authorization/models/active", s.getAuthorizationActiveModelRef)
+		r.Get("/authorization/models/active/resource-types", s.listAuthorizationActiveModelResourceTypes)
 	})
 
 	r.With(s.pluginRouteAuthMiddleware("name")).Get("/apps/{name}/operations", s.listOperations)


### PR DESCRIPTION
## Description

Adds authenticated authorization provider HTTP endpoints and matching `gestalt authorization` CLI commands for access checks, relationship management, and active model inspection.