### PR TITLE
[ci] run docs build only on the hourly schedule

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,17 +1,10 @@
 name: Build Docs
 
+# The docs build is an expensive, multi-build smoke check (it runs a full
+# Next.js production build per docs version). It is not run on pushes or pull
+# requests; instead ci.yml invokes it on its hourly schedule as a health check.
+# Use workflow_dispatch to validate docs changes on demand before the next run.
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - '.github/workflows/build-docs.yml'
-      - 'docs/**'
-  pull_request:
-    paths:
-      - '.github/workflows/build-docs.yml'
-      - 'docs/**'
-
   workflow_dispatch:
   workflow_call:
     inputs:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,10 +1,10 @@
 name: CD (gestaltd)
 
 # Continuous delivery for gestaltd. Re-runs the validation suite (including the
-# race matrix), builds + pushes the per-commit CI image to Artifact Registry,
-# and then builds the docs. Every CD run publishes: it is triggered by pushes to
-# main and by manual dispatch for a specific commit SHA. The hourly health check
-# runs in ci.yml instead.
+# race matrix) and builds + pushes the per-commit CI image to Artifact Registry.
+# Every CD run publishes: it is triggered by pushes to main and by manual
+# dispatch for a specific commit SHA. The hourly health check (and the docs
+# build smoke check) runs in ci.yml instead.
 
 on:
   push:
@@ -111,16 +111,3 @@ jobs:
           image-repository: ${{ vars.GESTALTD_CI_IMAGE_REPOSITORY }}
           gcp-service-account: ${{ vars.GESTALTD_CI_GCP_SERVICE_ACCOUNT }}
           gcp-workload-identity-provider: ${{ vars.GESTALTD_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}
-
-  # Docs build runs after the CI image is built and pushed, so a docs failure
-  # never blocks the image publish. It is skipped if the image build did not
-  # succeed (default needs gating).
-  docs-build:
-    name: Docs Build
-    needs: [resolve-ref, build-and-push]
-    if: ${{ needs.resolve-ref.outputs.publish == 'true' }}
-    uses: ./.github/workflows/build-docs.yml
-    with:
-      gestalt_ref: ${{ needs.resolve-ref.outputs.sha }}
-    permissions:
-      contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,17 @@ jobs:
       run-race: ${{ github.event_name == 'schedule' }}
       run-e2e: ${{ github.event_name == 'schedule' }}
 
+  # The docs build is an expensive multi-build smoke check, so like race/e2e it
+  # runs only on the hourly schedule, not on pull requests. It is intentionally
+  # absent from cd.yml: docs are published by deploy-gestalt-docs.yml, so this
+  # is pure validation and must not gate the gestaltd image publish.
+  docs-build:
+    name: Docs Build
+    if: ${{ github.event_name == 'schedule' }}
+    uses: ./.github/workflows/build-docs.yml
+    permissions:
+      contents: read
+
   # Build-only Dockerfile/packaging validation. Depends on resolve-ref rather
   # than validate so it runs in parallel with the Go + Helm checks instead of
   # waiting for them.


### PR DESCRIPTION
## Description
Move the docs build smoke check out of the CD path and onto ci.yml's hourly schedule. Adds a schedule-gated `docs-build` job to ci.yml (same pattern as `run-race`/`run-e2e`), removes the `docs-build` job from cd.yml, and strips build-docs.yml's own `push`/`pull_request` triggers so it runs only on the hourly schedule (or manual `workflow_dispatch`).

The docs build runs a full Next.js production build per version (~3-4 min) and its output is discarded — actual docs publishing is handled separately by deploy-gestalt-docs.yml. So it was pure validation that was slowing every gestaltd main push for no publish benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)