### PR TITLE
[gestaltd] Gate /ready on workflow provider startup

### DIFF
--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -264,12 +264,6 @@ func serveRuntime(ctx context.Context, cfg *config.Config, connMaps bootstrap.Co
 			workflowErr <- err
 			return
 		}
-		// The workflow provider promotes this build to the deployment's current
-		// Temporal version inside the StartProvider RPC that StartWorkflowProviders
-		// drives, so a successful return means promotion is confirmed. Only now is
-		// /ready allowed to report ready — if promotion fails, the channel never
-		// closes, /ready never returns, and the Cloud Run deploy fails without
-		// shifting traffic.
 		close(workflowProvidersReady)
 
 		result.StartWorkflowConfigReconciliation(ctx)

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -258,14 +258,20 @@ func serveRuntime(ctx context.Context, cfg *config.Config, connMaps bootstrap.Co
 		}
 	}()
 
-	close(workflowProvidersReady)
-
 	workflowErr := make(chan error, 1)
 	go func() {
 		if err := result.StartWorkflowProviders(ctx); err != nil {
 			workflowErr <- err
 			return
 		}
+		// The workflow provider promotes this build to the deployment's current
+		// Temporal version inside the StartProvider RPC that StartWorkflowProviders
+		// drives, so a successful return means promotion is confirmed. Only now is
+		// /ready allowed to report ready — if promotion fails, the channel never
+		// closes, /ready never returns, and the Cloud Run deploy fails without
+		// shifting traffic.
+		close(workflowProvidersReady)
+
 		result.StartWorkflowConfigReconciliation(ctx)
 		slog.Info("workflow providers ready", "count", len(result.ExtraWorkflows))
 

--- a/gestaltd/internal/server/runtime_test.go
+++ b/gestaltd/internal/server/runtime_test.go
@@ -77,8 +77,6 @@ func TestRuntimeReadinessStatusChecksIndexedDBAfterProviders(t *testing.T) {
 	}
 }
 
-// gatedWorkflowProvider is a coreworkflow.Provider whose Start blocks until its
-// gate is released, so a test can observe readiness while startup is in flight.
 type gatedWorkflowProvider struct {
 	coreworkflow.Provider
 	started chan struct{}
@@ -95,9 +93,6 @@ func (p *gatedWorkflowProvider) Start(ctx context.Context) error {
 	}
 }
 
