### PR TITLE
Fix undefined public in mounted_app_static production path

### DIFF
--- a/gestaltd/internal/server/mounted_app_static.go
+++ b/gestaltd/internal/server/mounted_app_static.go
@@ -66,7 +66,7 @@ func mountedAppStaticsFromEntries(apps map[string]*config.ProviderEntry, devHand
 			Path:                mount,
 			AppName:             name,
 			AuthorizationPolicy: entry.AuthorizationPolicy,
-			AppLevelAuth:        !public,
+			AppLevelAuth:        !entry.Static.Public,
 			Handler:             handler,
 			ThemeStylesheet:     entry.ResolvedThemeStylesheet,
 			ThemeAssetsDir:      entry.ResolvedThemeAssetsDir,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the build break on `main` after merging #2618.

The dev-active static mount path correctly used `!entry.Static.Public`, but the production static handler still referenced a removed local variable `public`, causing:

```
internal/server/mounted_app_static.go:69:26: undefined: public
```

## Fix

Use `!entry.Static.Public` in the production `MountedUI` construction, matching the dev-active branch.

## Verification

- `go build ./...`
- `go vet ./...`
- `go test ./internal/server/...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e645459b-705d-4c6a-82bd-aeffc8a3b831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e645459b-705d-4c6a-82bd-aeffc8a3b831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

