### PR TITLE
Add manifest contract fields for strict source decode

### DIFF
--- a/gestaltd/internal/daemon/app_publish.go
+++ b/gestaltd/internal/daemon/app_publish.go
@@ -398,12 +398,12 @@ func buildAppPublishPlan(input appPublishPlanInput) (appPublishPlan, error) {
 
 	indexRel := layout.IndexPath
 	return appPublishPlan{
-		Schema:       appPublishPlanSchema,
-		AppName:      entry.App,
-		DisplayName:  input.DisplayName,
-		Description:  input.Description,
-		Version:      input.Version,
-		Entry:        entry,
+		Schema:      appPublishPlanSchema,
+		AppName:     entry.App,
+		DisplayName: input.DisplayName,
+		Description: input.Description,
+		Version:     input.Version,
+		Entry:       entry,
 		EntryObject: appPublishObject{
 			Kind:       "entry",
 			LocalPath:  entryPath,

--- a/gestaltd/internal/daemon/provider_release_finalize.go
+++ b/gestaltd/internal/daemon/provider_release_finalize.go
@@ -249,7 +249,15 @@ func buildProviderReleaseMetadata(manifest *providermanifestv1.Manifest, version
 	if err != nil {
 		return nil, err
 	}
-	requires, compatibility, err := providerrelease.ParseContract(manifest, contractRaw)
+	var requires providerrelease.Requires
+	var compatibility providerrelease.Compatibility
+	if len(rawManifest) > 0 {
+		// Provider publish passes authoritative source --manifest bytes separately from
+		// the built archive manifest struct; contract metadata must follow the source file.
+		requires, compatibility, err = providerrelease.ParseContractFromManifestRaw(contractRaw)
+	} else {
+		requires, compatibility, err = providerrelease.ParseContract(manifest, contractRaw)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("parse release contract from manifest: %w", err)
 	}

--- a/gestaltd/internal/daemon/provider_release_finalize.go
+++ b/gestaltd/internal/daemon/provider_release_finalize.go
@@ -249,7 +249,7 @@ func buildProviderReleaseMetadata(manifest *providermanifestv1.Manifest, version
 	if err != nil {
 		return nil, err
 	}
-	requires, compatibility, err := providerrelease.ParseContractFromManifestRaw(contractRaw)
+	requires, compatibility, err := providerrelease.ParseContract(manifest, contractRaw)
 	if err != nil {
 		return nil, fmt.Errorf("parse release contract from manifest: %w", err)
 	}

--- a/gestaltd/internal/daemon/provider_release_finalize_test.go
+++ b/gestaltd/internal/daemon/provider_release_finalize_test.go
@@ -452,6 +452,63 @@ func TestProviderReleaseMetadataRejectsMCPAppWithoutStaticCatalog(t *testing.T) 
 	}
 }
 
+func TestProviderReleaseMetadataSnapshotsManifestContract(t *testing.T) {
+	t.Parallel()
+
+	metadata, err := buildProviderReleaseMetadataForRawManifest(t, `kind: app
+source: github.com/testowner/apps/catalog/release-test
+version: 1.0.0
+displayName: Contract App
+dependencies:
+  apps:
+    github.com/acme/apps/base:
+      version: 1.2.3
+      operations:
+        listItems:
+          inputSchemaHash: abc123
+compatibility:
+  minGestaltdVersion: 0.5.0
+artifacts:
+  - os: test
+    arch: test
+    path: provider
+    sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+entrypoint:
+  artifactPath: provider
+spec:
+  surfaces:
+    rest:
+      connection: default
+      baseUrl: https://api.example.test
+      operations:
+        - name: createThing
+          method: POST
+          path: /things
+  connections:
+    default:
+      auth:
+        type: none
+`, map[string]string{
+		"provider": "",
+	})
+	if err != nil {
+		t.Fatalf("buildProviderReleaseMetadata: %v", err)
+	}
+	if metadata.StaticValidation == nil || metadata.StaticValidation.Requires == nil {
+		t.Fatalf("requires metadata missing: %#v", metadata.StaticValidation)
+	}
+	app := metadata.StaticValidation.Requires.Apps["github.com/acme/apps/base"]
+	if app.Version != "1.2.3" {
+		t.Fatalf("requires app version = %q", app.Version)
+	}
+	if app.Operations["listItems"].InputSchemaHash != "abc123" {
+		t.Fatalf("requires operations = %#v", app.Operations)
+	}
+	if metadata.StaticValidation.Compatibility == nil || metadata.StaticValidation.Compatibility.MinGestaltdVersion != "0.5.0" {
+		t.Fatalf("compatibility metadata missing: %#v", metadata.StaticValidation.Compatibility)
+	}
+}
+
 func buildProviderReleaseMetadataForManifest(t *testing.T, manifest *providermanifestv1.Manifest, files map[string]string) (*providerrelease.Metadata, error) {
 	t.Helper()
 

--- a/gestaltd/internal/daemon/provider_release_finalize_test.go
+++ b/gestaltd/internal/daemon/provider_release_finalize_test.go
@@ -509,6 +509,83 @@ spec:
 	}
 }
 
+func TestProviderReleaseMetadataUsesExplicitSourceContractBytes(t *testing.T) {
+	t.Parallel()
+
+	archiveManifest := &providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindApp,
+		Source:      releaseTestSource,
+		Version:     "1.0.0",
+		DisplayName: "Contract App",
+		Dependencies: &providermanifestv1.ManifestDependencies{
+			Apps: map[string]providermanifestv1.ManifestAppDependency{
+				"github.com/acme/apps/base": {Version: "1.0.0"},
+			},
+		},
+		Compatibility: &providermanifestv1.ManifestCompatibility{
+			MinGestaltdVersion: "0.4.0",
+		},
+		Spec: &providermanifestv1.Spec{
+			Surfaces: &providermanifestv1.ProviderSurfaces{
+				REST: &providermanifestv1.RESTSurface{
+					Connection: "default",
+					BaseURL:    "https://api.example.test",
+					Operations: []providermanifestv1.ProviderOperation{{Name: "createThing", Method: "POST", Path: "/things"}},
+				},
+			},
+			Connections: map[string]*providermanifestv1.ManifestConnectionDef{
+				"default": {Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone}},
+			},
+		},
+		Artifacts: []providermanifestv1.Artifact{{
+			OS:     "test",
+			Arch:   "test",
+			Path:   "provider",
+			SHA256: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		}},
+		Entrypoint: &providermanifestv1.Entrypoint{ArtifactPath: "provider"},
+	}
+	sourceManifest := `kind: app
+source: github.com/testowner/apps/catalog/release-test
+version: 1.0.0
+displayName: Contract App
+compatibility:
+  minGestaltdVersion: 0.5.0
+artifacts:
+  - os: test
+    arch: test
+    path: provider
+    sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+entrypoint:
+  artifactPath: provider
+spec:
+  surfaces:
+    rest:
+      connection: default
+      baseUrl: https://api.example.test
+      operations:
+        - name: createThing
+          method: POST
+          path: /things
+  connections:
+    default:
+      auth:
+        type: none
+`
+	metadata, err := buildProviderReleaseMetadataForManifestWithExplicitSource(t, archiveManifest, sourceManifest, map[string]string{
+		"provider": "",
+	})
+	if err != nil {
+		t.Fatalf("buildProviderReleaseMetadata: %v", err)
+	}
+	if metadata.StaticValidation != nil && metadata.StaticValidation.Requires != nil {
+		t.Fatalf("requires metadata = %#v, want source manifest without dependencies", metadata.StaticValidation.Requires)
+	}
+	if metadata.StaticValidation == nil || metadata.StaticValidation.Compatibility == nil || metadata.StaticValidation.Compatibility.MinGestaltdVersion != "0.5.0" {
+		t.Fatalf("compatibility metadata = %#v, want minGestaltdVersion from source manifest", metadata.StaticValidation)
+	}
+}
+
 func buildProviderReleaseMetadataForManifest(t *testing.T, manifest *providermanifestv1.Manifest, files map[string]string) (*providerrelease.Metadata, error) {
 	t.Helper()
 
@@ -544,6 +621,44 @@ func buildProviderReleaseMetadataForManifest(t *testing.T, manifest *providerman
 		"1.0.0",
 		[]releaseArchive{{Path: archive, SHA256: archiveSHA, Target: providerpkg.CurrentPlatformString()}},
 		nil,
+	)
+}
+
+func buildProviderReleaseMetadataForManifestWithExplicitSource(t *testing.T, manifest *providermanifestv1.Manifest, sourceManifest string, files map[string]string) (*providerrelease.Metadata, error) {
+	t.Helper()
+
+	packageDir := t.TempDir()
+	data, err := providerpkg.EncodeManifestFormat(manifest, providerpkg.ManifestFormatJSON)
+	if err != nil {
+		t.Fatalf("EncodeManifestFormat: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(packageDir, providerpkg.ManifestFile), data, 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	for name, contents := range files {
+		path := filepath.Join(packageDir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("create %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	outputDir := t.TempDir()
+	archive := filepath.Join(outputDir, "gestalt-app-release-test_v1.0.0.tar.gz")
+	if err := providerpkg.CreatePackageFromDir(packageDir, archive); err != nil {
+		t.Fatalf("CreatePackageFromDir: %v", err)
+	}
+	archiveSHA, err := providerpkg.ArchiveDigest(archive)
+	if err != nil {
+		t.Fatalf("ArchiveDigest: %v", err)
+	}
+
+	return buildProviderReleaseMetadata(
+		manifest,
+		"1.0.0",
+		[]releaseArchive{{Path: archive, SHA256: archiveSHA, Target: providerpkg.CurrentPlatformString()}},
+		[]byte(sourceManifest),
 	)
 }
 

--- a/gestaltd/internal/providerrelease/contract.go
+++ b/gestaltd/internal/providerrelease/contract.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"gopkg.in/yaml.v3"
 )
 
@@ -24,6 +25,41 @@ type OperationRequirement struct {
 
 type Compatibility struct {
 	MinGestaltdVersion string `yaml:"minGestaltdVersion,omitempty" json:"minGestaltdVersion,omitempty"`
+}
+
+// ParseContract prefers contract fields decoded on the manifest struct and falls back
+// to parsing raw manifest bytes for older packages that only embed contract metadata.
+func ParseContract(manifest *providermanifestv1.Manifest, raw []byte) (Requires, Compatibility, error) {
+	requires, compatibility := ContractFromManifest(manifest)
+	if len(requires.Apps) > 0 || compatibility.MinGestaltdVersion != "" {
+		return requires, compatibility, nil
+	}
+	return ParseContractFromManifestRaw(raw)
+}
+
+func ContractFromManifest(manifest *providermanifestv1.Manifest) (Requires, Compatibility) {
+	if manifest == nil {
+		return Requires{}, Compatibility{}
+	}
+	var requires Requires
+	if manifest.Dependencies != nil && len(manifest.Dependencies.Apps) > 0 {
+		requires.Apps = make(map[string]AppRequirement, len(manifest.Dependencies.Apps))
+		for name, dep := range manifest.Dependencies.Apps {
+			req := AppRequirement{Version: dep.Version}
+			if len(dep.Operations) > 0 {
+				req.Operations = make(map[string]OperationRequirement, len(dep.Operations))
+				for opName, opDep := range dep.Operations {
+					req.Operations[opName] = OperationRequirement{InputSchemaHash: opDep.InputSchemaHash}
+				}
+			}
+			requires.Apps[name] = req
+		}
+	}
+	var compatibility Compatibility
+	if manifest.Compatibility != nil {
+		compatibility.MinGestaltdVersion = manifest.Compatibility.MinGestaltdVersion
+	}
+	return requires, compatibility
 }
 
 func ParseContractFromManifestRaw(raw []byte) (Requires, Compatibility, error) {

--- a/gestaltd/internal/providerrelease/contract.go
+++ b/gestaltd/internal/providerrelease/contract.go
@@ -27,8 +27,9 @@ type Compatibility struct {
 	MinGestaltdVersion string `yaml:"minGestaltdVersion,omitempty" json:"minGestaltdVersion,omitempty"`
 }
 
-// ParseContract prefers contract fields decoded on the manifest struct and falls back
-// to parsing raw manifest bytes for older packages that only embed contract metadata.
+// ParseContract prefers contract fields decoded on the release archive manifest struct
+// and falls back to parsing raw manifest bytes for older packages that only embed
+// contract metadata in the archive file.
 func ParseContract(manifest *providermanifestv1.Manifest, raw []byte) (Requires, Compatibility, error) {
 	requires, compatibility := ContractFromManifest(manifest)
 	if len(requires.Apps) > 0 || compatibility.MinGestaltdVersion != "" {

--- a/gestaltd/internal/providerrelease/contract_test.go
+++ b/gestaltd/internal/providerrelease/contract_test.go
@@ -1,0 +1,81 @@
+package providerrelease
+
+import (
+	"testing"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+func TestParseContract_PrefersManifestStruct(t *testing.T) {
+	t.Parallel()
+
+	manifest := &providermanifestv1.Manifest{
+		Dependencies: &providermanifestv1.ManifestDependencies{
+			Apps: map[string]providermanifestv1.ManifestAppDependency{
+				"github.com/acme/apps/base": {
+					Version: "1.0.0",
+					Operations: map[string]providermanifestv1.ManifestOperationDependency{
+						"listItems": {InputSchemaHash: "abc123"},
+					},
+				},
+			},
+		},
+		Compatibility: &providermanifestv1.ManifestCompatibility{
+			MinGestaltdVersion: "0.5.0",
+		},
+	}
+	raw := []byte(`dependencies:
+  apps:
+    github.com/other/apps/ignored:
+      version: 9.9.9
+compatibility:
+  minGestaltdVersion: 9.9.9
+`)
+
+	requires, compatibility, err := ParseContract(manifest, raw)
+	if err != nil {
+		t.Fatalf("ParseContract: %v", err)
+	}
+	if len(requires.Apps) != 1 {
+		t.Fatalf("requires.Apps = %#v, want one app", requires.Apps)
+	}
+	app, ok := requires.Apps["github.com/acme/apps/base"]
+	if !ok {
+		t.Fatalf("requires.Apps = %#v", requires.Apps)
+	}
+	if app.Version != "1.0.0" {
+		t.Fatalf("app version = %q", app.Version)
+	}
+	if app.Operations["listItems"].InputSchemaHash != "abc123" {
+		t.Fatalf("operations = %#v", app.Operations)
+	}
+	if compatibility.MinGestaltdVersion != "0.5.0" {
+		t.Fatalf("minGestaltdVersion = %q", compatibility.MinGestaltdVersion)
+	}
+}
+
+func TestParseContract_FallsBackToRawManifest(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`kind: app
+source: github.com/testowner/apps/contract
+version: 1.0.0
+dependencies:
+  apps:
+    github.com/acme/apps/base:
+      version: 2.0.0
+compatibility:
+  minGestaltdVersion: 0.4.0
+`)
+
+	requires, compatibility, err := ParseContract(nil, raw)
+	if err != nil {
+		t.Fatalf("ParseContract: %v", err)
+	}
+	if requires.Apps["github.com/acme/apps/base"].Version != "2.0.0" {
+		t.Fatalf("requires.Apps = %#v", requires.Apps)
+	}
+	if compatibility.MinGestaltdVersion != "0.4.0" {
+		t.Fatalf("minGestaltdVersion = %q", compatibility.MinGestaltdVersion)
+	}
+}

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -40,9 +40,30 @@ type Manifest struct {
 	Install     *SourceInstall `json:"install,omitempty" yaml:"install,omitempty"`
 	Build       *SourceBuild   `json:"build,omitempty" yaml:"build,omitempty"`
 	Run         *SourceRun     `json:"run,omitempty" yaml:"run,omitempty"`
-	Artifacts   []Artifact     `json:"artifacts,omitempty" yaml:"artifacts,omitempty"`
-	Entrypoint  *Entrypoint    `json:"entrypoint,omitempty" yaml:"entrypoint,omitempty"`
-	Spec        *Spec          `json:"spec,omitempty" yaml:"spec,omitempty"`
+	Artifacts     []Artifact             `json:"artifacts,omitempty" yaml:"artifacts,omitempty"`
+	Entrypoint    *Entrypoint            `json:"entrypoint,omitempty" yaml:"entrypoint,omitempty"`
+	Spec          *Spec                  `json:"spec,omitempty" yaml:"spec,omitempty"`
+	Dependencies  *ManifestDependencies  `json:"dependencies,omitempty" yaml:"dependencies,omitempty"`
+	Compatibility *ManifestCompatibility `json:"compatibility,omitempty" yaml:"compatibility,omitempty"`
+}
+
+// ManifestDependencies declares app registry contract requirements for a provider package.
+type ManifestDependencies struct {
+	Apps map[string]ManifestAppDependency `json:"apps,omitempty" yaml:"apps,omitempty"`
+}
+
+type ManifestAppDependency struct {
+	Version    string                                    `json:"version,omitempty" yaml:"version,omitempty"`
+	Operations map[string]ManifestOperationDependency    `json:"operations,omitempty" yaml:"operations,omitempty"`
+}
+
+type ManifestOperationDependency struct {
+	InputSchemaHash string `json:"inputSchemaHash,omitempty" yaml:"inputSchemaHash,omitempty"`
+}
+
+// ManifestCompatibility declares runtime compatibility constraints for a provider package.
+type ManifestCompatibility struct {
+	MinGestaltdVersion string `json:"minGestaltdVersion,omitempty" yaml:"minGestaltdVersion,omitempty"`
 }
 
 type SourceBuild struct {

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -31,15 +31,15 @@ func NormalizeKind(kind string) string {
 }
 
 type Manifest struct {
-	Kind        string         `json:"kind,omitempty" yaml:"kind,omitempty"`
-	Source      string         `json:"source,omitempty" yaml:"source,omitempty"`
-	Version     string         `json:"version" yaml:"version"`
-	DisplayName string         `json:"displayName,omitempty" yaml:"displayName,omitempty"`
-	Description string         `json:"description,omitempty" yaml:"description,omitempty"`
-	IconFile    string         `json:"iconFile,omitempty" yaml:"iconFile,omitempty"`
-	Install     *SourceInstall `json:"install,omitempty" yaml:"install,omitempty"`
-	Build       *SourceBuild   `json:"build,omitempty" yaml:"build,omitempty"`
-	Run         *SourceRun     `json:"run,omitempty" yaml:"run,omitempty"`
+	Kind          string                 `json:"kind,omitempty" yaml:"kind,omitempty"`
+	Source        string                 `json:"source,omitempty" yaml:"source,omitempty"`
+	Version       string                 `json:"version" yaml:"version"`
+	DisplayName   string                 `json:"displayName,omitempty" yaml:"displayName,omitempty"`
+	Description   string                 `json:"description,omitempty" yaml:"description,omitempty"`
+	IconFile      string                 `json:"iconFile,omitempty" yaml:"iconFile,omitempty"`
+	Install       *SourceInstall         `json:"install,omitempty" yaml:"install,omitempty"`
+	Build         *SourceBuild           `json:"build,omitempty" yaml:"build,omitempty"`
+	Run           *SourceRun             `json:"run,omitempty" yaml:"run,omitempty"`
 	Artifacts     []Artifact             `json:"artifacts,omitempty" yaml:"artifacts,omitempty"`
 	Entrypoint    *Entrypoint            `json:"entrypoint,omitempty" yaml:"entrypoint,omitempty"`
 	Spec          *Spec                  `json:"spec,omitempty" yaml:"spec,omitempty"`
@@ -53,8 +53,8 @@ type ManifestDependencies struct {
 }
 
 type ManifestAppDependency struct {
-	Version    string                                    `json:"version,omitempty" yaml:"version,omitempty"`
-	Operations map[string]ManifestOperationDependency    `json:"operations,omitempty" yaml:"operations,omitempty"`
+	Version    string                                 `json:"version,omitempty" yaml:"version,omitempty"`
+	Operations map[string]ManifestOperationDependency `json:"operations,omitempty" yaml:"operations,omitempty"`
 }
 
 type ManifestOperationDependency struct {

--- a/gestaltd/services/apps/packageio/paths_test.go
+++ b/gestaltd/services/apps/packageio/paths_test.go
@@ -24,3 +24,52 @@ build:
 		t.Fatalf("DecodeSourceManifestFormat err = %v, want source entrypoint rejection", err)
 	}
 }
+
+func TestDecodeSourceManifestFormat_AcceptsContractFields(t *testing.T) {
+	t.Parallel()
+
+	manifestYAML := []byte(`kind: workflow
+source: github.com/testowner/workflows/contract
+version: 1.0.0
+dependencies:
+  apps:
+    github.com/acme/apps/base:
+      version: 1.0.0
+      operations:
+        listItems:
+          inputSchemaHash: abc123
+compatibility:
+  minGestaltdVersion: 0.5.0
+build:
+  command:
+    - echo
+    - build
+`)
+	manifest, err := DecodeSourceManifestFormat(manifestYAML, ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("DecodeSourceManifestFormat: %v", err)
+	}
+	if manifest.Dependencies == nil || manifest.Dependencies.Apps["github.com/acme/apps/base"].Version != "1.0.0" {
+		t.Fatalf("dependencies = %#v", manifest.Dependencies)
+	}
+	if manifest.Compatibility == nil || manifest.Compatibility.MinGestaltdVersion != "0.5.0" {
+		t.Fatalf("compatibility = %#v", manifest.Compatibility)
+	}
+}
+
+func TestDecodeSourceManifestFormat_RejectsLegacyReleaseField(t *testing.T) {
+	t.Parallel()
+
+	manifestJSON := []byte(`{
+  "kind": "workflow",
+  "source": "github.com/testowner/workflows/legacy",
+  "version": "1.0.0",
+  "release": {
+    "build": "deleted"
+  }
+}`)
+	_, err := DecodeSourceManifestFormat(manifestJSON, ManifestFormatJSON)
+	if err == nil || !strings.Contains(err.Error(), "release") {
+		t.Fatalf("DecodeSourceManifestFormat err = %v, want unknown release field rejection", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `dependencies` and `compatibility` to `providermanifestv1.Manifest` so app registry contract metadata decodes under strict manifest validation (follow-up to #2714).
- Introduce `ParseContract` / `ContractFromManifest` to prefer struct fields and fall back to raw manifest bytes for older packages.
- Add tests covering strict decode of contract fields, legacy `release` rejection, and provider-release metadata snapshotting.

## Context
Step 1 (#2709) added contract parsing from raw manifest bytes and temporarily used lenient decode so unknown top-level fields would not fail. #2714 restored strict decode to fix `TestRun_ProviderPackageRejectsDeletedBuild`, but manifests with `dependencies`/`compatibility` would fail strict decode without these struct fields.

## Test plan
- [x] `go test ./internal/providerrelease/...`
- [x] `go test ./services/apps/packageio/... ./services/apps/providerpkg/...`
- [x] `go test ./internal/daemon/e2e/... -run TestRun_ProviderPackageRejectsDeletedBuild`
- [x] `go test ./internal/daemon/e2e/app_publish/...`


Made with [Cursor](https://cursor.com)