### PR TITLE
sdkgen: Go provider-surface emitter code

### DIFF
--- a/sdk/tools/sdkgen/internal/emit/golang/render_server.go
+++ b/sdk/tools/sdkgen/internal/emit/golang/render_server.go
@@ -1,0 +1,149 @@
+package golang
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/sdk/tools/sdkgen/internal/model"
+)
+
+// providerName renders the handler interface name for a provider service:
+// the service name with a Provider suffix. A service already named *Provider
+// takes a Handler suffix instead — its generated client owns the bare name
+// (service AppProvider: client AppProvider, handler AppProviderHandler).
+func providerName(svcName string) string {
+	if strings.HasSuffix(svcName, "Provider") {
+		return svcName + "Handler"
+	}
+	return svcName + "Provider"
+}
+
+// operationString renders the human-readable operation tag carried on
+// handler errors: the lowercased service name followed by the method name
+// split on word boundaries ("workflow apply definition").
+func operationString(svcName, methodName string) string {
+	var b strings.Builder
+	b.WriteString(strings.ToLower(svcName))
+	for i, r := range methodName {
+		if i == 0 || (r >= 'A' && r <= 'Z') {
+			b.WriteByte(' ')
+		}
+		b.WriteRune(r)
+	}
+	return strings.ToLower(strings.Join(strings.Fields(b.String()), " "))
+}
+
+// handlerSignature renders one handler method's parameter and result lists.
+// Handlers are transport-shaped: the full native request in, the full native
+// response out. Client-side call ergonomics (signature flattening, response
+// collapses) intentionally do not apply.
+func (r *renderer) handlerSignature(m *model.Method) (params, results string) {
+	params = "ctx context.Context"
+	if !m.InputIsEmpty {
+		params += ", request *" + r.messageType(m.Input.FullName)
+	}
+	if m.OutputIsEmpty {
+		return params, "error"
+	}
+	return params, fmt.Sprintf("(*%s, error)", r.messageType(m.Output.FullName))
+}
+
+// renderProviderHandler renders the native handler interface and its
+// Unimplemented defaults struct for one provider service.
+func (r *renderer) renderProviderHandler(svc *model.Service) {
+	name := providerName(localName(svc.FullName))
+	r.features.context = true
+
+	r.writeIdentDoc("", fmt.Sprintf("%s is the handler interface implemented by providers serving\nthe %s service. Methods receive the full native request;\nwire conversion and error mapping live in the generated adapter (see\n[New%sServer]). Embed [Unimplemented%s] to default\nunimplemented methods.", name, svc.FullName, name, name), svc.Doc)
+	fmt.Fprintf(&r.body, "type %s interface {\n", name)
+	for _, m := range svc.Methods {
+		r.writeIdentDoc("\t", fmt.Sprintf("%s handles the %s RPC.", m.Name, m.Name), m.Doc)
+		params, results := r.handlerSignature(m)
+		fmt.Fprintf(&r.body, "\t%s(%s) %s\n", m.Name, params, results)
+	}
+	r.body.WriteString("}\n\n")
+
+	fmt.Fprintf(&r.body, "// Unimplemented%s fails every %s method with a\n// GestaltErrorCodeUnimplemented error; embed it to default the methods a\n// provider does not implement.\n", name, name)
+	fmt.Fprintf(&r.body, "type Unimplemented%s struct{}\n\n", name)
+	for _, m := range svc.Methods {
+		params, results := r.handlerSignature(m)
+		op := operationString(localName(svc.FullName), m.Name)
+		fmt.Fprintf(&r.body, "// %s returns Unimplemented; embed Unimplemented%s to default\n// unimplemented handler methods.\n", m.Name, name)
+		fmt.Fprintf(&r.body, "func (Unimplemented%s) %s(%s) %s {\n", name, m.Name, stripParamNames(params), results)
+		failure := fmt.Sprintf("&GestaltError{Code: GestaltErrorCodeUnimplemented, Message: %q}", op+" is not implemented")
+		if m.OutputIsEmpty {
+			fmt.Fprintf(&r.body, "\treturn %s\n}\n\n", failure)
+		} else {
+			fmt.Fprintf(&r.body, "\treturn nil, %s\n}\n\n", failure)
+		}
+	}
+}
+
+// stripParamNames rewrites a parameter list to types only, for method stubs
+// whose bodies ignore every argument.
+func stripParamNames(params string) string {
+	parts := strings.Split(params, ", ")
+	for i, p := range parts {
+		if j := strings.IndexByte(p, ' '); j >= 0 {
+			parts[i] = p[j+1:]
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+// renderProviderServer renders the wire dispatch adapter for one provider
+// service: a wire-level gRPC server that converts requests from the wire,
+// calls the handler, converts responses back, and maps handler errors to
+// gRPC statuses.
+func (r *renderer) renderProviderServer(svc *model.Service) {
+	svcName := localName(svc.FullName)
+	name := providerName(svcName)
+	adapter := lowerFirst(name) + "Server"
+	r.features.context = true
+	r.features.proto = true
+
+	fmt.Fprintf(&r.body, "// New%sServer adapts provider to the wire-level\n// [proto.%sServer]: requests convert from the wire, responses convert to\n// the wire, and handler errors map to gRPC statuses.\n", name, svcName)
+	fmt.Fprintf(&r.body, "func New%sServer(provider %s) proto.%sServer {\n", name, name, svcName)
+	fmt.Fprintf(&r.body, "\treturn &%s{provider: provider}\n}\n\n", adapter)
+
+	fmt.Fprintf(&r.body, "type %s struct {\n\tproto.Unimplemented%sServer\n\tprovider %s\n}\n\n", adapter, svcName, name)
+
+	for _, m := range svc.Methods {
+		op := operationString(svcName, m.Name)
+		wireIn, wireOut := "*emptypb.Empty", "*emptypb.Empty"
+		if !m.InputIsEmpty {
+			wireIn = "*" + wireMessage(m.Input.FullName)
+		}
+		if !m.OutputIsEmpty {
+			wireOut = "*" + wireMessage(m.Output.FullName)
+		}
+		if m.InputIsEmpty || m.OutputIsEmpty {
+			r.features.emptypb = true
+		}
+
+		requestParam := "request " + wireIn
+		callArgs := "ctx"
+		if m.InputIsEmpty {
+			requestParam = "_ " + wireIn
+		} else {
+			callArgs += ", " + fromWireFunc(r.messageType(m.Input.FullName)) + "(request)"
+		}
+
+		fmt.Fprintf(&r.body, "func (s *%s) %s(ctx context.Context, %s) (%s, error) {\n", adapter, m.Name, requestParam, wireOut)
+		if m.OutputIsEmpty {
+			fmt.Fprintf(&r.body, "\tif err := s.provider.%s(%s); err != nil {\n\t\treturn nil, statusError(%q, err)\n\t}\n", m.Name, callArgs, op)
+			r.body.WriteString("\treturn &emptypb.Empty{}, nil\n}\n\n")
+		} else {
+			fmt.Fprintf(&r.body, "\tresponse, err := s.provider.%s(%s)\n", m.Name, callArgs)
+			fmt.Fprintf(&r.body, "\tif err != nil {\n\t\treturn nil, statusError(%q, err)\n\t}\n", op)
+			fmt.Fprintf(&r.body, "\treturn %s(response), nil\n}\n\n", toWireFunc(r.messageType(m.Output.FullName)))
+		}
+	}
+}
+
+func lowerFirst(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToLower(s[:1]) + s[1:]
+}

--- a/sdk/tools/sdkgen/internal/emit/golang/render_server_test.go
+++ b/sdk/tools/sdkgen/internal/emit/golang/render_server_test.go
@@ -1,0 +1,65 @@
+package golang
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/sdk/tools/sdkgen/internal/model"
+)
+
+// TestRenderProviderSurface exercises the provider handler + dispatch adapter
+// rendering in isolation, before it is wired into Emit(). It renders a small
+// hand-built provider service and asserts the shape of the generated handler
+// interface, the Unimplemented defaults, and the wire dispatch adapter, so the
+// rendering logic is reviewable on its own. Hermetic: no buf, no pipeline.
+func TestRenderProviderSurface(t *testing.T) {
+	t.Parallel()
+
+	req := &model.Message{FullName: "gestalt.test.v1.FooRequest", Name: "FooRequest", ProtoFile: "test.proto"}
+	resp := &model.Message{FullName: "gestalt.test.v1.FooResponse", Name: "FooResponse", ProtoFile: "test.proto"}
+	svc := &model.Service{
+		FullName: "gestalt.test.v1.Thing",
+		Name:     "Thing",
+		Provider: true,
+		Methods: []*model.Method{
+			{Name: "Foo", Stream: model.Unary, Input: req, Output: resp},
+			{Name: "Bar", Stream: model.Unary, Input: req, OutputIsEmpty: true},
+		},
+	}
+	idx := &index{
+		messages: map[string]*model.Message{req.FullName: req, resp.FullName: resp},
+		enums:    map[string]*model.Enum{},
+	}
+
+	r := newRenderer(idx)
+	r.renderProviderHandler(svc)
+	r.renderProviderServer(svc)
+	out := r.assemble()
+
+	for _, want := range []string{
+		// Handler interface: one method per RPC, transport-shaped (full request
+		// in, full response out); an Empty response collapses to error-only.
+		"type ThingProvider interface {",
+		"Foo(ctx context.Context, request *FooRequest) (*FooResponse, error)",
+		"Bar(ctx context.Context, request *FooRequest) error",
+		// Unimplemented defaults carrying the canonical error code + operation.
+		"type UnimplementedThingProvider struct{}",
+		"GestaltErrorCodeUnimplemented",
+		"thing foo is not implemented",
+		// Wire dispatch adapter over the existing codecs + error mapping.
+		"func NewThingProviderServer(provider ThingProvider) proto.ThingServer {",
+		"fromWireFooRequest(request)",
+		"toWireFooResponse(response)",
+		`statusError("thing foo", err)`,
+		"return &emptypb.Empty{}, nil",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rendered provider surface missing %q\n---\n%s", want, out)
+		}
+	}
+
+	// The provider error-mapping support file backs the generated adapter.
+	if !strings.Contains(serverSupportFile, "func statusError(operation string, err error) error") {
+		t.Error("serverSupportFile missing statusError")
+	}
+}

--- a/sdk/tools/sdkgen/internal/emit/golang/support.go
+++ b/sdk/tools/sdkgen/internal/emit/golang/support.go
@@ -227,6 +227,35 @@ func applyInvokeErrorFields(err *InvokeError, parsed any) {
 }
 `
 
+// serverSupportFile is the provider-side error mapping, emitted as
+// support_server.go when any service carries the provider annotation.
+const serverSupportFile = `package client
+
+import (
+	"errors"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// statusError converts one handler error to the gRPC status returned to the
+// host: *GestaltError carries its code through, status errors pass through
+// unchanged, and any other error is codes.Unknown tagged with the operation.
+func statusError(operation string, err error) error {
+	if err == nil {
+		return nil
+	}
+	var gerr *GestaltError
+	if errors.As(err, &gerr) {
+		return status.Error(codes.Code(gerr.Code), gerr.Message)
+	}
+	if st, ok := status.FromError(err); ok {
+		return st.Err()
+	}
+	return status.Errorf(codes.Unknown, "%s: %v", operation, err)
+}
+`
+
 // contextSupportFile is the client option machinery, emitted as
 // support_context.go when any service carries a request context. The fmt verb
 // is the native request context type.


### PR DESCRIPTION
## Summary

The Go emitter's provider rendering — the second layer of the stack on top of the `provider` annotation (#2433). For any service carrying `provider`, this generates the native handler interface, `Unimplemented` defaults, and the wire dispatch adapter, built on the bidirectional codecs sdkgen already emits.

This PR is the rendering logic only, exercised by a hermetic unit test. It is **not wired into `Emit()`**, so no generated SDK output changes (`sdkgen --check` stays green). Wiring it in, regenerating, and deleting the handwritten Go provider surface is the next PR in the Go chain.

Stacked on #2433 (review/merge that first). Reuses the rendering proven in the now-superseded #2432, minus the getter over-generation that was trimmed there.

## Interfaces

`internal/emit/golang/render_server.go` adds (all unexported, used by the emitter):
- `renderProviderHandler(svc)` — the `type <Name>Provider interface { ... }` (one method per RPC, transport-shaped: full native request in, full native response out; an `Empty` response collapses to error-only) plus `Unimplemented<Name>Provider` defaults returning `GestaltErrorCodeUnimplemented`.
- `renderProviderServer(svc)` — `New<Name>ProviderServer(provider) proto.<Name>Server`, the wire servicer: `fromWire<Req>(request)` → handler → `toWire<Resp>(response)`, handler errors mapped via `statusError`.
- `serverSupportFile` (emitted later as `client/support_server.go`): `statusError` mapping `*GestaltError` codes through and tagging unknowns with the operation.

A service already named `*Provider` takes a `Handler` suffix on its interface, since its generated client owns the bare name.

## Runtime

No runtime or generated-output change. `internal/emit/golang/render_server_test.go` builds a small provider service by hand and asserts the rendered interface, Unimplemented defaults, dispatch adapter, error mapping, and empty-response path. sdkgen tests + `--check` (all four targets) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)