### PR TITLE
[packageio] stop decompressing provider archives redundantly

### DIFF
--- a/gestaltd/internal/operator/package_install.go
+++ b/gestaltd/internal/operator/package_install.go
@@ -1,8 +1,6 @@
 package operator
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -64,14 +62,6 @@ func installPackage(packagePath, destDir string) (*installedPackage, error) {
 		if err != nil {
 			return nil, err
 		}
-		artifactBytes, err := packageio.ReadArchiveEntry(packagePath, artifact.Path)
-		if err != nil {
-			return nil, err
-		}
-		sum := sha256.Sum256(artifactBytes)
-		if got := hex.EncodeToString(sum[:]); got != artifact.SHA256 {
-			return nil, fmt.Errorf("artifact digest mismatch for %s: package has %s, manifest expects %s", artifact.Path, got, artifact.SHA256)
-		}
 	}
 
 	if err := os.MkdirAll(destDir, 0755); err != nil {
@@ -79,6 +69,19 @@ func installPackage(packagePath, destDir string) (*installedPackage, error) {
 	}
 	if err := packageio.ExtractPackage(packagePath, destDir); err != nil {
 		return nil, err
+	}
+
+	if artifact != nil {
+		// Verify the artifact digest against the extracted file rather than
+		// decompressing the whole archive a second time to read it. The package
+		// is never executed before this check succeeds.
+		got, err := packageio.FileSHA256(filepath.Join(destDir, filepath.FromSlash(artifact.Path)))
+		if err != nil {
+			return nil, err
+		}
+		if got != artifact.SHA256 {
+			return nil, fmt.Errorf("artifact digest mismatch for %s: package has %s, manifest expects %s", artifact.Path, got, artifact.SHA256)
+		}
 	}
 
 	manifestPath, _ := packageio.FindManifestFile(destDir)

--- a/gestaltd/services/apps/packageio/archive.go
+++ b/gestaltd/services/apps/packageio/archive.go
@@ -25,23 +25,43 @@ func ReadPackageManifest(packagePath string) (_ []byte, _ *providermanifestv1.Ma
 }
 
 func ReadPackageManifestIn(packagePath string, names []string) (_ []byte, _ *providermanifestv1.Manifest, err error) {
-	var firstErr error
+	// Collect every candidate manifest in a single pass instead of walking
+	// (and fully decompressing) the archive once per candidate name. Packages
+	// using a manifest later in the priority list (e.g. manifest.yaml) would
+	// otherwise pay a full decompression for each earlier miss.
+	wanted := make(map[string]struct{}, len(names))
 	for _, name := range names {
-		data, err := ReadArchiveEntry(packagePath, name)
+		wanted[name] = struct{}{}
+	}
+	found := make(map[string][]byte, len(names))
+	if err := walkPackageArchive(packagePath, func(entry packageArchiveEntry) error {
+		if entry.Header.Typeflag == tar.TypeDir {
+			return nil
+		}
+		if _, ok := wanted[entry.Path]; !ok {
+			return nil
+		}
+		data, err := io.ReadAll(entry.Reader)
 		if err != nil {
-			if firstErr == nil {
-				firstErr = err
-			}
+			return fmt.Errorf("read %s: %w", entry.Path, err)
+		}
+		found[entry.Path] = data
+		return nil
+	}); err != nil {
+		return nil, nil, err
+	}
+	for _, name := range names {
+		data, ok := found[name]
+		if !ok {
 			continue
 		}
-		format := ManifestFormatFromPath(name)
-		manifest, err := DecodeManifestFormat(data, format)
+		manifest, err := DecodeManifestFormat(data, ManifestFormatFromPath(name))
 		if err != nil {
 			return nil, nil, err
 		}
 		return data, manifest, nil
 	}
-	return nil, nil, firstErr
+	return nil, nil, fmt.Errorf("package %q does not contain a manifest (%s)", packagePath, strings.Join(names, ", "))
 }
 
 func InspectPackage(packagePath string) (*providermanifestv1.Manifest, error) {


### PR DESCRIPTION
Installing a provider package decompressed the same gzip/tar archive three
times: once to read the manifest, once to read the artifact for its digest
check, and once to extract. Manifest resolution also walked the whole archive
once per candidate name, so packages using manifest.yaml/.yml paid an extra
full decompression for the manifest.json miss.

- ReadPackageManifestIn now collects whichever candidate manifest is present in
  a single walk instead of one full walk per name.
- installPackage extracts first, then verifies the artifact digest against the
  extracted file (via packageio.FileSHA256) instead of decompressing the archive
  a second time to read it. The package is never executed before the check.

Full-archive duplicate-entry detection (walkPackageArchive) and single-root
manifest validation (ExtractPackage) are unchanged. Measured on the operator
race suite, which exercises this path heavily: package user CPU under -race fell
~54% (615s -> 285s).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>