### PR TITLE
Gate provider snapshots on a protocol epoch

### DIFF
--- a/gestaltd/internal/daemon/provider_release_finalize.go
+++ b/gestaltd/internal/daemon/provider_release_finalize.go
@@ -249,6 +249,7 @@ func buildProviderReleaseMetadata(manifest *providermanifestv1.Manifest, version
 	metadata := &providerrelease.Metadata{
 		Schema:        providerrelease.SchemaName,
 		SchemaVersion: providerrelease.SchemaVersion,
+		ProtocolEpoch: providerrelease.ProtocolEpoch,
 		Package:       manifest.Source,
 		Kind:          manifest.Kind,
 		Version:       version,

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -74,6 +74,7 @@ type LockSourceRef struct {
 
 type LockEntry struct {
 	InputDigest        string                       `json:"inputDigest,omitempty"`
+	ProtocolEpoch      int                          `json:"protocolEpoch,omitempty"`
 	Package            string                       `json:"package,omitempty"`
 	Kind               string                       `json:"kind,omitempty"`
 	Runtime            string                       `json:"runtime,omitempty"`
@@ -3060,6 +3061,9 @@ func (l *Lifecycle) installMetadataSourcePackage(ctx context.Context, expectedKi
 		return nil, LockEntry{}, fmt.Errorf("%s fetch metadata %q: %w", subject, sourceLocation, err)
 	}
 	metadata := bundle.Metadata
+	if err := providerrelease.ValidateProtocolEpoch(metadata.ProtocolEpoch); err != nil {
+		return nil, LockEntry{}, fmt.Errorf("%s: %w", subject, err)
+	}
 	expectedManifestKind := archivePolicyKind(expectedKind)
 	if metadata.Kind != expectedManifestKind {
 		return nil, LockEntry{}, fmt.Errorf("%s metadata kind %q does not match expected kind %q", subject, metadata.Kind, expectedManifestKind)
@@ -3069,12 +3073,13 @@ func (l *Lifecycle) installMetadataSourcePackage(ctx context.Context, expectedKi
 		return nil, LockEntry{}, fmt.Errorf("%s resolve archive metadata %q: %w", subject, sourceLocation, err)
 	}
 	entry := LockEntry{
-		Package:  metadata.Package,
-		Kind:     metadata.Kind,
-		Runtime:  providerrelease.RuntimeForManifest(metadata.Kind, bundle.Manifest),
-		Source:   providerSourceLockLocation(app, configDir),
-		Version:  metadata.Version,
-		Archives: archives,
+		Package:       metadata.Package,
+		Kind:          metadata.Kind,
+		Runtime:       providerrelease.RuntimeForManifest(metadata.Kind, bundle.Manifest),
+		Source:        providerSourceLockLocation(app, configDir),
+		Version:       metadata.Version,
+		Archives:      archives,
+		ProtocolEpoch: metadata.ProtocolEpoch,
 	}
 	staticManifest, err := portableStaticValidationManifest(bundle.Manifest, "", true)
 	if err != nil {

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -6281,3 +6281,87 @@ func TestLoadForExecutionAtPath_UnlockedMetadataSecretsProviderResolvesConfigSec
 		t.Fatal("secrets provider command is empty after load")
 	}
 }
+
+func TestLifecycleGitSourceSnapshotRejectsUnsupportedProtocolEpoch(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	const (
+		ref           = "cccccccccccccccccccccccccccccccccccccccc"
+		packageSource = "github.com/acme/providers/apps/alpha"
+		version       = "0.0.0-snapshot.gcccccccccccccccccccccccccccccccccccccccc"
+	)
+	archivePath := buildV2Archive(t, dir, packageSource, version, "snapshot-binary")
+	archiveSHA, err := providerpkg.ArchiveDigest(archivePath)
+	if err != nil {
+		t.Fatalf("archive digest: %v", err)
+	}
+	epoch := providerrelease.ProtocolEpoch
+	var epochMu sync.Mutex
+	metadataPath := "/snapshots/github.com/acme/providers/" + ref + "/apps/alpha/provider-release.yaml"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		epochMu.Lock()
+		fixtureEpoch := epoch
+		epochMu.Unlock()
+		metadata := providerReleaseMetadataFixture{
+			Package:       packageSource,
+			Kind:          providermanifestv1.KindApp,
+			Version:       version,
+			ProtocolEpoch: fixtureEpoch,
+			ArchivePath:   archivePath,
+			Artifacts: map[string]providerrelease.Artifact{
+				providerpkg.CurrentPlatformString(): {
+					Path:   "alpha.tar.gz",
+					SHA256: archiveSHA,
+				},
+			},
+		}
+		if !serveProviderReleaseFixture(t, w, r.URL.Path, metadataPath, metadata) {
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	artifactsDir := filepath.Join(dir, "artifacts")
+	configPath := filepath.Join(dir, "gestaltd.yaml")
+	configYAML := fmt.Sprintf(`
+apiVersion: gestaltd.config/v6
+providerSnapshotRepositories:
+  valon:
+    url: %s/snapshots
+%s
+server:
+  providers:
+    indexeddb: sqlite
+  artifactsDir: %s
+  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+apps:
+  alpha:
+    source:
+      git:
+        repo: https://github.com/acme/providers.git
+        ref: %s
+        path: apps/alpha/manifest.yaml
+        artifactRepository: valon
+        materialization: snapshot
+`, srv.URL, requiredComponentConfigYAML(t, dir, filepath.Join(dir, "snapshot-epoch.db")), filepath.ToSlash(artifactsDir), ref)
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	lock, err := NewLifecycle().WithHTTPClient(srv.Client()).LockAtPathsWithStatePaths([]string{configPath}, StatePaths{})
+	if err != nil {
+		t.Fatalf("LockAtPathsWithStatePaths with current epoch: %v", err)
+	}
+	if got := lock.Providers.App["alpha"].ProtocolEpoch; got != providerrelease.ProtocolEpoch {
+		t.Fatalf("lock entry protocolEpoch = %d, want %d", got, providerrelease.ProtocolEpoch)
+	}
+
+	epochMu.Lock()
+	epoch = providerrelease.ProtocolEpoch + 1
+	epochMu.Unlock()
+	_, err = NewLifecycle().WithHTTPClient(srv.Client()).LockAtPathsWithStatePaths([]string{configPath}, StatePaths{})
+	if err == nil || !strings.Contains(err.Error(), "protocol epoch") {
+		t.Fatalf("LockAtPathsWithStatePaths error = %v, want unsupported protocol epoch", err)
+	}
+}

--- a/gestaltd/internal/operator/release_metadata_test_helpers_test.go
+++ b/gestaltd/internal/operator/release_metadata_test_helpers_test.go
@@ -18,15 +18,16 @@ import (
 )
 
 type providerReleaseMetadataFixture struct {
-	Package      string
-	Kind         string
-	Version      string
-	Artifacts    map[string]providerrelease.Artifact
-	ArchivePath  string
-	Manifest     *providermanifestv1.Manifest
-	Catalog      *catalog.Catalog
-	NoCatalog    bool
-	AllowInvalid bool
+	Package       string
+	Kind          string
+	Version       string
+	ProtocolEpoch int
+	Artifacts     map[string]providerrelease.Artifact
+	ArchivePath   string
+	Manifest      *providermanifestv1.Manifest
+	Catalog       *catalog.Catalog
+	NoCatalog     bool
+	AllowInvalid  bool
 }
 
 type providerReleaseFixtureFiles struct {
@@ -61,6 +62,7 @@ func newProviderReleaseFixtureFiles(t *testing.T, fixture providerReleaseMetadat
 	metadata := &providerrelease.Metadata{
 		Schema:        providerrelease.SchemaName,
 		SchemaVersion: providerrelease.SchemaVersion,
+		ProtocolEpoch: fixture.ProtocolEpoch,
 		Package:       fixture.Package,
 		Kind:          fixture.Kind,
 		Version:       fixture.Version,

--- a/gestaltd/internal/providerrelease/release.go
+++ b/gestaltd/internal/providerrelease/release.go
@@ -25,9 +25,35 @@ const (
 	MaxBytes           = 16 << 20 // One file carries descriptor, validation manifest, and optional catalog.
 )
 
+// ProtocolEpoch identifies the host-provider protocol generation this gestaltd
+// builds and serves. Bump it in the same change as any breaking host-provider
+// protocol change (renamed proto services, removed compatibility fallbacks) so
+// stale provider snapshots fail `gestaltd lock` and `gestaltd lock --check` at
+// build time instead of crash-looping at bootstrap.
+const ProtocolEpoch = 1
+
+// MinSupportedProtocolEpoch is the oldest provider protocol generation this
+// gestaltd still serves. Raise it when compatibility for older generations is
+// removed.
+const MinSupportedProtocolEpoch = 1
+
+// ValidateProtocolEpoch rejects provider releases built against a protocol
+// generation this gestaltd cannot serve. Releases published before epochs were
+// stamped carry zero and are allowed.
+func ValidateProtocolEpoch(epoch int) error {
+	if epoch == 0 {
+		return nil
+	}
+	if epoch < MinSupportedProtocolEpoch || epoch > ProtocolEpoch {
+		return fmt.Errorf("provider release protocol epoch %d is outside this gestaltd's supported range [%d, %d]; republish the snapshot with a matching gestalt toolchain", epoch, MinSupportedProtocolEpoch, ProtocolEpoch)
+	}
+	return nil
+}
+
 type Metadata struct {
 	Schema           string            `yaml:"schema"`
 	SchemaVersion    int               `yaml:"schemaVersion"`
+	ProtocolEpoch    int               `yaml:"protocolEpoch,omitempty"`
 	Package          string            `yaml:"package"`
 	Kind             string            `yaml:"kind"`
 	Version          string            `yaml:"version"`


### PR DESCRIPTION
The 2026-06-09 incident chained three silent protocol skews between gestaltd and independently pinned provider snapshots (provider-scoped follow-ups, turn tools, the proto service rename), each discovered at runtime in production. This adds the deploy-time gate:

- `gestaltd provider publish` stamps `protocolEpoch` into release metadata from the toolchain that built the snapshot.
- `gestaltd lock` / `lock --check` reject any release whose epoch falls outside `[MinSupportedProtocolEpoch, ProtocolEpoch]`, with the rule that breaking host-provider protocol changes bump `ProtocolEpoch` in the same PR.
- Pre-epoch releases carry zero and pass, so existing snapshots keep resolving until rebuilt.

Since toolshed's image build already runs `gestaltd lock --check` with the deploy image's binary, a mismatched snapshot now fails CI instead of crash-looping bootstrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)