### PR TITLE
[sdk] Migrations degrade to lockless when the lease is unavailable

### DIFF
--- a/sdk/typescript/src/providers/migrations.ts
+++ b/sdk/typescript/src/providers/migrations.ts
@@ -195,9 +195,12 @@ export class MigrationError extends Error {
 
 /**
  * Brings the database up to head, acquiring the migration lease first so only
- * one instance migrates at a time. Idempotent — a no-op when nothing is
- * pending. Releases the lease and never leaves it held on error. Returns the
- * revision ids applied this run and the declared head.
+ * one instance migrates at a time. If the backend does not support the lease
+ * (or acquiring it errors), it degrades to running lockless — idempotency is
+ * the correctness guarantee, the lease only prevents redundant concurrent work.
+ * Idempotent — a no-op when nothing is pending. Releases the lease and never
+ * leaves it held on error. Returns the revision ids applied this run and the
+ * declared head.
  */
 export async function runMigrations(
   db: IndexedDB,
@@ -215,9 +218,11 @@ export async function runMigrations(
   const holder = options.holder?.trim() || randomHolderId();
 
   await ensureLedgerStore(db, ledgerStore);
-  await acquireLease(db, lockKey, holder, ttlMs, acquireTimeoutMs);
+  const held = await acquireLease(db, lockKey, holder, ttlMs, acquireTimeoutMs);
 
-  const renew = startLeaseRenewal(db, lockKey, holder, ttlMs);
+  const renew = held
+    ? startLeaseRenewal(db, lockKey, holder, ttlMs)
+    : { stop: () => {}, lost: () => false };
   try {
     const applied = new Set(await db.objectStore(ledgerStore).getAllKeys());
     assertNotAheadOfCode(revisions, applied);
@@ -255,7 +260,9 @@ export async function runMigrations(
     return { applied: appliedNow, head: attemptedHead };
   } finally {
     renew.stop();
-    await releaseQuietly(db, lockKey, holder);
+    if (held) {
+      await releaseQuietly(db, lockKey, holder);
+    }
   }
 }
 
@@ -470,12 +477,15 @@ async function acquireLease(
   holder: string,
   ttlMs: number,
   timeoutMs: number,
-): Promise<void> {
+): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
   for (;;) {
-    const lease = await db.acquireLock(key, holder, ttlMs);
+    const lease = await db.acquireLock(key, holder, ttlMs).catch(() => null);
+    if (lease === null) {
+      return false;
+    }
     if (lease.acquired) {
-      return;
+      return true;
     }
     if (Date.now() >= deadline) {
       throw new MigrationError(

--- a/sdk/typescript/tests/migrations.test.ts
+++ b/sdk/typescript/tests/migrations.test.ts
@@ -23,6 +23,7 @@ class FakeIndexedDB {
   readonly calls: string[] = [];
   lock: { holder: string; expiresAt: number } | null = null;
   createObjectStoreError: Error | null = null;
+  acquireLockError: Error | null = null;
 
   async createObjectStore(
     name: string,
@@ -112,6 +113,9 @@ class FakeIndexedDB {
     ttlMs: number,
   ): Promise<AcquireLockResult> {
     this.calls.push(`acquireLock:${holder}`);
+    if (this.acquireLockError) {
+      throw this.acquireLockError;
+    }
     const now = Date.now();
     if (this.lock && this.lock.holder !== holder && this.lock.expiresAt > now) {
       return {
@@ -331,6 +335,19 @@ describe("runMigrations", () => {
     ).rejects.toThrow(/lost the migration lease/);
     expect(await ledgerIds(fake)).toEqual(["0001_seed"]);
     expect(fake.stores.get("issues")?.rows.has("x")).toBe(false);
+  });
+
+  test("runs lockless when acquireLock is Unimplemented", async () => {
+    const { db, fake } = fakeDb();
+    fake.acquireLockError = Object.assign(new Error("advisory locks not supported"), {
+      code: 12,
+    });
+
+    await runMigrations(db, { revisions: [issuesRevision] });
+
+    expect(fake.stores.has("issues")).toBe(true);
+    expect(await ledgerIds(fake)).toEqual(["0001_issues"]);
+    expect(fake.calls.some((c) => c.startsWith("releaseLock:"))).toBe(false);
   });
 
   test("fails closed when the ledger is ahead of the code", async () => {


### PR DESCRIPTION
## Description

Fixes the root cause of the g-issues install failure. `acquireLease` let any `AcquireLock` error propagate out of `runMigrations`, so an IndexedDB backend that doesn't implement `AcquireLock` (the deployed `relationaldb` predates the lock RPC / PR #1112) returned `Unimplemented`, which **aborted the entire migration** → `configure` threw → app install failed → "integration g-issues not found".

That contradicts the design: the lease is an optimization, not a correctness mechanism — idempotency is the guarantee, and the lease only prevents redundant concurrent work. So `runMigrations` now **degrades to lockless** when the lease can't be acquired (unsupported or errored): it skips renewal/release and runs the migrations. A *contended* lease (`acquired: false`) still waits/times out as before.

Test added: migration completes and records the ledger when `acquireLock` throws `Unimplemented`, and no release is attempted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)