### PR TITLE
Make registry provider cards respond instantly on hover

### DIFF
--- a/docs/app/registry/registry.module.css
+++ b/docs/app/registry/registry.module.css
@@ -358,6 +358,7 @@
 }
 
 .providerCard {
+  position: relative;
   display: grid;
   min-height: 72px;
   align-items: center;
@@ -370,18 +371,39 @@
   color: inherit;
   padding: 12px;
   text-align: left;
+  /* hover-out timing; :hover snaps in instantly */
   transition:
-    background-color 150ms ease,
-    border-color 150ms ease,
-    box-shadow 150ms ease,
-    transform 150ms ease;
+    background-color 200ms var(--valon-ease-out-quart),
+    border-color 200ms var(--valon-ease-out-quart),
+    transform 200ms var(--valon-ease-out-quart);
+}
+
+/*
+ * Hover shadow lives on a pre-rendered pseudo-element faded via opacity:
+ * transitioning box-shadow itself repaints every frame and stutters, while
+ * opacity runs on the compositor.
+ */
+.providerCard::after {
+  content: "";
+  position: absolute;
+  inset: -1px;
+  border-radius: 12px;
+  box-shadow: 0 8px 24px var(--registry-shadow);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 200ms var(--valon-ease-out-quart);
 }
 
 .providerCard:hover {
   border-color: var(--valon-line-strong);
   background: var(--registry-surface-hover);
-  box-shadow: 0 8px 24px var(--registry-shadow);
   transform: translateY(-1px);
+  transition: none;
+}
+
+.providerCard:hover::after {
+  opacity: 1;
+  transition: none;
 }
 
 .selectedCard {
@@ -393,9 +415,6 @@
 .selectedCard:hover {
   border-color: rgba(var(--valon-ink), 0.34);
   background: var(--registry-selected-hover);
-  box-shadow:
-    inset 3px 0 0 var(--valon-gold),
-    0 8px 24px var(--registry-shadow);
 }
 
 .providerText {
@@ -485,7 +504,8 @@
   align-items: center;
   justify-content: center;
   border: 1px solid var(--valon-line);
-  border-radius: 12px;
+  /* half the providerCard radius; also clips full-bleed tile icons */
+  border-radius: 6px;
   background: var(--registry-icon-surface);
   object-fit: contain;
 }

--- a/docs/globals.css
+++ b/docs/globals.css
@@ -64,6 +64,7 @@
   --valon-muted: rgba(35, 24, 16, 0.6);
   --valon-secondary: rgba(35, 24, 16, 0.8);
   --valon-gold: #e19614;
+  --valon-ease-out-quart: cubic-bezier(0.25, 1, 0.5, 1);
   --valon-content-width: 46rem;
   --nextra-primary-hue: 37deg;
   --nextra-primary-saturation: 84%;


### PR DESCRIPTION
## Summary

Hovering a provider card in the registry now feels like pressing a real button: it reacts the instant the cursor lands, and relaxes back smoothly when you leave. Icon tiles also get a slightly tighter corner radius so they read as content inside the card rather than competing with it.

## Why

My intention was to make the provider list feel snappy. A button that reacts with a slow transition — like the cards did before — feels sluggish; to feel responsive it has to react *immediately*. So the hover-in state now applies instantly, while the hover-out eases back over 200ms with an ease-out-quart curve. The asymmetry creates a slightly dissonant, organic effect, but it preserves the snap on the way in, which is the part you actually feel.

While tuning this I noticed the drop shadow flickered during the transition. Animating `box-shadow` forces the browser to repaint the shadow every frame, which stutters at short durations. The fix is to render the shadow at full strength on a hidden pseudo-element and animate its *opacity* instead — fading the shadow in and out rather than growing it — which the browser can composite smoothly.

## What changed

- Provider card hover: instant in (`transition: none` on `:hover`), 200ms ease-out-quart on the way out.
- The easing curve is now a shared design token, `--valon-ease-out-quart` in `globals.css`, instead of a repeated hard-coded `cubic-bezier`.
- Hover shadow moved to a pre-rendered `::after` faded via opacity (and the selected card no longer double-stacks the old element shadow on top of it).
- Icon tiles use a 6px corner radius, half the card's 12px, which also crops the full-bleed tile icons shipped in valon-technologies/gestalt-providers#1000.

## Demo

![Provider card hover demo](https://raw.githubusercontent.com/valon-technologies/gestalt/pr-media/provider-hover-2026-06-09.gif)

[Full-quality screen recording (.mov)](https://github.com/valon-technologies/gestalt/blob/pr-media/provider-hover-2026-06-09.mov)