### PR TITLE
Refactor remote routing tests to reuse existing infrastructure

### DIFF
--- a/gestaltd/internal/bootstrap/provider_build_test.go
+++ b/gestaltd/internal/bootstrap/provider_build_test.go
@@ -14,18 +14,25 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/valon-technologies/gestalt/server/core"
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/remote"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/agents/agentmanager"
 	"github.com/valon-technologies/gestalt/server/services/apps/declarative"
+	"github.com/valon-technologies/gestalt/server/services/apps/registry"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"gopkg.in/yaml.v3"
 )
 
@@ -623,5 +630,273 @@ func TestMCPAllowedOperationsForSpecCompositeOmitsMCPWhenNoMCPAllowlistEntries(t
 	}
 	if filtered != nil {
 		t.Fatalf("filtered allowedOperations = %#v, want nil", filtered)
+	}
+}
+
+type recordingRemoteAppClient struct {
+	mu    sync.Mutex
+	calls []remoteAppInvokeCall
+	err   error
+}
+
+type remoteAppInvokeCall struct {
+	app       string
+	operation string
+}
+
+func (c *recordingRemoteAppClient) Invoke(_ context.Context, req *proto.AppInvokeRequest, _ ...grpc.CallOption) (*proto.OperationResult, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.err != nil {
+		return nil, c.err
+	}
+	c.calls = append(c.calls, remoteAppInvokeCall{
+		app:       req.GetApp(),
+		operation: req.GetOperation(),
+	})
+	return &proto.OperationResult{Status: 202, Body: []byte("relayed")}, nil
+}
+
+func (c *recordingRemoteAppClient) InvokeGraphQL(context.Context, *proto.AppInvokeGraphQLRequest, ...grpc.CallOption) (*proto.OperationResult, error) {
+	return nil, status.Error(codes.Unimplemented, "unimplemented")
+}
+
+func (c *recordingRemoteAppClient) snapshot() []remoteAppInvokeCall {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]remoteAppInvokeCall, len(c.calls))
+	copy(out, c.calls)
+	return out
+}
+
+func remoteRoutingAppEntry(t *testing.T, name string, operations ...string) *config.ProviderEntry {
+	t.Helper()
+	catalogOps := make([]catalog.CatalogOperation, len(operations))
+	for i, op := range operations {
+		catalogOps[i] = catalog.CatalogOperation{ID: op}
+	}
+	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
+		Name:       name,
+		Operations: catalogOps,
+	})
+	return &config.ProviderEntry{
+		ResolvedManifest:     newExecutableManifest(name, name),
+		ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+	}
+}
+
+func remoteRoutingConfig(t *testing.T, localDevActive map[string]bool) *config.Config {
+	t.Helper()
+	apps := map[string]*config.ProviderEntry{
+		"linear":        remoteRoutingAppEntry(t, "linear", "issues.list"),
+		"valon-profile": remoteRoutingAppEntry(t, "valon-profile", "issues.list"),
+		"ci-cd":         remoteRoutingAppEntry(t, "ci-cd", "ping"),
+	}
+	for name, active := range localDevActive {
+		if entry := apps[name]; entry != nil {
+			entry.DevActive = active
+		}
+	}
+	return &config.Config{
+		Server: config.ServerConfig{Remote: "https://remote.test"},
+		Apps:   apps,
+	}
+}
+
+func localRoutingAppStub(name string) *coretesting.StubIntegration {
+	return &coretesting.StubIntegration{
+		N:        name,
+		ConnMode: core.ConnectionModeNone,
+		CatalogVal: &catalog.Catalog{
+			Operations: []catalog.CatalogOperation{{ID: "ping"}},
+		},
+		ExecuteFn: func(context.Context, string, map[string]any, string) (*core.OperationResult, error) {
+			return &core.OperationResult{Status: 201, Body: []byte("local")}, nil
+		},
+	}
+}
+
+func newRemoteRoutingBroker(t *testing.T, cfg *config.Config, remoteApp proto.AppClient, localApps ...core.Provider) *invocation.Broker {
+	t.Helper()
+	reg := registry.New()
+	for _, provider := range localApps {
+		if err := reg.Providers.Register(provider.Name(), provider); err != nil {
+			t.Fatalf("Register %q: %v", provider.Name(), err)
+		}
+	}
+	if err := registerRemoteApps(&reg.Providers, cfg, Deps{RemoteClients: &remote.ClientSet{App: remoteApp}}); err != nil {
+		t.Fatalf("registerRemoteApps: %v", err)
+	}
+	svc := testutil.NewStubServices(t)
+	return invocation.NewBroker(&reg.Providers, svc.Users, svc.ExternalCredentials)
+}
+
+func remoteRoutingPrincipal(scopes ...string) *principal.Principal {
+	return &principal.Principal{
+		SubjectID: "user:dev@example.com",
+		Kind:      principal.KindUser,
+		Scopes:    scopes,
+	}
+}
+
+func invokeRemoteRoutingApp(t *testing.T, broker *invocation.Broker, app, operation string) *core.OperationResult {
+	t.Helper()
+	result, err := broker.Invoke(context.Background(), remoteRoutingPrincipal(app), app, "", operation, nil)
+	if err != nil {
+		t.Fatalf("Invoke(%q): %v", app, err)
+	}
+	return result
+}
+
+func TestRemoteAppRoutingLifecycles(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name          string
+		localApps     map[string]bool
+		localStubs    []core.Provider
+		localChecks   []struct{ app, operation string }
+		remoteChecks  []struct{ app, operation string }
+		wantRemoteApp string
+		wantRemoteN   int
+	}{
+		{
+			name:      "nothing local",
+			localApps: nil,
+			remoteChecks: []struct{ app, operation string }{
+				{"linear", "issues.list"},
+				{"valon-profile", "issues.list"},
+			},
+			wantRemoteN: 2,
+		},
+		{
+			name:       "ci-cd local",
+			localApps:  map[string]bool{"ci-cd": true},
+			localStubs: []core.Provider{localRoutingAppStub("ci-cd")},
+			localChecks: []struct{ app, operation string }{
+				{"ci-cd", "ping"},
+			},
+			remoteChecks: []struct{ app, operation string }{
+				{"linear", "issues.list"},
+				{"valon-profile", "issues.list"},
+			},
+			wantRemoteN: 2,
+		},
+		{
+			name:      "ci-cd and valon-profile local",
+			localApps: map[string]bool{"ci-cd": true, "valon-profile": true},
+			localStubs: []core.Provider{
+				localRoutingAppStub("ci-cd"),
+				localRoutingAppStub("valon-profile"),
+			},
+			localChecks: []struct{ app, operation string }{
+				{"valon-profile", "ping"},
+			},
+			remoteChecks: []struct{ app, operation string }{
+				{"linear", "issues.list"},
+			},
+			wantRemoteApp: "linear",
+			wantRemoteN:   1,
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			remoteClient := &recordingRemoteAppClient{}
+			broker := newRemoteRoutingBroker(t, remoteRoutingConfig(t, tc.localApps), remoteClient, tc.localStubs...)
+
+			for _, check := range tc.localChecks {
+				result := invokeRemoteRoutingApp(t, broker, check.app, check.operation)
+				if result.Status != 201 || string(result.Body) != "local" {
+					t.Fatalf("Invoke(%q) = %#v, want local 201", check.app, result)
+				}
+			}
+			for _, check := range tc.remoteChecks {
+				result := invokeRemoteRoutingApp(t, broker, check.app, check.operation)
+				if result.Status != 202 || string(result.Body) != "relayed" {
+					t.Fatalf("Invoke(%q) = %#v, want remote 202 relayed", check.app, result)
+				}
+			}
+
+			calls := remoteClient.snapshot()
+			if len(calls) != tc.wantRemoteN {
+				t.Fatalf("remote client calls = %d, want %d", len(calls), tc.wantRemoteN)
+			}
+			if tc.wantRemoteApp != "" && (len(calls) != 1 || calls[0].app != tc.wantRemoteApp) {
+				t.Fatalf("remote client calls = %#v, want %q only", calls, tc.wantRemoteApp)
+			}
+		})
+	}
+}
+
+func TestRemoteAppRoutingFailureSemantics(t *testing.T) {
+	t.Parallel()
+
+	t.Run("undeclared provider remains not found", func(t *testing.T) {
+		t.Parallel()
+
+		remoteClient := &recordingRemoteAppClient{}
+		broker := newRemoteRoutingBroker(t, remoteRoutingConfig(t, nil), remoteClient)
+
+		_, err := broker.Invoke(context.Background(), remoteRoutingPrincipal("missing"), "missing", "", "op", nil)
+		if !errors.Is(err, invocation.ErrProviderNotFound) {
+			t.Fatalf("err = %v, want ErrProviderNotFound", err)
+		}
+	})
+
+	t.Run("dev active does not fall back to remote", func(t *testing.T) {
+		t.Parallel()
+
+		remoteClient := &recordingRemoteAppClient{}
+		cfg := remoteRoutingConfig(t, map[string]bool{"linear": true})
+		broker := newRemoteRoutingBroker(t, cfg, remoteClient)
+
+		_, err := broker.Invoke(context.Background(), remoteRoutingPrincipal("linear"), "linear", "", "issues.list", nil)
+		if !errors.Is(err, invocation.ErrProviderNotFound) {
+			t.Fatalf("err = %v, want ErrProviderNotFound without local provider", err)
+		}
+		if len(remoteClient.snapshot()) != 0 {
+			t.Fatalf("remote client calls = %d, want 0", len(remoteClient.snapshot()))
+		}
+	})
+
+	t.Run("remote client auth error surfaces not authenticated", func(t *testing.T) {
+		t.Parallel()
+
+		remoteClient := &recordingRemoteAppClient{
+			err: status.Error(codes.Unauthenticated, "invalid token"),
+		}
+		broker := newRemoteRoutingBroker(t, remoteRoutingConfig(t, nil), remoteClient)
+
+		_, err := broker.Invoke(context.Background(), remoteRoutingPrincipal("linear"), "linear", "", "issues.list", nil)
+		if err == nil {
+			t.Fatal("expected auth error, got nil")
+		}
+		if !errors.Is(err, invocation.ErrNotAuthenticated) {
+			t.Fatalf("err = %v, want ErrNotAuthenticated", err)
+		}
+		if len(remoteClient.snapshot()) != 0 {
+			t.Fatalf("remote client calls = %d, want 0", len(remoteClient.snapshot()))
+		}
+	})
+}
+
+func TestProviderBuildsLocal(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{Server: config.ServerConfig{Remote: "https://remote.test"}}
+
+	if !providerBuildsLocal(cfg, &config.ProviderEntry{DevActive: true}) {
+		t.Fatal("DevActive entry should build local")
+	}
+	if providerBuildsLocal(cfg, &config.ProviderEntry{}) {
+		t.Fatal("non-DevActive entry with remote configured should not build local")
+	}
+	if !providerBuildsLocal(&config.Config{}, &config.ProviderEntry{}) {
+		t.Fatal("entry without remote configured should build local")
+	}
+	if providerBuildsLocal(cfg, nil) {
+		t.Fatal("nil entry should not build local")
 	}
 }

