### PR TITLE
Expose count on ergonomic IndexedDB getAll across SDKs

### DIFF
--- a/sdk/go/indexeddb_transport_test.go
+++ b/sdk/go/indexeddb_transport_test.go
@@ -590,6 +590,75 @@ func TestTransport_IndexDelete(t *testing.T) {
 	}
 }
 
+func TestTransport_GetAllCount(t *testing.T) {
+	ctx := context.Background()
+	store := "getall_count_" + t.Name()
+	if _, err := testClient.CreateObjectStore(ctx, store, gestalt.ObjectStoreOptions{}); err != nil {
+		t.Fatalf("CreateObjectStore: %v", err)
+	}
+	s := testClient.ObjectStore(store)
+	for _, id := range []string{"a", "b", "c", "d", "e"} {
+		if err := s.Put(ctx, gestalt.Record{"id": id, "val": id}); err != nil {
+			t.Fatalf("Put %s: %v", id, err)
+		}
+	}
+
+	page, err := s.GetAll(ctx, nil, 2)
+	if err != nil {
+		t.Fatalf("GetAll count=2: %v", err)
+	}
+	if got := len(page); got != 2 {
+		t.Fatalf("GetAll page len = %d, want 2", got)
+	}
+	if page[0]["id"] != "a" || page[1]["id"] != "b" {
+		t.Fatalf("GetAll page ids = %v %v, want a b", page[0]["id"], page[1]["id"])
+	}
+
+	keys, err := s.GetAllKeys(ctx, nil, 3)
+	if err != nil {
+		t.Fatalf("GetAllKeys count=3: %v", err)
+	}
+	if len(keys) != 3 || keys[0] != "a" || keys[1] != "b" || keys[2] != "c" {
+		t.Fatalf("GetAllKeys = %v, want [a b c]", keys)
+	}
+
+	if _, err := testClient.CreateObjectStore(ctx, store+"_idx", gestalt.ObjectStoreOptions{
+		Indexes: []gestalt.IndexSchema{{Name: "by_status", KeyPath: []string{"status"}}},
+	}); err != nil {
+		t.Fatalf("CreateObjectStore indexed: %v", err)
+	}
+	idxStore := testClient.ObjectStore(store + "_idx")
+	for _, id := range []string{"a", "b", "c", "d"} {
+		if err := idxStore.Put(ctx, gestalt.Record{"id": id, "status": "active"}); err != nil {
+			t.Fatalf("Put indexed %s: %v", id, err)
+		}
+	}
+	if err := idxStore.Put(ctx, gestalt.Record{"id": "e", "status": "inactive"}); err != nil {
+		t.Fatalf("Put inactive: %v", err)
+	}
+
+	active, err := idxStore.Index("by_status").GetAll(ctx, "active", 2)
+	if err != nil {
+		t.Fatalf("Index GetAll count=2: %v", err)
+	}
+	if len(active) != 2 || active[0]["id"] != "a" || active[1]["id"] != "b" {
+		t.Fatalf("Index GetAll = %#v, want first two active rows", active)
+	}
+
+	tx, err := testClient.Transaction(ctx, []string{store}, gestalt.TransactionReadonly, gestalt.TransactionOptions{})
+	if err != nil {
+		t.Fatalf("Transaction: %v", err)
+	}
+	defer tx.Abort(ctx)
+	txPage, err := tx.ObjectStore(store).GetAll(ctx, nil, 2)
+	if err != nil {
+		t.Fatalf("tx GetAll count=2: %v", err)
+	}
+	if len(txPage) != 2 || txPage[0]["id"] != "a" || txPage[1]["id"] != "b" {
+		t.Fatalf("tx GetAll = %#v, want first two rows", txPage)
+	}
+}
+
 func TestTransport_TransactionReadwriteSerializesScope(t *testing.T) {
 	ctx := context.Background()
 	store := "tx_serialize_" + t.Name()

--- a/sdk/python/gestalt/_indexeddb.py
+++ b/sdk/python/gestalt/_indexeddb.py
@@ -135,10 +135,10 @@ class ObjectStoreProtocol(Protocol):
     def clear(self) -> None:
         """Delete every record in the store."""
 
-    def get_all(self, query: Query = None) -> list[dict[str, Any]]:
+    def get_all(self, query: Query = None, *, count: int | None = None) -> list[dict[str, Any]]:
         """Return all records that match ``query``."""
 
-    def get_all_keys(self, query: Query = None) -> list[str]:
+    def get_all_keys(self, query: Query = None, *, count: int | None = None) -> list[str]:
         """Return all primary keys that match ``query``."""
 
     def count(self, query: Query = None) -> int:
@@ -174,10 +174,10 @@ class IndexProtocol(Protocol):
     def get_key(self, query: Query = None) -> str:
         """Fetch the first matching primary key for ``query``."""
 
-    def get_all(self, query: Query = None) -> list[dict[str, Any]]:
+    def get_all(self, query: Query = None, *, count: int | None = None) -> list[dict[str, Any]]:
         """Return all records matching ``query``."""
 
-    def get_all_keys(self, query: Query = None) -> list[str]:
+    def get_all_keys(self, query: Query = None, *, count: int | None = None) -> list[str]:
         """Return all primary keys matching ``query``."""
 
     def count(self, query: Query = None) -> int:
@@ -238,10 +238,10 @@ class TransactionObjectStoreProtocol(Protocol):
     def clear(self) -> None:
         """Delete every record in the store."""
 
-    def get_all(self, query: Query = None) -> list[dict[str, Any]]:
+    def get_all(self, query: Query = None, *, count: int | None = None) -> list[dict[str, Any]]:
         """Return all records that match ``query``."""
 
-    def get_all_keys(self, query: Query = None) -> list[str]:
+    def get_all_keys(self, query: Query = None, *, count: int | None = None) -> list[str]:
         """Return all primary keys that match ``query``."""
 
     def count(self, query: Query = None) -> int:
@@ -263,10 +263,10 @@ class TransactionIndexProtocol(Protocol):
     def get_key(self, query: Query = None) -> str:
         """Fetch the first matching primary key for ``query``."""
 
-    def get_all(self, query: Query = None) -> list[dict[str, Any]]:
+    def get_all(self, query: Query = None, *, count: int | None = None) -> list[dict[str, Any]]:
         """Return all records matching ``query``."""
 
-    def get_all_keys(self, query: Query = None) -> list[str]:
+    def get_all_keys(self, query: Query = None, *, count: int | None = None) -> list[str]:
         """Return all primary keys matching ``query``."""
 
     def count(self, query: Query = None) -> int:
@@ -753,25 +753,21 @@ class ObjectStore:
 
         _grpc_call(self._stub.Clear, pb.ObjectStoreNameRequest(store=self._store))
 
-    def get_all(self, query: Query = None) -> list[dict[str, Any]]:
+    def get_all(self, query: Query = None, *, count: int | None = None) -> list[dict[str, Any]]:
         """Return all records that match ``query``."""
 
         resp = _grpc_call(
             self._stub.GetAll,
-            pb.ObjectStoreRangeRequest(
-                store=self._store, query=_query_to_proto(query)
-            ),
+            _object_store_range_request(self._store, query, count=count),
         )
         return [_record_to_dict(r) for r in resp.records]
 
-    def get_all_keys(self, query: Query = None) -> list[str]:
+    def get_all_keys(self, query: Query = None, *, count: int | None = None) -> list[str]:
         """Return all primary keys that match ``query``."""
 
         resp = _grpc_call(
             self._stub.GetAllKeys,
-            pb.ObjectStoreRangeRequest(
-                store=self._store, query=_query_to_proto(query)
-            ),
+            _object_store_range_request(self._store, query, count=count),
         )
         return list(resp.keys)
 
@@ -847,16 +843,16 @@ class Index:
         resp = _grpc_call(self._stub.IndexGetKey, self._req(query))
         return resp.key
 
-    def get_all(self, query: Query = None) -> list[dict[str, Any]]:
+    def get_all(self, query: Query = None, *, count: int | None = None) -> list[dict[str, Any]]:
         """Return all records matching ``query``."""
 
-        resp = _grpc_call(self._stub.IndexGetAll, self._req(query))
+        resp = _grpc_call(self._stub.IndexGetAll, self._req(query, count=count))
         return [_record_to_dict(r) for r in resp.records]
 
-    def get_all_keys(self, query: Query = None) -> list[str]:
+    def get_all_keys(self, query: Query = None, *, count: int | None = None) -> list[str]:
         """Return all primary keys matching ``query``."""
 
-        resp = _grpc_call(self._stub.IndexGetAllKeys, self._req(query))
+        resp = _grpc_call(self._stub.IndexGetAllKeys, self._req(query, count=count))
         return list(resp.keys)
 
     def count(self, query: Query = None) -> int:
@@ -908,12 +904,8 @@ class Index:
             index=self._index,
         )
 
