### PR TITLE
Skip gateway authorization for App.Invoke dispatch RPCs

### DIFF
--- a/gestaltd/internal/server/public_grpc_test.go
+++ b/gestaltd/internal/server/public_grpc_test.go
@@ -191,11 +191,11 @@ func TestPublicGRPCRouting(t *testing.T) {
 		}
 	})
 
-	t.Run("identity skips provider authorization", func(t *testing.T) {
+	t.Run("app invoke skips gateway authorization", func(t *testing.T) {
 		t.Parallel()
 
 		deniedAuthz := &serviceAccountCredentialAuthorizationProvider{allowed: false}
-		ts, _ := startPublicGRPCServer(t, func(cfg *server.Config) {
+		ts, invoker := startPublicGRPCServer(t, func(cfg *server.Config) {
 			cfg.Providers = testutil.NewProviderRegistry(t, remoteRoutingAppStub("linear", "issues.list"))
 			cfg.Authorization = deniedAuthz
 			cfg.PublicGatewayTransport.SetAuthorizationProvider(deniedAuthz)
@@ -209,8 +209,11 @@ func TestPublicGRPCRouting(t *testing.T) {
 			App:       "linear",
 			Operation: "issues.list",
 		})
-		if status.Code(err) != codes.PermissionDenied {
-			t.Fatalf("App.Invoke code = %v, want %v (%v)", status.Code(err), codes.PermissionDenied, err)
+		if err != nil {
+			t.Fatalf("App.Invoke: %v", err)
+		}
+		if got := invoker.snapshot().operation; got != "issues.list" {
+			t.Fatalf("invoker operation = %q, want issues.list", got)
 		}
 
 		token := publicGRPCTestBearer("linear")
@@ -221,11 +224,8 @@ func TestPublicGRPCRouting(t *testing.T) {
 		if !introspect.GetActive() {
 			t.Fatal("Introspect active = false, want true")
 		}
-		if len(deniedAuthz.requests) != 1 {
-			t.Fatalf("authorization requests = %d, want 1 for app invoke only", len(deniedAuthz.requests))
-		}
-		if got := deniedAuthz.requests[0].GetResource().GetId(); got != "linear" {
-			t.Fatalf("authorization resource = %q, want linear", got)
+		if len(deniedAuthz.requests) != 0 {
+			t.Fatalf("authorization requests = %d, want 0 at gateway", len(deniedAuthz.requests))
 		}
 	})
 

--- a/gestaltd/services/providergateway/gateway_test.go
+++ b/gestaltd/services/providergateway/gateway_test.go
@@ -458,6 +458,7 @@ func TestPreparePublicRequest(t *testing.T) {
 			fullMethod: proto.App_Invoke_FullMethodName,
 			withOrigin: true,
 			introspect: activeAlice,
+			authAllow:  &denied,
 			req:        &proto.AppInvokeRequest{App: "roadmap", Operation: "sync"},
 			checkAdapted: func(t *testing.T, adapted gproto.Message) {
 				t.Helper()
@@ -470,15 +471,6 @@ func TestPreparePublicRequest(t *testing.T) {
 				}
 				if out.GetRunAs() != nil {
 					t.Fatal("run_as should remain unset")
-				}
-			},
-			checkAuth: func(t *testing.T, auth *stubAuthorizationProvider) {
-				t.Helper()
-				if got := auth.request.GetResource().GetId(); got != "roadmap" {
-					t.Fatalf("Resource.Id = %q, want %q", got, "roadmap")
-				}
-				if got := auth.request.GetAction().GetName(); got != proto.App_Invoke_FullMethodName {
-					t.Fatalf("Action.Name = %q, want %q", got, proto.App_Invoke_FullMethodName)
 				}
 			},
 		},
@@ -556,31 +548,22 @@ func TestPreparePublicRequest(t *testing.T) {
 		},
 		{
 			name:       "requires authorization provider",
-			fullMethod: proto.App_Invoke_FullMethodName,
+			fullMethod: proto.Workflow_DeliverEvent_FullMethodName,
 			withOrigin: true,
 			introspect: activeAlice,
-			req:        &proto.AppInvokeRequest{App: "roadmap", Operation: "sync"},
+			req:        &proto.DeliverWorkflowProviderEventRequest{AppName: "roadmap", Event: &proto.WorkflowEvent{}},
 			wantCode:   codes.PermissionDenied,
 			setup: func(transport *ProviderGatewayTransport) {
 				transport.SetAuthorizationProvider(nil)
 			},
 		},
 		{
-			name:       "authorization denied",
-			fullMethod: proto.App_Invoke_FullMethodName,
+			name:       "workflow authorization denied",
+			fullMethod: proto.Workflow_DeliverEvent_FullMethodName,
 			withOrigin: true,
 			introspect: activeAlice,
 			authAllow:  &denied,
-			req:        &proto.AppInvokeRequest{App: "roadmap", Operation: "sync"},
-			wantCode:   codes.PermissionDenied,
-		},
-		{
-			name:       "app named identity still requires authorization",
-			fullMethod: proto.App_Invoke_FullMethodName,
-			withOrigin: true,
-			introspect: activeAlice,
-			authAllow:  &denied,
-			req:        &proto.AppInvokeRequest{App: "identity", Operation: "sync"},
+			req:        &proto.DeliverWorkflowProviderEventRequest{AppName: "roadmap", Event: &proto.WorkflowEvent{}},
 			wantCode:   codes.PermissionDenied,
 		},
 		{

--- a/gestaltd/services/providergateway/public_request.go
+++ b/gestaltd/services/providergateway/public_request.go
@@ -103,6 +103,10 @@ func (t *ProviderGatewayTransport) enforcePublicAuthorization(
 	if publicIdentityServiceMethod(fullMethod) {
 		return nil
 	}
+	service, method := splitFullMethod(fullMethod)
+	if service == proto.App_ServiceDesc.ServiceName && (method == "Invoke" || method == "InvokeGraphQL") {
+		return nil
+	}
 	if t == nil || t.authorization == nil {
 		return status.Error(codes.PermissionDenied, "authorization provider is not configured")
 	}


### PR DESCRIPTION
## Summary
- Skip `enforcePublicAuthorization` for public `App.Invoke` and `App.InvokeGraphQL`, matching the existing Identity service exemption
- Bearer authentication and request-context filling are unchanged; the invocation broker continues to enforce per-app operation tuples from deploy config
- Fixes remote `server.remote` flows where gateway checks used `{type: provider, action: /gestalt.provider.v1.App/Invoke}` instead of broker checks like `{type: dataSchemaExplorer, action: get_schema}`

## Test plan
- [x] `go test ./gestaltd/services/providergateway/... -run TestPreparePublicRequest`
- [x] `go test ./gestaltd/internal/server/... -run TestPublicGRPCRouting`
- [ ] Restart local gestaltd with valon-tools remote config and confirm `dataSchemaExplorer.get_schema` succeeds for an authorized user


Made with [Cursor](https://cursor.com)