### PR TITLE
Fix base() for relative base href values

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@valon-technologies/gestalt",
-  "version": "0.0.1-alpha.71",
+  "version": "0.0.1-alpha.72",
   "description": "TypeScript SDK for Gestalt executable providers",
   "type": "module",
   "repository": {

--- a/sdk/typescript/src/mount.ts
+++ b/sdk/typescript/src/mount.ts
@@ -18,10 +18,10 @@ export function base(): string {
   if (!baseEl || baseEl.tagName !== "BASE") {
     throw new Error("base() requires <base href> to be present in the document");
   }
-  const href = baseEl.getAttribute("href")?.trim();
+  const href = (baseEl as HTMLBaseElement).href.trim();
   if (!href) {
     throw new Error("base() requires <base href> to be present in the document");
   }
-  const pathname = new URL(href, "http://localhost").pathname.replace(/\/+$/, "");
+  const pathname = new URL(href).pathname.replace(/\/+$/, "");
   return pathname;
 }

--- a/sdk/typescript/tests/mount.test.ts
+++ b/sdk/typescript/tests/mount.test.ts
@@ -5,6 +5,7 @@ import { base } from "../src/mount.ts";
 type BaseElement = {
   tagName: string;
   href: string;
+  getAttribute?: (name: string) => string | null;
 };
 
 function installDocument(baseEl: BaseElement | null): void {
@@ -38,10 +39,15 @@ describe("base", () => {
       href: "http://example.com/example-app/",
     });
     expect(base()).toBe("/example-app");
+  });
 
+  test("resolves a relative base href from HTMLBaseElement.href", () => {
     installDocument({
       tagName: "BASE",
       href: "http://example.com/mounted-app/",
+      getAttribute(name: string) {
+        return name === "href" ? "./" : null;
+      },
     });
     expect(base()).toBe("/mounted-app");
   });

--- a/sdk/typescript/tests/mount.test.ts
+++ b/sdk/typescript/tests/mount.test.ts
@@ -4,7 +4,7 @@ import { base } from "../src/mount.ts";
 
 type BaseElement = {
   tagName: string;
-  getAttribute(name: string): string | null;
+  href: string;
 };
 
 function installDocument(baseEl: BaseElement | null): void {
@@ -35,19 +35,21 @@ describe("base", () => {
   test("returns the mount prefix without a trailing slash", () => {
     installDocument({
       tagName: "BASE",
-      getAttribute(name: string) {
-        return name === "href" ? "/vm-style-guide/" : null;
-      },
+      href: "http://example.com/vm-style-guide/",
     });
     expect(base()).toBe("/vm-style-guide");
+
+    installDocument({
+      tagName: "BASE",
+      href: "http://example.com/create-customer-roadmap-review/",
+    });
+    expect(base()).toBe("/create-customer-roadmap-review");
   });
 
   test("returns empty string for a root mount", () => {
     installDocument({
       tagName: "BASE",
-      getAttribute(name: string) {
-        return name === "href" ? "/" : null;
-      },
+      href: "http://example.com/",
     });
     expect(base()).toBe("");
   });

--- a/sdk/typescript/tests/mount.test.ts
+++ b/sdk/typescript/tests/mount.test.ts
@@ -35,15 +35,15 @@ describe("base", () => {
   test("returns the mount prefix without a trailing slash", () => {
     installDocument({
       tagName: "BASE",
-      href: "http://example.com/vm-style-guide/",
+      href: "http://example.com/example-app/",
     });
-    expect(base()).toBe("/vm-style-guide");
+    expect(base()).toBe("/example-app");
 
     installDocument({
       tagName: "BASE",
-      href: "http://example.com/create-customer-roadmap-review/",
+      href: "http://example.com/mounted-app/",
     });
-    expect(base()).toBe("/create-customer-roadmap-review");
+    expect(base()).toBe("/mounted-app");
   });
 
   test("returns empty string for a root mount", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`base()` was parsing `getAttribute("href")` with `new URL(href, "http://localhost")`, so a production `<base href="./">` resolved to an empty basepath and broke TanStack Router on mounted apps. It now reads `HTMLBaseElement.href`, the browser-resolved URL, and takes the pathname from that. Bumps the SDK to `0.0.1-alpha.72`.

After publish, toolshed can drop the registry `gestalt-mount` shim and Vite alias from #3147.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c0305cb-04f8-4e27-85a2-65cd5a112626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c0305cb-04f8-4e27-85a2-65cd5a112626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

