### PR TITLE
Classify app releases with platform artifacts as executable

### DIFF
--- a/gestaltd/internal/daemon/provider_release_finalize.go
+++ b/gestaltd/internal/daemon/provider_release_finalize.go
@@ -252,7 +252,6 @@ func buildProviderReleaseMetadata(manifest *providermanifestv1.Manifest, version
 		Package:       manifest.Source,
 		Kind:          manifest.Kind,
 		Version:       version,
-		Runtime:       providerrelease.RuntimeForManifest(manifest.Kind, staticManifest),
 		Artifacts:     providerrelease.Artifacts{},
 		StaticValidation: &providerrelease.StaticValidation{
 			Manifest: staticManifest,
@@ -269,6 +268,7 @@ func buildProviderReleaseMetadata(manifest *providermanifestv1.Manifest, version
 		}
 		metadata.Artifacts[target] = providerrelease.Artifact{Path: filepath.Base(archive.Path), SHA256: archive.SHA256}
 	}
+	metadata.Runtime = providerrelease.RuntimeForRelease(manifest.Kind, staticManifest, metadata.Artifacts)
 	if err := providerrelease.ValidateMetadata(metadata); err != nil {
 		return nil, fmt.Errorf("validate provider release metadata: %w", err)
 	}

--- a/gestaltd/internal/daemon/provider_release_finalize_test.go
+++ b/gestaltd/internal/daemon/provider_release_finalize_test.go
@@ -487,3 +487,111 @@ func uiReleaseManifestForTest(version string) *providermanifestv1.Manifest {
 		Spec:        &providermanifestv1.Spec{AssetRoot: uiTestAssetRoot},
 	}
 }
+
+func TestProviderReleaseMetadataClassifiesHybridAppAsExecutable(t *testing.T) {
+	t.Parallel()
+
+	metadata, err := buildProviderReleaseMetadataForRawManifest(t, `kind: app
+source: github.com/testowner/apps/hybrid-test
+version: 1.0.0
+displayName: Hybrid App
+artifacts:
+  - os: test
+    arch: test
+    path: provider
+    sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+entrypoint:
+  artifactPath: provider
+spec:
+  surfaces:
+    openapi:
+      connection: default
+      document: openapi.yaml
+  connections:
+    default:
+      auth:
+        type: none
+`, map[string]string{
+		"provider": "",
+		"openapi.yaml": `openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: ok
+`,
+	})
+	if err != nil {
+		t.Fatalf("buildProviderReleaseMetadata: %v", err)
+	}
+	if metadata.Runtime != providerrelease.RuntimeExecutable {
+		t.Fatalf("runtime = %q, want %q for hybrid app with entrypoint + spec surface", metadata.Runtime, providerrelease.RuntimeExecutable)
+	}
+}
+
+func TestProviderReleaseMetadataClassifiesSpecOnlyAppAsDeclarative(t *testing.T) {
+	t.Parallel()
+
+	packageDir := t.TempDir()
+	rawManifest := `kind: app
+source: github.com/testowner/apps/spec-only-test
+version: 1.0.0
+displayName: Spec Only App
+spec:
+  surfaces:
+    openapi:
+      connection: default
+      document: openapi.yaml
+  connections:
+    default:
+      auth:
+        type: none
+`
+	if err := os.WriteFile(filepath.Join(packageDir, "manifest.yaml"), []byte(rawManifest), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(packageDir, "openapi.yaml"), []byte(`openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: ok
+`), 0o644); err != nil {
+		t.Fatalf("write openapi: %v", err)
+	}
+	_, manifest, _, err := providerpkg.LoadManifestFromPath(packageDir)
+	if err != nil {
+		t.Fatalf("LoadManifestFromPath: %v", err)
+	}
+	outputDir := t.TempDir()
+	archive := filepath.Join(outputDir, "gestalt-app-spec-only-test_v1.0.0.tar.gz")
+	if err := providerpkg.CreatePackageFromDir(packageDir, archive); err != nil {
+		t.Fatalf("CreatePackageFromDir: %v", err)
+	}
+	archiveSHA, err := providerpkg.ArchiveDigest(archive)
+	if err != nil {
+		t.Fatalf("ArchiveDigest: %v", err)
+	}
+
+	metadata, err := buildProviderReleaseMetadata(
+		manifest,
+		"1.0.0",
+		[]releaseArchive{{Path: archive, SHA256: archiveSHA, Target: providerrelease.GenericTarget}},
+	)
+	if err != nil {
+		t.Fatalf("buildProviderReleaseMetadata: %v", err)
+	}
+	if metadata.Runtime != providerrelease.RuntimeDeclarative {
+		t.Fatalf("runtime = %q, want %q for spec-only app without entrypoint", metadata.Runtime, providerrelease.RuntimeDeclarative)
+	}
+}

