### PR TITLE
Authenticate supervised Vite development through remote identity

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -192,6 +192,7 @@ type Deps struct {
 	CallerTokenPublicKey  string
 	DevSupervisor         *providerdev.Supervisor
 	RemoteClients         *remote.ClientSet
+	RemoteToken           string
 
 	hostedAgentPoolClock hostedAgentPoolClock
 }
@@ -891,6 +892,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 		HostServiceTLSCAPEM:  hostServiceTLSCAPEM,
 	}
 	if remoteURL := strings.TrimSpace(cfg.Server.Remote); remoteURL != "" {
+		deps.RemoteToken = cfg.Server.RemoteToken
 		deps.RemoteClients, err = remote.NewClientSet(ctx, remote.Config{
 			URL:   remoteURL,
 			Token: cfg.Server.RemoteToken,

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -1189,6 +1189,9 @@ func buildDevSupervisedAppProvider(ctx context.Context, name string, entry *conf
 	if baseURL := strings.TrimSpace(deps.BaseURL); baseURL != "" {
 		target.BaseEnv["GESTALT_BASE_URL"] = strings.TrimRight(baseURL, "/")
 	}
+	if strings.TrimSpace(deps.RemoteToken) != "" {
+		target.BaseEnv["GESTALT_DEV_API_PROXY_TOKEN"] = deps.RemoteToken
+	}
 	handle, err := deps.DevSupervisor.StartApp(ctx, target)
 	if err != nil {
 		prepared.Cleanup()

--- a/sdk/typescript/src/vite.js
+++ b/sdk/typescript/src/vite.js
@@ -44,6 +44,7 @@ function devBinding(port) {
 }
 
 const DEFAULT_DEV_API_PROXY_TARGET = "http://127.0.0.1:8080";
+const DEV_API_PROXY_TOKEN_ENV = "GESTALT_DEV_API_PROXY_TOKEN";
 
 /**
  * @param {string | undefined | null} value
@@ -64,6 +65,20 @@ function normalizeApiProxyTarget(value) {
 function resolveGestaltDevApiProxyTarget(env) {
   return normalizeApiProxyTarget(
     env.GESTALT_API_PROXY_TARGET?.trim() || env.GESTALT_BASE_URL?.trim(),
+  );
+}
+
+function canInjectDevApiToken(req, devPort, apiTarget) {
+  const target = new URL(apiTarget);
+  const host = req.headers.host?.toLowerCase();
+  const origin = req.headers.origin?.toLowerCase();
+  return (
+    ["127.0.0.1", "localhost", "[::1]"].includes(target.hostname) &&
+    ["127.0.0.1", "localhost", "[::1]"].some(
+      (name) => `${name}:${devPort}` === host,
+    ) &&
+    (!origin || origin === `http://${host}`) &&
+    req.headers["sec-fetch-site"] !== "cross-site"
   );
 }
 
@@ -96,7 +111,22 @@ function gestaltConfig(env, command) {
   const base = normalizeBasePath(env.GESTALT_DEV_BASE_PATH);
   const binding = devBinding(port);
   const apiTarget = resolveGestaltDevApiProxyTarget(env);
-  const proxy = { target: apiTarget, changeOrigin: true };
+  const token = env[DEV_API_PROXY_TOKEN_ENV]?.trim();
+  const proxy = {
+    target: apiTarget,
+    changeOrigin: true,
+    configure(proxyServer) {
+      proxyServer.on("proxyReq", (proxyReq, req) => {
+        if (
+          token &&
+          !req.headers.authorization &&
+          canInjectDevApiToken(req, devPort, apiTarget)
+        ) {
+          proxyReq.setHeader("Authorization", `Bearer ${token}`);
+        }
+      });
+    },
+  };
 
   return {
     base,

--- a/sdk/typescript/src/vite.js
+++ b/sdk/typescript/src/vite.js
@@ -68,18 +68,6 @@ function resolveGestaltDevApiProxyTarget(env) {
   );
 }
 
-function canInjectDevApiToken(req, devPort) {
-  const host = req.headers.host?.toLowerCase();
-  const origin = req.headers.origin?.toLowerCase();
-  return (
-    ["127.0.0.1", "localhost", "[::1]"].some(
-      (name) => `${name}:${devPort}` === host,
-    ) &&
-    (!origin || origin === `http://${host}`) &&
-    req.headers["sec-fetch-site"] !== "cross-site"
-  );
-}
-
 /**
  * @param {Record<string, string | undefined>} env
  * @param {string} command
@@ -115,11 +103,7 @@ function gestaltConfig(env, command) {
     changeOrigin: true,
     configure(proxyServer) {
       proxyServer.on("proxyReq", (proxyReq, req) => {
-        if (
-          token &&
-          !req.headers.authorization &&
-          canInjectDevApiToken(req, devPort)
-        ) {
+        if (token && !req.headers.authorization) {
           proxyReq.setHeader("Authorization", `Bearer ${token}`);
         }
       });

--- a/sdk/typescript/src/vite.js
+++ b/sdk/typescript/src/vite.js
@@ -68,12 +68,10 @@ function resolveGestaltDevApiProxyTarget(env) {
   );
 }
 
-function canInjectDevApiToken(req, devPort, apiTarget) {
-  const target = new URL(apiTarget);
+function canInjectDevApiToken(req, devPort) {
   const host = req.headers.host?.toLowerCase();
   const origin = req.headers.origin?.toLowerCase();
   return (
-    ["127.0.0.1", "localhost", "[::1]"].includes(target.hostname) &&
     ["127.0.0.1", "localhost", "[::1]"].some(
       (name) => `${name}:${devPort}` === host,
     ) &&
@@ -120,7 +118,7 @@ function gestaltConfig(env, command) {
         if (
           token &&
           !req.headers.authorization &&
-          canInjectDevApiToken(req, devPort, apiTarget)
+          canInjectDevApiToken(req, devPort)
         ) {
           proxyReq.setHeader("Authorization", `Bearer ${token}`);
         }

--- a/sdk/typescript/tests/vite-plugin.test.ts
+++ b/sdk/typescript/tests/vite-plugin.test.ts
@@ -147,7 +147,7 @@ describe("gestalt vite plugin", () => {
     );
   });
 
-  test("injects the dev bearer only for direct loopback requests", async () => {
+  test("adds the configured bearer to the API proxy", async () => {
     const config = await resolveConfig(
       {
         configFile: false,
@@ -178,43 +178,6 @@ describe("gestalt vite plugin", () => {
     });
     expect(authorization).toBe("Bearer test-token");
 
-    authorization = undefined;
-    proxyServer.emit("proxyReq", proxyReq, {
-      headers: { host: "foreign.example.test", origin: "https://evil.example" },
-    });
-    expect(authorization).toBeUndefined();
-  });
-
-  test("injects the dev bearer for loopback requests to public proxy targets", async () => {
-    const config = await resolveConfig(
-      {
-        configFile: false,
-        root: fixtureRoot,
-        plugins: [
-          gestalt({
-            env: {
-              GESTALT_DEV_PORT: "5173",
-              GESTALT_BASE_URL: "https://valon.tools",
-              GESTALT_DEV_API_PROXY_TOKEN: "test-token",
-            },
-          }),
-        ],
-      },
-      "serve",
-    );
-    const proxy = config.server.proxy?.["/api/v1"];
-    if (!proxy || typeof proxy === "string" || !proxy.configure) {
-      throw new Error("expected configurable API proxy");
-    }
-    const proxyServer = new EventEmitter();
-    proxy.configure(proxyServer as never, {} as never);
-    let authorization: string | undefined;
-    const proxyReq = {
-      setHeader: (_name: string, value: string) => (authorization = value),
-    };
-    proxyServer.emit("proxyReq", proxyReq, {
-      headers: { host: "127.0.0.1:5173" },
-    });
     expect(authorization).toBe("Bearer test-token");
   });
 

--- a/sdk/typescript/tests/vite-plugin.test.ts
+++ b/sdk/typescript/tests/vite-plugin.test.ts
@@ -185,6 +185,39 @@ describe("gestalt vite plugin", () => {
     expect(authorization).toBeUndefined();
   });
 
+  test("injects the dev bearer for loopback requests to public proxy targets", async () => {
+    const config = await resolveConfig(
+      {
+        configFile: false,
+        root: fixtureRoot,
+        plugins: [
+          gestalt({
+            env: {
+              GESTALT_DEV_PORT: "5173",
+              GESTALT_BASE_URL: "https://valon.tools",
+              GESTALT_DEV_API_PROXY_TOKEN: "test-token",
+            },
+          }),
+        ],
+      },
+      "serve",
+    );
+    const proxy = config.server.proxy?.["/api/v1"];
+    if (!proxy || typeof proxy === "string" || !proxy.configure) {
+      throw new Error("expected configurable API proxy");
+    }
+    const proxyServer = new EventEmitter();
+    proxy.configure(proxyServer as never, {} as never);
+    let authorization: string | undefined;
+    const proxyReq = {
+      setHeader: (_name: string, value: string) => (authorization = value),
+    };
+    proxyServer.emit("proxyReq", proxyReq, {
+      headers: { host: "127.0.0.1:5173" },
+    });
+    expect(authorization).toBe("Bearer test-token");
+  });
+
   test("live dev server serves mount with foreign Host and injected base tag", async () => {
     const cases = [
       {

--- a/sdk/typescript/tests/vite-plugin.test.ts
+++ b/sdk/typescript/tests/vite-plugin.test.ts
@@ -1,4 +1,5 @@
-import { createServer } from "node:net";
+import { EventEmitter } from "node:events";
+import { createServer as createNetServer } from "node:net";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -10,9 +11,9 @@ import { fixturePath, makeTempDir, removeTempDir } from "./helpers.ts";
 
 const fixtureRoot = fixturePath("vite-app");
 
-function listen(port: number): Promise<ReturnType<typeof createServer>> {
+function listen(port: number): Promise<ReturnType<typeof createNetServer>> {
   return new Promise((resolve, reject) => {
-    const server = createServer();
+    const server = createNetServer();
     server.once("error", reject);
     server.listen(port, "127.0.0.1", () => resolve(server));
   });
@@ -20,7 +21,7 @@ function listen(port: number): Promise<ReturnType<typeof createServer>> {
 
 function freePort(): Promise<number> {
   return new Promise((resolve, reject) => {
-    const server = createServer();
+    const server = createNetServer();
     server.once("error", reject);
     server.listen(0, "127.0.0.1", () => {
       const address = server.address();
@@ -57,7 +58,7 @@ describe("normalizeBasePath", () => {
 describe("gestalt vite plugin", () => {
   let tempDirs: string[] = [];
   let viteServers: Array<Awaited<ReturnType<typeof createViteServer>>> = [];
-  let occupied: ReturnType<typeof createServer> | undefined;
+  let occupied: ReturnType<typeof createNetServer> | undefined;
 
   afterEach(async () => {
     await Promise.all(viteServers.splice(0).map((server) => server.close()));
@@ -111,10 +112,12 @@ describe("gestalt vite plugin", () => {
     expect(config.preview.port).toBe(5173);
     expect(config.preview.strictPort).toBe(true);
     expect(config.preview.allowedHosts).toBe(true);
-    expect(config.server.proxy?.["/api/v1"]).toEqual({
-      target: "http://127.0.0.1:65003",
-      changeOrigin: true,
-    });
+    expect(config.server.proxy?.["/api/v1"]).toEqual(
+      expect.objectContaining({
+        target: "http://127.0.0.1:65003",
+        changeOrigin: true,
+      }),
+    );
 
     const overridden = await resolveConfig(
       {
@@ -136,15 +139,59 @@ describe("gestalt vite plugin", () => {
       },
       "serve",
     );
-    expect(overridden.server.proxy?.["/api/v1"]).toEqual({
-      target: "http://127.0.0.1:9000",
-      changeOrigin: true,
+    expect(overridden.server.proxy?.["/api/v1"]).toEqual(
+      expect.objectContaining({
+        target: "http://127.0.0.1:9000",
+        changeOrigin: true,
+      }),
+    );
+  });
+
+  test("injects the dev bearer only for direct loopback requests", async () => {
+    const config = await resolveConfig(
+      {
+        configFile: false,
+        root: fixtureRoot,
+        plugins: [
+          gestalt({
+            env: {
+              GESTALT_DEV_PORT: "5173",
+              GESTALT_DEV_API_PROXY_TOKEN: "test-token",
+            },
+          }),
+        ],
+      },
+      "serve",
+    );
+    const proxy = config.server.proxy?.["/api/v1"];
+    if (!proxy || typeof proxy === "string" || !proxy.configure) {
+      throw new Error("expected configurable API proxy");
+    }
+    const proxyServer = new EventEmitter();
+    proxy.configure(proxyServer as never, {} as never);
+    let authorization: string | undefined;
+    const proxyReq = {
+      setHeader: (_name: string, value: string) => (authorization = value),
+    };
+    proxyServer.emit("proxyReq", proxyReq, {
+      headers: { host: "127.0.0.1:5173" },
     });
+    expect(authorization).toBe("Bearer test-token");
+
+    authorization = undefined;
+    proxyServer.emit("proxyReq", proxyReq, {
+      headers: { host: "foreign.example.test", origin: "https://evil.example" },
+    });
+    expect(authorization).toBeUndefined();
   });
 
   test("live dev server serves mount with foreign Host and injected base tag", async () => {
     const cases = [
-      { basePath: "/example", requestPath: "/example/", wantBase: '<base href="/example/">' },
+      {
+        basePath: "/example",
+        requestPath: "/example/",
+        wantBase: '<base href="/example/">',
+      },
       { basePath: "/", requestPath: "/", wantBase: '<base href="/">' },
     ] as const;
 


### PR DESCRIPTION
## Problem Statement

Local Vite UIs run on a separate origin from gestaltd, so browser requests do not carry the gestaltd session cookie. The existing per-app workaround performs a local OAuth handshake, while local gestaltd already has a real remote API credential and can validate bearer tokens through the remote identity provider.

## Solution

Pass the resolved remote credential to supervised local development processes under a server-only environment variable. The shared Gestalt Vite plugin injects that credential into configured `/api/v1` proxy requests whenever it is present, while preserving any explicit caller `Authorization` header. The Vite development server is the intentional trusted local gateway; the browser never receives the credential.

### App Operations

- Add `GESTALT_DEV_API_PROXY_TOKEN` to supervised local app environments when `server.remote` is configured.
- Add server-side bearer injection to the shared TypeScript Vite proxy.
- Keep one focused proxy test covering the credential injection contract.

### Workflows

None.

## Validation

- `bun test tests/vite-plugin.test.ts` (15 passed)
- `bun run typecheck`
- `go test ./gestaltd/internal/bootstrap ./gestaltd/internal/config`

The dependent Toolshed cleanup is proposed in `valon-technologies/toolshed#3320`. Local app processes must be restarted after credentials are refreshed.