-// TestServeRuntimeReadyAfterWorkflowProvidersStart proves the /ready gate stays
-// closed until StartWorkflowProviders returns — the provider's Temporal promotion
-// runs inside that call, so readiness must not flip before it completes.
 func TestServeRuntimeReadyAfterWorkflowProvidersStart(t *testing.T) {
 	t.Parallel()
 
@@ -123,8 +118,6 @@ func TestServeRuntimeReadyAfterWorkflowProvidersStart(t *testing.T) {
 	serveDone := make(chan struct{})
 	go func() {
 		defer close(serveDone)
-		// Invoker is nil, so newMCPHandler returns an error after the ready gate
-		// closes and serveRuntime unwinds — which is fine for this test.
 		_ = serveRuntime(ctx, &config.Config{}, bootstrap.ConnectionMaps{}, result, nil, servers, &switchableHandler{}, workflowProvidersReady, nil)
 	}()
 

--- a/gestaltd/internal/server/runtime_test.go
+++ b/gestaltd/internal/server/runtime_test.go
@@ -99,6 +99,8 @@ func (p *gatedWorkflowProvider) Start(ctx context.Context) error {
 // closed until StartWorkflowProviders returns — the provider's Temporal promotion
 // runs inside that call, so readiness must not flip before it completes.
 func TestServeRuntimeReadyAfterWorkflowProvidersStart(t *testing.T) {
+	t.Parallel()
+
 	provider := &gatedWorkflowProvider{
 		started: make(chan struct{}),
 		gate:    make(chan struct{}),
@@ -139,10 +141,7 @@ func TestServeRuntimeReadyAfterWorkflowProvidersStart(t *testing.T) {
 	close(provider.gate)
 
 	deadline := time.After(5 * time.Second)
-	for {
-		if ready() == "" {
-			break
-		}
+	for ready() != "" {
 		select {
 		case <-deadline:
 			t.Fatal("readiness never became ready after workflow providers started")

--- a/gestaltd/internal/server/runtime_test.go
+++ b/gestaltd/internal/server/runtime_test.go
@@ -10,7 +10,9 @@ import (
 	"time"
 
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"github.com/valon-technologies/gestalt/server/services/apps/registry"
@@ -73,6 +75,83 @@ func TestRuntimeReadinessStatusChecksIndexedDBAfterProviders(t *testing.T) {
 	if got := check(); got != "indexeddb unavailable" {
 		t.Fatalf("readiness with indexeddb error = %q, want %q", got, "indexeddb unavailable")
 	}
+}
+
+// gatedWorkflowProvider is a coreworkflow.Provider whose Start blocks until its
+// gate is released, so a test can observe readiness while startup is in flight.
+type gatedWorkflowProvider struct {
+	coreworkflow.Provider
+	started chan struct{}
+	gate    chan struct{}
+}
+
+func (p *gatedWorkflowProvider) Start(ctx context.Context) error {
+	close(p.started)
+	select {
+	case <-p.gate:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// TestServeRuntimeReadyAfterWorkflowProvidersStart proves the /ready gate stays
+// closed until StartWorkflowProviders returns — the provider's Temporal promotion
+// runs inside that call, so readiness must not flip before it completes.
+func TestServeRuntimeReadyAfterWorkflowProvidersStart(t *testing.T) {
+	provider := &gatedWorkflowProvider{
+		started: make(chan struct{}),
+		gate:    make(chan struct{}),
+	}
+	result := &bootstrap.Result{
+		ExtraWorkflows: []coreworkflow.Provider{provider},
+	}
+
+	workflowProvidersReady := make(chan struct{})
+	ready := runtimeReadinessStatus(workflowProvidersReady, fakeIndexedDBPinger{})
+
+	servers := []namedHTTPServer{{
+		name:   "public",
+		server: newHTTPServer("127.0.0.1:0", http.NewServeMux()),
+	}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	serveDone := make(chan struct{})
+	go func() {
+		defer close(serveDone)
+		// Invoker is nil, so newMCPHandler returns an error after the ready gate
+		// closes and serveRuntime unwinds — which is fine for this test.
+		_ = serveRuntime(ctx, &config.Config{}, bootstrap.ConnectionMaps{}, result, nil, servers, &switchableHandler{}, workflowProvidersReady, nil)
+	}()
+
+	select {
+	case <-provider.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("workflow provider Start was never invoked")
+	}
+
+	if got := ready(); got != "workflow providers loading" {
+		t.Fatalf("readiness while workflow provider starting = %q, want %q", got, "workflow providers loading")
+	}
+
+	close(provider.gate)
+
+	deadline := time.After(5 * time.Second)
+	for {
+		if ready() == "" {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("readiness never became ready after workflow providers started")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	cancel()
+	<-serveDone
 }
 
 type runtimeTestCacheServer struct {


### PR DESCRIPTION
## Description

Gates `/ready` on workflow provider startup by moving `close(workflowProvidersReady)` to *after* `result.StartWorkflowProviders(ctx)` returns successfully (previously it closed before).

The Temporal workflow provider now promotes this build to the deployment's current version inside the `StartProvider` RPC that `StartWorkflowProviders` drives (see gestalt-providers#1106), so a successful return means promotion is confirmed. If promotion fails, the channel never closes, `/ready` never returns, and the Cloud Run deploy times out without shifting traffic — so the rollback story needs no explicit Temporal restore.

Part of the gestaltd deferred-app-startup plan (Step 2). Pairs with [gestalt-providers#1106](https://github.com/valon-technologies/gestalt-providers/pull/1106).