### PR TITLE
[provider-gateway] inject caller token public key env

### DIFF
--- a/gestaltd/internal/bootstrap/authorization_bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/authorization_bootstrap_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
-	"github.com/valon-technologies/gestalt/server/services/providergateway"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	gproto "google.golang.org/protobuf/proto"
 	"gopkg.in/yaml.v3"
@@ -361,7 +360,7 @@ config:
 	var capturedName string
 	var capturedHostServices []runtimehost.HostService
 	factories := &FactoryRegistry{
-		Authorization: func(_ context.Context, name string, _ yaml.Node, hostServices []runtimehost.HostService, _ providergateway.ProviderGateway) (core.AuthorizationProvider, error) {
+		Authorization: func(_ context.Context, name string, _ yaml.Node, hostServices []runtimehost.HostService, _ Deps) (core.AuthorizationProvider, error) {
 			capturedName = name
 			capturedHostServices = append([]runtimehost.HostService(nil), hostServices...)
 			return &recordingAuthorizationProvider{}, nil
@@ -399,6 +398,67 @@ config:
 		}
 	}
 	t.Fatalf("authorization host services = %#v, want indexeddb host service", capturedHostServices)
+}
+
+func TestBuildAuthorizationProviderPassesCallerTokenPublicKeyDep(t *testing.T) {
+	t.Parallel()
+
+	var runtimeConfig yaml.Node
+	if err := yaml.Unmarshal([]byte(`
+command: /bin/true
+`), &runtimeConfig); err != nil {
+		t.Fatalf("decode runtime config: %v", err)
+	}
+	var capturedPublicKey string
+	factories := &FactoryRegistry{
+		Authorization: func(_ context.Context, _ string, _ yaml.Node, _ []runtimehost.HostService, deps Deps) (core.AuthorizationProvider, error) {
+			capturedPublicKey = deps.CallerTokenPublicKey
+			return &recordingAuthorizationProvider{}, nil
+		},
+	}
+	cfg := &config.Config{
+		Server: config.ServerConfig{Providers: config.ServerProvidersConfig{Authorization: "indexeddb"}},
+		Providers: config.ProvidersConfig{
+			Authorization: map[string]*config.ProviderEntry{
+				"indexeddb": {Config: *runtimeConfig.Content[0]},
+			},
+		},
+	}
+	deps := Deps{
+		CallerTokenPublicKey: "public-key-pem",
+	}
+
+	_, err := buildAuthorizationProviders(context.Background(), cfg, factories, deps)
+	if err != nil {
+		t.Fatalf("buildAuthorizationProviders: %v", err)
+	}
+	if capturedPublicKey != "public-key-pem" {
+		t.Fatalf("CallerTokenPublicKey = %q, want public-key-pem", capturedPublicKey)
+	}
+}
+
+func TestResolveCallerTokenPublicKey(t *testing.T) {
+	t.Parallel()
+
+	got, err := resolveCallerTokenPublicKey(context.Background(), &coretesting.StubSecretManager{
+		Secrets: map[string]string{
+			callerTokenPublicKeySecretName: " public-key-pem ",
+		},
+	})
+	if err != nil {
+		t.Fatalf("resolveCallerTokenPublicKey: %v", err)
+	}
+	if got != "public-key-pem" {
+		t.Fatalf("public key = %q, want public-key-pem", got)
+	}
+
+	missing, err := resolveCallerTokenPublicKey(context.Background(), &coretesting.StubSecretManager{})
+	if err != nil {
+		t.Fatalf("resolveCallerTokenPublicKey missing: %v", err)
+	}
+	if missing != "" {
+		t.Fatalf("missing public key = %q, want empty", missing)
+	}
 }
 
 func assertAppInvocationRelationship(t *testing.T, relationship *proto.Relationship, resourceType string) {

--- a/gestaltd/internal/bootstrap/authorization_bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/authorization_bootstrap_test.go
@@ -461,6 +461,22 @@ func TestResolveCallerTokenPublicKey(t *testing.T) {
 	}
 }
 
