### PR TITLE
Allow auth login with env API key

### DIFF
--- a/gestalt/cli/src/commands/auth.rs
+++ b/gestalt/cli/src/commands/auth.rs
@@ -52,11 +52,11 @@ where
     F: FnOnce(&str) -> Result<()>,
 {
     if api::env_api_key_is_set() {
-        bail!(
-            "{} is set in your environment and takes priority over stored CLI credentials. \
-             Unset it before logging in, or use the API key directly.",
+        output::print_warning(&format!(
+            "{} is set in your environment. Gestalt will prioritize it over credentials saved by this login; unset {} to use stored CLI credentials.",
             api::ENV_API_KEY,
-        );
+            api::ENV_API_KEY,
+        ));
     }
 
     let base_url = api::resolve_url(url_override)?;

--- a/gestalt/cli/tests/auth_flow.rs
+++ b/gestalt/cli/tests/auth_flow.rs
@@ -30,6 +30,9 @@ fn test_auth_login_stores_credentials_and_serves_browser_callback_page() {
     let _lock = env_lock();
     let tempdir = tempfile::tempdir().unwrap();
     let _env = EnvGuard::new(tempdir.path());
+    unsafe {
+        std::env::set_var(gestalt::api::ENV_API_KEY, "env-token");
+    }
     let server = spawn_login_server();
     let browser = Arc::new(Mutex::new(None));
     let browser_handle = Arc::clone(&browser);


### PR DESCRIPTION
Allows gestalt auth login to continue when GESTALT_API_KEY is set.

It now warns that GESTALT_API_KEY still takes precedence over the saved credentials.

The existing auth login flow test now covers login with the env var present.