### PR TITLE
Set up Cloud dev environment (AGENTS.md + startup script)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,64 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Gestalt is a polyglot monorepo. Standard per-component build/lint/test commands live in
+`CONTRIBUTING.md` — use those as the source of truth. This section only captures
+non-obvious, durable caveats for running things in the Cloud environment.
+
+### Components / services
+
+- `gestaltd` (Go) — the server daemon and the core product. Build: `cd gestaltd && go build ./cmd/gestaltd`.
+- `gestalt` (Rust) — CLI client used to drive the server. Build: `cd gestalt && cargo build`.
+- `sdk/{go,python,rust,typescript}` — client/provider SDK libraries (optional for core work).
+- `docs` (Next.js/Nextra) — documentation site (optional).
+
+There is no root Makefile or docker-compose; each component builds independently. SQLite is
+embedded (no external DB process). No auth is required for local runs.
+
+### Toolchain gotchas (important)
+
+- **Go**: the base `go` on PATH is 1.22.2, but the repo needs 1.26.x. `GOTOOLCHAIN=auto` will
+  fetch `go1.26.4` on demand for the workspace (`go.work` pins `1.26.4`). When building/serving a
+  **local source app** whose `go.mod` says `go 1.26` (no patch), `GOTOOLCHAIN=auto` tries to
+  download a nonexistent `go1.26` toolchain and fails — always pin `GOTOOLCHAIN=go1.26.4` in that
+  case (e.g. `GOTOOLCHAIN=go1.26.4 go test ./...`).
+- **Rust**: the crates use edition 2024 (needs Rust ≥ 1.85). The rustup default may be pinned to an
+  older toolchain; run `rustup default stable` (the update script does this). `cargo`/`rustc` must
+  report ≥ 1.85 or `cargo build` fails with `feature edition2024 is required`.
+
+### Running the server end-to-end (do NOT rely on zero-config `gestaltd`)
+
+Running bare `gestaltd` (or `gestaltd lock`) uses "full config mode", which resolves and locks
+providers from `github.com/valon-technologies/gestalt-providers`. Those published releases are
+drifted from `main`: the default home app `app/default` release 404s and older app releases
+(e.g. httpbin) lack the validation manifest the current server requires. So the README quickstart
+(`gestaltd` with no args → HTTPBin) does not work from a source build against current releases.
+
+For a reliable local run, serve a **local source app** with `gestaltd serve <path>/manifest.yaml`.
+The repo ships an example Go-SDK app at `gestaltd/internal/testutil/testdata/provider-go`
+(operations: `greet`, `echo`, `status`, ...). Two caveats when serving it directly:
+
+- Its on-disk `manifest.yaml` uses an older format that declares `entrypoint.artifactPath`; current
+  source manifests must NOT declare that field (Gestalt derives it). Remove the `entrypoint:` block.
+- Its `go.mod` `replace` directives are relative to the repo tree (`../../../../../sdk/go` etc.), so
+  copy the app elsewhere only if you rewrite those replaces to absolute paths.
+
+Example that works (server + CLI):
+
+```sh
+# copy + adapt the example app (remove entrypoint:, absolute replaces), then:
+GOTOOLCHAIN=go1.26.4 ./gestaltd/gestaltd serve /path/to/app/manifest.yaml --port 8080
+# in another shell:
+./gestalt/target/debug/gestalt --url http://127.0.0.1:8080 app list
+./gestalt/target/debug/gestalt --url http://127.0.0.1:8080 app invoke provider_go greet -p name=Cursor
+```
+
+Endpoints: HTTP API `GET/POST /api/v1/<app>/<operation>`, admin UI at `/admin/`, MCP at `/mcp`,
+default port `8080`. The public root `/` is only served when a UI app is mounted.
+
+### SDK / docs dependency refresh
+
+`bun` and `uv` are installed in the environment. Refresh deps only when lockfiles change:
+`sdk/typescript` → `bun install --frozen-lockfile`; `sdk/python` → `uv sync --frozen --group dev`;
+`docs` → `npm ci`. The startup update script already runs these guarded.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the Gestalt monorepo in Cursor Cloud and documents the non-obvious gotchas discovered while getting the core product running end-to-end. The only code change is a new `AGENTS.md`; the rest is environment configuration (startup update script).

## What was set up

- **gestaltd** (Go server): built with `go build ./cmd/gestaltd`.
- **gestalt** (Rust CLI): built with `cargo build` after `rustup default stable` (crates need edition 2024 / Rust ≥ 1.85; default was pinned to 1.83.0).
- **SDKs + docs** (optional): TypeScript (`bun`), Python (`uv`), Go, Rust, and the Next.js docs site.

## Hello-world (end-to-end)

Served the repo's example Go-SDK app locally and invoked operations via both the CLI and HTTP:

[gestaltd_admin_and_api_demo.mp4](https://cursor.com/agents/bc-2e25c24b-f74d-4c1b-abca-68bdb5fff78e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgestaltd_admin_and_api_demo.mp4)

[Gestalt Admin dashboard](https://cursor.com/agents/bc-2e25c24b-f74d-4c1b-abca-68bdb5fff78e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgestaltd_admin_dashboard.webp)
[greet API response](https://cursor.com/agents/bc-2e25c24b-f74d-4c1b-abca-68bdb5fff78e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgestaltd_greet_api.webp)

[hello_world_gestalt.log](https://cursor.com/agents/bc-2e25c24b-f74d-4c1b-abca-68bdb5fff78e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_gestalt.log)

## Key gotchas (captured in AGENTS.md)

- Bare `gestaltd` (zero-config) does not work from a source build: published providers in `gestalt-providers` are drifted from `main` (`app/default` release 404s; older releases lack the required validation manifest). Use `gestaltd serve <manifest>` with a local source app instead.
- Go: base `go` is 1.22.2; pin `GOTOOLCHAIN=go1.26.4` (a bare `go 1.26` directive makes `auto` try to fetch a nonexistent `go1.26` toolchain).
- Rust: `rustup default stable` required for edition 2024.

## Testing

- ✅ `cd gestalt && cargo fmt --check`
- ✅ `cd gestalt && cargo test --workspace`
- ✅ `cd gestaltd && GOTOOLCHAIN=go1.26.4 go vet ./internal/config/...`
- ✅ `cd gestaltd && GOTOOLCHAIN=go1.26.4 go test ./internal/config/... ./core/...`
- ✅ `cd sdk/go && GOTOOLCHAIN=go1.26.4 go test ./...`
- ✅ `cd sdk/rust && cargo test`
- ✅ `cd sdk/python && uv run python -m unittest discover -s tests` (188 tests)
- ✅ `cd sdk/typescript && bun run check` (158 tests)
- ✅ `cd docs && npm run build`

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e25c24b-f74d-4c1b-abca-68bdb5fff78e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e25c24b-f74d-4c1b-abca-68bdb5fff78e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

