### PR TITLE
Use metadata.Runtime for lock entries from release metadata

### DIFF
--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -3051,7 +3051,7 @@ func (l *Lifecycle) installMetadataSourcePackage(ctx context.Context, expectedKi
 	entry := LockEntry{
 		Package:  metadata.Package,
 		Kind:     metadata.Kind,
-		Runtime:  providerrelease.RuntimeForManifest(metadata.Kind, bundle.Manifest),
+		Runtime:  metadata.Runtime,
 		Source:   providerSourceLockLocation(app, configDir),
 		Version:  metadata.Version,
 		Archives: archives,


### PR DESCRIPTION
## Summary
- `installMetadataSourcePackage` derived the lock entry `Runtime` from `RuntimeForManifest(metadata.Kind, bundle.Manifest)`, where `bundle.Manifest` is the platform-neutral validation manifest with `Entrypoint` stripped.
- Hybrid app providers (spec surface + hosted binary like gmail, bigquery, hex, vercel) projected to `RuntimeDeclarative`, so the lock entry recorded `runtime: declarative` even though the published `provider-release.yaml` said `runtime: executable`.
- Use `metadata.Runtime` directly — it is already validated by `ValidateMetadata` (fixed in #2524) and reflects the full packaged manifest classification.

## Key changes
- `gestaltd/internal/operator/lifecycle.go`: change `Runtime: providerrelease.RuntimeForManifest(metadata.Kind, bundle.Manifest)` to `Runtime: metadata.Runtime` in the `installMetadataSourcePackage` lock entry.

## Test plan
- [x] Built gestaltd from this branch and ran `gestaltd lock` against the deploy config — gmail, bigquery, hex, vercel now show `runtime: executable` with `catalogAvailable: true`
- [ ] CI passes