### PR TITLE
Multi-command manifest phases and GESTALT_BUILD_STATIC packaging (issue-72)

### DIFF
--- a/gestaltd/internal/operator/fingerprint.go
+++ b/gestaltd/internal/operator/fingerprint.go
@@ -14,30 +14,32 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/apps/providerpkg"
 )
 
-// fingerprintSkipper is the fingerprint exclusion policy: which paths a source
-// fingerprint walk excludes. Two structural invariants apply regardless of
-// .gitignore: the declared build output (never hash the artifact about to be
-// produced) and the .git directory itself (git metadata, never a build input).
-// Everything else is decided by the enclosing repo's .gitignore rules. Explicit
-// per-input file listings are honored verbatim by the callers; shouldSkip is
-// only consulted on directory walks and on the walk root.
 type fingerprintSkipper struct {
-	matcher   gitignore.Matcher
-	repoRoot  string
-	outputAbs string
+	matcher        gitignore.Matcher
+	repoRoot       string
+	outputAbs      string
+	staticBuildAbs string
 }
 
-func newFingerprintSkipper(sourceDir, outputAbs string) (fingerprintSkipper, error) {
+func newFingerprintSkipper(sourceDir, outputAbs, staticBuildAbs string) (fingerprintSkipper, error) {
 	matcher, repoRoot, err := gitignoreMatcherForDir(sourceDir)
 	if err != nil {
 		return fingerprintSkipper{}, err
 	}
-	return fingerprintSkipper{matcher: matcher, repoRoot: repoRoot, outputAbs: outputAbs}, nil
+	return fingerprintSkipper{
+		matcher:        matcher,
+		repoRoot:       repoRoot,
+		outputAbs:      outputAbs,
+		staticBuildAbs: filepath.Clean(staticBuildAbs),
+	}, nil
 }
 
 func (s fingerprintSkipper) shouldSkip(path string, d os.DirEntry) bool {
 	cleanPath := filepath.Clean(path)
 	if s.outputAbs != "" && pathWithinRoot(s.outputAbs, cleanPath) {
+		return true
+	}
+	if s.staticBuildAbs != "" && pathWithinRoot(s.staticBuildAbs, cleanPath) {
 		return true
 	}
 	if d != nil && d.IsDir() && d.Name() == gitDirName {
@@ -50,9 +52,6 @@ func (s fingerprintSkipper) shouldSkip(path string, d os.DirEntry) bool {
 	return s.matcher.Match(components, d != nil && d.IsDir())
 }
 
-// digestCollector accumulates "relpath=sha256" lines for a source fingerprint,
-// deduplicating by path relative to sourceDir. It is the shared sink for every
-// fingerprint walk in this file.
 type digestCollector struct {
 	sourceDir string
 	digests   []string
@@ -93,10 +92,6 @@ func (c *digestCollector) joinedOver(baseDigest string) string {
 	return hex.EncodeToString(combined[:])
 }
 
-// walkDigestFiles walks root recursively, skipping paths the skipper excludes
-// and hashing every surviving file into the collector. This is the single
-// implementation of the fingerprint walk contract; both the build and install
-// paths route through it so future exclusion rules change in one place.
 func walkDigestFiles(root string, skipper fingerprintSkipper, c *digestCollector) error {
 	return filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
@@ -132,21 +127,21 @@ func fingerprintLocalBuildInputs(sourceDir, manifestPath string, manifest *provi
 	if outputRel, _, err := providerpkg.SourceBuildOutput(manifest); err == nil && outputRel != "" {
 		outputAbs = filepath.Clean(filepath.Join(sourceDir, filepath.FromSlash(outputRel)))
 	}
-	skipper, err := newFingerprintSkipper(sourceDir, outputAbs)
+	skipper, err := newFingerprintSkipper(sourceDir, outputAbs, providerpkg.SourceStaticBuildDir(manifestPath))
 	if err != nil {
 		return "", err
 	}
 
-	inputs := append([]string(nil), build.Inputs...)
+	var inputs []string
+	for _, command := range build.Commands {
+		inputs = append(inputs, command.Inputs...)
+	}
 	inputs = append(inputs, providerpkg.SourceInstallInputs(manifest)...)
 	if len(inputs) == 0 {
-		workdir := "."
-		if strings.TrimSpace(build.Workdir) != "" {
-			workdir = build.Workdir
-		}
-		rootAbs := filepath.Clean(filepath.Join(sourceDir, filepath.FromSlash(workdir)))
-		if err := walkDigestFiles(rootAbs, skipper, c); err != nil {
-			return "", fmt.Errorf("digest build inputs under %q: %w", workdir, err)
+		for _, rootAbs := range providerpkg.BuildWorkdirAbsPaths(sourceDir, build.Commands) {
+			if err := walkDigestFiles(rootAbs, skipper, c); err != nil {
+				return "", fmt.Errorf("digest build inputs under %q: %w", rootAbs, err)
+			}
 		}
 	} else {
 		for _, input := range inputs {
@@ -155,8 +150,6 @@ func fingerprintLocalBuildInputs(sourceDir, manifestPath string, manifest *provi
 			if err != nil {
 				return "", fmt.Errorf("stat build input %q: %w", input, err)
 			}
-			// Explicit file inputs are hashed verbatim (explicit beats ignore);
-			// only directory inputs walk through the matcher.
 			if !info.IsDir() {
 				if err := c.addFile(inputAbs); err != nil {
 					return "", fmt.Errorf("digest build input %q: %w", input, err)
@@ -172,8 +165,8 @@ func fingerprintLocalBuildInputs(sourceDir, manifestPath string, manifest *provi
 	return c.joined(), nil
 }
 
-func foldInstallInputsDigest(sourceDir, baseDigest string, installInputs []string) (string, error) {
-	skipper, err := newFingerprintSkipper(sourceDir, "")
+func foldInstallInputsDigest(sourceDir, manifestPath, baseDigest string, installInputs []string) (string, error) {
+	skipper, err := newFingerprintSkipper(sourceDir, "", providerpkg.SourceStaticBuildDir(manifestPath))
 	if err != nil {
 		return "", err
 	}

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -999,6 +999,9 @@ func (l *Lifecycle) markSourceRunAppProviders(cfg *config.Config) error {
 		case hasRun && manifest.Spec != nil && manifest.Spec.IsManifestBacked():
 			return fmt.Errorf("app %q: local-source apps cannot combine run: with a declarative surface", name)
 		case hasRun:
+			if err := providerpkg.RejectMultipleSourceRuns(manifest); err != nil {
+				return fmt.Errorf("app %q: %w", name, err)
+			}
 			configMap, err := config.NodeToMap(entry.Config)
 			if err != nil {
 				return fmt.Errorf("app %q: decode config: %w", name, err)
@@ -1007,7 +1010,7 @@ func (l *Lifecycle) markSourceRunAppProviders(cfg *config.Config) error {
 				return fmt.Errorf("app %q: %w", name, err)
 			}
 			workdir := normalized.sourceDir
-			if run := providerpkg.EffectiveSourceRun(manifest); run != nil {
+			if run := providerpkg.EffectiveSourceRunCommand(manifest); run != nil {
 				if w := strings.TrimSpace(run.Workdir); w != "" && w != "." {
 					workdir = filepath.Join(normalized.sourceDir, filepath.FromSlash(w))
 				}
@@ -1064,6 +1067,9 @@ func (l *Lifecycle) markDevActiveUIProviders(cfg *config.Config) error {
 			}
 			continue
 		}
+		if err := providerpkg.RejectMultipleSourceRuns(manifest); err != nil {
+			return fmt.Errorf("ui %q: %w", name, err)
+		}
 		configMap, err := config.NodeToMap(entry.Config)
 		if err != nil {
 			return fmt.Errorf("ui %q: decode config: %w", name, err)
@@ -1072,8 +1078,10 @@ func (l *Lifecycle) markDevActiveUIProviders(cfg *config.Config) error {
 			return fmt.Errorf("ui %q: %w", name, err)
 		}
 		workdir := normalized.sourceDir
-		if w := strings.TrimSpace(manifest.Run.Workdir); w != "" && w != "." {
-			workdir = filepath.Join(normalized.sourceDir, filepath.FromSlash(w))
+		if run := providerpkg.EffectiveSourceRunCommand(manifest); run != nil {
+			if w := strings.TrimSpace(run.Workdir); w != "" && w != "." {
+				workdir = filepath.Join(normalized.sourceDir, filepath.FromSlash(w))
+			}
 		}
 		entry.DevActive = true
 		entry.ResolvedDevWorkdir = workdir
@@ -2738,7 +2746,7 @@ func fingerprintLocalSourceDigest(sourcePath string) (string, error) {
 	if len(installInputs) == 0 {
 		return digest, nil
 	}
-	return foldInstallInputsDigest(normalized.sourceDir, digest, installInputs)
+	return foldInstallInputsDigest(normalized.sourceDir, normalized.manifestPath, digest, installInputs)
 }
 
 func fingerprintLocalReleaseMetadataDigest(sourcePath string) (string, error) {
@@ -3592,15 +3600,11 @@ func sourceBuildPathDomains(sourceDir string, manifest *providermanifestv1.Manif
 	if build == nil {
 		return nil, nil
 	}
-	workdir := sourceDir
-	if build.Workdir != "" && build.Workdir != "." {
-		workdir = filepath.Join(sourceDir, filepath.FromSlash(build.Workdir))
-	}
+	domains := providerpkg.BuildWorkdirAbsPaths(sourceDir, build.Commands)
 	outputRel, _, err := providerpkg.SourceBuildOutput(manifest)
 	if err != nil {
 		return nil, err
 	}
-	domains := []string{workdir}
 	if outputRel != "" {
 		domains = append(domains, filepath.Join(sourceDir, filepath.FromSlash(outputRel)))
 	}

--- a/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
@@ -72,8 +72,44 @@
           "type": "array",
           "minItems": 1,
           "items": {
-            "type": "string",
-            "minLength": 1
+            "oneOf": [
+              {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "command"
+                ],
+                "properties": {
+                  "workdir": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "command": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "inputs": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
+                }
+              }
+            ]
           }
         },
         {
@@ -107,69 +143,174 @@
       ]
     },
     "sourceRun": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "command"
-      ],
-      "properties": {
-        "workdir": {
-          "type": "string",
-          "minLength": 1
-        },
-        "command": {
+      "oneOf": [
+        {
           "type": "array",
           "minItems": 1,
           "items": {
-            "type": "string",
-            "minLength": 1
+            "oneOf": [
+              {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "command"
+                ],
+                "properties": {
+                  "workdir": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "command": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "env": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "readyTimeout": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              }
+            ]
           }
         },
-        "env": {
+        {
           "type": "object",
-          "additionalProperties": {
-            "type": "string"
+          "additionalProperties": false,
+          "required": [
+            "command"
+          ],
+          "properties": {
+            "workdir": {
+              "type": "string",
+              "minLength": 1
+            },
+            "command": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "env": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "readyTimeout": {
+              "type": "string",
+              "minLength": 1
+            }
           }
-        },
-        "readyTimeout": {
-          "type": "string",
-          "minLength": 1
         }
-      }
+      ]
     },
     "sourceInstall": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "command"
-      ],
-      "properties": {
-        "workdir": {
-          "type": "string",
-          "minLength": 1
-        },
-        "command": {
+      "oneOf": [
+        {
           "type": "array",
           "minItems": 1,
           "items": {
-            "type": "string",
-            "minLength": 1
+            "oneOf": [
+              {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "command"
+                ],
+                "properties": {
+                  "workdir": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "command": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "inputs": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "env": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            ]
           }
         },
-        "inputs": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "minLength": 1
-          }
-        },
-        "env": {
+        {
           "type": "object",
-          "additionalProperties": {
-            "type": "string"
+          "additionalProperties": false,
+          "required": [
+            "command"
+          ],
+          "properties": {
+            "workdir": {
+              "type": "string",
+              "minLength": 1
+            },
+            "command": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "inputs": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "env": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
           }
         }
-      }
+      ]
     },
     "spec": {
       "type": "object",

--- a/gestaltd/sdk/providermanifest/v1/phase_command.go
+++ b/gestaltd/sdk/providermanifest/v1/phase_command.go
@@ -1,0 +1,220 @@
+package providermanifestv1
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// SourcePhaseCommand is one serial step in an install, build, or run phase.
+type SourcePhaseCommand struct {
+	Command      []string          `json:"command" yaml:"command"`
+	Workdir      string            `json:"workdir,omitempty" yaml:"workdir,omitempty"`
+	Env          map[string]string `json:"env,omitempty" yaml:"env,omitempty"`
+	Inputs       []string          `json:"inputs,omitempty" yaml:"inputs,omitempty"`
+	ReadyTimeout string            `json:"readyTimeout,omitempty" yaml:"readyTimeout,omitempty"`
+}
+
+type phaseWireForm int
+
+const (
+	phaseWireUnset phaseWireForm = iota
+	phaseWireLegacyObject
+	phaseWirePrepareOnlySequence
+	phaseWireCommandList
+)
+
+type sourcePhaseCommandWire struct {
+	Command      []string          `json:"command" yaml:"command"`
+	Workdir      string            `json:"workdir,omitempty" yaml:"workdir,omitempty"`
+	Env          map[string]string `json:"env,omitempty" yaml:"env,omitempty"`
+	Inputs       []string          `json:"inputs,omitempty" yaml:"inputs,omitempty"`
+	ReadyTimeout string            `json:"readyTimeout,omitempty" yaml:"readyTimeout,omitempty"`
+}
+
+func parsePhaseCommandFromJSON(data []byte, allowed map[string]struct{}, subject string) (SourcePhaseCommand, error) {
+	if err := validateJSONWireObjectFields(data, allowed); err != nil {
+		return SourcePhaseCommand{}, err
+	}
+	var raw sourcePhaseCommandWire
+	if err := decodeJSONKnownFields(data, &raw); err != nil {
+		return SourcePhaseCommand{}, err
+	}
+	if len(raw.Command) == 0 {
+		return SourcePhaseCommand{}, fmt.Errorf("%s.command is required", subject)
+	}
+	return SourcePhaseCommand(raw), nil
+}
+
+func parsePhaseCommandFromYAML(node *yaml.Node, allowed map[string]struct{}, subject string) (SourcePhaseCommand, error) {
+	if node.Kind != yaml.MappingNode {
+		return SourcePhaseCommand{}, fmt.Errorf("%s must be a mapping", subject)
+	}
+	if err := validateYAMLWireObjectFields(node, allowed, subject); err != nil {
+		return SourcePhaseCommand{}, err
+	}
+	var raw sourcePhaseCommandWire
+	if err := decodeYAMLKnownFields(node, &raw); err != nil {
+		return SourcePhaseCommand{}, err
+	}
+	if len(raw.Command) == 0 {
+		return SourcePhaseCommand{}, fmt.Errorf("%s.command is required", subject)
+	}
+	return SourcePhaseCommand(raw), nil
+}
+
+func parsePhaseCommandListFromJSON(data []byte, allowed map[string]struct{}, subject string, scalarSeqOK bool) ([]SourcePhaseCommand, error) {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || trimmed[0] != '[' {
+		return nil, fmt.Errorf("%s must be a sequence", subject)
+	}
+	var nodes []json.RawMessage
+	if err := json.Unmarshal(trimmed, &nodes); err != nil {
+		return nil, err
+	}
+	if len(nodes) == 0 {
+		return nil, fmt.Errorf("%s must not be empty", subject)
+	}
+	if scalarSeqOK && allJSONScalars(nodes) {
+		var command []string
+		if err := json.Unmarshal(trimmed, &command); err != nil {
+			return nil, err
+		}
+		return []SourcePhaseCommand{{Command: command}}, nil
+	}
+	commands := make([]SourcePhaseCommand, 0, len(nodes))
+	for i, node := range nodes {
+		entrySubject := fmt.Sprintf("%s[%d]", subject, i)
+		trimmedNode := bytes.TrimSpace(node)
+		if len(trimmedNode) > 0 && trimmedNode[0] == '[' {
+			var command []string
+			if err := json.Unmarshal(trimmedNode, &command); err != nil {
+				return nil, err
+			}
+			if len(command) == 0 {
+				return nil, fmt.Errorf("%s.command is required", entrySubject)
+			}
+			commands = append(commands, SourcePhaseCommand{Command: command})
+			continue
+		}
+		cmd, err := parsePhaseCommandFromJSON(trimmedNode, allowed, entrySubject)
+		if err != nil {
+			return nil, err
+		}
+		commands = append(commands, cmd)
+	}
+	return commands, nil
+}
+
+func parsePhaseCommandListFromYAML(node *yaml.Node, allowed map[string]struct{}, subject string, scalarSeqOK bool) ([]SourcePhaseCommand, error) {
+	if node == nil || node.Kind != yaml.SequenceNode {
+		return nil, fmt.Errorf("%s must be a sequence", subject)
+	}
+	if len(node.Content) == 0 {
+		return nil, fmt.Errorf("%s must not be empty", subject)
+	}
+	if scalarSeqOK && allYAMLScalars(node) {
+		var command []string
+		if err := node.Decode(&command); err != nil {
+			return nil, err
+		}
+		return []SourcePhaseCommand{{Command: command}}, nil
+	}
+	commands := make([]SourcePhaseCommand, 0, len(node.Content))
+	for i, child := range node.Content {
+		entrySubject := fmt.Sprintf("%s[%d]", subject, i)
+		switch child.Kind {
+		case yaml.SequenceNode:
+			var command []string
+			if err := child.Decode(&command); err != nil {
+				return nil, err
+			}
+			if len(command) == 0 {
+				return nil, fmt.Errorf("%s.command is required", entrySubject)
+			}
+			commands = append(commands, SourcePhaseCommand{Command: command})
+		case yaml.MappingNode:
+			cmd, err := parsePhaseCommandFromYAML(child, allowed, entrySubject)
+			if err != nil {
+				return nil, err
+			}
+			commands = append(commands, cmd)
+		default:
+			return nil, fmt.Errorf("%s must be a sequence or mapping", entrySubject)
+		}
+	}
+	return commands, nil
+}
+
+func allJSONScalars(nodes []json.RawMessage) bool {
+	for _, node := range nodes {
+		trimmed := bytes.TrimSpace(node)
+		if len(trimmed) == 0 {
+			return false
+		}
+		switch trimmed[0] {
+		case '"', 'n', 't', 'f':
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func allYAMLScalars(node *yaml.Node) bool {
+	for _, child := range node.Content {
+		if child.Kind != yaml.ScalarNode {
+			return false
+		}
+	}
+	return true
+}
+
+func syncLegacyPhaseFields(command *[]string, workdir *string, env *map[string]string, inputs *[]string, readyTimeout *string, commands []SourcePhaseCommand, wire phaseWireForm) {
+	if len(commands) != 1 {
+		return
+	}
+	if wire != phaseWireLegacyObject && wire != phaseWirePrepareOnlySequence {
+		return
+	}
+	*command = append([]string(nil), commands[0].Command...)
+	*workdir = commands[0].Workdir
+	if commands[0].Env != nil {
+		*env = commands[0].Env
+	} else {
+		*env = nil
+	}
+	*inputs = append([]string(nil), commands[0].Inputs...)
+	*readyTimeout = commands[0].ReadyTimeout
+}
+
+func marshalPhaseCommandListJSONValue(commands []SourcePhaseCommand, allowed map[string]struct{}) []any {
+	out := make([]any, 0, len(commands))
+	for _, cmd := range commands {
+		if cmd.Workdir == "" && len(cmd.Env) == 0 && len(cmd.Inputs) == 0 && cmd.ReadyTimeout == "" {
+			out = append(out, append([]string(nil), cmd.Command...))
+			continue
+		}
+		out = append(out, sourcePhaseCommandWire(cmd))
+	}
+	return out
+}
+
+func marshalPhaseCommandListJSON(commands []SourcePhaseCommand, allowed map[string]struct{}) ([]byte, error) {
+	return json.Marshal(marshalPhaseCommandListJSONValue(commands, allowed))
+}
+
+func marshalPhaseCommandListYAML(commands []SourcePhaseCommand, allowed map[string]struct{}) ([]any, error) {
+	out := make([]any, 0, len(commands))
+	for _, cmd := range commands {
+		if cmd.Workdir == "" && len(cmd.Env) == 0 && len(cmd.Inputs) == 0 && cmd.ReadyTimeout == "" {
+			out = append(out, append([]string(nil), cmd.Command...))
+			continue
+		}
+		out = append(out, sourcePhaseCommandWire(cmd))
+	}
+	return out, nil
+}

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -51,12 +51,37 @@ type SourceBuild struct {
 	Command     []string `json:"command" yaml:"command"`
 	Inputs      []string `json:"inputs,omitempty" yaml:"inputs,omitempty"`
 	PrepareOnly bool     `json:"-" yaml:"-"`
+
+	Commands []SourcePhaseCommand `json:"-" yaml:"-"`
+	WireForm phaseWireForm        `json:"-" yaml:"-"`
 }
 
-type sourceBuildWire struct {
-	Workdir string   `json:"workdir,omitempty" yaml:"workdir,omitempty"`
-	Command []string `json:"command" yaml:"command"`
-	Inputs  []string `json:"inputs,omitempty" yaml:"inputs,omitempty"`
+func (b *SourceBuild) PhaseCommands() []SourcePhaseCommand {
+	if b == nil {
+		return nil
+	}
+	if len(b.Commands) > 0 {
+		out := make([]SourcePhaseCommand, len(b.Commands))
+		copy(out, b.Commands)
+		return out
+	}
+	if len(b.Command) == 0 {
+		return nil
+	}
+	return []SourcePhaseCommand{{
+		Command: append([]string(nil), b.Command...),
+		Workdir: b.Workdir,
+		Inputs:  append([]string(nil), b.Inputs...),
+	}}
+}
+
+func (b *SourceBuild) setCommands(commands []SourcePhaseCommand, wire phaseWireForm, prepareOnly bool) {
+	b.Commands = commands
+	b.WireForm = wire
+	b.PrepareOnly = prepareOnly
+	var env map[string]string
+	var ready string
+	syncLegacyPhaseFields(&b.Command, &b.Workdir, &env, &b.Inputs, &ready, commands, wire)
 }
 
 func (b *SourceBuild) UnmarshalJSON(data []byte) error {
@@ -69,37 +94,55 @@ func (b *SourceBuild) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	if len(trimmed) > 0 && trimmed[0] == '[' {
-		var command []string
-		if err := json.Unmarshal(trimmed, &command); err != nil {
+		var nodes []json.RawMessage
+		if err := json.Unmarshal(trimmed, &nodes); err != nil {
 			return err
 		}
-		*b = SourceBuild{Command: command, PrepareOnly: true}
+		if allJSONScalars(nodes) {
+			var command []string
+			if err := json.Unmarshal(trimmed, &command); err != nil {
+				return err
+			}
+			b.setCommands([]SourcePhaseCommand{{Command: command}}, phaseWirePrepareOnlySequence, true)
+			return nil
+		}
+		commands, err := parsePhaseCommandListFromJSON(trimmed, sourceBuildWireFields, "build", false)
+		if err != nil {
+			return err
+		}
+		b.setCommands(commands, phaseWireCommandList, false)
 		return nil
 	}
-	if err := validateJSONWireObjectFields(trimmed, sourceBuildWireFields); err != nil {
+	cmd, err := parsePhaseCommandFromJSON(trimmed, sourceBuildWireFields, "build")
+	if err != nil {
 		return err
 	}
-	var raw sourceBuildWire
-	if err := decodeJSONKnownFields(trimmed, &raw); err != nil {
-		return err
-	}
-	*b = SourceBuild{
-		Workdir: raw.Workdir,
-		Command: raw.Command,
-		Inputs:  raw.Inputs,
-	}
+	b.setCommands([]SourcePhaseCommand{cmd}, phaseWireLegacyObject, false)
 	return nil
 }
 
 func (b SourceBuild) MarshalJSON() ([]byte, error) {
-	if b.PrepareOnly {
-		return json.Marshal(b.Command)
+	commands := b.PhaseCommands()
+	if b.PrepareOnly || b.WireForm == phaseWirePrepareOnlySequence {
+		if len(commands) != 1 {
+			return nil, fmt.Errorf("prepare-only build must have exactly one command")
+		}
+		return json.Marshal(commands[0].Command)
 	}
-	return json.Marshal(sourceBuildWire{
-		Workdir: b.Workdir,
-		Command: b.Command,
-		Inputs:  b.Inputs,
-	})
+	switch b.WireForm {
+	case phaseWirePrepareOnlySequence:
+		if len(commands) != 1 {
+			return nil, fmt.Errorf("prepare-only build must have exactly one command")
+		}
+		return json.Marshal(commands[0].Command)
+	case phaseWireCommandList:
+		return marshalPhaseCommandListJSON(commands, sourceBuildWireFields)
+	default:
+		if len(commands) != 1 {
+			return marshalPhaseCommandListJSON(commands, sourceBuildWireFields)
+		}
+		return json.Marshal(sourcePhaseCommandWire(commands[0]))
+	}
 }
 
 func (b *SourceBuild) UnmarshalYAML(value *yaml.Node) error {
@@ -112,25 +155,22 @@ func (b *SourceBuild) UnmarshalYAML(value *yaml.Node) error {
 	}
 	switch value.Kind {
 	case yaml.SequenceNode:
-		var command []string
-		if err := value.Decode(&command); err != nil {
+		commands, err := parsePhaseCommandListFromYAML(value, sourceBuildWireFields, "build", true)
+		if err != nil {
 			return err
 		}
-		*b = SourceBuild{Command: command, PrepareOnly: true}
+		wire := phaseWirePrepareOnlySequence
+		if !allYAMLScalars(value) {
+			wire = phaseWireCommandList
+		}
+		b.setCommands(commands, wire, wire == phaseWirePrepareOnlySequence)
 		return nil
 	case yaml.MappingNode:
-		if err := validateYAMLWireObjectFields(value, sourceBuildWireFields, "build"); err != nil {
+		cmd, err := parsePhaseCommandFromYAML(value, sourceBuildWireFields, "build")
+		if err != nil {
 			return err
 		}
-		var raw sourceBuildWire
-		if err := decodeYAMLKnownFields(value, &raw); err != nil {
-			return err
-		}
-		*b = SourceBuild{
-			Workdir: raw.Workdir,
-			Command: raw.Command,
-			Inputs:  raw.Inputs,
-		}
+		b.setCommands([]SourcePhaseCommand{cmd}, phaseWireLegacyObject, false)
 		return nil
 	default:
 		return fmt.Errorf("build must be a sequence or mapping")
@@ -138,14 +178,27 @@ func (b *SourceBuild) UnmarshalYAML(value *yaml.Node) error {
 }
 
 func (b SourceBuild) MarshalYAML() (any, error) {
-	if b.PrepareOnly {
-		return append([]string(nil), b.Command...), nil
+	commands := b.PhaseCommands()
+	if b.PrepareOnly || b.WireForm == phaseWirePrepareOnlySequence {
+		if len(commands) != 1 {
+			return nil, fmt.Errorf("prepare-only build must have exactly one command")
+		}
+		return append([]string(nil), commands[0].Command...), nil
 	}
-	return sourceBuildWire{
-		Workdir: b.Workdir,
-		Command: b.Command,
-		Inputs:  b.Inputs,
-	}, nil
+	switch b.WireForm {
+	case phaseWirePrepareOnlySequence:
+		if len(commands) != 1 {
+			return nil, fmt.Errorf("prepare-only build must have exactly one command")
+		}
+		return append([]string(nil), commands[0].Command...), nil
+	case phaseWireCommandList:
+		return marshalPhaseCommandListYAML(commands, sourceBuildWireFields)
+	default:
+		if len(commands) != 1 {
+			return marshalPhaseCommandListYAML(commands, sourceBuildWireFields)
+		}
+		return sourcePhaseCommandWire(commands[0]), nil
+	}
 }
 
 // SourceInstall declares a pre-build dependency-install command. It is a peer
@@ -159,13 +212,36 @@ type SourceInstall struct {
 	Workdir string            `json:"workdir,omitempty"  yaml:"workdir,omitempty"`
 	Inputs  []string          `json:"inputs,omitempty"   yaml:"inputs,omitempty"`
 	Env     map[string]string `json:"env,omitempty"      yaml:"env,omitempty"`
+
+	Commands []SourcePhaseCommand `json:"-" yaml:"-"`
+	WireForm phaseWireForm        `json:"-" yaml:"-"`
 }
 
-type sourceInstallWire struct {
-	Command []string          `json:"command"            yaml:"command"`
-	Workdir string            `json:"workdir,omitempty"  yaml:"workdir,omitempty"`
-	Inputs  []string          `json:"inputs,omitempty"   yaml:"inputs,omitempty"`
-	Env     map[string]string `json:"env,omitempty"      yaml:"env,omitempty"`
+func (i *SourceInstall) PhaseCommands() []SourcePhaseCommand {
+	if i == nil {
+		return nil
+	}
+	if len(i.Commands) > 0 {
+		out := make([]SourcePhaseCommand, len(i.Commands))
+		copy(out, i.Commands)
+		return out
+	}
+	if len(i.Command) == 0 {
+		return nil
+	}
+	return []SourcePhaseCommand{{
+		Command: append([]string(nil), i.Command...),
+		Workdir: i.Workdir,
+		Inputs:  append([]string(nil), i.Inputs...),
+		Env:     i.Env,
+	}}
+}
+
+func (i *SourceInstall) setCommands(commands []SourcePhaseCommand, wire phaseWireForm) {
+	i.Commands = commands
+	i.WireForm = wire
+	var ready string
+	syncLegacyPhaseFields(&i.Command, &i.Workdir, &i.Env, &i.Inputs, &ready, commands, wire)
 }
 
 func (i *SourceInstall) UnmarshalJSON(data []byte) error {
@@ -178,24 +254,32 @@ func (i *SourceInstall) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	if len(trimmed) > 0 && trimmed[0] == '[' {
-		return fmt.Errorf("install must be a mapping")
+		commands, err := parsePhaseCommandListFromJSON(trimmed, sourceInstallWireFields, "install", false)
+		if err != nil {
+			return err
+		}
+		i.setCommands(commands, phaseWireCommandList)
+		return nil
 	}
-	if err := validateJSONWireObjectFields(trimmed, sourceInstallWireFields); err != nil {
+	cmd, err := parsePhaseCommandFromJSON(trimmed, sourceInstallWireFields, "install")
+	if err != nil {
 		return err
 	}
-	var raw sourceInstallWire
-	if err := decodeJSONKnownFields(trimmed, &raw); err != nil {
-		return err
-	}
-	if len(raw.Command) == 0 {
-		return fmt.Errorf("install.command is required")
-	}
-	*i = SourceInstall(raw)
+	i.setCommands([]SourcePhaseCommand{cmd}, phaseWireLegacyObject)
 	return nil
 }
 
 func (i SourceInstall) MarshalJSON() ([]byte, error) {
-	return json.Marshal(sourceInstallWire(i))
+	commands := i.PhaseCommands()
+	switch i.WireForm {
+	case phaseWireCommandList:
+		return marshalPhaseCommandListJSON(commands, sourceInstallWireFields)
+	default:
+		if len(commands) != 1 {
+			return marshalPhaseCommandListJSON(commands, sourceInstallWireFields)
+		}
+		return json.Marshal(sourcePhaseCommandWire(commands[0]))
+	}
 }
 
 func (i *SourceInstall) UnmarshalYAML(value *yaml.Node) error {
@@ -206,25 +290,37 @@ func (i *SourceInstall) UnmarshalYAML(value *yaml.Node) error {
 		*i = SourceInstall{}
 		return nil
 	}
-	if value.Kind != yaml.MappingNode {
-		return fmt.Errorf("install must be a mapping")
+	switch value.Kind {
+	case yaml.SequenceNode:
+		commands, err := parsePhaseCommandListFromYAML(value, sourceInstallWireFields, "install", false)
+		if err != nil {
+			return err
+		}
+		i.setCommands(commands, phaseWireCommandList)
+		return nil
+	case yaml.MappingNode:
+		cmd, err := parsePhaseCommandFromYAML(value, sourceInstallWireFields, "install")
+		if err != nil {
+			return err
+		}
+		i.setCommands([]SourcePhaseCommand{cmd}, phaseWireLegacyObject)
+		return nil
+	default:
+		return fmt.Errorf("install must be a sequence or mapping")
 	}
-	if err := validateYAMLWireObjectFields(value, sourceInstallWireFields, "install"); err != nil {
-		return err
-	}
-	var raw sourceInstallWire
-	if err := decodeYAMLKnownFields(value, &raw); err != nil {
-		return err
-	}
-	if len(raw.Command) == 0 {
-		return fmt.Errorf("install.command is required")
-	}
-	*i = SourceInstall(raw)
-	return nil
 }
 
 func (i SourceInstall) MarshalYAML() (any, error) {
-	return sourceInstallWire(i), nil
+	commands := i.PhaseCommands()
+	switch i.WireForm {
+	case phaseWireCommandList:
+		return marshalPhaseCommandListYAML(commands, sourceInstallWireFields)
+	default:
+		if len(commands) != 1 {
+			return marshalPhaseCommandListYAML(commands, sourceInstallWireFields)
+		}
+		return sourcePhaseCommandWire(commands[0]), nil
+	}
 }
 
 // SourceRun declares how a local-source provider is executed from source.
@@ -236,13 +332,36 @@ type SourceRun struct {
 	Workdir      string            `json:"workdir,omitempty" yaml:"workdir,omitempty"`
 	Env          map[string]string `json:"env,omitempty" yaml:"env,omitempty"`
 	ReadyTimeout string            `json:"readyTimeout,omitempty" yaml:"readyTimeout,omitempty"`
+
+	Commands []SourcePhaseCommand `json:"-" yaml:"-"`
+	WireForm phaseWireForm        `json:"-" yaml:"-"`
 }
 
-type sourceRunWire struct {
-	Command      []string          `json:"command" yaml:"command"`
-	Workdir      string            `json:"workdir,omitempty" yaml:"workdir,omitempty"`
-	Env          map[string]string `json:"env,omitempty" yaml:"env,omitempty"`
-	ReadyTimeout string            `json:"readyTimeout,omitempty" yaml:"readyTimeout,omitempty"`
+func (r *SourceRun) PhaseCommands() []SourcePhaseCommand {
+	if r == nil {
+		return nil
+	}
+	if len(r.Commands) > 0 {
+		out := make([]SourcePhaseCommand, len(r.Commands))
+		copy(out, r.Commands)
+		return out
+	}
+	if len(r.Command) == 0 {
+		return nil
+	}
+	return []SourcePhaseCommand{{
+		Command:      append([]string(nil), r.Command...),
+		Workdir:      r.Workdir,
+		Env:          r.Env,
+		ReadyTimeout: r.ReadyTimeout,
+	}}
+}
+
+func (r *SourceRun) setCommands(commands []SourcePhaseCommand, wire phaseWireForm) {
+	r.Commands = commands
+	r.WireForm = wire
+	var inputs []string
+	syncLegacyPhaseFields(&r.Command, &r.Workdir, &r.Env, &inputs, &r.ReadyTimeout, commands, wire)
 }
 
 func (r *SourceRun) UnmarshalJSON(data []byte) error {
@@ -255,24 +374,32 @@ func (r *SourceRun) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	if len(trimmed) > 0 && trimmed[0] == '[' {
-		return fmt.Errorf("run must be a mapping")
+		commands, err := parsePhaseCommandListFromJSON(trimmed, sourceRunWireFields, "run", false)
+		if err != nil {
+			return err
+		}
+		r.setCommands(commands, phaseWireCommandList)
+		return nil
 	}
-	if err := validateJSONWireObjectFields(trimmed, sourceRunWireFields); err != nil {
+	cmd, err := parsePhaseCommandFromJSON(trimmed, sourceRunWireFields, "run")
+	if err != nil {
 		return err
 	}
-	var raw sourceRunWire
-	if err := decodeJSONKnownFields(trimmed, &raw); err != nil {
-		return err
-	}
-	if len(raw.Command) == 0 {
-		return fmt.Errorf("run.command is required")
-	}
-	*r = SourceRun(raw)
+	r.setCommands([]SourcePhaseCommand{cmd}, phaseWireLegacyObject)
 	return nil
 }
 
 func (r SourceRun) MarshalJSON() ([]byte, error) {
-	return json.Marshal(sourceRunWire(r))
+	commands := r.PhaseCommands()
+	switch r.WireForm {
+	case phaseWireCommandList:
+		return marshalPhaseCommandListJSON(commands, sourceRunWireFields)
+	default:
+		if len(commands) != 1 {
+			return marshalPhaseCommandListJSON(commands, sourceRunWireFields)
+		}
+		return json.Marshal(sourcePhaseCommandWire(commands[0]))
+	}
 }
 
 func (r *SourceRun) UnmarshalYAML(value *yaml.Node) error {
@@ -283,25 +410,37 @@ func (r *SourceRun) UnmarshalYAML(value *yaml.Node) error {
 		*r = SourceRun{}
 		return nil
 	}
-	if value.Kind != yaml.MappingNode {
-		return fmt.Errorf("run must be a mapping")
+	switch value.Kind {
+	case yaml.SequenceNode:
+		commands, err := parsePhaseCommandListFromYAML(value, sourceRunWireFields, "run", false)
+		if err != nil {
+			return err
+		}
+		r.setCommands(commands, phaseWireCommandList)
+		return nil
+	case yaml.MappingNode:
+		cmd, err := parsePhaseCommandFromYAML(value, sourceRunWireFields, "run")
+		if err != nil {
+			return err
+		}
+		r.setCommands([]SourcePhaseCommand{cmd}, phaseWireLegacyObject)
+		return nil
+	default:
+		return fmt.Errorf("run must be a sequence or mapping")
 	}
-	if err := validateYAMLWireObjectFields(value, sourceRunWireFields, "run"); err != nil {
-		return err
-	}
-	var raw sourceRunWire
-	if err := decodeYAMLKnownFields(value, &raw); err != nil {
-		return err
-	}
-	if len(raw.Command) == 0 {
-		return fmt.Errorf("run.command is required")
-	}
-	*r = SourceRun(raw)
-	return nil
 }
 
 func (r SourceRun) MarshalYAML() (any, error) {
-	return sourceRunWire(r), nil
+	commands := r.PhaseCommands()
+	switch r.WireForm {
+	case phaseWireCommandList:
+		return marshalPhaseCommandListYAML(commands, sourceRunWireFields)
+	default:
+		if len(commands) != 1 {
+			return marshalPhaseCommandListYAML(commands, sourceRunWireFields)
+		}
+		return sourcePhaseCommandWire(commands[0]), nil
+	}
 }
 
 // Spec is a union type validated per kind. For auth/indexeddb/secrets only

--- a/gestaltd/services/apps/packageio/manifest.go
+++ b/gestaltd/services/apps/packageio/manifest.go
@@ -231,6 +231,13 @@ func validateManifest(manifest *providermanifestv1.Manifest, sourceMode bool) er
 		if err := validateOwnedUI(spec.UI, sourceMode); err != nil {
 			return err
 		}
+		if !sourceMode && spec != nil && spec.AssetRoot != "" {
+			if err := validateRelativePackagePath(spec.AssetRoot, "spec.assetRoot"); err != nil {
+				return err
+			}
+		} else if sourceMode && spec != nil && spec.AssetRoot != "" {
+			return fmt.Errorf("spec.assetRoot is only allowed in prepared app manifests")
+		}
 		if spec != nil && spec.IsDeclarative() {
 			if err := validateDeclarativeProvider(spec); err != nil {
 				return err
@@ -241,6 +248,7 @@ func validateManifest(manifest *providermanifestv1.Manifest, sourceMode bool) er
 			if err := validateEntrypoint(kind, manifest.Entrypoint, artifactPaths, sourceMode); err != nil {
 				return err
 			}
+		case spec != nil && spec.AssetRoot != "" && !sourceMode:
 		case manifest.Build != nil && !manifest.Build.PrepareOnly && !sourceMode:
 			return fmt.Errorf("entrypoint is required when build is set")
 		case manifest.IsDeclarativeOnlyProvider():
@@ -456,32 +464,44 @@ func validateSourceBuild(build *providermanifestv1.SourceBuild) error {
 	if build == nil {
 		return nil
 	}
-	if build.PrepareOnly && build.Workdir != "" {
-		return fmt.Errorf("build.workdir is only supported with object-form build metadata")
-	}
-	if build.PrepareOnly && len(build.Inputs) > 0 {
-		return fmt.Errorf("build.inputs is only supported with object-form build metadata")
-	}
-	if build.Workdir != "" {
-		if err := validateRelativeSourcePath(build.Workdir, "build.workdir"); err != nil {
-			return err
-		}
-	}
-	if len(build.Command) == 0 {
+	commands := build.PhaseCommands()
+	if len(commands) == 0 {
 		return fmt.Errorf("build.command is required")
 	}
-	for i, arg := range build.Command {
-		if strings.TrimSpace(arg) == "" {
-			return fmt.Errorf("build.command[%d] is required", i)
+	if build.PrepareOnly {
+		if build.Workdir != "" {
+			return fmt.Errorf("build.workdir is only supported with object-form build metadata")
+		}
+		if len(build.Inputs) > 0 {
+			return fmt.Errorf("build.inputs is only supported with object-form build metadata")
 		}
 	}
-	for i, input := range build.Inputs {
-		label := fmt.Sprintf("build.inputs[%d]", i)
-		if strings.ContainsAny(input, "*?[") {
-			return fmt.Errorf("%s does not support glob syntax", label)
+	for i, command := range commands {
+		label := "build"
+		if len(commands) > 1 {
+			label = fmt.Sprintf("build[%d]", i)
 		}
-		if err := validateRelativeSourcePath(input, label); err != nil {
-			return err
+		if command.Workdir != "" {
+			if err := validateRelativeSourcePath(command.Workdir, label+".workdir"); err != nil {
+				return err
+			}
+		}
+		if len(command.Command) == 0 {
+			return fmt.Errorf("%s.command is required", label)
+		}
+		for j, arg := range command.Command {
+			if strings.TrimSpace(arg) == "" {
+				return fmt.Errorf("%s.command[%d] is required", label, j)
+			}
+		}
+		for j, input := range command.Inputs {
+			inputLabel := fmt.Sprintf("%s.inputs[%d]", label, j)
+			if strings.ContainsAny(input, "*?[") {
+				return fmt.Errorf("%s does not support glob syntax", inputLabel)
+			}
+			if err := validateRelativeSourcePath(input, inputLabel); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -491,26 +511,36 @@ func validateSourceInstall(install *providermanifestv1.SourceInstall) error {
 	if install == nil {
 		return nil
 	}
-	if install.Workdir != "" {
-		if err := validateRelativeSourcePath(install.Workdir, "install.workdir"); err != nil {
-			return err
-		}
-	}
-	if len(install.Command) == 0 {
+	commands := install.PhaseCommands()
+	if len(commands) == 0 {
 		return fmt.Errorf("install.command is required")
 	}
-	for i, arg := range install.Command {
-		if strings.TrimSpace(arg) == "" {
-			return fmt.Errorf("install.command[%d] is required", i)
+	for i, command := range commands {
+		label := "install"
+		if len(commands) > 1 {
+			label = fmt.Sprintf("install[%d]", i)
 		}
-	}
-	for i, input := range install.Inputs {
-		label := fmt.Sprintf("install.inputs[%d]", i)
-		if strings.ContainsAny(input, "*?[") {
-			return fmt.Errorf("%s does not support glob syntax", label)
+		if command.Workdir != "" {
+			if err := validateRelativeSourcePath(command.Workdir, label+".workdir"); err != nil {
+				return err
+			}
 		}
-		if err := validateRelativeSourcePath(input, label); err != nil {
-			return err
+		if len(command.Command) == 0 {
+			return fmt.Errorf("%s.command is required", label)
+		}
+		for j, arg := range command.Command {
+			if strings.TrimSpace(arg) == "" {
+				return fmt.Errorf("%s.command[%d] is required", label, j)
+			}
+		}
+		for j, input := range command.Inputs {
+			inputLabel := fmt.Sprintf("%s.inputs[%d]", label, j)
+			if strings.ContainsAny(input, "*?[") {
+				return fmt.Errorf("%s does not support glob syntax", inputLabel)
+			}
+			if err := validateRelativeSourcePath(input, inputLabel); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -520,22 +550,32 @@ func validateSourceRun(run *providermanifestv1.SourceRun) error {
 	if run == nil {
 		return nil
 	}
-	if run.Workdir != "" {
-		if err := validateRelativeSourcePath(run.Workdir, "run.workdir"); err != nil {
-			return err
-		}
-	}
-	if len(run.Command) == 0 {
+	commands := run.PhaseCommands()
+	if len(commands) == 0 {
 		return fmt.Errorf("run.command is required")
 	}
-	for i, arg := range run.Command {
-		if strings.TrimSpace(arg) == "" {
-			return fmt.Errorf("run.command[%d] is required", i)
+	for i, command := range commands {
+		label := "run"
+		if len(commands) > 1 {
+			label = fmt.Sprintf("run[%d]", i)
 		}
-	}
-	if strings.TrimSpace(run.ReadyTimeout) != "" {
-		if _, err := time.ParseDuration(strings.TrimSpace(run.ReadyTimeout)); err != nil {
-			return fmt.Errorf("run.readyTimeout: %w", err)
+		if command.Workdir != "" {
+			if err := validateRelativeSourcePath(command.Workdir, label+".workdir"); err != nil {
+				return err
+			}
+		}
+		if len(command.Command) == 0 {
+			return fmt.Errorf("%s.command is required", label)
+		}
+		for j, arg := range command.Command {
+			if strings.TrimSpace(arg) == "" {
+				return fmt.Errorf("%s.command[%d] is required", label, j)
+			}
+		}
+		if strings.TrimSpace(command.ReadyTimeout) != "" {
+			if _, err := time.ParseDuration(strings.TrimSpace(command.ReadyTimeout)); err != nil {
+				return fmt.Errorf("%s.readyTimeout: %w", label, err)
+			}
 		}
 	}
 	return nil

--- a/gestaltd/services/apps/providerpkg/manifest_source_run_test.go
+++ b/gestaltd/services/apps/providerpkg/manifest_source_run_test.go
@@ -141,8 +141,8 @@ spec:
 `))
 
 	_, _, err := ReadSourceManifestFile(manifestPath)
-	if err == nil || !strings.Contains(err.Error(), "install must be a mapping") {
-		t.Fatalf("ReadSourceManifestFile error = %v, want install must be a mapping", err)
+	if err == nil || !strings.Contains(err.Error(), "install[0] must be a sequence or mapping") {
+		t.Fatalf("ReadSourceManifestFile error = %v, want install sequence rejection", err)
 	}
 }
 
@@ -170,5 +170,77 @@ func TestPrepareSourceManifest_RunsInstallBeforeRunCatalog(t *testing.T) {
 
 	if _, _, err := PrepareSourceManifest(manifestPath); err != nil {
 		t.Fatalf("PrepareSourceManifest: %v (install should run before run/catalog)", err)
+	}
+}
+
+func TestSourceManifestRoundTripsMixedPhaseLists(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	original := []byte(`
+kind: app
+source: github.com/acme/apps/mixed-phases
+version: 0.0.1-alpha.1
+install:
+  - [uv, sync]
+  - {command: [bun, install], workdir: ui, inputs: [bun.lock]}
+build:
+  - [go, build]
+  - {command: [bun, run, build], workdir: ui}
+run:
+  command: [uv, run, provider.py, --serve]
+spec:
+  connections:
+    default:
+      auth:
+        type: none
+`)
+	manifestPath := mustWriteManifestData(t, dir, "manifest.yaml", original)
+
+	_, manifest, err := ReadSourceManifestFile(manifestPath)
+	if err != nil {
+		t.Fatalf("ReadSourceManifestFile: %v", err)
+	}
+	if len(manifest.Install.PhaseCommands()) != 2 || len(manifest.Build.PhaseCommands()) != 2 {
+		t.Fatalf("install/build phase commands = %#v / %#v", manifest.Install, manifest.Build)
+	}
+
+	encoded, err := EncodeSourceManifestFormat(manifest, ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("EncodeSourceManifestFormat: %v", err)
+	}
+	roundTripped, err := DecodeSourceManifestFormat(encoded, ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("DecodeSourceManifestFormat: %v\n%s", err, encoded)
+	}
+	if len(roundTripped.Install.PhaseCommands()) != 2 || len(roundTripped.Build.PhaseCommands()) != 2 {
+		t.Fatalf("round-tripped phases = %#v / %#v", roundTripped.Install, roundTripped.Build)
+	}
+}
+
+func TestSourceRunCommand_RejectsMultipleRunEntries(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	manifestPath := mustWriteManifestData(t, dir, "manifest.yaml", []byte(`
+kind: app
+source: github.com/test/apps/multi-run
+version: 0.0.1-alpha.1
+run:
+  - [sh, -c, "true"]
+  - [sh, -c, "true"]
+spec: {}
+`))
+	_, err := SourceRunCommand(manifestPath)
+	if err == nil || !strings.Contains(err.Error(), errMultipleRunCommandsRequireDevMode) {
+		t.Fatalf("SourceRunCommand err = %v", err)
+	}
+	if _, _, err := PrepareSourceManifest(manifestPath); err == nil || !strings.Contains(err.Error(), errMultipleRunCommandsRequireDevMode) {
+		t.Fatalf("PrepareSourceManifest err = %v", err)
+	}
+	if _, err := StageSourcePreparedInstallDir(manifestPath, filepath.Join(t.TempDir(), "prepared"), StageSourcePreparedInstallOptions{
+		Kind: providermanifestv1.KindApp,
+	}); err == nil || !strings.Contains(err.Error(), errMultipleRunCommandsRequireDevMode) {
+		t.Fatalf("StageSourcePreparedInstallDir err = %v", err)
 	}
 }

--- a/gestaltd/services/apps/providerpkg/manifest_workflow_test.go
+++ b/gestaltd/services/apps/providerpkg/manifest_workflow_test.go
@@ -509,7 +509,7 @@ spec:
 `))
 			},
 			readSource: true,
-			wantError:  "run must be a mapping",
+			wantError:  "run[0] must be a sequence or mapping",
 		},
 		{
 			name: "released package rejects run metadata",

--- a/gestaltd/services/apps/providerpkg/prepared_stage.go
+++ b/gestaltd/services/apps/providerpkg/prepared_stage.go
@@ -60,6 +60,9 @@ func StageSourcePreparedInstallDir(manifestPath, stagingDir string, opts StageSo
 	if err != nil {
 		return nil, fmt.Errorf("read %s: %w", manifestPath, err)
 	}
+	if err := RejectMultipleSourceRuns(manifest); err != nil {
+		return nil, err
+	}
 	if strings.TrimSpace(opts.Kind) == "" {
 		if _, err := ManifestKind(manifest); err != nil {
 			return nil, err
@@ -211,6 +214,9 @@ func stagePreparedInstallDir(manifestPath, stagingDir string, srcManifest *provi
 	if err := copyPreparedInstallSupportFiles(stagedManifest, sourceDir, stagingDir, includeArtifacts); err != nil {
 		return nil, err
 	}
+	if err := stagePreparedStaticBundle(manifestPath, stagingDir, stagedManifest); err != nil {
+		return nil, err
+	}
 
 	stagedManifestPath := filepath.Join(stagingDir, manifestFile)
 	if err := writePreparedManifestFile(stagedManifestPath, manifestFormat, stagedManifest); err != nil {
@@ -316,14 +322,25 @@ func buildPreparedInstallSourceManifest(srcManifest *providermanifestv1.Manifest
 		if err != nil {
 			return nil, err
 		}
-		stagedRel := PackageExecutablePath(configuredName, goos)
-		digest, err := FileSHA256(filepath.Join(sourceDir, filepath.FromSlash(sourceRel)))
-		if err != nil {
-			return nil, fmt.Errorf("hash artifact %s: %w", sourceRel, err)
+		execPath := filepath.Join(sourceDir, filepath.FromSlash(sourceRel))
+		staticOK := false
+		if manifestPath, err := FindManifestFile(sourceDir); err == nil {
+			if ok, err := sourceStaticQualifies(SourceStaticBuildDir(manifestPath)); err == nil {
+				staticOK = ok
+			}
 		}
-		manifest.Entrypoint = &providermanifestv1.Entrypoint{ArtifactPath: stagedRel}
-		manifest.Artifacts = []providermanifestv1.Artifact{
-			{OS: goos, Arch: goarch, Path: stagedRel, SHA256: digest},
+		if _, err := os.Stat(execPath); err == nil {
+			stagedRel := PackageExecutablePath(configuredName, goos)
+			digest, err := FileSHA256(execPath)
+			if err != nil {
+				return nil, fmt.Errorf("hash artifact %s: %w", sourceRel, err)
+			}
+			manifest.Entrypoint = &providermanifestv1.Entrypoint{ArtifactPath: stagedRel}
+			manifest.Artifacts = []providermanifestv1.Artifact{
+				{OS: goos, Arch: goarch, Path: stagedRel, SHA256: digest},
+			}
+		} else if !staticOK {
+			return nil, fmt.Errorf("hash artifact %s: %w", sourceRel, err)
 		}
 	}
 

--- a/gestaltd/services/apps/providerpkg/prepared_stage_test.go
+++ b/gestaltd/services/apps/providerpkg/prepared_stage_test.go
@@ -754,3 +754,109 @@ chmod +x ` + buildOutputRel + `
 		t.Fatalf("SourceManifestExecution: %v (install should run before build)", err)
 	}
 }
+
+func TestStageSourcePreparedInstallDir_StagesStaticBundle(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == windowsOS {
+		t.Skip("POSIX shell fixture")
+	}
+
+	root := t.TempDir()
+	const source = "github.com/test/apps/static-frontend"
+	buildOutputRel := sourceBuildOutputRel(t, source, runtime.GOOS)
+	mustWriteFile(t, filepath.Join(root, "build.sh"), []byte(`#!/bin/sh
+set -eu
+out="`+buildOutputRel+`"
+mkdir -p "$(dirname "$out")"
+cat > "$out" <<'SH'
+#!/bin/sh
+if [ -n "$GESTALT_APP_WRITE_CATALOG" ]; then
+  printf 'name: provider\noperations:\n  - id: echo\n    method: POST\n' > "$GESTALT_APP_WRITE_CATALOG"
+fi
+SH
+chmod +x "$out"
+mkdir -p "$GESTALT_BUILD_STATIC"
+printf '<html>alpha</html>\n' > "$GESTALT_BUILD_STATIC/index.html"
+`), 0o755)
+	manifestPath := mustWriteManifestData(t, root, "manifest.yaml", []byte(`
+kind: app
+source: github.com/test/apps/static-frontend
+version: 0.0.1-alpha.1
+build:
+  - [sh, ./build.sh]
+run:
+  command: [sh, -c, "true"]
+spec: {}
+`))
+
+	stagingDir := filepath.Join(t.TempDir(), "prepared")
+	staged, err := StageSourcePreparedInstallDir(manifestPath, stagingDir, StageSourcePreparedInstallOptions{
+		Kind:    providermanifestv1.KindApp,
+		AppName: "alpha",
+		GOOS:    runtime.GOOS,
+		GOARCH:  runtime.GOARCH,
+	})
+	if err != nil {
+		t.Fatalf("StageSourcePreparedInstallDir: %v", err)
+	}
+	indexPath := filepath.Join(stagingDir, "static", "index.html")
+	data, err := os.ReadFile(indexPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", indexPath, err)
+	}
+	if !strings.Contains(string(data), "alpha") {
+		t.Fatalf("static index = %q", data)
+	}
+	if staged.Manifest == nil || staged.Manifest.Spec == nil || staged.Manifest.Spec.AssetRoot != "static" {
+		t.Fatalf("staged manifest spec.assetRoot = %#v, want static", staged.Manifest)
+	}
+}
+
+func TestStageSourcePreparedInstallDir_SerialBuildAbortOnFailure(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == windowsOS {
+		t.Skip("POSIX shell fixture")
+	}
+
+	root := t.TempDir()
+	logPath := filepath.Join(root, "build.log")
+	mustWriteFile(t, filepath.Join(root, "step.sh"), []byte(`#!/bin/sh
+set -eu
+step="$1"
+echo "$step" >> build.log
+if [ "$step" = "two" ] && [ "${FAIL_STEP_TWO:-}" = "1" ]; then
+  exit 1
+fi
+`), 0o755)
+	manifestPath := mustWriteManifestData(t, root, "manifest.yaml", []byte(`
+kind: app
+source: github.com/test/apps/serial-build
+version: 0.0.1-alpha.1
+build:
+  - [sh, ./step.sh, one]
+  - [sh, ./step.sh, two]
+  - [sh, ./step.sh, three]
+run:
+  command: [sh, -c, "true"]
+spec: {}
+`))
+	if err := os.Setenv("FAIL_STEP_TWO", "1"); err != nil {
+		t.Fatalf("Setenv: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Unsetenv("FAIL_STEP_TWO") })
+
+	_, err := StageSourcePreparedInstallDir(manifestPath, filepath.Join(t.TempDir(), "prepared"), StageSourcePreparedInstallOptions{
+		Kind: providermanifestv1.KindApp,
+	})
+	if err == nil {
+		t.Fatal("StageSourcePreparedInstallDir: want failure on step two")
+	}
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("ReadFile(build.log): %v", err)
+	}
+	got := string(logData)
+	if !strings.Contains(got, "one") || strings.Contains(got, "three") {
+		t.Fatalf("build.log = %q, want one without three after abort", got)
+	}
+}

--- a/gestaltd/services/apps/providerpkg/release_target.go
+++ b/gestaltd/services/apps/providerpkg/release_target.go
@@ -35,7 +35,7 @@ func releaseRequiresBuildForKind(manifest *providermanifestv1.Manifest, kind str
 }
 
 func HasExplicitSourceRun(manifest *providermanifestv1.Manifest) bool {
-	return manifest != nil && manifest.Run != nil && len(manifest.Run.Command) > 0
+	return manifest != nil && manifest.Run != nil && len(manifest.Run.PhaseCommands()) > 0
 }
 
 func ValidateExplicitRunPackaging(root string, manifest *providermanifestv1.Manifest) error {

--- a/gestaltd/services/apps/providerpkg/source_build.go
+++ b/gestaltd/services/apps/providerpkg/source_build.go
@@ -13,26 +13,25 @@ import (
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 )
 
+type ResolvedCommand struct {
+	Workdir      string
+	Command      []string
+	Env          map[string]string
+	Inputs       []string
+	ReadyTimeout time.Duration
+}
+
 type ResolvedSourceBuild struct {
-	Label       string
-	Workdir     string
-	Command     []string
-	Inputs      []string
+	Commands    []ResolvedCommand
 	PrepareOnly bool
 }
 
 type ResolvedSourceInstall struct {
-	Workdir string
-	Command []string
-	Inputs  []string
-	Env     map[string]string
+	Commands []ResolvedCommand
 }
 
 type ResolvedSourceRun struct {
-	Workdir      string
-	Command      []string
-	Env          map[string]string
-	ReadyTimeout time.Duration
+	Commands []ResolvedCommand
 }
 
 type SourceBuildOptions struct {
@@ -62,20 +61,48 @@ type ResolvedSourceExecution struct {
 	Intent SourceExecutionIntent
 }
 
+func resolvePhaseCommands(label string, phases []providermanifestv1.SourcePhaseCommand) ([]ResolvedCommand, error) {
+	if len(phases) == 0 {
+		return nil, nil
+	}
+	out := make([]ResolvedCommand, 0, len(phases))
+	for i, phase := range phases {
+		if len(phase.Command) == 0 {
+			return nil, fmt.Errorf("%s[%d].command is required", label, i)
+		}
+		readyTimeout, err := parseSourceRunReadyTimeout(phase.ReadyTimeout)
+		if err != nil {
+			return nil, fmt.Errorf("%s[%d].readyTimeout: %w", label, i, err)
+		}
+		out = append(out, ResolvedCommand{
+			Workdir:      phase.Workdir,
+			Command:      append([]string(nil), phase.Command...),
+			Env:          maps.Clone(phase.Env),
+			Inputs:       append([]string(nil), phase.Inputs...),
+			ReadyTimeout: readyTimeout,
+		})
+	}
+	return out, nil
+}
+
 func EffectiveSourceRun(manifest *providermanifestv1.Manifest) *ResolvedSourceRun {
 	if manifest == nil || manifest.Run == nil {
 		return nil
 	}
-	readyTimeout, err := parseSourceRunReadyTimeout(manifest.Run.ReadyTimeout)
-	if err != nil {
-		readyTimeout = 0
+	commands, err := resolvePhaseCommands("run", manifest.Run.PhaseCommands())
+	if err != nil || len(commands) == 0 {
+		return nil
 	}
-	return &ResolvedSourceRun{
-		Workdir:      manifest.Run.Workdir,
-		Command:      append([]string(nil), manifest.Run.Command...),
-		Env:          maps.Clone(manifest.Run.Env),
-		ReadyTimeout: readyTimeout,
+	return &ResolvedSourceRun{Commands: commands}
+}
+
+func EffectiveSourceRunCommand(manifest *providermanifestv1.Manifest) *ResolvedCommand {
+	run := EffectiveSourceRun(manifest)
+	if run == nil || len(run.Commands) == 0 {
+		return nil
 	}
+	cmd := run.Commands[0]
+	return &cmd
 }
 
 func parseSourceRunReadyTimeout(raw string) (time.Duration, error) {
@@ -86,20 +113,39 @@ func parseSourceRunReadyTimeout(raw string) (time.Duration, error) {
 	return time.ParseDuration(raw)
 }
 
+func BuildWorkdirAbsPaths(sourceDir string, commands []ResolvedCommand) []string {
+	if len(commands) == 0 {
+		return []string{filepath.Clean(sourceDir)}
+	}
+	seen := map[string]struct{}{}
+	var paths []string
+	for _, command := range commands {
+		root := sourceDir
+		if w := strings.TrimSpace(command.Workdir); w != "" && w != "." {
+			root = filepath.Join(sourceDir, filepath.FromSlash(w))
+		}
+		root = filepath.Clean(root)
+		if _, ok := seen[root]; ok {
+			continue
+		}
+		seen[root] = struct{}{}
+		paths = append(paths, root)
+	}
+	return paths
+}
+
 func EffectiveSourceBuild(manifest *providermanifestv1.Manifest) *ResolvedSourceBuild {
-	if manifest == nil {
+	if manifest == nil || manifest.Build == nil {
 		return nil
 	}
-	if manifest.Build != nil {
-		return &ResolvedSourceBuild{
-			Label:       "build",
-			Workdir:     manifest.Build.Workdir,
-			Command:     append([]string(nil), manifest.Build.Command...),
-			Inputs:      append([]string(nil), manifest.Build.Inputs...),
-			PrepareOnly: manifest.Build.PrepareOnly,
-		}
+	commands, err := resolvePhaseCommands("build", manifest.Build.PhaseCommands())
+	if err != nil || len(commands) == 0 {
+		return nil
 	}
-	return nil
+	return &ResolvedSourceBuild{
+		Commands:    commands,
+		PrepareOnly: manifest.Build.PrepareOnly,
+	}
 }
 
 func SourceBuildProducesOutput(manifest *providermanifestv1.Manifest) bool {
@@ -111,24 +157,26 @@ func EffectiveSourceInstall(manifest *providermanifestv1.Manifest) *ResolvedSour
 	if manifest == nil || manifest.Install == nil {
 		return nil
 	}
-	return &ResolvedSourceInstall{
-		Workdir: manifest.Install.Workdir,
-		Command: append([]string(nil), manifest.Install.Command...),
-		Inputs:  append([]string(nil), manifest.Install.Inputs...),
-		Env:     maps.Clone(manifest.Install.Env),
+	commands, err := resolvePhaseCommands("install", manifest.Install.PhaseCommands())
+	if err != nil || len(commands) == 0 {
+		return nil
 	}
+	return &ResolvedSourceInstall{Commands: commands}
 }
 
-// RunSourceInstall execs the declared install command (no shell) from the
-// source root. Side-effect only: no entrypoint artifact is verified. A nil
-// install phase is a no-op. opts carries the target platform env that
-// sourceBuildEnv injects; install.Env is merged on top (install wins).
+// RunSourceInstall execs declared install commands serially (no shell) from the
+// source root. Side-effect only: no entrypoint artifact is verified.
 func RunSourceInstall(manifestPath string, manifest *providermanifestv1.Manifest, opts SourceBuildOptions) error {
 	install := EffectiveSourceInstall(manifest)
 	if install == nil {
 		return nil
 	}
-	return runSourcePhase(manifestPath, "install", install.Workdir, install.Command, envMapToSlice(install.Env), opts)
+	for i, command := range install.Commands {
+		if err := runSourcePhase(manifestPath, fmt.Sprintf("install[%d]", i), command.Workdir, command.Command, envMapToSlice(command.Env), opts); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func envMapToSlice(env map[string]string) []string {
@@ -142,45 +190,56 @@ func envMapToSlice(env map[string]string) []string {
 	return out
 }
 
-// RunSourceBuild execs the declared build command (no shell) and, when the
-// build is not prepare-only, verifies the entrypoint artifact. It does NOT run
-// the install phase; callers that need install-before-build should use
-// EnsureSourceBuildOutput, which is the canonical install-then-build entry.
+// RunSourceBuild execs declared build commands serially (no shell) and verifies output.
 func RunSourceBuild(manifestPath string, manifest *providermanifestv1.Manifest, opts SourceBuildOptions) error {
 	build := EffectiveSourceBuild(manifest)
 	if build == nil {
 		return nil
 	}
-	if len(build.Command) == 0 {
-		return fmt.Errorf("%s.command is required", build.Label)
+	if len(build.Commands) == 0 {
+		return fmt.Errorf("build.command is required")
 	}
 
 	rootDir := filepath.Dir(manifestPath)
 	var outputRel, outputKind, outputPath string
+	var staticBuildEnv string
 	if !build.PrepareOnly {
 		var err error
 		outputRel, outputKind, err = SourceBuildOutput(manifest)
 		if err != nil {
 			return err
 		}
-		outputPath = filepath.Join(rootDir, filepath.FromSlash(outputRel))
-		if err := os.RemoveAll(outputPath); err != nil {
-			return fmt.Errorf("remove %s output %q: %w", build.Label, outputRel, err)
+		if outputRel != "" {
+			outputPath = filepath.Join(rootDir, filepath.FromSlash(outputRel))
+			if err := os.RemoveAll(outputPath); err != nil {
+				return fmt.Errorf("remove build output %q: %w", outputRel, err)
+			}
+		}
+		staticBuildEnv, err = prepareSourceStaticBuildDir(manifestPath)
+		if err != nil {
+			return err
 		}
 	}
 
-	if err := runSourcePhase(manifestPath, build.Label, build.Workdir, build.Command, nil, opts); err != nil {
-		return err
+	for i, command := range build.Commands {
+		label := "build"
+		if len(build.Commands) > 1 {
+			label = fmt.Sprintf("build[%d]", i)
+		}
+		envOverrides := envMapToSlice(command.Env)
+		if staticBuildEnv != "" {
+			envOverrides = append(envOverrides, envGestaltBuildStatic+"="+staticBuildEnv)
+		}
+		if err := runSourcePhase(manifestPath, label, command.Workdir, command.Command, envOverrides, opts); err != nil {
+			return err
+		}
 	}
 	if build.PrepareOnly {
 		return nil
 	}
-	return verifySourceBuildOutput(outputPath, outputRel, outputKind, opts)
+	return verifyAppBuildOutputs(manifestPath, manifest, outputPath, outputRel, outputKind, opts)
 }
 
-// runSourcePhase execs a declared phase command (no shell) from the source
-// root, resolving the optional relative workdir and merging phase env over the
-// target-platform env. Shared by install and build.
 func runSourcePhase(manifestPath, label, workdir string, command, envOverrides []string, opts SourceBuildOptions) error {
 	if len(command) == 0 {
 		return fmt.Errorf("%s.command is required", label)
@@ -211,8 +270,6 @@ func runSourcePhase(manifestPath, label, workdir string, command, envOverrides [
 	return nil
 }
 
-// mergePhaseEnv folds a phase's env overrides (as "KEY=VALUE" strings) over the
-// target-platform env; phase values win.
 func mergePhaseEnv(base, overrides []string) []string {
 	if len(overrides) == 0 {
 		return base
@@ -281,6 +338,9 @@ func SourceBuildOutput(manifest *providermanifestv1.Manifest) (rel string, kind 
 }
 
 func verifySourceBuildOutput(outputPath, outputRel, outputKind string, opts SourceBuildOptions) error {
+	if outputRel == "" {
+		return nil
+	}
 	info, err := os.Stat(outputPath)
 	if err != nil {
 		return fmt.Errorf("build output %q not found: %w", outputRel, err)
@@ -342,12 +402,6 @@ func SourceBuildTarget(opts SourceBuildOptions) (string, string) {
 	return goos, goarch
 }
 
-// HostLibC reports the C library of the current build host ("musl" or "glibc"),
-// or "" on non-linux. Bun-compiled provider binaries are dynamically linked
-// against their libc, so one built for the wrong libc cannot be exec'd (a musl
-// binary on a glibc runner fails with ENOENT for the absent /lib/ld-musl
-// loader). Packaging uses this to build the host-side catalog binary for the
-// build host while still shipping the musl artifact the deploy runtime needs.
 func HostLibC() string {
 	if runtime.GOOS != "linux" {
 		return ""
@@ -358,8 +412,6 @@ func HostLibC() string {
 	return "glibc"
 }
 
-// effectiveTargetLibC is the libc a build targets: the explicit opts.LibC, else
-// the SDK default (musl for linux; none elsewhere).
 func effectiveTargetLibC(opts SourceBuildOptions) string {
 	if opts.LibC != "" {
 		return opts.LibC
@@ -370,8 +422,6 @@ func effectiveTargetLibC(opts SourceBuildOptions) string {
 	return ""
 }
 
-// EnsureSourceBuildOutput is the canonical install-then-build entry; callers
-// that need a build output should use this rather than RunSourceBuild.
 func EnsureSourceBuildOutput(manifestPath string, manifest *providermanifestv1.Manifest, opts SourceBuildOptions) error {
 	if err := RunSourceInstall(manifestPath, manifest, opts); err != nil {
 		return err
@@ -390,7 +440,7 @@ func EnsureSourceBuildOutput(manifestPath string, manifest *providermanifestv1.M
 		return err
 	}
 	outputPath := filepath.Join(filepath.Dir(manifestPath), filepath.FromSlash(outputRel))
-	return verifySourceBuildOutput(outputPath, outputRel, outputKind, opts)
+	return verifyAppBuildOutputs(manifestPath, manifest, outputPath, outputRel, outputKind, opts)
 }
 
 func ensurePrepareOnlyBuild(manifestPath string, manifest *providermanifestv1.Manifest, opts SourceBuildOptions) error {
@@ -406,7 +456,11 @@ func SourceBuildInputs(manifest *providermanifestv1.Manifest) []string {
 	if build == nil {
 		return nil
 	}
-	return append([]string(nil), build.Inputs...)
+	var inputs []string
+	for _, command := range build.Commands {
+		inputs = append(inputs, command.Inputs...)
+	}
+	return inputs
 }
 
 func SourceInstallInputs(manifest *providermanifestv1.Manifest) []string {
@@ -414,7 +468,11 @@ func SourceInstallInputs(manifest *providermanifestv1.Manifest) []string {
 	if install == nil {
 		return nil
 	}
-	return append([]string(nil), install.Inputs...)
+	var inputs []string
+	for _, command := range install.Commands {
+		inputs = append(inputs, command.Inputs...)
+	}
+	return inputs
 }
 
 func SourceRunCommand(manifestPath string) (SourceExecution, error) {
@@ -430,6 +488,9 @@ func SourceRunCommand(manifestPath string) (SourceExecution, error) {
 	if !HasExplicitSourceRun(manifest) {
 		return SourceExecution{}, fmt.Errorf("manifest %s: run command required", manifestPath)
 	}
+	if err := RejectMultipleSourceRuns(manifest); err != nil {
+		return SourceExecution{}, err
+	}
 	return explicitRunExecution(filepath.Dir(manifestPath), manifest).SourceExecution, nil
 }
 
@@ -444,6 +505,9 @@ func SourceManifestExecution(manifestPath, kind string, opts SourceBuildOptions)
 		return SourceExecution{}, err
 	}
 	if HasExplicitSourceRun(manifest) {
+		if err := RejectMultipleSourceRuns(manifest); err != nil {
+			return SourceExecution{}, err
+		}
 		if err := RunSourceInstall(manifestPath, manifest, opts); err != nil {
 			return SourceExecution{}, err
 		}
@@ -465,6 +529,9 @@ func SourceManifestExecution(manifestPath, kind string, opts SourceBuildOptions)
 func resolveSourceExecution(manifestPath string, manifest *providermanifestv1.Manifest, kind string, opts SourceBuildOptions, skipExplicitRun bool) (ResolvedSourceExecution, error) {
 	rootDir := filepath.Dir(manifestPath)
 	if !skipExplicitRun && HasExplicitSourceRun(manifest) {
+		if err := RejectMultipleSourceRuns(manifest); err != nil {
+			return ResolvedSourceExecution{}, err
+		}
 		return explicitRunExecution(rootDir, manifest), nil
 	}
 	if _, err := sourceExecutionKind(manifest, kind); err != nil {
@@ -484,23 +551,27 @@ func resolveSourceExecution(manifestPath string, manifest *providermanifestv1.Ma
 }
 
 func explicitRunExecution(rootDir string, manifest *providermanifestv1.Manifest) ResolvedSourceExecution {
-	run := EffectiveSourceRun(manifest)
+	run := EffectiveSourceRunCommand(manifest)
 	workdir := rootDir
-	if run != nil && run.Workdir != "" && run.Workdir != "." {
-		workdir = filepath.Join(rootDir, filepath.FromSlash(run.Workdir))
-	}
 	command := ""
 	var args []string
-	if run != nil && len(run.Command) > 0 {
-		command = run.Command[0]
-		args = append([]string(nil), run.Command[1:]...)
+	var env map[string]string
+	if run != nil {
+		if run.Workdir != "" && run.Workdir != "." {
+			workdir = filepath.Join(rootDir, filepath.FromSlash(run.Workdir))
+		}
+		if len(run.Command) > 0 {
+			command = run.Command[0]
+			args = append([]string(nil), run.Command[1:]...)
+		}
+		env = maps.Clone(run.Env)
 	}
 	return ResolvedSourceExecution{
 		SourceExecution: SourceExecution{
 			Command: command,
 			Args:    args,
 			Workdir: workdir,
-			Env:     maps.Clone(run.Env),
+			Env:     env,
 		},
 		Intent: SourceExecutionIntentLocalRun,
 	}

--- a/gestaltd/services/apps/providerpkg/source_prepare.go
+++ b/gestaltd/services/apps/providerpkg/source_prepare.go
@@ -53,6 +53,9 @@ func prepareSourceManifest(manifestPath string, packaging bool, buildOpts Source
 	if err != nil {
 		return nil, nil, err
 	}
+	if err := RejectMultipleSourceRuns(manifest); err != nil {
+		return nil, nil, err
+	}
 	format := ManifestFormatFromPath(manifestPath)
 	originalManifest, err := DecodeSourceManifestFormat(data, format)
 	if err != nil {
@@ -126,6 +129,11 @@ func generateSourceStaticCatalog(manifestPath, rootDir string, manifest *provide
 	resolved, err := resolveSourceExecution(manifestPath, manifest, providermanifestv1.KindApp, SourceBuildOptions{}, opts.SkipExplicitRun)
 	if err != nil {
 		return fmt.Errorf("prepare source provider for static catalog: %w", err)
+	}
+	if opts.SkipExplicitRun && resolved.Intent == SourceExecutionIntentPackagedEntrypoint {
+		if _, err := os.Stat(resolved.Command); err != nil && os.IsNotExist(err) && HasExplicitSourceRun(manifest) {
+			resolved = explicitRunExecution(rootDir, manifest)
+		}
 	}
 	execution := resolved.SourceExecution
 	if execution.Cleanup != nil {

--- a/gestaltd/services/apps/providerpkg/source_static.go
+++ b/gestaltd/services/apps/providerpkg/source_static.go
@@ -1,0 +1,70 @@
+package providerpkg
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const sourceStaticBuildDirName = ".gestalt/build-static"
+const envGestaltBuildStatic = "GESTALT_BUILD_STATIC"
+
+// SourceStaticBuildDir is the absolute path where build commands write static assets.
+func SourceStaticBuildDir(manifestPath string) string {
+	return filepath.Join(filepath.Dir(manifestPath), filepath.FromSlash(sourceStaticBuildDirName))
+}
+
+func sourceStaticBuildDirRel() string {
+	return sourceStaticBuildDirName
+}
+
+func sourceStaticQualifies(staticDir string) (bool, error) {
+	info, err := os.Stat(staticDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if !info.IsDir() {
+		return false, nil
+	}
+	indexPath := filepath.Join(staticDir, "index.html")
+	if _, err := os.Stat(indexPath); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	entries, err := os.ReadDir(staticDir)
+	if err != nil {
+		return false, err
+	}
+	return len(entries) > 0, nil
+}
+
+func prepareSourceStaticBuildDir(manifestPath string) (string, error) {
+	staticDir := SourceStaticBuildDir(manifestPath)
+	if err := os.RemoveAll(staticDir); err != nil {
+		return "", fmt.Errorf("remove static build dir: %w", err)
+	}
+	if err := os.MkdirAll(staticDir, 0o755); err != nil {
+		return "", fmt.Errorf("create static build dir: %w", err)
+	}
+	abs, err := filepath.Abs(staticDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve static build dir: %w", err)
+	}
+	return abs, nil
+}
+
+func verifySourceStaticBuildOutput(staticDir string) error {
+	ok, err := sourceStaticQualifies(staticDir)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("static build output missing index.html under %q", sourceStaticBuildDirRel())
+	}
+	return nil
+}

--- a/gestaltd/services/apps/providerpkg/source_static_packaging.go
+++ b/gestaltd/services/apps/providerpkg/source_static_packaging.go
@@ -1,0 +1,74 @@
+package providerpkg
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+const errMultipleRunCommandsRequireDevMode = "multiple run commands require dev mode support"
+
+func HasMultipleSourceRuns(manifest *providermanifestv1.Manifest) bool {
+	if manifest == nil || manifest.Run == nil {
+		return false
+	}
+	return len(manifest.Run.PhaseCommands()) > 1
+}
+
+func RejectMultipleSourceRuns(manifest *providermanifestv1.Manifest) error {
+	if HasMultipleSourceRuns(manifest) {
+		return errors.New(errMultipleRunCommandsRequireDevMode)
+	}
+	return nil
+}
+
+func verifyAppBuildOutputs(manifestPath string, manifest *providermanifestv1.Manifest, outputPath, outputRel, outputKind string, opts SourceBuildOptions) error {
+	staticDir := SourceStaticBuildDir(manifestPath)
+	staticOK, err := sourceStaticQualifies(staticDir)
+	if err != nil {
+		return err
+	}
+	if outputRel != "" {
+		if err := verifySourceBuildOutput(outputPath, outputRel, outputKind, opts); err == nil {
+			if staticOK {
+				return verifySourceStaticBuildOutput(staticDir)
+			}
+			return nil
+		} else if HasExplicitSourceRun(manifest) && !staticOK {
+			return fmt.Errorf("build produced neither executable nor static output with index.html")
+		} else if !staticOK {
+			return err
+		}
+		return verifySourceStaticBuildOutput(staticDir)
+	}
+	if staticOK {
+		return verifySourceStaticBuildOutput(staticDir)
+	}
+	return fmt.Errorf("build produced neither executable nor static output with index.html")
+}
+
+func stagePreparedStaticBundle(manifestPath, stagingDir string, manifest *providermanifestv1.Manifest) error {
+	staticDir := SourceStaticBuildDir(manifestPath)
+	ok, err := sourceStaticQualifies(staticDir)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	dstDir := filepath.Join(stagingDir, "static")
+	if err := os.RemoveAll(dstDir); err != nil {
+		return fmt.Errorf("remove staged static dir: %w", err)
+	}
+	if err := copyPreparedInstallDir(staticDir, dstDir); err != nil {
+		return fmt.Errorf("stage static bundle: %w", err)
+	}
+	if manifest.Spec == nil {
+		manifest.Spec = &providermanifestv1.Spec{}
+	}
+	manifest.Spec.AssetRoot = "static"
+	return nil
+}

--- a/gestaltd/services/providerdev/supervisor.go
+++ b/gestaltd/services/providerdev/supervisor.go
@@ -78,7 +78,7 @@ func TargetsFromConfig(cfg *config.Config) ([]Target, error) {
 		if entry == nil || !entry.DevActive {
 			continue
 		}
-		run := providerpkg.EffectiveSourceRun(entry.ResolvedManifest)
+		run := providerpkg.EffectiveSourceRunCommand(entry.ResolvedManifest)
 		if run == nil {
 			return nil, fmt.Errorf("ui %q: dev-active without run manifest", name)
 		}


### PR DESCRIPTION
Manifest `install`, `build`, and `run` accept list-form phases with byte-stable legacy round-trips; build steps run serially and set `GESTALT_BUILD_STATIC` for static bundle staging (`spec.assetRoot: static`).

```yaml
build:
  - [uv, sync, --frozen]
  - {command: [bun, run, build], workdir: ui}
run:
  command: [uv, run, provider.py, --serve]
```

Multi-step `run` lists are rejected until dev-mode classification lands; fingerprints skip `.gestalt/build-static` beside the manifest and cover every build workdir.