### PR TITLE
[gestaltd] Two-phase startup: return /ready before app providers finish loading

### DIFF
--- a/gestaltd/internal/bootstrap/app_startup_category.go
+++ b/gestaltd/internal/bootstrap/app_startup_category.go
@@ -1,0 +1,19 @@
+package bootstrap
+
+import "github.com/valon-technologies/gestalt/server/internal/config"
+
+// AppStartupCategory controls when an app provider is started relative to /ready.
+type AppStartupCategory int
+
+const (
+	// AppStartupNOOP means the app provider must finish loading before /ready is returned.
+	AppStartupNOOP AppStartupCategory = iota
+	// AppStartupUpdate means the app provider starts after /ready and loads in the background.
+	AppStartupUpdate
+)
+
+// appStartupCategory returns the startup category for an app provider.
+// Currently always returns AppStartupNOOP so all apps block /ready.
+func appStartupCategory(_ string, _ *config.ProviderEntry) AppStartupCategory {
+	return AppStartupNOOP
+}

--- a/gestaltd/internal/bootstrap/app_startup_category.go
+++ b/gestaltd/internal/bootstrap/app_startup_category.go
@@ -5,7 +5,7 @@ import "github.com/valon-technologies/gestalt/server/internal/config"
 type AppStartupCategory int
 
 const (
-	AppStartupNOOP   AppStartupCategory = iota
+	AppStartupNOOP AppStartupCategory = iota
 	AppStartupUpdate
 )
 

--- a/gestaltd/internal/bootstrap/app_startup_category.go
+++ b/gestaltd/internal/bootstrap/app_startup_category.go
@@ -2,18 +2,13 @@ package bootstrap
 
 import "github.com/valon-technologies/gestalt/server/internal/config"
 
-// AppStartupCategory controls when an app provider is started relative to /ready.
 type AppStartupCategory int
 
 const (
-	// AppStartupNOOP means the app provider must finish loading before /ready is returned.
-	AppStartupNOOP AppStartupCategory = iota
-	// AppStartupUpdate means the app provider starts after /ready and loads in the background.
+	AppStartupNOOP   AppStartupCategory = iota
 	AppStartupUpdate
 )
 
-// appStartupCategory returns the startup category for an app provider.
-// Currently always returns AppStartupNOOP so all apps block /ready.
 func appStartupCategory(_ string, _ *config.ProviderEntry) AppStartupCategory {
 	return AppStartupNOOP
 }

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1233,7 +1233,6 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	}()
 	noopBuilds, updateBuilds := providerBuilds.partition(appStartupCategory)
 
-	// NOOP apps: block until all are ready before /ready is returned.
 	var noopConnAuth func() map[string]map[string]OAuthHandler
 	var noopManualConnAuth func() map[string]map[string]ManualTokenExchanger
 	noopReady, noopConnAuth, noopManualConnAuth, _ = noopBuilds.Start(ctx, prepared.Deps, buildProvider)
@@ -1244,7 +1243,6 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	}
 	slog.InfoContext(ctx, "all ready-blocking app providers loaded", "count", len(noopBuilds.pending))
 
-	// UPDATE apps: start in background and complete after /ready.
 	var updateConnAuth func() map[string]map[string]OAuthHandler
 	var updateManualConnAuth func() map[string]map[string]ManualTokenExchanger
 	providersReady, updateConnAuth, updateManualConnAuth, _ = updateBuilds.Start(ctx, prepared.Deps, buildProvider)

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1228,6 +1228,12 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		}
 	}()
 	providersReady, connAuthResolver, manualConnAuthResolver, _ = providerBuilds.Start(ctx, prepared.Deps, buildProvider)
