### PR TITLE
[codex] Fix Notion MCP operation routing

### DIFF
--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -767,7 +767,7 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 		s.writeInvocationError(w, r, providerName, operationName, invocation.ErrOperationNotFound)
 		return
 	}
-	sessionConnections := s.catalogSelectorConfig().SessionCatalogConnections(providerName, connection)
+	sessionConnections := s.sessionCatalogSelectorConfig().SessionCatalogConnections(providerName, connection)
 	opMeta, transport, resolvedConnection, err := invocation.ResolveOperation(ctx, prov, providerName, resolver, p, operationName, sessionConnections, instance)
 	if err != nil {
 		s.writeInvocationError(w, r, providerName, operationName, err)

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -92,10 +92,10 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 		Invoker:              httpInvoker,
 		AppInvocation:        result.AppInvocation,
 		DefaultConnection:    connMaps.DefaultConnection,
-		// HTTP routes expose REST-visible operations, so unqualified session-catalog
-		// resolution should follow the API surface by default. The MCP server keeps
-		// its own MCP-specific routing below.
+		// Public HTTP catalog listing should follow the API surface by default.
+		// Dynamic/session operation execution uses MCPConnection below.
 		CatalogConnection:    httpCatalogConnectionMap(connMaps),
+		MCPConnection:        connMaps.MCPConnection,
 		ConnectionAuth:       result.ConnectionAuth,
 		ManualConnectionAuth: result.ManualConnectionAuth,
 		AppDefs:              cfg.Apps,

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -112,6 +112,7 @@ type Server struct {
 	agentStreamHeartbeat   time.Duration
 	defaultConnection      map[string]string
 	catalogConnection      map[string]string
+	mcpConnection          map[string]string
 	connectionAuth         func() map[string]map[string]bootstrap.OAuthHandler
 	manualConnectionAuth   func() map[string]map[string]bootstrap.ManualTokenExchanger
 	pluginDefs             map[string]*config.ProviderEntry
@@ -152,6 +153,18 @@ func (s *Server) catalogSelectorConfig() invocation.CatalogSelectorConfig {
 	}
 }
 
+func (s *Server) sessionCatalogSelectorConfig() invocation.CatalogSelectorConfig {
+	catalogConnection := s.mcpConnection
+	if len(catalogConnection) == 0 {
+		catalogConnection = s.catalogConnection
+	}
+	return invocation.CatalogSelectorConfig{
+		Invoker:           s.invoker,
+		CatalogConnection: catalogConnection,
+		DefaultConnection: s.defaultConnection,
+	}
+}
+
 type Config struct {
 	Auth                 core.AuthenticationProvider
 	SelectedAuthProvider string
@@ -169,6 +182,7 @@ type Config struct {
 	AppInvocation        invocation.Invoker
 	DefaultConnection    map[string]string
 	CatalogConnection    map[string]string
+	MCPConnection        map[string]string
 	ConnectionAuth       func() map[string]map[string]bootstrap.OAuthHandler
 	ManualConnectionAuth func() map[string]map[string]bootstrap.ManualTokenExchanger
 	AppDefs              map[string]*config.ProviderEntry
@@ -369,6 +383,7 @@ func New(cfg Config) (*Server, error) {
 		agentStreamHeartbeat:   agentStreamHeartbeat,
 		defaultConnection:      cfg.DefaultConnection,
 		catalogConnection:      cfg.CatalogConnection,
+		mcpConnection:          cfg.MCPConnection,
 		connectionAuth:         cfg.ConnectionAuth,
 		manualConnectionAuth:   cfg.ManualConnectionAuth,
 		pluginDefs:             cfg.AppDefs,

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -119,7 +119,11 @@ func newTestHandler(t *testing.T, opts ...func(*server.Config)) http.Handler {
 	if cfg.DefaultConnection != nil {
 		brokerOpts = append(brokerOpts, invocation.WithConnectionMapper(invocation.ConnectionMap(cfg.DefaultConnection)))
 	}
-	if cfg.CatalogConnection != nil {
+	if cfg.MCPConnection != nil {
+		brokerOpts = append(brokerOpts,
+			invocation.WithMCPConnectionMapper(invocation.ConnectionMap(cfg.MCPConnection)),
+		)
+	} else if cfg.CatalogConnection != nil {
 		brokerOpts = append(brokerOpts,
 			invocation.WithMCPConnectionMapper(invocation.ConnectionMap(cfg.CatalogConnection)),
 		)
@@ -7970,6 +7974,95 @@ func TestExecuteOperation_PinsSessionCatalogConnectionIntoExecution(t *testing.T
 	}
 	if gotToken != "mcp-token" {
 		t.Fatalf("execute token = %q, want %q", gotToken, "mcp-token")
+	}
+}
+
+func TestExecuteOperation_UsesMCPConnectionWhenHTTPCatalogUsesAPIConnection(t *testing.T) {
+	t.Parallel()
+
+	var gotUpstreamToken string
+	sessionStub := &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{
+				N:        "sample-int",
+				ConnMode: core.ConnectionModeSubject,
+			},
+		},
+		catalogForRequestFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
+			switch token {
+			case "mcp-token":
+				return &catalog.Catalog{
+					Name: "sample-int",
+					Operations: []catalog.CatalogOperation{{
+						ID:          "get_page_content",
+						Description: "Read page content",
+						Transport:   catalog.TransportMCPPassthrough,
+					}},
+				}, nil
+			case "rest-token":
+				return &catalog.Catalog{Name: "sample-int"}, nil
+			default:
+				return nil, fmt.Errorf("unexpected token %q", token)
+			}
+		},
+		callFn: func(ctx context.Context, name string, args map[string]any) (*mcpgo.CallToolResult, error) {
+			gotUpstreamToken = mcpupstream.UpstreamTokenFromContext(ctx)
+			if name != "get_page_content" {
+				t.Fatalf("tool name = %q, want get_page_content", name)
+			}
+			if args["page_id"] != "page-123" {
+				t.Fatalf("page_id arg = %#v, want page-123", args["page_id"])
+			}
+			return &mcpgo.CallToolResult{
+				Content:           []mcpgo.Content{mcpgo.NewTextContent("ok")},
+				StructuredContent: map[string]any{"ok": true},
+			}, nil
+		},
+	}
+
+	providers := testutil.NewProviderRegistry(t, sessionStub)
+	svc := testutil.NewStubServices(t)
+	u := seedUser(t, svc, "anonymous@gestalt")
+	seedToken(t, svc, &core.ExternalCredential{
+		ID:        "tok-mcp",
+		Subject:   principal.UserSubjectID(u.ID),
+		Audience:  "sample-int:mcp-conn",
+		Qualifier: "default",
+		Grant:     &core.ExternalCredentialGrant{AccessToken: "mcp-token"},
+	})
+	seedToken(t, svc, &core.ExternalCredential{
+		ID:        "tok-rest",
+		Subject:   principal.UserSubjectID(u.ID),
+		Audience:  "sample-int:rest-conn",
+		Qualifier: "default",
+		Grant:     &core.ExternalCredentialGrant{AccessToken: "rest-token"},
+	})
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = providers
+		cfg.Services = svc
+		cfg.DefaultConnection = map[string]string{"sample-int": "rest-conn"}
+		cfg.CatalogConnection = map[string]string{"sample-int": "rest-conn"}
+		cfg.MCPConnection = map[string]string{"sample-int": "mcp-conn"}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Post(
+		ts.URL+"/api/v1/sample-int/get_page_content",
+		"application/json",
+		strings.NewReader(`{"page_id":"page-123"}`),
+	)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	if gotUpstreamToken != "mcp-token" {
+		t.Fatalf("upstream token = %q, want %q", gotUpstreamToken, "mcp-token")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Route HTTP execution of dynamic/session catalog operations through the MCP connection map instead of the API catalog connection.
- Keep public HTTP operation listing on the API/REST catalog connection.
- Add regression coverage for mixed REST OAuth plus MCP OAuth providers like Notion.

## Test plan

- [x] go test ./internal/server ./services/invocation
