### PR TITLE
Fix two-origin Vite API proxy for ephemeral gestaltd ports

### DIFF
--- a/docs/content/applications.mdx
+++ b/docs/content/applications.mdx
@@ -859,8 +859,9 @@ export default defineConfig({
 });
 ```
 
-`gestalt()` sets `base` to a relative path and configures the dev server for
-`GESTALT_DEV_*` when gestaltd proxies local `run` commands.
+`gestalt()` sets `base` to a relative path, configures the dev server for
+`GESTALT_DEV_*` when gestaltd proxies local `run` commands, and proxies `/api/v1`
+to `GESTALT_BASE_URL` for two-origin local dev.
 
 Manual equivalent when not using the plugin:
 
@@ -1072,6 +1073,7 @@ gestaltd appends these environment variables to each `run` command (manifest
 | `GESTALT_DEV` | `1` while gestaltd manages the dev process |
 | `GESTALT_DEV_PORT` | Ephemeral `127.0.0.1` port the frontend dev server must bind |
 | `GESTALT_DEV_BASE_PATH` | Mount path from `apps.<name>.static.mount` |
+| `GESTALT_BASE_URL` | Public gestaltd origin; consumed by `gestalt()` for `/api/v1` proxying |
 | `GESTALT_PROVIDER_SOCKET` | Unix socket for the app provider (full-stack apps only) |
 
 The dev supervisor probes frontend readiness on `GESTALT_DEV_PORT`, restarts

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -182,6 +182,7 @@ gestaltd injects (after manifest `env` entries):
 | `GESTALT_DEV` | Set to `1` |
 | `GESTALT_DEV_PORT` | Port the frontend dev server must bind on `127.0.0.1` |
 | `GESTALT_DEV_BASE_PATH` | Mount path from `apps.<name>.static.mount` |
+| `GESTALT_BASE_URL` | Public gestaltd origin for two-origin Vite `/api/v1` proxying |
 | `GESTALT_PROVIDER_SOCKET` | Unix socket for the app provider when a backend `run` command is present |
 
 Map these in your framework dev script. See

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -1154,6 +1154,9 @@ func buildDevSupervisedAppProvider(ctx context.Context, name string, entry *conf
 		target.BaseEnv = map[string]string{}
 	}
 	maps.Copy(target.BaseEnv, prepared.Env)
+	if baseURL := strings.TrimSpace(deps.BaseURL); baseURL != "" {
+		target.BaseEnv["GESTALT_BASE_URL"] = strings.TrimRight(baseURL, "/")
+	}
 	handle, err := deps.DevSupervisor.StartApp(ctx, target)
 	if err != nil {
 		prepared.Cleanup()

--- a/sdk/typescript/src/vite.js
+++ b/sdk/typescript/src/vite.js
@@ -43,6 +43,30 @@ function devBinding(port) {
   };
 }
 
+const DEFAULT_DEV_API_PROXY_TARGET = "http://127.0.0.1:8080";
+
+/**
+ * @param {string | undefined | null} value
+ * @returns {string}
+ */
+function normalizeApiProxyTarget(value) {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return DEFAULT_DEV_API_PROXY_TARGET;
+  }
+  return trimmed.replace(/\/+$/, "");
+}
+
+/**
+ * @param {Record<string, string | undefined>} env
+ * @returns {string}
+ */
+function resolveGestaltDevApiProxyTarget(env) {
+  return normalizeApiProxyTarget(
+    env.GESTALT_API_PROXY_TARGET?.trim() || env.GESTALT_BASE_URL?.trim(),
+  );
+}
+
 /**
  * @param {Record<string, string | undefined>} env
  * @param {string} command
@@ -71,10 +95,17 @@ function gestaltConfig(env, command) {
   const port = parseDevPort(devPort);
   const base = normalizeBasePath(env.GESTALT_DEV_BASE_PATH);
   const binding = devBinding(port);
+  const apiTarget = resolveGestaltDevApiProxyTarget(env);
+  const proxy = { target: apiTarget, changeOrigin: true };
 
   return {
     base,
-    server: binding,
+    server: {
+      ...binding,
+      proxy: {
+        "/api/v1": proxy,
+      },
+    },
     preview: binding,
   };
 }

--- a/sdk/typescript/tests/vite-plugin.test.ts
+++ b/sdk/typescript/tests/vite-plugin.test.ts
@@ -85,12 +85,20 @@ describe("gestalt vite plugin", () => {
     expect(config.build.outDir).toBe("dist");
   });
 
-  test("dev env resolves base, port, strictPort, and allowedHosts", async () => {
+  test("dev env applies gestaltd dev contract and /api/v1 proxy", async () => {
     const config = await resolveConfig(
       {
         configFile: false,
         root: fixtureRoot,
-        plugins: [gestalt({ env: { GESTALT_DEV_PORT: "5173", GESTALT_DEV_BASE_PATH: "/example" } })],
+        plugins: [
+          gestalt({
+            env: {
+              GESTALT_DEV_PORT: "5173",
+              GESTALT_DEV_BASE_PATH: "/example",
+              GESTALT_BASE_URL: "http://127.0.0.1:65003",
+            },
+          }),
+        ],
       },
       "serve",
     );
@@ -103,6 +111,35 @@ describe("gestalt vite plugin", () => {
     expect(config.preview.port).toBe(5173);
     expect(config.preview.strictPort).toBe(true);
     expect(config.preview.allowedHosts).toBe(true);
+    expect(config.server.proxy?.["/api/v1"]).toEqual({
+      target: "http://127.0.0.1:65003",
+      changeOrigin: true,
+    });
+
+    const overridden = await resolveConfig(
+      {
+        configFile: false,
+        root: fixtureRoot,
+        server: {
+          proxy: {
+            "/api/v1": { target: "http://127.0.0.1:8080", changeOrigin: true },
+          },
+        },
+        plugins: [
+          gestalt({
+            env: {
+              GESTALT_DEV_PORT: "5173",
+              GESTALT_API_PROXY_TARGET: "http://127.0.0.1:9000",
+            },
+          }),
+        ],
+      },
+      "serve",
+    );
+    expect(overridden.server.proxy?.["/api/v1"]).toEqual({
+      target: "http://127.0.0.1:9000",
+      changeOrigin: true,
+    });
   });
 
   test("live dev server serves mount with foreign Host and injected base tag", async () => {


### PR DESCRIPTION
Isolated `gestaltd serve` binds an ephemeral port, but two-origin Vite dev still proxies `/api/v1` to `:8080`, so API calls from the Vite URL get ECONNREFUSED.

```mermaid
sequenceDiagram
  participant Browser
  participant Vite
  participant Gestaltd
  Browser->>Vite: /api/v1/...
  Vite--xGestaltd: proxy 127.0.0.1:8080
  Note over Gestaltd: listening elsewhere
