### PR TITLE
Build startup provider proxies for MCP-only manifest apps

### DIFF
--- a/gestaltd/internal/bootstrap/executable_app_test.go
+++ b/gestaltd/internal/bootstrap/executable_app_test.go
@@ -3115,6 +3115,37 @@ func TestBuildStartupProviderSpecPreservesStaticCatalogConnectionRouting(t *test
 	}
 }
 
+func TestBuildStartupProviderSpecMCPOnlyManifestHasNoStartupCatalog(t *testing.T) {
+	t.Parallel()
+
+	manifest := &providermanifestv1.Manifest{
+		Source:      "mcponly",
+		DisplayName: "MCP Only",
+		Spec: &providermanifestv1.Spec{
+			Connections: map[string]*providermanifestv1.ManifestConnectionDef{
+				"mcp": {
+					Mode: providermanifestv1.ConnectionModeSubject,
+					Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeMCPOAuth},
+				},
+			},
+			Surfaces: &providermanifestv1.ProviderSurfaces{
+				MCP: &providermanifestv1.MCPSurface{URL: "https://example.invalid/mcp", Connection: "mcp"},
+			},
+		},
+	}
+
+	spec, operationRouting, err := buildStartupProviderSpec("mcponly", &config.ProviderEntry{ResolvedManifest: manifest})
+	if err != nil {
+		t.Fatalf("buildStartupProviderSpec: %v", err)
+	}
+	if spec.Catalog != nil {
+		t.Fatalf("unexpected startup catalog for MCP-only manifest: %+v", spec.Catalog)
+	}
+	if len(operationRouting.connections) != 0 {
+		t.Fatalf("unexpected operation connections: %+v", operationRouting.connections)
+	}
+}
+
 func TestStartupProviderProxyResolvesDeclarativeConnectionSelectorBeforeProviderReady(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -282,28 +282,25 @@ func buildStartupProviderSpec(name string, entry *config.ProviderEntry) (appserv
 	if err != nil {
 		return appservice.StaticProviderSpec{}, startupOperationRouting{}, err
 	}
-	if spec.Catalog != nil {
-		return spec, startupOperationRouting{connections: operationConnectionsForCatalog(spec.Catalog, plan, restConnections)}, nil
+	if spec.Catalog == nil && manifestApp.IsDeclarative() {
+		declarative, err := appservice.NewDeclarativeProvider(
+			manifest,
+			nil,
+			appservice.WithDeclarativeMetadataOverrides(meta.displayName, meta.description, meta.iconSVG),
+			appservice.WithDeclarativeConnectionMode(plan.ConnectionMode()),
+			appservice.WithDeclarativeOperationConnections(restConnections, restSelectors, restLocks),
+		)
+		if err != nil {
+			return appservice.StaticProviderSpec{}, startupOperationRouting{}, err
+		}
+		spec.Catalog = declarative.Catalog()
+		return spec, startupOperationRouting{
+			connections:    operationConnectionsForCatalog(spec.Catalog, plan, restConnections),
+			resolver:       declarative,
+			overridePolicy: declarative,
+		}, nil
 	}
-	if !manifestApp.IsDeclarative() && !manifestApp.IsSpecLoaded() {
-		return spec, startupOperationRouting{connections: map[string]string{}}, nil
-	}
-	declarative, err := appservice.NewDeclarativeProvider(
-		manifest,
-		nil,
-		appservice.WithDeclarativeMetadataOverrides(meta.displayName, meta.description, meta.iconSVG),
-		appservice.WithDeclarativeConnectionMode(plan.ConnectionMode()),
-		appservice.WithDeclarativeOperationConnections(restConnections, restSelectors, restLocks),
-	)
-	if err != nil {
-		return appservice.StaticProviderSpec{}, startupOperationRouting{}, err
-	}
-	spec.Catalog = declarative.Catalog()
-	return spec, startupOperationRouting{
-		connections:    operationConnectionsForCatalog(spec.Catalog, plan, restConnections),
-		resolver:       declarative,
-		overridePolicy: declarative,
-	}, nil
+	return spec, startupOperationRouting{connections: operationConnectionsForCatalog(spec.Catalog, plan, restConnections)}, nil
 }
 
 func operationConnectionsForCatalog(cat *catalog.Catalog, plan config.StaticConnectionPlan, restConnections map[string]string) map[string]string {


### PR DESCRIPTION
## Summary

Fixes the gestaltd startup proxy builder so MCP-only manifest apps (PlanetScale, Excalidraw) stop logging `manifest is not a declarative provider` at boot and actually get a startup proxy.

`buildStartupProviderSpec` gated declarative catalog synthesis on `!IsDeclarative() && !IsSpecLoaded()`, conflating spec-loaded manifests with declarative ones. An MCP-only app is spec-loaded but has no inline REST operations, so the builder fell through to `NewDeclarativeProvider` on a manifest that constructor rejects.

The gate is now `spec.Catalog == nil && manifestApp.IsDeclarative()`, the same precondition `NewDeclarativeProvider` enforces, so the failing call is unreachable. The redundant empty-connections early return is deleted; `operationConnectionsForCatalog` already returns an empty map for a nil catalog.

## Runtime

MCP-only apps now get a metadata-only startup proxy with no static catalog. Their tools are still discovered at runtime through the MCP composite path, which is unchanged. Previously the proxy build failed, the WARN was logged, and the server had no placeholder for these apps until the full provider finished loading.

Prepared provider stubs use the same builder and previously hard-failed for MCP-only apps; they now build a metadata-only stub.

Hybrid and declarative apps are unchanged: a static catalog on disk still wins, and inline REST operations still produce the synthesized startup catalog with connection routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)