### PR TITLE
Fix CLI login callback state exchange

### DIFF
--- a/gestaltd/internal/server/handlers_auth.go
+++ b/gestaltd/internal/server/handlers_auth.go
@@ -427,7 +427,7 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 		Code:        code,
 		RedirectURI: redirectURI,
 		ClientID:    core.DefaultOAuthClientID,
-		State:       originalState,
+		State:       loginState.State,
 	})
 	if err != nil || tokenResp == nil || strings.TrimSpace(tokenResp.AccessToken) == "" {
 		auditErr = errors.New("login failed")

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -8561,8 +8561,20 @@ func TestLoginCallbackForCLIWithCallbackPortStrippedState(t *testing.T) {
 
 	svc := testutil.NewStubServices(t)
 	_ = seedUser(t, svc, "host@example.com")
+	auth := newHostIssuedSessionAuthStub([]byte("host-issued-secret"), hostIssuedSessionAuthOpts{})
+	baseTokenFn := auth.TokenFn
+	var gotAuthorizationCodeState string
+	auth.TokenFn = func(ctx context.Context, req *core.TokenRequest) (*core.TokenResponse, error) {
+		if req != nil && req.GrantType == core.GrantTypeAuthorizationCode {
+			gotAuthorizationCodeState = req.State
+			if req.State != "cli:54305:test-state" {
+				return nil, fmt.Errorf("authorization code state = %q, want prefixed CLI state", req.State)
+			}
+		}
+		return baseTokenFn(ctx, req)
+	}
 	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.Auth = newHostIssuedSessionAuthStub([]byte("host-issued-secret"), hostIssuedSessionAuthOpts{})
+		cfg.Auth = auth
 		cfg.Services = svc
 	})
 	testutil.CloseOnCleanup(t, ts)
@@ -8596,6 +8608,9 @@ func TestLoginCallbackForCLIWithCallbackPortStrippedState(t *testing.T) {
 	}
 	if result["token"] == "" {
 		t.Fatal("expected token in CLI login response")
+	}
+	if gotAuthorizationCodeState != "cli:54305:test-state" {
+		t.Fatalf("authorization code state = %q, want prefixed CLI state", gotAuthorizationCodeState)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes CLI browser login after the OAuth grant migration by redeeming authorization codes with the original provider state from the login-state cookie. The CLI callback still validates the stripped local state, but the authentication provider now receives the same state that was sent during authorize, which is required by OIDC PKCE-backed providers.

## Testing

- `go test ./internal/server -run 'TestLoginCallback|TestStartLogin|TestCreate.*APIToken|TestListAPITokens|TestRevoke.*APIToken|TestMCP.*OAuth|TestOAuth'`

## Notes

Observed production `gestalt auth login` callbacks returning `401` for `cli=1` after the browser redirect reached the local CLI. The failing request shape matches the stripped-state CLI exchange path.