### PR TITLE
Tolerate provider-release.yaml missing staticValidation

### DIFF
--- a/gestaltd/.gitignore
+++ b/gestaltd/.gitignore
@@ -1,1 +1,2 @@
 gestaltd/gestaltd
+gestaltd

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -84,10 +84,11 @@ type LockEntry struct {
 	ValidationManifest *providermanifestv1.Manifest `json:"manifest,omitempty"`
 	CatalogAvailable   bool                         `json:"catalogAvailable,omitempty"`
 	CatalogFingerprint string                       `json:"catalogFingerprint,omitempty"`
-	CatalogSessionOnly bool                         `json:"catalogSessionOnly,omitempty"`
-	ArtifactManifest   string                       `json:"-"`
-	Executable         string                       `json:"-"`
-	AssetRoot          string                       `json:"-"`
+	CatalogSessionOnly    bool                         `json:"catalogSessionOnly,omitempty"`
+	SynthesizedValidation bool                         `json:"synthesizedValidation,omitempty"`
+	ArtifactManifest      string                       `json:"-"`
+	Executable            string                       `json:"-"`
+	AssetRoot             string                       `json:"-"`
 }
 
 type StaticValidationOptions struct {
@@ -3064,6 +3065,7 @@ func (l *Lifecycle) installMetadataSourcePackage(ctx context.Context, expectedKi
 	entry.ValidationManifest = staticManifest
 	entry.CatalogAvailable = bundle.Catalog != nil
 	entry.CatalogSessionOnly = bundle.Catalog == nil && providerrelease.CatalogSessionModeAllowed(metadata.Kind, bundle.Manifest)
+	entry.SynthesizedValidation = bundle.Synthesized
 
 	currentPlatform := providerpkg.CurrentPlatformString()
 	archive, resolvedKey, ok := resolveArchiveForPlatform(entry, currentPlatform)
@@ -3125,7 +3127,16 @@ func validateInstalledPackageMatchesReleaseBundle(subject string, installed *ins
 		return fmt.Errorf("%s project installed validation manifest: %w", subject, err)
 	}
 	addCatalogOperationIDsToManifest(manifest, bundle.Catalog)
-	if !providerManifestsEqual(manifest, entry.ValidationManifest) {
+	if entry.SynthesizedValidation {
+		// The release metadata predates staticValidation; the validation
+		// manifest was synthesized from identity fields. Only check that
+		// the installed manifest's identity matches, not the full JSON.
+		if manifest.Kind != entry.ValidationManifest.Kind ||
+			strings.TrimSpace(manifest.Source) != strings.TrimSpace(entry.ValidationManifest.Source) ||
+			strings.TrimSpace(manifest.Version) != strings.TrimSpace(entry.ValidationManifest.Version) {
+			return fmt.Errorf("%s installed package identity does not match release metadata", subject)
+		}
+	} else if !providerManifestsEqual(manifest, entry.ValidationManifest) {
 		return fmt.Errorf("%s installed package manifest does not match provider release validation manifest", subject)
 	}
 	if entry.CatalogSessionOnly {

--- a/gestaltd/internal/operator/release_metadata.go
+++ b/gestaltd/internal/operator/release_metadata.go
@@ -55,9 +55,10 @@ type gitHubReleaseByTagResponse struct {
 }
 
 type providerReleaseValidationBundle struct {
-	Metadata *providerrelease.Metadata
-	Manifest *providermanifestv1.Manifest
-	Catalog  *catalog.Catalog
+	Metadata    *providerrelease.Metadata
+	Manifest    *providermanifestv1.Manifest
+	Catalog     *catalog.Catalog
+	Synthesized bool
 }
 
 type sidecarProviderReleaseMetadata struct {
@@ -122,9 +123,10 @@ func fetchProviderReleaseBundle(ctx context.Context, client *http.Client, metada
 		return providerReleaseValidationBundle{}, "", nil, err
 	}
 	return providerReleaseValidationBundle{
-		Metadata: metadata,
-		Manifest: metadata.StaticValidation.Manifest,
-		Catalog:  metadata.StaticValidation.Catalog,
+		Metadata:    metadata,
+		Manifest:    metadata.StaticValidation.Manifest,
+		Catalog:     metadata.StaticValidation.Catalog,
+		Synthesized: metadata.StaticValidation.Synthesized,
 	}, resolvedMetadataLocation, gitHubReleaseAssets, nil
 }
 

--- a/gestaltd/internal/providerrelease/release.go
+++ b/gestaltd/internal/providerrelease/release.go
@@ -47,6 +47,10 @@ type StaticValidation struct {
 	Manifest           *providermanifestv1.Manifest `yaml:"manifest,omitempty"`
 	Catalog            *catalog.Catalog             `yaml:"catalog,omitempty"`
 	CatalogSessionOnly bool                         `yaml:"catalogSessionOnly,omitempty"`
+	// Synthesized is true when the Manifest was derived from the release
+	// metadata's own identity fields because the original provider-release.yaml
+	// lacked a staticValidation section. This is not serialized to YAML.
+	Synthesized bool `yaml:"-"`
 }
 
 type staticValidationYAML struct {
@@ -164,8 +168,22 @@ func ValidateMetadata(metadata *Metadata) error {
 	default:
 		return fmt.Errorf("provider release runtime %q is not supported", metadata.Runtime)
 	}
-	if metadata.StaticValidation == nil || metadata.StaticValidation.Manifest == nil {
-		return fmt.Errorf("provider release validation manifest is required")
+	if metadata.StaticValidation == nil {
+		metadata.StaticValidation = &StaticValidation{}
+	}
+	if metadata.StaticValidation.Manifest == nil {
+		// Backward compatibility: older provider-release.yaml metadata
+		// published before staticValidation was added lacks a validation
+		// manifest. Synthesize a minimal one from the metadata's own
+		// identity fields so the release remains usable without requiring
+		// a re-publish. The cross-validation below is effectively a no-op
+		// since the manifest is derived from the metadata itself.
+		metadata.StaticValidation.Manifest = &providermanifestv1.Manifest{
+			Kind:    metadata.Kind,
+			Source:  strings.TrimSpace(metadata.Package),
+			Version: strings.TrimSpace(metadata.Version),
+		}
+		metadata.StaticValidation.Synthesized = true
 	}
 	manifest := metadata.StaticValidation.Manifest
 	inheritValidationManifestIdentity(metadata, manifest)

--- a/gestaltd/internal/providerrelease/release_test.go
+++ b/gestaltd/internal/providerrelease/release_test.go
@@ -115,3 +115,40 @@ func validReleaseMetadataForTest() *Metadata {
 		},
 	}
 }
+
+const releaseMetadataWithoutStaticValidationYAML = `schema: gestaltd-provider-release
+schemaVersion: 1
+package: github.com/valon-technologies/gestalt-providers/externalcredentials/default
+kind: externalcredentials
+version: 0.0.1-alpha.1
+runtime: executable
+artifacts:
+  darwin/arm64:
+    path: gestalt-app-default_v0.0.1-alpha.1_darwin_arm64.tar.gz
+    sha256: afd9532e25e44bd3664412d59837e5c8bb0e5f6e8966c61b8577a81fdb0c3111
+  linux/amd64:
+    path: gestalt-app-default_v0.0.1-alpha.1_linux_amd64.tar.gz
+    sha256: 08d7c8aa0e8f7995573f8b2c7292a0218fa35f4c3902b0d71e51756e98d05616
+`
+
+func TestDecodeMetadataWithoutStaticValidationSynthesizesManifest(t *testing.T) {
+	t.Parallel()
+
+	metadata, err := Decode([]byte(releaseMetadataWithoutStaticValidationYAML))
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if metadata.StaticValidation == nil || metadata.StaticValidation.Manifest == nil {
+		t.Fatalf("expected synthesized StaticValidation.Manifest, got nil")
+	}
+	manifest := metadata.StaticValidation.Manifest
+	if manifest.Kind != "externalcredentials" {
+		t.Fatalf("manifest.Kind = %q, want %q", manifest.Kind, "externalcredentials")
+	}
+	if manifest.Source != "github.com/valon-technologies/gestalt-providers/externalcredentials/default" {
+		t.Fatalf("manifest.Source = %q, want package", manifest.Source)
+	}
+	if manifest.Version != "0.0.1-alpha.1" {
+		t.Fatalf("manifest.Version = %q, want version", manifest.Version)
+	}
+}


### PR DESCRIPTION
## Problem

`gestaltd serve --path` (isolated mode) fetches infrastructure provider metadata from legacy GitHub release URLs. These releases (e.g. `externalcredentials/default/v0.0.1-alpha.1`, `indexeddb/relationaldb/v0.0.1-alpha.2`) were published before the `staticValidation` section was added to the `provider-release.yaml` schema. `ValidateMetadata` hard-rejected them with:

```
provider release validation manifest is required
```

This blocked isolated local development entirely — the only workaround was setting `GESTALT_PROVIDERS_DIR` to a local gestalt-providers checkout.

## Fix

When `staticValidation` is absent from release metadata, synthesize a minimal validation manifest from the metadata's own identity fields (kind, package, version). Mark it with a `Synthesized` flag (not YAML-serialized) so downstream manifest comparison uses identity-only matching instead of strict JSON equality.

This is backward-compatible: releases with `staticValidation` are unaffected, and old releases without it become usable without requiring a re-publish.

## Test

Added `TestDecodeMetadataWithoutStaticValidationSynthesizesManifest` covering a release metadata YAML without `staticValidation` (modeled on the actual `externalcredentials/default/v0.0.1-alpha.1` release). All existing `providerrelease`, `operator`, and `daemon` tests pass.

## Files

- `internal/providerrelease/release.go`: synthesize manifest + `Synthesized` flag
- `internal/operator/release_metadata.go`: propagate `Synthesized` through the bundle
- `internal/operator/lifecycle.go`: identity-only manifest comparison when synthesized
- `internal/providerrelease/release_test.go`: backward-compat test