### PR TITLE
Propagate CLI artifacts dir into server config at load time

### DIFF
--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -975,6 +975,7 @@ func (l *Lifecycle) LoadForExecutionAtPaths(configPaths []string, lockfilePath, 
 		return nil, nil, fmt.Errorf("loading config: %v", err)
 	}
 	paths := resolveLifecyclePaths(configPaths, cfg, lockfilePath, artifactsDir)
+	cfg.Server.ArtifactsDir = paths.artifactsDir
 	if l.devServeEligible || len(l.forcedDevAppKeys) > 0 {
 		for _, name := range slices.Sorted(maps.Keys(cfg.Apps)) {
 			entry := cfg.Apps[name]

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -458,6 +458,9 @@ func TestLoadForExecutionAtPath_ResolvesLocalManifestPluginWithoutLockfile(t *te
 	if err != nil {
 		t.Fatalf("LoadForExecutionAtPath: %v", err)
 	}
+	if loaded.Server.ArtifactsDir != artifactsDir {
+		t.Fatalf("Server.ArtifactsDir = %q, want %q", loaded.Server.ArtifactsDir, artifactsDir)
+	}
 
 	intg := loaded.Apps["example"]
 	if intg == nil || intg.ResolvedManifest == nil {


### PR DESCRIPTION
## Summary
- Set `cfg.Server.ArtifactsDir` from resolved lifecycle paths in `LoadForExecutionAtPaths`
- Ensures `gestaltd serve --artifacts-dir` is available on the loaded server config, not only internal lifecycle path resolution

Split from [gestalt#2720](https://github.com/valon-technologies/gestalt/pull/2720) so CLI/serve wiring can land on `main` before the registry install prototype.

## Test plan
- [x] `go test ./internal/operator/ -run TestLoadForExecutionAtPath_ResolvesLocalManifestPluginWithoutLockfile`
- [ ] After merge, rebase `app-registry-install-prototype` onto `main` and drop the duplicate commit


Made with [Cursor](https://cursor.com)