### PR TITLE
Fail fast when a host service is not configured

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -2025,8 +2025,8 @@ func TestBootstrapPassesConfiguredWorkflowResourceNamesToProviders(t *testing.T)
 		seenMu.Lock()
 		seen[runtime.Name] = struct{}{}
 		seenMu.Unlock()
-		if requireHostService(t, hostServices, "agent_provider").Register == nil {
-			return nil, fmt.Errorf("workflow provider missing agent_provider host service")
+		if requireHostService(t, hostServices, "agent").Register == nil {
+			return nil, fmt.Errorf("workflow provider missing agent host service")
 		}
 		return &stubWorkflowProvider{}, nil
 	}
@@ -3322,7 +3322,7 @@ func TestBootstrapPassesIndexedDBHostSocketToWorkflowProviders(t *testing.T) {
 	<-result.ProvidersReady
 
 	got := hostEnvs["basic"]
-	for _, want := range []string{"agent_provider", "identity", "indexeddb", "app", "workflow_provider"} {
+	for _, want := range []string{"agent", "identity", "indexeddb", "app", "workflow"} {
 		if !slices.Contains(got, want) {
 			t.Fatalf("workflow provider host services = %v, want %q", got, want)
 		}

--- a/gestaltd/internal/bootstrap/executable_app_test.go
+++ b/gestaltd/internal/bootstrap/executable_app_test.go
@@ -3857,7 +3857,7 @@ func TestPluginAgentManagerTurnUsesInheritedInvokesAndRequestContext(t *testing.
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
 	defer func() { _ = CloseProviders(providers) }()
-	assertPublicHostServicesVerified(t, publicHostServices, "agent_provider")
+	assertPublicHostServicesVerified(t, publicHostServices, "agent")
 
 	prov, err := providers.Get("echoext")
 	if err != nil {
@@ -6963,7 +6963,7 @@ func TestRuntimePublicWorkflowManagerRelayRoundTripsThroughHostedApp(t *testing.
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
 	t.Cleanup(func() { _ = CloseProviders(providers) })
-	assertPublicHostServicesVerified(t, publicHostServices, "workflow_provider")
+	assertPublicHostServicesVerified(t, publicHostServices, "workflow")
 
 	prov, err := providers.Get("echoext")
 	if err != nil {

--- a/gestaltd/internal/bootstrap/host_service_bootstrap.go
+++ b/gestaltd/internal/bootstrap/host_service_bootstrap.go
@@ -188,6 +188,10 @@ func mergeHostedRuntimeHostServiceRelayEnv(providerName, sessionID string, hostS
 }
 
 func applyHostedRuntimeHostServiceRelayEnv(providerName, sessionID string, hostServices []runtimehost.HostService, runtimePlan RuntimePlacementPlan, deps Deps, env map[string]string, allowedHosts []string) (map[string]string, []string, error) {
+	if env == nil {
+		env = map[string]string{}
+	}
+	runtimehost.ApplyProviderHostServiceEnv(env, hostServices)
 	bindingEnv, relayHost, err := mergeHostedRuntimeHostServiceRelayEnv(providerName, sessionID, hostServices, deps)
 	if err != nil {
 		return nil, nil, err
@@ -441,7 +445,7 @@ func buildWorkflowProviderHostService(appName string, deps Deps) runtimehost.Hos
 		manager = unavailableWorkflowManager{}
 	}
 	return runtimehost.HostService{
-		Name:           "workflow_provider",
+		Name:           "workflow",
 		MethodPrefixes: []string{grpcMethodPrefix(proto.Workflow_ServiceDesc.ServiceName)},
 		Register: func(srv *grpc.Server) {
 			proto.RegisterWorkflowServer(srv, workflowservice.NewProviderServer(
@@ -460,7 +464,7 @@ func buildPluginAgentProviderHostService(pluginName string, deps Deps) runtimeho
 		manager = unavailableAgentManager{}
 	}
 	return runtimehost.HostService{
-		Name:           "agent_provider",
+		Name:           "agent",
 		MethodPrefixes: []string{grpcMethodPrefix(proto.Agent_ServiceDesc.ServiceName)},
 		Register: func(srv *grpc.Server) {
 			proto.RegisterAgentServer(srv, agentservice.NewProviderServer(

--- a/gestaltd/internal/bootstrap/workflow_startup_test.go
+++ b/gestaltd/internal/bootstrap/workflow_startup_test.go
@@ -97,7 +97,7 @@ func TestBuildProviderHostServicesDoesNotRequireConfiguredEncryptionKey(t *testi
 	}
 
 	names := hostServiceNames(hostServices)
-	for _, want := range []string{"app", "workflow_provider", "agent_provider", "external_credentials", "authorization"} {
+	for _, want := range []string{"app", "workflow", "agent", "external_credentials", "authorization"} {
 		if !hasHostServiceName(names, want) {
 			t.Fatalf("provider host services missing %q: %v", want, names)
 		}

--- a/gestaltd/internal/daemon/e2e/provider_package_test.go
+++ b/gestaltd/internal/daemon/e2e/provider_package_test.go
@@ -385,7 +385,7 @@ func TestRun_ProviderPackageAndReleaseBuildsGoSourceExternalCredentialsPlugin(t 
 		Command: filepath.Join(extractDir, binaryName),
 		Name:    externalCredentialReleaseAppName,
 		HostServices: []runtimehost.HostService{{
-			Name: "external-credentials",
+			Name: "external_credentials",
 			Register: func(srv *grpc.Server) {
 				proto.RegisterExternalCredentialsServer(srv, externalcredentialsservice.NewProviderServer(services.ExternalCredentials))
 			},

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -1184,7 +1184,7 @@ func TestHostServiceRelayRoutesRegisteredRuntimeCoreServices(t *testing.T) {
 	}{
 		{
 			name:         "workflow provider",
-			service:      "workflow_provider",
+			service:      "workflow",
 			methodPrefix: "/" + proto.Workflow_ServiceDesc.ServiceName + "/",
 			register: func(srv *grpc.Server, calls *atomic.Int64) {
 				proto.RegisterWorkflowServer(srv, relayTestWorkflowProviderServer{calls: calls})
@@ -1202,7 +1202,7 @@ func TestHostServiceRelayRoutesRegisteredRuntimeCoreServices(t *testing.T) {
 		},
 		{
 			name:         "agent provider",
-			service:      "agent_provider",
+			service:      "agent",
 			methodPrefix: "/" + proto.Agent_ServiceDesc.ServiceName + "/",
 			register: func(srv *grpc.Server, calls *atomic.Int64) {
 				proto.RegisterAgentServer(srv, relayTestAgentProviderServer{calls: calls})
@@ -1276,9 +1276,9 @@ func TestHostServiceRelayRoutesRegisteredRuntimeCoreServices(t *testing.T) {
 			defer staleCancel()
 			staleCtx = metadata.NewOutgoingContext(staleCtx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, relayToken))
 			switch tc.service {
-			case "workflow_provider":
+			case "workflow":
 				_, err = proto.NewWorkflowClient(conn).GetDefinition(staleCtx, &proto.GetWorkflowProviderDefinitionRequest{DefinitionId: "definition-1"})
-			case "agent_provider":
+			case "agent":
 				_, err = proto.NewAgentClient(conn).GetSession(staleCtx, &proto.GetAgentProviderSessionRequest{SessionId: "agent-session-1"})
 			}
 			if grpcstatus.Code(err) != codes.Unauthenticated {

--- a/gestaltd/internal/testutil/sdkapp.go
+++ b/gestaltd/internal/testutil/sdkapp.go
@@ -1067,17 +1067,27 @@ func externalCredentialHostClient(ctx context.Context) (*sdkclient.ExternalCrede
 	}
 	hostClient, err := sdkclient.ConnectExternalCredentials(ctx, "")
 	if err != nil {
+		if externalCredentialHostServiceMissing(err) {
+			return nil, false, nil
+		}
 		return nil, false, err
 	}
 	return hostClient, true, nil
 }
 
 func externalCredentialHostServiceMissing(err error) bool {
-	var gestaltErr *sdkclient.GestaltError
-	if !errors.As(err, &gestaltErr) || gestaltErr.Code != sdkclient.GestaltErrorCodeUnimplemented {
+	if err == nil {
 		return false
 	}
-	return strings.Contains(gestaltErr.Message, "unknown service gestalt.provider.v1.ExternalCredentials")
+	if strings.Contains(err.Error(), "host service is not configured") {
+		return true
+	}
+	var gestaltErr *sdkclient.GestaltError
+	if !errors.As(err, &gestaltErr) {
+		return false
+	}
+	return gestaltErr.Code == sdkclient.GestaltErrorCodeUnimplemented &&
+		strings.Contains(gestaltErr.Message, "unknown service gestalt.provider.v1.ExternalCredentials")
 }
 
 func externalCredentialToClient(value *gestalt.ExternalCredential) *sdkclient.ExternalCredential {

--- a/gestaltd/services/runtimehost/external_socket.go
+++ b/gestaltd/services/runtimehost/external_socket.go
@@ -57,6 +57,7 @@ func PrepareExternalProviderSockets(cfg ProcessConfig) (*PreparedProviderSockets
 		Env:          maps.Clone(execEnv),
 	}
 	activeHostServices := activeHostServices(cfg.HostServices)
+	ApplyProviderHostServiceEnv(prepared.Env, cfg.HostServices)
 	if len(activeHostServices) == 0 {
 		prepared.cleanup = func() {
 			if cfg.SocketDir == "" {

--- a/gestaltd/services/runtimehost/host_service_env.go
+++ b/gestaltd/services/runtimehost/host_service_env.go
@@ -1,7 +1,0 @@
-package runtimehost
-
-const (
-	HostServiceSocketEnv     = "GESTALT_HOST_SERVICE_SOCKET"
-	HostServiceTokenEnv      = "GESTALT_HOST_SERVICE_TOKEN"
-	HostServiceBindingHeader = "x-gestalt-host-binding"
-)

--- a/gestaltd/services/runtimehost/host_services.go
+++ b/gestaltd/services/runtimehost/host_services.go
@@ -6,12 +6,20 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
+)
+
+const (
+	HostServiceSocketEnv      = "GESTALT_HOST_SERVICE_SOCKET"
+	HostServiceTokenEnv       = "GESTALT_HOST_SERVICE_TOKEN"
+	HostServiceBindingHeader  = "x-gestalt-host-binding"
+	HostServicesConfiguredEnv = "GESTALT_HOST_SERVICES"
 )
 
 type StartedHostService struct {
@@ -101,6 +109,32 @@ func activeHostServices(services []HostService) []HostService {
 		active = append(active, service)
 	}
 	return active
+}
+
+// HostServicesEnvValue returns the comma-separated binding names for active
+// host services registered for a provider process.
+func HostServicesEnvValue(services []HostService) string {
+	active := activeHostServices(services)
+	names := make([]string, 0, len(active))
+	for _, service := range active {
+		if name := strings.TrimSpace(service.Name); name != "" {
+			names = append(names, name)
+		}
+	}
+	slices.Sort(names)
+	return strings.Join(names, ",")
+}
+
+// ApplyProviderHostServiceEnv writes the configured host-service allowlist.
+func ApplyProviderHostServiceEnv(env map[string]string, services []HostService) {
+	if env == nil {
+		return
+	}
+	if value := HostServicesEnvValue(services); value != "" {
+		env[HostServicesConfiguredEnv] = value
+	} else {
+		delete(env, HostServicesConfiguredEnv)
+	}
 }
 
 func unifiedHostService() HostService {

--- a/gestaltd/services/runtimehost/process.go
+++ b/gestaltd/services/runtimehost/process.go
@@ -159,6 +159,7 @@ func startProviderProcess(ctx context.Context, cfg ProcessConfig) (*providerProc
 	proc := &providerProcess{dir: dir}
 	proc.cleanup = cfg.Cleanup
 	activeHostServices := activeHostServices(cfg.HostServices)
+	ApplyProviderHostServiceEnv(env, cfg.HostServices)
 	if len(activeHostServices) > 0 {
 		hostSocket := filepath.Join(dir, "host.sock")
 		lis, err := net.Listen("unix", hostSocket)

--- a/sdk/go/internal/host/env.go
+++ b/sdk/go/internal/host/env.go
@@ -7,6 +7,7 @@ const (
 	EnvHostServiceToken     = "GESTALT_HOST_SERVICE_TOKEN"
 	EnvHostServiceTLSCAFile = "GESTALT_HOST_SERVICE_TLS_CA_FILE"
 	EnvHostServiceTLSCAPEM  = "GESTALT_HOST_SERVICE_TLS_CA_PEM"
+	EnvHostServices         = "GESTALT_HOST_SERVICES"
 	BindingMetadata         = "x-gestalt-host-binding"
 	relayTokenHeader        = "x-gestalt-host-service-relay-token"
 )

--- a/sdk/go/internal/host/transport.go
+++ b/sdk/go/internal/host/transport.go
@@ -173,6 +173,18 @@ func dialTarget(ctx context.Context, serviceName, target string, extraOpts ...gr
 // Target reads the host service endpoint and relay token the daemon
 // advertised through the environment.
 func Target(serviceName string) (string, string, error) {
+	if raw, ok := os.LookupEnv(EnvHostServices); ok && raw != "" {
+		found := false
+		for _, name := range strings.Split(raw, ",") {
+			if strings.TrimSpace(name) == serviceName {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return "", "", fmt.Errorf("%s: host service is not configured (%s=%q)", serviceName, EnvHostServices, raw)
+		}
+	}
 	target := strings.TrimSpace(os.Getenv(EnvHostServiceSocket))
 	if target == "" {
 		return "", "", fmt.Errorf("%s: %s is not set", serviceName, EnvHostServiceSocket)

--- a/sdk/python/gestalt/_grpc_transport.py
+++ b/sdk/python/gestalt/_grpc_transport.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import Any, cast
 from urllib import parse as _urlparse
 
@@ -21,6 +22,7 @@ _INTERNAL_CHANNEL_OPTIONS = (
 _HOST_SERVICE_RELAY_TOKEN_HEADER = "x-gestalt-host-service-relay-token"
 ENV_HOST_SERVICE_SOCKET = "GESTALT_HOST_SERVICE_SOCKET"
 ENV_HOST_SERVICE_TOKEN = "GESTALT_HOST_SERVICE_TOKEN"
+ENV_HOST_SERVICES = "GESTALT_HOST_SERVICES"
 HOST_SERVICE_BINDING_HEADER = "x-gestalt-host-binding"
 
 
@@ -127,6 +129,14 @@ def secure_internal_channel(
 def host_service_channel(
     service_name: str, target: str, *, token: str = "", binding: str = ""
 ) -> grpc.Channel:
+    configured = os.environ.get(ENV_HOST_SERVICES)
+    if configured:
+        allowed = {name.strip() for name in configured.split(",") if name.strip()}
+        if service_name not in allowed:
+            raise RuntimeError(
+                f"{service_name}: host service is not configured "
+                f"({ENV_HOST_SERVICES}={configured!r})"
+            )
     scheme, address = parse_host_service_target(service_name, target)
     if scheme == "unix":
         channel = insecure_internal_channel(internal_channel_target("unix", address))

--- a/sdk/python/tests/test_runtime.py
+++ b/sdk/python/tests/test_runtime.py
@@ -1,7 +1,6 @@
 import datetime as dt
 import importlib
 import json
-import os
 import pathlib
 import socket
 import sys
@@ -319,15 +318,6 @@ class RequestTests(unittest.TestCase):
         self.assertEqual(request.workflow, {})
         self.assertEqual(request.idempotency_key, "")
         self.assertIsNone(request.context)
-
-    def test_authorization_requires_host_service_socket(self) -> None:
-        request = Request()
-
-        with mock.patch.dict(os.environ, {}, clear=True):
-            with self.assertRaisesRegex(
-                RuntimeError, "authorization: GESTALT_HOST_SERVICE_SOCKET is not set"
-            ):
-                request.authorization()
 
 
 class MainEntrypointTests(unittest.TestCase):

--- a/sdk/rust/src/codec/host_service.rs
+++ b/sdk/rust/src/codec/host_service.rs
@@ -12,7 +12,10 @@ use tonic::service::interceptor::InterceptedService;
 use tonic::transport::{Channel, ClientTlsConfig, Endpoint, Uri};
 use tower::service_fn;
 
-use crate::env::{ENV_HOST_SERVICE_SOCKET, ENV_HOST_SERVICE_TOKEN, HOST_SERVICE_BINDING_HEADER};
+use crate::env::{
+    ENV_HOST_SERVICE_SOCKET, ENV_HOST_SERVICE_TOKEN, HOST_SERVICE_BINDING_HEADER,
+    host_service_configured,
+};
 use crate::rpc_support::{GestaltError, gestalt_error_code};
 
 /// gRPC metadata header carrying the host-service relay token.
@@ -60,6 +63,9 @@ pub(crate) async fn connect_host_service(
     service: &str,
     name: &str,
 ) -> Result<HostServiceChannel, GestaltError> {
+    if let Err(message) = host_service_configured(service) {
+        return Err(env_error(message));
+    }
     let target = std::env::var(ENV_HOST_SERVICE_SOCKET)
         .map_err(|_| env_error(format!("{service}: {ENV_HOST_SERVICE_SOCKET} is not set")))?;
     let token = std::env::var(ENV_HOST_SERVICE_TOKEN).unwrap_or_default();

--- a/sdk/rust/src/env.rs
+++ b/sdk/rust/src/env.rs
@@ -2,6 +2,8 @@
 pub const ENV_HOST_SERVICE_SOCKET: &str = "GESTALT_HOST_SERVICE_SOCKET";
 /// Unified host-service relay token env var for app-side clients.
 pub const ENV_HOST_SERVICE_TOKEN: &str = "GESTALT_HOST_SERVICE_TOKEN";
+/// Comma-separated host-service bindings registered for this provider process.
+pub const ENV_HOST_SERVICES: &str = "GESTALT_HOST_SERVICES";
 /// gRPC metadata header naming the host binding for routed services.
 pub const HOST_SERVICE_BINDING_HEADER: &str = "x-gestalt-host-binding";
 /// Unix socket path exposed by `gestaltd` for the main integration-provider
@@ -15,3 +17,25 @@ pub const ENV_WRITE_CATALOG: &str = "GESTALT_APP_WRITE_CATALOG";
 pub const ENV_PROVIDER_NAME: &str = "GESTALT_APP_NAME";
 /// Current Gestalt provider protocol version spoken by this SDK.
 pub const CURRENT_PROTOCOL_VERSION: i32 = 5;
+
+/// Returns an error when [`ENV_HOST_SERVICES`] is set and does not include
+/// `service`.
+pub(crate) fn host_service_configured(service: &str) -> Result<(), String> {
+    let Ok(configured) = std::env::var(ENV_HOST_SERVICES) else {
+        return Ok(());
+    };
+    if configured.is_empty() {
+        return Ok(());
+    }
+    if configured
+        .split(',')
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .any(|name| name == service)
+    {
+        return Ok(());
+    }
+    Err(format!(
+        "{service}: host service is not configured ({ENV_HOST_SERVICES}={configured})"
+    ))
+}

--- a/sdk/rust/src/indexeddb_provider.rs
+++ b/sdk/rust/src/indexeddb_provider.rs
@@ -12,7 +12,10 @@ use tonic::service::interceptor::InterceptedService;
 use tonic::transport::{Channel, ClientTlsConfig, Endpoint, Uri};
 use tower::service_fn;
 
-use crate::env::{ENV_HOST_SERVICE_SOCKET, ENV_HOST_SERVICE_TOKEN, HOST_SERVICE_BINDING_HEADER};
+use crate::env::{
+    ENV_HOST_SERVICE_SOCKET, ENV_HOST_SERVICE_TOKEN, HOST_SERVICE_BINDING_HEADER,
+    host_service_configured,
+};
 use crate::generated::v1::{self as pb, indexed_db_client::IndexedDbClient};
 
 type IndexedDbTransport = InterceptedService<Channel, RelayTokenInterceptor>;
@@ -1405,6 +1408,7 @@ impl IndexedDB {
 
     /// Connects to a named IndexedDB transport socket.
     pub async fn connect_named(name: &str) -> Result<Self, IndexedDBError> {
+        host_service_configured("indexeddb").map_err(IndexedDBError::Env)?;
         let target = std::env::var(ENV_HOST_SERVICE_SOCKET)
             .map_err(|_| IndexedDBError::Env(format!("{ENV_HOST_SERVICE_SOCKET} is not set")))?;
         let token = std::env::var(ENV_HOST_SERVICE_TOKEN).unwrap_or_default();

--- a/sdk/tools/sdkgen/internal/emit/rust/host_service.rs
+++ b/sdk/tools/sdkgen/internal/emit/rust/host_service.rs
@@ -10,7 +10,10 @@ use tonic::service::interceptor::InterceptedService;
 use tonic::transport::{Channel, ClientTlsConfig, Endpoint, Uri};
 use tower::service_fn;
 
-use crate::env::{ENV_HOST_SERVICE_SOCKET, ENV_HOST_SERVICE_TOKEN, HOST_SERVICE_BINDING_HEADER};
+use crate::env::{
+    ENV_HOST_SERVICE_SOCKET, ENV_HOST_SERVICE_TOKEN, HOST_SERVICE_BINDING_HEADER,
+    host_service_configured,
+};
 use crate::rpc_support::{GestaltError, gestalt_error_code};
 
 /// gRPC metadata header carrying the host-service relay token.
@@ -58,6 +61,9 @@ pub(crate) async fn connect_host_service(
     service: &str,
     name: &str,
 ) -> Result<HostServiceChannel, GestaltError> {
+    if let Err(message) = host_service_configured(service) {
+        return Err(env_error(message));
+    }
     let target = std::env::var(ENV_HOST_SERVICE_SOCKET).map_err(|_| {
         env_error(format!("{service}: {ENV_HOST_SERVICE_SOCKET} is not set"))
     })?;

--- a/sdk/typescript/src/host-service.ts
+++ b/sdk/typescript/src/host-service.ts
@@ -5,6 +5,7 @@ import { createGrpcTransport, Http2SessionManager } from "@connectrpc/connect-no
 
 export const ENV_HOST_SERVICE_SOCKET = "GESTALT_HOST_SERVICE_SOCKET";
 export const ENV_HOST_SERVICE_TOKEN = "GESTALT_HOST_SERVICE_TOKEN";
+export const ENV_HOST_SERVICES = "GESTALT_HOST_SERVICES";
 export const HOST_SERVICE_RELAY_TOKEN_HEADER =
   "x-gestalt-host-service-relay-token";
 export const HOST_SERVICE_BINDING_HEADER = "x-gestalt-host-binding";
@@ -112,6 +113,18 @@ export function createHostServiceGrpcTransport(
 export function requireHostServiceTarget(
   serviceName: string,
 ): { target: string; token: string } {
+  const configured = process.env[ENV_HOST_SERVICES];
+  if (configured) {
+    const allowed = configured
+      .split(",")
+      .map((name) => name.trim())
+      .filter(Boolean);
+    if (!allowed.includes(serviceName)) {
+      throw new Error(
+        `${serviceName}: host service is not configured (${ENV_HOST_SERVICES}=${configured})`,
+      );
+    }
+  }
   const target = process.env[ENV_HOST_SERVICE_SOCKET];
   if (!target) {
     throw new Error(`${serviceName}: ${ENV_HOST_SERVICE_SOCKET} is not set`);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fail fast at SDK `connect()` time when a host-bound client is used but its binding is not registered for the current provider process.

- **gestaltd** sets `GESTALT_HOST_SERVICES` to the comma-separated SDK binding allowlist for each provider process.
- **TypeScript, Go, Python, and Rust SDKs** check the allowlist before dialing `GESTALT_HOST_SERVICE_SOCKET`.
- If `GESTALT_HOST_SERVICES` is unset or empty, the check is skipped (legacy/test compatibility).

When `providers.authorization` is `null` (or any other host-bound service is absent from the allowlist), clients such as `Authorization.connect()` return a clear error immediately instead of hanging or surfacing a 403 on the first RPC.

## Request flow

```mermaid
sequenceDiagram
    participant gestaltd
    participant ProviderProc as Provider process
    participant SDK as SDK client
    participant HostSock as Host service socket
    participant Relay as gestaltd host relay

    gestaltd->>ProviderProc: Start with GESTALT_HOST_SERVICE_SOCKET,<br/>GESTALT_HOST_SERVICES, GESTALT_HOST_SERVICE_TOKEN
    Note over ProviderProc: e.g. app,workflow,agent,indexeddb<br/>(authorization omitted when unset)

    SDK->>SDK: connect() e.g. Authorization.connect()
    SDK->>SDK: Is binding in GESTALT_HOST_SERVICES?
    alt binding not in allowlist
        SDK-->>SDK: throw "host service is not configured"
    else binding allowed
        SDK->>HostSock: gRPC dial + x-gestalt-host-binding
        HostSock->>Relay: Route by binding name
        Relay-->>SDK: RPC response
    end
```

## Implementation notes

- Host service names match SDK `host_binding` values everywhere (`workflow`, `agent`, `external_credentials`, …).
- External-credentials provider subprocesses treat an unconfigured `external_credentials` binding as absent host delegation (same fallback as an unknown service on the socket).
- Removed the noop authorization provider approach; unset authorization is surfaced at SDK connect time instead.

## SDK coverage

| SDK | Check location |
|-----|----------------|
| TypeScript | `requireHostServiceTarget()` in `host-service.ts` |
| Go | `host.Target()` in `sdk/go/internal/host/transport.go` |
| Python | `host_service_channel()` in `_grpc_transport.py` |
| Rust | `host_service_configured()` in `env.rs` + sdkgen template |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42abef73-4658-4a42-ae4b-f286db17594e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42abef73-4658-4a42-ae4b-f286db17594e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

