### PR TITLE
Tighten public gRPC auth routing

### DIFF
--- a/gestaltd/internal/server/public_grpc.go
+++ b/gestaltd/internal/server/public_grpc.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"net/http"
-	"strings"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/publicrpc"
@@ -79,11 +78,6 @@ func (s *Server) publicGRPCMiddleware(next http.Handler) http.Handler {
 			return
 		}
 		if !isGRPCRequest(r) || s.hostServiceRelayToken(r) != "" {
-			next.ServeHTTP(w, r)
-			return
-		}
-		auth := strings.TrimSpace(r.Header.Get("Authorization"))
-		if len(auth) <= 7 || !strings.EqualFold(auth[:7], "Bearer ") || strings.TrimSpace(auth[7:]) == "" {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/gestaltd/internal/server/public_grpc_test.go
+++ b/gestaltd/internal/server/public_grpc_test.go
@@ -19,7 +19,9 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/providergateway"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 var publicGRPCTestSecret = []byte("public-grpc-test-secret-01234567")
@@ -65,6 +67,20 @@ func startPublicGRPCServer(t *testing.T, configure func(*server.Config)) (*httpt
 	return ts, invoker
 }
 
+func startExamplePublicGRPCServer(t *testing.T) (*httptest.Server, *relayTestInvoker) {
+	t.Helper()
+	return startPublicGRPCServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+			N:        "example",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{
+				Name:       "example",
+				Operations: []catalog.CatalogOperation{{ID: "sync", Method: "POST"}},
+			},
+		})
+	})
+}
+
 // TestPublicGRPCRouting verifies public gRPC wiring end-to-end: bearer-authenticated
 // gRPC is handled by the public gateway surface, while host-service relay traffic
 // continues through the trusted relay path. Individual RPC policy and per-service
