### PR TITLE
gestaltd: add authenticated remote gRPC client set (issue-93)

### DIFF
--- a/gestaltd/internal/remote/remote.go
+++ b/gestaltd/internal/remote/remote.go
@@ -1,0 +1,146 @@
+package remote
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+)
+
+// Config configures an authenticated client to a remote public gestaltd API.
+type Config struct {
+	URL       string
+	Token     string
+	TLSConfig *tls.Config
+}
+
+// ClientSet exposes typed public gRPC clients for a remote gestaltd instance.
+type ClientSet struct {
+	App       proto.AppClient
+	Agent     proto.AgentClient
+	Workflow  proto.WorkflowClient
+	IndexedDB proto.IndexedDBClient
+
+	conn *grpc.ClientConn
+}
+
+// NewClientSet dials the remote public gestaltd gRPC surface and returns typed clients.
+func NewClientSet(_ context.Context, cfg Config) (*ClientSet, error) {
+	url := strings.TrimSpace(cfg.URL)
+	if url == "" {
+		return nil, fmt.Errorf("remote: URL is required")
+	}
+	token := strings.TrimSpace(cfg.Token)
+	if token == "" {
+		return nil, fmt.Errorf("remote: token is required")
+	}
+
+	target, creds, err := grpcTarget(url, cfg.TLSConfig)
+	if err != nil {
+		return nil, err
+	}
+	unary, stream := bearerTokenInterceptors(token)
+	conn, err := grpc.NewClient(
+		target,
+		grpc.WithTransportCredentials(creds),
+		grpc.WithChainUnaryInterceptor(unary),
+		grpc.WithChainStreamInterceptor(stream),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("remote: dial %s: %w", target, err)
+	}
+	return clientSetFromConn(conn), nil
+}
+
+// Close releases the underlying gRPC connection.
+func (c *ClientSet) Close() error {
+	if c == nil || c.conn == nil {
+		return nil
+	}
+	conn := c.conn
+	c.conn = nil
+	return conn.Close()
+}
+
+func clientSetFromConn(conn *grpc.ClientConn) *ClientSet {
+	return &ClientSet{
+		App:       proto.NewAppClient(conn),
+		Agent:     proto.NewAgentClient(conn),
+		Workflow:  proto.NewWorkflowClient(conn),
+		IndexedDB: proto.NewIndexedDBClient(conn),
+		conn:      conn,
+	}
+}
+
+func grpcTarget(rawURL string, tlsConfig *tls.Config) (target string, creds credentials.TransportCredentials, err error) {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return "", nil, fmt.Errorf("remote: parse URL %q: %w", rawURL, err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return "", nil, fmt.Errorf("remote: URL %q must include scheme and host", rawURL)
+	}
+
+	host := parsed.Hostname()
+	port := parsed.Port()
+	switch parsed.Scheme {
+	case "https":
+		if port == "" {
+			port = "443"
+		}
+		if tlsConfig == nil {
+			tlsConfig = &tls.Config{
+				MinVersion: tls.VersionTLS12,
+				ServerName: host,
+			}
+		}
+		creds = credentials.NewTLS(tlsConfig)
+	case "http":
+		if port == "" {
+			port = "80"
+		}
+		creds = insecure.NewCredentials()
+	default:
+		return "", nil, fmt.Errorf("remote: unsupported URL scheme %q", parsed.Scheme)
+	}
+	return net.JoinHostPort(host, port), creds, nil
+}
+
+func bearerTokenInterceptors(token string) (grpc.UnaryClientInterceptor, grpc.StreamClientInterceptor) {
+	withBearer := func(ctx context.Context) context.Context {
+		token = strings.TrimSpace(token)
+		if token == "" {
+			return ctx
+		}
+		return metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+token)
+	}
+	unary := func(
+		ctx context.Context,
+		method string,
+		req, reply any,
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
+		return invoker(withBearer(ctx), method, req, reply, cc, opts...)
+	}
+	stream := func(
+		ctx context.Context,
+		desc *grpc.StreamDesc,
+		cc *grpc.ClientConn,
+		method string,
+		streamer grpc.Streamer,
+		opts ...grpc.CallOption,
+	) (grpc.ClientStream, error) {
+		return streamer(withBearer(ctx), desc, cc, method, opts...)
+	}
+	return unary, stream
+}

