### PR TITLE
Normalize typed containers in the generated Go wire codec

### DIFF
--- a/sdk/go/client/support_codec.go
+++ b/sdk/go/client/support_codec.go
@@ -6,6 +6,8 @@
 package client
 
 import (
+	"encoding/json"
+	"fmt"
 	"time"
 
 	rpcstatus "google.golang.org/genproto/googleapis/rpc/status"
@@ -67,12 +69,26 @@ func fromWireStruct(value *structpb.Struct) map[string]any {
 }
 
 // toWireValue converts a native JSON value to its wire form. Absent and JSON
-// null conflate: nil becomes JSON null. Values with no JSON representation
-// also become JSON null, keeping conversion total.
+// null conflate: nil becomes JSON null. Typed Go containers (e.g.
+// []map[string]any) normalize through JSON before conversion. Values with no
+// JSON representation are caller bugs and panic rather than silently
+// corrupting the payload.
 func toWireValue(value any) *structpb.Value {
 	v, err := structpb.NewValue(value)
+	if err == nil {
+		return v
+	}
+	data, jsonErr := json.Marshal(value)
+	if jsonErr != nil {
+		panic(fmt.Sprintf("codec: value of type %T is not JSON-representable: %v", value, jsonErr))
+	}
+	var normalized any
+	if err := json.Unmarshal(data, &normalized); err != nil {
+		panic(fmt.Sprintf("codec: normalize value of type %T: %v", value, err))
+	}
+	v, err = structpb.NewValue(normalized)
 	if err != nil {
-		return structpb.NewNullValue()
+		panic(fmt.Sprintf("codec: convert value of type %T: %v", value, err))
 	}
 	return v
 }

--- a/sdk/go/client/support_codec_test.go
+++ b/sdk/go/client/support_codec_test.go
@@ -1,0 +1,25 @@
+package client
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestToWireStructNormalizesTypedContainers(t *testing.T) {
+	in := map[string]any{
+		"kind": "steps",
+		"steps": []map[string]any{
+			{"id": "generateTeam", "kind": "app", "app": "delta", "operation": "generate.teamWorkflow"},
+		},
+	}
+	out := fromWireStruct(toWireStruct(in))
+	want := map[string]any{
+		"kind": "steps",
+		"steps": []any{
+			map[string]any{"id": "generateTeam", "kind": "app", "app": "delta", "operation": "generate.teamWorkflow"},
+		},
+	}
+	if !reflect.DeepEqual(out, want) {
+		t.Fatalf("round-trip mismatch:\ngot  %#v\nwant %#v", out, want)
+	}
+}

--- a/sdk/tools/sdkgen/internal/emit/golang/support_codec.go.tmpl
+++ b/sdk/tools/sdkgen/internal/emit/golang/support_codec.go.tmpl
@@ -4,6 +4,8 @@
 package client
 
 import (
+	"encoding/json"
+	"fmt"
 	"time"
 
 	rpcstatus "google.golang.org/genproto/googleapis/rpc/status"
@@ -65,12 +67,26 @@ func fromWireStruct(value *structpb.Struct) map[string]any {
 }
 
 // toWireValue converts a native JSON value to its wire form. Absent and JSON
-// null conflate: nil becomes JSON null. Values with no JSON representation
-// also become JSON null, keeping conversion total.
+// null conflate: nil becomes JSON null. Typed Go containers (e.g.
+// []map[string]any) normalize through JSON before conversion. Values with no
+// JSON representation are caller bugs and panic rather than silently
+// corrupting the payload.
 func toWireValue(value any) *structpb.Value {
 	v, err := structpb.NewValue(value)
+	if err == nil {
+		return v
+	}
+	data, jsonErr := json.Marshal(value)
+	if jsonErr != nil {
+		panic(fmt.Sprintf("codec: value of type %T is not JSON-representable: %v", value, jsonErr))
+	}
+	var normalized any
+	if err := json.Unmarshal(data, &normalized); err != nil {
+		panic(fmt.Sprintf("codec: normalize value of type %T: %v", value, err))
+	}
+	v, err = structpb.NewValue(normalized)
 	if err != nil {
-		return structpb.NewNullValue()
+		panic(fmt.Sprintf("codec: convert value of type %T: %v", value, err))
 	}
 	return v
 }


### PR DESCRIPTION
## Summary

Fixes the silent data corruption behind the 2026-06-12 workflow outage. The sdkgen-emitted `toWireValue` replaced any value `structpb.NewValue` rejects with JSON null, "keeping conversion total" at the cost of correctness. Typed Go containers such as `[]map[string]any` are outside structpb's accepted types, so the workflow step context's `target.steps` (built by `WorkflowTargetContext`) arrived at gestaltd as `null`, and the step authority check from #2331 correctly failed closed on every workflow step invocation platform-wide. Only the Go emitter is affected: the TypeScript, Python, and Rust converters are already faithful.

## Interfaces

```go
// sdkgen template: internal/emit/golang/support_codec.go.tmpl
func toWireValue(value any) *structpb.Value {
	v, err := structpb.NewValue(value)
	if err == nil {
		return v
	}
	data, jsonErr := json.Marshal(value)            // normalize typed containers
	if jsonErr != nil {
		panic(...)                              // non-JSON values are caller bugs
	}
	...
}
```

Regenerated output: `sdk/go/client/support_codec.go` only (`sdkgen --check` reports no drift). One round-trip test covers the exact failing shape.

## Runtime

Any `map[string]any` field crossing the generated Go clients now survives intact regardless of nested Go container types; previously such values silently became null. The panic path is unreachable for the JSON-value domain these fields are typed as. Providers pick this up at their next snapshot publish (`gestalt-ref`); no daemon change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
