### PR TITLE
Fix surface-aware MCP catalog routing for composite providers

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1188,6 +1188,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		Audit:             audit,
 		DefaultConnection: connMaps.DefaultConnection,
 		CatalogConnection: connMaps.APIConnection,
+		MCPConnection:     connMaps.MCPConnection,
 	}))
 	agentManager.SetTarget(agentmanager.New(agentmanager.Config{
 		Providers:         providers,
@@ -1198,6 +1199,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		Invoker:           sharedInvoker,
 		DefaultConnection: connMaps.DefaultConnection,
 		CatalogConnection: connMaps.APIConnection,
+		MCPConnection:     connMaps.MCPConnection,
 		AgentConnections:  agentConnectionBindings(cfg),
 		SessionStart:      agentSessionStartConfigs(cfg),
 	}))

--- a/gestaltd/internal/bootstrap/validate.go
+++ b/gestaltd/internal/bootstrap/validate.go
@@ -81,6 +81,7 @@ func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistr
 		Invoker:           sharedInvoker,
 		DefaultConnection: connMaps.DefaultConnection,
 		CatalogConnection: connMaps.APIConnection,
+		MCPConnection:     connMaps.MCPConnection,
 	}))
 	prepared.AgentManager.SetTarget(agentmanager.New(agentmanager.Config{
 		Providers:         providers,
@@ -91,6 +92,7 @@ func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistr
 		Invoker:           sharedInvoker,
 		DefaultConnection: connMaps.DefaultConnection,
 		CatalogConnection: connMaps.APIConnection,
+		MCPConnection:     connMaps.MCPConnection,
 		AgentConnections:  agentConnectionBindings(cfg),
 		SessionStart:      agentSessionStartConfigs(cfg),
 	}))

--- a/gestaltd/internal/server/catalog_resolution_test.go
+++ b/gestaltd/internal/server/catalog_resolution_test.go
@@ -561,6 +561,88 @@ func TestResolveCatalogStrict_SessionCatalogUnavailableReturnsTypedError(t *test
 	}
 }
 
+func TestResolveCatalogStrict_ClassifiesSessionAuthFailureAsReconnectRequired(t *testing.T) {
+	t.Parallel()
+
+	prov := &stubSessionProvider{
+		stubCatalogProvider: stubCatalogProvider{
+			stubProvider: stubProvider{
+				name:     "strict-api",
+				connMode: core.ConnectionModeSubject,
+			},
+			cat: &catalog.Catalog{
+				Name: "strict-api",
+				Operations: []catalog.CatalogOperation{
+					{ID: "static_op", Method: http.MethodGet},
+				},
+			},
+		},
+		sessionErr: fmt.Errorf("mcpupstream notion: initialize: transport error: unauthorized (401)"),
+	}
+
+	resolver := &stubTokenResolver{token: "tok_789"}
+	p := &principal.Principal{UserID: "u1"}
+
+	cat, metadata, err := invocation.ResolveCatalogStrictWithMetadata(context.Background(), prov, "strict-api", resolver, p, "default", "")
+	if err == nil {
+		t.Fatalf("expected strict resolution error, got catalog %+v", cat)
+	}
+	if !errors.Is(err, invocation.ErrReconnectRequired) {
+		t.Fatalf("expected ErrReconnectRequired, got %v", err)
+	}
+	if !metadata.SessionAttempted {
+		t.Fatal("expected session resolution attempt to be reported")
+	}
+	if !metadata.SessionFailed {
+		t.Fatal("expected session resolution failure to be reported")
+	}
+}
+
+func TestResolveCatalogForTargetsWithMetadata_ClassifiesSessionAuthFailure(t *testing.T) {
+	t.Parallel()
+
+	prov := &stubSessionProvider{
+		stubCatalogProvider: stubCatalogProvider{
+			stubProvider: stubProvider{
+				name:     "strict-api",
+				connMode: core.ConnectionModeSubject,
+			},
+			cat: &catalog.Catalog{
+				Name: "strict-api",
+				Operations: []catalog.CatalogOperation{
+					{ID: "static_op", Method: http.MethodGet},
+				},
+			},
+		},
+		sessionErr: fmt.Errorf("mcpupstream notion: initialize: transport error: unauthorized (401)"),
+	}
+
+	resolver := &stubTokenResolver{token: "tok_789"}
+	p := &principal.Principal{UserID: "u1"}
+
+	cat, metadata, err := invocation.ResolveCatalogForTargetsWithMetadata(
+		context.Background(),
+		prov,
+		"strict-api",
+		resolver,
+		p,
+		[]invocation.CatalogResolutionTarget{{Connection: "OAuth"}},
+		true,
+	)
+	if err == nil {
+		t.Fatalf("expected strict catalog resolution error, got catalog %+v", cat)
+	}
+	if !errors.Is(err, invocation.ErrReconnectRequired) {
+		t.Fatalf("expected ErrReconnectRequired, got %v", err)
+	}
+	if !metadata.SessionAttempted {
+		t.Fatal("expected session resolution attempt to be reported")
+	}
+	if !metadata.SessionFailed {
+		t.Fatal("expected session resolution failure to be reported")
+	}
+}
+
 func TestResolveCatalogForTargetsWithMetadata_PrefersLaterSuccessfulTarget(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/server/composite_resolution_test.go
+++ b/gestaltd/internal/server/composite_resolution_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -20,50 +21,62 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 )
 
