### PR TITLE
Step 4: List app registry versions via admin API

### DIFF
--- a/gestaltd/internal/appregistry/reader.go
+++ b/gestaltd/internal/appregistry/reader.go
@@ -42,7 +42,7 @@ func (r *RegistryReader) FetchAppIndex(ctx context.Context, publicRoot, appName 
 	if err != nil {
 		return nil, fmt.Errorf("fetch app registry index %s: %w", url, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode == http.StatusNotFound {
 		return NewEmptyIndex(), nil
 	}
@@ -67,11 +67,11 @@ type VersionSummary struct {
 // VersionsFromIndex returns version summaries for appName, newest first.
 func VersionsFromIndex(index *Index, appName string) []VersionSummary {
 	if index == nil || len(index.Apps) == 0 {
-		return nil
+		return []VersionSummary{}
 	}
 	appVersions, ok := index.Apps[appName]
 	if !ok || len(appVersions.Versions) == 0 {
-		return nil
+		return []VersionSummary{}
 	}
 	out := make([]VersionSummary, 0, len(appVersions.Versions))
 	for version, summary := range appVersions.Versions {

--- a/gestaltd/internal/appregistry/reader.go
+++ b/gestaltd/internal/appregistry/reader.go
@@ -8,6 +8,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/valon-technologies/gestalt/server/internal/providerregistry"
 )
 
 // RegistryReader fetches registry documents over HTTP from a registry public root.
@@ -27,6 +29,9 @@ func (r *RegistryReader) FetchAppIndex(ctx context.Context, publicRoot, appName 
 	appName = strings.TrimSpace(appName)
 	if appName == "" {
 		return nil, fmt.Errorf("app name is required")
+	}
+	if err := providerregistry.ValidateRepositoryName(appName); err != nil {
+		return nil, err
 	}
 	publicRoot = strings.TrimRight(strings.TrimSpace(publicRoot), "/")
 	if publicRoot == "" {

--- a/gestaltd/internal/appregistry/reader.go
+++ b/gestaltd/internal/appregistry/reader.go
@@ -1,0 +1,96 @@
+package appregistry
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+)
+
+// RegistryReader fetches registry documents over HTTP from a registry public root.
+type RegistryReader struct {
+	HTTPClient *http.Client
+}
+
+func (r *RegistryReader) client() *http.Client {
+	if r != nil && r.HTTPClient != nil {
+		return r.HTTPClient
+	}
+	return http.DefaultClient
+}
+
+// FetchAppIndex downloads apps/{app}/index.json from a registry public root.
+func (r *RegistryReader) FetchAppIndex(ctx context.Context, publicRoot, appName string) (*Index, error) {
+	appName = strings.TrimSpace(appName)
+	if appName == "" {
+		return nil, fmt.Errorf("app name is required")
+	}
+	publicRoot = strings.TrimRight(strings.TrimSpace(publicRoot), "/")
+	if publicRoot == "" {
+		return nil, fmt.Errorf("registry public URL is required")
+	}
+
+	url := PublicURL(publicRoot, AppIndexPath(appName))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build app registry index request: %w", err)
+	}
+	resp, err := r.client().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch app registry index %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return NewEmptyIndex(), nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("fetch app registry index %s: unexpected status %s", url, resp.Status)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	if err != nil {
+		return nil, fmt.Errorf("read app registry index %s: %w", url, err)
+	}
+	return DecodeIndex(body)
+}
+
+// VersionSummary is a lightweight view of one published app version from an index.
+type VersionSummary struct {
+	Version     string    `json:"version"`
+	Metadata    string    `json:"metadata"`
+	Platforms   []string  `json:"platforms,omitempty"`
+	PublishedAt time.Time `json:"publishedAt"`
+}
+
+// VersionsFromIndex returns version summaries for appName, newest first.
+func VersionsFromIndex(index *Index, appName string) []VersionSummary {
+	if index == nil || len(index.Apps) == 0 {
+		return nil
+	}
+	appVersions, ok := index.Apps[appName]
+	if !ok || len(appVersions.Versions) == 0 {
+		return nil
+	}
+	out := make([]VersionSummary, 0, len(appVersions.Versions))
+	for version, summary := range appVersions.Versions {
+		out = append(out, VersionSummary{
+			Version:     version,
+			Metadata:    summary.Metadata,
+			Platforms:   append([]string(nil), summary.Platforms...),
+			PublishedAt: summary.PublishedAt.UTC(),
+		})
+	}
+	sortVersionsNewestFirst(out)
+	return out
+}
+
+func sortVersionsNewestFirst(versions []VersionSummary) {
+	sort.Slice(versions, func(i, j int) bool {
+		if versions[i].PublishedAt.Equal(versions[j].PublishedAt) {
+			return versions[i].Version > versions[j].Version
+		}
+		return versions[i].PublishedAt.After(versions[j].PublishedAt)
+	})
+}

--- a/gestaltd/internal/appregistry/reader_test.go
+++ b/gestaltd/internal/appregistry/reader_test.go
@@ -91,6 +91,16 @@ func TestRegistryReader_FetchAppIndex_NotFoundReturnsEmpty(t *testing.T) {
 	}
 }
 
+func TestRegistryReader_FetchAppIndex_RejectsInvalidAppName(t *testing.T) {
+	t.Parallel()
+
+	reader := &RegistryReader{}
+	_, err := reader.FetchAppIndex(t.Context(), "https://example.com", "..")
+	if err == nil {
+		t.Fatal("expected invalid app name error")
+	}
+}
+
 func TestRegistryReader_FetchAppIndex_RejectsInvalidJSON(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/appregistry/reader_test.go
+++ b/gestaltd/internal/appregistry/reader_test.go
@@ -1,0 +1,140 @@
+package appregistry
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestRegistryReader_FetchAppIndex(t *testing.T) {
+	t.Parallel()
+
+	indexJSON := `{
+  "schemaVersion": 1,
+  "apps": {
+    "g-issues": {
+      "displayName": "g-issues",
+      "versions": {
+        "0.0.1": {
+          "metadata": "apps/g-issues/versions/0.0.1.json",
+          "platforms": ["linux/amd64"],
+          "publishedAt": "2026-07-10T02:00:00Z"
+        }
+      }
+    }
+  }
+}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/apps/g-issues/index.json" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(indexJSON))
+	}))
+	defer srv.Close()
+
+	reader := &RegistryReader{HTTPClient: srv.Client()}
+	index, err := reader.FetchAppIndex(t.Context(), srv.URL, "g-issues")
+	if err != nil {
+		t.Fatalf("FetchAppIndex: %v", err)
+	}
+	versions := VersionsFromIndex(index, "g-issues")
+	if len(versions) != 1 || versions[0].Version != "0.0.1" {
+		t.Fatalf("versions = %#v", versions)
+	}
+}
+
+func TestVersionsFromIndex_SortsNewestFirst(t *testing.T) {
+	t.Parallel()
+
+	index := &Index{
+		SchemaVersion: IndexSchemaVersion,
+		Apps: map[string]AppVersions{
+			"g-issues": {
+				Versions: map[string]IndexVersion{
+					"0.0.1": {
+						Metadata:    "apps/g-issues/versions/0.0.1.json",
+						PublishedAt: time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC),
+					},
+					"0.0.2": {
+						Metadata:    "apps/g-issues/versions/0.0.2.json",
+						PublishedAt: time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC),
+					},
+				},
+			},
+		},
+	}
+	versions := VersionsFromIndex(index, "g-issues")
+	if len(versions) != 2 || versions[0].Version != "0.0.2" {
+		t.Fatalf("versions = %#v, want 0.0.2 first", versions)
+	}
+}
+
+func TestRegistryReader_FetchAppIndex_NotFoundReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	reader := &RegistryReader{HTTPClient: srv.Client()}
+	index, err := reader.FetchAppIndex(t.Context(), srv.URL, "missing-app")
+	if err != nil {
+		t.Fatalf("FetchAppIndex: %v", err)
+	}
+	if index == nil || len(index.Apps) != 0 {
+		t.Fatalf("index = %#v, want empty index", index)
+	}
+}
+
+func TestRegistryReader_FetchAppIndex_RejectsInvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{`))
+	}))
+	defer srv.Close()
+
+	reader := &RegistryReader{HTTPClient: srv.Client()}
+	_, err := reader.FetchAppIndex(t.Context(), srv.URL, "g-issues")
+	if err == nil {
+		t.Fatal("expected decode error")
+	}
+}
+
+func TestVersionsFromIndex_RoundTripsPublishedAt(t *testing.T) {
+	t.Parallel()
+
+	raw := `{
+  "schemaVersion": 1,
+  "apps": {
+    "g-issues": {
+      "versions": {
+        "0.0.1": {
+          "metadata": "apps/g-issues/versions/0.0.1.json",
+          "publishedAt": "2026-07-10T02:21:54.802491326Z"
+        }
+      }
+    }
+  }
+}`
+	index, err := DecodeIndex([]byte(raw))
+	if err != nil {
+		t.Fatalf("DecodeIndex: %v", err)
+	}
+	versions := VersionsFromIndex(index, "g-issues")
+	if len(versions) != 1 {
+		t.Fatalf("versions = %#v", versions)
+	}
+	got, err := json.Marshal(versions[0].PublishedAt)
+	if err != nil {
+		t.Fatalf("marshal publishedAt: %v", err)
+	}
+	if string(got) != `"2026-07-10T02:21:54.802491326Z"` {
+		t.Fatalf("publishedAt json = %s", got)
+	}
+}

