### PR TITLE
Clear git/package sources in positional PATH fleet overlays

### DIFF
--- a/gestaltd/internal/daemon/e2e/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e/e2e_test.go
@@ -450,32 +450,75 @@ func TestE2EProviderValidateSourceUI(t *testing.T) {
 func TestE2EProviderValidateReusesConfiguredAppKey(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
-	providersDir := setupDefaultLocalProvidersDir(t, dir)
-	appDir := setupAppDir(t, dir)
-	manifestPath := componentProviderManifestPath(t, appDir)
-	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v8
+	cases := []struct {
+		name       string
+		appKey     string
+		setupApp   func(t *testing.T, dir string) string
+		configYAML func(manifestPath string) string
+	}{
+		{
+			name:   "local path in config",
+			appKey: "provider_go",
+			setupApp: func(t *testing.T, dir string) string {
+				return setupAppDir(t, dir)
+			},
+			configYAML: func(manifestPath string) string {
+				return fmt.Sprintf(`apiVersion: gestaltd.config/v8
 apps:
   provider_go:
     source:
       path: %s
 `, manifestPath)
-	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
-		t.Fatalf("write config: %v", err)
+			},
+		},
+		{
+			name:   "git source fleet config",
+			appKey: "oncall",
+			setupApp: func(t *testing.T, dir string) string {
+				appDir := setupAppDir(t, filepath.Join(dir, "oncall"))
+				setUIManifestSource(t, componentProviderManifestPath(t, appDir), "github.com/valon/apps/oncall")
+				return appDir
+			},
+			configYAML: func(manifestPath string) string {
+				return `apiVersion: gestaltd.config/v8
+apps:
+  oncall:
+    source:
+      git:
+        repo: https://github.com/valon-technologies/valon-tools.git
+        ref: cbd1f53e00000000000000000000000000000000
+        path: apps/oncall/manifest.yaml
+`
+			},
+		},
 	}
 
-	cmd := gestaltdCommand("provider", "validate", "--path", appDir, "--config", cfgPath)
-	cmd.Env = append(os.Environ(),
-		"GESTALT_PROVIDERS_DIR="+providersDir,
-		"GOTELEMETRY=off",
-	)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("gestaltd provider validate failed: %v\noutput: %s", err, out)
-	}
-	if !strings.Contains(string(out), "app=provider_go") {
-		t.Fatalf("expected configured app key in output, got: %s", out)
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			providersDir := setupDefaultLocalProvidersDir(t, dir)
+			appDir := tc.setupApp(t, dir)
+			cfgPath := filepath.Join(dir, "config.yaml")
+			if err := os.WriteFile(cfgPath, []byte(tc.configYAML(componentProviderManifestPath(t, appDir))), 0o644); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+
+			cmd := gestaltdCommand("provider", "validate", "--path", appDir, "--config", cfgPath)
+			cmd.Env = append(os.Environ(),
+				"GESTALT_PROVIDERS_DIR="+providersDir,
+				"GOTELEMETRY=off",
+			)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("gestaltd provider validate failed: %v\noutput: %s", err, out)
+			}
+			if !strings.Contains(string(out), "app="+tc.appKey) {
+				t.Fatalf("expected configured app key %q in output, got: %s", tc.appKey, out)
+			}
+		})
 	}
 }
 

--- a/gestaltd/internal/daemon/provider_local.go
+++ b/gestaltd/internal/daemon/provider_local.go
@@ -536,9 +536,6 @@ func providerLocalSourceOverride(manifestPath string) map[string]any {
 		"url":           nil,
 		"githubRelease": nil,
 		"git":           nil,
-		"package":       nil,
-		"repo":          nil,
-		"version":       nil,
 		"auth":          nil,
 	}
 }

--- a/gestaltd/internal/daemon/provider_local.go
+++ b/gestaltd/internal/daemon/provider_local.go
@@ -535,6 +535,10 @@ func providerLocalSourceOverride(manifestPath string) map[string]any {
 		"path":          manifestPath,
 		"url":           nil,
 		"githubRelease": nil,
+		"git":           nil,
+		"package":       nil,
+		"repo":          nil,
+		"version":       nil,
 		"auth":          nil,
 	}
 }

