### PR TITLE
Bump Gestalt CLI to 0.0.2-alpha.5

### DIFF
--- a/gestalt/Cargo.toml
+++ b/gestalt/Cargo.toml
@@ -3,5 +3,5 @@ resolver = "2"
 members = ["cli"]
 
 [workspace.package]
-version = "0.0.2-alpha.4"
+version = "0.0.2-alpha.5"
 edition = "2024"


### PR DESCRIPTION
## Summary

Bumps the Gestalt CLI workspace version to `0.0.2-alpha.5` so the `gestalt/v0.0.2-alpha.5` release tag can pass the release workflow version guard.

This release is needed for the auth grant migration rollout because the CLI token UX changed: `gestalt tokens create` now requires scopes, and token listing displays grant IDs, scopes, and RFC3339 timestamps.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p gestalt`
