### PR TITLE
[authorization] expose HTTP and CLI endpoints

### DIFF
--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -249,6 +249,8 @@ pub enum AuthorizationRelationshipCommands {
     List(AuthorizationRelationshipListArgs),
     /// Add a relationship from a JSON request file
     Add(AuthorizationRelationshipAddArgs),
+    /// Delete a subject relationship
+    Delete(AuthorizationRelationshipDeleteArgs),
 }
 
 #[derive(Args)]
@@ -287,6 +289,25 @@ pub struct AuthorizationRelationshipAddArgs {
     /// Required path to a full AddRelationshipRequest JSON file; use - to read from stdin
     #[arg(long = "input-file")]
     pub input_file: String,
+}
+
+#[derive(Args)]
+pub struct AuthorizationRelationshipDeleteArgs {
+    /// Target subject id
+    #[arg(long = "target-subject-id")]
+    pub target_subject_id: String,
+    /// Target subject type/namespace, usually subject
+    #[arg(long = "target-subject-type")]
+    pub target_subject_type: String,
+    /// Relation to delete from the resource
+    #[arg(long)]
+    pub relation: String,
+    /// Resource type on the relationship tuple
+    #[arg(long = "resource-type")]
+    pub resource_type: String,
+    /// Resource id on the relationship tuple
+    #[arg(long = "resource-id")]
+    pub resource_id: String,
 }
 #[derive(Subcommand)]
 pub enum WorkflowCommands {

--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -247,6 +247,8 @@ pub struct AuthorizationCheckAccessArgs {
 pub enum AuthorizationRelationshipCommands {
     /// List relationships
     List(AuthorizationRelationshipListArgs),
+    /// Add a relationship from a JSON request file
+    Add(AuthorizationRelationshipAddArgs),
 }
 
 #[derive(Args)]
@@ -278,6 +280,13 @@ pub struct AuthorizationRelationshipListArgs {
     /// Optional path to a full ListRelationshipsRequest JSON file; use - to read from stdin
     #[arg(long = "input-file")]
     pub input_file: Option<String>,
+}
+
+#[derive(Args)]
+pub struct AuthorizationRelationshipAddArgs {
+    /// Required path to a full AddRelationshipRequest JSON file; use - to read from stdin
+    #[arg(long = "input-file")]
+    pub input_file: String,
 }
 #[derive(Subcommand)]
 pub enum WorkflowCommands {

--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -252,10 +252,6 @@ pub struct AuthorizationCheckAccessArgs {
 pub enum AuthorizationRelationshipCommands {
     /// List relationships
     List(AuthorizationRelationshipListArgs),
-    /// Add a relationship from a JSON request file
-    Add(AuthorizationRelationshipAddArgs),
-    /// Delete a subject relationship
-    Delete(AuthorizationRelationshipDeleteArgs),
 }
 
 #[derive(Args)]
@@ -287,32 +283,6 @@ pub struct AuthorizationRelationshipListArgs {
     /// Optional path to a full ListRelationshipsRequest JSON file; use - to read from stdin
     #[arg(long = "input-file")]
     pub input_file: Option<String>,
-}
-
-#[derive(Args)]
-pub struct AuthorizationRelationshipAddArgs {
-    /// Required path to a full AddRelationshipRequest JSON file; use - to read from stdin
-    #[arg(long = "input-file")]
-    pub input_file: String,
-}
-
-#[derive(Args)]
-pub struct AuthorizationRelationshipDeleteArgs {
-    /// Target subject id
-    #[arg(long = "target-subject-id")]
-    pub target_subject_id: String,
-    /// Target subject type/namespace, usually subject
-    #[arg(long = "target-subject-type")]
-    pub target_subject_type: String,
-    /// Relation to delete from the resource
-    #[arg(long)]
-    pub relation: String,
-    /// Resource type on the relationship tuple
-    #[arg(long = "resource-type")]
-    pub resource_type: String,
-    /// Resource id on the relationship tuple
-    #[arg(long = "resource-id")]
-    pub resource_id: String,
 }
 
 #[derive(Subcommand)]

--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -280,9 +280,6 @@ pub struct AuthorizationRelationshipListArgs {
     /// Pagination cursor returned by a previous list response
     #[arg(long = "page-token")]
     pub page_token: Option<String>,
-    /// Optional path to a full ListRelationshipsRequest JSON file; use - to read from stdin
-    #[arg(long = "input-file")]
-    pub input_file: Option<String>,
 }
 
 #[derive(Subcommand)]

--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -38,6 +38,12 @@ pub enum Commands {
         command: AuthCommands,
     },
 
+    /// Inspect and manage authorization state
+    Authorization {
+        #[command(subcommand)]
+        command: AuthorizationCommands,
+    },
+
     /// Manage persistent configuration
     Config {
         #[command(subcommand)]
@@ -205,6 +211,31 @@ pub enum TokenCommands {
         /// Token ID to revoke
         id: String,
     },
+}
+
+#[derive(Subcommand)]
+pub enum AuthorizationCommands {
+    /// Check whether a subject can perform an action on a resource
+    CheckAccess(AuthorizationCheckAccessArgs),
+}
+
+#[derive(Args)]
+pub struct AuthorizationCheckAccessArgs {
+    /// Subject identifier within the subject type
+    #[arg(long = "subject-id")]
+    pub subject_id: String,
+    /// Subject type/namespace, usually subject
+    #[arg(long = "subject-type")]
+    pub subject_type: String,
+    /// Action name to check
+    #[arg(long)]
+    pub action: String,
+    /// Resource identifier within the resource type
+    #[arg(long = "resource-id")]
+    pub resource_id: String,
+    /// Resource type on the relationship tuple
+    #[arg(long = "resource-type")]
+    pub resource_type: String,
 }
 #[derive(Subcommand)]
 pub enum WorkflowCommands {

--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -217,6 +217,11 @@ pub enum TokenCommands {
 pub enum AuthorizationCommands {
     /// Check whether a subject can perform an action on a resource
     CheckAccess(AuthorizationCheckAccessArgs),
+    /// Inspect and manage authorization relationships
+    Relationships {
+        #[command(subcommand)]
+        command: AuthorizationRelationshipCommands,
+    },
 }
 
 #[derive(Args)]
@@ -236,6 +241,43 @@ pub struct AuthorizationCheckAccessArgs {
     /// Resource type on the relationship tuple
     #[arg(long = "resource-type")]
     pub resource_type: String,
+}
+
+#[derive(Subcommand)]
+pub enum AuthorizationRelationshipCommands {
+    /// List relationships
+    List(AuthorizationRelationshipListArgs),
+}
+
+#[derive(Args)]
+pub struct AuthorizationRelationshipListArgs {
+    /// Filter by target subject id
+    #[arg(long = "subject-id")]
+    pub subject_id: Option<String>,
+    /// Filter by target subject type
+    #[arg(long = "subject-type")]
+    pub subject_type: Option<String>,
+    /// Filter to relationships with this relation name
+    #[arg(long)]
+    pub relation: Option<String>,
+    /// Resource type on the relationship tuple
+    #[arg(long = "resource-type")]
+    pub resource_type: Option<String>,
+    /// Filter to relationships whose resource has this id
+    #[arg(long = "resource-id")]
+    pub resource_id: Option<String>,
+    /// Filter by source layer, such as static_config or runtime
+    #[arg(long = "source-layer")]
+    pub source_layer: Option<String>,
+    /// Maximum number of relationships to return
+    #[arg(long = "page-size")]
+    pub page_size: Option<u32>,
+    /// Pagination cursor returned by a previous list response
+    #[arg(long = "page-token")]
+    pub page_token: Option<String>,
+    /// Optional path to a full ListRelationshipsRequest JSON file; use - to read from stdin
+    #[arg(long = "input-file")]
+    pub input_file: Option<String>,
 }
 #[derive(Subcommand)]
 pub enum WorkflowCommands {

--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -257,19 +257,19 @@ pub enum AuthorizationRelationshipCommands {
 #[derive(Args)]
 pub struct AuthorizationRelationshipListArgs {
     /// Filter by target subject id
-    #[arg(long = "subject-id")]
+    #[arg(long = "subject-id", requires = "subject_type")]
     pub subject_id: Option<String>,
     /// Filter by target subject type
-    #[arg(long = "subject-type")]
+    #[arg(long = "subject-type", requires = "subject_id")]
     pub subject_type: Option<String>,
     /// Filter to relationships with this relation name
     #[arg(long)]
     pub relation: Option<String>,
     /// Resource type on the relationship tuple
-    #[arg(long = "resource-type")]
+    #[arg(long = "resource-type", requires = "resource_id")]
     pub resource_type: Option<String>,
     /// Filter to relationships whose resource has this id
-    #[arg(long = "resource-id")]
+    #[arg(long = "resource-id", requires = "resource_type")]
     pub resource_id: Option<String>,
     /// Filter by source layer, such as static_config or runtime
     #[arg(long = "source-layer")]

--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -328,6 +328,33 @@ pub enum AuthorizationModelCommands {
 pub enum AuthorizationActiveModelCommands {
     /// Get the active model reference
     Get,
+    /// List resource types in the active model
+    ResourceTypes {
+        #[command(subcommand)]
+        command: AuthorizationActiveModelResourceTypeCommands,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum AuthorizationActiveModelResourceTypeCommands {
+    /// List active model resource types
+    List(AuthorizationActiveModelResourceTypeListArgs),
+}
+
+#[derive(Args)]
+pub struct AuthorizationActiveModelResourceTypeListArgs {
+    /// Filter to one resource type name
+    #[arg(long)]
+    pub name: Option<String>,
+    /// Filter by source layer, such as static_config or runtime
+    #[arg(long = "source-layer")]
+    pub source_layer: Option<String>,
+    /// Maximum number of resource types to return
+    #[arg(long = "page-size")]
+    pub page_size: Option<u32>,
+    /// Pagination cursor returned by a previous list response
+    #[arg(long = "page-token")]
+    pub page_token: Option<String>,
 }
 #[derive(Subcommand)]
 pub enum WorkflowCommands {

--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -222,6 +222,11 @@ pub enum AuthorizationCommands {
         #[command(subcommand)]
         command: AuthorizationRelationshipCommands,
     },
+    /// Inspect authorization models
+    Models {
+        #[command(subcommand)]
+        command: AuthorizationModelCommands,
+    },
 }
 
 #[derive(Args)]
@@ -308,6 +313,21 @@ pub struct AuthorizationRelationshipDeleteArgs {
     /// Resource id on the relationship tuple
     #[arg(long = "resource-id")]
     pub resource_id: String,
+}
+
+#[derive(Subcommand)]
+pub enum AuthorizationModelCommands {
+    /// Inspect the active authorization model
+    Active {
+        #[command(subcommand)]
+        command: AuthorizationActiveModelCommands,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum AuthorizationActiveModelCommands {
+    /// Get the active model reference
+    Get,
 }
 #[derive(Subcommand)]
 pub enum WorkflowCommands {

--- a/gestalt/cli/src/commands/authorization.rs
+++ b/gestalt/cli/src/commands/authorization.rs
@@ -7,7 +7,6 @@ use crate::cli::{
     AuthorizationCommands, AuthorizationModelCommands, AuthorizationRelationshipCommands,
 };
 use crate::output::{self, Format};
-use crate::params;
 use crate::query;
 
 const CHECK_ACCESS_PATH: &str = "/api/v1/authorization/check-access";
@@ -77,78 +76,16 @@ pub fn dispatch(client: &ApiClient, command: AuthorizationCommands, format: Form
 }
 
 fn relationships_list_path(args: &crate::cli::AuthorizationRelationshipListArgs) -> Result<String> {
-    let input = match args.input_file.as_deref() {
-        Some(path) => Some(Value::Object(params::load_input_file(path)?)),
-        None => None,
-    };
-    let subject_id = args
-        .subject_id
-        .as_deref()
-        .or_else(|| json_path_str(input.as_ref(), &["filter", "target", "subject", "id"]));
-    let subject_type = args
-        .subject_type
-        .as_deref()
-        .or_else(|| json_path_str(input.as_ref(), &["filter", "target", "subject", "type"]));
-    validate_pair(
-        subject_type,
-        subject_id,
-        "subjectType and subjectId must be provided together",
-    )?;
-    let resource_type = args
-        .resource_type
-        .as_deref()
-        .or_else(|| json_path_str(input.as_ref(), &["filter", "resourceType"]))
-        .or_else(|| json_path_str(input.as_ref(), &["filter", "resource", "type"]));
-    let resource_id = args
-        .resource_id
-        .as_deref()
-        .or_else(|| json_path_str(input.as_ref(), &["filter", "resource", "id"]));
-    validate_pair(
-        resource_type,
-        resource_id,
-        "resourceType and resourceId must be provided together",
-    )?;
-
     let mut params = Vec::new();
-    query::push_opt_param(&mut params, "subjectId", subject_id);
-    query::push_opt_param(&mut params, "subjectType", subject_type);
-    query::push_opt_param(
-        &mut params,
-        "relation",
-        args.relation
-            .as_deref()
-            .or_else(|| json_path_str(input.as_ref(), &["filter", "relation"])),
-    );
-    query::push_opt_param(&mut params, "resourceType", resource_type);
-    query::push_opt_param(&mut params, "resourceId", resource_id);
-    query::push_opt_param(
-        &mut params,
-        "sourceLayer",
-        args.source_layer
-            .as_deref()
-            .or_else(|| json_path_str(input.as_ref(), &["filter", "sourceLayer"])),
-    );
-    query::push_opt_u32(
-        &mut params,
-        "pageSize",
-        args.page_size
-            .or_else(|| json_path_u32(input.as_ref(), &["pageSize"])),
-    );
-    query::push_opt_param(
-        &mut params,
-        "pageToken",
-        args.page_token
-            .as_deref()
-            .or_else(|| json_path_str(input.as_ref(), &["pageToken"])),
-    );
+    query::push_opt_param(&mut params, "subjectId", args.subject_id.as_deref());
+    query::push_opt_param(&mut params, "subjectType", args.subject_type.as_deref());
+    query::push_opt_param(&mut params, "relation", args.relation.as_deref());
+    query::push_opt_param(&mut params, "resourceType", args.resource_type.as_deref());
+    query::push_opt_param(&mut params, "resourceId", args.resource_id.as_deref());
+    query::push_opt_param(&mut params, "sourceLayer", args.source_layer.as_deref());
+    query::push_opt_u32(&mut params, "pageSize", args.page_size);
+    query::push_opt_param(&mut params, "pageToken", args.page_token.as_deref());
     query::append_query(RELATIONSHIPS_PATH, &params)
-}
-
-fn validate_pair(left: Option<&str>, right: Option<&str>, message: &str) -> Result<()> {
-    if left.is_some() != right.is_some() {
-        anyhow::bail!("{message}");
-    }
-    Ok(())
 }
 
 fn active_model_resource_types_path(
@@ -209,27 +146,11 @@ fn model_id(value: &Value) -> Option<&str> {
         .filter(|model_id| !model_id.is_empty())
 }
 
-fn json_path_str<'a>(value: Option<&'a Value>, path: &[&str]) -> Option<&'a str> {
-    let mut current = value?;
-    for segment in path {
-        current = current.get(*segment)?;
-    }
-    current.as_str()
-}
-
-fn json_path_u32(value: Option<&Value>, path: &[&str]) -> Option<u32> {
-    let mut current = value?;
-    for segment in path {
-        current = current.get(*segment)?;
-    }
-    current.as_u64().and_then(|value| u32::try_from(value).ok())
-}
-
 #[cfg(test)]
 mod tests {
     use serde_json::json;
 
-    use super::{model_id, next_page_token, validate_pair};
+    use super::{model_id, next_page_token};
 
     #[test]
     fn next_page_token_returns_trimmed_non_empty_token() {
@@ -250,17 +171,5 @@ mod tests {
         let value = json!({"modelId": " model-1 "});
 
         assert_eq!(model_id(&value), Some("model-1"));
-    }
-
-    #[test]
-    fn validate_pair_accepts_absent_or_complete_pairs() {
-        assert!(validate_pair(None, None, "missing pair").is_ok());
-        assert!(validate_pair(Some("type"), Some("id"), "missing pair").is_ok());
-    }
-
-    #[test]
-    fn validate_pair_rejects_partial_pairs() {
-        assert!(validate_pair(Some("type"), None, "missing pair").is_err());
-        assert!(validate_pair(None, Some("id"), "missing pair").is_err());
     }
 }

--- a/gestalt/cli/src/commands/authorization.rs
+++ b/gestalt/cli/src/commands/authorization.rs
@@ -81,21 +81,37 @@ fn relationships_list_path(args: &crate::cli::AuthorizationRelationshipListArgs)
         Some(path) => Some(Value::Object(params::load_input_file(path)?)),
         None => None,
     };
+    let subject_id = args
+        .subject_id
+        .as_deref()
+        .or_else(|| json_path_str(input.as_ref(), &["filter", "target", "subject", "id"]));
+    let subject_type = args
+        .subject_type
+        .as_deref()
+        .or_else(|| json_path_str(input.as_ref(), &["filter", "target", "subject", "type"]));
+    validate_pair(
+        subject_type,
+        subject_id,
+        "subjectType and subjectId must be provided together",
+    )?;
+    let resource_type = args
+        .resource_type
+        .as_deref()
+        .or_else(|| json_path_str(input.as_ref(), &["filter", "resourceType"]))
+        .or_else(|| json_path_str(input.as_ref(), &["filter", "resource", "type"]));
+    let resource_id = args
+        .resource_id
+        .as_deref()
+        .or_else(|| json_path_str(input.as_ref(), &["filter", "resource", "id"]));
+    validate_pair(
+        resource_type,
+        resource_id,
+        "resourceType and resourceId must be provided together",
+    )?;
+
     let mut params = Vec::new();
-    query::push_opt_param(
-        &mut params,
-        "subjectId",
-        args.subject_id
-            .as_deref()
-            .or_else(|| json_path_str(input.as_ref(), &["filter", "target", "subject", "id"])),
-    );
-    query::push_opt_param(
-        &mut params,
-        "subjectType",
-        args.subject_type
-            .as_deref()
-            .or_else(|| json_path_str(input.as_ref(), &["filter", "target", "subject", "type"])),
-    );
+    query::push_opt_param(&mut params, "subjectId", subject_id);
+    query::push_opt_param(&mut params, "subjectType", subject_type);
     query::push_opt_param(
         &mut params,
         "relation",
@@ -103,21 +119,8 @@ fn relationships_list_path(args: &crate::cli::AuthorizationRelationshipListArgs)
             .as_deref()
             .or_else(|| json_path_str(input.as_ref(), &["filter", "relation"])),
     );
-    query::push_opt_param(
-        &mut params,
-        "resourceType",
-        args.resource_type
-            .as_deref()
-            .or_else(|| json_path_str(input.as_ref(), &["filter", "resourceType"]))
-            .or_else(|| json_path_str(input.as_ref(), &["filter", "resource", "type"])),
-    );
-    query::push_opt_param(
-        &mut params,
-        "resourceId",
-        args.resource_id
-            .as_deref()
-            .or_else(|| json_path_str(input.as_ref(), &["filter", "resource", "id"])),
-    );
+    query::push_opt_param(&mut params, "resourceType", resource_type);
+    query::push_opt_param(&mut params, "resourceId", resource_id);
     query::push_opt_param(
         &mut params,
         "sourceLayer",
@@ -139,6 +142,13 @@ fn relationships_list_path(args: &crate::cli::AuthorizationRelationshipListArgs)
             .or_else(|| json_path_str(input.as_ref(), &["pageToken"])),
     );
     query::append_query(RELATIONSHIPS_PATH, &params)
+}
+
+fn validate_pair(left: Option<&str>, right: Option<&str>, message: &str) -> Result<()> {
+    if left.is_some() != right.is_some() {
+        anyhow::bail!("{message}");
+    }
+    Ok(())
 }
 
 fn active_model_resource_types_path(
@@ -219,7 +229,7 @@ fn json_path_u32(value: Option<&Value>, path: &[&str]) -> Option<u32> {
 mod tests {
     use serde_json::json;
 
-    use super::{model_id, next_page_token};
+    use super::{model_id, next_page_token, validate_pair};
 
     #[test]
     fn next_page_token_returns_trimmed_non_empty_token() {
@@ -240,5 +250,17 @@ mod tests {
         let value = json!({"modelId": " model-1 "});
 
         assert_eq!(model_id(&value), Some("model-1"));
+    }
+
+    #[test]
+    fn validate_pair_accepts_absent_or_complete_pairs() {
+        assert!(validate_pair(None, None, "missing pair").is_ok());
+        assert!(validate_pair(Some("type"), Some("id"), "missing pair").is_ok());
+    }
+
+    #[test]
+    fn validate_pair_rejects_partial_pairs() {
+        assert!(validate_pair(Some("type"), None, "missing pair").is_err());
+        assert!(validate_pair(None, Some("id"), "missing pair").is_err());
     }
 }

--- a/gestalt/cli/src/commands/authorization.rs
+++ b/gestalt/cli/src/commands/authorization.rs
@@ -2,13 +2,17 @@ use anyhow::{Context, Result};
 use serde_json::{Value, json};
 
 use crate::api::ApiClient;
-use crate::cli::{AuthorizationCommands, AuthorizationRelationshipCommands};
+use crate::cli::{
+    AuthorizationActiveModelCommands, AuthorizationCommands, AuthorizationModelCommands,
+    AuthorizationRelationshipCommands,
+};
 use crate::output::{self, Format};
 use crate::params;
 use crate::query;
 
 const CHECK_ACCESS_PATH: &str = "/api/v1/authorization/check-access";
 const RELATIONSHIPS_PATH: &str = "/api/v1/authorization/relationships";
+const ACTIVE_MODEL_PATH: &str = "/api/v1/authorization/models/active";
 
 pub fn dispatch(client: &ApiClient, command: AuthorizationCommands, format: Format) -> Result<()> {
     match command {
@@ -71,6 +75,17 @@ pub fn dispatch(client: &ApiClient, command: AuthorizationCommands, format: Form
                 print_value(&resp, format);
                 Ok(())
             }
+        },
+        AuthorizationCommands::Models { command } => match command {
+            AuthorizationModelCommands::Active { command } => match command {
+                AuthorizationActiveModelCommands::Get => {
+                    let resp = client
+                        .get(ACTIVE_MODEL_PATH)
+                        .context("failed to get active authorization model")?;
+                    print_value(&resp, format);
+                    Ok(())
+                }
+            },
         },
     }
 }
@@ -150,6 +165,9 @@ fn print_value(value: &Value, format: Format) {
 fn table_value(value: &Value) -> Value {
     if let Some(items) = value.get("relationships").and_then(Value::as_array) {
         return Value::Array(items.clone());
+    }
+    if let Some(model) = value.get("model").and_then(Value::as_object) {
+        return Value::Object(model.clone());
     }
     value.clone()
 }

--- a/gestalt/cli/src/commands/authorization.rs
+++ b/gestalt/cli/src/commands/authorization.rs
@@ -158,7 +158,15 @@ fn active_model_resource_types_path(
 fn print_value(value: &Value, format: Format) {
     match format {
         Format::Json => output::print_json(value),
-        Format::Table => output::print_json_table(&table_value(value)),
+        Format::Table => {
+            output::print_json_table(&table_value(value));
+            if let Some(token) = next_page_token(value) {
+                eprintln!("Next page token: {token}");
+            }
+            if let Some(model_id) = model_id(value) {
+                eprintln!("Model ID: {model_id}");
+            }
+        }
     }
 }
 
@@ -175,6 +183,22 @@ fn table_value(value: &Value) -> Value {
     value.clone()
 }
 
+fn next_page_token(value: &Value) -> Option<&str> {
+    value
+        .get("nextPageToken")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|token| !token.is_empty())
+}
+
+fn model_id(value: &Value) -> Option<&str> {
+    value
+        .get("modelId")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|model_id| !model_id.is_empty())
+}
+
 fn json_path_str<'a>(value: Option<&'a Value>, path: &[&str]) -> Option<&'a str> {
     let mut current = value?;
     for segment in path {
@@ -189,4 +213,32 @@ fn json_path_u32(value: Option<&Value>, path: &[&str]) -> Option<u32> {
         current = current.get(*segment)?;
     }
     current.as_u64().and_then(|value| u32::try_from(value).ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{model_id, next_page_token};
+
+    #[test]
+    fn next_page_token_returns_trimmed_non_empty_token() {
+        let value = json!({"nextPageToken": " next "});
+
+        assert_eq!(next_page_token(&value), Some("next"));
+    }
+
+    #[test]
+    fn next_page_token_ignores_blank_tokens() {
+        let value = json!({"nextPageToken": " "});
+
+        assert_eq!(next_page_token(&value), None);
+    }
+
+    #[test]
+    fn model_id_returns_trimmed_non_empty_id() {
+        let value = json!({"modelId": " model-1 "});
+
+        assert_eq!(model_id(&value), Some("model-1"));
+    }
 }

--- a/gestalt/cli/src/commands/authorization.rs
+++ b/gestalt/cli/src/commands/authorization.rs
@@ -1,0 +1,40 @@
+use anyhow::{Context, Result};
+use serde_json::{Value, json};
+
+use crate::api::ApiClient;
+use crate::cli::AuthorizationCommands;
+use crate::output::{self, Format};
+
+const CHECK_ACCESS_PATH: &str = "/api/v1/authorization/check-access";
+
+pub fn dispatch(client: &ApiClient, command: AuthorizationCommands, format: Format) -> Result<()> {
+    match command {
+        AuthorizationCommands::CheckAccess(args) => {
+            let body = json!({
+                "subject": {
+                    "type": args.subject_type,
+                    "id": args.subject_id,
+                },
+                "action": {
+                    "name": args.action,
+                },
+                "resource": {
+                    "type": args.resource_type,
+                    "id": args.resource_id,
+                },
+            });
+            let resp = client
+                .post(CHECK_ACCESS_PATH, &body)
+                .context("failed to check authorization access")?;
+            print_value(&resp, format);
+            Ok(())
+        }
+    }
+}
+
+fn print_value(value: &Value, format: Format) {
+    match format {
+        Format::Json => output::print_json(value),
+        Format::Table => output::print_json_table(value),
+    }
+}

--- a/gestalt/cli/src/commands/authorization.rs
+++ b/gestalt/cli/src/commands/authorization.rs
@@ -3,8 +3,8 @@ use serde_json::{Value, json};
 
 use crate::api::ApiClient;
 use crate::cli::{
-    AuthorizationActiveModelCommands, AuthorizationCommands, AuthorizationModelCommands,
-    AuthorizationRelationshipCommands,
+    AuthorizationActiveModelCommands, AuthorizationActiveModelResourceTypeCommands,
+    AuthorizationCommands, AuthorizationModelCommands, AuthorizationRelationshipCommands,
 };
 use crate::output::{self, Format};
 use crate::params;
@@ -13,6 +13,7 @@ use crate::query;
 const CHECK_ACCESS_PATH: &str = "/api/v1/authorization/check-access";
 const RELATIONSHIPS_PATH: &str = "/api/v1/authorization/relationships";
 const ACTIVE_MODEL_PATH: &str = "/api/v1/authorization/models/active";
+const ACTIVE_MODEL_RESOURCE_TYPES_PATH: &str = "/api/v1/authorization/models/active/resource-types";
 
 pub fn dispatch(client: &ApiClient, command: AuthorizationCommands, format: Format) -> Result<()> {
     match command {
@@ -85,6 +86,21 @@ pub fn dispatch(client: &ApiClient, command: AuthorizationCommands, format: Form
                     print_value(&resp, format);
                     Ok(())
                 }
+                AuthorizationActiveModelCommands::ResourceTypes { command } => match command {
+                    AuthorizationActiveModelResourceTypeCommands::List(args) => {
+                        let path = active_model_resource_types_path(
+                            args.name.as_deref(),
+                            args.source_layer.as_deref(),
+                            args.page_size,
+                            args.page_token.as_deref(),
+                        )?;
+                        let resp = client
+                            .get(&path)
+                            .context("failed to list active authorization model resource types")?;
+                        print_value(&resp, format);
+                        Ok(())
+                    }
+                },
             },
         },
     }
@@ -155,6 +171,20 @@ fn relationships_list_path(args: &crate::cli::AuthorizationRelationshipListArgs)
     query::append_query(RELATIONSHIPS_PATH, &params)
 }
 
+fn active_model_resource_types_path(
+    name: Option<&str>,
+    source_layer: Option<&str>,
+    page_size: Option<u32>,
+    page_token: Option<&str>,
+) -> Result<String> {
+    let mut params = Vec::new();
+    query::push_opt_param(&mut params, "name", name);
+    query::push_opt_param(&mut params, "sourceLayer", source_layer);
+    query::push_opt_u32(&mut params, "pageSize", page_size);
+    query::push_opt_param(&mut params, "pageToken", page_token);
+    query::append_query(ACTIVE_MODEL_RESOURCE_TYPES_PATH, &params)
+}
+
 fn print_value(value: &Value, format: Format) {
     match format {
         Format::Json => output::print_json(value),
@@ -164,6 +194,9 @@ fn print_value(value: &Value, format: Format) {
 
 fn table_value(value: &Value) -> Value {
     if let Some(items) = value.get("relationships").and_then(Value::as_array) {
+        return Value::Array(items.clone());
+    }
+    if let Some(items) = value.get("resourceTypes").and_then(Value::as_array) {
         return Value::Array(items.clone());
     }
     if let Some(model) = value.get("model").and_then(Value::as_object) {

--- a/gestalt/cli/src/commands/authorization.rs
+++ b/gestalt/cli/src/commands/authorization.rs
@@ -41,6 +41,14 @@ pub fn dispatch(client: &ApiClient, command: AuthorizationCommands, format: Form
                 print_value(&resp, format);
                 Ok(())
             }
+            AuthorizationRelationshipCommands::Add(args) => {
+                let body = Value::Object(params::load_input_file(&args.input_file)?);
+                let resp = client
+                    .post(RELATIONSHIPS_PATH, &body)
+                    .context("failed to add authorization relationship")?;
+                print_value(&resp, format);
+                Ok(())
+            }
         },
     }
 }

--- a/gestalt/cli/src/commands/authorization.rs
+++ b/gestalt/cli/src/commands/authorization.rs
@@ -46,36 +46,6 @@ pub fn dispatch(client: &ApiClient, command: AuthorizationCommands, format: Form
                 print_value(&resp, format);
                 Ok(())
             }
-            AuthorizationRelationshipCommands::Add(args) => {
-                let body = Value::Object(params::load_input_file(&args.input_file)?);
-                let resp = client
-                    .post(RELATIONSHIPS_PATH, &body)
-                    .context("failed to add authorization relationship")?;
-                print_value(&resp, format);
-                Ok(())
-            }
-            AuthorizationRelationshipCommands::Delete(args) => {
-                let body = json!({
-                    "relationshipTuple": {
-                        "target": {
-                            "subject": {
-                                "type": args.target_subject_type,
-                                "id": args.target_subject_id,
-                            },
-                        },
-                        "relation": args.relation,
-                        "resource": {
-                            "type": args.resource_type,
-                            "id": args.resource_id,
-                        },
-                    },
-                });
-                let resp = client
-                    .delete_json(RELATIONSHIPS_PATH, &body)
-                    .context("failed to delete authorization relationship")?;
-                print_value(&resp, format);
-                Ok(())
-            }
         },
         AuthorizationCommands::Models { command } => match command {
             AuthorizationModelCommands::Active { command } => match command {

--- a/gestalt/cli/src/commands/authorization.rs
+++ b/gestalt/cli/src/commands/authorization.rs
@@ -49,6 +49,28 @@ pub fn dispatch(client: &ApiClient, command: AuthorizationCommands, format: Form
                 print_value(&resp, format);
                 Ok(())
             }
+            AuthorizationRelationshipCommands::Delete(args) => {
+                let body = json!({
+                    "relationshipTuple": {
+                        "target": {
+                            "subject": {
+                                "type": args.target_subject_type,
+                                "id": args.target_subject_id,
+                            },
+                        },
+                        "relation": args.relation,
+                        "resource": {
+                            "type": args.resource_type,
+                            "id": args.resource_id,
+                        },
+                    },
+                });
+                let resp = client
+                    .delete_json(RELATIONSHIPS_PATH, &body)
+                    .context("failed to delete authorization relationship")?;
+                print_value(&resp, format);
+                Ok(())
+            }
         },
     }
 }

--- a/gestalt/cli/src/commands/authorization.rs
+++ b/gestalt/cli/src/commands/authorization.rs
@@ -2,10 +2,13 @@ use anyhow::{Context, Result};
 use serde_json::{Value, json};
 
 use crate::api::ApiClient;
-use crate::cli::AuthorizationCommands;
+use crate::cli::{AuthorizationCommands, AuthorizationRelationshipCommands};
 use crate::output::{self, Format};
+use crate::params;
+use crate::query;
 
 const CHECK_ACCESS_PATH: &str = "/api/v1/authorization/check-access";
+const RELATIONSHIPS_PATH: &str = "/api/v1/authorization/relationships";
 
 pub fn dispatch(client: &ApiClient, command: AuthorizationCommands, format: Format) -> Result<()> {
     match command {
@@ -29,12 +32,110 @@ pub fn dispatch(client: &ApiClient, command: AuthorizationCommands, format: Form
             print_value(&resp, format);
             Ok(())
         }
+        AuthorizationCommands::Relationships { command } => match command {
+            AuthorizationRelationshipCommands::List(args) => {
+                let path = relationships_list_path(&args)?;
+                let resp = client
+                    .get(&path)
+                    .context("failed to list authorization relationships")?;
+                print_value(&resp, format);
+                Ok(())
+            }
+        },
     }
+}
+
+fn relationships_list_path(args: &crate::cli::AuthorizationRelationshipListArgs) -> Result<String> {
+    let input = match args.input_file.as_deref() {
+        Some(path) => Some(Value::Object(params::load_input_file(path)?)),
+        None => None,
+    };
+    let mut params = Vec::new();
+    query::push_opt_param(
+        &mut params,
+        "subjectId",
+        args.subject_id
+            .as_deref()
+            .or_else(|| json_path_str(input.as_ref(), &["filter", "target", "subject", "id"])),
+    );
+    query::push_opt_param(
+        &mut params,
+        "subjectType",
+        args.subject_type
+            .as_deref()
+            .or_else(|| json_path_str(input.as_ref(), &["filter", "target", "subject", "type"])),
+    );
+    query::push_opt_param(
+        &mut params,
+        "relation",
+        args.relation
+            .as_deref()
+            .or_else(|| json_path_str(input.as_ref(), &["filter", "relation"])),
+    );
+    query::push_opt_param(
+        &mut params,
+        "resourceType",
+        args.resource_type
+            .as_deref()
+            .or_else(|| json_path_str(input.as_ref(), &["filter", "resourceType"]))
+            .or_else(|| json_path_str(input.as_ref(), &["filter", "resource", "type"])),
+    );
+    query::push_opt_param(
+        &mut params,
+        "resourceId",
+        args.resource_id
+            .as_deref()
+            .or_else(|| json_path_str(input.as_ref(), &["filter", "resource", "id"])),
+    );
+    query::push_opt_param(
+        &mut params,
+        "sourceLayer",
+        args.source_layer
+            .as_deref()
+            .or_else(|| json_path_str(input.as_ref(), &["filter", "sourceLayer"])),
+    );
+    query::push_opt_u32(
+        &mut params,
+        "pageSize",
+        args.page_size
+            .or_else(|| json_path_u32(input.as_ref(), &["pageSize"])),
+    );
+    query::push_opt_param(
+        &mut params,
+        "pageToken",
+        args.page_token
+            .as_deref()
+            .or_else(|| json_path_str(input.as_ref(), &["pageToken"])),
+    );
+    query::append_query(RELATIONSHIPS_PATH, &params)
 }
 
 fn print_value(value: &Value, format: Format) {
     match format {
         Format::Json => output::print_json(value),
-        Format::Table => output::print_json_table(value),
+        Format::Table => output::print_json_table(&table_value(value)),
     }
+}
+
+fn table_value(value: &Value) -> Value {
+    if let Some(items) = value.get("relationships").and_then(Value::as_array) {
+        return Value::Array(items.clone());
+    }
+    value.clone()
+}
+
+fn json_path_str<'a>(value: Option<&'a Value>, path: &[&str]) -> Option<&'a str> {
+    let mut current = value?;
+    for segment in path {
+        current = current.get(*segment)?;
+    }
+    current.as_str()
+}
+
+fn json_path_u32(value: Option<&Value>, path: &[&str]) -> Option<u32> {
+    let mut current = value?;
+    for segment in path {
+        current = current.get(*segment)?;
+    }
+    current.as_u64().and_then(|value| u32::try_from(value).ok())
 }

--- a/gestalt/cli/src/commands/mod.rs
+++ b/gestalt/cli/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod agents;
 mod app_errors;
 pub mod apps;
 pub mod auth;
+pub mod authorization;
 pub mod config;
 pub mod describe;
 pub mod init;

--- a/gestalt/cli/src/main.rs
+++ b/gestalt/cli/src/main.rs
@@ -33,6 +33,10 @@ fn run() -> anyhow::Result<()> {
             ConfigCommands::Unset { key } => commands::config::unset(&key),
             ConfigCommands::List => commands::config::list(format),
         },
+        Commands::Authorization { command } => {
+            let client = ApiClient::from_env(url)?;
+            commands::authorization::dispatch(&client, command, format)
+        }
         Commands::App { command } => dispatch_app_command(command, url, format),
         Commands::Invoke(args) => dispatch_app_command(AppCommands::Invoke(args), url, format),
         Commands::Describe(args) => dispatch_app_command(AppCommands::Describe(args), url, format),

--- a/gestaltd/internal/server/authorization_api_test.go
+++ b/gestaltd/internal/server/authorization_api_test.go
@@ -104,6 +104,8 @@ func TestAuthorizationAPIListRelationships(t *testing.T) {
 }
 
 func TestAuthorizationAPIListRelationshipsRejectsPartialEntityFilters(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		name  string
 		query string

--- a/gestaltd/internal/server/authorization_api_test.go
+++ b/gestaltd/internal/server/authorization_api_test.go
@@ -102,6 +102,31 @@ func TestAuthorizationAPIAddRelationship(t *testing.T) {
 	}
 }
 
+func TestAuthorizationAPIDeleteRelationship(t *testing.T) {
+	authz := &authorizationAPITestProvider{}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Authorization = authz
+	})
+	defer ts.Close()
+	t.Parallel()
+
+	resp := doAuthorizationJSONRequest(t, http.MethodDelete, ts.URL+"/api/v1/authorization/relationships", `{
+		"relationshipTuple": {
+			"target": {"subject": {"type": "subject", "id": "user:alice"}},
+			"relation": "member",
+			"resource": {"type": "group", "id": "engineering"}
+		}
+	}`)
+	defer closeResponseBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	if got := authz.deleteRelationshipRequest.GetRelationshipTuple().GetResource().GetId(); got != "engineering" {
+		t.Fatalf("resource id = %q, want engineering", got)
+	}
+}
+
 func doAuthorizationJSONRequest(t *testing.T, method, url, body string) *http.Response {
 	t.Helper()
 	var reader io.Reader
@@ -132,9 +157,10 @@ func closeResponseBody(t *testing.T, resp *http.Response) {
 type authorizationAPITestProvider struct {
 	core.AuthorizationProvider
 
-	checkAccessRequest       *proto.CheckAccessRequest
-	listRelationshipsRequest *proto.ListRelationshipsRequest
-	addRelationshipRequest   *proto.AddRelationshipRequest
+	checkAccessRequest        *proto.CheckAccessRequest
+	listRelationshipsRequest  *proto.ListRelationshipsRequest
+	addRelationshipRequest    *proto.AddRelationshipRequest
+	deleteRelationshipRequest *proto.DeleteRelationshipRequest
 }
 
 func (p *authorizationAPITestProvider) CheckAccess(_ context.Context, req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
@@ -164,4 +190,9 @@ func (p *authorizationAPITestProvider) ListRelationships(_ context.Context, req 
 func (p *authorizationAPITestProvider) AddRelationship(_ context.Context, req *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {
 	p.addRelationshipRequest = req
 	return &proto.AddRelationshipResponse{Relationship: req.GetRelationship()}, nil
+}
+
+func (p *authorizationAPITestProvider) DeleteRelationship(_ context.Context, req *proto.DeleteRelationshipRequest) (*proto.DeleteRelationshipResponse, error) {
+	p.deleteRelationshipRequest = req
+	return &proto.DeleteRelationshipResponse{}, nil
 }

--- a/gestaltd/internal/server/authorization_api_test.go
+++ b/gestaltd/internal/server/authorization_api_test.go
@@ -151,6 +151,29 @@ func TestAuthorizationAPIGetActiveModelRef(t *testing.T) {
 	}
 }
 
+func TestAuthorizationAPIListActiveModelResourceTypes(t *testing.T) {
+	authz := &authorizationAPITestProvider{}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Authorization = authz
+	})
+	defer ts.Close()
+	t.Parallel()
+
+	resp := doAuthorizationJSONRequest(t, http.MethodGet, ts.URL+"/api/v1/authorization/models/active/resource-types?name=group&sourceLayer=static_config&pageSize=10&pageToken=next", "")
+	defer closeResponseBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	req := authz.listResourceTypesRequest
+	if req.GetFilter().GetName() != "group" || req.GetFilter().GetSourceLayer() != proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG {
+		t.Fatalf("filter = %#v", req.GetFilter())
+	}
+	if req.GetPageSize() != 10 || req.GetPageToken() != "next" {
+		t.Fatalf("pagination = (%d, %q), want (10, next)", req.GetPageSize(), req.GetPageToken())
+	}
+}
+
 func doAuthorizationJSONRequest(t *testing.T, method, url, body string) *http.Response {
 	t.Helper()
 	var reader io.Reader
@@ -185,6 +208,7 @@ type authorizationAPITestProvider struct {
 	listRelationshipsRequest  *proto.ListRelationshipsRequest
 	addRelationshipRequest    *proto.AddRelationshipRequest
 	deleteRelationshipRequest *proto.DeleteRelationshipRequest
+	listResourceTypesRequest  *proto.ListActiveModelResourceTypesRequest
 }
 
 func (p *authorizationAPITestProvider) CheckAccess(_ context.Context, req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
@@ -227,6 +251,16 @@ func (p *authorizationAPITestProvider) GetActiveModelRef(context.Context) (*prot
 			Id:        "model-1",
 			Version:   "v1",
 			CreatedAt: timestamppb.Now(),
+		},
+	}, nil
+}
+
+func (p *authorizationAPITestProvider) ListActiveModelResourceTypes(_ context.Context, req *proto.ListActiveModelResourceTypesRequest) (*proto.ListActiveModelResourceTypesResponse, error) {
+	p.listResourceTypesRequest = req
+	return &proto.ListActiveModelResourceTypesResponse{
+		ModelId: "model-1",
+		ResourceTypes: []*proto.AuthorizationModelResourceType{
+			{Name: "group", SourceLayer: proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG},
 		},
 	}, nil
 }

--- a/gestaltd/internal/server/authorization_api_test.go
+++ b/gestaltd/internal/server/authorization_api_test.go
@@ -75,6 +75,37 @@ func TestAuthorizationAPIListRelationships(t *testing.T) {
 	}
 }
 
+func TestAuthorizationAPIListRelationshipsRejectsPartialEntityFilters(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		query string
+	}{
+		{name: "subject type only", query: "subjectType=subject"},
+		{name: "subject id only", query: "subjectId=user%3Aalice"},
+		{name: "resource type only", query: "resourceType=group"},
+		{name: "resource id only", query: "resourceId=engineering"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			authz := &authorizationAPITestProvider{}
+			ts := newTestServer(t, func(cfg *server.Config) {
+				cfg.Authorization = authz
+			})
+			defer ts.Close()
+			t.Parallel()
+
+			resp := doAuthorizationJSONRequest(t, http.MethodGet, ts.URL+"/api/v1/authorization/relationships?"+tc.query, "")
+			defer closeResponseBody(t, resp)
+			if resp.StatusCode != http.StatusBadRequest {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("status = %d, want 400: %s", resp.StatusCode, body)
+			}
+			if authz.listRelationshipsRequest != nil {
+				t.Fatalf("ListRelationships request = %#v, want nil", authz.listRelationshipsRequest)
+			}
+		})
+	}
+}
+
 func TestAuthorizationAPIRelationshipMutationsNotExposed(t *testing.T) {
 	authz := &authorizationAPITestProvider{}
 	ts := newTestServer(t, func(cfg *server.Config) {

--- a/gestaltd/internal/server/authorization_api_test.go
+++ b/gestaltd/internal/server/authorization_api_test.go
@@ -44,6 +44,36 @@ func TestAuthorizationAPICheckAccess(t *testing.T) {
 	}
 }
 
+func TestAuthorizationAPIListRelationships(t *testing.T) {
+	authz := &authorizationAPITestProvider{}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Authorization = authz
+	})
+	defer ts.Close()
+	t.Parallel()
+
+	resp := doAuthorizationJSONRequest(t, http.MethodGet, ts.URL+"/api/v1/authorization/relationships?subjectType=subject&subjectId=user%3Aalice&relation=member&resourceType=group&resourceId=engineering&sourceLayer=runtime&pageSize=25&pageToken=next", "")
+	defer closeResponseBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	req := authz.listRelationshipsRequest
+	if req.GetPageSize() != 25 || req.GetPageToken() != "next" {
+		t.Fatalf("pagination = (%d, %q), want (25, next)", req.GetPageSize(), req.GetPageToken())
+	}
+	filter := req.GetFilter()
+	if filter.GetTarget().GetSubject().GetType() != "subject" || filter.GetTarget().GetSubject().GetId() != "user:alice" {
+		t.Fatalf("target subject = %#v", filter.GetTarget().GetSubject())
+	}
+	if filter.GetRelation() != "member" || filter.GetResource().GetType() != "group" || filter.GetResource().GetId() != "engineering" {
+		t.Fatalf("filter = %#v", filter)
+	}
+	if filter.GetSourceLayer() != proto.SourceLayer_SOURCE_LAYER_RUNTIME {
+		t.Fatalf("source layer = %v, want runtime", filter.GetSourceLayer())
+	}
+}
+
 func doAuthorizationJSONRequest(t *testing.T, method, url, body string) *http.Response {
 	t.Helper()
 	var reader io.Reader
@@ -74,10 +104,30 @@ func closeResponseBody(t *testing.T, resp *http.Response) {
 type authorizationAPITestProvider struct {
 	core.AuthorizationProvider
 
-	checkAccessRequest *proto.CheckAccessRequest
+	checkAccessRequest       *proto.CheckAccessRequest
+	listRelationshipsRequest *proto.ListRelationshipsRequest
 }
 
 func (p *authorizationAPITestProvider) CheckAccess(_ context.Context, req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
 	p.checkAccessRequest = req
 	return &proto.CheckAccessResponse{Allowed: true, ModelId: "model-1"}, nil
+}
+
+func (p *authorizationAPITestProvider) ListRelationships(_ context.Context, req *proto.ListRelationshipsRequest) (*proto.ListRelationshipsResponse, error) {
+	p.listRelationshipsRequest = req
+	return &proto.ListRelationshipsResponse{
+		Relationships: []*proto.Relationship{
+			{
+				Tuple: &proto.RelationshipTuple{
+					Target: &proto.RelationshipTarget{
+						Kind: &proto.RelationshipTarget_Subject{
+							Subject: &proto.Subject{Type: "subject", Id: "user:alice"},
+						},
+					},
+					Relation: "member",
+					Resource: &proto.Resource{Type: "group", Id: "engineering"},
+				},
+			},
+		},
+	}, nil
 }

--- a/gestaltd/internal/server/authorization_api_test.go
+++ b/gestaltd/internal/server/authorization_api_test.go
@@ -1,0 +1,83 @@
+package server_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/server"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+)
+
+func TestAuthorizationAPICheckAccess(t *testing.T) {
+	authz := &authorizationAPITestProvider{}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Authorization = authz
+	})
+	defer ts.Close()
+	t.Parallel()
+
+	resp := doAuthorizationJSONRequest(t, http.MethodPost, ts.URL+"/api/v1/authorization/check-access", `{
+		"subject": {"type": "subject", "id": "user:alice"},
+		"action": {"name": "view"},
+		"resource": {"type": "group", "id": "engineering"}
+	}`)
+	defer closeResponseBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	if got := authz.checkAccessRequest.GetSubject().GetId(); got != "user:alice" {
+		t.Fatalf("subject id = %q, want user:alice", got)
+	}
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["allowed"] != true || body["modelId"] != "model-1" {
+		t.Fatalf("response = %#v, want allowed true model-1", body)
+	}
+}
+
+func doAuthorizationJSONRequest(t *testing.T, method, url, body string) *http.Response {
+	t.Helper()
+	var reader io.Reader
+	if strings.TrimSpace(body) != "" {
+		reader = bytes.NewBufferString(body)
+	}
+	req, err := http.NewRequest(method, url, reader)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if reader != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, url, err)
+	}
+	return resp
+}
+
+func closeResponseBody(t *testing.T, resp *http.Response) {
+	t.Helper()
+	if err := resp.Body.Close(); err != nil {
+		t.Fatalf("close response body: %v", err)
+	}
+}
+
+type authorizationAPITestProvider struct {
+	core.AuthorizationProvider
+
+	checkAccessRequest *proto.CheckAccessRequest
+}
+
+func (p *authorizationAPITestProvider) CheckAccess(_ context.Context, req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
+	p.checkAccessRequest = req
+	return &proto.CheckAccessResponse{Allowed: true, ModelId: "model-1"}, nil
+}

--- a/gestaltd/internal/server/authorization_api_test.go
+++ b/gestaltd/internal/server/authorization_api_test.go
@@ -45,6 +45,34 @@ func TestAuthorizationAPICheckAccess(t *testing.T) {
 	}
 }
 
+func TestAuthorizationAPICheckAccessDeniedIncludesAllowedFalse(t *testing.T) {
+	authz := &authorizationAPITestProvider{checkAccessDenied: true}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Authorization = authz
+	})
+	defer ts.Close()
+	t.Parallel()
+
+	resp := doAuthorizationJSONRequest(t, http.MethodPost, ts.URL+"/api/v1/authorization/check-access", `{
+		"subject": {"type": "subject", "id": "user:alice"},
+		"action": {"name": "admin"},
+		"resource": {"type": "group", "id": "engineering"}
+	}`)
+	defer closeResponseBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	allowed, ok := body["allowed"].(bool)
+	if !ok || allowed {
+		t.Fatalf("allowed = %#v, want explicit false", body["allowed"])
+	}
+}
+
 func TestAuthorizationAPIListRelationships(t *testing.T) {
 	authz := &authorizationAPITestProvider{}
 	ts := newTestServer(t, func(cfg *server.Config) {
@@ -208,13 +236,14 @@ type authorizationAPITestProvider struct {
 	core.AuthorizationProvider
 
 	checkAccessRequest       *proto.CheckAccessRequest
+	checkAccessDenied        bool
 	listRelationshipsRequest *proto.ListRelationshipsRequest
 	listResourceTypesRequest *proto.ListActiveModelResourceTypesRequest
 }
 
 func (p *authorizationAPITestProvider) CheckAccess(_ context.Context, req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
 	p.checkAccessRequest = req
-	return &proto.CheckAccessResponse{Allowed: true, ModelId: "model-1"}, nil
+	return &proto.CheckAccessResponse{Allowed: !p.checkAccessDenied, ModelId: "model-1"}, nil
 }
 
 func (p *authorizationAPITestProvider) ListRelationships(_ context.Context, req *proto.ListRelationshipsRequest) (*proto.ListRelationshipsResponse, error) {

--- a/gestaltd/internal/server/authorization_api_test.go
+++ b/gestaltd/internal/server/authorization_api_test.go
@@ -75,7 +75,7 @@ func TestAuthorizationAPIListRelationships(t *testing.T) {
 	}
 }
 
-func TestAuthorizationAPIAddRelationship(t *testing.T) {
+func TestAuthorizationAPIRelationshipMutationsNotExposed(t *testing.T) {
 	authz := &authorizationAPITestProvider{}
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Authorization = authz
@@ -83,48 +83,20 @@ func TestAuthorizationAPIAddRelationship(t *testing.T) {
 	defer ts.Close()
 	t.Parallel()
 
-	resp := doAuthorizationJSONRequest(t, http.MethodPost, ts.URL+"/api/v1/authorization/relationships", `{
-		"relationship": {
-			"tuple": {
+	for _, method := range []string{http.MethodPost, http.MethodDelete} {
+		resp := doAuthorizationJSONRequest(t, method, ts.URL+"/api/v1/authorization/relationships", `{
+			"relationshipTuple": {
 				"target": {"subject": {"type": "subject", "id": "user:alice"}},
 				"relation": "member",
 				"resource": {"type": "group", "id": "engineering"}
-			},
-			"sourceLayer": "SOURCE_LAYER_RUNTIME"
+			}
+		}`)
+		closeResponseBody(t, resp)
+		switch resp.StatusCode {
+		case http.StatusNotFound, http.StatusMethodNotAllowed:
+		default:
+			t.Fatalf("%s status = %d, want 404 or 405", method, resp.StatusCode)
 		}
-	}`)
-	defer closeResponseBody(t, resp)
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
-	}
-	if got := authz.addRelationshipRequest.GetRelationship().GetTuple().GetRelation(); got != "member" {
-		t.Fatalf("relation = %q, want member", got)
-	}
-}
-
-func TestAuthorizationAPIDeleteRelationship(t *testing.T) {
-	authz := &authorizationAPITestProvider{}
-	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.Authorization = authz
-	})
-	defer ts.Close()
-	t.Parallel()
-
-	resp := doAuthorizationJSONRequest(t, http.MethodDelete, ts.URL+"/api/v1/authorization/relationships", `{
-		"relationshipTuple": {
-			"target": {"subject": {"type": "subject", "id": "user:alice"}},
-			"relation": "member",
-			"resource": {"type": "group", "id": "engineering"}
-		}
-	}`)
-	defer closeResponseBody(t, resp)
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
-	}
-	if got := authz.deleteRelationshipRequest.GetRelationshipTuple().GetResource().GetId(); got != "engineering" {
-		t.Fatalf("resource id = %q, want engineering", got)
 	}
 }
 
@@ -204,11 +176,9 @@ func closeResponseBody(t *testing.T, resp *http.Response) {
 type authorizationAPITestProvider struct {
 	core.AuthorizationProvider
 
-	checkAccessRequest        *proto.CheckAccessRequest
-	listRelationshipsRequest  *proto.ListRelationshipsRequest
-	addRelationshipRequest    *proto.AddRelationshipRequest
-	deleteRelationshipRequest *proto.DeleteRelationshipRequest
-	listResourceTypesRequest  *proto.ListActiveModelResourceTypesRequest
+	checkAccessRequest       *proto.CheckAccessRequest
+	listRelationshipsRequest *proto.ListRelationshipsRequest
+	listResourceTypesRequest *proto.ListActiveModelResourceTypesRequest
 }
 
 func (p *authorizationAPITestProvider) CheckAccess(_ context.Context, req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
@@ -236,12 +206,10 @@ func (p *authorizationAPITestProvider) ListRelationships(_ context.Context, req 
 }
 
 func (p *authorizationAPITestProvider) AddRelationship(_ context.Context, req *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {
-	p.addRelationshipRequest = req
 	return &proto.AddRelationshipResponse{Relationship: req.GetRelationship()}, nil
 }
 
 func (p *authorizationAPITestProvider) DeleteRelationship(_ context.Context, req *proto.DeleteRelationshipRequest) (*proto.DeleteRelationshipResponse, error) {
-	p.deleteRelationshipRequest = req
 	return &proto.DeleteRelationshipResponse{}, nil
 }
 

--- a/gestaltd/internal/server/authorization_api_test.go
+++ b/gestaltd/internal/server/authorization_api_test.go
@@ -74,6 +74,34 @@ func TestAuthorizationAPIListRelationships(t *testing.T) {
 	}
 }
 
+func TestAuthorizationAPIAddRelationship(t *testing.T) {
+	authz := &authorizationAPITestProvider{}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Authorization = authz
+	})
+	defer ts.Close()
+	t.Parallel()
+
+	resp := doAuthorizationJSONRequest(t, http.MethodPost, ts.URL+"/api/v1/authorization/relationships", `{
+		"relationship": {
+			"tuple": {
+				"target": {"subject": {"type": "subject", "id": "user:alice"}},
+				"relation": "member",
+				"resource": {"type": "group", "id": "engineering"}
+			},
+			"sourceLayer": "SOURCE_LAYER_RUNTIME"
+		}
+	}`)
+	defer closeResponseBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	if got := authz.addRelationshipRequest.GetRelationship().GetTuple().GetRelation(); got != "member" {
+		t.Fatalf("relation = %q, want member", got)
+	}
+}
+
 func doAuthorizationJSONRequest(t *testing.T, method, url, body string) *http.Response {
 	t.Helper()
 	var reader io.Reader
@@ -106,6 +134,7 @@ type authorizationAPITestProvider struct {
 
 	checkAccessRequest       *proto.CheckAccessRequest
 	listRelationshipsRequest *proto.ListRelationshipsRequest
+	addRelationshipRequest   *proto.AddRelationshipRequest
 }
 
 func (p *authorizationAPITestProvider) CheckAccess(_ context.Context, req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
@@ -130,4 +159,9 @@ func (p *authorizationAPITestProvider) ListRelationships(_ context.Context, req 
 			},
 		},
 	}, nil
+}
+
+func (p *authorizationAPITestProvider) AddRelationship(_ context.Context, req *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {
+	p.addRelationshipRequest = req
+	return &proto.AddRelationshipResponse{Relationship: req.GetRelationship()}, nil
 }

--- a/gestaltd/internal/server/authorization_api_test.go
+++ b/gestaltd/internal/server/authorization_api_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/server"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestAuthorizationAPICheckAccess(t *testing.T) {
@@ -127,6 +128,29 @@ func TestAuthorizationAPIDeleteRelationship(t *testing.T) {
 	}
 }
 
+func TestAuthorizationAPIGetActiveModelRef(t *testing.T) {
+	authz := &authorizationAPITestProvider{}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Authorization = authz
+	})
+	defer ts.Close()
+	t.Parallel()
+
+	resp := doAuthorizationJSONRequest(t, http.MethodGet, ts.URL+"/api/v1/authorization/models/active", "")
+	defer closeResponseBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	var body map[string]map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["model"]["id"] != "model-1" || body["model"]["version"] != "v1" {
+		t.Fatalf("model = %#v, want model-1/v1", body["model"])
+	}
+}
+
 func doAuthorizationJSONRequest(t *testing.T, method, url, body string) *http.Response {
 	t.Helper()
 	var reader io.Reader
@@ -195,4 +219,14 @@ func (p *authorizationAPITestProvider) AddRelationship(_ context.Context, req *p
 func (p *authorizationAPITestProvider) DeleteRelationship(_ context.Context, req *proto.DeleteRelationshipRequest) (*proto.DeleteRelationshipResponse, error) {
 	p.deleteRelationshipRequest = req
 	return &proto.DeleteRelationshipResponse{}, nil
+}
+
+func (p *authorizationAPITestProvider) GetActiveModelRef(context.Context) (*proto.GetActiveModelRefResponse, error) {
+	return &proto.GetActiveModelRefResponse{
+		Model: &proto.AuthorizationModelRef{
+			Id:        "model-1",
+			Version:   "v1",
+			CreatedAt: timestamppb.Now(),
+		},
+	}, nil
 }

--- a/gestaltd/internal/server/handlers_authorization.go
+++ b/gestaltd/internal/server/handlers_authorization.go
@@ -1,8 +1,10 @@
 package server
 
 import (
+	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
@@ -19,6 +21,22 @@ func (s *Server) checkAuthorizationAccess(w http.ResponseWriter, r *http.Request
 		return
 	}
 	resp, err := s.authorization.CheckAccess(r.Context(), &req)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeProtoJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) listAuthorizationRelationships(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAuthorizationProvider(w) {
+		return
+	}
+	req, ok := listAuthorizationRelationshipsRequestFromQuery(w, r)
+	if !ok {
+		return
+	}
+	resp, err := s.authorization.ListRelationships(r.Context(), req)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -61,4 +79,101 @@ func writeProtoJSON(w http.ResponseWriter, status int, msg gproto.Message) {
 	w.WriteHeader(status)
 	_, _ = w.Write(body)
 	_, _ = w.Write([]byte("\n"))
+}
+
+func listAuthorizationRelationshipsRequestFromQuery(w http.ResponseWriter, r *http.Request) (*proto.ListRelationshipsRequest, bool) {
+	query := r.URL.Query()
+	pageSize, ok := parseOptionalInt32Query(w, queryValue(query, "pageSize", "page_size"), "pageSize")
+	if !ok {
+		return nil, false
+	}
+	targetType, ok := relationshipTargetTypeFromQuery(w, queryValue(query, "targetType", "target_type"))
+	if !ok {
+		return nil, false
+	}
+	sourceLayer, ok := sourceLayerFromQuery(w, queryValue(query, "sourceLayer", "source_layer"))
+	if !ok {
+		return nil, false
+	}
+
+	filter := &proto.RelationshipFilter{
+		Relation:         strings.TrimSpace(query.Get("relation")),
+		TargetType:       targetType,
+		TargetEntityType: strings.TrimSpace(queryValue(query, "targetEntityType", "target_entity_type")),
+		ResourceType:     strings.TrimSpace(queryValue(query, "resourceType", "resource_type")),
+		SourceLayer:      sourceLayer,
+	}
+	if subjectID := strings.TrimSpace(queryValue(query, "subjectId", "subject_id", "targetSubjectId", "target_subject_id")); subjectID != "" {
+		filter.Target = &proto.RelationshipTarget{
+			Kind: &proto.RelationshipTarget_Subject{
+				Subject: &proto.Subject{
+					Type: strings.TrimSpace(queryValue(query, "subjectType", "subject_type", "targetSubjectType", "target_subject_type")),
+					Id:   subjectID,
+				},
+			},
+		}
+	}
+	if resourceID := strings.TrimSpace(queryValue(query, "resourceId", "resource_id")); resourceID != "" || filter.ResourceType != "" {
+		filter.Resource = &proto.Resource{
+			Type: strings.TrimSpace(queryValue(query, "resourceType", "resource_type")),
+			Id:   resourceID,
+		}
+	}
+
+	return &proto.ListRelationshipsRequest{
+		Filter:    filter,
+		PageSize:  pageSize,
+		PageToken: strings.TrimSpace(queryValue(query, "pageToken", "page_token")),
+	}, true
+}
+
+func parseOptionalInt32Query(w http.ResponseWriter, raw, name string) (int32, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0, true
+	}
+	value, err := strconv.ParseInt(raw, 10, 32)
+	if err != nil || value < 0 {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("%s must be a non-negative integer", name))
+		return 0, false
+	}
+	return int32(value), true
+}
+
+func relationshipTargetTypeFromQuery(w http.ResponseWriter, raw string) (proto.RelationshipTargetType, bool) {
+	switch normalizeEnumQuery(raw) {
+	case "":
+		return proto.RelationshipTargetType_RELATIONSHIP_TARGET_TYPE_UNSPECIFIED, true
+	case "subject":
+		return proto.RelationshipTargetType_RELATIONSHIP_TARGET_TYPE_SUBJECT, true
+	case "resource":
+		return proto.RelationshipTargetType_RELATIONSHIP_TARGET_TYPE_RESOURCE, true
+	case "subject_set", "subjectset":
+		return proto.RelationshipTargetType_RELATIONSHIP_TARGET_TYPE_SUBJECT_SET, true
+	default:
+		writeError(w, http.StatusBadRequest, "targetType must be subject, resource, or subject_set")
+		return proto.RelationshipTargetType_RELATIONSHIP_TARGET_TYPE_UNSPECIFIED, false
+	}
+}
+
+func sourceLayerFromQuery(w http.ResponseWriter, raw string) (proto.SourceLayer, bool) {
+	switch normalizeEnumQuery(raw) {
+	case "":
+		return proto.SourceLayer_SOURCE_LAYER_UNSPECIFIED, true
+	case "static_config", "staticconfig":
+		return proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG, true
+	case "runtime":
+		return proto.SourceLayer_SOURCE_LAYER_RUNTIME, true
+	default:
+		writeError(w, http.StatusBadRequest, "sourceLayer must be static_config or runtime")
+		return proto.SourceLayer_SOURCE_LAYER_UNSPECIFIED, false
+	}
+}
+
+func normalizeEnumQuery(raw string) string {
+	raw = strings.TrimSpace(strings.ToLower(raw))
+	raw = strings.TrimPrefix(raw, "relationship_target_type_")
+	raw = strings.TrimPrefix(raw, "source_layer_")
+	raw = strings.ReplaceAll(raw, "-", "_")
+	return raw
 }

--- a/gestaltd/internal/server/handlers_authorization.go
+++ b/gestaltd/internal/server/handlers_authorization.go
@@ -76,6 +76,18 @@ func (s *Server) deleteAuthorizationRelationship(w http.ResponseWriter, r *http.
 	writeProtoJSON(w, http.StatusOK, resp)
 }
 
+func (s *Server) getAuthorizationActiveModelRef(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAuthorizationProvider(w) {
+		return
+	}
+	resp, err := s.authorization.GetActiveModelRef(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeProtoJSON(w, http.StatusOK, resp)
+}
+
 func (s *Server) requireAuthorizationProvider(w http.ResponseWriter) bool {
 	if s.authorization == nil {
 		writeError(w, http.StatusPreconditionFailed, "authorization provider is not configured")

--- a/gestaltd/internal/server/handlers_authorization.go
+++ b/gestaltd/internal/server/handlers_authorization.go
@@ -1,0 +1,64 @@
+package server
+
+import (
+	"io"
+	"net/http"
+	"strings"
+
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+	gproto "google.golang.org/protobuf/proto"
+)
+
+func (s *Server) checkAuthorizationAccess(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAuthorizationProvider(w) {
+		return
+	}
+	var req proto.CheckAccessRequest
+	if !decodeProtoJSONBody(w, r, &req) {
+		return
+	}
+	resp, err := s.authorization.CheckAccess(r.Context(), &req)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeProtoJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) requireAuthorizationProvider(w http.ResponseWriter) bool {
+	if s.authorization == nil {
+		writeError(w, http.StatusPreconditionFailed, "authorization provider is not configured")
+		return false
+	}
+	return true
+}
+
+func decodeProtoJSONBody(w http.ResponseWriter, r *http.Request, msg gproto.Message) bool {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "failed to read request body")
+		return false
+	}
+	if len(strings.TrimSpace(string(body))) == 0 {
+		writeError(w, http.StatusBadRequest, "request body is required")
+		return false
+	}
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: false}).Unmarshal(body, msg); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return false
+	}
+	return true
+}
+
+func writeProtoJSON(w http.ResponseWriter, status int, msg gproto.Message) {
+	body, err := (protojson.MarshalOptions{EmitUnpopulated: false}).Marshal(msg)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to encode response")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write(body)
+	_, _ = w.Write([]byte("\n"))
+}

