### PR TITLE
Forward provider process logs to Cloud Logging

### DIFF
--- a/gestaltd/services/runtimehost/runtimeprovider/local.go
+++ b/gestaltd/services/runtimehost/runtimeprovider/local.go
@@ -315,9 +315,23 @@ func (p *LocalProvider) StartApp(ctx context.Context, req *proto.StartHostedAppR
 
 	stdout := io.Writer(nil)
 	stderr := io.Writer(nil)
+	var processCleanup func()
 	if p.sessionLogs != nil {
-		stdout = newSessionLogWriter(p.sessionLogs, p.runtimeProviderName, req.GetSessionId(), runtimelogs.StreamStdout, &session.logSeq)
-		stderr = newSessionLogWriter(p.sessionLogs, p.runtimeProviderName, req.GetSessionId(), runtimelogs.StreamStderr, &session.logSeq)
+		sessionStdout := newSessionLogWriter(p.sessionLogs, p.runtimeProviderName, req.GetSessionId(), runtimelogs.StreamStdout, &session.logSeq)
+		sessionStderr := newSessionLogWriter(p.sessionLogs, p.runtimeProviderName, req.GetSessionId(), runtimelogs.StreamStderr, &session.logSeq)
+		// Tee provider output to the container stderr so it is visible in Cloud
+		// Logging, while preserving the in-memory session log stream. Use a separate
+		// prefix writer per stream so partial lines from stdout and stderr are not
+		// mixed together.
+		providerStdout := newProviderLogWriter(os.Stderr, req.GetAppName())
+		providerStderr := newProviderLogWriter(os.Stderr, req.GetAppName())
+		stdout = io.MultiWriter(sessionStdout, providerStdout)
+		stderr = io.MultiWriter(sessionStderr, providerStderr)
+		// Flush any trailing partial line when the process is closed.
+		processCleanup = func() {
+			_ = providerStdout.Close()
+			_ = providerStderr.Close()
+		}
 		_, _ = p.sessionLogs.AppendSessionLogs(context.Background(), p.runtimeProviderName, req.GetSessionId(), []runtimelogs.AppendEntry{{
 			SourceSeq:  int64(atomic.AddUint64(&session.logSeq, 1)),
 			Stream:     runtimelogs.StreamRuntime,
@@ -341,6 +355,7 @@ func (p *LocalProvider) StartApp(ctx context.Context, req *proto.StartHostedAppR
 		Telemetry:    p.telemetry,
 		Stdout:       stdout,
 		Stderr:       stderr,
+		Cleanup:      processCleanup,
 	})
 	if err != nil {
 		p.mu.Lock()

--- a/gestaltd/services/runtimehost/runtimeprovider/local_test.go
+++ b/gestaltd/services/runtimehost/runtimeprovider/local_test.go
@@ -1,8 +1,10 @@
 package runtimeprovider
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -284,5 +286,173 @@ func runWorkspaceGit(t *testing.T, dir string, args ...string) {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("git %s: %v: %s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+}
+
+func TestLocalProviderTeesSessionLogsToStderr(t *testing.T) {
+	store := runtimelogs.NewMemoryStore()
+	var sessionID string
+	captured := captureStderr(t, func() {
+		runtime := NewLocalProvider(WithLocalRuntimeSessionLogs("local", store))
+		defer func() { _ = runtime.Close() }()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		session, err := runtime.StartSession(ctx, &proto.StartRuntimeSessionRequest{AppName: "log-tee"})
+		if err != nil {
+			t.Fatalf("StartSession: %v", err)
+		}
+		sessionID = session.GetId()
+
+		_, _ = runtime.StartApp(ctx, &proto.StartHostedAppRequest{
+			SessionId: sessionID,
+			AppName:   "log-tee",
+			Command:   "/bin/sh",
+			Args: []string{
+				"-c",
+				"printf 'hello stdout\n'; printf 'hello stderr\n' >&2; exit 17",
+			},
+		})
+	})
+	if sessionID == "" {
+		t.Fatal("session ID was not set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	logs, err := store.ListSessionLogs(ctx, "local", sessionID, 0, 100)
+	if err != nil {
+		t.Fatalf("ListSessionLogs: %v", err)
+	}
+	byStream := map[runtimelogs.Stream]string{}
+	for _, entry := range logs {
+		byStream[entry.Stream] += entry.Message
+	}
+	if got := byStream[runtimelogs.StreamStdout]; !strings.Contains(got, "hello stdout") {
+		t.Fatalf("stdout logs = %q, want hello stdout", got)
+	}
+	if got := byStream[runtimelogs.StreamStderr]; !strings.Contains(got, "hello stderr") {
+		t.Fatalf("stderr logs = %q, want hello stderr", got)
+	}
+
+	if !strings.Contains(captured, "provider=log-tee hello stdout") {
+		t.Fatalf("captured stderr = %q, want provider=log-tee hello stdout", captured)
+	}
+	if !strings.Contains(captured, "provider=log-tee hello stderr") {
+		t.Fatalf("captured stderr = %q, want provider=log-tee hello stderr", captured)
+	}
+}
+
+func TestLocalProviderNoSessionLogsDefaultsToStderr(t *testing.T) {
+	var sessionID string
+	captured := captureStderr(t, func() {
+		runtime := NewLocalProvider()
+		defer func() { _ = runtime.Close() }()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		session, err := runtime.StartSession(ctx, &proto.StartRuntimeSessionRequest{AppName: "no-log-tee"})
+		if err != nil {
+			t.Fatalf("StartSession: %v", err)
+		}
+		sessionID = session.GetId()
+
+		_, _ = runtime.StartApp(ctx, &proto.StartHostedAppRequest{
+			SessionId: sessionID,
+			AppName:   "no-log-tee",
+			Command:   "/bin/sh",
+			Args: []string{
+				"-c",
+				"printf 'hello stdout\n'; printf 'hello stderr\n' >&2; exit 17",
+			},
+		})
+	})
+
+	if !strings.Contains(captured, "hello stdout") {
+		t.Fatalf("captured stderr = %q, want hello stdout", captured)
+	}
+	if !strings.Contains(captured, "hello stderr") {
+		t.Fatalf("captured stderr = %q, want hello stderr", captured)
+	}
+	if strings.Contains(captured, "provider=") {
+		t.Fatalf("captured stderr = %q, want no provider prefix", captured)
+	}
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stderr pipe: %v", err)
+	}
+	os.Stderr = w
+	defer func() { os.Stderr = oldStderr }()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close stderr pipe: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("read stderr pipe: %v", err)
+	}
+	_ = r.Close()
+	return buf.String()
+}
+
+func TestProviderLogWriterPrefixesLines(t *testing.T) {
+	var buf bytes.Buffer
+	w := newProviderLogWriter(&buf, "codeReview")
+	if _, err := w.Write([]byte("first line\nsecond line\n")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	want := "provider=codeReview first line\nprovider=codeReview second line\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestProviderLogWriterBuffersPartialLines(t *testing.T) {
+	var buf bytes.Buffer
+	w := newProviderLogWriter(&buf, "codeReview")
+	if _, err := w.Write([]byte("first")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if _, err := w.Write([]byte(" second\n")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	want := "provider=codeReview first second\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestProviderLogWriterFlushWithoutNewline(t *testing.T) {
+	var buf bytes.Buffer
+	w := newProviderLogWriter(&buf, "codeReview")
+	if _, err := w.Write([]byte("partial")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	want := "provider=codeReview partial"
+	if got := buf.String(); got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestProviderLogWriterEmptyNameFallsBack(t *testing.T) {
+	var buf bytes.Buffer
+	w := newProviderLogWriter(&buf, "")
+	if _, err := w.Write([]byte("line\n")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if got := buf.String(); got != "provider=unknown line\n" {
+		t.Fatalf("output = %q", got)
 	}
 }

--- a/gestaltd/services/runtimehost/runtimeprovider/provider_log_writer.go
+++ b/gestaltd/services/runtimehost/runtimeprovider/provider_log_writer.go
@@ -1,0 +1,90 @@
+package runtimeprovider
+
+import (
+	"fmt"
+	"io"
+	"sync"
+)
+
+// providerLogWriter prefixes every line written to it with provider=<name>
+// so that provider process output tee'd to the container stderr can be
+// filtered in Cloud Logging.
+type providerLogWriter struct {
+	w      io.Writer
+	prefix string
+	mu     sync.Mutex
+	buf    []byte
+}
+
+func newProviderLogWriter(w io.Writer, providerName string) *providerLogWriter {
+	if w == nil {
+		return nil
+	}
+	if providerName == "" {
+		providerName = "unknown"
+	}
+	return &providerLogWriter{
+		w:      w,
+		prefix: fmt.Sprintf("provider=%s ", providerName),
+	}
+}
+
+func (w *providerLogWriter) Write(p []byte) (int, error) {
+	if w == nil || w.w == nil {
+		return len(p), nil
+	}
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	prevLen := len(w.buf)
+	data := append(append([]byte(nil), w.buf...), p...)
+	w.buf = nil
+
+	start := 0
+	for i := 0; i <= len(data); i++ {
+		if i < len(data) && data[i] != '\n' {
+			continue
+		}
+		if i == len(data) {
+			if start < len(data) {
+				w.buf = append([]byte(nil), data[start:]...)
+			}
+			return len(p), nil
+		}
+		if _, err := fmt.Fprintf(w.w, "%s%s\n", w.prefix, data[start:i]); err != nil {
+			consumed := i - prevLen
+			if consumed < 0 {
+				consumed = 0
+			}
+			if consumed > len(p) {
+				consumed = len(p)
+			}
+			return consumed, err
+		}
+		start = i + 1
+	}
+
+	return len(p), nil
+}
+
+func (w *providerLogWriter) Flush() error {
+	if w == nil || w.w == nil {
+		return nil
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if len(w.buf) == 0 {
+		return nil
+	}
+	_, err := fmt.Fprintf(w.w, "%s%s", w.prefix, w.buf)
+	w.buf = nil
+	return err
+}
+
+func (w *providerLogWriter) Close() error {
+	return w.Flush()
+}


### PR DESCRIPTION
## Summary

- Tee provider stdout/stderr to the container stderr alongside the existing in-memory runtime session log store, so provider logs are visible in Cloud Logging.
- Add a `providerLogWriter` that prefixes each line with `provider=<name>` so provider output is distinguishable from host logs in Cloud Logging queries.
- Buffer incomplete lines and flush them on newline or `Close`; wire `Close` into `ProcessConfig.Cleanup` so the final partial line is emitted when the process shuts down.
- Keep the session log store unchanged; the tee is additive and the non-session-log path is unaffected.
- Verify `runtimeprovider/executable.go` does not override stdout/stderr, so it continues to default to `os.Stderr` via `runtimehost.StartAppProcess`.

## Test plan

- [x] Unit test: `TestLocalProviderTeesSessionLogsToStderr` asserts that fake provider output appears in both the session log store and the captured stderr with the `provider=` prefix.
- [x] Unit test: `TestLocalProviderNoSessionLogsDefaultsToStderr` asserts that without session logs, stdout/stderr still reach `os.Stderr` without any prefix and without session log capture.
- [x] Unit tests: `TestProviderLogWriter*` cover complete lines, buffered partial lines, flush on close, and empty-name fallback.
- [x] Package tests: `go test ./gestaltd/services/runtimehost/...` passes.
- [ ] Manual verification after deploy: open a PR against `valon-technologies/toolshed` and confirm `provider=codeReview` lines appear in `run.googleapis.com/stderr`.
