### PR TITLE
Keep checked-in catalog.yaml for manifest-backed apps during packaging

### DIFF
--- a/gestaltd/services/apps/providerpkg/source_prepare.go
+++ b/gestaltd/services/apps/providerpkg/source_prepare.go
@@ -26,9 +26,16 @@ func prepareSourceManifestForPreparedInstallWithOptions(manifestPath string, opt
 }
 
 // Local prepare may create catalog.yaml from run; packaging must regenerate it
-// from the packaged entrypoint instead.
+// from the packaged entrypoint instead. Manifest-backed apps keep checked-in
+// catalog.yaml because generateSourceStaticCatalog does not run for them.
 func explicitRunStaleCatalog(manifest *providermanifestv1.Manifest) bool {
-	return HasExplicitSourceRun(manifest)
+	if !HasExplicitSourceRun(manifest) {
+		return false
+	}
+	if manifest != nil && manifest.Spec != nil && manifest.Spec.IsManifestBacked() {
+		return false
+	}
+	return true
 }
 
 func prepareSourceManifest(manifestPath string, packaging bool, buildOpts SourceBuildOptions) ([]byte, *providermanifestv1.Manifest, error) {


### PR DESCRIPTION
## Summary
- Stop deleting `catalog.yaml` during packaging when an app has explicit `run:` but is manifest-backed (OpenAPI/GraphQL/MCP surfaces).
- `generateSourceStaticCatalog` already skips those apps; refreshing the catalog left hybrid providers like gmail without static operations such as `labels.list`.

## Test plan
- [x] `go test ./services/apps/providerpkg/ -run TestExplicitRunStaleCatalog`
- [ ] Merge and re-run gestalt-providers PR #1097 `Validate app/gmail`


Made with [Cursor](https://cursor.com)