### PR TITLE
Revert "[sdk] Drop the AcquireLock lease from the migration runner"

### DIFF
--- a/sdk/typescript/src/providers/migrations.ts
+++ b/sdk/typescript/src/providers/migrations.ts
@@ -12,6 +12,10 @@ import {
 const DEFAULT_LEDGER_STORE = "_gestalt_migrations";
 const LEDGER_KEY_COLUMN = "revision_id";
 const LEDGER_APPLIED_COLUMN = "applied_at";
+const DEFAULT_LOCK_KEY = "_gestalt_migrations";
+const DEFAULT_LOCK_TTL_MS = 30_000;
+const DEFAULT_ACQUIRE_TIMEOUT_MS = 10 * 60_000;
+const LOCK_POLL_INTERVAL_MS = 500;
 
 export type Query = Key | KeyRange;
 
@@ -85,6 +89,14 @@ export interface MigrationRunOptions {
   dbBinding?: string;
   /** Ledger store name. Defaults to `_gestalt_migrations`. */
   ledgerStore?: string;
+  /** Advisory-lock key. Defaults to `_gestalt_migrations`. */
+  lockKey?: string;
+  /** Lease TTL in milliseconds. Defaults to 30s (renewed while running). */
+  lockTtlMs?: number;
+  /** Max time to wait to acquire the lease. Defaults to 10 minutes. */
+  acquireTimeoutMs?: number;
+  /** Stable identifier for this instance. Defaults to a random id. */
+  holder?: string;
 }
 
 /**
@@ -123,11 +135,13 @@ export class MigrationError extends Error {
 }
 
 /**
- * Brings the database up to head. Concurrent instances may run this at once;
- * that is safe because every revision is idempotent by construction, so
- * concurrent runs converge to the same state and the ledger records each
- * revision once. Idempotent — a no-op when nothing is pending. Returns the
- * revision ids applied this run and the declared head.
+ * Brings the database up to head, acquiring the migration lease first so only
+ * one instance migrates at a time. If the backend does not support the lease
+ * (or acquiring it errors), it degrades to running lockless — idempotency is
+ * the correctness guarantee, the lease only prevents redundant concurrent work.
+ * Idempotent — a no-op when nothing is pending. Releases the lease and never
+ * leaves it held on error. Returns the revision ids applied this run and the
+ * declared head.
  */
 export async function runMigrations(
   db: IndexedDB,
@@ -139,35 +153,58 @@ export async function runMigrations(
   }
 
   const ledgerStore = options.ledgerStore?.trim() || DEFAULT_LEDGER_STORE;
+  const lockKey = options.lockKey?.trim() || DEFAULT_LOCK_KEY;
+  const ttlMs = options.lockTtlMs ?? DEFAULT_LOCK_TTL_MS;
+  const acquireTimeoutMs = options.acquireTimeoutMs ?? DEFAULT_ACQUIRE_TIMEOUT_MS;
+  const holder = options.holder?.trim() || randomHolderId();
+
   await ensureLedgerStore(db, ledgerStore);
+  const held = await acquireLease(db, lockKey, holder, ttlMs, acquireTimeoutMs);
 
-  const applied = new Set(await db.objectStore(ledgerStore).getAllKeys());
-  assertNotAheadOfCode(revisions, applied);
-  assertContiguousPrefix(revisions, applied);
+  const renew = held
+    ? startLeaseRenewal(db, lockKey, holder, ttlMs)
+    : { stop: () => {}, lost: () => false };
+  try {
+    const applied = new Set(await db.objectStore(ledgerStore).getAllKeys());
+    assertNotAheadOfCode(revisions, applied);
+    assertContiguousPrefix(revisions, applied);
 
-  const attemptedHead = revisions[revisions.length - 1]?.id ?? "";
-  let current = latestAppliedId(revisions, applied);
-  const appliedNow: string[] = [];
-  for (const revision of revisions) {
-    if (applied.has(revision.id)) {
-      continue;
-    }
-    try {
-      await applyRevision(db, revision);
-      await recordRevision(db, ledgerStore, revision.id);
-      appliedNow.push(revision.id);
-      current = revision.id;
-    } catch (error) {
-      if (error instanceof MigrationError) {
-        throw error;
+    const attemptedHead = revisions[revisions.length - 1]?.id ?? "";
+    let current = latestAppliedId(revisions, applied);
+    const appliedNow: string[] = [];
+    for (const revision of revisions) {
+      if (applied.has(revision.id)) {
+        continue;
       }
-      throw new MigrationError(
-        `migration ${JSON.stringify(revision.id)} failed: ${errorText(error)}`,
-        { current, attempted: attemptedHead, cause: error },
-      );
+      const assertHeld = (): void => {
+        if (renew.lost()) {
+          throw leaseLostError(revision.id, current, attemptedHead);
+        }
+      };
+      assertHeld();
+      try {
+        await applyRevision(db, revision, assertHeld);
+        assertHeld();
+        await recordRevision(db, ledgerStore, revision.id);
+        appliedNow.push(revision.id);
+        current = revision.id;
+      } catch (error) {
+        if (error instanceof MigrationError) {
+          throw error;
+        }
+        throw new MigrationError(
+          `migration ${JSON.stringify(revision.id)} failed: ${errorText(error)}`,
+          { current, attempted: attemptedHead, cause: error },
+        );
+      }
+    }
+    return { applied: appliedNow, head: attemptedHead };
+  } finally {
+    renew.stop();
+    if (held) {
+      await releaseQuietly(db, lockKey, holder);
     }
   }
-  return { applied: appliedNow, head: attemptedHead };
 }
 
 function validateRevisions(revisions: Revision[]): Revision[] {
@@ -258,6 +295,18 @@ function latestAppliedId(
   return current;
 }
 
+function leaseLostError(
+  revisionId: string,
+  current: string | undefined,
+  attemptedHead: string,
+): MigrationError {
+  return new MigrationError(
+    `lost the migration lease while migrating ${JSON.stringify(revisionId)}; ` +
+      `another instance may hold it — aborting to avoid concurrent migration`,
+    { current, attempted: attemptedHead },
+  );
+}
+
 async function ensureLedgerStore(
   db: IndexedDB,
   ledgerStore: string,
@@ -271,17 +320,22 @@ async function ensureLedgerStore(
   });
 }
 
-async function applyRevision(db: IndexedDB, revision: Revision): Promise<void> {
+async function applyRevision(
+  db: IndexedDB,
+  revision: Revision,
+  assertHeld: () => void,
+): Promise<void> {
   if (isSchemaRevision(revision)) {
-    await applySchema(db, revision.schema);
+    await applySchema(db, revision.schema, assertHeld);
     return;
   }
-  await applyBackfill(db, revision.backfill);
+  await applyBackfill(db, revision.backfill, assertHeld);
 }
 
 async function applyBackfill(
   db: IndexedDB,
   transform: BackfillTransform,
+  assertHeld: () => void,
 ): Promise<void> {
   const target = db.objectStore(transform.into);
   const cursor = await db.objectStore(transform.from).openCursor();
@@ -290,6 +344,7 @@ async function applyBackfill(
   }
   try {
     while (await cursor.continue()) {
+      assertHeld();
       const row = cursor.value;
       if (row === undefined) {
         continue;
@@ -304,17 +359,22 @@ async function applyBackfill(
 async function applySchema(
   db: IndexedDB,
   schema: SchemaDeclaration,
+  assertHeld: () => void,
 ): Promise<void> {
   for (const store of schema.stores ?? []) {
+    assertHeld();
     await createStoreIfAbsent(db, store);
   }
   for (const entry of schema.addIndexes ?? []) {
+    assertHeld();
     await createIndexIfAbsent(db, entry.store, entry.index);
   }
   for (const entry of schema.dropIndexes ?? []) {
+    assertHeld();
     await dropIndexIfPresent(db, entry.store, entry.name);
   }
   for (const name of schema.dropStores ?? []) {
+    assertHeld();
     await dropStoreIfPresent(db, name);
   }
 }
@@ -384,8 +444,81 @@ async function recordRevision(
   });
 }
 
+async function acquireLease(
+  db: IndexedDB,
+  key: string,
+  holder: string,
+  ttlMs: number,
+  timeoutMs: number,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const lease = await db.acquireLock(key, holder, ttlMs).catch(() => null);
+    if (lease === null) {
+      return false;
+    }
+    if (lease.acquired) {
+      return true;
+    }
+    if (Date.now() >= deadline) {
+      throw new MigrationError(
+        `timed out after ${timeoutMs}ms waiting for the migration lease ` +
+          `(held by ${JSON.stringify(lease.holder)})`,
+      );
+    }
+    await sleep(LOCK_POLL_INTERVAL_MS);
+  }
+}
+
+function startLeaseRenewal(
+  db: IndexedDB,
+  key: string,
+  holder: string,
+  ttlMs: number,
+): { stop: () => void; lost: () => boolean } {
+  const interval = Math.max(1, Math.min(Math.floor(ttlMs / 2), ttlMs - 1));
+  let lost = false;
+  const timer = setInterval(() => {
+    void db.acquireLock(key, holder, ttlMs).then(
+      (lease) => {
+        if (!lease.acquired) {
+          lost = true;
+        }
+      },
+      () => {},
+    );
+  }, interval);
+  if (typeof timer === "object" && "unref" in timer) {
+    (timer as { unref: () => void }).unref();
+  }
+  return {
+    stop: () => clearInterval(timer),
+    lost: () => lost,
+  };
+}
+
+async function releaseQuietly(
+  db: IndexedDB,
+  key: string,
+  holder: string,
+): Promise<void> {
+  try {
+    await db.releaseLock(key, holder);
+  } catch {
+    return;
+  }
+}
+
 function isSchemaRevision(revision: Revision): revision is SchemaRevision {
   return "schema" in revision && revision.schema != null;
+}
+
+function randomHolderId(): string {
+  const uuid = globalThis.crypto?.randomUUID?.();
+  if (uuid) {
+    return uuid;
+  }
+  return `holder-${Math.random().toString(36).slice(2)}-${Date.now()}`;
 }
 
 function errorText(error: unknown): string {
@@ -393,4 +526,8 @@ function errorText(error: unknown): string {
     return error.message;
   }
   return String(error);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/sdk/typescript/tests/migrations.test.ts
+++ b/sdk/typescript/tests/migrations.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   AlreadyExistsError,
+  type AcquireLockResult,
   type IndexedDB,
   MigrationError,
   NotFoundError,
@@ -20,7 +21,10 @@ class FakeIndexedDB {
   readonly stores = new Map<string, FakeStoreState>();
   readonly indexes = new Set<string>();
   readonly calls: string[] = [];
+  lock: { holder: string; expiresAt: number } | null = null;
   createObjectStoreError: Error | null = null;
+  acquireLockError: Error | null = null;
+  putHook: (() => Promise<void> | void) | null = null;
 
   async createObjectStore(
     name: string,
@@ -96,6 +100,9 @@ class FakeIndexedDB {
       },
       async put(record: DBRecord): Promise<void> {
         const s = state();
+        if (db.putHook) {
+          await db.putHook();
+        }
         s.rows.set(String(record[s.pk]), record);
       },
       async delete(id: string): Promise<void> {
@@ -124,6 +131,9 @@ class FakeIndexedDB {
             return true;
           },
           update: async (record: DBRecord): Promise<void> => {
+            if (db.putHook) {
+              await db.putHook();
+            }
             s.rows.set(String(record[s.pk]), record);
           },
           close: (): void => {},
@@ -131,6 +141,40 @@ class FakeIndexedDB {
         return cursor;
       },
     };
+  }
+
+  async acquireLock(
+    _key: string,
+    holder: string,
+    ttlMs: number,
+  ): Promise<AcquireLockResult> {
+    this.calls.push(`acquireLock:${holder}`);
+    if (this.acquireLockError) {
+      throw this.acquireLockError;
+    }
+    const now = Date.now();
+    if (this.lock && this.lock.holder !== holder && this.lock.expiresAt > now) {
+      return {
+        acquired: false,
+        holder: this.lock.holder,
+        expiresAt: new Date(this.lock.expiresAt),
+        fencingToken: 0n,
+      };
+    }
+    this.lock = { holder, expiresAt: now + ttlMs };
+    return {
+      acquired: true,
+      holder,
+      expiresAt: new Date(this.lock.expiresAt),
+      fencingToken: 1n,
+    };
+  }
+
+  async releaseLock(_key: string, holder: string): Promise<void> {
+    this.calls.push(`releaseLock:${holder}`);
+    if (this.lock?.holder === holder) {
+      this.lock = null;
+    }
   }
 
   close(): void {}
@@ -167,6 +211,9 @@ describe("runMigrations", () => {
 
     expect(fake.stores.has("issues")).toBe(true);
     expect(await ledgerIds(fake)).toEqual(["0001_issues"]);
+    expect(fake.calls.some((c) => c.startsWith("acquireLock:"))).toBe(true);
+    expect(fake.calls.some((c) => c.startsWith("releaseLock:"))).toBe(true);
+    expect(fake.lock).toBeNull();
   });
 
   test("returns the applied ids and declared head", async () => {
@@ -276,6 +323,7 @@ describe("runMigrations", () => {
     ).rejects.toThrow(MigrationError);
 
     expect(await ledgerIds(fake)).toEqual(["0001_issues"]);
+    expect(fake.lock).toBeNull();
   });
 
   test("failure after an earlier revision reports the applied one as current", async () => {
@@ -300,42 +348,97 @@ describe("runMigrations", () => {
     expect((error as MigrationError).attempted).toBe("0002_boom");
   });
 
-  test("concurrent runners converge without a lock", async () => {
+  test("lease lost during a revision aborts before recording it", async () => {
     const { db, fake } = fakeDb();
+    const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
     const seed: Revision = {
       id: "0001_seed",
-      schema: { stores: [{ name: "issues", columns: [{ name: "id", primaryKey: true }] }] },
-    };
-    await runMigrations(db, { revisions: [seed] });
-    await db.objectStore("issues").put({ id: "a" });
-    await db.objectStore("issues").put({ id: "b", status: "closed" });
-
-    const backfill: Revision = {
-      id: "0002_index",
-      backfill: {
-        from: "issues",
-        into: "issue_index",
-        value: (row) => ({ id: row.id, text: `issue-${String(row.id)}` }),
+      schema: {
+        stores: [
+          { name: "src", columns: [{ name: "id", primaryKey: true }] },
+          { name: "dst", columns: [{ name: "id", primaryKey: true }] },
+        ],
       },
     };
-    const full: Revision[] = [
-      seed,
-      { id: "0001_5_index", schema: { stores: [{ name: "issue_index", columns: [{ name: "id", primaryKey: true }] }] } },
-      backfill,
-    ];
 
-    await Promise.all([
-      runMigrations(db, { revisions: full }),
-      runMigrations(db, { revisions: full }),
-    ]);
+    await runMigrations(db, { revisions: [seed] });
+    await db.objectStore("src").put({ id: "a" });
 
-    expect(await ledgerIds(fake)).toEqual(["0001_seed", "0001_5_index", "0002_index"]);
-    expect((await db.objectStore("issue_index").get("a")).text).toBe("issue-a");
-    expect((await db.objectStore("issue_index").get("b")).text).toBe("issue-b");
+    fake.putHook = async () => {
+      fake.lock = { holder: "other", expiresAt: Date.now() + 60_000 };
+      await sleep(1_400);
+    };
+    const backfill: Revision = {
+      id: "0002_backfill",
+      backfill: {
+        from: "src",
+        into: "dst",
+        value: (row) => ({ ...row }),
+      },
+    };
+
+    await expect(
+      runMigrations(db, { revisions: [seed, backfill], lockTtlMs: 2_000 }),
+    ).rejects.toThrow(/lost the migration lease/);
+    expect(await ledgerIds(fake)).toEqual(["0001_seed"]);
+  });
+
+  test("a backfill write is refused once the lease is lost mid-revision", async () => {
+    const { db, fake } = fakeDb();
+    const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+    const seed: Revision = {
+      id: "0001_seed",
+      schema: {
+        stores: [
+          { name: "src", columns: [{ name: "id", primaryKey: true }] },
+          { name: "dst", columns: [{ name: "id", primaryKey: true }] },
+        ],
+      },
+    };
+
+    await runMigrations(db, { revisions: [seed] });
+    await db.objectStore("src").put({ id: "a" });
+    await db.objectStore("src").put({ id: "b" });
+
+    let puts = 0;
+    fake.putHook = async () => {
+      puts += 1;
+      if (puts === 1) {
+        fake.lock = { holder: "other", expiresAt: Date.now() + 60_000 };
+        await sleep(1_400);
+      }
+    };
+    const backfill: Revision = {
+      id: "0002_backfill",
+      backfill: {
+        from: "src",
+        into: "dst",
+        value: (row) => ({ ...row }),
+      },
+    };
+
+    await expect(
+      runMigrations(db, { revisions: [seed, backfill], lockTtlMs: 2_000 }),
+    ).rejects.toThrow(/lost the migration lease/);
+    expect(await ledgerIds(fake)).toEqual(["0001_seed"]);
+    expect(fake.stores.get("dst")?.rows.has("b")).toBe(false);
+  });
+
+  test("runs lockless when acquireLock is Unimplemented", async () => {
+    const { db, fake } = fakeDb();
+    fake.acquireLockError = Object.assign(new Error("advisory locks not supported"), {
+      code: 12,
+    });
+
+    await runMigrations(db, { revisions: [issuesRevision] });
+
+    expect(fake.stores.has("issues")).toBe(true);
+    expect(await ledgerIds(fake)).toEqual(["0001_issues"]);
+    expect(fake.calls.some((c) => c.startsWith("releaseLock:"))).toBe(false);
   });
 
   test("fails closed when the ledger is ahead of the code", async () => {
-    const { db } = fakeDb();
+    const { db, fake } = fakeDb();
     await runMigrations(db, { revisions: [issuesRevision] });
 
     await db.objectStore("_gestalt_migrations").put({
@@ -346,6 +449,7 @@ describe("runMigrations", () => {
     await expect(
       runMigrations(db, { revisions: [issuesRevision] }),
     ).rejects.toThrow(/ledger is ahead/);
+    expect(fake.lock).toBeNull();
   });
 
   test("fails closed when a revision is inserted before an applied one", async () => {
@@ -365,6 +469,31 @@ describe("runMigrations", () => {
     await expect(
       runMigrations(db, { revisions: [first, inserted, later] }),
     ).rejects.toThrow(/ledger has gaps/);
+  });
+
+  test("waits for a contended lease then acquires it", async () => {
+    const { db, fake } = fakeDb();
+    fake.lock = { holder: "other", expiresAt: Date.now() + 40 };
+
+    await runMigrations(db, {
+      revisions: [issuesRevision],
+      lockTtlMs: 1_000,
+      acquireTimeoutMs: 5_000,
+    });
+
+    expect(await ledgerIds(fake)).toEqual(["0001_issues"]);
+  });
+
+  test("times out if the lease is never free", async () => {
+    const { db, fake } = fakeDb();
+    fake.lock = { holder: "other", expiresAt: Date.now() + 60_000 };
+
+    await expect(
+      runMigrations(db, {
+        revisions: [issuesRevision],
+        acquireTimeoutMs: 50,
+      }),
+    ).rejects.toThrow(/waiting for the migration lease/);
   });
 
   test("rejects duplicate revision ids", async () => {


### PR DESCRIPTION
## Description

This reverts commit d4b94ab74, which was **pushed directly to `main` by accident** (bypassing PR review) due to a git tracking bug: `git checkout -B <branch> origin/main` sets the new branch's upstream to `origin/main`, and a subsequent `gs branch submit` pushed to that tracked upstream before its PR-creation call failed. `main` has no branch protection, so the push succeeded silently.

`main` is currently one fast-forward commit ahead of #2642 with no review. This PR reverts that commit (a clean revert, no force-push, no history rewritten) to restore `main` to its pre-incident state. The AcquireLock-removal change itself is correct and fully tested — it will be resubmitted as a fresh, properly-reviewed PR once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)