### PR TITLE
gestaltd: polish remote provider client and bootstrap paths

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -928,7 +928,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	if selectedIndexedDBName == "" || def == nil {
 		return nil, fmt.Errorf("bootstrap: indexeddb resource name is required")
 	}
-	store, storeErr := buildIndexedDB(def, factories)
+	store, storeErr := buildIndexedDB(cfg, selectedIndexedDBName, def, factories, deps)
 	if storeErr != nil {
 		return nil, fmt.Errorf("bootstrap: system indexeddb from resource %q: %w", selectedIndexedDBName, storeErr)
 	}
@@ -944,19 +944,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 		if name == selectedIndexedDBName || entry == nil {
 			continue
 		}
-		if !providerBuildsLocal(cfg, entry) {
-			ds, err := indexeddbpkg.NewPublicRemote(deps.RemoteClients.IndexedDB, name)
-			if err != nil {
-				_ = svc.Close()
-				_ = closeIndexedDBs(extraIndexedDBs...)
-				return nil, fmt.Errorf("bootstrap: indexeddb from resource %q: %w", name, err)
-			}
-			ds = metricutil.InstrumentIndexedDB(ds, name)
-			indexedDBs[name] = ds
-			extraIndexedDBs = append(extraIndexedDBs, ds)
-			continue
-		}
-		ds, err := buildIndexedDB(entry, factories)
+		ds, err := buildIndexedDB(cfg, name, entry, factories, deps)
 		if err != nil {
 			_ = svc.Close()
 			_ = closeIndexedDBs(extraIndexedDBs...)
@@ -2099,9 +2087,15 @@ func resolveCallerTokenKey(ctx context.Context, sm core.SecretManager, name stri
 	return value, nil
 }
 
-func buildIndexedDB(entry *config.ProviderEntry, factories *FactoryRegistry) (indexeddb.IndexedDB, error) {
+func buildIndexedDB(cfg *config.Config, name string, entry *config.ProviderEntry, factories *FactoryRegistry, deps Deps) (indexeddb.IndexedDB, error) {
 	if entry == nil {
 		return nil, fmt.Errorf("indexeddb provider is required")
+	}
+	if !providerBuildsLocal(cfg, entry) {
+		return indexeddbpkg.NewRemote(indexeddbpkg.RemoteConfig{
+			Client: deps.RemoteClients.IndexedDB,
+			Name:   name,
+		})
 	}
 	if factories.IndexedDB == nil {
 		return nil, fmt.Errorf("indexeddb factory is not registered")

--- a/gestaltd/internal/bootstrap/executable_app_test.go
+++ b/gestaltd/internal/bootstrap/executable_app_test.go
@@ -6641,7 +6641,7 @@ func testRuntimePublicEndpointDeps(t *testing.T, deps Deps) Deps {
 			if entry == nil {
 				continue
 			}
-			db, err := buildIndexedDB(entry, &FactoryRegistry{IndexedDB: deps.IndexedDBFactory})
+			db, err := buildIndexedDB(nil, name, entry, &FactoryRegistry{IndexedDB: deps.IndexedDBFactory}, Deps{})
 			if err != nil {
 				t.Fatalf("build test indexeddb %q: %v", name, err)
 			}

--- a/gestaltd/internal/protoutil/proto.go
+++ b/gestaltd/internal/protoutil/proto.go
@@ -3,9 +3,12 @@ package protoutil
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	gproto "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -67,6 +70,23 @@ func ValueFromAny(value any) (*structpb.Value, error) {
 		return nil, err
 	}
 	return structpb.NewValue(normalized)
+}
+
+// SetProviderNameIfEmpty sets provider_name on a protobuf request when absent.
+func SetProviderNameIfEmpty(req gproto.Message, name string) {
+	name = strings.TrimSpace(name)
+	if req == nil || name == "" {
+		return
+	}
+	msg := req.ProtoReflect()
+	field := msg.Descriptor().Fields().ByName("provider_name")
+	if field == nil || field.Kind() != protoreflect.StringKind {
+		return
+	}
+	if strings.TrimSpace(msg.Get(field).String()) != "" {
+		return
+	}
+	msg.Set(field, protoreflect.ValueOfString(name))
 }
 
 func normalizeStructMap(values map[string]any) (map[string]any, error) {

--- a/gestaltd/services/agents/client.go
+++ b/gestaltd/services/agents/client.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
+	"github.com/valon-technologies/gestalt/server/internal/protoutil"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"github.com/valon-technologies/gestalt/server/services/appaccess"
 	"github.com/valon-technologies/gestalt/server/services/egress"
@@ -300,27 +301,11 @@ func cloneAgentRequest[T interface {
 	return gproto.Clone(req).(T)
 }
 
-func setProviderNameIfEmpty(req gproto.Message, name string) {
-	name = strings.TrimSpace(name)
-	if req == nil || name == "" {
-		return
-	}
-	msg := req.ProtoReflect()
-	field := msg.Descriptor().Fields().ByName("provider_name")
-	if field == nil || field.Kind() != protoreflect.StringKind {
-		return
-	}
-	if strings.TrimSpace(msg.Get(field).String()) != "" {
-		return
-	}
-	msg.Set(field, protoreflect.ValueOfString(name))
-}
-
 func attachAgentProviderRequestContext(ctx context.Context, req gproto.Message, providerName string) error {
 	if req == nil {
 		return nil
 	}
-	setProviderNameIfEmpty(req, providerName)
+	protoutil.SetProviderNameIfEmpty(req, providerName)
 	reqCtx, err := appaccess.RequestContextProto(ctx, "", invocation.CallerProvider{})
 	if err != nil {
 		return err

--- a/gestaltd/services/apps/provider_client.go
+++ b/gestaltd/services/apps/provider_client.go
@@ -58,7 +58,7 @@ type integrationProviderSupport struct {
 	sessionCatalog bool
 }
 
-// RemoteProviderOption configures a remote provider returned by NewRemoteProvider.
+// RemoteProviderOption configures a remote provider returned by NewRemote.
 type RemoteProviderOption func(*remoteProviderBase)
 
 // WithCloser attaches a closer that is called when the provider is closed.
@@ -106,10 +106,6 @@ func NewRemote(ctx context.Context, client proto.AppProviderClient, spec StaticP
 	}
 
 	return base, nil
-}
-
-func NewRemoteProvider(ctx context.Context, client proto.AppProviderClient, spec StaticProviderSpec, config map[string]any, opts ...RemoteProviderOption) (core.Provider, error) {
-	return NewRemote(ctx, client, spec, config, opts...)
 }
 
 func getAppProviderSupportWithRetry(ctx context.Context, client proto.AppProviderClient) (*integrationProviderSupport, error) {

--- a/gestaltd/services/apps/provider_test.go
+++ b/gestaltd/services/apps/provider_test.go
@@ -168,9 +168,9 @@ func TestRemoteProviderRoundTrip(t *testing.T) {
 	t.Parallel()
 
 	client := newAppProviderClient(t, NewProviderServer(&roundTripProvider{}))
-	prov, err := NewRemoteProvider(context.Background(), client, roundTripStaticSpec(), nil, WithHostContext(" https://gestalt.example.test/ "))
+	prov, err := NewRemote(context.Background(), client, roundTripStaticSpec(), nil, WithHostContext(" https://gestalt.example.test/ "))
 	if err != nil {
-		t.Fatalf("NewRemoteProvider: %v", err)
+		t.Fatalf("NewRemote: %v", err)
 	}
 
 	if prov.Name() != "roundtrip" {
@@ -656,9 +656,9 @@ func TestRemoteProviderManualAuthOnly(t *testing.T) {
 	t.Parallel()
 
 	client := newAppProviderClient(t, &unsupportedCapabilityProviderServer{})
-	prov, err := NewRemoteProvider(context.Background(), client, manualOnlyStaticSpec(), nil)
+	prov, err := NewRemote(context.Background(), client, manualOnlyStaticSpec(), nil)
 	if err != nil {
-		t.Fatalf("NewRemoteProvider: %v", err)
+		t.Fatalf("NewRemote: %v", err)
 	}
 
 	if got := prov.AuthTypes(); len(got) != 1 || got[0] != "manual" {
@@ -751,9 +751,9 @@ func TestRemoteProviderUnsupportedCapabilitiesDoNotDispatchRPCs(t *testing.T) {
 			t.Parallel()
 
 			server := &unsupportedCapabilityProviderServer{metadataErr: tc.metadataErr}
-			prov, err := NewRemoteProvider(context.Background(), newAppProviderClient(t, server), manualOnlyStaticSpec(), nil)
+			prov, err := NewRemote(context.Background(), newAppProviderClient(t, server), manualOnlyStaticSpec(), nil)
 			if err != nil {
-				t.Fatalf("NewRemoteProvider: %v", err)
+				t.Fatalf("NewRemote: %v", err)
 			}
 			if _, ok := prov.(core.SessionCatalogProvider); !ok {
 				t.Fatal("expected remote provider to implement SessionCatalogProvider")
@@ -785,16 +785,16 @@ func TestRemoteProviderUnsupportedCapabilitiesDoNotDispatchRPCs(t *testing.T) {
 	}
 }
 
-func TestNewRemoteProviderLabelsMetadataFailures(t *testing.T) {
+func TestNewRemoteLabelsMetadataFailures(t *testing.T) {
 	t.Parallel()
 
 	client := newAppProviderClient(t, &metadataFailureProviderServer{})
-	_, err := NewRemoteProvider(context.Background(), client, roundTripStaticSpec(), nil)
+	_, err := NewRemote(context.Background(), client, roundTripStaticSpec(), nil)
 	if err == nil {
-		t.Fatal("expected NewRemoteProvider to fail")
+		t.Fatal("expected NewRemote to fail")
 	}
 	if got := err.Error(); got != `get provider metadata: rpc error: code = Unknown desc = provider metadata: metadata exploded` {
-		t.Fatalf("NewRemoteProvider error = %q", got)
+		t.Fatalf("NewRemote error = %q", got)
 	}
 }
 

--- a/gestaltd/services/indexeddb/client.go
+++ b/gestaltd/services/indexeddb/client.go
@@ -100,17 +100,21 @@ func (r *remoteIndexedDB) DeleteIndex(ctx context.Context, store, name string) e
 	return manager.DeleteIndex(ctx, store, name)
 }
 
-// NewPublicRemote returns an IndexedDB provider backed by a remote public gestaltd API.
-func NewPublicRemote(client proto.IndexedDBClient, name string) (coreindexeddb.IndexedDB, error) {
-	name = strings.TrimSpace(name)
-	if client == nil {
+type RemoteConfig struct {
+	Client proto.IndexedDBClient
+	Name   string
+}
+
+func NewRemote(cfg RemoteConfig) (coreindexeddb.IndexedDB, error) {
+	name := strings.TrimSpace(cfg.Name)
+	if cfg.Client == nil {
 		return nil, status.Error(codes.InvalidArgument, "indexeddb provider client is required")
 	}
 	if name == "" {
 		return nil, status.Error(codes.InvalidArgument, "indexeddb provider name is required")
 	}
 	return &remoteIndexedDB{
-		Database: rpcidb.NewClient(client, rpcidb.Options{
+		Database: rpcidb.NewClient(cfg.Client, rpcidb.Options{
 			UnaryTimeout: runtimehost.ProviderRPCTimeout,
 			Binding:      name,
 		}),

--- a/gestaltd/services/workflows/client.go
+++ b/gestaltd/services/workflows/client.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+	"github.com/valon-technologies/gestalt/server/internal/protoutil"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	appaccessservice "github.com/valon-technologies/gestalt/server/services/appaccess"
 	"github.com/valon-technologies/gestalt/server/services/egress"
@@ -97,10 +98,9 @@ func NewRemote(ctx context.Context, cfg RemoteConfig) (coreworkflow.Provider, er
 
 func (r *remoteWorkflow) ApplyDefinition(ctx context.Context, req *proto.ApplyWorkflowProviderDefinitionRequest) (definition *proto.WorkflowDefinition, err error) {
 	req = cloneWorkflowRequest(req, &proto.ApplyWorkflowProviderDefinitionRequest{}).(*proto.ApplyWorkflowProviderDefinitionRequest)
-	req.ProviderName = r.name
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationApplyDefinition, workflowDims{targetKind: workflowProtoTargetKind(req.GetSpec().GetTarget())})
 	defer func() { end(err) }()
-	ctx, cancel, err := workflowProviderRequestContext(ctx, req)
+	ctx, cancel, err := workflowProviderRequestContext(ctx, req, r.name)
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +112,7 @@ func (r *remoteWorkflow) GetDefinition(ctx context.Context, req *proto.GetWorkfl
 	req = cloneWorkflowRequest(req, &proto.GetWorkflowProviderDefinitionRequest{}).(*proto.GetWorkflowProviderDefinitionRequest)
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationGetDefinition, workflowDims{})
 	defer func() { end(err) }()
-	ctx, cancel, err := workflowProviderRequestContext(ctx, req)
+	ctx, cancel, err := workflowProviderRequestContext(ctx, req, r.name)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +124,7 @@ func (r *remoteWorkflow) ListDefinitions(ctx context.Context, req *proto.ListWor
 	req = cloneWorkflowRequest(req, &proto.ListWorkflowProviderDefinitionsRequest{}).(*proto.ListWorkflowProviderDefinitionsRequest)
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationListDefinitions, workflowDims{})
 	defer func() { end(err) }()
-	ctx, cancel, err := workflowProviderRequestContext(ctx, req)
+	ctx, cancel, err := workflowProviderRequestContext(ctx, req, r.name)
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +136,7 @@ func (r *remoteWorkflow) SetDefinitionPaused(ctx context.Context, req *proto.Set
 	req = cloneWorkflowRequest(req, &proto.SetWorkflowProviderDefinitionPausedRequest{}).(*proto.SetWorkflowProviderDefinitionPausedRequest)
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationSetDefinitionPaused, workflowDims{})
 	defer func() { end(err) }()
-	ctx, cancel, err := workflowProviderRequestContext(ctx, req)
+	ctx, cancel, err := workflowProviderRequestContext(ctx, req, r.name)
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +148,7 @@ func (r *remoteWorkflow) SetActivationPaused(ctx context.Context, req *proto.Set
 	req = cloneWorkflowRequest(req, &proto.SetWorkflowProviderActivationPausedRequest{}).(*proto.SetWorkflowProviderActivationPausedRequest)
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationSetActivationPaused, workflowDims{})
 	defer func() { end(err) }()
-	ctx, cancel, err := workflowProviderRequestContext(ctx, req)
+	ctx, cancel, err := workflowProviderRequestContext(ctx, req, r.name)
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +160,7 @@ func (r *remoteWorkflow) DeleteDefinition(ctx context.Context, req *proto.Delete
 	req = cloneWorkflowRequest(req, &proto.DeleteWorkflowProviderDefinitionRequest{}).(*proto.DeleteWorkflowProviderDefinitionRequest)
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationDeleteDefinition, workflowDims{})
 	defer func() { end(err) }()
-	ctx, cancel, err := workflowProviderRequestContext(ctx, req)
+	ctx, cancel, err := workflowProviderRequestContext(ctx, req, r.name)
 	if err != nil {
 		return err
 	}
@@ -171,10 +171,9 @@ func (r *remoteWorkflow) DeleteDefinition(ctx context.Context, req *proto.Delete
 
 func (r *remoteWorkflow) StartRun(ctx context.Context, req *proto.StartWorkflowProviderRunRequest) (run *proto.WorkflowRun, err error) {
 	req = cloneWorkflowRequest(req, &proto.StartWorkflowProviderRunRequest{}).(*proto.StartWorkflowProviderRunRequest)
-	req.ProviderName = r.name
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationStartRun, workflowDims{triggerKind: observability.WorkflowTriggerKindManual})
 	defer func() { end(err) }()
-	ctx, cancel, err := workflowProviderRequestContext(ctx, req)
+	ctx, cancel, err := workflowProviderRequestContext(ctx, req, r.name)
 	if err != nil {
 		return nil, err
 	}
@@ -197,7 +196,7 @@ func (r *remoteWorkflow) GetRun(ctx context.Context, req *proto.GetWorkflowProvi
 	req = cloneWorkflowRequest(req, &proto.GetWorkflowProviderRunRequest{}).(*proto.GetWorkflowProviderRunRequest)
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationGetRun, workflowDims{})
 	defer func() { end(err) }()
-	ctx, cancel, err := workflowProviderRequestContext(ctx, req)
+	ctx, cancel, err := workflowProviderRequestContext(ctx, req, r.name)
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +208,7 @@ func (r *remoteWorkflow) ListRuns(ctx context.Context, req *proto.ListWorkflowPr
 	req = cloneWorkflowRequest(req, &proto.ListWorkflowProviderRunsRequest{}).(*proto.ListWorkflowProviderRunsRequest)
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationListRuns, workflowDims{})
 	defer func() { end(err) }()
-	ctx, cancel, err := workflowProviderRequestContext(ctx, req)
+	ctx, cancel, err := workflowProviderRequestContext(ctx, req, r.name)
 	if err != nil {
 		return nil, err
 	}
@@ -221,7 +220,7 @@ func (r *remoteWorkflow) GetRunEvents(ctx context.Context, req *proto.GetWorkflo
 	req = cloneWorkflowRequest(req, &proto.GetWorkflowProviderRunEventsRequest{}).(*proto.GetWorkflowProviderRunEventsRequest)
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationGetRunEvents, workflowDims{})
 	defer func() { end(err) }()
-	ctx, cancel, err := workflowProviderRequestContext(ctx, req)
+	ctx, cancel, err := workflowProviderRequestContext(ctx, req, r.name)
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +232,7 @@ func (r *remoteWorkflow) GetRunOutput(ctx context.Context, req *proto.GetWorkflo
 	req = cloneWorkflowRequest(req, &proto.GetWorkflowProviderRunOutputRequest{}).(*proto.GetWorkflowProviderRunOutputRequest)
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationGetRunOutput, workflowDims{})
 	defer func() { end(err) }()
-	ctx, cancel, err := workflowProviderRequestContext(ctx, req)
+	ctx, cancel, err := workflowProviderRequestContext(ctx, req, r.name)
 	if err != nil {
 		return nil, err
 	}
@@ -245,7 +244,7 @@ func (r *remoteWorkflow) CancelRun(ctx context.Context, req *proto.CancelWorkflo
 	req = cloneWorkflowRequest(req, &proto.CancelWorkflowProviderRunRequest{}).(*proto.CancelWorkflowProviderRunRequest)
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationCancelRun, workflowDims{})
 	defer func() { end(err) }()
-	ctx, cancel, err := workflowProviderRequestContext(ctx, req)
+	ctx, cancel, err := workflowProviderRequestContext(ctx, req, r.name)
 	if err != nil {
 		return nil, err
 	}
@@ -257,7 +256,7 @@ func (r *remoteWorkflow) SignalRun(ctx context.Context, req *proto.SignalWorkflo
 	req = cloneWorkflowRequest(req, &proto.SignalWorkflowProviderRunRequest{}).(*proto.SignalWorkflowProviderRunRequest)
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationSignalRun, workflowDims{triggerKind: observability.WorkflowTriggerKindSignal})
 	defer func() { end(err) }()
-	ctx, cancel, err := workflowProviderRequestContext(ctx, req)
+	ctx, cancel, err := workflowProviderRequestContext(ctx, req, r.name)
 	if err != nil {
 		return nil, err
 	}
@@ -267,10 +266,9 @@ func (r *remoteWorkflow) SignalRun(ctx context.Context, req *proto.SignalWorkflo
 
 func (r *remoteWorkflow) SignalOrStartRun(ctx context.Context, req *proto.SignalOrStartWorkflowProviderRunRequest) (out *proto.SignalWorkflowRunResponse, err error) {
 	req = cloneWorkflowRequest(req, &proto.SignalOrStartWorkflowProviderRunRequest{}).(*proto.SignalOrStartWorkflowProviderRunRequest)
-	req.ProviderName = r.name
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationSignalOrStartRun, workflowDims{triggerKind: observability.WorkflowTriggerKindSignal})
 	defer func() { end(err) }()
-	ctx, cancel, err := workflowProviderRequestContext(ctx, req)
+	ctx, cancel, err := workflowProviderRequestContext(ctx, req, r.name)
 	if err != nil {
 		return nil, err
 	}
@@ -292,14 +290,13 @@ func (r *remoteWorkflow) SignalOrStartRun(ctx context.Context, req *proto.Signal
 
 func (r *remoteWorkflow) DeliverEvent(ctx context.Context, req *proto.DeliverWorkflowProviderEventRequest) (out *proto.WorkflowEvent, err error) {
 	req = cloneWorkflowRequest(req, &proto.DeliverWorkflowProviderEventRequest{}).(*proto.DeliverWorkflowProviderEventRequest)
-	req.ProviderName = r.name
 	ctx, end := r.startProviderOperation(ctx, observability.WorkflowOperationDeliverEvent, workflowDims{triggerKind: observability.WorkflowTriggerKindEvent})
 	metricCtx := ctx
 	defer func() {
 		end(err)
 		observability.RecordWorkflowEventDelivered(metricCtx, err, r.workflowMetricDims(observability.WorkflowOperationDeliverEvent, workflowDims{triggerKind: observability.WorkflowTriggerKindEvent}))
 	}()
-	ctx, cancel, err := workflowProviderRequestContext(ctx, req)
+	ctx, cancel, err := workflowProviderRequestContext(ctx, req, r.name)
 	if err != nil {
 		return nil, err
 	}
@@ -371,8 +368,8 @@ func workflowProtoTargetKind(target *proto.BoundWorkflowTarget) string {
 	return observability.WorkflowTargetKindUnknown
 }
 
-func workflowProviderRequestContext(ctx context.Context, req gproto.Message) (context.Context, context.CancelFunc, error) {
-	if err := attachWorkflowProviderRequestContext(ctx, req); err != nil {
+func workflowProviderRequestContext(ctx context.Context, req gproto.Message, providerName string) (context.Context, context.CancelFunc, error) {
+	if err := attachWorkflowProviderRequestContext(ctx, req, providerName); err != nil {
 		cancelCtx, cancel := context.WithCancel(ctx)
 		return cancelCtx, cancel, err
 	}
@@ -387,10 +384,11 @@ func cloneWorkflowRequest(req gproto.Message, empty gproto.Message) gproto.Messa
 	return gproto.Clone(req)
 }
 
-func attachWorkflowProviderRequestContext(ctx context.Context, req gproto.Message) error {
+func attachWorkflowProviderRequestContext(ctx context.Context, req gproto.Message, providerName string) error {
 	if req == nil {
 		return nil
 	}
+	protoutil.SetProviderNameIfEmpty(req, providerName)
 	reqCtx, err := appaccessservice.RequestContextProto(ctx, "", invocation.CallerProvider{})
 	if err != nil {
 		return err


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up polish after #2673 and #2689.

## Summary

- **IndexedDB bootstrap**: remote routing moves into `buildIndexedDB` (same pattern as `buildAgent` / `buildWorkflow`); `prepareCore` loop no longer special-cases remote
- **`provider_name` stamping**: shared `protoutil.SetProviderNameIfEmpty` used by agent and workflow remote clients; removes manual `req.ProviderName = r.name` assignments
- **IndexedDB API**: `NewPublicRemote` → `NewRemote` + `RemoteConfig` (matches agent/workflow naming)
- **Apps API**: drop `NewRemoteProvider` alias; tests call `NewRemote` directly

**Net: −3 lines**, consistent remote-provider patterns across provider kinds.

## Test plan

- [x] `go test ./internal/bootstrap/... ./services/agents/... ./services/workflows/... ./services/indexeddb/... ./services/apps/...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7241af1-bdc5-4758-88cc-cc265a7a3c61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7241af1-bdc5-4758-88cc-cc265a7a3c61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

