### PR TITLE
Category A app authorization: emit type app for standard apps

### DIFF
--- a/Formula/gestaltd.rb
+++ b/Formula/gestaltd.rb
@@ -3,30 +3,30 @@
 class Gestaltd < Formula
   desc "Gestalt server daemon"
   homepage "https://github.com/valon-technologies/gestalt"
-  version "0.0.2-alpha.41"
+  version "0.0.2-alpha.40"
   license "Apache-2.0"
 
   on_macos do
     on_arm do
-      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.41/gestaltd-macos-arm64.tar.gz"
-      sha256 "263d96a5586542661d9f770b2730045df36cd40c33b1efbe119cdec33ad8eaa6"
+      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.40/gestaltd-macos-arm64.tar.gz"
+      sha256 "48d8e2853d8137c446fcaac668edb43491b4cfeb054549fee012bd7ebb9bd815"
     end
 
     on_intel do
-      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.41/gestaltd-macos-x86_64.tar.gz"
-      sha256 "014a8adb50978658088c7d12a81b20b137ad54b8dedd6475a895b4d3784cb9e2"
+      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.40/gestaltd-macos-x86_64.tar.gz"
+      sha256 "b4210119f9dc455b3a3f15145c181686fceec838158972fd9e6312d07e4b2824"
     end
   end
 
   on_linux do
     on_arm do
-      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.41/gestaltd-linux-arm64.tar.gz"
-      sha256 "7cd624bfbad43d75f31cd6f5170840bde47f8c186aa81999ced267d12d4ec846"
+      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.40/gestaltd-linux-arm64.tar.gz"
+      sha256 "e9c9c28c1ed2086d67148c8a42f321b6ff5429b991f301a9f6dcffea0f824ced"
     end
 
     on_intel do
-      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.41/gestaltd-linux-x86_64.tar.gz"
-      sha256 "c478f7d85a090d64305df8417f1b6325acba9b5ae9898bae4ed52e4ff83828a8"
+      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.40/gestaltd-linux-x86_64.tar.gz"
+      sha256 "341142924f983a14c60f43c61932bc50bcb7b3b2281d39955fdead6f3c1a1acd"
     end
   end
 

--- a/docs/content/applications.mdx
+++ b/docs/content/applications.mdx
@@ -927,7 +927,7 @@ Mounted app static assets support three access tiers:
 | --- | --- | --- |
 | Public | `static.public: true` | No login required to load HTML, CSS, JS, or theme assets. API calls still require a session. |
 | Authenticated | Default (`static.public` omitted or `false`) | Browser login required before any bytes are served from the mount. |
-| Authorized | `authorizationPolicy` set (or app name as resource type) | After login, Gestalt checks relationships before serving bytes. Unauthorized requests receive a login redirect or `403` without leaking asset contents. |
+| Authorized | `authorizationPolicy` set (or app name as resource id) | After login, Gestalt checks relationships before serving bytes. Unauthorized requests receive a login redirect or `403` without leaking asset contents. |
 
 When `static.public: true`, authorization policy and relationships do not gate static serving. They still apply to `/api/v1/{app}/{operation}` routes.
 
@@ -948,7 +948,7 @@ authorization:
   models:
     default:
       resourceTypes:
-        workspace_review:
+        app:
           defaultRole: viewer
           relations:
             viewer:
@@ -961,7 +961,7 @@ authorization:
         id: user:alice
       relation: viewer
       resource:
