### PR TITLE
Expose custom app operations regardless of allowedOperations

### DIFF
--- a/gestaltd/internal/daemon/provider_release_finalize_test.go
+++ b/gestaltd/internal/daemon/provider_release_finalize_test.go
@@ -307,6 +307,68 @@ paths:
 	}
 }
 
+func TestProviderReleaseMetadataExposesCustomOpsAbsentFromAllowedOperations(t *testing.T) {
+	t.Parallel()
+
+	metadata, err := buildProviderReleaseMetadataForRawManifest(t, `kind: app
+source: github.com/testowner/apps/catalog/custom-ops-test
+version: 1.0.0
+displayName: Custom Ops App
+artifacts:
+  - os: test
+    arch: test
+    path: provider
+    sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+entrypoint:
+  artifactPath: provider
+spec:
+  surfaces:
+    openapi:
+      connection: default
+      document: openapi.yaml
+  allowedOperations:
+    sharedRead: {}
+    getTeams: {}
+  connections:
+    default:
+      auth:
+        type: none
+`, map[string]string{
+		"provider": "",
+		"catalog.yaml": `name: test
+operations:
+  - id: sharedRead
+    method: GET
+  - id: customWrite
+    method: POST
+`,
+		"openapi.yaml": `openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /teams:
+    get:
+      operationId: getTeams
+      responses:
+        "200":
+          description: ok
+`,
+	})
+	if err != nil {
+		t.Fatalf("buildProviderReleaseMetadata: %v", err)
+	}
+	cat := metadata.StaticValidation.Catalog
+	if cat == nil {
+		t.Fatalf("catalog metadata missing: %#v", metadata.StaticValidation)
+	}
+	for _, id := range []string{"customWrite", "sharedRead", "getTeams"} {
+		if _, ok := catalog.OperationByID(cat, id); !ok {
+			t.Fatalf("catalog operations = %#v, want %q", cat.Operations, id)
+		}
+	}
+}
+
 func TestProviderReleaseMetadataClassifiesHybridProviderAsExecutable(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/apps/validation.go
+++ b/gestaltd/services/apps/validation.go
@@ -189,7 +189,10 @@ func resolveExecutableCatalog(ctx context.Context, name string, entry *Validatio
 		return filtered, false, nil
 	}
 
-	filteredPluginCatalog, err := applyOperationExposure(pluginCatalog, operationexposure.MatchingAllowedOperations(allowed, pluginCatalog))
+	// allowedOperations gates the API surface, not the provider's own custom
+	// operations, so every plugin operation stays exposed while listed ones still
+	// carry their overrides.
+	filteredPluginCatalog, err := applyOperationExposure(pluginCatalog, exposeAllOperations(allowed, pluginCatalog))
 	if err != nil {
 		return nil, false, fmt.Errorf("plugin %q static catalog: %w", name, err)
 	}
@@ -206,7 +209,7 @@ func resolveExecutableCatalog(ctx context.Context, name string, entry *Validatio
 		if err != nil {
 			return nil, false, err
 		}
-		merged, err := mergeCatalogs(name, filteredPluginCatalog, filteredAPICatalog)
+		merged, err := mergeCatalogs(name, filteredPluginCatalog, excludeOperations(filteredAPICatalog, filteredPluginCatalog))
 		if err != nil {
 			return nil, false, err
 		}
@@ -225,11 +228,46 @@ func resolveExecutableCatalog(ctx context.Context, name string, entry *Validatio
 		return nil, false, fmt.Errorf("plugin %q API catalog: %w", name, err)
 	}
 	_, hasMCP := resolvedSurfaceURL(entry, spec, SpecSurfaceMCP)
-	merged, err := mergeCatalogs(name, filteredPluginCatalog, filteredAPICatalog)
+	merged, err := mergeCatalogs(name, filteredPluginCatalog, excludeOperations(filteredAPICatalog, filteredPluginCatalog))
 	if err != nil {
 		return nil, false, err
 	}
 	return merged, hasMCP && merged == nil, nil
+}
+
+// exposeAllOperations maps every operation in cat to its allowed_operations
+// override, if any. nil for an empty catalog avoids building an allow-none policy.
+func exposeAllOperations(allowed map[string]*OperationOverride, cat *catalog.Catalog) map[string]*OperationOverride {
+	if cat == nil || len(cat.Operations) == 0 {
+		return nil
+	}
+	exposure := make(map[string]*OperationOverride, len(cat.Operations))
+	for i := range cat.Operations {
+		exposure[cat.Operations[i].ID] = allowed[cat.Operations[i].ID]
+	}
+	return exposure
+}
+
+// excludeOperations drops operations from cat whose ID appears in other, letting
+// custom operations win over same-named API operations.
+func excludeOperations(cat, other *catalog.Catalog) *catalog.Catalog {
+	if cat == nil || other == nil || len(other.Operations) == 0 {
+		return cat
+	}
+	exclude := make(map[string]struct{}, len(other.Operations))
+	for i := range other.Operations {
+		exclude[other.Operations[i].ID] = struct{}{}
+	}
+	pruned := cat.Clone()
+	kept := make([]catalog.CatalogOperation, 0, len(pruned.Operations))
+	for i := range pruned.Operations {
+		if _, skip := exclude[pruned.Operations[i].ID]; skip {
+			continue
+		}
+		kept = append(kept, pruned.Operations[i])
+	}
+	pruned.Operations = kept
+	return pruned
 }
 
 func readStaticCatalog(name string, entry *ValidationApp, manifest *providermanifestv1.Manifest) (*catalog.Catalog, error) {


### PR DESCRIPTION
## Problem

A hybrid app provider that defines custom `@app.operation` handlers *and* a spec (OpenAPI/GraphQL) surface loses those handlers from its effective catalog whenever it also declares `allowedOperations`. The allowlist was applied to the merged plugin + API catalog, so any custom operation not listed in `allowedOperations` was filtered out — at both publish (`provider-release.yaml`) and runtime — and surfaced as a 404 on invocation.

This is what broke `messages.send` on the gmail app (reported in prod): its `allowedOperations` lists only the 12 OpenAPI ops, so the 6 custom write ops (`messages.send`, `messages.reply`, `messages.forward`, `drafts.create/update/send`) were dropped. `hex` has the same latent issue.

## Fix

`allowedOperations` curates the external API surface, not the provider's own hand-written operations. In `resolveExecutableCatalog`:

- The plugin (custom-op) catalog now exposes **every** operation, still honoring alias/description overrides for any listed in `allowedOperations`.
- The API catalog stays gated by `allowedOperations`, and is deduplicated against the plugin catalog so a custom handler wins over a same-named API op (no new merge conflicts).
- Pure-executable providers (no spec surface) are unchanged.

## Test

`TestProviderReleaseMetadataExposesCustomOpsAbsentFromAllowedOperations` exercises the real publish path: a hybrid provider whose `allowedOperations` lists only an API op plus one shared plugin op, with a custom op that is not listed. It fails on `main` (custom op dropped) and passes with this change.

## Rollout

The catalog half of the gmail 404. Once merged, the affected provider snapshots (gmail, hex) must be republished with the new gestaltd so `provider-release.yaml` includes the custom ops. End-to-end `messages.send` also depends on the in-flight musl snapshot fix so the provider binary loads on the Alpine runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)