### PR TITLE
Use canonical IndexedDB host-service binding names

### DIFF
--- a/sdk/python/gestalt/_indexeddb.py
+++ b/sdk/python/gestalt/_indexeddb.py
@@ -662,7 +662,7 @@ class IndexedDB:
             raise RuntimeError(f"{ENV_HOST_SERVICE_SOCKET} is not set")
         token = os.environ.get(ENV_HOST_SERVICE_TOKEN, "")
         self._channel = host_service_channel(
-            "IndexedDB", target, token=token.strip(), binding=(name or "").strip()
+            "indexeddb", target, token=token.strip(), binding=(name or "").strip()
         )
         self._stub = pb_grpc.IndexedDBStub(self._channel)
 

--- a/sdk/typescript/src/providers/indexeddb.ts
+++ b/sdk/typescript/src/providers/indexeddb.ts
@@ -1079,9 +1079,9 @@ class IndexedDBImpl implements IndexedDB {
   private readonly transport: HostServiceGrpcTransport;
 
   constructor(name?: string) {
-    const { target, token } = requireHostServiceTarget("IndexedDB");
+    const { target, token } = requireHostServiceTarget("indexeddb");
     const transport = createHostServiceGrpcTransport(
-      parseHostServiceTarget("IndexedDB", target),
+      parseHostServiceTarget("indexeddb", target),
       hostServiceMetadataInterceptors(token, name?.trim() ?? ""),
     );
     this.transport = transport;


### PR DESCRIPTION
## Summary

- Use the canonical lowercase `indexeddb` host-service binding in the ergonomic TypeScript and Python IndexedDB clients.
- Keep the fix limited to the two production call sites.

The host advertises `indexeddb`, while both facades passed the case-sensitive display-style name `IndexedDB` to the host-service allowlist check.

## Test plan

- [x] `bun run check` (159 tests)
- [x] `uv run ruff check .`
- [x] `uv run python -m unittest tests.test_indexeddb_transport` (27 tests)
- [x] `uv run python -m unittest discover -s tests` (190 tests)