### PR TITLE
[gestaltd] Add /activate endpoint to trigger deferred app provider startup

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -261,8 +261,16 @@ type Result struct {
 	workflowConfigReconcileTasks        []workflowConfigReconcileTask
 	workflowConfigReconcileTasksStarted bool
 	auditClose                          func(context.Context) error
+	activateAppProviders                func(context.Context)
 	mu                                  sync.Mutex
 	closed                              bool
+}
+
+func (r *Result) ActivateAppProviders(ctx context.Context) {
+	if r == nil || r.activateAppProviders == nil {
+		return
+	}
+	r.activateAppProviders(ctx)
 }
 
 type workflowConfigReconcileTask struct {
@@ -1248,7 +1256,16 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 
 	var updateConnAuth func() map[string]map[string]OAuthHandler
 	var updateManualConnAuth func() map[string]map[string]ManualTokenExchanger
-	providersReady, updateConnAuth, updateManualConnAuth, _ = updateBuilds.Start(ctx, prepared.Deps, buildProvider)
+	activateAppProviders := newProviderActivation(updateBuilds, prepared.Deps, buildProvider, func(
+		ready <-chan struct{},
+		connAuth func() map[string]map[string]OAuthHandler,
+		manualConnAuth func() map[string]map[string]ManualTokenExchanger,
+	) {
+		providersReady = ready
+		updateConnAuth = connAuth
+		updateManualConnAuth = manualConnAuth
+	})
+	activateAppProviders(ctx)
 
 	connAuthResolver = func() map[string]map[string]OAuthHandler {
 		b := updateConnAuth()
@@ -1336,6 +1353,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		runtimeRegistry:              prepared.runtimeRegistry,
 		workflowConfigReconcileTasks: deferredWorkflowConfigReconcileTasks,
 		auditClose:                   auditClose,
+		activateAppProviders:         activateAppProviders,
 	}, nil
 }
 

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -5365,6 +5365,33 @@ func TestBootstrapNoIntegrations(t *testing.T) {
 	}
 }
 
+func TestBootstrapActivateAppProvidersIsIdempotentAfterAutoStart(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	result, err := bootstrap.Bootstrap(ctx, validConfig(), validFactories())
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := result.Close(context.Background()); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	})
+
+	result.ActivateAppProviders(ctx)
+	result.ActivateAppProviders(ctx)
+
+	<-result.ProvidersReady
+}
+
+func TestResultActivateAppProvidersNilReceiverIsSafe(t *testing.T) {
+	t.Parallel()
+
+	var result *bootstrap.Result
+	result.ActivateAppProviders(context.Background())
+}
+
 func TestBootstrap_ReusesPreparedComponentRuntimeConfig(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/bootstrap/provider_activation_test.go
+++ b/gestaltd/internal/bootstrap/provider_activation_test.go
@@ -1,0 +1,70 @@
+package bootstrap
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+)
+
+func TestNewProviderActivationStartsProvidersOnce(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Apps: map[string]*config.ProviderEntry{
+			"noop": {Source: config.ProviderSource{Path: "stub"}},
+		},
+	}
+	builds, err := prepareProviderBuilds(cfg, NewFactoryRegistry(), Deps{})
+	if err != nil {
+		t.Fatalf("prepareProviderBuilds: %v", err)
+	}
+	t.Cleanup(func() { _ = CloseProviders(builds.providers) })
+
+	var builderCalls atomic.Int32
+	builder := func(context.Context, string, *config.ProviderEntry, Deps) (*ProviderBuildResult, error) {
+		builderCalls.Add(1)
+		return &ProviderBuildResult{Provider: &coretesting.StubIntegration{N: "noop"}}, nil
+	}
+
+	var gotReady <-chan struct{}
+	activate := newProviderActivation(builds, Deps{}, builder, func(
+		ready <-chan struct{},
+		_ func() map[string]map[string]OAuthHandler,
+		_ func() map[string]map[string]ManualTokenExchanger,
+	) {
+		gotReady = ready
+	})
+
+	done := make(chan struct{})
+	go func() {
+		activate(context.Background())
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ActivateAppProviders blocked instead of firing goroutines and returning")
+	}
+
+	if gotReady == nil {
+		t.Fatal("expected onStart to be invoked with a ready channel")
+	}
+	select {
+	case <-gotReady:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for provider build to complete")
+	}
+	if got := builderCalls.Load(); got != 1 {
+		t.Fatalf("builder calls after first activation = %d, want 1", got)
+	}
+
+	activate(context.Background())
+	activate(context.Background())
+	if got := builderCalls.Load(); got != 1 {
+		t.Fatalf("builder calls after repeated activation = %d, want 1 (idempotent)", got)
+	}
+}

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -259,6 +259,25 @@ func (b *preparedProviderBuilds) Start(
 	return ready, resolver, manualResolver, errResolver
 }
 
