### PR TITLE
Propagate OTLP telemetry env vars to hosted runtime providers

### DIFF
--- a/gestaltd/internal/bootstrap/executable_app_test.go
+++ b/gestaltd/internal/bootstrap/executable_app_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/egressproxy"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
+	telemetrynoop "github.com/valon-technologies/gestalt/server/services/observability/drivers/noop"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost/runtimeprovider"
 	"github.com/valon-technologies/gestalt/server/services/workflows/workflowauth"
@@ -8266,5 +8267,119 @@ func TestExecutablePluginRequiresManifest(t *testing.T) {
 	}
 	if got := err.Error(); got != `bootstrap: provider validation failed: integration "echoext": integration "echoext" must resolve to a provider manifest` {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// stubTelemetryWithEnv is a core.TelemetryProvider that also implements
+// runtimehost's ProviderTelemetryEnv, so tests can verify OTLP env vars
+// are propagated to hosted provider StartApp requests.
+type stubTelemetryWithEnv struct {
+	telemetrynoop.Provider
+	env map[string]string
+}
+
+func (s *stubTelemetryWithEnv) ProviderTelemetryEnv(providerName string) map[string]string {
+	out := make(map[string]string, len(s.env))
+	maps.Copy(out, s.env)
+	return out
+}
+
+func TestHostedAppStartAppReceivesTelemetryEnv(t *testing.T) {
+	t.Parallel()
+
+	bin := buildEchoPluginBinary(t)
+	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
+		Name: "echoext",
+		Operations: []catalog.CatalogOperation{
+			{ID: "echo", Method: http.MethodPost},
+			{ID: "read_env", Method: http.MethodGet, Parameters: []catalog.CatalogParameter{{Name: "name", Type: "string", Required: true}}},
+		},
+	})
+	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
+	artifactBytes, err := os.ReadFile(bin)
+	if err != nil {
+		t.Fatalf("ReadFile(bin): %v", err)
+	}
+	artifactFile := filepath.Join(manifestRoot, filepath.Base(bin))
+	if err := os.WriteFile(artifactFile, artifactBytes, 0o755); err != nil {
+		t.Fatalf("WriteFile(artifact): %v", err)
+	}
+	artifactDigest, err := providerpkg.FileSHA256(artifactFile)
+	if err != nil {
+		t.Fatalf("FileSHA256: %v", err)
+	}
+	manifest.Artifacts = []providermanifestv1.Artifact{{
+		OS:     runtime.GOOS,
+		Arch:   runtime.GOARCH,
+		Path:   filepath.Base(bin),
+		SHA256: artifactDigest,
+	}}
+	manifest.Entrypoint = &providermanifestv1.Entrypoint{ArtifactPath: filepath.Base(bin)}
+	manifestPath := filepath.Join(manifestRoot, "manifest.yaml")
+	manifestData, err := providerpkg.EncodeManifestFormat(manifest, providerpkg.ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("EncodeManifestFormat: %v", err)
+	}
+	if err := os.WriteFile(manifestPath, manifestData, 0o644); err != nil {
+		t.Fatalf("WriteFile(manifest.yaml): %v", err)
+	}
+
+	runtimeProvider := newCapturingBundleRuntime()
+	factories := NewFactoryRegistry()
+	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (runtimeprovider.Provider, error) {
+		return runtimeProvider, nil
+	}
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
+		},
+		Runtime: config.RuntimeConfig{
+			Providers: map[string]*config.RuntimeProviderEntry{
+				"hosted": {Driver: config.RuntimeProviderDriver("capture")},
+			},
+		},
+		Apps: map[string]*config.ProviderEntry{
+			"echoext": {
+				Command:              bin,
+				Args:                 []string{"provider"},
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: manifestPath,
+				Runtime:              &config.RuntimePlacementConfig{},
+			},
+		},
+	}
+
+	deps := testRuntimePublicEndpointDeps(t, Deps{})
+	deps.Telemetry = &stubTelemetryWithEnv{
+		env: map[string]string{
+			"OTEL_EXPORTER_OTLP_ENDPOINT": "otel-collector:4317",
+			"OTEL_SERVICE_NAME":           "test-echoext",
+		},
+	}
+	deps.RuntimeRegistry = newRuntimeRegistry(cfg, factories.Runtime, deps)
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, deps)
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	defer func() { _ = CloseProviders(providers) }()
+
+	prov, err := providers.Get("echoext")
+	if err != nil {
+		t.Fatalf("providers.Get(echoext): %v", err)
+	}
+	if _, err := prov.Execute(context.Background(), "echo", map[string]any{"name": "test"}, ""); err != nil {
+		t.Fatalf("Execute(echo): %v", err)
+	}
+
+	requests := runtimeProvider.startAppRequestsCopy()
+	if len(requests) != 1 {
+		t.Fatalf("start app requests = %d, want 1", len(requests))
+	}
+	env := requests[0].GetEnv()
+	if got := env["OTEL_EXPORTER_OTLP_ENDPOINT"]; got != "otel-collector:4317" {
+		t.Fatalf("StartApp OTEL_EXPORTER_OTLP_ENDPOINT = %q, want otel-collector:4317", got)
+	}
+	if got := env["OTEL_SERVICE_NAME"]; got != "test-echoext" {
+		t.Fatalf("StartApp OTEL_SERVICE_NAME = %q, want test-echoext", got)
 	}
 }

