### PR TITLE
Step 6: Prototype registry app install with shared IndexedDB state

### DIFF
--- a/gestaltd/internal/appregistry/installer.go
+++ b/gestaltd/internal/appregistry/installer.go
@@ -1,0 +1,307 @@
+package appregistry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
+	"github.com/valon-technologies/gestalt/server/internal/operator"
+	"github.com/valon-technologies/gestalt/server/internal/providerregistry"
+	"github.com/valon-technologies/gestalt/server/services/apps/providerpkg"
+)
+
+const RegistryInstallSubdir = "registry-installed"
+
+// Installer writes shared install state and materializes registry apps on the
+// handling instance.
+type Installer struct {
+	Registries    map[string]config.AppRegistryConfig
+	Reader        *RegistryReader
+	Installations *coredata.AppInstallationService
+	Events        *coredata.AppInstallationEventService
+	ArtifactsDir  string
+	Now           func() time.Time
+	installLocks  sync.Map // app name -> *sync.Mutex
+}
+
+type InstallInput struct {
+	Registry string
+	App      string
+	Version  string
+	Actor    string
+}
+
+type InstallOutput struct {
+	Installation     *core.AppInstallation
+	MaterializedPath string
+}
+
+func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOutput, error) {
+	if i == nil {
+		return nil, fmt.Errorf("app registry installer is not configured")
+	}
+	registryName := strings.TrimSpace(input.Registry)
+	appName := strings.TrimSpace(input.App)
+	version := strings.TrimSpace(input.Version)
+	actor := strings.TrimSpace(input.Actor)
+	if registryName == "" {
+		return nil, fmt.Errorf("registry is required")
+	}
+	if appName == "" {
+		return nil, fmt.Errorf("app is required")
+	}
+	if version == "" {
+		return nil, fmt.Errorf("version is required")
+	}
+	if err := providerregistry.ValidateRepositoryName(appName); err != nil {
+		return nil, fmt.Errorf("invalid app name: %w", err)
+	}
+
+	unlock := i.lockInstall(appName)
+	defer unlock()
+
+	if i.Installations == nil || i.Events == nil {
+		return nil, fmt.Errorf("app installation services are not configured")
+	}
+	artifactsDir := strings.TrimSpace(i.ArtifactsDir)
+	if artifactsDir == "" {
+		return nil, fmt.Errorf("artifacts directory is not configured")
+	}
+	registry, ok := i.Registries[registryName]
+	if !ok {
+		return nil, fmt.Errorf("app registry not found")
+	}
+	if strings.TrimSpace(registry.Kind) != config.AppRegistryKindGCS {
+		return nil, fmt.Errorf("unsupported app registry kind")
+	}
+	publicRoot, err := registry.PublicURL()
+	if err != nil {
+		return nil, fmt.Errorf("app registry public URL is invalid: %w", err)
+	}
+
+	reader := i.Reader
+	if reader == nil {
+		reader = &RegistryReader{}
+	}
+	entry, err := reader.FetchEntry(ctx, publicRoot, appName, version)
+	if err != nil {
+		return nil, fmt.Errorf("fetch app registry entry: %w", err)
+	}
+	if entry.App != appName {
+		return nil, fmt.Errorf("registry entry app %q does not match requested app %q", entry.App, appName)
+	}
+	if entry.Version != version {
+		return nil, fmt.Errorf("registry entry version %q does not match requested version %q", entry.Version, version)
+	}
+
+	platform := providerpkg.CurrentPlatformString()
+	artifact, ok := entry.Artifacts[platform]
+	if !ok {
+		return nil, fmt.Errorf("registry entry has no artifact for platform %q", platform)
+	}
+	artifactURL := strings.TrimSpace(artifact.PublicURL)
+	if artifactURL == "" {
+		artifactURL = strings.TrimSpace(artifact.URL)
+	}
+	if artifactURL == "" {
+		return nil, fmt.Errorf("registry entry artifact for platform %q has no download URL", platform)
+	}
+	expectedSHA := strings.TrimSpace(artifact.SHA256)
+	if expectedSHA == "" {
+		return nil, fmt.Errorf("registry entry artifact for platform %q is missing sha256", platform)
+	}
+
+	previousVersion := ""
+	existing, existingErr := i.Installations.GetInstallation(ctx, appName)
+	if existingErr == nil {
+		if existing.RolloutStatus == core.AppInstallationRolloutStatusPromoted {
+			previousVersion = strings.TrimSpace(existing.ResolvedVersion)
+		}
+	} else if !errors.Is(existingErr, core.ErrNotFound) {
+		return nil, fmt.Errorf("load existing app installation: %w", existingErr)
+	}
+
+	entryURL := PublicURL(publicRoot, AppVersionEntryPath(appName, version))
+	checksums := map[string]string{platform: expectedSHA}
+	pending := &core.AppInstallation{
+		AppName:                 appName,
+		VersionConstraint:       version,
+		ResolvedVersion:         version,
+		SourceRef:               entry.SourceRef,
+		Registry:                registryName,
+		ProviderReleaseURL:      entryURL,
+		ArtifactChecksums:       checksums,
+		RolloutStatus:           core.AppInstallationRolloutStatusPending,
+		PreviousResolvedVersion: previousVersion,
+		InstalledBy:             actor,
+	}
+
+	if existingErr == core.ErrNotFound {
+		if _, err := i.Installations.PutInstallation(ctx, pending); err != nil {
+			return nil, fmt.Errorf("write pending app installation: %w", err)
+		}
+	} else {
+		if _, err := i.Installations.UpdateInstallation(ctx, appName, func(installation *core.AppInstallation) error {
+			*installation = *pending
+			installation.AppName = appName
+			return nil
+		}); err != nil {
+			return nil, fmt.Errorf("write pending app installation: %w", err)
+		}
+	}
+	if _, err := i.Events.AppendEvent(ctx, &core.AppInstallationEvent{
+		InstallationID: appName,
+		FromVersion:    previousVersion,
+		ToVersion:      version,
+		Type:           core.AppInstallationEventTypeInstallRequested,
+		Actor:          actor,
+		Metadata: map[string]any{
+			"registry": registryName,
+		},
+	}); err != nil {
+		return i.failInstall(ctx, appName, previousVersion, version, actor, registryName, fmt.Errorf("append install_requested event: %w", err))
+	}
+
+	materializedPath := filepath.Join(artifactsDir, RegistryInstallSubdir, appName, version)
+	stagingPath := materializedPath + ".staging"
+
+	download, err := downloadRegistryArtifact(ctx, reader.client(), artifactURL)
+	if err != nil {
+		return i.failInstall(ctx, appName, previousVersion, version, actor, registryName, err)
+	}
+	defer func() {
+		if download.Cleanup != nil {
+			download.Cleanup()
+		}
+	}()
+	if !strings.EqualFold(strings.TrimSpace(download.SHA256Hex), expectedSHA) {
+		return i.failInstall(ctx, appName, previousVersion, version, actor, registryName, fmt.Errorf("artifact digest mismatch: got %s, want %s", download.SHA256Hex, expectedSHA))
+	}
+
+	if err := os.RemoveAll(stagingPath); err != nil {
+		return i.failInstall(ctx, appName, previousVersion, version, actor, registryName, fmt.Errorf("reset staging directory: %w", err))
+	}
+	if _, err := operator.InstallPublishedPackage(download.LocalPath, stagingPath, appName); err != nil {
+		_ = os.RemoveAll(stagingPath)
+		return i.failInstall(ctx, appName, previousVersion, version, actor, registryName, fmt.Errorf("materialize app artifact: %w", err))
+	}
+	if err := os.RemoveAll(materializedPath); err != nil {
+		_ = os.RemoveAll(stagingPath)
+		return i.failInstall(ctx, appName, previousVersion, version, actor, registryName, fmt.Errorf("reset materialization directory: %w", err))
+	}
+	if err := os.Rename(stagingPath, materializedPath); err != nil {
+		_ = os.RemoveAll(stagingPath)
+		return i.failInstall(ctx, appName, previousVersion, version, actor, registryName, fmt.Errorf("promote staged app artifact: %w", err))
+	}
+
+	activeSince := i.now()
+	stored, err := i.Installations.UpdateInstallation(ctx, appName, func(installation *core.AppInstallation) error {
+		installation.VersionConstraint = version
+		installation.ResolvedVersion = version
+		installation.SourceRef = entry.SourceRef
+		installation.Registry = registryName
+		installation.ProviderReleaseURL = entryURL
+		installation.ArtifactChecksums = checksums
+		installation.RolloutStatus = core.AppInstallationRolloutStatusPromoted
+		installation.ActiveSince = &activeSince
+		installation.PreviousResolvedVersion = previousVersion
+		installation.InstalledBy = actor
+		return nil
+	})
+	if err != nil {
+		return i.failInstall(ctx, appName, previousVersion, version, actor, registryName, fmt.Errorf("write promoted app installation: %w", err))
+	}
+	if _, err := i.Events.AppendEvent(ctx, &core.AppInstallationEvent{
+		InstallationID: appName,
+		FromVersion:    previousVersion,
+		ToVersion:      version,
+		Type:           core.AppInstallationEventTypePromoted,
+		Actor:          actor,
+		Metadata: map[string]any{
+			"registry":          registryName,
+			"materialized_path": materializedPath,
+		},
+	}); err != nil {
+		return nil, fmt.Errorf("append promoted event after successful install: %w", err)
+	}
+
+	return &InstallOutput{
+		Installation:     stored,
+		MaterializedPath: materializedPath,
+	}, nil
+}
+
+func (i *Installer) failInstall(ctx context.Context, appName, previousVersion, version, actor, registryName string, cause error) (*InstallOutput, error) {
+	cleanupCtx := context.WithoutCancel(ctx)
+	_, updateErr := i.Installations.UpdateInstallation(cleanupCtx, appName, func(installation *core.AppInstallation) error {
+		installation.RolloutStatus = core.AppInstallationRolloutStatusFailed
+		installation.VersionConstraint = version
+		installation.ResolvedVersion = version
+		installation.Registry = registryName
+		installation.PreviousResolvedVersion = previousVersion
+		installation.InstalledBy = actor
+		installation.ActiveSince = nil
+		installation.SourceRef = ""
+		installation.ProviderReleaseURL = ""
+		installation.ArtifactChecksums = nil
+		return nil
+	})
+	if updateErr != nil {
+		return nil, fmt.Errorf("%w; also failed to mark installation failed: %v", cause, updateErr)
+	}
+	if _, eventErr := i.Events.AppendEvent(cleanupCtx, &core.AppInstallationEvent{
+		InstallationID: appName,
+		FromVersion:    previousVersion,
+		ToVersion:      version,
+		Type:           core.AppInstallationEventTypeFailed,
+		Actor:          actor,
+		Metadata: map[string]any{
+			"registry": registryName,
+			"error":    cause.Error(),
+		},
+	}); eventErr != nil {
+		return nil, fmt.Errorf("%w; also failed to append failed event: %v", cause, eventErr)
+	}
+	return nil, cause
+}
+
+func (i *Installer) lockInstall(appName string) func() {
+	if i == nil {
+		return func() {}
+	}
+	value, _ := i.installLocks.LoadOrStore(appName, &sync.Mutex{})
+	mu := value.(*sync.Mutex)
+	mu.Lock()
+	return mu.Unlock
+}
+
+func (i *Installer) now() time.Time {
+	if i != nil && i.Now != nil {
+		return i.Now().UTC().Truncate(time.Millisecond)
+	}
+	return time.Now().UTC().Truncate(time.Millisecond)
+}
+
+func downloadRegistryArtifact(ctx context.Context, client *http.Client, artifactURL string) (*providerpkg.DownloadResult, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, artifactURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build artifact download request: %w", err)
+	}
+	result, err := providerpkg.DownloadRequest(client, req)
+	if err != nil {
+		return nil, fmt.Errorf("download registry artifact: %w", err)
+	}
+	return result, nil
+}

