### PR TITLE
Extend gestaltd serve --path for locked fleet + local UI dev

### DIFF
--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -55,8 +55,8 @@ the platform where they run.
 | `gestaltd provider repo list` | List the default, user-level, and project provider repositories. |
 | `gestaltd provider repo update` | Fetch and cache provider repository indexes. |
 | `gestaltd provider repo remove NAME` | Remove a provider repository from the user-level store. Pass `--config PATH` to remove it from project config instead. |
-| `gestaltd serve --path PATH` | Run a local source app or UI bundle inside a synthesized Gestalt config. Serves `/admin` and any configured or inferred public UIs. |
-| `gestaltd serve --path PATH --config PATH` | Layer supporting providers, apps, and UI mounts on top of the synthesized local baseline. Repeat `--config` to merge left-to-right. |
+| `gestaltd serve --path PATH` | Run one or more local source app or UI bundles. Repeat `--path` for multiple targets. Without `--config`, serves a synthesized baseline (unlocked). |
+| `gestaltd serve --path PATH --config PATH` | Layer `--path` local-source overrides on top of the user config. Repeat `--path` and `--config` as needed. With `--locked`, the fleet loads pinned artifacts while `--path` UIs that declare a manifest `dev:` block hot-reload from local trees. |
 | `gestaltd provider validate --path PATH` | Validate a local source app or UI bundle inside the same synthesized Gestalt config used by `gestaltd serve --path`. |
 | `gestaltd provider validate --config PATH` | Validate the target provider together with selected supporting providers and `null` deletions from layered config overlays. |
 | `gestaltd provider package --version VERSION` | Build provider release archives from a source directory. Executable source providers use SDK-native source packages or `build.command` and default to the host platform; UI and declarative providers default to a generic archive. Pass `--platform ...` with `os/arch` targets or `--platform all` for multi-platform builds. |
@@ -191,11 +191,23 @@ Map these in your framework dev script, for example
 `NEXT_BASE_PATH=$GESTALT_DEV_BASE_PATH next dev --port $GESTALT_DEV_PORT`.
 
 Production and `gestaltd serve --locked` ignore `dev:` and continue to serve the
-static `build` output. Config or provider changes require restarting gestaltd.
+static `build` output, except for UIs selected with `--path` that declare a
+`dev:` block — those are dev-proxied even under `--locked`. Config or provider
+changes require restarting gestaltd.
 
