### PR TITLE
Remove legacy workflow runAs compatibility

### DIFF
--- a/gestaltd/core/subjects.go
+++ b/gestaltd/core/subjects.go
@@ -6,9 +6,8 @@ import "strings"
 // ClientInfo credentials minted via RFC 7591 dynamic client registration.
 const GestaltdSubjectID = "system:gestaltd"
 
-// TODO(#1823): Add first-class run-as subject and external-identity grant
-// provisioning instead of relying on opaque subject IDs plus separate tuple
-// seeding.
+// RunAsSubject is retained for agent and app-invoke delegation. Workflow
+// definitions store their run-as identity as a plain subject ID string.
 type RunAsSubject struct {
 	SubjectID string
 }

--- a/gestaltd/core/workflow/workflow.go
+++ b/gestaltd/core/workflow/workflow.go
@@ -203,7 +203,7 @@ type Run struct {
 	Steps                []StepExecution
 	Trigger              RunTrigger
 	CreatedBy            string
-	RunAs                *core.RunAsSubject
+	RunAs                string
 	CreatedAt            *time.Time
 	StartedAt            *time.Time
 	CompletedAt          *time.Time
@@ -242,7 +242,7 @@ type Schedule struct {
 	DefinitionID string
 	Paused       bool
 	CreatedBy    string
-	RunAs        *core.RunAsSubject
+	RunAs        string
 	CreatedAt    *time.Time
 	UpdatedAt    *time.Time
 	NextRunAt    *time.Time
@@ -255,7 +255,7 @@ type EventTrigger struct {
 	DefinitionID string
 	Paused       bool
 	CreatedBy    string
-	RunAs        *core.RunAsSubject
+	RunAs        string
 	CreatedAt    *time.Time
 	UpdatedAt    *time.Time
 }
@@ -270,7 +270,7 @@ type Definition struct {
 	CreatedAt    *time.Time
 	UpdatedAt    *time.Time
 	ProviderName string
-	RunAs        *core.RunAsSubject
+	RunAs        string
 }
 
 type DefinitionSpec struct {
@@ -278,7 +278,7 @@ type DefinitionSpec struct {
 	Target      Target
 	Activations []Activation
 	Paused      bool
-	RunAs       *core.RunAsSubject
+	RunAs       string
 }
 
 type ScheduleActivation struct {

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -1477,12 +1477,8 @@ func setWorkflowFixture(cfg *config.Config, app string, workflow *workflowFixtur
 	}
 }
 
-func workflowFixtureRunAs(app string) *config.WorkflowRunAsConfig {
-	return &config.WorkflowRunAsConfig{
-		Subject: &config.WorkflowRunAsSubjectConfig{
-			ID: "service_account:" + strings.TrimSpace(app) + "-workflow",
-		},
-	}
+func workflowFixtureRunAs(app string) string {
+	return "service_account:" + strings.TrimSpace(app) + "-workflow"
 }
 
 func workflowFixtureSteps(app, operation string, input map[string]any) []config.WorkflowStepConfig {
@@ -3882,11 +3878,7 @@ func TestBootstrapConfiguredWorkflowDefinitionRunAsAllowsUserCredentialedTarget(
 		},
 	})
 	nightly := cfg.Workflows.Definitions["nightly_sync"]
-	nightly.RunAs = &config.WorkflowRunAsConfig{
-		Subject: &config.WorkflowRunAsSubjectConfig{
-			ID: " service_account:roadmap-sync ",
-		},
-	}
+	nightly.RunAs = " service_account:roadmap-sync "
 	cfg.Workflows.Definitions["nightly_sync"] = nightly
 
 	factories := validFactories()
@@ -3929,9 +3921,7 @@ func TestBootstrapPersistsConfiguredWorkflowDefinitionRunAsUserSubject(t *testin
 		},
 	})
 	nightly := cfg.Workflows.Definitions["nightly_sync"]
-	nightly.RunAs = &config.WorkflowRunAsConfig{
-		Subject: &config.WorkflowRunAsSubjectConfig{ID: "user:ada"},
-	}
+	nightly.RunAs = "user:ada"
 	cfg.Workflows.Definitions["nightly_sync"] = nightly
 
 	factories := validFactories()
@@ -3981,9 +3971,7 @@ func TestBootstrapAppliesConfiguredWorkflowDefinitionsForRunAsConnectionOnUserDe
 	})
 	nightly := cfg.Workflows.Definitions["nightly_sync"]
 	nightly.Steps[0].App.Connection = "bot"
