### PR TITLE
[gestaltd] grant the valon-tools GKE node SA read on the chart repo

### DIFF
--- a/gestaltd/terraform/variables.tf
+++ b/gestaltd/terraform/variables.tf
@@ -41,9 +41,8 @@ variable "gestaltd_chart_reader_service_accounts" {
     "github-deploy-stage@valon-tools-stage.iam.gserviceaccount.com",
     "terraform-dev@valon-tools-dev.iam.gserviceaccount.com",
     "terraform-stage@valon-tools-stage.iam.gserviceaccount.com",
-    # GKE node service accounts: gestaltd pods now pull the runtime image from
-    # this repo, so the nodes that run them need read access (cross-project).
     "tools-dev-nodes@valon-tools-dev.iam.gserviceaccount.com",
+    "tools-stage-nodes@valon-tools-stage.iam.gserviceaccount.com",
   ]
 }
 

--- a/gestaltd/terraform/variables.tf
+++ b/gestaltd/terraform/variables.tf
@@ -41,6 +41,9 @@ variable "gestaltd_chart_reader_service_accounts" {
     "github-deploy-stage@valon-tools-stage.iam.gserviceaccount.com",
     "terraform-dev@valon-tools-dev.iam.gserviceaccount.com",
     "terraform-stage@valon-tools-stage.iam.gserviceaccount.com",
+    # GKE node service accounts: gestaltd pods now pull the runtime image from
+    # this repo, so the nodes that run them need read access (cross-project).
+    "tools-dev-nodes@valon-tools-dev.iam.gserviceaccount.com",
   ]
 }
 


### PR DESCRIPTION
gestaltd pods now pull the runtime image from gestaltd-charts (the
gestaltd-image sub-path) in gitlab-peach-street, a different project than
the cluster. The node SA's default role only grants Artifact Registry read
within its own project, so add the dev cluster node SA to the chart-reader
set; otherwise pods ImagePullBackOff at startup.

Stage: its cluster is not in valon-tools-infra, so its node SA
(tools-stage-nodes@valon-tools-stage by convention) should be added once
confirmed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>