--- a/gestaltd/internal/server/handlers_admin_app_registry.go
+++ b/gestaltd/internal/server/handlers_admin_app_registry.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/internal/appregistry"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/providerregistry"
 )
 
 type adminAppRegistryInfo struct {
@@ -68,6 +69,10 @@ func (s *Server) listAdminAppRegistryAppVersions(w http.ResponseWriter, r *http.
 	}
 	if appName == "" {
 		writeError(w, http.StatusBadRequest, "app is required")
+		return
+	}
+	if err := providerregistry.ValidateRepositoryName(appName); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid app name")
 		return
 	}
 	if len(s.appRegistries) == 0 {

--- a/gestaltd/internal/server/handlers_admin_app_registry.go
+++ b/gestaltd/internal/server/handlers_admin_app_registry.go
@@ -1,0 +1,117 @@
+package server
+
+import (
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/valon-technologies/gestalt/server/internal/appregistry"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+)
+
+type adminAppRegistryInfo struct {
+	Name       string `json:"name"`
+	Kind       string `json:"kind"`
+	PublicURL  string `json:"publicUrl,omitempty"`
+	StorageURL string `json:"storageUrl,omitempty"`
+}
+
+type adminAppRegistryVersionsResponse struct {
+	Registry string                      `json:"registry"`
+	App      string                      `json:"app"`
+	Versions []appregistry.VersionSummary `json:"versions"`
+}
+
+func (s *Server) mountAdminAppRegistryRoutes(r chi.Router) {
+	r.Get("/app-registries", s.listAdminAppRegistries)
+	r.Get("/app-registries/{registry}/apps/{app}/versions", s.listAdminAppRegistryAppVersions)
+}
+
+func (s *Server) listAdminAppRegistries(w http.ResponseWriter, r *http.Request) {
+	registries := s.appRegistries
+	if len(registries) == 0 {
+		writeJSON(w, http.StatusOK, []adminAppRegistryInfo{})
+		return
+	}
+	names := make([]string, 0, len(registries))
+	for name := range registries {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+
+	out := make([]adminAppRegistryInfo, 0, len(names))
+	for _, name := range names {
+		registry := registries[name]
+		info := adminAppRegistryInfo{
+			Name: name,
+			Kind: strings.TrimSpace(registry.Kind),
+		}
+		if publicURL, err := registry.PublicURL(); err == nil {
+			info.PublicURL = publicURL
+		}
+		if storageURL, err := registry.StorageURL(); err == nil {
+			info.StorageURL = storageURL
+		}
+		out = append(out, info)
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (s *Server) listAdminAppRegistryAppVersions(w http.ResponseWriter, r *http.Request) {
+	registryName := strings.TrimSpace(chi.URLParam(r, "registry"))
+	appName := strings.TrimSpace(chi.URLParam(r, "app"))
+	if registryName == "" {
+		writeError(w, http.StatusBadRequest, "registry is required")
+		return
+	}
+	if appName == "" {
+		writeError(w, http.StatusBadRequest, "app is required")
+		return
+	}
+	if len(s.appRegistries) == 0 {
+		writeError(w, http.StatusNotFound, "app registry not found")
+		return
+	}
+	registry, ok := s.appRegistries[registryName]
+	if !ok {
+		writeError(w, http.StatusNotFound, "app registry not found")
+		return
+	}
+	if strings.TrimSpace(registry.Kind) != config.AppRegistryKindGCS {
+		writeError(w, http.StatusBadRequest, "unsupported app registry kind")
+		return
+	}
+	publicRoot, err := registry.PublicURL()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "app registry public URL is invalid")
+		return
+	}
+
+	reader := s.appRegistryReader
+	if reader == nil {
+		reader = &appregistry.RegistryReader{}
+	}
+	index, err := reader.FetchAppIndex(r.Context(), publicRoot, appName)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "failed to fetch app registry index")
+		return
+	}
+	writeJSON(w, http.StatusOK, adminAppRegistryVersionsResponse{
+		Registry: registryName,
+		App:      appName,
+		Versions: appregistry.VersionsFromIndex(index, appName),
+	})
+}
+
+func cloneAppRegistryConfig(src map[string]config.AppRegistryConfig) map[string]config.AppRegistryConfig {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make(map[string]config.AppRegistryConfig, len(src))
+	for name, registry := range src {
+		out[name] = registry
+	}
+	return out
+}

--- a/gestaltd/internal/server/handlers_admin_app_registry.go
+++ b/gestaltd/internal/server/handlers_admin_app_registry.go
@@ -19,8 +19,8 @@ type adminAppRegistryInfo struct {
 }
 
 type adminAppRegistryVersionsResponse struct {
-	Registry string                      `json:"registry"`
-	App      string                      `json:"app"`
+	Registry string                       `json:"registry"`
+	App      string                       `json:"app"`
 	Versions []appregistry.VersionSummary `json:"versions"`
 }
 

--- a/gestaltd/internal/server/handlers_admin_app_registry_test.go
+++ b/gestaltd/internal/server/handlers_admin_app_registry_test.go
@@ -180,3 +180,29 @@ func TestAdminAppRegistryVersionsReturnsEmptyForUnknownApp(t *testing.T) {
 		t.Fatalf("versions = %#v, want empty", payload.Versions)
 	}
 }
