### PR TITLE
Add explicit base() mount helper for client routers

### DIFF
--- a/gestaltd/internal/daemon/e2e/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e/e2e_test.go
@@ -469,7 +469,7 @@ apps:
 			appKey: "oncall",
 			setupApp: func(t *testing.T, dir string) string {
 				appDir := setupAppDir(t, filepath.Join(dir, "oncall"))
-				setUIManifestSource(t, componentProviderManifestPath(t, appDir), "github.com/valon/apps/oncall")
+				setAppManifestSource(t, appDir, "github.com/valon/apps/oncall")
 				return appDir
 			},
 			configYAML: func(manifestPath string) string {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -2760,37 +2760,67 @@ func TestMountedAppStaticServing(t *testing.T) {
 	t.Run("base href injection", func(t *testing.T) {
 		t.Parallel()
 
-		rootDir := t.TempDir()
-		writeTestUIAsset(t, filepath.Join(rootDir, "index.html"), "<html><head><title>alpha</title></head><body>alpha-shell</body></html>")
+		cases := []struct {
+			name     string
+			mount    string
+			request  string
+			wantBase string
+			shell    string
+		}{
+			{
+				name:     "subpath mount",
+				mount:    "/alpha",
+				request:  "/alpha/",
+				wantBase: `<base href="/alpha/">`,
+				shell:    "alpha-shell",
+			},
+			{
+				name:     "root mount",
+				mount:    "/",
+				request:  "/",
+				wantBase: `<base href="/">`,
+				shell:    "root-shell",
+			},
+		}
 
-		ts := newTestServer(t, func(cfg *server.Config) {
-			cfg.AppDefs = map[string]*config.ProviderEntry{
-				"alpha": {
-					Static:             &config.AppStaticConfig{Mount: "/alpha"},
-					ResolvedStaticRoot: rootDir,
-				},
-			}
-		})
-		testutil.CloseOnCleanup(t, ts)
+		for _, tc := range cases {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
 
-		resp, err := http.Get(ts.URL + "/alpha/")
-		if err != nil {
-			t.Fatalf("GET /alpha/: %v", err)
-		}
-		body, err := io.ReadAll(resp.Body)
-		_ = resp.Body.Close()
-		if err != nil {
-			t.Fatalf("ReadAll: %v", err)
-		}
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("status = %d, want 200", resp.StatusCode)
-		}
-		text := string(body)
-		if !strings.Contains(text, `<base href="/alpha/">`) {
-			t.Fatalf("body = %q, want injected base href", text)
-		}
-		if !strings.Contains(text, "alpha-shell") {
-			t.Fatalf("body = %q, want alpha shell", text)
+				rootDir := t.TempDir()
+				writeTestUIAsset(t, filepath.Join(rootDir, "index.html"), "<html><head><title>"+tc.name+"</title></head><body>"+tc.shell+"</body></html>")
+
+				ts := newTestServer(t, func(cfg *server.Config) {
+					cfg.AppDefs = map[string]*config.ProviderEntry{
+						tc.name: {
+							Static:             &config.AppStaticConfig{Mount: tc.mount},
+							ResolvedStaticRoot: rootDir,
+						},
+					}
+				})
+				testutil.CloseOnCleanup(t, ts)
+
+				resp, err := http.Get(ts.URL + tc.request)
+				if err != nil {
+					t.Fatalf("GET %s: %v", tc.request, err)
+				}
+				body, err := io.ReadAll(resp.Body)
+				_ = resp.Body.Close()
+				if err != nil {
+					t.Fatalf("ReadAll: %v", err)
+				}
+				if resp.StatusCode != http.StatusOK {
+					t.Fatalf("status = %d, want 200", resp.StatusCode)
+				}
+				text := string(body)
+				if !strings.Contains(text, tc.wantBase) {
+					t.Fatalf("body = %q, want injected base href %q", text, tc.wantBase)
+				}
+				if !strings.Contains(text, tc.shell) {
+					t.Fatalf("body = %q, want %q shell", text, tc.shell)
+				}
+			})
 		}
 	})
 

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@valon-technologies/gestalt",
-  "version": "0.0.1-alpha.69",
+  "version": "0.0.1-alpha.71",
   "description": "TypeScript SDK for Gestalt executable providers",
   "type": "module",
   "repository": {
@@ -10,6 +10,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./build": "./src/build.ts",
+    "./mount": "./src/mount.ts",
     "./runtime": "./src/providers/runtime-public.ts",
     "./schema": "./src/schema.ts",
     "./telemetry": "./src/telemetry.ts",

--- a/sdk/typescript/src/mount.ts
+++ b/sdk/typescript/src/mount.ts
@@ -1,0 +1,27 @@
+/**
+ * Resolves the absolute mount prefix for the running app.
+ *
+ * @module mount
+ */
+
+/**
+ * Returns the base path for absolute links from application code.
+ *
+ * gestaltd injects a base element with an href attribute into the served
+ * HTML (via `injectBaseHref`); this reads that element's path.
+ */
+export function base(): string {
+  if (typeof document === "undefined") {
+    throw new Error("base() requires a browser document");
+  }
+  const baseEl = document.querySelector("base[href]");
+  if (!baseEl || baseEl.tagName !== "BASE") {
+    throw new Error("base() requires <base href> to be present in the document");
+  }
+  const href = baseEl.getAttribute("href")?.trim();
+  if (!href) {
+    throw new Error("base() requires <base href> to be present in the document");
+  }
+  const pathname = new URL(href, "http://localhost").pathname.replace(/\/+$/, "");
+  return pathname;
+}

--- a/sdk/typescript/src/vite.js
+++ b/sdk/typescript/src/vite.js
@@ -130,10 +130,6 @@ export function gestalt(options = {}) {
           return html;
         }
         const devBase = normalizeBasePath(env.GESTALT_DEV_BASE_PATH);
-        // Root mount: relative refs resolve without <base>; gestaltd skips it in prod too.
-        if (devBase === "/") {
-          return html;
-        }
         if (/<base\b/i.test(html)) {
           return html;
         }

--- a/sdk/typescript/tests/mount.test.ts
+++ b/sdk/typescript/tests/mount.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { base } from "../src/mount.ts";
+
+type BaseElement = {
+  tagName: string;
+  getAttribute(name: string): string | null;
+};
+
+function installDocument(baseEl: BaseElement | null): void {
+  (globalThis as { document?: { querySelector(selector: string): BaseElement | null } }).document = {
+    querySelector(selector: string) {
+      if (selector === "base[href]") {
+        return baseEl;
+      }
+      return null;
+    },
+  };
+}
+
+describe("base", () => {
+  afterEach(() => {
+    delete (globalThis as { document?: unknown }).document;
+  });
+
+  test("throws without a browser document", () => {
+    expect(() => base()).toThrow("base() requires a browser document");
+  });
+
+  test("throws without a base href element", () => {
+    installDocument(null);
+    expect(() => base()).toThrow("base() requires <base href> to be present in the document");
+  });
+
+  test("returns the mount prefix without a trailing slash", () => {
+    installDocument({
+      tagName: "BASE",
+      getAttribute(name: string) {
+        return name === "href" ? "/vm-style-guide/" : null;
+      },
+    });
+    expect(base()).toBe("/vm-style-guide");
+  });
+
+  test("returns empty string for a root mount", () => {
+    installDocument({
+      tagName: "BASE",
+      getAttribute(name: string) {
+        return name === "href" ? "/" : null;
+      },
+    });
+    expect(base()).toBe("");
+  });
+});

--- a/sdk/typescript/tests/vite-plugin.test.ts
+++ b/sdk/typescript/tests/vite-plugin.test.ts
@@ -143,25 +143,34 @@ describe("gestalt vite plugin", () => {
   });
 
   test("live dev server serves mount with foreign Host and injected base tag", async () => {
-    const port = await freePort();
-    const env = {
-      GESTALT_DEV_PORT: String(port),
-      GESTALT_DEV_BASE_PATH: "/example",
-    };
-    const server = await createViteServer({
-      configFile: false,
-      root: fixtureRoot,
-      plugins: [gestalt({ env })],
-    });
-    viteServers.push(server);
-    await server.listen();
+    const cases = [
+      { basePath: "/example", requestPath: "/example/", wantBase: '<base href="/example/">' },
+      { basePath: "/", requestPath: "/", wantBase: '<base href="/">' },
+    ] as const;
 
-    const response = await fetch(`http://127.0.0.1:${port}/example/`, {
-      headers: { Host: "foreign.example.test" },
-    });
-    expect(response.status).toBe(200);
-    const html = await response.text();
-    expect(html).toContain('<base href="/example/">');
+    for (const { basePath, requestPath, wantBase } of cases) {
+      const port = await freePort();
+      const env = {
+        GESTALT_DEV_PORT: String(port),
+        GESTALT_DEV_BASE_PATH: basePath,
+      };
+      const server = await createViteServer({
+        configFile: false,
+        root: fixtureRoot,
+        plugins: [gestalt({ env })],
+      });
+      viteServers.push(server);
+      await server.listen();
+
+      const response = await fetch(`http://127.0.0.1:${port}${requestPath}`, {
+        headers: { Host: "foreign.example.test" },
+      });
+      expect(response.status).toBe(200);
+      const html = await response.text();
+      expect(html).toContain(wantBase);
+      await server.close();
+      viteServers.pop();
+    }
   });
 
   test("build emits relative asset references into GESTALT_BUILD_STATIC", async () => {

--- a/sdk/typescript/typedoc.json
+++ b/sdk/typescript/typedoc.json
@@ -3,6 +3,7 @@
   "entryPoints": [
     "src/index.ts",
     "src/build.ts",
+    "src/mount.ts",
     "src/providers/runtime-public.ts",
     "src/schema.ts",
     "src/telemetry.ts",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `base()` to `@valon-technologies/gestalt/mount` so apps read the mount prefix from the injected `<base href>` instead of hand-rolling `document.baseURI` parsing or local helpers with hard-coded fallbacks. gestaltd injects the tag when serving static HTML; the Vite dev plugin now does the same for root mounts. If the contract is missing, `base()` throws rather than guessing. Bumps the SDK to `0.0.1-alpha.71`.

Without the mount helper, apps inline parsing at every call site or maintain local helpers with fallbacks:

```ts
// Inline at every router setup
const basepath = new URL(document.baseURI).pathname.replace(/\/+$/, "");

// TanStack Router
const router = createRouter({ routeTree, basepath });

// React Router
<BrowserRouter basename={basepath}>

// Wouter
<Router base={basepath}><App /></Router>

// Absolute link outside a router
const reportUrl = `${basepath}/reports/${id}`;
```

```ts
// Or a local helper with hard-coded / env fallbacks (g-issues, workplace-hub today)
export function mountedBasePath(): string {
  if (typeof document === "undefined") return "/workplace-hub";
  const path = new URL(document.baseURI).pathname.replace(/\/+$/, "");
  return path || import.meta.env.BASE_URL || "/workplace-hub";
}

const basepath = mountedBasePath();

// TanStack Router
const router = createRouter({ routeTree, basepath });

// React Router
<BrowserRouter basename={basepath}>

// Wouter
<Router base={basepath}><App /></Router>

// Absolute link outside a router
const reportUrl = `${basepath}/reports/${id}`;
```

With `base()`:

```ts
import { base } from "@valon-technologies/gestalt/mount";

// TanStack Router
const router = createRouter({ routeTree, basepath: base() });

// React Router
<BrowserRouter basename={base()}>

// Wouter
<Router base={base()}><App /></Router>

// Absolute link outside a router
const reportUrl = `${base()}/reports/${id}`;
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c0305cb-04f8-4e27-85a2-65cd5a112626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c0305cb-04f8-4e27-85a2-65cd5a112626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