--- a/gestaltd/internal/daemon/provider_local_serve_test.go
+++ b/gestaltd/internal/daemon/provider_local_serve_test.go
@@ -5,8 +5,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/valon-technologies/gestalt/server/internal/config"
 )
 
 func TestMaybeRunServeProviderLocalRejectsLockedWithoutConfig(t *testing.T) {
@@ -148,98 +146,4 @@ providers:
 	if !session.NoSync {
 		t.Fatalf("session.NoSync = false, want true so --locked --no-sync binds pinned artifacts as-is")
 	}
-}
-
-func TestPrepareProviderLocalSessionClearsGitSourceOnFleetOverlay(t *testing.T) {
-	t.Parallel()
-
-	t.Run("git source", func(t *testing.T) {
-		t.Parallel()
-
-		dir := t.TempDir()
-		appDir := setupAppDir(t, filepath.Join(dir, "oncall"))
-		setAppManifestSource(t, appDir, "github.com/valon/apps/oncall")
-
-		baseCfg := filepath.Join(dir, "base.yaml")
-		baseYAML := `apiVersion: gestaltd.config/v8
-apps:
-  oncall:
-    source:
-      git:
-        repo: https://github.com/valon-technologies/valon-tools.git
-        ref: cbd1f53e00000000000000000000000000000000
-        path: apps/oncall/manifest.yaml
-`
-		if err := os.WriteFile(baseCfg, []byte(baseYAML), 0o644); err != nil {
-			t.Fatalf("WriteFile base config: %v", err)
-		}
-
-		session, err := prepareProviderLocalSession(providerLocalCommandOptions{
-			Paths:        []string{componentProviderManifestPath(t, appDir)},
-			ConfigPaths:  []string{baseCfg},
-			FleetOverlay: true,
-		})
-		if err != nil {
-			t.Fatalf("prepareProviderLocalSession: %v", err)
-		}
-		defer func() { _ = os.RemoveAll(session.Dir) }()
-
-		cfg, err := config.LoadPaths(session.ConfigPaths)
-		if err != nil {
-			t.Fatalf("LoadPaths(session.ConfigPaths): %v", err)
-		}
-		entry := cfg.Apps["oncall"]
-		if entry == nil {
-			t.Fatal(`Apps["oncall"] = nil`)
-		}
-		if !entry.Source.IsLocal() {
-			t.Fatalf("Apps[oncall].Source.IsLocal() = false, want true")
-		}
-		if entry.Source.IsGit() {
-			t.Fatalf("Apps[oncall].Source.IsGit() = true, want false")
-		}
-	})
-
-	t.Run("metadata URL source", func(t *testing.T) {
-		t.Parallel()
-
-		dir := t.TempDir()
-		appDir := setupAppDir(t, filepath.Join(dir, "oncall"))
-		setAppManifestSource(t, appDir, "github.com/valon/apps/oncall")
-
-		baseCfg := filepath.Join(dir, "base.yaml")
-		baseYAML := `apiVersion: gestaltd.config/v8
-apps:
-  oncall:
-    source: https://example.invalid/providers/oncall/provider-release.yaml
-`
-		if err := os.WriteFile(baseCfg, []byte(baseYAML), 0o644); err != nil {
-			t.Fatalf("WriteFile base config: %v", err)
-		}
-
-		session, err := prepareProviderLocalSession(providerLocalCommandOptions{
-			Paths:        []string{componentProviderManifestPath(t, appDir)},
-			ConfigPaths:  []string{baseCfg},
-			FleetOverlay: true,
-		})
-		if err != nil {
-			t.Fatalf("prepareProviderLocalSession: %v", err)
-		}
-		defer func() { _ = os.RemoveAll(session.Dir) }()
-
-		cfg, err := config.LoadPaths(session.ConfigPaths)
-		if err != nil {
-			t.Fatalf("LoadPaths(session.ConfigPaths): %v", err)
-		}
-		entry := cfg.Apps["oncall"]
-		if entry == nil {
-			t.Fatal(`Apps["oncall"] = nil`)
-		}
-		if !entry.Source.IsLocal() {
-			t.Fatalf("Apps[oncall].Source.IsLocal() = false, want true")
-		}
-		if entry.Source.IsMetadataURL() {
-			t.Fatalf("Apps[oncall].Source.IsMetadataURL() = true, want false")
-		}
-	})
 }

