### PR TITLE
Step 8: per-replica catalog polling

### DIFF
--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -45,6 +45,13 @@ type AppVersionChangeRequest struct {
 	Metadata    map[string]any
 }
 
+type AppInstanceMaterialization struct {
+	InstanceID     string
+	App            string
+	Version        string
+	AcknowledgedAt time.Time
+}
+
 type ExternalCredentialGrant struct {
 	AccessToken       string
 	RefreshToken      string

--- a/gestaltd/internal/appregistry/poller.go
+++ b/gestaltd/internal/appregistry/poller.go
@@ -1,0 +1,191 @@
+package appregistry
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
+)
+
+const DefaultCatalogPollInterval = time.Minute
+
+type CatalogPoller struct {
+	ChangeRequests   *coredata.AppVersionChangeRequestService
+	Materializations *coredata.AppInstanceMaterializationService
+	InstanceID       string
+	Interval         time.Duration
+	Now              func() time.Time
+
+	startOnce sync.Once
+	passMu    sync.Mutex
+	mu        sync.Mutex
+	inflight  map[string]struct{}
+}
+
+type CatalogPollerConfig struct {
+	ChangeRequests   *coredata.AppVersionChangeRequestService
+	Materializations *coredata.AppInstanceMaterializationService
+	InstanceID       string
+	Interval         time.Duration
+	Now              func() time.Time
+}
+
+func NewCatalogPoller(cfg CatalogPollerConfig) *CatalogPoller {
+	return &CatalogPoller{
+		ChangeRequests:   cfg.ChangeRequests,
+		Materializations: cfg.Materializations,
+		InstanceID:       strings.TrimSpace(cfg.InstanceID),
+		Interval:         cfg.Interval,
+		Now:              cfg.Now,
+		inflight:         make(map[string]struct{}),
+	}
+}
+
+func ResolveInstanceID() string {
+	host, err := os.Hostname()
+	if err == nil {
+		host = strings.TrimSpace(host)
+		if host != "" {
+			return host
+		}
+	}
+	return uuid.NewString()
+}
+
+func (p *CatalogPoller) Start(ctx context.Context) {
+	if p == nil || p.ChangeRequests == nil || p.Materializations == nil {
+		return
+	}
+	p.startOnce.Do(func() {
+		if strings.TrimSpace(p.InstanceID) == "" {
+			p.InstanceID = ResolveInstanceID()
+		}
+		go p.loop(ctx)
+	})
+}
+
+func (p *CatalogPoller) loop(ctx context.Context) {
+	p.runOnce(ctx)
+	ticker := time.NewTicker(p.pollInterval())
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			p.runOnce(context.WithoutCancel(ctx))
+		}
+	}
+}
+
+func (p *CatalogPoller) runOnce(ctx context.Context) {
+	if !p.passMu.TryLock() {
+		return
+	}
+	defer p.passMu.Unlock()
+
+	if err := p.ReconcileOnce(ctx); err != nil {
+		slog.Warn("app registry catalog poll finished with errors", "error", err)
+	}
+}
+
+func (p *CatalogPoller) ReconcileOnce(ctx context.Context) error {
+	if p == nil {
+		return nil
+	}
+	if p.ChangeRequests == nil || p.Materializations == nil {
+		return fmt.Errorf("app registry catalog poller is not configured")
+	}
+	instanceID := strings.TrimSpace(p.InstanceID)
+	if instanceID == "" {
+		return fmt.Errorf("app registry catalog poller: instance id is required")
+	}
+
+	known, err := p.ChangeRequests.ListAllKnownVersions(ctx)
+	if err != nil {
+		return fmt.Errorf("list catalog known versions: %w", err)
+	}
+
+	var firstErr error
+	for _, installation := range known {
+		if err := p.reconcileInstallation(ctx, instanceID, installation); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func (p *CatalogPoller) reconcileInstallation(ctx context.Context, instanceID string, installation *core.AppInstallation) error {
+	if installation == nil {
+		return nil
+	}
+	appName := strings.TrimSpace(installation.AppName)
+	version := strings.TrimSpace(installation.Version)
+	if appName == "" || version == "" {
+		return nil
+	}
+	key := appName + "\x00" + version
+	if !p.beginInflight(key) {
+		return nil
+	}
+	defer p.endInflight(key)
+
+	alreadyAcked, err := p.Materializations.HasAcknowledged(ctx, instanceID, appName, version)
+	if err != nil {
+		return fmt.Errorf("check ack for %s@%s: %w", appName, version, err)
+	}
+	if alreadyAcked {
+		return nil
+	}
+
+	acknowledgedAt := p.now()
+	if _, err := p.Materializations.Acknowledge(ctx, &core.AppInstanceMaterialization{
+		InstanceID:     instanceID,
+		App:            appName,
+		Version:        version,
+		AcknowledgedAt: acknowledgedAt,
+	}); err != nil {
+		return fmt.Errorf("acknowledge %s@%s: %w", appName, version, err)
+	}
+	return nil
+}
+
+func (p *CatalogPoller) beginInflight(key string) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.inflight == nil {
+		p.inflight = make(map[string]struct{})
+	}
+	if _, ok := p.inflight[key]; ok {
+		return false
+	}
+	p.inflight[key] = struct{}{}
+	return true
+}
+
+func (p *CatalogPoller) endInflight(key string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.inflight, key)
+}
+
+func (p *CatalogPoller) pollInterval() time.Duration {
+	if p != nil && p.Interval > 0 {
+		return p.Interval
+	}
+	return DefaultCatalogPollInterval
+}
+
+func (p *CatalogPoller) now() time.Time {
+	if p != nil && p.Now != nil {
+		return p.Now().UTC().Truncate(time.Millisecond)
+	}
+	return time.Now().UTC().Truncate(time.Millisecond)
+}

