### PR TITLE
Step 6: Prototype registry app install with shared IndexedDB state

### DIFF
--- a/gestaltd/core/testing/indexeddb_stub_tx.go
+++ b/gestaltd/core/testing/indexeddb_stub_tx.go
@@ -2,6 +2,7 @@ package coretesting
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	idb "github.com/valon-technologies/gestalt/sdk/go/indexeddb"
@@ -137,6 +138,9 @@ func (s *stubTransactionObjectStore) Get(ctx context.Context, id string) (idb.Re
 	}
 	record, err := s.store.Get(ctx, id)
 	if err != nil {
+		if errors.Is(err, idb.ErrNotFound) {
+			return nil, err
+		}
 		return nil, s.tx.abortWithError(err)
 	}
 	return record, nil
@@ -148,6 +152,9 @@ func (s *stubTransactionObjectStore) GetKey(ctx context.Context, id string) (str
 	}
 	key, err := s.store.GetKey(ctx, id)
 	if err != nil {
+		if errors.Is(err, idb.ErrNotFound) {
+			return "", err
+		}
 		return "", s.tx.abortWithError(err)
 	}
 	return key, nil

--- a/gestaltd/internal/appregistry/fail_install_test.go
+++ b/gestaltd/internal/appregistry/fail_install_test.go
@@ -64,6 +64,53 @@ func TestInstallerFleetRaceGuards(t *testing.T) {
 		}
 	})
 
