### PR TITLE
Remove app S3 key namespacing

### DIFF
--- a/gestaltd/internal/bootstrap/executable_app_test.go
+++ b/gestaltd/internal/bootstrap/executable_app_test.go
@@ -6154,9 +6154,9 @@ func TestRuntimePublicS3RelayRoundTripsThroughHostedApp(t *testing.T) {
 	}
 
 	if _, err := boundS3.HeadObject(context.Background(), s3sdk.ObjectRef{
-		Key: testPluginS3NamespacePrefix("echoext") + "plans/q3.txt",
+		Key: "plans/q3.txt",
 	}); err != nil {
-		t.Fatalf("expected namespaced backing key: %v", err)
+		t.Fatalf("expected backing key: %v", err)
 	}
 
 	startRequests := runtimeProvider.startAppRequestsCopy()
@@ -8065,7 +8065,7 @@ func TestPluginIndexedDBBindingsDoNotDependOnAppS3Bindings(t *testing.T) {
 	t.Cleanup(func() { _ = CloseProviders(providers) })
 }
 
-func TestPluginS3BindingsRoundtripAndNamespaceKeys(t *testing.T) {
+func TestPluginS3BindingsRoundtripKeys(t *testing.T) {
 	t.Parallel()
 
 	bin := buildEchoPluginBinary(t)
@@ -8150,14 +8150,9 @@ func TestPluginS3BindingsRoundtripAndNamespaceKeys(t *testing.T) {
 	}
 
 	if _, err := stubS3.HeadObject(context.Background(), s3sdk.ObjectRef{
-		Key: testPluginS3NamespacePrefix("echoext") + "plans/q1.txt",
-	}); err != nil {
-		t.Fatalf("expected namespaced backing key: %v", err)
-	}
-	if _, err := stubS3.HeadObject(context.Background(), s3sdk.ObjectRef{
 		Key: "plans/q1.txt",
-	}); err == nil {
-		t.Fatal("unnamespaced backing key should remain empty")
+	}); err != nil {
+		t.Fatalf("expected backing key: %v", err)
 	}
 }
 
@@ -8218,12 +8213,12 @@ func TestPluginS3BindingsRouteExplicitBinding(t *testing.T) {
 	}
 
 	if _, err := archiveS3.HeadObject(context.Background(), s3sdk.ObjectRef{
-		Key: testPluginS3NamespacePrefix("echoext") + "plans/q2.txt",
+		Key: "plans/q2.txt",
 	}); err != nil {
 		t.Fatalf("archive binding should receive the write: %v", err)
 	}
 	if _, err := mainS3.HeadObject(context.Background(), s3sdk.ObjectRef{
-		Key: testPluginS3NamespacePrefix("echoext") + "plans/q2.txt",
+		Key: "plans/q2.txt",
 	}); err == nil {
 		t.Fatal("main binding should remain untouched when archive is selected explicitly")
 	}