-        type: workspace_review
+        type: app
         id: workspace_review
 ```
 

--- a/gestaltd/deploy/helm/gestaltd/Chart.yaml
+++ b/gestaltd/deploy/helm/gestaltd/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: gestaltd
 description: gestaltd - OAuth token management proxy with pluggable integrations
 type: application
-version: 0.0.2-alpha.41
-appVersion: "0.0.2-alpha.41"
+version: 0.0.2-alpha.40
+appVersion: "0.0.2-alpha.40"

--- a/gestaltd/internal/bootstrap/authorization_bootstrap.go
+++ b/gestaltd/internal/bootstrap/authorization_bootstrap.go
@@ -287,6 +287,20 @@ func staticAuthorizationResource(def config.AuthorizationResourceDef) *proto.Res
 	}
 }
 
+// AuthorizationResourceTypeNames returns configured authorization model resource type names.
+func AuthorizationResourceTypeNames(cfg *config.Config) map[string]struct{} {
+	names := map[string]struct{}{}
+	if cfg == nil {
+		return names
+	}
+	for _, model := range cfg.Authorization.Models {
+		for name := range model.ResourceTypes {
+			names[name] = struct{}{}
+		}
+	}
+	return names
+}
+
 func stringPropertiesStruct(properties map[string]string) (*structpb.Struct, error) {
 	if len(properties) == 0 {
 		return nil, nil

--- a/gestaltd/internal/bootstrap/authorization_bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/authorization_bootstrap_test.go
@@ -16,6 +16,7 @@ import (
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/providerdrivers"
 	"github.com/valon-technologies/gestalt/server/services/providergateway"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
@@ -644,4 +645,42 @@ func testProviderGatewayCallerTokenKeyPair(t testing.TB) (string, string) {
 	privateKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privateKeyBytes})
 	publicKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: publicKeyBytes})
 	return string(privateKeyPEM), string(publicKeyPEM)
+}
+
+func TestProviderAuthorizationKindsSkipsDedicatedAppResourceTypes(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Apps: map[string]*config.ProviderEntry{
+			"workspace_review": {},
+			"legacy_app":       {},
+		},
+		Providers: config.ProvidersConfig{
+			Workflow: map[string]*config.ProviderEntry{"nightly": {}},
+			Agent:    map[string]*config.ProviderEntry{"assistant": {}},
+		},
+		Authorization: config.AuthorizationConfig{
+			Models: map[string]config.AuthorizationModelDef{
+				"default": {
+					ResourceTypes: map[string]config.AuthorizationResourceTypeDef{
+						"legacy_app": {},
+					},
+				},
+			},
+		},
+	}
+
+	got := ProviderAuthorizationKinds(cfg)
+	if _, ok := got["workspace_review"]; !ok || got["workspace_review"] != invocation.ProviderKindApp {
+		t.Fatalf("workspace_review kind = %v, want app", got["workspace_review"])
+	}
+	if _, ok := got["legacy_app"]; ok {
+		t.Fatalf("legacy_app should be excluded from provider kinds, got %v", got["legacy_app"])
+	}
+	if got["nightly"] != invocation.ProviderKindWorkflow {
+		t.Fatalf("nightly kind = %v, want workflow", got["nightly"])
+	}
+	if got["assistant"] != invocation.ProviderKindAgent {
+		t.Fatalf("assistant kind = %v, want agent", got["assistant"])
+	}
 }

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1222,11 +1222,13 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		failPendingStartupProviders(prepared.Deps, err)
 		return nil, err
 	}
+	kinds := ProviderAuthorizationKinds(cfg)
 	sharedInvoker := invocation.NewBroker(providers, prepared.Services.Users, prepared.Services.ExternalCredentials,
 		invocation.WithConnectionMapper(invocation.ConnectionMap(connMaps.APIConnection)),
 		invocation.WithMCPConnectionMapper(invocation.ConnectionMap(connMaps.MCPConnection)),
 		invocation.WithConnectionRuntime(connRuntime.Resolve),
 		invocation.WithAuthorizationProvider(authorizationProvider),
+		invocation.WithProviderKinds(kinds),
 	)
 	audit, auditClose, err := buildAuditSink(ctx, cfg, factories, prepared.Telemetry)
 	if err != nil {
@@ -2309,4 +2311,25 @@ func buildPublicGatewayTransport(
 		transport.SetPublicBaseURL(cfg.Server.BaseURL)
 	}
 	return transport, nil
+}
+
+func ProviderAuthorizationKinds(cfg *config.Config) map[string]invocation.ProviderKind {
+	kinds := map[string]invocation.ProviderKind{}
+	if cfg == nil {
+		return kinds
+	}
+	dedicatedResourceTypes := AuthorizationResourceTypeNames(cfg)
+	for name := range cfg.Apps {
+		if _, hasDedicatedResourceType := dedicatedResourceTypes[name]; hasDedicatedResourceType {
+			continue
+		}
+		kinds[name] = invocation.ProviderKindApp
+	}
+	for name := range cfg.Providers.Workflow {
+		kinds[name] = invocation.ProviderKindWorkflow
+	}
+	for name := range cfg.Providers.Agent {
+		kinds[name] = invocation.ProviderKindAgent
+	}
+	return kinds
 }

--- a/gestaltd/internal/server/mounted_ui.go
+++ b/gestaltd/internal/server/mounted_ui.go
@@ -300,10 +300,7 @@ func (s *Server) mountedUIAuthorizationRoles(ctx context.Context, subjectID, res
 						Id:   strings.TrimSpace(subjectID),
 					}},
 				},
-				Resource: &proto.Resource{
-					Type: strings.TrimSpace(resourceName),
-					Id:   strings.TrimSpace(resourceName),
-				},
+				Resource: invocation.AuthorizationResource(resourceName, s.providerKinds),
 			},
 			PageSize:  500,
 			PageToken: pageToken,
@@ -325,15 +322,16 @@ func (s *Server) mountedUIAuthorizationRoles(ctx context.Context, subjectID, res
 }
 
 func (s *Server) mountedUIResourceDefaultRole(ctx context.Context, resourceName string) (string, error) {
+	typeName := invocation.AuthorizationResource(resourceName, s.providerKinds).GetType()
 	resp, err := s.authorization.ListActiveModelResourceTypes(ctx, &proto.ListActiveModelResourceTypesRequest{
-		Filter:   &proto.AuthorizationModelResourceTypeFilter{Name: strings.TrimSpace(resourceName)},
+		Filter:   &proto.AuthorizationModelResourceTypeFilter{Name: strings.TrimSpace(typeName)},
 		PageSize: 1,
 	})
 	if err != nil {
 		return "", err
 	}
 	for _, resourceType := range resp.GetResourceTypes() {
-		if strings.TrimSpace(resourceType.GetName()) == strings.TrimSpace(resourceName) {
+		if strings.TrimSpace(resourceType.GetName()) == strings.TrimSpace(typeName) {
 			return strings.TrimSpace(resourceType.GetDefaultRole()), nil
 		}
 	}

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -77,6 +77,7 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 		SelectedAuthProvider: result.SelectedAuthProvider,
 		AuthProviders:        result.AuthProviders,
 		Authorization:        authorizationProvider,
+		ProviderKinds:        bootstrap.ProviderAuthorizationKinds(cfg),
 		AuditSink:            result.AuditSink,
 		Services:             result.Services,
 		Providers:            result.Providers,

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -93,6 +93,7 @@ type Server struct {
 	authProviders          map[string]core.IdentityProvider
 	serverAuthProvider     string
 	authorization          core.AuthorizationProvider
+	providerKinds          map[string]invocation.ProviderKind
 	auditSink              core.AuditSink
 	users                  *coredata.UserService
 	externalCredentials    core.ExternalCredentialProvider
@@ -162,6 +163,7 @@ type Config struct {
 	SelectedAuthProvider   string
 	AuthProviders          map[string]core.IdentityProvider
 	Authorization          core.AuthorizationProvider
+	ProviderKinds          map[string]invocation.ProviderKind
 	AuditSink              core.AuditSink
 	Services               *coredata.Services
 	Providers              *registry.ProviderMap[core.Provider]
@@ -346,6 +348,7 @@ func New(cfg Config) (*Server, error) {
 		authProviders:          authProviders,
 		serverAuthProvider:     serverAuthProvider,
 		authorization:          cfg.Authorization,
+		providerKinds:          cfg.ProviderKinds,
 		auditSink:              cfg.AuditSink,
 		users:                  users,
 		externalCredentials:    externalCredentials,

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -88,6 +88,17 @@ func mustStruct(t *testing.T, fields map[string]any) *structpb.Struct {
 	return out
 }
 
+func testProviderKindsFromAppDefs(apps map[string]*config.ProviderEntry) map[string]invocation.ProviderKind {
+	if len(apps) == 0 {
+		return nil
+	}
+	kinds := make(map[string]invocation.ProviderKind, len(apps))
+	for name := range apps {
+		kinds[name] = invocation.ProviderKindApp
+	}
+	return kinds
+}
+
 func newTestServer(t *testing.T, opts ...func(*server.Config)) *httptest.Server {
 	t.Helper()
 	return newTestHTTPServer(t, httptest.NewServer, opts...)
@@ -110,6 +121,9 @@ func newTestHandler(t *testing.T, opts ...func(*server.Config)) http.Handler {
 	}
 	for _, opt := range opts {
 		opt(&cfg)
+	}
+	if cfg.ProviderKinds == nil && len(cfg.AppDefs) > 0 {
+		cfg.ProviderKinds = testProviderKindsFromAppDefs(cfg.AppDefs)
 	}
 	installTestExternalCredentialResolver(&cfg)
 	brokerOpts := []invocation.BrokerOption{}
@@ -2573,7 +2587,7 @@ func TestMountedUIAppLevelAuthorizationRelationships(t *testing.T) {
 
 	authz := &serverTestAuthorizationProvider{
 		resourceTypes: []*proto.AuthorizationModelResourceType{
-			{Name: "sampleApp"},
+			{Name: "app"},
 			{Name: "viewerPolicy", DefaultRole: "viewer"},
 			{Name: "defaultRolePolicy", DefaultRole: "reader"},
 			{Name: "adminPolicy"},
@@ -2582,7 +2596,7 @@ func TestMountedUIAppLevelAuthorizationRelationships(t *testing.T) {
 			testAuthorizationRelationship(
 				principal.UserSubjectID(user.ID),
 				"admin",
-				"sampleApp",
+				"app",
 				"sampleApp",
 			),
 			testAuthorizationRelationship(
@@ -2598,6 +2612,7 @@ func TestMountedUIAppLevelAuthorizationRelationships(t *testing.T) {
 		cfg.Auth = sessionAuth
 		cfg.Services = svc
 		cfg.Authorization = authz
+		cfg.AppDefs = map[string]*config.ProviderEntry{"sampleApp": {}}
 		cfg.MountedUIs = []server.MountedUI{
 			{
 				Name:         "sample-ui",
@@ -2645,8 +2660,8 @@ func TestMountedUIAppLevelAuthorizationRelationships(t *testing.T) {
 	if len(authz.listRelationshipRequests) == 0 {
 		t.Fatal("authorization ListRelationships was not called")
 	}
-	if got := authz.listRelationshipRequests[0].GetFilter().GetResource().GetType(); got != "sampleApp" {
-		t.Fatalf("relationship resource type = %q, want sampleApp", got)
+	if got := authz.listRelationshipRequests[0].GetFilter().GetResource().GetType(); got != "app" {
+		t.Fatalf("relationship resource type = %q, want app", got)
 	}
 
 	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/viewer/", nil)
@@ -2903,9 +2918,9 @@ func TestMountedAppStaticAuthorizationRelationshipAllow(t *testing.T) {
 	svc := testutil.NewStubServices(t)
 	user := seedUserRecord(t, svc, "alpha-user", "alpha-user@example.test", time.Now())
 	authz := &serverTestAuthorizationProvider{
-		resourceTypes: []*proto.AuthorizationModelResourceType{{Name: "alpha"}},
+		resourceTypes: []*proto.AuthorizationModelResourceType{{Name: "app"}},
 		relationships: []*proto.Relationship{
-			testAuthorizationRelationship(principal.UserSubjectID(user.ID), "viewer", "alpha", "alpha"),
+			testAuthorizationRelationship(principal.UserSubjectID(user.ID), "viewer", "app", "alpha"),
 		},
 	}
 

--- a/gestaltd/services/invocation/authorization_resource.go
+++ b/gestaltd/services/invocation/authorization_resource.go
@@ -1,0 +1,15 @@
+package invocation
+
+import (
+	"strings"
+
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+)
+
+func AuthorizationResource(name string, kinds map[string]ProviderKind) *proto.Resource {
+	name = strings.TrimSpace(name)
+	if kind, ok := kinds[name]; ok {
+		return &proto.Resource{Type: string(kind), Id: name}
+	}
+	return &proto.Resource{Type: name, Id: name}
+}

--- a/gestaltd/services/invocation/authorization_resource_test.go
+++ b/gestaltd/services/invocation/authorization_resource_test.go
@@ -1,0 +1,49 @@
+package invocation
+
+import (
+	"testing"
+)
+
+func TestAuthorizationResource(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		kinds map[string]ProviderKind
+		want  struct{ typ, id string }
+	}{
+		{
+			name:  "category a app",
+			kinds: map[string]ProviderKind{"slack": ProviderKindApp},
+			want:  struct{ typ, id string }{"app", "slack"},
+		},
+		{
+			name:  "dedicated resource type fallback",
+			kinds: map[string]ProviderKind{"slack": ProviderKindApp},
+			want:  struct{ typ, id string }{"legacyApp", "legacyApp"},
+		},
+		{
+			name:  "workflow provider",
+			kinds: map[string]ProviderKind{"nightly": ProviderKindWorkflow},
+			want:  struct{ typ, id string }{"workflow", "nightly"},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			resourceName := "slack"
+			if tc.name == "dedicated resource type fallback" {
+				resourceName = "legacyApp"
+			}
+			if tc.name == "workflow provider" {
+				resourceName = "nightly"
+			}
+			got := AuthorizationResource(resourceName, tc.kinds)
+			if got.GetType() != tc.want.typ || got.GetId() != tc.want.id {
+				t.Fatalf("AuthorizationResource(%q) = {%q, %q}, want {%q, %q}", resourceName, got.GetType(), got.GetId(), tc.want.typ, tc.want.id)
+			}
+		})
+	}
+}

--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -121,6 +121,7 @@ type Broker struct {
 	mcpMapper         ConnectionMapper
 	connectionRuntime ConnectionRuntimeResolver
 	authorization     core.AuthorizationProvider
+	providerKinds     map[string]ProviderKind
 	logger            *slog.Logger
 	tracerProvider    trace.TracerProvider
 }
@@ -141,6 +142,10 @@ func WithConnectionRuntime(r ConnectionRuntimeResolver) BrokerOption {
 
 func WithAuthorizationProvider(provider core.AuthorizationProvider) BrokerOption {
 	return func(b *Broker) { b.authorization = provider }
+}
+
+func WithProviderKinds(kinds map[string]ProviderKind) BrokerOption {
+	return func(b *Broker) { b.providerKinds = kinds }
 }
 
 func WithLogger(l *slog.Logger) BrokerOption {
@@ -547,7 +552,7 @@ func (b *Broker) checkAuthorizationAccess(ctx context.Context, p *principal.Prin
 	if b == nil || b.authorization == nil {
 		return nil
 	}
-	req := authorizationAccessRequest(p, providerName, operationID)
+	req := authorizationAccessRequest(b.providerKinds, p, providerName, operationID)
 	resp, err := b.authorization.CheckAccess(ctx, req)
 	if err != nil {
 		return fmt.Errorf("%w: %s.%s: %v", ErrAuthorizationDenied, providerName, operationID, err)
@@ -558,7 +563,7 @@ func (b *Broker) checkAuthorizationAccess(ctx context.Context, p *principal.Prin
 	return nil
 }
 
-func authorizationAccessRequest(p *principal.Principal, providerName, operationID string) *proto.CheckAccessRequest {
+func authorizationAccessRequest(kinds map[string]ProviderKind, p *principal.Principal, providerName, operationID string) *proto.CheckAccessRequest {
 	p = principal.Canonicalized(p)
 	subjectID := principal.EffectiveCredentialSubjectID(p)
 	providerName = strings.TrimSpace(providerName)
@@ -573,11 +578,8 @@ func authorizationAccessRequest(p *principal.Principal, providerName, operationI
 			Id:         subjectID,
 			Properties: properties,
 		},
-		Action: &proto.Action{Name: strings.TrimSpace(operationID)},
-		Resource: &proto.Resource{
-			Type: providerName,
-			Id:   providerName,
-		},
+		Action:   &proto.Action{Name: strings.TrimSpace(operationID)},
+		Resource: AuthorizationResource(providerName, kinds),
 	}
 }
 

--- a/gestaltd/services/invocation/broker_test.go
+++ b/gestaltd/services/invocation/broker_test.go
@@ -282,6 +282,7 @@ func TestBrokerInvokeChecksAuthorizationBeforeExecution(t *testing.T) {
 		nil,
 		nil,
 		WithAuthorizationProvider(authz),
+		WithProviderKinds(map[string]ProviderKind{"slack": ProviderKindApp}),
 	)
 
 	result, err := broker.Invoke(
@@ -311,8 +312,8 @@ func TestBrokerInvokeChecksAuthorizationBeforeExecution(t *testing.T) {
 	if got := req.GetSubject().GetId(); got != "user:u-123" {
 		t.Fatalf("subject id = %q, want user:u-123", got)
 	}
-	if got := req.GetResource().GetType(); got != "slack" {
-		t.Fatalf("resource type = %q, want slack", got)
+	if got := req.GetResource().GetType(); got != "app" {
+		t.Fatalf("resource type = %q, want app", got)
 	}
 	if got := req.GetResource().GetId(); got != "slack" {
 		t.Fatalf("resource id = %q, want slack", got)
@@ -392,6 +393,7 @@ func TestBrokerInvokeGraphQLAuthorizationDeniesBeforeCredentialResolution(t *tes
 		nil,
 		nil,
 		WithAuthorizationProvider(authz),
+		WithProviderKinds(map[string]ProviderKind{"github": ProviderKindApp}),
 	)
 
 	_, err := broker.InvokeGraphQL(
@@ -420,8 +422,8 @@ func TestBrokerInvokeGraphQLAuthorizationDeniesBeforeCredentialResolution(t *tes
 	if got := req.GetSubject().GetId(); got != "service_account:reports" {
 		t.Fatalf("subject id = %q, want service_account:reports", got)
 	}
-	if got := req.GetResource().GetType(); got != "github" {
-		t.Fatalf("resource type = %q, want github", got)
+	if got := req.GetResource().GetType(); got != "app" {
+		t.Fatalf("resource type = %q, want app", got)
 	}
 	if got := req.GetResource().GetId(); got != "github" {
 		t.Fatalf("resource id = %q, want github", got)


### PR DESCRIPTION
## Summary

Broker and mounted UI authorization use provider-kind resources: `{type: app|workflow|agent, id: providerName}` with operation name as action.

Hard cutover with [toolshed#3277](https://github.com/valon-technologies/toolshed/pull/3277) + CloudSQL tuple migration (`{type: AppName, id: AppName}` → `{type: app, id: AppName}`).

### Broker invoke

```mermaid
sequenceDiagram
    participant Client
    participant Broker
    participant Authz as AuthorizationProvider
    participant Provider

    Client->>Broker: Invoke(providerName, operation)
    Broker->>Broker: kind = ProviderKinds[providerName]
    Broker->>Authz: CheckAccess(subject, app|workflow|agent:providerName, operation)
    Authz-->>Broker: allowed
    Broker->>Provider: Execute(operation)
    Provider-->>Broker: result
    Broker-->>Client: result
```

### Mounted UI

```mermaid
sequenceDiagram
    participant Browser
    participant Server
    participant Authz as AuthorizationProvider

    Browser->>Server: GET /app/
    Server->>Server: resource = app:appName if in AppDefs else name:name
    Server->>Authz: ListRelationships(subject, resource)
    Authz-->>Server: roles
    Server-->>Browser: 200 or 403
```

### Resource shape

```mermaid
flowchart LR
    subgraph providers [Configured providers]
        Apps["cfg.Apps → app:id"]
        Workflow["cfg.Providers.Workflow → workflow:id"]
        Agent["cfg.Providers.Agent → agent:id"]
    end
    subgraph nonProviders [Non-providers]
        Other["gestaltAdmin, deal_hub.*, policies → type:id = name:name"]
    end
    providers --> CheckAccess
    nonProviders --> CheckAccess
    CheckAccess["CheckAccess / ListRelationships"]
```

### Cutover state

```mermaid
stateDiagram-v2
    [*] --> Legacy: type=name id=name tuples
    Legacy --> Migrated: CloudSQL + toolshed#3277 + this PR
    Migrated --> [*]: app:id tuples, shared app resource type
    Legacy --> Broken: gestalt only
    Broken --> Legacy: rollback gestalt
```