### PR TITLE
Default lockfile and artifacts to cwd; remove StatePaths

### DIFF
--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -265,9 +265,9 @@ gestaltd provider release --dist-dir dist --version 0.0.1-alpha.1
 
 When repeated, `--config` files merge left-to-right. Maps deep-merge, later
 scalar values win, lists replace inherited lists, and `null` deletes inherited
-keys. By default, lockfiles and artifact paths stay rooted at the leftmost
-config file. `--lockfile` overrides only the lockfile path. `--artifacts-dir`
-keeps the same config-relative resolution used by `sync` and `serve`.
+keys. By default, lockfiles and artifact paths use the current working directory.
+`--lockfile` overrides only the lockfile path. `--artifacts-dir` overrides only the
+artifacts directory path.
 
 For source-backed providers, `gestaltd serve --path` starts the manifest `run`
 argv when one is declared. If `run` is omitted, it serves or starts the declared

--- a/docs/content/reference/configuration.mdx
+++ b/docs/content/reference/configuration.mdx
@@ -109,10 +109,11 @@ them with these rules:
 - Later lists replace inherited lists.
 - `null` deletes inherited keys.
 
-Relative paths resolve from the file that declared them. By default, lockfiles
-and prepared-artifact paths stay rooted at the leftmost config file.
-`--lockfile` overrides only the lockfile path and resolves like a normal CLI
-path.
+Relative paths resolve from the file that declared them. The lockfile
+defaults to the current working directory (`./gestalt.lock.json`); `--lockfile`
+overrides only the lockfile path and resolves like a normal CLI path. Prepared
+artifact paths default to the current working directory; `server.artifactsDir`
+and `--artifacts-dir` override that location.
 
 ## Environment And Secrets
 

--- a/gestaltd/internal/daemon/agent_local_test.go
+++ b/gestaltd/internal/daemon/agent_local_test.go
@@ -40,7 +40,7 @@ providers:
 		t.Fatalf("write config: %v", err)
 	}
 
-	out, err := exec.Command(gestaltdBin, "agent", "launch", "--config", cfgPath, "--dry-run").CombinedOutput()
+	out, err := gestaltdCommand("agent", "launch", "--config", cfgPath, "--dry-run").CombinedOutput()
 	if err != nil {
 		t.Fatalf("agent launch --dry-run failed: %v\n%s", err, out)
 	}
@@ -115,7 +115,7 @@ providers:
 		t.Fatalf("write config: %v", err)
 	}
 
-	out, err := exec.Command(gestaltdBin, "agent", "launch", "--config", cfgPath).CombinedOutput()
+	out, err := gestaltdCommand("agent", "launch", "--config", cfgPath).CombinedOutput()
 	var exitErr *exec.ExitError
 	if !errors.As(err, &exitErr) {
 		t.Fatalf("agent launch err = %v, want exit status 7\n%s", err, out)
@@ -159,7 +159,7 @@ providers:
 		t.Fatalf("write config: %v", err)
 	}
 
-	out, err := exec.Command(gestaltdBin, "agent", "doctor", "--config", cfgPath).CombinedOutput()
+	out, err := gestaltdCommand("agent", "doctor", "--config", cfgPath).CombinedOutput()
 	if err == nil {
 		t.Fatalf("agent doctor unexpectedly succeeded:\n%s", out)
 	}
@@ -197,7 +197,7 @@ providers:
 		t.Fatalf("write config: %v", err)
 	}
 
-	cmd := exec.Command(gestaltdBin, "agent", "launch", "--config", cfgPath, "--dry-run")
+	cmd := gestaltdCommand("agent", "launch", "--config", cfgPath, "--dry-run")
 	cmd.Env = withoutEnv(os.Environ(), missingEnv, "GESTALT_TEST_MISSING_UNSELECTED_HARNESS_ENV")
 	out, err := cmd.CombinedOutput()
 	if err == nil {

--- a/gestaltd/internal/daemon/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e_test.go
@@ -48,7 +48,7 @@ apps:
 		t.Fatalf("write config audit: %v", err)
 	}
 
-	out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+	out, err := gestaltdCommand("validate", "--config", cfgPath).CombinedOutput()
 	if err == nil {
 		t.Fatalf("expected gestaltd validate to fail, got success\n%s", out)
 	}
@@ -106,7 +106,7 @@ func TestE2EValidateRejectsInvalidAuditSettings(t *testing.T) {
 				t.Fatalf("write config audit: %v", err)
 			}
 
-			out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+			out, err := gestaltdCommand("validate", "--config", cfgPath).CombinedOutput()
 			if err == nil {
 				t.Fatalf("expected gestaltd validate to fail, got success\n%s", out)
 			}
@@ -181,7 +181,7 @@ apps:
 				t.Fatalf("write config: %v", err)
 			}
 
-			out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+			out, err := gestaltdCommand("validate", "--config", cfgPath).CombinedOutput()
 			if err != nil {
 				t.Fatalf("gestaltd validate failed: %v\noutput: %s", err, out)
 			}
@@ -314,7 +314,7 @@ workflows:
 		t.Fatalf("write config: %v", err)
 	}
 
-	out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+	out, err := gestaltdCommand("validate", "--config", cfgPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("gestaltd validate failed: %v\noutput: %s", err, out)
 	}
@@ -384,7 +384,7 @@ apps:
 				t.Fatalf("write invalid config: %v", err)
 			}
 
-			out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+			out, err := gestaltdCommand("validate", "--config", cfgPath).CombinedOutput()
 			if err == nil {
 				t.Fatalf("expected gestaltd validate to fail, got success\n%s", out)
 			}
@@ -402,7 +402,7 @@ func TestE2EProviderValidateIsolatedSourceApp(t *testing.T) {
 	providersDir := setupDefaultLocalProvidersDir(t, dir)
 	appDir := setupAppDir(t, dir)
 
-	cmd := exec.Command(gestaltdBin, "provider", "validate", "--path", appDir)
+	cmd := gestaltdCommand("provider", "validate", "--path", appDir)
 	cmd.Env = append(os.Environ(),
 		"GESTALT_PROVIDERS_DIR="+providersDir,
 		"GOTELEMETRY=off",
@@ -427,7 +427,7 @@ func TestE2EProviderValidateSourceUI(t *testing.T) {
 	mountedUI := setupMountedUIDir(t, dir)
 	setUIManifestSource(t, mountedUI.ManifestPath, "github.com/test/ui/roadmap.review")
 
-	cmd := exec.Command(gestaltdBin, "provider", "validate", "--path", mountedUI.ManifestPath)
+	cmd := gestaltdCommand("provider", "validate", "--path", mountedUI.ManifestPath)
 	cmd.Env = append(os.Environ(),
 		"GESTALT_PROVIDERS_DIR="+providersDir,
 		"GOTELEMETRY=off",
@@ -465,7 +465,7 @@ apps:
 		t.Fatalf("write config: %v", err)
 	}
 
-	cmd := exec.Command(gestaltdBin, "provider", "validate", "--path", appDir, "--config", cfgPath)
+	cmd := gestaltdCommand("provider", "validate", "--path", appDir, "--config", cfgPath)
 	cmd.Env = append(os.Environ(),
 		"GESTALT_PROVIDERS_DIR="+providersDir,
 		"GOTELEMETRY=off",
@@ -485,7 +485,7 @@ func TestE2EProviderValidateRejectsNonAppManifest(t *testing.T) {
 	dir := t.TempDir()
 	manifestPath := componentProviderManifestPath(t, setupIndexedDBProviderDir(t, dir))
 
-	out, err := exec.Command(gestaltdBin, "provider", "validate", "--path", manifestPath).CombinedOutput()
+	out, err := gestaltdCommand("provider", "validate", "--path", manifestPath).CombinedOutput()
 	if err == nil {
 		t.Fatalf("expected gestaltd provider validate to fail for non-app manifest\n%s", out)
 	}
@@ -546,7 +546,7 @@ apps:
 		t.Fatalf("write support override: %v", err)
 	}
 
-	failingCmd := exec.Command(gestaltdBin, "provider", "validate", "--path", targetDir, "--config", baseCfgPath)
+	failingCmd := gestaltdCommand("provider", "validate", "--path", targetDir, "--config", baseCfgPath)
 	failingCmd.Env = append(os.Environ(),
 		"GESTALT_PROVIDERS_DIR="+providersDir,
 		"GOTELEMETRY=off",
@@ -559,7 +559,7 @@ apps:
 		t.Fatalf("expected mount collision error, got: %s", failingOut)
 	}
 
-	successCmd := exec.Command(gestaltdBin, "provider", "validate", "--path", targetDir, "--config", baseCfgPath, "--config", overrideCfgPath)
+	successCmd := gestaltdCommand("provider", "validate", "--path", targetDir, "--config", baseCfgPath, "--config", overrideCfgPath)
 	successCmd.Env = append(os.Environ(),
 		"GESTALT_PROVIDERS_DIR="+providersDir,
 		"GOTELEMETRY=off",
@@ -670,7 +670,7 @@ func TestE2EValidateConfigPathPrecedence(t *testing.T) {
 				args = append(args, tc.before(t, root, home, workdir)...)
 			}
 
-			cmd := exec.Command(gestaltdBin, args...)
+			cmd := gestaltdCommand(args...)
 			cmd.Dir = workdir
 			cmd.Env = append(os.Environ(),
 				"HOME="+home,
@@ -742,7 +742,7 @@ apps:
 		t.Fatalf("WriteFile override config: %v", err)
 	}
 
-	out, err := exec.Command(gestaltdBin, "validate", "--config", baseConfigPath).CombinedOutput()
+	out, err := gestaltdCommand("validate", "--config", baseConfigPath).CombinedOutput()
 	if err == nil {
 		t.Fatalf("expected base config validate to fail, output: %s", out)
 	}
@@ -750,7 +750,7 @@ apps:
 		t.Fatalf("expected base config failure to mention missing manifest, got: %s", out)
 	}
 
-	out, err = exec.Command(gestaltdBin, "validate", "--config", baseConfigPath, "--config", overrideConfigPath).CombinedOutput()
+	out, err = gestaltdCommand("validate", "--config", baseConfigPath, "--config", overrideConfigPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("expected layered config validate to succeed: %v\n%s", err, out)
 	}
@@ -790,7 +790,7 @@ apps:
 		t.Fatalf("WriteFile config: %v", err)
 	}
 
-	out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+	out, err := gestaltdCommand("validate", "--config", cfgPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("expected validate to succeed: %v\n%s", err, out)
 	}
@@ -804,7 +804,7 @@ apps:
 		t.Fatalf("validate should not leave prepared artifacts in config dir, got err=%v", err)
 	}
 	overrideLockfilePath := filepath.Join(dir, "state", "validate", operator.LockfileName)
-	out, err = exec.Command(gestaltdBin, "validate", "--config", cfgPath, "--lockfile", overrideLockfilePath).CombinedOutput()
+	out, err = gestaltdCommand("validate", "--config", cfgPath, "--lockfile", overrideLockfilePath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("expected validate with --lockfile to succeed: %v\n%s", err, out)
 	}
@@ -813,7 +813,7 @@ apps:
 	}
 
 	providedArtifactsDir := filepath.Join(dir, "artifacts", "validate")
-	out, err = exec.Command(gestaltdBin, "validate", "--config", cfgPath, "--artifacts-dir", providedArtifactsDir).CombinedOutput()
+	out, err = gestaltdCommand("validate", "--config", cfgPath, "--artifacts-dir", providedArtifactsDir).CombinedOutput()
 	if err == nil {
 		t.Fatalf("expected validate with --artifacts-dir to fail, got success:\n%s", out)
 	}
@@ -836,7 +836,7 @@ func TestE2EValidateStaticAcceptsMissingRuntimeEnvPlaceholder(t *testing.T) {
 		t.Fatalf("write config: %v", err)
 	}
 
-	out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+	out, err := gestaltdCommand("validate", "--config", cfgPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("expected static validate to succeed with missing runtime env placeholder: %v\n%s", err, out)
 	}
@@ -880,7 +880,7 @@ apps:
 		t.Fatalf("write config: %v", err)
 	}
 	lockPath := filepath.Join(dir, "gestalt.lock.json")
-	out, err := exec.Command(gestaltdBin, "lock", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
+	out, err := gestaltdCommand("lock", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("gestaltd lock failed: %v\n%s", err, out)
 	}
@@ -918,7 +918,7 @@ apps:
 		t.Fatalf("write lockfile: %v", err)
 	}
 
-	out, err = exec.Command(gestaltdBin, "validate", "--platform", "linux/amd64", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
+	out, err = gestaltdCommand("validate", "--platform", "linux/amd64", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("expected platform validate to use locked static metadata: %v\n%s", err, out)
 	}
@@ -973,13 +973,13 @@ apps:
 		}
 	}
 	writeConfig("echo")
