### PR TITLE
Simplify CLI URL and credential config

### DIFF
--- a/gestalt/cli/src/api.rs
+++ b/gestalt/cli/src/api.rs
@@ -4,9 +4,7 @@ use reqwest::StatusCode;
 use reqwest::blocking::Client;
 use reqwest::header::{self, HeaderValue};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
 use std::fmt;
-use std::path::{Path, PathBuf};
 
 use crate::config::ConfigStore;
 use crate::credentials::CredentialStore;
@@ -15,8 +13,6 @@ use crate::http;
 pub const DEFAULT_URL: &str = "http://localhost:8080";
 pub const ENV_API_KEY: &str = "GESTALT_API_KEY";
 pub const ENV_URL: &str = "GESTALT_URL";
-pub const PROJECT_CONFIG_DIR: &str = ".gestalt";
-pub const PROJECT_CONFIG_FILE: &str = ".gestalt/config.json";
 pub const AUTH_INFO_PATH: &str = "/api/v1/auth/info";
 pub const AUTH_LOGIN_PATH: &str = "/api/v1/auth/login";
 pub const AUTH_LOGIN_CALLBACK_PATH: &str = "/api/v1/auth/login/callback";
@@ -76,19 +72,6 @@ pub fn resolve_url(url_override: Option<&str>) -> Result<String> {
     }
 }
 
-pub fn resolve_url_with_fallback(
-    url_override: Option<&str>,
-    fallback_url: Option<&str>,
-) -> Result<String> {
-    match find_configured_url(url_override)? {
-        Some(url) => Ok(url),
-        None => match fallback_url {
-            Some(url) => Ok(normalize_url(url)),
-            None => bail_no_url_configured(),
-        },
-    }
-}
-
 pub fn fetch_auth_info(base_url: &str) -> Result<AuthInfo> {
     let auth_info_url = format!("{}{}", base_url.trim_end_matches('/'), AUTH_INFO_PATH);
     let client = Client::builder()
@@ -135,13 +118,6 @@ fn find_configured_url_with_source(url_override: Option<&str>) -> Result<Option<
             format!("{ENV_URL} environment variable"),
         )));
     }