--- a/gestaltd/internal/daemon/provider_local_serve_test.go
+++ b/gestaltd/internal/daemon/provider_local_serve_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
 )
 
 func TestMaybeRunServeProviderLocalRejectsLockedWithoutConfig(t *testing.T) {
@@ -146,4 +148,98 @@ providers:
 	if !session.NoSync {
 		t.Fatalf("session.NoSync = false, want true so --locked --no-sync binds pinned artifacts as-is")
 	}
+}
+
+func TestPrepareProviderLocalSessionClearsGitSourceOnFleetOverlay(t *testing.T) {
+	t.Parallel()
+
+	t.Run("git source", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		appDir := setupAppDir(t, filepath.Join(dir, "oncall"))
+		setAppManifestSource(t, appDir, "github.com/valon/apps/oncall")
+
+		baseCfg := filepath.Join(dir, "base.yaml")
+		baseYAML := `apiVersion: gestaltd.config/v8
+apps:
+  oncall:
+    source:
+      git:
+        repo: https://github.com/valon-technologies/valon-tools.git
+        ref: cbd1f53e00000000000000000000000000000000
+        path: apps/oncall/manifest.yaml
+`
+		if err := os.WriteFile(baseCfg, []byte(baseYAML), 0o644); err != nil {
+			t.Fatalf("WriteFile base config: %v", err)
+		}
+
+		session, err := prepareProviderLocalSession(providerLocalCommandOptions{
+			Paths:        []string{componentProviderManifestPath(t, appDir)},
+			ConfigPaths:  []string{baseCfg},
+			FleetOverlay: true,
+		})
+		if err != nil {
+			t.Fatalf("prepareProviderLocalSession: %v", err)
+		}
+		defer func() { _ = os.RemoveAll(session.Dir) }()
+
+		cfg, err := config.LoadPaths(session.ConfigPaths)
+		if err != nil {
+			t.Fatalf("LoadPaths(session.ConfigPaths): %v", err)
+		}
+		entry := cfg.Apps["oncall"]
+		if entry == nil {
+			t.Fatal(`Apps["oncall"] = nil`)
+		}
+		if !entry.Source.IsLocal() {
+			t.Fatalf("Apps[oncall].Source.IsLocal() = false, want true")
+		}
+		if entry.Source.IsGit() {
+			t.Fatalf("Apps[oncall].Source.IsGit() = true, want false")
+		}
+	})
+
+	t.Run("metadata URL source", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		appDir := setupAppDir(t, filepath.Join(dir, "oncall"))
+		setAppManifestSource(t, appDir, "github.com/valon/apps/oncall")
+
+		baseCfg := filepath.Join(dir, "base.yaml")
+		baseYAML := `apiVersion: gestaltd.config/v8
+apps:
+  oncall:
+    source: https://example.invalid/providers/oncall/provider-release.yaml
+`
+		if err := os.WriteFile(baseCfg, []byte(baseYAML), 0o644); err != nil {
+			t.Fatalf("WriteFile base config: %v", err)
+		}
+
+		session, err := prepareProviderLocalSession(providerLocalCommandOptions{
+			Paths:        []string{componentProviderManifestPath(t, appDir)},
+			ConfigPaths:  []string{baseCfg},
+			FleetOverlay: true,
+		})
+		if err != nil {
+			t.Fatalf("prepareProviderLocalSession: %v", err)
+		}
+		defer func() { _ = os.RemoveAll(session.Dir) }()
+
+		cfg, err := config.LoadPaths(session.ConfigPaths)
+		if err != nil {
+			t.Fatalf("LoadPaths(session.ConfigPaths): %v", err)
+		}
+		entry := cfg.Apps["oncall"]
+		if entry == nil {
+			t.Fatal(`Apps["oncall"] = nil`)
+		}
+		if !entry.Source.IsLocal() {
+			t.Fatalf("Apps[oncall].Source.IsLocal() = false, want true")
+		}
+		if entry.Source.IsMetadataURL() {
+			t.Fatalf("Apps[oncall].Source.IsMetadataURL() = true, want false")
+		}
+	})
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When `gestaltd serve` receives positional PATH arguments with `--config`, the auto-generated overlay must clear `source.git` before setting `source.path`. Without that, merged config fails validation for fleet apps pinned to snapshot git refs.

## Changes

- Add `git: nil` to `providerLocalSourceOverride` in `gestaltd/internal/daemon/provider_local.go`
- Extend `TestE2EProviderValidateReusesConfiguredAppKey` with a `git source fleet config` case (no new unit test)

## Test plan

- [x] `go test ./gestaltd/internal/daemon/e2e/ -run TestE2EProviderValidateReusesConfiguredAppKey -count=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-72eac029-608b-46a5-bd5e-d635b3145f68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-72eac029-608b-46a5-bd5e-d635b3145f68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