--- a/gestaltd/internal/bootstrap/provider_build_test.go
+++ b/gestaltd/internal/bootstrap/provider_build_test.go
@@ -849,11 +849,11 @@ func TestRemoteAppRoutingFailureSemantics(t *testing.T) {
 			wantErr:   invocation.ErrProviderNotFound,
 		},
 		{
-			name:       "dev active does not fall back to remote",
-			localApps:  map[string]bool{"linear": true},
-			app:        "linear",
-			operation:  "issues.list",
-			wantErr:    invocation.ErrProviderNotFound,
+			name:      "dev active does not fall back to remote",
+			localApps: map[string]bool{"linear": true},
+			app:       "linear",
+			operation: "issues.list",
+			wantErr:   invocation.ErrProviderNotFound,
 		},
 		{
 			name:      "remote client auth error surfaces not authenticated",

--- a/gestaltd/internal/bootstrap/provider_build_test.go
+++ b/gestaltd/internal/bootstrap/provider_build_test.go
@@ -833,53 +833,52 @@ func TestRemoteAppRoutingLifecycles(t *testing.T) {
 func TestRemoteAppRoutingFailureSemantics(t *testing.T) {
 	t.Parallel()
 
-	t.Run("undeclared provider remains not found", func(t *testing.T) {
-		t.Parallel()
+	for _, tc := range []struct {
+		name       string
+		localApps  map[string]bool
+		remoteErr  error
+		app        string
+		operation  string
+		wantErr    error
+		wantRemote int
+	}{
+		{
+			name:      "undeclared provider remains not found",
+			app:       "missing",
+			operation: "op",
+			wantErr:   invocation.ErrProviderNotFound,
+		},
+		{
+			name:       "dev active does not fall back to remote",
+			localApps:  map[string]bool{"linear": true},
+			app:        "linear",
+			operation:  "issues.list",
+			wantErr:    invocation.ErrProviderNotFound,
+		},
+		{
+			name:      "remote client auth error surfaces not authenticated",
+			remoteErr: status.Error(codes.Unauthenticated, "invalid token"),
+			app:       "linear",
+			operation: "issues.list",
+			wantErr:   invocation.ErrNotAuthenticated,
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-		remoteClient := &recordingRemoteAppClient{}
-		broker := newRemoteRoutingBroker(t, remoteRoutingConfig(t, nil), remoteClient)
+			remoteClient := &recordingRemoteAppClient{err: tc.remoteErr}
+			broker := newRemoteRoutingBroker(t, remoteRoutingConfig(t, tc.localApps), remoteClient)
 
-		_, err := broker.Invoke(context.Background(), remoteRoutingPrincipal("missing"), "missing", "", "op", nil)
-		if !errors.Is(err, invocation.ErrProviderNotFound) {
-			t.Fatalf("err = %v, want ErrProviderNotFound", err)
-		}
-	})
-
-	t.Run("dev active does not fall back to remote", func(t *testing.T) {
-		t.Parallel()
-
-		remoteClient := &recordingRemoteAppClient{}
-		cfg := remoteRoutingConfig(t, map[string]bool{"linear": true})
-		broker := newRemoteRoutingBroker(t, cfg, remoteClient)
-
-		_, err := broker.Invoke(context.Background(), remoteRoutingPrincipal("linear"), "linear", "", "issues.list", nil)
-		if !errors.Is(err, invocation.ErrProviderNotFound) {
-			t.Fatalf("err = %v, want ErrProviderNotFound without local provider", err)
-		}
-		if len(remoteClient.snapshot()) != 0 {
-			t.Fatalf("remote client calls = %d, want 0", len(remoteClient.snapshot()))
-		}
-	})
-
-	t.Run("remote client auth error surfaces not authenticated", func(t *testing.T) {
-		t.Parallel()
-
-		remoteClient := &recordingRemoteAppClient{
-			err: status.Error(codes.Unauthenticated, "invalid token"),
-		}
-		broker := newRemoteRoutingBroker(t, remoteRoutingConfig(t, nil), remoteClient)
-
-		_, err := broker.Invoke(context.Background(), remoteRoutingPrincipal("linear"), "linear", "", "issues.list", nil)
-		if err == nil {
-			t.Fatal("expected auth error, got nil")
-		}
-		if !errors.Is(err, invocation.ErrNotAuthenticated) {
-			t.Fatalf("err = %v, want ErrNotAuthenticated", err)
-		}
-		if len(remoteClient.snapshot()) != 0 {
-			t.Fatalf("remote client calls = %d, want 0", len(remoteClient.snapshot()))
-		}
-	})
+			_, err := broker.Invoke(context.Background(), remoteRoutingPrincipal(tc.app), tc.app, "", tc.operation, nil)
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("err = %v, want %v", err, tc.wantErr)
+			}
+			if len(remoteClient.snapshot()) != tc.wantRemote {
+				t.Fatalf("remote client calls = %d, want %d", len(remoteClient.snapshot()), tc.wantRemote)
+			}
+		})
+	}
 }
 
 func TestProviderBuildsLocal(t *testing.T) {

--- a/gestaltd/internal/server/public_grpc_test.go
+++ b/gestaltd/internal/server/public_grpc_test.go
@@ -112,34 +112,7 @@ func remoteRoutingAppStub(name, operation string) *coretesting.StubIntegration {
 func TestPublicGRPCRouting(t *testing.T) {
 	t.Parallel()
 
-	t.Run("bearer routes through public gateway", func(t *testing.T) {
-		t.Parallel()
-
-		ts, invoker := startExamplePublicGRPCServer(t)
-		clients, err := remote.NewClientSet(context.Background(), remote.Config{
-			URL:       ts.URL,
-			Token:     publicGRPCTestBearer("example"),
-			TLSConfig: &tls.Config{InsecureSkipVerify: true},
-		})
-		if err != nil {
-			t.Fatalf("remote.NewClientSet: %v", err)
-		}
-		defer func() { _ = clients.Close() }()
-
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		if _, err := clients.App.Invoke(ctx, &proto.AppInvokeRequest{
-			App:       "example",
-			Operation: "sync",
-		}); err != nil {
-			t.Fatalf("remote App.Invoke: %v", err)
-		}
-		if call := invoker.snapshot(); call.calls != 1 || call.providerName != "example" || call.operation != "sync" {
-			t.Fatalf("invoker call = %+v, want example/sync", call)
-		}
-	})
-
-	t.Run("multiple apps relay through public gateway", func(t *testing.T) {
+	t.Run("bearer routes apps through public gateway", func(t *testing.T) {
 		t.Parallel()
 
 		ts, invoker := startPublicGRPCServer(t, func(cfg *server.Config) {
@@ -175,59 +148,50 @@ func TestPublicGRPCRouting(t *testing.T) {
 		}
 	})
 
-	t.Run("invalid bearer rejects remote client", func(t *testing.T) {
-		t.Parallel()
-
-		ts, invoker := startExamplePublicGRPCServer(t)
-		clients, err := remote.NewClientSet(context.Background(), remote.Config{
-			URL:       ts.URL,
-			Token:     "wrong-token",
-			TLSConfig: &tls.Config{InsecureSkipVerify: true},
-		})
-		if err != nil {
-			t.Fatalf("remote.NewClientSet: %v", err)
-		}
-		t.Cleanup(func() { _ = clients.Close() })
-
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		_, err = clients.App.Invoke(ctx, &proto.AppInvokeRequest{
-			App:       "example",
-			Operation: "sync",
-		})
-		if status.Code(err) != codes.Unauthenticated {
-			t.Fatalf("remote App.Invoke code = %v, want %v (%v)", status.Code(err), codes.Unauthenticated, err)
-		}
-		if call := invoker.snapshot(); call.calls != 0 {
-			t.Fatalf("invoker calls = %d, want 0", call.calls)
-		}
-	})
-
 	for _, tc := range []struct {
-		name     string
-		metadata []string
+		name        string
+		metadata    []string
+		remoteToken string
 	}{
 		{name: "missing bearer is rejected"},
 		{name: "invalid bearer scheme is rejected", metadata: []string{"authorization", "Basic not-a-bearer-token"}},
+		{name: "invalid bearer via remote client is rejected", remoteToken: "wrong-token"},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			ts, invoker := startExamplePublicGRPCServer(t)
-			conn := newRelayGRPCConn(t, ts)
-			defer func() { _ = conn.Close() }()
-
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
-			if len(tc.metadata) > 0 {
-				ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(tc.metadata...))
+
+			var err error
+			if tc.remoteToken != "" {
+				clients, clientErr := remote.NewClientSet(context.Background(), remote.Config{
+					URL:       ts.URL,
+					Token:     tc.remoteToken,
+					TLSConfig: &tls.Config{InsecureSkipVerify: true},
+				})
+				if clientErr != nil {
+					t.Fatalf("remote.NewClientSet: %v", clientErr)
+				}
+				t.Cleanup(func() { _ = clients.Close() })
+				_, err = clients.App.Invoke(ctx, &proto.AppInvokeRequest{
+					App:       "example",
+					Operation: "sync",
+				})
+			} else {
+				conn := newRelayGRPCConn(t, ts)
+				defer func() { _ = conn.Close() }()
+				if len(tc.metadata) > 0 {
+					ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(tc.metadata...))
+				}
+				_, err = proto.NewAppClient(conn).Invoke(ctx, &proto.AppInvokeRequest{
+					App:       "example",
+					Operation: "sync",
+				})
 			}
 
-			_, err := proto.NewAppClient(conn).Invoke(ctx, &proto.AppInvokeRequest{
-				App:       "example",
-				Operation: "sync",
-			})
 			if status.Code(err) != codes.Unauthenticated {
 				t.Fatalf("public App.Invoke code = %v, want %v (%v)", status.Code(err), codes.Unauthenticated, err)
 			}

--- a/gestaltd/internal/server/public_grpc_test.go
+++ b/gestaltd/internal/server/public_grpc_test.go
@@ -3,28 +3,19 @@ package server_test
 import (
 	"context"
 	"crypto/tls"
-	"errors"
-	"fmt"
 	"net/http/httptest"
-	"strings"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
-	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/publicrpc"
 	"github.com/valon-technologies/gestalt/server/internal/remote"
 	"github.com/valon-technologies/gestalt/server/internal/server"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	appaccessservice "github.com/valon-technologies/gestalt/server/services/appaccess"
-	appservice "github.com/valon-technologies/gestalt/server/services/apps"
-	"github.com/valon-technologies/gestalt/server/services/apps/registry"
-	"github.com/valon-technologies/gestalt/server/services/identity/principal"
-	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/providergateway"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"google.golang.org/grpc"
@@ -90,6 +81,30 @@ func startExamplePublicGRPCServer(t *testing.T) (*httptest.Server, *relayTestInv
 	})
 }
 
+func publicGRPCRemoteClientSet(t *testing.T, ts *httptest.Server, scope string) *remote.ClientSet {
+	t.Helper()
+	clients, err := remote.NewClientSet(context.Background(), remote.Config{
+		URL:       ts.URL,
+		Token:     publicGRPCTestBearer(scope),
+		TLSConfig: &tls.Config{InsecureSkipVerify: true},
+	})
+	if err != nil {
+		t.Fatalf("remote.NewClientSet: %v", err)
+	}
+	t.Cleanup(func() { _ = clients.Close() })
+	return clients
+}
+
+func remoteRoutingAppStub(name, operation string) *coretesting.StubIntegration {
+	return &coretesting.StubIntegration{
+		N:        name,
+		ConnMode: core.ConnectionModeNone,
+		CatalogVal: &catalog.Catalog{
+			Operations: []catalog.CatalogOperation{{ID: operation}},
+		},
+	}
+}
+
 // TestPublicGRPCRouting verifies public gRPC wiring end-to-end: bearer-authenticated
 // gRPC is handled by the public gateway surface, while host-service relay traffic
 // continues through the trusted relay path. Individual RPC policy and per-service
@@ -121,6 +136,70 @@ func TestPublicGRPCRouting(t *testing.T) {
 		}
 		if call := invoker.snapshot(); call.calls != 1 || call.providerName != "example" || call.operation != "sync" {
 			t.Fatalf("invoker call = %+v, want example/sync", call)
+		}
+	})
+
+	t.Run("multiple apps relay through public gateway", func(t *testing.T) {
+		t.Parallel()
+
+		ts, invoker := startPublicGRPCServer(t, func(cfg *server.Config) {
+			cfg.Providers = testutil.NewProviderRegistry(t,
+				remoteRoutingAppStub("linear", "issues.list"),
+				remoteRoutingAppStub("valon-profile", "issues.list"),
+			)
+		})
+		clients := publicGRPCRemoteClientSet(t, ts, "linear")
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		for _, app := range []string{"linear", "valon-profile"} {
+			if _, err := clients.App.Invoke(ctx, &proto.AppInvokeRequest{
+				App:       app,
+				Operation: "issues.list",
+			}); err != nil {
+				t.Fatalf("remote App.Invoke(%q): %v", app, err)
+			}
+		}
+
+		calls := invoker.snapshots()
+		if len(calls) != 2 {
+			t.Fatalf("invoker calls = %d, want 2", len(calls))
+		}
+		for i, want := range []struct{ provider, operation string }{
+			{"linear", "issues.list"},
+			{"valon-profile", "issues.list"},
+		} {
+			if calls[i].providerName != want.provider || calls[i].operation != want.operation {
+				t.Fatalf("invoker call[%d] = %+v, want %s/%s", i, calls[i], want.provider, want.operation)
+			}
+		}
+	})
+
+	t.Run("invalid bearer rejects remote client", func(t *testing.T) {
+		t.Parallel()
+
+		ts, invoker := startExamplePublicGRPCServer(t)
+		clients, err := remote.NewClientSet(context.Background(), remote.Config{
+			URL:       ts.URL,
+			Token:     "wrong-token",
+			TLSConfig: &tls.Config{InsecureSkipVerify: true},
+		})
+		if err != nil {
+			t.Fatalf("remote.NewClientSet: %v", err)
+		}
+		t.Cleanup(func() { _ = clients.Close() })
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_, err = clients.App.Invoke(ctx, &proto.AppInvokeRequest{
+			App:       "example",
+			Operation: "sync",
+		})
+		if status.Code(err) != codes.Unauthenticated {
+			t.Fatalf("remote App.Invoke code = %v, want %v (%v)", status.Code(err), codes.Unauthenticated, err)
+		}
+		if call := invoker.snapshot(); call.calls != 0 {
+			t.Fatalf("invoker calls = %d, want 0", call.calls)
 		}
 	})
 
@@ -217,321 +296,6 @@ func TestPublicGRPCRouting(t *testing.T) {
 		}
 		if call := invoker.snapshot(); call.calls != 1 || call.providerName != "slack" {
 			t.Fatalf("relay invoker call = %+v, want slack", call)
-		}
-	})
-}
-
-type plan6RelayInvoker struct {
-	mu    sync.Mutex
-	calls []relayTestInvokerCall
-}
-
-func (i *plan6RelayInvoker) Invoke(ctx context.Context, _ *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error) {
-	i.mu.Lock()
-	i.calls = append(i.calls, relayTestInvokerCall{
-		calls:        len(i.calls) + 1,
-		providerName: providerName,
-		instance:     instance,
-		operation:    operation,
-	})
-	i.mu.Unlock()
-	return &core.OperationResult{Status: 202, Body: []byte("relayed")}, nil
-}
-
-func (i *plan6RelayInvoker) snapshot() []relayTestInvokerCall {
-	i.mu.Lock()
-	defer i.mu.Unlock()
-	out := make([]relayTestInvokerCall, len(i.calls))
-	copy(out, i.calls)
-	return out
-}
-
-func plan6RemoteAppsConfig(localApps map[string]bool) *config.Config {
-	apps := map[string]*config.ProviderEntry{
-		"linear":        {},
-		"valon-profile": {},
-		"ci-cd":         {},
-	}
-	for name, active := range localApps {
-		if entry := apps[name]; entry != nil {
-			entry.DevActive = active
-		}
-	}
-	return &config.Config{
-		Server: config.ServerConfig{Remote: "https://remote.test"},
-		Apps:   apps,
-	}
-}
-
-func plan6BuildsLocal(cfg *config.Config, entry *config.ProviderEntry) bool {
-	if entry == nil {
-		return false
-	}
-	if entry.DevActive {
-		return true
-	}
-	return cfg == nil || strings.TrimSpace(cfg.Server.Remote) == ""
-}
-
-func plan6LocalAppStub(name string) *coretesting.StubIntegration {
-	return &coretesting.StubIntegration{
-		N:        name,
-		ConnMode: core.ConnectionModeNone,
-		CatalogVal: &catalog.Catalog{
-			Operations: []catalog.CatalogOperation{{ID: "ping"}},
-		},
-		ExecuteFn: func(context.Context, string, map[string]any, string) (*core.OperationResult, error) {
-			return &core.OperationResult{Status: 201, Body: []byte("local")}, nil
-		},
-	}
-}
-
-func plan6RemoteAppStubs() []core.Provider {
-	return []core.Provider{
-		&coretesting.StubIntegration{
-			N:        "linear",
-			ConnMode: core.ConnectionModeNone,
-			CatalogVal: &catalog.Catalog{
-				Operations: []catalog.CatalogOperation{{ID: "issues.list"}},
-			},
-		},
-		&coretesting.StubIntegration{
-			N:        "valon-profile",
-			ConnMode: core.ConnectionModeNone,
-			CatalogVal: &catalog.Catalog{
-				Operations: []catalog.CatalogOperation{{ID: "issues.list"}},
-			},
-		},
-	}
-}
-
-func startPlan6RemotePublicGRPCServer(t *testing.T) (*httptest.Server, *plan6RelayInvoker) {
-	t.Helper()
-	invoker := &plan6RelayInvoker{}
-	ts := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
-		configurePublicGRPCTestServer(t, cfg, nil)
-		cfg.Invoker = invoker
-		cfg.Providers = testutil.NewProviderRegistry(t, plan6RemoteAppStubs()...)
-	}))
-	ts.EnableHTTP2 = true
-	ts.StartTLS()
-	testutil.CloseOnCleanup(t, ts)
-	return ts, invoker
-}
-
-func plan6RemoteClientSet(t *testing.T, ts *httptest.Server, scope string) *remote.ClientSet {
-	t.Helper()
-	clients, err := remote.NewClientSet(context.Background(), remote.Config{
-		URL:       ts.URL,
-		Token:     publicGRPCTestBearer(scope),
-		TLSConfig: &tls.Config{InsecureSkipVerify: true},
-	})
-	if err != nil {
-		t.Fatalf("remote.NewClientSet: %v", err)
-	}
-	t.Cleanup(func() { _ = clients.Close() })
-	return clients
-}
-
-func registerPlan6RemoteApps(reg *registry.ProviderMap[core.Provider], cfg *config.Config, client proto.AppClient) error {
-	for name, entry := range cfg.Apps {
-		if entry == nil || plan6BuildsLocal(cfg, entry) {
-			continue
-		}
-		spec := appservice.StaticProviderSpec{
-			Name:           name,
-			ConnectionMode: core.ConnectionModeNone,
-			Catalog:        &catalog.Catalog{Operations: []catalog.CatalogOperation{{ID: "issues.list"}, {ID: "ping"}}},
-		}
-		provider := appservice.NewGestaltRemote(client, spec)
-		if provider == nil {
-			return fmt.Errorf("remote app %q: provider client is required", name)
-		}
-		if err := reg.Register(name, provider); err != nil {
-			return fmt.Errorf("remote app %q: %w", name, err)
-		}
-	}
-	return nil
-}
-
-func newPlan6Broker(t *testing.T, cfg *config.Config, clients *remote.ClientSet, localApps ...core.Provider) *invocation.Broker {
-	t.Helper()
-	reg := testutil.NewProviderRegistry(t, localApps...)
-	if err := registerPlan6RemoteApps(reg, cfg, clients.App); err != nil {
-		t.Fatalf("registerPlan6RemoteApps: %v", err)
-	}
-	svc := testutil.NewStubServices(t)
-	return invocation.NewBroker(reg, svc.Users, svc.ExternalCredentials)
-}
-
-func plan6Principal(scopes ...string) *principal.Principal {
-	return &principal.Principal{
-		SubjectID: "user:dev@example.com",
-		Kind:      principal.KindUser,
-		Scopes:    scopes,
-	}
-}
-
-func invokePlan6App(t *testing.T, broker *invocation.Broker, app, operation string) *core.OperationResult {
-	t.Helper()
-	result, err := broker.Invoke(context.Background(), plan6Principal(app), app, "", operation, nil)
-	if err != nil {
-		t.Fatalf("Invoke(%q): %v", app, err)
-	}
-	return result
-}
-
-func TestPlan6RemoteAppRoutingLifecycles(t *testing.T) {
-	t.Parallel()
-
-	for _, tc := range []struct {
-		name          string
-		localApps     map[string]bool
-		localStubs    []core.Provider
-		localChecks   []struct{ app, operation string }
-		remoteChecks  []struct{ app, operation string }
-		wantRemoteApp string
-		wantRemoteN   int
-	}{
-		{
-			name:      "nothing local",
-			localApps: nil,
-			remoteChecks: []struct{ app, operation string }{
-				{"linear", "issues.list"},
-				{"valon-profile", "issues.list"},
-			},
-			wantRemoteN: 2,
-		},
-		{
-			name:       "ci-cd local",
-			localApps:  map[string]bool{"ci-cd": true},
-			localStubs: []core.Provider{plan6LocalAppStub("ci-cd")},
-			localChecks: []struct{ app, operation string }{
-				{"ci-cd", "ping"},
-			},
-			remoteChecks: []struct{ app, operation string }{
-				{"linear", "issues.list"},
-				{"valon-profile", "issues.list"},
-			},
-			wantRemoteN: 2,
-		},
-		{
-			name:      "ci-cd and valon-profile local",
-			localApps: map[string]bool{"ci-cd": true, "valon-profile": true},
-			localStubs: []core.Provider{
-				plan6LocalAppStub("ci-cd"),
-				plan6LocalAppStub("valon-profile"),
-			},
-			localChecks: []struct{ app, operation string }{
-				{"valon-profile", "ping"},
-			},
-			remoteChecks: []struct{ app, operation string }{
-				{"linear", "issues.list"},
-			},
-			wantRemoteApp: "linear",
-			wantRemoteN:   1,
-		},
-	} {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			remoteTS, invoker := startPlan6RemotePublicGRPCServer(t)
-			clients := plan6RemoteClientSet(t, remoteTS, "linear")
-			broker := newPlan6Broker(t, plan6RemoteAppsConfig(tc.localApps), clients, tc.localStubs...)
-
-			for _, check := range tc.localChecks {
-				result := invokePlan6App(t, broker, check.app, check.operation)
-				if result.Status != 201 || string(result.Body) != "local" {
-					t.Fatalf("Invoke(%q) = %#v, want local 201", check.app, result)
-				}
-			}
-			for _, check := range tc.remoteChecks {
-				result := invokePlan6App(t, broker, check.app, check.operation)
-				if result.Status != 202 || string(result.Body) != "relayed" {
-					t.Fatalf("Invoke(%q) = %#v, want remote 202 relayed", check.app, result)
-				}
-			}
-
-			calls := invoker.snapshot()
-			if len(calls) != tc.wantRemoteN {
-				t.Fatalf("remote invoker calls = %d, want %d", len(calls), tc.wantRemoteN)
-			}
-			if tc.wantRemoteApp != "" && (len(calls) != 1 || calls[0].providerName != tc.wantRemoteApp) {
-				t.Fatalf("remote invoker calls = %#v, want %q only", calls, tc.wantRemoteApp)
-			}
-		})
-	}
-}
-
-func TestPlan6RemoteFailureSemantics(t *testing.T) {
-	t.Parallel()
-
-	t.Run("undeclared provider remains not found", func(t *testing.T) {
-		t.Parallel()
-
-		remoteTS, _ := startPlan6RemotePublicGRPCServer(t)
-		clients := plan6RemoteClientSet(t, remoteTS, "linear")
-		broker := newPlan6Broker(t, plan6RemoteAppsConfig(nil), clients)
-
-		_, err := broker.Invoke(context.Background(), plan6Principal("missing"), "missing", "", "op", nil)
-		if !errors.Is(err, invocation.ErrProviderNotFound) {
-			t.Fatalf("err = %v, want ErrProviderNotFound", err)
-		}
-	})
-
-	t.Run("dev active does not fall back to remote", func(t *testing.T) {
-		t.Parallel()
-
-		remoteTS, invoker := startPlan6RemotePublicGRPCServer(t)
-		clients := plan6RemoteClientSet(t, remoteTS, "linear")
-		cfg := plan6RemoteAppsConfig(map[string]bool{"linear": true})
-		broker := newPlan6Broker(t, cfg, clients)
-
-		_, err := broker.Invoke(context.Background(), plan6Principal("linear"), "linear", "", "issues.list", nil)
-		if !errors.Is(err, invocation.ErrProviderNotFound) {
-			t.Fatalf("err = %v, want ErrProviderNotFound without local provider", err)
-		}
-		if len(invoker.snapshot()) != 0 {
-			t.Fatalf("remote invoker calls = %d, want 0", len(invoker.snapshot()))
-		}
-	})
-
-	t.Run("wrong remote token surfaces auth error", func(t *testing.T) {
-		t.Parallel()
-
-		remoteTS, invoker := startPlan6RemotePublicGRPCServer(t)
-		clients, err := remote.NewClientSet(context.Background(), remote.Config{
-			URL:       remoteTS.URL,
-			Token:     "wrong-token",
-			TLSConfig: &tls.Config{InsecureSkipVerify: true},
-		})
-		if err != nil {
-			t.Fatalf("NewClientSet: %v", err)
-		}
-		t.Cleanup(func() { _ = clients.Close() })
-
-		reg := testutil.NewProviderRegistry(t)
-		spec := appservice.StaticProviderSpec{
-			Name:           "linear",
-			ConnectionMode: core.ConnectionModeNone,
-			Catalog:        &catalog.Catalog{Operations: []catalog.CatalogOperation{{ID: "issues.list"}}},
-		}
-		if err := reg.Register("linear", appservice.NewGestaltRemote(clients.App, spec)); err != nil {
-			t.Fatalf("Register linear: %v", err)
-		}
-		svc := testutil.NewStubServices(t)
-		broker := invocation.NewBroker(reg, svc.Users, svc.ExternalCredentials)
-
-		_, err = broker.Invoke(context.Background(), plan6Principal("linear"), "linear", "", "issues.list", nil)
-		if err == nil {
-			t.Fatal("expected auth error, got nil")
-		}
-		if !errors.Is(err, invocation.ErrNotAuthenticated) {
-			t.Fatalf("err = %v, want ErrNotAuthenticated", err)
-		}
-		if len(invoker.snapshot()) != 0 {
-			t.Fatalf("remote invoker calls = %d, want 0", len(invoker.snapshot()))
 		}
 	})
 }

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -630,6 +630,7 @@ func (s *relayTestCacheServer) calls() int {
 type relayTestInvoker struct {
 	mu             sync.Mutex
 	calls          int
+	history        []relayTestInvokerCall
 	providerName   string
 	instance       string
 	operation      string
@@ -641,11 +642,20 @@ func (i *relayTestInvoker) Invoke(ctx context.Context, _ *principal.Principal, p
 	i.mu.Lock()
 	defer i.mu.Unlock()
 	i.calls++
+	call := relayTestInvokerCall{
+		calls:          i.calls,
+		providerName:   providerName,
+		instance:       instance,
+		operation:      operation,
+		idempotencyKey: invocation.IdempotencyKeyFromContext(ctx),
+		params:         maps.Clone(params),
+	}
+	i.history = append(i.history, call)
 	i.providerName = providerName
 	i.instance = instance
 	i.operation = operation
-	i.idempotencyKey = invocation.IdempotencyKeyFromContext(ctx)
-	i.params = maps.Clone(params)
+	i.idempotencyKey = call.idempotencyKey
+	i.params = call.params
 	return &core.OperationResult{Status: 202, Body: []byte("relayed")}, nil
 }
 
@@ -661,14 +671,23 @@ type relayTestInvokerCall struct {
 func (i *relayTestInvoker) snapshot() relayTestInvokerCall {
 	i.mu.Lock()
 	defer i.mu.Unlock()
-	return relayTestInvokerCall{
-		calls:          i.calls,
-		providerName:   i.providerName,
-		instance:       i.instance,
-		operation:      i.operation,
-		idempotencyKey: i.idempotencyKey,
-		params:         maps.Clone(i.params),
+	if len(i.history) == 0 {
+		return relayTestInvokerCall{}
 	}
+	last := i.history[len(i.history)-1]
+	last.params = maps.Clone(last.params)
+	return last
+}
+
+func (i *relayTestInvoker) snapshots() []relayTestInvokerCall {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	out := make([]relayTestInvokerCall, len(i.history))
+	for j, call := range i.history {
+		call.params = maps.Clone(call.params)
+		out[j] = call
+	}
+	return out
 }
 
 type callerTokenRecordingInvoker struct {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #2676: the merged remote routing tests were additive and duplicated existing helpers under plan6-specific naming. This refactor folds the same coverage into existing infrastructure and trims redundant cases.

## Changes

- **Extend `relayTestInvoker`** with `snapshots()` so multi-call relay assertions reuse the existing invoker instead of a parallel `plan6RelayInvoker`.
- **Augment `TestPublicGRPCRouting`** with multi-app relay and consolidated auth-rejection cases (missing bearer, invalid scheme, invalid remote client token).
- **Move broker routing lifecycle tests** to `bootstrap/provider_build_test.go`, exercising production `registerRemoteApps` and `providerBuildsLocal` instead of duplicated test-only registration logic.
- **Remove all plan6 naming** and ~300 lines of parallel server/client/broker helpers from `public_grpc_test.go`.
- **Consolidate redundant cases**: drop the single-app bearer relay subtest (subsumed by multi-app), merge three auth-rejection subtests into one table, and table-drive bootstrap failure semantics.

## Test plan

- [x] `go test ./internal/server/... -run TestPublicGRPCRouting`
- [x] `go test ./internal/bootstrap/... -run 'TestRemoteAppRouting|TestProviderBuildsLocal'`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b82670e8-5aa3-4a12-bf98-8c2cdfed9dd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b82670e8-5aa3-4a12-bf98-8c2cdfed9dd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

