### PR TITLE
Pass host services to authentication providers

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -185,7 +185,7 @@ type Deps struct {
 	hostedAgentPoolClock hostedAgentPoolClock
 }
 
-type AuthFactory func(node yaml.Node, deps Deps) (core.AuthenticationProvider, error)
+type AuthFactory func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps Deps) (core.AuthenticationProvider, error)
 type AuthorizationFactory func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps Deps) (providerdrivers.AuthorizationBuildResult, error)
 type ExternalCredentialFactory func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps Deps) (core.ExternalCredentialProvider, error)
 type SecretManagerFactory func(node yaml.Node) (core.SecretManager, error)
@@ -869,12 +869,6 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	}
 	deps.AgentRuntime = agentRuntime
 
-	selectedAuthName, authProviders, err := buildAuthProviders(cfg, factories, deps)
-	if err != nil {
-		return nil, err
-	}
-	auth := authProviders[selectedAuthName]
-
 	selectedIndexedDBName, def, err := cfg.SelectedIndexedDBProvider()
 	if err != nil {
 		return nil, err
@@ -967,6 +961,13 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	deps.SelectedIndexedDBName = selectedIndexedDBName
 	deps.Caches = hostCaches
 	deps.S3 = hostS3s
+
+	selectedAuthName, authProviders, err := buildAuthProviders(cfg, factories, deps)
+	if err != nil {
+		return nil, err
+	}
+	auth := authProviders[selectedAuthName]
+
 	callerTokenPrivateKey, err := resolveCallerTokenPrivateKey(ctx, sm)
 	if err != nil {
 		_ = closeAuthProviders(authProviders)
@@ -1845,7 +1846,11 @@ func buildNamedAuthProvider(name string, authEntry *config.ProviderEntry, factor
 			return nil, fmt.Errorf("bootstrap: authentication provider %q: %w", name, err)
 		}
 	}
-	auth, err := factories.Auth(node, deps)
+	hostServices, err := buildProviderHostServices(name, deps)
+	if err != nil {
+		return nil, fmt.Errorf("bootstrap: authentication provider %q: %w", name, err)
+	}
+	auth, err := factories.Auth(context.Background(), name, node, hostServices, deps)
 	if err != nil {
 		return nil, fmt.Errorf("bootstrap: authentication provider %q: %w", name, err)
 	}

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -82,7 +82,7 @@ func bootstrapAgentRequestContext(t testing.TB, p *principal.Principal, callerNa
 }
 
 func stubAuthFactory(name string) bootstrap.AuthFactory {
-	return func(yaml.Node, bootstrap.Deps) (core.AuthenticationProvider, error) {
+	return func(context.Context, string, yaml.Node, []runtimehost.HostService, bootstrap.Deps) (core.AuthenticationProvider, error) {
 		return &coretesting.StubAuthProvider{N: name}, nil
 	}
 }
@@ -3573,6 +3573,37 @@ func TestBootstrapRoutesExternalCredentialsIndexedDBHostServices(t *testing.T) {
 	})
 }
 
