### PR TITLE
[providergateway] consolidate metric tags into gd.origin

### DIFF
--- a/docs/provider-gateway-origin-tag-plan.md
+++ b/docs/provider-gateway-origin-tag-plan.md
@@ -1,0 +1,153 @@
+# Plan: consolidate provider-gateway metric tags into a single `gd.origin`
+
+## Goal
+
+Replace the two overlapping tags on `gestaltd.provider_gateway.*` metrics
+(`gd.source` and `gd.invocation_surface`) with **one** tag, `gd.origin`, that
+classifies *what kind of caller initiated the invocation*:
+
+| `gd.origin` | Meaning |
+|---|---|
+| `external` | Entered via an external request boundary — the HTTP invoke API (`gestalt invoke`), HTTP bindings/webhooks, MCP clients |
+| `workflow` | Driven by the workflow manager |
+| `app_sdk` | An app calling back into gestaltd via the SDK over gRPC |
+| `internal` | Server-side system invocations (bootstrap, state setup, background) |
+| `unknown` | Fallback — a path that has not been instrumented yet |
+
+Applies to every metric emitted under `gestaltd.provider_gateway.*`
+(`operation.count`, `operation.duration`, `operation.error_count`,
+`authorization.count`).
+
+## Reasoning
+
+- **Today the two tags are redundant and confusing.** `gd.source` only ever
+  takes `sdk_grpc` / `internal` / `N/A` and describes how the *transport* was
+  entered; `gd.invocation_surface` describes the originating *surface*
+  (`http`/`http_binding`/`mcp`/`unknown`). They answer overlapping questions and
+  neither alone tells you "who called this."
+- **The question we actually want to answer is caller class.** External API
+  traffic vs. workflow-driven vs. app-SDK callbacks vs. internal system calls.
+  That is a single, mutually-exclusive dimension, so it belongs in one tag.
+- **Most volume is currently `unknown`/`N/A`** because internal originators
+  (bootstrap, workflows) and the SDK path go through the same gateway but never
+  decorate their context. They *do* flow through the gateway — they just don't
+  declare themselves. This plan makes them declare.
+- **Keep an explicit `unknown` fallback.** Do **not** let un-instrumented paths
+  silently collapse into `internal`. The `unknown` bucket is the signal that a
+  code path still needs a stamp; losing it is how we got here.
+- **Caller class is the *nearest* caller, not the ultimate origin.** An app SDK
+  call that was itself triggered by an external request is reported as
+  `app_sdk`. This is intentional and defined by the precedence below.
+
+## Design
+
+### Single context value + resolver
+
+Introduce one context key and a resolver that both metric recorders call.
+
+Precedence (first match wins):
+
+1. `workflow` — set by the workflow manager
+2. `app_sdk` — set at SDK-facing gRPC entry points
+3. `external` — set at external request boundaries
+4. `internal` — explicitly set at system/bootstrap originators
+5. `unknown` — default when nothing was stamped
+
+A single explicit stamp per entry point keeps this unambiguous; the resolver
+never has to "guess" — it just reads the one value, defaulting to `unknown`.
+
+### Tradeoff (accepted)
+
+`gd.origin` collapses `http` / `http_binding` / `mcp` into `external`, so the
+protocol breakdown is lost. If protocol granularity is needed later, add it back
+as a *separate* tag rather than sub-typing `external`.
+
+## Code pointers
+
+### New: the origin type + context plumbing
+
+- Define an `Origin` string type with the five constants. Natural home is the
+  `invocation` package next to the existing surface enum:
+  - `gestaltd/services/invocation/context.go:108-111` — existing
+    `InvocationSurface` enum (model the new type after this)
+  - `gestaltd/services/invocation/context.go:324-330` — existing
+    `WithInvocationSurface` / `InvocationSurfaceFromContext` (model
+    `WithOrigin` / `OriginFromContext` after these)
+- Import note: `providergateway` already imports `invocation` (added in PR
+  #2493), and `invocation` does not depend on `providergateway`, so this stays
+  cycle-free.
+
+### The resolver + metric emission
+
+- `gestaltd/services/providergateway/metrics.go:15-25` — tag-key declarations.
+  Add `attrProviderGatewayOrigin = attribute.Key("gd.origin")`; **remove**
+  `attrProviderGatewaySource` and `attrProviderGatewayInvocationSurface`.
+- `gestaltd/services/providergateway/metrics.go:109-129`
+  (`recordProviderGatewayOperation`) — replace the `gd.source` and
+  `gd.invocation_surface` attributes with a single
+  `attrProviderGatewayOrigin.String(resolveOrigin(ctx))`.
+- `gestaltd/services/providergateway/metrics.go:72-90`
+  (`recordProviderGatewayAuthorizationCheck`) — add the same
+  `gd.origin` attribute so all `provider_gateway.*` metrics are consistent.
+- Retire `GatewaySource` once `gd.source` is gone:
+  - `gestaltd/services/providergateway/types.go:15-19,47` — `GatewaySource`
+    type/constants and the `Source` field on `ProviderGatewayRequest`
+  - `gestaltd/services/providergateway/context.go:8,13-24` — `WithSource` /
+    `SourceFromContext`
+  - `gestaltd/rpc/authorization/client.go:151` — currently sets
+    `Source: SourceFromContext(ctx)` on the request; drop it
+  - `gestaltd/services/authorization/server.go:17-24,105` — `WithGatewaySource`
+    option + `providerGatewayContext` that calls `WithSource`; replace with a
+    `WithOrigin(ctx, OriginAppSDK)` stamp (see app_sdk below)
+
+### Stamping each origin
+
+- **external** — already partially done; switch these from
+  `WithInvocationSurface` to `WithOrigin(ctx, OriginExternal)`:
+  - `gestaltd/internal/server/handlers.go:829` (HTTP invoke API / `gestalt invoke`)
+  - `gestaltd/internal/server/http_binding_dispatch.go:75` (webhooks)
+  - `gestaltd/services/apps/mcp/stateless_http.go:260` (MCP)
+- **workflow** — add a stamp on the ctx before the workflow manager invokes:
+  - `gestaltd/services/workflows/workflowmanager/manager_target.go` (the target
+    execution path that holds `m.invoker`; stamp `WithOrigin(ctx, OriginWorkflow)`
+    before the invoke). Confirm exact invoke line during implementation.
+- **app_sdk** — stamp at the SDK-facing gRPC entry points:
+  - `gestaltd/services/authorization/server.go:105` (authz host service — today's
+    `sdk_grpc`)
+  - `gestaltd/services/appaccess/app_server.go:62-96` (app-to-app `Invoke`) and
+    `:100` (`InvokeGraphQL`). Note `app_server.go:372-373` currently restores a
+    propagated surface; reconcile so app-access reports `app_sdk` as the
+    immediate caller class.
+- **internal** — stamp system/bootstrap originators:
+  - `gestaltd/internal/bootstrap/authorization_bootstrap.go:24-61`
+    (`bootstrapAuthorizationProviderState` → `SetAuthorizationState`)
+  - audit other in-process callers of the invoker that aren't covered above and
+    stamp `OriginInternal`; anything missed correctly falls through to `unknown`.
+
+### Cross-process propagation (follow-up, optional)
+
+The `RequestContext` proto already carries `Invocation.Surface`
+(`appaccess/app_server.go:372`, `apps/provider_server.go:165`). If we want origin
+to survive app→app / plugin hops the same way, add an `origin` field to that
+proto and restore it on the receiving side. Not required for the first cut —
+without it, hops resolve to the nearest caller class, which is acceptable.
+
+## Rollout / sequencing
+
+1. Add `Origin` type + `WithOrigin`/`OriginFromContext` + `resolveOrigin`.
+2. Swap emission in both recorders to `gd.origin`; delete the two old tags.
+3. Add stamps at all entry points (external, workflow, app_sdk, internal).
+4. Remove the now-dead `GatewaySource` plumbing.
+5. `go build ./...`; update any dashboards/monitors referencing `gd.source` or
+   `gd.invocation_surface` to `gd.origin`.
+
+Because `gd.invocation_surface` is only days old (PR #2493) and not yet relied
+on, retiring it now is low-cost.
+
+## Verification
+
+- After deploy, `sum:gestaltd.provider_gateway.operation.count{*} by {gd.origin}`
+  should show `external` / `workflow` / `app_sdk` / `internal` populated and
+  `unknown` trending toward zero.
+- A non-zero `unknown` is the signal that an invocation entry point still needs a
+  stamp — treat it as a TODO, not noise.

--- a/gestaltd/internal/bootstrap/authorization_bootstrap.go
+++ b/gestaltd/internal/bootstrap/authorization_bootstrap.go
@@ -15,6 +15,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/protoutil"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	gproto "google.golang.org/protobuf/proto"
@@ -58,6 +59,7 @@ func bootstrapAuthorizationProviderState(ctx context.Context, cfg *config.Config
 		return fmt.Errorf("bootstrap: authorization provider %q: %w", name, err)
 	}
 	staticRelationships = append(staticRelationships, runtimeRelationships...)
+	ctx = invocation.WithOrigin(ctx, invocation.OriginInternal)
 	if _, err := provider.SetAuthorizationState(ctx, &proto.SetAuthorizationStateRequest{
 		Model:         model,
 		Relationships: staticRelationships,

--- a/gestaltd/internal/bootstrap/host_service_bootstrap.go
+++ b/gestaltd/internal/bootstrap/host_service_bootstrap.go
@@ -21,7 +21,6 @@ import (
 	cacheservice "github.com/valon-technologies/gestalt/server/services/cache"
 	externalcredentialsservice "github.com/valon-technologies/gestalt/server/services/externalcredentials"
 	indexeddbservice "github.com/valon-technologies/gestalt/server/services/indexeddb"
-	"github.com/valon-technologies/gestalt/server/services/providergateway"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost/runtimeprovider"
 	"github.com/valon-technologies/gestalt/server/services/s3"
@@ -96,7 +95,6 @@ func authorizationHostServiceFromDeps(deps Deps) (runtimehost.HostService, bool)
 		Register: func(srv *grpc.Server) {
 			proto.RegisterAuthorizationServer(srv, authorizationservice.NewProviderServer(
 				deps.Authorization,
-				authorizationservice.WithGatewaySource(providergateway.GatewaySourceSDKGRPC),
 			))
 		},
 	}, true

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -827,6 +827,7 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 		Surface:        metricutil.InvocationSurfaceHTTP,
 	})
 	ctx = invocation.WithInvocationSurface(ctx, invocation.InvocationSurfaceHTTP)
+	ctx = invocation.WithOrigin(ctx, invocation.OriginExternal)
 	ctx, err = s.withProviderGatewayCallerToken(ctx, p)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "issue provider gateway caller token", "error", err)

--- a/gestaltd/internal/server/http_binding_dispatch.go
+++ b/gestaltd/internal/server/http_binding_dispatch.go
@@ -73,6 +73,7 @@ func (s *Server) httpBindingOperationInvocation(ctx context.Context, binding Mou
 	ctx = principal.WithPrincipal(ctx, p)
 	ctx = invocation.WithWorkflowContext(ctx, httpBindingContextValue(binding, r, verified, parsed))
 	ctx = invocation.WithInvocationSurface(ctx, invocation.InvocationSurfaceHTTPBinding)
+	ctx = invocation.WithOrigin(ctx, invocation.OriginExternal)
 	ctx = invocation.WithHTTPBinding(ctx, binding.Name)
 	if binding.CredentialMode != "" {
 		ctx = invocation.WithCredentialModeOverride(ctx, binding.CredentialMode)

--- a/gestaltd/rpc/authorization/client.go
+++ b/gestaltd/rpc/authorization/client.go
@@ -148,7 +148,6 @@ func (c *Client) invoke(ctx context.Context, operation string, in gproto.Message
 		ServiceName:    proto.Authorization_ServiceDesc.ServiceName,
 		Operation:      operation,
 		RequestContext: providergateway.RequestContextFromContext(ctx),
-		Source:         providergateway.SourceFromContext(ctx),
 		CallerToken:    providergateway.CallerTokenFromContext(ctx),
 		Payload:        payload,
 	}, func(ctx context.Context, _ providergateway.ProviderGatewayRequest) (providergateway.ProviderGatewayResponse, error) {

--- a/gestaltd/services/appaccess/app_server.go
+++ b/gestaltd/services/appaccess/app_server.go
@@ -350,6 +350,10 @@ func restoreRequestInvocationContext(ctx context.Context, callCtx requestInvocat
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	// App-access is the SDK-facing gRPC entry point: a reaching caller is an app
+	// calling back into gestaltd over gRPC, so it reports app_sdk as the
+	// immediate caller class regardless of any propagated surface.
+	ctx = invocation.WithOrigin(ctx, invocation.OriginAppSDK)
 	if callCtx.principal != nil {
 		ctx = principal.WithPrincipal(ctx, principal.Canonicalized(callCtx.principal))
 	}

--- a/gestaltd/services/apps/mcp/stateless_http.go
+++ b/gestaltd/services/apps/mcp/stateless_http.go
@@ -258,6 +258,7 @@ func (h *StatelessHTTPHandler) callTool(ctx context.Context, req mcpgo.CallToolR
 		return nil, err
 	}
 	ctx = invocation.WithInvocationSurface(ctx, invocation.InvocationSurfaceMCP)
+	ctx = invocation.WithOrigin(ctx, invocation.OriginExternal)
 	ctx = invocation.WithCatalogOperation(ctx, provName, opMeta)
 	if resolvedConnection != "" {
 		ctx = invocation.WithConnection(ctx, resolvedConnection)

--- a/gestaltd/services/authorization/server.go
+++ b/gestaltd/services/authorization/server.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
-	"github.com/valon-technologies/gestalt/server/services/providergateway"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -13,17 +13,10 @@ import (
 
 type providerServer struct {
 	proto.UnimplementedAuthorizationServer
-	provider      core.AuthorizationProvider
-	gatewaySource providergateway.GatewaySource
+	provider core.AuthorizationProvider
 }
 
 type ProviderServerOption func(*providerServer)
-
-func WithGatewaySource(source providergateway.GatewaySource) ProviderServerOption {
-	return func(s *providerServer) {
-		s.gatewaySource = source
-	}
-}
 
 func NewProviderServer(provider core.AuthorizationProvider, opts ...ProviderServerOption) proto.AuthorizationServer {
 	s := &providerServer{provider: provider}
@@ -98,11 +91,11 @@ func (s *providerServer) ListActiveModelResourceTypes(ctx context.Context, req *
 	return s.provider.ListActiveModelResourceTypes(s.providerGatewayContext(ctx), req)
 }
 
+// providerGatewayContext stamps the caller class for the authorization host
+// service: apps reaching this gRPC entry point are calling back into gestaltd
+// via the SDK, so they report as app_sdk.
 func (s *providerServer) providerGatewayContext(ctx context.Context) context.Context {
-	if s == nil {
-		return ctx
-	}
-	return providergateway.WithSource(ctx, s.gatewaySource)
+	return invocation.WithOrigin(ctx, invocation.OriginAppSDK)
 }
 
 func (s *providerServer) requireProvider() error {

--- a/gestaltd/services/authorization/server_test.go
+++ b/gestaltd/services/authorization/server_test.go
@@ -6,48 +6,30 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
-	"github.com/valon-technologies/gestalt/server/services/providergateway"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
 )
 
-func TestProviderServerLeavesGatewaySourceInternalByDefault(t *testing.T) {
+func TestProviderServerStampsAppSDKOrigin(t *testing.T) {
 	t.Parallel()
 
-	provider := &sourceRecordingAuthorizationProvider{}
+	provider := &originRecordingAuthorizationProvider{}
 	server := NewProviderServer(provider)
 
 	_, err := server.CheckAccess(context.Background(), &proto.CheckAccessRequest{})
 	if err != nil {
 		t.Fatalf("CheckAccess: %v", err)
 	}
-	if provider.source != providergateway.GatewaySourceInternal {
-		t.Fatalf("source = %q, want %q", provider.source, providergateway.GatewaySourceInternal)
+	if provider.origin != invocation.OriginAppSDK {
+		t.Fatalf("origin = %q, want %q", provider.origin, invocation.OriginAppSDK)
 	}
 }
 
-func TestProviderServerAppliesConfiguredGatewaySource(t *testing.T) {
-	t.Parallel()
-
-	provider := &sourceRecordingAuthorizationProvider{}
-	server := NewProviderServer(
-		provider,
-		WithGatewaySource(providergateway.GatewaySourceSDKGRPC),
-	)
-
-	_, err := server.CheckAccess(context.Background(), &proto.CheckAccessRequest{})
-	if err != nil {
-		t.Fatalf("CheckAccess: %v", err)
-	}
-	if provider.source != providergateway.GatewaySourceSDKGRPC {
-		t.Fatalf("source = %q, want %q", provider.source, providergateway.GatewaySourceSDKGRPC)
-	}
-}
-
-type sourceRecordingAuthorizationProvider struct {
+type originRecordingAuthorizationProvider struct {
 	core.AuthorizationProvider
-	source providergateway.GatewaySource
+	origin invocation.Origin
 }
 
-func (p *sourceRecordingAuthorizationProvider) CheckAccess(ctx context.Context, _ *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
-	p.source = providergateway.SourceFromContext(ctx)
+func (p *originRecordingAuthorizationProvider) CheckAccess(ctx context.Context, _ *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
+	p.origin = invocation.OriginFromContext(ctx)
 	return &proto.CheckAccessResponse{Allowed: true}, nil
 }

--- a/gestaltd/services/invocation/context.go
+++ b/gestaltd/services/invocation/context.go
@@ -88,6 +88,7 @@ type CallerProvider struct {
 }
 
 type invocationSurfaceCtxKey struct{}
+type originCtxKey struct{}
 type httpBindingCtxKey struct{}
 type credentialCtxKey struct{}
 type callerProviderCtxKey struct{}
@@ -109,6 +110,28 @@ const (
 	InvocationSurfaceHTTP        InvocationSurface = "http"
 	InvocationSurfaceHTTPBinding InvocationSurface = "http_binding"
 	InvocationSurfaceMCP         InvocationSurface = "mcp"
+)
+
+// Origin classifies the kind of caller that initiated an invocation. It is the
+// nearest caller class, not the ultimate origin: an app SDK call that was
+// itself triggered by an external request is reported as OriginAppSDK.
+type Origin string
+
+const (
+	// OriginExternal entered via an external request boundary (the HTTP invoke
+	// API, HTTP bindings/webhooks, or MCP clients).
+	OriginExternal Origin = "external"
+	// OriginWorkflow was driven by the workflow manager.
+	OriginWorkflow Origin = "workflow"
+	// OriginAppSDK is an app calling back into gestaltd via the SDK over gRPC.
+	OriginAppSDK Origin = "app_sdk"
+	// OriginInternal is a server-side system invocation (bootstrap, state
+	// setup, background work).
+	OriginInternal Origin = "internal"
+	// OriginUnknown is the fallback for a path that has not been instrumented
+	// yet. A non-zero unknown count is the signal that an entry point still
+	// needs a stamp.
+	OriginUnknown Origin = "unknown"
 )
 
 func WithRequestMeta(ctx context.Context, meta RequestMeta) context.Context {
@@ -328,6 +351,30 @@ func WithInvocationSurface(ctx context.Context, surface InvocationSurface) conte
 func InvocationSurfaceFromContext(ctx context.Context) InvocationSurface {
 	surface, _ := ctx.Value(invocationSurfaceCtxKey{}).(InvocationSurface)
 	return surface
+}
+
+// WithOrigin stamps the caller class onto the context. Each entry point stamps
+// exactly once; the nearest stamp wins, so deeper boundaries (e.g. an SDK
+// callback) overwrite outer ones.
+func WithOrigin(ctx context.Context, origin Origin) context.Context {
+	if origin == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, originCtxKey{}, origin)
+}
+
+func OriginFromContext(ctx context.Context) Origin {
+	origin, _ := ctx.Value(originCtxKey{}).(Origin)
+	return origin
+}
+
+// ResolveOrigin reads the stamped origin, defaulting to OriginUnknown when no
+// entry point declared itself.
+func ResolveOrigin(ctx context.Context) Origin {
+	if origin := OriginFromContext(ctx); origin != "" {
+		return origin
+	}
+	return OriginUnknown
 }
 
 func WithHTTPBinding(ctx context.Context, binding string) context.Context {

--- a/gestaltd/services/providergateway/context.go
+++ b/gestaltd/services/providergateway/context.go
@@ -5,25 +5,9 @@ import "context"
 type contextKey string
 
 const (
-	sourceContextKey         contextKey = "provider_gateway_source"
 	requestContextContextKey contextKey = "provider_gateway_request_context"
 	callerTokenContextKey    contextKey = "provider_gateway_caller_token"
 )
-
-func WithSource(ctx context.Context, source GatewaySource) context.Context {
-	if source == "" {
-		return ctx
-	}
-	return context.WithValue(ctx, sourceContextKey, source)
-}
-
-func SourceFromContext(ctx context.Context) GatewaySource {
-	source, _ := ctx.Value(sourceContextKey).(GatewaySource)
-	if source == "" {
-		return GatewaySourceInternal
-	}
-	return source
-}
 
 func WithRequestContext(ctx context.Context, reqCtx *RequestContext) context.Context {
 	if reqCtx == nil {

--- a/gestaltd/services/providergateway/gateway_test.go
+++ b/gestaltd/services/providergateway/gateway_test.go
@@ -155,6 +155,7 @@ func TestAuthorizeRecordsAuthorizationMetrics(t *testing.T) {
 
 	rm := metrictest.CollectMetrics(t, metrics.Reader)
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.provider_gateway.authorization.count", 1, map[string]string{
+		"gd.origin":   "unknown",
 		"gd.allowed":  "false",
 		"gd.subject":  "subject/user:alice",
 		"gd.resource": "provider/authz-primary",
@@ -289,7 +290,6 @@ func TestDirectTransportInvokeRecordsMetrics(t *testing.T) {
 		ProviderKind: ProviderKindAuthorization,
 		ServiceName:  "gestalt.v1.Authorization",
 		Operation:    "CheckAccess",
-		Source:       GatewaySourceSDKGRPC,
 	}
 
 	_, err := (DirectTransport{}).Invoke(ctx, req, func(ctx context.Context, req ProviderGatewayRequest) (ProviderGatewayResponse, error) {
@@ -316,7 +316,6 @@ func TestDirectTransportInvokeRecordsErrorMetrics(t *testing.T) {
 		ProviderKind: ProviderKindAuthorization,
 		ServiceName:  "gestalt.v1.Authorization",
 		Operation:    "CheckAccess",
-		Source:       GatewaySourceInternal,
 	}
 	wantErr := errors.New("provider failed")
 
@@ -345,7 +344,6 @@ func TestProviderGatewayTransportInvokeRecordsMetrics(t *testing.T) {
 		ProviderKind: ProviderKindAuthorization,
 		ServiceName:  "gestalt.v1.Authorization",
 		Operation:    "CheckAccess",
-		Source:       GatewaySourceSDKGRPC,
 	}
 
 	_, err := transport.Invoke(ctx, req, func(ctx context.Context, req ProviderGatewayRequest) (ProviderGatewayResponse, error) {
@@ -373,7 +371,6 @@ func TestProviderGatewayTransportInvokeRecordsErrorMetrics(t *testing.T) {
 		ProviderKind: ProviderKindAuthorization,
 		ServiceName:  "gestalt.v1.Authorization",
 		Operation:    "CheckAccess",
-		Source:       GatewaySourceInternal,
 	}
 	wantErr := errors.New("provider failed")
 
@@ -397,7 +394,7 @@ func providerGatewayMetricAttrs(req ProviderGatewayRequest, transportPath Transp
 		"gd.provider_kind": string(req.ProviderKind),
 		"gd.service":       req.ServiceName,
 		"gd.operation":     req.Operation,
-		"gd.source":        string(req.Source),
+		"gd.origin":        "unknown",
 		"gd.transport":     string(transportPath),
 	}
 }

--- a/gestaltd/services/providergateway/metrics.go
+++ b/gestaltd/services/providergateway/metrics.go
@@ -18,9 +18,8 @@ var (
 	attrProviderGatewayProviderKind          = attribute.Key("gd.provider_kind")
 	attrProviderGatewayServiceName           = attribute.Key("gd.service")
 	attrProviderGatewayOperation             = attribute.Key("gd.operation")
-	attrProviderGatewaySource                = attribute.Key("gd.source")
+	attrProviderGatewayOrigin                = attribute.Key("gd.origin")
 	attrProviderGatewayTransportPath         = attribute.Key("gd.transport")
-	attrProviderGatewayInvocationSurface     = attribute.Key("gd.invocation_surface")
 	attrProviderGatewayAuthorizationAllowed  = attribute.Key("gd.allowed")
 	attrProviderGatewayAuthorizationSubject  = attribute.Key("gd.subject")
 	attrProviderGatewayAuthorizationResource = attribute.Key("gd.resource")
@@ -77,6 +76,7 @@ func recordProviderGatewayAuthorizationCheck(ctx context.Context, allowed bool, 
 	}
 	metrics := providerGatewayAuthorizationChecks.Load(ctx, "gestaltd", newProviderGatewayAuthorizationMetrics)
 	attrs := []attribute.KeyValue{
+		attrProviderGatewayOrigin.String(string(invocation.ResolveOrigin(ctx))),
 		attrProviderGatewayAuthorizationAllowed.String(strconv.FormatBool(allowed)),
 		attrProviderGatewayAuthorizationSubject.String(metricutil.AttrValue(authorizationCheckSubjectValue(req))),
 		attrProviderGatewayAuthorizationResource.String(metricutil.AttrValue(authorizationCheckResourceValue(req))),
@@ -118,9 +118,8 @@ func recordProviderGatewayOperation(ctx context.Context, startedAt time.Time, er
 		attrProviderGatewayProviderKind.String(metricutil.AttrValue(string(req.ProviderKind))),
 		attrProviderGatewayServiceName.String(metricutil.AttrValue(req.ServiceName)),
 		attrProviderGatewayOperation.String(metricutil.AttrValue(req.Operation)),
-		attrProviderGatewaySource.String(metricutil.AttrValue(string(req.Source))),
+		attrProviderGatewayOrigin.String(string(invocation.ResolveOrigin(ctx))),
 		attrProviderGatewayTransportPath.String(metricutil.AttrValue(string(transportPath))),
-		attrProviderGatewayInvocationSurface.String(metricutil.AttrValue(string(invocation.InvocationSurfaceFromContext(ctx)))),
 	}
 	metricAttrs := metric.WithAttributes(attrs...)
 

--- a/gestaltd/services/providergateway/types.go
+++ b/gestaltd/services/providergateway/types.go
@@ -12,13 +12,6 @@ const (
 	ProviderKindAuthorization ProviderKind = "authorization"
 )
 
-type GatewaySource string
-
-const (
-	GatewaySourceSDKGRPC  GatewaySource = "sdk_grpc"
-	GatewaySourceInternal GatewaySource = "internal"
-)
-
 type TransportPath string
 
 const (
@@ -44,7 +37,6 @@ type ProviderGatewayRequest struct {
 	ServiceName    string
 	Operation      string
 	RequestContext *RequestContext
-	Source         GatewaySource
 	CallerToken    string
 	Payload        []byte
 }

--- a/gestaltd/services/workflows/workflowmanager/manager.go
+++ b/gestaltd/services/workflows/workflowmanager/manager.go
@@ -58,6 +58,9 @@ func workflowCaller(ctx context.Context, requested invocation.CallerProvider) in
 }
 
 func withWorkflowCaller(ctx context.Context, caller invocation.CallerProvider) context.Context {
+	// Invocations driven by the workflow manager report as workflow, even when
+	// the caller provider is unset.
+	ctx = invocation.WithOrigin(ctx, invocation.OriginWorkflow)
 	caller = normalizeWorkflowCaller(caller)
 	if caller.Kind == "" || caller.Name == "" {
 		return ctx


### PR DESCRIPTION
## Description

Replaces the two overlapping tags on `gestaltd.provider_gateway.*` metrics (`gd.source` and `gd.invocation_surface`) with a single `gd.origin` tag that classifies the nearest caller class: `external`, `workflow`, `app_sdk`, `internal`, or `unknown`. Implements `docs/provider-gateway-origin-tag-plan.md`.

- New `Origin` type + `WithOrigin`/`OriginFromContext`/`ResolveOrigin` in the `invocation` package.
- `gd.origin` emitted on all `provider_gateway.*` metrics (operation count/duration/error_count and authorization.count); the two old tags are removed.
- Origin stamped at each entry point: external request boundaries (HTTP invoke, HTTP bindings, MCP), the workflow manager, SDK-facing gRPC entry points (authorization host service + app-access), and system/bootstrap originators.
- Retires the now-dead `GatewaySource` plumbing.

Note: existing `WithInvocationSurface` stamps are kept — `gd.invocation_surface` is only dropped from provider-gateway metrics; the surface context value is still consumed by `gestaltd.invocation.*` metrics and other callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)