### PR TITLE
Remove --name provider key override from serve and provider validate

### DIFF
--- a/gestaltd/internal/daemon/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e_test.go
@@ -453,17 +453,19 @@ func TestE2EProviderValidateReusesConfiguredAppKey(t *testing.T) {
 	dir := t.TempDir()
 	providersDir := setupDefaultLocalProvidersDir(t, dir)
 	appDir := setupAppDir(t, dir)
+	manifestPath := componentProviderManifestPath(t, appDir)
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := `apiVersion: gestaltd.config/v8
+	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v8
 apps:
   provider_go:
-    source: https://example.test/provider-release.yaml
-`
+    source:
+      path: %s
+`, manifestPath)
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 
-	cmd := exec.Command(gestaltdBin, "provider", "validate", "--path", appDir, "--config", cfgPath, "--name", "provider_go")
+	cmd := exec.Command(gestaltdBin, "provider", "validate", "--path", appDir, "--config", cfgPath)
 	cmd.Env = append(os.Environ(),
 		"GESTALT_PROVIDERS_DIR="+providersDir,
 		"GOTELEMETRY=off",

--- a/gestaltd/internal/daemon/main_test.go
+++ b/gestaltd/internal/daemon/main_test.go
@@ -55,7 +55,7 @@ func TestE2ECLIHelp(t *testing.T) {
 		{
 			name:      "serve",
 			args:      []string{"serve", "--help"},
-			wantParts: []string{"gestaltd serve [PATH]", "--port PORT", "--no-sync", "--name", "dev:"},
+			wantParts: []string{"gestaltd serve [PATH]", "--port PORT", "--no-sync", "dev:"},
 		},
 		{
 			name:      "provider repo",

--- a/gestaltd/internal/daemon/provider_local.go
+++ b/gestaltd/internal/daemon/provider_local.go
@@ -35,7 +35,6 @@ const (
 type providerLocalCommandOptions struct {
 	Paths        []string
 	ConfigPaths  []string
-	Name         string
 	Port         int
 	Locked       bool
 	NoSync       bool
@@ -79,7 +78,6 @@ func runProviderValidate(args []string) error {
 	var configPaths repeatedStringFlag
 	fs.Var(&configPaths, "config", "path to config file (repeat to layer overrides)")
 	pathFlag := fs.String("path", "", "provider manifest path or directory (defaults to current working directory)")
-	nameFlag := fs.String("name", "", "provider key override")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -90,7 +88,6 @@ func runProviderValidate(args []string) error {
 	session, err := prepareProviderLocalSession(providerLocalCommandOptions{
 		Paths:       []string{*pathFlag},
 		ConfigPaths: []string(configPaths),
-		Name:        *nameFlag,
 		Port:        8080,
 	})
 	if err != nil {
@@ -164,7 +161,7 @@ func buildProviderLocalTargetOverlay(sessionDir string, index int, opts provider
 
 	switch kind {
 	case providermanifestv1.KindUI:
-		resolvedKey, err := resolveProviderLocalUIKey(opts.ConfigPaths, targetManifestPath, manifest, opts.Name)
+		resolvedKey, err := resolveProviderLocalUIKey(opts.ConfigPaths, targetManifestPath, manifest)
 		if err != nil {
 			return nil, err
 		}
@@ -182,7 +179,7 @@ func buildProviderLocalTargetOverlay(sessionDir string, index int, opts provider
 		result.mountPath = mountPath
 		return result, nil
 	case providermanifestv1.KindApp:
-		resolvedKey, err := resolveProviderLocalPluginKey(opts.ConfigPaths, targetManifestPath, manifest, opts.Name)
+		resolvedKey, err := resolveProviderPluginKey(opts.ConfigPaths, targetManifestPath, manifest, loadConfiguredPlugins)
 		if err != nil {
 			return nil, err
 		}
@@ -393,11 +390,7 @@ func resolveProviderTargetManifest(pathFlag string) (string, *providermanifestv1
 	return manifestPath, manifest, nil
 }
 
-func resolveProviderLocalPluginKey(configPaths []string, targetManifestPath string, manifest *providermanifestv1.Manifest, explicitName string) (string, error) {
-	return resolveProviderPluginKey(configPaths, targetManifestPath, manifest, explicitName, loadConfiguredPlugins)
-}
-
-func resolveProviderPluginKey(configPaths []string, targetManifestPath string, manifest *providermanifestv1.Manifest, explicitName string, loadApps func([]string) (map[string]*config.ProviderEntry, error)) (string, error) {
+func resolveProviderPluginKey(configPaths []string, targetManifestPath string, manifest *providermanifestv1.Manifest, loadApps func([]string) (map[string]*config.ProviderEntry, error)) (string, error) {
 	plugins, err := loadApps(configPaths)
 	if err != nil {
 		return "", err
@@ -407,24 +400,11 @@ func resolveProviderPluginKey(configPaths []string, targetManifestPath string, m
 		return "", err
 	}
 
-	if explicitName != "" {
-		if !isValidExplicitPluginKey(explicitName) {
-			return "", fmt.Errorf("invalid --name %q: use only letters, numbers, and underscores", explicitName)
-		}
-		if len(matchingKeys) == 1 && matchingKeys[0] != explicitName {
-			return "", fmt.Errorf("target manifest is already configured as apps.%s; pass --name %q or remove the conflicting config entry", matchingKeys[0], matchingKeys[0])
-		}
-		if len(matchingKeys) > 1 && !slices.Contains(matchingKeys, explicitName) {
-			return "", fmt.Errorf("target manifest is configured by multiple app keys (%s); remove the ambiguity before using --name", strings.Join(matchingKeys, ", "))
-		}
-		return explicitName, nil
-	}
-
 	if len(matchingKeys) == 1 {
 		return matchingKeys[0], nil
 	}
 	if len(matchingKeys) > 1 {
-		return "", fmt.Errorf("target manifest is configured by multiple app keys (%s); pass --name to choose the target key", strings.Join(matchingKeys, ", "))
+		return "", fmt.Errorf("target manifest is configured by multiple app keys (%s); remove the ambiguity in config", strings.Join(matchingKeys, ", "))
 	}
 
 	if name := derivedPluginKey(manifest, targetManifestPath); name != "" {
@@ -433,7 +413,7 @@ func resolveProviderPluginKey(configPaths []string, targetManifestPath string, m
 		}
 		return name, nil
 	}
-	return "", fmt.Errorf("unable to derive an app key for %s; pass --name", targetManifestPath)
+	return "", fmt.Errorf("unable to derive an app key for %s; set a manifest source app name or rename the directory", targetManifestPath)
 }
 
 func writeProviderLocalBaseConfig(path, dbPath string) error {
@@ -850,17 +830,27 @@ func sanitizeProviderLocalMountSlug(value string) string {
 	return strings.Trim(b.String(), "-_.")
 }
 
-func isValidExplicitPluginKey(value string) bool {
-	if value == "" {
-		return false
+func resolveProviderLocalUIKey(configPaths []string, targetManifestPath string, manifest *providermanifestv1.Manifest) (string, error) {
+	uis, err := loadConfiguredUIs(configPaths)
+	if err != nil {
+		return "", err
 	}
-	for _, r := range value {
-		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' {
-			continue
-		}
-		return false
+	matchingKeys, err := matchingUIKeys(uis, targetManifestPath)
+	if err != nil {
+		return "", err
 	}
-	return true
+
+	if len(matchingKeys) == 1 {
+		return matchingKeys[0], nil
+	}
+	if len(matchingKeys) > 1 {
+		return "", fmt.Errorf("target manifest is configured by multiple ui keys (%s); remove the ambiguity in config", strings.Join(matchingKeys, ", "))
+	}
+
+	if name := derivedPluginKey(manifest, targetManifestPath); name != "" {
+		return name, nil
+	}
+	return "", fmt.Errorf("unable to derive a ui key for %s; set a manifest source app name or rename the directory", targetManifestPath)
 }
 
 func loadConfiguredPlugins(configPaths []string) (map[string]*config.ProviderEntry, error) {
@@ -906,42 +896,6 @@ func matchingPluginKeys(plugins map[string]*config.ProviderEntry, targetManifest
 	}
 	slices.Sort(matches)
 	return matches, nil
-}
-
-func resolveProviderLocalUIKey(configPaths []string, targetManifestPath string, manifest *providermanifestv1.Manifest, explicitName string) (string, error) {
-	uis, err := loadConfiguredUIs(configPaths)
-	if err != nil {
-		return "", err
-	}
-	matchingKeys, err := matchingUIKeys(uis, targetManifestPath)
-	if err != nil {
-		return "", err
-	}
-
-	if explicitName != "" {
-		if !isValidExplicitPluginKey(explicitName) {
-			return "", fmt.Errorf("invalid --name %q: use only letters, numbers, and underscores", explicitName)
-		}
-		if len(matchingKeys) == 1 && matchingKeys[0] != explicitName {
-			return "", fmt.Errorf("target manifest is already configured as providers.ui.%s; pass --name %q or remove the conflicting config entry", matchingKeys[0], matchingKeys[0])
-		}
-		if len(matchingKeys) > 1 && !slices.Contains(matchingKeys, explicitName) {
-			return "", fmt.Errorf("target manifest is configured by multiple ui keys (%s); remove the ambiguity before using --name", strings.Join(matchingKeys, ", "))
-		}
-		return explicitName, nil
-	}
-
-	if len(matchingKeys) == 1 {
-		return matchingKeys[0], nil
-	}
-	if len(matchingKeys) > 1 {
-		return "", fmt.Errorf("target manifest is configured by multiple ui keys (%s); pass --name to choose the target key", strings.Join(matchingKeys, ", "))
-	}
-
-	if name := derivedPluginKey(manifest, targetManifestPath); name != "" {
-		return name, nil
-	}
-	return "", fmt.Errorf("unable to derive a ui key for %s; pass --name", targetManifestPath)
 }
 
 func matchingUIKeys(entries map[string]*config.UIEntry, targetManifestPath string) ([]string, error) {
@@ -1004,7 +958,7 @@ func writeYAMLFile(path string, value any) error {
 
 func printProviderValidateUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
-	writeUsageLine(w, "  gestaltd provider validate [--path PATH] [--config PATH]... [--name NAME]")
+	writeUsageLine(w, "  gestaltd provider validate [--path PATH] [--config PATH]...")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Validate a local source app or ui inside a synthesized Gestalt config.")
 	writeUsageLine(w, "v1 supports kind: app and kind: ui manifests.")
@@ -1013,5 +967,4 @@ func printProviderValidateUsage(w io.Writer) {
 	writeUsageLine(w, "Flags:")
 	writeUsageLine(w, "  --path     Provider manifest path or directory (default: current working directory)")
 	writeUsageLine(w, "  --config   Additional config file to merge; repeat to add support providers or null deletions")
-	writeUsageLine(w, "  --name     Provider key override when the target key is ambiguous")
 }

--- a/gestaltd/internal/daemon/provider_local_serve_test.go
+++ b/gestaltd/internal/daemon/provider_local_serve_test.go
@@ -20,19 +20,6 @@ func TestMaybeRunServeProviderLocalRejectsLockedWithoutConfig(t *testing.T) {
 	}
 }
 
-func TestMaybeRunServeProviderLocalRejectsNameWithMultiplePaths(t *testing.T) {
-	t.Parallel()
-
-	_, err := maybeRunServeProviderLocal(serveProviderLocalOptions{
-		Paths:       []string{"./ui/a", "./ui/b"},
-		ConfigPaths: []string{filepath.Join(t.TempDir(), "config.yaml")},
-		Name:        "demo",
-	})
-	if err == nil || !strings.Contains(err.Error(), "multiple PATH") {
-		t.Fatalf("error = %v, want multiple PATH name error", err)
-	}
-}
-
 func TestMaybeRunServeProviderLocalRejectsStatePathsWithoutConfig(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/daemon/run.go
+++ b/gestaltd/internal/daemon/run.go
@@ -96,11 +96,7 @@ func runServeCommand(name string, usage func(io.Writer), args []string, opts ser
 	fs.Var(&configPaths, "config", "path to config file (repeat to layer overrides)")
 	artifactsDir := fs.String("artifacts-dir", "", "path to writable prepared-artifacts directory")
 	lockfilePath := fs.String("lockfile", "", "path to lockfile; defaults to gestalt.lock.json next to the primary config")
-	var nameFlag *string
 	portFlag := fs.Int("port", 0, "public listener port; overrides server.public.port. If in use, gestaltd tries the next free port unless --port was given explicitly")
-	if opts.allowProviderLocal {
-		nameFlag = fs.String("name", "", "provider key override for a single PATH")
-	}
 	var lockedFlag *bool
 	var noSyncFlag *bool
 	if opts.allowLocked {
@@ -142,7 +138,6 @@ func runServeCommand(name string, usage func(io.Writer), args []string, opts ser
 		ranProviderLocal, err := maybeRunServeProviderLocal(serveProviderLocalOptions{
 			ConfigPaths:   []string(configPaths),
 			Paths:         positionals,
-			Name:          flagStringValue(nameFlag),
 			Port:          flagIntValue(portFlag),
 			ArtifactsDir:  *artifactsDir,
 			LockfilePath:  *lockfilePath,
@@ -171,7 +166,6 @@ func runServeCommand(name string, usage func(io.Writer), args []string, opts ser
 type serveProviderLocalOptions struct {
 	ConfigPaths   []string
 	Paths         []string
-	Name          string
 	Port          int
 	ArtifactsDir  string
 	LockfilePath  string
@@ -187,16 +181,8 @@ func maybeRunServeProviderLocal(opts serveProviderLocalOptions) (bool, error) {
 			paths = append(paths, trimmed)
 		}
 	}
-	name := strings.TrimSpace(opts.Name)
-
 	if len(paths) == 0 {
-		if name != "" {
-			return false, fmt.Errorf("--name requires a PATH argument")
-		}
 		return false, nil
-	}
-	if len(paths) > 1 && name != "" {
-		return true, fmt.Errorf("--name cannot be used with multiple PATH arguments")
 	}
 	if opts.LockedAllowed && opts.Locked && len(opts.ConfigPaths) == 0 {
 		return true, fmt.Errorf("--locked requires --config when serving local PATH arguments")
@@ -207,20 +193,12 @@ func maybeRunServeProviderLocal(opts serveProviderLocalOptions) (bool, error) {
 	return true, runServeProviderLocal(providerLocalCommandOptions{
 		Paths:        paths,
 		ConfigPaths:  opts.ConfigPaths,
-		Name:         name,
 		Port:         opts.Port,
 		Locked:       opts.Locked,
 		NoSync:       opts.NoSync,
 		ArtifactsDir: opts.ArtifactsDir,
 		LockfilePath: opts.LockfilePath,
 	})
-}
-
-func flagStringValue(flag *string) string {
-	if flag == nil {
-		return ""
-	}
-	return *flag
 }
 
 func flagIntValue(flag *int) int {
@@ -484,7 +462,7 @@ func printMainUsage(w io.Writer) {
 	writeUsageLine(w, "  gestaltd lock [--config PATH]... [--lockfile PATH] [--check]")
 	writeUsageLine(w, "  gestaltd sync [--locked] [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--parallelism N] [--cache-dir PATH] [--output-format text|json] [-v|--verbose] [--check]")
 	writeUsageLine(w, "  gestaltd serve [PATH]... [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--locked] [--no-sync] [--port PORT]")
-	writeUsageLine(w, "  gestaltd serve [PATH]... [--config PATH]... [--locked] [--no-sync] [--artifacts-dir PATH] [--lockfile PATH] [--name NAME] [--port PORT]")
+	writeUsageLine(w, "  gestaltd serve [PATH]... [--config PATH]... [--locked] [--no-sync] [--artifacts-dir PATH] [--lockfile PATH] [--port PORT]")
 	writeUsageLine(w, "  gestaltd agent <command> [flags]")
 	writeUsageLine(w, "  gestaltd provider <command> [flags]")
 	writeUsageLine(w, "  gestaltd validate [--config PATH]... [--lockfile PATH] [--platform os/arch] [--runtime]")
@@ -506,7 +484,7 @@ func printMainUsage(w io.Writer) {
 
 func printServeUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
-	writeUsageLine(w, "  gestaltd serve [PATH]... [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--locked] [--no-sync] [--name NAME] [--port PORT]")
+	writeUsageLine(w, "  gestaltd serve [PATH]... [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--locked] [--no-sync] [--port PORT]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Start the server. Without --locked, auto lock/syncs if state is missing or stale.")
 	writeUsageLine(w, "--port overrides server.public.port; if the port is in use, gestaltd tries the next free port unless --port was given explicitly.")


### PR DESCRIPTION
## Summary
- Remove the `--name` flag from `gestaltd serve` and `gestaltd provider validate`; local PATH targets now resolve provider keys only via config match or derivation.
- Delete `isValidExplicitPluginKey`, the explicit-name conflict checks, and related usage text/tests.
- Reword surviving ambiguity/derivation errors to guide users toward manifest source names or config cleanup instead of `--name`.

## Test plan
- [x] `go build ./gestaltd/...`
- [x] `go test ./gestaltd/internal/daemon/...`
- [x] `gestaltd serve --help` and `gestaltd provider validate --help` no longer list `--name`
- [x] `provider_local_session_test.go` derivation assertions unchanged
- [x] `gestaltd provider add --name` preserved (distinct feature)


Made with [Cursor](https://cursor.com)