### PR TITLE
gestaltd: PR2 plan-6 thermo-nuclear deletion cleanup

### DIFF
--- a/gestaltd/core/testing/stubs_authorization.go
+++ b/gestaltd/core/testing/stubs_authorization.go
@@ -1,0 +1,105 @@
+package coretesting
+
+import (
+	"context"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+)
+
+// StubAuthorizationProvider is a no-op authorization provider for tests.
+// When Allowed is nil, CheckAccess allows requests.
+type StubAuthorizationProvider struct {
+	Allowed *bool
+
+	Called   bool
+	Ctx      context.Context
+	Request  *proto.CheckAccessRequest
+	Requests []*proto.CheckAccessRequest
+
+	CheckAccessFn func(context.Context, *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error)
+}
+
+// NewStubAuthorizationProvider returns an authorization stub that allows all requests.
+func NewStubAuthorizationProvider() *StubAuthorizationProvider {
+	return &StubAuthorizationProvider{}
+}
+
+func (p *StubAuthorizationProvider) CheckAccess(ctx context.Context, req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
+	if p == nil {
+		return &proto.CheckAccessResponse{}, nil
+	}
+	if p.CheckAccessFn != nil {
+		return p.CheckAccessFn(ctx, req)
+	}
+	p.Called = true
+	p.Ctx = ctx
+	p.Request = req
+	p.Requests = append(p.Requests, req)
+	allowed := true
+	if p.Allowed != nil {
+		allowed = *p.Allowed
+	}
+	return &proto.CheckAccessResponse{Allowed: allowed}, nil
+}
+
+func (p *StubAuthorizationProvider) CheckAccessMany(ctx context.Context, req *proto.CheckAccessManyRequest) (*proto.CheckAccessManyResponse, error) {
+	resp := &proto.CheckAccessManyResponse{Decisions: make([]*proto.CheckAccessResponse, 0, len(req.GetRequests()))}
+	for _, check := range req.GetRequests() {
+		decision, err := p.CheckAccess(ctx, check)
+		if err != nil {
+			return nil, err
+		}
+		resp.Decisions = append(resp.Decisions, decision)
+	}
+	return resp, nil
+}
+
+func (p *StubAuthorizationProvider) ListRelationships(context.Context, *proto.ListRelationshipsRequest) (*proto.ListRelationshipsResponse, error) {
+	return &proto.ListRelationshipsResponse{}, nil
+}
+
+func (p *StubAuthorizationProvider) AddRelationship(context.Context, *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {
+	return &proto.AddRelationshipResponse{}, nil
+}
+
+func (p *StubAuthorizationProvider) DeleteRelationship(context.Context, *proto.DeleteRelationshipRequest) (*proto.DeleteRelationshipResponse, error) {
+	return &proto.DeleteRelationshipResponse{}, nil
+}
+
+func (p *StubAuthorizationProvider) SetAuthorizationState(context.Context, *proto.SetAuthorizationStateRequest) (*proto.SetAuthorizationStateResponse, error) {
+	return &proto.SetAuthorizationStateResponse{}, nil
+}
+
+func (p *StubAuthorizationProvider) GetActiveModelRef(context.Context) (*proto.GetActiveModelRefResponse, error) {
+	return &proto.GetActiveModelRefResponse{}, nil
+}
+
+func (p *StubAuthorizationProvider) SetActiveModel(context.Context, *proto.SetActiveModelRequest) (*proto.SetActiveModelResponse, error) {
+	return &proto.SetActiveModelResponse{}, nil
+}
+
+func (p *StubAuthorizationProvider) ListActiveModelResourceTypes(context.Context, *proto.ListActiveModelResourceTypesRequest) (*proto.ListActiveModelResourceTypesResponse, error) {
+	return &proto.ListActiveModelResourceTypesResponse{}, nil
+}
+
+func (p *StubAuthorizationProvider) Ping(context.Context) error { return nil }
+
+func (p *StubAuthorizationProvider) Close() error { return nil }
+
+// AppRoutingStub returns a catalog-only app provider stub for remote routing tests.
+func AppRoutingStub(name, operation string) *StubIntegration {
+	return &StubIntegration{
+		N:        name,
+		ConnMode: core.ConnectionModeNone,
+		CatalogVal: &catalog.Catalog{
+			Operations: []catalog.CatalogOperation{{ID: operation}},
+		},
+	}
+}
+
+// BoolPtr returns a pointer to the given bool value.
+func BoolPtr(value bool) *bool {
+	return &value
+}

--- a/gestaltd/internal/bootstrap/executable_app_test.go
+++ b/gestaltd/internal/bootstrap/executable_app_test.go
@@ -101,52 +101,6 @@ type nestedInvokeHarness struct {
 	services *coredata.Services
 }
 
-type allowAllAuthorizationProvider struct{}
-
-func newAllowAllAuthorizationProvider() core.AuthorizationProvider {
-	return &allowAllAuthorizationProvider{}
-}
-
-func (p *allowAllAuthorizationProvider) CheckAccess(context.Context, *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
-	return &proto.CheckAccessResponse{Allowed: true}, nil
-}
-
-func (p *allowAllAuthorizationProvider) CheckAccessMany(ctx context.Context, req *proto.CheckAccessManyRequest) (*proto.CheckAccessManyResponse, error) {
-	resp := &proto.CheckAccessManyResponse{Decisions: make([]*proto.CheckAccessResponse, 0, len(req.GetRequests()))}
-	for range req.GetRequests() {
-		decision, err := p.CheckAccess(ctx, nil)
-		if err != nil {
-			return nil, err
-		}
-		resp.Decisions = append(resp.Decisions, decision)
-	}
-	return resp, nil
-}
-
-func (p *allowAllAuthorizationProvider) ListRelationships(context.Context, *proto.ListRelationshipsRequest) (*proto.ListRelationshipsResponse, error) {
-	return &proto.ListRelationshipsResponse{}, nil
-}
-func (p *allowAllAuthorizationProvider) AddRelationship(context.Context, *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {
-	return &proto.AddRelationshipResponse{}, nil
-}
-func (p *allowAllAuthorizationProvider) DeleteRelationship(context.Context, *proto.DeleteRelationshipRequest) (*proto.DeleteRelationshipResponse, error) {
-	return &proto.DeleteRelationshipResponse{}, nil
-}
-func (p *allowAllAuthorizationProvider) SetAuthorizationState(context.Context, *proto.SetAuthorizationStateRequest) (*proto.SetAuthorizationStateResponse, error) {
-	return &proto.SetAuthorizationStateResponse{}, nil
-}
-func (p *allowAllAuthorizationProvider) GetActiveModelRef(context.Context) (*proto.GetActiveModelRefResponse, error) {
-	return &proto.GetActiveModelRefResponse{}, nil
-}
-func (p *allowAllAuthorizationProvider) SetActiveModel(context.Context, *proto.SetActiveModelRequest) (*proto.SetActiveModelResponse, error) {
-	return &proto.SetActiveModelResponse{}, nil
-}
-func (p *allowAllAuthorizationProvider) ListActiveModelResourceTypes(context.Context, *proto.ListActiveModelResourceTypesRequest) (*proto.ListActiveModelResourceTypesResponse, error) {
-	return &proto.ListActiveModelResourceTypesResponse{}, nil
-}
-func (p *allowAllAuthorizationProvider) Ping(context.Context) error { return nil }
-func (p *allowAllAuthorizationProvider) Close() error               { return nil }
-
 type workflowCapabilitiesAuthorizationProvider struct {
 	allowed map[string]map[string]struct{}
 }
@@ -2886,7 +2840,7 @@ func newNestedInvokeHarness(t *testing.T, brokerOpts ...invocation.BrokerOption)
 	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), testRuntimePublicEndpointDeps(t, Deps{
 		EncryptionKey: secret,
 		AppInvocation: bridge,
-		Authorization: newAllowAllAuthorizationProvider(),
+		Authorization: coretesting.NewStubAuthorizationProvider(),
 	}))
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
@@ -3006,7 +2960,7 @@ func newGraphQLSurfaceInvokeHarness(t *testing.T, graphQLURL string, allowSurfac
 	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), testRuntimePublicEndpointDeps(t, Deps{
 		EncryptionKey: secret,
 		AppInvocation: bridge,
-		Authorization: newAllowAllAuthorizationProvider(),
+		Authorization: coretesting.NewStubAuthorizationProvider(),
 	}))
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
@@ -3993,7 +3947,7 @@ func TestAppWorkflowManagerDefinitionLifecycleUsesRequestContext(t *testing.T) {
 	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), testRuntimePublicEndpointDeps(t, Deps{
 		EncryptionKey:   secret,
 		WorkflowManager: manager,
-		Authorization:   newAllowAllAuthorizationProvider(),
+		Authorization:   coretesting.NewStubAuthorizationProvider(),
 	}))
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
@@ -6193,7 +6147,7 @@ func TestRuntimePublicAppInvocationRelayRoundTripsThroughHostedApp(t *testing.T)
 		EncryptionKey:      secret,
 		AppInvocation:      bridge,
 		PublicHostServices: publicHostServices,