+func newProviderActivation(
+	b *preparedProviderBuilds,
+	deps Deps,
+	builder func(context.Context, string, *config.ProviderEntry, Deps) (*ProviderBuildResult, error),
+	onStart func(
+		ready <-chan struct{},
+		connAuth func() map[string]map[string]OAuthHandler,
+		manualConnAuth func() map[string]map[string]ManualTokenExchanger,
+	),
+) func(context.Context) {
+	var once sync.Once
+	return func(ctx context.Context) {
+		once.Do(func() {
+			ready, connAuth, manualConnAuth, _ := b.Start(ctx, deps, builder)
+			onStart(ready, connAuth, manualConnAuth)
+		})
+	}
+}
+
 func validateProviderConnectionMode(provider string, mode core.ConnectionMode) error {
 	switch core.NormalizeConnectionMode(mode) {
 	case core.ConnectionModeNone, core.ConnectionModeSubject:

--- a/gestaltd/internal/server/handlers_activate.go
+++ b/gestaltd/internal/server/handlers_activate.go
@@ -1,0 +1,18 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func (s *Server) mountActivateRoute(r chi.Router) {
+	r.Post("/activate", s.activateAppProvidersHandler)
+}
+
+func (s *Server) activateAppProvidersHandler(w http.ResponseWriter, r *http.Request) {
+	if s.activateAppProviders != nil {
+		s.activateAppProviders(r.Context())
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}

--- a/gestaltd/internal/server/handlers_activate_test.go
+++ b/gestaltd/internal/server/handlers_activate_test.go
@@ -1,0 +1,81 @@
+package server_test
+
+import (
+	"context"
+	"net/http"
+	"sync/atomic"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/server"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+)
+
+func TestActivateAppProvidersEndpointTriggersActivation(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	srv := newTestServer(t, func(cfg *server.Config) {
+		cfg.ActivateAppProviders = func(context.Context) { calls.Add(1) }
+	})
+	testutil.CloseOnCleanup(t, srv)
+
+	for i := 1; i <= 2; i++ {
+		resp, err := http.Post(srv.URL+"/activate", "", nil)
+		if err != nil {
+			t.Fatalf("POST /activate: %v", err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("call %d: status = %d, want %d", i, resp.StatusCode, http.StatusOK)
+		}
+		if got := calls.Load(); got != int32(i) {
+			t.Fatalf("call %d: activation calls = %d, want %d", i, got, i)
+		}
+	}
+}
+
+func TestActivateAppProvidersEndpointNotExposedOnPublicRouteProfile(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	srv := newTestServer(t, func(cfg *server.Config) {
+		cfg.RouteProfile = server.RouteProfilePublic
+		cfg.ActivateAppProviders = func(context.Context) { calls.Add(1) }
+	})
+	testutil.CloseOnCleanup(t, srv)
+
+	resp, err := http.Post(srv.URL+"/activate", "", nil)
+	if err != nil {
+		t.Fatalf("POST /activate: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+	if got := calls.Load(); got != 0 {
+		t.Fatalf("activation calls = %d, want 0 on public route profile", got)
+	}
+}
+
+func TestActivateAppProvidersEndpointExposedOnManagementRouteProfile(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	srv := newTestServer(t, func(cfg *server.Config) {
+		cfg.RouteProfile = server.RouteProfileManagement
+		cfg.ActivateAppProviders = func(context.Context) { calls.Add(1) }
+	})
+	testutil.CloseOnCleanup(t, srv)
+
+	resp, err := http.Post(srv.URL+"/activate", "", nil)
+	if err != nil {
+		t.Fatalf("POST /activate: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("activation calls = %d, want 1", got)
+	}
+}

--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -33,6 +33,7 @@ func (s *Server) routes() {
 		s.mountManagementRootRedirect(r)
 		s.mountAdminAPIRoutes(r)
 		s.mountAdminUIRoutes(r)
+		s.mountActivateRoute(r)
 	default:
 		s.mountCoreRoutes(r, metricsAuthenticated)
 		s.mountMCPRoutes(r)
@@ -42,6 +43,7 @@ func (s *Server) routes() {
 		s.mountMountedUIRoutes(r)
 		s.mountAdminAPIRoutes(r)
 		s.mountAdminUIRoutes(r)
+		s.mountActivateRoute(r)
 	}
 }
 
@@ -145,6 +147,7 @@ func (s *Server) mountManagementHiddenRoutes(r chi.Router) {
 	r.Handle("/admin/api/v1/*", notFound)
 	r.Handle("/admin", notFound)
 	r.Handle("/admin/*", notFound)
+	r.Handle("/activate", notFound)
 }
 
 func (s *Server) mountMCPRoutes(r chi.Router) {

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -99,6 +99,7 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 		Readiness:            runtimeReadinessStatus(workflowProvidersReady, result.Services),
 		PrometheusMetrics:    result.Telemetry.PrometheusHandler(),
 		PublicHostServices:   result.PublicHostServices,
+		ActivateAppProviders: result.ActivateAppProviders,
 		Admin: AdminRouteConfig{
 			AuthorizationPolicy: cfg.Server.Admin.AuthorizationPolicy,
 			AllowedRoles:        append([]string(nil), cfg.Server.Admin.AllowedRoles...),

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -140,6 +141,7 @@ type Server struct {
 	adminRoute             AdminRouteConfig
 	adminUI                http.Handler
 	routeProfile           RouteProfile
+	activateAppProviders   func(context.Context)
 }
 
 func (s *Server) catalogSelectorConfig() invocation.CatalogSelectorConfig {
@@ -195,6 +197,7 @@ type Config struct {
 	RouteProfile         RouteProfile
 	MeterProvider        metric.MeterProvider
 	TracerProvider       trace.TracerProvider
+	ActivateAppProviders func(context.Context)
 }
 
 func New(cfg Config) (*Server, error) {
@@ -393,6 +396,7 @@ func New(cfg Config) (*Server, error) {
 		adminRoute:             adminRoute,
 		adminUI:                adminUI,
 		routeProfile:           cfg.RouteProfile,
+		activateAppProviders:   cfg.ActivateAppProviders,
 	}
 	s.workflowSchedules = workflowmanager.New(workflowmanager.Config{
 		Providers:         cfg.Providers,


### PR DESCRIPTION
## Description

Adds a `POST /activate` endpoint on the management listener that triggers app provider startup via a new `Result.ActivateAppProviders`. Bootstrap still starts providers automatically today, so this is purely additive — the endpoint wraps `providerBuilds.Start` in a `sync.Once` so it's safe to call even after bootstrap already started providers, laying the groundwork for deferring provider startup in a later change.