### PR TITLE
Cache local source-path provider builds in gestaltd sync --cache-dir

### DIFF
--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -4458,6 +4458,19 @@ func equivalentProviderManifestPath(current, expected string) bool {
 		currentManifest.Version == expectedManifest.Version
 }
 
+func sourceManifestCacheRequest(kind, name, subject, destDir, sourceDigest string) materializedCacheRequest {
+	return materializedCacheRequest{
+		Subject:        subject,
+		Kind:           kind,
+		Name:           name,
+		SourceKind:     syncArtifactSourceLocalSource,
+		ArchiveSHA256:  sourceDigest,
+		ResolvedKey:    "source-manifest",
+		Platform:       providerpkg.CurrentPlatformString(),
+		DestinationDir: destDir,
+	}
+}
+
 func (l *Lifecycle) ensureLocalPreparedInstall(paths lifecyclePaths, kind, name string, provider *config.ProviderEntry, configMap map[string]any, destDir, subject string, mode artifactMode) (*preparedInstall, error) {
 	if provider == nil || !provider.HasLocalSource() {
 		return nil, fmt.Errorf("%s requires local source configuration", subject)
@@ -4480,6 +4493,48 @@ func (l *Lifecycle) ensureLocalPreparedInstall(paths lifecyclePaths, kind, name 
 		if !mode.canMaterialize() {
 			return nil, artifactMaterializeDeniedError(paths, mode, "prepared artifact for %s is missing or stale", subject)
 		}
+
+		cache := paths.syncCache
+		var cacheReq materializedCacheRequest
+		cacheEligible := false
+		if cache.dir != "" {
+			sourceDigest, digestErr := fingerprintLocalSourceDigest(provider.SourcePath())
+			if digestErr == nil {
+				cacheEligible = true
+				cacheReq = sourceManifestCacheRequest(kind, name, subject, destDir, sourceDigest)
+				restore, restoreErr := cache.Restore(cacheReq)
+				if restoreErr != nil {
+					return nil, fmt.Errorf("restore materialized cache for %s: %w", subject, restoreErr)
+				}
+				if restore != nil {
+					recordSyncCacheEntry(paths, syncCacheMetricsEvent{
+						Subject: subject, SourceKind: cacheReq.SourceKind,
+						Key: restore.Key.Display, SHA256: restore.Key.ArchiveSHA256,
+						Platform: cacheReq.Platform, Result: string(restore.Result),
+						Lookup: true, Bytes: restore.Bytes, Files: restore.Files,
+					})
+					if restore.Result == materializedCacheHit {
+						defer func() { _ = restore.cleanup() }()
+						if err := validateInstalledManifestKind(kind, name, restore.Install.manifest); err != nil {
+							return nil, err
+						}
+						if err := writePreparedLockMetadata(paths, restore.Install, kind, name, provider); err != nil {
+							return nil, fmt.Errorf("write prepared lock metadata for %s: %w", subject, err)
+						}
+						if err := restore.commit(); err != nil {
+							return nil, fmt.Errorf("activate cached source for %s: %w", subject, err)
+						}
+						install, err = inspectPreparedInstall(destDir)
+						if err != nil {
+							return nil, fmt.Errorf("read prepared manifest for %s: %w", subject, err)
+						}
+						recordSyncArtifact(paths, kind, name, subject, destDir, syncArtifactSourceLocalSource, syncArtifactResultMaterialized, reason, start, 0, 0)
+						return install, nil
+					}
+				}
+			}
+		}
+
 		prepareStart := time.Now()
 		stagedInstall, cleanupStaged, commitStaged, err := stageLocalSourceInstall(kind, name, provider.SourcePath(), destDir, paths.stageOptions())
 		prepareDuration := time.Since(prepareStart)
@@ -4495,8 +4550,17 @@ func (l *Lifecycle) ensureLocalPreparedInstall(paths lifecyclePaths, kind, name 
 		if err := providerpkg.ValidateConfigForManifest(stagedInstall.manifestPath, stagedInstall.manifest, kind, configMap); err != nil {
 			return nil, fmt.Errorf("provider config validation for %s: %w", subject, err)
 		}
+		if cache.dir != "" && cacheEligible {
+			putResult, putErr := cache.Put(context.Background(), cacheReq, filepath.Dir(stagedInstall.manifestPath))
+			recordSyncCacheEntry(paths, syncCacheMetricsEvent{
+				Subject: subject, SourceKind: cacheReq.SourceKind,
+				Key: putResult.Key.Display, SHA256: putResult.Key.ArchiveSHA256,
+				Platform: cacheReq.Platform, Result: syncCacheResultMiss,
+				Put: true, PutFailed: putErr != nil, Bytes: putResult.Bytes, Files: putResult.Files,
+			})
+		}
 		if err := writePreparedLockMetadata(paths, stagedInstall, kind, name, provider); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("write prepared lock metadata for %s: %w", subject, err)
 		}
 		activateStart := time.Now()
 		if err := commitStaged(); err != nil {

--- a/gestaltd/internal/operator/sync_observability.go
+++ b/gestaltd/internal/operator/sync_observability.go
@@ -36,59 +36,92 @@ func (paths lifecyclePaths) prefetchMaterializedCache(ctx context.Context, reque
 }
 
 func (l *Lifecycle) prefetchAppMaterializedCache(paths lifecyclePaths, lock *Lockfile, work []*preparedAppWork, mode artifactMode, parallelism int) {
-	if mode != artifactModeMaterialize || lock == nil || paths.syncCache.remote == nil {
+	if mode != artifactModeMaterialize || paths.syncCache.remote == nil {
 		return
 	}
 	var requests []materializedCacheRequest
-	for _, work := range work {
-		if work == nil || !providerRequiresCommittedLock(work.entry) {
-			continue
-		}
-		entry, ok := lock.Providers.App[work.name]
-		if !ok || !needsLockedMaterializedCachePrefetch(paths, providermanifestv1.KindApp, work.name, work.name, work.entry, entry, providerDestDir(paths, work.name), mode) {
-			continue
-		}
-		req, ok := l.materializedCacheRequestForLockedEntry(paths, providermanifestv1.KindApp, work.name, "provider "+strconv.Quote(work.name), entry, providerDestDir(paths, work.name))
-		if ok {
-			requests = append(requests, req)
+	if lock != nil {
+		for _, work := range work {
+			if work == nil || !providerRequiresCommittedLock(work.entry) {
+				continue
+			}
+			entry, ok := lock.Providers.App[work.name]
+			if !ok || !needsLockedMaterializedCachePrefetch(paths, providermanifestv1.KindApp, work.name, work.name, work.entry, entry, providerDestDir(paths, work.name), mode) {
+				continue
+			}
+			req, ok := l.materializedCacheRequestForLockedEntry(paths, providermanifestv1.KindApp, work.name, "provider "+strconv.Quote(work.name), entry, providerDestDir(paths, work.name))
+			if ok {
+				requests = append(requests, req)
+			}
 		}
 	}
+	requests = append(requests, materializedCacheRequestsForLocalSourceApps(paths, work, mode)...)
 	paths.prefetchMaterializedCache(context.Background(), requests, parallelism)
 }
 
 func (l *Lifecycle) prefetchComponentMaterializedCache(paths lifecyclePaths, lock *Lockfile, cfg *config.Config, mode artifactMode, parallelism int) {
-	if mode != artifactModeMaterialize || lock == nil || cfg == nil || paths.syncCache.remote == nil {
+	if mode != artifactModeMaterialize || cfg == nil || paths.syncCache.remote == nil {
 		return
 	}
 	var requests []materializedCacheRequest
-	for _, collection := range hostProviderCollections(cfg) {
-		kind := providerManifestKind(collection.kind)
-		requests = append(requests, l.materializedCacheRequestsForProviders(paths, lockEntriesForKind(lock, collection.kind), kind, collection.entries, func(name string) string {
-			return componentDestDir(paths, collection.kind, name)
+	if lock != nil {
+		for _, collection := range hostProviderCollections(cfg) {
+			kind := providerManifestKind(collection.kind)
+			requests = append(requests, l.materializedCacheRequestsForProviders(paths, lockEntriesForKind(lock, collection.kind), kind, collection.entries, func(name string) string {
+				return componentDestDir(paths, collection.kind, name)
+			}, func(name string) string {
+				return name
+			})...)
+		}
+		requests = append(requests, l.materializedCacheRequestsForProviders(paths, lockEntriesForProviderKind(lock, providermanifestv1.KindRuntime), providermanifestv1.KindRuntime, runtimeProviderEntries(cfg), func(name string) string {
+			return runtimeDestDir(paths, name)
 		}, func(name string) string {
 			return name
 		})...)
+		requests = append(requests, l.materializedCacheRequestsForProviders(paths, lockEntriesForProviderKind(lock, providermanifestv1.KindIndexedDB), providermanifestv1.KindIndexedDB, cfg.Providers.IndexedDB, func(name string) string {
+			return indexeddbDestDir(paths, name)
+		}, func(name string) string {
+			return name
+		})...)
+		requests = append(requests, l.materializedCacheRequestsForProviders(paths, lockEntriesForProviderKind(lock, providermanifestv1.KindS3), providermanifestv1.KindS3, cfg.Providers.S3, func(name string) string {
+			return s3DestDir(paths, name)
+		}, func(name string) string {
+			return name
+		})...)
+		requests = append(requests, l.materializedCacheRequestsForProviders(paths, lockEntriesForProviderKind(lock, providermanifestv1.KindUI), providermanifestv1.KindUI, uiProviderEntries(cfg), func(name string) string {
+			return uiDestDir(paths, name)
+		}, func(name string) string {
+			return "ui:" + name
+		})...)
 	}
-	requests = append(requests, l.materializedCacheRequestsForProviders(paths, lockEntriesForProviderKind(lock, providermanifestv1.KindRuntime), providermanifestv1.KindRuntime, runtimeProviderEntries(cfg), func(name string) string {
+	for _, collection := range hostProviderCollections(cfg) {
+		kind := providerManifestKind(collection.kind)
+		requests = append(requests, materializedCacheRequestsForLocalSourceProviders(paths, kind, collection.entries, func(name string) string {
+			return componentDestDir(paths, collection.kind, name)
+		}, func(name string) string {
+			return fmt.Sprintf("%s %q", kind, name)
+		}, mode)...)
+	}
+	requests = append(requests, materializedCacheRequestsForLocalSourceProviders(paths, providermanifestv1.KindRuntime, runtimeProviderEntries(cfg), func(name string) string {
 		return runtimeDestDir(paths, name)
 	}, func(name string) string {
-		return name
-	})...)
-	requests = append(requests, l.materializedCacheRequestsForProviders(paths, lockEntriesForProviderKind(lock, providermanifestv1.KindIndexedDB), providermanifestv1.KindIndexedDB, cfg.Providers.IndexedDB, func(name string) string {
+		return fmt.Sprintf("%s %q", providermanifestv1.KindRuntime, name)
+	}, mode)...)
+	requests = append(requests, materializedCacheRequestsForLocalSourceProviders(paths, providermanifestv1.KindIndexedDB, cfg.Providers.IndexedDB, func(name string) string {
 		return indexeddbDestDir(paths, name)
 	}, func(name string) string {
-		return name
-	})...)
-	requests = append(requests, l.materializedCacheRequestsForProviders(paths, lockEntriesForProviderKind(lock, providermanifestv1.KindS3), providermanifestv1.KindS3, cfg.Providers.S3, func(name string) string {
+		return fmt.Sprintf("%s %q", providermanifestv1.KindIndexedDB, name)
+	}, mode)...)
+	requests = append(requests, materializedCacheRequestsForLocalSourceProviders(paths, providermanifestv1.KindS3, cfg.Providers.S3, func(name string) string {
 		return s3DestDir(paths, name)
 	}, func(name string) string {
-		return name
-	})...)
-	requests = append(requests, l.materializedCacheRequestsForProviders(paths, lockEntriesForProviderKind(lock, providermanifestv1.KindUI), providermanifestv1.KindUI, uiProviderEntries(cfg), func(name string) string {
+		return fmt.Sprintf("%s %q", providermanifestv1.KindS3, name)
+	}, mode)...)
+	requests = append(requests, materializedCacheRequestsForLocalSourceProviders(paths, providermanifestv1.KindUI, uiProviderEntries(cfg), func(name string) string {
 		return uiDestDir(paths, name)
 	}, func(name string) string {
-		return "ui:" + name
-	})...)
+		return "ui " + strconv.Quote(name)
+	}, mode)...)
 	paths.prefetchMaterializedCache(context.Background(), requests, parallelism)
 }
 
@@ -113,6 +146,57 @@ func (l *Lifecycle) materializedCacheRequestsForProviders(paths lifecyclePaths, 
 		}
 	}
 	return requests
+}
+
+func materializedCacheRequestsForLocalSourceApps(paths lifecyclePaths, work []*preparedAppWork, mode artifactMode) []materializedCacheRequest {
+	var requests []materializedCacheRequest
+	for _, work := range work {
+		if work == nil || work.entry == nil || !work.entry.HasLocalSource() {
+			continue
+		}
+		dest := providerDestDir(paths, work.name)
+		if !needsLocalSourceMaterializedCachePrefetch(paths, providermanifestv1.KindApp, work.name, work.entry, dest, mode) {
+			continue
+		}
+		sourceDigest, err := fingerprintLocalSourceDigest(work.entry.SourcePath())
+		if err != nil {
+			continue
+		}
+		requests = append(requests, sourceManifestCacheRequest(
+			providermanifestv1.KindApp, work.name, "provider "+strconv.Quote(work.name), dest, sourceDigest))
+	}
+	return requests
+}
+
+func materializedCacheRequestsForLocalSourceProviders(paths lifecyclePaths, kind string, entries map[string]*config.ProviderEntry, destDir func(string) string, subject func(string) string, mode artifactMode) []materializedCacheRequest {
+	var requests []materializedCacheRequest
+	for _, name := range slices.Sorted(maps.Keys(entries)) {
+		entry := entries[name]
+		if entry == nil || !entry.HasLocalSource() {
+			continue
+		}
+		dest := destDir(name)
+		if !needsLocalSourceMaterializedCachePrefetch(paths, kind, name, entry, dest, mode) {
+			continue
+		}
+		sourceDigest, err := fingerprintLocalSourceDigest(entry.SourcePath())
+		if err != nil {
+			continue
+		}
+		requests = append(requests, sourceManifestCacheRequest(kind, name, subject(name), dest, sourceDigest))
+	}
+	return requests
+}
+
+func needsLocalSourceMaterializedCachePrefetch(paths lifecyclePaths, kind, name string, provider *config.ProviderEntry, destDir string, mode artifactMode) bool {
+	if mode != artifactModeMaterialize || provider == nil || strings.TrimSpace(destDir) == "" {
+		return false
+	}
+	install, err := inspectPreparedInstall(destDir)
+	if err != nil {
+		return true
+	}
+	return inspectPreparedLockMetadata(paths, install, kind, name, provider, mode) != preparedLockMetadataMatch
 }
 
 func (l *Lifecycle) materializedCacheRequestForLockedEntry(paths lifecyclePaths, kind, name, subject string, entry LockEntry, destDir string) (materializedCacheRequest, bool) {


### PR DESCRIPTION
`gestaltd sync --cache-dir` already caches providers pinned to release archives (the `materializeLockedArchive` path). This extends the same materialized cache to providers built from local source manifests (`source.path`), so a fresh CI checkout can restore builds from cache instead of rebuilding every provider from scratch.

## What changed

`ensureLocalPreparedInstall` — the single function all local-source builds route through — now consults the cache before rebuilding and stores the result after:

- **Restore before rebuild:** when `--cache-dir` is set and a rebuild is needed, compute the source content digest (`fingerprintLocalSourceDigest`), use it as the cache key, and try `cache.Restore`. On a hit, the prepared install is restored to the dest dir — no source build. On a miss, fall through to the existing rebuild path.
- **Put after rebuild:** after a successful rebuild, store the output in the cache from the staged temp dir (before commit), matching the archive path pattern. Put failure is non-fatal.
- **No changes to the staleness gate.** The `.gestaltd-lock-metadata.json` freshness check stays as-is. The cache layers on top: the gate decides whether a rebuild is needed; the cache decides whether to rebuild or restore.

No new CLI flags, no lockfile changes, no new cache schema. `--cache-dir` and `GESTALTD_SYNC_CACHE_REMOTE` are reused as-is.

## Cache key

The content digest (`fingerprintLocalSourceDigest` — SHA256 of all build-input files by `relpath=sha256`) flows through the existing `ArchiveSHA256` field. A fixed marker `"source-manifest"` flows through `ResolvedKey`, which cannot collide with the archive path URL/package identities.

## Example

```
# CI Runner A: first build, populates cache
$ gestaltd sync --locked --config app.yaml --cache-dir /tmp/cache
  → provider-a: cache MISS, building from source... → stored to cache
  → provider-b: cache MISS, building from source... → stored to cache

# CI Runner B: identical checkout, restores from cache
$ GESTALTD_SYNC_CACHE_REMOTE=gs://my-bucket/cache \
    gestaltd sync --locked --config app.yaml --cache-dir /tmp/cache
  → provider-a: cache HIT, restoring... (no rebuild)
  → provider-b: cache HIT, restoring... (no rebuild)
```

Without `--cache-dir`, all cache logic is skipped — zero overhead, identical to today.