### PR TITLE
[provider-gateway] add authorization hook

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -180,7 +180,7 @@ type Deps struct {
 	HostServiceTLSCAFile  string
 	HostServiceTLSCAPEM   string
 	Telemetry             core.TelemetryProvider
-	ProviderGateway       providergateway.ProviderGateway
+	ProviderTransport     providergateway.Transport
 	CallerTokenPublicKey  string
 
 	hostedAgentPoolClock hostedAgentPoolClock
@@ -979,14 +979,19 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 		_ = closeAuthProviders(authProviders)
 		return nil, fmt.Errorf("bootstrap: caller token private key: %w", err)
 	}
-	providerGateway := providergateway.New(providergateway.WithCallerTokenIssuer(callerTokenIssuer))
-	deps.ProviderGateway = providerGateway
+	providerTransport := providergateway.DirectTransport{}
 	callerTokenPublicKey, err := resolveCallerTokenPublicKey(ctx, sm)
 	if err != nil {
 		_ = closeAuthProviders(authProviders)
 		return nil, err
 	}
 	deps.CallerTokenPublicKey = callerTokenPublicKey
+	providerGatewayTransport := providergateway.NewProviderGatewayTransport(providerTransport)
+	providerGateway := providergateway.New(
+		providergateway.WithTransport(providerGatewayTransport),
+		providergateway.WithCallerTokenIssuer(callerTokenIssuer),
+	)
+	deps.ProviderTransport = providerGateway
 	authorizationProviders, err := buildAuthorizationProviders(ctx, cfg, factories, deps)
 	if err != nil {
 		_ = closeAuthProviders(authProviders)
@@ -1002,10 +1007,12 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 		_ = closeAuthProviders(authProviders)
 		return nil, err
 	}
