### PR TITLE
sdkgen: python provider-surface emitter code

### DIFF
--- a/sdk/tools/sdkgen/internal/emit/python/render_server.go
+++ b/sdk/tools/sdkgen/internal/emit/python/render_server.go
@@ -1,0 +1,268 @@
+package python
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/sdk/tools/sdkgen/internal/model"
+)
+
+// providerName renders the handler ABC name for a provider service: the
+// service name with a Handler suffix. A service already named *Provider takes
+// a Handler suffix directly — its generated client owns the bare name (service
+// CacheProvider: client CacheProvider, handler CacheProviderHandler). A
+// service not named *Provider also takes a Handler suffix (service Cache:
+// handler CacheHandler).
+func providerName(svcName string) string {
+	return svcName + "Handler"
+}
+
+// operationString renders the human-readable operation tag carried on handler
+// errors: the lowercased service name followed by the method name split on
+// word boundaries ("workflow apply definition").
+func operationString(svcName, methodName string) string {
+	var b strings.Builder
+	b.WriteString(strings.ToLower(svcName))
+	for i, r := range methodName {
+		if i == 0 || (r >= 'A' && r <= 'Z') {
+			b.WriteByte(' ')
+		}
+		b.WriteRune(r)
+	}
+	return strings.ToLower(strings.Join(strings.Fields(b.String()), " "))
+}
+
+// serverRenderer holds state for rendering one provider service's handler and
+// dispatch adapter to a standalone Python module. It is separate from the
+// public/codec renderer so the server files stay independent.
+type serverRenderer struct {
+	idx  *index
+	base string // generated file base (e.g. "cache")
+	body strings.Builder
+
+	// tracked imports
+	needsABC       bool
+	needsAbsMethod bool
+	needsGrpc      bool
+	needsAny       bool
+	needsEmptyPb   bool
+	codecBase      string // codec module alias for this file's converters
+	wireGrpcBase   string // pb2_grpc module alias
+}
+
+func newServerRenderer(idx *index, base string) *serverRenderer {
+	return &serverRenderer{idx: idx, base: base}
+}
+
+// handlerParams renders the abstract method signature for a handler method.
+// Handlers are transport-shaped: the full native request in, the full native
+// response out. Empty input takes no request parameter; empty output returns
+// None. Types are qualified with the native module alias (_native).
+func (r *serverRenderer) handlerParams(m *model.Method) (params, retType string) {
+	if !m.InputIsEmpty {
+		reqType := "_native." + localName(m.Input.FullName)
+		params = "request: " + reqType
+	}
+	if m.OutputIsEmpty {
+		retType = "None"
+	} else {
+		retType = "_native." + localName(m.Output.FullName)
+	}
+	return params, retType
+}
+
+// renderProviderHandler renders the native handler ABC and its Unimplemented
+// default mixin for one provider service.
+func (r *serverRenderer) renderProviderHandler(svc *model.Service) {
+	svcName := localName(svc.FullName)
+	name := providerName(svcName)
+	r.needsABC = true
+	r.needsAbsMethod = true
+
+	// Handler ABC
+	doc := fmt.Sprintf(
+		"%s is the handler interface implemented by providers serving\nthe %s service. Methods receive the full native request;\nwire conversion and error mapping live in the generated dispatch servicer.",
+		name, svc.FullName,
+	)
+	if svc.Doc != "" {
+		doc = svc.Doc + "\n\n" + doc
+	}
+	fmt.Fprintf(&r.body, "class %s(ABC):\n", name)
+	r.writeDocstring("    ", doc)
+	r.body.WriteString("\n")
+	for _, m := range svc.Methods {
+		params, retType := r.handlerParams(m)
+		r.body.WriteString("    @abstractmethod\n")
+		if params != "" {
+			fmt.Fprintf(&r.body, "    def %s(self, %s) -> %s:\n        ...\n\n", snakeCase(m.Name), params, retType)
+		} else {
+			fmt.Fprintf(&r.body, "    def %s(self) -> %s:\n        ...\n\n", snakeCase(m.Name), retType)
+		}
+	}
+	r.body.WriteString("\n")
+
+	// Unimplemented mixin
+	fmt.Fprintf(&r.body, "class Unimplemented%s(%s):\n", name, name)
+	fmt.Fprintf(&r.body,
+		"    \"\"\"Unimplemented%s fails every %s method with a\n    GestaltErrorCode.UNIMPLEMENTED error; subclass it to default the\n    methods a provider does not implement.\"\"\"\n\n",
+		name, name)
+	for _, m := range svc.Methods {
+		params, retType := r.handlerParams(m)
+		op := operationString(svcName, m.Name)
+		if params != "" {
+			fmt.Fprintf(&r.body, "    def %s(self, %s) -> %s:\n", snakeCase(m.Name), params, retType)
+		} else {
+			fmt.Fprintf(&r.body, "    def %s(self) -> %s:\n", snakeCase(m.Name), retType)
+		}
+		fmt.Fprintf(&r.body, "        raise GestaltError(GestaltErrorCode.UNIMPLEMENTED, %q)\n\n", op+" is not implemented")
+	}
+	r.body.WriteString("\n")
+}
+
+// renderProviderServer renders the wire dispatch servicer for one provider
+// service: a subclass of the grpc-generated <Svc>Servicer that converts wire
+// requests to native via the existing _codec.from_wire_*, calls the handler,
+// converts native responses back via _codec.to_wire_*, and maps handler errors
+// to gRPC status via status_error.
+func (r *serverRenderer) renderProviderServer(svc *model.Service) {
+	svcName := localName(svc.FullName)
+	name := providerName(svcName)
+	adapterClass := "_" + name + "Servicer"
+	wireGrpcMod := "_" + r.base + "_pb2_grpc"
+	codecMod := "_codec"
+
+	r.needsGrpc = true
+	r.wireGrpcBase = r.base
+	r.codecBase = r.base
+
+	// Factory function
+	fmt.Fprintf(&r.body,
+		"def new_%s_server(handler: %s) -> %s.%sServicer:\n",
+		snakeCase(name), name, wireGrpcMod, svcName,
+	)
+	fmt.Fprintf(&r.body,
+		"    \"\"\"Adapt handler to the wire-level %s.%sServicer: requests convert\n    from the wire, responses convert to the wire, and handler errors map to\n    gRPC statuses via status_error.\"\"\"\n",
+		wireGrpcMod, svcName,
+	)
+	fmt.Fprintf(&r.body, "    return %s(handler)\n\n\n", adapterClass)
+
+	// Adapter class
+	fmt.Fprintf(&r.body, "class %s(%s.%sServicer):\n", adapterClass, wireGrpcMod, svcName)
+	fmt.Fprintf(&r.body, "    def __init__(self, handler: %s) -> None:\n        self._handler = handler\n\n", name)
+
+	for _, m := range svc.Methods {
+		op := operationString(svcName, m.Name)
+		r.renderDispatchMethod(m, op, codecMod)
+	}
+}
+
+// renderDispatchMethod renders one dispatch method of the adapter servicer.
+func (r *serverRenderer) renderDispatchMethod(m *model.Method, op, codecMod string) {
+	methodName := m.Name // gRPC servicer methods use PascalCase matching proto
+	r.needsAny = true
+	if m.InputIsEmpty {
+		fmt.Fprintf(&r.body, "    def %s(self, _request: Any, context: grpc.ServicerContext) -> Any:\n", methodName)
+	} else {
+		fmt.Fprintf(&r.body, "    def %s(self, request: Any, context: grpc.ServicerContext) -> Any:\n", methodName)
+	}
+
+	// Convert wire request to native
+	if m.InputIsEmpty {
+		if m.OutputIsEmpty {
+			r.needsEmptyPb = true
+			fmt.Fprintf(&r.body, "        try:\n            self._handler.%s()\n        except Exception as err:\n            status_error(context, %q, err)\n            return\n        return _empty_pb2.Empty()\n\n", snakeCase(m.Name), op)
+		} else {
+			outFunc := toWireFunc(m.Output.FullName)
+			fmt.Fprintf(&r.body, "        try:\n            response = self._handler.%s()\n        except Exception as err:\n            return status_error(context, %q, err)\n        return %s.%s(response)\n\n", snakeCase(m.Name), op, codecMod, outFunc)
+		}
+	} else {
+		inFunc := fromWireFunc(m.Input.FullName)
+		if m.OutputIsEmpty {
+			r.needsEmptyPb = true
+			fmt.Fprintf(&r.body, "        native_req = %s.%s(request)\n        try:\n            self._handler.%s(native_req)\n        except Exception as err:\n            status_error(context, %q, err)\n            return\n        return _empty_pb2.Empty()\n\n", codecMod, inFunc, snakeCase(m.Name), op)
+		} else {
+			outFunc := toWireFunc(m.Output.FullName)
+			fmt.Fprintf(&r.body, "        native_req = %s.%s(request)\n        try:\n            response = self._handler.%s(native_req)\n        except Exception as err:\n            return status_error(context, %q, err)\n        return %s.%s(response)\n\n", codecMod, inFunc, snakeCase(m.Name), op, codecMod, outFunc)
+		}
+	}
+}
+
+// writeDocstring renders doc as a docstring at the given indent.
+func (r *serverRenderer) writeDocstring(indent, doc string) {
+	lines := strings.Split(docstringText(doc), "\n")
+	if len(lines) == 1 {
+		text := lines[0]
+		if strings.HasSuffix(text, `"`) {
+			text = text[:len(text)-1] + `\"`
+		}
+		fmt.Fprintf(&r.body, "%s\"\"\"%s\"\"\"\n", indent, text)
+		return
+	}
+	fmt.Fprintf(&r.body, "%s\"\"\"%s\n", indent, lines[0])
+	for _, line := range lines[1:] {
+		if line == "" {
+			r.body.WriteString("\n")
+		} else {
+			r.body.WriteString(indent + line + "\n")
+		}
+	}
+	fmt.Fprintf(&r.body, "%s\"\"\"\n", indent)
+}
+
+// assembleServer assembles the final module source, prepending the module
+// docstring, imports, and the body rendered by renderProviderHandler +
+// renderProviderServer.
+func (r *serverRenderer) assembleServer(base string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "\"\"\"Generated provider handler and dispatch servicer for %s.proto.\"\"\"\n\n", base)
+	b.WriteString("from __future__ import annotations\n")
+
+	var stdlib []string
+	if r.needsABC || r.needsAbsMethod {
+		stdlib = append(stdlib, fromImport("abc", []string{"ABC", "abstractmethod"}))
+	}
+	if len(stdlib) > 0 {
+		b.WriteString("\n")
+		for _, line := range stdlib {
+			b.WriteString(line)
+		}
+	}
+
+	var thirdParty []string
+	if r.needsGrpc {
+		thirdParty = append(thirdParty, "import grpc\n")
+	}
+	if r.needsAny {
+		thirdParty = append(thirdParty, "from typing import Any\n")
+	}
+	if r.needsEmptyPb {
+		thirdParty = append(thirdParty, "from google.protobuf import empty_pb2 as _empty_pb2\n")
+	}
+	if len(thirdParty) > 0 {
+		b.WriteString("\n")
+		for _, line := range thirdParty {
+			b.WriteString(line)
+		}
+	}
+
+	// Local imports: native module, codec, pb2_grpc, rpc_support, support.
+	// The native module is imported as _native so type annotations in the ABC
+	// and Unimplemented class resolve; from __future__ import annotations makes
+	// them lazy, but the import is still needed for static analysis.
+	b.WriteString("\n")
+	if base != "" {
+		fmt.Fprintf(&b, "from .. import %s as _native\n", base)
+	}
+	if r.codecBase != "" {
+		fmt.Fprintf(&b, "from .._codec import %s as _codec\n", r.codecBase)
+	}
+	if r.wireGrpcBase != "" {
+		fmt.Fprintf(&b, "from .._gen.v1 import %s_pb2_grpc as _%s_pb2_grpc\n", r.wireGrpcBase, r.wireGrpcBase)
+	}
+	b.WriteString("from ..rpc_support import GestaltError, GestaltErrorCode\n")
+	b.WriteString("from .support import status_error\n")
+
+	b.WriteString("\n\n")
+	b.WriteString(r.body.String())
+	return strings.TrimRight(b.String(), "\n") + "\n"
+}

