### PR TITLE
Add GET /api/v1/auth/session for browser session display

### DIFF
--- a/gestaltd/internal/server/handlers_auth.go
+++ b/gestaltd/internal/server/handlers_auth.go
@@ -34,6 +34,45 @@ type authInfoFeaturesResponse struct {
 	Agent bool `json:"agent"`
 }
 
+type authSessionResponse struct {
+	SubjectID   string `json:"subjectId"`
+	Email       string `json:"email,omitempty"`
+	DisplayName string `json:"displayName,omitempty"`
+}
+
+func (s *Server) authSession(w http.ResponseWriter, r *http.Request) {
+	p := principal.Canonicalized(PrincipalFromContext(r.Context()))
+	subjectID := ""
+	if p != nil {
+		subjectID = strings.TrimSpace(p.SubjectID)
+	}
+	if subjectID == "" && p != nil {
+		subjectID = strings.TrimSpace(principal.EffectiveCredentialSubjectID(p))
+	}
+	if subjectID == "" && p != nil && p.Identity != nil {
+		if email := strings.TrimSpace(p.Identity.Email); email != "" {
+			subjectID = principal.UserSubjectID(email)
+		}
+	}
+	if subjectID == "" {
+		writeError(w, http.StatusUnauthorized, "missing authenticated session")
+		return
+	}
+
+	resp := authSessionResponse{
+		SubjectID: subjectID,
+	}
+	if p != nil && p.Identity != nil {
+		resp.Email = strings.TrimSpace(p.Identity.Email)
+		resp.DisplayName = strings.TrimSpace(p.Identity.DisplayName)
+	}
+	if resp.DisplayName == "" && p != nil {
+		resp.DisplayName = strings.TrimSpace(p.DisplayName)
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
 func (s *Server) authProviderName() string {
 	if s.serverAuthProvider != "" {
 		return s.serverAuthProvider

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -46,6 +46,7 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 			r.Post("/{turnID}/interactions/{interactionID}/resolve", s.resolveAgentInteraction)
 		})
 
+		r.Get("/auth/session", s.authSession)
 		r.Post("/auth/start-oauth", s.startIntegrationOAuth)
 		r.Post("/auth/connect-manual", s.connectManual)
 

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -8386,6 +8386,35 @@ func TestLoginCallback(t *testing.T) {
 	if _, ok := auditRecord["user_id"]; ok {
 		t.Fatalf("expected emitted audit record to omit user_id, got %v", auditRecord["user_id"])
 	}
+
+	sessionResp, err := client.Get(ts.URL + "/api/v1/auth/session")
+	if err != nil {
+		t.Fatalf("GET /api/v1/auth/session: %v", err)
+	}
+	defer func() { _ = sessionResp.Body.Close() }()
+	if sessionResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected session 200, got %d", sessionResp.StatusCode)
+	}
+	var sessionBody map[string]any
+	if err := json.NewDecoder(sessionResp.Body).Decode(&sessionBody); err != nil {
+		t.Fatalf("decoding session: %v", err)
+	}
+	subjectID, _ := sessionBody["subjectId"].(string)
+	if strings.TrimSpace(subjectID) == "" {
+		t.Fatalf("expected non-empty subjectId, got %v", sessionBody["subjectId"])
+	}
+	if sessionBody["email"] != "user@example.com" {
+		t.Fatalf("expected email user@example.com, got %v", sessionBody["email"])
+	}
+	if displayName, ok := sessionBody["displayName"].(string); ok && displayName != "" && displayName != "User" {
+		t.Fatalf("unexpected displayName %q", displayName)
+	}
+	if _, ok := sessionBody["credentialSubjectId"]; ok {
+		t.Fatalf("expected session response to omit credentialSubjectId, got %v", sessionBody["credentialSubjectId"])
+	}
+	if _, ok := sessionBody["kind"]; ok {
+		t.Fatalf("expected session response to omit kind, got %v", sessionBody["kind"])
+	}
 }
 
 func TestLoginCallback_MissingPluginRouteAuthProviderAuditsAttemptedProvider(t *testing.T) {
@@ -10759,6 +10788,30 @@ func TestAuthInfoNoAuth(t *testing.T) {
 		t.Fatalf("expected loginSupported false, got %#v", body["loginSupported"])
 	}
 	requireAuthInfoAgentFeature(t, body, false)
+
+	sessionResp, err := http.Get(ts.URL + "/api/v1/auth/session")
+	if err != nil {
+		t.Fatalf("GET /api/v1/auth/session: %v", err)
+	}
+	defer func() { _ = sessionResp.Body.Close() }()
+	if sessionResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected session 200, got %d", sessionResp.StatusCode)
+	}
+	var sessionBody map[string]any
+	if err := json.NewDecoder(sessionResp.Body).Decode(&sessionBody); err != nil {
+		t.Fatalf("decoding session: %v", err)
+	}
+	subjectID, _ := sessionBody["subjectId"].(string)
+	email, _ := sessionBody["email"].(string)
+	if strings.TrimSpace(subjectID) == "" && strings.TrimSpace(email) != "anonymous@gestalt" {
+		t.Fatalf("expected non-empty subjectId or anonymous@gestalt email, got %#v", sessionBody)
+	}
+	if _, ok := sessionBody["credentialSubjectId"]; ok {
+		t.Fatalf("expected session response to omit credentialSubjectId, got %v", sessionBody["credentialSubjectId"])
+	}
+	if _, ok := sessionBody["kind"]; ok {
+		t.Fatalf("expected session response to omit kind, got %v", sessionBody["kind"])
+	}
 }
 
 func TestAuthInfoAgentFeature(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add authenticated `GET /api/v1/auth/session` returning `subjectId` plus optional `email` and `displayName`.
- Resolve the principal from existing `authMiddleware` without parsing cookies or calling provider introspect directly.
- Extend `TestLoginCallback` and `TestAuthInfoNoAuth` to cover the new endpoint contract.

## Test plan
- [x] `go test ./internal/server -run 'TestLoginCallback$|TestAuthInfoNoAuth'`
- [ ] Merge gestalt-providers UI PR that consumes this endpoint
- [ ] Verify browser login shows display name/email instead of `undefined`


Made with [Cursor](https://cursor.com)