### PR TITLE
Bump TypeScript SDK to 0.0.1-alpha.68

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@valon-technologies/gestalt",
-  "version": "0.0.1-alpha.67",
+  "version": "0.0.1-alpha.68",
   "description": "TypeScript SDK for Gestalt executable providers",
   "type": "module",
   "repository": {


### PR DESCRIPTION
## Summary
- Bump `@valon-technologies/gestalt` to `0.0.1-alpha.68` so downstream migration agents can install `@valon-technologies/gestalt/vite` alongside the dual-stack gestaltd rollout (plan-22).

## Test plan
- [ ] Merge and tag `sdk/typescript/v0.0.1-alpha.68`
- [ ] Verify Release SDK workflow publishes to npm with `./vite` export


Made with [Cursor](https://cursor.com)