### PR TITLE
[gestaltd] rename Terraform Apply workflow

### DIFF
--- a/.github/workflows/deploy-gestaltd-artifacts.yml
+++ b/.github/workflows/deploy-gestaltd-artifacts.yml
@@ -1,4 +1,4 @@
-name: Deploy gestaltd Artifacts
+name: Terraform Apply (gestaltd)
 
 on:
   push:


### PR DESCRIPTION
## Description

Renames the `Deploy gestaltd Artifacts` workflow to `Terraform Apply (gestaltd)` to better reflect that it runs `terraform apply` to provision the GCP artifact-publishing infrastructure. Only the display name changes; triggers, filename, and job logic are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)