### PR TITLE
Pass provider OTLP endpoint env as a URL

### DIFF
--- a/gestaltd/services/observability/drivers/otlp/otlp.go
+++ b/gestaltd/services/observability/drivers/otlp/otlp.go
@@ -199,7 +199,13 @@ func buildProviderTelemetryEnv(cfg yamlConfig) map[string]string {
 		"OTEL_EXPORTER_OTLP_PROTOCOL": otelEnvProtocol(cfg.Protocol),
 	}
 	if cfg.Endpoint != "" {
-		env["OTEL_EXPORTER_OTLP_ENDPOINT"] = cfg.Endpoint
+		// OTEL_EXPORTER_OTLP_ENDPOINT requires a URL; the host:port form used
+		// by WithEndpoint parses with an empty host in the SDK env config.
+		scheme := "https"
+		if cfg.Insecure {
+			scheme = "http"
+		}
+		env["OTEL_EXPORTER_OTLP_ENDPOINT"] = scheme + "://" + cfg.Endpoint
 	}
 	if cfg.Insecure {
 		env["OTEL_EXPORTER_OTLP_INSECURE"] = "true"

--- a/gestaltd/services/observability/drivers/otlp/otlp_test.go
+++ b/gestaltd/services/observability/drivers/otlp/otlp_test.go
@@ -28,8 +28,8 @@ func TestProviderTelemetryEnvUsesOTLPConfig(t *testing.T) {
 	if got := env["OTEL_SERVICE_NAME"]; got != "gestalt-provider-simple" {
 		t.Fatalf("OTEL_SERVICE_NAME = %q, want provider service name", got)
 	}
-	if got := env["OTEL_EXPORTER_OTLP_ENDPOINT"]; got != "otel-collector:4317" {
-		t.Fatalf("OTEL_EXPORTER_OTLP_ENDPOINT = %q, want endpoint", got)
+	if got := env["OTEL_EXPORTER_OTLP_ENDPOINT"]; got != "http://otel-collector:4317" {
+		t.Fatalf("OTEL_EXPORTER_OTLP_ENDPOINT = %q, want endpoint URL", got)
 	}
 	if got := env["OTEL_EXPORTER_OTLP_PROTOCOL"]; got != "grpc" {
 		t.Fatalf("OTEL_EXPORTER_OTLP_PROTOCOL = %q, want grpc", got)


### PR DESCRIPTION
Provider subprocesses receive the collector address via `OTEL_EXPORTER_OTLP_ENDPOINT`, which the OpenTelemetry SDKs parse as a URL. gestaltd forwarded its configured endpoint verbatim, so host:port values like `otel.peachstreet.dev:4317` parsed with an empty host and provider exporters dialed an empty gRPC target, failing every export with `delegating_resolver: invalid target address "": missing address` and never delivering provider telemetry. The valon-tools Cloud Run service logs this every metric export interval for each Go provider process.

This prefixes the endpoint with a scheme when building the provider telemetry env: `http://` when the exporter is configured insecure and `https://` otherwise. The parent process keeps the raw host:port form, which is what `WithEndpoint` expects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)