### PR TITLE
Fix IndexedDB cursor stream lifecycle over gRPC

### DIFF
--- a/gestaltd/rpc/indexeddb/client.go
+++ b/gestaltd/rpc/indexeddb/client.go
@@ -250,15 +250,11 @@ func (o *objectStore) DeleteRange(ctx context.Context, r idb.KeyRange) (int64, e
 
 // OpenCursor opens a full-value cursor over the object store.
 func (o *objectStore) OpenCursor(ctx context.Context, r *idb.KeyRange, dir idb.CursorDirection) (idb.Cursor, error) {
-	ctx, cancel := attachTimeout(ctx, o.opts.UnaryTimeout)
-	defer cancel()
 	return openCursor(ctx, o.client, o.store, "", r, dir, false, nil)
 }
 
 // OpenKeyCursor opens a key-only cursor over the object store.
 func (o *objectStore) OpenKeyCursor(ctx context.Context, r *idb.KeyRange, dir idb.CursorDirection) (idb.Cursor, error) {
-	ctx, cancel := attachTimeout(ctx, o.opts.UnaryTimeout)
-	defer cancel()
 	return openCursor(ctx, o.client, o.store, "", r, dir, true, nil)
 }
 
@@ -410,15 +406,11 @@ func (idx *indexClient) DeleteRange(ctx context.Context, r *idb.KeyRange, values
 
 // OpenCursor opens a full-value cursor over one secondary index.
 func (idx *indexClient) OpenCursor(ctx context.Context, r *idb.KeyRange, dir idb.CursorDirection, values ...any) (idb.Cursor, error) {
-	ctx, cancel := attachTimeout(ctx, idx.opts.UnaryTimeout)
-	defer cancel()
 	return openCursor(ctx, idx.client, idx.store, idx.index, r, dir, false, values)
 }
 
 // OpenKeyCursor opens a key-only cursor over one secondary index.
 func (idx *indexClient) OpenKeyCursor(ctx context.Context, r *idb.KeyRange, dir idb.CursorDirection, values ...any) (idb.Cursor, error) {
-	ctx, cancel := attachTimeout(ctx, idx.opts.UnaryTimeout)
-	defer cancel()
 	return openCursor(ctx, idx.client, idx.store, idx.index, r, dir, true, values)
 }
 

--- a/gestaltd/rpc/indexeddb/client_test.go
+++ b/gestaltd/rpc/indexeddb/client_test.go
@@ -79,6 +79,15 @@ func (s *cursorStreamStub) Recv() (*proto.CursorResponse, error) {
 
 func (s *cursorStreamStub) CloseSend() error { return nil }
 
+func assertStreamContextSurvivesUnaryTimeout(t *testing.T, streamCtx context.Context) {
+	t.Helper()
+
+	time.Sleep(15 * time.Millisecond)
+	if err := streamCtx.Err(); err != nil {
+		t.Fatalf("stream context cancelled after return: %v", err)
+	}
+}
+
 func TestBidiStreamSurvivesUnaryTimeoutAfterReturn(t *testing.T) {
 	t.Parallel()
 
@@ -91,10 +100,7 @@ func TestBidiStreamSurvivesUnaryTimeoutAfterReturn(t *testing.T) {
 			t.Fatalf("Transaction: %v", err)
 		}
 
-		time.Sleep(15 * time.Millisecond)
-		if err := stub.streamCtx.Err(); err != nil {
-			t.Fatalf("transaction stream context cancelled after return: %v", err)
-		}
+		assertStreamContextSurvivesUnaryTimeout(t, stub.streamCtx)
 
 		if err := tx.Abort(context.Background()); err != nil {
 			t.Fatalf("Abort: %v", err)
@@ -110,10 +116,7 @@ func TestBidiStreamSurvivesUnaryTimeoutAfterReturn(t *testing.T) {
 			t.Fatalf("OpenCursor: %v", err)
 		}
 
-		time.Sleep(15 * time.Millisecond)
-		if err := stub.streamCtx.Err(); err != nil {
-			t.Fatalf("cursor stream context cancelled after return: %v", err)
-		}
+		assertStreamContextSurvivesUnaryTimeout(t, stub.streamCtx)
 
 		if cursor.Continue() {
 			t.Fatal("Continue returned true, want false")

--- a/gestaltd/rpc/indexeddb/client_test.go
+++ b/gestaltd/rpc/indexeddb/client_test.go
@@ -47,6 +47,62 @@ func (s *txnStreamStub) Recv() (*proto.TransactionServerMessage, error) {
 
 func (s *txnStreamStub) CloseSend() error { return nil }
 
+type cursorStreamClient struct {
+	proto.IndexedDBClient
+	streamCtx context.Context
+}
+
+func (c *cursorStreamClient) OpenCursor(ctx context.Context, _ ...grpc.CallOption) (grpc.BidiStreamingClient[proto.CursorClientMessage, proto.CursorResponse], error) {
+	c.streamCtx = ctx
+	return &cursorStreamStub{}, nil
+}
+
+type cursorStreamStub struct {
+	grpc.ClientStream
+	recvStage int
+}
+
+func (s *cursorStreamStub) Send(*proto.CursorClientMessage) error { return nil }
+
+func (s *cursorStreamStub) Recv() (*proto.CursorResponse, error) {
+	switch s.recvStage {
+	case 0:
+		s.recvStage++
+		return &proto.CursorResponse{Result: &proto.CursorResponse_Done{}}, nil
+	case 1:
+		s.recvStage++
+		return &proto.CursorResponse{Result: &proto.CursorResponse_Done{Done: true}}, nil
+	default:
+		return nil, io.EOF
+	}
+}
+
+func (s *cursorStreamStub) CloseSend() error { return nil }
+
+func TestCursorStreamSurvivesUnaryTimeoutAfterReturn(t *testing.T) {
+	t.Parallel()
+
+	stub := &cursorStreamClient{}
+	db := NewClient(stub, Options{UnaryTimeout: 5 * time.Millisecond})
+
+	cursor, err := db.ObjectStore("events").OpenCursor(context.Background(), nil, idb.CursorNext)
+	if err != nil {
+		t.Fatalf("OpenCursor: %v", err)
+	}
+
+	time.Sleep(15 * time.Millisecond)
+	if err := stub.streamCtx.Err(); err != nil {
+		t.Fatalf("cursor stream context cancelled after return: %v", err)
+	}
+
+	if cursor.Continue() {
+		t.Fatal("Continue returned true, want false")
+	}
+	if err := cursor.Err(); err != nil {
+		t.Fatalf("cursor.Err() = %v, want nil", err)
+	}
+}
+
 func TestTransactionStreamSurvivesUnaryTimeoutAfterReturn(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/rpc/indexeddb/client_test.go
+++ b/gestaltd/rpc/indexeddb/client_test.go
@@ -79,47 +79,47 @@ func (s *cursorStreamStub) Recv() (*proto.CursorResponse, error) {
 
 func (s *cursorStreamStub) CloseSend() error { return nil }
 
-func TestCursorStreamSurvivesUnaryTimeoutAfterReturn(t *testing.T) {
+func TestBidiStreamSurvivesUnaryTimeoutAfterReturn(t *testing.T) {
 	t.Parallel()
 
-	stub := &cursorStreamClient{}
-	db := NewClient(stub, Options{UnaryTimeout: 5 * time.Millisecond})
+	t.Run("transaction", func(t *testing.T) {
+		stub := &txnStreamClient{}
+		db := NewClient(stub, Options{UnaryTimeout: 5 * time.Millisecond})
 
-	cursor, err := db.ObjectStore("events").OpenCursor(context.Background(), nil, idb.CursorNext)
-	if err != nil {
-		t.Fatalf("OpenCursor: %v", err)
-	}
+		tx, err := db.Transaction(context.Background(), []string{"events"}, idb.TransactionReadwrite, idb.TransactionOptions{})
+		if err != nil {
+			t.Fatalf("Transaction: %v", err)
+		}
 
-	time.Sleep(15 * time.Millisecond)
-	if err := stub.streamCtx.Err(); err != nil {
-		t.Fatalf("cursor stream context cancelled after return: %v", err)
-	}
+		time.Sleep(15 * time.Millisecond)
+		if err := stub.streamCtx.Err(); err != nil {
+			t.Fatalf("transaction stream context cancelled after return: %v", err)
+		}
 
-	if cursor.Continue() {
-		t.Fatal("Continue returned true, want false")
-	}
-	if err := cursor.Err(); err != nil {
-		t.Fatalf("cursor.Err() = %v, want nil", err)
-	}
-}
+		if err := tx.Abort(context.Background()); err != nil {
+			t.Fatalf("Abort: %v", err)
+		}
+	})
 
-func TestTransactionStreamSurvivesUnaryTimeoutAfterReturn(t *testing.T) {
-	t.Parallel()
+	t.Run("cursor", func(t *testing.T) {
+		stub := &cursorStreamClient{}
+		db := NewClient(stub, Options{UnaryTimeout: 5 * time.Millisecond})
 
-	stub := &txnStreamClient{}
-	db := NewClient(stub, Options{UnaryTimeout: 5 * time.Millisecond})
+		cursor, err := db.ObjectStore("events").OpenCursor(context.Background(), nil, idb.CursorNext)
+		if err != nil {
+			t.Fatalf("OpenCursor: %v", err)
+		}
 
-	tx, err := db.Transaction(context.Background(), []string{"events"}, idb.TransactionReadwrite, idb.TransactionOptions{})
-	if err != nil {
-		t.Fatalf("Transaction: %v", err)
-	}
+		time.Sleep(15 * time.Millisecond)
+		if err := stub.streamCtx.Err(); err != nil {
+			t.Fatalf("cursor stream context cancelled after return: %v", err)
+		}
 
-	time.Sleep(15 * time.Millisecond)
-	if err := stub.streamCtx.Err(); err != nil {
-		t.Fatalf("transaction stream context cancelled after return: %v", err)
-	}
-
-	if err := tx.Abort(context.Background()); err != nil {
-		t.Fatalf("Abort: %v", err)
-	}
+		if cursor.Continue() {
+			t.Fatal("Continue returned true, want false")
+		}
+		if err := cursor.Err(); err != nil {
+			t.Fatalf("cursor.Err() = %v, want nil", err)
+		}
+	})
 }

--- a/gestaltd/services/indexeddb/cursor_stream_test.go
+++ b/gestaltd/services/indexeddb/cursor_stream_test.go
@@ -1,0 +1,120 @@
+package indexeddb
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	idb "github.com/valon-technologies/gestalt/sdk/go/indexeddb"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func newEmptyStoreCursorClient(t *testing.T) proto.IndexedDBClient {
+	t.Helper()
+
+	stub := &coretesting.StubIndexedDB{}
+	ctx := context.Background()
+	if _, err := stub.CreateObjectStore(ctx, "empty", idb.ObjectStoreOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	conn := newBufconnConn(t, func(srv *grpc.Server) {
+		proto.RegisterIndexedDBServer(srv, NewServer(stub, "", ServerOptions{}))
+	})
+	return proto.NewIndexedDBClient(conn)
+}
+
+func openEmptyStoreCursorStream(t *testing.T, client proto.IndexedDBClient) grpc.BidiStreamingClient[proto.CursorClientMessage, proto.CursorResponse] {
+	t.Helper()
+
+	stream, err := client.OpenCursor(context.Background())
+	if err != nil {
+		t.Fatalf("OpenCursor: %v", err)
+	}
+
+	if err := stream.Send(&proto.CursorClientMessage{
+		Msg: &proto.CursorClientMessage_Open{
+			Open: &proto.OpenCursorRequest{
+				Store:     "empty",
+				Direction: proto.CursorDirection_CURSOR_NEXT,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("Send open: %v", err)
+	}
+
+	resp, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("Recv open ack: %v", err)
+	}
+	done, ok := resp.GetResult().(*proto.CursorResponse_Done)
+	if !ok || done.Done {
+		t.Fatalf("open ack = %#v, want Done{Done:false}", resp.GetResult())
+	}
+	return stream
+}
+
+func TestCursorStream_ClientHalfClose(t *testing.T) {
+	t.Parallel()
+
+	client := newEmptyStoreCursorClient(t)
+
+	t.Run("after_open", func(t *testing.T) {
+		stream := openEmptyStoreCursorStream(t, client)
+		if err := stream.CloseSend(); err != nil {
+			t.Fatalf("CloseSend: %v", err)
+		}
+		assertCursorStreamTerminalEOF(t, stream)
+	})
+
+	t.Run("after_exhaustion", func(t *testing.T) {
+		stream := openEmptyStoreCursorStream(t, client)
+
+		if err := stream.Send(&proto.CursorClientMessage{
+			Msg: &proto.CursorClientMessage_Command{
+				Command: &proto.CursorCommand{
+					Command: &proto.CursorCommand_Next{Next: true},
+				},
+			},
+		}); err != nil {
+			t.Fatalf("Send next: %v", err)
+		}
+
+		resp, err := stream.Recv()
+		if err != nil {
+			t.Fatalf("Recv exhaustion: %v", err)
+		}
+		done, ok := resp.GetResult().(*proto.CursorResponse_Done)
+		if !ok || !done.Done {
+			t.Fatalf("exhaustion response = %#v, want Done{Done:true}", resp.GetResult())
+		}
+
+		if err := stream.CloseSend(); err != nil {
+			t.Fatalf("CloseSend: %v", err)
+		}
+		assertCursorStreamTerminalEOF(t, stream)
+	})
+}
+
+func assertCursorStreamTerminalEOF(t *testing.T, stream grpc.BidiStreamingClient[proto.CursorClientMessage, proto.CursorResponse]) {
+	t.Helper()
+
+	for {
+		_, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			return
+		}
+		if err != nil {
+			if st, ok := status.FromError(err); ok && st.Code() != codes.OK {
+				t.Fatalf("terminal Recv error = %v (code=%v), want io.EOF", err, st.Code())
+			}
+			t.Fatalf("terminal Recv error = %v, want io.EOF", err)
+		}
+		t.Fatal("terminal Recv returned message after CloseSend, want io.EOF")
+	}
+}

--- a/gestaltd/services/indexeddb/cursor_stream_test.go
+++ b/gestaltd/services/indexeddb/cursor_stream_test.go
@@ -62,9 +62,10 @@ func openEmptyStoreCursorStream(t *testing.T, client proto.IndexedDBClient) grpc
 func TestCursorStream_ClientHalfClose(t *testing.T) {
 	t.Parallel()
 
-	client := newEmptyStoreCursorClient(t)
-
 	t.Run("after_open", func(t *testing.T) {
+		t.Parallel()
+
+		client := newEmptyStoreCursorClient(t)
 		stream := openEmptyStoreCursorStream(t, client)
 		if err := stream.CloseSend(); err != nil {
 			t.Fatalf("CloseSend: %v", err)
@@ -73,6 +74,9 @@ func TestCursorStream_ClientHalfClose(t *testing.T) {
 	})
 
 	t.Run("after_exhaustion", func(t *testing.T) {
+		t.Parallel()
+
+		client := newEmptyStoreCursorClient(t)
 		stream := openEmptyStoreCursorStream(t, client)
 
 		if err := stream.Send(&proto.CursorClientMessage{

--- a/gestaltd/services/indexeddb/cursor_test.go
+++ b/gestaltd/services/indexeddb/cursor_test.go
@@ -3,7 +3,6 @@ package indexeddb
 import (
 	"context"
 	"errors"
-	"io"
 	"testing"
 
 	idb "github.com/valon-technologies/gestalt/sdk/go/indexeddb"
@@ -610,8 +609,7 @@ func TestCursor_EmptyResultSetDoneOnly(t *testing.T) {
 	conn := newBufconnConn(t, func(srv *grpc.Server) {
 		proto.RegisterIndexedDBServer(srv, NewServer(stub, "", ServerOptions{}))
 	})
-	client := proto.NewIndexedDBClient(conn)
-	remote := &remoteIndexedDB{Database: rpcidb.NewClient(client, rpcidb.Options{})}
+	remote := &remoteIndexedDB{Database: rpcidb.NewClient(proto.NewIndexedDBClient(conn), rpcidb.Options{})}
 
 	// Value cursor on empty store
 	cursor, err := remote.ObjectStore("empty").OpenCursor(ctx, nil, idb.CursorNext)
@@ -652,13 +650,6 @@ func TestCursor_EmptyResultSetDoneOnly(t *testing.T) {
 	if icursor.Err() != nil {
 		t.Fatalf("index cursor unexpected error: %v", icursor.Err())
 	}
-
-	t.Run("client_half_close_after_open", func(t *testing.T) {
-		assertCursorStreamHalfCloseAfterOpen(t, client)
-	})
-	t.Run("client_half_close_after_exhaustion", func(t *testing.T) {
-		assertCursorStreamHalfCloseAfterExhaustion(t, client)
-	})
 }
 
 func TestCursor_ValueCursorExhaustionNoExtraEntry(t *testing.T) {
@@ -804,107 +795,5 @@ func TestCursor_CloseMakesFurtherCallsInert(t *testing.T) {
 	}
 	if err := cursor.Update(idb.Record{"id": "x"}); !errors.Is(err, idb.ErrNotFound) {
 		t.Fatalf("Update after Close = %v, want ErrNotFound", err)
-	}
-}
-
-func assertCursorStreamHalfCloseAfterOpen(t *testing.T, client proto.IndexedDBClient) {
-	t.Helper()
-
-	stream, err := client.OpenCursor(context.Background())
-	if err != nil {
-		t.Fatalf("OpenCursor: %v", err)
-	}
-
-	if err := stream.Send(&proto.CursorClientMessage{
-		Msg: &proto.CursorClientMessage_Open{
-			Open: &proto.OpenCursorRequest{
-				Store:     "empty",
-				Direction: proto.CursorDirection_CURSOR_NEXT,
-			},
-		},
-	}); err != nil {
-		t.Fatalf("Send open: %v", err)
-	}
-
-	resp, err := stream.Recv()
-	if err != nil {
-		t.Fatalf("Recv open ack: %v", err)
-	}
-	done, ok := resp.GetResult().(*proto.CursorResponse_Done)
-	if !ok || done.Done {
-		t.Fatalf("open ack = %#v, want Done{Done:false}", resp.GetResult())
-	}
-
-	if err := stream.CloseSend(); err != nil {
-		t.Fatalf("CloseSend: %v", err)
-	}
-
-	assertCursorStreamTerminalEOF(t, stream)
-}
-
-func assertCursorStreamHalfCloseAfterExhaustion(t *testing.T, client proto.IndexedDBClient) {
-	t.Helper()
-
-	stream, err := client.OpenCursor(context.Background())
-	if err != nil {
-		t.Fatalf("OpenCursor: %v", err)
-	}
-
-	if err := stream.Send(&proto.CursorClientMessage{
-		Msg: &proto.CursorClientMessage_Open{
-			Open: &proto.OpenCursorRequest{
-				Store:     "empty",
-				Direction: proto.CursorDirection_CURSOR_NEXT,
-			},
-		},
-	}); err != nil {
-		t.Fatalf("Send open: %v", err)
-	}
-
-	if _, err := stream.Recv(); err != nil {
-		t.Fatalf("Recv open ack: %v", err)
-	}
-
-	if err := stream.Send(&proto.CursorClientMessage{
-		Msg: &proto.CursorClientMessage_Command{
-			Command: &proto.CursorCommand{
-				Command: &proto.CursorCommand_Next{Next: true},
-			},
-		},
-	}); err != nil {
-		t.Fatalf("Send next: %v", err)
-	}
-
-	resp, err := stream.Recv()
-	if err != nil {
-		t.Fatalf("Recv exhaustion: %v", err)
-	}
-	done, ok := resp.GetResult().(*proto.CursorResponse_Done)
-	if !ok || !done.Done {
-		t.Fatalf("exhaustion response = %#v, want Done{Done:true}", resp.GetResult())
-	}
-
-	if err := stream.CloseSend(); err != nil {
-		t.Fatalf("CloseSend: %v", err)
-	}
-
-	assertCursorStreamTerminalEOF(t, stream)
-}
-
-func assertCursorStreamTerminalEOF(t *testing.T, stream grpc.BidiStreamingClient[proto.CursorClientMessage, proto.CursorResponse]) {
-	t.Helper()
-
-	for {
-		_, err := stream.Recv()
-		if errors.Is(err, io.EOF) {
-			return
-		}
-		if err == nil {
-			continue
-		}
-		if st, ok := status.FromError(err); ok && st.Code() != codes.OK {
-			t.Fatalf("terminal Recv error = %v (code=%v), want io.EOF", err, st.Code())
-		}
-		t.Fatalf("terminal Recv error = %v, want io.EOF", err)
 	}
 }

--- a/gestaltd/services/indexeddb/cursor_test.go
+++ b/gestaltd/services/indexeddb/cursor_test.go
@@ -87,29 +87,6 @@ func TestCursor_ForwardIteration(t *testing.T) {
 	}
 }
 
-func TestCursor_EmptyCursor(t *testing.T) {
-	t.Parallel()
-
-	stub := &coretesting.StubIndexedDB{}
-	ctx := context.Background()
-	_, _ = stub.CreateObjectStore(ctx, "empty", idb.ObjectStoreOptions{})
-
-	conn := newBufconnConn(t, func(srv *grpc.Server) {
-		proto.RegisterIndexedDBServer(srv, NewServer(stub, "", ServerOptions{}))
-	})
-	remote := &remoteIndexedDB{Database: rpcidb.NewClient(proto.NewIndexedDBClient(conn), rpcidb.Options{})}
-
-	cursor, err := remote.ObjectStore("empty").OpenCursor(ctx, nil, idb.CursorNext)
-	if err != nil {
-		t.Fatalf("OpenCursor: %v", err)
-	}
-	defer func() { _ = cursor.Close() }()
-
-	if cursor.Continue() {
-		t.Fatal("Continue returned true on empty store")
-	}
-}
-
 func TestCursor_KeysOnly(t *testing.T) {
 	t.Parallel()
 
@@ -618,14 +595,23 @@ func TestCursor_StubSingleFieldIndexKeyMatchesRemoteShape(t *testing.T) {
 
 func TestCursor_EmptyResultSetDoneOnly(t *testing.T) {
 	t.Parallel()
+
 	stub := &coretesting.StubIndexedDB{}
 	ctx := context.Background()
-	_, _ = stub.CreateObjectStore(ctx, "empty", idb.ObjectStoreOptions{})
+	schema := idb.ObjectStoreOptions{
+		Indexes: []idb.IndexSchema{
+			{Name: "by_status", KeyPath: []string{"status"}, Unique: false},
+		},
+	}
+	if _, err := stub.CreateObjectStore(ctx, "empty", schema); err != nil {
+		t.Fatal(err)
+	}
 
 	conn := newBufconnConn(t, func(srv *grpc.Server) {
 		proto.RegisterIndexedDBServer(srv, NewServer(stub, "", ServerOptions{}))
 	})
-	remote := &remoteIndexedDB{Database: rpcidb.NewClient(proto.NewIndexedDBClient(conn), rpcidb.Options{})}
+	client := proto.NewIndexedDBClient(conn)
+	remote := &remoteIndexedDB{Database: rpcidb.NewClient(client, rpcidb.Options{})}
 
 	// Value cursor on empty store
 	cursor, err := remote.ObjectStore("empty").OpenCursor(ctx, nil, idb.CursorNext)
@@ -653,6 +639,26 @@ func TestCursor_EmptyResultSetDoneOnly(t *testing.T) {
 	if kcursor.Err() != nil {
 		t.Fatalf("key cursor unexpected error: %v", kcursor.Err())
 	}
+	// Index cursor on empty store
+	icursor, err := remote.ObjectStore("empty").Index("by_status").OpenCursor(ctx, nil, idb.CursorNext)
+	if err != nil {
+		t.Fatalf("index OpenCursor: %v", err)
+	}
+	defer func() { _ = icursor.Close() }()
+
+	if icursor.Continue() {
+		t.Fatal("index cursor Continue returned true on empty store")
+	}
+	if icursor.Err() != nil {
+		t.Fatalf("index cursor unexpected error: %v", icursor.Err())
+	}
+
+	t.Run("client_half_close_after_open", func(t *testing.T) {
+		assertCursorStreamHalfCloseAfterOpen(t, client)
+	})
+	t.Run("client_half_close_after_exhaustion", func(t *testing.T) {
+		assertCursorStreamHalfCloseAfterExhaustion(t, client)
+	})
 }
 
 func TestCursor_ValueCursorExhaustionNoExtraEntry(t *testing.T) {
@@ -801,28 +807,10 @@ func TestCursor_CloseMakesFurtherCallsInert(t *testing.T) {
 	}
 }
 
-func newEmptyStoreConn(t *testing.T) *grpc.ClientConn {
+func assertCursorStreamHalfCloseAfterOpen(t *testing.T, client proto.IndexedDBClient) {
 	t.Helper()
 
-	stub := &coretesting.StubIndexedDB{}
-	ctx := context.Background()
-	if _, err := stub.CreateObjectStore(ctx, "empty", idb.ObjectStoreOptions{}); err != nil {
-		t.Fatal(err)
-	}
-
-	return newBufconnConn(t, func(srv *grpc.Server) {
-		proto.RegisterIndexedDBServer(srv, NewServer(stub, "", ServerOptions{}))
-	})
-}
-
-func TestCursor_ClientHalfCloseAfterOpenIsNormal(t *testing.T) {
-	t.Parallel()
-
-	conn := newEmptyStoreConn(t)
-	client := proto.NewIndexedDBClient(conn)
-	ctx := context.Background()
-
-	stream, err := client.OpenCursor(ctx)
+	stream, err := client.OpenCursor(context.Background())
 	if err != nil {
 		t.Fatalf("OpenCursor: %v", err)
 	}
@@ -851,29 +839,13 @@ func TestCursor_ClientHalfCloseAfterOpenIsNormal(t *testing.T) {
 		t.Fatalf("CloseSend: %v", err)
 	}
 
-	for {
-		_, err := stream.Recv()
-		if errors.Is(err, io.EOF) {
-			return
-		}
-		if err == nil {
-			continue
-		}
-		if st, ok := status.FromError(err); ok && st.Code() != codes.OK {
-			t.Fatalf("terminal Recv error = %v (code=%v), want io.EOF", err, st.Code())
-		}
-		t.Fatalf("terminal Recv error = %v, want io.EOF", err)
-	}
+	assertCursorStreamTerminalEOF(t, stream)
 }
 
-func TestCursor_ClientHalfCloseAfterExhaustionIsNormal(t *testing.T) {
-	t.Parallel()
+func assertCursorStreamHalfCloseAfterExhaustion(t *testing.T, client proto.IndexedDBClient) {
+	t.Helper()
 
-	conn := newEmptyStoreConn(t)
-	client := proto.NewIndexedDBClient(conn)
-	ctx := context.Background()
-
-	stream, err := client.OpenCursor(ctx)
+	stream, err := client.OpenCursor(context.Background())
 	if err != nil {
 		t.Fatalf("OpenCursor: %v", err)
 	}
@@ -916,12 +888,22 @@ func TestCursor_ClientHalfCloseAfterExhaustionIsNormal(t *testing.T) {
 		t.Fatalf("CloseSend: %v", err)
 	}
 
-	_, err = stream.Recv()
-	if !errors.Is(err, io.EOF) {
-		if err != nil {
-			if st, ok := status.FromError(err); ok && st.Code() != codes.OK {
-				t.Fatalf("terminal Recv error = %v (code=%v), want io.EOF", err, st.Code())
-			}
+	assertCursorStreamTerminalEOF(t, stream)
+}
+
+func assertCursorStreamTerminalEOF(t *testing.T, stream grpc.BidiStreamingClient[proto.CursorClientMessage, proto.CursorResponse]) {
+	t.Helper()
+
+	for {
+		_, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			return
+		}
+		if err == nil {
+			continue
+		}
+		if st, ok := status.FromError(err); ok && st.Code() != codes.OK {
+			t.Fatalf("terminal Recv error = %v (code=%v), want io.EOF", err, st.Code())
 		}
 		t.Fatalf("terminal Recv error = %v, want io.EOF", err)
 	}

--- a/gestaltd/services/indexeddb/cursor_test.go
+++ b/gestaltd/services/indexeddb/cursor_test.go
@@ -3,6 +3,7 @@ package indexeddb
 import (
 	"context"
 	"errors"
+	"io"
 	"testing"
 
 	idb "github.com/valon-technologies/gestalt/sdk/go/indexeddb"
@@ -797,5 +798,131 @@ func TestCursor_CloseMakesFurtherCallsInert(t *testing.T) {
 	}
 	if err := cursor.Update(idb.Record{"id": "x"}); !errors.Is(err, idb.ErrNotFound) {
 		t.Fatalf("Update after Close = %v, want ErrNotFound", err)
+	}
+}
+
+func newEmptyStoreConn(t *testing.T) *grpc.ClientConn {
+	t.Helper()
+
+	stub := &coretesting.StubIndexedDB{}
+	ctx := context.Background()
+	if _, err := stub.CreateObjectStore(ctx, "empty", idb.ObjectStoreOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	return newBufconnConn(t, func(srv *grpc.Server) {
+		proto.RegisterIndexedDBServer(srv, NewServer(stub, "", ServerOptions{}))
+	})
+}
+
+func TestCursor_ClientHalfCloseAfterOpenIsNormal(t *testing.T) {
+	t.Parallel()
+
+	conn := newEmptyStoreConn(t)
+	client := proto.NewIndexedDBClient(conn)
+	ctx := context.Background()
+
+	stream, err := client.OpenCursor(ctx)
+	if err != nil {
+		t.Fatalf("OpenCursor: %v", err)
+	}
+
+	if err := stream.Send(&proto.CursorClientMessage{
+		Msg: &proto.CursorClientMessage_Open{
+			Open: &proto.OpenCursorRequest{
+				Store:     "empty",
+				Direction: proto.CursorDirection_CURSOR_NEXT,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("Send open: %v", err)
+	}
+
+	resp, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("Recv open ack: %v", err)
+	}
+	done, ok := resp.GetResult().(*proto.CursorResponse_Done)
+	if !ok || done.Done {
+		t.Fatalf("open ack = %#v, want Done{Done:false}", resp.GetResult())
+	}
+
+	if err := stream.CloseSend(); err != nil {
+		t.Fatalf("CloseSend: %v", err)
+	}
+
+	for {
+		_, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			return
+		}
+		if err == nil {
+			continue
+		}
+		if st, ok := status.FromError(err); ok && st.Code() != codes.OK {
+			t.Fatalf("terminal Recv error = %v (code=%v), want io.EOF", err, st.Code())
+		}
+		t.Fatalf("terminal Recv error = %v, want io.EOF", err)
+	}
+}
+
+func TestCursor_ClientHalfCloseAfterExhaustionIsNormal(t *testing.T) {
+	t.Parallel()
+
+	conn := newEmptyStoreConn(t)
+	client := proto.NewIndexedDBClient(conn)
+	ctx := context.Background()
+
+	stream, err := client.OpenCursor(ctx)
+	if err != nil {
+		t.Fatalf("OpenCursor: %v", err)
+	}
+
+	if err := stream.Send(&proto.CursorClientMessage{
+		Msg: &proto.CursorClientMessage_Open{
+			Open: &proto.OpenCursorRequest{
+				Store:     "empty",
+				Direction: proto.CursorDirection_CURSOR_NEXT,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("Send open: %v", err)
+	}
+
+	if _, err := stream.Recv(); err != nil {
+		t.Fatalf("Recv open ack: %v", err)
+	}
+
+	if err := stream.Send(&proto.CursorClientMessage{
+		Msg: &proto.CursorClientMessage_Command{
+			Command: &proto.CursorCommand{
+				Command: &proto.CursorCommand_Next{Next: true},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("Send next: %v", err)
+	}
+
+	resp, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("Recv exhaustion: %v", err)
+	}
+	done, ok := resp.GetResult().(*proto.CursorResponse_Done)
+	if !ok || !done.Done {
+		t.Fatalf("exhaustion response = %#v, want Done{Done:true}", resp.GetResult())
+	}
+
+	if err := stream.CloseSend(); err != nil {
+		t.Fatalf("CloseSend: %v", err)
+	}
+
+	_, err = stream.Recv()
+	if !errors.Is(err, io.EOF) {
+		if err != nil {
+			if st, ok := status.FromError(err); ok && st.Code() != codes.OK {
+				t.Fatalf("terminal Recv error = %v (code=%v), want io.EOF", err, st.Code())
+			}
+		}
+		t.Fatalf("terminal Recv error = %v, want io.EOF", err)
 	}
 }

--- a/gestaltd/services/indexeddb/server.go
+++ b/gestaltd/services/indexeddb/server.go
@@ -877,6 +877,9 @@ func (s *indexedDBServer) OpenCursor(stream proto.IndexedDB_OpenCursorServer) er
 	for {
 		msg, recvErr := stream.Recv()
 		if recvErr != nil {
+			if errors.Is(recvErr, io.EOF) {
+				return nil
+			}
 			return recvErr
 		}
 		cmd := msg.GetCommand()


### PR DESCRIPTION
## Summary

- Treat client CloseSend() as normal cleanup in the gestaltd OpenCursor handler (return OK on io.EOF, matching transaction stream behavior).
- Stop wrapping cursor stream opens in unary RPC timeouts so executable-provider cursors remain usable after OpenCursor returns.
- Add server half-close tests and RPC client timeout-survival coverage.

## Test plan

- [x] go test ./gestaltd/services/indexeddb ./gestaltd/rpc/indexeddb
- [x] bun run test indexeddb.transport.test.ts
- [x] gestalt-providers EmptyCursorExhaustion contract test (paired PR)
- [ ] MySQL contract run when GESTALT_TEST_MYSQL_DSN is available