--- a/gestaltd/internal/remote/remote.go
+++ b/gestaltd/internal/remote/remote.go
@@ -15,7 +15,7 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-// Config configures an authenticated client to a remote public gestaltd API.
+// Config configures a client to a remote public gestaltd API.
 type Config struct {
 	URL       string
 	Token     string
@@ -32,30 +32,43 @@ type ClientSet struct {
 	conn *grpc.ClientConn
 }
 
-// NewClientSet dials the remote public gestaltd gRPC surface and returns typed clients.
-func NewClientSet(_ context.Context, cfg Config) (*ClientSet, error) {
+// Dial opens a gRPC connection to the remote public gestaltd surface.
+// Token is optional; when set, bearer authorization is attached to every RPC.
+func Dial(_ context.Context, cfg Config) (*grpc.ClientConn, error) {
 	url := strings.TrimSpace(cfg.URL)
 	if url == "" {
 		return nil, fmt.Errorf("remote: URL is required")
-	}
-	token := strings.TrimSpace(cfg.Token)
-	if token == "" {
-		return nil, fmt.Errorf("remote: token is required")
 	}
 
 	target, creds, err := grpcTarget(url, cfg.TLSConfig)
 	if err != nil {
 		return nil, err
 	}
-	unary, stream := bearerTokenInterceptors(token)
-	conn, err := grpc.NewClient(
-		target,
-		grpc.WithTransportCredentials(creds),
-		grpc.WithChainUnaryInterceptor(unary),
-		grpc.WithChainStreamInterceptor(stream),
-	)
+
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(creds)}
+	if token := strings.TrimSpace(cfg.Token); token != "" {
+		unary, stream := bearerTokenInterceptors(token)
+		opts = append(opts,
+			grpc.WithChainUnaryInterceptor(unary),
+			grpc.WithChainStreamInterceptor(stream),
+		)
+	}
+
+	conn, err := grpc.NewClient(target, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("remote: dial %s: %w", target, err)
+	}
+	return conn, nil
+}
+
+// NewClientSet dials the remote public gestaltd gRPC surface and returns typed clients.
+func NewClientSet(ctx context.Context, cfg Config) (*ClientSet, error) {
+	if strings.TrimSpace(cfg.Token) == "" {
+		return nil, fmt.Errorf("remote: token is required")
+	}
+	conn, err := Dial(ctx, cfg)
+	if err != nil {
+		return nil, err
 	}
 	return clientSetFromConn(conn), nil
 }

--- a/gestaltd/internal/remote/remote_test.go
+++ b/gestaltd/internal/remote/remote_test.go
@@ -1,0 +1,30 @@
+package remote
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestNewClientSetRequiresURLAndToken(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewClientSet(context.Background(), Config{Token: "token"})
+	if err == nil || !strings.Contains(err.Error(), "URL is required") {
+		t.Fatalf("NewClientSet(empty URL) = %v, want URL required", err)
+	}
+
+	_, err = NewClientSet(context.Background(), Config{URL: "https://valon.tools"})
+	if err == nil || !strings.Contains(err.Error(), "token is required") {
+		t.Fatalf("NewClientSet(empty token) = %v, want token required", err)
+	}
+}
+
+func TestGRPCUnsupportedScheme(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := grpcTarget("ftp://valon.tools", nil)
+	if err == nil || !strings.Contains(err.Error(), "unsupported URL scheme") {
+		t.Fatalf("grpcTarget(ftp) = %v, want unsupported scheme", err)
+	}
+}

--- a/gestaltd/internal/remote/remote_test.go
+++ b/gestaltd/internal/remote/remote_test.go
@@ -1,30 +1,28 @@
-package remote
+package remote_test
 
 import (
 	"context"
 	"strings"
 	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/remote"
 )
 
-func TestNewClientSetRequiresURLAndToken(t *testing.T) {
+func TestDialValidation(t *testing.T) {
 	t.Parallel()
 
-	_, err := NewClientSet(context.Background(), Config{Token: "token"})
+	_, err := remote.Dial(context.Background(), remote.Config{})
 	if err == nil || !strings.Contains(err.Error(), "URL is required") {
-		t.Fatalf("NewClientSet(empty URL) = %v, want URL required", err)
+		t.Fatalf("Dial(empty URL) = %v, want URL required", err)
 	}
 
-	_, err = NewClientSet(context.Background(), Config{URL: "https://valon.tools"})
+	_, err = remote.Dial(context.Background(), remote.Config{URL: "ftp://valon.tools"})
+	if err == nil || !strings.Contains(err.Error(), "unsupported URL scheme") {
+		t.Fatalf("Dial(ftp URL) = %v, want unsupported scheme", err)
+	}
+
+	_, err = remote.NewClientSet(context.Background(), remote.Config{URL: "https://valon.tools"})
 	if err == nil || !strings.Contains(err.Error(), "token is required") {
 		t.Fatalf("NewClientSet(empty token) = %v, want token required", err)
-	}
-}
-
-func TestGRPCUnsupportedScheme(t *testing.T) {
-	t.Parallel()
-
-	_, _, err := grpcTarget("ftp://valon.tools", nil)
-	if err == nil || !strings.Contains(err.Error(), "unsupported URL scheme") {
-		t.Fatalf("grpcTarget(ftp) = %v, want unsupported scheme", err)
 	}
 }

--- a/gestaltd/internal/server/public_grpc_test.go
+++ b/gestaltd/internal/server/public_grpc_test.go
@@ -89,7 +89,7 @@ func TestPublicGRPCRouting(t *testing.T) {
 		clients, err := remote.NewClientSet(context.Background(), remote.Config{
 			URL:       ts.URL,
 			Token:     publicGRPCTestBearer("roadmap"),
-			TLSConfig: publicGRPCTestTLS(),
+			TLSConfig: &tls.Config{InsecureSkipVerify: true},
 		})
 		if err != nil {
 			t.Fatalf("remote.NewClientSet: %v", err)

--- a/gestaltd/internal/server/public_grpc_test.go
+++ b/gestaltd/internal/server/public_grpc_test.go
@@ -2,6 +2,7 @@ package server_test
 
 import (
 	"context"
+	"crypto/tls"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/publicrpc"
+	"github.com/valon-technologies/gestalt/server/internal/remote"
 	"github.com/valon-technologies/gestalt/server/internal/server"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
@@ -99,6 +101,44 @@ func TestPublicGRPCRouting(t *testing.T) {
 		})
 		if err != nil {
 			t.Fatalf("public App.Invoke: %v", err)
+		}
+		if call := invoker.snapshot(); call.calls != 1 || call.providerName != "roadmap" || call.operation != "sync" {
+			t.Fatalf("invoker call = %+v, want roadmap/sync", call)
+		}
+	})
+
+	t.Run("remote client set dials public surface", func(t *testing.T) {
+		t.Parallel()
+
+		ts, invoker := startPublicGRPCServer(t, func(cfg *server.Config) {
+			cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+				N:        "roadmap",
+				ConnMode: core.ConnectionModeNone,
+				CatalogVal: &catalog.Catalog{
+					Name:       "roadmap",
+					Operations: []catalog.CatalogOperation{{ID: "sync", Method: "POST"}},
+				},
+			})
+		})
+
+		bearer := publicGRPCTestBearer("roadmap")
+		clients, err := remote.NewClientSet(context.Background(), remote.Config{
+			URL:       ts.URL,
+			Token:     bearer,
+			TLSConfig: &tls.Config{InsecureSkipVerify: true},
+		})
+		if err != nil {
+			t.Fatalf("remote.NewClientSet: %v", err)
+		}
+		defer func() { _ = clients.Close() }()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if _, err := clients.App.Invoke(ctx, &proto.AppInvokeRequest{
+			App:       "roadmap",
+			Operation: "sync",
+		}); err != nil {
+			t.Fatalf("remote App.Invoke: %v", err)
 		}
 		if call := invoker.snapshot(); call.calls != 1 || call.providerName != "roadmap" || call.operation != "sync" {
 			t.Fatalf("invoker call = %+v, want roadmap/sync", call)

--- a/gestaltd/internal/server/public_grpc_test.go
+++ b/gestaltd/internal/server/public_grpc_test.go
@@ -50,13 +50,6 @@ func publicGRPCTestBearer(scope string) string {
 	return scopedTestBearerToken("public-grpc-user", scope)
 }
 
-func publicGRPCContext(t *testing.T, bearerToken string) context.Context {
-	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	t.Cleanup(cancel)
-	return metadata.NewOutgoingContext(ctx, metadata.Pairs("authorization", "Bearer "+bearerToken))
-}
-
 func startPublicGRPCServer(t *testing.T, configure func(*server.Config)) (*httptest.Server, *relayTestInvoker) {
 	t.Helper()
 	invoker := &relayTestInvoker{}
@@ -92,40 +85,11 @@ func TestPublicGRPCRouting(t *testing.T) {
 				},
 			})
 		})
