### PR TITLE
Point the default provider repository at registry.gestaltd.ai

### DIFF
--- a/gestaltd/internal/providerregistry/registry.go
+++ b/gestaltd/internal/providerregistry/registry.go
@@ -24,8 +24,12 @@ const (
 	IndexSchemaVersion = 1
 	MaxIndexBytes      = 10 << 20
 
-	DefaultRepositoryName = "valon"
-	DefaultRepositoryURL  = "https://raw.githubusercontent.com/valon-technologies/gestalt-providers/main/provider-index.yaml"
+	// The project's provider index at its canonical, consumer-neutral
+	// home. Provider entries installed from the default repository omit
+	// the repo name in config, so renaming the default re-resolves them
+	// here transparently.
+	DefaultRepositoryName = "gestalt"
+	DefaultRepositoryURL  = "https://registry.gestaltd.ai/provider-index.yaml"
 )
 
 var (

--- a/gestaltd/internal/providerregistry/registry.go
+++ b/gestaltd/internal/providerregistry/registry.go
@@ -190,6 +190,21 @@ func (r *Resolver) Resolve(ctx context.Context, req ResolveRequest) (*ResolvedPa
 		}
 		return nil, fmt.Errorf("%w: %s", errNoPackageMatch, pkg)
 	}
+	if len(matches) > 1 {
+		// Repositories that resolve the package to the same version and
+		// metadata URL are mirrors or aliases of one index (e.g. a legacy
+		// explicit "valon" entry alongside the built-in default), not an
+		// ambiguity. Keep the first match — repository order puts the
+		// default repository first. Only genuinely divergent answers are
+		// ambiguous.
+		distinct := matches[:1]
+		for _, m := range matches[1:] {
+			if m.Version != matches[0].Version || m.MetadataURL != matches[0].MetadataURL {
+				distinct = append(distinct, m)
+			}
+		}
+		matches = distinct
+	}
 	if len(matches) > 1 && strings.TrimSpace(req.RepositoryName) == "" {
 		names := make([]string, 0, len(matches))
 		for i := range matches {

--- a/gestaltd/internal/providerregistry/registry.go
+++ b/gestaltd/internal/providerregistry/registry.go
@@ -198,9 +198,9 @@ func (r *Resolver) Resolve(ctx context.Context, req ResolveRequest) (*ResolvedPa
 		// default repository first. Only genuinely divergent answers are
 		// ambiguous.
 		distinct := matches[:1]
-		for _, m := range matches[1:] {
-			if m.Version != matches[0].Version || m.MetadataURL != matches[0].MetadataURL {
-				distinct = append(distinct, m)
+		for i := 1; i < len(matches); i++ {
+			if matches[i].Version != matches[0].Version || matches[i].MetadataURL != matches[0].MetadataURL {
+				distinct = append(distinct, matches[i])
 			}
 		}
 		matches = distinct

--- a/gestaltd/internal/providerregistry/registry_test.go
+++ b/gestaltd/internal/providerregistry/registry_test.go
@@ -55,6 +55,7 @@ func newIndexServer(t *testing.T) *httptest.Server {
 // the built-in default) — resolution must succeed and prefer the first
 // repository in order, not report an ambiguity.
 func TestResolveCollapsesMirroredRepositories(t *testing.T) {
+	t.Parallel()
 	server := newIndexServer(t)
 	resolver := &Resolver{Client: server.Client()}
 	resolved, err := resolver.Resolve(context.Background(), ResolveRequest{
@@ -78,6 +79,7 @@ func TestResolveCollapsesMirroredRepositories(t *testing.T) {
 // Repositories whose answers genuinely diverge stay ambiguous: picking one
 // silently would mean resolving a package from the wrong publisher.
 func TestResolveRejectsDivergentRepositories(t *testing.T) {
+	t.Parallel()
 	server := newIndexServer(t)
 	resolver := &Resolver{Client: server.Client()}
 	_, err := resolver.Resolve(context.Background(), ResolveRequest{
@@ -97,6 +99,7 @@ func TestResolveRejectsDivergentRepositories(t *testing.T) {
 
 // An explicit --repo selection bypasses the ambiguity question entirely.
 func TestResolveHonorsExplicitRepositorySelection(t *testing.T) {
+	t.Parallel()
 	server := newIndexServer(t)
 	resolver := &Resolver{Client: server.Client()}
 	resolved, err := resolver.Resolve(context.Background(), ResolveRequest{

--- a/gestaltd/internal/providerregistry/registry_test.go
+++ b/gestaltd/internal/providerregistry/registry_test.go
@@ -1,0 +1,116 @@
+package providerregistry
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const testPackage = "github.com/example/providers/app/demo"
+
+const mirroredIndex = `schema: gestaltd-provider-index
+schemaVersion: 1
+packages:
+  github.com/example/providers/app/demo:
+    versions:
+      "1.0.0":
+        metadata: "https://example.com/releases/demo/v1.0.0/provider-release.yaml"
+        kind: "app"
+        runtime: "executable"
+`
+
+const divergentIndex = `schema: gestaltd-provider-index
+schemaVersion: 1
+packages:
+  github.com/example/providers/app/demo:
+    versions:
+      "1.0.0":
+        metadata: "https://other.example.com/releases/demo/v1.0.0/provider-release.yaml"
+        kind: "app"
+        runtime: "executable"
+`
+
+func newIndexServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	for path, body := range map[string]string{
+		"/canonical.yaml": mirroredIndex,
+		"/mirror.yaml":    mirroredIndex,
+		"/divergent.yaml": divergentIndex,
+	} {
+		body := body
+		mux.HandleFunc(path, func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(body))
+		})
+	}
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return server
+}
+
+// Two repositories that resolve a package to the same version and metadata
+// URL are aliases of one index (e.g. a legacy explicit "valon" entry next to
+// the built-in default) — resolution must succeed and prefer the first
+// repository in order, not report an ambiguity.
+func TestResolveCollapsesMirroredRepositories(t *testing.T) {
+	server := newIndexServer(t)
+	resolver := &Resolver{Client: server.Client()}
+	resolved, err := resolver.Resolve(context.Background(), ResolveRequest{
+		Package: testPackage,
+		Repositories: []NamedRepository{
+			{Name: "gestalt", URL: server.URL + "/canonical.yaml"},
+			{Name: "valon", URL: server.URL + "/mirror.yaml"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Resolve returned error for mirrored repositories: %v", err)
+	}
+	if resolved.RepositoryName != "gestalt" {
+		t.Fatalf("Resolve picked %q, want the first repository %q", resolved.RepositoryName, "gestalt")
+	}
+	if resolved.Version != "1.0.0" {
+		t.Fatalf("Resolve picked version %q, want %q", resolved.Version, "1.0.0")
+	}
+}
+
+// Repositories whose answers genuinely diverge stay ambiguous: picking one
+// silently would mean resolving a package from the wrong publisher.
+func TestResolveRejectsDivergentRepositories(t *testing.T) {
+	server := newIndexServer(t)
+	resolver := &Resolver{Client: server.Client()}
+	_, err := resolver.Resolve(context.Background(), ResolveRequest{
+		Package: testPackage,
+		Repositories: []NamedRepository{
+			{Name: "gestalt", URL: server.URL + "/canonical.yaml"},
+			{Name: "fork", URL: server.URL + "/divergent.yaml"},
+		},
+	})
+	if err == nil {
+		t.Fatal("Resolve succeeded for divergent repositories, want ambiguity error")
+	}
+	if !strings.Contains(err.Error(), "multiple repositories") {
+		t.Fatalf("Resolve error = %q, want it to name the multiple-repositories ambiguity", err)
+	}
+}
+
+// An explicit --repo selection bypasses the ambiguity question entirely.
+func TestResolveHonorsExplicitRepositorySelection(t *testing.T) {
+	server := newIndexServer(t)
+	resolver := &Resolver{Client: server.Client()}
+	resolved, err := resolver.Resolve(context.Background(), ResolveRequest{
+		Package:        testPackage,
+		RepositoryName: "fork",
+		Repositories: []NamedRepository{
+			{Name: "gestalt", URL: server.URL + "/canonical.yaml"},
+			{Name: "fork", URL: server.URL + "/divergent.yaml"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Resolve with explicit repository returned error: %v", err)
+	}
+	if resolved.RepositoryName != "fork" {
+		t.Fatalf("Resolve picked %q, want explicitly selected %q", resolved.RepositoryName, "fork")
+	}
+}


### PR DESCRIPTION
## Summary

Every fresh `gestaltd` install registers a built-in provider repository literally named `valon`, reading the index from `raw.githubusercontent.com/valon-technologies/gestalt-providers`. Gestalt is an open-source project whose docs and registry now live on project-neutral URLs — the daemon's own default should match. The default becomes `gestalt` → `https://registry.gestaltd.ai/provider-index.yaml` (the index #2404 starts serving there).

One real edge (caught by Cursor) is handled in the resolver rather than papered over: a legacy explicit `valon` repository pointing at the same index would have made every unqualified package resolve fail with the multiple-repositories error. The ambiguity guard now collapses matches that agree on version + metadata URL (mirrors/aliases of one index) and keeps erroring only when answers genuinely diverge — which is what the guard was for. Covered by new resolver tests (mirrored / divergent / explicit `--repo`).

Compatibility otherwise falls out of an existing design choice: provider entries installed from the *default* repository deliberately omit `repo:` in config (`provider_lifecycle.go`), so existing installs re-resolve through the renamed default transparently — same index artifact, different name and URL. Anyone who explicitly added a `valon` alias keeps it as an ordinary explicit repository. And following the docs' `provider repo add gestalt <canonical url>` example now merges with the built-in instead of duplicating every package (Cursor's finding on #2404).

## ⚠️ Merge order

**Deploy #2404 first.** Today the canonical URL serves the registry SPA's HTML; until the index is live there, fresh installs with no configured repositories would fail index validation.

Validation: `go build ./gestaltd/...`, `providerregistry` and `daemon` tests pass. The `operator` suite fails locally on an environmental Python floor (3.9 vs ≥3.10), unrelated — CI will confirm.
