### PR TITLE
Apply --port and next-free-port fallback to positional-PATH serve

### DIFF
--- a/gestaltd/internal/daemon/provider_local.go
+++ b/gestaltd/internal/daemon/provider_local.go
@@ -57,6 +57,7 @@ type providerLocalSession struct {
 	State             operator.StatePaths
 	Locked            bool
 	NoSync            bool
+	PublicPort        int
 	PublicURL         string
 	AdminURL          string
 	PublicUIPaths     []string
@@ -127,6 +128,12 @@ func runServeProviderLocal(opts providerLocalCommandOptions) error {
 	if err != nil {
 		return err
 	}
+	if err := resolveServePort(env.Config, session.PublicPort); err != nil {
+		env.Close()
+		return err
+	}
+	session.PublicURL = providerLocalPublicURL(env.Config)
+	session.AdminURL = strings.TrimRight(session.PublicURL, "/") + "/admin/"
 	logProviderLocalSummary("local provider ready", session)
 	return runServer(env)
 }
@@ -279,10 +286,9 @@ func prepareProviderLocalSession(opts providerLocalCommandOptions) (*providerLoc
 	}
 	locked := opts.Locked && opts.FleetOverlay
 	noSync := opts.NoSync && opts.FleetOverlay
-	port := opts.Port
+	devPort := 0
 	if opts.FleetOverlay {
 		configPaths = append([]string(nil), opts.ConfigPaths...)
-		port = 0
 	} else {
 		baseConfigPath := filepath.Join(sessionDir, "provider-base.yaml")
 		dbPath := filepath.Join(sessionDir, "provider.db")
@@ -295,13 +301,11 @@ func prepareProviderLocalSession(opts providerLocalCommandOptions) (*providerLoc
 			LockfilePath: filepath.Join(sessionDir, "gestalt.lock.json"),
 		}
 		locked = false
-		if port == 0 {
-			selectedPort, err := reserveLocalPort()
-			if err != nil {
-				return nil, err
-			}
-			port = selectedPort
+		selectedPort, err := reserveLocalPort()
+		if err != nil {
+			return nil, err
 		}
+		devPort = selectedPort
 	}
 
 	var (
@@ -311,7 +315,7 @@ func prepareProviderLocalSession(opts providerLocalCommandOptions) (*providerLoc
 		lastOverlay *providerLocalTargetOverlay
 	)
 	for i, path := range opts.Paths {
-		overlay, err := buildProviderLocalTargetOverlay(sessionDir, i, opts, path, port, configPaths)
+		overlay, err := buildProviderLocalTargetOverlay(sessionDir, i, opts, path, devPort, configPaths)
 		if err != nil {
 			return nil, err
 		}
@@ -347,6 +351,7 @@ func prepareProviderLocalSession(opts providerLocalCommandOptions) (*providerLoc
 		State:         state,
 		Locked:        locked,
 		NoSync:        noSync,
+		PublicPort:    opts.Port,
 		PublicURL:     providerLocalPublicURL(loadedCfg),
 		AdminURL:      strings.TrimRight(providerLocalPublicURL(loadedCfg), "/") + "/admin/",
 		PublicUIPaths: publicUIPaths,


### PR DESCRIPTION
## Problem

When `gestaltd serve <PATH>... --config …` serves local source trees by positional PATH, startup goes through the provider-local code path, which calls `runServer` directly and **never resolves the public listener port**. So:

- `--port` was silently ignored (the public listener always used the config's port, default 8080).
- There was no next-free-port fallback.

This breaks concurrent local development across worktrees: running two apps in two worktrees both try to bind 8080 and the second crash-loops with `bind: address already in use`. Surfaced while testing the one-command local-dev flow with g-issues and valon-profile in separate worktrees.

## Fix

Wire `resolveServePort` into `runServeProviderLocal` so the positional-PATH serve path matches the bare `serve` semantics:

- Explicit `--port` pins the port and fails fast if it is in use.
- Unset `--port` scans for the next free port from the configured one.

The internal hot-reload dev-server port is now always auto-assigned and decoupled from `--port` (previously `--port` doubled as the dev-server port in the no-`--config` baseline), and the "local provider ready" log reflects the port actually bound.

## Validation

Built from this branch and ran the documented one-command flow against the Valon Tools fleet in two `origin/main` worktrees:

- g-issues (no `--port`) → bound 8080.
- valon-profile (no `--port`), launched concurrently → auto-picked 8081 (`port in use; using next free port`). Both served 200; previously the second crashed.
- Explicit `--port 8080` while 8080 was busy → `port 8080 is in use; free it or specify a different port`, exit 1 (pins, no fallback).

Added `TestPrepareProviderLocalOverlaySessionForwardsPublicPort`; full `./internal/daemon/` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)