### PR TITLE
Unify gestaltd lock/sync/serve behavior matrices

### DIFF
--- a/gestaltd/internal/daemon/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e_test.go
@@ -2091,8 +2091,8 @@ func TestRunLockSyncLocalProviders(t *testing.T) {
 	if err == nil {
 		t.Fatal("runSync --check before sync unexpectedly succeeded")
 	}
-	if !strings.Contains(err.Error(), "gestaltd sync --locked") {
-		t.Fatalf("sync --check error should point at sync, got: %v", err)
+	if !strings.Contains(err.Error(), "artifacts would be materialized") {
+		t.Fatalf("sync --check error should report artifacts would be materialized, got: %v", err)
 	}
 
 	if err := runSync([]string{"--locked", "--config", cfgPath}); err != nil {
@@ -2125,16 +2125,8 @@ func TestRunSyncStaleLocalProviderRemediation(t *testing.T) {
 	if err == nil {
 		t.Fatal("runSync --check with stale lock unexpectedly succeeded")
 	}
-	if !strings.Contains(err.Error(), "prepared artifact for provider") ||
-		!strings.Contains(err.Error(), "renamed") ||
-		!strings.Contains(err.Error(), "gestaltd sync --locked") {
-		t.Fatalf("stale local source error should point at sync, got: %v", err)
-	}
-	if !strings.Contains(err.Error(), "--artifacts-dir") {
-		t.Fatalf("sync remediation should include --artifacts-dir, got: %v", err)
-	}
-	if strings.Contains(err.Error(), "--lockfile") {
-		t.Fatalf("sync remediation should not include default --lockfile, got: %v", err)
+	if !strings.Contains(err.Error(), "artifacts would be materialized") {
+		t.Fatalf("stale local source sync --check error = %v", err)
 	}
 
 	staleArtifactsDir := filepath.Join(dir, "prepared-stale")
@@ -2149,11 +2141,8 @@ func TestRunSyncStaleLocalProviderRemediation(t *testing.T) {
 	if err == nil {
 		t.Fatal("runSync --check with stale explicit lock unexpectedly succeeded")
 	}
-	if !strings.Contains(err.Error(), "--lockfile "+lockPath) {
-		t.Fatalf("sync remediation should preserve explicit --lockfile, got: %v", err)
-	}
-	if !strings.Contains(err.Error(), "--artifacts-dir") {
-		t.Fatalf("sync remediation should include --artifacts-dir, got: %v", err)
+	if !strings.Contains(err.Error(), "artifacts would be materialized") {
+		t.Fatalf("sync --check with stale explicit lock error = %v", err)
 	}
 }
 
@@ -2209,7 +2198,7 @@ func TestRunLockSyncLayeredConfigs(t *testing.T) {
 		t.Fatalf("runSync with layered configs: %v", err)
 	}
 
-	env, err := setupBootstrapWithConfigPaths([]string{basePath, overridePath}, operator.StatePaths{}, true)
+	env, err := setupBootstrapWithConfigPaths([]string{basePath, overridePath}, operator.StatePaths{}, true, false)
 	if err != nil {
 		t.Fatalf("setupBootstrapWithConfigPaths locked layered configs: %v", err)
 	}
@@ -2235,7 +2224,7 @@ func TestRunServeLockedUsesOverrideLockfile(t *testing.T) {
 		t.Fatalf("runSync with --lockfile: %v", err)
 	}
 
-	env, err := setupBootstrapWithConfigPaths([]string{cfgPath}, operator.StatePaths{LockfilePath: lockPath}, true)
+	env, err := setupBootstrapWithConfigPaths([]string{cfgPath}, operator.StatePaths{LockfilePath: lockPath}, true, false)
 	if err != nil {
 		t.Fatalf("setupBootstrapWithConfigPaths locked with --lockfile: %v", err)
 	}

--- a/gestaltd/internal/daemon/factories.go
+++ b/gestaltd/internal/daemon/factories.go
@@ -34,13 +34,13 @@ type bootstrapEnv struct {
 	prevLogger *slog.Logger
 }
 
-func setupBootstrapWithConfigPaths(configPaths []string, state operator.StatePaths, locked bool, forcedDevUIKeys ...string) (*bootstrapEnv, error) {
+func setupBootstrapWithConfigPaths(configPaths []string, state operator.StatePaths, locked, noSync bool, forcedDevUIKeys ...string) (*bootstrapEnv, error) {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	return setupBootstrapWithConfigPathsContext(ctx, stop, configPaths, state, locked, forcedDevUIKeys...)
+	return setupBootstrapWithConfigPathsContext(ctx, stop, configPaths, state, locked, noSync, forcedDevUIKeys...)
 }
 
-func setupBootstrapWithConfigPathsContext(ctx context.Context, stop context.CancelFunc, configPaths []string, state operator.StatePaths, locked bool, forcedDevUIKeys ...string) (*bootstrapEnv, error) {
-	cfg, err := loadConfigForExecutionAtPathsWithStatePaths(configPaths, state, locked, forcedDevUIKeys...)
+func setupBootstrapWithConfigPathsContext(ctx context.Context, stop context.CancelFunc, configPaths []string, state operator.StatePaths, locked, noSync bool, forcedDevUIKeys ...string) (*bootstrapEnv, error) {
+	cfg, err := loadConfigForExecutionAtPathsWithStatePaths(configPaths, state, locked, noSync, forcedDevUIKeys...)
 	if err != nil {
 		stop()
 		return nil, err

--- a/gestaltd/internal/daemon/lifecycle.go
+++ b/gestaltd/internal/daemon/lifecycle.go
@@ -37,12 +37,12 @@ func syncConfigWithStatePathsOptions(configFlags []string, state operator.StateP
 	return operatorLifecycle().SyncAtPathsWithStatePathsOptions(configPaths, state, opts)
 }
 
-func loadConfigForExecutionAtPathsWithStatePaths(configPaths []string, state operator.StatePaths, locked bool, forcedDevUIKeys ...string) (*config.Config, error) {
+func loadConfigForExecutionAtPathsWithStatePaths(configPaths []string, state operator.StatePaths, locked, noSync bool, forcedDevUIKeys ...string) (*config.Config, error) {
 	lc := operatorLifecycle().WithDevServeEligible(!locked)
 	if len(forcedDevUIKeys) > 0 {
 		lc = lc.WithForcedDevUIKeys(forcedDevUIKeys)
 	}
-	cfg, _, err := lc.LoadForExecutionAtPathsWithStatePaths(configPaths, state, locked)
+	cfg, _, err := lc.LoadForExecutionAtPathsWithStatePaths(configPaths, state, locked, noSync)
 	if err != nil {
 		return nil, err
 	}

--- a/gestaltd/internal/daemon/main_test.go
+++ b/gestaltd/internal/daemon/main_test.go
@@ -27,7 +27,7 @@ func TestE2ECLIHelp(t *testing.T) {
 		{
 			name:      "root",
 			args:      []string{"--help"},
-			wantParts: []string{"gestaltd validate", "gestaltd lock", "gestaltd sync --locked", "gestaltd agent <command> [flags]", "gestaltd provider <command> [flags]", "gestaltd serve", "--locked", "[--config PATH]...", "--lockfile PATH"},
+			wantParts: []string{"gestaltd validate", "gestaltd lock", "gestaltd sync [--locked]", "gestaltd agent <command> [flags]", "gestaltd provider <command> [flags]", "gestaltd serve", "--locked", "--no-sync", "[--config PATH]...", "--lockfile PATH"},
 			notWant:   []string{"gestaltd lock [--config PATH]... [--lockfile PATH] [--platform", "gestaltd bundle", "gestaltd dev", "gestaltd init", "\n  init"},
 		},
 		{
@@ -44,7 +44,7 @@ func TestE2ECLIHelp(t *testing.T) {
 		{
 			name:      "sync",
 			args:      []string{"sync", "--help"},
-			wantParts: []string{"gestaltd sync --locked", "Materialize prepared artifacts", "--artifacts-dir", "--parallelism", "--cache-dir", "--output-format", "-v, --verbose", "--check"},
+			wantParts: []string{"gestaltd sync [--locked]", "Materialize prepared artifacts", "--artifacts-dir", "--parallelism", "--cache-dir", "--output-format", "-v, --verbose", "--check"},
 		},
 		{
 			name:      "provider",
@@ -55,7 +55,7 @@ func TestE2ECLIHelp(t *testing.T) {
 		{
 			name:      "serve",
 			args:      []string{"serve", "--help"},
-			wantParts: []string{"gestaltd serve --path PATH", "--port PORT", "dev:"},
+			wantParts: []string{"gestaltd serve --path PATH", "--port PORT", "--no-sync", "dev:"},
 		},
 		{
 			name:      "provider repo",
@@ -136,33 +136,33 @@ func TestRunSyncParallelismValidation(t *testing.T) {
 		},
 		{
 			name:      "one accepted",
-			args:      []string{"--parallelism", "1"},
-			wantError: "gestaltd sync currently requires --locked",
+			args:      []string{"--parallelism", "1", "--config", filepath.Join(t.TempDir(), "missing.yaml")},
+			wantError: "loading config",
 		},
 		{
 			name:      "two accepted",
-			args:      []string{"--parallelism", "2"},
-			wantError: "gestaltd sync currently requires --locked",
+			args:      []string{"--parallelism", "2", "--config", filepath.Join(t.TempDir(), "missing.yaml")},
+			wantError: "loading config",
 		},
 		{
 			name:      "cache dir accepted",
-			args:      []string{"--cache-dir", filepath.Join(t.TempDir(), "cache")},
-			wantError: "gestaltd sync currently requires --locked",
+			args:      []string{"--cache-dir", filepath.Join(t.TempDir(), "cache"), "--config", filepath.Join(t.TempDir(), "missing.yaml")},
+			wantError: "loading config",
 		},
 		{
 			name:      "verbose long accepted",
-			args:      []string{"--verbose"},
-			wantError: "gestaltd sync currently requires --locked",
+			args:      []string{"--verbose", "--config", filepath.Join(t.TempDir(), "missing.yaml")},
+			wantError: "loading config",
 		},
 		{
 			name:      "verbose short accepted",
-			args:      []string{"-v"},
-			wantError: "gestaltd sync currently requires --locked",
+			args:      []string{"-v", "--config", filepath.Join(t.TempDir(), "missing.yaml")},
+			wantError: "loading config",
 		},
 		{
 			name:      "repeated verbose short accepted",
-			args:      []string{"-v", "-v"},
-			wantError: "gestaltd sync currently requires --locked",
+			args:      []string{"-v", "-v", "--config", filepath.Join(t.TempDir(), "missing.yaml")},
+			wantError: "loading config",
 		},
 		{
 			name:      "condensed verbose short rejected",
@@ -171,13 +171,13 @@ func TestRunSyncParallelismValidation(t *testing.T) {
 		},
 		{
 			name:      "output format text accepted",
-			args:      []string{"--output-format", "text"},
-			wantError: "gestaltd sync currently requires --locked",
+			args:      []string{"--output-format", "text", "--config", filepath.Join(t.TempDir(), "missing.yaml")},
+			wantError: "loading config",
 		},
 		{
 			name:      "output format json accepted",
-			args:      []string{"--output-format=json"},
-			wantError: "gestaltd sync currently requires --locked",
+			args:      []string{"--output-format=json", "--config", filepath.Join(t.TempDir(), "missing.yaml")},
+			wantError: "loading config",
 		},
 		{
 			name:      "output format invalid",

--- a/gestaltd/internal/daemon/provider_local.go
+++ b/gestaltd/internal/daemon/provider_local.go
@@ -38,6 +38,7 @@ type providerLocalCommandOptions struct {
 	Name         string
 	Port         int
 	Locked       bool
+	NoSync       bool
 	ArtifactsDir string
 	LockfilePath string
 	// FleetOverlay is true for serve --path with --config. Validate always leaves
@@ -55,6 +56,7 @@ type providerLocalSession struct {
 	ConfigPaths       []string
 	State             operator.StatePaths
 	Locked            bool
+	NoSync            bool
 	PublicURL         string
 	AdminURL          string
 	PublicUIPaths     []string
@@ -121,7 +123,7 @@ func runServeProviderLocal(opts providerLocalCommandOptions) error {
 	if session.Locked {
 		forcedDevUIKeys = session.DevUIKeys
 	}
-	env, err := setupBootstrapWithConfigPaths(session.ConfigPaths, session.State, session.Locked, forcedDevUIKeys...)
+	env, err := setupBootstrapWithConfigPaths(session.ConfigPaths, session.State, session.Locked, session.NoSync, forcedDevUIKeys...)
 	if err != nil {
 		return err
 	}
@@ -276,6 +278,7 @@ func prepareProviderLocalSession(opts providerLocalCommandOptions) (*providerLoc
 		LockfilePath: opts.LockfilePath,
 	}
 	locked := opts.Locked && opts.FleetOverlay
+	noSync := opts.NoSync && opts.FleetOverlay
 	port := opts.Port
 	if opts.FleetOverlay {
 		configPaths = append([]string(nil), opts.ConfigPaths...)
@@ -343,6 +346,7 @@ func prepareProviderLocalSession(opts providerLocalCommandOptions) (*providerLoc
 		ConfigPaths:   configPaths,
 		State:         state,
 		Locked:        locked,
+		NoSync:        noSync,
 		PublicURL:     providerLocalPublicURL(loadedCfg),
 		AdminURL:      strings.TrimRight(providerLocalPublicURL(loadedCfg), "/") + "/admin/",
 		PublicUIPaths: publicUIPaths,

--- a/gestaltd/internal/daemon/provider_local_serve_test.go
+++ b/gestaltd/internal/daemon/provider_local_serve_test.go
@@ -103,3 +103,60 @@ providers:
 		t.Fatalf("ConfigPaths len = %d, want base + 2 overlays", len(session.ConfigPaths))
 	}
 }
+
+func TestPrepareProviderLocalOverlaySessionForwardsNoSync(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	uiDir := filepath.Join(dir, "ui", "demo")
+	if err := os.MkdirAll(uiDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	manifest := `kind: ui
+source: github.com/acme/apps/demo-ui
+version: "1.0.0"
+dev:
+  command: [sh, -c, echo]
+build:
+  command: [sh, -c, "mkdir -p out && echo ok > out/index.html"]
+spec:
+  assetRoot: out
+  routes:
+    - path: /
+      allowedRoles: [viewer]
+`
+	if err := os.WriteFile(filepath.Join(uiDir, "manifest.yaml"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("WriteFile manifest: %v", err)
+	}
+
+	baseCfg := filepath.Join(dir, "base.yaml")
+	baseYAML := `apiVersion: gestaltd.config/v8
+providers:
+  ui:
+    demo:
+      path: /demo
+      source: https://example.invalid/ui/demo
+`
+	if err := os.WriteFile(baseCfg, []byte(baseYAML), 0o644); err != nil {
+		t.Fatalf("WriteFile base config: %v", err)
+	}
+
+	session, err := prepareProviderLocalSession(providerLocalCommandOptions{
+		Paths:        []string{uiDir},
+		ConfigPaths:  []string{baseCfg},
+		Locked:       true,
+		NoSync:       true,
+		FleetOverlay: true,
+	})
+	if err != nil {
+		t.Fatalf("prepareProviderLocalSession: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(session.Dir) }()
+
+	if !session.Locked {
+		t.Fatalf("session.Locked = false, want true under fleet overlay")
+	}
+	if !session.NoSync {
+		t.Fatalf("session.NoSync = false, want true so --locked --no-sync binds pinned artifacts as-is")
+	}
+}

--- a/gestaltd/internal/daemon/run.go
+++ b/gestaltd/internal/daemon/run.go
@@ -104,8 +104,10 @@ func runServeCommand(name string, usage func(io.Writer), args []string, opts ser
 		nameFlag = fs.String("name", "", "provider key override for --path")
 	}
 	var lockedFlag *bool
+	var noSyncFlag *bool
 	if opts.allowLocked {
-		lockedFlag = fs.Bool("locked", false, "require exact lock state; do not auto lock/sync")
+		lockedFlag = fs.Bool("locked", false, "require a fresh lockfile; do not re-resolve metadata")
+		noSyncFlag = fs.Bool("no-sync", false, "do not materialize artifacts; serve pinned artifacts as-is")
 	}
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -126,8 +128,15 @@ func runServeCommand(name string, usage func(io.Writer), args []string, opts ser
 	}
 
 	locked := false
+	noSync := false
 	if lockedFlag != nil {
 		locked = *lockedFlag
+	}
+	if noSyncFlag != nil {
+		noSync = *noSyncFlag
+	}
+	if noSync && !locked {
+		return fmt.Errorf("--no-sync requires --locked")
 	}
 
 	if opts.allowProviderLocal {
@@ -139,6 +148,7 @@ func runServeCommand(name string, usage func(io.Writer), args []string, opts ser
 			ArtifactsDir:  *artifactsDir,
 			LockfilePath:  *lockfilePath,
 			Locked:        locked,
+			NoSync:        noSync,
 			LockedAllowed: lockedFlag != nil,
 		})
 		if ranProviderLocal || err != nil {
@@ -148,7 +158,7 @@ func runServeCommand(name string, usage func(io.Writer), args []string, opts ser
 	env, err := setupBootstrapWithConfigPaths(resolvedConfigPaths, operator.StatePaths{
 		ArtifactsDir: *artifactsDir,
 		LockfilePath: *lockfilePath,
-	}, locked)
+	}, locked, noSync)
 	if err != nil {
 		return err
 	}
@@ -167,6 +177,7 @@ type serveProviderLocalOptions struct {
 	ArtifactsDir  string
 	LockfilePath  string
 	Locked        bool
+	NoSync        bool
 	LockedAllowed bool
 }
 
@@ -200,6 +211,7 @@ func maybeRunServeProviderLocal(opts serveProviderLocalOptions) (bool, error) {
 		Name:         name,
 		Port:         opts.Port,
 		Locked:       opts.Locked,
+		NoSync:       opts.NoSync,
 		ArtifactsDir: opts.ArtifactsDir,
 		LockfilePath: opts.LockfilePath,
 	})
@@ -302,9 +314,6 @@ func runSync(args []string) error {
 	if err := validateSyncOutputFormat(*outputFormat); err != nil {
 		return err
 	}
-	if !*locked {
-		return fmt.Errorf("gestaltd sync currently requires --locked")
-	}
 
 	verbose := *verboseLong || *verboseShort
 	observabilityRequested := verbose || *outputFormat == syncOutputFormatJSON
@@ -319,6 +328,7 @@ func runSync(args []string) error {
 		observability.BuildOutput = providerpkg.CommandOutput{Stdout: os.Stderr, Stderr: os.Stderr}
 	}
 	opts := operator.SyncOptions{
+		Locked:        *locked,
 		Parallelism:   *parallelism,
 		CacheDir:      *cacheDir,
 		Observability: observability,
@@ -473,9 +483,9 @@ func printMainUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
 	writeUsageLine(w, "  gestaltd [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH]")
 	writeUsageLine(w, "  gestaltd lock [--config PATH]... [--lockfile PATH] [--check]")
-	writeUsageLine(w, "  gestaltd sync --locked [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--parallelism N] [--cache-dir PATH] [--output-format text|json] [-v|--verbose] [--check]")
-	writeUsageLine(w, "  gestaltd serve [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--locked] [--port PORT]")
-	writeUsageLine(w, "  gestaltd serve --path PATH [--path PATH]... [--config PATH]... [--locked] [--artifacts-dir PATH] [--lockfile PATH] [--name NAME] [--port PORT]")
+	writeUsageLine(w, "  gestaltd sync [--locked] [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--parallelism N] [--cache-dir PATH] [--output-format text|json] [-v|--verbose] [--check]")
+	writeUsageLine(w, "  gestaltd serve [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--locked] [--no-sync] [--port PORT]")
+	writeUsageLine(w, "  gestaltd serve --path PATH [--path PATH]... [--config PATH]... [--locked] [--no-sync] [--artifacts-dir PATH] [--lockfile PATH] [--name NAME] [--port PORT]")
 	writeUsageLine(w, "  gestaltd agent <command> [flags]")
 	writeUsageLine(w, "  gestaltd provider <command> [flags]")
 	writeUsageLine(w, "  gestaltd validate [--config PATH]... [--lockfile PATH] [--platform os/arch] [--runtime]")
@@ -485,7 +495,7 @@ func printMainUsage(w io.Writer) {
 	writeUsageLine(w, "  lock        Resolve provider metadata and write lock state")
 	writeUsageLine(w, "  sync        Materialize prepared artifacts from lock state")
 	writeUsageLine(w, "  provider    Develop, validate, or build provider release archives")
-	writeUsageLine(w, "  serve       Start the server (use --locked for production)")
+	writeUsageLine(w, "  serve       Start the server (use --locked --no-sync for production)")
 	writeUsageLine(w, "  validate    Load and validate configuration without starting the server")
 	writeUsageLine(w, "  version     Print the version and exit")
 	writeUsageLine(w, "")
@@ -497,8 +507,8 @@ func printMainUsage(w io.Writer) {
 
 func printServeUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
-	writeUsageLine(w, "  gestaltd serve [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--locked] [--port PORT]")
-	writeUsageLine(w, "  gestaltd serve --path PATH [--path PATH]... [--config PATH]... [--locked] [--artifacts-dir PATH] [--lockfile PATH] [--name NAME] [--port PORT]")
+	writeUsageLine(w, "  gestaltd serve [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--locked] [--no-sync] [--port PORT]")
+	writeUsageLine(w, "  gestaltd serve --path PATH [--path PATH]... [--config PATH]... [--locked] [--no-sync] [--artifacts-dir PATH] [--lockfile PATH] [--name NAME] [--port PORT]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Start the server. Without --locked, auto lock/syncs if state is missing or stale.")
 	writeUsageLine(w, "--port overrides server.public.port; if the port is in use, gestaltd tries the next free port unless --port was given explicitly.")
@@ -506,8 +516,9 @@ func printServeUsage(w io.Writer) {
 	writeUsageLine(w, "the fleet loads pinned artifacts while --path UIs with a manifest dev: block hot-reload.")
 	writeUsageLine(w, "Without --config, --path runs an isolated synthesized baseline (unlocked).")
 	writeUsageLine(w, "Local UIs with a manifest dev: block are proxied to a hot-reload dev server automatically.")
-	writeUsageLine(w, "For production, strongly prefer --locked so startup uses the pinned")
-	writeUsageLine(w, "lockfile and prepared artifacts instead of resolving or mutating state.")
+	writeUsageLine(w, "For production, use --locked --no-sync to trust the committed lockfile and prebuilt")
+	writeUsageLine(w, "artifacts without materialization or staleness checks.")
+	writeUsageLine(w, "Use --locked alone when artifacts may need to be materialized at startup.")
 	writeUsageLine(w, "When locked, run `gestaltd lock` before deploy and `gestaltd sync --locked` during build.")
 	writeUsageLine(w, "When repeated, --config files merge left-to-right. Maps deep-merge,")
 	writeUsageLine(w, "later scalars win, lists replace, and null deletes inherited keys.")
@@ -530,10 +541,11 @@ func printLockUsage(w io.Writer) {
 
 func printSyncUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
-	writeUsageLine(w, "  gestaltd sync --locked [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--parallelism N] [--cache-dir PATH] [--output-format text|json] [-v|--verbose] [--check]")
+	writeUsageLine(w, "  gestaltd sync [--locked] [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--parallelism N] [--cache-dir PATH] [--output-format text|json] [-v|--verbose] [--check]")
 	writeUsageLine(w, "")
-	writeUsageLine(w, "Materialize prepared artifacts from the existing lockfile.")
-	writeUsageLine(w, "Does not resolve new metadata or rewrite the lockfile.")
+	writeUsageLine(w, "Materialize prepared artifacts from lock state.")
+	writeUsageLine(w, "By default, re-locks when the lockfile is stale, then materializes artifacts.")
+	writeUsageLine(w, "--locked requires a fresh lockfile and only materializes artifacts.")
 	writeUsageLine(w, "--cache-dir reuses materialized prepared artifacts keyed by locked archive identity; --check remains read-only.")
 	writeUsageLine(w, "--parallelism caps concurrent local source UI preparation.")
 	writeUsageLine(w, "--output-format=json writes one machine-readable metrics document to stdout on success.")
@@ -544,7 +556,7 @@ func printSyncUsage(w io.Writer) {
 	writeUsageLine(w, "  --config          Path to a config file; repeat to layer left-to-right")
 	writeUsageLine(w, "  --artifacts-dir   Path to writable prepared-artifacts directory; relative paths use the current working directory")
 	writeUsageLine(w, "  --lockfile        Path to lockfile; defaults to gestalt.lock.json next to the primary config")
-	writeUsageLine(w, "  --locked          Require an existing lockfile")
+	writeUsageLine(w, "  --locked          Require a fresh lockfile; do not re-resolve metadata")
 	writeUsageLine(w, "  --parallelism     Maximum concurrent local source UI preparations")
 	writeUsageLine(w, "  --cache-dir       Opt-in cache for materialized prepared artifacts; relative paths use the current working directory")
 	writeUsageLine(w, "  --output-format   Output format: text or json")

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -114,6 +114,7 @@ type StatePaths struct {
 }
 
 type SyncOptions struct {
+	Locked        bool
 	Parallelism   int
 	CacheDir      string
 	Observability SyncObservability
@@ -142,7 +143,7 @@ type artifactMode int
 const (
 	artifactModeMaterialize artifactMode = iota
 	artifactModeCheck
-	artifactModeReadOnly
+	artifactModeBind
 )
 
 type configSecretResolutionMode int
@@ -154,6 +155,10 @@ const (
 
 func (m artifactMode) canMaterialize() bool {
 	return m == artifactModeMaterialize
+}
+
+func (m artifactMode) toleratesStale() bool {
+	return m == artifactModeBind
 }
 
 func NewLifecycle() *Lifecycle {
@@ -295,14 +300,6 @@ func (l *Lifecycle) CheckLockAtPathsWithStatePaths(configPaths []string, state S
 		return fmt.Errorf("lockfile is out of date; run `%s`", formatLockCommand(paths))
 	}
 	return nil
-}
-
-func (l *Lifecycle) SyncAtPathsWithStatePaths(configPaths []string, state StatePaths) error {
-	return l.SyncAtPathsWithStatePathsOptions(configPaths, state, SyncOptions{})
-}
-
-func (l *Lifecycle) CheckSyncAtPathsWithStatePaths(configPaths []string, state StatePaths) error {
-	return l.CheckSyncAtPathsWithStatePathsOptions(configPaths, state, SyncOptions{})
 }
 
 func (l *Lifecycle) SyncAtPathsWithStatePathsOptions(configPaths []string, state StatePaths, opts SyncOptions) error {
@@ -1023,10 +1020,10 @@ func (l *Lifecycle) LoadForExecutionAtPath(configPath string, locked bool) (*con
 }
 
 func (l *Lifecycle) LoadForExecutionAtPaths(configPaths []string, locked bool) (*config.Config, map[string]string, error) {
-	return l.LoadForExecutionAtPathsWithStatePaths(configPaths, StatePaths{}, locked)
+	return l.LoadForExecutionAtPathsWithStatePaths(configPaths, StatePaths{}, locked, false)
 }
 
-func (l *Lifecycle) LoadForExecutionAtPathsWithStatePaths(configPaths []string, state StatePaths, locked bool) (*config.Config, map[string]string, error) {
+func (l *Lifecycle) LoadForExecutionAtPathsWithStatePaths(configPaths []string, state StatePaths, locked, noSync bool) (*config.Config, map[string]string, error) {
 	cfg, err := l.loadConfigForLifecycle(configPaths, state, false)
 	if err != nil {
 		return nil, nil, fmt.Errorf("loading config: %v", err)
@@ -1043,8 +1040,8 @@ func (l *Lifecycle) LoadForExecutionAtPathsWithStatePaths(configPaths []string, 
 		}
 	}
 	mode := artifactModeMaterialize
-	if locked {
-		mode = artifactModeReadOnly
+	if locked && noSync {
+		mode = artifactModeBind
 	}
 	secretsLock, err := l.lockForSecretsBootstrap(configPaths, state, paths, cfg, locked)
 	if err != nil {
@@ -1184,12 +1181,22 @@ func (l *Lifecycle) syncAtPathsWithStatePaths(configPaths []string, state StateP
 	if err != nil {
 		if os.IsNotExist(err) && !configRequiresCommittedLock(cfg) {
 			lock = newLockfile()
-		} else {
-			return fmt.Errorf("source-backed providers require lock metadata; run `%s`: %w", formatLockCommand(paths), err)
+			err = nil
 		}
 	}
+	relockLocked := opts.Locked || mode == artifactModeCheck
+	lock, err = l.autoRelockAtPathsIfNeeded(configPaths, state, cfg, paths, lock, relockLocked, err)
+	if err != nil {
+		if relockLocked && os.IsNotExist(err) && configRequiresCommittedLock(cfg) {
+			return fmt.Errorf("lockfile required")
+		}
+		return fmt.Errorf("source-backed providers require lock metadata; run `%s`: %w", formatLockCommand(paths), err)
+	}
+	if relockLocked && configRequiresCommittedLock(cfg) && lock == nil {
+		return fmt.Errorf("lockfile required")
+	}
 	if !lockFreshForConfig(cfg, paths, lock, lockFreshnessOptions{}) {
-		return fmt.Errorf("lockfile is out of date; run `%s`", formatLockCommand(paths))
+		return lockMetadataStaleError(paths, "lockfile stale")
 	}
 	if _, err := l.primeSecretsProviderForConfigResolution(context.Background(), paths, cfg, lock, mode, configSecretResolutionSourceAuth); err != nil {
 		return err
@@ -1722,6 +1729,16 @@ func preparedArtifactStaleError(paths lifecyclePaths, format string, args ...any
 	return fmt.Errorf(format+"; run `%s`", append(args, formatSyncLockedCommand(paths))...)
 }
 
+func artifactMaterializeDeniedError(paths lifecyclePaths, mode artifactMode, format string, args ...any) error {
+	if mode == artifactModeCheck {
+		return fmt.Errorf("artifacts would be materialized")
+	}
+	if mode == artifactModeBind {
+		return preparedArtifactStaleError(paths, "artifacts missing")
+	}
+	return preparedArtifactStaleError(paths, format, args...)
+}
+
 func lockMetadataStaleError(paths lifecyclePaths, format string, args ...any) error {
 	return fmt.Errorf(format+"; run `%s`", append(args, formatLockCommand(paths))...)
 }
@@ -2229,7 +2246,7 @@ func inspectPreparedLockMetadata(paths lifecyclePaths, install *preparedInstall,
 		strings.TrimSpace(metadata.Name) != strings.TrimSpace(name) {
 		return preparedLockMetadataStale
 	}
-	expected, err := expectedPreparedLockMetadata(paths, install, kind, name, provider, mode != artifactModeReadOnly)
+	expected, err := expectedPreparedLockMetadata(paths, install, kind, name, provider, !mode.toleratesStale())
 	if err != nil {
 		return preparedLockMetadataStale
 	}
@@ -2241,7 +2258,7 @@ func inspectPreparedLockMetadata(paths lifecyclePaths, install *preparedInstall,
 		strings.TrimSpace(metadata.OutputDigest) != strings.TrimSpace(expected.OutputDigest) {
 		return preparedLockMetadataStale
 	}
-	if mode != artifactModeReadOnly {
+	if !mode.toleratesStale() {
 		if strings.TrimSpace(metadata.InputDigest) != strings.TrimSpace(expected.InputDigest) ||
 			strings.TrimSpace(metadata.SourceIdentity) != strings.TrimSpace(expected.SourceIdentity) ||
 			strings.TrimSpace(metadata.SourceInputDigest) != strings.TrimSpace(expected.SourceInputDigest) {
@@ -2547,7 +2564,7 @@ func lockEntryFingerprintMatchesProvider(name string, provider *config.ProviderE
 }
 
 func lockEntryFingerprintMatchesProviderForMode(name string, provider *config.ProviderEntry, configDir string, entry LockEntry, mode artifactMode) (bool, error) {
-	if mode == artifactModeReadOnly && providerHasReadOnlyLocalSource(provider) {
+	if mode.toleratesStale() && providerHasReadOnlyLocalSource(provider) {
 		return true, nil
 	}
 	if providerHasReadOnlyLocalSource(provider) && localSourcePathMissing(provider) {
@@ -3532,14 +3549,25 @@ func (l *Lifecycle) applyLockedProviders(configPaths []string, state StatePaths,
 	var err error
 	if lock == nil {
 		lock, err = ReadLockfile(paths.lockfilePath)
-		if locked && err != nil && os.IsNotExist(err) {
+		if locked && err != nil && os.IsNotExist(err) && !configRequiresCommittedLock(cfg) {
 			lock = newLockfile()
 			err = nil
+		}
+	}
+	if locked && configRequiresCommittedLock(cfg) {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("lockfile required")
+			}
+			return fmt.Errorf("lockfile required: %w", err)
 		}
 	}
 	lock, err = l.autoRelockAtPathsIfNeeded(configPaths, state, cfg, paths, lock, locked, err)
 	if err != nil {
 		return fmt.Errorf("source-backed providers require lock metadata; full config mode prepares all source-backed providers. For local single-app development, use `gestaltd serve --path PATH` or a layered local config; otherwise run `%s` then `%s`: %w", formatLockCommand(paths), formatSyncLockedCommand(paths), err)
+	}
+	if locked && configRequiresCommittedLock(cfg) && !lockFreshForConfig(cfg, paths, lock, lockFreshnessOptions{}) {
+		return lockMetadataStaleError(paths, "lockfile stale")
 	}
 	if err := l.applyPreparedProviders(paths, lock, cfg, mode, SyncOptions{Parallelism: 1}); err != nil {
 		return err
@@ -4438,7 +4466,7 @@ func (l *Lifecycle) ensureLocalPreparedInstall(paths lifecyclePaths, kind, name 
 	install, err := inspectPreparedInstall(destDir)
 	needMaterialize := err != nil
 	reason := syncArtifactReasonPreparedMissing
-	if !needMaterialize {
+	if !needMaterialize && !mode.toleratesStale() {
 		switch inspectPreparedLockMetadata(paths, install, kind, name, provider, mode) {
 		case preparedLockMetadataMatch:
 			needMaterialize = false
@@ -4450,7 +4478,7 @@ func (l *Lifecycle) ensureLocalPreparedInstall(paths lifecyclePaths, kind, name 
 	}
 	if needMaterialize {
 		if !mode.canMaterialize() {
-			return nil, preparedArtifactStaleError(paths, "prepared artifact for %s is missing or stale", subject)
+			return nil, artifactMaterializeDeniedError(paths, mode, "prepared artifact for %s is missing or stale", subject)
 		}
 		prepareStart := time.Now()
 		stagedInstall, cleanupStaged, commitStaged, err := stageLocalSourceInstall(kind, name, provider.SourcePath(), destDir, paths.stageOptions())
@@ -4481,8 +4509,8 @@ func (l *Lifecycle) ensureLocalPreparedInstall(paths lifecyclePaths, kind, name 
 		}
 		recordSyncArtifact(paths, kind, name, subject, destDir, syncArtifactSourceLocalSource, syncArtifactResultMaterialized, reason, start, prepareDuration, activateDuration)
 	}
-	if inspectPreparedLockMetadata(paths, install, kind, name, provider, mode) != preparedLockMetadataMatch {
-		return nil, preparedArtifactStaleError(paths, "prepared artifact for %s is missing or stale", subject)
+	if !mode.toleratesStale() && inspectPreparedLockMetadata(paths, install, kind, name, provider, mode) != preparedLockMetadataMatch {
+		return nil, artifactMaterializeDeniedError(paths, mode, "prepared artifact for %s is missing or stale", subject)
 	}
 	if !needMaterialize {
 		recordSyncArtifact(paths, kind, name, subject, destDir, syncArtifactSourceLocalSource, syncArtifactResultReused, syncArtifactReasonFresh, start, 0, 0)
@@ -4614,7 +4642,7 @@ func (l *Lifecycle) applyConfiguredUIProvider(paths lifecyclePaths, lockEntry *L
 		}
 		start := time.Now()
 		install, err := inspectPreparedInstall(destDir)
-		needMaterialize := err != nil || !preparedInstallMatchesLockForMode(providermanifestv1.KindUI, logicalName, provider, *lockEntry, install, mode)
+		needMaterialize := err != nil || (!mode.toleratesStale() && !preparedInstallMatchesLockForMode(providermanifestv1.KindUI, logicalName, provider, *lockEntry, install, mode))
 		reason := syncArtifactReasonPreparedMissing
 		if err == nil && needMaterialize {
 			reason = syncArtifactReasonManifestStale
@@ -4631,11 +4659,11 @@ func (l *Lifecycle) applyConfiguredUIProvider(paths lifecyclePaths, lockEntry *L
 		}
 		if needMaterialize {
 			if !mode.canMaterialize() {
-				return "", preparedArtifactStaleError(paths, "prepared artifact for %s is missing or stale", subject)
+				return "", artifactMaterializeDeniedError(paths, mode, "prepared artifact for %s is missing or stale", subject)
 			}
 			if len(lockEntry.Archives) == 0 {
 				if !provider.HasLocalSource() && !provider.HasGitSource() {
-					return "", preparedArtifactStaleError(paths, "prepared artifact for %s is missing or stale", subject)
+					return "", artifactMaterializeDeniedError(paths, mode, "prepared artifact for %s is missing or stale", subject)
 				}
 				var prepareDuration time.Duration
 				if stagedInstall == nil {
@@ -4760,7 +4788,7 @@ func (l *Lifecycle) applyLockedProviderEntry(paths lifecyclePaths, lock *Lockfil
 
 	start := time.Now()
 	install, err := inspectPreparedInstall(destDir)
-	needMaterialize := err != nil || !preparedInstallMatchesLockForMode(providermanifestv1.KindApp, name, app, entry, install, mode)
+	needMaterialize := err != nil || (!mode.toleratesStale() && !preparedInstallMatchesLockForMode(providermanifestv1.KindApp, name, app, entry, install, mode))
 	reason := syncArtifactReasonPreparedMissing
 	if err == nil && needMaterialize {
 		reason = syncArtifactReasonManifestStale
@@ -4781,7 +4809,7 @@ func (l *Lifecycle) applyLockedProviderEntry(paths lifecyclePaths, lock *Lockfil
 	}
 	if needMaterialize {
 		if !mode.canMaterialize() {
-			return preparedArtifactStaleError(paths, "prepared artifact for provider %q is missing or stale", name)
+			return artifactMaterializeDeniedError(paths, mode, "prepared artifact for provider %q is missing or stale", name)
 		}
 		if len(entry.Archives) == 0 {
 			if !app.HasLocalSource() && !app.HasGitSource() {
@@ -4870,7 +4898,7 @@ func (l *Lifecycle) applyLockedComponentEntry(paths lifecyclePaths, entry *LockE
 
 	start := time.Now()
 	install, err := inspectPreparedInstall(destDir)
-	needMaterialize := err != nil || !preparedInstallMatchesLockForMode(kind, name, app, *entry, install, mode)
+	needMaterialize := err != nil || (!mode.toleratesStale() && !preparedInstallMatchesLockForMode(kind, name, app, *entry, install, mode))
 	reason := syncArtifactReasonPreparedMissing
 	if err == nil && needMaterialize {
 		reason = syncArtifactReasonManifestStale
@@ -4895,11 +4923,11 @@ func (l *Lifecycle) applyLockedComponentEntry(paths lifecyclePaths, entry *LockE
 	}
 	if needMaterialize {
 		if !mode.canMaterialize() {
-			return preparedArtifactStaleError(paths, "prepared artifact for %s %q is missing or stale", kind, name)
+			return artifactMaterializeDeniedError(paths, mode, "prepared artifact for %s %q is missing or stale", kind, name)
 		}
 		if len(entry.Archives) == 0 {
 			if !app.HasLocalSource() && !app.HasGitSource() {
-				return preparedArtifactStaleError(paths, "prepared artifact for %s %q is missing or stale", kind, name)
+				return artifactMaterializeDeniedError(paths, mode, "prepared artifact for %s %q is missing or stale", kind, name)
 			}
 			var prepareDuration time.Duration
 			if stagedInstall == nil {

--- a/gestaltd/internal/operator/lifecycle_dev_test.go
+++ b/gestaltd/internal/operator/lifecycle_dev_test.go
@@ -222,7 +222,7 @@ server:
 	if _, err := lc.LockAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
 		t.Fatalf("LockAtPathsWithStatePaths: %v", err)
 	}
-	if err := lc.SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
+	if err := lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{}); err != nil {
 		t.Fatalf("SyncAtPathsWithStatePaths: %v", err)
 	}
 	preparedUI := filepath.Join(artifactsDir, "ui", "demo", "dist", "index.html")
@@ -284,7 +284,7 @@ server:
 		t.Fatalf("WriteFile config: %v", err)
 	}
 
-	loaded, _, err := NewLifecycle().WithDevServeEligible(true).LoadForExecutionAtPathsWithStatePaths([]string{cfgPath}, StatePaths{}, false)
+	loaded, _, err := NewLifecycle().WithDevServeEligible(true).LoadForExecutionAtPathsWithStatePaths([]string{cfgPath}, StatePaths{}, false, false)
 	if err != nil {
 		t.Fatalf("LoadForExecutionAtPathsWithStatePaths: %v", err)
 	}

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -108,7 +108,7 @@ apps:
 	if err := os.RemoveAll(filepath.Join(artifactsDir, "providers", "alpha")); err != nil {
 		t.Fatalf("remove prepared provider: %v", err)
 	}
-	if err := lc.SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
+	if err := lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{}); err != nil {
 		t.Fatalf("SyncAtPathsWithStatePaths after removing prepared provider: %v", err)
 	}
 	preparedManifest := filepath.Join(artifactsDir, "providers", "alpha", "manifest.yaml")
@@ -175,7 +175,7 @@ server:
 	if err := os.RemoveAll(filepath.Join(artifactsDir, "ui", "roadmap")); err != nil {
 		t.Fatalf("remove prepared ui: %v", err)
 	}
-	if err := lc.SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
+	if err := lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{}); err != nil {
 		t.Fatalf("SyncAtPathsWithStatePaths after removing prepared ui: %v", err)
 	}
 	if _, err := os.Stat(preparedIndex); err != nil {
@@ -590,7 +590,7 @@ printf '<html>alpha</html>\n' > dist/index.html
 		"alpha": filepath.Join(uiDir, "manifest.yaml"),
 	})
 	err := NewLifecycle().CheckSyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{Parallelism: 2})
-	if err == nil || !strings.Contains(err.Error(), `prepared artifact`) {
+	if err == nil || !strings.Contains(err.Error(), "artifacts would be materialized") {
 		t.Fatalf("CheckSyncAtPathsWithStatePathsOptions error = %v, want stale prepared artifact", err)
 	}
 	if _, err := os.Stat(startedPath); !os.IsNotExist(err) {
@@ -663,7 +663,7 @@ apps:
 	if _, ok := lock.Providers.UI["roadmap"]; ok {
 		t.Fatalf("restored local source ui lock entry should be omitted: %#v", lock.Providers.UI)
 	}
-	if err := lc.SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
+	if err := lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{}); err != nil {
 		t.Fatalf("SyncAtPathsWithStatePaths: %v", err)
 	}
 
@@ -695,9 +695,9 @@ apps:
 		t.Fatalf("remove ui source tree: %v", err)
 	}
 
-	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
+	cfg, _, err := lc.LoadForExecutionAtPathsWithStatePaths([]string{configPath}, StatePaths{}, true, true)
 	if err != nil {
-		t.Fatalf("LoadForExecutionAtPath(locked=true) without local source tree: %v", err)
+		t.Fatalf("LoadForExecutionAtPath(locked=true, noSync=true) without local source tree: %v", err)
 	}
 	app := cfg.Apps["alpha"]
 	if app == nil || app.ResolvedManifest == nil {
@@ -713,10 +713,10 @@ apps:
 	if got, want := filepath.ToSlash(ui.ResolvedAssetRoot), filepath.ToSlash(preparedUI); got != want {
 		t.Fatalf("ResolvedAssetRoot = %q, want %q", got, want)
 	}
-	if err := lc.CheckSyncAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err == nil || !strings.Contains(err.Error(), `prepared artifact for provider "alpha" is missing or stale`) {
+	if err := lc.CheckSyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{}); err == nil || !strings.Contains(err.Error(), "artifacts would be materialized") {
 		t.Fatalf("CheckSyncAtPathsWithStatePaths without local source tree error = %v, want stale provider artifact", err)
 	}
-	if err := lc.SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err == nil || !strings.Contains(err.Error(), `manifest for app "alpha" not found`) {
+	if err := lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{}); err == nil || !strings.Contains(err.Error(), `manifest for app "alpha" not found`) {
 		t.Fatalf("SyncAtPathsWithStatePaths without local source tree error = %v, want missing source manifest", err)
 	}
 
@@ -731,10 +731,10 @@ apps:
 	if err := os.Remove(preparedUIMetadata); err != nil {
 		t.Fatalf("remove prepared ui lock metadata: %v", err)
 	}
-	if err := lc.CheckSyncAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err == nil || !strings.Contains(err.Error(), `prepared artifact for provider "alpha" is missing or stale`) {
+	if err := lc.CheckSyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{}); err == nil || !strings.Contains(err.Error(), "artifacts would be materialized") {
 		t.Fatalf("CheckSyncAtPathsWithStatePaths without prepared lock metadata error = %v, want stale provider artifact", err)
 	}
-	if err := lc.SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
+	if err := lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{}); err != nil {
 		t.Fatalf("SyncAtPathsWithStatePaths backfilling prepared lock metadata: %v", err)
 	}
 	if _, err := os.Stat(preparedProviderMetadata); err != nil {
@@ -755,7 +755,7 @@ apps:
 	if err := os.WriteFile(preparedUIMetadata, []byte(`{"inputDigest":"stale","kind":"ui","name":"roadmap"}`+"\n"), 0o644); err != nil {
 		t.Fatalf("write stale prepared ui lock metadata before sync: %v", err)
 	}
-	if err := lc.SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
+	if err := lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{}); err != nil {
 		t.Fatalf("SyncAtPathsWithStatePaths re-materializing stale prepared lock metadata: %v", err)
 	}
 	providerData, err := os.ReadFile(preparedProvider)
@@ -778,15 +778,17 @@ apps:
 	if err := os.RemoveAll(filepath.Join(dir, "ui")); err != nil {
 		t.Fatalf("remove ui source tree after backfill: %v", err)
 	}
-	if _, _, err := lc.LoadForExecutionAtPath(configPath, true); err != nil {
-		t.Fatalf("LoadForExecutionAtPath(locked=true) after metadata backfill: %v", err)
+	if _, _, err := lc.LoadForExecutionAtPathsWithStatePaths([]string{configPath}, StatePaths{}, true, true); err != nil {
+		t.Fatalf("LoadForExecutionAtPath(locked=true, noSync=true) after metadata backfill: %v", err)
 	}
 
+	writeSourceProviderTree(t, appDir, appSource, version, "alpha-binary")
+	writeSourceUITree(t, uiDir, uiSource, version)
 	if err := os.WriteFile(preparedProviderMetadata, []byte(`{"inputDigest":"stale","kind":"app","name":"alpha"}`+"\n"), 0o644); err != nil {
 		t.Fatalf("write stale prepared provider lock metadata: %v", err)
 	}
-	if _, _, err := lc.LoadForExecutionAtPath(configPath, true); err == nil || !strings.Contains(err.Error(), `prepared artifact for provider "alpha" is missing or stale`) {
-		t.Fatalf("LoadForExecutionAtPath with stale prepared provider metadata error = %v, want stale provider artifact", err)
+	if _, _, err := lc.LoadForExecutionAtPath(configPath, true); err != nil {
+		t.Fatalf("LoadForExecutionAtPath(locked=true) with stale prepared provider metadata should re-materialize: %v", err)
 	}
 	if err := os.WriteFile(preparedProviderMetadata, providerMetadata, 0o644); err != nil {
 		t.Fatalf("restore prepared provider lock metadata: %v", err)
@@ -794,8 +796,8 @@ apps:
 	if err := os.WriteFile(preparedUIMetadata, []byte(`{"inputDigest":"stale","kind":"ui","name":"roadmap"}`+"\n"), 0o644); err != nil {
 		t.Fatalf("write stale prepared ui lock metadata: %v", err)
 	}
-	if _, _, err := lc.LoadForExecutionAtPath(configPath, true); err == nil || !strings.Contains(err.Error(), `prepared artifact for ui "roadmap" is missing or stale`) {
-		t.Fatalf("LoadForExecutionAtPath with stale prepared ui metadata error = %v, want stale ui artifact", err)
+	if _, _, err := lc.LoadForExecutionAtPathsWithStatePaths([]string{configPath}, StatePaths{}, true, true); err != nil {
+		t.Fatalf("LoadForExecutionAtPathsWithStatePaths(locked=true, noSync=true) with stale prepared ui metadata: %v", err)
 	}
 }
 
@@ -2557,7 +2559,7 @@ func TestSourceAppMetadataURLPrepareAndLockedLoad(t *testing.T) {
 
 			metadataBefore := metadataCount.Load()
 			currentBefore := currentArchiveCount.Load()
-			err = lc.SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{})
+			err = lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{})
 			if tc.tamperLocalArchive {
 				if handlerErr := nextHandlerErr(); handlerErr != nil {
 					t.Fatal(handlerErr)
@@ -2633,8 +2635,8 @@ func TestSourceAppMetadataURLPrepareAndLockedLoad(t *testing.T) {
 						},
 					},
 				})
-				if _, _, err := lc.LoadForExecutionAtPath(configPath, true); err == nil || !strings.Contains(err.Error(), `lock entry for provider "alpha" is stale`) {
-					t.Fatalf("LoadForExecutionAtPath after stale local metadata error = %v, want stale lock entry", err)
+				if _, _, err := lc.LoadForExecutionAtPath(configPath, true); err == nil || !strings.Contains(err.Error(), "lockfile stale") {
+					t.Fatalf("LoadForExecutionAtPath after stale local metadata error = %v, want stale lockfile", err)
 				}
 			}
 		})
@@ -2826,7 +2828,7 @@ packages:
 	indexBefore := indexCount.Load()
 	metadataBefore := metadataCount.Load()
 	archiveBefore := archiveCount.Load()
-	if err := lc.SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
+	if err := lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{}); err != nil {
 		if handlerErr := nextHandlerErr(); handlerErr != nil {
 			t.Fatal(handlerErr)
 		}
@@ -3191,7 +3193,7 @@ func TestSourceWorkflowMetadataURLPrepareAndLockedLoad(t *testing.T) {
 
 	metadataBefore := metadataCount.Load()
 	archiveBefore := archiveCount.Load()
-	err = lc.SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{})
+	err = lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{})
 	if err != nil {
 		t.Fatalf("SyncAtPathsWithStatePaths: %v", err)
 	}
@@ -3362,7 +3364,7 @@ func TestSourceExternalCredentialsMetadataURLPrepareAndLockedLoad(t *testing.T) 
 
 	metadataBefore := metadataCount.Load()
 	archiveBefore := archiveCount.Load()
-	err = lc.SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{})
+	err = lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{})
 	if err != nil {
 		t.Fatalf("SyncAtPathsWithStatePaths: %v", err)
 	}
@@ -3539,7 +3541,7 @@ func TestSourceUIMetadataURLPrepareAndLockedLoad(t *testing.T) {
 
 	metadataBefore := metadataCount.Load()
 	archiveBefore := archiveCount.Load()
-	err = lc.SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{})
+	err = lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{})
 	if err != nil {
 		t.Fatalf("SyncAtPathsWithStatePaths: %v", err)
 	}
@@ -3799,7 +3801,7 @@ func TestSourceAppMetadataURLUsesGenericAuthenticatedFetch(t *testing.T) {
 
 	metadataBefore := metadataCount.Load()
 	archiveBefore := archiveCount.Load()
-	err = lc.SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{})
+	err = lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{})
 	if err != nil {
 		t.Fatalf("SyncAtPathsWithStatePaths: %v", err)
 	}
@@ -4522,7 +4524,7 @@ func TestSourceAppLoadForExecution_RehydratesWhenCachedManifestVersionMismatches
 	}
 
 	downloadsBefore := downloadCount.Load()
-	if err := lc.SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
+	if err := lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{}); err != nil {
 		t.Fatalf("SyncAtPathsWithStatePaths: %v", err)
 	}
 	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
@@ -4683,7 +4685,7 @@ func TestSourceAuthAppLoadForExecution(t *testing.T) {
 	}
 
 	downloadsBefore := downloadCount.Load()
-	err = lc.SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{})
+	err = lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{})
 	if err != nil {
 		t.Fatalf("SyncAtPathsWithStatePaths after cache removal: %v", err)
 	}
@@ -4902,10 +4904,10 @@ func TestLockAndSyncSkipRuntimeOnlySecretRefs(t *testing.T) {
 	if err := lc.CheckLockAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
 		t.Fatalf("CheckLockAtPathsWithStatePaths: %v", err)
 	}
-	if err := lc.SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
+	if err := lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{}); err != nil {
 		t.Fatalf("SyncAtPathsWithStatePaths: %v", err)
 	}
-	if err := lc.CheckSyncAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
+	if err := lc.CheckSyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{}); err != nil {
 		t.Fatalf("CheckSyncAtPathsWithStatePaths: %v", err)
 	}
 	if fullResolverCalled.Load() {
@@ -5282,7 +5284,7 @@ packages:
 	appMetadataBefore := appMetadataCount.Load()
 	secretsArchivesBefore := secretsArchiveCount.Load()
 	appArchivesBefore := appArchiveCount.Load()
-	if err := lc.SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
+	if err := lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{}); err != nil {
 		if handlerErr := nextHandlerErr(); handlerErr != nil {
 			t.Fatal(handlerErr)
 		}
@@ -5985,7 +5987,7 @@ func TestSourceSecretsAppBootstrapsManagedAuthSourceToken(t *testing.T) {
 	authMetadataBefore := authMetadataCount.Load()
 	secretsDownloadsBefore := secretsDownloads.Load()
 	authDownloadsBefore := authDownloads.Load()
-	err = lc.SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{})
+	err = lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{})
 	if err != nil {
 		t.Fatalf("SyncAtPathsWithStatePaths: %v", err)
 	}

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -1879,7 +1879,7 @@ server:
 		t.Fatalf("WriteLockfile: %v", err)
 	}
 
-	if err := lc.SyncAtPathsWithStatePaths([]string{cfgPath}, StatePaths{}); err != nil {
+	if err := lc.SyncAtPathsWithStatePathsOptions([]string{cfgPath}, StatePaths{}, SyncOptions{}); err != nil {
 		t.Fatalf("SyncAtPathsWithStatePaths: %v", err)
 	}
 	loaded, _, err := lc.LoadForExecutionAtPath(cfgPath, true)
@@ -2547,9 +2547,9 @@ func TestLoadForExecutionAtPath_LockedLocalSourcePluginUsesPreparedArtifactWitho
 		}
 	}
 
-	locked, _, err := lc.LoadForExecutionAtPath(cfgPath, true)
+	locked, _, err := lc.LoadForExecutionAtPathsWithStatePaths([]string{cfgPath}, StatePaths{}, true, true)
 	if err != nil {
-		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
+		t.Fatalf("LoadForExecutionAtPath(locked=true, noSync=true): %v", err)
 	}
 	intg := locked.Apps["example"]
 	if intg == nil || intg.ResolvedManifest == nil {


### PR DESCRIPTION
## Summary
- Default `gestaltd sync` composes lock then materialize (no longer requires `--locked`); `--locked` and `--check` enforce fresh lockfile semantics per the product matrices.
- `gestaltd serve --locked` now materializes missing/stale artifacts; new `--no-sync` flag (requires `--locked`) binds prebuilt artifacts as-is for production container startup.
- Replaced `artifactModeReadOnly` with `artifactModeBind` + `toleratesStale()`, removed dead sync wrappers, and added lockfile freshness gates for locked serve/sync.

## Test plan
- [x] `go build ./... && go vet ./internal/operator/ ./internal/daemon/`
- [x] `go test ./internal/operator/ ./internal/daemon/`
- [ ] Verify `gestaltd serve` boots clean without manual lock/sync (fleet dev config)
- [ ] Verify `gestaltd serve --locked --no-sync` skips materialization in production-like image
- [ ] Follow-up (valon-tools): update `deploy/entrypoint.sh` to `serve --locked --no-sync` after this release ships


Made with [Cursor](https://cursor.com)