### PR TITLE
Replace gestaltd serve --path with positional PATH arguments

### DIFF
--- a/gestaltd/internal/daemon/main_test.go
+++ b/gestaltd/internal/daemon/main_test.go
@@ -451,21 +451,6 @@ packages:
 	}
 }
 
-func TestE2ECLIServeAcceptsPositionalPath(t *testing.T) {
-	t.Parallel()
-
-	out, err := exec.Command(gestaltdBin, "serve", "nonexistent-local-path").CombinedOutput()
-	if err == nil {
-		t.Fatalf("gestaltd serve with missing path unexpectedly succeeded:\n%s", out)
-	}
-	if strings.Contains(string(out), "unexpected arguments") {
-		t.Fatalf("positional path was rejected as unexpected argument:\n%s", out)
-	}
-	if strings.Contains(string(out), "flag provided but not defined: -path") {
-		t.Fatalf("serve should not use --path flag:\n%s", out)
-	}
-}
-
 func TestE2ECLIRejectsBadArgs(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/daemon/main_test.go
+++ b/gestaltd/internal/daemon/main_test.go
@@ -55,7 +55,7 @@ func TestE2ECLIHelp(t *testing.T) {
 		{
 			name:      "serve",
 			args:      []string{"serve", "--help"},
-			wantParts: []string{"gestaltd serve --path PATH", "--port PORT", "--no-sync", "dev:"},
+			wantParts: []string{"gestaltd serve [PATH]", "--port PORT", "--no-sync", "--name", "dev:"},
 		},
 		{
 			name:      "provider repo",
@@ -451,6 +451,21 @@ packages:
 	}
 }
 
+func TestE2ECLIServeAcceptsPositionalPath(t *testing.T) {
+	t.Parallel()
+
+	out, err := exec.Command(gestaltdBin, "serve", "nonexistent-local-path").CombinedOutput()
+	if err == nil {
+		t.Fatalf("gestaltd serve with missing path unexpectedly succeeded:\n%s", out)
+	}
+	if strings.Contains(string(out), "unexpected arguments") {
+		t.Fatalf("positional path was rejected as unexpected argument:\n%s", out)
+	}
+	if strings.Contains(string(out), "flag provided but not defined: -path") {
+		t.Fatalf("serve should not use --path flag:\n%s", out)
+	}
+}
+
 func TestE2ECLIRejectsBadArgs(t *testing.T) {
 	t.Parallel()
 
@@ -470,9 +485,9 @@ func TestE2ECLIRejectsBadArgs(t *testing.T) {
 			wantPart: "unexpected arguments: extra",
 		},
 		{
-			name:     "serve trailing args",
-			args:     []string{"serve", "--config", "foo.yaml", "extra"},
-			wantPart: "unexpected arguments: extra",
+			name:     "serve rejects legacy path flag",
+			args:     []string{"serve", "--path", "."},
+			wantPart: "flag provided but not defined: -path",
 		},
 		{
 			name:     "validate trailing args",
@@ -487,11 +502,6 @@ func TestE2ECLIRejectsBadArgs(t *testing.T) {
 		{
 			name:     "provider validate trailing args",
 			args:     []string{"provider", "validate", "--path", ".", "extra"},
-			wantPart: "unexpected arguments: extra",
-		},
-		{
-			name:     "serve path trailing args",
-			args:     []string{"serve", "--path", ".", "extra"},
 			wantPart: "unexpected arguments: extra",
 		},
 	}

--- a/gestaltd/internal/daemon/provider_local.go
+++ b/gestaltd/internal/daemon/provider_local.go
@@ -41,7 +41,7 @@ type providerLocalCommandOptions struct {
 	NoSync       bool
 	ArtifactsDir string
 	LockfilePath string
-	// FleetOverlay is true for serve --path with --config. Validate always leaves
+	// FleetOverlay is true for serve PATH arguments with --config. Validate always leaves
 	// this false so it keeps the synthesized baseline even with --config.
 	FleetOverlay bool
 }
@@ -141,7 +141,7 @@ func buildProviderLocalTargetOverlay(sessionDir string, index int, opts provider
 		return nil, err
 	}
 	if kind != providermanifestv1.KindApp && kind != providermanifestv1.KindUI {
-		return nil, fmt.Errorf("gestaltd serve --path and provider validate only support kind: app or ui in v1 (got %q)", kind)
+		return nil, fmt.Errorf("gestaltd serve PATH arguments and provider validate only support kind: app or ui in v1 (got %q)", kind)
 	}
 	targetManifestPath, err := canonicalPath(manifestPath)
 	if err != nil {

--- a/gestaltd/internal/daemon/provider_local_serve_test.go
+++ b/gestaltd/internal/daemon/provider_local_serve_test.go
@@ -28,8 +28,8 @@ func TestMaybeRunServeProviderLocalRejectsNameWithMultiplePaths(t *testing.T) {
 		ConfigPaths: []string{filepath.Join(t.TempDir(), "config.yaml")},
 		Name:        "demo",
 	})
-	if err == nil || !strings.Contains(err.Error(), "multiple --path") {
-		t.Fatalf("error = %v, want multiple --path name error", err)
+	if err == nil || !strings.Contains(err.Error(), "multiple PATH") {
+		t.Fatalf("error = %v, want multiple PATH name error", err)
 	}
 }
 

--- a/gestaltd/internal/daemon/run.go
+++ b/gestaltd/internal/daemon/run.go
@@ -96,12 +96,10 @@ func runServeCommand(name string, usage func(io.Writer), args []string, opts ser
 	fs.Var(&configPaths, "config", "path to config file (repeat to layer overrides)")
 	artifactsDir := fs.String("artifacts-dir", "", "path to writable prepared-artifacts directory")
 	lockfilePath := fs.String("lockfile", "", "path to lockfile; defaults to gestalt.lock.json next to the primary config")
-	var pathFlags repeatedStringFlag
 	var nameFlag *string
 	portFlag := fs.Int("port", 0, "public listener port; overrides server.public.port. If in use, gestaltd tries the next free port unless --port was given explicitly")
 	if opts.allowProviderLocal {
-		fs.Var(&pathFlags, "path", "provider manifest path or directory for local source serve (repeatable)")
-		nameFlag = fs.String("name", "", "provider key override for --path")
+		nameFlag = fs.String("name", "", "provider key override for a single PATH")
 	}
 	var lockedFlag *bool
 	var noSyncFlag *bool
@@ -109,11 +107,12 @@ func runServeCommand(name string, usage func(io.Writer), args []string, opts ser
 		lockedFlag = fs.Bool("locked", false, "require a fresh lockfile; do not re-resolve metadata")
 		noSyncFlag = fs.Bool("no-sync", false, "do not materialize artifacts; serve pinned artifacts as-is")
 	}
-	if err := fs.Parse(args); err != nil {
+	if err := parseInterspersed(fs, args); err != nil {
 		return err
 	}
-	if fs.NArg() > 0 {
-		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
+	positionals := fs.Args()
+	if !opts.allowProviderLocal && len(positionals) > 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(positionals, " "))
 	}
 
 	var resolvedConfigPaths []string
@@ -142,7 +141,7 @@ func runServeCommand(name string, usage func(io.Writer), args []string, opts ser
 	if opts.allowProviderLocal {
 		ranProviderLocal, err := maybeRunServeProviderLocal(serveProviderLocalOptions{
 			ConfigPaths:   []string(configPaths),
-			Paths:         []string(pathFlags),
+			Paths:         positionals,
 			Name:          flagStringValue(nameFlag),
 			Port:          flagIntValue(portFlag),
 			ArtifactsDir:  *artifactsDir,
@@ -192,18 +191,18 @@ func maybeRunServeProviderLocal(opts serveProviderLocalOptions) (bool, error) {
 
 	if len(paths) == 0 {
 		if name != "" {
-			return false, fmt.Errorf("--name requires --path")
+			return false, fmt.Errorf("--name requires a PATH argument")
 		}
 		return false, nil
 	}
 	if len(paths) > 1 && name != "" {
-		return true, fmt.Errorf("--name cannot be used with multiple --path flags")
+		return true, fmt.Errorf("--name cannot be used with multiple PATH arguments")
 	}
 	if opts.LockedAllowed && opts.Locked && len(opts.ConfigPaths) == 0 {
-		return true, fmt.Errorf("--locked requires --config when using --path")
+		return true, fmt.Errorf("--locked requires --config when serving local PATH arguments")
 	}
 	if len(opts.ConfigPaths) == 0 && (opts.ArtifactsDir != "" || opts.LockfilePath != "") {
-		return true, fmt.Errorf("--artifacts-dir and --lockfile require --config when using --path")
+		return true, fmt.Errorf("--artifacts-dir and --lockfile require --config when serving local PATH arguments")
 	}
 	return true, runServeProviderLocal(providerLocalCommandOptions{
 		Paths:        paths,
@@ -484,8 +483,8 @@ func printMainUsage(w io.Writer) {
 	writeUsageLine(w, "  gestaltd [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH]")
 	writeUsageLine(w, "  gestaltd lock [--config PATH]... [--lockfile PATH] [--check]")
 	writeUsageLine(w, "  gestaltd sync [--locked] [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--parallelism N] [--cache-dir PATH] [--output-format text|json] [-v|--verbose] [--check]")
-	writeUsageLine(w, "  gestaltd serve [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--locked] [--no-sync] [--port PORT]")
-	writeUsageLine(w, "  gestaltd serve --path PATH [--path PATH]... [--config PATH]... [--locked] [--no-sync] [--artifacts-dir PATH] [--lockfile PATH] [--name NAME] [--port PORT]")
+	writeUsageLine(w, "  gestaltd serve [PATH]... [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--locked] [--no-sync] [--port PORT]")
+	writeUsageLine(w, "  gestaltd serve [PATH]... [--config PATH]... [--locked] [--no-sync] [--artifacts-dir PATH] [--lockfile PATH] [--name NAME] [--port PORT]")
 	writeUsageLine(w, "  gestaltd agent <command> [flags]")
 	writeUsageLine(w, "  gestaltd provider <command> [flags]")
 	writeUsageLine(w, "  gestaltd validate [--config PATH]... [--lockfile PATH] [--platform os/arch] [--runtime]")
@@ -507,14 +506,13 @@ func printMainUsage(w io.Writer) {
 
 func printServeUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
-	writeUsageLine(w, "  gestaltd serve [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--locked] [--no-sync] [--port PORT]")
-	writeUsageLine(w, "  gestaltd serve --path PATH [--path PATH]... [--config PATH]... [--locked] [--no-sync] [--artifacts-dir PATH] [--lockfile PATH] [--name NAME] [--port PORT]")
+	writeUsageLine(w, "  gestaltd serve [PATH]... [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--locked] [--no-sync] [--name NAME] [--port PORT]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Start the server. Without --locked, auto lock/syncs if state is missing or stale.")
 	writeUsageLine(w, "--port overrides server.public.port; if the port is in use, gestaltd tries the next free port unless --port was given explicitly.")
-	writeUsageLine(w, "Use --path (repeatable) to override selected UIs to local source trees; with --config and --locked,")
-	writeUsageLine(w, "the fleet loads pinned artifacts while --path UIs with a manifest dev: block hot-reload.")
-	writeUsageLine(w, "Without --config, --path runs an isolated synthesized baseline (unlocked).")
+	writeUsageLine(w, "PATH arguments (repeatable) override selected UIs to local source trees; with --config and --locked,")
+	writeUsageLine(w, "the fleet loads pinned artifacts while PATH UIs with a manifest dev: block hot-reload.")
+	writeUsageLine(w, "Without --config, PATH arguments run an isolated synthesized baseline (unlocked).")
 	writeUsageLine(w, "Local UIs with a manifest dev: block are proxied to a hot-reload dev server automatically.")
 	writeUsageLine(w, "For production, use --locked --no-sync to trust the committed lockfile and prebuilt")
 	writeUsageLine(w, "artifacts without materialization or staleness checks.")

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -994,7 +994,7 @@ func (l *Lifecycle) markDevActiveUIProviders(cfg *config.Config) error {
 		}
 		if providerpkg.EffectiveDev(manifest) == nil {
 			if l.forcedDevUIKeys[name] {
-				return fmt.Errorf("--path target %q has no dev: block; cannot dev-serve under --locked", name)
+				return fmt.Errorf("PATH argument %q has no dev: block; cannot dev-serve under --locked", name)
 			}
 			continue
 		}
@@ -1496,7 +1496,7 @@ func (l *Lifecycle) lockForSecretsBootstrap(configPaths []string, state StatePat
 	}
 	lock, err = l.autoRelockAtPathsIfNeeded(configPaths, state, cfg, paths, lock, locked, err)
 	if err != nil {
-		return nil, fmt.Errorf("source-backed providers require lock metadata; full config mode prepares all source-backed providers. For local single-app development, use `gestaltd serve --path PATH` or a layered local config; otherwise run `%s` then `%s`: %w", formatLockCommand(paths), formatSyncLockedCommand(paths), err)
+		return nil, fmt.Errorf("source-backed providers require lock metadata; full config mode prepares all source-backed providers. For local single-app development, use `gestaltd serve PATH` or a layered local config; otherwise run `%s` then `%s`: %w", formatLockCommand(paths), formatSyncLockedCommand(paths), err)
 	}
 	return lock, nil
 }
@@ -3564,7 +3564,7 @@ func (l *Lifecycle) applyLockedProviders(configPaths []string, state StatePaths,
 	}
 	lock, err = l.autoRelockAtPathsIfNeeded(configPaths, state, cfg, paths, lock, locked, err)
 	if err != nil {
-		return fmt.Errorf("source-backed providers require lock metadata; full config mode prepares all source-backed providers. For local single-app development, use `gestaltd serve --path PATH` or a layered local config; otherwise run `%s` then `%s`: %w", formatLockCommand(paths), formatSyncLockedCommand(paths), err)
+		return fmt.Errorf("source-backed providers require lock metadata; full config mode prepares all source-backed providers. For local single-app development, use `gestaltd serve PATH` or a layered local config; otherwise run `%s` then `%s`: %w", formatLockCommand(paths), formatSyncLockedCommand(paths), err)
 	}
 	if locked && configRequiresCommittedLock(cfg) && !lockFreshForConfig(cfg, paths, lock, lockFreshnessOptions{}) {
 		return lockMetadataStaleError(paths, "lockfile stale")


### PR DESCRIPTION
## Summary
- `gestaltd serve` accepts local app/UI source paths as positional arguments (`gestaltd serve PATH... [flags]`), including interleaved before or after flags via `parseInterspersed`.
- Removes the `--path` flag entirely (no deprecated alias); bare `gestaltd` still rejects stray positionals.
- Updates validation errors, help text, and user-facing operator messages to reference positional PATH instead of `--path`.

## Follow-up
- toolshed PR to migrate local-dev docs from `--path` to positionals (blocked on releasing this CLI change).

## Test plan
- [x] `go build ./... && go vet ./internal/daemon/ && go test ./internal/daemon/`
- [ ] `gestaltd serve apps/foo/ui --config A --config B` (positional before flags)
- [ ] `gestaltd serve --config A apps/foo/ui` (positional after flags)
- [ ] `gestaltd serve --path foo` fails with unknown flag
- [ ] `gestaltd --config x foo` still rejects stray positional


Made with [Cursor](https://cursor.com)