### PR TITLE
Add typed workflow authoring builders

### DIFF
--- a/sdk/go/client/workflow_bridge.go
+++ b/sdk/go/client/workflow_bridge.go
@@ -1,0 +1,43 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// WorkflowDefinitionSpecSource is implemented by handwritten workflow
+// builders that can lower themselves to the generated client spec.
+type WorkflowDefinitionSpecSource interface {
+	ToWorkflowDefinitionSpec() (*WorkflowDefinitionSpec, error)
+}
+
+// ApplyDefinitionFrom applies a generated workflow definition spec produced by
+// a handwritten source such as the root package's WorkflowBuilder.
+func (c *Workflow) ApplyDefinitionFrom(ctx context.Context, provider, idempotencyKey string, source WorkflowDefinitionSpecSource) (*WorkflowDefinition, error) {
+	spec, err := resolveWorkflowDefinitionSpecSource(source)
+	if err != nil {
+		return nil, err
+	}
+	return c.ApplyDefinition(ctx, provider, idempotencyKey, spec)
+}
+
+func resolveWorkflowDefinitionSpecSource(source WorkflowDefinitionSpecSource) (*WorkflowDefinitionSpec, error) {
+	if source == nil {
+		return nil, fmt.Errorf("workflow definition spec source is nil")
+	}
+	spec, err := source.ToWorkflowDefinitionSpec()
+	if err != nil {
+		return nil, err
+	}
+	if spec == nil {
+		return nil, fmt.Errorf("workflow definition spec is nil")
+	}
+	if strings.TrimSpace(spec.Id) == "" {
+		return nil, fmt.Errorf("workflow definition requires ID")
+	}
+	if strings.TrimSpace(spec.RunAs) == "" {
+		return nil, fmt.Errorf("workflow definition requires RunAs")
+	}
+	return spec, nil
+}

--- a/sdk/go/workflow_builders.go
+++ b/sdk/go/workflow_builders.go
@@ -760,7 +760,7 @@ type WorkflowDefinitionSpec struct {
 	Target      *BoundWorkflowTarget
 	Activations []WorkflowActivation
 	Paused      bool
-	RunAs       *Subject
+	RunAs       string
 }
 
 // WorkflowDefinition is the provider-owned definition projection.
@@ -778,6 +778,9 @@ type WorkflowDefinition struct {
 }
 
 func workflowDefinitionSpecToProto(input WorkflowDefinitionSpec) (*proto.WorkflowDefinitionSpec, error) {
+	if err := input.Validate(); err != nil {
+		return nil, err
+	}
 	target, err := newOptionalBoundWorkflowTarget(input.Target)
 	if err != nil {
 		return nil, err
@@ -791,7 +794,7 @@ func workflowDefinitionSpecToProto(input WorkflowDefinitionSpec) (*proto.Workflo
 		Target:      target,
 		Activations: activations,
 		Paused:      input.Paused,
-		RunAs:       workflowSubjectID(input.RunAs),
+		RunAs:       strings.TrimSpace(input.RunAs),
 	}, nil
 }
 
@@ -808,7 +811,7 @@ func workflowDefinitionSpecFromProto(value *proto.WorkflowDefinitionSpec) (Workf
 		Target:      workflowTargetInputPtrFromTarget(value.GetTarget()),
 		Activations: activations,
 		Paused:      value.GetPaused(),
-		RunAs:       workflowSubjectFromID(value.GetRunAs()),
+		RunAs:       strings.TrimSpace(value.GetRunAs()),
 	}, nil
 }
 
@@ -1158,4 +1161,361 @@ func workflowSubjectFromID(value string) *Subject {
 		return nil
 	}
 	return &Subject{ID: value}
+}
+
+// WorkflowRefInput references a run-input path in a workflow definition.
+func WorkflowRefInput(path string) WorkflowValue {
+	return WorkflowValue{Input: strings.TrimSpace(path)}
+}
+
+// WorkflowRefSignal references an activation signal path in a workflow definition.
+func WorkflowRefSignal(path string) WorkflowValue {
+	return WorkflowValue{Signal: strings.TrimSpace(path)}
+}
+
+// WorkflowRefStepOutput references a prior step output path.
+func WorkflowRefStepOutput(stepID, path string) WorkflowValue {
+	return WorkflowValue{StepOutput: &WorkflowStepOutputSource{
+		StepID: strings.TrimSpace(stepID),
+		Path:   strings.TrimSpace(path),
+	}}
+}
+
+// WorkflowRefStepInput references a prior step input path.
+func WorkflowRefStepInput(stepID, path string) WorkflowValue {
+	return WorkflowValue{StepInput: &WorkflowStepInputSource{
+		StepID: strings.TrimSpace(stepID),
+		Path:   strings.TrimSpace(path),
+	}}
+}
+
+// WorkflowRefLiteral builds a literal workflow value.
+func WorkflowRefLiteral(value any) WorkflowValue {
+	return WorkflowValue{Literal: value, LiteralSet: true}
+}
+
+// WorkflowRefTemplate builds a template workflow value.
+func WorkflowRefTemplate(template string) WorkflowValue {
+	text := WorkflowText{Template: template}
+	return WorkflowValue{Template: &text}
+}
+
+// WorkflowRefObject builds an object workflow value from field builders.
+func WorkflowRefObject(fields map[string]WorkflowValue) WorkflowValue {
+	return WorkflowValue{Object: fields}
+}
+
+// WorkflowRefArray builds an array workflow value.
+func WorkflowRefArray(values ...WorkflowValue) WorkflowValue {
+	return WorkflowValue{Array: values}
+}
+
+// WorkflowEventActivationOptions configures an event activation.
+type WorkflowEventActivationOptions struct {
+	ID      string
+	Source  string
+	Subject string
+	Paused  bool
+}
+
+// WorkflowScheduleActivationOptions configures a schedule activation.
+type WorkflowScheduleActivationOptions struct {
+	ID       string
+	Timezone string
+	Paused   bool
+}
+
+// WorkflowEventActivationConfig is accepted by WorkflowBuilder.On.
+type WorkflowEventActivationConfig struct {
+	Type     string
+	MapInput func() map[string]WorkflowValue
+	Options  WorkflowEventActivationOptions
+}
+
+// WorkflowScheduleActivationConfig is accepted by WorkflowBuilder.On.
+type WorkflowScheduleActivationConfig struct {
+	Cron     string
+	MapInput func() map[string]WorkflowValue
+	Options  WorkflowScheduleActivationOptions
+}
+
+// WorkflowActivationConfig is an activation accepted by WorkflowBuilder.On.
+type WorkflowActivationConfig interface {
+	workflowActivationConfig()
+}
+
+func (WorkflowEventActivationConfig) workflowActivationConfig()    {}
+func (WorkflowScheduleActivationConfig) workflowActivationConfig() {}
+
+// WorkflowStepAppConfig configures an app step action.
+type WorkflowStepAppConfig struct {
+	Name           string
+	Operation      string
+	Input          func() map[string]WorkflowValue
+	Connection     string
+	Instance       string
+	CredentialMode string
+}
+
+// WorkflowStepAgentMessageConfig configures one agent message.
+type WorkflowStepAgentMessageConfig struct {
+	Role string
+	Text string
+}
+
+// WorkflowStepAgentConfig configures an agent step action.
+type WorkflowStepAgentConfig struct {
+	Provider     string
+	Model        string
+	SessionKey   string
+	Prompt       string
+	Messages     []WorkflowStepAgentMessageConfig
+	Tools        []AgentToolRef
+	Output       *AgentOutput
+	ModelOptions any
+}
+
+// WorkflowStepWhenConfig configures a step guard.
+type WorkflowStepWhenConfig struct {
+	Value  WorkflowValue
+	Equals any
+}
+
+// WorkflowStepConfig configures one workflow step.
+type WorkflowStepConfig struct {
+	Inputs         func() map[string]WorkflowValue
+	App            *WorkflowStepAppConfig
+	Agent          *WorkflowStepAgentConfig
+	When           *WorkflowStepWhenConfig
+	TimeoutSeconds int32
+	Metadata       any
+}
+
+// WorkflowBuilder incrementally authors a workflow definition spec.
+type WorkflowBuilder struct {
+	id          string
+	runAs       string
+	activations []WorkflowActivation
+	steps       []WorkflowStep
+}
+
+// Event creates an event activation configuration. The options argument is
+// optional; its zero value is used when it is omitted.
+func Event(typeName string, mapInput func() map[string]WorkflowValue, options ...WorkflowEventActivationOptions) WorkflowEventActivationConfig {
+	var config WorkflowEventActivationOptions
+	if len(options) > 0 {
+		config = options[0]
+	}
+	return WorkflowEventActivationConfig{
+		Type:     typeName,
+		MapInput: mapInput,
+		Options:  config,
+	}
+}
+
+// Schedule creates a schedule activation configuration. The options argument
+// is optional; its zero value is used when it is omitted.
+func Schedule(cron string, mapInput func() map[string]WorkflowValue, options ...WorkflowScheduleActivationOptions) WorkflowScheduleActivationConfig {
+	var config WorkflowScheduleActivationOptions
+	if len(options) > 0 {
+		config = options[0]
+	}
+	return WorkflowScheduleActivationConfig{
+		Cron:     cron,
+		MapInput: mapInput,
+		Options:  config,
+	}
+}
+
+// DefineWorkflow starts a fluent workflow definition builder. ID and runAs
+// are checked when ToSpec or an apply bridge materializes the definition.
+func DefineWorkflow(id, runAs string) *WorkflowBuilder {
+	return &WorkflowBuilder{
+		id:    strings.TrimSpace(id),
+		runAs: strings.TrimSpace(runAs),
+	}
+}
+
+// On appends one activation to the builder.
+func (b *WorkflowBuilder) On(activation WorkflowActivationConfig) *WorkflowBuilder {
+	if b == nil {
+		return b
+	}
+	switch typed := activation.(type) {
+	case WorkflowEventActivationConfig:
+		activationID := strings.TrimSpace(typed.Options.ID)
+		if activationID == "" {
+			activationID = strings.TrimSpace(typed.Type)
+		}
+		var input WorkflowValue
+		if typed.MapInput != nil {
+			input = WorkflowRefObject(typed.MapInput())
+		}
+		b.activations = append(b.activations, WorkflowActivation{
+			ID:     activationID,
+			Paused: typed.Options.Paused,
+			Event: &WorkflowEventActivation{Match: &WorkflowEventMatch{
+				Type:    typed.Type,
+				Source:  typed.Options.Source,
+				Subject: typed.Options.Subject,
+			}},
+			Input: input,
+		})
+	case WorkflowScheduleActivationConfig:
+		activationID := strings.TrimSpace(typed.Options.ID)
+		if activationID == "" {
+			activationID = strings.TrimSpace(typed.Cron)
+		}
+		var input WorkflowValue
+		if typed.MapInput != nil {
+			input = WorkflowRefObject(typed.MapInput())
+		}
+		b.activations = append(b.activations, WorkflowActivation{
+			ID:     activationID,
+			Paused: typed.Options.Paused,
+			Schedule: &WorkflowScheduleActivation{
+				Cron:     typed.Cron,
+				Timezone: typed.Options.Timezone,
+			},
+			Input: input,
+		})
+	}
+	return b
+}
+
+// Step appends one step to the builder.
+func (b *WorkflowBuilder) Step(stepID string, config WorkflowStepConfig) *WorkflowBuilder {
+	if b == nil {
+		return b
+	}
+	if config.App != nil && config.Agent != nil {
+		panic("workflow step cannot configure both app and agent actions")
+	}
+	step := WorkflowStep{ID: stepID}
+	if config.Inputs != nil {
+		step.Inputs = config.Inputs()
+	}
+	if config.App != nil {
+		var input WorkflowValue
+		if config.App.Input != nil {
+			input = WorkflowRefObject(config.App.Input())
+		}
+		step.App = &WorkflowStepAppCall{
+			Name:           config.App.Name,
+			Operation:      config.App.Operation,
+			Input:          input,
+			Connection:     config.App.Connection,
+			Instance:       config.App.Instance,
+			CredentialMode: config.App.CredentialMode,
+		}
+	}
+	if config.Agent != nil {
+		messages := make([]WorkflowAgentMessage, 0, len(config.Agent.Messages))
+		for _, message := range config.Agent.Messages {
+			messages = append(messages, WorkflowAgentMessage{
+				Role: message.Role,
+				Text: WorkflowText{Template: message.Text},
+			})
+		}
+		step.Agent = &WorkflowStepAgentTurn{
+			Provider:     config.Agent.Provider,
+			Model:        config.Agent.Model,
+			SessionKey:   config.Agent.SessionKey,
+			Prompt:       WorkflowText{Template: config.Agent.Prompt},
+			Messages:     messages,
+			Tools:        config.Agent.Tools,
+			Output:       config.Agent.Output,
+			ModelOptions: config.Agent.ModelOptions,
+		}
+	}
+	if config.When != nil {
+		step.When = &WorkflowStepWhen{
+			Value:  config.When.Value,
+			Equals: config.When.Equals,
+		}
+	}
+	step.TimeoutSeconds = config.TimeoutSeconds
+	step.Metadata = config.Metadata
+	b.steps = append(b.steps, step)
+	return b
+}
+
+// Validate checks the required identity fields of a workflow definition.
+func (s WorkflowDefinitionSpec) Validate() error {
+	if strings.TrimSpace(s.ID) == "" {
+		return fmt.Errorf("workflow definition requires ID")
+	}
+	if strings.TrimSpace(s.RunAs) == "" {
+		return fmt.Errorf("workflow definition requires RunAs")
+	}
+	return nil
+}
+
+// ToSpec returns the authored workflow definition spec after validating its
+// required identity fields.
+func (b *WorkflowBuilder) ToSpec() (WorkflowDefinitionSpec, error) {
+	if b == nil {
+		return WorkflowDefinitionSpec{}, fmt.Errorf("workflow builder is nil")
+	}
+	var target *BoundWorkflowTarget
+	if len(b.steps) > 0 {
+		target = &BoundWorkflowTarget{Steps: append([]WorkflowStep(nil), b.steps...)}
+	}
+	spec := WorkflowDefinitionSpec{
+		ID:          strings.TrimSpace(b.id),
+		RunAs:       strings.TrimSpace(b.runAs),
+		Activations: append([]WorkflowActivation(nil), b.activations...),
+		Target:      target,
+	}
+	if err := spec.Validate(); err != nil {
+		return WorkflowDefinitionSpec{}, err
+	}
+	return spec, nil
+}
+
+// Text builds workflow template text from literals and workflow value
+// references. Step output and input references intentionally lower to the
+// plural outputs and inputs template paths.
+func Text(parts ...any) string {
+	var builder strings.Builder
+	for _, part := range parts {
+		switch typed := part.(type) {
+		case string:
+			builder.WriteString(typed)
+		case WorkflowValue:
+			builder.WriteString(workflowValueToTemplatePlaceholder(typed))
+		default:
+			panic(fmt.Sprintf("Text parts must be strings or WorkflowValue, got %T", part))
+		}
+	}
+	return builder.String()
+}
+
+// WorkflowComposeText is kept as a compatibility alias for Text.
+func WorkflowComposeText(parts ...any) string {
+	return Text(parts...)
+}
+
+func workflowValueToTemplatePlaceholder(value WorkflowValue) string {
+	if value.Input != "" {
+		return fmt.Sprintf("${{ input.%s }}", strings.TrimSpace(value.Input))
+	}
+	if value.Signal != "" {
+		return fmt.Sprintf("${{ signal.%s }}", strings.TrimSpace(value.Signal))
+	}
+	if value.StepOutput != nil {
+		return fmt.Sprintf(
+			"${{ steps.%s.outputs.%s }}",
+			strings.TrimSpace(value.StepOutput.StepID),
+			strings.TrimSpace(value.StepOutput.Path),
+		)
+	}
+	if value.StepInput != nil {
+		return fmt.Sprintf(
+			"${{ steps.%s.inputs.%s }}",
+			strings.TrimSpace(value.StepInput.StepID),
+			strings.TrimSpace(value.StepInput.Path),
+		)
+	}
+	panic("Text references must be input, signal, step output, or step input paths")
 }