-	nightly.RunAs = &config.WorkflowRunAsConfig{
-		Subject: &config.WorkflowRunAsSubjectConfig{ID: "service_account:roadmap-sync"},
-	}
+	nightly.RunAs = "service_account:roadmap-sync"
 	cfg.Workflows.Definitions["nightly_sync"] = nightly
 
 	factories := validFactories()
@@ -4629,11 +4617,7 @@ func TestBootstrapConfiguredWorkflowEventDefinitionRunAsAllowsUserCredentialedTa
 		},
 	})
 	definition := cfg.Workflows.Definitions["task_updated"]
-	definition.RunAs = &config.WorkflowRunAsConfig{
-		Subject: &config.WorkflowRunAsSubjectConfig{
-			ID: "service_account:roadmap-events",
-		},
-	}
+	definition.RunAs = "service_account:roadmap-events"
 	cfg.Workflows.Definitions["task_updated"] = definition
 
 	factories := validFactories()

--- a/gestaltd/internal/bootstrap/workflow_config_definitions.go
+++ b/gestaltd/internal/bootstrap/workflow_config_definitions.go
@@ -65,7 +65,7 @@ func reconcileWorkflowConfigDefinitions(ctx context.Context, cfg *config.Config,
 		default:
 			return fmt.Errorf("bootstrap: get workflow definition %q for app %q: %w", desiredEntry.DefinitionID, appName, err)
 		}
-		runAs := definition.RunAs.SubjectRef()
+		runAs := strings.TrimSpace(definition.RunAs)
 		if err := workflowConfigValidateExecutionTarget(cfg, target, runAs); err != nil {
 			return fmt.Errorf("bootstrap: workflow definition %q for app %q: %w", desiredEntry.DefinitionKey, appName, err)
 		}
@@ -250,9 +250,8 @@ func workflowConfigDefinitionID(definitionKey string) string {
 	return "cfg_" + strings.TrimSpace(definitionKey)
 }
 
