### PR TITLE
Restore implicit Go provider build synthesis

### DIFF
--- a/gestaltd/internal/daemon/provider_package.go
+++ b/gestaltd/internal/daemon/provider_package.go
@@ -264,6 +264,12 @@ func resolveReleaseBuildTarget(root string, manifest *providermanifestv1.Manifes
 	}
 	entry := providerpkg.EntrypointForKind(manifest, kind)
 	if entry != nil && strings.TrimSpace(entry.ArtifactPath) != "" {
+		// A Go provider with an entrypoint but no build.command is built
+		// implicitly by gestaltd (synthesized wrapper main); otherwise the
+		// entrypoint artifact is assumed to be prebuilt.
+		if providerpkg.HasGoProviderPackage(root) {
+			return &releaseBuildTarget{Kind: kind, ImplicitGoBuild: true}, nil
+		}
 		return &releaseBuildTarget{Kind: kind, Prebuilt: true}, nil
 	}
 	if providerpkg.ReleaseRequiresBuild(manifest) {
@@ -283,7 +289,7 @@ func resolveReleaseBuildPlatforms(root string, manifest *providermanifestv1.Mani
 		return nil, fmt.Errorf("provider package requires build.command for executable source providers")
 	}
 
-	buildRequired := target.DeclaredBuild || providerpkg.ReleaseRequiresBuild(manifest)
+	buildRequired := target.DeclaredBuild || target.ImplicitGoBuild || providerpkg.ReleaseRequiresBuild(manifest)
 	if !buildRequired && !explicit {
 		return nil, nil
 	}

--- a/gestaltd/internal/daemon/provider_release_types.go
+++ b/gestaltd/internal/daemon/provider_release_types.go
@@ -10,9 +10,10 @@ type releasePlatform struct {
 }
 
 type releaseBuildTarget struct {
-	Kind          string
-	DeclaredBuild bool
-	Prebuilt      bool
+	Kind            string
+	DeclaredBuild   bool
+	Prebuilt        bool
+	ImplicitGoBuild bool
 }
 
 type releaseArchive struct {

--- a/gestaltd/services/apps/providerpkg/go_provider.go
+++ b/gestaltd/services/apps/providerpkg/go_provider.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"text/template"
 
@@ -18,9 +17,8 @@ import (
 const goReadonlyFlag = "-mod=readonly"
 
 var (
-	ErrNoGoProviderPackage  = errors.New("no Go provider package found")
-	ErrGoToolUnavailable    = errors.New("go tool unavailable")
-	goProviderNameSlugRegex = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
+	ErrNoGoProviderPackage = errors.New("no Go provider package found")
+	ErrGoToolUnavailable   = errors.New("go tool unavailable")
 )
 
 type goExecutableWrapperData struct {

--- a/gestaltd/services/apps/providerpkg/go_provider.go
+++ b/gestaltd/services/apps/providerpkg/go_provider.go
@@ -1,0 +1,220 @@
+package providerpkg
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"go/format"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"text/template"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+const goReadonlyFlag = "-mod=readonly"
+
+var (
+	ErrNoGoProviderPackage  = errors.New("no Go provider package found")
+	ErrGoToolUnavailable    = errors.New("go tool unavailable")
+	goProviderNameSlugRegex = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
+)
+
+type goExecutableWrapperData struct {
+	ImportPath string
+	ServeCall  string
+}
+
+const goExecutableWrapperSource = `package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	providerpkg {{printf "%q" .ImportPath}}
+	gestalt "github.com/valon-technologies/gestalt/sdk/go"
+)
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	if err := {{.ServeCall}}; err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+`
+
+var goExecutableWrapperTemplate = template.Must(template.New("go-executable-wrapper").Parse(goExecutableWrapperSource))
+
+// HasGoProviderPackage reports whether root looks like a Go source provider:
+// `go list .` (which walks up to the nearest go.mod) resolves a package with
+// .go files in root. The go.mod may live in root or an ancestor directory.
+func HasGoProviderPackage(root string) bool {
+	cmd := exec.Command("go", "list", goReadonlyFlag, "-f", "{{.ImportPath}} {{join .GoFiles \"|\"}}", ".")
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(), "GOWORK=off")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return false
+	}
+	body := strings.TrimSpace(string(out))
+	i := strings.IndexByte(body, ' ')
+	if i < 0 {
+		return false
+	}
+	return strings.TrimSpace(body[i+1:]) != ""
+}
+
+// goProviderServeCall maps a provider kind to the SDK serve call that runs the
+// provider's New() constructor. Matches the kind-specific Serve<Kind>Provider
+// surface in sdk/go.
+func goProviderServeCall(kind string) (string, error) {
+	switch providermanifestv1.NormalizeKind(kind) {
+	case providermanifestv1.KindIdentity:
+		return "gestalt.ServeIdentityProvider(ctx, providerpkg.New())", nil
+	case providermanifestv1.KindAuthorization:
+		return "gestalt.ServeAuthorizationProvider(ctx, providerpkg.New())", nil
+	case providermanifestv1.KindExternalCredentials:
+		return "gestalt.ServeExternalCredentialProvider(ctx, providerpkg.New())", nil
+	case providermanifestv1.KindIndexedDB:
+		return "gestalt.ServeIndexedDBProvider(ctx, providerpkg.New())", nil
+	case providermanifestv1.KindCache:
+		return "gestalt.ServeCacheProvider(ctx, providerpkg.New())", nil
+	case providermanifestv1.KindS3:
+		return "gestalt.ServeS3Provider(ctx, providerpkg.New())", nil
+	case providermanifestv1.KindWorkflow:
+		return "gestalt.ServeWorkflowProvider(ctx, providerpkg.New())", nil
+	case providermanifestv1.KindAgent:
+		return "gestalt.ServeAgentProvider(ctx, providerpkg.New())", nil
+	case providermanifestv1.KindSecrets:
+		return "gestalt.ServeSecretsProvider(ctx, providerpkg.New())", nil
+	case providermanifestv1.KindRuntime:
+		return "gestalt.ServeRuntimeProvider(ctx, providerpkg.New())", nil
+	default:
+		return "", fmt.Errorf("unsupported Go provider kind %q", kind)
+	}
+}
+
+// detectGoProviderImportPath resolves the import path of the Go package at
+// root (the provider package itself, not a synthesized wrapper) via `go list`.
+func detectGoProviderImportPath(root, goos, goarch string) (string, error) {
+	cmd := exec.Command("go", "list", goReadonlyFlag, "-f", "{{.ImportPath}}", ".")
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(), "GOWORK=off", "GOOS="+goos, "GOARCH="+goarch)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		if bytes.Contains(stderr.Bytes(), []byte("no Go files")) {
+			return "", ErrNoGoProviderPackage
+		}
+		if errors.Is(err, exec.ErrNotFound) {
+			return "", ErrGoToolUnavailable
+		}
+		return "", fmt.Errorf("go list: %w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	importPath := strings.TrimSpace(string(out))
+	if importPath == "" || importPath == "." {
+		return goModulePathFromFile(root)
+	}
+	return importPath, nil
+}
+
+func goModulePathFromFile(root string) (string, error) {
+	file, err := os.Open(filepath.Join(root, "go.mod"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", ErrNoGoProviderPackage
+		}
+		return "", fmt.Errorf("read go.mod: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	var moduleLine string
+	for {
+		var line string
+		if _, scanErr := fmt.Fscanln(file, &line); scanErr != nil {
+			break
+		}
+		if strings.HasPrefix(line, "module") {
+			moduleLine = line
+			break
+		}
+	}
+	if moduleLine == "" {
+		return "", fmt.Errorf("parse go.mod: module path not found")
+	}
+	fields := strings.Fields(moduleLine)
+	if len(fields) < 2 {
+		return "", fmt.Errorf("parse go.mod: module path is required")
+	}
+	return strings.Trim(fields[1], `"`), nil
+}
+
+// BuildGoProviderBinary synthesizes a wrapper main that serves the provider at
+// root via the SDK Serve<Kind>Provider call, compiles it with `go build`, and
+// writes the executable to outputPath. It is the implicit-build fallback used
+// when a Go provider declares an entrypoint but no build.command.
+func BuildGoProviderBinary(root, outputPath, kind, goos, goarch string) error {
+	importPath, err := detectGoProviderImportPath(root, goos, goarch)
+	if err != nil {
+		return err
+	}
+	serveCall, err := goProviderServeCall(kind)
+	if err != nil {
+		return err
+	}
+	wrapper, cleanup, err := newGoWrapper("gestalt-go-provider-*.go", "Go provider wrapper", goExecutableWrapperTemplate, goExecutableWrapperData{
+		ImportPath: importPath,
+		ServeCall:  serveCall,
+	})
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	return buildGoWrapperBinary(root, outputPath, wrapper, goos, goarch)
+}
+
+func newGoWrapper(tempPattern, description string, tmpl *template.Template, data any) (string, func(), error) {
+	file, err := os.CreateTemp("", tempPattern)
+	if err != nil {
+		return "", nil, fmt.Errorf("create %s: %w", description, err)
+	}
+	path := file.Name()
+	cleanup := func() { _ = os.Remove(path) }
+	defer func() { _ = file.Close() }()
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("render %s: %w", description, err)
+	}
+	source, err := format.Source(buf.Bytes())
+	if err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("format %s: %w", description, err)
+	}
+	if _, err := file.Write(source); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("write %s: %w", description, err)
+	}
+	return path, cleanup, nil
+}
+
+func buildGoWrapperBinary(root, outputPath, wrapperPath, goos, goarch string) error {
+	cmd := exec.Command("go", "-C", root, "build", goReadonlyFlag, "-trimpath", "-ldflags", "-s -w", "-o", outputPath, wrapperPath)
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0", "GOWORK=off", "GOOS="+goos, "GOARCH="+goarch)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("go build: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/gestaltd/services/apps/providerpkg/prepared_stage.go
+++ b/gestaltd/services/apps/providerpkg/prepared_stage.go
@@ -78,7 +78,7 @@ func StageSourcePreparedInstallDir(manifestPath, stagingDir string, opts StageSo
 	if err != nil {
 		return nil, fmt.Errorf("prepare %s: %w", manifestPath, err)
 	}
-	if SourceBuildProducesOutput(manifest) && (!hostBuiltForCatalog || !sourceBuildTargetsHost(targetOpts)) {
+	if sourceBuildProducesOutputOrImplicitGo(filepath.Dir(manifestPath), manifest) && (!hostBuiltForCatalog || !sourceBuildTargetsHost(targetOpts)) {
 		if err := EnsureSourceBuildOutput(manifestPath, manifest, targetOpts); err != nil {
 			return nil, err
 		}

--- a/gestaltd/services/apps/providerpkg/release_target.go
+++ b/gestaltd/services/apps/providerpkg/release_target.go
@@ -60,7 +60,19 @@ func HasSourceReleaseTarget(root, kind string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return SourceBuildProducesOutput(manifest), nil
+	if SourceBuildProducesOutput(manifest) {
+		return true, nil
+	}
+	// A Go provider that declares an entrypoint but no build.command is built
+	// implicitly by gestaltd (synthesized wrapper main), so it has a release
+	// target even without a declared build phase.
+	if HasGoProviderPackage(root) {
+		resolved, kerr := ManifestKind(manifest)
+		if kerr == nil && EntrypointForKind(manifest, resolved) != nil {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func MissingDeclaredSourceBuildError(manifest *providermanifestv1.Manifest, kind string) error {

--- a/gestaltd/services/apps/providerpkg/release_target.go
+++ b/gestaltd/services/apps/providerpkg/release_target.go
@@ -68,8 +68,10 @@ func HasSourceReleaseTarget(root, kind string) (bool, error) {
 	// target even without a declared build phase.
 	if HasGoProviderPackage(root) {
 		resolved, kerr := ManifestKind(manifest)
-		if kerr == nil && EntrypointForKind(manifest, resolved) != nil {
-			return true, nil
+		if kerr == nil {
+			if entry := EntrypointForKind(manifest, resolved); entry != nil && strings.TrimSpace(entry.ArtifactPath) != "" {
+				return true, nil
+			}
 		}
 	}
 	return false, nil

--- a/gestaltd/services/apps/providerpkg/source_build.go
+++ b/gestaltd/services/apps/providerpkg/source_build.go
@@ -207,12 +207,20 @@ func runImplicitGoBuild(manifestPath string, manifest *providermanifestv1.Manife
 	}
 	outputRel := entry.ArtifactPath
 	outputPath := filepath.Join(rootDir, filepath.FromSlash(outputRel))
-	if err := os.RemoveAll(outputPath); err != nil {
-		return fmt.Errorf("remove build output %q: %w", outputRel, err)
-	}
 	goos, goarch := SourceBuildTarget(opts)
-	if err := BuildGoProviderBinary(rootDir, outputPath, kind, goos, goarch); err != nil {
+	// Build to a sibling temp path first so a failed build does not delete a
+	// pre-existing entrypoint artifact; only replace the entrypoint on success.
+	tmpOutput := outputPath + ".build"
+	if err := os.RemoveAll(tmpOutput); err != nil {
+		return fmt.Errorf("remove staged build output %q: %w", outputRel, err)
+	}
+	if err := BuildGoProviderBinary(rootDir, tmpOutput, kind, goos, goarch); err != nil {
+		_ = os.RemoveAll(tmpOutput)
 		return err
+	}
+	if err := os.Rename(tmpOutput, outputPath); err != nil {
+		_ = os.RemoveAll(tmpOutput)
+		return fmt.Errorf("install build output %q: %w", outputRel, err)
 	}
 	return verifySourceBuildOutput(outputPath, outputRel, "executable", opts)
 }

--- a/gestaltd/services/apps/providerpkg/source_build.go
+++ b/gestaltd/services/apps/providerpkg/source_build.go
@@ -96,6 +96,24 @@ func SourceBuildProducesOutput(manifest *providermanifestv1.Manifest) bool {
 	return build != nil && !build.PrepareOnly
 }
 
+// sourceBuildProducesOutputOrImplicitGo reports whether a build output will be
+// produced for the provider at root: either a declared build phase that
+// produces output, or a Go provider with an entrypoint (built implicitly by
+// gestaltd via a synthesized wrapper main).
+func sourceBuildProducesOutputOrImplicitGo(root string, manifest *providermanifestv1.Manifest) bool {
+	if SourceBuildProducesOutput(manifest) {
+		return true
+	}
+	if !HasGoProviderPackage(root) {
+		return false
+	}
+	kind, err := ManifestKind(manifest)
+	if err != nil {
+		return false
+	}
+	return EntrypointForKind(manifest, kind) != nil
+}
+
 func EffectiveSourceInstall(manifest *providermanifestv1.Manifest) *ResolvedSourceInstall {
 	if manifest == nil || manifest.Install == nil {
 		return nil
@@ -138,7 +156,7 @@ func envMapToSlice(env map[string]string) []string {
 func RunSourceBuild(manifestPath string, manifest *providermanifestv1.Manifest, opts SourceBuildOptions) error {
 	build := EffectiveSourceBuild(manifest)
 	if build == nil {
-		return nil
+		return runImplicitGoBuild(manifestPath, manifest, opts)
 	}
 	if len(build.Command) == 0 {
 		return fmt.Errorf("%s.command is required", build.Label)
@@ -165,6 +183,37 @@ func RunSourceBuild(manifestPath string, manifest *providermanifestv1.Manifest, 
 		return nil
 	}
 	return verifySourceBuildOutput(outputPath, outputRel, outputKind, opts)
+}
+
+// runImplicitGoBuild is the fallback build path for a Go provider that declares
+// an entrypoint but no build.command: gestaltd synthesizes a wrapper main that
+// serves the provider via the SDK Serve<Kind>Provider call and compiles it with
+// `go build` to the entrypoint.artifactPath. Non-Go providers with no declared
+// build are a no-op (the caller enforces that a declared build is required for
+// release packaging elsewhere).
+func runImplicitGoBuild(manifestPath string, manifest *providermanifestv1.Manifest, opts SourceBuildOptions) error {
+	rootDir := filepath.Dir(manifestPath)
+	if !HasGoProviderPackage(rootDir) {
+		return nil
+	}
+	kind, err := ManifestKind(manifest)
+	if err != nil {
+		return err
+	}
+	entry := EntrypointForKind(manifest, kind)
+	if entry == nil || strings.TrimSpace(entry.ArtifactPath) == "" {
+		return fmt.Errorf("entrypoint.artifactPath is required to build a Go provider without a declared build.command")
+	}
+	outputRel := entry.ArtifactPath
+	outputPath := filepath.Join(rootDir, filepath.FromSlash(outputRel))
+	if err := os.RemoveAll(outputPath); err != nil {
+		return fmt.Errorf("remove build output %q: %w", outputRel, err)
+	}
+	goos, goarch := SourceBuildTarget(opts)
+	if err := BuildGoProviderBinary(rootDir, outputPath, kind, goos, goarch); err != nil {
+		return err
+	}
+	return verifySourceBuildOutput(outputPath, outputRel, "executable", opts)
 }
 
 // runSourcePhase execs a declared phase command (no shell) from the source

--- a/gestaltd/services/apps/providerpkg/source_build.go
+++ b/gestaltd/services/apps/providerpkg/source_build.go
@@ -111,7 +111,8 @@ func sourceBuildProducesOutputOrImplicitGo(root string, manifest *providermanife
 	if err != nil {
 		return false
 	}
-	return EntrypointForKind(manifest, kind) != nil
+	entry := EntrypointForKind(manifest, kind)
+	return entry != nil && strings.TrimSpace(entry.ArtifactPath) != ""
 }
 
 func EffectiveSourceInstall(manifest *providermanifestv1.Manifest) *ResolvedSourceInstall {


### PR DESCRIPTION
## Summary

Restores the Go provider build derivation that #2498 removed, so a Go provider that declares `entrypoint.artifactPath` but no `build.command` is built implicitly by gestaltd: it synthesizes a wrapper `main` that serves the provider via the SDK `Serve<Kind>Provider` call and compiles it with `go build` to the entrypoint path. Go providers no longer need a per-provider `cmd/main.go` or `build.command`; they declare only `entrypoint.artifactPath`.

This re-introduces the detection #2498 removed, scoped to Go only (Python and TypeScript keep the #2503 zero-arg SDK build derivation). Non-Go providers with no declared build and prebuilt entrypoints are unaffected.

## Interfaces

```go
// HasGoProviderPackage reports whether root is a Go source provider (go list
// resolves a package with .go files; go.mod may be in root or an ancestor).
func HasGoProviderPackage(root string) bool

// BuildGoProviderBinary synthesizes a wrapper main serving the provider via
// Serve<Kind>Provider and compiles it to outputPath with go build.
func BuildGoProviderBinary(root, outputPath, kind, goos, goarch string) error
```

The wrapper template renders `gestalt.Serve<Kind>Provider(ctx, providerpkg.New())` for the provider's kind; the kind->serve map mirrors `sdk/go`. `runImplicitGoBuild` is the fallback in `RunSourceBuild` when no `build:` is declared. `resolveReleaseBuildTarget` sets `ImplicitGoBuild` (a new `releaseBuildTarget` state, distinct from `Prebuilt`) when a Go provider is detected with an entrypoint, so packaging proceeds instead of erroring.

## Runtime

`GOWORK=off` is set on the `go list`/`go build` invocations so provider packages in workspace-excluded modules (e.g. gestalt-providers `auth/oidc`, whose go.mod is the parent `auth/`) resolve. Verified end-to-end: `gestaltd provider package` on a Go provider with only `entrypoint.artifactPath` synthesizes, compiles, and produces the release archive. Existing providerpkg and daemon tests pass. Downstream (gestalt-providers #1083) can drop the 11 per-provider `cmd/main.go` files and `build.command` declarations, keeping only `entrypoint.artifactPath`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
