### PR TITLE
[cli] release gestalt CLI v0.0.2-alpha.6

### DIFF
--- a/gestalt/Cargo.toml
+++ b/gestalt/Cargo.toml
@@ -3,5 +3,5 @@ resolver = "2"
 members = ["cli"]
 
 [workspace.package]
-version = "0.0.2-alpha.5"
+version = "0.0.2-alpha.6"
 edition = "2024"


### PR DESCRIPTION
## Description

Bumps the Gestalt CLI package version and lockfile for the next release.