--- a/gestaltd/internal/coredata/app_instance_materializations.go
+++ b/gestaltd/internal/coredata/app_instance_materializations.go
@@ -1,0 +1,115 @@
+package coredata
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	idb "github.com/valon-technologies/gestalt/sdk/go/indexeddb"
+
+	"github.com/google/uuid"
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+)
+
+type AppInstanceMaterializationService struct {
+	store idb.ObjectStore
+}
+
+func NewAppInstanceMaterializationService(ds indexeddb.IndexedDB) *AppInstanceMaterializationService {
+	return &AppInstanceMaterializationService{store: ds.ObjectStore(StoreAppInstanceMaterializations)}
+}
+
+func (s *AppInstanceMaterializationService) HasAcknowledged(ctx context.Context, instanceID, app, version string) (bool, error) {
+	if s == nil {
+		return false, fmt.Errorf("has app instance materialization: service is not configured")
+	}
+	_, err := s.findByInstanceAppVersion(ctx, instanceID, app, version)
+	if errors.Is(err, idb.ErrNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("has app instance materialization: %w", err)
+	}
+	return true, nil
+}
+
+func (s *AppInstanceMaterializationService) Acknowledge(ctx context.Context, materialization *core.AppInstanceMaterialization) (*core.AppInstanceMaterialization, error) {
+	if s == nil {
+		return nil, fmt.Errorf("acknowledge app instance materialization: service is not configured")
+	}
+	if materialization == nil {
+		return nil, fmt.Errorf("acknowledge app instance materialization: record is required")
+	}
+	instanceID := strings.TrimSpace(materialization.InstanceID)
+	app := strings.TrimSpace(materialization.App)
+	version := strings.TrimSpace(materialization.Version)
+	if instanceID == "" || app == "" || version == "" {
+		return nil, fmt.Errorf("acknowledge app instance materialization: instance_id, app, and version are required")
+	}
+
+	if existing, err := s.findByInstanceAppVersion(ctx, instanceID, app, version); err == nil {
+		return recordToAppInstanceMaterialization(existing), nil
+	} else if !errors.Is(err, idb.ErrNotFound) {
+		return nil, fmt.Errorf("acknowledge app instance materialization: %w", err)
+	}
+
+	acknowledgedAt := materialization.AcknowledgedAt
+	if acknowledgedAt.IsZero() {
+		acknowledgedAt = time.Now().UTC().Truncate(time.Millisecond)
+	} else {
+		acknowledgedAt = acknowledgedAt.UTC().Truncate(time.Millisecond)
+	}
+	rec := idb.Record{
+		"id":              uuid.NewString(),
+		"instance_id":     instanceID,
+		"app":             app,
+		"version":         version,
+		"acknowledged_at": acknowledgedAt,
+	}
+	if err := s.store.Add(ctx, rec); err != nil {
+		if errors.Is(err, idb.ErrAlreadyExists) {
+			existing, getErr := s.findByInstanceAppVersion(ctx, instanceID, app, version)
+			if getErr != nil {
+				return nil, fmt.Errorf("acknowledge app instance materialization: %w", getErr)
+			}
+			return recordToAppInstanceMaterialization(existing), nil
+		}
+		return nil, fmt.Errorf("acknowledge app instance materialization: %w", err)
+	}
+	return recordToAppInstanceMaterialization(rec), nil
+}
+
+func (s *AppInstanceMaterializationService) findByInstanceAppVersion(ctx context.Context, instanceID, app, version string) (idb.Record, error) {
+	instanceID = strings.TrimSpace(instanceID)
+	app = strings.TrimSpace(app)
+	version = strings.TrimSpace(version)
+	if instanceID == "" || app == "" || version == "" {
+		return nil, fmt.Errorf("find app instance materialization: instance_id, app, and version are required")
+	}
+	query := idb.Bound(
+		[]any{instanceID, app, version},
+		[]any{instanceID, app, version},
+		false,
+		false,
+	)
+	recs, err := s.store.Index("by_instance_app_version").GetAll(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	if len(recs) == 0 {
+		return nil, idb.ErrNotFound
+	}
+	return recs[0], nil
+}
+
+func recordToAppInstanceMaterialization(rec idb.Record) *core.AppInstanceMaterialization {
+	return &core.AppInstanceMaterialization{
+		InstanceID:     recString(rec, "instance_id"),
+		App:            recString(rec, "app"),
+		Version:        recString(rec, "version"),
+		AcknowledgedAt: recTime(rec, "acknowledged_at"),
+	}
+}

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -11,6 +11,7 @@ const (
 	StoreAppSHAs                       = "app_shas"
 	StoreAppVersionChangeRequests      = "app_version_change_requests"
 	StoreAppVersionInstallLocks        = "app_version_install_locks"
+	StoreAppInstanceMaterializations   = "app_instance_materializations"
 )
 
 var AppSHAsSchema = idb.ObjectStoreOptions{
@@ -84,6 +85,21 @@ var AppVersionInstallLocksSchema = idb.ObjectStoreOptions{
 		{Name: "holder", Type: idb.TypeString, NotNull: true},
 		{Name: "acquired_at", Type: idb.TypeTime, NotNull: true},
 		{Name: "expires_at", Type: idb.TypeTime, NotNull: true},
+	},
+}
+
+var AppInstanceMaterializationsSchema = idb.ObjectStoreOptions{
+	Indexes: []idb.IndexSchema{
+		{Name: "by_instance", KeyPath: []string{"instance_id"}},
+		{Name: "by_instance_app_version", KeyPath: []string{"instance_id", "app", "version"}, Unique: true},
+		{Name: "by_app_version", KeyPath: []string{"app", "version"}},
+	},
+	Columns: []idb.ColumnDef{
+		{Name: "id", Type: idb.TypeString, PrimaryKey: true},
+		{Name: "instance_id", Type: idb.TypeString, NotNull: true},
+		{Name: "app", Type: idb.TypeString, NotNull: true},
+		{Name: "version", Type: idb.TypeString, NotNull: true},
+		{Name: "acknowledged_at", Type: idb.TypeTime, NotNull: true},
 	},
 }
 

--- a/gestaltd/internal/coredata/services.go
+++ b/gestaltd/internal/coredata/services.go
@@ -9,12 +9,13 @@ import (
 )
 
 type Services struct {
-	Users                    *UserService
-	ExternalCredentials      core.ExternalCredentialProvider
-	ManagedSubjects          *ManagedSubjectService
-	AppVersionChangeRequests *AppVersionChangeRequestService
-	AppVersionInstallLocks   *AppVersionInstallLockService
-	DB                       indexeddb.IndexedDB
+	Users                       *UserService
+	ExternalCredentials         core.ExternalCredentialProvider
+	ManagedSubjects             *ManagedSubjectService
+	AppVersionChangeRequests    *AppVersionChangeRequestService
+	AppVersionInstallLocks      *AppVersionInstallLockService
+	AppInstanceMaterializations *AppInstanceMaterializationService
+	DB                          indexeddb.IndexedDB
 }
 
 // NewOptions configures coredata bootstrap behavior.
@@ -52,18 +53,23 @@ func NewWithOptions(ctx context.Context, ds indexeddb.IndexedDB, opts NewOptions
 		if _, err := ds.CreateObjectStore(ctx, StoreAppVersionInstallLocks, AppVersionInstallLocksSchema); err != nil {
 			return nil, fmt.Errorf("create app_version_install_locks store: %w", err)
 		}
+		if _, err := ds.CreateObjectStore(ctx, StoreAppInstanceMaterializations, AppInstanceMaterializationsSchema); err != nil {
+			return nil, fmt.Errorf("create app_instance_materializations store: %w", err)
+		}
 	}
 	users := NewUserService(ds)
 	managedSubjects := NewManagedSubjectService(ds)
 	appVersionChangeRequests := NewAppVersionChangeRequestService(ds)
 	appVersionInstallLocks := NewAppVersionInstallLockService(ds)
+	appInstanceMaterializations := NewAppInstanceMaterializationService(ds)
 	return &Services{
-		ExternalCredentials:      nil,
-		Users:                    users,
-		ManagedSubjects:          managedSubjects,
-		AppVersionChangeRequests: appVersionChangeRequests,
-		AppVersionInstallLocks:   appVersionInstallLocks,
-		DB:                       ds,
+		ExternalCredentials:         nil,
+		Users:                       users,
+		ManagedSubjects:             managedSubjects,
+		AppVersionChangeRequests:    appVersionChangeRequests,
+		AppVersionInstallLocks:      appVersionInstallLocks,
+		AppInstanceMaterializations: appInstanceMaterializations,
+		DB:                          ds,
 	}, nil
 }
 

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -15,6 +15,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/core/crypto"
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+	"github.com/valon-technologies/gestalt/server/internal/appregistry"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	gestaltmcp "github.com/valon-technologies/gestalt/server/services/apps/mcp"
@@ -119,6 +120,7 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 	if err := result.Start(ctx); err != nil {
 		return err
 	}
