### PR TITLE
[ci] install buf from prebuilt binary instead of go install

### DIFF
--- a/.github/workflows/build-sdkgen.yml
+++ b/.github/workflows/build-sdkgen.yml
@@ -60,8 +60,10 @@ jobs:
           pin="$(sed -n 's/^const BufVersion = "\(.*\)"$/\1/p' internal/toolchain/versions.go)"
           test -n "$pin"
           repo_root="$(git rev-parse --show-toplevel)"
-          if grep -RhoE 'buf/cmd/buf@v[0-9][0-9.]*' "$repo_root/.github/workflows" | grep -v "@v${pin}$"; then
+          mismatches="$(grep -RhoE 'buf/cmd/buf@v[0-9][0-9.]*|buf_version="v[0-9][0-9.]*"' "$repo_root/.github/workflows" | grep -vE "@v${pin}\$|=\"v${pin}\"\$" || true)"
+          if [[ -n "$mismatches" ]]; then
             echo "buf pins above do not match toolchain/versions.go (${pin})" >&2
+            printf '%s\n' "$mismatches" >&2
             exit 1
           fi
 

--- a/.github/workflows/validate-gestaltd.yml
+++ b/.github/workflows/validate-gestaltd.yml
@@ -73,8 +73,22 @@ jobs:
 
       - name: Install Buf
         if: ${{ needs.resolve-ref.outputs.should_validate == 'true' }}
-        working-directory: gestaltd
-        run: go install github.com/bufbuild/buf/cmd/buf@v1.66.1
+        run: |
+          set -euo pipefail
+          version="v1.66.1"
+          checksum="ef835cb38ed973849f68e0e6a88153cb2168507e09eecbec43a2ada2f6a698be"
+          bin_dir="$(go env GOPATH)/bin"
+          mkdir -p "${bin_dir}"
+          bin_path="${bin_dir}/buf"
+
+          curl -fsSLo "${bin_path}" \
+            "https://github.com/bufbuild/buf/releases/download/${version}/buf-Linux-x86_64"
+          actual_checksum="$(sha256sum "${bin_path}" | awk '{print $1}')"
+          if [ "${actual_checksum}" != "${checksum}" ]; then
+            echo "Checksum mismatch for buf ${version}: ${actual_checksum}" >&2
+            exit 1
+          fi
+          chmod +x "${bin_path}"
 
       - name: Check go mod tidy
         if: ${{ needs.resolve-ref.outputs.should_validate == 'true' }}

--- a/.github/workflows/validate-gestaltd.yml
+++ b/.github/workflows/validate-gestaltd.yml
@@ -75,17 +75,19 @@ jobs:
         if: ${{ needs.resolve-ref.outputs.should_validate == 'true' }}
         run: |
           set -euo pipefail
-          version="v1.66.1"
+          # buf_version is enforced against sdk/tools/sdkgen/internal/toolchain/versions.go
+          # (BufVersion) by the "Verify buf pin consistency" step in build-sdkgen.yml.
+          buf_version="v1.66.1"
           checksum="ef835cb38ed973849f68e0e6a88153cb2168507e09eecbec43a2ada2f6a698be"
           bin_dir="$(go env GOPATH)/bin"
           mkdir -p "${bin_dir}"
           bin_path="${bin_dir}/buf"
 
           curl -fsSLo "${bin_path}" \
-            "https://github.com/bufbuild/buf/releases/download/${version}/buf-Linux-x86_64"
+            "https://github.com/bufbuild/buf/releases/download/${buf_version}/buf-Linux-x86_64"
           actual_checksum="$(sha256sum "${bin_path}" | awk '{print $1}')"
           if [ "${actual_checksum}" != "${checksum}" ]; then
-            echo "Checksum mismatch for buf ${version}: ${actual_checksum}" >&2
+            echo "Checksum mismatch for buf ${buf_version}: ${actual_checksum}" >&2
             exit 1
           fi
           chmod +x "${bin_path}"


### PR DESCRIPTION
## Description
The `Install Buf` step in `validate-gestaltd.yml` used to run `go install .../buf@v1.66.1`, which compiles buf and its entire dependency tree from source on every CI run (~60s). This switches to downloading the prebuilt Linux release binary with checksum verification, matching the pattern already used for `kubeconform` in the same workflow.