### PR TITLE
gestaltd: UI dev-server proxy (HMR) + serve --only

### DIFF
--- a/docs/content/providers/ui.mdx
+++ b/docs/content/providers/ui.mdx
@@ -1,4 +1,5 @@
 import ActiveDevelopmentCallout from '../../components/ActiveDevelopmentCallout'
+import { Callout } from 'nextra/components'
 
 # UI
 
@@ -83,6 +84,38 @@ Plugin-backed mounted UIs inherit the owning plugin's dynamic grants when that
 plugin declares `authorizationPolicy`. They also inherit the plugin's route-auth
 provider when the app declares `auth.provider`. Direct `providers.ui` bundles
 and the built-in admin UI use the server-wide auth configuration.
+
+## Local dev server proxy (HMR)
+
+For UI development with hot module reload, point a mounted UI at a running
+framework dev server instead of prepared static assets. Add `devProxy` to the
+`providers.ui` entry, usually in a local overlay config layered on top of the
+deployment config:
+
+```yaml
+providers:
+  ui:
+    roadmap:
+      source: ./customer-roadmap-review/ui/manifest.yaml
+      path: /create-customer-roadmap-review
+      devProxy:
+        url: http://127.0.0.1:3000
+```
+
+When `devProxy.url` is set, Gestalt reverse-proxies the entire mount — including
+the HMR WebSocket — to that URL and **skips building the bundle** (no
+`assetRoot` is prepared). A frontend edit hot-reloads in the browser without a
+server restart, while the backend keeps serving `/api` from the same origin.
+
+Run the dev server under the **same base path** as the mount (for example
+`next dev` with `basePath: /create-customer-roadmap-review`) so its asset and
+HMR URLs line up; Gestalt forwards the full mount-prefixed path unchanged.
+
+<Callout type="warning">
+  Dev-proxy mounts are served without route authorization and bypass the static
+  build pipeline. Use them only in local overlay configs for development, never
+  in a deployment config.
+</Callout>
 
 ## The Admin UI
 

--- a/docs/content/providers/ui.mdx
+++ b/docs/content/providers/ui.mdx
@@ -111,6 +111,11 @@ Run the dev server under the **same base path** as the mount (for example
 `next dev` with `basePath: /create-customer-roadmap-review`) so its asset and
 HMR URLs line up; Gestalt forwards the full mount-prefixed path unchanged.
 
+Gestalt redirects the bare mount path to a trailing slash
+(`/dashboard` → `/dashboard/`). Configure the dev server **not** to issue the
+reverse redirect, or the two bounce in a loop — for Next.js, set
+`skipTrailingSlashRedirect: true`.
+
 <Callout type="warning">
   Dev-proxy mounts are served without route authorization and bypass the static
   build pipeline. Use them only in local overlay configs for development, never

--- a/docs/content/providers/ui.mdx
+++ b/docs/content/providers/ui.mdx
@@ -117,6 +117,9 @@ HMR URLs line up; Gestalt forwards the full mount-prefixed path unchanged.
   in a deployment config.
 </Callout>
 
