### PR TITLE
[authorization] attach caller token for HTTP API

### DIFF
--- a/gestaltd/internal/server/authorization_api_test.go
+++ b/gestaltd/internal/server/authorization_api_test.go
@@ -11,7 +11,11 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/server"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
+	"github.com/valon-technologies/gestalt/server/services/providergateway"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -184,6 +188,56 @@ func TestAuthorizationAPIGetActiveModelRef(t *testing.T) {
 	}
 }
 
+func TestAuthorizationAPIAddsProviderGatewayCallerToken(t *testing.T) {
+	authz := &authorizationAPITestProvider{}
+	svc := testutil.NewStubServices(t)
+	user := seedUser(t, svc, "authorization-user@test.local")
+	plaintext := scopedTestBearerToken(user.ID, "")
+	privateKeyPEM, publicKeyPEM := testProviderGatewayCallerTokenKeyPair(t)
+	issuer, err := providergateway.NewCallerTokenIssuer(privateKeyPEM)
+	if err != nil {
+		t.Fatalf("NewCallerTokenIssuer: %v", err)
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = testAuthStubForScopedBearer()
+		cfg.Authorization = authz
+		cfg.CallerTokenIssuer = issuer
+		cfg.Services = svc
+	})
+	defer ts.Close()
+	t.Parallel()
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/authorization/models/active", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+plaintext)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET active model: %v", err)
+	}
+	defer closeResponseBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	if authz.callerToken == "" {
+		t.Fatal("authorization provider did not receive caller token")
+	}
+	if authz.entry != invocation.EntryHTTP {
+		t.Fatalf("entry = %q, want %q", authz.entry, invocation.EntryHTTP)
+	}
+	claims, err := providergateway.Verify(authz.callerToken, publicKeyPEM)
+	if err != nil {
+		t.Fatalf("Verify caller token: %v", err)
+	}
+	wantSubjectID := principal.UserSubjectID(user.ID)
+	if claims.SubjectID != wantSubjectID {
+		t.Fatalf("SubjectID = %q, want %q", claims.SubjectID, wantSubjectID)
+	}
+}
+
 func TestAuthorizationAPIListActiveModelResourceTypes(t *testing.T) {
 	authz := &authorizationAPITestProvider{}
 	ts := newTestServer(t, func(cfg *server.Config) {
@@ -241,6 +295,8 @@ type authorizationAPITestProvider struct {
 	checkAccessDenied        bool
 	listRelationshipsRequest *proto.ListRelationshipsRequest
 	listResourceTypesRequest *proto.ListActiveModelResourceTypesRequest
+	callerToken              string
+	entry                    invocation.Entry
 }
 
 func (p *authorizationAPITestProvider) CheckAccess(_ context.Context, req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
@@ -275,7 +331,9 @@ func (p *authorizationAPITestProvider) DeleteRelationship(_ context.Context, req
 	return &proto.DeleteRelationshipResponse{}, nil
 }
 
-func (p *authorizationAPITestProvider) GetActiveModelRef(context.Context) (*proto.GetActiveModelRefResponse, error) {
+func (p *authorizationAPITestProvider) GetActiveModelRef(ctx context.Context) (*proto.GetActiveModelRefResponse, error) {
+	p.callerToken = providergateway.CallerTokenFromContext(ctx)
+	p.entry = invocation.EntryFromContext(ctx)
 	return &proto.GetActiveModelRefResponse{
 		Model: &proto.AuthorizationModelRef{
 			Id:        "model-1",

--- a/gestaltd/internal/server/handlers_authorization.go
+++ b/gestaltd/internal/server/handlers_authorization.go
@@ -1,13 +1,16 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
 
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"google.golang.org/protobuf/encoding/protojson"
 	gproto "google.golang.org/protobuf/proto"
 )
@@ -20,7 +23,11 @@ func (s *Server) checkAuthorizationAccess(w http.ResponseWriter, r *http.Request
 	if !decodeProtoJSONBody(w, r, &req) {
 		return
 	}
-	resp, err := s.authorization.CheckAccess(r.Context(), &req)
+	ctx, ok := s.authorizationHTTPContext(w, r)
+	if !ok {
+		return
+	}
+	resp, err := s.authorization.CheckAccess(ctx, &req)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -36,7 +43,11 @@ func (s *Server) listAuthorizationRelationships(w http.ResponseWriter, r *http.R
 	if !ok {
 		return
 	}
-	resp, err := s.authorization.ListRelationships(r.Context(), req)
+	ctx, ok := s.authorizationHTTPContext(w, r)
+	if !ok {
+		return
+	}
+	resp, err := s.authorization.ListRelationships(ctx, req)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -48,7 +59,11 @@ func (s *Server) getAuthorizationActiveModelRef(w http.ResponseWriter, r *http.R
 	if !s.requireAuthorizationProvider(w) {
 		return
 	}
-	resp, err := s.authorization.GetActiveModelRef(r.Context())
+	ctx, ok := s.authorizationHTTPContext(w, r)
+	if !ok {
+		return
+	}
+	resp, err := s.authorization.GetActiveModelRef(ctx)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -64,12 +79,27 @@ func (s *Server) listAuthorizationActiveModelResourceTypes(w http.ResponseWriter
 	if !ok {
 		return
 	}
-	resp, err := s.authorization.ListActiveModelResourceTypes(r.Context(), req)
+	ctx, ok := s.authorizationHTTPContext(w, r)
+	if !ok {
+		return
+	}
+	resp, err := s.authorization.ListActiveModelResourceTypes(ctx, req)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 	writeProtoJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) authorizationHTTPContext(w http.ResponseWriter, r *http.Request) (context.Context, bool) {
+	ctx := invocation.WithEntry(r.Context(), invocation.EntryHTTP)
+	ctx, err := s.withProviderGatewayCallerToken(ctx, PrincipalFromContext(r.Context()))
+	if err != nil {
+		slog.ErrorContext(r.Context(), "issue authorization provider gateway caller token", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to prepare authorization context")
+		return nil, false
+	}
+	return ctx, true
 }
 
 func (s *Server) requireAuthorizationProvider(w http.ResponseWriter) bool {


### PR DESCRIPTION
## Description

Attaches provider-gateway caller tokens and HTTP entry metadata when authenticated authorization API handlers invoke the authorization provider.