### PR TITLE
[gestaltd] publish image and Helm chart under commit-SHA labels

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -77,8 +77,10 @@ jobs:
           gcp-service-account: ${{ vars.GESTALTD_CI_GCP_SERVICE_ACCOUNT }}
           gcp-workload-identity-provider: ${{ vars.GESTALTD_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}
 
-  # Publish the per-commit chart (0.0.0-g<sha12>) to the charts repo, the
-  # per-commit counterpart to release-gestaltd.yml's semver chart.
+  # Publish the per-commit chart (0.0.0-g<sha12>) to the immutable gestaltd-ci
+  # repo under the deploy/ path, the per-commit counterpart to
+  # release-gestaltd.yml's semver chart. Skipped if the immutable version is
+  # already published (re-runs / same-commit dispatch).
   publish-chart:
     name: Publish Helm Chart to GCP Artifact Registry
     needs: [resolve-ref, validate, build-and-push, publish-alpine-image]
@@ -97,25 +99,33 @@ jobs:
         id: gcp-auth
         uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
         with:
-          workload_identity_provider: ${{ vars.GESTALTD_GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.GESTALTD_GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ vars.GESTALTD_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GESTALTD_CI_GCP_SERVICE_ACCOUNT }}
           token_format: access_token
       - name: Package and push Helm chart by commit SHA
         env:
           SHA: ${{ needs.resolve-ref.outputs.sha }}
           ARTIFACT_REGISTRY_HOST: ${{ vars.GESTALTD_ARTIFACT_REGISTRY_HOST }}
-          CHART_REPOSITORY: ${{ vars.GESTALTD_CHART_REPOSITORY }}
+          CI_IMAGE_REPOSITORY: ${{ vars.GESTALTD_CI_IMAGE_REPOSITORY }}
         run: |
           sha_version="0.0.0-g${SHA:0:12}"
+          # gestaltd-ci is immutable; per-commit deployables live under deploy/ so
+          # they never collide with the static CI image at <repo>/gestaltd.
+          chart_repo="oci://${CI_IMAGE_REPOSITORY%/gestaltd}/deploy"
+          echo "${{ steps.gcp-auth.outputs.access_token }}" | helm registry login "${ARTIFACT_REGISTRY_HOST}" --username oauth2accesstoken --password-stdin
+          if helm show chart "${chart_repo}/gestaltd" --version "${sha_version}" >/dev/null 2>&1; then
+            echo "Chart ${sha_version} already published; skipping."
+            exit 0
+          fi
           helm package gestaltd/deploy/helm/gestaltd \
             --version "${sha_version}" \
             --app-version "${SHA}" \
             --destination /tmp/charts
-          echo "${{ steps.gcp-auth.outputs.access_token }}" | helm registry login "${ARTIFACT_REGISTRY_HOST}" --username oauth2accesstoken --password-stdin
-          helm push "/tmp/charts/gestaltd-${sha_version}.tgz" "${CHART_REPOSITORY}"
+          helm push "/tmp/charts/gestaltd-${sha_version}.tgz" "${chart_repo}"
 
-  # Publish the per-commit alpine image (sha-<commit>-alpine) to the release image
-  # repo, built multi-arch from the Dockerfile's `alpine` target.
+  # Publish the per-commit alpine image (sha-<commit>-alpine) to the immutable
+  # gestaltd-ci repo under the deploy/ path, built multi-arch from the
+  # Dockerfile's `alpine` target. Skipped if the immutable tag already exists.
   publish-alpine-image:
     name: Publish Alpine Image to GCP Artifact Registry
     needs: [resolve-ref, validate, build-and-push]
@@ -125,21 +135,29 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    env:
-      IMAGE_NAME: ${{ vars.GESTALTD_RELEASE_IMAGE_REPOSITORY }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ needs.resolve-ref.outputs.sha }}
-      - name: Compute image metadata
+      - name: Compute image reference
         id: meta
-        run: echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+        env:
+          SHA: ${{ needs.resolve-ref.outputs.sha }}
+          CI_IMAGE_REPOSITORY: ${{ vars.GESTALTD_CI_IMAGE_REPOSITORY }}
+        run: |
+          # gestaltd-ci is immutable; per-commit deployables live under deploy/ so
+          # they never collide with the static CI image at <repo>/gestaltd.
+          image="${CI_IMAGE_REPOSITORY%/gestaltd}/deploy/gestaltd-image:sha-${SHA}-alpine"
+          {
+            echo "image=${image}"
+            echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          } >> "$GITHUB_OUTPUT"
       - name: Authenticate to Google Cloud
         id: gcp-auth
         uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
         with:
-          workload_identity_provider: ${{ vars.GESTALTD_GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.GESTALTD_GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ vars.GESTALTD_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GESTALTD_CI_GCP_SERVICE_ACCOUNT }}
           token_format: access_token
       - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
