### PR TITLE
Render code blocks with Vitesse themes across docs and registry

### DIFF
--- a/docs/app/registry/registry-app.tsx
+++ b/docs/app/registry/registry-app.tsx
@@ -3,6 +3,7 @@
 import type { MouseEvent } from "react";
 import { useEffect, useMemo, useState } from "react";
 import { renderMarkdown } from "./registry-markdown";
+import ShikiCode from "./shiki-code";
 import styles from "./registry.module.css";
 
 type ConfigTarget = {
@@ -602,6 +603,9 @@ function ProviderDocBody({
       {renderMarkdown(loadState.source, {
         resolveLink: (href) =>
           resolveProviderDocLink(href, provider, docs, selectedDoc, routePrefix),
+        renderCode: (language, text, key) => (
+          <ShikiCode key={key} language={language} text={text} />
+        ),
       })}
     </div>
   );

--- a/docs/app/registry/registry-markdown.tsx
+++ b/docs/app/registry/registry-markdown.tsx
@@ -8,6 +8,10 @@ type LinkTarget = {
 
 export type MarkdownRenderContext = {
   resolveLink: (href: string) => LinkTarget | null;
+  // Optional code-block renderer (e.g. a syntax highlighter); plain
+  // <pre><code> when absent. This file stays dependency-free because the
+  // docs-render check transpiles it standalone.
+  renderCode?: (language: string, text: string, key: number) => ReactNode;
 };
 
 type Block =
@@ -219,6 +223,9 @@ function renderBlock(block: Block, context: MarkdownRenderContext, index: number
         </blockquote>
       );
     case "code":
+      if (context.renderCode) {
+        return context.renderCode(block.language, block.text, index);
+      }
       return (
         <pre key={index}>
           <code data-language={block.language || undefined}>{block.text}</code>

--- a/docs/app/registry/registry.module.css
+++ b/docs/app/registry/registry.module.css
@@ -1030,3 +1030,12 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* Shiki dual-theme output (defaultColor: false → per-token CSS vars). */
+.markdownBody :global(pre.shiki) span {
+  color: var(--shiki-light);
+}
+
+.darkShell .markdownBody :global(pre.shiki) span {
+  color: var(--shiki-dark);
+}

--- a/docs/app/registry/shiki-code.tsx
+++ b/docs/app/registry/shiki-code.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+// Vitesse Light/Dark, matching the docs MDX pipeline. Backgrounds left to the
+// page surface and the light comment color lifted to an AA-passing warm
+// brown (vitesse's #a0ada0 is 2.3:1 on our cream).
+const themes = { light: "vitesse-light", dark: "vitesse-dark" } as const;
+const colorReplacements = {
+  "vitesse-light": { "#a0ada0": "#76705f" },
+} as const;
+
+const htmlCache = new Map<string, Promise<string | null>>();
+
+function highlight(language: string, text: string) {
+  const key = `${language}\u0000${text}`;
+  const cached = htmlCache.get(key);
+  if (cached) {
+    return cached;
+  }
+  const promise = import("shiki")
+    .then((shiki) =>
+      shiki.codeToHtml(text, {
+        lang: language || "text",
+        themes,
+        defaultColor: false,
+        colorReplacements,
+      }),
+    )
+    .catch(() => null);
+  htmlCache.set(key, promise);
+  return promise;
+}
+
+export default function ShikiCode({
+  language,
+  text,
+}: {
+  language: string;
+  text: string;
+}) {
+  const [html, setHtml] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void highlight(language, text).then((result) => {
+      if (!cancelled) {
+        setHtml(result);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [language, text]);
+
+  if (!html) {
+    return (
+      <pre>
+        <code data-language={language || undefined}>{text}</code>
+      </pre>
+    );
+  }
+  // Shiki escapes all code content; this is its own generated markup.
+  // eslint-disable-next-line react/no-danger
+  return <div dangerouslySetInnerHTML={{ __html: html }} />;
+}

--- a/docs/app/registry/shiki-code.tsx
+++ b/docs/app/registry/shiki-code.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import type { HighlighterCore } from "shiki/core";
 
 // Vitesse Light/Dark, matching the docs MDX pipeline. Backgrounds left to the
 // page surface and the light comment color lifted to an AA-passing warm
@@ -10,6 +11,37 @@ const colorReplacements = {
   "vitesse-light": { "#a0ada0": "#76705f" },
 } as const;
 
+// A curated core bundle instead of `import("shiki")`: the full bundle
+// code-splits every one of its ~300 grammars into the static export, and
+// the proto grammar's literal "protobuf" strings even trip the SDK-doc
+// leak check over the exported JS. These are the languages provider docs
+// actually use; anything else renders as plain text via highlight().
+let highlighterPromise: Promise<HighlighterCore> | null = null;
+
+function getHighlighter() {
+  highlighterPromise ??= Promise.all([
+    import("shiki/core"),
+    import("shiki/engine/javascript"),
+  ]).then(([core, engine]) =>
+    core.createHighlighterCore({
+      themes: [
+        import("@shikijs/themes/vitesse-light"),
+        import("@shikijs/themes/vitesse-dark"),
+      ],
+      langs: [
+        import("@shikijs/langs/shellscript"),
+        import("@shikijs/langs/yaml"),
+        import("@shikijs/langs/json"),
+        import("@shikijs/langs/typescript"),
+        import("@shikijs/langs/javascript"),
+        import("@shikijs/langs/go"),
+      ],
+      engine: engine.createJavaScriptRegexEngine({ forgiving: true }),
+    }),
+  );
+  return highlighterPromise;
+}
+
 const htmlCache = new Map<string, Promise<string | null>>();
 
 function highlight(language: string, text: string) {
@@ -18,15 +50,19 @@ function highlight(language: string, text: string) {
   if (cached) {
     return cached;
   }
-  const promise = import("shiki")
-    .then((shiki) =>
-      shiki.codeToHtml(text, {
-        lang: language || "text",
+  const promise = getHighlighter()
+    .then((highlighter) => {
+      const lang =
+        language && highlighter.getLoadedLanguages().includes(language)
+          ? language
+          : "text";
+      return highlighter.codeToHtml(text, {
+        lang,
         themes,
         defaultColor: false,
         colorReplacements,
-      }),
-    )
+      });
+    })
     .catch(() => null);
   htmlCache.set(key, promise);
   return promise;

--- a/docs/app/registry/shiki-code.tsx
+++ b/docs/app/registry/shiki-code.tsx
@@ -39,6 +39,13 @@ function getHighlighter() {
       engine: engine.createJavaScriptRegexEngine({ forgiving: true }),
     }),
   );
+  // A failed init (e.g. a transient chunk-load error) must not poison
+  // every later attempt: drop the rejected promise so the next call
+  // retries, and rethrow for the per-snippet catch below.
+  highlighterPromise = highlighterPromise.catch((error) => {
+    highlighterPromise = null;
+    throw error;
+  });
   return highlighterPromise;
 }
 
@@ -63,7 +70,11 @@ function highlight(language: string, text: string) {
         colorReplacements,
       });
     })
-    .catch(() => null);
+    .catch(() => {
+      // Do not cache failures — the same block retries on its next render.
+      htmlCache.delete(key);
+      return null;
+    });
   htmlCache.set(key, promise);
   return promise;
 }

--- a/docs/app/registry/shiki-code.tsx
+++ b/docs/app/registry/shiki-code.tsx
@@ -90,6 +90,10 @@ export default function ShikiCode({
 
   useEffect(() => {
     let cancelled = false;
+    // Reset before highlighting: when language/text change on a mounted
+    // instance, the previous block's markup must not linger while (or if)
+    // the new highlight resolves.
+    setHtml(null);
     void highlight(language, text).then((result) => {
       if (!cancelled) {
         setHtml(result);

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -10,6 +10,11 @@ const withNextra = nextra({
         light: "vitesse-light",
         dark: "vitesse-dark",
       },
+      // Same comment-color lift as the registry renderer: vitesse-light's
+      // #a0ada0 comments are 2.3:1 on our cream pre background.
+      colorReplacements: {
+        "vitesse-light": { "#a0ada0": "#76705f" },
+      },
     },
   },
 });

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -1,6 +1,18 @@
 import nextra from "nextra";
 
-const withNextra = nextra({});
+const withNextra = nextra({
+  mdxOptions: {
+    rehypePrettyCodeOptions: {
+      // Vitesse pair for docs MDX code blocks; the registry's client
+      // renderer (app/registry/shiki-code.tsx) uses the same themes so
+      // code looks identical on both sides of the site.
+      theme: {
+        light: "vitesse-light",
+        dark: "vitesse-dark",
+      },
+    },
+  },
+});
 const basePath = process.env.GESTALT_DOCS_BASE_PATH || "";
 
 export default withNextra({

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -13,7 +13,8 @@
         "nextra": "^4.6.1",
         "nextra-theme-docs": "^4.6.1",
         "react": "^19.2.4",
-        "react-dom": "^19.2.6"
+        "react-dom": "^19.2.6",
+        "shiki": "^3.23.0"
       },
       "devDependencies": {
         "@types/node": "25.9.1",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,6 +8,8 @@
       "name": "gestalt-docs",
       "version": "0.0.1-alpha.1",
       "dependencies": {
+        "@shikijs/langs": "^3.23.0",
+        "@shikijs/themes": "^3.23.0",
         "@types/react-dom": "^19.2.3",
         "next": "^16.2.6",
         "nextra": "^4.6.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -20,6 +20,8 @@
     "test:registry-docs": "node scripts/check-registry-docs-render.mjs"
   },
   "dependencies": {
+    "@shikijs/langs": "^3.23.0",
+    "@shikijs/themes": "^3.23.0",
     "@types/react-dom": "^19.2.3",
     "next": "^16.2.6",
     "nextra": "^4.6.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -25,7 +25,8 @@
     "nextra": "^4.6.1",
     "nextra-theme-docs": "^4.6.1",
     "react": "^19.2.4",
-    "react-dom": "^19.2.6"
+    "react-dom": "^19.2.6",
+    "shiki": "^3.23.0"
   },
   "devDependencies": {
     "@types/node": "25.9.1",


### PR DESCRIPTION
## Summary

Code blocks now render with the Vitesse light/dark pair everywhere: docs MDX through `rehype-pretty-code`, and the registry's provider docs through a new client-side Shiki renderer. Previously registry code was unhighlighted plain text and docs used the default theme.

The registry renders provider docs from fetched markdown at runtime, so it can't use the MDX pipeline — the fix is a lazy client renderer using the same Shiki engine and themes, with a plain `<pre>` fallback while it loads. Vitesse's light comment color fails AA on our background, so it's lifted to a warm brown that passes.

Two latent bugs fixed while lifting this from the original branch: the highlight cache key contained a literal NUL byte (git treated the file as binary — no reviewable diffs), and `shiki` was imported but undeclared, resolving only through nextra's transitive copy.

Validation: typecheck and `test:registry-docs` pass.

## Demo

![vitesse code blocks](https://raw.githubusercontent.com/valon-technologies/gestalt/pr-media/vitesse-code-blocks-registry-2026-06-11.png)
