### PR TITLE
Key materialized cache by installed provider name

### DIFF
--- a/gestaltd/internal/operator/materialized_cache.go
+++ b/gestaltd/internal/operator/materialized_cache.go
@@ -118,9 +118,22 @@ func materializedCacheKeyForRequest(req materializedCacheRequest) (materializedC
 	if strings.TrimSpace(req.Platform) == "" || strings.TrimSpace(req.ResolvedKey) == "" {
 		return materializedCacheKey{}, false, nil
 	}
-	resolvedHash := sha256Hex([]byte(req.ResolvedKey))
+	resolvedIdentity := req.ResolvedKey
+	if variant := materializedCacheInstallVariant(req); variant != "" {
+		resolvedIdentity += "\ninstall:" + variant
+	}
+	resolvedHash := sha256Hex([]byte(resolvedIdentity))
 	platformPath := strings.ReplaceAll(req.Platform, "/", "_")
 	return materializedCacheKeyForParts(req.Platform, platformPath, sha, resolvedHash), true, nil
+}
+
+func materializedCacheInstallVariant(req materializedCacheRequest) string {
+	kind := strings.TrimSpace(req.Kind)
+	name := strings.TrimSpace(req.Name)
+	if kind == "" || name == "" || kind == "ui" {
+		return ""
+	}
+	return kind + ":" + name
 }
 
 func materializedCacheKeyForParts(platform, platformPath, sha, resolvedHash string) materializedCacheKey {

--- a/gestaltd/internal/operator/materialized_cache_test.go
+++ b/gestaltd/internal/operator/materialized_cache_test.go
@@ -66,6 +66,27 @@ func TestMaterializedCacheRestoresSharedArchiveForDifferentSubjects(t *testing.T
 	defer func() { _ = restore.cleanup() }()
 }
 
+func TestMaterializedCacheSeparatesExecutableArchiveByConfiguredName(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	source := writeMaterializedCacheExecutableSource(t, dir, "source", "alpha")
+	cache := materializedCache{dir: filepath.Join(dir, "cache")}
+	req := materializedCacheExecutableRequest(dir, "alpha", "dest-alpha")
+	if _, err := cache.Put(context.Background(), req, source); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	aliasReq := materializedCacheExecutableRequest(dir, "beta", "dest-beta")
+	restore, err := cache.Restore(aliasReq)
+	if err != nil {
+		t.Fatalf("Restore alias archive: %v", err)
+	}
+	if restore == nil || restore.Result != materializedCacheMiss {
+		t.Fatalf("alias Restore result = %#v, want miss", restore)
+	}
+}
+
 func TestMaterializedCachePrefetchesRequestedRemoteEntriesBeforeRestore(t *testing.T) {
 	t.Parallel()
 
@@ -259,6 +280,31 @@ func materializedCacheUIRequest(dir, name, destName string) materializedCacheReq
 		Version:        "0.0.1",
 		DestinationDir: filepath.Join(dir, destName),
 	}
+}
+
+func writeMaterializedCacheExecutableSource(t *testing.T, dir, name, executableName string) string {
+	t.Helper()
+	source := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Join(source, "bin"), 0o755); err != nil {
+		t.Fatalf("create executable source bin: %v", err)
+	}
+	executable := filepath.Join(source, "bin", executableName)
+	if err := os.WriteFile(executable, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write executable: %v", err)
+	}
+	manifest := []byte("kind: agent\nsource: github.com/acme/pkg/agent\nversion: 0.0.1\ndisplayName: Test Agent\ndescription: Test Agent\nentrypoint:\n  artifactPath: bin/" + executableName + "\n")
+	if err := os.WriteFile(filepath.Join(source, "manifest.yaml"), manifest, 0o644); err != nil {
+		t.Fatalf("write executable manifest: %v", err)
+	}
+	return source
+}
+
+func materializedCacheExecutableRequest(dir, name, destName string) materializedCacheRequest {
+	req := materializedCacheUIRequest(dir, name, destName)
+	req.Subject = `agent "` + name + `"`
+	req.Kind = "agent"
+	req.Package = "github.com/acme/pkg/agent"
+	return req
 }
 
 func TestMaterializedCacheTreatsUnsafeMetadataAsInvalid(t *testing.T) {


### PR DESCRIPTION
## Summary
- include non-UI configured provider identity in the materialized cache key
- keep UI archive cache sharing unchanged
- add a regression test for executable aliases sharing one archive

## Validation
- go test ./internal/operator -run TestMaterializedCache
- go test ./internal/operator
- built a patched gestaltd and verified toolshed sync produces agent/<name>/bin/<name> for aliased agents with a fresh cache