### PR TITLE
[gestaltd] publish per-commit binaries to GCS by SHA

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,8 +1,10 @@
 name: CD (gestaltd)
 
 # Continuous delivery for gestaltd. Re-runs the validation suite (including the
-# race matrix) and builds + pushes the per-commit CI image to Artifact Registry.
-# Every CD run publishes: it is triggered by pushes to main and by manual
+# race matrix) and publishes per-commit artifacts addressed by commit SHA: the
+# CI image and alpine image to Artifact Registry, the Helm chart to the OCI chart
+# repo, and cross-compiled binaries (linux + macOS) to the public CI binary
+# bucket. Every CD run publishes: it is triggered by pushes to main and by manual
 # dispatch for a specific commit SHA. The hourly health check (and the docs
 # build smoke check) runs in ci.yml instead.
 
@@ -153,6 +155,85 @@ jobs:
             --app-version "${SHA}" \
             --destination /tmp/charts
           helm push "/tmp/charts/gestaltd-${sha_version}.tgz" "${CHART_REPOSITORY}"
+
+  # Publish per-commit gestaltd binaries (linux + macOS, amd64 + arm64) to the
+  # public CI binary bucket, addressed by commit SHA. This is the per-commit
+  # counterpart to release-gestaltd.yml's semver GitHub Release tarballs, and the
+  # only SHA-addressed artifact that ships a native macOS binary — the CI and
+  # alpine images are linux-only. Toolshed's app-packaging workflow pulls these
+  # by SHA to build provider artifacts on macOS runners without waiting for a
+  # semver release cut.
+  #
+  # Gated on validation like publish-chart: these binaries feed production app
+  # packaging, so they publish only after the tests clear. Cross-compilation is
+  # cheap, so all four targets build in one job (no per-platform runner matrix).
+  # The bucket is public-read and writable by the CI image publisher SA, so it
+  # reuses that identity. Each object is skipped if already present (re-runs /
+  # same-commit dispatch); the bucket keeps immutable, versioned history.
+  publish-binaries:
+    name: Publish gestaltd Binaries to GCS
+    needs: [resolve-ref, validate]
+    if: ${{ needs.resolve-ref.result == 'success' && needs.validate.result == 'success' && needs.resolve-ref.outputs.should_validate == 'true' && needs.resolve-ref.outputs.publish == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ needs.resolve-ref.outputs.sha }}
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: gestaltd/go.mod
+          cache-dependency-path: gestaltd/go.sum
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
+        with:
+          workload_identity_provider: ${{ vars.GESTALTD_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GESTALTD_CI_GCP_SERVICE_ACCOUNT }}
+      - uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2
+      - name: Build, package, and upload binaries by commit SHA
+        env:
+          SHA: ${{ needs.resolve-ref.outputs.sha }}
+          VERSION: ${{ needs.resolve-ref.outputs.version }}
+          BUCKET: ${{ vars.GESTALTD_CI_BINARY_BUCKET }}
+        run: |
+          set -euo pipefail
+          : "${BUCKET:?GESTALTD_CI_BINARY_BUCKET repository variable is required}"
+
+          dest="gs://${BUCKET}/gestaltd/sha-${SHA}"
+          # goos/goarch/asset-suffix triples; suffixes match release-gestaltd.yml.
+          platforms=(
+            "darwin/arm64/macos-arm64"
+            "darwin/amd64/macos-x86_64"
+            "linux/amd64/linux-x86_64"
+            "linux/arm64/linux-arm64"
+          )
+
+          mkdir -p build dist
+          for entry in "${platforms[@]}"; do
+            IFS=/ read -r goos goarch suffix <<<"${entry}"
+            asset="gestaltd-${suffix}.tar.gz"
+
+            if gcloud storage ls "${dest}/${asset}" >/dev/null 2>&1; then
+              echo "${asset} already published for ${SHA}; skipping."
+              continue
+            fi
+
+            (
+              cd gestaltd
+              CGO_ENABLED=0 GOOS="${goos}" GOARCH="${goarch}" go build \
+                -ldflags "-X main.version=${VERSION}" \
+                -o "${GITHUB_WORKSPACE}/build/gestaltd" \
+                ./cmd/gestaltd
+            )
+            tar -czf "dist/${asset}" -C build gestaltd
+            # Bare filename in the checksum file so `sha256sum -c` works after download.
+            (cd dist && shasum -a 256 "${asset}" > "${asset}.sha256")
+            gcloud storage cp "dist/${asset}" "dist/${asset}.sha256" "${dest}/"
+            rm -f build/gestaltd
+          done
 
   # Post-validation gate for the alpine release image. By now build-alpine-image
   # has already pushed the immutable sha-<commit>-alpine image, so the action's

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -210,26 +210,41 @@ jobs:
             IFS=/ read -r goos goarch suffix <<<"${entry}"
             asset="gestaltd-${suffix}.tar.gz"
 
