### PR TITLE
[provider-gateway] add caller token helpers

### DIFF
--- a/gestaltd/internal/bootstrap/authorization_bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/authorization_bootstrap_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
-	"github.com/valon-technologies/gestalt/server/services/providergateway"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	gproto "google.golang.org/protobuf/proto"
 	"gopkg.in/yaml.v3"
@@ -361,7 +360,7 @@ config:
 	var capturedName string
 	var capturedHostServices []runtimehost.HostService
 	factories := &FactoryRegistry{
-		Authorization: func(_ context.Context, name string, _ yaml.Node, hostServices []runtimehost.HostService, _ providergateway.ProviderGateway) (core.AuthorizationProvider, error) {
+		Authorization: func(_ context.Context, name string, _ yaml.Node, hostServices []runtimehost.HostService, _ Deps) (core.AuthorizationProvider, error) {
 			capturedName = name
 			capturedHostServices = append([]runtimehost.HostService(nil), hostServices...)
 			return &recordingAuthorizationProvider{}, nil
@@ -399,6 +398,67 @@ config:
 		}
 	}
 	t.Fatalf("authorization host services = %#v, want indexeddb host service", capturedHostServices)
+}
+
+func TestBuildAuthorizationProviderPassesCallerTokenPublicKeyDep(t *testing.T) {
+	t.Parallel()
+
+	var runtimeConfig yaml.Node
+	if err := yaml.Unmarshal([]byte(`
+command: /bin/true
+`), &runtimeConfig); err != nil {
+		t.Fatalf("decode runtime config: %v", err)
+	}
+	var capturedPublicKey string
+	factories := &FactoryRegistry{
+		Authorization: func(_ context.Context, _ string, _ yaml.Node, _ []runtimehost.HostService, deps Deps) (core.AuthorizationProvider, error) {
+			capturedPublicKey = deps.CallerTokenPublicKey
+			return &recordingAuthorizationProvider{}, nil
+		},
+	}
+	cfg := &config.Config{
+		Server: config.ServerConfig{Providers: config.ServerProvidersConfig{Authorization: "indexeddb"}},
+		Providers: config.ProvidersConfig{
+			Authorization: map[string]*config.ProviderEntry{
+				"indexeddb": {Config: *runtimeConfig.Content[0]},
+			},
+		},
+	}
+	deps := Deps{
+		CallerTokenPublicKey: "public-key-pem",
+	}
+
+	_, err := buildAuthorizationProviders(context.Background(), cfg, factories, deps)
+	if err != nil {
+		t.Fatalf("buildAuthorizationProviders: %v", err)
+	}
+	if capturedPublicKey != "public-key-pem" {
+		t.Fatalf("CallerTokenPublicKey = %q, want public-key-pem", capturedPublicKey)
+	}
+}
+
+func TestResolveCallerTokenPublicKey(t *testing.T) {
+	t.Parallel()
+
+	got, err := resolveCallerTokenPublicKey(context.Background(), &coretesting.StubSecretManager{
+		Secrets: map[string]string{
+			callerTokenPublicKeySecretName: " public-key-pem ",
+		},
+	})
+	if err != nil {
+		t.Fatalf("resolveCallerTokenPublicKey: %v", err)
+	}
+	if got != "public-key-pem" {
+		t.Fatalf("public key = %q, want public-key-pem", got)
+	}
+
+	missing, err := resolveCallerTokenPublicKey(context.Background(), &coretesting.StubSecretManager{})
+	if err != nil {
+		t.Fatalf("resolveCallerTokenPublicKey missing: %v", err)
+	}
+	if missing != "" {
+		t.Fatalf("missing public key = %q, want empty", missing)
+	}
 }
 
 func assertAppInvocationRelationship(t *testing.T, relationship *proto.Relationship, resourceType string) {

--- a/gestaltd/internal/bootstrap/authorization_bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/authorization_bootstrap_test.go
@@ -461,6 +461,22 @@ func TestResolveCallerTokenPublicKey(t *testing.T) {
 	}
 }
 
+func TestResolveCallerTokenPrivateKey(t *testing.T) {
+	t.Parallel()
+
+	got, err := resolveCallerTokenPrivateKey(context.Background(), &coretesting.StubSecretManager{
+		Secrets: map[string]string{
+			callerTokenPrivateKeySecretName: " private-key-pem ",
+		},
+	})
+	if err != nil {
+		t.Fatalf("resolveCallerTokenPrivateKey: %v", err)
+	}
+	if got != "private-key-pem" {
+		t.Fatalf("private key = %q, want private-key-pem", got)
+	}
+}
+
 func assertAppInvocationRelationship(t *testing.T, relationship *proto.Relationship, resourceType string) {
 	t.Helper()
 	tuple := relationship.GetTuple()

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -181,12 +181,13 @@ type Deps struct {
 	HostServiceTLSCAPEM   string
 	Telemetry             core.TelemetryProvider
 	ProviderGateway       providergateway.ProviderGateway
+	CallerTokenPublicKey  string
 
 	hostedAgentPoolClock hostedAgentPoolClock
 }
 
 type AuthFactory func(node yaml.Node, deps Deps) (core.AuthenticationProvider, error)
-type AuthorizationFactory func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, gateway providergateway.ProviderGateway) (core.AuthorizationProvider, error)
+type AuthorizationFactory func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps Deps) (core.AuthorizationProvider, error)
 type ExternalCredentialFactory func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps Deps) (core.ExternalCredentialProvider, error)
 type SecretManagerFactory func(node yaml.Node) (core.SecretManager, error)
 type IndexedDBFactory func(node yaml.Node) (indexeddb.IndexedDB, error)
