### PR TITLE
Add IndexedDB install state for registry app versions (step 5)

### DIFF
--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -24,22 +24,22 @@ type ManagedSubject struct {
 }
 
 const (
-	AppInstallationDesiredStatePending = "pending"
-	AppInstallationDesiredStateActive  = "active"
-	AppInstallationDesiredStateFailed  = "failed"
+	AppInstallationRolloutStatusPending  = "pending"
+	AppInstallationRolloutStatusPromoted = "promoted"
+	AppInstallationRolloutStatusFailed   = "failed"
 )
 
-// AppInstallation records the shared desired and active version for a
-// registry-installed app. app_name is the primary key.
+// AppInstallation records the shared fleet-wide rollout for a registry-installed
+// app. app_name is the primary key.
 type AppInstallation struct {
-	AppName                  string
-	DesiredVersionConstraint string
-	ResolvedVersion          string
-	SourceRef                string
-	Registry                 string
-	ProviderReleaseURL       string
-	ArtifactChecksums        map[string]string
-	DesiredState             string
+	AppName             string
+	VersionConstraint   string
+	ResolvedVersion     string
+	SourceRef           string
+	Registry            string
+	ProviderReleaseURL  string
+	ArtifactChecksums   map[string]string
+	RolloutStatus       string
 	ActiveSince              *time.Time
 	PreviousResolvedVersion  string
 	InstalledBy              string

--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -38,7 +38,7 @@ const (
 )
 
 // AppInstallation records the shared fleet-wide rollout for a registry-installed
-// app. app_name is the primary key.
+// app. The IndexedDB primary key id holds the app name (for example g-issues).
 type AppInstallation struct {
 	AppName                 string
 	VersionConstraint       string
@@ -56,16 +56,16 @@ type AppInstallation struct {
 }
 
 // AppInstallationEvent is an append-only audit record for install lifecycle
-// changes on one app.
+// changes on one app. InstallationID matches app_installations.id.
 type AppInstallationEvent struct {
-	ID          string
-	AppName     string
-	FromVersion string
-	ToVersion   string
-	Type        string
-	Actor       string
-	Timestamp   time.Time
-	Metadata    map[string]any
+	ID             string
+	InstallationID string
+	FromVersion    string
+	ToVersion      string
+	Type           string
+	Actor          string
+	Timestamp      time.Time
+	Metadata       map[string]any
 }
 
 type ExternalCredentialGrant struct {

--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -23,6 +23,43 @@ type ManagedSubject struct {
 	DeletedAt          *time.Time
 }
 
+const (
+	AppInstallationDesiredStatePending = "pending"
+	AppInstallationDesiredStateActive  = "active"
+	AppInstallationDesiredStateFailed  = "failed"
+)
+
+// AppInstallation records the shared desired and active version for a
+// registry-installed app. app_name is the primary key.
+type AppInstallation struct {
+	AppName                  string
+	DesiredVersionConstraint string
+	ResolvedVersion          string
+	SourceRef                string
+	Registry                 string
+	ProviderReleaseURL       string
+	ArtifactChecksums        map[string]string
+	DesiredState             string
+	ActiveSince              *time.Time
+	PreviousResolvedVersion  string
+	InstalledBy              string
+	InstalledAt              time.Time
+	UpdatedAt                time.Time
+}
+
+// AppInstallationEvent is an append-only audit record for install lifecycle
+// changes on one app.
+type AppInstallationEvent struct {
+	EventID     string
+	AppName     string
+	FromVersion string
+	ToVersion   string
+	EventType   string
+	Actor       string
+	CreatedAt   time.Time
+	Metadata    map[string]any
+}
+
 type ExternalCredentialGrant struct {
 	AccessToken       string
 	RefreshToken      string

--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -30,29 +30,29 @@ const (
 )
 
 const (
-	AppInstallationEventTypeInstallRequested  = "install_requested"
-	AppInstallationEventTypePromoted          = "promoted"
-	AppInstallationEventTypeFailed            = "failed"
-	AppInstallationEventTypeRollback          = "rollback"
+	AppInstallationEventTypeInstallRequested   = "install_requested"
+	AppInstallationEventTypePromoted           = "promoted"
+	AppInstallationEventTypeFailed             = "failed"
+	AppInstallationEventTypeRollback           = "rollback"
 	AppInstallationEventTypeUninstallRequested = "uninstall_requested"
 )
 
 // AppInstallation records the shared fleet-wide rollout for a registry-installed
 // app. app_name is the primary key.
 type AppInstallation struct {
-	AppName             string
-	VersionConstraint   string
-	ResolvedVersion     string
-	SourceRef           string
-	Registry            string
-	ProviderReleaseURL  string
-	ArtifactChecksums   map[string]string
-	RolloutStatus       string
-	ActiveSince              *time.Time
-	PreviousResolvedVersion  string
-	InstalledBy              string
-	InstalledAt              time.Time
-	UpdatedAt                time.Time
+	AppName                 string
+	VersionConstraint       string
+	ResolvedVersion         string
+	SourceRef               string
+	Registry                string
+	ProviderReleaseURL      string
+	ArtifactChecksums       map[string]string
+	RolloutStatus           string
+	ActiveSince             *time.Time
+	PreviousResolvedVersion string
+	InstalledBy             string
+	InstalledAt             time.Time
+	UpdatedAt               time.Time
 }
 
 // AppInstallationEvent is an append-only audit record for install lifecycle

--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -29,6 +29,14 @@ const (
 	AppInstallationRolloutStatusFailed   = "failed"
 )
 
+const (
+	AppInstallationEventTypeInstallRequested  = "install_requested"
+	AppInstallationEventTypePromoted          = "promoted"
+	AppInstallationEventTypeFailed            = "failed"
+	AppInstallationEventTypeRollback          = "rollback"
+	AppInstallationEventTypeUninstallRequested = "uninstall_requested"
+)
+
 // AppInstallation records the shared fleet-wide rollout for a registry-installed
 // app. app_name is the primary key.
 type AppInstallation struct {

--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -58,14 +58,14 @@ type AppInstallation struct {
 // AppInstallationEvent is an append-only audit record for install lifecycle
 // changes on one app.
 type AppInstallationEvent struct {
-	EventID     string
-	AppName     string
-	FromVersion string
-	ToVersion   string
-	EventType   string
-	Actor       string
-	CreatedAt   time.Time
-	Metadata    map[string]any
+	EventID        string
+	AppName        string
+	FromVersion    string
+	ToVersion      string
+	EventType      string
+	Actor          string
+	EventTimestamp time.Time
+	Metadata       map[string]any
 }
 
 type ExternalCredentialGrant struct {

--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -58,14 +58,14 @@ type AppInstallation struct {
 // AppInstallationEvent is an append-only audit record for install lifecycle
 // changes on one app.
 type AppInstallationEvent struct {
-	EventID        string
-	AppName        string
-	FromVersion    string
-	ToVersion      string
-	EventType      string
-	Actor          string
-	EventTimestamp time.Time
-	Metadata       map[string]any
+	ID          string
+	AppName     string
+	FromVersion string
+	ToVersion   string
+	Type        string
+	Actor       string
+	Timestamp   time.Time
+	Metadata    map[string]any
 }
 
 type ExternalCredentialGrant struct {

--- a/gestaltd/internal/coredata/app_installation_events.go
+++ b/gestaltd/internal/coredata/app_installation_events.go
@@ -1,0 +1,93 @@
+package coredata
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	idb "github.com/valon-technologies/gestalt/sdk/go/indexeddb"
+
+	"github.com/google/uuid"
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+)
+
+type AppInstallationEventService struct {
+	store idb.ObjectStore
+}
+
+func NewAppInstallationEventService(ds indexeddb.IndexedDB) *AppInstallationEventService {
+	return &AppInstallationEventService{store: ds.ObjectStore(StoreAppInstallationEvents)}
+}
+
+func (s *AppInstallationEventService) AppendEvent(ctx context.Context, event *core.AppInstallationEvent) (*core.AppInstallationEvent, error) {
+	if event == nil {
+		return nil, fmt.Errorf("append app installation event: event is required")
+	}
+	appName := strings.TrimSpace(event.AppName)
+	if appName == "" {
+		return nil, fmt.Errorf("append app installation event: app_name is required")
+	}
+	eventType := strings.TrimSpace(event.EventType)
+	if eventType == "" {
+		return nil, fmt.Errorf("append app installation event: event_type is required")
+	}
+
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	eventID := strings.TrimSpace(event.EventID)
+	if eventID == "" {
+		eventID = uuid.NewString()
+	}
+	rec := idb.Record{
+		"id":           eventID,
+		"event_id":     eventID,
+		"app_name":     appName,
+		"from_version": strings.TrimSpace(event.FromVersion),
+		"to_version":   strings.TrimSpace(event.ToVersion),
+		"event_type":   eventType,
+		"actor":        strings.TrimSpace(event.Actor),
+		"created_at":   now,
+		"metadata_json": jsonValue(event.Metadata),
+	}
+	if !event.CreatedAt.IsZero() {
+		rec["created_at"] = event.CreatedAt.UTC().Truncate(time.Millisecond)
+	}
+	if err := s.store.Add(ctx, rec); err != nil {
+		return nil, fmt.Errorf("append app installation event: %w", err)
+	}
+	return recordToAppInstallationEvent(rec), nil
+}
+
+func (s *AppInstallationEventService) ListEventsByApp(ctx context.Context, appName string) ([]*core.AppInstallationEvent, error) {
+	appName = strings.TrimSpace(appName)
+	if appName == "" {
+		return nil, fmt.Errorf("list app installation events: app_name is required")
+	}
+	recs, err := s.store.Index("by_app_name").GetAll(ctx, appName)
+	if err != nil {
+		return nil, fmt.Errorf("list app installation events: %w", err)
+	}
+	out := make([]*core.AppInstallationEvent, 0, len(recs))
+	for _, rec := range recs {
+		out = append(out, recordToAppInstallationEvent(rec))
+	}
+	return out, nil
+}
+
+func recordToAppInstallationEvent(rec idb.Record) *core.AppInstallationEvent {
+	eventID := recString(rec, "event_id")
+	if eventID == "" {
+		eventID = recString(rec, "id")
+	}
+	return &core.AppInstallationEvent{
+		EventID:     eventID,
+		AppName:     recString(rec, "app_name"),
+		FromVersion: recString(rec, "from_version"),
+		ToVersion:   recString(rec, "to_version"),
+		EventType:   recString(rec, "event_type"),
+		Actor:       recString(rec, "actor"),
+		CreatedAt:   recTime(rec, "created_at"),
+		Metadata:    recAnyMap(rec, "metadata_json"),
+	}
+}

--- a/gestaltd/internal/coredata/app_installation_events.go
+++ b/gestaltd/internal/coredata/app_installation_events.go
@@ -42,19 +42,22 @@ func (s *AppInstallationEventService) AppendEvent(ctx context.Context, event *co
 	if eventID == "" {
 		eventID = uuid.NewString()
 	}
-	rec := idb.Record{
-		"id":            eventID,
-		"event_id":      eventID,
-		"app_name":      appName,
-		"from_version":  strings.TrimSpace(event.FromVersion),
-		"to_version":    strings.TrimSpace(event.ToVersion),
-		"event_type":    eventType,
-		"actor":         strings.TrimSpace(event.Actor),
-		"created_at":    now,
-		"metadata_json": jsonValue(event.Metadata),
+	eventTimestamp := event.EventTimestamp
+	if eventTimestamp.IsZero() {
+		eventTimestamp = now
+	} else {
+		eventTimestamp = eventTimestamp.UTC().Truncate(time.Millisecond)
 	}
-	if !event.CreatedAt.IsZero() {
-		rec["created_at"] = event.CreatedAt.UTC().Truncate(time.Millisecond)
+	rec := idb.Record{
+		"id":              eventID,
+		"event_id":        eventID,
+		"app_name":        appName,
+		"from_version":    strings.TrimSpace(event.FromVersion),
+		"to_version":      strings.TrimSpace(event.ToVersion),
+		"event_type":      eventType,
+		"actor":           strings.TrimSpace(event.Actor),
+		"event_timestamp": eventTimestamp,
+		"metadata_json":   jsonValue(event.Metadata),
 	}
 	if err := s.store.Add(ctx, rec); err != nil {
 		return nil, fmt.Errorf("append app installation event: %w", err)
@@ -75,7 +78,7 @@ func (s *AppInstallationEventService) ListEventsByApp(ctx context.Context, appNa
 		false,
 		false,
 	)
-	recs, err := s.store.Index("by_app_created").GetAll(ctx, query)
+	recs, err := s.store.Index("by_app_name_event_timestamp").GetAll(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("list app installation events: %w", err)
 	}
@@ -105,13 +108,13 @@ func recordToAppInstallationEvent(rec idb.Record) *core.AppInstallationEvent {
 		eventID = recString(rec, "id")
 	}
 	return &core.AppInstallationEvent{
-		EventID:     eventID,
-		AppName:     recString(rec, "app_name"),
-		FromVersion: recString(rec, "from_version"),
-		ToVersion:   recString(rec, "to_version"),
-		EventType:   recString(rec, "event_type"),
-		Actor:       recString(rec, "actor"),
-		CreatedAt:   recTime(rec, "created_at"),
-		Metadata:    recAnyMap(rec, "metadata_json"),
+		EventID:        eventID,
+		AppName:        recString(rec, "app_name"),
+		FromVersion:    recString(rec, "from_version"),
+		ToVersion:      recString(rec, "to_version"),
+		EventType:      recString(rec, "event_type"),
+		Actor:          recString(rec, "actor"),
+		EventTimestamp: recTime(rec, "event_timestamp"),
+		Metadata:       recAnyMap(rec, "metadata_json"),
 	}
 }

--- a/gestaltd/internal/coredata/app_installation_events.go
+++ b/gestaltd/internal/coredata/app_installation_events.go
@@ -33,6 +33,9 @@ func (s *AppInstallationEventService) AppendEvent(ctx context.Context, event *co
 	if eventType == "" {
 		return nil, fmt.Errorf("append app installation event: event_type is required")
 	}
+	if err := validateAppInstallationEventType(eventType); err != nil {
+		return nil, err
+	}
 
 	now := time.Now().UTC().Truncate(time.Millisecond)
 	eventID := strings.TrimSpace(event.EventID)
@@ -73,6 +76,19 @@ func (s *AppInstallationEventService) ListEventsByApp(ctx context.Context, appNa
 		out = append(out, recordToAppInstallationEvent(rec))
 	}
 	return out, nil
+}
+
+func validateAppInstallationEventType(eventType string) error {
+	switch eventType {
+	case core.AppInstallationEventTypeInstallRequested,
+		core.AppInstallationEventTypePromoted,
+		core.AppInstallationEventTypeFailed,
+		core.AppInstallationEventTypeRollback,
+		core.AppInstallationEventTypeUninstallRequested:
+		return nil
+	default:
+		return fmt.Errorf("append app installation event: unsupported event_type %q", eventType)
+	}
 }
 
 func recordToAppInstallationEvent(rec idb.Record) *core.AppInstallationEvent {

--- a/gestaltd/internal/coredata/app_installation_events.go
+++ b/gestaltd/internal/coredata/app_installation_events.go
@@ -43,14 +43,14 @@ func (s *AppInstallationEventService) AppendEvent(ctx context.Context, event *co
 		eventID = uuid.NewString()
 	}
 	rec := idb.Record{
-		"id":           eventID,
-		"event_id":     eventID,
-		"app_name":     appName,
-		"from_version": strings.TrimSpace(event.FromVersion),
-		"to_version":   strings.TrimSpace(event.ToVersion),
-		"event_type":   eventType,
-		"actor":        strings.TrimSpace(event.Actor),
-		"created_at":   now,
+		"id":            eventID,
+		"event_id":      eventID,
+		"app_name":      appName,
+		"from_version":  strings.TrimSpace(event.FromVersion),
+		"to_version":    strings.TrimSpace(event.ToVersion),
+		"event_type":    eventType,
+		"actor":         strings.TrimSpace(event.Actor),
+		"created_at":    now,
 		"metadata_json": jsonValue(event.Metadata),
 	}
 	if !event.CreatedAt.IsZero() {
@@ -62,12 +62,20 @@ func (s *AppInstallationEventService) AppendEvent(ctx context.Context, event *co
 	return recordToAppInstallationEvent(rec), nil
 }
 
+var indexedDBMaxTime = time.Date(2262, 1, 1, 0, 0, 0, 0, time.UTC)
+
 func (s *AppInstallationEventService) ListEventsByApp(ctx context.Context, appName string) ([]*core.AppInstallationEvent, error) {
 	appName = strings.TrimSpace(appName)
 	if appName == "" {
 		return nil, fmt.Errorf("list app installation events: app_name is required")
 	}
-	recs, err := s.store.Index("by_app_name").GetAll(ctx, appName)
+	query := idb.Bound(
+		[]any{appName, time.Time{}},
+		[]any{appName, indexedDBMaxTime},
+		false,
+		false,
+	)
+	recs, err := s.store.Index("by_app_created").GetAll(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("list app installation events: %w", err)
 	}

--- a/gestaltd/internal/coredata/app_installation_events.go
+++ b/gestaltd/internal/coredata/app_installation_events.go
@@ -25,9 +25,9 @@ func (s *AppInstallationEventService) AppendEvent(ctx context.Context, event *co
 	if event == nil {
 		return nil, fmt.Errorf("append app installation event: event is required")
 	}
-	appName := strings.TrimSpace(event.AppName)
-	if appName == "" {
-		return nil, fmt.Errorf("append app installation event: app_name is required")
+	installationID := strings.TrimSpace(event.InstallationID)
+	if installationID == "" {
+		return nil, fmt.Errorf("append app installation event: installation_id is required")
 	}
 	eventType := strings.TrimSpace(event.Type)
 	if eventType == "" {
@@ -49,14 +49,14 @@ func (s *AppInstallationEventService) AppendEvent(ctx context.Context, event *co
 		timestamp = timestamp.UTC().Truncate(time.Millisecond)
 	}
 	rec := idb.Record{
-		"id":            id,
-		"app_name":      appName,
-		"from_version":  strings.TrimSpace(event.FromVersion),
-		"to_version":    strings.TrimSpace(event.ToVersion),
-		"type":          eventType,
-		"actor":         strings.TrimSpace(event.Actor),
-		"timestamp":     timestamp,
-		"metadata_json": jsonValue(event.Metadata),
+		"id":              id,
+		"installation_id": installationID,
+		"from_version":    strings.TrimSpace(event.FromVersion),
+		"to_version":      strings.TrimSpace(event.ToVersion),
+		"type":            eventType,
+		"actor":           strings.TrimSpace(event.Actor),
+		"timestamp":       timestamp,
+		"metadata_json":   jsonValue(event.Metadata),
 	}
 	if err := s.store.Add(ctx, rec); err != nil {
 		return nil, fmt.Errorf("append app installation event: %w", err)
@@ -66,18 +66,18 @@ func (s *AppInstallationEventService) AppendEvent(ctx context.Context, event *co
 
 var indexedDBMaxTime = time.Date(2262, 1, 1, 0, 0, 0, 0, time.UTC)
 
-func (s *AppInstallationEventService) ListEventsByApp(ctx context.Context, appName string) ([]*core.AppInstallationEvent, error) {
-	appName = strings.TrimSpace(appName)
-	if appName == "" {
-		return nil, fmt.Errorf("list app installation events: app_name is required")
+func (s *AppInstallationEventService) ListEventsByApp(ctx context.Context, installationID string) ([]*core.AppInstallationEvent, error) {
+	installationID = strings.TrimSpace(installationID)
+	if installationID == "" {
+		return nil, fmt.Errorf("list app installation events: installation_id is required")
 	}
 	query := idb.Bound(
-		[]any{appName, time.Time{}},
-		[]any{appName, indexedDBMaxTime},
+		[]any{installationID, time.Time{}},
+		[]any{installationID, indexedDBMaxTime},
 		false,
 		false,
 	)
-	recs, err := s.store.Index("by_app_name_timestamp").GetAll(ctx, query)
+	recs, err := s.store.Index("by_installation_id_timestamp").GetAll(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("list app installation events: %w", err)
 	}
@@ -103,13 +103,13 @@ func validateAppInstallationEventType(eventType string) error {
 
 func recordToAppInstallationEvent(rec idb.Record) *core.AppInstallationEvent {
 	return &core.AppInstallationEvent{
-		ID:          recString(rec, "id"),
-		AppName:     recString(rec, "app_name"),
-		FromVersion: recString(rec, "from_version"),
-		ToVersion:   recString(rec, "to_version"),
-		Type:        recString(rec, "type"),
-		Actor:       recString(rec, "actor"),
-		Timestamp:   recTime(rec, "timestamp"),
-		Metadata:    recAnyMap(rec, "metadata_json"),
+		ID:             recString(rec, "id"),
+		InstallationID: recString(rec, "installation_id"),
+		FromVersion:    recString(rec, "from_version"),
+		ToVersion:      recString(rec, "to_version"),
+		Type:           recString(rec, "type"),
+		Actor:          recString(rec, "actor"),
+		Timestamp:      recTime(rec, "timestamp"),
+		Metadata:       recAnyMap(rec, "metadata_json"),
 	}
 }

--- a/gestaltd/internal/coredata/app_installation_events.go
+++ b/gestaltd/internal/coredata/app_installation_events.go
@@ -29,35 +29,34 @@ func (s *AppInstallationEventService) AppendEvent(ctx context.Context, event *co
 	if appName == "" {
 		return nil, fmt.Errorf("append app installation event: app_name is required")
 	}
-	eventType := strings.TrimSpace(event.EventType)
+	eventType := strings.TrimSpace(event.Type)
 	if eventType == "" {
-		return nil, fmt.Errorf("append app installation event: event_type is required")
+		return nil, fmt.Errorf("append app installation event: type is required")
 	}
 	if err := validateAppInstallationEventType(eventType); err != nil {
 		return nil, err
 	}
 
 	now := time.Now().UTC().Truncate(time.Millisecond)
-	eventID := strings.TrimSpace(event.EventID)
-	if eventID == "" {
-		eventID = uuid.NewString()
+	id := strings.TrimSpace(event.ID)
+	if id == "" {
+		id = uuid.NewString()
 	}
-	eventTimestamp := event.EventTimestamp
-	if eventTimestamp.IsZero() {
-		eventTimestamp = now
+	timestamp := event.Timestamp
+	if timestamp.IsZero() {
+		timestamp = now
 	} else {
-		eventTimestamp = eventTimestamp.UTC().Truncate(time.Millisecond)
+		timestamp = timestamp.UTC().Truncate(time.Millisecond)
 	}
 	rec := idb.Record{
-		"id":              eventID,
-		"event_id":        eventID,
-		"app_name":        appName,
-		"from_version":    strings.TrimSpace(event.FromVersion),
-		"to_version":      strings.TrimSpace(event.ToVersion),
-		"event_type":      eventType,
-		"actor":           strings.TrimSpace(event.Actor),
-		"event_timestamp": eventTimestamp,
-		"metadata_json":   jsonValue(event.Metadata),
+		"id":            id,
+		"app_name":      appName,
+		"from_version":  strings.TrimSpace(event.FromVersion),
+		"to_version":    strings.TrimSpace(event.ToVersion),
+		"type":          eventType,
+		"actor":         strings.TrimSpace(event.Actor),
+		"timestamp":     timestamp,
+		"metadata_json": jsonValue(event.Metadata),
 	}
 	if err := s.store.Add(ctx, rec); err != nil {
 		return nil, fmt.Errorf("append app installation event: %w", err)
@@ -78,7 +77,7 @@ func (s *AppInstallationEventService) ListEventsByApp(ctx context.Context, appNa
 		false,
 		false,
 	)
-	recs, err := s.store.Index("by_app_name_event_timestamp").GetAll(ctx, query)
+	recs, err := s.store.Index("by_app_name_timestamp").GetAll(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("list app installation events: %w", err)
 	}
@@ -98,23 +97,19 @@ func validateAppInstallationEventType(eventType string) error {
 		core.AppInstallationEventTypeUninstallRequested:
 		return nil
 	default:
-		return fmt.Errorf("append app installation event: unsupported event_type %q", eventType)
+		return fmt.Errorf("append app installation event: unsupported type %q", eventType)
 	}
 }
 
 func recordToAppInstallationEvent(rec idb.Record) *core.AppInstallationEvent {
-	eventID := recString(rec, "event_id")
-	if eventID == "" {
-		eventID = recString(rec, "id")
-	}
 	return &core.AppInstallationEvent{
-		EventID:        eventID,
-		AppName:        recString(rec, "app_name"),
-		FromVersion:    recString(rec, "from_version"),
-		ToVersion:      recString(rec, "to_version"),
-		EventType:      recString(rec, "event_type"),
-		Actor:          recString(rec, "actor"),
-		EventTimestamp: recTime(rec, "event_timestamp"),
-		Metadata:       recAnyMap(rec, "metadata_json"),
+		ID:          recString(rec, "id"),
+		AppName:     recString(rec, "app_name"),
+		FromVersion: recString(rec, "from_version"),
+		ToVersion:   recString(rec, "to_version"),
+		Type:        recString(rec, "type"),
+		Actor:       recString(rec, "actor"),
+		Timestamp:   recTime(rec, "timestamp"),
+		Metadata:    recAnyMap(rec, "metadata_json"),
 	}
 }

--- a/gestaltd/internal/coredata/app_installations.go
+++ b/gestaltd/internal/coredata/app_installations.go
@@ -38,6 +38,11 @@ func (s *AppInstallationService) GetInstallation(ctx context.Context, appName st
 
 func (s *AppInstallationService) ListInstallations(ctx context.Context, rolloutStatus string) ([]*core.AppInstallation, error) {
 	rolloutStatus = strings.TrimSpace(rolloutStatus)
+	if rolloutStatus != "" {
+		if err := validateAppInstallationRolloutStatus(rolloutStatus); err != nil {
+			return nil, fmt.Errorf("list app installations: %w", err)
+		}
+	}
 	var (
 		recs []idb.Record
 		err  error
@@ -74,19 +79,22 @@ func (s *AppInstallationService) PutInstallation(ctx context.Context, installati
 	}
 
 	now := time.Now().UTC().Truncate(time.Millisecond)
-	rec := appInstallationToRecord(installation)
+	existingRec, err := s.store.Get(ctx, appName)
+	if err != nil && !errors.Is(err, idb.ErrNotFound) {
+		return nil, fmt.Errorf("put app installation: %w", err)
+	}
+	var existing *core.AppInstallation
+	if err == nil {
+		existing = recordToAppInstallation(existingRec)
+	}
+	toStore := mergeAppInstallation(existing, installation)
+	if toStore.InstalledAt.IsZero() {
+		toStore.InstalledAt = now
+	}
+	rec := appInstallationToRecord(toStore)
 	rec["id"] = appName
 	rec["rollout_status"] = rolloutStatus
-	installedAt := installation.InstalledAt
-	if installedAt.IsZero() {
-		if existing, err := s.store.Get(ctx, appName); err == nil {
-			installedAt = recTime(existing, "installed_at")
-		}
-	}
-	if installedAt.IsZero() {
-		installedAt = now
-	}
-	rec["installed_at"] = installedAt
+	rec["installed_at"] = toStore.InstalledAt
 	rec["updated_at"] = now
 	if err := s.store.Put(ctx, rec); err != nil {
 		return nil, fmt.Errorf("put app installation: %w", err)
@@ -145,8 +153,48 @@ func validateAppInstallationRolloutStatus(rolloutStatus string) error {
 		core.AppInstallationRolloutStatusFailed:
 		return nil
 	default:
-		return fmt.Errorf("put app installation: unsupported rollout_status %q", rolloutStatus)
+		return fmt.Errorf("unsupported rollout_status %q", rolloutStatus)
 	}
+}
+
+func mergeAppInstallation(existing *core.AppInstallation, incoming *core.AppInstallation) *core.AppInstallation {
+	if existing == nil {
+		out := *incoming
+		return &out
+	}
+	out := *existing
+	out.RolloutStatus = incoming.RolloutStatus
+	if v := strings.TrimSpace(incoming.VersionConstraint); v != "" {
+		out.VersionConstraint = v
+	}
+	if v := strings.TrimSpace(incoming.ResolvedVersion); v != "" {
+		out.ResolvedVersion = v
+	}
+	if v := strings.TrimSpace(incoming.SourceRef); v != "" {
+		out.SourceRef = v
+	}
+	if v := strings.TrimSpace(incoming.Registry); v != "" {
+		out.Registry = v
+	}
+	if v := strings.TrimSpace(incoming.ProviderReleaseURL); v != "" {
+		out.ProviderReleaseURL = v
+	}
+	if v := strings.TrimSpace(incoming.PreviousResolvedVersion); v != "" {
+		out.PreviousResolvedVersion = v
+	}
+	if v := strings.TrimSpace(incoming.InstalledBy); v != "" {
+		out.InstalledBy = v
+	}
+	if len(incoming.ArtifactChecksums) > 0 {
+		out.ArtifactChecksums = incoming.ArtifactChecksums
+	}
+	if incoming.ActiveSince != nil {
+		out.ActiveSince = incoming.ActiveSince
+	}
+	if !incoming.InstalledAt.IsZero() {
+		out.InstalledAt = incoming.InstalledAt
+	}
+	return &out
 }
 
 func recordToAppInstallation(rec idb.Record) *core.AppInstallation {

--- a/gestaltd/internal/coredata/app_installations.go
+++ b/gestaltd/internal/coredata/app_installations.go
@@ -78,9 +78,16 @@ func (s *AppInstallationService) PutInstallation(ctx context.Context, installati
 	rec["id"] = appName
 	rec["app_name"] = appName
 	rec["rollout_status"] = rolloutStatus
-	if recTime(rec, "installed_at").IsZero() {
-		rec["installed_at"] = now
+	installedAt := installation.InstalledAt
+	if installedAt.IsZero() {
+		if existing, err := s.store.Get(ctx, appName); err == nil {
+			installedAt = recTime(existing, "installed_at")
+		}
 	}
+	if installedAt.IsZero() {
+		installedAt = now
+	}
+	rec["installed_at"] = installedAt
 	rec["updated_at"] = now
 	if err := s.store.Put(ctx, rec); err != nil {
 		return nil, fmt.Errorf("put app installation: %w", err)
@@ -169,19 +176,19 @@ func recordToAppInstallation(rec idb.Record) *core.AppInstallation {
 func appInstallationToRecord(installation *core.AppInstallation) idb.Record {
 	appName := strings.TrimSpace(installation.AppName)
 	return idb.Record{
-		"id":                          appName,
-		"app_name":                    appName,
-		"version_constraint":          strings.TrimSpace(installation.VersionConstraint),
-		"resolved_version":            strings.TrimSpace(installation.ResolvedVersion),
-		"source_ref":                  strings.TrimSpace(installation.SourceRef),
-		"registry":                    strings.TrimSpace(installation.Registry),
-		"provider_release_url":        strings.TrimSpace(installation.ProviderReleaseURL),
-		"artifact_checksums_json":     jsonValue(installation.ArtifactChecksums),
-		"rollout_status":              strings.TrimSpace(installation.RolloutStatus),
-		"active_since":                installation.ActiveSince,
-		"previous_resolved_version":   strings.TrimSpace(installation.PreviousResolvedVersion),
-		"installed_by":                strings.TrimSpace(installation.InstalledBy),
-		"installed_at":                installation.InstalledAt,
-		"updated_at":                  installation.UpdatedAt,
+		"id":                        appName,
+		"app_name":                  appName,
+		"version_constraint":        strings.TrimSpace(installation.VersionConstraint),
+		"resolved_version":          strings.TrimSpace(installation.ResolvedVersion),
+		"source_ref":                strings.TrimSpace(installation.SourceRef),
+		"registry":                  strings.TrimSpace(installation.Registry),
+		"provider_release_url":      strings.TrimSpace(installation.ProviderReleaseURL),
+		"artifact_checksums_json":   jsonValue(installation.ArtifactChecksums),
+		"rollout_status":            strings.TrimSpace(installation.RolloutStatus),
+		"active_since":              installation.ActiveSince,
+		"previous_resolved_version": strings.TrimSpace(installation.PreviousResolvedVersion),
+		"installed_by":              strings.TrimSpace(installation.InstalledBy),
+		"installed_at":              installation.InstalledAt,
+		"updated_at":                installation.UpdatedAt,
 	}
 }

--- a/gestaltd/internal/coredata/app_installations.go
+++ b/gestaltd/internal/coredata/app_installations.go
@@ -1,0 +1,187 @@
+package coredata
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	idb "github.com/valon-technologies/gestalt/sdk/go/indexeddb"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+)
+
+type AppInstallationService struct {
+	store idb.ObjectStore
+}
+
+func NewAppInstallationService(ds indexeddb.IndexedDB) *AppInstallationService {
+	return &AppInstallationService{store: ds.ObjectStore(StoreAppInstallations)}
+}
+
+func (s *AppInstallationService) GetInstallation(ctx context.Context, appName string) (*core.AppInstallation, error) {
+	appName = strings.TrimSpace(appName)
+	if appName == "" {
+		return nil, fmt.Errorf("get app installation: app_name is required")
+	}
+	rec, err := s.store.Get(ctx, appName)
+	if err != nil {
+		if errors.Is(err, idb.ErrNotFound) {
+			return nil, core.ErrNotFound
+		}
+		return nil, fmt.Errorf("get app installation: %w", err)
+	}
+	return recordToAppInstallation(rec), nil
+}
+
+func (s *AppInstallationService) ListInstallations(ctx context.Context, desiredState string) ([]*core.AppInstallation, error) {
+	desiredState = strings.TrimSpace(desiredState)
+	var (
+		recs []idb.Record
+		err  error
+	)
+	if desiredState == "" {
+		recs, err = s.store.GetAll(ctx, nil)
+	} else {
+		recs, err = s.store.Index("by_desired_state").GetAll(ctx, desiredState)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("list app installations: %w", err)
+	}
+	out := make([]*core.AppInstallation, 0, len(recs))
+	for _, rec := range recs {
+		out = append(out, recordToAppInstallation(rec))
+	}
+	return out, nil
+}
+
+func (s *AppInstallationService) PutInstallation(ctx context.Context, installation *core.AppInstallation) (*core.AppInstallation, error) {
+	if installation == nil {
+		return nil, fmt.Errorf("put app installation: installation is required")
+	}
+	appName := strings.TrimSpace(installation.AppName)
+	if appName == "" {
+		return nil, fmt.Errorf("put app installation: app_name is required")
+	}
+	desiredState := strings.TrimSpace(installation.DesiredState)
+	if desiredState == "" {
+		return nil, fmt.Errorf("put app installation: desired_state is required")
+	}
+	if err := validateAppInstallationDesiredState(desiredState); err != nil {
+		return nil, err
+	}
+
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	rec := appInstallationToRecord(installation)
+	rec["id"] = appName
+	rec["app_name"] = appName
+	rec["desired_state"] = desiredState
+	if recTime(rec, "installed_at").IsZero() {
+		rec["installed_at"] = now
+	}
+	rec["updated_at"] = now
+	if err := s.store.Put(ctx, rec); err != nil {
+		return nil, fmt.Errorf("put app installation: %w", err)
+	}
+	return recordToAppInstallation(rec), nil
+}
+
+func (s *AppInstallationService) UpdateInstallation(ctx context.Context, appName string, update func(*core.AppInstallation) error) (*core.AppInstallation, error) {
+	appName = strings.TrimSpace(appName)
+	if appName == "" {
+		return nil, fmt.Errorf("update app installation: app_name is required")
+	}
+	if update == nil {
+		return nil, fmt.Errorf("update app installation: update is required")
+	}
+	installation, err := s.GetInstallation(ctx, appName)
+	if err != nil {
+		return nil, err
+	}
+	if err := update(installation); err != nil {
+		return nil, err
+	}
+	desiredState := strings.TrimSpace(installation.DesiredState)
+	if desiredState == "" {
+		return nil, fmt.Errorf("update app installation: desired_state is required")
+	}
+	if err := validateAppInstallationDesiredState(desiredState); err != nil {
+		return nil, err
+	}
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	rec := appInstallationToRecord(installation)
+	rec["id"] = appName
+	rec["app_name"] = appName
+	rec["desired_state"] = desiredState
+	rec["updated_at"] = now
+	if err := s.store.Put(ctx, rec); err != nil {
+		return nil, fmt.Errorf("update app installation: %w", err)
+	}
+	return recordToAppInstallation(rec), nil
+}
+
+func (s *AppInstallationService) DeleteInstallation(ctx context.Context, appName string) error {
+	appName = strings.TrimSpace(appName)
+	if appName == "" {
+		return fmt.Errorf("delete app installation: app_name is required")
+	}
+	if err := s.store.Delete(ctx, appName); err != nil {
+		return fmt.Errorf("delete app installation: %w", err)
+	}
+	return nil
+}
+
+func validateAppInstallationDesiredState(desiredState string) error {
+	switch desiredState {
+	case core.AppInstallationDesiredStatePending,
+		core.AppInstallationDesiredStateActive,
+		core.AppInstallationDesiredStateFailed:
+		return nil
+	default:
+		return fmt.Errorf("put app installation: unsupported desired_state %q", desiredState)
+	}
+}
+
+func recordToAppInstallation(rec idb.Record) *core.AppInstallation {
+	appName := recString(rec, "app_name")
+	if appName == "" {
+		appName = recString(rec, "id")
+	}
+	return &core.AppInstallation{
+		AppName:                  appName,
+		DesiredVersionConstraint: recString(rec, "desired_version_constraint"),
+		ResolvedVersion:          recString(rec, "resolved_version"),
+		SourceRef:                recString(rec, "source_ref"),
+		Registry:                 recString(rec, "registry"),
+		ProviderReleaseURL:       recString(rec, "provider_release_url"),
+		ArtifactChecksums:        recStringMap(rec, "artifact_checksums_json"),
+		DesiredState:             recString(rec, "desired_state"),
+		ActiveSince:              recTimePtr(rec, "active_since"),
+		PreviousResolvedVersion:  recString(rec, "previous_resolved_version"),
+		InstalledBy:              recString(rec, "installed_by"),
+		InstalledAt:              recTime(rec, "installed_at"),
+		UpdatedAt:                recTime(rec, "updated_at"),
+	}
+}
+
+func appInstallationToRecord(installation *core.AppInstallation) idb.Record {
+	appName := strings.TrimSpace(installation.AppName)
+	return idb.Record{
+		"id":                         appName,
+		"app_name":                   appName,
+		"desired_version_constraint": strings.TrimSpace(installation.DesiredVersionConstraint),
+		"resolved_version":           strings.TrimSpace(installation.ResolvedVersion),
+		"source_ref":                 strings.TrimSpace(installation.SourceRef),
+		"registry":                   strings.TrimSpace(installation.Registry),
+		"provider_release_url":       strings.TrimSpace(installation.ProviderReleaseURL),
+		"artifact_checksums_json":    jsonValue(installation.ArtifactChecksums),
+		"desired_state":              strings.TrimSpace(installation.DesiredState),
+		"active_since":               installation.ActiveSince,
+		"previous_resolved_version":  strings.TrimSpace(installation.PreviousResolvedVersion),
+		"installed_by":               strings.TrimSpace(installation.InstalledBy),
+		"installed_at":               installation.InstalledAt,
+		"updated_at":                 installation.UpdatedAt,
+	}
+}

--- a/gestaltd/internal/coredata/app_installations.go
+++ b/gestaltd/internal/coredata/app_installations.go
@@ -76,7 +76,6 @@ func (s *AppInstallationService) PutInstallation(ctx context.Context, installati
 	now := time.Now().UTC().Truncate(time.Millisecond)
 	rec := appInstallationToRecord(installation)
 	rec["id"] = appName
-	rec["app_name"] = appName
 	rec["rollout_status"] = rolloutStatus
 	installedAt := installation.InstalledAt
 	if installedAt.IsZero() {
@@ -120,7 +119,6 @@ func (s *AppInstallationService) UpdateInstallation(ctx context.Context, appName
 	now := time.Now().UTC().Truncate(time.Millisecond)
 	rec := appInstallationToRecord(installation)
 	rec["id"] = appName
-	rec["app_name"] = appName
 	rec["rollout_status"] = rolloutStatus
 	rec["updated_at"] = now
 	if err := s.store.Put(ctx, rec); err != nil {
@@ -152,12 +150,8 @@ func validateAppInstallationRolloutStatus(rolloutStatus string) error {
 }
 
 func recordToAppInstallation(rec idb.Record) *core.AppInstallation {
-	appName := recString(rec, "app_name")
-	if appName == "" {
-		appName = recString(rec, "id")
-	}
 	return &core.AppInstallation{
-		AppName:                 appName,
+		AppName:                 recString(rec, "id"),
 		VersionConstraint:       recString(rec, "version_constraint"),
 		ResolvedVersion:         recString(rec, "resolved_version"),
 		SourceRef:               recString(rec, "source_ref"),
@@ -177,7 +171,6 @@ func appInstallationToRecord(installation *core.AppInstallation) idb.Record {
 	appName := strings.TrimSpace(installation.AppName)
 	return idb.Record{
 		"id":                        appName,
-		"app_name":                  appName,
 		"version_constraint":        strings.TrimSpace(installation.VersionConstraint),
 		"resolved_version":          strings.TrimSpace(installation.ResolvedVersion),
 		"source_ref":                strings.TrimSpace(installation.SourceRef),

--- a/gestaltd/internal/coredata/app_installations.go
+++ b/gestaltd/internal/coredata/app_installations.go
@@ -36,16 +36,16 @@ func (s *AppInstallationService) GetInstallation(ctx context.Context, appName st
 	return recordToAppInstallation(rec), nil
 }
 
-func (s *AppInstallationService) ListInstallations(ctx context.Context, desiredState string) ([]*core.AppInstallation, error) {
-	desiredState = strings.TrimSpace(desiredState)
+func (s *AppInstallationService) ListInstallations(ctx context.Context, rolloutStatus string) ([]*core.AppInstallation, error) {
+	rolloutStatus = strings.TrimSpace(rolloutStatus)
 	var (
 		recs []idb.Record
 		err  error
 	)
-	if desiredState == "" {
+	if rolloutStatus == "" {
 		recs, err = s.store.GetAll(ctx, nil)
 	} else {
-		recs, err = s.store.Index("by_desired_state").GetAll(ctx, desiredState)
+		recs, err = s.store.Index("by_rollout_status").GetAll(ctx, rolloutStatus)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("list app installations: %w", err)
@@ -65,11 +65,11 @@ func (s *AppInstallationService) PutInstallation(ctx context.Context, installati
 	if appName == "" {
 		return nil, fmt.Errorf("put app installation: app_name is required")
 	}
-	desiredState := strings.TrimSpace(installation.DesiredState)
-	if desiredState == "" {
-		return nil, fmt.Errorf("put app installation: desired_state is required")
+	rolloutStatus := strings.TrimSpace(installation.RolloutStatus)
+	if rolloutStatus == "" {
+		return nil, fmt.Errorf("put app installation: rollout_status is required")
 	}
-	if err := validateAppInstallationDesiredState(desiredState); err != nil {
+	if err := validateAppInstallationRolloutStatus(rolloutStatus); err != nil {
 		return nil, err
 	}
 
@@ -77,7 +77,7 @@ func (s *AppInstallationService) PutInstallation(ctx context.Context, installati
 	rec := appInstallationToRecord(installation)
 	rec["id"] = appName
 	rec["app_name"] = appName
-	rec["desired_state"] = desiredState
+	rec["rollout_status"] = rolloutStatus
 	if recTime(rec, "installed_at").IsZero() {
 		rec["installed_at"] = now
 	}
@@ -103,18 +103,18 @@ func (s *AppInstallationService) UpdateInstallation(ctx context.Context, appName
 	if err := update(installation); err != nil {
 		return nil, err
 	}
-	desiredState := strings.TrimSpace(installation.DesiredState)
-	if desiredState == "" {
-		return nil, fmt.Errorf("update app installation: desired_state is required")
+	rolloutStatus := strings.TrimSpace(installation.RolloutStatus)
+	if rolloutStatus == "" {
+		return nil, fmt.Errorf("update app installation: rollout_status is required")
 	}
-	if err := validateAppInstallationDesiredState(desiredState); err != nil {
+	if err := validateAppInstallationRolloutStatus(rolloutStatus); err != nil {
 		return nil, err
 	}
 	now := time.Now().UTC().Truncate(time.Millisecond)
 	rec := appInstallationToRecord(installation)
 	rec["id"] = appName
 	rec["app_name"] = appName
-	rec["desired_state"] = desiredState
+	rec["rollout_status"] = rolloutStatus
 	rec["updated_at"] = now
 	if err := s.store.Put(ctx, rec); err != nil {
 		return nil, fmt.Errorf("update app installation: %w", err)
@@ -133,14 +133,14 @@ func (s *AppInstallationService) DeleteInstallation(ctx context.Context, appName
 	return nil
 }
 
-func validateAppInstallationDesiredState(desiredState string) error {
-	switch desiredState {
-	case core.AppInstallationDesiredStatePending,
-		core.AppInstallationDesiredStateActive,
-		core.AppInstallationDesiredStateFailed:
+func validateAppInstallationRolloutStatus(rolloutStatus string) error {
+	switch rolloutStatus {
+	case core.AppInstallationRolloutStatusPending,
+		core.AppInstallationRolloutStatusPromoted,
+		core.AppInstallationRolloutStatusFailed:
 		return nil
 	default:
-		return fmt.Errorf("put app installation: unsupported desired_state %q", desiredState)
+		return fmt.Errorf("put app installation: unsupported rollout_status %q", rolloutStatus)
 	}
 }
 
@@ -150,38 +150,38 @@ func recordToAppInstallation(rec idb.Record) *core.AppInstallation {
 		appName = recString(rec, "id")
 	}
 	return &core.AppInstallation{
-		AppName:                  appName,
-		DesiredVersionConstraint: recString(rec, "desired_version_constraint"),
-		ResolvedVersion:          recString(rec, "resolved_version"),
-		SourceRef:                recString(rec, "source_ref"),
-		Registry:                 recString(rec, "registry"),
-		ProviderReleaseURL:       recString(rec, "provider_release_url"),
-		ArtifactChecksums:        recStringMap(rec, "artifact_checksums_json"),
-		DesiredState:             recString(rec, "desired_state"),
-		ActiveSince:              recTimePtr(rec, "active_since"),
-		PreviousResolvedVersion:  recString(rec, "previous_resolved_version"),
-		InstalledBy:              recString(rec, "installed_by"),
-		InstalledAt:              recTime(rec, "installed_at"),
-		UpdatedAt:                recTime(rec, "updated_at"),
+		AppName:                 appName,
+		VersionConstraint:       recString(rec, "version_constraint"),
+		ResolvedVersion:         recString(rec, "resolved_version"),
+		SourceRef:               recString(rec, "source_ref"),
+		Registry:                recString(rec, "registry"),
+		ProviderReleaseURL:      recString(rec, "provider_release_url"),
+		ArtifactChecksums:       recStringMap(rec, "artifact_checksums_json"),
+		RolloutStatus:           recString(rec, "rollout_status"),
+		ActiveSince:             recTimePtr(rec, "active_since"),
+		PreviousResolvedVersion: recString(rec, "previous_resolved_version"),
+		InstalledBy:             recString(rec, "installed_by"),
+		InstalledAt:             recTime(rec, "installed_at"),
+		UpdatedAt:               recTime(rec, "updated_at"),
 	}
 }
 
 func appInstallationToRecord(installation *core.AppInstallation) idb.Record {
 	appName := strings.TrimSpace(installation.AppName)
 	return idb.Record{
-		"id":                         appName,
-		"app_name":                   appName,
-		"desired_version_constraint": strings.TrimSpace(installation.DesiredVersionConstraint),
-		"resolved_version":           strings.TrimSpace(installation.ResolvedVersion),
-		"source_ref":                 strings.TrimSpace(installation.SourceRef),
-		"registry":                   strings.TrimSpace(installation.Registry),
-		"provider_release_url":       strings.TrimSpace(installation.ProviderReleaseURL),
-		"artifact_checksums_json":    jsonValue(installation.ArtifactChecksums),
-		"desired_state":              strings.TrimSpace(installation.DesiredState),
-		"active_since":               installation.ActiveSince,
-		"previous_resolved_version":  strings.TrimSpace(installation.PreviousResolvedVersion),
-		"installed_by":               strings.TrimSpace(installation.InstalledBy),
-		"installed_at":               installation.InstalledAt,
-		"updated_at":                 installation.UpdatedAt,
+		"id":                          appName,
+		"app_name":                    appName,
+		"version_constraint":          strings.TrimSpace(installation.VersionConstraint),
+		"resolved_version":            strings.TrimSpace(installation.ResolvedVersion),
+		"source_ref":                  strings.TrimSpace(installation.SourceRef),
+		"registry":                    strings.TrimSpace(installation.Registry),
+		"provider_release_url":        strings.TrimSpace(installation.ProviderReleaseURL),
+		"artifact_checksums_json":     jsonValue(installation.ArtifactChecksums),
+		"rollout_status":              strings.TrimSpace(installation.RolloutStatus),
+		"active_since":                installation.ActiveSince,
+		"previous_resolved_version":   strings.TrimSpace(installation.PreviousResolvedVersion),
+		"installed_by":                strings.TrimSpace(installation.InstalledBy),
+		"installed_at":                installation.InstalledAt,
+		"updated_at":                  installation.UpdatedAt,
 	}
 }

--- a/gestaltd/internal/coredata/app_installations_test.go
+++ b/gestaltd/internal/coredata/app_installations_test.go
@@ -178,7 +178,7 @@ func TestAppInstallationEventService(t *testing.T) {
 			AppName:     "g-issues",
 			FromVersion: "",
 			ToVersion:   "v1",
-			EventType:   "install_requested",
+			EventType:   core.AppInstallationEventTypeInstallRequested,
 			Actor:       "user:alice",
 			Metadata:    map[string]any{"registry": "toolshed"},
 		})
@@ -193,7 +193,7 @@ func TestAppInstallationEventService(t *testing.T) {
 			AppName:     "g-issues",
 			FromVersion: "v1",
 			ToVersion:   "v2",
-			EventType:   "promoted",
+			EventType:   core.AppInstallationEventTypePromoted,
 			Actor:       "user:alice",
 		})
 		if err != nil {
@@ -219,6 +219,21 @@ func TestAppInstallationEventService(t *testing.T) {
 		}
 		if !foundMetadata {
 			t.Fatalf("expected install_requested metadata on one event, got %#v", events)
+		}
+	})
+
+	t.Run("AppendEvent_rejects_unknown_event_type", func(t *testing.T) {
+		t.Parallel()
+		svc, err := coredata.New(&coretesting.StubIndexedDB{})
+		if err != nil {
+			t.Fatalf("coredata.New: %v", err)
+		}
+		_, err = svc.AppInstallationEvents.AppendEvent(context.Background(), &core.AppInstallationEvent{
+			AppName:   "g-issues",
+			EventType: "activated",
+		})
+		if err == nil {
+			t.Fatal("expected unsupported event_type error")
 		}
 	})
 }

--- a/gestaltd/internal/coredata/app_installations_test.go
+++ b/gestaltd/internal/coredata/app_installations_test.go
@@ -1,0 +1,224 @@
+package coredata_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
+)
+
+func TestAppInstallationService(t *testing.T) {
+	t.Parallel()
+
+	t.Run("PutGet_round_trip", func(t *testing.T) {
+		t.Parallel()
+		svc, err := coredata.New(&coretesting.StubIndexedDB{})
+		if err != nil {
+			t.Fatalf("coredata.New: %v", err)
+		}
+		ctx := context.Background()
+		activeSince := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+
+		got, err := svc.AppInstallations.PutInstallation(ctx, &core.AppInstallation{
+			AppName:                  "g-issues",
+			DesiredVersionConstraint: "0.0.0-snapshot.gabc123",
+			ResolvedVersion:          "0.0.0-snapshot.gabc123",
+			SourceRef:                "abc123def456abc123def456abc123def456abcd",
+			Registry:                 "toolshed",
+			ProviderReleaseURL:         "https://storage.googleapis.com/gitlab-peach-street-gestalt-app-registry/apps/g-issues/versions/0.0.0-snapshot.gabc123.json",
+			ArtifactChecksums: map[string]string{
+				"linux/amd64": "sha256:deadbeef",
+			},
+			DesiredState:            core.AppInstallationDesiredStateActive,
+			ActiveSince:             &activeSince,
+			PreviousResolvedVersion: "",
+			InstalledBy:             "user:alice",
+		})
+		if err != nil {
+			t.Fatalf("PutInstallation: %v", err)
+		}
+		if got.AppName != "g-issues" {
+			t.Fatalf("AppName = %q, want g-issues", got.AppName)
+		}
+		if got.ResolvedVersion != "0.0.0-snapshot.gabc123" {
+			t.Fatalf("ResolvedVersion = %q", got.ResolvedVersion)
+		}
+		if got.ArtifactChecksums["linux/amd64"] != "sha256:deadbeef" {
+			t.Fatalf("ArtifactChecksums = %#v", got.ArtifactChecksums)
+		}
+		if got.InstalledAt.IsZero() || got.UpdatedAt.IsZero() {
+			t.Fatalf("InstalledAt/UpdatedAt should be set: %+v", got)
+		}
+
+		stored, err := svc.AppInstallations.GetInstallation(ctx, "g-issues")
+		if err != nil {
+			t.Fatalf("GetInstallation: %v", err)
+		}
+		if stored.DesiredState != core.AppInstallationDesiredStateActive {
+			t.Fatalf("DesiredState = %q, want active", stored.DesiredState)
+		}
+		if stored.ActiveSince == nil || !stored.ActiveSince.Equal(activeSince) {
+			t.Fatalf("ActiveSince = %v, want %v", stored.ActiveSince, activeSince)
+		}
+	})
+
+	t.Run("GetInstallation_not_found", func(t *testing.T) {
+		t.Parallel()
+		svc, err := coredata.New(&coretesting.StubIndexedDB{})
+		if err != nil {
+			t.Fatalf("coredata.New: %v", err)
+		}
+		_, err = svc.AppInstallations.GetInstallation(context.Background(), "missing")
+		if err != core.ErrNotFound {
+			t.Fatalf("GetInstallation = %v, want ErrNotFound", err)
+		}
+	})
+
+	t.Run("PutInstallation_rejects_unknown_desired_state", func(t *testing.T) {
+		t.Parallel()
+		svc, err := coredata.New(&coretesting.StubIndexedDB{})
+		if err != nil {
+			t.Fatalf("coredata.New: %v", err)
+		}
+		_, err = svc.AppInstallations.PutInstallation(context.Background(), &core.AppInstallation{
+			AppName:      "g-issues",
+			DesiredState: "installing",
+		})
+		if err == nil {
+			t.Fatal("expected unsupported desired_state error")
+		}
+	})
+
+	t.Run("ListInstallations_filters_by_desired_state", func(t *testing.T) {
+		t.Parallel()
+		svc, err := coredata.New(&coretesting.StubIndexedDB{})
+		if err != nil {
+			t.Fatalf("coredata.New: %v", err)
+		}
+		ctx := context.Background()
+		for _, installation := range []*core.AppInstallation{
+			{AppName: "g-issues", DesiredState: core.AppInstallationDesiredStateActive, ResolvedVersion: "v1"},
+			{AppName: "dealHub", DesiredState: core.AppInstallationDesiredStatePending, ResolvedVersion: "v2"},
+		} {
+			if _, err := svc.AppInstallations.PutInstallation(ctx, installation); err != nil {
+				t.Fatalf("PutInstallation(%s): %v", installation.AppName, err)
+			}
+		}
+
+		active, err := svc.AppInstallations.ListInstallations(ctx, core.AppInstallationDesiredStateActive)
+		if err != nil {
+			t.Fatalf("ListInstallations(active): %v", err)
+		}
+		if len(active) != 1 || active[0].AppName != "g-issues" {
+			t.Fatalf("active installations = %#v, want g-issues only", active)
+		}
+
+		all, err := svc.AppInstallations.ListInstallations(ctx, "")
+		if err != nil {
+			t.Fatalf("ListInstallations(all): %v", err)
+		}
+		if len(all) != 2 {
+			t.Fatalf("all installations = %d, want 2", len(all))
+		}
+	})
+
+	t.Run("UpdateInstallation", func(t *testing.T) {
+		t.Parallel()
+		svc, err := coredata.New(&coretesting.StubIndexedDB{})
+		if err != nil {
+			t.Fatalf("coredata.New: %v", err)
+		}
+		ctx := context.Background()
+		if _, err := svc.AppInstallations.PutInstallation(ctx, &core.AppInstallation{
+			AppName:         "g-issues",
+			DesiredState:    core.AppInstallationDesiredStatePending,
+			ResolvedVersion: "v1",
+		}); err != nil {
+			t.Fatalf("PutInstallation: %v", err)
+		}
+
+		updated, err := svc.AppInstallations.UpdateInstallation(ctx, "g-issues", func(installation *core.AppInstallation) error {
+			installation.PreviousResolvedVersion = installation.ResolvedVersion
+			installation.ResolvedVersion = "v2"
+			installation.DesiredState = core.AppInstallationDesiredStateActive
+			now := time.Now().UTC().Truncate(time.Millisecond)
+			installation.ActiveSince = &now
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("UpdateInstallation: %v", err)
+		}
+		if updated.ResolvedVersion != "v2" {
+			t.Fatalf("ResolvedVersion = %q, want v2", updated.ResolvedVersion)
+		}
+		if updated.PreviousResolvedVersion != "v1" {
+			t.Fatalf("PreviousResolvedVersion = %q, want v1", updated.PreviousResolvedVersion)
+		}
+		if updated.DesiredState != core.AppInstallationDesiredStateActive {
+			t.Fatalf("DesiredState = %q, want active", updated.DesiredState)
+		}
+	})
+}
+
+func TestAppInstallationEventService(t *testing.T) {
+	t.Parallel()
+
+	t.Run("AppendListEventsByApp", func(t *testing.T) {
+		t.Parallel()
+		svc, err := coredata.New(&coretesting.StubIndexedDB{})
+		if err != nil {
+			t.Fatalf("coredata.New: %v", err)
+		}
+		ctx := context.Background()
+
+		first, err := svc.AppInstallationEvents.AppendEvent(ctx, &core.AppInstallationEvent{
+			AppName:     "g-issues",
+			FromVersion: "",
+			ToVersion:   "v1",
+			EventType:   "install_requested",
+			Actor:       "user:alice",
+			Metadata:    map[string]any{"registry": "toolshed"},
+		})
+		if err != nil {
+			t.Fatalf("AppendEvent(first): %v", err)
+		}
+		if first.EventID == "" {
+			t.Fatal("EventID should be generated")
+		}
+
+		second, err := svc.AppInstallationEvents.AppendEvent(ctx, &core.AppInstallationEvent{
+			AppName:     "g-issues",
+			FromVersion: "v1",
+			ToVersion:   "v2",
+			EventType:   "activated",
+			Actor:       "user:alice",
+		})
+		if err != nil {
+			t.Fatalf("AppendEvent(second): %v", err)
+		}
+		if second.EventID == first.EventID {
+			t.Fatal("expected distinct event IDs")
+		}
+
+		events, err := svc.AppInstallationEvents.ListEventsByApp(ctx, "g-issues")
+		if err != nil {
+			t.Fatalf("ListEventsByApp: %v", err)
+		}
+		if len(events) != 2 {
+			t.Fatalf("events = %d, want 2", len(events))
+		}
+		var foundMetadata bool
+		for _, event := range events {
+			if event.Metadata != nil && event.Metadata["registry"] == "toolshed" {
+				foundMetadata = true
+				break
+			}
+		}
+		if !foundMetadata {
+			t.Fatalf("expected install_requested metadata on one event, got %#v", events)
+		}
+	})
+}

--- a/gestaltd/internal/coredata/app_installations_test.go
+++ b/gestaltd/internal/coredata/app_installations_test.go
@@ -204,12 +204,12 @@ func TestAppInstallationEventService(t *testing.T) {
 		ctx := context.Background()
 
 		first, err := svc.AppInstallationEvents.AppendEvent(ctx, &core.AppInstallationEvent{
-			AppName:     "g-issues",
-			FromVersion: "",
-			ToVersion:   "v1",
-			Type:        core.AppInstallationEventTypeInstallRequested,
-			Actor:       "user:alice",
-			Metadata:    map[string]any{"registry": "toolshed"},
+			InstallationID: "g-issues",
+			FromVersion:    "",
+			ToVersion:      "v1",
+			Type:           core.AppInstallationEventTypeInstallRequested,
+			Actor:          "user:alice",
+			Metadata:       map[string]any{"registry": "toolshed"},
 		})
 		if err != nil {
 			t.Fatalf("AppendEvent(first): %v", err)
@@ -219,11 +219,11 @@ func TestAppInstallationEventService(t *testing.T) {
 		}
 
 		second, err := svc.AppInstallationEvents.AppendEvent(ctx, &core.AppInstallationEvent{
-			AppName:     "g-issues",
-			FromVersion: "v1",
-			ToVersion:   "v2",
-			Type:        core.AppInstallationEventTypePromoted,
-			Actor:       "user:alice",
+			InstallationID: "g-issues",
+			FromVersion:    "v1",
+			ToVersion:      "v2",
+			Type:           core.AppInstallationEventTypePromoted,
+			Actor:          "user:alice",
 		})
 		if err != nil {
 			t.Fatalf("AppendEvent(second): %v", err)
@@ -261,16 +261,16 @@ func TestAppInstallationEventService(t *testing.T) {
 		firstAt := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
 		secondAt := time.Date(2026, 7, 10, 13, 0, 0, 0, time.UTC)
 		if _, err := svc.AppInstallationEvents.AppendEvent(ctx, &core.AppInstallationEvent{
-			AppName:   "g-issues",
-			Type:      core.AppInstallationEventTypeInstallRequested,
-			Timestamp: secondAt,
+			InstallationID: "g-issues",
+			Type:           core.AppInstallationEventTypeInstallRequested,
+			Timestamp:      secondAt,
 		}); err != nil {
 			t.Fatalf("AppendEvent(first): %v", err)
 		}
 		if _, err := svc.AppInstallationEvents.AppendEvent(ctx, &core.AppInstallationEvent{
-			AppName:   "g-issues",
-			Type:      core.AppInstallationEventTypePromoted,
-			Timestamp: firstAt,
+			InstallationID: "g-issues",
+			Type:           core.AppInstallationEventTypePromoted,
+			Timestamp:      firstAt,
 		}); err != nil {
 			t.Fatalf("AppendEvent(second): %v", err)
 		}
@@ -297,8 +297,8 @@ func TestAppInstallationEventService(t *testing.T) {
 			t.Fatalf("coredata.New: %v", err)
 		}
 		_, err = svc.AppInstallationEvents.AppendEvent(context.Background(), &core.AppInstallationEvent{
-			AppName: "g-issues",
-			Type:    "activated",
+			InstallationID: "g-issues",
+			Type:           "activated",
 		})
 		if err == nil {
 			t.Fatal("expected unsupported type error")

--- a/gestaltd/internal/coredata/app_installations_test.go
+++ b/gestaltd/internal/coredata/app_installations_test.go
@@ -207,28 +207,28 @@ func TestAppInstallationEventService(t *testing.T) {
 			AppName:     "g-issues",
 			FromVersion: "",
 			ToVersion:   "v1",
-			EventType:   core.AppInstallationEventTypeInstallRequested,
+			Type:        core.AppInstallationEventTypeInstallRequested,
 			Actor:       "user:alice",
 			Metadata:    map[string]any{"registry": "toolshed"},
 		})
 		if err != nil {
 			t.Fatalf("AppendEvent(first): %v", err)
 		}
-		if first.EventID == "" {
-			t.Fatal("EventID should be generated")
+		if first.ID == "" {
+			t.Fatal("ID should be generated")
 		}
 
 		second, err := svc.AppInstallationEvents.AppendEvent(ctx, &core.AppInstallationEvent{
 			AppName:     "g-issues",
 			FromVersion: "v1",
 			ToVersion:   "v2",
-			EventType:   core.AppInstallationEventTypePromoted,
+			Type:        core.AppInstallationEventTypePromoted,
 			Actor:       "user:alice",
 		})
 		if err != nil {
 			t.Fatalf("AppendEvent(second): %v", err)
 		}
-		if second.EventID == first.EventID {
+		if second.ID == first.ID {
 			t.Fatal("expected distinct event IDs")
 		}
 
@@ -251,7 +251,7 @@ func TestAppInstallationEventService(t *testing.T) {
 		}
 	})
 
-	t.Run("ListEventsByApp_returns_event_timestamp_order", func(t *testing.T) {
+	t.Run("ListEventsByApp_returns_timestamp_order", func(t *testing.T) {
 		t.Parallel()
 		svc, err := coredata.New(&coretesting.StubIndexedDB{})
 		if err != nil {
@@ -261,16 +261,16 @@ func TestAppInstallationEventService(t *testing.T) {
 		firstAt := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
 		secondAt := time.Date(2026, 7, 10, 13, 0, 0, 0, time.UTC)
 		if _, err := svc.AppInstallationEvents.AppendEvent(ctx, &core.AppInstallationEvent{
-			AppName:        "g-issues",
-			EventType:      core.AppInstallationEventTypeInstallRequested,
-			EventTimestamp: secondAt,
+			AppName:   "g-issues",
+			Type:      core.AppInstallationEventTypeInstallRequested,
+			Timestamp: secondAt,
 		}); err != nil {
 			t.Fatalf("AppendEvent(first): %v", err)
 		}
 		if _, err := svc.AppInstallationEvents.AppendEvent(ctx, &core.AppInstallationEvent{
-			AppName:        "g-issues",
-			EventType:      core.AppInstallationEventTypePromoted,
-			EventTimestamp: firstAt,
+			AppName:   "g-issues",
+			Type:      core.AppInstallationEventTypePromoted,
+			Timestamp: firstAt,
 		}); err != nil {
 			t.Fatalf("AppendEvent(second): %v", err)
 		}
@@ -282,26 +282,26 @@ func TestAppInstallationEventService(t *testing.T) {
 		if len(events) != 2 {
 			t.Fatalf("events = %d, want 2", len(events))
 		}
-		if !events[0].EventTimestamp.Equal(firstAt) || events[1].EventTimestamp.Equal(secondAt) == false {
-			t.Fatalf("event order = [%v, %v], want [%v, %v]", events[0].EventTimestamp, events[1].EventTimestamp, firstAt, secondAt)
+		if !events[0].Timestamp.Equal(firstAt) || events[1].Timestamp.Equal(secondAt) == false {
+			t.Fatalf("event order = [%v, %v], want [%v, %v]", events[0].Timestamp, events[1].Timestamp, firstAt, secondAt)
 		}
-		if events[0].EventType != core.AppInstallationEventTypePromoted {
-			t.Fatalf("first event type = %q, want promoted", events[0].EventType)
+		if events[0].Type != core.AppInstallationEventTypePromoted {
+			t.Fatalf("first event type = %q, want promoted", events[0].Type)
 		}
 	})
 
-	t.Run("AppendEvent_rejects_unknown_event_type", func(t *testing.T) {
+	t.Run("AppendEvent_rejects_unknown_type", func(t *testing.T) {
 		t.Parallel()
 		svc, err := coredata.New(&coretesting.StubIndexedDB{})
 		if err != nil {
 			t.Fatalf("coredata.New: %v", err)
 		}
 		_, err = svc.AppInstallationEvents.AppendEvent(context.Background(), &core.AppInstallationEvent{
-			AppName:   "g-issues",
-			EventType: "activated",
+			AppName: "g-issues",
+			Type:    "activated",
 		})
 		if err == nil {
-			t.Fatal("expected unsupported event_type error")
+			t.Fatal("expected unsupported type error")
 		}
 	})
 }

--- a/gestaltd/internal/coredata/app_installations_test.go
+++ b/gestaltd/internal/coredata/app_installations_test.go
@@ -251,7 +251,7 @@ func TestAppInstallationEventService(t *testing.T) {
 		}
 	})
 
-	t.Run("ListEventsByApp_returns_created_at_order", func(t *testing.T) {
+	t.Run("ListEventsByApp_returns_event_timestamp_order", func(t *testing.T) {
 		t.Parallel()
 		svc, err := coredata.New(&coretesting.StubIndexedDB{})
 		if err != nil {
@@ -261,16 +261,16 @@ func TestAppInstallationEventService(t *testing.T) {
 		firstAt := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
 		secondAt := time.Date(2026, 7, 10, 13, 0, 0, 0, time.UTC)
 		if _, err := svc.AppInstallationEvents.AppendEvent(ctx, &core.AppInstallationEvent{
-			AppName:   "g-issues",
-			EventType: core.AppInstallationEventTypeInstallRequested,
-			CreatedAt: secondAt,
+			AppName:        "g-issues",
+			EventType:      core.AppInstallationEventTypeInstallRequested,
+			EventTimestamp: secondAt,
 		}); err != nil {
 			t.Fatalf("AppendEvent(first): %v", err)
 		}
 		if _, err := svc.AppInstallationEvents.AppendEvent(ctx, &core.AppInstallationEvent{
-			AppName:   "g-issues",
-			EventType: core.AppInstallationEventTypePromoted,
-			CreatedAt: firstAt,
+			AppName:        "g-issues",
+			EventType:      core.AppInstallationEventTypePromoted,
+			EventTimestamp: firstAt,
 		}); err != nil {
 			t.Fatalf("AppendEvent(second): %v", err)
 		}
@@ -282,8 +282,8 @@ func TestAppInstallationEventService(t *testing.T) {
 		if len(events) != 2 {
 			t.Fatalf("events = %d, want 2", len(events))
 		}
-		if !events[0].CreatedAt.Equal(firstAt) || events[1].CreatedAt.Equal(secondAt) == false {
-			t.Fatalf("event order = [%v, %v], want [%v, %v]", events[0].CreatedAt, events[1].CreatedAt, firstAt, secondAt)
+		if !events[0].EventTimestamp.Equal(firstAt) || events[1].EventTimestamp.Equal(secondAt) == false {
+			t.Fatalf("event order = [%v, %v], want [%v, %v]", events[0].EventTimestamp, events[1].EventTimestamp, firstAt, secondAt)
 		}
 		if events[0].EventType != core.AppInstallationEventTypePromoted {
 			t.Fatalf("first event type = %q, want promoted", events[0].EventType)

--- a/gestaltd/internal/coredata/app_installations_test.go
+++ b/gestaltd/internal/coredata/app_installations_test.go
@@ -190,6 +190,51 @@ func TestAppInstallationService(t *testing.T) {
 			t.Fatalf("InstalledAt = %v, want %v", got.InstalledAt, installedAt)
 		}
 	})
+
+	t.Run("PutInstallation_preserves_fields_on_partial_reupsert", func(t *testing.T) {
+		t.Parallel()
+		svc, err := coredata.New(&coretesting.StubIndexedDB{})
+		if err != nil {
+			t.Fatalf("coredata.New: %v", err)
+		}
+		ctx := context.Background()
+		if _, err := svc.AppInstallations.PutInstallation(ctx, &core.AppInstallation{
+			AppName:           "g-issues",
+			RolloutStatus:     core.AppInstallationRolloutStatusPending,
+			Registry:          "toolshed",
+			ResolvedVersion:   "v1",
+			ArtifactChecksums: map[string]string{"linux/amd64": "sha256:deadbeef"},
+		}); err != nil {
+			t.Fatalf("PutInstallation: %v", err)
+		}
+
+		got, err := svc.AppInstallations.PutInstallation(ctx, &core.AppInstallation{
+			AppName:         "g-issues",
+			RolloutStatus:   core.AppInstallationRolloutStatusPromoted,
+			ResolvedVersion: "v2",
+		})
+		if err != nil {
+			t.Fatalf("PutInstallation reupsert: %v", err)
+		}
+		if got.Registry != "toolshed" {
+			t.Fatalf("Registry = %q, want toolshed", got.Registry)
+		}
+		if got.ArtifactChecksums["linux/amd64"] != "sha256:deadbeef" {
+			t.Fatalf("ArtifactChecksums = %#v", got.ArtifactChecksums)
+		}
+	})
+
+	t.Run("ListInstallations_rejects_unknown_rollout_status", func(t *testing.T) {
+		t.Parallel()
+		svc, err := coredata.New(&coretesting.StubIndexedDB{})
+		if err != nil {
+			t.Fatalf("coredata.New: %v", err)
+		}
+		_, err = svc.AppInstallations.ListInstallations(context.Background(), "installing")
+		if err == nil {
+			t.Fatal("expected unsupported rollout_status error")
+		}
+	})
 }
 
 func TestAppInstallationEventService(t *testing.T) {

--- a/gestaltd/internal/coredata/app_installations_test.go
+++ b/gestaltd/internal/coredata/app_installations_test.go
@@ -23,16 +23,16 @@ func TestAppInstallationService(t *testing.T) {
 		activeSince := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
 
 		got, err := svc.AppInstallations.PutInstallation(ctx, &core.AppInstallation{
-			AppName:                  "g-issues",
-			DesiredVersionConstraint: "0.0.0-snapshot.gabc123",
-			ResolvedVersion:          "0.0.0-snapshot.gabc123",
-			SourceRef:                "abc123def456abc123def456abc123def456abcd",
-			Registry:                 "toolshed",
-			ProviderReleaseURL:         "https://storage.googleapis.com/gitlab-peach-street-gestalt-app-registry/apps/g-issues/versions/0.0.0-snapshot.gabc123.json",
+			AppName:           "g-issues",
+			VersionConstraint: "0.0.0-snapshot.gabc123",
+			ResolvedVersion:   "0.0.0-snapshot.gabc123",
+			SourceRef:         "abc123def456abc123def456abc123def456abcd",
+			Registry:          "toolshed",
+			ProviderReleaseURL: "https://storage.googleapis.com/gitlab-peach-street-gestalt-app-registry/apps/g-issues/versions/0.0.0-snapshot.gabc123.json",
 			ArtifactChecksums: map[string]string{
 				"linux/amd64": "sha256:deadbeef",
 			},
-			DesiredState:            core.AppInstallationDesiredStateActive,
+			RolloutStatus:           core.AppInstallationRolloutStatusPromoted,
 			ActiveSince:             &activeSince,
 			PreviousResolvedVersion: "",
 			InstalledBy:             "user:alice",
@@ -57,8 +57,8 @@ func TestAppInstallationService(t *testing.T) {
 		if err != nil {
 			t.Fatalf("GetInstallation: %v", err)
 		}
-		if stored.DesiredState != core.AppInstallationDesiredStateActive {
-			t.Fatalf("DesiredState = %q, want active", stored.DesiredState)
+		if stored.RolloutStatus != core.AppInstallationRolloutStatusPromoted {
+			t.Fatalf("RolloutStatus = %q, want promoted", stored.RolloutStatus)
 		}
 		if stored.ActiveSince == nil || !stored.ActiveSince.Equal(activeSince) {
 			t.Fatalf("ActiveSince = %v, want %v", stored.ActiveSince, activeSince)
@@ -77,22 +77,22 @@ func TestAppInstallationService(t *testing.T) {
 		}
 	})
 
-	t.Run("PutInstallation_rejects_unknown_desired_state", func(t *testing.T) {
+	t.Run("PutInstallation_rejects_unknown_rollout_status", func(t *testing.T) {
 		t.Parallel()
 		svc, err := coredata.New(&coretesting.StubIndexedDB{})
 		if err != nil {
 			t.Fatalf("coredata.New: %v", err)
 		}
 		_, err = svc.AppInstallations.PutInstallation(context.Background(), &core.AppInstallation{
-			AppName:      "g-issues",
-			DesiredState: "installing",
+			AppName:       "g-issues",
+			RolloutStatus: "installing",
 		})
 		if err == nil {
-			t.Fatal("expected unsupported desired_state error")
+			t.Fatal("expected unsupported rollout_status error")
 		}
 	})
 
-	t.Run("ListInstallations_filters_by_desired_state", func(t *testing.T) {
+	t.Run("ListInstallations_filters_by_rollout_status", func(t *testing.T) {
 		t.Parallel()
 		svc, err := coredata.New(&coretesting.StubIndexedDB{})
 		if err != nil {
@@ -100,20 +100,20 @@ func TestAppInstallationService(t *testing.T) {
 		}
 		ctx := context.Background()
 		for _, installation := range []*core.AppInstallation{
-			{AppName: "g-issues", DesiredState: core.AppInstallationDesiredStateActive, ResolvedVersion: "v1"},
-			{AppName: "dealHub", DesiredState: core.AppInstallationDesiredStatePending, ResolvedVersion: "v2"},
+			{AppName: "g-issues", RolloutStatus: core.AppInstallationRolloutStatusPromoted, ResolvedVersion: "v1"},
+			{AppName: "dealHub", RolloutStatus: core.AppInstallationRolloutStatusPending, ResolvedVersion: "v2"},
 		} {
 			if _, err := svc.AppInstallations.PutInstallation(ctx, installation); err != nil {
 				t.Fatalf("PutInstallation(%s): %v", installation.AppName, err)
 			}
 		}
 
-		active, err := svc.AppInstallations.ListInstallations(ctx, core.AppInstallationDesiredStateActive)
+		promoted, err := svc.AppInstallations.ListInstallations(ctx, core.AppInstallationRolloutStatusPromoted)
 		if err != nil {
-			t.Fatalf("ListInstallations(active): %v", err)
+			t.Fatalf("ListInstallations(promoted): %v", err)
 		}
-		if len(active) != 1 || active[0].AppName != "g-issues" {
-			t.Fatalf("active installations = %#v, want g-issues only", active)
+		if len(promoted) != 1 || promoted[0].AppName != "g-issues" {
+			t.Fatalf("promoted installations = %#v, want g-issues only", promoted)
 		}
 
 		all, err := svc.AppInstallations.ListInstallations(ctx, "")
@@ -134,7 +134,7 @@ func TestAppInstallationService(t *testing.T) {
 		ctx := context.Background()
 		if _, err := svc.AppInstallations.PutInstallation(ctx, &core.AppInstallation{
 			AppName:         "g-issues",
-			DesiredState:    core.AppInstallationDesiredStatePending,
+			RolloutStatus:   core.AppInstallationRolloutStatusPending,
 			ResolvedVersion: "v1",
 		}); err != nil {
 			t.Fatalf("PutInstallation: %v", err)
@@ -143,7 +143,7 @@ func TestAppInstallationService(t *testing.T) {
 		updated, err := svc.AppInstallations.UpdateInstallation(ctx, "g-issues", func(installation *core.AppInstallation) error {
 			installation.PreviousResolvedVersion = installation.ResolvedVersion
 			installation.ResolvedVersion = "v2"
-			installation.DesiredState = core.AppInstallationDesiredStateActive
+			installation.RolloutStatus = core.AppInstallationRolloutStatusPromoted
 			now := time.Now().UTC().Truncate(time.Millisecond)
 			installation.ActiveSince = &now
 			return nil
@@ -157,8 +157,8 @@ func TestAppInstallationService(t *testing.T) {
 		if updated.PreviousResolvedVersion != "v1" {
 			t.Fatalf("PreviousResolvedVersion = %q, want v1", updated.PreviousResolvedVersion)
 		}
-		if updated.DesiredState != core.AppInstallationDesiredStateActive {
-			t.Fatalf("DesiredState = %q, want active", updated.DesiredState)
+		if updated.RolloutStatus != core.AppInstallationRolloutStatusPromoted {
+			t.Fatalf("RolloutStatus = %q, want promoted", updated.RolloutStatus)
 		}
 	})
 }
@@ -193,7 +193,7 @@ func TestAppInstallationEventService(t *testing.T) {
 			AppName:     "g-issues",
 			FromVersion: "v1",
 			ToVersion:   "v2",
-			EventType:   "activated",
+			EventType:   "promoted",
 			Actor:       "user:alice",
 		})
 		if err != nil {

--- a/gestaltd/internal/coredata/app_installations_test.go
+++ b/gestaltd/internal/coredata/app_installations_test.go
@@ -23,11 +23,11 @@ func TestAppInstallationService(t *testing.T) {
 		activeSince := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
 
 		got, err := svc.AppInstallations.PutInstallation(ctx, &core.AppInstallation{
-			AppName:           "g-issues",
-			VersionConstraint: "0.0.0-snapshot.gabc123",
-			ResolvedVersion:   "0.0.0-snapshot.gabc123",
-			SourceRef:         "abc123def456abc123def456abc123def456abcd",
-			Registry:          "toolshed",
+			AppName:            "g-issues",
+			VersionConstraint:  "0.0.0-snapshot.gabc123",
+			ResolvedVersion:    "0.0.0-snapshot.gabc123",
+			SourceRef:          "abc123def456abc123def456abc123def456abcd",
+			Registry:           "toolshed",
 			ProviderReleaseURL: "https://storage.googleapis.com/gitlab-peach-street-gestalt-app-registry/apps/g-issues/versions/0.0.0-snapshot.gabc123.json",
 			ArtifactChecksums: map[string]string{
 				"linux/amd64": "sha256:deadbeef",
@@ -161,6 +161,35 @@ func TestAppInstallationService(t *testing.T) {
 			t.Fatalf("RolloutStatus = %q, want promoted", updated.RolloutStatus)
 		}
 	})
+
+	t.Run("PutInstallation_preserves_installed_at_on_reupsert", func(t *testing.T) {
+		t.Parallel()
+		svc, err := coredata.New(&coretesting.StubIndexedDB{})
+		if err != nil {
+			t.Fatalf("coredata.New: %v", err)
+		}
+		ctx := context.Background()
+		installedAt := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+		if _, err := svc.AppInstallations.PutInstallation(ctx, &core.AppInstallation{
+			AppName:       "g-issues",
+			RolloutStatus: core.AppInstallationRolloutStatusPending,
+			InstalledAt:   installedAt,
+		}); err != nil {
+			t.Fatalf("PutInstallation: %v", err)
+		}
+
+		got, err := svc.AppInstallations.PutInstallation(ctx, &core.AppInstallation{
+			AppName:         "g-issues",
+			RolloutStatus:   core.AppInstallationRolloutStatusPromoted,
+			ResolvedVersion: "v2",
+		})
+		if err != nil {
+			t.Fatalf("PutInstallation reupsert: %v", err)
+		}
+		if !got.InstalledAt.Equal(installedAt) {
+			t.Fatalf("InstalledAt = %v, want %v", got.InstalledAt, installedAt)
+		}
+	})
 }
 
 func TestAppInstallationEventService(t *testing.T) {
@@ -219,6 +248,45 @@ func TestAppInstallationEventService(t *testing.T) {
 		}
 		if !foundMetadata {
 			t.Fatalf("expected install_requested metadata on one event, got %#v", events)
+		}
+	})
+
+	t.Run("ListEventsByApp_returns_created_at_order", func(t *testing.T) {
+		t.Parallel()
+		svc, err := coredata.New(&coretesting.StubIndexedDB{})
+		if err != nil {
+			t.Fatalf("coredata.New: %v", err)
+		}
+		ctx := context.Background()
+		firstAt := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+		secondAt := time.Date(2026, 7, 10, 13, 0, 0, 0, time.UTC)
+		if _, err := svc.AppInstallationEvents.AppendEvent(ctx, &core.AppInstallationEvent{
+			AppName:   "g-issues",
+			EventType: core.AppInstallationEventTypeInstallRequested,
+			CreatedAt: secondAt,
+		}); err != nil {
+			t.Fatalf("AppendEvent(first): %v", err)
+		}
+		if _, err := svc.AppInstallationEvents.AppendEvent(ctx, &core.AppInstallationEvent{
+			AppName:   "g-issues",
+			EventType: core.AppInstallationEventTypePromoted,
+			CreatedAt: firstAt,
+		}); err != nil {
+			t.Fatalf("AppendEvent(second): %v", err)
+		}
+
+		events, err := svc.AppInstallationEvents.ListEventsByApp(ctx, "g-issues")
+		if err != nil {
+			t.Fatalf("ListEventsByApp: %v", err)
+		}
+		if len(events) != 2 {
+			t.Fatalf("events = %d, want 2", len(events))
+		}
+		if !events[0].CreatedAt.Equal(firstAt) || events[1].CreatedAt.Equal(secondAt) == false {
+			t.Fatalf("event order = [%v, %v], want [%v, %v]", events[0].CreatedAt, events[1].CreatedAt, firstAt, secondAt)
+		}
+		if events[0].EventType != core.AppInstallationEventTypePromoted {
+			t.Fatalf("first event type = %q, want promoted", events[0].EventType)
 		}
 	})
 

--- a/gestaltd/internal/coredata/convert.go
+++ b/gestaltd/internal/coredata/convert.go
@@ -1,6 +1,7 @@
 package coredata
 
 import (
+	"encoding/json"
 	"time"
 
 	idb "github.com/valon-technologies/gestalt/sdk/go/indexeddb"
@@ -42,6 +43,77 @@ func recTime(rec idb.Record, key string) time.Time {
 		return parsed
 	default:
 		return time.Time{}
+	}
+}
+
+func recStringMap(rec idb.Record, key string) map[string]string {
+	raw := recJSON(rec, key)
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make(map[string]string)
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil
+	}
+	return out
+}
+
+func recAnyMap(rec idb.Record, key string) map[string]any {
+	raw := recJSON(rec, key)
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make(map[string]any)
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil
+	}
+	return out
+}
+
+func recJSON(rec idb.Record, key string) []byte {
+	v, ok := rec[key]
+	if !ok || v == nil {
+		return nil
+	}
+	switch raw := v.(type) {
+	case []byte:
+		return raw
+	case string:
+		return []byte(raw)
+	case json.RawMessage:
+		return raw
+	case map[string]any:
+		encoded, err := json.Marshal(raw)
+		if err != nil {
+			return nil
+		}
+		return encoded
+	default:
+		encoded, err := json.Marshal(raw)
+		if err != nil {
+			return nil
+		}
+		return encoded
+	}
+}
+
+func jsonValue(v any) any {
+	if v == nil {
+		return nil
+	}
+	switch value := v.(type) {
+	case map[string]string:
+		if len(value) == 0 {
+			return nil
+		}
+		return value
+	case map[string]any:
+		if len(value) == 0 {
+			return nil
+		}
+		return value
+	default:
+		return v
 	}
 }
 

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -59,7 +59,6 @@ var AppInstallationsSchema = idb.ObjectStoreOptions{
 	Indexes: []idb.IndexSchema{
 		{Name: "by_rollout_status", KeyPath: []string{"rollout_status"}},
 		{Name: "by_registry", KeyPath: []string{"registry"}},
-		{Name: "by_resolved_version", KeyPath: []string{"resolved_version"}},
 	},
 	Columns: []idb.ColumnDef{
 		{Name: "id", Type: idb.TypeString, PrimaryKey: true},
@@ -82,7 +81,7 @@ var AppInstallationsSchema = idb.ObjectStoreOptions{
 var AppInstallationEventsSchema = idb.ObjectStoreOptions{
 	Indexes: []idb.IndexSchema{
 		{Name: "by_app_name", KeyPath: []string{"app_name"}},
-		{Name: "by_app_created", KeyPath: []string{"app_name", "created_at"}},
+		{Name: "by_app_name_event_timestamp", KeyPath: []string{"app_name", "event_timestamp"}},
 	},
 	Columns: []idb.ColumnDef{
 		{Name: "id", Type: idb.TypeString, PrimaryKey: true},
@@ -92,7 +91,7 @@ var AppInstallationEventsSchema = idb.ObjectStoreOptions{
 		{Name: "to_version", Type: idb.TypeString},
 		{Name: "event_type", Type: idb.TypeString, NotNull: true},
 		{Name: "actor", Type: idb.TypeString},
-		{Name: "created_at", Type: idb.TypeTime, NotNull: true},
+		{Name: "event_timestamp", Type: idb.TypeTime, NotNull: true},
 		{Name: "metadata_json", Type: idb.TypeJSON},
 	},
 }

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -57,20 +57,20 @@ var ManagedSubjectsSchema = idb.ObjectStoreOptions{
 
 var AppInstallationsSchema = idb.ObjectStoreOptions{
 	Indexes: []idb.IndexSchema{
-		{Name: "by_desired_state", KeyPath: []string{"desired_state"}},
+		{Name: "by_rollout_status", KeyPath: []string{"rollout_status"}},
 		{Name: "by_registry", KeyPath: []string{"registry"}},
 		{Name: "by_resolved_version", KeyPath: []string{"resolved_version"}},
 	},
 	Columns: []idb.ColumnDef{
 		{Name: "id", Type: idb.TypeString, PrimaryKey: true},
 		{Name: "app_name", Type: idb.TypeString, NotNull: true, Unique: true},
-		{Name: "desired_version_constraint", Type: idb.TypeString},
+		{Name: "version_constraint", Type: idb.TypeString},
 		{Name: "resolved_version", Type: idb.TypeString},
 		{Name: "source_ref", Type: idb.TypeString},
 		{Name: "registry", Type: idb.TypeString},
 		{Name: "provider_release_url", Type: idb.TypeString},
 		{Name: "artifact_checksums_json", Type: idb.TypeJSON},
-		{Name: "desired_state", Type: idb.TypeString, NotNull: true},
+		{Name: "rollout_status", Type: idb.TypeString, NotNull: true},
 		{Name: "active_since", Type: idb.TypeTime},
 		{Name: "previous_resolved_version", Type: idb.TypeString},
 		{Name: "installed_by", Type: idb.TypeString},

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -62,7 +62,6 @@ var AppInstallationsSchema = idb.ObjectStoreOptions{
 	},
 	Columns: []idb.ColumnDef{
 		{Name: "id", Type: idb.TypeString, PrimaryKey: true},
-		{Name: "app_name", Type: idb.TypeString, NotNull: true, Unique: true},
 		{Name: "version_constraint", Type: idb.TypeString},
 		{Name: "resolved_version", Type: idb.TypeString},
 		{Name: "source_ref", Type: idb.TypeString},
@@ -80,12 +79,12 @@ var AppInstallationsSchema = idb.ObjectStoreOptions{
 
 var AppInstallationEventsSchema = idb.ObjectStoreOptions{
 	Indexes: []idb.IndexSchema{
-		{Name: "by_app_name", KeyPath: []string{"app_name"}},
-		{Name: "by_app_name_timestamp", KeyPath: []string{"app_name", "timestamp"}},
+		{Name: "by_installation_id", KeyPath: []string{"installation_id"}},
+		{Name: "by_installation_id_timestamp", KeyPath: []string{"installation_id", "timestamp"}},
 	},
 	Columns: []idb.ColumnDef{
 		{Name: "id", Type: idb.TypeString, PrimaryKey: true},
-		{Name: "app_name", Type: idb.TypeString, NotNull: true},
+		{Name: "installation_id", Type: idb.TypeString, NotNull: true},
 		{Name: "from_version", Type: idb.TypeString},
 		{Name: "to_version", Type: idb.TypeString},
 		{Name: "type", Type: idb.TypeString, NotNull: true},

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -9,6 +9,8 @@ const (
 	StoreManagedSubjects               = "managed_subjects"
 	StoreAuthorizationDynamicFragments = "authz_dynamic_fragments"
 	StoreAppSHAs                       = "app_shas"
+	StoreAppInstallations              = "app_installations"
+	StoreAppInstallationEvents         = "app_installation_events"
 )
 
 var AppSHAsSchema = idb.ObjectStoreOptions{
@@ -50,6 +52,48 @@ var ManagedSubjectsSchema = idb.ObjectStoreOptions{
 		{Name: "created_at", Type: idb.TypeTime},
 		{Name: "updated_at", Type: idb.TypeTime},
 		{Name: "deleted_at", Type: idb.TypeTime},
+	},
+}
+
+var AppInstallationsSchema = idb.ObjectStoreOptions{
+	Indexes: []idb.IndexSchema{
+		{Name: "by_desired_state", KeyPath: []string{"desired_state"}},
+		{Name: "by_registry", KeyPath: []string{"registry"}},
+		{Name: "by_resolved_version", KeyPath: []string{"resolved_version"}},
+	},
+	Columns: []idb.ColumnDef{
+		{Name: "id", Type: idb.TypeString, PrimaryKey: true},
+		{Name: "app_name", Type: idb.TypeString, NotNull: true, Unique: true},
+		{Name: "desired_version_constraint", Type: idb.TypeString},
+		{Name: "resolved_version", Type: idb.TypeString},
+		{Name: "source_ref", Type: idb.TypeString},
+		{Name: "registry", Type: idb.TypeString},
+		{Name: "provider_release_url", Type: idb.TypeString},
+		{Name: "artifact_checksums_json", Type: idb.TypeJSON},
+		{Name: "desired_state", Type: idb.TypeString, NotNull: true},
+		{Name: "active_since", Type: idb.TypeTime},
+		{Name: "previous_resolved_version", Type: idb.TypeString},
+		{Name: "installed_by", Type: idb.TypeString},
+		{Name: "installed_at", Type: idb.TypeTime},
+		{Name: "updated_at", Type: idb.TypeTime},
+	},
+}
+
+var AppInstallationEventsSchema = idb.ObjectStoreOptions{
+	Indexes: []idb.IndexSchema{
+		{Name: "by_app_name", KeyPath: []string{"app_name"}},
+		{Name: "by_app_created", KeyPath: []string{"app_name", "created_at"}},
+	},
+	Columns: []idb.ColumnDef{
+		{Name: "id", Type: idb.TypeString, PrimaryKey: true},
+		{Name: "event_id", Type: idb.TypeString, NotNull: true, Unique: true},
+		{Name: "app_name", Type: idb.TypeString, NotNull: true},
+		{Name: "from_version", Type: idb.TypeString},
+		{Name: "to_version", Type: idb.TypeString},
+		{Name: "event_type", Type: idb.TypeString, NotNull: true},
+		{Name: "actor", Type: idb.TypeString},
+		{Name: "created_at", Type: idb.TypeTime, NotNull: true},
+		{Name: "metadata_json", Type: idb.TypeJSON},
 	},
 }
 

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -81,17 +81,16 @@ var AppInstallationsSchema = idb.ObjectStoreOptions{
 var AppInstallationEventsSchema = idb.ObjectStoreOptions{
 	Indexes: []idb.IndexSchema{
 		{Name: "by_app_name", KeyPath: []string{"app_name"}},
-		{Name: "by_app_name_event_timestamp", KeyPath: []string{"app_name", "event_timestamp"}},
+		{Name: "by_app_name_timestamp", KeyPath: []string{"app_name", "timestamp"}},
 	},
 	Columns: []idb.ColumnDef{
 		{Name: "id", Type: idb.TypeString, PrimaryKey: true},
-		{Name: "event_id", Type: idb.TypeString, NotNull: true, Unique: true},
 		{Name: "app_name", Type: idb.TypeString, NotNull: true},
 		{Name: "from_version", Type: idb.TypeString},
 		{Name: "to_version", Type: idb.TypeString},
-		{Name: "event_type", Type: idb.TypeString, NotNull: true},
+		{Name: "type", Type: idb.TypeString, NotNull: true},
 		{Name: "actor", Type: idb.TypeString},
-		{Name: "event_timestamp", Type: idb.TypeTime, NotNull: true},
+		{Name: "timestamp", Type: idb.TypeTime, NotNull: true},
 		{Name: "metadata_json", Type: idb.TypeJSON},
 	},
 }

--- a/gestaltd/internal/coredata/services.go
+++ b/gestaltd/internal/coredata/services.go
@@ -9,10 +9,12 @@ import (
 )
 
 type Services struct {
-	Users               *UserService
-	ExternalCredentials core.ExternalCredentialProvider
-	ManagedSubjects     *ManagedSubjectService
-	DB                  indexeddb.IndexedDB
+	Users                   *UserService
+	ExternalCredentials     core.ExternalCredentialProvider
+	ManagedSubjects         *ManagedSubjectService
+	AppInstallations        *AppInstallationService
+	AppInstallationEvents   *AppInstallationEventService
+	DB                      indexeddb.IndexedDB
 }
 
 // NewOptions configures coredata bootstrap behavior.
@@ -44,14 +46,24 @@ func NewWithOptions(ctx context.Context, ds indexeddb.IndexedDB, opts NewOptions
 		if _, err := ds.CreateObjectStore(ctx, StoreAppSHAs, AppSHAsSchema); err != nil {
 			return nil, fmt.Errorf("create app_shas store: %w", err)
 		}
+		if _, err := ds.CreateObjectStore(ctx, StoreAppInstallations, AppInstallationsSchema); err != nil {
+			return nil, fmt.Errorf("create app_installations store: %w", err)
+		}
+		if _, err := ds.CreateObjectStore(ctx, StoreAppInstallationEvents, AppInstallationEventsSchema); err != nil {
+			return nil, fmt.Errorf("create app_installation_events store: %w", err)
+		}
 	}
 	users := NewUserService(ds)
 	managedSubjects := NewManagedSubjectService(ds)
+	appInstallations := NewAppInstallationService(ds)
+	appInstallationEvents := NewAppInstallationEventService(ds)
 	return &Services{
-		ExternalCredentials: nil,
-		Users:               users,
-		ManagedSubjects:     managedSubjects,
-		DB:                  ds,
+		ExternalCredentials:   nil,
+		Users:                 users,
+		ManagedSubjects:       managedSubjects,
+		AppInstallations:      appInstallations,
+		AppInstallationEvents: appInstallationEvents,
+		DB:                    ds,
 	}, nil
 }
 

--- a/gestaltd/internal/coredata/services.go
+++ b/gestaltd/internal/coredata/services.go
@@ -9,12 +9,12 @@ import (
 )
 
 type Services struct {
-	Users                   *UserService
-	ExternalCredentials     core.ExternalCredentialProvider
-	ManagedSubjects         *ManagedSubjectService
-	AppInstallations        *AppInstallationService
-	AppInstallationEvents   *AppInstallationEventService
-	DB                      indexeddb.IndexedDB
+	Users                 *UserService
+	ExternalCredentials   core.ExternalCredentialProvider
+	ManagedSubjects       *ManagedSubjectService
+	AppInstallations      *AppInstallationService
+	AppInstallationEvents *AppInstallationEventService
+	DB                    indexeddb.IndexedDB
 }
 
 // NewOptions configures coredata bootstrap behavior.

--- a/gestaltd/internal/coredata/services_test.go
+++ b/gestaltd/internal/coredata/services_test.go
@@ -243,7 +243,11 @@ func TestNew(t *testing.T) {
 		if len(contexts) == 0 {
 			t.Fatal("NewWithContext did not create any object stores")
 		}
-		for _, store := range []string{coredata.StoreUsers} {
+		for _, store := range []string{
+			coredata.StoreUsers,
+			coredata.StoreAppInstallations,
+			coredata.StoreAppInstallationEvents,
+		} {
 			if _, ok := contexts[store]; !ok {
 				t.Fatalf("NewWithContext did not create store %q", store)
 			}


### PR DESCRIPTION
## Summary
- Add `app_installations` and `app_installation_events` IndexedDB stores to the gestaltd host control plane, bootstrapped via `coredata.New`.
- Introduce `AppInstallation` / `AppInstallationEvent` domain types and CRUD-style services for persisting shared install records (version, registry, checksums, desired state, audit events).
- Implements [app registry plan step 5](https://github.com/valon-technologies/toolshed/blob/main/valon-tools/deploy/README.md): install state persistence ahead of runtime materialization (steps 6–8).

## Test plan
- [x] `go test ./internal/coredata/... -count=1`
- [ ] Deploy gestaltd build and confirm bootstrap creates `app_installations` / `app_installation_events` on main-db startup (no API surface yet)


Made with [Cursor](https://cursor.com)