--- a/gestaltd/internal/providerrelease/release.go
+++ b/gestaltd/internal/providerrelease/release.go
@@ -181,7 +181,7 @@ func ValidateMetadata(metadata *Metadata) error {
 	if version := strings.TrimSpace(manifest.Version); version != "" && version != strings.TrimSpace(metadata.Version) {
 		return fmt.Errorf("provider release validation manifest version %q does not match %q", version, metadata.Version)
 	}
-	if runtime := RuntimeForManifest(metadataKind, manifest); metadata.Runtime != runtime {
+	if runtime := RuntimeForRelease(metadataKind, manifest, metadata.Artifacts); metadata.Runtime != runtime {
 		return fmt.Errorf("provider release runtime %q does not match validation manifest runtime %q", metadata.Runtime, runtime)
 	}
 	if len(manifest.Artifacts) != 0 {
@@ -274,6 +274,35 @@ func RuntimeForManifest(kind string, manifest *providermanifestv1.Manifest) stri
 		}
 	}
 	return RuntimeExecutable
+}
+
+// RuntimeForRelease classifies the runtime for a provider release using the
+// validation manifest and the published artifact targets. A release with
+// platform-specific artifacts is executable regardless of whether the
+// platform-neutral validation manifest retains an entrypoint, because
+// ProjectManifest strips entrypoint and artifacts for static validation.
+func RuntimeForRelease(kind string, manifest *providermanifestv1.Manifest, artifacts Artifacts) string {
+	switch providermanifestv1.NormalizeKind(kind) {
+	case providermanifestv1.KindUI:
+		return RuntimeUI
+	case providermanifestv1.KindApp:
+		if hasPlatformArtifacts(artifacts) {
+			return RuntimeExecutable
+		}
+		if manifest != nil && manifest.IsDeclarativeOnlyProvider() {
+			return RuntimeDeclarative
+		}
+	}
+	return RuntimeExecutable
+}
+
+func hasPlatformArtifacts(artifacts Artifacts) bool {
+	for target := range artifacts {
+		if strings.TrimSpace(target) != "" && strings.TrimSpace(target) != GenericTarget {
+			return true
+		}
+	}
+	return false
 }
 
 func CatalogRequired(kind string, manifest *providermanifestv1.Manifest) bool {


### PR DESCRIPTION
## Summary
- App providers with both a spec surface (OpenAPI/rest) and a build that produces a hosted binary were misclassified as `runtime: declarative` in `provider-release.yaml`.
- The packaging stage correctly sets `Entrypoint` and `Artifacts` on the prepared manifest, but `staticvalidation.ProjectManifest` strips both for the platform-neutral validation manifest. `RuntimeForManifest` then saw `Entrypoint == nil` with `IsManifestBacked() == true` and returned `RuntimeDeclarative`, even though the release contained platform-specific binaries.
- This caused gmail, bigquery, hex, and vercel to publish with `runtime: declarative` and an empty catalog fingerprint, so their custom Python operations were never served at runtime.

## Key changes
- Add `RuntimeForRelease(kind, manifest, artifacts)` in `providerrelease/release.go` — classifies based on both the validation manifest and published artifact targets. A release with platform-specific artifacts is `executable` regardless of the stripped validation manifest.
- Update `buildProviderReleaseMetadata` to set `Runtime` via `RuntimeForRelease` after populating the artifacts map.
- Update `ValidateMetadata` to validate runtime via `RuntimeForRelease` instead of `RuntimeForManifest`.

## Interfaces
- New exported function `providerrelease.RuntimeForRelease`. `RuntimeForManifest` is unchanged.

## Test plan
- [x] `TestProviderReleaseMetadataClassifiesHybridAppAsExecutable` — app with OpenAPI surface + entrypoint + platform artifacts → `executable`
- [x] `TestProviderReleaseMetadataClassifiesSpecOnlyAppAsDeclarative` — app with OpenAPI surface, no entrypoint, generic artifact → `declarative`
- [x] Full `gestaltd/internal/daemon` and `gestaltd/internal/providerrelease` test suites pass
- [ ] Re-publish gmail/bigquery/hex/vercel snapshots and verify `runtime: executable` in `provider-release.yaml`
- [ ] Repin deploy lock file and verify non-empty catalog fingerprint