### PR TITLE
Classify app providers with build output as executable in release metadata

### DIFF
--- a/gestaltd/internal/daemon/provider_lifecycle_test.go
+++ b/gestaltd/internal/daemon/provider_lifecycle_test.go
@@ -504,7 +504,7 @@ func writeProviderLifecycleRelease(t *testing.T, dir, pkg, version string) strin
 		Package:       pkg,
 		Kind:          providermanifestv1.KindApp,
 		Version:       version,
-		Runtime:       providerrelease.RuntimeForManifest(providermanifestv1.KindApp, staticManifest),
+		Runtime:       providerrelease.RuntimeForManifest(providermanifestv1.KindApp, manifest),
 		Artifacts: providerrelease.Artifacts{
 			providerpkg.CurrentPlatformString(): {
 				Path:   archiveName,

--- a/gestaltd/internal/daemon/provider_release_finalize.go
+++ b/gestaltd/internal/daemon/provider_release_finalize.go
@@ -252,7 +252,7 @@ func buildProviderReleaseMetadata(manifest *providermanifestv1.Manifest, version
 		Package:       manifest.Source,
 		Kind:          manifest.Kind,
 		Version:       version,
-		Runtime:       providerrelease.RuntimeForManifest(manifest.Kind, staticManifest),
+		Runtime:       providerrelease.RuntimeForManifest(manifest.Kind, manifest),
 		Artifacts:     providerrelease.Artifacts{},
 		StaticValidation: &providerrelease.StaticValidation{
 			Manifest: staticManifest,

--- a/gestaltd/internal/daemon/provider_release_finalize_test.go
+++ b/gestaltd/internal/daemon/provider_release_finalize_test.go
@@ -327,6 +327,93 @@ paths:
 	}
 }
 
+func TestProviderReleaseMetadataClassifiesHybridProviderAsExecutable(t *testing.T) {
+	t.Parallel()
+
+	// A hybrid app provider has both a manifest-backed spec surface (REST) and a
+	// build-produced entrypoint. It must be classified as executable in the release
+	// metadata, not declarative, even though the static validation projection strips
+	// the entrypoint. This is the regression guard for gmail/bigquery/hex/vercel-style
+	// providers whose custom operations would otherwise never be served.
+	metadata, err := buildProviderReleaseMetadataForRawManifest(t, `kind: app
+source: github.com/testowner/apps/catalog/hybrid
+version: 1.0.0
+displayName: Hybrid App
+artifacts:
+  - os: test
+    arch: test
+    path: provider
+    sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+entrypoint:
+  artifactPath: provider
+spec:
+  surfaces:
+    rest:
+      connection: default
+      baseUrl: https://api.example.test
+      operations:
+        - name: listThings
+          method: GET
+          path: /things
+  connections:
+    default:
+      auth:
+        type: none
+`, map[string]string{
+		"provider": "",
+		"catalog.yaml": `name: hybrid
+operations:
+  - id: staticOp
+    method: POST
+    description: Static plugin operation
+`,
+	})
+	if err != nil {
+		t.Fatalf("buildProviderReleaseMetadata: %v", err)
+	}
+	if metadata.Runtime != providerrelease.RuntimeExecutable {
+		t.Fatalf("runtime = %q, want %q for hybrid provider with entrypoint and spec surface", metadata.Runtime, providerrelease.RuntimeExecutable)
+	}
+}
+
+func TestProviderReleaseMetadataClassifiesDeclarativeOnlyApp(t *testing.T) {
+	t.Parallel()
+
+	// An app provider with a manifest-backed spec surface and no entrypoint is purely
+	// declarative and must remain classified as declarative.
+	metadata, err := buildProviderReleaseMetadataForRawManifest(t, `kind: app
+source: github.com/testowner/apps/catalog/declarative
+version: 1.0.0
+displayName: Declarative App
+spec:
+  surfaces:
+    rest:
+      connection: default
+      baseUrl: https://api.example.test
+      operations:
+        - name: listThings
+          method: GET
+          path: /things
+  connections:
+    default:
+      auth:
+        type: none
+`, map[string]string{
+		"catalog.yaml": `name: declarative
+operations:
+  - id: staticOp
+    method: POST
+    description: Static plugin operation
+`,
+	})
+	if err != nil {
+		t.Fatalf("buildProviderReleaseMetadata: %v", err)
+	}
+	if metadata.Runtime != providerrelease.RuntimeDeclarative {
+		t.Fatalf("runtime = %q, want %q for declarative-only provider", metadata.Runtime, providerrelease.RuntimeDeclarative)
+	}
+}
+
 func TestProviderReleaseMetadataBuildsGraphQLCatalog(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/daemon/testmain_test.go
+++ b/gestaltd/internal/daemon/testmain_test.go
@@ -411,7 +411,7 @@ func writeLocalProviderReleaseMetadata(dir string) error {
 		Package:       manifest.Source,
 		Kind:          manifest.Kind,
 		Version:       manifest.Version,
-		Runtime:       providerrelease.RuntimeForManifest(manifest.Kind, staticManifest),
+		Runtime:       providerrelease.RuntimeForManifest(manifest.Kind, manifest),
 		Artifacts: providerrelease.Artifacts{
 			providerpkg.CurrentPlatformString(): {
 				Path:   filepath.ToSlash(filepath.Join("..", filepath.Base(archivePath))),

--- a/gestaltd/internal/providerrelease/release.go
+++ b/gestaltd/internal/providerrelease/release.go
@@ -181,8 +181,28 @@ func ValidateMetadata(metadata *Metadata) error {
 	if version := strings.TrimSpace(manifest.Version); version != "" && version != strings.TrimSpace(metadata.Version) {
 		return fmt.Errorf("provider release validation manifest version %q does not match %q", version, metadata.Version)
 	}
-	if runtime := RuntimeForManifest(metadataKind, manifest); metadata.Runtime != runtime {
-		return fmt.Errorf("provider release runtime %q does not match validation manifest runtime %q", metadata.Runtime, runtime)
+	// The validation manifest is a platform-neutral projection of the packaged
+	// manifest: it intentionally strips Entrypoint and Artifacts (see staticvalidation.ProjectManifest).
+	// Because the entrypoint signal is gone, RuntimeForManifest on the projection cannot distinguish a
+	// hybrid app provider (manifest-backed spec surface plus a hosted binary) from a declarative-only
+	// app provider (manifest-backed spec surface, no binary) - both project to RuntimeDeclarative. The
+	// real classification lives in metadata.Runtime, which is derived from the full packaged manifest.
+	// Validate against the projection accordingly: a declarative release must project to declarative,
+	// and an executable release must project to declarative or executable (never UI).
+	validationRuntime := RuntimeForManifest(metadataKind, manifest)
+	switch metadata.Runtime {
+	case RuntimeDeclarative:
+		if validationRuntime != RuntimeDeclarative {
+			return fmt.Errorf("provider release runtime %q does not match validation manifest runtime %q", metadata.Runtime, validationRuntime)
+		}
+	case RuntimeExecutable:
+		if validationRuntime == RuntimeUI {
+			return fmt.Errorf("provider release runtime %q does not match validation manifest runtime %q", metadata.Runtime, validationRuntime)
+		}
+	case RuntimeUI:
+		if validationRuntime != RuntimeUI {
+			return fmt.Errorf("provider release runtime %q does not match validation manifest runtime %q", metadata.Runtime, validationRuntime)
+		}
 	}
 	if len(manifest.Artifacts) != 0 {
 		return fmt.Errorf("provider release validation manifest must not include platform artifacts")
@@ -206,8 +226,8 @@ func ValidateMetadata(metadata *Metadata) error {
 	case CatalogRequired(metadataKind, manifest) && staticCatalog == nil && !metadata.StaticValidation.CatalogSessionOnly && !CatalogSessionModeAllowed(metadataKind, manifest):
 		return fmt.Errorf("provider release validation for package %q must include catalog metadata unless the validation manifest is MCP-only", metadata.Package)
 	}
-	if _, ok := metadata.Artifacts[GenericTarget]; ok && metadataKind == providermanifestv1.KindApp && RuntimeForManifest(metadataKind, manifest) != RuntimeDeclarative {
-		return fmt.Errorf("provider release generic app artifact requires declarative-only validation manifest")
+	if _, ok := metadata.Artifacts[GenericTarget]; ok && metadataKind == providermanifestv1.KindApp && metadata.Runtime != RuntimeDeclarative {
+		return fmt.Errorf("provider release generic app artifact requires a declarative-only provider")
 	}
 	return nil
 }

--- a/gestaltd/internal/providerrelease/release_test.go
+++ b/gestaltd/internal/providerrelease/release_test.go
@@ -62,6 +62,39 @@ func TestDecodeMetadataInheritsStaticValidationManifestIdentity(t *testing.T) {
 	}
 }
 
+func TestValidateMetadataAllowsExecutableForHybridProjection(t *testing.T) {
+	t.Parallel()
+
+	// A hybrid app provider (manifest-backed spec surface plus a hosted binary) projects to a
+	// validation manifest whose entrypoint is stripped, so RuntimeForManifest on the projection
+	// returns declarative. The release metadata runtime is executable (the binary exists), and
+	// ValidateMetadata must accept this because the projection cannot carry the entrypoint signal.
+	metadata := validReleaseMetadataForTest()
+	metadata.Runtime = RuntimeExecutable
+	metadata.StaticValidation.Manifest = &providermanifestv1.Manifest{
+		Kind:    providermanifestv1.KindApp,
+		Source:  metadata.Package,
+		Version: metadata.Version,
+		Spec: &providermanifestv1.Spec{
+			Surfaces: &providermanifestv1.ProviderSurfaces{
+				REST: &providermanifestv1.RESTSurface{
+					Connection: "default",
+					BaseURL:    "https://api.example.test",
+					Operations: []providermanifestv1.ProviderOperation{{
+						Name:   "listThings",
+						Method: "GET",
+						Path:   "/things",
+					}},
+				},
+			},
+		},
+	}
+
+	if err := ValidateMetadata(metadata); err != nil {
+		t.Fatalf("ValidateMetadata error = %v, want nil for executable release with declarative projection", err)
+	}
+}
+
 func TestValidateMetadataRejectsRuntimeMismatch(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Hybrid app providers (`gmail`, `bigquery`, `hex`, `vercel`) have both a manifest-backed spec surface (OpenAPI/REST) and a build section that produces a hosted binary. At serve time gestaltd dispatches these correctly as executable via the packaged manifest `Entrypoint`, but the **release metadata** classification recorded them as `declarative`, so the deploy lock recorded `runtime: declarative` with an empty catalog fingerprint and the custom operations were never served.

## Root cause

`buildProviderReleaseMetadata` passed the **static validation projection** (produced by `staticvalidation.ProjectManifest(..., platformNeutral=true)`, which clears `Entrypoint` and `Artifacts`) to `RuntimeForManifest`. With `Entrypoint == nil` and `Spec.IsManifestBacked() == true`, `IsDeclarativeOnlyProvider()` returned `true`, so `RuntimeForManifest` returned `RuntimeDeclarative` — even though the original packaged manifest had an entrypoint.

A second, related flaw lived in `ValidateMetadata`: it re-derived runtime from the same entrypoint-stripped projection and rejected any metadata runtime that did not match it. This enforced the misclassification, so even after fixing the producer the corrected `executable` value would fail validation.

## Changes

1. **`gestaltd/internal/daemon/provider_release_finalize.go`** — Pass the original packaged manifest (with `Entrypoint` intact) to `RuntimeForManifest` instead of the projected `staticManifest`. The projection is still used for `StaticValidation.Manifest`, which needs the platform-neutral form. This is the one-line fix from the plan.

2. **`gestaltd/internal/providerrelease/release.go`** — Fix `ValidateMetadata` so it no longer rejects the corrected classification. The validation manifest is a platform-neutral projection that deliberately strips `Entrypoint`, so `RuntimeForManifest` on it cannot distinguish a hybrid provider from a declarative-only one (both project to `RuntimeDeclarative`). Validate against the projection as a lower bound:
   - a `declarative` release must project to `declarative`;
   - an `executable` release may project to `declarative` (hybrid) or `executable` (pure binary), never `ui`;
   - a `ui` release must project to `ui`.
   
   The generic-artifact check now uses the authoritative `metadata.Runtime` instead of re-deriving from the projection, so a hybrid provider (which has a real binary) is not allowed to ship a generic artifact.

3. **Test helpers** (`provider_lifecycle_test.go`, `testmain_test.go`) — Updated to derive `Runtime` from the unprojected manifest, matching the production fix.

## Tests

Added regression tests at both layers:
- `TestProviderReleaseMetadataClassifiesHybridProviderAsExecutable` / `TestProviderReleaseMetadataClassifiesDeclarativeOnlyApp` — producer-side classification via `buildProviderReleaseMetadata`.
- `TestValidateMetadataAllowsExecutableForHybridProjection` — validation accepts an executable release whose projection classifies as declarative (the hybrid case).

The existing `TestValidateMetadataRejectsRuntimeMismatch` continues to guard the genuine mismatch: a `declarative` runtime declared for a pure-executable (non-manifest-backed) projection is still rejected.

## Notes

- `RuntimeForManifest` itself is unchanged; it already checks `IsDeclarativeOnlyProvider()`, which returns `false` when `Entrypoint != nil`.
- The operator lifecycle paths (`lifecycle.go`, `git_source.go`) were never affected — they pass the prepared `install.manifest` (with `Entrypoint`) to `RuntimeForManifest`.
- Per the plan, source manifests for `gmail`/`bigquery`/`hex`/`vercel` do not need explicit entrypoint declarations: the packaging stage sets `Entrypoint` on the prepared manifest from the build output, and `RuntimeForManifest` now sees it. PR #1092 (adding entrypoint to source manifests) becomes unnecessary.