### PR TITLE
[gestaltd] Stop auto-starting deferred app providers; require /activate in Cloud Run

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -271,6 +271,15 @@ func (r *Result) ActivateAppProviders(ctx context.Context) {
 	if r == nil || r.activateAppProviders == nil {
 		return
 	}
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return
+	}
+	if r.deferred != nil {
+		r.deferred.markActivating()
+	}
+	r.mu.Unlock()
 	r.activateAppProviders(ctx)
 }
 
@@ -1143,7 +1152,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		connAuthResolver       func() map[string]map[string]OAuthHandler
 		manualConnAuthResolver func() map[string]map[string]ManualTokenExchanger
 	)
-	deferred := &deferredProviders{}
+	deferred := newDeferredProviders()
 	closeProviders := true
 	defer func() {
 		if closeProviders {
@@ -1262,19 +1271,18 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	noopAuth := noopConnAuth()
 	noopManualAuth := noopManualConnAuth()
 
-	providersReady := make(chan struct{})
 	activateAppProviders := newProviderActivation(updateBuilds, prepared.Deps, buildProvider, func(
 		ready <-chan struct{},
 		connAuth func() map[string]map[string]OAuthHandler,
 		manualConnAuth func() map[string]map[string]ManualTokenExchanger,
 	) {
-		deferred.set(ready, connAuth, manualConnAuth)
+		deferred.set(connAuth, manualConnAuth)
 		go func() {
 			select {
 			case <-ready:
 			case <-ctx.Done():
 			}
-			close(providersReady)
+			deferred.finish()
 		}()
 	})
 	if autoActivate {
@@ -1352,7 +1360,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		WorkflowControl:              prepared.Deps.WorkflowRuntime,
 		AgentControl:                 prepared.Deps.AgentRuntime,
 		AgentManager:                 prepared.Deps.AgentManager,
-		ProvidersReady:               providersReady,
+		ProvidersReady:               deferred.ready(),
 		ConnectionAuth:               connAuthResolver,
 		ManualConnectionAuth:         manualConnAuthResolver,
 		Invoker:                      sharedInvoker,

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1271,7 +1271,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	noopAuth := noopConnAuth()
 	noopManualAuth := noopManualConnAuth()
 
-	activateAppProviders := newProviderActivation(updateBuilds, prepared.Deps, buildProvider, func(
+	startDeferredProviders := newProviderActivation(ctx, updateBuilds, prepared.Deps, buildProvider, func(
 		ready <-chan struct{},
 		connAuth func() map[string]map[string]OAuthHandler,
 		manualConnAuth func() map[string]map[string]ManualTokenExchanger,
@@ -1282,8 +1282,9 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 			deferred.finish()
 		}()
 	})
+	activateAppProviders := func(context.Context) { startDeferredProviders() }
 	if autoActivate {
-		activateAppProviders(ctx)
+		startDeferredProviders()
 	}
 
 	connAuthResolver = func() map[string]map[string]OAuthHandler {

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -262,6 +262,7 @@ type Result struct {
 	workflowConfigReconcileTasksStarted bool
 	auditClose                          func(context.Context) error
 	activateAppProviders                func(context.Context)
+	deferred                            *deferredProviders
 	mu                                  sync.Mutex
 	closed                              bool
 }
@@ -375,7 +376,9 @@ func (r *Result) Close(ctx context.Context) error {
 	if r.closed {
 		return nil
 	}
-	if r.ProvidersReady != nil {
+	if r.deferred != nil {
+		r.deferred.waitReady()
+	} else if r.ProvidersReady != nil {
 		<-r.ProvidersReady
 	}
 	var errs []error
@@ -1137,19 +1140,17 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	providers := providerBuilds.providers
 	var (
 		noopReady              <-chan struct{}
-		providersReady         <-chan struct{}
 		connAuthResolver       func() map[string]map[string]OAuthHandler
 		manualConnAuthResolver func() map[string]map[string]ManualTokenExchanger
 	)
+	deferred := &deferredProviders{}
 	closeProviders := true
 	defer func() {
 		if closeProviders {
 			if noopReady != nil {
 				<-noopReady
 			}
-			if providersReady != nil {
-				<-providersReady
-			}
+			deferred.waitReady()
 			_ = CloseProviders(providers)
 		}
 	}()
@@ -1261,21 +1262,27 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	noopAuth := noopConnAuth()
 	noopManualAuth := noopManualConnAuth()
 
-	var updateConnAuth func() map[string]map[string]OAuthHandler
-	var updateManualConnAuth func() map[string]map[string]ManualTokenExchanger
+	providersReady := make(chan struct{})
 	activateAppProviders := newProviderActivation(updateBuilds, prepared.Deps, buildProvider, func(
 		ready <-chan struct{},
 		connAuth func() map[string]map[string]OAuthHandler,
 		manualConnAuth func() map[string]map[string]ManualTokenExchanger,
 	) {
-		providersReady = ready
-		updateConnAuth = connAuth
-		updateManualConnAuth = manualConnAuth
+		deferred.set(ready, connAuth, manualConnAuth)
+		go func() {
+			select {
+			case <-ready:
+			case <-ctx.Done():
+			}
+			close(providersReady)
+		}()
 	})
-	activateAppProviders(ctx)
+	if autoActivate {
+		activateAppProviders(ctx)
+	}
 
 	connAuthResolver = func() map[string]map[string]OAuthHandler {
-		b := updateConnAuth()
+		b := deferred.connectionAuth()
 		if len(b) == 0 {
 			return noopAuth
 		}
@@ -1289,7 +1296,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		return merged
 	}
 	manualConnAuthResolver = func() map[string]map[string]ManualTokenExchanger {
-		b := updateManualConnAuth()
+		b := deferred.manualConnectionAuth()
 		if len(b) == 0 {
 			return noopManualAuth
 		}
@@ -1361,6 +1368,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		workflowConfigReconcileTasks: deferredWorkflowConfigReconcileTasks,
 		auditClose:                   auditClose,
 		activateAppProviders:         activateAppProviders,
+		deferred:                     deferred,
 	}, nil
 }
 

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1278,10 +1278,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	) {
 		deferred.set(connAuth, manualConnAuth)
 		go func() {
-			select {
-			case <-ready:
-			case <-ctx.Done():
-			}
+			<-ready
 			deferred.finish()
 		}()
 	})

--- a/gestaltd/internal/bootstrap/deferred_providers.go
+++ b/gestaltd/internal/bootstrap/deferred_providers.go
@@ -1,0 +1,57 @@
+package bootstrap
+
+import "sync"
+
+type deferredProviders struct {
+	mu             sync.Mutex
+	triggered      bool
+	ready          <-chan struct{}
+	connAuth       func() map[string]map[string]OAuthHandler
+	manualConnAuth func() map[string]map[string]ManualTokenExchanger
+}
+
+func (d *deferredProviders) set(
+	ready <-chan struct{},
+	connAuth func() map[string]map[string]OAuthHandler,
+	manualConnAuth func() map[string]map[string]ManualTokenExchanger,
+) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.triggered = true
+	d.ready = ready
+	d.connAuth = connAuth
+	d.manualConnAuth = manualConnAuth
+}
+
+func (d *deferredProviders) connectionAuth() map[string]map[string]OAuthHandler {
+	d.mu.Lock()
+	fn := d.connAuth
+	d.mu.Unlock()
+	if fn == nil {
+		return nil
+	}
+	return fn()
+}
+
+func (d *deferredProviders) manualConnectionAuth() map[string]map[string]ManualTokenExchanger {
+	d.mu.Lock()
+	fn := d.manualConnAuth
+	d.mu.Unlock()
+	if fn == nil {
+		return nil
+	}
+	return fn()
+}
+
+func (d *deferredProviders) waitReady() {
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	triggered := d.triggered
+	ready := d.ready
+	d.mu.Unlock()
+	if triggered && ready != nil {
+		<-ready
+	}
+}

--- a/gestaltd/internal/bootstrap/deferred_providers.go
+++ b/gestaltd/internal/bootstrap/deferred_providers.go
@@ -5,22 +5,40 @@ import "sync"
 type deferredProviders struct {
 	mu             sync.Mutex
 	triggered      bool
-	ready          <-chan struct{}
 	connAuth       func() map[string]map[string]OAuthHandler
 	manualConnAuth func() map[string]map[string]ManualTokenExchanger
+
+	done       chan struct{}
+	finishOnce sync.Once
+}
+
+func newDeferredProviders() *deferredProviders {
+	return &deferredProviders{done: make(chan struct{})}
+}
+
+func (d *deferredProviders) ready() <-chan struct{} {
+	return d.done
+}
+
+func (d *deferredProviders) markActivating() {
+	d.mu.Lock()
+	d.triggered = true
+	d.mu.Unlock()
 }
 
 func (d *deferredProviders) set(
-	ready <-chan struct{},
 	connAuth func() map[string]map[string]OAuthHandler,
 	manualConnAuth func() map[string]map[string]ManualTokenExchanger,
 ) {
 	d.mu.Lock()
-	defer d.mu.Unlock()
 	d.triggered = true
-	d.ready = ready
 	d.connAuth = connAuth
 	d.manualConnAuth = manualConnAuth
+	d.mu.Unlock()
+}
+
+func (d *deferredProviders) finish() {
+	d.finishOnce.Do(func() { close(d.done) })
 }
 
 func (d *deferredProviders) connectionAuth() map[string]map[string]OAuthHandler {
@@ -49,9 +67,8 @@ func (d *deferredProviders) waitReady() {
 	}
 	d.mu.Lock()
 	triggered := d.triggered
-	ready := d.ready
 	d.mu.Unlock()
-	if triggered && ready != nil {
-		<-ready
+	if triggered {
+		<-d.done
 	}
 }

--- a/gestaltd/internal/bootstrap/deferred_providers_test.go
+++ b/gestaltd/internal/bootstrap/deferred_providers_test.go
@@ -1,0 +1,66 @@
+package bootstrap
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDeferredProvidersUntriggered(t *testing.T) {
+	t.Parallel()
+
+	var nilD *deferredProviders
+	nilD.waitReady()
+
+	d := &deferredProviders{}
+	if got := d.connectionAuth(); got != nil {
+		t.Fatalf("connectionAuth before set = %v, want nil", got)
+	}
+	if got := d.manualConnectionAuth(); got != nil {
+		t.Fatalf("manualConnectionAuth before set = %v, want nil", got)
+	}
+
+	done := make(chan struct{})
+	go func() { d.waitReady(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("waitReady blocked while untriggered")
+	}
+}
+
+func TestDeferredProvidersSetPopulatesAndWaits(t *testing.T) {
+	t.Parallel()
+
+	ready := make(chan struct{})
+	d := &deferredProviders{}
+	d.set(
+		ready,
+		func() map[string]map[string]OAuthHandler {
+			return map[string]map[string]OAuthHandler{"gh": nil}
+		},
+		func() map[string]map[string]ManualTokenExchanger {
+			return map[string]map[string]ManualTokenExchanger{"sl": nil}
+		},
+	)
+
+	if _, ok := d.connectionAuth()["gh"]; !ok {
+		t.Fatal("connectionAuth not populated after set")
+	}
+	if _, ok := d.manualConnectionAuth()["sl"]; !ok {
+		t.Fatal("manualConnectionAuth not populated after set")
+	}
+
+	done := make(chan struct{})
+	go func() { d.waitReady(); close(done) }()
+	select {
+	case <-done:
+		t.Fatal("waitReady returned before its ready channel closed")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(ready)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("waitReady did not return after ready closed")
+	}
+}

--- a/gestaltd/internal/bootstrap/deferred_providers_test.go
+++ b/gestaltd/internal/bootstrap/deferred_providers_test.go
@@ -11,7 +11,7 @@ func TestDeferredProvidersUntriggered(t *testing.T) {
 	var nilD *deferredProviders
 	nilD.waitReady()
 
-	d := &deferredProviders{}
+	d := newDeferredProviders()
 	if got := d.connectionAuth(); got != nil {
 		t.Fatalf("connectionAuth before set = %v, want nil", got)
 	}
@@ -31,10 +31,8 @@ func TestDeferredProvidersUntriggered(t *testing.T) {
 func TestDeferredProvidersSetPopulatesAndWaits(t *testing.T) {
 	t.Parallel()
 
-	ready := make(chan struct{})
-	d := &deferredProviders{}
+	d := newDeferredProviders()
 	d.set(
-		ready,
 		func() map[string]map[string]OAuthHandler {
 			return map[string]map[string]OAuthHandler{"gh": nil}
 		},
@@ -50,17 +48,32 @@ func TestDeferredProvidersSetPopulatesAndWaits(t *testing.T) {
 		t.Fatal("manualConnectionAuth not populated after set")
 	}
 
+	assertWaitReadyBlocksUntilFinish(t, d)
+}
+
+func TestDeferredProvidersMarkActivatingWaitsUntilFinish(t *testing.T) {
+	t.Parallel()
+
+	d := newDeferredProviders()
+	d.markActivating()
+	assertWaitReadyBlocksUntilFinish(t, d)
+}
+
+func assertWaitReadyBlocksUntilFinish(t *testing.T, d *deferredProviders) {
+	t.Helper()
+
 	done := make(chan struct{})
 	go func() { d.waitReady(); close(done) }()
 	select {
 	case <-done:
-		t.Fatal("waitReady returned before its ready channel closed")
+		t.Fatal("waitReady returned before finish() while triggered")
 	case <-time.After(100 * time.Millisecond):
 	}
-	close(ready)
+
+	d.finish()
 	select {
 	case <-done:
 	case <-time.After(time.Second):
-		t.Fatal("waitReady did not return after ready closed")
+		t.Fatal("waitReady did not return after finish()")
 	}
 }

--- a/gestaltd/internal/bootstrap/provider_activation_test.go
+++ b/gestaltd/internal/bootstrap/provider_activation_test.go
@@ -31,7 +31,7 @@ func TestNewProviderActivationStartsProvidersOnce(t *testing.T) {
 	}
 
 	var gotReady <-chan struct{}
-	activate := newProviderActivation(builds, Deps{}, builder, func(
+	activate := newProviderActivation(context.Background(), builds, Deps{}, builder, func(
 		ready <-chan struct{},
 		_ func() map[string]map[string]OAuthHandler,
 		_ func() map[string]map[string]ManualTokenExchanger,
@@ -41,7 +41,7 @@ func TestNewProviderActivationStartsProvidersOnce(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		activate(context.Background())
+		activate()
 		close(done)
 	}()
 	select {
@@ -62,8 +62,8 @@ func TestNewProviderActivationStartsProvidersOnce(t *testing.T) {
 		t.Fatalf("builder calls after first activation = %d, want 1", got)
 	}
 
-	activate(context.Background())
-	activate(context.Background())
+	activate()
+	activate()
 	if got := builderCalls.Load(); got != 1 {
 		t.Fatalf("builder calls after repeated activation = %d, want 1 (idempotent)", got)
 	}

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -46,6 +46,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const providerInstallTimeout = 10 * time.Minute
+
 type pendingProviderBuild struct {
 	name  string
 	entry *config.ProviderEntry
@@ -175,11 +177,13 @@ func (b *preparedProviderBuilds) Start(
 	var errMu sync.Mutex
 	var wg sync.WaitGroup
 
+	installCtx, cancelInstall := context.WithTimeout(ctx, providerInstallTimeout)
+
 	for _, pending := range b.pending {
 		wg.Add(1)
 		go func(pending pendingProviderBuild) {
 			defer wg.Done()
-			buildCtx := invocation.WithCallerProvider(ctx, invocation.ProviderKindApp, pending.name)
+			buildCtx := invocation.WithCallerProvider(installCtx, invocation.ProviderKindApp, pending.name)
 			result, err := builder(buildCtx, pending.name, pending.entry, deps)
 			if err != nil {
 				errMu.Lock()
@@ -245,6 +249,7 @@ func (b *preparedProviderBuilds) Start(
 
 	go func() {
 		wg.Wait()
+		cancelInstall()
 		close(ready)
 	}()
 
@@ -266,6 +271,7 @@ func (b *preparedProviderBuilds) Start(
 }
 
 func newProviderActivation(
+	baseCtx context.Context,
 	b *preparedProviderBuilds,
 	deps Deps,
 	builder func(context.Context, string, *config.ProviderEntry, Deps) (*ProviderBuildResult, error),
@@ -274,11 +280,11 @@ func newProviderActivation(
 		connAuth func() map[string]map[string]OAuthHandler,
 		manualConnAuth func() map[string]map[string]ManualTokenExchanger,
 	),
-) func(context.Context) {
+) func() {
 	var once sync.Once
-	return func(ctx context.Context) {
+	return func() {
 		once.Do(func() {
-			ready, connAuth, manualConnAuth, _ := b.Start(ctx, deps, builder)
+			ready, connAuth, manualConnAuth, _ := b.Start(baseCtx, deps, builder)
 			onStart(ready, connAuth, manualConnAuth)
 		})
 	}

--- a/gestaltd/internal/bootstrap/provider_deferral_test.go
+++ b/gestaltd/internal/bootstrap/provider_deferral_test.go
@@ -41,6 +41,34 @@ func TestBootstrapDefersActivationWhenAutoActivateDisabled(t *testing.T) {
 	}
 }
 
+func TestActivateAppProvidersAfterCloseIsNoOp(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	cfg := validConfig()
+	disabled := false
+	cfg.Server.AutoActivate = &disabled
+
+	result, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	if err := result.Close(ctx); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		result.ActivateAppProviders(ctx)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ActivateAppProviders after Close should be a no-op, not block")
+	}
+}
+
 func TestBootstrapAutoActivateEnabledStartsWithoutActivateCall(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/gestaltd/internal/bootstrap/provider_deferral_test.go
+++ b/gestaltd/internal/bootstrap/provider_deferral_test.go
@@ -41,6 +41,35 @@ func TestBootstrapDefersActivationWhenAutoActivateDisabled(t *testing.T) {
 	}
 }
 
+func TestActivateAppProvidersIgnoresCallerContext(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	cfg := validConfig()
+	disabled := false
+	cfg.Server.AutoActivate = &disabled
+
+	result, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := result.Close(context.Background()); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	})
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	result.ActivateAppProviders(canceled)
+
+	select {
+	case <-result.ProvidersReady:
+	case <-time.After(5 * time.Second):
+		t.Fatal("activation should run under the server context, not the already-canceled caller context")
+	}
+}
+
 func TestActivateAppProvidersAfterCloseIsNoOp(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/gestaltd/internal/bootstrap/provider_deferral_test.go
+++ b/gestaltd/internal/bootstrap/provider_deferral_test.go
@@ -1,0 +1,67 @@
+package bootstrap_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
+)
+
+func TestBootstrapDefersActivationWhenAutoActivateDisabled(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	cfg := validConfig()
+	disabled := false
+	cfg.Server.AutoActivate = &disabled
+
+	result, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := result.Close(context.Background()); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	})
+
+	select {
+	case <-result.ProvidersReady:
+		t.Fatal("deferred providers should not activate before ActivateAppProviders is called")
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	result.ActivateAppProviders(ctx)
+
+	select {
+	case <-result.ProvidersReady:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ProvidersReady should close after ActivateAppProviders")
+	}
+}
+
+func TestBootstrapAutoActivateEnabledStartsWithoutActivateCall(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	cfg := validConfig()
+	enabled := true
+	cfg.Server.AutoActivate = &enabled
+
+	result, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := result.Close(context.Background()); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	})
+
+	select {
+	case <-result.ProvidersReady:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ProvidersReady should close at startup when autoActivate is enabled")
+	}
+}


### PR DESCRIPTION
## Description

Step 5 (final) of the gestaltd-deferred-app-startup plan: bootstrap no longer auto-starts the version-changed provider group. Those providers now start only when `POST /activate` is called (which the deploy workflow does after shifting traffic), so a deploy's slow provider installs no longer happen before the revision is serving.

- The bootstrap-time `activateAppProviders` call is now gated on `autoActivate`:
  - **`autoActivate=false` (Cloud Run):** version-changed providers are deferred until `/activate`. Unchanged providers still start at bootstrap and block readiness.
  - **`autoActivate=true` (local-dev default, K_REVISION unset):** everything starts at bootstrap, unchanged from before.
- Removing the unconditional start meant the deferred group's connection-auth resolvers and readiness channel were previously populated *synchronously* by that call. Introduced a mutex-guarded `deferredProviders` holder so:
  - the connection-auth resolvers read it **race-safely** (verified with `go test -race`) and fall back to the immediate (noop) group's auth until `/activate` populates it;
  - `Close()` waits on the deferred group **only if activation was triggered**, avoiding a shutdown deadlock when `/activate` never fires.

## Behavior note
This completes the deferral: after this deploys, a version-changed provider is genuinely not started until `/activate` fires post-traffic-shift. Requests to a not-yet-activated changed provider are queued by the startup proxy until it installs (existing behavior). Unchanged providers remain available immediately on the new revision.

## Test plan
- Unit tests: `deferredProviders` holder (nil/untriggered safety, set/populate/wait ordering).
- Bootstrap tests: with `autoActivate=false` the deferred group does not activate until `ActivateAppProviders` is called; with `autoActivate=true` it starts at bootstrap without an `/activate` call.
- `go test -race ./internal/bootstrap` passes.
- [ ] Deploy and confirm a changed provider stays idle until the workflow's `/activate`, then installs.