-            # Skip only when both the tarball and its checksum are present, so a
-            # prior run that uploaded the archive but died before the .sha256 is
-            # repaired on retry. `ls` exits non-zero if either object is missing.
-            if gcloud storage ls "${dest}/${asset}" "${dest}/${asset}.sha256" >/dev/null 2>&1; then
+            # Upload each object only when it is absent: objectCreator cannot
+            # overwrite, so re-uploading an existing object would 403. This also
+            # makes a partial prior run (tarball uploaded, checksum not) self-heal.
+            has_tarball=false
+            has_sha=false
+            gcloud storage ls "${dest}/${asset}" >/dev/null 2>&1 && has_tarball=true
+            gcloud storage ls "${dest}/${asset}.sha256" >/dev/null 2>&1 && has_sha=true
+
+            if [[ "${has_tarball}" == true && "${has_sha}" == true ]]; then
               echo "${asset} (+ checksum) already published for ${SHA}; skipping."
               continue
             fi
 
-            (
-              cd gestaltd
-              CGO_ENABLED=0 GOOS="${goos}" GOARCH="${goarch}" go build \
-                -ldflags "-X main.version=${VERSION}" \
-                -o "${GITHUB_WORKSPACE}/build/gestaltd" \
-                ./cmd/gestaltd
-            )
-            tar -czf "dist/${asset}" -C build gestaltd
-            # Bare filename in the checksum file so `sha256sum -c` works after download.
-            (cd dist && shasum -a 256 "${asset}" > "${asset}.sha256")
-            gcloud storage cp "dist/${asset}" "dist/${asset}.sha256" "${dest}/"
-            rm -f build/gestaltd
+            if [[ "${has_tarball}" == true ]]; then
+              # Checksum the published bytes, not a rebuild: gzip records an mtime,
+              # so a fresh archive would not be identical to the stored one.
+              gcloud storage cp "${dest}/${asset}" "dist/${asset}"
+            else
+              (
+                cd gestaltd
+                CGO_ENABLED=0 GOOS="${goos}" GOARCH="${goarch}" go build \
+                  -ldflags "-X main.version=${VERSION}" \
+                  -o "${GITHUB_WORKSPACE}/build/gestaltd" \
+                  ./cmd/gestaltd
+              )
+              tar -czf "dist/${asset}" -C build gestaltd
+              gcloud storage cp "dist/${asset}" "${dest}/${asset}"
+              rm -f build/gestaltd
+            fi
+
+            if [[ "${has_sha}" != true ]]; then
+              # Bare filename so `sha256sum -c` works after download.
+              (cd dist && shasum -a 256 "${asset}" > "${asset}.sha256")
+              gcloud storage cp "dist/${asset}.sha256" "${dest}/${asset}.sha256"
+            fi
           done
 
   # Post-validation gate for the alpine release image. By now build-alpine-image

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -157,19 +157,13 @@ jobs:
           helm push "/tmp/charts/gestaltd-${sha_version}.tgz" "${CHART_REPOSITORY}"
 
   # Publish per-commit gestaltd binaries (linux + macOS, amd64 + arm64) to the
