### PR TITLE
Make personal API token scopes optional

### DIFF
--- a/gestaltd/internal/server/handlers_tokens.go
+++ b/gestaltd/internal/server/handlers_tokens.go
@@ -19,10 +19,10 @@ func (s *Server) validateCreateGrantRequest(req createTokenRequest) (string, err
 	if strings.TrimSpace(req.Name) == "" {
 		return "", errors.New("name is required")
 	}
+	// Scopes are optional: an empty scope mints a grant that inherits the
+	// caller's full scope (token-exchange attenuation), i.e. a token that acts
+	// as the signed-in identity. Provided scopes must reference a known app.
 	scope := strings.TrimSpace(req.Scopes)
-	if scope == "" {
-		return "", errors.New("scopes are required")
-	}
 	for _, part := range strings.Fields(scope) {
 		appName, _, _ := strings.Cut(part, ":")
 		if _, err := s.providers.Get(appName); err != nil {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -9563,7 +9563,7 @@ func TestCreateAndListAPITokens(t *testing.T) {
 	}
 }
 
-func TestCreateAPITokenRejectsEmptyScopes(t *testing.T) {
+func TestCreateAPITokenAllowsEmptyScopes(t *testing.T) {
 	t.Parallel()
 
 	ts := newTestServer(t, func(cfg *server.Config) {
@@ -9586,11 +9586,25 @@ func TestCreateAPITokenRejectsEmptyScopes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read create response: %v", err)
 	}
-	if resp.StatusCode != http.StatusBadRequest {
-		t.Fatalf("create status = %d, want 400: %s", resp.StatusCode, respBody)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create status = %d, want 201: %s", resp.StatusCode, respBody)
 	}
-	if !strings.Contains(string(respBody), "scopes are required") {
-		t.Fatalf("create response = %s, want scopes are required error", respBody)
+	var result struct {
+		ID     string   `json:"id"`
+		Token  string   `json:"token"`
+		Scopes []string `json:"scopes"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if result.Token == "" {
+		t.Fatalf("expected token in response, got empty: %s", respBody)
+	}
+	if result.ID == "" {
+		t.Fatalf("expected grant id in response, got empty: %s", respBody)
+	}
+	if len(result.Scopes) != 0 {
+		t.Fatalf("expected empty scopes for full-identity token, got %v", result.Scopes)
 	}
 }
 


### PR DESCRIPTION
## Problem
Creating a personal API token (`POST /api/v1/tokens`) requires a non-empty `scopes` field and rejects anything else with 400. #2460 added `if scope == "" { return "scopes are required" }`, contradicting the UI ("these act as your signed-in identity") and the authorization model.

## Why scopes can be optional
An empty scope is the full-identity case: `AllowsProviderPermission`/`AllowsOperationPermission` treat a principal with no scopes as allow-all, and token-exchange `attenuateScope` returns the caller's full scope when the request scope is empty. So an empty scope mints a grant that inherits the caller's identity.

## Change
Drop the mandatory-scope check in `validateCreateGrantRequest`. Provided scopes are still validated against registered apps. Flips `TestCreateAPITokenRejectsEmptyScopes` -> `TestCreateAPITokenAllowsEmptyScopes` (expects 201 with empty scope set).

Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>