### PR TITLE
[gestaltd] don't run the full Go suite twice on main

### DIFF
--- a/.github/workflows/validate-gestaltd.yml
+++ b/.github/workflows/validate-gestaltd.yml
@@ -259,6 +259,7 @@ jobs:
   test:
     name: Go Tests
     needs: resolve-ref
+    if: ${{ !inputs.run-coverage }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -309,7 +310,7 @@ jobs:
           go test $packages
 
   coverage:
-    name: Go Coverage
+    name: Go Tests with Coverage
     needs: resolve-ref
     if: ${{ inputs.run-coverage && needs.resolve-ref.outputs.should_validate == 'true' }}
     runs-on: ubuntu-latest
@@ -325,6 +326,9 @@ jobs:
         with:
           go-version-file: gestaltd/go.mod
           cache-dependency-path: gestaltd/go.sum
+
+      - name: Set up Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
       - name: Run coverage
         working-directory: gestaltd


### PR DESCRIPTION
The CD/scheduled validation runs both the Go Tests job (go test ./...) and the
Go Coverage job (go test -coverprofile ./...), which is the same full suite
executed twice. Coverage is a strict superset and already fails on any test
failure, so the plain run adds no signal.

Skip the Go Tests job whenever coverage is enabled (main push, workflow
dispatch, hourly schedule) and let coverage be the authoritative full-suite
gate. Pull requests keep the fast, package-scoped Go Tests job (coverage stays
off there). Add the Helm setup to the coverage job so it is a complete
replacement for tests that shell out to the helm binary.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>