### PR TITLE
Fix search on the docs site

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -15,10 +15,6 @@ server {
         try_files $uri =404;
     }
 
-    location /_pagefind/ {
-        try_files $uri =404;
-    }
-
     location /favicon.svg {
         try_files $uri =404;
     }
@@ -130,10 +126,6 @@ server {
 
     location /_next/ {
         add_header Cache-Control "public, max-age=31536000, immutable" always;
-        try_files $uri =404;
-    }
-
-    location /_pagefind/ {
         try_files $uri =404;
     }
 

--- a/docs/scripts/build-versioned-site.mjs
+++ b/docs/scripts/build-versioned-site.mjs
@@ -13,6 +13,7 @@ import {
 import { existsSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { gunzipSync } from "node:zlib";
 import { fileURLToPath } from "node:url";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
@@ -32,7 +33,6 @@ const globalPrefixes = [
   "/registry",
   "/videos/",
   "/versions.json",
-  "/_pagefind/",
 ];
 const unversionedApiPathPattern = /^\/(?:dev|latest|versions\/v[^/]+)(\/api\/.*)$/;
 
@@ -615,7 +615,7 @@ async function assertNoUnversionedDocLinks(finalOut) {
   }
   const bad = [];
   const patterns = [
-    /\b(?:href|src|action)=["']\/(?!dev(?:\/|["'])|latest(?:\/|["'])|versions(?:\/|["'])|api\/|admin(?:\/|["'])|favicon\.svg|fonts\/|install(?:-|\.sh)|mcp(?:\/|["'])|registry(?:\/|["'])|videos\/|versions\.json|_pagefind\/)/g,
+    /\b(?:href|src|action)=["']\/(?!dev(?:\/|["'])|latest(?:\/|["'])|versions(?:\/|["'])|api\/|admin(?:\/|["'])|favicon\.svg|fonts\/|install(?:-|\.sh)|mcp(?:\/|["'])|registry(?:\/|["'])|videos\/|versions\.json)/g,
   ];
   for (const file of files.filter((candidate) => candidate.endsWith(".html"))) {
     const body = await readFile(file, "utf8");
@@ -701,7 +701,53 @@ async function versionedOutputRoots(finalOut) {
 }
 
 async function runPagefind(finalOut) {
-  run("npx", ["pagefind", "--site", finalOut, "--output-subdir", "_pagefind"], docsRoot);
+  // Each channel owns its search index: Nextra requests
+  // `${basePath}/_pagefind/pagefind.js` and Next.js prepends the basePath to
+  // result links, so the index must live at the channel root and contain only
+  // that channel's pages. A site-wide index would 404 under every channel
+  // prefix and store already-prefixed URLs that Next.js would prefix again.
+  const channels = await versionedOutputRoots(finalOut);
+  for (const { root } of channels) {
+    run("npx", ["pagefind", "--site", root, "--output-subdir", "_pagefind"], docsRoot);
+  }
+  const missing = channels
+    .filter(
+      ({ root }) =>
+        !existsSync(path.join(root, "_pagefind", "pagefind.js")) ||
+        !existsSync(path.join(root, "_pagefind", "pagefind-entry.json")),
+    )
+    .map(({ prefix }) => prefix);
+  if (missing.length > 0) {
+    throw new Error(
+      `pagefind did not emit a search index for: ${missing.join(", ")}`,
+    );
+  }
+  for (const { prefix, root } of channels) {
+    await assertChannelRelativeSearchUrls(prefix, root);
+  }
+}
+
+async function assertChannelRelativeSearchUrls(prefix, root) {
+  // Result links must be channel-relative: Next.js prepends the basePath, so
+  // a stored URL that already carries the channel prefix would render as
+  // /latest/latest/… even though the index files themselves load fine.
+  const fragmentDir = path.join(root, "_pagefind", "fragment");
+  if (!existsSync(fragmentDir)) {
+    throw new Error(`search index for ${prefix} contains no pages`);
+  }
+  for (const name of await readdir(fragmentDir)) {
+    const raw = await readFile(path.join(fragmentDir, name));
+    const gzipStart = raw.indexOf(Buffer.from([0x1f, 0x8b]));
+    const decoded = gunzipSync(gzipStart > 0 ? raw.subarray(gzipStart) : raw);
+    const { url } = JSON.parse(
+      decoded.subarray(decoded.indexOf(0x7b)).toString("utf8"),
+    );
+    if (url === prefix || url.startsWith(`${prefix}/`)) {
+      throw new Error(
+        `search index for ${prefix} stores the prefixed URL ${url}; index each channel from its own root so result links stay channel-relative`,
+      );
+    }
+  }
 }
 
 async function walk(root) {

--- a/docs/scripts/check-nginx-routing.mjs
+++ b/docs/scripts/check-nginx-routing.mjs
@@ -87,6 +87,12 @@ try {
     cacheControlIncludes: "immutable",
   });
   await assertResponse({
+    url: `${baseUrl}/dev/_pagefind/pagefind.js`,
+    host: "gestaltd.ai",
+    status: 200,
+    contentTypeIncludes: "javascript",
+  });
+  await assertResponse({
     url: `${baseUrl}/dev/providers/`,
     host: "gestaltd.ai",
     status: 301,
@@ -129,10 +135,34 @@ try {
     cacheControlIncludes: "immutable",
   });
   await assertResponse({
+    url: `${baseUrl}/latest/_pagefind/pagefind.js`,
+    host: "gestaltd.ai",
+    status: 200,
+    contentTypeIncludes: "javascript",
+  });
+  await assertResponse({
+    url: `${baseUrl}/latest/_pagefind/pagefind-entry.json`,
+    host: "gestaltd.ai",
+    status: 200,
+    contentTypeIncludes: "json",
+  });
+  await assertResponse({
+    url: `${baseUrl}/_pagefind/pagefind.js`,
+    host: "gestaltd.ai",
+    status: 301,
+    location: "/latest/_pagefind/pagefind.js",
+  });
+  await assertResponse({
     url: `${baseUrl}/latest/getting-started/`,
     host: "gestaltd.ai",
     status: 301,
     location: "/latest/getting-started",
+  });
+  await assertResponse({
+    url: `${baseUrl}${exactVersionPrefix}/_pagefind/pagefind.js`,
+    host: "gestaltd.ai",
+    status: 200,
+    contentTypeIncludes: "javascript",
   });
   await assertResponse({
     url: `${baseUrl}${exactVersionPrefix}/reference/cli`,
@@ -224,6 +254,7 @@ async function assertResponse({
   excludes,
   location,
   cacheControlIncludes,
+  contentTypeIncludes,
 }) {
   const response = await httpGet(url, host);
   const body = response.body;
@@ -234,6 +265,14 @@ async function assertResponse({
     const actualLocation = response.headers.location;
     if (actualLocation !== location) {
       throw new Error(`${host} ${url} redirected to ${actualLocation}, want ${location}`);
+    }
+  }
+  if (contentTypeIncludes) {
+    const contentType = response.headers["content-type"] ?? "";
+    if (!contentType.includes(contentTypeIncludes)) {
+      throw new Error(
+        `${host} ${url} returned Content-Type ${contentType}, want ${contentTypeIncludes}`,
+      );
     }
   }
   if (cacheControlIncludes) {

--- a/docs/scripts/check-registry-docs-render.mjs
+++ b/docs/scripts/check-registry-docs-render.mjs
@@ -36,7 +36,6 @@ const server = createServer(async (request, response) => {
     }
     if (
       pathname.startsWith("/_next/") ||
-      pathname.startsWith("/_pagefind/") ||
       pathname === "/favicon.svg" ||
       pathname.startsWith("/images/") ||
       pathname.startsWith("/fonts/")

--- a/docs/scripts/check-registry-static.mjs
+++ b/docs/scripts/check-registry-static.mjs
@@ -144,6 +144,11 @@ try {
     host: "gestaltd.ai",
     status: 200,
   });
+  await assertResponse({
+    url: `${baseUrl}/dev/_pagefind/pagefind.js`,
+    host: "gestaltd.ai",
+    status: 200,
+  });
   await assertRedirect({
     url: `${baseUrl}/dev/providers/`,
     host: "gestaltd.ai",
@@ -169,6 +174,21 @@ try {
     includes: "Getting Started",
     excludes: registryMarker,
   });
+  await assertResponse({
+    url: `${baseUrl}/latest/_pagefind/pagefind.js`,
+    host: "gestaltd.ai",
+    status: 200,
+  });
+  await assertResponse({
+    url: `${baseUrl}/latest/_pagefind/pagefind-entry.json`,
+    host: "gestaltd.ai",
+    status: 200,
+  });
+  await assertRedirect({
+    url: `${baseUrl}/_pagefind/pagefind.js`,
+    host: "gestaltd.ai",
+    location: "/latest/_pagefind/pagefind.js",
+  });
   await assertRedirect({
     url: `${baseUrl}/latest/getting-started/`,
     host: "gestaltd.ai",
@@ -185,6 +205,11 @@ try {
     status: 200,
     includes: "Gestalt",
     excludes: registryMarker,
+  });
+  await assertResponse({
+    url: `${baseUrl}${exactVersionPrefix}/_pagefind/pagefind.js`,
+    host: "gestaltd.ai",
+    status: 200,
   });
   await assertResponse({
     url: `${baseUrl}${exactVersionPrefix}/reference/cli`,
@@ -269,7 +294,6 @@ try {
 async function serveRegistryHost(pathname, response) {
   if (
     pathname.startsWith("/_next/") ||
-    pathname.startsWith("/_pagefind/") ||
     pathname === "/favicon.svg" ||
     pathname.startsWith("/images/") ||
     pathname.startsWith("/fonts/") ||
@@ -321,7 +345,6 @@ async function serveDocsHost(pathname, response) {
   if (
     pathname.startsWith("/api/") ||
     pathname.startsWith("/_next/") ||
-    pathname.startsWith("/_pagefind/") ||
     pathname === "/favicon.svg" ||
     pathname.startsWith("/images/") ||
     pathname.startsWith("/fonts/") ||


### PR DESCRIPTION
## Summary

Search on gestaltd.ai was dead on every versioned channel — pages under `/latest` request `/latest/_pagefind/pagefind.js`, but the build emitted one site-wide index at the root. Each channel now **owns its own Pagefind index at its own root**: search loads, and results stay scoped to the version you're reading.

## Why

This is the recurring "search is broken again" bug; the only prior fix never merged and no check asserted search worked. I rejected an nginx rewrite to the shared root index — even when it loads, it stores already-prefixed URLs that Next.js **double-prefixes into dead `/latest/latest/…` links** and mixes every version into one result list.

## What changed

- The build and the PR-CI routing checks now **fail on any regression**: missing channel index, prefixed result URLs, or wrong content type.
- Verified in a real browser against the built site: scoped results on `/dev`, `/latest`, and a pinned version; result links resolve; no console errors.

## Demo

![docs search working on a versioned channel](https://raw.githubusercontent.com/valon-technologies/gestalt/pr-media/docs-search-fix-2026-06-11.gif)

[Full-quality video](https://github.com/valon-technologies/gestalt/blob/pr-media/docs-search-fix-2026-06-11.mov)