@@ -197,6 +198,10 @@ type AgentFactory func(ctx context.Context, name string, node yaml.Node, hostSer
 type RuntimeFactory func(ctx context.Context, name string, entry *config.RuntimeProviderEntry, deps Deps) (runtimeprovider.Provider, error)
 type TelemetryFactory func(node yaml.Node) (core.TelemetryProvider, error)
 type AuditFactory func(ctx context.Context, cfg config.ProviderEntry, telemetry core.TelemetryProvider) (core.AuditSink, func(context.Context) error, error)
+
+const (
+	callerTokenPublicKeySecretName = "gestaltd-caller-token-ed25519-public-key"
+)
 
 type FactoryRegistry struct {
 	Auth                AuthFactory
@@ -962,6 +967,12 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	deps.S3 = hostS3s
 	deps.AppAccessProfiles = appAccessProfiles(cfg.Apps)
 	deps.ProviderGateway = providergateway.New()
+	callerTokenPublicKey, err := resolveCallerTokenPublicKey(ctx, sm)
+	if err != nil {
+		_ = closeAuthProviders(authProviders)
+		return nil, err
+	}
+	deps.CallerTokenPublicKey = callerTokenPublicKey
 	authorizationProviders, err := buildAuthorizationProviders(ctx, cfg, factories, deps)
 	if err != nil {
 		_ = closeAuthProviders(authProviders)
@@ -1860,11 +1871,29 @@ func buildNamedAuthorizationProvider(ctx context.Context, name string, entry *co
 	if err != nil {
 		return nil, fmt.Errorf("bootstrap: authorization provider %q: %w", logicalName, err)
 	}
-	provider, err := factories.Authorization(ctx, logicalName, node, hostServices, deps.ProviderGateway)
+	provider, err := factories.Authorization(ctx, logicalName, node, hostServices, deps)
 	if err != nil {
 		return nil, fmt.Errorf("bootstrap: authorization provider %q: %w", logicalName, err)
 	}
 	return provider, nil
+}
+
+func resolveCallerTokenPublicKey(ctx context.Context, sm core.SecretManager) (string, error) {
+	if sm == nil {
+		return "", nil
+	}
+	value, err := sm.GetSecret(ctx, callerTokenPublicKeySecretName)
+	if err != nil {
+		if errors.Is(err, core.ErrSecretNotFound) {
+			return "", nil
+		}
+		return "", fmt.Errorf("bootstrap: resolve %s: %w", callerTokenPublicKeySecretName, err)
+	}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("bootstrap: secret %q resolved to empty value", callerTokenPublicKeySecretName)
+	}
+	return value, nil
 }
 
 func buildIndexedDB(entry *config.ProviderEntry, factories *FactoryRegistry) (indexeddb.IndexedDB, error) {

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -255,6 +255,7 @@ type Result struct {
 	Telemetry            core.TelemetryProvider
 	Runtimes             RuntimeInspector
 	PublicHostServices   *runtimehost.PublicHostServiceRegistry
+	ProviderGateway      *providergateway.Gateway
 
 	runtimeRegistry                     *runtimeRegistry
 	workflowConfigReconcileTasks        []workflowConfigReconcileTask
@@ -671,6 +672,7 @@ type preparedCore struct {
 	WorkflowManager      *lazyWorkflowManager
 	AgentManager         *lazyAgentManager
 	PublicHostServices   *runtimehost.PublicHostServiceRegistry
+	ProviderGateway      *providergateway.Gateway
 
 	runtimeRegistry *runtimeRegistry
 }
@@ -972,7 +974,13 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 		_ = closeAuthProviders(authProviders)
 		return nil, err
 	}
-	deps.ProviderGateway = providergateway.New(providergateway.WithCallerTokenPrivateKey(callerTokenPrivateKey))
+	callerTokenIssuer, err := providergateway.NewCallerTokenIssuer(callerTokenPrivateKey)
+	if err != nil {
+		_ = closeAuthProviders(authProviders)
+		return nil, fmt.Errorf("bootstrap: caller token private key: %w", err)
+	}
+	providerGateway := providergateway.New(providergateway.WithCallerTokenIssuer(callerTokenIssuer))
+	deps.ProviderGateway = providerGateway
 	callerTokenPublicKey, err := resolveCallerTokenPublicKey(ctx, sm)
 	if err != nil {
 		_ = closeAuthProviders(authProviders)
@@ -1040,6 +1048,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 		WorkflowManager:      workflowManager,
 		AgentManager:         agentManager,
 		PublicHostServices:   publicHostServices,
+		ProviderGateway:      providerGateway,
 		runtimeRegistry:      runtimeRegistry,
 	}, nil
 }
@@ -1264,6 +1273,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		Telemetry:                    prepared.Telemetry,
 		Runtimes:                     prepared.runtimeRegistry,
 		PublicHostServices:           publicHostServices,
+		ProviderGateway:              prepared.ProviderGateway,
 		runtimeRegistry:              prepared.runtimeRegistry,
 		workflowConfigReconcileTasks: deferredWorkflowConfigReconcileTasks,
 		auditClose:                   auditClose,

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -200,7 +200,8 @@ type TelemetryFactory func(node yaml.Node) (core.TelemetryProvider, error)
 type AuditFactory func(ctx context.Context, cfg config.ProviderEntry, telemetry core.TelemetryProvider) (core.AuditSink, func(context.Context) error, error)
 
 const (
-	callerTokenPublicKeySecretName = "gestaltd-caller-token-ed25519-public-key"
+	callerTokenPrivateKeySecretName = "gestaltd-caller-token-ed25519-private-key"
+	callerTokenPublicKeySecretName  = "gestaltd-caller-token-ed25519-public-key"
 )
 
 type FactoryRegistry struct {
@@ -966,7 +967,12 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	deps.Caches = hostCaches
 	deps.S3 = hostS3s
 	deps.AppAccessProfiles = appAccessProfiles(cfg.Apps)
-	deps.ProviderGateway = providergateway.New()
+	callerTokenPrivateKey, err := resolveCallerTokenPrivateKey(ctx, sm)
+	if err != nil {
+		_ = closeAuthProviders(authProviders)
+		return nil, err
+	}
+	deps.ProviderGateway = providergateway.New(providergateway.WithCallerTokenPrivateKey(callerTokenPrivateKey))
 	callerTokenPublicKey, err := resolveCallerTokenPublicKey(ctx, sm)
 	if err != nil {
 		_ = closeAuthProviders(authProviders)
@@ -1878,20 +1884,28 @@ func buildNamedAuthorizationProvider(ctx context.Context, name string, entry *co
 	return provider, nil
 }
 
+func resolveCallerTokenPrivateKey(ctx context.Context, sm core.SecretManager) (string, error) {
+	return resolveCallerTokenKey(ctx, sm, callerTokenPrivateKeySecretName)
+}
+
 func resolveCallerTokenPublicKey(ctx context.Context, sm core.SecretManager) (string, error) {
+	return resolveCallerTokenKey(ctx, sm, callerTokenPublicKeySecretName)
+}
+
+func resolveCallerTokenKey(ctx context.Context, sm core.SecretManager, name string) (string, error) {
 	if sm == nil {
 		return "", nil
 	}
-	value, err := sm.GetSecret(ctx, callerTokenPublicKeySecretName)
+	value, err := sm.GetSecret(ctx, name)
 	if err != nil {
 		if errors.Is(err, core.ErrSecretNotFound) {
 			return "", nil
 		}
-		return "", fmt.Errorf("bootstrap: resolve %s: %w", callerTokenPublicKeySecretName, err)
+		return "", fmt.Errorf("bootstrap: resolve %s: %w", name, err)
 	}
 	value = strings.TrimSpace(value)
 	if value == "" {
-		return "", fmt.Errorf("bootstrap: secret %q resolved to empty value", callerTokenPublicKeySecretName)
+		return "", fmt.Errorf("bootstrap: secret %q resolved to empty value", name)
 	}
 	return value, nil
 }

--- a/gestaltd/internal/daemon/factories.go
+++ b/gestaltd/internal/daemon/factories.go
@@ -129,7 +129,12 @@ func buildFactories() *bootstrap.FactoryRegistry {
 			SessionKey:         deps.EncryptionKey,
 		})
 	}
-	factories.Authorization = providerdrivers.AuthorizationFactory
+	factories.Authorization = func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps bootstrap.Deps) (core.AuthorizationProvider, error) {
+		return providerdrivers.AuthorizationFactory(ctx, name, node, hostServices, providerdrivers.AuthorizationDeps{
+			Gateway:              deps.ProviderGateway,
+			CallerTokenPublicKey: deps.CallerTokenPublicKey,
+		})
+	}
 	factories.ExternalCredentials = func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, _ bootstrap.Deps) (core.ExternalCredentialProvider, error) {
 		return providerdrivers.ExternalCredentialsFactory(ctx, name, node, hostServices)
 	}

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -836,6 +836,12 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 		Surface:        metricutil.InvocationSurfaceHTTP,
 	})
 	ctx = invocation.WithInvocationSurface(ctx, invocation.InvocationSurfaceHTTP)
+	ctx, err = s.withProviderGatewayCallerToken(ctx, p)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "issue provider gateway caller token", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to prepare invocation context")
+		return
+	}
 
 	result, err := s.invoker.Invoke(ctx, p, providerName, instance, operationName, params)
 	if err != nil {

--- a/gestaltd/internal/server/provider_gateway_caller_token.go
+++ b/gestaltd/internal/server/provider_gateway_caller_token.go
@@ -1,0 +1,25 @@
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+	"github.com/valon-technologies/gestalt/server/services/providergateway"
+)
+
+func (s *Server) withProviderGatewayCallerToken(ctx context.Context, p *principal.Principal) (context.Context, error) {
+	subjectID := invokingPrincipalSubjectID(p)
+	if subjectID == "" || len(s.sessionIssuer) == 0 {
+		return ctx, nil
+	}
+	claims, err := providergateway.GenerateCallerTokenClaims(subjectID, s.now())
+	if err != nil {
+		return ctx, fmt.Errorf("provider gateway caller token claims: %w", err)
+	}
+	token, err := providergateway.Issue(claims, s.sessionIssuer)
+	if err != nil {
+		return ctx, fmt.Errorf("provider gateway caller token: %w", err)
+	}
+	return providergateway.WithCallerToken(ctx, token), nil
+}

