### PR TITLE
[gestaltd] rename alpine publish job to "Alpine Docker Image"

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -165,7 +165,7 @@ jobs:
   # failed build-alpine-image still lets this run — it just falls back to a full
   # multi-arch build + push. Runs in parallel with build-and-push and publish-chart.
   publish-alpine-image:
-    name: Publish Alpine Image to GCP AR
+    name: Publish Alpine Docker Image to GCP AR
     needs: [resolve-ref, validate, build-alpine-image]
     if: ${{ !cancelled() && needs.resolve-ref.result == 'success' && needs.validate.result == 'success' && needs.resolve-ref.outputs.should_validate == 'true' && needs.resolve-ref.outputs.publish == 'true' }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Rename the CD job display name `Publish Alpine Image to GCP AR` → `Publish Alpine Docker Image to GCP AR`. Display-name only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)