### PR TITLE
Reject provider-owned operation allowedRoles

### DIFF
--- a/gestaltd/internal/bootstrap/graphql_session_provider_test.go
+++ b/gestaltd/internal/bootstrap/graphql_session_provider_test.go
@@ -211,10 +211,9 @@ func TestConfiguredStaticGraphQLProviderSkipsSessionCatalog(t *testing.T) {
 					},
 				},
 				"searchRecords": {
-					Alias:        "records.search",
-					Description:  "Search record metadata.",
-					AllowedRoles: []string{"viewer"},
-					Tags:         []string{"records"},
+					Alias:       "records.search",
+					Description: "Search record metadata.",
+					Tags:        []string{"records"},
 					GraphQL: &providermanifestv1.ManifestGraphQLOperation{
 						Document:      searchRecordsDocument,
 						OperationName: "SearchRecords",
@@ -236,9 +235,6 @@ func TestConfiguredStaticGraphQLProviderSkipsSessionCatalog(t *testing.T) {
 	searchOp, ok := graphQLCatalogOperation(prov.Catalog(), "records.search")
 	if !ok {
 		t.Fatalf("catalog operations = %#v, want records.search", prov.Catalog().Operations)
-	}
-	if got, want := searchOp.AllowedRoles, []string{"viewer"}; !slices.Equal(got, want) {
-		t.Fatalf("records.search roles = %#v, want %#v", got, want)
 	}
 	if got, want := searchOp.Tags, []string{"records"}; !slices.Equal(got, want) {
 		t.Fatalf("records.search tags = %#v, want %#v", got, want)

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -476,10 +476,7 @@ func buildProvider(ctx context.Context, name string, entry *config.ProviderEntry
 		return nil, fmt.Errorf("integration %q must resolve to a provider manifest", name)
 	}
 
-	allowedOperations := entry.AllowedOperations
-	if allowedOperations == nil {
-		allowedOperations = maps.Clone(manifestApp.AllowedOperations)
-	}
+	allowedOperations := entry.EffectiveAllowedOperations()
 
 	switch {
 	case manifestApp.IsSpecLoaded() && manifest.Entrypoint == nil:
@@ -529,10 +526,7 @@ func buildExecutableAppProvider(ctx context.Context, name string, entry *config.
 	if err != nil {
 		return nil, err
 	}
-	allowedOperations := entry.AllowedOperations
-	if allowedOperations == nil && manifestApp != nil {
-		allowedOperations = maps.Clone(manifestApp.AllowedOperations)
-	}
+	allowedOperations := entry.EffectiveAllowedOperations()
 	staticAllowedOperations := operationexposure.MatchingAllowedOperations(allowedOperations, pluginProv.Catalog())
 
 	if manifestApp.IsDeclarative() {

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -21,6 +21,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/apps/operationexposure"
 	"github.com/valon-technologies/gestalt/server/services/apps/packageio"
 	"gopkg.in/yaml.v3"
 )
@@ -1742,6 +1743,19 @@ func (e *ProviderEntry) ManifestSpec() *providermanifestv1.Spec {
 	return e.ResolvedManifest.Spec
 }
 
+func (e *ProviderEntry) EffectiveAllowedOperations() map[string]*OperationOverride {
+	if e == nil {
+		return nil
+	}
+	if e.AllowedOperations != nil {
+		return e.AllowedOperations
+	}
+	if spec := e.ManifestSpec(); spec != nil {
+		return operationexposure.FromManifestAllowed(spec.AllowedOperations)
+	}
+	return nil
+}
+
 func (e *ProviderEntry) EffectiveHTTPSecuritySchemes() map[string]*HTTPSecurityScheme {
 	var merged map[string]*HTTPSecurityScheme
 	if spec := e.ManifestSpec(); spec != nil && spec.SecuritySchemes != nil {
@@ -2259,8 +2273,8 @@ func cloneAuthValue(src AuthValueDef) AuthValueDef {
 	return dst
 }
 
-// OperationOverride holds optional alias and description for an allowed operation.
-type OperationOverride = providermanifestv1.ManifestOperationOverride
+// OperationOverride holds deployer-owned allowed-operation metadata from config.
+type OperationOverride = operationexposure.OperationOverride
 
 type AppCapabilitiesConfig struct {
 	Workflow *AppWorkflowCapabilitiesConfig `yaml:"workflow,omitempty"`

--- a/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
@@ -1130,13 +1130,6 @@
         "connectionSelector": {
           "$ref": "#/$defs/operationConnectionSelector"
         },
-        "allowedRoles": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "minLength": 1
-          }
-        },
         "tags": {
           "type": "array",
           "items": {
@@ -1313,13 +1306,6 @@
         },
         "description": {
           "type": "string"
-        },
-        "allowedRoles": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "minLength": 1
-          }
         },
         "tags": {
           "type": "array",

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -722,7 +722,6 @@ type ManifestPaginationConfig struct {
 type ManifestOperationOverride struct {
 	Alias        string                    `json:"alias,omitempty" yaml:"alias,omitempty"`
 	Description  string                    `json:"description,omitempty" yaml:"description,omitempty"`
-	AllowedRoles []string                  `json:"allowedRoles,omitempty" yaml:"allowedRoles,omitempty"`
 	Tags         []string                  `json:"tags,omitempty" yaml:"tags,omitempty"`
 	Paginate     bool                      `json:"paginate,omitempty" yaml:"paginate,omitempty"`
 	Pagination   *ManifestPaginationConfig `json:"pagination,omitempty" yaml:"pagination,omitempty"`
@@ -756,7 +755,6 @@ type ProviderOperation struct {
 	Path               string                       `json:"path" yaml:"path"`
 	Connection         string                       `json:"connection,omitempty" yaml:"connection,omitempty"`
 	ConnectionSelector *OperationConnectionSelector `json:"connectionSelector,omitempty" yaml:"connectionSelector,omitempty"`
-	AllowedRoles       []string                     `json:"allowedRoles,omitempty" yaml:"allowedRoles,omitempty"`
 	Tags               []string                     `json:"tags,omitempty" yaml:"tags,omitempty"`
 	Parameters         []ProviderParameter          `json:"parameters,omitempty" yaml:"parameters,omitempty"`
 }

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -720,12 +720,12 @@ type ManifestPaginationConfig struct {
 }
 
 type ManifestOperationOverride struct {
-	Alias        string                    `json:"alias,omitempty" yaml:"alias,omitempty"`
-	Description  string                    `json:"description,omitempty" yaml:"description,omitempty"`
-	Tags         []string                  `json:"tags,omitempty" yaml:"tags,omitempty"`
-	Paginate     bool                      `json:"paginate,omitempty" yaml:"paginate,omitempty"`
-	Pagination   *ManifestPaginationConfig `json:"pagination,omitempty" yaml:"pagination,omitempty"`
-	GraphQL      *ManifestGraphQLOperation `json:"graphql,omitempty" yaml:"graphql,omitempty"`
+	Alias       string                    `json:"alias,omitempty" yaml:"alias,omitempty"`
+	Description string                    `json:"description,omitempty" yaml:"description,omitempty"`
+	Tags        []string                  `json:"tags,omitempty" yaml:"tags,omitempty"`
+	Paginate    bool                      `json:"paginate,omitempty" yaml:"paginate,omitempty"`
+	Pagination  *ManifestPaginationConfig `json:"pagination,omitempty" yaml:"pagination,omitempty"`
+	GraphQL     *ManifestGraphQLOperation `json:"graphql,omitempty" yaml:"graphql,omitempty"`
 }
 
 type ManifestGraphQLOperation struct {

--- a/gestaltd/services/apps/declarative_provider.go
+++ b/gestaltd/services/apps/declarative_provider.go
@@ -322,7 +322,6 @@ func declarativeCatalog(manifest *providermanifestv1.Manifest, opts declarativeO
 			Method:       mop.Method,
 			Path:         mop.Path,
 			Description:  mop.Description,
-			AllowedRoles: mop.AllowedRoles,
 			Tags:         catalog.MergeTags(mop.Tags),
 			Transport:    catalog.TransportREST,
 			Parameters:   make([]catalog.CatalogParameter, 0, len(mop.Parameters)),

--- a/gestaltd/services/apps/declarative_provider.go
+++ b/gestaltd/services/apps/declarative_provider.go
@@ -318,13 +318,13 @@ func declarativeCatalog(manifest *providermanifestv1.Manifest, opts declarativeO
 	for i := range ops {
 		mop := &ops[i]
 		catOp := catalog.CatalogOperation{
-			ID:           mop.Name,
-			Method:       mop.Method,
-			Path:         mop.Path,
-			Description:  mop.Description,
-			Tags:         catalog.MergeTags(mop.Tags),
-			Transport:    catalog.TransportREST,
-			Parameters:   make([]catalog.CatalogParameter, 0, len(mop.Parameters)),
+			ID:          mop.Name,
+			Method:      mop.Method,
+			Path:        mop.Path,
+			Description: mop.Description,
+			Tags:        catalog.MergeTags(mop.Tags),
+			Transport:   catalog.TransportREST,
+			Parameters:  make([]catalog.CatalogParameter, 0, len(mop.Parameters)),
 		}
 		for _, mp := range mop.Parameters {
 			catOp.Parameters = append(catOp.Parameters, catalog.CatalogParameter{

--- a/gestaltd/services/apps/graphql/loader_test.go
+++ b/gestaltd/services/apps/graphql/loader_test.go
@@ -156,9 +156,8 @@ func TestLoadDefinitionWithAllowedOps(t *testing.T) {
 
 	def, err := LoadDefinition(t.Context(), "test", srv.URL, map[string]*operationexposure.OperationOverride{
 		"teams": {
-			Description:  "My custom description",
-			AllowedRoles: []string{"workspace-admin"},
-			Tags:         []string{"workspace"},
+			Description: "My custom description",
+			Tags:        []string{"workspace"},
 		},
 	})
 	if err != nil {
@@ -174,9 +173,6 @@ func TestLoadDefinitionWithAllowedOps(t *testing.T) {
 	}
 	if got, want := teams.Tags, []string{"workspace"}; !slices.Equal(got, want) {
 		t.Errorf("teams.Tags: got %#v, want %#v", got, want)
-	}
-	if got, want := teams.AllowedRoles, []string{"workspace-admin"}; !slices.Equal(got, want) {
-		t.Errorf("teams.AllowedRoles: got %#v, want %#v", got, want)
 	}
 	if got := teams.Parameters; len(got) != 1 || got[0].Name != "first" || got[0].Type != "integer" {
 		t.Fatalf("teams.Parameters = %#v, want first integer param", got)

--- a/gestaltd/services/apps/graphql/static_test.go
+++ b/gestaltd/services/apps/graphql/static_test.go
@@ -38,10 +38,9 @@ fragment TeamFields on Team {
 `
 	def, err := StaticAllowedOperationsDefinition("linear", "https://example.com/graphql", map[string]*operationexposure.OperationOverride{
 		"listTeams": {
-			Alias:        "teams",
-			Description:  "List Linear teams",
-			AllowedRoles: []string{"workspace-admin"},
-			Tags:         []string{"workspace"},
+			Alias:       "teams",
+			Description: "List Linear teams",
+			Tags:        []string{"workspace"},
 			GraphQL: &providermanifestv1.ManifestGraphQLOperation{
 				Document:      document,
 				OperationName: "ListTeams",

--- a/gestaltd/services/apps/openapi/loader_test.go
+++ b/gestaltd/services/apps/openapi/loader_test.go
@@ -83,7 +83,7 @@ func TestLoadDefinition(t *testing.T) {
 	testutil.CloseOnCleanup(t, srv)
 
 	allowed := map[string]*operationexposure.OperationOverride{
-		"list_items": {Description: "List items with pagination", AllowedRoles: []string{"reader"}, Tags: []string{"pagination"}},
+		"list_items": {Description: "List items with pagination", Tags: []string{"pagination"}},
 		"get_item":   nil,
 	}
 
@@ -117,9 +117,6 @@ func TestLoadDefinition(t *testing.T) {
 	}
 	if got, want := listOp.Tags, []string{"inventory", "pagination"}; !slices.Equal(got, want) {
 		t.Errorf("list_items tags = %#v, want %#v", got, want)
-	}
-	if got, want := listOp.AllowedRoles, []string{"reader"}; !slices.Equal(got, want) {
-		t.Errorf("list_items allowed roles = %#v, want %#v", got, want)
 	}
 	if len(listOp.Parameters) != 1 {
 		t.Fatalf("list_items params = %d, want 1", len(listOp.Parameters))

--- a/gestaltd/services/apps/operationexposure/policy.go
+++ b/gestaltd/services/apps/operationexposure/policy.go
@@ -281,8 +281,11 @@ func (p *Policy) ApplyCatalog(cat *catalog.Catalog) *catalog.Catalog {
 // present in the provided catalog. It returns nil when either input is empty or
 // when no allowed operations match the catalog.
 func MatchingAllowedOperations(allowed map[string]*OperationOverride, cat *catalog.Catalog) map[string]*OperationOverride {
-	if len(allowed) == 0 || cat == nil || len(cat.Operations) == 0 {
+	if allowed == nil || cat == nil || len(cat.Operations) == 0 {
 		return nil
+	}
+	if len(allowed) == 0 {
+		return allowed
 	}
 	available := make(map[string]struct{}, len(cat.Operations))
 	for i := range cat.Operations {

--- a/gestaltd/services/apps/operationexposure/policy.go
+++ b/gestaltd/services/apps/operationexposure/policy.go
@@ -10,7 +10,37 @@ import (
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 )
 
-type OperationOverride = providermanifestv1.ManifestOperationOverride
+type OperationOverride struct {
+	Alias        string                                       `yaml:"alias,omitempty" json:"alias,omitempty"`
+	Description  string                                       `yaml:"description,omitempty" json:"description,omitempty"`
+	AllowedRoles []string                                     `yaml:"allowedRoles,omitempty" json:"allowedRoles,omitempty"`
+	Tags         []string                                     `yaml:"tags,omitempty" json:"tags,omitempty"`
+	Paginate     bool                                         `yaml:"paginate,omitempty" json:"paginate,omitempty"`
+	Pagination   *providermanifestv1.ManifestPaginationConfig `yaml:"pagination,omitempty" json:"pagination,omitempty"`
+	GraphQL      *providermanifestv1.ManifestGraphQLOperation `yaml:"graphql,omitempty" json:"graphql,omitempty"`
+}
+
+func FromManifestAllowed(allowed map[string]*providermanifestv1.ManifestOperationOverride) map[string]*OperationOverride {
+	if allowed == nil {
+		return nil
+	}
+	out := make(map[string]*OperationOverride, len(allowed))
+	for name, override := range allowed {
+		if override == nil {
+			out[name] = nil
+			continue
+		}
+		out[name] = &OperationOverride{
+			Alias:       override.Alias,
+			Description: override.Description,
+			Tags:        override.Tags,
+			Paginate:    override.Paginate,
+			Pagination:  override.Pagination,
+			GraphQL:     override.GraphQL,
+		}
+	}
+	return out
+}
 
 // Policy normalizes allowed_operations handling so every provider type uses the
 // same validation, aliasing, and description override behavior.

--- a/gestaltd/services/apps/operationexposure/policy_test.go
+++ b/gestaltd/services/apps/operationexposure/policy_test.go
@@ -32,6 +32,22 @@ func TestPolicyNewRejectsAliasCollisions(t *testing.T) {
 	}
 }
 
+func TestMatchingAllowedOperationsPreservesEmptyMap(t *testing.T) {
+	t.Parallel()
+
+	cat := &catalog.Catalog{
+		Name:       "example",
+		Operations: []catalog.CatalogOperation{{ID: "op"}},
+	}
+	out := MatchingAllowedOperations(map[string]*OperationOverride{}, cat)
+	if out == nil {
+		t.Fatal("expected non-nil empty map")
+	}
+	if len(out) != 0 {
+		t.Fatalf("got %d entries, want 0", len(out))
+	}
+}
+
 func TestPolicyValidateAndApply(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/apps/packageio/archive.go
+++ b/gestaltd/services/apps/packageio/archive.go
@@ -523,7 +523,7 @@ func validatePackageStaticCatalog(manifest *providermanifestv1.Manifest, data []
 	if err := decodeStrict(data, ManifestFormatFromPath(StaticCatalogFile), "static catalog", &cat); err != nil {
 		return err
 	}
-	if err := cat.Validate(); err != nil {
+	if err := validateStaticCatalog(&cat); err != nil {
 		return fmt.Errorf("validate static catalog %q: %w", StaticCatalogFile, err)
 	}
 	return nil

--- a/gestaltd/services/apps/packageio/catalog.go
+++ b/gestaltd/services/apps/packageio/catalog.go
@@ -40,8 +40,17 @@ func ReadStaticCatalog(rootDir, name string) (*catalog.Catalog, error) {
 	if cat.Name == "" && name != "" {
 		cat.Name = name
 	}
-	if err := cat.Validate(); err != nil {
+	if err := validateStaticCatalog(&cat); err != nil {
 		return nil, fmt.Errorf("validate static catalog %q: %w", catalogPath, err)
 	}
 	return &cat, nil
+}
+
+func validateStaticCatalog(cat *catalog.Catalog) error {
+	for i := range cat.Operations {
+		if len(cat.Operations[i].AllowedRoles) > 0 {
+			return fmt.Errorf("catalog %q operation %q: provider-owned allowedRoles are not supported; move roles to apps.<name>.allowedOperations in config.yaml", cat.Name, cat.Operations[i].ID)
+		}
+	}
+	return cat.Validate()
 }

--- a/gestaltd/services/apps/providerpkg/archive_boundary_test.go
+++ b/gestaltd/services/apps/providerpkg/archive_boundary_test.go
@@ -136,6 +136,28 @@ func TestInspectPackageRejectsMissingProviderSchema(t *testing.T) {
 	}
 }
 
+func TestInspectPackageRejectsProviderOwnedAllowedRoles(t *testing.T) {
+	t.Parallel()
+
+	artifactPath := testArtifactPath("provider")
+	manifest := newProviderManifest("github.com/acme/apps/provider", "0.0.1-alpha.1", artifactPath, sha256Hex("provider"))
+
+	archivePath := filepath.Join(t.TempDir(), "provider-owned-roles.tar.gz")
+	mustCreateArchive(t, archivePath,
+		archiveTestFile{name: ManifestFile, data: mustRawManifestJSON(t, manifest), mode: 0644},
+		archiveTestFile{name: artifactPath, data: []byte("provider"), mode: 0755},
+		archiveTestFile{name: StaticCatalogFile, data: []byte("name: provider\noperations:\n  - id: echo\n    method: POST\n    allowedRoles:\n      - admin\n"), mode: 0644},
+	)
+
+	_, err := InspectPackage(archivePath)
+	if err == nil {
+		t.Fatal("expected provider-owned allowedRoles error")
+	}
+	if !strings.Contains(err.Error(), "provider-owned allowedRoles") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestReadArchiveEntryRejectsDuplicateEntry(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/apps/providerpkg/catalog_test.go
+++ b/gestaltd/services/apps/providerpkg/catalog_test.go
@@ -73,7 +73,7 @@ operations:
 	}
 }
 
-func TestReadStaticCatalogRejectsBlankAllowedRoles(t *testing.T) {
+func TestReadStaticCatalogRejectsProviderOwnedAllowedRoles(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
@@ -83,14 +83,14 @@ operations:
   - id: echo
     method: POST
     allowedRoles:
-      - "   "
+      - admin
 `)
 	if err := os.WriteFile(filepath.Join(root, StaticCatalogFile), data, 0o644); err != nil {
 		t.Fatalf("WriteFile(catalog.yaml): %v", err)
 	}
 
 	_, err := ReadStaticCatalog(root, "")
-	if err == nil || err.Error() == "" || !strings.Contains(err.Error(), "allowedRoles entry with empty value") {
-		t.Fatalf("ReadStaticCatalog error = %v, want blank allowedRoles error", err)
+	if err == nil || err.Error() == "" || !strings.Contains(err.Error(), "provider-owned allowedRoles") {
+		t.Fatalf("ReadStaticCatalog error = %v, want provider-owned allowedRoles error", err)
 	}
 }

--- a/gestaltd/services/apps/validation.go
+++ b/gestaltd/services/apps/validation.go
@@ -348,5 +348,5 @@ func effectiveAllowedOperations(entry *ValidationApp, spec *providermanifestv1.S
 	if spec == nil {
 		return nil
 	}
-	return spec.AllowedOperations
+	return operationexposure.FromManifestAllowed(spec.AllowedOperations)
 }


### PR DESCRIPTION
## Summary

Provider packages should define operations and transport metadata, while deployers own authorization roles in `config.yaml`. This change removes `allowedRoles` from manifest types and REST operation metadata, keeps config-local `OperationOverride` with roles, and rejects `catalog.yaml` entries that still declare provider-owned roles.

```mermaid
sequenceDiagram
  participant Package as App package manifest/catalog/provider
  participant Gestaltd as gestalt/gestaltd
  participant Config as Deployer config.yaml
  participant Catalog as Effective catalog
  Package->>Gestaltd: Operation metadata without allowedRoles
  Config->>Gestaltd: Optional allowedOperations.allowedRoles
  Gestaltd->>Catalog: Apply only config-owned roles
  Gestaltd-->>Package: Reject provider-owned allowedRoles if present
```

Existing deployments that relied on manifest or static catalog role defaults must migrate those roles into `apps.<name>.allowedOperations` before upgrading.

## Test plan
- [x] `go test ./services/apps/... ./internal/config ./internal/bootstrap`
- [ ] Verify strict manifest/catalog parsing rejects `allowedRoles`
- [ ] Confirm config `allowedOperations.allowedRoles` still applies to effective catalogs


Made with [Cursor](https://cursor.com)