-    def _req(self, query: Query = None) -> Any:
-        return pb.IndexQueryRequest(
-            store=self._store,
-            index=self._index,
-            query=_query_to_proto(query),
-        )
+    def _req(self, query: Query = None, *, count: int | None = None) -> Any:
+        return _index_query_request(self._store, self._index, query, count=count)
 
 
 class Transaction:
@@ -1099,22 +1091,18 @@ class TransactionObjectStore:
             pb.TransactionOperation(clear=pb.ObjectStoreNameRequest(store=self._store))
         )
 
-    def get_all(self, query: Query = None) -> list[dict[str, Any]]:
+    def get_all(self, query: Query = None, *, count: int | None = None) -> list[dict[str, Any]]:
         resp = self._tx._send_operation(
             pb.TransactionOperation(
-                get_all=pb.ObjectStoreRangeRequest(
-                    store=self._store, query=_query_to_proto(query)
-                )
+                get_all=_object_store_range_request(self._store, query, count=count)
             )
         )
         return [_record_to_dict(r) for r in resp.records.records]
 
-    def get_all_keys(self, query: Query = None) -> list[str]:
+    def get_all_keys(self, query: Query = None, *, count: int | None = None) -> list[str]:
         resp = self._tx._send_operation(
             pb.TransactionOperation(
-                get_all_keys=pb.ObjectStoreRangeRequest(
-                    store=self._store, query=_query_to_proto(query)
-                )
+                get_all_keys=_object_store_range_request(self._store, query, count=count)
             )
         )
         return list(resp.keys.keys)