-  # public CI binary bucket, addressed by commit SHA. This is the per-commit
-  # counterpart to release-gestaltd.yml's semver GitHub Release tarballs, and the
-  # only SHA-addressed artifact that ships a native macOS binary — the CI and
-  # alpine images are linux-only. Toolshed's app-packaging workflow pulls these
-  # by SHA to build provider artifacts on macOS runners without waiting for a
-  # semver release cut.
+  # public CI binary bucket, addressed by commit SHA — the per-commit counterpart
+  # to release-gestaltd.yml's semver release tarballs, and the only SHA-addressed
+  # artifact that ships a native macOS binary (the CI and alpine images are
+  # linux-only). Toolshed's app-packaging workflow pulls these by SHA.
   #
-  # Gated on validation like publish-chart: these binaries feed production app
-  # packaging, so they publish only after the tests clear. Cross-compilation is
-  # cheap, so all four targets build in one job (no per-platform runner matrix).
-  # The bucket is public-read and writable by the CI image publisher SA, so it
-  # reuses that identity. Each object is skipped if already present (re-runs /
-  # same-commit dispatch); the bucket keeps immutable, versioned history.
+  # Gated on validation like publish-chart, since these feed production app
+  # packaging. Reuses the CI image publisher SA, which can write the bucket.
   publish-binaries:
     name: Publish gestaltd Binaries to GCS
     needs: [resolve-ref, validate]
@@ -203,7 +197,7 @@ jobs:
           : "${BUCKET:?GESTALTD_CI_BINARY_BUCKET repository variable is required}"
 
           dest="gs://${BUCKET}/gestaltd/sha-${SHA}"
