### PR TITLE
Add the request accessors and the provider context bridge

### DIFF
--- a/sdk/go/app_invocation_transport_test.go
+++ b/sdk/go/app_invocation_transport_test.go
@@ -54,7 +54,7 @@ func (h *pluginAppTransportHarness) InvokeGraphQL(ctx context.Context, req *prot
 
 	return &proto.OperationResult{
 		Status: 208,
-		Body:   []byte("graphql-ok"),
+		Body:   []byte(`{"data":{"viewer":"graphql-ok"},"errors":[]}`),
 	}, nil
 }
 
@@ -137,14 +137,34 @@ func TestTransport_AppTCPTargetTokenEnv(t *testing.T) {
 	if err != nil {
 		t.Fatalf("InvokeGraphQL: %v", err)
 	}
-	if graphQLResult.Status != 208 || string(graphQLResult.Body) != "graphql-ok" {
-		t.Fatalf("InvokeGraphQL result = %+v, want status=208 body=graphql-ok", graphQLResult)
+	if graphQLResult.Status != 208 || string(graphQLResult.Body) != `{"data":{"viewer":"graphql-ok"},"errors":[]}` {
+		t.Fatalf("InvokeGraphQL result = %+v, want the raw graphql envelope", graphQLResult)
+	}
+
+	rawGraphQL, err := app.InvokeGraphQL(context.Background(), "linear", "query { viewer { id } }", &client.AppInvokeGraphQLOptions{
+		IdempotencyKey: "graphql-call-43",
+		Variables:      map[string]any{"team": "eng"},
+	})
+	if err != nil {
+		t.Fatalf("InvokeGraphQL: %v", err)
+	}
+	decodedGraphQL, err := client.DecodeGraphQLResult("linear", rawGraphQL.Status, rawGraphQL.Body)
+	if err != nil {
+		t.Fatalf("DecodeGraphQLResult: %v", err)
+	}
+	if got := decodedGraphQL.(map[string]any)["data"].(map[string]any)["viewer"]; got != "graphql-ok" {
+		t.Fatalf("decoded graphql = %#v, want viewer graphql-ok", decodedGraphQL)
 	}
 
 	harness.mu.Lock()
 	defer harness.mu.Unlock()
-	if len(harness.tokens) != 3 || harness.tokens[0] != "relay-token-go" || harness.tokens[1] != "relay-token-go" || harness.tokens[2] != "relay-token-go" {
-		t.Fatalf("relay tokens = %#v, want three relay-token-go entries", harness.tokens)
+	if len(harness.tokens) != 4 {
+		t.Fatalf("relay tokens = %#v, want four entries", harness.tokens)
+	}
+	for _, token := range harness.tokens {
+		if token != "relay-token-go" {
+			t.Fatalf("relay tokens = %#v, want only relay-token-go entries", harness.tokens)
+		}
 	}
 	if len(harness.requests) != 2 {
 		t.Fatalf("invoke requests len = %d, want 2", len(harness.requests))
@@ -170,8 +190,11 @@ func TestTransport_AppTCPTargetTokenEnv(t *testing.T) {
 	if got := harness.requests[1].GetParams().AsMap(); len(got) != 1 || got["issue_number"] != float64(43) {
 		t.Fatalf("flattened invoke params = %#v, want only issue_number=43", got)
 	}
-	if len(harness.graphQL) != 1 {
-		t.Fatalf("graphql requests len = %d, want 1", len(harness.graphQL))
+	if len(harness.graphQL) != 2 {
+		t.Fatalf("graphql requests len = %d, want 2", len(harness.graphQL))
+	}
+	if harness.graphQL[1].GetIdempotencyKey() != "graphql-call-43" || harness.graphQL[1].GetDocument() != "query { viewer { id } }" {
+		t.Fatalf("helper graphql request = %+v, want trimmed key and document", harness.graphQL[1])
 	}
 	if got := harness.graphQL[0].GetContext().GetSubject().GetId(); got != "user:transport" {
 		t.Fatalf("graphql subject = %q, want user:transport", got)

--- a/sdk/python/docs/reference.rst
+++ b/sdk/python/docs/reference.rst
@@ -62,6 +62,36 @@ Core authoring types
 
 .. _python-app-authoring:
 
+Invocation results and request context
+--------------------------------------
+
+These helpers decode app invocation results carrying the standard JSON
+operation envelope, report and enforce HTTP statuses on raw results, and
+convert a protocol-level request context into the generated clients' native
+form.
+
+.. autosummary::
+   :nosignatures:
+
+   InvokeError
+   decode_app_result
+   decode_graphql_result
+   ok
+   raise_for_status
+   native_request_context
+
+.. autoexception:: InvokeError
+
+.. autofunction:: decode_app_result
+
+.. autofunction:: decode_graphql_result
+
+.. autofunction:: ok
+
+.. autofunction:: raise_for_status
+
+.. autofunction:: native_request_context
+
 App authoring
 ----------------
 

--- a/sdk/python/gestalt/__init__.py
+++ b/sdk/python/gestalt/__init__.py
@@ -35,6 +35,7 @@ from ._api import (
     Subject,
     SubjectPermission,
     field,
+    native_request_context,
     parse_subject_id,
 )
 from .invoke_support import (
@@ -636,6 +637,7 @@ __all__ = [
     "indexeddb_range_bounds",
     "new_indexeddb_cursor_snapshot",
     "operation",
+    "native_request_context",
     "parse_subject_id",
     "session_catalog",
     "telemetry",

--- a/sdk/python/gestalt/_api.py
+++ b/sdk/python/gestalt/_api.py
@@ -128,26 +128,26 @@ class Request:
 
         return self.connection_params.get(name)
 
-    def app(self) -> "App":
+    def app(self, *, timeout: float | None = None) -> "App":
         """Return a generated :class:`gestalt.app.App` client bound to this
         request's ambient context."""
 
         from .app import App
 
-        return App.connect(context=self._native_context())
+        return App.connect(context=self._native_context(), timeout=timeout)
 
-    def agent(self) -> "Agent":
+    def agent(self, *, timeout: float | None = None) -> "Agent":
         """Return a generated :class:`gestalt.agent.Agent` client bound to this
         request's ambient context."""
 
         from .agent import Agent
 
-        return Agent.connect(context=self._native_context())
+        return Agent.connect(context=self._native_context(), timeout=timeout)
 
-    def workflows(self) -> "Workflow":
+    def workflows(self, *, timeout: float | None = None) -> "Workflow":
         from ._workflow import Workflow
 
-        return Workflow(self)
+        return Workflow(self, timeout=timeout)
 
     def authorization(self) -> "Authorization":
         """Return the shared generated :class:`gestalt.authorization.Authorization`
@@ -156,16 +156,23 @@ class Request:
         return _shared_authorization_client()
 
     def _native_context(self) -> "RequestContext | None":
-        if self.context is None:
-            return None
-        from ._codec.app import from_wire_request_context
-
-        return from_wire_request_context(self.context)
+        return native_request_context(self.context)
 
     def workflow_run_context(self) -> "WorkflowRunContext":
         from ._workflow import parse_workflow_run_context
 
         return parse_workflow_run_context(self.workflow)
+
+
+def native_request_context(context: Any | None) -> "RequestContext | None":
+    """Convert a provider-protocol wire request context into the native
+    :class:`RequestContext` accepted by the generated clients."""
+
+    if context is None:
+        return None
+    from ._codec.app import from_wire_request_context
+
+    return from_wire_request_context(context)
 
 
 @dataclasses.dataclass(slots=True)

--- a/sdk/python/gestalt/_workflow.py
+++ b/sdk/python/gestalt/_workflow.py
@@ -2349,7 +2349,13 @@ class Workflow:
     include one.
     """
 
-    def __init__(self, request: Request, *, idempotency_key: str = "") -> None:
+    def __init__(
+        self,
+        request: Request,
+        *,
+        idempotency_key: str = "",
+        timeout: float | None = None,
+    ) -> None:
         target = os.environ.get(ENV_HOST_SERVICE_SOCKET, "")
         if not target:
             raise RuntimeError(f"workflow: {ENV_HOST_SERVICE_SOCKET} is not set")
@@ -2357,6 +2363,7 @@ class Workflow:
 
         self._channel = host_service_channel("workflow", target, token=relay_token)
         self._stub = pb_grpc.WorkflowStub(self._channel)
+        self._timeout = timeout
         self._context = request.context
         if not idempotency_key.strip():
             idempotency_key = request.idempotency_key
@@ -2376,7 +2383,7 @@ class Workflow:
         self._attach_context(request)
         if not getattr(request, "idempotency_key", "").strip():
             request.idempotency_key = self._idempotency_key
-        return workflow_run_from_proto(_grpc_call(self._stub.StartRun, request))
+        return workflow_run_from_proto(_grpc_call(self._stub.StartRun, request, timeout=self._timeout))
 
     def signal_run(
         self, request: WorkflowSignalRunInput = None, **kwargs: object
@@ -2385,7 +2392,7 @@ class Workflow:
 
         request = _workflow_signal_run_request(request, **kwargs)
         self._attach_context(request)
-        return workflow_run_signal_from_proto(_grpc_call(self._stub.SignalRun, request))
+        return workflow_run_signal_from_proto(_grpc_call(self._stub.SignalRun, request, timeout=self._timeout))
 
     def signal_or_start_run(
         self, request: WorkflowSignalOrStartRunInput = None, **kwargs: object
@@ -2397,7 +2404,7 @@ class Workflow:
         if not getattr(request, "idempotency_key", "").strip():
             request.idempotency_key = self._idempotency_key
         return workflow_run_signal_from_proto(
-            _grpc_call(self._stub.SignalOrStartRun, request)
+            _grpc_call(self._stub.SignalOrStartRun, request, timeout=self._timeout)
         )
 
     def apply_definition(
@@ -2410,7 +2417,7 @@ class Workflow:
         if not getattr(request, "idempotency_key", "").strip():
             request.idempotency_key = self._idempotency_key
         return workflow_definition_from_proto(
-            _grpc_call(self._stub.ApplyDefinition, request)
+            _grpc_call(self._stub.ApplyDefinition, request, timeout=self._timeout)
         )
 
     def get_definition(
@@ -2421,7 +2428,7 @@ class Workflow:
         request = _workflow_get_definition_request(request, **kwargs)
         self._attach_context(request)
         return workflow_definition_from_proto(
-            _grpc_call(self._stub.GetDefinition, request)
+            _grpc_call(self._stub.GetDefinition, request, timeout=self._timeout)
         )
 
     def list_definitions(self) -> list[WorkflowDefinition]:
@@ -2429,7 +2436,7 @@ class Workflow:
 
         request = pb.ListWorkflowProviderDefinitionsRequest()
         self._attach_context(request)
-        response = _grpc_call(self._stub.ListDefinitions, request)
+        response = _grpc_call(self._stub.ListDefinitions, request, timeout=self._timeout)
         return [workflow_definition_from_proto(item) for item in response.definitions]
 
     def set_definition_paused(
@@ -2440,7 +2447,7 @@ class Workflow:
         request = _workflow_set_definition_paused_request(request, **kwargs)
         self._attach_context(request)
         return workflow_definition_from_proto(
-            _grpc_call(self._stub.SetDefinitionPaused, request)
+            _grpc_call(self._stub.SetDefinitionPaused, request, timeout=self._timeout)
         )
 
     def set_activation_paused(
@@ -2451,7 +2458,7 @@ class Workflow:
         request = _workflow_set_activation_paused_request(request, **kwargs)
         self._attach_context(request)
         return workflow_definition_from_proto(
-            _grpc_call(self._stub.SetActivationPaused, request)
+            _grpc_call(self._stub.SetActivationPaused, request, timeout=self._timeout)
         )
 
     def delete_definition(
@@ -2461,7 +2468,7 @@ class Workflow:
 
         request = _workflow_delete_definition_request(request, **kwargs)
         self._attach_context(request)
-        _grpc_call(self._stub.DeleteDefinition, request)
+        _grpc_call(self._stub.DeleteDefinition, request, timeout=self._timeout)
         return None
 
     def get_run_events(
@@ -2471,7 +2478,7 @@ class Workflow:
 
         request = _workflow_get_run_events_request(request, **kwargs)
         self._attach_context(request)
-        response = _grpc_call(self._stub.GetRunEvents, request)
+        response = _grpc_call(self._stub.GetRunEvents, request, timeout=self._timeout)
         return GetWorkflowProviderRunEventsResponse(
             events=[
                 cast(WorkflowRunEvent, workflow_run_event_input_from_event(item))
@@ -2486,7 +2493,7 @@ class Workflow:
 
         request = _workflow_get_run_output_request(request, **kwargs)
         self._attach_context(request)
-        response = _grpc_call(self._stub.GetRunOutput, request)
+        response = _grpc_call(self._stub.GetRunOutput, request, timeout=self._timeout)
         return GetWorkflowProviderRunOutputResponse(
             output=cast(WorkflowJsonValue, value_to_json(response.output))
             if has_field(response, "output")
@@ -2501,7 +2508,7 @@ class Workflow:
         request = _workflow_deliver_event_request(request, **kwargs)
         self._attach_context(request)
         return workflow_event_input_from_event(
-            _grpc_call(self._stub.DeliverEvent, request)
+            _grpc_call(self._stub.DeliverEvent, request, timeout=self._timeout)
         )
 
     def _attach_context(self, request: Any) -> None:
@@ -2519,9 +2526,9 @@ class Workflow:
         self.close()
 
 
-def _grpc_call(method: Any, request: Any) -> Any:
+def _grpc_call(method: Any, request: Any, timeout: float | None = None) -> Any:
     try:
-        return method(request)
+        return method(request, timeout=timeout)
     except grpc.RpcError:
         raise
 

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -7,6 +7,7 @@ mod agent_provider;
 mod api;
 /// Generated App and AppProvider client and native types.
 pub mod app;
+/// Generated shared runtime for the sdkgen clients.
 mod auth;
 mod auth_server;
 /// Generated Authentication client and native types.
@@ -27,7 +28,6 @@ mod generated;
 /// Generated IndexedDB client and native types.
 pub mod indexeddb;
 mod indexeddb_provider;
-/// Generated shared runtime for the sdkgen clients.
 pub mod invoke_support;
 mod protocol;
 mod provider_server;

--- a/sdk/rust/tests/app_transport.rs
+++ b/sdk/rust/tests/app_transport.rs
@@ -377,12 +377,31 @@ async fn app_invokes_graphql_surface() {
         })
     );
 
+    // The generated decode helper composes with the raw graphql method; the
+    // echoed body has no envelope, so it passes through unchanged.
+    let raw_graphql = app
+        .invoke_graphql(
+            "linear".to_string(),
+            "query Viewer($team: String!) { viewer(team: $team) { id } }".to_string(),
+            gestalt::app::AppInvokeGraphQLOptions {
+                idempotency_key: "graphql-call-43".to_string(),
+                variables: Some(variables.as_object().expect("variables object").clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("invoke graphql raw");
+    let decoded = gestalt::decode_graphql_result("linear", raw_graphql.status, &raw_graphql.body)
+        .expect("decode graphql");
+    assert_eq!(decoded["app"], "linear");
+    assert_eq!(decoded["idempotency_key"], "graphql-call-43");
+
     let seen = server
         .seen_graphql_invokes
         .lock()
         .expect("lock seen graphql invokes")
         .clone();
-    assert_eq!(seen.len(), 1);
+    assert_eq!(seen.len(), 2);
     assert_eq!(
         seen[0],
         SeenGraphQlRequest {

--- a/sdk/typescript/docs/entrypoints/runtime/index.ts
+++ b/sdk/typescript/docs/entrypoints/runtime/index.ts
@@ -1,10 +1,11 @@
 /**
- * Runtime helpers for loading and serving TypeScript providers locally.
+ * Provider-protocol bridges for code that receives Gestalt requests through
+ * its own protocol surface.
  *
- * The runtime entrypoint reads the configured provider target, starts the
- * matching gRPC provider server, and connects back to the `gestaltd` host over
- * the socket supplied by the provider process environment.
+ * Import from `@valon-technologies/gestalt/runtime`. The provider-serving
+ * loader that this entrypoint also hosts at runtime is internal and
+ * intentionally undocumented.
  *
  * @module
  */
-export * from "../../../src/providers/runtime.ts";
+export { nativeRequestContext } from "../../../src/providers/runtime.ts";

--- a/sdk/typescript/src/api.ts
+++ b/sdk/typescript/src/api.ts
@@ -2,7 +2,9 @@
  * Common request and response types shared across authored Gestalt providers.
  */
 import type { AgentToolRef } from "./providers/agent.ts";
+import { Agent } from "./agent.ts";
 import { App, type RequestContext } from "./app.ts";
+import { Workflow } from "./workflow.ts";
 
 export interface Subject {
   id: string;
@@ -75,7 +77,12 @@ export interface Request {
   toolRefs: AgentToolRef[];
   toolRefsSet: boolean;
   __requestContext?: RequestContext | undefined;
-  app(): Promise<App>;
+  /** Returns the generated App client carrying this request's context. */
+  app(options?: { timeoutMs?: number | undefined }): Promise<App>;
+  /** Returns the generated Agent client carrying this request's context. */
+  agent(options?: { timeoutMs?: number | undefined }): Promise<Agent>;
+  /** Returns the generated Workflow client carrying this request's context. */
+  workflows(options?: { timeoutMs?: number | undefined }): Promise<Workflow>;
 }
 
 /**
@@ -180,7 +187,7 @@ export function request(
   toolRefsSet = false,
   requestContext?: RequestContext,
 ): Request {
-  const req: Omit<Request, "app"> = {
+  const req: Omit<Request, "app" | "agent" | "workflows"> = {
     token,
     connectionParams: {
       ...connectionParams,
@@ -232,9 +239,16 @@ export function request(
   return attachRequestHelpers(req);
 }
 
-export function attachRequestHelpers<T extends Omit<Request, "app">>(input: T): Request {
+export function attachRequestHelpers<T extends Omit<Request, "app" | "agent" | "workflows">>(
+  input: T,
+): Request {
   const req = input as unknown as Request;
-  req.app = async () => App.connect({ context: req.__requestContext });
+  req.app = async (options) =>
+    App.connect({ context: req.__requestContext, timeoutMs: options?.timeoutMs });
+  req.agent = async (options) =>
+    Agent.connect({ context: req.__requestContext, timeoutMs: options?.timeoutMs });
+  req.workflows = async (options) =>
+    Workflow.connect({ context: req.__requestContext, timeoutMs: options?.timeoutMs });
   return req;
 }
 

--- a/sdk/typescript/src/providers/runtime.ts
+++ b/sdk/typescript/src/providers/runtime.ts
@@ -94,6 +94,8 @@ import {
 } from "./agent.ts";
 import { agentToolRefFromProto } from "../agent-conversions.ts";
 import { fromWireRequestContext } from "../internal/codec/app.ts";
+import type { RequestContext as WireRequestContext } from "../internal/gen/v1/app_pb.ts";
+import type { RequestContext } from "../app.ts";
 import {
   AuthenticationProvider,
   isAuthenticationProvider,
@@ -1109,4 +1111,15 @@ if (import.meta.main) {
       process.exitCode = 1;
     },
   );
+}
+
+/**
+ * Converts a protocol-level wire request context into the generated clients'
+ * native form, for providers that receive contexts through their own protocol
+ * surfaces and need to hand them to `connect(..., { context })`.
+ */
+export function nativeRequestContext(
+  context: WireRequestContext | undefined,
+): RequestContext | undefined {
+  return context === undefined ? undefined : fromWireRequestContext(context);
 }

--- a/sdk/typescript/typedoc.json
+++ b/sdk/typescript/typedoc.json
@@ -4,6 +4,7 @@
     "docs/entrypoints/@valon-technologies/gestalt",
     "docs/entrypoints/schema",
     "docs/entrypoints/telemetry",
+    "docs/entrypoints/runtime",
     "docs/entrypoints/services/agent",
     "docs/entrypoints/services/app",
     "docs/entrypoints/services/authentication",


### PR DESCRIPTION
## Summary

Completes the request-scoped surface over the generated clients. The TypeScript request gains `request.agent()` and `request.workflows()` beside `request.app()`, all accessors (TypeScript and Python) take an optional timeout passed through to the client's unary deadline, and the wire-context bridge is public in both provider languages: `nativeRequestContext` from `providers/runtime` in TypeScript and `gestalt.native_request_context` in Python. No handwritten GraphQL wrapper is kept — composing the generated raw call with `decodeGraphQLResult` is two lines.

## Interfaces

```ts
const app = await request.app({ timeoutMs: 5_000 });   // generated client, request context attached
const app2 = App.connect({ context: nativeRequestContext(input.requestContext) });
```

```python
app = request.app(timeout=5.0)
app = App.connect(context=gestalt.native_request_context(wire_context))
```

## Runtime

The accessors install the request's context as the client's ambient default (a caller-supplied context wins); the timeout is the generator-level unary deadline, streams stay deadline-free; the context bridges are pure conversions with no transport behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
