### PR TITLE
Drop storageUrl from app registry list admin API

### DIFF
--- a/gestaltd/internal/server/handlers_admin_app_registry.go
+++ b/gestaltd/internal/server/handlers_admin_app_registry.go
@@ -13,10 +13,9 @@ import (
 )
 
 type adminAppRegistryInfo struct {
-	Name       string `json:"name"`
-	Kind       string `json:"kind"`
-	PublicURL  string `json:"publicUrl,omitempty"`
-	StorageURL string `json:"storageUrl,omitempty"`
+	Name      string `json:"name"`
+	Kind      string `json:"kind"`
+	PublicURL string `json:"publicUrl,omitempty"`
 }
 
 type adminAppRegistryVersionsResponse struct {
@@ -51,9 +50,6 @@ func (s *Server) listAdminAppRegistries(w http.ResponseWriter, r *http.Request) 
 		}
 		if publicURL, err := registry.PublicURL(); err == nil {
 			info.PublicURL = publicURL
-		}
-		if storageURL, err := registry.StorageURL(); err == nil {
-			info.StorageURL = storageURL
 		}
 		out = append(out, info)
 	}

--- a/gestaltd/internal/server/handlers_admin_app_registry_test.go
+++ b/gestaltd/internal/server/handlers_admin_app_registry_test.go
@@ -99,6 +99,12 @@ func TestAdminAppRegistryEndpointsListConfiguredRegistriesAndVersions(t *testing
 	if len(registries) != 1 || registries[0]["name"] != "toolshed" {
 		t.Fatalf("registries = %#v", registries)
 	}
+	if registries[0]["publicUrl"] != "https://storage.googleapis.com/gitlab-peach-street-gestalt-app-registry" {
+		t.Fatalf("publicUrl = %#v", registries[0]["publicUrl"])
+	}
+	if _, ok := registries[0]["storageUrl"]; ok {
+		t.Fatalf("storageUrl should be omitted, got %#v", registries[0]["storageUrl"])
+	}
 
 	versionsResp, err := http.Get(ts.URL + "/admin/api/v1/app-registries/toolshed/apps/g-issues/versions")
 	if err != nil {


### PR DESCRIPTION
## Summary
- Remove `storageUrl` from `GET /admin/api/v1/app-registries` responses; keep `name`, `kind`, and `publicUrl` only.
- `publicUrl` is what gestaltd derives from `gcs.bucket` and uses for HTTP registry reads; `gs://` remains internal to publish/upload paths.
- Assert the slimmer response shape in the admin app registry handler test.

## Test plan
- [x] `go test ./internal/server/... -run AdminAppRegistry`


Made with [Cursor](https://cursor.com)