### PR TITLE
OAuth connect: serve a self-closing popup callback page

### DIFF
--- a/gestaltd/internal/server/handlers_oauth.go
+++ b/gestaltd/internal/server/handlers_oauth.go
@@ -322,5 +322,11 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 	}
 	auditAllowed = true
 	auditErr = nil
+	// A browser popup can't be closed by its opener after OAuth (COOP severs the
+	// link), so serve a self-closing page; API clients keep the redirect.
+	if strings.Contains(strings.ToLower(r.Header.Get("Accept")), "text/html") {
+		writeConnectionCompletePage(w, providerName)
+		return
+	}
 	http.Redirect(w, r, "/apps?connected="+url.QueryEscape(providerName), http.StatusSeeOther)
 }

--- a/gestaltd/internal/server/pending_connection.go
+++ b/gestaltd/internal/server/pending_connection.go
@@ -113,6 +113,12 @@ var pendingConnectionSelectionPage = template.Must(template.New("pending-connect
     <p class="footer">{{.Footer}}</p>
     {{end}}
   </main>
+  {{if .AutoClose}}
+  <script>
+    try { if (window.opener) { window.opener.postMessage({ type: "gestalt:connection-complete" }, "*"); } } catch (e) {}
+    setTimeout(function () { window.close(); }, 600);
+  </script>
+  {{end}}
 </body>
 </html>
 `))
@@ -126,6 +132,7 @@ type pendingConnectionPageView struct {
 	LinkURL      string
 	LinkLabel    string
 	Footer       string
+	AutoClose    bool
 }
 
 func writePendingConnectionPage(w http.ResponseWriter, status int, view pendingConnectionPageView, renderErr string) {
@@ -227,6 +234,24 @@ func (s *Server) writePendingConnectionSelectionPage(w http.ResponseWriter, stat
 		Candidates:   state.Candidates,
 		Footer:       "If you did not expect this screen, close this tab and restart the connect flow.",
 	}, "failed to render pending connection page")
+}
+
+// writeConnectionCompletePage renders the OAuth-callback success page for a
+// browser popup: it closes itself (window.close) since, post-OAuth, the opener
+// can't close it — Cross-Origin-Opener-Policy on the provider's pages severs the
+// opener↔popup link. A visible message + link is the fallback if close is blocked.
+func writeConnectionCompletePage(w http.ResponseWriter, integration string) {
+	linkURL := "/apps"
+	if connectedURL, err := setURLQueryParam(linkURL, "connected", integration); err == nil {
+		linkURL = connectedURL
+	}
+	writePendingConnectionPage(w, http.StatusOK, pendingConnectionPageView{
+		Title:     integration + " connected",
+		Message:   "Your connection has been saved. This window will close automatically.",
+		LinkURL:   linkURL,
+		LinkLabel: "Open integrations",
+		AutoClose: true,
+	}, "failed to render connection success page")
 }
 
 func (s *Server) writePendingConnectionSuccessPage(w http.ResponseWriter, integration string) {


### PR DESCRIPTION
## Summary

After connecting a provider in a popup, the popup can't be closed by its opener, and in split-origin local dev it lands on a 404. This serves a small **self-closing "Connected" page** for browser callbacks instead of redirecting to `/apps`.

## Why

The OAuth callback (`integrationOAuthCallback`) ends by redirecting the popup to `/apps?connected=<provider>`. Two problems for the popup case:
- **The opener can't close the popup.** Providers' auth pages send `Cross-Origin-Opener-Policy: same-origin`, which severs the `opener ↔ popup` handle, so `popup.close()` from the app is a no-op. The popup must close **itself**.
- **Split-origin dev 404s.** When the UI and API are on different origins (local two-origin dev), the relative `/apps` redirect resolves to the API origin, which serves no UI → the popup shows a 404.

So the callback page itself should close the window. I **rejected** a client-side fix (the opener can't touch the popup post-COOP) and a `returnTo` param (more surface for every app); a built-in self-closing page fixes every connector flow with zero per-app code.

## What changed

- On a successful callback, if the request accepts `text/html` (a browser popup), render a self-closing page (`window.close()` + `postMessage` to the opener) via the existing pending-connection page template (new `AutoClose` flag). **API clients keep the `303` redirect** — the existing callback test still passes.
- A visible "Connected — you can close this window" message + link is the fallback if a browser blocks the auto-close.

Built clean. The redirect path is covered by `TestIntegrationOAuthCallback`; the new HTML path is presentational (window.close + a static message).