```

gestaltd exports `GESTALT_BASE_URL` to dev `run:` children. The `gestalt()` preset proxies `/api/v1` there (post-enforce overrides stale per-app targets).

```mermaid
sequenceDiagram
  participant Vite
  participant Gestaltd
  Note over Gestaltd: GESTALT_BASE_URL
  Vite->>Gestaltd: proxy /api/v1
```

With the preset:

```ts
// ui/vite.config.ts
import { gestalt } from "@valon-technologies/gestalt/vite";

export default defineConfig({
  plugins: [gestalt(), react()],
});
```

Without the preset (manual equivalent):

```ts
// ui/vite.config.ts
export default defineConfig({
  base: process.env.GESTALT_DEV_BASE_PATH
    ? `${process.env.GESTALT_DEV_BASE_PATH}/`
    : "/",
  server: {
    host: "127.0.0.1",
    port: Number(process.env.GESTALT_DEV_PORT),
    strictPort: true,
    proxy: {
      "/api/v1": {
        target:
          process.env.GESTALT_API_PROXY_TARGET ??
          process.env.GESTALT_BASE_URL ??
          "http://127.0.0.1:8080",
        changeOrigin: true,
      },
    },
  },
});
```

```ts
// src/lib/api.ts — same-origin /api/v1 works through the dev proxy
await fetch("/api/v1/vdsForge/getMe", { credentials: "include" });
```

`GESTALT_API_PROXY_TARGET` overrides when needed; `:8080` remains the fallback for older gestaltd.