### PR TITLE
Bump TypeScript SDK to 0.0.1-alpha.69

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@valon-technologies/gestalt",
-  "version": "0.0.1-alpha.68",
+  "version": "0.0.1-alpha.69",
   "description": "TypeScript SDK for Gestalt executable providers",
   "type": "module",
   "repository": {


### PR DESCRIPTION
## Summary
- Bump `@valon-technologies/gestalt` to `0.0.1-alpha.69`.
- `0.0.1-alpha.68` was tagged on 2026-06-27 before the `./vite` export landed (#2604), so npm already has an alpha.68 without `@valon-technologies/gestalt/vite`. This release publishes the vite preset for plan-22 migration agents.

## Test plan
- [ ] Merge and tag `sdk/typescript/v0.0.1-alpha.69`
- [ ] Verify Release SDK workflow publishes to npm with `./vite` export


Made with [Cursor](https://cursor.com)