### PR TITLE
[providergateway] tag operation.count with invocation surface

### DIFF
--- a/gestaltd/services/providergateway/metrics.go
+++ b/gestaltd/services/providergateway/metrics.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -19,6 +20,7 @@ var (
 	attrProviderGatewayOperation             = attribute.Key("gd.operation")
 	attrProviderGatewaySource                = attribute.Key("gd.source")
 	attrProviderGatewayTransportPath         = attribute.Key("gd.transport")
+	attrProviderGatewayInvocationSurface     = attribute.Key("gd.invocation_surface")
 	attrProviderGatewayAuthorizationAllowed  = attribute.Key("gd.allowed")
 	attrProviderGatewayAuthorizationSubject  = attribute.Key("gd.subject")
 	attrProviderGatewayAuthorizationResource = attribute.Key("gd.resource")
@@ -118,6 +120,7 @@ func recordProviderGatewayOperation(ctx context.Context, startedAt time.Time, er
 		attrProviderGatewayOperation.String(metricutil.AttrValue(req.Operation)),
 		attrProviderGatewaySource.String(metricutil.AttrValue(string(req.Source))),
 		attrProviderGatewayTransportPath.String(metricutil.AttrValue(string(transportPath))),
+		attrProviderGatewayInvocationSurface.String(metricutil.AttrValue(string(invocation.InvocationSurfaceFromContext(ctx)))),
 	}
 	metricAttrs := metric.WithAttributes(attrs...)
 


### PR DESCRIPTION
## Description

Adds a `gd.invocation_surface` tag to `gestaltd.provider_gateway.operation.count` so operations can be attributed to their originating surface (`http`, `http_binding`, `mcp`, app-access). The existing `gd.source` tag only distinguishes `sdk_grpc`/`internal` and cannot tell these apart.

The surface is already present in `ctx` at record time (every surface calls `invocation.WithInvocationSurface` before invoking), so the recorder just reads `invocation.InvocationSurfaceFromContext(ctx)`. Paths that never set a surface fall back to `unknown` via `metricutil.AttrValue`. Verified no import cycle (`invocation` does not depend on `providergateway`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)