+func TestResolveCallerTokenPrivateKey(t *testing.T) {
+	t.Parallel()
+
+	got, err := resolveCallerTokenPrivateKey(context.Background(), &coretesting.StubSecretManager{
+		Secrets: map[string]string{
+			callerTokenPrivateKeySecretName: " private-key-pem ",
+		},
+	})
+	if err != nil {
+		t.Fatalf("resolveCallerTokenPrivateKey: %v", err)
+	}
+	if got != "private-key-pem" {
+		t.Fatalf("private key = %q, want private-key-pem", got)
+	}
+}
+
 func assertAppInvocationRelationship(t *testing.T, relationship *proto.Relationship, resourceType string) {
 	t.Helper()
 	tuple := relationship.GetTuple()

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -181,12 +181,13 @@ type Deps struct {
 	HostServiceTLSCAPEM   string
 	Telemetry             core.TelemetryProvider
 	ProviderGateway       providergateway.ProviderGateway
+	CallerTokenPublicKey  string
 
 	hostedAgentPoolClock hostedAgentPoolClock
 }
 
 type AuthFactory func(node yaml.Node, deps Deps) (core.AuthenticationProvider, error)
-type AuthorizationFactory func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, gateway providergateway.ProviderGateway) (core.AuthorizationProvider, error)
+type AuthorizationFactory func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps Deps) (core.AuthorizationProvider, error)
 type ExternalCredentialFactory func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps Deps) (core.ExternalCredentialProvider, error)
 type SecretManagerFactory func(node yaml.Node) (core.SecretManager, error)
 type IndexedDBFactory func(node yaml.Node) (indexeddb.IndexedDB, error)
