### PR TITLE
[gestaltd] run publish jobs in parallel in CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -80,10 +80,15 @@ jobs:
   # Publish the per-commit chart (0.0.0-g<sha12>) to the immutable charts repo,
   # the per-commit counterpart to release-gestaltd.yml's semver chart. Skipped if
   # the immutable version is already published (re-runs / same-commit dispatch).
+  #
+  # Gated only on validation, not on the image-publish jobs: the chart packages
+  # YAML and consumes no output from build-and-push / publish-alpine-image, so it
+  # runs in parallel with them. Trade-off: a failed image build no longer blocks
+  # the chart, so a commit's chart can land without its companion images.
   publish-chart:
     name: Publish Helm Chart to GCP Artifact Registry
-    needs: [resolve-ref, validate, build-and-push, publish-alpine-image]
-    if: ${{ needs.resolve-ref.result == 'success' && needs.validate.result == 'success' && needs.build-and-push.result == 'success' && needs.publish-alpine-image.result == 'success' && needs.resolve-ref.outputs.should_validate == 'true' && needs.resolve-ref.outputs.publish == 'true' }}
+    needs: [resolve-ref, validate]
+    if: ${{ needs.resolve-ref.result == 'success' && needs.validate.result == 'success' && needs.resolve-ref.outputs.should_validate == 'true' && needs.resolve-ref.outputs.publish == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -122,10 +127,14 @@ jobs:
   # Publish the per-commit alpine image (sha-<commit>-alpine) to the immutable
   # release image repo, built multi-arch from the Dockerfile's `alpine` target.
   # Skipped if the immutable tag already exists.
+  #
+  # Builds an independent image (different repo + target than build-and-push) and
+  # consumes none of its output, so it is gated only on validation and runs in
+  # parallel with build-and-push and publish-chart.
   publish-alpine-image:
     name: Publish Alpine Image to GCP Artifact Registry
-    needs: [resolve-ref, validate, build-and-push]
-    if: ${{ needs.resolve-ref.result == 'success' && needs.validate.result == 'success' && needs.build-and-push.result == 'success' && needs.resolve-ref.outputs.should_validate == 'true' && needs.resolve-ref.outputs.publish == 'true' }}
+    needs: [resolve-ref, validate]
+    if: ${{ needs.resolve-ref.result == 'success' && needs.validate.result == 'success' && needs.resolve-ref.outputs.should_validate == 'true' && needs.resolve-ref.outputs.publish == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:


### PR DESCRIPTION
## Description

Fan out `build-and-push` (Publish Docker Image), `publish-alpine-image`, and `publish-chart` from `validate` instead of chaining them. The alpine image and Helm chart consume no output from the docker image publish, so gating them on it only added wall-clock latency. `publish-chart` no longer waits on the image jobs — the trade-off is a chart can publish without its companion images on a failed build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)