### PR TITLE
[gestaltd] compile-check PRs with go vet instead of go test -run '^$'

### DIFF
--- a/.github/workflows/validate-gestaltd.yml
+++ b/.github/workflows/validate-gestaltd.yml
@@ -198,7 +198,12 @@ jobs:
 
           if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
             packages=$("$GITHUB_WORKSPACE/.github/scripts/collect-go-test-packages.sh" "$GITHUB_WORKSPACE/gestaltd")
-            go test -run '^$' ./...
+            # Compile-check every package (including test files) without running
+            # any tests, so packages whose tests aren't in the affected set still
+            # fail the build if they stop compiling. `go vet ./...` type-checks
+            # and compiles all packages but, unlike `go test -run '^$' ./...`,
+            # never executes TestMain — avoiding its expensive fixture builds.
+            go vet ./...
             if [[ -z "$packages" ]]; then
               echo "No Go packages affected by this pull request."
               exit 0


### PR DESCRIPTION
## Description

The PR compile-check ran `go test -run '^$' ./...` to confirm every package still builds even when only the affected packages' tests run. That executes each package's `TestMain` (`m.Run` with no tests), so the daemon/bootstrap/operator integration packages spent ~25s each building gestaltd + provider fixtures during a pass that runs nothing.

Switch the compile-check to `go vet ./...`: it type-checks and compiles every package including test files, but never executes `TestMain`, so those fixture builds no longer happen during the compile-check. The affected packages' tests still run afterward, and the full `go test ./...` on main/coverage continues to build and link every test binary.