-		conn := newRelayGRPCConn(t, ts)
-		defer func() { _ = conn.Close() }()
 
-		_, err := proto.NewAppClient(conn).Invoke(publicGRPCContext(t, publicGRPCTestBearer("roadmap")), &proto.AppInvokeRequest{
-			App:       "roadmap",
-			Operation: "sync",
-		})
-		if err != nil {
-			t.Fatalf("public App.Invoke: %v", err)
-		}
-		if call := invoker.snapshot(); call.calls != 1 || call.providerName != "roadmap" || call.operation != "sync" {
-			t.Fatalf("invoker call = %+v, want roadmap/sync", call)
-		}
-	})
-
-	t.Run("remote client set dials public surface", func(t *testing.T) {
-		t.Parallel()
-
-		ts, invoker := startPublicGRPCServer(t, func(cfg *server.Config) {
-			cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
-				N:        "roadmap",
-				ConnMode: core.ConnectionModeNone,
-				CatalogVal: &catalog.Catalog{
-					Name:       "roadmap",
-					Operations: []catalog.CatalogOperation{{ID: "sync", Method: "POST"}},
-				},
-			})
-		})
-
-		bearer := publicGRPCTestBearer("roadmap")
 		clients, err := remote.NewClientSet(context.Background(), remote.Config{
 			URL:       ts.URL,
-			Token:     bearer,
-			TLSConfig: &tls.Config{InsecureSkipVerify: true},
+			Token:     publicGRPCTestBearer("roadmap"),
+			TLSConfig: publicGRPCTestTLS(),
 		})
 		if err != nil {
 			t.Fatalf("remote.NewClientSet: %v", err)

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	"github.com/valon-technologies/gestalt/server/internal/indexeddbcodec"
+	"github.com/valon-technologies/gestalt/server/internal/remote"
 	"github.com/valon-technologies/gestalt/server/internal/server"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
@@ -72,7 +73,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/ui"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
 	grpcstatus "google.golang.org/grpc/status"
 	gproto "google.golang.org/protobuf/proto"
@@ -1757,16 +1757,12 @@ func TestEgressProxyConnectForwardsBufferedClientBytes(t *testing.T) {
 
 func newRelayGRPCConn(t *testing.T, ts *httptest.Server) *grpc.ClientConn {
 	t.Helper()
-	targetURL, err := url.Parse(ts.URL)
+	conn, err := remote.Dial(context.Background(), remote.Config{
+		URL:       ts.URL,
+		TLSConfig: &tls.Config{InsecureSkipVerify: true},
+	})
 	if err != nil {
-		t.Fatalf("parse relay URL: %v", err)
-	}
-	conn, err := grpc.NewClient(
-		targetURL.Host,
-		grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})),
-	)
-	if err != nil {
-		t.Fatalf("grpc.NewClient: %v", err)
+		t.Fatalf("remote.Dial: %v", err)
 	}
 	return conn
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements [issue-93](https://valon.tools/g-issues/issues/issue-93) for plan-6 remote gestaltd delegation. 

```go
clients, err := remote.NewClientSet(ctx, remote.Config{
    URL:   cfg.Server.Remote,
    Token: cfg.Server.RemoteToken,
})
```

`internal/remote` dials the public gestaltd gRPC surface over HTTPS, attaches `Authorization: Bearer` on every unary/stream RPC, and returns typed `App` / `Agent` / `Workflow` / `IndexedDB` clients. `remote.Dial` is the lower-level entry point (token optional) and is reused by relay gRPC test helpers.

```mermaid
flowchart LR
  local[local gestaltd] -->|bearer token| remote[remote public gRPC]
```

### Out of scope

Issue-94 will wire placement on top of this client set.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e9d75fc5-b052-459b-8904-3d5669aae8a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9d75fc5-b052-459b-8904-3d5669aae8a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

