### PR TITLE
[gestaltd] build catalog binary for host libc (fix bun app publish on glibc)

### DIFF
--- a/gestaltd/services/apps/providerpkg/prepared_stage.go
+++ b/gestaltd/services/apps/providerpkg/prepared_stage.go
@@ -69,7 +69,9 @@ func StageSourcePreparedInstallDir(manifestPath, stagingDir string, opts StageSo
 		return nil, err
 	}
 	targetOpts := SourceBuildOptions{GOOS: opts.GOOS, GOARCH: opts.GOARCH, Output: opts.BuildOutput}
-	hostBuiltForCatalog, err := ensureHostBuildForSourceStaticCatalog(manifestPath, manifest, SourceBuildOptions{Output: opts.BuildOutput})
+	// Build the catalog binary for the build host's libc so it can be exec'd here
+	// to generate the static catalog (a musl binary cannot run on a glibc runner).
+	hostBuiltForCatalog, err := ensureHostBuildForSourceStaticCatalog(manifestPath, manifest, SourceBuildOptions{Output: opts.BuildOutput, LibC: HostLibC()})
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +83,14 @@ func StageSourcePreparedInstallDir(manifestPath, stagingDir string, opts StageSo
 	if err != nil {
 		return nil, err
 	}
-	if producesOutput && (!hostBuiltForCatalog || !sourceBuildTargetsHost(targetOpts)) {
+	// The catalog build is reusable as the shipped artifact only when it targets
+	// the same platform AND libc; otherwise build the target artifact (e.g. the
+	// musl artifact, after a glibc host catalog build) so it overwrites the
+	// host-libc catalog binary before staging.
+	reuseHostBuild := hostBuiltForCatalog &&
+		sourceBuildTargetsHost(targetOpts) &&
+		HostLibC() == effectiveTargetLibC(targetOpts)
+	if producesOutput && !reuseHostBuild {
 		if err := EnsureSourceBuildOutput(manifestPath, manifest, targetOpts); err != nil {
 			return nil, err
 		}

--- a/gestaltd/services/apps/providerpkg/source_build.go
+++ b/gestaltd/services/apps/providerpkg/source_build.go
@@ -342,6 +342,34 @@ func SourceBuildTarget(opts SourceBuildOptions) (string, string) {
 	return goos, goarch
 }
 
+// HostLibC reports the C library of the current build host ("musl" or "glibc"),
+// or "" on non-linux. Bun-compiled provider binaries are dynamically linked
+// against their libc, so one built for the wrong libc cannot be exec'd (a musl
+// binary on a glibc runner fails with ENOENT for the absent /lib/ld-musl
+// loader). Packaging uses this to build the host-side catalog binary for the
+// build host while still shipping the musl artifact the deploy runtime needs.
+func HostLibC() string {
+	if runtime.GOOS != "linux" {
+		return ""
+	}
+	if matches, _ := filepath.Glob("/lib/ld-musl-*.so.1"); len(matches) > 0 {
+		return "musl"
+	}
+	return "glibc"
+}
+
+// effectiveTargetLibC is the libc a build targets: the explicit opts.LibC, else
+// the SDK default (musl for linux; none elsewhere).
+func effectiveTargetLibC(opts SourceBuildOptions) string {
+	if opts.LibC != "" {
+		return opts.LibC
+	}
+	if goos, _ := SourceBuildTarget(opts); goos == "linux" {
+		return "musl"
+	}
+	return ""
+}
+
 // EnsureSourceBuildOutput is the canonical install-then-build entry; callers
 // that need a build output should use this rather than RunSourceBuild.
 func EnsureSourceBuildOutput(manifestPath string, manifest *providermanifestv1.Manifest, opts SourceBuildOptions) error {

--- a/sdk/typescript/src/build.ts
+++ b/sdk/typescript/src/build.ts
@@ -36,6 +36,7 @@ export type BuildArgs = {
   providerName: string;
   goos: string;
   goarch: string;
+  libc?: string;
   compileTarget?: string;
 };
 
@@ -58,6 +59,7 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<numb
 
 const TARGET_OS_ENV = "GESTALT_TARGET_OS";
 const TARGET_ARCH_ENV = "GESTALT_TARGET_ARCH";
+const TARGET_LIBC_ENV = "GESTALT_TARGET_LIBC";
 
 /**
  * Derives build args from the source manifest + package metadata + env. Used
@@ -79,6 +81,7 @@ export function deriveBuildArgs(root: string): BuildArgs | undefined {
       providerName: providerNameFromSource(source),
       goos: targetGoos(),
       goarch: targetGoarch(),
+      libc: targetLibc(),
     };
   } catch (error) {
     console.error(error instanceof Error ? error.message : String(error));
@@ -109,6 +112,14 @@ function targetGoarch(): string {
     return env.trim();
   }
   return ARCH_ALIASES[process.arch] ?? process.arch;
+}
+
+// Optional libc selector for linux targets. gestaltd sets this to "musl" for the
+// shipped artifact (the deploy runtime is musl) and to the build host's libc for
+// the host-side catalog build, which must exec on the build machine. Empty/unset
+// keeps the musl default.
+function targetLibc(): string {
+  return (process.env[TARGET_LIBC_ENV] ?? "").trim();
 }
 
 /**
@@ -144,6 +155,7 @@ export function buildProviderBinary(args: BuildArgs): void {
       outputPath,
       args.goos,
       args.goarch,
+      args.libc ?? "",
       args.compileTarget,
     );
     const result = spawnSync(bunCommand.command, bunCommand.args, {
@@ -169,7 +181,8 @@ export function bunBuildCommand(
   outputPath: string,
   goos: string,
   goarch: string,
-  compileTarget = bunTarget(goos, goarch),
+  libc = "",
+  compileTarget = bunTarget(goos, goarch, libc),
 ): { command: string; args: string[] } {
   return {
     command: resolveBunExecutable(),
@@ -188,17 +201,21 @@ export function bunBuildCommand(
 /**
  * Maps a Go-style `GOOS` / `GOARCH` target into Bun's compile target format.
  */
-export function bunTarget(goos: string, goarch: string): string {
+export function bunTarget(goos: string, goarch: string, libc = "musl"): string {
   const key = `${goos}/${goarch}`;
+  // linux defaults to musl (the deploy runtime); "glibc"/"gnu" selects the
+  // glibc target so a binary built for catalog generation can exec on a glibc
+  // build host. libc is ignored for non-linux targets.
+  const gnu = libc === "glibc" || libc === "gnu";
   switch (key) {
     case "darwin/amd64":
       return "bun-darwin-x64";
     case "darwin/arm64":
       return "bun-darwin-arm64";
     case "linux/amd64":
-      return "bun-linux-x64-musl";
+      return gnu ? "bun-linux-x64" : "bun-linux-x64-musl";
     case "linux/arm64":
-      return "bun-linux-arm64-musl";
+      return gnu ? "bun-linux-arm64" : "bun-linux-arm64-musl";
     case "windows/amd64":
       return "bun-windows-x64";
     case "windows/arm64":


### PR DESCRIPTION
## Description

`gestaltd provider package` generates the static catalog by exec'ing the compiled provider binary. For TypeScript providers the SDK always compiled `bun-linux-x64-musl`, so on a **glibc** runner (GitHub `ubuntu-latest`, where Valon Tools app snapshots are published) the catalog exec failed with `no such file or directory` — the musl ELF loader `/lib/ld-musl-x86_64.so.1` is absent. This broke publishing for **every bun app** (g-issues, etc.). The deploy path was unaffected because it builds on alpine/musl.

Completes the existing-but-unwired `GESTALT_TARGET_LIBC` / `SourceBuildOptions.LibC` plumbing:
- **SDK** (`sdk/typescript/src/build.ts`): `bunTarget` honors libc — `glibc`/`gnu` → `bun-linux-x64`; default stays musl (no change for existing callers).
- **gestaltd** (`providerpkg`): the host-side catalog build targets the **build host's libc** (`HostLibC`) so it execs locally; the shipped artifact stays **musl**. The catalog build is reused as the artifact only when platform **and** libc match, so a glibc host catalog build is followed by a musl target build for the deploy runtime.

## Verification
- SDK target mapping: `linux/amd64` default → `bun-linux-x64-musl` (unchanged), `glibc` → `bun-linux-x64`, non-linux ignores libc.
- `go test ./services/apps/providerpkg/...` passes.
- Darwin packaging still emits a musl `linux/amd64` artifact (deploy unaffected).
- In a glibc container the catalog `ENOENT` is gone (reproduced before; resolved after).

## Rollout (both halves required to take effect)
1. Publish a new `@valon-technologies/gestalt` SDK including the `build.ts` change and bump g-issues' (and other bun apps') dependency to it.
2. Pin the publish workflow's gestaltd (`GESTALTD_PINNED_SHA`) to a commit including this gestaltd change.

cc @hughhan1 — this completes the `GESTALT_TARGET_LIBC` scaffolding from the plan-17 build-output work.