### PR TITLE
Fix nil map panic in telemetry env propagation

### DIFF
--- a/gestaltd/internal/bootstrap/hosted_workflow_provider.go
+++ b/gestaltd/internal/bootstrap/hosted_workflow_provider.go
@@ -202,6 +202,9 @@ func startHostedWorkflowProviderInstance(ctx context.Context, launch *hostedWork
 
 	startEnv := maps.Clone(launch.cfg.Env)
 	startEnv = withHostServiceTLSCAEnv(startEnv, deps)
+	if startEnv == nil {
+		startEnv = map[string]string{}
+	}
 	maps.Copy(startEnv, runtimehost.ProviderTelemetryEnv(deps.Telemetry, name))
 	workflowAllowedHosts := launch.cfg.EgressPolicy("").AllowedHosts
 	if len(workflowAllowedHosts) == 0 {

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -991,6 +991,9 @@ func buildAppProvider(ctx context.Context, name string, entry *config.ProviderEn
 	launchCleanup = nil
 	startEnv := maps.Clone(env)
 	startEnv = withHostServiceTLSCAEnv(startEnv, deps)
+	if startEnv == nil {
+		startEnv = map[string]string{}
+	}
 	maps.Copy(startEnv, runtimehost.ProviderTelemetryEnv(deps.Telemetry, name))
 	egressPolicy := deps.Egress.ProviderPolicy(entry)
 	allowedHosts := entry.EffectiveAllowedHosts()
@@ -1229,6 +1232,9 @@ func startHostedAgentProviderInstance(ctx context.Context, launch *hostedAgentPr
 
 	startEnv := maps.Clone(cfg.Env)
 	startEnv = withHostServiceTLSCAEnv(startEnv, deps)
+	if startEnv == nil {
+		startEnv = map[string]string{}
+	}
 	maps.Copy(startEnv, runtimehost.ProviderTelemetryEnv(deps.Telemetry, name))
 	agentAllowedHosts := cfg.EgressPolicy("").AllowedHosts
 	if len(agentAllowedHosts) == 0 {


### PR DESCRIPTION
The maps.Copy call added in #2516 panics when startEnv is nil. maps.Clone(nil) returns nil and withHostServiceTLSCAEnv returns nil when no TLS CA is configured, so maps.Copy(nil, ...) panics with "assignment to entry in nil map". This caused the new gestaltd revisions to crash-loop on bootstrap, preventing the OTLP fixes from deploying. Initialize startEnv to an empty map before maps.Copy at all three StartApp call sites.