@@ -8295,10 +8290,6 @@ func TestPluginS3BindingsExposeHostSocketEnv(t *testing.T) {
 	if got := checkEnv(t, []string{"main", "archive"}, runtimehost.HostServiceSocketEnv); !got {
 		t.Fatal("unified host-service env should be set with multiple app s3 bindings")
 	}
-}
-
-func testPluginS3NamespacePrefix(pluginName string) string {
-	return "plugin_" + strconv.Itoa(len(pluginName)) + "_" + pluginName + "/"
 }
 
 type trackedIndexedDB struct {

--- a/gestaltd/internal/server/handlers_s3_object_access.go
+++ b/gestaltd/internal/server/handlers_s3_object_access.go
@@ -46,7 +46,6 @@ func (s *Server) handleS3ObjectAccess(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	ref := target.Ref
-	ref.Key = s3.AppObjectKey(target.AppName, ref.Key)
 
 	switch target.Method {
 	case s3sdk.PresignMethodGet:

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -14,7 +14,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
-	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -373,14 +372,8 @@ func TestS3ObjectAccessURLUploadsAndDownloadsAppScopedObject(t *testing.T) {
 		t.Fatal("PUT response missing ETag")
 	}
 
-	prefixed := s3sdk.ObjectRef{
-		Key: s3.AppObjectKey("brain", targetRef.Key),
-	}
-	if _, err := store.HeadObject(context.Background(), prefixed); err != nil {
-		t.Fatalf("HeadObject(prefixed): %v", err)
-	}
-	if _, err := store.HeadObject(context.Background(), targetRef); !errors.Is(err, s3sdk.ErrNotFound) {
-		t.Fatalf("HeadObject(unprefixed) error = %v, want ErrNotFound", err)
+	if _, err := store.HeadObject(context.Background(), targetRef); err != nil {
+		t.Fatalf("HeadObject: %v", err)
 	}
 
 	getURL, err := manager.MintURL(s3.ObjectAccessURLRequest{

--- a/gestaltd/services/s3/object_access_urls.go
+++ b/gestaltd/services/s3/object_access_urls.go
@@ -169,10 +169,6 @@ func (m *ObjectAccessURLManager) tokenTTL(ttl time.Duration) time.Duration {
 	return ttl
 }
 
-func AppObjectKey(appName, key string) string {
-	return s3NamespacePrefix(appName) + key
-}
-
 func normalizeS3ObjectAccessRequest(req ObjectAccessURLRequest, expiresAt time.Time) (ObjectAccessTarget, error) {
 	pluginName := strings.TrimSpace(req.AppName)
 	if pluginName == "" {

--- a/gestaltd/services/s3/server.go
+++ b/gestaltd/services/s3/server.go
@@ -5,10 +5,8 @@ package s3
 
 import (
 	"context"
-	"encoding/base64"
 	"errors"
 	"io"
-	"strconv"
 	"strings"
 	"time"
 
@@ -24,13 +22,10 @@ import (
 type s3Server struct {
 	proto.UnimplementedS3Server
 	client      s3sdk.S3
-	keyPrefix   string
 	pluginName  string
 	bindingName string
 	accessURLs  *ObjectAccessURLManager
 }
-
-const s3ContinuationTokenPrefix = "gestalt_s3_ct_"
 
 type ServerOptions struct {
 	BindingName string
@@ -44,7 +39,6 @@ func NewServer(client s3sdk.S3, pluginName string) proto.S3Server {
 func NewServerWithOptions(client s3sdk.S3, pluginName string, opts ServerOptions) proto.S3Server {
 	return &s3Server{
 		client:      client,
-		keyPrefix:   s3NamespacePrefix(pluginName),
 		pluginName:  strings.TrimSpace(pluginName),
 		bindingName: strings.TrimSpace(opts.BindingName),
 		accessURLs:  opts.AccessURLs,
@@ -111,29 +105,21 @@ func (s *routingS3ObjectAccessServer) server(ctx context.Context) (proto.S3Objec
 }
 
 func (s *s3Server) HeadObject(ctx context.Context, req *proto.HeadObjectRequest) (*proto.HeadObjectResponse, error) {
-	meta, err := s.client.HeadObject(ctx, s.namespacedRef(objectRefFromProto(req.GetRef())))
+	meta, err := s.client.HeadObject(ctx, objectRefFromProto(req.GetRef()))
 	if err != nil {
 		return nil, s3ToGRPCErr(err)
-	}
-	meta, err = s.requireOwnedMetaNamespace(meta)
-	if err != nil {
-		return nil, err
 	}
 	return &proto.HeadObjectResponse{Meta: objectMetaToProto(meta)}, nil
 }
 
 func (s *s3Server) ReadObject(req *proto.ReadObjectRequest, stream proto.S3_ReadObjectServer) error {
-	result, err := s.client.ReadObject(stream.Context(), s.namespacedReadRequest(req))
+	result, err := s.client.ReadObject(stream.Context(), s.readRequest(req))
 	if err != nil {
 		return s3ToGRPCErr(err)
 	}
 	defer func() { _ = result.Body.Close() }()
-	meta, err := s.requireOwnedMetaNamespace(result.Meta)
-	if err != nil {
-		return err
-	}
 	if err := stream.Send(&proto.ReadObjectChunk{
-		Result: &proto.ReadObjectChunk_Meta{Meta: objectMetaToProto(meta)},
+		Result: &proto.ReadObjectChunk_Meta{Meta: objectMetaToProto(result.Meta)},
 	}); err != nil {
 		return err
 	}
@@ -192,7 +178,7 @@ func (s *s3Server) WriteObject(stream proto.S3_WriteObjectServer) error {
 		}
 	}()
 
-	meta, err := s.client.WriteObject(stream.Context(), s.namespacedWriteRequest(open, pr))
+	meta, err := s.client.WriteObject(stream.Context(), s.writeRequest(open, pr))
 	if err != nil {
 		_ = pr.CloseWithError(err)
 		select {
@@ -200,11 +186,6 @@ func (s *s3Server) WriteObject(stream proto.S3_WriteObjectServer) error {
 		case <-stream.Context().Done():
 		}
 		return s3ToGRPCErr(err)
-	}
-	meta, err = s.requireOwnedMetaNamespace(meta)
-	if err != nil {
-		_ = pr.CloseWithError(err)
-		return err
 	}
 	_ = pr.Close()
 	sendErr := stream.SendAndClose(&proto.WriteObjectResponse{Meta: objectMetaToProto(meta)})
@@ -226,61 +207,47 @@ func (s *s3Server) WriteObject(stream proto.S3_WriteObjectServer) error {
 }
 
 func (s *s3Server) DeleteObject(ctx context.Context, req *proto.DeleteObjectRequest) (*emptypb.Empty, error) {
-	if err := s.client.DeleteObject(ctx, s.namespacedRef(objectRefFromProto(req.GetRef()))); err != nil {
+	if err := s.client.DeleteObject(ctx, objectRefFromProto(req.GetRef())); err != nil {
 		return nil, s3ToGRPCErr(err)
 	}
 	return &emptypb.Empty{}, nil
 }
 
 func (s *s3Server) ListObjects(ctx context.Context, req *proto.ListObjectsRequest) (*proto.ListObjectsResponse, error) {
-	listReq, err := s.namespacedListRequest(req)
-	if err != nil {
-		return nil, err
-	}
-	page, err := s.client.ListObjects(ctx, listReq)
+	page, err := s.client.ListObjects(ctx, s.listRequest(req))
 	if err != nil {
 		return nil, s3ToGRPCErr(err)
 	}
 	resp := &proto.ListObjectsResponse{
 		CommonPrefixes:        make([]string, 0, len(page.CommonPrefixes)),
-		NextContinuationToken: s.wrapContinuationToken(page.NextContinuationToken),
+		NextContinuationToken: page.NextContinuationToken,
 		HasMore:               page.HasMore,
 		Objects:               make([]*proto.S3ObjectMeta, 0, len(page.Objects)),
 	}
-	for i := range page.CommonPrefixes {
-		if prefix, ok := s.stripOwnedKeyNamespace(page.CommonPrefixes[i]); ok {
-			resp.CommonPrefixes = append(resp.CommonPrefixes, prefix)
-		}
-	}
+	resp.CommonPrefixes = append(resp.CommonPrefixes, page.CommonPrefixes...)
 	for i := range page.Objects {
-		if obj, ok := s.stripOwnedMetaNamespace(page.Objects[i]); ok {
-			resp.Objects = append(resp.Objects, objectMetaToProto(obj))
-		}
+		resp.Objects = append(resp.Objects, objectMetaToProto(page.Objects[i]))
 	}
 	return resp, nil
 }
 
 func (s *s3Server) CopyObject(ctx context.Context, req *proto.CopyObjectRequest) (*proto.CopyObjectResponse, error) {
 	meta, err := s.client.CopyObject(ctx, s3sdk.CopyRequest{
-		Source:      s.namespacedRef(objectRefFromProto(req.GetSource())),
-		Destination: s.namespacedRef(objectRefFromProto(req.GetDestination())),
+		Source:      objectRefFromProto(req.GetSource()),
+		Destination: objectRefFromProto(req.GetDestination()),
 		IfMatch:     req.GetIfMatch(),
 		IfNoneMatch: req.GetIfNoneMatch(),
 	})
 	if err != nil {
 		return nil, s3ToGRPCErr(err)
 	}
-	meta, err = s.requireOwnedMetaNamespace(meta)
-	if err != nil {
-		return nil, err
-	}
 	return &proto.CopyObjectResponse{Meta: objectMetaToProto(meta)}, nil
 }
 
 func (s *s3Server) PresignObject(ctx context.Context, req *proto.PresignObjectRequest) (*proto.PresignObjectResponse, error) {
-	if s.keyPrefix != "" {
+	if s.pluginName != "" {
 		if s.accessURLs == nil || s.bindingName == "" {
-			return nil, status.Error(codes.FailedPrecondition, "presign is not supported for plugin-scoped s3 bindings")
+			return nil, status.Error(codes.FailedPrecondition, "presign is not supported for app s3 bindings")
 		}
 		result, err := s.accessURLs.MintURL(ObjectAccessURLRequest{
 			AppName:            s.pluginName,
@@ -306,7 +273,7 @@ func (s *s3Server) PresignObject(ctx context.Context, req *proto.PresignObjectRe
 		return resp, nil
 	}
 	result, err := s.client.PresignObject(ctx, s3sdk.PresignRequest{
-		Ref:                s.namespacedRef(objectRefFromProto(req.GetRef())),
+		Ref:                objectRefFromProto(req.GetRef()),
 		Method:             presignMethodFromProto(req.GetMethod()),
 		Expires:            timeDurationSeconds(req.GetExpiresSeconds()),
 		ContentType:        req.GetContentType(),
@@ -327,45 +294,9 @@ func (s *s3Server) PresignObject(ctx context.Context, req *proto.PresignObjectRe
 	return resp, nil
 }
 
-func (s *s3Server) namespacedRef(ref s3sdk.ObjectRef) s3sdk.ObjectRef {
-	ref.Key = s.applyKeyNamespace(ref.Key)
-	return ref
-}
-
-func (s *s3Server) stripOwnedMetaNamespace(meta s3sdk.ObjectMeta) (s3sdk.ObjectMeta, bool) {
-	key, ok := s.stripOwnedKeyNamespace(meta.Ref.Key)
-	if !ok {
-		return s3sdk.ObjectMeta{}, false
-	}
-	meta.Ref.Key = key
-	return meta, true
-}
-
-func (s *s3Server) requireOwnedMetaNamespace(meta s3sdk.ObjectMeta) (s3sdk.ObjectMeta, error) {
-	meta, ok := s.stripOwnedMetaNamespace(meta)
-	if !ok {
-		return s3sdk.ObjectMeta{}, status.Error(codes.Internal, "s3 provider returned object outside app namespace")
-	}
-	return meta, nil
-}
-
-func (s *s3Server) applyKeyNamespace(key string) string {
-	return s.keyPrefix + key
-}
-
-func (s *s3Server) stripOwnedKeyNamespace(key string) (string, bool) {
-	if s.keyPrefix == "" {
-		return key, true
-	}
-	if !strings.HasPrefix(key, s.keyPrefix) {
-		return "", false
-	}
-	return strings.TrimPrefix(key, s.keyPrefix), true
-}
-
-func (s *s3Server) namespacedReadRequest(req *proto.ReadObjectRequest) s3sdk.ReadRequest {
+func (s *s3Server) readRequest(req *proto.ReadObjectRequest) s3sdk.ReadRequest {
 	out := s3sdk.ReadRequest{
-		Ref:         s.namespacedRef(objectRefFromProto(req.GetRef())),
+		Ref:         objectRefFromProto(req.GetRef()),
 		Range:       byteRangeFromProto(req.GetRange()),
 		IfMatch:     req.GetIfMatch(),
 		IfNoneMatch: req.GetIfNoneMatch(),
@@ -381,9 +312,9 @@ func (s *s3Server) namespacedReadRequest(req *proto.ReadObjectRequest) s3sdk.Rea
 	return out
 }
 
-func (s *s3Server) namespacedWriteRequest(open *proto.WriteObjectOpen, body io.Reader) s3sdk.WriteRequest {
+func (s *s3Server) writeRequest(open *proto.WriteObjectOpen, body io.Reader) s3sdk.WriteRequest {
 	return s3sdk.WriteRequest{
-		Ref:                s.namespacedRef(objectRefFromProto(open.GetRef())),
+		Ref:                objectRefFromProto(open.GetRef()),
 		ContentType:        open.GetContentType(),
 		CacheControl:       open.GetCacheControl(),
 		ContentDisposition: open.GetContentDisposition(),
@@ -396,50 +327,14 @@ func (s *s3Server) namespacedWriteRequest(open *proto.WriteObjectOpen, body io.R
 	}
 }
 
-func (s *s3Server) namespacedListRequest(req *proto.ListObjectsRequest) (s3sdk.ListRequest, error) {
-	continuationToken, err := s.unwrapContinuationToken(req.GetContinuationToken())
-	if err != nil {
-		return s3sdk.ListRequest{}, err
-	}
-	startAfter := req.GetStartAfter()
-	if startAfter != "" {
-		startAfter = s.applyKeyNamespace(startAfter)
-	}
+func (s *s3Server) listRequest(req *proto.ListObjectsRequest) s3sdk.ListRequest {
 	return s3sdk.ListRequest{
-		Prefix:            s.applyKeyNamespace(req.GetPrefix()),
+		Prefix:            req.GetPrefix(),
 		Delimiter:         req.GetDelimiter(),
-		ContinuationToken: continuationToken,
-		StartAfter:        startAfter,
+		ContinuationToken: req.GetContinuationToken(),
+		StartAfter:        req.GetStartAfter(),
 		MaxKeys:           req.GetMaxKeys(),
-	}, nil
-}
-
-func s3NamespacePrefix(pluginName string) string {
-	if pluginName == "" {
-		return ""
 	}
-	return "plugin_" + strconv.Itoa(len(pluginName)) + "_" + pluginName + "/"
-}
-
-func (s *s3Server) wrapContinuationToken(token string) string {
-	if token == "" || s.keyPrefix == "" {
-		return token
-	}
-	return s3ContinuationTokenPrefix + base64.RawURLEncoding.EncodeToString([]byte(token))
-}
-
-func (s *s3Server) unwrapContinuationToken(token string) (string, error) {
-	if token == "" || s.keyPrefix == "" {
-		return token, nil
-	}
-	if !strings.HasPrefix(token, s3ContinuationTokenPrefix) {
-		return token, nil
-	}
-	decoded, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(token, s3ContinuationTokenPrefix))
-	if err != nil {
-		return "", status.Error(codes.InvalidArgument, "invalid continuation token")
-	}
-	return string(decoded), nil
 }
 
 func timeDurationSeconds(seconds int64) time.Duration {

--- a/gestaltd/services/s3/server_test.go
+++ b/gestaltd/services/s3/server_test.go
@@ -18,7 +18,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func TestS3ServerPrefixesKeysPerPlugin(t *testing.T) {
+func TestS3ServerPassesKeysThroughUnchanged(t *testing.T) {
 	t.Parallel()
 
 	store := &coretesting.StubS3{}
@@ -45,17 +45,9 @@ func TestS3ServerPrefixesKeysPerPlugin(t *testing.T) {
 		t.Fatal("expected WriteObject response")
 	}
 
-	_, err := store.HeadObject(ctx, s3sdk.ObjectRef{
-		Key: s3NamespacePrefix("roadmap") + "plans/q2.txt",
-	})
+	_, err := store.HeadObject(ctx, s3sdk.ObjectRef{Key: "plans/q2.txt"})
 	if err != nil {
-		t.Fatalf("HeadObject(prefixed): %v", err)
-	}
-	_, err = store.HeadObject(ctx, s3sdk.ObjectRef{
-		Key: "plans/q2.txt",
-	})
-	if !errors.Is(err, s3sdk.ErrNotFound) {
-		t.Fatalf("HeadObject(unprefixed) error = %v, want ErrNotFound", err)
+		t.Fatalf("HeadObject: %v", err)
 	}
 }
 
@@ -86,48 +78,44 @@ func TestRoutingS3ServerRoutesByHostBindingMetadata(t *testing.T) {
 		t.Fatalf("WriteObject: %v", err)
 	}
 	if _, err := archive.HeadObject(context.Background(), s3sdk.ObjectRef{
-		Key: s3NamespacePrefix("roadmap") + "plans/q2.txt",
+		Key: "plans/q2.txt",
 	}); err != nil {
 		t.Fatalf("archive HeadObject: %v", err)
 	}
 	if _, err := main.HeadObject(context.Background(), s3sdk.ObjectRef{
-		Key: s3NamespacePrefix("roadmap") + "plans/q2.txt",
+		Key: "plans/q2.txt",
 	}); !errors.Is(err, s3sdk.ErrNotFound) {
 		t.Fatalf("main HeadObject error = %v, want ErrNotFound", err)
 	}
 }
 
-func TestS3ServerLeavesEmptyStartAfterUnset(t *testing.T) {
+func TestS3ServerPassesListKeysThroughUnchanged(t *testing.T) {
 	t.Parallel()
 
 	store := &coretesting.StubS3{}
 	srv := NewServer(store, "roadmap").(*s3Server)
 
-	got, gotErr := srv.namespacedListRequest(&proto.ListObjectsRequest{
+	got := srv.listRequest(&proto.ListObjectsRequest{
 		Prefix: "plans/",
 	})
-	if gotErr != nil {
-		t.Fatalf("namespacedListRequest: %v", gotErr)
-	}
 	if got.StartAfter != "" {
 		t.Fatalf("StartAfter = %q, want empty", got.StartAfter)
 	}
-	wantPrefix := s3NamespacePrefix("roadmap") + "plans/"
-	if got.Prefix != wantPrefix {
-		t.Fatalf("Prefix = %q, want %q", got.Prefix, wantPrefix)
+	if got.Prefix != "plans/" {
+		t.Fatalf("Prefix = %q, want plans/", got.Prefix)
 	}
 }
 
-func TestS3ServerListWrapsContinuationTokensForNamespacedPlugins(t *testing.T) {
+func TestS3ServerListPassesKeysThroughUnchanged(t *testing.T) {
 	t.Parallel()
 
 	store := &coretesting.StubS3{}
 	srv := NewServer(store, "roadmap").(*s3Server)
 	ctx := context.Background()
 	for _, key := range []string{
-		s3NamespacePrefix("roadmap") + "plans/a.txt",
-		s3NamespacePrefix("roadmap") + "plans/nested/b.txt",
-		s3NamespacePrefix("roadmap") + "plans/z.txt",
+		"plans/a.txt",
+		"plans/nested/b.txt",
+		"plans/z.txt",
 	} {
 		if _, err := store.WriteObject(ctx, s3sdk.WriteRequest{
 			Ref:  s3sdk.ObjectRef{Key: key},
@@ -144,9 +132,6 @@ func TestS3ServerListWrapsContinuationTokensForNamespacedPlugins(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("ListObjects(first): %v", err)
-	}
-	if got := first.GetNextContinuationToken(); strings.Contains(got, s3NamespacePrefix("roadmap")) {
-		t.Fatalf("NextContinuationToken leaked namespace prefix: %q", got)
 	}
 	if len(first.GetObjects()) != 1 || first.GetObjects()[0].GetRef().GetKey() != "plans/a.txt" {
 		t.Fatalf("first objects = %v, want [plans/a.txt]", first.GetObjects())
@@ -206,8 +191,8 @@ func TestS3ServerListRoundTripsOpaqueBackendContinuationTokens(t *testing.T) {
 	if client.reqs[0].ContinuationToken != "" {
 		t.Fatalf("first backend continuation token = %q, want empty", client.reqs[0].ContinuationToken)
 	}
-	if got := first.GetNextContinuationToken(); got == "" || got == "plugin_roadmap/internal-offset-2" || strings.Contains(got, s3NamespacePrefix("roadmap")) {
-		t.Fatalf("wrapped continuation token = %q, want opaque wrapped token", got)
+	if got := first.GetNextContinuationToken(); got != "plugin_roadmap/internal-offset-2" {
+		t.Fatalf("continuation token = %q, want backend token", got)
 	}
 
 	_, err = srv.ListObjects(context.Background(), &proto.ListObjectsRequest{
@@ -336,17 +321,17 @@ func TestS3ServerWriteObjectPropagatesRecvErrorObservedDuringSendAndClose(t *tes
 	}
 }
 
-func TestS3ServerListDropsKeysOutsideAppNamespace(t *testing.T) {
+func TestS3ServerListReturnsBackendKeys(t *testing.T) {
 	t.Parallel()
 
 	srv := NewServer(listResultS3Client{
 		page: s3sdk.ListPage{
 			Objects: []s3sdk.ObjectMeta{
-				{Ref: s3sdk.ObjectRef{Key: s3NamespacePrefix("roadmap") + "plans/a.txt"}},
+				{Ref: s3sdk.ObjectRef{Key: "plans/a.txt"}},
 				{Ref: s3sdk.ObjectRef{Key: "plans/escape.txt"}},
 			},
 			CommonPrefixes: []string{
-				s3NamespacePrefix("roadmap") + "plans/nested/",
+				"plans/nested/",
 				"plans/escape/",
 			},
 		},
@@ -359,15 +344,15 @@ func TestS3ServerListDropsKeysOutsideAppNamespace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListObjects: %v", err)
 	}
-	if got := resp.GetCommonPrefixes(); len(got) != 1 || got[0] != "plans/nested/" {
-		t.Fatalf("CommonPrefixes = %v, want [plans/nested/]", got)
+	if got := resp.GetCommonPrefixes(); len(got) != 2 || got[0] != "plans/nested/" || got[1] != "plans/escape/" {
+		t.Fatalf("CommonPrefixes = %v, want backend prefixes", got)
 	}
-	if got := resp.GetObjects(); len(got) != 1 || got[0].GetRef().GetKey() != "plans/a.txt" {
-		t.Fatalf("Objects = %v, want [plans/a.txt]", got)
+	if got := resp.GetObjects(); len(got) != 2 || got[0].GetRef().GetKey() != "plans/a.txt" || got[1].GetRef().GetKey() != "plans/escape.txt" {
+		t.Fatalf("Objects = %v, want backend objects", got)
 	}
 }
 
-func TestS3ServerRejectsForeignMetadataOutsideAppNamespace(t *testing.T) {
+func TestS3ServerReturnsBackendMetadata(t *testing.T) {
 	t.Parallel()
 
 	t.Run("head", func(t *testing.T) {
@@ -379,11 +364,11 @@ func TestS3ServerRejectsForeignMetadataOutsideAppNamespace(t *testing.T) {
 			},
 		}, "roadmap")
 
-		_, err := srv.HeadObject(context.Background(), &proto.HeadObjectRequest{
+		resp, err := srv.HeadObject(context.Background(), &proto.HeadObjectRequest{
 			Ref: &proto.S3ObjectRef{Key: "plans/q2.txt"},
 		})
-		if status.Code(err) != codes.Internal {
-			t.Fatalf("HeadObject error = %v, want codes.Internal", err)
+		if err != nil || resp.GetMeta().GetRef().GetKey() != "plans/escape.txt" {
+			t.Fatalf("HeadObject = %#v, %v; want backend metadata", resp, err)
 		}
 	})
 
@@ -403,11 +388,8 @@ func TestS3ServerRejectsForeignMetadataOutsideAppNamespace(t *testing.T) {
 		err := srv.ReadObject(&proto.ReadObjectRequest{
 			Ref: &proto.S3ObjectRef{Key: "plans/q2.txt"},
 		}, stream)
-		if status.Code(err) != codes.Internal {
-			t.Fatalf("ReadObject error = %v, want codes.Internal", err)
-		}
-		if len(stream.chunks) != 0 {
-			t.Fatalf("ReadObject leaked chunks = %d, want 0", len(stream.chunks))
+		if err != nil || len(stream.chunks) != 2 {
+			t.Fatalf("ReadObject = %v with %d chunks; want backend metadata and body", err, len(stream.chunks))
 		}
 	})
 
@@ -431,8 +413,8 @@ func TestS3ServerRejectsForeignMetadataOutsideAppNamespace(t *testing.T) {
 		})
 
 		err := srv.WriteObject(stream)
-		if status.Code(err) != codes.Internal {
-			t.Fatalf("WriteObject error = %v, want codes.Internal", err)
+		if err != nil || stream.resp.GetMeta().GetRef().GetKey() != "plans/escape.txt" {
+			t.Fatalf("WriteObject = %v, %#v; want backend metadata", err, stream.resp)
 		}
 	})
 
@@ -445,12 +427,12 @@ func TestS3ServerRejectsForeignMetadataOutsideAppNamespace(t *testing.T) {
 			},
 		}, "roadmap")
 
-		_, err := srv.CopyObject(context.Background(), &proto.CopyObjectRequest{
+		resp, err := srv.CopyObject(context.Background(), &proto.CopyObjectRequest{
 			Source:      &proto.S3ObjectRef{Key: "plans/source.txt"},
 			Destination: &proto.S3ObjectRef{Key: "plans/dest.txt"},
 		})
-		if status.Code(err) != codes.Internal {
-			t.Fatalf("CopyObject error = %v, want codes.Internal", err)
+		if err != nil || resp.GetMeta().GetRef().GetKey() != "plans/escape.txt" {
+			t.Fatalf("CopyObject = %#v, %v; want backend metadata", resp, err)
 		}
 	})
 }
@@ -473,7 +455,7 @@ func TestS3ServerRejectsAppScopedPresign(t *testing.T) {
 		t.Fatalf("PresignObject error = %v, want codes.FailedPrecondition", err)
 	}
 	if called {
-		t.Fatal("PresignObject called backend for plugin-scoped binding")
+		t.Fatal("PresignObject called backend for app binding")
 	}
 }
 
@@ -503,13 +485,13 @@ func TestS3ServerAppScopedPresignReturnsHostedObjectAccessURL(t *testing.T) {
 		t.Fatalf("PresignObject: %v", err)
 	}
 	if called {
-		t.Fatal("PresignObject called backend for plugin-scoped binding")
+		t.Fatal("PresignObject called backend for app binding")
 	}
 	if !strings.HasPrefix(resp.GetUrl(), "https://gestalt.example.test"+ObjectAccessPathPrefix) {
 		t.Fatalf("url = %q, want hosted object access URL", resp.GetUrl())
 	}
-	if strings.Contains(resp.GetUrl(), s3NamespacePrefix("roadmap")) || strings.Contains(resp.GetUrl(), "plans/q2.txt") {
-		t.Fatalf("url leaks plugin-scoped object path: %q", resp.GetUrl())
+	if strings.Contains(resp.GetUrl(), "plans/q2.txt") {
+		t.Fatalf("url leaks object path: %q", resp.GetUrl())
 	}
 	if resp.GetMethod() != proto.PresignMethod_PRESIGN_METHOD_PUT {
 		t.Fatalf("method = %v, want PUT", resp.GetMethod())


### PR DESCRIPTION
## Summary

- Remove the automatic `plugin_<app>/` prefix from Gestalt host-service S3 keys.
- Preserve S3 binding selection and signed object-access URL authorization while forwarding physical keys unchanged.
- Fix externally produced GCS objects under a configured `keyPrefix` being looked up beneath an unexpected app namespace.

## Test plan

- [x] `go test ./gestaltd/services/s3 ./gestaltd/internal/server ./gestaltd/internal/bootstrap`
- [ ] `go test ./gestaltd/...` (blocked by the existing missing `github.com/go-sql-driver/mysql` dependency in `cmd/reseed-fp-cred`)

Existing objects written beneath `plugin_<app>/...` need migration or compatibility handling before this behavior is deployed.