### PR TITLE
Bump TypeScript SDK to 0.0.1-alpha.74.

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@valon-technologies/gestalt",
-  "version": "0.0.1-alpha.73",
+  "version": "0.0.1-alpha.74",
   "description": "TypeScript SDK for Gestalt executable providers",
   "type": "module",
   "repository": {


### PR DESCRIPTION
## Description

Bumps the TypeScript SDK to `0.0.1-alpha.74` to publish the migration runner's lockless-degrade fix (#2636). Merge, then push the `sdk/typescript/v0.0.1-alpha.74` tag to release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)