### PR TITLE
Prepare gestalt CLI 0.0.2-alpha.8 release

### DIFF
--- a/gestalt/Cargo.toml
+++ b/gestalt/Cargo.toml
@@ -3,5 +3,5 @@ resolver = "2"
 members = ["cli"]
 
 [workspace.package]
-version = "0.0.2-alpha.7"
+version = "0.0.2-alpha.8"
 edition = "2024"

--- a/gestaltd/services/identity/principal/resolver.go
+++ b/gestaltd/services/identity/principal/resolver.go
@@ -55,7 +55,6 @@ func (r *Resolver) ResolveToken(ctx context.Context, token string) (*Principal, 
 		if _, _, ok := core.ParseSubjectID(subject); !ok {
 			return nil, ErrInvalidToken
 		}
-		resp.Subject = subject
 		return r.enrichPrincipalWithUserInfo(ctx, token, principalFromIntrospection(resp)), nil
 	}
 	return nil, ErrInvalidToken


### PR DESCRIPTION
Bumps `gestalt` CLI to `0.0.2-alpha.8`.

After merge, push `gestalt/v0.0.2-alpha.8` to publish GitHub Release and Homebrew.

Docker will be published manually from `gestalt/Dockerfile` for the same version tag.