--- a/gestaltd/internal/appregistry/installer.go
+++ b/gestaltd/internal/appregistry/installer.go
@@ -121,8 +121,10 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 	}
 
 	previousVersion := ""
+	var restoreBaseline *core.AppInstallation
 	existing, existingErr := i.Installations.GetInstallation(ctx, appName)
 	if existingErr == nil {
+		restoreBaseline = restoreBaselineForInstall(existing)
 		if existing.RolloutStatus == core.AppInstallationRolloutStatusPromoted {
 			previousVersion = strings.TrimSpace(existing.ResolvedVersion)
 		}
@@ -169,7 +171,7 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 			"registry": registryName,
 		},
 	}); err != nil {
-		return i.failInstall(ctx, appName, previousVersion, version, actor, registryName, fmt.Errorf("append install_requested event: %w", err))
+		return i.failInstall(ctx, appName, restoreBaseline, previousVersion, version, actor, registryName, fmt.Errorf("append install_requested event: %w", err))
 	}
 
 	materializedPath := filepath.Join(artifactsDir, RegistryInstallSubdir, appName, version)
@@ -177,7 +179,7 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 
 	download, err := downloadRegistryArtifact(ctx, reader.client(), artifactURL)
 	if err != nil {
-		return i.failInstall(ctx, appName, previousVersion, version, actor, registryName, err)
+		return i.failInstall(ctx, appName, restoreBaseline, previousVersion, version, actor, registryName, err)
 	}
 	defer func() {
 		if download.Cleanup != nil {
@@ -185,15 +187,34 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 		}
 	}()
 	if !strings.EqualFold(strings.TrimSpace(download.SHA256Hex), expectedSHA) {
-		return i.failInstall(ctx, appName, previousVersion, version, actor, registryName, fmt.Errorf("artifact digest mismatch: got %s, want %s", download.SHA256Hex, expectedSHA))
+		return i.failInstall(ctx, appName, restoreBaseline, previousVersion, version, actor, registryName, fmt.Errorf("artifact digest mismatch: got %s, want %s", download.SHA256Hex, expectedSHA))
 	}
 
 	if err := os.RemoveAll(stagingPath); err != nil {
-		return i.failInstall(ctx, appName, previousVersion, version, actor, registryName, fmt.Errorf("reset staging directory: %w", err))
+		return i.failInstall(ctx, appName, restoreBaseline, previousVersion, version, actor, registryName, fmt.Errorf("reset staging directory: %w", err))
 	}
 	if _, err := operator.InstallPublishedPackage(download.LocalPath, stagingPath, appName); err != nil {
 		_ = os.RemoveAll(stagingPath)
-		return i.failInstall(ctx, appName, previousVersion, version, actor, registryName, fmt.Errorf("materialize app artifact: %w", err))
+		return i.failInstall(ctx, appName, restoreBaseline, previousVersion, version, actor, registryName, fmt.Errorf("materialize app artifact: %w", err))
+	}
+
+	backupPath := materializedPath + ".backup"
+	if err := os.RemoveAll(backupPath); err != nil {
+		_ = os.RemoveAll(stagingPath)
+		return i.failInstall(ctx, appName, restoreBaseline, previousVersion, version, actor, registryName, fmt.Errorf("reset materialization backup directory: %w", err))
+	}
+	if _, err := os.Stat(materializedPath); err == nil {
+		if err := os.Rename(materializedPath, backupPath); err != nil {
+			_ = os.RemoveAll(stagingPath)
+			return i.failInstall(ctx, appName, restoreBaseline, previousVersion, version, actor, registryName, fmt.Errorf("backup current materialization directory: %w", err))
+		}
+	} else if !os.IsNotExist(err) {
+		_ = os.RemoveAll(stagingPath)
+		return i.failInstall(ctx, appName, restoreBaseline, previousVersion, version, actor, registryName, fmt.Errorf("stat materialization directory: %w", err))
+	}
+	if err := os.Rename(stagingPath, materializedPath); err != nil {
+		restoreMaterializationBackup(materializedPath, backupPath)
+		return i.failInstall(ctx, appName, restoreBaseline, previousVersion, version, actor, registryName, fmt.Errorf("promote staged app artifact: %w", err))
 	}
 
 	activeSince := i.now()
@@ -211,17 +232,10 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 		return nil
 	})
 	if err != nil {
-		_ = os.RemoveAll(stagingPath)
-		return i.failInstall(ctx, appName, previousVersion, version, actor, registryName, fmt.Errorf("write promoted app installation: %w", err))
+		restoreMaterializationBackup(materializedPath, backupPath)
+		return i.failInstall(ctx, appName, restoreBaseline, previousVersion, version, actor, registryName, fmt.Errorf("write promoted app installation: %w", err))
 	}
-	if err := os.RemoveAll(materializedPath); err != nil {
-		_ = os.RemoveAll(stagingPath)
-		return nil, fmt.Errorf("reset materialization directory after promote: %w", err)
-	}
-	if err := os.Rename(stagingPath, materializedPath); err != nil {
-		_ = os.RemoveAll(stagingPath)
-		return nil, fmt.Errorf("promote staged app artifact after promote: %w", err)
-	}
+	_ = os.RemoveAll(backupPath)
 
 	i.appendInstallEventBestEffort(ctx, &core.AppInstallationEvent{
 		InstallationID: appName,
@@ -241,9 +255,15 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 	}, nil
 }
 
