### PR TITLE
Stop forwarding resolved tools on agent turns

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -329,23 +329,6 @@ func bootstrapAgentMessagesFromProto(src []*proto.AgentMessage) []coreagent.Mess
 	return out
 }
 
-func bootstrapAgentToolsFromProto(src []*proto.ResolvedAgentTool) []coreagent.Tool {
-	out := make([]coreagent.Tool, 0, len(src))
-	for _, tool := range src {
-		if tool == nil {
-			continue
-		}
-		out = append(out, coreagent.Tool{
-			ID:               tool.GetId(),
-			Name:             tool.GetName(),
-			Description:      tool.GetDescription(),
-			ParametersSchema: bootstrapAgentProtoStructToMap(tool.GetParametersSchema()),
-			Target:           bootstrapAgentToolTargetFromProto(tool.GetRef()),
-		})
-	}
-	return out
-}
-
 func bootstrapAgentToolsToProto(src []coreagent.Tool) []*proto.ResolvedAgentTool {
 	out := make([]*proto.ResolvedAgentTool, 0, len(src))
 	for _, tool := range src {
@@ -358,21 +341,6 @@ func bootstrapAgentToolsToProto(src []coreagent.Tool) []*proto.ResolvedAgentTool
 		})
 	}
 	return out
-}
-
-func bootstrapAgentToolTargetFromProto(ref *proto.AgentToolRef) coreagent.ToolTarget {
-	if ref == nil {
-		return coreagent.ToolTarget{}
-	}
-	return coreagent.ToolTarget{
-		System:         strings.TrimSpace(ref.GetSystem()),
-		App:            strings.TrimSpace(ref.GetApp()),
-		Operation:      strings.TrimSpace(ref.GetOperation()),
-		Connection:     core.ResolveConnectionAlias(strings.TrimSpace(ref.GetConnection())),
-		Instance:       strings.TrimSpace(ref.GetInstance()),
-		CredentialMode: core.ConnectionMode(strings.TrimSpace(ref.GetCredentialMode())),
-		RunAs:          agentwire.RunAsSubjectFromProto(ref.GetRunAs()),
-	}
 }
 
 func bootstrapAgentToolRefFromTarget(target coreagent.ToolTarget) coreagent.ToolRef {
@@ -731,7 +699,24 @@ type callbackAgentProvider struct {
 	*recordingAgentProvider
 	started                *runtimehost.StartedHostServices
 	toolBodies             []string
+	sessionToolRefs        map[string]*proto.AgentToolRef
 	resolveInteractionHook func(context.Context, *proto.ResolveAgentProviderInteractionRequest) error
+}
+
+func (p *callbackAgentProvider) CreateSession(ctx context.Context, req *proto.CreateAgentProviderSessionRequest) (*coreagent.Session, error) {
+	session, err := p.recordingAgentProvider.CreateSession(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if tools := req.GetTools().GetCatalog().GetTools(); len(tools) > 0 {
+		p.mu.Lock()
+		if p.sessionToolRefs == nil {
+			p.sessionToolRefs = map[string]*proto.AgentToolRef{}
+		}
+		p.sessionToolRefs[session.ID] = gproto.Clone(tools[0].GetRef()).(*proto.AgentToolRef)
+		p.mu.Unlock()
+	}
+	return session, nil
 }
 
 type callbackSessionCatalogIntegration struct {
@@ -816,7 +801,10 @@ func (p *callbackAgentProvider) CreateTurn(ctx context.Context, req *proto.Creat
 	}
 
 	outputBody := ""
-	if len(req.GetTools()) > 0 {
+	p.mu.Lock()
+	toolRef := p.sessionToolRefs[req.GetSessionId()]
+	p.mu.Unlock()
+	if toolRef != nil {
 		socketPath := strings.TrimSpace(p.started.SocketBinding().SocketPath)
 		if socketPath == "" {
 			cleanupPendingTurn()
@@ -835,35 +823,31 @@ func (p *callbackAgentProvider) CreateTurn(ctx context.Context, req *proto.Creat
 			return nil, fmt.Errorf("dial app host: %w", err)
 		}
 		defer func() { _ = conn.Close() }()
-		tools := bootstrapAgentToolsFromProto(req.GetTools())
-		if len(tools) > 0 {
-			target := tools[0].Target
-			if strings.TrimSpace(target.App) == "" || strings.TrimSpace(target.Operation) == "" {
-				cleanupPendingTurn()
-				return nil, fmt.Errorf("resolved app tool target is missing")
-			}
-			resp, err := proto.NewAppClient(conn).Invoke(ctx, &proto.AppInvokeRequest{
-				App:            strings.TrimSpace(target.App),
-				Operation:      strings.TrimSpace(target.Operation),
-				Connection:     core.ResolveConnectionAlias(strings.TrimSpace(target.Connection)),
-				Instance:       strings.TrimSpace(target.Instance),
-				CredentialMode: string(core.NormalizeOptionalConnectionMode(target.CredentialMode)),
-				Context:        req.GetContext(),
-				Params: func() *structpb.Struct {
-					value, err := structpb.NewStruct(map[string]any{"taskId": "task-123"})
-					if err != nil {
-						panic(err)
-					}
-					return value
-				}(),
-				IdempotencyKey: "tool-call-1",
-			})
-			if err != nil {
-				cleanupPendingTurn()
-				return nil, err
-			}
-			outputBody = string(resp.GetBody())
+		if strings.TrimSpace(toolRef.GetApp()) == "" || strings.TrimSpace(toolRef.GetOperation()) == "" {
+			cleanupPendingTurn()
+			return nil, fmt.Errorf("session catalog tool ref is missing")
 		}
+		resp, err := proto.NewAppClient(conn).Invoke(ctx, &proto.AppInvokeRequest{
+			App:            strings.TrimSpace(toolRef.GetApp()),
+			Operation:      strings.TrimSpace(toolRef.GetOperation()),
+			Connection:     core.ResolveConnectionAlias(strings.TrimSpace(toolRef.GetConnection())),
+			Instance:       strings.TrimSpace(toolRef.GetInstance()),
+			CredentialMode: string(core.NormalizeOptionalConnectionMode(core.ConnectionMode(toolRef.GetCredentialMode()))),
+			Context:        req.GetContext(),
+			Params: func() *structpb.Struct {
+				value, err := structpb.NewStruct(map[string]any{"taskId": "task-123"})
+				if err != nil {
+					panic(err)
+				}
+				return value
+			}(),
+			IdempotencyKey: "tool-call-1",
+		})
+		if err != nil {
+			cleanupPendingTurn()
+			return nil, err
+		}
+		outputBody = string(resp.GetBody())
 	}
 
 	p.mu.Lock()
@@ -2298,11 +2282,8 @@ func TestBootstrapAgentManagerCreateTurnPersistsMetadataForToolCallbacks(t *test
 	if createTurnReq.GetCreatedBySubjectId() != p.SubjectID {
 		t.Fatalf("CreateTurn created_by_subject_id = %q, want %q", createTurnReq.GetCreatedBySubjectId(), p.SubjectID)
 	}
-	if len(createTurnReq.GetTools()) != 1 {
-		t.Fatalf("CreateTurn tools = %#v, want one resolved catalog tool", createTurnReq.GetTools())
-	}
-	if ref := createTurnReq.GetTools()[0].GetRef(); ref.GetApp() != "roadmap" || ref.GetOperation() != "sync" {
-		t.Fatalf("CreateTurn tool ref = %#v, want roadmap.sync", ref)
+	if len(createTurnReq.GetTools()) != 0 {
+		t.Fatalf("CreateTurn tools = %#v, want none for catalog sessions", createTurnReq.GetTools())
 	}
 	if createTurnReq.GetContext() == nil {
 		t.Fatal("CreateTurn context is empty")

--- a/gestaltd/internal/bootstrap/executable_app_test.go
+++ b/gestaltd/internal/bootstrap/executable_app_test.go
@@ -3893,11 +3893,8 @@ func TestPluginAgentManagerTurnUsesInheritedInvokesAndRequestContext(t *testing.
 	if requireInteraction, _ := turnMetadata["requireInteraction"].(bool); !requireInteraction {
 		t.Fatalf("CreateTurn metadata = %#v, want requireInteraction=true", turnMetadata)
 	}
-	if len(turnReq.Tools) != 1 {
-		t.Fatalf("CreateTurn tools = %#v, want one resolved catalog tool", turnReq.Tools)
-	}
-	if ref := turnReq.Tools[0].GetRef(); ref.GetApp() != "roadmap" || ref.GetOperation() != "sync" {
-		t.Fatalf("CreateTurn tool ref = %#v, want roadmap.sync", ref)
+	if len(turnReq.Tools) != 0 {
+		t.Fatalf("CreateTurn tools = %#v, want none for catalog sessions", turnReq.Tools)
 	}
 }
 

--- a/gestaltd/internal/server/agent_session_turn_test.go
+++ b/gestaltd/internal/server/agent_session_turn_test.go
@@ -928,10 +928,8 @@ func TestAgentSessionsAndTurnsRoundTrip(t *testing.T) {
 	if len(turnRequests) != 1 {
 		t.Fatalf("provider turn requests len = %d, want 1", len(turnRequests))
 	}
-	if got := turnRequests[0].GetTools(); len(got) != 1 {
-		t.Fatalf("provider turn tools = %#v, want one resolved catalog tool", got)
-	} else if ref := got[0].GetRef(); ref.GetApp() != "docs" || ref.GetOperation() != "search" {
-		t.Fatalf("provider turn tool ref = %#v, want docs.search", ref)
+	if got := turnRequests[0].GetTools(); len(got) != 0 {
+		t.Fatalf("provider turn tools = %#v, want none for catalog sessions", got)
 	}
 
 	eventsReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/agent/turns/"+turnID+"/events?provider=managed&after=0&limit=10", nil)

--- a/gestaltd/services/agents/agentmanager/agent_app_authority.go
+++ b/gestaltd/services/agents/agentmanager/agent_app_authority.go
@@ -276,11 +276,6 @@ func agentWorkflowOperationAllowed(scope agentturnscope.Scope, operation string)
 			return true
 		}
 	}
-	for i := range scope.Tools {
-		if workflowToolTargetMatches(scope.Tools[i].Target, operation) {
-			return true
-		}
-	}
 	return false
 }
 
@@ -345,11 +340,6 @@ func agentWorkflowAppStepAllowed(scope agentturnscope.Scope, target coreworkflow
 			return true
 		}
 	}
-	for i := range scope.Tools {
-		if scope.Tools[i].Target.Unavailable == nil && agentWorkflowToolTargetMatchesAppCall(scope.Tools[i].Target, target) {
-			return true
-		}
-	}
 	return false
 }
 
@@ -361,11 +351,6 @@ func agentWorkflowAppRefAllowed(scope agentturnscope.Scope, target coreagent.Too
 	}
 	for i := range scope.ListedTools {
 		if scope.ListedTools[i].Target.Unavailable == nil && agentWorkflowToolTargetMatchesToolRef(scope.ListedTools[i].Target, target) {
-			return true
-		}
-	}
-	for i := range scope.Tools {
-		if scope.Tools[i].Target.Unavailable == nil && agentWorkflowToolTargetMatchesToolRef(scope.Tools[i].Target, target) {
 			return true
 		}
 	}

--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -816,9 +816,11 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req *p
 	if callerKind != "" && callerName != "" {
 		ctx = invocation.WithCallerProvider(ctx, callerKind, callerName)
 	}
+	if len(req.GetTools()) > 0 {
+		return nil, fmt.Errorf("%w: turn-level resolved tools are not supported; configure session tools instead", invocation.ErrInvalidInvocation)
+	}
 	toolSource := coreagent.ToolSourceModeNone
 	var toolRefs []coreagent.ToolRef
-	var tools []coreagent.Tool
 	var listedTools []coreagent.ListedTool
 	toolRefsSet := true
 	if sessionScope, ok, err := m.sessionScopeForSession(ctx, p, ownedSession.providerName, ownedSession.session); err != nil {
@@ -826,7 +828,6 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req *p
 	} else if ok {
 		toolSource = normalizeAgentToolSource(sessionScope.ToolSource)
 		toolRefs = append([]coreagent.ToolRef(nil), sessionScope.ToolRefs...)
-		tools = append([]coreagent.Tool(nil), sessionScope.Tools...)
 		listedTools = append([]coreagent.ListedTool(nil), sessionScope.ListedTools...)
 	}
 	requestedOutput := agentOutputFromProto(req.GetOutput())
@@ -857,25 +858,12 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req *p
 	default:
 		return nil, fmt.Errorf("%w: unsupported agent tool source %q", invocation.ErrInvalidInvocation, toolSource)
 	}
-	switch toolSource {
-	case coreagent.ToolSourceModeCatalog:
-		if len(tools) == 0 {
-			tools, err = resolvedAgentToolsFromListedTools(listedTools)
-			if err != nil {
-				return nil, err
-			}
-		}
-	case coreagent.ToolSourceModeNone:
-		tools = nil
+	if toolSource == coreagent.ToolSourceModeNone {
 		listedTools = nil
-	}
-	providerTools, err := resolvedAgentToolsToProto(tools)
-	if err != nil {
-		return nil, err
 	}
 	idempotencyKey := strings.TrimSpace(req.GetIdempotencyKey())
 	turnID := newAgentTurnID(ownedSession.session.ID, idempotencyKey)
-	if err := m.storeTurnScope(ctx, req.GetContext(), p, ownedSession.providerName, ownedSession.session.ID, turnID, callerKind, callerName, toolRefs, toolRefsSet, tools, listedTools, toolSource); err != nil {
+	if err := m.storeTurnScope(ctx, req.GetContext(), p, ownedSession.providerName, ownedSession.session.ID, turnID, callerKind, callerName, toolRefs, toolRefsSet, listedTools, toolSource); err != nil {
 		return nil, err
 	}
 	scopeCommitted := false
@@ -890,7 +878,6 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req *p
 	providerReq.ProviderName = ownedSession.providerName
 	providerReq.IdempotencyKey = idempotencyKey
 	providerReq.Model = strings.TrimSpace(req.GetModel())
-	providerReq.Tools = providerTools
 	providerReq.CreatedBySubjectId = agentSubjectIDFromPrincipal(p)
 	providerReq.ExecutionRef = turnID
 	providerReq.Subject = agentSubjectToProto(agentSubjectFromPrincipal(p))
@@ -1600,7 +1587,7 @@ func agentProviderReturnedNotFound(err error) bool {
 	return errors.Is(err, core.ErrNotFound) || status.Code(err) == codes.NotFound
 }
 
-func (m *Manager) storeTurnScope(ctx context.Context, reqContext *proto.RequestContext, p *principal.Principal, providerName, sessionID, turnID string, callerKind invocation.ProviderKind, callerName string, toolRefs []coreagent.ToolRef, toolRefsSet bool, tools []coreagent.Tool, listedTools []coreagent.ListedTool, toolSource coreagent.ToolSourceMode) error {
+func (m *Manager) storeTurnScope(ctx context.Context, reqContext *proto.RequestContext, p *principal.Principal, providerName, sessionID, turnID string, callerKind invocation.ProviderKind, callerName string, toolRefs []coreagent.ToolRef, toolRefsSet bool, listedTools []coreagent.ListedTool, toolSource coreagent.ToolSourceMode) error {
 	if m == nil || m.turnScopes == nil {
 		return fmt.Errorf("%w: agent turn scopes are not configured", invocation.ErrInternal)
 	}
@@ -1628,7 +1615,6 @@ func (m *Manager) storeTurnScope(ctx context.Context, reqContext *proto.RequestC
 		Permissions:         permissions,
 		ToolRefs:            append([]coreagent.ToolRef(nil), toolRefs...),
 		ToolRefsSet:         toolRefsSet,
-		Tools:               append([]coreagent.Tool(nil), tools...),
 		ListedTools:         append([]coreagent.ListedTool(nil), listedTools...),
 		ToolSource:          toolSource,
 		Connections:         connections,
@@ -2759,77 +2745,6 @@ func listedAgentToolsToProto(tools []coreagent.ListedTool) []*proto.ListedAgentT
 		out = append(out, listedAgentToolToProto(tools[i]))
 	}
 	return out
-}
-
-func resolvedAgentToolsFromListedTools(tools []coreagent.ListedTool) ([]coreagent.Tool, error) {
-	if len(tools) == 0 {
-		return nil, nil
-	}
-	out := make([]coreagent.Tool, 0, len(tools))
-	for i := range tools {
-		tool := tools[i]
-		if tool.Target.Unavailable != nil {
-			continue
-		}
-		parametersSchema := agentToolPermissiveInputSchemaMap()
-		if raw := strings.TrimSpace(tool.InputSchemaJSON); raw != "" {
-			var decoded map[string]any
-			if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
-				return nil, fmt.Errorf("decode listed agent tool input schema: %w", err)
-			}
-			if len(decoded) > 0 {
-				parametersSchema = decoded
-			}
-		}
-		name := strings.TrimSpace(tool.MCPName)
-		if name == "" {
-			name = strings.TrimSpace(tool.Title)
-		}
-		if name == "" {
-			name = strings.TrimSpace(tool.ToolID)
-		}
-		out = append(out, coreagent.Tool{
-			ID:               strings.TrimSpace(tool.ToolID),
-			Name:             name,
-			Description:      strings.TrimSpace(tool.Description),
-			ParametersSchema: parametersSchema,
-			Target:           tool.Target,
-			Hidden:           tool.Hidden,
-		})
-	}
-	return out, nil
-}
-
-func resolvedAgentToolsToProto(tools []coreagent.Tool) ([]*proto.ResolvedAgentTool, error) {
-	if len(tools) == 0 {
-		return nil, nil
-	}
-	out := make([]*proto.ResolvedAgentTool, 0, len(tools))
-	for i := range tools {
-		if tools[i].Target.Unavailable != nil {
-			continue
-		}
-		tool, err := resolvedAgentToolToProto(tools[i])
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, tool)
-	}
-	return out, nil
-}
-
-func resolvedAgentToolToProto(tool coreagent.Tool) (*proto.ResolvedAgentTool, error) {
-	parametersSchema, err := protoutil.StructFromMap(tool.ParametersSchema)
-	if err != nil {
-		return nil, fmt.Errorf("agent tool parameters schema: %w", err)
-	}
-	return &proto.ResolvedAgentTool{
-		Id:               strings.TrimSpace(tool.ID),
-		Name:             strings.TrimSpace(tool.Name),
-		Description:      strings.TrimSpace(tool.Description),
-		ParametersSchema: parametersSchema,
-		Ref:              agentwire.ToolRefToProto(agentToolRefFromTarget(tool.Target)),
-	}, nil
 }
 
 func listedAgentToolToProto(tool coreagent.ListedTool) *proto.ListedAgentTool {

--- a/gestaltd/services/agents/agentmanager/manager_test.go
+++ b/gestaltd/services/agents/agentmanager/manager_test.go
@@ -2326,8 +2326,46 @@ func TestManagerCreateTurnUsesNoToolsWhenSessionToolsAreOmitted(t *testing.T) {
 	if scope.ToolSource != coreagent.ToolSourceModeNone {
 		t.Fatalf("scope tool source = %q, want none", scope.ToolSource)
 	}
-	if len(scope.ToolRefs) != 0 || len(scope.Tools) != 0 || len(scope.Connections) != 0 {
-		t.Fatalf("turn scope = refs:%#v tools:%#v connections:%#v, want no tool or connection scope", scope.ToolRefs, scope.Tools, scope.Connections)
+	if len(scope.ToolRefs) != 0 || len(scope.Connections) != 0 {
+		t.Fatalf("turn scope = refs:%#v connections:%#v, want no tool or connection scope", scope.ToolRefs, scope.Connections)
+	}
+}
+
+func TestManagerCreateTurnRejectsResolvedTools(t *testing.T) {
+	t.Parallel()
+
+	alpha := newRouteCountingAgentProvider("alpha")
+	manager := newTestManager(t, Config{
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers: map[string]*routeCountingAgentProvider{
+				"alpha": alpha,
+			},
+		},
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+
+	session, err := manager.CreateSession(context.Background(), p, &proto.CreateAgentProviderSessionRequest{
+		ProviderName: "alpha",
+		Model:        "test-model",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	_, err = manager.CreateTurn(context.Background(), p, &proto.CreateAgentProviderTurnRequest{
+		ProviderName:   "alpha",
+		TimeoutSeconds: 1,
+		SessionId:      session.ID,
+		Model:          "test-model",
+		Output:         agentTextOutputProto(),
+		Tools:          []*proto.ResolvedAgentTool{{Id: "tool-1", Name: "tool"}},
+	})
+	if !errors.Is(err, invocation.ErrInvalidInvocation) {
+		t.Fatalf("CreateTurn error = %v, want invalid invocation", err)
+	}
+	if len(alpha.createTurnReqs) != 0 {
+		t.Fatalf("CreateTurn requests = %d, want 0", len(alpha.createTurnReqs))
 	}
 }
 

--- a/gestaltd/services/agents/agentturnscope/store.go
+++ b/gestaltd/services/agents/agentturnscope/store.go
@@ -2,7 +2,6 @@ package agentturnscope
 
 import (
 	"fmt"
-	"maps"
 	"strings"
 	"sync"
 
@@ -30,7 +29,6 @@ type Scope struct {
 	ToolRefs            []coreagent.ToolRef
 	ToolRefsSet         bool
 	ListedTools         []coreagent.ListedTool
-	Tools               []coreagent.Tool
 	ToolSource          coreagent.ToolSourceMode
 	Connections         []ConnectionBinding
 	Revoked             bool
@@ -216,7 +214,6 @@ func cloneScope(src Scope) Scope {
 		ToolRefs:            cloneToolRefs(src.ToolRefs),
 		ToolRefsSet:         src.ToolRefsSet || len(src.ToolRefs) > 0,
 		ListedTools:         cloneListedTools(src.ListedTools),
-		Tools:               cloneTools(src.Tools),
 		ToolSource:          src.ToolSource,
 		Connections:         cloneConnectionBindings(src.Connections),
 		Revoked:             src.Revoked,
@@ -275,24 +272,6 @@ func cloneListedTools(src []coreagent.ListedTool) []coreagent.ListedTool {
 			OutputSchemaJSON: strings.TrimSpace(src[i].OutputSchemaJSON),
 			Annotations:      src[i].Annotations,
 			Ref:              cloneToolRefs([]coreagent.ToolRef{src[i].Ref})[0],
-			Target:           cloneToolTarget(src[i].Target),
-			Hidden:           src[i].Hidden,
-		})
-	}
-	return out
-}
-
-func cloneTools(src []coreagent.Tool) []coreagent.Tool {
-	if len(src) == 0 {
-		return nil
-	}
-	out := make([]coreagent.Tool, 0, len(src))
-	for i := range src {
-		out = append(out, coreagent.Tool{
-			ID:               strings.TrimSpace(src[i].ID),
-			Name:             strings.TrimSpace(src[i].Name),
-			Description:      strings.TrimSpace(src[i].Description),
-			ParametersSchema: maps.Clone(src[i].ParametersSchema),
 			Target:           cloneToolTarget(src[i].Target),
 			Hidden:           src[i].Hidden,
 		})


### PR DESCRIPTION
Every agent provider (claude, codex, cursor, hermes) rejects turn-level resolved tools and builds its tool surface from the session catalog config, but #2346 changed CreateTurn to forward resolved tools derived from listed tools. The two halves are incompatible: any catalog session turn fails with InvalidArgument "resolved tools are not supported by agent/<provider>". This broke every workflow agent step in production today (stuck "thinking..." Slack diagnoses).

This deletes the turn-level resolved tool plumbing rather than gating it: no derivation from listed tools, no forwarding to providers, callers supplying turn tools get InvalidArgument, and the redundant Scope.Tools field plus its authority branches are removed (listed tools already back every authority check). Net -75 lines.

Follow-up: reserve the CreateAgentProviderTurnRequest.tools proto field and drop the provider-side rejection guards once providers bump SDKs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)