### PR TITLE
[cli] bump gestalt CLI to 0.0.2-alpha.5

### DIFF
--- a/gestalt/Cargo.toml
+++ b/gestalt/Cargo.toml
@@ -3,5 +3,5 @@ resolver = "2"
 members = ["cli"]
 
 [workspace.package]
-version = "0.0.2-alpha.4"
+version = "0.0.2-alpha.5"
 edition = "2024"


### PR DESCRIPTION
## Description

Bumps the Gestalt CLI workspace package version to 0.0.2-alpha.5 so the next `gestalt/v0.0.2-alpha.5` release tag passes version verification.