### PR TITLE
[authorization] add provider gateway metrics

### DIFF
--- a/gestaltd/services/providergateway/gateway.go
+++ b/gestaltd/services/providergateway/gateway.go
@@ -18,16 +18,16 @@ func (t *ProviderGatewayTransport) Authorize(ctx context.Context, params Authori
 
 type DirectTransport struct{}
 
-func (DirectTransport) Invoke(ctx context.Context, req ProviderGatewayRequest, next Next) (ProviderGatewayResponse, error) {
+func (DirectTransport) Invoke(ctx context.Context, req ProviderGatewayRequest, next Next) (resp ProviderGatewayResponse, err error) {
 	startedAt := time.Now()
+	defer func() {
+		recordProviderGatewayOperation(ctx, startedAt, err, req, TransportPathDirect)
+	}()
+
 	if next == nil {
-		err := fmt.Errorf("provider gateway: next handler is required")
-		recordProviderGatewayOperation(ctx, startedAt, err, req)
-		return ProviderGatewayResponse{}, err
+		return ProviderGatewayResponse{}, fmt.Errorf("provider gateway: next handler is required")
 	}
-	resp, err := next(ctx, req)
-	recordProviderGatewayOperation(ctx, startedAt, err, req)
-	return resp, err
+	return next(ctx, req)
 }
 
 type ProviderGatewayTransport struct {
@@ -45,7 +45,12 @@ func (t *ProviderGatewayTransport) SetAuthorizationProvider(authorization Author
 	t.authorization = authorization
 }
 
-func (t *ProviderGatewayTransport) Invoke(ctx context.Context, req ProviderGatewayRequest, next Next) (ProviderGatewayResponse, error) {
+func (t *ProviderGatewayTransport) Invoke(ctx context.Context, req ProviderGatewayRequest, next Next) (resp ProviderGatewayResponse, err error) {
+	startedAt := time.Now()
+	defer func() {
+		recordProviderGatewayOperation(ctx, startedAt, err, req, TransportPathProviderGateway)
+	}()
+
 	if t == nil {
 		return ProviderGatewayResponse{}, fmt.Errorf("provider gateway: transport is nil")
 	}

--- a/gestaltd/services/providergateway/gateway.go
+++ b/gestaltd/services/providergateway/gateway.go
@@ -3,6 +3,7 @@ package providergateway
 import (
 	"context"
 	"fmt"
+	"time"
 )
 
 type AuthorizationParams struct {
@@ -18,10 +19,15 @@ func (t *ProviderGatewayTransport) Authorize(ctx context.Context, params Authori
 type DirectTransport struct{}
 
 func (DirectTransport) Invoke(ctx context.Context, req ProviderGatewayRequest, next Next) (ProviderGatewayResponse, error) {
+	startedAt := time.Now()
 	if next == nil {
-		return ProviderGatewayResponse{}, fmt.Errorf("provider gateway: next handler is required")
+		err := fmt.Errorf("provider gateway: next handler is required")
+		recordProviderGatewayOperation(ctx, startedAt, err, req)
+		return ProviderGatewayResponse{}, err
 	}
-	return next(ctx, req)
+	resp, err := next(ctx, req)
+	recordProviderGatewayOperation(ctx, startedAt, err, req)
+	return resp, err
 }
 
 type ProviderGatewayTransport struct {

--- a/gestaltd/services/providergateway/gateway_test.go
+++ b/gestaltd/services/providergateway/gateway_test.go
@@ -2,12 +2,10 @@ package providergateway
 
 import (
 	"context"
-	"testing"
-
-	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"errors"
 	"testing"
 
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
 )
@@ -160,10 +158,9 @@ func (p *stubAuthorizationProvider) Ping(context.Context) error { return nil }
 
 func (p *stubAuthorizationProvider) Close() error { return nil }
 
-func TestGatewayInvokeRecordsMetrics(t *testing.T) {
+func TestDirectTransportInvokeRecordsMetrics(t *testing.T) {
 	metrics := metrictest.NewManualMeterProvider(t)
 	ctx := metricutil.WithMeterProvider(context.Background(), metrics.Provider)
-	gateway := New()
 	req := ProviderGatewayRequest{
 		ProviderID:   "authz",
 		ProviderKind: ProviderKindAuthorization,
@@ -172,7 +169,7 @@ func TestGatewayInvokeRecordsMetrics(t *testing.T) {
 		Source:       GatewaySourceSDKGRPC,
 	}
 
-	_, err := gateway.Invoke(ctx, req, func(ctx context.Context, req ProviderGatewayRequest) (ProviderGatewayResponse, error) {
+	_, err := (DirectTransport{}).Invoke(ctx, req, func(ctx context.Context, req ProviderGatewayRequest) (ProviderGatewayResponse, error) {
 		return ProviderGatewayResponse{Payload: []byte("ok")}, nil
 	})
 	if err != nil {
@@ -180,16 +177,15 @@ func TestGatewayInvokeRecordsMetrics(t *testing.T) {
 	}
 
 	rm := metrictest.CollectMetrics(t, metrics.Reader)
-	attrs := providerGatewayMetricAttrs(req)
+	attrs := providerGatewayMetricAttrs(req, TransportPathDirect)
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.provider_gateway.operation.count", 1, attrs)
 	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.provider_gateway.operation.duration", attrs)
 	metrictest.RequireNoInt64Sum(t, rm, "gestaltd.provider_gateway.operation.error_count", attrs)
 }
 
-func TestGatewayInvokeRecordsErrorMetrics(t *testing.T) {
+func TestDirectTransportInvokeRecordsErrorMetrics(t *testing.T) {
 	metrics := metrictest.NewManualMeterProvider(t)
 	ctx := metricutil.WithMeterProvider(context.Background(), metrics.Provider)
-	gateway := New()
 	req := ProviderGatewayRequest{
 		ProviderID:   "authz",
 		ProviderKind: ProviderKindAuthorization,
@@ -199,7 +195,7 @@ func TestGatewayInvokeRecordsErrorMetrics(t *testing.T) {
 	}
 	wantErr := errors.New("provider failed")
 
-	_, err := gateway.Invoke(ctx, req, func(ctx context.Context, req ProviderGatewayRequest) (ProviderGatewayResponse, error) {
+	_, err := (DirectTransport{}).Invoke(ctx, req, func(ctx context.Context, req ProviderGatewayRequest) (ProviderGatewayResponse, error) {
 		return ProviderGatewayResponse{}, wantErr
 	})
 	if !errors.Is(err, wantErr) {
@@ -207,18 +203,72 @@ func TestGatewayInvokeRecordsErrorMetrics(t *testing.T) {
 	}
 
 	rm := metrictest.CollectMetrics(t, metrics.Reader)
-	attrs := providerGatewayMetricAttrs(req)
+	attrs := providerGatewayMetricAttrs(req, TransportPathDirect)
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.provider_gateway.operation.count", 1, attrs)
 	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.provider_gateway.operation.duration", attrs)
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.provider_gateway.operation.error_count", 1, attrs)
 }
 
-func providerGatewayMetricAttrs(req ProviderGatewayRequest) map[string]string {
+func TestProviderGatewayTransportInvokeRecordsMetrics(t *testing.T) {
+	metrics := metrictest.NewManualMeterProvider(t)
+	ctx := metricutil.WithMeterProvider(context.Background(), metrics.Provider)
+	transport := NewProviderGatewayTransport()
+	req := ProviderGatewayRequest{
+		ProviderID:   "authz",
+		ProviderKind: ProviderKindAuthorization,
+		ServiceName:  "gestalt.v1.Authorization",
+		Operation:    "CheckAccess",
+		Source:       GatewaySourceSDKGRPC,
+	}
+
+	_, err := transport.Invoke(ctx, req, func(ctx context.Context, req ProviderGatewayRequest) (ProviderGatewayResponse, error) {
+		return ProviderGatewayResponse{Payload: []byte("ok")}, nil
+	})
+	if err != nil {
+		t.Fatalf("Invoke error = %v", err)
+	}
+
+	rm := metrictest.CollectMetrics(t, metrics.Reader)
+	attrs := providerGatewayMetricAttrs(req, TransportPathProviderGateway)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.provider_gateway.operation.count", 1, attrs)
+	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.provider_gateway.operation.duration", attrs)
+	metrictest.RequireNoInt64Sum(t, rm, "gestaltd.provider_gateway.operation.error_count", attrs)
+}
+
+func TestProviderGatewayTransportInvokeRecordsErrorMetrics(t *testing.T) {
+	metrics := metrictest.NewManualMeterProvider(t)
+	ctx := metricutil.WithMeterProvider(context.Background(), metrics.Provider)
+	transport := NewProviderGatewayTransport()
+	req := ProviderGatewayRequest{
+		ProviderID:   "authz",
+		ProviderKind: ProviderKindAuthorization,
+		ServiceName:  "gestalt.v1.Authorization",
+		Operation:    "CheckAccess",
+		Source:       GatewaySourceInternal,
+	}
+	wantErr := errors.New("provider failed")
+
+	_, err := transport.Invoke(ctx, req, func(ctx context.Context, req ProviderGatewayRequest) (ProviderGatewayResponse, error) {
+		return ProviderGatewayResponse{}, wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Invoke error = %v, want %v", err, wantErr)
+	}
+
+	rm := metrictest.CollectMetrics(t, metrics.Reader)
+	attrs := providerGatewayMetricAttrs(req, TransportPathProviderGateway)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.provider_gateway.operation.count", 1, attrs)
+	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.provider_gateway.operation.duration", attrs)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.provider_gateway.operation.error_count", 1, attrs)
+}
+
+func providerGatewayMetricAttrs(req ProviderGatewayRequest, transportPath TransportPath) map[string]string {
 	return map[string]string{
-		"gestaltd.provider_gateway.provider.id":    req.ProviderID,
-		"gestaltd.provider_gateway.provider.kind":  string(req.ProviderKind),
-		"gestaltd.provider_gateway.service.name":   req.ServiceName,
-		"gestaltd.provider_gateway.operation.name": req.Operation,
-		"gestaltd.provider_gateway.source":         string(req.Source),
+		"gestaltd.provider_gateway.provider.id":       req.ProviderID,
+		"gestaltd.provider_gateway.provider.kind":     string(req.ProviderKind),
+		"gestaltd.provider_gateway.service.name":      req.ServiceName,
+		"gestaltd.provider_gateway.operation.name":    req.Operation,
+		"gestaltd.provider_gateway.source":            string(req.Source),
+		"gestaltd.provider_gateway.transport.path":    string(transportPath),
 	}
 }

--- a/gestaltd/services/providergateway/gateway_test.go
+++ b/gestaltd/services/providergateway/gateway_test.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"testing"
 
-	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
 )
 
@@ -159,6 +159,8 @@ func (p *stubAuthorizationProvider) Ping(context.Context) error { return nil }
 func (p *stubAuthorizationProvider) Close() error { return nil }
 
 func TestDirectTransportInvokeRecordsMetrics(t *testing.T) {
+	t.Parallel()
+
 	metrics := metrictest.NewManualMeterProvider(t)
 	ctx := metricutil.WithMeterProvider(context.Background(), metrics.Provider)
 	req := ProviderGatewayRequest{
@@ -184,6 +186,8 @@ func TestDirectTransportInvokeRecordsMetrics(t *testing.T) {
 }
 
 func TestDirectTransportInvokeRecordsErrorMetrics(t *testing.T) {
+	t.Parallel()
+
 	metrics := metrictest.NewManualMeterProvider(t)
 	ctx := metricutil.WithMeterProvider(context.Background(), metrics.Provider)
 	req := ProviderGatewayRequest{
@@ -210,6 +214,8 @@ func TestDirectTransportInvokeRecordsErrorMetrics(t *testing.T) {
 }
 
 func TestProviderGatewayTransportInvokeRecordsMetrics(t *testing.T) {
+	t.Parallel()
+
 	metrics := metrictest.NewManualMeterProvider(t)
 	ctx := metricutil.WithMeterProvider(context.Background(), metrics.Provider)
 	transport := NewProviderGatewayTransport()
@@ -236,6 +242,8 @@ func TestProviderGatewayTransportInvokeRecordsMetrics(t *testing.T) {
 }
 
 func TestProviderGatewayTransportInvokeRecordsErrorMetrics(t *testing.T) {
+	t.Parallel()
+
 	metrics := metrictest.NewManualMeterProvider(t)
 	ctx := metricutil.WithMeterProvider(context.Background(), metrics.Provider)
 	transport := NewProviderGatewayTransport()
@@ -264,11 +272,11 @@ func TestProviderGatewayTransportInvokeRecordsErrorMetrics(t *testing.T) {
 
 func providerGatewayMetricAttrs(req ProviderGatewayRequest, transportPath TransportPath) map[string]string {
 	return map[string]string{
-		"gestaltd.provider_gateway.provider.id":       req.ProviderID,
-		"gestaltd.provider_gateway.provider.kind":     string(req.ProviderKind),
-		"gestaltd.provider_gateway.service.name":      req.ServiceName,
-		"gestaltd.provider_gateway.operation.name":    req.Operation,
-		"gestaltd.provider_gateway.source":            string(req.Source),
-		"gestaltd.provider_gateway.transport.path":    string(transportPath),
+		"gestaltd.provider_gateway.provider.id":    req.ProviderID,
+		"gestaltd.provider_gateway.provider.kind":  string(req.ProviderKind),
+		"gestaltd.provider_gateway.service.name":   req.ServiceName,
+		"gestaltd.provider_gateway.operation.name": req.Operation,
+		"gestaltd.provider_gateway.source":         string(req.Source),
+		"gestaltd.provider_gateway.transport.path": string(transportPath),
 	}
 }

--- a/gestaltd/services/providergateway/gateway_test.go
+++ b/gestaltd/services/providergateway/gateway_test.go
@@ -5,6 +5,11 @@ import (
 	"testing"
 
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"errors"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
+	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
 )
 
 func TestAuthorizeAllowsRequests(t *testing.T) {
@@ -154,3 +159,66 @@ func (p *stubAuthorizationProvider) ListActiveModelResourceTypes(context.Context
 func (p *stubAuthorizationProvider) Ping(context.Context) error { return nil }
 
 func (p *stubAuthorizationProvider) Close() error { return nil }
+
+func TestGatewayInvokeRecordsMetrics(t *testing.T) {
+	metrics := metrictest.NewManualMeterProvider(t)
+	ctx := metricutil.WithMeterProvider(context.Background(), metrics.Provider)
+	gateway := New()
+	req := ProviderGatewayRequest{
+		ProviderID:   "authz",
+		ProviderKind: ProviderKindAuthorization,
+		ServiceName:  "gestalt.v1.Authorization",
+		Operation:    "CheckAccess",
+		Source:       GatewaySourceSDKGRPC,
+	}
+
+	_, err := gateway.Invoke(ctx, req, func(ctx context.Context, req ProviderGatewayRequest) (ProviderGatewayResponse, error) {
+		return ProviderGatewayResponse{Payload: []byte("ok")}, nil
+	})
+	if err != nil {
+		t.Fatalf("Invoke error = %v", err)
+	}
+
+	rm := metrictest.CollectMetrics(t, metrics.Reader)
+	attrs := providerGatewayMetricAttrs(req)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.provider_gateway.operation.count", 1, attrs)
+	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.provider_gateway.operation.duration", attrs)
+	metrictest.RequireNoInt64Sum(t, rm, "gestaltd.provider_gateway.operation.error_count", attrs)
+}
+
+func TestGatewayInvokeRecordsErrorMetrics(t *testing.T) {
+	metrics := metrictest.NewManualMeterProvider(t)
+	ctx := metricutil.WithMeterProvider(context.Background(), metrics.Provider)
+	gateway := New()
+	req := ProviderGatewayRequest{
+		ProviderID:   "authz",
+		ProviderKind: ProviderKindAuthorization,
+		ServiceName:  "gestalt.v1.Authorization",
+		Operation:    "CheckAccess",
+		Source:       GatewaySourceInternal,
+	}
+	wantErr := errors.New("provider failed")
+
+	_, err := gateway.Invoke(ctx, req, func(ctx context.Context, req ProviderGatewayRequest) (ProviderGatewayResponse, error) {
+		return ProviderGatewayResponse{}, wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Invoke error = %v, want %v", err, wantErr)
+	}
+
+	rm := metrictest.CollectMetrics(t, metrics.Reader)
+	attrs := providerGatewayMetricAttrs(req)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.provider_gateway.operation.count", 1, attrs)
+	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.provider_gateway.operation.duration", attrs)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.provider_gateway.operation.error_count", 1, attrs)
+}
+
+func providerGatewayMetricAttrs(req ProviderGatewayRequest) map[string]string {
+	return map[string]string{
+		"gestaltd.provider_gateway.provider.id":    req.ProviderID,
+		"gestaltd.provider_gateway.provider.kind":  string(req.ProviderKind),
+		"gestaltd.provider_gateway.service.name":   req.ServiceName,
+		"gestaltd.provider_gateway.operation.name": req.Operation,
+		"gestaltd.provider_gateway.source":         string(req.Source),
+	}
+}

--- a/gestaltd/services/providergateway/metrics.go
+++ b/gestaltd/services/providergateway/metrics.go
@@ -1,0 +1,68 @@
+package providergateway
+
+import (
+	"context"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+var (
+	attrProviderGatewayProviderID   = attribute.Key("gestaltd.provider_gateway.provider.id")
+	attrProviderGatewayProviderKind = attribute.Key("gestaltd.provider_gateway.provider.kind")
+	attrProviderGatewayServiceName  = attribute.Key("gestaltd.provider_gateway.service.name")
+	attrProviderGatewayOperation    = attribute.Key("gestaltd.provider_gateway.operation.name")
+	attrProviderGatewaySource       = attribute.Key("gestaltd.provider_gateway.source")
+
+	providerGatewayOperationMetrics metricutil.MeterCache[providerGatewayMetrics]
+)
+
+type providerGatewayMetrics struct {
+	count      metric.Int64Counter
+	errorCount metric.Int64Counter
+	duration   metric.Float64Histogram
+}
+
+func newProviderGatewayMetrics(meter metric.Meter) providerGatewayMetrics {
+	return providerGatewayMetrics{
+		count: metricutil.NewInt64Counter(
+			meter,
+			"gestaltd.provider_gateway.operation.count",
+			"Counts provider gateway operations.",
+		),
+		errorCount: metricutil.NewInt64Counter(
+			meter,
+			"gestaltd.provider_gateway.operation.error_count",
+			"Counts failed provider gateway operations.",
+		),
+		duration: metricutil.NewFloat64Histogram(
+			meter,
+			"gestaltd.provider_gateway.operation.duration",
+			"Measures provider gateway operation duration.",
+			"s",
+		),
+	}
+}
+
+func recordProviderGatewayOperation(ctx context.Context, startedAt time.Time, err error, req ProviderGatewayRequest) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	metrics := providerGatewayOperationMetrics.Load(ctx, "gestaltd", newProviderGatewayMetrics)
+	attrs := []attribute.KeyValue{
+		attrProviderGatewayProviderID.String(metricutil.AttrValue(req.ProviderID)),
+		attrProviderGatewayProviderKind.String(metricutil.AttrValue(string(req.ProviderKind))),
+		attrProviderGatewayServiceName.String(metricutil.AttrValue(req.ServiceName)),
+		attrProviderGatewayOperation.String(metricutil.AttrValue(req.Operation)),
+		attrProviderGatewaySource.String(metricutil.AttrValue(string(req.Source))),
+	}
+	metricAttrs := metric.WithAttributes(attrs...)
+
+	metrics.count.Add(ctx, 1, metricAttrs)
+	metrics.duration.Record(ctx, time.Since(startedAt).Seconds(), metricAttrs)
+	if err != nil {
+		metrics.errorCount.Add(ctx, 1, metricAttrs)
+	}
+}

--- a/gestaltd/services/providergateway/metrics.go
+++ b/gestaltd/services/providergateway/metrics.go
@@ -10,10 +10,10 @@ import (
 )
 
 var (
-	attrProviderGatewayProviderID   = attribute.Key("gestaltd.provider_gateway.provider.id")
-	attrProviderGatewayProviderKind = attribute.Key("gestaltd.provider_gateway.provider.kind")
-	attrProviderGatewayServiceName  = attribute.Key("gestaltd.provider_gateway.service.name")
-	attrProviderGatewayOperation    = attribute.Key("gestaltd.provider_gateway.operation.name")
+	attrProviderGatewayProviderID    = attribute.Key("gestaltd.provider_gateway.provider.id")
+	attrProviderGatewayProviderKind  = attribute.Key("gestaltd.provider_gateway.provider.kind")
+	attrProviderGatewayServiceName   = attribute.Key("gestaltd.provider_gateway.service.name")
+	attrProviderGatewayOperation     = attribute.Key("gestaltd.provider_gateway.operation.name")
 	attrProviderGatewaySource        = attribute.Key("gestaltd.provider_gateway.source")
 	attrProviderGatewayTransportPath = attribute.Key("gestaltd.provider_gateway.transport.path")
 

--- a/gestaltd/services/providergateway/metrics.go
+++ b/gestaltd/services/providergateway/metrics.go
@@ -14,7 +14,8 @@ var (
 	attrProviderGatewayProviderKind = attribute.Key("gestaltd.provider_gateway.provider.kind")
 	attrProviderGatewayServiceName  = attribute.Key("gestaltd.provider_gateway.service.name")
 	attrProviderGatewayOperation    = attribute.Key("gestaltd.provider_gateway.operation.name")
-	attrProviderGatewaySource       = attribute.Key("gestaltd.provider_gateway.source")
+	attrProviderGatewaySource        = attribute.Key("gestaltd.provider_gateway.source")
+	attrProviderGatewayTransportPath = attribute.Key("gestaltd.provider_gateway.transport.path")
 
 	providerGatewayOperationMetrics metricutil.MeterCache[providerGatewayMetrics]
 )
@@ -46,7 +47,7 @@ func newProviderGatewayMetrics(meter metric.Meter) providerGatewayMetrics {
 	}
 }
 
-func recordProviderGatewayOperation(ctx context.Context, startedAt time.Time, err error, req ProviderGatewayRequest) {
+func recordProviderGatewayOperation(ctx context.Context, startedAt time.Time, err error, req ProviderGatewayRequest, transportPath TransportPath) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -57,6 +58,7 @@ func recordProviderGatewayOperation(ctx context.Context, startedAt time.Time, er
 		attrProviderGatewayServiceName.String(metricutil.AttrValue(req.ServiceName)),
 		attrProviderGatewayOperation.String(metricutil.AttrValue(req.Operation)),
 		attrProviderGatewaySource.String(metricutil.AttrValue(string(req.Source))),
+		attrProviderGatewayTransportPath.String(metricutil.AttrValue(string(transportPath))),
 	}
 	metricAttrs := metric.WithAttributes(attrs...)
 

--- a/gestaltd/services/providergateway/types.go
+++ b/gestaltd/services/providergateway/types.go
@@ -19,6 +19,13 @@ const (
 	GatewaySourceInternal GatewaySource = "internal"
 )
 
+type TransportPath string
+
+const (
+	TransportPathDirect          TransportPath = "direct"
+	TransportPathProviderGateway TransportPath = "provider_gateway"
+)
+
 type RequestContext = proto.RequestContext
 
 type Transport interface {


### PR DESCRIPTION
## Description

Adds OpenTelemetry count, error count, and duration metrics around provider gateway invocations with provider, service, operation, and source dimensions.