### PR TITLE
[gestaltd] Register app public host services on every replica at startup

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -265,6 +265,7 @@ type Result struct {
 	workflowConfigReconcileTasks        []workflowConfigReconcileTask
 	workflowConfigReconcileTasksStarted bool
 	auditClose                          func(context.Context) error
+	appHostServiceCleanup               func()
 	activateAppProviders                func(context.Context)
 	deferred                            *deferredProviders
 	mu                                  sync.Mutex
@@ -419,6 +420,9 @@ func (r *Result) Close(ctx context.Context) error {
 		closeSecretManager(r.SecretManager),
 		closeRuntimeRegistry(r.runtimeRegistry),
 	)
+	if r.appHostServiceCleanup != nil {
+		r.appHostServiceCleanup()
+	}
 	if r.auditClose != nil {
 		errs = append(errs, r.auditClose(ctx))
 	}
@@ -1240,6 +1244,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		SessionStart:      agentSessionStartConfigs(cfg),
 	}))
 	pluginInvoker.SetTarget(invocation.NewGuarded(sharedInvoker, nil, "app", audit, invocation.WithoutRateLimit()))
+	appHostServiceCleanup := registerConfiguredAppPublicHostServices(ctx, cfg, prepared.Deps)
 	// Build workflow/agent providers before app providers: they establish their
 	// backend connection during build, which must not race concurrent app startup.
 	extraWorkflows, extraAgents, err := buildWorkflowsAndAgents(ctx, cfg, factories, prepared.Deps)
@@ -1385,6 +1390,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		runtimeRegistry:              prepared.runtimeRegistry,
 		workflowConfigReconcileTasks: deferredWorkflowConfigReconcileTasks,
 		auditClose:                   auditClose,
+		appHostServiceCleanup:        appHostServiceCleanup,
 		activateAppProviders:         activateAppProviders,
 		deferred:                     deferred,
 	}

--- a/gestaltd/internal/bootstrap/host_service_bootstrap.go
+++ b/gestaltd/internal/bootstrap/host_service_bootstrap.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"maps"
 	"slices"
 	"strings"
@@ -248,6 +249,41 @@ func registerPublicRuntimeHostServices(providerName string, hostServices []runti
 		providerName: providerName,
 		provider:     runtimeProvider,
 	}, false)
+}
+
+func registerConfiguredAppPublicHostServices(ctx context.Context, cfg *config.Config, deps Deps) func() {
+	if cfg == nil || !hostCanRelayRuntimeHostServices(deps) {
+		return func() {}
+	}
+	var cleanups []func()
+	for _, name := range slices.Sorted(maps.Keys(cfg.Apps)) {
+		entry := cfg.Apps[name]
+		if !entry.UsesRuntimePlacement() {
+			continue
+		}
+		_, runtimeProvider, _, err := effectiveRuntime(ctx, name, entry, deps)
+		if err != nil {
+			slog.Warn("eager public host service registration skipped", "provider", name, "error", err)
+			continue
+		}
+		hostServices, err := buildProviderHostServices(name, appProviderHostServiceDeps(entry, deps))
+		if err != nil {
+			slog.Warn("eager public host service registration skipped", "provider", name, "error", err)
+			continue
+		}
+		if len(hostServices) == 0 {
+			continue
+		}
+		cleanup, err := registerPublicRuntimeHostServices(name, hostServices, deps, runtimeProvider)
+		if err != nil {
+			slog.Warn("eager public host service registration failed", "provider", name, "error", err)
+			continue
+		}
+		if cleanup != nil {
+			cleanups = append(cleanups, cleanup)
+		}
+	}
+	return chainCleanup(cleanups...)
 }
 
 type workflowProviderHostServiceSessionVerifier struct{}

