### PR TITLE
[gestaltd] Defer only version-changed app providers to /activate

### DIFF
--- a/gestaltd/internal/bootstrap/app_shas.go
+++ b/gestaltd/internal/bootstrap/app_shas.go
@@ -1,0 +1,58 @@
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+
+	idb "github.com/valon-technologies/gestalt/sdk/go/indexeddb"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
+	"github.com/valon-technologies/gestalt/server/services/apps/providerpkg"
+)
+
+// currentAppSHA returns the artifact SHA256 for the current platform from an
+// app's resolved manifest, or "" when unavailable (e.g. path/source providers
+// that carry no pinned artifact).
+func currentAppSHA(entry *config.ProviderEntry) string {
+	if entry == nil || entry.ResolvedManifest == nil {
+		return ""
+	}
+	artifact, err := providerpkg.CurrentPlatformArtifact(entry.ResolvedManifest)
+	if err != nil || artifact == nil {
+		return ""
+	}
+	return artifact.SHA256
+}
+
+// readAppSHAs returns the stored artifact SHA for each app, keyed by app name.
+// A nil db or read error yields an empty map, which makes every app look
+// version-changed — the safe default (start via /activate rather than skip).
+func readAppSHAs(ctx context.Context, db indexeddb.IndexedDB) map[string]string {
+	shas := make(map[string]string)
+	if db == nil {
+		return shas
+	}
+	records, err := db.ObjectStore(coredata.StoreAppSHAs).GetAll(ctx, nil)
+	if err != nil {
+		return shas
+	}
+	for _, record := range records {
+		name, _ := record["id"].(string)
+		sha, _ := record["sha"].(string)
+		if name != "" && sha != "" {
+			shas[name] = sha
+		}
+	}
+	return shas
+}
+
+// writeAppSHA persists the artifact SHA for a single app after it installs
+// successfully. Writing only on success means a failed install leaves the
+// stored SHA unchanged, so the next deploy still treats the app as changed.
+func writeAppSHA(ctx context.Context, db indexeddb.IndexedDB, appName, sha string) error {
+	if db == nil {
+		return fmt.Errorf("indexeddb is required to persist app sha")
+	}
+	return db.ObjectStore(coredata.StoreAppSHAs).Put(ctx, idb.Record{"id": appName, "sha": sha})
+}

--- a/gestaltd/internal/bootstrap/app_shas.go
+++ b/gestaltd/internal/bootstrap/app_shas.go
@@ -11,9 +11,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/apps/providerpkg"
 )
 
