### PR TITLE
Mark the registry app with a stable data attribute

### DIFF
--- a/docs/app/registry/registry-app.tsx
+++ b/docs/app/registry/registry-app.tsx
@@ -251,7 +251,7 @@ export default function RegistryApp({ catalogUrl }: { catalogUrl: string }) {
       : `${styles.shell} ${styles.lightShell}`;
 
   return (
-    <main className={shellClassName}>
+    <main className={shellClassName} data-registry-shell="true">
       <header className={styles.header}>
         <a className={styles.brand} href={routePrefix || "/"}>
           <span className={styles.brandWord}>Gestalt</span>

--- a/docs/scripts/check-nginx-routing.mjs
+++ b/docs/scripts/check-nginx-routing.mjs
@@ -62,7 +62,7 @@ try {
     status: 200,
     cacheControlIncludes: "no-cache",
     includes: "Gestalt",
-    excludes: "registry_shell__",
+    excludes: "data-registry-shell",
   });
   await assertResponse({
     url: `${baseUrl}/dev/providers`,
@@ -70,7 +70,7 @@ try {
     status: 200,
     cacheControlIncludes: "no-cache",
     includes: "Providers",
-    excludes: "registry_shell__",
+    excludes: "data-registry-shell",
   });
   await assertResponse({
     url: `${baseUrl}/dev/providers.txt`,
@@ -78,7 +78,7 @@ try {
     status: 200,
     cacheControlIncludes: "no-cache",
     includes: "What Providers Do",
-    excludes: "registry_shell__",
+    excludes: "data-registry-shell",
   });
   await assertResponse({
     url: `${baseUrl}${devAssetPath}`,
@@ -96,7 +96,7 @@ try {
     url: `${baseUrl}/dev/does-not-exist`,
     host: "gestaltd.ai",
     status: 404,
-    excludes: "registry_shell__",
+    excludes: "data-registry-shell",
   });
   await assertResponse({
     url: `${baseUrl}/latest/`,
@@ -104,7 +104,7 @@ try {
     status: 200,
     cacheControlIncludes: "no-cache",
     includes: "Gestalt",
-    excludes: "registry_shell__",
+    excludes: "data-registry-shell",
   });
   await assertResponse({
     url: `${baseUrl}/latest/providers`,
@@ -112,7 +112,7 @@ try {
     status: 200,
     cacheControlIncludes: "no-cache",
     includes: "Providers",
-    excludes: "registry_shell__",
+    excludes: "data-registry-shell",
   });
   await assertResponse({
     url: `${baseUrl}/latest/providers.txt`,
@@ -120,7 +120,7 @@ try {
     status: 200,
     cacheControlIncludes: "no-cache",
     includes: "What Providers Do",
-    excludes: "registry_shell__",
+    excludes: "data-registry-shell",
   });
   await assertResponse({
     url: `${baseUrl}${latestAssetPath}`,
@@ -139,7 +139,7 @@ try {
     host: "gestaltd.ai",
     status: 200,
     includes: "Server CLI",
-    excludes: "registry_shell__",
+    excludes: "data-registry-shell",
   });
   await assertResponse({
     url: `${baseUrl}${exactVersionPrefix}/reference/cli/`,
@@ -163,19 +163,19 @@ try {
     url: `${baseUrl}/versions/v9.9.9/`,
     host: "gestaltd.ai",
     status: 404,
-    excludes: "registry_shell__",
+    excludes: "data-registry-shell",
   });
   await assertResponse({
     url: `${baseUrl}/api/does-not-exist`,
     host: "gestaltd.ai",
     status: 404,
-    excludes: "registry_shell__",
+    excludes: "data-registry-shell",
   });
   await assertResponse({
     url: `${baseUrl}/providers/app/slack/`,
     host: "gestaltd.ai",
     status: 404,
-    excludes: "registry_shell__",
+    excludes: "data-registry-shell",
   });
   await assertResponse({
     url: `${baseUrl}/reference/sdk/python`,
@@ -188,7 +188,7 @@ try {
     host: "registry.gestaltd.ai",
     status: 200,
     cacheControlIncludes: "no-cache",
-    includes: "registry_shell__",
+    includes: "data-registry-shell",
   });
 } finally {
   if (container) {

--- a/docs/scripts/check-registry-docs-render.mjs
+++ b/docs/scripts/check-registry-docs-render.mjs
@@ -10,7 +10,7 @@ import ts from "typescript";
 const siteRoot = path.resolve("out");
 const fixtureRoot = path.resolve("scripts/fixtures/registry-docs");
 const registryHtml = path.join(siteRoot, "registry.html");
-const registryMarker = "registry_shell__";
+const registryMarker = "data-registry-shell";
 
 if (!existsSync(registryHtml)) {
   throw new Error("out/registry.html is missing; run npm run build first");

--- a/docs/scripts/check-registry-static.mjs
+++ b/docs/scripts/check-registry-static.mjs
@@ -27,7 +27,7 @@ const sdkReferenceTargets = {
   go: "https://pkg.go.dev/github.com/valon-technologies/gestalt/sdk/go",
   rust: "https://docs.rs/gestalt-sdk/latest/gestalt/",
 };
-const registryMarker = "registry_shell__";
+const registryMarker = "data-registry-shell";
 
 const server = createServer(async (request, response) => {
   try {


### PR DESCRIPTION
## Summary

The routing check scripts decide "this response is the registry app" by searching served HTML for `registry_shell__` — the hashed CSS-module class prefix the build happens to emit. That's an accident of the build, not a contract: moving or renaming `registry.module.css` (which the registry rehome later in this stack does), or any change to Next's module hashing, silently breaks every assertion.

This replaces the marker with an explicit `data-registry-shell="true"` attribute on the registry's root `<main>`, and points all 14 assertion sites across `check-nginx-routing.mjs`, `check-registry-static.mjs`, and `check-registry-docs-render.mjs` at it. Landing the swap first keeps the later PRs' diffs free of this noise.
