### PR TITLE
Skip symlinks in source fingerprint walk

### DIFF
--- a/gestaltd/internal/operator/fingerprint.go
+++ b/gestaltd/internal/operator/fingerprint.go
@@ -111,6 +111,9 @@ func walkDigestFiles(root string, skipper fingerprintSkipper, c *digestCollector
 		if d.IsDir() {
 			return nil
 		}
+		if d.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
 		return c.addFile(path)
 	})
 }


### PR DESCRIPTION
`filepath.WalkDir` does not follow symlinks. A symlink to a directory (e.g. `.venv/lib64 -> lib` in a Python venv) appears with `IsDir()==false` and `ModeSymlink` set. The fingerprint walk treated it as a regular file and called `fileSHA256`, which opens the symlink target (a directory) and fails with "is a directory".

This crashes `gestaltd sync` for source-path providers that have `.venv/` in their source tree, which happens when the `install` step (`uv sync --frozen`) creates a venv inside the source directory and there is no `.git` directory (so `.gitignore` patterns are inert).

The fix skips symlinks in `walkDigestFiles`. Symlinks are filesystem artifacts, not source inputs.