-          # goos/goarch/asset-suffix triples; suffixes match release-gestaltd.yml.
+          # goos/goarch/suffix; suffixes match release-gestaltd.yml's naming.
           platforms=(
             "darwin/arm64/macos-arm64"
             "darwin/amd64/macos-x86_64"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -216,8 +216,11 @@ jobs:
             IFS=/ read -r goos goarch suffix <<<"${entry}"
             asset="gestaltd-${suffix}.tar.gz"
 
-            if gcloud storage ls "${dest}/${asset}" >/dev/null 2>&1; then
-              echo "${asset} already published for ${SHA}; skipping."
+            # Skip only when both the tarball and its checksum are present, so a
+            # prior run that uploaded the archive but died before the .sha256 is
+            # repaired on retry. `ls` exits non-zero if either object is missing.
+            if gcloud storage ls "${dest}/${asset}" "${dest}/${asset}.sha256" >/dev/null 2>&1; then
+              echo "${asset} (+ checksum) already published for ${SHA}; skipping."
               continue
             fi
 

--- a/gestaltd/terraform/README.md
+++ b/gestaltd/terraform/README.md
@@ -25,6 +25,7 @@ values into the `valon-technologies/gestalt` repository variables:
 ```text
 GESTALTD_ARTIFACT_REGISTRY_HOST
 GESTALTD_CHART_REPOSITORY
+GESTALTD_CI_BINARY_BUCKET
 GESTALTD_CI_GCP_SERVICE_ACCOUNT
 GESTALTD_CI_GCP_WORKLOAD_IDENTITY_PROVIDER
 GESTALTD_CI_IMAGE_REPOSITORY
@@ -49,9 +50,20 @@ on `main`. To backfill an older commit, run that workflow manually with
 `gestalt_ref` set to the full commit SHA. Manual backfill runs the same
 validation jobs before publishing the image.
 
-The legacy GCS CI binary bucket remains managed so Terraform does not destroy
-historical artifacts during this migration. Current workflows do not publish new
-GCS binary artifacts.
+The GCS CI binary bucket (`GESTALTD_CI_BINARY_BUCKET`) holds commit-addressed
+gestaltd binaries published by the `CD (gestaltd)` workflow. It is public-read
+and writable by the CI image publisher service account. Cross-compiled tarballs
+(linux + macOS, amd64 + arm64) land under:
+
+```text
+gs://${GESTALTD_CI_BINARY_BUCKET}/gestaltd/sha-<40-character-commit-sha>/gestaltd-<platform>.tar.gz
+```
+
+Each tarball has a companion `.tar.gz.sha256`. These are the per-commit
+counterpart to the semver GitHub Release binaries, and the only SHA-addressed
+artifact carrying a native macOS binary (the CI and alpine images are
+linux-only). Consumers fetch them over plain public HTTPS by commit SHA, with no
+authentication.
 
 `valon-tools` environments should consume the chart repository location as input
 variables instead of creating their own per-environment chart repository.

--- a/gestaltd/terraform/main.tf
+++ b/gestaltd/terraform/main.tf
@@ -294,6 +294,16 @@ resource "google_storage_bucket_iam_member" "legacy_ci_binary_publisher" {
   member = "serviceAccount:${google_service_account.ci_image_publisher.email}"
 }
 
+# The CD publish-binaries job lists existing objects to skip already-published
+# commits. objectCreator alone cannot list/get, so grant the publisher explicit
+# read rather than depending on the public allUsers grant for its own idempotency
+# check (that grant could be tightened without warning).
+resource "google_storage_bucket_iam_member" "ci_binary_publisher_viewer" {
+  bucket = google_storage_bucket.gestaltd_ci_binaries.name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.ci_image_publisher.email}"
+}
+
 resource "google_storage_bucket_iam_member" "legacy_ci_binary_public_readers" {
   bucket = google_storage_bucket.gestaltd_ci_binaries.name
   role   = "roles/storage.objectViewer"

--- a/gestaltd/terraform/outputs.tf
+++ b/gestaltd/terraform/outputs.tf
@@ -3,6 +3,7 @@ output "github_actions_variables" {
   value = {
     GESTALTD_ARTIFACT_REGISTRY_HOST            = local.artifact_registry_host
     GESTALTD_CHART_REPOSITORY                  = local.chart_repository
+    GESTALTD_CI_BINARY_BUCKET                  = google_storage_bucket.gestaltd_ci_binaries.name
     GESTALTD_CI_GCP_SERVICE_ACCOUNT            = google_service_account.ci_image_publisher.email
     GESTALTD_CI_GCP_WORKLOAD_IDENTITY_PROVIDER = local.ci_image_workload_identity_provider
     GESTALTD_CI_IMAGE_REPOSITORY               = local.ci_image_repository
@@ -34,6 +35,11 @@ output "ci_image_repository" {
 output "ci_image_publisher_service_account" {
   description = "Service account used by GitHub Actions to publish gestaltd CI images."
   value       = google_service_account.ci_image_publisher.email
+}
+
+output "ci_binary_bucket" {
+  description = "Public GCS bucket holding commit-addressed gestaltd CI binaries."
+  value       = google_storage_bucket.gestaltd_ci_binaries.name
 }
 
 output "workload_identity_provider" {


### PR DESCRIPTION
## Description

Add a `publish-binaries` job to `cd.yml` that cross-compiles gestaltd for linux and macOS (amd64 + arm64) and uploads SHA-addressed tarballs (with `.sha256`) to the public CI binary bucket under `gestaltd/sha-<commit>/`. This is the per-commit counterpart to `release-gestaltd.yml`'s semver GitHub Release binaries, and the only SHA-addressed artifact carrying a native macOS binary (the CI and alpine images are linux-only). Gated on validation like the chart publish.

Reuses the existing CI image publisher SA + WIF and the already-public CI binary bucket — no new IAM. Exposes the bucket name via the `github_actions_variables` Terraform output as `GESTALTD_CI_BINARY_BUCKET` (set this repo variable after apply).