### PR TITLE
Add providers.local for selective remote delegation

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -935,7 +935,8 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 		return nil, fmt.Errorf("bootstrap: system indexeddb from resource %q: %w", selectedIndexedDBName, storeErr)
 	}
 	store = metricutil.InstrumentIndexedDB(store, selectedIndexedDBName)
-	svc, svcErr := coredata.NewWithContext(ctx, store)
+	skipSchemaBootstrap := !providerBuildsLocal(cfg, def)
+	svc, svcErr := coredata.NewWithOptions(ctx, store, coredata.NewOptions{SkipSchemaBootstrap: skipSchemaBootstrap})
 	if svcErr != nil {
 		_ = store.Close()
 		return nil, fmt.Errorf("bootstrap: system indexeddb from resource %q: %w", selectedIndexedDBName, svcErr)
@@ -1535,7 +1536,7 @@ func providerBuildsLocal(cfg *config.Config, entry *config.ProviderEntry) bool {
 	if entry == nil {
 		return false
 	}
-	if entry.DevActive {
+	if entry.DevActive || entry.Local {
 		return true
 	}
 	return cfg == nil || strings.TrimSpace(cfg.Server.Remote) == ""

--- a/gestaltd/internal/bootstrap/provider_build_test.go
+++ b/gestaltd/internal/bootstrap/provider_build_test.go
@@ -889,6 +889,9 @@ func TestProviderBuildsLocal(t *testing.T) {
 	if !providerBuildsLocal(cfg, &config.ProviderEntry{DevActive: true}) {
 		t.Fatal("DevActive entry should build local")
 	}
+	if !providerBuildsLocal(cfg, &config.ProviderEntry{Local: true}) {
+		t.Fatal("local entry should build local when server.remote is configured")
+	}
 	if providerBuildsLocal(cfg, &config.ProviderEntry{}) {
 		t.Fatal("non-DevActive entry with remote configured should not build local")
 	}

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -487,9 +487,9 @@ func normalizeGitLocationManifestPath(raw string) string {
 
 // ProviderEntry is the universal configuration for any provider.
 type ProviderEntry struct {
-	Source          ProviderSource                         `yaml:"source"`
-	Config          yaml.Node                              `yaml:"config,omitempty"`
-	Default         bool                                   `yaml:"default,omitempty"`
+	Source  ProviderSource `yaml:"source"`
+	Config  yaml.Node      `yaml:"config,omitempty"`
+	Default bool           `yaml:"default,omitempty"`
 	// Local forces this provider to build in-process locally even when
 	// server.remote delegates other host providers to a remote gestaltd.
 	Local           bool                                   `yaml:"local,omitempty"`

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -490,6 +490,9 @@ type ProviderEntry struct {
 	Source          ProviderSource                         `yaml:"source"`
 	Config          yaml.Node                              `yaml:"config,omitempty"`
 	Default         bool                                   `yaml:"default,omitempty"`
+	// Local forces this provider to build in-process locally even when
+	// server.remote delegates other host providers to a remote gestaltd.
+	Local           bool                                   `yaml:"local,omitempty"`
 	Env             map[string]string                      `yaml:"env,omitempty"`
 	Egress          *ProviderEgressConfig                  `yaml:"egress,omitempty"`
 	DisplayName     string                                 `yaml:"displayName,omitempty"`

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -143,6 +143,32 @@ func singletonProviderEntry(entry *ProviderEntry) map[string]*ProviderEntry {
 	}
 }
 
+func TestLoadConfigProviderLocalFlag(t *testing.T) {
+	t.Parallel()
+
+	path := mustWriteConfigFile(t, `
+apiVersion: gestaltd.config/v8
+server:
+  remote: https://valon.tools
+providers:
+  indexeddb:
+    local-dev:
+      local: true
+      source: https://example.com/indexeddb/provider-release.yaml
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	entry := cfg.Providers.IndexedDB["local-dev"]
+	if entry == nil {
+		t.Fatal("local-dev indexeddb provider is missing")
+	}
+	if !entry.Local {
+		t.Fatal("expected providers.indexeddb.local-dev.local = true")
+	}
+}
+
 func TestLoadConfigGenericFixture(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/coredata/services.go
+++ b/gestaltd/internal/coredata/services.go
@@ -15,22 +15,35 @@ type Services struct {
 	DB                  indexeddb.IndexedDB
 }
 
+// NewOptions configures coredata bootstrap behavior.
+type NewOptions struct {
+	// SkipSchemaBootstrap skips CreateObjectStore for host control-plane stores.
+	// Use when main-db is delegated to a remote gestaltd that already owns schema.
+	SkipSchemaBootstrap bool
+}
+
 func New(ds indexeddb.IndexedDB) (*Services, error) {
-	return NewWithContext(context.Background(), ds)
+	return NewWithOptions(context.Background(), ds, NewOptions{})
 }
 
 func NewWithContext(ctx context.Context, ds indexeddb.IndexedDB) (*Services, error) {
+	return NewWithOptions(ctx, ds, NewOptions{})
+}
+
+func NewWithOptions(ctx context.Context, ds indexeddb.IndexedDB, opts NewOptions) (*Services, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if _, err := ds.CreateObjectStore(ctx, StoreUsers, UsersSchema); err != nil {
-		return nil, fmt.Errorf("create users store: %w", err)
-	}
-	if _, err := ds.CreateObjectStore(ctx, StoreManagedSubjects, ManagedSubjectsSchema); err != nil {
-		return nil, fmt.Errorf("create managed_subjects store: %w", err)
-	}
-	if _, err := ds.CreateObjectStore(ctx, StoreAppSHAs, AppSHAsSchema); err != nil {
-		return nil, fmt.Errorf("create app_shas store: %w", err)
+	if !opts.SkipSchemaBootstrap {
+		if _, err := ds.CreateObjectStore(ctx, StoreUsers, UsersSchema); err != nil {
+			return nil, fmt.Errorf("create users store: %w", err)
+		}
+		if _, err := ds.CreateObjectStore(ctx, StoreManagedSubjects, ManagedSubjectsSchema); err != nil {
+			return nil, fmt.Errorf("create managed_subjects store: %w", err)
+		}
+		if _, err := ds.CreateObjectStore(ctx, StoreAppSHAs, AppSHAsSchema); err != nil {
+			return nil, fmt.Errorf("create app_shas store: %w", err)
+		}
 	}
 	users := NewUserService(ds)
 	managedSubjects := NewManagedSubjectService(ds)

--- a/gestaltd/internal/coredata/services_test.go
+++ b/gestaltd/internal/coredata/services_test.go
@@ -255,6 +255,18 @@ func TestNew(t *testing.T) {
 		}
 	})
 
+	t.Run("skip_schema_bootstrap", func(t *testing.T) {
+		t.Parallel()
+
+		db := newCreateContextRecordingIndexedDB(&coretesting.StubIndexedDB{})
+		if _, err := coredata.NewWithOptions(context.Background(), db, coredata.NewOptions{SkipSchemaBootstrap: true}); err != nil {
+			t.Fatalf("coredata.NewWithOptions: %v", err)
+		}
+		if len(db.createdStoreContexts()) != 0 {
+			t.Fatalf("CreateObjectStore calls = %d, want 0", len(db.createdStoreContexts()))
+		}
+	})
+
 }
 
 func TestUserService(t *testing.T) {

--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -274,8 +274,10 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 	if !principal.AllowsOperationPermission(p, providerName, opMeta.ID) {
 		return fail(fmt.Errorf("%w: %s.%s", ErrScopeDenied, providerName, opMeta.ID))
 	}
-	if err := b.checkAuthorizationAccess(ctx, p, providerName, opMeta.ID); err != nil {
-		return fail(err)
+	if !providerDelegatesRemoteAuthorization(prov) {
+		if err := b.checkAuthorizationAccess(ctx, p, providerName, opMeta.ID); err != nil {
+			return fail(err)
+		}
 	}
 	metricOperation = operation
 	metricTransport = metricutil.AttrValue(transport)
@@ -463,8 +465,10 @@ func (b *Broker) InvokeGraphQL(ctx context.Context, p *principal.Principal, prov
 	}
 	ctx = withResolvedPrincipal(ctx, p)
 	setSubjectAttribute(p)
-	if err := b.checkAuthorizationAccess(ctx, p, providerName, graphQLOperationID); err != nil {
-		return fail(err)
+	if !providerDelegatesRemoteAuthorization(prov) {
+		if err := b.checkAuthorizationAccess(ctx, p, providerName, graphQLOperationID); err != nil {
+			return fail(err)
+		}
 	}
 
 	conn := ConnectionFromContext(ctx)
@@ -529,6 +533,14 @@ func (b *Broker) ResolveToken(ctx context.Context, p *principal.Principal, provi
 		return ctx, "", fmt.Errorf("%w: looking up provider: %v", ErrInternal, err)
 	}
 	return b.resolveToken(ctx, prov, p, providerName, connection, instance)
+}
+
+func providerDelegatesRemoteAuthorization(prov core.Provider) bool {
+	if prov == nil {
+		return false
+	}
+	delegated, ok := prov.(RemoteCredentialDelegated)
+	return ok && delegated.RemoteCredentialDelegated()
 }
 
 func (b *Broker) checkAuthorizationAccess(ctx context.Context, p *principal.Principal, providerName, operationID string) error {

--- a/gestaltd/services/invocation/broker_test.go
+++ b/gestaltd/services/invocation/broker_test.go
@@ -322,6 +322,56 @@ func TestBrokerInvokeChecksAuthorizationBeforeExecution(t *testing.T) {
 	}
 }
 
+func TestBrokerInvokeSkipsLocalAuthorizationForRemoteDelegatedApps(t *testing.T) {
+	t.Parallel()
+
+	executed := false
+	provider := &remoteDelegatedAppStub{
+		StubIntegration: &coretesting.StubIntegration{
+			N:        "linear",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{
+				Operations: []catalog.CatalogOperation{{ID: "issues.list"}},
+			},
+			ExecuteFn: func(context.Context, string, map[string]any, string) (*core.OperationResult, error) {
+				executed = true
+				return &core.OperationResult{Status: 200, Body: []byte("ok")}, nil
+			},
+		},
+	}
+	authz := &recordingAuthorizationProvider{allowed: false}
+	broker := NewBroker(
+		testutil.NewProviderRegistry(t, provider),
+		nil,
+		nil,
+		WithAuthorizationProvider(authz),
+	)
+
+	_, err := broker.Invoke(
+		context.Background(),
+		&principal.Principal{SubjectID: "user:u-123", Kind: principal.KindUser},
+		"linear",
+		"",
+		"issues.list",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if !executed {
+		t.Fatal("Execute was not called")
+	}
+	if authz.lastCheckAccess != nil {
+		t.Fatal("CheckAccess should be skipped for remote-delegated apps")
+	}
+}
+
+type remoteDelegatedAppStub struct {
+	*coretesting.StubIntegration
+}
+
+func (p *remoteDelegatedAppStub) RemoteCredentialDelegated() bool { return true }
+
 func TestBrokerInvokeGraphQLAuthorizationDeniesBeforeCredentialResolution(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
`providers.*.local: true` keeps named host providers on the machine when `server.remote` is set.

```yaml
server:
  remote: https://valon.tools
providers:
  indexeddb:
    local-dev:
      local: true
      config:
        dsn: sqlite://./valon-tools-local-dev.db
  authorization:
    indexeddb:
      local: true
      config:
        indexeddb: local-dev
apps:
  ciCd:
    indexeddb:
      provider: local-dev
```

```mermaid
sequenceDiagram
    actor Dev as Developer
    box rgb(200, 230, 255) Local
        participant GD as gestaltd
        participant Authz as Authorization
        participant IDB as IndexedDB local-dev
        participant App as ci-cd
    end
    box rgb(255, 220, 200) Remote
        participant GW as public gRPC gateway
        participant Id as Identity
    end
    Dev->>GD: invoke ciCd prs.list
    GD->>GW: Identity/Introspect
    GW-->>GD: subject
    GD->>Authz: CheckAccess(ciCd, prs.list)
    Authz->>IDB: local authorization.models
    GD->>App: execute
```

Remote app invokes skip local `CheckAccess`; prod gateway authorizes `App/Invoke`. Remote `main-db` skips coredata schema bootstrap.

Made with [Cursor](https://cursor.com)