### PR TITLE
Bump TypeScript SDK to 0.0.1-alpha.73.

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@valon-technologies/gestalt",
-  "version": "0.0.1-alpha.72",
+  "version": "0.0.1-alpha.73",
   "description": "TypeScript SDK for Gestalt executable providers",
   "type": "module",
   "repository": {


### PR DESCRIPTION
## Description

Bumps the TypeScript SDK to `0.0.1-alpha.73` so the declarative migrations runner (#2632) and the CreateIndex/DeleteIndex client (#2631) can be published. Merge, then push the `sdk/typescript/v0.0.1-alpha.73` tag to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)