### PR TITLE
[gestaltd] Trust the relay token for host services; drop session verification

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1244,7 +1244,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		SessionStart:      agentSessionStartConfigs(cfg),
 	}))
 	pluginInvoker.SetTarget(invocation.NewGuarded(sharedInvoker, nil, "app", audit, invocation.WithoutRateLimit()))
-	appHostServiceCleanup := registerConfiguredAppPublicHostServices(ctx, cfg, prepared.Deps)
+	appHostServiceCleanup := registerConfiguredAppPublicHostServices(cfg, prepared.Deps)
 	// Build workflow/agent providers before app providers: they establish their
 	// backend connection during build, which must not race concurrent app startup.
 	extraWorkflows, extraAgents, err := buildWorkflowsAndAgents(ctx, cfg, factories, prepared.Deps)

--- a/gestaltd/internal/bootstrap/executable_app_test.go
+++ b/gestaltd/internal/bootstrap/executable_app_test.go
@@ -5755,13 +5755,12 @@ func TestRuntimePublicIndexedDBRelayRoundTripsThroughHostedApp(t *testing.T) {
 	runtimeProvider.setSessionLifecycle(startRequests[0].GetSessionId(), &proto.RuntimeSessionLifecycle{
 		ExpiresAt: timestamppb.New(expiredAt),
 	})
-	_, err = prov.Execute(context.Background(), "indexeddb_roundtrip", map[string]any{
+	if _, err = prov.Execute(context.Background(), "indexeddb_roundtrip", map[string]any{
 		"store": "tasks",
 		"id":    "task-2",
 		"value": "expired-session",
-	}, "")
-	if err == nil || !strings.Contains(err.Error(), "invalid-host-service-relay-session") {
-		t.Fatalf("Execute indexeddb_roundtrip after runtime expiry error = %v, want relay session rejection", err)
+	}, ""); err != nil {
+		t.Fatalf("Execute indexeddb_roundtrip after runtime expiry error = %v, want success (host-service access is authorized by the signed relay token, not the runtime session)", err)
 	}
 }
 

--- a/gestaltd/internal/bootstrap/host_service_bootstrap.go
+++ b/gestaltd/internal/bootstrap/host_service_bootstrap.go
@@ -23,7 +23,6 @@ import (
 	identityservice "github.com/valon-technologies/gestalt/server/services/identity"
 	indexeddbservice "github.com/valon-technologies/gestalt/server/services/indexeddb"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
-	"github.com/valon-technologies/gestalt/server/services/runtimehost/runtimeprovider"
 	"github.com/valon-technologies/gestalt/server/services/s3"
 	workflowservice "github.com/valon-technologies/gestalt/server/services/workflows"
 	"google.golang.org/grpc"
@@ -205,53 +204,21 @@ func applyHostedRuntimeHostServiceRelayEnv(providerName, sessionID string, hostS
 	return env, allowedHosts, nil
 }
 
-type runtimeHostServiceSessionVerifier struct {
-	providerName string
-	provider     runtimeprovider.Provider
+type runtimeHostServiceSessionVerifier struct{}
+
+func (runtimeHostServiceSessionVerifier) VerifyHostServiceSession(context.Context, string) error {
+	// The signed relay token already scopes the call by provider, service, and
+	// method. Runtime sessions are process-local to the replica that started the
+	// app, so re-checking them here cannot work once a callback is load-balanced
+	// to another replica; trust the token instead.
+	return nil
 }
 
-func (v runtimeHostServiceSessionVerifier) VerifyHostServiceSession(ctx context.Context, sessionID string) error {
-	sessionID = strings.TrimSpace(sessionID)
-	if sessionID == "" {
-		return fmt.Errorf("runtime session id is required")
-	}
-	if v.provider == nil {
-		return fmt.Errorf("runtime provider is not configured")
-	}
-	session, err := v.provider.GetSession(ctx, &proto.GetRuntimeSessionRequest{SessionId: sessionID})
-	if err != nil {
-		return err
-	}
-	if session == nil {
-		return fmt.Errorf("runtime session %q was not found", sessionID)
-	}
-	if expected := strings.TrimSpace(v.providerName); expected != "" {
-		if got := strings.TrimSpace(session.GetMetadata()["provider_name"]); got != "" && got != expected {
-			return fmt.Errorf("runtime session %q belongs to provider %q", sessionID, got)
-		}
-	}
-	if session.GetLifecycle().GetExpiresAt() != nil {
-		expiresAt := session.GetLifecycle().GetExpiresAt().AsTime().UTC()
-		if !time.Now().UTC().Before(expiresAt) {
-			return fmt.Errorf("runtime session %q expired at %s", sessionID, expiresAt.Format(time.RFC3339Nano))
-		}
-	}
-	switch session.GetState() {
-	case runtimeprovider.SessionStatePending, runtimeprovider.SessionStateReady, runtimeprovider.SessionStateRunning:
-		return nil
-	default:
-		return fmt.Errorf("runtime session %q is %s", sessionID, session.GetState())
-	}
+func registerPublicRuntimeHostServices(providerName string, hostServices []runtimehost.HostService, deps Deps) (func(), error) {
+	return registerVerifiedPublicHostServices(providerName, hostServices, deps, runtimeHostServiceSessionVerifier{}, false)
 }
 
-func registerPublicRuntimeHostServices(providerName string, hostServices []runtimehost.HostService, deps Deps, runtimeProvider runtimeprovider.Provider) (func(), error) {
-	return registerVerifiedPublicHostServices(providerName, hostServices, deps, runtimeHostServiceSessionVerifier{
-		providerName: providerName,
-		provider:     runtimeProvider,
-	}, false)
-}
-
-func registerConfiguredAppPublicHostServices(ctx context.Context, cfg *config.Config, deps Deps) func() {
+func registerConfiguredAppPublicHostServices(cfg *config.Config, deps Deps) func() {
 	if cfg == nil || !hostCanRelayRuntimeHostServices(deps) {
 		return func() {}
 	}
@@ -259,11 +226,6 @@ func registerConfiguredAppPublicHostServices(ctx context.Context, cfg *config.Co
 	for _, name := range slices.Sorted(maps.Keys(cfg.Apps)) {
 		entry := cfg.Apps[name]
 		if entry != nil && entry.DevActive && deps.DevSupervisor != nil {
-			continue
-		}
-		_, runtimeProvider, _, err := effectiveRuntime(ctx, name, entry, deps)
-		if err != nil {
-			slog.Warn("eager public host service registration skipped", "provider", name, "error", err)
 			continue
 		}
 		hostServices, err := buildProviderHostServices(name, appProviderHostServiceDeps(entry, deps))
@@ -274,7 +236,7 @@ func registerConfiguredAppPublicHostServices(ctx context.Context, cfg *config.Co
 		if len(hostServices) == 0 {
 			continue
 		}
-		cleanup, err := registerPublicRuntimeHostServices(name, hostServices, deps, runtimeProvider)
+		cleanup, err := registerPublicRuntimeHostServices(name, hostServices, deps)
 		if err != nil {
 			slog.Warn("eager public host service registration failed", "provider", name, "error", err)
 			continue

--- a/gestaltd/internal/bootstrap/host_service_bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/host_service_bootstrap_test.go
@@ -1,7 +1,6 @@
 package bootstrap
 
 import (
-	"context"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
@@ -45,7 +44,7 @@ func TestRegisterConfiguredAppPublicHostServicesRegistersDefaultRuntimeApp(t *te
 		},
 	}
 
-	cleanup := registerConfiguredAppPublicHostServices(context.Background(), cfg, deps)
+	cleanup := registerConfiguredAppPublicHostServices(cfg, deps)
 
 	assertPublicHostServicesVerified(t, registry, "indexeddb")
 	if !appIndexedDBRegistered(registry, "gIssues") {
@@ -72,7 +71,7 @@ func TestRegisterConfiguredAppPublicHostServicesRegistersDevActiveWithoutSupervi
 		},
 	}
 
-	registerConfiguredAppPublicHostServices(context.Background(), cfg, deps)
+	registerConfiguredAppPublicHostServices(cfg, deps)
 
 	if !appIndexedDBRegistered(registry, "gIssues") {
 		t.Fatalf("registry = %#v, want indexeddb host service registered without a DevSupervisor", registry.Snapshot())
@@ -93,7 +92,7 @@ func TestRegisterConfiguredAppPublicHostServicesNoopWithoutRelay(t *testing.T) {
 		},
 	}
 
-	registerConfiguredAppPublicHostServices(context.Background(), cfg, deps)
+	registerConfiguredAppPublicHostServices(cfg, deps)
 
 	if services := registry.Snapshot(); len(services) != 0 {
 		t.Fatalf("registry = %#v, want no registration when the public relay is unavailable", services)

--- a/gestaltd/internal/bootstrap/hosted_workflow_provider.go
+++ b/gestaltd/internal/bootstrap/hosted_workflow_provider.go
@@ -48,7 +48,7 @@ func buildHostedWorkflowWorkerPool(ctx context.Context, name string, entry *conf
 	if err != nil {
 		return nil, err
 	}
-	publicHostServicesCleanup, err := registerPublicRuntimeHostServices(name, hostServices, deps, launch.runtimeProvider)
+	publicHostServicesCleanup, err := registerPublicRuntimeHostServices(name, hostServices, deps)
 	if err != nil {
 		launch.close()
 		return nil, err

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -1058,7 +1058,7 @@ func buildAppProvider(ctx context.Context, name string, entry *config.ProviderEn
 	if err != nil {
 		return nil, err
 	}
-	publicHostServicesCleanup, err := registerPublicRuntimeHostServices(name, hostServices, deps, runtimeProvider)
+	publicHostServicesCleanup, err := registerPublicRuntimeHostServices(name, hostServices, deps)
 	if err != nil {
 		return nil, err
 	}
@@ -1228,7 +1228,7 @@ func buildHostedAgentProvider(ctx context.Context, name string, entry *config.Pr
 		launch.close()
 		return nil, fmt.Errorf("parse hosted agent runtime lifecycle policy: %w", err)
 	}
-	publicHostServicesCleanup, err := registerPublicRuntimeHostServices(name, hostServices, deps, launch.runtimeProvider)
+	publicHostServicesCleanup, err := registerPublicRuntimeHostServices(name, hostServices, deps)
 	if err != nil {
 		launch.close()
 		return nil, err


### PR DESCRIPTION
## Description

Completes the cross-replica host-service fix. After eager registration (#2639/#2640) put the host-service entry on every replica, callbacks got past `host-service-relay-unavailable` but then failed with `invalid-host-service-relay-session`: the verifier calls `runtimeProvider.GetSession`, and for the **local runtime** (which every `apps:` entry uses — none declare a `runtime:` block, and the `default: true` runtime only applies to apps that *have* a runtime block) sessions are **in-memory and process-local**. A callback load-balanced to a different replica can never validate a session another replica minted.

The relay token is already a **signed, provider/service/method-scoped, TTL'd** credential validated by the relay middleware before the verifier runs — it authenticates the call on its own. This is the same reasoning `workflowProviderHostServiceSessionVerifier` already uses. So:

- Make `runtimeHostServiceSessionVerifier` a no-op that trusts the token.
- Drop the now-unused runtime-provider handle from `registerPublicRuntimeHostServices` and its callers, which also lets the eager registration path stop resolving the runtime at boot.

Together with eager registration, a cold replica now resolves the token, finds the entry, trusts the token, and serves the call against the shared backend — cross-replica, migrations in `Configure` included.

**Tradeoff (intentional):** host-service access is no longer gated on runtime-session liveness — a valid token authorizes the app's own host services until it expires. Token TTL is left at its current value. Scope is limited to the app's own host services.

Tests: updated the relay round-trip test (an expired runtime session no longer blocks the call); full bootstrap + server + runtimehost suites pass.

Requires a `GESTALTD_PINNED_SHA` bump to this merge commit to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)