+	t.Run("write_pending_clears_active_since", func(t *testing.T) {
+		t.Parallel()
+
+		services := testutil.NewStubServices(t)
+		activeSince := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+		if _, err := services.AppInstallations.PutInstallation(context.Background(), &core.AppInstallation{
+			AppName:           "g-issues",
+			VersionConstraint: "0.0.0-snapshot.v1",
+			ResolvedVersion:   "0.0.0-snapshot.v1",
+			Registry:          "toolshed",
+			RolloutStatus:     core.AppInstallationRolloutStatusPromoted,
+			ActiveSince:       &activeSince,
+		}); err != nil {
+			t.Fatalf("PutInstallation: %v", err)
+		}
+
+		baseline, err := services.AppInstallations.GetInstallation(context.Background(), "g-issues")
+		if err != nil {
+			t.Fatalf("GetInstallation: %v", err)
+		}
+
+		installer := &Installer{
+			Installations: services.AppInstallations,
+			Events:        services.AppInstallationEvents,
+		}
+		if err := installer.writePendingInstall(context.Background(), "g-issues", baseline, &core.AppInstallation{
+			AppName:           "g-issues",
+			VersionConstraint: "0.0.0-snapshot.v2",
+			ResolvedVersion:   "0.0.0-snapshot.v2",
+			Registry:          "toolshed",
+			RolloutStatus:     core.AppInstallationRolloutStatusPending,
+		}); err != nil {
+			t.Fatalf("writePendingInstall: %v", err)
+		}
+
+		stored, err := services.AppInstallations.GetInstallation(context.Background(), "g-issues")
+		if err != nil {
+			t.Fatalf("GetInstallation: %v", err)
+		}
+		if stored.RolloutStatus != core.AppInstallationRolloutStatusPending {
+			t.Fatalf("rollout_status = %q, want pending", stored.RolloutStatus)
+		}
+		if stored.ActiveSince != nil {
+			t.Fatalf("active_since = %v, want nil while pending", stored.ActiveSince)
+		}
+	})
+
 	t.Run("write_pending_rejects_advanced_fleet_state", func(t *testing.T) {
 		t.Parallel()
 

--- a/gestaltd/internal/appregistry/fail_install_test.go
+++ b/gestaltd/internal/appregistry/fail_install_test.go
@@ -44,7 +44,12 @@ func TestInstallerFleetRaceGuards(t *testing.T) {
 			Events:        services.AppInstallationEvents,
 		}
 
-		_, err := installer.failInstall(context.Background(), "g-issues", priorV1, "0.0.0-snapshot.v1", "0.0.0-snapshot.v2", "user:test", "toolshed", fmt.Errorf("download failed"))
+		_, err := installer.failInstall(context.Background(), "g-issues", priorV1, &core.AppInstallation{
+			AppName:           "g-issues",
+			VersionConstraint: "0.0.0-snapshot.v2",
+			ResolvedVersion:   "0.0.0-snapshot.v2",
+			RolloutStatus:     core.AppInstallationRolloutStatusPending,
+		}, "0.0.0-snapshot.v1", "0.0.0-snapshot.v2", "user:test", "toolshed", fmt.Errorf("download failed"))
 		if err == nil {
 			t.Fatal("expected failure")
 		}

--- a/gestaltd/internal/appregistry/fail_install_test.go
+++ b/gestaltd/internal/appregistry/fail_install_test.go
@@ -155,7 +155,7 @@ func TestInstallerFleetRaceGuards(t *testing.T) {
 			Installations: services.AppInstallations,
 			Events:        services.AppInstallationEvents,
 		}
-		if err := installer.writePendingInstall(context.Background(), "g-issues", baseline, &core.AppInstallation{
+		if _, err := installer.writePendingInstall(context.Background(), "g-issues", baseline, &core.AppInstallation{
 			AppName:           "g-issues",
 			VersionConstraint: "0.0.0-snapshot.v2",
 			ResolvedVersion:   "0.0.0-snapshot.v2",
@@ -217,7 +217,7 @@ func TestInstallerFleetRaceGuards(t *testing.T) {
 			Events:        services.AppInstallationEvents,
 		}
 
-		err := installer.writePendingInstall(context.Background(), "g-issues", staleBaseline, &core.AppInstallation{
+		_, err := installer.writePendingInstall(context.Background(), "g-issues", staleBaseline, &core.AppInstallation{
 			AppName:           "g-issues",
 			VersionConstraint: "0.0.0-snapshot.v2",
 			ResolvedVersion:   "0.0.0-snapshot.v2",

--- a/gestaltd/internal/appregistry/fail_install_test.go
+++ b/gestaltd/internal/appregistry/fail_install_test.go
@@ -1,0 +1,122 @@
+package appregistry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+)
+
+func TestInstallerFleetRaceGuards(t *testing.T) {
+	t.Parallel()
+
+	t.Run("fail_install_skips_restore_when_fleet_advanced", func(t *testing.T) {
+		t.Parallel()
+
+		services := testutil.NewStubServices(t)
+		activeSince := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+		if _, err := services.AppInstallations.PutInstallation(context.Background(), &core.AppInstallation{
+			AppName:           "g-issues",
+			VersionConstraint: "0.0.0-snapshot.v3",
+			ResolvedVersion:   "0.0.0-snapshot.v3",
+			Registry:          "toolshed",
+			SourceRef:         "newer-source-ref",
+			RolloutStatus:     core.AppInstallationRolloutStatusPromoted,
+			ActiveSince:       &activeSince,
+		}); err != nil {
+			t.Fatalf("PutInstallation: %v", err)
+		}
+
+		priorV1 := &core.AppInstallation{
+			AppName:           "g-issues",
+			VersionConstraint: "0.0.0-snapshot.v1",
+			ResolvedVersion:   "0.0.0-snapshot.v1",
+			Registry:          "toolshed",
+			SourceRef:         "stale-source-ref",
+			RolloutStatus:     core.AppInstallationRolloutStatusPromoted,
+		}
+		installer := &Installer{
+			Installations: services.AppInstallations,
+			Events:        services.AppInstallationEvents,
+		}
+
+		_, err := installer.failInstall(context.Background(), "g-issues", priorV1, "0.0.0-snapshot.v1", "0.0.0-snapshot.v2", "user:test", "toolshed", fmt.Errorf("download failed"))
+		if err == nil {
+			t.Fatal("expected failure")
+		}
+
+		stored, err := services.AppInstallations.GetInstallation(context.Background(), "g-issues")
+		if err != nil {
+			t.Fatalf("GetInstallation: %v", err)
+		}
+		if stored.RolloutStatus != core.AppInstallationRolloutStatusPromoted {
+			t.Fatalf("rollout_status = %q, want promoted", stored.RolloutStatus)
+		}
+		if stored.ResolvedVersion != "0.0.0-snapshot.v3" {
+			t.Fatalf("resolved_version = %q, want newer promoted version preserved", stored.ResolvedVersion)
+		}
+		if stored.SourceRef != "newer-source-ref" {
+			t.Fatalf("source_ref = %q, want newer promoted metadata preserved", stored.SourceRef)
+		}
+	})
+
+	t.Run("write_pending_rejects_advanced_fleet_state", func(t *testing.T) {
+		t.Parallel()
+
+		services := testutil.NewStubServices(t)
+		activeSince := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+		updatedAt := time.Date(2026, 7, 10, 13, 0, 0, 0, time.UTC)
+		if _, err := services.AppInstallations.PutInstallation(context.Background(), &core.AppInstallation{
+			AppName:           "g-issues",
+			VersionConstraint: "0.0.0-snapshot.v3",
+			ResolvedVersion:   "0.0.0-snapshot.v3",
+			Registry:          "toolshed",
+			SourceRef:         "newer-source-ref",
+			RolloutStatus:     core.AppInstallationRolloutStatusPromoted,
+			ActiveSince:       &activeSince,
+			UpdatedAt:         updatedAt,
+		}); err != nil {
+			t.Fatalf("PutInstallation: %v", err)
+		}
+
+		staleBaseline := &core.AppInstallation{
+			AppName:           "g-issues",
+			VersionConstraint: "0.0.0-snapshot.v1",
+			ResolvedVersion:   "0.0.0-snapshot.v1",
+			Registry:          "toolshed",
+			SourceRef:         "stale-source-ref",
+			RolloutStatus:     core.AppInstallationRolloutStatusPromoted,
+			UpdatedAt:         time.Date(2026, 7, 10, 11, 0, 0, 0, time.UTC),
+		}
+		installer := &Installer{
+			Installations: services.AppInstallations,
+			Events:        services.AppInstallationEvents,
+		}
+
+		err := installer.writePendingInstall(context.Background(), "g-issues", staleBaseline, &core.AppInstallation{
+			AppName:           "g-issues",
+			VersionConstraint: "0.0.0-snapshot.v2",
+			ResolvedVersion:   "0.0.0-snapshot.v2",
+			Registry:          "toolshed",
+			RolloutStatus:     core.AppInstallationRolloutStatusPending,
+		})
+		if !errors.Is(err, ErrInstallFleetStateAdvanced) {
+			t.Fatalf("writePendingInstall error = %v, want ErrInstallFleetStateAdvanced", err)
+		}
+
+		stored, err := services.AppInstallations.GetInstallation(context.Background(), "g-issues")
+		if err != nil {
+			t.Fatalf("GetInstallation: %v", err)
+		}
+		if stored.RolloutStatus != core.AppInstallationRolloutStatusPromoted {
+			t.Fatalf("rollout_status = %q, want promoted preserved", stored.RolloutStatus)
+		}
+		if stored.ResolvedVersion != "0.0.0-snapshot.v3" {
+			t.Fatalf("resolved_version = %q, want newer promoted version preserved", stored.ResolvedVersion)
+		}
+	})
+}

--- a/gestaltd/internal/appregistry/fail_install_test.go
+++ b/gestaltd/internal/appregistry/fail_install_test.go
@@ -4,12 +4,72 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 )
+
+func TestRestoreMaterializationBackup(t *testing.T) {
+	t.Parallel()
+
+	t.Run("restores_when_backup_exists", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		materialized := filepath.Join(dir, "g-issues", "0.0.0-snapshot.v1")
+		backup := materialized + ".backup"
+		if err := os.MkdirAll(materialized, 0o755); err != nil {
+			t.Fatalf("MkdirAll materialized: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(materialized, "content.txt"), []byte("old"), 0o644); err != nil {
+			t.Fatalf("WriteFile old: %v", err)
+		}
+		if err := os.Rename(materialized, backup); err != nil {
+			t.Fatalf("Rename to backup: %v", err)
+		}
+		if err := os.MkdirAll(materialized, 0o755); err != nil {
+			t.Fatalf("MkdirAll staged materialized: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(materialized, "content.txt"), []byte("new"), 0o644); err != nil {
+			t.Fatalf("WriteFile staged: %v", err)
+		}
+
+		restoreMaterializationBackup(materialized, backup)
+
+		if _, err := os.Stat(backup); !os.IsNotExist(err) {
+			t.Fatalf("backup should be removed, stat err = %v", err)
+		}
+		if data, err := os.ReadFile(filepath.Join(materialized, "content.txt")); err != nil {
+			t.Fatalf("ReadFile restored materialized: %v", err)
+		} else if string(data) != "old" {
+			t.Fatalf("restored content = %q, want old", data)
+		}
+	})
+
+	t.Run("removes_materialized_when_no_backup", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		materialized := filepath.Join(dir, "g-issues", "0.0.0-snapshot.v1")
+		backup := materialized + ".backup"
+		if err := os.MkdirAll(materialized, 0o755); err != nil {
+			t.Fatalf("MkdirAll materialized: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(materialized, "orphan.txt"), []byte("orphan"), 0o644); err != nil {
+			t.Fatalf("WriteFile orphan: %v", err)
+		}
+
+		restoreMaterializationBackup(materialized, backup)
+
+		if _, err := os.Stat(materialized); !os.IsNotExist(err) {
+			t.Fatalf("materialized should be removed on first-install rollback, stat err = %v", err)
+		}
+	})
+}
 
 func TestInstallerFleetRaceGuards(t *testing.T) {
 	t.Parallel()

--- a/gestaltd/internal/appregistry/fail_install_test.go
+++ b/gestaltd/internal/appregistry/fail_install_test.go
@@ -64,7 +64,7 @@ func TestInstallerFleetRaceGuards(t *testing.T) {
 		}
 	})
 
-	t.Run("write_pending_clears_active_since", func(t *testing.T) {
+	t.Run("write_pending_preserves_promoted_metadata", func(t *testing.T) {
 		t.Parallel()
 
 		services := testutil.NewStubServices(t)
@@ -74,6 +74,7 @@ func TestInstallerFleetRaceGuards(t *testing.T) {
 			VersionConstraint: "0.0.0-snapshot.v1",
 			ResolvedVersion:   "0.0.0-snapshot.v1",
 			Registry:          "toolshed",
+			SourceRef:         "gold-source-ref",
 			RolloutStatus:     core.AppInstallationRolloutStatusPromoted,
 			ActiveSince:       &activeSince,
 		}); err != nil {
@@ -94,6 +95,7 @@ func TestInstallerFleetRaceGuards(t *testing.T) {
 			VersionConstraint: "0.0.0-snapshot.v2",
 			ResolvedVersion:   "0.0.0-snapshot.v2",
 			Registry:          "toolshed",
+			SourceRef:         "pending-source-ref",
 			RolloutStatus:     core.AppInstallationRolloutStatusPending,
 		}); err != nil {
 			t.Fatalf("writePendingInstall: %v", err)
@@ -106,8 +108,14 @@ func TestInstallerFleetRaceGuards(t *testing.T) {
 		if stored.RolloutStatus != core.AppInstallationRolloutStatusPending {
 			t.Fatalf("rollout_status = %q, want pending", stored.RolloutStatus)
 		}
-		if stored.ActiveSince != nil {
-			t.Fatalf("active_since = %v, want nil while pending", stored.ActiveSince)
+		if stored.ResolvedVersion != "0.0.0-snapshot.v2" {
+			t.Fatalf("resolved_version = %q, want pending target", stored.ResolvedVersion)
+		}
+		if stored.SourceRef != "gold-source-ref" {
+			t.Fatalf("source_ref = %q, want promoted metadata preserved", stored.SourceRef)
+		}
+		if stored.ActiveSince == nil || !stored.ActiveSince.Equal(activeSince) {
+			t.Fatalf("active_since = %v, want promoted metadata preserved", stored.ActiveSince)
 		}
 	})
 

--- a/gestaltd/internal/appregistry/installer.go
+++ b/gestaltd/internal/appregistry/installer.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -33,6 +34,7 @@ type Installer struct {
 	Events        *coredata.AppInstallationEventService
 	ArtifactsDir  string
 	Now           func() time.Time
+	installLocks  sync.Map // app name -> *sync.Mutex
 }
 
 type InstallInput struct {
@@ -66,6 +68,8 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 	if err := providerregistry.ValidateRepositoryName(appName); err != nil {
 		return nil, fmt.Errorf("invalid app name: %w", err)
 	}
+	unlock := i.lockInstall(appName)
+	defer unlock()
 	if i.Installations == nil || i.Events == nil {
 		return nil, fmt.Errorf("app installation services are not configured")
 	}
@@ -349,6 +353,16 @@ func (i *Installer) failInstall(ctx context.Context, appName string, restoreBase
 		return nil, fmt.Errorf("%w; also failed to append failed event: %v", cause, eventErr)
 	}
 	return nil, cause
+}
+
+func (i *Installer) lockInstall(appName string) func() {
+	if i == nil {
+		return func() {}
+	}
+	value, _ := i.installLocks.LoadOrStore(appName, &sync.Mutex{})
+	mu := value.(*sync.Mutex)
+	mu.Lock()
+	return mu.Unlock
 }
 
 func (i *Installer) appendInstallEventBestEffort(ctx context.Context, event *core.AppInstallationEvent) {

--- a/gestaltd/internal/appregistry/installer.go
+++ b/gestaltd/internal/appregistry/installer.go
@@ -144,12 +144,9 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 		PreviousResolvedVersion: previousVersion,
 		InstalledBy:             strings.TrimSpace(input.Actor),
 	}
-	if err := i.writePendingInstall(ctx, appName, installBaseline, pending); err != nil {
-		return nil, err
-	}
-	pendingBaseline, err := i.Installations.GetInstallation(ctx, appName)
+	pendingBaseline, err := i.writePendingInstall(ctx, appName, installBaseline, pending)
 	if err != nil {
-		return nil, fmt.Errorf("load pending app installation: %w", err)
+		return nil, err
 	}
 	if _, err := i.Events.AppendEvent(ctx, &core.AppInstallationEvent{
 		InstallationID: appName,
@@ -392,8 +389,8 @@ func restoredInstallationAfterFailure(prior *core.AppInstallation, attemptedVers
 	}
 }
 
-func (i *Installer) writePendingInstall(ctx context.Context, appName string, baseline *core.AppInstallation, pending *core.AppInstallation) error {
-	_, err := i.Installations.CompareAndSwapInstallation(ctx, appName, baseline, func(installation *core.AppInstallation) error {
+func (i *Installer) writePendingInstall(ctx context.Context, appName string, baseline *core.AppInstallation, pending *core.AppInstallation) (*core.AppInstallation, error) {
+	stored, err := i.Installations.CompareAndSwapInstallation(ctx, appName, baseline, func(installation *core.AppInstallation) error {
 		if baseline == nil {
 			*installation = *pending
 			installation.AppName = appName
@@ -404,11 +401,11 @@ func (i *Installer) writePendingInstall(ctx context.Context, appName string, bas
 	})
 	if err != nil {
 		if errors.Is(err, coredata.ErrInstallationStateConflict) {
-			return fmt.Errorf("%w: install baseline no longer current", ErrInstallFleetStateAdvanced)
+			return nil, fmt.Errorf("%w: install baseline no longer current", ErrInstallFleetStateAdvanced)
 		}
-		return fmt.Errorf("write pending app installation: %w", err)
+		return nil, fmt.Errorf("write pending app installation: %w", err)
 	}
-	return nil
+	return stored, nil
 }
 
 func applyPendingInstall(dst *core.AppInstallation, pending *core.AppInstallation, baseline *core.AppInstallation) {

--- a/gestaltd/internal/appregistry/installer.go
+++ b/gestaltd/internal/appregistry/installer.go
@@ -448,11 +448,15 @@ func shouldPreservePriorMetadata(baseline *core.AppInstallation) bool {
 }
 
 func restoreMaterializationBackup(materializedPath, backupPath string) {
-	if _, err := os.Stat(backupPath); err != nil {
+	_, err := os.Stat(backupPath)
+	if err == nil {
+		_ = os.RemoveAll(materializedPath)
+		_ = os.Rename(backupPath, materializedPath)
 		return
 	}
-	_ = os.RemoveAll(materializedPath)
-	_ = os.Rename(backupPath, materializedPath)
+	if os.IsNotExist(err) {
+		_ = os.RemoveAll(materializedPath)
+	}
 }
 
 func installationMatchesFailedAttempt(current *core.AppInstallation, attemptedVersion string) bool {

--- a/gestaltd/internal/appregistry/installer.go
+++ b/gestaltd/internal/appregistry/installer.go
@@ -147,6 +147,10 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 	if err := i.writePendingInstall(ctx, appName, installBaseline, pending); err != nil {
 		return nil, err
 	}
+	pendingBaseline, err := i.Installations.GetInstallation(ctx, appName)
+	if err != nil {
+		return nil, fmt.Errorf("load pending app installation: %w", err)
+	}
 	if _, err := i.Events.AppendEvent(ctx, &core.AppInstallationEvent{
 		InstallationID: appName,
 		FromVersion:    previousVersion,
@@ -157,15 +161,15 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 			"registry": registryName,
 		},
 	}); err != nil {
-		return i.failInstall(ctx, appName, restoreBaseline, previousVersion, version, input.Actor, registryName, fmt.Errorf("append install_requested event: %w", err))
+		return i.failInstall(ctx, appName, restoreBaseline, pendingBaseline, previousVersion, version, input.Actor, registryName, fmt.Errorf("append install_requested event: %w", err))
 	}
 
 	materializedPath := filepath.Join(artifactsDir, RegistryInstallSubdir, appName, version)
-	stagingPath := materializedPath + ".staging"
+	stagingPath := fmt.Sprintf("%s.staging.%d", materializedPath, i.now().UnixNano())
 
 	download, err := downloadRegistryArtifact(ctx, reader.client(), artifactURL)
 	if err != nil {
-		return i.failInstall(ctx, appName, restoreBaseline, previousVersion, version, input.Actor, registryName, err)
+		return i.failInstall(ctx, appName, restoreBaseline, pendingBaseline, previousVersion, version, input.Actor, registryName, err)
 	}
 	defer func() {
 		if download.Cleanup != nil {
@@ -173,11 +177,11 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 		}
 	}()
 	if !strings.EqualFold(strings.TrimSpace(download.SHA256Hex), expectedSHA) {
-		return i.failInstall(ctx, appName, restoreBaseline, previousVersion, version, input.Actor, registryName, fmt.Errorf("artifact digest mismatch: got %s, want %s", download.SHA256Hex, expectedSHA))
+		return i.failInstall(ctx, appName, restoreBaseline, pendingBaseline, previousVersion, version, input.Actor, registryName, fmt.Errorf("artifact digest mismatch: got %s, want %s", download.SHA256Hex, expectedSHA))
 	}
 
 	if err := os.RemoveAll(stagingPath); err != nil {
-		return i.failInstall(ctx, appName, restoreBaseline, previousVersion, version, input.Actor, registryName, fmt.Errorf("reset staging directory: %w", err))
+		return i.failInstall(ctx, appName, restoreBaseline, pendingBaseline, previousVersion, version, input.Actor, registryName, fmt.Errorf("reset staging directory: %w", err))
 	}
 	stagingCleanup := true
 	defer func() {
@@ -187,30 +191,27 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 	}()
 
 	if _, err := operator.InstallPublishedPackage(download.LocalPath, stagingPath, appName); err != nil {
-		return i.failInstall(ctx, appName, restoreBaseline, previousVersion, version, input.Actor, registryName, fmt.Errorf("materialize app artifact: %w", err))
+		return i.failInstall(ctx, appName, restoreBaseline, pendingBaseline, previousVersion, version, input.Actor, registryName, fmt.Errorf("materialize app artifact: %w", err))
 	}
 	backupPath := materializedPath + ".backup"
 	if err := os.RemoveAll(backupPath); err != nil {
-		return i.failInstall(ctx, appName, restoreBaseline, previousVersion, version, input.Actor, registryName, fmt.Errorf("reset materialization backup directory: %w", err))
+		return i.failInstall(ctx, appName, restoreBaseline, pendingBaseline, previousVersion, version, input.Actor, registryName, fmt.Errorf("reset materialization backup directory: %w", err))
 	}
 	if _, err := os.Stat(materializedPath); err == nil {
 		if err := os.Rename(materializedPath, backupPath); err != nil {
-			return i.failInstall(ctx, appName, restoreBaseline, previousVersion, version, input.Actor, registryName, fmt.Errorf("backup current materialization directory: %w", err))
+			return i.failInstall(ctx, appName, restoreBaseline, pendingBaseline, previousVersion, version, input.Actor, registryName, fmt.Errorf("backup current materialization directory: %w", err))
 		}
 	} else if !os.IsNotExist(err) {
-		return i.failInstall(ctx, appName, restoreBaseline, previousVersion, version, input.Actor, registryName, fmt.Errorf("stat materialization directory: %w", err))
+		return i.failInstall(ctx, appName, restoreBaseline, pendingBaseline, previousVersion, version, input.Actor, registryName, fmt.Errorf("stat materialization directory: %w", err))
 	}
 	if err := os.Rename(stagingPath, materializedPath); err != nil {
 		restoreMaterializationBackup(materializedPath, backupPath)
-		return i.failInstall(ctx, appName, restoreBaseline, previousVersion, version, input.Actor, registryName, fmt.Errorf("promote staged app artifact: %w", err))
+		return i.failInstall(ctx, appName, restoreBaseline, pendingBaseline, previousVersion, version, input.Actor, registryName, fmt.Errorf("promote staged app artifact: %w", err))
 	}
 	stagingCleanup = false
 
 	activeSince := i.now()
-	stored, err := i.Installations.UpdateInstallation(ctx, appName, func(installation *core.AppInstallation) error {
-		if !installationMatchesFailedAttempt(installation, version) {
-			return fmt.Errorf("%w: pending install for version %q no longer active", ErrInstallFleetStateAdvanced, version)
-		}
+	stored, err := i.Installations.CompareAndSwapInstallation(ctx, appName, pendingBaseline, func(installation *core.AppInstallation) error {
 		installation.VersionConstraint = version
 		installation.ResolvedVersion = version
 		installation.SourceRef = publishedVersion.SourceRef
@@ -224,7 +225,7 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 		return nil
 	})
 	if err != nil {
-		if errors.Is(err, ErrInstallFleetStateAdvanced) {
+		if errors.Is(err, coredata.ErrInstallationStateConflict) {
 			i.appendInstallEventBestEffort(ctx, &core.AppInstallationEvent{
 				InstallationID: appName,
 				FromVersion:    previousVersion,
@@ -237,10 +238,10 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 					"skipped":  "fleet state advanced past this install attempt",
 				},
 			})
-			return nil, err
+			return nil, fmt.Errorf("%w: pending install for version %q no longer active", ErrInstallFleetStateAdvanced, version)
 		}
 		restoreMaterializationBackup(materializedPath, backupPath)
-		return i.failInstall(ctx, appName, restoreBaseline, previousVersion, version, input.Actor, registryName, fmt.Errorf("write promoted app installation: %w", err))
+		return i.failInstall(ctx, appName, restoreBaseline, pendingBaseline, previousVersion, version, input.Actor, registryName, fmt.Errorf("write promoted app installation: %w", err))
 	}
 	_ = os.RemoveAll(backupPath)
 	i.appendInstallEventBestEffort(ctx, &core.AppInstallationEvent{
@@ -261,13 +262,29 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 	}, nil
 }
 
-func (i *Installer) failInstall(ctx context.Context, appName string, priorInstallation *core.AppInstallation, previousVersion, version, actor, registryName string, cause error) (*InstallOutput, error) {
+func (i *Installer) failInstall(ctx context.Context, appName string, restoreBaseline, pendingBaseline *core.AppInstallation, previousVersion, version, actor, registryName string, cause error) (*InstallOutput, error) {
 	cleanupCtx := context.WithoutCancel(ctx)
 	current, getErr := i.Installations.GetInstallation(cleanupCtx, appName)
 	if getErr != nil && getErr != core.ErrNotFound {
 		return nil, fmt.Errorf("%w; also failed to load current installation: %v", cause, getErr)
 	}
-	if !installationMatchesFailedAttempt(current, version) {
+	if pendingBaseline != nil {
+		if getErr == core.ErrNotFound || !installationMatchesInstallBaseline(current, pendingBaseline) {
+			i.appendInstallEventBestEffort(cleanupCtx, &core.AppInstallationEvent{
+				InstallationID: appName,
+				FromVersion:    previousVersion,
+				ToVersion:      version,
+				Type:           core.AppInstallationEventTypeFailed,
+				Actor:          strings.TrimSpace(actor),
+				Metadata: map[string]any{
+					"registry": registryName,
+					"error":    cause.Error(),
+					"skipped":  "fleet state advanced past this install attempt",
+				},
+			})
+			return nil, cause
+		}
+	} else if !installationMatchesFailedAttempt(current, version) {
 		i.appendInstallEventBestEffort(cleanupCtx, &core.AppInstallationEvent{
 			InstallationID: appName,
 			FromVersion:    previousVersion,
@@ -283,11 +300,8 @@ func (i *Installer) failInstall(ctx context.Context, appName string, priorInstal
 		return nil, cause
 	}
 
-	_, putErr := i.Installations.UpdateInstallation(cleanupCtx, appName, func(installation *core.AppInstallation) error {
-		if !installationMatchesFailedAttempt(installation, version) {
-			return fmt.Errorf("%w: pending install for version %q no longer active during failure handling", ErrInstallFleetStateAdvanced, version)
-		}
-		if restored := restoredInstallationAfterFailure(priorInstallation, version, actor, registryName); restored != nil {
+	_, putErr := i.Installations.CompareAndSwapInstallation(cleanupCtx, appName, pendingBaseline, func(installation *core.AppInstallation) error {
+		if restored := restoredInstallationAfterFailure(restoreBaseline, version, actor, registryName); restored != nil {
 			*installation = *restored
 			installation.AppName = appName
 			installation.RolloutStatus = core.AppInstallationRolloutStatusFailed
@@ -306,7 +320,7 @@ func (i *Installer) failInstall(ctx context.Context, appName string, priorInstal
 		return nil
 	})
 	if putErr != nil {
-		if errors.Is(putErr, ErrInstallFleetStateAdvanced) {
+		if errors.Is(putErr, coredata.ErrInstallationStateConflict) {
 			i.appendInstallEventBestEffort(cleanupCtx, &core.AppInstallationEvent{
 				InstallationID: appName,
 				FromVersion:    previousVersion,
@@ -378,28 +392,19 @@ func restoredInstallationAfterFailure(prior *core.AppInstallation, attemptedVers
 }
 
 func (i *Installer) writePendingInstall(ctx context.Context, appName string, baseline *core.AppInstallation, pending *core.AppInstallation) error {
-	if baseline == nil {
-		current, err := i.Installations.GetInstallation(ctx, appName)
-		if err != nil && err != core.ErrNotFound {
-			return fmt.Errorf("load current app installation: %w", err)
-		}
-		if current != nil {
-			return fmt.Errorf("%w: install baseline no longer current", ErrInstallFleetStateAdvanced)
-		}
-		if _, err := i.Installations.PutInstallation(ctx, pending); err != nil {
-			return fmt.Errorf("write pending app installation: %w", err)
-		}
-		return nil
-	}
-
-	_, err := i.Installations.UpdateInstallation(ctx, appName, func(installation *core.AppInstallation) error {
-		if !installationMatchesInstallBaseline(installation, baseline) {
-			return fmt.Errorf("%w: install baseline no longer current", ErrInstallFleetStateAdvanced)
+	_, err := i.Installations.CompareAndSwapInstallation(ctx, appName, baseline, func(installation *core.AppInstallation) error {
+		if baseline == nil {
+			*installation = *pending
+			installation.AppName = appName
+			return nil
 		}
 		applyPendingInstall(installation, pending, baseline)
 		return nil
 	})
 	if err != nil {
+		if errors.Is(err, coredata.ErrInstallationStateConflict) {
+			return fmt.Errorf("%w: install baseline no longer current", ErrInstallFleetStateAdvanced)
+		}
 		return fmt.Errorf("write pending app installation: %w", err)
 	}
 	return nil

--- a/gestaltd/internal/appregistry/installer.go
+++ b/gestaltd/internal/appregistry/installer.go
@@ -434,6 +434,8 @@ func shouldPreservePriorMetadata(baseline *core.AppInstallation) bool {
 		previous := strings.TrimSpace(baseline.PreviousResolvedVersion)
 		resolved := strings.TrimSpace(baseline.ResolvedVersion)
 		return previous != "" && previous != resolved
+	case core.AppInstallationRolloutStatusFailed:
+		return strings.TrimSpace(baseline.ResolvedVersion) != ""
 	default:
 		return false
 	}

--- a/gestaltd/internal/appregistry/installer.go
+++ b/gestaltd/internal/appregistry/installer.go
@@ -187,49 +187,60 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 	if _, err := operator.InstallPublishedPackage(download.LocalPath, stagingPath, appName); err != nil {
 		return i.failInstall(ctx, appName, priorInstallation, previousVersion, version, input.Actor, registryName, fmt.Errorf("materialize app artifact: %w", err))
 	}
-	if err := os.RemoveAll(materializedPath); err != nil {
-		return i.failInstall(ctx, appName, priorInstallation, previousVersion, version, input.Actor, registryName, fmt.Errorf("reset materialization directory: %w", err))
+	backupPath := materializedPath + ".backup"
+	if err := os.RemoveAll(backupPath); err != nil {
+		return i.failInstall(ctx, appName, priorInstallation, previousVersion, version, input.Actor, registryName, fmt.Errorf("reset materialization backup directory: %w", err))
+	}
+	if _, err := os.Stat(materializedPath); err == nil {
+		if err := os.Rename(materializedPath, backupPath); err != nil {
+			return i.failInstall(ctx, appName, priorInstallation, previousVersion, version, input.Actor, registryName, fmt.Errorf("backup current materialization directory: %w", err))
+		}
+	} else if !os.IsNotExist(err) {
+		return i.failInstall(ctx, appName, priorInstallation, previousVersion, version, input.Actor, registryName, fmt.Errorf("stat materialization directory: %w", err))
 	}
 	if err := os.Rename(stagingPath, materializedPath); err != nil {
+		if _, statErr := os.Stat(backupPath); statErr == nil {
+			_ = os.RemoveAll(materializedPath)
+			_ = os.Rename(backupPath, materializedPath)
+		}
 		return i.failInstall(ctx, appName, priorInstallation, previousVersion, version, input.Actor, registryName, fmt.Errorf("promote staged app artifact: %w", err))
 	}
 	stagingCleanup = false
+	_ = os.RemoveAll(backupPath)
 
 	activeSince := i.now()
-	promoted := &core.AppInstallation{
-		AppName:                 appName,
-		VersionConstraint:       version,
-		ResolvedVersion:         version,
-		SourceRef:               publishedVersion.SourceRef,
-		Registry:                registryName,
-		ProviderReleaseURL:      publishedVersionPublicURL,
-		ArtifactChecksums:       checksums,
-		RolloutStatus:           core.AppInstallationRolloutStatusPromoted,
-		ActiveSince:             &activeSince,
-		PreviousResolvedVersion: previousVersion,
-		InstalledBy:             strings.TrimSpace(input.Actor),
-	}
-	current, err := i.Installations.GetInstallation(ctx, appName)
+	stored, err := i.Installations.UpdateInstallation(ctx, appName, func(installation *core.AppInstallation) error {
+		if !installationMatchesFailedAttempt(installation, version) {
+			return fmt.Errorf("%w: pending install for version %q no longer active", ErrInstallFleetStateAdvanced, version)
+		}
+		installation.VersionConstraint = version
+		installation.ResolvedVersion = version
+		installation.SourceRef = publishedVersion.SourceRef
+		installation.Registry = registryName
+		installation.ProviderReleaseURL = publishedVersionPublicURL
+		installation.ArtifactChecksums = checksums
+		installation.RolloutStatus = core.AppInstallationRolloutStatusPromoted
+		installation.ActiveSince = &activeSince
+		installation.PreviousResolvedVersion = previousVersion
+		installation.InstalledBy = strings.TrimSpace(input.Actor)
+		return nil
+	})
 	if err != nil {
-		return i.failInstall(ctx, appName, priorInstallation, previousVersion, version, input.Actor, registryName, fmt.Errorf("load current app installation: %w", err))
-	}
-	if !installationMatchesFailedAttempt(current, version) {
-		i.appendInstallEventBestEffort(ctx, &core.AppInstallationEvent{
-			InstallationID: appName,
-			FromVersion:    previousVersion,
-			ToVersion:      version,
-			Type:           core.AppInstallationEventTypeFailed,
-			Actor:          strings.TrimSpace(input.Actor),
-			Metadata: map[string]any{
-				"registry": registryName,
-				"error":    "fleet state advanced past pending install",
-				"skipped":  "fleet state advanced past this install attempt",
-			},
-		})
-		return nil, fmt.Errorf("%w: pending install for version %q no longer active", ErrInstallFleetStateAdvanced, version)
-	}
-	stored, err := i.Installations.PutInstallation(ctx, promoted)
-	if err != nil {
+		if errors.Is(err, ErrInstallFleetStateAdvanced) {
+			i.appendInstallEventBestEffort(ctx, &core.AppInstallationEvent{
+				InstallationID: appName,
+				FromVersion:    previousVersion,
+				ToVersion:      version,
+				Type:           core.AppInstallationEventTypeFailed,
+				Actor:          strings.TrimSpace(input.Actor),
+				Metadata: map[string]any{
+					"registry": registryName,
+					"error":    "fleet state advanced past pending install",
+					"skipped":  "fleet state advanced past this install attempt",
+				},
+			})
+			return nil, err
+		}
 		return i.failInstall(ctx, appName, priorInstallation, previousVersion, version, input.Actor, registryName, fmt.Errorf("write promoted app installation: %w", err))
 	}
 	i.appendInstallEventBestEffort(ctx, &core.AppInstallationEvent{
@@ -273,6 +284,9 @@ func (i *Installer) failInstall(ctx context.Context, appName string, priorInstal
 	}
 
 	_, putErr := i.Installations.UpdateInstallation(cleanupCtx, appName, func(installation *core.AppInstallation) error {
+		if !installationMatchesFailedAttempt(installation, version) {
+			return fmt.Errorf("%w: pending install for version %q no longer active during failure handling", ErrInstallFleetStateAdvanced, version)
+		}
 		if restored := restoredInstallationAfterFailure(priorInstallation, version, actor, registryName); restored != nil {
 			*installation = *restored
 			installation.AppName = appName
@@ -292,6 +306,21 @@ func (i *Installer) failInstall(ctx context.Context, appName string, priorInstal
 		return nil
 	})
 	if putErr != nil {
+		if errors.Is(putErr, ErrInstallFleetStateAdvanced) {
+			i.appendInstallEventBestEffort(cleanupCtx, &core.AppInstallationEvent{
+				InstallationID: appName,
+				FromVersion:    previousVersion,
+				ToVersion:      version,
+				Type:           core.AppInstallationEventTypeFailed,
+				Actor:          strings.TrimSpace(actor),
+				Metadata: map[string]any{
+					"registry": registryName,
+					"error":    cause.Error(),
+					"skipped":  "fleet state advanced past this install attempt",
+				},
+			})
+			return nil, cause
+		}
 		return nil, fmt.Errorf("%w; also failed to mark installation failed: %v", cause, putErr)
 	}
 	if _, eventErr := i.Events.AppendEvent(cleanupCtx, &core.AppInstallationEvent{
@@ -332,8 +361,7 @@ func restoredInstallationAfterFailure(prior *core.AppInstallation, attemptedVers
 		}
 		return restored
 	case core.AppInstallationRolloutStatusFailed:
-		resolved := strings.TrimSpace(prior.ResolvedVersion)
-		if resolved == "" || resolved == attemptedVersion {
+		if strings.TrimSpace(prior.ResolvedVersion) == "" {
 			return nil
 		}
 		restored := cloneAppInstallation(prior)
@@ -350,17 +378,44 @@ func restoredInstallationAfterFailure(prior *core.AppInstallation, attemptedVers
 }
 
 func (i *Installer) writePendingInstall(ctx context.Context, appName string, baseline *core.AppInstallation, pending *core.AppInstallation) error {
-	current, err := i.Installations.GetInstallation(ctx, appName)
-	if err != nil && err != core.ErrNotFound {
-		return fmt.Errorf("load current app installation: %w", err)
+	if baseline == nil {
+		current, err := i.Installations.GetInstallation(ctx, appName)
+		if err != nil && err != core.ErrNotFound {
+			return fmt.Errorf("load current app installation: %w", err)
+		}
+		if current != nil {
+			return fmt.Errorf("%w: install baseline no longer current", ErrInstallFleetStateAdvanced)
+		}
+		if _, err := i.Installations.PutInstallation(ctx, pending); err != nil {
+			return fmt.Errorf("write pending app installation: %w", err)
+		}
+		return nil
 	}
-	if !installationMatchesInstallBaseline(current, baseline) {
-		return fmt.Errorf("%w: install baseline no longer current", ErrInstallFleetStateAdvanced)
-	}
-	if _, err := i.Installations.PutInstallation(ctx, pending); err != nil {
+
+	_, err := i.Installations.UpdateInstallation(ctx, appName, func(installation *core.AppInstallation) error {
+		if !installationMatchesInstallBaseline(installation, baseline) {
+			return fmt.Errorf("%w: install baseline no longer current", ErrInstallFleetStateAdvanced)
+		}
+		applyPendingInstall(installation, pending)
+		return nil
+	})
+	if err != nil {
 		return fmt.Errorf("write pending app installation: %w", err)
 	}
 	return nil
+}
+
+func applyPendingInstall(dst *core.AppInstallation, pending *core.AppInstallation) {
+	dst.RolloutStatus = pending.RolloutStatus
+	dst.VersionConstraint = pending.VersionConstraint
+	dst.ResolvedVersion = pending.ResolvedVersion
+	dst.SourceRef = pending.SourceRef
+	dst.Registry = pending.Registry
+	dst.ProviderReleaseURL = pending.ProviderReleaseURL
+	dst.ArtifactChecksums = pending.ArtifactChecksums
+	dst.PreviousResolvedVersion = pending.PreviousResolvedVersion
+	dst.InstalledBy = pending.InstalledBy
+	dst.ActiveSince = nil
 }
 
 func installationMatchesInstallBaseline(current, baseline *core.AppInstallation) bool {

--- a/gestaltd/internal/appregistry/installer.go
+++ b/gestaltd/internal/appregistry/installer.go
@@ -269,7 +269,7 @@ func (i *Installer) failInstall(ctx context.Context, appName string, restoreBase
 		return nil, fmt.Errorf("%w; also failed to load current installation: %v", cause, getErr)
 	}
 	if pendingBaseline != nil {
-		if getErr == core.ErrNotFound || !installationMatchesInstallBaseline(current, pendingBaseline) {
+		if getErr == core.ErrNotFound || !coredata.InstallationMatchesBaseline(current, pendingBaseline) {
 			i.appendInstallEventBestEffort(cleanupCtx, &core.AppInstallationEvent{
 				InstallationID: appName,
 				FromVersion:    previousVersion,
@@ -452,18 +452,6 @@ func restoreMaterializationBackup(materializedPath, backupPath string) {
 	}
 	_ = os.RemoveAll(materializedPath)
 	_ = os.Rename(backupPath, materializedPath)
-}
-
-func installationMatchesInstallBaseline(current, baseline *core.AppInstallation) bool {
-	if baseline == nil {
-		return current == nil
-	}
-	if current == nil {
-		return false
-	}
-	return strings.TrimSpace(current.RolloutStatus) == strings.TrimSpace(baseline.RolloutStatus) &&
-		strings.TrimSpace(current.ResolvedVersion) == strings.TrimSpace(baseline.ResolvedVersion) &&
-		current.UpdatedAt.Equal(baseline.UpdatedAt)
 }
 
 func installationMatchesFailedAttempt(current *core.AppInstallation, attemptedVersion string) bool {

--- a/gestaltd/internal/appregistry/installer.go
+++ b/gestaltd/internal/appregistry/installer.go
@@ -118,11 +118,13 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 	}
 
 	var previousVersion string
-	var priorInstallation *core.AppInstallation
+	var installBaseline *core.AppInstallation
+	var restoreBaseline *core.AppInstallation
 	existing, err := i.Installations.GetInstallation(ctx, appName)
 	if err == nil {
-		priorInstallation = cloneAppInstallation(existing)
-		previousVersion = strings.TrimSpace(existing.ResolvedVersion)
+		installBaseline = cloneAppInstallation(existing)
+		restoreBaseline = restoreBaselineForInstall(existing)
+		previousVersion = previousVersionForInstall(existing)
 	} else if err != core.ErrNotFound {
 		return nil, fmt.Errorf("load existing app installation: %w", err)
 	}
@@ -142,7 +144,7 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 		PreviousResolvedVersion: previousVersion,
 		InstalledBy:             strings.TrimSpace(input.Actor),
 	}
-	if err := i.writePendingInstall(ctx, appName, priorInstallation, pending); err != nil {
+	if err := i.writePendingInstall(ctx, appName, installBaseline, pending); err != nil {
 		return nil, err
 	}
 	if _, err := i.Events.AppendEvent(ctx, &core.AppInstallationEvent{
@@ -155,7 +157,7 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 			"registry": registryName,
 		},
 	}); err != nil {
-		return i.failInstall(ctx, appName, priorInstallation, previousVersion, version, input.Actor, registryName, fmt.Errorf("append install_requested event: %w", err))
+		return i.failInstall(ctx, appName, restoreBaseline, previousVersion, version, input.Actor, registryName, fmt.Errorf("append install_requested event: %w", err))
 	}
 
 	materializedPath := filepath.Join(artifactsDir, RegistryInstallSubdir, appName, version)
@@ -163,7 +165,7 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 
 	download, err := downloadRegistryArtifact(ctx, reader.client(), artifactURL)
 	if err != nil {
-		return i.failInstall(ctx, appName, priorInstallation, previousVersion, version, input.Actor, registryName, err)
+		return i.failInstall(ctx, appName, restoreBaseline, previousVersion, version, input.Actor, registryName, err)
 	}
 	defer func() {
 		if download.Cleanup != nil {
@@ -171,11 +173,11 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 		}
 	}()
 	if !strings.EqualFold(strings.TrimSpace(download.SHA256Hex), expectedSHA) {
-		return i.failInstall(ctx, appName, priorInstallation, previousVersion, version, input.Actor, registryName, fmt.Errorf("artifact digest mismatch: got %s, want %s", download.SHA256Hex, expectedSHA))
+		return i.failInstall(ctx, appName, restoreBaseline, previousVersion, version, input.Actor, registryName, fmt.Errorf("artifact digest mismatch: got %s, want %s", download.SHA256Hex, expectedSHA))
 	}
 
 	if err := os.RemoveAll(stagingPath); err != nil {
-		return i.failInstall(ctx, appName, priorInstallation, previousVersion, version, input.Actor, registryName, fmt.Errorf("reset staging directory: %w", err))
+		return i.failInstall(ctx, appName, restoreBaseline, previousVersion, version, input.Actor, registryName, fmt.Errorf("reset staging directory: %w", err))
 	}
 	stagingCleanup := true
 	defer func() {
@@ -185,25 +187,25 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 	}()
 
 	if _, err := operator.InstallPublishedPackage(download.LocalPath, stagingPath, appName); err != nil {
-		return i.failInstall(ctx, appName, priorInstallation, previousVersion, version, input.Actor, registryName, fmt.Errorf("materialize app artifact: %w", err))
+		return i.failInstall(ctx, appName, restoreBaseline, previousVersion, version, input.Actor, registryName, fmt.Errorf("materialize app artifact: %w", err))
 	}
 	backupPath := materializedPath + ".backup"
 	if err := os.RemoveAll(backupPath); err != nil {
-		return i.failInstall(ctx, appName, priorInstallation, previousVersion, version, input.Actor, registryName, fmt.Errorf("reset materialization backup directory: %w", err))
+		return i.failInstall(ctx, appName, restoreBaseline, previousVersion, version, input.Actor, registryName, fmt.Errorf("reset materialization backup directory: %w", err))
 	}
 	if _, err := os.Stat(materializedPath); err == nil {
 		if err := os.Rename(materializedPath, backupPath); err != nil {
-			return i.failInstall(ctx, appName, priorInstallation, previousVersion, version, input.Actor, registryName, fmt.Errorf("backup current materialization directory: %w", err))
+			return i.failInstall(ctx, appName, restoreBaseline, previousVersion, version, input.Actor, registryName, fmt.Errorf("backup current materialization directory: %w", err))
 		}
 	} else if !os.IsNotExist(err) {
-		return i.failInstall(ctx, appName, priorInstallation, previousVersion, version, input.Actor, registryName, fmt.Errorf("stat materialization directory: %w", err))
+		return i.failInstall(ctx, appName, restoreBaseline, previousVersion, version, input.Actor, registryName, fmt.Errorf("stat materialization directory: %w", err))
 	}
 	if err := os.Rename(stagingPath, materializedPath); err != nil {
 		if _, statErr := os.Stat(backupPath); statErr == nil {
 			_ = os.RemoveAll(materializedPath)
 			_ = os.Rename(backupPath, materializedPath)
 		}
-		return i.failInstall(ctx, appName, priorInstallation, previousVersion, version, input.Actor, registryName, fmt.Errorf("promote staged app artifact: %w", err))
+		return i.failInstall(ctx, appName, restoreBaseline, previousVersion, version, input.Actor, registryName, fmt.Errorf("promote staged app artifact: %w", err))
 	}
 	stagingCleanup = false
 	_ = os.RemoveAll(backupPath)
@@ -241,7 +243,7 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 			})
 			return nil, err
 		}
-		return i.failInstall(ctx, appName, priorInstallation, previousVersion, version, input.Actor, registryName, fmt.Errorf("write promoted app installation: %w", err))
+		return i.failInstall(ctx, appName, restoreBaseline, previousVersion, version, input.Actor, registryName, fmt.Errorf("write promoted app installation: %w", err))
 	}
 	i.appendInstallEventBestEffort(ctx, &core.AppInstallationEvent{
 		InstallationID: appName,
@@ -440,6 +442,37 @@ func installationMatchesFailedAttempt(current *core.AppInstallation, attemptedVe
 	}
 	return strings.TrimSpace(current.RolloutStatus) == core.AppInstallationRolloutStatusPending &&
 		strings.TrimSpace(current.ResolvedVersion) == attemptedVersion
+}
+
+func previousVersionForInstall(existing *core.AppInstallation) string {
+	if existing == nil {
+		return ""
+	}
+	if strings.TrimSpace(existing.RolloutStatus) == core.AppInstallationRolloutStatusPending {
+		return strings.TrimSpace(existing.PreviousResolvedVersion)
+	}
+	return strings.TrimSpace(existing.ResolvedVersion)
+}
+
+func restoreBaselineForInstall(existing *core.AppInstallation) *core.AppInstallation {
+	if existing == nil {
+		return nil
+	}
+	switch strings.TrimSpace(existing.RolloutStatus) {
+	case core.AppInstallationRolloutStatusPending:
+		previous := strings.TrimSpace(existing.PreviousResolvedVersion)
+		resolved := strings.TrimSpace(existing.ResolvedVersion)
+		if previous == "" || previous == resolved {
+			return nil
+		}
+		restored := cloneAppInstallation(existing)
+		restored.RolloutStatus = core.AppInstallationRolloutStatusPromoted
+		restored.VersionConstraint = previous
+		restored.ResolvedVersion = previous
+		return restored
+	default:
+		return cloneAppInstallation(existing)
+	}
 }
 
 func cloneAppInstallation(installation *core.AppInstallation) *core.AppInstallation {

--- a/gestaltd/internal/appregistry/installer.go
+++ b/gestaltd/internal/appregistry/installer.go
@@ -226,6 +226,7 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 	})
 	if err != nil {
 		if errors.Is(err, coredata.ErrInstallationStateConflict) {
+			restoreMaterializationBackup(materializedPath, backupPath)
 			i.appendInstallEventBestEffort(ctx, &core.AppInstallationEvent{
 				InstallationID: appName,
 				FromVersion:    previousVersion,

--- a/gestaltd/internal/appregistry/installer.go
+++ b/gestaltd/internal/appregistry/installer.go
@@ -1,0 +1,428 @@
+package appregistry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
+	"github.com/valon-technologies/gestalt/server/internal/operator"
+	"github.com/valon-technologies/gestalt/server/internal/providerregistry"
+	"github.com/valon-technologies/gestalt/server/services/apps/providerpkg"
+)
+
+const RegistryInstallSubdir = "registry-installed"
+
+// ErrInstallFleetStateAdvanced indicates another install changed shared fleet
+// state after this attempt started.
+var ErrInstallFleetStateAdvanced = errors.New("fleet state advanced during install")
+
+// Installer writes shared install state and materializes registry apps on the
+// handling instance.
+type Installer struct {
+	Registries    map[string]config.AppRegistryConfig
+	Reader        *RegistryReader
+	Installations *coredata.AppInstallationService
+	Events        *coredata.AppInstallationEventService
+	ArtifactsDir  string
+	Now           func() time.Time
+}
+
+type InstallInput struct {
+	Registry string
+	App      string
+	Version  string
+	Actor    string
+}
+
+type InstallOutput struct {
+	Installation     *core.AppInstallation
+	MaterializedPath string
+}
+
+func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOutput, error) {
+	if i == nil {
+		return nil, fmt.Errorf("app registry installer is not configured")
+	}
+	registryName := strings.TrimSpace(input.Registry)
+	appName := strings.TrimSpace(input.App)
+	version := strings.TrimSpace(input.Version)
+	if registryName == "" {
+		return nil, fmt.Errorf("registry is required")
+	}
+	if appName == "" {
+		return nil, fmt.Errorf("app is required")
+	}
+	if version == "" {
+		return nil, fmt.Errorf("version is required")
+	}
+	if err := providerregistry.ValidateRepositoryName(appName); err != nil {
+		return nil, fmt.Errorf("invalid app name: %w", err)
+	}
+	if i.Installations == nil || i.Events == nil {
+		return nil, fmt.Errorf("app installation services are not configured")
+	}
+	artifactsDir := strings.TrimSpace(i.ArtifactsDir)
+	if artifactsDir == "" {
+		return nil, fmt.Errorf("artifacts directory is not configured")
+	}
+	registry, ok := i.Registries[registryName]
+	if !ok {
+		return nil, fmt.Errorf("app registry not found")
+	}
+	if strings.TrimSpace(registry.Kind) != config.AppRegistryKindGCS {
+		return nil, fmt.Errorf("unsupported app registry kind")
+	}
+	publicRoot, err := registry.PublicURL()
+	if err != nil {
+		return nil, fmt.Errorf("app registry public URL is invalid: %w", err)
+	}
+
+	reader := i.Reader
+	if reader == nil {
+		reader = &RegistryReader{}
+	}
+	publishedVersion, err := reader.FetchPublishedVersion(ctx, publicRoot, appName, version)
+	if err != nil {
+		return nil, fmt.Errorf("fetch app registry published version: %w", err)
+	}
+	if publishedVersion.App != appName {
+		return nil, fmt.Errorf("registry published version app %q does not match requested app %q", publishedVersion.App, appName)
+	}
+	if publishedVersion.Version != version {
+		return nil, fmt.Errorf("registry published version version %q does not match requested version %q", publishedVersion.Version, version)
+	}
+
+	platform := providerpkg.CurrentPlatformString()
+	artifact, ok := publishedVersion.Artifacts[platform]
+	if !ok {
+		return nil, fmt.Errorf("registry published version has no artifact for platform %q", platform)
+	}
+	artifactURL := strings.TrimSpace(artifact.PublicURL)
+	if artifactURL == "" {
+		artifactURL = strings.TrimSpace(artifact.URL)
+	}
+	if artifactURL == "" {
+		return nil, fmt.Errorf("registry published version artifact for platform %q has no download URL", platform)
+	}
+	expectedSHA := strings.TrimSpace(artifact.SHA256)
+	if expectedSHA == "" {
+		return nil, fmt.Errorf("registry published version artifact for platform %q is missing sha256", platform)
+	}
+
+	var previousVersion string
+	var priorInstallation *core.AppInstallation
+	existing, err := i.Installations.GetInstallation(ctx, appName)
+	if err == nil {
+		priorInstallation = cloneAppInstallation(existing)
+		previousVersion = strings.TrimSpace(existing.ResolvedVersion)
+	} else if err != core.ErrNotFound {
+		return nil, fmt.Errorf("load existing app installation: %w", err)
+	}
+
+	publishedVersionPublicURL := PublicURL(publicRoot, PublishedVersionPath(appName, version))
+	checksums := map[string]string{platform: expectedSHA}
+
+	pending := &core.AppInstallation{
+		AppName:                 appName,
+		VersionConstraint:       version,
+		ResolvedVersion:         version,
+		SourceRef:               publishedVersion.SourceRef,
+		Registry:                registryName,
+		ProviderReleaseURL:      publishedVersionPublicURL,
+		ArtifactChecksums:       checksums,
+		RolloutStatus:           core.AppInstallationRolloutStatusPending,
+		PreviousResolvedVersion: previousVersion,
+		InstalledBy:             strings.TrimSpace(input.Actor),
+	}
+	if err := i.writePendingInstall(ctx, appName, priorInstallation, pending); err != nil {
+		return nil, err
+	}
+	if _, err := i.Events.AppendEvent(ctx, &core.AppInstallationEvent{
+		InstallationID: appName,
+		FromVersion:    previousVersion,
+		ToVersion:      version,
+		Type:           core.AppInstallationEventTypeInstallRequested,
+		Actor:          strings.TrimSpace(input.Actor),
+		Metadata: map[string]any{
+			"registry": registryName,
+		},
+	}); err != nil {
+		return i.failInstall(ctx, appName, priorInstallation, previousVersion, version, input.Actor, registryName, fmt.Errorf("append install_requested event: %w", err))
+	}
+
+	materializedPath := filepath.Join(artifactsDir, RegistryInstallSubdir, appName, version)
+	stagingPath := materializedPath + ".staging"
+
+	download, err := downloadRegistryArtifact(ctx, reader.client(), artifactURL)
+	if err != nil {
+		return i.failInstall(ctx, appName, priorInstallation, previousVersion, version, input.Actor, registryName, err)
+	}
+	defer func() {
+		if download.Cleanup != nil {
+			download.Cleanup()
+		}
+	}()
+	if !strings.EqualFold(strings.TrimSpace(download.SHA256Hex), expectedSHA) {
+		return i.failInstall(ctx, appName, priorInstallation, previousVersion, version, input.Actor, registryName, fmt.Errorf("artifact digest mismatch: got %s, want %s", download.SHA256Hex, expectedSHA))
+	}
+
+	if err := os.RemoveAll(stagingPath); err != nil {
+		return i.failInstall(ctx, appName, priorInstallation, previousVersion, version, input.Actor, registryName, fmt.Errorf("reset staging directory: %w", err))
+	}
+	stagingCleanup := true
+	defer func() {
+		if stagingCleanup {
+			_ = os.RemoveAll(stagingPath)
+		}
+	}()
+
+	if _, err := operator.InstallPublishedPackage(download.LocalPath, stagingPath, appName); err != nil {
+		return i.failInstall(ctx, appName, priorInstallation, previousVersion, version, input.Actor, registryName, fmt.Errorf("materialize app artifact: %w", err))
+	}
+	if err := os.RemoveAll(materializedPath); err != nil {
+		return i.failInstall(ctx, appName, priorInstallation, previousVersion, version, input.Actor, registryName, fmt.Errorf("reset materialization directory: %w", err))
+	}
+	if err := os.Rename(stagingPath, materializedPath); err != nil {
+		return i.failInstall(ctx, appName, priorInstallation, previousVersion, version, input.Actor, registryName, fmt.Errorf("promote staged app artifact: %w", err))
+	}
+	stagingCleanup = false
+
+	activeSince := i.now()
+	promoted := &core.AppInstallation{
+		AppName:                 appName,
+		VersionConstraint:       version,
+		ResolvedVersion:         version,
+		SourceRef:               publishedVersion.SourceRef,
+		Registry:                registryName,
+		ProviderReleaseURL:      publishedVersionPublicURL,
+		ArtifactChecksums:       checksums,
+		RolloutStatus:           core.AppInstallationRolloutStatusPromoted,
+		ActiveSince:             &activeSince,
+		PreviousResolvedVersion: previousVersion,
+		InstalledBy:             strings.TrimSpace(input.Actor),
+	}
+	current, err := i.Installations.GetInstallation(ctx, appName)
+	if err != nil {
+		return i.failInstall(ctx, appName, priorInstallation, previousVersion, version, input.Actor, registryName, fmt.Errorf("load current app installation: %w", err))
+	}
+	if !installationMatchesFailedAttempt(current, version) {
+		i.appendInstallEventBestEffort(ctx, &core.AppInstallationEvent{
+			InstallationID: appName,
+			FromVersion:    previousVersion,
+			ToVersion:      version,
+			Type:           core.AppInstallationEventTypeFailed,
+			Actor:          strings.TrimSpace(input.Actor),
+			Metadata: map[string]any{
+				"registry": registryName,
+				"error":    "fleet state advanced past pending install",
+				"skipped":  "fleet state advanced past this install attempt",
+			},
+		})
+		return nil, fmt.Errorf("%w: pending install for version %q no longer active", ErrInstallFleetStateAdvanced, version)
+	}
+	stored, err := i.Installations.PutInstallation(ctx, promoted)
+	if err != nil {
+		return i.failInstall(ctx, appName, priorInstallation, previousVersion, version, input.Actor, registryName, fmt.Errorf("write promoted app installation: %w", err))
+	}
+	i.appendInstallEventBestEffort(ctx, &core.AppInstallationEvent{
+		InstallationID: appName,
+		FromVersion:    previousVersion,
+		ToVersion:      version,
+		Type:           core.AppInstallationEventTypePromoted,
+		Actor:          strings.TrimSpace(input.Actor),
+		Metadata: map[string]any{
+			"registry":          registryName,
+			"materialized_path": materializedPath,
+		},
+	})
+
+	return &InstallOutput{
+		Installation:     stored,
+		MaterializedPath: materializedPath,
+	}, nil
+}
+
+func (i *Installer) failInstall(ctx context.Context, appName string, priorInstallation *core.AppInstallation, previousVersion, version, actor, registryName string, cause error) (*InstallOutput, error) {
+	cleanupCtx := context.WithoutCancel(ctx)
+	current, getErr := i.Installations.GetInstallation(cleanupCtx, appName)
+	if getErr != nil && getErr != core.ErrNotFound {
+		return nil, fmt.Errorf("%w; also failed to load current installation: %v", cause, getErr)
+	}
+	if !installationMatchesFailedAttempt(current, version) {
+		i.appendInstallEventBestEffort(cleanupCtx, &core.AppInstallationEvent{
+			InstallationID: appName,
+			FromVersion:    previousVersion,
+			ToVersion:      version,
+			Type:           core.AppInstallationEventTypeFailed,
+			Actor:          strings.TrimSpace(actor),
+			Metadata: map[string]any{
+				"registry": registryName,
+				"error":    cause.Error(),
+				"skipped":  "fleet state advanced past this install attempt",
+			},
+		})
+		return nil, cause
+	}
+
+	_, putErr := i.Installations.UpdateInstallation(cleanupCtx, appName, func(installation *core.AppInstallation) error {
+		if restored := restoredInstallationAfterFailure(priorInstallation, version, actor, registryName); restored != nil {
+			*installation = *restored
+			installation.AppName = appName
+			installation.RolloutStatus = core.AppInstallationRolloutStatusFailed
+			return nil
+		}
+		installation.RolloutStatus = core.AppInstallationRolloutStatusFailed
+		installation.VersionConstraint = version
+		installation.ResolvedVersion = version
+		installation.Registry = registryName
+		installation.PreviousResolvedVersion = previousVersion
+		installation.InstalledBy = strings.TrimSpace(actor)
+		installation.ActiveSince = nil
+		installation.SourceRef = ""
+		installation.ProviderReleaseURL = ""
+		installation.ArtifactChecksums = nil
+		return nil
+	})
+	if putErr != nil {
+		return nil, fmt.Errorf("%w; also failed to mark installation failed: %v", cause, putErr)
+	}
+	if _, eventErr := i.Events.AppendEvent(cleanupCtx, &core.AppInstallationEvent{
+		InstallationID: appName,
+		FromVersion:    previousVersion,
+		ToVersion:      version,
+		Type:           core.AppInstallationEventTypeFailed,
+		Actor:          strings.TrimSpace(actor),
+		Metadata: map[string]any{
+			"registry": registryName,
+			"error":    cause.Error(),
+		},
+	}); eventErr != nil {
+		return nil, fmt.Errorf("%w; also failed to append failed event: %v", cause, eventErr)
+	}
+	return nil, cause
+}
+
+func (i *Installer) appendInstallEventBestEffort(ctx context.Context, event *core.AppInstallationEvent) {
+	if i == nil || i.Events == nil || event == nil {
+		return
+	}
+	_, _ = i.Events.AppendEvent(context.WithoutCancel(ctx), event)
+}
+
+func restoredInstallationAfterFailure(prior *core.AppInstallation, attemptedVersion, actor, registryName string) *core.AppInstallation {
+	if prior == nil {
+		return nil
+	}
+	switch prior.RolloutStatus {
+	case core.AppInstallationRolloutStatusPromoted:
+		restored := cloneAppInstallation(prior)
+		if strings.TrimSpace(actor) != "" {
+			restored.InstalledBy = strings.TrimSpace(actor)
+		}
+		if strings.TrimSpace(registryName) != "" && strings.TrimSpace(restored.Registry) == "" {
+			restored.Registry = registryName
+		}
+		return restored
+	case core.AppInstallationRolloutStatusFailed:
+		resolved := strings.TrimSpace(prior.ResolvedVersion)
+		if resolved == "" || resolved == attemptedVersion {
+			return nil
+		}
+		restored := cloneAppInstallation(prior)
+		if strings.TrimSpace(actor) != "" {
+			restored.InstalledBy = strings.TrimSpace(actor)
+		}
+		if strings.TrimSpace(registryName) != "" && strings.TrimSpace(restored.Registry) == "" {
+			restored.Registry = registryName
+		}
+		return restored
+	default:
+		return nil
+	}
+}
+
+func (i *Installer) writePendingInstall(ctx context.Context, appName string, baseline *core.AppInstallation, pending *core.AppInstallation) error {
+	current, err := i.Installations.GetInstallation(ctx, appName)
+	if err != nil && err != core.ErrNotFound {
+		return fmt.Errorf("load current app installation: %w", err)
+	}
+	if !installationMatchesInstallBaseline(current, baseline) {
+		return fmt.Errorf("%w: install baseline no longer current", ErrInstallFleetStateAdvanced)
+	}
+	if _, err := i.Installations.PutInstallation(ctx, pending); err != nil {
+		return fmt.Errorf("write pending app installation: %w", err)
+	}
+	return nil
+}
+
+func installationMatchesInstallBaseline(current, baseline *core.AppInstallation) bool {
+	if baseline == nil {
+		return current == nil
+	}
+	if current == nil {
+		return false
+	}
+	return strings.TrimSpace(current.RolloutStatus) == strings.TrimSpace(baseline.RolloutStatus) &&
+		strings.TrimSpace(current.ResolvedVersion) == strings.TrimSpace(baseline.ResolvedVersion) &&
+		current.UpdatedAt.Equal(baseline.UpdatedAt)
+}
+
+func installationMatchesFailedAttempt(current *core.AppInstallation, attemptedVersion string) bool {
+	if current == nil {
+		return false
+	}
+	attemptedVersion = strings.TrimSpace(attemptedVersion)
+	if attemptedVersion == "" {
+		return false
+	}
+	return strings.TrimSpace(current.RolloutStatus) == core.AppInstallationRolloutStatusPending &&
+		strings.TrimSpace(current.ResolvedVersion) == attemptedVersion
+}
+
+func cloneAppInstallation(installation *core.AppInstallation) *core.AppInstallation {
+	if installation == nil {
+		return nil
+	}
+	cloned := *installation
+	if installation.ActiveSince != nil {
+		activeSince := *installation.ActiveSince
+		cloned.ActiveSince = &activeSince
+	}
+	if len(installation.ArtifactChecksums) > 0 {
+		cloned.ArtifactChecksums = make(map[string]string, len(installation.ArtifactChecksums))
+		for platform, digest := range installation.ArtifactChecksums {
+			cloned.ArtifactChecksums[platform] = digest
+		}
+	}
+	return &cloned
+}
+
+func (i *Installer) now() time.Time {
+	if i != nil && i.Now != nil {
+		return i.Now().UTC().Truncate(time.Millisecond)
+	}
+	return time.Now().UTC().Truncate(time.Millisecond)
+}
+
+func downloadRegistryArtifact(ctx context.Context, client *http.Client, artifactURL string) (*providerpkg.DownloadResult, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, artifactURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build artifact download request: %w", err)
+	}
+	result, err := providerpkg.DownloadRequest(client, req)
+	if err != nil {
+		return nil, fmt.Errorf("download registry artifact: %w", err)
+	}
+	return result, nil
+}

--- a/gestaltd/internal/appregistry/installer.go
+++ b/gestaltd/internal/appregistry/installer.go
@@ -201,14 +201,10 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 		return i.failInstall(ctx, appName, restoreBaseline, previousVersion, version, input.Actor, registryName, fmt.Errorf("stat materialization directory: %w", err))
 	}
 	if err := os.Rename(stagingPath, materializedPath); err != nil {
-		if _, statErr := os.Stat(backupPath); statErr == nil {
-			_ = os.RemoveAll(materializedPath)
-			_ = os.Rename(backupPath, materializedPath)
-		}
+		restoreMaterializationBackup(materializedPath, backupPath)
 		return i.failInstall(ctx, appName, restoreBaseline, previousVersion, version, input.Actor, registryName, fmt.Errorf("promote staged app artifact: %w", err))
 	}
 	stagingCleanup = false
-	_ = os.RemoveAll(backupPath)
 
 	activeSince := i.now()
 	stored, err := i.Installations.UpdateInstallation(ctx, appName, func(installation *core.AppInstallation) error {
@@ -243,8 +239,10 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 			})
 			return nil, err
 		}
+		restoreMaterializationBackup(materializedPath, backupPath)
 		return i.failInstall(ctx, appName, restoreBaseline, previousVersion, version, input.Actor, registryName, fmt.Errorf("write promoted app installation: %w", err))
 	}
+	_ = os.RemoveAll(backupPath)
 	i.appendInstallEventBestEffort(ctx, &core.AppInstallationEvent{
 		InstallationID: appName,
 		FromVersion:    previousVersion,
@@ -398,7 +396,7 @@ func (i *Installer) writePendingInstall(ctx context.Context, appName string, bas
 		if !installationMatchesInstallBaseline(installation, baseline) {
 			return fmt.Errorf("%w: install baseline no longer current", ErrInstallFleetStateAdvanced)
 		}
-		applyPendingInstall(installation, pending)
+		applyPendingInstall(installation, pending, baseline)
 		return nil
 	})
 	if err != nil {
@@ -407,17 +405,46 @@ func (i *Installer) writePendingInstall(ctx context.Context, appName string, bas
 	return nil
 }
 
-func applyPendingInstall(dst *core.AppInstallation, pending *core.AppInstallation) {
+func applyPendingInstall(dst *core.AppInstallation, pending *core.AppInstallation, baseline *core.AppInstallation) {
 	dst.RolloutStatus = pending.RolloutStatus
 	dst.VersionConstraint = pending.VersionConstraint
 	dst.ResolvedVersion = pending.ResolvedVersion
-	dst.SourceRef = pending.SourceRef
-	dst.Registry = pending.Registry
-	dst.ProviderReleaseURL = pending.ProviderReleaseURL
-	dst.ArtifactChecksums = pending.ArtifactChecksums
 	dst.PreviousResolvedVersion = pending.PreviousResolvedVersion
 	dst.InstalledBy = pending.InstalledBy
+	if strings.TrimSpace(pending.Registry) != "" {
+		dst.Registry = pending.Registry
+	}
+	if shouldPreservePriorMetadata(baseline) {
+		return
+	}
+	dst.SourceRef = pending.SourceRef
+	dst.ProviderReleaseURL = pending.ProviderReleaseURL
+	dst.ArtifactChecksums = pending.ArtifactChecksums
 	dst.ActiveSince = nil
+}
+
+func shouldPreservePriorMetadata(baseline *core.AppInstallation) bool {
+	if baseline == nil {
+		return false
+	}
+	switch strings.TrimSpace(baseline.RolloutStatus) {
+	case core.AppInstallationRolloutStatusPromoted:
+		return true
+	case core.AppInstallationRolloutStatusPending:
+		previous := strings.TrimSpace(baseline.PreviousResolvedVersion)
+		resolved := strings.TrimSpace(baseline.ResolvedVersion)
+		return previous != "" && previous != resolved
+	default:
+		return false
+	}
+}
+
+func restoreMaterializationBackup(materializedPath, backupPath string) {
+	if _, err := os.Stat(backupPath); err != nil {
+		return
+	}
+	_ = os.RemoveAll(materializedPath)
+	_ = os.Rename(backupPath, materializedPath)
 }
 
 func installationMatchesInstallBaseline(current, baseline *core.AppInstallation) bool {

--- a/gestaltd/internal/appregistry/installer_test.go
+++ b/gestaltd/internal/appregistry/installer_test.go
@@ -273,9 +273,12 @@ func TestInstallerInstallFailureHandling(t *testing.T) {
 					AppName:                 "g-issues",
 					VersionConstraint:       fixture.Version,
 					ResolvedVersion:         fixture.Version,
+					SourceRef:               sourceRef,
 					Registry:                "toolshed",
+					ArtifactChecksums:       checksums,
 					RolloutStatus:           core.AppInstallationRolloutStatusPending,
 					PreviousResolvedVersion: goldVersion,
+					ActiveSince:             &activeSince,
 				}); err != nil {
 					t.Fatalf("PutInstallation: %v", err)
 				}
@@ -301,6 +304,12 @@ func TestInstallerInstallFailureHandling(t *testing.T) {
 				}
 				if stored.PreviousResolvedVersion != goldVersion {
 					t.Fatalf("previous_resolved_version = %q, want %q", stored.PreviousResolvedVersion, goldVersion)
+				}
+				if stored.SourceRef != sourceRef {
+					t.Fatalf("source_ref = %q, want preserved gold metadata", stored.SourceRef)
+				}
+				if stored.ActiveSince == nil || !stored.ActiveSince.Equal(activeSince) {
+					t.Fatalf("active_since = %v, want preserved gold metadata", stored.ActiveSince)
 				}
 			},
 		},

--- a/gestaltd/internal/appregistry/installer_test.go
+++ b/gestaltd/internal/appregistry/installer_test.go
@@ -265,6 +265,45 @@ func TestInstallerInstallFailureHandling(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "pending_retry_preserves_gold",
+			seed: func(t *testing.T, services *testutil.Services) {
+				t.Helper()
+				if _, err := services.AppInstallations.PutInstallation(t.Context(), &core.AppInstallation{
+					AppName:                 "g-issues",
+					VersionConstraint:       fixture.Version,
+					ResolvedVersion:         fixture.Version,
+					Registry:                "toolshed",
+					RolloutStatus:           core.AppInstallationRolloutStatusPending,
+					PreviousResolvedVersion: goldVersion,
+				}); err != nil {
+					t.Fatalf("PutInstallation: %v", err)
+				}
+			},
+			run: func(t *testing.T, installer *appregistry.Installer) {
+				t.Helper()
+				_, err := installer.Install(t.Context(), appregistry.InstallInput{
+					Registry: "toolshed",
+					App:      "g-issues",
+					Version:  fixture.Version,
+				})
+				if err == nil {
+					t.Fatal("expected install failure")
+				}
+			},
+			want: func(t *testing.T, stored *core.AppInstallation) {
+				t.Helper()
+				if stored.RolloutStatus != core.AppInstallationRolloutStatusFailed {
+					t.Fatalf("rollout_status = %q, want failed", stored.RolloutStatus)
+				}
+				if stored.ResolvedVersion != goldVersion {
+					t.Fatalf("resolved_version = %q, want %q", stored.ResolvedVersion, goldVersion)
+				}
+				if stored.PreviousResolvedVersion != goldVersion {
+					t.Fatalf("previous_resolved_version = %q, want %q", stored.PreviousResolvedVersion, goldVersion)
+				}
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/gestaltd/internal/appregistry/installer_test.go
+++ b/gestaltd/internal/appregistry/installer_test.go
@@ -1,0 +1,297 @@
+package appregistry_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/appregistry"
+	"github.com/valon-technologies/gestalt/server/internal/appregistry/registrytest"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	"github.com/valon-technologies/gestalt/server/services/apps/providerpkg"
+)
+
+func TestInstallerInstallsRegistryAppAndWritesPromotedState(t *testing.T) {
+	t.Parallel()
+
+	fixture := registrytest.NewInstallFixture(t)
+	services := testutil.NewStubServices(t)
+	artifactsDir := t.TempDir()
+	promotedAt := time.Date(2026, 7, 10, 15, 30, 0, 0, time.UTC)
+
+	installer := &appregistry.Installer{
+		Registries: map[string]config.AppRegistryConfig{
+			"toolshed": fixture.Registry,
+		},
+		Reader:        fixture.Reader,
+		Installations: services.AppInstallations,
+		Events:        services.AppInstallationEvents,
+		ArtifactsDir:  artifactsDir,
+		Now: func() time.Time {
+			return promotedAt
+		},
+	}
+
+	result, err := installer.Install(t.Context(), appregistry.InstallInput{
+		Registry: "toolshed",
+		App:      "g-issues",
+		Version:  fixture.Version,
+		Actor:    "user:test",
+	})
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if result.Installation.RolloutStatus != core.AppInstallationRolloutStatusPromoted {
+		t.Fatalf("rollout_status = %q, want promoted", result.Installation.RolloutStatus)
+	}
+	if result.Installation.ResolvedVersion != fixture.Version {
+		t.Fatalf("resolved_version = %q", result.Installation.ResolvedVersion)
+	}
+	if result.Installation.ActiveSince == nil {
+		t.Fatal("active_since is nil")
+	}
+	if !result.Installation.ActiveSince.Equal(promotedAt) {
+		t.Fatalf("active_since = %v, want %v", result.Installation.ActiveSince, promotedAt)
+	}
+	if result.MaterializedPath == "" {
+		t.Fatal("materialized path is empty")
+	}
+	if _, err := os.Stat(filepath.Join(result.MaterializedPath, "manifest.yaml")); err != nil {
+		t.Fatalf("stat materialized manifest: %v", err)
+	}
+
+	events, err := services.AppInstallationEvents.ListEventsByApp(t.Context(), "g-issues")
+	if err != nil {
+		t.Fatalf("ListEventsByApp: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("events len = %d, want 2", len(events))
+	}
+	if events[0].Type != core.AppInstallationEventTypeInstallRequested {
+		t.Fatalf("events[0].type = %q", events[0].Type)
+	}
+	if events[1].Type != core.AppInstallationEventTypePromoted {
+		t.Fatalf("events[1].type = %q", events[1].Type)
+	}
+}
+
+func TestRegistryReader_FetchPublishedVersionNotFound(t *testing.T) {
+	t.Parallel()
+
+	fixture := registrytest.NewInstallFixture(t)
+	publicURL, err := fixture.Registry.PublicURL()
+	if err != nil {
+		t.Fatalf("PublicURL: %v", err)
+	}
+	_, err = fixture.Reader.FetchPublishedVersion(t.Context(), publicURL, "g-issues", "missing-version")
+	if !errors.Is(err, appregistry.ErrRegistryDocumentNotFound) {
+		t.Fatalf("FetchPublishedVersion error = %v, want ErrRegistryDocumentNotFound", err)
+	}
+}
+
+func TestInstallerInstallFailureHandling(t *testing.T) {
+	t.Parallel()
+
+	fixture := registrytest.NewInstallFixture(t)
+	activeSince := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	goldVersion := "0.0.0-snapshot.gold"
+	sourceRef := "abc123def456abc123def456abc123def456abcd"
+	platform := providerpkg.CurrentPlatformString()
+	checksums := map[string]string{platform: fixture.SHA256}
+
+	tests := []struct {
+		name string
+		seed func(t *testing.T, services *testutil.Services)
+		run  func(t *testing.T, installer *appregistry.Installer)
+		want func(t *testing.T, stored *core.AppInstallation)
+	}{
+		{
+			name: "fresh_install",
+			seed: func(t *testing.T, services *testutil.Services) {},
+			run: func(t *testing.T, installer *appregistry.Installer) {
+				t.Helper()
+				_, err := installer.Install(t.Context(), appregistry.InstallInput{
+					Registry: "toolshed",
+					App:      "g-issues",
+					Version:  fixture.Version,
+				})
+				if err == nil {
+					t.Fatal("expected install failure")
+				}
+			},
+			want: func(t *testing.T, stored *core.AppInstallation) {
+				t.Helper()
+				if stored.RolloutStatus != core.AppInstallationRolloutStatusFailed {
+					t.Fatalf("rollout_status = %q, want failed", stored.RolloutStatus)
+				}
+			},
+		},
+		{
+			name: "failed_upgrade_preserves_promoted",
+			seed: func(t *testing.T, services *testutil.Services) {
+				t.Helper()
+				if _, err := services.AppInstallations.PutInstallation(t.Context(), &core.AppInstallation{
+					AppName:           "g-issues",
+					VersionConstraint: goldVersion,
+					ResolvedVersion:   goldVersion,
+					Registry:          "toolshed",
+					RolloutStatus:     core.AppInstallationRolloutStatusPromoted,
+					ActiveSince:       &activeSince,
+				}); err != nil {
+					t.Fatalf("PutInstallation: %v", err)
+				}
+			},
+			run: func(t *testing.T, installer *appregistry.Installer) {
+				t.Helper()
+				_, err := installer.Install(t.Context(), appregistry.InstallInput{
+					Registry: "toolshed",
+					App:      "g-issues",
+					Version:  fixture.Version,
+				})
+				if err == nil {
+					t.Fatal("expected install failure")
+				}
+			},
+			want: func(t *testing.T, stored *core.AppInstallation) {
+				t.Helper()
+				if stored.RolloutStatus != core.AppInstallationRolloutStatusFailed {
+					t.Fatalf("rollout_status = %q, want failed", stored.RolloutStatus)
+				}
+				if stored.ResolvedVersion != goldVersion {
+					t.Fatalf("resolved_version = %q, want %q", stored.ResolvedVersion, goldVersion)
+				}
+				if stored.ActiveSince == nil || !stored.ActiveSince.Equal(activeSince) {
+					t.Fatalf("active_since = %v, want %v", stored.ActiveSince, activeSince)
+				}
+			},
+		},
+		{
+			name: "same_version_reinstall_preserves_metadata",
+			seed: func(t *testing.T, services *testutil.Services) {
+				t.Helper()
+				if _, err := services.AppInstallations.PutInstallation(t.Context(), &core.AppInstallation{
+					AppName:           "g-issues",
+					VersionConstraint: fixture.Version,
+					ResolvedVersion:   fixture.Version,
+					SourceRef:         sourceRef,
+					Registry:          "toolshed",
+					ArtifactChecksums: checksums,
+					RolloutStatus:     core.AppInstallationRolloutStatusPromoted,
+					ActiveSince:       &activeSince,
+				}); err != nil {
+					t.Fatalf("PutInstallation: %v", err)
+				}
+			},
+			run: func(t *testing.T, installer *appregistry.Installer) {
+				t.Helper()
+				_, err := installer.Install(t.Context(), appregistry.InstallInput{
+					Registry: "toolshed",
+					App:      "g-issues",
+					Version:  fixture.Version,
+				})
+				if err == nil {
+					t.Fatal("expected install failure")
+				}
+			},
+			want: func(t *testing.T, stored *core.AppInstallation) {
+				t.Helper()
+				if stored.RolloutStatus != core.AppInstallationRolloutStatusFailed {
+					t.Fatalf("rollout_status = %q, want failed", stored.RolloutStatus)
+				}
+				if stored.ResolvedVersion != fixture.Version {
+					t.Fatalf("resolved_version = %q", stored.ResolvedVersion)
+				}
+				if stored.SourceRef != sourceRef {
+					t.Fatalf("source_ref = %q, want preserved", stored.SourceRef)
+				}
+				if stored.ArtifactChecksums[platform] != checksums[platform] {
+					t.Fatalf("artifact_checksums = %#v, want preserved", stored.ArtifactChecksums)
+				}
+				if stored.ActiveSince == nil || !stored.ActiveSince.Equal(activeSince) {
+					t.Fatalf("active_since = %v, want %v", stored.ActiveSince, activeSince)
+				}
+			},
+		},
+		{
+			name: "second_failed_retry_preserves_gold",
+			seed: func(t *testing.T, services *testutil.Services) {
+				t.Helper()
+				if _, err := services.AppInstallations.PutInstallation(t.Context(), &core.AppInstallation{
+					AppName:           "g-issues",
+					VersionConstraint: goldVersion,
+					ResolvedVersion:   goldVersion,
+					Registry:          "toolshed",
+					RolloutStatus:     core.AppInstallationRolloutStatusPromoted,
+					ActiveSince:       &activeSince,
+				}); err != nil {
+					t.Fatalf("PutInstallation: %v", err)
+				}
+			},
+			run: func(t *testing.T, installer *appregistry.Installer) {
+				t.Helper()
+				otherVersion := "0.0.0-snapshot.other"
+				for _, version := range []string{fixture.Version, otherVersion} {
+					reader := fixture.NewDigestMismatchReader(t, version)
+					retryInstaller := &appregistry.Installer{
+						Registries: map[string]config.AppRegistryConfig{
+							"toolshed": fixture.Registry,
+						},
+						Reader:        reader,
+						Installations: installer.Installations,
+						Events:        installer.Events,
+						ArtifactsDir:  installer.ArtifactsDir,
+					}
+					_, err := retryInstaller.Install(t.Context(), appregistry.InstallInput{
+						Registry: "toolshed",
+						App:      "g-issues",
+						Version:  version,
+					})
+					if err == nil {
+						t.Fatalf("expected install failure for version %q", version)
+					}
+				}
+			},
+			want: func(t *testing.T, stored *core.AppInstallation) {
+				t.Helper()
+				if stored.RolloutStatus != core.AppInstallationRolloutStatusFailed {
+					t.Fatalf("rollout_status = %q, want failed", stored.RolloutStatus)
+				}
+				if stored.ResolvedVersion != goldVersion {
+					t.Fatalf("resolved_version = %q, want %q", stored.ResolvedVersion, goldVersion)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			services := testutil.NewStubServices(t)
+			tc.seed(t, services)
+
+			reader := fixture.NewDigestMismatchReader(t, fixture.Version)
+			installer := &appregistry.Installer{
+				Registries: map[string]config.AppRegistryConfig{
+					"toolshed": fixture.Registry,
+				},
+				Reader:        reader,
+				Installations: services.AppInstallations,
+				Events:        services.AppInstallationEvents,
+				ArtifactsDir:  t.TempDir(),
+			}
+
+			tc.run(t, installer)
+
+			stored, err := services.AppInstallations.GetInstallation(t.Context(), "g-issues")
+			if err != nil {
+				t.Fatalf("GetInstallation: %v", err)
+			}
+			tc.want(t, stored)
+		})
+	}
+}

--- a/gestaltd/internal/appregistry/reader.go
+++ b/gestaltd/internal/appregistry/reader.go
@@ -2,6 +2,7 @@ package appregistry
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,6 +12,9 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/internal/providerregistry"
 )
+
+// ErrRegistryDocumentNotFound indicates a registry document path does not exist.
+var ErrRegistryDocumentNotFound = errors.New("app registry document not found")
 
 // RegistryReader fetches registry documents over HTTP from a registry public root.
 type RegistryReader struct {
@@ -22,6 +26,32 @@ func (r *RegistryReader) client() *http.Client {
 		return r.HTTPClient
 	}
 	return http.DefaultClient
+}
+
+func (r *RegistryReader) fetchJSON(ctx context.Context, url string, notFoundEmpty bool) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build app registry request: %w", err)
+	}
+	resp, err := r.client().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch app registry document %s: %w", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusNotFound {
+		if notFoundEmpty {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("%w: %s", ErrRegistryDocumentNotFound, url)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("fetch app registry document %s: unexpected status %s", url, resp.Status)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	if err != nil {
+		return nil, fmt.Errorf("read app registry document %s: %w", url, err)
+	}
+	return body, nil
 }
 
 // FetchAppIndex downloads apps/{app}/index.json from a registry public root.
@@ -39,26 +69,40 @@ func (r *RegistryReader) FetchAppIndex(ctx context.Context, publicRoot, appName 
 	}
 
 	url := PublicURL(publicRoot, AppIndexPath(appName))
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	body, err := r.fetchJSON(ctx, url, true)
 	if err != nil {
-		return nil, fmt.Errorf("build app registry index request: %w", err)
+		return nil, err
 	}
-	resp, err := r.client().Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("fetch app registry index %s: %w", url, err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode == http.StatusNotFound {
+	if body == nil {
 		return NewEmptyIndex(), nil
 	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("fetch app registry index %s: unexpected status %s", url, resp.Status)
-	}
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
-	if err != nil {
-		return nil, fmt.Errorf("read app registry index %s: %w", url, err)
-	}
 	return DecodeIndex(body)
+}
+
+// FetchPublishedVersion downloads apps/{app}/versions/{version}.json from a registry public root.
+func (r *RegistryReader) FetchPublishedVersion(ctx context.Context, publicRoot, appName, version string) (*PublishedVersion, error) {
+	appName = strings.TrimSpace(appName)
+	version = strings.TrimSpace(version)
+	if appName == "" {
+		return nil, fmt.Errorf("app name is required")
+	}
+	if version == "" {
+		return nil, fmt.Errorf("version is required")
+	}
+	if err := providerregistry.ValidateRepositoryName(appName); err != nil {
+		return nil, err
+	}
+	publicRoot = strings.TrimRight(strings.TrimSpace(publicRoot), "/")
+	if publicRoot == "" {
+		return nil, fmt.Errorf("registry public URL is required")
+	}
+
+	url := PublicURL(publicRoot, PublishedVersionPath(appName, version))
+	body, err := r.fetchJSON(ctx, url, false)
+	if err != nil {
+		return nil, err
+	}
+	return DecodePublishedVersion(body)
 }
 
 // VersionSummary is a lightweight view of one published app version from an index.

--- a/gestaltd/internal/appregistry/registry.go
+++ b/gestaltd/internal/appregistry/registry.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	IndexSchemaVersion  = 1
-	EntrySchemaVersion  = 1
+	PublishedVersionSchemaVersion = 1
 	IndexFileName       = "index.json"
 	appSourcePathPrefix = "apps/"
 )
@@ -43,7 +43,7 @@ type IndexVersion struct {
 	PublishedAt time.Time `json:"publishedAt"`
 }
 
-type Entry struct {
+type PublishedVersion struct {
 	SchemaVersion int                 `json:"schemaVersion"`
 	App           string              `json:"app"`
 	Version       string              `json:"version"`
@@ -102,10 +102,10 @@ type PublishPlan struct {
 	RegistryName string
 	AppName      string
 	Version      string
-	Entry        Entry
-	EntryPath    string
-	EntryURL     string
-	EntryPublic  string
+	PublishedVersion PublishedVersion
+	PublishedVersionPath    string
+	PublishedVersionURL     string
+	PublishedVersionPublic  string
 	IndexPath    string
 	IndexURL     string
 	IndexPublic  string
@@ -159,20 +159,20 @@ func ValidatePublishInput(manifest *providermanifestv1.Manifest, version, source
 	return nil
 }
 
-func BuildEntry(input BuildEntryInput) (Entry, error) {
+func BuildPublishedVersion(input BuildPublishedVersionInput) (PublishedVersion, error) {
 	if err := ValidatePublishInput(input.Manifest, input.Version, input.SourceRef); err != nil {
-		return Entry{}, err
+		return PublishedVersion{}, err
 	}
 	if input.Release == nil {
-		return Entry{}, fmt.Errorf("provider release metadata is required")
+		return PublishedVersion{}, fmt.Errorf("provider release metadata is required")
 	}
 	appName, repository, err := parseAppSource(input.Manifest.Source)
 	if err != nil {
-		return Entry{}, err
+		return PublishedVersion{}, err
 	}
 	artifacts, err := buildArtifacts(input.Artifacts)
 	if err != nil {
-		return Entry{}, err
+		return PublishedVersion{}, err
 	}
 	requires := RequiresFromRelease(input.Release)
 	compatibility := CompatibilityFromRelease(input.Release)
@@ -180,8 +180,8 @@ func BuildEntry(input BuildEntryInput) (Entry, error) {
 	if publishedAt.IsZero() {
 		publishedAt = time.Now().UTC()
 	}
-	entry := Entry{
-		SchemaVersion: EntrySchemaVersion,
+	publishedVersion := PublishedVersion{
+		SchemaVersion: PublishedVersionSchemaVersion,
 		App:           appName,
 		Version:       strings.TrimSpace(input.Version),
 		SourceRef:     strings.ToLower(strings.TrimSpace(input.SourceRef)),
@@ -193,13 +193,13 @@ func BuildEntry(input BuildEntryInput) (Entry, error) {
 		Compatibility: compatibility,
 		PublishedAt:   publishedAt.UTC(),
 	}
-	if err := validateEntry(&entry); err != nil {
-		return Entry{}, err
+	if err := validatePublishedVersion(&publishedVersion); err != nil {
+		return PublishedVersion{}, err
 	}
-	return entry, nil
+	return publishedVersion, nil
 }
 
-type BuildEntryInput struct {
+type BuildPublishedVersionInput struct {
 	Manifest     *providermanifestv1.Manifest
 	Version      string
 	SourceRef    string
@@ -302,9 +302,9 @@ func requiresFromProviderRelease(requires providerrelease.Requires) Requires {
 	return Requires{Apps: apps}
 }
 
-// EntriesEqualIgnoringPublishedAt reports whether two entries are identical except
-// for publishedAt, which is ignored for idempotent republish checks.
-func EntriesEqualIgnoringPublishedAt(a, b Entry) bool {
+// PublishedVersionsEqualIgnoringPublishedAt reports whether two published versions are
+// identical except for publishedAt, which is ignored for idempotent republish checks.
+func PublishedVersionsEqualIgnoringPublishedAt(a, b PublishedVersion) bool {
 	a.PublishedAt = time.Time{}
 	b.PublishedAt = time.Time{}
 	aData, err := json.Marshal(a)
@@ -318,58 +318,58 @@ func EntriesEqualIgnoringPublishedAt(a, b Entry) bool {
 	return bytes.Equal(aData, bData)
 }
 
-// EntryFileEquivalentIgnoringPublishedAt compares a local entry JSON file with
-// existing registry bytes, ignoring publishedAt differences.
-func EntryFileEquivalentIgnoringPublishedAt(localPath string, existing []byte) (bool, error) {
+// PublishedVersionFileEquivalentIgnoringPublishedAt compares a local published-version
+// JSON file with existing registry bytes, ignoring publishedAt differences.
+func PublishedVersionFileEquivalentIgnoringPublishedAt(localPath string, existing []byte) (bool, error) {
 	localData, err := os.ReadFile(localPath)
 	if err != nil {
-		return false, fmt.Errorf("read local entry %s: %w", localPath, err)
+		return false, fmt.Errorf("read local published version %s: %w", localPath, err)
 	}
-	localEntry, err := DecodeEntry(localData)
+	localPublishedVersion, err := DecodePublishedVersion(localData)
 	if err != nil {
-		return false, fmt.Errorf("decode local entry: %w", err)
+		return false, fmt.Errorf("decode local published version: %w", err)
 	}
-	existingEntry, err := DecodeEntry(existing)
+	existingPublishedVersion, err := DecodePublishedVersion(existing)
 	if err != nil {
-		return false, fmt.Errorf("decode existing entry: %w", err)
+		return false, fmt.Errorf("decode existing published version: %w", err)
 	}
-	return EntriesEqualIgnoringPublishedAt(*localEntry, *existingEntry), nil
+	return PublishedVersionsEqualIgnoringPublishedAt(*localPublishedVersion, *existingPublishedVersion), nil
 }
 
-func validateEntry(entry *Entry) error {
-	if entry == nil {
-		return fmt.Errorf("registry entry is required")
+func validatePublishedVersion(publishedVersion *PublishedVersion) error {
+	if publishedVersion == nil {
+		return fmt.Errorf("registry published version is required")
 	}
-	if entry.SchemaVersion != EntrySchemaVersion {
-		return fmt.Errorf("unsupported registry entry schema version %d", entry.SchemaVersion)
+	if publishedVersion.SchemaVersion != PublishedVersionSchemaVersion {
+		return fmt.Errorf("unsupported registry published version schema version %d", publishedVersion.SchemaVersion)
 	}
-	if strings.TrimSpace(entry.App) == "" {
-		return fmt.Errorf("registry entry app is required")
+	if strings.TrimSpace(publishedVersion.App) == "" {
+		return fmt.Errorf("registry published version app is required")
 	}
-	if err := source.ValidateVersion(strings.TrimSpace(entry.Version)); err != nil {
-		return fmt.Errorf("registry entry version: %w", err)
+	if err := source.ValidateVersion(strings.TrimSpace(publishedVersion.Version)); err != nil {
+		return fmt.Errorf("registry published version version: %w", err)
 	}
-	if err := validateSourceRef(entry.SourceRef); err != nil {
-		return fmt.Errorf("registry entry sourceRef: %w", err)
+	if err := validateSourceRef(publishedVersion.SourceRef); err != nil {
+		return fmt.Errorf("registry published version sourceRef: %w", err)
 	}
-	if strings.TrimSpace(entry.ManifestPath) == "" {
-		return fmt.Errorf("registry entry manifestPath is required")
+	if strings.TrimSpace(publishedVersion.ManifestPath) == "" {
+		return fmt.Errorf("registry published version manifestPath is required")
 	}
-	if err := validateEntryRepository(entry.Repository, entry.App); err != nil {
-		return fmt.Errorf("registry entry repository: %w", err)
+	if err := validatePublishedVersionRepository(publishedVersion.Repository, publishedVersion.App); err != nil {
+		return fmt.Errorf("registry published version repository: %w", err)
 	}
-	if len(entry.Artifacts) == 0 {
-		return fmt.Errorf("registry entry artifacts are required")
+	if len(publishedVersion.Artifacts) == 0 {
+		return fmt.Errorf("registry published version artifacts are required")
 	}
-	for target, artifact := range entry.Artifacts {
+	for target, artifact := range publishedVersion.Artifacts {
 		if err := validateArtifactPlatform(target); err != nil {
-			return fmt.Errorf("registry entry artifact: %w", err)
+			return fmt.Errorf("registry published version artifact: %w", err)
 		}
 		if strings.TrimSpace(artifact.URL) == "" || strings.TrimSpace(artifact.PublicURL) == "" {
-			return fmt.Errorf("registry entry artifact %q URLs are required", target)
+			return fmt.Errorf("registry published version artifact %q URLs are required", target)
 		}
 		if strings.TrimSpace(artifact.SHA256) == "" {
-			return fmt.Errorf("registry entry artifact %q sha256 is required", target)
+			return fmt.Errorf("registry published version artifact %q sha256 is required", target)
 		}
 	}
 	return nil
@@ -418,15 +418,15 @@ func DecodeIndex(data []byte) (*Index, error) {
 	return &index, nil
 }
 
-func DecodeEntry(data []byte) (*Entry, error) {
-	var entry Entry
-	if err := json.Unmarshal(data, &entry); err != nil {
-		return nil, fmt.Errorf("decode app registry entry: %w", err)
+func DecodePublishedVersion(data []byte) (*PublishedVersion, error) {
+	var publishedVersion PublishedVersion
+	if err := json.Unmarshal(data, &publishedVersion); err != nil {
+		return nil, fmt.Errorf("decode app registry published version: %w", err)
 	}
-	if err := validateEntry(&entry); err != nil {
+	if err := validatePublishedVersion(&publishedVersion); err != nil {
 		return nil, err
 	}
-	return &entry, nil
+	return &publishedVersion, nil
 }
 
 func NewEmptyIndex() *Index {
@@ -459,7 +459,7 @@ func applyAppIndexAppMetadata(app *AppVersions, displayName, description string)
 
 // UpsertAppIndex updates the per-app index for a published version. The second
 // return value reports whether the index was modified.
-func UpsertAppIndex(index *Index, entry Entry, metadataPath string, displayName, description string) (*Index, bool, error) {
+func UpsertAppIndex(index *Index, publishedVersion PublishedVersion, metadataPath string, displayName, description string) (*Index, bool, error) {
 	if index == nil {
 		index = &Index{
 			SchemaVersion: IndexSchemaVersion,
@@ -472,14 +472,14 @@ func UpsertAppIndex(index *Index, entry Entry, metadataPath string, displayName,
 	if index.Apps == nil {
 		index.Apps = map[string]AppVersions{}
 	}
-	appName := strings.TrimSpace(entry.App)
+	appName := strings.TrimSpace(publishedVersion.App)
 	app := index.Apps[appName]
 	if app.Versions == nil {
 		app.Versions = map[string]IndexVersion{}
 	}
-	if existing, ok := app.Versions[entry.Version]; ok {
+	if existing, ok := app.Versions[publishedVersion.Version]; ok {
 		if strings.TrimSpace(existing.Metadata) != strings.TrimSpace(metadataPath) {
-			return nil, false, fmt.Errorf("app %q version %q is already indexed", appName, entry.Version)
+			return nil, false, fmt.Errorf("app %q version %q is already indexed", appName, publishedVersion.Version)
 		}
 		changed := applyAppIndexAppMetadata(&app, displayName, description)
 		if !changed {
@@ -492,12 +492,12 @@ func UpsertAppIndex(index *Index, entry Entry, metadataPath string, displayName,
 		return index, true, nil
 	}
 	applyAppIndexAppMetadata(&app, displayName, description)
-	platforms := artifactPlatforms(entry.Artifacts)
+	platforms := artifactPlatforms(publishedVersion.Artifacts)
 	sort.Strings(platforms)
-	app.Versions[entry.Version] = IndexVersion{
+	app.Versions[publishedVersion.Version] = IndexVersion{
 		Metadata:    strings.TrimSpace(metadataPath),
 		Platforms:   platforms,
-		PublishedAt: entry.PublishedAt.UTC(),
+		PublishedAt: publishedVersion.PublishedAt.UTC(),
 	}
 	index.Apps[appName] = app
 	if err := validateIndex(index); err != nil {
@@ -513,7 +513,7 @@ func AppArtifactPrefix(appName, version string) string {
 type PublishLayout struct {
 	AppName        string
 	ArtifactPrefix string
-	EntryPath      string
+	PublishedVersionPath string
 	IndexPath      string
 }
 
@@ -525,12 +525,12 @@ func ResolvePublishLayout(source, version string) (PublishLayout, error) {
 	return PublishLayout{
 		AppName:        appName,
 		ArtifactPrefix: AppArtifactPrefix(appName, version),
-		EntryPath:      AppVersionEntryPath(appName, version),
+		PublishedVersionPath: PublishedVersionPath(appName, version),
 		IndexPath:      AppIndexPath(appName),
 	}, nil
 }
 
-func AppVersionEntryPath(appName, version string) string {
+func PublishedVersionPath(appName, version string) string {
 	return path.Join("apps", appName, "versions", version+".json")
 }
 
@@ -550,7 +550,7 @@ func StorageURL(storageRoot, rel string) string {
 	return strings.TrimRight(strings.TrimSpace(storageRoot), "/") + "/" + strings.TrimLeft(rel, "/")
 }
 
-func validateEntryRepository(repository, appName string) error {
+func validatePublishedVersionRepository(repository, appName string) error {
 	repository = strings.TrimSpace(repository)
 	appName = strings.TrimSpace(appName)
 	if repository == "" {

--- a/gestaltd/internal/appregistry/registry.go
+++ b/gestaltd/internal/appregistry/registry.go
@@ -20,10 +20,10 @@ import (
 )
 
 const (
-	IndexSchemaVersion  = 1
+	IndexSchemaVersion            = 1
 	PublishedVersionSchemaVersion = 1
-	IndexFileName       = "index.json"
-	appSourcePathPrefix = "apps/"
+	IndexFileName                 = "index.json"
+	appSourcePathPrefix           = "apps/"
 )
 
 type Index struct {
@@ -99,17 +99,17 @@ type PublishArtifact struct {
 }
 
 type PublishPlan struct {
-	RegistryName string
-	AppName      string
-	Version      string
-	PublishedVersion PublishedVersion
-	PublishedVersionPath    string
-	PublishedVersionURL     string
-	PublishedVersionPublic  string
-	IndexPath    string
-	IndexURL     string
-	IndexPublic  string
-	Artifacts    []PublishArtifact
+	RegistryName           string
+	AppName                string
+	Version                string
+	PublishedVersion       PublishedVersion
+	PublishedVersionPath   string
+	PublishedVersionURL    string
+	PublishedVersionPublic string
+	IndexPath              string
+	IndexURL               string
+	IndexPublic            string
+	Artifacts              []PublishArtifact
 }
 
 func parseAppSource(raw string) (appName, repository string, err error) {
@@ -511,10 +511,10 @@ func AppArtifactPrefix(appName, version string) string {
 }
 
 type PublishLayout struct {
-	AppName        string
-	ArtifactPrefix string
+	AppName              string
+	ArtifactPrefix       string
 	PublishedVersionPath string
-	IndexPath      string
+	IndexPath            string
 }
 
 func ResolvePublishLayout(source, version string) (PublishLayout, error) {
@@ -523,10 +523,10 @@ func ResolvePublishLayout(source, version string) (PublishLayout, error) {
 		return PublishLayout{}, err
 	}
 	return PublishLayout{
-		AppName:        appName,
-		ArtifactPrefix: AppArtifactPrefix(appName, version),
+		AppName:              appName,
+		ArtifactPrefix:       AppArtifactPrefix(appName, version),
 		PublishedVersionPath: PublishedVersionPath(appName, version),
-		IndexPath:      AppIndexPath(appName),
+		IndexPath:            AppIndexPath(appName),
 	}, nil
 }
 

--- a/gestaltd/internal/appregistry/registrytest/fixture.go
+++ b/gestaltd/internal/appregistry/registrytest/fixture.go
@@ -1,0 +1,232 @@
+package registrytest
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/internal/appregistry"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/apps/packageio"
+	"github.com/valon-technologies/gestalt/server/services/apps/providerpkg"
+)
+
+const Bucket = "gitlab-peach-street-gestalt-app-registry"
+
+// InstallFixture is a published g-issues registry version with a downloadable archive.
+type InstallFixture struct {
+	Registry     config.AppRegistryConfig
+	Reader       *appregistry.RegistryReader
+	Version      string
+	SHA256       string
+	ArchiveBytes []byte
+}
+
+// NewInstallFixture builds a mock GCS registry with one installable app version.
+func NewInstallFixture(t *testing.T) InstallFixture {
+	t.Helper()
+
+	version := "0.0.0-snapshot.gabc123"
+	sourceRef := "abc123def456abc123def456abc123def456abcd"
+	platform := providerpkg.CurrentPlatformString()
+
+	root := t.TempDir()
+	packageRoot := filepath.Join(root, "package")
+	artifactRel := packageio.PackageExecutablePath("g-issues", runtime.GOOS)
+	artifactPath := filepath.Join(packageRoot, filepath.FromSlash(artifactRel))
+	if err := os.MkdirAll(filepath.Dir(artifactPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(artifactPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	digest, err := packageio.FileSHA256(artifactPath)
+	if err != nil {
+		t.Fatalf("FileSHA256: %v", err)
+	}
+
+	manifest := &providermanifestv1.Manifest{
+		Kind:    providermanifestv1.KindApp,
+		Source:  "github.com/valon-technologies/valon-tools/apps/g-issues",
+		Version: version,
+		Spec:    &providermanifestv1.Spec{},
+		Entrypoint: &providermanifestv1.Entrypoint{
+			ArtifactPath: artifactRel,
+		},
+		Artifacts: []providermanifestv1.Artifact{
+			{
+				OS:     runtime.GOOS,
+				Arch:   runtime.GOARCH,
+				Path:   artifactRel,
+				SHA256: digest,
+			},
+		},
+	}
+	manifestData, err := packageio.EncodeManifestFormat(manifest, packageio.ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("EncodeManifestFormat: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(packageRoot, "manifest.yaml"), manifestData, 0o644); err != nil {
+		t.Fatalf("WriteFile manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(packageRoot, providerpkg.StaticCatalogFile), []byte("name: g-issues\noperations:\n  - id: issues.list\n    method: POST\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile catalog: %v", err)
+	}
+
+	packagePath := filepath.Join(root, "artifact.tar.gz")
+	if err := packageio.CreatePackageFromDir(packageRoot, packagePath); err != nil {
+		t.Fatalf("CreatePackageFromDir: %v", err)
+	}
+	archiveBytes, err := os.ReadFile(packagePath)
+	if err != nil {
+		t.Fatalf("ReadFile package: %v", err)
+	}
+	archiveSHA, err := packageio.FileSHA256(packagePath)
+	if err != nil {
+		t.Fatalf("FileSHA256 package: %v", err)
+	}
+
+	publishedVersion := appregistry.PublishedVersion{
+		SchemaVersion: appregistry.PublishedVersionSchemaVersion,
+		App:           "g-issues",
+		Version:       version,
+		SourceRef:     sourceRef,
+		ManifestPath:  "valon-tools/apps/g-issues/manifest.yaml",
+		Repository:    "github.com/valon-technologies/valon-tools",
+		Artifacts: map[string]appregistry.Artifact{
+			platform: {
+				URL:       "gs://" + Bucket + "/apps/g-issues/artifacts/" + version + "/artifact.tar.gz",
+				PublicURL: "https://storage.googleapis.com/" + Bucket + "/apps/g-issues/artifacts/" + version + "/artifact.tar.gz",
+				SHA256:    archiveSHA,
+			},
+		},
+		PublishedAt: time.Date(2026, 7, 10, 2, 21, 54, 0, time.UTC),
+	}
+	publishedVersionJSON, err := json.Marshal(publishedVersion)
+	if err != nil {
+		t.Fatalf("Marshal published version: %v", err)
+	}
+
+	index := appregistry.Index{
+		SchemaVersion: appregistry.IndexSchemaVersion,
+		Apps: map[string]appregistry.AppVersions{
+			"g-issues": {
+				Versions: map[string]appregistry.IndexVersion{
+					version: {
+						Metadata:    appregistry.PublishedVersionPath("g-issues", version),
+						Platforms:   []string{platform},
+						PublishedAt: publishedVersion.PublishedAt,
+					},
+				},
+			},
+		},
+	}
+	indexJSON, err := json.Marshal(index)
+	if err != nil {
+		t.Fatalf("Marshal index: %v", err)
+	}
+
+	registrySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/" + Bucket + "/apps/g-issues/index.json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(indexJSON)
+		case "/" + Bucket + "/apps/g-issues/versions/" + version + ".json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(publishedVersionJSON)
+		case "/" + Bucket + "/apps/g-issues/artifacts/" + version + "/artifact.tar.gz":
+			w.Header().Set("Content-Type", "application/gzip")
+			_, _ = w.Write(archiveBytes)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(registrySrv.Close)
+
+	registry, err := config.NewGCSAppRegistry(Bucket)
+	if err != nil {
+		t.Fatalf("NewGCSAppRegistry: %v", err)
+	}
+
+	return InstallFixture{
+		Registry:     registry,
+		Reader:       NewReaderForServer(t, registrySrv.URL),
+		Version:      version,
+		SHA256:       archiveSHA,
+		ArchiveBytes: archiveBytes,
+	}
+}
+
+// NewReaderForServer returns a reader that rewrites GCS public URLs to a test server.
+func NewReaderForServer(t *testing.T, serverURL string) *appregistry.RegistryReader {
+	t.Helper()
+	registryHost := strings.TrimPrefix(serverURL, "http://")
+	return &appregistry.RegistryReader{
+		HTTPClient: &http.Client{
+			Transport: &RewriteHostTransport{Host: registryHost, Scheme: "http"},
+		},
+	}
+}
+
+// NewDigestMismatchReader returns a reader whose published version advertises a bad checksum.
+func (f InstallFixture) NewDigestMismatchReader(t *testing.T, version string) *appregistry.RegistryReader {
+	t.Helper()
+
+	publicURL, err := f.Registry.PublicURL()
+	if err != nil {
+		t.Fatalf("PublicURL: %v", err)
+	}
+	publishedVersion, err := f.Reader.FetchPublishedVersion(t.Context(), publicURL, "g-issues", f.Version)
+	if err != nil {
+		t.Fatalf("FetchPublishedVersion: %v", err)
+	}
+	publishedVersion.Version = version
+	platform := providerpkg.CurrentPlatformString()
+	artifact := publishedVersion.Artifacts[platform]
+	artifact.SHA256 = "deadbeef"
+	publishedVersion.Artifacts[platform] = artifact
+	publishedVersionJSON, err := json.Marshal(publishedVersion)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	registrySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/" + Bucket + "/apps/g-issues/versions/" + version + ".json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(publishedVersionJSON)
+		case "/" + Bucket + "/apps/g-issues/artifacts/" + f.Version + "/artifact.tar.gz":
+			w.Header().Set("Content-Type", "application/gzip")
+			_, _ = w.Write(f.ArchiveBytes)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(registrySrv.Close)
+	return NewReaderForServer(t, registrySrv.URL)
+}
+
+// RewriteHostTransport redirects requests to a local test HTTP server.
+type RewriteHostTransport struct {
+	Host   string
+	Scheme string
+	Inner  http.RoundTripper
+}
+
+func (t *RewriteHostTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	clone.URL.Scheme = t.Scheme
+	clone.URL.Host = t.Host
+	inner := t.Inner
+	if inner == nil {
+		inner = http.DefaultTransport
+	}
+	return inner.RoundTrip(clone)
+}

--- a/gestaltd/internal/coredata/app_installations.go
+++ b/gestaltd/internal/coredata/app_installations.go
@@ -152,14 +152,15 @@ func (s *AppInstallationService) CompareAndSwapInstallation(ctx context.Context,
 		return nil, fmt.Errorf("compare and swap app installation: update is required")
 	}
 
-	tx, err := s.db.Transaction(ctx, []string{StoreAppInstallations}, idb.TransactionReadwrite, idb.TransactionOptions{})
+	cleanupCtx := context.WithoutCancel(ctx)
+	tx, err := s.db.Transaction(cleanupCtx, []string{StoreAppInstallations}, idb.TransactionReadwrite, idb.TransactionOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("compare and swap app installation: %w", err)
 	}
 	committed := false
 	defer func() {
 		if !committed {
-			_ = tx.Abort(ctx)
+			_ = tx.Abort(cleanupCtx)
 		}
 	}()
 
@@ -175,7 +176,7 @@ func (s *AppInstallationService) CompareAndSwapInstallation(ctx context.Context,
 		}
 	} else {
 		current = recordToAppInstallation(rec)
-		if !appInstallationMatchesBaseline(current, baseline) {
+		if !InstallationMatchesBaseline(current, baseline) {
 			return nil, ErrInstallationStateConflict
 		}
 	}
@@ -228,7 +229,7 @@ func (s *AppInstallationService) DeleteInstallation(ctx context.Context, appName
 	return nil
 }
 
-func appInstallationMatchesBaseline(current, baseline *core.AppInstallation) bool {
+func InstallationMatchesBaseline(current, baseline *core.AppInstallation) bool {
 	if baseline == nil {
 		return current == nil
 	}

--- a/gestaltd/internal/coredata/app_installations.go
+++ b/gestaltd/internal/coredata/app_installations.go
@@ -13,12 +13,20 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 )
 
+// ErrInstallationStateConflict indicates the stored installation row changed
+// before a compare-and-swap update could commit.
+var ErrInstallationStateConflict = errors.New("app installation state conflict")
+
 type AppInstallationService struct {
+	db    indexeddb.IndexedDB
 	store idb.ObjectStore
 }
 
 func NewAppInstallationService(ds indexeddb.IndexedDB) *AppInstallationService {
-	return &AppInstallationService{store: ds.ObjectStore(StoreAppInstallations)}
+	return &AppInstallationService{
+		db:    ds,
+		store: ds.ObjectStore(StoreAppInstallations),
+	}
 }
 
 func (s *AppInstallationService) GetInstallation(ctx context.Context, appName string) (*core.AppInstallation, error) {
@@ -135,6 +143,80 @@ func (s *AppInstallationService) UpdateInstallation(ctx context.Context, appName
 	return recordToAppInstallation(rec), nil
 }
 
+func (s *AppInstallationService) CompareAndSwapInstallation(ctx context.Context, appName string, baseline *core.AppInstallation, update func(*core.AppInstallation) error) (*core.AppInstallation, error) {
+	appName = strings.TrimSpace(appName)
+	if appName == "" {
+		return nil, fmt.Errorf("compare and swap app installation: app_name is required")
+	}
+	if update == nil {
+		return nil, fmt.Errorf("compare and swap app installation: update is required")
+	}
+
+	tx, err := s.db.Transaction(ctx, []string{StoreAppInstallations}, idb.TransactionReadwrite, idb.TransactionOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("compare and swap app installation: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Abort(ctx)
+		}
+	}()
+
+	store := tx.ObjectStore(StoreAppInstallations)
+	rec, getErr := store.Get(ctx, appName)
+	var current *core.AppInstallation
+	if getErr != nil {
+		if !errors.Is(getErr, idb.ErrNotFound) {
+			return nil, fmt.Errorf("compare and swap app installation: %w", getErr)
+		}
+		if baseline != nil {
+			return nil, ErrInstallationStateConflict
+		}
+	} else {
+		current = recordToAppInstallation(rec)
+		if !appInstallationMatchesBaseline(current, baseline) {
+			return nil, ErrInstallationStateConflict
+		}
+	}
+
+	installation := &core.AppInstallation{AppName: appName}
+	if current != nil {
+		*installation = *current
+	}
+	if err := update(installation); err != nil {
+		return nil, err
+	}
+
+	rolloutStatus := strings.TrimSpace(installation.RolloutStatus)
+	if rolloutStatus == "" {
+		return nil, fmt.Errorf("compare and swap app installation: rollout_status is required")
+	}
+	if err := validateAppInstallationRolloutStatus(rolloutStatus); err != nil {
+		return nil, err
+	}
+
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	if installation.InstalledAt.IsZero() {
+		installation.InstalledAt = now
+	}
+	installation.UpdatedAt = now
+
+	outRec := appInstallationToRecord(installation)
+	outRec["id"] = appName
+	outRec["rollout_status"] = rolloutStatus
+	outRec["installed_at"] = installation.InstalledAt
+	outRec["updated_at"] = now
+	if err := store.Put(ctx, outRec); err != nil {
+		return nil, fmt.Errorf("compare and swap app installation: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("compare and swap app installation: %w", err)
+	}
+	committed = true
+	return recordToAppInstallation(outRec), nil
+}
+
 func (s *AppInstallationService) DeleteInstallation(ctx context.Context, appName string) error {
 	appName = strings.TrimSpace(appName)
 	if appName == "" {
@@ -144,6 +226,18 @@ func (s *AppInstallationService) DeleteInstallation(ctx context.Context, appName
 		return fmt.Errorf("delete app installation: %w", err)
 	}
 	return nil
+}
+
+func appInstallationMatchesBaseline(current, baseline *core.AppInstallation) bool {
+	if baseline == nil {
+		return current == nil
+	}
+	if current == nil {
+		return false
+	}
+	return strings.TrimSpace(current.RolloutStatus) == strings.TrimSpace(baseline.RolloutStatus) &&
+		strings.TrimSpace(current.ResolvedVersion) == strings.TrimSpace(baseline.ResolvedVersion) &&
+		current.UpdatedAt.Equal(baseline.UpdatedAt)
 }
 
 func validateAppInstallationRolloutStatus(rolloutStatus string) error {

--- a/gestaltd/internal/coredata/app_installations_test.go
+++ b/gestaltd/internal/coredata/app_installations_test.go
@@ -2,6 +2,7 @@ package coredata_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -159,6 +160,37 @@ func TestAppInstallationService(t *testing.T) {
 		}
 		if updated.RolloutStatus != core.AppInstallationRolloutStatusPromoted {
 			t.Fatalf("RolloutStatus = %q, want promoted", updated.RolloutStatus)
+		}
+	})
+
+	t.Run("CompareAndSwapInstallation_rejects_stale_baseline", func(t *testing.T) {
+		t.Parallel()
+		svc, err := coredata.New(&coretesting.StubIndexedDB{})
+		if err != nil {
+			t.Fatalf("coredata.New: %v", err)
+		}
+		ctx := context.Background()
+		stored, err := svc.AppInstallations.PutInstallation(ctx, &core.AppInstallation{
+			AppName:         "g-issues",
+			RolloutStatus:   core.AppInstallationRolloutStatusPromoted,
+			ResolvedVersion: "v1",
+		})
+		if err != nil {
+			t.Fatalf("PutInstallation: %v", err)
+		}
+
+		staleBaseline := &core.AppInstallation{
+			AppName:         stored.AppName,
+			RolloutStatus:   stored.RolloutStatus,
+			ResolvedVersion: stored.ResolvedVersion,
+			UpdatedAt:       stored.UpdatedAt.Add(-time.Second),
+		}
+		_, err = svc.AppInstallations.CompareAndSwapInstallation(ctx, "g-issues", staleBaseline, func(installation *core.AppInstallation) error {
+			installation.RolloutStatus = core.AppInstallationRolloutStatusPending
+			return nil
+		})
+		if !errors.Is(err, coredata.ErrInstallationStateConflict) {
+			t.Fatalf("CompareAndSwapInstallation error = %v, want ErrInstallationStateConflict", err)
 		}
 	})
 

--- a/gestaltd/internal/daemon/app_publish.go
+++ b/gestaltd/internal/daemon/app_publish.go
@@ -45,8 +45,8 @@ type appPublishPlan struct {
 	DisplayName     string             `json:"displayName,omitempty"`
 	Description     string             `json:"description,omitempty"`
 	Version         string             `json:"version"`
-	Entry           appregistry.Entry  `json:"entry"`
-	EntryObject     appPublishObject   `json:"entryObject"`
+	PublishedVersion           appregistry.PublishedVersion `json:"publishedVersion"`
+	PublishedVersionObject     appPublishObject             `json:"publishedVersionObject"`
 	IndexObject     appPublishObject   `json:"indexObject"`
 	ArtifactObjects []appPublishObject `json:"artifactObjects"`
 }
@@ -166,7 +166,7 @@ func runAppPublish(args []string) (err error) {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = os.Remove(plan.EntryObject.LocalPath) }()
+	defer func() { _ = os.Remove(plan.PublishedVersionObject.LocalPath) }()
 
 	if *dryRun {
 		return printAppPublishPlanJSON(plan)
@@ -370,7 +370,7 @@ func buildAppPublishPlan(input appPublishPlanInput) (appPublishPlan, error) {
 		})
 	}
 
-	entry, err := appregistry.BuildEntry(appregistry.BuildEntryInput{
+	publishedVersion, err := appregistry.BuildPublishedVersion(appregistry.BuildPublishedVersionInput{
 		Manifest:     input.Manifest,
 		Version:      input.Version,
 		SourceRef:    input.SourceRef,
@@ -382,16 +382,16 @@ func buildAppPublishPlan(input appPublishPlanInput) (appPublishPlan, error) {
 		return appPublishPlan{}, err
 	}
 
-	entryRel := layout.EntryPath
-	entryData, err := json.MarshalIndent(entry, "", "  ")
+	publishedVersionRel := layout.PublishedVersionPath
+	publishedVersionData, err := json.MarshalIndent(publishedVersion, "", "  ")
 	if err != nil {
 		return appPublishPlan{}, err
 	}
-	entryPath, err := writeTempJSON("gestalt-app-entry-*", entryData)
+	publishedVersionPath, err := writeTempJSON("gestalt-app-published-version-*", publishedVersionData)
 	if err != nil {
 		return appPublishPlan{}, err
 	}
-	entryDigest, err := sha256File(entryPath)
+	publishedVersionDigest, err := sha256File(publishedVersionPath)
 	if err != nil {
 		return appPublishPlan{}, err
 	}
@@ -399,17 +399,17 @@ func buildAppPublishPlan(input appPublishPlanInput) (appPublishPlan, error) {
 	indexRel := layout.IndexPath
 	return appPublishPlan{
 		Schema:      appPublishPlanSchema,
-		AppName:     entry.App,
+		AppName:     publishedVersion.App,
 		DisplayName: input.DisplayName,
 		Description: input.Description,
 		Version:     input.Version,
-		Entry:       entry,
-		EntryObject: appPublishObject{
-			Kind:       "entry",
-			LocalPath:  entryPath,
-			StorageURL: appregistry.StorageURL(storageRoot, entryRel),
-			PublicURL:  appregistry.PublicURL(publicRoot, entryRel),
-			SHA256:     entryDigest,
+		PublishedVersion:       publishedVersion,
+		PublishedVersionObject: appPublishObject{
+			Kind:       "publishedVersion",
+			LocalPath:  publishedVersionPath,
+			StorageURL: appregistry.StorageURL(storageRoot, publishedVersionRel),
+			PublicURL:  appregistry.PublicURL(publicRoot, publishedVersionRel),
+			SHA256:     publishedVersionDigest,
 		},
 		IndexObject: appPublishObject{
 			Kind:       "index",
@@ -442,7 +442,7 @@ func preflightAppPublishPlan(plan appPublishPlan) error {
 	if err := preflightAppRegistryIndex(plan); err != nil {
 		return err
 	}
-	for _, object := range append([]appPublishObject{plan.EntryObject}, plan.ArtifactObjects...) {
+	for _, object := range append([]appPublishObject{plan.PublishedVersionObject}, plan.ArtifactObjects...) {
 		if err := preflightAppPublishObject(object); err != nil {
 			return err
 		}
@@ -464,8 +464,8 @@ func preflightAppRegistryIndex(plan appPublishPlan) error {
 			return fmt.Errorf("decode existing app index: %w", err)
 		}
 	}
-	metadataPath := appregistry.AppVersionEntryPath(plan.AppName, plan.Version)
-	_, _, err = appregistry.UpsertAppIndex(index, plan.Entry, metadataPath, plan.DisplayName, plan.Description)
+	metadataPath := appregistry.PublishedVersionPath(plan.AppName, plan.Version)
+	_, _, err = appregistry.UpsertAppIndex(index, plan.PublishedVersion, metadataPath, plan.DisplayName, plan.Description)
 	return err
 }
 
@@ -500,7 +500,7 @@ func uploadAppPublishImmutableObjects(plan appPublishPlan, sourceRef string) err
 			return err
 		}
 	}
-	return uploadAppPublishObjectIfNeeded(plan.EntryObject, sourceRef)
+	return uploadAppPublishObjectIfNeeded(plan.PublishedVersionObject, sourceRef)
 }
 
 func uploadAppPublishObjectIfNeeded(object appPublishObject, sourceRef string) error {
@@ -526,12 +526,12 @@ func appPublishObjectMatchesExisting(object appPublishObject) (bool, error) {
 	if object.SHA256 != "" && existingSHA == object.SHA256 {
 		return true, nil
 	}
-	if object.Kind == "entry" && object.LocalPath != "" {
+	if object.Kind == "publishedVersion" && object.LocalPath != "" {
 		_, existing, err := downloadAppRegistryObject(object.StorageURL)
 		if err != nil {
 			return false, err
 		}
-		return appregistry.EntryFileEquivalentIgnoringPublishedAt(object.LocalPath, existing)
+		return appregistry.PublishedVersionFileEquivalentIgnoringPublishedAt(object.LocalPath, existing)
 	}
 	return false, nil
 }
@@ -564,8 +564,8 @@ func uploadAppRegistryIndex(plan appPublishPlan, sourceRef string) error {
 				return fmt.Errorf("decode existing app index: %w", err)
 			}
 		}
-		metadataPath := appregistry.AppVersionEntryPath(plan.AppName, plan.Version)
-		updated, changed, err := appregistry.UpsertAppIndex(index, plan.Entry, metadataPath, plan.DisplayName, plan.Description)
+		metadataPath := appregistry.PublishedVersionPath(plan.AppName, plan.Version)
+		updated, changed, err := appregistry.UpsertAppIndex(index, plan.PublishedVersion, metadataPath, plan.DisplayName, plan.Description)
 		if err != nil {
 			return err
 		}

--- a/gestaltd/internal/daemon/app_publish.go
+++ b/gestaltd/internal/daemon/app_publish.go
@@ -40,15 +40,15 @@ func (d *appPublishDistDirs) Set(value string) error {
 }
 
 type appPublishPlan struct {
-	Schema          string             `json:"schema"`
-	AppName         string             `json:"appName"`
-	DisplayName     string             `json:"displayName,omitempty"`
-	Description     string             `json:"description,omitempty"`
-	Version         string             `json:"version"`
-	PublishedVersion           appregistry.PublishedVersion `json:"publishedVersion"`
-	PublishedVersionObject     appPublishObject             `json:"publishedVersionObject"`
-	IndexObject     appPublishObject   `json:"indexObject"`
-	ArtifactObjects []appPublishObject `json:"artifactObjects"`
+	Schema                 string                       `json:"schema"`
+	AppName                string                       `json:"appName"`
+	DisplayName            string                       `json:"displayName,omitempty"`
+	Description            string                       `json:"description,omitempty"`
+	Version                string                       `json:"version"`
+	PublishedVersion       appregistry.PublishedVersion `json:"publishedVersion"`
+	PublishedVersionObject appPublishObject             `json:"publishedVersionObject"`
+	IndexObject            appPublishObject             `json:"indexObject"`
+	ArtifactObjects        []appPublishObject           `json:"artifactObjects"`
 }
 
 const appPublishIndexUpdateAttempts = 5
@@ -398,12 +398,12 @@ func buildAppPublishPlan(input appPublishPlanInput) (appPublishPlan, error) {
 
 	indexRel := layout.IndexPath
 	return appPublishPlan{
-		Schema:      appPublishPlanSchema,
-		AppName:     publishedVersion.App,
-		DisplayName: input.DisplayName,
-		Description: input.Description,
-		Version:     input.Version,
-		PublishedVersion:       publishedVersion,
+		Schema:           appPublishPlanSchema,
+		AppName:          publishedVersion.App,
+		DisplayName:      input.DisplayName,
+		Description:      input.Description,
+		Version:          input.Version,
+		PublishedVersion: publishedVersion,
 		PublishedVersionObject: appPublishObject{
 			Kind:       "publishedVersion",
 			LocalPath:  publishedVersionPath,

--- a/gestaltd/internal/daemon/e2e/app_publish/app_publish_test.go
+++ b/gestaltd/internal/daemon/e2e/app_publish/app_publish_test.go
@@ -33,9 +33,9 @@ func TestRun_AppPublishDryRunPlansVersionedRegistryUploads(t *testing.T) {
 		t.Fatalf("app publish failed: %v\n%s", err, out)
 	}
 	var plan struct {
-		Schema      string `json:"schema"`
-		AppName     string `json:"appName"`
-		Version     string `json:"version"`
+		Schema                 string `json:"schema"`
+		AppName                string `json:"appName"`
+		Version                string `json:"version"`
 		PublishedVersionObject struct {
 			PublicURL string `json:"publicUrl"`
 		} `json:"publishedVersionObject"`

--- a/gestaltd/internal/daemon/e2e/app_publish/app_publish_test.go
+++ b/gestaltd/internal/daemon/e2e/app_publish/app_publish_test.go
@@ -36,9 +36,9 @@ func TestRun_AppPublishDryRunPlansVersionedRegistryUploads(t *testing.T) {
 		Schema      string `json:"schema"`
 		AppName     string `json:"appName"`
 		Version     string `json:"version"`
-		EntryObject struct {
+		PublishedVersionObject struct {
 			PublicURL string `json:"publicUrl"`
-		} `json:"entryObject"`
+		} `json:"publishedVersionObject"`
 		ArtifactObjects []struct {
 			StorageURL string `json:"storageUrl"`
 		} `json:"artifactObjects"`
@@ -58,9 +58,9 @@ func TestRun_AppPublishDryRunPlansVersionedRegistryUploads(t *testing.T) {
 	if plan.Version != version {
 		t.Fatalf("version = %q", plan.Version)
 	}
-	wantEntry := "https://storage.googleapis.com/gestalt-app-registry/apps/" + releaseTestAppName + "/versions/" + version + ".json"
-	if plan.EntryObject.PublicURL != wantEntry {
-		t.Fatalf("entry publicUrl = %q, want %q", plan.EntryObject.PublicURL, wantEntry)
+	wantPublishedVersion := "https://storage.googleapis.com/gestalt-app-registry/apps/" + releaseTestAppName + "/versions/" + version + ".json"
+	if plan.PublishedVersionObject.PublicURL != wantPublishedVersion {
+		t.Fatalf("publishedVersion publicUrl = %q, want %q", plan.PublishedVersionObject.PublicURL, wantPublishedVersion)
 	}
 	archiveName := platformArchiveNameForTest(releaseTestAppName, version, runtime.GOOS, runtime.GOARCH)
 	wantArtifact := "gs://gestalt-app-registry/apps/" + releaseTestAppName + "/artifacts/" + version + "/" + archiveName

--- a/gestaltd/internal/operator/package_install.go
+++ b/gestaltd/internal/operator/package_install.go
@@ -19,6 +19,37 @@ type installedPackage struct {
 	Manifest       *providermanifestv1.Manifest
 }
 
+// InstalledPackage is the on-disk layout after extracting a published app archive.
+type InstalledPackage struct {
+	Root           string
+	ManifestPath   string
+	ExecutablePath string
+	AssetRoot      string
+	Manifest       *providermanifestv1.Manifest
+}
+
+func installedPackageView(pkg *installedPackage) *InstalledPackage {
+	if pkg == nil {
+		return nil
+	}
+	return &InstalledPackage{
+		Root:           pkg.Root,
+		ManifestPath:   pkg.ManifestPath,
+		ExecutablePath: pkg.ExecutablePath,
+		AssetRoot:      pkg.AssetRoot,
+		Manifest:       pkg.Manifest,
+	}
+}
+
+// InstallPublishedPackage extracts a published app archive into destDir.
+func InstallPublishedPackage(packagePath, destDir, configuredName string) (*InstalledPackage, error) {
+	pkg, err := installPackageAs(packagePath, destDir, configuredName)
+	if err != nil {
+		return nil, err
+	}
+	return installedPackageView(pkg), nil
+}
+
 func isAssetOnly(manifest *providermanifestv1.Manifest) bool {
 	if manifest == nil || manifest.Spec == nil || strings.TrimSpace(manifest.Spec.AssetRoot) == "" {
 		return false

--- a/gestaltd/internal/providerrelease/contract.go
+++ b/gestaltd/internal/providerrelease/contract.go
@@ -8,7 +8,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// Requires and Compatibility mirror app registry entry contract fields. They are
+// Requires and Compatibility mirror app registry published-version contract fields. They are
 // snapshotted into provider-release.yaml at release finalization time.
 type Requires struct {
 	Apps map[string]AppRequirement `yaml:"apps,omitempty" json:"apps,omitempty"`

--- a/gestaltd/internal/server/handlers_admin_app_install.go
+++ b/gestaltd/internal/server/handlers_admin_app_install.go
@@ -208,9 +208,6 @@ func newAppRegistryInstaller(cfg Config) *appregistry.Installer {
 	if cfg.Services == nil || cfg.Services.AppInstallations == nil || cfg.Services.AppInstallationEvents == nil {
 		return nil
 	}
-	if len(cfg.AppRegistries) == 0 {
-		return nil
-	}
 	reader := cfg.AppRegistryReader
 	if reader == nil {
 		reader = &appregistry.RegistryReader{}

--- a/gestaltd/internal/server/handlers_admin_app_install.go
+++ b/gestaltd/internal/server/handlers_admin_app_install.go
@@ -60,7 +60,11 @@ func (s *Server) listAdminAppInstallations(w http.ResponseWriter, r *http.Reques
 	rolloutStatus := strings.TrimSpace(r.URL.Query().Get("rolloutStatus"))
 	installations, err := s.appRegistryInstaller.Installations.ListInstallations(r.Context(), rolloutStatus)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "failed to list app installations")
+		status := http.StatusInternalServerError
+		if strings.Contains(err.Error(), "unsupported rollout_status") {
+			status = http.StatusBadRequest
+		}
+		writeError(w, status, "failed to list app installations")
 		return
 	}
 	out := make([]adminAppInstallationInfo, 0, len(installations))

--- a/gestaltd/internal/server/handlers_admin_app_install.go
+++ b/gestaltd/internal/server/handlers_admin_app_install.go
@@ -1,0 +1,221 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/appregistry"
+	"github.com/valon-technologies/gestalt/server/internal/providerregistry"
+)
+
+type adminAppInstallationInfo struct {
+	AppName                 string            `json:"app"`
+	VersionConstraint       string            `json:"versionConstraint,omitempty"`
+	ResolvedVersion         string            `json:"resolvedVersion,omitempty"`
+	SourceRef               string            `json:"sourceRef,omitempty"`
+	Registry                string            `json:"registry,omitempty"`
+	ProviderReleaseURL      string            `json:"providerReleaseUrl,omitempty"`
+	ArtifactChecksums       map[string]string `json:"artifactChecksums,omitempty"`
+	RolloutStatus           string            `json:"rolloutStatus"`
+	ActiveSince             *string           `json:"activeSince,omitempty"`
+	PreviousResolvedVersion string            `json:"previousResolvedVersion,omitempty"`
+	InstalledBy             string            `json:"installedBy,omitempty"`
+	InstalledAt             string            `json:"installedAt,omitempty"`
+	UpdatedAt               string            `json:"updatedAt,omitempty"`
+}
+
+type adminAppRegistryInstallRequest struct {
+	Version string `json:"version"`
+	Actor   string `json:"actor,omitempty"`
+}
+
+type adminAppRegistryInstallResponse struct {
+	Registry         string                   `json:"registry"`
+	App              string                   `json:"app"`
+	Installation     adminAppInstallationInfo `json:"installation"`
+	MaterializedPath string                   `json:"materializedPath"`
+}
+
+func (s *Server) mountAdminAppInstallReadRoutes(r chi.Router) {
+	r.Get("/app-installations", s.listAdminAppInstallations)
+	r.Get("/app-installations/{app}", s.getAdminAppInstallation)
+}
+
+func (s *Server) mountAdminAppInstallWriteRoutes(r chi.Router) {
+	r.Post("/app-registries/{registry}/apps/{app}/install", s.installAdminAppRegistryApp)
+}
+
+func (s *Server) listAdminAppInstallations(w http.ResponseWriter, r *http.Request) {
+	if s.appRegistryInstaller == nil || s.appRegistryInstaller.Installations == nil {
+		writeError(w, http.StatusServiceUnavailable, "app installation service is unavailable")
+		return
+	}
+	rolloutStatus := strings.TrimSpace(r.URL.Query().Get("rolloutStatus"))
+	installations, err := s.appRegistryInstaller.Installations.ListInstallations(r.Context(), rolloutStatus)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "failed to list app installations")
+		return
+	}
+	out := make([]adminAppInstallationInfo, 0, len(installations))
+	for _, installation := range installations {
+		out = append(out, adminAppInstallationFromCore(installation))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (s *Server) getAdminAppInstallation(w http.ResponseWriter, r *http.Request) {
+	if s.appRegistryInstaller == nil || s.appRegistryInstaller.Installations == nil {
+		writeError(w, http.StatusServiceUnavailable, "app installation service is unavailable")
+		return
+	}
+	appName := strings.TrimSpace(chi.URLParam(r, "app"))
+	if appName == "" {
+		writeError(w, http.StatusBadRequest, "app is required")
+		return
+	}
+	if err := providerregistry.ValidateRepositoryName(appName); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid app name")
+		return
+	}
+	installation, err := s.appRegistryInstaller.Installations.GetInstallation(r.Context(), appName)
+	if err != nil {
+		if err == core.ErrNotFound {
+			writeError(w, http.StatusNotFound, "app installation not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to load app installation")
+		return
+	}
+	writeJSON(w, http.StatusOK, adminAppInstallationFromCore(installation))
+}
+
+func (s *Server) installAdminAppRegistryApp(w http.ResponseWriter, r *http.Request) {
+	if s.appRegistryInstaller == nil {
+		writeError(w, http.StatusServiceUnavailable, "app registry installer is unavailable")
+		return
+	}
+	registryName := strings.TrimSpace(chi.URLParam(r, "registry"))
+	appName := strings.TrimSpace(chi.URLParam(r, "app"))
+	if registryName == "" {
+		writeError(w, http.StatusBadRequest, "registry is required")
+		return
+	}
+	if appName == "" {
+		writeError(w, http.StatusBadRequest, "app is required")
+		return
+	}
+	if err := providerregistry.ValidateRepositoryName(appName); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid app name")
+		return
+	}
+	if len(s.appRegistries) == 0 {
+		writeError(w, http.StatusNotFound, "app registry not found")
+		return
+	}
+	if _, ok := s.appRegistries[registryName]; !ok {
+		writeError(w, http.StatusNotFound, "app registry not found")
+		return
+	}
+
+	var req adminAppRegistryInstallRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	version := strings.TrimSpace(req.Version)
+	if version == "" {
+		writeError(w, http.StatusBadRequest, "version is required")
+		return
+	}
+
+	result, err := s.appRegistryInstaller.Install(r.Context(), appregistry.InstallInput{
+		Registry: registryName,
+		App:      appName,
+		Version:  version,
+		Actor:    strings.TrimSpace(req.Actor),
+	})
+	if err != nil {
+		status := http.StatusBadGateway
+		switch {
+		case strings.Contains(err.Error(), "app registry not found"):
+			status = http.StatusNotFound
+		case strings.Contains(err.Error(), "artifacts directory is not configured"):
+			status = http.StatusInternalServerError
+		case strings.Contains(err.Error(), "invalid app name"),
+			strings.Contains(err.Error(), "registry is required"),
+			strings.Contains(err.Error(), "app is required"),
+			strings.Contains(err.Error(), "version is required"),
+			strings.Contains(err.Error(), "unsupported app registry kind"):
+			status = http.StatusBadRequest
+		case errors.Is(err, appregistry.ErrRegistryDocumentNotFound):
+			status = http.StatusNotFound
+		case errors.Is(err, appregistry.ErrInstallFleetStateAdvanced):
+			status = http.StatusConflict
+		}
+		writeError(w, status, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, adminAppRegistryInstallResponse{
+		Registry:         registryName,
+		App:              appName,
+		Installation:     adminAppInstallationFromCore(result.Installation),
+		MaterializedPath: result.MaterializedPath,
+	})
+}
+
+func adminAppInstallationFromCore(installation *core.AppInstallation) adminAppInstallationInfo {
+	if installation == nil {
+		return adminAppInstallationInfo{}
+	}
+	info := adminAppInstallationInfo{
+		AppName:                 installation.AppName,
+		VersionConstraint:       installation.VersionConstraint,
+		ResolvedVersion:         installation.ResolvedVersion,
+		SourceRef:               installation.SourceRef,
+		Registry:                installation.Registry,
+		ProviderReleaseURL:      installation.ProviderReleaseURL,
+		ArtifactChecksums:       installation.ArtifactChecksums,
+		RolloutStatus:           installation.RolloutStatus,
+		PreviousResolvedVersion: installation.PreviousResolvedVersion,
+		InstalledBy:             installation.InstalledBy,
+	}
+	if installation.ActiveSince != nil {
+		formatted := installation.ActiveSince.UTC().Format(time.RFC3339)
+		info.ActiveSince = &formatted
+	}
+	if !installation.InstalledAt.IsZero() {
+		info.InstalledAt = installation.InstalledAt.UTC().Format(time.RFC3339)
+	}
+	if !installation.UpdatedAt.IsZero() {
+		info.UpdatedAt = installation.UpdatedAt.UTC().Format(time.RFC3339)
+	}
+	return info
+}
+
+func newAppRegistryInstaller(cfg Config) *appregistry.Installer {
+	if cfg.Services == nil || cfg.Services.AppInstallations == nil || cfg.Services.AppInstallationEvents == nil {
+		return nil
+	}
+	if len(cfg.AppRegistries) == 0 {
+		return nil
+	}
+	reader := cfg.AppRegistryReader
+	if reader == nil {
+		reader = &appregistry.RegistryReader{}
+	}
+	return &appregistry.Installer{
+		Registries:    cloneAppRegistryConfig(cfg.AppRegistries),
+		Reader:        reader,
+		Installations: cfg.Services.AppInstallations,
+		Events:        cfg.Services.AppInstallationEvents,
+		ArtifactsDir:  strings.TrimSpace(cfg.ArtifactsDir),
+	}
+}

--- a/gestaltd/internal/server/handlers_admin_app_install_test.go
+++ b/gestaltd/internal/server/handlers_admin_app_install_test.go
@@ -120,4 +120,30 @@ func TestAdminAppRegistryInstall(t *testing.T) {
 			t.Fatalf("install status = %d, want 404: %s", resp.StatusCode, raw)
 		}
 	})
+
+	t.Run("invalid_rollout_status_returns_bad_request", func(t *testing.T) {
+		t.Parallel()
+
+		registry, err := config.NewGCSAppRegistry(registrytest.Bucket)
+		if err != nil {
+			t.Fatalf("NewGCSAppRegistry: %v", err)
+		}
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.AppRegistries = map[string]config.AppRegistryConfig{
+				"toolshed": registry,
+			}
+			cfg.ArtifactsDir = t.TempDir()
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		resp, err := http.Get(ts.URL + "/admin/api/v1/app-installations?rolloutStatus=invalid")
+		if err != nil {
+			t.Fatalf("GET app-installations: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusBadRequest {
+			raw, _ := io.ReadAll(resp.Body)
+			t.Fatalf("list status = %d, want 400: %s", resp.StatusCode, raw)
+		}
+	})
 }

--- a/gestaltd/internal/server/handlers_admin_app_install_test.go
+++ b/gestaltd/internal/server/handlers_admin_app_install_test.go
@@ -146,4 +146,41 @@ func TestAdminAppRegistryInstall(t *testing.T) {
 			t.Fatalf("list status = %d, want 400: %s", resp.StatusCode, raw)
 		}
 	})
+
+	t.Run("list_works_without_app_registries", func(t *testing.T) {
+		t.Parallel()
+
+		ts := newTestServer(t)
+		testutil.CloseOnCleanup(t, ts)
+
+		listResp, err := http.Get(ts.URL + "/admin/api/v1/app-installations")
+		if err != nil {
+			t.Fatalf("GET app-installations: %v", err)
+		}
+		defer func() { _ = listResp.Body.Close() }()
+		if listResp.StatusCode != http.StatusOK {
+			raw, _ := io.ReadAll(listResp.Body)
+			t.Fatalf("list status = %d, want 200: %s", listResp.StatusCode, raw)
+		}
+	})
+
+	t.Run("install_without_app_registries_returns_not_found", func(t *testing.T) {
+		t.Parallel()
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.ArtifactsDir = t.TempDir()
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		body := []byte(`{"version":"0.0.0-snapshot.v1"}`)
+		resp, err := http.Post(ts.URL+"/admin/api/v1/app-registries/toolshed/apps/g-issues/install", "application/json", bytes.NewReader(body))
+		if err != nil {
+			t.Fatalf("POST install: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusNotFound {
+			raw, _ := io.ReadAll(resp.Body)
+			t.Fatalf("install status = %d, want 404: %s", resp.StatusCode, raw)
+		}
+	})
 }

--- a/gestaltd/internal/server/handlers_admin_app_install_test.go
+++ b/gestaltd/internal/server/handlers_admin_app_install_test.go
@@ -1,0 +1,123 @@
+package server_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/appregistry/registrytest"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/server"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+)
+
+func TestAdminAppRegistryInstall(t *testing.T) {
+	t.Parallel()
+
+	t.Run("promotes_and_lists_installation", func(t *testing.T) {
+		t.Parallel()
+
+		fixture := registrytest.NewInstallFixture(t)
+		artifactsDir := t.TempDir()
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.AppRegistries = map[string]config.AppRegistryConfig{
+				"toolshed": fixture.Registry,
+			}
+			cfg.AppRegistryReader = fixture.Reader
+			cfg.ArtifactsDir = artifactsDir
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		body := []byte(`{"version":"` + fixture.Version + `","actor":"user:alice"}`)
+		resp, err := http.Post(ts.URL+"/admin/api/v1/app-registries/toolshed/apps/g-issues/install", "application/json", bytes.NewReader(body))
+		if err != nil {
+			t.Fatalf("POST install: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			raw, _ := io.ReadAll(resp.Body)
+			t.Fatalf("install status = %d: %s", resp.StatusCode, raw)
+		}
+
+		var payload struct {
+			Registry         string `json:"registry"`
+			App              string `json:"app"`
+			MaterializedPath string `json:"materializedPath"`
+			Installation     struct {
+				RolloutStatus   string `json:"rolloutStatus"`
+				ResolvedVersion string `json:"resolvedVersion"`
+			} `json:"installation"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode install response: %v", err)
+		}
+		if payload.Registry != "toolshed" || payload.App != "g-issues" {
+			t.Fatalf("payload = %#v", payload)
+		}
+		if payload.Installation.RolloutStatus != core.AppInstallationRolloutStatusPromoted {
+			t.Fatalf("installation.rolloutStatus = %q", payload.Installation.RolloutStatus)
+		}
+		if payload.Installation.ResolvedVersion != fixture.Version {
+			t.Fatalf("installation.resolvedVersion = %q", payload.Installation.ResolvedVersion)
+		}
+		if payload.MaterializedPath == "" {
+			t.Fatal("materializedPath is empty")
+		}
+
+		listResp, err := http.Get(ts.URL + "/admin/api/v1/app-installations")
+		if err != nil {
+			t.Fatalf("GET app-installations: %v", err)
+		}
+		defer func() { _ = listResp.Body.Close() }()
+		if listResp.StatusCode != http.StatusOK {
+			raw, _ := io.ReadAll(listResp.Body)
+			t.Fatalf("list status = %d: %s", listResp.StatusCode, raw)
+		}
+		var installations []map[string]any
+		if err := json.NewDecoder(listResp.Body).Decode(&installations); err != nil {
+			t.Fatalf("decode installations: %v", err)
+		}
+		if len(installations) != 1 {
+			t.Fatalf("installations = %#v", installations)
+		}
+	})
+
+	t.Run("missing_version_returns_not_found", func(t *testing.T) {
+		t.Parallel()
+
+		registrySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.NotFound(w, r)
+		}))
+		defer registrySrv.Close()
+
+		reader := registrytest.NewReaderForServer(t, registrySrv.URL)
+		registry, err := config.NewGCSAppRegistry(registrytest.Bucket)
+		if err != nil {
+			t.Fatalf("NewGCSAppRegistry: %v", err)
+		}
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.AppRegistries = map[string]config.AppRegistryConfig{
+				"toolshed": registry,
+			}
+			cfg.AppRegistryReader = reader
+			cfg.ArtifactsDir = t.TempDir()
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		body := []byte(`{"version":"missing-version"}`)
+		resp, err := http.Post(ts.URL+"/admin/api/v1/app-registries/toolshed/apps/g-issues/install", "application/json", bytes.NewReader(body))
+		if err != nil {
+			t.Fatalf("POST install: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusNotFound {
+			raw, _ := io.ReadAll(resp.Body)
+			t.Fatalf("install status = %d, want 404: %s", resp.StatusCode, raw)
+		}
+	})
+}

--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -93,10 +93,17 @@ func (s *Server) mountAdminUIRoutes(r chi.Router) {
 
 func (s *Server) mountAdminAPIRoutes(r chi.Router) {
 	r.Route("/admin/api/v1", func(r chi.Router) {
-		r.Use(middleware.Timeout(60 * time.Second))
 		r.Use(s.adminAPIAuthMiddleware)
-		s.mountAdminRuntimeRoutes(r)
-		s.mountAdminAppRegistryRoutes(r)
+		r.Group(func(r chi.Router) {
+			r.Use(middleware.Timeout(60 * time.Second))
+			s.mountAdminRuntimeRoutes(r)
+			s.mountAdminAppRegistryRoutes(r)
+			s.mountAdminAppInstallReadRoutes(r)
+		})
+		r.Group(func(r chi.Router) {
+			r.Use(middleware.Timeout(10 * time.Minute))
+			s.mountAdminAppInstallWriteRoutes(r)
+		})
 	})
 }
 

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -113,6 +113,7 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 			AllowedRoles:        append([]string(nil), cfg.Server.Admin.AllowedRoles...),
 		},
 		AppRegistries: cfg.AppRegistries,
+		ArtifactsDir:  cfg.Server.ArtifactsDir,
 	}
 
 	if err := result.Start(ctx); err != nil {

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -145,6 +145,7 @@ type Server struct {
 	adminUI                http.Handler
 	appRegistries          map[string]config.AppRegistryConfig
 	appRegistryReader      *appregistry.RegistryReader
+	appRegistryInstaller   *appregistry.Installer
 	routeProfile           RouteProfile
 	activateAppProviders   func(context.Context)
 }
@@ -201,6 +202,7 @@ type Config struct {
 	BuiltinAdminUI         *BuiltinAdminUIOptions
 	AppRegistries          map[string]config.AppRegistryConfig
 	AppRegistryReader      *appregistry.RegistryReader
+	ArtifactsDir           string
 	RouteProfile           RouteProfile
 	MeterProvider          metric.MeterProvider
 	TracerProvider         trace.TracerProvider
@@ -395,6 +397,7 @@ func New(cfg Config) (*Server, error) {
 		adminUI:                adminUI,
 		appRegistries:          cloneAppRegistryConfig(cfg.AppRegistries),
 		appRegistryReader:      cfg.AppRegistryReader,
+		appRegistryInstaller:   newAppRegistryInstaller(cfg),
 		routeProfile:           cfg.RouteProfile,
 		activateAppProviders:   cfg.ActivateAppProviders,
 	}


### PR DESCRIPTION
## Summary

Implements [plan step 6](https://github.com/valon-technologies/gestalt/blob/main/plans/app_registry/plan.md): prototype installing one registry app by writing shared install state and materializing it on the handling instance.

- Add `appregistry.Installer` to fetch a version entry, write `pending` → `promoted` (or `failed`) rows in `app_installations`, append lifecycle events to `app_installation_events`, download the platform artifact, verify SHA256, and extract it under `{artifactsDir}/registry-installed/{app}/{version}/`.
- Extend `RegistryReader` with `FetchEntry` for `apps/{app}/versions/{version}.json`.
- Expose admin routes:
  - `POST /admin/api/v1/app-registries/{registry}/apps/{app}/install` — install a specific version (`{"version":"…","actor":"…"}` optional)
  - `GET /admin/api/v1/app-installations` — list shared install records (optional `?rolloutStatus=`)
  - `GET /admin/api/v1/app-installations/{app}` — fetch one install record
- Wire `server.ArtifactsDir` from deploy config (`server.artifactsDir` / `--artifacts-dir`) into the installer.

Builds on step 5 (#2718) IndexedDB install state and step 4 (#2716) registry listing API.

## Test plan

- [x] `go test ./internal/appregistry/... -run Install`
- [x] `go test ./internal/server/... -run Install`
- [ ] Manual: with `appRegistries` configured and a published `g-issues` snapshot, call install on a running gestaltd management listener and confirm promoted row + materialized artifact path

Example:

```bash
curl -sS -X POST "$GESTALTD_URL/admin/api/v1/app-registries/toolshed/apps/g-issues/install" \
  -H 'Content-Type: application/json' \
  -d '{"version":"0.0.0-snapshot.gabc123","actor":"user:alice"}' | jq .
```


Made with [Cursor](https://cursor.com)