### PR TITLE
[docker] add Alpine runtime libraries

### DIFF
--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -36,7 +36,8 @@ certificates on a `scratch` base. There is no shell, no package manager, and
 minimal attack surface.
 
 For debugging or app compatibility, use the `-alpine` variant. It includes
-a shell, `ca-certificates`, and a writable `/data` directory owned by `nobody`.
+a shell, `ca-certificates`, `libgcc`, `libstdc++`, and a writable `/data`
+directory owned by `nobody`.
 
 ## Run a simple config
 

--- a/gestaltd/Dockerfile
+++ b/gestaltd/Dockerfile
@@ -86,7 +86,7 @@ ARG GESTALT_CREATED
 ARG GESTALT_SOURCE
 ARG GESTALT_DOCUMENTATION
 ARG GESTALT_URL
-RUN apk upgrade --no-cache && apk add --no-cache ca-certificates && rm -f /usr/bin/wget
+RUN apk upgrade --no-cache && apk add --no-cache ca-certificates libgcc libstdc++ && rm -f /usr/bin/wget
 COPY --from=build-binary /out/ /usr/local/bin/
 RUN mkdir -p /data && chown nobody:nobody /data
 LABEL org.opencontainers.image.title="gestaltd" \
@@ -109,7 +109,7 @@ ARG GESTALT_CREATED
 ARG GESTALT_SOURCE
 ARG GESTALT_DOCUMENTATION
 ARG GESTALT_URL
-RUN apk upgrade --no-cache && apk add --no-cache ca-certificates && rm -f /usr/bin/wget
+RUN apk upgrade --no-cache && apk add --no-cache ca-certificates libgcc libstdc++ && rm -f /usr/bin/wget
 COPY --from=prebuilt-binary /out/gestaltd /usr/local/bin/gestaltd
 RUN mkdir -p /data && chown nobody:nobody /data
 LABEL org.opencontainers.image.title="gestaltd" \


### PR DESCRIPTION
## Description

Adds libgcc and libstdc++ to the gestaltd Alpine image variants so dynamically linked tools can resolve libgcc_s.so.1 and libstdc++.so.6 at runtime.