### PR TITLE
[http] expose binding headers to operations

### DIFF
--- a/gestaltd/internal/server/http_binding_dispatch.go
+++ b/gestaltd/internal/server/http_binding_dispatch.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"net/http"
 	"strings"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -25,13 +26,16 @@ func (s *Server) httpBindingPrincipal(binding MountedHTTPBinding, verified *veri
 	})
 }
 
-func httpBindingContextValue(binding MountedHTTPBinding, verified *verifiedHTTPBindingSender, parsed *parsedHTTPBindingRequest) map[string]any {
+func httpBindingContextValue(binding MountedHTTPBinding, r *http.Request, verified *verifiedHTTPBindingSender, parsed *parsedHTTPBindingRequest) map[string]any {
 	value := map[string]any{
 		"name":   binding.Name,
 		"app":    binding.AppName,
 		"path":   binding.Path,
 		"method": binding.Method,
 		"target": binding.Target,
+	}
+	if headers := requestHeaderValues(r); len(headers) > 0 {
+		value["headers"] = headers
 	}
 	if parsed != nil && parsed.ContentType != "" {
 		value["contentType"] = parsed.ContentType
@@ -54,7 +58,7 @@ func httpBindingContextValue(binding MountedHTTPBinding, verified *verifiedHTTPB
 	return map[string]any{"http": value}
 }
 
-func (s *Server) httpBindingOperationInvocation(ctx context.Context, binding MountedHTTPBinding, p *principal.Principal, verified *verifiedHTTPBindingSender, parsed *parsedHTTPBindingRequest) (*core.OperationResult, error) {
+func (s *Server) httpBindingOperationInvocation(ctx context.Context, binding MountedHTTPBinding, r *http.Request, p *principal.Principal, verified *verifiedHTTPBindingSender, parsed *parsedHTTPBindingRequest) (*core.OperationResult, error) {
 	params := map[string]any{}
 	if parsed != nil && parsed.Params != nil {
 		params = cloneAnyMap(parsed.Params)
@@ -63,7 +67,7 @@ func (s *Server) httpBindingOperationInvocation(ctx context.Context, binding Mou
 		p = s.httpBindingPrincipal(binding, verified)
 	}
 	ctx = principal.WithPrincipal(ctx, p)
-	ctx = invocation.WithWorkflowContext(ctx, httpBindingContextValue(binding, verified, parsed))
+	ctx = invocation.WithWorkflowContext(ctx, httpBindingContextValue(binding, r, verified, parsed))
 	ctx = invocation.WithInvocationSurface(ctx, invocation.InvocationSurfaceHTTPBinding)
 	ctx = invocation.WithHTTPBinding(ctx, binding.Name)
 	if binding.CredentialMode != "" {
@@ -81,4 +85,17 @@ func cloneAnyMap(src map[string]any) map[string]any {
 		dst[key] = value
 	}
 	return dst
+}
+
+func requestHeaderValues(r *http.Request) map[string]any {
+	if r == nil || len(r.Header) == 0 {
+		return nil
+	}
+	headers := make(map[string]any, len(r.Header))
+	for key, values := range r.Header {
+		copied := make([]string, len(values))
+		copy(copied, values)
+		headers[key] = copied
+	}
+	return headers
 }

--- a/gestaltd/internal/server/http_binding_handler.go
+++ b/gestaltd/internal/server/http_binding_handler.go
@@ -58,7 +58,7 @@ func (s *Server) handleHTTPBinding(binding MountedHTTPBinding, w http.ResponseWr
 		return
 	}
 
-	result, err := s.httpBindingOperationInvocation(r.Context(), binding, resolvedPrincipal, verified, parsed)
+	result, err := s.httpBindingOperationInvocation(r.Context(), binding, r, resolvedPrincipal, verified, parsed)
 	if err != nil {
 		s.writeInvocationError(w, r, binding.AppName, binding.Target, err)
 		return

--- a/gestaltd/internal/server/http_binding_subject.go
+++ b/gestaltd/internal/server/http_binding_subject.go
@@ -20,7 +20,7 @@ func (s *Server) resolveHTTPBindingPrincipal(ctx context.Context, binding Mounte
 		return nil, err
 	}
 	resolveCtx := principal.WithPrincipal(ctx, bindingPrincipal)
-	resolveCtx = invocation.WithWorkflowContext(resolveCtx, httpBindingContextValue(binding, verified, parsed))
+	resolveCtx = invocation.WithWorkflowContext(resolveCtx, httpBindingContextValue(binding, r, verified, parsed))
 	resolveCtx = invocation.WithInvocationSurface(resolveCtx, invocation.InvocationSurfaceHTTP)
 	resolveCtx = invocation.WithHTTPBinding(resolveCtx, binding.Name)
 

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -10511,6 +10511,83 @@ func TestHostedHTTPBinding_RejectsGenericOperationRouteConflicts(t *testing.T) {
 	}
 }
 
+func TestHostedHTTPBinding_AddsRequestHeadersToWorkflowContext(t *testing.T) {
+	t.Parallel()
+
+	const providerName = "webhook-context"
+	workflowSeen := make(chan map[string]any, 1)
+	provider := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        providerName,
+			ConnMode: core.ConnectionModeNone,
+			ExecuteFn: func(ctx context.Context, operation string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				if operation == "receive_event" {
+					workflowSeen <- invocation.WorkflowContextFromContext(ctx)
+					return &core.OperationResult{Status: http.StatusOK, Body: []byte(`{"ok":true}`)}, nil
+				}
+				return &core.OperationResult{Status: http.StatusNotFound, Body: []byte(`{}`)}, nil
+			},
+		},
+		ops: []core.Operation{{Name: "receive_event", Method: http.MethodPost}},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, provider)
+		cfg.AppDefs = map[string]*config.ProviderEntry{
+			providerName: {
+				SecuritySchemes: map[string]*config.HTTPSecurityScheme{
+					"public": {Type: providermanifestv1.HTTPSecuritySchemeTypeNone},
+				},
+				HTTP: map[string]*config.HTTPBinding{
+					"delivery": {
+						Path:     "/delivery",
+						Method:   http.MethodPost,
+						Security: "public",
+						Target:   "receive_event",
+					},
+				},
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/"+providerName+"/delivery", strings.NewReader(`{"event":"opened"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Slack-Request-Timestamp", "123")
+	req.Header.Set("X-Slack-Signature", "v0=abc")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("http binding request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("http binding status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	var workflow map[string]any
+	select {
+	case workflow = <-workflowSeen:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timed out waiting for http binding invocation")
+	}
+	httpContext := invocation.WorkflowContextMap(workflow, "http")
+	if httpContext == nil {
+		t.Fatal("workflow http context is missing")
+	}
+	headers, ok := httpContext["headers"].(map[string]any)
+	if !ok {
+		t.Fatalf("workflow http headers = %#v, want map", httpContext["headers"])
+	}
+	signatures, ok := headers["X-Slack-Signature"].([]string)
+	if !ok || len(signatures) != 1 || signatures[0] != "v0=abc" {
+		t.Fatalf("X-Slack-Signature header = %#v, want [v0=abc]", headers["X-Slack-Signature"])
+	}
+	timestamps, ok := headers["X-Slack-Request-Timestamp"].([]string)
+	if !ok || len(timestamps) != 1 || timestamps[0] != "123" {
+		t.Fatalf("X-Slack-Request-Timestamp header = %#v, want [123]", headers["X-Slack-Request-Timestamp"])
+	}
+}
+
 func TestHostedHTTPBinding_RejectsInvalidConfigBindings(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Description

Expose hosted HTTP binding request headers in the operation workflow context so provider-owned webhook handlers can validate signatures inside the target operation.