@@ -1163,15 +1151,15 @@ class TransactionIndex:
         )
         return resp.key.key
 
-    def get_all(self, query: Query = None) -> list[dict[str, Any]]:
+    def get_all(self, query: Query = None, *, count: int | None = None) -> list[dict[str, Any]]:
         resp = self._tx._send_operation(
-            pb.TransactionOperation(index_get_all=self._req(query))
+            pb.TransactionOperation(index_get_all=self._req(query, count=count))
         )
         return [_record_to_dict(r) for r in resp.records.records]
 
-    def get_all_keys(self, query: Query = None) -> list[str]:
+    def get_all_keys(self, query: Query = None, *, count: int | None = None) -> list[str]:
         resp = self._tx._send_operation(
-            pb.TransactionOperation(index_get_all_keys=self._req(query))
+            pb.TransactionOperation(index_get_all_keys=self._req(query, count=count))
         )
         return list(resp.keys.keys)
 
@@ -1193,12 +1181,8 @@ class TransactionIndex:
         )
         return int(resp.delete.deleted)
 
-    def _req(self, query: Query = None) -> Any:
-        return pb.IndexQueryRequest(
-            store=self._store,
-            index=self._index,
-            query=_query_to_proto(query),
-        )
+    def _req(self, query: Query = None, *, count: int | None = None) -> Any:
+        return _index_query_request(self._store, self._index, query, count=count)
 
 
 class _RequestIterator:
