### PR TITLE
Step 7: Lazy per-instance catalog convergence on startup

### DIFF
--- a/gestaltd/internal/appregistry/converger.go
+++ b/gestaltd/internal/appregistry/converger.go
@@ -1,0 +1,124 @@
+package appregistry
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
+)
+
+// Converger lazily materializes catalog-known app versions on this instance.
+type Converger struct {
+	Installer *Installer
+	Catalog   *coredata.AppVersionCatalogService
+
+	mu       sync.Mutex
+	inflight map[string]struct{}
+}
+
+func NewConverger(installer *Installer, catalog *coredata.AppVersionCatalogService) *Converger {
+	if installer == nil || catalog == nil {
+		return nil
+	}
+	return &Converger{
+		Installer: installer,
+		Catalog:   catalog,
+		inflight:  make(map[string]struct{}),
+	}
+}
+
+// ConvergeOnce materializes any catalog-known versions that are missing locally.
+func (c *Converger) ConvergeOnce(ctx context.Context) error {
+	if c == nil {
+		return nil
+	}
+	if c.Installer == nil || c.Catalog == nil {
+		return fmt.Errorf("app registry converger is not configured")
+	}
+	known, err := c.Catalog.ListAllKnownVersions(ctx)
+	if err != nil {
+		return fmt.Errorf("list catalog known versions: %w", err)
+	}
+	var firstErr error
+	for _, installation := range known {
+		if err := c.convergeInstallation(ctx, installation); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+// StartBackground runs ConvergeOnce without blocking server startup.
+func (c *Converger) StartBackground(ctx context.Context) {
+	if c == nil {
+		return
+	}
+	go func() {
+		if err := c.ConvergeOnce(context.WithoutCancel(ctx)); err != nil {
+			slog.Warn("app registry catalog convergence finished with errors", "error", err)
+			return
+		}
+		slog.Info("app registry catalog convergence complete")
+	}()
+}
+
+func (c *Converger) convergeInstallation(ctx context.Context, installation *core.AppInstallation) error {
+	if installation == nil {
+		return nil
+	}
+	appName := strings.TrimSpace(installation.AppName)
+	version := strings.TrimSpace(installation.Version)
+	if appName == "" || version == "" {
+		return nil
+	}
+	key := appName + "\x00" + version
+	if !c.beginInflight(key) {
+		return nil
+	}
+	defer c.endInflight(key)
+
+	materializedPath := LocalMaterializedPath(c.Installer.ArtifactsDir, appName, version)
+	if IsLocallyMaterialized(materializedPath) {
+		return nil
+	}
+
+	path, err := c.Installer.materializeKnownVersion(ctx, installation)
+	if err != nil {
+		slog.Warn("app registry local materialization failed",
+			"app", appName,
+			"version", version,
+			"registry", installation.Registry,
+			"error", err,
+		)
+		return fmt.Errorf("materialize %s@%s: %w", appName, version, err)
+	}
+	slog.Info("app registry local materialization complete",
+		"app", appName,
+		"version", version,
+		"path", path,
+	)
+	return nil
+}
+
+func (c *Converger) beginInflight(key string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.inflight == nil {
+		c.inflight = make(map[string]struct{})
+	}
+	if _, ok := c.inflight[key]; ok {
+		return false
+	}
+	c.inflight[key] = struct{}{}
+	return true
+}
+
+func (c *Converger) endInflight(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.inflight, key)
+}

--- a/gestaltd/internal/appregistry/converger_test.go
+++ b/gestaltd/internal/appregistry/converger_test.go
@@ -1,0 +1,105 @@
+package appregistry_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/appregistry"
+	"github.com/valon-technologies/gestalt/server/internal/appregistry/registrytest"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	"github.com/valon-technologies/gestalt/server/services/apps/providerpkg"
+)
+
+func TestConverger_materializes_catalog_known_version_locally(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc := testutil.NewStubServices(t)
+	fixture := registrytest.NewInstallFixture(t)
+	platform := providerpkg.CurrentPlatformString()
+	publicRoot, err := fixture.Registry.PublicURL()
+	if err != nil {
+		t.Fatalf("PublicURL: %v", err)
+	}
+
+	artifactsDir := t.TempDir()
+	_, err = svc.AppVersionCatalog.AppendRecord(ctx, &core.AppVersionCatalogRecord{
+		App:       "g-issues",
+		Version:   fixture.Version,
+		Type:      core.AppVersionCatalogRecordTypeVersionAdded,
+		Actor:     "user:alice",
+		Timestamp: time.Now().UTC().Truncate(time.Millisecond),
+		Metadata: coredata.VersionAddedMetadata(&core.AppInstallation{
+			AppName:            "g-issues",
+			Version:            fixture.Version,
+			Registry:           "toolshed",
+			SourceRef:          "abc123def456abc123def456abc123def456abcd",
+			ProviderReleaseURL: appregistry.PublicURL(publicRoot, appregistry.AppVersionEntryPath("g-issues", fixture.Version)),
+			ArtifactChecksums:  map[string]string{platform: fixture.SHA256},
+		}, appregistry.LocalMaterializedPath(artifactsDir, "g-issues", fixture.Version)),
+	})
+	if err != nil {
+		t.Fatalf("AppendRecord: %v", err)
+	}
+
+	installer := &appregistry.Installer{
+		Registries: map[string]config.AppRegistryConfig{
+			"toolshed": fixture.Registry,
+		},
+		Reader:       fixture.Reader,
+		Catalog:      svc.AppVersionCatalog,
+		Locks:        svc.AppVersionInstallLocks,
+		ArtifactsDir: artifactsDir,
+	}
+	converger := appregistry.NewConverger(installer, svc.AppVersionCatalog)
+	if converger == nil {
+		t.Fatal("expected converger")
+	}
+
+	path := appregistry.LocalMaterializedPath(artifactsDir, "g-issues", fixture.Version)
+	if appregistry.IsLocallyMaterialized(path) {
+		t.Fatal("expected version to be missing before convergence")
+	}
+	if err := converger.ConvergeOnce(ctx); err != nil {
+		t.Fatalf("ConvergeOnce: %v", err)
+	}
+	if !appregistry.IsLocallyMaterialized(path) {
+		t.Fatalf("expected version materialized at %s", path)
+	}
+}
+
+func TestConverger_skips_already_materialized_version(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc := testutil.NewStubServices(t)
+	fixture := registrytest.NewInstallFixture(t)
+	artifactsDir := t.TempDir()
+
+	installer := &appregistry.Installer{
+		Registries: map[string]config.AppRegistryConfig{
+			"toolshed": fixture.Registry,
+		},
+		Reader:       fixture.Reader,
+		Catalog:      svc.AppVersionCatalog,
+		Locks:        svc.AppVersionInstallLocks,
+		ArtifactsDir: artifactsDir,
+	}
+	if _, err := installer.Install(ctx, appregistry.InstallInput{
+		Registry: "toolshed",
+		App:      "g-issues",
+		Version:  fixture.Version,
+		Actor:    "user:alice",
+	}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	converger := appregistry.NewConverger(installer, svc.AppVersionCatalog)
+	if err := converger.ConvergeOnce(ctx); err != nil {
+		t.Fatalf("ConvergeOnce: %v", err)
+	}
+}

--- a/gestaltd/internal/appregistry/installer.go
+++ b/gestaltd/internal/appregistry/installer.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -99,79 +98,24 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 	if artifactsDir == "" {
 		return nil, fmt.Errorf("artifacts directory is not configured")
 	}
-	registry, ok := i.Registries[registryName]
-	if !ok {
-		return i.failInstall(installCtx, appName, version, actor, registryName, fmt.Errorf("app registry not found"))
-	}
-	if strings.TrimSpace(registry.Kind) != config.AppRegistryKindGCS {
-		return i.failInstall(installCtx, appName, version, actor, registryName, fmt.Errorf("unsupported app registry kind"))
-	}
-	publicRoot, err := registry.PublicURL()
-	if err != nil {
-		return i.failInstall(installCtx, appName, version, actor, registryName, fmt.Errorf("app registry public URL is invalid: %w", err))
-	}
 
-	reader := i.Reader
-	if reader == nil {
-		reader = &RegistryReader{}
-	}
-	entry, err := reader.FetchEntry(installCtx, publicRoot, appName, version)
-	if err != nil {
-		return i.failInstall(installCtx, appName, version, actor, registryName, fmt.Errorf("fetch app registry entry: %w", err))
-	}
-	if entry.App != appName {
-		return i.failInstall(installCtx, appName, version, actor, registryName, fmt.Errorf("registry entry app %q does not match requested app %q", entry.App, appName))
-	}
-	if entry.Version != version {
-		return i.failInstall(installCtx, appName, version, actor, registryName, fmt.Errorf("registry entry version %q does not match requested version %q", entry.Version, version))
-	}
-
-	platform := providerpkg.CurrentPlatformString()
-	artifact, ok := entry.Artifacts[platform]
-	if !ok {
-		return i.failInstall(installCtx, appName, version, actor, registryName, fmt.Errorf("registry entry has no artifact for platform %q", platform))
-	}
-	artifactURL := strings.TrimSpace(artifact.PublicURL)
-	if artifactURL == "" {
-		artifactURL = strings.TrimSpace(artifact.URL)
-	}
-	if artifactURL == "" {
-		return i.failInstall(installCtx, appName, version, actor, registryName, fmt.Errorf("registry entry artifact for platform %q has no download URL", platform))
-	}
-	expectedSHA := strings.TrimSpace(artifact.SHA256)
-	if expectedSHA == "" {
-		return i.failInstall(installCtx, appName, version, actor, registryName, fmt.Errorf("registry entry artifact for platform %q is missing sha256", platform))
-	}
-
-	entryURL := PublicURL(publicRoot, AppVersionEntryPath(appName, version))
-	checksums := map[string]string{platform: expectedSHA}
-	materializedPath := filepath.Join(artifactsDir, RegistryInstallSubdir, appName, version)
-
-	download, err := downloadRegistryArtifact(installCtx, reader.client(), artifactURL)
+	materialized, err := i.materializeRegistryVersion(installCtx, materializeRegistryVersionInput{
+		registryName: registryName,
+		appName:      appName,
+		version:      version,
+	})
 	if err != nil {
 		return i.failInstall(installCtx, appName, version, actor, registryName, err)
-	}
-	defer func() {
-		if download.Cleanup != nil {
-			download.Cleanup()
-		}
-	}()
-	if !strings.EqualFold(strings.TrimSpace(download.SHA256Hex), expectedSHA) {
-		return i.failInstall(installCtx, appName, version, actor, registryName, fmt.Errorf("artifact digest mismatch: got %s, want %s", download.SHA256Hex, expectedSHA))
-	}
-
-	if err := i.materializePublishedPackage(installCtx, download.LocalPath, materializedPath, appName); err != nil {
-		return i.failInstall(installCtx, appName, version, actor, registryName, fmt.Errorf("materialize app artifact: %w", err))
 	}
 
 	addedAt := i.now()
 	known := &core.AppInstallation{
 		AppName:            appName,
 		Version:            version,
-		SourceRef:          entry.SourceRef,
+		SourceRef:          materialized.entry.SourceRef,
 		Registry:           registryName,
-		ProviderReleaseURL: entryURL,
-		ArtifactChecksums:  checksums,
+		ProviderReleaseURL: materialized.entryURL,
+		ArtifactChecksums:  materialized.checksums,
 		InstalledBy:        actor,
 		InstalledAt:        addedAt,
 		UpdatedAt:          addedAt,
@@ -183,7 +127,7 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 		Type:      core.AppVersionCatalogRecordTypeVersionAdded,
 		Actor:     actor,
 		Timestamp: addedAt,
-		Metadata:  coredata.VersionAddedMetadata(known, materializedPath),
+		Metadata:  coredata.VersionAddedMetadata(known, materialized.materializedPath),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("append version_added record: %w", err)
@@ -191,7 +135,7 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 
 	return &InstallOutput{
 		Installation:     coredata.InstallationFromVersionAddedRecord(addedRecord),
-		MaterializedPath: materializedPath,
+		MaterializedPath: materialized.materializedPath,
 	}, nil
 }
 

--- a/gestaltd/internal/appregistry/materializer.go
+++ b/gestaltd/internal/appregistry/materializer.go
@@ -1,0 +1,174 @@
+package appregistry
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/providerregistry"
+	"github.com/valon-technologies/gestalt/server/services/apps/packageio"
+	"github.com/valon-technologies/gestalt/server/services/apps/providerpkg"
+)
+
+type materializeRegistryVersionInput struct {
+	registryName string
+	appName      string
+	version      string
+}
+
+type materializeRegistryVersionResult struct {
+	materializedPath string
+	entry            *Entry
+	entryURL         string
+	checksums        map[string]string
+}
+
+// LocalMaterializedPath returns the on-disk path for one registry-installed app version.
+func LocalMaterializedPath(artifactsDir, appName, version string) string {
+	artifactsDir = strings.TrimSpace(artifactsDir)
+	appName = strings.TrimSpace(appName)
+	version = strings.TrimSpace(version)
+	if artifactsDir == "" || appName == "" || version == "" {
+		return ""
+	}
+	return filepath.Join(artifactsDir, RegistryInstallSubdir, appName, version)
+}
+
+// IsLocallyMaterialized reports whether destDir contains an extracted provider manifest.
+func IsLocallyMaterialized(destDir string) bool {
+	destDir = strings.TrimSpace(destDir)
+	if destDir == "" {
+		return false
+	}
+	if _, err := os.Stat(destDir); err != nil {
+		return false
+	}
+	manifestPath, _ := packageio.FindManifestFile(destDir)
+	return strings.TrimSpace(manifestPath) != ""
+}
+
+func (i *Installer) materializeRegistryVersion(ctx context.Context, input materializeRegistryVersionInput) (*materializeRegistryVersionResult, error) {
+	if i == nil {
+		return nil, fmt.Errorf("app registry installer is not configured")
+	}
+	registryName := strings.TrimSpace(input.registryName)
+	appName := strings.TrimSpace(input.appName)
+	version := strings.TrimSpace(input.version)
+	if registryName == "" {
+		return nil, fmt.Errorf("registry is required")
+	}
+	if appName == "" {
+		return nil, fmt.Errorf("app is required")
+	}
+	if version == "" {
+		return nil, fmt.Errorf("version is required")
+	}
+	if err := providerregistry.ValidateRepositoryName(appName); err != nil {
+		return nil, fmt.Errorf("invalid app name: %w", err)
+	}
+	artifactsDir := strings.TrimSpace(i.ArtifactsDir)
+	if artifactsDir == "" {
+		return nil, fmt.Errorf("artifacts directory is not configured")
+	}
+	registry, ok := i.Registries[registryName]
+	if !ok {
+		return nil, fmt.Errorf("app registry not found")
+	}
+	if strings.TrimSpace(registry.Kind) != config.AppRegistryKindGCS {
+		return nil, fmt.Errorf("unsupported app registry kind")
+	}
+	publicRoot, err := registry.PublicURL()
+	if err != nil {
+		return nil, fmt.Errorf("app registry public URL is invalid: %w", err)
+	}
+
+	reader := i.Reader
+	if reader == nil {
+		reader = &RegistryReader{}
+	}
+	entry, err := reader.FetchEntry(ctx, publicRoot, appName, version)
+	if err != nil {
+		return nil, fmt.Errorf("fetch app registry entry: %w", err)
+	}
+	if entry.App != appName {
+		return nil, fmt.Errorf("registry entry app %q does not match requested app %q", entry.App, appName)
+	}
+	if entry.Version != version {
+		return nil, fmt.Errorf("registry entry version %q does not match requested version %q", entry.Version, version)
+	}
+
+	platform := providerpkg.CurrentPlatformString()
+	artifact, ok := entry.Artifacts[platform]
+	if !ok {
+		return nil, fmt.Errorf("registry entry has no artifact for platform %q", platform)
+	}
+	artifactURL := strings.TrimSpace(artifact.PublicURL)
+	if artifactURL == "" {
+		artifactURL = strings.TrimSpace(artifact.URL)
+	}
+	if artifactURL == "" {
+		return nil, fmt.Errorf("registry entry artifact for platform %q has no download URL", platform)
+	}
+	expectedSHA := strings.TrimSpace(artifact.SHA256)
+	if expectedSHA == "" {
+		return nil, fmt.Errorf("registry entry artifact for platform %q is missing sha256", platform)
+	}
+
+	materializedPath := LocalMaterializedPath(artifactsDir, appName, version)
+	download, err := downloadRegistryArtifact(ctx, reader.client(), artifactURL)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if download.Cleanup != nil {
+			download.Cleanup()
+		}
+	}()
+	if !strings.EqualFold(strings.TrimSpace(download.SHA256Hex), expectedSHA) {
+		return nil, fmt.Errorf("artifact digest mismatch: got %s, want %s", download.SHA256Hex, expectedSHA)
+	}
+	if err := i.materializePublishedPackage(ctx, download.LocalPath, materializedPath, appName); err != nil {
+		return nil, fmt.Errorf("materialize app artifact: %w", err)
+	}
+
+	return &materializeRegistryVersionResult{
+		materializedPath: materializedPath,
+		entry:            entry,
+		entryURL:         PublicURL(publicRoot, AppVersionEntryPath(appName, version)),
+		checksums:        map[string]string{platform: expectedSHA},
+	}, nil
+}
+
+func (i *Installer) materializeKnownVersion(ctx context.Context, installation *core.AppInstallation) (string, error) {
+	if installation == nil {
+		return "", fmt.Errorf("installation is required")
+	}
+	appName := strings.TrimSpace(installation.AppName)
+	version := strings.TrimSpace(installation.Version)
+	registryName := strings.TrimSpace(installation.Registry)
+	if appName == "" || version == "" {
+		return "", fmt.Errorf("app and version are required")
+	}
+	if registryName == "" {
+		return "", fmt.Errorf("registry is required")
+	}
+
+	materializedPath := LocalMaterializedPath(i.ArtifactsDir, appName, version)
+	if IsLocallyMaterialized(materializedPath) {
+		return materializedPath, nil
+	}
+
+	result, err := i.materializeRegistryVersion(ctx, materializeRegistryVersionInput{
+		registryName: registryName,
+		appName:      appName,
+		version:      version,
+	})
+	if err != nil {
+		return "", err
+	}
+	return result.materializedPath, nil
+}

