### PR TITLE
Auto-derive per-provider migration ledger stores

### DIFF
--- a/sdk/go/migrations/ledger_store.go
+++ b/sdk/go/migrations/ledger_store.go
@@ -1,0 +1,39 @@
+package migrations
+
+import (
+	"regexp"
+	"strings"
+)
+
+var camelBoundary = regexp.MustCompile(`([a-z0-9])([A-Z])`)
+
+// ProviderLedgerStore derives the default migration ledger store for a
+// configured provider name.
+func ProviderLedgerStore(providerName string) string {
+	normalized := strings.TrimSpace(providerName)
+	if at := strings.LastIndex(normalized, "/"); at >= 0 {
+		normalized = normalized[at+1:]
+	}
+	if normalized == "" {
+		return defaultLedgerStore
+	}
+	slug := slugName(normalized)
+	if slug == "" {
+		return defaultLedgerStore
+	}
+	snake := strings.ToLower(strings.ReplaceAll(camelBoundary.ReplaceAllString(slug, `${1}_${2}`), "-", "_"))
+	return snake + "_migrations"
+}
+
+func slugName(value string) string {
+	var b strings.Builder
+	for _, r := range value {
+		switch {
+		case r >= 'A' && r <= 'Z', r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '.', r == '_', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}

--- a/sdk/go/migrations/ledger_store.go
+++ b/sdk/go/migrations/ledger_store.go
@@ -7,8 +7,6 @@ import (
 
 var camelBoundary = regexp.MustCompile(`([a-z0-9])([A-Z])`)
 
-// ProviderLedgerStore derives the default migration ledger store for a
-// configured provider name.
 func ProviderLedgerStore(providerName string) string {
 	normalized := strings.TrimSpace(providerName)
 	if at := strings.LastIndex(normalized, "/"); at >= 0 {

--- a/sdk/go/migrations/ledger_store.go
+++ b/sdk/go/migrations/ledger_store.go
@@ -7,6 +7,7 @@ import (
 
 var camelBoundary = regexp.MustCompile(`([a-z0-9])([A-Z])`)
 
+// ProviderLedgerStore returns the default ledger store for a provider name.
 func ProviderLedgerStore(providerName string) string {
 	normalized := strings.TrimSpace(providerName)
 	if at := strings.LastIndex(normalized, "/"); at >= 0 {

--- a/sdk/go/migrations/ledger_store_test.go
+++ b/sdk/go/migrations/ledger_store_test.go
@@ -1,0 +1,28 @@
+package migrations_test
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/sdk/go/migrations"
+)
+
+func TestProviderLedgerStore(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		want     string
+	}{
+		{name: "camelCase provider", provider: "gIssues", want: "g_issues_migrations"},
+		{name: "multi-word camelCase", provider: "dealHub", want: "deal_hub_migrations"},
+		{name: "hyphenated slug", provider: "deal-hub", want: "deal_hub_migrations"},
+		{name: "scoped package name", provider: "@scope/gIssues", want: "g_issues_migrations"},
+		{name: "empty falls back", provider: "   ", want: "_gestalt_migrations"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := migrations.ProviderLedgerStore(tt.provider); got != tt.want {
+				t.Fatalf("ProviderLedgerStore(%q) = %q, want %q", tt.provider, got, tt.want)
+			}
+		})
+	}
+}

--- a/sdk/go/migrations/ledger_store_test.go
+++ b/sdk/go/migrations/ledger_store_test.go
@@ -16,6 +16,8 @@ func TestProviderLedgerStore(t *testing.T) {
 		{name: "multi-word camelCase", provider: "dealHub", want: "deal_hub_migrations"},
 		{name: "hyphenated slug", provider: "deal-hub", want: "deal_hub_migrations"},
 		{name: "scoped package name", provider: "@scope/gIssues", want: "g_issues_migrations"},
+		{name: "path-like provider name", provider: "github.com/foo/myApp", want: "my_app_migrations"},
+		{name: "spaces become separate dashes", provider: "my  app", want: "my__app_migrations"},
 		{name: "empty falls back", provider: "   ", want: "_gestalt_migrations"},
 	}
 	for _, tt := range tests {

--- a/sdk/go/migrations_configure.go
+++ b/sdk/go/migrations_configure.go
@@ -26,6 +26,9 @@ func ConfigureMigrations(ctx context.Context, provider Provider, name string, co
 			}
 		}
 	}
+	if strings.TrimSpace(opts.LedgerStore) == "" {
+		opts.LedgerStore = migrations.ProviderLedgerStore(name)
+	}
 	db, err := IndexedDB(ctx, binding)
 	if err != nil {
 		return fmt.Errorf("migrations: open indexeddb: %w", err)

--- a/sdk/python/gestalt/__init__.py
+++ b/sdk/python/gestalt/__init__.py
@@ -53,6 +53,7 @@ _MIGRATIONS_EXPORTS = (
     "SchemaDeclaration",
     "SchemaRevision",
     "StoreDeclaration",
+    "provider_migration_ledger_store",
     "run_migrations",
 )
 

--- a/sdk/python/gestalt/__init__.py
+++ b/sdk/python/gestalt/__init__.py
@@ -611,6 +611,7 @@ __all__ = [
     "SchemaDeclaration",
     "SchemaRevision",
     "StoreDeclaration",
+    "provider_migration_ledger_store",
     "run_migrations",
     "Model",
     "NotFoundError",

--- a/sdk/python/gestalt/migrations.py
+++ b/sdk/python/gestalt/migrations.py
@@ -27,8 +27,6 @@ Record = dict[str, Any]
 
 
 def provider_migration_ledger_store(provider_name: str) -> str:
-    """Derive the default migration ledger store for a configured provider name."""
-
     normalized = provider_name.strip()
     if "/" in normalized:
         normalized = normalized.rsplit("/", 1)[-1]

--- a/sdk/python/gestalt/migrations.py
+++ b/sdk/python/gestalt/migrations.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime as dt
 import json
+import re
 from collections.abc import Callable
 from dataclasses import dataclass, replace
 from typing import Any, Protocol, runtime_checkable
@@ -20,8 +21,34 @@ from ._indexeddb import (
 DEFAULT_LEDGER_STORE = "_gestalt_migrations"
 LEDGER_KEY_COLUMN = "revision_id"
 LEDGER_APPLIED_COLUMN = "applied_at"
+_CAMEL_BOUNDARY = re.compile(r"([a-z0-9])([A-Z])")
 
 Record = dict[str, Any]
+
+
+def provider_migration_ledger_store(provider_name: str) -> str:
+    """Derive the default migration ledger store for a configured provider name."""
+
+    normalized = provider_name.strip()
+    if "/" in normalized:
+        normalized = normalized.rsplit("/", 1)[-1]
+    if not normalized:
+        return DEFAULT_LEDGER_STORE
+    slug = _slug_name(normalized)
+    if not slug:
+        return DEFAULT_LEDGER_STORE
+    snake = _CAMEL_BOUNDARY.sub(r"\1_\2", slug).replace("-", "_").lower()
+    return f"{snake}_migrations"
+
+
+def _slug_name(value: str) -> str:
+    chars: list[str] = []
+    for char in value:
+        if char.isalnum() or char in "._-":
+            chars.append(char)
+        else:
+            chars.append("-")
+    return "".join(chars).strip("-")
 
 
 @dataclass
@@ -221,6 +248,12 @@ def configure_migrations(provider: Any, name: str, config: dict[str, Any]) -> No
     options = normalize_migrations(migration_options(name, config))
     if options is None:
         return
+
+    if not (options.ledger_store or "").strip():
+        options = replace(
+            options,
+            ledger_store=provider_migration_ledger_store(name),
+        )
 
     binding = (options.db_binding or "").strip()
     if not binding:

--- a/sdk/python/gestalt/migrations.py
+++ b/sdk/python/gestalt/migrations.py
@@ -44,7 +44,12 @@ def provider_migration_ledger_store(provider_name: str) -> str:
 def _slug_name(value: str) -> str:
     chars: list[str] = []
     for char in value:
-        if char.isalnum() or char in "._-":
+        if (
+            ("A" <= char <= "Z")
+            or ("a" <= char <= "z")
+            or ("0" <= char <= "9")
+            or char in "._-"
+        ):
             chars.append(char)
         else:
             chars.append("-")

--- a/sdk/python/tests/test_migrations.py
+++ b/sdk/python/tests/test_migrations.py
@@ -4,8 +4,8 @@ from unittest.mock import patch
 from gestalt.migrations import (
     MigrationError,
     MigrationRunOptions,
-    SchemaRevision,
     SchemaDeclaration,
+    SchemaRevision,
     StoreDeclaration,
     configure_migrations,
     provider_migration_ledger_store,

--- a/sdk/python/tests/test_migrations.py
+++ b/sdk/python/tests/test_migrations.py
@@ -150,6 +150,11 @@ class MigrationTests(unittest.TestCase):
         self.assertEqual(provider_migration_ledger_store("dealHub"), "deal_hub_migrations")
         self.assertEqual(provider_migration_ledger_store("deal-hub"), "deal_hub_migrations")
         self.assertEqual(provider_migration_ledger_store("@scope/gIssues"), "g_issues_migrations")
+        self.assertEqual(
+            provider_migration_ledger_store("github.com/foo/myApp"),
+            "my_app_migrations",
+        )
+        self.assertEqual(provider_migration_ledger_store("my  app"), "my__app_migrations")
         self.assertEqual(provider_migration_ledger_store("   "), "_gestalt_migrations")
 
     def test_configure_migrations_derives_per_provider_ledger_store(self) -> None:

--- a/sdk/python/tests/test_migrations.py
+++ b/sdk/python/tests/test_migrations.py
@@ -1,12 +1,14 @@
 import unittest
+from unittest.mock import patch
 
 from gestalt.migrations import (
     MigrationError,
     MigrationRunOptions,
-    Revision,
-    SchemaDeclaration,
     SchemaRevision,
+    SchemaDeclaration,
     StoreDeclaration,
+    configure_migrations,
+    provider_migration_ledger_store,
     run_migrations,
 )
 
@@ -69,7 +71,7 @@ def _data_store_calls(calls: list[str]) -> list[str]:
 class MigrationTests(unittest.TestCase):
     def test_fresh_install_and_restart(self) -> None:
         db = FakeDB()
-        revisions: list[Revision] = [init_revision("0001_init", "widgets")]
+        revisions = [init_revision("0001_init", "widgets")]
         result = run_migrations(db, MigrationRunOptions(revisions=revisions))
         self.assertEqual(result.applied, ["0001_init"])
         self.assertEqual(result.head, "0001_init")
@@ -92,7 +94,7 @@ class MigrationTests(unittest.TestCase):
 
     def test_ledger_ahead_of_code(self) -> None:
         db = FakeDB()
-        revisions: list[Revision] = [init_revision("0001_init", "widgets")]
+        revisions = [init_revision("0001_init", "widgets")]
         run_migrations(db, MigrationRunOptions(revisions=revisions))
         db.object_store("_gestalt_migrations").put(
             {
@@ -136,12 +138,59 @@ class MigrationTests(unittest.TestCase):
 
     def test_duplicate_revision_ids(self) -> None:
         db = FakeDB()
-        revisions: list[Revision] = [
+        revisions = [
             init_revision("0001_init", "widgets"),
             init_revision("0001_init", "gadgets"),
         ]
         with self.assertRaises(MigrationError):
             run_migrations(db, MigrationRunOptions(revisions=revisions))
+
+    def test_provider_migration_ledger_store(self) -> None:
+        self.assertEqual(provider_migration_ledger_store("gIssues"), "g_issues_migrations")
+        self.assertEqual(provider_migration_ledger_store("dealHub"), "deal_hub_migrations")
+        self.assertEqual(provider_migration_ledger_store("deal-hub"), "deal_hub_migrations")
+        self.assertEqual(provider_migration_ledger_store("@scope/gIssues"), "g_issues_migrations")
+        self.assertEqual(provider_migration_ledger_store("   "), "_gestalt_migrations")
+
+    def test_configure_migrations_derives_per_provider_ledger_store(self) -> None:
+        class Provider:
+            def migration_options(self, _name: str, _config: dict) -> MigrationRunOptions:
+                return MigrationRunOptions(
+                    revisions=[init_revision("gIssues/0001_init", "widgets")]
+                )
+
+        db = FakeDB()
+
+        class FakeIndexedDB:
+            def __init__(self, _binding: str = "") -> None:
+                self._db = db
+
+            def object_store(self, name: str) -> FakeStore:
+                return self._db.object_store(name)
+
+            def create_object_store(self, name: str, schema=None) -> FakeStore:
+                return self._db.create_object_store(name, schema)
+
+            def delete_object_store(self, name: str) -> None:
+                self._db.delete_object_store(name)
+
+            def create_index(self, store: str, index) -> None:
+                self._db.create_index(store, index)
+
+            def delete_index(self, store: str, name: str) -> None:
+                self._db.delete_index(store, name)
+
+            def close(self) -> None:
+                self._db.close()
+
+        with patch("gestalt.migrations.IndexedDB", FakeIndexedDB):
+            configure_migrations(Provider(), "gIssues", {"indexeddb": "main-db"})
+
+        self.assertEqual(
+            db.object_store("g_issues_migrations").get_all_keys(),
+            ["gIssues/0001_init"],
+        )
+        self.assertNotIn("_gestalt_migrations", db.stores)
 
 
 if __name__ == "__main__":

--- a/sdk/python/tests/test_migrations.py
+++ b/sdk/python/tests/test_migrations.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from gestalt.migrations import (
     MigrationError,
     MigrationRunOptions,
+    Revision,
     SchemaDeclaration,
     SchemaRevision,
     StoreDeclaration,
@@ -71,7 +72,7 @@ def _data_store_calls(calls: list[str]) -> list[str]:
 class MigrationTests(unittest.TestCase):
     def test_fresh_install_and_restart(self) -> None:
         db = FakeDB()
-        revisions = [init_revision("0001_init", "widgets")]
+        revisions: list[Revision] = [init_revision("0001_init", "widgets")]
         result = run_migrations(db, MigrationRunOptions(revisions=revisions))
         self.assertEqual(result.applied, ["0001_init"])
         self.assertEqual(result.head, "0001_init")
@@ -94,7 +95,7 @@ class MigrationTests(unittest.TestCase):
 
     def test_ledger_ahead_of_code(self) -> None:
         db = FakeDB()
-        revisions = [init_revision("0001_init", "widgets")]
+        revisions: list[Revision] = [init_revision("0001_init", "widgets")]
         run_migrations(db, MigrationRunOptions(revisions=revisions))
         db.object_store("_gestalt_migrations").put(
             {
@@ -138,7 +139,7 @@ class MigrationTests(unittest.TestCase):
 
     def test_duplicate_revision_ids(self) -> None:
         db = FakeDB()
-        revisions = [
+        revisions: list[Revision] = [
             init_revision("0001_init", "widgets"),
             init_revision("0001_init", "gadgets"),
         ]

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -223,6 +223,7 @@ export {
 } from "./providers/app.ts";
 export {
   MigrationError,
+  providerMigrationLedgerStore,
   runMigrations,
   type AddIndexDeclaration,
   type BackfillRevision,

--- a/sdk/typescript/src/provider.ts
+++ b/sdk/typescript/src/provider.ts
@@ -3,6 +3,7 @@ import { IndexedDB } from "./providers/indexeddb.ts";
 import {
   type MigrationRunOptions,
   type Revision,
+  providerMigrationLedgerStore,
   resolveMigrationDbBinding,
   runMigrations,
 } from "./providers/migrations.ts";
@@ -244,16 +245,26 @@ function resolveMigrations(
   }
   if (typeof source === "function") {
     const resolved = source(name, config);
-    return resolved === undefined ? undefined : normalizeMigrationRunOptions(resolved);
+    return resolved === undefined
+      ? undefined
+      : normalizeMigrationRunOptions(resolved, name);
   }
-  return normalizeMigrationRunOptions(source);
+  return normalizeMigrationRunOptions(source, name);
 }
 
 function normalizeMigrationRunOptions(
   input: Revision[] | MigrationRunOptions,
+  providerName: string,
 ): MigrationRunOptions | undefined {
-  if (Array.isArray(input)) {
-    return input.length > 0 ? { revisions: input } : undefined;
+  const base = Array.isArray(input) ? { revisions: input } : input;
+  if (base.revisions.length === 0) {
+    return undefined;
   }
-  return input.revisions.length > 0 ? input : undefined;
+  if (base.ledgerStore?.trim()) {
+    return base;
+  }
+  return {
+    ...base,
+    ledgerStore: providerMigrationLedgerStore(providerName),
+  };
 }

--- a/sdk/typescript/src/providers/migrations.ts
+++ b/sdk/typescript/src/providers/migrations.ts
@@ -95,13 +95,15 @@ export interface MigrationRunOptions {
  * Derive the default migration ledger store for a configured provider name.
  */
 export function providerMigrationLedgerStore(providerName: string): string {
-  const normalized = providerName.trim().replace(/^@[^/]+\//, "");
+  let normalized = providerName.trim();
+  const slash = normalized.lastIndexOf("/");
+  if (slash >= 0) {
+    normalized = normalized.slice(slash + 1);
+  }
   if (!normalized) {
     return DEFAULT_LEDGER_STORE;
   }
-  const slug = normalized
-    .replace(/[^A-Za-z0-9._-]+/g, "-")
-    .replace(/^-+|-+$/g, "");
+  const slug = migrationLedgerSlug(normalized);
   if (!slug) {
     return DEFAULT_LEDGER_STORE;
   }
@@ -110,6 +112,25 @@ export function providerMigrationLedgerStore(providerName: string): string {
     .replace(/-/g, "_")
     .toLowerCase();
   return `${snake}_migrations`;
+}
+
+function migrationLedgerSlug(value: string): string {
+  let slug = "";
+  for (const char of value) {
+    if (
+      (char >= "A" && char <= "Z") ||
+      (char >= "a" && char <= "z") ||
+      (char >= "0" && char <= "9") ||
+      char === "." ||
+      char === "_" ||
+      char === "-"
+    ) {
+      slug += char;
+    } else {
+      slug += "-";
+    }
+  }
+  return slug.replace(/^-+|-+$/g, "");
 }
 
 /** Resolve the IndexedDB binding for migration runs. */

--- a/sdk/typescript/src/providers/migrations.ts
+++ b/sdk/typescript/src/providers/migrations.ts
@@ -83,17 +83,10 @@ export interface MigrationRunOptions {
   revisions: Revision[];
   /** Name of the IndexedDB binding to migrate. */
   dbBinding?: string;
-  /**
-   * Ledger store name. When omitted, {@link runMigrations} defaults to
-   * `_gestalt_migrations`; provider startup derives a per-provider store from
-   * the configured provider name.
-   */
+  /** Ledger store name. */
   ledgerStore?: string;
 }
 
-/**
- * Derive the default migration ledger store for a configured provider name.
- */
 export function providerMigrationLedgerStore(providerName: string): string {
   let normalized = providerName.trim();
   const slash = normalized.lastIndexOf("/");

--- a/sdk/typescript/src/providers/migrations.ts
+++ b/sdk/typescript/src/providers/migrations.ts
@@ -83,8 +83,33 @@ export interface MigrationRunOptions {
   revisions: Revision[];
   /** Name of the IndexedDB binding to migrate. */
   dbBinding?: string;
-  /** Ledger store name. Defaults to `_gestalt_migrations`. */
+  /**
+   * Ledger store name. When omitted, {@link runMigrations} defaults to
+   * `_gestalt_migrations`; provider startup derives a per-provider store from
+   * the configured provider name.
+   */
   ledgerStore?: string;
+}
+
+/**
+ * Derive the default migration ledger store for a configured provider name.
+ */
+export function providerMigrationLedgerStore(providerName: string): string {
+  const normalized = providerName.trim().replace(/^@[^/]+\//, "");
+  if (!normalized) {
+    return DEFAULT_LEDGER_STORE;
+  }
+  const slug = normalized
+    .replace(/[^A-Za-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  if (!slug) {
+    return DEFAULT_LEDGER_STORE;
+  }
+  const snake = slug
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/-/g, "_")
+    .toLowerCase();
+  return `${snake}_migrations`;
 }
 
 /** Resolve the IndexedDB binding for migration runs. */

--- a/sdk/typescript/tests/migrations.test.ts
+++ b/sdk/typescript/tests/migrations.test.ts
@@ -433,6 +433,10 @@ describe("runMigrations", () => {
     expect(providerMigrationLedgerStore("dealHub")).toBe("deal_hub_migrations");
     expect(providerMigrationLedgerStore("deal-hub")).toBe("deal_hub_migrations");
     expect(providerMigrationLedgerStore("@scope/gIssues")).toBe("g_issues_migrations");
+    expect(providerMigrationLedgerStore("github.com/foo/myApp")).toBe(
+      "my_app_migrations",
+    );
+    expect(providerMigrationLedgerStore("my  app")).toBe("my__app_migrations");
     expect(providerMigrationLedgerStore("   ")).toBe("_gestalt_migrations");
   });
 });

--- a/sdk/typescript/tests/migrations.test.ts
+++ b/sdk/typescript/tests/migrations.test.ts
@@ -8,6 +8,7 @@ import {
   type ObjectStoreSchema,
   type Record as DBRecord,
   type Revision,
+  providerMigrationLedgerStore,
   runMigrations,
 } from "../src/index.ts";
 
@@ -425,5 +426,13 @@ describe("runMigrations", () => {
 
     expect((await db.objectStore("dst").get("a")).id).toBe("a");
     expect(await ledgerIds(fake)).toEqual(["0001_seed", "0002_weird"]);
+  });
+
+  test("providerMigrationLedgerStore derives per-provider ledger names", () => {
+    expect(providerMigrationLedgerStore("gIssues")).toBe("g_issues_migrations");
+    expect(providerMigrationLedgerStore("dealHub")).toBe("deal_hub_migrations");
+    expect(providerMigrationLedgerStore("deal-hub")).toBe("deal_hub_migrations");
+    expect(providerMigrationLedgerStore("@scope/gIssues")).toBe("g_issues_migrations");
+    expect(providerMigrationLedgerStore("   ")).toBe("_gestalt_migrations");
   });
 });

--- a/sdk/typescript/tests/provider-migrations.test.ts
+++ b/sdk/typescript/tests/provider-migrations.test.ts
@@ -1,0 +1,130 @@
+import { expect, mock, test } from "bun:test";
+
+import * as gestalt from "../src/index.ts";
+
+type FakeRow = Record<string, unknown>;
+
+const fakeStores = new Map<string, Map<string, FakeRow>>();
+
+class FakeObjectStore {
+  constructor(private readonly name: string) {}
+
+  async get(id: string): Promise<FakeRow> {
+    const row = fakeStores.get(this.name)?.get(id);
+    if (!row) throw new gestalt.NotFoundError(`record ${id} not found`);
+    return structuredClone(row);
+  }
+
+  async put(row: FakeRow): Promise<void> {
+    const store = fakeStores.get(this.name) ?? new Map<string, FakeRow>();
+    fakeStores.set(this.name, store);
+    store.set(String(row.revision_id ?? row.id), structuredClone(row));
+  }
+
+  async delete(): Promise<void> {}
+
+  async clear(): Promise<void> {
+    fakeStores.get(this.name)?.clear();
+  }
+
+  async getAll(): Promise<FakeRow[]> {
+    return [...(fakeStores.get(this.name)?.values() ?? [])].map((row) =>
+      structuredClone(row),
+    );
+  }
+
+  async getAllKeys(): Promise<string[]> {
+    return [...(fakeStores.get(this.name)?.keys() ?? [])];
+  }
+
+  async openCursor() {
+    return {
+      value: undefined,
+      async continue() {
+        return false;
+      },
+      close() {},
+    };
+  }
+}
+
+class FakeIndexedDB {
+  async createObjectStore(name: string): Promise<void> {
+    if (!fakeStores.has(name)) {
+      fakeStores.set(name, new Map());
+    }
+  }
+
+  async deleteObjectStore(): Promise<void> {}
+
+  objectStore(name: string): FakeObjectStore {
+    if (!fakeStores.has(name)) {
+      fakeStores.set(name, new Map());
+    }
+    return new FakeObjectStore(name);
+  }
+
+  close(): void {}
+}
+
+mock.module("../src/providers/indexeddb.ts", () => ({
+  IndexedDB: FakeIndexedDB,
+}));
+
+class MigrationProvider extends gestalt.ProviderBase {
+  readonly kind = "integration" as const;
+
+  constructor(migrations: gestalt.Revision[]) {
+    super({ migrations });
+  }
+}
+
+test("configureProvider derives a per-provider migration ledger store", async () => {
+  fakeStores.clear();
+  const provider = new MigrationProvider([
+    {
+      id: "gIssues/0001_init",
+      schema: {
+        stores: [{ name: "widgets", columns: [{ name: "id", primaryKey: true }] }],
+      },
+    },
+  ]);
+
+  await provider.configureProvider("gIssues", { indexeddb: "main-db" });
+
+  expect([...(fakeStores.get("g_issues_migrations")?.keys() ?? [])]).toEqual([
+    "gIssues/0001_init",
+  ]);
+  expect(fakeStores.has("_gestalt_migrations")).toBe(false);
+});
+
+test("configureProvider keeps an explicit migration ledger override", async () => {
+  fakeStores.clear();
+  class CustomLedgerProvider extends gestalt.ProviderBase {
+    readonly kind = "integration" as const;
+
+    constructor() {
+      super({
+        migrations: {
+          revisions: [
+            {
+              id: "gIssues/0001_init",
+              schema: {
+                stores: [{ name: "widgets", columns: [{ name: "id", primaryKey: true }] }],
+              },
+            },
+          ],
+          ledgerStore: "custom_migrations",
+        },
+      });
+    }
+  }
+
+  const provider = new CustomLedgerProvider();
+  await provider.configureProvider("gIssues", { indexeddb: "main-db" });
+
+  expect([...(fakeStores.get("custom_migrations")?.keys() ?? [])]).toEqual([
+    "gIssues/0001_init",
+  ]);
+  expect(fakeStores.has("g_issues_migrations")).toBe(false);
+});


### PR DESCRIPTION
## Summary

- When a provider declares migrations without an explicit `ledgerStore`, the SDK now derives one from the configured provider name (e.g. `gIssues` → `g_issues_migrations`).
- Applies consistently across TypeScript, Go, and Python provider configure paths.
- Direct `runMigrations` / `migrations.Run` callers still default to `_gestalt_migrations`, so low-level migration runs are unchanged.

This removes the need for apps like g-issues to hardcode ledger store names after #3337.

## Test plan

- [x] `bun test tests/migrations.test.ts tests/provider-migrations.test.ts` (TypeScript)
- [x] `go test ./...` in `sdk/go/migrations`
- [ ] Python `tests/test_migrations.py` (local env missing protobuf deps; logic mirrors TS/Go)


Made with [Cursor](https://cursor.com)