### PR TITLE
fix(gestaltd): bounce CLI OAuth callback before login_state cookie check

### DIFF
--- a/gestaltd/internal/server/handlers_auth.go
+++ b/gestaltd/internal/server/handlers_auth.go
@@ -455,6 +455,19 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	originalState := r.URL.Query().Get("state")
+
+	// Browser OAuth callbacks for CLI login do not carry the login_state
+	// cookie stored on the CLI HTTP client from POST /auth/login. Extract
+	// the provider-returned cli:port:state before loginStateForCallback.
+	if r.URL.Query().Get("cli") != "1" {
+		if port, rawState, ok := extractCLIState(originalState); ok {
+			auditAllowed = true
+			auditErr = nil
+			redirectCLIAuthorization(w, r, port, code, rawState)
+			return
+		}
+	}
+
 	loginState, err := s.loginStateForCallback(r)
 	if err != nil {
 		auditErr = errors.New("login state validation failed")

--- a/gestaltd/internal/server/handlers_auth.go
+++ b/gestaltd/internal/server/handlers_auth.go
@@ -455,10 +455,6 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	originalState := r.URL.Query().Get("state")
-
-	// Browser OAuth callbacks for CLI login do not carry the login_state
-	// cookie stored on the CLI HTTP client from POST /auth/login. Extract
-	// the provider-returned cli:port:state before loginStateForCallback.
 	if r.URL.Query().Get("cli") != "1" {
 		if port, rawState, ok := extractCLIState(originalState); ok {
 			auditAllowed = true

--- a/gestaltd/internal/server/handlers_auth.go
+++ b/gestaltd/internal/server/handlers_auth.go
@@ -478,8 +478,7 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	mode, cliPort, cliRawState := resolveLoginCallbackMode(r, loginState.State)
-	switch mode {
-	case loginCallbackBounce:
+	if mode == loginCallbackBounce {
 		redirectCLIAuthorization(w, r, cliPort, code, cliRawState)
 		return
 	}

--- a/gestaltd/internal/server/handlers_auth.go
+++ b/gestaltd/internal/server/handlers_auth.go
@@ -457,8 +457,6 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 	originalState := r.URL.Query().Get("state")
 	if r.URL.Query().Get("cli") != "1" {
 		if port, rawState, ok := extractCLIState(originalState); ok {
-			auditAllowed = true
-			auditErr = nil
 			redirectCLIAuthorization(w, r, port, code, rawState)
 			return
 		}

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -8753,7 +8753,6 @@ func TestLoginCallbackForCLIWithCallbackPortStrippedState(t *testing.T) {
 				return http.ErrUseLastResponse
 			},
 		}
-		// No cookie jar — simulates browser after Google OAuth redirect.
 		resp, err := noRedirect.Get(ts.URL + "/api/v1/auth/login/callback?code=good-code&state=cli:54305:raw-cli-state")
 		if err != nil {
 			t.Fatalf("callback request: %v", err)

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -8740,7 +8740,7 @@ func TestLoginCallbackForCLIWithCallbackPortStrippedState(t *testing.T) {
 		}
 	})
 
-	t.Run("redirects to localhost without cli=1", func(t *testing.T) {
+	t.Run("redirects browser OAuth callback to localhost", func(t *testing.T) {
 		t.Parallel()
 
 		ts := newTestServer(t, func(cfg *server.Config) {
@@ -8748,23 +8748,13 @@ func TestLoginCallbackForCLIWithCallbackPortStrippedState(t *testing.T) {
 		})
 		testutil.CloseOnCleanup(t, ts)
 
-		jar, _ := cookiejar.New(nil)
-		client := &http.Client{Jar: jar}
-
-		body := bytes.NewBufferString(`{"state":"raw-cli-state","callbackPort":54305}`)
-		loginResp, err := client.Post(ts.URL+"/api/v1/auth/login", "application/json", body)
-		if err != nil {
-			t.Fatalf("start login: %v", err)
-		}
-		_ = loginResp.Body.Close()
-
 		noRedirect := &http.Client{
-			Jar: jar,
 			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
 				return http.ErrUseLastResponse
 			},
 		}
-		resp, err := noRedirect.Get(ts.URL + "/api/v1/auth/login/callback?code=good-code&state=raw-cli-state")
+		// No cookie jar — simulates browser after Google OAuth redirect.
+		resp, err := noRedirect.Get(ts.URL + "/api/v1/auth/login/callback?code=good-code&state=cli:54305:raw-cli-state")
 		if err != nil {
 			t.Fatalf("callback request: %v", err)
 		}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes `gestalt auth login` against remote hosts (e.g. `https://valon.tools`) where the browser OAuth callback failed with `{"error":"login state validation failed"}`.

The `login_state` cookie is set on the CLI HTTP client during `POST /api/v1/auth/login`, but the Google OAuth redirect lands in the browser without that cookie. The existing localhost bounce logic ran only after `loginStateForCallback`, so the request never reached it.

## Changes

- **`handlers_auth.go`**: Before `loginStateForCallback`, detect provider-returned `cli:<port>:<state>` in the OAuth `state` query param (when `cli=1` is not set) and redirect to the CLI localhost listener.
- **`server_test.go`**: Replace the cookie-jar subtest with a cookieless browser simulation that hits the callback with the full prefixed OAuth state.

## Security

The `cli:<port>:<rawState>` format is only issued by the server during `POST /auth/login` with a `callbackPort`. The CLI retains the `login_state` cookie for the final `cli=1` exchange. An attacker would need to guess both port and state within the short login window.

Unchanged: `cli=1` grant path and `loginStatesMatch` logic.

## Test plan

- [x] `go test ./internal/server/ -run TestLoginCallbackForCLI`
- [x] `go test ./internal/server/ -run TestLoginCallbackStateMismatch`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3484-1754-7bf8-b8b8-4d4be9971029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3484-1754-7bf8-b8b8-4d4be9971029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

