### PR TITLE
Make source entrypoint.artifactPath optional for executable providers

### DIFF
--- a/gestaltd/internal/daemon/provider_package.go
+++ b/gestaltd/internal/daemon/provider_package.go
@@ -84,7 +84,7 @@ func runProviderPackage(args []string) (err error) {
 		return err
 	}
 
-	buildTarget, err := resolveReleaseBuildTarget(sourceDir, releaseManifest)
+	buildTarget, err := resolveReleaseBuild(sourceDir, releaseManifest)
 	if err != nil {
 		return err
 	}
@@ -241,52 +241,32 @@ func (s *sourceStaticCatalogSnapshot) Restore() error {
 	return nil
 }
 
-func resolveReleaseBuildTarget(root string, manifest *providermanifestv1.Manifest) (*releaseBuildTarget, error) {
-	kind, err := providerpkg.ManifestKind(manifest)
-	if err != nil {
-		return nil, err
-	}
-	if kind == providermanifestv1.KindUI {
-		return nil, nil
-	}
+func resolveReleaseBuild(root string, manifest *providermanifestv1.Manifest) (*providerpkg.ResolvedSourceReleaseBuild, error) {
 	if err := providerpkg.ValidateExplicitRunPackaging(root, manifest); err != nil {
 		return nil, err
 	}
-	if providerpkg.EffectiveSourceBuild(manifest) != nil {
-		entry := providerpkg.EntrypointForKind(manifest, kind)
-		if entry == nil || strings.TrimSpace(entry.ArtifactPath) == "" {
-			if providerpkg.ReleaseRequiresBuild(manifest) {
-				return nil, providerpkg.MissingDeclaredSourceBuildError(manifest, kind)
-			}
-			return nil, nil
-		}
-		return &releaseBuildTarget{Kind: kind, Mode: releaseBuildDeclared}, nil
+	resolved, err := providerpkg.ResolveSourceReleaseBuild(root, manifest)
+	if err != nil {
+		return nil, err
 	}
-	entry := providerpkg.EntrypointForKind(manifest, kind)
-	if entry != nil && strings.TrimSpace(entry.ArtifactPath) != "" {
-		if implicit, err := providerpkg.ImplicitGoBuildTarget(root, manifest); err == nil && implicit {
-			return &releaseBuildTarget{Kind: kind, Mode: releaseBuildImplicitGo}, nil
-		}
-		return &releaseBuildTarget{Kind: kind, Mode: releaseBuildPrebuilt}, nil
-	}
-	if providerpkg.ReleaseRequiresBuild(manifest) {
-		return nil, providerpkg.MissingDeclaredSourceBuildError(manifest, kind)
-	}
-	return nil, nil
-}
-
-func resolveReleaseBuildPlatforms(root string, manifest *providermanifestv1.Manifest, target *releaseBuildTarget, value string, explicit bool) ([]releasePlatform, error) {
-	if target == nil {
+	if resolved.Mode == providerpkg.SourceReleaseBuildNone {
 		return nil, nil
 	}
-	if target.Mode == releaseBuildPrebuilt {
+	return &resolved, nil
+}
+
+func resolveReleaseBuildPlatforms(root string, manifest *providermanifestv1.Manifest, build *providerpkg.ResolvedSourceReleaseBuild, value string, explicit bool) ([]releasePlatform, error) {
+	if build == nil {
+		return nil, nil
+	}
+	if build.Mode == providerpkg.SourceReleaseBuildPrebuilt {
 		if explicit {
 			return nil, fmt.Errorf("--platform requires build.command for executable source providers")
 		}
 		return nil, fmt.Errorf("provider package requires build.command for executable source providers")
 	}
 
-	buildRequired := target.Mode == releaseBuildDeclared || target.Mode == releaseBuildImplicitGo || providerpkg.ReleaseRequiresBuild(manifest)
+	buildRequired := build.Mode.RequiresPlatformBuild() || providerpkg.ReleaseRequiresBuild(manifest)
 	if !buildRequired && !explicit {
 		return nil, nil
 	}

--- a/gestaltd/internal/daemon/provider_package_edge_test.go
+++ b/gestaltd/internal/daemon/provider_package_edge_test.go
@@ -563,6 +563,23 @@ func TestRun_ProviderPackageAndReleaseCompilesProviderWithoutSourceArtifacts(t *
 	t.Parallel()
 
 	pluginDir := newSourceProviderReleaseFixtureWithoutCatalog(t, t.TempDir())
+	const defaultArtifactPath = ".gestalt/build/release-test"
+	writeReleaseTestManifest(t, pluginDir, &providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindApp,
+		Source:      releaseTestSource,
+		Version:     "0.0.1",
+		DisplayName: "Release Test",
+		IconFile:    releaseTestIconPath,
+		Spec: &providermanifestv1.Spec{
+			ConfigSchemaPath: releaseProviderSchemaPath,
+		},
+		Build: &providermanifestv1.SourceBuild{
+			Command: []string{"sh", "./build.sh"},
+			Inputs:  []string{"go.mod", "go.sum", "provider.go", "cmd", "build.sh"},
+		},
+	})
+	writeTestFile(t, pluginDir, "build.sh", []byte("mkdir -p .gestalt/build\ngo build -o "+defaultArtifactPath+" ./cmd/provider\n"), 0o755)
+	_ = os.Remove(filepath.Join(pluginDir, providerpkg.StaticCatalogFile))
 	outputDir := t.TempDir()
 	const testVersion = "0.0.4-source.1"
 
@@ -576,10 +593,10 @@ func TestRun_ProviderPackageAndReleaseCompilesProviderWithoutSourceArtifacts(t *
 	extractDir := extractReleasedArchive(t, outputDir, archiveName)
 	manifest := readReleasedManifest(t, outputDir, archiveName)
 
-	if len(manifest.Artifacts) != 1 || manifest.Artifacts[0].Path != ".gestalt/build/provider" {
+	if len(manifest.Artifacts) != 1 || manifest.Artifacts[0].Path != defaultArtifactPath {
 		t.Fatalf("artifacts = %+v", manifest.Artifacts)
 	}
-	if manifest.Entrypoint == nil || manifest.Entrypoint.ArtifactPath != ".gestalt/build/provider" {
+	if manifest.Entrypoint == nil || manifest.Entrypoint.ArtifactPath != defaultArtifactPath {
 		t.Fatalf("provider entrypoint = %+v", manifest.Entrypoint)
 	}
 	if manifest.Spec == nil || manifest.Spec.ConfigSchemaPath != releaseProviderSchemaPath {
@@ -611,6 +628,9 @@ func TestRun_ProviderPackageRejectsSDKSourceProviderWithoutBuildCommand(t *testi
 	_ = os.Remove(filepath.Join(pluginDir, providerpkg.StaticCatalogFile))
 	_ = os.Remove(filepath.Join(pluginDir, "build.sh"))
 	_ = os.RemoveAll(filepath.Join(pluginDir, "cmd"))
+	_ = os.Remove(filepath.Join(pluginDir, "provider.go"))
+	_ = os.Remove(filepath.Join(pluginDir, "go.mod"))
+	_ = os.Remove(filepath.Join(pluginDir, "go.sum"))
 
 	outputDir := t.TempDir()
 	const testVersion = "0.0.4-sdk-source.1"

--- a/gestaltd/internal/daemon/provider_release_types.go
+++ b/gestaltd/internal/daemon/provider_release_types.go
@@ -9,20 +9,6 @@ type releasePlatform struct {
 	GOARCH string
 }
 
-type releaseBuildMode int
-
-const (
-	releaseBuildNone releaseBuildMode = iota
-	releaseBuildDeclared
-	releaseBuildImplicitGo
-	releaseBuildPrebuilt
-)
-
-type releaseBuildTarget struct {
-	Kind string
-	Mode releaseBuildMode
-}
-
 type releaseArchive struct {
 	Path   string
 	SHA256 string

--- a/gestaltd/services/apps/packageio/entrypoint_policy.go
+++ b/gestaltd/services/apps/packageio/entrypoint_policy.go
@@ -1,0 +1,111 @@
+package packageio
+
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/apps/source"
+)
+
+type entrypointPolicy struct {
+	mayDefault       bool
+	omitInValidation bool
+}
+
+func entrypointPolicyFor(manifest *providermanifestv1.Manifest, kind string) entrypointPolicy {
+	if manifest == nil || manifest.Entrypoint != nil {
+		return entrypointPolicy{}
+	}
+	if len(manifest.Run) > 0 && (manifest.Build == nil || manifest.Build.PrepareOnly) {
+		return entrypointPolicy{omitInValidation: true}
+	}
+
+	switch kind {
+	case providermanifestv1.KindUI:
+		if manifest.Build != nil && !manifest.Build.PrepareOnly {
+			return entrypointPolicy{omitInValidation: true}
+		}
+		return entrypointPolicy{}
+	case providermanifestv1.KindApp:
+		if manifest.IsDeclarativeOnlyProvider() ||
+			(manifest.Spec != nil && manifest.Spec.IsSpecLoaded()) ||
+			(manifest.Spec != nil && manifest.Spec.IsManifestBacked()) {
+			return entrypointPolicy{omitInValidation: true}
+		}
+		if manifest.Build != nil && !manifest.Build.PrepareOnly {
+			return entrypointPolicy{mayDefault: true, omitInValidation: true}
+		}
+		return entrypointPolicy{omitInValidation: manifest.Build == nil || manifest.Build.PrepareOnly}
+	case providermanifestv1.KindIdentity, providermanifestv1.KindAuthorization, providermanifestv1.KindExternalCredentials, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindAgent, providermanifestv1.KindSecrets, providermanifestv1.KindRuntime:
+		if manifest.Build != nil && !manifest.Build.PrepareOnly {
+			return entrypointPolicy{mayDefault: true, omitInValidation: true}
+		}
+		if manifest.Build == nil {
+			return entrypointPolicy{mayDefault: true, omitInValidation: true}
+		}
+		return entrypointPolicy{omitInValidation: manifest.Build.PrepareOnly}
+	default:
+		return entrypointPolicy{}
+	}
+}
+
+// DefaultSourceEntrypointArtifactPath returns .gestalt/build/<last source segment>
+// for a source manifest. The path uses forward slashes.
+func DefaultSourceEntrypointArtifactPath(manifest *providermanifestv1.Manifest) (string, error) {
+	if manifest == nil {
+		return "", fmt.Errorf("manifest is required")
+	}
+	if manifest.Source == "" {
+		return "", fmt.Errorf("manifest source is required")
+	}
+	src, err := source.Parse(manifest.Source)
+	if err != nil {
+		return "", fmt.Errorf("manifest source: %w", err)
+	}
+	return path.Join(".gestalt", "build", src.AppName()), nil
+}
+
+// EffectiveSourceEntrypointForKind returns the explicit entrypoint when set, or the
+// default source executable artifact path. It returns a copy and never mutates manifest.
+func EffectiveSourceEntrypointForKind(manifest *providermanifestv1.Manifest, kind string) (*providermanifestv1.Entrypoint, error) {
+	if manifest == nil {
+		return nil, fmt.Errorf("manifest is required")
+	}
+	if kind == "" {
+		var err error
+		kind, err = ManifestKind(manifest)
+		if err != nil {
+			return nil, err
+		}
+	}
+	entry := EntrypointForKind(manifest, kind)
+	if entry != nil && strings.TrimSpace(entry.ArtifactPath) != "" {
+		cloned := *entry
+		cloned.Args = append([]string(nil), entry.Args...)
+		return &cloned, nil
+	}
+	if !entrypointPolicyFor(manifest, kind).mayDefault {
+		return nil, fmt.Errorf("entrypoint.artifactPath is required")
+	}
+	defaultPath, err := DefaultSourceEntrypointArtifactPath(manifest)
+	if err != nil {
+		return nil, err
+	}
+	cloned := &providermanifestv1.Entrypoint{ArtifactPath: defaultPath}
+	if entry != nil {
+		cloned.Args = append([]string(nil), entry.Args...)
+	}
+	return cloned, nil
+}
+
+// SourceEntrypointMayDefault reports whether a source manifest may rely on the
+// default .gestalt/build/<source-name> artifact path in executable contexts.
+func SourceEntrypointMayDefault(manifest *providermanifestv1.Manifest, kind string) bool {
+	return entrypointPolicyFor(manifest, kind).mayDefault
+}
+
+func sourceEntrypointOmissionAllowed(manifest *providermanifestv1.Manifest, kind string) bool {
+	return entrypointPolicyFor(manifest, kind).omitInValidation
+}

--- a/gestaltd/services/apps/packageio/entrypoint_policy_test.go
+++ b/gestaltd/services/apps/packageio/entrypoint_policy_test.go
@@ -1,0 +1,97 @@
+package packageio
+
+import (
+	"strings"
+	"testing"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+func TestEffectiveSourceEntrypointForKind_DefaultsForDeclaredBuild(t *testing.T) {
+	t.Parallel()
+
+	manifest := &providermanifestv1.Manifest{
+		Kind:   providermanifestv1.KindAgent,
+		Source: "github.com/valon-technologies/gestalt-providers/agent/example-agent",
+		Build: &providermanifestv1.SourceBuild{
+			Command: []string{"./build.sh"},
+		},
+	}
+	entry, err := EffectiveSourceEntrypointForKind(manifest, providermanifestv1.KindAgent)
+	if err != nil {
+		t.Fatalf("EffectiveSourceEntrypointForKind: %v", err)
+	}
+	if entry == nil || entry.ArtifactPath != ".gestalt/build/example-agent" {
+		t.Fatalf("entry = %#v, want default .gestalt/build/example-agent", entry)
+	}
+}
+
+func TestEffectiveSourceEntrypointForKind_ExplicitOverrideWins(t *testing.T) {
+	t.Parallel()
+
+	manifest := &providermanifestv1.Manifest{
+		Kind:   providermanifestv1.KindAgent,
+		Source: "github.com/valon-technologies/gestalt-providers/agent/example-agent",
+		Entrypoint: &providermanifestv1.Entrypoint{
+			ArtifactPath: "dist/custom-agent",
+		},
+		Build: &providermanifestv1.SourceBuild{
+			Command: []string{"./build.sh"},
+		},
+	}
+	entry, err := EffectiveSourceEntrypointForKind(manifest, providermanifestv1.KindAgent)
+	if err != nil {
+		t.Fatalf("EffectiveSourceEntrypointForKind: %v", err)
+	}
+	if entry == nil || entry.ArtifactPath != "dist/custom-agent" {
+		t.Fatalf("entry = %#v, want explicit dist/custom-agent", entry)
+	}
+}
+
+func TestEffectiveSourceEntrypointForKind_UIWithBuildHasNoDefault(t *testing.T) {
+	t.Parallel()
+
+	manifest := &providermanifestv1.Manifest{
+		Kind:   providermanifestv1.KindUI,
+		Source: "github.com/valon-technologies/gestalt-providers/ui/foo-ui",
+		Build: &providermanifestv1.SourceBuild{
+			Command: []string{"npm", "run", "build"},
+		},
+		Spec: &providermanifestv1.Spec{
+			AssetRoot: "dist",
+		},
+	}
+	_, err := EffectiveSourceEntrypointForKind(manifest, providermanifestv1.KindUI)
+	if err == nil || !strings.Contains(err.Error(), "entrypoint.artifactPath is required") {
+		t.Fatalf("EffectiveSourceEntrypointForKind err = %v, want no default for ui", err)
+	}
+	if SourceEntrypointMayDefault(manifest, providermanifestv1.KindUI) {
+		t.Fatal("ui provider with build should not allow default entrypoint")
+	}
+}
+
+func TestEffectiveSourceEntrypointForKind_ManifestBackedAppHasNoDefault(t *testing.T) {
+	t.Parallel()
+
+	manifest := &providermanifestv1.Manifest{
+		Kind:   providermanifestv1.KindApp,
+		Source: "github.com/test/apps/manifest-backed",
+		Run:    []string{"npm", "run", "dev"},
+		Spec: &providermanifestv1.Spec{
+			Surfaces: &providermanifestv1.ProviderSurfaces{
+				REST: &providermanifestv1.RESTSurface{
+					BaseURL: "https://api.example.com",
+					Operations: []providermanifestv1.ProviderOperation{{
+						Name:   "get_status",
+						Method: "GET",
+						Path:   "/status",
+					}},
+				},
+			},
+		},
+	}
+	_, err := EffectiveSourceEntrypointForKind(manifest, providermanifestv1.KindApp)
+	if err == nil || !strings.Contains(err.Error(), "entrypoint.artifactPath is required") {
+		t.Fatalf("EffectiveSourceEntrypointForKind err = %v, want no default for manifest-backed app", err)
+	}
+}

--- a/gestaltd/services/apps/packageio/manifest.go
+++ b/gestaltd/services/apps/packageio/manifest.go
@@ -189,7 +189,7 @@ func validateManifest(manifest *providermanifestv1.Manifest, sourceMode bool) er
 		return fmt.Errorf("artifacts are not allowed in source manifests; prepared and released manifests generate them")
 	}
 
-	allowsSourceEntrypointOmission := sourceMode && manifest.Entrypoint == nil && (manifest.Build == nil || manifest.Build.PrepareOnly)
+	allowsSourceEntrypointOmission := sourceMode && manifest.Entrypoint == nil && sourceEntrypointOmissionAllowed(manifest, kind)
 
 	needsArtifacts := len(manifest.Artifacts) > 0
 	switch kind {
@@ -250,7 +250,7 @@ func validateManifest(manifest *providermanifestv1.Manifest, sourceMode bool) er
 			if err := validateEntrypoint(kind, manifest.Entrypoint, artifactPaths, sourceMode); err != nil {
 				return err
 			}
-		case manifest.Build != nil && !manifest.Build.PrepareOnly:
+		case manifest.Build != nil && !manifest.Build.PrepareOnly && !sourceMode:
 			return fmt.Errorf("entrypoint is required when build is set")
 		case manifest.IsDeclarativeOnlyProvider():
 		case spec != nil && spec.IsSpecLoaded():

--- a/gestaltd/services/apps/providerpkg/go_provider.go
+++ b/gestaltd/services/apps/providerpkg/go_provider.go
@@ -1,6 +1,7 @@
 package providerpkg
 
 import (
+	"bufio"
 	"bytes"
 	"errors"
 	"fmt"
@@ -70,24 +71,11 @@ func HasGoProviderPackage(root string) bool {
 	return strings.TrimSpace(body[i+1:]) != ""
 }
 
-// ImplicitGoBuildTarget is the single eligibility check for the implicit Go
-// build path; callers should not re-derive these conditions.
-func ImplicitGoBuildTarget(root string, manifest *providermanifestv1.Manifest) (bool, error) {
-	if EffectiveSourceBuild(manifest) != nil {
-		return false, nil
-	}
-	kind, err := ManifestKind(manifest)
-	if err != nil {
-		return false, err
-	}
-	if kind == providermanifestv1.KindUI {
-		return false, nil
-	}
-	entry := EntrypointForKind(manifest, kind)
-	if entry == nil || strings.TrimSpace(entry.ArtifactPath) == "" {
-		return false, nil
-	}
-	return HasGoProviderPackage(root), nil
+// SupportsImplicitGoBuild reports whether gestaltd can synthesize a Go provider
+// binary for the given manifest kind.
+func SupportsImplicitGoBuild(kind string) bool {
+	_, err := goProviderServeCall(kind)
+	return err == nil
 }
 
 // goProviderServeCall maps a provider kind to the SDK serve call that runs the
@@ -155,25 +143,22 @@ func goModulePathFromFile(root string) (string, error) {
 	}
 	defer func() { _ = file.Close() }()
 
-	var moduleLine string
-	for {
-		var line string
-		if _, scanErr := fmt.Fscanln(file, &line); scanErr != nil {
-			break
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if !strings.HasPrefix(line, "module ") {
+			continue
 		}
-		if strings.HasPrefix(line, "module") {
-			moduleLine = line
-			break
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			return "", fmt.Errorf("parse go.mod: module path is required")
 		}
+		return strings.Trim(fields[1], `"`), nil
 	}
-	if moduleLine == "" {
-		return "", fmt.Errorf("parse go.mod: module path not found")
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("read go.mod: %w", err)
 	}
-	fields := strings.Fields(moduleLine)
-	if len(fields) < 2 {
-		return "", fmt.Errorf("parse go.mod: module path is required")
-	}
-	return strings.Trim(fields[1], `"`), nil
+	return "", fmt.Errorf("parse go.mod: module path not found")
 }
 
 // BuildGoProviderBinary synthesizes a wrapper main that serves the provider at

--- a/gestaltd/services/apps/providerpkg/manifest.go
+++ b/gestaltd/services/apps/providerpkg/manifest.go
@@ -54,6 +54,18 @@ func EntrypointForKind(manifest *providermanifestv1.Manifest, kind string) *prov
 	return packageio.EntrypointForKind(manifest, kind)
 }
 
+func DefaultSourceEntrypointArtifactPath(manifest *providermanifestv1.Manifest) (string, error) {
+	return packageio.DefaultSourceEntrypointArtifactPath(manifest)
+}
+
+func EffectiveSourceEntrypointForKind(manifest *providermanifestv1.Manifest, kind string) (*providermanifestv1.Entrypoint, error) {
+	return packageio.EffectiveSourceEntrypointForKind(manifest, kind)
+}
+
+func SourceEntrypointMayDefault(manifest *providermanifestv1.Manifest, kind string) bool {
+	return packageio.SourceEntrypointMayDefault(manifest, kind)
+}
+
 func EnsureEntrypoint(manifest *providermanifestv1.Manifest) *providermanifestv1.Entrypoint {
 	return packageio.EnsureEntrypoint(manifest)
 }

--- a/gestaltd/services/apps/providerpkg/manifest_workflow_test.go
+++ b/gestaltd/services/apps/providerpkg/manifest_workflow_test.go
@@ -522,6 +522,27 @@ spec:
 			},
 			wantError: "run metadata is only allowed in source manifests",
 		},
+		{
+			name: "released package requires entrypoint when artifacts present",
+			buildData: func(t *testing.T, dir string) string {
+				artifactPath := testArtifactPath("oidc")
+				manifest := &providermanifestv1.Manifest{
+					Kind:    providermanifestv1.KindIdentity,
+					Source:  "github.com/valon-technologies/gestalt-providers/auth/oidc",
+					Version: "0.0.1-alpha.2",
+					Spec:    &providermanifestv1.Spec{},
+					Artifacts: []providermanifestv1.Artifact{{
+						OS:     testArtifactOS,
+						Arch:   testArtifactArch,
+						Path:   artifactPath,
+						SHA256: sha256Hex("oidc"),
+					}},
+				}
+				mustWriteFile(t, filepath.Join(dir, filepath.FromSlash(artifactPath)), []byte("oidc"), 0o755)
+				return mustWriteManifestData(t, dir, ManifestFile, mustRawManifestJSON(t, manifest))
+			},
+			wantError: "entrypoint is required",
+		},
 	}
 
 	for _, tc := range tests {
@@ -667,6 +688,22 @@ spec:
 `,
 			readSource: true,
 			wantErr:    "build.inputs[0] does not support glob syntax",
+		},
+		{
+			name: "source ui rejects entrypoint",
+			manifest: `
+kind: ui
+source: github.com/test/ui/example
+version: 0.0.1-alpha.1
+entrypoint:
+  artifactPath: dist/index.html
+build:
+  command: [npm, run, build]
+spec:
+  assetRoot: dist
+`,
+			readSource: true,
+			wantErr:    "ui manifests may not define entrypoints",
 		},
 	}
 

--- a/gestaltd/services/apps/providerpkg/prepared_stage.go
+++ b/gestaltd/services/apps/providerpkg/prepared_stage.go
@@ -78,7 +78,11 @@ func StageSourcePreparedInstallDir(manifestPath, stagingDir string, opts StageSo
 	if err != nil {
 		return nil, fmt.Errorf("prepare %s: %w", manifestPath, err)
 	}
-	if sourceBuildProducesOutputOrImplicitGo(filepath.Dir(manifestPath), manifest) && (!hostBuiltForCatalog || !sourceBuildTargetsHost(targetOpts)) {
+	producesOutput, err := SourceReleaseBuildProducesOutput(filepath.Dir(manifestPath), manifest)
+	if err != nil {
+		return nil, err
+	}
+	if producesOutput && (!hostBuiltForCatalog || !sourceBuildTargetsHost(targetOpts)) {
 		if err := EnsureSourceBuildOutput(manifestPath, manifest, targetOpts); err != nil {
 			return nil, err
 		}
@@ -110,7 +114,13 @@ func sourceStaticCatalogShouldBePreparedForPackaging(manifestPath string, manife
 	if manifest == nil || manifest.Kind != providermanifestv1.KindApp {
 		return false, nil
 	}
-	entry := EntrypointForKind(manifest, providermanifestv1.KindApp)
+	if !SourceBuildProducesOutput(manifest) {
+		return false, nil
+	}
+	entry, err := EffectiveSourceEntrypointForKind(manifest, providermanifestv1.KindApp)
+	if err != nil {
+		return false, err
+	}
 	if entry == nil || strings.TrimSpace(entry.ArtifactPath) == "" {
 		return false, nil
 	}
@@ -217,8 +227,7 @@ func preparedManifestFileName(format string) string {
 }
 
 func validatePreparedInstallDeclaredBuild(root string, manifest *providermanifestv1.Manifest, kind string) error {
-	kind = strings.TrimSpace(kind)
-	if kind == "" {
+	if strings.TrimSpace(kind) == "" {
 		var err error
 		kind, err = ManifestKind(manifest)
 		if err != nil {
@@ -228,14 +237,20 @@ func validatePreparedInstallDeclaredBuild(root string, manifest *providermanifes
 	if kind == providermanifestv1.KindUI {
 		return nil
 	}
-	entry := EntrypointForKind(manifest, kind)
+	entry, err := EffectiveSourceEntrypointForKind(manifest, kind)
+	if err != nil {
+		if releaseRequiresBuildForKind(manifest, kind) {
+			return missingDeclaredSourceBuildError(manifest, kind)
+		}
+		return nil
+	}
+	if entry == nil || strings.TrimSpace(entry.ArtifactPath) == "" {
+		return nil
+	}
 	if artifactExistsForEntrypoint(root, entry) {
 		return nil
 	}
-	if releaseRequiresBuildForKind(manifest, kind) {
-		return missingDeclaredSourceBuildError(manifest, kind)
-	}
-	return nil
+	return missingDeclaredSourceBuildError(manifest, kind)
 }
 
 func artifactExistsForEntrypoint(root string, entry *providermanifestv1.Entrypoint) bool {
@@ -246,6 +261,18 @@ func artifactExistsForEntrypoint(root string, entry *providermanifestv1.Entrypoi
 	return err == nil
 }
 
+func preparedInstallEntrypoint(manifest *providermanifestv1.Manifest, kind string) (*providermanifestv1.Entrypoint, error) {
+	if manifest != nil && manifest.Entrypoint != nil && strings.TrimSpace(manifest.Entrypoint.ArtifactPath) != "" {
+		cloned := *manifest.Entrypoint
+		cloned.Args = append([]string(nil), manifest.Entrypoint.Args...)
+		return &cloned, nil
+	}
+	if !SourceEntrypointMayDefault(manifest, kind) {
+		return nil, nil
+	}
+	return EffectiveSourceEntrypointForKind(manifest, kind)
+}
+
 func buildPreparedInstallSourceManifest(srcManifest *providermanifestv1.Manifest, version, sourceDir, goos, goarch string) (*providermanifestv1.Manifest, error) {
 	manifest, err := cloneManifest(srcManifest)
 	if err != nil {
@@ -253,24 +280,31 @@ func buildPreparedInstallSourceManifest(srcManifest *providermanifestv1.Manifest
 	}
 	uiAssetRoot := SourceUIBuildOutput(manifest)
 	manifest.Version = version
-	manifest.Install = nil
-	manifest.Build = nil
-	manifest.Run = nil
-	manifest.Dev = nil
-	manifest.Artifacts = nil
 
 	kind, err := ManifestKind(manifest)
 	if err != nil {
 		return nil, err
 	}
+	entry, err := preparedInstallEntrypoint(srcManifest, kind)
+	if err != nil {
+		return nil, err
+	}
+	manifest.Install = nil
+	manifest.Build = nil
+	manifest.Run = nil
+	manifest.Dev = nil
+	manifest.Artifacts = nil
 	if kind == providermanifestv1.KindUI && uiAssetRoot != "" {
 		if manifest.Spec == nil {
 			manifest.Spec = &providermanifestv1.Spec{}
 		}
 		manifest.Spec.AssetRoot = uiAssetRoot
 	}
-	entry := EntrypointForKind(manifest, kind)
-	if entry != nil && strings.TrimSpace(entry.ArtifactPath) != "" {
+	if kind != providermanifestv1.KindUI && entry != nil && strings.TrimSpace(entry.ArtifactPath) != "" {
+		manifest.Entrypoint = &providermanifestv1.Entrypoint{
+			ArtifactPath: entry.ArtifactPath,
+			Args:         append([]string(nil), entry.Args...),
+		}
 		artifactPath := entry.ArtifactPath
 		digest, err := FileSHA256(filepath.Join(sourceDir, filepath.FromSlash(artifactPath)))
 		if err != nil {

--- a/gestaltd/services/apps/providerpkg/prepared_stage_test.go
+++ b/gestaltd/services/apps/providerpkg/prepared_stage_test.go
@@ -174,8 +174,30 @@ func TestValidateExplicitRunPackaging_AllowsManifestBackedRunOnlyPlugin(t *testi
 	if ReleaseRequiresBuild(manifest) {
 		t.Fatal("manifest-backed app should not require a release build")
 	}
+	if _, err := EffectiveSourceEntrypointForKind(manifest, providermanifestv1.KindApp); err == nil {
+		t.Fatal("expected effective entrypoint error for non-executable manifest-backed app")
+	}
 	if err := ValidateExplicitRunPackaging(t.TempDir(), manifest); err != nil {
 		t.Fatalf("ValidateExplicitRunPackaging: %v", err)
+	}
+}
+
+func TestValidatePreparedInstallDeclaredBuild_RequiresArtifactWhenReleaseBuildRequired(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	manifest := &providermanifestv1.Manifest{
+		Kind:    providermanifestv1.KindAgent,
+		Source:  "github.com/test/providers/example-agent",
+		Version: "0.0.1-alpha.1",
+		Spec:    &providermanifestv1.Spec{},
+		Build: &providermanifestv1.SourceBuild{
+			Command: []string{"sh", "./build.sh"},
+		},
+	}
+	err := validatePreparedInstallDeclaredBuild(root, manifest, providermanifestv1.KindAgent)
+	if err == nil || !strings.Contains(err.Error(), "declare object-form build.command and entrypoint.artifactPath") {
+		t.Fatalf("validatePreparedInstallDeclaredBuild err = %v, want missing declared build error", err)
 	}
 }
 

--- a/gestaltd/services/apps/providerpkg/release_build.go
+++ b/gestaltd/services/apps/providerpkg/release_build.go
@@ -1,0 +1,94 @@
+package providerpkg
+
+import (
+	"strings"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+type SourceReleaseBuildMode int
+
+const (
+	SourceReleaseBuildNone SourceReleaseBuildMode = iota
+	SourceReleaseBuildDeclared
+	SourceReleaseBuildImplicitGo
+	SourceReleaseBuildPrebuilt
+)
+
+func (m SourceReleaseBuildMode) RequiresPlatformBuild() bool {
+	return m == SourceReleaseBuildDeclared || m == SourceReleaseBuildImplicitGo
+}
+
+type ResolvedSourceReleaseBuild struct {
+	Kind       string
+	Mode       SourceReleaseBuildMode
+	Entrypoint *providermanifestv1.Entrypoint
+}
+
+// ResolveSourceReleaseBuild is the canonical release-build decision for a source
+// provider tree. When root is empty, implicit Go detection is skipped.
+func ResolveSourceReleaseBuild(root string, manifest *providermanifestv1.Manifest) (ResolvedSourceReleaseBuild, error) {
+	if manifest == nil {
+		return ResolvedSourceReleaseBuild{}, nil
+	}
+	kind, err := ManifestKind(manifest)
+	if err != nil {
+		return ResolvedSourceReleaseBuild{}, err
+	}
+	if kind == providermanifestv1.KindUI {
+		return ResolvedSourceReleaseBuild{Kind: kind, Mode: SourceReleaseBuildNone}, nil
+	}
+	if HasExplicitSourceRun(manifest) && (manifest.Build == nil || manifest.Build.PrepareOnly) {
+		return ResolvedSourceReleaseBuild{Kind: kind, Mode: SourceReleaseBuildNone}, nil
+	}
+
+	entry, err := effectiveReleaseEntrypoint(manifest, kind)
+	if err != nil {
+		return ResolvedSourceReleaseBuild{}, err
+	}
+	if entry == nil {
+		return ResolvedSourceReleaseBuild{Kind: kind, Mode: SourceReleaseBuildNone}, nil
+	}
+
+	if SourceBuildProducesOutput(manifest) {
+		return ResolvedSourceReleaseBuild{Kind: kind, Mode: SourceReleaseBuildDeclared, Entrypoint: entry}, nil
+	}
+	if root != "" && HasGoProviderPackage(root) && SupportsImplicitGoBuild(kind) {
+		return ResolvedSourceReleaseBuild{Kind: kind, Mode: SourceReleaseBuildImplicitGo, Entrypoint: entry}, nil
+	}
+	if manifest.Entrypoint != nil && strings.TrimSpace(manifest.Entrypoint.ArtifactPath) != "" {
+		return ResolvedSourceReleaseBuild{Kind: kind, Mode: SourceReleaseBuildPrebuilt, Entrypoint: entry}, nil
+	}
+	if releaseRequiresBuildForKind(manifest, kind) {
+		return ResolvedSourceReleaseBuild{}, missingDeclaredSourceBuildError(manifest, kind)
+	}
+	return ResolvedSourceReleaseBuild{Kind: kind, Mode: SourceReleaseBuildNone, Entrypoint: entry}, nil
+}
+
+func effectiveReleaseEntrypoint(manifest *providermanifestv1.Manifest, kind string) (*providermanifestv1.Entrypoint, error) {
+	entry, err := EffectiveSourceEntrypointForKind(manifest, kind)
+	if err != nil {
+		if releaseRequiresBuildForKind(manifest, kind) {
+			return nil, missingDeclaredSourceBuildError(manifest, kind)
+		}
+		return nil, nil
+	}
+	if entry == nil || strings.TrimSpace(entry.ArtifactPath) == "" {
+		if releaseRequiresBuildForKind(manifest, kind) {
+			return nil, missingDeclaredSourceBuildError(manifest, kind)
+		}
+		return nil, nil
+	}
+	return entry, nil
+}
+
+func SourceReleaseBuildProducesOutput(root string, manifest *providermanifestv1.Manifest) (bool, error) {
+	if SourceBuildProducesOutput(manifest) {
+		return true, nil
+	}
+	resolved, err := ResolveSourceReleaseBuild(root, manifest)
+	if err != nil {
+		return false, err
+	}
+	return resolved.Mode.RequiresPlatformBuild(), nil
+}

--- a/gestaltd/services/apps/providerpkg/release_target.go
+++ b/gestaltd/services/apps/providerpkg/release_target.go
@@ -16,14 +16,25 @@ func ReleaseRequiresBuild(manifest *providermanifestv1.Manifest) bool {
 }
 
 func releaseRequiresBuildForKind(manifest *providermanifestv1.Manifest, kind string) bool {
-	switch kind {
-	case providermanifestv1.KindApp:
-		return manifest != nil && manifest.Entrypoint == nil && (manifest.Spec == nil || !manifest.Spec.IsManifestBacked())
-	case providermanifestv1.KindIdentity, providermanifestv1.KindAuthorization, providermanifestv1.KindExternalCredentials, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindAgent, providermanifestv1.KindSecrets, providermanifestv1.KindRuntime:
-		return EntrypointForKind(manifest, kind) == nil
-	default:
+	if kind == providermanifestv1.KindUI {
 		return false
 	}
+	if manifest == nil {
+		return false
+	}
+	if kind == providermanifestv1.KindApp && manifest.Spec != nil && manifest.Spec.IsManifestBacked() {
+		return false
+	}
+	if SourceBuildProducesOutput(manifest) {
+		return false
+	}
+	if manifest.Entrypoint != nil && strings.TrimSpace(manifest.Entrypoint.ArtifactPath) != "" {
+		return false
+	}
+	if HasExplicitSourceRun(manifest) {
+		return true
+	}
+	return manifest.Entrypoint == nil
 }
 
 func HasExplicitSourceRun(manifest *providermanifestv1.Manifest) bool {
@@ -41,11 +52,11 @@ func ValidateExplicitRunPackaging(root string, manifest *providermanifestv1.Mani
 	if kind == providermanifestv1.KindUI || !releaseRequiresBuildForKind(manifest, kind) {
 		return nil
 	}
-	hasDeclaredBuild, err := HasSourceReleaseTarget(root, kind)
+	resolved, err := ResolveSourceReleaseBuild(root, manifest)
 	if err != nil {
 		return fmt.Errorf("validate %s release build: %w", kind, err)
 	}
-	if hasDeclaredBuild {
+	if resolved.Mode != SourceReleaseBuildNone {
 		return nil
 	}
 	return LocalOnlyRunReleaseError(kind)
@@ -60,14 +71,11 @@ func HasSourceReleaseTarget(root, kind string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if SourceBuildProducesOutput(manifest) {
-		return true, nil
-	}
-	ok, err := ImplicitGoBuildTarget(root, manifest)
+	resolved, err := ResolveSourceReleaseBuild(root, manifest)
 	if err != nil {
 		return false, err
 	}
-	return ok, nil
+	return resolved.Mode != SourceReleaseBuildNone, nil
 }
 
 func MissingDeclaredSourceBuildError(manifest *providermanifestv1.Manifest, kind string) error {

--- a/gestaltd/services/apps/providerpkg/source_build.go
+++ b/gestaltd/services/apps/providerpkg/source_build.go
@@ -96,14 +96,6 @@ func SourceBuildProducesOutput(manifest *providermanifestv1.Manifest) bool {
 	return build != nil && !build.PrepareOnly
 }
 
-func sourceBuildProducesOutputOrImplicitGo(root string, manifest *providermanifestv1.Manifest) bool {
-	if SourceBuildProducesOutput(manifest) {
-		return true
-	}
-	ok, err := ImplicitGoBuildTarget(root, manifest)
-	return err == nil && ok
-}
-
 func EffectiveSourceInstall(manifest *providermanifestv1.Manifest) *ResolvedSourceInstall {
 	if manifest == nil || manifest.Install == nil {
 		return nil
@@ -175,26 +167,30 @@ func RunSourceBuild(manifestPath string, manifest *providermanifestv1.Manifest, 
 	return verifySourceBuildOutput(outputPath, outputRel, outputKind, opts)
 }
 
-// runImplicitGoBuild only builds; eligibility is decided by ImplicitGoBuildTarget.
+// runImplicitGoBuild synthesizes and compiles a Go provider when no build.command
+// is declared. Eligibility follows ResolveSourceReleaseBuild implicit Go mode.
+// The build writes to a sibling temp path and renames only on success so a
+// failed build does not delete a pre-existing entrypoint artifact.
 func runImplicitGoBuild(manifestPath string, manifest *providermanifestv1.Manifest, opts SourceBuildOptions) error {
 	rootDir := filepath.Dir(manifestPath)
-	ok, err := ImplicitGoBuildTarget(rootDir, manifest)
+	resolved, err := ResolveSourceReleaseBuild(rootDir, manifest)
 	if err != nil {
 		return err
 	}
-	if !ok {
+	if resolved.Mode != SourceReleaseBuildImplicitGo {
 		return nil
 	}
 	kind, err := ManifestKind(manifest)
 	if err != nil {
 		return err
 	}
-	entry := EntrypointForKind(manifest, kind)
+	entry := resolved.Entrypoint
+	if entry == nil || strings.TrimSpace(entry.ArtifactPath) == "" {
+		return fmt.Errorf("entrypoint.artifactPath is required to build a Go provider without a declared build.command")
+	}
 	outputRel := entry.ArtifactPath
 	outputPath := filepath.Join(rootDir, filepath.FromSlash(outputRel))
 	goos, goarch := SourceBuildTarget(opts)
-	// Build to a sibling temp path first so a failed build does not delete a
-	// pre-existing entrypoint artifact; only replace the entrypoint on success.
 	tmpOutput := outputPath + ".build"
 	if err := os.RemoveAll(tmpOutput); err != nil {
 		return fmt.Errorf("remove staged build output %q: %w", outputRel, err)
@@ -304,7 +300,10 @@ func SourceBuildOutput(manifest *providermanifestv1.Manifest) (rel string, kind 
 		}
 		return output, providermanifestv1.KindUI, nil
 	}
-	entry := EntrypointForKind(manifest, manifestKind)
+	entry, err := EffectiveSourceEntrypointForKind(manifest, manifestKind)
+	if err != nil {
+		return "", "", err
+	}
 	if entry == nil || strings.TrimSpace(entry.ArtifactPath) == "" {
 		return "", "", fmt.Errorf("entrypoint.artifactPath is required when build is set")
 	}
@@ -459,7 +458,10 @@ func resolveSourceExecution(manifestPath string, manifest *providermanifestv1.Ma
 		return ResolvedSourceExecution{}, err
 	}
 	exec := SourceExecution{Workdir: rootDir}
-	entry := EntrypointForKind(manifest, kind)
+	entry, err := EffectiveSourceEntrypointForKind(manifest, kind)
+	if err != nil {
+		return ResolvedSourceExecution{}, err
+	}
 	if entry != nil && strings.TrimSpace(entry.ArtifactPath) != "" {
 		exec.Command = filepath.Join(rootDir, filepath.FromSlash(entry.ArtifactPath))
 		exec.Args = append([]string(nil), entry.Args...)

--- a/sdk/python/gestalt/_bootstrap.py
+++ b/sdk/python/gestalt/_bootstrap.py
@@ -26,7 +26,8 @@ def read_source_manifest(root: pathlib.Path) -> SourceManifest:
     """Read the build-relevant fields from a provider source manifest.
 
     Dispatches on the manifest file extension. Raises ``FileNotFoundError`` if
-    no manifest is present in ``root``.
+    no manifest is present in ``root``. ``entrypoint_artifact_path`` is optional;
+    when omitted, build derivation defaults to ``.gestalt/build/<source-name>``.
     """
     for name in _MANIFEST_BASENAMES:
         path = root / name

--- a/sdk/python/gestalt/_build.py
+++ b/sdk/python/gestalt/_build.py
@@ -81,14 +81,15 @@ def derive_build_args(root: pathlib.Path) -> BuildArgs | None:
     """
     try:
         manifest = read_source_manifest(root)
-        if manifest.entrypoint_artifact_path is None:
-            raise RuntimeError("manifest entrypoint.artifactPath is required")
         if manifest.source is None:
             raise RuntimeError("manifest source is required")
+        output_path = manifest.entrypoint_artifact_path
+        if output_path is None:
+            output_path = f".gestalt/build/{manifest.source.rsplit('/', 1)[-1]}"
         return BuildArgs(
             root=root,
             target=read_pyproject_provider(root),
-            output_path=pathlib.Path(manifest.entrypoint_artifact_path),
+            output_path=pathlib.Path(output_path),
             app_name=manifest.source.rsplit("/", 1)[-1],
             runtime_kind=_runtime_kind_for_manifest_kind(manifest.kind),
             goos=_target_goos(),

--- a/sdk/python/tests/test_build.py
+++ b/sdk/python/tests/test_build.py
@@ -412,12 +412,15 @@ class BuildTests(unittest.TestCase):
         self.assertEqual(args.goos, "darwin")
         self.assertEqual(args.goarch, "arm64")
 
-    def test_derive_build_args_missing_entrypoint_returns_none(self) -> None:
-        """A manifest without entrypoint.artifactPath surfaces a derivation error."""
+    def test_derive_build_args_missing_entrypoint_uses_default_output(self) -> None:
+        """A manifest without entrypoint.artifactPath derives the default output path."""
         with tempfile.TemporaryDirectory() as tmpdir:
             root = pathlib.Path(tmpdir)
             (root / "manifest.yaml").write_text(
-                "kind: app\nsource: github.com/x/y\n",
+                "kind: agent\n"
+                "source: github.com/valon-technologies/gestalt-providers/agent/example-agent\n"
+                "build:\n"
+                "  command: [python, -m, build]\n",
                 encoding="utf-8",
             )
             (root / "pyproject.toml").write_text(
@@ -427,7 +430,10 @@ class BuildTests(unittest.TestCase):
             with mock.patch.dict(_build.os.environ, {}, clear=False):
                 result = _build.derive_build_args(root)
 
-        self.assertIsNone(result)
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result.output_path, pathlib.Path(".gestalt/build/example-agent"))
+        self.assertEqual(result.app_name, "example-agent")
 
 
 if __name__ == "__main__":

--- a/sdk/typescript/src/build.ts
+++ b/sdk/typescript/src/build.ts
@@ -67,14 +67,12 @@ export function deriveBuildArgs(root: string): BuildArgs | undefined {
   try {
     const manifest = readSourceManifest(root);
     const target = formatProviderTarget(readPackageProviderTarget(root));
-    const artifactPath = manifest.entrypoint?.artifactPath;
-    if (!artifactPath) {
-      throw new Error("manifest entrypoint.artifactPath is required");
-    }
     const source = manifest.source;
     if (!source) {
       throw new Error("manifest source is required");
     }
+    const artifactPath =
+      manifest.entrypoint?.artifactPath ?? `.gestalt/build/${providerNameFromSource(source)}`;
     return {
       root,
       target,

--- a/sdk/typescript/tests/build.test.ts
+++ b/sdk/typescript/tests/build.test.ts
@@ -208,20 +208,23 @@ test("deriveBuildArgs derives identity name from manifest source not package nam
   }
 });
 
-test("deriveBuildArgs returns undefined when entrypoint.artifactPath is missing", () => {
+test("deriveBuildArgs returns default output when entrypoint.artifactPath is missing", () => {
   const root = mkdtempSync(join(tmpdir(), "gestalt-derive-noentry-"));
   writeFileSync(
     join(root, "manifest.yaml"),
-    "kind: app\nsource: github.com/x/y\n",
+    "kind: agent\nsource: github.com/valon-technologies/gestalt-providers/agent/example-agent\nbuild:\n  command: [npm, run, build]\n",
     "utf8",
   );
   writeFileSync(
     join(root, "package.json"),
-    JSON.stringify({ gestalt: { provider: { kind: "app", target: "./provider.ts#provider" } } }),
+    JSON.stringify({ gestalt: { provider: { kind: "agent", target: "./provider.ts#provider" } } }),
     "utf8",
   );
   try {
-    expect(deriveBuildArgs(root)).toBeUndefined();
+    const args = deriveBuildArgs(root);
+    expect(args).toBeDefined();
+    expect(args!.outputPath).toBe(".gestalt/build/example-agent");
+    expect(args!.providerName).toBe("example-agent");
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
Make source entrypoint.artifactPath optional for executable providers with output-producing builds, defaulting omitted entrypoints to `.gestalt/build/<source-last-segment>` while excluding UI and manifest-backed app providers.