### PR TITLE
Fix www redirect path matcher name for GCP URL map

### DIFF
--- a/docs/terraform/main.tf
+++ b/docs/terraform/main.tf
@@ -22,7 +22,8 @@ provider "google" {
 locals {
   www_domain                = "www.${var.domain}"
   docs_cert_name            = "${var.resource_prefix}-cert-${replace(var.domain, ".", "-")}-${replace(var.registry_domain, ".", "-")}"
-  docs_cert_with_www_name   = "${var.resource_prefix}-cert-${replace(var.domain, ".", "-")}-${replace(local.www_domain, ".", "-")}-${replace(var.registry_domain, ".", "-")}"
+  # GCP SSL certificate names must be <=63 chars and match [a-z]([-a-z0-9]*[a-z0-9])?
+  docs_cert_with_www_name = "${var.resource_prefix}-cert-with-www"
   github_actions_email      = "github-actions@${var.project_id}.iam.gserviceaccount.com"
   sdk_api_docs_bucket_name  = var.sdk_api_docs_bucket_name != "" ? var.sdk_api_docs_bucket_name : "${var.resource_prefix}-sdk-api-docs"
   sdk_api_docs_backend_name = "${var.resource_prefix}-sdk-api-docs-backend"

--- a/docs/terraform/main.tf
+++ b/docs/terraform/main.tf
@@ -118,7 +118,7 @@ resource "google_compute_url_map" "docs" {
 
   host_rule {
     hosts        = [local.www_domain]
-    path_matcher = "www_redirect"
+    path_matcher = "www-redirect"
   }
 
   host_rule {
@@ -127,7 +127,7 @@ resource "google_compute_url_map" "docs" {
   }
 
   path_matcher {
-    name = "www_redirect"
+    name = "www-redirect"
 
     default_url_redirect {
       host_redirect          = var.domain


### PR DESCRIPTION
## Summary
- Rename URL map path matcher from `www_redirect` to `www-redirect`
- Unblocks terraform apply for the merged www DNS/redirect work (#2391)

## Context
Deploy for #2391 partially applied: the `www` CNAME was created, but URL map update failed because GCP path matcher names cannot contain underscores.

## Test plan
- [ ] Docs deploy workflow succeeds
- [ ] `curl -sI https://www.gestaltd.ai/` returns 301 to apex