### PR TITLE
[gestaltd] build the CI image in parallel with the Go + Helm checks

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,6 +14,7 @@ on:
       - '.dockerignore'
       - '.github/workflows/cd.yml'
       - '.github/workflows/validate-gestaltd.yml'
+      - '.github/workflows/resolve-gestaltd-ref.yml'
       - '.github/actions/build-gestaltd-image/**'
       - 'gestaltd/**'
       - '!gestaltd/rpc/protov1/**'
@@ -28,6 +29,11 @@ permissions:
   contents: read
 
 jobs:
+  resolve-ref:
+    uses: ./.github/workflows/resolve-gestaltd-ref.yml
+    with:
+      ref: ${{ inputs.gestalt_ref }}
+
   validate:
     uses: ./.github/workflows/validate-gestaltd.yml
     with:
@@ -35,10 +41,41 @@ jobs:
       run-race: true
       run-coverage: true
 
+  # Build the image (no push) in parallel with the validation suite. This warms
+  # the shared GHA layer cache so the publish step below is a fast cache hit
+  # rather than a second full compile.
+  build-image:
+    name: Build CI Image
+    needs: resolve-ref
+    if: ${{ needs.resolve-ref.outputs.should_validate == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ needs.resolve-ref.outputs.sha }}
+
+      - uses: ./.github/actions/build-gestaltd-image
+        with:
+          push: 'false'
+          build-alpine: 'false'
+          sha: ${{ needs.resolve-ref.outputs.sha }}
+          version: ${{ needs.resolve-ref.outputs.version }}
+
+  # Publish only after validation passes. Reuses the layer cache warmed by
+  # build-image, so this is build (cache hit) + push + attest + smoke test.
+  #
+  # build-image is in `needs` only to wait for that warmed cache; it is an
+  # optional optimization, so its failure must not block a publish the tests
+  # have already cleared. The `if` therefore gates on validate + resolve-ref
+  # succeeding (not on build-image) and uses !cancelled() so a failed warmup
+  # still lets this run — it just falls back to a full compile.
   build-and-push:
     name: Build & Publish CI Image
-    needs: validate
-    if: ${{ needs.validate.outputs.should-validate == 'true' }}
+    needs: [resolve-ref, validate, build-image]
+    if: ${{ !cancelled() && needs.resolve-ref.result == 'success' && needs.validate.result == 'success' && needs.resolve-ref.outputs.should_validate == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -47,14 +84,14 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ needs.validate.outputs.sha }}
+          ref: ${{ needs.resolve-ref.outputs.sha }}
 
       - uses: ./.github/actions/build-gestaltd-image
         with:
-          push: ${{ needs.validate.outputs.publish == 'true' }}
+          push: ${{ needs.resolve-ref.outputs.publish == 'true' }}
           build-alpine: 'false'
-          sha: ${{ needs.validate.outputs.sha }}
-          version: ${{ needs.validate.outputs.version }}
+          sha: ${{ needs.resolve-ref.outputs.sha }}
+          version: ${{ needs.resolve-ref.outputs.version }}
           registry-host: ${{ vars.GESTALTD_ARTIFACT_REGISTRY_HOST }}
           image-repository: ${{ vars.GESTALTD_CI_IMAGE_REPOSITORY }}
           gcp-service-account: ${{ vars.GESTALTD_CI_GCP_SERVICE_ACCOUNT }}
@@ -65,10 +102,10 @@ jobs:
   # succeed (default needs gating).
   docs-build:
     name: Docs Build
-    needs: [validate, build-and-push]
-    if: ${{ needs.validate.outputs.publish == 'true' }}
+    needs: [resolve-ref, build-and-push]
+    if: ${{ needs.resolve-ref.outputs.publish == 'true' }}
     uses: ./.github/workflows/build-docs.yml
     with:
-      gestalt_ref: ${{ needs.validate.outputs.sha }}
+      gestalt_ref: ${{ needs.resolve-ref.outputs.sha }}
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ permissions:
   contents: read
 
 jobs:
+  resolve-ref:
+    uses: ./.github/workflows/resolve-gestaltd-ref.yml
+
   validate:
     uses: ./.github/workflows/validate-gestaltd.yml
     with:
@@ -22,10 +25,13 @@ jobs:
       run-race: ${{ github.event_name == 'schedule' }}
       run-coverage: ${{ github.event_name == 'schedule' }}
 
+  # Build-only Dockerfile/packaging validation. Depends on resolve-ref rather
+  # than validate so it runs in parallel with the Go + Helm checks instead of
+  # waiting for them.
   build:
     name: Build CI Image
-    needs: validate
-    if: ${{ needs.validate.outputs.should-validate == 'true' }}
+    needs: resolve-ref
+    if: ${{ needs.resolve-ref.outputs.should_validate == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -33,11 +39,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ needs.validate.outputs.sha }}
+          ref: ${{ needs.resolve-ref.outputs.sha }}
 
       - uses: ./.github/actions/build-gestaltd-image
         with:
           push: 'false'
           build-alpine: 'true'
