### PR TITLE
Unblock default build-output rollout

### DIFF
--- a/gestaltd/internal/daemon/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e_test.go
@@ -1256,17 +1256,18 @@ func setupExecutableProviderDir(t *testing.T, baseDir, kind, name string) string
 		Spec:        &providermanifestv1.Spec{},
 		Entrypoint:  &providermanifestv1.Entrypoint{ArtifactPath: artifactRel},
 	}
-	if kind == providermanifestv1.KindWorkflow {
+	switch kind {
+	case providermanifestv1.KindWorkflow:
 		manifest.Build = &providermanifestv1.SourceBuild{
 			Command: []string{"sh", "./build.sh"},
 			Inputs:  []string{"go.mod", "go.sum", "workflow.go", "cmd", "build.sh"},
 		}
-	} else if kind == providermanifestv1.KindAgent {
+	case providermanifestv1.KindAgent:
 		manifest.Build = &providermanifestv1.SourceBuild{
 			Command: []string{"sh", "./build.sh"},
 			Inputs:  []string{"build.sh", "agent-staging"},
 		}
-	} else {
+	default:
 		manifest.Build = &providermanifestv1.SourceBuild{
 			Command: []string{"sh", "./build.sh"},
 			Inputs:  []string{"build.sh", "provider-staging"},
@@ -1427,17 +1428,6 @@ func writeManifestFile(t *testing.T, appDir string, manifest *providermanifestv1
 	data, err := encodeTestManifestFormat(manifest, providerpkg.ManifestFormatYAML)
 	if err != nil {
 		t.Fatalf("EncodeSourceManifestFormat: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(appDir, "manifest.yaml"), data, 0o644); err != nil {
-		t.Fatalf("write manifest: %v", err)
-	}
-}
-
-func writePackageManifestFile(t *testing.T, appDir string, manifest *providermanifestv1.Manifest) {
-	t.Helper()
-	data, err := providerpkg.EncodeManifestFormat(manifest, providerpkg.ManifestFormatYAML)
-	if err != nil {
-		t.Fatalf("EncodeManifestFormat: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(appDir, "manifest.yaml"), data, 0o644); err != nil {
 		t.Fatalf("write manifest: %v", err)

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -1225,7 +1225,7 @@ func sha256hex(data string) string {
 	return hex.EncodeToString(sum[:])
 }
 
-func 	writeSourceProviderTree(t *testing.T, dir, source, version, binaryContent string) {
+func writeSourceProviderTree(t *testing.T, dir, source, version, binaryContent string) {
 	t.Helper()
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("create source provider dir: %v", err)

--- a/gestaltd/services/apps/providerpkg/prepared_stage.go
+++ b/gestaltd/services/apps/providerpkg/prepared_stage.go
@@ -240,7 +240,7 @@ func validatePreparedInstallDeclaredBuild(root string, manifest *providermanifes
 	if err != nil {
 		return err
 	}
-	if resolved.Mode.RequiresPlatformBuild() {
+	if resolved.Mode == SourceReleaseBuildDeclared {
 		return missingDeclaredSourceBuildError(manifest, kind)
 	}
 	return nil

--- a/gestaltd/services/apps/providerpkg/prepared_stage_test.go
+++ b/gestaltd/services/apps/providerpkg/prepared_stage_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 )
 
@@ -177,6 +178,50 @@ func TestValidateExplicitRunPackaging_AllowsManifestBackedRunOnlyPlugin(t *testi
 	}
 	if err := ValidateExplicitRunPackaging(t.TempDir(), manifest); err != nil {
 		t.Fatalf("ValidateExplicitRunPackaging: %v", err)
+	}
+}
+
+func TestStageSourcePreparedInstallDir_AllowsImplicitGoProviderWithoutBuildCommand(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	const source = "github.com/test/providers/cache/local-cache"
+	const configuredName = "configured-cache"
+	mustWriteFile(t, filepath.Join(root, "go.mod"), []byte(testutil.GeneratedProviderModuleSource(t, "example.com/implicit-cache")), 0o644)
+	mustWriteFile(t, filepath.Join(root, "go.sum"), testutil.GeneratedProviderModuleSum(t), 0o644)
+	mustWriteFile(t, filepath.Join(root, "provider.go"), []byte(testutil.GeneratedCachePackageSource()), 0o644)
+	manifestPath := mustWriteManifestData(t, root, "manifest.yaml", mustManifestYAML(t, &providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindCache,
+		Source:      source,
+		Version:     "0.0.1-alpha.1",
+		DisplayName: "Implicit Cache",
+		Spec:        &providermanifestv1.Spec{},
+	}))
+
+	stagingDir := filepath.Join(t.TempDir(), "prepared")
+	staged, err := StageSourcePreparedInstallDir(manifestPath, stagingDir, StageSourcePreparedInstallOptions{
+		Kind:    providermanifestv1.KindCache,
+		AppName: configuredName,
+		GOOS:    runtime.GOOS,
+		GOARCH:  runtime.GOARCH,
+	})
+	if err != nil {
+		t.Fatalf("StageSourcePreparedInstallDir: %v", err)
+	}
+
+	stagedEntrypoint := stagedExecutableRel(configuredName, runtime.GOOS)
+	if staged.Manifest == nil || staged.Manifest.Entrypoint == nil || staged.Manifest.Entrypoint.ArtifactPath != stagedEntrypoint {
+		var entrypoint any
+		if staged.Manifest != nil {
+			entrypoint = staged.Manifest.Entrypoint
+		}
+		t.Fatalf("staged manifest entrypoint = %#v, want artifact path %q", entrypoint, stagedEntrypoint)
+	}
+	if staged.Manifest.Build != nil || staged.Manifest.Run != nil {
+		t.Fatalf("staged manifest retained source execution metadata: build=%#v run=%#v", staged.Manifest.Build, staged.Manifest.Run)
+	}
+	if _, err := os.Stat(filepath.Join(stagingDir, filepath.FromSlash(stagedEntrypoint))); err != nil {
+		t.Fatalf("staged implicit Go executable: %v", err)
 	}
 }
 

--- a/gestaltd/services/apps/providerpkg/source_build.go
+++ b/gestaltd/services/apps/providerpkg/source_build.go
@@ -450,8 +450,7 @@ func resolveSourceExecution(manifestPath string, manifest *providermanifestv1.Ma
 	if !skipExplicitRun && HasExplicitSourceRun(manifest) {
 		return explicitRunExecution(rootDir, manifest), nil
 	}
-	kind, err := sourceExecutionKind(manifest, kind)
-	if err != nil {
+	if _, err := sourceExecutionKind(manifest, kind); err != nil {
 		return ResolvedSourceExecution{}, err
 	}
 	exec := SourceExecution{Workdir: rootDir}

--- a/gestaltd/services/apps/providerpkg/test_helpers_test.go
+++ b/gestaltd/services/apps/providerpkg/test_helpers_test.go
@@ -120,15 +120,6 @@ func mustProviderManifest(source, version, osName, arch, artifactPath, sha strin
 	}
 }
 
-func mustManifestJSON(t *testing.T, manifest *providermanifestv1.Manifest) []byte {
-	t.Helper()
-	data, err := EncodeSourceManifestFormat(manifest, ManifestFormatJSON)
-	if err != nil {
-		t.Fatalf("EncodeSourceManifestFormat(JSON): %v", err)
-	}
-	return data
-}
-
 func mustManifestYAML(t *testing.T, manifest *providermanifestv1.Manifest) []byte {
 	t.Helper()
 	data, err := EncodeSourceManifestFormat(manifest, ManifestFormatYAML)

--- a/gestaltd/services/providerdrivers/runtime_deps_contract_test.go
+++ b/gestaltd/services/providerdrivers/runtime_deps_contract_test.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -111,11 +113,15 @@ func main() {
 	}
 }
 `, "example.com/providers/"+kind+"/"+name)), 0o644)
-	artifactRel := ".gestalt/build/provider"
-	writeTestFile(t, providerDir, "build.sh", []byte("mkdir -p .gestalt/build\ngo build -o .gestalt/build/provider ./cmd/provider\n"), 0o755)
+	providerSource := "github.com/test/providers/" + name
+	artifactRel, err := providerpkg.SourceBuildOutputPath(&providermanifestv1.Manifest{Source: providerSource}, runtime.GOOS)
+	if err != nil {
+		t.Fatalf("SourceBuildOutputPath: %v", err)
+	}
+	writeTestFile(t, providerDir, "build.sh", []byte(fmt.Sprintf("mkdir -p %q\ngo build -o %q ./cmd/provider\n", path.Dir(artifactRel), artifactRel)), 0o755)
 	writeManifestFile(t, providerDir, &providermanifestv1.Manifest{
 		Kind:        kind,
-		Source:      "github.com/test/providers/" + name,
+		Source:      providerSource,
 		Version:     "0.0.1-alpha.1",
 		DisplayName: name,
 		Spec:        &providermanifestv1.Spec{},
@@ -123,7 +129,6 @@ func main() {
 			Command: []string{"sh", "./build.sh"},
 			Inputs:  []string{"go.mod", "go.sum", "provider.go", "cmd", "build.sh"},
 		},
-		Entrypoint: &providermanifestv1.Entrypoint{ArtifactPath: artifactRel},
 	})
 	return providerDir
 }

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@valon-technologies/gestalt",
-  "version": "0.0.1-alpha.65",
+  "version": "0.0.1-alpha.66",
   "description": "TypeScript SDK for Gestalt executable providers",
   "type": "module",
   "repository": {


### PR DESCRIPTION
## Summary
- Bump the TypeScript SDK to `0.0.1-alpha.66` so the `.gestaltd/bin/<source-name>` build-script change from #2520 can be published to npm.
- Allow prepared-install staging for implicit Go providers without requiring object-form `build.command`. This preserves the intended source manifest contract: Go providers can keep only `kind`, `source`, and `spec` without `build:` or `entrypoint:`.

## Why
Provider rollout PR valon-technologies/gestalt-providers#1090 exposed two post-merge gaps:
- `agent/cursor` installs published TS SDK `0.0.1-alpha.65`, which still writes `.gestalt/build/cursor`; the merged core now expects `.gestaltd/bin/cursor`.
- Go providers such as `indexeddb/relationaldb` and `runtime/gkeagentsandbox` were rejected during prepared staging with `declare object-form build.command`, even though implicit Go builds should be valid.

## Test plan
- [x] `bun run check` from `sdk/typescript`
- [x] `go test ./gestaltd/services/apps/providerpkg -run 'TestStageSourcePreparedInstallDir_AllowsImplicitGoProviderWithoutBuildCommand|TestValidatePreparedInstallDeclaredBuild_RequiresArtifactWhenReleaseBuildRequired'`\n- [x] `go test ./gestaltd/services/apps/providerpkg`