### PR TITLE
Fix shared migration ledger ahead-of-code checks

### DIFF
--- a/sdk/go/migrations/migrations.go
+++ b/sdk/go/migrations/migrations.go
@@ -121,16 +121,49 @@ func validateRevisions(revisions []Revision) ([]Revision, error) {
 	return out, nil
 }
 
+func revisionNamespaces(revisions []Revision) (prefixes map[string]struct{}, hasFlat bool) {
+	prefixes = make(map[string]struct{}, len(revisions))
+	for _, revision := range revisions {
+		id := strings.TrimSpace(revision.ID)
+		if id == "" {
+			continue
+		}
+		if i := strings.LastIndex(id, "/"); i >= 0 {
+			prefixes[id[:i+1]] = struct{}{}
+			continue
+		}
+		hasFlat = true
+	}
+	return prefixes, hasFlat
+}
+
+func ledgerIDOwnedByProvider(id string, prefixes map[string]struct{}, hasFlat bool) bool {
+	if strings.Contains(id, "/") {
+		for prefix := range prefixes {
+			if strings.HasPrefix(id, prefix) {
+				return true
+			}
+		}
+		return false
+	}
+	return hasFlat && len(prefixes) == 0
+}
+
 func assertNotAheadOfCode(revisions []Revision, applied map[string]struct{}) error {
 	declared := make(map[string]struct{}, len(revisions))
 	for _, revision := range revisions {
 		declared[revision.ID] = struct{}{}
 	}
+	prefixes, hasFlat := revisionNamespaces(revisions)
 	var unknown []string
 	for id := range applied {
-		if _, ok := declared[id]; !ok {
-			unknown = append(unknown, id)
+		if _, ok := declared[id]; ok {
+			continue
 		}
+		if !ledgerIDOwnedByProvider(id, prefixes, hasFlat) {
+			continue
+		}
+		unknown = append(unknown, id)
 	}
 	if len(unknown) == 0 {
 		return nil

--- a/sdk/go/migrations/migrations.go
+++ b/sdk/go/migrations/migrations.go
@@ -137,14 +137,17 @@ func revisionNamespaces(revisions []Revision) (prefixes map[string]struct{}, has
 	return prefixes, hasFlat
 }
 
+func ledgerIDDirectoryPrefix(id string) string {
+	if i := strings.LastIndex(id, "/"); i >= 0 {
+		return id[:i+1]
+	}
+	return ""
+}
+
 func ledgerIDOwnedByProvider(id string, prefixes map[string]struct{}, hasFlat bool) bool {
 	if strings.Contains(id, "/") {
-		for prefix := range prefixes {
-			if strings.HasPrefix(id, prefix) {
-				return true
-			}
-		}
-		return false
+		_, ok := prefixes[ledgerIDDirectoryPrefix(id)]
+		return ok
 	}
 	return hasFlat && len(prefixes) == 0
 }

--- a/sdk/go/migrations/migrations_test.go
+++ b/sdk/go/migrations/migrations_test.go
@@ -273,6 +273,20 @@ func TestRun_LedgerAheadOfCode(t *testing.T) {
 	}
 }
 
+func TestRun_IgnoresOtherProviderLedgerRowsOnSharedDB(t *testing.T) {
+	ctx := context.Background()
+	db := newFakeDB()
+	otherRevision := initRevision("authorization/indexeddb/0001_init", "relationships")
+	if _, err := migrations.Run(ctx, db, migrations.RunOptions{Revisions: []migrations.Revision{otherRevision}}); err != nil {
+		t.Fatalf("seed other provider Run() error = %v", err)
+	}
+
+	revisions := []migrations.Revision{initRevision("auth/oidc/0001_init", "grants")}
+	if _, err := migrations.Run(ctx, db, migrations.RunOptions{Revisions: revisions}); err != nil {
+		t.Fatalf("Run() error = %v, want success on shared ledger", err)
+	}
+}
+
 func TestRun_DuplicateRevisionIDs(t *testing.T) {
 	ctx := context.Background()
 	db := newFakeDB()

--- a/sdk/go/migrations/migrations_test.go
+++ b/sdk/go/migrations/migrations_test.go
@@ -287,6 +287,20 @@ func TestRun_IgnoresOtherProviderLedgerRowsOnSharedDB(t *testing.T) {
 	}
 }
 
+func TestRun_IgnoresDeeperNamespaceLedgerRowsOnSharedDB(t *testing.T) {
+	ctx := context.Background()
+	db := newFakeDB()
+	otherRevision := initRevision("auth/oidc/nested/0001_init", "nested")
+	if _, err := migrations.Run(ctx, db, migrations.RunOptions{Revisions: []migrations.Revision{otherRevision}}); err != nil {
+		t.Fatalf("seed deeper namespace Run() error = %v", err)
+	}
+
+	revisions := []migrations.Revision{initRevision("auth/oidc/0001_init", "grants")}
+	if _, err := migrations.Run(ctx, db, migrations.RunOptions{Revisions: revisions}); err != nil {
+		t.Fatalf("Run() error = %v, want success when ancestor prefix differs", err)
+	}
+}
+
 func TestRun_DuplicateRevisionIDs(t *testing.T) {
 	ctx := context.Background()
 	db := newFakeDB()

--- a/sdk/python/gestalt/migrations.py
+++ b/sdk/python/gestalt/migrations.py
@@ -269,13 +269,39 @@ def _validate_revisions(revisions: list[Revision]) -> list[Revision]:
     return normalized
 
 
+def _revision_namespaces(revisions: list[Revision]) -> tuple[set[str], bool]:
+    prefixes: set[str] = set()
+    has_flat = False
+    for revision in revisions:
+        revision_id = (revision.id or "").strip()
+        if not revision_id:
+            continue
+        if "/" in revision_id:
+            prefixes.add(revision_id.rsplit("/", 1)[0] + "/")
+            continue
+        has_flat = True
+    return prefixes, has_flat
+
+
+def _ledger_id_owned_by_provider(
+    revision_id: str, prefixes: set[str], has_flat: bool
+) -> bool:
+    if "/" in revision_id:
+        return any(revision_id.startswith(prefix) for prefix in prefixes)
+    return has_flat and not prefixes
+
+
 def _assert_not_ahead_of_code(
     revisions: list[Revision],
     applied: set[str],
 ) -> None:
     declared = {revision.id for revision in revisions}
+    prefixes, has_flat = _revision_namespaces(revisions)
     unknown = sorted(
-        revision_id for revision_id in applied if revision_id not in declared
+        revision_id
+        for revision_id in applied
+        if revision_id not in declared
+        and _ledger_id_owned_by_provider(revision_id, prefixes, has_flat)
     )
     if not unknown:
         return

--- a/sdk/python/gestalt/migrations.py
+++ b/sdk/python/gestalt/migrations.py
@@ -283,11 +283,17 @@ def _revision_namespaces(revisions: list[Revision]) -> tuple[set[str], bool]:
     return prefixes, has_flat
 
 
+def _ledger_id_directory_prefix(revision_id: str) -> str:
+    if "/" not in revision_id:
+        return ""
+    return revision_id.rsplit("/", 1)[0] + "/"
+
+
 def _ledger_id_owned_by_provider(
     revision_id: str, prefixes: set[str], has_flat: bool
 ) -> bool:
     if "/" in revision_id:
-        return any(revision_id.startswith(prefix) for prefix in prefixes)
+        return _ledger_id_directory_prefix(revision_id) in prefixes
     return has_flat and not prefixes
 
 

--- a/sdk/python/tests/test_migrations.py
+++ b/sdk/python/tests/test_migrations.py
@@ -119,6 +119,21 @@ class MigrationTests(unittest.TestCase):
             ),
         )
 
+    def test_ignores_deeper_namespace_ledger_rows_on_shared_db(self) -> None:
+        db = FakeDB()
+        run_migrations(
+            db,
+            MigrationRunOptions(
+                revisions=[init_revision("auth/oidc/nested/0001_init", "nested")]
+            ),
+        )
+        run_migrations(
+            db,
+            MigrationRunOptions(
+                revisions=[init_revision("auth/oidc/0001_init", "grants")]
+            ),
+        )
+
     def test_duplicate_revision_ids(self) -> None:
         db = FakeDB()
         revisions: list[Revision] = [

--- a/sdk/python/tests/test_migrations.py
+++ b/sdk/python/tests/test_migrations.py
@@ -104,6 +104,21 @@ class MigrationTests(unittest.TestCase):
         with self.assertRaisesRegex(MigrationError, "ledger is ahead of code"):
             run_migrations(db, MigrationRunOptions(revisions=revisions))
 
+    def test_ignores_other_provider_ledger_rows_on_shared_db(self) -> None:
+        db = FakeDB()
+        run_migrations(
+            db,
+            MigrationRunOptions(
+                revisions=[init_revision("authorization/indexeddb/0001_init", "relationships")]
+            ),
+        )
+        run_migrations(
+            db,
+            MigrationRunOptions(
+                revisions=[init_revision("auth/oidc/0001_init", "grants")]
+            ),
+        )
+
     def test_duplicate_revision_ids(self) -> None:
         db = FakeDB()
         revisions: list[Revision] = [

--- a/sdk/typescript/src/providers/migrations.ts
+++ b/sdk/typescript/src/providers/migrations.ts
@@ -215,12 +215,55 @@ function validateRevisions(revisions: Revision[]): Revision[] {
   return normalized;
 }
 
+function revisionNamespaces(revisions: Revision[]): {
+  prefixes: Set<string>;
+  hasFlat: boolean;
+} {
+  const prefixes = new Set<string>();
+  let hasFlat = false;
+  for (const revision of revisions) {
+    const id = revision.id.trim();
+    if (!id) {
+      continue;
+    }
+    const slash = id.lastIndexOf("/");
+    if (slash >= 0) {
+      prefixes.add(id.slice(0, slash + 1));
+      continue;
+    }
+    hasFlat = true;
+  }
+  return { prefixes, hasFlat };
+}
+
+function ledgerIDOwnedByProvider(
+  id: string,
+  prefixes: Set<string>,
+  hasFlat: boolean,
+): boolean {
+  if (id.includes("/")) {
+    for (const prefix of prefixes) {
+      if (id.startsWith(prefix)) {
+        return true;
+      }
+    }
+    return false;
+  }
+  return hasFlat && prefixes.size === 0;
+}
+
 function assertNotAheadOfCode(
   revisions: Revision[],
   applied: Set<string>,
 ): void {
   const declared = new Set(revisions.map((revision) => revision.id));
-  const unknown = [...applied].filter((id) => !declared.has(id)).sort();
+  const { prefixes, hasFlat } = revisionNamespaces(revisions);
+  const unknown = [...applied]
+    .filter(
+      (id) =>
+        !declared.has(id) && ledgerIDOwnedByProvider(id, prefixes, hasFlat),
+    )
+    .sort();
   if (unknown.length > 0) {
     const attemptedHead = revisions[revisions.length - 1]?.id;
     throw new MigrationError(

--- a/sdk/typescript/src/providers/migrations.ts
+++ b/sdk/typescript/src/providers/migrations.ts
@@ -236,18 +236,21 @@ function revisionNamespaces(revisions: Revision[]): {
   return { prefixes, hasFlat };
 }
 
+function ledgerIDDirectoryPrefix(id: string): string {
+  const slash = id.lastIndexOf("/");
+  if (slash < 0) {
+    return "";
+  }
+  return id.slice(0, slash + 1);
+}
+
 function ledgerIDOwnedByProvider(
   id: string,
   prefixes: Set<string>,
   hasFlat: boolean,
 ): boolean {
   if (id.includes("/")) {
-    for (const prefix of prefixes) {
-      if (id.startsWith(prefix)) {
-        return true;
-      }
-    }
-    return false;
+    return prefixes.has(ledgerIDDirectoryPrefix(id));
   }
   return hasFlat && prefixes.size === 0;
 }

--- a/sdk/typescript/tests/migrations.test.ts
+++ b/sdk/typescript/tests/migrations.test.ts
@@ -348,6 +348,25 @@ describe("runMigrations", () => {
     ).rejects.toThrow(/ledger is ahead/);
   });
 
+  test("ignores deeper namespace ledger rows on a shared db", async () => {
+    const { db } = fakeDb();
+    const nested: Revision = {
+      id: "auth/oidc/nested/0001_init",
+      schema: {
+        stores: [{ name: "nested", columns: [{ name: "id", primaryKey: true }] }],
+      },
+    };
+    await runMigrations(db, { revisions: [nested] });
+
+    const sibling: Revision = {
+      id: "auth/oidc/0001_init",
+      schema: {
+        stores: [{ name: "grants", columns: [{ name: "id", primaryKey: true }] }],
+      },
+    };
+    await expect(runMigrations(db, { revisions: [sibling] })).resolves.toBeDefined();
+  });
+
   test("fails closed when a revision is inserted before an applied one", async () => {
     const { db } = fakeDb();
     const first = issuesRevision; // 0001_issues


### PR DESCRIPTION
Multiple providers share one ledger on `main-db`. Ahead-of-code validation now only considers rows in the configuring provider's revision namespace.

```mermaid
flowchart TB
  subgraph main_db["main-db"]
    subgraph ledger["_gestalt_migrations"]
      R1["authorization/indexeddb/0001_init"]
      R2["auth/oidc/0001_init"]
      R3["workflow/temporal/0001_init"]
    end
    S1[(authorization stores)]
    S2[(oidc stores)]
  end
  P1[authorization/indexeddb] -->|namespace: authorization/indexeddb/*| ledger
  P2[auth/oidc] -->|namespace: auth/oidc/*| ledger
```

```mermaid
flowchart LR
  subgraph before["before"]
    L1[ledger has R1] --> C1[auth/oidc configures]
    C1 --> X1["R1 ∉ declared → ahead of code"]
  end
  subgraph after["after"]
    L2[ledger has R1] --> C2[auth/oidc configures]
    C2 --> OK["ignore R1; validate auth/oidc/* only"]
  end
```

```text
# Ledger record
{ "revision_id": "authorization/indexeddb/0001_init", "applied_at": "..." }

# auth/oidc RunOptions.revisions
[{ id: "auth/oidc/0001_init", schema: ... }]

# ahead-of-code: unknown ⊆ { applied keys with prefix "auth/oidc/" } \ declared
```