+	startAppRegistryCatalogPoller(ctx, result)
 
 	publicConfig := baseConfig
 	if managementAddr == "" {
@@ -391,4 +393,20 @@ func (h *switchableHandler) Set(handler http.Handler) {
 	h.mu.Lock()
 	h.handler = handler
 	h.mu.Unlock()
+}
+
+func startAppRegistryCatalogPoller(ctx context.Context, result *bootstrap.Result) {
+	if result == nil || result.Services == nil {
+		return
+	}
+	changeRequests := result.Services.AppVersionChangeRequests
+	materializations := result.Services.AppInstanceMaterializations
+	if changeRequests == nil || materializations == nil {
+		return
+	}
+	appregistry.NewCatalogPoller(appregistry.CatalogPollerConfig{
+		ChangeRequests:   changeRequests,
+		Materializations: materializations,
+		InstanceID:       appregistry.ResolveInstanceID(),
+	}).Start(ctx)
 }

--- a/plans/app_registry/indexeddb.md
+++ b/plans/app_registry/indexeddb.md
@@ -57,8 +57,9 @@ When `SkipSchemaBootstrap` is false (default for a **local** main-db provider), 
 App registry stores:
 
 ```text
-app_version_change_requests    ← source of truth (append-only)
-app_version_install_locks      ← fleet install lock per (app, version)
+app_version_change_requests      ← source of truth (append-only)
+app_version_install_locks        ← fleet install lock per (app, version)
+app_instance_materializations    ← per-replica ack of fleet-known versions
 ```
 
 Other host stores created at bootstrap include `users`, `managed_subjects`, `app_shas`, etc.
@@ -188,4 +189,35 @@ Primary key: `id` = `app` + `\x00` + `version`.
 | `Acquire(ctx, app, version, holder, ttl)` | Claim lock; returns `ErrAppVersionInstallLockHeld` if another holder owns a non-expired lock |
 | `Release(ctx, app, version, holder)` | Drop lock when this holder still owns it |
 
-Used by `POST …/install` before download; released on success or failure.
+Used by `POST …/install` before change request write; released on success or failure.
+
+---
+
+## Store: `app_instance_materializations` (per-replica ack)
+
+Records that one gestaltd replica observed a fleet-known `(app, version)` from `app_version_change_requests`.
+
+Primary key: `id` (UUID). Uniqueness for `(instance_id, app, version)` is enforced by the `by_instance_app_version` index.
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "instance_id": "cloud-run-revision-pod",
+  "app": "g-issues",
+  "version": "0.0.0-snapshot.gabc123",
+  "acknowledged_at": "2026-07-13T21:00:00Z"
+}
+```
+
+`instance_id` defaults to the process hostname (`os.Hostname()`).
+
+### Service API
+
+`AppInstanceMaterializationService` (`gestaltd/internal/coredata/app_instance_materializations.go`):
+
+| Method | Description |
+|--------|-------------|
+| `HasAcknowledged(ctx, instanceID, app, version)` | Whether this replica already acked the pair. |
+| `Acknowledge(ctx, materialization)` | Insert ack row; idempotent if already present. |
+
+Written by the background catalog poller (`gestaltd/internal/appregistry/poller.go`).

--- a/plans/app_registry/lifecycle.md
+++ b/plans/app_registry/lifecycle.md
@@ -7,7 +7,7 @@ Install is change-request-only; per-replica convergence (ack → download → re
 Related docs:
 
 - [plan.md](./plan.md) — install flow, catalog model, rollout steps
-- [indexeddb.md](./indexeddb.md) — `app_version_change_requests`, install locks, planned `app_instance_materializations`
+- [indexeddb.md](./indexeddb.md) — `app_version_change_requests`, `app_instance_materializations`, install locks
 - [config.md](./config.md) — `appRegistries` deploy reader config
 - [models.md](./models.md) — index and published version JSON stored in GCS
 - [service.md](./service.md) — Go publish/read helpers behind the registry bucket
@@ -19,6 +19,7 @@ Implementation:
 - Install handlers — `gestaltd/internal/server/handlers_admin_app_install.go`
 - Registry fetcher — `gestaltd/internal/appregistry/reader.go`
 - Registry installer — `gestaltd/internal/appregistry/installer.go`
+- Catalog poller — `gestaltd/internal/appregistry/poller.go`
 - Change request projections — `gestaltd/internal/coredata/app_version_change_requests_projection.go`
 
 ## Startup
@@ -36,19 +37,15 @@ Install is HTTP-triggered for fleet declaration. On startup, gestaltd does not b
 
 ## Polling
 
-**Planned.** Every replica will run a background catalog controller after `gestaltd serve` is up: one reconcile pass at startup, then every **1 minute** in a goroutine.
+Every replica runs one background catalog controller after `gestaltd serve` is up: one reconcile pass at startup, then every **1 minute** on a single loop goroutine.
 
 The controller is **pull-based** and **local**: each replica reads `app_version_change_requests` (`ListAllKnownVersions`) and reconciles itself against fleet install state. No replica fans out install RPCs to peers.
 
-Each pass, for every known `(app, version)` this replica has not yet converged:
+Each pass, for every known `(app, version)` this replica has not yet acknowledged, write a per-instance row in `app_instance_materializations`.
 
-1. Acknowledge the catalog row in per-instance IndexedDB state (planned `app_instance_materializations`) and emit a metric.
-2. Download the registry artifact and materialize under `registry-installed/{app}/{version}/` before stopping the running app.
-3. Stop the app and start again from the newly materialized binary (bind the provider graph to the new path instead of the old one).
+Later steps add download, restart, and binary mount. See [plan.md](./plan.md) steps 9–11.
 
-Skip pairs already at the target version. Use per-`(app, version)` inflight guards so overlapping ticks do not double-download or double-restart.
-
-Rollout phasing for these behaviors is in [plan.md](./plan.md) steps 8–11.
+Skip pairs already acknowledged on this replica. If a reconcile pass is still running when the next tick fires, skip the tick. Use per-`(app, version)` inflight guards within a pass.
 
 ## Runtime
 

--- a/plans/app_registry/plan.md
+++ b/plans/app_registry/plan.md
@@ -260,7 +260,7 @@ Core recovery paths must not depend on dynamically installed apps.
 5. Add IndexedDB change request store and projection helpers (`app_version_change_requests` + known-version views). See [indexeddb.md](./indexeddb.md).
 6. Prototype installing one registry app: materialize on the handling instance, record known versions in the catalog, expose via admin HTTP. **Done:** catalog writes; `app_installations` store removed. See [lifecycle.md](./lifecycle.md), [tests.md](./tests.md).
 7. Split install from local materialization — `POST …/install` writes `app_version_change_requests` only. See [lifecycle.md](./lifecycle.md).
-8. Per-replica catalog polling: acknowledge each new `change request` row in IndexedDB and emit a metric. See [lifecycle.md](./lifecycle.md#polling).
+8. Per-replica catalog polling: acknowledge each new fleet-known `(app, version)` in IndexedDB. **Done:** `app_instance_materializations` + background poller. See [lifecycle.md](./lifecycle.md#polling).
 9. Stop the running app and start the same app back up (restart machinery only; no binary change yet). Use a **1 minute** delay between stop and start during early rollout testing so operators can observe that the process started; production restart has no intentional wait.
 10. Download and materialize the new version artifact **before** bringing the app down.
 11. Mount the newly materialized binary instead of the old one when restarting.

--- a/plans/app_registry/tests.md
+++ b/plans/app_registry/tests.md
@@ -17,15 +17,16 @@ Related docs:
 | Package | File | Tests | Layer | PR |
 |---------|------|-------|-------|-----|
 | `internal/daemon/e2e/appregistry` | `appregistry_test.go` | 1 | E2E (CLI) | [gestalt#2709](https://github.com/valon-technologies/gestalt/pull/2709) |
+| `internal/appregistry` | `poller_test.go` | 2 | Unit (poller) | [gestalt#2750](https://github.com/valon-technologies/gestalt/pull/2750) |
 | `internal/server` | `handlers_admin_app_install_test.go` | 3 | HTTP integration | [gestalt#2730](https://github.com/valon-technologies/gestalt/pull/2730) |
 
 Test fixture for install HTTP tests: `internal/appregistry/registrytest/fixture.go`
 
 ---
 
-## Step 1: publish dry-run E2E
+## Publish dry-run E2E
 
-Added in [gestalt#2709](https://github.com/valon-technologies/gestalt/pull/2709) (step 1: GCS app registry + `gestaltd app publish`).
+Added in [gestalt#2709](https://github.com/valon-technologies/gestalt/pull/2709) (GCS app registry + `gestaltd app publish`).
 
 Run:
 
@@ -61,7 +62,7 @@ Expected plan fields:
 
 ---
 
-## Step 6: install HTTP integration
+## Install HTTP integration
 
 Added in [gestalt#2730](https://github.com/valon-technologies/gestalt/pull/2730) (registry app install via `app_version_change_requests`).
 
@@ -84,10 +85,29 @@ All three subtests use `newTestServer` (`httptest.NewServer` on localhost), `tes
 
 ---
 
