### PR TITLE
Bump default provider versions for isolated serve mode

### DIFF
--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -35,9 +35,9 @@ const (
 	DefaultProviderRepo = "github.com/valon-technologies/gestalt-providers"
 
 	DefaultIndexedDBProvider           = DefaultProviderRepo + "/indexeddb/relationaldb"
-	DefaultIndexedDBVersion            = "0.0.1-alpha.2"
+	DefaultIndexedDBVersion            = "0.0.1-alpha.3"
 	DefaultExternalCredentialsProvider = DefaultProviderRepo + "/externalcredentials/default"
-	DefaultExternalCredentialsVersion  = "0.0.1-alpha.1"
+	DefaultExternalCredentialsVersion  = "0.0.1-alpha.2"
 	DefaultUIProvider                  = DefaultProviderRepo + "/ui/default"
 	DefaultUIVersion                   = "0.0.2-alpha.1"
 	DefaultProviderInstance            = "default"


### PR DESCRIPTION
Republished externalcredentials/default and indexeddb/relationaldb with staticValidation metadata and v5 binaries. Bumps DefaultExternalCredentialsVersion to 0.0.1-alpha.2 and DefaultIndexedDBVersion to 0.0.1-alpha.3 so gestaltd serve --path (isolated mode) works without GESTALT_PROVIDERS_DIR.