### PR TITLE
Publish the Go and Rust SDK API references alongside Python and TypeScript

### DIFF
--- a/.github/workflows/bootstrap-sdk-api-docs.yml
+++ b/.github/workflows/bootstrap-sdk-api-docs.yml
@@ -19,6 +19,22 @@ on:
         description: TypeScript SDK tag version without the sdk/typescript/v prefix, such as 0.0.1-alpha.18
         required: false
         type: string
+      go-ref:
+        description: Git ref containing the Go SDK source to publish
+        required: false
+        type: string
+      go-version:
+        description: Go SDK tag version without the sdk/go/v prefix, such as 0.0.1-alpha.8
+        required: false
+        type: string
+      rust-ref:
+        description: Git ref containing the Rust SDK source to publish
+        required: false
+        type: string
+      rust-version:
+        description: Rust SDK tag version without the sdk/rust/v prefix, such as 0.0.1-alpha.8
+        required: false
+        type: string
       latest-policy:
         description: Latest alias update policy
         required: true
@@ -196,5 +212,105 @@ jobs:
             --version "${{ inputs.typescript-version }}" \
             --source-tag "${{ inputs.typescript-ref }}" \
             --source-dir "${RUNNER_TEMP}/typescript-sdk-api-docs" \
+            --bucket "${DOCS_SDK_API_BUCKET}" \
+            --latest-policy "${{ inputs.latest-policy }}"
+
+  bootstrap-go:
+    if: ${{ inputs.go-ref != '' && inputs.go-version != '' }}
+    name: Bootstrap Go SDK API Docs
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    concurrency:
+      group: sdk-go-docs-release
+      cancel-in-progress: false
+    defaults:
+      run:
+        working-directory: sdk/go
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.go-ref }}
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          path: tooling
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: sdk/go/go.mod
+          cache-dependency-path: sdk/go/go.sum
+
+      - name: Build Go SDK API docs
+        run: |
+          go install golang.org/x/tools/cmd/godoc@v0.30.0
+          PATH="$(go env GOPATH)/bin:$PATH"             "${GITHUB_WORKSPACE}/tooling/docs/scripts/build-go-sdk-docs.sh" "${RUNNER_TEMP}/go-sdk-api-docs"
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
+        with:
+          workload_identity_provider: projects/${{ secrets.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/${{ vars.GCP_WIF_POOL_ID }}/providers/${{ vars.GCP_WIF_PROVIDER_ID }}
+          service_account: github-actions@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com
+          token_format: access_token
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2
+      - name: Upload Go SDK API docs
+        run: |
+          python3 "${GITHUB_WORKSPACE}/tooling/docs/scripts/publish-sdk-api-docs.py" \
+            --mode upload \
+            --language go \
+            --version "${{ inputs.go-version }}" \
+            --source-tag "bootstrap/${{ inputs.go-ref }}" \
+            --source-dir "${RUNNER_TEMP}/go-sdk-api-docs" \
+            --bucket "${DOCS_SDK_API_BUCKET}" \
+            --latest-policy "${{ inputs.latest-policy }}"
+
+  bootstrap-rust:
+    if: ${{ inputs.rust-ref != '' && inputs.rust-version != '' }}
+    name: Bootstrap Rust SDK API Docs
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      group: sdk-rust-docs-release
+      cancel-in-progress: false
+    defaults:
+      run:
+        working-directory: sdk/rust
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.rust-ref }}
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          path: tooling
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Build Rust SDK API docs
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: |
+          cargo doc --no-deps
+          cat > target/doc/index.html <<'HTML'
+          <!doctype html>
+          <meta http-equiv="refresh" content="0; url=./gestalt/" />
+          <title>Gestalt Rust SDK</title>
+          <a href="./gestalt/">Gestalt Rust SDK API reference</a>
+          HTML
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
+        with:
+          workload_identity_provider: projects/${{ secrets.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/${{ vars.GCP_WIF_POOL_ID }}/providers/${{ vars.GCP_WIF_PROVIDER_ID }}
+          service_account: github-actions@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com
+          token_format: access_token
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2
+      - name: Upload Rust SDK API docs
+        run: |
+          python3 "${GITHUB_WORKSPACE}/tooling/docs/scripts/publish-sdk-api-docs.py" \
+            --mode upload \
+            --language rust \
+            --version "${{ inputs.rust-version }}" \
+            --source-tag "bootstrap/${{ inputs.rust-ref }}" \
+            --source-dir "target/doc" \
             --bucket "${DOCS_SDK_API_BUCKET}" \
             --latest-policy "${{ inputs.latest-policy }}"

--- a/.github/workflows/deploy-gestalt-docs.yml
+++ b/.github/workflows/deploy-gestalt-docs.yml
@@ -7,7 +7,9 @@ on:
       - 'gestaltd/v*'
     paths:
       - 'docs/**'
+      - 'sdk/go/**'
       - 'sdk/python/**'
+      - 'sdk/rust/**'
       - 'sdk/typescript/**'
       - '.github/workflows/deploy-gestalt-docs.yml'
   workflow_dispatch:
@@ -67,6 +69,36 @@ jobs:
         run: |
           rm -rf ../../docs/public/api/typescript
           bun run docs:build:deploy
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: sdk/go/go.mod
+          cache-dependency-path: sdk/go/go.sum
+
+      - name: Build Go SDK API docs
+        working-directory: sdk/go
+        run: |
+          go install golang.org/x/tools/cmd/godoc@v0.30.0
+          rm -rf ../../docs/public/api/go
+          PATH="$(go env GOPATH)/bin:$PATH" ../../docs/scripts/build-go-sdk-docs.sh ../../docs/public/api/go
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Build Rust SDK API docs
+        working-directory: sdk/rust
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: |
+          cargo doc --no-deps
+          rm -rf ../../docs/public/api/rust
+          mkdir -p ../../docs/public/api/rust
+          cp -R target/doc/. ../../docs/public/api/rust/
+          cat > ../../docs/public/api/rust/index.html <<'HTML'
+          <!doctype html>
+          <meta http-equiv="refresh" content="0; url=./gestalt/" />
+          <title>Gestalt Rust SDK</title>
+          <a href="./gestalt/">Gestalt Rust SDK API reference</a>
+          HTML
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -45,7 +45,7 @@ jobs:
         Go SDK for building against Gestalt's app and protocol surfaces, including the generated protobuf types used by the server and apps.
       install-markdown: |
         - Go modules: `go get github.com/valon-technologies/gestalt/sdk/go@v${version}`
-        - Package docs: [pkg.go.dev/github.com/valon-technologies/gestalt/sdk/go@v${version}](https://pkg.go.dev/github.com/valon-technologies/gestalt/sdk/go@v${version})
+        - Package docs: [gestaltd.ai/api/go](https://gestaltd.ai/api/go/index.html)
 
   warm-go-sdk-module-proxy:
     if: ${{ startsWith(github.ref_name, 'sdk/go/v') }}
@@ -194,7 +194,7 @@ jobs:
       install-markdown: |
         - Crate: `cargo add gestalt-sdk`
         - In code, continue importing the library as `gestalt`
-        - API docs: [docs.rs/gestalt-sdk/${version}/gestalt](https://docs.rs/gestalt-sdk/${version}/gestalt/)
+        - API docs: [gestaltd.ai/api/rust](https://gestaltd.ai/api/rust/index.html)
         - Package page: [crates.io/crates/gestalt-sdk](https://crates.io/crates/gestalt-sdk)
 
   publish-python-sdk:
@@ -414,5 +414,124 @@ jobs:
             --version "${{ steps.version.outputs.version }}" \
             --source-tag "${GITHUB_REF_NAME}" \
             --source-dir "${RUNNER_TEMP}/typescript-sdk-api-docs" \
+            --bucket "${DOCS_SDK_API_BUCKET}" \
+            --latest-policy auto
+
+  publish-go-sdk-docs:
+    if: ${{ startsWith(github.ref_name, 'sdk/go/v') }}
+    name: Publish Go SDK API Docs
+    concurrency:
+      group: sdk-go-docs-release
+      cancel-in-progress: false
+    needs: validate-go-sdk
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      DOCS_SDK_API_BUCKET: ${{ vars.DOCS_SDK_API_BUCKET || format('{0}-sdk-api-docs', vars.DOCS_RESOURCE_PREFIX) }}
+    defaults:
+      run:
+        working-directory: sdk/go
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: sdk/go/go.mod
+          cache-dependency-path: sdk/go/go.sum
+
+      - name: Resolve version
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#sdk/go/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Install godoc
+        run: go install golang.org/x/tools/cmd/godoc@v0.30.0
+
+      - name: Build Go SDK API docs
+        run: PATH="$(go env GOPATH)/bin:$PATH" ../../docs/scripts/build-go-sdk-docs.sh "${RUNNER_TEMP}/go-sdk-api-docs"
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
+        with:
+          workload_identity_provider: projects/${{ secrets.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/${{ vars.GCP_WIF_POOL_ID }}/providers/${{ vars.GCP_WIF_PROVIDER_ID }}
+          service_account: github-actions@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com
+          token_format: access_token
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2
+      - name: Upload Go SDK API docs
+        run: |
+          if [ -z "${DOCS_SDK_API_BUCKET}" ]; then
+            echo "DOCS_SDK_API_BUCKET repository variable must be configured" >&2
+            exit 1
+          fi
+          python3 ../../docs/scripts/publish-sdk-api-docs.py \
+            --mode upload \
+            --language go \
+            --version "${{ steps.version.outputs.version }}" \
+            --source-tag "${GITHUB_REF_NAME}" \
+            --source-dir "${RUNNER_TEMP}/go-sdk-api-docs" \
+            --bucket "${DOCS_SDK_API_BUCKET}" \
+            --latest-policy auto
+
+  publish-rust-sdk-docs:
+    if: ${{ startsWith(github.ref_name, 'sdk/rust/v') }}
+    name: Publish Rust SDK API Docs
+    concurrency:
+      group: sdk-rust-docs-release
+      cancel-in-progress: false
+    needs: validate-rust-sdk
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      DOCS_SDK_API_BUCKET: ${{ vars.DOCS_SDK_API_BUCKET || format('{0}-sdk-api-docs', vars.DOCS_RESOURCE_PREFIX) }}
+    defaults:
+      run:
+        working-directory: sdk/rust
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Resolve version
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#sdk/rust/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Build Rust SDK API docs
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: |
+          cargo doc --no-deps
+          cat > target/doc/index.html <<'HTML'
+          <!doctype html>
+          <meta http-equiv="refresh" content="0; url=./gestalt/" />
+          <title>Gestalt Rust SDK</title>
+          <a href="./gestalt/">Gestalt Rust SDK API reference</a>
+          HTML
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
+        with:
+          workload_identity_provider: projects/${{ secrets.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/${{ vars.GCP_WIF_POOL_ID }}/providers/${{ vars.GCP_WIF_PROVIDER_ID }}
+          service_account: github-actions@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com
+          token_format: access_token
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2
+      - name: Upload Rust SDK API docs
+        run: |
+          if [ -z "${DOCS_SDK_API_BUCKET}" ]; then
+            echo "DOCS_SDK_API_BUCKET repository variable must be configured" >&2
+            exit 1
+          fi
+          python3 ../../docs/scripts/publish-sdk-api-docs.py \
+            --mode upload \
+            --language rust \
+            --version "${{ steps.version.outputs.version }}" \
+            --source-tag "${GITHUB_REF_NAME}" \
+            --source-dir "target/doc" \
             --bucket "${DOCS_SDK_API_BUCKET}" \
             --latest-policy auto

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -165,11 +165,11 @@ server {
     }
 
     location ~ ^/reference/(go-sdk|sdk/go)(\.html)?/?$ {
-        return 301 https://pkg.go.dev/github.com/valon-technologies/gestalt/sdk/go;
+        return 301 /api/go/index.html;
     }
 
     location ~ ^/reference/(rust-sdk|sdk/rust)(\.html)?/?$ {
-        return 301 https://docs.rs/gestalt-sdk/latest/gestalt/;
+        return 301 /api/rust/index.html;
     }
 
     location ~ ^/providers/[^/]+/.+ {

--- a/docs/content/reference/sdk/_meta.ts
+++ b/docs/content/reference/sdk/_meta.ts
@@ -9,10 +9,10 @@ export default {
   },
   go: {
     title: "Go SDK",
-    href: "https://pkg.go.dev/github.com/valon-technologies/gestalt/sdk/go",
+    href: "/api/go/index.html",
   },
   rust: {
     title: "Rust SDK",
-    href: "https://docs.rs/gestalt-sdk/latest/gestalt/",
+    href: "/api/rust/index.html",
   },
 };

--- a/docs/scripts/build-go-sdk-docs.sh
+++ b/docs/scripts/build-go-sdk-docs.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Renders the Go SDK API reference as static HTML with the official godoc
+# server: serve the module, mirror the package tree (and source views and
+# static assets) to disk, and write a root redirect into the package tree.
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <output-dir>" >&2
+  exit 2
+fi
+
+out="$(mkdir -p "$1" && cd "$1" && pwd)"
+module="github.com/valon-technologies/gestalt/sdk/go"
+port="${GODOC_PORT:-6060}"
+
+godoc -http="127.0.0.1:${port}" &
+godoc_pid=$!
+trap 'kill "${godoc_pid}" 2>/dev/null || true' EXIT
+
+ready=""
+for _ in $(seq 1 120); do
+  if curl -fsS -o /dev/null "http://127.0.0.1:${port}/pkg/${module}/"; then
+    ready=1
+    break
+  fi
+  sleep 1
+done
+if [[ -z "${ready}" ]]; then
+  echo "godoc did not serve ${module} within 120s" >&2
+  exit 1
+fi
+
+rm -rf "${out:?}"/*
+(
+  cd "${out}"
+  # wget's exit codes are noisy for mirrors (404s on side links, source
+  # views with query strings); the required artifacts are verified below.
+  wget --quiet -e robots=off --mirror --no-host-directories --page-requisites --convert-links \
+    --include-directories="/pkg/${module},/src/${module},/lib/godoc" \
+    "http://127.0.0.1:${port}/pkg/${module}/" || true
+)
+
+test -f "${out}/pkg/${module}/index.html" || {
+  echo "mirror missing the module package page" >&2
+  exit 1
+}
+grep -q "func " "${out}/pkg/${module}/client/index.html" || {
+  echo "mirror missing the client package rendering" >&2
+  exit 1
+}
+
+cat > "${out}/index.html" <<HTML
+<!doctype html>
+<meta http-equiv="refresh" content="0; url=./pkg/${module}/" />
+<title>Gestalt Go SDK</title>
+<a href="./pkg/${module}/">Gestalt Go SDK API reference</a>
+HTML

--- a/docs/scripts/check-registry-static.mjs
+++ b/docs/scripts/check-registry-static.mjs
@@ -24,8 +24,8 @@ const contentTypes = new Map([
 const sdkReferenceTargets = {
   python: "/api/python/index.html",
   typescript: "/api/typescript/index.html",
-  go: "https://pkg.go.dev/github.com/valon-technologies/gestalt/sdk/go",
-  rust: "https://docs.rs/gestalt-sdk/latest/gestalt/",
+  go: "/api/go/index.html",
+  rust: "/api/rust/index.html",
 };
 const registryMarker = "data-registry-shell";
 

--- a/docs/scripts/check-sdk-api-docs-publish.mjs
+++ b/docs/scripts/check-sdk-api-docs-publish.mjs
@@ -93,6 +93,41 @@ try {
     "api/typescript/latest.json",
   ]);
 
+  for (const [language, sourceTag] of [
+    ["go", "sdk/go/v0.0.1-alpha.10"],
+    ["rust", "sdk/rust/v0.0.1-alpha.10"],
+  ]) {
+    const langManifest = await manifest({
+      language,
+      version: "0.0.1-alpha.10",
+      sourceTag,
+      sourceDir: docsRoot,
+      currentLatestVersion: "0.0.1-alpha.9",
+    });
+    assert(langManifest.updatesLatest === true, `${language} semver comparison should work`);
+    assert(
+      langManifest.cleanupLatestPrefix === `api/${language}/latest/`,
+      `latest-updating ${language} manifest should clean the latest prefix`,
+    );
+    assertKeys(langManifest, [
+      `api/${language}/0.0.1-alpha.10/`,
+      `api/${language}/0.0.1-alpha.10/index.html`,
+      `api/${language}/0.0.1-alpha.10/_static/style.css`,
+      `api/${language}/latest/`,
+      `api/${language}/latest/index.html`,
+      `api/${language}/latest/_static/style.css`,
+      `api/${language}`,
+      `api/${language}/`,
+      `api/${language}/index.html`,
+      `api/${language}/latest.json`,
+    ]);
+    assertCache(
+      langManifest,
+      `api/${language}/0.0.1-alpha.10/index.html`,
+      "public, max-age=31536000, immutable",
+    );
+  }
+
   const pypiMetadata = path.join(tempRoot, "pypi.json");
   await writeFile(pypiMetadata, JSON.stringify({ releases: { "0.0.1a2": [] } }));
   await assertPackageExists(["pypi", "gestalt-sdk", "0.0.1a2", "--metadata-file", pypiMetadata], true);

--- a/docs/scripts/publish-sdk-api-docs.py
+++ b/docs/scripts/publish-sdk-api-docs.py
@@ -53,7 +53,7 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Publish versioned SDK API docs to the Gestalt docs bucket.",
     )
-    parser.add_argument("--language", choices=["python", "typescript"], required=True)
+    parser.add_argument("--language", choices=["python", "typescript", "go", "rust"], required=True)
     parser.add_argument("--version", required=True)
     parser.add_argument("--source-dir", type=Path, required=True)
     parser.add_argument("--bucket")

--- a/docs/terraform/main.tf
+++ b/docs/terraform/main.tf
@@ -143,8 +143,12 @@ resource "google_compute_url_map" "docs" {
 
     path_rule {
       paths = [
+        "/api/go",
+        "/api/go/*",
         "/api/python",
         "/api/python/*",
+        "/api/rust",
+        "/api/rust/*",
         "/api/typescript",
         "/api/typescript/*",
       ]


### PR DESCRIPTION
## Summary

Go and Rust get published API references, completing four-language parity on the same tag-driven pipeline as Python and TypeScript. Go renders with the **official godoc** server via a new serve-and-mirror script (`docs/scripts/build-go-sdk-docs.sh`, validated locally: module mode renders, 1,500+ pages, artifact-verified rather than trusting wget's noisy exit codes); Rust uploads its `cargo doc` tree with a root redirect. Release, deploy, and bootstrap workflows gain the corresponding jobs; the LB, nginx redirects, and the docs-site SDK index point at `/api/go` and `/api/rust` instead of pkg.go.dev/docs.rs — **both dead links today for a private repo**.

## Interfaces

```bash
docs/scripts/publish-sdk-api-docs.py --language go|rust ...   # same versioned+latest model
docs/scripts/build-go-sdk-docs.sh <output-dir>                # godoc serve → wget mirror → verify
```

Tags `sdk/go/v*` and `sdk/rust/v*` (which already trigger validate jobs) now also publish versioned + latest docs, identical to python/typescript.

## Runtime

No SDK behavior changes — pipeline and routing only. The publish-contract test (`test:sdk-api-docs`, runs in build-docs CI) and the registry static check now assert four languages, so the pipeline cannot regress to two. Terraform adds `/api/go*` and `/api/rust*` LB paths to the existing docs bucket backend; the bootstrap workflow can seed the bucket before the first post-merge tags so the new routes never 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
