### PR TITLE
Authorize workflow execution using run_as service account

### DIFF
--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -24,12 +24,6 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-// TargetAccessChecker checks whether a subject may use workflow execution targets.
-type TargetAccessChecker interface {
-	CheckOperationAccess(ctx context.Context, p *principal.Principal, providerName, operationID string) error
-	CheckProviderAccess(ctx context.Context, p *principal.Principal, providerName string) error
-}
-
 const (
 	tracerName         = "gestaltd"
 	graphQLOperationID = "graphql"
@@ -579,20 +573,7 @@ func (b *Broker) CheckOperationAccess(ctx context.Context, p *principal.Principa
 }
 
 func (b *Broker) CheckProviderAccess(ctx context.Context, p *principal.Principal, providerName string) error {
-	if b == nil || b.authorization == nil {
-		if !principal.AllowsProviderPermission(p, providerName) {
-			return fmt.Errorf("%w: %s", ErrAuthorizationDenied, providerName)
-		}
-		return nil
-	}
-	resp, err := b.authorization.CheckAccess(ctx, accessRequest(b.providerKinds, p, providerName, providerName))
-	if err != nil {
-		return fmt.Errorf("%w: %s: %v", ErrAuthorizationDenied, providerName, err)
-	}
-	if resp == nil || !resp.GetAllowed() {
-		return fmt.Errorf("%w: %s", ErrAuthorizationDenied, providerName)
-	}
-	return nil
+	return b.CheckOperationAccess(ctx, p, providerName, providerName)
 }
 
 func accessRequest(kinds map[string]ProviderKind, p *principal.Principal, providerName, action string) *proto.CheckAccessRequest {

--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -548,6 +548,14 @@ func providerDelegatesRemoteAuthorization(prov core.Provider) bool {
 	return ok && delegated.RemoteCredentialDelegated()
 }
 
+func (b *Broker) providerDelegatesRemoteAuthorization(providerName string) bool {
+	if b == nil || b.providers == nil {
+		return false
+	}
+	provider, err := b.providers.Get(providerName)
+	return err == nil && providerDelegatesRemoteAuthorization(provider)
+}
+
 func (b *Broker) checkAuthorizationAccess(ctx context.Context, p *principal.Principal, providerName, operationID string) error {
 	if b == nil || b.authorization == nil {
 		return nil
@@ -556,10 +564,10 @@ func (b *Broker) checkAuthorizationAccess(ctx context.Context, p *principal.Prin
 }
 
 func (b *Broker) CheckOperationAccess(ctx context.Context, p *principal.Principal, providerName, operationID string) error {
-	if b == nil || b.authorization == nil {
-		if !principal.AllowsOperationPermission(p, providerName, operationID) {
-			return fmt.Errorf("%w: %s.%s", ErrAuthorizationDenied, providerName, operationID)
-		}
+	if !principal.AllowsOperationPermission(p, providerName, operationID) {
+		return fmt.Errorf("%w: %s.%s", ErrAuthorizationDenied, providerName, operationID)
+	}
+	if b == nil || b.authorization == nil || b.providerDelegatesRemoteAuthorization(providerName) {
 		return nil
 	}
 	resp, err := b.authorization.CheckAccess(ctx, accessRequest(b.providerKinds, p, providerName, operationID))
@@ -570,10 +578,6 @@ func (b *Broker) CheckOperationAccess(ctx context.Context, p *principal.Principa
 		return fmt.Errorf("%w: %s.%s", ErrAuthorizationDenied, providerName, operationID)
 	}
 	return nil
-}
-
-func (b *Broker) CheckProviderAccess(ctx context.Context, p *principal.Principal, providerName string) error {
-	return b.CheckOperationAccess(ctx, p, providerName, providerName)
 }
 
 func accessRequest(kinds map[string]ProviderKind, p *principal.Principal, providerName, action string) *proto.CheckAccessRequest {

--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -24,6 +24,12 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
+// TargetAccessChecker checks whether a subject may use workflow execution targets.
+type TargetAccessChecker interface {
+	CheckOperationAccess(ctx context.Context, p *principal.Principal, providerName, operationID string) error
+	CheckProviderAccess(ctx context.Context, p *principal.Principal, providerName string) error
+}
+
 const (
 	tracerName         = "gestaltd"
 	graphQLOperationID = "graphql"
@@ -552,8 +558,17 @@ func (b *Broker) checkAuthorizationAccess(ctx context.Context, p *principal.Prin
 	if b == nil || b.authorization == nil {
 		return nil
 	}
-	req := authorizationAccessRequest(b.providerKinds, p, providerName, operationID)
-	resp, err := b.authorization.CheckAccess(ctx, req)
+	return b.CheckOperationAccess(ctx, p, providerName, operationID)
+}
+
+func (b *Broker) CheckOperationAccess(ctx context.Context, p *principal.Principal, providerName, operationID string) error {
+	if b == nil || b.authorization == nil {
+		if !principal.AllowsOperationPermission(p, providerName, operationID) {
+			return fmt.Errorf("%w: %s.%s", ErrAuthorizationDenied, providerName, operationID)
+		}
+		return nil
+	}
+	resp, err := b.authorization.CheckAccess(ctx, accessRequest(b.providerKinds, p, providerName, operationID))
 	if err != nil {
 		return fmt.Errorf("%w: %s.%s: %v", ErrAuthorizationDenied, providerName, operationID, err)
 	}
@@ -563,10 +578,25 @@ func (b *Broker) checkAuthorizationAccess(ctx context.Context, p *principal.Prin
 	return nil
 }
 
-func authorizationAccessRequest(kinds map[string]ProviderKind, p *principal.Principal, providerName, operationID string) *proto.CheckAccessRequest {
+func (b *Broker) CheckProviderAccess(ctx context.Context, p *principal.Principal, providerName string) error {
+	if b == nil || b.authorization == nil {
+		if !principal.AllowsProviderPermission(p, providerName) {
+			return fmt.Errorf("%w: %s", ErrAuthorizationDenied, providerName)
+		}
+		return nil
+	}
+	resp, err := b.authorization.CheckAccess(ctx, accessRequest(b.providerKinds, p, providerName, providerName))
+	if err != nil {
+		return fmt.Errorf("%w: %s: %v", ErrAuthorizationDenied, providerName, err)
+	}
+	if resp == nil || !resp.GetAllowed() {
+		return fmt.Errorf("%w: %s", ErrAuthorizationDenied, providerName)
+	}
+	return nil
+}
+
+func accessRequest(kinds map[string]ProviderKind, p *principal.Principal, providerName, action string) *proto.CheckAccessRequest {
 	p = principal.Canonicalized(p)
-	subjectID := principal.EffectiveCredentialSubjectID(p)
-	providerName = strings.TrimSpace(providerName)
 	properties, _ := structpb.NewStruct(map[string]any{
 		"scope":     strings.Join(p.Scopes, " "),
 		"client_id": strings.TrimSpace(p.ClientID),
@@ -575,10 +605,10 @@ func authorizationAccessRequest(kinds map[string]ProviderKind, p *principal.Prin
 	return &proto.CheckAccessRequest{
 		Subject: &proto.Subject{
 			Type:       "subject",
-			Id:         subjectID,
+			Id:         principal.EffectiveCredentialSubjectID(p),
 			Properties: properties,
 		},
-		Action:   &proto.Action{Name: strings.TrimSpace(operationID)},
+		Action:   &proto.Action{Name: strings.TrimSpace(action)},
 		Resource: AuthorizationResource(providerName, kinds),
 	}
 }

--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -560,16 +560,6 @@ func (b *Broker) checkAuthorizationAccess(ctx context.Context, p *principal.Prin
 	if b == nil || b.authorization == nil {
 		return nil
 	}
-	return b.CheckOperationAccess(ctx, p, providerName, operationID)
-}
-
-func (b *Broker) CheckOperationAccess(ctx context.Context, p *principal.Principal, providerName, operationID string) error {
-	if !principal.AllowsOperationPermission(p, providerName, operationID) {
-		return fmt.Errorf("%w: %s.%s", ErrAuthorizationDenied, providerName, operationID)
-	}
-	if b == nil || b.authorization == nil || b.providerDelegatesRemoteAuthorization(providerName) {
-		return nil
-	}
 	resp, err := b.authorization.CheckAccess(ctx, accessRequest(b.providerKinds, p, providerName, operationID))
 	if err != nil {
 		return fmt.Errorf("%w: %s.%s: %v", ErrAuthorizationDenied, providerName, operationID, err)
@@ -578,6 +568,26 @@ func (b *Broker) CheckOperationAccess(ctx context.Context, p *principal.Principa
 		return fmt.Errorf("%w: %s.%s", ErrAuthorizationDenied, providerName, operationID)
 	}
 	return nil
+}
+
+func (b *Broker) CheckOperationAccess(ctx context.Context, p *principal.Principal, providerName, operationID string) error {
+	if !principal.AllowsOperationPermission(p, providerName, operationID) {
+		return fmt.Errorf("%w: %s.%s", ErrAuthorizationDenied, providerName, operationID)
+	}
+	if b.providerDelegatesRemoteAuthorization(providerName) {
+		return nil
+	}
+	return b.checkAuthorizationAccess(ctx, p, providerName, operationID)
+}
+
+func (b *Broker) CheckProviderAccess(ctx context.Context, p *principal.Principal, providerName string) error {
+	if !principal.AllowsProviderPermission(p, providerName) {
+		return fmt.Errorf("%w: %s", ErrAuthorizationDenied, providerName)
+	}
+	if b.providerDelegatesRemoteAuthorization(providerName) {
+		return nil
+	}
+	return b.checkAuthorizationAccess(ctx, p, providerName, providerName)
 }
 
 func accessRequest(kinds map[string]ProviderKind, p *principal.Principal, providerName, action string) *proto.CheckAccessRequest {

--- a/gestaltd/services/invocation/broker_test.go
+++ b/gestaltd/services/invocation/broker_test.go
@@ -373,6 +373,19 @@ type remoteDelegatedAppStub struct {
 
 func (p *remoteDelegatedAppStub) RemoteCredentialDelegated() bool { return true }
 
+func TestBrokerCheckProviderAccessAllowsProviderScopedPrincipal(t *testing.T) {
+	t.Parallel()
+
+	broker := NewBroker(nil, nil, nil)
+	p := &principal.Principal{
+		SubjectID: "service_account:workflow-runner",
+		Scopes:    []string{"github:issues.triage"},
+	}
+	if err := broker.CheckProviderAccess(context.Background(), p, "github"); err != nil {
+		t.Fatalf("CheckProviderAccess: %v", err)
+	}
+}
+
 func TestBrokerInvokeGraphQLAuthorizationDeniesBeforeCredentialResolution(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/providergateway/public_request.go
+++ b/gestaltd/services/providergateway/public_request.go
@@ -235,10 +235,6 @@ func adaptPublicRequest(
 	return adapted, nil
 }
 
-func publicCallerProvider(_ protoreflect.Message, _ string) invocation.CallerProvider {
-	return invocation.CallerProvider{Kind: invocation.ProviderKindApp, Name: "gestaltd"}
-}
-
 func fillPublicField(ctx context.Context, publicBaseURL string, p *principal.Principal, msg protoreflect.Message, name, fullMethod string) error {
 	fd := msg.Descriptor().Fields().ByName(protoreflect.Name(name))
 	if fd == nil {
@@ -259,6 +255,10 @@ func fillPublicField(ctx context.Context, publicBaseURL string, p *principal.Pri
 		return status.Errorf(codes.Internal, "no public fill rule for %q", name)
 	}
 	return nil
+}
+
+func publicCallerProvider(_ protoreflect.Message, _ string) invocation.CallerProvider {
+	return invocation.CallerProvider{Kind: invocation.ProviderKindApp, Name: "gestaltd"}
 }
 
 func fieldSet(msg protoreflect.Message, name string) bool {

--- a/gestaltd/services/providergateway/public_request.go
+++ b/gestaltd/services/providergateway/public_request.go
@@ -235,6 +235,10 @@ func adaptPublicRequest(
 	return adapted, nil
 }
 
+func publicCallerProvider(_ protoreflect.Message, _ string) invocation.CallerProvider {
+	return invocation.CallerProvider{Kind: invocation.ProviderKindApp, Name: "gestaltd"}
+}
+
 func fillPublicField(ctx context.Context, publicBaseURL string, p *principal.Principal, msg protoreflect.Message, name, fullMethod string) error {
 	fd := msg.Descriptor().Fields().ByName(protoreflect.Name(name))
 	if fd == nil {
@@ -255,10 +259,6 @@ func fillPublicField(ctx context.Context, publicBaseURL string, p *principal.Pri
 		return status.Errorf(codes.Internal, "no public fill rule for %q", name)
 	}
 	return nil
-}
-
-func publicCallerProvider(_ protoreflect.Message, _ string) invocation.CallerProvider {
-	return invocation.CallerProvider{Kind: invocation.ProviderKindApp, Name: "gestaltd"}
 }
 
 func fieldSet(msg protoreflect.Message, name string) bool {

--- a/gestaltd/services/workflows/telemetry_test.go
+++ b/gestaltd/services/workflows/telemetry_test.go
@@ -248,19 +248,26 @@ func TestWorkflowProviderRecordsSignalOrStartMetricsAcrossTransport(t *testing.T
 	t.Parallel()
 
 	metrics := metrictest.NewManualMeterProvider(t)
+	authz := &managerServerAuthorizationProvider{allowed: true}
 	provider := newWorkflowManagerTelemetryProvider()
-	manager := workflowmanager.New(workflowmanager.Config{
-		Providers: testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
-			N:        "github",
-			ConnMode: core.ConnectionModeNone,
-			CatalogVal: &catalog.Catalog{
-				Name: "github",
-				Operations: []catalog.CatalogOperation{
-					{ID: "issues.triage", Method: "POST"},
-				},
+	providers := testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+		N:        "github",
+		ConnMode: core.ConnectionModeNone,
+		CatalogVal: &catalog.Catalog{
+			Name: "github",
+			Operations: []catalog.CatalogOperation{
+				{ID: "issues.triage", Method: "POST"},
 			},
-		}),
-		Workflow: workflowManagerTelemetryControl{provider: provider},
+		},
+	})
+	invoker := invocation.NewBroker(providers, nil, nil,
+		invocation.WithAuthorizationProvider(authz),
+		invocation.WithProviderKinds(map[string]invocation.ProviderKind{"github": invocation.ProviderKindApp}),
+	)
+	manager := workflowmanager.New(workflowmanager.Config{
+		Providers: providers,
+		Workflow:  workflowManagerTelemetryControl{provider: provider},
+		Invoker:   invoker,
 	})
 	lis := bufconn.Listen(1024 * 1024)
 	srv := grpc.NewServer(grpc.UnaryInterceptor(func(
@@ -271,7 +278,7 @@ func TestWorkflowProviderRecordsSignalOrStartMetricsAcrossTransport(t *testing.T
 	) (any, error) {
 		return handler(metricutil.WithMeterProvider(ctx, metrics.Provider), req)
 	}))
-	proto.RegisterWorkflowServer(srv, NewProviderServer("slack", manager, &managerServerAuthorizationProvider{allowed: true}))
+	proto.RegisterWorkflowServer(srv, NewProviderServer("slack", manager, authz))
 	go func() {
 		_ = srv.Serve(lis)
 	}()
@@ -423,6 +430,7 @@ func (p *workflowManagerTelemetryProvider) GetDefinition(context.Context, *proto
 	return &proto.WorkflowDefinition{
 		Id:         "definition-1",
 		Generation: 7,
+		RunAs:      "service_account:workflow-runner",
 		Target:     telemetryProtoAppStepTarget("github", "issues.triage"),
 	}, nil
 }

--- a/gestaltd/services/workflows/workflowmanager/manager_definitions.go
+++ b/gestaltd/services/workflows/workflowmanager/manager_definitions.go
@@ -242,7 +242,7 @@ func (m *Manager) resolveDefinitionSpec(ctx context.Context, p *principal.Princi
 	if _, err := m.authorizeAgentWorkflowTarget(ctx, authorizedPrincipal, workflowManagerOperationTargetScopeOnly, target, invocation.CallerProvider{}); err != nil {
 		return coreworkflow.DefinitionSpec{}, err
 	}
-	if err := m.authorizeRunAsTarget(ctx, spec.RunAs, target); err != nil {
+	if err := m.authorizeRunAsTarget(ctx, execPrincipal, target); err != nil {
 		return coreworkflow.DefinitionSpec{}, err
 	}
 	activations, err := normalizeDefinitionActivations(spec.Activations)

--- a/gestaltd/services/workflows/workflowmanager/manager_definitions.go
+++ b/gestaltd/services/workflows/workflowmanager/manager_definitions.go
@@ -231,11 +231,18 @@ func (m *Manager) resolveDefinitionSpec(ctx context.Context, p *principal.Princi
 	if err != nil {
 		return coreworkflow.DefinitionSpec{}, err
 	}
-	target, err := m.resolveTarget(ctx, authorizedPrincipal, spec.Target)
+	execPrincipal, err := m.executionPrincipal(spec.RunAs)
+	if err != nil {
+		return coreworkflow.DefinitionSpec{}, err
+	}
+	target, err := m.resolveTarget(ctx, execPrincipal, spec.Target)
 	if err != nil {
 		return coreworkflow.DefinitionSpec{}, err
 	}
 	if _, err := m.authorizeAgentWorkflowTarget(ctx, authorizedPrincipal, workflowManagerOperationTargetScopeOnly, target, invocation.CallerProvider{}); err != nil {
+		return coreworkflow.DefinitionSpec{}, err
+	}
+	if err := m.authorizeRunAsTarget(ctx, spec.RunAs, target); err != nil {
 		return coreworkflow.DefinitionSpec{}, err
 	}
 	activations, err := normalizeDefinitionActivations(spec.Activations)

--- a/gestaltd/services/workflows/workflowmanager/manager_definitions.go
+++ b/gestaltd/services/workflows/workflowmanager/manager_definitions.go
@@ -235,6 +235,9 @@ func (m *Manager) resolveDefinitionSpec(ctx context.Context, p *principal.Princi
 	if err != nil {
 		return coreworkflow.DefinitionSpec{}, err
 	}
+	if err := m.authorizeRunAsTarget(ctx, execPrincipal, spec.Target); err != nil {
+		return coreworkflow.DefinitionSpec{}, err
+	}
 	target, err := m.resolveTarget(ctx, execPrincipal, spec.Target)
 	if err != nil {
 		return coreworkflow.DefinitionSpec{}, err

--- a/gestaltd/services/workflows/workflowmanager/manager_target.go
+++ b/gestaltd/services/workflows/workflowmanager/manager_target.go
@@ -16,6 +16,7 @@ import (
 
 type targetAccessChecker interface {
 	CheckOperationAccess(ctx context.Context, p *principal.Principal, providerName, operationID string) error
+	CheckProviderAccess(ctx context.Context, p *principal.Principal, providerName string) error
 }
 
 func (m *Manager) resolveProvider(ctx context.Context, providerName string) (string, coreworkflow.Provider, error) {
@@ -41,6 +42,9 @@ func (m *Manager) resolveRequestProviderTarget(ctx context.Context, p *principal
 	}
 	if definition == nil || definition.Definition == nil {
 		return "", nil, coreworkflow.Target{}, 0, core.ErrNotFound
+	}
+	if _, err := m.authorizeAgentWorkflowTarget(ctx, p, operation, definition.Definition.Target, caller); err != nil {
+		return "", nil, coreworkflow.Target{}, 0, err
 	}
 	execPrincipal, err := m.executionPrincipal(definition.Definition.RunAs)
 	if err != nil {
@@ -313,7 +317,11 @@ func (m *Manager) checkOperationAccess(ctx context.Context, p *principal.Princip
 }
 
 func (m *Manager) checkProviderAccess(ctx context.Context, p *principal.Principal, providerName string) error {
-	return m.checkOperationAccess(ctx, p, providerName, providerName)
+	checker, ok := m.invoker.(targetAccessChecker)
+	if !ok {
+		return fmt.Errorf("%w: workflow target access checker is not configured", invocation.ErrInternal)
+	}
+	return checker.CheckProviderAccess(ctx, p, providerName)
 }
 
 func (m *Manager) checkTargetAuthorization(ctx context.Context, p *principal.Principal, target coreworkflow.Target) targetAuthorizationDecision {

--- a/gestaltd/services/workflows/workflowmanager/manager_target.go
+++ b/gestaltd/services/workflows/workflowmanager/manager_target.go
@@ -14,6 +14,11 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 )
 
+type targetAccessChecker interface {
+	CheckOperationAccess(ctx context.Context, p *principal.Principal, providerName, operationID string) error
+	CheckProviderAccess(ctx context.Context, p *principal.Principal, providerName string) error
+}
+
 func (m *Manager) resolveProvider(ctx context.Context, providerName string) (string, coreworkflow.Provider, error) {
 	if m == nil || m.workflow == nil {
 		return "", nil, ErrWorkflowNotConfigured
@@ -38,7 +43,11 @@ func (m *Manager) resolveRequestProviderTarget(ctx context.Context, p *principal
 	if definition == nil || definition.Definition == nil {
 		return "", nil, coreworkflow.Target{}, 0, core.ErrNotFound
 	}
-	if err := m.authorizeRunAsTarget(ctx, definition.Definition.RunAs, definition.Definition.Target); err != nil {
+	execPrincipal, err := m.executionPrincipal(definition.Definition.RunAs)
+	if err != nil {
+		return "", nil, coreworkflow.Target{}, 0, err
+	}
+	if err := m.authorizeRunAsTarget(ctx, execPrincipal, definition.Definition.Target); err != nil {
 		return "", nil, coreworkflow.Target{}, 0, err
 	}
 	return definition.ProviderName, definition.provider, definition.Definition.Target, definition.Definition.Generation, nil
@@ -49,11 +58,7 @@ func (m *Manager) executionPrincipal(runAs *core.RunAsSubject) (*principal.Princ
 	if runAs == nil || strings.TrimSpace(runAs.SubjectID) == "" {
 		return nil, fmt.Errorf("%w: workflow run_as is required", invocation.ErrInvalidInvocation)
 	}
-	p := &principal.Principal{SubjectID: strings.TrimSpace(runAs.SubjectID)}
-	if kind, _, ok := core.ParseSubjectID(p.SubjectID); ok {
-		p.Kind = principal.Kind(kind)
-	}
-	return principal.Canonicalize(p), nil
+	return invocation.RunAsPrincipal(nil, runAs), nil
 }
 
 func (m *Manager) resolveTarget(ctx context.Context, p *principal.Principal, target coreworkflow.Target) (coreworkflow.Target, error) {
@@ -289,10 +294,9 @@ func workflowTargetAuthorizationFailure(err error) (*targetAuthorizationFailure,
 	return &failure, true
 }
 
-func (m *Manager) authorizeRunAsTarget(ctx context.Context, runAs *core.RunAsSubject, target coreworkflow.Target) error {
-	p, err := m.executionPrincipal(runAs)
-	if err != nil {
-		return err
+func (m *Manager) authorizeRunAsTarget(ctx context.Context, p *principal.Principal, target coreworkflow.Target) error {
+	if p == nil || strings.TrimSpace(p.SubjectID) == "" {
+		return fmt.Errorf("%w: workflow run_as is required", invocation.ErrInvalidInvocation)
 	}
 	decision := m.checkTargetAuthorization(ctx, p, target)
 	if decision.allowed {
@@ -302,23 +306,19 @@ func (m *Manager) authorizeRunAsTarget(ctx context.Context, runAs *core.RunAsSub
 }
 
 func (m *Manager) checkOperationAccess(ctx context.Context, p *principal.Principal, providerName, operation string) error {
-	if checker, ok := m.invoker.(invocation.TargetAccessChecker); ok {
-		return checker.CheckOperationAccess(ctx, p, providerName, operation)
+	checker, ok := m.invoker.(targetAccessChecker)
+	if !ok {
+		return fmt.Errorf("%w: workflow target access checker is not configured", invocation.ErrInternal)
 	}
-	if !principal.AllowsOperationPermission(p, providerName, operation) {
-		return invocation.ErrAuthorizationDenied
-	}
-	return nil
+	return checker.CheckOperationAccess(ctx, p, providerName, operation)
 }
 
 func (m *Manager) checkProviderAccess(ctx context.Context, p *principal.Principal, providerName string) error {
-	if checker, ok := m.invoker.(invocation.TargetAccessChecker); ok {
-		return checker.CheckProviderAccess(ctx, p, providerName)
+	checker, ok := m.invoker.(targetAccessChecker)
+	if !ok {
+		return fmt.Errorf("%w: workflow target access checker is not configured", invocation.ErrInternal)
 	}
-	if !principal.AllowsProviderPermission(p, providerName) {
-		return invocation.ErrAuthorizationDenied
-	}
-	return nil
+	return checker.CheckProviderAccess(ctx, p, providerName)
 }
 
 func (m *Manager) checkTargetAuthorization(ctx context.Context, p *principal.Principal, target coreworkflow.Target) targetAuthorizationDecision {

--- a/gestaltd/services/workflows/workflowmanager/manager_target.go
+++ b/gestaltd/services/workflows/workflowmanager/manager_target.go
@@ -16,7 +16,6 @@ import (
 
 type targetAccessChecker interface {
 	CheckOperationAccess(ctx context.Context, p *principal.Principal, providerName, operationID string) error
-	CheckProviderAccess(ctx context.Context, p *principal.Principal, providerName string) error
 }
 
 func (m *Manager) resolveProvider(ctx context.Context, providerName string) (string, coreworkflow.Provider, error) {
@@ -314,11 +313,7 @@ func (m *Manager) checkOperationAccess(ctx context.Context, p *principal.Princip
 }
 
 func (m *Manager) checkProviderAccess(ctx context.Context, p *principal.Principal, providerName string) error {
-	checker, ok := m.invoker.(targetAccessChecker)
-	if !ok {
-		return fmt.Errorf("%w: workflow target access checker is not configured", invocation.ErrInternal)
-	}
-	return checker.CheckProviderAccess(ctx, p, providerName)
+	return m.checkOperationAccess(ctx, p, providerName, providerName)
 }
 
 func (m *Manager) checkTargetAuthorization(ctx context.Context, p *principal.Principal, target coreworkflow.Target) targetAuthorizationDecision {

--- a/gestaltd/services/workflows/workflowmanager/manager_target.go
+++ b/gestaltd/services/workflows/workflowmanager/manager_target.go
@@ -38,13 +38,22 @@ func (m *Manager) resolveRequestProviderTarget(ctx context.Context, p *principal
 	if definition == nil || definition.Definition == nil {
 		return "", nil, coreworkflow.Target{}, 0, core.ErrNotFound
 	}
-	// The caller must still be authorized for every referenced app operation and
-	// agent tool. This is an independent prerequisite; the provider worker then
-	// executes the step as the definition's stored run_as subject.
-	if !m.allowStoredTarget(ctx, p, definition.Definition.Target) {
-		return "", nil, coreworkflow.Target{}, 0, invocation.ErrAuthorizationDenied
+	if err := m.authorizeRunAsTarget(ctx, definition.Definition.RunAs, definition.Definition.Target); err != nil {
+		return "", nil, coreworkflow.Target{}, 0, err
 	}
 	return definition.ProviderName, definition.provider, definition.Definition.Target, definition.Definition.Generation, nil
+}
+
+func (m *Manager) executionPrincipal(runAs *core.RunAsSubject) (*principal.Principal, error) {
+	runAs = core.NormalizeRunAsSubject(runAs)
+	if runAs == nil || strings.TrimSpace(runAs.SubjectID) == "" {
+		return nil, fmt.Errorf("%w: workflow run_as is required", invocation.ErrInvalidInvocation)
+	}
+	p := &principal.Principal{SubjectID: strings.TrimSpace(runAs.SubjectID)}
+	if kind, _, ok := core.ParseSubjectID(p.SubjectID); ok {
+		p.Kind = principal.Kind(kind)
+	}
+	return principal.Canonicalize(p), nil
 }
 
 func (m *Manager) resolveTarget(ctx context.Context, p *principal.Principal, target coreworkflow.Target) (coreworkflow.Target, error) {
@@ -139,7 +148,6 @@ func (m *Manager) resolveWorkflowStepApp(ctx context.Context, p *principal.Princ
 		return coreworkflow.AppCall{}, fmt.Errorf("instance name contains invalid characters")
 	}
 
-	ctx = invocation.WithAccessContext(ctx, m.providerAccessContext(ctx, p, appName))
 	var resolver invocation.TokenResolver
 	if tr, ok := m.invoker.(invocation.TokenResolver); ok {
 		resolver = tr
@@ -149,9 +157,6 @@ func (m *Manager) resolveWorkflowStepApp(ctx context.Context, p *principal.Princ
 	opMeta, _, resolvedConnection, err := invocation.ResolveOperation(ctx, prov, appName, resolver, p, operation, sessionConnections, sessionInstance)
 	if err != nil {
 		return coreworkflow.AppCall{}, err
-	}
-	if !principal.AllowsOperationPermission(p, appName, opMeta.ID) {
-		return coreworkflow.AppCall{}, fmt.Errorf("%w: %s.%s", invocation.ErrAuthorizationDenied, appName, opMeta.ID)
 	}
 	if connection == "" {
 		connection = resolvedConnection
@@ -196,9 +201,6 @@ func (m *Manager) resolveWorkflowStepAgent(ctx context.Context, p *principal.Pri
 	if target.Prompt.Template == "" && len(target.Messages) == 0 {
 		return coreworkflow.AgentTurn{}, fmt.Errorf("%w: workflow target agent prompt or messages is required", invocation.ErrInvalidInvocation)
 	}
-	if !principal.AllowsProviderPermission(p, target.ProviderName) {
-		return coreworkflow.AgentTurn{}, fmt.Errorf("%w: %s", invocation.ErrAuthorizationDenied, target.ProviderName)
-	}
 	target.Model = strings.TrimSpace(target.Model)
 	target.SessionKey = strings.TrimSpace(target.SessionKey)
 	target.ToolRefs = append([]coreagent.ToolRef(nil), target.ToolRefs...)
@@ -239,10 +241,6 @@ func validateWorkflowAgentOutput(output coreagent.Output) error {
 	return nil
 }
 
-func (m *Manager) providerAccessContext(ctx context.Context, p *principal.Principal, provider string) invocation.AccessContext {
-	return invocation.AccessContext{}
-}
-
 const (
 	targetAuthorizationComponentTarget        = "target"
 	targetAuthorizationComponentAgentProvider = "agent_provider"
@@ -277,8 +275,10 @@ type workflowTargetAuthorizationError struct {
 	failure targetAuthorizationFailure
 }
 
-func (e workflowTargetAuthorizationError) Error() string { return core.ErrNotFound.Error() }
-func (e workflowTargetAuthorizationError) Unwrap() error { return core.ErrNotFound }
+func (e workflowTargetAuthorizationError) Error() string {
+	return invocation.ErrAuthorizationDenied.Error()
+}
+func (e workflowTargetAuthorizationError) Unwrap() error { return invocation.ErrAuthorizationDenied }
 
 func workflowTargetAuthorizationFailure(err error) (*targetAuthorizationFailure, bool) {
 	var targetErr workflowTargetAuthorizationError
@@ -289,13 +289,36 @@ func workflowTargetAuthorizationFailure(err error) (*targetAuthorizationFailure,
 	return &failure, true
 }
 
-func (m *Manager) allowStoredTarget(ctx context.Context, p *principal.Principal, target coreworkflow.Target) bool {
-	authorizedPrincipal, err := m.authorizeAgentWorkflowTarget(ctx, p, workflowManagerOperationTargetScopeOnly, target, invocation.CallerProvider{})
+func (m *Manager) authorizeRunAsTarget(ctx context.Context, runAs *core.RunAsSubject, target coreworkflow.Target) error {
+	p, err := m.executionPrincipal(runAs)
 	if err != nil {
-		return false
+		return err
 	}
-	p = authorizedPrincipal
-	return m.checkTargetAuthorization(ctx, p, target).allowed
+	decision := m.checkTargetAuthorization(ctx, p, target)
+	if decision.allowed {
+		return nil
+	}
+	return workflowTargetAuthorizationError{failure: decision.failure}
+}
+
+func (m *Manager) checkOperationAccess(ctx context.Context, p *principal.Principal, providerName, operation string) error {
+	if checker, ok := m.invoker.(invocation.TargetAccessChecker); ok {
+		return checker.CheckOperationAccess(ctx, p, providerName, operation)
+	}
+	if !principal.AllowsOperationPermission(p, providerName, operation) {
+		return invocation.ErrAuthorizationDenied
+	}
+	return nil
+}
+
+func (m *Manager) checkProviderAccess(ctx context.Context, p *principal.Principal, providerName string) error {
+	if checker, ok := m.invoker.(invocation.TargetAccessChecker); ok {
+		return checker.CheckProviderAccess(ctx, p, providerName)
+	}
+	if !principal.AllowsProviderPermission(p, providerName) {
+		return invocation.ErrAuthorizationDenied
+	}
+	return nil
 }
 
 func (m *Manager) checkTargetAuthorization(ctx context.Context, p *principal.Principal, target coreworkflow.Target) targetAuthorizationDecision {
@@ -314,7 +337,7 @@ func (m *Manager) checkTargetAuthorization(ctx context.Context, p *principal.Pri
 			if agentProviderName == "" {
 				return targetAuthorizationDenied(targetAuthorizationComponentAgentProvider, targetAuthorizationReasonMissingAgentProvider, "", "", -1)
 			}
-			if !principal.AllowsProviderPermission(p, agentProviderName) {
+			if err := m.checkProviderAccess(ctx, p, agentProviderName); err != nil {
 				return targetAuthorizationDenied(targetAuthorizationComponentAgentProvider, targetAuthorizationReasonPrincipalProviderPermissionDenied, agentProviderName, "", -1)
 			}
 			hasSystemTools := workflowAgentToolRefsContainSystem(step.Agent.ToolRefs)
@@ -341,7 +364,7 @@ func (m *Manager) checkWorkflowStepAppAuthorization(ctx context.Context, p *prin
 	if operation == "" {
 		return targetAuthorizationDenied(component, targetAuthorizationReasonMissingAppOperation, appName, "", -1)
 	}
-	if !principal.AllowsOperationPermission(p, appName, operation) {
+	if err := m.checkOperationAccess(ctx, p, appName, operation); err != nil {
 		return targetAuthorizationDenied(component, targetAuthorizationReasonPrincipalOperationPermissionDenied, appName, operation, -1)
 	}
 	return targetAuthorizationAllowed()
@@ -366,7 +389,7 @@ func (m *Manager) checkWorkflowAgentToolAuthorization(ctx context.Context, p *pr
 		return targetAuthorizationDenied(targetAuthorizationComponentAgentToolRef, targetAuthorizationReasonNonExactToolRefWithSystemTools, appName, operation, index)
 	}
 	if operation == "" {
-		if !principal.AllowsProviderPermission(p, appName) {
+		if err := m.checkProviderAccess(ctx, p, appName); err != nil {
 			return targetAuthorizationDenied(targetAuthorizationComponentAgentToolRef, targetAuthorizationReasonPrincipalProviderPermissionDenied, appName, "", index)
 		}
 		return targetAuthorizationAllowed()

--- a/gestaltd/services/workflows/workflowmanager/manager_test.go
+++ b/gestaltd/services/workflows/workflowmanager/manager_test.go
@@ -71,18 +71,163 @@ func requireWorkflowManagerRequestContext(t *testing.T, reqCtx *proto.RequestCon
 }
 
 func testWorkflowManagerWithGithub(t *testing.T, provider *testWorkflowProvider) *Manager {
-	return New(Config{
-		Providers: testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
-			N:        "github",
-			ConnMode: core.ConnectionModeNone,
-			CatalogVal: &catalog.Catalog{
-				Name: "github",
-				Operations: []catalog.CatalogOperation{
-					{ID: "issues.triage", Method: "POST"},
-				},
+	return testWorkflowManagerWithGithubInvoker(t, provider, nil)
+}
+
+func testWorkflowRunAsSubject() *core.RunAsSubject {
+	return &core.RunAsSubject{SubjectID: "service_account:workflow-runner"}
+}
+
+func testWorkflowManagerWithGithubInvoker(t *testing.T, provider *testWorkflowProvider, invoker invocation.Invoker) *Manager {
+	t.Helper()
+	providers := testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+		N:        "github",
+		ConnMode: core.ConnectionModeNone,
+		CatalogVal: &catalog.Catalog{
+			Name: "github",
+			Operations: []catalog.CatalogOperation{
+				{ID: "issues.triage", Method: "POST"},
 			},
-		}),
-		Workflow: testWorkflowControl{provider: provider},
+		},
+	})
+	cfg := Config{Providers: providers, Workflow: testWorkflowControl{provider: provider}}
+	if invoker != nil {
+		cfg.Invoker = invoker
+	}
+	return New(cfg)
+}
+
+func testWorkflowManagerPrincipalWithoutGithub() *principal.Principal {
+	return principal.Canonicalize(&principal.Principal{
+		SubjectID: principal.UserSubjectID("bob"),
+		UserID:    "bob",
+		Kind:      principal.KindUser,
+	})
+}
+
+type runAsGrantAuthz struct {
+	grants map[string]struct{}
+}
+
+func (a *runAsGrantAuthz) grantKey(subjectID, providerName, operation string) string {
+	return strings.TrimSpace(subjectID) + "|" + strings.TrimSpace(providerName) + "|" + strings.TrimSpace(operation)
+}
+
+func (a *runAsGrantAuthz) CheckAccess(_ context.Context, req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
+	_, ok := a.grants[a.grantKey(req.GetSubject().GetId(), req.GetResource().GetId(), req.GetAction().GetName())]
+	return &proto.CheckAccessResponse{Allowed: ok}, nil
+}
+
+func (a *runAsGrantAuthz) CheckAccessMany(context.Context, *proto.CheckAccessManyRequest) (*proto.CheckAccessManyResponse, error) {
+	return &proto.CheckAccessManyResponse{}, nil
+}
+
+func (a *runAsGrantAuthz) ListRelationships(context.Context, *proto.ListRelationshipsRequest) (*proto.ListRelationshipsResponse, error) {
+	return &proto.ListRelationshipsResponse{}, nil
+}
+
+func (a *runAsGrantAuthz) AddRelationship(context.Context, *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {
+	return &proto.AddRelationshipResponse{}, nil
+}
+
+func (a *runAsGrantAuthz) DeleteRelationship(context.Context, *proto.DeleteRelationshipRequest) (*proto.DeleteRelationshipResponse, error) {
+	return &proto.DeleteRelationshipResponse{}, nil
+}
+
+func (a *runAsGrantAuthz) SetAuthorizationState(context.Context, *proto.SetAuthorizationStateRequest) (*proto.SetAuthorizationStateResponse, error) {
+	return &proto.SetAuthorizationStateResponse{}, nil
+}
+
+func (a *runAsGrantAuthz) GetActiveModelRef(context.Context) (*proto.GetActiveModelRefResponse, error) {
+	return &proto.GetActiveModelRefResponse{}, nil
+}
+
+func (a *runAsGrantAuthz) SetActiveModel(context.Context, *proto.SetActiveModelRequest) (*proto.SetActiveModelResponse, error) {
+	return &proto.SetActiveModelResponse{}, nil
+}
+
+func (a *runAsGrantAuthz) ListActiveModelResourceTypes(context.Context, *proto.ListActiveModelResourceTypesRequest) (*proto.ListActiveModelResourceTypesResponse, error) {
+	return &proto.ListActiveModelResourceTypesResponse{}, nil
+}
+
+func (a *runAsGrantAuthz) Ping(context.Context) error { return nil }
+
+func (a *runAsGrantAuthz) Close() error { return nil }
+
+func testWorkflowManagerWithRunAsGrants(t *testing.T, provider *testWorkflowProvider, grants map[string]struct{}) *Manager {
+	t.Helper()
+	providers := testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+		N:        "github",
+		ConnMode: core.ConnectionModeNone,
+		CatalogVal: &catalog.Catalog{
+			Name:       "github",
+			Operations: []catalog.CatalogOperation{{ID: "issues.triage", Method: "POST"}},
+		},
+	})
+	invoker := invocation.NewBroker(providers, nil, nil,
+		invocation.WithAuthorizationProvider(&runAsGrantAuthz{grants: grants}),
+		invocation.WithProviderKinds(map[string]invocation.ProviderKind{"github": invocation.ProviderKindApp}),
+	)
+	cfg := Config{
+		Providers: providers,
+		Workflow:  testWorkflowControl{provider: provider},
+		Invoker:   invoker,
+	}
+	return New(cfg)
+}
+
+func TestRunAsTargetExecutionAuthority(t *testing.T) {
+	t.Parallel()
+
+	grant := map[string]struct{}{
+		"service_account:workflow-runner|github|issues.triage": {},
+	}
+	spec := coreworkflow.DefinitionSpec{
+		ID:     "definition-run-as",
+		RunAs:  testWorkflowRunAsSubject(),
+		Target: testWorkflowAppStepTarget("github", "issues.triage", nil),
+	}
+
+	t.Run("author without step grants", func(t *testing.T) {
+		t.Parallel()
+		manager := testWorkflowManagerWithRunAsGrants(t, newTestWorkflowProvider(), grant)
+		if _, err := manager.ApplyDefinition(context.Background(), testWorkflowManagerPrincipalWithoutGithub(), DefinitionApply{
+			ProviderName: "local",
+			Spec:         spec,
+		}); err != nil {
+			t.Fatalf("ApplyDefinition: %v", err)
+		}
+	})
+
+	t.Run("run_as without grants", func(t *testing.T) {
+		t.Parallel()
+		manager := testWorkflowManagerWithRunAsGrants(t, newTestWorkflowProvider(), nil)
+		_, err := manager.ApplyDefinition(context.Background(), testWorkflowManagerPrincipal(), DefinitionApply{
+			ProviderName: "local",
+			Spec:         spec,
+		})
+		if !errors.Is(err, invocation.ErrAuthorizationDenied) {
+			t.Fatalf("ApplyDefinition error = %v, want authorization denied", err)
+		}
+	})
+
+	t.Run("starter without step grants", func(t *testing.T) {
+		t.Parallel()
+		provider := newTestWorkflowProvider()
+		manager := testWorkflowManagerWithRunAsGrants(t, provider, grant)
+		if _, err := manager.ApplyDefinition(context.Background(), testWorkflowManagerPrincipal(), DefinitionApply{
+			ProviderName: "local",
+			Spec:         spec,
+		}); err != nil {
+			t.Fatalf("ApplyDefinition: %v", err)
+		}
+		if _, err := manager.StartRun(context.Background(), testWorkflowManagerPrincipalWithoutGithub(), RunStart{
+			ProviderName: "local",
+			DefinitionID: "definition-run-as",
+			WorkflowKey:  "github:issues:triage",
+		}); err != nil {
+			t.Fatalf("StartRun: %v", err)
+		}
 	})
 }
 
@@ -99,6 +244,7 @@ func TestApplyDefinitionAndStartRunUseDefinitionGenerationAndInput(t *testing.T)
 		IdempotencyKey: "definition-apply-1",
 		Spec: coreworkflow.DefinitionSpec{
 			ID:     "definition-1",
+			RunAs:  testWorkflowRunAsSubject(),
 			Target: testWorkflowAppStepTarget("github", "issues.triage", map[string]any{"mode": "full"}),
 			Activations: []coreworkflow.Activation{{
 				ID: "github_issue",
@@ -178,6 +324,7 @@ func TestSignalOrStartRunRequiresDefinitionAndCarriesInput(t *testing.T) {
 		Caller:       testWorkflowManagerCaller(),
 		Spec: coreworkflow.DefinitionSpec{
 			ID:     "definition-1",
+			RunAs:  testWorkflowRunAsSubject(),
 			Target: testWorkflowAppStepTarget("github", "issues.triage", nil),
 		},
 	}); err != nil {

--- a/gestaltd/services/workflows/workflowmanager/manager_test.go
+++ b/gestaltd/services/workflows/workflowmanager/manager_test.go
@@ -15,10 +15,13 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	"github.com/valon-technologies/gestalt/server/internal/workflowwire"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/agents/agentmanager"
 	appaccessservice "github.com/valon-technologies/gestalt/server/services/appaccess"
 	"github.com/valon-technologies/gestalt/server/services/apps/registry"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	gproto "google.golang.org/protobuf/proto"
 )
 
@@ -137,6 +140,16 @@ type remoteDelegatedWorkflowApp struct {
 }
 
 func (remoteDelegatedWorkflowApp) RemoteCredentialDelegated() bool { return true }
+
+type denyingAgentWorkflowAuthorizer struct {
+	agentmanager.Service
+	requests []invocation.AgentWorkflowAuthorizationRequest
+}
+
+func (a *denyingAgentWorkflowAuthorizer) AuthorizeWorkflowInvocation(_ context.Context, req invocation.AgentWorkflowAuthorizationRequest) (invocation.AgentWorkflowAuthorization, error) {
+	a.requests = append(a.requests, req)
+	return invocation.AgentWorkflowAuthorization{}, status.Error(codes.PermissionDenied, "agent workflow target is not allowed")
+}
 
 func (a *runAsGrantAuthz) grantKey(subjectID, providerName, operation string) string {
 	return strings.TrimSpace(subjectID) + "|" + strings.TrimSpace(providerName) + "|" + strings.TrimSpace(operation)
@@ -323,6 +336,48 @@ func TestApplyDefinitionAndStartRunUseDefinitionGenerationAndInput(t *testing.T)
 				WorkflowKey:  "linear:issues:triage",
 			}); err != nil {
 				t.Fatalf("StartRun: %v", err)
+			}
+		})
+
+		t.Run("agent starts authorize the stored target", func(t *testing.T) {
+			t.Parallel()
+			provider := newTestWorkflowProvider()
+			provider.definitions["definition-agent"] = &coreworkflow.Definition{
+				ID:         "definition-agent",
+				Generation: 1,
+				RunAs:      testWorkflowRunAsSubject(),
+				Target:     testWorkflowAppStepTarget("github", "issues.triage", nil),
+			}
+			providers := testWorkflowGithubProviders(t)
+			agentAuth := &denyingAgentWorkflowAuthorizer{}
+			manager := New(Config{
+				Providers:    providers,
+				Workflow:     testWorkflowControl{provider: provider},
+				AgentManager: agentAuth,
+				Invoker:      testWorkflowManagerBroker(t, providers, allowAllAuthz{}),
+			})
+			ctx := invocation.WithAgentInvocationContext(context.Background(), invocation.AgentInvocationContext{
+				ProviderName: "agent",
+				SessionID:    "session-1",
+				TurnID:       "turn-1",
+			})
+			operations := []string{workflowManagerOperationRunsStart, workflowManagerOperationRunsSignalOrStart}
+			for _, operation := range operations {
+				_, _, _, _, err := manager.resolveRequestProviderTarget(ctx, testWorkflowManagerPrincipal(), "local", "definition-agent", testWorkflowManagerCaller(), operation)
+				if status.Code(err) != codes.PermissionDenied {
+					t.Fatalf("resolveRequestProviderTarget(%q) error = %v, want permission denied", operation, err)
+				}
+			}
+			if len(agentAuth.requests) != 2 {
+				t.Fatalf("agent authorization requests = %d, want 2", len(agentAuth.requests))
+			}
+			for i, req := range agentAuth.requests {
+				if req.Operation != operations[i] {
+					t.Fatalf("agent authorization operation = %q, want %q", req.Operation, operations[i])
+				}
+				if req.Target == nil || requireWorkflowAppStep(t, *req.Target, 0).Name != "github" || requireWorkflowAppStep(t, *req.Target, 0).Operation != "issues.triage" {
+					t.Fatalf("agent authorization target = %#v, want github app step", req.Target)
+				}
 			}
 		})
 	})

--- a/gestaltd/services/workflows/workflowmanager/manager_test.go
+++ b/gestaltd/services/workflows/workflowmanager/manager_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/workflowwire"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	appaccessservice "github.com/valon-technologies/gestalt/server/services/appaccess"
+	"github.com/valon-technologies/gestalt/server/services/apps/registry"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	gproto "google.golang.org/protobuf/proto"
@@ -78,9 +79,9 @@ func testWorkflowRunAsSubject() *core.RunAsSubject {
 	return &core.RunAsSubject{SubjectID: "service_account:workflow-runner"}
 }
 
-func testWorkflowManagerWithGithubInvoker(t *testing.T, provider *testWorkflowProvider, invoker invocation.Invoker) *Manager {
+func testWorkflowGithubProviders(t *testing.T) *registry.ProviderMap[core.Provider] {
 	t.Helper()
-	providers := testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+	return testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
 		N:        "github",
 		ConnMode: core.ConnectionModeNone,
 		CatalogVal: &catalog.Catalog{
@@ -90,11 +91,21 @@ func testWorkflowManagerWithGithubInvoker(t *testing.T, provider *testWorkflowPr
 			},
 		},
 	})
+}
+
+func testWorkflowManagerBroker(t *testing.T, providers *registry.ProviderMap[core.Provider], authz core.AuthorizationProvider) invocation.Invoker {
+	t.Helper()
+	return invocation.NewBroker(providers, nil, nil,
+		invocation.WithAuthorizationProvider(authz),
+		invocation.WithProviderKinds(map[string]invocation.ProviderKind{"github": invocation.ProviderKindApp}),
+	)
+}
+
+func testWorkflowManagerWithGithubInvoker(t *testing.T, provider *testWorkflowProvider, invoker invocation.Invoker) *Manager {
+	t.Helper()
+	providers := testWorkflowGithubProviders(t)
 	if invoker == nil {
-		invoker = invocation.NewBroker(providers, nil, nil,
-			invocation.WithAuthorizationProvider(allowAllAuthz{}),
-			invocation.WithProviderKinds(map[string]invocation.ProviderKind{"github": invocation.ProviderKindApp}),
-		)
+		invoker = testWorkflowManagerBroker(t, providers, allowAllAuthz{})
 	}
 	cfg := Config{Providers: providers, Workflow: testWorkflowControl{provider: provider}, Invoker: invoker}
 	return New(cfg)
@@ -130,207 +141,208 @@ func (a *runAsGrantAuthz) CheckAccess(_ context.Context, req *proto.CheckAccessR
 	return &proto.CheckAccessResponse{Allowed: ok}, nil
 }
 
-func testWorkflowManagerWithRunAsGrants(t *testing.T, provider *testWorkflowProvider, grants map[string]struct{}) *Manager {
-	t.Helper()
-	providers := testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
-		N:        "github",
-		ConnMode: core.ConnectionModeNone,
-		CatalogVal: &catalog.Catalog{
-			Name:       "github",
-			Operations: []catalog.CatalogOperation{{ID: "issues.triage", Method: "POST"}},
-		},
-	})
-	invoker := invocation.NewBroker(providers, nil, nil,
-		invocation.WithAuthorizationProvider(&runAsGrantAuthz{grants: grants}),
-		invocation.WithProviderKinds(map[string]invocation.ProviderKind{"github": invocation.ProviderKindApp}),
-	)
-	cfg := Config{
-		Providers: providers,
-		Workflow:  testWorkflowControl{provider: provider},
-		Invoker:   invoker,
-	}
-	return New(cfg)
-}
-
-func TestRunAsTargetExecutionAuthority(t *testing.T) {
-	t.Parallel()
-
-	grant := map[string]struct{}{
-		"service_account:workflow-runner|github|issues.triage": {},
-	}
-	spec := coreworkflow.DefinitionSpec{
-		ID:     "definition-run-as",
-		RunAs:  testWorkflowRunAsSubject(),
-		Target: testWorkflowAppStepTarget("github", "issues.triage", nil),
-	}
-
-	t.Run("author without step grants", func(t *testing.T) {
-		t.Parallel()
-		manager := testWorkflowManagerWithRunAsGrants(t, newTestWorkflowProvider(), grant)
-		if _, err := manager.ApplyDefinition(context.Background(), testWorkflowManagerPrincipalWithoutGithub(), DefinitionApply{
-			ProviderName: "local",
-			Spec:         spec,
-		}); err != nil {
-			t.Fatalf("ApplyDefinition: %v", err)
-		}
-	})
-
-	t.Run("run_as without grants", func(t *testing.T) {
-		t.Parallel()
-		manager := testWorkflowManagerWithRunAsGrants(t, newTestWorkflowProvider(), nil)
-		_, err := manager.ApplyDefinition(context.Background(), testWorkflowManagerPrincipal(), DefinitionApply{
-			ProviderName: "local",
-			Spec:         spec,
-		})
-		if !errors.Is(err, invocation.ErrAuthorizationDenied) {
-			t.Fatalf("ApplyDefinition error = %v, want authorization denied", err)
-		}
-	})
-
-	t.Run("starter without step grants", func(t *testing.T) {
-		t.Parallel()
-		provider := newTestWorkflowProvider()
-		manager := testWorkflowManagerWithRunAsGrants(t, provider, grant)
-		if _, err := manager.ApplyDefinition(context.Background(), testWorkflowManagerPrincipal(), DefinitionApply{
-			ProviderName: "local",
-			Spec:         spec,
-		}); err != nil {
-			t.Fatalf("ApplyDefinition: %v", err)
-		}
-		if _, err := manager.StartRun(context.Background(), testWorkflowManagerPrincipalWithoutGithub(), RunStart{
-			ProviderName: "local",
-			DefinitionID: "definition-run-as",
-			WorkflowKey:  "github:issues:triage",
-		}); err != nil {
-			t.Fatalf("StartRun: %v", err)
-		}
-	})
-}
-
 func TestApplyDefinitionAndStartRunUseDefinitionGenerationAndInput(t *testing.T) {
 	t.Parallel()
 
-	provider := newTestWorkflowProvider()
-	manager := testWorkflowManagerWithGithub(t, provider)
-	caller := testWorkflowManagerPrincipal()
+	t.Run("generation and input", func(t *testing.T) {
+		t.Parallel()
 
-	definition, err := manager.ApplyDefinition(context.Background(), caller, DefinitionApply{
-		ProviderName:   "local",
-		Caller:         testWorkflowManagerCaller(),
-		IdempotencyKey: "definition-apply-1",
-		Spec: coreworkflow.DefinitionSpec{
-			ID:     "definition-1",
+		provider := newTestWorkflowProvider()
+		manager := testWorkflowManagerWithGithub(t, provider)
+		caller := testWorkflowManagerPrincipal()
+
+		definition, err := manager.ApplyDefinition(context.Background(), caller, DefinitionApply{
+			ProviderName:   "local",
+			Caller:         testWorkflowManagerCaller(),
+			IdempotencyKey: "definition-apply-1",
+			Spec: coreworkflow.DefinitionSpec{
+				ID:     "definition-1",
+				RunAs:  testWorkflowRunAsSubject(),
+				Target: testWorkflowAppStepTarget("github", "issues.triage", map[string]any{"mode": "full"}),
+				Activations: []coreworkflow.Activation{{
+					ID: "github_issue",
+					Event: &coreworkflow.EventActivation{Match: coreworkflow.EventMatch{
+						Type:   "github.issue",
+						Source: "github",
+					}},
+					Input: coreworkflow.Value{Object: map[string]coreworkflow.Value{
+						"issue": {Signal: "data.issue"},
+					}},
+				}},
+			},
+		})
+		if err != nil {
+			t.Fatalf("ApplyDefinition: %v", err)
+		}
+		if definition == nil || definition.Definition == nil || definition.Definition.ID != "definition-1" || definition.Definition.Generation != 1 {
+			t.Fatalf("definition = %#v", definition)
+		}
+		if len(provider.applyRequests) != 1 {
+			t.Fatalf("apply requests = %#v", provider.applyRequests)
+		}
+		if got := provider.applyRequests[0].GetProvider(); got != "local" {
+			t.Fatalf("apply provider name = %q, want local", got)
+		}
+		requireWorkflowManagerRequestContext(t, provider.applyRequests[0].GetContext(), invocation.ProviderKindApp, "github")
+
+		run, err := manager.StartRun(context.Background(), caller, RunStart{
+			ProviderName:   "local",
+			Caller:         testWorkflowManagerCaller(),
+			DefinitionID:   "definition-1",
+			WorkflowKey:    "github:issues:triage",
+			Input:          map[string]any{"issue": map[string]any{"number": 42}},
+			IdempotencyKey: "run-1",
+		})
+		if err != nil {
+			t.Fatalf("StartRun: %v", err)
+		}
+		if run == nil || run.Run == nil {
+			t.Fatalf("run = %#v", run)
+		}
+		if run.Run.DefinitionGeneration != 1 {
+			t.Fatalf("run generation = %d, want 1", run.Run.DefinitionGeneration)
+		}
+		if got := run.Run.Input["issue"].(map[string]any)["number"]; got != float64(42) {
+			t.Fatalf("run input issue.number = %#v, want 42", got)
+		}
+		runApp := requireWorkflowAppStep(t, run.Run.Target, 0)
+		if got := runApp.Operation; got != "issues.triage" {
+			t.Fatalf("run target operation = %q, want issues.triage", got)
+		}
+		if len(provider.startRunRequests) != 1 || provider.startRunRequests[0].GetExpectedDefinitionGeneration() != 1 {
+			t.Fatalf("start requests = %#v", provider.startRunRequests)
+		}
+		if got := provider.startRunRequests[0].GetProvider(); got != "local" {
+			t.Fatalf("start provider name = %q, want local", got)
+		}
+		requireWorkflowManagerRequestContext(t, provider.startRunRequests[0].GetContext(), invocation.ProviderKindApp, "github")
+	})
+
+	t.Run("run_as target grants", func(t *testing.T) {
+		t.Parallel()
+
+		grant := map[string]struct{}{
+			"service_account:workflow-runner|github|issues.triage": {},
+		}
+		spec := coreworkflow.DefinitionSpec{
+			ID:     "definition-run-as",
 			RunAs:  testWorkflowRunAsSubject(),
-			Target: testWorkflowAppStepTarget("github", "issues.triage", map[string]any{"mode": "full"}),
-			Activations: []coreworkflow.Activation{{
-				ID: "github_issue",
-				Event: &coreworkflow.EventActivation{Match: coreworkflow.EventMatch{
-					Type:   "github.issue",
-					Source: "github",
-				}},
-				Input: coreworkflow.Value{Object: map[string]coreworkflow.Value{
-					"issue": {Signal: "data.issue"},
-				}},
-			}},
-		},
-	})
-	if err != nil {
-		t.Fatalf("ApplyDefinition: %v", err)
-	}
-	if definition == nil || definition.Definition == nil || definition.Definition.ID != "definition-1" || definition.Definition.Generation != 1 {
-		t.Fatalf("definition = %#v", definition)
-	}
-	if len(provider.applyRequests) != 1 {
-		t.Fatalf("apply requests = %#v", provider.applyRequests)
-	}
-	if got := provider.applyRequests[0].GetProvider(); got != "local" {
-		t.Fatalf("apply provider name = %q, want local", got)
-	}
-	requireWorkflowManagerRequestContext(t, provider.applyRequests[0].GetContext(), invocation.ProviderKindApp, "github")
+			Target: testWorkflowAppStepTarget("github", "issues.triage", nil),
+		}
 
-	run, err := manager.StartRun(context.Background(), caller, RunStart{
-		ProviderName:   "local",
-		Caller:         testWorkflowManagerCaller(),
-		DefinitionID:   "definition-1",
-		WorkflowKey:    "github:issues:triage",
-		Input:          map[string]any{"issue": map[string]any{"number": 42}},
-		IdempotencyKey: "run-1",
+		t.Run("author without step grants", func(t *testing.T) {
+			t.Parallel()
+			providers := testWorkflowGithubProviders(t)
+			manager := New(Config{
+				Providers: providers,
+				Workflow:  testWorkflowControl{provider: newTestWorkflowProvider()},
+				Invoker:   testWorkflowManagerBroker(t, providers, &runAsGrantAuthz{grants: grant}),
+			})
+			if _, err := manager.ApplyDefinition(context.Background(), testWorkflowManagerPrincipalWithoutGithub(), DefinitionApply{
+				ProviderName: "local",
+				Spec:         spec,
+			}); err != nil {
+				t.Fatalf("ApplyDefinition: %v", err)
+			}
+		})
+
+		t.Run("run_as without grants", func(t *testing.T) {
+			t.Parallel()
+			providers := testWorkflowGithubProviders(t)
+			manager := New(Config{
+				Providers: providers,
+				Workflow:  testWorkflowControl{provider: newTestWorkflowProvider()},
+				Invoker:   testWorkflowManagerBroker(t, providers, &runAsGrantAuthz{}),
+			})
+			_, err := manager.ApplyDefinition(context.Background(), testWorkflowManagerPrincipal(), DefinitionApply{
+				ProviderName: "local",
+				Spec:         spec,
+			})
+			if !errors.Is(err, invocation.ErrAuthorizationDenied) {
+				t.Fatalf("ApplyDefinition error = %v, want authorization denied", err)
+			}
+		})
+
+		t.Run("starter without step grants", func(t *testing.T) {
+			t.Parallel()
+			provider := newTestWorkflowProvider()
+			providers := testWorkflowGithubProviders(t)
+			manager := New(Config{
+				Providers: providers,
+				Workflow:  testWorkflowControl{provider: provider},
+				Invoker:   testWorkflowManagerBroker(t, providers, &runAsGrantAuthz{grants: grant}),
+			})
+			if _, err := manager.ApplyDefinition(context.Background(), testWorkflowManagerPrincipal(), DefinitionApply{
+				ProviderName: "local",
+				Spec:         spec,
+			}); err != nil {
+				t.Fatalf("ApplyDefinition: %v", err)
+			}
+			if _, err := manager.StartRun(context.Background(), testWorkflowManagerPrincipalWithoutGithub(), RunStart{
+				ProviderName: "local",
+				DefinitionID: "definition-run-as",
+				WorkflowKey:  "github:issues:triage",
+			}); err != nil {
+				t.Fatalf("StartRun: %v", err)
+			}
+		})
 	})
-	if err != nil {
-		t.Fatalf("StartRun: %v", err)
-	}
-	if run == nil || run.Run == nil {
-		t.Fatalf("run = %#v", run)
-	}
-	if run.Run.DefinitionGeneration != 1 {
-		t.Fatalf("run generation = %d, want 1", run.Run.DefinitionGeneration)
-	}
-	if got := run.Run.Input["issue"].(map[string]any)["number"]; got != float64(42) {
-		t.Fatalf("run input issue.number = %#v, want 42", got)
-	}
-	runApp := requireWorkflowAppStep(t, run.Run.Target, 0)
-	if got := runApp.Operation; got != "issues.triage" {
-		t.Fatalf("run target operation = %q, want issues.triage", got)
-	}
-	if len(provider.startRunRequests) != 1 || provider.startRunRequests[0].GetExpectedDefinitionGeneration() != 1 {
-		t.Fatalf("start requests = %#v", provider.startRunRequests)
-	}
-	if got := provider.startRunRequests[0].GetProvider(); got != "local" {
-		t.Fatalf("start provider name = %q, want local", got)
-	}
-	requireWorkflowManagerRequestContext(t, provider.startRunRequests[0].GetContext(), invocation.ProviderKindApp, "github")
 }
 
 func TestSignalOrStartRunRequiresDefinitionAndCarriesInput(t *testing.T) {
 	t.Parallel()
 
-	provider := newTestWorkflowProvider()
-	manager := testWorkflowManagerWithGithub(t, provider)
-	caller := testWorkflowManagerPrincipal()
-	if _, err := manager.SignalOrStartRun(context.Background(), caller, RunSignalOrStart{
-		ProviderName: "local",
-		WorkflowKey:  "github:issue:42",
-		Signal:       coreworkflow.Signal{Name: "github.issue"},
-	}); !errors.Is(err, invocation.ErrInvalidInvocation) {
-		t.Fatalf("SignalOrStartRun without definition error = %v, want invalid invocation", err)
-	}
+	t.Run("carries input", func(t *testing.T) {
+		t.Parallel()
 
-	if _, err := manager.ApplyDefinition(context.Background(), caller, DefinitionApply{
-		ProviderName: "local",
-		Caller:       testWorkflowManagerCaller(),
-		Spec: coreworkflow.DefinitionSpec{
-			ID:     "definition-1",
-			RunAs:  testWorkflowRunAsSubject(),
-			Target: testWorkflowAppStepTarget("github", "issues.triage", nil),
-		},
-	}); err != nil {
-		t.Fatalf("ApplyDefinition: %v", err)
-	}
-	signaled, err := manager.SignalOrStartRun(context.Background(), caller, RunSignalOrStart{
-		ProviderName:   "local",
-		Caller:         testWorkflowManagerCaller(),
-		WorkflowKey:    "github:issue:42",
-		DefinitionID:   "definition-1",
-		Input:          map[string]any{"issue_number": 42},
-		IdempotencyKey: "signal-1",
-		Signal:         coreworkflow.Signal{Name: "github.issue", Payload: map[string]any{"ok": true}},
+		provider := newTestWorkflowProvider()
+		manager := testWorkflowManagerWithGithub(t, provider)
+		caller := testWorkflowManagerPrincipal()
+		if _, err := manager.SignalOrStartRun(context.Background(), caller, RunSignalOrStart{
+			ProviderName: "local",
+			WorkflowKey:  "github:issue:42",
+			Signal:       coreworkflow.Signal{Name: "github.issue"},
+		}); !errors.Is(err, invocation.ErrInvalidInvocation) {
+			t.Fatalf("SignalOrStartRun without definition error = %v, want invalid invocation", err)
+		}
+
+		if _, err := manager.ApplyDefinition(context.Background(), caller, DefinitionApply{
+			ProviderName: "local",
+			Caller:       testWorkflowManagerCaller(),
+			Spec: coreworkflow.DefinitionSpec{
+				ID:     "definition-1",
+				RunAs:  testWorkflowRunAsSubject(),
+				Target: testWorkflowAppStepTarget("github", "issues.triage", nil),
+			},
+		}); err != nil {
+			t.Fatalf("ApplyDefinition: %v", err)
+		}
+		signaled, err := manager.SignalOrStartRun(context.Background(), caller, RunSignalOrStart{
+			ProviderName:   "local",
+			Caller:         testWorkflowManagerCaller(),
+			WorkflowKey:    "github:issue:42",
+			DefinitionID:   "definition-1",
+			Input:          map[string]any{"issue_number": 42},
+			IdempotencyKey: "signal-1",
+			Signal:         coreworkflow.Signal{Name: "github.issue", Payload: map[string]any{"ok": true}},
+		})
+		if err != nil {
+			t.Fatalf("SignalOrStartRun: %v", err)
+		}
+		if signaled == nil || signaled.Run == nil || !signaled.StartedRun {
+			t.Fatalf("signaled = %#v", signaled)
+		}
+		if got := signaled.Run.Input["issue_number"]; got != float64(42) {
+			t.Fatalf("run input issue_number = %#v, want 42", got)
+		}
+		if len(provider.signalOrStartRequests) != 1 || provider.signalOrStartRequests[0].GetDefinitionId() != "definition-1" {
+			t.Fatalf("signal requests = %#v", provider.signalOrStartRequests)
+		}
+		if got := provider.signalOrStartRequests[0].GetProvider(); got != "local" {
+			t.Fatalf("signal provider name = %q, want local", got)
+		}
+		requireWorkflowManagerRequestContext(t, provider.signalOrStartRequests[0].GetContext(), invocation.ProviderKindApp, "github")
 	})
-	if err != nil {
-		t.Fatalf("SignalOrStartRun: %v", err)
-	}
-	if signaled == nil || signaled.Run == nil || !signaled.StartedRun {
-		t.Fatalf("signaled = %#v", signaled)
-	}
-	if got := signaled.Run.Input["issue_number"]; got != float64(42) {
-		t.Fatalf("run input issue_number = %#v, want 42", got)
-	}
-	if len(provider.signalOrStartRequests) != 1 || provider.signalOrStartRequests[0].GetDefinitionId() != "definition-1" {
-		t.Fatalf("signal requests = %#v", provider.signalOrStartRequests)
-	}
-	if got := provider.signalOrStartRequests[0].GetProvider(); got != "local" {
-		t.Fatalf("signal provider name = %q, want local", got)
-	}
-	requireWorkflowManagerRequestContext(t, provider.signalOrStartRequests[0].GetContext(), invocation.ProviderKindApp, "github")
 }
 
 func TestDeliverEventPreservesCallerApp(t *testing.T) {

--- a/gestaltd/services/workflows/workflowmanager/manager_test.go
+++ b/gestaltd/services/workflows/workflowmanager/manager_test.go
@@ -132,6 +132,12 @@ type runAsGrantAuthz struct {
 	grants map[string]struct{}
 }
 
+type remoteDelegatedWorkflowApp struct {
+	*coretesting.StubIntegration
+}
+
+func (remoteDelegatedWorkflowApp) RemoteCredentialDelegated() bool { return true }
+
 func (a *runAsGrantAuthz) grantKey(subjectID, providerName, operation string) string {
 	return strings.TrimSpace(subjectID) + "|" + strings.TrimSpace(providerName) + "|" + strings.TrimSpace(operation)
 }
@@ -282,6 +288,39 @@ func TestApplyDefinitionAndStartRunUseDefinitionGenerationAndInput(t *testing.T)
 				ProviderName: "local",
 				DefinitionID: "definition-run-as",
 				WorkflowKey:  "github:issues:triage",
+			}); err != nil {
+				t.Fatalf("StartRun: %v", err)
+			}
+		})
+
+		t.Run("remote delegated target skips local grants", func(t *testing.T) {
+			t.Parallel()
+			provider := newTestWorkflowProvider()
+			providers := testutil.NewProviderRegistry(t, remoteDelegatedWorkflowApp{StubIntegration: &coretesting.StubIntegration{
+				N:          "linear",
+				ConnMode:   core.ConnectionModeNone,
+				CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{{ID: "issues.triage", Method: "POST"}}},
+			}})
+			manager := New(Config{
+				Providers: providers,
+				Workflow:  testWorkflowControl{provider: provider},
+				Invoker:   testWorkflowManagerBroker(t, providers, &runAsGrantAuthz{}),
+			})
+			spec := coreworkflow.DefinitionSpec{
+				ID:     "definition-remote-delegated",
+				RunAs:  testWorkflowRunAsSubject(),
+				Target: testWorkflowAppStepTarget("linear", "issues.triage", nil),
+			}
+			if _, err := manager.ApplyDefinition(context.Background(), testWorkflowManagerPrincipalWithoutGithub(), DefinitionApply{
+				ProviderName: "local",
+				Spec:         spec,
+			}); err != nil {
+				t.Fatalf("ApplyDefinition: %v", err)
+			}
+			if _, err := manager.StartRun(context.Background(), testWorkflowManagerPrincipalWithoutGithub(), RunStart{
+				ProviderName: "local",
+				DefinitionID: spec.ID,
+				WorkflowKey:  "linear:issues:triage",
 			}); err != nil {
 				t.Fatalf("StartRun: %v", err)
 			}

--- a/gestaltd/services/workflows/workflowmanager/manager_test.go
+++ b/gestaltd/services/workflows/workflowmanager/manager_test.go
@@ -151,6 +151,16 @@ func (a *denyingAgentWorkflowAuthorizer) AuthorizeWorkflowInvocation(_ context.C
 	return invocation.AgentWorkflowAuthorization{}, status.Error(codes.PermissionDenied, "agent workflow target is not allowed")
 }
 
+type tokenCountingWorkflowBroker struct {
+	*invocation.Broker
+	tokenResolutions int
+}
+
+func (b *tokenCountingWorkflowBroker) ResolveToken(ctx context.Context, p *principal.Principal, providerName, connection, instance string) (context.Context, string, error) {
+	b.tokenResolutions++
+	return b.Broker.ResolveToken(ctx, p, providerName, connection, instance)
+}
+
 func (a *runAsGrantAuthz) grantKey(subjectID, providerName, operation string) string {
 	return strings.TrimSpace(subjectID) + "|" + strings.TrimSpace(providerName) + "|" + strings.TrimSpace(operation)
 }
@@ -268,10 +278,11 @@ func TestApplyDefinitionAndStartRunUseDefinitionGenerationAndInput(t *testing.T)
 		t.Run("run_as without grants", func(t *testing.T) {
 			t.Parallel()
 			providers := testWorkflowGithubProviders(t)
+			broker := &tokenCountingWorkflowBroker{Broker: testWorkflowManagerBroker(t, providers, &runAsGrantAuthz{}).(*invocation.Broker)}
 			manager := New(Config{
 				Providers: providers,
 				Workflow:  testWorkflowControl{provider: newTestWorkflowProvider()},
-				Invoker:   testWorkflowManagerBroker(t, providers, &runAsGrantAuthz{}),
+				Invoker:   broker,
 			})
 			_, err := manager.ApplyDefinition(context.Background(), testWorkflowManagerPrincipal(), DefinitionApply{
 				ProviderName: "local",
@@ -279,6 +290,9 @@ func TestApplyDefinitionAndStartRunUseDefinitionGenerationAndInput(t *testing.T)
 			})
 			if !errors.Is(err, invocation.ErrAuthorizationDenied) {
 				t.Fatalf("ApplyDefinition error = %v, want authorization denied", err)
+			}
+			if broker.tokenResolutions != 0 {
+				t.Fatalf("token resolutions = %d, want 0", broker.tokenResolutions)
 			}
 		})
 

--- a/gestaltd/services/workflows/workflowmanager/manager_test.go
+++ b/gestaltd/services/workflows/workflowmanager/manager_test.go
@@ -90,10 +90,13 @@ func testWorkflowManagerWithGithubInvoker(t *testing.T, provider *testWorkflowPr
 			},
 		},
 	})
-	cfg := Config{Providers: providers, Workflow: testWorkflowControl{provider: provider}}
-	if invoker != nil {
-		cfg.Invoker = invoker
+	if invoker == nil {
+		invoker = invocation.NewBroker(providers, nil, nil,
+			invocation.WithAuthorizationProvider(allowAllAuthz{}),
+			invocation.WithProviderKinds(map[string]invocation.ProviderKind{"github": invocation.ProviderKindApp}),
+		)
 	}
+	cfg := Config{Providers: providers, Workflow: testWorkflowControl{provider: provider}, Invoker: invoker}
 	return New(cfg)
 }
 
@@ -105,7 +108,16 @@ func testWorkflowManagerPrincipalWithoutGithub() *principal.Principal {
 	})
 }
 
+type allowAllAuthz struct {
+	core.AuthorizationProvider
+}
+
+func (allowAllAuthz) CheckAccess(context.Context, *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
+	return &proto.CheckAccessResponse{Allowed: true}, nil
+}
+
 type runAsGrantAuthz struct {
+	core.AuthorizationProvider
 	grants map[string]struct{}
 }
 
@@ -117,42 +129,6 @@ func (a *runAsGrantAuthz) CheckAccess(_ context.Context, req *proto.CheckAccessR
 	_, ok := a.grants[a.grantKey(req.GetSubject().GetId(), req.GetResource().GetId(), req.GetAction().GetName())]
 	return &proto.CheckAccessResponse{Allowed: ok}, nil
 }
-
-func (a *runAsGrantAuthz) CheckAccessMany(context.Context, *proto.CheckAccessManyRequest) (*proto.CheckAccessManyResponse, error) {
-	return &proto.CheckAccessManyResponse{}, nil
-}
-
-func (a *runAsGrantAuthz) ListRelationships(context.Context, *proto.ListRelationshipsRequest) (*proto.ListRelationshipsResponse, error) {
-	return &proto.ListRelationshipsResponse{}, nil
-}
-
-func (a *runAsGrantAuthz) AddRelationship(context.Context, *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {
-	return &proto.AddRelationshipResponse{}, nil
-}
-
-func (a *runAsGrantAuthz) DeleteRelationship(context.Context, *proto.DeleteRelationshipRequest) (*proto.DeleteRelationshipResponse, error) {
-	return &proto.DeleteRelationshipResponse{}, nil
-}
-
-func (a *runAsGrantAuthz) SetAuthorizationState(context.Context, *proto.SetAuthorizationStateRequest) (*proto.SetAuthorizationStateResponse, error) {
-	return &proto.SetAuthorizationStateResponse{}, nil
-}
-
-func (a *runAsGrantAuthz) GetActiveModelRef(context.Context) (*proto.GetActiveModelRefResponse, error) {
-	return &proto.GetActiveModelRefResponse{}, nil
-}
-
-func (a *runAsGrantAuthz) SetActiveModel(context.Context, *proto.SetActiveModelRequest) (*proto.SetActiveModelResponse, error) {
-	return &proto.SetActiveModelResponse{}, nil
-}
-
-func (a *runAsGrantAuthz) ListActiveModelResourceTypes(context.Context, *proto.ListActiveModelResourceTypesRequest) (*proto.ListActiveModelResourceTypesResponse, error) {
-	return &proto.ListActiveModelResourceTypesResponse{}, nil
-}
-
-func (a *runAsGrantAuthz) Ping(context.Context) error { return nil }
-
-func (a *runAsGrantAuthz) Close() error { return nil }
 
 func testWorkflowManagerWithRunAsGrants(t *testing.T, provider *testWorkflowProvider, grants map[string]struct{}) *Manager {
 	t.Helper()


### PR DESCRIPTION
Workflow targets are resolved and authorized as the stored `run_as` subject, not the caller that applies the definition or starts the run. The workflow manager reuses the invocation broker through `TargetAccessChecker`, so preflight and app-step execution share the same authorization provider and resource mapping.

```mermaid
sequenceDiagram
    actor Caller
    participant API as Workflow API
    participant Manager as Workflow manager
    participant Broker as Invocation broker
    participant Authz as Authorization provider
    participant Worker as Workflow provider
    participant AppAPI as App API
    participant App as Target app

    Caller->>API: ApplyDefinition or StartRun
    API->>Authz: Authorize caller for workflow RPC
    Authz-->>API: Allowed
    API->>Manager: Forward request

    alt ApplyDefinition
        Manager->>Manager: Resolve target as run_as
    else StartRun
        Manager->>Worker: Load stored definition
        Worker-->>Manager: Target and run_as
    end

    loop Each app operation, agent provider, and tool
        Manager->>Broker: CheckOperationAccess or CheckProviderAccess as run_as
        Broker->>Authz: CheckAccess(run_as, target)
        Authz-->>Broker: Allow or deny
        Broker-->>Manager: Allow or deny
    end

    alt Any target denied
        Manager-->>API: Permission denied
    else All targets allowed
        Manager->>Worker: Apply definition or start run
        opt Run executes an app step
            Worker->>AppAPI: Invoke with run_as
            AppAPI->>Broker: Invoke as run_as
            Broker->>Authz: CheckAccess(run_as, app operation)
            Authz-->>Broker: Allowed
            Broker->>App: Execute
            App-->>Broker: Result
            Broker-->>AppAPI: Result
            AppAPI-->>Worker: Result
        end
        Worker-->>Manager: Result
        Manager-->>API: Result
    end

    API-->>Caller: Result
```