### PR TITLE
Emit close() and context-manager lifecycle on generated Python SDK clients.

### DIFF
--- a/sdk/python/gestalt/_api.py
+++ b/sdk/python/gestalt/_api.py
@@ -312,6 +312,9 @@ def _shared_authorization_client() -> "Authorization":
         ):
             return client
         client = Authorization.connect()
+        # Process-lifetime singleton: callers must never close its channel, so a
+        # stray close()/__exit__ cannot leave the cache pointing at a dead client.
+        client._owns_channel = False
         _shared_authorization_state["target"] = target
         _shared_authorization_state["token"] = token
         _shared_authorization_state["client"] = client

--- a/sdk/python/gestalt/agent.py
+++ b/sdk/python/gestalt/agent.py
@@ -555,9 +555,11 @@ class Agent:
         context: RequestContext | None = None,
         timeout: float | None = None,
     ) -> None:
+        self._channel = channel
         self._stub = _agent_pb2_grpc.AgentStub(channel)
         self._context = context
         self._timeout = timeout
+        self._owns_channel = False
 
     @classmethod
     def connect(
@@ -574,7 +576,25 @@ class Agent:
         channel = host_service_channel(
             "agent", target, token=token.strip(), binding=(name or "").strip()
         )
-        return cls(channel, context=context, timeout=timeout)
+        client = cls(channel, context=context, timeout=timeout)
+        client._owns_channel = True
+        return client
+
+    def close(self) -> None:
+        """Close the owned gRPC channel; a no-op for injected channels."""
+
+        if self._owns_channel:
+            self._channel.close()
+
+    def __enter__(self) -> Agent:
+        """Return the client for ``with`` statements."""
+
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        """Close the client at the end of a context manager block."""
+
+        self.close()
 
     @overload
     def create_session(

--- a/sdk/python/gestalt/app.py
+++ b/sdk/python/gestalt/app.py
@@ -391,9 +391,11 @@ class App:
         context: RequestContext | None = None,
         timeout: float | None = None,
     ) -> None:
+        self._channel = channel
         self._stub = _app_pb2_grpc.AppStub(channel)
         self._context = context
         self._timeout = timeout
+        self._owns_channel = False
 
     @classmethod
     def connect(
@@ -410,7 +412,25 @@ class App:
         channel = host_service_channel(
             "app", target, token=token.strip(), binding=(name or "").strip()
         )
-        return cls(channel, context=context, timeout=timeout)
+        client = cls(channel, context=context, timeout=timeout)
+        client._owns_channel = True
+        return client
+
+    def close(self) -> None:
+        """Close the owned gRPC channel; a no-op for injected channels."""
+
+        if self._owns_channel:
+            self._channel.close()
+
+    def __enter__(self) -> App:
+        """Return the client for ``with`` statements."""
+
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        """Close the client at the end of a context manager block."""
+
+        self.close()
 
     @overload
     def invoke(self, request: AppInvokeRequest) -> Any: ...
@@ -558,9 +578,27 @@ class AppProvider:
         context: RequestContext | None = None,
         timeout: float | None = None,
     ) -> None:
+        self._channel = channel
         self._stub = _app_pb2_grpc.AppProviderStub(channel)
         self._context = context
         self._timeout = timeout
+        self._owns_channel = False
+
+    def close(self) -> None:
+        """Close the owned gRPC channel; a no-op for injected channels."""
+
+        if self._owns_channel:
+            self._channel.close()
+
+    def __enter__(self) -> AppProvider:
+        """Return the client for ``with`` statements."""
+
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        """Close the client at the end of a context manager block."""
+
+        self.close()
 
     def get_metadata(self) -> ProviderMetadata:
         response = _support.call_unary(

--- a/sdk/python/gestalt/authorization.py
+++ b/sdk/python/gestalt/authorization.py
@@ -304,8 +304,10 @@ class Authorization:
     """Client for the gestalt.provider.v1.Authorization service."""
 
     def __init__(self, channel: grpc.Channel, *, timeout: float | None = None) -> None:
+        self._channel = channel
         self._stub = _authorization_pb2_grpc.AuthorizationStub(channel)
         self._timeout = timeout
+        self._owns_channel = False
 
     @classmethod
     def connect(
@@ -318,7 +320,25 @@ class Authorization:
         channel = host_service_channel(
             "authorization", target, token=token.strip(), binding=(name or "").strip()
         )
-        return cls(channel, timeout=timeout)
+        client = cls(channel, timeout=timeout)
+        client._owns_channel = True
+        return client
+
+    def close(self) -> None:
+        """Close the owned gRPC channel; a no-op for injected channels."""
+
+        if self._owns_channel:
+            self._channel.close()
+
+    def __enter__(self) -> Authorization:
+        """Return the client for ``with`` statements."""
+
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        """Close the client at the end of a context manager block."""
+
+        self.close()
 
     @overload
     def check_access(self, request: CheckAccessRequest) -> CheckAccessResponse: ...

--- a/sdk/python/gestalt/cache.py
+++ b/sdk/python/gestalt/cache.py
@@ -135,8 +135,10 @@ class Cache:
     """
 
     def __init__(self, channel: grpc.Channel, *, timeout: float | None = None) -> None:
+        self._channel = channel
         self._stub = _cache_pb2_grpc.CacheStub(channel)
         self._timeout = timeout
+        self._owns_channel = False
 
     @classmethod
     def connect(cls, name: str | None = None, *, timeout: float | None = None) -> Cache:
@@ -147,7 +149,25 @@ class Cache:
         channel = host_service_channel(
             "cache", target, token=token.strip(), binding=(name or "").strip()
         )
-        return cls(channel, timeout=timeout)
+        client = cls(channel, timeout=timeout)
+        client._owns_channel = True
+        return client
+
+    def close(self) -> None:
+        """Close the owned gRPC channel; a no-op for injected channels."""
+
+        if self._owns_channel:
+            self._channel.close()
+
+    def __enter__(self) -> Cache:
+        """Return the client for ``with`` statements."""
+
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        """Close the client at the end of a context manager block."""
+
+        self.close()
 
     @overload
     def get(self, request: CacheGetRequest) -> bytes | None: ...

--- a/sdk/python/gestalt/external_credential.py
+++ b/sdk/python/gestalt/external_credential.py
@@ -209,8 +209,10 @@ class ExternalCredentials:
     """Client for the gestalt.provider.v1.ExternalCredentials service."""
 
     def __init__(self, channel: grpc.Channel, *, timeout: float | None = None) -> None:
+        self._channel = channel
         self._stub = _external_credential_pb2_grpc.ExternalCredentialsStub(channel)
         self._timeout = timeout
+        self._owns_channel = False
 
     @classmethod
     def connect(
@@ -226,7 +228,25 @@ class ExternalCredentials:
             token=token.strip(),
             binding=(name or "").strip(),
         )
-        return cls(channel, timeout=timeout)
+        client = cls(channel, timeout=timeout)
+        client._owns_channel = True
+        return client
+
+    def close(self) -> None:
+        """Close the owned gRPC channel; a no-op for injected channels."""
+
+        if self._owns_channel:
+            self._channel.close()
+
+    def __enter__(self) -> ExternalCredentials:
+        """Return the client for ``with`` statements."""
+
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        """Close the client at the end of a context manager block."""
+
+        self.close()
 
     @overload
     def create_credential(

--- a/sdk/python/gestalt/identity.py
+++ b/sdk/python/gestalt/identity.py
@@ -179,8 +179,10 @@ class Identity:
     """
 
     def __init__(self, channel: grpc.Channel, *, timeout: float | None = None) -> None:
+        self._channel = channel
         self._stub = _identity_pb2_grpc.IdentityStub(channel)
         self._timeout = timeout
+        self._owns_channel = False
 
     @classmethod
     def connect(
@@ -193,7 +195,25 @@ class Identity:
         channel = host_service_channel(
             "identity", target, token=token.strip(), binding=(name or "").strip()
         )
-        return cls(channel, timeout=timeout)
+        client = cls(channel, timeout=timeout)
+        client._owns_channel = True
+        return client
+
+    def close(self) -> None:
+        """Close the owned gRPC channel; a no-op for injected channels."""
+
+        if self._owns_channel:
+            self._channel.close()
+
+    def __enter__(self) -> Identity:
+        """Return the client for ``with`` statements."""
+
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        """Close the client at the end of a context manager block."""
+
+        self.close()
 
     @overload
     def authorize(self, request: AuthorizeRequest) -> AuthorizeResponse: ...

--- a/sdk/python/gestalt/indexeddb.py
+++ b/sdk/python/gestalt/indexeddb.py
@@ -735,8 +735,10 @@ class IndexedDB:
     """
 
     def __init__(self, channel: grpc.Channel, *, timeout: float | None = None) -> None:
+        self._channel = channel
         self._stub = _indexeddb_pb2_grpc.IndexedDBStub(channel)
         self._timeout = timeout
+        self._owns_channel = False
 
     @classmethod
     def connect(
@@ -749,7 +751,25 @@ class IndexedDB:
         channel = host_service_channel(
             "indexeddb", target, token=token.strip(), binding=(name or "").strip()
         )
-        return cls(channel, timeout=timeout)
+        client = cls(channel, timeout=timeout)
+        client._owns_channel = True
+        return client
+
+    def close(self) -> None:
+        """Close the owned gRPC channel; a no-op for injected channels."""
+
+        if self._owns_channel:
+            self._channel.close()
+
+    def __enter__(self) -> IndexedDB:
+        """Return the client for ``with`` statements."""
+
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        """Close the client at the end of a context manager block."""
+
+        self.close()
 
     @overload
     def create_object_store(self, request: CreateObjectStoreRequest) -> None: ...

--- a/sdk/python/gestalt/runtime.py
+++ b/sdk/python/gestalt/runtime.py
@@ -102,8 +102,26 @@ class ProviderLifecycle:
     """
 
     def __init__(self, channel: grpc.Channel, *, timeout: float | None = None) -> None:
+        self._channel = channel
         self._stub = _runtime_pb2_grpc.ProviderLifecycleStub(channel)
         self._timeout = timeout
+        self._owns_channel = False
+
+    def close(self) -> None:
+        """Close the owned gRPC channel; a no-op for injected channels."""
+
+        if self._owns_channel:
+            self._channel.close()
+
+    def __enter__(self) -> ProviderLifecycle:
+        """Return the client for ``with`` statements."""
+
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        """Close the client at the end of a context manager block."""
+
+        self.close()
 
     def get_provider_identity(self) -> ProviderIdentity:
         response = _support.call_unary(

--- a/sdk/python/gestalt/runtime_provider.py
+++ b/sdk/python/gestalt/runtime_provider.py
@@ -146,8 +146,26 @@ class Runtime:
     """Client for the gestalt.provider.v1.Runtime service."""
 
     def __init__(self, channel: grpc.Channel, *, timeout: float | None = None) -> None:
+        self._channel = channel
         self._stub = _runtime_provider_pb2_grpc.RuntimeStub(channel)
         self._timeout = timeout
+        self._owns_channel = False
+
+    def close(self) -> None:
+        """Close the owned gRPC channel; a no-op for injected channels."""
+
+        if self._owns_channel:
+            self._channel.close()
+
+    def __enter__(self) -> Runtime:
+        """Return the client for ``with`` statements."""
+
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        """Close the client at the end of a context manager block."""
+
+        self.close()
 
     def get_support(self) -> RuntimeSupport:
         response = _support.call_unary(

--- a/sdk/python/gestalt/s3.py
+++ b/sdk/python/gestalt/s3.py
@@ -258,8 +258,10 @@ class S3:
     """
 
     def __init__(self, channel: grpc.Channel, *, timeout: float | None = None) -> None:
+        self._channel = channel
         self._stub = _s3_pb2_grpc.S3Stub(channel)
         self._timeout = timeout
+        self._owns_channel = False
 
     @classmethod
     def connect(cls, name: str | None = None, *, timeout: float | None = None) -> S3:
@@ -270,7 +272,25 @@ class S3:
         channel = host_service_channel(
             "s3", target, token=token.strip(), binding=(name or "").strip()
         )
-        return cls(channel, timeout=timeout)
+        client = cls(channel, timeout=timeout)
+        client._owns_channel = True
+        return client
+
+    def close(self) -> None:
+        """Close the owned gRPC channel; a no-op for injected channels."""
+
+        if self._owns_channel:
+            self._channel.close()
+
+    def __enter__(self) -> S3:
+        """Return the client for ``with`` statements."""
+
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        """Close the client at the end of a context manager block."""
+
+        self.close()
 
     @overload
     def head_object(self, request: HeadObjectRequest) -> HeadObjectResponse: ...
@@ -530,8 +550,26 @@ class S3ObjectAccess:
     """
 
     def __init__(self, channel: grpc.Channel, *, timeout: float | None = None) -> None:
+        self._channel = channel
         self._stub = _s3_pb2_grpc.S3ObjectAccessStub(channel)
         self._timeout = timeout
+        self._owns_channel = False
+
+    def close(self) -> None:
+        """Close the owned gRPC channel; a no-op for injected channels."""
+
+        if self._owns_channel:
+            self._channel.close()
+
+    def __enter__(self) -> S3ObjectAccess:
+        """Return the client for ``with`` statements."""
+
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        """Close the client at the end of a context manager block."""
+
+        self.close()
 
     @overload
     def create_object_access_url(

--- a/sdk/python/gestalt/secrets.py
+++ b/sdk/python/gestalt/secrets.py
@@ -35,8 +35,26 @@ class Secrets:
     """
 
     def __init__(self, channel: grpc.Channel, *, timeout: float | None = None) -> None:
+        self._channel = channel
         self._stub = _secrets_pb2_grpc.SecretsStub(channel)
         self._timeout = timeout
+        self._owns_channel = False
+
+    def close(self) -> None:
+        """Close the owned gRPC channel; a no-op for injected channels."""
+
+        if self._owns_channel:
+            self._channel.close()
+
+    def __enter__(self) -> Secrets:
+        """Return the client for ``with`` statements."""
+
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        """Close the client at the end of a context manager block."""
+
+        self.close()
 
     @overload
     def get_secret(self, request: GetSecretRequest) -> str: ...

--- a/sdk/python/gestalt/test.py
+++ b/sdk/python/gestalt/test.py
@@ -35,8 +35,26 @@ class Test:
     """
 
     def __init__(self, channel: grpc.Channel, *, timeout: float | None = None) -> None:
+        self._channel = channel
         self._stub = _test_pb2_grpc.TestStub(channel)
         self._timeout = timeout
+        self._owns_channel = False
+
+    def close(self) -> None:
+        """Close the owned gRPC channel; a no-op for injected channels."""
+
+        if self._owns_channel:
+            self._channel.close()
+
+    def __enter__(self) -> Test:
+        """Return the client for ``with`` statements."""
+
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        """Close the client at the end of a context manager block."""
+
+        self.close()
 
     def hello_world(self, request: HelloWorldRequest) -> str:
         response = _codec.from_wire_hello_world_response(

--- a/sdk/python/gestalt/workflow.py
+++ b/sdk/python/gestalt/workflow.py
@@ -555,9 +555,11 @@ class Workflow:
         context: RequestContext | None = None,
         timeout: float | None = None,
     ) -> None:
+        self._channel = channel
         self._stub = _workflow_pb2_grpc.WorkflowStub(channel)
         self._context = context
         self._timeout = timeout
+        self._owns_channel = False
 
     @classmethod
     def connect(
@@ -574,7 +576,25 @@ class Workflow:
         channel = host_service_channel(
             "workflow", target, token=token.strip(), binding=(name or "").strip()
         )
-        return cls(channel, context=context, timeout=timeout)
+        client = cls(channel, context=context, timeout=timeout)
+        client._owns_channel = True
+        return client
+
+    def close(self) -> None:
+        """Close the owned gRPC channel; a no-op for injected channels."""
+
+        if self._owns_channel:
+            self._channel.close()
+
+    def __enter__(self) -> Workflow:
+        """Return the client for ``with`` statements."""
+
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        """Close the client at the end of a context manager block."""
+
+        self.close()
 
     @overload
     def apply_definition(

--- a/sdk/tools/sdkgen/internal/emit/python/render.go
+++ b/sdk/tools/sdkgen/internal/emit/python/render.go
@@ -591,13 +591,17 @@ func (r *renderer) renderClient(svc *model.Service) {
 	if ctxField != nil {
 		ctxType := r.fieldType(ctxField)
 		fmt.Fprintf(&r.body, "    def __init__(self, channel: grpc.Channel, *, context: %s | None = None, timeout: float | None = None) -> None:\n", ctxType)
+		r.body.WriteString("        self._channel = channel\n")
 		fmt.Fprintf(&r.body, "        self._stub = %s.%sStub(channel)\n", r.wireGrpcModule(), wireName)
 		r.body.WriteString("        self._context = context\n")
-		r.body.WriteString("        self._timeout = timeout\n\n")
+		r.body.WriteString("        self._timeout = timeout\n")
+		r.body.WriteString("        self._owns_channel = False\n\n")
 	} else {
 		r.body.WriteString("    def __init__(self, channel: grpc.Channel, *, timeout: float | None = None) -> None:\n")
+		r.body.WriteString("        self._channel = channel\n")
 		fmt.Fprintf(&r.body, "        self._stub = %s.%sStub(channel)\n", r.wireGrpcModule(), wireName)
-		r.body.WriteString("        self._timeout = timeout\n\n")
+		r.body.WriteString("        self._timeout = timeout\n")
+		r.body.WriteString("        self._owns_channel = False\n\n")
 	}
 
 	if svc.HostBinding != "" {
@@ -620,8 +624,24 @@ func (r *renderer) renderClient(svc *model.Service) {
 		r.body.WriteString("        channel = host_service_channel(\n")
 		fmt.Fprintf(&r.body, "            %q, target, token=token.strip(), binding=(name or \"\").strip()\n", svc.HostBinding)
 		r.body.WriteString("        )\n")
-		fmt.Fprintf(&r.body, "        return cls(%s)\n\n", forward)
+		fmt.Fprintf(&r.body, "        client = cls(%s)\n", forward)
+		r.body.WriteString("        client._owns_channel = True\n")
+		r.body.WriteString("        return client\n\n")
 	}
+
+	r.body.WriteString("    def close(self) -> None:\n")
+	r.writeDocstring("        ", "Close the owned gRPC channel; a no-op for injected channels.")
+	r.body.WriteString("\n")
+	r.body.WriteString("        if self._owns_channel:\n")
+	r.body.WriteString("            self._channel.close()\n\n")
+	fmt.Fprintf(&r.body, "    def __enter__(self) -> %s:\n", name)
+	r.writeDocstring("        ", "Return the client for ``with`` statements.")
+	r.body.WriteString("\n")
+	r.body.WriteString("        return self\n\n")
+	r.body.WriteString("    def __exit__(self, *args: object) -> None:\n")
+	r.writeDocstring("        ", "Close the client at the end of a context manager block.")
+	r.body.WriteString("\n")
+	r.body.WriteString("        self.close()\n\n")
 
 	for _, method := range svc.Methods {
 		r.renderMethod(method)


### PR DESCRIPTION
Emit close() and context-manager lifecycle on generated Python SDK clients.

The Python emitter now retains the gRPC channel, tracks ownership for connect()-created clients, and generates close()/__enter__/__exit__ so request.app() and other host-bound clients match the documented contract and stop leaking channels.

Made with [Cursor](https://cursor.com)