-          sha: ${{ needs.validate.outputs.sha }}
-          version: ${{ needs.validate.outputs.version }}
+          sha: ${{ needs.resolve-ref.outputs.sha }}
+          version: ${{ needs.resolve-ref.outputs.version }}

--- a/.github/workflows/resolve-gestaltd-ref.yml
+++ b/.github/workflows/resolve-gestaltd-ref.yml
@@ -1,0 +1,137 @@
+name: Resolve Gestaltd Build Ref
+
+# Reusable ref-resolution for gestaltd CI/CD. Resolves the commit SHA to build,
+# whether the run should publish, and whether gestaltd validation is required
+# for the triggering event. Extracted from the validation suite so the image
+# build can start from the resolved ref in parallel with the Go + Helm checks.
+# The github context (event name, PR diff) is inherited from the caller.
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Optional full commit SHA to resolve (defaults to the triggering ref).
+        required: false
+        type: string
+    outputs:
+      sha:
+        value: ${{ jobs.resolve.outputs.sha }}
+      version:
+        value: ${{ jobs.resolve.outputs.version }}
+      should_validate:
+        value: ${{ jobs.resolve.outputs.should_validate }}
+      publish:
+        value: ${{ jobs.resolve.outputs.publish }}
+
+permissions:
+  contents: read
+
+jobs:
+  resolve:
+    name: Resolve Build Ref
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      publish: ${{ steps.resolve.outputs.publish }}
+      sha: ${{ steps.resolve.outputs.sha }}
+      should_validate: ${{ steps.resolve.outputs.should_validate }}
+      version: ${{ steps.resolve.outputs.version }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Resolve commit
+        id: resolve
+        env:
+          PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
+          REQUESTED_GESTALT_REF: ${{ inputs.ref || '' }}
+        run: |
+          set -euo pipefail
+
+          requested_ref="${REQUESTED_GESTALT_REF}"
+          if [[ -n "${requested_ref}" && ! "${requested_ref}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "ref must be a full lowercase 40-character commit SHA." >&2
+            exit 1
+          fi
+
+          ref="${requested_ref:-${GITHUB_SHA}}"
+          sha="$(git rev-parse "${ref}^{commit}")"
+          if [[ ! "${sha}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Resolved ref '${ref}' to invalid commit '${sha}'." >&2
+            exit 1
+          fi
+
+          publish="false"
+          if [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" == "refs/heads/main" ]]; then
+            publish="true"
+          fi
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" && -n "${requested_ref}" ]]; then
+            publish="true"
+          fi
+
+          should_validate="true"
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            validate_exact_paths=(
+              ".dockerignore"
+              ".github/workflows/ci.yml"
+              ".github/workflows/cd.yml"
+              ".github/workflows/validate-gestaltd.yml"
+              ".github/workflows/resolve-gestaltd-ref.yml"
+            )
+            validate_path_prefixes=(
+              "gestaltd/"
+              ".github/actions/build-gestaltd-image/"
+            )
+            ignore_path_prefixes=(
+              "gestaltd/rpc/protov1/"
+            )
+
+            should_validate="false"
+            base_sha="${PULL_REQUEST_BASE_SHA}"
+            head_sha="${PULL_REQUEST_HEAD_SHA:-${sha}}"
+
+            if [[ -z "${base_sha}" ]]; then
+              echo "Pull request base SHA is unavailable; running Gestaltd validation." >&2
+              should_validate="true"
+            elif changed_files="$(git diff --name-only "${base_sha}" "${head_sha}")"; then
+              while IFS= read -r changed_file; do
+                for ignored_prefix in "${ignore_path_prefixes[@]}"; do
+                  if [[ "${changed_file}" == "${ignored_prefix}"* ]]; then
+                    continue 2
+                  fi
+                done
+
+                for exact_path in "${validate_exact_paths[@]}"; do
+                  if [[ "${changed_file}" == "${exact_path}" ]]; then
+                    should_validate="true"
+                    break
+                  fi
+                done
+                if [[ "${should_validate}" == "true" ]]; then
+                  break
+                fi
+
+                for path_prefix in "${validate_path_prefixes[@]}"; do
+                  if [[ "${changed_file}" == "${path_prefix}"* ]]; then
+                    should_validate="true"
+                    break
+                  fi
+                done
+                if [[ "${should_validate}" == "true" ]]; then
+                  break
+                fi
+              done <<< "${changed_files}"
+            else
+              echo "Unable to diff pull request files; running Gestaltd validation." >&2
+              should_validate="true"
+            fi
+          fi
+
+          {
+            echo "sha=${sha}"
+            echo "publish=${publish}"
+            echo "should_validate=${should_validate}"
+            echo "version=0.0.0-ci+g${sha:0:12}"
+          } >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/validate-gestaltd.yml
+++ b/.github/workflows/validate-gestaltd.yml
@@ -37,113 +37,14 @@ permissions:
   contents: read
 
 jobs:
+  # Ref resolution lives in its own reusable workflow so the callers (ci.yml /
+  # cd.yml) can resolve the build ref once and start the image build in parallel
+  # with this suite. Its outputs stay accessible here as
+  # needs.resolve-ref.outputs.*.
   resolve-ref:
-    name: Resolve Build Ref
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    outputs:
-      publish: ${{ steps.resolve.outputs.publish }}
-      sha: ${{ steps.resolve.outputs.sha }}
-      should_validate: ${{ steps.resolve.outputs.should_validate }}
-      version: ${{ steps.resolve.outputs.version }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-
-      - name: Resolve commit
-        id: resolve
-        env:
-          PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
-          PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
-          REQUESTED_GESTALT_REF: ${{ inputs.ref || '' }}
-        run: |
-          set -euo pipefail
-
-          requested_ref="${REQUESTED_GESTALT_REF}"
-          if [[ -n "${requested_ref}" && ! "${requested_ref}" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "ref must be a full lowercase 40-character commit SHA." >&2
-            exit 1
-          fi
-
-          ref="${requested_ref:-${GITHUB_SHA}}"
-          sha="$(git rev-parse "${ref}^{commit}")"
-          if [[ ! "${sha}" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "Resolved ref '${ref}' to invalid commit '${sha}'." >&2
-            exit 1
-          fi
-
-          publish="false"
-          if [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" == "refs/heads/main" ]]; then
-            publish="true"
-          fi
-          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" && -n "${requested_ref}" ]]; then
-            publish="true"
-          fi
-
-          should_validate="true"
-          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
-            validate_exact_paths=(
-              ".dockerignore"
-              ".github/workflows/ci.yml"
-              ".github/workflows/cd.yml"
-              ".github/workflows/validate-gestaltd.yml"
-            )
-            validate_path_prefixes=(
-              "gestaltd/"
-              ".github/actions/build-gestaltd-image/"
-            )
-            ignore_path_prefixes=(
-              "gestaltd/rpc/protov1/"
-            )
-
-            should_validate="false"
-            base_sha="${PULL_REQUEST_BASE_SHA}"
-            head_sha="${PULL_REQUEST_HEAD_SHA:-${sha}}"
-
-            if [[ -z "${base_sha}" ]]; then
-              echo "Pull request base SHA is unavailable; running Gestaltd validation." >&2
-              should_validate="true"
-            elif changed_files="$(git diff --name-only "${base_sha}" "${head_sha}")"; then
-              while IFS= read -r changed_file; do
-                for ignored_prefix in "${ignore_path_prefixes[@]}"; do
-                  if [[ "${changed_file}" == "${ignored_prefix}"* ]]; then
-                    continue 2
-                  fi
-                done
-
-                for exact_path in "${validate_exact_paths[@]}"; do
-                  if [[ "${changed_file}" == "${exact_path}" ]]; then
-                    should_validate="true"
-                    break
-                  fi
-                done
-                if [[ "${should_validate}" == "true" ]]; then
-                  break
-                fi
-
-                for path_prefix in "${validate_path_prefixes[@]}"; do
-                  if [[ "${changed_file}" == "${path_prefix}"* ]]; then
-                    should_validate="true"
-                    break
-                  fi
-                done
-                if [[ "${should_validate}" == "true" ]]; then
-                  break
-                fi
-              done <<< "${changed_files}"
-            else
-              echo "Unable to diff pull request files; running Gestaltd validation." >&2
-              should_validate="true"
-            fi
-          fi
-
-          {
-            echo "sha=${sha}"
-            echo "publish=${publish}"
-            echo "should_validate=${should_validate}"
-            echo "version=0.0.0-ci+g${sha:0:12}"
-          } >> "${GITHUB_OUTPUT}"
+    uses: ./.github/workflows/resolve-gestaltd-ref.yml
+    with:
+      ref: ${{ inputs.ref }}
 
   lint:
     name: Go Lint & Vet


### PR DESCRIPTION
The image build waited on the entire validation suite (needs: validate),
serializing ~5 min of tests before the Dockerfile build started, even though it
only needs the resolved build ref.

Extract ref resolution into a reusable resolve-gestaltd-ref.yml so both the
build and the validation suite can consume it. In CI the build job now depends
on resolve-ref and runs in parallel with the checks. In CD the build is split:
build-image (push=false) runs in parallel and warms the shared GHA layer cache,
and build-and-push (push=true) still waits for validate to pass, so publishing
stays gated on the tests — the cache makes that step a fast hit rather than a
second full compile.

validate-gestaltd.yml keeps resolving internally (now via the same reusable
workflow), so its downstream needs.resolve-ref.outputs.* references are
unchanged.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>