@@ -1614,6 +1598,26 @@ def _query_to_proto(query: Query) -> Any:
     if isinstance(query, KeyRange):
         return pb.IndexedDBQuery(range=_kr_to_proto(query))
     return pb.IndexedDBQuery(key=_python_to_key_value(query))
+
+
+def _object_store_range_request(
+    store: str, query: Query = None, *, count: int | None = None
+) -> Any:
+    req = pb.ObjectStoreRangeRequest(store=store, query=_query_to_proto(query))
+    if count is not None:
+        req.count = count
+    return req
+
+
+def _index_query_request(
+    store: str, index: str, query: Query = None, *, count: int | None = None
+) -> Any:
+    req = pb.IndexQueryRequest(
+        store=store, index=index, query=_query_to_proto(query)
+    )
+    if count is not None:
+        req.count = count
+    return req
 
 
 def _query_from_proto(q: pb.IndexedDBQuery) -> Query:

--- a/sdk/python/tests/test_indexeddb_getall_count.py
+++ b/sdk/python/tests/test_indexeddb_getall_count.py
@@ -1,0 +1,38 @@
+"""Parity guards for IndexedDB getAll count forwarding."""
+
+from __future__ import annotations
+
+import inspect
+import unittest
+
+from gestalt._indexeddb import (
+    Index,
+    ObjectStore,
+    TransactionIndex,
+    TransactionObjectStore,
+)
+
+
+class TestGetAllCountSignature(unittest.TestCase):
+    def test_object_store_exposes_count_keyword(self) -> None:
+        for method in (ObjectStore.get_all, ObjectStore.get_all_keys):
+            params = inspect.signature(method).parameters
+            self.assertIn("count", params)
+            self.assertEqual(params["count"].kind, inspect.Parameter.KEYWORD_ONLY)
+
+    def test_index_exposes_count_keyword(self) -> None:
+        for method in (Index.get_all, Index.get_all_keys):
+            params = inspect.signature(method).parameters
+            self.assertIn("count", params)
+            self.assertEqual(params["count"].kind, inspect.Parameter.KEYWORD_ONLY)
+
+    def test_transaction_scoped_exposes_count_keyword(self) -> None:
+        for cls in (TransactionObjectStore, TransactionIndex):
+            for method in (cls.get_all, cls.get_all_keys):
+                params = inspect.signature(method).parameters
+                self.assertIn("count", params)
+                self.assertEqual(params["count"].kind, inspect.Parameter.KEYWORD_ONLY)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/python/tests/test_indexeddb_transport.py
+++ b/sdk/python/tests/test_indexeddb_transport.py
@@ -658,6 +658,52 @@ class TestIndexCompoundRange(unittest.TestCase):
         c.close()
 
 
+class TestGetAllCount(unittest.TestCase):
+    def test_object_store_get_all_and_get_all_keys_honor_count(self) -> None:
+        c = _client()
+        c.create_object_store("getall_count_store")
+        s = c.object_store("getall_count_store")
+        for row_id in ["a", "b", "c", "d", "e"]:
+            s.put({"id": row_id, "val": row_id})
+
+        page = s.get_all(count=2)
+        self.assertEqual([row["id"] for row in page], ["a", "b"])
+        key_page = s.get_all_keys(count=3)
+        self.assertEqual(key_page, ["a", "b", "c"])
+        self.assertEqual(len(s.get_all()), 5)
+        c.close()
+
+    def test_index_and_transaction_get_all_honor_count(self) -> None:
+        c = _client()
+        c.create_object_store(
+            "getall_count_index_tx",
+            ObjectStoreSchema(
+                indexes=[IndexSchema(name="by_status", key_path=["status"], unique=False)]
+            ),
+        )
+        s = c.object_store("getall_count_index_tx")
+        for row_id in ["a", "b", "c", "d"]:
+            s.put({"id": row_id, "status": "active"})
+        s.put({"id": "e", "status": "inactive"})
+
+        idx = s.index("by_status")
+        self.assertEqual(
+            [row["id"] for row in idx.get_all(query="active", count=2)],
+            ["a", "b"],
+        )
+        self.assertEqual(idx.get_all_keys(query="active", count=2), ["a", "b"])
+
+        tx = c.transaction(["getall_count_index_tx"], "readonly")
+        txs = tx.object_store("getall_count_index_tx")
+        self.assertEqual([row["id"] for row in txs.get_all(count=2)], ["a", "b"])
+        self.assertEqual(
+            txs.index("by_status").get_all_keys(query="active", count=2),
+            ["a", "b"],
+        )
+        tx.commit()
+        c.close()
+
+
 class TestErrorMapping(unittest.TestCase):
     def test_not_found(self) -> None:
         c = _client()