--- a/sdk/tools/sdkgen/internal/emit/python/render_server_test.go
+++ b/sdk/tools/sdkgen/internal/emit/python/render_server_test.go
@@ -1,0 +1,140 @@
+package python
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/sdk/tools/sdkgen/internal/model"
+)
+
+// TestRenderProviderSurface exercises the provider handler ABC and dispatch
+// servicer rendering in isolation, before it is wired into Emit(). It renders
+// a small hand-built provider service and asserts the shape of the generated
+// handler ABC, the Unimplemented defaults, and the wire dispatch servicer, so
+// the rendering logic is reviewable on its own. Hermetic: no buf, no pipeline.
+func TestRenderProviderSurface(t *testing.T) {
+	t.Parallel()
+
+	req := &model.Message{FullName: "gestalt.test.v1.FooRequest", Name: "FooRequest", ProtoFile: "test.proto"}
+	resp := &model.Message{FullName: "gestalt.test.v1.FooResponse", Name: "FooResponse", ProtoFile: "test.proto"}
+	svc := &model.Service{
+		FullName: "gestalt.test.v1.Thing",
+		Name:     "Thing",
+		Provider: true,
+		Methods: []*model.Method{
+			{Name: "Foo", Stream: model.Unary, Input: req, Output: resp},
+			{Name: "Bar", Stream: model.Unary, Input: req, OutputIsEmpty: true},
+		},
+	}
+	idx := &index{
+		messages: map[string]*model.Message{req.FullName: req, resp.FullName: resp},
+		enums:    map[string]*model.Enum{},
+	}
+
+	r := newServerRenderer(idx, "test")
+	r.renderProviderHandler(svc)
+	r.renderProviderServer(svc)
+	out := r.assembleServer("test")
+
+	for _, want := range []string{
+		// Handler ABC: one abstract method per RPC, transport-shaped (full
+		// request in, full response out); an Empty response collapses to None.
+		// Types are qualified with the _native module alias for static analysis.
+		"class ThingHandler(ABC):",
+		"@abstractmethod",
+		"def foo(self, request: _native.FooRequest) -> _native.FooResponse:",
+		"def bar(self, request: _native.FooRequest) -> None:",
+		// Unimplemented defaults carrying the canonical error code + operation.
+		"class UnimplementedThingHandler(ThingHandler):",
+		"GestaltErrorCode.UNIMPLEMENTED",
+		"thing foo is not implemented",
+		"thing bar is not implemented",
+		// Wire dispatch servicer over the existing codecs + error mapping.
+		"def new_thing_handler_server(handler: ThingHandler)",
+		"class _ThingHandlerServicer(_test_pb2_grpc.ThingServicer):",
+		"from_wire_foo_request(request)",
+		"to_wire_foo_response(response)",
+		`status_error(context, "thing foo", err)`,
+		`status_error(context, "thing bar", err)`,
+		"_empty_pb2.Empty()",
+		// Imports
+		"from abc import ABC, abstractmethod",
+		"from ..rpc_support import GestaltError, GestaltErrorCode",
+		"from .support import status_error",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rendered provider surface missing %q\n---\n%s", want, out)
+		}
+	}
+
+	// The provider error-mapping support file backs the generated adapters.
+	if !strings.Contains(serverSupportFile, "def status_error(") {
+		t.Error("serverSupportFile missing status_error")
+	}
+}
+
+// TestRenderProviderSurface_EmptyInput exercises the empty-input path: methods
+// with no request take no request parameter and still map errors through
+// status_error.
+func TestRenderProviderSurface_EmptyInput(t *testing.T) {
+	t.Parallel()
+
+	resp := &model.Message{FullName: "gestalt.test.v1.PingResponse", Name: "PingResponse", ProtoFile: "test.proto"}
+	svc := &model.Service{
+		FullName: "gestalt.test.v1.Pinger",
+		Name:     "Pinger",
+		Provider: true,
+		Methods: []*model.Method{
+			// Empty input + normal output
+			{Name: "Ping", Stream: model.Unary, InputIsEmpty: true, Output: resp},
+			// Empty input + empty output
+			{Name: "Reset", Stream: model.Unary, InputIsEmpty: true, OutputIsEmpty: true},
+		},
+	}
+	idx := &index{
+		messages: map[string]*model.Message{resp.FullName: resp},
+		enums:    map[string]*model.Enum{},
+	}
+
+	r := newServerRenderer(idx, "test")
+	r.renderProviderHandler(svc)
+	r.renderProviderServer(svc)
+	out := r.assembleServer("test")
+
+	for _, want := range []string{
+		// Empty-input handler methods take no request parameter.
+		// Types are qualified with the _native module alias for static analysis.
+		"def ping(self) -> _native.PingResponse:",
+		"def reset(self) -> None:",
+		// Unimplemented defaults still compile with no request arg.
+		"class UnimplementedPingerHandler(PingerHandler):",
+		"pinger ping is not implemented",
+		// Dispatch adapter accepts wire Empty, does not forward it.
+		"class _PingerHandlerServicer(_test_pb2_grpc.PingerServicer):",
+		"self._handler.ping()",
+		"self._handler.reset()",
+		"_empty_pb2.Empty()",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rendered empty-input provider surface missing %q\n---\n%s", want, out)
+		}
+	}
+}
+
+// TestOperationString verifies the operation tag format used in error messages.
+func TestOperationString(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		svc, method, want string
+	}{
+		{"Workflow", "ApplyDefinition", "workflow apply definition"},
+		{"Thing", "Foo", "thing foo"},
+		{"Cache", "GetMany", "cache get many"},
+	}
+	for _, tc := range cases {
+		got := operationString(tc.svc, tc.method)
+		if got != tc.want {
+			t.Errorf("operationString(%q, %q) = %q, want %q", tc.svc, tc.method, got, tc.want)
+		}
+	}
+}

