### PR TITLE
Let deployments theme their mounted UIs

### DIFF
--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1186,6 +1186,43 @@ type UIEntry struct {
 	ProviderEntry `yaml:",inline"`
 	Path          string `yaml:"path,omitempty"`
 	OwnerApp      string `yaml:"-"`
+
+	// Runtime-resolved theme paths (populated during sync from the entry's
+	// config.theme block, not from YAML).
+	ResolvedThemeStylesheet string `yaml:"-"`
+	ResolvedThemeAssetsDir  string `yaml:"-"`
+}
+
+// UIThemeConfig is the typed `theme` block of a ui mount's provider config.
+// It points at a deployment-supplied stylesheet served at <mount>/theme.css
+// and an optional asset directory served under <mount>/theme/. Paths are
+// relative to the deployment config file.
+type UIThemeConfig struct {
+	Stylesheet string `yaml:"stylesheet,omitempty"`
+	AssetsDir  string `yaml:"assetsDir,omitempty"`
+}
+
+// UIThemeConfigFromProviderConfig decodes the optional theme block of a ui
+// mount's provider config node. Keys other than theme belong to the mounted
+// provider's own config and are ignored here; keys inside theme are strict.
+func UIThemeConfigFromProviderConfig(node yaml.Node) (*UIThemeConfig, error) {
+	if node.Kind == 0 {
+		return nil, nil
+	}
+	var raw struct {
+		Theme yaml.Node `yaml:"theme"`
+	}
+	if err := node.Decode(&raw); err != nil {
+		return nil, err
+	}
+	if raw.Theme.Kind == 0 || raw.Theme.Tag == "!!null" {
+		return nil, nil
+	}
+	theme := &UIThemeConfig{}
+	if err := decodeYAMLNodeKnownFields(&raw.Theme, theme); err != nil {
+		return nil, fmt.Errorf("theme: %w", err)
+	}
+	return theme, nil
 }
 
 func (e *UIEntry) UnmarshalYAML(value *yaml.Node) error {

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -3455,6 +3455,9 @@ func (l *Lifecycle) applyPreparedUIProviders(paths lifecyclePaths, lock *Lockfil
 	}
 
 	for _, work := range ordered {
+		if err := resolveUIThemeConfig(paths, work.name, work.entry); err != nil {
+			return err
+		}
 		if work.install != nil {
 			resolvedAssetRoot, err := bindPreparedUIInstall(&work.entry.ProviderEntry, work.subject, work.destDir, work.configMap, work.install)
 			if err != nil {
@@ -5240,6 +5243,57 @@ func validateLockedInstalledManifest(kind, name, subject string, manifest *provi
 		return fmt.Errorf("locked source manifest version mismatch for %s: got %q, want %q", subject, manifest.Version, entry.Version)
 	}
 	return validateLockedArchivePolicy(subject, archivePolicyKind(kind), manifest, entry, platform, resolvedKey)
+}
+
+// resolveUIThemeConfig decodes the optional theme block of a mounted ui's
+// config and resolves its paths against the deployment config directory at
+// sync time. Unlike resolveProviderIcon, a configured-but-missing path is an
+// error: theme content is served verbatim and a typo would otherwise degrade
+// silently to the empty stylesheet.
+func resolveUIThemeConfig(paths lifecyclePaths, name string, entry *config.UIEntry) error {
+	entry.ResolvedThemeStylesheet = ""
+	entry.ResolvedThemeAssetsDir = ""
+	theme, err := config.UIThemeConfigFromProviderConfig(entry.Config)
+	if err != nil {
+		return fmt.Errorf("decode ui %q theme config: %w", name, err)
+	}
+	if theme == nil {
+		return nil
+	}
+	if stylesheet := strings.TrimSpace(theme.Stylesheet); stylesheet != "" {
+		resolved := resolveUIThemePath(paths.configDir, stylesheet)
+		info, err := os.Stat(resolved)
+		if err != nil {
+			return fmt.Errorf("ui %q theme stylesheet not found at %s: %w", name, resolved, err)
+		}
+		if info.IsDir() {
+			return fmt.Errorf("ui %q theme stylesheet at %s is a directory", name, resolved)
+		}
+		entry.ResolvedThemeStylesheet = resolved
+	}
+	if assetsDir := strings.TrimSpace(theme.AssetsDir); assetsDir != "" {
+		resolved := resolveUIThemePath(paths.configDir, assetsDir)
+		info, err := os.Stat(resolved)
+		if err != nil {
+			return fmt.Errorf("ui %q theme assetsDir not found at %s: %w", name, resolved, err)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("ui %q theme assetsDir at %s is not a directory", name, resolved)
+		}
+		entry.ResolvedThemeAssetsDir = resolved
+	}
+	return nil
+}
+
+func resolveUIThemePath(configDir, value string) string {
+	resolved := filepath.FromSlash(value)
+	if !filepath.IsAbs(resolved) {
+		resolved = filepath.Join(configDir, resolved)
+	}
+	if abs, err := filepath.Abs(resolved); err == nil {
+		return abs
+	}
+	return filepath.Clean(resolved)
 }
 
 func resolveProviderIcon(manifest *providermanifestv1.Manifest, manifestPath string, app *config.ProviderEntry) {

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -1706,6 +1706,145 @@ server:
 	}
 }
 
+func TestLoadForExecutionAtPath_ResolvesMountedUIThemeConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		themeYAML      string
+		wantStylesheet string
+		wantAssetsDir  string
+		wantErr        string
+	}{
+		{
+			name: "stylesheet and assetsDir resolved against the config dir",
+			themeYAML: `      config:
+        theme:
+          stylesheet: ./theme/tenant.css
+          assetsDir: ./theme/assets
+`,
+			wantStylesheet: filepath.Join("theme", "tenant.css"),
+			wantAssetsDir:  filepath.Join("theme", "assets"),
+		},
+		{
+			name: "no theme block leaves theme paths empty",
+		},
+		{
+			name: "missing stylesheet fails sync",
+			themeYAML: `      config:
+        theme:
+          stylesheet: ./theme/missing.css
+`,
+			wantErr: "theme stylesheet not found",
+		},
+		{
+			name: "assetsDir pointing at a file fails sync",
+			themeYAML: `      config:
+        theme:
+          stylesheet: ./theme/tenant.css
+          assetsDir: ./theme/tenant.css
+`,
+			wantErr: "is not a directory",
+		},
+		{
+			name: "unknown theme key fails decode",
+			themeYAML: `      config:
+        theme:
+          stylesheet: ./theme/tenant.css
+          asetsDir: ./theme/assets
+`,
+			wantErr: "theme config",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			uiDir := filepath.Join(dir, "ui")
+			if err := os.MkdirAll(filepath.Join(uiDir, "dist"), 0o755); err != nil {
+				t.Fatalf("MkdirAll ui dist: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(uiDir, "dist", "index.html"), []byte("<html>roadmap</html>"), 0o644); err != nil {
+				t.Fatalf("WriteFile index.html: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(uiDir, "build.sh"), []byte("mkdir -p dist\nprintf '<html>roadmap</html>\\n' > dist/index.html\n"), 0o755); err != nil {
+				t.Fatalf("WriteFile build.sh: %v", err)
+			}
+			manifest, err := providerpkg.EncodeSourceManifestFormat(&providermanifestv1.Manifest{
+				Kind:        providermanifestv1.KindUI,
+				Source:      "github.com/testowner/web/roadmap",
+				Version:     "0.0.1-alpha.1",
+				DisplayName: "Roadmap UI",
+				Build: &providermanifestv1.SourceBuild{
+					Command: []string{"sh", "./build.sh"},
+				},
+				Spec: &providermanifestv1.Spec{AssetRoot: "dist"},
+			}, providerpkg.ManifestFormatYAML)
+			if err != nil {
+				t.Fatalf("EncodeManifest: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(uiDir, "manifest.yaml"), manifest, 0o644); err != nil {
+				t.Fatalf("WriteFile manifest: %v", err)
+			}
+			if err := os.MkdirAll(filepath.Join(dir, "theme", "assets"), 0o755); err != nil {
+				t.Fatalf("MkdirAll theme assets: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, "theme", "tenant.css"), []byte(":root{--brand:#123456;}"), 0o644); err != nil {
+				t.Fatalf("WriteFile tenant.css: %v", err)
+			}
+
+			cfgPath := filepath.Join(dir, "config.yaml")
+			cfg := requiredComponentConfigWithAPIVersionYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `  ui:
+    roadmap:
+      source:
+        path: ./ui/manifest.yaml
+      path: /roadmap
+` + tc.themeYAML + `server:
+` + requiredServerIndexedDBYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`
+			if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+				t.Fatalf("WriteFile config: %v", err)
+			}
+
+			loaded, _, err := NewLifecycle().LoadForExecutionAtPath(cfgPath, false)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("LoadForExecutionAtPath: expected error containing %q", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("LoadForExecutionAtPath error = %q, want substring %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("LoadForExecutionAtPath: %v", err)
+			}
+
+			entry := loaded.Providers.UI["roadmap"]
+			if entry == nil {
+				t.Fatal(`Providers.UI["roadmap"] = nil`)
+			}
+			wantStylesheet := ""
+			if tc.wantStylesheet != "" {
+				wantStylesheet = filepath.Join(dir, tc.wantStylesheet)
+			}
+			if got := entry.ResolvedThemeStylesheet; got != wantStylesheet {
+				t.Fatalf("ResolvedThemeStylesheet = %q, want %q", got, wantStylesheet)
+			}
+			wantAssetsDir := ""
+			if tc.wantAssetsDir != "" {
+				wantAssetsDir = filepath.Join(dir, tc.wantAssetsDir)
+			}
+			if got := entry.ResolvedThemeAssetsDir; got != wantAssetsDir {
+				t.Fatalf("ResolvedThemeAssetsDir = %q, want %q", got, wantAssetsDir)
+			}
+		})
+	}
+}
+
 func TestLoadForExecutionAtPath_ResolvesManagedPluginOwnedUIFromManagedPath(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/server/http_bindings.go
+++ b/gestaltd/internal/server/http_bindings.go
@@ -232,7 +232,8 @@ func validateMountedHTTPBindingRoutes(bindings []MountedHTTPBinding, mountedUIs 
 				return fmt.Errorf("http binding %s.%s path %q conflicts with core route namespace %q", binding.AppName, binding.Name, binding.Path, prefix)
 			}
 		}
-		for _, mounted := range mountedUIs {
+		for i := range mountedUIs {
+			mounted := &mountedUIs[i]
 			if mounted.Path == "" || mounted.Path == "/" {
 				continue
 			}

--- a/gestaltd/internal/server/integration_visibility.go
+++ b/gestaltd/internal/server/integration_visibility.go
@@ -51,19 +51,21 @@ func (s *Server) integrationMountedPathForPrincipalContext(ctx context.Context, 
 }
 
 func (s *Server) mountedUIForProvider(provider, mountedPath string) (MountedUI, bool) {
-	for _, mounted := range s.mountedUIs {
+	for i := range s.mountedUIs {
+		mounted := &s.mountedUIs[i]
 		if mounted.Handler == nil || mounted.Path != mountedPath {
 			continue
 		}
 		if mounted.AppName == provider {
-			return mounted, true
+			return *mounted, true
 		}
 	}
-	for _, mounted := range s.mountedUIs {
+	for i := range s.mountedUIs {
+		mounted := &s.mountedUIs[i]
 		if mounted.Handler == nil || mounted.Path != mountedPath {
 			continue
 		}
-		return mounted, true
+		return *mounted, true
 	}
 	return MountedUI{}, false
 }

--- a/gestaltd/internal/server/mounted_ui.go
+++ b/gestaltd/internal/server/mounted_ui.go
@@ -143,6 +143,8 @@ func mountedUIsFromEntries(entries map[string]*config.UIEntry) ([]MountedUI, err
 			AuthorizationPolicy: entry.AuthorizationPolicy,
 			Routes:              routes,
 			Handler:             handler,
+			ThemeStylesheet:     entry.ResolvedThemeStylesheet,
+			ThemeAssetsDir:      entry.ResolvedThemeAssetsDir,
 		})
 	}
 
@@ -327,6 +329,11 @@ func (s *Server) mountedUIHandler(mounted MountedUI) http.Handler {
 	if inner == nil {
 		return http.NotFoundHandler()
 	}
+	// The theme interceptor wraps the static handler under StripPrefix (it
+	// matches mount-relative paths) and runs inside protectedUIHandler:
+	// policy-bound mounts keep their auth semantics for /theme.css and
+	// /theme/* exactly like any other mount path.
+	inner = mountedUIThemeHandler(mounted, inner)
 	if mounted.Path != "/" {
 		inner = http.StripPrefix(mounted.Path, inner)
 	}

--- a/gestaltd/internal/server/mounted_ui_theme.go
+++ b/gestaltd/internal/server/mounted_ui_theme.go
@@ -1,0 +1,121 @@
+package server
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"io/fs"
+	"mime"
+	"net/http"
+	"os"
+	stdpath "path"
+	"strings"
+	"time"
+)
+
+const (
+	mountedUIThemeStylesheetPath = "/theme.css"
+	mountedUIThemeAssetsPrefix   = "/theme/"
+)
+
+// mountedUIThemeHandler intercepts the deployment theme endpoints ahead of
+// the static handler, so its SPA fallback can never answer /theme.css with
+// index.html as text/html. An unconfigured mount serves an empty stylesheet
+// (200, text/css) instead of falling through; /theme/* falls through unless
+// an assets directory is configured.
+func mountedUIThemeHandler(mounted MountedUI, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			next.ServeHTTP(w, r)
+			return
+		}
+		switch {
+		case r.URL.Path == mountedUIThemeStylesheetPath:
+			serveMountedUIThemeStylesheet(w, r, mounted.ThemeStylesheet)
+		case mounted.ThemeAssetsDir != "" && strings.HasPrefix(r.URL.Path, mountedUIThemeAssetsPrefix):
+			serveMountedUIThemeAsset(w, r, mounted.ThemeAssetsDir)
+		default:
+			next.ServeHTTP(w, r)
+		}
+	})
+}
+
+func serveMountedUIThemeStylesheet(w http.ResponseWriter, r *http.Request, stylesheet string) {
+	body := []byte(nil)
+	if stylesheet != "" {
+		data, err := os.ReadFile(stylesheet)
+		if err != nil {
+			http.Error(w, "failed to read theme stylesheet", http.StatusInternalServerError)
+			return
+		}
+		body = data
+	}
+	serveMountedUIThemeContent(w, r, "text/css; charset=utf-8", body)
+}
+
+func serveMountedUIThemeAsset(w http.ResponseWriter, r *http.Request, assetsDir string) {
+	assetPath, ok := cleanMountedUIThemeAssetPath(strings.TrimPrefix(r.URL.Path, mountedUIThemeAssetsPrefix))
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	fsys := os.DirFS(assetsDir)
+	info, err := fs.Stat(fsys, assetPath)
+	if err != nil || info.IsDir() {
+		http.NotFound(w, r)
+		return
+	}
+	body, err := fs.ReadFile(fsys, assetPath)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	ext := strings.ToLower(stdpath.Ext(assetPath))
+	contentType := mountedUIThemeContentTypes[ext]
+	if contentType == "" {
+		contentType = mime.TypeByExtension(ext)
+	}
+	if contentType == "" {
+		contentType = http.DetectContentType(body)
+	}
+	serveMountedUIThemeContent(w, r, contentType, body)
+}
+
+// mountedUIThemeContentTypes covers font types explicitly: Go's builtin mime
+// table lacks .woff2, and OS mime databases are absent in minimal containers
+// — while delivering licensed fonts is the main reason assetsDir exists.
+var mountedUIThemeContentTypes = map[string]string{
+	".woff2": "font/woff2",
+	".woff":  "font/woff",
+}
+
+// cleanMountedUIThemeAssetPath guards /theme/ requests against path
+// traversal, mirroring the static handler's cleanStaticPath: backslashes,
+// parent path elements, and anything fs.ValidPath rejects are refused.
+func cleanMountedUIThemeAssetPath(requestPath string) (string, bool) {
+	if strings.Contains(requestPath, "\\") {
+		return "", false
+	}
+	for _, part := range strings.Split(requestPath, "/") {
+		if part == ".." {
+			return "", false
+		}
+	}
+	cleaned := stdpath.Clean(strings.TrimPrefix(requestPath, "/"))
+	if cleaned == "." || cleaned == "" {
+		return "", false
+	}
+	return cleaned, fs.ValidPath(cleaned)
+}
+
+// serveMountedUIThemeContent serves theme bytes with a content-hash ETag and
+// Cache-Control: no-cache — the artifact's /theme.css href is frozen, so
+// revalidation (If-None-Match → 304) is the caching strategy.
+func serveMountedUIThemeContent(w http.ResponseWriter, r *http.Request, contentType string, body []byte) {
+	sum := sha256.Sum256(body)
+	header := w.Header()
+	header.Set("Content-Type", contentType)
+	header.Set("Cache-Control", "no-cache")
+	header.Set("ETag", `"`+hex.EncodeToString(sum[:])+`"`)
+	http.ServeContent(w, r, "", time.Time{}, bytes.NewReader(body))
+}

--- a/gestaltd/internal/server/route_auth_runtime.go
+++ b/gestaltd/internal/server/route_auth_runtime.go
@@ -128,8 +128,8 @@ func (s *Server) mountedUIForPath(path string) (MountedUI, bool) {
 		}
 	}
 
-	for _, mounted := range s.mountedUIs {
-		consider(mounted)
+	for i := range s.mountedUIs {
+		consider(s.mountedUIs[i])
 	}
 	if s.adminUI != nil {
 		consider(s.adminMountedUI())

--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -97,12 +97,13 @@ func (s *Server) mountAdminAPIRoutes(r chi.Router) {
 
 func (s *Server) mountMountedUIRoutes(r chi.Router) {
 	var rootHandler http.Handler
-	for _, mounted := range s.mountedUIs {
+	for i := range s.mountedUIs {
+		mounted := &s.mountedUIs[i]
 		if mounted.Handler == nil || mounted.Path == "" {
 			continue
 		}
 		path := mounted.Path
-		handler := s.mountedUIHandler(mounted)
+		handler := s.mountedUIHandler(*mounted)
 		if path == "/" {
 			rootHandler = handler
 			continue

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -53,7 +53,12 @@ type MountedUI struct {
 	AuthorizationPolicy string
 	Routes              []MountedUIRoute
 	Handler             http.Handler
-	builtInAdmin        bool
+	// ThemeStylesheet and ThemeAssetsDir are resolved absolute paths to a
+	// deployment-configured theme, served at <mount>/theme.css and under
+	// <mount>/theme/ respectively. Both are optional.
+	ThemeStylesheet string
+	ThemeAssetsDir  string
+	builtInAdmin    bool
 }
 
 type MountedHTTPBinding struct {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -2327,6 +2327,296 @@ func TestMountedUIRoutes_PrefersNestedMount(t *testing.T) {
 	}
 }
 
+func TestMountedUIThemeRoutes(t *testing.T) {
+	t.Parallel()
+
+	uiDir := t.TempDir()
+	writeTestUIAsset(t, filepath.Join(uiDir, "index.html"), "<html>portal-shell</html>")
+
+	themeDir := t.TempDir()
+	const stylesheetBody = ":root{--brand:#123456;}"
+	writeTestUIAsset(t, filepath.Join(themeDir, "tenant.css"), stylesheetBody)
+	writeTestUIAsset(t, filepath.Join(themeDir, "secret.css"), "outside-theme-assets")
+	writeTestUIAsset(t, filepath.Join(themeDir, "assets", "fonts", "brand.woff2"), "woff2-bytes")
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.ProviderUIs = map[string]*config.UIEntry{
+			"portal": {
+				Path: "/portal",
+				ProviderEntry: config.ProviderEntry{
+					ResolvedAssetRoot: uiDir,
+				},
+				ResolvedThemeStylesheet: filepath.Join(themeDir, "tenant.css"),
+				ResolvedThemeAssetsDir:  filepath.Join(themeDir, "assets"),
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/portal/theme.css")
+	if err != nil {
+		t.Fatalf("GET theme.css: %v", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("ReadAll theme.css: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("theme.css status = %d, want 200", resp.StatusCode)
+	}
+	if got := string(body); got != stylesheetBody {
+		t.Fatalf("theme.css body = %q, want %q", got, stylesheetBody)
+	}
+	if got := resp.Header.Get("Content-Type"); got != "text/css; charset=utf-8" {
+		t.Fatalf("theme.css Content-Type = %q, want text/css; charset=utf-8", got)
+	}
+	if got := resp.Header.Get("Cache-Control"); got != "no-cache" {
+		t.Fatalf("theme.css Cache-Control = %q, want no-cache", got)
+	}
+	sum := sha256.Sum256([]byte(stylesheetBody))
+	wantETag := `"` + hex.EncodeToString(sum[:]) + `"`
+	if got := resp.Header.Get("ETag"); got != wantETag {
+		t.Fatalf("theme.css ETag = %q, want %q", got, wantETag)
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/portal/theme.css", nil)
+	req.Header.Set("If-None-Match", wantETag)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET theme.css revalidation: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNotModified {
+		t.Fatalf("theme.css revalidation status = %d, want 304", resp.StatusCode)
+	}
+	if got := resp.Header.Get("ETag"); got != wantETag {
+		t.Fatalf("theme.css revalidation ETag = %q, want %q", got, wantETag)
+	}
+
+	resp, err = http.Get(ts.URL + "/portal/theme/fonts/brand.woff2")
+	if err != nil {
+		t.Fatalf("GET theme asset: %v", err)
+	}
+	body, err = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("ReadAll theme asset: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("theme asset status = %d, want 200", resp.StatusCode)
+	}
+	if got := string(body); got != "woff2-bytes" {
+		t.Fatalf("theme asset body = %q, want woff2-bytes", got)
+	}
+	if got := resp.Header.Get("Content-Type"); got != "font/woff2" {
+		t.Fatalf("theme asset Content-Type = %q, want font/woff2", got)
+	}
+
+	for _, traversal := range []string{
+		"/portal/theme/../secret.css",
+		"/portal/theme/%2e%2e/secret.css",
+		"/portal/theme/fonts/../../secret.css",
+	} {
+		req, err := http.NewRequest(http.MethodGet, ts.URL+traversal, nil)
+		if err != nil {
+			t.Fatalf("NewRequest %q: %v", traversal, err)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("GET %q: %v", traversal, err)
+		}
+		body, err := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if err != nil {
+			t.Fatalf("ReadAll %q: %v", traversal, err)
+		}
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("traversal %q status = %d, want 404", traversal, resp.StatusCode)
+		}
+		if strings.Contains(string(body), "outside-theme-assets") {
+			t.Fatalf("traversal %q leaked file outside the theme assets dir", traversal)
+		}
+	}
+
+	resp, err = http.Get(ts.URL + "/portal/theme/missing.css")
+	if err != nil {
+		t.Fatalf("GET missing theme asset: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("missing theme asset status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestMountedUIThemeStylesheetUnconfigured(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	writeTestUIAsset(t, filepath.Join(rootDir, "index.html"), "<html>root-shell</html>")
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.ProviderUIs = map[string]*config.UIEntry{
+			"root": {
+				Path: "/",
+				ProviderEntry: config.ProviderEntry{
+					ResolvedAssetRoot: rootDir,
+				},
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/theme.css")
+	if err != nil {
+		t.Fatalf("GET theme.css: %v", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("ReadAll theme.css: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("theme.css status = %d, want 200", resp.StatusCode)
+	}
+	if len(body) != 0 {
+		t.Fatalf("theme.css body = %q, want empty (must not fall through to index.html)", body)
+	}
+	if got := resp.Header.Get("Content-Type"); got != "text/css; charset=utf-8" {
+		t.Fatalf("theme.css Content-Type = %q, want text/css; charset=utf-8", got)
+	}
+	if got := resp.Header.Get("Cache-Control"); got != "no-cache" {
+		t.Fatalf("theme.css Cache-Control = %q, want no-cache", got)
+	}
+	etag := resp.Header.Get("ETag")
+	if etag == "" {
+		t.Fatal("theme.css ETag missing")
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/theme.css", nil)
+	req.Header.Set("If-None-Match", etag)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET theme.css revalidation: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNotModified {
+		t.Fatalf("theme.css revalidation status = %d, want 304", resp.StatusCode)
+	}
+
+	// The SPA fallback still answers navigations; only /theme.css is intercepted.
+	resp, err = http.Get(ts.URL + "/dashboard")
+	if err != nil {
+		t.Fatalf("GET SPA navigation: %v", err)
+	}
+	body, err = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("ReadAll SPA navigation: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("SPA navigation status = %d, want 200", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "root-shell") {
+		t.Fatalf("SPA navigation body = %q, want root shell", body)
+	}
+}
+
+func TestPolicyBoundMountedUIThemeKeepsAuthSemantics(t *testing.T) {
+	t.Parallel()
+
+	uiDir := t.TempDir()
+	writeTestUIAsset(t, filepath.Join(uiDir, "index.html"), "<html>brand-shell</html>")
+	themeDir := t.TempDir()
+	const stylesheetBody = ":root{--brand:#654321;}"
+	writeTestUIAsset(t, filepath.Join(themeDir, "tenant.css"), stylesheetBody)
+
+	handler, err := testutilUIHandler(uiDir)
+	if err != nil {
+		t.Fatalf("ui handler: %v", err)
+	}
+
+	svc := testutil.NewStubServices(t)
+	user := seedUserRecord(t, svc, "theme-user", "theme-user@example.test", time.Now())
+	authz := &serverTestAuthorizationProvider{
+		resourceTypes: []*proto.AuthorizationModelResourceType{{
+			Name:                "brandPolicy",
+			DefaultAccessPolicy: proto.DefaultAccessPolicy_DEFAULT_ACCESS_POLICY_DENY,
+		}},
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(
+				principal.UserSubjectID(user.ID),
+				"viewer",
+				"brandPolicy",
+				"brandPolicy",
+			),
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "session-token" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: "theme-user@example.test"}, nil
+			},
+		}
+		cfg.Services = svc
+		cfg.Authorization = authz
+		cfg.MountedUIs = []server.MountedUI{{
+			Name:                "brand-ui",
+			Path:                "/brand",
+			AppName:             "brand",
+			AuthorizationPolicy: "brandPolicy",
+			Routes: []server.MountedUIRoute{{
+				Path:         "/*",
+				AllowedRoles: []string{"viewer"},
+			}},
+			Handler:         handler,
+			ThemeStylesheet: filepath.Join(themeDir, "tenant.css"),
+		}}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	noRedirect := &http.Client{CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+	resp, err := noRedirect.Get(ts.URL + "/brand/theme.css")
+	if err != nil {
+		t.Fatalf("GET theme.css unauthenticated: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("unauthenticated theme.css status = %d, want 302", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Location"); !strings.HasPrefix(got, "/api/v1/auth/login") {
+		t.Fatalf("unauthenticated theme.css Location = %q, want login redirect", got)
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/brand/theme.css", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "session-token"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET theme.css authorized: %v", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("ReadAll theme.css authorized: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("authorized theme.css status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	if got := string(body); got != stylesheetBody {
+		t.Fatalf("authorized theme.css body = %q, want %q", got, stylesheetBody)
+	}
+	if got := resp.Header.Get("Content-Type"); got != "text/css; charset=utf-8" {
+		t.Fatalf("authorized theme.css Content-Type = %q, want text/css; charset=utf-8", got)
+	}
+}
+
 func TestPolicyBoundMountedUIUsesAuthorizationRelationships(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

A deployment can now point a mounted UI at a tenant stylesheet (`config.theme.stylesheet`, optional `theme.assetsDir`); gestaltd serves it at the mount's `/theme.css` and `/theme/*`. Unthemed mounts serve an **empty 200**, so the bundled generic theme renders untouched, with no console noise.

## Why

UI bundles are immutable content-addressed snapshots, so tenant branding can't be built in without breaking the one-artifact model. I wanted valon.tools to carry the Valon brand without forking or rebuilding ui/default. I rejected build-time imports of the private theme (a private dependency leaks the repo and its licensed fonts into the public artifact) and runtime JS token application (flashes the generic theme) — serving one stylesheet the artifact always links is the Discourse/Grafana pattern.

## What changed

- Two decisions I'd most like pushback on: a mistyped `theme` block **fails sync** (the alternative — the silent no-op every unknown config key gets today — is how this stayed unimplemented), and theme endpoints sit **inside the mount's auth policy**, so branding doesn't leak from protected mounts.
- Tests cover the serve matrix: configured / empty / 304 / SPA-fallback non-interception / path traversal / policy-bound mounts. `go build`, `go vet`, suites green.

Pairs with valon-technologies/gestalt-providers#1017 (bundle contract) and valon-technologies/toolshed#2512 (tenant wiring).
