### PR TITLE
[ci] give the cross-compiled binary build its own Go cache key

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -181,14 +181,6 @@ jobs:
         with:
           go-version-file: gestaltd/go.mod
           cache-dependency-path: gestaltd/go.sum
-      # setup-go's own cache is keyed only by OS + go.sum, the same key the
-      # lint/test jobs use for a default (CGO_ENABLED=1, native-arch) build.
-      # This job cross-compiles with CGO_ENABLED=0 for four GOOS/GOARCH
-      # combinations, none of which share build cache entries with that
-      # default build, but a cache already exists under that key by the time
-      # this job runs — so this job's own compiled objects were never able to
-      # be saved back. A separate cache under a job-specific key lets its
-      # cross-compiled build cache actually persist across runs.
       - name: Cache Go build cache (cross-compiled binaries)
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -181,6 +181,23 @@ jobs:
         with:
           go-version-file: gestaltd/go.mod
           cache-dependency-path: gestaltd/go.sum
+      # setup-go's own cache is keyed only by OS + go.sum, the same key the
+      # lint/test jobs use for a default (CGO_ENABLED=1, native-arch) build.
+      # This job cross-compiles with CGO_ENABLED=0 for four GOOS/GOARCH
+      # combinations, none of which share build cache entries with that
+      # default build, but a cache already exists under that key by the time
+      # this job runs — so this job's own compiled objects were never able to
+      # be saved back. A separate cache under a job-specific key lets its
+      # cross-compiled build cache actually persist across runs.
+      - name: Cache Go build cache (cross-compiled binaries)
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-gestaltd-publish-binaries-go-${{ hashFiles('gestaltd/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-gestaltd-publish-binaries-go-
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
         with:


### PR DESCRIPTION
## Description
The `publish-binaries` job's `go build` calls (~80s each, for four GOOS/GOARCH targets) never benefited from Go's build cache: `setup-go`'s automatic cache is keyed only by OS + `go.sum`, the same key the lint/test jobs populate with a default `CGO_ENABLED=1` native-arch build. Since this job cross-compiles with `CGO_ENABLED=0` — a flag that changes the build cache ID for nearly every package — none of its compiled objects match that cache, but because a cache already exists under that shared key, this job could never save its own additions back (GitHub's cache service won't overwrite an existing key). This adds a dedicated `actions/cache` step keyed specifically for this job, so its cross-compiled build cache actually persists and gets reused across runs.