+	select {
+	case <-providersReady:
+	case <-ctx.Done():
+		return nil, fmt.Errorf("app provider startup interrupted: %w", ctx.Err())
+	}
+	slog.InfoContext(ctx, "all app providers ready", "count", len(providerBuilds.providers.List()))
 	reconcileWorkflowConfig := func(ctx context.Context, includeProvider workflowConfigProviderFilter) error {
 		if err := reconcileWorkflowConfigDefinitions(ctx, cfg, prepared.Deps.WorkflowRuntime, includeProvider); err != nil {
 			return err

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1227,13 +1227,51 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 			_ = closeAgents(extraAgents...)
 		}
 	}()
-	providersReady, connAuthResolver, manualConnAuthResolver, _ = providerBuilds.Start(ctx, prepared.Deps, buildProvider)
+	noopBuilds, updateBuilds := providerBuilds.partition(appStartupCategory)
+
+	// NOOP apps: block until all are ready before /ready is returned.
+	noopReady, noopConnAuth, noopManualConnAuth, _ := noopBuilds.Start(ctx, prepared.Deps, buildProvider)
 	select {
-	case <-providersReady:
+	case <-noopReady:
 	case <-ctx.Done():
 		return nil, fmt.Errorf("app provider startup interrupted: %w", ctx.Err())
 	}