@@ -75,20 +91,10 @@ func TestPublicGRPCRouting(t *testing.T) {
 	t.Run("bearer routes through public gateway", func(t *testing.T) {
 		t.Parallel()
 
-		ts, invoker := startPublicGRPCServer(t, func(cfg *server.Config) {
-			cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
-				N:        "roadmap",
-				ConnMode: core.ConnectionModeNone,
-				CatalogVal: &catalog.Catalog{
-					Name:       "roadmap",
-					Operations: []catalog.CatalogOperation{{ID: "sync", Method: "POST"}},
-				},
-			})
-		})
-
+		ts, invoker := startExamplePublicGRPCServer(t)
 		clients, err := remote.NewClientSet(context.Background(), remote.Config{
 			URL:       ts.URL,
-			Token:     publicGRPCTestBearer("roadmap"),
+			Token:     publicGRPCTestBearer("example"),
 			TLSConfig: &tls.Config{InsecureSkipVerify: true},
 		})
 		if err != nil {
@@ -99,15 +105,49 @@ func TestPublicGRPCRouting(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		if _, err := clients.App.Invoke(ctx, &proto.AppInvokeRequest{
-			App:       "roadmap",
+			App:       "example",
 			Operation: "sync",
 		}); err != nil {
 			t.Fatalf("remote App.Invoke: %v", err)
 		}
-		if call := invoker.snapshot(); call.calls != 1 || call.providerName != "roadmap" || call.operation != "sync" {
-			t.Fatalf("invoker call = %+v, want roadmap/sync", call)
+		if call := invoker.snapshot(); call.calls != 1 || call.providerName != "example" || call.operation != "sync" {
+			t.Fatalf("invoker call = %+v, want example/sync", call)
 		}
 	})
+
+	for _, tc := range []struct {
+		name     string
+		metadata []string
+	}{
+		{name: "missing bearer is rejected"},
+		{name: "invalid bearer scheme is rejected", metadata: []string{"authorization", "Basic not-a-bearer-token"}},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ts, invoker := startExamplePublicGRPCServer(t)
+			conn := newRelayGRPCConn(t, ts)
+			defer func() { _ = conn.Close() }()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if len(tc.metadata) > 0 {
+				ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(tc.metadata...))
+			}
+
+			_, err := proto.NewAppClient(conn).Invoke(ctx, &proto.AppInvokeRequest{
+				App:       "example",
+				Operation: "sync",
+			})
+			if status.Code(err) != codes.Unauthenticated {
+				t.Fatalf("public App.Invoke code = %v, want %v (%v)", status.Code(err), codes.Unauthenticated, err)
+			}
+			if call := invoker.snapshot(); call.calls != 0 {
+				t.Fatalf("invoker calls = %d, want 0", call.calls)
+			}
+		})
+	}
 
 	t.Run("relay token bypasses public gateway", func(t *testing.T) {
 		t.Parallel()

--- a/gestaltd/services/providergateway/gateway_test.go
+++ b/gestaltd/services/providergateway/gateway_test.go
@@ -443,6 +443,7 @@ func TestPreparePublicRequest(t *testing.T) {
 		name         string
 		fullMethod   string
 		withOrigin   bool
+		metadata     []string
 		introspect   *core.IntrospectResponse
 		authAllow    *bool
 		req          gproto.Message
@@ -584,6 +585,15 @@ func TestPreparePublicRequest(t *testing.T) {
 			wantCode:   codes.Unauthenticated,
 		},
 		{
+			name:       "rejects caller bearer metadata",
+			fullMethod: proto.App_Invoke_FullMethodName,
+			withOrigin: true,
+			metadata:   []string{"x-gestalt-caller-bearer-token", "test-token"},
+			introspect: activeAlice,
+			req:        &proto.AppInvokeRequest{App: "roadmap", Operation: "sync"},
+			wantCode:   codes.Unauthenticated,
+		},
+		{
 			name:       "requires public origin",
 			fullMethod: proto.App_Invoke_FullMethodName,
 			introspect: activeAlice,
@@ -616,7 +626,11 @@ func TestPreparePublicRequest(t *testing.T) {
 			if tc.withOrigin {
 				ctx = publicrpc.WithPublicOrigin(ctx, tc.fullMethod)
 			}
-			ctx = metadata.NewIncomingContext(ctx, metadata.Pairs("authorization", "Bearer test-token"))
+			metadataPairs := tc.metadata
+			if metadataPairs == nil {
+				metadataPairs = []string{"authorization", "Bearer test-token"}
+			}
+			ctx = metadata.NewIncomingContext(ctx, metadata.Pairs(metadataPairs...))
 
 			p, adapted, err := transport.PreparePublicRequest(ctx, tc.fullMethod, tc.req)
 			if tc.wantCode != codes.OK {

--- a/gestaltd/services/providergateway/public_request.go
+++ b/gestaltd/services/providergateway/public_request.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strings"
 
-	gestalt "github.com/valon-technologies/gestalt/sdk/go"
 	"github.com/valon-technologies/gestalt/server/internal/publicrpc"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"github.com/valon-technologies/gestalt/server/services/appaccess"
@@ -112,9 +111,6 @@ func (t *ProviderGatewayTransport) enforcePublicAuthorization(
 }
 
 func bearerTokenFromContext(ctx context.Context) string {
-	if token := strings.TrimSpace(gestalt.CallerBearerTokenFromIncomingContext(ctx)); token != "" {
-		return token
-	}
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
 		return ""


### PR DESCRIPTION
## Summary
- route non-relay gRPC requests to the public gRPC handler so unauthenticated requests cannot fall through to internal handlers
- keep public gRPC authentication in the gRPC gateway path, using authorization metadata and the shared IdentityProvider-backed principal resolver
- remove the caller-bearer metadata fallback from public request auth while preserving relay-token bypass

## Tests
- go test ./gestaltd/internal/server/...
- go test ./gestaltd/services/providergateway/...