### PR TITLE
Allow deployment OpenAPI connection overrides

### DIFF
--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -746,8 +746,8 @@ func buildConfiguredAPIProvider(ctx context.Context, name string, plan config.St
 	for i := range built {
 		specSurface := &built[i]
 		boundProviders = append(boundProviders, composite.BoundProvider{
-			Provider:   specSurface.provider,
-			Connection: specSurface.resolved.ConnectionName,
+			Provider:           specSurface.provider,
+			FallbackConnection: specSurface.resolved.ConnectionName,
 		})
 		providers = append(providers, specSurface.provider)
 	}

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1167,11 +1167,13 @@ type ProviderRESTSurfaceOverride struct {
 }
 
 type ProviderOpenAPISurfaceOverride struct {
-	BaseURL string `yaml:"baseUrl,omitempty"`
+	BaseURL    string `yaml:"baseUrl,omitempty"`
+	Connection string `yaml:"connection,omitempty"`
 }
 
 type ProviderGraphQLSurfaceOverride struct {
-	URL string `yaml:"url,omitempty"`
+	URL        string `yaml:"url,omitempty"`
+	Connection string `yaml:"connection,omitempty"`
 }
 
 type ProviderMCPSurfaceOverride struct {

--- a/gestaltd/internal/config/connection_plan.go
+++ b/gestaltd/internal/config/connection_plan.go
@@ -115,7 +115,7 @@ func BuildStaticConnectionPlan(app *ProviderEntry, manifestApp *providermanifest
 		resolved := ResolvedSpecSurface{
 			Surface:        surface,
 			URL:            url,
-			ConnectionName: plan.resolveSurfaceConnectionName(ManifestProviderSurfaceConnectionName(manifestApp, surface)),
+			ConnectionName: plan.resolveSurfaceConnectionName(EffectiveProviderSurfaceConnectionName(app, manifestApp, surface)),
 		}
 		conn, err := plan.connectionDef(resolved.ConnectionName)
 		if err != nil {

--- a/gestaltd/internal/config/surfaces.go
+++ b/gestaltd/internal/config/surfaces.go
@@ -57,6 +57,30 @@ func ManifestProviderSurfaceConnectionName(provider *providermanifestv1.Spec, su
 	return provider.SurfaceConnectionName(string(surface))
 }
 
+func ProviderSurfaceConnectionOverride(entry *ProviderEntry, surface SpecSurface) string {
+	if entry == nil || entry.Surfaces == nil {
+		return ""
+	}
+	switch surface {
+	case SpecSurfaceOpenAPI:
+		if entry.Surfaces.OpenAPI != nil {
+			return strings.TrimSpace(entry.Surfaces.OpenAPI.Connection)
+		}
+	case SpecSurfaceGraphQL:
+		if entry.Surfaces.GraphQL != nil {
+			return strings.TrimSpace(entry.Surfaces.GraphQL.Connection)
+		}
+	}
+	return ""
+}
+
+func EffectiveProviderSurfaceConnectionName(entry *ProviderEntry, provider *providermanifestv1.Spec, surface SpecSurface) string {
+	if override := ProviderSurfaceConnectionOverride(entry, surface); override != "" {
+		return override
+	}
+	return ManifestProviderSurfaceConnectionName(provider, surface)
+}
+
 func ProviderSurfaceURLOverride(entry *ProviderEntry, surface SpecSurface) string {
 	if entry != nil && entry.Surfaces != nil {
 		switch surface {

--- a/gestaltd/internal/config/surfaces_test.go
+++ b/gestaltd/internal/config/surfaces_test.go
@@ -111,6 +111,32 @@ func TestProviderSurfaceURLOverride(t *testing.T) {
 	}
 }
 
+func TestEffectiveProviderSurfaceConnectionName(t *testing.T) {
+	t.Parallel()
+
+	manifest := &providermanifestv1.Spec{
+		Surfaces: &providermanifestv1.ProviderSurfaces{
+			OpenAPI: &providermanifestv1.OpenAPISurface{
+				Document:   "openapi.yaml",
+				Connection: "OAuth",
+			},
+		},
+	}
+
+	if got := EffectiveProviderSurfaceConnectionName(nil, manifest, SpecSurfaceOpenAPI); got != "OAuth" {
+		t.Fatalf("EffectiveProviderSurfaceConnectionName(nil) = %q, want OAuth", got)
+	}
+
+	entry := &ProviderEntry{
+		Surfaces: &ProviderSurfaceOverrides{
+			OpenAPI: &ProviderOpenAPISurfaceOverride{Connection: "PAT"},
+		},
+	}
+	if got := EffectiveProviderSurfaceConnectionName(entry, manifest, SpecSurfaceOpenAPI); got != "PAT" {
+		t.Fatalf("EffectiveProviderSurfaceConnectionName(override) = %q, want PAT", got)
+	}
+}
+
 func TestEffectiveProviderSpecBaseURL(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Add `apps.<name>.surfaces.openapi.connection` (and GraphQL equivalent) deployment overrides so hosts can choose a different REST auth connection than the provider manifest default.
- Bind configured OpenAPI surfaces with fallback connection routing so callers can still override to another declared connection (for example OAuth service accounts on a PAT-default deployment).

## Why
valon.tools has both Notion OAuth and PAT connected, but REST operations were locked to OAuth from the provider manifest. This blocks `gestalt invoke notion --connection PAT`.

## Test plan
- [x] `go test ./internal/config/... ./internal/bootstrap/... ./services/invocation/... ./services/apps/composite/... -short`
- [ ] After deploy, verify `gestalt invoke notion --connection PAT --instance default search` succeeds on valon.tools
- [ ] Verify eng-background-agent Notion tools still work with explicit `connection: OAuth`


Made with [Cursor](https://cursor.com)