@@ -148,7 +166,19 @@ jobs:
           password: ${{ steps.gcp-auth.outputs.access_token }}
       - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+      - name: Check for existing image
+        id: existing
+        env:
+          IMAGE: ${{ steps.meta.outputs.image }}
+        run: |
+          if docker buildx imagetools inspect "${IMAGE}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Image ${IMAGE} already published; skipping build."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Build and push alpine image by commit SHA
+        if: ${{ steps.existing.outputs.exists != 'true' }}
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         with:
           context: .
@@ -156,14 +186,14 @@ jobs:
           target: alpine
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ${{ env.IMAGE_NAME }}:sha-${{ needs.resolve-ref.outputs.sha }}-alpine
+          tags: ${{ steps.meta.outputs.image }}
           build-args: |
             GESTALT_VERSION=${{ needs.resolve-ref.outputs.version }}
             GESTALT_REVISION=${{ needs.resolve-ref.outputs.sha }}
             GESTALT_CREATED=${{ steps.meta.outputs.created }}
             GESTALT_SOURCE=https://github.com/${{ github.repository }}
             GESTALT_DOCUMENTATION=https://gestaltd.ai
-            GESTALT_URL=${{ env.IMAGE_NAME }}:sha-${{ needs.resolve-ref.outputs.sha }}-alpine
+            GESTALT_URL=${{ steps.meta.outputs.image }}
           cache-from: type=gha
           cache-to: type=gha,mode=min
           sbom: true

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -77,6 +77,49 @@ jobs:
           gcp-service-account: ${{ vars.GESTALTD_CI_GCP_SERVICE_ACCOUNT }}
           gcp-workload-identity-provider: ${{ vars.GESTALTD_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}
 
+  # Publish the per-commit Helm chart to the charts repository, versioned by
+  # commit SHA (0.0.0-g<sha12>), so valon-tools can deploy any main commit by SHA.
+  # release-gestaltd.yml publishes the chart under its semver version for formal
+  # releases; this is the per-commit counterpart. Helm requires SemVer chart
+  # versions and rewrites '+' to '_' in OCI tags, so the SHA is encoded as a
+  # prerelease identifier rather than build metadata; appVersion carries the full
+  # commit. Runs only after validation passes, so a chart is published only for a
+  # commit whose tests are green.
+  publish-chart:
+    name: Publish Helm Chart to GCP Artifact Registry
+    needs: [resolve-ref, validate]
+    if: ${{ needs.resolve-ref.result == 'success' && needs.validate.result == 'success' && needs.resolve-ref.outputs.should_validate == 'true' && needs.resolve-ref.outputs.publish == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ needs.resolve-ref.outputs.sha }}
+      - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
+      - name: Authenticate to Google Cloud
+        id: gcp-auth
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
+        with:
+          workload_identity_provider: ${{ vars.GESTALTD_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GESTALTD_GCP_SERVICE_ACCOUNT }}
+          token_format: access_token
+      - name: Package and push Helm chart by commit SHA
+        env:
+          SHA: ${{ needs.resolve-ref.outputs.sha }}
+          ARTIFACT_REGISTRY_HOST: ${{ vars.GESTALTD_ARTIFACT_REGISTRY_HOST }}
+          CHART_REPOSITORY: ${{ vars.GESTALTD_CHART_REPOSITORY }}
+        run: |
+          sha_version="0.0.0-g${SHA:0:12}"
+          helm package gestaltd/deploy/helm/gestaltd \
+            --version "${sha_version}" \
+            --app-version "${SHA}" \
+            --destination /tmp/charts
+          echo "${{ steps.gcp-auth.outputs.access_token }}" | helm registry login "${ARTIFACT_REGISTRY_HOST}" --username oauth2accesstoken --password-stdin
+          helm push "/tmp/charts/gestaltd-${sha_version}.tgz" "${CHART_REPOSITORY}"
+
   # Runs only after validation passes. By now build-image has already pushed the
   # immutable sha-<commit> image, so the build action's existing-image check
   # short-circuits: it skips the build + push and just smoke-tests the published

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -120,6 +120,67 @@ jobs:
           echo "${{ steps.gcp-auth.outputs.access_token }}" | helm registry login "${ARTIFACT_REGISTRY_HOST}" --username oauth2accesstoken --password-stdin
           helm push "/tmp/charts/gestaltd-${sha_version}.tgz" "${CHART_REPOSITORY}"
 
+  # Publish the per-commit alpine image to the release image repository, tagged by
+  # commit SHA (sha-<commit>-alpine), so valon-tools can deploy any main commit's
+  # image alongside its SHA-versioned chart. release-gestaltd.yml publishes the
+  # same alpine image under its semver tag for formal releases; this is the
+  # per-commit counterpart. Built multi-arch from source via the Dockerfile's
+  # `alpine` target (which cross-compiles internally, so no prebuilt binaries are
+  # needed) and pushed with the chart_publisher identity, which is the writer on
+  # the charts repository. Runs only after validation passes.
+  publish-alpine-image:
+    name: Publish Alpine Image to GCP Artifact Registry
+    needs: [resolve-ref, validate]
+    if: ${{ needs.resolve-ref.result == 'success' && needs.validate.result == 'success' && needs.resolve-ref.outputs.should_validate == 'true' && needs.resolve-ref.outputs.publish == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      IMAGE_NAME: ${{ vars.GESTALTD_RELEASE_IMAGE_REPOSITORY }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ needs.resolve-ref.outputs.sha }}
+      - name: Compute image metadata
+        id: meta
+        run: echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+      - name: Authenticate to Google Cloud
+        id: gcp-auth
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
+        with:
+          workload_identity_provider: ${{ vars.GESTALTD_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GESTALTD_GCP_SERVICE_ACCOUNT }}
+          token_format: access_token
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          registry: ${{ vars.GESTALTD_ARTIFACT_REGISTRY_HOST }}
+          username: oauth2accesstoken
+          password: ${{ steps.gcp-auth.outputs.access_token }}
+      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+      - name: Build and push alpine image by commit SHA
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        with:
+          context: .
+          file: gestaltd/Dockerfile
+          target: alpine
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ env.IMAGE_NAME }}:sha-${{ needs.resolve-ref.outputs.sha }}-alpine
+          build-args: |
+            GESTALT_VERSION=${{ needs.resolve-ref.outputs.version }}
+            GESTALT_REVISION=${{ needs.resolve-ref.outputs.sha }}
+            GESTALT_CREATED=${{ steps.meta.outputs.created }}
+            GESTALT_SOURCE=https://github.com/${{ github.repository }}
+            GESTALT_DOCUMENTATION=https://gestaltd.ai
+            GESTALT_URL=${{ env.IMAGE_NAME }}:sha-${{ needs.resolve-ref.outputs.sha }}-alpine
+          cache-from: type=gha
+          cache-to: type=gha,mode=min
+          sbom: true
+          provenance: mode=max
+
   # Runs only after validation passes. By now build-image has already pushed the
   # immutable sha-<commit> image, so the build action's existing-image check
   # short-circuits: it skips the build + push and just smoke-tests the published

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -77,10 +77,9 @@ jobs:
           gcp-service-account: ${{ vars.GESTALTD_CI_GCP_SERVICE_ACCOUNT }}
           gcp-workload-identity-provider: ${{ vars.GESTALTD_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}
 
-  # Publish the per-commit chart (0.0.0-g<sha12>) to the immutable gestaltd-ci
-  # repo under the deploy/ path, the per-commit counterpart to
-  # release-gestaltd.yml's semver chart. Skipped if the immutable version is
-  # already published (re-runs / same-commit dispatch).
+  # Publish the per-commit chart (0.0.0-g<sha12>) to the immutable charts repo,
+  # the per-commit counterpart to release-gestaltd.yml's semver chart. Skipped if
+  # the immutable version is already published (re-runs / same-commit dispatch).
   publish-chart:
     name: Publish Helm Chart to GCP Artifact Registry
     needs: [resolve-ref, validate, build-and-push, publish-alpine-image]
@@ -106,14 +105,11 @@ jobs:
         env:
           SHA: ${{ needs.resolve-ref.outputs.sha }}
           ARTIFACT_REGISTRY_HOST: ${{ vars.GESTALTD_ARTIFACT_REGISTRY_HOST }}
-          CI_IMAGE_REPOSITORY: ${{ vars.GESTALTD_CI_IMAGE_REPOSITORY }}
+          CHART_REPOSITORY: ${{ vars.GESTALTD_CHART_REPOSITORY }}
         run: |
           sha_version="0.0.0-g${SHA:0:12}"
-          # gestaltd-ci is immutable; per-commit deployables live under deploy/ so
-          # they never collide with the static CI image at <repo>/gestaltd.
-          chart_repo="oci://${CI_IMAGE_REPOSITORY%/gestaltd}/deploy"
           echo "${{ steps.gcp-auth.outputs.access_token }}" | helm registry login "${ARTIFACT_REGISTRY_HOST}" --username oauth2accesstoken --password-stdin
-          if helm show chart "${chart_repo}/gestaltd" --version "${sha_version}" >/dev/null 2>&1; then
+          if helm show chart "${CHART_REPOSITORY}/gestaltd" --version "${sha_version}" >/dev/null 2>&1; then
             echo "Chart ${sha_version} already published; skipping."
             exit 0
           fi
@@ -121,11 +117,11 @@ jobs:
             --version "${sha_version}" \
             --app-version "${SHA}" \
             --destination /tmp/charts
-          helm push "/tmp/charts/gestaltd-${sha_version}.tgz" "${chart_repo}"
+          helm push "/tmp/charts/gestaltd-${sha_version}.tgz" "${CHART_REPOSITORY}"
 
   # Publish the per-commit alpine image (sha-<commit>-alpine) to the immutable
-  # gestaltd-ci repo under the deploy/ path, built multi-arch from the
-  # Dockerfile's `alpine` target. Skipped if the immutable tag already exists.
+  # release image repo, built multi-arch from the Dockerfile's `alpine` target.
+  # Skipped if the immutable tag already exists.
   publish-alpine-image:
     name: Publish Alpine Image to GCP Artifact Registry
     needs: [resolve-ref, validate, build-and-push]
@@ -143,13 +139,10 @@ jobs:
         id: meta
         env:
           SHA: ${{ needs.resolve-ref.outputs.sha }}
-          CI_IMAGE_REPOSITORY: ${{ vars.GESTALTD_CI_IMAGE_REPOSITORY }}
+          IMAGE_NAME: ${{ vars.GESTALTD_RELEASE_IMAGE_REPOSITORY }}
         run: |
-          # gestaltd-ci is immutable; per-commit deployables live under deploy/ so
-          # they never collide with the static CI image at <repo>/gestaltd.
-          image="${CI_IMAGE_REPOSITORY%/gestaltd}/deploy/gestaltd-image:sha-${SHA}-alpine"
           {
-            echo "image=${image}"
+            echo "image=${IMAGE_NAME}:sha-${SHA}-alpine"
             echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           } >> "$GITHUB_OUTPUT"
       - name: Authenticate to Google Cloud

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -77,14 +77,8 @@ jobs:
           gcp-service-account: ${{ vars.GESTALTD_CI_GCP_SERVICE_ACCOUNT }}
           gcp-workload-identity-provider: ${{ vars.GESTALTD_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}
 
-  # Publish the per-commit Helm chart to the charts repository, versioned by
-  # commit SHA (0.0.0-g<sha12>), so valon-tools can deploy any main commit by SHA.
-  # release-gestaltd.yml publishes the chart under its semver version for formal
-  # releases; this is the per-commit counterpart. Helm requires SemVer chart
-  # versions and rewrites '+' to '_' in OCI tags, so the SHA is encoded as a
-  # prerelease identifier rather than build metadata; appVersion carries the full
-  # commit. Runs only after validation passes, so a chart is published only for a
-  # commit whose tests are green.
+  # Publish the per-commit chart (0.0.0-g<sha12>) to the charts repo, the
+  # per-commit counterpart to release-gestaltd.yml's semver chart.
   publish-chart:
     name: Publish Helm Chart to GCP Artifact Registry
     needs: [resolve-ref, validate]
@@ -120,14 +114,8 @@ jobs:
           echo "${{ steps.gcp-auth.outputs.access_token }}" | helm registry login "${ARTIFACT_REGISTRY_HOST}" --username oauth2accesstoken --password-stdin
           helm push "/tmp/charts/gestaltd-${sha_version}.tgz" "${CHART_REPOSITORY}"
 
-  # Publish the per-commit alpine image to the release image repository, tagged by
-  # commit SHA (sha-<commit>-alpine), so valon-tools can deploy any main commit's
-  # image alongside its SHA-versioned chart. release-gestaltd.yml publishes the
-  # same alpine image under its semver tag for formal releases; this is the
-  # per-commit counterpart. Built multi-arch from source via the Dockerfile's
-  # `alpine` target (which cross-compiles internally, so no prebuilt binaries are
-  # needed) and pushed with the chart_publisher identity, which is the writer on
-  # the charts repository. Runs only after validation passes.
+  # Publish the per-commit alpine image (sha-<commit>-alpine) to the release image
+  # repo, built multi-arch from the Dockerfile's `alpine` target.
   publish-alpine-image:
     name: Publish Alpine Image to GCP Artifact Registry
     needs: [resolve-ref, validate]

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -81,8 +81,8 @@ jobs:
   # per-commit counterpart to release-gestaltd.yml's semver chart.
   publish-chart:
     name: Publish Helm Chart to GCP Artifact Registry
-    needs: [resolve-ref, validate]
-    if: ${{ needs.resolve-ref.result == 'success' && needs.validate.result == 'success' && needs.resolve-ref.outputs.should_validate == 'true' && needs.resolve-ref.outputs.publish == 'true' }}
+    needs: [resolve-ref, validate, build-and-push, publish-alpine-image]
+    if: ${{ needs.resolve-ref.result == 'success' && needs.validate.result == 'success' && needs.build-and-push.result == 'success' && needs.publish-alpine-image.result == 'success' && needs.resolve-ref.outputs.should_validate == 'true' && needs.resolve-ref.outputs.publish == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -118,8 +118,8 @@ jobs:
   # repo, built multi-arch from the Dockerfile's `alpine` target.
   publish-alpine-image:
     name: Publish Alpine Image to GCP Artifact Registry
-    needs: [resolve-ref, validate]
-    if: ${{ needs.resolve-ref.result == 'success' && needs.validate.result == 'success' && needs.resolve-ref.outputs.should_validate == 'true' && needs.resolve-ref.outputs.publish == 'true' }}
+    needs: [resolve-ref, validate, build-and-push]
+    if: ${{ needs.resolve-ref.result == 'success' && needs.validate.result == 'success' && needs.build-and-push.result == 'success' && needs.resolve-ref.outputs.should_validate == 'true' && needs.resolve-ref.outputs.publish == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:

--- a/.github/workflows/publish-gcp-ar-image.yml
+++ b/.github/workflows/publish-gcp-ar-image.yml
@@ -1,10 +1,11 @@
 name: Publish GCP Artifact Registry Image
 
 # Builds a gestaltd release image and pushes it to Google Artifact Registry under
-# both a semver tag and an immutable sha-<commit> tag (plus `latest`): the image
-# is addressed alongside the Helm chart in Artifact Registry and pulled by
-# valon-tools via Workload Identity, which pins the sha-<commit> tag. gestaltd is
-# no longer published to Docker Hub.
+# its semver tag (plus `latest`): the image is addressed alongside the Helm chart
+# in Artifact Registry. Per-commit sha-<commit> images are published separately by
+# cd.yml, which owns that tag; this workflow owns only the semver and latest tags,
+# so the two never overwrite each other. gestaltd is no longer published to Docker
+# Hub.
 
 on:
   workflow_call:
@@ -122,7 +123,6 @@ jobs:
           platforms: ${{ inputs.platforms }}
           tags: |
             ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}${{ inputs.tag-suffix }}
-            ${{ env.IMAGE_NAME }}:sha-${{ github.sha }}${{ inputs.tag-suffix }}
             ${{ env.IMAGE_NAME }}:latest${{ inputs.tag-suffix }}
           build-args: |
             GESTALT_VERSION=${{ steps.version.outputs.version }}

--- a/.github/workflows/publish-gcp-ar-image.yml
+++ b/.github/workflows/publish-gcp-ar-image.yml
@@ -1,11 +1,10 @@
 name: Publish GCP Artifact Registry Image
 
 # Builds a gestaltd release image and pushes it to Google Artifact Registry under
-# its semver tag (plus `latest`): the image is addressed alongside the Helm chart
-# in Artifact Registry. Per-commit sha-<commit> images are published separately by
-# cd.yml, which owns that tag; this workflow owns only the semver and latest tags,
-# so the two never overwrite each other. gestaltd is no longer published to Docker
-# Hub.
+# its semver tag: the image is addressed alongside the Helm chart in the immutable
+# charts repo. Per-commit sha-<commit> images are published separately by cd.yml;
+# every tag is unique, so nothing is ever overwritten, and the build is skipped if
+# the tag already exists. gestaltd is no longer published to Docker Hub.
 
 on:
   workflow_call:
@@ -113,7 +112,20 @@ jobs:
 
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
+      - name: Check for existing image
+        id: existing
+        env:
+          IMAGE: ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}${{ inputs.tag-suffix }}
+        run: |
+          if docker buildx imagetools inspect "${IMAGE}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Image ${IMAGE} already published; skipping build."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build and push image
+        if: ${{ steps.existing.outputs.exists != 'true' }}
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         with:
           context: ${{ inputs.build-context }}
@@ -121,9 +133,7 @@ jobs:
           target: ${{ inputs.target }}
           push: true
           platforms: ${{ inputs.platforms }}
-          tags: |
-            ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}${{ inputs.tag-suffix }}
-            ${{ env.IMAGE_NAME }}:latest${{ inputs.tag-suffix }}
+          tags: ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}${{ inputs.tag-suffix }}
           build-args: |
             GESTALT_VERSION=${{ steps.version.outputs.version }}
             GESTALT_REVISION=${{ github.sha }}

--- a/.github/workflows/publish-gcp-ar-image.yml
+++ b/.github/workflows/publish-gcp-ar-image.yml
@@ -1,9 +1,10 @@
 name: Publish GCP Artifact Registry Image
 
-# Builds a gestaltd release image and pushes it to Google Artifact Registry by
-# semver tag: the image is addressed alongside the Helm chart in Artifact Registry
-# and pulled by valon-tools via Workload Identity. gestaltd is no longer published
-# to Docker Hub.
+# Builds a gestaltd release image and pushes it to Google Artifact Registry under
+# both a semver tag and an immutable sha-<commit> tag (plus `latest`): the image
+# is addressed alongside the Helm chart in Artifact Registry and pulled by
+# valon-tools via Workload Identity, which pins the sha-<commit> tag. gestaltd is
+# no longer published to Docker Hub.
 
 on:
   workflow_call:
@@ -121,6 +122,7 @@ jobs:
           platforms: ${{ inputs.platforms }}
           tags: |
             ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}${{ inputs.tag-suffix }}
+            ${{ env.IMAGE_NAME }}:sha-${{ github.sha }}${{ inputs.tag-suffix }}
             ${{ env.IMAGE_NAME }}:latest${{ inputs.tag-suffix }}
           build-args: |
             GESTALT_VERSION=${{ steps.version.outputs.version }}

--- a/.github/workflows/release-gestaltd.yml
+++ b/.github/workflows/release-gestaltd.yml
@@ -216,16 +216,6 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           helm package gestaltd/deploy/helm/gestaltd --destination /tmp/charts
-          # Also package a chart labeled by commit SHA so valon-tools can pin a
-          # single commit for both the image and the chart. Helm requires SemVer
-          # chart versions and rewrites '+' to '_' in OCI tags, so the SHA is
-          # encoded as a prerelease identifier (0.0.0-g<sha12>) rather than build
-          # metadata. appVersion carries the full commit for traceability.
-          sha_version="0.0.0-g${GITHUB_SHA:0:12}"
-          helm package gestaltd/deploy/helm/gestaltd \
-            --version "${sha_version}" \
-            --app-version "${GITHUB_SHA}" \
-            --destination /tmp/charts
       - name: Authenticate to Google Cloud
         id: gcp-auth
         uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
@@ -241,8 +231,6 @@ jobs:
         run: |
           echo "${{ steps.gcp-auth.outputs.access_token }}" | helm registry login "${ARTIFACT_REGISTRY_HOST}" --username oauth2accesstoken --password-stdin
           helm push "/tmp/charts/gestaltd-${VERSION}.tgz" "${CHART_REPOSITORY}"
-          sha_version="0.0.0-g${GITHUB_SHA:0:12}"
-          helm push "/tmp/charts/gestaltd-${sha_version}.tgz" "${CHART_REPOSITORY}"
       - name: Commit and push repository updates
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/release-gestaltd.yml
+++ b/.github/workflows/release-gestaltd.yml
@@ -230,6 +230,11 @@ jobs:
           CHART_REPOSITORY: ${{ vars.GESTALTD_CHART_REPOSITORY }}
         run: |
           echo "${{ steps.gcp-auth.outputs.access_token }}" | helm registry login "${ARTIFACT_REGISTRY_HOST}" --username oauth2accesstoken --password-stdin
+          # The charts repo is immutable; skip the push if this version already exists (re-runs).
+          if helm show chart "${CHART_REPOSITORY}/gestaltd" --version "${VERSION}" >/dev/null 2>&1; then
+            echo "Chart ${VERSION} already published; skipping."
+            exit 0
+          fi
           helm push "/tmp/charts/gestaltd-${VERSION}.tgz" "${CHART_REPOSITORY}"
       - name: Commit and push repository updates
         run: |

--- a/.github/workflows/release-gestaltd.yml
+++ b/.github/workflows/release-gestaltd.yml
@@ -216,6 +216,16 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           helm package gestaltd/deploy/helm/gestaltd --destination /tmp/charts
+          # Also package a chart labeled by commit SHA so valon-tools can pin a
+          # single commit for both the image and the chart. Helm requires SemVer
+          # chart versions and rewrites '+' to '_' in OCI tags, so the SHA is
+          # encoded as a prerelease identifier (0.0.0-g<sha12>) rather than build
+          # metadata. appVersion carries the full commit for traceability.
+          sha_version="0.0.0-g${GITHUB_SHA:0:12}"
+          helm package gestaltd/deploy/helm/gestaltd \
+            --version "${sha_version}" \
+            --app-version "${GITHUB_SHA}" \
+            --destination /tmp/charts
       - name: Authenticate to Google Cloud
         id: gcp-auth
         uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
@@ -231,6 +241,8 @@ jobs:
         run: |
           echo "${{ steps.gcp-auth.outputs.access_token }}" | helm registry login "${ARTIFACT_REGISTRY_HOST}" --username oauth2accesstoken --password-stdin
           helm push "/tmp/charts/gestaltd-${VERSION}.tgz" "${CHART_REPOSITORY}"
+          sha_version="0.0.0-g${GITHUB_SHA:0:12}"
+          helm push "/tmp/charts/gestaltd-${sha_version}.tgz" "${CHART_REPOSITORY}"
       - name: Commit and push repository updates
         run: |
           git config user.name "github-actions[bot]"

--- a/gestaltd/terraform/main.tf
+++ b/gestaltd/terraform/main.tf
@@ -52,11 +52,15 @@ locals {
     var.labels,
   )
 
-  artifact_registry_host              = "${var.region}-docker.pkg.dev"
-  chart_repository                    = "oci://${local.artifact_registry_host}/${var.project_id}/${var.artifact_registry_repository_id}"
-  ci_image_repository                 = "${local.artifact_registry_host}/${var.project_id}/${google_artifact_registry_repository.gestaltd_ci_images.repository_id}/gestaltd"
-  deployer_member                     = "serviceAccount:${var.deployer_service_account_id}@${var.project_id}.iam.gserviceaccount.com"
-  chart_ref_condition                 = "assertion.ref.startsWith(\"${var.github_ref_prefix}\")"
+  artifact_registry_host = "${var.region}-docker.pkg.dev"
+  chart_repository       = "oci://${local.artifact_registry_host}/${var.project_id}/${var.artifact_registry_repository_id}"
+  ci_image_repository    = "${local.artifact_registry_host}/${var.project_id}/${google_artifact_registry_repository.gestaltd_ci_images.repository_id}/gestaltd"
+  deployer_member        = "serviceAccount:${var.deployer_service_account_id}@${var.project_id}.iam.gserviceaccount.com"
+  # The chart publisher identity is assumed both by release-gestaltd.yml (on
+  # gestaltd/v* tags) and by cd.yml (on main pushes). cd.yml publishes the
+  # per-commit SHA-versioned chart and alpine image to the charts repository, so
+  # the chart provider must trust main in addition to release tags.
+  chart_ref_condition                 = "(assertion.ref.startsWith(\"${var.github_ref_prefix}\") || assertion.ref == \"${var.ci_image_github_ref}\")"
   ci_image_ref_condition              = "assertion.ref == \"${var.ci_image_github_ref}\""
   workload_identity_provider          = "projects/${data.google_project.current.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.github_actions.workload_identity_pool_id}/providers/${google_iam_workload_identity_pool_provider.gestaltd_github_actions.workload_identity_pool_provider_id}"
   ci_image_workload_identity_provider = "projects/${data.google_project.current.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.github_actions.workload_identity_pool_id}/providers/${google_iam_workload_identity_pool_provider.gestaltd_ci_image_github_actions.workload_identity_pool_provider_id}"
@@ -179,7 +183,7 @@ resource "google_iam_workload_identity_pool_provider" "gestaltd_github_actions" 
   workload_identity_pool_id          = google_iam_workload_identity_pool.github_actions.workload_identity_pool_id
   workload_identity_pool_provider_id = var.gestaltd_github_actions_provider_id
   display_name                       = "gestaltd"
-  description                        = "OIDC provider for ${var.github_repository} gestaltd release workflows."
+  description                        = "OIDC provider for ${var.github_repository} gestaltd release (tags) and CD (main) chart/image publish workflows."
 
   attribute_mapping = {
     "google.subject"             = "assertion.sub"

--- a/gestaltd/terraform/main.tf
+++ b/gestaltd/terraform/main.tf
@@ -99,8 +99,15 @@ resource "google_artifact_registry_repository" "gestaltd_charts" {
   location      = var.region
   repository_id = var.artifact_registry_repository_id
   format        = "DOCKER"
-  description   = "OCI Helm charts for gestaltd"
+  description   = "OCI Helm charts and images for gestaltd (semver releases and per-commit builds)"
   labels        = local.labels
+
+  # Both release (semver) and per-commit (sha-<commit> / 0.0.0-g<sha>) artifacts
+  # are addressed by unique tags, so the repo is immutable: a published tag can
+  # never be reassigned to a different digest.
+  docker_config {
+    immutable_tags = true
+  }
 
   depends_on = [
     google_project_service.required,
@@ -238,6 +245,16 @@ resource "google_artifact_registry_repository_iam_member" "chart_publisher" {
   repository = google_artifact_registry_repository.gestaltd_charts.repository_id
   role       = "roles/artifactregistry.writer"
   member     = "serviceAccount:${google_service_account.chart_publisher.email}"
+}
+
+# cd.yml (on main) publishes per-commit charts and images to the charts repo via
+# the CI identity, which is the only identity trusted on refs/heads/main.
+resource "google_artifact_registry_repository_iam_member" "ci_image_chart_publisher" {
+  project    = var.project_id
+  location   = google_artifact_registry_repository.gestaltd_charts.location
+  repository = google_artifact_registry_repository.gestaltd_charts.repository_id
+  role       = "roles/artifactregistry.writer"
+  member     = "serviceAccount:${google_service_account.ci_image_publisher.email}"
 }
 
 resource "google_artifact_registry_repository_iam_member" "chart_readers" {

--- a/gestaltd/terraform/main.tf
+++ b/gestaltd/terraform/main.tf
@@ -52,14 +52,10 @@ locals {
     var.labels,
   )
 
-  artifact_registry_host = "${var.region}-docker.pkg.dev"
-  chart_repository       = "oci://${local.artifact_registry_host}/${var.project_id}/${var.artifact_registry_repository_id}"
-  ci_image_repository    = "${local.artifact_registry_host}/${var.project_id}/${google_artifact_registry_repository.gestaltd_ci_images.repository_id}/gestaltd"
-  deployer_member        = "serviceAccount:${var.deployer_service_account_id}@${var.project_id}.iam.gserviceaccount.com"
-  # The chart publisher identity is assumed both by release-gestaltd.yml (on
-  # gestaltd/v* tags) and by cd.yml (on main pushes). cd.yml publishes the
-  # per-commit SHA-versioned chart and alpine image to the charts repository, so
-  # the chart provider must trust main in addition to release tags.
+  artifact_registry_host              = "${var.region}-docker.pkg.dev"
+  chart_repository                    = "oci://${local.artifact_registry_host}/${var.project_id}/${var.artifact_registry_repository_id}"
+  ci_image_repository                 = "${local.artifact_registry_host}/${var.project_id}/${google_artifact_registry_repository.gestaltd_ci_images.repository_id}/gestaltd"
+  deployer_member                     = "serviceAccount:${var.deployer_service_account_id}@${var.project_id}.iam.gserviceaccount.com"
   chart_ref_condition                 = "(assertion.ref.startsWith(\"${var.github_ref_prefix}\") || assertion.ref == \"${var.ci_image_github_ref}\")"
   ci_image_ref_condition              = "assertion.ref == \"${var.ci_image_github_ref}\""
   workload_identity_provider          = "projects/${data.google_project.current.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.github_actions.workload_identity_pool_id}/providers/${google_iam_workload_identity_pool_provider.gestaltd_github_actions.workload_identity_pool_provider_id}"

--- a/gestaltd/terraform/main.tf
+++ b/gestaltd/terraform/main.tf
@@ -56,7 +56,7 @@ locals {
   chart_repository                    = "oci://${local.artifact_registry_host}/${var.project_id}/${var.artifact_registry_repository_id}"
   ci_image_repository                 = "${local.artifact_registry_host}/${var.project_id}/${google_artifact_registry_repository.gestaltd_ci_images.repository_id}/gestaltd"
   deployer_member                     = "serviceAccount:${var.deployer_service_account_id}@${var.project_id}.iam.gserviceaccount.com"
-  chart_ref_condition                 = "(assertion.ref.startsWith(\"${var.github_ref_prefix}\") || assertion.ref == \"${var.ci_image_github_ref}\")"
+  chart_ref_condition                 = "assertion.ref.startsWith(\"${var.github_ref_prefix}\")"
   ci_image_ref_condition              = "assertion.ref == \"${var.ci_image_github_ref}\""
   workload_identity_provider          = "projects/${data.google_project.current.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.github_actions.workload_identity_pool_id}/providers/${google_iam_workload_identity_pool_provider.gestaltd_github_actions.workload_identity_pool_provider_id}"
   ci_image_workload_identity_provider = "projects/${data.google_project.current.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.github_actions.workload_identity_pool_id}/providers/${google_iam_workload_identity_pool_provider.gestaltd_ci_image_github_actions.workload_identity_pool_provider_id}"
@@ -179,7 +179,7 @@ resource "google_iam_workload_identity_pool_provider" "gestaltd_github_actions" 
   workload_identity_pool_id          = google_iam_workload_identity_pool.github_actions.workload_identity_pool_id
   workload_identity_pool_provider_id = var.gestaltd_github_actions_provider_id
   display_name                       = "gestaltd"
-  description                        = "OIDC provider for ${var.github_repository} gestaltd release (tags) and CD (main) chart/image publish workflows."
+  description                        = "OIDC provider for ${var.github_repository} gestaltd release workflows."
 
   attribute_mapping = {
     "google.subject"             = "assertion.sub"


### PR DESCRIPTION
## Description

Additionally publish the gestaltd release image under a `sha-<commit>-alpine` tag and the Helm chart under a `0.0.0-g<sha12>` SemVer version (alongside the existing semver labels), so valon-tools can pin both the image and the chart to a single commit SHA. The chart SHA is encoded as a SemVer prerelease (not build metadata) to remain a valid OCI tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)