-    if let Some((url, path)) = find_project_config_value("url")? {
-        return Ok(Some((
-            normalize_url(&url),
-            format!("project config ({})", path.display()),
-        )));
-    }
-
     let config_store = ConfigStore::new()?;
     match config_store.get("url")? {
         Some(url) => Ok(Some((
@@ -161,42 +137,10 @@ pub fn describe_server_config(url_override: Option<&str>) -> Option<(String, Str
 fn bail_no_url_configured() -> Result<String> {
     let config_store = ConfigStore::new()?;
     bail!(
-        "no URL configured: use --url, {}, {}, or the user-local config file at {}",
+        "no URL configured: use --url, {}, or the user-local config file at {}",
         ENV_URL,
-        PROJECT_CONFIG_FILE,
         config_store.path().display()
     )
-}
-
-fn find_project_config_value(key: &str) -> Result<Option<(String, PathBuf)>> {
-    let mut dir = std::env::current_dir().context("failed to determine current directory")?;
-    loop {
-        let candidate = dir.join(PROJECT_CONFIG_FILE);
-        if let Some(value) = read_project_config_value(&candidate, key)? {
-            return Ok(Some((value, candidate)));
-        }
-        if !dir.pop() {
-            return Ok(None);
-        }
-    }
-}
-
-fn read_project_config_value(path: &Path, key: &str) -> Result<Option<String>> {
-    if !path.exists() {
-        return Ok(None);
-    }
-    if !path.is_file() {
-        bail!(
-            "project config path {} exists but is not a file",
-            path.display()
-        );
-    }
-
-    let contents = std::fs::read_to_string(path)
-        .with_context(|| format!("failed to read project config {}", path.display()))?;
-    let map: BTreeMap<String, String> = serde_json::from_str(&contents)
-        .with_context(|| format!("failed to parse project config {}", path.display()))?;
-    Ok(map.get(key).cloned())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -267,16 +211,7 @@ impl ApiClient {
             None
         };
 
-        let base_url = match resolve_url(url_override) {
-            Ok(url) => url,
-            Err(err) => match stored_credentials
-                .as_ref()
-                .and_then(|creds| creds.api_url())
-            {
-                Some(url) => normalize_url(url),
-                None => return Err(err),
-            },
-        };
+        let base_url = resolve_url(url_override)?;
         let (token, source) = match env_api_key {
             Some(key) => (key, TokenSource::EnvVar),
             None => match stored_credentials.as_ref() {

--- a/gestalt/cli/src/commands/auth.rs
+++ b/gestalt/cli/src/commands/auth.rs
@@ -188,7 +188,6 @@ where
 
     let store = CredentialStore::new()?;
     store.save(&Credentials {
-        api_url: Some(base_url),
         api_token: token_result["token"]
             .as_str()
             .context("token response missing token field")?
@@ -232,11 +231,7 @@ pub fn logout() -> Result<()> {
     let store = CredentialStore::new()?;
     match store.load() {
         Ok(Some(creds)) => {
-            let revoke_url = creds
-                .api_url()
-                .map(str::to_owned)
-                .or_else(|| api::resolve_url(None).ok());
-            if let Some(url) = revoke_url {
+            if let Ok(url) = api::resolve_url(None) {
                 let client = ApiClient::new(&url, &creds.api_token)?;
                 if let Err(err) = client.revoke_api_token(&creds.api_token_id) {
                     output::print_warning(&format!(
@@ -246,7 +241,7 @@ pub fn logout() -> Result<()> {
                 }
             } else {
                 output::print_warning(&format!(
-                    "Stored CLI token {} has no associated URL and no configured fallback; removing it locally only.",
+                    "Stored CLI token {} has no configured server URL; removing it locally only.",
                     creds.api_token_id
                 ));
             }

--- a/gestalt/cli/src/commands/init.rs
+++ b/gestalt/cli/src/commands/init.rs
@@ -1,6 +1,6 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 
-use crate::api::{self, DEFAULT_URL, PROJECT_CONFIG_DIR, PROJECT_CONFIG_FILE};
+use crate::api::{self, DEFAULT_URL};
 use crate::commands::auth;
 use crate::config::ConfigStore;
 use crate::interactive::{InputPrompt, prompt_confirm, prompt_input};
@@ -28,16 +28,6 @@ pub fn run(url_override: Option<&str>) -> Result<()> {
         eprintln!();
         auth::login(Some(&url))?;
         eprintln!();
-    }
-
-    if prompt_confirm("Create .gestalt/config.json in current directory?", false)? {
-        let config = serde_json::json!({"url": url});
-        let json = serde_json::to_string_pretty(&config).context("failed to serialize config")?;
-        std::fs::create_dir_all(PROJECT_CONFIG_DIR)
-            .with_context(|| format!("failed to create {}", PROJECT_CONFIG_DIR))?;
-        std::fs::write(PROJECT_CONFIG_FILE, format!("{json}\n"))
-            .context("failed to write .gestalt/config.json")?;
-        output::print_success(&format!("Created {}", PROJECT_CONFIG_FILE));
     }
 
     eprintln!();

--- a/gestalt/cli/src/credentials.rs
+++ b/gestalt/cli/src/credentials.rs
@@ -6,19 +6,8 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Credentials {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub api_url: Option<String>,
     pub api_token: String,
     pub api_token_id: String,
-}
-
-impl Credentials {
-    pub fn api_url(&self) -> Option<&str> {
-        self.api_url
-            .as_deref()
-            .map(str::trim)
-            .filter(|url| !url.is_empty())
-    }
 }
 
 pub struct CredentialStore {

--- a/gestalt/cli/tests/apps_connect.rs
+++ b/gestalt/cli/tests/apps_connect.rs
@@ -607,11 +607,14 @@ fn test_cli_apps_list_table_output() {
     write_credentials(
         home.path(),
         serde_json::json!({
-            "api_url": server.url(),
             "api_token": TEST_TOKEN,
             "api_token_id": "tok-123",
         }),
     );
+    cli_command(home.path())
+        .args(["config", "set", "url", &server.url()])
+        .assert()
+        .success();
     let mock = authed_json_mock!(server, Method::GET, "/api/v1/apps", StatusCode::OK)
 		.with_body(
 			r#"[

--- a/gestalt/cli/tests/auth_flow.rs
+++ b/gestalt/cli/tests/auth_flow.rs
@@ -44,7 +44,7 @@ fn test_auth_login_stores_credentials_and_serves_browser_callback_page() {
     .unwrap();
 
     let LoginServer {
-        base_url,
+        base_url: _,
         state,
         handle,
     } = server;
@@ -68,7 +68,7 @@ fn test_auth_login_stores_credentials_and_serves_browser_callback_page() {
         .join("credentials.json");
     let credentials: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(credentials_path).unwrap()).unwrap();
-    assert_eq!(credentials["api_url"], base_url);
+    assert!(credentials.get("api_url").is_none());
     assert_eq!(credentials["api_token"], "cli-long-secret");
     assert_eq!(credentials["api_token_id"], "tok-long");
 }
@@ -96,7 +96,7 @@ fn test_auth_login_fails_when_server_auth_is_disabled() {
 }
 
 #[test]
-fn test_auth_logout_revokes_token_using_credential_url_even_when_configured_url_differs() {
+fn test_auth_logout_revokes_token_using_configured_url() {
     let mut token_server = Server::new();
     let revoke = authed_json_mock!(
         token_server,
@@ -106,20 +106,18 @@ fn test_auth_logout_revokes_token_using_credential_url_even_when_configured_url_
     )
     .with_body(r#"{"status":"ok"}"#)
     .create();
-    let wrong_server = Server::new();
 
     let home = tempfile::tempdir().unwrap();
     write_credentials(
         home.path(),
         serde_json::json!({
-            "api_url": token_server.url(),
             "api_token": TEST_TOKEN,
             "api_token_id": "tok-123",
         }),
     );
 
     cli_command(home.path())
-        .args(["config", "set", "url", &wrong_server.url()])
+        .args(["config", "set", "url", &token_server.url()])
         .assert()
         .success();
 
@@ -173,7 +171,6 @@ fn test_auth_status_reports_auth_disabled_before_stored_credentials() {
     write_credentials(
         home.path(),
         serde_json::json!({
-            "api_url": server.url(),
             "api_token": TEST_TOKEN,
             "api_token_id": "tok-123",
         }),
@@ -197,7 +194,6 @@ fn test_auth_status_reports_unreachable_server() {
     write_credentials(
         home.path(),
         serde_json::json!({
-            "api_url": "http://127.0.0.1:1",
             "api_token": TEST_TOKEN,
             "api_token_id": "tok-123",
         }),

--- a/gestalt/cli/tests/config_resolution.rs
+++ b/gestalt/cli/tests/config_resolution.rs
@@ -3,10 +3,10 @@ mod support;
 use support::*;
 
 #[test]
-fn test_cli_reuses_stored_credentials_api_url() {
+fn test_cli_ignores_legacy_stored_credentials_api_url() {
     let mut server = Server::new();
-    let _tokens = authed_json_mock!(server, Method::GET, "/api/v1/tokens", StatusCode::OK)
-        .with_body("[]")
+    let tokens = authed_json_mock!(server, Method::GET, "/api/v1/tokens", StatusCode::OK)
+        .expect(0)
         .create();
 
     let home = tempfile::tempdir().unwrap();
@@ -22,25 +22,9 @@ fn test_cli_reuses_stored_credentials_api_url() {
     cli_command(home.path())
         .args(["auth", "token", "list"])
         .assert()
-        .success();
-}
-
-#[test]
-fn test_cli_ignores_blank_stored_credentials_api_url() {
-    let home = tempfile::tempdir().unwrap();
-    write_cli_credentials(
-        home.path(),
-        &format!(
-            r#"{{"api_url":"   ","api_token":"{}","api_token_id":"tok-123"}}"#,
-            TEST_TOKEN
-        ),
-    );
-
-    cli_command(home.path())
-        .args(["auth", "token", "list"])
-        .assert()
         .failure()
         .stderr(predicate::str::contains("no URL configured"));
+    tokens.assert();
 }
 
 #[test]
@@ -87,7 +71,7 @@ fn test_cli_config_set_and_get_json() {
 }
 
 #[test]
-fn test_resolve_url_prefers_project_config_file_and_propagates_project_config_errors() {
+fn test_resolve_url_ignores_project_config_file() {
     let _lock = env_lock();
     let config_root = TempDir::new().unwrap();
     let _env = EnvGuard::new(config_root.path());
@@ -98,49 +82,29 @@ fn test_resolve_url_prefers_project_config_file_and_propagates_project_config_er
     std::fs::create_dir_all(repo_root.join(".gestalt")).unwrap();
     std::fs::create_dir_all(&nested).unwrap();
     std::fs::write(
+        repo_root.join(".gestalt.json"),
+        "{\n  \"url\": \"https://unsupported.example.com\"\n}\n",
+    )
+    .unwrap();
+    std::fs::write(
         repo_root.join(".gestalt/config.json"),
         "{\n  \"url\": \"https://project.example.com\"\n}\n",
     )
     .unwrap();
+    gestalt::config::ConfigStore::new()
+        .unwrap()
+        .set("url", "https://global.example.com")
+        .unwrap();
 
     let _cwd = CurrentDirGuard::new(&nested);
     let resolved = gestalt::api::resolve_url(Some("localhost:9999")).unwrap();
     assert_eq!(resolved, "http://localhost:9999");
 
     let resolved = gestalt::api::resolve_url(None).unwrap();
-    assert_eq!(resolved, "https://project.example.com");
+    assert_eq!(resolved, "https://global.example.com");
 
     std::fs::write(repo_root.join(".gestalt/config.json"), "{\n  invalid\n}\n").unwrap();
 
-    let err = gestalt::api::resolve_url_with_fallback(None, Some("https://fallback.example.com"))
-        .unwrap_err();
-    assert!(
-        err.to_string().contains("failed to parse project config"),
-        "{err:#}"
-    );
-}
-
-#[test]
-fn test_resolve_url_does_not_read_unsupported_dot_gestalt_json_file() {
-    let _lock = env_lock();
-    let config_root = TempDir::new().unwrap();
-    let _env = EnvGuard::new(config_root.path());
-    let workspace = TempDir::new().unwrap();
-    let repo_root = workspace.path().join("repo");
-    let nested = repo_root.join("nested");
-
-    std::fs::create_dir_all(&nested).unwrap();
-    std::fs::write(
-        repo_root.join(".gestalt.json"),
-        "{\n  \"url\": \"https://unsupported.example.com\"\n}\n",
-    )
-    .unwrap();
-
-    let mut set_cmd = cli_command(config_root.path());
-    set_cmd.args(["config", "set", "url", "https://global.example.com"]);
-    set_cmd.assert().success();
-
-    let _cwd = CurrentDirGuard::new(&nested);
     let resolved = gestalt::api::resolve_url(None).unwrap();
     assert_eq!(resolved, "https://global.example.com");
 }


### PR DESCRIPTION
Removes project-local .gestalt/config.json URL resolution and stops storing server URLs in credentials.json.

URL resolution is now only --url, GESTALT_URL, or the global config.json.

Credentials now contain token data only, while legacy api_url fields are ignored.

Updated existing CLI tests cover the new behavior.