### PR TITLE
feat(gestaltd): POST login next path and CLI OAuth bounce (v3)

### DIFF
--- a/gestaltd/internal/server/handlers_auth.go
+++ b/gestaltd/internal/server/handlers_auth.go
@@ -126,21 +126,15 @@ func (s *Server) startLogin(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
-	nextPath := ""
-	if strings.TrimSpace(req.Next) != "" {
-		var err error
-		nextPath, err = resolveLoginRedirectPath(req.Next, s.allowedLoginRedirectBaseURLs())
-		if err != nil {
-			auditErr = err
-			writeError(w, http.StatusBadRequest, err.Error())
-			return
+	auth, nextPath, err := s.resolveLoginStartAuth(req.Next, false)
+	if err != nil {
+		auditErr = err
+		status := http.StatusBadRequest
+		if !errors.Is(err, errBadLoginRedirectPath) {
+			status = http.StatusInternalServerError
 		}
-		auth, err = s.loginAuthRuntimeForNextPath(nextPath)
-		if err != nil {
-			auditErr = err
-			writeError(w, http.StatusInternalServerError, err.Error())
-			return
-		}
+		writeError(w, status, err.Error())
+		return
 	}
 	state := req.State
 	if req.CallbackPort > 0 && req.CallbackPort <= maxPort {
@@ -178,16 +172,14 @@ func (s *Server) startBrowserLogin(w http.ResponseWriter, r *http.Request) {
 		s.auditHTTPEvent(r.Context(), nil, auth.providerName, "auth.login.start", auditAllowed, auditErr)
 	}()
 
-	nextPath, err := resolveLoginRedirectPath(r.URL.Query().Get("next"), s.allowedLoginRedirectBaseURLs())
+	auth, nextPath, err := s.resolveLoginStartAuth(r.URL.Query().Get("next"), true)
 	if err != nil {
 		auditErr = err
-		writeError(w, http.StatusBadRequest, err.Error())
-		return
-	}
-	auth, err = s.loginAuthRuntimeForNextPath(nextPath)
-	if err != nil {
-		auditErr = err
-		writeError(w, http.StatusInternalServerError, err.Error())
+		status := http.StatusBadRequest
+		if !errors.Is(err, errBadLoginRedirectPath) {
+			status = http.StatusInternalServerError
+		}
+		writeError(w, status, err.Error())
 		return
 	}
 	if auth.noAuth || auth.provider == nil {
@@ -256,10 +248,29 @@ func (s *Server) allowedLoginRedirectBaseURLs() []string {
 	return []string{strings.TrimRight(s.managementBaseURL, "/") + "/admin"}
 }
 
+func (s *Server) resolveLoginStartAuth(nextRaw string, defaultRoot bool) (authRuntime, string, error) {
+	nextPath, err := resolveLoginRedirectPath(nextRaw, s.allowedLoginRedirectBaseURLs())
+	if err != nil {
+		return authRuntime{}, "", err
+	}
+	if nextPath == "" && defaultRoot {
+		nextPath = "/"
+	}
+	auth := s.serverAuthRuntime()
+	if nextPath != "" {
+		var authErr error
+		auth, authErr = s.loginAuthRuntimeForNextPath(nextPath)
+		if authErr != nil {
+			return auth, nextPath, authErr
+		}
+	}
+	return auth, nextPath, nil
+}
+
 func resolveLoginRedirectPath(raw string, allowedBaseURLs []string) (string, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
-		return "/", nil
+		return "", nil
 	}
 	parsed, err := url.Parse(raw)
 	if err != nil {
@@ -459,11 +470,11 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if r.URL.Query().Get("cli") != "1" {
-		if port, rawState, ok := extractCLIState(loginState.State); ok {
-			redirectCLIAuthorization(w, r, port, code, rawState)
-			return
-		}
+	mode, cliPort, cliRawState := resolveLoginCallbackMode(r, loginState.State)
+	switch mode {
+	case loginCallbackBounce:
+		redirectCLIAuthorization(w, r, cliPort, code, cliRawState)
+		return
 	}
 
 	auth, err = s.authRuntimeForProvider(loginState.Provider)
@@ -511,7 +522,7 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if r.URL.Query().Get("cli") == "1" {
+	if mode == loginCallbackCLIGrant {
 		apiGrant, exchangeErr := auth.provider.Token(r.Context(), &core.TokenRequest{
 			GrantType:        core.GrantTypeTokenExchange,
 			SubjectToken:     tokenResp.AccessToken,
@@ -577,20 +588,22 @@ func loginStatesMatch(expectedState, originalState string) bool {
 	return false
 }
 
-func stripCLIStatePrefix(state string) (string, bool) {
-	if !strings.HasPrefix(state, cliStatePrefix) {
-		return "", false
+type loginCallbackMode int
+
+const (
+	loginCallbackBrowser loginCallbackMode = iota
+	loginCallbackBounce
+	loginCallbackCLIGrant
+)
+
+func resolveLoginCallbackMode(r *http.Request, cookieState string) (loginCallbackMode, int, string) {
+	if r.URL.Query().Get("cli") == "1" {
+		return loginCallbackCLIGrant, 0, ""
 	}
-	rest := strings.TrimPrefix(state, cliStatePrefix)
-	portText, rawState, ok := strings.Cut(rest, ":")
-	if !ok || portText == "" || rawState == "" {
-		return "", false
+	if port, rawState, ok := extractCLIState(cookieState); ok {
+		return loginCallbackBounce, port, rawState
 	}
-	port, err := strconv.Atoi(portText)
-	if err != nil || port < 1 || port > maxPort {
-		return "", false
-	}
-	return rawState, true
+	return loginCallbackBrowser, 0, ""
 }
 
 func extractCLIState(state string) (port int, rawState string, ok bool) {
@@ -607,6 +620,11 @@ func extractCLIState(state string) (port int, rawState string, ok bool) {
 		return 0, "", false
 	}
 	return p, raw, true
+}
+
+func stripCLIStatePrefix(state string) (string, bool) {
+	_, rawState, ok := extractCLIState(state)
+	return rawState, ok
 }
 
 func redirectCLIAuthorization(w http.ResponseWriter, r *http.Request, port int, code, rawState string) {

--- a/gestaltd/internal/server/handlers_auth.go
+++ b/gestaltd/internal/server/handlers_auth.go
@@ -21,6 +21,7 @@ import (
 type loginRequest struct {
 	State        string `json:"state"`
 	CallbackPort int    `json:"callbackPort,omitempty"`
+	Next         string `json:"next,omitempty"`
 }
 
 type authInfoResponse struct {
@@ -125,6 +126,18 @@ func (s *Server) startLogin(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
+	nextPath, err := resolveLoginRedirectPath(req.Next, s.allowedLoginRedirectBaseURLs())
+	if err != nil {
+		auditErr = err
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	auth, err = s.loginAuthRuntimeForNextPath(nextPath)
+	if err != nil {
+		auditErr = err
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
 	state := req.State
 	if req.CallbackPort > 0 && req.CallbackPort <= maxPort {
 		state = fmt.Sprintf("%s%d:%s", cliStatePrefix, req.CallbackPort, req.State)
@@ -134,7 +147,7 @@ func (s *Server) startLogin(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "auth is disabled")
 		return
 	}
-	loginURL, err := s.beginLogin(w, r, auth, state, "")
+	loginURL, err := s.beginLogin(w, r, auth, state, nextPath)
 	if err != nil {
 		auditErr = err
 		status := http.StatusInternalServerError
@@ -442,6 +455,13 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if r.URL.Query().Get("cli") != "1" {
+		if port, rawState, ok := extractCLIState(loginState.State); ok {
+			redirectCLIAuthorization(w, r, port, code, rawState)
+			return
+		}
+	}
+
 	auth, err = s.authRuntimeForProvider(loginState.Provider)
 	if err != nil {
 		auditErr = err
@@ -567,6 +587,32 @@ func stripCLIStatePrefix(state string) (string, bool) {
 		return "", false
 	}
 	return rawState, true
+}
+
+func extractCLIState(state string) (port int, rawState string, ok bool) {
+	if !strings.HasPrefix(state, cliStatePrefix) {
+		return 0, "", false
+	}
+	rest := strings.TrimPrefix(state, cliStatePrefix)
+	portText, raw, found := strings.Cut(rest, ":")
+	if !found || portText == "" || raw == "" {
+		return 0, "", false
+	}
+	p, err := strconv.Atoi(portText)
+	if err != nil || p < 1 || p > maxPort {
+		return 0, "", false
+	}
+	return p, raw, true
+}
+
+func redirectCLIAuthorization(w http.ResponseWriter, r *http.Request, port int, code, rawState string) {
+	target := fmt.Sprintf(
+		"http://127.0.0.1:%d/?code=%s&state=%s",
+		port,
+		url.QueryEscape(code),
+		url.QueryEscape(rawState),
+	)
+	http.Redirect(w, r, target, http.StatusFound)
 }
 
 func (s *Server) clearLoginStateCookie(w http.ResponseWriter) {

--- a/gestaltd/internal/server/handlers_auth.go
+++ b/gestaltd/internal/server/handlers_auth.go
@@ -126,17 +126,21 @@ func (s *Server) startLogin(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
-	nextPath, err := resolveLoginRedirectPath(req.Next, s.allowedLoginRedirectBaseURLs())
-	if err != nil {
-		auditErr = err
-		writeError(w, http.StatusBadRequest, err.Error())
-		return
-	}
-	auth, err = s.loginAuthRuntimeForNextPath(nextPath)
-	if err != nil {
-		auditErr = err
-		writeError(w, http.StatusInternalServerError, err.Error())
-		return
+	nextPath := ""
+	if strings.TrimSpace(req.Next) != "" {
+		var err error
+		nextPath, err = resolveLoginRedirectPath(req.Next, s.allowedLoginRedirectBaseURLs())
+		if err != nil {
+			auditErr = err
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		auth, err = s.loginAuthRuntimeForNextPath(nextPath)
+		if err != nil {
+			auditErr = err
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
 	}
 	state := req.State
 	if req.CallbackPort > 0 && req.CallbackPort <= maxPort {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -8378,87 +8378,137 @@ func TestStartBrowserLogin_MissingPluginRouteAuthProviderAuditsAttemptedProvider
 func TestLoginCallback(t *testing.T) {
 	t.Parallel()
 
-	svc := testutil.NewStubServices(t)
-	existing := seedUserRecord(t, svc, "user-existing", "user@example.com", time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
-	var auditBuf bytes.Buffer
-	auditSink := invocation.NewSlogAuditSink(&auditBuf)
-	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.Auth = &coretesting.StubAuthProvider{
-			N: "test",
-			HandleCallbackFn: func(_ context.Context, code string) (*core.UserIdentity, error) {
-				if code == "good-code" {
-					return &core.UserIdentity{Email: "user@example.com", DisplayName: "User"}, nil
-				}
-				return nil, fmt.Errorf("bad code")
+	t.Run("issues session cookie on success", func(t *testing.T) {
+		t.Parallel()
+
+		svc := testutil.NewStubServices(t)
+		existing := seedUserRecord(t, svc, "user-existing", "user@example.com", time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+		var auditBuf bytes.Buffer
+		auditSink := invocation.NewSlogAuditSink(&auditBuf)
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Auth = &coretesting.StubAuthProvider{
+				N: "test",
+				HandleCallbackFn: func(_ context.Context, code string) (*core.UserIdentity, error) {
+					if code == "good-code" {
+						return &core.UserIdentity{Email: "user@example.com", DisplayName: "User"}, nil
+					}
+					return nil, fmt.Errorf("bad code")
+				},
+			}
+			cfg.Services = svc
+			cfg.AuditSink = auditSink
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		jar, _ := cookiejar.New(nil)
+		client := &http.Client{Jar: jar}
+
+		body := bytes.NewBufferString(`{"state":"test-state"}`)
+		loginResp, err := client.Post(ts.URL+"/api/v1/auth/login", "application/json", body)
+		if err != nil {
+			t.Fatalf("start login: %v", err)
+		}
+		_ = loginResp.Body.Close()
+
+		resp, err := client.Get(ts.URL + "/api/v1/auth/login/callback?code=good-code&state=test-state")
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+
+		var result map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			t.Fatalf("decoding: %v", err)
+		}
+		if result["status"] != "ok" {
+			t.Fatalf("unexpected status: %v", result["status"])
+		}
+		var sessionCookie *http.Cookie
+		for _, cookie := range resp.Cookies() {
+			if cookie.Name == "session_token" && cookie.Value != "" {
+				sessionCookie = cookie
+				break
+			}
+		}
+		if sessionCookie == nil {
+			t.Fatal("expected session_token cookie after login")
+		}
+		stored, err := svc.Users.GetUser(context.Background(), existing.ID)
+		if err != nil {
+			t.Fatalf("get user: %v", err)
+		}
+		if stored.Email != "user@example.com" {
+			t.Fatalf("expected user email %q, got %q", "user@example.com", stored.Email)
+		}
+
+		lines := bytes.Split(bytes.TrimSpace(auditBuf.Bytes()), []byte("\n"))
+		if len(lines) == 0 {
+			t.Fatal("expected login audit record")
+		}
+		var auditRecord map[string]any
+		if err := json.Unmarshal(lines[len(lines)-1], &auditRecord); err != nil {
+			t.Fatalf("parsing audit record: %v\nraw: %s", err, auditBuf.String())
+		}
+		if auditRecord["operation"] != "auth.login.complete" {
+			t.Fatalf("expected audit operation auth.login.complete, got %v", auditRecord["operation"])
+		}
+		if subjectID, ok := auditRecord["subject_id"].(string); !ok || subjectID != principal.UserSubjectID(existing.ID) {
+			t.Fatalf("expected audit subject_id %q, got %v", principal.UserSubjectID(existing.ID), auditRecord["subject_id"])
+		}
+		if _, ok := auditRecord["user_id"]; ok {
+			t.Fatalf("expected emitted audit record to omit user_id, got %v", auditRecord["user_id"])
+		}
+	})
+
+	t.Run("redirects to next path when POST included next", func(t *testing.T) {
+		t.Parallel()
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Auth = &coretesting.StubAuthProvider{
+				N: "test",
+				HandleCallbackFn: func(_ context.Context, code string) (*core.UserIdentity, error) {
+					if code == "good-code" {
+						return &core.UserIdentity{Email: "user@example.com", DisplayName: "User"}, nil
+					}
+					return nil, fmt.Errorf("bad code")
+				},
+			}
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		jar, _ := cookiejar.New(nil)
+		client := &http.Client{Jar: jar}
+
+		body := bytes.NewBufferString(`{"state":"test-state","next":"/apps"}`)
+		loginResp, err := client.Post(ts.URL+"/api/v1/auth/login", "application/json", body)
+		if err != nil {
+			t.Fatalf("start login: %v", err)
+		}
+		_ = loginResp.Body.Close()
+
+		noRedirect := &http.Client{
+			Jar: jar,
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
 			},
 		}
-		cfg.Services = svc
-		cfg.AuditSink = auditSink
-	})
-	testutil.CloseOnCleanup(t, ts)
-
-	jar, _ := cookiejar.New(nil)
-	client := &http.Client{Jar: jar}
-
-	body := bytes.NewBufferString(`{"state":"test-state"}`)
-	loginResp, err := client.Post(ts.URL+"/api/v1/auth/login", "application/json", body)
-	if err != nil {
-		t.Fatalf("start login: %v", err)
-	}
-	_ = loginResp.Body.Close()
-
-	resp, err := client.Get(ts.URL + "/api/v1/auth/login/callback?code=good-code&state=test-state")
-	if err != nil {
-		t.Fatalf("request: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("expected 200, got %d", resp.StatusCode)
-	}
-
-	var result map[string]any
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		t.Fatalf("decoding: %v", err)
-	}
-	if result["status"] != "ok" {
-		t.Fatalf("unexpected status: %v", result["status"])
-	}
-	var sessionCookie *http.Cookie
-	for _, cookie := range resp.Cookies() {
-		if cookie.Name == "session_token" && cookie.Value != "" {
-			sessionCookie = cookie
-			break
+		resp, err := noRedirect.Get(ts.URL + "/api/v1/auth/login/callback?code=good-code&state=test-state")
+		if err != nil {
+			t.Fatalf("callback request: %v", err)
 		}
-	}
-	if sessionCookie == nil {
-		t.Fatal("expected session_token cookie after login")
-	}
-	stored, err := svc.Users.GetUser(context.Background(), existing.ID)
-	if err != nil {
-		t.Fatalf("get user: %v", err)
-	}
-	if stored.Email != "user@example.com" {
-		t.Fatalf("expected user email %q, got %q", "user@example.com", stored.Email)
-	}
+		defer func() { _ = resp.Body.Close() }()
 
-	lines := bytes.Split(bytes.TrimSpace(auditBuf.Bytes()), []byte("\n"))
-	if len(lines) == 0 {
-		t.Fatal("expected login audit record")
-	}
-	var auditRecord map[string]any
-	if err := json.Unmarshal(lines[len(lines)-1], &auditRecord); err != nil {
-		t.Fatalf("parsing audit record: %v\nraw: %s", err, auditBuf.String())
-	}
-	if auditRecord["operation"] != "auth.login.complete" {
-		t.Fatalf("expected audit operation auth.login.complete, got %v", auditRecord["operation"])
-	}
-	if subjectID, ok := auditRecord["subject_id"].(string); !ok || subjectID != principal.UserSubjectID(existing.ID) {
-		t.Fatalf("expected audit subject_id %q, got %v", principal.UserSubjectID(existing.ID), auditRecord["subject_id"])
-	}
-	if _, ok := auditRecord["user_id"]; ok {
-		t.Fatalf("expected emitted audit record to omit user_id, got %v", auditRecord["user_id"])
-	}
+		if resp.StatusCode != http.StatusFound {
+			t.Fatalf("expected 302, got %d", resp.StatusCode)
+		}
+		if got := resp.Header.Get("Location"); got != "/apps" {
+			t.Fatalf("Location = %q, want /apps", got)
+		}
+	})
 }
 
 func TestLoginCallback_MissingPluginRouteAuthProviderAuditsAttemptedProvider(t *testing.T) {
@@ -8632,145 +8682,103 @@ func TestLoginCallbackForCLI(t *testing.T) {
 func TestLoginCallbackForCLIWithCallbackPortStrippedState(t *testing.T) {
 	t.Parallel()
 
-	svc := testutil.NewStubServices(t)
-	_ = seedUser(t, svc, "host@example.com")
-	auth := newHostIssuedSessionAuthStub([]byte("host-issued-secret"), hostIssuedSessionAuthOpts{})
-	baseTokenFn := auth.TokenFn
-	var gotAuthorizationCodeState string
-	auth.TokenFn = func(ctx context.Context, req *core.TokenRequest) (*core.TokenResponse, error) {
-		if req != nil && req.GrantType == core.GrantTypeAuthorizationCode {
-			gotAuthorizationCodeState = req.State
-			if req.State != "cli:54305:test-state" {
-				return nil, fmt.Errorf("authorization code state = %q, want prefixed CLI state", req.State)
-			}
-		}
-		return baseTokenFn(ctx, req)
-	}
-	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.Auth = auth
-		cfg.Services = svc
-	})
-	testutil.CloseOnCleanup(t, ts)
+	t.Run("completes with cli=1", func(t *testing.T) {
+		t.Parallel()
 
-	jar, _ := cookiejar.New(nil)
-	client := &http.Client{Jar: jar}
-
-	body := bytes.NewBufferString(`{"state":"test-state","callbackPort":54305}`)
-	loginResp, err := client.Post(ts.URL+"/api/v1/auth/login", "application/json", body)
-	if err != nil {
-		t.Fatalf("start login: %v", err)
-	}
-	_ = loginResp.Body.Close()
-
-	resp, err := client.Get(ts.URL + "/api/v1/auth/login/callback?code=good-code&state=test-state&cli=1")
-	if err != nil {
-		t.Fatalf("request: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("expected 200, got %d", resp.StatusCode)
-	}
-
-	var result map[string]any
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		t.Fatalf("decoding: %v", err)
-	}
-	if result["id"] == "" {
-		t.Fatal("expected id in CLI login response")
-	}
-	if result["token"] == "" {
-		t.Fatal("expected token in CLI login response")
-	}
-	if gotAuthorizationCodeState != "cli:54305:test-state" {
-		t.Fatalf("authorization code state = %q, want prefixed CLI state", gotAuthorizationCodeState)
-	}
-}
-
-func TestStartLoginWithNextPath(t *testing.T) {
-	t.Parallel()
-
-	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.Auth = &coretesting.StubAuthProvider{
-			N: "test",
-			HandleCallbackFn: func(_ context.Context, code string) (*core.UserIdentity, error) {
-				if code == "good-code" {
-					return &core.UserIdentity{Email: "user@example.com", DisplayName: "User"}, nil
+		svc := testutil.NewStubServices(t)
+		_ = seedUser(t, svc, "host@example.com")
+		auth := newHostIssuedSessionAuthStub([]byte("host-issued-secret"), hostIssuedSessionAuthOpts{})
+		baseTokenFn := auth.TokenFn
+		var gotAuthorizationCodeState string
+		auth.TokenFn = func(ctx context.Context, req *core.TokenRequest) (*core.TokenResponse, error) {
+			if req != nil && req.GrantType == core.GrantTypeAuthorizationCode {
+				gotAuthorizationCodeState = req.State
+				if req.State != "cli:54305:test-state" {
+					return nil, fmt.Errorf("authorization code state = %q, want prefixed CLI state", req.State)
 				}
-				return nil, fmt.Errorf("bad code")
+			}
+			return baseTokenFn(ctx, req)
+		}
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Auth = auth
+			cfg.Services = svc
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		jar, _ := cookiejar.New(nil)
+		client := &http.Client{Jar: jar}
+
+		body := bytes.NewBufferString(`{"state":"test-state","callbackPort":54305}`)
+		loginResp, err := client.Post(ts.URL+"/api/v1/auth/login", "application/json", body)
+		if err != nil {
+			t.Fatalf("start login: %v", err)
+		}
+		_ = loginResp.Body.Close()
+
+		resp, err := client.Get(ts.URL + "/api/v1/auth/login/callback?code=good-code&state=test-state&cli=1")
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+
+		var result map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			t.Fatalf("decoding: %v", err)
+		}
+		if result["id"] == "" {
+			t.Fatal("expected id in CLI login response")
+		}
+		if result["token"] == "" {
+			t.Fatal("expected token in CLI login response")
+		}
+		if gotAuthorizationCodeState != "cli:54305:test-state" {
+			t.Fatalf("authorization code state = %q, want prefixed CLI state", gotAuthorizationCodeState)
+		}
+	})
+
+	t.Run("redirects to localhost without cli=1", func(t *testing.T) {
+		t.Parallel()
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Auth = &coretesting.StubAuthProvider{N: "test"}
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		jar, _ := cookiejar.New(nil)
+		client := &http.Client{Jar: jar}
+
+		body := bytes.NewBufferString(`{"state":"raw-cli-state","callbackPort":54305}`)
+		loginResp, err := client.Post(ts.URL+"/api/v1/auth/login", "application/json", body)
+		if err != nil {
+			t.Fatalf("start login: %v", err)
+		}
+		_ = loginResp.Body.Close()
+
+		noRedirect := &http.Client{
+			Jar: jar,
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
 			},
 		}
+		resp, err := noRedirect.Get(ts.URL + "/api/v1/auth/login/callback?code=good-code&state=raw-cli-state")
+		if err != nil {
+			t.Fatalf("callback request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusFound {
+			t.Fatalf("expected 302, got %d", resp.StatusCode)
+		}
+		got := resp.Header.Get("Location")
+		want := "http://127.0.0.1:54305/?code=good-code&state=raw-cli-state"
+		if got != want {
+			t.Fatalf("Location = %q, want %q", got, want)
+		}
 	})
-	testutil.CloseOnCleanup(t, ts)
-
-	jar, _ := cookiejar.New(nil)
-	client := &http.Client{Jar: jar}
-
-	body := bytes.NewBufferString(`{"state":"test-state","next":"/apps"}`)
-	loginResp, err := client.Post(ts.URL+"/api/v1/auth/login", "application/json", body)
-	if err != nil {
-		t.Fatalf("start login: %v", err)
-	}
-	_ = loginResp.Body.Close()
-
-	noRedirect := &http.Client{
-		Jar: jar,
-		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
-	resp, err := noRedirect.Get(ts.URL + "/api/v1/auth/login/callback?code=good-code&state=test-state")
-	if err != nil {
-		t.Fatalf("callback request: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusFound {
-		t.Fatalf("expected 302, got %d", resp.StatusCode)
-	}
-	if got := resp.Header.Get("Location"); got != "/apps" {
-		t.Fatalf("Location = %q, want /apps", got)
-	}
-}
-
-func TestLoginCallbackCLILocalhostBounce(t *testing.T) {
-	t.Parallel()
-
-	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.Auth = &coretesting.StubAuthProvider{N: "test"}
-	})
-	testutil.CloseOnCleanup(t, ts)
-
-	jar, _ := cookiejar.New(nil)
-	client := &http.Client{Jar: jar}
-
-	body := bytes.NewBufferString(`{"state":"raw-cli-state","callbackPort":54305}`)
-	loginResp, err := client.Post(ts.URL+"/api/v1/auth/login", "application/json", body)
-	if err != nil {
-		t.Fatalf("start login: %v", err)
-	}
-	_ = loginResp.Body.Close()
-
-	noRedirect := &http.Client{
-		Jar: jar,
-		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
-	resp, err := noRedirect.Get(ts.URL + "/api/v1/auth/login/callback?code=good-code&state=raw-cli-state")
-	if err != nil {
-		t.Fatalf("callback request: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusFound {
-		t.Fatalf("expected 302, got %d", resp.StatusCode)
-	}
-	got := resp.Header.Get("Location")
-	want := "http://127.0.0.1:54305/?code=good-code&state=raw-cli-state"
-	if got != want {
-		t.Fatalf("Location = %q, want %q", got, want)
-	}
 }
 
 func TestLoginCallbackStateMismatch(t *testing.T) {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -8687,6 +8687,92 @@ func TestLoginCallbackForCLIWithCallbackPortStrippedState(t *testing.T) {
 	}
 }
 
+func TestStartLoginWithNextPath(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			HandleCallbackFn: func(_ context.Context, code string) (*core.UserIdentity, error) {
+				if code == "good-code" {
+					return &core.UserIdentity{Email: "user@example.com", DisplayName: "User"}, nil
+				}
+				return nil, fmt.Errorf("bad code")
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	jar, _ := cookiejar.New(nil)
+	client := &http.Client{Jar: jar}
+
+	body := bytes.NewBufferString(`{"state":"test-state","next":"/apps"}`)
+	loginResp, err := client.Post(ts.URL+"/api/v1/auth/login", "application/json", body)
+	if err != nil {
+		t.Fatalf("start login: %v", err)
+	}
+	_ = loginResp.Body.Close()
+
+	noRedirect := &http.Client{
+		Jar: jar,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := noRedirect.Get(ts.URL + "/api/v1/auth/login/callback?code=good-code&state=test-state")
+	if err != nil {
+		t.Fatalf("callback request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("expected 302, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Location"); got != "/apps" {
+		t.Fatalf("Location = %q, want /apps", got)
+	}
+}
+
+func TestLoginCallbackCLILocalhostBounce(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{N: "test"}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	jar, _ := cookiejar.New(nil)
+	client := &http.Client{Jar: jar}
+
+	body := bytes.NewBufferString(`{"state":"raw-cli-state","callbackPort":54305}`)
+	loginResp, err := client.Post(ts.URL+"/api/v1/auth/login", "application/json", body)
+	if err != nil {
+		t.Fatalf("start login: %v", err)
+	}
+	_ = loginResp.Body.Close()
+
+	noRedirect := &http.Client{
+		Jar: jar,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := noRedirect.Get(ts.URL + "/api/v1/auth/login/callback?code=good-code&state=raw-cli-state")
+	if err != nil {
+		t.Fatalf("callback request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("expected 302, got %d", resp.StatusCode)
+	}
+	got := resp.Header.Get("Location")
+	want := "http://127.0.0.1:54305/?code=good-code&state=raw-cli-state"
+	if got != want {
+		t.Fatalf("Location = %q, want %q", got, want)
+	}
+}
+
 func TestLoginCallbackStateMismatch(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Server-first OAuth for valon.tools: **no `publicPaths`**, keep existing `AppLevelAuth` + `browserLoginPath` (`/api/v1/auth/login`).

```mermaid
sequenceDiagram
  participant Browser
  participant Shell as apps.home AppLevelAuth
  participant API as /api/v1/auth

  Browser->>Shell: GET /apps (no cookie)
  Shell->>Browser: 302 /api/v1/auth/login?next=/apps
  Browser->>API: GET /auth/login?next=/apps
  API->>Browser: Google → /api/v1/auth/login/callback
  Browser->>Shell: GET /apps (session)
```

**Changes (handlers only):**
- `POST /api/v1/auth/login` accepts `{ state, next?, callbackPort? }` — stores `next` in login state cookie
- CLI OAuth: `cli:port:state` → `302 http://127.0.0.1:{port}/?code&state=` before token exchange

**Not in scope:** `publicPaths`, `browserLoginPath` change, mount/routing changes.

Supersedes #2612. After merge, bump `GESTALTD_PINNED_SHA`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6430cf86-e6f8-41c3-8964-66366c74a94a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6430cf86-e6f8-41c3-8964-66366c74a94a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

