### PR TITLE
[codex] Resolve gestaltd remote token defaults

### DIFF
--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -4988,11 +4988,20 @@ server:
 }
 
 func TestLoadConfigRemoteGestaltd(t *testing.T) {
-	t.Parallel()
+	loadRemoteConfigForServe := func(t *testing.T) (*Config, error) {
+		t.Helper()
+		path := mustWriteConfigFile(t, `
+server:
+  remote: https://valon.tools
+`)
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		return cfg, ApplyServeRemoteOverrides(cfg, "", "")
+	}
 
 	t.Run("accepts and trims remote url", func(t *testing.T) {
-		t.Parallel()
-
 		path := mustWriteConfigFile(t, `
 server:
   remote: https://valon.tools/
@@ -5012,8 +5021,6 @@ server:
 	})
 
 	t.Run("rejects remote url with path", func(t *testing.T) {
-		t.Parallel()
-
 		path := mustWriteConfigFile(t, `
 server:
   remote: https://valon.tools/api
@@ -5029,23 +5036,47 @@ server:
 		}
 	})
 
-	t.Run("allows remote without token before serve", func(t *testing.T) {
-		t.Parallel()
+	t.Run("fills remote token from env before serve", func(t *testing.T) {
+		t.Setenv("GESTALT_API_KEY", "env-token")
 
-		path := mustWriteConfigFile(t, `
-server:
-  remote: https://valon.tools
-`)
-
-		cfg, err := Load(path)
+		cfg, err := loadRemoteConfigForServe(t)
 		if err != nil {
-			t.Fatalf("Load: %v", err)
+			t.Fatalf("ApplyServeRemoteOverrides: %v", err)
 		}
+		if got := cfg.Server.RemoteToken; got != "env-token" {
+			t.Fatalf("server.remoteToken = %q, want env-token", got)
+		}
+	})
+
+	t.Run("fills remote token from stored credentials before serve", func(t *testing.T) {
+		t.Setenv("GESTALT_API_KEY", "")
+		xdg := t.TempDir()
+		t.Setenv("XDG_CONFIG_HOME", xdg)
+		credentialsDir := filepath.Join(xdg, "gestalt")
+		if err := os.MkdirAll(credentialsDir, 0o755); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(credentialsDir, "credentials.json"), []byte(`{"api_token":"stored-token","api_token_id":"tok_1"}`), 0o600); err != nil {
+			t.Fatalf("WriteFile credentials: %v", err)
+		}
+
+		cfg, err := loadRemoteConfigForServe(t)
+		if err != nil {
+			t.Fatalf("ApplyServeRemoteOverrides: %v", err)
+		}
+		if got := cfg.Server.RemoteToken; got != "stored-token" {
+			t.Fatalf("server.remoteToken = %q, want stored-token", got)
+		}
+	})
+
+	t.Run("requires token before serve when no default exists", func(t *testing.T) {
+		t.Setenv("GESTALT_API_KEY", "")
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+		cfg, err := loadRemoteConfigForServe(t)
 		if got := cfg.Server.Remote; got != "https://valon.tools" {
 			t.Fatalf("server.remote = %q", got)
 		}
-
-		err = ApplyServeRemoteOverrides(cfg, "", "")
 		if err == nil {
 			t.Fatal("ApplyServeRemoteOverrides: expected error, got nil")
 		}

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -5038,52 +5038,53 @@ server:
 		}
 	})
 
-	t.Run("fills remote token from env before serve", func(t *testing.T) {
-		t.Setenv("GESTALT_API_KEY", "env-token")
+	t.Run("resolves default remote token before serve", func(t *testing.T) {
+		for _, tc := range []struct {
+			name        string
+			envToken    string
+			storedToken string
+			wantToken   string
+			wantErr     string
+		}{
+			{name: "env", envToken: "env-token", wantToken: "env-token"},
+			{name: "stored credentials", storedToken: "stored-token", wantToken: "stored-token"},
+			{name: "missing", wantErr: "server.remoteToken is required when server.remote is set"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Setenv("GESTALT_API_KEY", tc.envToken)
+				xdg := t.TempDir()
+				t.Setenv("XDG_CONFIG_HOME", xdg)
+				if tc.storedToken != "" {
+					credentialsDir := filepath.Join(xdg, "gestalt")
+					if err := os.MkdirAll(credentialsDir, 0o755); err != nil {
+						t.Fatalf("MkdirAll: %v", err)
+					}
+					credentials := fmt.Sprintf(`{"api_token":%q,"api_token_id":"tok_1"}`, tc.storedToken)
+					if err := os.WriteFile(filepath.Join(credentialsDir, "credentials.json"), []byte(credentials), 0o600); err != nil {
+						t.Fatalf("WriteFile credentials: %v", err)
+					}
+				}
 
-		cfg, err := loadRemoteConfigForServe(t)
-		if err != nil {
-			t.Fatalf("ApplyServeRemoteOverrides: %v", err)
-		}
-		if got := cfg.Server.RemoteToken; got != "env-token" {
-			t.Fatalf("server.remoteToken = %q, want env-token", got)
-		}
-	})
-
-	t.Run("fills remote token from stored credentials before serve", func(t *testing.T) {
-		t.Setenv("GESTALT_API_KEY", "")
-		xdg := t.TempDir()
-		t.Setenv("XDG_CONFIG_HOME", xdg)
-		credentialsDir := filepath.Join(xdg, "gestalt")
-		if err := os.MkdirAll(credentialsDir, 0o755); err != nil {
-			t.Fatalf("MkdirAll: %v", err)
-		}
-		if err := os.WriteFile(filepath.Join(credentialsDir, "credentials.json"), []byte(`{"api_token":"stored-token","api_token_id":"tok_1"}`), 0o600); err != nil {
-			t.Fatalf("WriteFile credentials: %v", err)
-		}
-
-		cfg, err := loadRemoteConfigForServe(t)
-		if err != nil {
-			t.Fatalf("ApplyServeRemoteOverrides: %v", err)
-		}
-		if got := cfg.Server.RemoteToken; got != "stored-token" {
-			t.Fatalf("server.remoteToken = %q, want stored-token", got)
-		}
-	})
-
-	t.Run("requires token before serve when no default exists", func(t *testing.T) {
-		t.Setenv("GESTALT_API_KEY", "")
-		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-
-		cfg, err := loadRemoteConfigForServe(t)
-		if got := cfg.Server.Remote; got != "https://valon.tools" {
-			t.Fatalf("server.remote = %q", got)
-		}
-		if err == nil {
-			t.Fatal("ApplyServeRemoteOverrides: expected error, got nil")
-		}
-		if !strings.Contains(err.Error(), "server.remoteToken is required when server.remote is set") {
-			t.Fatalf("unexpected error: %v", err)
+				cfg, err := loadRemoteConfigForServe(t)
+				if got := cfg.Server.Remote; got != "https://valon.tools" {
+					t.Fatalf("server.remote = %q", got)
+				}
+				if tc.wantErr != "" {
+					if err == nil {
+						t.Fatal("ApplyServeRemoteOverrides: expected error, got nil")
+					}
+					if !strings.Contains(err.Error(), tc.wantErr) {
+						t.Fatalf("unexpected error: %v", err)
+					}
+					return
+				}
+				if err != nil {
+					t.Fatalf("ApplyServeRemoteOverrides: %v", err)
+				}
+				if got := cfg.Server.RemoteToken; got != tc.wantToken {
+					t.Fatalf("server.remoteToken = %q, want %q", got, tc.wantToken)
+				}
+			})
 		}
 	})
 }

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -5002,6 +5002,7 @@ server:
 	}
 
 	t.Run("accepts and trims remote url", func(t *testing.T) {
+		t.Parallel()
 		path := mustWriteConfigFile(t, `
 server:
   remote: https://valon.tools/
@@ -5021,6 +5022,7 @@ server:
 	})
 
 	t.Run("rejects remote url with path", func(t *testing.T) {
+		t.Parallel()
 		path := mustWriteConfigFile(t, `
 server:
   remote: https://valon.tools/api

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"net"
 	"net/url"
+	"os"
 	"path"
 	"path/filepath"
 	"slices"
@@ -832,7 +833,48 @@ func ApplyServeRemoteOverrides(cfg *Config, remote, remoteToken string) error {
 	if err := normalizeRemoteGestaltdConfig(cfg); err != nil {
 		return err
 	}
+	if strings.TrimSpace(cfg.Server.Remote) != "" && strings.TrimSpace(cfg.Server.RemoteToken) == "" {
+		token, err := defaultRemoteToken()
+		if err != nil {
+			return err
+		}
+		cfg.Server.RemoteToken = token
+	}
 	return ValidateRemoteGestaltd(cfg)
+}
+
+func defaultRemoteToken() (string, error) {
+	if token := strings.TrimSpace(os.Getenv("GESTALT_API_KEY")); token != "" {
+		return token, nil
+	}
+	path := gestaltCredentialsPath()
+	if path == "" {
+		return "", nil
+	}
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("config validation: read Gestalt credentials: %w", err)
+	}
+	var creds struct {
+		APIToken string `json:"api_token"`
+	}
+	if err := json.Unmarshal(data, &creds); err != nil {
+		return "", fmt.Errorf("config validation: parse Gestalt credentials: %w", err)
+	}
+	return strings.TrimSpace(creds.APIToken), nil
+}
+
+func gestaltCredentialsPath() string {
+	if xdg := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")); xdg != "" {
+		return filepath.Join(xdg, "gestalt", "credentials.json")
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		return filepath.Join(home, ".config", "gestalt", "credentials.json")
+	}
+	return ""
 }
 
 func runtimeProviderUsesSource(entry *RuntimeProviderEntry) bool {


### PR DESCRIPTION
Resolves remote tokens from `GESTALT_API_KEY`, then CLI `credentials.json`, when no `server.remoteToken` is set. Validation: `go test ./internal/config -run TestLoadConfigRemoteGestaltd`, `go test ./internal/bootstrap`, `go test ./internal/server`.

```mermaid
stateDiagram-v2
    state "--remote-token" as TokenFlag
    state "server.remoteToken" as TokenConfig
    state "GESTALT_API_KEY" as EnvToken
    state "Success" as Success
    state "Failure" as FailNoToken

    TokenFlag --> Success: present
    TokenFlag --> TokenConfig: missing
    TokenConfig --> Success: present
    TokenConfig --> EnvToken: missing
    EnvToken --> Success: present
    EnvToken --> FailNoToken: missing
```