### PR TITLE
Document the entire Rust surface and deny missing docs

### DIFF
--- a/sdk/rust/src/agent_provider.rs
+++ b/sdk/rust/src/agent_provider.rs
@@ -17,21 +17,31 @@ pub type AgentJson = serde_json::Value;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
 #[repr(i32)]
+/// Native enum for `gestalt.provider.v1.AgentMessagePartType`.
 pub enum AgentMessagePartType {
     #[default]
+    /// The `Unspecified` variant.
     Unspecified = 0,
+    /// The `Text` variant.
     Text = 1,
+    /// The `Json` variant.
     Json = 2,
+    /// The `ToolCall` variant.
     ToolCall = 3,
+    /// The `ToolResult` variant.
     ToolResult = 4,
+    /// The `ImageRef` variant.
     ImageRef = 5,
 }
 
 impl AgentMessagePartType {
+    /// Returns the wire integer for this value.
     pub const fn as_i32(self) -> i32 {
         self as i32
     }
 
+    /// Converts a wire integer, mapping unknown values to the unspecified
+    /// variant.
     pub const fn from_i32_lossy(value: i32) -> Self {
         match value {
             1 => Self::Text,
@@ -64,18 +74,25 @@ impl TryFrom<i32> for AgentMessagePartType {
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
 #[repr(i32)]
+/// Native enum for `gestalt.provider.v1.AgentToolSourceMode`.
 pub enum AgentToolSourceMode {
     #[default]
+    /// The `Unspecified` variant.
     Unspecified = 0,
+    /// The `Catalog` variant.
     Catalog = 2,
+    /// The `None` variant.
     None = 3,
 }
 
 impl AgentToolSourceMode {
+    /// Returns the wire integer for this value.
     pub const fn as_i32(self) -> i32 {
         self as i32
     }
 
+    /// Converts a wire integer, mapping unknown values to the unspecified
+    /// variant.
     pub const fn from_i32_lossy(value: i32) -> Self {
         match value {
             2 => Self::Catalog,
@@ -102,22 +119,33 @@ impl TryFrom<i32> for AgentToolSourceMode {
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
 #[repr(i32)]
+/// Native enum for `gestalt.provider.v1.AgentExecutionStatus`.
 pub enum AgentExecutionStatus {
     #[default]
+    /// The `Unspecified` variant.
     Unspecified = 0,
+    /// The `Pending` variant.
     Pending = 1,
+    /// The `Running` variant.
     Running = 2,
+    /// The `Succeeded` variant.
     Succeeded = 3,
+    /// The `Failed` variant.
     Failed = 4,
+    /// The `Canceled` variant.
     Canceled = 5,
+    /// The `WaitingForInput` variant.
     WaitingForInput = 6,
 }
 
 impl AgentExecutionStatus {
+    /// Returns the wire integer for this value.
     pub const fn as_i32(self) -> i32 {
         self as i32
     }
 
+    /// Converts a wire integer, mapping unknown values to the unspecified
+    /// variant.
     pub const fn from_i32_lossy(value: i32) -> Self {
         match value {
             1 => Self::Pending,
@@ -152,18 +180,25 @@ impl TryFrom<i32> for AgentExecutionStatus {
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
 #[repr(i32)]
+/// Native enum for `gestalt.provider.v1.AgentSessionState`.
 pub enum AgentSessionState {
     #[default]
+    /// The `Unspecified` variant.
     Unspecified = 0,
+    /// The `Active` variant.
     Active = 1,
+    /// The `Archived` variant.
     Archived = 2,
 }
 
 impl AgentSessionState {
+    /// Returns the wire integer for this value.
     pub const fn as_i32(self) -> i32 {
         self as i32
     }
 
+    /// Converts a wire integer, mapping unknown values to the unspecified
+    /// variant.
     pub const fn from_i32_lossy(value: i32) -> Self {
         match value {
             1 => Self::Active,
@@ -190,19 +225,27 @@ impl TryFrom<i32> for AgentSessionState {
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
 #[repr(i32)]
+/// Native enum for `gestalt.provider.v1.AgentInteractionType`.
 pub enum AgentInteractionType {
     #[default]
+    /// The `Unspecified` variant.
     Unspecified = 0,
+    /// The `Approval` variant.
     Approval = 1,
+    /// The `Clarification` variant.
     Clarification = 2,
+    /// The `Input` variant.
     Input = 3,
 }
 
 impl AgentInteractionType {
+    /// Returns the wire integer for this value.
     pub const fn as_i32(self) -> i32 {
         self as i32
     }
 
+    /// Converts a wire integer, mapping unknown values to the unspecified
+    /// variant.
     pub const fn from_i32_lossy(value: i32) -> Self {
         match value {
             1 => Self::Approval,
@@ -231,19 +274,27 @@ impl TryFrom<i32> for AgentInteractionType {
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
 #[repr(i32)]
+/// Native enum for `gestalt.provider.v1.AgentInteractionState`.
 pub enum AgentInteractionState {
     #[default]
+    /// The `Unspecified` variant.
     Unspecified = 0,
+    /// The `Pending` variant.
     Pending = 1,
+    /// The `Resolved` variant.
     Resolved = 2,
+    /// The `Canceled` variant.
     Canceled = 3,
 }
 
 impl AgentInteractionState {
+    /// Returns the wire integer for this value.
     pub const fn as_i32(self) -> i32 {
         self as i32
     }
 
+    /// Converts a wire integer, mapping unknown values to the unspecified
+    /// variant.
     pub const fn from_i32_lossy(value: i32) -> Self {
         match value {
             1 => Self::Pending,
@@ -271,71 +322,113 @@ impl TryFrom<i32> for AgentInteractionState {
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]
+/// Native message type for `gestalt.provider.v1.AgentMessage`.
 pub struct AgentMessage {
+    /// The `role` field.
     pub role: String,
+    /// The `text` field.
     pub text: String,
+    /// The `parts` field.
     pub parts: Vec<AgentMessagePart>,
+    /// The `metadata` field.
     pub metadata: Option<AgentJson>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]
+/// Native message type for `gestalt.provider.v1.AgentMessagePartToolCall`.
 pub struct AgentMessagePartToolCall {
+    /// The `id` field.
     pub id: String,
+    /// The `tool_id` field.
     pub tool_id: String,
+    /// The `arguments` field.
     pub arguments: Option<AgentJson>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]
+/// Native message type for `gestalt.provider.v1.AgentMessagePartToolResult`.
 pub struct AgentMessagePartToolResult {
+    /// The `tool_call_id` field.
     pub tool_call_id: String,
+    /// The `status` field.
     pub status: i32,
+    /// The `content` field.
     pub content: String,
+    /// The `output` field.
     pub output: Option<AgentJson>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+/// Native message type for `gestalt.provider.v1.AgentMessagePartImageRef`.
 pub struct AgentMessagePartImageRef {
+    /// The `uri` field.
     pub uri: String,
+    /// The `mime_type` field.
     pub mime_type: String,
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]
+/// Native message type for `gestalt.provider.v1.AgentMessagePart`.
 pub struct AgentMessagePart {
+    /// The `type` field.
     pub r#type: AgentMessagePartType,
+    /// The `text` field.
     pub text: String,
+    /// The `json` field.
     pub json: Option<AgentJson>,
+    /// The `tool_call` field.
     pub tool_call: Option<AgentMessagePartToolCall>,
+    /// The `tool_result` field.
     pub tool_result: Option<AgentMessagePartToolResult>,
+    /// The `image_ref` field.
     pub image_ref: Option<AgentMessagePartImageRef>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+/// Describes the workspace a provider prepared for a session.
 pub struct AgentPreparedWorkspace {
+    /// The `root` field.
     pub root: String,
+    /// The `cwd` field.
     pub cwd: String,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+/// Native message type for `gestalt.provider.v1.AgentToolRef`.
 pub struct AgentToolRef {
+    /// The `app` field.
     pub app: String,
+    /// The `operation` field.
     pub operation: String,
+    /// The `connection` field.
     pub connection: String,
+    /// The `instance` field.
     pub instance: String,
+    /// The `title` field.
     pub title: String,
+    /// The `description` field.
     pub description: String,
+    /// The `credential_mode` field.
     pub credential_mode: String,
+    /// The `system` field.
     pub system: String,
+    /// The `run_as` field.
     pub run_as: Option<Subject>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]
+/// Native message type for `gestalt.provider.v1.AgentToolConfig`.
 pub struct AgentToolConfig {
+    /// The `source` field.
     pub source: Option<AgentToolConfigSource>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
+/// Selects where a session's tools come from.
 pub enum AgentToolConfigSource {
+    /// The `None` variant.
     None(AgentNoTools),
+    /// The `Catalog` variant.
     Catalog(AgentCatalogToolConfig),
 }
 
@@ -343,8 +436,11 @@ pub enum AgentToolConfigSource {
 pub struct AgentNoTools {}
 
 #[derive(Debug, Clone, Default, PartialEq)]
+/// Native message type for `gestalt.provider.v1.AgentCatalogToolConfig`.
 pub struct AgentCatalogToolConfig {
+    /// The `refs` field.
     pub refs: Vec<AgentToolRef>,
+    /// The `tools` field.
     pub tools: Vec<ListedAgentTool>,
 }
 
@@ -395,211 +491,349 @@ impl AgentMessagePartToolResult {
 /// Native agent workspace request data.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AgentWorkspace {
+    /// The `checkouts` field.
     pub checkouts: Vec<AgentWorkspaceGitCheckout>,
+    /// The `cwd` field.
     pub cwd: String,
 }
 
 /// Native agent workspace git checkout data.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AgentWorkspaceGitCheckout {
+    /// The `url` field.
     pub url: String,
+    /// The `reference` field.
     pub reference: String,
+    /// The `path` field.
     pub path: String,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+/// Native message type for `gestalt.provider.v1.AgentProviderCapabilities`.
 pub struct AgentProviderCapabilities {
+    /// The `streaming_text` field.
     pub streaming_text: bool,
+    /// The `tool_calls` field.
     pub tool_calls: bool,
+    /// The `parallel_tool_calls` field.
     pub parallel_tool_calls: bool,
+    /// The `interactions` field.
     pub interactions: bool,
+    /// The `resumable_turns` field.
     pub resumable_turns: bool,
+    /// The `reasoning_summaries` field.
     pub reasoning_summaries: bool,
+    /// The `bounded_list_hydration` field.
     pub bounded_list_hydration: bool,
+    /// The `supported_tool_sources` field.
     pub supported_tool_sources: Vec<AgentToolSourceMode>,
+    /// The `supports_session_start` field.
     pub supports_session_start: bool,
+    /// The `supports_prepared_workspace` field.
     pub supports_prepared_workspace: bool,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+/// Native message type for `gestalt.provider.v1.GetAgentProviderCapabilitiesRequest`.
 pub struct GetAgentProviderCapabilitiesRequest {}
 
 #[derive(Debug, Clone, Default, PartialEq)]
+/// Native message type for `gestalt.provider.v1.AgentInteraction`.
 pub struct AgentInteraction {
+    /// The `id` field.
     pub id: String,
+    /// The `type` field.
     pub r#type: AgentInteractionType,
+    /// The `state` field.
     pub state: AgentInteractionState,
+    /// The `title` field.
     pub title: String,
+    /// The `prompt` field.
     pub prompt: String,
+    /// The `request` field.
     pub request: Option<AgentJson>,
+    /// The `resolution` field.
     pub resolution: Option<AgentJson>,
+    /// The `created_at` field.
     pub created_at: Option<SystemTime>,
+    /// The `resolved_at` field.
     pub resolved_at: Option<SystemTime>,
+    /// The `turn_id` field.
     pub turn_id: String,
+    /// The `session_id` field.
     pub session_id: String,
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]
+/// Native message type for `gestalt.provider.v1.AgentSession`.
 pub struct AgentSession {
+    /// The `id` field.
     pub id: String,
+    /// The `provider_name` field.
     pub provider_name: String,
+    /// The `model` field.
     pub model: String,
+    /// The `client_ref` field.
     pub client_ref: String,
+    /// The `state` field.
     pub state: AgentSessionState,
+    /// The `metadata` field.
     pub metadata: Option<AgentJson>,
+    /// The `created_by_subject_id` field.
     pub created_by_subject_id: Option<String>,
+    /// The `created_at` field.
     pub created_at: Option<SystemTime>,
+    /// The `updated_at` field.
     pub updated_at: Option<SystemTime>,
+    /// The `last_turn_at` field.
     pub last_turn_at: Option<SystemTime>,
 }
 
 /// Request passed to [`AgentProvider::create_session`].
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct CreateAgentProviderSessionRequest {
+    /// The `idempotency_key` field.
     pub idempotency_key: String,
+    /// The `model` field.
     pub model: String,
+    /// The `client_ref` field.
     pub client_ref: String,
+    /// The `metadata` field.
     pub metadata: Option<AgentJson>,
+    /// The `created_by_subject_id` field.
     pub created_by_subject_id: Option<String>,
+    /// The `subject` field.
     pub subject: Option<Subject>,
+    /// The `session_start` field.
     pub session_start: Option<AgentSessionStartConfig>,
+    /// The `prepared_workspace` field.
     pub prepared_workspace: Option<AgentPreparedWorkspace>,
+    /// The `tools` field.
     pub tools: Option<AgentToolConfig>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+/// Native message type for `gestalt.provider.v1.AgentSessionStartConfig`.
 pub struct AgentSessionStartConfig {
+    /// The `hooks` field.
     pub hooks: Vec<AgentSessionStartHook>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+/// Native message type for `gestalt.provider.v1.AgentSessionStartHook`.
 pub struct AgentSessionStartHook {
+    /// The `id` field.
     pub id: String,
+    /// The `type` field.
     pub r#type: String,
+    /// The `command` field.
     pub command: Vec<String>,
+    /// The `cwd` field.
     pub cwd: String,
+    /// The `timeout` field.
     pub timeout: String,
+    /// The `env` field.
     pub env: std::collections::HashMap<String, String>,
+    /// The `output` field.
     pub output: Option<AgentSessionStartHookOutput>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+/// Native message type for `gestalt.provider.v1.AgentSessionStartHookOutput`.
 pub struct AgentSessionStartHookOutput {
+    /// The `additional_context` field.
     pub additional_context: bool,
+    /// The `metadata` field.
     pub metadata: bool,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+/// Native message type for `gestalt.provider.v1.GetAgentProviderSessionRequest`.
 pub struct GetAgentProviderSessionRequest {
+    /// The `provider_name` field.
     pub provider_name: String,
+    /// The `session_id` field.
     pub session_id: String,
+    /// The `subject` field.
     pub subject: Option<Subject>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+/// Native message type for `gestalt.provider.v1.ListAgentProviderSessionsRequest`.
 pub struct ListAgentProviderSessionsRequest {
+    /// The `provider_name` field.
     pub provider_name: String,
+    /// The `subject` field.
     pub subject: Option<Subject>,
+    /// The `session_ids` field.
     pub session_ids: Vec<String>,
+    /// The `state` field.
     pub state: AgentSessionState,
+    /// The `limit` field.
     pub limit: i32,
+    /// The `summary_only` field.
     pub summary_only: bool,
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]
+/// Native message type for `gestalt.provider.v1.ListAgentProviderSessionsResponse`.
 pub struct ListAgentProviderSessionsResponse {
+    /// The `sessions` field.
     pub sessions: Vec<AgentSession>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]
+/// Native message type for `gestalt.provider.v1.UpdateAgentProviderSessionRequest`.
 pub struct UpdateAgentProviderSessionRequest {
+    /// The `provider_name` field.
     pub provider_name: String,
+    /// The `session_id` field.
     pub session_id: String,
+    /// The `client_ref` field.
     pub client_ref: String,
+    /// The `state` field.
     pub state: AgentSessionState,
+    /// The `metadata` field.
     pub metadata: Option<AgentJson>,
+    /// The `subject` field.
     pub subject: Option<Subject>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]
+/// Native message type for `gestalt.provider.v1.AgentTurn`.
 pub struct AgentTurn {
+    /// The `id` field.
     pub id: String,
+    /// The `session_id` field.
     pub session_id: String,
+    /// The `provider_name` field.
     pub provider_name: String,
+    /// The `model` field.
     pub model: String,
+    /// The `status` field.
     pub status: AgentExecutionStatus,
+    /// The `messages` field.
     pub messages: Vec<AgentMessage>,
+    /// The `output` field.
     pub output: Option<AgentTurnOutput>,
+    /// The `status_message` field.
     pub status_message: String,
+    /// The `created_by_subject_id` field.
     pub created_by_subject_id: Option<String>,
+    /// The `created_at` field.
     pub created_at: Option<SystemTime>,
+    /// The `started_at` field.
     pub started_at: Option<SystemTime>,
+    /// The `completed_at` field.
     pub completed_at: Option<SystemTime>,
+    /// The `execution_ref` field.
     pub execution_ref: String,
 }
 
 #[derive(Debug, Clone, PartialEq)]
+/// The structured-or-text output of a finished turn.
 pub enum AgentTurnOutput {
+    /// The `Text` variant.
     Text(AgentTurnTextOutput),
+    /// The `Structured` variant.
     Structured(AgentTurnStructuredOutput),
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+/// Native message type for `gestalt.provider.v1.AgentTurnTextOutput`.
 pub struct AgentTurnTextOutput {
+    /// The `text` field.
     pub text: String,
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]
+/// Native message type for `gestalt.provider.v1.AgentTurnStructuredOutput`.
 pub struct AgentTurnStructuredOutput {
+    /// The `text` field.
     pub text: String,
+    /// The `value` field.
     pub value: Option<AgentJson>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]
+/// Native message type for `gestalt.provider.v1.AgentTurnDisplay`.
 pub struct AgentTurnDisplay {
+    /// The `kind` field.
     pub kind: String,
+    /// The `phase` field.
     pub phase: String,
+    /// The `text` field.
     pub text: String,
+    /// The `label` field.
     pub label: String,
+    /// The `ref` field.
     pub r#ref: String,
+    /// The `parent_ref` field.
     pub parent_ref: String,
+    /// The `input` field.
     pub input: Option<AgentJson>,
+    /// The `output` field.
     pub output: Option<AgentJson>,
+    /// The `error` field.
     pub error: Option<AgentJson>,
+    /// The `action` field.
     pub action: String,
+    /// The `format` field.
     pub format: String,
+    /// The `language` field.
     pub language: String,
 }
 
 #[derive(Debug, Clone, PartialEq)]
+/// Native message type for `gestalt.provider.v1.CreateAgentProviderTurnRequest`.
 pub struct CreateAgentProviderTurnRequest {
+    /// The `provider_name` field.
     pub provider_name: String,
+    /// The `turn_id` field.
     pub turn_id: String,
+    /// The `session_id` field.
     pub session_id: String,
+    /// The `idempotency_key` field.
     pub idempotency_key: String,
+    /// The `model` field.
     pub model: String,
+    /// The `messages` field.
     pub messages: Vec<AgentMessage>,
+    /// The `output` field.
     pub output: AgentOutput,
+    /// The `metadata` field.
     pub metadata: Option<AgentJson>,
+    /// The `created_by_subject_id` field.
     pub created_by_subject_id: Option<String>,
+    /// The `execution_ref` field.
     pub execution_ref: String,
+    /// The `subject` field.
     pub subject: Option<Subject>,
+    /// The `model_options` field.
     pub model_options: Option<AgentJson>,
+    /// The `timeout_seconds` field.
     pub timeout_seconds: i32,
+    /// The `context` field.
     pub context: Option<pb::RequestContext>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
+/// Native enum for `gestalt.provider.v1.AgentOutput`.
 pub enum AgentOutput {
+    /// The `Text` variant.
     Text(AgentTextOutput),
+    /// The `Structured` variant.
     Structured(AgentStructuredOutput),
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+/// Native message type for `gestalt.provider.v1.AgentTextOutput`.
 pub struct AgentTextOutput {}
 
 #[derive(Debug, Clone, PartialEq)]
+/// Native message type for `gestalt.provider.v1.AgentStructuredOutput`.
 pub struct AgentStructuredOutput {
+    /// The `schema` field.
     pub schema: AgentJson,
 }
 
@@ -618,108 +852,175 @@ impl AgentOutput {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+/// Native message type for `gestalt.provider.v1.GetAgentProviderTurnRequest`.
 pub struct GetAgentProviderTurnRequest {
+    /// The `provider_name` field.
     pub provider_name: String,
+    /// The `turn_id` field.
     pub turn_id: String,
+    /// The `subject` field.
     pub subject: Option<Subject>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+/// Native message type for `gestalt.provider.v1.ListAgentProviderTurnsRequest`.
 pub struct ListAgentProviderTurnsRequest {
+    /// The `provider_name` field.
     pub provider_name: String,
+    /// The `session_id` field.
     pub session_id: String,
+    /// The `subject` field.
     pub subject: Option<Subject>,
+    /// The `turn_ids` field.
     pub turn_ids: Vec<String>,
+    /// The `status` field.
     pub status: AgentExecutionStatus,
+    /// The `limit` field.
     pub limit: i32,
+    /// The `summary_only` field.
     pub summary_only: bool,
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]
+/// Native message type for `gestalt.provider.v1.ListAgentProviderTurnsResponse`.
 pub struct ListAgentProviderTurnsResponse {
+    /// The `turns` field.
     pub turns: Vec<AgentTurn>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+/// Native message type for `gestalt.provider.v1.CancelAgentProviderTurnRequest`.
 pub struct CancelAgentProviderTurnRequest {
+    /// The `provider_name` field.
     pub provider_name: String,
+    /// The `turn_id` field.
     pub turn_id: String,
+    /// The `reason` field.
     pub reason: String,
+    /// The `subject` field.
     pub subject: Option<Subject>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]
+/// Native message type for `gestalt.provider.v1.AgentTurnEvent`.
 pub struct AgentTurnEvent {
+    /// The `id` field.
     pub id: String,
+    /// The `turn_id` field.
     pub turn_id: String,
+    /// The `seq` field.
     pub seq: i64,
+    /// The `type` field.
     pub r#type: String,
+    /// The `source` field.
     pub source: String,
+    /// The `visibility` field.
     pub visibility: String,
+    /// The `data` field.
     pub data: Option<AgentJson>,
+    /// The `created_at` field.
     pub created_at: Option<SystemTime>,
+    /// The `display` field.
     pub display: Option<AgentTurnDisplay>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+/// Native message type for `gestalt.provider.v1.ListAgentProviderTurnEventsRequest`.
 pub struct ListAgentProviderTurnEventsRequest {
+    /// The `provider_name` field.
     pub provider_name: String,
+    /// The `turn_id` field.
     pub turn_id: String,
+    /// The `after_seq` field.
     pub after_seq: i64,
+    /// The `limit` field.
     pub limit: i32,
+    /// The `subject` field.
     pub subject: Option<Subject>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]
+/// Native message type for `gestalt.provider.v1.ListAgentProviderTurnEventsResponse`.
 pub struct ListAgentProviderTurnEventsResponse {
+    /// The `events` field.
     pub events: Vec<AgentTurnEvent>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+/// Native message type for `gestalt.provider.v1.GetAgentProviderInteractionRequest`.
 pub struct GetAgentProviderInteractionRequest {
+    /// The `interaction_id` field.
     pub interaction_id: String,
+    /// The `subject` field.
     pub subject: Option<Subject>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+/// Native message type for `gestalt.provider.v1.ListAgentProviderInteractionsRequest`.
 pub struct ListAgentProviderInteractionsRequest {
+    /// The `provider_name` field.
     pub provider_name: String,
+    /// The `turn_id` field.
     pub turn_id: String,
+    /// The `subject` field.
     pub subject: Option<Subject>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]
+/// Native message type for `gestalt.provider.v1.ListAgentProviderInteractionsResponse`.
 pub struct ListAgentProviderInteractionsResponse {
+    /// The `interactions` field.
     pub interactions: Vec<AgentInteraction>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]
+/// Native message type for `gestalt.provider.v1.ResolveAgentProviderInteractionRequest`.
 pub struct ResolveAgentProviderInteractionRequest {
+    /// The `provider_name` field.
     pub provider_name: String,
+    /// The `interaction_id` field.
     pub interaction_id: String,
+    /// The `resolution` field.
     pub resolution: Option<AgentJson>,
+    /// The `subject` field.
     pub subject: Option<Subject>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+/// MCP-style behavior hints of a tool.
 pub struct AgentToolAnnotations {
+    /// The `read_only_hint` field.
     pub read_only_hint: Option<bool>,
+    /// The `idempotent_hint` field.
     pub idempotent_hint: Option<bool>,
+    /// The `destructive_hint` field.
     pub destructive_hint: Option<bool>,
+    /// The `open_world_hint` field.
     pub open_world_hint: Option<bool>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]
+/// Native message type for `gestalt.provider.v1.ListedAgentTool`.
 pub struct ListedAgentTool {
+    /// The `id` field.
     pub id: String,
+    /// The `mcp_name` field.
     pub mcp_name: String,
+    /// The `title` field.
     pub title: String,
+    /// The `description` field.
     pub description: String,
+    /// The `input_schema` field.
     pub input_schema: String,
+    /// The `output_schema` field.
     pub output_schema: String,
+    /// The `annotations` field.
     pub annotations: Option<AgentToolAnnotations>,
+    /// The `ref` field.
     pub r#ref: Option<AgentToolRef>,
+    /// The `tags` field.
     pub tags: Vec<String>,
+    /// The `search_text` field.
     pub search_text: String,
 }
 

--- a/sdk/rust/src/auth.rs
+++ b/sdk/rust/src/auth.rs
@@ -8,41 +8,57 @@ use crate::error::{Error, Result};
 /// Normalized user identity returned by an authentication provider.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AuthenticatedUser {
+    /// The `subject` field.
     pub subject: String,
+    /// The `email` field.
     pub email: String,
+    /// The `email_verified` field.
     pub email_verified: bool,
+    /// The `display_name` field.
     pub display_name: String,
+    /// The `avatar_url` field.
     pub avatar_url: String,
+    /// The `claims` field.
     pub claims: std::collections::BTreeMap<String, String>,
 }
 
 /// Starts an interactive login flow.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct BeginLoginRequest {
+    /// The `callback_url` field.
     pub callback_url: String,
+    /// The `host_state` field.
     pub host_state: String,
+    /// The `scopes` field.
     pub scopes: Vec<String>,
+    /// The `options` field.
     pub options: std::collections::BTreeMap<String, String>,
 }
 
 /// Provider-managed authorization URL and opaque state for login completion.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct BeginLoginResponse {
+    /// The `authorization_url` field.
     pub authorization_url: String,
+    /// The `provider_state` field.
     pub provider_state: Vec<u8>,
 }
 
 /// Finishes an interactive login flow.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct CompleteLoginRequest {
+    /// The `query` field.
     pub query: std::collections::BTreeMap<String, String>,
+    /// The `provider_state` field.
     pub provider_state: Vec<u8>,
+    /// The `callback_url` field.
     pub callback_url: String,
 }
 
 /// Host persistence settings for authenticated sessions.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub struct AuthSessionSettings {
+    /// The `session_ttl` field.
     pub session_ttl: Duration,
 }
 

--- a/sdk/rust/src/catalog.rs
+++ b/sdk/rust/src/catalog.rs
@@ -10,48 +10,76 @@ use crate::generated::v1;
 /// Catalog schema used by the provider runtime.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Catalog {
+    /// The `name` field.
     pub name: String,
+    /// The `display_name` field.
     pub display_name: String,
+    /// The `description` field.
     pub description: String,
+    /// The `icon_svg` field.
     pub icon_svg: String,
+    /// The `operations` field.
     pub operations: Vec<CatalogOperation>,
 }
 
 /// One operation exposed by a catalog.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct CatalogOperation {
+    /// The `id` field.
     pub id: String,
+    /// The `method` field.
     pub method: String,
+    /// The `title` field.
     pub title: String,
+    /// The `description` field.
     pub description: String,
+    /// The `input_schema` field.
     pub input_schema: String,
+    /// The `output_schema` field.
     pub output_schema: String,
+    /// The `annotations` field.
     pub annotations: Option<OperationAnnotations>,
+    /// The `parameters` field.
     pub parameters: Vec<CatalogParameter>,
+    /// The `required_scopes` field.
     pub required_scopes: Vec<String>,
+    /// The `tags` field.
     pub tags: Vec<String>,
+    /// The `read_only` field.
     pub read_only: bool,
+    /// The `visible` field.
     pub visible: Option<bool>,
+    /// The `transport` field.
     pub transport: String,
+    /// The `allowed_roles` field.
     pub allowed_roles: Vec<String>,
 }
 
 /// One input parameter surfaced in a generated catalog operation.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct CatalogParameter {
+    /// The `name` field.
     pub name: String,
+    /// The `type` field.
     pub r#type: String,
+    /// The `description` field.
     pub description: String,
+    /// The `required` field.
     pub required: bool,
+    /// The `default` field.
     pub default: Option<JsonValue>,
 }
 
 /// Optional host hints attached to a catalog operation.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct OperationAnnotations {
+    /// The `read_only_hint` field.
     pub read_only_hint: Option<bool>,
+    /// The `idempotent_hint` field.
     pub idempotent_hint: Option<bool>,
+    /// The `destructive_hint` field.
     pub destructive_hint: Option<bool>,
+    /// The `open_world_hint` field.
     pub open_world_hint: Option<bool>,
 }
 

--- a/sdk/rust/src/indexeddb_provider.rs
+++ b/sdk/rust/src/indexeddb_provider.rs
@@ -158,7 +158,9 @@ pub struct TransactionOptions {
 #[async_trait]
 /// Fakeable client contract for IndexedDB-compatible storage.
 pub trait IndexedDBApi: Send {
+    /// The store handle this scope yields.
     type ObjectStore: ObjectStoreApi;
+    /// The transaction handle this database yields.
     type Transaction: TransactionApi;
 
     /// Creates a named object store and returns a typed handle for it.
@@ -186,7 +188,9 @@ pub trait IndexedDBApi: Send {
 #[async_trait]
 /// Fakeable IndexedDB object-store contract.
 pub trait ObjectStoreApi: Send {
+    /// The index handle this store yields.
     type Index: IndexApi;
+    /// The cursor handle this scope yields.
     type Cursor: CursorApi;
 
     /// Loads one record by primary key.
@@ -243,6 +247,7 @@ pub trait ObjectStoreApi: Send {
 #[async_trait]
 /// Fakeable IndexedDB secondary-index contract.
 pub trait IndexApi: Send {
+    /// The cursor handle this scope yields.
     type Cursor: CursorApi;
 
     /// Loads the first row that matches values.
@@ -302,6 +307,7 @@ pub trait IndexApi: Send {
 #[async_trait]
 /// Fakeable explicit IndexedDB transaction contract.
 pub trait TransactionApi: Send {
+    /// The transaction-scoped store handle.
     type ObjectStore<'a>: TransactionObjectStoreApi + 'a
     where
         Self: 'a;
@@ -319,6 +325,7 @@ pub trait TransactionApi: Send {
 #[async_trait]
 /// Fakeable transaction-scoped object-store contract.
 pub trait TransactionObjectStoreApi: Send {
+    /// The transaction-scoped index handle.
     type Index<'a>: TransactionIndexApi + 'a
     where
         Self: 'a;

--- a/sdk/rust/src/invoke_support.rs
+++ b/sdk/rust/src/invoke_support.rs
@@ -9,12 +9,19 @@ use crate::rpc_support::GestaltError;
 #[derive(Clone, Debug, thiserror::Error)]
 #[error("{message}")]
 pub struct InvokeResultError {
+    /// The invoked app.
     pub app: String,
+    /// The invoked operation.
     pub operation: String,
+    /// The HTTP status when the result carried one.
     pub status: Option<u16>,
+    /// The error envelope's code when present.
     pub code: Option<String>,
+    /// The failure message.
     pub message: String,
+    /// The decoded result body when it parsed as JSON.
     pub body: Option<Box<Value>>,
+    /// The raw result body bytes.
     pub raw_body: Vec<u8>,
 }
 
@@ -22,8 +29,10 @@ pub struct InvokeResultError {
 /// result carried a payload failure.
 #[derive(Debug, thiserror::Error)]
 pub enum InvokeError {
+    /// The transport failed before a result decoded.
     #[error(transparent)]
     Transport(#[from] GestaltError),
+    /// The decoded result carried a payload failure.
     #[error(transparent)]
     Result(#[from] Box<InvokeResultError>),
 }

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(rustdoc::broken_intra_doc_links)]
+#![deny(missing_docs)]
 #![doc = include_str!("../README.md")]
 
 /// Generated Agent client and native types.
@@ -24,10 +25,14 @@ mod env;
 mod error;
 /// Generated ExternalCredentials client and native types.
 pub mod external_credential;
+// The prost wire module is reachable only through the doc-hidden proto
+// escape hatch; its items are not part of the documented surface.
+#[allow(missing_docs)]
 mod generated;
 /// Generated IndexedDB client and native types.
 pub mod indexeddb;
 mod indexeddb_provider;
+/// Decoded app invocation results and the canonical invoke error.
 pub mod invoke_support;
 mod protocol;
 mod provider_server;

--- a/sdk/rust/src/runtime_log_host.rs
+++ b/sdk/rust/src/runtime_log_host.rs
@@ -25,9 +25,13 @@ const RUNTIME_LOG_RELAY_TOKEN_HEADER: &str = "x-gestalt-host-service-relay-token
 /// Runtime log stream for runtime log entries.
 pub enum RuntimeLogStream {
     #[default]
+    /// The `Unspecified` variant.
     Unspecified = 0,
+    /// The `Stdout` variant.
     Stdout = 1,
+    /// The `Stderr` variant.
     Stderr = 2,
+    /// The `Runtime` variant.
     Runtime = 3,
 }
 
@@ -40,22 +44,29 @@ impl RuntimeLogStream {
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// One runtime log entry.
 pub struct RuntimeLogEntry {
+    /// The `stream` field.
     pub stream: RuntimeLogStream,
+    /// The `message` field.
     pub message: String,
+    /// The `observed_at` field.
     pub observed_at: SystemTime,
+    /// The `source_seq` field.
     pub source_seq: i64,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 /// Request for appending runtime logs.
 pub struct AppendRuntimeLogsRequest {
+    /// The `session_id` field.
     pub session_id: String,
+    /// The `logs` field.
     pub logs: Vec<RuntimeLogEntry>,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 /// Response returned after appending runtime logs.
 pub struct AppendRuntimeLogsResponse {
+    /// The `last_seq` field.
     pub last_seq: i64,
 }
 

--- a/sdk/rust/src/runtime_provider_impl.rs
+++ b/sdk/rust/src/runtime_provider_impl.rs
@@ -13,19 +13,27 @@ use crate::rpc_status::rpc_status;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 #[repr(i32)]
+/// Native enum for `gestalt.provider.v1.RuntimeEgressMode`.
 pub enum RuntimeEgressMode {
     #[default]
+    /// The `Unspecified` variant.
     Unspecified = 0,
+    /// The `None` variant.
     None = 1,
+    /// The `Cidr` variant.
     Cidr = 2,
+    /// The `Hostname` variant.
     Hostname = 3,
 }
 
 impl RuntimeEgressMode {
+    /// Returns the wire integer for this value.
     pub const fn as_i32(self) -> i32 {
         self as i32
     }
 
+    /// Converts a wire integer, mapping unknown values to the unspecified
+    /// variant.
     pub const fn from_i32_lossy(value: i32) -> Self {
         match value {
             1 => Self::None,
@@ -37,101 +45,158 @@ impl RuntimeEgressMode {
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+/// Native message type for `gestalt.provider.v1.RuntimeSupport`.
 pub struct RuntimeSupport {
+    /// The `can_host_apps` field.
     pub can_host_apps: bool,
+    /// The `egress_mode` field.
     pub egress_mode: RuntimeEgressMode,
+    /// The `supports_prepare_workspace` field.
     pub supports_prepare_workspace: bool,
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
+/// Native message type for `gestalt.provider.v1.RuntimeSession`.
 pub struct RuntimeSession {
+    /// The `id` field.
     pub id: String,
+    /// The `state` field.
     pub state: String,
+    /// The `metadata` field.
     pub metadata: std::collections::BTreeMap<String, String>,
+    /// The `lifecycle` field.
     pub lifecycle: Option<RuntimeSessionLifecycle>,
+    /// The `state_reason` field.
     pub state_reason: String,
+    /// The `state_message` field.
     pub state_message: String,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+/// Native message type for `gestalt.provider.v1.RuntimeSessionLifecycle`.
 pub struct RuntimeSessionLifecycle {
+    /// The `started_at` field.
     pub started_at: Option<SystemTime>,
+    /// The `recommended_drain_at` field.
     pub recommended_drain_at: Option<SystemTime>,
+    /// The `expires_at` field.
     pub expires_at: Option<SystemTime>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
+/// Native message type for `gestalt.provider.v1.RuntimeImagePullAuth`.
 pub struct RuntimeImagePullAuth {
+    /// The `docker_config_json` field.
     pub docker_config_json: String,
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
+/// Native message type for `gestalt.provider.v1.StartRuntimeSessionRequest`.
 pub struct StartRuntimeSessionRequest {
+    /// The `app_name` field.
     pub app_name: String,
+    /// The `template` field.
     pub template: String,
+    /// The `image` field.
     pub image: String,
+    /// The `metadata` field.
     pub metadata: std::collections::BTreeMap<String, String>,
+    /// The `image_pull_auth` field.
     pub image_pull_auth: Option<RuntimeImagePullAuth>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
+/// Native message type for `gestalt.provider.v1.GetRuntimeSessionRequest`.
 pub struct GetRuntimeSessionRequest {
+    /// The `session_id` field.
     pub session_id: String,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
+/// Native message type for `gestalt.provider.v1.ListRuntimeSessionsRequest`.
 pub struct ListRuntimeSessionsRequest {
+    /// The `page_size` field.
     pub page_size: i32,
+    /// The `page_token` field.
     pub page_token: String,
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
+/// Native message type for `gestalt.provider.v1.ListRuntimeSessionsResponse`.
 pub struct ListRuntimeSessionsResponse {
+    /// The `sessions` field.
     pub sessions: Vec<RuntimeSession>,
+    /// The `next_page_token` field.
     pub next_page_token: String,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
+/// Native message type for `gestalt.provider.v1.StopRuntimeSessionRequest`.
 pub struct StopRuntimeSessionRequest {
+    /// The `session_id` field.
     pub session_id: String,
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
+/// Native message type for `gestalt.provider.v1.PrepareRuntimeWorkspaceRequest`.
 pub struct PrepareRuntimeWorkspaceRequest {
+    /// The `session_id` field.
     pub session_id: String,
+    /// The `agent_session_id` field.
     pub agent_session_id: String,
+    /// The `workspace` field.
     pub workspace: Option<AgentWorkspace>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
+/// Native message type for `gestalt.provider.v1.PrepareRuntimeWorkspaceResponse`.
 pub struct PrepareRuntimeWorkspaceResponse {
+    /// The `workspace` field.
     pub workspace: Option<AgentPreparedWorkspace>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
+/// Native message type for `gestalt.provider.v1.RemoveRuntimeWorkspaceRequest`.
 pub struct RemoveRuntimeWorkspaceRequest {
+    /// The `session_id` field.
     pub session_id: String,
+    /// The `agent_session_id` field.
     pub agent_session_id: String,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
+/// Native message type for `gestalt.provider.v1.StartHostedAppRequest`.
 pub struct StartHostedAppRequest {
+    /// The `session_id` field.
     pub session_id: String,
+    /// The `app_name` field.
     pub app_name: String,
+    /// The `command` field.
     pub command: String,
+    /// The `args` field.
     pub args: Vec<String>,
+    /// The `env` field.
     pub env: std::collections::BTreeMap<String, String>,
+    /// The `allowed_hosts` field.
     pub allowed_hosts: Vec<String>,
+    /// The `default_action` field.
     pub default_action: String,
+    /// The `host_binary` field.
     pub host_binary: String,
+    /// The `workdir` field.
     pub workdir: String,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
+/// Native message type for `gestalt.provider.v1.HostedApp`.
 pub struct HostedApp {
+    /// The `id` field.
     pub id: String,
+    /// The `session_id` field.
     pub session_id: String,
+    /// The `app_name` field.
     pub app_name: String,
+    /// The `dial_target` field.
     pub dial_target: String,
 }
 

--- a/sdk/rust/src/s3_provider.rs
+++ b/sdk/rust/src/s3_provider.rs
@@ -22,29 +22,43 @@ type S3RpcReadObjectStream =
 #[derive(Clone, Debug, PartialEq)]
 /// One frame in a provider-authored object read stream.
 pub enum S3ReadObjectFrame {
+    /// The `Meta` variant.
     Meta(ObjectMeta),
+    /// The `Data` variant.
     Data(Vec<u8>),
 }
 
 #[derive(Clone, Debug, PartialEq)]
 /// One frame in a provider-backed object write stream.
 pub enum S3WriteObjectFrame {
+    /// The `Open` variant.
     Open(Box<S3WriteObjectOpen>),
+    /// The `Data` variant.
     Data(Vec<u8>),
+    /// The `Empty` variant.
     Empty,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 /// Metadata frame that starts an object write stream.
 pub struct S3WriteObjectOpen {
+    /// The `reference` field.
     pub reference: Option<ObjectRef>,
+    /// The `content_type` field.
     pub content_type: String,
+    /// The `cache_control` field.
     pub cache_control: String,
+    /// The `content_disposition` field.
     pub content_disposition: String,
+    /// The `content_encoding` field.
     pub content_encoding: String,
+    /// The `content_language` field.
     pub content_language: String,
+    /// The `metadata` field.
     pub metadata: BTreeMap<String, String>,
+    /// The `if_match` field.
     pub if_match: String,
+    /// The `if_none_match` field.
     pub if_none_match: String,
 }
 
@@ -125,89 +139,123 @@ pub enum PresignMethod {
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 /// Fetches metadata for one object.
 pub struct HeadObjectRequest {
+    /// The `reference` field.
     pub reference: Option<ObjectRef>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
 /// Returns object metadata.
 pub struct HeadObjectResponse {
+    /// The `meta` field.
     pub meta: Option<ObjectMeta>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
 /// Opens a streaming object read.
 pub struct ReadObjectRequest {
+    /// The `reference` field.
     pub reference: Option<ObjectRef>,
+    /// The `range` field.
     pub range: Option<ByteRange>,
+    /// The `if_match` field.
     pub if_match: String,
+    /// The `if_none_match` field.
     pub if_none_match: String,
+    /// The `if_modified_since` field.
     pub if_modified_since: Option<SystemTime>,
+    /// The `if_unmodified_since` field.
     pub if_unmodified_since: Option<SystemTime>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
 /// Returns metadata for a committed object write.
 pub struct WriteObjectResponse {
+    /// The `meta` field.
     pub meta: Option<ObjectMeta>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 /// Deletes one object.
 pub struct DeleteObjectRequest {
+    /// The `reference` field.
     pub reference: Option<ObjectRef>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 /// Lists objects in the provider's configured bucket.
 pub struct ListObjectsRequest {
+    /// The `prefix` field.
     pub prefix: String,
+    /// The `delimiter` field.
     pub delimiter: String,
+    /// The `continuation_token` field.
     pub continuation_token: String,
+    /// The `start_after` field.
     pub start_after: String,
+    /// The `max_keys` field.
     pub max_keys: i32,
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
 /// One page of list-objects results.
 pub struct ListObjectsResponse {
+    /// The `objects` field.
     pub objects: Vec<ObjectMeta>,
+    /// The `common_prefixes` field.
     pub common_prefixes: Vec<String>,
+    /// The `next_continuation_token` field.
     pub next_continuation_token: String,
+    /// The `has_more` field.
     pub has_more: bool,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 /// Copies one object to another location.
 pub struct CopyObjectRequest {
+    /// The `source` field.
     pub source: Option<ObjectRef>,
+    /// The `destination` field.
     pub destination: Option<ObjectRef>,
+    /// The `if_match` field.
     pub if_match: String,
+    /// The `if_none_match` field.
     pub if_none_match: String,
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
 /// Returns metadata for a copied object.
 pub struct CopyObjectResponse {
+    /// The `meta` field.
     pub meta: Option<ObjectMeta>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 /// Asks the provider to mint a presigned URL.
 pub struct PresignObjectRequest {
+    /// The `reference` field.
     pub reference: Option<ObjectRef>,
+    /// The `method` field.
     pub method: PresignMethod,
+    /// The `expires` field.
     pub expires: Duration,
+    /// The `content_type` field.
     pub content_type: String,
+    /// The `content_disposition` field.
     pub content_disposition: String,
+    /// The `headers` field.
     pub headers: BTreeMap<String, String>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
 /// Returns a presigned URL plus required headers.
 pub struct PresignObjectResponse {
+    /// The `url` field.
     pub url: String,
+    /// The `method` field.
     pub method: PresignMethod,
+    /// The `expires_at` field.
     pub expires_at: Option<SystemTime>,
+    /// The `headers` field.
     pub headers: BTreeMap<String, String>,
 }
 

--- a/sdk/rust/src/workflow_provider.rs
+++ b/sdk/rust/src/workflow_provider.rs
@@ -18,146 +18,217 @@ pub type WorkflowJson = serde_json::Value;
 
 pub use pb::{workflow_activation, workflow_run_trigger, workflow_step, workflow_value};
 
+/// Alias for `pb::BoundWorkflowTarget`.
 pub type BoundWorkflowTarget = pb::BoundWorkflowTarget;
+/// Alias for `pb::WorkflowStep`.
 pub type WorkflowStep = pb::WorkflowStep;
+/// Alias for `pb::workflow_step::Action`.
 pub type WorkflowStepAction = pb::workflow_step::Action;
+/// Alias for `pb::WorkflowStepAppCall`.
 pub type WorkflowStepAppCall = pb::WorkflowStepAppCall;
+/// Alias for `pb::WorkflowStepAgentTurn`.
 pub type WorkflowStepAgentTurn = pb::WorkflowStepAgentTurn;
+/// Alias for `pb::WorkflowAgentMessage`.
 pub type WorkflowAgentMessage = pb::WorkflowAgentMessage;
+/// Alias for `pb::WorkflowText`.
 pub type WorkflowText = pb::WorkflowText;
+/// Alias for `pb::WorkflowStepWhen`.
 pub type WorkflowStepWhen = pb::WorkflowStepWhen;
+/// Alias for `pb::WorkflowValue`.
 pub type WorkflowValue = pb::WorkflowValue;
+/// Alias for `pb::WorkflowObject`.
 pub type WorkflowObject = pb::WorkflowObject;
+/// Alias for `pb::WorkflowArray`.
 pub type WorkflowArray = pb::WorkflowArray;
+/// Alias for `pb::WorkflowPathSource`.
 pub type WorkflowPathSource = pb::WorkflowPathSource;
+/// Alias for `pb::WorkflowStepOutputSource`.
 pub type WorkflowStepOutputSource = pb::WorkflowStepOutputSource;
+/// Alias for `pb::WorkflowStepInputSource`.
 pub type WorkflowStepInputSource = pb::WorkflowStepInputSource;
+/// Alias for `pb::WorkflowEvent`.
 pub type WorkflowEvent = pb::WorkflowEvent;
+/// Alias for `pb::WorkflowEventMatch`.
 pub type WorkflowEventMatch = pb::WorkflowEventMatch;
+/// Alias for `pb::WorkflowScheduleActivation`.
 pub type WorkflowScheduleActivation = pb::WorkflowScheduleActivation;
+/// Alias for `pb::WorkflowEventActivation`.
 pub type WorkflowEventActivation = pb::WorkflowEventActivation;
+/// Alias for `pb::WorkflowActivation`.
 pub type WorkflowActivation = pb::WorkflowActivation;
+/// Alias for `pb::WorkflowDefinitionSpec`.
 pub type WorkflowDefinitionSpec = pb::WorkflowDefinitionSpec;
+/// Alias for `pb::WorkflowDefinition`.
 pub type WorkflowDefinition = pb::WorkflowDefinition;
+/// Alias for `pb::WorkflowManualTrigger`.
 pub type WorkflowManualTrigger = pb::WorkflowManualTrigger;
+/// Alias for `pb::WorkflowScheduleTrigger`.
 pub type WorkflowScheduleTrigger = pb::WorkflowScheduleTrigger;
+/// Alias for `pb::WorkflowEventTriggerInvocation`.
 pub type WorkflowEventTriggerInvocation = pb::WorkflowEventTriggerInvocation;
+/// Alias for `pb::WorkflowRunTrigger`.
 pub type WorkflowRunTrigger = pb::WorkflowRunTrigger;
+/// Alias for `pb::WorkflowStepAttempt`.
 pub type WorkflowStepAttempt = pb::WorkflowStepAttempt;
+/// Alias for `pb::WorkflowStepExecution`.
 pub type WorkflowStepExecution = pb::WorkflowStepExecution;
+/// Alias for `pb::WorkflowRun`.
 pub type WorkflowRun = pb::WorkflowRun;
+/// Alias for `pb::WorkflowSignal`.
 pub type WorkflowSignal = pb::WorkflowSignal;
+/// Alias for `pb::SignalWorkflowRunResponse`.
 pub type SignalWorkflowRunResponse = pb::SignalWorkflowRunResponse;
+/// Alias for `pb::WorkflowRunEvent`.
 pub type WorkflowRunEvent = pb::WorkflowRunEvent;
+/// Alias for `pb::WorkflowRunStatus`.
 pub type WorkflowRunStatus = pb::WorkflowRunStatus;
+/// Alias for `pb::WorkflowStepStatus`.
 pub type WorkflowStepStatus = pb::WorkflowStepStatus;
 
+/// Alias for `pb::ApplyWorkflowProviderDefinitionRequest`.
 pub type ApplyWorkflowProviderDefinitionRequest = pb::ApplyWorkflowProviderDefinitionRequest;
+/// Alias for `pb::GetWorkflowProviderDefinitionRequest`.
 pub type GetWorkflowProviderDefinitionRequest = pb::GetWorkflowProviderDefinitionRequest;
+/// Alias for `pb::ListWorkflowProviderDefinitionsRequest`.
 pub type ListWorkflowProviderDefinitionsRequest = pb::ListWorkflowProviderDefinitionsRequest;
+/// Alias for `pb::ListWorkflowProviderDefinitionsResponse`.
 pub type ListWorkflowProviderDefinitionsResponse = pb::ListWorkflowProviderDefinitionsResponse;
+/// Alias for the definitionpaused request message.
 pub type SetWorkflowProviderDefinitionPausedRequest =
     pb::SetWorkflowProviderDefinitionPausedRequest;
+/// Alias for the activationpaused request message.
 pub type SetWorkflowProviderActivationPausedRequest =
     pb::SetWorkflowProviderActivationPausedRequest;
+/// Alias for `pb::DeleteWorkflowProviderDefinitionRequest`.
 pub type DeleteWorkflowProviderDefinitionRequest = pb::DeleteWorkflowProviderDefinitionRequest;
+/// Alias for `pb::StartWorkflowProviderRunRequest`.
 pub type StartWorkflowProviderRunRequest = pb::StartWorkflowProviderRunRequest;
+/// Alias for `pb::GetWorkflowProviderRunRequest`.
 pub type GetWorkflowProviderRunRequest = pb::GetWorkflowProviderRunRequest;
+/// Alias for `pb::ListWorkflowProviderRunsRequest`.
 pub type ListWorkflowProviderRunsRequest = pb::ListWorkflowProviderRunsRequest;
+/// Alias for `pb::ListWorkflowProviderRunsResponse`.
 pub type ListWorkflowProviderRunsResponse = pb::ListWorkflowProviderRunsResponse;
+/// Alias for `pb::GetWorkflowProviderRunEventsRequest`.
 pub type GetWorkflowProviderRunEventsRequest = pb::GetWorkflowProviderRunEventsRequest;
+/// Alias for `pb::GetWorkflowProviderRunEventsResponse`.
 pub type GetWorkflowProviderRunEventsResponse = pb::GetWorkflowProviderRunEventsResponse;
+/// Alias for `pb::GetWorkflowProviderRunOutputRequest`.
 pub type GetWorkflowProviderRunOutputRequest = pb::GetWorkflowProviderRunOutputRequest;
+/// Alias for `pb::GetWorkflowProviderRunOutputResponse`.
 pub type GetWorkflowProviderRunOutputResponse = pb::GetWorkflowProviderRunOutputResponse;
+/// Alias for `pb::CancelWorkflowProviderRunRequest`.
 pub type CancelWorkflowProviderRunRequest = pb::CancelWorkflowProviderRunRequest;
+/// Alias for `pb::SignalWorkflowProviderRunRequest`.
 pub type SignalWorkflowProviderRunRequest = pb::SignalWorkflowProviderRunRequest;
+/// Alias for `pb::SignalOrStartWorkflowProviderRunRequest`.
 pub type SignalOrStartWorkflowProviderRunRequest = pb::SignalOrStartWorkflowProviderRunRequest;
+/// Alias for `pb::DeliverWorkflowProviderEventRequest`.
 pub type DeliverWorkflowProviderEventRequest = pb::DeliverWorkflowProviderEventRequest;
 
+/// Validates and returns the bound workflow target value.
 pub fn new_bound_workflow_target(
     input: BoundWorkflowTarget,
 ) -> ProviderResult<BoundWorkflowTarget> {
     Ok(input)
 }
 
+/// Builds the value from an existing target.
 pub fn new_bound_workflow_target_from_target(
     input: &BoundWorkflowTarget,
 ) -> ProviderResult<BoundWorkflowTarget> {
     Ok(input.clone())
 }
 
+/// Validates and returns the workflow definition spec value.
 pub fn new_workflow_definition_spec(
     input: WorkflowDefinitionSpec,
 ) -> ProviderResult<WorkflowDefinitionSpec> {
     Ok(input)
 }
 
+/// Validates and returns the workflow definition value.
 pub fn new_workflow_definition(input: WorkflowDefinition) -> ProviderResult<WorkflowDefinition> {
     Ok(input)
 }
 
+/// Validates and returns the workflow run value.
 pub fn new_workflow_run(input: WorkflowRun) -> ProviderResult<WorkflowRun> {
     Ok(input)
 }
 
+/// Builds the value from an existing run.
 pub fn new_workflow_run_from_run(input: &WorkflowRun) -> ProviderResult<WorkflowRun> {
     Ok(input.clone())
 }
 
+/// Validates and returns the workflow event value.
 pub fn new_workflow_event(input: WorkflowEvent) -> ProviderResult<WorkflowEvent> {
     Ok(input)
 }
 
+/// Builds the value from an existing event.
 pub fn new_workflow_event_from_event(input: &WorkflowEvent) -> ProviderResult<WorkflowEvent> {
     Ok(input.clone())
 }
 
+/// Validates and returns the workflow event match value.
 pub fn new_workflow_event_match(input: WorkflowEventMatch) -> WorkflowEventMatch {
     input
 }
 
+/// Validates and returns the workflow signal value.
 pub fn new_workflow_signal(input: WorkflowSignal) -> ProviderResult<WorkflowSignal> {
     Ok(input)
 }
 
+/// Builds the value from an existing signal.
 pub fn new_workflow_signal_from_signal(input: &WorkflowSignal) -> ProviderResult<WorkflowSignal> {
     Ok(input.clone())
 }
 
+/// Validates and returns the workflow step value.
 pub fn new_workflow_step(input: WorkflowStep) -> ProviderResult<WorkflowStep> {
     Ok(input)
 }
 
+/// Validates and returns the workflow step app call value.
 pub fn new_workflow_step_app_call(
     input: WorkflowStepAppCall,
 ) -> ProviderResult<WorkflowStepAppCall> {
     Ok(input)
 }
 
+/// Validates and returns the workflow step agent turn value.
 pub fn new_workflow_step_agent_turn(
     input: WorkflowStepAgentTurn,
 ) -> ProviderResult<WorkflowStepAgentTurn> {
     Ok(input)
 }
 
+/// Validates and returns the workflow agent message value.
 pub fn new_workflow_agent_message(
     input: WorkflowAgentMessage,
 ) -> ProviderResult<WorkflowAgentMessage> {
     Ok(input)
 }
 
+/// Validates and returns the workflow step when value.
 pub fn new_workflow_step_when(input: WorkflowStepWhen) -> ProviderResult<WorkflowStepWhen> {
     Ok(input)
 }
 
+/// Validates and returns the workflow text value.
 pub fn new_workflow_text(input: WorkflowText) -> WorkflowText {
     input
 }
 
+/// Validates and returns the workflow value value.
 pub fn new_workflow_value(input: WorkflowValue) -> ProviderResult<WorkflowValue> {
     Ok(input)
 }
 
+/// Builds a workflow value carrying a literal JSON value.
 pub fn workflow_value_literal<T: Serialize>(value: T) -> ProviderResult<WorkflowValue> {
     Ok(WorkflowValue {
         kind: Some(workflow_value::Kind::Literal(protocol::value_from_json(
@@ -166,18 +237,21 @@ pub fn workflow_value_literal<T: Serialize>(value: T) -> ProviderResult<Workflow
     })
 }
 
+/// Builds a workflow value from named member values.
 pub fn workflow_value_object(fields: BTreeMap<String, WorkflowValue>) -> WorkflowValue {
     WorkflowValue {
         kind: Some(workflow_value::Kind::Object(WorkflowObject { fields })),
     }
 }
 
+/// Builds a workflow value from element values.
 pub fn workflow_value_array(values: Vec<WorkflowValue>) -> WorkflowValue {
     WorkflowValue {
         kind: Some(workflow_value::Kind::Array(WorkflowArray { values })),
     }
 }
 
+/// Builds a workflow value rendered from a text template.
 pub fn workflow_value_template(template: impl Into<String>) -> WorkflowValue {
     WorkflowValue {
         kind: Some(workflow_value::Kind::Template(WorkflowText {
@@ -186,6 +260,7 @@ pub fn workflow_value_template(template: impl Into<String>) -> WorkflowValue {
     }
 }
 
+/// Builds a workflow value read from a run input path.
 pub fn workflow_value_input(path: impl Into<String>) -> WorkflowValue {
     WorkflowValue {
         kind: Some(workflow_value::Kind::Input(WorkflowPathSource {
@@ -194,6 +269,7 @@ pub fn workflow_value_input(path: impl Into<String>) -> WorkflowValue {
     }
 }
 
+/// Builds a workflow value read from a delivered signal path.
 pub fn workflow_value_signal(path: impl Into<String>) -> WorkflowValue {
     WorkflowValue {
         kind: Some(workflow_value::Kind::Signal(WorkflowPathSource {
@@ -202,6 +278,7 @@ pub fn workflow_value_signal(path: impl Into<String>) -> WorkflowValue {
     }
 }
 
+/// Builds a workflow value read from a prior step's output.
 pub fn workflow_value_step_output(
     step_id: impl Into<String>,
     path: impl Into<String>,
@@ -214,6 +291,7 @@ pub fn workflow_value_step_output(
     }
 }
 
+/// Builds a workflow value read from a step's input.
 pub fn workflow_value_step_input(
     step_id: impl Into<String>,
     path: impl Into<String>,
@@ -226,36 +304,44 @@ pub fn workflow_value_step_input(
     }
 }
 
+/// Builds the input form of an existing event.
 pub fn workflow_event_input_from_event(input: &WorkflowEvent) -> WorkflowEvent {
     input.clone()
 }
 
+/// Builds the input form of an existing match.
 pub fn workflow_event_match_input_from_match(input: &WorkflowEventMatch) -> WorkflowEventMatch {
     input.clone()
 }
 
+/// Builds the input form of an existing signal.
 pub fn workflow_signal_input_from_signal(input: &WorkflowSignal) -> WorkflowSignal {
     input.clone()
 }
 
+/// Builds the input form of an existing step.
 pub fn workflow_step_input_from_step(input: &WorkflowStep) -> WorkflowStep {
     input.clone()
 }
 
+/// Builds the input form of an existing call.
 pub fn workflow_step_app_call_input_from_call(input: &WorkflowStepAppCall) -> WorkflowStepAppCall {
     input.clone()
 }
 
+/// Builds the input form of an existing turn.
 pub fn workflow_step_agent_turn_input_from_turn(
     input: &WorkflowStepAgentTurn,
 ) -> WorkflowStepAgentTurn {
     input.clone()
 }
 
+/// Builds the input form of an existing value.
 pub fn workflow_value_input_from_value(input: &WorkflowValue) -> WorkflowValue {
     input.clone()
 }
 
+/// Builds the input form of an existing trigger.
 pub fn workflow_run_trigger_input_from_trigger(input: &WorkflowRunTrigger) -> WorkflowRunTrigger {
     input.clone()
 }
@@ -297,6 +383,7 @@ pub trait WorkflowProvider: Send + Sync + 'static {
         Ok(())
     }
 
+    /// Applies a workflow definition, creating or updating it.
     async fn apply_definition(
         &self,
         _request: ApplyWorkflowProviderDefinitionRequest,
@@ -306,6 +393,7 @@ pub trait WorkflowProvider: Send + Sync + 'static {
         ))
     }
 
+    /// Fetches one workflow definition.
     async fn get_definition(
         &self,
         _request: GetWorkflowProviderDefinitionRequest,
@@ -315,6 +403,7 @@ pub trait WorkflowProvider: Send + Sync + 'static {
         ))
     }
 
+    /// Lists workflow definitions.
     async fn list_definitions(
         &self,
         _request: ListWorkflowProviderDefinitionsRequest,
@@ -324,6 +413,7 @@ pub trait WorkflowProvider: Send + Sync + 'static {
         ))
     }
 
+    /// Pauses or resumes a workflow definition.
     async fn set_definition_paused(
         &self,
         _request: SetWorkflowProviderDefinitionPausedRequest,
@@ -333,6 +423,7 @@ pub trait WorkflowProvider: Send + Sync + 'static {
         ))
     }
 
+    /// Pauses or resumes one activation.
     async fn set_activation_paused(
         &self,
         _request: SetWorkflowProviderActivationPausedRequest,
@@ -342,6 +433,7 @@ pub trait WorkflowProvider: Send + Sync + 'static {
         ))
     }
 
+    /// Deletes a workflow definition.
     async fn delete_definition(
         &self,
         _request: DeleteWorkflowProviderDefinitionRequest,
@@ -351,6 +443,7 @@ pub trait WorkflowProvider: Send + Sync + 'static {
         ))
     }
 
+    /// Starts a workflow run.
     async fn start_run(
         &self,
         _request: StartWorkflowProviderRunRequest,
@@ -360,6 +453,7 @@ pub trait WorkflowProvider: Send + Sync + 'static {
         ))
     }
 
+    /// Lists workflow runs.
     async fn list_runs(
         &self,
         _request: ListWorkflowProviderRunsRequest,
@@ -369,6 +463,7 @@ pub trait WorkflowProvider: Send + Sync + 'static {
         ))
     }
 
+    /// Fetches one workflow run.
     async fn get_run(
         &self,
         _request: GetWorkflowProviderRunRequest,
@@ -378,6 +473,7 @@ pub trait WorkflowProvider: Send + Sync + 'static {
         ))
     }
 
+    /// Fetches the events of a workflow run.
     async fn get_run_events(
         &self,
         _request: GetWorkflowProviderRunEventsRequest,
@@ -387,6 +483,7 @@ pub trait WorkflowProvider: Send + Sync + 'static {
         ))
     }
 
+    /// Fetches the output value of a workflow run.
     async fn get_run_output(
         &self,
         _request: GetWorkflowProviderRunOutputRequest,
@@ -396,6 +493,7 @@ pub trait WorkflowProvider: Send + Sync + 'static {
         ))
     }
 
+    /// Cancels a workflow run.
     async fn cancel_run(
         &self,
         _request: CancelWorkflowProviderRunRequest,
@@ -405,6 +503,7 @@ pub trait WorkflowProvider: Send + Sync + 'static {
         ))
     }
 
+    /// Signals an existing workflow run.
     async fn signal_run(
         &self,
         _request: SignalWorkflowProviderRunRequest,
@@ -414,6 +513,7 @@ pub trait WorkflowProvider: Send + Sync + 'static {
         ))
     }
 
+    /// Signals a run, starting it first when absent.
     async fn signal_or_start_run(
         &self,
         _request: SignalOrStartWorkflowProviderRunRequest,
@@ -423,6 +523,7 @@ pub trait WorkflowProvider: Send + Sync + 'static {
         ))
     }
 
+    /// Delivers an external event to the workflow engine.
     async fn deliver_event(
         &self,
         _request: DeliverWorkflowProviderEventRequest,
@@ -631,30 +732,47 @@ where
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
+/// One workflow callback execution request.
 pub struct WorkflowExecutionRequest {
+    /// The `provider_name` field.
     pub provider_name: String,
+    /// The `run_id` field.
     pub run_id: String,
+    /// The `target` field.
     pub target: Option<BoundWorkflowTarget>,
+    /// The `trigger` field.
     pub trigger: Option<WorkflowRunTrigger>,
+    /// The `input` field.
     pub input: Option<Value>,
+    /// The `metadata` field.
     pub metadata: Option<Value>,
+    /// The `signals` field.
     pub signals: Vec<WorkflowSignal>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
+/// The run context a workflow value evaluates against.
 pub struct WorkflowEvalContext {
+    /// The `request` field.
     pub request: WorkflowExecutionRequest,
+    /// The `outputs` field.
     pub outputs: BTreeMap<String, Value>,
+    /// The `inputs` field.
     pub inputs: BTreeMap<String, Value>,
+    /// The `allow_inputs` field.
     pub allow_inputs: bool,
 }
 
 #[derive(Clone, Debug, PartialEq)]
+/// The resolved value of one workflow value expression.
 pub struct WorkflowEvalResult {
+    /// The `value` field.
     pub value: Option<Value>,
+    /// The `resolved` field.
     pub resolved: bool,
 }
 
+/// Resolves one workflow value expression against a run context.
 pub fn evaluate_workflow_value(
     ctx: &WorkflowEvalContext,
     value: &WorkflowValue,
@@ -746,6 +864,7 @@ pub fn evaluate_workflow_value(
     }
 }
 
+/// Renders a workflow text template against provided values.
 pub fn render_workflow_template(ctx: &WorkflowEvalContext, template: &str) -> Result<String> {
     let mut out = String::new();
     let mut i = 0;
@@ -780,10 +899,12 @@ pub fn render_workflow_template(ctx: &WorkflowEvalContext, template: &str) -> Re
     Ok(out)
 }
 
+/// Returns the most recent delivery of a named signal.
 pub fn latest_workflow_signal(signals: &[WorkflowSignal]) -> Option<&WorkflowSignal> {
     signals.last()
 }
 
+/// Reads a dotted path from a JSON-like value.
 pub fn path_value(root: &Value, path: &str) -> Result<WorkflowEvalResult> {
     if path.trim().is_empty() {
         return Ok(WorkflowEvalResult {

--- a/sdk/tools/sdkgen/internal/emit/rust/invoke_support.rs
+++ b/sdk/tools/sdkgen/internal/emit/rust/invoke_support.rs
@@ -7,12 +7,19 @@ use crate::rpc_support::GestaltError;
 #[derive(Clone, Debug, thiserror::Error)]
 #[error("{message}")]
 pub struct InvokeResultError {
+    /// The invoked app.
     pub app: String,
+    /// The invoked operation.
     pub operation: String,
+    /// The HTTP status when the result carried one.
     pub status: Option<u16>,
+    /// The error envelope's code when present.
     pub code: Option<String>,
+    /// The failure message.
     pub message: String,
+    /// The decoded result body when it parsed as JSON.
     pub body: Option<Box<Value>>,
+    /// The raw result body bytes.
     pub raw_body: Vec<u8>,
 }
 
@@ -20,8 +27,10 @@ pub struct InvokeResultError {
 /// result carried a payload failure.
 #[derive(Debug, thiserror::Error)]
 pub enum InvokeError {
+    /// The transport failed before a result decoded.
     #[error(transparent)]
     Transport(#[from] GestaltError),
+    /// The decoded result carried a payload failure.
     #[error(transparent)]
     Result(#[from] Box<InvokeResultError>),
 }


### PR DESCRIPTION
## Summary

Every public item in the Rust SDK now carries a doc comment, and `#![deny(missing_docs)]` makes an undocumented export a compile error. The 1,874 `missing_docs` findings are closed: handwritten provider scaffolding (agent, workflow, runtime, IndexedDB, catalog, auth, telemetry) gains terse prose — contract types in the generated style, fields/variants in the emitter's field-doc form, wire-integer conversions, value builders, and every workflow-provider trait method described; the `invoke_support` template gains its field and variant docs at the generator; and the prost wire module (reachable only through the `#[doc(hidden)]` proto escape hatch) allows the lint explicitly with rationale, since it is not documented surface.

## Interfaces

```rust
#![deny(missing_docs)]   // sdk/rust/src/lib.rs — the enforcement

/// The HTTP status when the result carried one.
pub status: Option<u16>,
```

No API changes — comments and the lint only.

## Runtime

No behavior changes. Validated by cargo build, clippy `-D warnings` across all targets, the full test suite, `cargo doc -D warnings`, the rust emitter suite, and sdkgen `--check` at zero drift (the two generated files are documented through their templates, not hand edits). With rustdoc rendering the whole crate and publishing landing in #2424, the Rust reference is total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
