### PR TITLE
Cap the docs shell width and widen column gutters on large screens

### DIFF
--- a/docs/globals.css
+++ b/docs/globals.css
@@ -68,6 +68,8 @@
   --valon-content-width: 46rem;
   --nextra-primary-hue: 37deg;
   --nextra-primary-saturation: 84%;
+  /* nextra's Head component normally injects this; without it the shell has no max-width */
+  --nextra-content-width: 90rem;
 }
 
 .dark {
@@ -161,6 +163,16 @@ article li {
   margin-top: 0.75rem !important;
 }
 
+/* Wider gutters between sidebar, article, and TOC on large screens.
+   Ramps 3rem→7.5rem between 1280px and the 90rem shell cap, where the
+   text column lands at --valon-content-width (46rem ≈ Notion/Substack
+   reading measure). */
+@media (min-width: 80rem) {
+  article {
+    padding-inline: clamp(3rem, 45vw - 33rem, 7.5rem) !important;
+  }
+}
+
 article a:not(.nextra-card):not(.subheading-anchor) {
   color: rgba(var(--valon-ink), 1);
   text-decoration-color: rgba(var(--valon-ink), 0.24);
@@ -221,12 +233,6 @@ pre code {
 
 pre code > span {
   white-space: pre !important;
-}
-
-.nextra-navbar > nav,
-body > .nextra-skip-nav ~ div,
-footer {
-  max-width: 100% !important;
 }
 
 .nextra-navbar {


### PR DESCRIPTION
## Summary

On wide displays the docs filled the whole screen and body text ran past 110 characters per line — the single biggest readability cost on a docs site. This caps the shell at 90rem and ramps the article gutters up on large screens so the text column lands at a 46rem reading measure (the width Notion and Substack settle on).

Nextra normally injects its own `--nextra-content-width` via its `Head` component, which our layout never renders — so the cap was missing rather than chosen. The fix defines it in `globals.css`, drops the `max-width: 100%` override, and ramps article `padding-inline` 3rem→7.5rem above 1280px via `clamp()`.

First PR of the docs-shell stack (#2399 → #2405).

## Demo

| Laptop | Ultrawide |
|---|---|
| ![laptop](https://raw.githubusercontent.com/valon-technologies/gestalt/pr-media/docs-width-cap-laptop-2026-06-11.png) | ![ultrawide](https://raw.githubusercontent.com/valon-technologies/gestalt/pr-media/docs-width-cap-ultrawide-2026-06-11.png) |
