### PR TITLE
[gestaltd] publish alpine release image to GCP Artifact Registry

### DIFF
--- a/.github/workflows/publish-gcp-ar-image.yml
+++ b/.github/workflows/publish-gcp-ar-image.yml
@@ -1,0 +1,144 @@
+name: Publish GCP Artifact Registry Image
+
+# Builds a gestaltd release image and pushes it to Google Artifact Registry by
+# semver tag. This is the internal-deploy counterpart to publish-dockerhub-image.yml:
+# the image is addressed alongside the Helm chart in Artifact Registry and pulled
+# by valon-tools via Workload Identity rather than from public Docker Hub.
+
+on:
+  workflow_call:
+    inputs:
+      image-name:
+        description: Full Artifact Registry image path, e.g. us-east1-docker.pkg.dev/<project>/<repo>/gestaltd.
+        required: true
+        type: string
+      image-url:
+        description: Repository URL for OCI labels.
+        required: true
+        type: string
+      registry-host:
+        description: Artifact Registry host used for docker login, e.g. us-east1-docker.pkg.dev.
+        required: true
+        type: string
+      dockerfile:
+        description: Dockerfile path relative to the repository root.
+        required: true
+        type: string
+      version-prefix:
+        description: Tag prefix to strip from github.ref_name when rendering the image version.
+        required: true
+        type: string
+      download-artifact-pattern:
+        description: Optional release artifact pattern to download before docker build.
+        required: false
+        default: ''
+        type: string
+      platforms:
+        description: Target platforms to publish (e.g. "linux/amd64,linux/arm64").
+        required: true
+        type: string
+      build-context:
+        description: Docker build context relative to the repository root.
+        required: false
+        default: '.'
+        type: string
+      tag-suffix:
+        description: Optional suffix appended to image tags (e.g. "-alpine").
+        required: false
+        default: ''
+        type: string
+      target:
+        description: Dockerfile build target (e.g. "alpine-prebuilt").
+        required: true
+        type: string
+      gcp-service-account:
+        description: GCP service account for Workload Identity Federation.
+        required: true
+        type: string
+      gcp-workload-identity-provider:
+        description: GCP Workload Identity provider.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish Docker Image
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      IMAGE_NAME: ${{ inputs.image-name }}
+      IMAGE_SOURCE: https://github.com/${{ github.repository }}
+      IMAGE_DOCUMENTATION: https://gestaltd.ai
+      IMAGE_URL: ${{ inputs.image-url }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Download release artifacts
+        if: ${{ inputs.download-artifact-pattern != '' }}
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: ${{ inputs.download-artifact-pattern }}
+          path: dist
+          merge-multiple: true
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#${{ inputs.version-prefix }}}" >> "$GITHUB_OUTPUT"
+
+      - name: Compute image metadata
+        id: meta
+        run: echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
+      - name: Authenticate to Google Cloud
+        id: gcp-auth
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
+        with:
+          workload_identity_provider: ${{ inputs.gcp-workload-identity-provider }}
+          service_account: ${{ inputs.gcp-service-account }}
+          token_format: access_token
+
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          registry: ${{ inputs.registry-host }}
+          username: oauth2accesstoken
+          password: ${{ steps.gcp-auth.outputs.access_token }}
+
+      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
+
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - name: Build and push image
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        with:
+          context: ${{ inputs.build-context }}
+          file: ${{ inputs.dockerfile }}
+          target: ${{ inputs.target }}
+          push: true
+          platforms: ${{ inputs.platforms }}
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}${{ inputs.tag-suffix }}
+            ${{ env.IMAGE_NAME }}:latest${{ inputs.tag-suffix }}
+          build-args: |
+            GESTALT_VERSION=${{ steps.version.outputs.version }}
+            GESTALT_REVISION=${{ github.sha }}
+            GESTALT_CREATED=${{ steps.meta.outputs.created }}
+            GESTALT_SOURCE=${{ env.IMAGE_SOURCE }}
+            GESTALT_DOCUMENTATION=${{ env.IMAGE_DOCUMENTATION }}
+            GESTALT_URL=${{ env.IMAGE_URL }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=min
+          sbom: true
+          provenance: mode=max
+
+      - name: Scan image for vulnerabilities
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          image-ref: ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}${{ inputs.tag-suffix }}
+          format: table
+          exit-code: '1'
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true

