### PR TITLE
Route top-level agent turn exports to the client layer

### DIFF
--- a/sdk/python/gestalt/__init__.py
+++ b/sdk/python/gestalt/__init__.py
@@ -94,11 +94,8 @@ _AGENT_PROTOCOL_EXPORTS = (
     "AgentToolRef",
     "AgentStructuredOutput",
     "AgentTextOutput",
-    "AgentTurn",
     "AgentTurnDisplay",
     "AgentTurnEvent",
-    "AgentTurnOutput",
-    "AgentTurnStructuredOutput",
     "CancelAgentProviderTurnRequest",
     "CreateAgentProviderSessionRequest",
     "CreateAgentProviderTurnRequest",
@@ -117,6 +114,15 @@ _AGENT_PROTOCOL_EXPORTS = (
     "ListedAgentTool",
     "ResolveAgentProviderInteractionRequest",
     "UpdateAgentProviderSessionRequest",
+)
+
+_AGENT_CLIENT_EXPORTS = (
+    "AgentTurn",
+    "AgentTurnOutput",
+    "AgentTurnStructured",
+    "AgentTurnStructuredOutput",
+    "AgentTurnText",
+    "AgentTurnTextOutput",
 )
 
 _AGENT_HELPER_EXPORTS = (
@@ -481,6 +487,7 @@ _LAZY_EXPORTS = {
     "session_catalog": ("._app", "session_catalog"),
 }
 
+_LAZY_EXPORTS.update({name: (".agent", name) for name in _AGENT_CLIENT_EXPORTS})
 _LAZY_EXPORTS.update({name: ("._agent", name) for name in _AGENT_PROTOCOL_EXPORTS})
 _LAZY_EXPORTS.update({name: ("._agent", name) for name in _AGENT_HELPER_EXPORTS})
 _LAZY_EXPORTS.update(
@@ -529,6 +536,7 @@ __all__ = [
     "decode_graphql_result",
     "ok",
     "raise_for_status",
+    *_AGENT_CLIENT_EXPORTS,
     *_AGENT_PROTOCOL_EXPORTS,
     *_AGENT_HELPER_EXPORTS,
     *_AUTHENTICATION_AUTHORED_EXPORTS,

--- a/sdk/python/gestalt/agent_provider.py
+++ b/sdk/python/gestalt/agent_provider.py
@@ -1,0 +1,24 @@
+"""Provider-authoring types for Gestalt agent turn output.
+
+Use these types when implementing :class:`~gestalt.AgentProvider` and returning
+turn results from ``create_turn`` / ``get_turn``. They match the wire shape the
+SDK serializes on the provider request path.
+
+Client code that calls :class:`~gestalt.Agent` should use the top-level
+``gestalt.AgentTurn`` exports instead — those denote the generated client types
+returned by ``get_turn`` / ``create_turn``.
+"""
+
+from __future__ import annotations
+
+from ._agent import (
+    AgentTurn,
+    AgentTurnOutput,
+    AgentTurnStructuredOutput,
+)
+
+__all__ = [
+    "AgentTurn",
+    "AgentTurnOutput",
+    "AgentTurnStructuredOutput",
+]

--- a/sdk/python/tests/test_agent_transport.py
+++ b/sdk/python/tests/test_agent_transport.py
@@ -35,9 +35,7 @@ from gestalt import (
     AgentProvider,
     AgentProviderCapabilities,
     AgentSession,
-    AgentTurn,
     AgentTurnEvent,
-    AgentTurnOutput,
     Error,
     ListAgentProviderInteractionsResponse,
     ListAgentProviderSessionsResponse,
@@ -59,6 +57,7 @@ from gestalt._gen.v1 import agent_pb2_grpc as _agent_pb2_grpc
 from gestalt._gen.v1 import app_pb2 as _app_pb2
 from gestalt._gen.v1 import runtime_pb2 as _runtime_pb2
 from gestalt._gen.v1 import runtime_pb2_grpc as _runtime_pb2_grpc
+from gestalt.agent_provider import AgentTurn, AgentTurnOutput
 
 agent_pb2: Any = _agent_pb2
 agent_pb2_grpc: Any = _agent_pb2_grpc


### PR DESCRIPTION
## Summary
- Route `gestalt.AgentTurn`, `AgentTurnOutput`, `AgentTurnStructured`, `AgentTurnStructuredOutput`, `AgentTurnText`, and `AgentTurnTextOutput` to the generated client module, so top-level names match what `gestalt.Agent.get_turn()` / `create_turn()` return.
- Add `gestalt.agent_provider` as the explicit import path for provider-authoring turn types used by `AgentProvider` implementations, and migrate `test_agent_transport.py` to it.

## Test plan
- [x] `cd sdk/python && .venv/bin/python -m pytest tests/test_agent_transport.py -q` (12 passed)
- [x] `python -c "import gestalt; print(gestalt.AgentTurn.__module__)"` -> `gestalt.agent`