--- a/gestaltd/internal/server/provider_gateway_caller_token.go
+++ b/gestaltd/internal/server/provider_gateway_caller_token.go
@@ -10,16 +10,15 @@ import (
 
 func (s *Server) withProviderGatewayCallerToken(ctx context.Context, p *principal.Principal) (context.Context, error) {
 	subjectID := invokingPrincipalSubjectID(p)
-	if subjectID == "" || len(s.sessionIssuer) == 0 {
+	if subjectID == "" || s.providerGateway == nil {
 		return ctx, nil
 	}
-	claims, err := providergateway.GenerateCallerTokenClaims(subjectID, s.now())
-	if err != nil {
-		return ctx, fmt.Errorf("provider gateway caller token claims: %w", err)
-	}
-	token, err := providergateway.Issue(claims, s.sessionIssuer)
+	token, ok, err := s.providerGateway.IssueCallerToken(subjectID, s.now())
 	if err != nil {
 		return ctx, fmt.Errorf("provider gateway caller token: %w", err)
+	}
+	if !ok {
+		return ctx, nil
 	}
 	return providergateway.WithCallerToken(ctx, token), nil
 }

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -83,6 +83,7 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 		AuditSink:            result.AuditSink,
 		Services:             result.Services,
 		Providers:            result.Providers,
+		ProviderGateway:      result.ProviderGateway,
 		Agent:                result.AgentControl,
 		AgentManager:         result.AgentManager,
 		Workflow:             result.WorkflowControl,

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/observability"
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
+	"github.com/valon-technologies/gestalt/server/services/providergateway"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"github.com/valon-technologies/gestalt/server/services/s3"
 	"github.com/valon-technologies/gestalt/server/services/workflows/workflowmanager"
@@ -94,6 +95,7 @@ type Server struct {
 	workflowSchedules      *workflowmanager.Manager
 	agentRuns              agentmanager.Service
 	providers              *registry.ProviderMap[core.Provider]
+	providerGateway        *providergateway.Gateway
 	workflow               bootstrap.WorkflowControl
 	pluginRuntimes         bootstrap.RuntimeInspector
 	resolver               *principal.Resolver
@@ -152,6 +154,7 @@ type Config struct {
 	AuditSink            core.AuditSink
 	Services             *coredata.Services
 	Providers            *registry.ProviderMap[core.Provider]
+	ProviderGateway      *providergateway.Gateway
 	Agent                bootstrap.AgentControl
 	AgentManager         agentmanager.Service
 	Workflow             bootstrap.WorkflowControl
@@ -348,6 +351,7 @@ func New(cfg Config) (*Server, error) {
 		agent:                  cfg.Agent,
 		agentRuns:              cfg.AgentManager,
 		providers:              cfg.Providers,
+		providerGateway:        cfg.ProviderGateway,
 		workflow:               cfg.Workflow,
 		pluginRuntimes:         cfg.Runtimes,
 		resolver:               resolver,

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -63,6 +63,7 @@ import (
 	indexeddbservice "github.com/valon-technologies/gestalt/server/services/indexeddb"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
+	"github.com/valon-technologies/gestalt/server/services/providergateway"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost/runtimelogs"
 	"github.com/valon-technologies/gestalt/server/services/s3"
@@ -685,6 +686,24 @@ func (i *relayTestInvoker) snapshot() relayTestInvokerCall {
 		idempotencyKey: i.idempotencyKey,
 		params:         maps.Clone(i.params),
 	}
+}
+
+type callerTokenRecordingInvoker struct {
+	mu          sync.Mutex
+	callerToken string
+}
+
+func (i *callerTokenRecordingInvoker) Invoke(ctx context.Context, _ *principal.Principal, _, _, _ string, _ map[string]any) (*core.OperationResult, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.callerToken = providergateway.CallerTokenFromContext(ctx)
+	return &core.OperationResult{Status: http.StatusOK, Body: []byte(`{"ok":true}`)}, nil
+}
+
+func (i *callerTokenRecordingInvoker) token() string {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.callerToken
 }
 
 type relayAllowAuthorizationProvider struct {
@@ -14553,6 +14572,69 @@ func TestAPITokenScopes_EmptyScopesAllowAll(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestExecuteOperationIssuesProviderGatewayCallerToken(t *testing.T) {
+	t.Parallel()
+
+	const stateSecret = "0123456789abcdef0123456789abcdef"
+	stub := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{N: "cli-provider", ConnMode: core.ConnectionModeNone},
+		ops:             []core.Operation{{Name: "do_thing", Method: http.MethodGet}},
+	}
+
+	svc := testutil.NewStubServices(t)
+	plaintext, hashed, err := principal.GenerateToken(principal.TokenTypeAPI)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	user := seedAPITokenWithPermissions(t, svc, plaintext, hashed, "cli-user", nil)
+	invoker := &callerTokenRecordingInvoker{}
+	now := time.Now().UTC()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, _ string) (*core.UserIdentity, error) {
+				return nil, fmt.Errorf("not a session token")
+			},
+		}
+		cfg.Invoker = invoker
+		cfg.Now = func() time.Time { return now }
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.Services = svc
+		cfg.StateSecret = []byte(stateSecret)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/cli-provider/do_thing", nil)
+	req.Header.Set("Authorization", "Bearer "+plaintext)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	token := invoker.token()
+	if token == "" {
+		t.Fatalf("expected provider gateway caller token")
+	}
+	claims, err := providergateway.Verify(token, []byte(stateSecret))
+	if err != nil {
+		t.Fatalf("Verify caller token: %v", err)
+	}
+	if claims.SubjectID != principal.UserSubjectID(user.ID) {
+		t.Fatalf("SubjectID = %q, want %q", claims.SubjectID, principal.UserSubjectID(user.ID))
+	}
+	if claims.IssuedAt != now.Unix() {
+		t.Fatalf("IssuedAt = %d, want %d", claims.IssuedAt, now.Unix())
+	}
+	if claims.ExpiresAt != now.Add(5*time.Minute).Unix() {
+		t.Fatalf("ExpiresAt = %d, want %d", claims.ExpiresAt, now.Add(5*time.Minute).Unix())
 	}
 }
 

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -4,12 +4,16 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/ed25519"
 	"crypto/hmac"
+	"crypto/rand"
 	"crypto/sha256"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"io"
@@ -14578,7 +14582,6 @@ func TestAPITokenScopes_EmptyScopesAllowAll(t *testing.T) {
 func TestExecuteOperationIssuesProviderGatewayCallerToken(t *testing.T) {
 	t.Parallel()
 
-	const stateSecret = "0123456789abcdef0123456789abcdef"
 	stub := &stubIntegrationWithOps{
 		StubIntegration: coretesting.StubIntegration{N: "cli-provider", ConnMode: core.ConnectionModeNone},
 		ops:             []core.Operation{{Name: "do_thing", Method: http.MethodGet}},
@@ -14592,6 +14595,11 @@ func TestExecuteOperationIssuesProviderGatewayCallerToken(t *testing.T) {
 	user := seedAPITokenWithPermissions(t, svc, plaintext, hashed, "cli-user", nil)
 	invoker := &callerTokenRecordingInvoker{}
 	now := time.Now().UTC()
+	privateKeyPEM, publicKeyPEM := testProviderGatewayCallerTokenKeyPair(t)
+	issuer, err := providergateway.NewCallerTokenIssuer(privateKeyPEM)
+	if err != nil {
+		t.Fatalf("NewCallerTokenIssuer: %v", err)
+	}
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{
@@ -14603,8 +14611,8 @@ func TestExecuteOperationIssuesProviderGatewayCallerToken(t *testing.T) {
 		cfg.Invoker = invoker
 		cfg.Now = func() time.Time { return now }
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.ProviderGateway = providergateway.New(providergateway.WithCallerTokenIssuer(issuer))
 		cfg.Services = svc
-		cfg.StateSecret = []byte(stateSecret)
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -14623,7 +14631,7 @@ func TestExecuteOperationIssuesProviderGatewayCallerToken(t *testing.T) {
 	if token == "" {
 		t.Fatalf("expected provider gateway caller token")
 	}
-	claims, err := providergateway.Verify(token, []byte(stateSecret))
+	claims, err := providergateway.Verify(token, publicKeyPEM)
 	if err != nil {
 		t.Fatalf("Verify caller token: %v", err)
 	}
@@ -14636,6 +14644,25 @@ func TestExecuteOperationIssuesProviderGatewayCallerToken(t *testing.T) {
 	if claims.ExpiresAt != now.Add(5*time.Minute).Unix() {
 		t.Fatalf("ExpiresAt = %d, want %d", claims.ExpiresAt, now.Add(5*time.Minute).Unix())
 	}
+}
+
+func testProviderGatewayCallerTokenKeyPair(t testing.TB) (string, string) {
+	t.Helper()
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	privateKeyBytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		t.Fatalf("MarshalPKCS8PrivateKey: %v", err)
+	}
+	publicKeyBytes, err := x509.MarshalPKIXPublicKey(publicKey)
+	if err != nil {
+		t.Fatalf("MarshalPKIXPublicKey: %v", err)
+	}
+	privateKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privateKeyBytes})
+	publicKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: publicKeyBytes})
+	return string(privateKeyPEM), string(publicKeyPEM)
 }
 
 func TestCreateAPIToken_InvalidScope(t *testing.T) {

--- a/gestaltd/rpc/authorization/client.go
+++ b/gestaltd/rpc/authorization/client.go
@@ -149,6 +149,7 @@ func (c *Client) invoke(ctx context.Context, operation string, in gproto.Message
 		Operation:      operation,
 		RequestContext: providergateway.RequestContextFromContext(ctx),
 		Source:         providergateway.SourceFromContext(ctx),
+		CallerToken:    providergateway.CallerTokenFromContext(ctx),
 		Payload:        payload,
 	}, func(ctx context.Context, _ providergateway.ProviderGatewayRequest) (providergateway.ProviderGatewayResponse, error) {
 		msg, err := call(ctx)

--- a/gestaltd/rpc/authorization/client_test.go
+++ b/gestaltd/rpc/authorization/client_test.go
@@ -21,7 +21,8 @@ func TestClientCheckAccessInvokesProviderGatewayBeforeGRPC(t *testing.T) {
 		ProviderID: "authz",
 	}, gateway)
 
-	resp, err := client.CheckAccess(context.Background(), &proto.CheckAccessRequest{
+	ctx := providergateway.WithCallerToken(context.Background(), "caller-token")
+	resp, err := client.CheckAccess(ctx, &proto.CheckAccessRequest{
 		Subject:  &proto.Subject{Type: "subject", Id: "user:checked"},
 		Action:   &proto.Action{Name: "view"},
 		Resource: &proto.Resource{Type: "team", Id: "servicing"},
@@ -48,6 +49,9 @@ func TestClientCheckAccessInvokesProviderGatewayBeforeGRPC(t *testing.T) {
 	}
 	if got.Operation != "CheckAccess" {
 		t.Fatalf("Operation = %q", got.Operation)
+	}
+	if got.CallerToken != "caller-token" {
+		t.Fatalf("CallerToken = %q, want caller-token", got.CallerToken)
 	}
 	var payload proto.CheckAccessRequest
 	if err := gproto.Unmarshal(got.Payload, &payload); err != nil {

--- a/gestaltd/services/providerdrivers/authorization.go
+++ b/gestaltd/services/providerdrivers/authorization.go
@@ -13,11 +13,19 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func AuthorizationFactory(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, gateway providergateway.ProviderGateway) (core.AuthorizationProvider, error) {
+const CallerTokenPublicKeyEnv = "GESTALTD_CALLER_TOKEN_ED25519_PUBLIC_KEY"
+
+type AuthorizationDeps struct {
+	Gateway              providergateway.ProviderGateway
+	CallerTokenPublicKey string
+}
+
+func AuthorizationFactory(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps AuthorizationDeps) (core.AuthorizationProvider, error) {
 	var cfg componentprovider.YAMLConfig
 	if err := node.Decode(&cfg); err != nil {
 		return nil, fmt.Errorf("authorization provider: parsing config: %w", err)
 	}
+	cfg.Env = authorizationEnvWithCallerTokenPublicKey(cfg.Env, deps.CallerTokenPublicKey)
 	prepared, err := componentprovider.PrepareExecution(componentprovider.PrepareParams{
 		Kind:                 providermanifestv1.KindAuthorization,
 		Subject:              "authorization provider",
@@ -40,6 +48,18 @@ func AuthorizationFactory(ctx context.Context, name string, node yaml.Node, host
 		Cleanup:      prepared.Cleanup,
 		HostServices: hostServices,
 		Name:         name,
-		Gateway:      gateway,
+		Gateway:      deps.Gateway,
 	})
+}
+
+func authorizationEnvWithCallerTokenPublicKey(env map[string]string, publicKey string) map[string]string {
+	if publicKey == "" || env[CallerTokenPublicKeyEnv] != "" {
+		return env
+	}
+	next := make(map[string]string, len(env)+1)
+	for key, value := range env {
+		next[key] = value
+	}
+	next[CallerTokenPublicKeyEnv] = publicKey
+	return next
 }

--- a/gestaltd/services/providerdrivers/authorization_test.go
+++ b/gestaltd/services/providerdrivers/authorization_test.go
@@ -1,0 +1,28 @@
+package providerdrivers
+
+import "testing"
+
+func TestAuthorizationEnvWithCallerTokenPublicKey(t *testing.T) {
+	t.Parallel()
+
+	env := authorizationEnvWithCallerTokenPublicKey(map[string]string{"EXISTING": "value"}, "public-key-pem")
+
+	if env["EXISTING"] != "value" {
+		t.Fatalf("EXISTING = %q, want value", env["EXISTING"])
+	}
+	if env[CallerTokenPublicKeyEnv] != "public-key-pem" {
+		t.Fatalf("%s = %q, want public-key-pem", CallerTokenPublicKeyEnv, env[CallerTokenPublicKeyEnv])
+	}
+}
+
+func TestAuthorizationEnvWithCallerTokenPublicKeyPreservesConfiguredEnv(t *testing.T) {
+	t.Parallel()
+
+	env := authorizationEnvWithCallerTokenPublicKey(map[string]string{
+		CallerTokenPublicKeyEnv: "configured-public-key",
+	}, "secret-public-key")
+
+	if env[CallerTokenPublicKeyEnv] != "configured-public-key" {
+		t.Fatalf("%s = %q, want configured-public-key", CallerTokenPublicKeyEnv, env[CallerTokenPublicKeyEnv])
+	}
+}

--- a/gestaltd/services/providergateway/caller_token.go
+++ b/gestaltd/services/providergateway/caller_token.go
@@ -1,0 +1,162 @@
+package providergateway
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	callerTokenAlgorithm = "HS256"
+	callerTokenType      = "JWT"
+	callerTokenIssuer    = "gestaltd"
+	callerTokenAudience  = "provider-gateway"
+	callerTokenTTL       = 5 * time.Minute
+)
+
+type CallerTokenClaims struct {
+	SubjectID string `json:"sub"`
+	IssuedAt  int64  `json:"iat"`
+	ExpiresAt int64  `json:"exp"`
+	Issuer    string `json:"iss"`
+	Audience  string `json:"aud"`
+	ID        string `json:"jti"`
+}
+
+type callerTokenHeader struct {
+	Algorithm string `json:"alg"`
+	Type      string `json:"typ"`
+}
+
+func GenerateCallerTokenClaims(subjectID string, now time.Time) (CallerTokenClaims, error) {
+	subjectID = strings.TrimSpace(subjectID)
+	if subjectID == "" {
+		return CallerTokenClaims{}, fmt.Errorf("caller token: subject id is required")
+	}
+	now = now.UTC()
+	return CallerTokenClaims{
+		SubjectID: subjectID,
+		IssuedAt:  now.Unix(),
+		ExpiresAt: now.Add(callerTokenTTL).Unix(),
+		Issuer:    callerTokenIssuer,
+		Audience:  callerTokenAudience,
+		ID:        uuid.NewString(),
+	}, nil
+}
+
+func Issue(claims CallerTokenClaims, secret []byte) (string, error) {
+	if err := validateCallerTokenSecret(secret); err != nil {
+		return "", err
+	}
+	if err := validateCallerTokenClaims(claims); err != nil {
+		return "", err
+	}
+	header := callerTokenHeader{
+		Algorithm: callerTokenAlgorithm,
+		Type:      callerTokenType,
+	}
+	encodedHeader, err := encodeCallerTokenPart(header)
+	if err != nil {
+		return "", fmt.Errorf("caller token: encode header: %w", err)
+	}
+	encodedClaims, err := encodeCallerTokenPart(claims)
+	if err != nil {
+		return "", fmt.Errorf("caller token: encode claims: %w", err)
+	}
+	signingInput := encodedHeader + "." + encodedClaims
+	signature := signCallerToken(signingInput, secret)
+	return signingInput + "." + signature, nil
+}
+
+func Verify(token string, secret []byte) (CallerTokenClaims, error) {
+	if err := validateCallerTokenSecret(secret); err != nil {
+		return CallerTokenClaims{}, err
+	}
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return CallerTokenClaims{}, fmt.Errorf("caller token: invalid token format")
+	}
+	var header callerTokenHeader
+	if err := decodeCallerTokenPart(parts[0], &header); err != nil {
+		return CallerTokenClaims{}, fmt.Errorf("caller token: decode header: %w", err)
+	}
+	if header.Algorithm != callerTokenAlgorithm || header.Type != callerTokenType {
+		return CallerTokenClaims{}, fmt.Errorf("caller token: unsupported token header")
+	}
+	signingInput := parts[0] + "." + parts[1]
+	expectedSignature := signCallerToken(signingInput, secret)
+	if !hmac.Equal([]byte(expectedSignature), []byte(parts[2])) {
+		return CallerTokenClaims{}, fmt.Errorf("caller token: invalid signature")
+	}
+	var claims CallerTokenClaims
+	if err := decodeCallerTokenPart(parts[1], &claims); err != nil {
+		return CallerTokenClaims{}, fmt.Errorf("caller token: decode claims: %w", err)
+	}
+	if err := validateCallerTokenClaims(claims); err != nil {
+		return CallerTokenClaims{}, err
+	}
+	if time.Now().UTC().Unix() >= claims.ExpiresAt {
+		return CallerTokenClaims{}, fmt.Errorf("caller token: expired")
+	}
+	return claims, nil
+}
+
+func validateCallerTokenSecret(secret []byte) error {
+	if len(secret) == 0 {
+		return fmt.Errorf("caller token: secret is required")
+	}
+	return nil
+}
+
+func validateCallerTokenClaims(claims CallerTokenClaims) error {
+	if strings.TrimSpace(claims.SubjectID) == "" {
+		return fmt.Errorf("caller token: subject id is required")
+	}
+	if claims.Issuer != callerTokenIssuer {
+		return fmt.Errorf("caller token: invalid issuer")
+	}
+	if claims.Audience != callerTokenAudience {
+		return fmt.Errorf("caller token: invalid audience")
+	}
+	if claims.ID == "" {
+		return fmt.Errorf("caller token: id is required")
+	}
+	if claims.IssuedAt <= 0 {
+		return fmt.Errorf("caller token: issued at is required")
+	}
+	if claims.ExpiresAt <= claims.IssuedAt {
+		return fmt.Errorf("caller token: expires at must be after issued at")
+	}
+	if claims.ExpiresAt-claims.IssuedAt > int64(callerTokenTTL/time.Second) {
+		return fmt.Errorf("caller token: lifetime exceeds maximum")
+	}
+	return nil
+}
+
+func encodeCallerTokenPart(value any) (string, error) {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(data), nil
+}
+
+func decodeCallerTokenPart(encoded string, out any) error {
+	data, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, out)
+}
+
+func signCallerToken(signingInput string, secret []byte) string {
+	mac := hmac.New(sha256.New, secret)
+	_, _ = mac.Write([]byte(signingInput))
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}

--- a/gestaltd/services/providergateway/caller_token.go
+++ b/gestaltd/services/providergateway/caller_token.go
@@ -1,10 +1,11 @@
 package providergateway
 
 import (
-	"crypto/hmac"
-	"crypto/sha256"
+	"crypto/ed25519"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"strings"
 	"time"
@@ -13,7 +14,7 @@ import (
 )
 
 const (
-	callerTokenAlgorithm = "HS256"
+	callerTokenAlgorithm = "EdDSA"
 	callerTokenType      = "JWT"
 	callerTokenIssuer    = "gestaltd"
 	callerTokenAudience  = "provider-gateway"
@@ -34,6 +35,22 @@ type callerTokenHeader struct {
 	Type      string `json:"typ"`
 }
 
+type CallerTokenIssuer struct {
+	privateKey ed25519.PrivateKey
+}
+
+func NewCallerTokenIssuer(privateKeyPEM string) (*CallerTokenIssuer, error) {
+	privateKeyPEM = strings.TrimSpace(privateKeyPEM)
+	if privateKeyPEM == "" {
+		return nil, nil
+	}
+	privateKey, err := parseCallerTokenPrivateKey(privateKeyPEM)
+	if err != nil {
+		return nil, err
+	}
+	return &CallerTokenIssuer{privateKey: privateKey}, nil
+}
+
 func GenerateCallerTokenClaims(subjectID string, now time.Time) (CallerTokenClaims, error) {
 	subjectID = strings.TrimSpace(subjectID)
 	if subjectID == "" {
@@ -50,9 +67,9 @@ func GenerateCallerTokenClaims(subjectID string, now time.Time) (CallerTokenClai
 	}, nil
 }
 
-func Issue(claims CallerTokenClaims, secret []byte) (string, error) {
-	if err := validateCallerTokenSecret(secret); err != nil {
-		return "", err
+func (i *CallerTokenIssuer) Issue(claims CallerTokenClaims) (string, error) {
+	if i == nil || len(i.privateKey) == 0 {
+		return "", fmt.Errorf("caller token: private key is required")
 	}
 	if err := validateCallerTokenClaims(claims); err != nil {
 		return "", err
@@ -70,12 +87,13 @@ func Issue(claims CallerTokenClaims, secret []byte) (string, error) {
 		return "", fmt.Errorf("caller token: encode claims: %w", err)
 	}
 	signingInput := encodedHeader + "." + encodedClaims
-	signature := signCallerToken(signingInput, secret)
+	signature := signCallerToken(signingInput, i.privateKey)
 	return signingInput + "." + signature, nil
 }
 
-func Verify(token string, secret []byte) (CallerTokenClaims, error) {
-	if err := validateCallerTokenSecret(secret); err != nil {
+func Verify(token string, publicKeyPEM string) (CallerTokenClaims, error) {
+	publicKey, err := parseCallerTokenPublicKey(publicKeyPEM)
+	if err != nil {
 		return CallerTokenClaims{}, err
 	}
 	parts := strings.Split(token, ".")
@@ -90,8 +108,11 @@ func Verify(token string, secret []byte) (CallerTokenClaims, error) {
 		return CallerTokenClaims{}, fmt.Errorf("caller token: unsupported token header")
 	}
 	signingInput := parts[0] + "." + parts[1]
-	expectedSignature := signCallerToken(signingInput, secret)
-	if !hmac.Equal([]byte(expectedSignature), []byte(parts[2])) {
+	signature, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return CallerTokenClaims{}, fmt.Errorf("caller token: decode signature: %w", err)
+	}
+	if !ed25519.Verify(publicKey, []byte(signingInput), signature) {
 		return CallerTokenClaims{}, fmt.Errorf("caller token: invalid signature")
 	}
 	var claims CallerTokenClaims
@@ -107,11 +128,36 @@ func Verify(token string, secret []byte) (CallerTokenClaims, error) {
 	return claims, nil
 }
 
-func validateCallerTokenSecret(secret []byte) error {
-	if len(secret) == 0 {
-		return fmt.Errorf("caller token: secret is required")
+func parseCallerTokenPrivateKey(privateKeyPEM string) (ed25519.PrivateKey, error) {
+	block, _ := pem.Decode([]byte(strings.TrimSpace(privateKeyPEM)))
+	if block == nil {
+		return nil, fmt.Errorf("caller token: decode private key PEM")
 	}
-	return nil
+	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("caller token: parse private key: %w", err)
+	}
+	privateKey, ok := key.(ed25519.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("caller token: private key must be Ed25519")
+	}
+	return privateKey, nil
+}
+
+func parseCallerTokenPublicKey(publicKeyPEM string) (ed25519.PublicKey, error) {
+	block, _ := pem.Decode([]byte(strings.TrimSpace(publicKeyPEM)))
+	if block == nil {
+		return nil, fmt.Errorf("caller token: decode public key PEM")
+	}
+	key, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("caller token: parse public key: %w", err)
+	}
+	publicKey, ok := key.(ed25519.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("caller token: public key must be Ed25519")
+	}
+	return publicKey, nil
 }
 
 func validateCallerTokenClaims(claims CallerTokenClaims) error {
@@ -155,8 +201,6 @@ func decodeCallerTokenPart(encoded string, out any) error {
 	return json.Unmarshal(data, out)
 }
 
-func signCallerToken(signingInput string, secret []byte) string {
-	mac := hmac.New(sha256.New, secret)
-	_, _ = mac.Write([]byte(signingInput))
-	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+func signCallerToken(signingInput string, privateKey ed25519.PrivateKey) string {
+	return base64.RawURLEncoding.EncodeToString(ed25519.Sign(privateKey, []byte(signingInput)))
 }

--- a/gestaltd/services/providergateway/caller_token_test.go
+++ b/gestaltd/services/providergateway/caller_token_test.go
@@ -1,0 +1,214 @@
+package providergateway
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCallerTokenIssueVerify(t *testing.T) {
+	secret := []byte("test-secret")
+	now := time.Now().UTC()
+	claims, err := GenerateCallerTokenClaims("user:123", now)
+	if err != nil {
+		t.Fatalf("GenerateCallerTokenClaims: %v", err)
+	}
+
+	token, err := Issue(claims, secret)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	got, err := Verify(token, secret)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+
+	if got != claims {
+		t.Fatalf("claims = %+v, want %+v", got, claims)
+	}
+}
+
+func TestCallerTokenGenerateClaims(t *testing.T) {
+	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+
+	claims, err := GenerateCallerTokenClaims(" user:abc ", now)
+	if err != nil {
+		t.Fatalf("GenerateCallerTokenClaims: %v", err)
+	}
+
+	if claims.SubjectID != "user:abc" {
+		t.Fatalf("SubjectID = %q, want %q", claims.SubjectID, "user:abc")
+	}
+	if claims.IssuedAt != now.Unix() {
+		t.Fatalf("IssuedAt = %d, want %d", claims.IssuedAt, now.Unix())
+	}
+	if claims.ExpiresAt != now.Add(callerTokenTTL).Unix() {
+		t.Fatalf("ExpiresAt = %d, want %d", claims.ExpiresAt, now.Add(callerTokenTTL).Unix())
+	}
+	if claims.Issuer != callerTokenIssuer {
+		t.Fatalf("Issuer = %q, want %q", claims.Issuer, callerTokenIssuer)
+	}
+	if claims.Audience != callerTokenAudience {
+		t.Fatalf("Audience = %q, want %q", claims.Audience, callerTokenAudience)
+	}
+	if claims.ID == "" {
+		t.Fatal("ID = empty, want generated id")
+	}
+}
+
+func TestCallerTokenGenerateClaimsRequiresSubjectID(t *testing.T) {
+	_, err := GenerateCallerTokenClaims(" ", time.Now())
+	if err == nil {
+		t.Fatal("GenerateCallerTokenClaims error = nil, want error")
+	}
+}
+
+func TestCallerTokenVerifyRejectsTamperedClaims(t *testing.T) {
+	secret := []byte("test-secret")
+	claims, err := GenerateCallerTokenClaims("user:123", time.Now().UTC())
+	if err != nil {
+		t.Fatalf("GenerateCallerTokenClaims: %v", err)
+	}
+	token, err := Issue(claims, secret)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Fatalf("token parts = %d, want 3", len(parts))
+	}
+	claims.SubjectID = "user:admin"
+	tamperedClaims, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("Marshal tampered claims: %v", err)
+	}
+	parts[1] = base64.RawURLEncoding.EncodeToString(tamperedClaims)
+	tamperedToken := strings.Join(parts, ".")
+
+	if _, err := Verify(tamperedToken, secret); err == nil {
+		t.Fatal("Verify tampered token error = nil, want error")
+	}
+}
+
+func TestCallerTokenVerifyRejectsWrongSecret(t *testing.T) {
+	claims, err := GenerateCallerTokenClaims("user:123", time.Now().UTC())
+	if err != nil {
+		t.Fatalf("GenerateCallerTokenClaims: %v", err)
+	}
+	token, err := Issue(claims, []byte("test-secret"))
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+
+	if _, err := Verify(token, []byte("other-secret")); err == nil {
+		t.Fatal("Verify with wrong secret error = nil, want error")
+	}
+}
+
+func TestCallerTokenVerifyRejectsExpiredToken(t *testing.T) {
+	now := time.Now().UTC()
+	claims := CallerTokenClaims{
+		SubjectID: "user:123",
+		IssuedAt:  now.Add(-10 * time.Minute).Unix(),
+		ExpiresAt: now.Add(-5 * time.Minute).Unix(),
+		Issuer:    callerTokenIssuer,
+		Audience:  callerTokenAudience,
+		ID:        "expired-token",
+	}
+	token, err := Issue(claims, []byte("test-secret"))
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+
+	if _, err := Verify(token, []byte("test-secret")); err == nil {
+		t.Fatal("Verify expired token error = nil, want error")
+	}
+}
+
+func TestCallerTokenVerifyRejectsLifetimeAboveMaximum(t *testing.T) {
+	now := time.Now().UTC()
+	claims := CallerTokenClaims{
+		SubjectID: "user:123",
+		IssuedAt:  now.Unix(),
+		ExpiresAt: now.Add(callerTokenTTL + time.Second).Unix(),
+		Issuer:    callerTokenIssuer,
+		Audience:  callerTokenAudience,
+		ID:        "long-lived-token",
+	}
+	token, err := issueCallerTokenWithoutValidation(t, claims, []byte("test-secret"))
+	if err != nil {
+		t.Fatalf("issueCallerTokenWithoutValidation: %v", err)
+	}
+
+	if _, err := Verify(token, []byte("test-secret")); err == nil {
+		t.Fatal("Verify long-lived token error = nil, want error")
+	}
+}
+
+func TestCallerTokenVerifyRejectsInvalidIssuerAndAudience(t *testing.T) {
+	now := time.Now().UTC()
+	base := CallerTokenClaims{
+		SubjectID: "user:123",
+		IssuedAt:  now.Unix(),
+		ExpiresAt: now.Add(time.Minute).Unix(),
+		Issuer:    callerTokenIssuer,
+		Audience:  callerTokenAudience,
+		ID:        "token-id",
+	}
+
+	for _, tc := range []struct {
+		name   string
+		claims CallerTokenClaims
+	}{
+		{
+			name: "issuer",
+			claims: CallerTokenClaims{
+				SubjectID: base.SubjectID,
+				IssuedAt:  base.IssuedAt,
+				ExpiresAt: base.ExpiresAt,
+				Issuer:    "other-issuer",
+				Audience:  base.Audience,
+				ID:        base.ID,
+			},
+		},
+		{
+			name: "audience",
+			claims: CallerTokenClaims{
+				SubjectID: base.SubjectID,
+				IssuedAt:  base.IssuedAt,
+				ExpiresAt: base.ExpiresAt,
+				Issuer:    base.Issuer,
+				Audience:  "other-audience",
+				ID:        base.ID,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			token, err := issueCallerTokenWithoutValidation(t, tc.claims, []byte("test-secret"))
+			if err != nil {
+				t.Fatalf("issueCallerTokenWithoutValidation: %v", err)
+			}
+			if _, err := Verify(token, []byte("test-secret")); err == nil {
+				t.Fatal("Verify error = nil, want error")
+			}
+		})
+	}
+}
+
+func issueCallerTokenWithoutValidation(t testing.TB, claims CallerTokenClaims, secret []byte) (string, error) {
+	t.Helper()
+	header := callerTokenHeader{Algorithm: callerTokenAlgorithm, Type: callerTokenType}
+	encodedHeader, err := encodeCallerTokenPart(header)
+	if err != nil {
+		return "", err
+	}
+	encodedClaims, err := encodeCallerTokenPart(claims)
+	if err != nil {
+		return "", err
+	}
+	signingInput := encodedHeader + "." + encodedClaims
+	return signingInput + "." + signCallerToken(signingInput, secret), nil
+}

--- a/gestaltd/services/providergateway/caller_token_test.go
+++ b/gestaltd/services/providergateway/caller_token_test.go
@@ -1,8 +1,12 @@
 package providergateway
 
 import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"strings"
 	"testing"
 	"time"
@@ -11,18 +15,22 @@ import (
 func TestCallerTokenIssueVerify(t *testing.T) {
 	t.Parallel()
 
-	secret := []byte("test-secret")
+	privateKeyPEM, publicKeyPEM := testCallerTokenKeyPair(t)
+	issuer, err := NewCallerTokenIssuer(privateKeyPEM)
+	if err != nil {
+		t.Fatalf("NewCallerTokenIssuer: %v", err)
+	}
 	now := time.Now().UTC()
 	claims, err := GenerateCallerTokenClaims("user:123", now)
 	if err != nil {
 		t.Fatalf("GenerateCallerTokenClaims: %v", err)
 	}
 
-	token, err := Issue(claims, secret)
+	token, err := issuer.Issue(claims)
 	if err != nil {
 		t.Fatalf("Issue: %v", err)
 	}
-	got, err := Verify(token, secret)
+	got, err := Verify(token, publicKeyPEM)
 	if err != nil {
 		t.Fatalf("Verify: %v", err)
 	}
@@ -74,12 +82,16 @@ func TestCallerTokenGenerateClaimsRequiresSubjectID(t *testing.T) {
 func TestCallerTokenVerifyRejectsTamperedClaims(t *testing.T) {
 	t.Parallel()
 
-	secret := []byte("test-secret")
+	privateKeyPEM, publicKeyPEM := testCallerTokenKeyPair(t)
+	issuer, err := NewCallerTokenIssuer(privateKeyPEM)
+	if err != nil {
+		t.Fatalf("NewCallerTokenIssuer: %v", err)
+	}
 	claims, err := GenerateCallerTokenClaims("user:123", time.Now().UTC())
 	if err != nil {
 		t.Fatalf("GenerateCallerTokenClaims: %v", err)
 	}
-	token, err := Issue(claims, secret)
+	token, err := issuer.Issue(claims)
 	if err != nil {
 		t.Fatalf("Issue: %v", err)
 	}
@@ -96,7 +108,7 @@ func TestCallerTokenVerifyRejectsTamperedClaims(t *testing.T) {
 	parts[1] = base64.RawURLEncoding.EncodeToString(tamperedClaims)
 	tamperedToken := strings.Join(parts, ".")
 
-	if _, err := Verify(tamperedToken, secret); err == nil {
+	if _, err := Verify(tamperedToken, publicKeyPEM); err == nil {
 		t.Fatal("Verify tampered token error = nil, want error")
 	}
 }
@@ -104,23 +116,34 @@ func TestCallerTokenVerifyRejectsTamperedClaims(t *testing.T) {
 func TestCallerTokenVerifyRejectsWrongSecret(t *testing.T) {
 	t.Parallel()
 
+	privateKeyPEM, _ := testCallerTokenKeyPair(t)
+	_, otherPublicKeyPEM := testCallerTokenKeyPair(t)
+	issuer, err := NewCallerTokenIssuer(privateKeyPEM)
+	if err != nil {
+		t.Fatalf("NewCallerTokenIssuer: %v", err)
+	}
 	claims, err := GenerateCallerTokenClaims("user:123", time.Now().UTC())
 	if err != nil {
 		t.Fatalf("GenerateCallerTokenClaims: %v", err)
 	}
-	token, err := Issue(claims, []byte("test-secret"))
+	token, err := issuer.Issue(claims)
 	if err != nil {
 		t.Fatalf("Issue: %v", err)
 	}
 
-	if _, err := Verify(token, []byte("other-secret")); err == nil {
-		t.Fatal("Verify with wrong secret error = nil, want error")
+	if _, err := Verify(token, otherPublicKeyPEM); err == nil {
+		t.Fatal("Verify with wrong public key error = nil, want error")
 	}
 }
 
 func TestCallerTokenVerifyRejectsExpiredToken(t *testing.T) {
 	t.Parallel()
 
+	privateKeyPEM, publicKeyPEM := testCallerTokenKeyPair(t)
+	issuer, err := NewCallerTokenIssuer(privateKeyPEM)
+	if err != nil {
+		t.Fatalf("NewCallerTokenIssuer: %v", err)
+	}
 	now := time.Now().UTC()
 	claims := CallerTokenClaims{
 		SubjectID: "user:123",
@@ -130,12 +153,12 @@ func TestCallerTokenVerifyRejectsExpiredToken(t *testing.T) {
 		Audience:  callerTokenAudience,
 		ID:        "expired-token",
 	}
-	token, err := Issue(claims, []byte("test-secret"))
+	token, err := issuer.Issue(claims)
 	if err != nil {
 		t.Fatalf("Issue: %v", err)
 	}
 
-	if _, err := Verify(token, []byte("test-secret")); err == nil {
+	if _, err := Verify(token, publicKeyPEM); err == nil {
 		t.Fatal("Verify expired token error = nil, want error")
 	}
 }
@@ -143,6 +166,8 @@ func TestCallerTokenVerifyRejectsExpiredToken(t *testing.T) {
 func TestCallerTokenVerifyRejectsLifetimeAboveMaximum(t *testing.T) {
 	t.Parallel()
 
+	privateKeyPEM, publicKeyPEM := testCallerTokenKeyPair(t)
+	privateKey := testParseCallerTokenPrivateKey(t, privateKeyPEM)
 	now := time.Now().UTC()
 	claims := CallerTokenClaims{
 		SubjectID: "user:123",
@@ -152,12 +177,12 @@ func TestCallerTokenVerifyRejectsLifetimeAboveMaximum(t *testing.T) {
 		Audience:  callerTokenAudience,
 		ID:        "long-lived-token",
 	}
-	token, err := issueCallerTokenWithoutValidation(t, claims, []byte("test-secret"))
+	token, err := issueCallerTokenWithoutValidation(t, claims, privateKey)
 	if err != nil {
 		t.Fatalf("issueCallerTokenWithoutValidation: %v", err)
 	}
 
-	if _, err := Verify(token, []byte("test-secret")); err == nil {
+	if _, err := Verify(token, publicKeyPEM); err == nil {
 		t.Fatal("Verify long-lived token error = nil, want error")
 	}
 }
@@ -165,6 +190,8 @@ func TestCallerTokenVerifyRejectsLifetimeAboveMaximum(t *testing.T) {
 func TestCallerTokenVerifyRejectsInvalidIssuerAndAudience(t *testing.T) {
 	t.Parallel()
 
+	privateKeyPEM, publicKeyPEM := testCallerTokenKeyPair(t)
+	privateKey := testParseCallerTokenPrivateKey(t, privateKeyPEM)
 	now := time.Now().UTC()
 	base := CallerTokenClaims{
 		SubjectID: "user:123",
@@ -206,18 +233,18 @@ func TestCallerTokenVerifyRejectsInvalidIssuerAndAudience(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			token, err := issueCallerTokenWithoutValidation(t, tc.claims, []byte("test-secret"))
+			token, err := issueCallerTokenWithoutValidation(t, tc.claims, privateKey)
 			if err != nil {
 				t.Fatalf("issueCallerTokenWithoutValidation: %v", err)
 			}
-			if _, err := Verify(token, []byte("test-secret")); err == nil {
+			if _, err := Verify(token, publicKeyPEM); err == nil {
 				t.Fatal("Verify error = nil, want error")
 			}
 		})
 	}
 }
 
-func issueCallerTokenWithoutValidation(t testing.TB, claims CallerTokenClaims, secret []byte) (string, error) {
+func issueCallerTokenWithoutValidation(t testing.TB, claims CallerTokenClaims, privateKey ed25519.PrivateKey) (string, error) {
 	t.Helper()
 	header := callerTokenHeader{Algorithm: callerTokenAlgorithm, Type: callerTokenType}
 	encodedHeader, err := encodeCallerTokenPart(header)
@@ -229,5 +256,33 @@ func issueCallerTokenWithoutValidation(t testing.TB, claims CallerTokenClaims, s
 		return "", err
 	}
 	signingInput := encodedHeader + "." + encodedClaims
-	return signingInput + "." + signCallerToken(signingInput, secret), nil
+	return signingInput + "." + signCallerToken(signingInput, privateKey), nil
+}
+
+func testCallerTokenKeyPair(t testing.TB) (string, string) {
+	t.Helper()
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	privateKeyBytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		t.Fatalf("MarshalPKCS8PrivateKey: %v", err)
+	}
+	publicKeyBytes, err := x509.MarshalPKIXPublicKey(publicKey)
+	if err != nil {
+		t.Fatalf("MarshalPKIXPublicKey: %v", err)
+	}
+	privateKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privateKeyBytes})
+	publicKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: publicKeyBytes})
+	return string(privateKeyPEM), string(publicKeyPEM)
+}
+
+func testParseCallerTokenPrivateKey(t testing.TB, privateKeyPEM string) ed25519.PrivateKey {
+	t.Helper()
+	privateKey, err := parseCallerTokenPrivateKey(privateKeyPEM)
+	if err != nil {
+		t.Fatalf("parseCallerTokenPrivateKey: %v", err)
+	}
+	return privateKey
 }

--- a/gestaltd/services/providergateway/caller_token_test.go
+++ b/gestaltd/services/providergateway/caller_token_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestCallerTokenIssueVerify(t *testing.T) {
+	t.Parallel()
+
 	secret := []byte("test-secret")
 	now := time.Now().UTC()
 	claims, err := GenerateCallerTokenClaims("user:123", now)
@@ -31,6 +33,8 @@ func TestCallerTokenIssueVerify(t *testing.T) {
 }
 
 func TestCallerTokenGenerateClaims(t *testing.T) {
+	t.Parallel()
+
 	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
 
 	claims, err := GenerateCallerTokenClaims(" user:abc ", now)
@@ -59,6 +63,8 @@ func TestCallerTokenGenerateClaims(t *testing.T) {
 }
 
 func TestCallerTokenGenerateClaimsRequiresSubjectID(t *testing.T) {
+	t.Parallel()
+
 	_, err := GenerateCallerTokenClaims(" ", time.Now())
 	if err == nil {
 		t.Fatal("GenerateCallerTokenClaims error = nil, want error")
@@ -66,6 +72,8 @@ func TestCallerTokenGenerateClaimsRequiresSubjectID(t *testing.T) {
 }
 
 func TestCallerTokenVerifyRejectsTamperedClaims(t *testing.T) {
+	t.Parallel()
+
 	secret := []byte("test-secret")
 	claims, err := GenerateCallerTokenClaims("user:123", time.Now().UTC())
 	if err != nil {
@@ -94,6 +102,8 @@ func TestCallerTokenVerifyRejectsTamperedClaims(t *testing.T) {
 }
 
 func TestCallerTokenVerifyRejectsWrongSecret(t *testing.T) {
+	t.Parallel()
+
 	claims, err := GenerateCallerTokenClaims("user:123", time.Now().UTC())
 	if err != nil {
 		t.Fatalf("GenerateCallerTokenClaims: %v", err)
@@ -109,6 +119,8 @@ func TestCallerTokenVerifyRejectsWrongSecret(t *testing.T) {
 }
 
 func TestCallerTokenVerifyRejectsExpiredToken(t *testing.T) {
+	t.Parallel()
+
 	now := time.Now().UTC()
 	claims := CallerTokenClaims{
 		SubjectID: "user:123",
@@ -129,6 +141,8 @@ func TestCallerTokenVerifyRejectsExpiredToken(t *testing.T) {
 }
 
 func TestCallerTokenVerifyRejectsLifetimeAboveMaximum(t *testing.T) {
+	t.Parallel()
+
 	now := time.Now().UTC()
 	claims := CallerTokenClaims{
 		SubjectID: "user:123",
@@ -149,6 +163,8 @@ func TestCallerTokenVerifyRejectsLifetimeAboveMaximum(t *testing.T) {
 }
 
 func TestCallerTokenVerifyRejectsInvalidIssuerAndAudience(t *testing.T) {
+	t.Parallel()
+
 	now := time.Now().UTC()
 	base := CallerTokenClaims{
 		SubjectID: "user:123",
@@ -186,7 +202,10 @@ func TestCallerTokenVerifyRejectsInvalidIssuerAndAudience(t *testing.T) {
 			},
 		},
 	} {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			token, err := issueCallerTokenWithoutValidation(t, tc.claims, []byte("test-secret"))
 			if err != nil {
 				t.Fatalf("issueCallerTokenWithoutValidation: %v", err)

--- a/gestaltd/services/providergateway/context.go
+++ b/gestaltd/services/providergateway/context.go
@@ -7,6 +7,7 @@ type contextKey string
 const (
 	sourceContextKey         contextKey = "provider_gateway_source"
 	requestContextContextKey contextKey = "provider_gateway_request_context"
+	callerTokenContextKey    contextKey = "provider_gateway_caller_token"
 )
 
 func WithSource(ctx context.Context, source GatewaySource) context.Context {
@@ -34,4 +35,16 @@ func WithRequestContext(ctx context.Context, reqCtx *RequestContext) context.Con
 func RequestContextFromContext(ctx context.Context) *RequestContext {
 	reqCtx, _ := ctx.Value(requestContextContextKey).(*RequestContext)
 	return reqCtx
+}
+
+func WithCallerToken(ctx context.Context, token string) context.Context {
+	if token == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, callerTokenContextKey, token)
+}
+
+func CallerTokenFromContext(ctx context.Context) string {
+	token, _ := ctx.Value(callerTokenContextKey).(string)
+	return token
 }

--- a/gestaltd/services/providergateway/gateway.go
+++ b/gestaltd/services/providergateway/gateway.go
@@ -3,12 +3,52 @@ package providergateway
 import (
 	"context"
 	"fmt"
+	"strings"
 )
 
-type Gateway struct{}
+type Gateway struct {
+	callerTokenIssuer *CallerTokenIssuer
+}
 
-func New() *Gateway {
-	return &Gateway{}
+type CallerTokenIssuer struct {
+	privateKey string
+}
+
+func NewCallerTokenIssuer(privateKey string) *CallerTokenIssuer {
+	privateKey = strings.TrimSpace(privateKey)
+	if privateKey == "" {
+		return nil
+	}
+	return &CallerTokenIssuer{privateKey: privateKey}
+}
+
+func (i *CallerTokenIssuer) privateKeyForTesting() string {
+	if i == nil {
+		return ""
+	}
+	return i.privateKey
+}
+
+type GatewayOption func(*Gateway)
+
+func WithCallerTokenPrivateKey(privateKey string) GatewayOption {
+	return WithCallerTokenIssuer(NewCallerTokenIssuer(privateKey))
+}
+
+func WithCallerTokenIssuer(issuer *CallerTokenIssuer) GatewayOption {
+	return func(g *Gateway) {
+		g.callerTokenIssuer = issuer
+	}
+}
+
+func New(opts ...GatewayOption) *Gateway {
+	g := &Gateway{}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(g)
+		}
+	}
+	return g
 }
 
 func (g *Gateway) Invoke(ctx context.Context, req ProviderGatewayRequest, next Next) (ProviderGatewayResponse, error) {

--- a/gestaltd/services/providergateway/gateway.go
+++ b/gestaltd/services/providergateway/gateway.go
@@ -3,37 +3,14 @@ package providergateway
 import (
 	"context"
 	"fmt"
-	"strings"
+	"time"
 )
 
 type Gateway struct {
 	callerTokenIssuer *CallerTokenIssuer
 }
 
-type CallerTokenIssuer struct {
-	privateKey string
-}
-
-func NewCallerTokenIssuer(privateKey string) *CallerTokenIssuer {
-	privateKey = strings.TrimSpace(privateKey)
-	if privateKey == "" {
-		return nil
-	}
-	return &CallerTokenIssuer{privateKey: privateKey}
-}
-
-func (i *CallerTokenIssuer) privateKeyForTesting() string {
-	if i == nil {
-		return ""
-	}
-	return i.privateKey
-}
-
 type GatewayOption func(*Gateway)
-
-func WithCallerTokenPrivateKey(privateKey string) GatewayOption {
-	return WithCallerTokenIssuer(NewCallerTokenIssuer(privateKey))
-}
 
 func WithCallerTokenIssuer(issuer *CallerTokenIssuer) GatewayOption {
 	return func(g *Gateway) {
@@ -49,6 +26,21 @@ func New(opts ...GatewayOption) *Gateway {
 		}
 	}
 	return g
+}
+
+func (g *Gateway) IssueCallerToken(subjectID string, now time.Time) (string, bool, error) {
+	if g == nil || g.callerTokenIssuer == nil {
+		return "", false, nil
+	}
+	claims, err := GenerateCallerTokenClaims(subjectID, now)
+	if err != nil {
+		return "", true, err
+	}
+	token, err := g.callerTokenIssuer.Issue(claims)
+	if err != nil {
+		return "", true, err
+	}
+	return token, true, nil
 }
 
 func (g *Gateway) Invoke(ctx context.Context, req ProviderGatewayRequest, next Next) (ProviderGatewayResponse, error) {

--- a/gestaltd/services/providergateway/gateway_test.go
+++ b/gestaltd/services/providergateway/gateway_test.go
@@ -1,38 +1,60 @@
 package providergateway
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestNewWithCallerTokenIssuer(t *testing.T) {
 	t.Parallel()
 
-	issuer := NewCallerTokenIssuer(" private-key-pem ")
+	privateKeyPEM, _ := testCallerTokenKeyPair(t)
+	issuer, err := NewCallerTokenIssuer(privateKeyPEM)
+	if err != nil {
+		t.Fatalf("NewCallerTokenIssuer: %v", err)
+	}
 	gateway := New(WithCallerTokenIssuer(issuer))
 
 	if gateway.callerTokenIssuer == nil {
 		t.Fatal("callerTokenIssuer = nil")
 	}
-	if got := gateway.callerTokenIssuer.privateKeyForTesting(); got != "private-key-pem" {
-		t.Fatalf("private key = %q, want private-key-pem", got)
-	}
 }
 
-func TestWithCallerTokenPrivateKeyBuildsIssuer(t *testing.T) {
+func TestIssueCallerToken(t *testing.T) {
 	t.Parallel()
 
-	gateway := New(WithCallerTokenPrivateKey(" private-key-pem "))
-
-	if gateway.callerTokenIssuer == nil {
-		t.Fatal("callerTokenIssuer = nil")
+	privateKeyPEM, publicKeyPEM := testCallerTokenKeyPair(t)
+	issuer, err := NewCallerTokenIssuer(privateKeyPEM)
+	if err != nil {
+		t.Fatalf("NewCallerTokenIssuer: %v", err)
 	}
-	if got := gateway.callerTokenIssuer.privateKeyForTesting(); got != "private-key-pem" {
-		t.Fatalf("private key = %q, want private-key-pem", got)
+	gateway := New(WithCallerTokenIssuer(issuer))
+
+	now := time.Now().UTC()
+	token, ok, err := gateway.IssueCallerToken("user:123", now)
+	if err != nil {
+		t.Fatalf("IssueCallerToken: %v", err)
+	}
+	if !ok {
+		t.Fatal("IssueCallerToken ok = false, want true")
+	}
+	claims, err := Verify(token, publicKeyPEM)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if claims.SubjectID != "user:123" {
+		t.Fatalf("SubjectID = %q, want user:123", claims.SubjectID)
 	}
 }
 
 func TestNewCallerTokenIssuerEmptyKey(t *testing.T) {
 	t.Parallel()
 
-	if issuer := NewCallerTokenIssuer(" "); issuer != nil {
+	issuer, err := NewCallerTokenIssuer(" ")
+	if err != nil {
+		t.Fatalf("NewCallerTokenIssuer: %v", err)
+	}
+	if issuer != nil {
 		t.Fatalf("issuer = %#v, want nil", issuer)
 	}
 }

--- a/gestaltd/services/providergateway/gateway_test.go
+++ b/gestaltd/services/providergateway/gateway_test.go
@@ -1,0 +1,38 @@
+package providergateway
+
+import "testing"
+
+func TestNewWithCallerTokenIssuer(t *testing.T) {
+	t.Parallel()
+
+	issuer := NewCallerTokenIssuer(" private-key-pem ")
+	gateway := New(WithCallerTokenIssuer(issuer))
+
+	if gateway.callerTokenIssuer == nil {
+		t.Fatal("callerTokenIssuer = nil")
+	}
+	if got := gateway.callerTokenIssuer.privateKeyForTesting(); got != "private-key-pem" {
+		t.Fatalf("private key = %q, want private-key-pem", got)
+	}
+}
+
+func TestWithCallerTokenPrivateKeyBuildsIssuer(t *testing.T) {
+	t.Parallel()
+
+	gateway := New(WithCallerTokenPrivateKey(" private-key-pem "))
+
+	if gateway.callerTokenIssuer == nil {
+		t.Fatal("callerTokenIssuer = nil")
+	}
+	if got := gateway.callerTokenIssuer.privateKeyForTesting(); got != "private-key-pem" {
+		t.Fatalf("private key = %q, want private-key-pem", got)
+	}
+}
+
+func TestNewCallerTokenIssuerEmptyKey(t *testing.T) {
+	t.Parallel()
+
+	if issuer := NewCallerTokenIssuer(" "); issuer != nil {
+		t.Fatalf("issuer = %#v, want nil", issuer)
+	}
+}

--- a/gestaltd/services/providergateway/types.go
+++ b/gestaltd/services/providergateway/types.go
@@ -34,6 +34,7 @@ type ProviderGatewayRequest struct {
 	Operation      string
 	RequestContext *RequestContext
 	Source         GatewaySource
+	CallerToken    string
 	Payload        []byte
 }
 


### PR DESCRIPTION
## Description

Adds provider gateway caller-token claim generation plus HMAC-signed issue and verify helpers for short-lived subject attribution tokens.