### PR TITLE
Provision replacement docs TLS cert alongside live cert

### DIFF
--- a/docs/terraform/main.tf
+++ b/docs/terraform/main.tf
@@ -20,6 +20,7 @@ provider "google" {
 }
 
 locals {
+  www_domain                = "www.${var.domain}"
   docs_cert_name            = "${var.resource_prefix}-cert-${replace(var.domain, ".", "-")}-${replace(var.registry_domain, ".", "-")}"
   github_actions_email      = "github-actions@${var.project_id}.iam.gserviceaccount.com"
   sdk_api_docs_bucket_name  = var.sdk_api_docs_bucket_name != "" ? var.sdk_api_docs_bucket_name : "${var.resource_prefix}-sdk-api-docs"
@@ -115,8 +116,24 @@ resource "google_compute_url_map" "docs" {
   default_service = google_compute_backend_service.docs.id
 
   host_rule {
+    hosts        = [local.www_domain]
+    path_matcher = "www_redirect"
+  }
+
+  host_rule {
     hosts        = ["*"]
     path_matcher = "docs"
+  }
+
+  path_matcher {
+    name = "www_redirect"
+
+    default_url_redirect {
+      host_redirect          = var.domain
+      https_redirect         = false
+      strip_query            = false
+      redirect_response_code = "MOVED_PERMANENTLY_DEFAULT"
+    }
   }
 
   path_matcher {
@@ -219,6 +236,15 @@ resource "google_dns_record_set" "registry" {
   type         = "A"
   ttl          = 300
   rrdatas      = [google_compute_global_address.docs.address]
+}
+
+resource "google_dns_record_set" "www" {
+  provider     = google.dns
+  managed_zone = google_dns_managed_zone.docs.name
+  name         = "${local.www_domain}."
+  type         = "CNAME"
+  ttl          = 300
+  rrdatas      = ["${var.domain}."]
 }
 
 # ---------- Workload Identity Federation ----------

--- a/docs/terraform/main.tf
+++ b/docs/terraform/main.tf
@@ -22,6 +22,7 @@ provider "google" {
 locals {
   www_domain                = "www.${var.domain}"
   docs_cert_name            = "${var.resource_prefix}-cert-${replace(var.domain, ".", "-")}-${replace(var.registry_domain, ".", "-")}"
+  docs_cert_with_www_name   = "${var.resource_prefix}-cert-${replace(var.domain, ".", "-")}-${replace(local.www_domain, ".", "-")}-${replace(var.registry_domain, ".", "-")}"
   github_actions_email      = "github-actions@${var.project_id}.iam.gserviceaccount.com"
   sdk_api_docs_bucket_name  = var.sdk_api_docs_bucket_name != "" ? var.sdk_api_docs_bucket_name : "${var.resource_prefix}-sdk-api-docs"
   sdk_api_docs_backend_name = "${var.resource_prefix}-sdk-api-docs-backend"
@@ -161,17 +162,28 @@ resource "google_compute_managed_ssl_certificate" "docs" {
 
   lifecycle {
     create_before_destroy = true
-    # A newly-created Google-managed certificate can be provisioned in Terraform
-    # before it is actually served at the edge. Refuse certificate replacement
-    # plans so domain changes cannot detach the active certificate first.
-    prevent_destroy = true
+  }
+}
+
+resource "google_compute_managed_ssl_certificate" "docs_with_www" {
+  name = local.docs_cert_with_www_name
+
+  managed {
+    domains = [var.domain, local.www_domain, var.registry_domain]
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 
 resource "google_compute_target_https_proxy" "docs" {
-  name             = "${var.resource_prefix}-https-proxy"
-  url_map          = google_compute_url_map.docs.id
-  ssl_certificates = [google_compute_managed_ssl_certificate.docs.id]
+  name    = "${var.resource_prefix}-https-proxy"
+  url_map = google_compute_url_map.docs.id
+  ssl_certificates = [
+    google_compute_managed_ssl_certificate.docs.id,
+    google_compute_managed_ssl_certificate.docs_with_www.id,
+  ]
 }
 
 resource "google_compute_global_address" "docs" {


### PR DESCRIPTION
## Summary
- Create a new Google-managed certificate covering apex, `www`, and registry.
- Attach **both** the existing and replacement certificates to the HTTPS proxy.
- Remove `prevent_destroy` on the legacy cert so it can be retired in the next PR.

Part 2 of 3. Stacked on #2391.

## Why dual certs
Google’s zero-downtime rotation pattern: provision the replacement while the live cert keeps serving apex/registry traffic.

## Merge order
1. Merge and deploy #2391
2. **This PR (#2392)** → merge and deploy
3. Wait until the replacement cert is `ACTIVE` in GCP (up to ~60 min)
4. Merge [#2393](https://github.com/valon-technologies/gestalt/pull/2393)

## Test plan
- [ ] After deploy: HTTPS proxy lists two managed certificates
- [ ] `https://gestaltd.ai/` and `https://registry.gestaltd.ai/` still work
- [ ] Replacement cert moves from `PROVISIONING` → `ACTIVE`