### PR TITLE
[gestaltd] drop GESTALTD_CI_IMAGE_PUBLISH_ENABLED from terraform

### DIFF
--- a/gestaltd/terraform/README.md
+++ b/gestaltd/terraform/README.md
@@ -27,7 +27,6 @@ GESTALTD_ARTIFACT_REGISTRY_HOST
 GESTALTD_CHART_REPOSITORY
 GESTALTD_CI_GCP_SERVICE_ACCOUNT
 GESTALTD_CI_GCP_WORKLOAD_IDENTITY_PROVIDER
-GESTALTD_CI_IMAGE_PUBLISH_ENABLED
 GESTALTD_CI_IMAGE_REPOSITORY
 GESTALTD_GCP_SERVICE_ACCOUNT
 GESTALTD_GCP_WORKLOAD_IDENTITY_PROVIDER
@@ -45,15 +44,10 @@ Consumers should pin full image references with digests:
 ${GESTALTD_CI_IMAGE_REPOSITORY}:sha-<40-character-commit-sha>@sha256:<manifest-digest>
 ```
 
-The `Build Gestaltd` workflow publishes CI images after its validation jobs pass
+The `CD (gestaltd)` workflow publishes CI images after its validation jobs pass
 on `main`. To backfill an older commit, run that workflow manually with
 `gestalt_ref` set to the full commit SHA. Manual backfill runs the same
 validation jobs before publishing the image.
-
-Set `GESTALTD_CI_IMAGE_PUBLISH_ENABLED=true` only after the CI image repository,
-publisher service account, Workload Identity binding, reader grants, and
-repository variables are ready. Until then, the publish job is skipped and the
-existing validation jobs continue to run normally.
 
 The legacy GCS CI binary bucket remains managed so Terraform does not destroy
 historical artifacts during this migration. Current workflows do not publish new

--- a/gestaltd/terraform/outputs.tf
+++ b/gestaltd/terraform/outputs.tf
@@ -5,7 +5,6 @@ output "github_actions_variables" {
     GESTALTD_CHART_REPOSITORY                  = local.chart_repository
     GESTALTD_CI_GCP_SERVICE_ACCOUNT            = google_service_account.ci_image_publisher.email
     GESTALTD_CI_GCP_WORKLOAD_IDENTITY_PROVIDER = local.ci_image_workload_identity_provider
-    GESTALTD_CI_IMAGE_PUBLISH_ENABLED          = "false"
     GESTALTD_CI_IMAGE_REPOSITORY               = local.ci_image_repository
     GESTALTD_GCP_SERVICE_ACCOUNT               = google_service_account.chart_publisher.email
     GESTALTD_GCP_WORKLOAD_IDENTITY_PROVIDER    = local.workload_identity_provider


### PR DESCRIPTION
## Description

The CI-image publish kill switch (`GESTALTD_CI_IMAGE_PUBLISH_ENABLED`) was removed when the build workflow was split into `ci.yml`/`cd.yml`. `cd.yml` no longer reads it and the repository variable has been deleted, so this removes the dead references in Terraform:

- `outputs.tf`: drop it from the `github_actions_variables` recommendation map.
- `README.md`: drop it from the variables list, remove the setup note about enabling it, and rename the stale `Build Gestaltd` workflow reference to `CD (gestaltd)`.

No functional change — `outputs.tf` only emits a recommendation map (there is no `github_actions_variable` resource), so nothing managed is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)