### PR TITLE
[authorization] route authz provider calls through gateway

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -34,6 +34,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/observability"
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
+	"github.com/valon-technologies/gestalt/server/services/providergateway"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost/runtimeprovider"
 	"github.com/valon-technologies/gestalt/server/services/workflows/workflowmanager"
@@ -975,6 +976,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 		_ = closeAuthProviders(authProviders)
 		return nil, err
 	}
+	authorizationProviders = providergateway.WrapAuthorizationProviders(authorizationProviders)
 	closeAuthorizationOnError := true
 	defer func() {
 		if closeAuthorizationOnError {

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -24,6 +24,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
+	"github.com/valon-technologies/gestalt/server/services/providergateway"
 
 	"google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
@@ -182,6 +183,7 @@ func (s *Server) authorizeServiceAccountCredentialManagement(ctx context.Context
 	if subjectID == "" {
 		return fmt.Errorf("not authenticated")
 	}
+	ctx = providergateway.WithInvokingSubjectID(ctx, subjectID)
 	resp, err := s.authorization.CheckAccess(ctx, &proto.CheckAccessRequest{
 		Subject: &proto.Subject{
 			Type: "subject",

--- a/gestaltd/internal/server/handlers_authorization.go
+++ b/gestaltd/internal/server/handlers_authorization.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -8,6 +9,7 @@ import (
 	"strings"
 
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/providergateway"
 	"google.golang.org/protobuf/encoding/protojson"
 	gproto "google.golang.org/protobuf/proto"
 )
@@ -20,7 +22,7 @@ func (s *Server) checkAuthorizationAccess(w http.ResponseWriter, r *http.Request
 	if !decodeProtoJSONBody(w, r, &req) {
 		return
 	}
-	resp, err := s.authorization.CheckAccess(r.Context(), &req)
+	resp, err := s.authorization.CheckAccess(providerGatewayHTTPContext(r), &req)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -36,7 +38,7 @@ func (s *Server) listAuthorizationRelationships(w http.ResponseWriter, r *http.R
 	if !ok {
 		return
 	}
-	resp, err := s.authorization.ListRelationships(r.Context(), req)
+	resp, err := s.authorization.ListRelationships(providerGatewayHTTPContext(r), req)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -52,7 +54,7 @@ func (s *Server) addAuthorizationRelationship(w http.ResponseWriter, r *http.Req
 	if !decodeProtoJSONBody(w, r, &req) {
 		return
 	}
-	resp, err := s.authorization.AddRelationship(r.Context(), &req)
+	resp, err := s.authorization.AddRelationship(providerGatewayHTTPContext(r), &req)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -68,7 +70,7 @@ func (s *Server) deleteAuthorizationRelationship(w http.ResponseWriter, r *http.
 	if !decodeProtoJSONBody(w, r, &req) {
 		return
 	}
-	resp, err := s.authorization.DeleteRelationship(r.Context(), &req)
+	resp, err := s.authorization.DeleteRelationship(providerGatewayHTTPContext(r), &req)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -80,7 +82,7 @@ func (s *Server) getAuthorizationActiveModelRef(w http.ResponseWriter, r *http.R
 	if !s.requireAuthorizationProvider(w) {
 		return
 	}
-	resp, err := s.authorization.GetActiveModelRef(r.Context())
+	resp, err := s.authorization.GetActiveModelRef(providerGatewayHTTPContext(r))
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -96,12 +98,20 @@ func (s *Server) listAuthorizationActiveModelResourceTypes(w http.ResponseWriter
 	if !ok {
 		return
 	}
-	resp, err := s.authorization.ListActiveModelResourceTypes(r.Context(), req)
+	resp, err := s.authorization.ListActiveModelResourceTypes(providerGatewayHTTPContext(r), req)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 	writeProtoJSON(w, http.StatusOK, resp)
+}
+
+func providerGatewayHTTPContext(r *http.Request) context.Context {
+	ctx := providergateway.WithSource(r.Context(), providergateway.GatewaySourceHTTP)
+	if subjectID := invokingPrincipalSubjectID(PrincipalFromContext(r.Context())); subjectID != "" {
+		ctx = providergateway.WithInvokingSubjectID(ctx, subjectID)
+	}
+	return ctx
 }
 
 func (s *Server) requireAuthorizationProvider(w http.ResponseWriter) bool {

--- a/gestaltd/internal/server/mounted_ui.go
+++ b/gestaltd/internal/server/mounted_ui.go
@@ -18,6 +18,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
+	"github.com/valon-technologies/gestalt/server/services/providergateway"
 	"github.com/valon-technologies/gestalt/server/services/ui"
 	"github.com/valon-technologies/gestalt/server/services/ui/adminui"
 )
@@ -477,6 +478,7 @@ func mountedUIRequiresAuthorization(mounted MountedUI) bool {
 }
 
 func (s *Server) mountedUIAuthorizationRoles(ctx context.Context, subjectID, resourceName string) (map[string]struct{}, error) {
+	ctx = providergateway.WithInvokingSubjectID(ctx, strings.TrimSpace(subjectID))
 	roles := map[string]struct{}{}
 	pageToken := ""
 	for {
@@ -513,6 +515,7 @@ func (s *Server) mountedUIAuthorizationRoles(ctx context.Context, subjectID, res
 }
 
 func (s *Server) mountedUIResourceDefaultAllows(ctx context.Context, resourceName string) (bool, error) {
+	ctx = providergateway.WithInvokingSubjectID(ctx, invokingPrincipalSubjectID(PrincipalFromContext(ctx)))
 	resp, err := s.authorization.ListActiveModelResourceTypes(ctx, &proto.ListActiveModelResourceTypesRequest{
 		Filter:   &proto.AuthorizationModelResourceTypeFilter{Name: strings.TrimSpace(resourceName)},
 		PageSize: 1,

--- a/gestaltd/services/appaccess/app_server.go
+++ b/gestaltd/services/appaccess/app_server.go
@@ -13,6 +13,7 @@ import (
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
+	"github.com/valon-technologies/gestalt/server/services/providergateway"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -297,6 +298,8 @@ func (s *AppServer) authorizeAppInvocation(ctx context.Context, callCtx requestI
 	if s == nil || s.authorization == nil {
 		return status.Error(codes.FailedPrecondition, "authorization provider is required for app invocation")
 	}
+	ctx = providergateway.WithInvokingSubjectID(ctx, callCtx.callerName)
+	ctx = providergateway.WithRequestContext(ctx, callCtx.requestContext)
 	resp, err := s.authorization.CheckAccess(ctx, &proto.CheckAccessRequest{
 		Subject: &proto.Subject{
 			Type: appInvocationAuthorizationSubjectTypeApp,

--- a/gestaltd/services/authorization/server.go
+++ b/gestaltd/services/authorization/server.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/providergateway"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -23,63 +24,67 @@ func (s *providerServer) CheckAccess(ctx context.Context, req *proto.CheckAccess
 	if err := s.requireProvider(); err != nil {
 		return nil, err
 	}
-	return s.provider.CheckAccess(ctx, req)
+	return s.provider.CheckAccess(providerGatewayGRPCContext(ctx), req)
 }
 
 func (s *providerServer) CheckAccessMany(ctx context.Context, req *proto.CheckAccessManyRequest) (*proto.CheckAccessManyResponse, error) {
 	if err := s.requireProvider(); err != nil {
 		return nil, err
 	}
-	return s.provider.CheckAccessMany(ctx, req)
+	return s.provider.CheckAccessMany(providerGatewayGRPCContext(ctx), req)
 }
 
 func (s *providerServer) ListRelationships(ctx context.Context, req *proto.ListRelationshipsRequest) (*proto.ListRelationshipsResponse, error) {
 	if err := s.requireProvider(); err != nil {
 		return nil, err
 	}
-	return s.provider.ListRelationships(ctx, req)
+	return s.provider.ListRelationships(providerGatewayGRPCContext(ctx), req)
 }
 
 func (s *providerServer) AddRelationship(ctx context.Context, req *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {
 	if err := s.requireProvider(); err != nil {
 		return nil, err
 	}
-	return s.provider.AddRelationship(ctx, req)
+	return s.provider.AddRelationship(providerGatewayGRPCContext(ctx), req)
 }
 
 func (s *providerServer) DeleteRelationship(ctx context.Context, req *proto.DeleteRelationshipRequest) (*proto.DeleteRelationshipResponse, error) {
 	if err := s.requireProvider(); err != nil {
 		return nil, err
 	}
-	return s.provider.DeleteRelationship(ctx, req)
+	return s.provider.DeleteRelationship(providerGatewayGRPCContext(ctx), req)
 }
 
 func (s *providerServer) SetAuthorizationState(ctx context.Context, req *proto.SetAuthorizationStateRequest) (*proto.SetAuthorizationStateResponse, error) {
 	if err := s.requireProvider(); err != nil {
 		return nil, err
 	}
-	return s.provider.SetAuthorizationState(ctx, req)
+	return s.provider.SetAuthorizationState(providerGatewayGRPCContext(ctx), req)
 }
 
 func (s *providerServer) GetActiveModelRef(ctx context.Context, _ *emptypb.Empty) (*proto.GetActiveModelRefResponse, error) {
 	if err := s.requireProvider(); err != nil {
 		return nil, err
 	}
-	return s.provider.GetActiveModelRef(ctx)
+	return s.provider.GetActiveModelRef(providerGatewayGRPCContext(ctx))
 }
 
 func (s *providerServer) SetActiveModel(ctx context.Context, req *proto.SetActiveModelRequest) (*proto.SetActiveModelResponse, error) {
 	if err := s.requireProvider(); err != nil {
 		return nil, err
 	}
-	return s.provider.SetActiveModel(ctx, req)
+	return s.provider.SetActiveModel(providerGatewayGRPCContext(ctx), req)
 }
 
 func (s *providerServer) ListActiveModelResourceTypes(ctx context.Context, req *proto.ListActiveModelResourceTypesRequest) (*proto.ListActiveModelResourceTypesResponse, error) {
 	if err := s.requireProvider(); err != nil {
 		return nil, err
 	}
-	return s.provider.ListActiveModelResourceTypes(ctx, req)
+	return s.provider.ListActiveModelResourceTypes(providerGatewayGRPCContext(ctx), req)
+}
+
+func providerGatewayGRPCContext(ctx context.Context) context.Context {
+	return providergateway.WithSource(ctx, providergateway.GatewaySourceSDKGRPC)
 }
 
 func (s *providerServer) requireProvider() error {

--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -17,6 +17,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/apps/registry"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
+	"github.com/valon-technologies/gestalt/server/services/providergateway"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -531,6 +532,7 @@ func (b *Broker) checkAuthorizationAccess(ctx context.Context, p *principal.Prin
 		return nil
 	}
 	req := authorizationAccessRequest(p, providerName, operationID)
+	ctx = providergateway.WithInvokingSubjectID(ctx, req.GetSubject().GetId())
 	resp, err := b.authorization.CheckAccess(ctx, req)
 	if err != nil {
 		return fmt.Errorf("%w: %s.%s: %v", ErrAuthorizationDenied, providerName, operationID, err)

--- a/gestaltd/services/providergateway/authorization_provider.go
+++ b/gestaltd/services/providergateway/authorization_provider.go
@@ -1,0 +1,172 @@
+package providergateway
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	gproto "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+var _ core.AuthorizationProvider = (*AuthorizationProvider)(nil)
+
+type AuthorizationProvider struct {
+	providerID string
+	gateway    ProviderGateway
+	downstream core.AuthorizationProvider
+}
+
+func NewAuthorizationProvider(providerID string, gateway ProviderGateway, downstream core.AuthorizationProvider) *AuthorizationProvider {
+	return &AuthorizationProvider{
+		providerID: providerID,
+		gateway:    gateway,
+		downstream: downstream,
+	}
+}
+
+func WrapAuthorizationProviders(providers map[string]core.AuthorizationProvider) map[string]core.AuthorizationProvider {
+	if len(providers) == 0 {
+		return providers
+	}
+	wrapped := make(map[string]core.AuthorizationProvider, len(providers))
+	for providerID, provider := range providers {
+		if provider == nil {
+			continue
+		}
+		gateway := New(WithAuthorizationProvider(providerID, provider))
+		wrapped[providerID] = NewAuthorizationProvider(providerID, gateway, provider)
+	}
+	return wrapped
+}
+
+func (p *AuthorizationProvider) CheckAccess(ctx context.Context, req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
+	var out proto.CheckAccessResponse
+	if err := p.invoke(ctx, "CheckAccess", req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (p *AuthorizationProvider) CheckAccessMany(ctx context.Context, req *proto.CheckAccessManyRequest) (*proto.CheckAccessManyResponse, error) {
+	var out proto.CheckAccessManyResponse
+	if err := p.invoke(ctx, "CheckAccessMany", req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (p *AuthorizationProvider) ListRelationships(ctx context.Context, req *proto.ListRelationshipsRequest) (*proto.ListRelationshipsResponse, error) {
+	var out proto.ListRelationshipsResponse
+	if err := p.invoke(ctx, "ListRelationships", req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (p *AuthorizationProvider) AddRelationship(ctx context.Context, req *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {
+	var out proto.AddRelationshipResponse
+	if err := p.invoke(ctx, "AddRelationship", req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (p *AuthorizationProvider) DeleteRelationship(ctx context.Context, req *proto.DeleteRelationshipRequest) (*proto.DeleteRelationshipResponse, error) {
+	var out proto.DeleteRelationshipResponse
+	if err := p.invoke(ctx, "DeleteRelationship", req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (p *AuthorizationProvider) SetAuthorizationState(ctx context.Context, req *proto.SetAuthorizationStateRequest) (*proto.SetAuthorizationStateResponse, error) {
+	var out proto.SetAuthorizationStateResponse
+	if err := p.invoke(ctx, "SetAuthorizationState", req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (p *AuthorizationProvider) GetActiveModelRef(ctx context.Context) (*proto.GetActiveModelRefResponse, error) {
+	var out proto.GetActiveModelRefResponse
+	if err := p.invoke(ctx, "GetActiveModelRef", &emptypb.Empty{}, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (p *AuthorizationProvider) SetActiveModel(ctx context.Context, req *proto.SetActiveModelRequest) (*proto.SetActiveModelResponse, error) {
+	var out proto.SetActiveModelResponse
+	if err := p.invoke(ctx, "SetActiveModel", req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (p *AuthorizationProvider) ListActiveModelResourceTypes(ctx context.Context, req *proto.ListActiveModelResourceTypesRequest) (*proto.ListActiveModelResourceTypesResponse, error) {
+	var out proto.ListActiveModelResourceTypesResponse
+	if err := p.invoke(ctx, "ListActiveModelResourceTypes", req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (p *AuthorizationProvider) Ping(ctx context.Context) error {
+	if p == nil || p.downstream == nil {
+		return nil
+	}
+	return p.downstream.Ping(ctx)
+}
+
+func (p *AuthorizationProvider) Close() error {
+	if p == nil || p.downstream == nil {
+		return nil
+	}
+	return p.downstream.Close()
+}
+
+func (p *AuthorizationProvider) invoke(ctx context.Context, operation string, in gproto.Message, out gproto.Message) error {
+	if p == nil || p.gateway == nil {
+		return fmt.Errorf("provider gateway: authorization provider %q is not configured", p.providerID)
+	}
+	payload, err := gproto.Marshal(in)
+	if err != nil {
+		return fmt.Errorf("provider gateway: encode %s request: %w", operation, err)
+	}
+	resp, err := p.gateway.Invoke(ctx, ProviderGatewayRequest{
+		ProviderID:        p.providerID,
+		ProviderKind:      ProviderKindAuthorization,
+		FullMethod:        "/" + proto.Authorization_ServiceDesc.ServiceName + "/" + operation,
+		InvokingSubjectID: invokingSubjectID(ctx, in),
+		RequestContext:    RequestContextFromContext(ctx),
+		Source:            SourceFromContext(ctx),
+		Payload:           payload,
+	})
+	if err != nil {
+		return err
+	}
+	if out == nil || len(resp.Payload) == 0 {
+		return nil
+	}
+	if err := gproto.Unmarshal(resp.Payload, out); err != nil {
+		return fmt.Errorf("provider gateway: decode %s response: %w", operation, err)
+	}
+	return nil
+}
+
+func invokingSubjectID(ctx context.Context, msg gproto.Message) string {
+	if subjectID := InvokingSubjectIDFromContext(ctx); subjectID != "" {
+		return subjectID
+	}
+	switch req := msg.(type) {
+	case *proto.CheckAccessRequest:
+		return req.GetSubject().GetId()
+	case *proto.CheckAccessManyRequest:
+		if len(req.GetRequests()) > 0 {
+			return req.GetRequests()[0].GetSubject().GetId()
+		}
+	}
+	return ""
+}

--- a/gestaltd/services/providergateway/authorization_provider.go
+++ b/gestaltd/services/providergateway/authorization_provider.go
@@ -139,7 +139,7 @@ func (p *AuthorizationProvider) invoke(ctx context.Context, operation string, in
 		ProviderID:        p.providerID,
 		ProviderKind:      ProviderKindAuthorization,
 		FullMethod:        "/" + proto.Authorization_ServiceDesc.ServiceName + "/" + operation,
-		InvokingSubjectID: invokingSubjectID(ctx, in),
+		InvokingSubjectID: InvokingSubjectIDFromContext(ctx),
 		RequestContext:    RequestContextFromContext(ctx),
 		Source:            SourceFromContext(ctx),
 		Payload:           payload,
@@ -154,19 +154,4 @@ func (p *AuthorizationProvider) invoke(ctx context.Context, operation string, in
 		return fmt.Errorf("provider gateway: decode %s response: %w", operation, err)
 	}
 	return nil
-}
-
-func invokingSubjectID(ctx context.Context, msg gproto.Message) string {
-	if subjectID := InvokingSubjectIDFromContext(ctx); subjectID != "" {
-		return subjectID
-	}
-	switch req := msg.(type) {
-	case *proto.CheckAccessRequest:
-		return req.GetSubject().GetId()
-	case *proto.CheckAccessManyRequest:
-		if len(req.GetRequests()) > 0 {
-			return req.GetRequests()[0].GetSubject().GetId()
-		}
-	}
-	return ""
 }

--- a/gestaltd/services/providergateway/authorization_provider_test.go
+++ b/gestaltd/services/providergateway/authorization_provider_test.go
@@ -1,0 +1,117 @@
+package providergateway
+
+import (
+	"context"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	gproto "google.golang.org/protobuf/proto"
+)
+
+func TestAuthorizationProviderWrapsCheckAccessInGatewayRequest(t *testing.T) {
+	gateway := &recordingGateway{
+		response: mustMarshal(t, &proto.CheckAccessResponse{Allowed: true, ModelId: "model-1"}),
+	}
+	provider := NewAuthorizationProvider("authz", gateway, nil)
+	ctx := WithSource(context.Background(), GatewaySourceHTTP)
+	ctx = WithInvokingSubjectID(ctx, "user:caller")
+
+	resp, err := provider.CheckAccess(ctx, &proto.CheckAccessRequest{
+		Subject:  &proto.Subject{Type: "subject", Id: "user:target"},
+		Action:   &proto.Action{Name: "view"},
+		Resource: &proto.Resource{Type: "team", Id: "servicing"},
+	})
+	if err != nil {
+		t.Fatalf("CheckAccess: %v", err)
+	}
+	if !resp.GetAllowed() || resp.GetModelId() != "model-1" {
+		t.Fatalf("response = %+v, want allowed model-1", resp)
+	}
+
+	got := gateway.request
+	if got.ProviderID != "authz" {
+		t.Fatalf("ProviderID = %q, want authz", got.ProviderID)
+	}
+	if got.ProviderKind != ProviderKindAuthorization {
+		t.Fatalf("ProviderKind = %q, want %q", got.ProviderKind, ProviderKindAuthorization)
+	}
+	if got.FullMethod != "/gestalt.provider.v1.Authorization/CheckAccess" {
+		t.Fatalf("FullMethod = %q", got.FullMethod)
+	}
+	if got.Source != GatewaySourceHTTP {
+		t.Fatalf("Source = %q, want %q", got.Source, GatewaySourceHTTP)
+	}
+	if got.InvokingSubjectID != "user:caller" {
+		t.Fatalf("InvokingSubjectID = %q, want user:caller", got.InvokingSubjectID)
+	}
+	var payload proto.CheckAccessRequest
+	if err := gproto.Unmarshal(got.Payload, &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload.GetSubject().GetId() != "user:target" {
+		t.Fatalf("payload subject = %q, want user:target", payload.GetSubject().GetId())
+	}
+}
+
+func TestGatewayInvokesAuthorizationProvider(t *testing.T) {
+	authz := &stubAuthorizationProvider{
+		checkAccess: &proto.CheckAccessResponse{Allowed: true},
+	}
+	gateway := New(WithAuthorizationProvider("authz", authz))
+	payload := mustMarshal(t, &proto.CheckAccessRequest{
+		Subject:  &proto.Subject{Type: "subject", Id: "user:alice"},
+		Action:   &proto.Action{Name: "manage"},
+		Resource: &proto.Resource{Type: "team", Id: "servicing"},
+	})
+
+	resp, err := gateway.Invoke(context.Background(), ProviderGatewayRequest{
+		ProviderID:   "authz",
+		ProviderKind: ProviderKindAuthorization,
+		FullMethod:   "/gestalt.provider.v1.Authorization/CheckAccess",
+		Payload:      payload,
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	var out proto.CheckAccessResponse
+	if err := gproto.Unmarshal(resp.Payload, &out); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if !out.GetAllowed() {
+		t.Fatal("allowed = false, want true")
+	}
+	if authz.lastCheckAccess.GetSubject().GetId() != "user:alice" {
+		t.Fatalf("provider subject = %q, want user:alice", authz.lastCheckAccess.GetSubject().GetId())
+	}
+}
+
+type recordingGateway struct {
+	request  ProviderGatewayRequest
+	response []byte
+}
+
+func (g *recordingGateway) Invoke(_ context.Context, req ProviderGatewayRequest) (ProviderGatewayResponse, error) {
+	g.request = req
+	return ProviderGatewayResponse{Payload: g.response}, nil
+}
+
+type stubAuthorizationProvider struct {
+	core.AuthorizationProvider
+	checkAccess     *proto.CheckAccessResponse
+	lastCheckAccess *proto.CheckAccessRequest
+}
+
+func (p *stubAuthorizationProvider) CheckAccess(_ context.Context, req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
+	p.lastCheckAccess = req
+	return p.checkAccess, nil
+}
+
+func mustMarshal(t *testing.T, msg gproto.Message) []byte {
+	t.Helper()
+	payload, err := gproto.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return payload
+}

--- a/gestaltd/services/providergateway/authorization_provider_test.go
+++ b/gestaltd/services/providergateway/authorization_provider_test.go
@@ -86,6 +86,25 @@ func TestGatewayInvokesAuthorizationProvider(t *testing.T) {
 	}
 }
 
+func TestAuthorizationProviderDoesNotInferInvokingSubjectFromPayload(t *testing.T) {
+	gateway := &recordingGateway{
+		response: mustMarshal(t, &proto.CheckAccessResponse{Allowed: true}),
+	}
+	provider := NewAuthorizationProvider("authz", gateway, nil)
+
+	_, err := provider.CheckAccess(context.Background(), &proto.CheckAccessRequest{
+		Subject:  &proto.Subject{Type: "subject", Id: "user:checked"},
+		Action:   &proto.Action{Name: "view"},
+		Resource: &proto.Resource{Type: "team", Id: "servicing"},
+	})
+	if err != nil {
+		t.Fatalf("CheckAccess: %v", err)
+	}
+	if gateway.request.InvokingSubjectID != "" {
+		t.Fatalf("InvokingSubjectID = %q, want empty", gateway.request.InvokingSubjectID)
+	}
+}
+
 type recordingGateway struct {
 	request  ProviderGatewayRequest
 	response []byte

--- a/gestaltd/services/providergateway/context.go
+++ b/gestaltd/services/providergateway/context.go
@@ -1,0 +1,50 @@
+package providergateway
+
+import "context"
+
+type contextKey string
+
+const (
+	sourceContextKey            contextKey = "provider_gateway_source"
+	invokingSubjectIDContextKey contextKey = "provider_gateway_invoking_subject_id"
+	requestContextContextKey    contextKey = "provider_gateway_request_context"
+)
+
+func WithSource(ctx context.Context, source GatewaySource) context.Context {
+	if source == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, sourceContextKey, source)
+}
+
+func SourceFromContext(ctx context.Context) GatewaySource {
+	source, _ := ctx.Value(sourceContextKey).(GatewaySource)
+	if source == "" {
+		return GatewaySourceInternal
+	}
+	return source
+}
+
+func WithInvokingSubjectID(ctx context.Context, subjectID string) context.Context {
+	if subjectID == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, invokingSubjectIDContextKey, subjectID)
+}
+
+func InvokingSubjectIDFromContext(ctx context.Context) string {
+	subjectID, _ := ctx.Value(invokingSubjectIDContextKey).(string)
+	return subjectID
+}
+
+func WithRequestContext(ctx context.Context, reqCtx *RequestContext) context.Context {
+	if reqCtx == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, requestContextContextKey, reqCtx)
+}
+
+func RequestContextFromContext(ctx context.Context) *RequestContext {
+	reqCtx, _ := ctx.Value(requestContextContextKey).(*RequestContext)
+	return reqCtx
+}

--- a/gestaltd/services/providergateway/gateway.go
+++ b/gestaltd/services/providergateway/gateway.go
@@ -1,0 +1,146 @@
+package providergateway
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	gproto "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+type Gateway struct {
+	authorization map[string]core.AuthorizationProvider
+}
+
+type Option func(*Gateway)
+
+func WithAuthorizationProvider(providerID string, provider core.AuthorizationProvider) Option {
+	return func(g *Gateway) {
+		if provider == nil {
+			return
+		}
+		if g.authorization == nil {
+			g.authorization = map[string]core.AuthorizationProvider{}
+		}
+		g.authorization[strings.TrimSpace(providerID)] = provider
+	}
+}
+
+func New(opts ...Option) *Gateway {
+	g := &Gateway{}
+	for _, opt := range opts {
+		opt(g)
+	}
+	return g
+}
+
+func (g *Gateway) Invoke(ctx context.Context, req ProviderGatewayRequest) (ProviderGatewayResponse, error) {
+	switch req.ProviderKind {
+	case ProviderKindAuthorization:
+		return g.invokeAuthorization(ctx, req)
+	default:
+		return ProviderGatewayResponse{}, fmt.Errorf("provider gateway: unsupported provider kind %q", req.ProviderKind)
+	}
+}
+
+func (g *Gateway) invokeAuthorization(ctx context.Context, req ProviderGatewayRequest) (ProviderGatewayResponse, error) {
+	provider := g.authorization[strings.TrimSpace(req.ProviderID)]
+	if provider == nil {
+		return ProviderGatewayResponse{}, fmt.Errorf("provider gateway: authorization provider %q is not configured", req.ProviderID)
+	}
+	method := strings.TrimPrefix(strings.TrimSpace(req.FullMethod), authorizationMethodPrefix())
+	if method == req.FullMethod || method == "" {
+		return ProviderGatewayResponse{}, fmt.Errorf("provider gateway: unsupported authorization method %q", req.FullMethod)
+	}
+
+	switch method {
+	case "CheckAccess":
+		var in proto.CheckAccessRequest
+		if err := gproto.Unmarshal(req.Payload, &in); err != nil {
+			return ProviderGatewayResponse{}, fmt.Errorf("provider gateway: decode CheckAccess request: %w", err)
+		}
+		out, err := provider.CheckAccess(ctx, &in)
+		return marshalGatewayResponse(out, err)
+	case "CheckAccessMany":
+		var in proto.CheckAccessManyRequest
+		if err := gproto.Unmarshal(req.Payload, &in); err != nil {
+			return ProviderGatewayResponse{}, fmt.Errorf("provider gateway: decode CheckAccessMany request: %w", err)
+		}
+		out, err := provider.CheckAccessMany(ctx, &in)
+		return marshalGatewayResponse(out, err)
+	case "ListRelationships":
+		var in proto.ListRelationshipsRequest
+		if err := gproto.Unmarshal(req.Payload, &in); err != nil {
+			return ProviderGatewayResponse{}, fmt.Errorf("provider gateway: decode ListRelationships request: %w", err)
+		}
+		out, err := provider.ListRelationships(ctx, &in)
+		return marshalGatewayResponse(out, err)
+	case "AddRelationship":
+		var in proto.AddRelationshipRequest
+		if err := gproto.Unmarshal(req.Payload, &in); err != nil {
+			return ProviderGatewayResponse{}, fmt.Errorf("provider gateway: decode AddRelationship request: %w", err)
+		}
+		out, err := provider.AddRelationship(ctx, &in)
+		return marshalGatewayResponse(out, err)
+	case "DeleteRelationship":
+		var in proto.DeleteRelationshipRequest
+		if err := gproto.Unmarshal(req.Payload, &in); err != nil {
+			return ProviderGatewayResponse{}, fmt.Errorf("provider gateway: decode DeleteRelationship request: %w", err)
+		}
+		out, err := provider.DeleteRelationship(ctx, &in)
+		return marshalGatewayResponse(out, err)
+	case "SetAuthorizationState":
+		var in proto.SetAuthorizationStateRequest
+		if err := gproto.Unmarshal(req.Payload, &in); err != nil {
+			return ProviderGatewayResponse{}, fmt.Errorf("provider gateway: decode SetAuthorizationState request: %w", err)
+		}
+		out, err := provider.SetAuthorizationState(ctx, &in)
+		return marshalGatewayResponse(out, err)
+	case "GetActiveModelRef":
+		if len(req.Payload) > 0 {
+			var in emptypb.Empty
+			if err := gproto.Unmarshal(req.Payload, &in); err != nil {
+				return ProviderGatewayResponse{}, fmt.Errorf("provider gateway: decode GetActiveModelRef request: %w", err)
+			}
+		}
+		out, err := provider.GetActiveModelRef(ctx)
+		return marshalGatewayResponse(out, err)
+	case "SetActiveModel":
+		var in proto.SetActiveModelRequest
+		if err := gproto.Unmarshal(req.Payload, &in); err != nil {
+			return ProviderGatewayResponse{}, fmt.Errorf("provider gateway: decode SetActiveModel request: %w", err)
+		}
+		out, err := provider.SetActiveModel(ctx, &in)
+		return marshalGatewayResponse(out, err)
+	case "ListActiveModelResourceTypes":
+		var in proto.ListActiveModelResourceTypesRequest
+		if err := gproto.Unmarshal(req.Payload, &in); err != nil {
+			return ProviderGatewayResponse{}, fmt.Errorf("provider gateway: decode ListActiveModelResourceTypes request: %w", err)
+		}
+		out, err := provider.ListActiveModelResourceTypes(ctx, &in)
+		return marshalGatewayResponse(out, err)
+	default:
+		return ProviderGatewayResponse{}, fmt.Errorf("provider gateway: unsupported authorization method %q", method)
+	}
+}
+
+func authorizationMethodPrefix() string {
+	return "/" + proto.Authorization_ServiceDesc.ServiceName + "/"
+}
+
+func marshalGatewayResponse(msg gproto.Message, err error) (ProviderGatewayResponse, error) {
+	if err != nil {
+		return ProviderGatewayResponse{}, err
+	}
+	if msg == nil {
+		return ProviderGatewayResponse{}, nil
+	}
+	payload, err := gproto.Marshal(msg)
+	if err != nil {
+		return ProviderGatewayResponse{}, fmt.Errorf("provider gateway: encode response: %w", err)
+	}
+	return ProviderGatewayResponse{Payload: payload}, nil
+}

--- a/gestaltd/services/providergateway/types.go
+++ b/gestaltd/services/providergateway/types.go
@@ -1,0 +1,41 @@
+package providergateway
+
+import (
+	"context"
+
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+)
+
+type ProviderKind string
+
+const (
+	ProviderKindAuthorization ProviderKind = "authorization"
+)
+
+type GatewaySource string
+
+const (
+	GatewaySourceHTTP     GatewaySource = "http"
+	GatewaySourceSDKGRPC  GatewaySource = "sdk_grpc"
+	GatewaySourceInternal GatewaySource = "internal"
+)
+
+type RequestContext = proto.RequestContext
+
+type ProviderGateway interface {
+	Invoke(ctx context.Context, req ProviderGatewayRequest) (ProviderGatewayResponse, error)
+}
+
+type ProviderGatewayRequest struct {
+	ProviderID        string
+	ProviderKind      ProviderKind
+	FullMethod        string
+	InvokingSubjectID string
+	RequestContext    *RequestContext
+	Source            GatewaySource
+	Payload           []byte
+}
+
+type ProviderGatewayResponse struct {
+	Payload []byte
+}

--- a/gestaltd/services/workflows/manager_server.go
+++ b/gestaltd/services/workflows/manager_server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/observability"
+	"github.com/valon-technologies/gestalt/server/services/providergateway"
 	"github.com/valon-technologies/gestalt/server/services/workflows/workflowauth"
 	"github.com/valon-technologies/gestalt/server/services/workflows/workflowmanager"
 	"google.golang.org/grpc/codes"
@@ -596,6 +597,7 @@ func (s *ProviderServer) requireWorkflowAccess(ctx context.Context, authCtx work
 	if s == nil || s.authorization == nil {
 		return status.Error(codes.FailedPrecondition, "authorization provider is required for workflow manager operation")
 	}
+	ctx = providergateway.WithInvokingSubjectID(ctx, authCtx.CallerName())
 	resp, err := s.authorization.CheckAccess(ctx, &proto.CheckAccessRequest{
 		Subject: &proto.Subject{
 			Type: workflowauth.SubjectTypeApp,


### PR DESCRIPTION
## Description

Introduces a ProviderGateway envelope and wraps configured authorization providers so HTTP, SDK gRPC, and internal authorization requests flow through the gateway before reaching the underlying provider.