### PR TITLE
Fix daemon e2e failure: restore strict source manifest decode

### DIFF
--- a/gestaltd/services/apps/packageio/manifest.go
+++ b/gestaltd/services/apps/packageio/manifest.go
@@ -77,13 +77,7 @@ func DecodeManifestFormat(data []byte, format string) (*providermanifestv1.Manif
 
 func decodeManifest(data []byte, format string, sourceMode bool) (*providermanifestv1.Manifest, error) {
 	var manifest providermanifestv1.Manifest
-	var err error
-	if sourceMode {
-		err = decodeLenient(data, format, "manifest", &manifest)
-	} else {
-		err = decodeStrict(data, format, "manifest", &manifest)
-	}
-	if err != nil {
+	if err := decodeStrict(data, format, "manifest", &manifest); err != nil {
 		return nil, err
 	}
 	if err := validateManifest(&manifest, sourceMode); err != nil {
@@ -803,26 +797,6 @@ func decodeStrict(data []byte, format, subject string, target any) error {
 	case ManifestFormatYAML:
 		dec := yaml.NewDecoder(bytes.NewReader(data))
 		dec.KnownFields(true)
-		if err := dec.Decode(target); err != nil {
-			return fmt.Errorf("parse %s YAML: %w", subject, err)
-		}
-		return nil
-	default:
-		return fmt.Errorf("unsupported %s format %q", subject, format)
-	}
-}
-
-func decodeLenient(data []byte, format, subject string, target any) error {
-	switch format {
-	case ManifestFormatJSON:
-		dec := json.NewDecoder(bytes.NewReader(data))
-		if err := dec.Decode(target); err != nil {
-			return fmt.Errorf("parse %s JSON: %w", subject, err)
-		}
-		return nil
-	case ManifestFormatYAML:
-		dec := yaml.NewDecoder(bytes.NewReader(data))
-		dec.KnownFields(false)
 		if err := dec.Decode(target); err != nil {
 			return fmt.Errorf("parse %s YAML: %w", subject, err)
 		}


### PR DESCRIPTION
## Summary
- Restore `decodeStrict` for source manifests in `packageio/manifest.go`.
- Remove the `decodeLenient` path added in gestalt step 1 (#2709).

Step 1 switched source manifests to lenient JSON decode, which silently dropped deleted top-level fields like `release`. That caused `TestRun_ProviderPackageRejectsDeletedBuild` to fail on unrelated validation (`spec.assetRoot`) instead of the intended `unknown field` error, breaking scheduled `Go E2E Tests (daemon)` on `main`.

## Test plan
- [x] `go test ./internal/daemon/e2e/... -run TestRun_ProviderPackageRejectsDeletedBuild`
- [x] `go test ./services/apps/packageio/... ./services/apps/providerpkg/...`
- [x] `go test ./internal/daemon/e2e/app_publish/...`


Made with [Cursor](https://cursor.com)