@@ -197,6 +198,10 @@ type AgentFactory func(ctx context.Context, name string, node yaml.Node, hostSer
 type RuntimeFactory func(ctx context.Context, name string, entry *config.RuntimeProviderEntry, deps Deps) (runtimeprovider.Provider, error)
 type TelemetryFactory func(node yaml.Node) (core.TelemetryProvider, error)
 type AuditFactory func(ctx context.Context, cfg config.ProviderEntry, telemetry core.TelemetryProvider) (core.AuditSink, func(context.Context) error, error)
+
+const (
+	callerTokenPublicKeySecretName = "gestaltd-caller-token-ed25519-public-key"
+)
 
 type FactoryRegistry struct {
 	Auth                AuthFactory
@@ -962,6 +967,12 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	deps.S3 = hostS3s
 	deps.AppAccessProfiles = appAccessProfiles(cfg.Apps)
 	deps.ProviderGateway = providergateway.New()
+	callerTokenPublicKey, err := resolveCallerTokenPublicKey(ctx, sm)
+	if err != nil {
+		_ = closeAuthProviders(authProviders)
+		return nil, err
+	}
+	deps.CallerTokenPublicKey = callerTokenPublicKey
 	authorizationProviders, err := buildAuthorizationProviders(ctx, cfg, factories, deps)
 	if err != nil {
 		_ = closeAuthProviders(authProviders)
@@ -1860,11 +1871,29 @@ func buildNamedAuthorizationProvider(ctx context.Context, name string, entry *co
 	if err != nil {
 		return nil, fmt.Errorf("bootstrap: authorization provider %q: %w", logicalName, err)
 	}
-	provider, err := factories.Authorization(ctx, logicalName, node, hostServices, deps.ProviderGateway)
+	provider, err := factories.Authorization(ctx, logicalName, node, hostServices, deps)
 	if err != nil {
 		return nil, fmt.Errorf("bootstrap: authorization provider %q: %w", logicalName, err)
 	}
 	return provider, nil
+}
+
+func resolveCallerTokenPublicKey(ctx context.Context, sm core.SecretManager) (string, error) {
+	if sm == nil {
+		return "", nil
+	}
+	value, err := sm.GetSecret(ctx, callerTokenPublicKeySecretName)
+	if err != nil {
+		if errors.Is(err, core.ErrSecretNotFound) {
+			return "", nil
+		}
+		return "", fmt.Errorf("bootstrap: resolve %s: %w", callerTokenPublicKeySecretName, err)
+	}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("bootstrap: secret %q resolved to empty value", callerTokenPublicKeySecretName)
+	}
+	return value, nil
 }
 
 func buildIndexedDB(entry *config.ProviderEntry, factories *FactoryRegistry) (indexeddb.IndexedDB, error) {

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -200,7 +200,8 @@ type TelemetryFactory func(node yaml.Node) (core.TelemetryProvider, error)
 type AuditFactory func(ctx context.Context, cfg config.ProviderEntry, telemetry core.TelemetryProvider) (core.AuditSink, func(context.Context) error, error)
 
 const (
-	callerTokenPublicKeySecretName = "gestaltd-caller-token-ed25519-public-key"
+	callerTokenPrivateKeySecretName = "gestaltd-caller-token-ed25519-private-key"
+	callerTokenPublicKeySecretName  = "gestaltd-caller-token-ed25519-public-key"
 )
 
 type FactoryRegistry struct {
@@ -966,7 +967,12 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	deps.Caches = hostCaches
 	deps.S3 = hostS3s
 	deps.AppAccessProfiles = appAccessProfiles(cfg.Apps)
-	deps.ProviderGateway = providergateway.New()
+	callerTokenPrivateKey, err := resolveCallerTokenPrivateKey(ctx, sm)
+	if err != nil {
+		_ = closeAuthProviders(authProviders)
+		return nil, err
+	}
+	deps.ProviderGateway = providergateway.New(providergateway.WithCallerTokenPrivateKey(callerTokenPrivateKey))
 	callerTokenPublicKey, err := resolveCallerTokenPublicKey(ctx, sm)
 	if err != nil {
 		_ = closeAuthProviders(authProviders)
@@ -1878,20 +1884,28 @@ func buildNamedAuthorizationProvider(ctx context.Context, name string, entry *co
 	return provider, nil
 }
 
+func resolveCallerTokenPrivateKey(ctx context.Context, sm core.SecretManager) (string, error) {
+	return resolveCallerTokenKey(ctx, sm, callerTokenPrivateKeySecretName)
+}
+
 func resolveCallerTokenPublicKey(ctx context.Context, sm core.SecretManager) (string, error) {
+	return resolveCallerTokenKey(ctx, sm, callerTokenPublicKeySecretName)
+}
+
+func resolveCallerTokenKey(ctx context.Context, sm core.SecretManager, name string) (string, error) {
 	if sm == nil {
 		return "", nil
 	}
-	value, err := sm.GetSecret(ctx, callerTokenPublicKeySecretName)
+	value, err := sm.GetSecret(ctx, name)
 	if err != nil {
 		if errors.Is(err, core.ErrSecretNotFound) {
 			return "", nil
 		}
-		return "", fmt.Errorf("bootstrap: resolve %s: %w", callerTokenPublicKeySecretName, err)
+		return "", fmt.Errorf("bootstrap: resolve %s: %w", name, err)
 	}
 	value = strings.TrimSpace(value)
 	if value == "" {
-		return "", fmt.Errorf("bootstrap: secret %q resolved to empty value", callerTokenPublicKeySecretName)
+		return "", fmt.Errorf("bootstrap: secret %q resolved to empty value", name)
 	}
 	return value, nil
 }

--- a/gestaltd/internal/daemon/factories.go
+++ b/gestaltd/internal/daemon/factories.go
@@ -129,7 +129,12 @@ func buildFactories() *bootstrap.FactoryRegistry {
 			SessionKey:         deps.EncryptionKey,
 		})
 	}
-	factories.Authorization = providerdrivers.AuthorizationFactory
+	factories.Authorization = func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps bootstrap.Deps) (core.AuthorizationProvider, error) {
+		return providerdrivers.AuthorizationFactory(ctx, name, node, hostServices, providerdrivers.AuthorizationDeps{
+			Gateway:              deps.ProviderGateway,
+			CallerTokenPublicKey: deps.CallerTokenPublicKey,
+		})
+	}
 	factories.ExternalCredentials = func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, _ bootstrap.Deps) (core.ExternalCredentialProvider, error) {
 		return providerdrivers.ExternalCredentialsFactory(ctx, name, node, hostServices)
 	}

--- a/gestaltd/services/providerdrivers/authorization.go
+++ b/gestaltd/services/providerdrivers/authorization.go
@@ -13,11 +13,19 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func AuthorizationFactory(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, gateway providergateway.ProviderGateway) (core.AuthorizationProvider, error) {
+const CallerTokenPublicKeyEnv = "GESTALTD_CALLER_TOKEN_ED25519_PUBLIC_KEY"
+
+type AuthorizationDeps struct {
+	Gateway              providergateway.ProviderGateway
+	CallerTokenPublicKey string
+}
+
+func AuthorizationFactory(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps AuthorizationDeps) (core.AuthorizationProvider, error) {
 	var cfg componentprovider.YAMLConfig
 	if err := node.Decode(&cfg); err != nil {
 		return nil, fmt.Errorf("authorization provider: parsing config: %w", err)
 	}
+	cfg.Env = authorizationEnvWithCallerTokenPublicKey(cfg.Env, deps.CallerTokenPublicKey)
 	prepared, err := componentprovider.PrepareExecution(componentprovider.PrepareParams{
 		Kind:                 providermanifestv1.KindAuthorization,
 		Subject:              "authorization provider",
@@ -40,6 +48,18 @@ func AuthorizationFactory(ctx context.Context, name string, node yaml.Node, host
 		Cleanup:      prepared.Cleanup,
 		HostServices: hostServices,
 		Name:         name,
-		Gateway:      gateway,
+		Gateway:      deps.Gateway,
 	})
+}
+
+func authorizationEnvWithCallerTokenPublicKey(env map[string]string, publicKey string) map[string]string {
+	if publicKey == "" || env[CallerTokenPublicKeyEnv] != "" {
+		return env
+	}
+	next := make(map[string]string, len(env)+1)
+	for key, value := range env {
+		next[key] = value
+	}
+	next[CallerTokenPublicKeyEnv] = publicKey
+	return next
 }

--- a/gestaltd/services/providerdrivers/authorization_test.go
+++ b/gestaltd/services/providerdrivers/authorization_test.go
@@ -1,0 +1,28 @@
+package providerdrivers
+
+import "testing"
+
+func TestAuthorizationEnvWithCallerTokenPublicKey(t *testing.T) {
+	t.Parallel()
+
+	env := authorizationEnvWithCallerTokenPublicKey(map[string]string{"EXISTING": "value"}, "public-key-pem")
+
+	if env["EXISTING"] != "value" {
+		t.Fatalf("EXISTING = %q, want value", env["EXISTING"])
+	}
+	if env[CallerTokenPublicKeyEnv] != "public-key-pem" {
+		t.Fatalf("%s = %q, want public-key-pem", CallerTokenPublicKeyEnv, env[CallerTokenPublicKeyEnv])
+	}
+}
+
+func TestAuthorizationEnvWithCallerTokenPublicKeyPreservesConfiguredEnv(t *testing.T) {
+	t.Parallel()
+
+	env := authorizationEnvWithCallerTokenPublicKey(map[string]string{
+		CallerTokenPublicKeyEnv: "configured-public-key",
+	}, "secret-public-key")
+
+	if env[CallerTokenPublicKeyEnv] != "configured-public-key" {
+		t.Fatalf("%s = %q, want configured-public-key", CallerTokenPublicKeyEnv, env[CallerTokenPublicKeyEnv])
+	}
+}

--- a/gestaltd/services/providergateway/gateway.go
+++ b/gestaltd/services/providergateway/gateway.go
@@ -3,12 +3,52 @@ package providergateway
 import (
 	"context"
 	"fmt"
+	"strings"
 )
 
-type Gateway struct{}
+type Gateway struct {
+	callerTokenIssuer *CallerTokenIssuer
+}
 
-func New() *Gateway {
-	return &Gateway{}
+type CallerTokenIssuer struct {
+	privateKey string
+}
+
+func NewCallerTokenIssuer(privateKey string) *CallerTokenIssuer {
+	privateKey = strings.TrimSpace(privateKey)
+	if privateKey == "" {
+		return nil
+	}
+	return &CallerTokenIssuer{privateKey: privateKey}
+}
+
+func (i *CallerTokenIssuer) privateKeyForTesting() string {
+	if i == nil {
+		return ""
+	}
+	return i.privateKey
+}
+
+type GatewayOption func(*Gateway)
+
+func WithCallerTokenPrivateKey(privateKey string) GatewayOption {
+	return WithCallerTokenIssuer(NewCallerTokenIssuer(privateKey))
+}
+
+func WithCallerTokenIssuer(issuer *CallerTokenIssuer) GatewayOption {
+	return func(g *Gateway) {
+		g.callerTokenIssuer = issuer
+	}
+}
+
+func New(opts ...GatewayOption) *Gateway {
+	g := &Gateway{}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(g)
+		}
+	}
+	return g
 }
 
 func (g *Gateway) Invoke(ctx context.Context, req ProviderGatewayRequest, next Next) (ProviderGatewayResponse, error) {

--- a/gestaltd/services/providergateway/gateway_test.go
+++ b/gestaltd/services/providergateway/gateway_test.go
@@ -1,0 +1,38 @@
+package providergateway
+
+import "testing"
+
+func TestNewWithCallerTokenIssuer(t *testing.T) {
+	t.Parallel()
+
+	issuer := NewCallerTokenIssuer(" private-key-pem ")
+	gateway := New(WithCallerTokenIssuer(issuer))
+
+	if gateway.callerTokenIssuer == nil {
+		t.Fatal("callerTokenIssuer = nil")
+	}
+	if got := gateway.callerTokenIssuer.privateKeyForTesting(); got != "private-key-pem" {
+		t.Fatalf("private key = %q, want private-key-pem", got)
+	}
+}
+
+func TestWithCallerTokenPrivateKeyBuildsIssuer(t *testing.T) {
+	t.Parallel()
+
+	gateway := New(WithCallerTokenPrivateKey(" private-key-pem "))
+
+	if gateway.callerTokenIssuer == nil {
+		t.Fatal("callerTokenIssuer = nil")
+	}
+	if got := gateway.callerTokenIssuer.privateKeyForTesting(); got != "private-key-pem" {
+		t.Fatalf("private key = %q, want private-key-pem", got)
+	}
+}
+
+func TestNewCallerTokenIssuerEmptyKey(t *testing.T) {
+	t.Parallel()
+
+	if issuer := NewCallerTokenIssuer(" "); issuer != nil {
+		t.Fatalf("issuer = %#v, want nil", issuer)
+	}
+}


### PR DESCRIPTION
## Description

Reads the gestaltd caller-token Ed25519 public key from the configured secrets provider during bootstrap and injects it into the authorization provider environment when present.