### PR TITLE
[gestaltd] Fix broken e2e compile (setUIManifestSource -> setAppManifestSource)

### DIFF
--- a/gestaltd/internal/daemon/e2e/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e/e2e_test.go
@@ -469,7 +469,7 @@ apps:
 			appKey: "oncall",
 			setupApp: func(t *testing.T, dir string) string {
 				appDir := setupAppDir(t, filepath.Join(dir, "oncall"))
-				setUIManifestSource(t, componentProviderManifestPath(t, appDir), "github.com/valon/apps/oncall")
+				setAppManifestSource(t, appDir, "github.com/valon/apps/oncall")
 				return appDir
 			},
 			configYAML: func(manifestPath string) string {


### PR DESCRIPTION
## Description
`main`'s `internal/daemon/e2e` package fails to compile: `setUIManifestSource` is called at `e2e_test.go:472`, but that helper was removed in #2613 (renamed to `setAppManifestSource(t, appDir, source)`). The git-source-fleet test case added in #2622 wasn't updated to the new helper — a clean-but-semantically-broken merge — so `validate / Go Lint & Vet` and `validate / Go E2E Tests (daemon)` are red on `main` and block every open PR.

One-line fix to the current helper, matching every other call site (e.g. line 424).

🤖 Generated with [Claude Code](https://claude.com/claude-code)