### PR TITLE
Add install phase and zero-arg SDK build derivation

### DIFF
--- a/docs/content/providers/apps.mdx
+++ b/docs/content/providers/apps.mdx
@@ -350,6 +350,40 @@ See [Provider Manifests](/reference/app-manifests) for the full field reference.
   </Tabs.Tab>
 </Tabs>
 
+### Install and build phases
+
+A source provider declares up to three inline phases, each an argv list that
+gestaltd execs directly with no shell:
+
+- `install` — runs once before any build or dev execution. Use it for
+  dependency installation (`bun install`, `uv sync`). Side-effect only; its
+  output is not verified. `inputs` is the cache-key allowlist, typically the
+  lockfile.
+- `build` — compiles the provider into the entrypoint artifact. Its output is
+  verified against `entrypoint.artifactPath`.
+- `dev` — a long-running dev server for local `gestaltd serve` only.
+
+Run order is `install` → `build` (for packaging/lock/sync) and `install` →
+`dev` (for local serve). All three are optional and additive; providers that
+only need `build` continue to work without `install`.
+
+```yaml
+install:
+  command: [bun, install, --frozen-lockfile]
+  inputs: [package.json, bun.lock]
+build:
+  command: [bun, run, gestalt-ts-build]
+  inputs: [provider.ts, tsconfig.json, package.json]
+entrypoint:
+  artifactPath: .gestalt/build/provider
+```
+
+The TypeScript and Python SDK build entrypoints derive their arguments from
+`manifest.yaml` plus the language package manifest when invoked with zero
+positional args, so `build.command` is a fixed per-language argv (`bun run
+gestalt-ts-build` for TypeScript, `uv run python -m gestalt._build` for
+Python) with no per-provider wrapper script.
+
 ### Defining operations
 
 Operations are the callable units of an app. Each operation has an ID, an HTTP method, input and output types, and a handler function. Executable source apps can use SDK-native source package metadata, declare `run` for local source execution, or declare `build.command` and `entrypoint.artifactPath` when they need a compiled release artifact.

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -2667,7 +2667,64 @@ func fingerprintLocalSourceDigest(sourcePath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return providerpkg.DirectoryDigest(normalized.sourceDir, normalized.manifestPath, manifest)
+	digest, err := providerpkg.DirectoryDigest(normalized.sourceDir, normalized.manifestPath, manifest)
+	if err != nil {
+		return "", err
+	}
+	installInputs := providerpkg.SourceInstallInputs(manifest)
+	if len(installInputs) == 0 {
+		return digest, nil
+	}
+	return foldInstallInputsDigest(normalized.sourceDir, digest, installInputs)
+}
+
+func foldInstallInputsDigest(sourceDir, baseDigest string, installInputs []string) (string, error) {
+	var digests []string
+	seen := map[string]struct{}{}
+	addFile := func(path string) error {
+		rel, err := filepath.Rel(sourceDir, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(filepath.Clean(rel))
+		if _, ok := seen[rel]; ok {
+			return nil
+		}
+		seen[rel] = struct{}{}
+		sum, err := providerpkg.FileSHA256(path)
+		if err != nil {
+			return err
+		}
+		digests = append(digests, rel+"="+sum)
+		return nil
+	}
+	for _, input := range installInputs {
+		inputAbs := filepath.Clean(filepath.Join(sourceDir, filepath.FromSlash(input)))
+		info, err := os.Stat(inputAbs)
+		if err != nil {
+			return "", fmt.Errorf("stat install input %q: %w", input, err)
+		}
+		if info.IsDir() {
+			if err := filepath.WalkDir(inputAbs, func(path string, d os.DirEntry, err error) error {
+				if err != nil {
+					return err
+				}
+				if d.IsDir() {
+					return nil
+				}
+				return addFile(path)
+			}); err != nil {
+				return "", fmt.Errorf("digest install input %q: %w", input, err)
+			}
+			continue
+		}
+		if err := addFile(inputAbs); err != nil {
+			return "", fmt.Errorf("digest install input %q: %w", input, err)
+		}
+	}
+	slices.Sort(digests)
+	combined := sha256.Sum256([]byte(baseDigest + "\n" + strings.Join(digests, "\n")))
+	return hex.EncodeToString(combined[:]), nil
 }
 
 func fingerprintLocalBuildInputs(sourceDir, manifestPath string, manifest *providermanifestv1.Manifest, build *providerpkg.ResolvedSourceBuild) (string, error) {
@@ -2750,6 +2807,7 @@ func fingerprintLocalBuildInputs(sourceDir, manifestPath string, manifest *provi
 	}
 
 	inputs := append([]string(nil), build.Inputs...)
+	inputs = append(inputs, providerpkg.SourceInstallInputs(manifest)...)
 	if len(inputs) == 0 {
 		workdir := "."
 		if strings.TrimSpace(build.Workdir) != "" {

--- a/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
@@ -46,6 +46,9 @@
     "build": {
       "$ref": "#/$defs/sourceBuild"
     },
+    "install": {
+      "$ref": "#/$defs/sourceInstall"
+    },
     "run": {
       "$ref": "#/$defs/sourceRun"
     },
@@ -109,6 +112,40 @@
       "items": {
         "type": "string",
         "minLength": 1
+      }
+    },
+    "sourceInstall": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "command"
+      ],
+      "properties": {
+        "workdir": {
+          "type": "string",
+          "minLength": 1
+        },
+        "command": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "inputs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "env": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
       }
     },
     "spec": {

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -32,18 +32,19 @@ func NormalizeKind(kind string) string {
 }
 
 type Manifest struct {
-	Kind        string       `json:"kind,omitempty" yaml:"kind,omitempty"`
-	Source      string       `json:"source,omitempty" yaml:"source,omitempty"`
-	Version     string       `json:"version" yaml:"version"`
-	DisplayName string       `json:"displayName,omitempty" yaml:"displayName,omitempty"`
-	Description string       `json:"description,omitempty" yaml:"description,omitempty"`
-	IconFile    string       `json:"iconFile,omitempty" yaml:"iconFile,omitempty"`
-	Build       *SourceBuild `json:"build,omitempty" yaml:"build,omitempty"`
-	Dev         *SourceDev   `json:"dev,omitempty" yaml:"dev,omitempty"`
-	Run         []string     `json:"run,omitempty" yaml:"run,omitempty"`
-	Artifacts   []Artifact   `json:"artifacts,omitempty" yaml:"artifacts,omitempty"`
-	Entrypoint  *Entrypoint  `json:"entrypoint,omitempty" yaml:"entrypoint,omitempty"`
-	Spec        *Spec        `json:"spec,omitempty" yaml:"spec,omitempty"`
+	Kind        string         `json:"kind,omitempty" yaml:"kind,omitempty"`
+	Source      string         `json:"source,omitempty" yaml:"source,omitempty"`
+	Version     string         `json:"version" yaml:"version"`
+	DisplayName string         `json:"displayName,omitempty" yaml:"displayName,omitempty"`
+	Description string         `json:"description,omitempty" yaml:"description,omitempty"`
+	IconFile    string         `json:"iconFile,omitempty" yaml:"iconFile,omitempty"`
+	Install     *SourceInstall `json:"install,omitempty" yaml:"install,omitempty"`
+	Build       *SourceBuild   `json:"build,omitempty" yaml:"build,omitempty"`
+	Dev         *SourceDev     `json:"dev,omitempty" yaml:"dev,omitempty"`
+	Run         []string       `json:"run,omitempty" yaml:"run,omitempty"`
+	Artifacts   []Artifact     `json:"artifacts,omitempty" yaml:"artifacts,omitempty"`
+	Entrypoint  *Entrypoint    `json:"entrypoint,omitempty" yaml:"entrypoint,omitempty"`
+	Spec        *Spec          `json:"spec,omitempty" yaml:"spec,omitempty"`
 }
 
 type SourceBuild struct {
@@ -146,6 +147,85 @@ func (b SourceBuild) MarshalYAML() (any, error) {
 		Command: b.Command,
 		Inputs:  b.Inputs,
 	}, nil
+}
+
+// SourceInstall declares a pre-build dependency-install command. It is a peer
+// to Build and Dev: gestaltd execs Command directly (no shell) once before any
+// Build or Dev execution for a local-source provider. Side-effect only — it
+// never declares an entrypoint artifact and its output is not verified, like a
+// prepare-only build. Inputs is the cache-key allowlist (typically the
+// lockfile). Env may carry registry credentials.
+type SourceInstall struct {
+	Command []string          `json:"command"            yaml:"command"`
+	Workdir string            `json:"workdir,omitempty"  yaml:"workdir,omitempty"`
+	Inputs  []string          `json:"inputs,omitempty"   yaml:"inputs,omitempty"`
+	Env     map[string]string `json:"env,omitempty"      yaml:"env,omitempty"`
+}
+
+type sourceInstallWire struct {
+	Command []string          `json:"command"            yaml:"command"`
+	Workdir string            `json:"workdir,omitempty"  yaml:"workdir,omitempty"`
+	Inputs  []string          `json:"inputs,omitempty"   yaml:"inputs,omitempty"`
+	Env     map[string]string `json:"env,omitempty"      yaml:"env,omitempty"`
+}
+
+func (i *SourceInstall) UnmarshalJSON(data []byte) error {
+	if i == nil {
+		return nil
+	}
+	trimmed := bytes.TrimSpace(data)
+	if bytes.Equal(trimmed, []byte("null")) {
+		*i = SourceInstall{}
+		return nil
+	}
+	if len(trimmed) > 0 && trimmed[0] == '[' {
+		return fmt.Errorf("install must be a mapping")
+	}
+	if err := validateJSONWireObjectFields(trimmed, sourceInstallWireFields); err != nil {
+		return err
+	}
+	var raw sourceInstallWire
+	if err := decodeJSONKnownFields(trimmed, &raw); err != nil {
+		return err
+	}
+	if len(raw.Command) == 0 {
+		return fmt.Errorf("install.command is required")
+	}
+	*i = SourceInstall(raw)
+	return nil
+}
+
+func (i SourceInstall) MarshalJSON() ([]byte, error) {
+	return json.Marshal(sourceInstallWire(i))
+}
+
+func (i *SourceInstall) UnmarshalYAML(value *yaml.Node) error {
+	if i == nil {
+		return nil
+	}
+	if value == nil {
+		*i = SourceInstall{}
+		return nil
+	}
+	if value.Kind != yaml.MappingNode {
+		return fmt.Errorf("install must be a mapping")
+	}
+	if err := validateYAMLWireObjectFields(value, sourceInstallWireFields, "install"); err != nil {
+		return err
+	}
+	var raw sourceInstallWire
+	if err := decodeYAMLKnownFields(value, &raw); err != nil {
+		return err
+	}
+	if len(raw.Command) == 0 {
+		return fmt.Errorf("install.command is required")
+	}
+	*i = SourceInstall(raw)
+	return nil
+}
+
+func (i SourceInstall) MarshalYAML() (any, error) {
+	return sourceInstallWire(i), nil
 }
 
 // SourceDev declares a long-running development command that owns its own file
@@ -1005,6 +1085,13 @@ var sourceBuildWireFields = map[string]struct{}{
 	"workdir": {},
 	"command": {},
 	"inputs":  {},
+}
+
+var sourceInstallWireFields = map[string]struct{}{
+	"command": {},
+	"workdir": {},
+	"inputs":  {},
+	"env":     {},
 }
 
 var sourceDevWireFields = map[string]struct{}{

--- a/gestaltd/services/apps/packageio/manifest.go
+++ b/gestaltd/services/apps/packageio/manifest.go
@@ -157,6 +157,14 @@ func validateManifest(manifest *providermanifestv1.Manifest, sourceMode bool) er
 			return err
 		}
 	}
+	if manifest.Install != nil {
+		if !sourceMode {
+			return fmt.Errorf("install metadata is only allowed in source manifests")
+		}
+		if err := validateSourceInstall(manifest.Install); err != nil {
+			return err
+		}
+	}
 	if manifest.Run != nil {
 		if !sourceMode {
 			return fmt.Errorf("run metadata is only allowed in source manifests")
@@ -478,6 +486,35 @@ func validateSourceBuild(build *providermanifestv1.SourceBuild) error {
 	}
 	for i, input := range build.Inputs {
 		label := fmt.Sprintf("build.inputs[%d]", i)
+		if strings.ContainsAny(input, "*?[") {
+			return fmt.Errorf("%s does not support glob syntax", label)
+		}
+		if err := validateRelativeSourcePath(input, label); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateSourceInstall(install *providermanifestv1.SourceInstall) error {
+	if install == nil {
+		return nil
+	}
+	if install.Workdir != "" {
+		if err := validateRelativeSourcePath(install.Workdir, "install.workdir"); err != nil {
+			return err
+		}
+	}
+	if len(install.Command) == 0 {
+		return fmt.Errorf("install.command is required")
+	}
+	for i, arg := range install.Command {
+		if strings.TrimSpace(arg) == "" {
+			return fmt.Errorf("install.command[%d] is required", i)
+		}
+	}
+	for i, input := range install.Inputs {
+		label := fmt.Sprintf("install.inputs[%d]", i)
 		if strings.ContainsAny(input, "*?[") {
 			return fmt.Errorf("%s does not support glob syntax", label)
 		}

--- a/gestaltd/services/apps/providerpkg/manifest_source_run_test.go
+++ b/gestaltd/services/apps/providerpkg/manifest_source_run_test.go
@@ -1,8 +1,12 @@
 package providerpkg
 
 import (
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 )
 
 func TestSourceManifestPrepareBuildAndRunCommand(t *testing.T) {
@@ -58,5 +62,116 @@ spec:
 
 	if _, _, err := ReadManifestFile(manifestPath); err == nil || !strings.Contains(err.Error(), "build metadata is only allowed in source manifests") {
 		t.Fatalf("ReadManifestFile error = %v, want package build rejection", err)
+	}
+}
+
+func TestSourceManifestParsesInstallPhase(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	manifestPath := mustWriteManifestData(t, dir, "manifest.yaml", []byte(`
+kind: app
+source: github.com/acme/apps/install-phase
+version: 0.0.1-alpha.1
+install:
+  command: [uv, sync, --frozen]
+  inputs: [uv.lock]
+build:
+  command: [uv, run, python, -m, gestalt._build]
+  inputs: [provider.py]
+entrypoint:
+  artifactPath: .gestalt/build/provider
+spec:
+  connections:
+    default:
+      auth:
+        type: none
+`))
+
+	_, manifest, err := ReadSourceManifestFile(manifestPath)
+	if err != nil {
+		t.Fatalf("ReadSourceManifestFile: %v", err)
+	}
+	if manifest.Install == nil {
+		t.Fatalf("install = nil, want parsed install phase")
+	}
+	if got := strings.Join(manifest.Install.Command, " "); got != "uv sync --frozen" {
+		t.Fatalf("install.command = %q, want %q", got, "uv sync --frozen")
+	}
+	if len(manifest.Install.Inputs) != 1 || manifest.Install.Inputs[0] != "uv.lock" {
+		t.Fatalf("install.inputs = %#v, want [uv.lock]", manifest.Install.Inputs)
+	}
+
+	cloned, err := cloneManifest(manifest)
+	if err != nil {
+		t.Fatalf("cloneManifest: %v", err)
+	}
+	encoded, err := EncodeSourceManifestFormat(cloned, ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("EncodeSourceManifestFormat: %v", err)
+	}
+	roundTripped, err := DecodeSourceManifestFormat(encoded, ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("DecodeSourceManifestFormat(round trip): %v\n%s", err, encoded)
+	}
+	if roundTripped.Install == nil || strings.Join(roundTripped.Install.Command, " ") != "uv sync --frozen" {
+		t.Fatalf("round-tripped install = %#v", roundTripped.Install)
+	}
+
+	if _, _, err := ReadManifestFile(manifestPath); err == nil || !strings.Contains(err.Error(), "is only allowed in source manifests") {
+		t.Fatalf("ReadManifestFile error = %v, want source-only rejection", err)
+	}
+}
+
+func TestSourceManifestRejectsSequenceFormInstall(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	manifestPath := mustWriteManifestData(t, dir, "manifest.yaml", []byte(`
+kind: app
+source: github.com/acme/apps/sequence-install
+version: 0.0.1-alpha.1
+install: [uv, sync, --frozen]
+build:
+  command: [uv, run, python, -m, gestalt._build]
+entrypoint:
+  artifactPath: .gestalt/build/provider
+spec:
+  connections:
+    default:
+      auth:
+        type: none
+`))
+
+	_, _, err := ReadSourceManifestFile(manifestPath)
+	if err == nil || !strings.Contains(err.Error(), "install must be a mapping") {
+		t.Fatalf("ReadSourceManifestFile error = %v, want install must be a mapping", err)
+	}
+}
+
+func TestPrepareSourceManifest_RunsInstallBeforeRunCatalog(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == windowsOS {
+		t.Skip("install marker fixture uses POSIX shell")
+	}
+
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "install.sh"), []byte("#!/bin/sh\nset -eu\nprintf 'ok\n' > install-ran.txt\n"), 0o755)
+	mustWriteFile(t, filepath.Join(dir, "run.sh"), []byte("#!/bin/sh\nset -eu\ntest -f install-ran.txt\nif [ -n \"${GESTALT_APP_WRITE_CATALOG:-}\" ]; then\n  printf 'name: provider\\noperations:\\n  - id: echo\\n    method: POST\\n' > \"$GESTALT_APP_WRITE_CATALOG\"\nfi\n"), 0o755)
+	manifestPath := mustWriteManifestData(t, dir, "manifest.yaml", mustManifestYAML(t, &providermanifestv1.Manifest{
+		Kind:    providermanifestv1.KindApp,
+		Source:  "github.com/acme/apps/run-only-install",
+		Version: "0.0.1-alpha.1",
+		Install: &providermanifestv1.SourceInstall{
+			Command: []string{"sh", "./install.sh"},
+			Inputs:  []string{"install.sh"},
+		},
+		Run:  []string{"sh", "./run.sh"},
+		Spec: &providermanifestv1.Spec{},
+	}))
+
+	if _, _, err := PrepareSourceManifest(manifestPath); err != nil {
+		t.Fatalf("PrepareSourceManifest: %v (install should run before run/catalog)", err)
 	}
 }

--- a/gestaltd/services/apps/providerpkg/prepared_stage.go
+++ b/gestaltd/services/apps/providerpkg/prepared_stage.go
@@ -253,6 +253,7 @@ func buildPreparedInstallSourceManifest(srcManifest *providermanifestv1.Manifest
 	}
 	uiAssetRoot := SourceUIBuildOutput(manifest)
 	manifest.Version = version
+	manifest.Install = nil
 	manifest.Build = nil
 	manifest.Run = nil
 	manifest.Dev = nil

--- a/gestaltd/services/apps/providerpkg/prepared_stage_test.go
+++ b/gestaltd/services/apps/providerpkg/prepared_stage_test.go
@@ -562,3 +562,127 @@ func TestStagedReleaseBinaryNameAddsWindowsSuffix(t *testing.T) {
 		t.Fatalf("linux binary name = %q, want %q", got, "gestalt-app-release-test")
 	}
 }
+
+func TestStageSourcePreparedInstallDir_RunsInstallBeforeBuild(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	artifactPath := ".gestalt/build/provider"
+	installScript := `#!/bin/sh
+set -eu
+printf 'install-marker\n' > install-ran.txt
+`
+	buildScript := `#!/bin/sh
+set -eu
+test -f install-ran.txt
+mkdir -p .gestalt/build
+cat > .gestalt/build/provider <<'SH'
+#!/bin/sh
+if [ -n "$GESTALT_APP_WRITE_CATALOG" ]; then
+  printf 'name: provider\noperations:\n  - id: echo\n    method: POST\n' > "$GESTALT_APP_WRITE_CATALOG"
+fi
+SH
+chmod +x .gestalt/build/provider
+`
+	mustWriteFile(t, filepath.Join(root, "install.sh"), []byte(installScript), 0o755)
+	mustWriteFile(t, filepath.Join(root, "build.sh"), []byte(buildScript), 0o755)
+	manifestPath := mustWriteManifestData(t, root, "manifest.yaml", mustManifestYAML(t, &providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindApp,
+		Source:      "github.com/test/apps/install-phase",
+		Version:     "0.0.1-alpha.1",
+		DisplayName: "Install Phase",
+		Spec:        &providermanifestv1.Spec{},
+		Install: &providermanifestv1.SourceInstall{
+			Command: []string{"sh", "./install.sh"},
+			Inputs:  []string{"install.sh"},
+		},
+		Build: &providermanifestv1.SourceBuild{
+			Command: []string{"sh", "./build.sh"},
+			Inputs:  []string{"build.sh", "install-ran.txt"},
+		},
+		Entrypoint: &providermanifestv1.Entrypoint{ArtifactPath: artifactPath},
+	}))
+
+	stagingDir := filepath.Join(t.TempDir(), "prepared")
+	staged, err := StageSourcePreparedInstallDir(manifestPath, stagingDir, StageSourcePreparedInstallOptions{
+		Kind:    providermanifestv1.KindApp,
+		AppName: "install-phase-test",
+		GOOS:    runtime.GOOS,
+		GOARCH:  runtime.GOARCH,
+	})
+	if err != nil {
+		t.Fatalf("StageSourcePreparedInstallDir: %v", err)
+	}
+
+	if staged.Manifest == nil || staged.Manifest.Install != nil {
+		t.Fatalf("staged manifest should strip install: %#v", staged.Manifest)
+	}
+
+	stagedBinaryPath := filepath.Join(stagingDir, filepath.FromSlash(artifactPath))
+	if _, err := os.Stat(stagedBinaryPath); err != nil {
+		t.Fatalf("staged binary not produced: %v", err)
+	}
+}
+
+func TestRunSourceInstall_NoopWithoutInstall(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	manifestPath := mustWriteManifestData(t, root, "manifest.yaml", mustManifestYAML(t, &providermanifestv1.Manifest{
+		Kind:       providermanifestv1.KindApp,
+		Source:     "github.com/test/apps/no-install",
+		Version:    "0.0.1-alpha.1",
+		Spec:       &providermanifestv1.Spec{},
+		Entrypoint: &providermanifestv1.Entrypoint{ArtifactPath: ".gestalt/build/provider"},
+	}))
+	_, manifest, err := ReadSourceManifestFile(manifestPath)
+	if err != nil {
+		t.Fatalf("ReadSourceManifestFile: %v", err)
+	}
+	if err := RunSourceInstall(manifestPath, manifest, SourceBuildOptions{}); err != nil {
+		t.Fatalf("RunSourceInstall with nil install should be a no-op, got: %v", err)
+	}
+}
+
+func TestSourceManifestExecution_RunsInstallBeforeBuild(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == windowsOS {
+		t.Skip("install marker fixture uses POSIX shell")
+	}
+
+	root := t.TempDir()
+	artifactPath := ".gestalt/build/provider"
+	installScript := `#!/bin/sh
+set -eu
+printf 'install-marker\n' > install-ran.txt
+`
+	buildScript := `#!/bin/sh
+set -eu
+test -f install-ran.txt
+mkdir -p .gestalt/build
+printf '#!/bin/sh\nexit 0\n' > .gestalt/build/provider
+chmod +x .gestalt/build/provider
+`
+	mustWriteFile(t, filepath.Join(root, "install.sh"), []byte(installScript), 0o755)
+	mustWriteFile(t, filepath.Join(root, "build.sh"), []byte(buildScript), 0o755)
+	manifestPath := mustWriteManifestData(t, root, "manifest.yaml", mustManifestYAML(t, &providermanifestv1.Manifest{
+		Kind:    providermanifestv1.KindApp,
+		Source:  "github.com/test/apps/exec-install-phase",
+		Version: "0.0.1-alpha.1",
+		Spec:    &providermanifestv1.Spec{},
+		Install: &providermanifestv1.SourceInstall{
+			Command: []string{"sh", "./install.sh"},
+			Inputs:  []string{"install.sh"},
+		},
+		Build: &providermanifestv1.SourceBuild{
+			Command: []string{"sh", "./build.sh"},
+			Inputs:  []string{"build.sh", "install-ran.txt"},
+		},
+		Entrypoint: &providermanifestv1.Entrypoint{ArtifactPath: artifactPath},
+	}))
+
+	if _, err := SourceManifestExecution(manifestPath, providermanifestv1.KindApp, SourceBuildOptions{}); err != nil {
+		t.Fatalf("SourceManifestExecution: %v (install should run before build)", err)
+	}
+}

--- a/gestaltd/services/apps/providerpkg/source_build.go
+++ b/gestaltd/services/apps/providerpkg/source_build.go
@@ -20,6 +20,13 @@ type ResolvedSourceBuild struct {
 	PrepareOnly bool
 }
 
+type ResolvedSourceInstall struct {
+	Workdir string
+	Command []string
+	Inputs  []string
+	Env     map[string]string
+}
+
 type ResolvedSourceDev struct {
 	Workdir      string
 	Command      []string
@@ -89,6 +96,45 @@ func SourceBuildProducesOutput(manifest *providermanifestv1.Manifest) bool {
 	return build != nil && !build.PrepareOnly
 }
 
+func EffectiveSourceInstall(manifest *providermanifestv1.Manifest) *ResolvedSourceInstall {
+	if manifest == nil || manifest.Install == nil {
+		return nil
+	}
+	return &ResolvedSourceInstall{
+		Workdir: manifest.Install.Workdir,
+		Command: append([]string(nil), manifest.Install.Command...),
+		Inputs:  append([]string(nil), manifest.Install.Inputs...),
+		Env:     maps.Clone(manifest.Install.Env),
+	}
+}
+
+// RunSourceInstall execs the declared install command (no shell) from the
+// source root. Side-effect only: no entrypoint artifact is verified. A nil
+// install phase is a no-op. opts carries the target platform env that
+// sourceBuildEnv injects; install.Env is merged on top (install wins).
+func RunSourceInstall(manifestPath string, manifest *providermanifestv1.Manifest, opts SourceBuildOptions) error {
+	install := EffectiveSourceInstall(manifest)
+	if install == nil {
+		return nil
+	}
+	return runSourcePhase(manifestPath, "install", install.Workdir, install.Command, envMapToSlice(install.Env), opts)
+}
+
+func envMapToSlice(env map[string]string) []string {
+	if len(env) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(env))
+	for key, value := range env {
+		out = append(out, key+"="+value)
+	}
+	return out
+}
+
+// RunSourceBuild execs the declared build command (no shell) and, when the
+// build is not prepare-only, verifies the entrypoint artifact. It does NOT run
+// the install phase; callers that need install-before-build should use
+// EnsureSourceBuildOutput, which is the canonical install-then-build entry.
 func RunSourceBuild(manifestPath string, manifest *providermanifestv1.Manifest, opts SourceBuildOptions) error {
 	build := EffectiveSourceBuild(manifest)
 	if build == nil {
@@ -99,19 +145,6 @@ func RunSourceBuild(manifestPath string, manifest *providermanifestv1.Manifest, 
 	}
 
 	rootDir := filepath.Dir(manifestPath)
-	workdir := rootDir
-	if build.Workdir != "" && build.Workdir != "." {
-		workdir = filepath.Join(rootDir, filepath.FromSlash(build.Workdir))
-	}
-
-	info, err := os.Stat(workdir)
-	if err != nil {
-		return fmt.Errorf("stat %s.workdir %q: %w", build.Label, build.Workdir, err)
-	}
-	if !info.IsDir() {
-		return fmt.Errorf("%s.workdir %q is not a directory", build.Label, build.Workdir)
-	}
-
 	var outputRel, outputKind, outputPath string
 	if !build.PrepareOnly {
 		var err error
@@ -125,18 +158,92 @@ func RunSourceBuild(manifestPath string, manifest *providermanifestv1.Manifest, 
 		}
 	}
 
-	cmd := exec.Command(build.Command[0], build.Command[1:]...)
-	cmd.Dir = workdir
-	cmd.Env = sourceBuildEnv(os.Environ(), opts)
-	cmd.Stdout = commandStdout(opts.Output)
-	cmd.Stderr = commandStderr(opts.Output)
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("run %s.command: %w", build.Label, err)
+	if err := runSourcePhase(manifestPath, build.Label, build.Workdir, build.Command, nil, opts); err != nil {
+		return err
 	}
 	if build.PrepareOnly {
 		return nil
 	}
 	return verifySourceBuildOutput(outputPath, outputRel, outputKind, opts)
+}
+
+// runSourcePhase execs a declared phase command (no shell) from the source
+// root, resolving the optional relative workdir and merging phase env over the
+// target-platform env. Shared by install and build.
+func runSourcePhase(manifestPath, label, workdir string, command, envOverrides []string, opts SourceBuildOptions) error {
+	if len(command) == 0 {
+		return fmt.Errorf("%s.command is required", label)
+	}
+
+	rootDir := filepath.Dir(manifestPath)
+	phaseWorkdir := rootDir
+	if workdir != "" && workdir != "." {
+		phaseWorkdir = filepath.Join(rootDir, filepath.FromSlash(workdir))
+	}
+
+	info, err := os.Stat(phaseWorkdir)
+	if err != nil {
+		return fmt.Errorf("stat %s.workdir %q: %w", label, workdir, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s.workdir %q is not a directory", label, workdir)
+	}
+
+	cmd := exec.Command(command[0], command[1:]...)
+	cmd.Dir = phaseWorkdir
+	cmd.Env = mergePhaseEnv(sourceBuildEnv(os.Environ(), opts), envOverrides)
+	cmd.Stdout = commandStdout(opts.Output)
+	cmd.Stderr = commandStderr(opts.Output)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("run %s.command: %w", label, err)
+	}
+	return nil
+}
+
+// mergePhaseEnv folds a phase's env overrides (as "KEY=VALUE" strings) over the
+// target-platform env; phase values win.
+func mergePhaseEnv(base, overrides []string) []string {
+	if len(overrides) == 0 {
+		return base
+	}
+	overridden := make(map[string]struct{}, len(overrides))
+	merged := make([]string, 0, len(base)+len(overrides))
+	for _, kv := range base {
+		key, _, ok := strings.Cut(kv, "=")
+		if ok {
+			if _, hit := overridden[key]; hit {
+				continue
+			}
+			if override, hit := lookupEnv(overrides, key); hit {
+				overridden[key] = struct{}{}
+				merged = append(merged, key+"="+override)
+				continue
+			}
+		}
+		merged = append(merged, kv)
+	}
+	for _, kv := range overrides {
+		key, value, ok := strings.Cut(kv, "=")
+		if !ok {
+			continue
+		}
+		if _, hit := overridden[key]; hit {
+			continue
+		}
+		overridden[key] = struct{}{}
+		merged = append(merged, key+"="+value)
+	}
+	return merged
+}
+
+func lookupEnv(env []string, key string) (string, bool) {
+	for _, kv := range env {
+		k, v, ok := strings.Cut(kv, "=")
+		if ok && k == key {
+			return v, true
+		}
+	}
+	return "", false
 }
 
 func SourceBuildOutput(manifest *providermanifestv1.Manifest) (rel string, kind string, err error) {
@@ -223,7 +330,14 @@ func SourceBuildTarget(opts SourceBuildOptions) (string, string) {
 	return goos, goarch
 }
 
+// EnsureSourceBuildOutput is the canonical install-then-build entry for a
+// source provider: it runs the install phase (if declared) before the build,
+// then verifies the entrypoint artifact. Callers that need a build output
+// should use this rather than RunSourceBuild, which is build-only.
 func EnsureSourceBuildOutput(manifestPath string, manifest *providermanifestv1.Manifest, opts SourceBuildOptions) error {
+	if err := RunSourceInstall(manifestPath, manifest, opts); err != nil {
+		return err
+	}
 	if err := RunSourceBuild(manifestPath, manifest, opts); err != nil {
 		return err
 	}
@@ -257,6 +371,14 @@ func SourceBuildInputs(manifest *providermanifestv1.Manifest) []string {
 	return append([]string(nil), build.Inputs...)
 }
 
+func SourceInstallInputs(manifest *providermanifestv1.Manifest) []string {
+	install := EffectiveSourceInstall(manifest)
+	if install == nil {
+		return nil
+	}
+	return append([]string(nil), install.Inputs...)
+}
+
 func SourceManifestExecution(manifestPath, kind string, opts SourceBuildOptions) (SourceExecution, error) {
 	absoluteManifestPath, err := filepath.Abs(manifestPath)
 	if err != nil {
@@ -268,6 +390,9 @@ func SourceManifestExecution(manifestPath, kind string, opts SourceBuildOptions)
 		return SourceExecution{}, err
 	}
 	if HasExplicitSourceRun(manifest) {
+		if err := RunSourceInstall(manifestPath, manifest, opts); err != nil {
+			return SourceExecution{}, err
+		}
 		if err := ensurePrepareOnlyBuild(manifestPath, manifest, opts); err != nil {
 			return SourceExecution{}, err
 		}

--- a/gestaltd/services/apps/providerpkg/source_prepare.go
+++ b/gestaltd/services/apps/providerpkg/source_prepare.go
@@ -51,6 +51,11 @@ func prepareSourceManifest(manifestPath string, packaging bool, buildOpts Source
 	if err != nil {
 		return nil, nil, err
 	}
+	if !packaging {
+		if err := RunSourceInstall(manifestPath, manifest, buildOpts); err != nil {
+			return nil, nil, err
+		}
+	}
 	if err := ensurePrepareOnlyBuild(manifestPath, manifest, buildOpts); err != nil {
 		return nil, nil, err
 	}

--- a/gestaltd/services/providerdev/supervisor.go
+++ b/gestaltd/services/providerdev/supervisor.go
@@ -81,6 +81,9 @@ func TargetsFromConfig(cfg *config.Config) ([]Target, error) {
 		if dev == nil {
 			return nil, fmt.Errorf("ui %q: dev-active without dev manifest", name)
 		}
+		if err := providerpkg.RunSourceInstall(entry.ResolvedManifestPath, entry.ResolvedManifest, providerpkg.SourceBuildOptions{}); err != nil {
+			return nil, fmt.Errorf("ui %q: install: %w", name, err)
+		}
 		readyTimeout := defaultReadyTimeout
 		if strings.TrimSpace(dev.ReadyTimeout) != "" {
 			parsed, err := config.ParseDuration(dev.ReadyTimeout)

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -49,6 +49,29 @@ routes, passthrough surfaces, and release metadata. Use Python code for
 executable operations, provider lifecycle hooks, host-service clients, and
 provider-specific runtimes.
 
+## Build entrypoint
+
+The Python build entrypoint freezes a provider into a standalone executable
+with PyInstaller. It accepts seven explicit positional args, or zero args:
+
+```sh
+# explicit
+python -m gestalt._build ROOT MODULE[:ATTRIBUTE] OUTPUT PLUGIN_NAME RUNTIME_KIND GOOS GOARCH
+
+# zero-arg: derive from manifest.yaml + pyproject.toml + env
+python -m gestalt._build
+```
+
+With zero args the entrypoint derives the target from
+`pyproject.toml`'s `[tool.gestalt].provider`, the output path from
+`manifest.yaml#entrypoint.artifactPath`, the plugin name from the last segment
+of `manifest.yaml#source`, the runtime kind from `manifest.yaml#kind`
+(`app` maps to `integration`), and the target platform from the
+`GESTALT_TARGET_OS` / `GESTALT_TARGET_ARCH` env vars (falling back to the host
+platform). This lets a provider declare a fixed
+`build.command: [uv, run, python, -m, gestalt._build]` with no per-provider
+wrapper script.
+
 ## Build cache
 
 Python executable provider builds can opt into the generic Gestalt build cache

--- a/sdk/python/gestalt/_bootstrap.py
+++ b/sdk/python/gestalt/_bootstrap.py
@@ -1,9 +1,104 @@
+import importlib
 import json
 import pathlib
 from dataclasses import dataclass
-from typing import Final
+from typing import Any, Final
+
+import yaml
 
 BUNDLED_CONFIG_NAME: Final[str] = "gestalt-runtime.json"
+
+_MANIFEST_BASENAMES: Final[tuple[str, ...]] = (
+    "manifest.yaml",
+    "manifest.yml",
+    "manifest.json",
+)
+
+
+@dataclass(frozen=True)
+class SourceManifest:
+    kind: str | None
+    source: str | None
+    entrypoint_artifact_path: str | None
+
+
+def read_source_manifest(root: pathlib.Path) -> SourceManifest:
+    """Read the build-relevant fields from a provider source manifest.
+
+    Dispatches on the manifest file extension. Raises ``FileNotFoundError`` if
+    no manifest is present in ``root``.
+    """
+    for name in _MANIFEST_BASENAMES:
+        path = root / name
+        if not path.exists():
+            continue
+        return _parse_source_manifest(path)
+    raise FileNotFoundError(
+        f"no manifest file found in {root} (tried {', '.join(_MANIFEST_BASENAMES)})"
+    )
+
+
+def _parse_source_manifest(path: pathlib.Path) -> SourceManifest:
+    text = path.read_text(encoding="utf-8")
+    data: Any
+    if path.suffix.lower() == ".json":
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError as err:
+            raise RuntimeError(f"{path.name}: {err}") from err
+    else:
+        try:
+            data = yaml.safe_load(text)
+        except yaml.YAMLError as err:
+            raise RuntimeError(f"{path.name}: {err}") from err
+    if not isinstance(data, dict):
+        raise RuntimeError(f"{path.name} must be a mapping")
+
+    kind = data.get("kind")
+    kind = kind.strip() if isinstance(kind, str) else None
+
+    source = data.get("source")
+    source = source.strip() if isinstance(source, str) else None
+
+    entrypoint = data.get("entrypoint")
+    artifact_path = None
+    if isinstance(entrypoint, dict):
+        raw_path = entrypoint.get("artifactPath")
+        if isinstance(raw_path, str):
+            artifact_path = raw_path.strip() or None
+
+    return SourceManifest(
+        kind=kind,
+        source=source,
+        entrypoint_artifact_path=artifact_path,
+    )
+
+
+def read_pyproject_provider(root: pathlib.Path) -> str:
+    """Read ``[tool.gestalt].provider`` from a project's pyproject.toml.
+
+    Returns the provider target string (``module`` or ``module:attribute``).
+    Raises ``RuntimeError`` if the value is missing or not a string.
+    """
+    tomllib = _load_tomllib()
+
+    pyproject_path = root / "pyproject.toml"
+    with pyproject_path.open("rb") as handle:
+        data = tomllib.load(handle)
+
+    provider = data.get("tool", {}).get("gestalt", {}).get("provider")
+    if not isinstance(provider, str) or not provider.strip():
+        raise RuntimeError("pyproject.toml [tool.gestalt].provider is required")
+    return provider.strip()
+
+
+def _load_tomllib() -> Any:
+    # tomllib is stdlib on 3.11+; tomli is the 3.10 backport (declared dep).
+    # Resolved via importlib so static analysis does not pin to one version.
+    try:
+        return importlib.import_module("tomllib")
+    except ModuleNotFoundError:
+        return importlib.import_module("tomli")
 
 
 @dataclass(frozen=True)

--- a/sdk/python/gestalt/_build.py
+++ b/sdk/python/gestalt/_build.py
@@ -16,14 +16,39 @@ from typing import Final
 from ._bootstrap import (
     BUNDLED_CONFIG_NAME,
     parse_plugin_target,
+    read_pyproject_provider,
+    read_source_manifest,
     write_bundled_plugin_config,
 )
 
 USAGE: Final[str] = (
-    "usage: python -m gestalt._build ROOT MODULE[:ATTRIBUTE] OUTPUT PLUGIN_NAME RUNTIME_KIND GOOS GOARCH"
+    "usage: python -m gestalt._build [ROOT MODULE[:ATTRIBUTE] OUTPUT PLUGIN_NAME RUNTIME_KIND GOOS GOARCH]\n"
+    "  (zero args: derive from manifest.yaml + pyproject.toml + env)"
 )
 BUILD_CACHE_DIR_ENV_VAR: Final[str] = "GESTALT_BUILD_CACHE_DIR"
 BUILD_CACHE_SCHEMA_VERSION: Final[str] = "python-provider-package-v1"
+TARGET_OS_ENV: Final[str] = "GESTALT_TARGET_OS"
+TARGET_ARCH_ENV: Final[str] = "GESTALT_TARGET_ARCH"
+
+_RUNTIME_KIND_BY_MANIFEST_KIND: Final[dict[str, str]] = {
+    "app": "integration",
+    "identity": "identity",
+    "authorization": "authorization",
+    "externalcredentials": "externalcredentials",
+    "indexeddb": "indexeddb",
+    "cache": "cache",
+    "s3": "s3",
+    "workflow": "workflow",
+    "agent": "agent",
+    "secrets": "secrets",
+    "runtime": "runtime",
+    "telemetry": "telemetry",
+}
+_DEFAULT_RUNTIME_KIND: Final[str] = "integration"
+_ARCH_ALIASES: Final[dict[str, str]] = {
+    "x86_64": "amd64",
+    "aarch64": "arm64",
+}
 
 
 @dataclass(frozen=True)
@@ -38,13 +63,62 @@ class BuildArgs:
 
 
 def main(argv: list[str] | None = None) -> int:
-    build_args = _parse_build_args(sys.argv[1:] if argv is None else argv)
+    args = sys.argv[1:] if argv is None else argv
+    build_args = derive_build_args(pathlib.Path.cwd()) if len(args) == 0 else _parse_build_args(args)
     if build_args is None:
         print(USAGE, file=sys.stderr)
         return 2
 
     build_plugin_binary(build_args)
     return 0
+
+
+def derive_build_args(root: pathlib.Path) -> BuildArgs | None:
+    """Derive build args from manifest.yaml + pyproject.toml + env.
+
+    Used when the build entrypoint is invoked with zero positional args.
+    Returns ``None`` (after printing the error) so ``main`` surfaces USAGE.
+    """
+    try:
+        manifest = read_source_manifest(root)
+        if manifest.entrypoint_artifact_path is None:
+            raise RuntimeError("manifest entrypoint.artifactPath is required")
+        if manifest.source is None:
+            raise RuntimeError("manifest source is required")
+        return BuildArgs(
+            root=root,
+            target=read_pyproject_provider(root),
+            output_path=pathlib.Path(manifest.entrypoint_artifact_path),
+            app_name=manifest.source.rsplit("/", 1)[-1],
+            runtime_kind=_runtime_kind_for_manifest_kind(manifest.kind),
+            goos=_target_goos(),
+            goarch=_target_goarch(),
+        )
+    except (OSError, RuntimeError, ValueError) as err:
+        print(str(err) if str(err) else repr(err), file=sys.stderr)
+        return None
+
+
+def _runtime_kind_for_manifest_kind(kind: str | None) -> str:
+    if kind is None:
+        return _DEFAULT_RUNTIME_KIND
+    normalized = kind.strip().lower()
+    return _RUNTIME_KIND_BY_MANIFEST_KIND.get(normalized, _DEFAULT_RUNTIME_KIND)
+
+
+def _target_goos() -> str:
+    raw = os.environ.get(TARGET_OS_ENV, "").strip()
+    if raw:
+        return raw
+    return platform.system().lower()
+
+
+def _target_goarch() -> str:
+    raw = os.environ.get(TARGET_ARCH_ENV, "").strip()
+    if raw:
+        return raw
+    machine = platform.machine().lower()
+    return _ARCH_ALIASES.get(machine, machine)
 
 
 def _parse_build_args(args: list[str]) -> BuildArgs | None:

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
   "pyinstaller<7",
   "protobuf>=6.33.1,<8",
   "typing-extensions==4.12.2",
+  "tomli>=2.0.1,<3; python_version < '3.11'",
 ]
 
 [dependency-groups]

--- a/sdk/python/tests/test_build.py
+++ b/sdk/python/tests/test_build.py
@@ -327,5 +327,108 @@ class BuildTests(unittest.TestCase):
         self.assertEqual(result.goarch, "amd64")
 
 
+    def test_derive_build_args_reads_manifest_and_pyproject(self) -> None:
+        """Zero-arg derivation reads target, output, name, and runtime kind."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = pathlib.Path(tmpdir)
+            (root / "manifest.yaml").write_text(
+                "kind: app\n"
+                "source: github.com/valon-technologies/valon-tools/apps/code-review\n"
+                "entrypoint:\n"
+                "  artifactPath: .gestalt/build/provider\n",
+                encoding="utf-8",
+            )
+            (root / "pyproject.toml").write_text(
+                "[tool.gestalt]\nprovider = \"provider\"\n",
+                encoding="utf-8",
+            )
+            with mock.patch.dict(
+                _build.os.environ,
+                {_build.TARGET_OS_ENV: "linux", _build.TARGET_ARCH_ENV: "arm64"},
+                clear=False,
+            ):
+                args = _build.derive_build_args(root)
+
+        self.assertIsNotNone(args)
+        assert args is not None
+        self.assertEqual(args.root, root)
+        self.assertEqual(args.target, "provider")
+        self.assertEqual(args.output_path, pathlib.Path(".gestalt/build/provider"))
+        self.assertEqual(args.app_name, "code-review")
+        self.assertEqual(args.runtime_kind, "integration")
+        self.assertEqual(args.goos, "linux")
+        self.assertEqual(args.goarch, "arm64")
+
+    def test_derive_build_args_maps_identity_kind_to_identity_runtime(self) -> None:
+        """A non-app manifest kind derives the matching runtime kind."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = pathlib.Path(tmpdir)
+            (root / "manifest.yaml").write_text(
+                "kind: identity\n"
+                "source: github.com/valon-technologies/valon-tools/identity/local\n"
+                "entrypoint:\n"
+                "  artifactPath: .gestalt/build/local\n",
+                encoding="utf-8",
+            )
+            (root / "pyproject.toml").write_text(
+                "[tool.gestalt]\nprovider = \"provider:provider\"\n",
+                encoding="utf-8",
+            )
+            args = _build.derive_build_args(root)
+
+        self.assertIsNotNone(args)
+        assert args is not None
+        self.assertEqual(args.app_name, "local")
+        self.assertEqual(args.runtime_kind, "identity")
+        self.assertEqual(args.target, "provider:provider")
+
+    def test_derive_build_args_falls_back_to_host_platform(self) -> None:
+        """Missing target env vars fall back to the host platform."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = pathlib.Path(tmpdir)
+            (root / "manifest.yaml").write_text(
+                "kind: app\n"
+                "source: github.com/x/y\n"
+                "entrypoint:\n"
+                "  artifactPath: out\n",
+                encoding="utf-8",
+            )
+            (root / "pyproject.toml").write_text(
+                "[tool.gestalt]\nprovider = \"provider\"\n",
+                encoding="utf-8",
+            )
+            env = {
+                _build.TARGET_OS_ENV: "",
+                _build.TARGET_ARCH_ENV: "",
+            }
+            with (
+                mock.patch.dict(_build.os.environ, env, clear=False),
+                mock.patch.object(_build.platform, "system", lambda: "Darwin"),
+                mock.patch.object(_build.platform, "machine", lambda: "arm64"),
+            ):
+                args = _build.derive_build_args(root)
+
+        assert args is not None
+        self.assertEqual(args.goos, "darwin")
+        self.assertEqual(args.goarch, "arm64")
+
+    def test_derive_build_args_missing_entrypoint_returns_none(self) -> None:
+        """A manifest without entrypoint.artifactPath surfaces a derivation error."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = pathlib.Path(tmpdir)
+            (root / "manifest.yaml").write_text(
+                "kind: app\nsource: github.com/x/y\n",
+                encoding="utf-8",
+            )
+            (root / "pyproject.toml").write_text(
+                "[tool.gestalt]\nprovider = \"provider\"\n",
+                encoding="utf-8",
+            )
+            with mock.patch.dict(_build.os.environ, {}, clear=False):
+                result = _build.derive_build_args(root)
+
+        self.assertIsNone(result)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -192,6 +192,7 @@ dependencies = [
     { name = "protobuf" },
     { name = "pyinstaller" },
     { name = "pyyaml" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions" },
 ]
 
@@ -215,6 +216,7 @@ requires-dist = [
     { name = "protobuf", specifier = ">=6.33.1,<8" },
     { name = "pyinstaller", specifier = "<7" },
     { name = "pyyaml", specifier = "==6.0.3" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.1,<3" },
     { name = "typing-extensions", specifier = "==4.12.2" },
 ]
 

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -149,6 +149,21 @@ Release build:
 gestalt-ts-build ROOT app:./provider.ts#app OUTPUT PROVIDER_NAME GOOS GOARCH
 ```
 
+With no positional args, the build entrypoint derives every field from
+`manifest.yaml` plus `package.json` and the `GESTALT_TARGET_OS` /
+`GESTALT_TARGET_ARCH` env vars that gestaltd injects:
+
+```sh
+gestalt-ts-build
+```
+
+The derivation reads the provider target from `package.json#gestalt.provider`,
+the output path from `manifest.yaml#entrypoint.artifactPath`, the provider
+name from the last segment of `manifest.yaml#source`, and the target platform
+from env (falling back to the host platform). This lets a provider declare a
+fixed `build.command: [bun, run, gestalt-ts-build]` with no per-provider
+wrapper script.
+
 The build entrypoint compiles a standalone executable with Bun and bundles the
 provider source into the result.
 

--- a/sdk/typescript/src/build.ts
+++ b/sdk/typescript/src/build.ts
@@ -16,13 +16,15 @@ import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
 import { defaultProviderExportNames } from "./provider-kind.ts";
-import { parseProviderTarget, resolveProviderModulePath, type ProviderTarget } from "./target.ts";
+import { readSourceManifest } from "./manifest.ts";
+import { parseProviderTarget, readPackageProviderTarget, resolveProviderModulePath, formatProviderTarget, type ProviderTarget } from "./target.ts";
 
 /**
  * Command-line usage for the bundled build entrypoint.
  */
 export const USAGE =
-  "usage: bun run build.ts ROOT PROVIDER_TARGET OUTPUT PROVIDER_NAME GOOS GOARCH";
+  "usage: bun run build.ts [ROOT PROVIDER_TARGET OUTPUT PROVIDER_NAME GOOS GOARCH]\n" +
+  "  (zero args: derive ROOT/PROVIDER_TARGET/OUTPUT/PROVIDER_NAME/GOOS/GOARCH from manifest.yaml + package.json + env)";
 
 /**
  * Parsed arguments for the build entrypoint.
@@ -39,15 +41,77 @@ export type BuildArgs = {
 
 /**
  * CLI entrypoint that compiles a provider into a standalone Bun executable.
+ *
+ * With no positional args, derives every field from `manifest.yaml` +
+ * `package.json` + the `GESTALT_TARGET_OS`/`GESTALT_TARGET_ARCH` env vars that
+ * gestaltd injects. With six positional args, uses the explicit contract.
  */
 export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
-  const args = parseBuildArgs(argv);
+  const args = argv.length === 0 ? deriveBuildArgs(process.cwd()) : parseBuildArgs(argv);
   if (!args) {
     console.error(USAGE);
     return 2;
   }
   buildProviderBinary(args);
   return 0;
+}
+
+const TARGET_OS_ENV = "GESTALT_TARGET_OS";
+const TARGET_ARCH_ENV = "GESTALT_TARGET_ARCH";
+
+/**
+ * Derives build args from the source manifest + package metadata + env. Used
+ * when the build entrypoint is invoked with zero positional args.
+ */
+export function deriveBuildArgs(root: string): BuildArgs | undefined {
+  try {
+    const manifest = readSourceManifest(root);
+    const target = formatProviderTarget(readPackageProviderTarget(root));
+    const artifactPath = manifest.entrypoint?.artifactPath;
+    if (!artifactPath) {
+      throw new Error("manifest entrypoint.artifactPath is required");
+    }
+    const source = manifest.source;
+    if (!source) {
+      throw new Error("manifest source is required");
+    }
+    return {
+      root,
+      target,
+      outputPath: artifactPath,
+      providerName: providerNameFromSource(source),
+      goos: targetGoos(),
+      goarch: targetGoarch(),
+    };
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return undefined;
+  }
+}
+
+function providerNameFromSource(source: string): string {
+  return source.split("/").pop()!.trim();
+}
+
+function targetGoos(): string {
+  const env = process.env[TARGET_OS_ENV];
+  if (env && env.trim()) {
+    return env.trim();
+  }
+  return process.platform === "win32" ? "windows" : process.platform;
+}
+
+const ARCH_ALIASES: Record<string, string> = {
+  x64: "amd64",
+  aarch64: "arm64",
+};
+
+function targetGoarch(): string {
+  const env = process.env[TARGET_ARCH_ENV];
+  if (env && env.trim()) {
+    return env.trim();
+  }
+  return ARCH_ALIASES[process.arch] ?? process.arch;
 }
 
 /**

--- a/sdk/typescript/src/manifest.ts
+++ b/sdk/typescript/src/manifest.ts
@@ -1,0 +1,62 @@
+/**
+ * Source manifest reader for the zero-arg build derivation.
+ *
+ * The build entrypoint derives its positional args from `manifest.yaml` plus
+ * the language package manifest when invoked with no arguments. This module
+ * reads just the fields the derivation needs (kind, source, entrypoint artifact
+ * path), dispatching on the manifest file extension.
+ *
+ * @module manifest
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import YAML from "yaml";
+
+export type SourceManifest = {
+  kind?: string | undefined;
+  source?: string | undefined;
+  entrypoint?: {
+    artifactPath?: string | undefined;
+  } | undefined;
+};
+
+const MANIFEST_BASENAMES = ["manifest.yaml", "manifest.yml", "manifest.json"] as const;
+
+/**
+ * Reads the source manifest from a provider root, returning the fields the
+ * build derivation consumes. Throws if no manifest is found.
+ */
+export function readSourceManifest(root: string): SourceManifest {
+  for (const name of MANIFEST_BASENAMES) {
+    const path = resolve(root, name);
+    let raw: string;
+    try {
+      raw = readFileSync(path, "utf8");
+    } catch {
+      continue;
+    }
+    return parseSourceManifest(raw, name);
+  }
+  throw new Error(`no manifest file found in ${root} (tried ${MANIFEST_BASENAMES.join(", ")})`);
+}
+
+function parseSourceManifest(raw: string, name: string): SourceManifest {
+  const data = name.endsWith(".json") ? (JSON.parse(raw) as Record<string, unknown>) : YAML.parse(raw);
+  if (data === null || typeof data !== "object" || Array.isArray(data)) {
+    throw new Error(`${name} must be a mapping`);
+  }
+  const record = data as Record<string, unknown>;
+  const entrypoint = record.entrypoint;
+  const manifest: SourceManifest = {
+    kind: typeof record.kind === "string" ? record.kind : undefined,
+    source: typeof record.source === "string" ? record.source : undefined,
+  };
+  if (entrypoint !== null && typeof entrypoint === "object" && !Array.isArray(entrypoint)) {
+    const artifactPath = (entrypoint as Record<string, unknown>).artifactPath;
+    if (typeof artifactPath === "string") {
+      manifest.entrypoint = { artifactPath };
+    }
+  }
+  return manifest;
+}

--- a/sdk/typescript/tests/build.test.ts
+++ b/sdk/typescript/tests/build.test.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcess } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { create } from "@bufbuild/protobuf";
@@ -48,6 +49,7 @@ import {
 import {
   buildProviderBinary,
   bunTarget,
+  deriveBuildArgs,
   parseBuildArgs,
 } from "../src/build.ts";
 import { Cache } from "../src/index.ts";
@@ -130,6 +132,99 @@ test("build arg parsing validates required arguments", () => {
   expect(() => bunTarget("plan9", "amd64")).toThrow(
     "unsupported Bun target for plan9/amd64",
   );
+});
+
+function writeDerivationFixture(kind: string, source: string, artifactPath: string, providerTarget: string): string {
+  const root = mkdtempSync(join(tmpdir(), "gestalt-derive-"));
+  writeFileSync(
+    join(root, "manifest.yaml"),
+    `kind: ${kind}\nsource: ${source}\nentrypoint:\n  artifactPath: ${artifactPath}\n`,
+    "utf8",
+  );
+  writeFileSync(
+    join(root, "package.json"),
+    JSON.stringify({
+      name: "@valon-technologies/does-not-matter",
+      gestalt: { provider: { kind, target: providerTarget } },
+    }),
+    "utf8",
+  );
+  return root;
+}
+
+test("deriveBuildArgs reads manifest and package metadata", () => {
+  const root = writeDerivationFixture(
+    "app",
+    "github.com/valon-technologies/valon-tools/apps/agent-trace-viewer",
+    ".gestalt/build/provider",
+    "./provider.ts#provider",
+  );
+  try {
+    const originalOs = process.env.GESTALT_TARGET_OS;
+    const originalArch = process.env.GESTALT_TARGET_ARCH;
+    process.env.GESTALT_TARGET_OS = "linux";
+    process.env.GESTALT_TARGET_ARCH = "arm64";
+    try {
+      const args = deriveBuildArgs(root);
+      expect(args).toBeDefined();
+      expect(args!.root).toBe(root);
+      expect(args!.target).toBe("app:./provider.ts#provider");
+      expect(args!.outputPath).toBe(".gestalt/build/provider");
+      expect(args!.providerName).toBe("agent-trace-viewer");
+      expect(args!.goos).toBe("linux");
+      expect(args!.goarch).toBe("arm64");
+    } finally {
+      if (originalOs === undefined) {
+        delete process.env.GESTALT_TARGET_OS;
+      } else {
+        process.env.GESTALT_TARGET_OS = originalOs;
+      }
+      if (originalArch === undefined) {
+        delete process.env.GESTALT_TARGET_ARCH;
+      } else {
+        process.env.GESTALT_TARGET_ARCH = originalArch;
+      }
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("deriveBuildArgs derives identity name from manifest source not package name", () => {
+  const root = writeDerivationFixture(
+    "identity",
+    "github.com/valon-technologies/valon-tools/identity/local",
+    ".gestalt/build/local",
+    "./provider.ts#provider",
+  );
+  try {
+    const args = deriveBuildArgs(root);
+    expect(args).toBeDefined();
+    expect(args!.target).toBe("identity:./provider.ts#provider");
+    expect(args!.providerName).toBe("local");
+    expect(args!.outputPath).toBe(".gestalt/build/local");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("deriveBuildArgs returns undefined when entrypoint.artifactPath is missing", () => {
+  const root = mkdtempSync(join(tmpdir(), "gestalt-derive-noentry-"));
+  writeFileSync(
+    join(root, "manifest.yaml"),
+    "kind: app\nsource: github.com/x/y\n",
+    "utf8",
+  );
+  writeFileSync(
+    join(root, "package.json"),
+    JSON.stringify({ gestalt: { provider: { kind: "app", target: "./provider.ts#provider" } } }),
+    "utf8",
+  );
+  try {
+    expect(deriveBuildArgs(root)).toBeUndefined();
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("buildProviderBinary compiles a runnable identity provider executable", async () => {


### PR DESCRIPTION
## Summary

Declared provider builds use a single `build.command` slot that gestaltd execs directly with no shell. That forced providers to fuse dependency install and compile into one opaque `sh -c "install && build"` string and to ship a per-app `build.sh` wrapper that translates manifest and package fields into the 6-7 positional args the language SDK build CLIs require. This adds an optional `install` phase as a peer to `build` and `dev`, and teaches the TypeScript and Python SDK build entrypoints to derive their args from `manifest.yaml` plus the language package manifest when invoked with zero args.

`install` is object-form only, source-mode only, and side-effect only (no entrypoint artifact verified). gestaltd runs it once before any build execution (packaging/lock/sync, via `StageSourcePreparedInstallDir`) and once before dev execution (via `providerdev.TargetsFromConfig`), skipping silently when absent. The provider fingerprint folds `install.inputs` into the local-source digest so a lockfile bump re-runs install and build. The staged manifest strips `install` alongside `build`/`run`/`dev` so prebuilt snapshots never carry or re-run it. The change is additive and backward-compatible: existing manifests parse and build unchanged.

The zero-arg SDK derivation reads the provider target from `package.json#gestalt.provider` (TS) or `pyproject [tool.gestalt].provider` (Python), the output path from `manifest.yaml#entrypoint.artifactPath`, the provider name from the last segment of `manifest.yaml#source` (not the package name, which diverges for every provider), the runtime kind from the manifest kind (`app` maps to `integration`), and the target platform from the `GESTALT_TARGET_OS`/`GESTALT_TARGET_ARCH` env vars gestaltd injects. The existing 6/7-arg explicit contract is retained for tests and overrides. Together the two changes let a provider declare fixed per-language `install` and `build` argv lists with no wrapper script.

## Interfaces

```yaml
install:
  command: [bun, install, --frozen-lockfile]   # argv, NO shell
  inputs: [package.json, bun.lock]              # cache-key allowlist
  workdir: ""                                   # optional, relative
  env: {}                                       # optional, e.g. registry auth
build:
  command: [bun, run, gestalt-ts-build]         # zero-arg; SDK derives the rest
  inputs: [provider.ts, tsconfig.json, package.json]
entrypoint:
  artifactPath: .gestalt/build/provider
```

```go
type SourceInstall struct {
    Command []string          // argv, exec'd directly (NO shell)
    Workdir string            // relative, optional
    Inputs  []string          // cache-key allowlist (typically the lockfile)
    Env     map[string]string // merged over gestaltd's target-platform env
}
```

Run order: `install` -> `build` (packaging/lock/sync); `install` -> `dev` (local serve). Both skip when `install` is absent.

## Manifest schema

`Manifest.Install` is added before `Build`, with object-form-only wire encode/decode (sequence and scalar forms are rejected with `install must be a mapping`). `install.command` is required. Validation mirrors `build`: relative `workdir`, relative glob-free `inputs`, non-empty command args. The JSON schema gains a `sourceInstall` definition.

## SDK zero-arg derivation

```ts
// sdk/typescript/src/build.ts
export function deriveBuildArgs(root: string): BuildArgs | undefined;
export async function main(argv = process.argv.slice(2)): Promise<number> {
  const args = argv.length === 0 ? deriveBuildArgs(process.cwd()) : parseBuildArgs(argv);
  ...
}
```

```python
# sdk/python/gestalt/_build.py
def derive_build_args(root: pathlib.Path) -> BuildArgs | None: ...
def main(argv: list[str] | None = None) -> int:
    args = sys.argv[1:] if argv is None else argv
    build_args = derive_build_args(pathlib.Path.cwd()) if len(args) == 0 else _parse_build_args(args)
    ...
```

The Python SDK adds a conditional `tomli` dependency for 3.10 (stdlib `tomllib` on 3.11+), resolved via `importlib` so static analysis does not pin to one version.

## Tests

Integration tests cover install-before-build ordering (build fails if install did not run), staging strip of `install`, `RunSourceInstall` no-op when absent, manifest decode/round-trip of the install phase, sequence-form rejection, and source-mode gating. SDK tests cover `deriveBuildArgs`/`derive_build_args` for app and identity kinds, host-platform fallback, and missing-field errors; existing explicit-arg tests stay green. No proto/wire change, so sdkgen is unaffected.

## Follow-up

A separate toolshed PR will bump the app SDK dep, delete the ~33 `build.sh` wrappers, rewrite manifests to the `install:` + zero-arg `build:` form, bump `GESTALTD_IMAGE` to the published image from this PR, and regenerate the deploy lockfile.
