### PR TITLE
Skip gestalt-managed dirs in source fingerprints

### DIFF
--- a/gestaltd/internal/operator/fingerprint.go
+++ b/gestaltd/internal/operator/fingerprint.go
@@ -15,16 +15,40 @@ import (
 )
 
 // fingerprintSkipper is the fingerprint exclusion policy: which paths a source
-// fingerprint walk excludes. Two structural invariants apply regardless of
+// fingerprint walk excludes. Structural invariants apply regardless of
 // .gitignore: the declared build output (never hash the artifact about to be
-// produced) and the .git directory itself (git metadata, never a build input).
-// Everything else is decided by the enclosing repo's .gitignore rules. Explicit
-// per-input file listings are honored verbatim by the callers; shouldSkip is
-// only consulted on directory walks and on the walk root.
+// produced), the .git directory (git metadata, never a build input), and
+// gestalt's own managed directories (see reservedFingerprintDir). Everything
+// else is decided by the enclosing repo's .gitignore rules. Explicit per-input
+// file listings are honored verbatim by the callers; shouldSkip is only
+// consulted on directory walks and on the walk root.
 type fingerprintSkipper struct {
 	matcher   gitignore.Matcher
 	repoRoot  string
 	outputAbs string
+}
+
+// gestaltStateDirName is the daemon's prepared-artifacts/state directory, created
+// inside --artifacts-dir. gestaltBuildDirName is a provider's build scratch/output
+// directory. Both are gestalt-managed and must never count as source inputs: when
+// --artifacts-dir nests under a provider source tree, materializing an artifact
+// (staging→final rename, lock-metadata write) mutates these dirs, so including
+// them would make the source-input fingerprint unstable and sync's post-
+// materialize re-check would never converge (it would always see a "stale" input).
+const (
+	gestaltStateDirName = ".gestaltd"
+	gestaltBuildDirName = ".gestalt"
+)
+
+// reservedFingerprintDir reports whether a directory name is gestalt- or
+// git-managed and therefore excluded from every source fingerprint walk.
+func reservedFingerprintDir(name string) bool {
+	switch name {
+	case gitDirName, gestaltStateDirName, gestaltBuildDirName:
+		return true
+	default:
+		return false
+	}
 }
 
 func newFingerprintSkipper(sourceDir, outputAbs string) (fingerprintSkipper, error) {
@@ -40,7 +64,7 @@ func (s fingerprintSkipper) shouldSkip(path string, d os.DirEntry) bool {
 	if s.outputAbs != "" && pathWithinRoot(s.outputAbs, cleanPath) {
 		return true
 	}
-	if d != nil && d.IsDir() && d.Name() == gitDirName {
+	if d != nil && d.IsDir() && reservedFingerprintDir(d.Name()) {
 		return true
 	}
 	components := gitignorePathComponents(s.repoRoot, cleanPath)

--- a/gestaltd/internal/operator/lifecycle_fingerprint_gitignore_test.go
+++ b/gestaltd/internal/operator/lifecycle_fingerprint_gitignore_test.go
@@ -68,6 +68,59 @@ func fingerprintOf(t *testing.T, manifestPath string) string {
 	return digest
 }
 
+// TestFingerprintExcludesNestedGestaltManagedDirs asserts the source-input
+// fingerprint ignores gestalt-managed directories that may nest under a provider
+// source tree: the daemon's .gestaltd artifacts/state dir (when --artifacts-dir
+// is placed under the source) and a .gestalt build scratch dir. Regression for
+// sync's post-materialize re-check never converging: materializing an artifact
+// (staging→final rename + lock-metadata write) mutated these nested dirs, so the
+// SourceInputDigest/InputDigest shifted between write and re-check and every sync
+// reported the just-built artifact "stale".
+func TestFingerprintExcludesNestedGestaltManagedDirs(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "provider")
+	writeBuildableSourceProviderTree(t, src, "github.com/acme/apps/alpha", "dist/out", nil)
+	initGitRepo(t, dir)
+	manifestPath := filepath.Join(src, "manifest.yaml")
+
+	base := fingerprintOf(t, manifestPath)
+
+	mustWrite := func(rel, content string) {
+		t.Helper()
+		p := filepath.Join(src, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", rel, err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+
+	// A nested artifacts dir mid-materialize (staging temp provider) plus a build
+	// scratch dir. Neither is gitignored, so without the reserved-dir skip the
+	// walk would include them.
+	mustWrite(".local/.art/.gestaltd/providers/gIssues.tmp-123/catalog.yaml", "a: 1\n")
+	mustWrite(".local/.art/.gestaltd/providers/gIssues.tmp-123/manifest.yaml", "kind: app\n")
+	mustWrite(".gestalt/build/extra", "scratch\n")
+
+	if got := fingerprintOf(t, manifestPath); got != base {
+		t.Fatalf("fingerprint changed when gestalt-managed dirs nested under source:\n base=%s\n got =%s", base, got)
+	}
+
+	// Simulate commit: staging→final rename + lock-metadata write (the exact churn
+	// that destabilized the digest between write and re-check).
+	art := filepath.Join(src, ".local", ".art", ".gestaltd", "providers")
+	if err := os.Rename(filepath.Join(art, "gIssues.tmp-123"), filepath.Join(art, "gIssues")); err != nil {
+		t.Fatalf("rename staging→final: %v", err)
+	}
+	mustWrite(".local/.art/.gestaltd/providers/gIssues/.gestaltd-lock-metadata.json", "{}\n")
+
+	if got := fingerprintOf(t, manifestPath); got != base {
+		t.Fatalf("fingerprint changed after simulated staging→final commit:\n base=%s\n got =%s", base, got)
+	}
+}
+
 // TestFingerprintGitignoreRepoRootExclusion asserts the core repo-root
 // anchoring contract: with no inputs, the fingerprint walks the whole provider
 // dir, excludes gitignored paths (node_modules, .venv) resolved from the


### PR DESCRIPTION
## What

Source-input fingerprints now skip gestalt's own managed directories — `.gestaltd` (artifacts/state) and `.gestalt` (build scratch) — the same way they already skip `.git`.

## Why (in simple terms)

When you run an isolated local-dev backend with `--artifacts-dir` placed **inside** a provider's source tree, `gestaltd sync` could never finish: it kept reporting the artifact it had **just built** as "missing or stale," looping forever.

The cause: to decide whether a prepared artifact is still fresh, gestaltd fingerprints the provider's **source** files. But that walk descended into the artifacts directory when it was nested under the source. Materializing an artifact renames a staging dir (`X.tmp-123` → `X`) and writes a lock-metadata file — so the "source" fingerprint changed **between** the moment gestaltd recorded it and the moment it re-checked it. The re-check saw a different digest and declared the just-built artifact stale.

`sync` (which validates source inputs) hit this on the first provider and never converged. `serve --locked` (which skips source-input validation) got one provider further before failing the same way — so the two commands **disagreed about the same artifact**.

The fix treats gestalt's artifact/build directories as non-source, exactly like `.git`. They are **outputs**, never source inputs, so excluding them keeps the source fingerprint stable no matter where `--artifacts-dir` lives.

## Test

`TestFingerprintExcludesNestedGestaltManagedDirs` reproduces the exact churn (a nested `.gestaltd` artifacts dir + staging→final rename + lock-metadata write) and asserts the source fingerprint stays stable. It fails without the fix and passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)