-		Authorization:      newAllowAllAuthorizationProvider(),
+		Authorization:      coretesting.NewStubAuthorizationProvider(),
 	}
 	deps.RuntimeRegistry = newRuntimeRegistry(cfg, factories.Runtime, deps)
 
@@ -6954,7 +6908,7 @@ func TestRuntimePublicWorkflowManagerRelayRoundTripsThroughHostedApp(t *testing.
 		EncryptionKey:      secret,
 		WorkflowManager:    manager,
 		PublicHostServices: publicHostServices,
-		Authorization:      newAllowAllAuthorizationProvider(),
+		Authorization:      coretesting.NewStubAuthorizationProvider(),
 	}
 	deps.RuntimeRegistry = newRuntimeRegistry(cfg, factories.Runtime, deps)
 

--- a/gestaltd/internal/server/public_grpc_test.go
+++ b/gestaltd/internal/server/public_grpc_test.go
@@ -34,7 +34,7 @@ func configurePublicGRPCTestServer(t *testing.T, cfg *server.Config, invoker *re
 		t.Fatalf("NewGeneratedRegistry: %v", err)
 	}
 	transport := providergateway.NewProviderGatewayTransport()
-	authz := &serviceAccountCredentialAuthorizationProvider{allowed: true}
+	authz := coretesting.NewStubAuthorizationProvider()
 	transport.SetIdentityProvider(testAuthStubForScopedBearer())
 	transport.SetPublicMethods(registry)
 	transport.SetAuthorizationProvider(authz)