+
+func TestAdminAppRegistryVersionsRejectsInvalidAppName(t *testing.T) {
+	t.Parallel()
+
+	registry, err := config.NewGCSAppRegistry("gitlab-peach-street-gestalt-app-registry")
+	if err != nil {
+		t.Fatalf("NewGCSAppRegistry: %v", err)
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.AppRegistries = map[string]config.AppRegistryConfig{
+			"toolshed": registry,
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/admin/api/v1/app-registries/toolshed/apps/..%2f../versions")
+	if err != nil {
+		t.Fatalf("GET versions: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d: %s, want 400", resp.StatusCode, body)
+	}
+}

--- a/gestaltd/internal/server/handlers_admin_app_registry_test.go
+++ b/gestaltd/internal/server/handlers_admin_app_registry_test.go
@@ -87,7 +87,7 @@ func TestAdminAppRegistryEndpointsListConfiguredRegistriesAndVersions(t *testing
 	if err != nil {
 		t.Fatalf("GET app registries: %v", err)
 	}
-	defer listResp.Body.Close()
+	defer func() { _ = listResp.Body.Close() }()
 	if listResp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(listResp.Body)
 		t.Fatalf("app registries status = %d: %s", listResp.StatusCode, body)
@@ -104,7 +104,7 @@ func TestAdminAppRegistryEndpointsListConfiguredRegistriesAndVersions(t *testing
 	if err != nil {
 		t.Fatalf("GET app registry versions: %v", err)
 	}
-	defer versionsResp.Body.Close()
+	defer func() { _ = versionsResp.Body.Close() }()
 	if versionsResp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(versionsResp.Body)
 		t.Fatalf("versions status = %d: %s", versionsResp.StatusCode, body)
@@ -165,7 +165,7 @@ func TestAdminAppRegistryVersionsReturnsEmptyForUnknownApp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET versions: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("status = %d: %s", resp.StatusCode, body)

--- a/gestaltd/internal/server/handlers_admin_app_registry_test.go
+++ b/gestaltd/internal/server/handlers_admin_app_registry_test.go
@@ -1,0 +1,182 @@
+package server_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/appregistry"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/server"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+)
+
+type rewriteHostTransport struct {
+	host   string
+	scheme string
+	inner  http.RoundTripper
+}
+
+func (t *rewriteHostTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	clone.URL.Scheme = t.scheme
+	clone.URL.Host = t.host
+	inner := t.inner
+	if inner == nil {
+		inner = http.DefaultTransport
+	}
+	return inner.RoundTrip(clone)
+}
+
+func TestAdminAppRegistryEndpointsListConfiguredRegistriesAndVersions(t *testing.T) {
+	t.Parallel()
+
+	indexJSON := `{
+  "schemaVersion": 1,
+  "apps": {
+    "g-issues": {
+      "displayName": "g-issues",
+      "versions": {
+        "0.0.0-snapshot.gabc123": {
+          "metadata": "apps/g-issues/versions/0.0.0-snapshot.gabc123.json",
+          "platforms": ["linux/amd64", "darwin/arm64"],
+          "publishedAt": "2026-07-10T02:21:54Z"
+        },
+        "0.0.0-snapshot.gdef456": {
+          "metadata": "apps/g-issues/versions/0.0.0-snapshot.gdef456.json",
+          "platforms": ["linux/amd64"],
+          "publishedAt": "2026-07-09T12:00:00Z"
+        }
+      }
+    }
+  }
+}`
+	registrySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/gitlab-peach-street-gestalt-app-registry/apps/g-issues/index.json" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(indexJSON))
+	}))
+	defer registrySrv.Close()
+
+	registryHost := strings.TrimPrefix(registrySrv.URL, "http://")
+	reader := &appregistry.RegistryReader{
+		HTTPClient: &http.Client{
+			Transport: &rewriteHostTransport{host: registryHost, scheme: "http"},
+		},
+	}
+	registry, err := config.NewGCSAppRegistry("gitlab-peach-street-gestalt-app-registry")
+	if err != nil {
+		t.Fatalf("NewGCSAppRegistry: %v", err)
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.AppRegistries = map[string]config.AppRegistryConfig{
+			"toolshed": registry,
+		}
+		cfg.AppRegistryReader = reader
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	listResp, err := http.Get(ts.URL + "/admin/api/v1/app-registries")
+	if err != nil {
+		t.Fatalf("GET app registries: %v", err)
+	}
+	defer listResp.Body.Close()
+	if listResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(listResp.Body)
+		t.Fatalf("app registries status = %d: %s", listResp.StatusCode, body)
+	}
+	var registries []map[string]any
+	if err := json.NewDecoder(listResp.Body).Decode(&registries); err != nil {
+		t.Fatalf("decode app registries: %v", err)
+	}
+	if len(registries) != 1 || registries[0]["name"] != "toolshed" {
+		t.Fatalf("registries = %#v", registries)
+	}
+
+	versionsResp, err := http.Get(ts.URL + "/admin/api/v1/app-registries/toolshed/apps/g-issues/versions")
+	if err != nil {
+		t.Fatalf("GET app registry versions: %v", err)
+	}
+	defer versionsResp.Body.Close()
+	if versionsResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(versionsResp.Body)
+		t.Fatalf("versions status = %d: %s", versionsResp.StatusCode, body)
+	}
+	var payload struct {
+		Registry string `json:"registry"`
+		App      string `json:"app"`
+		Versions []struct {
+			Version string `json:"version"`
+		} `json:"versions"`
+	}
+	if err := json.NewDecoder(versionsResp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode versions: %v", err)
+	}
+	if payload.Registry != "toolshed" || payload.App != "g-issues" {
+		t.Fatalf("payload = %#v", payload)
+	}
+	if len(payload.Versions) != 2 {
+		t.Fatalf("versions len = %d, want 2", len(payload.Versions))
+	}
+	if payload.Versions[0].Version != "0.0.0-snapshot.gabc123" {
+		t.Fatalf("versions[0] = %#v, want newest first", payload.Versions[0])
+	}
+}
+
+func TestAdminAppRegistryVersionsReturnsEmptyForUnknownApp(t *testing.T) {
+	t.Parallel()
+
+	registrySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/gitlab-peach-street-gestalt-app-registry/apps/missing/index.json" {
+			http.NotFound(w, r)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer registrySrv.Close()
+
+	registryHost := strings.TrimPrefix(registrySrv.URL, "http://")
+	reader := &appregistry.RegistryReader{
+		HTTPClient: &http.Client{
+			Transport: &rewriteHostTransport{host: registryHost, scheme: "http"},
+		},
+	}
+	registry, err := config.NewGCSAppRegistry("gitlab-peach-street-gestalt-app-registry")
+	if err != nil {
+		t.Fatalf("NewGCSAppRegistry: %v", err)
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.AppRegistries = map[string]config.AppRegistryConfig{
+			"toolshed": registry,
+		}
+		cfg.AppRegistryReader = reader
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/admin/api/v1/app-registries/toolshed/apps/missing/versions")
+	if err != nil {
+		t.Fatalf("GET versions: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d: %s", resp.StatusCode, body)
+	}
+	var payload struct {
+		Versions []any `json:"versions"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(payload.Versions) != 0 {
+		t.Fatalf("versions = %#v, want empty", payload.Versions)
+	}
+}

--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -95,6 +95,7 @@ func (s *Server) mountAdminAPIRoutes(r chi.Router) {
 	r.Route("/admin/api/v1", func(r chi.Router) {
 		r.Use(middleware.Timeout(60 * time.Second))
 		s.mountAdminRuntimeRoutes(r)
+		s.mountAdminAppRegistryRoutes(r)
 	})
 }
 

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -111,6 +111,7 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 			AuthorizationPolicy: cfg.Server.Admin.AuthorizationPolicy,
 			AllowedRoles:        append([]string(nil), cfg.Server.Admin.AllowedRoles...),
 		},
+		AppRegistries: cfg.AppRegistries,
 	}
 
 	if err := result.Start(ctx); err != nil {

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	cryptoutil "github.com/valon-technologies/gestalt/server/core/crypto"
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+	"github.com/valon-technologies/gestalt/server/internal/appregistry"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
@@ -141,6 +142,8 @@ type Server struct {
 	mountedUIs             []MountedUI
 	adminRoute             AdminRouteConfig
 	adminUI                http.Handler
+	appRegistries          map[string]config.AppRegistryConfig
+	appRegistryReader      *appregistry.RegistryReader
 	routeProfile           RouteProfile
 	activateAppProviders   func(context.Context)
 }
@@ -194,6 +197,8 @@ type Config struct {
 	Admin                  AdminRouteConfig
 	AdminUI                http.Handler
 	BuiltinAdminUI         *BuiltinAdminUIOptions
+	AppRegistries          map[string]config.AppRegistryConfig
+	AppRegistryReader      *appregistry.RegistryReader
 	RouteProfile           RouteProfile
 	MeterProvider          metric.MeterProvider
 	TracerProvider         trace.TracerProvider
@@ -385,6 +390,8 @@ func New(cfg Config) (*Server, error) {
 		mountedUIs:             mountedUIs,
 		adminRoute:             adminRoute,
 		adminUI:                adminUI,
+		appRegistries:          cloneAppRegistryConfig(cfg.AppRegistries),
+		appRegistryReader:      cfg.AppRegistryReader,
 		routeProfile:           cfg.RouteProfile,
 		activateAppProviders:   cfg.ActivateAppProviders,
 	}


### PR DESCRIPTION
## Summary
Prototype step 4 of the app registry plan: Gestalt can list published app versions from configured `appRegistries`.

- Add `appregistry.RegistryReader` to fetch `apps/{app}/index.json` over HTTP from a registry public root
- Add admin API routes:
  - `GET /admin/api/v1/app-registries` — configured registry metadata from `config.yaml`
  - `GET /admin/api/v1/app-registries/{registry}/apps/{app}/versions` — live version list from the registry index
- Wire `cfg.AppRegistries` into the server at startup

## Usage
After deploy config includes `appRegistries` (see plan `config.md`), query the management listener:

```bash
curl http://localhost:8081/admin/api/v1/app-registries
curl http://localhost:8081/admin/api/v1/app-registries/toolshed/apps/g-issues/versions
```

## Test plan
- [x] `go test ./internal/appregistry/... ./internal/server/... -run 'TestRegistryReader|TestAdminAppRegistry'`
- [ ] Add `appRegistries.toolshed` to toolshed `deploy/config.yaml` and verify against live `gs://gitlab-peach-street-gestalt-app-registry`


Made with [Cursor](https://cursor.com)