-func TestExecuteOperation_CompositeStaticRESTBypassesMCPSessionResolution(t *testing.T) {
-	t.Parallel()
+type compositeNotionEnv struct {
+	ts *httptest.Server
+}
 
-	var (
-		gotToken        string
-		mcpCatalogCalls atomic.Int32
-	)
+type compositeNotionConfig struct {
+	apiOperations []catalog.CatalogOperation
+	apiExecuteFn  func(context.Context, string, map[string]any, string) (*core.OperationResult, error)
+	mcpCatalogFn  func(context.Context, string) (*catalog.Catalog, error)
+	seedOAuth     bool
+	seedMCP       bool
+	mcpToken      string
+}
+
+func setupCompositeNotion(t *testing.T, cfg compositeNotionConfig) compositeNotionEnv {
+	t.Helper()
 
 	apiProv := &stubIntegrationWithCatalog{
 		StubIntegration: coretesting.StubIntegration{
-			N:        "notion",
-			ConnMode: core.ConnectionModeSubject,
-			ExecuteFn: func(_ context.Context, op string, _ map[string]any, token string) (*core.OperationResult, error) {
-				gotToken = token
-				return &core.OperationResult{Status: http.StatusOK, Body: []byte(fmt.Sprintf(`{"operation":%q,"token":%q}`, op, token))}, nil
-			},
+			N:         "notion",
+			ConnMode:  core.ConnectionModeSubject,
+			ExecuteFn: cfg.apiExecuteFn,
 		},
-		catalog: serverTestCatalog("notion", []catalog.CatalogOperation{
-			{ID: "api_get_self", Description: "Retrieve self", Method: http.MethodGet, Transport: catalog.TransportREST},
-		}),
+		catalog: serverTestCatalog("notion", cfg.apiOperations),
 	}
 	mcpUpstream := &stubIntegrationWithSessionCatalog{
 		stubIntegrationWithOps: stubIntegrationWithOps{
-			StubIntegration: coretesting.StubIntegration{
-				N:        "notion",
-				ConnMode: core.ConnectionModeSubject,
-			},
+			StubIntegration: coretesting.StubIntegration{N: "notion", ConnMode: core.ConnectionModeSubject},
 		},
-		catalogForRequestFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
-			mcpCatalogCalls.Add(1)
-			return nil, fmt.Errorf("mcpupstream notion: initialize: transport error: unauthorized (401) for %q", token)
-		},
+		catalogForRequestFn: cfg.mcpCatalogFn,
 	}
 
 	providers := testutil.NewProviderRegistry(t, composite.New("notion", apiProv, mcpUpstream))
 	svc := testutil.NewStubServices(t)
 	u := seedUser(t, svc, "anonymous@gestalt")
-	seedToken(t, svc, &core.ExternalCredential{
-		ID:        "tok-oauth",
-		Subject:   principal.UserSubjectID(u.ID),
-		Audience:  "notion:OAuth",
-		Qualifier: "default",
-		Grant:     &core.ExternalCredentialGrant{AccessToken: "oauth-token"},
-	})
+	if cfg.seedOAuth {
+		seedToken(t, svc, &core.ExternalCredential{
+			ID:        "tok-oauth",
+			Subject:   principal.UserSubjectID(u.ID),
+			Audience:  "notion:OAuth",
+			Qualifier: "default",
+			Grant:     &core.ExternalCredentialGrant{AccessToken: "oauth-token"},
+		})
+	}
+	if cfg.seedMCP {
+		mcpToken := cfg.mcpToken
+		if mcpToken == "" {
+			mcpToken = "mcp-token"
+		}
+		seedToken(t, svc, &core.ExternalCredential{
+			ID:        "tok-mcp",
+			Subject:   principal.UserSubjectID(u.ID),
+			Audience:  "notion:MCP",
+			Qualifier: "default",
+			Grant:     &core.ExternalCredentialGrant{AccessToken: mcpToken},
+		})
+	}
 
 	broker := invocation.NewBroker(
 		providers,
@@ -73,30 +86,16 @@ func TestExecuteOperation_CompositeStaticRESTBypassesMCPSessionResolution(t *tes
 		invocation.WithMCPConnectionMapper(invocation.ConnectionMap(map[string]string{"notion": "MCP"})),
 	)
 
-	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.Providers = providers
-		cfg.Services = svc
-		cfg.Invoker = broker
+	ts := newTestServer(t, func(serverCfg *server.Config) {
+		serverCfg.Providers = providers
+		serverCfg.Services = svc
+		serverCfg.Invoker = broker
+		serverCfg.CatalogConnection = map[string]string{"notion": "OAuth"}
+		serverCfg.MCPConnection = map[string]string{"notion": "MCP"}
 	})
 	testutil.CloseOnCleanup(t, ts)
 
-	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/notion/api_get_self", nil)
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("request: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
-	}
-	if gotToken != "oauth-token" {
-		t.Fatalf("execute token = %q, want %q", gotToken, "oauth-token")
-	}
-	if got := mcpCatalogCalls.Load(); got != 0 {
-		t.Fatalf("catalog calls = %d, want 0", got)
-	}
+	return compositeNotionEnv{ts: ts}
 }
 
 func TestExecuteOperation_CompositeSearchUsesOAuthWithoutMCPCatalogDiscovery(t *testing.T) {
@@ -107,58 +106,22 @@ func TestExecuteOperation_CompositeSearchUsesOAuthWithoutMCPCatalogDiscovery(t *
 		mcpCatalogCalls atomic.Int32
 	)
 
-	apiProv := &stubIntegrationWithCatalog{
-		StubIntegration: coretesting.StubIntegration{
-			N:        "notion",
-			ConnMode: core.ConnectionModeSubject,
-			ExecuteFn: func(_ context.Context, op string, _ map[string]any, token string) (*core.OperationResult, error) {
-				gotToken = token
-				return &core.OperationResult{Status: http.StatusOK, Body: []byte(fmt.Sprintf(`{"operation":%q}`, op))}, nil
-			},
-		},
-		catalog: serverTestCatalog("notion", []catalog.CatalogOperation{
+	env := setupCompositeNotion(t, compositeNotionConfig{
+		apiOperations: []catalog.CatalogOperation{
 			{ID: "search", Description: "Search", Method: http.MethodPost, Transport: catalog.TransportREST},
-		}),
-	}
-	mcpUpstream := &stubIntegrationWithSessionCatalog{
-		stubIntegrationWithOps: stubIntegrationWithOps{
-			StubIntegration: coretesting.StubIntegration{N: "notion", ConnMode: core.ConnectionModeSubject},
 		},
-		catalogForRequestFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
+		apiExecuteFn: func(_ context.Context, op string, _ map[string]any, token string) (*core.OperationResult, error) {
+			gotToken = token
+			return &core.OperationResult{Status: http.StatusOK, Body: []byte(fmt.Sprintf(`{"operation":%q}`, op))}, nil
+		},
+		mcpCatalogFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
 			mcpCatalogCalls.Add(1)
 			return nil, fmt.Errorf("mcpupstream notion: initialize: transport error: unauthorized (401) for %q", token)
 		},
-	}
-
-	providers := testutil.NewProviderRegistry(t, composite.New("notion", apiProv, mcpUpstream))
-	svc := testutil.NewStubServices(t)
-	u := seedUser(t, svc, "anonymous@gestalt")
-	seedToken(t, svc, &core.ExternalCredential{
-		ID:        "tok-oauth",
-		Subject:   principal.UserSubjectID(u.ID),
-		Audience:  "notion:OAuth",
-		Qualifier: "default",
-		Grant:     &core.ExternalCredentialGrant{AccessToken: "oauth-token"},
+		seedOAuth: true,
 	})
 
-	broker := invocation.NewBroker(
-		providers,
-		svc.Users,
-		svc.ExternalCredentials,
-		invocation.WithConnectionMapper(invocation.ConnectionMap(map[string]string{"notion": "OAuth"})),
-		invocation.WithMCPConnectionMapper(invocation.ConnectionMap(map[string]string{"notion": "MCP"})),
-	)
-
-	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.Providers = providers
-		cfg.Services = svc
-		cfg.Invoker = broker
-		cfg.CatalogConnection = map[string]string{"notion": "OAuth"}
-		cfg.MCPConnection = map[string]string{"notion": "MCP"}
-	})
-	testutil.CloseOnCleanup(t, ts)
-
-	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/notion/search", strings.NewReader("{}"))
+	req, _ := http.NewRequest(http.MethodPost, env.ts.URL+"/api/v1/notion/search", strings.NewReader("{}"))
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("request: %v", err)
@@ -182,15 +145,10 @@ func TestExecuteOperation_CompositeMCPOperationUsesMCPToken(t *testing.T) {
 
 	var mcpCatalogCalls atomic.Int32
 
-	apiProv := &stubIntegrationWithCatalog{
-		StubIntegration: coretesting.StubIntegration{N: "notion", ConnMode: core.ConnectionModeSubject},
-		catalog:         serverTestCatalog("notion", nil),
-	}
-	mcpUpstream := &stubIntegrationWithSessionCatalog{
-		stubIntegrationWithOps: stubIntegrationWithOps{
-			StubIntegration: coretesting.StubIntegration{N: "notion", ConnMode: core.ConnectionModeSubject},
-		},
-		catalogForRequestFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
+	env := setupCompositeNotion(t, compositeNotionConfig{
+		seedOAuth: true,
+		seedMCP:   true,
+		mcpCatalogFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
 			mcpCatalogCalls.Add(1)
 			if token != "mcp-token" {
 				return nil, fmt.Errorf("unexpected token %q", token)
@@ -202,44 +160,9 @@ func TestExecuteOperation_CompositeMCPOperationUsesMCPToken(t *testing.T) {
 				},
 			}, nil
 		},
-	}
-
-	providers := testutil.NewProviderRegistry(t, composite.New("notion", apiProv, mcpUpstream))
-	svc := testutil.NewStubServices(t)
-	u := seedUser(t, svc, "anonymous@gestalt")
-	seedToken(t, svc, &core.ExternalCredential{
-		ID:        "tok-oauth",
-		Subject:   principal.UserSubjectID(u.ID),
-		Audience:  "notion:OAuth",
-		Qualifier: "default",
-		Grant:     &core.ExternalCredentialGrant{AccessToken: "oauth-token"},
-	})
-	seedToken(t, svc, &core.ExternalCredential{
-		ID:        "tok-mcp",
-		Subject:   principal.UserSubjectID(u.ID),
-		Audience:  "notion:MCP",
-		Qualifier: "default",
-		Grant:     &core.ExternalCredentialGrant{AccessToken: "mcp-token"},
 	})
 
-	broker := invocation.NewBroker(
-		providers,
-		svc.Users,
-		svc.ExternalCredentials,
-		invocation.WithConnectionMapper(invocation.ConnectionMap(map[string]string{"notion": "OAuth"})),
-		invocation.WithMCPConnectionMapper(invocation.ConnectionMap(map[string]string{"notion": "MCP"})),
-	)
-
-	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.Providers = providers
-		cfg.Services = svc
-		cfg.Invoker = broker
-		cfg.CatalogConnection = map[string]string{"notion": "OAuth"}
-		cfg.MCPConnection = map[string]string{"notion": "MCP"}
-	})
-	testutil.CloseOnCleanup(t, ts)
-
-	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/notion/get_page_content", strings.NewReader("{}"))
+	req, _ := http.NewRequest(http.MethodPost, env.ts.URL+"/api/v1/notion/get_page_content", strings.NewReader("{}"))
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("request: %v", err)
@@ -258,15 +181,9 @@ func TestExecuteOperation_CompositeMCPOperationUsesMCPToken(t *testing.T) {
 func TestExecuteOperation_CompositeMCPOperationRejectsGETWithAllowPost(t *testing.T) {
 	t.Parallel()
 
-	apiProv := &stubIntegrationWithCatalog{
-		StubIntegration: coretesting.StubIntegration{N: "notion", ConnMode: core.ConnectionModeSubject},
-		catalog:         serverTestCatalog("notion", nil),
-	}
-	mcpUpstream := &stubIntegrationWithSessionCatalog{
-		stubIntegrationWithOps: stubIntegrationWithOps{
-			StubIntegration: coretesting.StubIntegration{N: "notion", ConnMode: core.ConnectionModeSubject},
-		},
-		catalogForRequestFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
+	env := setupCompositeNotion(t, compositeNotionConfig{
+		seedMCP: true,
+		mcpCatalogFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
 			if token != "mcp-token" {
 				return nil, fmt.Errorf("unexpected token %q", token)
 			}
@@ -277,37 +194,9 @@ func TestExecuteOperation_CompositeMCPOperationRejectsGETWithAllowPost(t *testin
 				},
 			}, nil
 		},
-	}
-
-	providers := testutil.NewProviderRegistry(t, composite.New("notion", apiProv, mcpUpstream))
-	svc := testutil.NewStubServices(t)
-	u := seedUser(t, svc, "anonymous@gestalt")
-	seedToken(t, svc, &core.ExternalCredential{
-		ID:        "tok-mcp",
-		Subject:   principal.UserSubjectID(u.ID),
-		Audience:  "notion:MCP",
-		Qualifier: "default",
-		Grant:     &core.ExternalCredentialGrant{AccessToken: "mcp-token"},
 	})
 
-	broker := invocation.NewBroker(
-		providers,
-		svc.Users,
-		svc.ExternalCredentials,
-		invocation.WithConnectionMapper(invocation.ConnectionMap(map[string]string{"notion": "OAuth"})),
-		invocation.WithMCPConnectionMapper(invocation.ConnectionMap(map[string]string{"notion": "MCP"})),
-	)
-
-	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.Providers = providers
-		cfg.Services = svc
-		cfg.Invoker = broker
-		cfg.CatalogConnection = map[string]string{"notion": "OAuth"}
-		cfg.MCPConnection = map[string]string{"notion": "MCP"}
-	})
-	testutil.CloseOnCleanup(t, ts)
-
-	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/notion/get_page_content", nil)
+	req, _ := http.NewRequest(http.MethodGet, env.ts.URL+"/api/v1/notion/get_page_content", nil)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("request: %v", err)
@@ -326,49 +215,15 @@ func TestExecuteOperation_CompositeMCPOperationRejectsGETWithAllowPost(t *testin
 func TestExecuteOperation_CompositeMCPOperationWithoutCredentialReturnsNotConnected(t *testing.T) {
 	t.Parallel()
 
-	apiProv := &stubIntegrationWithCatalog{
-		StubIntegration: coretesting.StubIntegration{N: "notion", ConnMode: core.ConnectionModeSubject},
-		catalog:         serverTestCatalog("notion", nil),
-	}
-	mcpUpstream := &stubIntegrationWithSessionCatalog{
-		stubIntegrationWithOps: stubIntegrationWithOps{
-			StubIntegration: coretesting.StubIntegration{N: "notion", ConnMode: core.ConnectionModeSubject},
-		},
-		catalogForRequestFn: func(context.Context, string) (*catalog.Catalog, error) {
+	env := setupCompositeNotion(t, compositeNotionConfig{
+		seedOAuth: true,
+		mcpCatalogFn: func(context.Context, string) (*catalog.Catalog, error) {
 			t.Fatal("MCP catalog discovery should not run without MCP credential")
 			return nil, nil
 		},
-	}
-
-	providers := testutil.NewProviderRegistry(t, composite.New("notion", apiProv, mcpUpstream))
-	svc := testutil.NewStubServices(t)
-	u := seedUser(t, svc, "anonymous@gestalt")
-	seedToken(t, svc, &core.ExternalCredential{
-		ID:        "tok-oauth",
-		Subject:   principal.UserSubjectID(u.ID),
-		Audience:  "notion:OAuth",
-		Qualifier: "default",
-		Grant:     &core.ExternalCredentialGrant{AccessToken: "oauth-token"},
 	})
 
-	broker := invocation.NewBroker(
-		providers,
-		svc.Users,
-		svc.ExternalCredentials,
-		invocation.WithConnectionMapper(invocation.ConnectionMap(map[string]string{"notion": "OAuth"})),
-		invocation.WithMCPConnectionMapper(invocation.ConnectionMap(map[string]string{"notion": "MCP"})),
-	)
-
-	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.Providers = providers
-		cfg.Services = svc
-		cfg.Invoker = broker
-		cfg.CatalogConnection = map[string]string{"notion": "OAuth"}
-		cfg.MCPConnection = map[string]string{"notion": "MCP"}
-	})
-	testutil.CloseOnCleanup(t, ts)
-
-	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/notion/get_page_content", strings.NewReader("{}"))
+	req, _ := http.NewRequest(http.MethodPost, env.ts.URL+"/api/v1/notion/get_page_content", strings.NewReader("{}"))
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("request: %v", err)
@@ -384,48 +239,15 @@ func TestExecuteOperation_CompositeMCPOperationWithoutCredentialReturnsNotConnec
 func TestExecuteOperation_CompositeMCPAuthFailureReturnsReconnectRequired(t *testing.T) {
 	t.Parallel()
 
-	apiProv := &stubIntegrationWithCatalog{
-		StubIntegration: coretesting.StubIntegration{N: "notion", ConnMode: core.ConnectionModeSubject},
-		catalog:         serverTestCatalog("notion", nil),
-	}
-	mcpUpstream := &stubIntegrationWithSessionCatalog{
-		stubIntegrationWithOps: stubIntegrationWithOps{
-			StubIntegration: coretesting.StubIntegration{N: "notion", ConnMode: core.ConnectionModeSubject},
-		},
-		catalogForRequestFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
+	env := setupCompositeNotion(t, compositeNotionConfig{
+		seedMCP:   true,
+		mcpToken:  "stale-mcp-token",
+		mcpCatalogFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
 			return nil, fmt.Errorf("mcpupstream notion: initialize: transport error: unauthorized (401) for %q", token)
 		},
-	}
-
-	providers := testutil.NewProviderRegistry(t, composite.New("notion", apiProv, mcpUpstream))
-	svc := testutil.NewStubServices(t)
-	u := seedUser(t, svc, "anonymous@gestalt")
-	seedToken(t, svc, &core.ExternalCredential{
-		ID:        "tok-mcp",
-		Subject:   principal.UserSubjectID(u.ID),
-		Audience:  "notion:MCP",
-		Qualifier: "default",
-		Grant:     &core.ExternalCredentialGrant{AccessToken: "stale-mcp-token"},
 	})
 
-	broker := invocation.NewBroker(
-		providers,
-		svc.Users,
-		svc.ExternalCredentials,
-		invocation.WithConnectionMapper(invocation.ConnectionMap(map[string]string{"notion": "OAuth"})),
-		invocation.WithMCPConnectionMapper(invocation.ConnectionMap(map[string]string{"notion": "MCP"})),
-	)
-
-	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.Providers = providers
-		cfg.Services = svc
-		cfg.Invoker = broker
-		cfg.CatalogConnection = map[string]string{"notion": "OAuth"}
-		cfg.MCPConnection = map[string]string{"notion": "MCP"}
-	})
-	testutil.CloseOnCleanup(t, ts)
-
-	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/notion/get_page_content", strings.NewReader("{}"))
+	req, _ := http.NewRequest(http.MethodPost, env.ts.URL+"/api/v1/notion/get_page_content", strings.NewReader("{}"))
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("request: %v", err)

--- a/gestaltd/internal/server/composite_resolution_test.go
+++ b/gestaltd/internal/server/composite_resolution_test.go
@@ -2,9 +2,11 @@ package server_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -94,5 +96,354 @@ func TestExecuteOperation_CompositeStaticRESTBypassesMCPSessionResolution(t *tes
 	}
 	if got := mcpCatalogCalls.Load(); got != 0 {
 		t.Fatalf("catalog calls = %d, want 0", got)
+	}
+}
+
+func TestExecuteOperation_CompositeSearchUsesOAuthWithoutMCPCatalogDiscovery(t *testing.T) {
+	t.Parallel()
+
+	var (
+		gotToken        string
+		mcpCatalogCalls atomic.Int32
+	)
+
+	apiProv := &stubIntegrationWithCatalog{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "notion",
+			ConnMode: core.ConnectionModeSubject,
+			ExecuteFn: func(_ context.Context, op string, _ map[string]any, token string) (*core.OperationResult, error) {
+				gotToken = token
+				return &core.OperationResult{Status: http.StatusOK, Body: []byte(fmt.Sprintf(`{"operation":%q}`, op))}, nil
+			},
+		},
+		catalog: serverTestCatalog("notion", []catalog.CatalogOperation{
+			{ID: "search", Description: "Search", Method: http.MethodPost, Transport: catalog.TransportREST},
+		}),
+	}
+	mcpUpstream := &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{N: "notion", ConnMode: core.ConnectionModeSubject},
+		},
+		catalogForRequestFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
+			mcpCatalogCalls.Add(1)
+			return nil, fmt.Errorf("mcpupstream notion: initialize: transport error: unauthorized (401) for %q", token)
+		},
+	}
+
+	providers := testutil.NewProviderRegistry(t, composite.New("notion", apiProv, mcpUpstream))
+	svc := testutil.NewStubServices(t)
+	u := seedUser(t, svc, "anonymous@gestalt")
+	seedToken(t, svc, &core.ExternalCredential{
+		ID:        "tok-oauth",
+		Subject:   principal.UserSubjectID(u.ID),
+		Audience:  "notion:OAuth",
+		Qualifier: "default",
+		Grant:     &core.ExternalCredentialGrant{AccessToken: "oauth-token"},
+	})
+
+	broker := invocation.NewBroker(
+		providers,
+		svc.Users,
+		svc.ExternalCredentials,
+		invocation.WithConnectionMapper(invocation.ConnectionMap(map[string]string{"notion": "OAuth"})),
+		invocation.WithMCPConnectionMapper(invocation.ConnectionMap(map[string]string{"notion": "MCP"})),
+	)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = providers
+		cfg.Services = svc
+		cfg.Invoker = broker
+		cfg.CatalogConnection = map[string]string{"notion": "OAuth"}
+		cfg.MCPConnection = map[string]string{"notion": "MCP"}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/notion/search", strings.NewReader("{}"))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	if gotToken != "oauth-token" {
+		t.Fatalf("execute token = %q, want %q", gotToken, "oauth-token")
+	}
+	if got := mcpCatalogCalls.Load(); got != 0 {
+		t.Fatalf("catalog calls = %d, want 0", got)
+	}
+}
+
+func TestExecuteOperation_CompositeMCPOperationUsesMCPToken(t *testing.T) {
+	t.Parallel()
+
+	var mcpCatalogCalls atomic.Int32
+
+	apiProv := &stubIntegrationWithCatalog{
+		StubIntegration: coretesting.StubIntegration{N: "notion", ConnMode: core.ConnectionModeSubject},
+		catalog:         serverTestCatalog("notion", nil),
+	}
+	mcpUpstream := &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{N: "notion", ConnMode: core.ConnectionModeSubject},
+		},
+		catalogForRequestFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
+			mcpCatalogCalls.Add(1)
+			if token != "mcp-token" {
+				return nil, fmt.Errorf("unexpected token %q", token)
+			}
+			return &catalog.Catalog{
+				Name: "notion",
+				Operations: []catalog.CatalogOperation{
+					{ID: "get_page_content", Description: "Get page content", Method: http.MethodPost, Transport: catalog.TransportMCPPassthrough},
+				},
+			}, nil
+		},
+	}
+
+	providers := testutil.NewProviderRegistry(t, composite.New("notion", apiProv, mcpUpstream))
+	svc := testutil.NewStubServices(t)
+	u := seedUser(t, svc, "anonymous@gestalt")
+	seedToken(t, svc, &core.ExternalCredential{
+		ID:        "tok-oauth",
+		Subject:   principal.UserSubjectID(u.ID),
+		Audience:  "notion:OAuth",
+		Qualifier: "default",
+		Grant:     &core.ExternalCredentialGrant{AccessToken: "oauth-token"},
+	})
+	seedToken(t, svc, &core.ExternalCredential{
+		ID:        "tok-mcp",
+		Subject:   principal.UserSubjectID(u.ID),
+		Audience:  "notion:MCP",
+		Qualifier: "default",
+		Grant:     &core.ExternalCredentialGrant{AccessToken: "mcp-token"},
+	})
+
+	broker := invocation.NewBroker(
+		providers,
+		svc.Users,
+		svc.ExternalCredentials,
+		invocation.WithConnectionMapper(invocation.ConnectionMap(map[string]string{"notion": "OAuth"})),
+		invocation.WithMCPConnectionMapper(invocation.ConnectionMap(map[string]string{"notion": "MCP"})),
+	)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = providers
+		cfg.Services = svc
+		cfg.Invoker = broker
+		cfg.CatalogConnection = map[string]string{"notion": "OAuth"}
+		cfg.MCPConnection = map[string]string{"notion": "MCP"}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/notion/get_page_content", strings.NewReader("{}"))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	if got := mcpCatalogCalls.Load(); got < 1 {
+		t.Fatalf("catalog calls = %d, want at least 1", got)
+	}
+}
+
+func TestExecuteOperation_CompositeMCPOperationRejectsGETWithAllowPost(t *testing.T) {
+	t.Parallel()
+
+	apiProv := &stubIntegrationWithCatalog{
+		StubIntegration: coretesting.StubIntegration{N: "notion", ConnMode: core.ConnectionModeSubject},
+		catalog:         serverTestCatalog("notion", nil),
+	}
+	mcpUpstream := &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{N: "notion", ConnMode: core.ConnectionModeSubject},
+		},
+		catalogForRequestFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
+			if token != "mcp-token" {
+				return nil, fmt.Errorf("unexpected token %q", token)
+			}
+			return &catalog.Catalog{
+				Name: "notion",
+				Operations: []catalog.CatalogOperation{
+					{ID: "get_page_content", Description: "Get page content", Method: http.MethodPost, Transport: catalog.TransportMCPPassthrough},
+				},
+			}, nil
+		},
+	}
+
+	providers := testutil.NewProviderRegistry(t, composite.New("notion", apiProv, mcpUpstream))
+	svc := testutil.NewStubServices(t)
+	u := seedUser(t, svc, "anonymous@gestalt")
+	seedToken(t, svc, &core.ExternalCredential{
+		ID:        "tok-mcp",
+		Subject:   principal.UserSubjectID(u.ID),
+		Audience:  "notion:MCP",
+		Qualifier: "default",
+		Grant:     &core.ExternalCredentialGrant{AccessToken: "mcp-token"},
+	})
+
+	broker := invocation.NewBroker(
+		providers,
+		svc.Users,
+		svc.ExternalCredentials,
+		invocation.WithConnectionMapper(invocation.ConnectionMap(map[string]string{"notion": "OAuth"})),
+		invocation.WithMCPConnectionMapper(invocation.ConnectionMap(map[string]string{"notion": "MCP"})),
+	)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = providers
+		cfg.Services = svc
+		cfg.Invoker = broker
+		cfg.CatalogConnection = map[string]string{"notion": "OAuth"}
+		cfg.MCPConnection = map[string]string{"notion": "MCP"}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/notion/get_page_content", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 405, got %d: %s", resp.StatusCode, body)
+	}
+	if allow := resp.Header.Get("Allow"); allow != http.MethodPost {
+		t.Fatalf("Allow header = %q, want %q", allow, http.MethodPost)
+	}
+}
+
+func TestExecuteOperation_CompositeMCPOperationWithoutCredentialReturnsNotConnected(t *testing.T) {
+	t.Parallel()
+
+	apiProv := &stubIntegrationWithCatalog{
+		StubIntegration: coretesting.StubIntegration{N: "notion", ConnMode: core.ConnectionModeSubject},
+		catalog:         serverTestCatalog("notion", nil),
+	}
+	mcpUpstream := &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{N: "notion", ConnMode: core.ConnectionModeSubject},
+		},
+		catalogForRequestFn: func(context.Context, string) (*catalog.Catalog, error) {
+			t.Fatal("MCP catalog discovery should not run without MCP credential")
+			return nil, nil
+		},
+	}
+
+	providers := testutil.NewProviderRegistry(t, composite.New("notion", apiProv, mcpUpstream))
+	svc := testutil.NewStubServices(t)
+	u := seedUser(t, svc, "anonymous@gestalt")
+	seedToken(t, svc, &core.ExternalCredential{
+		ID:        "tok-oauth",
+		Subject:   principal.UserSubjectID(u.ID),
+		Audience:  "notion:OAuth",
+		Qualifier: "default",
+		Grant:     &core.ExternalCredentialGrant{AccessToken: "oauth-token"},
+	})
+
+	broker := invocation.NewBroker(
+		providers,
+		svc.Users,
+		svc.ExternalCredentials,
+		invocation.WithConnectionMapper(invocation.ConnectionMap(map[string]string{"notion": "OAuth"})),
+		invocation.WithMCPConnectionMapper(invocation.ConnectionMap(map[string]string{"notion": "MCP"})),
+	)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = providers
+		cfg.Services = svc
+		cfg.Invoker = broker
+		cfg.CatalogConnection = map[string]string{"notion": "OAuth"}
+		cfg.MCPConnection = map[string]string{"notion": "MCP"}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/notion/get_page_content", strings.NewReader("{}"))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusPreconditionFailed {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 412, got %d: %s", resp.StatusCode, body)
+	}
+}
+
+func TestExecuteOperation_CompositeMCPAuthFailureReturnsReconnectRequired(t *testing.T) {
+	t.Parallel()
+
+	apiProv := &stubIntegrationWithCatalog{
+		StubIntegration: coretesting.StubIntegration{N: "notion", ConnMode: core.ConnectionModeSubject},
+		catalog:         serverTestCatalog("notion", nil),
+	}
+	mcpUpstream := &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{N: "notion", ConnMode: core.ConnectionModeSubject},
+		},
+		catalogForRequestFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
+			return nil, fmt.Errorf("mcpupstream notion: initialize: transport error: unauthorized (401) for %q", token)
+		},
+	}
+
+	providers := testutil.NewProviderRegistry(t, composite.New("notion", apiProv, mcpUpstream))
+	svc := testutil.NewStubServices(t)
+	u := seedUser(t, svc, "anonymous@gestalt")
+	seedToken(t, svc, &core.ExternalCredential{
+		ID:        "tok-mcp",
+		Subject:   principal.UserSubjectID(u.ID),
+		Audience:  "notion:MCP",
+		Qualifier: "default",
+		Grant:     &core.ExternalCredentialGrant{AccessToken: "stale-mcp-token"},
+	})
+
+	broker := invocation.NewBroker(
+		providers,
+		svc.Users,
+		svc.ExternalCredentials,
+		invocation.WithConnectionMapper(invocation.ConnectionMap(map[string]string{"notion": "OAuth"})),
+		invocation.WithMCPConnectionMapper(invocation.ConnectionMap(map[string]string{"notion": "MCP"})),
+	)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = providers
+		cfg.Services = svc
+		cfg.Invoker = broker
+		cfg.CatalogConnection = map[string]string{"notion": "OAuth"}
+		cfg.MCPConnection = map[string]string{"notion": "MCP"}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/notion/get_page_content", strings.NewReader("{}"))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusPreconditionFailed {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 412, got %d: %s", resp.StatusCode, body)
+	}
+
+	var errResp struct {
+		Code string `json:"code"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if errResp.Code != "reconnect_required" {
+		t.Fatalf("error code = %q, want reconnect_required", errResp.Code)
 	}
 }

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -653,7 +653,7 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 		name,
 		resolver,
 		p,
-		s.catalogSelectorConfig().SessionCatalogTargets(name, requestedConnection, requestedInstance),
+		s.catalogSelectorConfig().APICatalogTargets(name, requestedConnection, requestedInstance),
 		strictCatalog,
 	)
 	discoveryFailed = metadata.SessionFailed

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -92,10 +92,10 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 		Invoker:              httpInvoker,
 		AppInvocation:        result.AppInvocation,
 		DefaultConnection:    connMaps.DefaultConnection,
-		// HTTP routes expose REST-visible operations, so unqualified session-catalog
-		// resolution should follow the API surface by default. The MCP server keeps
-		// its own MCP-specific routing below.
+		// HTTP routes expose REST-visible operations via the API surface catalog map.
+		// Dynamic session/MCP operation resolution uses MCPConnection below.
 		CatalogConnection:    httpCatalogConnectionMap(connMaps),
+		MCPConnection:        connMaps.MCPConnection,
 		ConnectionAuth:       result.ConnectionAuth,
 		ManualConnectionAuth: result.ManualConnectionAuth,
 		AppDefs:              cfg.Apps,

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -112,6 +112,7 @@ type Server struct {
 	agentStreamHeartbeat   time.Duration
 	defaultConnection      map[string]string
 	catalogConnection      map[string]string
+	mcpConnection          map[string]string
 	connectionAuth         func() map[string]map[string]bootstrap.OAuthHandler
 	manualConnectionAuth   func() map[string]map[string]bootstrap.ManualTokenExchanger
 	pluginDefs             map[string]*config.ProviderEntry
@@ -148,6 +149,7 @@ func (s *Server) catalogSelectorConfig() invocation.CatalogSelectorConfig {
 	return invocation.CatalogSelectorConfig{
 		Invoker:           s.invoker,
 		CatalogConnection: s.catalogConnection,
+		MCPConnection:     s.mcpConnection,
 		DefaultConnection: s.defaultConnection,
 	}
 }
@@ -169,6 +171,7 @@ type Config struct {
 	AppInvocation        invocation.Invoker
 	DefaultConnection    map[string]string
 	CatalogConnection    map[string]string
+	MCPConnection        map[string]string
 	ConnectionAuth       func() map[string]map[string]bootstrap.OAuthHandler
 	ManualConnectionAuth func() map[string]map[string]bootstrap.ManualTokenExchanger
 	AppDefs              map[string]*config.ProviderEntry
@@ -369,6 +372,7 @@ func New(cfg Config) (*Server, error) {
 		agentStreamHeartbeat:   agentStreamHeartbeat,
 		defaultConnection:      cfg.DefaultConnection,
 		catalogConnection:      cfg.CatalogConnection,
+		mcpConnection:          cfg.MCPConnection,
 		connectionAuth:         cfg.ConnectionAuth,
 		manualConnectionAuth:   cfg.ManualConnectionAuth,
 		pluginDefs:             cfg.AppDefs,
@@ -406,6 +410,7 @@ func New(cfg Config) (*Server, error) {
 		Audit:             cfg.AuditSink,
 		DefaultConnection: cfg.DefaultConnection,
 		CatalogConnection: cfg.CatalogConnection,
+		MCPConnection:     cfg.MCPConnection,
 		Now:               now,
 	})
 	if noAuth || hasAnonymousAuthProvider(authProviders) {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -119,9 +119,9 @@ func newTestHandler(t *testing.T, opts ...func(*server.Config)) http.Handler {
 	if cfg.DefaultConnection != nil {
 		brokerOpts = append(brokerOpts, invocation.WithConnectionMapper(invocation.ConnectionMap(cfg.DefaultConnection)))
 	}
-	if cfg.CatalogConnection != nil {
+	if cfg.MCPConnection != nil {
 		brokerOpts = append(brokerOpts,
-			invocation.WithMCPConnectionMapper(invocation.ConnectionMap(cfg.CatalogConnection)),
+			invocation.WithMCPConnectionMapper(invocation.ConnectionMap(cfg.MCPConnection)),
 		)
 	}
 	if cfg.TracerProvider != nil {
@@ -6453,7 +6453,8 @@ func TestListOperations_FallsBackToStaticCatalogWhenSessionCatalogErrors(t *test
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
-		cfg.CatalogConnection = map[string]string{"notion": "MCP"}
+		cfg.CatalogConnection = map[string]string{"notion": "OAuth"}
+		cfg.MCPConnection = map[string]string{"notion": "MCP"}
 		cfg.Services = svc
 	})
 	testutil.CloseOnCleanup(t, ts)
@@ -6547,6 +6548,7 @@ func TestListOperations_UsesBrokerCatalogConnectionFallback(t *testing.T) {
 		cfg.Services = svc
 		cfg.Invoker = broker
 		cfg.DefaultConnection = map[string]string{"sample-int": "rest-conn"}
+		cfg.CatalogConnection = map[string]string{"sample-int": "catalog-conn"}
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -7744,7 +7746,7 @@ func TestExecuteOperation_UnknownOperation(t *testing.T) {
 
 	ts = newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, sessionStub)
-		cfg.CatalogConnection = map[string]string{"sample-int": testCatalogConnection}
+		cfg.MCPConnection = map[string]string{"sample-int": testCatalogConnection}
 		cfg.Services = svc
 	})
 	testutil.CloseOnCleanup(t, ts)
@@ -7797,7 +7799,7 @@ func TestExecuteOperation_NoStoredToken(t *testing.T) {
 
 	ts = newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, sessionStub)
-		cfg.CatalogConnection = map[string]string{"test-int": testCatalogConnection}
+		cfg.MCPConnection = map[string]string{"test-int": testCatalogConnection}
 		cfg.Services = testutil.NewStubServices(t)
 	})
 	testutil.CloseOnCleanup(t, ts)
@@ -7864,14 +7866,14 @@ func TestExecuteOperation_UsesFallbackSessionCatalogConnectionAfterEarlierError(
 		t.Fatalf("request: %v", err)
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusPreconditionFailed {
 		body, _ := io.ReadAll(resp.Body)
 		_ = resp.Body.Close()
-		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+		t.Fatalf("expected 412 when MCP session catalog credential is missing, got %d: %s", resp.StatusCode, body)
 	}
-	if gotToken != "rest-token" {
+	if gotToken != "" {
 		_ = resp.Body.Close()
-		t.Fatalf("execute token = %q, want %q", gotToken, "rest-token")
+		t.Fatalf("execute token = %q, want no provider execution", gotToken)
 	}
 	_ = resp.Body.Close()
 
@@ -8043,6 +8045,7 @@ func TestExecuteOperation_UsesConfiguredCatalogConnectionWhenInvokerIsWrapped(t 
 		cfg.Invoker = wrappedInvoker
 		cfg.DefaultConnection = map[string]string{"sample-int": "rest-conn"}
 		cfg.CatalogConnection = map[string]string{"sample-int": "catalog-conn"}
+		cfg.MCPConnection = map[string]string{"sample-int": "catalog-conn"}
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -8062,7 +8065,7 @@ func TestExecuteOperation_UsesConfiguredCatalogConnectionWhenInvokerIsWrapped(t 
 	}
 }
 
-func TestExecuteOperation_UsesServerCatalogConnectionBeforeBrokerFallback(t *testing.T) {
+func TestExecuteOperation_UsesServerMCPConnectionBeforeBrokerFallback(t *testing.T) {
 	t.Parallel()
 
 	var gotToken string
@@ -8124,7 +8127,7 @@ func TestExecuteOperation_UsesServerCatalogConnectionBeforeBrokerFallback(t *tes
 		cfg.Services = svc
 		cfg.Invoker = broker
 		cfg.DefaultConnection = map[string]string{"sample-int": "rest-conn"}
-		cfg.CatalogConnection = map[string]string{"sample-int": "catalog-conn"}
+		cfg.MCPConnection = map[string]string{"sample-int": "catalog-conn"}
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -8144,7 +8147,7 @@ func TestExecuteOperation_UsesServerCatalogConnectionBeforeBrokerFallback(t *tes
 	}
 }
 
-func TestExecuteOperation_DoesNotFallbackPastConfiguredCatalogConnection(t *testing.T) {
+func TestExecuteOperation_DoesNotFallbackPastConfiguredMCPConnection(t *testing.T) {
 	t.Parallel()
 
 	var gotToken string
@@ -8206,7 +8209,7 @@ func TestExecuteOperation_DoesNotFallbackPastConfiguredCatalogConnection(t *test
 		cfg.Services = svc
 		cfg.Invoker = broker
 		cfg.DefaultConnection = map[string]string{"sample-int": "rest-conn"}
-		cfg.CatalogConnection = map[string]string{"sample-int": "catalog-conn"}
+		cfg.MCPConnection = map[string]string{"sample-int": "catalog-conn"}
 	})
 	testutil.CloseOnCleanup(t, ts)
 

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -6493,86 +6493,6 @@ func TestListOperations_FallsBackToStaticCatalogWhenSessionCatalogErrors(t *test
 	assertListOperations("/api/v1/apps/notion/operations?_connection=OAuth&_instance=OAuth")
 }
 
-func TestListOperations_UsesBrokerCatalogConnectionFallback(t *testing.T) {
-	t.Parallel()
-
-	stub := &stubIntegrationWithSessionCatalog{
-		stubIntegrationWithOps: stubIntegrationWithOps{
-			StubIntegration: coretesting.StubIntegration{N: "sample-int", ConnMode: core.ConnectionModeSubject},
-		},
-		catalogForRequestFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
-			switch token {
-			case "catalog-token":
-				return &catalog.Catalog{
-					Name: "sample-int",
-					Operations: []catalog.CatalogOperation{
-						{ID: "run", Description: "Run", Method: http.MethodGet, Transport: catalog.TransportREST},
-					},
-				}, nil
-			case "rest-token":
-				return &catalog.Catalog{Name: "sample-int"}, nil
-			default:
-				return nil, fmt.Errorf("unexpected token %q", token)
-			}
-		},
-	}
-
-	providers := testutil.NewProviderRegistry(t, stub)
-	svc := testutil.NewStubServices(t)
-	u := seedUser(t, svc, "anonymous@gestalt")
-	seedToken(t, svc, &core.ExternalCredential{
-		ID:        "tok-catalog",
-		Subject:   principal.UserSubjectID(u.ID),
-		Audience:  "sample-int:catalog-conn",
-		Qualifier: "default",
-		Grant:     &core.ExternalCredentialGrant{AccessToken: "catalog-token"},
-	})
-	seedToken(t, svc, &core.ExternalCredential{
-		ID:        "tok-rest",
-		Subject:   principal.UserSubjectID(u.ID),
-		Audience:  "sample-int:rest-conn",
-		Qualifier: "default",
-		Grant:     &core.ExternalCredentialGrant{AccessToken: "rest-token"},
-	})
-
-	broker := invocation.NewBroker(
-		providers,
-		svc.Users,
-		svc.ExternalCredentials,
-		invocation.WithConnectionMapper(invocation.ConnectionMap(map[string]string{"sample-int": "rest-conn"})),
-		invocation.WithMCPConnectionMapper(invocation.ConnectionMap(map[string]string{"sample-int": "catalog-conn"})),
-	)
-
-	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.Providers = providers
-		cfg.Services = svc
-		cfg.Invoker = broker
-		cfg.DefaultConnection = map[string]string{"sample-int": "rest-conn"}
-		cfg.CatalogConnection = map[string]string{"sample-int": "catalog-conn"}
-	})
-	testutil.CloseOnCleanup(t, ts)
-
-	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/sample-int/operations", nil)
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("request: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
-	}
-
-	var ops []map[string]any
-	if err := json.NewDecoder(resp.Body).Decode(&ops); err != nil {
-		t.Fatalf("decoding response: %v", err)
-	}
-	if len(ops) != 1 || ops[0]["id"] != "run" {
-		t.Fatalf("operations = %+v, want only run", ops)
-	}
-}
-
 func TestListOperations_RetriesDefaultConnectionAfterBrokerCatalogError(t *testing.T) {
 	t.Parallel()
 
@@ -7790,23 +7710,9 @@ func TestExecuteOperation_NoStoredToken(t *testing.T) {
 	if resp.StatusCode != http.StatusPreconditionFailed {
 		t.Fatalf("expected 412, got %d", resp.StatusCode)
 	}
-
-	sessionStub := &stubIntegrationWithSessionCatalog{
-		stubIntegrationWithOps: stubIntegrationWithOps{
-			StubIntegration: coretesting.StubIntegration{N: "test-int", ConnMode: core.ConnectionModeSubject},
-		},
-	}
-
-	ts = newTestServer(t, func(cfg *server.Config) {
-		cfg.Providers = testutil.NewProviderRegistry(t, sessionStub)
-		cfg.MCPConnection = map[string]string{"test-int": testCatalogConnection}
-		cfg.Services = testutil.NewStubServices(t)
-	})
-	testutil.CloseOnCleanup(t, ts)
-
 }
 
-func TestExecuteOperation_UsesFallbackSessionCatalogConnectionAfterEarlierError(t *testing.T) {
+func TestExecuteOperation_DoesNotFallbackToDefaultWhenBrokerMCPConnectionConfigured(t *testing.T) {
 	t.Parallel()
 
 	var gotToken string

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -6493,6 +6493,65 @@ func TestListOperations_FallsBackToStaticCatalogWhenSessionCatalogErrors(t *test
 	assertListOperations("/api/v1/apps/notion/operations?_connection=OAuth&_instance=OAuth")
 }
 
+func TestListOperations_SessionCatalogAuthFailureReturnsReconnectRequired(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{N: "notion", ConnMode: core.ConnectionModeSubject},
+		},
+		catalog: &catalog.Catalog{
+			Name: "notion",
+			Operations: []catalog.CatalogOperation{
+				{ID: "search", Description: "Search pages", Method: http.MethodPost, Transport: catalog.TransportREST},
+			},
+		},
+		catalogForRequestFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
+			return nil, fmt.Errorf("mcpupstream notion: initialize: transport error: unauthorized (401) for %q", token)
+		},
+	}
+
+	svc := testutil.NewStubServices(t)
+	u := seedUser(t, svc, "anonymous@gestalt")
+	seedToken(t, svc, &core.ExternalCredential{
+		ID:        "tok-oauth",
+		Subject:   principal.UserSubjectID(u.ID),
+		Audience:  "notion:OAuth",
+		Qualifier: "default",
+		Grant:     &core.ExternalCredentialGrant{AccessToken: "oauth-token"},
+	})
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.CatalogConnection = map[string]string{"notion": "OAuth"}
+		cfg.MCPConnection = map[string]string{"notion": "MCP"}
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/notion/operations", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusPreconditionFailed {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 412, got %d: %s", resp.StatusCode, body)
+	}
+
+	var errResp struct {
+		Code string `json:"code"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if errResp.Code != "reconnect_required" {
+		t.Fatalf("error code = %q, want reconnect_required", errResp.Code)
+	}
+}
+
 func TestListOperations_RetriesDefaultConnectionAfterBrokerCatalogError(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -129,6 +129,7 @@ type Config struct {
 	Invoker           invocation.Invoker
 	DefaultConnection map[string]string
 	CatalogConnection map[string]string
+	MCPConnection     map[string]string
 	AgentConnections  map[string][]string
 	SessionStart      map[string]*coreagent.SessionStartConfig
 }
@@ -142,6 +143,7 @@ type Manager struct {
 	invoker           invocation.Invoker
 	defaultConnection map[string]string
 	catalogConnection map[string]string
+	mcpConnection     map[string]string
 	agentConnections  map[string][]string
 	sessionStart      map[string]*coreagent.SessionStartConfig
 }
@@ -156,6 +158,7 @@ func New(cfg Config) *Manager {
 		invoker:           cfg.Invoker,
 		defaultConnection: maps.Clone(cfg.DefaultConnection),
 		catalogConnection: maps.Clone(cfg.CatalogConnection),
+		mcpConnection:     maps.Clone(cfg.MCPConnection),
 		agentConnections:  cloneStringSliceMap(cfg.AgentConnections),
 		sessionStart:      cloneSessionStartConfigMap(cfg.SessionStart),
 	}
@@ -2975,6 +2978,7 @@ func (m *Manager) catalogSelectorConfig() invocation.CatalogSelectorConfig {
 	return invocation.CatalogSelectorConfig{
 		Invoker:           m.invoker,
 		CatalogConnection: m.catalogConnection,
+		MCPConnection:     m.mcpConnection,
 		DefaultConnection: m.defaultConnection,
 	}
 }

--- a/gestaltd/services/invocation/catalog.go
+++ b/gestaltd/services/invocation/catalog.go
@@ -141,6 +141,7 @@ func ResolveOperation(ctx context.Context, prov core.Provider, provName string, 
 
 	sessionOp, sessionConnection, sessionFound, err := resolveSessionOperation(ctx, prov, provName, resolver, p, operation, sessionConnections, instance)
 	if err != nil {
+		err = ClassifySessionCatalogError(err)
 		if staticOK && sessionCatalogUnsupported(err) {
 			catalogSource = "static"
 			return staticOp, OperationTransport(staticOp), "", nil
@@ -267,7 +268,7 @@ func resolveSessionOperation(ctx context.Context, prov core.Provider, provName s
 		cat, attempted, err := resolveSessionCatalog(ctx, prov, provName, resolver, p, connection, instance)
 		if err != nil {
 			if firstErr == nil {
-				firstErr = err
+				firstErr = ClassifySessionCatalogError(err)
 			}
 			continue
 		}

--- a/gestaltd/services/invocation/catalog.go
+++ b/gestaltd/services/invocation/catalog.go
@@ -141,7 +141,6 @@ func ResolveOperation(ctx context.Context, prov core.Provider, provName string, 
 
 	sessionOp, sessionConnection, sessionFound, err := resolveSessionOperation(ctx, prov, provName, resolver, p, operation, sessionConnections, instance)
 	if err != nil {
-		err = ClassifySessionCatalogError(err)
 		if staticOK && sessionCatalogUnsupported(err) {
 			catalogSource = "static"
 			return staticOp, OperationTransport(staticOp), "", nil
@@ -206,6 +205,7 @@ func resolveCatalog(ctx context.Context, prov core.Provider, provName string, re
 	sessionCat, attempted, err := resolveSessionCatalog(ctx, prov, provName, resolver, p, defaultConnection, instance)
 	meta.SessionAttempted = attempted
 	if err != nil {
+		err = ClassifySessionCatalogError(err)
 		meta.SessionFailed = true
 		if strictSession || staticCat == nil {
 			return nil, meta, err

--- a/gestaltd/services/invocation/catalog_selectors.go
+++ b/gestaltd/services/invocation/catalog_selectors.go
@@ -1,14 +1,25 @@
 package invocation
 
-import "github.com/valon-technologies/gestalt/server/core"
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/core"
+)
 
 type CatalogSelectorConfig struct {
-	Invoker           any
+	Invoker any
+	// CatalogConnection selects the API/OAuth surface for REST-visible catalog listing.
 	CatalogConnection map[string]string
+	// MCPConnection selects the MCP surface for dynamic session operation resolution.
+	MCPConnection map[string]string
+	// DefaultConnection is the compatibility fallback when no surface-specific map is set.
 	DefaultConnection map[string]string
 }
 
-func (cfg CatalogSelectorConfig) SessionCatalogConnections(providerName string, explicit string) []string {
+// APICatalogConnections returns connection candidates for API catalog listing.
+func (cfg CatalogSelectorConfig) APICatalogConnections(providerName string, explicit string) []string {
 	if explicit != "" {
 		return []string{core.ResolveConnectionAlias(explicit)}
 	}
@@ -16,10 +27,6 @@ func (cfg CatalogSelectorConfig) SessionCatalogConnections(providerName string, 
 	connections := make([]string, 0, 2)
 	if conn := cfg.CatalogConnection[providerName]; conn != "" {
 		connections = append(connections, conn)
-	} else if broker, ok := cfg.Invoker.(interface{ MCPConnection(string) string }); ok {
-		if conn := broker.MCPConnection(providerName); conn != "" {
-			connections = append(connections, conn)
-		}
 	} else if conn := cfg.DefaultConnection[providerName]; conn != "" {
 		connections = append(connections, conn)
 	}
@@ -32,6 +39,41 @@ func (cfg CatalogSelectorConfig) SessionCatalogConnections(providerName string, 
 	return connections
 }
 
+// SessionCatalogConnections returns connection candidates for dynamic MCP/session
+// operation resolution. When an MCP surface connection is configured, OAuth/API
+// connections are not used as fallbacks.
+func (cfg CatalogSelectorConfig) SessionCatalogConnections(providerName string, explicit string) []string {
+	if explicit != "" {
+		return []string{core.ResolveConnectionAlias(explicit)}
+	}
+
+	if conn := cfg.MCPConnection[providerName]; conn != "" {
+		return []string{conn}
+	}
+	if broker, ok := cfg.Invoker.(interface{ MCPConnection(string) string }); ok {
+		if conn := broker.MCPConnection(providerName); conn != "" {
+			return []string{conn}
+		}
+	}
+
+	if conn := cfg.DefaultConnection[providerName]; conn != "" {
+		return []string{conn}
+	}
+	return []string{""}
+}
+
+func (cfg CatalogSelectorConfig) APICatalogTargets(providerName string, explicit, instance string) []CatalogResolutionTarget {
+	connections := cfg.APICatalogConnections(providerName, explicit)
+	targets := make([]CatalogResolutionTarget, 0, len(connections))
+	for _, connection := range connections {
+		targets = append(targets, CatalogResolutionTarget{
+			Connection: connection,
+			Instance:   instance,
+		})
+	}
+	return targets
+}
+
 func (cfg CatalogSelectorConfig) SessionCatalogTargets(providerName string, explicit, instance string) []CatalogResolutionTarget {
 	connections := cfg.SessionCatalogConnections(providerName, explicit)
 	targets := make([]CatalogResolutionTarget, 0, len(connections))
@@ -42,4 +84,30 @@ func (cfg CatalogSelectorConfig) SessionCatalogTargets(providerName string, expl
 		})
 	}
 	return targets
+}
+
+// ClassifySessionCatalogError maps known MCP/session catalog auth failures to
+// client-actionable credential errors instead of generic upstream failures.
+func ClassifySessionCatalogError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, ErrNoCredential) || errors.Is(err, ErrReconnectRequired) {
+		return err
+	}
+	if sessionCatalogAuthFailure(err) {
+		return fmt.Errorf("%w: %v", ErrReconnectRequired, err)
+	}
+	return err
+}
+
+func sessionCatalogAuthFailure(err error) bool {
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "unauthorized") ||
+		strings.Contains(msg, "(401)") ||
+		strings.Contains(msg, " 401 ") ||
+		strings.Contains(msg, "forbidden") ||
+		strings.Contains(msg, "(403)") ||
+		strings.Contains(msg, " 403 ") ||
+		strings.Contains(msg, "authorization required")
 }

--- a/gestaltd/services/invocation/catalog_selectors_test.go
+++ b/gestaltd/services/invocation/catalog_selectors_test.go
@@ -1,0 +1,97 @@
+package invocation
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+type stubMCPConnectionBroker struct {
+	connections map[string]string
+}
+
+func (b stubMCPConnectionBroker) MCPConnection(providerName string) string {
+	if b.connections == nil {
+		return ""
+	}
+	return b.connections[providerName]
+}
+
+func TestSessionCatalogConnections_UsesMCPConnectionForDynamicResolution(t *testing.T) {
+	t.Parallel()
+
+	cfg := CatalogSelectorConfig{
+		CatalogConnection: map[string]string{"notion": "OAuth"},
+		MCPConnection:     map[string]string{"notion": "MCP"},
+		DefaultConnection: map[string]string{"notion": "OAuth"},
+	}
+
+	got := cfg.SessionCatalogConnections("notion", "")
+	if len(got) != 1 || got[0] != "MCP" {
+		t.Fatalf("SessionCatalogConnections() = %v, want [MCP]", got)
+	}
+}
+
+func TestAPICatalogConnections_UsesAPIConnectionForListing(t *testing.T) {
+	t.Parallel()
+
+	cfg := CatalogSelectorConfig{
+		CatalogConnection: map[string]string{"notion": "OAuth"},
+		MCPConnection:     map[string]string{"notion": "MCP"},
+		DefaultConnection: map[string]string{"notion": "OAuth"},
+	}
+
+	got := cfg.APICatalogConnections("notion", "")
+	if len(got) != 1 || got[0] != "OAuth" {
+		t.Fatalf("APICatalogConnections() = %v, want [OAuth]", got)
+	}
+}
+
+func TestSessionCatalogConnections_FallsBackToDefaultWithoutSurfaceMaps(t *testing.T) {
+	t.Parallel()
+
+	cfg := CatalogSelectorConfig{
+		DefaultConnection: map[string]string{"sample-int": "default"},
+	}
+
+	got := cfg.SessionCatalogConnections("sample-int", "")
+	if len(got) != 1 || got[0] != "default" {
+		t.Fatalf("SessionCatalogConnections() = %v, want [default]", got)
+	}
+}
+
+func TestSessionCatalogConnections_UsesBrokerMCPConnection(t *testing.T) {
+	t.Parallel()
+
+	cfg := CatalogSelectorConfig{
+		Invoker: stubMCPConnectionBroker{connections: map[string]string{"notion": "MCP"}},
+	}
+
+	got := cfg.SessionCatalogConnections("notion", "")
+	if len(got) != 1 || got[0] != "MCP" {
+		t.Fatalf("SessionCatalogConnections() = %v, want [MCP]", got)
+	}
+}
+
+func TestSessionCatalogConnections_ExplicitConnectionOverridesSurfaceMaps(t *testing.T) {
+	t.Parallel()
+
+	cfg := CatalogSelectorConfig{
+		CatalogConnection: map[string]string{"notion": "OAuth"},
+		MCPConnection:     map[string]string{"notion": "MCP"},
+	}
+
+	got := cfg.SessionCatalogConnections("notion", "workspace")
+	if len(got) != 1 || got[0] != "workspace" {
+		t.Fatalf("SessionCatalogConnections() = %v, want [workspace]", got)
+	}
+}
+
+func TestClassifySessionCatalogError_MapsUnauthorizedToReconnectRequired(t *testing.T) {
+	t.Parallel()
+
+	err := ClassifySessionCatalogError(fmt.Errorf("mcpupstream notion: initialize: transport error: unauthorized (401)"))
+	if !errors.Is(err, ErrReconnectRequired) {
+		t.Fatalf("ClassifySessionCatalogError() = %v, want ErrReconnectRequired", err)
+	}
+}

--- a/gestaltd/services/workflows/workflowmanager/manager.go
+++ b/gestaltd/services/workflows/workflowmanager/manager.go
@@ -122,6 +122,7 @@ type Config struct {
 	Audit             core.AuditSink
 	DefaultConnection map[string]string
 	CatalogConnection map[string]string
+	MCPConnection     map[string]string
 	Now               func() time.Time
 	Logger            *slog.Logger
 }
@@ -135,6 +136,7 @@ type Manager struct {
 	audit             core.AuditSink
 	defaultConnection map[string]string
 	catalogConnection map[string]string
+	mcpConnection     map[string]string
 	now               func() time.Time
 	logger            *slog.Logger
 }
@@ -238,6 +240,7 @@ func New(cfg Config) *Manager {
 		audit:             cfg.Audit,
 		defaultConnection: maps.Clone(cfg.DefaultConnection),
 		catalogConnection: maps.Clone(cfg.CatalogConnection),
+		mcpConnection:     maps.Clone(cfg.MCPConnection),
 		now:               now,
 		logger:            cfg.Logger,
 	}

--- a/gestaltd/services/workflows/workflowmanager/manager_helpers.go
+++ b/gestaltd/services/workflows/workflowmanager/manager_helpers.go
@@ -15,6 +15,7 @@ func (m *Manager) catalogSelectorConfig() invocation.CatalogSelectorConfig {
 	return invocation.CatalogSelectorConfig{
 		Invoker:           m.invoker,
 		CatalogConnection: m.catalogConnection,
+		MCPConnection:     m.mcpConnection,
 		DefaultConnection: m.defaultConnection,
 	}
 }


### PR DESCRIPTION
Gestalt previously treated catalog connection selection as one concept, but composite providers like Notion expose two distinct surfaces: a REST/OpenAPI surface authenticated with OAuth, and an MCP surface authenticated with a separate MCP credential. Dynamic operations such as `get_page_content` are MCP-only, yet HTTP execution, agent tool resolution, and workflow app calls were discovering the session catalog using the API/OAuth connection. That caused MCP initialization to fail with the wrong token and return a generic 502 before POST-only validation could run.

This change splits routing into explicit surface-aware selectors. `CatalogConnection` now drives REST-visible catalog listing only, while a new `MCPConnection` map drives dynamic session/MCP operation resolution. The server, bootstrap wiring, agent manager, and workflow manager all pass both maps through `CatalogSelectorConfig`, and list-operations uses `APICatalogTargets` while execute paths use `SessionCatalogConnections`. When an MCP surface connection is configured for a provider, resolution uses that connection exclusively and does not fall back to OAuth after MCP auth failure. Static REST operations on composite providers continue to resolve from the static catalog without initializing MCP discovery, and MCP passthrough operations remain POST-only on the HTTP API. MCP upstream auth failures during catalog discovery are classified as `reconnect_required` rather than generic operation failures.

Made with [Cursor](https://cursor.com)