### PR TITLE
gestaltd: implement ProviderGateway public request handling (issue-90)

### DIFF
--- a/gestaltd/services/appaccess/request_context.go
+++ b/gestaltd/services/appaccess/request_context.go
@@ -278,7 +278,7 @@ func (c ProviderRequestContext) Restore(ctx context.Context, connectionOverride 
 		ctx = principal.WithPrincipal(ctx, principal.Canonicalized(c.principal))
 	}
 	if c.agentSubject != nil {
-		ctx = invocation.WithRunAsAudit(ctx, c.agentSubject, agentwire.RunAsSubjectFromProto(subjectContextFromPrincipal(c.principal)))
+		ctx = invocation.WithRunAsAudit(ctx, c.agentSubject, agentwire.RunAsSubjectFromProto(SubjectContextFromPrincipal(c.principal)))
 	}
 	if c.callerName != "" && c.callerKind != "" {
 		ctx = invocation.WithCallerProvider(ctx, c.callerKind, c.callerName)
@@ -361,7 +361,7 @@ func PrincipalFromSubjectContext(subject *proto.SubjectContext) *principal.Princ
 	return p
 }
 
-func subjectContextFromPrincipal(p *principal.Principal) *proto.SubjectContext {
+func SubjectContextFromPrincipal(p *principal.Principal) *proto.SubjectContext {
 	p = principal.Canonicalized(p)
 	if p == nil {
 		return nil

--- a/gestaltd/services/providergateway/gateway.go
+++ b/gestaltd/services/providergateway/gateway.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/publicrpc"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 )
 
@@ -25,15 +27,12 @@ func (t *ProviderGatewayTransport) Authorize(ctx context.Context, params Authori
 }
 
 func (t *ProviderGatewayTransport) shadowAuthorizationCheck(ctx context.Context, params AuthorizationParams) (bool, *proto.CheckAccessRequest) {
-	req, err := t.checkAccessRequest(params)
+	subject, err := t.authorizationSubject(params.CallerToken)
 	if err != nil {
 		return false, nil
 	}
-	resp, err := t.authorization.CheckAccess(ctx, req)
-	if err != nil || resp == nil {
-		return false, req
-	}
-	return resp.GetAllowed(), req
+	allowed, req, _ := t.runAuthorizationCheck(ctx, subject, params.ProviderID, params.Operation)
+	return allowed, req
 }
 
 type DirectTransport struct{}
@@ -53,6 +52,9 @@ func (DirectTransport) Invoke(ctx context.Context, req ProviderGatewayRequest, n
 type ProviderGatewayTransport struct {
 	authorization        AuthorizationProvider
 	callerTokenPublicKey string
+	identity             core.IdentityProvider
+	publicMethods        *publicrpc.Registry
+	publicBaseURL        string
 }
 
 func NewProviderGatewayTransport() *ProviderGatewayTransport {
@@ -71,6 +73,27 @@ func (t *ProviderGatewayTransport) SetCallerTokenPublicKey(publicKey string) {
 		return
 	}
 	t.callerTokenPublicKey = strings.TrimSpace(publicKey)
+}
+
+func (t *ProviderGatewayTransport) SetIdentityProvider(identity core.IdentityProvider) {
+	if t == nil {
+		return
+	}
+	t.identity = identity
+}
+
+func (t *ProviderGatewayTransport) SetPublicMethods(publicMethods *publicrpc.Registry) {
+	if t == nil {
+		return
+	}
+	t.publicMethods = publicMethods
+}
+
+func (t *ProviderGatewayTransport) SetPublicBaseURL(publicBaseURL string) {
+	if t == nil {
+		return
+	}
+	t.publicBaseURL = strings.TrimRight(strings.TrimSpace(publicBaseURL), "/")
 }
 
 func (t *ProviderGatewayTransport) Invoke(ctx context.Context, req ProviderGatewayRequest, next Next) (resp ProviderGatewayResponse, err error) {
@@ -99,24 +122,32 @@ func (t *ProviderGatewayTransport) Invoke(ctx context.Context, req ProviderGatew
 	return next(ctx, req)
 }
 
-func (t *ProviderGatewayTransport) checkAccessRequest(params AuthorizationParams) (*proto.CheckAccessRequest, error) {
-	subject, err := t.authorizationSubject(params.CallerToken)
-	if err != nil {
-		return nil, err
+func (t *ProviderGatewayTransport) runAuthorizationCheck(
+	ctx context.Context,
+	subject *proto.Subject,
+	providerID, operation string,
+) (bool, *proto.CheckAccessRequest, error) {
+	if t == nil || t.authorization == nil {
+		return true, nil, nil
 	}
-	resource, err := authorizationResource(params.ProviderID)
+	resource, err := authorizationResource(providerID)
 	if err != nil {
-		return nil, err
+		return false, nil, err
 	}
-	action, err := authorizationAction(params.Operation)
+	action, err := authorizationAction(operation)
 	if err != nil {
-		return nil, err
+		return false, nil, err
 	}
-	return &proto.CheckAccessRequest{
+	req := &proto.CheckAccessRequest{
 		Subject:  subject,
 		Resource: resource,
 		Action:   action,
-	}, nil
+	}
+	resp, err := t.authorization.CheckAccess(ctx, req)
+	if err != nil || resp == nil {
+		return false, req, err
+	}
+	return resp.GetAllowed(), req, nil
 }
 
 func (t *ProviderGatewayTransport) authorizationSubject(callerToken string) (*proto.Subject, error) {

--- a/gestaltd/services/providergateway/gateway_test.go
+++ b/gestaltd/services/providergateway/gateway_test.go
@@ -10,9 +10,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/valon-technologies/gestalt/server/core"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/publicrpc"
 	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	gproto "google.golang.org/protobuf/proto"
 )
 
 func TestAuthorizeAllowsRequests(t *testing.T) {
@@ -418,4 +425,229 @@ func testGatewayAuthorizeCallerTokenKeyPair(t testing.TB) (string, string) {
 	privateKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privateKeyBytes})
 	publicKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: publicKeyBytes})
 	return string(privateKeyPEM), string(publicKeyPEM)
+}
+
+func TestPreparePublicRequest(t *testing.T) {
+	t.Parallel()
+
+	registry, err := publicrpc.NewGeneratedRegistry()
+	if err != nil {
+		t.Fatalf("NewGeneratedRegistry: %v", err)
+	}
+
+	activeAlice := &core.IntrospectResponse{Active: true, Subject: "user:alice"}
+	inactive := &core.IntrospectResponse{Active: false}
+	denied := false
+
+	tests := []struct {
+		name         string
+		fullMethod   string
+		withOrigin   bool
+		introspect   *core.IntrospectResponse
+		authAllow    *bool
+		req          gproto.Message
+		wantCode     codes.Code
+		setup        func(*ProviderGatewayTransport)
+		checkAdapted func(t *testing.T, adapted gproto.Message)
+		checkAuth    func(t *testing.T, auth *stubAuthorizationProvider)
+	}{
+		{
+			name:       "app invoke fills context",
+			fullMethod: proto.App_Invoke_FullMethodName,
+			withOrigin: true,
+			introspect: activeAlice,
+			req:        &proto.AppInvokeRequest{App: "roadmap", Operation: "sync"},
+			checkAdapted: func(t *testing.T, adapted gproto.Message) {
+				t.Helper()
+				out, ok := adapted.(*proto.AppInvokeRequest)
+				if !ok {
+					t.Fatalf("adapted type = %T, want *proto.AppInvokeRequest", adapted)
+				}
+				if out.GetContext() == nil || out.GetContext().GetSubject().GetId() != "user:alice" {
+					t.Fatalf("context subject = %#v, want user:alice", out.GetContext())
+				}
+				if out.GetRunAs() != nil {
+					t.Fatal("run_as should remain unset")
+				}
+			},
+			checkAuth: func(t *testing.T, auth *stubAuthorizationProvider) {
+				t.Helper()
+				if got := auth.request.GetResource().GetId(); got != "roadmap" {
+					t.Fatalf("Resource.Id = %q, want %q", got, "roadmap")
+				}
+				if got := auth.request.GetAction().GetName(); got != proto.App_Invoke_FullMethodName {
+					t.Fatalf("Action.Name = %q, want %q", got, proto.App_Invoke_FullMethodName)
+				}
+			},
+		},
+		{
+			name:       "app invoke rejects run_as",
+			fullMethod: proto.App_Invoke_FullMethodName,
+			withOrigin: true,
+			introspect: activeAlice,
+			req: &proto.AppInvokeRequest{
+				App:       "roadmap",
+				Operation: "sync",
+				RunAs:     &proto.SubjectContext{Id: "user:bob"},
+			},
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			name:       "app invoke rejects client context",
+			fullMethod: proto.App_Invoke_FullMethodName,
+			withOrigin: true,
+			introspect: activeAlice,
+			req: &proto.AppInvokeRequest{
+				App:       "roadmap",
+				Operation: "sync",
+				Context:   &proto.RequestContext{Subject: &proto.SubjectContext{Id: "user:bob"}},
+			},
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			name:       "agent create session fills subject fields",
+			fullMethod: proto.Agent_CreateSession_FullMethodName,
+			withOrigin: true,
+			introspect: activeAlice,
+			req:        &proto.CreateAgentProviderSessionRequest{Model: "gpt-test"},
+			checkAdapted: func(t *testing.T, adapted gproto.Message) {
+				t.Helper()
+				out, ok := adapted.(*proto.CreateAgentProviderSessionRequest)
+				if !ok {
+					t.Fatalf("adapted type = %T, want *proto.CreateAgentProviderSessionRequest", adapted)
+				}
+				if out.GetSubject().GetId() != "user:alice" {
+					t.Fatalf("subject = %#v, want user:alice", out.GetSubject())
+				}
+				if out.GetCreatedBySubjectId() != "user:alice" {
+					t.Fatalf("created_by_subject_id = %q, want %q", out.GetCreatedBySubjectId(), "user:alice")
+				}
+			},
+		},
+		{
+			name:       "workflow deliver event fills delivered_by",
+			fullMethod: proto.Workflow_DeliverEvent_FullMethodName,
+			withOrigin: true,
+			introspect: activeAlice,
+			req:        &proto.DeliverWorkflowProviderEventRequest{AppName: "roadmap", Event: &proto.WorkflowEvent{}},
+			checkAdapted: func(t *testing.T, adapted gproto.Message) {
+				t.Helper()
+				out, ok := adapted.(*proto.DeliverWorkflowProviderEventRequest)
+				if !ok {
+					t.Fatalf("adapted type = %T, want *proto.DeliverWorkflowProviderEventRequest", adapted)
+				}
+				if out.GetDeliveredBySubjectId() != "user:alice" {
+					t.Fatalf("delivered_by_subject_id = %q, want %q", out.GetDeliveredBySubjectId(), "user:alice")
+				}
+			},
+			checkAuth: func(t *testing.T, auth *stubAuthorizationProvider) {
+				t.Helper()
+				if got := auth.request.GetResource().GetId(); got != "roadmap" {
+					t.Fatalf("Resource.Id = %q, want %q", got, "roadmap")
+				}
+			},
+		},
+		{
+			name:       "app invoke rejects empty app",
+			fullMethod: proto.App_Invoke_FullMethodName,
+			withOrigin: true,
+			introspect: activeAlice,
+			req:        &proto.AppInvokeRequest{Operation: "sync"},
+			wantCode:   codes.InvalidArgument,
+		},
+		{
+			name:       "requires authorization provider",
+			fullMethod: proto.App_Invoke_FullMethodName,
+			withOrigin: true,
+			introspect: activeAlice,
+			req:        &proto.AppInvokeRequest{App: "roadmap", Operation: "sync"},
+			wantCode:   codes.PermissionDenied,
+			setup: func(transport *ProviderGatewayTransport) {
+				transport.SetAuthorizationProvider(nil)
+			},
+		},
+		{
+			name:       "authorization denied",
+			fullMethod: proto.App_Invoke_FullMethodName,
+			withOrigin: true,
+			introspect: activeAlice,
+			authAllow:  &denied,
+			req:        &proto.AppInvokeRequest{App: "roadmap", Operation: "sync"},
+			wantCode:   codes.PermissionDenied,
+		},
+		{
+			name:       "identity failure",
+			fullMethod: proto.App_Invoke_FullMethodName,
+			withOrigin: true,
+			introspect: inactive,
+			req:        &proto.AppInvokeRequest{App: "roadmap", Operation: "sync"},
+			wantCode:   codes.Unauthenticated,
+		},
+		{
+			name:       "requires public origin",
+			fullMethod: proto.App_Invoke_FullMethodName,
+			introspect: activeAlice,
+			req:        &proto.AppInvokeRequest{App: "roadmap", Operation: "sync"},
+			wantCode:   codes.Internal,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			authorization := &stubAuthorizationProvider{allowedResult: tc.authAllow}
+			identity := &coretesting.StubAuthProvider{
+				IntrospectFn: func(context.Context, *core.IntrospectRequest) (*core.IntrospectResponse, error) {
+					return tc.introspect, nil
+				},
+			}
+			transport := NewProviderGatewayTransport()
+			transport.SetPublicMethods(registry)
+			transport.SetIdentityProvider(identity)
+			transport.SetAuthorizationProvider(authorization)
+			transport.SetPublicBaseURL("https://gestalt.example")
+			if tc.setup != nil {
+				tc.setup(transport)
+			}
+
+			ctx := context.Background()
+			if tc.withOrigin {
+				ctx = publicrpc.WithPublicOrigin(ctx, tc.fullMethod)
+			}
+			ctx = metadata.NewIncomingContext(ctx, metadata.Pairs("authorization", "Bearer test-token"))
+
+			p, adapted, err := transport.PreparePublicRequest(ctx, tc.fullMethod, tc.req)
+			if tc.wantCode != codes.OK {
+				assertGRPCCode(t, err, tc.wantCode)
+				return
+			}
+			if err != nil {
+				t.Fatalf("PreparePublicRequest: %v", err)
+			}
+			if p.SubjectID != "user:alice" {
+				t.Fatalf("SubjectID = %q, want %q", p.SubjectID, "user:alice")
+			}
+			if tc.checkAdapted != nil {
+				tc.checkAdapted(t, adapted)
+			}
+			if tc.checkAuth != nil {
+				if !authorization.called {
+					t.Fatal("authorization provider was not called")
+				}
+				tc.checkAuth(t, authorization)
+			}
+		})
+	}
+}
+
+func assertGRPCCode(t *testing.T, err error, want codes.Code) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("error = nil, want %v", want)
+	}
+	if status.Code(err) != want {
+		t.Fatalf("status.Code(err) = %v, want %v (%v)", status.Code(err), want, err)
+	}
 }

--- a/gestaltd/services/providergateway/public_request.go
+++ b/gestaltd/services/providergateway/public_request.go
@@ -1,0 +1,252 @@
+package providergateway
+
+import (
+	"context"
+	"strings"
+
+	gestalt "github.com/valon-technologies/gestalt/sdk/go"
+	"github.com/valon-technologies/gestalt/server/internal/publicrpc"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/appaccess"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	gproto "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+// PreparePublicRequest authenticates, authorizes, and adapts a public request.
+// Internal/provider-runtime requests should not call this helper.
+func (t *ProviderGatewayTransport) PreparePublicRequest(
+	ctx context.Context,
+	fullMethod string,
+	req gproto.Message,
+) (*principal.Principal, gproto.Message, error) {
+	if t == nil {
+		return nil, nil, status.Error(codes.Internal, "provider gateway: transport is nil")
+	}
+	if req == nil {
+		return nil, nil, status.Error(codes.InvalidArgument, "request is required")
+	}
+	fullMethod = strings.TrimSpace(fullMethod)
+	if fullMethod == "" {
+		return nil, nil, status.Error(codes.Internal, "provider gateway: full method is required")
+	}
+	origin, ok := publicrpc.PublicOriginFromContext(ctx)
+	if !ok {
+		return nil, nil, status.Error(codes.Internal, "provider gateway: public origin marker is required")
+	}
+	if origin.FullMethod != fullMethod {
+		return nil, nil, status.Errorf(codes.Internal, "provider gateway: public origin method %q does not match %q", origin.FullMethod, fullMethod)
+	}
+	if t.publicMethods == nil {
+		return nil, nil, status.Error(codes.NotFound, "method is not public")
+	}
+	policy, ok := t.publicMethods.Lookup(fullMethod)
+	if !ok {
+		return nil, nil, status.Error(codes.NotFound, "method is not public")
+	}
+
+	token := bearerTokenFromContext(ctx)
+	if token == "" {
+		return nil, nil, status.Error(codes.Unauthenticated, "bearer token is required")
+	}
+	p, err := t.resolvePublicPrincipal(ctx, token)
+	if err != nil {
+		return nil, nil, err
+	}
+	resourceID, err := publicResourceID(req, fullMethod)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := t.enforcePublicAuthorization(ctx, p, resourceID, fullMethod); err != nil {
+		return nil, nil, err
+	}
+	adapted, err := adaptPublicRequest(ctx, t.publicBaseURL, p, req, policy)
+	if err != nil {
+		return nil, nil, err
+	}
+	return p, adapted, nil
+}
+
+func (t *ProviderGatewayTransport) resolvePublicPrincipal(ctx context.Context, token string) (*principal.Principal, error) {
+	if t.identity == nil {
+		return nil, status.Error(codes.Unauthenticated, "identity provider is not configured")
+	}
+	p, err := principal.NewResolver(t.identity).ResolveToken(ctx, token)
+	if err != nil {
+		if err == principal.ErrInvalidToken {
+			return nil, status.Error(codes.Unauthenticated, "invalid bearer token")
+		}
+		return nil, status.Errorf(codes.Internal, "provider gateway: introspect: %v", err)
+	}
+	return p, nil
+}
+
+func (t *ProviderGatewayTransport) enforcePublicAuthorization(
+	ctx context.Context,
+	p *principal.Principal,
+	providerID, operation string,
+) error {
+	if t == nil || t.authorization == nil {
+		return status.Error(codes.PermissionDenied, "authorization provider is not configured")
+	}
+	p = principal.Canonicalized(p)
+	subjectID := strings.TrimSpace(p.SubjectID)
+	if subjectID == "" {
+		return status.Error(codes.Unauthenticated, "authenticated subject is required")
+	}
+	allowed, _, err := t.runAuthorizationCheck(ctx, &proto.Subject{
+		Type: "subject",
+		Id:   subjectID,
+	}, providerID, operation)
+	if err != nil {
+		return status.Errorf(codes.Internal, "provider gateway: authorize: %v", err)
+	}
+	if !allowed {
+		return status.Error(codes.PermissionDenied, "access denied")
+	}
+	return nil
+}
+
+func bearerTokenFromContext(ctx context.Context) string {
+	if token := strings.TrimSpace(gestalt.CallerBearerTokenFromIncomingContext(ctx)); token != "" {
+		return token
+	}
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return ""
+	}
+	for _, value := range md.Get("authorization") {
+		value = strings.TrimSpace(value)
+		if len(value) > 7 && strings.EqualFold(value[:7], "Bearer ") {
+			if token := strings.TrimSpace(value[7:]); token != "" {
+				return token
+			}
+		}
+	}
+	return ""
+}
+
+func publicResourceID(req gproto.Message, fullMethod string) (string, error) {
+	msg := req.ProtoReflect()
+	if fd := msg.Descriptor().Fields().ByName("app"); fd != nil {
+		app := strings.TrimSpace(msg.Get(fd).String())
+		if app == "" {
+			return "", status.Error(codes.InvalidArgument, "app is required")
+		}
+		return app, nil
+	}
+	for _, field := range []protoreflect.Name{"app_name", "provider_name"} {
+		fd := msg.Descriptor().Fields().ByName(field)
+		if fd == nil {
+			continue
+		}
+		if value := strings.TrimSpace(msg.Get(fd).String()); value != "" {
+			return value, nil
+		}
+	}
+	service, _ := splitFullMethod(fullMethod)
+	if idx := strings.LastIndex(service, "."); idx >= 0 && idx+1 < len(service) {
+		return strings.ToLower(service[idx+1:]), nil
+	}
+	if service == "" {
+		return "", status.Error(codes.InvalidArgument, "provider id is required")
+	}
+	return service, nil
+}
+
+func splitFullMethod(fullMethod string) (service, method string) {
+	fullMethod = strings.TrimSpace(fullMethod)
+	if !strings.HasPrefix(fullMethod, "/") {
+		return "", ""
+	}
+	service, method, ok := strings.Cut(strings.TrimPrefix(fullMethod, "/"), "/")
+	if !ok {
+		return "", ""
+	}
+	return service, method
+}
+
+func adaptPublicRequest(
+	ctx context.Context,
+	publicBaseURL string,
+	p *principal.Principal,
+	req gproto.Message,
+	policy publicrpc.PublicMethodPolicy,
+) (gproto.Message, error) {
+	adapted := gproto.Clone(req)
+	msg := adapted.ProtoReflect()
+	for _, name := range policy.Reject {
+		if fieldSet(msg, name) {
+			return nil, status.Errorf(codes.InvalidArgument, "%s is not public input", name)
+		}
+	}
+	for _, name := range policy.Fill {
+		if fieldSet(msg, name) {
+			return nil, status.Errorf(codes.InvalidArgument, "%s is server-filled", name)
+		}
+		if err := fillPublicField(ctx, publicBaseURL, p, msg, name); err != nil {
+			return nil, err
+		}
+	}
+	return adapted, nil
+}
+
+func fillPublicField(ctx context.Context, publicBaseURL string, p *principal.Principal, msg protoreflect.Message, name string) error {
+	fd := msg.Descriptor().Fields().ByName(protoreflect.Name(name))
+	if fd == nil {
+		return status.Errorf(codes.Internal, "no public fill rule for %q", name)
+	}
+	switch name {
+	case "context":
+		callCtx := principal.WithPrincipal(ctx, principal.Canonicalized(p))
+		reqCtx, err := appaccess.RequestContextProto(callCtx, publicBaseURL, invocation.CallerProvider{})
+		if err != nil {
+			return status.Errorf(codes.Internal, "provider gateway: build request context: %v", err)
+		}
+		if reqCtx == nil {
+			reqCtx = &proto.RequestContext{}
+		}
+		msg.Set(fd, protoreflect.ValueOfMessage(reqCtx.ProtoReflect()))
+	case "subject":
+		subject := appaccess.SubjectContextFromPrincipal(p)
+		if subject == nil {
+			return status.Error(codes.Internal, "provider gateway: subject is required")
+		}
+		msg.Set(fd, protoreflect.ValueOfMessage(subject.ProtoReflect()))
+	case "created_by_subject_id", "delivered_by_subject_id":
+		p = principal.Canonicalized(p)
+		subjectID := strings.TrimSpace(p.SubjectID)
+		if subjectID == "" {
+			return status.Errorf(codes.Internal, "provider gateway: %s is required", name)
+		}
+		msg.Set(fd, protoreflect.ValueOfString(subjectID))
+	default:
+		return status.Errorf(codes.Internal, "no public fill rule for %q", name)
+	}
+	return nil
+}
+
+func fieldSet(msg protoreflect.Message, name string) bool {
+	fd := msg.Descriptor().Fields().ByName(protoreflect.Name(name))
+	if fd == nil {
+		return false
+	}
+	if fd.IsList() {
+		return msg.Get(fd).List().Len() > 0
+	}
+	if fd.IsMap() {
+		return msg.Get(fd).Map().Len() > 0
+	}
+	switch fd.Kind() {
+	case protoreflect.MessageKind, protoreflect.GroupKind:
+		return msg.Has(fd)
+	case protoreflect.StringKind, protoreflect.BytesKind:
+		return msg.Has(fd) && strings.TrimSpace(msg.Get(fd).String()) != ""
+	default:
+		return msg.Has(fd)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Public gRPC wrappers mark requests with `publicrpc.WithPublicOrigin`; `ProviderGatewayTransport.PreparePublicRequest` handles the rest on the existing gateway.

```go
p, adapted, err := transport.PreparePublicRequest(ctx, fullMethod, req)
```

Flow: bearer introspection → `CheckAccess` (enforced, not shadow) → reject/fill per `option (public)`.

```mermaid
flowchart LR
  W[public wrapper] --> P[PreparePublicRequest]
  P --> I[IdentityProvider]
  P --> A[AuthorizationProvider]
  P --> D[dispatch]
```

Replaces PR #2651's separate `Gateway` type. Closes issue-90.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96fac707-5395-4c96-8be1-49531008d4bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96fac707-5395-4c96-8be1-49531008d4bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

