### PR TITLE
Bump TypeScript SDK to 0.0.1-alpha.64

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@valon-technologies/gestalt",
-  "version": "0.0.1-alpha.63",
+  "version": "0.0.1-alpha.64",
   "description": "TypeScript SDK for Gestalt executable providers",
   "type": "module",
   "repository": {


### PR DESCRIPTION
Release the Identity provider rename plus the request-side expires_in TTL on TokenRequest (#2500). Downstream consumers ride on alpha.64 for defineIdentityProvider and TokenRequest.expiresIn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)