### PR TITLE
Tighten serve remote config handling

### DIFF
--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -5029,7 +5029,7 @@ server:
 		}
 	})
 
-	t.Run("requires token when remote set", func(t *testing.T) {
+	t.Run("allows remote without token before serve", func(t *testing.T) {
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
@@ -5037,9 +5037,17 @@ server:
   remote: https://valon.tools
 `)
 
-		_, err := Load(path)
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if got := cfg.Server.Remote; got != "https://valon.tools" {
+			t.Fatalf("server.remote = %q", got)
+		}
+
+		err = ApplyServeRemoteOverrides(cfg, "", "")
 		if err == nil {
-			t.Fatal("Load: expected error, got nil")
+			t.Fatal("ApplyServeRemoteOverrides: expected error, got nil")
 		}
 		if !strings.Contains(err.Error(), "server.remoteToken is required when server.remote is set") {
 			t.Fatalf("unexpected error: %v", err)

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -734,12 +734,7 @@ func validateRuntimeConfig(cfg *Config) error {
 	if err := validateRuntimeRelayBaseURL(cfg.Server.Runtime.RelayBaseURL); err != nil {
 		return err
 	}
-	cfg.Server.Remote = strings.TrimRight(strings.TrimSpace(cfg.Server.Remote), "/")
-	cfg.Server.RemoteToken = strings.TrimSpace(cfg.Server.RemoteToken)
-	if err := validateRemoteGestaltdURL(cfg.Server.Remote); err != nil {
-		return err
-	}
-	if err := ValidateRemoteGestaltd(cfg); err != nil {
+	if err := normalizeRemoteGestaltdConfig(cfg); err != nil {
 		return err
 	}
 	for name, entry := range cfg.Runtime.Providers {
@@ -799,7 +794,16 @@ func validateRemoteGestaltdURL(raw string) error {
 	return validateHTTPOriginURL("server.remote", raw)
 }
 
-// ValidateRemoteGestaltd requires server.remoteToken when server.remote is set.
+func normalizeRemoteGestaltdConfig(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	cfg.Server.Remote = strings.TrimRight(strings.TrimSpace(cfg.Server.Remote), "/")
+	cfg.Server.RemoteToken = strings.TrimSpace(cfg.Server.RemoteToken)
+	return validateRemoteGestaltdURL(cfg.Server.Remote)
+}
+
+// ValidateRemoteGestaltd checks serve-time remote requirements.
 func ValidateRemoteGestaltd(cfg *Config) error {
 	if cfg == nil {
 		return nil
@@ -825,7 +829,10 @@ func ApplyServeRemoteOverrides(cfg *Config, remote, remoteToken string) error {
 	if remoteToken != "" {
 		cfg.Server.RemoteToken = remoteToken
 	}
-	return validateRuntimeConfig(cfg)
+	if err := normalizeRemoteGestaltdConfig(cfg); err != nil {
+		return err
+	}
+	return ValidateRemoteGestaltd(cfg)
 }
 
 func runtimeProviderUsesSource(entry *RuntimeProviderEntry) bool {

--- a/gestaltd/internal/daemon/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e_test.go
@@ -409,7 +409,7 @@ func TestRunLockSyncLayeredConfigs(t *testing.T) {
 		t.Fatalf("runSync with layered configs: %v", err)
 	}
 
-	env, err := setupBootstrapWithConfigPaths([]string{basePath, overridePath}, lockPath, artifactsDir, true, false)
+	env, err := setupBootstrapWithConfigPaths([]string{basePath, overridePath}, lockPath, artifactsDir, true, false, "", "")
 	if err != nil {
 		t.Fatalf("setupBootstrapWithConfigPaths locked layered configs: %v", err)
 	}
@@ -427,6 +427,14 @@ func TestRunServeLockedUsesOverrideLockfile(t *testing.T) {
 
 	dir := t.TempDir()
 	cfgPath := writeServeConfig(t, dir, 0)
+	cfgBytes, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	remoteCfg := strings.Replace(string(cfgBytes), "server:\n", "server:\n  remote: https://valon.tools/\n", 1)
+	if err := os.WriteFile(cfgPath, []byte(remoteCfg), 0o644); err != nil {
+		t.Fatalf("write remote config: %v", err)
+	}
 	lockPath := filepath.Join(dir, "state", "locked-serve", "gestalt.lock.json")
 	if err := runLock([]string{"--config", cfgPath, "--lockfile", lockPath}); err != nil {
 		t.Fatalf("runLock with --lockfile: %v", err)
@@ -436,11 +444,17 @@ func TestRunServeLockedUsesOverrideLockfile(t *testing.T) {
 		t.Fatalf("runSync with --lockfile: %v", err)
 	}
 
-	env, err := setupBootstrapWithConfigPaths([]string{cfgPath}, lockPath, artifactsDir, true, false)
+	env, err := setupBootstrapWithConfigPaths([]string{cfgPath}, lockPath, artifactsDir, true, false, "", "test-token")
 	if err != nil {
 		t.Fatalf("setupBootstrapWithConfigPaths locked with --lockfile: %v", err)
 	}
 	defer env.Close()
+	if got := env.Config.Server.Remote; got != "https://valon.tools" {
+		t.Fatalf("Server.Remote = %q, want https://valon.tools", got)
+	}
+	if got := env.Config.Server.RemoteToken; got != "test-token" {
+		t.Fatalf("Server.RemoteToken = %q, want test-token", got)
+	}
 	if env.Config.Apps["example"] == nil {
 		t.Fatal(`Apps["example"] = nil`)
 	}

--- a/gestaltd/internal/daemon/factories.go
+++ b/gestaltd/internal/daemon/factories.go
@@ -34,14 +34,18 @@ type bootstrapEnv struct {
 	prevLogger *slog.Logger
 }
 
-func setupBootstrapWithConfigPaths(configPaths []string, lockfilePath, artifactsDir string, locked, noSync bool, forcedDevAppKeys ...string) (*bootstrapEnv, error) {
+func setupBootstrapWithConfigPaths(configPaths []string, lockfilePath, artifactsDir string, locked, noSync bool, remote, remoteToken string, forcedDevAppKeys ...string) (*bootstrapEnv, error) {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	return setupBootstrapWithConfigPathsContext(ctx, stop, configPaths, lockfilePath, artifactsDir, locked, noSync, forcedDevAppKeys...)
+	return setupBootstrapWithConfigPathsContext(ctx, stop, configPaths, lockfilePath, artifactsDir, locked, noSync, remote, remoteToken, forcedDevAppKeys...)
 }
 
-func setupBootstrapWithConfigPathsContext(ctx context.Context, stop context.CancelFunc, configPaths []string, lockfilePath, artifactsDir string, locked, noSync bool, forcedDevAppKeys ...string) (*bootstrapEnv, error) {
+func setupBootstrapWithConfigPathsContext(ctx context.Context, stop context.CancelFunc, configPaths []string, lockfilePath, artifactsDir string, locked, noSync bool, remote, remoteToken string, forcedDevAppKeys ...string) (*bootstrapEnv, error) {
 	cfg, err := loadConfigForExecutionAtPaths(configPaths, lockfilePath, artifactsDir, locked, noSync, forcedDevAppKeys...)
 	if err != nil {
+		stop()
+		return nil, err
+	}
+	if err := config.ApplyServeRemoteOverrides(cfg, remote, remoteToken); err != nil {
 		stop()
 		return nil, err
 	}

--- a/gestaltd/internal/daemon/provider_local.go
+++ b/gestaltd/internal/daemon/provider_local.go
@@ -36,6 +36,8 @@ type providerLocalCommandOptions struct {
 	Port         int
 	Locked       bool
 	NoSync       bool
+	Remote       string
+	RemoteToken  string
 	ArtifactsDir string
 	LockfilePath string
 	// FleetOverlay is true for serve PATH arguments with --config. Validate always leaves
@@ -126,7 +128,7 @@ func runServeProviderLocal(opts providerLocalCommandOptions) error {
 	if session.Locked {
 		forcedDevAppKeys = session.DevAppKeys
 	}
-	env, err := setupBootstrapWithConfigPaths(session.ConfigPaths, session.LockfilePath, session.ArtifactsDir, session.Locked, session.NoSync, forcedDevAppKeys...)
+	env, err := setupBootstrapWithConfigPaths(session.ConfigPaths, session.LockfilePath, session.ArtifactsDir, session.Locked, session.NoSync, opts.Remote, opts.RemoteToken, forcedDevAppKeys...)
 	if err != nil {
 		return err
 	}

--- a/gestaltd/internal/daemon/run.go
+++ b/gestaltd/internal/daemon/run.go
@@ -145,18 +145,16 @@ func runServeCommand(name string, usage func(io.Writer), args []string, opts ser
 			LockfilePath:  *lockfilePath,
 			Locked:        locked,
 			NoSync:        noSync,
+			Remote:        *remoteFlag,
+			RemoteToken:   *remoteTokenFlag,
 			LockedAllowed: lockedFlag != nil,
 		})
 		if ranProviderLocal || err != nil {
 			return err
 		}
 	}
-	env, err := setupBootstrapWithConfigPaths(resolvedConfigPaths, *lockfilePath, *artifactsDir, locked, noSync)
+	env, err := setupBootstrapWithConfigPaths(resolvedConfigPaths, *lockfilePath, *artifactsDir, locked, noSync, *remoteFlag, *remoteTokenFlag)
 	if err != nil {
-		return err
-	}
-	if err := config.ApplyServeRemoteOverrides(env.Config, *remoteFlag, *remoteTokenFlag); err != nil {
-		env.Close()
 		return err
 	}
 	if err := resolveServePort(env.Config, flagIntValue(portFlag)); err != nil {
@@ -174,6 +172,8 @@ type serveProviderLocalOptions struct {
 	LockfilePath  string
 	Locked        bool
 	NoSync        bool
+	Remote        string
+	RemoteToken   string
 	LockedAllowed bool
 }
 
@@ -199,6 +199,8 @@ func maybeRunServeProviderLocal(opts serveProviderLocalOptions) (bool, error) {
 		Port:         opts.Port,
 		Locked:       opts.Locked,
 		NoSync:       opts.NoSync,
+		Remote:       opts.Remote,
+		RemoteToken:  opts.RemoteToken,
 		ArtifactsDir: opts.ArtifactsDir,
 		LockfilePath: opts.LockfilePath,
 	})
@@ -457,7 +459,6 @@ func printMainUsage(w io.Writer) {
 	writeUsageLine(w, "  gestaltd lock [--config PATH]... [--lockfile PATH] [--check]")
 	writeUsageLine(w, "  gestaltd sync [--locked] [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--parallelism N] [--cache-dir PATH] [--output-format text|json] [-v|--verbose] [--check]")
 	writeUsageLine(w, "  gestaltd serve [PATH]... [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--locked] [--no-sync] [--port PORT] [--remote URL] [--remote-token TOKEN]")
-	writeUsageLine(w, "  gestaltd serve [PATH]... [--config PATH]... [--locked] [--no-sync] [--artifacts-dir PATH] [--lockfile PATH] [--port PORT] [--remote URL] [--remote-token TOKEN]")
 	writeUsageLine(w, "  gestaltd agent <command> [flags]")
 	writeUsageLine(w, "  gestaltd provider <command> [flags]")
 	writeUsageLine(w, "  gestaltd validate [--config PATH]... [--lockfile PATH] [--platform os/arch] [--runtime]")


### PR DESCRIPTION
Keep remote token resolution at the serve boundary.

```text
config load -> serve flags -> remote validation -> bootstrap
```

Checked-in config can carry `server.remote` without committing `server.remoteToken`.
Also removes duplicate serve usage text and renames the local-placement predicate.