+## Catalog poller unit tests
+
+Added in [gestalt#2750](https://github.com/valon-technologies/gestalt/pull/2750). Exercise `CatalogPoller.ReconcileOnce` and `Start` against stub change requests + materialization services — no `gestaltd serve`, no real ticker timing.
+
+Run:
+
+```bash
+cd gestaltd
+go test ./internal/appregistry/... -run TestCatalogPoller -count=1
+```
+
+### `poller_test.go`
+
+- **`TestCatalogPoller_ReconcileOnce_acknowledges_known_versions`** — After a change request exists, reconcile writes an ack row for the poller `instance_id`; a second reconcile is a no-op.
+
+- **`TestCatalogPoller_Start_is_idempotent`** — Calling `Start` twice does not panic when the loop context is already cancelled.
+
+---
+
 ## What is not covered yet
 
 Publish tests validate **CLI dry-run behavior** only. Install HTTP tests cover the happy path, 404 on missing version, and get-by-app — but not:
 
 - Real GCS upload integration
 - Re-install idempotency (no duplicate change request)
-- Controller tick / convergence tests
+- Catalog poller integration test against real `gestaltd serve` startup

--- a/plans/app_registry/tests.md
+++ b/plans/app_registry/tests.md
@@ -17,7 +17,6 @@ Related docs:
 | Package | File | Tests | Layer | PR |
 |---------|------|-------|-------|-----|
 | `internal/daemon/e2e/appregistry` | `appregistry_test.go` | 1 | E2E (CLI) | [gestalt#2709](https://github.com/valon-technologies/gestalt/pull/2709) |
-| `internal/appregistry` | `poller_test.go` | 2 | Unit (poller) | [gestalt#2750](https://github.com/valon-technologies/gestalt/pull/2750) |
 | `internal/server` | `handlers_admin_app_install_test.go` | 3 | HTTP integration | [gestalt#2730](https://github.com/valon-technologies/gestalt/pull/2730) |
 
 Test fixture for install HTTP tests: `internal/appregistry/registrytest/fixture.go`
@@ -85,22 +84,21 @@ All three subtests use `newTestServer` (`httptest.NewServer` on localhost), `tes
 
 ---
 
-## Catalog poller unit tests
+## [PLANNED] Multi-replica materialization ack E2E
 
-Added in [gestalt#2750](https://github.com/valon-technologies/gestalt/pull/2750). Exercise `CatalogPoller.ReconcileOnce` and `Start` against stub change requests + materialization services — no `gestaltd serve`, no real ticker timing.
+End-to-end test for fleet install convergence across replicas. Replaces isolated catalog poller unit tests.
 
-Run:
+**Goal:** After a new version is installed fleet-wide, every running replica acknowledges the `(app, version)` pair in `app_instance_materializations`.
 
-```bash
-cd gestaltd
-go test ./internal/appregistry/... -run TestCatalogPoller -count=1
-```
+**Flow:**
 
-### `poller_test.go`
+1. Start multiple `gestaltd` replicas against shared IndexedDB (or a test harness that simulates distinct `instance_id` values with the catalog poller enabled).
+2. `POST /admin/api/v1/app-registries/{registry}/apps/{app}/install` with a new version.
+3. Assert `app_version_change_requests` contains the change request.
+4. Poll each replica's `app_instance_materializations` (or a future admin list endpoint) until every replica has an ack row for `(app, version)`.
+5. Assert ack timestamps are recent and `instance_id` values are distinct per replica.
 
-- **`TestCatalogPoller_ReconcileOnce_acknowledges_known_versions`** — After a change request exists, reconcile writes an ack row for the poller `instance_id`; a second reconcile is a no-op.
-
-- **`TestCatalogPoller_Start_is_idempotent`** — Calling `Start` twice does not panic when the loop context is already cancelled.
+**Not in scope for the first cut:** artifact download, provider restart, or mount swap — ack-only convergence.
 
 ---
 
@@ -110,4 +108,4 @@ Publish tests validate **CLI dry-run behavior** only. Install HTTP tests cover t
 
 - Real GCS upload integration
 - Re-install idempotency (no duplicate change request)
-- Catalog poller integration test against real `gestaltd serve` startup
+- Multi-replica materialization ack E2E (see [PLANNED] section above)


### PR DESCRIPTION
## Summary
- Add `app_instance_materializations` IndexedDB store for per-replica acknowledgments of fleet-known `(app, version)` pairs
- Start a background catalog poller at `gestaltd serve` (startup pass + 1 minute tick)

Step 8 only — no download, restart, or binary mount yet (steps 9–11).

## Test plan
- [x] CI lint/vet and Go tests
- [ ] [PLANNED] multi-replica install + materialization ack E2E (see `plans/app_registry/tests.md`)