--- a/gestaltd/internal/bootstrap/host_service_bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/host_service_bootstrap_test.go
@@ -1,0 +1,99 @@
+package bootstrap
+
+import (
+	"context"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
+)
+
+func eagerHostServiceTestDeps(registry *runtimehost.PublicHostServiceRegistry) Deps {
+	return Deps{
+		BaseURL:               "https://gestalt.example.test",
+		EncryptionKey:         []byte("0123456789abcdef0123456789abcdef"),
+		SelectedIndexedDBName: "main",
+		IndexedDBs: map[string]indexeddb.IndexedDB{
+			"main": &coretesting.StubIndexedDB{},
+		},
+		PublicHostServices: registry,
+		Runtime:            newCapturingRuntime(),
+	}
+}
+
+func TestRegisterConfiguredAppPublicHostServicesRegistersBeforeActivation(t *testing.T) {
+	t.Parallel()
+
+	registry := runtimehost.NewPublicHostServiceRegistry()
+	deps := eagerHostServiceTestDeps(registry)
+	cfg := &config.Config{
+		Apps: map[string]*config.ProviderEntry{
+			"gIssues": {
+				Runtime:   &config.RuntimePlacementConfig{},
+				IndexedDB: &config.IndexedDBBindingConfig{Provider: "main"},
+			},
+		},
+	}
+
+	cleanup := registerConfiguredAppPublicHostServices(context.Background(), cfg, deps)
+
+	assertPublicHostServicesVerified(t, registry, "indexeddb")
+	found := false
+	for _, service := range registry.Snapshot() {
+		if service.AppName == "gIssues" && service.Service.Name == "indexeddb" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("registry = %#v, want indexeddb host service for gIssues before activation", registry.Snapshot())
+	}
+
+	cleanup()
+	if services := registry.Snapshot(); len(services) != 0 {
+		t.Fatalf("after cleanup registry = %#v, want none", services)
+	}
+}
+
+func TestRegisterConfiguredAppPublicHostServicesSkipsNonRuntimeApps(t *testing.T) {
+	t.Parallel()
+
+	registry := runtimehost.NewPublicHostServiceRegistry()
+	deps := eagerHostServiceTestDeps(registry)
+	cfg := &config.Config{
+		Apps: map[string]*config.ProviderEntry{
+			"localApp": {
+				IndexedDB: &config.IndexedDBBindingConfig{Provider: "main"},
+			},
+		},
+	}
+
+	registerConfiguredAppPublicHostServices(context.Background(), cfg, deps)
+
+	if services := registry.Snapshot(); len(services) != 0 {
+		t.Fatalf("registry = %#v, want no eager registration for a non-runtime-placed app", services)
+	}
+}
+
+func TestRegisterConfiguredAppPublicHostServicesNoopWithoutRelay(t *testing.T) {
+	t.Parallel()
+
+	registry := runtimehost.NewPublicHostServiceRegistry()
+	deps := eagerHostServiceTestDeps(registry)
+	deps.EncryptionKey = nil
+	cfg := &config.Config{
+		Apps: map[string]*config.ProviderEntry{
+			"gIssues": {
+				Runtime:   &config.RuntimePlacementConfig{},
+				IndexedDB: &config.IndexedDBBindingConfig{Provider: "main"},
+			},
+		},
+	}
+
+	registerConfiguredAppPublicHostServices(context.Background(), cfg, deps)
+
+	if services := registry.Snapshot(); len(services) != 0 {
+		t.Fatalf("registry = %#v, want no registration when the public relay is unavailable", services)
+	}
+}


### PR DESCRIPTION
## Description

Registers every runtime-placed app's public host services from static config at **startup on each replica**, decoupled from lazy per-app activation.

**Why:** apps relay host-service calls (indexeddb → their DB provider, etc.) back to gestaltd through the shared public URL, which the load balancer spreads across replicas (prod runs minScale=5). Public host services were only registered on a replica once *that* replica had activated the app. So a host-service call made **during** an app's first activation — notably a declared migration running in `Configure` — was load-balanced to a replica that hadn't activated the app, whose process-local registry had no entry, and failed with `[unavailable] host-service-relay-unavailable`, aborting activation. (Operations avoided this because by steady state every replica had warmed up.)

Registering every app's host services up front on each replica makes a relayed callback resolve on any replica, so migrations can run in `Configure` on the first request.

**Cross-replica session verification holds:** the host service still verifies the relay token's runtime session via `runtimeProvider.GetSession`. Prod's `gkeAgentSandbox` runtime resolves sessions from shared GKE cluster state (`SandboxClaims`/`Sandboxes` by name), so a replica can validate a session another replica created.

**Safety:**
- Registration is **additive** — coexists with the existing activation-time registration in `buildAppProvider`; handler selection tries all verifiers, so duplicates are harmless.
- **Best-effort** — per-app resolve/build/register failures are logged and skipped, never blocking startup.
- Gated on `UsesRuntimePlacement()` + `hostCanRelayRuntimeHostServices` (baseURL + encryptionKey), so it's a no-op in dev/local and for non-relayed apps.
- Cleanup wired into `Result.Close`.

Tests: new `host_service_bootstrap_test.go` (registers before activation; skips non-runtime apps; no-op without relay); full bootstrap + server suites pass.

Note: the underlying failure was a multi-replica routing issue not reproducible in a single-process test — real verification is the staged deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)