### PR TITLE
[gestaltd] build the gestaltd test binary once and share it across CI jobs

### DIFF
--- a/.github/workflows/validate-gestaltd.yml
+++ b/.github/workflows/validate-gestaltd.yml
@@ -198,7 +198,12 @@ jobs:
 
           if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
             packages=$("$GITHUB_WORKSPACE/.github/scripts/collect-go-test-packages.sh" "$GITHUB_WORKSPACE/gestaltd")
-            go test -run '^$' ./...
+            # Compile-check every package (including test files) without running
+            # any tests, so packages whose tests aren't in the affected set still
+            # fail the build if they stop compiling. `go vet ./...` type-checks
+            # and compiles all packages but, unlike `go test -run '^$' ./...`,
+            # never executes TestMain — avoiding its expensive fixture builds.
+            go vet ./...
             if [[ -z "$packages" ]]; then
               echo "No Go packages affected by this pull request."
               exit 0

--- a/.github/workflows/validate-gestaltd.yml
+++ b/.github/workflows/validate-gestaltd.yml
@@ -215,9 +215,44 @@ jobs:
           echo "$packages"
           go test $packages
 
+  build-fixtures:
+    name: Build Test Fixtures
+    needs: resolve-ref
+    # Build the gestaltd binary once and share it with the coverage and race
+    # jobs, which otherwise each rebuild it in TestMain. Runs whenever any
+    # consuming job runs (the same gate as coverage OR race below).
+    if: ${{ (inputs.run-coverage || inputs.run-race) && needs.resolve-ref.outputs.should_validate == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ needs.resolve-ref.outputs.sha }}
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: gestaltd/go.mod
+          cache-dependency-path: gestaltd/go.sum
+
+      - name: Build gestaltd fixture
+        working-directory: gestaltd
+        run: |
+          mkdir -p "${RUNNER_TEMP}/test-fixtures"
+          go build -o "${RUNNER_TEMP}/test-fixtures/gestaltd" ./cmd/gestaltd
+
+      - name: Upload test fixtures
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: gestaltd-test-fixtures
+          path: ${{ runner.temp }}/test-fixtures
+          retention-days: 1
+          if-no-files-found: error
+
   coverage:
     name: Go Tests with Coverage
-    needs: resolve-ref
+    needs: [resolve-ref, build-fixtures]
     if: ${{ inputs.run-coverage && needs.resolve-ref.outputs.should_validate == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -236,8 +271,19 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
+      - name: Download test fixtures
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: gestaltd-test-fixtures
+          path: ${{ runner.temp }}/test-fixtures
+
+      - name: Restore fixture permissions
+        run: chmod +x "${RUNNER_TEMP}/test-fixtures/"*
+
       - name: Run coverage
         working-directory: gestaltd
+        env:
+          GESTALT_TEST_FIXTURE_DIR: ${{ runner.temp }}/test-fixtures
         run: go test -coverprofile=coverage.out ./...
 
       - name: Upload coverage
@@ -248,7 +294,7 @@ jobs:
 
   race:
     name: Go Race Tests (${{ matrix.name }})
-    needs: resolve-ref
+    needs: [resolve-ref, build-fixtures]
     if: ${{ inputs.run-race && needs.resolve-ref.outputs.should_validate == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -283,8 +329,18 @@ jobs:
           go-version-file: gestaltd/go.mod
           cache-dependency-path: gestaltd/go.sum
 
+      - name: Download test fixtures
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: gestaltd-test-fixtures
+          path: ${{ runner.temp }}/test-fixtures
+
+      - name: Restore fixture permissions
+        run: chmod +x "${RUNNER_TEMP}/test-fixtures/"*
+
       - name: Run race tests
         env:
+          GESTALT_TEST_FIXTURE_DIR: ${{ runner.temp }}/test-fixtures
           RACE_PACKAGES: ${{ matrix.packages }}
           RACE_PARALLEL: ${{ matrix.parallel }}
         run: |

--- a/gestaltd/internal/bootstrap/testmain_test.go
+++ b/gestaltd/internal/bootstrap/testmain_test.go
@@ -66,12 +66,19 @@ func TestMain(m *testing.M) {
 			output:    sharedAgentProviderBin,
 			sdkModule: true,
 		},
-		{
+	}
+
+	// Reuse a prebuilt gestaltd binary (shared across CI test jobs) when one is
+	// available; otherwise build it alongside the provider fixtures.
+	if prebuilt, ok := testutil.PrebuiltBinary("gestaltd"); ok {
+		sharedGestaltdBin = prebuilt
+	} else {
+		specs = append(specs, buildSpec{
 			name:   "gestaltd",
 			dir:    filepath.Join(root, "gestaltd"),
 			target: "./cmd/gestaltd",
 			output: sharedGestaltdBin,
-		},
+		})
 	}
 
 	errs := make([]error, len(specs))

--- a/gestaltd/internal/daemon/testmain_test.go
+++ b/gestaltd/internal/daemon/testmain_test.go
@@ -51,6 +51,10 @@ func TestMain(m *testing.M) {
 	wg.Add(4)
 	go func() {
 		defer wg.Done()
+		if prebuilt, ok := testutil.PrebuiltBinary("gestaltd"); ok {
+			gestaltdBin = prebuilt
+			return
+		}
 		errs[0] = buildTarget(".", "github.com/valon-technologies/gestalt/server/cmd/gestaltd", gestaltdBin)
 	}()
 	go func() {

--- a/gestaltd/internal/testutil/fixtures.go
+++ b/gestaltd/internal/testutil/fixtures.go
@@ -1,0 +1,32 @@
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// fixtureDirEnv names a directory of prebuilt test fixture binaries. CI builds
+// the expensive binaries once in a shared job and points the test jobs at the
+// downloaded artifact via this variable, so each lane reuses them instead of
+// rebuilding them in TestMain.
+const fixtureDirEnv = "GESTALT_TEST_FIXTURE_DIR"
+
+// PrebuiltBinary returns the path to a prebuilt fixture binary named `name`
+// inside the directory named by GESTALT_TEST_FIXTURE_DIR, and true, when that
+// directory is set and contains an executable file with that name. Otherwise it
+// returns ("", false) and the caller should build the binary itself.
+//
+// The returned path lives outside any per-test temp dir, so callers must not
+// remove or overwrite it; it is shared, read-only, and reused across packages.
+func PrebuiltBinary(name string) (string, bool) {
+	dir := os.Getenv(fixtureDirEnv)
+	if dir == "" {
+		return "", false
+	}
+	path := filepath.Join(dir, name)
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return "", false
+	}
+	return path, true
+}


### PR DESCRIPTION
The daemon and bootstrap integration packages build the full gestaltd binary
(~70MB) in TestMain, so it is compiled in the coverage job and again in the
daemon and bootstrap race lanes. Build it once in a new Build Test Fixtures job,
upload it as an artifact, and have the coverage and race jobs download it and
point GESTALT_TEST_FIXTURE_DIR at it.

testutil.PrebuiltBinary reports a shared binary when that variable is set; the
daemon and bootstrap TestMains use it for gestaltd and fall back to building
locally otherwise, so local 'go test' is unchanged. This trades a small serial
dependency (the build job) for not relinking gestaltd in every lane; the
provider/SDK fixtures still build per-package and can be shared the same way as
a follow-up.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>