### PR TITLE
[observability] use delta temporality for OTLP metrics

### DIFF
--- a/gestaltd/services/observability/drivers/otlp/otlp.go
+++ b/gestaltd/services/observability/drivers/otlp/otlp.go
@@ -220,6 +220,7 @@ func buildProviderTelemetryEnv(cfg yamlConfig) map[string]string {
 	if interval, err := time.ParseDuration(cfg.Metrics.Interval); err == nil && interval > 0 {
 		env["OTEL_METRIC_EXPORT_INTERVAL"] = strconv.FormatInt(interval.Milliseconds(), 10)
 	}
+	env["OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE"] = "delta"
 	return env
 }
 
@@ -325,7 +326,9 @@ func buildMeterProvider(ctx context.Context, cfg yamlConfig, res *resource.Resou
 	var exporter sdkmetric.Exporter
 	switch strings.ToLower(cfg.Protocol) {
 	case "http":
-		opts := []otlpmetrichttp.Option{}
+		opts := []otlpmetrichttp.Option{
+			otlpmetrichttp.WithTemporalitySelector(sdkmetric.DeltaTemporalitySelector),
+		}
 		if cfg.Endpoint != "" {
 			opts = append(opts, otlpmetrichttp.WithEndpoint(cfg.Endpoint))
 		}
@@ -337,7 +340,9 @@ func buildMeterProvider(ctx context.Context, cfg yamlConfig, res *resource.Resou
 		}
 		exporter, err = otlpmetrichttp.New(ctx, opts...)
 	default:
-		opts := []otlpmetricgrpc.Option{}
+		opts := []otlpmetricgrpc.Option{
+			otlpmetricgrpc.WithTemporalitySelector(sdkmetric.DeltaTemporalitySelector),
+		}
 		if cfg.Endpoint != "" {
 			opts = append(opts, otlpmetricgrpc.WithEndpoint(cfg.Endpoint))
 		}

--- a/gestaltd/services/observability/drivers/otlp/otlp_test.go
+++ b/gestaltd/services/observability/drivers/otlp/otlp_test.go
@@ -46,6 +46,9 @@ func TestProviderTelemetryEnvUsesOTLPConfig(t *testing.T) {
 	if got := env["OTEL_METRIC_EXPORT_INTERVAL"]; got != "15000" {
 		t.Fatalf("OTEL_METRIC_EXPORT_INTERVAL = %q, want 15000", got)
 	}
+	if got := env["OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE"]; got != "delta" {
+		t.Fatalf("OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE = %q, want delta", got)
+	}
 	if got := env["OTEL_EXPORTER_OTLP_HEADERS"]; got != "x-api-key=secret%20value%3D" {
 		t.Fatalf("OTEL_EXPORTER_OTLP_HEADERS = %q, want encoded header", got)
 	}


### PR DESCRIPTION
## Description

Configures gestaltd OTLP metric exports and spawned provider telemetry to prefer delta temporality so Datadog can ingest sparse counter and histogram series without relying on cumulative point differencing.