--- a/gestaltd/internal/bootstrap/hosted_workflow_provider.go
+++ b/gestaltd/internal/bootstrap/hosted_workflow_provider.go
@@ -202,6 +202,7 @@ func startHostedWorkflowProviderInstance(ctx context.Context, launch *hostedWork
 
 	startEnv := maps.Clone(launch.cfg.Env)
 	startEnv = withHostServiceTLSCAEnv(startEnv, deps)
+	maps.Copy(startEnv, runtimehost.ProviderTelemetryEnv(deps.Telemetry, name))
 	workflowAllowedHosts := launch.cfg.EgressPolicy("").AllowedHosts
 	if len(workflowAllowedHosts) == 0 {
 		workflowAllowedHosts = append([]string(nil), launch.allowedHosts...)

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -991,6 +991,7 @@ func buildAppProvider(ctx context.Context, name string, entry *config.ProviderEn
 	launchCleanup = nil
 	startEnv := maps.Clone(env)
 	startEnv = withHostServiceTLSCAEnv(startEnv, deps)
+	maps.Copy(startEnv, runtimehost.ProviderTelemetryEnv(deps.Telemetry, name))
 	egressPolicy := deps.Egress.ProviderPolicy(entry)
 	allowedHosts := entry.EffectiveAllowedHosts()
 	startEnv, allowedHosts, err = applyHostedRuntimeHostServiceRelayEnv(name, sessionID, hostServices, runtimePlan, deps, startEnv, allowedHosts)
@@ -1228,6 +1229,7 @@ func startHostedAgentProviderInstance(ctx context.Context, launch *hostedAgentPr
 
 	startEnv := maps.Clone(cfg.Env)
 	startEnv = withHostServiceTLSCAEnv(startEnv, deps)
+	maps.Copy(startEnv, runtimehost.ProviderTelemetryEnv(deps.Telemetry, name))
 	agentAllowedHosts := cfg.EgressPolicy("").AllowedHosts
 	if len(agentAllowedHosts) == 0 {
 		agentAllowedHosts = slices.Clone(launch.allowedHosts)

--- a/gestaltd/services/runtimehost/process.go
+++ b/gestaltd/services/runtimehost/process.go
@@ -491,7 +491,7 @@ func mergeExecEnv(base, extra map[string]string) map[string]string {
 }
 
 func providerProcessEnv(cfg ProcessConfig, execEnv map[string]string) map[string]string {
-	env := mergeExecEnv(providerTelemetryEnv(cfg.Telemetry, cfg.ProviderName), cfg.Env)
+	env := mergeExecEnv(ProviderTelemetryEnv(cfg.Telemetry, cfg.ProviderName), cfg.Env)
 	return mergeExecEnv(env, execEnv)
 }
 
@@ -499,7 +499,7 @@ type providerTelemetryEnvProvider interface {
 	ProviderTelemetryEnv(providerName string) map[string]string
 }
 
-func providerTelemetryEnv(telemetry metricutil.TelemetryProviders, providerName string) map[string]string {
+func ProviderTelemetryEnv(telemetry metricutil.TelemetryProviders, providerName string) map[string]string {
 	if telemetry == nil {
 		return nil
 	}


### PR DESCRIPTION
OTLP telemetry env vars were only injected into co-located provider processes. For hosted runtime providers (GKE agent sandbox, the default in prod), the env came from StartHostedAppRequest.Env which never included the telemetry env, making configure_from_environment silently no-op on every hosted provider. Exports ProviderTelemetryEnv from runtimehost and merges it into startEnv at all three StartApp call sites.