-	out, err := exec.Command(gestaltdBin, "lock", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
+	out, err := gestaltdCommand("lock", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("gestaltd lock failed: %v\n%s", err, out)
 	}
 
 	writeConfig("greet")
-	out, err = exec.Command(gestaltdBin, "validate", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
+	out, err = gestaltdCommand("validate", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
 	if err == nil {
 		t.Fatalf("expected stale static catalog metadata to fail validation:\n%s", out)
 	}
@@ -1019,7 +1019,7 @@ apps:
 		t.Fatalf("write config: %v", err)
 	}
 	lockPath := filepath.Join(dir, "missing.lock.json")
-	out, err := exec.Command(gestaltdBin, "validate", "--platform", runtime.GOOS+"/"+runtime.GOARCH, "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
+	out, err := gestaltdCommand("validate", "--platform", runtime.GOOS+"/"+runtime.GOARCH, "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
 	if err == nil {
 		t.Fatalf("expected explicit missing lockfile to fail:\n%s", out)
 	}
@@ -1061,7 +1061,7 @@ apps:
 		t.Fatalf("WriteFile config: %v", err)
 	}
 
-	out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+	out, err := gestaltdCommand("validate", "--config", cfgPath).CombinedOutput()
 	if err == nil {
 		t.Fatalf("expected validate to fail, got success:\n%s", out)
 	}
@@ -1129,7 +1129,7 @@ apps:
 		t.Fatalf("WriteFile config: %v", err)
 	}
 
-	out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+	out, err := gestaltdCommand("validate", "--config", cfgPath).CombinedOutput()
 	if err == nil {
 		t.Fatalf("expected validate to fail, got success:\n%s", out)
 	}
@@ -1898,7 +1898,7 @@ func TestE2EServeSplitManagementRoutes(t *testing.T) {
 	managementURL := fmt.Sprintf("http://127.0.0.1:%d", managementPort)
 	cfgPath := writeServeConfigWithManagement(t, dir, publicPort, managementPort, mountedUI)
 
-	cmd := exec.Command(gestaltdBin, "serve", "--config", cfgPath)
+	cmd := gestaltdCommand("serve", "--config", cfgPath)
 	releasePortHoldersAndStart(t, []net.Listener{publicHolder, managementHolder}, func() {
 		startCommandAndWaitReadyForURLs(t, cmd, []string{publicURL, managementURL})
 	})
@@ -1989,7 +1989,7 @@ func TestE2ELockLocalProviders(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := writeServeConfig(t, dir, 0, nil)
 
-	out, err := exec.Command(gestaltdBin, "lock", "--config", cfgPath).CombinedOutput()
+	out, err := gestaltdCommand("lock", "--config", cfgPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("gestaltd lock failed: %v\noutput: %s", err, out)
 	}
@@ -2053,15 +2053,15 @@ providers:
 	}
 
 	lockPath := filepath.Join(dir, "gestalt.lock.json")
-	out, err := exec.Command(gestaltdBin, "lock", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
+	out, err := gestaltdCommand("lock", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("gestaltd lock should not resolve runtime secret refs: %v\n%s", err, out)
 	}
-	out, err = exec.Command(gestaltdBin, "sync", "--locked", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
+	out, err = gestaltdCommand("sync", "--locked", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("gestaltd sync should not resolve runtime secret refs: %v\n%s", err, out)
 	}
-	out, err = exec.Command(gestaltdBin, "validate", "--runtime", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
+	out, err = gestaltdCommand("validate", "--runtime", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
 	if err == nil {
 		t.Fatalf("gestaltd validate --runtime unexpectedly succeeded without runtime secret:\n%s", out)
 	}
@@ -2074,22 +2074,24 @@ func TestRunLockSyncLocalProviders(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "gestalt.lock.json")
+	artifactsDir := filepath.Join(dir, "artifacts")
 	cfgPath := writeServeConfig(t, dir, 0, nil)
 
-	if err := runLock([]string{"--config", cfgPath}); err != nil {
+	if err := runLock([]string{"--config", cfgPath, "--lockfile", lockPath}); err != nil {
 		t.Fatalf("runLock: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(dir, "gestalt.lock.json")); err != nil {
-		t.Fatalf("expected default lockfile: %v", err)
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("expected lockfile at %s: %v", lockPath, err)
 	}
 	if _, err := os.Stat(filepath.Join(dir, ".gestaltd")); !os.IsNotExist(err) {
 		t.Fatalf("lock should not prepare final artifacts, got err=%v", err)
 	}
-	if err := runLock([]string{"--check", "--config", cfgPath}); err != nil {
+	if err := runLock([]string{"--check", "--config", cfgPath, "--lockfile", lockPath}); err != nil {
 		t.Fatalf("runLock --check: %v", err)
 	}
 
-	err := runSync([]string{"--locked", "--check", "--config", cfgPath})
+	err := runSync([]string{"--locked", "--check", "--config", cfgPath, "--lockfile", lockPath, "--artifacts-dir", artifactsDir})
 	if err == nil {
 		t.Fatal("runSync --check before sync unexpectedly succeeded")
 	}
@@ -2097,17 +2099,17 @@ func TestRunLockSyncLocalProviders(t *testing.T) {
 		t.Fatalf("sync --check error should report artifacts would be materialized, got: %v", err)
 	}
 
-	if err := runSync([]string{"--locked", "--config", cfgPath}); err != nil {
+	if err := runSync([]string{"--locked", "--config", cfgPath, "--lockfile", lockPath, "--artifacts-dir", artifactsDir}); err != nil {
 		t.Fatalf("runSync: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(dir, "providers", "example")); err != nil {
+	if _, err := os.Stat(filepath.Join(artifactsDir, "providers", "example")); err != nil {
 		t.Fatalf("expected synced app artifact: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(dir, "indexeddb", "inmem")); err != nil {
+	if _, err := os.Stat(filepath.Join(artifactsDir, "indexeddb", "inmem")); err != nil {
 		t.Fatalf("expected synced indexeddb artifact: %v", err)
 	}
 
-	if err := runSync([]string{"--locked", "--check", "--config", cfgPath}); err != nil {
+	if err := runSync([]string{"--locked", "--check", "--config", cfgPath, "--lockfile", lockPath, "--artifacts-dir", artifactsDir}); err != nil {
 		t.Fatalf("runSync --check after sync: %v", err)
 	}
 }
@@ -2118,12 +2120,12 @@ func TestRunSyncStaleLocalProviderRemediation(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := writeServeConfig(t, dir, 0, nil)
 	lockPath := filepath.Join(dir, "gestalt.lock.json")
-	if err := runLock([]string{"--config", cfgPath}); err != nil {
+	if err := runLock([]string{"--config", cfgPath, "--lockfile", lockPath}); err != nil {
 		t.Fatalf("runLock: %v", err)
 	}
 
 	staleCfgPath := writeRenamedProviderConfig(t, dir, cfgPath)
-	err := runSync([]string{"--locked", "--check", "--config", staleCfgPath, "--artifacts-dir", filepath.Join(dir, "prepared")})
+	err := runSync([]string{"--locked", "--check", "--config", staleCfgPath, "--lockfile", lockPath, "--artifacts-dir", filepath.Join(dir, "prepared")})
 	if err == nil {
 		t.Fatal("runSync --check with stale lock unexpectedly succeeded")
 	}
@@ -2132,7 +2134,7 @@ func TestRunSyncStaleLocalProviderRemediation(t *testing.T) {
 	}
 
 	staleArtifactsDir := filepath.Join(dir, "prepared-stale")
-	if err := runSync([]string{"--locked", "--config", staleCfgPath, "--artifacts-dir", staleArtifactsDir}); err != nil {
+	if err := runSync([]string{"--locked", "--config", staleCfgPath, "--lockfile", lockPath, "--artifacts-dir", staleArtifactsDir}); err != nil {
 		t.Fatalf("runSync with renamed local provider: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(staleArtifactsDir, "providers", "renamed")); err != nil {
@@ -2188,19 +2190,19 @@ func TestRunLockSyncLayeredConfigs(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	basePath, overridePath, lockPath, _ := writeLayeredE2EConfigs(t, dir, 0)
+	basePath, overridePath, lockPath, artifactsDir := writeLayeredE2EConfigs(t, dir, 0)
 
-	if err := runLock([]string{"--config", basePath, "--config", overridePath}); err != nil {
+	if err := runLock([]string{"--config", basePath, "--config", overridePath, "--lockfile", lockPath}); err != nil {
 		t.Fatalf("runLock with layered configs: %v", err)
 	}
 	if _, err := os.Stat(lockPath); err != nil {
 		t.Fatalf("expected lock file at %s: %v", lockPath, err)
 	}
-	if err := runSync([]string{"--locked", "--config", basePath, "--config", overridePath}); err != nil {
+	if err := runSync([]string{"--locked", "--config", basePath, "--config", overridePath, "--lockfile", lockPath, "--artifacts-dir", artifactsDir}); err != nil {
 		t.Fatalf("runSync with layered configs: %v", err)
 	}
 
-	env, err := setupBootstrapWithConfigPaths([]string{basePath, overridePath}, operator.StatePaths{}, true, false)
+	env, err := setupBootstrapWithConfigPaths([]string{basePath, overridePath}, lockPath, artifactsDir, true, false)
 	if err != nil {
 		t.Fatalf("setupBootstrapWithConfigPaths locked layered configs: %v", err)
 	}
@@ -2222,11 +2224,12 @@ func TestRunServeLockedUsesOverrideLockfile(t *testing.T) {
 	if err := runLock([]string{"--config", cfgPath, "--lockfile", lockPath}); err != nil {
 		t.Fatalf("runLock with --lockfile: %v", err)
 	}
-	if err := runSync([]string{"--locked", "--config", cfgPath, "--lockfile", lockPath}); err != nil {
+	artifactsDir := filepath.Join(dir, "artifacts")
+	if err := runSync([]string{"--locked", "--config", cfgPath, "--lockfile", lockPath, "--artifacts-dir", artifactsDir}); err != nil {
 		t.Fatalf("runSync with --lockfile: %v", err)
 	}
 
-	env, err := setupBootstrapWithConfigPaths([]string{cfgPath}, operator.StatePaths{LockfilePath: lockPath}, true, false)
+	env, err := setupBootstrapWithConfigPaths([]string{cfgPath}, lockPath, artifactsDir, true, false)
 	if err != nil {
 		t.Fatalf("setupBootstrapWithConfigPaths locked with --lockfile: %v", err)
 	}

--- a/gestaltd/internal/daemon/factories.go
+++ b/gestaltd/internal/daemon/factories.go
@@ -13,7 +13,6 @@ import (
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
-	"github.com/valon-technologies/gestalt/server/internal/operator"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	telemetrynoop "github.com/valon-technologies/gestalt/server/services/observability/drivers/noop"
 	telemetryotlp "github.com/valon-technologies/gestalt/server/services/observability/drivers/otlp"
@@ -34,13 +33,13 @@ type bootstrapEnv struct {
 	prevLogger *slog.Logger
 }
 
-func setupBootstrapWithConfigPaths(configPaths []string, state operator.StatePaths, locked, noSync bool, forcedDevUIKeys ...string) (*bootstrapEnv, error) {
+func setupBootstrapWithConfigPaths(configPaths []string, lockfilePath, artifactsDir string, locked, noSync bool, forcedDevUIKeys ...string) (*bootstrapEnv, error) {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	return setupBootstrapWithConfigPathsContext(ctx, stop, configPaths, state, locked, noSync, forcedDevUIKeys...)
+	return setupBootstrapWithConfigPathsContext(ctx, stop, configPaths, lockfilePath, artifactsDir, locked, noSync, forcedDevUIKeys...)
 }
 
-func setupBootstrapWithConfigPathsContext(ctx context.Context, stop context.CancelFunc, configPaths []string, state operator.StatePaths, locked, noSync bool, forcedDevUIKeys ...string) (*bootstrapEnv, error) {
-	cfg, err := loadConfigForExecutionAtPathsWithStatePaths(configPaths, state, locked, noSync, forcedDevUIKeys...)
+func setupBootstrapWithConfigPathsContext(ctx context.Context, stop context.CancelFunc, configPaths []string, lockfilePath, artifactsDir string, locked, noSync bool, forcedDevUIKeys ...string) (*bootstrapEnv, error) {
+	cfg, err := loadConfigForExecutionAtPaths(configPaths, lockfilePath, artifactsDir, locked, noSync, forcedDevUIKeys...)
 	if err != nil {
 		stop()
 		return nil, err

--- a/gestaltd/internal/daemon/lifecycle.go
+++ b/gestaltd/internal/daemon/lifecycle.go
@@ -16,49 +16,49 @@ func operatorLifecycle() *operator.Lifecycle {
 	})
 }
 
-func lockConfigWithStatePaths(configFlags []string, state operator.StatePaths, check bool) error {
+func lockConfig(configFlags []string, lockfilePath, artifactsDir string, check bool) error {
 	configPaths := operator.ResolveConfigPaths(configFlags)
 	if check {
-		return operatorLifecycle().CheckLockAtPathsWithStatePaths(configPaths, state)
+		return operatorLifecycle().CheckLockAtPaths(configPaths, lockfilePath, artifactsDir)
 	}
-	_, err := operatorLifecycle().LockAtPathsWithStatePaths(configPaths, state)
+	_, err := operatorLifecycle().LockAtPaths(configPaths, lockfilePath, artifactsDir)
 	return err
 }
 
-func syncConfigWithStatePaths(configFlags []string, state operator.StatePaths, check bool) error {
-	return syncConfigWithStatePathsOptions(configFlags, state, check, operator.SyncOptions{Parallelism: 1})
+func syncConfig(configFlags []string, lockfilePath, artifactsDir string, check bool) error {
+	return syncConfigOptions(configFlags, lockfilePath, artifactsDir, check, operator.SyncOptions{Parallelism: 1})
 }
 
-func syncConfigWithStatePathsOptions(configFlags []string, state operator.StatePaths, check bool, opts operator.SyncOptions) error {
+func syncConfigOptions(configFlags []string, lockfilePath, artifactsDir string, check bool, opts operator.SyncOptions) error {
 	configPaths := operator.ResolveConfigPaths(configFlags)
 	if check {
-		return operatorLifecycle().CheckSyncAtPathsWithStatePathsOptions(configPaths, state, opts)
+		return operatorLifecycle().CheckSyncAtPathsOptions(configPaths, lockfilePath, artifactsDir, opts)
 	}
-	return operatorLifecycle().SyncAtPathsWithStatePathsOptions(configPaths, state, opts)
+	return operatorLifecycle().SyncAtPathsOptions(configPaths, lockfilePath, artifactsDir, opts)
 }
 
-func loadConfigForExecutionAtPathsWithStatePaths(configPaths []string, state operator.StatePaths, locked, noSync bool, forcedDevUIKeys ...string) (*config.Config, error) {
+func loadConfigForExecutionAtPaths(configPaths []string, lockfilePath, artifactsDir string, locked, noSync bool, forcedDevUIKeys ...string) (*config.Config, error) {
 	lc := operatorLifecycle().WithDevServeEligible(!locked)
 	if len(forcedDevUIKeys) > 0 {
 		lc = lc.WithForcedDevUIKeys(forcedDevUIKeys)
 	}
-	cfg, _, err := lc.LoadForExecutionAtPathsWithStatePaths(configPaths, state, locked, noSync)
+	cfg, _, err := lc.LoadForExecutionAtPaths(configPaths, lockfilePath, artifactsDir, locked, noSync)
 	if err != nil {
 		return nil, err
 	}
 	return cfg, nil
 }
 
-func loadConfigForValidationWithStatePaths(configFlags []string, state operator.StatePaths, opts validateConfigOptions) ([]string, *config.Config, error) {
+func loadConfigForValidation(configFlags []string, lockfilePath, artifactsDir string, opts validateConfigOptions) ([]string, *config.Config, error) {
 	configPaths := operator.ResolveConfigPaths(configFlags)
 	var (
 		cfg *config.Config
 		err error
 	)
 	if opts.Runtime {
-		cfg, err = operatorLifecycle().LoadForValidationAtPathsWithStatePaths(configPaths, state)
+		cfg, err = operatorLifecycle().LoadForValidationAtPaths(configPaths, lockfilePath, artifactsDir)
 	} else {
-		cfg, err = operatorLifecycle().LoadForStaticValidationAtPathsWithStatePaths(configPaths, state, operator.StaticValidationOptions{Platform: opts.Platform})
+		cfg, err = operatorLifecycle().LoadForStaticValidationAtPaths(configPaths, lockfilePath, artifactsDir, operator.StaticValidationOptions{Platform: opts.Platform})
 	}
 	if err != nil {
 		return nil, nil, err

--- a/gestaltd/internal/daemon/main_test.go
+++ b/gestaltd/internal/daemon/main_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -74,7 +73,7 @@ func TestE2ECLIHelp(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			out, err := exec.Command(gestaltdBin, tc.args...).CombinedOutput()
+			out, err := gestaltdCommand(tc.args...).CombinedOutput()
 			if err != nil {
 				t.Fatalf("gestaltd %s: %v\n%s", strings.Join(tc.args, " "), err, out)
 			}
@@ -95,7 +94,7 @@ func TestE2ECLIHelp(t *testing.T) {
 func TestRunLockRejectsPlatformFlag(t *testing.T) {
 	t.Parallel()
 
-	out, err := exec.Command(gestaltdBin, "lock", "--platform", "linux/amd64").CombinedOutput()
+	out, err := gestaltdCommand("lock", "--platform", "linux/amd64").CombinedOutput()
 	if err == nil {
 		t.Fatalf("gestaltd lock --platform unexpectedly succeeded:\n%s", out)
 	}
@@ -107,7 +106,7 @@ func TestRunLockRejectsPlatformFlag(t *testing.T) {
 func TestE2ECLITopLevelVersionShortFlag(t *testing.T) {
 	t.Parallel()
 
-	out, err := exec.Command(gestaltdBin, "-v").CombinedOutput()
+	out, err := gestaltdCommand("-v").CombinedOutput()
 	if err != nil {
 		t.Fatalf("gestaltd -v: %v\n%s", err, out)
 	}
@@ -223,7 +222,7 @@ func TestE2ESyncJSONStdoutCleanWithSourceBuildOutput(t *testing.T) {
 		t.Fatalf("close unrelated sparse file: %v", err)
 	}
 
-	out, err := exec.Command(gestaltdBin, "lock", "--config", configPath).CombinedOutput()
+	out, err := gestaltdCommand("lock", "--config", configPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("gestaltd lock: %v\n%s", err, out)
 	}
@@ -231,7 +230,7 @@ func TestE2ESyncJSONStdoutCleanWithSourceBuildOutput(t *testing.T) {
 		t.Fatalf("remove prepared provider: %v", err)
 	}
 
-	cmd := exec.Command(gestaltdBin, "sync", "--locked", "--verbose", "--output-format=json", "--config", configPath)
+	cmd := gestaltdCommand("sync", "--locked", "--verbose", "--output-format=json", "--config", configPath)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -260,7 +259,7 @@ func TestE2ESyncJSONStdoutCleanWithSourceBuildOutput(t *testing.T) {
 
 	stdout.Reset()
 	stderr.Reset()
-	cmd = exec.Command(gestaltdBin, "sync", "--locked", "--check", "--output-format=json", "--config", configPath)
+	cmd = gestaltdCommand("sync", "--locked", "--check", "--output-format=json", "--config", configPath)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
@@ -296,7 +295,7 @@ func TestE2ESyncDefaultSuccessIsQuiet(t *testing.T) {
 	}
 	configPath := writeE2EConfig(t, dir, appDir, 18080)
 
-	out, err := exec.Command(gestaltdBin, "lock", "--config", configPath).CombinedOutput()
+	out, err := gestaltdCommand("lock", "--config", configPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("gestaltd lock: %v\n%s", err, out)
 	}
@@ -304,7 +303,7 @@ func TestE2ESyncDefaultSuccessIsQuiet(t *testing.T) {
 		t.Fatalf("remove prepared provider: %v", err)
 	}
 
-	cmd := exec.Command(gestaltdBin, "sync", "--locked", "--config", configPath)
+	cmd := gestaltdCommand("sync", "--locked", "--config", configPath)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -323,7 +322,7 @@ func TestE2ESyncJSONFailureLeavesStdoutEmpty(t *testing.T) {
 	t.Parallel()
 
 	missingConfig := filepath.Join(t.TempDir(), "missing.yaml")
-	cmd := exec.Command(gestaltdBin, "sync", "--locked", "--output-format=json", "--config", missingConfig)
+	cmd := gestaltdCommand("sync", "--locked", "--output-format=json", "--config", missingConfig)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -366,7 +365,7 @@ func TestE2ESyncJSONStdoutCleanWithPrepareOnlyBuildOutput(t *testing.T) {
 	writeManifestFile(t, appDir, manifest)
 	configPath := writeE2EConfig(t, dir, appDir, 18080)
 
-	out, err := exec.Command(gestaltdBin, "lock", "--config", configPath).CombinedOutput()
+	out, err := gestaltdCommand("lock", "--config", configPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("gestaltd lock: %v\n%s", err, out)
 	}
@@ -374,7 +373,7 @@ func TestE2ESyncJSONStdoutCleanWithPrepareOnlyBuildOutput(t *testing.T) {
 		t.Fatalf("remove prepared provider: %v", err)
 	}
 
-	cmd := exec.Command(gestaltdBin, "sync", "--locked", "--output-format=json", "--config", configPath)
+	cmd := gestaltdCommand("sync", "--locked", "--output-format=json", "--config", configPath)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -419,11 +418,11 @@ packages:
 	}
 	indexURL := (&url.URL{Scheme: "file", Path: indexPath}).String()
 
-	out, err := exec.Command(gestaltdBin, "provider", "repo", "add", "local", indexURL, "--config", cfgPath).CombinedOutput()
+	out, err := gestaltdCommand("provider", "repo", "add", "local", indexURL, "--config", cfgPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("provider repo add failed: %v\n%s", err, out)
 	}
-	out, err = exec.Command(gestaltdBin, "provider", "add", "github.com/acme/providers/alpha", "--config", cfgPath, "--repo", "local", "--name", "alpha", "--no-lock").CombinedOutput()
+	out, err = gestaltdCommand("provider", "add", "github.com/acme/providers/alpha", "--config", cfgPath, "--repo", "local", "--name", "alpha", "--no-lock").CombinedOutput()
 	if err != nil {
 		t.Fatalf("provider add failed: %v\n%s", err, out)
 	}
@@ -496,7 +495,7 @@ func TestE2ECLIRejectsBadArgs(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			out, err := exec.Command(gestaltdBin, tc.args...).CombinedOutput()
+			out, err := gestaltdCommand(tc.args...).CombinedOutput()
 			if err == nil {
 				t.Fatalf("expected gestaltd %s to fail, output: %s", strings.Join(tc.args, " "), out)
 			}

--- a/gestaltd/internal/daemon/provider_lifecycle.go
+++ b/gestaltd/internal/daemon/provider_lifecycle.go
@@ -332,8 +332,8 @@ func providerSourceBacked(entry *config.ProviderEntry) bool {
 	return entry != nil && (entry.Source.IsPackage() || entry.Source.IsMetadataURL() || entry.Source.IsGitHubRelease() || entry.Source.IsLocal() || entry.Source.IsLocalMetadataPath())
 }
 
-func readProviderListLockfile(configPath, lockfilePath string) (*operator.Lockfile, error) {
-	path := resolveProviderLockfilePath(configPath, lockfilePath)
+func readProviderListLockfile(lockfilePath string) (*operator.Lockfile, error) {
+	path := resolveProviderLockfilePath(lockfilePath)
 	lock, err := operator.ReadLockfile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -344,9 +344,12 @@ func readProviderListLockfile(configPath, lockfilePath string) (*operator.Lockfi
 	return lock, nil
 }
 
-func resolveProviderLockfilePath(configPath, lockfilePath string) string {
+func resolveProviderLockfilePath(lockfilePath string) string {
 	if strings.TrimSpace(lockfilePath) == "" {
-		return filepath.Join(filepath.Dir(configPath), operator.LockfileName)
+		if cwd, err := os.Getwd(); err == nil {
+			return filepath.Join(cwd, operator.LockfileName)
+		}
+		return operator.LockfileName
 	}
 	if filepath.IsAbs(lockfilePath) {
 		return lockfilePath
@@ -421,11 +424,9 @@ func preflightProviderConfigMutation(configPath string, root *yaml.Node, lockfil
 		return nil, err
 	}
 	defer func() { _ = os.RemoveAll(scratchDir) }()
-	scratchState := operator.StatePaths{
-		ArtifactsDir: filepath.Join(scratchDir, "artifacts"),
-		LockfilePath: filepath.Join(scratchDir, operator.LockfileName),
-	}
-	lock, err := operatorLifecycle().LockAtPathsWithStatePaths([]string{tempConfigPath}, scratchState)
+	scratchArtifactsDir := filepath.Join(scratchDir, "artifacts")
+	scratchLockfilePath := filepath.Join(scratchDir, operator.LockfileName)
+	lock, err := operatorLifecycle().LockAtPaths([]string{tempConfigPath}, scratchLockfilePath, scratchArtifactsDir)
 	if err != nil {
 		return nil, err
 	}
@@ -433,7 +434,7 @@ func preflightProviderConfigMutation(configPath string, root *yaml.Node, lockfil
 		ConfigPath: configPath,
 		Root:       root,
 		Lock:       lock,
-		LockPath:   resolveProviderLockfilePath(configPath, lockfilePath),
+		LockPath:   resolveProviderLockfilePath(lockfilePath),
 	}, nil
 }
 

--- a/gestaltd/internal/daemon/provider_lifecycle_test.go
+++ b/gestaltd/internal/daemon/provider_lifecycle_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -562,7 +561,7 @@ func runGestaltdResult(args ...string) (string, error) {
 }
 
 func runGestaltdResultWithEnv(env []string, args ...string) (string, error) {
-	cmd := exec.Command(gestaltdBin, args...)
+	cmd := gestaltdCommand(args...)
 	if len(env) > 0 {
 		cmd.Env = append(os.Environ(), env...)
 	}

--- a/gestaltd/internal/daemon/provider_local.go
+++ b/gestaltd/internal/daemon/provider_local.go
@@ -53,7 +53,8 @@ type providerLocalSession struct {
 	TargetKeys        []string
 	DevUIKeys         []string
 	ConfigPaths       []string
-	State             operator.StatePaths
+	LockfilePath      string
+	ArtifactsDir      string
 	Locked            bool
 	NoSync            bool
 	PublicPort        int
@@ -95,7 +96,13 @@ func runProviderValidate(args []string) error {
 	}
 	defer func() { _ = os.RemoveAll(session.Dir) }()
 
-	result, err := validateConfigWithStatePaths(session.ConfigPaths, session.State, validateConfigOptions{Runtime: true})
+	scratchArtifactsDir, err := os.MkdirTemp("", "gestaltd-provider-validate-*")
+	if err != nil {
+		return fmt.Errorf("create validation scratch dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(scratchArtifactsDir) }()
+
+	result, err := validateConfigAtPaths(session.ConfigPaths, session.LockfilePath, scratchArtifactsDir, validateConfigOptions{Runtime: true})
 	if err != nil {
 		return err
 	}
@@ -121,7 +128,7 @@ func runServeProviderLocal(opts providerLocalCommandOptions) error {
 	if session.Locked {
 		forcedDevUIKeys = session.DevUIKeys
 	}
-	env, err := setupBootstrapWithConfigPaths(session.ConfigPaths, session.State, session.Locked, session.NoSync, forcedDevUIKeys...)
+	env, err := setupBootstrapWithConfigPaths(session.ConfigPaths, session.LockfilePath, session.ArtifactsDir, session.Locked, session.NoSync, forcedDevUIKeys...)
 	if err != nil {
 		return err
 	}
@@ -238,8 +245,8 @@ type validatedConfigResult struct {
 	Warnings []string
 }
 
-func validateConfigWithStatePaths(configFlags []string, state operator.StatePaths, opts validateConfigOptions) (*validatedConfigResult, error) {
-	paths, cfg, err := loadConfigForValidationWithStatePaths(configFlags, state, opts)
+func validateConfigAtPaths(configFlags []string, lockfilePath, artifactsDir string, opts validateConfigOptions) (*validatedConfigResult, error) {
+	paths, cfg, err := loadConfigForValidation(configFlags, lockfilePath, artifactsDir, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -277,10 +284,8 @@ func prepareProviderLocalSession(opts providerLocalCommandOptions) (*providerLoc
 	}()
 
 	var configPaths []string
-	state := operator.StatePaths{
-		ArtifactsDir: opts.ArtifactsDir,
-		LockfilePath: opts.LockfilePath,
-	}
+	lockfilePath := opts.LockfilePath
+	artifactsDir := opts.ArtifactsDir
 	locked := opts.Locked && opts.FleetOverlay
 	noSync := opts.NoSync && opts.FleetOverlay
 	devPort := 0
@@ -293,10 +298,8 @@ func prepareProviderLocalSession(opts providerLocalCommandOptions) (*providerLoc
 			return nil, err
 		}
 		configPaths = append([]string{baseConfigPath}, opts.ConfigPaths...)
-		state = operator.StatePaths{
-			ArtifactsDir: filepath.Join(sessionDir, "artifacts"),
-			LockfilePath: filepath.Join(sessionDir, "gestalt.lock.json"),
-		}
+		lockfilePath = filepath.Join(sessionDir, operator.LockfileName)
+		artifactsDir = filepath.Join(sessionDir, "artifacts")
 		locked = false
 		selectedPort, err := reserveLocalPort()
 		if err != nil {
@@ -345,7 +348,8 @@ func prepareProviderLocalSession(opts providerLocalCommandOptions) (*providerLoc
 		TargetKeys:    targetKeys,
 		DevUIKeys:     devUIKeys,
 		ConfigPaths:   configPaths,
-		State:         state,
+		LockfilePath:  lockfilePath,
+		ArtifactsDir:  artifactsDir,
 		Locked:        locked,
 		NoSync:        noSync,
 		PublicPort:    opts.Port,
@@ -690,8 +694,8 @@ func logProviderLocalSummary(message string, session *providerLocalSession) {
 		args = append(args,
 			"dev_ui_keys", session.DevUIKeys,
 			"target_keys", session.TargetKeys,
-			"artifacts_dir", session.State.ArtifactsDir,
-			"lockfile", session.State.LockfilePath,
+			"artifacts_dir", session.ArtifactsDir,
+			"lockfile", session.LockfilePath,
 		)
 	}
 	if session.ManifestPath != "" {

--- a/gestaltd/internal/daemon/provider_local_serve_test.go
+++ b/gestaltd/internal/daemon/provider_local_serve_test.go
@@ -20,15 +20,15 @@ func TestMaybeRunServeProviderLocalRejectsLockedWithoutConfig(t *testing.T) {
 	}
 }
 
-func TestMaybeRunServeProviderLocalRejectsStatePathsWithoutConfig(t *testing.T) {
+func TestMaybeRunServeProviderLocalRejectsLockfileAndArtifactsDirWithoutConfig(t *testing.T) {
 	t.Parallel()
 
 	_, err := maybeRunServeProviderLocal(serveProviderLocalOptions{
 		Paths:        []string{"./ui"},
 		ArtifactsDir: t.TempDir(),
 	})
-	if err == nil || !strings.Contains(err.Error(), "--artifacts-dir and --lockfile require --config") {
-		t.Fatalf("error = %v, want --artifacts-dir/--lockfile require --config", err)
+	if err == nil || !strings.Contains(err.Error(), "--lockfile and --artifacts-dir require --config") {
+		t.Fatalf("error = %v, want --lockfile and --artifacts-dir require --config", err)
 	}
 }
 

--- a/gestaltd/internal/daemon/provider_package_edge_test.go
+++ b/gestaltd/internal/daemon/provider_package_edge_test.go
@@ -110,12 +110,14 @@ func TestRun_ProviderPackageAndReleaseStagesOwnedUIPackage(t *testing.T) {
 
 			configDir := t.TempDir()
 			configPath := writeManagedPluginConfigForTest(t, configDir, "roadmap", releaseServer.URL+"/provider-release.yaml", "/create-customer-roadmap-review")
+			lockfilePath := filepath.Join(configDir, operator.LockfileName)
+			artifactsDir := filepath.Join(configDir, "prepared-artifacts")
 			lc := operator.NewLifecycle().WithHTTPClient(releaseServer.Client())
-			if _, err := lc.PrepareAtPath(configPath); err != nil {
+			if _, err := lc.PrepareAtPaths([]string{configPath}, lockfilePath, artifactsDir); err != nil {
 				t.Fatalf("PrepareAtPath: %v", err)
 			}
 
-			loaded, _, err := lc.LoadForExecutionAtPath(configPath, true)
+			loaded, _, err := lc.LoadForExecutionAtPaths([]string{configPath}, lockfilePath, artifactsDir, true, false)
 			if err != nil {
 				t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
 			}

--- a/gestaltd/internal/daemon/provider_package_test.go
+++ b/gestaltd/internal/daemon/provider_package_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -129,7 +128,7 @@ func TestE2EProviderPackageAndReleaseBigquery(t *testing.T) {
 	const testVersion = "0.0.1-test"
 	const testPlatform = "linux/amd64"
 
-	cmd := exec.Command(gestaltdBin, "provider", "package",
+	cmd := gestaltdCommand("provider", "package",
 		"--version", testVersion,
 		"--platform", testPlatform,
 		"--output", outputDir,
@@ -139,7 +138,7 @@ func TestE2EProviderPackageAndReleaseBigquery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("provider package failed: %v\n%s", err, out)
 	}
-	cmd = exec.Command(gestaltdBin, "provider", "release",
+	cmd = gestaltdCommand("provider", "release",
 		"--version", testVersion,
 		"--dist-dir", outputDir,
 	)

--- a/gestaltd/internal/daemon/provider_registry.go
+++ b/gestaltd/internal/daemon/provider_registry.go
@@ -291,7 +291,7 @@ func runProviderList(args []string) error {
 	if err != nil {
 		return err
 	}
-	lock, err := readProviderListLockfile(paths[0], *lockfilePath)
+	lock, err := readProviderListLockfile(*lockfilePath)
 	if err != nil {
 		return err
 	}
@@ -397,7 +397,7 @@ func runProviderAdd(args []string) error {
 		return err
 	}
 	if *sync {
-		if err := syncConfigWithStatePaths(configPaths, operator.StatePaths{LockfilePath: *lockfilePath}, false); err != nil {
+		if err := syncConfig(configPaths, *lockfilePath, "", false); err != nil {
 			return err
 		}
 	}
@@ -492,7 +492,7 @@ func runProviderUpgrade(args []string) error {
 		}
 		return nil
 	}
-	if err := lockConfigWithStatePaths(configPaths, operator.StatePaths{LockfilePath: *lockfilePath}, false); err != nil {
+	if err := lockConfig(configPaths, *lockfilePath, "", false); err != nil {
 		return err
 	}
 	fmt.Println("Refreshed provider lock state")

--- a/gestaltd/internal/daemon/provider_release_helpers_test.go
+++ b/gestaltd/internal/daemon/provider_release_helpers_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
@@ -72,7 +71,7 @@ func runProviderPackageCommand(t *testing.T, pluginDir string, args ...string) s
 
 func runProviderCommandResult(pluginDir string, args ...string) ([]byte, error) {
 	cmdArgs := append([]string{"provider"}, args...)
-	cmd := exec.Command(gestaltdBin, cmdArgs...)
+	cmd := gestaltdCommand(cmdArgs...)
 	cmd.Dir = pluginDir
 	return cmd.CombinedOutput()
 }

--- a/gestaltd/internal/daemon/run.go
+++ b/gestaltd/internal/daemon/run.go
@@ -95,7 +95,7 @@ func runServeCommand(name string, usage func(io.Writer), args []string, opts ser
 	var configPaths repeatedStringFlag
 	fs.Var(&configPaths, "config", "path to config file (repeat to layer overrides)")
 	artifactsDir := fs.String("artifacts-dir", "", "path to writable prepared-artifacts directory")
-	lockfilePath := fs.String("lockfile", "", "path to lockfile; defaults to gestalt.lock.json next to the primary config")
+	lockfilePath := fs.String("lockfile", "", "path to lockfile; defaults to gestalt.lock.json in the current working directory")
 	portFlag := fs.Int("port", 0, "public listener port; overrides server.public.port. If in use, gestaltd tries the next free port unless --port was given explicitly")
 	var lockedFlag *bool
 	var noSyncFlag *bool
@@ -149,10 +149,7 @@ func runServeCommand(name string, usage func(io.Writer), args []string, opts ser
 			return err
 		}
 	}
-	env, err := setupBootstrapWithConfigPaths(resolvedConfigPaths, operator.StatePaths{
-		ArtifactsDir: *artifactsDir,
-		LockfilePath: *lockfilePath,
-	}, locked, noSync)
+	env, err := setupBootstrapWithConfigPaths(resolvedConfigPaths, *lockfilePath, *artifactsDir, locked, noSync)
 	if err != nil {
 		return err
 	}
@@ -188,7 +185,7 @@ func maybeRunServeProviderLocal(opts serveProviderLocalOptions) (bool, error) {
 		return true, fmt.Errorf("--locked requires --config when serving local PATH arguments")
 	}
 	if len(opts.ConfigPaths) == 0 && (opts.ArtifactsDir != "" || opts.LockfilePath != "") {
-		return true, fmt.Errorf("--artifacts-dir and --lockfile require --config when serving local PATH arguments")
+		return true, fmt.Errorf("--lockfile and --artifacts-dir require --config when serving local PATH arguments")
 	}
 	return true, runServeProviderLocal(providerLocalCommandOptions{
 		Paths:        paths,
@@ -251,7 +248,7 @@ func runLock(args []string) error {
 	fs.Usage = func() { printLockUsage(fs.Output()) }
 	var configPaths repeatedStringFlag
 	fs.Var(&configPaths, "config", "path to config file (repeat to layer overrides)")
-	lockfilePath := fs.String("lockfile", "", "path to lockfile; defaults to gestalt.lock.json next to the primary config")
+	lockfilePath := fs.String("lockfile", "", "path to lockfile; defaults to gestalt.lock.json in the current working directory")
 	check := fs.Bool("check", false, "fail if the lockfile would change")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -260,9 +257,7 @@ func runLock(args []string) error {
 		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
 	}
 
-	return lockConfigWithStatePaths(configPaths, operator.StatePaths{
-		LockfilePath: *lockfilePath,
-	}, *check)
+	return lockConfig(configPaths, *lockfilePath, "", *check)
 }
 
 func runSync(args []string) error {
@@ -271,7 +266,7 @@ func runSync(args []string) error {
 	var configPaths repeatedStringFlag
 	fs.Var(&configPaths, "config", "path to config file (repeat to layer overrides)")
 	artifactsDir := fs.String("artifacts-dir", "", "path to writable prepared-artifacts directory")
-	lockfilePath := fs.String("lockfile", "", "path to lockfile; defaults to gestalt.lock.json next to the primary config")
+	lockfilePath := fs.String("lockfile", "", "path to lockfile; defaults to gestalt.lock.json in the current working directory")
 	locked := fs.Bool("locked", false, "require an existing lockfile; do not resolve new metadata")
 	check := fs.Bool("check", false, "fail if artifacts would need to be materialized")
 	parallelism := fs.Int("parallelism", defaultSyncParallelism(), "maximum concurrent local UI source preparations")
@@ -311,10 +306,7 @@ func runSync(args []string) error {
 		Observability: observability,
 	}
 
-	if err := syncConfigWithStatePathsOptions(configPaths, operator.StatePaths{
-		ArtifactsDir: *artifactsDir,
-		LockfilePath: *lockfilePath,
-	}, *check, opts); err != nil {
+	if err := syncConfigOptions(configPaths, *lockfilePath, *artifactsDir, *check, opts); err != nil {
 		return err
 	}
 
@@ -337,7 +329,7 @@ func runValidate(args []string) error {
 	fs.Usage = func() { printValidateUsage(fs.Output()) }
 	var configPaths repeatedStringFlag
 	fs.Var(&configPaths, "config", "path to config file (repeat to layer overrides)")
-	lockfilePath := fs.String("lockfile", "", "path to lockfile; defaults to gestalt.lock.json next to the primary config")
+	lockfilePath := fs.String("lockfile", "", "path to lockfile; defaults to gestalt.lock.json in the current working directory")
 	platform := fs.String("platform", "", "target platform for static validation, formatted os/arch")
 	runtimeValidation := fs.Bool("runtime", false, "run deep runtime validation that starts configured providers")
 	if err := fs.Parse(args); err != nil {
@@ -351,9 +343,7 @@ func runValidate(args []string) error {
 	if err != nil {
 		return err
 	}
-	return validateConfig(configPaths, operator.StatePaths{
-		LockfilePath: *lockfilePath,
-	}, opts)
+	return validateConfig(configPaths, *lockfilePath, "", opts)
 }
 
 type validateConfigOptions struct {
@@ -376,17 +366,14 @@ func parseValidateConfigOptions(platform string, runtimeValidation bool) (valida
 	return validateConfigOptions{Platform: platform, Runtime: runtimeValidation}, nil
 }
 
-func validateConfig(configFlags []string, state operator.StatePaths, opts validateConfigOptions) error {
+func validateConfig(configFlags []string, lockfilePath, artifactsDir string, opts validateConfigOptions) error {
 	scratchDir, err := os.MkdirTemp("", "gestaltd-validate-*")
 	if err != nil {
 		return fmt.Errorf("create validation scratch dir: %w", err)
 	}
 	defer func() { _ = os.RemoveAll(scratchDir) }()
 
-	result, err := validateConfigWithStatePaths(configFlags, operator.StatePaths{
-		ArtifactsDir: scratchDir,
-		LockfilePath: state.LockfilePath,
-	}, opts)
+	result, err := validateConfigAtPaths(configFlags, lockfilePath, scratchDir, opts)
 	if err != nil {
 		return err
 	}
@@ -479,7 +466,7 @@ func printMainUsage(w io.Writer) {
 	writeUsageLine(w, "Flags:")
 	writeUsageLine(w, "  --config          Path to a config file; repeat to layer left-to-right")
 	writeUsageLine(w, "  --artifacts-dir   Path to writable prepared-artifacts directory for sync/serve; relative paths use the current working directory")
-	writeUsageLine(w, "  --lockfile        Path to lockfile; defaults to gestalt.lock.json next to the primary config")
+	writeUsageLine(w, "  --lockfile        Path to lockfile; defaults to gestalt.lock.json in the current working directory")
 }
 
 func printServeUsage(w io.Writer) {
@@ -511,7 +498,7 @@ func printLockUsage(w io.Writer) {
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Flags:")
 	writeUsageLine(w, "  --config          Path to a config file; repeat to layer left-to-right")
-	writeUsageLine(w, "  --lockfile        Path to lockfile; defaults to gestalt.lock.json next to the primary config")
+	writeUsageLine(w, "  --lockfile        Path to lockfile; defaults to gestalt.lock.json in the current working directory")
 	writeUsageLine(w, "  --check           Fail if the lockfile would change")
 }
 
@@ -531,7 +518,7 @@ func printSyncUsage(w io.Writer) {
 	writeUsageLine(w, "Flags:")
 	writeUsageLine(w, "  --config          Path to a config file; repeat to layer left-to-right")
 	writeUsageLine(w, "  --artifacts-dir   Path to writable prepared-artifacts directory; relative paths use the current working directory")
-	writeUsageLine(w, "  --lockfile        Path to lockfile; defaults to gestalt.lock.json next to the primary config")
+	writeUsageLine(w, "  --lockfile        Path to lockfile; defaults to gestalt.lock.json in the current working directory")
 	writeUsageLine(w, "  --locked          Require a fresh lockfile; do not re-resolve metadata")
 	writeUsageLine(w, "  --parallelism     Maximum concurrent local source UI preparations")
 	writeUsageLine(w, "  --cache-dir       Opt-in cache for materialized prepared artifacts; relative paths use the current working directory")

--- a/gestaltd/internal/daemon/testmain_test.go
+++ b/gestaltd/internal/daemon/testmain_test.go
@@ -27,6 +27,26 @@ var (
 	externalCredentialsBin string
 )
 
+// gestaltdCommand runs the gestaltd CLI binary. When args include --config PATH,
+// the subprocess working directory is set to PATH's directory so default lockfile
+// and artifacts paths resolve like a user running gestaltd from the project root.
+func gestaltdCommand(args ...string) *exec.Cmd {
+	cmd := exec.Command(gestaltdBin, args...)
+	if workDir := gestaltdWorkDirFromArgs(args); workDir != "" {
+		cmd.Dir = workDir
+	}
+	return cmd
+}
+
+func gestaltdWorkDirFromArgs(args []string) string {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "--config" {
+			return filepath.Dir(args[i+1])
+		}
+	}
+	return ""
+}
+
 func TestMain(m *testing.M) {
 	tmpDir, err := os.MkdirTemp("", "gestaltd-e2e-*")
 	if err != nil {

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -108,11 +108,6 @@ type Lifecycle struct {
 	forcedDevUIKeys map[string]bool
 }
 
-type StatePaths struct {
-	ArtifactsDir string
-	LockfilePath string
-}
-
 type SyncOptions struct {
 	Locked        bool
 	Parallelism   int
@@ -234,28 +229,24 @@ func (l *Lifecycle) providerPackageResolver() *providerregistry.Resolver {
 }
 
 func (l *Lifecycle) PrepareAtPath(configPath string) (*Lockfile, error) {
-	return l.PrepareAtPaths([]string{configPath})
+	return l.PrepareAtPaths([]string{configPath}, "", "")
 }
 
-func (l *Lifecycle) PrepareAtPaths(configPaths []string) (*Lockfile, error) {
-	return l.PrepareAtPathsWithStatePaths(configPaths, StatePaths{})
-}
-
-func (l *Lifecycle) PrepareAtPathsWithStatePaths(configPaths []string, state StatePaths) (*Lockfile, error) {
-	lock, _, _, err := l.prepareAtPathsAndWriteLock(configPaths, state)
+func (l *Lifecycle) PrepareAtPaths(configPaths []string, lockfilePath, artifactsDir string) (*Lockfile, error) {
+	lock, _, _, err := l.prepareAtPathsAndWriteLock(configPaths, lockfilePath, artifactsDir)
 	return lock, err
 }
 
-func (l *Lifecycle) LockAtPathsWithStatePaths(configPaths []string, state StatePaths) (*Lockfile, error) {
-	return l.lockAtPathsWithStatePaths(configPaths, state, lockAtPathsOptions{})
+func (l *Lifecycle) LockAtPaths(configPaths []string, lockfilePath, artifactsDir string) (*Lockfile, error) {
+	return l.lockAtPaths(configPaths, lockfilePath, artifactsDir, lockAtPathsOptions{})
 }
 
 type lockAtPathsOptions struct {
 	allowLocalSourceAuthSecrets bool
 }
 
-func (l *Lifecycle) lockAtPathsWithStatePaths(configPaths []string, state StatePaths, opts lockAtPathsOptions) (*Lockfile, error) {
-	lock, _, paths, cleanup, err := l.prepareCommittedLockAtPathsInScratch(configPaths, state, opts)
+func (l *Lifecycle) lockAtPaths(configPaths []string, lockfilePath, artifactsDir string, opts lockAtPathsOptions) (*Lockfile, error) {
+	lock, _, paths, cleanup, err := l.prepareCommittedLockAtPathsInScratch(configPaths, lockfilePath, artifactsDir, opts)
 	if cleanup != nil {
 		defer cleanup()
 	}
@@ -269,8 +260,8 @@ func (l *Lifecycle) lockAtPathsWithStatePaths(configPaths []string, state StateP
 	return normalizeLockfile(lock), nil
 }
 
-func (l *Lifecycle) CheckLockAtPathsWithStatePaths(configPaths []string, state StatePaths) error {
-	lock, cfg, paths, cleanup, err := l.prepareCommittedLockAtPathsInScratch(configPaths, state, lockAtPathsOptions{})
+func (l *Lifecycle) CheckLockAtPaths(configPaths []string, lockfilePath, artifactsDir string) error {
+	lock, cfg, paths, cleanup, err := l.prepareCommittedLockAtPathsInScratch(configPaths, lockfilePath, artifactsDir, lockAtPathsOptions{})
 	if cleanup != nil {
 		defer cleanup()
 	}
@@ -302,16 +293,16 @@ func (l *Lifecycle) CheckLockAtPathsWithStatePaths(configPaths []string, state S
 	return nil
 }
 
-func (l *Lifecycle) SyncAtPathsWithStatePathsOptions(configPaths []string, state StatePaths, opts SyncOptions) error {
-	return l.syncAtPathsWithStatePaths(configPaths, state, artifactModeMaterialize, opts)
+func (l *Lifecycle) SyncAtPathsOptions(configPaths []string, lockfilePath, artifactsDir string, opts SyncOptions) error {
+	return l.syncAtPaths(configPaths, lockfilePath, artifactsDir, artifactModeMaterialize, opts)
 }
 
-func (l *Lifecycle) CheckSyncAtPathsWithStatePathsOptions(configPaths []string, state StatePaths, opts SyncOptions) error {
-	return l.syncAtPathsWithStatePaths(configPaths, state, artifactModeCheck, opts)
+func (l *Lifecycle) CheckSyncAtPathsOptions(configPaths []string, lockfilePath, artifactsDir string, opts SyncOptions) error {
+	return l.syncAtPaths(configPaths, lockfilePath, artifactsDir, artifactModeCheck, opts)
 }
 
-func (l *Lifecycle) prepareAtPathsAndWriteLock(configPaths []string, state StatePaths) (*Lockfile, *config.Config, lifecyclePaths, error) {
-	lock, cfg, paths, err := l.prepareLockAtPaths(configPaths, state)
+func (l *Lifecycle) prepareAtPathsAndWriteLock(configPaths []string, lockfilePath, artifactsDir string) (*Lockfile, *config.Config, lifecyclePaths, error) {
+	lock, cfg, paths, err := l.prepareLockAtPaths(configPaths, lockfilePath, artifactsDir, "", "")
 	if err != nil {
 		return nil, nil, lifecyclePaths{}, err
 	}
@@ -324,53 +315,55 @@ func (l *Lifecycle) prepareAtPathsAndWriteLock(configPaths []string, state State
 	return lock, cfg, paths, nil
 }
 
-func (l *Lifecycle) prepareLockAtPathsInScratch(configPaths []string, state StatePaths) (*Lockfile, *config.Config, lifecyclePaths, func(), error) {
+func (l *Lifecycle) prepareLockAtPathsInScratch(configPaths []string, lockfilePath, artifactsDir string) (*Lockfile, *config.Config, lifecyclePaths, func(), error) {
 	scratchDir, err := os.MkdirTemp("", "gestaltd-lock-*")
 	if err != nil {
 		return nil, nil, lifecyclePaths{}, nil, fmt.Errorf("create lock scratch dir: %w", err)
 	}
 	cleanup := func() { _ = os.RemoveAll(scratchDir) }
-	scratchState := state
-	scratchState.ArtifactsDir = scratchDir
-	lock, cfg, paths, err := l.prepareLockAtPaths(configPaths, scratchState, state)
+	lock, cfg, paths, err := l.prepareLockAtPaths(configPaths, lockfilePath, scratchDir, lockfilePath, artifactsDir)
 	if err != nil {
 		return nil, nil, lifecyclePaths{}, cleanup, err
 	}
-	actualPaths := resolveLifecyclePaths(configPaths, cfg, state)
+	actualPaths := resolveLifecyclePaths(configPaths, cfg, lockfilePath, artifactsDir)
 	paths.lockfilePath = actualPaths.lockfilePath
 	paths.lockFlags = actualPaths.lockFlags
 	return lock, cfg, paths, cleanup, nil
 }
 
-func (l *Lifecycle) prepareCommittedLockAtPathsInScratch(configPaths []string, state StatePaths, opts lockAtPathsOptions) (*Lockfile, *config.Config, lifecyclePaths, func(), error) {
+func (l *Lifecycle) prepareCommittedLockAtPathsInScratch(configPaths []string, lockfilePath, artifactsDir string, opts lockAtPathsOptions) (*Lockfile, *config.Config, lifecyclePaths, func(), error) {
 	scratchDir, err := os.MkdirTemp("", "gestaltd-lock-*")
 	if err != nil {
 		return nil, nil, lifecyclePaths{}, nil, fmt.Errorf("create lock scratch dir: %w", err)
 	}
 	cleanup := func() { _ = os.RemoveAll(scratchDir) }
-	scratchState := state
-	scratchState.ArtifactsDir = scratchDir
-	lock, cfg, paths, err := l.prepareCommittedLockAtPaths(configPaths, scratchState, opts, state)
+	lock, cfg, paths, err := l.prepareCommittedLockAtPaths(configPaths, lockfilePath, scratchDir, opts, lockfilePath, artifactsDir)
 	if err != nil {
 		return nil, nil, lifecyclePaths{}, cleanup, err
 	}
-	actualPaths := resolveLifecyclePaths(configPaths, cfg, state)
+	actualPaths := resolveLifecyclePaths(configPaths, cfg, lockfilePath, artifactsDir)
 	paths.lockfilePath = actualPaths.lockfilePath
 	paths.lockFlags = actualPaths.lockFlags
 	return lock, cfg, paths, cleanup, nil
 }
 
-func (l *Lifecycle) prepareCommittedLockAtPaths(configPaths []string, state StatePaths, opts lockAtPathsOptions, displayState ...StatePaths) (*Lockfile, *config.Config, lifecyclePaths, error) {
-	cfg, err := l.loadConfigForLifecycle(configPaths, state, true)
+func (l *Lifecycle) prepareCommittedLockAtPaths(configPaths []string, lockfilePath, artifactsDir string, opts lockAtPathsOptions, displayLockfilePath, displayArtifactsDir string) (*Lockfile, *config.Config, lifecyclePaths, error) {
+	cfg, err := l.loadConfigForLifecycle(configPaths, true)
 	if err != nil {
 		return nil, nil, lifecyclePaths{}, fmt.Errorf("loading config: %v", err)
 	}
 	if err := config.OverlayRemotePluginConfigPaths(configPaths, cfg); err != nil {
 		return nil, nil, lifecyclePaths{}, fmt.Errorf("loading config: %v", err)
 	}
-	paths := resolveLifecyclePaths(configPaths, cfg, state)
-	if len(displayState) > 0 {
-		paths.configFlags = formatConfigStateFlags(configPaths, displayState[0])
+	paths := resolveLifecyclePaths(configPaths, cfg, lockfilePath, artifactsDir)
+	if displayLockfilePath != "" || displayArtifactsDir != "" {
+		if displayLockfilePath == "" {
+			displayLockfilePath = lockfilePath
+		}
+		if displayArtifactsDir == "" {
+			displayArtifactsDir = artifactsDir
+		}
+		paths.configFlags = formatConfigStateFlags(configPaths, displayArtifactsDir, displayLockfilePath)
 	}
 	if l.sourceAuthSecretResolver == nil {
 		if err := requireSourceAuthSecretResolver(cfg); err != nil {
@@ -399,17 +392,23 @@ func (l *Lifecycle) prepareCommittedLockAtPaths(configPaths []string, state Stat
 	return lock, cfg, paths, nil
 }
 
-func (l *Lifecycle) prepareLockAtPaths(configPaths []string, state StatePaths, displayState ...StatePaths) (*Lockfile, *config.Config, lifecyclePaths, error) {
-	cfg, err := l.loadConfigForLifecycle(configPaths, state, true)
+func (l *Lifecycle) prepareLockAtPaths(configPaths []string, lockfilePath, artifactsDir string, displayLockfilePath, displayArtifactsDir string) (*Lockfile, *config.Config, lifecyclePaths, error) {
+	cfg, err := l.loadConfigForLifecycle(configPaths, true)
 	if err != nil {
 		return nil, nil, lifecyclePaths{}, fmt.Errorf("loading config: %v", err)
 	}
 	if err := config.OverlayRemotePluginConfigPaths(configPaths, cfg); err != nil {
 		return nil, nil, lifecyclePaths{}, fmt.Errorf("loading config: %v", err)
 	}
-	paths := resolveLifecyclePaths(configPaths, cfg, state)
-	if len(displayState) > 0 {
-		paths.configFlags = formatConfigStateFlags(configPaths, displayState[0])
+	paths := resolveLifecyclePaths(configPaths, cfg, lockfilePath, artifactsDir)
+	if displayLockfilePath != "" || displayArtifactsDir != "" {
+		if displayLockfilePath == "" {
+			displayLockfilePath = lockfilePath
+		}
+		if displayArtifactsDir == "" {
+			displayArtifactsDir = artifactsDir
+		}
+		paths.configFlags = formatConfigStateFlags(configPaths, displayArtifactsDir, displayLockfilePath)
 	}
 	lock, err := l.prepareRuntimeLockFromLoadedConfigWithSecretMode(context.Background(), paths, cfg, configSecretResolutionSourceAuth)
 	if err != nil {
@@ -934,17 +933,7 @@ func cloneProviderRepositories(repos []providerregistry.NamedRepository) []provi
 	return append([]providerregistry.NamedRepository(nil), repos...)
 }
 
-func defaultLockfilePath(configPath string) string {
-	dir := filepath.Dir(configPath)
-	if !filepath.IsAbs(dir) {
-		if abs, err := filepath.Abs(dir); err == nil {
-			dir = abs
-		}
-	}
-	return filepath.Join(dir, LockfileName)
-}
-
-func (l *Lifecycle) loadConfigForLifecycle(configPaths []string, _ StatePaths, allowMissingEnv bool) (*config.Config, error) {
+func (l *Lifecycle) loadConfigForLifecycle(configPaths []string, allowMissingEnv bool) (*config.Config, error) {
 	var cfg *config.Config
 	var err error
 	if allowMissingEnv {
@@ -1016,19 +1005,15 @@ func (l *Lifecycle) markDevActiveUIProviders(cfg *config.Config) error {
 }
 
 func (l *Lifecycle) LoadForExecutionAtPath(configPath string, locked bool) (*config.Config, map[string]string, error) {
-	return l.LoadForExecutionAtPaths([]string{configPath}, locked)
+	return l.LoadForExecutionAtPaths([]string{configPath}, "", "", locked, false)
 }
 
-func (l *Lifecycle) LoadForExecutionAtPaths(configPaths []string, locked bool) (*config.Config, map[string]string, error) {
-	return l.LoadForExecutionAtPathsWithStatePaths(configPaths, StatePaths{}, locked, false)
-}
-
-func (l *Lifecycle) LoadForExecutionAtPathsWithStatePaths(configPaths []string, state StatePaths, locked, noSync bool) (*config.Config, map[string]string, error) {
-	cfg, err := l.loadConfigForLifecycle(configPaths, state, false)
+func (l *Lifecycle) LoadForExecutionAtPaths(configPaths []string, lockfilePath, artifactsDir string, locked, noSync bool) (*config.Config, map[string]string, error) {
+	cfg, err := l.loadConfigForLifecycle(configPaths, false)
 	if err != nil {
 		return nil, nil, fmt.Errorf("loading config: %v", err)
 	}
-	paths := resolveLifecyclePaths(configPaths, cfg, state)
+	paths := resolveLifecyclePaths(configPaths, cfg, lockfilePath, artifactsDir)
 	if l.devServeEligible || len(l.forcedDevUIKeys) > 0 {
 		for _, name := range slices.Sorted(maps.Keys(cfg.Providers.UI)) {
 			entry := cfg.Providers.UI[name]
@@ -1043,7 +1028,7 @@ func (l *Lifecycle) LoadForExecutionAtPathsWithStatePaths(configPaths []string, 
 	if locked && noSync {
 		mode = artifactModeBind
 	}
-	secretsLock, err := l.lockForSecretsBootstrap(configPaths, state, paths, cfg, locked)
+	secretsLock, err := l.lockForSecretsBootstrap(configPaths, lockfilePath, artifactsDir, paths, cfg, locked)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1057,7 +1042,7 @@ func (l *Lifecycle) LoadForExecutionAtPathsWithStatePaths(configPaths []string, 
 		return nil, nil, err
 	}
 
-	if err := l.applyLockedProviders(configPaths, state, cfg, locked, secretsLock, mode); err != nil {
+	if err := l.applyLockedProviders(configPaths, lockfilePath, artifactsDir, cfg, locked, secretsLock, mode); err != nil {
 		return nil, nil, err
 	}
 	if err := config.ValidateResolvedStructure(cfg); err != nil {
@@ -1069,12 +1054,12 @@ func (l *Lifecycle) LoadForExecutionAtPathsWithStatePaths(configPaths []string, 
 	return cfg, nil, nil
 }
 
-func (l *Lifecycle) LoadForValidationAtPathsWithStatePaths(configPaths []string, state StatePaths) (*config.Config, error) {
-	cfg, err := l.loadConfigForLifecycle(configPaths, state, false)
+func (l *Lifecycle) LoadForValidationAtPaths(configPaths []string, lockfilePath, artifactsDir string) (*config.Config, error) {
+	cfg, err := l.loadConfigForLifecycle(configPaths, false)
 	if err != nil {
 		return nil, fmt.Errorf("loading config: %v", err)
 	}
-	paths := resolveLifecyclePaths(configPaths, cfg, state)
+	paths := resolveLifecyclePaths(configPaths, cfg, lockfilePath, artifactsDir)
 	lock, err := l.prepareRuntimeLockFromLoadedConfig(context.Background(), paths, cfg)
 	if err != nil {
 		return nil, err
@@ -1094,15 +1079,15 @@ func (l *Lifecycle) LoadForValidationAtPathsWithStatePaths(configPaths []string,
 	return cfg, nil
 }
 
-func (l *Lifecycle) LoadForStaticValidationAtPathsWithStatePaths(configPaths []string, state StatePaths, opts StaticValidationOptions) (*config.Config, error) {
-	cfg, err := l.loadConfigForLifecycle(configPaths, state, true)
+func (l *Lifecycle) LoadForStaticValidationAtPaths(configPaths []string, lockfilePath, artifactsDir string, opts StaticValidationOptions) (*config.Config, error) {
+	cfg, err := l.loadConfigForLifecycle(configPaths, true)
 	if err != nil {
 		return nil, fmt.Errorf("loading config: %v", err)
 	}
 	if err := config.OverlayRemotePluginConfigPaths(configPaths, cfg); err != nil {
 		return nil, fmt.Errorf("loading config: %v", err)
 	}
-	paths := resolveLifecyclePaths(configPaths, cfg, state)
+	paths := resolveLifecyclePaths(configPaths, cfg, lockfilePath, artifactsDir)
 	platform := strings.TrimSpace(opts.Platform)
 	if platform == "" {
 		platform = providerpkg.CurrentPlatformString()
@@ -1119,7 +1104,7 @@ func (l *Lifecycle) LoadForStaticValidationAtPathsWithStatePaths(configPaths []s
 			if !canPrepareScratchLock {
 				return nil, fmt.Errorf("lockfile is missing or unreadable; run `%s`: %w", formatLockCommand(paths), lockErr)
 			}
-			_, scratchCfg, _, cleanup, err := l.prepareLockAtPathsInScratch(configPaths, state)
+			_, scratchCfg, _, cleanup, err := l.prepareLockAtPathsInScratch(configPaths, lockfilePath, artifactsDir)
 			if cleanup != nil {
 				defer cleanup()
 			}
@@ -1153,7 +1138,7 @@ func (l *Lifecycle) LoadForStaticValidationAtPathsWithStatePaths(configPaths []s
 	return cfg, nil
 }
 
-func (l *Lifecycle) syncAtPathsWithStatePaths(configPaths []string, state StatePaths, mode artifactMode, opts SyncOptions) error {
+func (l *Lifecycle) syncAtPaths(configPaths []string, lockfilePath, artifactsDir string, mode artifactMode, opts SyncOptions) error {
 	opts = normalizeSyncOptions(opts)
 	syncCache, err := materializedCacheFromSyncOptions(mode, opts)
 	if err != nil {
@@ -1163,14 +1148,14 @@ func (l *Lifecycle) syncAtPathsWithStatePaths(configPaths []string, state StateP
 	if recorder != nil {
 		recorder.Begin(syncActionForArtifactMode(mode), configPaths, mode == artifactModeCheck, opts.Parallelism)
 	}
-	cfg, err := l.loadConfigForLifecycle(configPaths, state, true)
+	cfg, err := l.loadConfigForLifecycle(configPaths, true)
 	if err != nil {
 		return fmt.Errorf("loading config: %v", err)
 	}
 	if err := config.OverlayRemotePluginConfigPaths(configPaths, cfg); err != nil {
 		return fmt.Errorf("loading config: %v", err)
 	}
-	paths := resolveLifecyclePaths(configPaths, cfg, state)
+	paths := resolveLifecyclePaths(configPaths, cfg, lockfilePath, artifactsDir)
 	paths.syncCache = syncCache
 	paths.syncMetrics = recorder
 	paths.syncBuildOutput = opts.Observability.BuildOutput
@@ -1185,7 +1170,7 @@ func (l *Lifecycle) syncAtPathsWithStatePaths(configPaths []string, state StateP
 		}
 	}
 	relockLocked := opts.Locked || mode == artifactModeCheck
-	lock, err = l.autoRelockAtPathsIfNeeded(configPaths, state, cfg, paths, lock, relockLocked, err)
+	lock, err = l.autoRelockAtPathsIfNeeded(configPaths, lockfilePath, artifactsDir, cfg, paths, lock, relockLocked, err)
 	if err != nil {
 		if relockLocked && os.IsNotExist(err) && configRequiresCommittedLock(cfg) {
 			return fmt.Errorf("lockfile required")
@@ -1467,7 +1452,7 @@ func (l *Lifecycle) resolveSecretsProviderMetadata(ctx context.Context, name str
 	return nil
 }
 
-func (l *Lifecycle) lockForSecretsBootstrap(configPaths []string, state StatePaths, paths lifecyclePaths, cfg *config.Config, locked bool) (*Lockfile, error) {
+func (l *Lifecycle) lockForSecretsBootstrap(configPaths []string, lockfilePath, artifactsDir string, paths lifecyclePaths, cfg *config.Config, locked bool) (*Lockfile, error) {
 	if cfg == nil {
 		return nil, nil
 	}
@@ -1494,7 +1479,7 @@ func (l *Lifecycle) lockForSecretsBootstrap(configPaths []string, state StatePat
 		lock = newLockfile()
 		err = nil
 	}
-	lock, err = l.autoRelockAtPathsIfNeeded(configPaths, state, cfg, paths, lock, locked, err)
+	lock, err = l.autoRelockAtPathsIfNeeded(configPaths, lockfilePath, artifactsDir, cfg, paths, lock, locked, err)
 	if err != nil {
 		return nil, fmt.Errorf("source-backed providers require lock metadata; full config mode prepares all source-backed providers. For local single-app development, use `gestaltd serve PATH` or a layered local config; otherwise run `%s` then `%s`: %w", formatLockCommand(paths), formatSyncLockedCommand(paths), err)
 	}
@@ -1678,7 +1663,7 @@ func primaryConfigPath(paths []string) string {
 	return paths[0]
 }
 
-func formatConfigStateFlags(paths []string, state StatePaths) string {
+func formatConfigStateFlags(paths []string, artifactsDir, lockfilePath string) string {
 	if len(paths) == 0 {
 		return ""
 	}
@@ -1686,25 +1671,25 @@ func formatConfigStateFlags(paths []string, state StatePaths) string {
 	for _, path := range paths {
 		args = append(args, "--config", path)
 	}
-	if state.ArtifactsDir != "" {
-		args = append(args, "--artifacts-dir", state.ArtifactsDir)
+	if artifactsDir != "" {
+		args = append(args, "--artifacts-dir", artifactsDir)
 	}
-	if state.LockfilePath != "" {
-		args = append(args, "--lockfile", state.LockfilePath)
+	if lockfilePath != "" {
+		args = append(args, "--lockfile", lockfilePath)
 	}
 	return strings.Join(args, " ")
 }
 
-func formatLockFlags(paths []string, state StatePaths) string {
-	if len(paths) == 0 && state.LockfilePath == "" {
+func formatLockFlags(paths []string, lockfilePath string) string {
+	if len(paths) == 0 && lockfilePath == "" {
 		return ""
 	}
 	args := make([]string, 0, len(paths)*2+2)
 	for _, path := range paths {
 		args = append(args, "--config", path)
 	}
-	if state.LockfilePath != "" {
-		args = append(args, "--lockfile", state.LockfilePath)
+	if lockfilePath != "" {
+		args = append(args, "--lockfile", lockfilePath)
 	}
 	return strings.Join(args, " ")
 }
@@ -1862,11 +1847,11 @@ func configHasLocalProviderSources(cfg *config.Config) bool {
 	return false
 }
 
-func (l *Lifecycle) autoRelockAtPathsIfNeeded(configPaths []string, state StatePaths, cfg *config.Config, paths lifecyclePaths, lock *Lockfile, locked bool, err error) (*Lockfile, error) {
+func (l *Lifecycle) autoRelockAtPathsIfNeeded(configPaths []string, lockfilePath, artifactsDir string, cfg *config.Config, paths lifecyclePaths, lock *Lockfile, locked bool, err error) (*Lockfile, error) {
 	if locked || (err == nil && lockFreshForConfig(cfg, paths, lock, lockFreshnessOptions{})) {
 		return lock, err
 	}
-	lock, err = l.lockAtPathsWithStatePaths(configPaths, state, lockAtPathsOptions{allowLocalSourceAuthSecrets: true})
+	lock, err = l.lockAtPaths(configPaths, lockfilePath, artifactsDir, lockAtPathsOptions{allowLocalSourceAuthSecrets: true})
 	if err != nil {
 		return nil, fmt.Errorf("auto-lock: %w", err)
 	}
@@ -1884,12 +1869,13 @@ func resolveArtifactsDir(configPath string, cfg *config.Config, override string)
 	if override != "" {
 		return resolveCLIArtifactsDir(override)
 	}
-	if cfg != nil {
-		if cfg.Server.ArtifactsDir != "" {
-			return resolveConfigArtifactsDir(configPath, cfg.Server.ArtifactsDir)
-		}
+	if cfg != nil && cfg.Server.ArtifactsDir != "" {
+		return resolveConfigArtifactsDir(configPath, cfg.Server.ArtifactsDir)
 	}
-	return absoluteConfigDir(configPath)
+	if cwd, err := os.Getwd(); err == nil {
+		return filepath.Clean(cwd)
+	}
+	return "."
 }
 
 func resolveCLIArtifactsDir(dir string) string {
@@ -1906,20 +1892,19 @@ func resolveConfigArtifactsDir(configPath, dir string) string {
 	if filepath.IsAbs(dir) {
 		return filepath.Clean(dir)
 	}
-	return filepath.Join(absoluteConfigDir(configPath), dir)
-}
-
-func absoluteConfigDir(configPath string) string {
-	dir := filepath.Dir(configPath)
-	if abs, err := filepath.Abs(dir); err == nil {
-		return filepath.Clean(abs)
+	configDir := filepath.Dir(configPath)
+	if abs, err := filepath.Abs(configDir); err == nil {
+		configDir = filepath.Clean(abs)
 	}
-	return filepath.Clean(dir)
+	return filepath.Join(configDir, dir)
 }
 
-func resolveLockfilePath(configPath, override string) string {
+func resolveLockfilePath(override string) string {
 	if override == "" {
-		return defaultLockfilePath(configPath)
+		if cwd, err := os.Getwd(); err == nil {
+			return filepath.Join(cwd, LockfileName)
+		}
+		return LockfileName
 	}
 	if filepath.IsAbs(override) {
 		return override
@@ -1930,36 +1915,36 @@ func resolveLockfilePath(configPath, override string) string {
 	return override
 }
 
-func resolveLifecyclePaths(configPaths []string, cfg *config.Config, state StatePaths) lifecyclePaths {
+func resolveLifecyclePaths(configPaths []string, cfg *config.Config, lockfilePath, artifactsDir string) lifecyclePaths {
 	configPath := primaryConfigPath(configPaths)
 	configDir := filepath.Dir(configPath)
-	artifactsDir := resolveArtifactsDir(configPath, cfg, state.ArtifactsDir)
-	lockfilePath := resolveLockfilePath(configPath, state.LockfilePath)
+	resolvedArtifactsDir := resolveArtifactsDir(configPath, cfg, artifactsDir)
+	resolvedLockfilePath := resolveLockfilePath(lockfilePath)
 	return lifecyclePaths{
 		configPaths:            append([]string(nil), configPaths...),
-		configFlags:            formatConfigStateFlags(configPaths, state),
-		lockFlags:              formatLockFlags(configPaths, state),
+		configFlags:            formatConfigStateFlags(configPaths, artifactsDir, lockfilePath),
+		lockFlags:              formatLockFlags(configPaths, lockfilePath),
 		configPath:             configPath,
 		configDir:              configDir,
-		artifactsDir:           artifactsDir,
-		lockfilePath:           lockfilePath,
-		providersDir:           filepath.Join(artifactsDir, filepath.FromSlash(PreparedProvidersDir)),
-		authDir:                filepath.Join(artifactsDir, filepath.FromSlash(PreparedAuthDir)),
-		authorizationDir:       filepath.Join(artifactsDir, filepath.FromSlash(PreparedAuthorizationDir)),
-		externalCredentialsDir: filepath.Join(artifactsDir, filepath.FromSlash(PreparedExternalCredentialsDir)),
-		secretsDir:             filepath.Join(artifactsDir, filepath.FromSlash(PreparedSecretsDir)),
-		telemetryDir:           filepath.Join(artifactsDir, filepath.FromSlash(PreparedTelemetryDir)),
-		auditDir:               filepath.Join(artifactsDir, filepath.FromSlash(PreparedAuditDir)),
-		cacheDir:               filepath.Join(artifactsDir, filepath.FromSlash(PreparedCacheDir)),
-		workflowDir:            filepath.Join(artifactsDir, filepath.FromSlash(PreparedWorkflowDir)),
-		agentDir:               filepath.Join(artifactsDir, filepath.FromSlash(PreparedAgentDir)),
-		runtimeDir:             filepath.Join(artifactsDir, filepath.FromSlash(PreparedRuntimeDir)),
-		uiDir:                  filepath.Join(artifactsDir, filepath.FromSlash(PreparedUIDir)),
+		artifactsDir:           resolvedArtifactsDir,
+		lockfilePath:           resolvedLockfilePath,
+		providersDir:           filepath.Join(resolvedArtifactsDir, filepath.FromSlash(PreparedProvidersDir)),
+		authDir:                filepath.Join(resolvedArtifactsDir, filepath.FromSlash(PreparedAuthDir)),
+		authorizationDir:       filepath.Join(resolvedArtifactsDir, filepath.FromSlash(PreparedAuthorizationDir)),
+		externalCredentialsDir: filepath.Join(resolvedArtifactsDir, filepath.FromSlash(PreparedExternalCredentialsDir)),
+		secretsDir:             filepath.Join(resolvedArtifactsDir, filepath.FromSlash(PreparedSecretsDir)),
+		telemetryDir:           filepath.Join(resolvedArtifactsDir, filepath.FromSlash(PreparedTelemetryDir)),
+		auditDir:               filepath.Join(resolvedArtifactsDir, filepath.FromSlash(PreparedAuditDir)),
+		cacheDir:               filepath.Join(resolvedArtifactsDir, filepath.FromSlash(PreparedCacheDir)),
+		workflowDir:            filepath.Join(resolvedArtifactsDir, filepath.FromSlash(PreparedWorkflowDir)),
+		agentDir:               filepath.Join(resolvedArtifactsDir, filepath.FromSlash(PreparedAgentDir)),
+		runtimeDir:             filepath.Join(resolvedArtifactsDir, filepath.FromSlash(PreparedRuntimeDir)),
+		uiDir:                  filepath.Join(resolvedArtifactsDir, filepath.FromSlash(PreparedUIDir)),
 	}
 }
 
 func lifecyclePathsForConfig(configPath string) lifecyclePaths {
-	return resolveLifecyclePaths([]string{configPath}, nil, StatePaths{})
+	return resolveLifecyclePaths([]string{configPath}, nil, "", "")
 }
 
 func providerDestDir(paths lifecyclePaths, name string) string {
@@ -3539,12 +3524,12 @@ func sourceBuildPathDomains(sourceDir string, manifest *providermanifestv1.Manif
 	return domains, nil
 }
 
-func (l *Lifecycle) applyLockedProviders(configPaths []string, state StatePaths, cfg *config.Config, locked bool, bootstrapLock *Lockfile, mode artifactMode) error {
+func (l *Lifecycle) applyLockedProviders(configPaths []string, lockfilePath, artifactsDir string, cfg *config.Config, locked bool, bootstrapLock *Lockfile, mode artifactMode) error {
 	if !configHasProviderLoading(cfg) {
 		return nil
 	}
 
-	paths := resolveLifecyclePaths(configPaths, cfg, state)
+	paths := resolveLifecyclePaths(configPaths, cfg, lockfilePath, artifactsDir)
 	lock := bootstrapLock
 	var err error
 	if lock == nil {
@@ -3562,7 +3547,7 @@ func (l *Lifecycle) applyLockedProviders(configPaths []string, state StatePaths,
 			return fmt.Errorf("lockfile required: %w", err)
 		}
 	}
-	lock, err = l.autoRelockAtPathsIfNeeded(configPaths, state, cfg, paths, lock, locked, err)
+	lock, err = l.autoRelockAtPathsIfNeeded(configPaths, lockfilePath, artifactsDir, cfg, paths, lock, locked, err)
 	if err != nil {
 		return fmt.Errorf("source-backed providers require lock metadata; full config mode prepares all source-backed providers. For local single-app development, use `gestaltd serve PATH` or a layered local config; otherwise run `%s` then `%s`: %w", formatLockCommand(paths), formatSyncLockedCommand(paths), err)
 	}

--- a/gestaltd/internal/operator/lifecycle_dev_test.go
+++ b/gestaltd/internal/operator/lifecycle_dev_test.go
@@ -48,7 +48,7 @@ providers:
 		t.Fatalf("WriteFile config: %v", err)
 	}
 
-	cfg, err := NewLifecycle().WithDevServeEligible(true).loadConfigForLifecycle([]string{cfgPath}, StatePaths{}, false)
+	cfg, err := NewLifecycle().WithDevServeEligible(true).loadConfigForLifecycle([]string{cfgPath}, false)
 	if err != nil {
 		t.Fatalf("loadConfigForLifecycle: %v", err)
 	}
@@ -105,7 +105,7 @@ providers:
 		t.Fatalf("WriteFile config: %v", err)
 	}
 
-	cfg, err := NewLifecycle().loadConfigForLifecycle([]string{cfgPath}, StatePaths{}, false)
+	cfg, err := NewLifecycle().loadConfigForLifecycle([]string{cfgPath}, false)
 	if err != nil {
 		t.Fatalf("loadConfigForLifecycle: %v", err)
 	}
@@ -134,7 +134,7 @@ providers:
 		t.Fatalf("WriteFile config: %v", err)
 	}
 
-	cfg, err := NewLifecycle().WithDevServeEligible(true).loadConfigForLifecycle([]string{cfgPath}, StatePaths{}, true)
+	cfg, err := NewLifecycle().WithDevServeEligible(true).loadConfigForLifecycle([]string{cfgPath}, true)
 	if err != nil {
 		t.Fatalf("loadConfigForLifecycle: %v", err)
 	}
@@ -201,6 +201,7 @@ spec:
 	}
 
 	artifactsDir := filepath.Join(dir, "artifacts")
+	lockfilePath := filepath.Join(dir, LockfileName)
 	configPath := filepath.Join(dir, "gestaltd.yaml")
 	configYAML := `apiVersion: gestaltd.config/v8
 ` + requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + `  ui:
@@ -219,11 +220,11 @@ server:
 	}
 
 	lc := NewLifecycle()
-	if _, err := lc.LockAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
-		t.Fatalf("LockAtPathsWithStatePaths: %v", err)
+	if _, err := lc.LockAtPaths([]string{configPath}, lockfilePath, artifactsDir); err != nil {
+		t.Fatalf("LockAtPaths: %v", err)
 	}
-	if err := lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{}); err != nil {
-		t.Fatalf("SyncAtPathsWithStatePaths: %v", err)
+	if err := lc.SyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{}); err != nil {
+		t.Fatalf("SyncAtPaths: %v", err)
 	}
 	preparedUI := filepath.Join(artifactsDir, "ui", "demo", "dist", "index.html")
 	if _, err := os.Stat(preparedUI); err != nil {
@@ -235,6 +236,7 @@ func TestUnlockedServeResolvesDevUITheme(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
+	lockfilePath, artifactsDir := configDirPaths(dir)
 	themeDir := filepath.Join(dir, "theme")
 	if err := os.MkdirAll(themeDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll theme: %v", err)
@@ -284,9 +286,9 @@ server:
 		t.Fatalf("WriteFile config: %v", err)
 	}
 
-	loaded, _, err := NewLifecycle().WithDevServeEligible(true).LoadForExecutionAtPathsWithStatePaths([]string{cfgPath}, StatePaths{}, false, false)
+	loaded, _, err := NewLifecycle().WithDevServeEligible(true).LoadForExecutionAtPaths([]string{cfgPath}, lockfilePath, artifactsDir, false, false)
 	if err != nil {
-		t.Fatalf("LoadForExecutionAtPathsWithStatePaths: %v", err)
+		t.Fatalf("LoadForExecutionAtPaths: %v", err)
 	}
 	entry := loaded.Providers.UI["demo"]
 	if entry == nil {
@@ -339,7 +341,7 @@ providers:
 		t.Fatalf("WriteFile config: %v", err)
 	}
 
-	cfg, err := NewLifecycle().WithForcedDevUIKeys([]string{"demo"}).loadConfigForLifecycle([]string{cfgPath}, StatePaths{}, false)
+	cfg, err := NewLifecycle().WithForcedDevUIKeys([]string{"demo"}).loadConfigForLifecycle([]string{cfgPath}, false)
 	if err != nil {
 		t.Fatalf("loadConfigForLifecycle: %v", err)
 	}
@@ -388,7 +390,7 @@ providers:
 		t.Fatalf("WriteFile config: %v", err)
 	}
 
-	_, err := NewLifecycle().WithForcedDevUIKeys([]string{"demo"}).loadConfigForLifecycle([]string{cfgPath}, StatePaths{}, false)
+	_, err := NewLifecycle().WithForcedDevUIKeys([]string{"demo"}).loadConfigForLifecycle([]string{cfgPath}, false)
 	if err == nil || !strings.Contains(err.Error(), `no run: block`) {
 		t.Fatalf("loadConfigForLifecycle error = %v, want no run: block error", err)
 	}
@@ -411,7 +413,7 @@ providers:
 		t.Fatalf("WriteFile config: %v", err)
 	}
 
-	_, err := NewLifecycle().WithForcedDevUIKeys([]string{"demo"}).loadConfigForLifecycle([]string{cfgPath}, StatePaths{}, false)
+	_, err := NewLifecycle().WithForcedDevUIKeys([]string{"demo"}).loadConfigForLifecycle([]string{cfgPath}, false)
 	if err == nil || !strings.Contains(err.Error(), `--path target "demo"`) {
 		t.Fatalf("loadConfigForLifecycle error = %v, want forced --path target error", err)
 	}

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -58,6 +58,7 @@ func TestLifecycleGitSourceBuildLockSyncContract(t *testing.T) {
 	ref := strings.TrimSpace(runGitTestOutput(t, repoDir, "rev-parse", "HEAD"))
 
 	artifactsDir := filepath.Join(dir, "artifacts")
+	lockfilePath := filepath.Join(dir, LockfileName)
 	configPath := filepath.Join(dir, "gestaltd.yaml")
 	configYAML := fmt.Sprintf(`
 apiVersion: gestaltd.config/v8
@@ -81,9 +82,9 @@ apps:
 	}
 
 	lc := NewLifecycle()
-	lock, err := lc.LockAtPathsWithStatePaths([]string{configPath}, StatePaths{})
+	lock, err := lc.LockAtPaths([]string{configPath}, lockfilePath, artifactsDir)
 	if err != nil {
-		t.Fatalf("LockAtPathsWithStatePaths: %v", err)
+		t.Fatalf("LockAtPaths: %v", err)
 	}
 	entry := lock.Providers.App["alpha"]
 	if entry.SourceRef == nil {
@@ -108,8 +109,8 @@ apps:
 	if err := os.RemoveAll(filepath.Join(artifactsDir, "providers", "alpha")); err != nil {
 		t.Fatalf("remove prepared provider: %v", err)
 	}
-	if err := lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{}); err != nil {
-		t.Fatalf("SyncAtPathsWithStatePaths after removing prepared provider: %v", err)
+	if err := lc.SyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{}); err != nil {
+		t.Fatalf("SyncAtPaths after removing prepared provider: %v", err)
 	}
 	preparedManifest := filepath.Join(artifactsDir, "providers", "alpha", "manifest.yaml")
 	if _, err := os.Stat(preparedManifest); err != nil {
@@ -136,6 +137,7 @@ func TestLifecycleGitSourceUIBuildLockSyncContract(t *testing.T) {
 	ref := strings.TrimSpace(runGitTestOutput(t, repoDir, "rev-parse", "HEAD"))
 
 	artifactsDir := filepath.Join(dir, "artifacts")
+	lockfilePath := filepath.Join(dir, LockfileName)
 	configPath := filepath.Join(dir, "gestaltd.yaml")
 	configYAML := fmt.Sprintf(`
 apiVersion: gestaltd.config/v8
@@ -160,9 +162,9 @@ server:
 	}
 
 	lc := NewLifecycle()
-	lock, err := lc.LockAtPathsWithStatePaths([]string{configPath}, StatePaths{})
+	lock, err := lc.LockAtPaths([]string{configPath}, lockfilePath, artifactsDir)
 	if err != nil {
-		t.Fatalf("LockAtPathsWithStatePaths: %v", err)
+		t.Fatalf("LockAtPaths: %v", err)
 	}
 	entry := lock.Providers.UI["roadmap"]
 	if entry.SourceRef == nil {
@@ -175,13 +177,13 @@ server:
 	if err := os.RemoveAll(filepath.Join(artifactsDir, "ui", "roadmap")); err != nil {
 		t.Fatalf("remove prepared ui: %v", err)
 	}
-	if err := lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{}); err != nil {
-		t.Fatalf("SyncAtPathsWithStatePaths after removing prepared ui: %v", err)
+	if err := lc.SyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{}); err != nil {
+		t.Fatalf("SyncAtPaths after removing prepared ui: %v", err)
 	}
 	if _, err := os.Stat(preparedIndex); err != nil {
 		t.Fatalf("prepared ui index not restored: %v", err)
 	}
-	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
+	cfg, _, err := lc.LoadForExecutionAtPaths([]string{configPath}, lockfilePath, artifactsDir, true, false)
 	if err != nil {
 		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
 	}
@@ -234,6 +236,8 @@ func TestLifecycleSyncLockedPreparesIndependentLocalUIsInParallel(t *testing.T) 
 			t.Parallel()
 
 			dir := t.TempDir()
+			lockfilePath := filepath.Join(dir, LockfileName)
+			artifactsDir := filepath.Join(dir, "artifacts")
 			syncDir := filepath.Join(dir, "sync")
 			if err := os.MkdirAll(syncDir, 0o755); err != nil {
 				t.Fatalf("mkdir sync dir: %v", err)
@@ -310,8 +314,8 @@ printf '<html>beta</html>\n' > dist/index.html
 			if err != nil {
 				t.Fatalf("read lockfile before sync: %v", err)
 			}
-			if err := NewLifecycle().SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{Parallelism: 2}); err != nil {
-				t.Fatalf("SyncAtPathsWithStatePathsOptions: %v", err)
+			if err := NewLifecycle().SyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{Parallelism: 2}); err != nil {
+				t.Fatalf("SyncAtPathsOptions: %v", err)
 			}
 			after, err := os.ReadFile(lockPath)
 			if err != nil {
@@ -337,6 +341,8 @@ func TestLifecycleSyncLockedParallelismOnePreparesLocalUIsSequentially(t *testin
 	}
 
 	dir := t.TempDir()
+	lockfilePath := filepath.Join(dir, LockfileName)
+	artifactsDir := filepath.Join(dir, "artifacts")
 	logPath := filepath.Join(dir, "build.log")
 	alphaApp := filepath.Join(dir, "apps", "alpha")
 	betaApp := filepath.Join(dir, "apps", "beta")
@@ -366,8 +372,8 @@ printf 'beta end\n' >> %s
 		"alpha": filepath.Join(alphaDir, "manifest.yaml"),
 		"beta":  filepath.Join(betaDir, "manifest.yaml"),
 	})
-	if err := NewLifecycle().SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{Parallelism: 1}); err != nil {
-		t.Fatalf("SyncAtPathsWithStatePathsOptions: %v", err)
+	if err := NewLifecycle().SyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{Parallelism: 1}); err != nil {
+		t.Fatalf("SyncAtPathsOptions: %v", err)
 	}
 	data, err := os.ReadFile(logPath)
 	if err != nil {
@@ -387,6 +393,8 @@ func TestLifecycleSyncLockedParallelizesAppOwnedUIs(t *testing.T) {
 	}
 
 	dir := t.TempDir()
+	lockfilePath := filepath.Join(dir, LockfileName)
+	artifactsDir := filepath.Join(dir, "artifacts")
 	syncDir := filepath.Join(dir, "sync")
 	if err := os.MkdirAll(syncDir, 0o755); err != nil {
 		t.Fatalf("mkdir sync dir: %v", err)
@@ -430,8 +438,8 @@ printf '<html>beta</html>\n' > dist/index.html
 		"alpha": alphaManifest,
 		"beta":  betaManifest,
 	})
-	if err := NewLifecycle().SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{Parallelism: 2}); err != nil {
-		t.Fatalf("SyncAtPathsWithStatePathsOptions: %v", err)
+	if err := NewLifecycle().SyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{Parallelism: 2}); err != nil {
+		t.Fatalf("SyncAtPathsOptions: %v", err)
 	}
 	for _, name := range []string{"alpha", "beta"} {
 		if _, err := os.Stat(filepath.Join(dir, "artifacts", "providers", name, "_owned_ui", name, "dist", "index.html")); err != nil {
@@ -448,6 +456,8 @@ func TestLifecycleSyncLockedParallelismOnePreparesAppOwnedUIsSequentially(t *tes
 	}
 
 	dir := t.TempDir()
+	lockfilePath := filepath.Join(dir, LockfileName)
+	artifactsDir := filepath.Join(dir, "artifacts")
 	logPath := filepath.Join(dir, "build.log")
 	alphaManifest := writeOwnedUISourceAppTree(t, filepath.Join(dir, "apps", "alpha"), filepath.Join(dir, "ui", "alpha"), "alpha", fmt.Sprintf(`#!/bin/sh
 set -eu
@@ -468,8 +478,8 @@ printf 'beta end\n' >> %s
 		"alpha": alphaManifest,
 		"beta":  betaManifest,
 	})
-	if err := NewLifecycle().SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{Parallelism: 1}); err != nil {
-		t.Fatalf("SyncAtPathsWithStatePathsOptions: %v", err)
+	if err := NewLifecycle().SyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{Parallelism: 1}); err != nil {
+		t.Fatalf("SyncAtPathsOptions: %v", err)
 	}
 	data, err := os.ReadFile(logPath)
 	if err != nil {
@@ -489,6 +499,8 @@ func TestLifecycleSyncLockedSerializesAppOwnedUIsWithSharedSource(t *testing.T) 
 	}
 
 	dir := t.TempDir()
+	lockfilePath := filepath.Join(dir, LockfileName)
+	artifactsDir := filepath.Join(dir, "artifacts")
 	logPath := filepath.Join(dir, "build.log")
 	lockDir := filepath.Join(dir, "owned-ui.lock")
 	sharedUI := filepath.Join(dir, "ui", "shared")
@@ -512,8 +524,8 @@ printf 'end\n' >> %s
 		"alpha": alphaManifest,
 		"beta":  betaManifest,
 	})
-	if err := NewLifecycle().SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{Parallelism: 2}); err != nil {
-		t.Fatalf("SyncAtPathsWithStatePathsOptions: %v", err)
+	if err := NewLifecycle().SyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{Parallelism: 2}); err != nil {
+		t.Fatalf("SyncAtPathsOptions: %v", err)
 	}
 	data, err := os.ReadFile(logPath)
 	if err != nil {
@@ -533,6 +545,8 @@ func TestLifecycleSyncLockedSerializesLocalUIsWithSharedOutput(t *testing.T) {
 	}
 
 	dir := t.TempDir()
+	lockfilePath := filepath.Join(dir, LockfileName)
+	artifactsDir := filepath.Join(dir, "artifacts")
 	uiDir := filepath.Join(dir, "ui", "shared")
 	if err := os.MkdirAll(uiDir, 0o755); err != nil {
 		t.Fatalf("mkdir ui dir: %v", err)
@@ -562,8 +576,8 @@ printf '<html>ok</html>\n' > dist/index.html
 		"alpha": filepath.Join(uiDir, "manifest-alpha.yaml"),
 		"beta":  filepath.Join(uiDir, "manifest-beta.yaml"),
 	})
-	if err := NewLifecycle().SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{Parallelism: 2}); err != nil {
-		t.Fatalf("SyncAtPathsWithStatePathsOptions: %v", err)
+	if err := NewLifecycle().SyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{Parallelism: 2}); err != nil {
+		t.Fatalf("SyncAtPathsOptions: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(uiDir, "overlap")); !os.IsNotExist(err) {
 		t.Fatalf("shared-output builds overlapped, stat overlap err=%v", err)
@@ -589,9 +603,10 @@ printf '<html>alpha</html>\n' > dist/index.html
 	configPath := writeLocalUITestConfig(t, dir, map[string]string{
 		"alpha": filepath.Join(uiDir, "manifest.yaml"),
 	})
-	err := NewLifecycle().CheckSyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{Parallelism: 2})
+	lockfilePath, artifactsDir := lockAndArtifactsForConfig(configPath)
+	err := NewLifecycle().CheckSyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{Parallelism: 2})
 	if err == nil || !strings.Contains(err.Error(), "artifacts would be materialized") {
-		t.Fatalf("CheckSyncAtPathsWithStatePathsOptions error = %v, want stale prepared artifact", err)
+		t.Fatalf("CheckSyncAtPathsOptions error = %v, want stale prepared artifact", err)
 	}
 	if _, err := os.Stat(startedPath); !os.IsNotExist(err) {
 		t.Fatalf("sync --check materialized local ui, stat started err=%v", err)
@@ -617,6 +632,7 @@ func TestLifecycleLocalSourceLockedExecutionUsesPreparedArtifactsWithoutSourceTr
 	writeSourceUITree(t, uiDir, uiSource, version)
 
 	artifactsDir := filepath.Join(dir, "artifacts")
+	lockfilePath := filepath.Join(dir, LockfileName)
 	configPath := filepath.Join(dir, "gestaltd.yaml")
 	configYAML := fmt.Sprintf(`
 apiVersion: gestaltd.config/v8
@@ -640,9 +656,9 @@ apps:
 	}
 
 	lc := NewLifecycle()
-	lock, err := lc.LockAtPathsWithStatePaths([]string{configPath}, StatePaths{})
+	lock, err := lc.LockAtPaths([]string{configPath}, lockfilePath, artifactsDir)
 	if err != nil {
-		t.Fatalf("LockAtPathsWithStatePaths: %v", err)
+		t.Fatalf("LockAtPaths: %v", err)
 	}
 	if _, ok := lock.Providers.App["alpha"]; ok {
 		t.Fatalf("local source provider lock entry should be omitted: %#v", lock.Providers)
@@ -653,9 +669,9 @@ apps:
 	if _, err := os.Stat(filepath.Join(artifactsDir, ".gestaltd")); !os.IsNotExist(err) {
 		t.Fatalf("lock should not create prepared artifact dirs for local source entries, stat err=%v", err)
 	}
-	lock, err = lc.LockAtPathsWithStatePaths([]string{configPath}, StatePaths{})
+	lock, err = lc.LockAtPaths([]string{configPath}, lockfilePath, artifactsDir)
 	if err != nil {
-		t.Fatalf("restore canonical LockAtPathsWithStatePaths: %v", err)
+		t.Fatalf("restore canonical LockAtPaths: %v", err)
 	}
 	if _, ok := lock.Providers.App["alpha"]; ok {
 		t.Fatalf("restored local source provider lock entry should be omitted: %#v", lock.Providers)
@@ -663,8 +679,8 @@ apps:
 	if _, ok := lock.Providers.UI["roadmap"]; ok {
 		t.Fatalf("restored local source ui lock entry should be omitted: %#v", lock.Providers.UI)
 	}
-	if err := lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{}); err != nil {
-		t.Fatalf("SyncAtPathsWithStatePaths: %v", err)
+	if err := lc.SyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{}); err != nil {
+		t.Fatalf("SyncAtPaths: %v", err)
 	}
 
 	preparedProviderDir := filepath.Join(artifactsDir, "providers", "alpha")
@@ -695,7 +711,7 @@ apps:
 		t.Fatalf("remove ui source tree: %v", err)
 	}
 
-	cfg, _, err := lc.LoadForExecutionAtPathsWithStatePaths([]string{configPath}, StatePaths{}, true, true)
+	cfg, _, err := lc.LoadForExecutionAtPaths([]string{configPath}, lockfilePath, artifactsDir, true, true)
 	if err != nil {
 		t.Fatalf("LoadForExecutionAtPath(locked=true, noSync=true) without local source tree: %v", err)
 	}
@@ -713,11 +729,11 @@ apps:
 	if got, want := filepath.ToSlash(ui.ResolvedAssetRoot), filepath.ToSlash(preparedUI); got != want {
 		t.Fatalf("ResolvedAssetRoot = %q, want %q", got, want)
 	}
-	if err := lc.CheckSyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{}); err == nil || !strings.Contains(err.Error(), "artifacts would be materialized") {
-		t.Fatalf("CheckSyncAtPathsWithStatePaths without local source tree error = %v, want stale provider artifact", err)
+	if err := lc.CheckSyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{}); err == nil || !strings.Contains(err.Error(), "artifacts would be materialized") {
+		t.Fatalf("CheckSyncAtPaths without local source tree error = %v, want stale provider artifact", err)
 	}
-	if err := lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{}); err == nil || !strings.Contains(err.Error(), `manifest for app "alpha" not found`) {
-		t.Fatalf("SyncAtPathsWithStatePaths without local source tree error = %v, want missing source manifest", err)
+	if err := lc.SyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{}); err == nil || !strings.Contains(err.Error(), `manifest for app "alpha" not found`) {
+		t.Fatalf("SyncAtPaths without local source tree error = %v, want missing source manifest", err)
 	}
 
 	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
@@ -731,11 +747,11 @@ apps:
 	if err := os.Remove(preparedUIMetadata); err != nil {
 		t.Fatalf("remove prepared ui lock metadata: %v", err)
 	}
-	if err := lc.CheckSyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{}); err == nil || !strings.Contains(err.Error(), "artifacts would be materialized") {
-		t.Fatalf("CheckSyncAtPathsWithStatePaths without prepared lock metadata error = %v, want stale provider artifact", err)
+	if err := lc.CheckSyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{}); err == nil || !strings.Contains(err.Error(), "artifacts would be materialized") {
+		t.Fatalf("CheckSyncAtPaths without prepared lock metadata error = %v, want stale provider artifact", err)
 	}
-	if err := lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{}); err != nil {
-		t.Fatalf("SyncAtPathsWithStatePaths backfilling prepared lock metadata: %v", err)
+	if err := lc.SyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{}); err != nil {
+		t.Fatalf("SyncAtPaths backfilling prepared lock metadata: %v", err)
 	}
 	if _, err := os.Stat(preparedProviderMetadata); err != nil {
 		t.Fatalf("prepared provider lock metadata not backfilled: %v", err)
@@ -755,8 +771,8 @@ apps:
 	if err := os.WriteFile(preparedUIMetadata, []byte(`{"inputDigest":"stale","kind":"ui","name":"roadmap"}`+"\n"), 0o644); err != nil {
 		t.Fatalf("write stale prepared ui lock metadata before sync: %v", err)
 	}
-	if err := lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{}); err != nil {
-		t.Fatalf("SyncAtPathsWithStatePaths re-materializing stale prepared lock metadata: %v", err)
+	if err := lc.SyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{}); err != nil {
+		t.Fatalf("SyncAtPaths re-materializing stale prepared lock metadata: %v", err)
 	}
 	providerData, err := os.ReadFile(preparedProvider)
 	if err != nil {
@@ -778,7 +794,7 @@ apps:
 	if err := os.RemoveAll(filepath.Join(dir, "ui")); err != nil {
 		t.Fatalf("remove ui source tree after backfill: %v", err)
 	}
-	if _, _, err := lc.LoadForExecutionAtPathsWithStatePaths([]string{configPath}, StatePaths{}, true, true); err != nil {
+	if _, _, err := lc.LoadForExecutionAtPaths([]string{configPath}, lockfilePath, artifactsDir, true, true); err != nil {
 		t.Fatalf("LoadForExecutionAtPath(locked=true, noSync=true) after metadata backfill: %v", err)
 	}
 
@@ -787,7 +803,7 @@ apps:
 	if err := os.WriteFile(preparedProviderMetadata, []byte(`{"inputDigest":"stale","kind":"app","name":"alpha"}`+"\n"), 0o644); err != nil {
 		t.Fatalf("write stale prepared provider lock metadata: %v", err)
 	}
-	if _, _, err := lc.LoadForExecutionAtPath(configPath, true); err != nil {
+	if _, _, err := lc.LoadForExecutionAtPaths([]string{configPath}, lockfilePath, artifactsDir, true, false); err != nil {
 		t.Fatalf("LoadForExecutionAtPath(locked=true) with stale prepared provider metadata should re-materialize: %v", err)
 	}
 	if err := os.WriteFile(preparedProviderMetadata, providerMetadata, 0o644); err != nil {
@@ -796,8 +812,8 @@ apps:
 	if err := os.WriteFile(preparedUIMetadata, []byte(`{"inputDigest":"stale","kind":"ui","name":"roadmap"}`+"\n"), 0o644); err != nil {
 		t.Fatalf("write stale prepared ui lock metadata: %v", err)
 	}
-	if _, _, err := lc.LoadForExecutionAtPathsWithStatePaths([]string{configPath}, StatePaths{}, true, true); err != nil {
-		t.Fatalf("LoadForExecutionAtPathsWithStatePaths(locked=true, noSync=true) with stale prepared ui metadata: %v", err)
+	if _, _, err := lc.LoadForExecutionAtPaths([]string{configPath}, lockfilePath, artifactsDir, true, true); err != nil {
+		t.Fatalf("LoadForExecutionAtPaths(locked=true, noSync=true) with stale prepared ui metadata: %v", err)
 	}
 }
 
@@ -806,6 +822,7 @@ func TestLockAtPathsSkipsMissingConfiguredLocalSources(t *testing.T) {
 
 	dir := t.TempDir()
 	artifactsDir := filepath.Join(dir, "artifacts")
+	lockfilePath := filepath.Join(dir, LockfileName)
 	configPath := filepath.Join(dir, "gestaltd.yaml")
 	configYAML := fmt.Sprintf(`
 apiVersion: gestaltd.config/v8
@@ -828,9 +845,9 @@ apps:
 		t.Fatalf("write config: %v", err)
 	}
 
-	lock, err := NewLifecycle().LockAtPathsWithStatePaths([]string{configPath}, StatePaths{})
+	lock, err := NewLifecycle().LockAtPaths([]string{configPath}, lockfilePath, artifactsDir)
 	if err != nil {
-		t.Fatalf("LockAtPathsWithStatePaths: %v", err)
+		t.Fatalf("LockAtPaths: %v", err)
 	}
 	if _, ok := lock.Providers.App["missing"]; ok {
 		t.Fatalf("local source provider lock entry should be omitted: %#v", lock.Providers)
@@ -847,6 +864,8 @@ func TestLockAtPathsRejectsCommittedProviderInvokesField(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
+	lockfilePath := filepath.Join(dir, LockfileName)
+	artifactsDir := filepath.Join(dir, "artifacts")
 	writeLocalRelease := func(name, source, version string) string {
 		t.Helper()
 
@@ -903,9 +922,9 @@ server:
 	}
 	writeConfig("")
 
-	lock, err := NewLifecycle().LockAtPathsWithStatePaths([]string{configPath}, StatePaths{})
+	lock, err := NewLifecycle().LockAtPaths([]string{configPath}, lockfilePath, artifactsDir)
 	if err != nil {
-		t.Fatalf("LockAtPathsWithStatePaths: %v", err)
+		t.Fatalf("LockAtPaths: %v", err)
 	}
 	callerStatic := lock.Providers.App["caller"].ValidationManifest
 	if callerStatic == nil || callerStatic.Entrypoint != nil {
@@ -916,11 +935,11 @@ server:
     invokes:
       - app: target
         operation: missing`)
-	if _, err := NewLifecycle().LoadForStaticValidationAtPathsWithStatePaths([]string{configPath}, StatePaths{}, StaticValidationOptions{}); err == nil || !strings.Contains(err.Error(), "field invokes not found") {
-		t.Fatalf("LoadForStaticValidationAtPathsWithStatePaths error = %v, want field invokes not found", err)
+	if _, err := NewLifecycle().LoadForStaticValidationAtPaths([]string{configPath}, lockfilePath, artifactsDir, StaticValidationOptions{}); err == nil || !strings.Contains(err.Error(), "field invokes not found") {
+		t.Fatalf("LoadForStaticValidationAtPaths error = %v, want field invokes not found", err)
 	}
-	if _, err := NewLifecycle().LockAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err == nil || !strings.Contains(err.Error(), "field invokes not found") {
-		t.Fatalf("LockAtPathsWithStatePaths error = %v, want field invokes not found", err)
+	if _, err := NewLifecycle().LockAtPaths([]string{configPath}, lockfilePath, artifactsDir); err == nil || !strings.Contains(err.Error(), "field invokes not found") {
+		t.Fatalf("LockAtPaths error = %v, want field invokes not found", err)
 	}
 }
 
@@ -973,22 +992,23 @@ server:
 		t.Fatalf("write config: %v", err)
 	}
 
+	lockfilePath, artifactsDir := lockAndArtifactsForConfig(configPath)
 	lc := NewLifecycle()
-	lock, err := lc.LockAtPathsWithStatePaths([]string{configPath}, StatePaths{})
+	lock, err := lc.LockAtPaths([]string{configPath}, lockfilePath, artifactsDir)
 	if err != nil {
-		t.Fatalf("LockAtPathsWithStatePaths: %v", err)
+		t.Fatalf("LockAtPaths: %v", err)
 	}
 	delete(lock.Providers.App, "target")
 	if err := WriteLockfile(filepath.Join(dir, LockfileName), lock); err != nil {
 		t.Fatalf("write stale lockfile: %v", err)
 	}
 
-	err = lc.CheckLockAtPathsWithStatePaths([]string{configPath}, StatePaths{})
+	err = lc.CheckLockAtPaths([]string{configPath}, lockfilePath, artifactsDir)
 	if err == nil {
-		t.Fatal("CheckLockAtPathsWithStatePaths unexpectedly succeeded")
+		t.Fatal("CheckLockAtPaths unexpectedly succeeded")
 	}
 	if got := err.Error(); !strings.Contains(got, "lockfile is out of date; run `gestaltd lock") || !strings.Contains(got, "missing providers.app.target") {
-		t.Fatalf("CheckLockAtPathsWithStatePaths error = %v, want lock command and missing provider drift", err)
+		t.Fatalf("CheckLockAtPaths error = %v, want lock command and missing provider drift", err)
 	}
 }
 
@@ -1045,6 +1065,7 @@ func TestLifecycleGitSourceSnapshotRequireContract(t *testing.T) {
 	defer srv.Close()
 
 	artifactsDir := filepath.Join(dir, "artifacts")
+	lockfilePath := filepath.Join(dir, LockfileName)
 	configPath := filepath.Join(dir, "gestaltd.yaml")
 	configYAML := fmt.Sprintf(`
 apiVersion: gestaltd.config/v8
@@ -1072,9 +1093,9 @@ apps:
 		t.Fatalf("write config: %v", err)
 	}
 
-	lock, err := NewLifecycle().WithHTTPClient(srv.Client()).LockAtPathsWithStatePaths([]string{configPath}, StatePaths{})
+	lock, err := NewLifecycle().WithHTTPClient(srv.Client()).LockAtPaths([]string{configPath}, lockfilePath, artifactsDir)
 	if err != nil {
-		t.Fatalf("LockAtPathsWithStatePaths: %v", err)
+		t.Fatalf("LockAtPaths: %v", err)
 	}
 	entry := lock.Providers.App["alpha"]
 	if entry.SourceRef == nil {
@@ -1099,8 +1120,8 @@ apps:
 		t.Fatalf("archive count = %d, want 0", got)
 	}
 	archiveBeforeCheck := archiveCount.Load()
-	if err := NewLifecycle().WithHTTPClient(srv.Client()).CheckLockAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
-		t.Fatalf("CheckLockAtPathsWithStatePaths: %v", err)
+	if err := NewLifecycle().WithHTTPClient(srv.Client()).CheckLockAtPaths([]string{configPath}, lockfilePath, artifactsDir); err != nil {
+		t.Fatalf("CheckLockAtPaths: %v", err)
 	}
 	if got := archiveCount.Load(); got != archiveBeforeCheck {
 		t.Fatalf("archive count after check = %d, want %d", got, archiveBeforeCheck)
@@ -1160,6 +1181,7 @@ func TestLifecycleGitSourceSnapshotRequirePrimesSecretsProvider(t *testing.T) {
 	defer srv.Close()
 
 	artifactsDir := filepath.Join(dir, "artifacts")
+	lockfilePath := filepath.Join(dir, LockfileName)
 	indexedDBManifestPath := writeStubIndexedDBManifest(t, dir)
 	configPath := filepath.Join(dir, "gestaltd.yaml")
 	configYAML := fmt.Sprintf(`
@@ -1197,9 +1219,9 @@ providers:
 		t.Fatalf("write config: %v", err)
 	}
 
-	lock, err := NewLifecycle().WithHTTPClient(srv.Client()).LockAtPathsWithStatePaths([]string{configPath}, StatePaths{})
+	lock, err := NewLifecycle().WithHTTPClient(srv.Client()).LockAtPaths([]string{configPath}, lockfilePath, artifactsDir)
 	if err != nil {
-		t.Fatalf("LockAtPathsWithStatePaths: %v", err)
+		t.Fatalf("LockAtPaths: %v", err)
 	}
 	entry := lock.Providers.Secrets["secrets"]
 	if entry.SourceRef == nil {
@@ -1376,6 +1398,8 @@ func writeNamedBlockingSourceUIManifest(t *testing.T, dir, manifestName, source,
 
 func writeLocalUITestConfig(t *testing.T, dir string, uiManifests map[string]string) string {
 	t.Helper()
+	lockfilePath := filepath.Join(dir, LockfileName)
+	artifactsDir := filepath.Join(dir, "artifacts")
 	var b strings.Builder
 	b.WriteString("apiVersion: gestaltd.config/v8\n")
 	b.WriteString(requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")))
@@ -1396,7 +1420,7 @@ func writeLocalUITestConfig(t *testing.T, dir string, uiManifests map[string]str
 	if err := os.WriteFile(configPath, []byte(b.String()), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
-	if _, err := NewLifecycle().LockAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
+	if _, err := NewLifecycle().LockAtPaths([]string{configPath}, lockfilePath, artifactsDir); err != nil {
 		t.Fatalf("write lockfile: %v", err)
 	}
 	return configPath
@@ -1404,6 +1428,8 @@ func writeLocalUITestConfig(t *testing.T, dir string, uiManifests map[string]str
 
 func writeOwnedUIAppTestConfig(t *testing.T, dir string, apps map[string]string) string {
 	t.Helper()
+	lockfilePath := filepath.Join(dir, LockfileName)
+	artifactsDir := filepath.Join(dir, "artifacts")
 	var b strings.Builder
 	b.WriteString("apiVersion: gestaltd.config/v8\n")
 	b.WriteString(requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")))
@@ -1425,7 +1451,7 @@ func writeOwnedUIAppTestConfig(t *testing.T, dir string, apps map[string]string)
 	if err := os.WriteFile(configPath, []byte(b.String()), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
-	if _, err := NewLifecycle().LockAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
+	if _, err := NewLifecycle().LockAtPaths([]string{configPath}, lockfilePath, artifactsDir); err != nil {
 		t.Fatalf("write lockfile: %v", err)
 	}
 	return configPath
@@ -1433,6 +1459,8 @@ func writeOwnedUIAppTestConfig(t *testing.T, dir string, apps map[string]string)
 
 func writeAppBoundLocalUITestConfig(t *testing.T, dir string, apps, uiManifests map[string]string) (string, *Lockfile) {
 	t.Helper()
+	lockfilePath := filepath.Join(dir, LockfileName)
+	artifactsDir := filepath.Join(dir, "artifacts")
 	var b strings.Builder
 	b.WriteString("apiVersion: gestaltd.config/v8\n")
 	b.WriteString(requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")))
@@ -1461,7 +1489,7 @@ func writeAppBoundLocalUITestConfig(t *testing.T, dir string, apps, uiManifests 
 	if err := os.WriteFile(configPath, []byte(b.String()), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
-	lock, err := NewLifecycle().LockAtPathsWithStatePaths([]string{configPath}, StatePaths{})
+	lock, err := NewLifecycle().LockAtPaths([]string{configPath}, lockfilePath, artifactsDir)
 	if err != nil {
 		t.Fatalf("write lockfile: %v", err)
 	}
@@ -1678,9 +1706,10 @@ server:
 		t.Fatalf("write config: %v", err)
 	}
 
-	lock, err := NewLifecycle().LockAtPathsWithStatePaths([]string{configPath}, StatePaths{})
+	lockfilePath, artifactsDir := lockAndArtifactsForConfig(configPath)
+	lock, err := NewLifecycle().LockAtPaths([]string{configPath}, lockfilePath, artifactsDir)
 	if err != nil {
-		t.Fatalf("LockAtPathsWithStatePaths: %v", err)
+		t.Fatalf("LockAtPaths: %v", err)
 	}
 	entry := lock.Providers.App["static-lock"]
 	if entry.ValidationManifest == nil {
@@ -1696,6 +1725,7 @@ func TestSyncAtPathsUsesLockedStaticValidationCatalogForOpenAPIProvider(t *testi
 
 	dir := t.TempDir()
 	artifactsDir := filepath.Join(dir, "artifacts")
+	lockfilePath := filepath.Join(dir, LockfileName)
 	packageSource := "github.com/acme/tools/static-openapi"
 	version := "1.2.3"
 	archivePath := buildExecutableArchiveDataWithSpec(t, dir, "static-openapi-src", packageSource, version, providermanifestv1.KindApp, "static-openapi", []byte("static-openapi-binary"), withNoAuthDefaultConnection(&providermanifestv1.Spec{
@@ -1739,11 +1769,11 @@ server:
 	}
 
 	lc := NewLifecycle()
-	if _, err := lc.LockAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
-		t.Fatalf("LockAtPathsWithStatePaths: %v", err)
+	if _, err := lc.LockAtPaths([]string{configPath}, lockfilePath, artifactsDir); err != nil {
+		t.Fatalf("LockAtPaths: %v", err)
 	}
-	if err := lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{Parallelism: 1}); err != nil {
-		t.Fatalf("SyncAtPathsWithStatePathsOptions: %v", err)
+	if err := lc.SyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{Parallelism: 1}); err != nil {
+		t.Fatalf("SyncAtPathsOptions: %v", err)
 	}
 }
 
@@ -1751,6 +1781,8 @@ func TestLockAtPathsRejectsProviderReleaseWhenStaticValidationCatalogMissing(t *
 	t.Parallel()
 
 	dir := t.TempDir()
+	lockfilePath := filepath.Join(dir, LockfileName)
+	artifactsDir := filepath.Join(dir, "artifacts")
 	packageSource := "github.com/acme/tools/static-lock"
 	version := "1.2.3"
 	metadataPath := filepath.Join(dir, "provider-release.yaml")
@@ -1790,14 +1822,14 @@ server:
 		t.Fatalf("write config: %v", err)
 	}
 
-	_, err := NewLifecycle().LockAtPathsWithStatePaths([]string{configPath}, StatePaths{})
+	_, err := NewLifecycle().LockAtPaths([]string{configPath}, lockfilePath, artifactsDir)
 	if err == nil {
-		t.Fatal("LockAtPathsWithStatePaths unexpectedly succeeded")
+		t.Fatal("LockAtPaths unexpectedly succeeded")
 	}
 	if got := err.Error(); !strings.Contains(got, "must include catalog metadata unless the validation manifest is MCP-only") ||
 		!strings.Contains(got, packageSource) ||
 		!strings.Contains(got, metadataPath) {
-		t.Fatalf("LockAtPathsWithStatePaths error = %v, want catalog validation failure", err)
+		t.Fatalf("LockAtPaths error = %v, want catalog validation failure", err)
 	}
 }
 
@@ -1805,6 +1837,8 @@ func TestLockAtPathsRejectsPackageLocalStaticValidationSurfaceAsSelfContained(t 
 	t.Parallel()
 
 	dir := t.TempDir()
+	lockfilePath := filepath.Join(dir, LockfileName)
+	artifactsDir := filepath.Join(dir, "artifacts")
 	packageSource := "github.com/acme/tools/static-openapi"
 	version := "1.2.3"
 	metadataPath := filepath.Join(dir, "provider-release.yaml")
@@ -1847,12 +1881,12 @@ server:
 		t.Fatalf("write config: %v", err)
 	}
 
-	_, err := NewLifecycle().LockAtPathsWithStatePaths([]string{configPath}, StatePaths{})
+	_, err := NewLifecycle().LockAtPaths([]string{configPath}, lockfilePath, artifactsDir)
 	if err == nil {
-		t.Fatal("LockAtPathsWithStatePaths unexpectedly succeeded")
+		t.Fatal("LockAtPaths unexpectedly succeeded")
 	}
 	if !strings.Contains(err.Error(), "validation manifest must be self-contained") {
-		t.Fatalf("LockAtPathsWithStatePaths error = %v, want self-contained validation manifest error", err)
+		t.Fatalf("LockAtPaths error = %v, want self-contained validation manifest error", err)
 	}
 }
 
@@ -2381,6 +2415,7 @@ func TestSourceAppMetadataURLPrepareAndLockedLoad(t *testing.T) {
 			}
 
 			artifactsDir := filepath.Join(dir, "prepared-artifacts")
+			lockfilePath := filepath.Join(dir, LockfileName)
 			configPath := filepath.Join(dir, "gestalt.yaml")
 			configLines := []string{
 				"apiVersion: " + tc.apiVersion,
@@ -2458,14 +2493,14 @@ func TestSourceAppMetadataURLPrepareAndLockedLoad(t *testing.T) {
 			}
 
 			lc := NewLifecycle()
-			lock, err := lc.LockAtPathsWithStatePaths([]string{configPath}, StatePaths{})
+			lock, err := lc.LockAtPaths([]string{configPath}, lockfilePath, artifactsDir)
 			if err == nil {
 				if handlerErr := nextHandlerErr(); handlerErr != nil {
 					t.Fatal(handlerErr)
 				}
 			}
 			if err != nil {
-				t.Fatalf("LockAtPathsWithStatePaths: %v", err)
+				t.Fatalf("LockAtPaths: %v", err)
 			}
 			if handlerErr := nextHandlerErr(); handlerErr != nil {
 				t.Fatal(handlerErr)
@@ -2559,13 +2594,13 @@ func TestSourceAppMetadataURLPrepareAndLockedLoad(t *testing.T) {
 
 			metadataBefore := metadataCount.Load()
 			currentBefore := currentArchiveCount.Load()
-			err = lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{})
+			err = lc.SyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{})
 			if tc.tamperLocalArchive {
 				if handlerErr := nextHandlerErr(); handlerErr != nil {
 					t.Fatal(handlerErr)
 				}
 				if err == nil || !strings.Contains(err.Error(), "digest mismatch") {
-					t.Fatalf("SyncAtPathsWithStatePaths error = %v, want digest mismatch", err)
+					t.Fatalf("SyncAtPaths error = %v, want digest mismatch", err)
 				}
 				return
 			}
@@ -2573,7 +2608,7 @@ func TestSourceAppMetadataURLPrepareAndLockedLoad(t *testing.T) {
 				if handlerErr := nextHandlerErr(); handlerErr != nil {
 					t.Fatal(handlerErr)
 				}
-				t.Fatalf("SyncAtPathsWithStatePaths: %v", err)
+				t.Fatalf("SyncAtPaths: %v", err)
 			}
 			if handlerErr := nextHandlerErr(); handlerErr != nil {
 				t.Fatal(handlerErr)
@@ -2591,7 +2626,7 @@ func TestSourceAppMetadataURLPrepareAndLockedLoad(t *testing.T) {
 			}
 			if tc.localSource && tc.remoteArchives {
 				cacheDir := filepath.Join(dir, "materialized-cache-local-metadata")
-				assertRemoteMaterializedCacheRoundTrip(t, lc, configPath, cacheDir, wantCurrentSHA, &currentArchiveCount, func() error {
+				assertRemoteMaterializedCacheRoundTrip(t, lc, configPath, lockfilePath, artifactsDir, cacheDir, wantCurrentSHA, &currentArchiveCount, func() error {
 					return os.RemoveAll(appRoot)
 				}, func() {
 					if handlerErr := nextHandlerErr(); handlerErr != nil {
@@ -2599,7 +2634,7 @@ func TestSourceAppMetadataURLPrepareAndLockedLoad(t *testing.T) {
 					}
 				})
 			}
-			cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
+			cfg, _, err := lc.LoadForExecutionAtPaths([]string{configPath}, lockfilePath, artifactsDir, true, false)
 			if err != nil {
 				t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
 			}
@@ -2635,7 +2670,7 @@ func TestSourceAppMetadataURLPrepareAndLockedLoad(t *testing.T) {
 						},
 					},
 				})
-				if _, _, err := lc.LoadForExecutionAtPath(configPath, true); err == nil || !strings.Contains(err.Error(), "lockfile stale") {
+				if _, _, err := lc.LoadForExecutionAtPaths([]string{configPath}, lockfilePath, artifactsDir, true, false); err == nil || !strings.Contains(err.Error(), "lockfile stale") {
 					t.Fatalf("LoadForExecutionAtPath after stale local metadata error = %v, want stale lockfile", err)
 				}
 			}
@@ -2751,6 +2786,7 @@ packages:
 	defer srv.Close()
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	lockfilePath := filepath.Join(dir, LockfileName)
 	configPath := filepath.Join(dir, "gestalt.yaml")
 	configYAML := strings.Join([]string{
 		"apiVersion: " + config.ConfigAPIVersion,
@@ -2777,7 +2813,7 @@ packages:
 	}
 
 	lc := NewLifecycle()
-	lock, err := lc.PrepareAtPath(configPath)
+	lock, err := lc.PrepareAtPaths([]string{configPath}, lockfilePath, artifactsDir)
 	if err == nil {
 		if handlerErr := nextHandlerErr(); handlerErr != nil {
 			t.Fatal(handlerErr)
@@ -2828,11 +2864,11 @@ packages:
 	indexBefore := indexCount.Load()
 	metadataBefore := metadataCount.Load()
 	archiveBefore := archiveCount.Load()
-	if err := lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{}); err != nil {
+	if err := lc.SyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{}); err != nil {
 		if handlerErr := nextHandlerErr(); handlerErr != nil {
 			t.Fatal(handlerErr)
 		}
-		t.Fatalf("SyncAtPathsWithStatePaths: %v", err)
+		t.Fatalf("SyncAtPaths: %v", err)
 	}
 	if handlerErr := nextHandlerErr(); handlerErr != nil {
 		t.Fatal(handlerErr)
@@ -2854,12 +2890,12 @@ packages:
 			t.Fatal(handlerErr)
 		}
 	}
-	assertCheckSyncDoesNotPopulateMaterializedCache(t, lc, configPath, cacheDir, resetAppRoot)
-	assertRemoteMaterializedCacheRoundTrip(t, lc, configPath, cacheDir, currentArchiveSHAHex, &archiveCount, resetAppRoot, drainHandlerErr)
-	assertRemoteMaterializedCacheRepair(t, lc, configPath, cacheDir, currentArchiveSHAHex, &archiveCount, resetAppRoot, drainHandlerErr)
+	assertCheckSyncDoesNotPopulateMaterializedCache(t, lc, configPath, lockfilePath, artifactsDir, cacheDir, resetAppRoot)
+	assertRemoteMaterializedCacheRoundTrip(t, lc, configPath, lockfilePath, artifactsDir, cacheDir, currentArchiveSHAHex, &archiveCount, resetAppRoot, drainHandlerErr)
+	assertRemoteMaterializedCacheRepair(t, lc, configPath, lockfilePath, artifactsDir, cacheDir, currentArchiveSHAHex, &archiveCount, resetAppRoot, drainHandlerErr)
 
 	archiveBeforeLoad := archiveCount.Load()
-	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
+	cfg, _, err := lc.LoadForExecutionAtPaths([]string{configPath}, lockfilePath, artifactsDir, true, false)
 	if err != nil {
 		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
 	}
@@ -2985,6 +3021,7 @@ func TestSourceProviderPackagesResolveIndexedDBAndS3(t *testing.T) {
 	defer srv.Close()
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	lockfilePath := filepath.Join(dir, LockfileName)
 	configPath := filepath.Join(dir, "gestalt.yaml")
 	configYAML := strings.Join([]string{
 		"apiVersion: " + config.ConfigAPIVersion,
@@ -3016,7 +3053,7 @@ func TestSourceProviderPackagesResolveIndexedDBAndS3(t *testing.T) {
 		t.Fatalf("write config: %v", err)
 	}
 
-	lock, err := NewLifecycle().PrepareAtPath(configPath)
+	lock, err := NewLifecycle().PrepareAtPaths([]string{configPath}, lockfilePath, artifactsDir)
 	if err == nil {
 		if handlerErr := nextHandlerErr(); handlerErr != nil {
 			t.Fatal(handlerErr)
@@ -3131,6 +3168,7 @@ func TestSourceWorkflowMetadataURLPrepareAndLockedLoad(t *testing.T) {
 	defer srv.Close()
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	lockfilePath := filepath.Join(dir, LockfileName)
 	configPath := filepath.Join(dir, "gestalt.yaml")
 	configYAML := "apiVersion: " + config.ConfigAPIVersion + "\n" + requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
 		"  workflow:",
@@ -3150,7 +3188,7 @@ func TestSourceWorkflowMetadataURLPrepareAndLockedLoad(t *testing.T) {
 	}
 
 	lc := NewLifecycle()
-	lock, err := lc.PrepareAtPath(configPath)
+	lock, err := lc.PrepareAtPaths([]string{configPath}, lockfilePath, artifactsDir)
 	if err == nil {
 		if handlerErr := nextHandlerErr(); handlerErr != nil {
 			t.Fatal(handlerErr)
@@ -3193,9 +3231,9 @@ func TestSourceWorkflowMetadataURLPrepareAndLockedLoad(t *testing.T) {
 
 	metadataBefore := metadataCount.Load()
 	archiveBefore := archiveCount.Load()
-	err = lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{})
+	err = lc.SyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{})
 	if err != nil {
-		t.Fatalf("SyncAtPathsWithStatePaths: %v", err)
+		t.Fatalf("SyncAtPaths: %v", err)
 	}
 	if handlerErr := nextHandlerErr(); handlerErr != nil {
 		t.Fatal(handlerErr)
@@ -3207,14 +3245,14 @@ func TestSourceWorkflowMetadataURLPrepareAndLockedLoad(t *testing.T) {
 		t.Fatalf("archive request count during sync = %d, want 1", got)
 	}
 	cacheDir := filepath.Join(dir, "materialized-cache")
-	assertRemoteMaterializedCacheRoundTrip(t, lc, configPath, cacheDir, archiveSHAHex, &archiveCount, func() error {
+	assertRemoteMaterializedCacheRoundTrip(t, lc, configPath, lockfilePath, artifactsDir, cacheDir, archiveSHAHex, &archiveCount, func() error {
 		return os.RemoveAll(workflowRoot)
 	}, func() {
 		if handlerErr := nextHandlerErr(); handlerErr != nil {
 			t.Fatal(handlerErr)
 		}
 	})
-	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
+	cfg, _, err := lc.LoadForExecutionAtPaths([]string{configPath}, lockfilePath, artifactsDir, true, false)
 	if err != nil {
 		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
 	}
@@ -3301,6 +3339,7 @@ func TestSourceExternalCredentialsMetadataURLPrepareAndLockedLoad(t *testing.T) 
 	defer srv.Close()
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	lockfilePath := filepath.Join(dir, LockfileName)
 	configPath := filepath.Join(dir, "gestalt.yaml")
 	configYAML := "apiVersion: " + config.ConfigAPIVersion + "\n" + requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
 		"  externalCredentials:",
@@ -3321,7 +3360,7 @@ func TestSourceExternalCredentialsMetadataURLPrepareAndLockedLoad(t *testing.T) 
 	}
 
 	lc := NewLifecycle()
-	lock, err := lc.PrepareAtPath(configPath)
+	lock, err := lc.PrepareAtPaths([]string{configPath}, lockfilePath, artifactsDir)
 	if err == nil {
 		if handlerErr := nextHandlerErr(); handlerErr != nil {
 			t.Fatal(handlerErr)
@@ -3364,9 +3403,9 @@ func TestSourceExternalCredentialsMetadataURLPrepareAndLockedLoad(t *testing.T) 
 
 	metadataBefore := metadataCount.Load()
 	archiveBefore := archiveCount.Load()
-	err = lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{})
+	err = lc.SyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{})
 	if err != nil {
-		t.Fatalf("SyncAtPathsWithStatePaths: %v", err)
+		t.Fatalf("SyncAtPaths: %v", err)
 	}
 	if handlerErr := nextHandlerErr(); handlerErr != nil {
 		t.Fatal(handlerErr)
@@ -3377,7 +3416,7 @@ func TestSourceExternalCredentialsMetadataURLPrepareAndLockedLoad(t *testing.T) 
 	if got := archiveCount.Load() - archiveBefore; got != 1 {
 		t.Fatalf("archive request count during sync = %d, want 1", got)
 	}
-	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
+	cfg, _, err := lc.LoadForExecutionAtPaths([]string{configPath}, lockfilePath, artifactsDir, true, false)
 	if err != nil {
 		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
 	}
@@ -3475,6 +3514,7 @@ func TestSourceUIMetadataURLPrepareAndLockedLoad(t *testing.T) {
 	defer srv.Close()
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	lockfilePath := filepath.Join(dir, LockfileName)
 	configPath := filepath.Join(dir, "gestalt.yaml")
 	configYAML := "apiVersion: " + config.ConfigAPIVersion + "\n" + requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
 		"  ui:",
@@ -3495,7 +3535,7 @@ func TestSourceUIMetadataURLPrepareAndLockedLoad(t *testing.T) {
 	}
 
 	lc := NewLifecycle()
-	lock, err := lc.PrepareAtPath(configPath)
+	lock, err := lc.PrepareAtPaths([]string{configPath}, lockfilePath, artifactsDir)
 	if err == nil {
 		if handlerErr := nextHandlerErr(); handlerErr != nil {
 			t.Fatal(handlerErr)
@@ -3541,9 +3581,9 @@ func TestSourceUIMetadataURLPrepareAndLockedLoad(t *testing.T) {
 
 	metadataBefore := metadataCount.Load()
 	archiveBefore := archiveCount.Load()
-	err = lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{})
+	err = lc.SyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{})
 	if err != nil {
-		t.Fatalf("SyncAtPathsWithStatePaths: %v", err)
+		t.Fatalf("SyncAtPaths: %v", err)
 	}
 	if handlerErr := nextHandlerErr(); handlerErr != nil {
 		t.Fatal(handlerErr)
@@ -3555,14 +3595,14 @@ func TestSourceUIMetadataURLPrepareAndLockedLoad(t *testing.T) {
 		t.Fatalf("archive request count during sync = %d, want 1", got)
 	}
 	cacheDir := filepath.Join(dir, "materialized-cache")
-	assertRemoteMaterializedCacheRoundTrip(t, lc, configPath, cacheDir, archiveSHAHex, &archiveCount, func() error {
+	assertRemoteMaterializedCacheRoundTrip(t, lc, configPath, lockfilePath, artifactsDir, cacheDir, archiveSHAHex, &archiveCount, func() error {
 		return os.RemoveAll(uiRoot)
 	}, func() {
 		if handlerErr := nextHandlerErr(); handlerErr != nil {
 			t.Fatal(handlerErr)
 		}
 	})
-	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
+	cfg, _, err := lc.LoadForExecutionAtPaths([]string{configPath}, lockfilePath, artifactsDir, true, false)
 	if err != nil {
 		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
 	}
@@ -3627,6 +3667,7 @@ func TestSourceAppPrepareRejectsMetadataSourceManifestMismatch(t *testing.T) {
 	defer srv.Close()
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	lockfilePath := filepath.Join(dir, LockfileName)
 	configYAML := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
 		"apiVersion: " + config.ConfigAPIVersion,
 		"apps:",
@@ -3645,7 +3686,7 @@ func TestSourceAppPrepareRejectsMetadataSourceManifestMismatch(t *testing.T) {
 	}
 
 	lc := NewLifecycle()
-	_, err = lc.PrepareAtPath(configPath)
+	_, err = lc.PrepareAtPaths([]string{configPath}, lockfilePath, artifactsDir)
 	if err == nil {
 		t.Fatal("PrepareAtPath unexpectedly succeeded")
 		return
@@ -3747,6 +3788,7 @@ func TestSourceAppMetadataURLUsesGenericAuthenticatedFetch(t *testing.T) {
 	currentMu.Unlock()
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	lockfilePath := filepath.Join(dir, LockfileName)
 	configPath := filepath.Join(dir, "gestalt.yaml")
 	configYAML := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
 		"apiVersion: " + config.ConfigAPIVersion,
@@ -3767,7 +3809,7 @@ func TestSourceAppMetadataURLUsesGenericAuthenticatedFetch(t *testing.T) {
 	}
 
 	lc := NewLifecycle()
-	lock, err := lc.PrepareAtPath(configPath)
+	lock, err := lc.PrepareAtPaths([]string{configPath}, lockfilePath, artifactsDir)
 	if err == nil {
 		if handlerErr := nextHandlerErr(); handlerErr != nil {
 			t.Fatal(handlerErr)
@@ -3801,9 +3843,9 @@ func TestSourceAppMetadataURLUsesGenericAuthenticatedFetch(t *testing.T) {
 
 	metadataBefore := metadataCount.Load()
 	archiveBefore := archiveCount.Load()
-	err = lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{})
+	err = lc.SyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{})
 	if err != nil {
-		t.Fatalf("SyncAtPathsWithStatePaths: %v", err)
+		t.Fatalf("SyncAtPaths: %v", err)
 	}
 	if handlerErr := nextHandlerErr(); handlerErr != nil {
 		t.Fatal(handlerErr)
@@ -3814,7 +3856,7 @@ func TestSourceAppMetadataURLUsesGenericAuthenticatedFetch(t *testing.T) {
 	if got := archiveCount.Load() - archiveBefore; got != 1 {
 		t.Fatalf("archive request count during sync = %d, want 1", got)
 	}
-	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
+	cfg, _, err := lc.LoadForExecutionAtPaths([]string{configPath}, lockfilePath, artifactsDir, true, false)
 	if err != nil {
 		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
 	}
@@ -3944,6 +3986,7 @@ func TestSourceAppGitHubReleaseSourceUsesResolvedAssetURL(t *testing.T) {
 	}
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	lockfilePath := filepath.Join(dir, LockfileName)
 	configPath := filepath.Join(dir, "gestalt.yaml")
 	configYAML := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
 		"apiVersion: " + config.ConfigAPIVersion,
@@ -3967,7 +4010,7 @@ func TestSourceAppGitHubReleaseSourceUsesResolvedAssetURL(t *testing.T) {
 	}
 
 	lc := NewLifecycle().WithHTTPClient(client)
-	lock, err := lc.PrepareAtPath(configPath)
+	lock, err := lc.PrepareAtPaths([]string{configPath}, lockfilePath, artifactsDir)
 	if err != nil {
 		t.Fatalf("PrepareAtPath: %v", err)
 	}
@@ -4067,6 +4110,7 @@ func TestSourceAppMetadataURLRetriesTransientRemoteMetadataFailure(t *testing.T)
 	defer srv.Close()
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	lockfilePath := filepath.Join(dir, LockfileName)
 	configPath := filepath.Join(dir, "gestalt.yaml")
 	configYAML := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
 		"apiVersion: " + config.ConfigAPIVersion,
@@ -4087,7 +4131,7 @@ func TestSourceAppMetadataURLRetriesTransientRemoteMetadataFailure(t *testing.T)
 	}
 
 	lc := NewLifecycle()
-	if _, err := lc.PrepareAtPath(configPath); err != nil {
+	if _, err := lc.PrepareAtPaths([]string{configPath}, lockfilePath, artifactsDir); err != nil {
 		t.Fatalf("PrepareAtPath: %v", err)
 	}
 	if handlerErr := nextHandlerErr(); handlerErr != nil {
@@ -4142,6 +4186,7 @@ func TestSourceAppMetadataURLRejectsOversizedRemoteMetadata(t *testing.T) {
 	defer srv.Close()
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	lockfilePath := filepath.Join(dir, LockfileName)
 	configPath := filepath.Join(dir, "gestalt.yaml")
 	configYAML := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
 		"apiVersion: " + config.ConfigAPIVersion,
@@ -4162,7 +4207,7 @@ func TestSourceAppMetadataURLRejectsOversizedRemoteMetadata(t *testing.T) {
 	}
 
 	lc := NewLifecycle()
-	_, err := lc.PrepareAtPath(configPath)
+	_, err := lc.PrepareAtPaths([]string{configPath}, lockfilePath, artifactsDir)
 	if err == nil {
 		t.Fatal("PrepareAtPath unexpectedly succeeded")
 		return
@@ -4271,6 +4316,7 @@ func TestSourceAppMetadataURLUnlockedLoadRefreshesMutableMetadata(t *testing.T) 
 	defer srv.Close()
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	lockfilePath := filepath.Join(dir, LockfileName)
 	configPath := filepath.Join(dir, "gestalt.yaml")
 	configYAML := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
 		"apiVersion: " + config.ConfigAPIVersion,
@@ -4291,7 +4337,7 @@ func TestSourceAppMetadataURLUnlockedLoadRefreshesMutableMetadata(t *testing.T) 
 	}
 
 	lc := NewLifecycle()
-	lock, err := lc.PrepareAtPath(configPath)
+	lock, err := lc.PrepareAtPaths([]string{configPath}, lockfilePath, artifactsDir)
 	if err == nil {
 		if handlerErr := nextHandlerErr(); handlerErr != nil {
 			t.Fatal(handlerErr)
@@ -4316,7 +4362,7 @@ func TestSourceAppMetadataURLUnlockedLoadRefreshesMutableMetadata(t *testing.T) 
 
 	metadataBefore := metadataCount.Load()
 	archiveBefore := archiveCount.Load()
-	cfg, _, err := lc.LoadForExecutionAtPath(configPath, false)
+	cfg, _, err := lc.LoadForExecutionAtPaths([]string{configPath}, lockfilePath, artifactsDir, false, false)
 	if err == nil {
 		if handlerErr := nextHandlerErr(); handlerErr != nil {
 			t.Fatal(handlerErr)
@@ -4350,9 +4396,9 @@ func TestSourceAppMetadataURLUnlockedLoadRefreshesMutableMetadata(t *testing.T) 
 		t.Fatalf("lock version after unlocked load = %q, want %q", got, initialVersion)
 	}
 
-	lock, err = lc.LockAtPathsWithStatePaths([]string{configPath}, StatePaths{})
+	lock, err = lc.LockAtPaths([]string{configPath}, lockfilePath, artifactsDir)
 	if err != nil {
-		t.Fatalf("LockAtPathsWithStatePaths after remote metadata drift: %v", err)
+		t.Fatalf("LockAtPaths after remote metadata drift: %v", err)
 	}
 	if got := lock.Providers.App["alpha"].Version; got != updatedVersion {
 		t.Fatalf("lock version after explicit re-lock = %q, want %q", got, updatedVersion)
@@ -4475,6 +4521,7 @@ func TestSourceAppLoadForExecution_RehydratesWhenCachedManifestVersionMismatches
 	defer srv.Close()
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	lockfilePath := filepath.Join(dir, LockfileName)
 	configYAML := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
 		"apiVersion: " + config.ConfigAPIVersion,
 		"apps:",
@@ -4493,7 +4540,7 @@ func TestSourceAppLoadForExecution_RehydratesWhenCachedManifestVersionMismatches
 	}
 
 	lc := NewLifecycle()
-	if _, err := lc.PrepareAtPath(configPath); err != nil {
+	if _, err := lc.PrepareAtPaths([]string{configPath}, lockfilePath, artifactsDir); err != nil {
 		t.Fatalf("PrepareAtPath: %v", err)
 	}
 
@@ -4524,10 +4571,10 @@ func TestSourceAppLoadForExecution_RehydratesWhenCachedManifestVersionMismatches
 	}
 
 	downloadsBefore := downloadCount.Load()
-	if err := lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{}); err != nil {
-		t.Fatalf("SyncAtPathsWithStatePaths: %v", err)
+	if err := lc.SyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{}); err != nil {
+		t.Fatalf("SyncAtPaths: %v", err)
 	}
-	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
+	cfg, _, err := lc.LoadForExecutionAtPaths([]string{configPath}, lockfilePath, artifactsDir, true, false)
 	if err != nil {
 		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
 	}
@@ -4612,6 +4659,7 @@ func TestSourceAuthAppLoadForExecution(t *testing.T) {
 	defer srv.Close()
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	lockfilePath := filepath.Join(dir, LockfileName)
 	configYAML := strings.Join([]string{
 		"apiVersion: " + config.ConfigAPIVersion,
 		requiredIndexedDBConfigYAML(t, dir, filepath.Join(dir, "data.db")),
@@ -4655,7 +4703,7 @@ func TestSourceAuthAppLoadForExecution(t *testing.T) {
 		return bootstrap.ResolveSourceAuthSecrets(ctx, cfg, factories)
 	})
 	lc = lc.WithHTTPClient(srv.Client())
-	lock, err := lc.PrepareAtPath(configPath)
+	lock, err := lc.PrepareAtPaths([]string{configPath}, lockfilePath, artifactsDir)
 	if err != nil {
 		t.Fatalf("PrepareAtPath: %v", err)
 	}
@@ -4671,7 +4719,7 @@ func TestSourceAuthAppLoadForExecution(t *testing.T) {
 	}
 
 	metadataBefore := metadataCount.Load()
-	_, _, err = lc.LoadForExecutionAtPath(configPath, true)
+	_, _, err = lc.LoadForExecutionAtPaths([]string{configPath}, lockfilePath, artifactsDir, true, false)
 	if err != nil {
 		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
 	}
@@ -4685,9 +4733,9 @@ func TestSourceAuthAppLoadForExecution(t *testing.T) {
 	}
 
 	downloadsBefore := downloadCount.Load()
-	err = lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{})
+	err = lc.SyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{})
 	if err != nil {
-		t.Fatalf("SyncAtPathsWithStatePaths after cache removal: %v", err)
+		t.Fatalf("SyncAtPaths after cache removal: %v", err)
 	}
 	if got := metadataCount.Load(); got != metadataBefore {
 		t.Fatalf("metadata request count during sync = %d, want %d", got, metadataBefore)
@@ -4695,7 +4743,7 @@ func TestSourceAuthAppLoadForExecution(t *testing.T) {
 	if got := downloadCount.Load() - downloadsBefore; got != 1 {
 		t.Fatalf("download count during sync = %d, want 1", got)
 	}
-	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
+	cfg, _, err := lc.LoadForExecutionAtPaths([]string{configPath}, lockfilePath, artifactsDir, true, false)
 	if err != nil {
 		t.Fatalf("LoadForExecutionAtPath after sync: %v", err)
 	}
@@ -4786,6 +4834,7 @@ func TestSourceAuthAppPrepareAllowsMissingEnvPlaceholderInNonStringField(t *test
 	defer srv.Close()
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	lockfilePath := filepath.Join(dir, LockfileName)
 	configYAML := strings.Join([]string{
 		"apiVersion: " + config.ConfigAPIVersion,
 		requiredIndexedDBConfigYAML(t, dir, filepath.Join(dir, "data.db")),
@@ -4831,7 +4880,7 @@ func TestSourceAuthAppPrepareAllowsMissingEnvPlaceholderInNonStringField(t *test
 		return bootstrap.ResolveSourceAuthSecrets(ctx, cfg, factories)
 	})
 	lc = lc.WithHTTPClient(srv.Client())
-	lock, err := lc.PrepareAtPath(configPath)
+	lock, err := lc.PrepareAtPaths([]string{configPath}, lockfilePath, artifactsDir)
 	if err != nil {
 		t.Fatalf("PrepareAtPath: %v", err)
 	}
@@ -4862,6 +4911,7 @@ func TestLockAndSyncSkipRuntimeOnlySecretRefs(t *testing.T) {
 	runtimeSecretsManifestPath := writeBootstrapSecretsManifest(t, dir, "github.com/acme/tools/runtime-secrets", "0.1.0")
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	lockfilePath := filepath.Join(dir, LockfileName)
 	configYAML := strings.Join([]string{
 		"apiVersion: " + config.ConfigAPIVersion,
 		requiredIndexedDBConfigYAML(t, dir, filepath.Join(dir, "data.db")),
@@ -4898,23 +4948,23 @@ func TestLockAndSyncSkipRuntimeOnlySecretRefs(t *testing.T) {
 			return nil
 		})
 
-	if _, err := lc.LockAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
-		t.Fatalf("LockAtPathsWithStatePaths: %v", err)
+	if _, err := lc.LockAtPaths([]string{configPath}, lockfilePath, artifactsDir); err != nil {
+		t.Fatalf("LockAtPaths: %v", err)
 	}
-	if err := lc.CheckLockAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
-		t.Fatalf("CheckLockAtPathsWithStatePaths: %v", err)
+	if err := lc.CheckLockAtPaths([]string{configPath}, lockfilePath, artifactsDir); err != nil {
+		t.Fatalf("CheckLockAtPaths: %v", err)
 	}
-	if err := lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{}); err != nil {
-		t.Fatalf("SyncAtPathsWithStatePaths: %v", err)
+	if err := lc.SyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{}); err != nil {
+		t.Fatalf("SyncAtPaths: %v", err)
 	}
-	if err := lc.CheckSyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{}); err != nil {
-		t.Fatalf("CheckSyncAtPathsWithStatePaths: %v", err)
+	if err := lc.CheckSyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{}); err != nil {
+		t.Fatalf("CheckSyncAtPaths: %v", err)
 	}
 	if fullResolverCalled.Load() {
 		t.Fatal("full config secret resolver ran during lock/sync")
 	}
 
-	if _, _, err := lc.LoadForExecutionAtPath(configPath, true); err == nil {
+	if _, _, err := lc.LoadForExecutionAtPaths([]string{configPath}, lockfilePath, artifactsDir, true, false); err == nil {
 		t.Fatal("LoadForExecutionAtPath unexpectedly succeeded without runtime secret resolution")
 	}
 }
@@ -4965,6 +5015,8 @@ func TestLockRejectsLocalSourceAuthSecretsProviderBeforeFetch(t *testing.T) {
 			t.Parallel()
 
 			dir := t.TempDir()
+			lockfilePath := filepath.Join(dir, LockfileName)
+			artifactsDir := filepath.Join(dir, "artifacts")
 			bootstrapManifestPath := writeBootstrapSecretsManifest(t, dir, "github.com/acme/tools/bootstrap-secrets", "0.1.0")
 			secretsYAML := make([]string, 0, len(tc.secretsYAML))
 			for _, line := range tc.secretsYAML {
@@ -5005,8 +5057,8 @@ func TestLockRejectsLocalSourceAuthSecretsProviderBeforeFetch(t *testing.T) {
 					return fmt.Errorf("source auth resolver should not run before local source secrets rejection")
 				})
 
-			if _, err := lc.LockAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err == nil || !strings.Contains(err.Error(), tc.wantError) {
-				t.Fatalf("LockAtPathsWithStatePaths error = %v, want local source secrets provider rejection", err)
+			if _, err := lc.LockAtPaths([]string{configPath}, lockfilePath, artifactsDir); err == nil || !strings.Contains(err.Error(), tc.wantError) {
+				t.Fatalf("LockAtPaths error = %v, want local source secrets provider rejection", err)
 			}
 		})
 	}
@@ -5175,6 +5227,7 @@ packages:
 	defer srv.Close()
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	lockfilePath := filepath.Join(dir, LockfileName)
 	configYAML := strings.Join([]string{
 		"apiVersion: " + config.ConfigAPIVersion,
 		"providerRepositories:",
@@ -5222,11 +5275,11 @@ packages:
 		}).
 		WithHTTPClient(srv.Client())
 
-	if _, err := lc.LockAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
+	if _, err := lc.LockAtPaths([]string{configPath}, lockfilePath, artifactsDir); err != nil {
 		if handlerErr := nextHandlerErr(); handlerErr != nil {
 			t.Fatal(handlerErr)
 		}
-		t.Fatalf("LockAtPathsWithStatePaths: %v", err)
+		t.Fatalf("LockAtPaths: %v", err)
 	}
 	if handlerErr := nextHandlerErr(); handlerErr != nil {
 		t.Fatal(handlerErr)
@@ -5247,11 +5300,11 @@ packages:
 		t.Fatalf("app archive request count = %d, want 0", got)
 	}
 
-	if err := lc.CheckLockAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
+	if err := lc.CheckLockAtPaths([]string{configPath}, lockfilePath, artifactsDir); err != nil {
 		if handlerErr := nextHandlerErr(); handlerErr != nil {
 			t.Fatal(handlerErr)
 		}
-		t.Fatalf("CheckLockAtPathsWithStatePaths: %v", err)
+		t.Fatalf("CheckLockAtPaths: %v", err)
 	}
 	if handlerErr := nextHandlerErr(); handlerErr != nil {
 		t.Fatal(handlerErr)
@@ -5263,11 +5316,11 @@ packages:
 	if strings.Contains(string(lockData), authToken) {
 		t.Fatal("lockfile contains resolved source auth token")
 	}
-	if _, err := lc.LoadForStaticValidationAtPathsWithStatePaths([]string{configPath}, StatePaths{}, StaticValidationOptions{}); err != nil {
+	if _, err := lc.LoadForStaticValidationAtPaths([]string{configPath}, lockfilePath, artifactsDir, StaticValidationOptions{}); err != nil {
 		if handlerErr := nextHandlerErr(); handlerErr != nil {
 			t.Fatal(handlerErr)
 		}
-		t.Fatalf("LoadForStaticValidationAtPathsWithStatePaths: %v", err)
+		t.Fatalf("LoadForStaticValidationAtPaths: %v", err)
 	}
 	if handlerErr := nextHandlerErr(); handlerErr != nil {
 		t.Fatal(handlerErr)
@@ -5284,11 +5337,11 @@ packages:
 	appMetadataBefore := appMetadataCount.Load()
 	secretsArchivesBefore := secretsArchiveCount.Load()
 	appArchivesBefore := appArchiveCount.Load()
-	if err := lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{}); err != nil {
+	if err := lc.SyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{}); err != nil {
 		if handlerErr := nextHandlerErr(); handlerErr != nil {
 			t.Fatal(handlerErr)
 		}
-		t.Fatalf("SyncAtPathsWithStatePaths: %v", err)
+		t.Fatalf("SyncAtPaths: %v", err)
 	}
 	if handlerErr := nextHandlerErr(); handlerErr != nil {
 		t.Fatal(handlerErr)
@@ -5319,11 +5372,11 @@ packages:
 		WithHTTPClient(srv.Client())
 	appMetadataBeforeValidation := appMetadataCount.Load()
 	secretsArchivesBeforeValidation := secretsArchiveCount.Load()
-	if _, err := validationLC.LoadForValidationAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
+	if _, err := validationLC.LoadForValidationAtPaths([]string{configPath}, lockfilePath, artifactsDir); err != nil {
 		if handlerErr := nextHandlerErr(); handlerErr != nil {
 			t.Fatal(handlerErr)
 		}
-		t.Fatalf("LoadForValidationAtPathsWithStatePaths: %v", err)
+		t.Fatalf("LoadForValidationAtPaths: %v", err)
 	}
 	if handlerErr := nextHandlerErr(); handlerErr != nil {
 		t.Fatal(handlerErr)
@@ -5376,8 +5429,9 @@ func TestLockSourceAuthSecretRefsRequireSourceAuthResolver(t *testing.T) {
 	lc := NewLifecycle().WithConfigSecretResolver(func(ctx context.Context, cfg *config.Config) error {
 		return bootstrap.ResolveConfigSecrets(ctx, cfg, factories)
 	})
-	if _, err := lc.LockAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err == nil || !strings.Contains(err.Error(), "source auth secret resolver is required") {
-		t.Fatalf("LockAtPathsWithStatePaths error = %v, want missing source auth resolver", err)
+	lockfilePath, artifactsDir := lockAndArtifactsForConfig(configPath)
+	if _, err := lc.LockAtPaths([]string{configPath}, lockfilePath, artifactsDir); err == nil || !strings.Contains(err.Error(), "source auth secret resolver is required") {
+		t.Fatalf("LockAtPaths error = %v, want missing source auth resolver", err)
 	}
 }
 
@@ -5397,6 +5451,7 @@ func TestManagedIndexedDBSourcesLoadForExecutionWithMultipleBindings(t *testing.
 	}})
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	lockfilePath := filepath.Join(dir, LockfileName)
 	configYAML := strings.Join([]string{
 		"apiVersion: " + config.ConfigAPIVersion,
 		"providers:",
@@ -5424,7 +5479,7 @@ func TestManagedIndexedDBSourcesLoadForExecutionWithMultipleBindings(t *testing.
 	}
 
 	lc := NewLifecycle()
-	lock, err := lc.PrepareAtPath(configPath)
+	lock, err := lc.PrepareAtPaths([]string{configPath}, lockfilePath, artifactsDir)
 	if err != nil {
 		t.Fatalf("PrepareAtPath: %v", err)
 	}
@@ -5432,7 +5487,7 @@ func TestManagedIndexedDBSourcesLoadForExecutionWithMultipleBindings(t *testing.
 		t.Fatalf("lock.Providers.IndexedDB = %#v, want no local source entries", lock.Providers.IndexedDB)
 	}
 
-	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
+	cfg, _, err := lc.LoadForExecutionAtPaths([]string{configPath}, lockfilePath, artifactsDir, true, false)
 	if err != nil {
 		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
 	}
@@ -5471,6 +5526,7 @@ func TestManagedCacheSourcesLoadForExecutionWithMultipleBindings(t *testing.T) {
 	}})
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	lockfilePath := filepath.Join(dir, LockfileName)
 	indexedDBManifestPath := writeStubIndexedDBManifest(t, dir)
 	configYAML := strings.Join([]string{
 		"apiVersion: " + config.ConfigAPIVersion,
@@ -5523,7 +5579,7 @@ func TestManagedCacheSourcesLoadForExecutionWithMultipleBindings(t *testing.T) {
 	lc := NewLifecycle().WithConfigSecretResolver(func(ctx context.Context, cfg *config.Config) error {
 		return bootstrap.ResolveConfigSecrets(ctx, cfg, factories)
 	})
-	lock, err := lc.PrepareAtPath(configPath)
+	lock, err := lc.PrepareAtPaths([]string{configPath}, lockfilePath, artifactsDir)
 	if err != nil {
 		t.Fatalf("PrepareAtPath: %v", err)
 	}
@@ -5543,7 +5599,7 @@ func TestManagedCacheSourcesLoadForExecutionWithMultipleBindings(t *testing.T) {
 		t.Fatalf("disk lock cache entries = %#v, want no local source entries", diskLock.Providers.Cache)
 	}
 
-	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
+	cfg, _, err := lc.LoadForExecutionAtPaths([]string{configPath}, lockfilePath, artifactsDir, true, false)
 	if err != nil {
 		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
 	}
@@ -5699,6 +5755,7 @@ func TestManagedCacheSourcesLockRecordsReleaseMetadataArchives(t *testing.T) {
 			}
 
 			artifactsDir := filepath.Join(dir, "prepared-artifacts")
+			lockfilePath := filepath.Join(dir, LockfileName)
 			configLines := []string{
 				"apiVersion: " + tc.apiVersion,
 				"providers:",
@@ -5722,9 +5779,9 @@ func TestManagedCacheSourcesLockRecordsReleaseMetadataArchives(t *testing.T) {
 			if client != nil {
 				lc = lc.WithHTTPClient(client)
 			}
-			lock, err := lc.LockAtPathsWithStatePaths([]string{configPath}, StatePaths{})
+			lock, err := lc.LockAtPaths([]string{configPath}, lockfilePath, artifactsDir)
 			if err != nil {
-				t.Fatalf("LockAtPathsWithStatePaths: %v", err)
+				t.Fatalf("LockAtPaths: %v", err)
 			}
 
 			entry, ok := lock.Providers.Cache["session"]
@@ -5910,6 +5967,7 @@ func TestSourceSecretsAppBootstrapsManagedAuthSourceToken(t *testing.T) {
 	defer srv.Close()
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	lockfilePath := filepath.Join(dir, LockfileName)
 	configYAML := strings.Join([]string{
 		"apiVersion: " + config.ConfigAPIVersion,
 		requiredIndexedDBConfigYAML(t, dir, filepath.Join(dir, "data.db")),
@@ -5961,7 +6019,7 @@ func TestSourceSecretsAppBootstrapsManagedAuthSourceToken(t *testing.T) {
 	})
 	lc = lc.WithHTTPClient(srv.Client())
 
-	lock, err := lc.PrepareAtPath(configPath)
+	lock, err := lc.PrepareAtPaths([]string{configPath}, lockfilePath, artifactsDir)
 	if err != nil {
 		t.Fatalf("PrepareAtPath: %v", err)
 	}
@@ -5987,9 +6045,9 @@ func TestSourceSecretsAppBootstrapsManagedAuthSourceToken(t *testing.T) {
 	authMetadataBefore := authMetadataCount.Load()
 	secretsDownloadsBefore := secretsDownloads.Load()
 	authDownloadsBefore := authDownloads.Load()
-	err = lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{})
+	err = lc.SyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{})
 	if err != nil {
-		t.Fatalf("SyncAtPathsWithStatePaths: %v", err)
+		t.Fatalf("SyncAtPaths: %v", err)
 	}
 	if got := secretsMetadataCount.Load(); got != secretsMetadataBefore {
 		t.Fatalf("secrets metadata requests during sync = %d, want %d", got, secretsMetadataBefore)
@@ -6003,7 +6061,7 @@ func TestSourceSecretsAppBootstrapsManagedAuthSourceToken(t *testing.T) {
 	if got := authDownloads.Load() - authDownloadsBefore; got != 1 {
 		t.Fatalf("auth download count during sync = %d, want 1", got)
 	}
-	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
+	cfg, _, err := lc.LoadForExecutionAtPaths([]string{configPath}, lockfilePath, artifactsDir, true, false)
 	if err != nil {
 		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
 	}
@@ -6120,6 +6178,7 @@ func TestLoadForExecutionAtPath_UnlockedBootstrapMetadataPreparesOnce(t *testing
 	defer srv.Close()
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	lockfilePath := filepath.Join(dir, LockfileName)
 	configYAML := strings.Join([]string{
 		"apiVersion: " + config.ConfigAPIVersion,
 		requiredIndexedDBConfigYAML(t, dir, filepath.Join(dir, "data.db")),
@@ -6162,7 +6221,7 @@ func TestLoadForExecutionAtPath_UnlockedBootstrapMetadataPreparesOnce(t *testing
 		return bootstrap.ResolveSourceAuthSecrets(ctx, cfg, factories)
 	})
 
-	cfg, _, err := lc.LoadForExecutionAtPath(configPath, false)
+	cfg, _, err := lc.LoadForExecutionAtPaths([]string{configPath}, lockfilePath, artifactsDir, false, false)
 	if err != nil {
 		if handlerErr := nextHandlerErr(); handlerErr != nil {
 			t.Fatal(handlerErr)
@@ -6248,6 +6307,7 @@ func TestLoadForExecutionAtPath_UnlockedMetadataSecretsProviderResolvesConfigSec
 	defer srv.Close()
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	lockfilePath := filepath.Join(dir, LockfileName)
 	configYAML := strings.Join([]string{
 		"apiVersion: " + config.ConfigAPIVersion,
 		requiredIndexedDBConfigYAML(t, dir, filepath.Join(dir, "data.db")),
@@ -6277,7 +6337,7 @@ func TestLoadForExecutionAtPath_UnlockedMetadataSecretsProviderResolvesConfigSec
 		return bootstrap.ResolveConfigSecrets(ctx, cfg, factories)
 	})
 
-	cfg, _, err := lc.LoadForExecutionAtPath(configPath, false)
+	cfg, _, err := lc.LoadForExecutionAtPaths([]string{configPath}, lockfilePath, artifactsDir, false, false)
 	if err != nil {
 		t.Fatalf("LoadForExecutionAtPath(locked=false): %v", err)
 	}

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -30,6 +30,21 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+func configDirPaths(dir string) (lockfilePath, artifactsDir string) {
+	return filepath.Join(dir, LockfileName), filepath.Join(dir, "artifacts")
+}
+
+func lockAndArtifactsForConfig(configPath string) (lockfilePath, artifactsDir string) {
+	configDir := filepath.Dir(configPath)
+	return filepath.Join(configDir, LockfileName), filepath.Join(configDir, "artifacts")
+}
+
+func prepareAtPathInTest(t *testing.T, lc *Lifecycle, cfgPath string) (*Lockfile, error) {
+	t.Helper()
+	lockfilePath, artifactsDir := lockAndArtifactsForConfig(cfgPath)
+	return lc.PrepareAtPaths([]string{cfgPath}, lockfilePath, artifactsDir)
+}
+
 func testDisplayName(name string) string {
 	parts := strings.Fields(strings.ReplaceAll(name, "-", " "))
 	for i, part := range parts {
@@ -504,6 +519,7 @@ func TestLoadForExecutionAtPath_ResolvesLocalManifestPluginWithoutLockfile(t *te
 	t.Parallel()
 
 	dir := t.TempDir()
+	lockfilePath, artifactsDir := configDirPaths(dir)
 	manifestPath := filepath.Join(dir, "manifest.yaml")
 	buildOutput := ".gestaltd/bin/local-provider"
 	buildScript := "mkdir -p .gestaltd/bin\nprintf 'local-provider' > " + buildOutput + "\nchmod +x " + buildOutput + "\n"
@@ -544,7 +560,7 @@ func TestLoadForExecutionAtPath_ResolvesLocalManifestPluginWithoutLockfile(t *te
 	}
 
 	lc := NewLifecycle()
-	loaded, _, err := lc.LoadForExecutionAtPath(cfgPath, false)
+	loaded, _, err := lc.LoadForExecutionAtPaths([]string{cfgPath}, lockfilePath, artifactsDir, false, false)
 	if err != nil {
 		t.Fatalf("LoadForExecutionAtPath: %v", err)
 	}
@@ -575,6 +591,7 @@ func TestLoadForExecutionAtPath_ResolvesLocalMCPOAuthManifestPluginWithoutLockfi
 	t.Parallel()
 
 	dir := t.TempDir()
+	lockfilePath, artifactsDir := configDirPaths(dir)
 	manifestPath := filepath.Join(dir, "manifest.yaml")
 	manifest := []byte(`
 kind: app
@@ -609,7 +626,7 @@ spec:
 	}
 
 	lc := NewLifecycle()
-	loaded, _, err := lc.LoadForExecutionAtPath(cfgPath, false)
+	loaded, _, err := lc.LoadForExecutionAtPaths([]string{cfgPath}, lockfilePath, artifactsDir, false, false)
 	if err != nil {
 		t.Fatalf("LoadForExecutionAtPath: %v", err)
 	}
@@ -715,7 +732,8 @@ spec:
 				t.Fatalf("WriteFile config: %v", err)
 			}
 
-			_, _, err := NewLifecycle().LoadForExecutionAtPath(cfgPath, false)
+			lockfilePath, artifactsDir := lockAndArtifactsForConfig(cfgPath)
+			_, _, err := NewLifecycle().LoadForExecutionAtPaths([]string{cfgPath}, lockfilePath, artifactsDir, false, false)
 			if err == nil {
 				t.Fatalf("LoadForExecutionAtPath: expected error containing %q", tc.wantErr)
 				return
@@ -748,7 +766,7 @@ server:
 		t.Fatalf("WriteFile config: %v", err)
 	}
 
-	_, err := NewLifecycle().PrepareAtPath(cfgPath)
+	_, err := prepareAtPathInTest(t, NewLifecycle(), cfgPath)
 	if err == nil || !strings.Contains(err.Error(), `field invokes not found`) {
 		t.Fatalf("PrepareAtPath error = %v, want field invokes not found", err)
 	}
@@ -829,7 +847,7 @@ func TestPrepareAtPath_RejectsInvalidAppWorkflowCapabilitiesShape(t *testing.T) 
 				t.Fatalf("WriteFile config: %v", err)
 			}
 
-			_, err := NewLifecycle().PrepareAtPath(cfgPath)
+			_, err := prepareAtPathInTest(t, NewLifecycle(), cfgPath)
 			if err == nil || !strings.Contains(err.Error(), tc.want) {
 				t.Fatalf("PrepareAtPath error = %v, want substring %q", err, tc.want)
 			}
@@ -858,7 +876,7 @@ server:
 		t.Fatalf("WriteFile config: %v", err)
 	}
 
-	if _, err := NewLifecycle().PrepareAtPath(cfgPath); err != nil {
+	if _, err := prepareAtPathInTest(t, NewLifecycle(), cfgPath); err != nil {
 		t.Fatalf("PrepareAtPath: %v", err)
 	}
 }
@@ -884,7 +902,7 @@ server:
 		t.Fatalf("WriteFile config: %v", err)
 	}
 
-	_, err := NewLifecycle().PrepareAtPath(cfgPath)
+	_, err := prepareAtPathInTest(t, NewLifecycle(), cfgPath)
 	if err == nil || !strings.Contains(err.Error(), `duplicate operation "ping" across merged catalogs`) {
 		t.Fatalf("PrepareAtPath error = %v, want duplicate operation error", err)
 	}
@@ -958,7 +976,8 @@ server:
 	}
 
 	lc := NewLifecycle()
-	lock, err := lc.PrepareAtPath(cfgPath)
+	lockfilePath, artifactsDir := lockAndArtifactsForConfig(cfgPath)
+	lock, err := lc.PrepareAtPaths([]string{cfgPath}, lockfilePath, artifactsDir)
 	if err != nil {
 		t.Fatalf("PrepareAtPath: %v", err)
 	}
@@ -971,6 +990,7 @@ func TestLoadForExecutionAtPath_RejectsAppInvokesField(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
+	lockfilePath, artifactsDir := configDirPaths(dir)
 	callerManifestPath := writeLocalExecutablePlugin(t, dir, "caller", "invoke")
 
 	cfgPath := filepath.Join(dir, "config.yaml")
@@ -988,7 +1008,7 @@ server:
 		t.Fatalf("WriteFile config: %v", err)
 	}
 
-	_, _, err := NewLifecycle().LoadForExecutionAtPath(cfgPath, false)
+	_, _, err := NewLifecycle().LoadForExecutionAtPaths([]string{cfgPath}, lockfilePath, artifactsDir, false, false)
 	if err == nil || !strings.Contains(err.Error(), `field invokes not found`) {
 		t.Fatalf("LoadForExecutionAtPath error = %v, want field invokes not found", err)
 	}
@@ -1124,6 +1144,8 @@ apps:
 			t.Parallel()
 
 			dir := t.TempDir()
+			lockfilePath := filepath.Join(dir, LockfileName)
+			artifactsDir := filepath.Join(dir, "artifacts")
 			uiDir := filepath.Join(dir, "ui")
 			if err := os.MkdirAll(uiDir, 0o755); err != nil {
 				t.Fatalf("MkdirAll ui dir: %v", err)
@@ -1222,7 +1244,7 @@ apps:
 			}
 
 			lc := NewLifecycle()
-			loaded, _, err := lc.LoadForExecutionAtPath(cfgPath, false)
+			loaded, _, err := lc.LoadForExecutionAtPaths([]string{cfgPath}, lockfilePath, artifactsDir, false, false)
 			if tc.wantErr != "" {
 				if err == nil {
 					t.Fatalf("LoadForExecutionAtPath: expected error containing %q", tc.wantErr)
@@ -1292,6 +1314,8 @@ func TestLoadForExecutionAtPath_AllowsLockedExplicitLocalUIWithoutPreparedUILock
 	t.Parallel()
 
 	dir := t.TempDir()
+	lockfilePath := filepath.Join(dir, LockfileName)
+	artifactsDir := filepath.Join(dir, "artifacts")
 	uiDir := filepath.Join(dir, "ui")
 	if err := os.MkdirAll(filepath.Join(uiDir, "dist"), 0o755); err != nil {
 		t.Fatalf("MkdirAll ui dist: %v", err)
@@ -1334,7 +1358,7 @@ server:
 	}
 
 	lc := NewLifecycle()
-	if _, err := lc.PrepareAtPath(cfgPath); err != nil {
+	if _, err := lc.PrepareAtPaths([]string{cfgPath}, lockfilePath, artifactsDir); err != nil {
 		t.Fatalf("PrepareAtPath: %v", err)
 	}
 	lockPath := filepath.Join(dir, LockfileName)
@@ -1347,7 +1371,7 @@ server:
 		t.Fatalf("WriteLockfile: %v", err)
 	}
 
-	cfgLoaded, _, err := lc.LoadForExecutionAtPath(cfgPath, true)
+	cfgLoaded, _, err := lc.LoadForExecutionAtPaths([]string{cfgPath}, lockfilePath, artifactsDir, true, false)
 	if err != nil {
 		t.Fatalf("LoadForExecutionAtPath locked: %v", err)
 	}
@@ -1413,6 +1437,7 @@ func TestLoadForExecutionAtPath_ResolvesMountedUIThemeConfig(t *testing.T) {
 			t.Parallel()
 
 			dir := t.TempDir()
+			lockfilePath, artifactsDir := configDirPaths(dir)
 			uiDir := filepath.Join(dir, "ui")
 			if err := os.MkdirAll(filepath.Join(uiDir, "dist"), 0o755); err != nil {
 				t.Fatalf("MkdirAll ui dist: %v", err)
@@ -1459,7 +1484,7 @@ func TestLoadForExecutionAtPath_ResolvesMountedUIThemeConfig(t *testing.T) {
 				t.Fatalf("WriteFile config: %v", err)
 			}
 
-			loaded, _, err := NewLifecycle().LoadForExecutionAtPath(cfgPath, false)
+			loaded, _, err := NewLifecycle().LoadForExecutionAtPaths([]string{cfgPath}, lockfilePath, artifactsDir, false, false)
 			if tc.wantErr != "" {
 				if err == nil {
 					t.Fatalf("LoadForExecutionAtPath: expected error containing %q", tc.wantErr)
@@ -1499,6 +1524,7 @@ func TestLoadForExecutionAtPath_ResolvesManagedPluginOwnedUIFromManagedPath(t *t
 	t.Parallel()
 
 	dir := t.TempDir()
+	var lockfilePath, artifactsDir string
 	const pluginRef = "github.com/testowner/apps/roadmap"
 	const version = "0.0.1-alpha.1"
 
@@ -1618,7 +1644,8 @@ func TestLoadForExecutionAtPath_ResolvesManagedPluginOwnedUIFromManagedPath(t *t
 	}
 
 	lc := NewLifecycle()
-	if _, err := lc.PrepareAtPath(cfgPath); err != nil {
+	lockfilePath, artifactsDir = lockAndArtifactsForConfig(cfgPath)
+	if _, err := lc.PrepareAtPaths([]string{cfgPath}, lockfilePath, artifactsDir); err != nil {
 		t.Fatalf("PrepareAtPath: %v", err)
 	}
 
@@ -1634,7 +1661,7 @@ func TestLoadForExecutionAtPath_ResolvesManagedPluginOwnedUIFromManagedPath(t *t
 	}
 
 	for _, locked := range []bool{false, true} {
-		loaded, _, err := lc.LoadForExecutionAtPath(cfgPath, locked)
+		loaded, _, err := lc.LoadForExecutionAtPaths([]string{cfgPath}, lockfilePath, artifactsDir, locked, false)
 		if err != nil {
 			t.Fatalf("LoadForExecutionAtPath(locked=%t): %v", locked, err)
 		}
@@ -1670,6 +1697,7 @@ func TestLoadForExecutionAtPath_RefreshesManagedPluginWhenGenericArchiveLockIsSt
 	t.Parallel()
 
 	dir := t.TempDir()
+	var lockfilePath, artifactsDir string
 	const pluginRef = "github.com/testowner/apps/roadmap"
 	const version = "0.0.1-alpha.1"
 
@@ -1709,7 +1737,8 @@ server:
 	}
 
 	lc := NewLifecycle()
-	if _, err := lc.PrepareAtPath(cfgPath); err != nil {
+	lockfilePath, artifactsDir = lockAndArtifactsForConfig(cfgPath)
+	if _, err := lc.PrepareAtPaths([]string{cfgPath}, lockfilePath, artifactsDir); err != nil {
 		t.Fatalf("PrepareAtPath: %v", err)
 	}
 
@@ -1736,7 +1765,7 @@ server:
 		t.Fatalf("WriteLockfile: %v", err)
 	}
 
-	loaded, _, err := lc.LoadForExecutionAtPath(cfgPath, false)
+	loaded, _, err := lc.LoadForExecutionAtPaths([]string{cfgPath}, lockfilePath, artifactsDir, false, false)
 	if err != nil {
 		t.Fatalf("LoadForExecutionAtPath: %v", err)
 	}
@@ -1764,6 +1793,7 @@ func TestLoadForExecutionAtPath_LockedManagedDeclarativePluginMaterializesBefore
 	t.Parallel()
 
 	dir := t.TempDir()
+	var lockfilePath, artifactsDir string
 	const pluginRef = "github.com/testowner/apps/roadmap"
 	const oldVersion = "0.0.1-alpha.1"
 	const newVersion = "0.0.2-alpha.1"
@@ -1852,7 +1882,8 @@ server:
 	writeConfig(oldVersion)
 
 	lc := NewLifecycle()
-	initialLock, err := lc.PrepareAtPath(cfgPath)
+	lockfilePath, artifactsDir = lockAndArtifactsForConfig(cfgPath)
+	initialLock, err := lc.PrepareAtPaths([]string{cfgPath}, lockfilePath, artifactsDir)
 	if err != nil {
 		t.Fatalf("PrepareAtPath: %v", err)
 	}
@@ -1879,10 +1910,10 @@ server:
 		t.Fatalf("WriteLockfile: %v", err)
 	}
 
-	if err := lc.SyncAtPathsWithStatePathsOptions([]string{cfgPath}, StatePaths{}, SyncOptions{}); err != nil {
-		t.Fatalf("SyncAtPathsWithStatePaths: %v", err)
+	if err := lc.SyncAtPathsOptions([]string{cfgPath}, lockfilePath, artifactsDir, SyncOptions{}); err != nil {
+		t.Fatalf("SyncAtPaths: %v", err)
 	}
-	loaded, _, err := lc.LoadForExecutionAtPath(cfgPath, true)
+	loaded, _, err := lc.LoadForExecutionAtPaths([]string{cfgPath}, lockfilePath, artifactsDir, true, false)
 	if err != nil {
 		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
 	}
@@ -1905,6 +1936,7 @@ func TestLoadForExecutionAtPath_UsesDerivedPreparedPathsWhenLockPathsAreStale(t 
 	t.Parallel()
 
 	dir := t.TempDir()
+	var lockfilePath, artifactsDir string
 	const version = "0.0.1-alpha.1"
 	pluginManifestPath := writeLocalExecutablePlugin(t, dir, "example", "ping")
 	indexedDBManifestPath := writeStubIndexedDBManifest(t, dir)
@@ -1942,7 +1974,8 @@ server:
 	}
 
 	lc := NewLifecycle()
-	lock, err := lc.PrepareAtPath(cfgPath)
+	lockfilePath, artifactsDir = lockAndArtifactsForConfig(cfgPath)
+	lock, err := lc.PrepareAtPaths([]string{cfgPath}, lockfilePath, artifactsDir)
 	if err != nil {
 		t.Fatalf("PrepareAtPath: %v", err)
 	}
@@ -1969,7 +2002,7 @@ server:
 	}
 
 	for _, locked := range []bool{false, true} {
-		loaded, _, err := lc.LoadForExecutionAtPath(cfgPath, locked)
+		loaded, _, err := lc.LoadForExecutionAtPaths([]string{cfgPath}, lockfilePath, artifactsDir, locked, false)
 		if err != nil {
 			t.Fatalf("LoadForExecutionAtPath(locked=%t): %v", locked, err)
 		}
@@ -2112,7 +2145,7 @@ server:
 	}
 
 	lc := NewLifecycle()
-	if _, err := lc.PrepareAtPath(cfgPath); err == nil || !strings.Contains(err.Error(), "spec.ui.path must stay within the package") {
+	if _, err := prepareAtPathInTest(t, lc, cfgPath); err == nil || !strings.Contains(err.Error(), "spec.ui.path must stay within the package") {
 		t.Fatalf("PrepareAtPath error = %v, want substring %q", err, "spec.ui.path must stay within the package")
 	}
 }
@@ -2181,7 +2214,7 @@ func TestPrepareAtPath_RejectsPolicyBoundManagedMountedUIWithoutExplicitRouteCov
 			}
 
 			lc := NewLifecycle()
-			_, err := lc.PrepareAtPath(cfgPath)
+			_, err := prepareAtPathInTest(t, lc, cfgPath)
 			if err == nil || !strings.Contains(err.Error(), tc.want) {
 				t.Fatalf("PrepareAtPath error = %v, want substring %q", err, tc.want)
 			}
@@ -2228,7 +2261,7 @@ server:
 		t.Fatalf("WriteFile config: %v", err)
 	}
 
-	_, err := lc.PrepareAtPath(cfgPath)
+	_, err := prepareAtPathInTest(t, lc, cfgPath)
 	if err == nil {
 		t.Fatal("expected provider kind validation error")
 		return
@@ -2242,6 +2275,7 @@ func TestLoadForExecutionAtPath_ResolvesLocalTopLevelPluginsWithoutLockfile(t *t
 	t.Parallel()
 
 	dir := t.TempDir()
+	lockfilePath, artifactsDir := configDirPaths(dir)
 	authManifestPath := filepath.Join(dir, "auth-manifest.yaml")
 	buildOutput := ".gestaltd/bin/local-auth"
 	buildScript := fmt.Sprintf("mkdir -p .gestaltd/bin\nprintf 'auth-binary' > %s\nchmod +x %s\n", buildOutput, buildOutput)
@@ -2294,7 +2328,7 @@ server:
 	}
 
 	lc := NewLifecycle()
-	loaded, _, err := lc.LoadForExecutionAtPath(cfgPath, false)
+	loaded, _, err := lc.LoadForExecutionAtPaths([]string{cfgPath}, lockfilePath, artifactsDir, false, false)
 	if err != nil {
 		t.Fatalf("LoadForExecutionAtPath: %v", err)
 	}
@@ -2389,8 +2423,9 @@ server:
 		t.Fatalf("WriteFile config: %v", err)
 	}
 
+	lockfilePath, artifactsDir := lockAndArtifactsForConfig(cfgPath)
 	lc := NewLifecycle()
-	loaded, _, err := lc.LoadForExecutionAtPath(cfgPath, false)
+	loaded, _, err := lc.LoadForExecutionAtPaths([]string{cfgPath}, lockfilePath, artifactsDir, false, false)
 	if err != nil {
 		t.Fatalf("LoadForExecutionAtPath: %v", err)
 	}
@@ -2420,6 +2455,7 @@ func TestLoadForExecutionAtPath_GeneratesStaticCatalogForLocalSourceHybridPlugin
 	t.Parallel()
 
 	dir := t.TempDir()
+	lockfilePath, artifactsDir := configDirPaths(dir)
 	writeTestFile := func(rel string, data []byte, mode os.FileMode) {
 		t.Helper()
 		path := filepath.Join(dir, rel)
@@ -2463,7 +2499,7 @@ func TestLoadForExecutionAtPath_GeneratesStaticCatalogForLocalSourceHybridPlugin
 	writeTestFile("config.yaml", []byte(cfg), 0o644)
 
 	lc := NewLifecycle()
-	loaded, _, err := lc.LoadForExecutionAtPath(cfgPath, false)
+	loaded, _, err := lc.LoadForExecutionAtPaths([]string{cfgPath}, lockfilePath, artifactsDir, false, false)
 	if err != nil {
 		t.Fatalf("LoadForExecutionAtPath: %v", err)
 	}
@@ -2488,6 +2524,7 @@ func TestLoadForExecutionAtPath_LockedLocalSourcePluginUsesPreparedArtifactWitho
 	t.Parallel()
 
 	dir := t.TempDir()
+	lockfilePath, artifactsDir := configDirPaths(dir)
 	writeTestFile := func(rel string, data []byte, mode os.FileMode) {
 		t.Helper()
 		path := filepath.Join(dir, rel)
@@ -2532,7 +2569,7 @@ func TestLoadForExecutionAtPath_LockedLocalSourcePluginUsesPreparedArtifactWitho
 	writeTestFile("config.yaml", []byte(cfg), 0o644)
 
 	lc := NewLifecycle()
-	loaded, _, err := lc.LoadForExecutionAtPath(cfgPath, false)
+	loaded, _, err := lc.LoadForExecutionAtPaths([]string{cfgPath}, lockfilePath, artifactsDir, false, false)
 	if err != nil {
 		t.Fatalf("LoadForExecutionAtPath(locked=false): %v", err)
 	}
@@ -2547,7 +2584,7 @@ func TestLoadForExecutionAtPath_LockedLocalSourcePluginUsesPreparedArtifactWitho
 		}
 	}
 
-	locked, _, err := lc.LoadForExecutionAtPathsWithStatePaths([]string{cfgPath}, StatePaths{}, true, true)
+	locked, _, err := lc.LoadForExecutionAtPaths([]string{cfgPath}, lockfilePath, artifactsDir, true, true)
 	if err != nil {
 		t.Fatalf("LoadForExecutionAtPath(locked=true, noSync=true): %v", err)
 	}
@@ -2568,6 +2605,7 @@ func TestLoadForExecutionAtPath_GeneratesStaticCatalogForLocalPythonSourcePlugin
 	}
 
 	dir := t.TempDir()
+	lockfilePath, artifactsDir := configDirPaths(dir)
 	python3Path, err := exec.LookPath("python3")
 	if err != nil {
 		t.Skipf("python3 not found: %v", err)
@@ -2808,7 +2846,7 @@ print(json.dumps({
 `), 0o644)
 
 	lc := NewLifecycle()
-	loaded, _, err := lc.LoadForExecutionAtPath(filepath.Join(dir, "config.yaml"), false)
+	loaded, _, err := lc.LoadForExecutionAtPaths([]string{filepath.Join(dir, "config.yaml")}, lockfilePath, artifactsDir, false, false)
 	if err != nil {
 		t.Fatalf("LoadForExecutionAtPath: %v", err)
 	}

--- a/gestaltd/internal/operator/materialized_cache_integration_test.go
+++ b/gestaltd/internal/operator/materialized_cache_integration_test.go
@@ -78,6 +78,7 @@ packages:
 	}))
 	defer srv.Close()
 
+	lockfilePath := filepath.Join(dir, LockfileName)
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
 	configPath := filepath.Join(dir, "gestalt.yaml")
 	configYAML := strings.Join([]string{
@@ -103,7 +104,7 @@ packages:
 	}
 
 	lc := NewLifecycle()
-	if _, err := lc.PrepareAtPath(configPath); err != nil {
+	if _, err := lc.PrepareAtPaths([]string{configPath}, lockfilePath, artifactsDir); err != nil {
 		t.Fatalf("PrepareAtPath: %v", err)
 	}
 
@@ -125,7 +126,7 @@ packages:
 	}
 	archiveBeforeSeed := archiveCount.Load()
 	seedCacheDir := filepath.Join(dir, "seed-cache")
-	if err := lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{CacheDir: seedCacheDir}); err != nil {
+	if err := lc.SyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{CacheDir: seedCacheDir}); err != nil {
 		t.Fatalf("seed sync: %v", err)
 	}
 	if got := archiveCount.Load(); got != archiveBeforeSeed+1 {
@@ -141,7 +142,7 @@ packages:
 	prefetchMetrics := NewSyncMetricsRecorder()
 	archiveBeforePrefetch := archiveCount.Load()
 	prefetchCacheDir := filepath.Join(dir, "prefetch-cache")
-	if err := lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{
+	if err := lc.SyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{
 		CacheDir:      prefetchCacheDir,
 		Observability: SyncObservability{Recorder: prefetchMetrics},
 	}); err != nil {
@@ -158,7 +159,7 @@ packages:
 	remoteGetsBeforeFreshSync := remote.gets
 	archiveBeforeFreshSync := archiveCount.Load()
 	freshMetrics := NewSyncMetricsRecorder()
-	if err := lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{
+	if err := lc.SyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{
 		CacheDir:      filepath.Join(dir, "fresh-cache"),
 		Observability: SyncObservability{Recorder: freshMetrics},
 	}); err != nil {
@@ -175,14 +176,14 @@ packages:
 	}
 }
 
-func assertCheckSyncDoesNotPopulateMaterializedCache(t *testing.T, lc *Lifecycle, configPath, cacheDir string, resetArtifacts func() error) {
+func assertCheckSyncDoesNotPopulateMaterializedCache(t *testing.T, lc *Lifecycle, configPath, lockfilePath, artifactsDir, cacheDir string, resetArtifacts func() error) {
 	t.Helper()
 
 	if err := resetArtifacts(); err != nil {
 		t.Fatalf("reset artifacts before check sync: %v", err)
 	}
-	if err := lc.CheckSyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{CacheDir: cacheDir}); err == nil {
-		t.Fatal("CheckSyncAtPathsWithStatePathsOptions with cache dir error = nil, want stale artifact error")
+	if err := lc.CheckSyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{CacheDir: cacheDir}); err == nil {
+		t.Fatal("CheckSyncAtPathsOptions with cache dir error = nil, want stale artifact error")
 	}
 	if _, err := os.Stat(cacheDir); !os.IsNotExist(err) {
 		t.Fatalf("cache dir after check sync stat err = %v, want not exist", err)
@@ -193,6 +194,8 @@ func assertRemoteMaterializedCacheRoundTrip(
 	t *testing.T,
 	lc *Lifecycle,
 	configPath string,
+	lockfilePath string,
+	artifactsDir string,
 	cacheDir string,
 	archiveSHAHex string,
 	archiveCount *atomic.Int64,
@@ -206,11 +209,11 @@ func assertRemoteMaterializedCacheRoundTrip(
 	}
 	archiveBeforeCacheMiss := archiveCount.Load()
 	coldMetrics := NewSyncMetricsRecorder()
-	if err := lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{CacheDir: cacheDir, Observability: SyncObservability{Recorder: coldMetrics}}); err != nil {
+	if err := lc.SyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{CacheDir: cacheDir, Observability: SyncObservability{Recorder: coldMetrics}}); err != nil {
 		if afterMiss != nil {
 			afterMiss()
 		}
-		t.Fatalf("SyncAtPathsWithStatePathsOptions cache miss: %v", err)
+		t.Fatalf("SyncAtPathsOptions cache miss: %v", err)
 	}
 	if afterMiss != nil {
 		afterMiss()
@@ -226,8 +229,8 @@ func assertRemoteMaterializedCacheRoundTrip(
 		t.Fatalf("reset artifacts before cache hit: %v", err)
 	}
 	archiveBeforeCacheHit := archiveCount.Load()
-	if err := lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{CacheDir: cacheDir}); err != nil {
-		t.Fatalf("SyncAtPathsWithStatePathsOptions cache hit: %v", err)
+	if err := lc.SyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{CacheDir: cacheDir}); err != nil {
+		t.Fatalf("SyncAtPathsOptions cache hit: %v", err)
 	}
 	if got := archiveCount.Load(); got != archiveBeforeCacheHit {
 		t.Fatalf("archive request count after cache hit = %d, want %d", got, archiveBeforeCacheHit)
@@ -238,6 +241,8 @@ func assertRemoteMaterializedCacheRepair(
 	t *testing.T,
 	lc *Lifecycle,
 	configPath string,
+	lockfilePath string,
+	artifactsDir string,
 	cacheDir string,
 	archiveSHAHex string,
 	archiveCount *atomic.Int64,
@@ -256,11 +261,11 @@ func assertRemoteMaterializedCacheRepair(
 		t.Fatalf("reset artifacts before cache repair: %v", err)
 	}
 	archiveBeforeCacheRepair := archiveCount.Load()
-	if err := lc.SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{CacheDir: cacheDir}); err != nil {
+	if err := lc.SyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{CacheDir: cacheDir}); err != nil {
 		if afterRepair != nil {
 			afterRepair()
 		}
-		t.Fatalf("SyncAtPathsWithStatePathsOptions cache repair: %v", err)
+		t.Fatalf("SyncAtPathsOptions cache repair: %v", err)
 	}
 	if afterRepair != nil {
 		afterRepair()


### PR DESCRIPTION
The lockfile and prepared-artifacts directory now default to the current working directory instead of the primary config file's directory, matching the convention used by npm, cargo, and uv. The `StatePaths` struct is deleted entirely; all lifecycle and daemon wrapper methods now take `lockfilePath, artifactsDir string` directly, and the `--lockfile` / `--artifacts-dir` CLI flags remain for explicit overrides.

Config-file-relative resolution for provider source paths, UI themes, and fingerprints is unchanged. The standalone zero-config provider-local path is deleted: `gestaltd serve PATH` and `provider validate --path` now require `--config`, removing the synthesized baseline config (`writeProviderLocalBaseConfig`, in-memory SQLite indexeddb, default external credentials, env secrets, port reservation) and the `FleetOverlay` field. The overlay path (`gestaltd serve PATH --config`) continues to work as before.

```go
// Before: lockfile defaulted to filepath.Join(filepath.Dir(configPath), "gestalt.lock.json")
// After:  lockfile defaults to filepath.Join(cwd, "gestalt.lock.json")
func resolveLockfilePath(override string) string {
    if override == "" {
        if cwd, err := os.Getwd(); err == nil {
            return filepath.Join(cwd, LockfileName)
        }
        return LockfileName
    }
    ...
}
```