-func (i *Installer) failInstall(ctx context.Context, appName, previousVersion, version, actor, registryName string, cause error) (*InstallOutput, error) {
+func (i *Installer) failInstall(ctx context.Context, appName string, restoreBaseline *core.AppInstallation, previousVersion, version, actor, registryName string, cause error) (*InstallOutput, error) {
 	cleanupCtx := context.WithoutCancel(ctx)
 	_, updateErr := i.Installations.UpdateInstallation(cleanupCtx, appName, func(installation *core.AppInstallation) error {
+		if restored := restoredInstallationAfterFailure(restoreBaseline, actor, registryName); restored != nil {
+			*installation = *restored
+			installation.AppName = appName
+			installation.RolloutStatus = core.AppInstallationRolloutStatusFailed
+			return nil
+		}
 		installation.RolloutStatus = core.AppInstallationRolloutStatusFailed
 		installation.VersionConstraint = version
 		installation.ResolvedVersion = version
@@ -316,6 +336,8 @@ func shouldPreservePriorMetadata(baseline *core.AppInstallation) bool {
 		previous := strings.TrimSpace(baseline.PreviousResolvedVersion)
 		resolved := strings.TrimSpace(baseline.ResolvedVersion)
 		return previous != "" && previous != resolved
+	case core.AppInstallationRolloutStatusFailed:
+		return strings.TrimSpace(baseline.ResolvedVersion) != ""
 	default:
 		return false
 	}
@@ -326,6 +348,88 @@ func (i *Installer) appendInstallEventBestEffort(ctx context.Context, event *cor
 		return
 	}
 	_, _ = i.Events.AppendEvent(context.WithoutCancel(ctx), event)
+}
+
+func restoreBaselineForInstall(existing *core.AppInstallation) *core.AppInstallation {
+	if existing == nil {
+		return nil
+	}
+	switch strings.TrimSpace(existing.RolloutStatus) {
+	case core.AppInstallationRolloutStatusPending:
+		previous := strings.TrimSpace(existing.PreviousResolvedVersion)
+		resolved := strings.TrimSpace(existing.ResolvedVersion)
+		if previous == "" || previous == resolved {
+			return nil
+		}
+		restored := cloneAppInstallation(existing)
+		restored.RolloutStatus = core.AppInstallationRolloutStatusPromoted
+		restored.VersionConstraint = previous
+		restored.ResolvedVersion = previous
+		return restored
+	default:
+		return cloneAppInstallation(existing)
+	}
+}
+
+func restoredInstallationAfterFailure(prior *core.AppInstallation, actor, registryName string) *core.AppInstallation {
+	if prior == nil {
+		return nil
+	}
+	switch strings.TrimSpace(prior.RolloutStatus) {
+	case core.AppInstallationRolloutStatusPromoted:
+		restored := cloneAppInstallation(prior)
+		if strings.TrimSpace(actor) != "" {
+			restored.InstalledBy = strings.TrimSpace(actor)
+		}
+		if strings.TrimSpace(registryName) != "" && strings.TrimSpace(restored.Registry) == "" {
+			restored.Registry = registryName
+		}
+		return restored
+	case core.AppInstallationRolloutStatusFailed:
+		if strings.TrimSpace(prior.ResolvedVersion) == "" {
+			return nil
+		}
+		restored := cloneAppInstallation(prior)
+		if strings.TrimSpace(actor) != "" {
+			restored.InstalledBy = strings.TrimSpace(actor)
+		}
+		if strings.TrimSpace(registryName) != "" && strings.TrimSpace(restored.Registry) == "" {
+			restored.Registry = registryName
+		}
+		return restored
+	default:
+		return nil
+	}
+}
+
+func restoreMaterializationBackup(materializedPath, backupPath string) {
+	_, err := os.Stat(backupPath)
+	if err == nil {
+		_ = os.RemoveAll(materializedPath)
+		_ = os.Rename(backupPath, materializedPath)
+		return
+	}
+	if os.IsNotExist(err) {
+		_ = os.RemoveAll(materializedPath)
+	}
+}
+
+func cloneAppInstallation(installation *core.AppInstallation) *core.AppInstallation {
+	if installation == nil {
+		return nil
+	}
+	cloned := *installation
+	if installation.ActiveSince != nil {
+		activeSince := *installation.ActiveSince
+		cloned.ActiveSince = &activeSince
+	}
+	if len(installation.ArtifactChecksums) > 0 {
+		cloned.ArtifactChecksums = make(map[string]string, len(installation.ArtifactChecksums))
+		for platform, digest := range installation.ArtifactChecksums {
+			cloned.ArtifactChecksums[platform] = digest
+		}
+	}
+	return &cloned
 }
 
 func (i *Installer) now() time.Time {

--- a/gestaltd/internal/appregistry/installer.go
+++ b/gestaltd/internal/appregistry/installer.go
@@ -150,8 +150,9 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 			return nil, fmt.Errorf("write pending app installation: %w", err)
 		}
 	} else {
+		baseline := existing
 		if _, err := i.Installations.UpdateInstallation(ctx, appName, func(installation *core.AppInstallation) error {
-			*installation = *pending
+			applyPendingInstall(installation, pending, baseline)
 			installation.AppName = appName
 			return nil
 		}); err != nil {
@@ -194,14 +195,6 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 		_ = os.RemoveAll(stagingPath)
 		return i.failInstall(ctx, appName, previousVersion, version, actor, registryName, fmt.Errorf("materialize app artifact: %w", err))
 	}
-	if err := os.RemoveAll(materializedPath); err != nil {
-		_ = os.RemoveAll(stagingPath)
-		return i.failInstall(ctx, appName, previousVersion, version, actor, registryName, fmt.Errorf("reset materialization directory: %w", err))
-	}
-	if err := os.Rename(stagingPath, materializedPath); err != nil {
-		_ = os.RemoveAll(stagingPath)
-		return i.failInstall(ctx, appName, previousVersion, version, actor, registryName, fmt.Errorf("promote staged app artifact: %w", err))
-	}
 
 	activeSince := i.now()
 	stored, err := i.Installations.UpdateInstallation(ctx, appName, func(installation *core.AppInstallation) error {
@@ -218,9 +211,19 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 		return nil
 	})
 	if err != nil {
+		_ = os.RemoveAll(stagingPath)
 		return i.failInstall(ctx, appName, previousVersion, version, actor, registryName, fmt.Errorf("write promoted app installation: %w", err))
 	}
-	if _, err := i.Events.AppendEvent(ctx, &core.AppInstallationEvent{
+	if err := os.RemoveAll(materializedPath); err != nil {
+		_ = os.RemoveAll(stagingPath)
+		return nil, fmt.Errorf("reset materialization directory after promote: %w", err)
+	}
+	if err := os.Rename(stagingPath, materializedPath); err != nil {
+		_ = os.RemoveAll(stagingPath)
+		return nil, fmt.Errorf("promote staged app artifact after promote: %w", err)
+	}
+
+	i.appendInstallEventBestEffort(ctx, &core.AppInstallationEvent{
 		InstallationID: appName,
 		FromVersion:    previousVersion,
 		ToVersion:      version,
@@ -230,9 +233,7 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 			"registry":          registryName,
 			"materialized_path": materializedPath,
 		},
-	}); err != nil {
-		return nil, fmt.Errorf("append promoted event after successful install: %w", err)
-	}
+	})
 
 	return &InstallOutput{
 		Installation:     stored,
@@ -282,6 +283,49 @@ func (i *Installer) lockInstall(appName string) func() {
 	mu := value.(*sync.Mutex)
 	mu.Lock()
 	return mu.Unlock
+}
+
+func applyPendingInstall(dst, pending, baseline *core.AppInstallation) {
+	dst.RolloutStatus = pending.RolloutStatus
+	dst.VersionConstraint = pending.VersionConstraint
+	dst.ResolvedVersion = pending.ResolvedVersion
+	dst.PreviousResolvedVersion = pending.PreviousResolvedVersion
+	if strings.TrimSpace(pending.InstalledBy) != "" {
+		dst.InstalledBy = pending.InstalledBy
+	}
+	if strings.TrimSpace(pending.Registry) != "" {
+		dst.Registry = pending.Registry
+	}
+	if shouldPreservePriorMetadata(baseline) {
+		return
+	}
+	dst.SourceRef = pending.SourceRef
+	dst.ProviderReleaseURL = pending.ProviderReleaseURL
+	dst.ArtifactChecksums = pending.ArtifactChecksums
+	dst.ActiveSince = nil
+}
+
+func shouldPreservePriorMetadata(baseline *core.AppInstallation) bool {
+	if baseline == nil {
+		return false
+	}
+	switch strings.TrimSpace(baseline.RolloutStatus) {
+	case core.AppInstallationRolloutStatusPromoted:
+		return true
+	case core.AppInstallationRolloutStatusPending:
+		previous := strings.TrimSpace(baseline.PreviousResolvedVersion)
+		resolved := strings.TrimSpace(baseline.ResolvedVersion)
+		return previous != "" && previous != resolved
+	default:
+		return false
+	}
+}
+
+func (i *Installer) appendInstallEventBestEffort(ctx context.Context, event *core.AppInstallationEvent) {
+	if i == nil || i.Events == nil || event == nil {
+		return
+	}
+	_, _ = i.Events.AppendEvent(context.WithoutCancel(ctx), event)
 }
 
 func (i *Installer) now() time.Time {

--- a/gestaltd/internal/appregistry/installer_backup_test.go
+++ b/gestaltd/internal/appregistry/installer_backup_test.go
@@ -1,0 +1,65 @@
+package appregistry
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRestoreMaterializationBackup(t *testing.T) {
+	t.Parallel()
+
+	t.Run("restores_when_backup_exists", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		materialized := filepath.Join(dir, "g-issues", "0.0.0-snapshot.v1")
+		backup := materialized + ".backup"
+		if err := os.MkdirAll(materialized, 0o755); err != nil {
+			t.Fatalf("MkdirAll materialized: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(materialized, "content.txt"), []byte("old"), 0o644); err != nil {
+			t.Fatalf("WriteFile old: %v", err)
+		}
+		if err := os.Rename(materialized, backup); err != nil {
+			t.Fatalf("Rename to backup: %v", err)
+		}
+		if err := os.MkdirAll(materialized, 0o755); err != nil {
+			t.Fatalf("MkdirAll staged materialized: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(materialized, "content.txt"), []byte("new"), 0o644); err != nil {
+			t.Fatalf("WriteFile staged: %v", err)
+		}
+
+		restoreMaterializationBackup(materialized, backup)
+
+		if _, err := os.Stat(backup); !os.IsNotExist(err) {
+			t.Fatalf("backup should be removed, stat err = %v", err)
+		}
+		if data, err := os.ReadFile(filepath.Join(materialized, "content.txt")); err != nil {
+			t.Fatalf("ReadFile restored materialized: %v", err)
+		} else if string(data) != "old" {
+			t.Fatalf("restored content = %q, want old", data)
+		}
+	})
+
+	t.Run("removes_materialized_when_no_backup", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		materialized := filepath.Join(dir, "g-issues", "0.0.0-snapshot.v1")
+		backup := materialized + ".backup"
+		if err := os.MkdirAll(materialized, 0o755); err != nil {
+			t.Fatalf("MkdirAll materialized: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(materialized, "orphan.txt"), []byte("orphan"), 0o644); err != nil {
+			t.Fatalf("WriteFile orphan: %v", err)
+		}
+
+		restoreMaterializationBackup(materialized, backup)
+
+		if _, err := os.Stat(materialized); !os.IsNotExist(err) {
+			t.Fatalf("materialized should be removed on first-install rollback, stat err = %v", err)
+		}
+	})
+}

--- a/gestaltd/internal/appregistry/installer_pending_test.go
+++ b/gestaltd/internal/appregistry/installer_pending_test.go
@@ -1,0 +1,72 @@
+package appregistry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+)
+
+func TestApplyPendingInstallPreservesPromotedMetadata(t *testing.T) {
+	t.Parallel()
+
+	activeSince := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	installedAt := time.Date(2026, 7, 8, 10, 0, 0, 0, time.UTC)
+	baseline := &core.AppInstallation{
+		AppName:            "g-issues",
+		VersionConstraint:  "0.0.0-snapshot.gold",
+		ResolvedVersion:    "0.0.0-snapshot.gold",
+		SourceRef:          "abc123def456abc123def456abc123def456abcd",
+		ProviderReleaseURL: "https://example.com/gold.json",
+		ArtifactChecksums:  map[string]string{"linux/amd64": "gold"},
+		RolloutStatus:      core.AppInstallationRolloutStatusPromoted,
+		ActiveSince:        &activeSince,
+		InstalledAt:        installedAt,
+	}
+	dst := cloneInstallation(baseline)
+	pending := &core.AppInstallation{
+		VersionConstraint:       "0.0.0-snapshot.new",
+		ResolvedVersion:         "0.0.0-snapshot.new",
+		SourceRef:               "def456abc123def456abc123def456abc123abcd",
+		ProviderReleaseURL:      "https://example.com/new.json",
+		ArtifactChecksums:       map[string]string{"linux/amd64": "new"},
+		RolloutStatus:           core.AppInstallationRolloutStatusPending,
+		PreviousResolvedVersion: "0.0.0-snapshot.gold",
+	}
+
+	applyPendingInstall(dst, pending, baseline)
+
+	if dst.RolloutStatus != core.AppInstallationRolloutStatusPending {
+		t.Fatalf("rollout_status = %q", dst.RolloutStatus)
+	}
+	if dst.ResolvedVersion != "0.0.0-snapshot.new" {
+		t.Fatalf("resolved_version = %q", dst.ResolvedVersion)
+	}
+	if dst.SourceRef != baseline.SourceRef {
+		t.Fatalf("source_ref = %q, want gold metadata preserved during pending", dst.SourceRef)
+	}
+	if dst.ActiveSince == nil || !dst.ActiveSince.Equal(activeSince) {
+		t.Fatalf("active_since = %v, want preserved during pending", dst.ActiveSince)
+	}
+	if !dst.InstalledAt.Equal(installedAt) {
+		t.Fatalf("installed_at = %v, want preserved", dst.InstalledAt)
+	}
+}
+
+func cloneInstallation(installation *core.AppInstallation) *core.AppInstallation {
+	if installation == nil {
+		return nil
+	}
+	cloned := *installation
+	if installation.ActiveSince != nil {
+		activeSince := *installation.ActiveSince
+		cloned.ActiveSince = &activeSince
+	}
+	if len(installation.ArtifactChecksums) > 0 {
+		cloned.ArtifactChecksums = make(map[string]string, len(installation.ArtifactChecksums))
+		for platform, digest := range installation.ArtifactChecksums {
+			cloned.ArtifactChecksums[platform] = digest
+		}
+	}
+	return &cloned
+}

--- a/gestaltd/internal/appregistry/installer_pending_test.go
+++ b/gestaltd/internal/appregistry/installer_pending_test.go
@@ -23,7 +23,7 @@ func TestApplyPendingInstallPreservesPromotedMetadata(t *testing.T) {
 		ActiveSince:        &activeSince,
 		InstalledAt:        installedAt,
 	}
-	dst := cloneInstallation(baseline)
+	dst := cloneAppInstallation(baseline)
 	pending := &core.AppInstallation{
 		VersionConstraint:       "0.0.0-snapshot.new",
 		ResolvedVersion:         "0.0.0-snapshot.new",
@@ -51,22 +51,4 @@ func TestApplyPendingInstallPreservesPromotedMetadata(t *testing.T) {
 	if !dst.InstalledAt.Equal(installedAt) {
 		t.Fatalf("installed_at = %v, want preserved", dst.InstalledAt)
 	}
-}
-
-func cloneInstallation(installation *core.AppInstallation) *core.AppInstallation {
-	if installation == nil {
-		return nil
-	}
-	cloned := *installation
-	if installation.ActiveSince != nil {
-		activeSince := *installation.ActiveSince
-		cloned.ActiveSince = &activeSince
-	}
-	if len(installation.ArtifactChecksums) > 0 {
-		cloned.ArtifactChecksums = make(map[string]string, len(installation.ArtifactChecksums))
-		for platform, digest := range installation.ArtifactChecksums {
-			cloned.ArtifactChecksums[platform] = digest
-		}
-	}
-	return &cloned
 }

--- a/gestaltd/internal/appregistry/installer_test.go
+++ b/gestaltd/internal/appregistry/installer_test.go
@@ -1,0 +1,172 @@
+package appregistry_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/appregistry"
+	"github.com/valon-technologies/gestalt/server/internal/appregistry/registrytest"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+)
+
+func TestInstallerInstallsRegistryAppAndWritesPromotedState(t *testing.T) {
+	t.Parallel()
+
+	fixture := registrytest.NewInstallFixture(t)
+	services := testutil.NewStubServices(t)
+	artifactsDir := t.TempDir()
+	promotedAt := time.Date(2026, 7, 10, 15, 30, 0, 0, time.UTC)
+
+	installer := &appregistry.Installer{
+		Registries: map[string]config.AppRegistryConfig{
+			"toolshed": fixture.Registry,
+		},
+		Reader:        fixture.Reader,
+		Installations: services.AppInstallations,
+		Events:        services.AppInstallationEvents,
+		ArtifactsDir:  artifactsDir,
+		Now: func() time.Time {
+			return promotedAt
+		},
+	}
+
+	result, err := installer.Install(t.Context(), appregistry.InstallInput{
+		Registry: "toolshed",
+		App:      "g-issues",
+		Version:  fixture.Version,
+		Actor:    "user:test",
+	})
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if result.Installation.RolloutStatus != core.AppInstallationRolloutStatusPromoted {
+		t.Fatalf("rollout_status = %q, want promoted", result.Installation.RolloutStatus)
+	}
+	if result.Installation.ResolvedVersion != fixture.Version {
+		t.Fatalf("resolved_version = %q", result.Installation.ResolvedVersion)
+	}
+	if result.Installation.ActiveSince == nil {
+		t.Fatal("active_since is nil")
+	}
+	if !result.Installation.ActiveSince.Equal(promotedAt) {
+		t.Fatalf("active_since = %v, want %v", result.Installation.ActiveSince, promotedAt)
+	}
+	if result.MaterializedPath == "" {
+		t.Fatal("materialized path is empty")
+	}
+	if _, err := os.Stat(filepath.Join(result.MaterializedPath, "manifest.yaml")); err != nil {
+		t.Fatalf("stat materialized manifest: %v", err)
+	}
+
+	events, err := services.AppInstallationEvents.ListEventsByApp(t.Context(), "g-issues")
+	if err != nil {
+		t.Fatalf("ListEventsByApp: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("events len = %d, want 2", len(events))
+	}
+	if events[0].Type != core.AppInstallationEventTypeInstallRequested {
+		t.Fatalf("events[0].type = %q", events[0].Type)
+	}
+	if events[1].Type != core.AppInstallationEventTypePromoted {
+		t.Fatalf("events[1].type = %q", events[1].Type)
+	}
+}
+
+func TestRegistryReader_FetchEntryNotFound(t *testing.T) {
+	t.Parallel()
+
+	fixture := registrytest.NewInstallFixture(t)
+	publicURL, err := fixture.Registry.PublicURL()
+	if err != nil {
+		t.Fatalf("PublicURL: %v", err)
+	}
+	_, err = fixture.Reader.FetchEntry(t.Context(), publicURL, "g-issues", "missing-version")
+	if !errors.Is(err, appregistry.ErrRegistryDocumentNotFound) {
+		t.Fatalf("FetchEntry error = %v, want ErrRegistryDocumentNotFound", err)
+	}
+}
+
+func TestInstallerMarksFailedOnDigestMismatch(t *testing.T) {
+	t.Parallel()
+
+	fixture := registrytest.NewInstallFixture(t)
+	badVersion := "0.0.0-snapshot.bad"
+	services := testutil.NewStubServices(t)
+	artifactsDir := t.TempDir()
+
+	installer := &appregistry.Installer{
+		Registries: map[string]config.AppRegistryConfig{
+			"toolshed": fixture.Registry,
+		},
+		Reader:        fixture.NewDigestMismatchReader(t, badVersion),
+		Installations: services.AppInstallations,
+		Events:        services.AppInstallationEvents,
+		ArtifactsDir:  artifactsDir,
+	}
+
+	_, err := installer.Install(t.Context(), appregistry.InstallInput{
+		Registry: "toolshed",
+		App:      "g-issues",
+		Version:  badVersion,
+	})
+	if err == nil {
+		t.Fatal("expected install failure")
+	}
+
+	stored, err := services.AppInstallations.GetInstallation(t.Context(), "g-issues")
+	if err != nil {
+		t.Fatalf("GetInstallation: %v", err)
+	}
+	if stored.RolloutStatus != core.AppInstallationRolloutStatusFailed {
+		t.Fatalf("rollout_status = %q, want failed", stored.RolloutStatus)
+	}
+}
+
+func TestInstallerSetsPreviousResolvedVersionOnUpgrade(t *testing.T) {
+	t.Parallel()
+
+	fixture := registrytest.NewInstallFixture(t)
+	services := testutil.NewStubServices(t)
+	artifactsDir := t.TempDir()
+	goldVersion := "0.0.0-snapshot.gold"
+	activeSince := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+
+	if _, err := services.AppInstallations.PutInstallation(t.Context(), &core.AppInstallation{
+		AppName:           "g-issues",
+		VersionConstraint: goldVersion,
+		ResolvedVersion:   goldVersion,
+		Registry:          "toolshed",
+		RolloutStatus:     core.AppInstallationRolloutStatusPromoted,
+		ActiveSince:       &activeSince,
+	}); err != nil {
+		t.Fatalf("PutInstallation: %v", err)
+	}
+
+	installer := &appregistry.Installer{
+		Registries: map[string]config.AppRegistryConfig{
+			"toolshed": fixture.Registry,
+		},
+		Reader:        fixture.Reader,
+		Installations: services.AppInstallations,
+		Events:        services.AppInstallationEvents,
+		ArtifactsDir:  artifactsDir,
+	}
+
+	result, err := installer.Install(t.Context(), appregistry.InstallInput{
+		Registry: "toolshed",
+		App:      "g-issues",
+		Version:  fixture.Version,
+	})
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if result.Installation.PreviousResolvedVersion != goldVersion {
+		t.Fatalf("previous_resolved_version = %q, want %q", result.Installation.PreviousResolvedVersion, goldVersion)
+	}
+}

--- a/gestaltd/internal/appregistry/installer_test.go
+++ b/gestaltd/internal/appregistry/installer_test.go
@@ -136,6 +136,7 @@ func TestInstallerSetsPreviousResolvedVersionOnUpgrade(t *testing.T) {
 	artifactsDir := t.TempDir()
 	goldVersion := "0.0.0-snapshot.gold"
 	activeSince := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	installedAt := time.Date(2026, 7, 8, 10, 0, 0, 0, time.UTC)
 
 	if _, err := services.AppInstallations.PutInstallation(t.Context(), &core.AppInstallation{
 		AppName:           "g-issues",
@@ -144,6 +145,7 @@ func TestInstallerSetsPreviousResolvedVersionOnUpgrade(t *testing.T) {
 		Registry:          "toolshed",
 		RolloutStatus:     core.AppInstallationRolloutStatusPromoted,
 		ActiveSince:       &activeSince,
+		InstalledAt:       installedAt,
 	}); err != nil {
 		t.Fatalf("PutInstallation: %v", err)
 	}
@@ -168,5 +170,8 @@ func TestInstallerSetsPreviousResolvedVersionOnUpgrade(t *testing.T) {
 	}
 	if result.Installation.PreviousResolvedVersion != goldVersion {
 		t.Fatalf("previous_resolved_version = %q, want %q", result.Installation.PreviousResolvedVersion, goldVersion)
+	}
+	if !result.Installation.InstalledAt.Equal(installedAt) {
+		t.Fatalf("installed_at = %v, want %v", result.Installation.InstalledAt, installedAt)
 	}
 }

--- a/gestaltd/internal/appregistry/installer_test.go
+++ b/gestaltd/internal/appregistry/installer_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/appregistry/registrytest"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	"github.com/valon-technologies/gestalt/server/services/apps/providerpkg"
 )
 
 func TestInstallerInstallsRegistryAppAndWritesPromotedState(t *testing.T) {
@@ -89,6 +90,69 @@ func TestRegistryReader_FetchEntryNotFound(t *testing.T) {
 	_, err = fixture.Reader.FetchEntry(t.Context(), publicURL, "g-issues", "missing-version")
 	if !errors.Is(err, appregistry.ErrRegistryDocumentNotFound) {
 		t.Fatalf("FetchEntry error = %v, want ErrRegistryDocumentNotFound", err)
+	}
+}
+
+func TestInstallerFailedUpgradePreservesPromotedMetadata(t *testing.T) {
+	t.Parallel()
+
+	fixture := registrytest.NewInstallFixture(t)
+	badVersion := "0.0.0-snapshot.bad"
+	services := testutil.NewStubServices(t)
+	artifactsDir := t.TempDir()
+	goldVersion := "0.0.0-snapshot.gold"
+	sourceRef := "abc123def456abc123def456abc123def456abcd"
+	activeSince := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	platform := providerpkg.CurrentPlatformString()
+
+	if _, err := services.AppInstallations.PutInstallation(t.Context(), &core.AppInstallation{
+		AppName:            "g-issues",
+		VersionConstraint:  goldVersion,
+		ResolvedVersion:    goldVersion,
+		SourceRef:          sourceRef,
+		Registry:           "toolshed",
+		ProviderReleaseURL: "https://example.com/gold.json",
+		ArtifactChecksums:  map[string]string{platform: "gold-checksum"},
+		RolloutStatus:      core.AppInstallationRolloutStatusPromoted,
+		ActiveSince:        &activeSince,
+	}); err != nil {
+		t.Fatalf("PutInstallation: %v", err)
+	}
+
+	installer := &appregistry.Installer{
+		Registries: map[string]config.AppRegistryConfig{
+			"toolshed": fixture.Registry,
+		},
+		Reader:        fixture.NewDigestMismatchReader(t, badVersion),
+		Installations: services.AppInstallations,
+		Events:        services.AppInstallationEvents,
+		ArtifactsDir:  artifactsDir,
+	}
+
+	_, err := installer.Install(t.Context(), appregistry.InstallInput{
+		Registry: "toolshed",
+		App:      "g-issues",
+		Version:  badVersion,
+	})
+	if err == nil {
+		t.Fatal("expected install failure")
+	}
+
+	stored, err := services.AppInstallations.GetInstallation(t.Context(), "g-issues")
+	if err != nil {
+		t.Fatalf("GetInstallation: %v", err)
+	}
+	if stored.RolloutStatus != core.AppInstallationRolloutStatusFailed {
+		t.Fatalf("rollout_status = %q, want failed", stored.RolloutStatus)
+	}
+	if stored.ResolvedVersion != goldVersion {
+		t.Fatalf("resolved_version = %q, want gold version preserved", stored.ResolvedVersion)
+	}
+	if stored.SourceRef != sourceRef {
+		t.Fatalf("source_ref = %q, want gold metadata preserved", stored.SourceRef)
+	}
+	if stored.ActiveSince == nil || !stored.ActiveSince.Equal(activeSince) {
+		t.Fatalf("active_since = %v, want gold metadata preserved", stored.ActiveSince)
 	}
 }
 

--- a/gestaltd/internal/appregistry/reader.go
+++ b/gestaltd/internal/appregistry/reader.go
@@ -2,6 +2,7 @@ package appregistry
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,6 +12,9 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/internal/providerregistry"
 )
+
+// ErrRegistryDocumentNotFound indicates a registry document path does not exist.
+var ErrRegistryDocumentNotFound = errors.New("app registry document not found")
 
 // RegistryReader fetches registry documents over HTTP from a registry public root.
 type RegistryReader struct {
@@ -22,6 +26,32 @@ func (r *RegistryReader) client() *http.Client {
 		return r.HTTPClient
 	}
 	return http.DefaultClient
+}
+
+func (r *RegistryReader) fetchJSON(ctx context.Context, url string, notFoundEmpty bool) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build app registry request: %w", err)
+	}
+	resp, err := r.client().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch app registry document %s: %w", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusNotFound {
+		if notFoundEmpty {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("%w: %s", ErrRegistryDocumentNotFound, url)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("fetch app registry document %s: unexpected status %s", url, resp.Status)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	if err != nil {
+		return nil, fmt.Errorf("read app registry document %s: %w", url, err)
+	}
+	return body, nil
 }
 
 // FetchAppIndex downloads apps/{app}/index.json from a registry public root.
@@ -39,26 +69,40 @@ func (r *RegistryReader) FetchAppIndex(ctx context.Context, publicRoot, appName 
 	}
 
 	url := PublicURL(publicRoot, AppIndexPath(appName))
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	body, err := r.fetchJSON(ctx, url, true)
 	if err != nil {
-		return nil, fmt.Errorf("build app registry index request: %w", err)
+		return nil, err
 	}
-	resp, err := r.client().Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("fetch app registry index %s: %w", url, err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode == http.StatusNotFound {
+	if body == nil {
 		return NewEmptyIndex(), nil
 	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("fetch app registry index %s: unexpected status %s", url, resp.Status)
-	}
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
-	if err != nil {
-		return nil, fmt.Errorf("read app registry index %s: %w", url, err)
-	}
 	return DecodeIndex(body)
+}
+
+// FetchEntry downloads apps/{app}/versions/{version}.json from a registry public root.
+func (r *RegistryReader) FetchEntry(ctx context.Context, publicRoot, appName, version string) (*Entry, error) {
+	appName = strings.TrimSpace(appName)
+	version = strings.TrimSpace(version)
+	if appName == "" {
+		return nil, fmt.Errorf("app name is required")
+	}
+	if version == "" {
+		return nil, fmt.Errorf("version is required")
+	}
+	if err := providerregistry.ValidateRepositoryName(appName); err != nil {
+		return nil, err
+	}
+	publicRoot = strings.TrimRight(strings.TrimSpace(publicRoot), "/")
+	if publicRoot == "" {
+		return nil, fmt.Errorf("registry public URL is required")
+	}
+
+	url := PublicURL(publicRoot, AppVersionEntryPath(appName, version))
+	body, err := r.fetchJSON(ctx, url, false)
+	if err != nil {
+		return nil, err
+	}
+	return DecodeEntry(body)
 }
 
 // VersionSummary is a lightweight view of one published app version from an index.

--- a/gestaltd/internal/appregistry/reader_test.go
+++ b/gestaltd/internal/appregistry/reader_test.go
@@ -101,6 +101,45 @@ func TestRegistryReader_FetchAppIndex_RejectsInvalidAppName(t *testing.T) {
 	}
 }
 
+func TestRegistryReader_FetchEntry(t *testing.T) {
+	t.Parallel()
+
+	entryJSON := `{
+  "schemaVersion": 1,
+  "app": "g-issues",
+  "version": "0.0.1",
+  "sourceRef": "abc123def456abc123def456abc123def456abcd",
+  "manifestPath": "valon-tools/apps/g-issues/manifest.yaml",
+  "repository": "github.com/valon-technologies/valon-tools",
+  "artifacts": {
+    "linux/amd64": {
+      "url": "gs://bucket/apps/g-issues/artifacts/0.0.1/pkg.tar.gz",
+      "publicUrl": "https://storage.googleapis.com/bucket/apps/g-issues/artifacts/0.0.1/pkg.tar.gz",
+      "sha256": "abc"
+    }
+  },
+  "publishedAt": "2026-07-10T02:00:00Z"
+}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/apps/g-issues/versions/0.0.1.json" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(entryJSON))
+	}))
+	defer srv.Close()
+
+	reader := &RegistryReader{HTTPClient: srv.Client()}
+	entry, err := reader.FetchEntry(t.Context(), srv.URL, "g-issues", "0.0.1")
+	if err != nil {
+		t.Fatalf("FetchEntry: %v", err)
+	}
+	if entry.App != "g-issues" || entry.Version != "0.0.1" {
+		t.Fatalf("entry = %#v", entry)
+	}
+}
+
 func TestRegistryReader_FetchAppIndex_RejectsInvalidJSON(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/appregistry/registrytest/fixture.go
+++ b/gestaltd/internal/appregistry/registrytest/fixture.go
@@ -1,0 +1,232 @@
+package registrytest
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/internal/appregistry"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/apps/packageio"
+	"github.com/valon-technologies/gestalt/server/services/apps/providerpkg"
+)
+
+const Bucket = "gitlab-peach-street-gestalt-app-registry"
+
+// InstallFixture is a published g-issues registry version with a downloadable archive.
+type InstallFixture struct {
+	Registry     config.AppRegistryConfig
+	Reader       *appregistry.RegistryReader
+	Version      string
+	SHA256       string
+	ArchiveBytes []byte
+}
+
+// NewInstallFixture builds a mock GCS registry with one installable app version.
+func NewInstallFixture(t *testing.T) InstallFixture {
+	t.Helper()
+
+	version := "0.0.0-snapshot.gabc123"
+	sourceRef := "abc123def456abc123def456abc123def456abcd"
+	platform := providerpkg.CurrentPlatformString()
+
+	root := t.TempDir()
+	packageRoot := filepath.Join(root, "package")
+	artifactRel := packageio.PackageExecutablePath("g-issues", runtime.GOOS)
+	artifactPath := filepath.Join(packageRoot, filepath.FromSlash(artifactRel))
+	if err := os.MkdirAll(filepath.Dir(artifactPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(artifactPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	digest, err := packageio.FileSHA256(artifactPath)
+	if err != nil {
+		t.Fatalf("FileSHA256: %v", err)
+	}
+
+	manifest := &providermanifestv1.Manifest{
+		Kind:    providermanifestv1.KindApp,
+		Source:  "github.com/valon-technologies/valon-tools/apps/g-issues",
+		Version: version,
+		Spec:    &providermanifestv1.Spec{},
+		Entrypoint: &providermanifestv1.Entrypoint{
+			ArtifactPath: artifactRel,
+		},
+		Artifacts: []providermanifestv1.Artifact{
+			{
+				OS:     runtime.GOOS,
+				Arch:   runtime.GOARCH,
+				Path:   artifactRel,
+				SHA256: digest,
+			},
+		},
+	}
+	manifestData, err := packageio.EncodeManifestFormat(manifest, packageio.ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("EncodeManifestFormat: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(packageRoot, "manifest.yaml"), manifestData, 0o644); err != nil {
+		t.Fatalf("WriteFile manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(packageRoot, providerpkg.StaticCatalogFile), []byte("name: g-issues\noperations:\n  - id: issues.list\n    method: POST\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile catalog: %v", err)
+	}
+
+	packagePath := filepath.Join(root, "artifact.tar.gz")
+	if err := packageio.CreatePackageFromDir(packageRoot, packagePath); err != nil {
+		t.Fatalf("CreatePackageFromDir: %v", err)
+	}
+	archiveBytes, err := os.ReadFile(packagePath)
+	if err != nil {
+		t.Fatalf("ReadFile package: %v", err)
+	}
+	archiveSHA, err := packageio.FileSHA256(packagePath)
+	if err != nil {
+		t.Fatalf("FileSHA256 package: %v", err)
+	}
+
+	entry := appregistry.Entry{
+		SchemaVersion: appregistry.EntrySchemaVersion,
+		App:           "g-issues",
+		Version:       version,
+		SourceRef:     sourceRef,
+		ManifestPath:  "valon-tools/apps/g-issues/manifest.yaml",
+		Repository:    "github.com/valon-technologies/valon-tools",
+		Artifacts: map[string]appregistry.Artifact{
+			platform: {
+				URL:       "gs://" + Bucket + "/apps/g-issues/artifacts/" + version + "/artifact.tar.gz",
+				PublicURL: "https://storage.googleapis.com/" + Bucket + "/apps/g-issues/artifacts/" + version + "/artifact.tar.gz",
+				SHA256:    archiveSHA,
+			},
+		},
+		PublishedAt: time.Date(2026, 7, 10, 2, 21, 54, 0, time.UTC),
+	}
+	entryJSON, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("Marshal entry: %v", err)
+	}
+
+	index := appregistry.Index{
+		SchemaVersion: appregistry.IndexSchemaVersion,
+		Apps: map[string]appregistry.AppVersions{
+			"g-issues": {
+				Versions: map[string]appregistry.IndexVersion{
+					version: {
+						Metadata:    appregistry.AppVersionEntryPath("g-issues", version),
+						Platforms:   []string{platform},
+						PublishedAt: entry.PublishedAt,
+					},
+				},
+			},
+		},
+	}
+	indexJSON, err := json.Marshal(index)
+	if err != nil {
+		t.Fatalf("Marshal index: %v", err)
+	}
+
+	registrySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/" + Bucket + "/apps/g-issues/index.json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(indexJSON)
+		case "/" + Bucket + "/apps/g-issues/versions/" + version + ".json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(entryJSON)
+		case "/" + Bucket + "/apps/g-issues/artifacts/" + version + "/artifact.tar.gz":
+			w.Header().Set("Content-Type", "application/gzip")
+			_, _ = w.Write(archiveBytes)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(registrySrv.Close)
+
+	registry, err := config.NewGCSAppRegistry(Bucket)
+	if err != nil {
+		t.Fatalf("NewGCSAppRegistry: %v", err)
+	}
+
+	return InstallFixture{
+		Registry:     registry,
+		Reader:       NewReaderForServer(t, registrySrv.URL),
+		Version:      version,
+		SHA256:       archiveSHA,
+		ArchiveBytes: archiveBytes,
+	}
+}
+
+// NewReaderForServer returns a reader that rewrites GCS public URLs to a test server.
+func NewReaderForServer(t *testing.T, serverURL string) *appregistry.RegistryReader {
+	t.Helper()
+	registryHost := strings.TrimPrefix(serverURL, "http://")
+	return &appregistry.RegistryReader{
+		HTTPClient: &http.Client{
+			Transport: &RewriteHostTransport{Host: registryHost, Scheme: "http"},
+		},
+	}
+}
+
+// NewDigestMismatchReader returns a reader whose entry advertises a bad checksum.
+func (f InstallFixture) NewDigestMismatchReader(t *testing.T, version string) *appregistry.RegistryReader {
+	t.Helper()
+
+	publicURL, err := f.Registry.PublicURL()
+	if err != nil {
+		t.Fatalf("PublicURL: %v", err)
+	}
+	entry, err := f.Reader.FetchEntry(t.Context(), publicURL, "g-issues", f.Version)
+	if err != nil {
+		t.Fatalf("FetchEntry: %v", err)
+	}
+	entry.Version = version
+	platform := providerpkg.CurrentPlatformString()
+	artifact := entry.Artifacts[platform]
+	artifact.SHA256 = "deadbeef"
+	entry.Artifacts[platform] = artifact
+	entryJSON, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	registrySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/" + Bucket + "/apps/g-issues/versions/" + version + ".json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(entryJSON)
+		case "/" + Bucket + "/apps/g-issues/artifacts/" + f.Version + "/artifact.tar.gz":
+			w.Header().Set("Content-Type", "application/gzip")
+			_, _ = w.Write(f.ArchiveBytes)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(registrySrv.Close)
+	return NewReaderForServer(t, registrySrv.URL)
+}
+
+// RewriteHostTransport redirects requests to a local test HTTP server.
+type RewriteHostTransport struct {
+	Host   string
+	Scheme string
+	Inner  http.RoundTripper
+}
+
+func (t *RewriteHostTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	clone.URL.Scheme = t.Scheme
+	clone.URL.Host = t.Host
+	inner := t.Inner
+	if inner == nil {
+		inner = http.DefaultTransport
+	}
+	return inner.RoundTrip(clone)
+}

--- a/gestaltd/internal/operator/package_install.go
+++ b/gestaltd/internal/operator/package_install.go
@@ -19,6 +19,37 @@ type installedPackage struct {
 	Manifest       *providermanifestv1.Manifest
 }
 
+// InstalledPackage is the on-disk layout after extracting a published app archive.
+type InstalledPackage struct {
+	Root           string
+	ManifestPath   string
+	ExecutablePath string
+	AssetRoot      string
+	Manifest       *providermanifestv1.Manifest
+}
+
+func installedPackageView(pkg *installedPackage) *InstalledPackage {
+	if pkg == nil {
+		return nil
+	}
+	return &InstalledPackage{
+		Root:           pkg.Root,
+		ManifestPath:   pkg.ManifestPath,
+		ExecutablePath: pkg.ExecutablePath,
+		AssetRoot:      pkg.AssetRoot,
+		Manifest:       pkg.Manifest,
+	}
+}
+
+// InstallPublishedPackage extracts a published app archive into destDir.
+func InstallPublishedPackage(packagePath, destDir, configuredName string) (*InstalledPackage, error) {
+	pkg, err := installPackageAs(packagePath, destDir, configuredName)
+	if err != nil {
+		return nil, err
+	}
+	return installedPackageView(pkg), nil
+}
+
 func isAssetOnly(manifest *providermanifestv1.Manifest) bool {
 	if manifest == nil || manifest.Spec == nil || strings.TrimSpace(manifest.Spec.AssetRoot) == "" {
 		return false

--- a/gestaltd/internal/server/handlers_admin_app_install.go
+++ b/gestaltd/internal/server/handlers_admin_app_install.go
@@ -1,0 +1,220 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/appregistry"
+	"github.com/valon-technologies/gestalt/server/internal/providerregistry"
+)
+
+type adminAppInstallationInfo struct {
+	AppName                 string            `json:"app"`
+	VersionConstraint       string            `json:"versionConstraint,omitempty"`
+	ResolvedVersion         string            `json:"resolvedVersion,omitempty"`
+	SourceRef               string            `json:"sourceRef,omitempty"`
+	Registry                string            `json:"registry,omitempty"`
+	ProviderReleaseURL      string            `json:"providerReleaseUrl,omitempty"`
+	ArtifactChecksums       map[string]string `json:"artifactChecksums,omitempty"`
+	RolloutStatus           string            `json:"rolloutStatus"`
+	ActiveSince             *string           `json:"activeSince,omitempty"`
+	PreviousResolvedVersion string            `json:"previousResolvedVersion,omitempty"`
+	InstalledBy             string            `json:"installedBy,omitempty"`
+	InstalledAt             string            `json:"installedAt,omitempty"`
+	UpdatedAt               string            `json:"updatedAt,omitempty"`
+}
+
+type adminAppRegistryInstallRequest struct {
+	Version string `json:"version"`
+	Actor   string `json:"actor,omitempty"`
+}
+
+type adminAppRegistryInstallResponse struct {
+	Registry         string                   `json:"registry"`
+	App              string                   `json:"app"`
+	Installation     adminAppInstallationInfo `json:"installation"`
+	MaterializedPath string                   `json:"materializedPath"`
+}
+
+func (s *Server) mountAdminAppInstallReadRoutes(r chi.Router) {
+	r.Get("/app-installations", s.listAdminAppInstallations)
+	r.Get("/app-installations/{app}", s.getAdminAppInstallation)
+}
+
+func (s *Server) mountAdminAppInstallWriteRoutes(r chi.Router) {
+	r.Post("/app-registries/{registry}/apps/{app}/install", s.installAdminAppRegistryApp)
+}
+
+func (s *Server) listAdminAppInstallations(w http.ResponseWriter, r *http.Request) {
+	if s.appRegistryInstaller == nil || s.appRegistryInstaller.Installations == nil {
+		writeError(w, http.StatusServiceUnavailable, "app installation service is unavailable")
+		return
+	}
+	rolloutStatus := strings.TrimSpace(r.URL.Query().Get("rolloutStatus"))
+	installations, err := s.appRegistryInstaller.Installations.ListInstallations(r.Context(), rolloutStatus)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if strings.Contains(err.Error(), "unsupported rollout_status") {
+			status = http.StatusBadRequest
+		}
+		writeError(w, status, "failed to list app installations")
+		return
+	}
+	out := make([]adminAppInstallationInfo, 0, len(installations))
+	for _, installation := range installations {
+		out = append(out, adminAppInstallationFromCore(installation))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (s *Server) getAdminAppInstallation(w http.ResponseWriter, r *http.Request) {
+	if s.appRegistryInstaller == nil || s.appRegistryInstaller.Installations == nil {
+		writeError(w, http.StatusServiceUnavailable, "app installation service is unavailable")
+		return
+	}
+	appName := strings.TrimSpace(chi.URLParam(r, "app"))
+	if appName == "" {
+		writeError(w, http.StatusBadRequest, "app is required")
+		return
+	}
+	if err := providerregistry.ValidateRepositoryName(appName); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid app name")
+		return
+	}
+	installation, err := s.appRegistryInstaller.Installations.GetInstallation(r.Context(), appName)
+	if err != nil {
+		if err == core.ErrNotFound {
+			writeError(w, http.StatusNotFound, "app installation not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to load app installation")
+		return
+	}
+	writeJSON(w, http.StatusOK, adminAppInstallationFromCore(installation))
+}
+
+func (s *Server) installAdminAppRegistryApp(w http.ResponseWriter, r *http.Request) {
+	if s.appRegistryInstaller == nil {
+		writeError(w, http.StatusServiceUnavailable, "app registry installer is unavailable")
+		return
+	}
+	registryName := strings.TrimSpace(chi.URLParam(r, "registry"))
+	appName := strings.TrimSpace(chi.URLParam(r, "app"))
+	if registryName == "" {
+		writeError(w, http.StatusBadRequest, "registry is required")
+		return
+	}
+	if appName == "" {
+		writeError(w, http.StatusBadRequest, "app is required")
+		return
+	}
+	if err := providerregistry.ValidateRepositoryName(appName); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid app name")
+		return
+	}
+	if len(s.appRegistries) == 0 {
+		writeError(w, http.StatusNotFound, "app registry not found")
+		return
+	}
+	if _, ok := s.appRegistries[registryName]; !ok {
+		writeError(w, http.StatusNotFound, "app registry not found")
+		return
+	}
+
+	var req adminAppRegistryInstallRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	version := strings.TrimSpace(req.Version)
+	if version == "" {
+		writeError(w, http.StatusBadRequest, "version is required")
+		return
+	}
+
+	result, err := s.appRegistryInstaller.Install(r.Context(), appregistry.InstallInput{
+		Registry: registryName,
+		App:      appName,
+		Version:  version,
+		Actor:    strings.TrimSpace(req.Actor),
+	})
+	if err != nil {
+		status := http.StatusBadGateway
+		switch {
+		case strings.Contains(err.Error(), "app registry not found"):
+			status = http.StatusNotFound
+		case strings.Contains(err.Error(), "artifacts directory is not configured"):
+			status = http.StatusInternalServerError
+		case strings.Contains(err.Error(), "invalid app name"),
+			strings.Contains(err.Error(), "registry is required"),
+			strings.Contains(err.Error(), "app is required"),
+			strings.Contains(err.Error(), "version is required"),
+			strings.Contains(err.Error(), "unsupported app registry kind"):
+			status = http.StatusBadRequest
+		case errors.Is(err, appregistry.ErrRegistryDocumentNotFound):
+			status = http.StatusNotFound
+		}
+		writeError(w, status, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, adminAppRegistryInstallResponse{
+		Registry:         registryName,
+		App:              appName,
+		Installation:     adminAppInstallationFromCore(result.Installation),
+		MaterializedPath: result.MaterializedPath,
+	})
+}
+
+func adminAppInstallationFromCore(installation *core.AppInstallation) adminAppInstallationInfo {
+	if installation == nil {
+		return adminAppInstallationInfo{}
+	}
+	info := adminAppInstallationInfo{
+		AppName:                 installation.AppName,
+		VersionConstraint:       installation.VersionConstraint,
+		ResolvedVersion:         installation.ResolvedVersion,
+		SourceRef:               installation.SourceRef,
+		Registry:                installation.Registry,
+		ProviderReleaseURL:      installation.ProviderReleaseURL,
+		ArtifactChecksums:       installation.ArtifactChecksums,
+		RolloutStatus:           installation.RolloutStatus,
+		PreviousResolvedVersion: installation.PreviousResolvedVersion,
+		InstalledBy:             installation.InstalledBy,
+	}
+	if installation.ActiveSince != nil {
+		formatted := installation.ActiveSince.UTC().Format(time.RFC3339)
+		info.ActiveSince = &formatted
+	}
+	if !installation.InstalledAt.IsZero() {
+		info.InstalledAt = installation.InstalledAt.UTC().Format(time.RFC3339)
+	}
+	if !installation.UpdatedAt.IsZero() {
+		info.UpdatedAt = installation.UpdatedAt.UTC().Format(time.RFC3339)
+	}
+	return info
+}
+
+func newAppRegistryInstaller(cfg Config) *appregistry.Installer {
+	if cfg.Services == nil || cfg.Services.AppInstallations == nil || cfg.Services.AppInstallationEvents == nil {
+		return nil
+	}
+	reader := cfg.AppRegistryReader
+	if reader == nil {
+		reader = &appregistry.RegistryReader{}
+	}
+	return &appregistry.Installer{
+		Registries:    cloneAppRegistryConfig(cfg.AppRegistries),
+		Reader:        reader,
+		Installations: cfg.Services.AppInstallations,
+		Events:        cfg.Services.AppInstallationEvents,
+		ArtifactsDir:  strings.TrimSpace(cfg.ArtifactsDir),
+	}
+}

--- a/gestaltd/internal/server/handlers_admin_app_install_test.go
+++ b/gestaltd/internal/server/handlers_admin_app_install_test.go
@@ -1,0 +1,165 @@
+package server_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/appregistry/registrytest"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/server"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+)
+
+func TestAdminAppRegistryInstall(t *testing.T) {
+	t.Parallel()
+
+	t.Run("promotes_and_lists_installation", func(t *testing.T) {
+		t.Parallel()
+
+		fixture := registrytest.NewInstallFixture(t)
+		artifactsDir := t.TempDir()
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.AppRegistries = map[string]config.AppRegistryConfig{
+				"toolshed": fixture.Registry,
+			}
+			cfg.AppRegistryReader = fixture.Reader
+			cfg.ArtifactsDir = artifactsDir
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		body := []byte(`{"version":"` + fixture.Version + `","actor":"user:alice"}`)
+		resp, err := http.Post(ts.URL+"/admin/api/v1/app-registries/toolshed/apps/g-issues/install", "application/json", bytes.NewReader(body))
+		if err != nil {
+			t.Fatalf("POST install: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			raw, _ := io.ReadAll(resp.Body)
+			t.Fatalf("install status = %d: %s", resp.StatusCode, raw)
+		}
+
+		var payload struct {
+			Registry         string `json:"registry"`
+			App              string `json:"app"`
+			MaterializedPath string `json:"materializedPath"`
+			Installation     struct {
+				RolloutStatus   string `json:"rolloutStatus"`
+				ResolvedVersion string `json:"resolvedVersion"`
+			} `json:"installation"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode install response: %v", err)
+		}
+		if payload.Registry != "toolshed" || payload.App != "g-issues" {
+			t.Fatalf("payload = %#v", payload)
+		}
+		if payload.Installation.RolloutStatus != core.AppInstallationRolloutStatusPromoted {
+			t.Fatalf("installation.rolloutStatus = %q", payload.Installation.RolloutStatus)
+		}
+		if payload.Installation.ResolvedVersion != fixture.Version {
+			t.Fatalf("installation.resolvedVersion = %q", payload.Installation.ResolvedVersion)
+		}
+		if payload.MaterializedPath == "" {
+			t.Fatal("materializedPath is empty")
+		}
+
+		listResp, err := http.Get(ts.URL + "/admin/api/v1/app-installations")
+		if err != nil {
+			t.Fatalf("GET app-installations: %v", err)
+		}
+		defer func() { _ = listResp.Body.Close() }()
+		if listResp.StatusCode != http.StatusOK {
+			raw, _ := io.ReadAll(listResp.Body)
+			t.Fatalf("list status = %d: %s", listResp.StatusCode, raw)
+		}
+		var installations []map[string]any
+		if err := json.NewDecoder(listResp.Body).Decode(&installations); err != nil {
+			t.Fatalf("decode installations: %v", err)
+		}
+		if len(installations) != 1 {
+			t.Fatalf("installations = %#v", installations)
+		}
+	})
+
+	t.Run("missing_version_returns_not_found", func(t *testing.T) {
+		t.Parallel()
+
+		registrySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.NotFound(w, r)
+		}))
+		defer registrySrv.Close()
+
+		reader := registrytest.NewReaderForServer(t, registrySrv.URL)
+		registry, err := config.NewGCSAppRegistry(registrytest.Bucket)
+		if err != nil {
+			t.Fatalf("NewGCSAppRegistry: %v", err)
+		}
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.AppRegistries = map[string]config.AppRegistryConfig{
+				"toolshed": registry,
+			}
+			cfg.AppRegistryReader = reader
+			cfg.ArtifactsDir = t.TempDir()
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		body := []byte(`{"version":"missing-version"}`)
+		resp, err := http.Post(ts.URL+"/admin/api/v1/app-registries/toolshed/apps/g-issues/install", "application/json", bytes.NewReader(body))
+		if err != nil {
+			t.Fatalf("POST install: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusNotFound {
+			raw, _ := io.ReadAll(resp.Body)
+			t.Fatalf("install status = %d, want 404: %s", resp.StatusCode, raw)
+		}
+	})
+
+	t.Run("get_installation_by_app", func(t *testing.T) {
+		t.Parallel()
+
+		fixture := registrytest.NewInstallFixture(t)
+		artifactsDir := t.TempDir()
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.AppRegistries = map[string]config.AppRegistryConfig{
+				"toolshed": fixture.Registry,
+			}
+			cfg.AppRegistryReader = fixture.Reader
+			cfg.ArtifactsDir = artifactsDir
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		installBody := []byte(`{"version":"` + fixture.Version + `"}`)
+		installResp, err := http.Post(ts.URL+"/admin/api/v1/app-registries/toolshed/apps/g-issues/install", "application/json", bytes.NewReader(installBody))
+		if err != nil {
+			t.Fatalf("POST install: %v", err)
+		}
+		_ = installResp.Body.Close()
+		if installResp.StatusCode != http.StatusOK {
+			t.Fatalf("install status = %d", installResp.StatusCode)
+		}
+
+		getResp, err := http.Get(ts.URL + "/admin/api/v1/app-installations/g-issues")
+		if err != nil {
+			t.Fatalf("GET installation: %v", err)
+		}
+		defer func() { _ = getResp.Body.Close() }()
+		if getResp.StatusCode != http.StatusOK {
+			raw, _ := io.ReadAll(getResp.Body)
+			t.Fatalf("get status = %d: %s", getResp.StatusCode, raw)
+		}
+		var installation map[string]any
+		if err := json.NewDecoder(getResp.Body).Decode(&installation); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if installation["app"] != "g-issues" {
+			t.Fatalf("installation = %#v", installation)
+		}
+	})
+}

