### PR TITLE
[gestaltd] split build workflow into CI and CD with reusable steps

### DIFF
--- a/.github/actions/build-gestaltd-image/action.yml
+++ b/.github/actions/build-gestaltd-image/action.yml
@@ -1,0 +1,200 @@
+name: Build gestaltd CI image
+description: >-
+  Build the static gestaltd image and optionally push it to Artifact Registry.
+  When push is false the image is built (and discarded) to validate the
+  Dockerfile; when push is true it is built, pushed by immutable per-commit tag
+  with SBOM + provenance attestations, and smoke-tested. Registry variables and
+  GCP identity are passed in by the caller, which must grant id-token: write
+  when pushing.
+
+inputs:
+  push:
+    description: "'true' to push to Artifact Registry, 'false' to build only."
+    required: true
+  sha:
+    description: Full commit SHA being built.
+    required: true
+  version:
+    description: Version string stamped into the binary (e.g. 0.0.0-ci+g<sha12>).
+    required: true
+  build-alpine:
+    description: "'true' to also build the alpine target for validation (never pushed)."
+    required: false
+    default: 'false'
+  registry-host:
+    description: Artifact Registry host (required when push is true).
+    required: false
+    default: ''
+  image-repository:
+    description: CI image repository, e.g. <host>/<project>/gestaltd-ci/gestaltd (required when push is true).
+    required: false
+    default: ''
+  gcp-service-account:
+    description: GCP service account for Workload Identity Federation (required when push is true).
+    required: false
+    default: ''
+  gcp-workload-identity-provider:
+    description: GCP Workload Identity provider (required when push is true).
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Compute image metadata
+      id: meta
+      shell: bash
+      run: echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "${GITHUB_OUTPUT}"
+
+    - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+    - name: Validate image configuration
+      if: ${{ inputs.push == 'true' }}
+      shell: bash
+      env:
+        GESTALTD_ARTIFACT_REGISTRY_HOST: ${{ inputs.registry-host }}
+        GESTALTD_CI_IMAGE_REPOSITORY: ${{ inputs.image-repository }}
+        GESTALTD_CI_GCP_SERVICE_ACCOUNT: ${{ inputs.gcp-service-account }}
+        GESTALTD_CI_GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ inputs.gcp-workload-identity-provider }}
+      run: |
+        set -euo pipefail
+        : "${GESTALTD_ARTIFACT_REGISTRY_HOST:?registry-host input is required when pushing}"
+        : "${GESTALTD_CI_IMAGE_REPOSITORY:?image-repository input is required when pushing}"
+        : "${GESTALTD_CI_GCP_SERVICE_ACCOUNT:?gcp-service-account input is required when pushing}"
+        : "${GESTALTD_CI_GCP_WORKLOAD_IDENTITY_PROVIDER:?gcp-workload-identity-provider input is required when pushing}"
+
+    - name: Authenticate to Google Cloud
+      id: gcp-auth
+      if: ${{ inputs.push == 'true' }}
+      uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
+      with:
+        workload_identity_provider: ${{ inputs.gcp-workload-identity-provider }}
+        service_account: ${{ inputs.gcp-service-account }}
+        token_format: access_token
+
+    - name: Authenticate to Artifact Registry
+      if: ${{ inputs.push == 'true' }}
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+      with:
+        registry: ${{ inputs.registry-host }}
+        username: oauth2accesstoken
+        password: ${{ steps.gcp-auth.outputs.access_token }}
+
+    - name: Check for existing CI image
+      id: existing-image
+      if: ${{ inputs.push == 'true' }}
+      shell: bash
+      env:
+        GESTALTD_CI_IMAGE_REPOSITORY: ${{ inputs.image-repository }}
+        GESTALTD_COMMIT: ${{ inputs.sha }}
+      run: |
+        set -euo pipefail
+        image="${GESTALTD_CI_IMAGE_REPOSITORY}:sha-${GESTALTD_COMMIT}"
+
+        if digest="$(docker buildx imagetools inspect "${image}" --format '{{.Manifest.Digest}}' 2>/dev/null)"; then
+          exists="true"
+        else
+          exists="false"
+          digest=""
+        fi
+
+        {
+          echo "image=${image}"
+          echo "exists=${exists}"
+          echo "digest=${digest}"
+        } >> "${GITHUB_OUTPUT}"
+
+    # Static image: built on every run; pushed only when publishing and not
+    # already present. On build-only runs this validates the build without a
+    # push (and without attestations, which require an image/oci exporter).
+    - name: Build CI image (static)
+      id: ci-image
+      if: ${{ inputs.push != 'true' || steps.existing-image.outputs.exists != 'true' }}
+      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+      with:
+        context: .
+        file: gestaltd/Dockerfile
+        target: static
+        push: ${{ inputs.push == 'true' }}
+        platforms: linux/amd64
+        tags: ${{ inputs.push == 'true' && format('{0}:sha-{1}', inputs.image-repository, inputs.sha) || 'gestaltd:ci-static' }}
+        build-args: |
+          GESTALT_VERSION=${{ inputs.version }}
+          GESTALT_REVISION=${{ inputs.sha }}
+          GESTALT_CREATED=${{ steps.meta.outputs.created }}
+          GESTALT_SOURCE=https://github.com/${{ github.repository }}
+          GESTALT_DOCUMENTATION=https://gestaltd.ai
+          GESTALT_URL=${{ inputs.push == 'true' && format('{0}:sha-{1}', inputs.image-repository, inputs.sha) || 'gestaltd:ci-static' }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        sbom: ${{ inputs.push == 'true' }}
+        provenance: ${{ inputs.push == 'true' && 'mode=max' || 'false' }}
+
+    # Alpine target: build-only packaging validation, never pushed. Reuses the
+    # compiled build-binary layer from the static build above (a few seconds).
+    - name: Build CI image (alpine, validation only)
+      if: ${{ inputs.build-alpine == 'true' }}
+      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+      with:
+        context: .
+        file: gestaltd/Dockerfile
+        target: alpine
+        push: false
+        platforms: linux/amd64
+        tags: gestaltd:ci-alpine
+        build-args: |
+          GESTALT_VERSION=${{ inputs.version }}
+        cache-from: type=gha
+
+    - name: Resolve published image
+      id: published-image
+      if: ${{ inputs.push == 'true' }}
+      shell: bash
+      env:
+        EXISTING_DIGEST: ${{ steps.existing-image.outputs.digest }}
+        GESTALTD_CI_IMAGE_REPOSITORY: ${{ inputs.image-repository }}
+        GESTALTD_COMMIT: ${{ inputs.sha }}
+        PUSHED_DIGEST: ${{ steps.ci-image.outputs.digest }}
+      run: |
+        set -euo pipefail
+        digest="${PUSHED_DIGEST:-${EXISTING_DIGEST}}"
+        : "${digest:?Expected a pushed or existing image digest}"
+        image="${GESTALTD_CI_IMAGE_REPOSITORY}:sha-${GESTALTD_COMMIT}@${digest}"
+        {
+          echo "digest=${digest}"
+          echo "image=${image}"
+        } >> "${GITHUB_OUTPUT}"
+
+    - name: Smoke test CI image
+      if: ${{ inputs.push == 'true' }}
+      shell: bash
+      env:
+        GESTALTD_CI_IMAGE: ${{ steps.published-image.outputs.image }}
+        GESTALTD_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        actual_version="$(docker run --rm "${GESTALTD_CI_IMAGE}" version)"
+        if [[ "${actual_version}" != "${GESTALTD_VERSION}" ]]; then
+          echo "gestaltd version output '${actual_version}' did not match expected '${GESTALTD_VERSION}'." >&2
+          exit 1
+        fi
+
+    - name: Summarize CI image
+      if: ${{ inputs.push == 'true' }}
+      shell: bash
+      env:
+        GESTALTD_CI_IMAGE: ${{ steps.published-image.outputs.image }}
+        GESTALTD_CI_IMAGE_EXISTS: ${{ steps.existing-image.outputs.exists }}
+      run: |
+        set -euo pipefail
+        {
+          echo "## gestaltd CI image"
+          echo
+          if [[ "${GESTALTD_CI_IMAGE_EXISTS}" == "true" ]]; then
+            echo "Existing immutable image reused."
+            echo
+          fi
+          echo '```text'
+          echo "${GESTALTD_CI_IMAGE}"
+          echo '```'
+        } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,80 @@
+name: CD (gestaltd)
+
+# Continuous delivery for gestaltd. Re-runs the validation suite (including the
+# race matrix), builds the docs, and builds + pushes the per-commit CI image to
+# Artifact Registry. Every CD run publishes: it is triggered by pushes to main
+# and by manual dispatch for a specific commit SHA. The hourly health check runs
+# in ci.yml instead.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.dockerignore'
+      - '.github/workflows/cd.yml'
+      - '.github/workflows/validate-gestaltd.yml'
+      - '.github/actions/build-gestaltd-image/**'
+      - 'gestaltd/**'
+      - '!gestaltd/rpc/protov1/**'
+  workflow_dispatch:
+    inputs:
+      gestalt_ref:
+        description: Full commit SHA to validate, build, and publish as a CI image.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    uses: ./.github/workflows/validate-gestaltd.yml
+    with:
+      ref: ${{ inputs.gestalt_ref }}
+      run-race: true
+      run-coverage: true
+
+  docs-build:
+    name: Docs Build
+    needs: validate
+    if: ${{ needs.validate.outputs.publish == 'true' }}
+    uses: ./.github/workflows/build-docs.yml
+    with:
+      gestalt_ref: ${{ needs.validate.outputs.sha }}
+    permissions:
+      contents: read
+
+  build-and-push:
+    name: Build & Publish CI Image
+    needs: [validate, docs-build]
+    # docs-build is skipped on non-publishing runs (schedule, kill-switch off).
+    # GitHub skips a job when a needed job is skipped unless the condition
+    # tolerates it, so gate explicitly with !cancelled(): require validation to
+    # succeed and accept a skipped docs-build (but require it to succeed when it
+    # does run on publishing runs).
+    if: >-
+      ${{ !cancelled()
+        && needs.validate.result == 'success'
+        && needs.validate.outputs.should-validate == 'true'
+        && (needs.docs-build.result == 'success' || needs.docs-build.result == 'skipped') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ needs.validate.outputs.sha }}
+
+      - uses: ./.github/actions/build-gestaltd-image
+        with:
+          push: ${{ needs.validate.outputs.publish == 'true' }}
+          build-alpine: 'false'
+          sha: ${{ needs.validate.outputs.sha }}
+          version: ${{ needs.validate.outputs.version }}
+          registry-host: ${{ vars.GESTALTD_ARTIFACT_REGISTRY_HOST }}
+          image-repository: ${{ vars.GESTALTD_CI_IMAGE_REPOSITORY }}
+          gcp-service-account: ${{ vars.GESTALTD_CI_GCP_SERVICE_ACCOUNT }}
+          gcp-workload-identity-provider: ${{ vars.GESTALTD_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI (gestaltd)
+
+# Pull-request checks for gestaltd. Runs the shared validation suite and builds
+# the CI image without pushing (build-only, plus alpine packaging validation).
+# Also runs hourly as a health check against the default branch. Publishing
+# happens in cd.yml on main / dispatch.
+
+on:
+  pull_request:
+  schedule:
+    - cron: '17 * * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    uses: ./.github/workflows/validate-gestaltd.yml
+    with:
+      # Pull requests run the light check set (no race, no coverage). The hourly
+      # schedule runs the full suite as a default-branch health check.
+      run-race: ${{ github.event_name == 'schedule' }}
+      run-coverage: ${{ github.event_name == 'schedule' }}
+
+  build:
+    name: Build CI Image
+    needs: validate
+    if: ${{ needs.validate.outputs.should-validate == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ needs.validate.outputs.sha }}
+
+      - uses: ./.github/actions/build-gestaltd-image
+        with:
+          push: 'false'
+          build-alpine: 'true'
+          sha: ${{ needs.validate.outputs.sha }}
+          version: ${{ needs.validate.outputs.version }}

--- a/.github/workflows/validate-gestaltd.yml
+++ b/.github/workflows/validate-gestaltd.yml
@@ -1,25 +1,37 @@
-name: Build Gestaltd
+name: Validate Gestaltd
+
+# Reusable validation suite for gestaltd: resolves the build ref and runs the
+# Go + Helm checks. Called by ci.yml (pull requests) and cd.yml (main / dispatch
+# / schedule). The check selection is controlled by inputs so each caller can
+# run the appropriate subset; github context (event name, PR diff) is inherited
+# from the caller, so the ref-resolution logic is unchanged.
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - '.dockerignore'
-      - '.github/workflows/build-gestaltd.yml'
-      - 'gestaltd/**'
-      - '!gestaltd/rpc/protov1/**'
-  pull_request:
-
-  schedule:
-    - cron: '17 * * * *'
-
-  workflow_dispatch:
+  workflow_call:
     inputs:
-      gestalt_ref:
-        description: Optional full commit SHA to validate, build, and publish as a CI image.
+      ref:
+        description: Optional full commit SHA to validate (defaults to the triggering ref).
         required: false
         type: string
+      run-race:
+        description: Whether to run the race-detector test matrix.
+        required: false
+        default: true
+        type: boolean
+      run-coverage:
+        description: Whether to run the coverage job (uploads to Codecov).
+        required: false
+        default: true
+        type: boolean
+    outputs:
+      sha:
+        value: ${{ jobs.resolve-ref.outputs.sha }}
+      version:
+        value: ${{ jobs.resolve-ref.outputs.version }}
+      should-validate:
+        value: ${{ jobs.resolve-ref.outputs.should_validate }}
+      publish:
+        value: ${{ jobs.resolve-ref.outputs.publish }}
 
 permissions:
   contents: read
@@ -44,13 +56,13 @@ jobs:
         env:
           PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
           PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
-          REQUESTED_GESTALT_REF: ${{ github.event.inputs.gestalt_ref || '' }}
+          REQUESTED_GESTALT_REF: ${{ inputs.ref || '' }}
         run: |
           set -euo pipefail
 
           requested_ref="${REQUESTED_GESTALT_REF}"
           if [[ -n "${requested_ref}" && ! "${requested_ref}" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "gestalt_ref must be a full lowercase 40-character commit SHA." >&2
+            echo "ref must be a full lowercase 40-character commit SHA." >&2
             exit 1
           fi
 
@@ -73,10 +85,13 @@ jobs:
           if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
             validate_exact_paths=(
               ".dockerignore"
-              ".github/workflows/build-gestaltd.yml"
+              ".github/workflows/ci.yml"
+              ".github/workflows/cd.yml"
+              ".github/workflows/validate-gestaltd.yml"
             )
             validate_path_prefixes=(
               "gestaltd/"
+              ".github/actions/build-gestaltd-image/"
             )
             ignore_path_prefixes=(
               "gestaltd/rpc/protov1/"
@@ -296,7 +311,7 @@ jobs:
   coverage:
     name: Go Coverage
     needs: resolve-ref
-    if: ${{ needs.resolve-ref.outputs.should_validate == 'true' }}
+    if: ${{ inputs.run-coverage && needs.resolve-ref.outputs.should_validate == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -324,7 +339,7 @@ jobs:
   race:
     name: Go Race Tests (${{ matrix.name }})
     needs: resolve-ref
-    if: ${{ github.event_name != 'pull_request' }}
+    if: ${{ inputs.run-race && needs.resolve-ref.outputs.should_validate == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
@@ -466,218 +481,3 @@ jobs:
       - name: Validate Kubernetes schemas (preparation)
         if: ${{ needs.resolve-ref.outputs.should_validate == 'true' }}
         run: kubeconform -strict -summary /tmp/rendered-preparation.yaml
-
-  docs-build:
-    name: Docs Build
-    needs: resolve-ref
-    if: ${{ needs.resolve-ref.outputs.publish == 'true' && vars.GESTALTD_CI_IMAGE_PUBLISH_ENABLED == 'true' }}
-    uses: ./.github/workflows/build-docs.yml
-    with:
-      gestalt_ref: ${{ needs.resolve-ref.outputs.sha }}
-    permissions:
-      contents: read
-
-  build-image:
-    name: Build CI Image
-    needs: [resolve-ref, lint, test, coverage, race, helm-validate, docs-build]
-    # Some needed jobs are conditionally skipped (race on pull requests;
-    # docs-build when not publishing). GitHub skips a job when any needed job is
-    # skipped unless the condition tolerates it, so gate explicitly on results
-    # with !cancelled(): require the always-run validations to succeed, and
-    # accept the conditionally-skipped jobs as long as they did not fail. This
-    # preserves publish-safety (race/docs-build must succeed when they do run on
-    # publishing runs) while still building on pull requests.
-    if: >-
-      ${{ !cancelled()
-        && needs.resolve-ref.outputs.should_validate == 'true'
-        && needs.resolve-ref.result == 'success'
-        && needs.lint.result == 'success'
-        && needs.test.result == 'success'
-        && needs.helm-validate.result == 'success'
-        && (needs.coverage.result == 'success' || needs.coverage.result == 'skipped')
-        && (needs.race.result == 'success' || needs.race.result == 'skipped')
-        && (needs.docs-build.result == 'success' || needs.docs-build.result == 'skipped') }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: ${{ needs.resolve-ref.outputs.sha }}
-
-      # Build the image on every validating run (including pull requests) and
-      # push it only when this run is allowed to publish. This builds once: the
-      # static image is compiled a single time and pushed in place, and the
-      # alpine target reuses the compiled build-binary layer from the same
-      # builder. The previous separate "Docker Image Build" job rebuilt the
-      # same image and threw it away.
-      - name: Resolve publish mode
-        id: publish-mode
-        env:
-          PUBLISH: ${{ needs.resolve-ref.outputs.publish }}
-          PUBLISH_ENABLED: ${{ vars.GESTALTD_CI_IMAGE_PUBLISH_ENABLED }}
-        run: |
-          set -euo pipefail
-          if [[ "${PUBLISH}" == "true" && "${PUBLISH_ENABLED}" == "true" ]]; then
-            echo "push=true" >> "${GITHUB_OUTPUT}"
-          else
-            echo "push=false" >> "${GITHUB_OUTPUT}"
-          fi
-
-      - name: Compute image metadata
-        id: meta
-        run: echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "${GITHUB_OUTPUT}"
-
-      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
-
-      - name: Validate image configuration
-        if: ${{ steps.publish-mode.outputs.push == 'true' }}
-        env:
-          GESTALTD_ARTIFACT_REGISTRY_HOST: ${{ vars.GESTALTD_ARTIFACT_REGISTRY_HOST }}
-          GESTALTD_CI_IMAGE_REPOSITORY: ${{ vars.GESTALTD_CI_IMAGE_REPOSITORY }}
-          GESTALTD_CI_GCP_SERVICE_ACCOUNT: ${{ vars.GESTALTD_CI_GCP_SERVICE_ACCOUNT }}
-          GESTALTD_CI_GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GESTALTD_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}
-        run: |
-          set -euo pipefail
-          : "${GESTALTD_ARTIFACT_REGISTRY_HOST:?GESTALTD_ARTIFACT_REGISTRY_HOST repository variable is required}"
-          : "${GESTALTD_CI_IMAGE_REPOSITORY:?GESTALTD_CI_IMAGE_REPOSITORY repository variable is required}"
-          : "${GESTALTD_CI_GCP_SERVICE_ACCOUNT:?GESTALTD_CI_GCP_SERVICE_ACCOUNT repository variable is required}"
-          : "${GESTALTD_CI_GCP_WORKLOAD_IDENTITY_PROVIDER:?GESTALTD_CI_GCP_WORKLOAD_IDENTITY_PROVIDER repository variable is required}"
-
-      - name: Authenticate to Google Cloud
-        id: gcp-auth
-        if: ${{ steps.publish-mode.outputs.push == 'true' }}
-        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
-        with:
-          workload_identity_provider: ${{ vars.GESTALTD_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.GESTALTD_CI_GCP_SERVICE_ACCOUNT }}
-          token_format: access_token
-
-      - name: Authenticate to Artifact Registry
-        if: ${{ steps.publish-mode.outputs.push == 'true' }}
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
-        with:
-          registry: ${{ vars.GESTALTD_ARTIFACT_REGISTRY_HOST }}
-          username: oauth2accesstoken
-          password: ${{ steps.gcp-auth.outputs.access_token }}
-
-      - name: Check for existing CI image
-        id: existing-image
-        if: ${{ steps.publish-mode.outputs.push == 'true' }}
-        env:
-          GESTALTD_CI_IMAGE_REPOSITORY: ${{ vars.GESTALTD_CI_IMAGE_REPOSITORY }}
-          GESTALTD_COMMIT: ${{ needs.resolve-ref.outputs.sha }}
-        run: |
-          set -euo pipefail
-          image="${GESTALTD_CI_IMAGE_REPOSITORY}:sha-${GESTALTD_COMMIT}"
-
-          if digest="$(docker buildx imagetools inspect "${image}" --format '{{.Manifest.Digest}}' 2>/dev/null)"; then
-            exists="true"
-          else
-            exists="false"
-            digest=""
-          fi
-
-          {
-            echo "image=${image}"
-            echo "exists=${exists}"
-            echo "digest=${digest}"
-          } >> "${GITHUB_OUTPUT}"
-
-      # Static image: built on every run; pushed only when publishing and not
-      # already present. On pull requests this validates the build without a
-      # push (and without attestations, which require an image/oci exporter).
-      - name: Build CI image (static)
-        id: ci-image
-        if: ${{ steps.publish-mode.outputs.push != 'true' || steps.existing-image.outputs.exists != 'true' }}
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
-        with:
-          context: .
-          file: gestaltd/Dockerfile
-          target: static
-          push: ${{ steps.publish-mode.outputs.push == 'true' }}
-          platforms: linux/amd64
-          tags: ${{ steps.publish-mode.outputs.push == 'true' && format('{0}:sha-{1}', vars.GESTALTD_CI_IMAGE_REPOSITORY, needs.resolve-ref.outputs.sha) || 'gestaltd:ci-static' }}
-          build-args: |
-            GESTALT_VERSION=${{ needs.resolve-ref.outputs.version }}
-            GESTALT_REVISION=${{ needs.resolve-ref.outputs.sha }}
-            GESTALT_CREATED=${{ steps.meta.outputs.created }}
-            GESTALT_SOURCE=https://github.com/${{ github.repository }}
-            GESTALT_DOCUMENTATION=https://gestaltd.ai
-            GESTALT_URL=${{ format('{0}:sha-{1}', vars.GESTALTD_CI_IMAGE_REPOSITORY, needs.resolve-ref.outputs.sha) }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          sbom: ${{ steps.publish-mode.outputs.push == 'true' }}
-          provenance: ${{ steps.publish-mode.outputs.push == 'true' && 'mode=max' || 'false' }}
-
-      # Alpine target: build-only validation on pull requests, never pushed.
-      # build-gestaltd.yml only publishes the static image; the shipped alpine
-      # image (alpine-prebuilt) is built and published by release-gestaltd.yml.
-      # This guards the shared alpine packaging early on PRs without adding work
-      # to publishing runs. Reuses the compiled build-binary layer from the
-      # static build above (a few seconds).
-      - name: Build CI image (alpine, validation only)
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
-        with:
-          context: .
-          file: gestaltd/Dockerfile
-          target: alpine
-          push: false
-          platforms: linux/amd64
-          tags: gestaltd:ci-alpine
-          build-args: |
-            GESTALT_VERSION=${{ needs.resolve-ref.outputs.version }}
-          cache-from: type=gha
-
-      - name: Resolve published image
-        id: published-image
-        if: ${{ steps.publish-mode.outputs.push == 'true' }}
-        env:
-          EXISTING_DIGEST: ${{ steps.existing-image.outputs.digest }}
-          GESTALTD_CI_IMAGE_REPOSITORY: ${{ vars.GESTALTD_CI_IMAGE_REPOSITORY }}
-          GESTALTD_COMMIT: ${{ needs.resolve-ref.outputs.sha }}
-          PUSHED_DIGEST: ${{ steps.ci-image.outputs.digest }}
-        run: |
-          set -euo pipefail
-          digest="${PUSHED_DIGEST:-${EXISTING_DIGEST}}"
-          : "${digest:?Expected a pushed or existing image digest}"
-          image="${GESTALTD_CI_IMAGE_REPOSITORY}:sha-${GESTALTD_COMMIT}@${digest}"
-          {
-            echo "digest=${digest}"
-            echo "image=${image}"
-          } >> "${GITHUB_OUTPUT}"
-
-      - name: Smoke test CI image
-        if: ${{ steps.publish-mode.outputs.push == 'true' }}
-        env:
-          GESTALTD_CI_IMAGE: ${{ steps.published-image.outputs.image }}
-          GESTALTD_VERSION: ${{ needs.resolve-ref.outputs.version }}
-        run: |
-          set -euo pipefail
-          actual_version="$(docker run --rm "${GESTALTD_CI_IMAGE}" version)"
-          if [[ "${actual_version}" != "${GESTALTD_VERSION}" ]]; then
-            echo "gestaltd version output '${actual_version}' did not match expected '${GESTALTD_VERSION}'." >&2
-            exit 1
-          fi
-
-      - name: Summarize CI image
-        if: ${{ steps.publish-mode.outputs.push == 'true' }}
-        env:
-          GESTALTD_CI_IMAGE: ${{ steps.published-image.outputs.image }}
-          GESTALTD_CI_IMAGE_EXISTS: ${{ steps.existing-image.outputs.exists }}
-        run: |
-          set -euo pipefail
-          {
-            echo "## gestaltd CI image"
-            echo
-            if [[ "${GESTALTD_CI_IMAGE_EXISTS}" == "true" ]]; then
-              echo "Existing immutable image reused."
-              echo
-            fi
-            echo '```text'
-            echo "${GESTALTD_CI_IMAGE}"
-            echo '```'
-          } >> "${GITHUB_STEP_SUMMARY}"


### PR DESCRIPTION
## Description

Splits the single `build-gestaltd.yml` into a **CI / CD** pair backed by shared, reusable pieces. Stacked on #2545.

**New files**
- `.github/workflows/validate-gestaltd.yml` — reusable workflow (`workflow_call`) with `resolve-ref` + the Go/Helm validation jobs. Check selection is parameterized (`run-race`, `run-coverage`); the build ref is an input. `github` context is inherited from the caller, so ref resolution is unchanged.
- `.github/actions/build-gestaltd-image/action.yml` — composite action with the image build/push steps (buildx, optional GCP auth, build once, push + SBOM/provenance + smoke test when publishing, optional alpine validation). Registry vars and GCP identity are passed as inputs.
- `.github/workflows/ci.yml` (`on: pull_request` + **hourly schedule**) — calls `validate` (no race) and builds the image **without pushing**, plus alpine packaging validation. The schedule is the default-branch health check.
- `.github/workflows/cd.yml` (`on: push:main` + **manual dispatch for a required SHA**) — calls `validate` (with race), builds docs, and **builds + pushes** the CI image. Every CD run publishes; pushing is gated only by `resolve-ref`'s `publish` output. No schedule, no dispatch-without-ref, and the `GESTALTD_CI_IMAGE_PUBLISH_ENABLED` kill switch is removed.

**Removed**
- `.github/workflows/build-gestaltd.yml` (content moved into the files above).

## Required follow-ups

1. **Required status-check renames** (validation jobs now report under the reusable workflow). Update the branch ruleset:
   - `Go Lint & Vet` → `validate / Go Lint & Vet`
   - `Go Tests` → `validate / Go Tests`
   - `Helm Chart Validation` → `validate / Helm Chart Validation`
   - `Docs Build` — already dropped from required.
   - `Cursor Bugbot` — unchanged.
   Confirm exact contexts from this PR's first `ci.yml` run before flipping the ruleset.
2. **`bump-toolshed-gestaltd.sh`** references `--workflow build-gestaltd.yml` (3 places); update to `cd.yml` or toolshed bumps will fail to find the build run.
3. **Delete the `GESTALTD_CI_IMAGE_PUBLISH_ENABLED` repository variable** once this stack merges (current `main`'s `build-gestaltd.yml` still uses it, so don't delete before then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)