### PR TITLE
[gestaltd] Eager-register host services for all non-dev apps

### DIFF
--- a/gestaltd/internal/bootstrap/host_service_bootstrap.go
+++ b/gestaltd/internal/bootstrap/host_service_bootstrap.go
@@ -258,7 +258,7 @@ func registerConfiguredAppPublicHostServices(ctx context.Context, cfg *config.Co
 	var cleanups []func()
 	for _, name := range slices.Sorted(maps.Keys(cfg.Apps)) {
 		entry := cfg.Apps[name]
-		if !entry.UsesRuntimePlacement() {
+		if entry != nil && entry.DevActive && deps.DevSupervisor != nil {
 			continue
 		}
 		_, runtimeProvider, _, err := effectiveRuntime(ctx, name, entry, deps)

--- a/gestaltd/internal/bootstrap/host_service_bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/host_service_bootstrap_test.go
@@ -23,7 +23,16 @@ func eagerHostServiceTestDeps(registry *runtimehost.PublicHostServiceRegistry) D
 	}
 }
 
-func TestRegisterConfiguredAppPublicHostServicesRegistersBeforeActivation(t *testing.T) {
+func appIndexedDBRegistered(registry *runtimehost.PublicHostServiceRegistry, appName string) bool {
+	for _, service := range registry.Snapshot() {
+		if service.AppName == appName && service.Service.Name == "indexeddb" {
+			return true
+		}
+	}
+	return false
+}
+
+func TestRegisterConfiguredAppPublicHostServicesRegistersDefaultRuntimeApp(t *testing.T) {
 	t.Parallel()
 
 	registry := runtimehost.NewPublicHostServiceRegistry()
@@ -31,7 +40,6 @@ func TestRegisterConfiguredAppPublicHostServicesRegistersBeforeActivation(t *tes
 	cfg := &config.Config{
 		Apps: map[string]*config.ProviderEntry{
 			"gIssues": {
-				Runtime:   &config.RuntimePlacementConfig{},
 				IndexedDB: &config.IndexedDBBindingConfig{Provider: "main"},
 			},
 		},
@@ -40,13 +48,7 @@ func TestRegisterConfiguredAppPublicHostServicesRegistersBeforeActivation(t *tes
 	cleanup := registerConfiguredAppPublicHostServices(context.Background(), cfg, deps)
 
 	assertPublicHostServicesVerified(t, registry, "indexeddb")
-	found := false
-	for _, service := range registry.Snapshot() {
-		if service.AppName == "gIssues" && service.Service.Name == "indexeddb" {
-			found = true
-		}
-	}
-	if !found {
+	if !appIndexedDBRegistered(registry, "gIssues") {
 		t.Fatalf("registry = %#v, want indexeddb host service for gIssues before activation", registry.Snapshot())
 	}
 
@@ -56,14 +58,15 @@ func TestRegisterConfiguredAppPublicHostServicesRegistersBeforeActivation(t *tes
 	}
 }
 
-func TestRegisterConfiguredAppPublicHostServicesSkipsNonRuntimeApps(t *testing.T) {
+func TestRegisterConfiguredAppPublicHostServicesRegistersDevActiveWithoutSupervisor(t *testing.T) {
 	t.Parallel()
 
 	registry := runtimehost.NewPublicHostServiceRegistry()
 	deps := eagerHostServiceTestDeps(registry)
 	cfg := &config.Config{
 		Apps: map[string]*config.ProviderEntry{
-			"localApp": {
+			"gIssues": {
+				DevActive: true,
 				IndexedDB: &config.IndexedDBBindingConfig{Provider: "main"},
 			},
 		},
@@ -71,8 +74,8 @@ func TestRegisterConfiguredAppPublicHostServicesSkipsNonRuntimeApps(t *testing.T
 
 	registerConfiguredAppPublicHostServices(context.Background(), cfg, deps)
 
-	if services := registry.Snapshot(); len(services) != 0 {
-		t.Fatalf("registry = %#v, want no eager registration for a non-runtime-placed app", services)
+	if !appIndexedDBRegistered(registry, "gIssues") {
+		t.Fatalf("registry = %#v, want indexeddb host service registered without a DevSupervisor", registry.Snapshot())
 	}
 }
 
@@ -85,7 +88,6 @@ func TestRegisterConfiguredAppPublicHostServicesNoopWithoutRelay(t *testing.T) {
 	cfg := &config.Config{
 		Apps: map[string]*config.ProviderEntry{
 			"gIssues": {
-				Runtime:   &config.RuntimePlacementConfig{},
 				IndexedDB: &config.IndexedDBBindingConfig{Provider: "main"},
 			},
 		},


### PR DESCRIPTION
## Description

Follow-up fix to #2639. The eager registration gated on `entry.UsesRuntimePlacement()` (i.e. an explicit `runtime:` block), but `gkeAgentSandbox` is configured `default: true`, so apps **without** a `runtime:` block — like **g-issues** — still run on it, still relay host-service calls through the public URL, and so were skipped by the eager loop. They kept failing with `host-service-relay-unavailable` during `Configure`.

Gate exactly like `buildAppProvider` (provider_build.go:964): register every configured app **except** dev-supervised ones (which use local sockets, not the public relay). Non-`runtime:`-block apps that run on the default runtime are now covered.

Tests updated: registers a default-runtime (no `runtime:` block) app; registers a dev-active app when no `DevSupervisor` is present; no-op without the relay. Full bootstrap + server suites pass.

Requires a `GESTALTD_PINNED_SHA` bump to this merge commit to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)