+func TestBootstrapRoutesAuthenticationIndexedDBHostServices(t *testing.T) {
+	t.Parallel()
+
+	cfg := validConfig()
+	cfg.Server.Providers.Authentication = "default"
+
+	factories := validFactories()
+	var hostServices []runtimehost.HostService
+	factories.Auth = func(_ context.Context, _ string, _ yaml.Node, services []runtimehost.HostService, _ bootstrap.Deps) (core.AuthenticationProvider, error) {
+		hostServices = append([]runtimehost.HostService(nil), services...)
+		return &coretesting.StubAuthProvider{N: "test-auth"}, nil
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	indexedDBService := requireHostService(t, hostServices, "indexeddb")
+	withIndexedDBHostClient(t, indexedDBService, func(client proto.IndexedDBClient) {
+		if _, err := client.CreateObjectStore(context.Background(), &proto.CreateObjectStoreRequest{
+			Name:   "authentication_grants",
+			Schema: &proto.ObjectStoreSchema{},
+		}); err != nil {
+			t.Fatalf("CreateObjectStore(authentication_grants): %v", err)
+		}
+	})
+}
+
 func TestBootstrapRoutesWorkflowIndexedDBHostServices(t *testing.T) {
 	t.Parallel()
 
@@ -4893,7 +4924,7 @@ func TestResultCloseClosesAuthProvider(t *testing.T) {
 
 	closed := &atomic.Bool{}
 	factories := validFactories()
-	factories.Auth = func(yaml.Node, bootstrap.Deps) (core.AuthenticationProvider, error) {
+	factories.Auth = func(context.Context, string, yaml.Node, []runtimehost.HostService, bootstrap.Deps) (core.AuthenticationProvider, error) {
 		return &closableAuthProvider{
 			StubAuthProvider: &coretesting.StubAuthProvider{N: "test-auth"},
 			closed:           closed,
@@ -5355,7 +5386,7 @@ func TestBootstrap_ReusesPreparedComponentRuntimeConfig(t *testing.T) {
 
 	var gotAuthNode yaml.Node
 	factories := validFactories()
-	factories.Auth = func(node yaml.Node, deps bootstrap.Deps) (core.AuthenticationProvider, error) {
+	factories.Auth = func(_ context.Context, _ string, node yaml.Node, _ []runtimehost.HostService, deps bootstrap.Deps) (core.AuthenticationProvider, error) {
 		gotAuthNode = node
 		return &coretesting.StubAuthProvider{N: "test-auth"}, nil
 	}
@@ -5394,7 +5425,7 @@ func TestBootstrapFactoryError(t *testing.T) {
 		{
 			name: "auth factory error",
 			mutate: func(f *bootstrap.FactoryRegistry) {
-				f.Auth = func(yaml.Node, bootstrap.Deps) (core.AuthenticationProvider, error) {
+				f.Auth = func(context.Context, string, yaml.Node, []runtimehost.HostService, bootstrap.Deps) (core.AuthenticationProvider, error) {
 					return nil, fmt.Errorf("auth broke")
 				}
 			},
@@ -5447,7 +5478,7 @@ func TestBootstrapEncryptionKeyDerivation(t *testing.T) {
 
 		var receivedKey []byte
 		factories := validFactories()
-		factories.Auth = func(_ yaml.Node, deps bootstrap.Deps) (core.AuthenticationProvider, error) {
+		factories.Auth = func(_ context.Context, _ string, _ yaml.Node, _ []runtimehost.HostService, deps bootstrap.Deps) (core.AuthenticationProvider, error) {
 			receivedKey = deps.EncryptionKey
 			return &coretesting.StubAuthProvider{N: "test-auth"}, nil
 		}
@@ -5476,7 +5507,7 @@ func TestBootstrapEncryptionKeyDerivation(t *testing.T) {
 
 		var receivedKey []byte
 		factories := validFactories()
-		factories.Auth = func(_ yaml.Node, deps bootstrap.Deps) (core.AuthenticationProvider, error) {
+		factories.Auth = func(_ context.Context, _ string, _ yaml.Node, _ []runtimehost.HostService, deps bootstrap.Deps) (core.AuthenticationProvider, error) {
 			receivedKey = deps.EncryptionKey
 			return &coretesting.StubAuthProvider{N: "test-auth"}, nil
 		}
@@ -5500,7 +5531,7 @@ func TestBootstrapEncryptionKeyDerivation(t *testing.T) {
 		var keys [][]byte
 		for i := 0; i < 2; i++ {
 			factories := validFactories()
-			factories.Auth = func(_ yaml.Node, deps bootstrap.Deps) (core.AuthenticationProvider, error) {
+			factories.Auth = func(_ context.Context, _ string, _ yaml.Node, _ []runtimehost.HostService, deps bootstrap.Deps) (core.AuthenticationProvider, error) {
 				keys = append(keys, deps.EncryptionKey)
 				return &coretesting.StubAuthProvider{N: "test-auth"}, nil
 			}
@@ -5532,7 +5563,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 				Secrets: map[string]string{"enc-key": "resolved-passphrase"},
 			}, nil
 		}
-		factories.Auth = func(_ yaml.Node, deps bootstrap.Deps) (core.AuthenticationProvider, error) {
+		factories.Auth = func(_ context.Context, _ string, _ yaml.Node, _ []runtimehost.HostService, deps bootstrap.Deps) (core.AuthenticationProvider, error) {
 			receivedKey = deps.EncryptionKey
 			return &coretesting.StubAuthProvider{N: "test-auth"}, nil
 		}
@@ -5614,7 +5645,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		}
 
 		var receivedNode yaml.Node
-		factories.Auth = func(node yaml.Node, _ bootstrap.Deps) (core.AuthenticationProvider, error) {
+		factories.Auth = func(_ context.Context, _ string, node yaml.Node, _ []runtimehost.HostService, _ bootstrap.Deps) (core.AuthenticationProvider, error) {
 			receivedNode = node
 			return &coretesting.StubAuthProvider{N: "test-auth"}, nil
 		}
@@ -5925,7 +5956,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 
 		var authNode yaml.Node
 		factories := validFactories()
-		factories.Auth = func(node yaml.Node, _ bootstrap.Deps) (core.AuthenticationProvider, error) {
+		factories.Auth = func(_ context.Context, _ string, node yaml.Node, _ []runtimehost.HostService, _ bootstrap.Deps) (core.AuthenticationProvider, error) {
 			authNode = node
 			return &coretesting.StubAuthProvider{N: "test-auth"}, nil
 		}
@@ -5960,7 +5991,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 
 		var authFactoryCalled atomic.Bool
 		factories := validFactories()
-		factories.Auth = func(yaml.Node, bootstrap.Deps) (core.AuthenticationProvider, error) {
+		factories.Auth = func(context.Context, string, yaml.Node, []runtimehost.HostService, bootstrap.Deps) (core.AuthenticationProvider, error) {
 			authFactoryCalled.Store(true)
 			return &coretesting.StubAuthProvider{N: "unexpected"}, nil
 		}

--- a/gestaltd/internal/daemon/factories.go
+++ b/gestaltd/internal/daemon/factories.go
@@ -119,7 +119,7 @@ func buildFactories() *bootstrap.FactoryRegistry {
 			return nil, nil, fmt.Errorf("unknown audit provider %q", cfg.Source.Builtin)
 		}
 	}
-	factories.Auth = func(node yaml.Node, deps bootstrap.Deps) (core.AuthenticationProvider, error) {
+	factories.Auth = func(_ context.Context, _ string, node yaml.Node, hostServices []runtimehost.HostService, deps bootstrap.Deps) (core.AuthenticationProvider, error) {
 		defaultCallbackURL := ""
 		if deps.BaseURL != "" {
 			defaultCallbackURL = deps.BaseURL + config.AuthCallbackPath
@@ -127,6 +127,7 @@ func buildFactories() *bootstrap.FactoryRegistry {
 		return providerdrivers.AuthenticationFactory(node, providerdrivers.AuthenticationDeps{
 			DefaultCallbackURL: defaultCallbackURL,
 			SessionKey:         deps.EncryptionKey,
+			HostServices:       hostServices,
 		})
 	}
 	factories.Authorization = func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps bootstrap.Deps) (providerdrivers.AuthorizationBuildResult, error) {

--- a/gestaltd/services/authentication/client.go
+++ b/gestaltd/services/authentication/client.go
@@ -25,16 +25,17 @@ type authenticationRPCClient interface {
 }
 
 type ExecConfig struct {
-	Command     string
-	Args        []string
-	Workdir     string
-	Env         map[string]string
-	Config      map[string]any
-	Egress      egress.Policy
-	HostBinary  string
-	Cleanup     func()
-	Name        string
-	CallbackURL string
+	Command      string
+	Args         []string
+	Workdir      string
+	Env          map[string]string
+	Config       map[string]any
+	Egress       egress.Policy
+	HostBinary   string
+	Cleanup      func()
+	HostServices []runtimehost.HostService
+	Name         string
+	CallbackURL  string
 }
 
 type remoteAuthenticationProvider struct {
@@ -56,6 +57,7 @@ func NewExecutable(ctx context.Context, cfg ExecConfig) (core.AuthenticationProv
 		Egress:       cfg.Egress,
 		HostBinary:   cfg.HostBinary,
 		Cleanup:      cfg.Cleanup,
+		HostServices: cfg.HostServices,
 		ProviderName: cfg.Name,
 	})
 	if err != nil {

--- a/gestaltd/services/providerdrivers/authentication.go
+++ b/gestaltd/services/providerdrivers/authentication.go
@@ -37,15 +37,16 @@ func AuthenticationFactory(node yaml.Node, deps AuthenticationDeps) (core.Authen
 		callbackURL = deps.DefaultCallbackURL
 	}
 	return authenticationservice.NewExecutable(context.Background(), authenticationservice.ExecConfig{
-		Command:     cfg.Command,
-		Args:        cfg.Args,
-		Workdir:     cfg.Workdir,
-		Env:         cfg.Env,
-		Config:      cfg.Config,
-		Egress:      cfg.EgressPolicy(""),
-		HostBinary:  cfg.HostBinary,
-		Cleanup:     prepared.Cleanup,
-		Name:        cfg.Name,
-		CallbackURL: callbackURL,
+		Command:      cfg.Command,
+		Args:         cfg.Args,
+		Workdir:      cfg.Workdir,
+		Env:          cfg.Env,
+		Config:       cfg.Config,
+		Egress:       cfg.EgressPolicy(""),
+		HostBinary:   cfg.HostBinary,
+		Cleanup:      prepared.Cleanup,
+		HostServices: deps.HostServices,
+		Name:         cfg.Name,
+		CallbackURL:  callbackURL,
 	})
 }

--- a/gestaltd/services/providerdrivers/deps.go
+++ b/gestaltd/services/providerdrivers/deps.go
@@ -8,6 +8,7 @@ import (
 type AuthenticationDeps struct {
 	DefaultCallbackURL string
 	SessionKey         []byte
+	HostServices       []runtimehost.HostService
 }
 
 type WorkflowDeps struct {

--- a/gestaltd/services/providerdrivers/runtime_deps_contract_test.go
+++ b/gestaltd/services/providerdrivers/runtime_deps_contract_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/apps/providerpkg"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
+	"google.golang.org/grpc"
 	"gopkg.in/yaml.v3"
 )
 
@@ -25,6 +27,11 @@ func TestAuthenticationFactoryForwardsRuntimeDepsToExecutableProvider(t *testing
 	authManifest := componentProviderManifestPath(t, setupGoContractProviderDir(t, dir, providermanifestv1.KindAuthentication, "local", authContractProviderSource(callbackURL)))
 	auth, err := AuthenticationFactory(contractRuntimeNode(t, "local", authManifest), AuthenticationDeps{
 		DefaultCallbackURL: callbackURL,
+		HostServices: []runtimehost.HostService{{
+			Name: "test",
+			Register: func(*grpc.Server) {
+			},
+		}},
 	})
 	if err != nil {
 		t.Fatalf("AuthenticationFactory: %v", err)
@@ -158,6 +165,10 @@ func closeProviderIfSupported(t *testing.T, provider any) {
 
 func authContractProviderSource(wantCallbackURL string) string {
 	source := testutil.GeneratedAuthPackageSource()
+	source = strings.Replace(source, `"net/url"
+	"strings"`, `"net/url"
+	"os"
+	"strings"`, 1)
 	source = strings.Replace(source, `func (p *Provider) Authorize(_ context.Context, req *gestalt.AuthorizeRequest) (*gestalt.AuthorizeResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("authorize request is required")
@@ -172,6 +183,9 @@ func authContractProviderSource(wantCallbackURL string) string {
 	redirectURI := strings.TrimSpace(req.RedirectURI)
 	if redirectURI == "" {
 		return nil, fmt.Errorf("redirect_uri is required")
+	}
+	if os.Getenv("GESTALT_HOST_SERVICE_SOCKET") == "" {
+		return nil, fmt.Errorf("GESTALT_HOST_SERVICE_SOCKET is not set")
 	}
 	if redirectURI != %q {
 		return nil, fmt.Errorf("redirect_uri = %%q, want %%q", redirectURI, %q)


### PR DESCRIPTION
Executable authentication providers can now use provider host services such as IndexedDB during startup. This is needed by the OIDC authentication provider after the OAuth grant migration because it opens its provider-owned grant store during Configure.

This changes boot order so shared IndexedDB/cache/S3 deps are available before authentication providers are constructed, forwards per-provider host services through the authentication driver, and adds coverage that authentication providers receive and can use the IndexedDB host service.

Tests:
- go test ./internal/bootstrap -count=1
- go test ./services/providerdrivers ./services/authentication -count=1
- go test ./internal/daemon -count=1