-func workflowConfigValidateExecutionTarget(cfg *config.Config, target coreworkflow.Target, runAs *core.RunAsSubject) error {
-	runAs = core.NormalizeRunAsSubject(runAs)
-	hasRunAs := runAs != nil
+func workflowConfigValidateExecutionTarget(cfg *config.Config, target coreworkflow.Target, runAs string) error {
+	hasRunAs := strings.TrimSpace(runAs) != ""
 	for i := range target.Steps {
 		step := target.Steps[i]
 		if step.App != nil {

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -763,7 +763,7 @@ type WorkflowsConfig struct {
 type WorkflowDefinitionConfig struct {
 	Provider string                              `yaml:"provider,omitempty"`
 	Steps    []WorkflowStepConfig                `yaml:"steps,omitempty"`
-	RunAs    *WorkflowRunAsConfig                `yaml:"runAs,omitempty"`
+	RunAs    string                              `yaml:"runAs,omitempty"`
 	Paused   bool                                `yaml:"paused,omitempty"`
 	On       map[string]WorkflowActivationConfig `yaml:"on,omitempty"`
 }
@@ -784,50 +784,6 @@ type WorkflowEventActivationConfig struct {
 	Type    string `yaml:"type,omitempty"`
 	Source  string `yaml:"source,omitempty"`
 	Subject string `yaml:"subject,omitempty"`
-}
-
-type WorkflowRunAsConfig struct {
-	Subject *WorkflowRunAsSubjectConfig `yaml:"subject,omitempty"`
-}
-
-// UnmarshalYAML accepts the canonical scalar service-account form while
-// retaining read compatibility with the legacy nested shape for one release.
-func (r *WorkflowRunAsConfig) UnmarshalYAML(value *yaml.Node) error {
-	if r == nil {
-		return nil
-	}
-	if value.Kind == yaml.ScalarNode {
-		var subjectID string
-		if err := value.Decode(&subjectID); err != nil {
-			return err
-		}
-		r.Subject = &WorkflowRunAsSubjectConfig{ID: strings.TrimSpace(subjectID)}
-		return nil
-	}
-	type legacy WorkflowRunAsConfig
-	var decoded legacy
-	if err := value.Decode(&decoded); err != nil {
-		return err
-	}
-	*r = WorkflowRunAsConfig(decoded)
-	return nil
-}
-
-type WorkflowRunAsSubjectConfig struct {
-	ID string `yaml:"id,omitempty"`
-}
-
-func (r *WorkflowRunAsConfig) SubjectRef() *core.RunAsSubject {
-	if r == nil || r.Subject == nil {
-		return nil
-	}
-	subjectID := strings.TrimSpace(r.Subject.ID)
-	if subjectID == "" {
-		return nil
-	}
-	return core.NormalizeRunAsSubject(&core.RunAsSubject{
-		SubjectID: subjectID,
-	})
 }
 
 type WorkflowTargetConfig struct {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -2870,9 +2870,7 @@ workflows:
   definitions:
     nightly:
       provider: temporal
-      runAs:
-        subject:
-          id: service_account:roadmap-workflow
+      runAs: service_account:roadmap-workflow
       steps:
         - id: main
           app:
@@ -2887,9 +2885,7 @@ workflows:
             cron: "0 2 * * *"
     task_updated:
       provider: temporal
-      runAs:
-        subject:
-          id: service_account:roadmap-events
+      runAs: service_account:roadmap-events
       steps:
         - id: main
           app:
@@ -2924,11 +2920,7 @@ server:
 		}
 		wantScheduleDefinition := WorkflowDefinitionConfig{
 			Provider: "temporal",
-			RunAs: &WorkflowRunAsConfig{
-				Subject: &WorkflowRunAsSubjectConfig{
-					ID: "service_account:roadmap-workflow",
-				},
-			},
+			RunAs:    "service_account:roadmap-workflow",
 			Steps: workflowTestAppStepConfig("roadmap", "nightly_sync", providermanifestv1.ConnectionModeNone, map[string]any{
 				"source": "yaml",
 			}),
@@ -2946,11 +2938,7 @@ server:
 		}
 		wantEventDefinition := WorkflowDefinitionConfig{
 			Provider: "temporal",
-			RunAs: &WorkflowRunAsConfig{
-				Subject: &WorkflowRunAsSubjectConfig{
-					ID: "service_account:roadmap-events",
-				},
-			},
+			RunAs:    "service_account:roadmap-events",
 			Steps: workflowTestAppStepConfig("roadmap", "backfill_items", "", map[string]any{
 				"source": "event",
 			}),
@@ -2981,9 +2969,7 @@ workflows:
   definitions:
     review:
       provider: temporal
-      runAs:
-        subject:
-          id: service_account:roadmap-events
+      runAs: service_account:roadmap-events
       steps:
         - id: collect
           app:
@@ -3057,9 +3043,7 @@ workflows:
   definitions:
     nightly:
       provider: temporal
-      runAs:
-        subject:
-          id: service_account:roadmap-workflow
+      runAs: service_account:roadmap-workflow
       steps:
         - id: main
           app:
@@ -3089,9 +3073,7 @@ workflows:
   definitions:
     nightly:
       provider: temporal
-      runAs:
-        subject:
-          id: service_account:roadmap-workflow
+      runAs: service_account:roadmap-workflow
       steps:
         - id: main
           app:
@@ -3120,9 +3102,7 @@ workflows:
   definitions:
     nightly:
       provider: temporal
-      runAs:
-        subject:
-          id: service_account:roadmap-workflow
+      runAs: service_account:roadmap-workflow
       steps:
         - id: main
           app:
@@ -3146,9 +3126,7 @@ workflows:
   definitions:
     nightly:
       provider: temporal
-      runAs:
-        subject:
-          id: service_account:roadmap-workflow
+      runAs: service_account:roadmap-workflow
       steps:
         - id: diagnosis
           timeout: -500ms
@@ -3182,9 +3160,7 @@ workflows:
   definitions:
     nightly:
       provider: temporal
-      runAs:
-        subject:
-          id: service_account:roadmap-workflow
+      runAs: service_account:roadmap-workflow
       steps:
         - id: diagnosis
           timeout: 1s
@@ -3220,9 +3196,7 @@ workflows:
   definitions:
     nightly:
       provider: temporal
-      runAs:
-        subject:
-          id: service_account:roadmap-workflow
+      runAs: service_account:roadmap-workflow
       steps:
         - id: diagnosis
           timeout: 1s
@@ -3268,9 +3242,7 @@ workflows:
   definitions:
     nightly:
       provider: temporal
-      runAs:
-        subject:
-          id: service_account:roadmap-workflow
+      runAs: service_account:roadmap-workflow
       steps:
         - id: diagnosis
           app:
@@ -3299,9 +3271,7 @@ workflows:
   definitions:
     nightly:
       provider: temporal
-      runAs:
-        subject:
-          id: service_account:roadmap-workflow
+      runAs: service_account:roadmap-workflow
       steps:
         - id: diagnosis
           timeout: 1s
@@ -3343,9 +3313,7 @@ workflows:
   definitions:
     nightly:
       provider: temporal
-      runAs:
-        subject:
-          id: service_account:roadmap-workflow
+      runAs: service_account:roadmap-workflow
       steps:
         - id: diagnosis
           timeout: 1s
@@ -3384,9 +3352,7 @@ workflows:
   definitions:
     task_updated:
       provider: temporal
-      runAs:
-        subject:
-          id: service_account:roadmap-events
+      runAs: service_account:roadmap-events
       steps:
         - id: run
           timeout: 1s
@@ -3528,7 +3494,44 @@ server:
 		if err == nil {
 			t.Fatal("Load succeeded, want error")
 		}
-		if !strings.Contains(err.Error(), "workflows.definitions.nightly.runAs.subject.id is required") {
+		if !strings.Contains(err.Error(), "workflows.definitions.nightly.runAs is required") {
+			t.Fatalf("Load error = %v", err)
+		}
+	})
+
+	t.Run("nested runAs shape is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+apps:
+  roadmap:
+    source:
+      path: ./app/manifest.yaml
+workflows:
+  definitions:
+    nightly:
+      provider: temporal
+      runAs:
+        subject:
+          id: service_account:roadmap-workflow
+      steps:
+        - id: main
+          app:
+            name: roadmap
+            operation: nightly_sync
+providers:
+  workflow:
+    temporal:
+      source:
+        path: ./providers/workflow/temporal
+server:
+  encryptionKey: server-key
+`)
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load succeeded, want nested runAs error")
+		}
+		if !strings.Contains(err.Error(), "cannot unmarshal !!map into string") {
 			t.Fatalf("Load error = %v", err)
 		}
 	})
@@ -3545,9 +3548,7 @@ workflows:
   definitions:
     nightly:
       provider: temporal
-      runAs:
-        subject:
-          id: service_account:roadmap-workflow
+      runAs: service_account:roadmap-workflow
       steps:
         - id: main
           app:
@@ -3628,9 +3629,7 @@ workflows:
   definitions:
     nightly:
       provider: missing
-      runAs:
-        subject:
-          id: service_account:roadmap-workflow
+      runAs: service_account:roadmap-workflow
       steps:
         - id: main
           app:
@@ -3672,9 +3671,7 @@ workflows:
   definitions:
     nightly:
       provider: temporal
-      runAs:
-        subject:
-          id: service_account:roadmap-workflow
+      runAs: service_account:roadmap-workflow
       steps:
         - id: main
           app:
@@ -3721,9 +3718,7 @@ workflows:
   definitions:
     invalid:
       provider: temporal
-      runAs:
-        subject:
-          id: service_account:roadmap-workflow
+      runAs: service_account:roadmap-workflow
       steps:
         - id: main
           app:
@@ -3762,9 +3757,7 @@ workflows:
   definitions:
     invalid:
       provider: temporal
-      runAs:
-        subject:
-          id: service_account:roadmap-events
+      runAs: service_account:roadmap-events
       steps:
         - id: main
           app:
@@ -3807,9 +3800,7 @@ workflows:
   definitions:
     invalid:
       provider: temporal
-      runAs:
-        subject:
-          id: service_account:roadmap-events
+      runAs: service_account:roadmap-events
       steps:
         - id: main
           app:
@@ -3855,9 +3846,7 @@ workflows:
   definitions:
     invalid:
       provider: temporal
-      runAs:
-        subject:
-          id: service_account:roadmap-workflow
+      runAs: service_account:roadmap-workflow
       steps:
         - id: main
           app:

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -2040,19 +2040,12 @@ func validateWorkflowStepApps(cfg *Config, path string, steps []WorkflowStepConf
 	return nil
 }
 
-func normalizeWorkflowRunAs(path string, runAs *WorkflowRunAsConfig) (*WorkflowRunAsConfig, error) {
-	if runAs == nil {
-		return nil, fmt.Errorf("config validation: %s is required", path)
+func normalizeWorkflowRunAs(path string, runAs string) (string, error) {
+	runAs = strings.TrimSpace(runAs)
+	if runAs == "" {
+		return "", fmt.Errorf("config validation: %s is required", path)
 	}
-	if runAs.Subject == nil {
-		return nil, fmt.Errorf("config validation: %s.subject is required", path)
-	}
-	subject := *runAs.Subject
-	subject.ID = strings.TrimSpace(subject.ID)
-	if subject.ID == "" {
-		return nil, fmt.Errorf("config validation: %s.subject.id is required", path)
-	}
-	return &WorkflowRunAsConfig{Subject: &subject}, nil
+	return runAs, nil
 }
 
 func normalizeWorkflowSteps(cfg *Config, path string, steps []WorkflowStepConfig) error {

--- a/gestaltd/internal/daemon/e2e/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e/e2e_test.go
@@ -253,9 +253,7 @@ apps:
 workflows:
   definitions:
     nightly_sync:
-      runAs:
-        subject:
-          id: service_account:roadmap-workflow
+      runAs: "service_account:roadmap-workflow"
       steps:
         - id: sync
           app:
@@ -270,9 +268,7 @@ workflows:
           schedule:
             cron: "0 2 * * *"
     nightly_summary:
-      runAs:
-        subject:
-          id: service_account:roadmap-workflow
+      runAs: "service_account:roadmap-workflow"
       steps:
         - id: summarize
           timeout: 120s
@@ -290,9 +286,7 @@ workflows:
           schedule:
             cron: "0 3 * * *"
     roadmap_updated:
-      runAs:
-        subject:
-          id: service_account:roadmap-workflow
+      runAs: "service_account:roadmap-workflow"
       steps:
         - id: sync
           app:

--- a/gestaltd/internal/workflowwire/entities.go
+++ b/gestaltd/internal/workflowwire/entities.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/valon-technologies/gestalt/server/core"
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/internal/protoutil"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
@@ -185,7 +184,7 @@ func RunFromProto(run *proto.WorkflowRun) (*coreworkflow.Run, error) {
 		CurrentStepID:        run.GetCurrentStepId(),
 		Steps:                steps,
 		Trigger:              trigger,
-		RunAs:                runAsSubjectFromString(run.GetRunAs()),
+		RunAs:                strings.TrimSpace(run.GetRunAs()),
 		CreatedAt:            TimeFromProto(run.GetCreatedAt()),
 		StartedAt:            TimeFromProto(run.GetStartedAt()),
 		CompletedAt:          TimeFromProto(run.GetCompletedAt()),
@@ -234,7 +233,7 @@ func RunToProto(run *coreworkflow.Run) (*proto.WorkflowRun, error) {
 		Input:                inputStruct,
 		CurrentStepId:        run.CurrentStepID,
 		Steps:                steps,
-		RunAs:                runAsSubjectToString(run.RunAs),
+		RunAs:                strings.TrimSpace(run.RunAs),
 	}, nil
 }
 
@@ -251,7 +250,7 @@ func DefinitionSpecFromProto(definition *proto.WorkflowDefinitionSpec) (*corewor
 		Target:      TargetFromProto(definition.GetTarget()),
 		Activations: activations,
 		Paused:      definition.GetPaused(),
-		RunAs:       runAsSubjectFromString(definition.GetRunAs()),
+		RunAs:       strings.TrimSpace(definition.GetRunAs()),
 	}, nil
 }
 
@@ -272,7 +271,7 @@ func DefinitionSpecToProto(definition *coreworkflow.DefinitionSpec) (*proto.Work
 		Target:      target,
 		Activations: activations,
 		Paused:      definition.Paused,
-		RunAs:       runAsSubjectToString(definition.RunAs),
+		RunAs:       strings.TrimSpace(definition.RunAs),
 	}, nil
 }
 
@@ -293,7 +292,7 @@ func DefinitionFromProto(definition *proto.WorkflowDefinition) (*coreworkflow.De
 		CreatedAt:    TimeFromProto(definition.GetCreatedAt()),
 		UpdatedAt:    TimeFromProto(definition.GetUpdatedAt()),
 		ProviderName: definition.GetProvider(),
-		RunAs:        runAsSubjectFromString(definition.GetRunAs()),
+		RunAs:        strings.TrimSpace(definition.GetRunAs()),
 	}, nil
 }
 
@@ -318,7 +317,7 @@ func DefinitionToProto(definition *coreworkflow.Definition) (*proto.WorkflowDefi
 		CreatedAt:   TimeToProto(definition.CreatedAt),
 		UpdatedAt:   TimeToProto(definition.UpdatedAt),
 		Provider:    definition.ProviderName,
-		RunAs:       runAsSubjectToString(definition.RunAs),
+		RunAs:       strings.TrimSpace(definition.RunAs),
 	}, nil
 }
 
@@ -719,20 +718,4 @@ func TimeFromProto(t *timestamppb.Timestamp) *time.Time {
 	}
 	value := t.AsTime()
 	return &value
-}
-
-func runAsSubjectFromString(value string) *core.RunAsSubject {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return nil
-	}
-	return core.NormalizeRunAsSubject(&core.RunAsSubject{SubjectID: value})
-}
-
-func runAsSubjectToString(value *core.RunAsSubject) string {
-	value = core.NormalizeRunAsSubject(value)
-	if value == nil {
-		return ""
-	}
-	return value.SubjectID
 }

--- a/gestaltd/services/workflows/workflowmanager/manager_target.go
+++ b/gestaltd/services/workflows/workflowmanager/manager_target.go
@@ -56,12 +56,12 @@ func (m *Manager) resolveRequestProviderTarget(ctx context.Context, p *principal
 	return definition.ProviderName, definition.provider, definition.Definition.Target, definition.Definition.Generation, nil
 }
 
-func (m *Manager) executionPrincipal(runAs *core.RunAsSubject) (*principal.Principal, error) {
-	runAs = core.NormalizeRunAsSubject(runAs)
-	if runAs == nil || strings.TrimSpace(runAs.SubjectID) == "" {
+func (m *Manager) executionPrincipal(runAs string) (*principal.Principal, error) {
+	runAs = strings.TrimSpace(runAs)
+	if runAs == "" {
 		return nil, fmt.Errorf("%w: workflow run_as is required", invocation.ErrInvalidInvocation)
 	}
-	return invocation.RunAsPrincipal(nil, runAs), nil
+	return invocation.RunAsPrincipal(nil, &core.RunAsSubject{SubjectID: runAs}), nil
 }
 
 func (m *Manager) resolveTarget(ctx context.Context, p *principal.Principal, target coreworkflow.Target) (coreworkflow.Target, error) {

--- a/gestaltd/services/workflows/workflowmanager/manager_test.go
+++ b/gestaltd/services/workflows/workflowmanager/manager_test.go
@@ -78,8 +78,8 @@ func testWorkflowManagerWithGithub(t *testing.T, provider *testWorkflowProvider)
 	return testWorkflowManagerWithGithubInvoker(t, provider, nil)
 }
 
-func testWorkflowRunAsSubject() *core.RunAsSubject {
-	return &core.RunAsSubject{SubjectID: "service_account:workflow-runner"}
+func testWorkflowRunAsSubject() string {
+	return "service_account:workflow-runner"
 }
 
 func testWorkflowGithubProviders(t *testing.T) *registry.ProviderMap[core.Provider] {


### PR DESCRIPTION
This draft removes legacy nested workflow `runAs` compatibility from server config, core, and wire layers. Workflow identity is now a validated scalar subject ID; the richer `RunAsSubject` form remains only at generic agent and app-invocation delegation boundaries.