--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -93,10 +93,17 @@ func (s *Server) mountAdminUIRoutes(r chi.Router) {
 
 func (s *Server) mountAdminAPIRoutes(r chi.Router) {
 	r.Route("/admin/api/v1", func(r chi.Router) {
-		r.Use(middleware.Timeout(60 * time.Second))
 		r.Use(s.adminAPIAuthMiddleware)
-		s.mountAdminRuntimeRoutes(r)
-		s.mountAdminAppRegistryRoutes(r)
+		r.Group(func(r chi.Router) {
+			r.Use(middleware.Timeout(60 * time.Second))
+			s.mountAdminRuntimeRoutes(r)
+			s.mountAdminAppRegistryRoutes(r)
+			s.mountAdminAppInstallReadRoutes(r)
+		})
+		r.Group(func(r chi.Router) {
+			r.Use(middleware.Timeout(10 * time.Minute))
+			s.mountAdminAppInstallWriteRoutes(r)
+		})
 	})
 }
 

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -113,6 +113,7 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 			AllowedRoles:        append([]string(nil), cfg.Server.Admin.AllowedRoles...),
 		},
 		AppRegistries: cfg.AppRegistries,
+		ArtifactsDir:  cfg.Server.ArtifactsDir,
 	}
 
 	if err := result.Start(ctx); err != nil {

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -145,6 +145,7 @@ type Server struct {
 	adminUI                http.Handler
 	appRegistries          map[string]config.AppRegistryConfig
 	appRegistryReader      *appregistry.RegistryReader
+	appRegistryInstaller   *appregistry.Installer
 	routeProfile           RouteProfile
 	activateAppProviders   func(context.Context)
 }
@@ -201,6 +202,7 @@ type Config struct {
 	BuiltinAdminUI         *BuiltinAdminUIOptions
 	AppRegistries          map[string]config.AppRegistryConfig
 	AppRegistryReader      *appregistry.RegistryReader
+	ArtifactsDir           string
 	RouteProfile           RouteProfile
 	MeterProvider          metric.MeterProvider
 	TracerProvider         trace.TracerProvider
@@ -395,6 +397,7 @@ func New(cfg Config) (*Server, error) {
 		adminUI:                adminUI,
 		appRegistries:          cloneAppRegistryConfig(cfg.AppRegistries),
 		appRegistryReader:      cfg.AppRegistryReader,
+		appRegistryInstaller:   newAppRegistryInstaller(cfg),
 		routeProfile:           cfg.RouteProfile,
 		activateAppProviders:   cfg.ActivateAppProviders,
 	}


### PR DESCRIPTION
## Summary

Clean reimplementation of [plan step 6](https://github.com/valon-technologies/gestalt/blob/main/plans/app_registry/plan.md) from `main`, replacing #2720 after review churn.

- Add `appregistry.Installer` to fetch a published version entry, write `pending` → `promoted` (or `failed`) rows in `app_installations`, append lifecycle events, download the platform artifact, verify SHA256, and extract it under `{artifactsDir}/registry-installed/{app}/{version}/`.
- Extend `RegistryReader` with `FetchEntry` for `apps/{app}/versions/{version}.json`.
- Expose admin routes per [api.md](https://github.com/valon-technologies/gestalt/blob/main/plans/app_registry/api.md):
  - `POST /admin/api/v1/app-registries/{registry}/apps/{app}/install`
  - `GET /admin/api/v1/app-installations` (optional `?rolloutStatus=`)
  - `GET /admin/api/v1/app-installations/{app}`
- Wire `server.ArtifactsDir` from deploy config into the installer; give install POST a 10-minute timeout.

Builds on step 5 (#2718) IndexedDB install state and step 4 (#2716) registry listing API.

## Test plan

- [x] `go test ./internal/appregistry/... -run Install`
- [x] `go test ./internal/server/... -run Install`
- [ ] Manual: with `appRegistries` configured and a published `g-issues` snapshot, call install on a running gestaltd management listener and confirm promoted row + materialized artifact path

Example:

```bash
curl -sS -X POST "$GESTALTD_URL/admin/api/v1/app-registries/toolshed/apps/g-issues/install" \
  -H 'Content-Type: application/json' \
  -d '{"version":"0.0.0-snapshot.gabc123","actor":"user:alice"}' | jq .
```

Made with [Cursor](https://cursor.com)