### PR TITLE
Use SubjectIDFromRequestContext in tests; remove stale comment

### DIFF
--- a/gestaltd/core/agent/provider.go
+++ b/gestaltd/core/agent/provider.go
@@ -15,11 +15,6 @@ import (
 // when the provider has durable state but cannot attach to the execution
 // runtime.
 type Provider interface {
-	// CreateSession mints the session id: the returned Session carries a
-	// non-empty, stable id of the provider's choosing. Creation must be
-	// idempotent on the request's idempotency_key scoped per subject
-	// (context.subject.id, or top-level subject when set for delegated provider
-	// calls); an empty key always creates a new session.
 	CreateSession(ctx context.Context, req *proto.CreateAgentProviderSessionRequest) (*Session, error)
 	GetSession(ctx context.Context, req *proto.GetAgentProviderSessionRequest) (*Session, error)
 	ListSessions(ctx context.Context, req *proto.ListAgentProviderSessionsRequest) ([]*Session, error)

--- a/gestaltd/internal/bootstrap/agent_runtime_test.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_test.go
@@ -193,10 +193,7 @@ func (p *workspaceAgentProvider) CreateSession(_ context.Context, req *proto.Cre
 			return &cloned, nil
 		}
 	}
-	createdBy := ""
-	if principal := appaccessservice.PrincipalFromSubjectContext(req.GetContext().GetSubject()); principal != nil {
-		createdBy = principal.SubjectID
-	}
+	createdBy := appaccessservice.SubjectIDFromRequestContext(req.GetContext())
 	session := &coreagent.Session{
 		ID:                 fmt.Sprintf("minted-session-%d", len(p.sessions)+1),
 		ProviderName:       "simple",

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -336,10 +336,7 @@ func (p *recordingAgentProvider) CreateSession(_ context.Context, req *proto.Cre
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.ensureStateLocked()
-	callerSubjectID := ""
-	if p := appaccessservice.PrincipalFromSubjectContext(req.GetContext().GetSubject()); p != nil {
-		callerSubjectID = p.SubjectID
-	}
+	callerSubjectID := appaccessservice.SubjectIDFromRequestContext(req.GetContext())
 	idempotencyScope := agentProviderSessionIdempotencyScope(req)
 	if sessionID, ok := p.sessionIdempotency[idempotencyScope]; idempotencyScope != "" && ok {
 		session, ok := p.sessions[sessionID]
@@ -416,10 +413,7 @@ func (p *recordingAgentProvider) CreateTurn(_ context.Context, req *proto.Create
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.ensureStateLocked()
-	callerSubjectID := ""
-	if p := appaccessservice.PrincipalFromSubjectContext(req.GetContext().GetSubject()); p != nil {
-		callerSubjectID = p.SubjectID
-	}
+	callerSubjectID := appaccessservice.SubjectIDFromRequestContext(req.GetContext())
 	idempotencyScope := agentProviderTurnIdempotencyScope(req)
 	if turnID, ok := p.turnIdempotency[idempotencyScope]; idempotencyScope != "" && ok {
 		turn, ok := p.turns[turnID]
@@ -647,10 +641,7 @@ func newCallbackAgentProvider(started *runtimehost.StartedHostServices) (*callba
 func (p *callbackAgentProvider) CreateTurn(ctx context.Context, req *proto.CreateAgentProviderTurnRequest) (*coreagent.Turn, error) {
 	p.mu.Lock()
 	p.ensureStateLocked()
-	callerSubjectID := ""
-	if p := appaccessservice.PrincipalFromSubjectContext(req.GetContext().GetSubject()); p != nil {
-		callerSubjectID = p.SubjectID
-	}
+	callerSubjectID := appaccessservice.SubjectIDFromRequestContext(req.GetContext())
 	idempotencyScope := agentProviderTurnIdempotencyScope(req)
 	if turnID, ok := p.turnIdempotency[idempotencyScope]; idempotencyScope != "" && ok {
 		turn, ok := p.turns[turnID]
@@ -1027,7 +1018,7 @@ func (p *recordingWorkflowProvider) ApplyDefinition(_ context.Context, req *prot
 		Target:             cloneBootstrapWorkflowTarget(spec.Target),
 		Activations:        append([]coreworkflow.Activation(nil), spec.Activations...),
 		Paused:             spec.Paused,
-		CreatedBySubjectID: strings.TrimSpace(req.GetContext().GetSubject().GetId()),
+		CreatedBySubjectID: appaccessservice.SubjectIDFromRequestContext(req.GetContext()),
 		ProviderName:       strings.TrimSpace(req.GetProviderName()),
 		RunAs:              spec.RunAs,
 	}

--- a/gestaltd/internal/bootstrap/executable_app_test.go
+++ b/gestaltd/internal/bootstrap/executable_app_test.go
@@ -1651,10 +1651,6 @@ func (p *stubAgentTurnManagerProvider) CreateSession(_ context.Context, req *pro
 	defer p.mu.Unlock()
 	now := time.Now().UTC().Truncate(time.Second)
 	p.createSessionRequests = append(p.createSessionRequests, req)
-	createdBy := ""
-	if principal := appaccessservice.PrincipalFromSubjectContext(req.GetContext().GetSubject()); principal != nil {
-		createdBy = principal.SubjectID
-	}
 	session := &coreagent.Session{
 		ID:                 fmt.Sprintf("managed-session-%d", len(p.sessions)+1),
 		ProviderName:       "managed",
@@ -1662,7 +1658,7 @@ func (p *stubAgentTurnManagerProvider) CreateSession(_ context.Context, req *pro
 		ClientRef:          req.GetClientRef(),
 		State:              coreagent.SessionStateActive,
 		Metadata:           stubAgentProtoStructToMap(req.GetMetadata()),
-		CreatedBySubjectID: createdBy,
+		CreatedBySubjectID: appaccessservice.SubjectIDFromRequestContext(req.GetContext()),
 		CreatedAt:          &now,
 		UpdatedAt:          &now,
 	}
@@ -1717,10 +1713,6 @@ func (p *stubAgentTurnManagerProvider) CreateTurn(_ context.Context, req *proto.
 
 	now := time.Now().UTC().Truncate(time.Second)
 	p.createTurnRequests = append(p.createTurnRequests, req)
-	createdBy := ""
-	if principal := appaccessservice.PrincipalFromSubjectContext(req.GetContext().GetSubject()); principal != nil {
-		createdBy = principal.SubjectID
-	}
 
 	turn := &coreagent.Turn{
 		ID:                 req.GetTurnId(),
@@ -1730,7 +1722,7 @@ func (p *stubAgentTurnManagerProvider) CreateTurn(_ context.Context, req *proto.
 		Status:             coreagent.ExecutionStatusSucceeded,
 		Messages:           stubAgentMessagesFromProto(req.GetMessages()),
 		Output:             coreagent.TurnOutput{Text: &coreagent.TurnTextOutput{Text: "turn completed"}},
-		CreatedBySubjectID: createdBy,
+		CreatedBySubjectID: appaccessservice.SubjectIDFromRequestContext(req.GetContext()),
 		CreatedAt:          &now,
 		StartedAt:          &now,
 		CompletedAt:        &now,

--- a/gestaltd/internal/bootstrap/provider_build_test.go
+++ b/gestaltd/internal/bootstrap/provider_build_test.go
@@ -43,15 +43,11 @@ type providerBuildOrderingAgentProvider struct {
 func (providerBuildOrderingAgentProvider) SupportsWorkspaceRequests() bool { return true }
 
 func (providerBuildOrderingAgentProvider) CreateSession(_ context.Context, req *proto.CreateAgentProviderSessionRequest) (*coreagent.Session, error) {
-	createdBy := ""
-	if principal := appaccessservice.PrincipalFromSubjectContext(req.GetContext().GetSubject()); principal != nil {
-		createdBy = principal.SubjectID
-	}
 	return &coreagent.Session{
 		ID:                 uuid.NewString(),
 		ProviderName:       "managed",
 		Model:              req.GetModel(),
-		CreatedBySubjectID: createdBy,
+		CreatedBySubjectID: appaccessservice.SubjectIDFromRequestContext(req.GetContext()),
 	}, nil
 }
 

--- a/gestaltd/internal/server/agent_session_turn_test.go
+++ b/gestaltd/internal/server/agent_session_turn_test.go
@@ -241,10 +241,6 @@ func (p *memoryAgentProvider) CreateSession(_ context.Context, req *proto.Create
 	}
 
 	now := time.Now().UTC().Truncate(time.Second)
-	createdBy := ""
-	if principal := appaccessservice.PrincipalFromSubjectContext(req.GetContext().GetSubject()); principal != nil {
-		createdBy = principal.SubjectID
-	}
 	session := &coreagent.Session{
 		ID:                 fmt.Sprintf("managed-session-%d", len(p.sessions)+1),
 		ProviderName:       "managed",
@@ -252,7 +248,7 @@ func (p *memoryAgentProvider) CreateSession(_ context.Context, req *proto.Create
 		ClientRef:          req.GetClientRef(),
 		State:              coreagent.SessionStateActive,
 		Metadata:           mapFromStruct(req.GetMetadata()),
-		CreatedBySubjectID: createdBy,
+		CreatedBySubjectID: appaccessservice.SubjectIDFromRequestContext(req.GetContext()),
 		CreatedAt:          &now,
 		UpdatedAt:          &now,
 	}
@@ -334,10 +330,6 @@ func (p *memoryAgentProvider) CreateTurn(_ context.Context, req *proto.CreateAge
 	}
 	now := time.Now().UTC().Truncate(time.Second)
 	metadata := mapFromStruct(req.GetMetadata())
-	createdBy := ""
-	if principal := appaccessservice.PrincipalFromSubjectContext(req.GetContext().GetSubject()); principal != nil {
-		createdBy = principal.SubjectID
-	}
 	turn := &coreagent.Turn{
 		ID:                 req.GetTurnId(),
 		SessionID:          req.GetSessionId(),
@@ -345,7 +337,7 @@ func (p *memoryAgentProvider) CreateTurn(_ context.Context, req *proto.CreateAge
 		Model:              req.GetModel(),
 		Status:             coreagent.ExecutionStatusSucceeded,
 		Messages:           messagesFromProto(req.GetMessages()),
-		CreatedBySubjectID: createdBy,
+		CreatedBySubjectID: appaccessservice.SubjectIDFromRequestContext(req.GetContext()),
 		CreatedAt:          &now,
 		StartedAt:          &now,
 		CompletedAt:        &now,

--- a/gestaltd/services/agents/agentmanager/manager_test.go
+++ b/gestaltd/services/agents/agentmanager/manager_test.go
@@ -250,7 +250,7 @@ func (p *routeCountingAgentProvider) CreateSession(_ context.Context, req *proto
 		ClientRef:          req.GetClientRef(),
 		State:              coreagent.SessionStateActive,
 		Metadata:           mapsCloneAny(protoutil.MapFromStruct(req.GetMetadata())),
-		CreatedBySubjectID: principalSubjectID(appaccessservice.PrincipalFromSubjectContext(req.GetContext().GetSubject())),
+		CreatedBySubjectID: appaccessservice.SubjectIDFromRequestContext(req.GetContext()),
 	}
 	p.sessions[session.ID] = session
 	if key != "" {
@@ -354,7 +354,7 @@ func (p *routeCountingAgentProvider) CreateTurn(_ context.Context, req *proto.Cr
 		Status:             status,
 		Messages:           agentwire.MessagesFromProto(req.GetMessages()),
 		Output:             p.createTurnOutput,
-		CreatedBySubjectID: principalSubjectID(appaccessservice.PrincipalFromSubjectContext(req.GetContext().GetSubject())),
+		CreatedBySubjectID: appaccessservice.SubjectIDFromRequestContext(req.GetContext()),
 		ExecutionRef:       req.GetExecutionRef(),
 	}
 	p.turns[turn.ID] = turn

--- a/gestaltd/services/workflows/telemetry_test.go
+++ b/gestaltd/services/workflows/telemetry_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
 	"github.com/valon-technologies/gestalt/server/internal/workflowwire"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	appaccessservice "github.com/valon-technologies/gestalt/server/services/appaccess"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/observability"
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
@@ -443,7 +444,7 @@ func (p *workflowManagerTelemetryProvider) SignalOrStartRun(_ context.Context, r
 			ID:  "run",
 			App: &coreworkflow.AppCall{Name: "github", Operation: "issues.triage"},
 		}}},
-		CreatedBySubjectID: strings.TrimSpace(req.GetContext().GetSubject().GetId()),
+		CreatedBySubjectID: appaccessservice.SubjectIDFromRequestContext(req.GetContext()),
 	})
 	if err != nil {
 		return nil, err

--- a/gestaltd/services/workflows/workflowmanager/manager_test.go
+++ b/gestaltd/services/workflows/workflowmanager/manager_test.go
@@ -21,10 +21,6 @@ import (
 	gproto "google.golang.org/protobuf/proto"
 )
 
-func workflowRequestSubjectID(reqCtx *proto.RequestContext) string {
-	return appaccessservice.SubjectIDFromRequestContext(reqCtx)
-}
-
 func testWorkflowAppStepTarget(appName, operation string, input map[string]any) coreworkflow.Target {
 	call := &coreworkflow.AppCall{Name: appName, Operation: operation}
 	if input != nil {
@@ -304,7 +300,7 @@ func (p *testWorkflowProvider) ApplyDefinition(_ context.Context, req *proto.App
 		Target:             spec.Target,
 		Activations:        spec.Activations,
 		Paused:             spec.Paused,
-		CreatedBySubjectID: workflowRequestSubjectID(req.GetContext()),
+		CreatedBySubjectID: appaccessservice.SubjectIDFromRequestContext(req.GetContext()),
 		RunAs:              spec.RunAs,
 	}
 	p.definitions[id] = definition
@@ -365,12 +361,12 @@ func (p *testWorkflowProvider) DeleteDefinition(_ context.Context, req *proto.De
 
 func (p *testWorkflowProvider) StartRun(_ context.Context, req *proto.StartWorkflowProviderRunRequest) (*proto.WorkflowRun, error) {
 	p.startRunRequests = append(p.startRunRequests, gproto.Clone(req).(*proto.StartWorkflowProviderRunRequest))
-	return p.startDefinitionRun(req.GetDefinitionId(), req.GetExpectedDefinitionGeneration(), req.GetWorkflowKey(), protoutil.MapFromStruct(req.GetInput()), workflowRequestSubjectID(req.GetContext()))
+	return p.startDefinitionRun(req.GetDefinitionId(), req.GetExpectedDefinitionGeneration(), req.GetWorkflowKey(), protoutil.MapFromStruct(req.GetInput()), appaccessservice.SubjectIDFromRequestContext(req.GetContext()))
 }
 
 func (p *testWorkflowProvider) SignalOrStartRun(_ context.Context, req *proto.SignalOrStartWorkflowProviderRunRequest) (*proto.SignalWorkflowRunResponse, error) {
 	p.signalOrStartRequests = append(p.signalOrStartRequests, gproto.Clone(req).(*proto.SignalOrStartWorkflowProviderRunRequest))
-	runProto, err := p.startDefinitionRun(req.GetDefinitionId(), req.GetExpectedDefinitionGeneration(), req.GetWorkflowKey(), protoutil.MapFromStruct(req.GetInput()), workflowRequestSubjectID(req.GetContext()))
+	runProto, err := p.startDefinitionRun(req.GetDefinitionId(), req.GetExpectedDefinitionGeneration(), req.GetWorkflowKey(), protoutil.MapFromStruct(req.GetInput()), appaccessservice.SubjectIDFromRequestContext(req.GetContext()))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up cleanup after caller-token / request-identity work (#2696, #2699).

- Replace ad-hoc `PrincipalFromSubjectContext(req.GetContext().GetSubject())` patterns in test stubs with `appaccess.SubjectIDFromRequestContext` for consistency with production code
- Remove obsolete `CreateSession` idempotency comment that referenced top-level `subject` on create requests
- Delete `workflowRequestSubjectID` wrapper in workflow manager tests; call `SubjectIDFromRequestContext` directly

## Files changed

| Area | Change |
|------|--------|
| `gestaltd/core/agent/provider.go` | Remove stale comment |
| Bootstrap / server tests | Use `SubjectIDFromRequestContext` in session/turn stubs |
| `agentmanager/manager_test.go` | Use helper for `CreatedBySubjectID` |
| `workflowmanager/manager_test.go` | Inline `SubjectIDFromRequestContext` |
| `workflows/telemetry_test.go` | Use helper |

## Testing

```bash
go test ./services/agents/agentmanager/...
go test ./services/workflows/workflowmanager/...
go test ./services/workflows/...
go test ./internal/bootstrap/...
go test ./internal/server/...
go test ./core/agent/...
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8239310d-27d0-4bc0-bb0f-125bf52b6aad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8239310d-27d0-4bc0-bb0f-125bf52b6aad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