-For faster iteration on one local plugin, use `gestaltd serve --path`
-for a standalone source tree or layer a small local config that includes only
-the app under test:
+For faster iteration on local UIs while the rest of the fleet runs from pinned
+artifacts, repeat `--path` together with `--config` and `--locked`:
+
+```sh
+gestaltd serve --locked \
+  --config ./deploy/config.yaml \
+  --config ./deploy/local/config.yaml \
+  --path ./apps/g-issues/ui \
+  --path ./apps/delta/ui
+```
+
+For a standalone local provider without the full fleet config, use `gestaltd serve --path`
+for a source tree or layer a small local config that includes only the app under test:
 
 ```sh
 gestaltd serve \
@@ -219,6 +231,7 @@ gestaltd lock --config ./config.yaml --lockfile ./local/gestalt.lock.json
 gestaltd sync --locked --config ./config.yaml --lockfile ./local/gestalt.lock.json
 gestaltd serve --config ./config.yaml --lockfile ./local/gestalt.lock.json
 gestaltd serve --path ./apps/support/manifest.yaml
+gestaltd serve --locked --config ./config.yaml --path ./apps/g-issues/ui
 gestaltd serve --locked --config ./config.yaml --lockfile ./local/gestalt.lock.json
 gestaltd lock --config ./base.yaml --config ./overrides/prod.yaml
 gestaltd sync --locked --config ./base.yaml --config ./overrides/prod.yaml
@@ -241,7 +254,9 @@ gestaltd provider validate --path ./ui/dashboard
 gestaltd provider validate --path ./apps/support --config ./dev/support.yaml --config ./dev/local.yaml
 gestaltd serve --path ./apps/support
 gestaltd serve --path ./ui/dashboard
+gestaltd serve --path ./apps/support --path ./ui/dashboard --config ./dev/support.yaml
 gestaltd serve --path ./apps/support --config ./dev/support.yaml --port 8080
+gestaltd serve --locked --config ./config.yaml --path ./apps/g-issues/ui --path ./apps/delta/ui
 gestaltd provider package --version 0.0.1-alpha.1
 gestaltd provider package --version 0.0.1-alpha.1 --platform all
 gestaltd provider package --version 0.0.1-alpha.1 --platform linux/amd64,linux/arm64

--- a/gestaltd/internal/daemon/factories.go
+++ b/gestaltd/internal/daemon/factories.go
@@ -34,13 +34,13 @@ type bootstrapEnv struct {
 	prevLogger *slog.Logger
 }
 
-func setupBootstrapWithConfigPaths(configPaths []string, state operator.StatePaths, locked bool) (*bootstrapEnv, error) {
+func setupBootstrapWithConfigPaths(configPaths []string, state operator.StatePaths, locked bool, forcedDevUIKeys ...string) (*bootstrapEnv, error) {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	return setupBootstrapWithConfigPathsContext(ctx, stop, configPaths, state, locked)
+	return setupBootstrapWithConfigPathsContext(ctx, stop, configPaths, state, locked, forcedDevUIKeys...)
 }
 
-func setupBootstrapWithConfigPathsContext(ctx context.Context, stop context.CancelFunc, configPaths []string, state operator.StatePaths, locked bool) (*bootstrapEnv, error) {
-	cfg, err := loadConfigForExecutionAtPathsWithStatePaths(configPaths, state, locked)
+func setupBootstrapWithConfigPathsContext(ctx context.Context, stop context.CancelFunc, configPaths []string, state operator.StatePaths, locked bool, forcedDevUIKeys ...string) (*bootstrapEnv, error) {
+	cfg, err := loadConfigForExecutionAtPathsWithStatePaths(configPaths, state, locked, forcedDevUIKeys...)
 	if err != nil {
 		stop()
 		return nil, err

--- a/gestaltd/internal/daemon/lifecycle.go
+++ b/gestaltd/internal/daemon/lifecycle.go
@@ -37,8 +37,12 @@ func syncConfigWithStatePathsOptions(configFlags []string, state operator.StateP
 	return operatorLifecycle().SyncAtPathsWithStatePathsOptions(configPaths, state, opts)
 }
 
-func loadConfigForExecutionAtPathsWithStatePaths(configPaths []string, state operator.StatePaths, locked bool) (*config.Config, error) {
-	cfg, _, err := operatorLifecycle().WithDevServeEligible(!locked).LoadForExecutionAtPathsWithStatePaths(configPaths, state, locked)
+func loadConfigForExecutionAtPathsWithStatePaths(configPaths []string, state operator.StatePaths, locked bool, forcedDevUIKeys ...string) (*config.Config, error) {
+	lc := operatorLifecycle().WithDevServeEligible(!locked)
+	if len(forcedDevUIKeys) > 0 {
+		lc = lc.WithForcedDevUIKeys(forcedDevUIKeys)
+	}
+	cfg, _, err := lc.LoadForExecutionAtPathsWithStatePaths(configPaths, state, locked)
 	if err != nil {
 		return nil, err
 	}

--- a/gestaltd/internal/daemon/provider_local.go
+++ b/gestaltd/internal/daemon/provider_local.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"log/slog"
 	"net"
-	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -23,7 +22,6 @@ import (
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/apps/providerpkg"
 	"github.com/valon-technologies/gestalt/server/services/apps/source"
-	"github.com/valon-technologies/gestalt/server/services/ui"
 	"gopkg.in/yaml.v3"
 )
 
@@ -35,10 +33,16 @@ const (
 )
 
 type providerLocalCommandOptions struct {
-	Path        string
-	ConfigPaths []string
-	Name        string
-	Port        int
+	Paths        []string
+	ConfigPaths  []string
+	Name         string
+	Port         int
+	Locked       bool
+	ArtifactsDir string
+	LockfilePath string
+	// FleetOverlay is true for serve --path with --config. Validate always leaves
+	// this false so it keeps the synthesized baseline even with --config.
+	FleetOverlay bool
 }
 
 type providerLocalSession struct {
@@ -46,12 +50,24 @@ type providerLocalSession struct {
 	Kind              string
 	ManifestPath      string
 	TargetKey         string
+	TargetKeys        []string
+	DevUIKeys         []string
 	ConfigPaths       []string
 	State             operator.StatePaths
+	Locked            bool
 	PublicURL         string
 	AdminURL          string
 	PublicUIPaths     []string
 	AutoMountedUIPath string
+}
+
+type providerLocalTargetOverlay struct {
+	overlayPath  string
+	targetKey    string
+	devUIKey     string
+	kind         string
+	manifestPath string
+	mountPath    string
 }
 
 func runProviderValidate(args []string) error {
@@ -69,7 +85,7 @@ func runProviderValidate(args []string) error {
 	}
 
 	session, err := prepareProviderLocalSession(providerLocalCommandOptions{
-		Path:        *pathFlag,
+		Paths:       []string{*pathFlag},
 		ConfigPaths: []string(configPaths),
 		Name:        *nameFlag,
 		Port:        8080,
@@ -94,33 +110,120 @@ func runProviderValidate(args []string) error {
 }
 
 func runServeProviderLocal(opts providerLocalCommandOptions) error {
-	port := opts.Port
-	if port == 0 {
-		selectedPort, err := reserveLocalPort()
-		if err != nil {
-			return err
-		}
-		port = selectedPort
-	}
-	opts.Port = port
-
-	session, err := prepareProviderLocalSession(providerLocalCommandOptions{
-		Path:        opts.Path,
-		ConfigPaths: opts.ConfigPaths,
-		Name:        opts.Name,
-		Port:        port,
-	})
+	opts.FleetOverlay = len(opts.ConfigPaths) > 0
+	session, err := prepareProviderLocalSession(opts)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = os.RemoveAll(session.Dir) }()
 
-	env, err := setupBootstrapWithConfigPaths(session.ConfigPaths, session.State, false)
+	var forcedDevUIKeys []string
+	if session.Locked {
+		forcedDevUIKeys = session.DevUIKeys
+	}
+	env, err := setupBootstrapWithConfigPaths(session.ConfigPaths, session.State, session.Locked, forcedDevUIKeys...)
 	if err != nil {
 		return err
 	}
 	logProviderLocalSummary("local provider ready", session)
 	return runServer(env)
+}
+
+func buildProviderLocalTargetOverlay(sessionDir string, index int, opts providerLocalCommandOptions, path string, port int, configPathsSoFar []string) (*providerLocalTargetOverlay, error) {
+	manifestPath, manifest, err := resolveProviderTargetManifest(path)
+	if err != nil {
+		return nil, err
+	}
+	kind, err := providerpkg.ManifestKind(manifest)
+	if err != nil {
+		return nil, err
+	}
+	if kind != providermanifestv1.KindApp && kind != providermanifestv1.KindUI {
+		return nil, fmt.Errorf("gestaltd serve --path and provider validate only support kind: app or ui in v1 (got %q)", kind)
+	}
+	targetManifestPath, err := canonicalPath(manifestPath)
+	if err != nil {
+		return nil, err
+	}
+
+	overlayPath := filepath.Join(sessionDir, fmt.Sprintf("provider-target-%d.yaml", index))
+	result := &providerLocalTargetOverlay{
+		overlayPath:  overlayPath,
+		kind:         kind,
+		manifestPath: targetManifestPath,
+	}
+
+	switch kind {
+	case providermanifestv1.KindUI:
+		resolvedKey, err := resolveProviderLocalUIKey(opts.ConfigPaths, targetManifestPath, manifest, opts.Name)
+		if err != nil {
+			return nil, err
+		}
+		mountPath := defaultProviderLocalMountPath(manifest, targetManifestPath, resolvedKey)
+		if configuredUIs, loadErr := loadConfiguredUIs(opts.ConfigPaths); loadErr == nil {
+			if entry := configuredUIs[resolvedKey]; entry != nil && strings.TrimSpace(entry.Path) != "" {
+				mountPath = strings.TrimSpace(entry.Path)
+			}
+		}
+		if err := writeProviderLocalUIOverlayConfig(overlayPath, resolvedKey, targetManifestPath, port, mountPath); err != nil {
+			return nil, err
+		}
+		result.targetKey = resolvedKey
+		result.devUIKey = resolvedKey
+		result.mountPath = mountPath
+		return result, nil
+	case providermanifestv1.KindApp:
+		resolvedKey, err := resolveProviderLocalPluginKey(opts.ConfigPaths, targetManifestPath, manifest, opts.Name)
+		if err != nil {
+			return nil, err
+		}
+		autoMountPath, uiName, uiManifestPath, err := resolveProviderLocalAppMount(configPathsSoFar, resolvedKey, targetManifestPath, manifest)
+		if err != nil {
+			return nil, err
+		}
+		if err := writeProviderLocalPluginOverlayConfig(overlayPath, resolvedKey, targetManifestPath, port, autoMountPath, uiName, uiManifestPath); err != nil {
+			return nil, err
+		}
+		result.targetKey = resolvedKey
+		result.mountPath = autoMountPath
+		return result, nil
+	default:
+		return nil, fmt.Errorf("unsupported provider local target kind %q", kind)
+	}
+}
+
+func resolveProviderLocalAppMount(configPaths []string, resolvedKey, targetManifestPath string, manifest *providermanifestv1.Manifest) (autoMountPath, uiName, uiManifestPath string, err error) {
+	siblingUIManifestPath, err := findSiblingUIManifestPath(targetManifestPath, manifest)
+	if err != nil {
+		return "", "", "", err
+	}
+	loadedCfg, loadErr := config.LoadPaths(configPaths)
+	if loadErr != nil {
+		return "", "", "", fmt.Errorf("load provider overlay config: %w", loadErr)
+	}
+	switch {
+	case shouldAutoMountOwnedUI(loadedCfg, resolvedKey, manifest):
+		autoMountPath = defaultProviderLocalMountPath(manifest, targetManifestPath, resolvedKey)
+		if err := ensureNoPublicUIPathCollision(loadedCfg, resolvedKey, autoMountPath); err != nil {
+			return "", "", "", err
+		}
+	case siblingUIManifestPath != "":
+		if entry := loadedCfg.Apps[resolvedKey]; entry != nil {
+			uiName = strings.TrimSpace(entry.UI)
+			autoMountPath = strings.TrimSpace(entry.MountPath)
+		}
+		if uiName == "" {
+			uiName = resolvedKey
+		}
+		if autoMountPath == "" {
+			autoMountPath = defaultProviderLocalMountPath(manifest, targetManifestPath, resolvedKey)
+			if err := ensureNoPublicUIPathCollision(loadedCfg, resolvedKey, autoMountPath); err != nil {
+				return "", "", "", err
+			}
+		}
+		uiManifestPath = siblingUIManifestPath
+	}
+	return autoMountPath, uiName, uiManifestPath, nil
 }
 
 type validatedConfigResult struct {
@@ -152,22 +255,8 @@ func validateConfigWithStatePaths(configFlags []string, state operator.StatePath
 }
 
 func prepareProviderLocalSession(opts providerLocalCommandOptions) (*providerLocalSession, error) {
-	manifestPath, manifest, err := resolveProviderTargetManifest(opts.Path)
-	if err != nil {
-		return nil, err
-	}
-
-	kind, err := providerpkg.ManifestKind(manifest)
-	if err != nil {
-		return nil, err
-	}
-	if kind != providermanifestv1.KindApp && kind != providermanifestv1.KindUI {
-		return nil, fmt.Errorf("gestaltd serve --path and provider validate only support kind: app or ui in v1 (got %q)", kind)
-	}
-
-	targetManifestPath, err := canonicalPath(manifestPath)
-	if err != nil {
-		return nil, err
+	if len(opts.Paths) == 0 {
+		return nil, fmt.Errorf("at least one --path is required")
 	}
 
 	sessionDir, err := os.MkdirTemp("", "gestaltd-provider-*")
@@ -181,186 +270,91 @@ func prepareProviderLocalSession(opts providerLocalCommandOptions) (*providerLoc
 		}
 	}()
 
-	baseConfigPath := filepath.Join(sessionDir, "provider-base.yaml")
-	dbPath := filepath.Join(sessionDir, "provider.db")
-	if err := writeProviderLocalBaseConfig(baseConfigPath, dbPath); err != nil {
-		return nil, err
-	}
+	var configPaths []string
 	state := operator.StatePaths{
-		ArtifactsDir: filepath.Join(sessionDir, "artifacts"),
-		LockfilePath: filepath.Join(sessionDir, "gestalt.lock.json"),
+		ArtifactsDir: opts.ArtifactsDir,
+		LockfilePath: opts.LockfilePath,
+	}
+	locked := opts.Locked && opts.FleetOverlay
+	port := opts.Port
+	if opts.FleetOverlay {
+		configPaths = append([]string(nil), opts.ConfigPaths...)
+		port = 0
+	} else {
+		baseConfigPath := filepath.Join(sessionDir, "provider-base.yaml")
+		dbPath := filepath.Join(sessionDir, "provider.db")
+		if err := writeProviderLocalBaseConfig(baseConfigPath, dbPath); err != nil {
+			return nil, err
+		}
+		configPaths = append([]string{baseConfigPath}, opts.ConfigPaths...)
+		state = operator.StatePaths{
+			ArtifactsDir: filepath.Join(sessionDir, "artifacts"),
+			LockfilePath: filepath.Join(sessionDir, "gestalt.lock.json"),
+		}
+		locked = false
+		if port == 0 {
+			selectedPort, err := reserveLocalPort()
+			if err != nil {
+				return nil, err
+			}
+			port = selectedPort
+		}
 	}
 
-	var session *providerLocalSession
-	switch kind {
-	case providermanifestv1.KindApp:
-		session, err = preparePluginLocalSession(sessionDir, baseConfigPath, state, opts, targetManifestPath, manifest)
-	case providermanifestv1.KindUI:
-		session, err = prepareUILocalSession(sessionDir, baseConfigPath, state, opts, targetManifestPath, manifest)
-	default:
-		err = fmt.Errorf("unsupported provider local target kind %q", kind)
+	var (
+		targetKeys  []string
+		devUIKeys   []string
+		publicPaths []string
+		lastOverlay *providerLocalTargetOverlay
+	)
+	for i, path := range opts.Paths {
+		overlay, err := buildProviderLocalTargetOverlay(sessionDir, i, opts, path, port, configPaths)
+		if err != nil {
+			return nil, err
+		}
+		configPaths = append(configPaths, overlay.overlayPath)
+		targetKeys = append(targetKeys, overlay.targetKey)
+		if overlay.devUIKey != "" && locked {
+			devUIKeys = append(devUIKeys, overlay.devUIKey)
+		}
+		if overlay.mountPath != "" {
+			publicPaths = append(publicPaths, overlay.mountPath)
+		}
+		lastOverlay = overlay
 	}
+
+	loadedCfg, err := config.LoadPaths(configPaths)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("loading local provider config: %w", err)
+	}
+	publicUIPaths := mountedPublicUIPaths(loadedCfg)
+	for _, mountPath := range publicPaths {
+		if mountPath != "" && !slices.Contains(publicUIPaths, mountPath) {
+			publicUIPaths = append(publicUIPaths, mountPath)
+		}
+	}
+	slices.Sort(publicUIPaths)
+	publicUIPaths = slices.Compact(publicUIPaths)
+
+	session := &providerLocalSession{
+		Dir:           sessionDir,
+		TargetKeys:    targetKeys,
+		DevUIKeys:     devUIKeys,
+		ConfigPaths:   configPaths,
+		State:         state,
+		Locked:        locked,
+		PublicURL:     providerLocalPublicURL(loadedCfg),
+		AdminURL:      strings.TrimRight(providerLocalPublicURL(loadedCfg), "/") + "/admin/",
+		PublicUIPaths: publicUIPaths,
+	}
+	if lastOverlay != nil {
+		session.Kind = lastOverlay.kind
+		session.ManifestPath = lastOverlay.manifestPath
+		session.TargetKey = lastOverlay.targetKey
+		session.AutoMountedUIPath = lastOverlay.mountPath
 	}
 	cleanupSessionDir = false
 	return session, nil
-}
-
-func preparePluginLocalSession(sessionDir, baseConfigPath string, state operator.StatePaths, opts providerLocalCommandOptions, targetManifestPath string, manifest *providermanifestv1.Manifest) (*providerLocalSession, error) {
-	resolvedKey, err := resolveProviderLocalPluginKey(opts.ConfigPaths, targetManifestPath, manifest, opts.Name)
-	if err != nil {
-		return nil, err
-	}
-
-	overlayConfigPath := filepath.Join(sessionDir, "provider-target.yaml")
-	if err := writeProviderLocalPluginOverlayConfig(overlayConfigPath, resolvedKey, targetManifestPath, opts.Port, "", "", ""); err != nil {
-		return nil, err
-	}
-
-	configPaths := append([]string{baseConfigPath}, opts.ConfigPaths...)
-	configPaths = append(configPaths, overlayConfigPath)
-
-	loadedCfg, err := config.LoadPaths(configPaths)
-	if err != nil {
-		return nil, fmt.Errorf("loading local provider config: %w", err)
-	}
-
-	autoMountPath := ""
-	siblingUIManifestPath, err := findSiblingUIManifestPath(targetManifestPath, manifest)
-	if err != nil {
-		return nil, err
-	}
-	switch {
-	case shouldAutoMountOwnedUI(loadedCfg, resolvedKey, manifest):
-		autoMountPath = defaultProviderLocalMountPath(manifest, targetManifestPath, resolvedKey)
-		if err := ensureNoPublicUIPathCollision(loadedCfg, resolvedKey, autoMountPath); err != nil {
-			return nil, err
-		}
-		if err := writeProviderLocalPluginOverlayConfig(overlayConfigPath, resolvedKey, targetManifestPath, opts.Port, autoMountPath, "", ""); err != nil {
-			return nil, err
-		}
-	case siblingUIManifestPath != "":
-		var uiName string
-		if entry := loadedCfg.Apps[resolvedKey]; entry != nil {
-			uiName = strings.TrimSpace(entry.UI)
-			autoMountPath = strings.TrimSpace(entry.MountPath)
-		}
-		if uiName == "" {
-			uiName = resolvedKey
-		}
-		if autoMountPath == "" {
-			autoMountPath = defaultProviderLocalMountPath(manifest, targetManifestPath, resolvedKey)
-			if err := ensureNoPublicUIPathCollision(loadedCfg, resolvedKey, autoMountPath); err != nil {
-				return nil, err
-			}
-		}
-		if err := writeProviderLocalPluginOverlayConfig(overlayConfigPath, resolvedKey, targetManifestPath, opts.Port, autoMountPath, uiName, siblingUIManifestPath); err != nil {
-			return nil, err
-		}
-	}
-
-	loadedCfg, err = config.LoadPaths(configPaths)
-	if err != nil {
-		return nil, fmt.Errorf("loading local provider config with mounted ui: %w", err)
-	}
-
-	publicURL := providerLocalPublicURL(loadedCfg)
-	publicUIPaths := mountedPublicUIPaths(loadedCfg)
-	if autoMountPath != "" && !slices.Contains(publicUIPaths, autoMountPath) {
-		publicUIPaths = append(publicUIPaths, autoMountPath)
-		slices.Sort(publicUIPaths)
-	}
-
-	return &providerLocalSession{
-		Dir:               sessionDir,
-		Kind:              providermanifestv1.KindApp,
-		ManifestPath:      targetManifestPath,
-		TargetKey:         resolvedKey,
-		ConfigPaths:       configPaths,
-		State:             state,
-		PublicURL:         publicURL,
-		AdminURL:          strings.TrimRight(publicURL, "/") + "/admin/",
-		PublicUIPaths:     publicUIPaths,
-		AutoMountedUIPath: autoMountPath,
-	}, nil
-}
-
-func prepareUILocalSession(sessionDir, baseConfigPath string, state operator.StatePaths, opts providerLocalCommandOptions, targetManifestPath string, manifest *providermanifestv1.Manifest) (*providerLocalSession, error) {
-	resolvedKey, err := resolveProviderLocalUIKey(opts.ConfigPaths, targetManifestPath, manifest, opts.Name)
-	if err != nil {
-		return nil, err
-	}
-
-	autoMountPath := defaultProviderLocalMountPath(manifest, targetManifestPath, resolvedKey)
-	if configuredUIs, err := loadConfiguredUIs(opts.ConfigPaths); err == nil {
-		if entry := configuredUIs[resolvedKey]; entry != nil && strings.TrimSpace(entry.Path) != "" {
-			autoMountPath = strings.TrimSpace(entry.Path)
-		}
-	}
-
-	overlayConfigPath := filepath.Join(sessionDir, "provider-target.yaml")
-	if err := writeProviderLocalUIOverlayConfig(overlayConfigPath, resolvedKey, targetManifestPath, opts.Port, autoMountPath); err != nil {
-		return nil, err
-	}
-
-	configPaths := append([]string{baseConfigPath}, opts.ConfigPaths...)
-	configPaths = append(configPaths, overlayConfigPath)
-
-	loadedCfg, err := config.LoadPaths(configPaths)
-	if err != nil {
-		return nil, fmt.Errorf("loading local provider config: %w", err)
-	}
-
-	publicURL := providerLocalPublicURL(loadedCfg)
-	publicUIPaths := mountedPublicUIPaths(loadedCfg)
-	if autoMountPath != "" && !slices.Contains(publicUIPaths, autoMountPath) {
-		publicUIPaths = append(publicUIPaths, autoMountPath)
-		slices.Sort(publicUIPaths)
-	}
-
-	return &providerLocalSession{
-		Dir:               sessionDir,
-		Kind:              providermanifestv1.KindUI,
-		ManifestPath:      targetManifestPath,
-		TargetKey:         resolvedKey,
-		ConfigPaths:       configPaths,
-		State:             state,
-		PublicURL:         publicURL,
-		AdminURL:          strings.TrimRight(publicURL, "/") + "/admin/",
-		PublicUIPaths:     publicUIPaths,
-		AutoMountedUIPath: autoMountPath,
-	}, nil
-}
-
-func sourceUIHandler(manifestPath string) (http.Handler, error) {
-	_, manifest, err := providerpkg.ReadSourceManifestFile(manifestPath)
-	if err != nil {
-		return nil, err
-	}
-	kind, err := providerpkg.ManifestKind(manifest)
-	if err != nil {
-		return nil, err
-	}
-	if kind != providermanifestv1.KindUI {
-		return nil, fmt.Errorf("ui manifest %q must have kind %q (got %q)", manifestPath, providermanifestv1.KindUI, kind)
-	}
-	if err := providerpkg.RunSourceBuild(manifestPath, manifest, providerpkg.SourceBuildOptions{}); err != nil {
-		return nil, err
-	}
-	_, manifest, err = providerpkg.ReadSourceManifestFile(manifestPath)
-	if err != nil {
-		return nil, fmt.Errorf("read ui manifest after source build: %w", err)
-	}
-	assetRootValue := providerpkg.SourceUIBuildOutput(manifest)
-	if strings.TrimSpace(assetRootValue) == "" {
-		return nil, fmt.Errorf("ui manifest %q missing spec.assetRoot", manifestPath)
-	}
-	assetRoot := filepath.Join(filepath.Dir(manifestPath), filepath.FromSlash(assetRootValue))
-	if _, err := os.Stat(assetRoot); err != nil {
-		return nil, fmt.Errorf("ui asset root not found at %s: %w", assetRoot, err)
-	}
-	return ui.DirHandler(assetRoot)
 }
 
 func resolveProviderTargetManifest(pathFlag string) (string, *providermanifestv1.Manifest, error) {
@@ -490,16 +484,18 @@ func writeProviderLocalPluginOverlayConfig(path, pluginKey, manifestPath string,
 
 	cfg := map[string]any{
 		"apiVersion": config.ConfigAPIVersion,
-		"server": map[string]any{
+		"apps": map[string]any{
+			pluginKey: pluginEntry,
+		},
+	}
+	if port > 0 {
+		cfg["server"] = map[string]any{
 			"baseUrl": providerLocalBaseURL(port),
 			"public": map[string]any{
 				"host": providerLocalHost,
 				"port": port,
 			},
-		},
-		"apps": map[string]any{
-			pluginKey: pluginEntry,
-		},
+		}
 	}
 	if uiName != "" && uiManifestPath != "" {
 		cfg["providers"] = map[string]any{
@@ -523,18 +519,20 @@ func writeProviderLocalUIOverlayConfig(path, uiKey, manifestPath string, port in
 
 	cfg := map[string]any{
 		"apiVersion": config.ConfigAPIVersion,
-		"server": map[string]any{
-			"baseUrl": providerLocalBaseURL(port),
-			"public": map[string]any{
-				"host": providerLocalHost,
-				"port": port,
-			},
-		},
 		"providers": map[string]any{
 			"ui": map[string]any{
 				uiKey: uiEntry,
 			},
 		},
+	}
+	if port > 0 {
+		cfg["server"] = map[string]any{
+			"baseUrl": providerLocalBaseURL(port),
+			"public": map[string]any{
+				"host": providerLocalHost,
+				"port": port,
+			},
+		}
 	}
 	return writeYAMLFile(path, cfg)
 }
@@ -694,19 +692,31 @@ func logProviderLocalSummary(message string, session *providerLocalSession) {
 		publicUIPaths = nil
 	}
 	args := []any{
-		"kind", session.Kind,
-		"manifest", session.ManifestPath,
+		"config_files", session.ConfigPaths,
 		"public_url", session.PublicURL,
 		"admin_url", session.AdminURL,
 		"mounted_ui_paths", publicUIPaths,
-		"auto_mounted_ui_path", session.AutoMountedUIPath,
-		"config_files", session.ConfigPaths,
 	}
-	switch session.Kind {
-	case providermanifestv1.KindUI:
-		args = append(args, "ui", session.TargetKey)
-	default:
-		args = append(args, "app", session.TargetKey)
+	if session.Locked || len(session.DevUIKeys) > 0 || len(session.TargetKeys) > 0 {
+		args = append(args,
+			"dev_ui_keys", session.DevUIKeys,
+			"target_keys", session.TargetKeys,
+			"artifacts_dir", session.State.ArtifactsDir,
+			"lockfile", session.State.LockfilePath,
+		)
+	}
+	if session.ManifestPath != "" {
+		args = append(args,
+			"kind", session.Kind,
+			"manifest", session.ManifestPath,
+			"auto_mounted_ui_path", session.AutoMountedUIPath,
+		)
+		switch session.Kind {
+		case providermanifestv1.KindUI:
+			args = append(args, "ui", session.TargetKey)
+		default:
+			args = append(args, "app", session.TargetKey)
+		}
 	}
 	slog.Info(message, args...)
 }

--- a/gestaltd/internal/daemon/provider_local_serve_test.go
+++ b/gestaltd/internal/daemon/provider_local_serve_test.go
@@ -1,0 +1,105 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMaybeRunServeProviderLocalRejectsLockedWithoutConfig(t *testing.T) {
+	t.Parallel()
+
+	_, err := maybeRunServeProviderLocal(serveProviderLocalOptions{
+		Paths:         []string{"./ui"},
+		Locked:        true,
+		LockedAllowed: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "--locked requires --config") {
+		t.Fatalf("error = %v, want --locked requires --config", err)
+	}
+}
+
+func TestMaybeRunServeProviderLocalRejectsNameWithMultiplePaths(t *testing.T) {
+	t.Parallel()
+
+	_, err := maybeRunServeProviderLocal(serveProviderLocalOptions{
+		Paths:       []string{"./ui/a", "./ui/b"},
+		ConfigPaths: []string{filepath.Join(t.TempDir(), "config.yaml")},
+		Name:        "demo",
+	})
+	if err == nil || !strings.Contains(err.Error(), "multiple --path") {
+		t.Fatalf("error = %v, want multiple --path name error", err)
+	}
+}
+
+func TestMaybeRunServeProviderLocalRejectsStatePathsWithoutConfig(t *testing.T) {
+	t.Parallel()
+
+	_, err := maybeRunServeProviderLocal(serveProviderLocalOptions{
+		Paths:        []string{"./ui"},
+		ArtifactsDir: t.TempDir(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "--artifacts-dir and --lockfile require --config") {
+		t.Fatalf("error = %v, want --artifacts-dir/--lockfile require --config", err)
+	}
+}
+
+func TestPrepareProviderLocalOverlaySessionCollectsDevUIKeys(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	uiDir := filepath.Join(dir, "ui", "demo")
+	if err := os.MkdirAll(uiDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	manifest := `kind: ui
+source: github.com/acme/apps/demo-ui
+version: "1.0.0"
+dev:
+  command: [sh, -c, echo]
+build:
+  command: [sh, -c, "mkdir -p out && echo ok > out/index.html"]
+spec:
+  assetRoot: out
+  routes:
+    - path: /
+      allowedRoles: [viewer]
+`
+	if err := os.WriteFile(filepath.Join(uiDir, "manifest.yaml"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("WriteFile manifest: %v", err)
+	}
+
+	baseCfg := filepath.Join(dir, "base.yaml")
+	baseYAML := `apiVersion: gestaltd.config/v6
+providers:
+  ui:
+    demo:
+      path: /demo
+      source: https://example.invalid/ui/demo
+`
+	if err := os.WriteFile(baseCfg, []byte(baseYAML), 0o644); err != nil {
+		t.Fatalf("WriteFile base config: %v", err)
+	}
+
+	session, err := prepareProviderLocalSession(providerLocalCommandOptions{
+		Paths:        []string{uiDir, uiDir},
+		ConfigPaths:  []string{baseCfg},
+		Locked:       true,
+		FleetOverlay: true,
+	})
+	if err != nil {
+		t.Fatalf("prepareProviderLocalSession: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(session.Dir) }()
+
+	if len(session.DevUIKeys) != 2 {
+		t.Fatalf("DevUIKeys = %#v, want two entries", session.DevUIKeys)
+	}
+	if session.DevUIKeys[0] != "demo_ui" || session.DevUIKeys[1] != "demo_ui" {
+		t.Fatalf("DevUIKeys = %#v, want demo_ui twice", session.DevUIKeys)
+	}
+	if len(session.ConfigPaths) != 3 {
+		t.Fatalf("ConfigPaths len = %d, want base + 2 overlays", len(session.ConfigPaths))
+	}
+}

--- a/gestaltd/internal/daemon/provider_local_session_test.go
+++ b/gestaltd/internal/daemon/provider_local_session_test.go
@@ -16,7 +16,7 @@ func TestPrepareProviderLocalSessionSupportsDirectUITarget(t *testing.T) {
 	mountedUI := setupMountedUIDir(t, dir)
 	setUIManifestSource(t, mountedUI.ManifestPath, "github.com/test/ui/roadmap.review")
 
-	session, err := prepareProviderLocalSession(providerLocalCommandOptions{Path: mountedUI.ManifestPath})
+	session, err := prepareProviderLocalSession(providerLocalCommandOptions{Paths: []string{mountedUI.ManifestPath}})
 	if err != nil {
 		t.Fatalf("prepareProviderLocalSession: %v", err)
 	}
@@ -66,7 +66,7 @@ func TestPrepareProviderLocalSessionAutoMountsSiblingUI(t *testing.T) {
 	siblingUI := setupMountedUIDirAt(t, filepath.Join(rootDir, "ui"), nil)
 	appManifest := componentProviderManifestPath(t, appDir)
 
-	session, err := prepareProviderLocalSession(providerLocalCommandOptions{Path: appManifest})
+	session, err := prepareProviderLocalSession(providerLocalCommandOptions{Paths: []string{appManifest}})
 	if err != nil {
 		t.Fatalf("prepareProviderLocalSession: %v", err)
 	}
@@ -122,7 +122,7 @@ func TestPrepareProviderLocalSessionLeavesAppWithoutUIUnmounted(t *testing.T) {
 	setAppManifestSource(t, appDir, "github.com/test/apps/api-only")
 	appManifest := componentProviderManifestPath(t, appDir)
 
-	session, err := prepareProviderLocalSession(providerLocalCommandOptions{Path: appManifest})
+	session, err := prepareProviderLocalSession(providerLocalCommandOptions{Paths: []string{appManifest}})
 	if err != nil {
 		t.Fatalf("prepareProviderLocalSession: %v", err)
 	}

--- a/gestaltd/internal/daemon/provider_package_edge_test.go
+++ b/gestaltd/internal/daemon/provider_package_edge_test.go
@@ -236,35 +236,6 @@ func TestRun_ProviderPackageAndReleaseBuildsSourceUIAssetsBeforePackaging(t *tes
 	}
 }
 
-func TestSourceUIHandlerBuildsSourceUIOutput(t *testing.T) {
-	t.Parallel()
-
-	if runtime.GOOS == "windows" {
-		t.Skip("source build fixture uses POSIX shell")
-	}
-
-	uiDir := newSourceBuiltUIReleaseFixture(t, t.TempDir())
-	manifestPath := filepath.Join(uiDir, providerpkg.ManifestFile)
-
-	handler, err := sourceUIHandler(manifestPath)
-	if err != nil {
-		t.Fatalf("sourceUIHandler: %v", err)
-	}
-	if _, err := os.Stat(filepath.Join(uiDir, "ui", "out", "index.html")); err != nil {
-		t.Fatalf("expected built index.html: %v", err)
-	}
-
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("GET / status = %d, want 200; body=%q", rec.Code, rec.Body.String())
-	}
-	if !strings.Contains(rec.Body.String(), "<html>") {
-		t.Fatalf("GET / body = %q, want built html", rec.Body.String())
-	}
-}
-
 func TestRun_ProviderPackageAndReleaseAllowsOverlappingSupportPaths(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/daemon/run.go
+++ b/gestaltd/internal/daemon/run.go
@@ -94,13 +94,13 @@ func runServeCommand(name string, usage func(io.Writer), args []string, opts ser
 	fs.Var(&configPaths, "config", "path to config file (repeat to layer overrides)")
 	artifactsDir := fs.String("artifacts-dir", "", "path to writable prepared-artifacts directory")
 	lockfilePath := fs.String("lockfile", "", "path to lockfile; defaults to gestalt.lock.json next to the primary config")
-	var pathFlag *string
+	var pathFlags repeatedStringFlag
 	var nameFlag *string
 	var portFlag *int
 	if opts.allowProviderLocal {
-		pathFlag = fs.String("path", "", "provider manifest path or directory for local source serve")
+		fs.Var(&pathFlags, "path", "provider manifest path or directory for local source serve (repeatable)")
 		nameFlag = fs.String("name", "", "provider key override for --path")
-		portFlag = fs.Int("port", 0, "public port for --path (defaults to a free localhost port)")
+		portFlag = fs.Int("port", 0, "public port for --path isolated serve (defaults to a free localhost port)")
 	}
 	var lockedFlag *bool
 	if opts.allowLocked {
@@ -132,7 +132,7 @@ func runServeCommand(name string, usage func(io.Writer), args []string, opts ser
 	if opts.allowProviderLocal {
 		ranProviderLocal, err := maybeRunServeProviderLocal(serveProviderLocalOptions{
 			ConfigPaths:   []string(configPaths),
-			Path:          flagStringValue(pathFlag),
+			Paths:         []string(pathFlags),
 			Name:          flagStringValue(nameFlag),
 			Port:          flagIntValue(portFlag),
 			ArtifactsDir:  *artifactsDir,
@@ -156,7 +156,7 @@ func runServeCommand(name string, usage func(io.Writer), args []string, opts ser
 
 type serveProviderLocalOptions struct {
 	ConfigPaths   []string
-	Path          string
+	Paths         []string
 	Name          string
 	Port          int
 	ArtifactsDir  string
@@ -166,34 +166,41 @@ type serveProviderLocalOptions struct {
 }
 
 func maybeRunServeProviderLocal(opts serveProviderLocalOptions) (bool, error) {
-	path := strings.TrimSpace(opts.Path)
+	paths := make([]string, 0, len(opts.Paths))
+	for _, path := range opts.Paths {
+		if trimmed := strings.TrimSpace(path); trimmed != "" {
+			paths = append(paths, trimmed)
+		}
+	}
 	name := strings.TrimSpace(opts.Name)
 
-	if path != "" {
-		if opts.ArtifactsDir != "" {
-			return true, fmt.Errorf("--artifacts-dir cannot be combined with --path")
+	if len(paths) == 0 {
+		if name != "" {
+			return false, fmt.Errorf("--name requires --path")
 		}
-		if opts.LockfilePath != "" {
-			return true, fmt.Errorf("--lockfile cannot be combined with --path")
+		if opts.Port != 0 {
+			return false, fmt.Errorf("--port requires --path")
 		}
-		if opts.LockedAllowed && opts.Locked {
-			return true, fmt.Errorf("--locked cannot be combined with --path")
-		}
-		return true, runServeProviderLocal(providerLocalCommandOptions{
-			Path:        opts.Path,
-			ConfigPaths: opts.ConfigPaths,
-			Name:        opts.Name,
-			Port:        opts.Port,
-		})
+		return false, nil
 	}
-
-	if name != "" {
-		return false, fmt.Errorf("--name requires --path")
+	if len(paths) > 1 && name != "" {
+		return true, fmt.Errorf("--name cannot be used with multiple --path flags")
 	}
-	if opts.Port != 0 {
-		return false, fmt.Errorf("--port requires --path")
+	if opts.LockedAllowed && opts.Locked && len(opts.ConfigPaths) == 0 {
+		return true, fmt.Errorf("--locked requires --config when using --path")
 	}
-	return false, nil
+	if len(opts.ConfigPaths) == 0 && (opts.ArtifactsDir != "" || opts.LockfilePath != "") {
+		return true, fmt.Errorf("--artifacts-dir and --lockfile require --config when using --path")
+	}
+	return true, runServeProviderLocal(providerLocalCommandOptions{
+		Paths:        paths,
+		ConfigPaths:  opts.ConfigPaths,
+		Name:         name,
+		Port:         opts.Port,
+		Locked:       opts.Locked,
+		ArtifactsDir: opts.ArtifactsDir,
+		LockfilePath: opts.LockfilePath,
+	})
 }
 
 func flagStringValue(flag *string) string {
@@ -433,7 +440,7 @@ func printMainUsage(w io.Writer) {
 	writeUsageLine(w, "  gestaltd lock [--config PATH]... [--lockfile PATH] [--check]")
 	writeUsageLine(w, "  gestaltd sync --locked [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--parallelism N] [--cache-dir PATH] [--output-format text|json] [-v|--verbose] [--check]")
 	writeUsageLine(w, "  gestaltd serve [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--locked]")
-	writeUsageLine(w, "  gestaltd serve --path PATH [--config PATH]... [--name NAME] [--port PORT]")
+	writeUsageLine(w, "  gestaltd serve --path PATH [--path PATH]... [--config PATH]... [--locked] [--artifacts-dir PATH] [--lockfile PATH] [--name NAME] [--port PORT]")
 	writeUsageLine(w, "  gestaltd agent <command> [flags]")
 	writeUsageLine(w, "  gestaltd provider <command> [flags]")
 	writeUsageLine(w, "  gestaltd validate [--config PATH]... [--lockfile PATH] [--platform os/arch] [--runtime]")
@@ -456,10 +463,12 @@ func printMainUsage(w io.Writer) {
 func printServeUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
 	writeUsageLine(w, "  gestaltd serve [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--locked]")
-	writeUsageLine(w, "  gestaltd serve --path PATH [--config PATH]... [--name NAME] [--port PORT]")
+	writeUsageLine(w, "  gestaltd serve --path PATH [--path PATH]... [--config PATH]... [--locked] [--artifacts-dir PATH] [--lockfile PATH] [--name NAME] [--port PORT]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Start the server. Without --locked, auto lock/syncs if state is missing or stale.")
-	writeUsageLine(w, "Use --path to serve one local source app or UI bundle inside a synthesized Gestalt config.")
+	writeUsageLine(w, "Use --path (repeatable) to override selected UIs to local source trees; with --config and --locked,")
+	writeUsageLine(w, "the fleet loads pinned artifacts while --path UIs with a manifest dev: block hot-reload.")
+	writeUsageLine(w, "Without --config, --path runs an isolated synthesized baseline (unlocked).")
 	writeUsageLine(w, "Local UIs with a manifest dev: block are proxied to a hot-reload dev server automatically.")
 	writeUsageLine(w, "For production, strongly prefer --locked so startup uses the pinned")
 	writeUsageLine(w, "lockfile and prepared artifacts instead of resolving or mutating state.")

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -103,6 +103,9 @@ type Lifecycle struct {
 	// unlocked `gestaltd serve`; false for lock/sync/validate and serve --locked,
 	// so committed lockfiles build and pin dev UIs normally.
 	devServeEligible bool
+	// forcedDevUIKeys marks specific UI keys dev-active even when devServeEligible
+	// is false (serve --locked --config … --path … overlay mode).
+	forcedDevUIKeys map[string]bool
 }
 
 type StatePaths struct {
@@ -185,6 +188,30 @@ func (l *Lifecycle) WithProviderResolver(resolver *providerregistry.Resolver) *L
 func (l *Lifecycle) WithDevServeEligible(v bool) *Lifecycle {
 	l.devServeEligible = v
 	return l
+}
+
+func (l *Lifecycle) WithForcedDevUIKeys(keys []string) *Lifecycle {
+	if len(keys) == 0 {
+		l.forcedDevUIKeys = nil
+		return l
+	}
+	l.forcedDevUIKeys = make(map[string]bool, len(keys))
+	for _, key := range keys {
+		if key = strings.TrimSpace(key); key != "" {
+			l.forcedDevUIKeys[key] = true
+		}
+	}
+	return l
+}
+
+func (l *Lifecycle) shouldMarkUIForDev(name string) bool {
+	if l == nil {
+		return false
+	}
+	if l.forcedDevUIKeys[name] {
+		return true
+	}
+	return l.devServeEligible
 }
 
 func (l *Lifecycle) metadataHTTPClient() *http.Client {
@@ -921,32 +948,47 @@ func (l *Lifecycle) loadConfigForLifecycle(configPaths []string, _ StatePaths, a
 	if err != nil {
 		return nil, err
 	}
-	if l != nil && l.devServeEligible {
-		if err := markDevActiveUIProviders(cfg); err != nil {
+	if l != nil && (l.devServeEligible || len(l.forcedDevUIKeys) > 0) {
+		if err := l.markDevActiveUIProviders(cfg); err != nil {
 			return nil, err
 		}
 	}
 	return cfg, nil
 }
 
-func markDevActiveUIProviders(cfg *config.Config) error {
+func (l *Lifecycle) markDevActiveUIProviders(cfg *config.Config) error {
 	if cfg == nil {
 		return nil
 	}
 	for _, name := range slices.Sorted(maps.Keys(cfg.Providers.UI)) {
 		entry := cfg.Providers.UI[name]
-		if entry == nil || !entry.HasLocalSource() {
+		if entry == nil || !l.shouldMarkUIForDev(name) {
+			continue
+		}
+		if !entry.HasLocalSource() {
+			if l.forcedDevUIKeys[name] {
+				return fmt.Errorf("--path target %q is not configured with a local source.path override", name)
+			}
 			continue
 		}
 		normalized, err := normalizeLocalSource(entry.SourcePath())
 		if err != nil {
+			if l.forcedDevUIKeys[name] {
+				return fmt.Errorf("--path target %q: resolve local source: %w", name, err)
+			}
 			continue
 		}
 		_, manifest, err := providerpkg.ReadSourceManifestFile(normalized.manifestPath)
 		if err != nil {
+			if l.forcedDevUIKeys[name] {
+				return fmt.Errorf("--path target %q: read source manifest: %w", name, err)
+			}
 			continue
 		}
 		if providerpkg.EffectiveDev(manifest) == nil {
+			if l.forcedDevUIKeys[name] {
+				return fmt.Errorf("--path target %q has no dev: block; cannot dev-serve under --locked", name)
+			}
 			continue
 		}
 		configMap, err := config.NodeToMap(entry.Config)
@@ -980,7 +1022,7 @@ func (l *Lifecycle) LoadForExecutionAtPathsWithStatePaths(configPaths []string, 
 		return nil, nil, fmt.Errorf("loading config: %v", err)
 	}
 	paths := resolveLifecyclePaths(configPaths, cfg, state)
-	if l.devServeEligible {
+	if l.devServeEligible || len(l.forcedDevUIKeys) > 0 {
 		for _, name := range slices.Sorted(maps.Keys(cfg.Providers.UI)) {
 			entry := cfg.Providers.UI[name]
 			if entry != nil && entry.DevActive {

--- a/gestaltd/internal/operator/lifecycle_dev_test.go
+++ b/gestaltd/internal/operator/lifecycle_dev_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
@@ -297,5 +298,121 @@ server:
 	wantStylesheet := filepath.Join(dir, "theme", "tenant.css")
 	if entry.ResolvedThemeStylesheet != wantStylesheet {
 		t.Fatalf("ResolvedThemeStylesheet = %q, want %q", entry.ResolvedThemeStylesheet, wantStylesheet)
+	}
+}
+
+func TestForcedDevUIKeysActivatesUnderLocked(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	uiDir := filepath.Join(dir, "ui")
+	if err := os.MkdirAll(uiDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	manifest := `kind: ui
+source: github.com/acme/apps/demo-ui
+version: "1.0.0"
+dev:
+  command: [sh, -c, echo]
+build:
+  command: [sh, -c, "mkdir -p out && echo ok > out/index.html"]
+spec:
+  assetRoot: out
+  routes:
+    - path: /
+      allowedRoles: [viewer]
+`
+	if err := os.WriteFile(filepath.Join(uiDir, "manifest.yaml"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("WriteFile manifest: %v", err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfgYAML := `apiVersion: gestaltd.config/v6
+providers:
+  ui:
+    demo:
+      path: /demo
+      source:
+        path: ./ui
+`
+	if err := os.WriteFile(cfgPath, []byte(cfgYAML), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	cfg, err := NewLifecycle().WithForcedDevUIKeys([]string{"demo"}).loadConfigForLifecycle([]string{cfgPath}, StatePaths{}, false)
+	if err != nil {
+		t.Fatalf("loadConfigForLifecycle: %v", err)
+	}
+	entry := cfg.Providers.UI["demo"]
+	if entry == nil {
+		t.Fatal("expected ui.demo entry")
+	}
+	if !entry.DevActive {
+		t.Fatal("forced dev key should mark UI dev-active even when devServeEligible is false")
+	}
+}
+
+func TestForcedDevUIKeyWithoutDevBlockErrors(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	uiDir := filepath.Join(dir, "ui")
+	if err := os.MkdirAll(uiDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	manifest := `kind: ui
+source: github.com/acme/apps/demo-ui
+version: "1.0.0"
+build:
+  command: [sh, -c, "mkdir -p out && echo ok > out/index.html"]
+spec:
+  assetRoot: out
+  routes:
+    - path: /
+      allowedRoles: [viewer]
+`
+	if err := os.WriteFile(filepath.Join(uiDir, "manifest.yaml"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("WriteFile manifest: %v", err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfgYAML := `apiVersion: gestaltd.config/v6
+providers:
+  ui:
+    demo:
+      path: /demo
+      source:
+        path: ./ui
+`
+	if err := os.WriteFile(cfgPath, []byte(cfgYAML), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	_, err := NewLifecycle().WithForcedDevUIKeys([]string{"demo"}).loadConfigForLifecycle([]string{cfgPath}, StatePaths{}, false)
+	if err == nil || !strings.Contains(err.Error(), `no dev: block`) {
+		t.Fatalf("loadConfigForLifecycle error = %v, want no dev: block error", err)
+	}
+}
+
+func TestForcedDevUIKeyWithUnreadableSourceErrors(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfgYAML := `apiVersion: gestaltd.config/v6
+providers:
+  ui:
+    demo:
+      path: /demo
+      source:
+        path: ./missing-ui
+`
+	if err := os.WriteFile(cfgPath, []byte(cfgYAML), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	_, err := NewLifecycle().WithForcedDevUIKeys([]string{"demo"}).loadConfigForLifecycle([]string{cfgPath}, StatePaths{}, false)
+	if err == nil || !strings.Contains(err.Error(), `--path target "demo"`) {
+		t.Fatalf("loadConfigForLifecycle error = %v, want forced --path target error", err)
 	}
 }


### PR DESCRIPTION
## Summary

- Make `gestaltd serve --path` repeatable and composable with `--config`, `--locked`, `--artifacts-dir`, and `--lockfile`.
- Add overlay mode (`--path` + `--config`): user config is authoritative; each `--path` target gets a local `source.path` overlay; under `--locked`, selected UIs are force dev-activated so the fleet loads pinned artifacts while `--path` UIs with a manifest `dev:` block hot-reload.
- Preserve isolated mode (`--path` without `--config`): synthesized baseline, unlocked, now supports multiple targets.
- Follow-up to #2472 (delegated dev servers); does not change the dev supervisor or manifest schema.

## Test plan

- [x] `go test ./internal/daemon/... ./internal/operator/...`
- [x] `golangci-lint run ./internal/daemon/... ./internal/operator/...`
- [ ] Manual: `gestaltd serve --locked --config <full> --config <local> --path <ui-with-dev>` boots; target UI dev-proxies; rest from lockfile
- [ ] Manual: multiple `--path` flags hot-reload both UIs
- [ ] Manual: bare `gestaltd serve --path <ui>` (no `--config`) unchanged


Made with [Cursor](https://cursor.com)