--- a/sdk/go/workflow_builders_test.go
+++ b/sdk/go/workflow_builders_test.go
@@ -3,6 +3,8 @@ package gestalt
 import (
 	"testing"
 	"time"
+
+	"github.com/valon-technologies/gestalt/sdk/go/client"
 )
 
 func TestWorkflowRunUsesNativeTimesInputAndSteps(t *testing.T) {
@@ -122,7 +124,8 @@ func TestWorkflowSignalAndEventUseNativePayloads(t *testing.T) {
 
 func TestWorkflowDefinitionSpecStepsAndActivationsUseNewValueRoots(t *testing.T) {
 	spec, err := workflowDefinitionSpecToProto(WorkflowDefinitionSpec{
-		ID: "definition-1",
+		ID:    "definition-1",
+		RunAs: "service_account:workflow-runner",
 		Target: &BoundWorkflowTarget{Steps: []WorkflowStep{
 			{
 				ID: "collect",
@@ -187,6 +190,106 @@ func TestWorkflowDefinitionSpecStepsAndActivationsUseNewValueRoots(t *testing.T)
 	activation := spec.GetActivations()[0]
 	if activation.GetEvent().GetMatch().GetType() != "slack.message" {
 		t.Fatalf("activation event = %#v", activation.GetEvent())
+	}
+}
+
+func TestWorkflowBuilderInlineExtractSummarizeChain(t *testing.T) {
+	builder := DefineWorkflow("summarize-analysis", "service_account:workflow-runner").
+		On(Event("analysis.extract.requested", func() map[string]WorkflowValue {
+			return map[string]WorkflowValue{
+				"analysis_id": WorkflowRefSignal("data.analysis_id"),
+			}
+		})).
+		Step("extract", WorkflowStepConfig{
+			App: &WorkflowStepAppConfig{
+				Name:      "dealHub",
+				Operation: "analyses.extractRowWorkflow",
+				Input: func() map[string]WorkflowValue {
+					return map[string]WorkflowValue{
+						"analysis_id": WorkflowRefInput("analysis_id"),
+					}
+				},
+			},
+		}).
+		Step("summarize", WorkflowStepConfig{
+			Agent: &WorkflowStepAgentConfig{
+				Provider: "openai",
+				Model:    "gpt-5",
+				Prompt: Text(
+					"Summarize the extracted analysis: ",
+					WorkflowRefStepOutput("extract", "app.body.json"),
+				),
+			},
+		})
+
+	spec, err := builder.ToSpec()
+	if err != nil {
+		t.Fatalf("ToSpec: %v", err)
+	}
+	if spec.ID != "summarize-analysis" || spec.RunAs != "service_account:workflow-runner" {
+		t.Fatalf("identity = %#v", spec)
+	}
+	if len(spec.Activations) != 1 || len(spec.Target.Steps) != 2 {
+		t.Fatalf("definition shape = %#v", spec)
+	}
+	if got := spec.Activations[0].Input.Object["analysis_id"].Signal; got != "data.analysis_id" {
+		t.Fatalf("activation input = %q", got)
+	}
+	if got := spec.Target.Steps[0].App.Input.Object["analysis_id"].Input; got != "analysis_id" {
+		t.Fatalf("extract input = %q", got)
+	}
+	if got := spec.Target.Steps[1].Agent.Prompt.Template; got != "Summarize the extracted analysis: ${{ steps.extract.outputs.app.body.json }}" {
+		t.Fatalf("summarize prompt = %q", got)
+	}
+}
+
+func TestWorkflowBuilderRejectsBothAppAndAgent(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic when configuring both app and agent on one step")
+		}
+	}()
+	DefineWorkflow("invalid-step", "service_account:workflow-runner").Step("broken", WorkflowStepConfig{
+		App: &WorkflowStepAppConfig{
+			Name:      "dealHub",
+			Operation: "extractRow",
+		},
+		Agent: &WorkflowStepAgentConfig{
+			Provider: "openai",
+			Prompt:   "summarize",
+		},
+	})
+}
+
+func TestWorkflowBuilderValidationAndApplySource(t *testing.T) {
+	if _, err := DefineWorkflow("", "service_account:workflow-runner").ToSpec(); err == nil {
+		t.Fatal("expected ID validation error")
+	}
+	if _, err := DefineWorkflow("workflow", "").ToSpec(); err == nil {
+		t.Fatal("expected RunAs validation error")
+	}
+
+	applyStub := func(source client.WorkflowDefinitionSpecSource) (*client.WorkflowDefinitionSpec, error) {
+		return source.ToWorkflowDefinitionSpec()
+	}
+	spec, err := applyStub(DefineWorkflow("workflow", "service_account:workflow-runner"))
+	if err != nil {
+		t.Fatalf("apply source: %v", err)
+	}
+	if spec.Id != "workflow" || spec.RunAs != "service_account:workflow-runner" {
+		t.Fatalf("client spec = %#v", spec)
+	}
+}
+
+func TestWorkflowTextLowersPluralStepPaths(t *testing.T) {
+	got := Text(
+		WorkflowRefStepOutput("extract", "body"),
+		" / ",
+		WorkflowRefStepInput("extract", "analysis_id"),
+	)
+	want := "${{ steps.extract.outputs.body }} / ${{ steps.extract.inputs.analysis_id }}"
+	if got != want {
+		t.Fatalf("Text = %q, want %q", got, want)
 	}
 }
 

--- a/sdk/go/workflow_client_bridge.go
+++ b/sdk/go/workflow_client_bridge.go
@@ -1,0 +1,21 @@
+package gestalt
+
+import (
+	"github.com/valon-technologies/gestalt/sdk/go/client"
+)
+
+var _ client.WorkflowDefinitionSpecSource = (*WorkflowBuilder)(nil)
+
+// ToWorkflowDefinitionSpec lowers the root workflow builder to the generated
+// client message without making the generated client import the root package.
+func (b *WorkflowBuilder) ToWorkflowDefinitionSpec() (*client.WorkflowDefinitionSpec, error) {
+	spec, err := b.ToSpec()
+	if err != nil {
+		return nil, err
+	}
+	wire, err := workflowDefinitionSpecToProto(spec)
+	if err != nil {
+		return nil, err
+	}
+	return client.FromWireWorkflowDefinitionSpec(wire), nil
+}

--- a/sdk/go/workflow_transport_test.go
+++ b/sdk/go/workflow_transport_test.go
@@ -102,25 +102,16 @@ func TestTransport_WorkflowApplyDefinitionTCPTargetTokenEnv(t *testing.T) {
 		t.Fatalf("Workflow: %v", err)
 	}
 
-	applied, err := workflow.ApplyDefinition(context.Background(), "default", "workflow-definition-key-go", &client.WorkflowDefinitionSpec{
-		Id: "definition-1",
-		Target: &client.BoundWorkflowTarget{Steps: []*client.WorkflowStep{{
-			Id: "review",
-			Action: &client.WorkflowStepActionApp{Value: &client.WorkflowStepAppCall{
+	builder := gestalt.DefineWorkflow("definition-1", "service_account:workflow-runner").
+		Step("review", gestalt.WorkflowStepConfig{
+			App: &gestalt.WorkflowStepAppConfig{
 				Name:      "github",
 				Operation: "pullRequests.review",
-			}},
-		}}},
-		Activations: []*client.WorkflowActivation{{
-			Id: "github_pr",
-			Trigger: &client.WorkflowActivationTriggerEvent{Value: &client.WorkflowEventActivation{Match: &client.WorkflowEventMatch{
-				Type:   "github.pull_request",
-				Source: "github",
-			}}},
-		}},
-	})
+			},
+		})
+	applied, err := workflow.ApplyDefinitionFrom(context.Background(), "default", "workflow-definition-key-go", builder)
 	if err != nil {
-		t.Fatalf("ApplyDefinition: %v", err)
+		t.Fatalf("ApplyDefinitionFrom: %v", err)
 	}
 	if applied.Provider != "default" || applied.Id != "definition-1" || applied.Generation != 3 {
 		t.Fatalf("definition = %#v", applied)

--- a/sdk/python/gestalt/__init__.py
+++ b/sdk/python/gestalt/__init__.py
@@ -266,6 +266,7 @@ _WORKFLOW_AUTHORED_EXPORTS = (
     "WorkflowApplyDefinition",
     "WorkflowDefinition",
     "WorkflowDefinitionSpec",
+    "WorkflowDefinitionBuilder",
     "WorkflowDeleteDefinition",
     "WorkflowDeliverEvent",
     "WorkflowEvent",
@@ -349,6 +350,16 @@ _WORKFLOW_AUTHORED_EXPORTS = (
     "workflow_text_input_from_text",
     "workflow_value",
     "workflow_value_input_from_value",
+)
+
+_WORKFLOW_DEFINE_EXPORTS = (
+    "WorkflowStepAppConfig",
+    "WorkflowStepAgentConfig",
+    "WorkflowBuilder",
+    "define_workflow",
+    "event",
+    "schedule",
+    "text",
 )
 
 _WORKFLOW_HELPER_EXPORTS = (
@@ -510,6 +521,9 @@ _LAZY_EXPORTS.update(
     {name: ("._workflow", name) for name in _WORKFLOW_AUTHORED_EXPORTS}
 )
 _LAZY_EXPORTS.update({name: ("._workflow", name) for name in _WORKFLOW_HELPER_EXPORTS})
+_LAZY_EXPORTS.update(
+    {name: ("._workflow_authoring", name) for name in _WORKFLOW_DEFINE_EXPORTS}
+)
 
 _LAZY_MODULES = {
     "telemetry": ".telemetry",
@@ -549,6 +563,7 @@ __all__ = [
     *_PROTOCOL_TYPE_EXPORTS,
     *_RUNTIME_PROVIDER_AUTHORED_EXPORTS,
     *_WORKFLOW_AUTHORED_EXPORTS,
+    *_WORKFLOW_DEFINE_EXPORTS,
     *_WORKFLOW_HELPER_EXPORTS,
     "Agent",
     "AgentProvider",

--- a/sdk/python/gestalt/_workflow.py
+++ b/sdk/python/gestalt/_workflow.py
@@ -1394,8 +1394,13 @@ def _workflow_signal_or_start_run_request(
 def _workflow_apply_definition_request(value: Any | None = None, **kwargs: Any) -> Any:
     if isinstance(value, pb.ApplyWorkflowProviderDefinitionRequest):
         return _copy(value)
+    if value is not None and callable(getattr(value, "to_spec", None)):
+        kwargs = {"spec": value.to_spec(), **kwargs}
+        value = None
     data = _data(value, kwargs)
     spec = data.get("spec")
+    if spec is not None and callable(getattr(spec, "to_spec", None)):
+        spec = spec.to_spec()
     return pb.ApplyWorkflowProviderDefinitionRequest(
         provider=data.get("provider", ""),
         spec=workflow_definition_spec(spec) if spec is not None else None,
@@ -2258,8 +2263,15 @@ WorkflowSignalRunInput: TypeAlias = WorkflowSignalRun | WorkflowRequestMapping |
 WorkflowSignalOrStartRunInput: TypeAlias = (
     WorkflowSignalOrStartRun | WorkflowRequestMapping | None
 )
+class WorkflowDefinitionBuilder(Protocol):
+    """Structural contract implemented by typed workflow definition builders."""
+
+    def to_spec(self) -> Any:
+        """Return a native workflow definition specification."""
+
+
 WorkflowApplyDefinitionInput: TypeAlias = (
-    WorkflowApplyDefinition | WorkflowRequestMapping | None
+    WorkflowApplyDefinition | WorkflowRequestMapping | WorkflowDefinitionBuilder | None
 )
 WorkflowGetDefinitionInput: TypeAlias = (
     WorkflowGetDefinition | WorkflowRequestMapping | None

--- a/sdk/python/gestalt/_workflow_authoring.py
+++ b/sdk/python/gestalt/_workflow_authoring.py
@@ -1,0 +1,511 @@
+"""Private fluent workflow-definition authoring helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+from ._gen.v1 import workflow_pb2 as pb
+from ._protocol import dataclass_mapping as _dataclass_mapping
+from ._workflow import (
+    WorkflowValue as _NativeWorkflowValue,
+)
+from ._workflow import (
+    bound_workflow_target,
+    workflow_activation,
+    workflow_agent_message,
+    workflow_definition_spec,
+    workflow_event_match,
+    workflow_step,
+    workflow_step_agent_turn,
+    workflow_step_app_call,
+    workflow_step_when,
+    workflow_text,
+    workflow_value,
+)
+
+__all__ = (
+    "WorkflowStepAppConfig",
+    "WorkflowStepAgentConfig",
+    "WorkflowBuilder",
+    "define_workflow",
+    "event",
+    "schedule",
+    "text",
+)
+
+class _Unset:
+    pass
+
+
+_UNSET = _Unset()
+
+
+class _TextExpression:
+    __slots__ = ("parts",)
+
+    def __init__(
+        self, parts: tuple[str | _WorkflowRef | _WorkflowRefProxy, ...]
+    ) -> None:
+        self.parts = parts
+
+
+class _WorkflowRef:
+    __slots__ = ("kind", "path", "step_id")
+
+    def __init__(self, kind: str, path: str = "", step_id: str = "") -> None:
+        self.kind = kind
+        self.path = path
+        self.step_id = step_id
+
+
+class _WorkflowRefProxy:
+    def __init__(self, kind: str, path: str = "", step_id: str = "") -> None:
+        self._ref = _WorkflowRef(kind, path, step_id)
+
+    def __getattr__(self, name: str) -> _WorkflowRefProxy:
+        next_path = f"{self._ref.path}.{name}" if self._ref.path else name
+        return _WorkflowRefProxy(self._ref.kind, next_path, self._ref.step_id)
+
+    def __getitem__(self, name: str) -> _WorkflowRefProxy:
+        return self.__getattr__(str(name))
+
+
+class _StepScope:
+    def __init__(self) -> None:
+        self.input = _WorkflowRefProxy("input")
+        self.signal = _WorkflowRefProxy("signal")
+
+    def step_output(self, step_id: str, path: str) -> _WorkflowRef:
+        return _WorkflowRef("stepOutput", path, step_id)
+
+    def step_input(self, step_id: str, path: str) -> _WorkflowRef:
+        return _WorkflowRef("stepInput", path, step_id)
+
+    @property
+    def steps(self) -> _StepOutputsMap:
+        return _StepOutputsMap()
+
+
+class _StepOutputs:
+    def __init__(self, step_id: str) -> None:
+        self.outputs = _WorkflowRefProxy("stepOutput", "", step_id)
+        # Keep the singular spelling as a compatibility alias for early users.
+        self.output = self.outputs
+        self.inputs = _WorkflowRefProxy("stepInput", "", step_id)
+        # Keep the singular spelling as a compatibility alias for early users.
+        self.input = self.inputs
+
+
+class _StepOutputsMap:
+    def __getitem__(self, step_id: str) -> _StepOutputs:
+        return _StepOutputs(step_id)
+
+
+class _EventScope:
+    def __init__(self) -> None:
+        self.data = _WorkflowRefProxy("signal", "data")
+
+
+@dataclass(frozen=True, slots=True)
+class WorkflowStepAppConfig:
+    """Typed configuration for an app action in a workflow step."""
+
+    name: str = ""
+    operation: str = ""
+    input: Mapping[str, Any] | Callable[[_StepScope], Mapping[str, Any]] | None = None
+    connection: str = ""
+    instance: str = ""
+    credential_mode: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class WorkflowStepAgentConfig:
+    """Typed configuration for an agent turn in a workflow step."""
+
+    provider: str = ""
+    model: str = ""
+    session_key: str = ""
+    prompt: (
+        str | _TextExpression | Callable[[_StepScope], str | _TextExpression] | None
+    ) = None
+    messages: Sequence[Any] = field(default_factory=list)
+    tools: Sequence[Any] = field(default_factory=list)
+    output: Any = None
+    model_options: Mapping[str, Any] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _EventActivationConfig:
+    type: str
+    map_input: Callable[[_EventScope], Mapping[str, Any]] | None = None
+    id: str = ""
+    source: str = ""
+    subject: str = ""
+    paused: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class _ScheduleActivationConfig:
+    cron: str
+    map_input: Callable[[_WorkflowRefProxy], Mapping[str, Any]] | None = None
+    id: str = ""
+    timezone: str = ""
+    paused: bool = False
+
+
+class WorkflowBuilder:
+    def __init__(self, *, id: str, run_as: str, paused: bool = False) -> None:
+        workflow_id = id.strip()
+        workflow_run_as = run_as.strip()
+        if not workflow_run_as:
+            raise ValueError("define_workflow requires run_as")
+        if not workflow_id:
+            raise ValueError("define_workflow requires id")
+        self._id = workflow_id
+        self._run_as = workflow_run_as
+        self._paused = paused
+        self._activations: list[Any] = []
+        self._steps: list[Any] = []
+
+    def on(
+        self, activation: _EventActivationConfig | _ScheduleActivationConfig
+    ) -> WorkflowBuilder:
+        if isinstance(activation, _EventActivationConfig):
+            activation_id = activation.id.strip() or activation.type
+            mapped = (
+                activation.map_input(_EventScope())
+                if activation.map_input is not None
+                else None
+            )
+            self._activations.append(
+                workflow_activation(
+                    id=activation_id,
+                    paused=activation.paused,
+                    event={
+                        "match": workflow_event_match(
+                            type=activation.type,
+                            source=activation.source,
+                            subject=activation.subject,
+                        )
+                    },
+                    input=(
+                        None
+                        if mapped is None
+                        else _capture_object_value(mapped, "signal")
+                    ),
+                )
+            )
+            return self
+
+        if not isinstance(activation, _ScheduleActivationConfig):
+            raise TypeError("workflow activation must be event() or schedule()")
+        activation_id = activation.id.strip() or activation.cron
+        mapped = (
+            activation.map_input(_WorkflowRefProxy("input"))
+            if activation.map_input is not None
+            else None
+        )
+        self._activations.append(
+            workflow_activation(
+                id=activation_id,
+                paused=activation.paused,
+                schedule={"cron": activation.cron, "timezone": activation.timezone},
+                input=(
+                    None if mapped is None else _capture_object_value(mapped, "input")
+                ),
+            )
+        )
+        return self
+
+    def step(
+        self,
+        step_id: str,
+        config: Mapping[str, Any] | None = None,
+        *,
+        inputs: Any = _UNSET,
+        app: WorkflowStepAppConfig | Mapping[str, Any] | None | _Unset = _UNSET,
+        agent: WorkflowStepAgentConfig | Mapping[str, Any] | None | _Unset = _UNSET,
+        when: Mapping[str, Any] | Any | None = _UNSET,
+        timeout_seconds: int | None | object = _UNSET,
+        metadata: Mapping[str, Any] | None | object = _UNSET,
+    ) -> WorkflowBuilder:
+        """Append a step, preferably using typed keyword arguments.
+
+        A mapping in the second positional argument remains accepted for
+        compatibility with the initial builder implementation.
+        """
+
+        if config is not None:
+            if any(
+                value is not _UNSET
+                for value in (inputs, app, agent, when, timeout_seconds, metadata)
+            ):
+                raise TypeError("step config cannot be combined with keyword fields")
+            step_data = dict(config)
+        else:
+            step_data = {
+                key: value
+                for key, value in (
+                    ("inputs", inputs),
+                    ("app", app),
+                    ("agent", agent),
+                    ("when", when),
+                    ("timeout_seconds", timeout_seconds),
+                    ("metadata", metadata),
+                )
+                if value is not _UNSET
+            }
+
+        scope = _StepScope()
+        step_kwargs: dict[str, Any] = {"id": step_id}
+
+        inputs_value = step_data.get("inputs")
+        if inputs_value is not None:
+            mapped = _resolve_mapped_object(inputs_value, scope)
+            step_kwargs["inputs"] = _capture_object(mapped, "input")
+
+        app_value = step_data.get("app")
+        agent_value = step_data.get("agent")
+        if app_value is not None and agent_value is not None:
+            raise ValueError(
+                "workflow step cannot configure both app and agent actions"
+            )
+
+        if app_value is not None:
+            app_data = _message_data(app_value, "WorkflowStepAppConfig")
+            mapped_input = app_data.get("input")
+            if mapped_input is not None:
+                mapped_input = _resolve_mapped_object(mapped_input, scope)
+            step_kwargs["app"] = workflow_step_app_call(
+                name=app_data.get("name", ""),
+                operation=app_data.get("operation", ""),
+                input=(
+                    None
+                    if mapped_input is None
+                    else _capture_object_value(mapped_input, "input")
+                ),
+                connection=app_data.get("connection", ""),
+                instance=app_data.get("instance", ""),
+                credential_mode=app_data.get("credential_mode", ""),
+            )
+
+        if agent_value is not None:
+            agent_data = _message_data(agent_value, "WorkflowStepAgentConfig")
+            prompt = agent_data.get("prompt")
+            if callable(prompt):
+                prompt = prompt(scope)
+            messages = []
+            for message in agent_data.get("messages") or []:
+                message_data = _message_data(message, "agent message")
+                message_text = message_data.get("text")
+                if callable(message_text):
+                    message_text = message_text(scope)
+                messages.append(
+                    workflow_agent_message(
+                        role=message_data.get("role", ""),
+                        text=workflow_text(_resolve_workflow_prompt(message_text)),
+                    )
+                )
+            step_kwargs["agent"] = workflow_step_agent_turn(
+                provider=agent_data.get("provider", ""),
+                model=agent_data.get("model", ""),
+                session_key=agent_data.get("session_key", ""),
+                prompt=(
+                    None
+                    if prompt is None
+                    else workflow_text(_resolve_workflow_prompt(prompt))
+                ),
+                messages=messages,
+                tools=agent_data.get("tools"),
+                output=agent_data.get("output"),
+                model_options=agent_data.get("model_options"),
+            )
+
+        when_value = step_data.get("when")
+        if when_value is not None:
+            if isinstance(when_value, pb.WorkflowStepWhen):
+                step_kwargs["when"] = workflow_step_when(when_value)
+            else:
+                when_data = _message_data(when_value, "WorkflowStepWhen")
+                when_kwargs: dict[str, Any] = {}
+                if "value" in when_data:
+                    when_kwargs["value"] = _capture_proto(when_data["value"], "input")
+                if "equals" in when_data:
+                    when_kwargs["equals"] = when_data["equals"]
+                step_kwargs["when"] = workflow_step_when(**when_kwargs)
+
+        timeout_value = step_data.get("timeout_seconds")
+        if timeout_value is not None:
+            step_kwargs["timeout_seconds"] = timeout_value
+        metadata_value = step_data.get("metadata")
+        if metadata_value is not None:
+            step_kwargs["metadata"] = metadata_value
+
+        self._steps.append(workflow_step(**step_kwargs))
+        return self
+
+    def to_spec(self) -> Any:
+        target = bound_workflow_target(steps=self._steps) if self._steps else None
+        return workflow_definition_spec(
+            id=self._id,
+            run_as=self._run_as,
+            paused=self._paused,
+            activations=self._activations,
+            target=target,
+        )
+
+
+def define_workflow(*, id: str, run_as: str, paused: bool = False) -> WorkflowBuilder:
+    return WorkflowBuilder(id=id, run_as=run_as, paused=paused)
+
+
+def event(
+    type_name: str,
+    map_input: Callable[[_EventScope], Mapping[str, Any]] | None = None,
+    *,
+    id: str = "",
+    source: str = "",
+    subject: str = "",
+    paused: bool = False,
+) -> _EventActivationConfig:
+    return _EventActivationConfig(
+        type=type_name,
+        map_input=map_input,
+        id=id,
+        source=source,
+        subject=subject,
+        paused=paused,
+    )
+
+
+def schedule(
+    cron: str,
+    map_input: Callable[[_WorkflowRefProxy], Mapping[str, Any]] | None = None,
+    *,
+    id: str = "",
+    timezone: str = "",
+    paused: bool = False,
+) -> _ScheduleActivationConfig:
+    return _ScheduleActivationConfig(
+        cron=cron,
+        map_input=map_input,
+        id=id,
+        timezone=timezone,
+        paused=paused,
+    )
+
+
+def text(*parts: str | _WorkflowRef | _WorkflowRefProxy) -> _TextExpression:
+    """Compose workflow prompt/message text from literals and references."""
+
+    return _TextExpression(parts)
+
+
+def _message_data(value: Any, field_name: str) -> dict[str, Any]:
+    if isinstance(value, pb.WorkflowAgentMessage):
+        return {
+            "role": value.role,
+            "text": value.text.template if value.HasField("text") else None,
+        }
+    mapping = _dataclass_mapping(value)
+    if mapping is not None:
+        return dict(mapping)
+    if isinstance(value, Mapping):
+        return dict(value)
+    raise TypeError(f"{field_name} must be a dataclass or mapping")
+
+
+def _capture_object(value: Mapping[str, Any], default_kind: str) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise TypeError("workflow mapped input must be a mapping")
+    return {key: _capture_proto(item, default_kind) for key, item in value.items()}
+
+
+def _resolve_mapped_object(value: Any, scope: _StepScope) -> Mapping[str, Any]:
+    if callable(value):
+        value = cast(Callable[[_StepScope], Mapping[str, Any]], value)(scope)
+    if not isinstance(value, Mapping):
+        raise TypeError("workflow mapped input must be a mapping or callback")
+    return value
+
+
+def _capture_object_value(value: Mapping[str, Any], default_kind: str) -> Any:
+    return pb.WorkflowValue(
+        object=pb.WorkflowObject(fields=_capture_object(value, default_kind))
+    )
+
+
+def _capture_proto(value: Any, default_kind: str) -> Any:
+    if isinstance(value, _WorkflowRef):
+        return _workflow_ref_value(value)
+    if isinstance(value, _WorkflowRefProxy):
+        return _workflow_ref_value(value._ref)
+    if isinstance(value, (pb.WorkflowValue, _NativeWorkflowValue)):
+        return workflow_value(value)
+    if isinstance(value, list | tuple):
+        return pb.WorkflowValue(
+            array=pb.WorkflowArray(
+                values=[_capture_proto(item, default_kind) for item in value]
+            )
+        )
+    if isinstance(value, Mapping):
+        return pb.WorkflowValue(
+            object=pb.WorkflowObject(
+                fields={
+                    key: _capture_proto(item, default_kind)
+                    for key, item in value.items()
+                }
+            )
+        )
+    return workflow_value(literal=value)
+
+
+def _workflow_ref_value(ref: _WorkflowRef) -> Any:
+    if ref.kind == "stepOutput":
+        return pb.WorkflowValue(
+            step_output=pb.WorkflowStepOutputSource(
+                step_id=ref.step_id,
+                path=ref.path,
+            )
+        )
+    if ref.kind == "stepInput":
+        return pb.WorkflowValue(
+            step_input=pb.WorkflowStepInputSource(
+                step_id=ref.step_id,
+                path=ref.path,
+            )
+        )
+    if ref.kind == "input":
+        return pb.WorkflowValue(input=pb.WorkflowPathSource(path=ref.path))
+    if ref.kind == "signal":
+        return pb.WorkflowValue(signal=pb.WorkflowPathSource(path=ref.path))
+    raise ValueError(f"unsupported workflow ref kind: {ref.kind}")
+
+
+def _resolve_workflow_prompt(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, _TextExpression):
+        rendered = ""
+        for part in value.parts:
+            rendered += (
+                part if isinstance(part, str) else _ref_to_template_placeholder(part)
+            )
+        return rendered
+    raise ValueError("workflow prompt must be a string or text() expression")
+
+
+def _ref_to_template_placeholder(ref: _WorkflowRef | _WorkflowRefProxy) -> str:
+    if isinstance(ref, _WorkflowRefProxy):
+        ref = ref._ref
+    if ref.kind == "input":
+        return f"${{{{ input.{ref.path} }}}}"
+    if ref.kind == "signal":
+        return f"${{{{ signal.{ref.path} }}}}"
+    if ref.kind == "stepOutput":
+        return f"${{{{ steps.{ref.step_id}.outputs.{ref.path} }}}}"
+    if ref.kind == "stepInput":
+        return f"${{{{ steps.{ref.step_id}.inputs.{ref.path} }}}}"
+    raise ValueError(f"unsupported workflow ref kind: {ref.kind}")

--- a/sdk/python/tests/test_workflow_define.py
+++ b/sdk/python/tests/test_workflow_define.py
@@ -1,0 +1,117 @@
+import pytest
+
+from gestalt import (
+    AgentOutput,
+    AgentTextOutput,
+    AgentTurn,
+    WorkflowStepAgentConfig,
+    WorkflowStepAppConfig,
+    define_workflow,
+    event,
+    schedule,
+    text,
+)
+
+
+def test_workflow_builder_lowers_references_and_text() -> None:
+    definition = (
+        define_workflow(
+            id="example",
+            run_as="service_account:workflow-runner",
+        )
+        .on(schedule("0 * * * *", lambda value: {"account_id": value.account_id}))
+        .on(event("deal.updated", lambda value: {"deal_id": value.data.deal_id}))
+        .step(
+            "extract",
+            app=WorkflowStepAppConfig(
+                name="dealHub",
+                operation="extractRow",
+                input=lambda scope: {"account_id": scope.input.account_id},
+            ),
+        )
+        .step(
+            "notify",
+            agent=WorkflowStepAgentConfig(
+                provider="openai",
+                output=AgentOutput(text=AgentTextOutput()),
+                prompt=lambda scope: text(
+                    "Extracted ",
+                    scope.steps["extract"].outputs.row_id,
+                    " for ",
+                    scope.steps["extract"].inputs.account_id,
+                ),
+            ),
+        )
+    )
+
+    spec = definition.to_spec()
+    assert spec.id == "example"
+    assert spec.run_as == "service_account:workflow-runner"
+    assert len(spec.activations) == 2
+    assert spec.target.steps[0].app.name == "dealHub"
+    assert spec.target.steps[1].agent.prompt.template == (
+        "Extracted ${{ steps.extract.outputs.row_id }} for "
+        "${{ steps.extract.inputs.account_id }}"
+    )
+
+
+def test_agent_turn_export_remains_the_provider_model() -> None:
+    codec_shaped_turn = AgentTurn(
+        id="turn-1",
+        model="provider-model",
+        status=1,
+        messages=[],
+        created_at=None,
+    )
+
+    assert isinstance(codec_shaped_turn, AgentTurn)
+    assert AgentTurn.__module__ == "gestalt._agent"
+
+
+def test_apply_definition_accepts_builder_as_top_level_request() -> None:
+    from gestalt._workflow import _workflow_apply_definition_request
+
+    definition = define_workflow(
+        id="example",
+        run_as="service_account:workflow-runner",
+    ).step(
+        "extract",
+        app=WorkflowStepAppConfig(
+            name="dealHub",
+            operation="extractRow",
+            input=lambda scope: {"account_id": scope.input.account_id},
+        ),
+    )
+
+    request = _workflow_apply_definition_request(
+        definition,
+        provider="local",
+        idempotency_key="workflow-definition-key",
+    )
+
+    assert request.provider == "local"
+    assert request.idempotency_key == "workflow-definition-key"
+    assert request.spec.id == "example"
+
+
+def test_workflow_builder_rejects_both_app_and_agent() -> None:
+    definition = define_workflow(
+        id="invalid-step",
+        run_as="service_account:workflow-runner",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="workflow step cannot configure both app and agent actions",
+    ):
+        definition.step(
+            "broken",
+            app=WorkflowStepAppConfig(
+                name="dealHub",
+                operation="extractRow",
+            ),
+            agent=WorkflowStepAgentConfig(
+                provider="openai",
+                prompt="summarize",
+            ),
+        )

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -60,8 +60,14 @@ mod secrets_server;
 pub mod telemetry;
 /// Generated Test client and native types.
 pub mod test;
-/// Generated Workflow client and native types.
-pub mod workflow;
+mod workflow_authoring;
+#[path = "workflow.rs"]
+mod workflow_generated;
+/// Generated workflow clients and native types plus typed workflow authoring helpers.
+pub mod workflow {
+    pub use crate::workflow_authoring::*;
+    pub use crate::workflow_generated::*;
+}
 /// Workflow provider contract and native workflow types.
 pub mod workflow_provider;
 

--- a/sdk/rust/src/workflow_authoring.rs
+++ b/sdk/rust/src/workflow_authoring.rs
@@ -1,0 +1,448 @@
+//! Typed workflow-definition authoring helpers.
+#![allow(missing_docs)]
+
+use std::collections::BTreeMap;
+
+use serde_json::{Map, Value};
+
+use crate::agent::AgentOutput;
+use crate::app::AgentToolRef;
+use crate::workflow::{
+    BoundWorkflowTarget, WorkflowActivation, WorkflowActivationTrigger, WorkflowAgentMessage,
+    WorkflowDefinitionSpec, WorkflowEventActivation, WorkflowEventMatch,
+    WorkflowScheduleActivation, WorkflowStep, WorkflowStepAction, WorkflowStepAgentTurn,
+    WorkflowStepAppCall, WorkflowStepWhen, WorkflowText, WorkflowValue, WorkflowValueKind,
+};
+
+type WorkflowMap = BTreeMap<String, WorkflowValue>;
+type WorkflowMapFn = Box<dyn Fn() -> WorkflowMap + Send + Sync>;
+
+fn value(kind: WorkflowValueKind) -> WorkflowValue {
+    WorkflowValue { kind: Some(kind) }
+}
+
+/// References a run-input path.
+pub fn input(path: impl Into<String>) -> WorkflowValue {
+    value(WorkflowValueKind::Input(
+        crate::workflow::WorkflowPathSource { path: path.into() },
+    ))
+}
+
+/// References an activation signal path.
+pub fn signal(path: impl Into<String>) -> WorkflowValue {
+    value(WorkflowValueKind::Signal(
+        crate::workflow::WorkflowPathSource { path: path.into() },
+    ))
+}
+
+/// References a prior step output path.
+pub fn step_output(step_id: impl Into<String>, path: impl Into<String>) -> WorkflowValue {
+    value(WorkflowValueKind::StepOutput(
+        crate::workflow::WorkflowStepOutputSource {
+            step_id: step_id.into(),
+            path: path.into(),
+        },
+    ))
+}
+
+/// References a prior step input path.
+pub fn step_input(step_id: impl Into<String>, path: impl Into<String>) -> WorkflowValue {
+    value(WorkflowValueKind::StepInput(
+        crate::workflow::WorkflowStepInputSource {
+            step_id: step_id.into(),
+            path: path.into(),
+        },
+    ))
+}
+
+/// Builds a literal workflow value.
+pub fn literal(literal: Value) -> crate::Result<WorkflowValue> {
+    Ok(value(WorkflowValueKind::Literal(literal)))
+}
+
+/// Builds a workflow template value.
+pub fn template(template: impl Into<String>) -> WorkflowValue {
+    value(WorkflowValueKind::Template(WorkflowText {
+        template: template.into(),
+    }))
+}
+
+/// Builds an object workflow value.
+pub fn object(fields: WorkflowMap) -> WorkflowValue {
+    value(WorkflowValueKind::Object(crate::workflow::WorkflowObject {
+        fields,
+    }))
+}
+
+/// Builds an array workflow value.
+pub fn array(values: Vec<WorkflowValue>) -> WorkflowValue {
+    value(WorkflowValueKind::Array(crate::workflow::WorkflowArray {
+        values,
+    }))
+}
+
+#[derive(Clone, Debug)]
+pub struct WorkflowBuilder {
+    id: String,
+    run_as: String,
+    paused: bool,
+    activations: Vec<WorkflowActivation>,
+    steps: Vec<WorkflowStep>,
+}
+
+/// Starts a fluent workflow definition builder.
+pub fn define_workflow(
+    id: impl Into<String>,
+    run_as: impl Into<String>,
+) -> crate::Result<WorkflowBuilder> {
+    let id = id.into();
+    let run_as = run_as.into();
+    if id.trim().is_empty() {
+        return Err(crate::Error::bad_request("define_workflow requires id"));
+    }
+    if run_as.trim().is_empty() {
+        return Err(crate::Error::bad_request("define_workflow requires run_as"));
+    }
+    Ok(WorkflowBuilder {
+        id,
+        run_as,
+        paused: false,
+        activations: Vec::new(),
+        steps: Vec::new(),
+    })
+}
+
+impl WorkflowBuilder {
+    /// Sets whether the definition starts paused.
+    pub fn paused(mut self, paused: bool) -> Self {
+        self.paused = paused;
+        self
+    }
+
+    pub fn on(mut self, activation: WorkflowActivationConfig) -> Self {
+        let (id, paused, trigger, input) = match activation.kind {
+            WorkflowActivationKind::Event {
+                type_name,
+                map_input,
+            } => (
+                type_name.clone(),
+                false,
+                WorkflowActivationTrigger::Event(WorkflowEventActivation {
+                    r#match: Some(WorkflowEventMatch {
+                        r#type: type_name,
+                        ..Default::default()
+                    }),
+                }),
+                Some(object(map_input())),
+            ),
+            WorkflowActivationKind::Schedule { cron, map_input } => (
+                cron.clone(),
+                false,
+                WorkflowActivationTrigger::Schedule(WorkflowScheduleActivation {
+                    cron,
+                    ..Default::default()
+                }),
+                Some(object(map_input())),
+            ),
+        };
+        self.activations.push(WorkflowActivation {
+            id,
+            paused,
+            trigger: Some(trigger),
+            input,
+        });
+        self
+    }
+
+    pub fn step(mut self, step_id: impl Into<String>, config: WorkflowStepConfig) -> Self {
+        assert!(
+            !(config.app.is_some() && config.agent.is_some()),
+            "workflow step cannot configure both app and agent actions"
+        );
+        let mut step = WorkflowStep {
+            id: step_id.into(),
+            ..Default::default()
+        };
+        if let Some(inputs) = config.inputs {
+            step.inputs = inputs();
+        }
+        if let Some(app) = config.app {
+            step.action = Some(WorkflowStepAction::App(WorkflowStepAppCall {
+                name: app.name,
+                operation: app.operation,
+                input: app.input.map(|callback| object(callback())),
+                connection: app.connection,
+                instance: app.instance,
+                credential_mode: app.credential_mode,
+            }));
+        }
+        if let Some(agent) = config.agent {
+            step.action = Some(WorkflowStepAction::Agent(WorkflowStepAgentTurn {
+                provider: agent.provider,
+                model: agent.model,
+                session_key: agent.session_key,
+                prompt: Some(agent.prompt),
+                messages: agent
+                    .messages
+                    .into_iter()
+                    .map(|message| WorkflowAgentMessage {
+                        role: message.role,
+                        text: Some(WorkflowText {
+                            template: message.text,
+                        }),
+                        ..Default::default()
+                    })
+                    .collect(),
+                tools: agent.tools,
+                output: agent.output,
+                model_options: agent.model_options,
+            }));
+        }
+        step.when = config.when.map(|when| WorkflowStepWhen {
+            value: Some(when.value),
+            equals: when.equals,
+        });
+        step.timeout_seconds = config.timeout_seconds;
+        step.metadata = config.metadata;
+        self.steps.push(step);
+        self
+    }
+
+    /// Consumes the builder and returns the generated workflow definition spec.
+    pub fn to_spec(self) -> WorkflowDefinitionSpec {
+        WorkflowDefinitionSpec {
+            id: self.id,
+            run_as: self.run_as,
+            paused: self.paused,
+            activations: self.activations,
+            target: (!self.steps.is_empty()).then_some(BoundWorkflowTarget { steps: self.steps }),
+        }
+    }
+}
+
+pub struct WorkflowActivationConfig {
+    kind: WorkflowActivationKind,
+}
+
+enum WorkflowActivationKind {
+    Event {
+        type_name: String,
+        map_input: WorkflowMapFn,
+    },
+    Schedule {
+        cron: String,
+        map_input: WorkflowMapFn,
+    },
+}
+
+/// Creates an event activation for [`WorkflowBuilder::on`].
+pub fn event<F>(type_name: impl Into<String>, map_input: F) -> WorkflowActivationConfig
+where
+    F: Fn() -> BTreeMap<String, WorkflowValue> + Send + Sync + 'static,
+{
+    WorkflowActivationConfig {
+        kind: WorkflowActivationKind::Event {
+            type_name: type_name.into(),
+            map_input: Box::new(map_input),
+        },
+    }
+}
+
+/// Creates a schedule activation for [`WorkflowBuilder::on`].
+pub fn schedule<F>(cron: impl Into<String>, map_input: F) -> WorkflowActivationConfig
+where
+    F: Fn() -> BTreeMap<String, WorkflowValue> + Send + Sync + 'static,
+{
+    WorkflowActivationConfig {
+        kind: WorkflowActivationKind::Schedule {
+            cron: cron.into(),
+            map_input: Box::new(map_input),
+        },
+    }
+}
+
+pub struct WorkflowStepAppConfig {
+    pub name: String,
+    pub operation: String,
+    input: Option<WorkflowMapFn>,
+    pub connection: String,
+    pub instance: String,
+    pub credential_mode: String,
+}
+
+impl WorkflowStepAppConfig {
+    /// Creates an app step configuration. Add mapped input with [`Self::with_input`].
+    pub fn new(name: impl Into<String>, operation: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            operation: operation.into(),
+            input: None,
+            connection: String::new(),
+            instance: String::new(),
+            credential_mode: String::new(),
+        }
+    }
+
+    /// Sets a zero-argument input mapper; the closure is boxed by the SDK.
+    pub fn with_input<F>(mut self, input: F) -> Self
+    where
+        F: Fn() -> BTreeMap<String, WorkflowValue> + Send + Sync + 'static,
+    {
+        self.input = Some(Box::new(input));
+        self
+    }
+}
+
+impl Default for WorkflowStepAppConfig {
+    fn default() -> Self {
+        Self::new("", "")
+    }
+}
+
+impl WorkflowStepAppConfig {
+    pub fn with_connection(mut self, connection: impl Into<String>) -> Self {
+        self.connection = connection.into();
+        self
+    }
+
+    pub fn with_instance(mut self, instance: impl Into<String>) -> Self {
+        self.instance = instance.into();
+        self
+    }
+
+    pub fn with_credential_mode(mut self, credential_mode: impl Into<String>) -> Self {
+        self.credential_mode = credential_mode.into();
+        self
+    }
+}
+
+#[derive(Clone)]
+pub struct WorkflowStepAgentMessageConfig {
+    pub role: String,
+    pub text: String,
+}
+
+#[derive(Clone, Default)]
+pub struct WorkflowStepAgentConfig {
+    pub provider: String,
+    pub model: String,
+    pub session_key: String,
+    pub prompt: WorkflowText,
+    pub messages: Vec<WorkflowStepAgentMessageConfig>,
+    pub tools: Vec<AgentToolRef>,
+    pub output: Option<AgentOutput>,
+    pub model_options: Option<Map<String, Value>>,
+}
+
+impl WorkflowStepAgentConfig {
+    pub fn new(provider: impl Into<String>) -> Self {
+        Self {
+            provider: provider.into(),
+            ..Default::default()
+        }
+    }
+
+    pub fn with_prompt(mut self, prompt: WorkflowText) -> Self {
+        self.prompt = prompt;
+        self
+    }
+}
+
+#[derive(Clone)]
+pub struct WorkflowStepWhenConfig {
+    pub value: WorkflowValue,
+    pub equals: Option<Value>,
+}
+
+#[derive(Default)]
+pub struct WorkflowStepConfig {
+    inputs: Option<WorkflowMapFn>,
+    pub app: Option<WorkflowStepAppConfig>,
+    pub agent: Option<WorkflowStepAgentConfig>,
+    pub when: Option<WorkflowStepWhenConfig>,
+    pub timeout_seconds: i32,
+    pub metadata: Option<Map<String, Value>>,
+}
+
+impl WorkflowStepConfig {
+    pub fn with_inputs<F>(mut self, inputs: F) -> Self
+    where
+        F: Fn() -> BTreeMap<String, WorkflowValue> + Send + Sync + 'static,
+    {
+        self.inputs = Some(Box::new(inputs));
+        self
+    }
+}
+
+fn value_placeholder(value: &WorkflowValue) -> crate::Result<String> {
+    let result = match value.kind.as_ref() {
+        Some(WorkflowValueKind::Input(source)) => format!("${{{{ input.{} }}}}", source.path),
+        Some(WorkflowValueKind::Signal(source)) => format!("${{{{ signal.{} }}}}", source.path),
+        Some(WorkflowValueKind::StepOutput(source)) => {
+            format!(
+                "${{{{ steps.{}.outputs.{} }}}}",
+                source.step_id, source.path
+            )
+        }
+        Some(WorkflowValueKind::StepInput(source)) => {
+            format!("${{{{ steps.{}.inputs.{} }}}}", source.step_id, source.path)
+        }
+        _ => {
+            return Err(crate::Error::bad_request(
+                "text references must be path values",
+            ));
+        }
+    };
+    Ok(result)
+}
+
+/// Composes workflow prompt text from workflow value references.
+pub fn text(parts: &[WorkflowValue]) -> crate::Result<WorkflowText> {
+    let mut template = String::new();
+    for part in parts {
+        template.push_str(&value_placeholder(part)?);
+    }
+    Ok(WorkflowText { template })
+}
+
+pub enum WorkflowDefinitionSpecOrBuilder {
+    Spec(WorkflowDefinitionSpec),
+    Builder(WorkflowBuilder),
+}
+
+impl From<WorkflowBuilder> for WorkflowDefinitionSpecOrBuilder {
+    fn from(builder: WorkflowBuilder) -> Self {
+        Self::Builder(builder)
+    }
+}
+
+impl From<WorkflowDefinitionSpec> for WorkflowDefinitionSpecOrBuilder {
+    fn from(spec: WorkflowDefinitionSpec) -> Self {
+        Self::Spec(spec)
+    }
+}
+
+impl WorkflowDefinitionSpecOrBuilder {
+    fn into_spec(self) -> WorkflowDefinitionSpec {
+        match self {
+            Self::Spec(spec) => spec,
+            Self::Builder(builder) => builder.to_spec(),
+        }
+    }
+}
+
+/// Applies a workflow definition from a raw spec or an authored builder.
+pub async fn apply_workflow_definition(
+    workflow: &mut crate::workflow::Workflow,
+    provider: String,
+    idempotency_key: String,
+    spec: Option<impl Into<WorkflowDefinitionSpecOrBuilder>>,
+) -> Result<crate::workflow::WorkflowDefinition, crate::rpc_support::GestaltError> {
+    workflow
+        .apply_definition(
+            provider,
+            idempotency_key,
+            spec.map(|value| value.into().into_spec()),
+        )
+        .await
+}

--- a/sdk/rust/tests/workflow_builders.rs
+++ b/sdk/rust/tests/workflow_builders.rs
@@ -3,7 +3,12 @@ mod helpers;
 
 use serde::Serialize;
 use serde_json::json;
+use std::collections::BTreeMap;
 
+use gestalt::workflow::{
+    WorkflowStepAgentConfig, WorkflowStepAppConfig, WorkflowStepConfig, define_workflow, schedule,
+    step_output, text,
+};
 use gestalt::{
     BoundWorkflowTarget, WorkflowAgentMessage, WorkflowEvalContext, WorkflowExecutionRequest,
     WorkflowSignal, WorkflowStep, WorkflowStepAction, WorkflowStepAgentTurn, WorkflowStepAppCall,
@@ -49,6 +54,61 @@ fn workflow_steps_do_not_require_timeout() -> gestalt::Result<()> {
         Some(json!({"ok": false, "count": 0.0}))
     );
     Ok(())
+}
+
+#[test]
+fn typed_workflow_builder_lowers_app_to_agent_chain() -> gestalt::Result<()> {
+    let mut extract = WorkflowStepConfig::default();
+    extract.app = Some(
+        WorkflowStepAppConfig::new("dealHub", "extractRow").with_input(|| {
+            BTreeMap::from([(
+                String::from("account_id"),
+                gestalt::workflow::input("account_id"),
+            )])
+        }),
+    );
+
+    let mut summarize = WorkflowStepConfig::default();
+    summarize.agent = Some(
+        WorkflowStepAgentConfig::new("openai")
+            .with_prompt(text(&[step_output("extract", "summary")])?),
+    );
+
+    let builder = define_workflow("example", "service_account:workflow-runner")?
+        .on(schedule("0 * * * *", || {
+            BTreeMap::from([(
+                String::from("account_id"),
+                gestalt::workflow::input("account_id"),
+            )])
+        }))
+        .step("extract", extract)
+        .step("summarize", summarize);
+    let spec = builder.to_spec();
+    assert_eq!(spec.run_as, "service_account:workflow-runner");
+    assert_eq!(spec.activations.len(), 1);
+    let steps = spec.target.expect("target").steps;
+    assert_eq!(steps.len(), 2);
+    let agent = match steps[1].action.as_ref() {
+        Some(gestalt::workflow::WorkflowStepAction::Agent(agent)) => agent,
+        _ => return Err(gestalt::Error::bad_request("expected summarize agent step")),
+    };
+    assert_eq!(
+        agent.prompt.as_ref().expect("prompt").template,
+        "${{ steps.extract.outputs.summary }}"
+    );
+    Ok(())
+}
+
+#[test]
+#[should_panic(expected = "workflow step cannot configure both app and agent actions")]
+fn workflow_builder_rejects_both_app_and_agent_actions() {
+    let builder = gestalt::workflow::define_workflow("example", "service_account:runner")
+        .expect("valid workflow metadata");
+    let mut config = WorkflowStepConfig::default();
+    config.app = Some(WorkflowStepAppConfig::default());
+    config.agent = Some(WorkflowStepAgentConfig::default());
+
+    let _ = builder.step("invalid", config);
 }
 
 #[test]

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -100,7 +100,7 @@ export {
   type AgentWorkspaceGitCheckout,
   type PreparedAgentWorkspace,
 } from "./agent.ts";
-export { Workflow } from "./workflow.ts";
+export { Workflow } from "./workflow-service.ts";
 export {
   GestaltError,
   GestaltErrorCode,
@@ -432,7 +432,7 @@ export {
   type ResolveAgentProviderInteractionRequest,
   type UpdateAgentProviderSessionRequest,
 } from "./providers/agent.ts";
-// The workflow authoring surface re-exports by name: its proto conversion
+// The workflow define surface re-exports by name: its proto conversion
 // helpers stay package-internal (cross-module plumbing, not public API).
 export {
   WorkflowProvider,
@@ -536,6 +536,24 @@ export {
   type WorkflowValue,
   type WorkflowValueKind,
 } from "./providers/workflow.ts";
+export {
+  WorkflowBuilder,
+  defineWorkflow,
+  event,
+  schedule,
+  text,
+  type ActivationConfig,
+  type DefineWorkflowOptions,
+  type EventActivationConfig,
+  type EventActivationOptions,
+  type ScheduleActivationConfig,
+  type ScheduleActivationOptions,
+  type StepAgentConfig,
+  type StepAgentMessageConfig,
+  type StepAppConfig,
+  type StepConfig,
+  type StepWhenConfig,
+} from "./workflow-define.ts";
 export {
   GENAI_OPERATION_CHAT,
   GENAI_OPERATION_EXECUTE_TOOL,

--- a/sdk/typescript/src/workflow-define.ts
+++ b/sdk/typescript/src/workflow-define.ts
@@ -1,0 +1,672 @@
+/**
+ * Fluent workflow definition builder with proxy-based reference capture.
+ *
+ * References are captured into workflow value nodes while step IDs and mapped
+ * run-input keys accumulate in the fluent builder's type parameters.
+ *
+ * @module
+ */
+
+import type { AgentOutput, AgentToolRef } from "./providers/agent.ts";
+import type { JsonInput, JsonObjectInput } from "./protocol.ts";
+import {
+  boundWorkflowTarget,
+  workflowActivation,
+  workflowAgentMessage,
+  workflowDefinitionSpec,
+  workflowEventActivation,
+  workflowEventMatch,
+  workflowStep,
+  workflowStepAgentTurn,
+  workflowStepAppCall,
+  workflowStepWhen,
+  workflowText,
+  workflowValue,
+  type BoundWorkflowTarget,
+  type WorkflowActivation,
+  type WorkflowDefinitionSpec,
+  type WorkflowStep,
+  type WorkflowValue,
+} from "./providers/workflow.ts";
+
+const WORKFLOW_REF = Symbol.for("gestalt.workflow.ref");
+
+type WorkflowRefKind = "input" | "signal" | "stepOutput" | "stepInput";
+
+interface WorkflowRef {
+  readonly [WORKFLOW_REF]: true;
+  readonly kind: WorkflowRefKind;
+  readonly path: string;
+  readonly stepId?: string | undefined;
+}
+
+interface WorkflowLiteralRef {
+  readonly [WORKFLOW_REF]: true;
+  readonly kind: "literal";
+  readonly value: JsonInput;
+}
+
+interface WorkflowTemplateRef {
+  readonly [WORKFLOW_REF]: true;
+  readonly kind: "template";
+  readonly template: string;
+}
+
+interface WorkflowTextExpression {
+  readonly [WORKFLOW_REF]: true;
+  readonly kind: "composedText";
+  readonly parts: ReadonlyArray<string | WorkflowRef>;
+}
+
+type CapturedRef = WorkflowRef | WorkflowLiteralRef | WorkflowTemplateRef | WorkflowTextExpression;
+
+type EmptyInput = Record<never, never>;
+type EmptySteps = Record<never, never>;
+
+export type WorkflowDefinitionInput =
+  | WorkflowDefinitionSpec
+  | WorkflowBuilder
+  | { toSpec(): WorkflowDefinitionSpec };
+
+export type WorkflowPrompt<
+  RunInput extends object = EmptyInput,
+  Steps extends WorkflowSteps = EmptySteps,
+> =
+  | string
+  | WorkflowTextExpression
+  | ((scope: StepScope<RunInput, Steps>) => string | WorkflowTextExpression);
+
+export interface DefineWorkflowOptions {
+  id: string;
+  runAs: string;
+  paused?: boolean | undefined;
+}
+
+export interface EventActivationOptions {
+  id?: string | undefined;
+  source?: string | undefined;
+  subject?: string | undefined;
+  paused?: boolean | undefined;
+}
+
+export interface ScheduleActivationOptions {
+  id?: string | undefined;
+  timezone?: string | undefined;
+  paused?: boolean | undefined;
+}
+
+export interface EventActivationConfig<ActivationInput extends object = EmptyInput> {
+  readonly __workflowActivation: "event";
+  readonly type: string;
+  readonly mapInput?: ((event: EventScope) => ActivationInput) | undefined;
+  readonly options?: EventActivationOptions | undefined;
+}
+
+export interface ScheduleActivationConfig<ActivationInput extends object = EmptyInput> {
+  readonly __workflowActivation: "schedule";
+  readonly cron: string;
+  readonly mapInput?: ((scope: ActivationScope) => ActivationInput) | undefined;
+  readonly options?: ScheduleActivationOptions | undefined;
+}
+
+export type ActivationConfig<ActivationInput extends object = EmptyInput> =
+  | EventActivationConfig<ActivationInput>
+  | ScheduleActivationConfig<ActivationInput>;
+
+export interface StepAppConfig<
+  RunInput extends object = EmptyInput,
+  Steps extends WorkflowSteps = EmptySteps,
+> {
+  name: string;
+  operation: string;
+  input?: (
+    (scope: StepScope<RunInput, Steps>) => Record<string, unknown> | StepRefProxy
+  ) | undefined;
+  connection?: string | undefined;
+  instance?: string | undefined;
+  credentialMode?: string | undefined;
+}
+
+export interface StepAgentMessageConfig<
+  RunInput extends object = EmptyInput,
+  Steps extends WorkflowSteps = EmptySteps,
+> {
+  role: string;
+  text: WorkflowPrompt<RunInput, Steps>;
+}
+
+export interface StepAgentConfig<
+  RunInput extends object = EmptyInput,
+  Steps extends WorkflowSteps = EmptySteps,
+> {
+  provider: string;
+  model?: string | undefined;
+  sessionKey?: string | undefined;
+  prompt?: WorkflowPrompt<RunInput, Steps> | undefined;
+  messages?: readonly StepAgentMessageConfig<RunInput, Steps>[] | undefined;
+  tools?: readonly AgentToolRef[] | undefined;
+  output?: AgentOutput | undefined;
+  modelOptions?: JsonObjectInput | undefined;
+}
+
+type RuntimeWorkflowPrompt =
+  | string
+  | WorkflowTextExpression
+  | ((scope: unknown) => string | WorkflowTextExpression);
+
+interface RuntimeStepAgentMessageConfig {
+  role: string;
+  text: RuntimeWorkflowPrompt;
+}
+
+export interface StepWhenConfig {
+  value: unknown;
+  equals?: JsonInput | undefined;
+}
+
+export interface StepConfig<
+  RunInput extends object = EmptyInput,
+  Steps extends WorkflowSteps = EmptySteps,
+> {
+  app?: StepAppConfig<RunInput, Steps> | undefined;
+  agent?: StepAgentConfig<RunInput, Steps> | undefined;
+  inputs?:
+    | Record<string, unknown>
+    | ((scope: StepScope<RunInput, Steps>) => Record<string, unknown>)
+    | undefined;
+  when?: StepWhenConfig | undefined;
+  timeoutSeconds?: number | undefined;
+  metadata?: JsonObjectInput | undefined;
+}
+
+interface StepRefProxy {
+  readonly [key: string]: StepRefProxy;
+}
+
+interface StepScopeRefs<Output = unknown> {
+  readonly outputs: RefView<Output>;
+  readonly inputs: StepRefProxy;
+}
+
+type WorkflowSteps = Record<string, unknown>;
+
+type RefView<T> = T extends readonly unknown[]
+  ? StepRefProxy
+  : T extends object
+  ? StepRefProxy & { readonly [K in keyof T]: RefView<T[K]> }
+  : StepRefProxy;
+
+type ScopeRefObject<T extends object> = StepRefProxy & {
+  readonly [K in keyof T]: RefView<T[K]>;
+};
+
+interface StepScope<
+  RunInput extends object = EmptyInput,
+  Steps extends WorkflowSteps = EmptySteps,
+> {
+  readonly input: ScopeRefObject<RunInput>;
+  readonly signal: StepRefProxy;
+  stepOutput(stepId: string, path: string): WorkflowRef;
+  stepInput(stepId: string, path: string): WorkflowRef;
+  readonly steps: {
+    readonly [K in keyof Steps]: StepScopeRefs<Steps[K]>;
+  } & { readonly [key: string]: StepScopeRefs };
+}
+
+interface EventScope {
+  readonly data: StepRefProxy;
+}
+
+interface ActivationScope {
+  readonly input: StepRefProxy;
+}
+
+/** Creates an event activation configuration for `.on()`. */
+export function event<ActivationInput extends object = EmptyInput>(
+  type: string,
+  mapInput?: (event: EventScope) => ActivationInput,
+  options?: EventActivationOptions,
+): EventActivationConfig<ActivationInput> {
+  return {
+    __workflowActivation: "event",
+    type,
+    mapInput,
+    options,
+  };
+}
+
+/** Creates a schedule activation configuration for `.on()`. */
+export function schedule<ActivationInput extends object = EmptyInput>(
+  cron: string,
+  mapInput?: (scope: ActivationScope) => ActivationInput,
+  options?: ScheduleActivationOptions,
+): ScheduleActivationConfig<ActivationInput> {
+  return {
+    __workflowActivation: "schedule",
+    cron,
+    mapInput,
+    options,
+  };
+}
+
+/** Starts a fluent workflow definition builder. `runAs` is required. */
+export function defineWorkflow<RunInput extends object = EmptyInput>(
+  options: DefineWorkflowOptions,
+): WorkflowBuilder<RunInput, EmptySteps> {
+  const runAs = options.runAs?.trim() ?? "";
+  if (!runAs) {
+    throw new Error("defineWorkflow requires runAs");
+  }
+  const id = options.id?.trim() ?? "";
+  if (!id) {
+    throw new Error("defineWorkflow requires id");
+  }
+  return new WorkflowBuilder<RunInput, EmptySteps>({
+    id,
+    runAs,
+    paused: options.paused ?? false,
+    activations: [],
+    steps: [],
+  });
+}
+
+/** Composes workflow prompt/message text from literals and captured references. */
+export function text(
+  // Indexed proxy properties are possibly undefined under
+  // `noUncheckedIndexedAccess`; the runtime proxy returns a reference for
+  // every string property.
+  ...parts: Array<string | StepRefProxy | WorkflowRef | undefined>
+): WorkflowTextExpression {
+  const normalized: Array<string | WorkflowRef> = [];
+  for (const part of parts) {
+    if (typeof part === "string") {
+      normalized.push(part);
+      continue;
+    }
+    if (isWorkflowRef(part)) {
+      normalized.push(part);
+      continue;
+    }
+    throw new Error("text() parts must be strings or workflow references");
+  }
+  return {
+    [WORKFLOW_REF]: true,
+    kind: "composedText",
+    parts: normalized,
+  };
+}
+
+/** Returns a workflow definition spec when a builder is passed where a raw spec is accepted. */
+export function resolveWorkflowDefinitionSpec(input: WorkflowDefinitionInput): WorkflowDefinitionSpec {
+  if (input instanceof WorkflowBuilder) {
+    return input.toSpec();
+  }
+  if (
+    typeof input === "object" &&
+    input !== null &&
+    "toSpec" in input &&
+    typeof input.toSpec === "function"
+  ) {
+    return input.toSpec();
+  }
+  return workflowDefinitionSpec(input as WorkflowDefinitionSpec);
+}
+
+type MergeRunInput<Current extends object, Next extends object> =
+  keyof Next extends never ? Current : Current & Next;
+
+export class WorkflowBuilder<
+  RunInput extends object = EmptyInput,
+  Steps extends WorkflowSteps = EmptySteps,
+> {
+  private readonly state: {
+    id: string;
+    runAs: string;
+    paused: boolean;
+    activations: WorkflowActivation[];
+    steps: WorkflowStep[];
+  };
+
+  constructor(state: WorkflowBuilder<RunInput, Steps>["state"]) {
+    this.state = state;
+  }
+
+  on<ActivationInput extends object>(
+    activation: ActivationConfig<ActivationInput>,
+  ): WorkflowBuilder<MergeRunInput<RunInput, ActivationInput>, Steps> {
+    if (activation.__workflowActivation === "event") {
+      const activationId = activation.options?.id?.trim() || activation.type;
+      const mapped = activation.mapInput
+        ? activation.mapInput({ data: createRefProxy("data", "signal") })
+        : undefined;
+      this.state.activations.push(
+        workflowActivation({
+          id: activationId,
+          paused: activation.options?.paused ?? false,
+          event: workflowEventActivation({
+            match: workflowEventMatch({
+              type: activation.type,
+              source: activation.options?.source ?? "",
+              subject: activation.options?.subject ?? "",
+            }),
+          }),
+          input:
+            mapped === undefined
+              ? undefined
+              : workflowValue({ object: captureObject(mapped, "signal") }),
+        }),
+      );
+      return this as unknown as WorkflowBuilder<
+        MergeRunInput<RunInput, ActivationInput>,
+        Steps
+      >;
+    }
+
+    const activationId = activation.options?.id?.trim() || activation.cron;
+    const mapped = activation.mapInput
+      ? activation.mapInput({ input: createRefProxy("", "input") })
+      : undefined;
+    this.state.activations.push(
+      workflowActivation({
+        id: activationId,
+        paused: activation.options?.paused ?? false,
+        schedule: {
+          cron: activation.cron,
+          timezone: activation.options?.timezone ?? "",
+        },
+        input:
+          mapped === undefined
+            ? undefined
+            : workflowValue({ object: captureObject(mapped, "input") }),
+      }),
+    );
+    return this as unknown as WorkflowBuilder<
+      MergeRunInput<RunInput, ActivationInput>,
+      Steps
+    >;
+  }
+
+  step<const StepId extends string, Output = unknown>(
+    stepId: StepId,
+    config: StepConfig<RunInput, Steps>,
+  ): WorkflowBuilder<RunInput, Steps & Record<StepId, Output>> {
+    const scope = createStepScope<RunInput, Steps>();
+    const step: WorkflowStep = { id: stepId };
+
+    if (config.inputs !== undefined) {
+      const mapped =
+        typeof config.inputs === "function" ? config.inputs(scope) : config.inputs;
+      step.inputs = captureObject(mapped, "input");
+    }
+
+    if (config.app !== undefined && config.agent !== undefined) {
+      throw new Error("workflow step cannot configure both app and agent actions");
+    }
+
+    if (config.app !== undefined) {
+      const input = config.app.input?.(scope);
+      step.app = workflowStepAppCall({
+        name: config.app.name,
+        operation: config.app.operation,
+        input:
+          input === undefined ? undefined : workflowValue(captureValue(input, "input")),
+        connection: config.app.connection,
+        instance: config.app.instance,
+        credentialMode: config.app.credentialMode,
+      });
+    }
+
+    if (config.agent !== undefined) {
+      const prompt =
+        typeof config.agent.prompt === "function"
+          ? config.agent.prompt(scope)
+          : config.agent.prompt;
+      const messages = config.agent.messages as unknown as
+        | readonly RuntimeStepAgentMessageConfig[]
+        | undefined;
+      step.agent = workflowStepAgentTurn({
+        provider: config.agent.provider,
+        model: config.agent.model,
+        sessionKey: config.agent.sessionKey,
+        prompt:
+          prompt === undefined ? undefined : workflowText(resolveWorkflowPrompt(prompt)),
+        messages: messages?.map((message) => {
+          const textValue =
+            typeof message.text === "function" ? message.text(scope) : message.text;
+          return workflowAgentMessage({
+            role: message.role,
+            text: workflowText(resolveWorkflowPrompt(textValue)),
+          });
+        }),
+        tools: config.agent.tools ? [...config.agent.tools] : undefined,
+        output: config.agent.output,
+        modelOptions: config.agent.modelOptions,
+      });
+    }
+
+    if (config.when !== undefined) {
+      const whenValue =
+        isWorkflowRef(config.when.value)
+          ? workflowValue(captureValue(config.when.value, "input"))
+          : typeof config.when.value === "object" &&
+              config.when.value !== null &&
+              "kind" in (config.when.value as WorkflowValue)
+            ? workflowValue(config.when.value as WorkflowValue)
+            : workflowValue(captureValue(config.when.value, "input"));
+      step.when = workflowStepWhen({
+        value: whenValue,
+        equals: config.when.equals,
+      });
+    }
+
+    if (config.timeoutSeconds !== undefined) {
+      step.timeoutSeconds = config.timeoutSeconds;
+    }
+    if (config.metadata !== undefined) {
+      step.metadata = config.metadata;
+    }
+
+    this.state.steps.push(workflowStep(step));
+    return this as unknown as WorkflowBuilder<
+      RunInput,
+      Steps & Record<StepId, Output>
+    >;
+  }
+
+  toSpec(): WorkflowDefinitionSpec {
+    const target: BoundWorkflowTarget | undefined =
+      this.state.steps.length === 0
+        ? undefined
+        : boundWorkflowTarget({ steps: this.state.steps });
+    return workflowDefinitionSpec({
+      id: this.state.id,
+      runAs: this.state.runAs,
+      paused: this.state.paused,
+      activations: this.state.activations,
+      target,
+    });
+  }
+}
+
+function createStepScope<
+  RunInput extends object,
+  Steps extends WorkflowSteps,
+>(): StepScope<RunInput, Steps> {
+  const steps = new Proxy(
+    {},
+    {
+      get(_target, stepId) {
+        if (typeof stepId !== "string") {
+          return undefined;
+        }
+        return {
+          outputs: createRefProxy("", "stepOutput", stepId) as StepRefProxy,
+          inputs: createRefProxy("", "stepInput", stepId) as StepRefProxy,
+        };
+      },
+    },
+  ) as Steps & WorkflowSteps;
+  return {
+    input: createRefProxy("", "input") as StepScope<RunInput, Steps>["input"],
+    signal: createRefProxy("", "signal") as StepRefProxy,
+    stepOutput(stepId: string, path: string): WorkflowRef {
+      return {
+        [WORKFLOW_REF]: true,
+        kind: "stepOutput",
+        stepId,
+        path,
+      };
+    },
+    stepInput(stepId: string, path: string): WorkflowRef {
+      return {
+        [WORKFLOW_REF]: true,
+        kind: "stepInput",
+        stepId,
+        path,
+      };
+    },
+    steps,
+  } as unknown as StepScope<RunInput, Steps>;
+}
+
+function createRefProxy(
+  path: string,
+  kind: WorkflowRefKind,
+  stepId?: string,
+): StepRefProxy {
+  const marker: WorkflowRef = {
+    [WORKFLOW_REF]: true,
+    kind,
+    path,
+    stepId,
+  };
+  return new Proxy(marker, {
+    get(target, prop, receiver) {
+      if (prop === WORKFLOW_REF) {
+        return true;
+      }
+      if (prop === "kind") {
+        return target.kind;
+      }
+      if (prop === "path") {
+        return target.path;
+      }
+      if (prop === "stepId") {
+        return target.stepId;
+      }
+      if (typeof prop === "symbol") {
+        return Reflect.get(target, prop, receiver);
+      }
+      const nextPath = target.path ? `${target.path}.${String(prop)}` : String(prop);
+      return createRefProxy(nextPath, target.kind, target.stepId);
+    },
+  }) as unknown as StepRefProxy;
+}
+
+function isCapturedRef(value: unknown): value is CapturedRef {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as CapturedRef)[WORKFLOW_REF] === true
+  );
+}
+
+function isWorkflowRef(value: unknown): value is WorkflowRef {
+  return (
+    isCapturedRef(value) &&
+    (value.kind === "input" ||
+      value.kind === "signal" ||
+      value.kind === "stepOutput" ||
+      value.kind === "stepInput")
+  );
+}
+
+function isTextExpression(value: unknown): value is WorkflowTextExpression {
+  return isCapturedRef(value) && value.kind === "composedText";
+}
+
+function resolveWorkflowPrompt(value: string | WorkflowTextExpression): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (isTextExpression(value)) {
+    return renderTextExpression(value);
+  }
+  throw new Error("workflow prompt must be a string or text() expression");
+}
+
+function renderTextExpression(expression: WorkflowTextExpression): string {
+  let rendered = "";
+  for (const part of expression.parts) {
+    if (typeof part === "string") {
+      rendered += part;
+      continue;
+    }
+    rendered += refToTemplatePlaceholder(part);
+  }
+  return rendered;
+}
+
+function refToTemplatePlaceholder(ref: WorkflowRef): string {
+  switch (ref.kind) {
+    case "input":
+      return `\${{ input.${ref.path} }}`;
+    case "signal":
+      return `\${{ signal.${ref.path} }}`;
+    case "stepOutput":
+      return `\${{ steps.${ref.stepId ?? ""}.outputs.${ref.path} }}`;
+    case "stepInput":
+      return `\${{ steps.${ref.stepId ?? ""}.inputs.${ref.path} }}`;
+  }
+}
+
+function captureObject(
+  value: object,
+  defaultKind: WorkflowRefKind,
+): Record<string, WorkflowValue> {
+  const out: Record<string, WorkflowValue> = {};
+  for (const [key, nested] of Object.entries(value)) {
+    out[key] = workflowValue(captureValue(nested, defaultKind));
+  }
+  return out;
+}
+
+function captureValue(value: unknown, defaultKind: WorkflowRefKind): WorkflowValue {
+  if (isCapturedRef(value)) {
+    if (value.kind === "composedText") {
+      throw new Error("workflow values cannot use text(); use text() only for prompts and messages");
+    }
+    switch (value.kind) {
+      case "input":
+        return { input: value.path };
+      case "signal":
+        return { signal: value.path };
+      case "stepOutput":
+        return { stepOutput: { stepId: value.stepId ?? "", path: value.path } };
+      case "stepInput":
+        return { stepInput: { stepId: value.stepId ?? "", path: value.path } };
+      case "literal":
+        return { literal: value.value };
+      case "template":
+        return { template: workflowText(value.template) };
+      default: {
+        const exhaustive: never = value;
+        throw new Error(`unsupported workflow ref kind: ${String(exhaustive)}`);
+      }
+    }
+  }
+
+  if (Array.isArray(value)) {
+    return {
+      array: value.map((item) => workflowValue(captureValue(item, defaultKind))),
+    };
+  }
+
+  if (value !== null && typeof value === "object") {
+    return {
+      object: captureObject(value as Record<string, unknown>, defaultKind),
+    };
+  }
+
+  return { literal: value as JsonInput };
+}

--- a/sdk/typescript/src/workflow-service.ts
+++ b/sdk/typescript/src/workflow-service.ts
@@ -1,0 +1,144 @@
+/**
+ * Hand-written workflow service client extensions.
+ *
+ * @module
+ */
+
+import { fromWireWorkflowDefinitionSpec } from "./internal/codec/workflow.ts";
+import {
+  createHostServiceGrpcTransport,
+  hostServiceMetadataInterceptors,
+  parseHostServiceTarget,
+  requireHostServiceTarget,
+} from "./host-service.ts";
+import {
+  resolveWorkflowDefinitionSpec,
+  WorkflowBuilder,
+  type WorkflowDefinitionInput,
+} from "./workflow-define.ts";
+import type { WorkflowValue as ProviderWorkflowValue } from "./providers/workflow.ts";
+import {
+  Workflow as GeneratedWorkflow,
+  type WorkflowDefinition,
+  type WorkflowDefinitionSpec,
+} from "./workflow.ts";
+import type { Init } from "./rpc_support.ts";
+import {
+  workflowDefinitionSpecToProto,
+  type WorkflowDefinitionSpec as BuilderWorkflowDefinitionSpec,
+} from "./providers/workflow.ts";
+
+export type { WorkflowDefinitionInput };
+
+type WorkflowServiceDefinitionInput =
+  | WorkflowDefinitionInput
+  | Init<WorkflowDefinitionSpec>;
+
+function toClientWorkflowDefinitionSpec(
+  spec: BuilderWorkflowDefinitionSpec,
+): import("./workflow.ts").WorkflowDefinitionSpec {
+  const proto = workflowDefinitionSpecToProto(spec);
+  if (proto === undefined) {
+    throw new Error("workflow definition spec is required");
+  }
+  return fromWireWorkflowDefinitionSpec(proto);
+}
+
+function providerWorkflowValueNeedsBridge(value: ProviderWorkflowValue): boolean {
+  const kind = value.kind;
+  if (kind?.case === "input" || kind?.case === "signal") {
+    return typeof kind.value === "string";
+  }
+  if (kind?.case === "object" && kind.value) {
+    return Object.values(kind.value).some(providerWorkflowValueNeedsBridge);
+  }
+  return false;
+}
+
+function authoredWorkflowDefinitionSpecNeedsBridge(
+  spec: BuilderWorkflowDefinitionSpec,
+): boolean {
+  for (const activation of spec.activations ?? []) {
+    if (activation.input !== undefined && providerWorkflowValueNeedsBridge(activation.input)) {
+      return true;
+    }
+  }
+  for (const step of spec.target?.steps ?? []) {
+    if (step.app?.input !== undefined && providerWorkflowValueNeedsBridge(step.app.input)) {
+      return true;
+    }
+    if (step.when?.value !== undefined && providerWorkflowValueNeedsBridge(step.when.value)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function resolveApplyDefinitionSpec(
+  spec: unknown,
+): import("./workflow.ts").WorkflowDefinitionSpec | undefined {
+  if (spec === undefined || spec === null) {
+    return undefined;
+  }
+  if (spec instanceof WorkflowBuilder) {
+    return toClientWorkflowDefinitionSpec(spec.toSpec());
+  }
+  if (
+    typeof spec === "object" &&
+    "toSpec" in spec &&
+    typeof spec.toSpec === "function"
+  ) {
+    return toClientWorkflowDefinitionSpec(
+      resolveWorkflowDefinitionSpec(spec as WorkflowDefinitionInput),
+    );
+  }
+  if (
+    typeof spec === "object" &&
+    "id" in spec &&
+    "runAs" in spec &&
+    authoredWorkflowDefinitionSpecNeedsBridge(spec as BuilderWorkflowDefinitionSpec)
+  ) {
+    return toClientWorkflowDefinitionSpec(
+      resolveWorkflowDefinitionSpec(spec as WorkflowDefinitionInput),
+    );
+  }
+  return undefined;
+}
+
+/** Workflow client that accepts fluent workflow builders in applyDefinition. */
+export class Workflow extends GeneratedWorkflow {
+  static connect(
+    options?: Parameters<typeof GeneratedWorkflow.connect>[0],
+  ): Workflow {
+    const { target, token } = requireHostServiceTarget("workflow");
+    const transport = createHostServiceGrpcTransport(
+      parseHostServiceTarget("workflow", target),
+      hostServiceMetadataInterceptors(token, options?.name?.trim() ?? ""),
+    );
+    return new Workflow(transport, {
+      context: options?.context,
+      timeoutMs: options?.timeoutMs,
+    });
+  }
+
+  override async applyDefinition(
+    provider: string,
+    idempotencyKey: string,
+    spec?: WorkflowServiceDefinitionInput,
+  ): Promise<WorkflowDefinition>;
+  override async applyDefinition(
+    provider: string,
+    idempotencyKey: string,
+    spec?: unknown,
+  ): Promise<WorkflowDefinition> {
+    const resolved = resolveApplyDefinitionSpec(spec);
+    if (resolved !== undefined) {
+      return super.applyDefinition(provider, idempotencyKey, resolved);
+    }
+    return super.applyDefinition(
+      provider,
+      idempotencyKey,
+      spec as Init<WorkflowDefinitionSpec> | undefined,
+    );
+  }
+}

--- a/sdk/typescript/tests/workflow-define.test.ts
+++ b/sdk/typescript/tests/workflow-define.test.ts
@@ -1,0 +1,166 @@
+import { expect, test } from "bun:test";
+
+import { fromWireWorkflowDefinitionSpec } from "../src/internal/codec/workflow.ts";
+import {
+  Workflow,
+  defineWorkflow,
+  event,
+  schedule,
+  text,
+} from "../src/index.ts";
+import { workflowDefinitionSpecToProto } from "../src/providers/workflow.ts";
+
+test("workflow builder infers mapped inputs and accumulates typed step references", () => {
+  const definition = defineWorkflow({
+    id: "example",
+    runAs: "service_account:workflow-runner",
+  })
+    .on(schedule("0 * * * *", (input) => ({ accountId: input.input.accountId })))
+    .on(event("deal.updated", (eventInput) => ({ dealId: eventInput.data.dealId })))
+    .step<"extract", { rowId: string }>("extract", {
+      app: {
+        name: "dealHub",
+        operation: "extractRow",
+        input: ({ input }) => ({ accountId: input.accountId }),
+      },
+    })
+    .step("passThrough", {
+      app: {
+        name: "dealHub",
+        operation: "passThrough",
+        input: ({ input }) => input,
+      },
+    })
+    .step("summarize", {
+      agent: {
+        provider: "openai",
+        prompt: ({ steps }) => text("Extracted ", steps.extract.outputs.rowId),
+      },
+    });
+
+  const spec = definition.toSpec();
+  expect(spec.id).toBe("example");
+  expect(spec.runAs).toBe("service_account:workflow-runner");
+  expect(spec.activations).toHaveLength(2);
+  expect(spec.activations?.[0]?.input?.kind).toEqual({
+    case: "object",
+    value: {
+      accountId: { kind: { case: "input", value: "accountId" } },
+    },
+  });
+  expect(spec.activations?.[1]?.input?.kind).toEqual({
+    case: "object",
+    value: {
+      dealId: { kind: { case: "signal", value: "data.dealId" } },
+    },
+  });
+  expect(spec.target?.steps).toHaveLength(3);
+  expect(spec.target?.steps?.[1]?.app?.input?.kind).toEqual({ case: "input", value: "" });
+  const prompt = spec.target?.steps?.[2]?.agent?.prompt;
+  expect(typeof prompt === "object" && prompt !== null ? prompt.template : prompt).toBe(
+    "Extracted ${{ steps.extract.outputs.rowId }}",
+  );
+
+  const applyBuilder = (workflow: Workflow) =>
+    workflow.applyDefinition("provider", "workflow-definition-key", definition);
+  void applyBuilder;
+});
+
+test("materialized workflow spec bridges to client path encoding", () => {
+  const definition = defineWorkflow({
+    id: "bridge-example",
+    runAs: "service_account:workflow-runner",
+  })
+    .on(schedule("0 * * * *", (input) => ({ accountId: input.input.accountId })))
+    .step("extract", {
+      app: {
+        name: "dealHub",
+        operation: "extractRow",
+        input: ({ input }) => ({ accountId: input.accountId }),
+      },
+    });
+
+  const providerSpec = definition.toSpec();
+  const clientSpec = fromWireWorkflowDefinitionSpec(
+    workflowDefinitionSpecToProto(providerSpec)!,
+  );
+
+  expect(clientSpec.activations[0]?.input?.kind).toEqual({
+    case: "object",
+    value: {
+      fields: {
+        accountId: {
+          kind: {
+            case: "input",
+            value: { path: "accountId" },
+          },
+        },
+      },
+    },
+  });
+  const stepInput =
+    clientSpec.target?.steps?.[0]?.action?.case === "app"
+      ? clientSpec.target.steps[0].action.value.input?.kind
+      : undefined;
+  expect(stepInput).toEqual({
+    case: "object",
+    value: {
+      fields: {
+        accountId: {
+          kind: {
+            case: "input",
+            value: { path: "accountId" },
+          },
+        },
+      },
+    },
+  });
+});
+
+test("workflow builder captures reference values in when guards", () => {
+  let guardValue: unknown;
+  const withSource = defineWorkflow({
+    id: "when-example",
+    runAs: "service_account:workflow-runner",
+  }).step("source", {
+    app: {
+      name: "dealHub",
+      operation: "extractRow",
+      input: (scope) => {
+        guardValue = scope.input.accountId;
+        return { accountId: scope.input.accountId };
+      },
+    },
+  });
+
+  const spec = withSource
+    .step("guard", {
+      when: { value: guardValue, equals: "ready" },
+    })
+    .toSpec();
+
+  expect(spec.target?.steps?.[1]?.when?.value?.kind).toEqual({
+    case: "input",
+    value: "accountId",
+  });
+});
+
+test("workflow builder rejects both app and agent on the same step", () => {
+  const definition = defineWorkflow({
+    id: "invalid-step",
+    runAs: "service_account:workflow-runner",
+  });
+
+  expect(() =>
+    definition.step("broken", {
+      app: {
+        name: "dealHub",
+        operation: "extractRow",
+      },
+      agent: {
+        provider: "openai",
+        prompt: "summarize",
+      },
+    }),
+  ).toThrow("workflow step cannot configure both app and agent actions");
+});


### PR DESCRIPTION
This PR gives workflow authors a typed, handwritten builder surface across TypeScript, Python, Go, and Rust. Builders stay at the public SDK boundary, preserve references such as `steps.extract.outputs.summary`, and lower into the existing workflow definition and apply messages without editing sdkgen-generated files.

A TypeScript workflow can be authored with the builder and applied directly:

```ts
import { defineWorkflow, event, text } from "@valon-technologies/gestalt";

const definition = defineWorkflow({
  id: "extractRow",
  runAs: "service_account:deal-hub-extraction",
})
  .on(event("deal_hub.analyses.extract.requested", (e) => ({
    analysisId: e.data.analysisId,
    rowId: e.data.rowId,
  })))
  .step<"extract", { summary: string }>("extract", {
    app: {
      name: "dealHub",
      operation: "analyses.extractRowWorkflow",
      input: (s) => ({
        analysisId: s.input.analysisId,
        rowId: s.input.rowId,
      }),
    },
  })
  .step("summarize", {
    agent: {
      provider: "claude",
      model: "claude-opus-4-8",
      prompt: (s) =>
        text("Summarize this extraction: ", s.steps.extract.outputs.summary),
    },
  });

await workflow.applyDefinition(
  "workflow-provider",
  "extract-row-definition",
  definition,
);
```

The equivalent declarative definition is:

```yaml
workflows:
  definitions:
    extractRow:
      runAs: service_account:deal-hub-extraction
      on:
        on_extract_requested:
          event:
            type: deal_hub.analyses.extract.requested
          input:
            analysisId: "${{ signal.data.analysisId }}"
            rowId: "${{ signal.data.rowId }}"
      steps:
        - id: extract
          app:
            name: dealHub
            operation: analyses.extractRowWorkflow
            input:
              analysisId: "${{ input.analysisId }}"
              rowId: "${{ input.rowId }}"
        - id: summarize
          agent:
            provider: claude
            model: claude-opus-4-8
            prompt: "Summarize this extraction: ${{ steps.extract.outputs.summary }}"
```