### PR TITLE
Document compound IndexedDB index prefix plus range semantics

### DIFF
--- a/sdk/go/indexeddb/interfaces.go
+++ b/sdk/go/indexeddb/interfaces.go
@@ -30,6 +30,7 @@ type ObjectStore interface {
 }
 
 // Index maps to IDBIndex for the supported Gestalt protocol subset.
+// Compound index query semantics: see IndexQueryRequest in indexeddb.proto.
 type Index interface {
 	Get(ctx context.Context, values ...any) (Record, error)
 	GetKey(ctx context.Context, values ...any) (string, error)

--- a/sdk/proto/v1/indexeddb.proto
+++ b/sdk/proto/v1/indexeddb.proto
@@ -109,6 +109,13 @@ message DeleteObjectStoreRequest {
 
 // IndexQueryRequest addresses a secondary index plus optional key values and
 // range constraints.
+//
+// W3C IndexedDB uses one key or IDBKeyRange over the full index key (scalar or
+// array). Gestalt convenience: values pins a compound key prefix; scalar range
+// is valid only when len(values) + 1 == key path length (lowers to a compound
+// array range). Otherwise pass a full compound array range with values empty.
+// Invalid: complete index key in values plus range; prefix plus range with
+// unpinned trailing key-path components.
 message IndexQueryRequest {
   string store = 1;
   string index = 2;
@@ -138,7 +145,7 @@ message OpenCursorRequest {
   bool keys_only = 4;
   // index selects a secondary index when non-empty.
   string index = 5;
-  // values selects a compound index key prefix when index is set.
+  // values pins leading compound index key components; see IndexQueryRequest.
   repeated TypedValue values = 6;
 }
 

--- a/sdk/typescript/src/providers/indexeddb.ts
+++ b/sdk/typescript/src/providers/indexeddb.ts
@@ -134,6 +134,7 @@ export interface ObjectStore {
 
 /**
  * Fakeable IndexedDB secondary-index contract.
+ * Compound index query semantics: see IndexQueryRequest in indexeddb.proto.
  */
 export interface Index {
   get(...values: unknown[]): Promise<Record>;


### PR DESCRIPTION
## Summary

Gestalt index queries on compound key paths may pin leading components with `values` and apply a `KeyRange` when the range completes the prefix (`len(values) + 1 == len(keyPath)`). Provider implementations and app authors need a single, W3C-aligned contract for that shape instead of inferring behavior from method signatures alone.

This documents the semantics on `IndexQueryRequest` in `indexeddb.proto` as the canonical source. Go and TypeScript `Index` interfaces cross-reference that message. No wire format or generated field changes are included.

## Query semantics

Documented on `IndexQueryRequest`:

- W3C IndexedDB uses one key or `IDBKeyRange` over the full index key (scalar or array).
- Gestalt convenience: `values` pins a compound key prefix; scalar `range` is valid only when it completes the prefix.
- Otherwise pass a full compound array range with `values` empty.
- Invalid: complete index key in `values` plus `range`; prefix plus `range` with unpinned trailing key-path components.

Made with [Cursor](https://cursor.com)