--- a/gestaltd/internal/server/handlers_authorization.go
+++ b/gestaltd/internal/server/handlers_authorization.go
@@ -25,7 +25,7 @@ func (s *Server) checkAuthorizationAccess(w http.ResponseWriter, r *http.Request
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	writeProtoJSON(w, http.StatusOK, resp)
+	writeCheckAccessProtoJSON(w, http.StatusOK, resp)
 }
 
 func (s *Server) listAuthorizationRelationships(w http.ResponseWriter, r *http.Request) {
@@ -99,6 +99,18 @@ func decodeProtoJSONBody(w http.ResponseWriter, r *http.Request, msg gproto.Mess
 
 func writeProtoJSON(w http.ResponseWriter, status int, msg gproto.Message) {
 	body, err := (protojson.MarshalOptions{EmitUnpopulated: false}).Marshal(msg)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to encode response")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write(body)
+	_, _ = w.Write([]byte("\n"))
+}
+
+func writeCheckAccessProtoJSON(w http.ResponseWriter, status int, msg *proto.CheckAccessResponse) {
+	body, err := (protojson.MarshalOptions{EmitUnpopulated: true}).Marshal(msg)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to encode response")
 		return

--- a/gestaltd/internal/server/handlers_authorization.go
+++ b/gestaltd/internal/server/handlers_authorization.go
@@ -60,6 +60,22 @@ func (s *Server) addAuthorizationRelationship(w http.ResponseWriter, r *http.Req
 	writeProtoJSON(w, http.StatusOK, resp)
 }
 
+func (s *Server) deleteAuthorizationRelationship(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAuthorizationProvider(w) {
+		return
+	}
+	var req proto.DeleteRelationshipRequest
+	if !decodeProtoJSONBody(w, r, &req) {
+		return
+	}
+	resp, err := s.authorization.DeleteRelationship(r.Context(), &req)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeProtoJSON(w, http.StatusOK, resp)
+}
+
 func (s *Server) requireAuthorizationProvider(w http.ResponseWriter) bool {
 	if s.authorization == nil {
 		writeError(w, http.StatusPreconditionFailed, "authorization provider is not configured")

--- a/gestaltd/internal/server/handlers_authorization.go
+++ b/gestaltd/internal/server/handlers_authorization.go
@@ -44,38 +44,6 @@ func (s *Server) listAuthorizationRelationships(w http.ResponseWriter, r *http.R
 	writeProtoJSON(w, http.StatusOK, resp)
 }
 
-func (s *Server) addAuthorizationRelationship(w http.ResponseWriter, r *http.Request) {
-	if !s.requireAuthorizationProvider(w) {
-		return
-	}
-	var req proto.AddRelationshipRequest
-	if !decodeProtoJSONBody(w, r, &req) {
-		return
-	}
-	resp, err := s.authorization.AddRelationship(r.Context(), &req)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
-		return
-	}
-	writeProtoJSON(w, http.StatusOK, resp)
-}
-
-func (s *Server) deleteAuthorizationRelationship(w http.ResponseWriter, r *http.Request) {
-	if !s.requireAuthorizationProvider(w) {
-		return
-	}
-	var req proto.DeleteRelationshipRequest
-	if !decodeProtoJSONBody(w, r, &req) {
-		return
-	}
-	resp, err := s.authorization.DeleteRelationship(r.Context(), &req)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
-		return
-	}
-	writeProtoJSON(w, http.StatusOK, resp)
-}
-
 func (s *Server) getAuthorizationActiveModelRef(w http.ResponseWriter, r *http.Request) {
 	if !s.requireAuthorizationProvider(w) {
 		return

--- a/gestaltd/internal/server/handlers_authorization.go
+++ b/gestaltd/internal/server/handlers_authorization.go
@@ -128,22 +128,33 @@ func listAuthorizationRelationshipsRequestFromQuery(w http.ResponseWriter, r *ht
 		Relation:         strings.TrimSpace(query.Get("relation")),
 		TargetType:       targetType,
 		TargetEntityType: strings.TrimSpace(queryValue(query, "targetEntityType", "target_entity_type")),
-		ResourceType:     strings.TrimSpace(queryValue(query, "resourceType", "resource_type")),
 		SourceLayer:      sourceLayer,
 	}
-	if subjectID := strings.TrimSpace(queryValue(query, "subjectId", "subject_id", "targetSubjectId", "target_subject_id")); subjectID != "" {
+	subjectType := strings.TrimSpace(queryValue(query, "subjectType", "subject_type", "targetSubjectType", "target_subject_type"))
+	subjectID := strings.TrimSpace(queryValue(query, "subjectId", "subject_id", "targetSubjectId", "target_subject_id"))
+	if (subjectType == "") != (subjectID == "") {
+		writeError(w, http.StatusBadRequest, "subjectType and subjectId must be provided together")
+		return nil, false
+	}
+	if subjectType != "" {
 		filter.Target = &proto.RelationshipTarget{
 			Kind: &proto.RelationshipTarget_Subject{
 				Subject: &proto.Subject{
-					Type: strings.TrimSpace(queryValue(query, "subjectType", "subject_type", "targetSubjectType", "target_subject_type")),
+					Type: subjectType,
 					Id:   subjectID,
 				},
 			},
 		}
 	}
-	if resourceID := strings.TrimSpace(queryValue(query, "resourceId", "resource_id")); resourceID != "" || filter.ResourceType != "" {
+	resourceType := strings.TrimSpace(queryValue(query, "resourceType", "resource_type"))
+	resourceID := strings.TrimSpace(queryValue(query, "resourceId", "resource_id"))
+	if (resourceType == "") != (resourceID == "") {
+		writeError(w, http.StatusBadRequest, "resourceType and resourceId must be provided together")
+		return nil, false
+	}
+	if resourceType != "" {
 		filter.Resource = &proto.Resource{
-			Type: strings.TrimSpace(queryValue(query, "resourceType", "resource_type")),
+			Type: resourceType,
 			Id:   resourceID,
 		}
 	}

--- a/gestaltd/internal/server/handlers_authorization.go
+++ b/gestaltd/internal/server/handlers_authorization.go
@@ -44,6 +44,22 @@ func (s *Server) listAuthorizationRelationships(w http.ResponseWriter, r *http.R
 	writeProtoJSON(w, http.StatusOK, resp)
 }
 
+func (s *Server) addAuthorizationRelationship(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAuthorizationProvider(w) {
+		return
+	}
+	var req proto.AddRelationshipRequest
+	if !decodeProtoJSONBody(w, r, &req) {
+		return
+	}
+	resp, err := s.authorization.AddRelationship(r.Context(), &req)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeProtoJSON(w, http.StatusOK, resp)
+}
+
 func (s *Server) requireAuthorizationProvider(w http.ResponseWriter) bool {
 	if s.authorization == nil {
 		writeError(w, http.StatusPreconditionFailed, "authorization provider is not configured")

--- a/gestaltd/internal/server/handlers_authorization.go
+++ b/gestaltd/internal/server/handlers_authorization.go
@@ -88,6 +88,22 @@ func (s *Server) getAuthorizationActiveModelRef(w http.ResponseWriter, r *http.R
 	writeProtoJSON(w, http.StatusOK, resp)
 }
 
+func (s *Server) listAuthorizationActiveModelResourceTypes(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAuthorizationProvider(w) {
+		return
+	}
+	req, ok := listAuthorizationActiveModelResourceTypesRequestFromQuery(w, r)
+	if !ok {
+		return
+	}
+	resp, err := s.authorization.ListActiveModelResourceTypes(r.Context(), req)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeProtoJSON(w, http.StatusOK, resp)
+}
+
 func (s *Server) requireAuthorizationProvider(w http.ResponseWriter) bool {
 	if s.authorization == nil {
 		writeError(w, http.StatusPreconditionFailed, "authorization provider is not configured")
@@ -166,6 +182,26 @@ func listAuthorizationRelationshipsRequestFromQuery(w http.ResponseWriter, r *ht
 
 	return &proto.ListRelationshipsRequest{
 		Filter:    filter,
+		PageSize:  pageSize,
+		PageToken: strings.TrimSpace(queryValue(query, "pageToken", "page_token")),
+	}, true
+}
+
+func listAuthorizationActiveModelResourceTypesRequestFromQuery(w http.ResponseWriter, r *http.Request) (*proto.ListActiveModelResourceTypesRequest, bool) {
+	query := r.URL.Query()
+	pageSize, ok := parseOptionalInt32Query(w, queryValue(query, "pageSize", "page_size"), "pageSize")
+	if !ok {
+		return nil, false
+	}
+	sourceLayer, ok := sourceLayerFromQuery(w, queryValue(query, "sourceLayer", "source_layer"))
+	if !ok {
+		return nil, false
+	}
+	return &proto.ListActiveModelResourceTypesRequest{
+		Filter: &proto.AuthorizationModelResourceTypeFilter{
+			Name:        strings.TrimSpace(query.Get("name")),
+			SourceLayer: sourceLayer,
+		},
 		PageSize:  pageSize,
 		PageToken: strings.TrimSpace(queryValue(query, "pageToken", "page_token")),
 	}, true

--- a/gestaltd/internal/server/http_bindings.go
+++ b/gestaltd/internal/server/http_bindings.go
@@ -25,6 +25,15 @@ var validMountedHTTPBindingMethods = map[string]bool{
 	http.MethodDelete: true,
 }
 
+var coreAPIRouteNamespaces = []string{
+	"/api/v1/auth",
+	"/api/v1/tokens",
+	"/api/v1/workflow",
+	"/api/v1/apps",
+	"/api/v1/s3",
+	"/api/v1/authorization",
+}
+
 func mountedHTTPBindingsFromEntries(entries map[string]*config.ProviderEntry, providers *registry.ProviderMap[core.Provider], mountedUIs []MountedUI) ([]MountedHTTPBinding, error) {
 	if len(entries) == 0 {
 		return nil, nil
@@ -227,7 +236,7 @@ func validateMountedHTTPBindingRoutes(bindings []MountedHTTPBinding, mountedUIs 
 		if binding.Path == "" {
 			return fmt.Errorf("http binding %s.%s path is required", binding.AppName, binding.Name)
 		}
-		for _, prefix := range []string{"/api/v1/auth", "/api/v1/tokens", "/api/v1/workflow", "/api/v1/apps", "/api/v1/s3"} {
+		for _, prefix := range coreAPIRouteNamespaces {
 			if binding.Path == prefix || strings.HasPrefix(binding.Path, prefix+"/") {
 				return fmt.Errorf("http binding %s.%s path %q conflicts with core route namespace %q", binding.AppName, binding.Name, binding.Path, prefix)
 			}

--- a/gestaltd/internal/server/http_bindings_test.go
+++ b/gestaltd/internal/server/http_bindings_test.go
@@ -1,0 +1,24 @@
+package server
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestValidateMountedHTTPBindingRoutesRejectsAuthorizationNamespace(t *testing.T) {
+	err := validateMountedHTTPBindingRoutes([]MountedHTTPBinding{
+		{
+			AppName: "authorization",
+			Name:    "check",
+			Method:  http.MethodPost,
+			Path:    "/api/v1/authorization/check-access",
+		},
+	}, nil)
+	if err == nil {
+		t.Fatal("validateMountedHTTPBindingRoutes returned nil, want error")
+	}
+	if got := err.Error(); !strings.Contains(got, `conflicts with core route namespace "/api/v1/authorization"`) {
+		t.Fatalf("error = %q, want authorization namespace conflict", got)
+	}
+}

--- a/gestaltd/internal/server/http_bindings_test.go
+++ b/gestaltd/internal/server/http_bindings_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestValidateMountedHTTPBindingRoutesRejectsAuthorizationNamespace(t *testing.T) {
+	t.Parallel()
+
 	err := validateMountedHTTPBindingRoutes([]MountedHTTPBinding{
 		{
 			AppName: "authorization",

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -60,6 +60,7 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 		r.Post("/authorization/relationships", s.addAuthorizationRelationship)
 		r.Delete("/authorization/relationships", s.deleteAuthorizationRelationship)
 		r.Get("/authorization/models/active", s.getAuthorizationActiveModelRef)
+		r.Get("/authorization/models/active/resource-types", s.listAuthorizationActiveModelResourceTypes)
 	})
 
 	r.With(s.pluginRouteAuthMiddleware("name")).Get("/apps/{name}/operations", s.listOperations)

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -57,6 +57,7 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 
 		r.Post("/authorization/check-access", s.checkAuthorizationAccess)
 		r.Get("/authorization/relationships", s.listAuthorizationRelationships)
+		r.Post("/authorization/relationships", s.addAuthorizationRelationship)
 	})
 
 	r.With(s.pluginRouteAuthMiddleware("name")).Get("/apps/{name}/operations", s.listOperations)

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -58,6 +58,7 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 		r.Post("/authorization/check-access", s.checkAuthorizationAccess)
 		r.Get("/authorization/relationships", s.listAuthorizationRelationships)
 		r.Post("/authorization/relationships", s.addAuthorizationRelationship)
+		r.Delete("/authorization/relationships", s.deleteAuthorizationRelationship)
 	})
 
 	r.With(s.pluginRouteAuthMiddleware("name")).Get("/apps/{name}/operations", s.listOperations)

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -55,6 +55,7 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 		r.Delete("/tokens", s.revokeAllAPITokens)
 		r.Delete("/tokens/{id}", s.revokeAPIToken)
 
+		r.Post("/authorization/check-access", s.checkAuthorizationAccess)
 	})
 
 	r.With(s.pluginRouteAuthMiddleware("name")).Get("/apps/{name}/operations", s.listOperations)

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -57,8 +57,6 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 
 		r.Post("/authorization/check-access", s.checkAuthorizationAccess)
 		r.Get("/authorization/relationships", s.listAuthorizationRelationships)
-		r.Post("/authorization/relationships", s.addAuthorizationRelationship)
-		r.Delete("/authorization/relationships", s.deleteAuthorizationRelationship)
 		r.Get("/authorization/models/active", s.getAuthorizationActiveModelRef)
 		r.Get("/authorization/models/active/resource-types", s.listAuthorizationActiveModelResourceTypes)
 	})

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -59,6 +59,7 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 		r.Get("/authorization/relationships", s.listAuthorizationRelationships)
 		r.Post("/authorization/relationships", s.addAuthorizationRelationship)
 		r.Delete("/authorization/relationships", s.deleteAuthorizationRelationship)
+		r.Get("/authorization/models/active", s.getAuthorizationActiveModelRef)
 	})
 
 	r.With(s.pluginRouteAuthMiddleware("name")).Get("/apps/{name}/operations", s.listOperations)

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -56,6 +56,7 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 		r.Delete("/tokens/{id}", s.revokeAPIToken)
 
 		r.Post("/authorization/check-access", s.checkAuthorizationAccess)
+		r.Get("/authorization/relationships", s.listAuthorizationRelationships)
 	})
 
 	r.With(s.pluginRouteAuthMiddleware("name")).Get("/apps/{name}/operations", s.listOperations)


### PR DESCRIPTION
## Description

Adds authenticated authorization provider HTTP endpoints and matching `gestalt authorization` CLI commands for access checks, relationship management, and active model inspection. The PR is split into endpoint-focused commits within a single PR.