-// currentAppSHA returns the artifact SHA256 for the current platform from an
-// app's resolved manifest, or "" when unavailable (e.g. path/source providers
-// that carry no pinned artifact).
 func currentAppSHA(entry *config.ProviderEntry) string {
 	if entry == nil || entry.ResolvedManifest == nil {
 		return ""
@@ -25,9 +22,6 @@ func currentAppSHA(entry *config.ProviderEntry) string {
 	return artifact.SHA256
 }
 
-// readAppSHAs returns the stored artifact SHA for each app, keyed by app name.
-// A nil db or read error yields an empty map, which makes every app look
-// version-changed — the safe default (start via /activate rather than skip).
 func readAppSHAs(ctx context.Context, db indexeddb.IndexedDB) map[string]string {
 	shas := make(map[string]string)
 	if db == nil {
@@ -47,9 +41,6 @@ func readAppSHAs(ctx context.Context, db indexeddb.IndexedDB) map[string]string 
 	return shas
 }
 
-// writeAppSHA persists the artifact SHA for a single app after it installs
-// successfully. Writing only on success means a failed install leaves the
-// stored SHA unchanged, so the next deploy still treats the app as changed.
 func writeAppSHA(ctx context.Context, db indexeddb.IndexedDB, appName, sha string) error {
 	if db == nil {
 		return fmt.Errorf("indexeddb is required to persist app sha")

--- a/gestaltd/internal/bootstrap/app_shas_test.go
+++ b/gestaltd/internal/bootstrap/app_shas_test.go
@@ -1,0 +1,189 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"sync"
+	"testing"
+
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/apps/registry"
+)
+
+func entryWithArtifactSHA(sha string) *config.ProviderEntry {
+	return &config.ProviderEntry{
+		ResolvedManifest: &providermanifestv1.Manifest{
+			Artifacts: []providermanifestv1.Artifact{
+				{OS: runtime.GOOS, Arch: runtime.GOARCH, SHA256: sha},
+			},
+		},
+	}
+}
+
+func TestCurrentAppSHA(t *testing.T) {
+	t.Parallel()
+
+	if got := currentAppSHA(entryWithArtifactSHA("abc123")); got != "abc123" {
+		t.Fatalf("currentAppSHA = %q, want abc123", got)
+	}
+	if got := currentAppSHA(&config.ProviderEntry{}); got != "" {
+		t.Fatalf("currentAppSHA with no manifest = %q, want empty", got)
+	}
+	if got := currentAppSHA(nil); got != "" {
+		t.Fatalf("currentAppSHA(nil) = %q, want empty", got)
+	}
+}
+
+func TestAppStartupCategorizer(t *testing.T) {
+	t.Parallel()
+
+	stored := map[string]string{"match": "sha-1"}
+
+	cases := []struct {
+		name         string
+		autoActivate bool
+		app          string
+		entry        *config.ProviderEntry
+		want         AppStartupCategory
+	}{
+		{name: "matching sha starts immediately", app: "match", entry: entryWithArtifactSHA("sha-1"), want: AppStartupNOOP},
+		{name: "changed sha is deferred", app: "match", entry: entryWithArtifactSHA("sha-2"), want: AppStartupUpdate},
+		{name: "no stored sha is deferred", app: "fresh", entry: entryWithArtifactSHA("sha-1"), want: AppStartupUpdate},
+		{name: "no current sha is deferred", app: "match", entry: &config.ProviderEntry{}, want: AppStartupUpdate},
+		{name: "autoActivate forces immediate", autoActivate: true, app: "match", entry: entryWithArtifactSHA("sha-2"), want: AppStartupNOOP},
+		{name: "autoActivate immediate for path source", autoActivate: true, app: "fresh", entry: &config.ProviderEntry{}, want: AppStartupNOOP},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			categorize := newAppStartupCategorizer(stored, tc.autoActivate)
+			if got := categorize(tc.app, tc.entry); got != tc.want {
+				t.Fatalf("category = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveAutoActivate(t *testing.T) {
+	boolPtr := func(b bool) *bool { return &b }
+
+	t.Run("explicit true wins over K_REVISION", func(t *testing.T) {
+		t.Setenv("K_REVISION", "rev-123")
+		cfg := &config.Config{}
+		cfg.Server.AutoActivate = boolPtr(true)
+		if !resolveAutoActivate(cfg) {
+			t.Fatal("explicit autoActivate=true should win")
+		}
+	})
+	t.Run("explicit false wins with no K_REVISION", func(t *testing.T) {
+		t.Setenv("K_REVISION", "")
+		cfg := &config.Config{}
+		cfg.Server.AutoActivate = boolPtr(false)
+		if resolveAutoActivate(cfg) {
+			t.Fatal("explicit autoActivate=false should win")
+		}
+	})
+	t.Run("defaults true without K_REVISION", func(t *testing.T) {
+		t.Setenv("K_REVISION", "")
+		if !resolveAutoActivate(&config.Config{}) {
+			t.Fatal("should default to true when K_REVISION unset")
+		}
+	})
+	t.Run("defaults false with K_REVISION", func(t *testing.T) {
+		t.Setenv("K_REVISION", "rev-123")
+		if resolveAutoActivate(&config.Config{}) {
+			t.Fatal("should default to false when K_REVISION set")
+		}
+	})
+}
+
+func TestReadWriteAppSHAs(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	db := &coretesting.StubIndexedDB{}
+	if _, err := coredata.New(db); err != nil {
+		t.Fatalf("coredata.New: %v", err)
+	}
+
+	if got := readAppSHAs(ctx, db); len(got) != 0 {
+		t.Fatalf("expected empty SHAs initially, got %v", got)
+	}
+
+	if err := writeAppSHA(ctx, db, "github", "sha-gh"); err != nil {
+		t.Fatalf("writeAppSHA: %v", err)
+	}
+	if err := writeAppSHA(ctx, db, "slack", "sha-sl"); err != nil {
+		t.Fatalf("writeAppSHA: %v", err)
+	}
+
+	got := readAppSHAs(ctx, db)
+	if got["github"] != "sha-gh" || got["slack"] != "sha-sl" {
+		t.Fatalf("readAppSHAs = %v, want github=sha-gh slack=sha-sl", got)
+	}
+
+	if err := writeAppSHA(ctx, db, "github", "sha-gh-2"); err != nil {
+		t.Fatalf("writeAppSHA overwrite: %v", err)
+	}
+	if got := readAppSHAs(ctx, db); got["github"] != "sha-gh-2" {
+		t.Fatalf("readAppSHAs after overwrite = %q, want sha-gh-2", got["github"])
+	}
+}
+
+func TestReadAppSHAsNilDB(t *testing.T) {
+	t.Parallel()
+	if got := readAppSHAs(context.Background(), nil); len(got) != 0 {
+		t.Fatalf("readAppSHAs(nil) = %v, want empty", got)
+	}
+}
+
+func TestStartWritesSHAOnlyOnSuccessfulInstall(t *testing.T) {
+	t.Parallel()
+
+	reg := registry.New()
+	t.Cleanup(func() { _ = CloseProviders(&reg.Providers) })
+
+	builds := &preparedProviderBuilds{
+		providers:      &reg.Providers,
+		connAuth:       map[string]map[string]OAuthHandler{},
+		manualConnAuth: map[string]map[string]ManualTokenExchanger{},
+		pending: []pendingProviderBuild{
+			{name: "ok", entry: &config.ProviderEntry{}, sha: "sha-ok"},
+			{name: "fails", entry: &config.ProviderEntry{}, sha: "sha-fails"},
+			{name: "no-sha", entry: &config.ProviderEntry{}},
+		},
+	}
+
+	var mu sync.Mutex
+	written := map[string]string{}
+	builds.onInstalled = func(name, sha string) {
+		mu.Lock()
+		defer mu.Unlock()
+		written[name] = sha
+	}
+
+	builder := func(_ context.Context, name string, _ *config.ProviderEntry, _ Deps) (*ProviderBuildResult, error) {
+		if name == "fails" {
+			return nil, errors.New("boom")
+		}
+		return &ProviderBuildResult{Provider: &coretesting.StubIntegration{N: name}}, nil
+	}
+
+	ready, _, _, _ := builds.Start(context.Background(), Deps{}, builder)
+	<-ready
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got, ok := written["ok"]; !ok || got != "sha-ok" {
+		t.Fatalf("expected ok -> sha-ok written, got %v", written)
+	}
+	if _, ok := written["fails"]; ok {
+		t.Fatal("failed install must not persist its SHA")
+	}
+	if _, ok := written["no-sha"]; ok {
+		t.Fatal("provider without an artifact SHA must not persist an empty SHA")
+	}
+}

--- a/gestaltd/internal/bootstrap/app_shas_test.go
+++ b/gestaltd/internal/bootstrap/app_shas_test.go
@@ -59,6 +59,7 @@ func TestAppStartupCategorizer(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			categorize := newAppStartupCategorizer(stored, tc.autoActivate)
 			if got := categorize(tc.app, tc.entry); got != tc.want {
 				t.Fatalf("category = %d, want %d", got, tc.want)

--- a/gestaltd/internal/bootstrap/app_startup_category.go
+++ b/gestaltd/internal/bootstrap/app_startup_category.go
@@ -7,10 +7,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 )
 
-// resolveAutoActivate reports whether all app providers should start
-// immediately (bypassing the version-changed deferral). An explicit
-// server.autoActivate config value wins; otherwise it defaults to true when
-// K_REVISION is absent (local dev) and false on Cloud Run.
 func resolveAutoActivate(cfg *config.Config) bool {
 	if cfg != nil && cfg.Server.AutoActivate != nil {
 		return *cfg.Server.AutoActivate
@@ -25,15 +21,6 @@ const (
 	AppStartupUpdate
 )
 
-// newAppStartupCategorizer decides, per app, whether it starts immediately
-// (AppStartupNOOP — same version as the last successful install, so it blocks
-// startup) or is deferred to /activate (AppStartupUpdate — version changed or
-// never installed).
-//
-// When autoActivate is set, every app is NOOP: the deferral split is bypassed
-// and all providers start immediately. This is the local-dev default, where
-// path/source providers carry no artifact SHA and would otherwise all look
-// changed on every restart.
 func newAppStartupCategorizer(stored map[string]string, autoActivate bool) func(string, *config.ProviderEntry) AppStartupCategory {
 	return func(name string, entry *config.ProviderEntry) AppStartupCategory {
 		if autoActivate {

--- a/gestaltd/internal/bootstrap/app_startup_category.go
+++ b/gestaltd/internal/bootstrap/app_startup_category.go
@@ -1,6 +1,22 @@
 package bootstrap
 
-import "github.com/valon-technologies/gestalt/server/internal/config"
+import (
+	"os"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+)
+
+// resolveAutoActivate reports whether all app providers should start
+// immediately (bypassing the version-changed deferral). An explicit
+// server.autoActivate config value wins; otherwise it defaults to true when
+// K_REVISION is absent (local dev) and false on Cloud Run.
+func resolveAutoActivate(cfg *config.Config) bool {
+	if cfg != nil && cfg.Server.AutoActivate != nil {
+		return *cfg.Server.AutoActivate
+	}
+	return strings.TrimSpace(os.Getenv("K_REVISION")) == ""
+}
 
 type AppStartupCategory int
 
@@ -9,6 +25,24 @@ const (
 	AppStartupUpdate
 )
 
-func appStartupCategory(_ string, _ *config.ProviderEntry) AppStartupCategory {
-	return AppStartupNOOP
+// newAppStartupCategorizer decides, per app, whether it starts immediately
+// (AppStartupNOOP — same version as the last successful install, so it blocks
+// startup) or is deferred to /activate (AppStartupUpdate — version changed or
+// never installed).
+//
+// When autoActivate is set, every app is NOOP: the deferral split is bypassed
+// and all providers start immediately. This is the local-dev default, where
+// path/source providers carry no artifact SHA and would otherwise all look
+// changed on every restart.
+func newAppStartupCategorizer(stored map[string]string, autoActivate bool) func(string, *config.ProviderEntry) AppStartupCategory {
+	return func(name string, entry *config.ProviderEntry) AppStartupCategory {
+		if autoActivate {
+			return AppStartupNOOP
+		}
+		current := currentAppSHA(entry)
+		if current != "" && stored[name] == current {
+			return AppStartupNOOP
+		}
+		return AppStartupUpdate
+	}
 }

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1239,7 +1239,16 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 			_ = closeAgents(extraAgents...)
 		}
 	}()
-	noopBuilds, updateBuilds := providerBuilds.partition(appStartupCategory)
+	storedSHAs := readAppSHAs(ctx, prepared.Services.DB)
+	autoActivate := resolveAutoActivate(cfg)
+	noopBuilds, updateBuilds := providerBuilds.partition(newAppStartupCategorizer(storedSHAs, autoActivate))
+	// Only version-changed (deferred) providers persist their SHA on successful
+	// install; unchanged providers already have the matching SHA stored.
+	updateBuilds.onInstalled = func(name, sha string) {
+		if err := writeAppSHA(ctx, prepared.Services.DB, name, sha); err != nil {
+			slog.WarnContext(ctx, "persisting app sha failed", "provider", name, "error", err)
+		}
+	}
 
 	var noopConnAuth func() map[string]map[string]OAuthHandler
 	var noopManualConnAuth func() map[string]map[string]ManualTokenExchanger

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1242,8 +1242,6 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	storedSHAs := readAppSHAs(ctx, prepared.Services.DB)
 	autoActivate := resolveAutoActivate(cfg)
 	noopBuilds, updateBuilds := providerBuilds.partition(newAppStartupCategorizer(storedSHAs, autoActivate))
-	// Only version-changed (deferred) providers persist their SHA on successful
-	// install; unchanged providers already have the matching SHA stored.
 	updateBuilds.onInstalled = func(name, sha string) {
 		if err := writeAppSHA(ctx, prepared.Services.DB, name, sha); err != nil {
 			slog.WarnContext(ctx, "persisting app sha failed", "provider", name, "error", err)

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -59,10 +59,7 @@ type preparedProviderBuilds struct {
 	connAuth       map[string]map[string]OAuthHandler
 	manualConnAuth map[string]map[string]ManualTokenExchanger
 	errs           []error
-	// onInstalled, if set, is called with (appName, sha) after a provider
-	// finishes installing successfully. Used to persist the SHA of deferred
-	// (version-changed) providers so the next deploy sees them as unchanged.
-	onInstalled func(name, sha string)
+	onInstalled    func(name, sha string)
 }
 
 func prepareProviderBuilds(

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -50,6 +50,7 @@ type pendingProviderBuild struct {
 	name  string
 	entry *config.ProviderEntry
 	proxy *startupProviderProxy
+	sha   string
 }
 
 type preparedProviderBuilds struct {
@@ -58,6 +59,10 @@ type preparedProviderBuilds struct {
 	connAuth       map[string]map[string]OAuthHandler
 	manualConnAuth map[string]map[string]ManualTokenExchanger
 	errs           []error
+	// onInstalled, if set, is called with (appName, sha) after a provider
+	// finishes installing successfully. Used to persist the SHA of deferred
+	// (version-changed) providers so the next deploy sees them as unchanged.
+	onInstalled func(name, sha string)
 }
 
 func prepareProviderBuilds(
@@ -92,10 +97,11 @@ func prepareProviderBuilds(
 
 	for name := range cfg.Apps {
 		intgDef := cfg.Apps[name]
+		sha := currentAppSHA(intgDef)
 		spec, operationRouting, err := buildStartupProviderSpec(name, intgDef)
 		if err != nil {
 			slog.Warn("building startup provider proxy metadata failed", "provider", name, "error", err)
-			builds.pending = append(builds.pending, pendingProviderBuild{name: name, entry: intgDef})
+			builds.pending = append(builds.pending, pendingProviderBuild{name: name, entry: intgDef, sha: sha})
 			continue
 		}
 		var tracker *startupWaitTracker
@@ -106,10 +112,10 @@ func prepareProviderBuilds(
 		if err := reg.Providers.Register(name, proxy); err != nil {
 			builds.errs = append(builds.errs, fmt.Errorf("integration %q: %w", name, err))
 			slog.Warn("registering startup provider proxy failed", "provider", name, "error", err)
-			builds.pending = append(builds.pending, pendingProviderBuild{name: name, entry: intgDef})
+			builds.pending = append(builds.pending, pendingProviderBuild{name: name, entry: intgDef, sha: sha})
 			continue
 		}
-		builds.pending = append(builds.pending, pendingProviderBuild{name: name, entry: intgDef, proxy: proxy})
+		builds.pending = append(builds.pending, pendingProviderBuild{name: name, entry: intgDef, proxy: proxy, sha: sha})
 	}
 	return builds, nil
 }
@@ -232,6 +238,9 @@ func (b *preparedProviderBuilds) Start(
 				connMu.Lock()
 				b.manualConnAuth[pending.name] = result.ManualConnectionAuth
 				connMu.Unlock()
+			}
+			if b.onInstalled != nil && pending.sha != "" {
+				b.onInstalled(pending.name, pending.sha)
 			}
 			slog.Info("loaded provider", "provider", pending.name, "operations", catalogOperationCount(result.Provider.Catalog()))
 		}(pending)

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -2047,6 +2047,11 @@ type ServerConfig struct {
 	Runtime       ServerRuntimeConfig      `yaml:"runtime,omitempty"`
 	Egress        EgressConfig             `yaml:"egress,omitempty"`
 	Admin         AdminConfig              `yaml:"admin,omitempty"`
+	// AutoActivate, when set, forces all app providers to start immediately at
+	// bootstrap instead of deferring version-changed ones to /activate. When
+	// unset it defaults to true if K_REVISION is absent (local dev) and false
+	// on Cloud Run, where the deploy workflow drives /activate.
+	AutoActivate *bool `yaml:"autoActivate,omitempty"`
 }
 
 type ServerAgentConfig struct{}

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -2047,11 +2047,7 @@ type ServerConfig struct {
 	Runtime       ServerRuntimeConfig      `yaml:"runtime,omitempty"`
 	Egress        EgressConfig             `yaml:"egress,omitempty"`
 	Admin         AdminConfig              `yaml:"admin,omitempty"`
-	// AutoActivate, when set, forces all app providers to start immediately at
-	// bootstrap instead of deferring version-changed ones to /activate. When
-	// unset it defaults to true if K_REVISION is absent (local dev) and false
-	// on Cloud Run, where the deploy workflow drives /activate.
-	AutoActivate *bool `yaml:"autoActivate,omitempty"`
+	AutoActivate  *bool                    `yaml:"autoActivate,omitempty"`
 }
 
 type ServerAgentConfig struct{}

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -11,10 +11,6 @@ const (
 	StoreAppSHAs                       = "app_shas"
 )
 
-// AppSHAsSchema records the artifact SHA of the last successfully installed
-// version of each app provider, keyed by app name. Bootstrap compares the
-// stored SHA against the current manifest artifact to decide whether an app is
-// unchanged (start immediately) or version-changed (defer to /activate).
 var AppSHAsSchema = idb.ObjectStoreOptions{
 	Columns: []idb.ColumnDef{
 		{Name: "id", Type: idb.TypeString, PrimaryKey: true},

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -8,7 +8,19 @@ const (
 	StoreUsers                         = "users"
 	StoreManagedSubjects               = "managed_subjects"
 	StoreAuthorizationDynamicFragments = "authz_dynamic_fragments"
+	StoreAppSHAs                       = "app_shas"
 )
+
+// AppSHAsSchema records the artifact SHA of the last successfully installed
+// version of each app provider, keyed by app name. Bootstrap compares the
+// stored SHA against the current manifest artifact to decide whether an app is
+// unchanged (start immediately) or version-changed (defer to /activate).
+var AppSHAsSchema = idb.ObjectStoreOptions{
+	Columns: []idb.ColumnDef{
+		{Name: "id", Type: idb.TypeString, PrimaryKey: true},
+		{Name: "sha", Type: idb.TypeString, NotNull: true},
+	},
+}
 
 var UsersSchema = idb.ObjectStoreOptions{
 	Indexes: []idb.IndexSchema{

--- a/gestaltd/internal/coredata/services.go
+++ b/gestaltd/internal/coredata/services.go
@@ -29,6 +29,9 @@ func NewWithContext(ctx context.Context, ds indexeddb.IndexedDB) (*Services, err
 	if _, err := ds.CreateObjectStore(ctx, StoreManagedSubjects, ManagedSubjectsSchema); err != nil {
 		return nil, fmt.Errorf("create managed_subjects store: %w", err)
 	}
+	if _, err := ds.CreateObjectStore(ctx, StoreAppSHAs, AppSHAsSchema); err != nil {
+		return nil, fmt.Errorf("create app_shas store: %w", err)
+	}
 	users := NewUserService(ds)
 	managedSubjects := NewManagedSubjectService(ds)
 	return &Services{


### PR DESCRIPTION
## Description

Step 4 of the gestaltd-deferred-app-startup plan: split app providers at bootstrap into unchanged (start immediately, block readiness) and version-changed (deferred) groups, so only providers actually being updated are held back.

The startup split machinery (`partition` / `newProviderActivation`) already existed; `appStartupCategory` was a stub that returned `NOOP` for every app, so nothing was ever deferred. This PR implements the actual detection:

- **SHA persistence** — new `app_shas` IndexedDB store (keyed by app name) records the artifact SHA of each app's last *successful* install. `readAppSHAs` loads them at bootstrap before partitioning; `writeAppSHA` records them.
- **Detection** — `newAppStartupCategorizer` compares each app's stored SHA against its current-platform artifact SHA (`providerpkg.CurrentPlatformArtifact`). Match → `AppStartupNOOP` (immediate). Mismatch or no stored SHA (first deploy) → `AppStartupUpdate` (deferred).
- **Write-on-success only** — only the deferred group persists its SHA, and only after a successful install, so a failed install leaves the stored SHA unchanged and the next deploy retries it.
- **`server.autoActivate`** — bypasses the split (all immediate). Defaults to `true` when `K_REVISION` is unset (local dev, where path/source providers have no artifact SHA and would otherwise all look changed on every restart) and `false` on Cloud Run.

### Behavior notes
- Bootstrap still calls `activateAppProviders` immediately, so deferred providers load in the **background** (they no longer block readiness) rather than being fully held for `/activate`. Step 5 removes that auto-start.
- **First post-deploy behavior**: on the first Cloud Run deploy after this ships, no SHAs are stored yet, so *every* provider is treated as changed and loads in the background while readiness returns early. The startup proxy queues requests to not-yet-ready providers during that window. Subsequent deploys only defer actually-changed providers. This is the intended trajectory and is safe, but worth knowing for the first rollout.

## Test plan
- Unit tests cover: SHA read/write round-trip, nil-DB safety, categorizer (match/mismatch/missing/autoActivate/path-source), `autoActivate` resolution (explicit vs K_REVISION default), and write-on-successful-install-only.
- [ ] Deploy and confirm unchanged providers are ready immediately while a changed provider loads in the background; confirm its SHA is persisted after install.