--- a/sdk/rust/tests/indexeddb_transport.rs
+++ b/sdk/rust/tests/indexeddb_transport.rs
@@ -278,6 +278,22 @@ async fn object_store_bulk_helpers() {
         .expect("get_all_keys");
     assert_eq!(all_keys, vec!["a", "b", "c", "d"]);
 
+    let paged = store
+        .get_all(Query::all(), Some(2))
+        .await
+        .expect("get_all with count");
+    let paged_ids: Vec<_> = paged
+        .iter()
+        .map(|record| record["id"].as_str().expect("id").to_string())
+        .collect();
+    assert_eq!(paged_ids, vec!["a", "b"]);
+
+    let paged_keys = store
+        .get_all_keys(Query::all(), Some(3))
+        .await
+        .expect("get_all_keys with count");
+    assert_eq!(paged_keys, vec!["a", "b", "c"]);
+
     let count = store.count(Query::all()).await.expect("count");
     assert_eq!(count, 4);
 

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -319,6 +319,7 @@ export {
   type IndexSchema,
   type ObjectStoreSchema,
   type OpenCursorOptions,
+  type GetAllOptions,
 } from "./providers/indexeddb.ts";
 export type { IndexedDBQuery as WireIndexedDBQuery, KeyValue } from "./indexeddb.ts";
 export {

--- a/sdk/typescript/src/providers/indexeddb.ts
+++ b/sdk/typescript/src/providers/indexeddb.ts
@@ -113,6 +113,13 @@ export interface OpenCursorOptions {
 }
 
 /**
+ * Optional parameters for W3C-aligned ranged getAll / getAllKeys reads.
+ */
+export type GetAllOptions = {
+  count?: number;
+};
+
+/**
  * Fakeable client contract for IndexedDB-compatible storage.
  */
 export interface IndexedDB {
@@ -140,8 +147,8 @@ export interface ObjectStore {
   put(record: Record): Promise<void>;
   delete(id: string): Promise<void>;
   clear(): Promise<void>;
-  getAll(query?: Key | KeyRange): Promise<Record[]>;
-  getAllKeys(query?: Key | KeyRange): Promise<string[]>;
+  getAll(query?: Key | KeyRange, options?: GetAllOptions): Promise<Record[]>;
+  getAllKeys(query?: Key | KeyRange, options?: GetAllOptions): Promise<string[]>;
   count(query?: Key | KeyRange): Promise<number>;
   deleteRange(query: Key | KeyRange): Promise<number>;
   openCursor(options?: OpenCursorOptions): Promise<Cursor | null>;
@@ -155,8 +162,8 @@ export interface ObjectStore {
 export interface Index {
   get(query?: Key | KeyRange): Promise<Record>;
   getKey(query?: Key | KeyRange): Promise<string>;
-  getAll(query?: Key | KeyRange): Promise<Record[]>;
-  getAllKeys(query?: Key | KeyRange): Promise<string[]>;
+  getAll(query?: Key | KeyRange, options?: GetAllOptions): Promise<Record[]>;
+  getAllKeys(query?: Key | KeyRange, options?: GetAllOptions): Promise<string[]>;
   count(query?: Key | KeyRange): Promise<number>;
   delete(query?: Key | KeyRange): Promise<number>;
   deleteRange(query: Key | KeyRange): Promise<number>;
@@ -183,8 +190,8 @@ export interface TransactionObjectStore {
   put(record: Record): Promise<void>;
   delete(id: string): Promise<void>;
   clear(): Promise<void>;
-  getAll(query?: Key | KeyRange): Promise<Record[]>;
-  getAllKeys(query?: Key | KeyRange): Promise<string[]>;
+  getAll(query?: Key | KeyRange, options?: GetAllOptions): Promise<Record[]>;
+  getAllKeys(query?: Key | KeyRange, options?: GetAllOptions): Promise<string[]>;
   count(query?: Key | KeyRange): Promise<number>;
   deleteRange(query: Key | KeyRange): Promise<number>;
   index(name: string): TransactionIndex;
@@ -196,8 +203,8 @@ export interface TransactionObjectStore {
 export interface TransactionIndex {
   get(query?: Key | KeyRange): Promise<Record>;
   getKey(query?: Key | KeyRange): Promise<string>;
-  getAll(query?: Key | KeyRange): Promise<Record[]>;
-  getAllKeys(query?: Key | KeyRange): Promise<string[]>;
+  getAll(query?: Key | KeyRange, options?: GetAllOptions): Promise<Record[]>;
+  getAllKeys(query?: Key | KeyRange, options?: GetAllOptions): Promise<string[]>;
   count(query?: Key | KeyRange): Promise<number>;
   delete(query?: Key | KeyRange): Promise<number>;
   deleteRange(query: Key | KeyRange): Promise<number>;
@@ -1402,12 +1409,13 @@ class TransactionObjectStoreImpl implements TransactionObjectStore {
   /**
    * Reads all records inside the transaction.
    */
-  async getAll(query?: Key | KeyRange): Promise<Record[]> {
+  async getAll(query?: Key | KeyRange, options?: GetAllOptions): Promise<Record[]> {
     const resp = await this.tx.sendOperation({
       case: "getAll" as const,
       value: {
         store: this.store,
         query: queryToWire(query),
+        ...(options?.count !== undefined ? { count: options.count } : {}),
       },
     });
     return resp.result.value.records.map((r: any) => fromProtoRecord(r));
@@ -1416,12 +1424,13 @@ class TransactionObjectStoreImpl implements TransactionObjectStore {
   /**
    * Reads all primary keys inside the transaction.
    */
-  async getAllKeys(query?: Key | KeyRange): Promise<string[]> {
+  async getAllKeys(query?: Key | KeyRange, options?: GetAllOptions): Promise<string[]> {
     const resp = await this.tx.sendOperation({
       case: "getAllKeys" as const,
       value: {
         store: this.store,
         query: queryToWire(query),
+        ...(options?.count !== undefined ? { count: options.count } : {}),
       },
     });
     return resp.result.value.keys;
@@ -1498,10 +1507,10 @@ class TransactionIndexImpl implements TransactionIndex {
   /**
    * Reads all indexed records inside the transaction.
    */
-  async getAll(query?: Key | KeyRange): Promise<Record[]> {
+  async getAll(query?: Key | KeyRange, options?: GetAllOptions): Promise<Record[]> {
     const resp = await this.tx.sendOperation({
       case: "indexGetAll" as const,
-      value: this.indexRequest(query),
+      value: this.indexRequest(query, options),
     });
     return resp.result.value.records.map((r: any) => fromProtoRecord(r));
   }
@@ -1509,10 +1518,10 @@ class TransactionIndexImpl implements TransactionIndex {
   /**
    * Reads all indexed primary keys inside the transaction.
    */
-  async getAllKeys(query?: Key | KeyRange): Promise<string[]> {
+  async getAllKeys(query?: Key | KeyRange, options?: GetAllOptions): Promise<string[]> {
     const resp = await this.tx.sendOperation({
       case: "indexGetAllKeys" as const,
-      value: this.indexRequest(query),
+      value: this.indexRequest(query, options),
     });
     return resp.result.value.keys;
   }
@@ -1550,11 +1559,12 @@ class TransactionIndexImpl implements TransactionIndex {
     return Number(resp.result.value.deleted);
   }
 
-  private indexRequest(query?: Key | KeyRange): any {
+  private indexRequest(query?: Key | KeyRange, options?: GetAllOptions): any {
     return {
       store: this.store,
       index: this.indexName,
       query: queryToWire(query),
+      ...(options?.count !== undefined ? { count: options.count } : {}),
     };
   }
 }
@@ -1622,10 +1632,11 @@ class ObjectStoreImpl implements ObjectStore {
   /**
    * Reads all records in the object store or within a key range.
    */
-  async getAll(query?: Key | KeyRange): Promise<Record[]> {
+  async getAll(query?: Key | KeyRange, options?: GetAllOptions): Promise<Record[]> {
     const resp = await this.client.getAll({
       store: this.store,
       query: queryToWire(query),
+      ...(options?.count !== undefined ? { count: options.count } : {}),
     });
     return resp.records.map((r) => fromProtoRecord(r));
   }
@@ -1633,10 +1644,11 @@ class ObjectStoreImpl implements ObjectStore {
   /**
    * Reads all primary keys in the object store or within a query.
    */
-  async getAllKeys(query?: Key | KeyRange): Promise<string[]> {
+  async getAllKeys(query?: Key | KeyRange, options?: GetAllOptions): Promise<string[]> {
     const resp = await this.client.getAllKeys({
       store: this.store,
       query: queryToWire(query),
+      ...(options?.count !== undefined ? { count: options.count } : {}),
     });
     return resp.keys;
   }
@@ -1732,11 +1744,12 @@ class IndexImpl implements Index {
   /**
    * Reads all records matching the supplied query.
    */
-  async getAll(query?: Key | KeyRange): Promise<Record[]> {
+  async getAll(query?: Key | KeyRange, options?: GetAllOptions): Promise<Record[]> {
     const resp = await this.client.indexGetAll({
       store: this.store,
       index: this.indexName,
       query: queryToWire(query),
+      ...(options?.count !== undefined ? { count: options.count } : {}),
     });
     return resp.records.map((r) => fromProtoRecord(r));
   }
@@ -1744,11 +1757,12 @@ class IndexImpl implements Index {
   /**
    * Reads all primary keys matching the supplied query.
    */
-  async getAllKeys(query?: Key | KeyRange): Promise<string[]> {
+  async getAllKeys(query?: Key | KeyRange, options?: GetAllOptions): Promise<string[]> {
     const resp = await this.client.indexGetAllKeys({
       store: this.store,
       index: this.indexName,
       query: queryToWire(query),
+      ...(options?.count !== undefined ? { count: options.count } : {}),
     });
     return resp.keys;
   }

--- a/sdk/typescript/tests/indexeddb-getall-count.test.ts
+++ b/sdk/typescript/tests/indexeddb-getall-count.test.ts
@@ -1,0 +1,11 @@
+import type { GetAllOptions, ObjectStore } from "../src/providers/indexeddb.ts";
+
+type ObjectStoreGetAllOptions = Parameters<ObjectStore["getAll"]>[1];
+type CountOptionAssignable = { count: number } extends GetAllOptions ? true : false;
+type WrapperOptionsMatchProto = { count?: number } extends ObjectStoreGetAllOptions ? true : false;
+
+const _assertCountOnGetAllOptions: CountOptionAssignable = true;
+const _assertWrapperOptions: WrapperOptionsMatchProto = true;
+
+void _assertCountOnGetAllOptions;
+void _assertWrapperOptions;

--- a/sdk/typescript/tests/indexeddb.transport.test.ts
+++ b/sdk/typescript/tests/indexeddb.transport.test.ts
@@ -578,6 +578,54 @@ describe("IndexedDB transport", () => {
     await expect(local.createObjectStore("dupe")).rejects.toThrow(AlreadyExistsError);
   });
 
+  test("getAll count limits object-store range reads", async () => {
+    const store = "getall_count_object_store";
+    await db.createObjectStore(store);
+    const os = db.objectStore(store);
+
+    for (const id of ["a", "b", "c", "d", "e"]) {
+      await os.put({ id, val: id });
+    }
+
+    const page = await os.getAll(undefined, { count: 2 });
+    expect(page.map((record) => record.id)).toEqual(["a", "b"]);
+
+    const keyPage = await os.getAllKeys(undefined, { count: 3 });
+    expect(keyPage).toEqual(["a", "b", "c"]);
+
+    const full = await os.getAll();
+    expect(full).toHaveLength(5);
+  });
+
+  test("getAll count limits index and transaction reads", async () => {
+    const store = "getall_count_index_tx";
+    await db.createObjectStore(store, {
+      indexes: [{ name: "by_status", keyPath: ["status"] }],
+    });
+    const os = db.objectStore(store);
+    const idx = os.index("by_status");
+
+    for (const id of ["a", "b", "c", "d"]) {
+      await os.put({ id, status: "active" });
+    }
+    await os.put({ id: "e", status: "inactive" });
+
+    expect((await idx.getAll("active", { count: 2 })).map((record) => record.id)).toEqual([
+      "a",
+      "b",
+    ]);
+    expect(await idx.getAllKeys("active", { count: 2 })).toEqual(["a", "b"]);
+
+    const tx = await db.transaction([store], "readonly");
+    const txos = tx.objectStore(store);
+    expect((await txos.getAll(undefined, { count: 2 })).map((record) => record.id)).toEqual([
+      "a",
+      "b",
+    ]);
+    expect(await txos.index("by_status").getAllKeys("active", { count: 2 })).toEqual(["a", "b"]);
+    await tx.commit();
+  });
+
   test("query parity: scalar key and bound range on object store", async () => {
     const store = "query_parity_scalar";
     await db.createObjectStore(store);


### PR DESCRIPTION
## Summary
- Thread optional `count` through TypeScript `getAll` / `getAllKeys` on object stores, indexes, and transaction-scoped variants (`store.getAll(range, { count })`), exporting `GetAllOptions` from `@valon-technologies/gestalt`.
- Add keyword-only `count` to the Python hand-written wrapper (`get_all(..., count=...)`) with shared request builders for object-store and index reads.
- Add behavioral drift-guard tests in TypeScript, Python, Go, and Rust transport suites, plus TypeScript type-level and Python `inspect.signature` parity checks. Go and Rust already forwarded count on the generated/provider surfaces; tests lock that in.

## Test plan
- [x] `cd sdk/typescript && bun run typecheck`
- [x] `cd sdk/typescript && bun test tests/indexeddb-getall-count.test.ts tests/indexeddb.transport.test.ts --test-name-pattern "getAll count"`
- [x] `cd sdk/python && uv run python -m unittest tests.test_indexeddb_getall_count tests.test_indexeddb_transport.TestGetAllCount`
- [x] `cd sdk/go && go test -run TestTransport_GetAllCount ./...`
- [x] `cd sdk/rust && cargo test object_store_bulk_helpers`

## Follow-up (after SDK release)
- Tag and publish `sdk/typescript/v<next-alpha>` (and Python parity tag).
- Bump `@valon-technologies/gestalt` in `toolshed` `valon-tools/apps/ai-spend-tracker` and simplify PR #2667 to use `store.getAll(range, { count })` without wire/proto bypass glue.

Made with [Cursor](https://cursor.com)