### PR TITLE
[provider-gateway] split transport dependency

### DIFF
--- a/gestaltd/internal/bootstrap/authorization_bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/authorization_bootstrap_test.go
@@ -12,6 +12,7 @@ import (
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/providerdrivers"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	gproto "google.golang.org/protobuf/proto"
 	"gopkg.in/yaml.v3"
@@ -201,10 +202,11 @@ config:
 	var capturedName string
 	var capturedHostServices []runtimehost.HostService
 	factories := &FactoryRegistry{
-		Authorization: func(_ context.Context, name string, _ yaml.Node, hostServices []runtimehost.HostService, _ Deps) (core.AuthorizationProvider, error) {
+		Authorization: func(_ context.Context, name string, _ yaml.Node, hostServices []runtimehost.HostService, _ Deps) (providerdrivers.AuthorizationBuildResult, error) {
 			capturedName = name
 			capturedHostServices = append([]runtimehost.HostService(nil), hostServices...)
-			return &recordingAuthorizationProvider{}, nil
+			provider := &recordingAuthorizationProvider{}
+			return providerdrivers.AuthorizationBuildResult{Raw: provider, Guarded: provider}, nil
 		},
 	}
 	cfg := &config.Config{
@@ -227,8 +229,11 @@ config:
 	if err != nil {
 		t.Fatalf("buildAuthorizationProviders: %v", err)
 	}
-	if providers["indexeddb"] == nil {
-		t.Fatal("authorization provider was not built")
+	if providers.Guarded["indexeddb"] == nil {
+		t.Fatal("guarded authorization provider was not built")
+	}
+	if providers.Raw["indexeddb"] == nil {
+		t.Fatal("raw authorization provider was not built")
 	}
 	if capturedName != "indexeddb" {
 		t.Fatalf("authorization provider name = %q, want indexeddb", capturedName)
@@ -252,9 +257,10 @@ command: /bin/true
 	}
 	var capturedPublicKey string
 	factories := &FactoryRegistry{
-		Authorization: func(_ context.Context, _ string, _ yaml.Node, _ []runtimehost.HostService, deps Deps) (core.AuthorizationProvider, error) {
+		Authorization: func(_ context.Context, _ string, _ yaml.Node, _ []runtimehost.HostService, deps Deps) (providerdrivers.AuthorizationBuildResult, error) {
 			capturedPublicKey = deps.CallerTokenPublicKey
-			return &recordingAuthorizationProvider{}, nil
+			provider := &recordingAuthorizationProvider{}
+			return providerdrivers.AuthorizationBuildResult{Raw: provider, Guarded: provider}, nil
 		},
 	}
 	cfg := &config.Config{

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -253,7 +253,7 @@ type Result struct {
 	Telemetry            core.TelemetryProvider
 	Runtimes             RuntimeInspector
 	PublicHostServices   *runtimehost.PublicHostServiceRegistry
-	ProviderGateway      *providergateway.Gateway
+	CallerTokenIssuer    *providergateway.CallerTokenIssuer
 
 	runtimeRegistry                     *runtimeRegistry
 	workflowConfigReconcileTasks        []workflowConfigReconcileTask
@@ -670,7 +670,7 @@ type preparedCore struct {
 	WorkflowManager      *lazyWorkflowManager
 	AgentManager         *lazyAgentManager
 	PublicHostServices   *runtimehost.PublicHostServiceRegistry
-	ProviderGateway      *providergateway.Gateway
+	CallerTokenIssuer    *providergateway.CallerTokenIssuer
 
 	runtimeRegistry *runtimeRegistry
 }
@@ -983,10 +983,6 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	}
 	deps.CallerTokenPublicKey = callerTokenPublicKey
 	providerGatewayTransport := providergateway.NewProviderGatewayTransport()
-	providerGateway := providergateway.New(
-		providergateway.WithTransport(providerGatewayTransport),
-		providergateway.WithCallerTokenIssuer(callerTokenIssuer),
-	)
 	deps.ProviderTransport = providerGatewayTransport
 	authorizationProviders, err := buildAuthorizationProviders(ctx, cfg, factories, deps)
 	if err != nil {
@@ -1052,7 +1048,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 		WorkflowManager:      workflowManager,
 		AgentManager:         agentManager,
 		PublicHostServices:   publicHostServices,
-		ProviderGateway:      providerGateway,
+		CallerTokenIssuer:    callerTokenIssuer,
 		runtimeRegistry:      runtimeRegistry,
 	}, nil
 }
@@ -1281,7 +1277,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		Telemetry:                    prepared.Telemetry,
 		Runtimes:                     prepared.runtimeRegistry,
 		PublicHostServices:           publicHostServices,
-		ProviderGateway:              prepared.ProviderGateway,
+		CallerTokenIssuer:            prepared.CallerTokenIssuer,
 		runtimeRegistry:              prepared.runtimeRegistry,
 		workflowConfigReconcileTasks: deferredWorkflowConfigReconcileTasks,
 		auditClose:                   auditClose,

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -178,7 +178,7 @@ type Deps struct {
 	HostServiceTLSCAFile  string
 	HostServiceTLSCAPEM   string
 	Telemetry             core.TelemetryProvider
-	ProviderGateway       providergateway.ProviderGateway
+	ProviderTransport     providergateway.Transport
 	CallerTokenPublicKey  string
 
 	hostedAgentPoolClock hostedAgentPoolClock
@@ -976,14 +976,18 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 		_ = closeAuthProviders(authProviders)
 		return nil, fmt.Errorf("bootstrap: caller token private key: %w", err)
 	}
-	providerGateway := providergateway.New(providergateway.WithCallerTokenIssuer(callerTokenIssuer))
-	deps.ProviderGateway = providerGateway
 	callerTokenPublicKey, err := resolveCallerTokenPublicKey(ctx, sm)
 	if err != nil {
 		_ = closeAuthProviders(authProviders)
 		return nil, err
 	}
 	deps.CallerTokenPublicKey = callerTokenPublicKey
+	providerGatewayTransport := providergateway.NewProviderGatewayTransport()
+	providerGateway := providergateway.New(
+		providergateway.WithTransport(providerGatewayTransport),
+		providergateway.WithCallerTokenIssuer(callerTokenIssuer),
+	)
+	deps.ProviderTransport = providerGatewayTransport
 	authorizationProviders, err := buildAuthorizationProviders(ctx, cfg, factories, deps)
 	if err != nil {
 		_ = closeAuthProviders(authProviders)
@@ -995,15 +999,18 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 			_ = closeAuthorizationProviders(authorizationProviders)
 		}
 	}()
-	if err := bootstrapAuthorizationProviderState(ctx, cfg, authorizationProviders); err != nil {
+	_, authorizationProvider, err := selectedAuthorizationProviderInstance(cfg, authorizationProviders)
+	if err != nil {
 		_ = closeAuthProviders(authProviders)
 		return nil, err
 	}
-	if _, authorizationProvider, err := selectedAuthorizationProviderInstance(cfg, authorizationProviders); err != nil {
+	if authorizationProvider != nil {
+		providerGatewayTransport.SetAuthorizationProvider(authorizationProvider)
+		deps.Authorization = authorizationProvider
+	}
+	if err := bootstrapAuthorizationProviderState(ctx, cfg, authorizationProviders); err != nil {
 		_ = closeAuthProviders(authProviders)
 		return nil, err
-	} else {
-		deps.Authorization = authorizationProvider
 	}
 	closeExternalCredentialsOnError := true
 	defer func() {

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -33,6 +33,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/observability"
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
+	"github.com/valon-technologies/gestalt/server/services/providerdrivers"
 	"github.com/valon-technologies/gestalt/server/services/providergateway"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost/runtimeprovider"
@@ -185,7 +186,7 @@ type Deps struct {
 }
 
 type AuthFactory func(node yaml.Node, deps Deps) (core.AuthenticationProvider, error)
-type AuthorizationFactory func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps Deps) (core.AuthorizationProvider, error)
+type AuthorizationFactory func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps Deps) (providerdrivers.AuthorizationBuildResult, error)
 type ExternalCredentialFactory func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps Deps) (core.ExternalCredentialProvider, error)
 type SecretManagerFactory func(node yaml.Node) (core.SecretManager, error)
 type IndexedDBFactory func(node yaml.Node) (indexeddb.IndexedDB, error)
@@ -976,14 +977,14 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 		_ = closeAuthProviders(authProviders)
 		return nil, fmt.Errorf("bootstrap: caller token private key: %w", err)
 	}
+	providerTransport := providergateway.DirectTransport{}
+	deps.ProviderTransport = providerTransport
 	callerTokenPublicKey, err := resolveCallerTokenPublicKey(ctx, sm)
 	if err != nil {
 		_ = closeAuthProviders(authProviders)
 		return nil, err
 	}
 	deps.CallerTokenPublicKey = callerTokenPublicKey
-	providerGatewayTransport := providergateway.NewProviderGatewayTransport()
-	deps.ProviderTransport = providerGatewayTransport
 	authorizationProviders, err := buildAuthorizationProviders(ctx, cfg, factories, deps)
 	if err != nil {
 		_ = closeAuthProviders(authProviders)
@@ -992,21 +993,20 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	closeAuthorizationOnError := true
 	defer func() {
 		if closeAuthorizationOnError {
-			_ = closeAuthorizationProviders(authorizationProviders)
+			_ = closeAuthorizationProviders(authorizationProviders.Guarded)
 		}
 	}()
-	_, authorizationProvider, err := selectedAuthorizationProviderInstance(cfg, authorizationProviders)
+	if err := bootstrapAuthorizationProviderState(ctx, cfg, authorizationProviders.Raw); err != nil {
+		_ = closeAuthProviders(authProviders)
+		return nil, err
+	}
+	_, authorizationProvider, err := selectedAuthorizationProviderInstance(cfg, authorizationProviders.Guarded)
 	if err != nil {
 		_ = closeAuthProviders(authProviders)
 		return nil, err
 	}
 	if authorizationProvider != nil {
-		providerGatewayTransport.SetAuthorizationProvider(authorizationProvider)
 		deps.Authorization = authorizationProvider
-	}
-	if err := bootstrapAuthorizationProviderState(ctx, cfg, authorizationProviders); err != nil {
-		_ = closeAuthProviders(authProviders)
-		return nil, err
 	}
 	closeExternalCredentialsOnError := true
 	defer func() {
@@ -1036,7 +1036,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 		Auth:                 auth,
 		SelectedAuthProvider: selectedAuthName,
 		AuthProviders:        authProviders,
-		Authorization:        authorizationProviders,
+		Authorization:        authorizationProviders.Guarded,
 		Services:             svc,
 		ExtraIndexedDBs:      extraIndexedDBs,
 		ExtraCaches:          extraCaches,
@@ -1850,50 +1850,58 @@ func buildNamedAuthProvider(name string, authEntry *config.ProviderEntry, factor
 	return auth, nil
 }
 
-func buildAuthorizationProviders(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, deps Deps) (map[string]core.AuthorizationProvider, error) {
+type authorizationProviderSets struct {
+	Raw     map[string]core.AuthorizationProvider
+	Guarded map[string]core.AuthorizationProvider
+}
+
+func buildAuthorizationProviders(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, deps Deps) (authorizationProviderSets, error) {
 	if len(cfg.Providers.Authorization) == 0 {
-		return nil, nil
+		return authorizationProviderSets{}, nil
 	}
 	if factories.Authorization == nil {
-		return nil, fmt.Errorf("bootstrap: authorization factory is not registered")
+		return authorizationProviderSets{}, fmt.Errorf("bootstrap: authorization factory is not registered")
 	}
 	name, entry, err := cfg.SelectedAuthorizationProvider()
 	if err != nil {
-		return nil, err
+		return authorizationProviderSets{}, err
 	}
 	if entry == nil {
-		return nil, nil
+		return authorizationProviderSets{}, nil
 	}
-	provider, err := buildNamedAuthorizationProvider(ctx, name, entry, factories, deps)
+	providers, err := buildNamedAuthorizationProvider(ctx, name, entry, factories, deps)
 	if err != nil {
-		return nil, err
+		return authorizationProviderSets{}, err
 	}
-	return map[string]core.AuthorizationProvider{name: provider}, nil
+	return authorizationProviderSets{
+		Raw:     map[string]core.AuthorizationProvider{name: providers.Raw},
+		Guarded: map[string]core.AuthorizationProvider{name: providers.Guarded},
+	}, nil
 }
 
-func buildNamedAuthorizationProvider(ctx context.Context, name string, entry *config.ProviderEntry, factories *FactoryRegistry, deps Deps) (core.AuthorizationProvider, error) {
+func buildNamedAuthorizationProvider(ctx context.Context, name string, entry *config.ProviderEntry, factories *FactoryRegistry, deps Deps) (providerdrivers.AuthorizationBuildResult, error) {
 	logicalName := strings.TrimSpace(name)
 	if logicalName == "" {
 		logicalName = "authorization"
 	}
 	if entry == nil {
-		return nil, fmt.Errorf("bootstrap: authorization provider %q is not configured", logicalName)
+		return providerdrivers.AuthorizationBuildResult{}, fmt.Errorf("bootstrap: authorization provider %q is not configured", logicalName)
 	}
 	node := entry.Config
 	if !config.IsComponentRuntimeConfigNode(node) {
 		var err error
 		node, err = config.BuildComponentRuntimeConfigNode(logicalName, providermanifestv1.KindAuthorization, entry, entry.Config)
 		if err != nil {
-			return nil, fmt.Errorf("bootstrap: authorization provider %q: %w", logicalName, err)
+			return providerdrivers.AuthorizationBuildResult{}, fmt.Errorf("bootstrap: authorization provider %q: %w", logicalName, err)
 		}
 	}
 	hostServices, err := buildProviderHostServices(logicalName, deps)
 	if err != nil {
-		return nil, fmt.Errorf("bootstrap: authorization provider %q: %w", logicalName, err)
+		return providerdrivers.AuthorizationBuildResult{}, fmt.Errorf("bootstrap: authorization provider %q: %w", logicalName, err)
 	}
 	provider, err := factories.Authorization(ctx, logicalName, node, hostServices, deps)
 	if err != nil {
-		return nil, fmt.Errorf("bootstrap: authorization provider %q: %w", logicalName, err)
+		return providerdrivers.AuthorizationBuildResult{}, fmt.Errorf("bootstrap: authorization provider %q: %w", logicalName, err)
 	}
 	return provider, nil
 }

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	telemetrynoop "github.com/valon-technologies/gestalt/server/services/observability/drivers/noop"
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
+	"github.com/valon-technologies/gestalt/server/services/providerdrivers"
 	"github.com/valon-technologies/gestalt/server/services/providergateway"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"google.golang.org/grpc"
@@ -1899,10 +1900,13 @@ func TestBootstrapAuthorizationProviderStateUsesProviderGatewayTransport(t *test
 			},
 		}, nil
 	}
-	factories.Authorization = func(_ context.Context, _ string, _ yaml.Node, _ []runtimehost.HostService, deps bootstrap.Deps) (core.AuthorizationProvider, error) {
-		provider := &bootstrapTransportRecordingAuthorizationProvider{transport: deps.ProviderTransport}
-		built = append(built, provider)
-		return provider, nil
+	factories.Authorization = func(_ context.Context, _ string, _ yaml.Node, _ []runtimehost.HostService, deps bootstrap.Deps) (providerdrivers.AuthorizationBuildResult, error) {
+		raw := &bootstrapTransportRecordingAuthorizationProvider{transport: deps.ProviderTransport}
+		guardedTransport := providergateway.NewProviderGatewayTransport()
+		guardedTransport.SetAuthorizationProvider(raw)
+		guarded := &bootstrapTransportRecordingAuthorizationProvider{transport: guardedTransport}
+		built = append(built, raw, guarded)
+		return providerdrivers.AuthorizationBuildResult{Raw: raw, Guarded: guarded}, nil
 	}
 
 	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
@@ -1911,21 +1915,32 @@ func TestBootstrapAuthorizationProviderStateUsesProviderGatewayTransport(t *test
 	}
 	t.Cleanup(func() { _ = result.Close(context.Background()) })
 
-	if len(built) != 1 {
-		t.Fatalf("authorization providers built = %d, want 1", len(built))
+	if len(built) != 2 {
+		t.Fatalf("authorization providers built = %d, want 2", len(built))
 	}
-	provider := built[0]
-	if _, ok := provider.transport.(*providergateway.ProviderGatewayTransport); !ok {
-		t.Fatalf("authorization provider transport = %T, want *providergateway.ProviderGatewayTransport", provider.transport)
+	rawProvider := built[0]
+	guardedProvider := built[1]
+	if _, ok := rawProvider.transport.(providergateway.DirectTransport); !ok {
+		t.Fatalf("raw authorization provider transport = %T, want providergateway.DirectTransport", rawProvider.transport)
+	}
+	transportGateway, ok := guardedProvider.transport.(*providergateway.ProviderGatewayTransport)
+	if !ok {
+		t.Fatalf("guarded authorization provider transport = %T, want *providergateway.ProviderGatewayTransport", guardedProvider.transport)
 	}
 	if result.CallerTokenIssuer == nil {
 		t.Fatal("CallerTokenIssuer is nil")
 	}
-	if provider.setAuthorizationState == nil {
-		t.Fatal("runtime authorization provider did not receive SetAuthorizationState")
+	if rawProvider.setAuthorizationState == nil {
+		t.Fatal("raw authorization provider did not receive SetAuthorizationState")
 	}
-	if result.Authorization["authz"] != provider {
-		t.Fatal("bootstrapped authorization provider is not the runtime authorization provider")
+	if guardedProvider.setAuthorizationState != nil {
+		t.Fatal("guarded authorization provider unexpectedly received SetAuthorizationState")
+	}
+	if result.Authorization["authz"] != guardedProvider {
+		t.Fatal("bootstrapped authorization provider is not the guarded runtime authorization provider")
+	}
+	if transportGateway != guardedProvider.transport {
+		t.Fatal("guarded authorization provider was not built with the runtime provider gateway")
 	}
 }
 

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	telemetrynoop "github.com/valon-technologies/gestalt/server/services/observability/drivers/noop"
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
+	"github.com/valon-technologies/gestalt/server/services/providergateway"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -1285,6 +1286,52 @@ func validFactories() *bootstrap.FactoryRegistry {
 	return f
 }
 
+type bootstrapTransportRecordingAuthorizationProvider struct {
+	transport             providergateway.Transport
+	setAuthorizationState *proto.SetAuthorizationStateRequest
+}
+
+func (p *bootstrapTransportRecordingAuthorizationProvider) CheckAccess(context.Context, *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
+	return &proto.CheckAccessResponse{}, nil
+}
+
+func (p *bootstrapTransportRecordingAuthorizationProvider) CheckAccessMany(context.Context, *proto.CheckAccessManyRequest) (*proto.CheckAccessManyResponse, error) {
+	return &proto.CheckAccessManyResponse{}, nil
+}
+
+func (p *bootstrapTransportRecordingAuthorizationProvider) ListRelationships(context.Context, *proto.ListRelationshipsRequest) (*proto.ListRelationshipsResponse, error) {
+	return &proto.ListRelationshipsResponse{}, nil
+}
+
+func (p *bootstrapTransportRecordingAuthorizationProvider) AddRelationship(context.Context, *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {
+	return &proto.AddRelationshipResponse{}, nil
+}
+
+func (p *bootstrapTransportRecordingAuthorizationProvider) DeleteRelationship(context.Context, *proto.DeleteRelationshipRequest) (*proto.DeleteRelationshipResponse, error) {
+	return &proto.DeleteRelationshipResponse{}, nil
+}
+
+func (p *bootstrapTransportRecordingAuthorizationProvider) SetAuthorizationState(_ context.Context, req *proto.SetAuthorizationStateRequest) (*proto.SetAuthorizationStateResponse, error) {
+	p.setAuthorizationState = req
+	return &proto.SetAuthorizationStateResponse{}, nil
+}
+
+func (p *bootstrapTransportRecordingAuthorizationProvider) GetActiveModelRef(context.Context) (*proto.GetActiveModelRefResponse, error) {
+	return &proto.GetActiveModelRefResponse{}, nil
+}
+
+func (p *bootstrapTransportRecordingAuthorizationProvider) SetActiveModel(context.Context, *proto.SetActiveModelRequest) (*proto.SetActiveModelResponse, error) {
+	return &proto.SetActiveModelResponse{}, nil
+}
+
+func (p *bootstrapTransportRecordingAuthorizationProvider) ListActiveModelResourceTypes(context.Context, *proto.ListActiveModelResourceTypesRequest) (*proto.ListActiveModelResourceTypesResponse, error) {
+	return &proto.ListActiveModelResourceTypesResponse{}, nil
+}
+
+func (p *bootstrapTransportRecordingAuthorizationProvider) Ping(context.Context) error { return nil }
+
+func (p *bootstrapTransportRecordingAuthorizationProvider) Close() error { return nil }
+
 func requireHostService(t *testing.T, hostServices []runtimehost.HostService, name string) runtimehost.HostService {
 	t.Helper()
 	for _, hostService := range hostServices {
@@ -1815,6 +1862,47 @@ func TestBootstrap(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestBootstrapAuthorizationProviderStateUsesProviderGatewayTransport(t *testing.T) {
+	t.Parallel()
+
+	cfg := validConfig()
+	cfg.Server.Providers.Authorization = "authz"
+	cfg.Providers.Authorization = map[string]*config.ProviderEntry{
+		"authz": {Config: yaml.Node{Kind: yaml.MappingNode}},
+	}
+
+	var built []*bootstrapTransportRecordingAuthorizationProvider
+	factories := validFactories()
+	factories.Authorization = func(_ context.Context, _ string, _ yaml.Node, _ []runtimehost.HostService, deps bootstrap.Deps) (core.AuthorizationProvider, error) {
+		provider := &bootstrapTransportRecordingAuthorizationProvider{transport: deps.ProviderTransport}
+		built = append(built, provider)
+		return provider, nil
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	t.Cleanup(func() { _ = result.Close(context.Background()) })
+
+	if len(built) != 1 {
+		t.Fatalf("authorization providers built = %d, want 1", len(built))
+	}
+	provider := built[0]
+	if _, ok := provider.transport.(*providergateway.ProviderGatewayTransport); !ok {
+		t.Fatalf("authorization provider transport = %T, want *providergateway.ProviderGatewayTransport", provider.transport)
+	}
+	if result.ProviderGateway == nil {
+		t.Fatal("ProviderGateway is nil")
+	}
+	if provider.setAuthorizationState == nil {
+		t.Fatal("runtime authorization provider did not receive SetAuthorizationState")
+	}
+	if result.Authorization["authz"] != provider {
+		t.Fatal("bootstrapped authorization provider is not the runtime authorization provider")
+	}
 }
 
 func TestBootstrapResultClosesExtraCaches(t *testing.T) {

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -2,9 +2,13 @@ package bootstrap_test
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"maps"
@@ -1545,6 +1549,19 @@ func transportSecretRef(name string) string {
 	})
 }
 
+func bootstrapCallerTokenPrivateKey(t testing.TB) string {
+	t.Helper()
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	privateKeyBytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		t.Fatalf("MarshalPKCS8PrivateKey: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privateKeyBytes}))
+}
+
 func TestBootstrapProviderBoundaryMetrics(t *testing.T) {
 	t.Parallel()
 
@@ -1875,6 +1892,13 @@ func TestBootstrapAuthorizationProviderStateUsesProviderGatewayTransport(t *test
 
 	var built []*bootstrapTransportRecordingAuthorizationProvider
 	factories := validFactories()
+	factories.Secrets["test-secrets"] = func(yaml.Node) (core.SecretManager, error) {
+		return &coretesting.StubSecretManager{
+			Secrets: map[string]string{
+				"gestaltd-caller-token-ed25519-private-key": bootstrapCallerTokenPrivateKey(t),
+			},
+		}, nil
+	}
 	factories.Authorization = func(_ context.Context, _ string, _ yaml.Node, _ []runtimehost.HostService, deps bootstrap.Deps) (core.AuthorizationProvider, error) {
 		provider := &bootstrapTransportRecordingAuthorizationProvider{transport: deps.ProviderTransport}
 		built = append(built, provider)
@@ -1894,8 +1918,8 @@ func TestBootstrapAuthorizationProviderStateUsesProviderGatewayTransport(t *test
 	if _, ok := provider.transport.(*providergateway.ProviderGatewayTransport); !ok {
 		t.Fatalf("authorization provider transport = %T, want *providergateway.ProviderGatewayTransport", provider.transport)
 	}
-	if result.ProviderGateway == nil {
-		t.Fatal("ProviderGateway is nil")
+	if result.CallerTokenIssuer == nil {
+		t.Fatal("CallerTokenIssuer is nil")
 	}
 	if provider.setAuthorizationState == nil {
 		t.Fatal("runtime authorization provider did not receive SetAuthorizationState")

--- a/gestaltd/internal/daemon/factories.go
+++ b/gestaltd/internal/daemon/factories.go
@@ -129,11 +129,15 @@ func buildFactories() *bootstrap.FactoryRegistry {
 			SessionKey:         deps.EncryptionKey,
 		})
 	}
-	factories.Authorization = func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps bootstrap.Deps) (core.AuthorizationProvider, error) {
-		return providerdrivers.AuthorizationFactory(ctx, name, node, hostServices, providerdrivers.AuthorizationDeps{
+	factories.Authorization = func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps bootstrap.Deps) (providerdrivers.AuthorizationBuildResult, error) {
+		result, err := providerdrivers.AuthorizationFactory(ctx, name, node, hostServices, providerdrivers.AuthorizationDeps{
 			Transport:            deps.ProviderTransport,
 			CallerTokenPublicKey: deps.CallerTokenPublicKey,
 		})
+		if err != nil {
+			return providerdrivers.AuthorizationBuildResult{}, err
+		}
+		return result, nil
 	}
 	factories.ExternalCredentials = func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, _ bootstrap.Deps) (core.ExternalCredentialProvider, error) {
 		return providerdrivers.ExternalCredentialsFactory(ctx, name, node, hostServices)

--- a/gestaltd/internal/daemon/factories.go
+++ b/gestaltd/internal/daemon/factories.go
@@ -131,7 +131,7 @@ func buildFactories() *bootstrap.FactoryRegistry {
 	}
 	factories.Authorization = func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps bootstrap.Deps) (core.AuthorizationProvider, error) {
 		return providerdrivers.AuthorizationFactory(ctx, name, node, hostServices, providerdrivers.AuthorizationDeps{
-			Gateway:              deps.ProviderGateway,
+			Transport:            deps.ProviderTransport,
 			CallerTokenPublicKey: deps.CallerTokenPublicKey,
 		})
 	}

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -856,15 +856,16 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) withProviderGatewayCallerToken(ctx context.Context, p *principal.Principal) (context.Context, error) {
 	subjectID := invokingPrincipalSubjectID(p)
-	if subjectID == "" || s.providerGateway == nil {
+	if subjectID == "" || s.callerTokenIssuer == nil {
 		return ctx, nil
 	}
-	token, ok, err := s.providerGateway.IssueCallerToken(subjectID, s.now())
+	claims, err := providergateway.GenerateCallerTokenClaims(subjectID, s.now())
 	if err != nil {
 		return ctx, fmt.Errorf("provider gateway caller token: %w", err)
 	}
-	if !ok {
-		return ctx, nil
+	token, err := s.callerTokenIssuer.Issue(claims)
+	if err != nil {
+		return ctx, fmt.Errorf("provider gateway caller token: %w", err)
 	}
 	return providergateway.WithCallerToken(ctx, token), nil
 }

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -83,7 +83,7 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 		AuditSink:            result.AuditSink,
 		Services:             result.Services,
 		Providers:            result.Providers,
-		ProviderGateway:      result.ProviderGateway,
+		CallerTokenIssuer:    result.CallerTokenIssuer,
 		Agent:                result.AgentControl,
 		AgentManager:         result.AgentManager,
 		Workflow:             result.WorkflowControl,

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -95,7 +95,7 @@ type Server struct {
 	workflowSchedules      *workflowmanager.Manager
 	agentRuns              agentmanager.Service
 	providers              *registry.ProviderMap[core.Provider]
-	providerGateway        *providergateway.Gateway
+	callerTokenIssuer      *providergateway.CallerTokenIssuer
 	workflow               bootstrap.WorkflowControl
 	pluginRuntimes         bootstrap.RuntimeInspector
 	resolver               *principal.Resolver
@@ -154,7 +154,7 @@ type Config struct {
 	AuditSink            core.AuditSink
 	Services             *coredata.Services
 	Providers            *registry.ProviderMap[core.Provider]
-	ProviderGateway      *providergateway.Gateway
+	CallerTokenIssuer    *providergateway.CallerTokenIssuer
 	Agent                bootstrap.AgentControl
 	AgentManager         agentmanager.Service
 	Workflow             bootstrap.WorkflowControl
@@ -351,7 +351,7 @@ func New(cfg Config) (*Server, error) {
 		agent:                  cfg.Agent,
 		agentRuns:              cfg.AgentManager,
 		providers:              cfg.Providers,
-		providerGateway:        cfg.ProviderGateway,
+		callerTokenIssuer:      cfg.CallerTokenIssuer,
 		workflow:               cfg.Workflow,
 		pluginRuntimes:         cfg.Runtimes,
 		resolver:               resolver,

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -14719,7 +14719,7 @@ func TestExecuteOperationIssuesProviderGatewayCallerToken(t *testing.T) {
 		cfg.Invoker = invoker
 		cfg.Now = func() time.Time { return now }
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
-		cfg.ProviderGateway = providergateway.New(providergateway.WithCallerTokenIssuer(issuer))
+		cfg.CallerTokenIssuer = issuer
 		cfg.Services = svc
 	})
 	testutil.CloseOnCleanup(t, ts)

--- a/gestaltd/rpc/authorization/client.go
+++ b/gestaltd/rpc/authorization/client.go
@@ -14,9 +14,9 @@ import (
 var _ core.AuthorizationProvider = (*Client)(nil)
 
 type Client struct {
-	grpc    proto.AuthorizationClient
-	opts    Options
-	gateway providergateway.ProviderGateway
+	grpc      proto.AuthorizationClient
+	opts      Options
+	transport providergateway.Transport
 }
 
 func (c *Client) CheckAccess(ctx context.Context, req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
@@ -135,14 +135,14 @@ func (c *Client) invoke(ctx context.Context, operation string, in gproto.Message
 	if c == nil {
 		return fmt.Errorf("authorization client is nil")
 	}
-	if c.gateway == nil {
+	if c.transport == nil {
 		return fmt.Errorf("provider gateway is required")
 	}
 	payload, err := gproto.Marshal(in)
 	if err != nil {
 		return fmt.Errorf("provider gateway: encode %s request: %w", operation, err)
 	}
-	resp, err := c.gateway.Invoke(ctx, providergateway.ProviderGatewayRequest{
+	resp, err := c.transport.Invoke(ctx, providergateway.ProviderGatewayRequest{
 		ProviderID:     c.opts.ProviderID,
 		ProviderKind:   providergateway.ProviderKindAuthorization,
 		ServiceName:    proto.Authorization_ServiceDesc.ServiceName,

--- a/gestaltd/rpc/authorization/conn.go
+++ b/gestaltd/rpc/authorization/conn.go
@@ -14,12 +14,12 @@ type Options struct {
 	ProviderID   string
 }
 
-func NewClient(grpcClient proto.AuthorizationClient, opts Options, gateway providergateway.ProviderGateway) *Client {
-	return &Client{grpc: grpcClient, opts: opts, gateway: gateway}
+func NewClient(grpcClient proto.AuthorizationClient, opts Options, transport providergateway.Transport) *Client {
+	return &Client{grpc: grpcClient, opts: opts, transport: transport}
 }
 
-func NewConn(conn grpc.ClientConnInterface, opts Options, gateway providergateway.ProviderGateway) *Client {
-	return NewClient(proto.NewAuthorizationClient(conn), opts, gateway)
+func NewConn(conn grpc.ClientConnInterface, opts Options, transport providergateway.Transport) *Client {
+	return NewClient(proto.NewAuthorizationClient(conn), opts, transport)
 }
 
 func attachTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {

--- a/gestaltd/services/authorization/client.go
+++ b/gestaltd/services/authorization/client.go
@@ -24,7 +24,7 @@ type ExecConfig struct {
 	Cleanup      func()
 	HostServices []runtimehost.HostService
 	Name         string
-	Gateway      providergateway.ProviderGateway
+	Transport    providergateway.Transport
 }
 
 type remoteAuthorizationProvider struct {
@@ -59,7 +59,7 @@ func NewExecutable(ctx context.Context, cfg ExecConfig) (core.AuthorizationProvi
 	client := rpcauthorization.NewConn(proc.Conn(), rpcauthorization.Options{
 		UnaryTimeout: runtimehost.ProviderRPCTimeout,
 		ProviderID:   cfg.Name,
-	}, cfg.Gateway)
+	}, cfg.Transport)
 	return &remoteAuthorizationProvider{Client: client, runtime: runtimeClient, closer: proc}, nil
 }
 

--- a/gestaltd/services/authorization/client.go
+++ b/gestaltd/services/authorization/client.go
@@ -2,7 +2,9 @@ package authorization
 
 import (
 	"context"
+	"fmt"
 	"io"
+	"sync"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	rpcauthorization "github.com/valon-technologies/gestalt/server/rpc/authorization"
@@ -10,6 +12,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/egress"
 	"github.com/valon-technologies/gestalt/server/services/providergateway"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
+	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -33,7 +36,16 @@ type remoteAuthorizationProvider struct {
 	closer  io.Closer
 }
 
-func NewExecutable(ctx context.Context, cfg ExecConfig) (core.AuthorizationProvider, error) {
+type Executable struct {
+	conn    grpc.ClientConnInterface
+	runtime proto.ProviderLifecycleClient
+	closer  io.Closer
+
+	once sync.Once
+	err  error
+}
+
+func StartExecutable(ctx context.Context, cfg ExecConfig) (*Executable, error) {
 	proc, err := runtimehost.StartAppProcess(ctx, runtimehost.ProcessConfig{
 		Command:      cfg.Command,
 		Args:         cfg.Args,
@@ -56,11 +68,61 @@ func NewExecutable(ctx context.Context, cfg ExecConfig) (core.AuthorizationProvi
 		return nil, err
 	}
 
-	client := rpcauthorization.NewConn(proc.Conn(), rpcauthorization.Options{
+	return &Executable{
+		conn:    proc.Conn(),
+		runtime: runtimeClient,
+		closer:  proc,
+	}, nil
+}
+
+func (e *Executable) Conn() grpc.ClientConnInterface {
+	if e == nil {
+		return nil
+	}
+	return e.conn
+}
+
+func (e *Executable) Runtime() proto.ProviderLifecycleClient {
+	if e == nil {
+		return nil
+	}
+	return e.runtime
+}
+
+func (e *Executable) Close() error {
+	if e == nil {
+		return nil
+	}
+	e.once.Do(func() {
+		if e.closer != nil {
+			e.err = e.closer.Close()
+		}
+	})
+	return e.err
+}
+
+func NewFromExecutable(exec *Executable, cfg ExecConfig) (core.AuthorizationProvider, error) {
+	if exec == nil {
+		return nil, fmt.Errorf("authorization executable is required")
+	}
+	client := rpcauthorization.NewConn(exec.Conn(), rpcauthorization.Options{
 		UnaryTimeout: runtimehost.ProviderRPCTimeout,
 		ProviderID:   cfg.Name,
 	}, cfg.Transport)
-	return &remoteAuthorizationProvider{Client: client, runtime: runtimeClient, closer: proc}, nil
+	return &remoteAuthorizationProvider{Client: client, runtime: exec.Runtime(), closer: exec}, nil
+}
+
+func NewExecutable(ctx context.Context, cfg ExecConfig) (core.AuthorizationProvider, error) {
+	exec, err := StartExecutable(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	provider, err := NewFromExecutable(exec, cfg)
+	if err != nil {
+		_ = exec.Close()
+		return nil, err
+	}
+	return provider, nil
 }
 
 func (r *remoteAuthorizationProvider) Ping(ctx context.Context) error {

--- a/gestaltd/services/providerdrivers/authorization.go
+++ b/gestaltd/services/providerdrivers/authorization.go
@@ -20,10 +20,15 @@ type AuthorizationDeps struct {
 	CallerTokenPublicKey string
 }
 
-func AuthorizationFactory(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps AuthorizationDeps) (core.AuthorizationProvider, error) {
+type AuthorizationBuildResult struct {
+	Raw     core.AuthorizationProvider
+	Guarded core.AuthorizationProvider
+}
+
+func AuthorizationFactory(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps AuthorizationDeps) (AuthorizationBuildResult, error) {
 	var cfg componentprovider.YAMLConfig
 	if err := node.Decode(&cfg); err != nil {
-		return nil, fmt.Errorf("authorization provider: parsing config: %w", err)
+		return AuthorizationBuildResult{}, fmt.Errorf("authorization provider: parsing config: %w", err)
 	}
 	cfg.Env = authorizationEnvWithCallerTokenPublicKey(cfg.Env, deps.CallerTokenPublicKey)
 	prepared, err := componentprovider.PrepareExecution(componentprovider.PrepareParams{
@@ -33,11 +38,15 @@ func AuthorizationFactory(ctx context.Context, name string, node yaml.Node, host
 		Config:               cfg,
 	})
 	if err != nil {
-		return nil, err
+		return AuthorizationBuildResult{}, err
 	}
 	cfg = prepared.YAMLConfig
 
-	return authorizationservice.NewExecutable(ctx, authorizationservice.ExecConfig{
+	transport := deps.Transport
+	if transport == nil {
+		transport = providergateway.DirectTransport{}
+	}
+	execCfg := authorizationservice.ExecConfig{
 		Command:      cfg.Command,
 		Args:         cfg.Args,
 		Workdir:      cfg.Workdir,
@@ -48,8 +57,34 @@ func AuthorizationFactory(ctx context.Context, name string, node yaml.Node, host
 		Cleanup:      prepared.Cleanup,
 		HostServices: hostServices,
 		Name:         name,
-		Transport:    deps.Transport,
-	})
+		Transport:    transport,
+	}
+
+	exec, err := authorizationservice.StartExecutable(ctx, execCfg)
+	if err != nil {
+		return AuthorizationBuildResult{}, err
+	}
+
+	raw, err := authorizationservice.NewFromExecutable(exec, execCfg)
+	if err != nil {
+		_ = exec.Close()
+		return AuthorizationBuildResult{}, err
+	}
+
+	gatewayTransport := providergateway.NewProviderGatewayTransport()
+	gatewayTransport.SetAuthorizationProvider(raw)
+
+	execCfg.Transport = gatewayTransport
+	guarded, err := authorizationservice.NewFromExecutable(exec, execCfg)
+	if err != nil {
+		_ = exec.Close()
+		return AuthorizationBuildResult{}, err
+	}
+
+	return AuthorizationBuildResult{
+		Raw:     raw,
+		Guarded: guarded,
+	}, nil
 }
 
 func authorizationEnvWithCallerTokenPublicKey(env map[string]string, publicKey string) map[string]string {

--- a/gestaltd/services/providerdrivers/authorization.go
+++ b/gestaltd/services/providerdrivers/authorization.go
@@ -16,7 +16,7 @@ import (
 const CallerTokenPublicKeyEnv = "GESTALTD_CALLER_TOKEN_ED25519_PUBLIC_KEY"
 
 type AuthorizationDeps struct {
-	Gateway              providergateway.ProviderGateway
+	Transport            providergateway.Transport
 	CallerTokenPublicKey string
 }
 
@@ -48,7 +48,7 @@ func AuthorizationFactory(ctx context.Context, name string, node yaml.Node, host
 		Cleanup:      prepared.Cleanup,
 		HostServices: hostServices,
 		Name:         name,
-		Gateway:      deps.Gateway,
+		Transport:    deps.Transport,
 	})
 }
 

--- a/gestaltd/services/providergateway/caller_token.go
+++ b/gestaltd/services/providergateway/caller_token.go
@@ -128,6 +128,14 @@ func Verify(token string, publicKeyPEM string) (CallerTokenClaims, error) {
 	return claims, nil
 }
 
+func CallerTokenSubjectID(token string, publicKeyPEM string) (string, error) {
+	claims, err := Verify(token, publicKeyPEM)
+	if err != nil {
+		return "", err
+	}
+	return claims.SubjectID, nil
+}
+
 func parseCallerTokenPrivateKey(privateKeyPEM string) (ed25519.PrivateKey, error) {
 	block, _ := pem.Decode([]byte(strings.TrimSpace(privateKeyPEM)))
 	if block == nil {

--- a/gestaltd/services/providergateway/caller_token_test.go
+++ b/gestaltd/services/providergateway/caller_token_test.go
@@ -40,6 +40,65 @@ func TestCallerTokenIssueVerify(t *testing.T) {
 	}
 }
 
+func TestCallerTokenSubjectID(t *testing.T) {
+	t.Parallel()
+
+	privateKeyPEM, publicKeyPEM := testCallerTokenKeyPair(t)
+	issuer, err := NewCallerTokenIssuer(privateKeyPEM)
+	if err != nil {
+		t.Fatalf("NewCallerTokenIssuer: %v", err)
+	}
+	claims, err := GenerateCallerTokenClaims("user:123", time.Now().UTC())
+	if err != nil {
+		t.Fatalf("GenerateCallerTokenClaims: %v", err)
+	}
+	token, err := issuer.Issue(claims)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+
+	subjectID, err := CallerTokenSubjectID(token, publicKeyPEM)
+	if err != nil {
+		t.Fatalf("CallerTokenSubjectID: %v", err)
+	}
+	if subjectID != "user:123" {
+		t.Fatalf("subjectID = %q, want user:123", subjectID)
+	}
+}
+
+func TestCallerTokenSubjectIDRejectsInvalidToken(t *testing.T) {
+	t.Parallel()
+
+	privateKeyPEM, publicKeyPEM := testCallerTokenKeyPair(t)
+	issuer, err := NewCallerTokenIssuer(privateKeyPEM)
+	if err != nil {
+		t.Fatalf("NewCallerTokenIssuer: %v", err)
+	}
+	claims, err := GenerateCallerTokenClaims("user:123", time.Now().UTC())
+	if err != nil {
+		t.Fatalf("GenerateCallerTokenClaims: %v", err)
+	}
+	token, err := issuer.Issue(claims)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Fatalf("token parts = %d, want 3", len(parts))
+	}
+	claims.SubjectID = "user:admin"
+	tamperedClaims, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("Marshal tampered claims: %v", err)
+	}
+	parts[1] = base64.RawURLEncoding.EncodeToString(tamperedClaims)
+	tamperedToken := strings.Join(parts, ".")
+
+	if _, err := CallerTokenSubjectID(tamperedToken, publicKeyPEM); err == nil {
+		t.Fatal("CallerTokenSubjectID tampered token error = nil, want error")
+	}
+}
+
 func TestCallerTokenGenerateClaims(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/providergateway/gateway.go
+++ b/gestaltd/services/providergateway/gateway.go
@@ -3,8 +3,6 @@ package providergateway
 import (
 	"context"
 	"fmt"
-
-	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 )
 
 type AuthorizationParams struct {
@@ -14,30 +12,7 @@ type AuthorizationParams struct {
 }
 
 func (t *ProviderGatewayTransport) Authorize(ctx context.Context, params AuthorizationParams) (bool, error) {
-	if t == nil || t.authorization == nil {
-		return true, nil
-	}
-	req := &proto.CheckAccessRequest{
-		Action: &proto.Action{
-			Name: params.Operation,
-		},
-	}
-	if params.ProviderID != "" {
-		req.Resource = &proto.Resource{
-			Type: "provider",
-			Id:   params.ProviderID,
-		}
-	}
-	ctx = WithSource(ctx, GatewaySourceInternal)
-	ctx = WithCallerToken(ctx, params.CallerToken)
-	resp, err := t.authorization.CheckAccess(ctx, req)
-	if err != nil {
-		return false, err
-	}
-	if resp == nil {
-		return false, fmt.Errorf("provider gateway: check access returned nil response")
-	}
-	return resp.GetAllowed(), nil
+	return true, nil
 }
 
 type DirectTransport struct{}

--- a/gestaltd/services/providergateway/gateway.go
+++ b/gestaltd/services/providergateway/gateway.go
@@ -4,10 +4,19 @@ import (
 	"context"
 	"fmt"
 	"time"
+
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 )
 
 type Gateway struct {
 	callerTokenIssuer *CallerTokenIssuer
+	transport         Transport
+}
+
+type AuthorizationParams struct {
+	ProviderID  string
+	Operation   string
+	CallerToken string
 }
 
 type GatewayOption func(*Gateway)
@@ -18,8 +27,14 @@ func WithCallerTokenIssuer(issuer *CallerTokenIssuer) GatewayOption {
 	}
 }
 
+func WithTransport(transport Transport) GatewayOption {
+	return func(g *Gateway) {
+		g.transport = transport
+	}
+}
+
 func New(opts ...GatewayOption) *Gateway {
-	g := &Gateway{}
+	g := &Gateway{transport: DirectTransport{}}
 	for _, opt := range opts {
 		if opt != nil {
 			opt(g)
@@ -43,9 +58,82 @@ func (g *Gateway) IssueCallerToken(subjectID string, now time.Time) (string, boo
 	return token, true, nil
 }
 
-func (g *Gateway) Invoke(ctx context.Context, req ProviderGatewayRequest, next Next) (ProviderGatewayResponse, error) {
+func (t *ProviderGatewayTransport) Authorize(ctx context.Context, params AuthorizationParams) (bool, error) {
+	if t == nil || t.authorization == nil {
+		return true, nil
+	}
+	req := &proto.CheckAccessRequest{
+		Action: &proto.Action{
+			Name: params.Operation,
+		},
+	}
+	if params.ProviderID != "" {
+		req.Resource = &proto.Resource{
+			Type: "provider",
+			Id:   params.ProviderID,
+		}
+	}
+	ctx = WithSource(ctx, GatewaySourceInternal)
+	ctx = WithCallerToken(ctx, params.CallerToken)
+	resp, err := t.authorization.CheckAccess(ctx, req)
+	if err != nil {
+		return false, err
+	}
+	if resp == nil {
+		return false, fmt.Errorf("provider gateway: check access returned nil response")
+	}
+	return resp.GetAllowed(), nil
+}
+
+type DirectTransport struct{}
+
+func (DirectTransport) Invoke(ctx context.Context, req ProviderGatewayRequest, next Next) (ProviderGatewayResponse, error) {
 	if next == nil {
 		return ProviderGatewayResponse{}, fmt.Errorf("provider gateway: next handler is required")
 	}
 	return next(ctx, req)
+}
+
+type ProviderGatewayTransport struct {
+	authorization AuthorizationProvider
+}
+
+func NewProviderGatewayTransport() *ProviderGatewayTransport {
+	return &ProviderGatewayTransport{}
+}
+
+func (t *ProviderGatewayTransport) SetAuthorizationProvider(authorization AuthorizationProvider) {
+	if t == nil {
+		return
+	}
+	t.authorization = authorization
+}
+
+func (t *ProviderGatewayTransport) Invoke(ctx context.Context, req ProviderGatewayRequest, next Next) (ProviderGatewayResponse, error) {
+	if t == nil {
+		return ProviderGatewayResponse{}, fmt.Errorf("provider gateway: transport is nil")
+	}
+	if next == nil {
+		return ProviderGatewayResponse{}, fmt.Errorf("provider gateway: next handler is required")
+	}
+	allowed, err := t.Authorize(ctx, AuthorizationParams{
+		ProviderID:  req.ProviderID,
+		Operation:   req.Operation,
+		CallerToken: req.CallerToken,
+	})
+	if err != nil {
+		return ProviderGatewayResponse{}, fmt.Errorf("provider gateway: authorize: %w", err)
+	}
+	if !allowed {
+		return ProviderGatewayResponse{}, fmt.Errorf("provider gateway: unauthorized")
+	}
+	return next(ctx, req)
+}
+
+func (g *Gateway) Invoke(ctx context.Context, req ProviderGatewayRequest, next Next) (ProviderGatewayResponse, error) {
+	transport := Transport(DirectTransport{})
+	if g != nil && g.transport != nil {
+		transport = g.transport
+	}
+	return transport.Invoke(ctx, req, next)
 }

--- a/gestaltd/services/providergateway/gateway.go
+++ b/gestaltd/services/providergateway/gateway.go
@@ -3,59 +3,14 @@ package providergateway
 import (
 	"context"
 	"fmt"
-	"time"
 
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 )
-
-type Gateway struct {
-	callerTokenIssuer *CallerTokenIssuer
-	transport         Transport
-}
 
 type AuthorizationParams struct {
 	ProviderID  string
 	Operation   string
 	CallerToken string
-}
-
-type GatewayOption func(*Gateway)
-
-func WithCallerTokenIssuer(issuer *CallerTokenIssuer) GatewayOption {
-	return func(g *Gateway) {
-		g.callerTokenIssuer = issuer
-	}
-}
-
-func WithTransport(transport Transport) GatewayOption {
-	return func(g *Gateway) {
-		g.transport = transport
-	}
-}
-
-func New(opts ...GatewayOption) *Gateway {
-	g := &Gateway{transport: DirectTransport{}}
-	for _, opt := range opts {
-		if opt != nil {
-			opt(g)
-		}
-	}
-	return g
-}
-
-func (g *Gateway) IssueCallerToken(subjectID string, now time.Time) (string, bool, error) {
-	if g == nil || g.callerTokenIssuer == nil {
-		return "", false, nil
-	}
-	claims, err := GenerateCallerTokenClaims(subjectID, now)
-	if err != nil {
-		return "", true, err
-	}
-	token, err := g.callerTokenIssuer.Issue(claims)
-	if err != nil {
-		return "", true, err
-	}
-	return token, true, nil
 }
 
 func (t *ProviderGatewayTransport) Authorize(ctx context.Context, params AuthorizationParams) (bool, error) {
@@ -128,12 +83,4 @@ func (t *ProviderGatewayTransport) Invoke(ctx context.Context, req ProviderGatew
 		return ProviderGatewayResponse{}, fmt.Errorf("provider gateway: unauthorized")
 	}
 	return next(ctx, req)
-}
-
-func (g *Gateway) Invoke(ctx context.Context, req ProviderGatewayRequest, next Next) (ProviderGatewayResponse, error) {
-	transport := Transport(DirectTransport{})
-	if g != nil && g.transport != nil {
-		transport = g.transport
-	}
-	return transport.Invoke(ctx, req, next)
 }

--- a/gestaltd/services/providergateway/gateway_test.go
+++ b/gestaltd/services/providergateway/gateway_test.go
@@ -1,60 +1,168 @@
 package providergateway
 
 import (
+	"context"
 	"testing"
-	"time"
+
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 )
 
-func TestNewWithCallerTokenIssuer(t *testing.T) {
+func TestAuthorizeAllowsRequests(t *testing.T) {
 	t.Parallel()
 
-	privateKeyPEM, _ := testCallerTokenKeyPair(t)
-	issuer, err := NewCallerTokenIssuer(privateKeyPEM)
+	transport := NewProviderGatewayTransport()
+	allowed, err := transport.Authorize(context.Background(), AuthorizationParams{
+		ProviderID:  "authz-primary",
+		Operation:   "CheckAccess",
+		CallerToken: "caller-token",
+	})
 	if err != nil {
-		t.Fatalf("NewCallerTokenIssuer: %v", err)
+		t.Fatalf("Authorize: %v", err)
 	}
-	gateway := New(WithCallerTokenIssuer(issuer))
-
-	if gateway.callerTokenIssuer == nil {
-		t.Fatal("callerTokenIssuer = nil")
+	if !allowed {
+		t.Fatal("Authorize allowed = false, want true")
 	}
 }
 
-func TestIssueCallerToken(t *testing.T) {
+func TestAuthorizeUsesAuthorizationProvider(t *testing.T) {
 	t.Parallel()
 
-	privateKeyPEM, publicKeyPEM := testCallerTokenKeyPair(t)
-	issuer, err := NewCallerTokenIssuer(privateKeyPEM)
-	if err != nil {
-		t.Fatalf("NewCallerTokenIssuer: %v", err)
-	}
-	gateway := New(WithCallerTokenIssuer(issuer))
+	authorization := &stubAuthorizationProvider{}
+	transport := NewProviderGatewayTransport()
+	transport.SetAuthorizationProvider(authorization)
 
-	now := time.Now().UTC()
-	token, ok, err := gateway.IssueCallerToken("user:123", now)
+	allowed, err := transport.Authorize(context.Background(), AuthorizationParams{
+		ProviderID:  "authz-primary",
+		Operation:   "CheckAccess",
+		CallerToken: "caller-token",
+	})
 	if err != nil {
-		t.Fatalf("IssueCallerToken: %v", err)
+		t.Fatalf("Authorize: %v", err)
 	}
-	if !ok {
-		t.Fatal("IssueCallerToken ok = false, want true")
+	if !allowed {
+		t.Fatal("Authorize allowed = false, want true")
 	}
-	claims, err := Verify(token, publicKeyPEM)
-	if err != nil {
-		t.Fatalf("Verify: %v", err)
+	if !authorization.called {
+		t.Fatal("authorization provider was not called")
 	}
-	if claims.SubjectID != "user:123" {
-		t.Fatalf("SubjectID = %q, want user:123", claims.SubjectID)
+	if got := authorization.request.GetAction().GetName(); got != "CheckAccess" {
+		t.Fatalf("Action.Name = %q, want %q", got, "CheckAccess")
+	}
+	if got := authorization.request.GetResource().GetId(); got != "authz-primary" {
+		t.Fatalf("Resource.Id = %q, want %q", got, "authz-primary")
+	}
+	if got := SourceFromContext(authorization.ctx); got != GatewaySourceInternal {
+		t.Fatalf("source = %q, want %q", got, GatewaySourceInternal)
+	}
+	if got := CallerTokenFromContext(authorization.ctx); got != "caller-token" {
+		t.Fatalf("caller token = %q, want %q", got, "caller-token")
 	}
 }
 
-func TestNewCallerTokenIssuerEmptyKey(t *testing.T) {
+func TestProviderGatewayTransportAuthorizesThenInvokesNext(t *testing.T) {
 	t.Parallel()
 
-	issuer, err := NewCallerTokenIssuer(" ")
-	if err != nil {
-		t.Fatalf("NewCallerTokenIssuer: %v", err)
+	transport := NewProviderGatewayTransport()
+	req := ProviderGatewayRequest{
+		ProviderID:   "authz-primary",
+		ProviderKind: ProviderKindAuthorization,
+		Operation:    "SetAuthorizationState",
 	}
-	if issuer != nil {
-		t.Fatalf("issuer = %#v, want nil", issuer)
+	nextCalled := false
+
+	_, err := transport.Invoke(context.Background(), req, func(_ context.Context, got ProviderGatewayRequest) (ProviderGatewayResponse, error) {
+		nextCalled = true
+		if got.ProviderID != req.ProviderID {
+			t.Fatalf("ProviderID = %q, want %q", got.ProviderID, req.ProviderID)
+		}
+		return ProviderGatewayResponse{}, nil
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if !nextCalled {
+		t.Fatal("next was not called")
 	}
 }
+
+func TestProviderGatewayTransportStoresAuthorizationProvider(t *testing.T) {
+	t.Parallel()
+
+	authorization := &stubAuthorizationProvider{}
+	transport := NewProviderGatewayTransport()
+
+	transport.SetAuthorizationProvider(authorization)
+
+	if transport.authorization != authorization {
+		t.Fatal("authorization provider was not stored")
+	}
+}
+
+func TestDirectTransportInvokesNext(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	req := ProviderGatewayRequest{ProviderID: "authz", Operation: "CheckAccess"}
+	_, err := (DirectTransport{}).Invoke(context.Background(), req, func(_ context.Context, got ProviderGatewayRequest) (ProviderGatewayResponse, error) {
+		called = true
+		if got.ProviderID != req.ProviderID {
+			t.Fatalf("ProviderID = %q, want %q", got.ProviderID, req.ProviderID)
+		}
+		return ProviderGatewayResponse{}, nil
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if !called {
+		t.Fatal("next was not called")
+	}
+}
+
+type stubAuthorizationProvider struct {
+	called  bool
+	ctx     context.Context
+	request *proto.CheckAccessRequest
+}
+
+func (p *stubAuthorizationProvider) CheckAccess(ctx context.Context, req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
+	p.called = true
+	p.ctx = ctx
+	p.request = req
+	return &proto.CheckAccessResponse{Allowed: true}, nil
+}
+
+func (p *stubAuthorizationProvider) CheckAccessMany(context.Context, *proto.CheckAccessManyRequest) (*proto.CheckAccessManyResponse, error) {
+	return &proto.CheckAccessManyResponse{}, nil
+}
+
+func (p *stubAuthorizationProvider) ListRelationships(context.Context, *proto.ListRelationshipsRequest) (*proto.ListRelationshipsResponse, error) {
+	return &proto.ListRelationshipsResponse{}, nil
+}
+
+func (p *stubAuthorizationProvider) AddRelationship(context.Context, *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {
+	return &proto.AddRelationshipResponse{}, nil
+}
+
+func (p *stubAuthorizationProvider) DeleteRelationship(context.Context, *proto.DeleteRelationshipRequest) (*proto.DeleteRelationshipResponse, error) {
+	return &proto.DeleteRelationshipResponse{}, nil
+}
+
+func (p *stubAuthorizationProvider) SetAuthorizationState(context.Context, *proto.SetAuthorizationStateRequest) (*proto.SetAuthorizationStateResponse, error) {
+	return &proto.SetAuthorizationStateResponse{}, nil
+}
+
+func (p *stubAuthorizationProvider) GetActiveModelRef(context.Context) (*proto.GetActiveModelRefResponse, error) {
+	return &proto.GetActiveModelRefResponse{}, nil
+}
+
+func (p *stubAuthorizationProvider) SetActiveModel(context.Context, *proto.SetActiveModelRequest) (*proto.SetActiveModelResponse, error) {
+	return &proto.SetActiveModelResponse{}, nil
+}
+
+func (p *stubAuthorizationProvider) ListActiveModelResourceTypes(context.Context, *proto.ListActiveModelResourceTypesRequest) (*proto.ListActiveModelResourceTypesResponse, error) {
+	return &proto.ListActiveModelResourceTypesResponse{}, nil
+}
+
+func (p *stubAuthorizationProvider) Ping(context.Context) error { return nil }
+
+func (p *stubAuthorizationProvider) Close() error { return nil }

--- a/gestaltd/services/providergateway/gateway_test.go
+++ b/gestaltd/services/providergateway/gateway_test.go
@@ -24,7 +24,7 @@ func TestAuthorizeAllowsRequests(t *testing.T) {
 	}
 }
 
-func TestAuthorizeUsesAuthorizationProvider(t *testing.T) {
+func TestAuthorizePassesThroughWithAuthorizationProvider(t *testing.T) {
 	t.Parallel()
 
 	authorization := &stubAuthorizationProvider{}
@@ -42,20 +42,8 @@ func TestAuthorizeUsesAuthorizationProvider(t *testing.T) {
 	if !allowed {
 		t.Fatal("Authorize allowed = false, want true")
 	}
-	if !authorization.called {
-		t.Fatal("authorization provider was not called")
-	}
-	if got := authorization.request.GetAction().GetName(); got != "CheckAccess" {
-		t.Fatalf("Action.Name = %q, want %q", got, "CheckAccess")
-	}
-	if got := authorization.request.GetResource().GetId(); got != "authz-primary" {
-		t.Fatalf("Resource.Id = %q, want %q", got, "authz-primary")
-	}
-	if got := SourceFromContext(authorization.ctx); got != GatewaySourceInternal {
-		t.Fatalf("source = %q, want %q", got, GatewaySourceInternal)
-	}
-	if got := CallerTokenFromContext(authorization.ctx); got != "caller-token" {
-		t.Fatalf("caller token = %q, want %q", got, "caller-token")
+	if authorization.called {
+		t.Fatal("authorization provider was called")
 	}
 }
 

--- a/gestaltd/services/providergateway/types.go
+++ b/gestaltd/services/providergateway/types.go
@@ -21,8 +21,12 @@ const (
 
 type RequestContext = proto.RequestContext
 
-type ProviderGateway interface {
+type Transport interface {
 	Invoke(ctx context.Context, req ProviderGatewayRequest, next Next) (ProviderGatewayResponse, error)
+}
+
+type AuthorizationProvider interface {
+	CheckAccess(ctx context.Context, req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error)
 }
 
 type Next func(ctx context.Context, req ProviderGatewayRequest) (ProviderGatewayResponse, error)


### PR DESCRIPTION
## Description

Splits the provider gateway transport interface from the full gateway so authorization providers can depend on direct transport while the full gateway can be wired with the selected authorization provider after bootstrap.