@@ -96,16 +96,6 @@ func publicGRPCRemoteClientSet(t *testing.T, ts *httptest.Server, scope string) 
 	return clients
 }
 
-func remoteRoutingAppStub(name, operation string) *coretesting.StubIntegration {
-	return &coretesting.StubIntegration{
-		N:        name,
-		ConnMode: core.ConnectionModeNone,
-		CatalogVal: &catalog.Catalog{
-			Operations: []catalog.CatalogOperation{{ID: operation}},
-		},
-	}
-}
-
 // TestPublicGRPCRouting verifies public gRPC wiring end-to-end: bearer-authenticated
 // gRPC is handled by the public gateway surface, while host-service relay traffic
 // continues through the trusted relay path. Individual RPC policy and per-service
@@ -119,8 +109,8 @@ func TestPublicGRPCRouting(t *testing.T) {
 		stubDB := &coretesting.StubIndexedDB{}
 		ts, invoker := startPublicGRPCServer(t, func(cfg *server.Config) {
 			cfg.Providers = testutil.NewProviderRegistry(t,
-				remoteRoutingAppStub("linear", "issues.list"),
-				remoteRoutingAppStub("valon-profile", "issues.list"),
+				coretesting.AppRoutingStub("linear", "issues.list"),
+				coretesting.AppRoutingStub("valon-profile", "issues.list"),
 			)
 			cfg.IndexedDB = stubDB
 		})
@@ -194,9 +184,9 @@ func TestPublicGRPCRouting(t *testing.T) {
 	t.Run("app invoke skips gateway authorization", func(t *testing.T) {
 		t.Parallel()
 
-		deniedAuthz := &serviceAccountCredentialAuthorizationProvider{allowed: false}
+		deniedAuthz := &coretesting.StubAuthorizationProvider{Allowed: coretesting.BoolPtr(false)}
 		ts, invoker := startPublicGRPCServer(t, func(cfg *server.Config) {
-			cfg.Providers = testutil.NewProviderRegistry(t, remoteRoutingAppStub("linear", "issues.list"))
+			cfg.Providers = testutil.NewProviderRegistry(t, coretesting.AppRoutingStub("linear", "issues.list"))
 			cfg.Authorization = deniedAuthz
 			cfg.PublicGatewayTransport.SetAuthorizationProvider(deniedAuthz)
 		})
@@ -224,8 +214,8 @@ func TestPublicGRPCRouting(t *testing.T) {
 		if !introspect.GetActive() {
 			t.Fatal("Introspect active = false, want true")
 		}
-		if len(deniedAuthz.requests) != 0 {
-			t.Fatalf("authorization requests = %d, want 0 at gateway", len(deniedAuthz.requests))
+		if len(deniedAuthz.Requests) != 0 {
+			t.Fatalf("authorization requests = %d, want 0 at gateway", len(deniedAuthz.Requests))
 		}
 	})
 

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -2740,18 +2740,6 @@ func (p *serverTestAuthorizationProvider) ListRelationships(_ context.Context, r
 	return &proto.ListRelationshipsResponse{Relationships: out}, nil
 }
 
-type serviceAccountCredentialAuthorizationProvider struct {
-	core.AuthorizationProvider
-
-	allowed  bool
-	requests []*proto.CheckAccessRequest
-}
-
-func (p *serviceAccountCredentialAuthorizationProvider) CheckAccess(_ context.Context, req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
-	p.requests = append(p.requests, req)
-	return &proto.CheckAccessResponse{Allowed: p.allowed}, nil
-}
-
 func (p *serverTestAuthorizationProvider) ListActiveModelResourceTypes(_ context.Context, req *proto.ListActiveModelResourceTypesRequest) (*proto.ListActiveModelResourceTypesResponse, error) {
 	name := strings.TrimSpace(req.GetFilter().GetName())
 	out := []*proto.AuthorizationModelResourceType{}
@@ -8906,7 +8894,7 @@ func TestStartIntegrationOAuth_ServiceAccountIDStoresCredentialForServiceAccount
 	const serviceAccountSubjectID = "service_account:oauth-bot"
 
 	svc := testutil.NewStubServices(t)
-	authz := &serviceAccountCredentialAuthorizationProvider{allowed: true}
+	authz := coretesting.NewStubAuthorizationProvider()
 
 	handler := &testOAuthHandler{
 		authorizationBaseURLVal: "https://auth.example.com/oauth/authorize",
@@ -8980,10 +8968,10 @@ func TestStartIntegrationOAuth_ServiceAccountIDStoresCredentialForServiceAccount
 	if tokens[0].Grant == nil || tokens[0].Grant.AccessToken != "service-account-oauth-token" {
 		t.Fatalf("stored grant = %+v, want access token service-account-oauth-token", tokens[0].Grant)
 	}
-	if len(authz.requests) != 1 {
-		t.Fatalf("authorization requests = %d, want 1", len(authz.requests))
+	if len(authz.Requests) != 1 {
+		t.Fatalf("authorization requests = %d, want 1", len(authz.Requests))
 	}
-	authReq := authz.requests[0]
+	authReq := authz.Requests[0]
 	if authReq.GetSubject().GetType() != "subject" || !strings.HasPrefix(authReq.GetSubject().GetId(), "user:") {
 		t.Fatalf("authorization subject = %+v, want user subject", authReq.GetSubject())
 	}
@@ -14392,7 +14380,7 @@ func TestConnectManual_ServiceAccountIDStoresCredentialForServiceAccount(t *test
 	const serviceAccountSubjectID = "service_account:manual-bot"
 
 	svc := testutil.NewStubServices(t)
-	authz := &serviceAccountCredentialAuthorizationProvider{allowed: true}
+	authz := coretesting.NewStubAuthorizationProvider()
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, &stubManualProvider{
@@ -14431,10 +14419,10 @@ func TestConnectManual_ServiceAccountIDStoresCredentialForServiceAccount(t *test
 	if tokens[0].Grant == nil || tokens[0].Grant.AccessToken != "manual-service-account-token" {
 		t.Fatalf("stored grant = %+v, want access token manual-service-account-token", tokens[0].Grant)
 	}
-	if len(authz.requests) != 1 {
-		t.Fatalf("authorization requests = %d, want 1", len(authz.requests))
+	if len(authz.Requests) != 1 {
+		t.Fatalf("authorization requests = %d, want 1", len(authz.Requests))
 	}
-	authReq := authz.requests[0]
+	authReq := authz.Requests[0]
 	if authReq.GetSubject().GetType() != "subject" || !strings.HasPrefix(authReq.GetSubject().GetId(), "user:") {
 		t.Fatalf("authorization subject = %+v, want user subject", authReq.GetSubject())
 	}
@@ -14459,7 +14447,7 @@ func TestConnectManual_ServiceAccountIDAuthorizesInvokingSubjectNotCredentialSub
 		t.Fatalf("FindOrCreateUser: %v", err)
 	}
 	apiToken := scopedTestBearerToken(user.ID, "")
-	authz := &serviceAccountCredentialAuthorizationProvider{allowed: true}
+	authz := coretesting.NewStubAuthorizationProvider()
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = testAuthStubForScopedBearer()
@@ -14489,10 +14477,10 @@ func TestConnectManual_ServiceAccountIDAuthorizesInvokingSubjectNotCredentialSub
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
 	}
-	if len(authz.requests) != 1 {
-		t.Fatalf("authorization requests = %d, want 1", len(authz.requests))
+	if len(authz.Requests) != 1 {
+		t.Fatalf("authorization requests = %d, want 1", len(authz.Requests))
 	}
-	authReq := authz.requests[0]
+	authReq := authz.Requests[0]
 	if got, want := authReq.GetSubject().GetId(), principal.UserSubjectID(user.ID); got != want {
 		t.Fatalf("authorization subject id = %q, want invoking subject %q", got, want)
 	}
@@ -14510,7 +14498,7 @@ func TestConnectManual_ServiceAccountIDRequiresManagesAuthorization(t *testing.T
 	const serviceAccountSubjectID = "service_account:manual-bot"
 
 	svc := testutil.NewStubServices(t)
-	authz := &serviceAccountCredentialAuthorizationProvider{allowed: false}
+	authz := &coretesting.StubAuthorizationProvider{Allowed: coretesting.BoolPtr(false)}
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, &stubManualProvider{
@@ -14538,10 +14526,10 @@ func TestConnectManual_ServiceAccountIDRequiresManagesAuthorization(t *testing.T
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("status = %d, want 403: %s", resp.StatusCode, body)
 	}
-	if len(authz.requests) != 1 {
-		t.Fatalf("authorization requests = %d, want 1", len(authz.requests))
+	if len(authz.Requests) != 1 {
+		t.Fatalf("authorization requests = %d, want 1", len(authz.Requests))
 	}
-	authReq := authz.requests[0]
+	authReq := authz.Requests[0]
 	if got := authReq.GetAction().GetName(); got != "manages" {
 		t.Fatalf("authorization action = %q, want manages", got)
 	}
@@ -14569,7 +14557,7 @@ func TestSelectPendingConnection_ServiceAccountIDRequiresManagesAuthorization(t 
 	testutil.CloseOnCleanup(t, discoverySrv)
 
 	svc := testutil.NewStubServices(t)
-	authz := &serviceAccountCredentialAuthorizationProvider{allowed: true}
+	authz := coretesting.NewStubAuthorizationProvider()
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{
@@ -14629,7 +14617,7 @@ func TestSelectPendingConnection_ServiceAccountIDRequiresManagesAuthorization(t 
 		t.Fatalf("connect response = %+v, want selection_required with pending token", connectResp)
 	}
 
-	authz.allowed = false
+	authz.Allowed = coretesting.BoolPtr(false)
 	form := url.Values{
 		"pending_token":   {connectResp.PendingToken},
 		"candidate_index": {"0"},
@@ -14646,10 +14634,10 @@ func TestSelectPendingConnection_ServiceAccountIDRequiresManagesAuthorization(t 
 		body, _ := io.ReadAll(selectResp.Body)
 		t.Fatalf("select status = %d, want 403: %s", selectResp.StatusCode, body)
 	}
-	if len(authz.requests) != 2 {
-		t.Fatalf("authorization requests = %d, want 2", len(authz.requests))
+	if len(authz.Requests) != 2 {
+		t.Fatalf("authorization requests = %d, want 2", len(authz.Requests))
 	}
-	for idx, authReq := range authz.requests {
+	for idx, authReq := range authz.Requests {
 		if got := authReq.GetAction().GetName(); got != "manages" {
 			t.Fatalf("authorization request %d action = %q, want manages", idx, got)
 		}

--- a/gestaltd/services/providergateway/gateway_test.go
+++ b/gestaltd/services/providergateway/gateway_test.go
@@ -55,7 +55,7 @@ func TestAuthorizeUsesAuthorizationProvider(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Issue: %v", err)
 	}
-	authorization := &stubAuthorizationProvider{}
+	authorization := &coretesting.StubAuthorizationProvider{}
 	transport := NewProviderGatewayTransport()
 	transport.SetAuthorizationProvider(authorization)
 	transport.SetCallerTokenPublicKey(publicKeyPEM)
@@ -71,22 +71,22 @@ func TestAuthorizeUsesAuthorizationProvider(t *testing.T) {
 	if !allowed {
 		t.Fatal("Authorize allowed = false, want true")
 	}
-	if !authorization.called {
+	if !authorization.Called {
 		t.Fatal("authorization provider was not called")
 	}
-	if got := authorization.request.GetSubject().GetType(); got != "subject" {
+	if got := authorization.Request.GetSubject().GetType(); got != "subject" {
 		t.Fatalf("Subject.Type = %q, want %q", got, "subject")
 	}
-	if got := authorization.request.GetSubject().GetId(); got != "user:alice" {
+	if got := authorization.Request.GetSubject().GetId(); got != "user:alice" {
 		t.Fatalf("Subject.Id = %q, want %q", got, "user:alice")
 	}
-	if got := authorization.request.GetAction().GetName(); got != "CheckAccess" {
+	if got := authorization.Request.GetAction().GetName(); got != "CheckAccess" {
 		t.Fatalf("Action.Name = %q, want %q", got, "CheckAccess")
 	}
-	if got := authorization.request.GetResource().GetType(); got != "provider" {
+	if got := authorization.Request.GetResource().GetType(); got != "provider" {
 		t.Fatalf("Resource.Type = %q, want %q", got, "provider")
 	}
-	if got := authorization.request.GetResource().GetId(); got != "authz-primary" {
+	if got := authorization.Request.GetResource().GetId(); got != "authz-primary" {
 		t.Fatalf("Resource.Id = %q, want %q", got, "authz-primary")
 	}
 }
@@ -107,7 +107,7 @@ func TestAuthorizeShadowModeAllowsDeniedRequests(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Issue: %v", err)
 	}
-	authorization := &stubAuthorizationProvider{allowedResult: boolPtr(false)}
+	authorization := &coretesting.StubAuthorizationProvider{Allowed: coretesting.BoolPtr(false)}
 	transport := NewProviderGatewayTransport()
 	transport.SetAuthorizationProvider(authorization)
 	transport.SetCallerTokenPublicKey(publicKeyPEM)
@@ -123,7 +123,7 @@ func TestAuthorizeShadowModeAllowsDeniedRequests(t *testing.T) {
 	if !allowed {
 		t.Fatal("Authorize allowed = false, want true in shadow mode")
 	}
-	if !authorization.called {
+	if !authorization.Called {
 		t.Fatal("authorization provider was not called")
 	}
 }
@@ -147,7 +147,7 @@ func TestAuthorizeRecordsAuthorizationMetrics(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Issue: %v", err)
 	}
-	authorization := &stubAuthorizationProvider{allowedResult: boolPtr(false)}
+	authorization := &coretesting.StubAuthorizationProvider{Allowed: coretesting.BoolPtr(false)}
 	transport := NewProviderGatewayTransport()
 	transport.SetAuthorizationProvider(authorization)
 	transport.SetCallerTokenPublicKey(publicKeyPEM)
@@ -200,7 +200,7 @@ func TestProviderGatewayTransportAuthorizesThenInvokesNext(t *testing.T) {
 func TestProviderGatewayTransportStoresAuthorizationProvider(t *testing.T) {
 	t.Parallel()
 
-	authorization := &stubAuthorizationProvider{}
+	authorization := &coretesting.StubAuthorizationProvider{}
 	transport := NewProviderGatewayTransport()
 
 	transport.SetAuthorizationProvider(authorization)
@@ -229,64 +229,6 @@ func TestDirectTransportInvokesNext(t *testing.T) {
 		t.Fatal("next was not called")
 	}
 }
-
-type stubAuthorizationProvider struct {
-	called        bool
-	allowedResult *bool
-	ctx           context.Context
-	request       *proto.CheckAccessRequest
-}
-
-func (p *stubAuthorizationProvider) CheckAccess(ctx context.Context, req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
-	p.called = true
-	p.ctx = ctx
-	p.request = req
-	allowed := true
-	if p.allowedResult != nil {
-		allowed = *p.allowedResult
-	}
-	return &proto.CheckAccessResponse{Allowed: allowed}, nil
-}
-
-func boolPtr(value bool) *bool {
-	return &value
-}
-
-func (p *stubAuthorizationProvider) CheckAccessMany(context.Context, *proto.CheckAccessManyRequest) (*proto.CheckAccessManyResponse, error) {
-	return &proto.CheckAccessManyResponse{}, nil
-}
-
-func (p *stubAuthorizationProvider) ListRelationships(context.Context, *proto.ListRelationshipsRequest) (*proto.ListRelationshipsResponse, error) {
-	return &proto.ListRelationshipsResponse{}, nil
-}
-
-func (p *stubAuthorizationProvider) AddRelationship(context.Context, *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {
-	return &proto.AddRelationshipResponse{}, nil
-}
-
-func (p *stubAuthorizationProvider) DeleteRelationship(context.Context, *proto.DeleteRelationshipRequest) (*proto.DeleteRelationshipResponse, error) {
-	return &proto.DeleteRelationshipResponse{}, nil
-}
-
-func (p *stubAuthorizationProvider) SetAuthorizationState(context.Context, *proto.SetAuthorizationStateRequest) (*proto.SetAuthorizationStateResponse, error) {
-	return &proto.SetAuthorizationStateResponse{}, nil
-}
-
-func (p *stubAuthorizationProvider) GetActiveModelRef(context.Context) (*proto.GetActiveModelRefResponse, error) {
-	return &proto.GetActiveModelRefResponse{}, nil
-}
-
-func (p *stubAuthorizationProvider) SetActiveModel(context.Context, *proto.SetActiveModelRequest) (*proto.SetActiveModelResponse, error) {
-	return &proto.SetActiveModelResponse{}, nil
-}
-
-func (p *stubAuthorizationProvider) ListActiveModelResourceTypes(context.Context, *proto.ListActiveModelResourceTypesRequest) (*proto.ListActiveModelResourceTypesResponse, error) {
-	return &proto.ListActiveModelResourceTypesResponse{}, nil
-}
-
-func (p *stubAuthorizationProvider) Ping(context.Context) error { return nil }
-
-func (p *stubAuthorizationProvider) Close() error { return nil }
 
 func TestDirectTransportInvokeRecordsMetrics(t *testing.T) {
 	t.Parallel()
@@ -451,7 +393,7 @@ func TestPreparePublicRequest(t *testing.T) {
 		wantSubject  string
 		setup        func(*ProviderGatewayTransport)
 		checkAdapted func(t *testing.T, adapted gproto.Message)
-		checkAuth    func(t *testing.T, auth *stubAuthorizationProvider)
+		checkAuth    func(t *testing.T, auth *coretesting.StubAuthorizationProvider)
 	}{
 		{
 			name:       "app invoke fills context",
@@ -531,9 +473,9 @@ func TestPreparePublicRequest(t *testing.T) {
 					t.Fatalf("context.subject.id = %q, want %q", out.GetContext().GetSubject().GetId(), "user:alice")
 				}
 			},
-			checkAuth: func(t *testing.T, auth *stubAuthorizationProvider) {
+			checkAuth: func(t *testing.T, auth *coretesting.StubAuthorizationProvider) {
 				t.Helper()
-				if got := auth.request.GetResource().GetId(); got != "roadmap" {
+				if got := auth.Request.GetResource().GetId(); got != "roadmap" {
 					t.Fatalf("Resource.Id = %q, want %q", got, "roadmap")
 				}
 			},
@@ -655,7 +597,7 @@ func TestPreparePublicRequest(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			authorization := &stubAuthorizationProvider{allowedResult: tc.authAllow}
+			authorization := &coretesting.StubAuthorizationProvider{Allowed: tc.authAllow}
 			identity := &coretesting.StubAuthProvider{
 				IntrospectFn: func(context.Context, *core.IntrospectRequest) (*core.IntrospectResponse, error) {
 					return tc.introspect, nil
@@ -698,7 +640,7 @@ func TestPreparePublicRequest(t *testing.T) {
 				tc.checkAdapted(t, adapted)
 			}
 			if tc.checkAuth != nil {
-				if !authorization.called {
+				if !authorization.Called {
 					t.Fatal("authorization provider was not called")
 				}
 				tc.checkAuth(t, authorization)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **PR 2** from the plan-6 remote routing sequence: maximum safe deletion without behavior changes.

The parent plan (`bc-019f5290`) is not accessible, so this applies the **thermo-nuclear deletion review** from PR #2672 against current `main`. Most high-priority targets from that review are already N/A on `main` because prior merges (#2689, #2694) consolidated `placement.go`, `remote_routing.go`, `remotefake`, and duplicate gRPC tests into simpler structures.

## Changes

- Add shared `coretesting.StubAuthorizationProvider` and `coretesting.AppRoutingStub`
- **Delete** duplicate `allowAllAuthorizationProvider` from `executable_app_test.go` (~45 lines)
- **Delete** duplicate `stubAuthorizationProvider` from `gateway_test.go` (~57 lines)
- **Delete** duplicate `serviceAccountCredentialAuthorizationProvider` from `server_test.go` (~12 lines)
- **Delete** redundant `remoteRoutingAppStub` wrapper in `public_grpc_test.go`

**Net: −21 lines** (175 deleted, 154 added in shared helper)

## Out of scope (PR 3)

- Issue-98 agent remote routing + bearer metadata E2E tests (draft PRs #2726, #2727)
- `remotefake` integration harness additions

## Test plan

- [x] `go test ./services/providergateway/...`
- [x] `go test ./internal/server/...`
- [x] `go test ./internal/bootstrap/...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f52a7-fb76-7788-b908-d26a02a4b3ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f52a7-fb76-7788-b908-d26a02a4b3ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