--- a/sdk/tools/sdkgen/internal/emit/python/server_support.py
+++ b/sdk/tools/sdkgen/internal/emit/python/server_support.py
@@ -1,0 +1,35 @@
+"""Provider-side error mapping for generated dispatch servicers.
+
+This module is emitted once as _serve/support.py when any service carries the
+provider annotation. Generated dispatch adapters call status_error to convert
+handler errors to the gRPC status the host receives."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import grpc
+
+from ..rpc_support import GestaltError, GestaltErrorCode
+
+
+def status_error(context: grpc.ServicerContext, operation: str, err: BaseException) -> Any:
+    """Convert one handler error to the gRPC status returned to the host.
+
+    GestaltError carries its code through as the gRPC status code.  An error
+    already carrying a gRPC status (grpc.Call) passes through unchanged.  Any
+    other error is mapped to UNKNOWN tagged with the operation string.
+    """
+    if isinstance(err, GestaltError):
+        code = grpc.StatusCode.UNKNOWN
+        for sc in grpc.StatusCode:
+            if sc.value[0] == err.code:
+                code = sc
+                break
+        context.abort(code, err.message)
+        return None
+    if isinstance(err, grpc.Call):
+        context.abort(err.code(), str(err.details() or ""))
+        return None
+    context.abort(grpc.StatusCode.UNKNOWN, f"{operation}: {err}")
+    return None

--- a/sdk/tools/sdkgen/internal/emit/python/support.go
+++ b/sdk/tools/sdkgen/internal/emit/python/support.go
@@ -22,6 +22,16 @@ var invokeSupportFile string
 //go:embed codec_support.py
 var runtimeFile string
 
+// serverSupportFile is the provider-side error mapping, emitted as
+// _serve/support.py when any service carries the provider annotation.
+//
+//go:embed server_support.py
+var serverSupportFile string
+
+// serveInit makes the generated _serve directory an importable package.
+const serveInit = `"""Generated provider dispatch servicers for the Gestalt SDK."""
+`
+
 // codecInit makes the generated _codec directory an importable package. The
 // underscore-prefixed package name keeps every codec module internal by the
 // SDK's naming convention (like _gen), so the converters inside carry no


### PR DESCRIPTION
## Summary

The Python emitter's provider-surface rendering — Layer 2 of the stack, sibling to the Go reference (#2434), on top of the `provider` annotation (#2433). For any service carrying `provider`, this renders a handler ABC (methods raising `self._unimplemented(...)`) and a grpc servicer subclass dispatching wire↔native through the existing `_codec`, emitted into `gestalt/_serve/<base>.py` plus `gestalt/_serve/support.py`.

Rendering logic only, exercised by a hermetic unit test; **not wired into `Emit()`**, so no generated SDK output changes (`--check` 0).

Stacked on #2433.

## Interfaces

`internal/emit/python/render_server.go` + `server_support.py` (embedded). Handler methods use snake_case; the servicer uses PascalCase to match the grpc servicer base. `status_error` maps `GestaltError` codes via `context.abort()` (the grpc-python idiom). Confirmed the Python codec emits both wire directions, so the servicer's `from_wire`/`to_wire` calls resolve.

## Runtime

No runtime/output change. **PR-3 reconciliation notes:** (1) this emitter names the handler `<Svc>Handler` unconditionally, which diverges from the Go convention (`<Svc>Provider`, `Handler` only when the service is already `*Provider`) — the convention will be unified when PR-3 exposes these under the public flat names (`gestalt.WorkflowProvider`, …). (2) Validation here was the unit test + codec-direction check; full wiring validation (mypy against the generated servicer) lands in PR-3-python. The `serve()` loop in `_runtime.py` stays handwritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)