-	slog.InfoContext(ctx, "all app providers ready", "count", len(providerBuilds.providers.List()))
+	slog.InfoContext(ctx, "all ready-blocking app providers loaded", "count", len(noopBuilds.pending))
+
+	// UPDATE apps: start in background and complete after /ready.
+	var updateConnAuth func() map[string]map[string]OAuthHandler
+	var updateManualConnAuth func() map[string]map[string]ManualTokenExchanger
+	providersReady, updateConnAuth, updateManualConnAuth, _ = updateBuilds.Start(ctx, prepared.Deps, buildProvider)
+
+	connAuthResolver = func() map[string]map[string]OAuthHandler {
+		a, b := noopConnAuth(), updateConnAuth()
+		if len(b) == 0 {
+			return a
+		}
+		merged := make(map[string]map[string]OAuthHandler, len(a)+len(b))
+		for k, v := range a {
+			merged[k] = v
+		}
+		for k, v := range b {
+			merged[k] = v
+		}
+		return merged
+	}
+	manualConnAuthResolver = func() map[string]map[string]ManualTokenExchanger {
+		a, b := noopManualConnAuth(), updateManualConnAuth()
+		if len(b) == 0 {
+			return a
+		}
+		merged := make(map[string]map[string]ManualTokenExchanger, len(a)+len(b))
+		for k, v := range a {
+			merged[k] = v
+		}
+		for k, v := range b {
+			merged[k] = v
+		}
+		return merged
+	}
+
 	reconcileWorkflowConfig := func(ctx context.Context, includeProvider workflowConfigProviderFilter) error {
 		if err := reconcileWorkflowConfigDefinitions(ctx, cfg, prepared.Deps.WorkflowRuntime, includeProvider); err != nil {
 			return err

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1243,17 +1243,20 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	}
 	slog.InfoContext(ctx, "all ready-blocking app providers loaded", "count", len(noopBuilds.pending))
 
+	noopAuth := noopConnAuth()
+	noopManualAuth := noopManualConnAuth()
+
 	var updateConnAuth func() map[string]map[string]OAuthHandler
 	var updateManualConnAuth func() map[string]map[string]ManualTokenExchanger
 	providersReady, updateConnAuth, updateManualConnAuth, _ = updateBuilds.Start(ctx, prepared.Deps, buildProvider)
 
 	connAuthResolver = func() map[string]map[string]OAuthHandler {
-		a, b := noopConnAuth(), updateConnAuth()
+		b := updateConnAuth()
 		if len(b) == 0 {
-			return a
+			return noopAuth
 		}
-		merged := make(map[string]map[string]OAuthHandler, len(a)+len(b))
-		for k, v := range a {
+		merged := make(map[string]map[string]OAuthHandler, len(noopAuth)+len(b))
+		for k, v := range noopAuth {
 			merged[k] = v
 		}
 		for k, v := range b {
@@ -1262,12 +1265,12 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		return merged
 	}
 	manualConnAuthResolver = func() map[string]map[string]ManualTokenExchanger {
-		a, b := noopManualConnAuth(), updateManualConnAuth()
+		b := updateManualConnAuth()
 		if len(b) == 0 {
-			return a
+			return noopManualAuth
 		}
-		merged := make(map[string]map[string]ManualTokenExchanger, len(a)+len(b))
-		for k, v := range a {
+		merged := make(map[string]map[string]ManualTokenExchanger, len(noopManualAuth)+len(b))
+		for k, v := range noopManualAuth {
 			merged[k] = v
 		}
 		for k, v := range b {

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1128,6 +1128,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	}
 	providers := providerBuilds.providers
 	var (
+		noopReady              <-chan struct{}
 		providersReady         <-chan struct{}
 		connAuthResolver       func() map[string]map[string]OAuthHandler
 		manualConnAuthResolver func() map[string]map[string]ManualTokenExchanger
@@ -1135,6 +1136,9 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	closeProviders := true
 	defer func() {
 		if closeProviders {
+			if noopReady != nil {
+				<-noopReady
+			}
 			if providersReady != nil {
 				<-providersReady
 			}
@@ -1230,7 +1234,9 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	noopBuilds, updateBuilds := providerBuilds.partition(appStartupCategory)
 
 	// NOOP apps: block until all are ready before /ready is returned.
-	noopReady, noopConnAuth, noopManualConnAuth, _ := noopBuilds.Start(ctx, prepared.Deps, buildProvider)
+	var noopConnAuth func() map[string]map[string]OAuthHandler
+	var noopManualConnAuth func() map[string]map[string]ManualTokenExchanger
+	noopReady, noopConnAuth, noopManualConnAuth, _ = noopBuilds.Start(ctx, prepared.Deps, buildProvider)
 	select {
 	case <-noopReady:
 	case <-ctx.Done():

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -92,19 +92,22 @@ func prepareProviderBuilds(
 
 	for name := range cfg.Apps {
 		intgDef := cfg.Apps[name]
-		var proxy *startupProviderProxy
+		spec, operationRouting, err := buildStartupProviderSpec(name, intgDef)
+		if err != nil {
+			slog.Warn("building startup provider proxy metadata failed", "provider", name, "error", err)
+			builds.pending = append(builds.pending, pendingProviderBuild{name: name, entry: intgDef})
+			continue
+		}
+		var tracker *startupWaitTracker
 		if deps.WorkflowRuntime != nil {
-			spec, operationRouting, err := buildStartupProviderSpec(name, intgDef)
-			if err != nil {
-				slog.Warn("building startup provider proxy metadata failed", "provider", name, "error", err)
-			} else {
-				proxy = newStartupProviderProxy(spec, operationRouting, deps.WorkflowRuntime.StartupWaitTracker())
-				if err := reg.Providers.Register(name, proxy); err != nil {
-					builds.errs = append(builds.errs, fmt.Errorf("integration %q: %w", name, err))
-					slog.Warn("registering startup provider proxy failed", "provider", name, "error", err)
-					proxy = nil
-				}
-			}
+			tracker = deps.WorkflowRuntime.StartupWaitTracker()
+		}
+		proxy := newStartupProviderProxy(spec, operationRouting, tracker)
+		if err := reg.Providers.Register(name, proxy); err != nil {
+			builds.errs = append(builds.errs, fmt.Errorf("integration %q: %w", name, err))
+			slog.Warn("registering startup provider proxy failed", "provider", name, "error", err)
+			builds.pending = append(builds.pending, pendingProviderBuild{name: name, entry: intgDef})
+			continue
 		}
 		builds.pending = append(builds.pending, pendingProviderBuild{name: name, entry: intgDef, proxy: proxy})
 	}

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -114,6 +114,32 @@ func prepareProviderBuilds(
 	return builds, nil
 }
 
+// partition splits pending builds into two groups by startup category.
+// Both partitions share the same provider registry so proxies registered
+// during prepareProviderBuilds remain visible regardless of which partition
+// eventually resolves them.
+func (b *preparedProviderBuilds) partition(categorize func(string, *config.ProviderEntry) AppStartupCategory) (noop, update *preparedProviderBuilds) {
+	noop = &preparedProviderBuilds{
+		providers:      b.providers,
+		connAuth:       make(map[string]map[string]OAuthHandler),
+		manualConnAuth: make(map[string]map[string]ManualTokenExchanger),
+		errs:           append([]error(nil), b.errs...),
+	}
+	update = &preparedProviderBuilds{
+		providers:      b.providers,
+		connAuth:       make(map[string]map[string]OAuthHandler),
+		manualConnAuth: make(map[string]map[string]ManualTokenExchanger),
+	}
+	for _, p := range b.pending {
+		if categorize(p.name, p.entry) == AppStartupUpdate {
+			update.pending = append(update.pending, p)
+		} else {
+			noop.pending = append(noop.pending, p)
+		}
+	}
+	return
+}
+
 func (b *preparedProviderBuilds) Start(
 	ctx context.Context,
 	deps Deps,

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -114,21 +114,19 @@ func prepareProviderBuilds(
 	return builds, nil
 }
 
-// partition splits pending builds into two groups by startup category.
-// Both partitions share the same provider registry so proxies registered
-// during prepareProviderBuilds remain visible regardless of which partition
-// eventually resolves them.
 func (b *preparedProviderBuilds) partition(categorize func(string, *config.ProviderEntry) AppStartupCategory) (noop, update *preparedProviderBuilds) {
+	prepErrs := append([]error(nil), b.errs...)
 	noop = &preparedProviderBuilds{
 		providers:      b.providers,
 		connAuth:       make(map[string]map[string]OAuthHandler),
 		manualConnAuth: make(map[string]map[string]ManualTokenExchanger),
-		errs:           append([]error(nil), b.errs...),
+		errs:           prepErrs,
 	}
 	update = &preparedProviderBuilds{
 		providers:      b.providers,
 		connAuth:       make(map[string]map[string]OAuthHandler),
 		manualConnAuth: make(map[string]map[string]ManualTokenExchanger),
+		errs:           prepErrs,
 	}
 	for _, p := range b.pending {
 		if categorize(p.name, p.entry) == AppStartupUpdate {

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -95,7 +95,7 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 		SecureCookies:        strings.HasPrefix(cfg.Server.BaseURL, "https://"),
 		StateSecret:          crypto.DeriveKey(cfg.Server.EncryptionKey),
 		S3:                   result.S3,
-		Readiness:            runtimeReadinessStatus(result.ProvidersReady, workflowProvidersReady, result.Services),
+		Readiness:            runtimeReadinessStatus(workflowProvidersReady, result.Services),
 		PrometheusMetrics:    result.Telemetry.PrometheusHandler(),
 		PublicHostServices:   result.PublicHostServices,
 		Admin: AdminRouteConfig{
@@ -193,14 +193,8 @@ type indexedDBPinger interface {
 	Ping(context.Context) error
 }
 
-func runtimeReadinessStatus(providersReady, workflowProvidersReady <-chan struct{}, services indexedDBPinger) ReadinessChecker {
+func runtimeReadinessStatus(workflowProvidersReady <-chan struct{}, services indexedDBPinger) ReadinessChecker {
 	return func() string {
-		select {
-		case <-providersReady:
-		default:
-			return "providers loading"
-		}
-
 		select {
 		case <-workflowProvidersReady:
 		default:
@@ -244,14 +238,13 @@ func serveRuntime(ctx context.Context, cfg *config.Config, connMaps bootstrap.Co
 		}
 	}()
 
-	select {
-	case <-result.ProvidersReady:
-		slog.Info("all providers ready", "count", len(result.Providers.List()))
-	case failure := <-listenErr:
-		return fmt.Errorf("%s http server: %v", failure.name, failure.err)
-	case <-ctx.Done():
-		return nil
-	}
+	go func() {
+		select {
+		case <-result.ProvidersReady:
+			slog.InfoContext(ctx, "all app providers ready", "count", len(result.Providers.List()))
+		case <-ctx.Done():
+		}
+	}()
 
 	if err := result.StartWorkflowProviders(ctx); err != nil {
 		return err

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -219,8 +219,6 @@ func serveRuntime(ctx context.Context, cfg *config.Config, connMaps bootstrap.Co
 		defer devSupervisor.Stop()
 	}
 
-	// Bind all sockets synchronously so a failed bind is caught before
-	// workflow providers and MCP setup run.
 	type boundServer struct {
 		name     string
 		server   *http.Server
@@ -259,8 +257,6 @@ func serveRuntime(ctx context.Context, cfg *config.Config, connMaps bootstrap.Co
 		}
 	}()
 
-	// App providers finished during bootstrap. Open the readiness gate now and
-	// start workflow providers separately in the background.
 	close(workflowProvidersReady)
 
 	workflowErr := make(chan error, 1)

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -259,31 +259,33 @@ func serveRuntime(ctx context.Context, cfg *config.Config, connMaps bootstrap.Co
 		}
 	}()
 
-	go func() {
-		select {
-		case <-result.ProvidersReady:
-			slog.InfoContext(ctx, "all app providers ready", "count", len(result.Providers.List()))
-		case <-ctx.Done():
-		}
-	}()
-
-	if err := result.StartWorkflowProviders(ctx); err != nil {
-		return err
-	}
+	// App providers finished during bootstrap. Open the readiness gate now and
+	// start workflow providers separately in the background.
 	close(workflowProvidersReady)
-	result.StartWorkflowConfigReconciliation(ctx)
-	slog.Info("workflow providers ready", "count", len(result.ExtraWorkflows))
 
-	mcpHandler, err := newMCPHandler(cfg, connMaps, result, mcpInvoker)
-	if err != nil {
-		return err
-	}
-	mcpSlot.Set(mcpHandler)
-	slog.Info("MCP endpoint enabled", "path", "/mcp")
+	workflowErr := make(chan error, 1)
+	go func() {
+		if err := result.StartWorkflowProviders(ctx); err != nil {
+			workflowErr <- err
+			return
+		}
+		result.StartWorkflowConfigReconciliation(ctx)
+		slog.Info("workflow providers ready", "count", len(result.ExtraWorkflows))
+
+		mcpHandler, err := newMCPHandler(cfg, connMaps, result, mcpInvoker)
+		if err != nil {
+			workflowErr <- err
+			return
+		}
+		mcpSlot.Set(mcpHandler)
+		slog.Info("MCP endpoint enabled", "path", "/mcp")
+	}()
 
 	select {
 	case failure := <-listenErr:
 		return fmt.Errorf("%s http server: %v", failure.name, failure.err)
+	case err := <-workflowErr:
+		return err
 	case <-ctx.Done():
 		return nil
 	}

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -279,6 +279,12 @@ func serveRuntime(ctx context.Context, cfg *config.Config, connMaps bootstrap.Co
 		}
 		mcpSlot.Set(mcpHandler)
 		slog.Info("MCP endpoint enabled", "path", "/mcp")
+
+		select {
+		case <-result.ProvidersReady:
+			slog.InfoContext(ctx, "all deferred app providers ready")
+		case <-ctx.Done():
+		}
 	}()
 
 	select {

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"slices"
 	"strings"
@@ -217,12 +218,32 @@ func serveRuntime(ctx context.Context, cfg *config.Config, connMaps bootstrap.Co
 	if devSupervisor != nil {
 		defer devSupervisor.Stop()
 	}
-	listenErr := make(chan namedListenFailure, len(servers))
+
+	// Bind all sockets synchronously so a failed bind is caught before
+	// workflow providers and MCP setup run.
+	type boundServer struct {
+		name     string
+		server   *http.Server
+		listener net.Listener
+	}
+	bound := make([]boundServer, 0, len(servers))
 	for _, entry := range servers {
+		ln, err := net.Listen("tcp", entry.server.Addr)
+		if err != nil {
+			for _, prev := range bound {
+				_ = prev.listener.Close()
+			}
+			return fmt.Errorf("%s http server: %w", entry.name, err)
+		}
+		bound = append(bound, boundServer{name: entry.name, server: entry.server, listener: ln})
+	}
+
+	listenErr := make(chan namedListenFailure, len(bound))
+	for _, entry := range bound {
 		entry := entry
 		go func() {
-			slog.Info("gestaltd listening", "listener", entry.name, "addr", entry.server.Addr)
-			if err := entry.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			slog.Info("gestaltd listening", "listener", entry.name, "addr", entry.listener.Addr())
+			if err := entry.server.Serve(entry.listener); err != nil && err != http.ErrServerClosed {
 				listenErr <- namedListenFailure{name: entry.name, err: err}
 			}
 		}()
@@ -231,7 +252,7 @@ func serveRuntime(ctx context.Context, cfg *config.Config, connMaps bootstrap.Co
 	defer func() {
 		drainCtx, drainCancel := context.WithTimeout(context.Background(), runtimeShutdownTimeout)
 		defer drainCancel()
-		for _, entry := range servers {
+		for _, entry := range bound {
 			if err := entry.server.Shutdown(drainCtx); err != nil {
 				slog.Warn("server shutdown", "listener", entry.name, "error", err)
 			}

--- a/gestaltd/internal/server/runtime_test.go
+++ b/gestaltd/internal/server/runtime_test.go
@@ -47,15 +47,9 @@ func (p fakeIndexedDBPinger) Ping(context.Context) error {
 func TestRuntimeReadinessStatusWaitsForWorkflowProviders(t *testing.T) {
 	t.Parallel()
 
-	providersReady := make(chan struct{})
 	workflowProvidersReady := make(chan struct{})
-	check := runtimeReadinessStatus(providersReady, workflowProvidersReady, fakeIndexedDBPinger{})
+	check := runtimeReadinessStatus(workflowProvidersReady, fakeIndexedDBPinger{})
 
-	if got := check(); got != "providers loading" {
-		t.Fatalf("readiness before providers = %q, want %q", got, "providers loading")
-	}
-
-	close(providersReady)
 	if got := check(); got != "workflow providers loading" {
 		t.Fatalf("readiness before workflow providers = %q, want %q", got, "workflow providers loading")
 	}
@@ -69,12 +63,9 @@ func TestRuntimeReadinessStatusWaitsForWorkflowProviders(t *testing.T) {
 func TestRuntimeReadinessStatusChecksIndexedDBAfterProviders(t *testing.T) {
 	t.Parallel()
 
-	providersReady := make(chan struct{})
-	close(providersReady)
 	workflowProvidersReady := make(chan struct{})
 	close(workflowProvidersReady)
 	check := runtimeReadinessStatus(
-		providersReady,
 		workflowProvidersReady,
 		fakeIndexedDBPinger{err: errors.New("down")},
 	)


### PR DESCRIPTION
## Description

App providers now return \`/ready\` as soon as the workflow provider (Temporal) is up and IndexedDB is reachable, rather than waiting for all app provider subprocesses to finish initializing.

Each app provider is immediately registered in the \`ProviderMap\` as a \`startupProviderProxy\` during bootstrap. Requests for a provider that is still loading block on the proxy's gate until that provider is ready, then proceed transparently. Previously, proxies were only registered when \`WorkflowRuntime != nil\` — they are now unconditional.