### PR TITLE
Gate admin API behind server.admin authorization policy

### DIFF
--- a/gestaltd/internal/server/handlers_admin_auth.go
+++ b/gestaltd/internal/server/handlers_admin_auth.go
@@ -1,0 +1,58 @@
+package server
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
+)
+
+func (s *Server) adminAPIAuthMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx, ok := s.authorizeAdminAPIRequest(w, r)
+		if !ok {
+			return
+		}
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func (s *Server) authorizeAdminAPIRequest(w http.ResponseWriter, r *http.Request) (context.Context, bool) {
+	mounted := s.adminMountedUI()
+	if !mountedUIRequiresAuthorization(mounted) {
+		return r.Context(), true
+	}
+
+	p, authenticated, err := s.resolveMountedUIPrincipal(r, mounted)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to resolve user")
+		return nil, false
+	}
+	if !authenticated {
+		writeError(w, http.StatusUnauthorized, "missing authorization")
+		return nil, false
+	}
+	if err := requireUserCaller(w, p); err != nil {
+		return nil, false
+	}
+
+	access, allowed, err := s.authorizeMountedAppAccess(r.Context(), p, mounted)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to authorize app access")
+		return nil, false
+	}
+	if !allowed {
+		writeError(w, http.StatusForbidden, "app access denied")
+		return nil, false
+	}
+
+	ctx := r.Context()
+	if p != nil {
+		ctx = principal.WithPrincipal(ctx, p)
+	}
+	if access.Policy != "" || access.Role != "" {
+		ctx = invocation.WithAccessContext(ctx, access)
+	}
+	return ctx, true
+}

--- a/gestaltd/internal/server/handlers_admin_auth_test.go
+++ b/gestaltd/internal/server/handlers_admin_auth_test.go
@@ -1,0 +1,138 @@
+package server_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/server"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+)
+
+func TestAdminAPIAllowsUnauthenticatedAccessWhenAdminAuthorizationDisabled(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t)
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/admin/api/v1/runtime/providers")
+	if err != nil {
+		t.Fatalf("GET admin API: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
+	}
+}
+
+func TestAdminAPIRequiresSessionWhenAdminAuthorizationEnabled(t *testing.T) {
+	t.Parallel()
+
+	ts := newAuthorizedAdminTestServer(t, true)
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/admin/api/v1/runtime/providers")
+	if err != nil {
+		t.Fatalf("GET admin API: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 401: %s", resp.StatusCode, body)
+	}
+}
+
+func TestAdminAPIAllowsAuthorizedAdminSession(t *testing.T) {
+	t.Parallel()
+
+	ts := newAuthorizedAdminTestServer(t, true)
+	testutil.CloseOnCleanup(t, ts)
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/runtime/providers", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "session-token"})
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET admin API: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
+	}
+}
+
+func TestAdminAPIRejectsAuthenticatedUserWithoutAdminRole(t *testing.T) {
+	t.Parallel()
+
+	ts := newAuthorizedAdminTestServer(t, false)
+	testutil.CloseOnCleanup(t, ts)
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/runtime/providers", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "session-token"})
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET admin API: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 403: %s", resp.StatusCode, body)
+	}
+}
+
+func newAuthorizedAdminTestServer(t *testing.T, grantAdmin bool) *httptest.Server {
+	t.Helper()
+
+	svc := testutil.NewStubServices(t)
+	user := seedUserRecord(t, svc, "admin-api-user", "admin-api-user@example.test", time.Now())
+
+	relationships := []*proto.Relationship(nil)
+	if grantAdmin {
+		relationships = append(relationships, testAuthorizationRelationship(
+			principal.UserSubjectID(user.ID),
+			"admin",
+			"gestaltAdmin",
+			"gestaltAdmin",
+		))
+	}
+
+	authz := &serverTestAuthorizationProvider{
+		resourceTypes: []*proto.AuthorizationModelResourceType{{
+			Name: "gestaltAdmin",
+		}},
+		relationships: relationships,
+	}
+
+	return newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "session-token" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: user.Email}, nil
+			},
+		}
+		cfg.Services = svc
+		cfg.Authorization = authz
+		cfg.AdminUI = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("admin-shell"))
+		})
+	})
+}

--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -94,6 +94,7 @@ func (s *Server) mountAdminUIRoutes(r chi.Router) {
 func (s *Server) mountAdminAPIRoutes(r chi.Router) {
 	r.Route("/admin/api/v1", func(r chi.Router) {
 		r.Use(middleware.Timeout(60 * time.Second))
+		r.Use(s.adminAPIAuthMiddleware)
 		s.mountAdminRuntimeRoutes(r)
 		s.mountAdminAppRegistryRoutes(r)
 	})


### PR DESCRIPTION
## Summary

- Add `adminAPIAuthMiddleware` on `/admin/api/v1/*` using the same `server.admin` session + authorization checks as the admin UI (`gestaltAdmin` policy, `admin` role by default).
- Unauthenticated requests get `401` JSON; authenticated users without the admin role get `403`.
- When admin authorization is not configured (local `noAuth` / no policy), behavior is unchanged — routes stay open.

## Test plan

- [x] `go test ./internal/server/... -run AdminAPI`
- [x] `go test ./internal/server/...`
- [ ] Manual: with identity + authorization configured, confirm `GET /admin/api/v1/runtime/providers` requires session cookie and admin relationship


Made with [Cursor](https://cursor.com)