### PR TITLE
Make --scopes optional for gestalt auth token create

### DIFF
--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -198,7 +198,7 @@ pub enum TokenCommands {
         #[arg(long)]
         name: Option<String>,
         /// OAuth scopes for the token (e.g. my-app or my-app:operation)
-        #[arg(long)]
+        #[arg(long, default_value = "")]
         scopes: String,
         /// Token lifetime in seconds (default: 30 days)
         #[arg(long = "expires-in", default_value_t = 30 * 24 * 3600)]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`gestalt auth token create` no longer requires `--scopes`. When omitted, the CLI defaults to an empty string, which the API already accepts for full-identity tokens (same behavior as the login flow).

## Changes

- Add `default_value = ""` to the `--scopes` flag in `TokenCommands::Create`

## Testing

```bash
cargo test -p gestalt --test tokens_cli --test auth_flow
```

All 17 tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-56a89989-4cc9-4304-8dce-a628f2c2afa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-56a89989-4cc9-4304-8dce-a628f2c2afa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

