### PR TITLE
Update gestaltd formula and chart to v0.0.2-alpha.15

### DIFF
--- a/Formula/gestaltd.rb
+++ b/Formula/gestaltd.rb
@@ -3,30 +3,30 @@
 class Gestaltd < Formula
   desc "Gestalt server daemon"
   homepage "https://github.com/valon-technologies/gestalt"
-  version "0.0.2-alpha.9"
+  version "0.0.2-alpha.15"
   license "Apache-2.0"
 
   on_macos do
     on_arm do
-      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.9/gestaltd-macos-arm64.tar.gz"
-      sha256 "c4a5f7cfa2c3b5d54151a0bd9b96f5ead6905fe62468c9c1dbe31317558279e6"
+      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.15/gestaltd-macos-arm64.tar.gz"
+      sha256 "a59e56e3a3834b33922d85924bcf60b9e47aef820268c014fe5d77da7e2fffb5"
     end
 
     on_intel do
-      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.9/gestaltd-macos-x86_64.tar.gz"
-      sha256 "ded925a36cede25ae0a92405d044cd02213a70a8a0c929a3ae584482ad5847d0"
+      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.15/gestaltd-macos-x86_64.tar.gz"
+      sha256 "43b7174ff6ccbb0fff4f705cea3378a4ce25cdfe392e7afefde59326cb3a8cb6"
     end
   end
 
   on_linux do
     on_arm do
-      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.9/gestaltd-linux-arm64.tar.gz"
-      sha256 "0d423e65e3d0dfd713e419c8126b616c68826ce8ac098c804d0352eaba1cbe55"
+      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.15/gestaltd-linux-arm64.tar.gz"
+      sha256 "2039b901846d87bdfff25d8f5daf03b4cd896bf072baf7ee98e29ae516a31969"
     end
 
     on_intel do
-      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.9/gestaltd-linux-x86_64.tar.gz"
-      sha256 "e53e696d5b98e0fc027d835962ca696924b86b926a70c1c0e1d11b9b6bd98a86"
+      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.15/gestaltd-linux-x86_64.tar.gz"
+      sha256 "02dbb7fbbeb4c8a24601c4c8e6feb3914f7aafdf906e94f7471e7aab4b6f099e"
     end
   end
 

--- a/gestaltd/deploy/helm/gestaltd/Chart.yaml
+++ b/gestaltd/deploy/helm/gestaltd/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: gestaltd
 description: gestaltd - OAuth token management proxy with pluggable integrations
 type: application
-version: 0.0.2-alpha.9
-appVersion: "0.0.2-alpha.9"
+version: 0.0.2-alpha.15
+appVersion: "0.0.2-alpha.15"


### PR DESCRIPTION
## Summary

Brings `Formula/gestaltd.rb` and `gestaltd/deploy/helm/gestaltd/Chart.yaml` up to the v0.0.2-alpha.15 release. Checksums come from the published release assets.

The Release Gestaltd workflow normally pushes this bump to `main` itself, but branch protection has rejected that push since v0.0.2-alpha.12 (`GH006: Changes must be made through a pull request`), so the formula and chart have been stuck at v0.0.2-alpha.9 while releases continued shipping. This applies the v0.0.2-alpha.15 state through a pull request.

## Runtime

No runtime change. Release binaries, Docker images, and Helm charts for v0.0.2-alpha.15 are already published; this only fixes what `brew install` and the in-repo chart metadata resolve to.

The workflow's direct-to-main push remains broken and will fail again on the next tag. It needs either a bypass-authorized token or a switch to opening a PR; that fix is intentionally not part of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)