### PR TITLE
Replace deprecated h2c.NewHandler with http.Server.Protocols

### DIFF
--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -19,8 +19,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/apps/source"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/providerdev"
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 )
 
 const (
@@ -330,9 +328,13 @@ func newMCPHandler(cfg *config.Config, connMaps bootstrap.ConnectionMaps, result
 }
 
 func newHTTPServer(addr string, handler http.Handler) *http.Server {
+	protocols := &http.Protocols{}
+	protocols.SetHTTP1(true)
+	protocols.SetUnencryptedHTTP2(true)
 	return &http.Server{
 		Addr:              addr,
-		Handler:           h2c.NewHandler(handler, &http2.Server{}),
+		Handler:           handler,
+		Protocols:         protocols,
 		ReadHeaderTimeout: 10 * time.Second,
 		IdleTimeout:       120 * time.Second,
 		MaxHeaderBytes:    1 << 20,

--- a/gestaltd/services/providerdev/proxy_test.go
+++ b/gestaltd/services/providerdev/proxy_test.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 	"golang.org/x/net/websocket"
 )
 
@@ -35,9 +33,13 @@ func TestReverseProxyWebSocketThroughH2C(t *testing.T) {
 	root.Handle("/mount/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		proxy.ServeHTTP(w, r)
 	}))
-	handler := h2c.NewHandler(root, &http2.Server{})
-
-	server := httptest.NewServer(handler)
+	protocols := &http.Protocols{}
+	protocols.SetHTTP1(true)
+	protocols.SetUnencryptedHTTP2(true)
+	server := httptest.NewUnstartedServer(root)
+	server.EnableHTTP2 = true
+	server.Config.Protocols = protocols
+	server.Start()
 	t.Cleanup(server.Close)
 
 	ws, err := websocket.Dial(strings.Replace(server.URL, "http://", "ws://", 1)+"/mount/ws", "", server.URL+"/mount/")


### PR DESCRIPTION
## Summary

- The `x/net` bump in #2512 deprecated `golang.org/x/net/http2/h2c`, causing `golangci-lint` `SA1019` failures on every PR including `main`.
- Go 1.26 supports unencrypted HTTP/2 natively via `http.Server.Protocols` with `SetUnencryptedHTTP2`, which is the recommended replacement per the deprecation message.
- Removes the `h2c` and `http2` imports from `runtime.go` and `proxy_test.go` and uses the standard library `Protocols` field instead.

## Test plan

- [x] `go build ./internal/server/ ./services/providerdev/` passes
- [x] `go test ./internal/server/... ./services/providerdev/...` passes
- [x] `golangci-lint run ./internal/... ./services/...` reports 0 issues (h2c SA1019 gone)
- [ ] CI `Go Lint & Vet` passes