### PR TITLE
[gestaltd] Lazily activate deferred providers on first request per instance

### DIFF
--- a/gestaltd/core/errors.go
+++ b/gestaltd/core/errors.go
@@ -9,4 +9,5 @@ var (
 	ErrMCPOnly             = errors.New("this integration is accessible only via MCP")
 	ErrAmbiguousCredential = errors.New("ambiguous external credential")
 	ErrReconnectRequired   = errors.New("external credential reconnect required")
+	ErrProviderActivating  = errors.New("provider is still activating")
 )

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1342,7 +1342,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	closeAudit = false
 	closeWorkflowsOnError = false
 	closeAgentsOnError = false
-	return &Result{
+	result := &Result{
 		Auth:                         prepared.Auth,
 		SelectedAuthProvider:         prepared.SelectedAuthProvider,
 		AuthProviders:                prepared.AuthProviders,
@@ -1375,7 +1375,13 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		auditClose:                   auditClose,
 		activateAppProviders:         activateAppProviders,
 		deferred:                     deferred,
-	}, nil
+	}
+	for _, pending := range updateBuilds.pending {
+		if pending.proxy != nil {
+			pending.proxy.setActivationTrigger(result.ActivateAppProviders)
+		}
+	}
+	return result, nil
 }
 
 type runtimeWorkerWorkflowProvider interface {

--- a/gestaltd/internal/bootstrap/startup_app_proxy.go
+++ b/gestaltd/internal/bootstrap/startup_app_proxy.go
@@ -19,6 +19,11 @@ type startupProviderProxy struct {
 	operationRouting startupOperationRouting
 	tracker          *startupWaitTracker
 	gate             startupGate[core.Provider]
+	activate         func(context.Context)
+}
+
+func (p *startupProviderProxy) setActivationTrigger(activate func(context.Context)) {
+	p.activate = activate
 }
 
 func newStartupProviderProxy(spec appservice.StaticProviderSpec, operationRouting startupOperationRouting, tracker *startupWaitTracker) *startupProviderProxy {
@@ -47,6 +52,9 @@ func (p *startupProviderProxy) finish(provider core.Provider, err error) {
 }
 
 func (p *startupProviderProxy) await(ctx context.Context) (core.Provider, error) {
+	if p.activate != nil && p.resolved() == nil {
+		p.activate(ctx)
+	}
 	provider, err := p.gate.await(ctx)
 	if err != nil {
 		return nil, err

--- a/gestaltd/internal/bootstrap/startup_app_proxy.go
+++ b/gestaltd/internal/bootstrap/startup_app_proxy.go
@@ -53,14 +53,15 @@ func (p *startupProviderProxy) finish(provider core.Provider, err error) {
 
 func (p *startupProviderProxy) await(ctx context.Context) (core.Provider, error) {
 	if p.activate != nil {
-		if provider := p.resolved(); provider != nil {
-			return provider, nil
+		if _, done, _ := p.gate.resolved(); !done {
+			p.activate(ctx)
+			if _, done, _ := p.gate.resolved(); !done {
+				return nil, fmt.Errorf("%w: %q", core.ErrProviderActivating, p.spec.Name)
+			}
 		}
-		p.activate(ctx)
-		if provider := p.resolved(); provider != nil {
-			return provider, nil
-		}
-		return nil, fmt.Errorf("%w: %q", core.ErrProviderActivating, p.spec.Name)
+		// The gate has finished (install succeeded or failed); fall through so
+		// callers get the resolved provider or the real install error, not a
+		// perpetual ErrProviderActivating.
 	}
 	provider, err := p.gate.await(ctx)
 	if err != nil {

--- a/gestaltd/internal/bootstrap/startup_app_proxy.go
+++ b/gestaltd/internal/bootstrap/startup_app_proxy.go
@@ -52,8 +52,15 @@ func (p *startupProviderProxy) finish(provider core.Provider, err error) {
 }
 
 func (p *startupProviderProxy) await(ctx context.Context) (core.Provider, error) {
-	if p.activate != nil && p.resolved() == nil {
+	if p.activate != nil {
+		if provider := p.resolved(); provider != nil {
+			return provider, nil
+		}
 		p.activate(ctx)
+		if provider := p.resolved(); provider != nil {
+			return provider, nil
+		}
+		return nil, fmt.Errorf("%w: %q", core.ErrProviderActivating, p.spec.Name)
 	}
 	provider, err := p.gate.await(ctx)
 	if err != nil {

--- a/gestaltd/internal/bootstrap/startup_proxy_test.go
+++ b/gestaltd/internal/bootstrap/startup_proxy_test.go
@@ -3,12 +3,67 @@ package bootstrap
 import (
 	"context"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/core"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	appservice "github.com/valon-technologies/gestalt/server/services/apps"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 )
+
+func TestStartupProviderProxyLazilyActivatesOnAwait(t *testing.T) {
+	t.Parallel()
+
+	proxy := newStartupProviderProxy(appservice.StaticProviderSpec{
+		Name:           "deferred",
+		ConnectionMode: core.ConnectionModeNone,
+	}, startupOperationRouting{}, nil)
+
+	var triggers atomic.Int32
+	proxy.setActivationTrigger(func(context.Context) {
+		triggers.Add(1)
+		proxy.publish(&coretesting.StubIntegration{N: "deferred"})
+	})
+
+	provider, err := proxy.await(context.Background())
+	if err != nil {
+		t.Fatalf("await after lazy activation: %v", err)
+	}
+	if provider == nil {
+		t.Fatal("expected a resolved provider after lazy activation")
+	}
+	if got := triggers.Load(); got != 1 {
+		t.Fatalf("activation trigger fired %d times, want 1", got)
+	}
+
+	if _, err := proxy.await(context.Background()); err != nil {
+		t.Fatalf("second await: %v", err)
+	}
+	if got := triggers.Load(); got != 1 {
+		t.Fatalf("activation trigger fired %d times after resolution, want 1 (already resolved)", got)
+	}
+}
+
+func TestStartupProviderProxyDoesNotActivateWhenAlreadyResolved(t *testing.T) {
+	t.Parallel()
+
+	proxy := newStartupProviderProxy(appservice.StaticProviderSpec{
+		Name:           "eager",
+		ConnectionMode: core.ConnectionModeNone,
+	}, startupOperationRouting{}, nil)
+
+	var triggers atomic.Int32
+	proxy.setActivationTrigger(func(context.Context) { triggers.Add(1) })
+	proxy.publish(&coretesting.StubIntegration{N: "eager"})
+
+	if _, err := proxy.await(context.Background()); err != nil {
+		t.Fatalf("await: %v", err)
+	}
+	if got := triggers.Load(); got != 0 {
+		t.Fatalf("activation trigger fired %d times for an already-resolved provider, want 0", got)
+	}
+}
 
 func TestStartupProviderProxyRejectsAppAgentCycle(t *testing.T) {
 	t.Parallel()

--- a/gestaltd/internal/bootstrap/startup_proxy_test.go
+++ b/gestaltd/internal/bootstrap/startup_proxy_test.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -12,7 +13,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 )
 
-func TestStartupProviderProxyLazilyActivatesOnAwait(t *testing.T) {
+func TestStartupProviderProxyLazilyActivatesAndFailsFast(t *testing.T) {
 	t.Parallel()
 
 	proxy := newStartupProviderProxy(appservice.StaticProviderSpec{
@@ -21,27 +22,31 @@ func TestStartupProviderProxyLazilyActivatesOnAwait(t *testing.T) {
 	}, startupOperationRouting{}, nil)
 
 	var triggers atomic.Int32
-	proxy.setActivationTrigger(func(context.Context) {
-		triggers.Add(1)
-		proxy.publish(&coretesting.StubIntegration{N: "deferred"})
-	})
+	// The install runs in the background; the trigger does not publish synchronously.
+	proxy.setActivationTrigger(func(context.Context) { triggers.Add(1) })
 
+	// First request triggers activation and fails fast rather than blocking.
+	_, err := proxy.await(context.Background())
+	if !errors.Is(err, core.ErrProviderActivating) {
+		t.Fatalf("await while activating = %v, want ErrProviderActivating", err)
+	}
+	if triggers.Load() == 0 {
+		t.Fatal("expected the first request to trigger activation")
+	}
+
+	// Still installing: keep failing fast.
+	if _, err := proxy.await(context.Background()); !errors.Is(err, core.ErrProviderActivating) {
+		t.Fatalf("await still activating = %v, want ErrProviderActivating", err)
+	}
+
+	// Install completes: subsequent requests resolve.
+	proxy.publish(&coretesting.StubIntegration{N: "deferred"})
 	provider, err := proxy.await(context.Background())
 	if err != nil {
-		t.Fatalf("await after lazy activation: %v", err)
+		t.Fatalf("await after install completed: %v", err)
 	}
 	if provider == nil {
-		t.Fatal("expected a resolved provider after lazy activation")
-	}
-	if got := triggers.Load(); got != 1 {
-		t.Fatalf("activation trigger fired %d times, want 1", got)
-	}
-
-	if _, err := proxy.await(context.Background()); err != nil {
-		t.Fatalf("second await: %v", err)
-	}
-	if got := triggers.Load(); got != 1 {
-		t.Fatalf("activation trigger fired %d times after resolution, want 1 (already resolved)", got)
+		t.Fatal("expected a resolved provider once activation finished")
 	}
 }
 

--- a/gestaltd/internal/bootstrap/startup_proxy_test.go
+++ b/gestaltd/internal/bootstrap/startup_proxy_test.go
@@ -50,6 +50,31 @@ func TestStartupProviderProxyLazilyActivatesAndFailsFast(t *testing.T) {
 	}
 }
 
+func TestStartupProviderProxySurfacesActivationFailure(t *testing.T) {
+	t.Parallel()
+
+	proxy := newStartupProviderProxy(appservice.StaticProviderSpec{
+		Name:           "deferred",
+		ConnectionMode: core.ConnectionModeNone,
+	}, startupOperationRouting{}, nil)
+	proxy.setActivationTrigger(func(context.Context) {})
+
+	if _, err := proxy.await(context.Background()); !errors.Is(err, core.ErrProviderActivating) {
+		t.Fatalf("await while activating = %v, want ErrProviderActivating", err)
+	}
+
+	installErr := errors.New("boom: bad manifest")
+	proxy.fail(installErr)
+
+	_, err := proxy.await(context.Background())
+	if errors.Is(err, core.ErrProviderActivating) {
+		t.Fatalf("await after install failure still returns ErrProviderActivating: %v", err)
+	}
+	if !errors.Is(err, installErr) {
+		t.Fatalf("await after install failure = %v, want the underlying install error", err)
+	}
+}
+
 func TestStartupProviderProxyDoesNotActivateWhenAlreadyResolved(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -903,6 +903,14 @@ func (s *Server) writeInvocationError(w http.ResponseWriter, r *http.Request, pr
 		writeError(w, http.StatusInternalServerError, "internal error")
 	case errors.Is(err, invocation.ErrInvalidInvocation):
 		writeError(w, http.StatusBadRequest, err.Error())
+	case errors.Is(err, core.ErrProviderActivating):
+		writeTypedError(
+			w,
+			http.StatusServiceUnavailable,
+			"provider_activating",
+			providerName,
+			fmt.Sprintf("integration %q is still activating; retry shortly", providerName),
+		)
 	case errors.Is(err, core.ErrMCPOnly):
 		writeError(w, http.StatusBadRequest, "this integration is accessible only via MCP")
 	case errors.Is(err, apiexec.ErrMissingPathParam):

--- a/gestaltd/internal/server/invocation_error_test.go
+++ b/gestaltd/internal/server/invocation_error_test.go
@@ -1,0 +1,33 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+)
+
+func TestWriteInvocationErrorProviderActivatingReturns503(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+
+	err := fmt.Errorf("%w: %q", core.ErrProviderActivating, "github")
+	s.writeInvocationError(rec, req, "github", "list_issues", err)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body["code"] != "provider_activating" {
+		t.Fatalf("error code = %v, want provider_activating (body=%s)", body["code"], rec.Body.String())
+	}
+}


### PR DESCRIPTION
## Description

Follow-up to the deferred-app-startup work (#2602). A single `POST /activate` only reaches **one** Cloud Run instance, so with `min-instances>1` the other instances never start their version-changed providers — and instances added later by autoscaling never do at all. Requests routed to an un-activated instance for a changed provider would queue on the startup proxy indefinitely.

Activation must happen **after traffic has shifted** (so a rolled-back candidate never commits changed-provider side effects), which rules out self-activating at startup. The earliest post-shift signal an instance has is **the first request it serves** — so this makes activation lazy and per-instance:

- The startup proxy gains an optional activation trigger. In `await`, if a deferred provider isn't resolved yet, it fires the trigger (idempotent) before waiting — kicking off the deferred group's install *on that instance*.
- The trigger is `Result.ActivateAppProviders`, so it reuses the existing closed-check, `markActivating`, and server-context wiring (the install survives the request returning and is bounded by the 10-minute timeout).
- Only deferred (update-group) proxies get the trigger; unchanged providers are already published at bootstrap and never need it.

The workflow's explicit `/activate` stays as an immediate warm-up of one instance right after the shift; lazy activation covers the remaining instances (and autoscaled ones) as traffic reaches them.

### Trade-off
The *first* request to a given changed provider on each instance waits for that provider to install (it queues until ready); every subsequent request is fast. Given the "activate only after traffic shift" constraint, someone has to absorb the post-shift install cost — this puts it on the first caller rather than leaving the provider permanently unavailable on that instance.

## Test plan
- `TestStartupProviderProxyLazilyActivatesOnAwait`: awaiting an unresolved deferred proxy fires the trigger once and resolves; a second await doesn't re-fire.
- `TestStartupProviderProxyDoesNotActivateWhenAlreadyResolved`: an already-published provider never fires the trigger.
- Full bootstrap suite passes under `-race`; gofmt clean; golangci-lint 0 issues.