### PR TITLE
Retry workflow provider build so a slow backend connect is not fatal

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -2007,6 +2007,42 @@ func buildS3(name string, entry *config.ProviderEntry, factories *FactoryRegistr
 	return client, nil
 }
 
+const workflowProviderBuildAttempts = 6
+
+// workflowProviderBuildBackoff is the base delay between workflow provider build
+// retries (grows linearly per attempt). A var so tests can shrink it.
+var workflowProviderBuildBackoff = 5 * time.Second
+
+// buildWorkflowProviderWithRetry retries a workflow provider build whose initial
+// backend connect can transiently time out under concurrent startup load, and
+// returns the last error after exhausting attempts so a genuine failure is still
+// surfaced to bootstrap.
+func buildWorkflowProviderWithRetry(ctx context.Context, build func() (coreworkflow.Provider, error)) (coreworkflow.Provider, error) {
+	var lastErr error
+	for attempt := 1; attempt <= workflowProviderBuildAttempts; attempt++ {
+		provider, err := build()
+		if err == nil {
+			return provider, nil
+		}
+		lastErr = err
+		if attempt == workflowProviderBuildAttempts {
+			break
+		}
+		backoff := time.Duration(attempt) * workflowProviderBuildBackoff
+		slog.WarnContext(ctx, "workflow provider build failed; retrying",
+			"attempt", attempt,
+			"maxAttempts", workflowProviderBuildAttempts,
+			"backoff", backoff.String(),
+			"error", err)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(backoff):
+		}
+	}
+	return nil, lastErr
+}
+
 func buildWorkflow(ctx context.Context, name string, entry *config.ProviderEntry, factories *FactoryRegistry, deps Deps) (coreworkflow.Provider, error) {
 	ctx = invocation.WithCallerProvider(ctx, invocation.ProviderKindWorkflow, name)
 	if entry == nil {
@@ -2040,7 +2076,15 @@ func buildWorkflow(ctx context.Context, name string, entry *config.ProviderEntry
 	if factories.Workflow == nil {
 		return nil, fmt.Errorf("workflow factory is not registered")
 	}
-	provider, err := factories.Workflow(ctx, name, node, hostServices, deps)
+	// The workflow provider connects to its backend (e.g. Temporal) during this
+	// build. Under heavy concurrent provider startup (many source-run apps) that
+	// connect can transiently exceed its deadline; retry with backoff so a slow
+	// connect does not fail bootstrap and crash-loop the daemon when it would
+	// succeed once the startup storm subsides. NewExecutable closes its process on
+	// a failed configure, so each attempt is self-contained.
+	provider, err := buildWorkflowProviderWithRetry(ctx, func() (coreworkflow.Provider, error) {
+		return factories.Workflow(ctx, name, node, hostServices, deps)
+	})
 	if err != nil {
 		return nil, fmt.Errorf("workflow provider: %w", err)
 	}

--- a/gestaltd/internal/bootstrap/workflow_retry_test.go
+++ b/gestaltd/internal/bootstrap/workflow_retry_test.go
@@ -1,0 +1,72 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+)
+
+// stubRetryProvider satisfies coreworkflow.Provider for retry tests. Its methods
+// are never called; only its non-nil identity is asserted.
+type stubRetryProvider struct{ coreworkflow.Provider }
+
+func TestBuildWorkflowProviderWithRetry(t *testing.T) {
+	orig := workflowProviderBuildBackoff
+	workflowProviderBuildBackoff = time.Millisecond
+	t.Cleanup(func() { workflowProviderBuildBackoff = orig })
+
+	t.Run("recovers after transient failures", func(t *testing.T) {
+		stub := &stubRetryProvider{}
+		calls := 0
+		provider, err := buildWorkflowProviderWithRetry(context.Background(), func() (coreworkflow.Provider, error) {
+			calls++
+			if calls < 3 {
+				return nil, errors.New("connect temporal: context deadline exceeded")
+			}
+			return stub, nil
+		})
+		if err != nil {
+			t.Fatalf("err = %v, want nil", err)
+		}
+		if provider != coreworkflow.Provider(stub) {
+			t.Fatalf("provider = %v, want stub", provider)
+		}
+		if calls != 3 {
+			t.Fatalf("calls = %d, want 3", calls)
+		}
+	})
+
+	t.Run("surfaces last error after exhausting attempts", func(t *testing.T) {
+		sentinel := errors.New("permanent failure")
+		calls := 0
+		_, err := buildWorkflowProviderWithRetry(context.Background(), func() (coreworkflow.Provider, error) {
+			calls++
+			return nil, sentinel
+		})
+		if !errors.Is(err, sentinel) {
+			t.Fatalf("err = %v, want sentinel", err)
+		}
+		if calls != workflowProviderBuildAttempts {
+			t.Fatalf("calls = %d, want %d", calls, workflowProviderBuildAttempts)
+		}
+	})
+
+	t.Run("stops promptly on context cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		calls := 0
+		_, err := buildWorkflowProviderWithRetry(ctx, func() (coreworkflow.Provider, error) {
+			calls++
+			return nil, errors.New("transient")
+		})
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("err = %v, want context.Canceled", err)
+		}
+		if calls != 1 {
+			t.Fatalf("calls = %d, want 1", calls)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
A workflow provider connects to its backend (e.g. Temporal) during its initial build (`buildWorkflow` -> `factories.Workflow` -> `NewExecutable`, which configures/connects). That build failure is **fatal** to bootstrap. Under heavy concurrent provider startup the connect can transiently exceed its deadline and crash-loop the daemon, even though it would succeed moments later.

This was hit in valon-tools after adopting source-run apps: ~35 app providers now start from source (uv/bun) concurrently, and that heavier startup starves the workflow provider's Temporal connect (`context deadline exceeded while waiting for connections to become ready`) -> fatal -> cold-start crash loop. (Confirmed it is not CPU — Cloud Run `--cpu-boost` had no effect — and gestaltd's workflow/bootstrap code is unchanged across the pins; it's the startup contention exposing the connect deadline.)

## Change
Wrap the workflow provider build in a bounded linear-backoff retry (`buildWorkflowProviderWithRetry`), returning the last error only after attempts are exhausted so a genuine failure stays fatal. `NewExecutable` closes its process on a failed configure (client.go), so each attempt is self-contained and cannot leak.

## Tests
- New `TestBuildWorkflowProviderWithRetry`: recovers after transient failures; surfaces last error after exhaustion; stops promptly on context cancellation.
- `go test ./gestaltd/internal/bootstrap/` green; `go vet` clean.

Note: this is the gestalt-side fix for the valon-tools source-run rollout. Real validation is prod observation after re-pinning valon-tools to a gestaltd image containing this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)