--- a/gestaltd/internal/server/handlers_admin_app_install.go
+++ b/gestaltd/internal/server/handlers_admin_app_install.go
@@ -213,3 +213,11 @@ func newAppRegistryInstaller(cfg Config) *appregistry.Installer {
 		ArtifactsDir: strings.TrimSpace(cfg.ArtifactsDir),
 	}
 }
+
+func newAppRegistryConverger(cfg Config) *appregistry.Converger {
+	installer := newAppRegistryInstaller(cfg)
+	if installer == nil || cfg.Services == nil || cfg.Services.AppVersionCatalog == nil {
+		return nil
+	}
+	return appregistry.NewConverger(installer, cfg.Services.AppVersionCatalog)
+}

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -146,6 +146,10 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 		return fmt.Errorf("creating public server: %w", err)
 	}
 
+	if converger := newAppRegistryConverger(publicConfig); converger != nil {
+		converger.StartBackground(ctx)
+	}
+
 	servers := []namedHTTPServer{{
 		name:   "public",
 		server: newHTTPServer(cfg.Server.PublicAddr(), publicHandler),

--- a/plans/app_registry/indexeddb.md
+++ b/plans/app_registry/indexeddb.md
@@ -72,6 +72,8 @@ Bootstrap does **not** write catalog records. After deploy the store is empty un
 
 Contrast with `app_shas`: bootstrap **does** read and update that store during artifact sync (`gestaltd/internal/bootstrap/app_shas.go`).
 
+Bootstrap starts background catalog convergence when `appRegistries` and IndexedDB catalog services are configured. See `appregistry.Converger` in `gestaltd/internal/appregistry/converger.go`, started from `gestaltd/internal/server/runtime.go` on `gestaltd serve`.
+
 Access install services after bootstrap via `Result.Services` / `prepared.Services`:
 
 ```text

--- a/plans/app_registry/plan.md
+++ b/plans/app_registry/plan.md
@@ -236,7 +236,7 @@ The install request should not directly command every instance. Instead, the han
 
 **Step 6 (implemented):** only the handling instance materializes artifacts and appends catalog records. Other instances do not read install state yet.
 
-**Step 7 (planned):** each instance reads known versions from `app_version_catalog`, then lazily materializes missing versions locally.
+**Step 7 (implemented):** each instance reads known versions from `app_version_catalog` on startup and lazily materializes missing versions locally in a background convergence loop (`appregistry.Converger`). Per-instance `app_instance_materializations` IndexedDB tracking, first-request convergence, and dynamic runtime binding remain planned follow-ups.
 
 The expected flow is:
 
@@ -333,5 +333,5 @@ Core recovery paths must not depend on dynamically installed apps.
 4. Prototype a Gestalt endpoint that lists available versions in configured registries. See [api.md](./api.md).
 5. Add IndexedDB version catalog store and projection helpers (`app_version_catalog` + known-version views). See [indexeddb.md](./indexeddb.md).
 6. Prototype installing one registry app: materialize on the handling instance, record known versions in the catalog, expose via admin HTTP. **Done:** catalog-only writes; `app_installations` store removed. See [api.md](./api.md), [tests.md](./tests.md).
-7. Add lazy per-instance materialization on startup or first request — each instance reads known versions from the catalog and materializes locally.
+7. Add lazy per-instance materialization on startup or first request — each instance reads known versions from the catalog and materializes locally. **Done (startup):** background `Converger` on `gestaltd serve`. **Planned:** first-request convergence, `app_instance_materializations` store, runtime app binding, 503 until ready.
 8. Add install-time validation, fleet activation/rollback, and concurrency guards.

--- a/plans/app_registry/tests.md
+++ b/plans/app_registry/tests.md
@@ -19,6 +19,7 @@ Related docs:
 | `internal/daemon/e2e/appregistry` | `appregistry_test.go` | 1 | E2E (CLI) | [gestalt#2709](https://github.com/valon-technologies/gestalt/pull/2709) |
 | `internal/coredata` | `app_version_catalog_test.go` | 5 | Unit (projection) | [gestalt#2730](https://github.com/valon-technologies/gestalt/pull/2730) |
 | `internal/server` | `handlers_admin_app_install_test.go` | 3 | HTTP integration | [gestalt#2730](https://github.com/valon-technologies/gestalt/pull/2730) |
+| `internal/appregistry` | `converger_test.go` | 2 | Unit (convergence) | step 7 |
 
 Test fixture for install HTTP tests: `internal/appregistry/registrytest/fixture.go`
 
@@ -110,6 +111,23 @@ go test ./internal/coredata/... -run TestAppVersionCatalog -count=1
 
 ---
 
+## Step 7: lazy local materialization
+
+Run:
+
+```bash
+cd gestaltd
+go test ./internal/appregistry/... -run TestConverger -count=1
+```
+
+### `converger_test.go`
+
+- **`TestConverger_materializes_catalog_known_version_locally`** — catalog `version_added` without local artifacts; `ConvergeOnce` downloads and extracts to this instance's artifacts dir.
+
+- **`TestConverger_skips_already_materialized_version`** — after a successful install, convergence is a no-op.
+
+---
+
 ## What is not covered yet
 
 Publish tests validate **CLI dry-run behavior** only. Install HTTP tests cover the happy path, 404 on missing version, and get-by-app — but not:
@@ -117,6 +135,7 @@ Publish tests validate **CLI dry-run behavior** only. Install HTTP tests cover t
 - Real GCS upload integration
 - Failed install `install_failed` record assertions
 - Re-install idempotency (no duplicate `version_added`)
-- Lazy per-instance materialization on other instances
+- Lazy per-instance materialization on other instances (startup convergence — see step 7 tests below)
+- First-request convergence and `app_instance_materializations` IndexedDB store
 
 See [plan.md](./plan.md) steps 7–8 for planned follow-up coverage.


### PR DESCRIPTION
## Summary

Implements [plan step 7](plans/app_registry/plan.md) (startup slice): after `gestaltd serve` boots, each instance reads `app_version_catalog` and materializes any fleet-known versions missing from its local artifacts tree.

- Add `appregistry.Converger` — background `ConvergeOnce` on startup; skips versions already on disk; per-`(app, version)` inflight guard
- Extract shared registry download/extract into `materializer.go` (`materializeRegistryVersion`, `LocalMaterializedPath`, `IsLocallyMaterialized`); refactor `Installer` to reuse it
- Wire converger from `server.Run` when catalog + `appRegistries` are configured

Builds on step 6 (#2730). Does **not** yet add `app_instance_materializations`, first-request convergence, dynamic runtime binding, or 503-until-ready — those remain planned follow-ups before step 8.

## Test plan

```bash
cd gestaltd
go test ./internal/appregistry/... -run TestConverger -count=1
go test ./internal/appregistry/... -run TestInstaller -count=1
go test ./internal/server/... -run TestAdminAppRegistryInstall -count=1
```

- [ ] Manual: install a version on instance A via `POST …/install`, restart instance B with same IndexedDB — confirm `registry-installed/{app}/{version}/` appears after startup convergence


Made with [Cursor](https://cursor.com)