### PR TITLE
Bump TypeScript SDK to 0.0.1-alpha.65

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@valon-technologies/gestalt",
-  "version": "0.0.1-alpha.64",
+  "version": "0.0.1-alpha.65",
   "description": "TypeScript SDK for Gestalt executable providers",
   "type": "module",
   "repository": {


### PR DESCRIPTION
Bumps the TypeScript SDK package version to 0.0.1-alpha.65 so that the published npm package reflects the post-#2510 default-entrypoint derivation.

This commit is tagged with `sdk/typescript/v0.0.1-alpha.65` to trigger the release workflow.