+This pairs well with [`serve --only`](/reference/cli#app-subset) to boot just the
+app under development out of a full fleet config.
+
 ## The Admin UI
 
 The built-in admin UI is served at `/admin` by default. It includes operator

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -22,6 +22,7 @@ the platform where they run.
 | `gestaltd` | Local-friendly startup. Generates a config if needed and serves. |
 | `gestaltd serve --config PATH` | Start the server. Repeat `--config` to layer overrides. |
 | `gestaltd serve --config PATH --watch` | Start from layered config and restart after debounced local config, source provider, or local release metadata changes. |
+| `gestaltd serve --config PATH --only NAME` | Boot only the named app and its dependency closure from the full config. Repeat `--only` for several apps; other apps and their unused providers are pruned before preparation. |
 | `gestaltd serve --locked --config PATH` | Start read-only from an existing lockfile and prepared artifacts. Repeat `--config` to layer overrides. |
 | `gestaltd serve --artifacts-dir DIR` | Directory for prepared provider artifacts. |
 | `gestaltd serve --lockfile PATH` | Override the lockfile location. `PATH` resolves like a normal CLI path. |
@@ -188,6 +189,33 @@ gestaltd serve \
 Watch mode applies only to config-based serve. It cannot be combined with
 `--locked` or `--path`.
 
+## App Subset
+
+Use `gestaltd serve --only NAME` to boot a single app out of a full fleet config
+without preparing or bootstrapping everything else. Repeat `--only` for several
+apps. Before any lock, sync, or bootstrap runs, the loaded config is pruned to
+the named apps and their dependency closure:
+
+- the named apps and the UI bundles they mount;
+- the `indexeddb`, `cache`, `s3`, and `runtime` providers those apps reference,
+  plus any marked `default` and the server-selected default `indexeddb`;
+- all shared infrastructure (authentication, authorization, secrets, telemetry,
+  audit, externalCredentials) and orchestration (workflow, agent) providers.
+
+Every other app, its orphaned UI and storage providers, and any workflow
+definition that targets a dropped app are removed, so unrelated source builds
+and cloud dependencies are never touched. This lets one canonical config replace
+hand-maintained single-app dev configs.
+
+```sh
+gestaltd serve --config ./deploy/config.yaml --only g_issues
+gestaltd serve --config ./deploy/config.yaml --only g_issues --only deal_hub --watch
+```
+
+`--only` cannot be combined with `--path` (which already synthesizes a
+single-target config). Pruned references that a retained app still needs surface
+as ordinary validation errors at startup.
+
 ## UI Dev Server Proxy
 
 For UI iteration with hot module reload, point a mounted UI at a running
@@ -205,7 +233,7 @@ providers:
         url: http://127.0.0.1:3000
 ```
 
-Gestalt then reverse-proxies the mount (the HMR WebSocket included) to that URL
+gestaltd then reverse-proxies the mount (the HMR WebSocket included) to that URL
 and skips building the bundle, so frontend edits hot-reload without a server
 restart while the backend keeps running. Run the dev server under the same base
 path as the mount so asset and HMR URLs line up. Dev-proxy mounts are served
@@ -228,6 +256,8 @@ gestaltd lock --config ./config.yaml --lockfile ./local/gestalt.lock.json
 gestaltd sync --locked --config ./config.yaml --lockfile ./local/gestalt.lock.json
 gestaltd serve --config ./config.yaml --lockfile ./local/gestalt.lock.json
 gestaltd serve --config ./config.yaml --watch
+gestaltd serve --config ./config.yaml --only g_issues
+gestaltd serve --config ./config.yaml --config ./dev/ui-proxy.yaml --only g_issues --watch
 gestaltd serve --path ./apps/support/manifest.yaml
 gestaltd serve --locked --config ./config.yaml --lockfile ./local/gestalt.lock.json
 gestaltd lock --config ./base.yaml --config ./overrides/prod.yaml

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -188,6 +188,30 @@ gestaltd serve \
 Watch mode applies only to config-based serve. It cannot be combined with
 `--locked` or `--path`.
 
+## UI Dev Server Proxy
+
+For UI iteration with hot module reload, point a mounted UI at a running
+framework dev server (e.g. `next dev`) instead of prepared static assets by
+adding `devProxy` to its `providers.ui` entry — typically in a local overlay
+config:
+
+```yaml
+providers:
+  ui:
+    dashboard:
+      source: ./ui/manifest.yaml
+      path: /dashboard
+      devProxy:
+        url: http://127.0.0.1:3000
+```
+
+Gestalt then reverse-proxies the mount (the HMR WebSocket included) to that URL
+and skips building the bundle, so frontend edits hot-reload without a server
+restart while the backend keeps running. Run the dev server under the same base
+path as the mount so asset and HMR URLs line up. Dev-proxy mounts are served
+without route authorization and are intended for local development only. See
+[UI providers](/providers/ui#local-dev-server-proxy-hmr).
+
 ## Examples
 
 ```sh

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -1712,6 +1712,7 @@ When `authorizationPolicy` is set on a mounted UI, the referenced UI manifest mu
 | `source` | Package source, local UI manifest path, published `provider-release.yaml` metadata URL, `source.url`, or `source.githubRelease` for a GitHub-hosted release asset. |
 | `source.auth` | Optional inline source auth for package repositories, remote release sources, direct metadata URLs, and `source.githubRelease`. |
 | `config` | Optional UI-provider config validated against the bundle schema when present. |
+| `devProxy.url` | Local-development only. When set, Gestalt reverse-proxies this mount (HMR WebSocket included) to the given `http(s)` dev server URL instead of serving prepared static assets, and skips building the bundle. Served without route authorization. See [UI dev server proxy](/providers/ui#local-dev-server-proxy-hmr). |
 
 ## Validation rules
 

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -598,12 +598,14 @@ type providerEntryMarshalYAML struct {
 
 type uiEntryYAML struct {
 	providerEntryYAML `yaml:",inline"`
-	Path              string `yaml:"path,omitempty"`
+	Path              string      `yaml:"path,omitempty"`
+	DevProxy          *UIDevProxy `yaml:"devProxy,omitempty"`
 }
 
 type uiEntryMarshalYAML struct {
 	providerEntryMarshalYAML `yaml:",inline"`
-	Path                     string `yaml:"path,omitempty"`
+	Path                     string      `yaml:"path,omitempty"`
+	DevProxy                 *UIDevProxy `yaml:"devProxy,omitempty"`
 }
 
 func (e *ProviderEntry) UnmarshalYAML(value *yaml.Node) error {
@@ -1261,9 +1263,16 @@ func (e *UIEntry) UnmarshalYAML(value *yaml.Node) error {
 	if err != nil {
 		return err
 	}
+	if raw.DevProxy != nil && strings.TrimSpace(raw.DevProxy.URL) != "" {
+		// A dev-proxy mount is served from a live dev server and is never
+		// built. Drop the source so no lifecycle path (lock, sync, serve,
+		// validate) treats it as source-backed and tries to prepare it.
+		decoded.Source = ProviderSource{}
+	}
 	*e = UIEntry{
 		ProviderEntry: decoded,
 		Path:          raw.Path,
+		DevProxy:      raw.DevProxy,
 	}
 	return nil
 }
@@ -1280,6 +1289,7 @@ func (e UIEntry) MarshalYAML() (any, error) {
 	return uiEntryMarshalYAML{
 		providerEntryMarshalYAML: entry,
 		Path:                     e.Path,
+		DevProxy:                 e.DevProxy,
 	}, nil
 }
 

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1186,10 +1186,38 @@ type UIEntry struct {
 	Path          string `yaml:"path,omitempty"`
 	OwnerApp      string `yaml:"-"`
 
+	// DevProxy, when set, makes this mount reverse-proxy to a local framework
+	// dev server (e.g. `next dev`) instead of serving prepared static assets,
+	// enabling hot module reload. It is intended for local overlay configs and
+	// short-circuits asset preparation: a dev-proxy mount is never built and has
+	// no ResolvedAssetRoot.
+	DevProxy *UIDevProxy `yaml:"devProxy,omitempty"`
+
 	// Runtime-resolved theme paths (populated during sync from the entry's
 	// config.theme block, not from YAML).
 	ResolvedThemeStylesheet string `yaml:"-"`
 	ResolvedThemeAssetsDir  string `yaml:"-"`
+}
+
+// UIDevProxy points a mounted UI at a running local dev server. The dev server
+// must serve the bundle under the same base path the mount is served at, so the
+// proxy can forward requests (and the HMR WebSocket) without rewriting paths.
+type UIDevProxy struct {
+	URL string `yaml:"url,omitempty"`
+}
+
+// HasDevProxy reports whether this UI mount serves from a live dev server
+// instead of prepared static assets.
+func (e *UIEntry) HasDevProxy() bool {
+	return e != nil && e.DevProxy != nil && strings.TrimSpace(e.DevProxy.URL) != ""
+}
+
+// DevProxyURL returns the trimmed dev server URL, or "" when not a dev-proxy mount.
+func (e *UIEntry) DevProxyURL() string {
+	if !e.HasDevProxy() {
+		return ""
+	}
+	return strings.TrimSpace(e.DevProxy.URL)
 }
 
 // UIThemeConfig is the typed `theme` block of a ui mount's provider config.

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -113,6 +113,9 @@ func ValidateCanonicalStructure(cfg *Config) error {
 		if err := validateUIDevProxy("ui."+name, entry); err != nil {
 			return err
 		}
+		if entry.HasDevProxy() {
+			continue
+		}
 		if err := validateAppOnlyProviderFields("ui."+name, &entry.ProviderEntry); err != nil {
 			return err
 		}

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -110,6 +110,9 @@ func ValidateCanonicalStructure(cfg *Config) error {
 		if entry == nil {
 			return fmt.Errorf("config validation: ui.%s is required", name)
 		}
+		if err := validateUIDevProxy("ui."+name, entry); err != nil {
+			return err
+		}
 		if err := validateAppOnlyProviderFields("ui."+name, &entry.ProviderEntry); err != nil {
 			return err
 		}
@@ -743,6 +746,9 @@ func ValidateResolvedStructure(cfg *Config) error {
 	for name, entry := range cfg.Providers.UI {
 		if entry == nil {
 			return fmt.Errorf("config validation: ui %q requires a source", name)
+		}
+		if entry.HasDevProxy() {
+			continue
 		}
 		if entry.AuthorizationPolicy == "" {
 			continue
@@ -2628,6 +2634,21 @@ func validateEgress(cfg *EgressConfig) error {
 	case "", "allow", "deny":
 	default:
 		return fmt.Errorf("config validation: egress.default_action must be \"allow\" or \"deny\", got %q", cfg.DefaultAction)
+	}
+	return nil
+}
+
+func validateUIDevProxy(label string, entry *UIEntry) error {
+	if entry == nil || entry.DevProxy == nil {
+		return nil
+	}
+	raw := strings.TrimSpace(entry.DevProxy.URL)
+	if raw == "" {
+		return fmt.Errorf("config validation: %s.devProxy.url is required", label)
+	}
+	u, err := url.Parse(raw)
+	if err != nil || !u.IsAbs() || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+		return fmt.Errorf("config validation: %s.devProxy.url must be an absolute http(s) URL, got %q", label, entry.DevProxy.URL)
 	}
 	return nil
 }

--- a/gestaltd/internal/config/devproxy_test.go
+++ b/gestaltd/internal/config/devproxy_test.go
@@ -1,0 +1,39 @@
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestUIEntryYAMLRoundTripsDevProxy(t *testing.T) {
+	const src = "source: ./ui/manifest.yaml\npath: /dash\ndevProxy:\n  url: http://127.0.0.1:3000\n"
+
+	var entry UIEntry
+	if err := yaml.Unmarshal([]byte(src), &entry); err != nil {
+		t.Fatalf("unmarshal ui entry with devProxy: %v", err)
+	}
+	if !entry.HasDevProxy() {
+		t.Fatal("HasDevProxy() = false after YAML decode")
+	}
+	if got := entry.DevProxyURL(); got != "http://127.0.0.1:3000" {
+		t.Fatalf("DevProxyURL() = %q, want http://127.0.0.1:3000", got)
+	}
+	// Source is neutralized so no lifecycle path treats a dev-proxy mount as
+	// source-backed and tries to build it.
+	if entry.HasLocalSource() {
+		t.Fatal("dev-proxy entry still reports a local source; prepare paths would build it")
+	}
+
+	out, err := yaml.Marshal(entry)
+	if err != nil {
+		t.Fatalf("marshal ui entry: %v", err)
+	}
+	var round UIEntry
+	if err := yaml.Unmarshal(out, &round); err != nil {
+		t.Fatalf("re-unmarshal marshalled ui entry: %v", err)
+	}
+	if !round.HasDevProxy() || round.DevProxyURL() != "http://127.0.0.1:3000" {
+		t.Fatalf("devProxy lost on round-trip: %q", round.DevProxyURL())
+	}
+}

--- a/gestaltd/internal/config/prune.go
+++ b/gestaltd/internal/config/prune.go
@@ -1,0 +1,198 @@
+package config
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// RetainAppsResult reports what RetainApps removed, for operator logging.
+type RetainAppsResult struct {
+	Kept             []string
+	DroppedApps      []string
+	DroppedWorkflows []string
+}
+
+// RetainApps prunes cfg in place to the named apps and their dependency
+// closure, so a full fleet config can boot a single app without preparing or
+// bootstrapping everything else.
+//
+// It keeps: the named apps; the UI bundles they mount; the indexeddb, cache,
+// s3, and runtime providers they reference (plus any marked default and the
+// server-selected default indexeddb); and all shared infra (authentication,
+// authorization, secrets, telemetry, audit, externalCredentials) and
+// orchestration (workflow, agent) providers. It drops every other app, their
+// orphaned UI/storage/runtime providers, and any workflow definition that
+// targets a dropped app.
+//
+// keep names must exist in cfg.Apps. Pruned references that a retained app
+// still needs surface as ordinary validation errors downstream.
+func RetainApps(cfg *Config, keep []string) (RetainAppsResult, error) {
+	if cfg == nil || len(keep) == 0 {
+		return RetainAppsResult{}, nil
+	}
+
+	retained := make(map[string]struct{}, len(keep))
+	var unknown []string
+	for _, name := range keep {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if _, ok := cfg.Apps[name]; !ok {
+			unknown = append(unknown, name)
+			continue
+		}
+		retained[name] = struct{}{}
+	}
+	if len(unknown) > 0 {
+		slices.Sort(unknown)
+		return RetainAppsResult{}, fmt.Errorf("--only names unknown apps: %s", strings.Join(unknown, ", "))
+	}
+	if len(retained) == 0 {
+		return RetainAppsResult{}, fmt.Errorf("--only matched no apps")
+	}
+
+	keepUI := map[string]struct{}{}
+	keepIndexedDB := map[string]struct{}{}
+	keepCache := map[string]struct{}{}
+	keepS3 := map[string]struct{}{}
+	keepRuntime := map[string]struct{}{}
+
+	for name := range retained {
+		app := cfg.Apps[name]
+		if app == nil {
+			continue
+		}
+		if ui := strings.TrimSpace(app.UI); ui != "" {
+			keepUI[ui] = struct{}{}
+		}
+		if app.IndexedDB != nil {
+			if p := strings.TrimSpace(app.IndexedDB.Provider); p != "" {
+				keepIndexedDB[p] = struct{}{}
+			}
+		}
+		for _, c := range app.Cache {
+			if c = strings.TrimSpace(c); c != "" {
+				keepCache[c] = struct{}{}
+			}
+		}
+		for _, s := range app.S3 {
+			if s = strings.TrimSpace(s); s != "" {
+				keepS3[s] = struct{}{}
+			}
+		}
+		if app.Runtime != nil {
+			if p := strings.TrimSpace(app.Runtime.Provider); p != "" {
+				keepRuntime[p] = struct{}{}
+			}
+		}
+	}
+
+	for name, ui := range cfg.Providers.UI {
+		if ui == nil {
+			continue
+		}
+		if _, ok := retained[ui.OwnerApp]; ok {
+			keepUI[name] = struct{}{}
+		}
+	}
+	if sel := strings.TrimSpace(cfg.Server.Providers.IndexedDB); sel != "" {
+		keepIndexedDB[sel] = struct{}{}
+	}
+
+	pruneMap(cfg.Apps, retained)
+	pruneMap(cfg.Providers.UI, keepUI)
+	pruneProviderMap(cfg.Providers.IndexedDB, keepIndexedDB)
+	pruneProviderMap(cfg.Providers.Cache, keepCache)
+	pruneProviderMap(cfg.Providers.S3, keepS3)
+	pruneRuntimeMap(cfg.Runtime.Providers, keepRuntime)
+
+	var droppedWorkflows []string
+	for name, def := range cfg.Workflows.Definitions {
+		if app := workflowReferencesDroppedApp(def, retained); app != "" {
+			droppedWorkflows = append(droppedWorkflows, name)
+			delete(cfg.Workflows.Definitions, name)
+		}
+	}
+
+	result := RetainAppsResult{
+		Kept:             sortedKeys(retained),
+		DroppedWorkflows: droppedWorkflows,
+	}
+	slices.Sort(result.DroppedWorkflows)
+	slices.Sort(result.Kept)
+	return result, nil
+}
+
+// pruneMap deletes every UIEntry/ProviderEntry key not in keep.
+func pruneMap[V any](m map[string]*V, keep map[string]struct{}) {
+	for name := range m {
+		if _, ok := keep[name]; !ok {
+			delete(m, name)
+		}
+	}
+}
+
+// pruneProviderMap drops unreferenced provider entries but always retains
+// entries marked default.
+func pruneProviderMap(m map[string]*ProviderEntry, keep map[string]struct{}) {
+	for name, entry := range m {
+		if _, ok := keep[name]; ok {
+			continue
+		}
+		if entry != nil && entry.Default {
+			continue
+		}
+		delete(m, name)
+	}
+}
+
+func pruneRuntimeMap(m map[string]*RuntimeProviderEntry, keep map[string]struct{}) {
+	for name, entry := range m {
+		if _, ok := keep[name]; ok {
+			continue
+		}
+		if entry != nil && entry.Default {
+			continue
+		}
+		delete(m, name)
+	}
+}
+
+func workflowReferencesDroppedApp(def WorkflowDefinitionConfig, retained map[string]struct{}) string {
+	dropped := func(app string) string {
+		app = strings.TrimSpace(app)
+		if app == "" {
+			return ""
+		}
+		if _, ok := retained[app]; ok {
+			return ""
+		}
+		return app
+	}
+	for _, step := range def.Steps {
+		if step.App != nil {
+			if app := dropped(step.App.Name); app != "" {
+				return app
+			}
+		}
+		if step.Agent != nil {
+			for _, tool := range step.Agent.Tools {
+				if app := dropped(tool.App); app != "" {
+					return app
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func sortedKeys(set map[string]struct{}) []string {
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	slices.Sort(out)
+	return out
+}

--- a/gestaltd/internal/config/prune_test.go
+++ b/gestaltd/internal/config/prune_test.go
@@ -1,0 +1,110 @@
+package config
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestRetainAppsPrunesToClosure(t *testing.T) {
+	cfg := &Config{
+		Apps: map[string]*ProviderEntry{
+			"alpha": {UI: "alphaUI", IndexedDB: &IndexedDBBindingConfig{Provider: "main"}},
+			"beta":  {UI: "betaUI", S3: []string{"betaStore"}},
+		},
+		Providers: ProvidersConfig{
+			UI: map[string]*UIEntry{
+				"alphaUI": {OwnerApp: "alpha"},
+				"betaUI":  {OwnerApp: "beta"},
+			},
+			IndexedDB: map[string]*ProviderEntry{"main": {}},
+			S3:        map[string]*ProviderEntry{"betaStore": {}},
+			// Shared infra is retained wholesale, even though no app names it.
+			Secrets: map[string]*ProviderEntry{"env": {}},
+		},
+		Server: ServerConfig{
+			Providers: ServerProvidersConfig{IndexedDB: "main"},
+		},
+		Workflows: WorkflowsConfig{
+			Definitions: map[string]WorkflowDefinitionConfig{
+				"betaFlow":  {Steps: []WorkflowStepConfig{{App: &WorkflowStepAppCallConfig{Name: "beta"}}}},
+				"alphaFlow": {Steps: []WorkflowStepConfig{{App: &WorkflowStepAppCallConfig{Name: "alpha"}}}},
+			},
+		},
+	}
+
+	result, err := RetainApps(cfg, []string{"alpha"})
+	if err != nil {
+		t.Fatalf("RetainApps: %v", err)
+	}
+
+	assertPresent := func(label string, present bool, want bool) {
+		t.Helper()
+		if present != want {
+			t.Fatalf("%s present=%v, want %v", label, present, want)
+		}
+	}
+	_, alphaApp := cfg.Apps["alpha"]
+	_, betaApp := cfg.Apps["beta"]
+	_, alphaUI := cfg.Providers.UI["alphaUI"]
+	_, betaUI := cfg.Providers.UI["betaUI"]
+	_, mainDB := cfg.Providers.IndexedDB["main"]
+	_, betaStore := cfg.Providers.S3["betaStore"]
+	_, secrets := cfg.Providers.Secrets["env"]
+	_, betaFlow := cfg.Workflows.Definitions["betaFlow"]
+	_, alphaFlow := cfg.Workflows.Definitions["alphaFlow"]
+
+	assertPresent("apps.alpha", alphaApp, true)
+	assertPresent("apps.beta", betaApp, false)
+	assertPresent("ui.alphaUI", alphaUI, true)
+	assertPresent("ui.betaUI (orphaned)", betaUI, false)
+	assertPresent("indexeddb.main (referenced+selected)", mainDB, true)
+	assertPresent("s3.betaStore (only beta used it)", betaStore, false)
+	assertPresent("secrets.env (shared infra)", secrets, true)
+	assertPresent("workflow betaFlow (targets dropped app)", betaFlow, false)
+	assertPresent("workflow alphaFlow", alphaFlow, true)
+
+	if !slices.Equal(result.Kept, []string{"alpha"}) {
+		t.Fatalf("Kept = %v, want [alpha]", result.Kept)
+	}
+	if !slices.Equal(result.DroppedWorkflows, []string{"betaFlow"}) {
+		t.Fatalf("DroppedWorkflows = %v, want [betaFlow]", result.DroppedWorkflows)
+	}
+}
+
+func TestRetainAppsKeepsDefaultProviders(t *testing.T) {
+	cfg := &Config{
+		Apps: map[string]*ProviderEntry{"alpha": {}},
+		Providers: ProvidersConfig{
+			IndexedDB: map[string]*ProviderEntry{
+				"unreferencedDefault": {Default: true},
+				"unreferenced":        {},
+			},
+		},
+	}
+	if _, err := RetainApps(cfg, []string{"alpha"}); err != nil {
+		t.Fatalf("RetainApps: %v", err)
+	}
+	if _, ok := cfg.Providers.IndexedDB["unreferencedDefault"]; !ok {
+		t.Fatal("default indexeddb dropped, want retained")
+	}
+	if _, ok := cfg.Providers.IndexedDB["unreferenced"]; ok {
+		t.Fatal("unreferenced non-default indexeddb retained, want dropped")
+	}
+}
+
+func TestRetainAppsUnknownApp(t *testing.T) {
+	cfg := &Config{Apps: map[string]*ProviderEntry{"alpha": {}}}
+	if _, err := RetainApps(cfg, []string{"ghost"}); err == nil {
+		t.Fatal("expected error for unknown app, got nil")
+	}
+}
+
+func TestRetainAppsEmptyKeepIsNoOp(t *testing.T) {
+	cfg := &Config{Apps: map[string]*ProviderEntry{"alpha": {}, "beta": {}}}
+	if _, err := RetainApps(cfg, nil); err != nil {
+		t.Fatalf("RetainApps nil: %v", err)
+	}
+	if len(cfg.Apps) != 2 {
+		t.Fatalf("apps pruned on no-op: %d, want 2", len(cfg.Apps))
+	}
+}

--- a/gestaltd/internal/daemon/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e_test.go
@@ -2200,7 +2200,7 @@ func TestRunLockSyncLayeredConfigs(t *testing.T) {
 		t.Fatalf("runSync with layered configs: %v", err)
 	}
 
-	env, err := setupBootstrapWithConfigPaths([]string{basePath, overridePath}, operator.StatePaths{}, true)
+	env, err := setupBootstrapWithConfigPaths([]string{basePath, overridePath}, operator.StatePaths{}, true, nil)
 	if err != nil {
 		t.Fatalf("setupBootstrapWithConfigPaths locked layered configs: %v", err)
 	}
@@ -2226,7 +2226,7 @@ func TestRunServeLockedUsesOverrideLockfile(t *testing.T) {
 		t.Fatalf("runSync with --lockfile: %v", err)
 	}
 
-	env, err := setupBootstrapWithConfigPaths([]string{cfgPath}, operator.StatePaths{LockfilePath: lockPath}, true)
+	env, err := setupBootstrapWithConfigPaths([]string{cfgPath}, operator.StatePaths{LockfilePath: lockPath}, true, nil)
 	if err != nil {
 		t.Fatalf("setupBootstrapWithConfigPaths locked with --lockfile: %v", err)
 	}

--- a/gestaltd/internal/daemon/factories.go
+++ b/gestaltd/internal/daemon/factories.go
@@ -34,13 +34,13 @@ type bootstrapEnv struct {
 	prevLogger *slog.Logger
 }
 
-func setupBootstrapWithConfigPaths(configPaths []string, state operator.StatePaths, locked bool) (*bootstrapEnv, error) {
+func setupBootstrapWithConfigPaths(configPaths []string, state operator.StatePaths, locked bool, onlyApps []string) (*bootstrapEnv, error) {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	return setupBootstrapWithConfigPathsContext(ctx, stop, configPaths, state, locked)
+	return setupBootstrapWithConfigPathsContext(ctx, stop, configPaths, state, locked, onlyApps)
 }
 
-func setupBootstrapWithConfigPathsContext(ctx context.Context, stop context.CancelFunc, configPaths []string, state operator.StatePaths, locked bool) (*bootstrapEnv, error) {
-	cfg, err := loadConfigForExecutionAtPathsWithStatePaths(configPaths, state, locked)
+func setupBootstrapWithConfigPathsContext(ctx context.Context, stop context.CancelFunc, configPaths []string, state operator.StatePaths, locked bool, onlyApps []string) (*bootstrapEnv, error) {
+	cfg, err := loadConfigForExecutionAtPathsWithStatePaths(configPaths, state, locked, onlyApps)
 	if err != nil {
 		stop()
 		return nil, err

--- a/gestaltd/internal/daemon/lifecycle.go
+++ b/gestaltd/internal/daemon/lifecycle.go
@@ -37,8 +37,8 @@ func syncConfigWithStatePathsOptions(configFlags []string, state operator.StateP
 	return operatorLifecycle().SyncAtPathsWithStatePathsOptions(configPaths, state, opts)
 }
 
-func loadConfigForExecutionAtPathsWithStatePaths(configPaths []string, state operator.StatePaths, locked bool) (*config.Config, error) {
-	cfg, _, err := operatorLifecycle().LoadForExecutionAtPathsWithStatePaths(configPaths, state, locked)
+func loadConfigForExecutionAtPathsWithStatePaths(configPaths []string, state operator.StatePaths, locked bool, onlyApps []string) (*config.Config, error) {
+	cfg, _, err := operatorLifecycle().WithRetainApps(onlyApps).LoadForExecutionAtPathsWithStatePaths(configPaths, state, locked)
 	if err != nil {
 		return nil, err
 	}

--- a/gestaltd/internal/daemon/main_test.go
+++ b/gestaltd/internal/daemon/main_test.go
@@ -490,6 +490,11 @@ func TestE2ECLIRejectsBadArgs(t *testing.T) {
 			args:     []string{"serve", "--path", ".", "--watch"},
 			wantPart: "--watch cannot be combined with --path",
 		},
+		{
+			name:     "serve only rejects path",
+			args:     []string{"serve", "--path", ".", "--only", "gIssues"},
+			wantPart: "--only cannot be combined with --path",
+		},
 	}
 
 	for _, tc := range cases {

--- a/gestaltd/internal/daemon/provider_local.go
+++ b/gestaltd/internal/daemon/provider_local.go
@@ -115,7 +115,7 @@ func runServeProviderLocal(opts providerLocalCommandOptions) error {
 	}
 	defer func() { _ = os.RemoveAll(session.Dir) }()
 
-	env, err := setupBootstrapWithConfigPaths(session.ConfigPaths, session.State, false)
+	env, err := setupBootstrapWithConfigPaths(session.ConfigPaths, session.State, false, nil)
 	if err != nil {
 		return err
 	}

--- a/gestaltd/internal/daemon/run.go
+++ b/gestaltd/internal/daemon/run.go
@@ -108,11 +108,16 @@ func runServeCommand(name string, usage func(io.Writer), args []string, opts ser
 	if opts.allowLocked {
 		lockedFlag = fs.Bool("locked", false, "require exact lock state; do not auto lock/sync")
 	}
+	var onlyApps repeatedStringFlag
+	fs.Var(&onlyApps, "only", "serve only the named app and its dependencies (repeatable); prunes other apps and their providers")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 	if fs.NArg() > 0 {
 		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	if len(onlyApps) > 0 && strings.TrimSpace(flagStringValue(pathFlag)) != "" {
+		return fmt.Errorf("--only cannot be combined with --path")
 	}
 
 	var resolvedConfigPaths []string
@@ -155,13 +160,13 @@ func runServeCommand(name string, usage func(io.Writer), args []string, opts ser
 		return runServeWatch(resolvedConfigPaths, operator.StatePaths{
 			ArtifactsDir: *artifactsDir,
 			LockfilePath: *lockfilePath,
-		})
+		}, []string(onlyApps))
 	}
 
 	env, err := setupBootstrapWithConfigPaths(resolvedConfigPaths, operator.StatePaths{
 		ArtifactsDir: *artifactsDir,
 		LockfilePath: *lockfilePath,
-	}, locked)
+	}, locked, []string(onlyApps))
 	if err != nil {
 		return err
 	}
@@ -486,6 +491,8 @@ func printServeUsage(w io.Writer) {
 	writeUsageLine(w, "Start the server. Without --locked, auto lock/syncs if state is missing or stale.")
 	writeUsageLine(w, "Use --path to serve one local source app or UI bundle inside a synthesized Gestalt config.")
 	writeUsageLine(w, "Use --watch to rebuild/restart after debounced local file changes.")
+	writeUsageLine(w, "Use --only NAME (repeatable) to boot just the named apps from the full config,")
+	writeUsageLine(w, "pruning other apps and their providers so unrelated builds and cloud deps are skipped.")
 	writeUsageLine(w, "For production, strongly prefer --locked so startup uses the pinned")
 	writeUsageLine(w, "lockfile and prepared artifacts instead of resolving or mutating state.")
 	writeUsageLine(w, "When locked, run `gestaltd lock` before deploy and `gestaltd sync --locked` during build.")

--- a/gestaltd/internal/daemon/serve_watch.go
+++ b/gestaltd/internal/daemon/serve_watch.go
@@ -20,11 +20,11 @@ type serveWatchCandidate struct {
 	done chan error
 }
 
-func runServeWatch(configPaths []string, state operator.StatePaths) error {
+func runServeWatch(configPaths []string, state operator.StatePaths, onlyApps []string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	active, err := prepareServeWatchCandidate(ctx, configPaths, state)
+	active, err := prepareServeWatchCandidate(ctx, configPaths, state, onlyApps)
 	if err != nil {
 		return err
 	}
@@ -93,13 +93,13 @@ func runServeWatch(configPaths []string, state operator.StatePaths) error {
 			}
 		case <-timerC:
 			timerC = nil
-			active, watcher = reloadServeWatchCandidate(ctx, configPaths, state, active, watcher)
+			active, watcher = reloadServeWatchCandidate(ctx, configPaths, state, onlyApps, active, watcher)
 		}
 	}
 }
 
-func reloadServeWatchCandidate(ctx context.Context, configPaths []string, state operator.StatePaths, active *serveWatchCandidate, watcher *fsnotify.Watcher) (*serveWatchCandidate, *fsnotify.Watcher) {
-	next, err := prepareServeWatchCandidate(ctx, configPaths, state)
+func reloadServeWatchCandidate(ctx context.Context, configPaths []string, state operator.StatePaths, onlyApps []string, active *serveWatchCandidate, watcher *fsnotify.Watcher) (*serveWatchCandidate, *fsnotify.Watcher) {
+	next, err := prepareServeWatchCandidate(ctx, configPaths, state, onlyApps)
 	if err != nil {
 		slog.Error("watch reload failed; keeping current server", "error", err)
 		return active, watcher
@@ -125,9 +125,9 @@ func reloadServeWatchCandidate(ctx context.Context, configPaths []string, state 
 	return next, nextWatcher
 }
 
-func prepareServeWatchCandidate(parent context.Context, configPaths []string, state operator.StatePaths) (*serveWatchCandidate, error) {
+func prepareServeWatchCandidate(parent context.Context, configPaths []string, state operator.StatePaths, onlyApps []string) (*serveWatchCandidate, error) {
 	ctx, cancel := context.WithCancel(parent)
-	env, err := setupBootstrapWithConfigPathsContext(ctx, cancel, configPaths, state, false)
+	env, err := setupBootstrapWithConfigPathsContext(ctx, cancel, configPaths, state, false, onlyApps)
 	if err != nil {
 		return nil, err
 	}

--- a/gestaltd/internal/daemon/serve_watch_test.go
+++ b/gestaltd/internal/daemon/serve_watch_test.go
@@ -14,7 +14,7 @@ func TestReloadServeWatchCandidateKeepsActiveWhenPrepareFails(t *testing.T) {
 	active := &serveWatchCandidate{}
 	missingConfigPath := filepath.Join(t.TempDir(), "missing.yaml")
 
-	gotActive, gotWatcher := reloadServeWatchCandidate(context.Background(), []string{missingConfigPath}, operator.StatePaths{}, active, nil)
+	gotActive, gotWatcher := reloadServeWatchCandidate(context.Background(), []string{missingConfigPath}, operator.StatePaths{}, nil, active, nil)
 	if gotActive != active {
 		t.Fatal("reload replaced active candidate after prepare failure")
 	}

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -698,7 +698,7 @@ func (l *Lifecycle) prepareRuntimeLockFromLoadedConfigWithSecretMode(ctx context
 		}
 	}
 	for name, entry := range cfg.Providers.UI {
-		if entry != nil && sourceBacked(&entry.ProviderEntry) {
+		if entry != nil && !entry.HasDevProxy() && sourceBacked(&entry.ProviderEntry) {
 			if _, existed := existingUIEntries[name]; !existed && (entry.HasLocalSource() || entry.HasLocalReleaseSource()) {
 				if app := cfg.Apps[name]; app != nil && strings.TrimSpace(app.UI) == "" && strings.TrimSpace(app.MountPath) != "" {
 					continue
@@ -3424,6 +3424,9 @@ func (l *Lifecycle) applyPreparedUIProviders(paths lifecyclePaths, lock *Lockfil
 	for _, name := range slices.Sorted(maps.Keys(cfg.Providers.UI)) {
 		entry := cfg.Providers.UI[name]
 		if entry == nil {
+			continue
+		}
+		if entry.HasDevProxy() {
 			continue
 		}
 		configMap, err := config.NodeToMap(entry.Config)

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -99,6 +99,7 @@ type Lifecycle struct {
 	sourceAuthSecretResolver func(context.Context, *config.Config) error
 	httpClient               *http.Client
 	providerResolver         *providerregistry.Resolver
+	retainApps               []string
 }
 
 type StatePaths struct {
@@ -175,6 +176,15 @@ func (l *Lifecycle) WithHTTPClient(client *http.Client) *Lifecycle {
 
 func (l *Lifecycle) WithProviderResolver(resolver *providerregistry.Resolver) *Lifecycle {
 	l.providerResolver = resolver
+	return l
+}
+
+// WithRetainApps restricts execution loads to the named apps and their
+// dependency closure, pruning the rest of the config before any preparation so
+// unrelated apps and providers are never built or bootstrapped. Empty is a
+// no-op. Only affects LoadForExecution; lock/sync/validation see the full config.
+func (l *Lifecycle) WithRetainApps(names []string) *Lifecycle {
+	l.retainApps = names
 	return l
 }
 
@@ -533,6 +543,9 @@ func (l *Lifecycle) prepareCommittedRuntimeLockFromLoadedConfig(ctx context.Cont
 	}
 	for name, entry := range cfg.Providers.UI {
 		if entry == nil {
+			continue
+		}
+		if entry.HasDevProxy() {
 			continue
 		}
 		if _, existed := existingUIEntries[name]; !existed && entry.HasLocalSource() && pathWithinRoot(filepath.Join(paths.artifactsDir, ".gestaltd"), entry.SourcePath()) {
@@ -914,6 +927,16 @@ func (l *Lifecycle) LoadForExecutionAtPathsWithStatePaths(configPaths []string, 
 	cfg, err := loadConfigForLifecycle(configPaths, state, false)
 	if err != nil {
 		return nil, nil, fmt.Errorf("loading config: %v", err)
+	}
+	if len(l.retainApps) > 0 {
+		result, err := config.RetainApps(cfg, l.retainApps)
+		if err != nil {
+			return nil, nil, err
+		}
+		slog.Info("serving app subset",
+			"only", result.Kept,
+			"dropped_workflows", result.DroppedWorkflows,
+		)
 	}
 	paths := resolveLifecyclePaths(configPaths, cfg, state)
 	mode := artifactModeMaterialize

--- a/gestaltd/internal/server/devproxy_test.go
+++ b/gestaltd/internal/server/devproxy_test.go
@@ -1,0 +1,149 @@
+package server_test
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/server"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+)
+
+// newDevProxyUpstream returns a stand-in framework dev server. Normal requests
+// echo the path they received (so tests can assert the full mount prefix is
+// forwarded); WebSocket upgrades complete a minimal handshake and echo a line
+// (so tests can assert HMR upgrades pass through gestaltd's middleware chain).
+func newDevProxyUpstream(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
+			conn, buf, err := http.NewResponseController(w).Hijack()
+			if err != nil {
+				t.Errorf("upstream hijack: %v", err)
+				return
+			}
+			defer func() { _ = conn.Close() }()
+			io.WriteString(buf, "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n")
+			_ = buf.Flush()
+			line, err := buf.ReadString('\n')
+			if err != nil {
+				return
+			}
+			io.WriteString(buf, "echo:"+line)
+			_ = buf.Flush()
+			return
+		}
+		w.Header().Set("X-Upstream", "dev-server")
+		fmt.Fprintf(w, "served:%s", r.URL.Path)
+	}))
+}
+
+func newDevProxyTestServer(t *testing.T, mountPath, upstreamURL string) *httptest.Server {
+	t.Helper()
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.ProviderUIs = map[string]*config.UIEntry{
+			"gIssues": {
+				Path:     mountPath,
+				DevProxy: &config.UIDevProxy{URL: upstreamURL},
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+	return ts
+}
+
+func TestUIDevProxyForwardsFullPath(t *testing.T) {
+	t.Parallel()
+
+	upstream := newDevProxyUpstream(t)
+	defer upstream.Close()
+	ts := newDevProxyTestServer(t, "/g-issues", upstream.URL)
+
+	resp, err := http.Get(ts.URL + "/g-issues/_next/static/app.js")
+	if err != nil {
+		t.Fatalf("GET dev-proxy mount: %v", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := resp.Header.Get("X-Upstream"); got != "dev-server" {
+		t.Fatalf("X-Upstream = %q, want dev-server (response not proxied)", got)
+	}
+	// The dev server must see the full mount-prefixed path so its basePath and
+	// HMR client URLs line up; gestaltd must not strip the /g-issues prefix.
+	if want := "served:/g-issues/_next/static/app.js"; string(body) != want {
+		t.Fatalf("body = %q, want %q", body, want)
+	}
+}
+
+func TestUIDevProxyForwardsWebSocketUpgrade(t *testing.T) {
+	t.Parallel()
+
+	upstream := newDevProxyUpstream(t)
+	defer upstream.Close()
+	ts := newDevProxyTestServer(t, "/g-issues", upstream.URL)
+
+	u, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("parse test server url: %v", err)
+	}
+	conn, err := net.Dial("tcp", u.Host)
+	if err != nil {
+		t.Fatalf("dial gestaltd: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+
+	req := "GET /g-issues/_next/webpack-hmr HTTP/1.1\r\n" +
+		"Host: " + u.Host + "\r\n" +
+		"Upgrade: websocket\r\n" +
+		"Connection: Upgrade\r\n" +
+		"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+		"Sec-WebSocket-Version: 13\r\n\r\n"
+	if _, err := io.WriteString(conn, req); err != nil {
+		t.Fatalf("write upgrade request: %v", err)
+	}
+
+	br := bufio.NewReader(conn)
+	status, err := br.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read upgrade status: %v", err)
+	}
+	if !strings.Contains(status, "101") {
+		t.Fatalf("status line = %q, want 101 Switching Protocols", status)
+	}
+	// Drain the rest of the response headers.
+	for {
+		line, err := br.ReadString('\n')
+		if err != nil {
+			t.Fatalf("read upgrade headers: %v", err)
+		}
+		if strings.TrimSpace(line) == "" {
+			break
+		}
+	}
+
+	if _, err := io.WriteString(conn, "ping\n"); err != nil {
+		t.Fatalf("write ws frame: %v", err)
+	}
+	echo, err := br.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read ws echo: %v", err)
+	}
+	if strings.TrimSpace(echo) != "echo:ping" {
+		t.Fatalf("ws echo = %q, want echo:ping (bidirectional stream broken)", strings.TrimSpace(echo))
+	}
+}

--- a/gestaltd/internal/server/mounted_ui.go
+++ b/gestaltd/internal/server/mounted_ui.go
@@ -116,6 +116,20 @@ func mountedUIsFromEntries(entries map[string]*config.UIEntry) ([]MountedUI, err
 		if entry == nil {
 			continue
 		}
+		if entry.HasDevProxy() {
+			handler, err := ui.DevProxyHandler(entry.DevProxyURL())
+			if err != nil {
+				return nil, fmt.Errorf("ui %q dev proxy: %w", name, err)
+			}
+			mounted = append(mounted, MountedUI{
+				Name:     name,
+				Path:     entry.Path,
+				AppName:  entry.OwnerApp,
+				Handler:  handler,
+				devProxy: true,
+			})
+			continue
+		}
 		if entry.ResolvedAssetRoot == "" {
 			return nil, fmt.Errorf("ui %q configured but asset root not resolved", name)
 		}
@@ -334,7 +348,7 @@ func (s *Server) mountedUIHandler(mounted MountedUI) http.Handler {
 	// policy-bound mounts keep their auth semantics for /theme.css and
 	// /theme/* exactly like any other mount path.
 	inner = mountedUIThemeHandler(mounted, inner)
-	if mounted.Path != "/" {
+	if mounted.Path != "/" && !mounted.devProxy {
 		inner = http.StripPrefix(mounted.Path, inner)
 	}
 	return mountedUITelemetryHandler(mounted, s.protectedUIHandler(mounted, inner, s.redirectMountedUILogin))

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -60,6 +60,10 @@ type MountedUI struct {
 	ThemeStylesheet string
 	ThemeAssetsDir  string
 	builtInAdmin    bool
+	// devProxy marks a mount whose Handler reverse-proxies to a local dev
+	// server. Such mounts forward the full request path (no prefix strip) and
+	// are served without route authorization (local development only).
+	devProxy bool
 }
 
 type MountedHTTPBinding struct {

--- a/gestaltd/services/ui/devproxy.go
+++ b/gestaltd/services/ui/devproxy.go
@@ -1,0 +1,29 @@
+package ui
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+)
+
+// DevProxyHandler returns an http.Handler that reverse-proxies every request to
+// target, a local framework dev server (e.g. `next dev`). It streams responses
+// immediately (FlushInterval = -1) so server-sent hot-reload events and the HMR
+// WebSocket upgrade are forwarded without buffering. The incoming request path
+// is forwarded unchanged, so the dev server must serve the bundle under the
+// same base path as the mount.
+func DevProxyHandler(target string) (http.Handler, error) {
+	u, err := url.Parse(strings.TrimSpace(target))
+	if err != nil || !u.IsAbs() || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+		return nil, fmt.Errorf("dev proxy target must be an absolute http(s) URL, got %q", target)
+	}
+	return &httputil.ReverseProxy{
+		FlushInterval: -1,
+		Rewrite: func(r *httputil.ProxyRequest) {
+			r.SetURL(u)
+			r.Out.Host = u.Host
+		},
+	}, nil
+}


### PR DESCRIPTION
Two related local-development features for gestaltd.

## 1. UI dev-server proxy (HMR)

Adds opt-in `providers.ui.<name>.devProxy.url`. When set, gestaltd reverse-proxies the mount to a running framework dev server (e.g. `next dev`) instead of serving prepared static assets — giving **hot module reload** on the same origin as the API.

- Builds an `httputil.ReverseProxy` (`FlushInterval: -1`, **WebSocket upgrade passthrough**) instead of the static handler.
- Forwards the **full mount-prefixed path** (no `StripPrefix`); run the dev server under the same base path.
- **Skips lock/prepare** for the bundle across all three lifecycle paths (runtime lock, committed lock, apply) — it is never built and has no `ResolvedAssetRoot`.
- Served **without route authorization** — local development only (validated as an absolute `http(s)` URL).

## 2. `serve --only NAME`

Boots a single app out of a full fleet config. Repeat `--only` for several apps. Before any lock/sync/bootstrap, the loaded config is pruned to the named apps and their dependency closure:

- keeps the named apps, the UI bundles they mount, and the `indexeddb`/`cache`/`s3`/`runtime` providers they reference (plus `default` ones and the server-selected default indexeddb);
- keeps all shared infra (authn/authz/secrets/telemetry/audit/externalCredentials) and orchestration (workflow/agent) providers;
- drops every other app, its orphaned UI/storage providers, and any workflow definition targeting a dropped app.

So unrelated source builds and cloud dependencies are never touched, letting one canonical config replace hand-maintained single-app dev configs. Cannot be combined with `--path`.

## Tests

- `internal/server/devproxy_test.go`: full-path forwarding + HMR WebSocket upgrade through the server middleware/auth chain.
- `internal/config/prune_test.go`: closure pruning, default-provider retention, unknown-app error, no-op.
- `internal/daemon` CLI test: `--only` + `--path` rejection.

## Docs

`reference/cli.mdx` (App Subset + UI Dev Server Proxy), `providers/ui.mdx` (Local dev server proxy), `reference/config-file.mdx` (`devProxy.url`).

## Review

Addressed the Bugbot finding: the committed-lock path (`gestaltd lock`) now also skips dev-proxy UI bundles, matching the sync/serve paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)