--- a/.github/workflows/release-gestaltd.yml
+++ b/.github/workflows/release-gestaltd.yml
@@ -112,25 +112,26 @@ jobs:
       platforms: 'linux/amd64,linux/arm64'
       target: alpine-prebuilt
 
-  # `-alpine` alias of the same Alpine image, kept because valon-tools pins
-  # `image.tag=<version>-alpine`. Once that pin moves to the unsuffixed tag,
-  # this job can be removed.
+  # `-alpine` tag of the same Alpine image, published to GCP Artifact Registry
+  # (not Docker Hub) alongside the Helm chart. valon-tools pins
+  # `image.tag=<version>-alpine` and pulls this image via Workload Identity, so
+  # it is not part of the public Docker Hub distribution.
   publish-image-alpine:
-    name: Publish Docker Image (Alpine alias)
+    name: Publish Docker Image (Alpine, GCP AR)
     needs: build
-    uses: ./.github/workflows/publish-dockerhub-image.yml
-    secrets: inherit
+    uses: ./.github/workflows/publish-gcp-ar-image.yml
     with:
-      image-name: valontechnologies/gestaltd
-      image-url: https://hub.docker.com/r/valontechnologies/gestaltd
+      image-name: ${{ vars.GESTALTD_RELEASE_IMAGE_REPOSITORY }}
+      image-url: https://gestaltd.ai
+      registry-host: ${{ vars.GESTALTD_ARTIFACT_REGISTRY_HOST }}
       dockerfile: gestaltd/Dockerfile
       version-prefix: 'gestaltd/v'
-      short-description: Platform for self-hostable, configurable integrations and tooling
-      readme-filepath: docs/dockerhub/gestaltd.md
       download-artifact-pattern: 'gestaltd-*'
       platforms: 'linux/amd64,linux/arm64'
       tag-suffix: '-alpine'
       target: alpine-prebuilt
+      gcp-service-account: ${{ vars.GESTALTD_GCP_SERVICE_ACCOUNT }}
+      gcp-workload-identity-provider: ${{ vars.GESTALTD_GCP_WORKLOAD_IDENTITY_PROVIDER }}
 
   update-formula:
     name: Update Homebrew Formula, Chart & OCI Publish


### PR DESCRIPTION
## Description

Publishes the gestaltd Alpine release image to GCP Artifact Registry so internal consumers (valon-tools) pull it via Workload Identity instead of from public Docker Hub.

The image reuses the **existing `gestaltd-charts` Artifact Registry repository** under a distinct sub-path (`gestaltd-charts/gestaltd-image`), so it sits next to the chart with no new repo and no new IAM — the `gestaltd-chart-publisher` SA already has `artifactregistry.writer` on that repo, which covers all sub-paths.

### Changes
- Add `publish-gcp-ar-image.yml`: reusable workflow mirroring `publish-dockerhub-image.yml`, but authenticating to Artifact Registry via the existing gestaltd WIF identity (no Docker Hub secrets / README sync). Keeps SBOM, provenance, and the Trivy scan.
- Point `release-gestaltd.yml`'s `publish-image-alpine` job at it, reusing the existing `GESTALTD_ARTIFACT_REGISTRY_HOST` / `GESTALTD_GCP_SERVICE_ACCOUNT` / `GESTALTD_GCP_WORKLOAD_IDENTITY_PROVIDER` vars plus a new `GESTALTD_RELEASE_IMAGE_REPOSITORY`.

The public unsuffixed Docker Hub image (`publish-image`) is unchanged — external `docker pull` and install docs still work.

### Config
- `GESTALTD_RELEASE_IMAGE_REPOSITORY` repo variable set to `us-east1-docker.pkg.dev/gitlab-peach-street/gestaltd-charts/gestaltd-image`.
- No Terraform/IAM change required for publishing (writer already granted on `gestaltd-charts`).

Consumed by valon-tools#208 (pull side); runtime pull access for the valon-tools cluster is handled separately.