-	if _, authorizationProvider, err := selectedAuthorizationProviderInstance(cfg, authorizationProviders); err != nil {
+	_, authorizationProvider, err := selectedAuthorizationProviderInstance(cfg, authorizationProviders)
+	if err != nil {
 		_ = closeAuthProviders(authProviders)
 		return nil, err
-	} else {
+	}
+	if authorizationProvider != nil {
 		deps.Authorization = authorizationProvider
 	}
 	closeExternalCredentialsOnError := true

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	telemetrynoop "github.com/valon-technologies/gestalt/server/services/observability/drivers/noop"
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
+	"github.com/valon-technologies/gestalt/server/services/providergateway"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -1348,6 +1349,52 @@ func validFactories() *bootstrap.FactoryRegistry {
 	return f
 }
 
+type bootstrapTransportRecordingAuthorizationProvider struct {
+	transport             providergateway.Transport
+	setAuthorizationState *proto.SetAuthorizationStateRequest
+}
+
+func (p *bootstrapTransportRecordingAuthorizationProvider) CheckAccess(context.Context, *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
+	return &proto.CheckAccessResponse{}, nil
+}
+
+func (p *bootstrapTransportRecordingAuthorizationProvider) CheckAccessMany(context.Context, *proto.CheckAccessManyRequest) (*proto.CheckAccessManyResponse, error) {
+	return &proto.CheckAccessManyResponse{}, nil
+}
+
+func (p *bootstrapTransportRecordingAuthorizationProvider) ListRelationships(context.Context, *proto.ListRelationshipsRequest) (*proto.ListRelationshipsResponse, error) {
+	return &proto.ListRelationshipsResponse{}, nil
+}
+
+func (p *bootstrapTransportRecordingAuthorizationProvider) AddRelationship(context.Context, *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {
+	return &proto.AddRelationshipResponse{}, nil
+}
+
+func (p *bootstrapTransportRecordingAuthorizationProvider) DeleteRelationship(context.Context, *proto.DeleteRelationshipRequest) (*proto.DeleteRelationshipResponse, error) {
+	return &proto.DeleteRelationshipResponse{}, nil
+}
+
+func (p *bootstrapTransportRecordingAuthorizationProvider) SetAuthorizationState(_ context.Context, req *proto.SetAuthorizationStateRequest) (*proto.SetAuthorizationStateResponse, error) {
+	p.setAuthorizationState = req
+	return &proto.SetAuthorizationStateResponse{}, nil
+}
+
+func (p *bootstrapTransportRecordingAuthorizationProvider) GetActiveModelRef(context.Context) (*proto.GetActiveModelRefResponse, error) {
+	return &proto.GetActiveModelRefResponse{}, nil
+}
+
+func (p *bootstrapTransportRecordingAuthorizationProvider) SetActiveModel(context.Context, *proto.SetActiveModelRequest) (*proto.SetActiveModelResponse, error) {
+	return &proto.SetActiveModelResponse{}, nil
+}
+
+func (p *bootstrapTransportRecordingAuthorizationProvider) ListActiveModelResourceTypes(context.Context, *proto.ListActiveModelResourceTypesRequest) (*proto.ListActiveModelResourceTypesResponse, error) {
+	return &proto.ListActiveModelResourceTypesResponse{}, nil
+}
+
+func (p *bootstrapTransportRecordingAuthorizationProvider) Ping(context.Context) error { return nil }
+
+func (p *bootstrapTransportRecordingAuthorizationProvider) Close() error { return nil }
+
 func requireHostService(t *testing.T, hostServices []runtimehost.HostService, name string) runtimehost.HostService {
 	t.Helper()
 	for _, hostService := range hostServices {
@@ -1878,6 +1925,48 @@ func TestBootstrap(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestBootstrapAuthorizationProviderStateUsesProviderGatewayTransport(t *testing.T) {
+	t.Parallel()
+
+	cfg := validConfig()
+	cfg.Server.Providers.Authorization = "authz"
+	cfg.Providers.Authorization = map[string]*config.ProviderEntry{
+		"authz": {Config: yaml.Node{Kind: yaml.MappingNode}},
+	}
+
+	var built []*bootstrapTransportRecordingAuthorizationProvider
+	factories := validFactories()
+	factories.Authorization = func(_ context.Context, _ string, _ yaml.Node, _ []runtimehost.HostService, deps bootstrap.Deps) (core.AuthorizationProvider, error) {
+		provider := &bootstrapTransportRecordingAuthorizationProvider{transport: deps.ProviderTransport}
+		built = append(built, provider)
+		return provider, nil
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	t.Cleanup(func() { _ = result.Close(context.Background()) })
+
+	if len(built) != 1 {
+		t.Fatalf("authorization providers built = %d, want 1", len(built))
+	}
+	provider := built[0]
+	transportGateway, ok := provider.transport.(*providergateway.Gateway)
+	if !ok {
+		t.Fatalf("authorization provider transport = %T, want *providergateway.Gateway", provider.transport)
+	}
+	if transportGateway != result.ProviderGateway {
+		t.Fatal("authorization provider was not built with the runtime provider gateway")
+	}
+	if provider.setAuthorizationState == nil {
+		t.Fatal("runtime authorization provider did not receive SetAuthorizationState")
+	}
+	if result.Authorization["authz"] != provider {
+		t.Fatal("bootstrapped authorization provider is not the runtime authorization provider")
+	}
 }
 
 func TestBootstrapResultClosesExtraCaches(t *testing.T) {

--- a/gestaltd/internal/daemon/factories.go
+++ b/gestaltd/internal/daemon/factories.go
@@ -131,7 +131,7 @@ func buildFactories() *bootstrap.FactoryRegistry {
 	}
 	factories.Authorization = func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps bootstrap.Deps) (core.AuthorizationProvider, error) {
 		return providerdrivers.AuthorizationFactory(ctx, name, node, hostServices, providerdrivers.AuthorizationDeps{
-			Gateway:              deps.ProviderGateway,
+			Transport:            deps.ProviderTransport,
 			CallerTokenPublicKey: deps.CallerTokenPublicKey,
 		})
 	}

--- a/gestaltd/rpc/authorization/client.go
+++ b/gestaltd/rpc/authorization/client.go
@@ -14,9 +14,9 @@ import (
 var _ core.AuthorizationProvider = (*Client)(nil)
 
 type Client struct {
-	grpc    proto.AuthorizationClient
-	opts    Options
-	gateway providergateway.ProviderGateway
+	grpc      proto.AuthorizationClient
+	opts      Options
+	transport providergateway.Transport
 }
 
 func (c *Client) CheckAccess(ctx context.Context, req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
@@ -135,14 +135,14 @@ func (c *Client) invoke(ctx context.Context, operation string, in gproto.Message
 	if c == nil {
 		return fmt.Errorf("authorization client is nil")
 	}
-	if c.gateway == nil {
+	if c.transport == nil {
 		return fmt.Errorf("provider gateway is required")
 	}
 	payload, err := gproto.Marshal(in)
 	if err != nil {
 		return fmt.Errorf("provider gateway: encode %s request: %w", operation, err)
 	}
-	resp, err := c.gateway.Invoke(ctx, providergateway.ProviderGatewayRequest{
+	resp, err := c.transport.Invoke(ctx, providergateway.ProviderGatewayRequest{
 		ProviderID:     c.opts.ProviderID,
 		ProviderKind:   providergateway.ProviderKindAuthorization,
 		ServiceName:    proto.Authorization_ServiceDesc.ServiceName,

--- a/gestaltd/rpc/authorization/conn.go
+++ b/gestaltd/rpc/authorization/conn.go
@@ -14,12 +14,12 @@ type Options struct {
 	ProviderID   string
 }
 
-func NewClient(grpcClient proto.AuthorizationClient, opts Options, gateway providergateway.ProviderGateway) *Client {
-	return &Client{grpc: grpcClient, opts: opts, gateway: gateway}
+func NewClient(grpcClient proto.AuthorizationClient, opts Options, transport providergateway.Transport) *Client {
+	return &Client{grpc: grpcClient, opts: opts, transport: transport}
 }
 
-func NewConn(conn grpc.ClientConnInterface, opts Options, gateway providergateway.ProviderGateway) *Client {
-	return NewClient(proto.NewAuthorizationClient(conn), opts, gateway)
+func NewConn(conn grpc.ClientConnInterface, opts Options, transport providergateway.Transport) *Client {
+	return NewClient(proto.NewAuthorizationClient(conn), opts, transport)
 }
 
 func attachTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {

--- a/gestaltd/services/authorization/client.go
+++ b/gestaltd/services/authorization/client.go
@@ -24,7 +24,7 @@ type ExecConfig struct {
 	Cleanup      func()
 	HostServices []runtimehost.HostService
 	Name         string
-	Gateway      providergateway.ProviderGateway
+	Transport    providergateway.Transport
 }
 
 type remoteAuthorizationProvider struct {
@@ -59,7 +59,7 @@ func NewExecutable(ctx context.Context, cfg ExecConfig) (core.AuthorizationProvi
 	client := rpcauthorization.NewConn(proc.Conn(), rpcauthorization.Options{
 		UnaryTimeout: runtimehost.ProviderRPCTimeout,
 		ProviderID:   cfg.Name,
-	}, cfg.Gateway)
+	}, cfg.Transport)
 	return &remoteAuthorizationProvider{Client: client, runtime: runtimeClient, closer: proc}, nil
 }
 

--- a/gestaltd/services/providerdrivers/authorization.go
+++ b/gestaltd/services/providerdrivers/authorization.go
@@ -16,7 +16,7 @@ import (
 const CallerTokenPublicKeyEnv = "GESTALTD_CALLER_TOKEN_ED25519_PUBLIC_KEY"
 
 type AuthorizationDeps struct {
-	Gateway              providergateway.ProviderGateway
+	Transport            providergateway.Transport
 	CallerTokenPublicKey string
 }
 
@@ -48,7 +48,7 @@ func AuthorizationFactory(ctx context.Context, name string, node yaml.Node, host
 		Cleanup:      prepared.Cleanup,
 		HostServices: hostServices,
 		Name:         name,
-		Gateway:      deps.Gateway,
+		Transport:    deps.Transport,
 	})
 }
 

--- a/gestaltd/services/providergateway/caller_token.go
+++ b/gestaltd/services/providergateway/caller_token.go
@@ -128,6 +128,14 @@ func Verify(token string, publicKeyPEM string) (CallerTokenClaims, error) {
 	return claims, nil
 }
 
+func CallerTokenSubjectID(token string, publicKeyPEM string) (string, error) {
+	claims, err := Verify(token, publicKeyPEM)
+	if err != nil {
+		return "", err
+	}
+	return claims.SubjectID, nil
+}
+
 func parseCallerTokenPrivateKey(privateKeyPEM string) (ed25519.PrivateKey, error) {
 	block, _ := pem.Decode([]byte(strings.TrimSpace(privateKeyPEM)))
 	if block == nil {

--- a/gestaltd/services/providergateway/caller_token_test.go
+++ b/gestaltd/services/providergateway/caller_token_test.go
@@ -40,6 +40,65 @@ func TestCallerTokenIssueVerify(t *testing.T) {
 	}
 }
 
+func TestCallerTokenSubjectID(t *testing.T) {
+	t.Parallel()
+
+	privateKeyPEM, publicKeyPEM := testCallerTokenKeyPair(t)
+	issuer, err := NewCallerTokenIssuer(privateKeyPEM)
+	if err != nil {
+		t.Fatalf("NewCallerTokenIssuer: %v", err)
+	}
+	claims, err := GenerateCallerTokenClaims("user:123", time.Now().UTC())
+	if err != nil {
+		t.Fatalf("GenerateCallerTokenClaims: %v", err)
+	}
+	token, err := issuer.Issue(claims)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+
+	subjectID, err := CallerTokenSubjectID(token, publicKeyPEM)
+	if err != nil {
+		t.Fatalf("CallerTokenSubjectID: %v", err)
+	}
+	if subjectID != "user:123" {
+		t.Fatalf("subjectID = %q, want user:123", subjectID)
+	}
+}
+
+func TestCallerTokenSubjectIDRejectsInvalidToken(t *testing.T) {
+	t.Parallel()
+
+	privateKeyPEM, publicKeyPEM := testCallerTokenKeyPair(t)
+	issuer, err := NewCallerTokenIssuer(privateKeyPEM)
+	if err != nil {
+		t.Fatalf("NewCallerTokenIssuer: %v", err)
+	}
+	claims, err := GenerateCallerTokenClaims("user:123", time.Now().UTC())
+	if err != nil {
+		t.Fatalf("GenerateCallerTokenClaims: %v", err)
+	}
+	token, err := issuer.Issue(claims)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Fatalf("token parts = %d, want 3", len(parts))
+	}
+	claims.SubjectID = "user:admin"
+	tamperedClaims, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("Marshal tampered claims: %v", err)
+	}
+	parts[1] = base64.RawURLEncoding.EncodeToString(tamperedClaims)
+	tamperedToken := strings.Join(parts, ".")
+
+	if _, err := CallerTokenSubjectID(tamperedToken, publicKeyPEM); err == nil {
+		t.Fatal("CallerTokenSubjectID tampered token error = nil, want error")
+	}
+}
+
 func TestCallerTokenGenerateClaims(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/providergateway/gateway.go
+++ b/gestaltd/services/providergateway/gateway.go
@@ -11,6 +11,12 @@ type Gateway struct {
 	transport         Transport
 }
 
+type AuthorizationParams struct {
+	ProviderID  string
+	Operation   string
+	CallerToken string
+}
+
 type GatewayOption func(*Gateway)
 
 func WithCallerTokenIssuer(issuer *CallerTokenIssuer) GatewayOption {
@@ -50,6 +56,10 @@ func (g *Gateway) IssueCallerToken(subjectID string, now time.Time) (string, boo
 	return token, true, nil
 }
 
+func (g *Gateway) Authorize(ctx context.Context, params AuthorizationParams) (bool, error) {
+	return true, nil
+}
+
 type DirectTransport struct{}
 
 func (DirectTransport) Invoke(ctx context.Context, req ProviderGatewayRequest, next Next) (ProviderGatewayResponse, error) {
@@ -78,6 +88,17 @@ func (t *ProviderGatewayTransport) Invoke(ctx context.Context, req ProviderGatew
 }
 
 func (g *Gateway) Invoke(ctx context.Context, req ProviderGatewayRequest, next Next) (ProviderGatewayResponse, error) {
+	allowed, err := g.Authorize(ctx, AuthorizationParams{
+		ProviderID:  req.ProviderID,
+		Operation:   req.Operation,
+		CallerToken: req.CallerToken,
+	})
+	if err != nil {
+		return ProviderGatewayResponse{}, fmt.Errorf("provider gateway: authorize: %w", err)
+	}
+	if !allowed {
+		return ProviderGatewayResponse{}, fmt.Errorf("provider gateway: unauthorized")
+	}
 	transport := Transport(DirectTransport{})
 	if g != nil && g.transport != nil {
 		transport = g.transport

--- a/gestaltd/services/providergateway/gateway.go
+++ b/gestaltd/services/providergateway/gateway.go
@@ -8,6 +8,7 @@ import (
 
 type Gateway struct {
 	callerTokenIssuer *CallerTokenIssuer
+	transport         Transport
 }
 
 type GatewayOption func(*Gateway)
@@ -18,8 +19,14 @@ func WithCallerTokenIssuer(issuer *CallerTokenIssuer) GatewayOption {
 	}
 }
 
+func WithTransport(transport Transport) GatewayOption {
+	return func(g *Gateway) {
+		g.transport = transport
+	}
+}
+
 func New(opts ...GatewayOption) *Gateway {
-	g := &Gateway{}
+	g := &Gateway{transport: DirectTransport{}}
 	for _, opt := range opts {
 		if opt != nil {
 			opt(g)
@@ -43,9 +50,37 @@ func (g *Gateway) IssueCallerToken(subjectID string, now time.Time) (string, boo
 	return token, true, nil
 }
 
-func (g *Gateway) Invoke(ctx context.Context, req ProviderGatewayRequest, next Next) (ProviderGatewayResponse, error) {
+type DirectTransport struct{}
+
+func (DirectTransport) Invoke(ctx context.Context, req ProviderGatewayRequest, next Next) (ProviderGatewayResponse, error) {
 	if next == nil {
 		return ProviderGatewayResponse{}, fmt.Errorf("provider gateway: next handler is required")
 	}
 	return next(ctx, req)
+}
+
+type ProviderGatewayTransport struct {
+	next Transport
+}
+
+func NewProviderGatewayTransport(next Transport) *ProviderGatewayTransport {
+	if next == nil {
+		next = DirectTransport{}
+	}
+	return &ProviderGatewayTransport{next: next}
+}
+
+func (t *ProviderGatewayTransport) Invoke(ctx context.Context, req ProviderGatewayRequest, next Next) (ProviderGatewayResponse, error) {
+	if t == nil {
+		return ProviderGatewayResponse{}, fmt.Errorf("provider gateway: transport is nil")
+	}
+	return t.next.Invoke(ctx, req, next)
+}
+
+func (g *Gateway) Invoke(ctx context.Context, req ProviderGatewayRequest, next Next) (ProviderGatewayResponse, error) {
+	transport := Transport(DirectTransport{})
+	if g != nil && g.transport != nil {
+		transport = g.transport
+	}
+	return transport.Invoke(ctx, req, next)
 }

--- a/gestaltd/services/providergateway/gateway_test.go
+++ b/gestaltd/services/providergateway/gateway_test.go
@@ -60,16 +60,46 @@ func TestNewCallerTokenIssuerEmptyKey(t *testing.T) {
 	}
 }
 
-func TestInvokeUsesConfiguredTransport(t *testing.T) {
+func TestAuthorizeAllowsRequests(t *testing.T) {
+	t.Parallel()
+
+	gateway := New()
+	allowed, err := gateway.Authorize(context.Background(), AuthorizationParams{
+		ProviderID:  "authz-primary",
+		Operation:   "CheckAccess",
+		CallerToken: "caller-token",
+	})
+	if err != nil {
+		t.Fatalf("Authorize: %v", err)
+	}
+	if !allowed {
+		t.Fatal("Authorize allowed = false, want true")
+	}
+}
+
+func TestInvokeAuthorizesThenCallsConfiguredTransport(t *testing.T) {
 	t.Parallel()
 
 	transport := &recordingTransport{}
 	gateway := New(WithTransport(transport))
-	req := ProviderGatewayRequest{ProviderID: "authz", Operation: "CheckAccess"}
+	req := ProviderGatewayRequest{
+		ProviderID:  "authz-primary",
+		Operation:   "CheckAccess",
+		CallerToken: "caller-token",
+	}
 	nextCalled := false
 
-	_, err := gateway.Invoke(context.Background(), req, func(context.Context, ProviderGatewayRequest) (ProviderGatewayResponse, error) {
+	_, err := gateway.Invoke(context.Background(), req, func(_ context.Context, got ProviderGatewayRequest) (ProviderGatewayResponse, error) {
 		nextCalled = true
+		if got.ProviderID != req.ProviderID {
+			t.Fatalf("ProviderID = %q, want %q", got.ProviderID, req.ProviderID)
+		}
+		if got.Operation != req.Operation {
+			t.Fatalf("Operation = %q, want %q", got.Operation, req.Operation)
+		}
+		if got.CallerToken != req.CallerToken {
+			t.Fatalf("CallerToken = %q, want %q", got.CallerToken, req.CallerToken)
+		}
 		return ProviderGatewayResponse{}, nil
 	})
 	if err != nil {

--- a/gestaltd/services/providergateway/gateway_test.go
+++ b/gestaltd/services/providergateway/gateway_test.go
@@ -1,6 +1,7 @@
 package providergateway
 
 import (
+	"context"
 	"testing"
 	"time"
 )
@@ -57,4 +58,91 @@ func TestNewCallerTokenIssuerEmptyKey(t *testing.T) {
 	if issuer != nil {
 		t.Fatalf("issuer = %#v, want nil", issuer)
 	}
+}
+
+func TestInvokeUsesConfiguredTransport(t *testing.T) {
+	t.Parallel()
+
+	transport := &recordingTransport{}
+	gateway := New(WithTransport(transport))
+	req := ProviderGatewayRequest{ProviderID: "authz", Operation: "CheckAccess"}
+	nextCalled := false
+
+	_, err := gateway.Invoke(context.Background(), req, func(context.Context, ProviderGatewayRequest) (ProviderGatewayResponse, error) {
+		nextCalled = true
+		return ProviderGatewayResponse{}, nil
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if !transport.called {
+		t.Fatal("transport was not called")
+	}
+	if transport.request.ProviderID != req.ProviderID {
+		t.Fatalf("ProviderID = %q, want %q", transport.request.ProviderID, req.ProviderID)
+	}
+	if !nextCalled {
+		t.Fatal("next was not called")
+	}
+}
+
+func TestProviderGatewayTransportInvokesNext(t *testing.T) {
+	t.Parallel()
+
+	inner := &recordingTransport{}
+	transport := NewProviderGatewayTransport(inner)
+	req := ProviderGatewayRequest{
+		ProviderID:   "authz-primary",
+		ProviderKind: ProviderKindAuthorization,
+		Operation:    "SetAuthorizationState",
+	}
+	nextCalled := false
+
+	_, err := transport.Invoke(context.Background(), req, func(_ context.Context, got ProviderGatewayRequest) (ProviderGatewayResponse, error) {
+		nextCalled = true
+		if got.ProviderID != req.ProviderID {
+			t.Fatalf("ProviderID = %q, want %q", got.ProviderID, req.ProviderID)
+		}
+		return ProviderGatewayResponse{}, nil
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if !inner.called {
+		t.Fatal("inner transport was not called")
+	}
+	if !nextCalled {
+		t.Fatal("next was not called")
+	}
+}
+
+func TestDirectTransportInvokesNext(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	req := ProviderGatewayRequest{ProviderID: "authz", Operation: "CheckAccess"}
+	_, err := (DirectTransport{}).Invoke(context.Background(), req, func(_ context.Context, got ProviderGatewayRequest) (ProviderGatewayResponse, error) {
+		called = true
+		if got.ProviderID != req.ProviderID {
+			t.Fatalf("ProviderID = %q, want %q", got.ProviderID, req.ProviderID)
+		}
+		return ProviderGatewayResponse{}, nil
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if !called {
+		t.Fatal("next was not called")
+	}
+}
+
+type recordingTransport struct {
+	called  bool
+	request ProviderGatewayRequest
+}
+
+func (t *recordingTransport) Invoke(ctx context.Context, req ProviderGatewayRequest, next Next) (ProviderGatewayResponse, error) {
+	t.called = true
+	t.request = req
+	return next(ctx, req)
 }

--- a/gestaltd/services/providergateway/types.go
+++ b/gestaltd/services/providergateway/types.go
@@ -21,7 +21,7 @@ const (
 
 type RequestContext = proto.RequestContext
 
-type ProviderGateway interface {
+type Transport interface {
 	Invoke(ctx context.Context, req ProviderGatewayRequest, next Next) (ProviderGatewayResponse, error)
 }
 


### PR DESCRIPTION
## Description

Adds a provider gateway authorization hook that receives the provider ID, operation, and caller token before forwarding requests. The initial implementation allows all requests.