### PR TITLE
Improve provider command progress and confirmations

### DIFF
--- a/gestaltd/internal/daemon/e2e/provider_lifecycle_test.go
+++ b/gestaltd/internal/daemon/e2e/provider_lifecycle_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"fmt"
 	"net/http"
@@ -34,7 +35,7 @@ func TestE2EProviderAddDefaultsToPackageSource(t *testing.T) {
 	runGestaltd(t, "provider", "repo", "add", "local", indexURL, "--config", cfgPath)
 	out := runGestaltd(t, "provider", "add", "github.com/acme/providers/alpha", "--config", cfgPath, "--repo", "local", "--name", "alpha", "--no-lock")
 	assertContains(t, out, "Added app alpha")
-	assertContains(t, out, "Version: 1.2.3")
+	assertContains(t, out, "version 1.2.3")
 
 	cfg, err := config.Load(cfgPath)
 	if err != nil {
@@ -60,6 +61,77 @@ func TestE2EProviderAddDefaultsToPackageSource(t *testing.T) {
 	if got := entry.Source.PackageVersionConstraint(); got != "" {
 		t.Fatalf("Source.PackageVersionConstraint = %q, want empty", got)
 	}
+}
+
+func TestE2EProviderCommandProgressAndRepositoryMutationOutput(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "gestalt.yaml")
+	writeProviderLifecycleTestFile(t, cfgPath, "apiVersion: gestaltd.config/v8\napps:\n")
+	indexURL := writeProviderLifecycleIndex(t, dir)
+	env := []string{
+		"XDG_CONFIG_HOME=" + filepath.Join(dir, "xdg-config"),
+		"XDG_CACHE_HOME=" + filepath.Join(dir, "xdg-cache"),
+	}
+
+	stdout, stderr, err := runGestaltdStreamsWithEnv(env, "provider", "repo", "add", "local", indexURL, "--config", cfgPath)
+	if err != nil {
+		t.Fatalf("provider repo add: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+	assertContains(t, stderr, `Added provider repository "local"`)
+	if strings.TrimSpace(stdout) != "" {
+		t.Fatalf("provider repo add stdout = %q, want empty", stdout)
+	}
+
+	stdout, stderr, err = runGestaltdStreamsWithEnv(env, "provider", "search", "alpha", "--repo", "local", "--config", cfgPath)
+	if err != nil {
+		t.Fatalf("provider search: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+	assertContains(t, stdout, "local\tgithub.com/acme/providers/alpha\tAlpha")
+	if strings.Contains(stdout, "Fetching provider repository") {
+		t.Fatalf("provider search progress leaked to stdout: %s", stdout)
+	}
+	assertContains(t, stderr, `Fetching provider repository "local"`)
+
+	stdout, stderr, err = runGestaltdStreamsWithEnv(env, "provider", "info", "github.com/acme/providers/alpha", "--repo", "local", "--config", cfgPath)
+	if err != nil {
+		t.Fatalf("provider info: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+	assertContains(t, stdout, "local\tgithub.com/acme/providers/alpha\tAlpha")
+	assertContains(t, stderr, `Fetching provider repository "local"`)
+
+	stdout, stderr, err = runGestaltdStreamsWithEnv(env, "provider", "repo", "remove", "local", "--config", cfgPath)
+	if err != nil {
+		t.Fatalf("provider repo remove: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+	assertContains(t, stderr, `Removed provider repository "local"`)
+	if strings.TrimSpace(stdout) != "" {
+		t.Fatalf("provider repo remove stdout = %q, want empty", stdout)
+	}
+
+	stdout, stderr, err = runGestaltdStreamsWithEnv(env, "provider", "repo", "remove", "local", "--config", cfgPath)
+	if err == nil {
+		t.Fatalf("provider repo remove missing name succeeded\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+	if strings.Contains(stderr, `Removed provider repository`) {
+		t.Fatalf("missing repo remove reported success: stderr=%q", stderr)
+	}
+	if !strings.Contains(stdout+stderr, "not found") {
+		t.Fatalf("missing repo remove error = stdout:%q stderr:%q", stdout, stderr)
+	}
+
+	updateConfigPath := filepath.Join(dir, "update.yaml")
+	writeProviderLifecycleTestFile(t, updateConfigPath, fmt.Sprintf("apiVersion: gestaltd.config/v8\nproviderRepositories:\n  gestalt:\n    url: %s\n", indexURL))
+	stdout, stderr, err = runGestaltdStreamsWithEnv(env, "provider", "repo", "update", "--config", updateConfigPath)
+	if err != nil {
+		t.Fatalf("provider repo update: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+	assertContains(t, stderr, `Updated provider repository "gestalt"`)
+	if strings.TrimSpace(stdout) != "" {
+		t.Fatalf("provider repo update stdout = %q, want empty", stdout)
+	}
+	assertContains(t, stderr, `Fetching provider repository "gestalt"`)
 }
 
 func TestE2EProviderAddAndUpgradeWriteLockWithTokenedRepository(t *testing.T) {
@@ -114,9 +186,11 @@ packages:
 	writeProviderLifecycleTestFile(t, cfgPath, "apiVersion: gestaltd.config/v8\napps:\n")
 	env := []string{"XDG_CONFIG_HOME=" + xdgConfigHome}
 
-	out := runGestaltdWithEnv(t, env, "provider", "add", pkg, "--config", cfgPath, "--repo", "private", "--name", "alpha", "--version", "1.2.3", "--lockfile", lockPath)
-	assertContains(t, out, "Added app alpha")
-	assertContains(t, out, "Lockfile: "+lockPath)
+	stdout, stderr, err := runGestaltdStreamsWithEnv(env, "provider", "add", pkg, "--config", cfgPath, "--repo", "private", "--name", "alpha", "--version", "1.2.3", "--lockfile", lockPath)
+	if err != nil {
+		t.Fatalf("provider add: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+	assertProviderMutationStatusStderr(t, stdout, stderr, "Added app alpha", "Lockfile: "+lockPath)
 
 	cfg, err := config.Load(cfgPath)
 	if err != nil {
@@ -130,9 +204,11 @@ packages:
 	}
 	assertProviderLifecycleLockEntry(t, lockPath, "1.2.3", server.URL+"/"+metadata123)
 
-	out = runGestaltdWithEnv(t, env, "provider", "upgrade", "alpha", "--version", "1.3.0", "--config", cfgPath, "--lockfile", lockPath)
-	assertContains(t, out, "Updated app alpha version constraint to 1.3.0")
-	assertContains(t, out, "Lockfile: "+lockPath)
+	stdout, stderr, err = runGestaltdStreamsWithEnv(env, "provider", "upgrade", "alpha", "--version", "1.3.0", "--config", cfgPath, "--lockfile", lockPath)
+	if err != nil {
+		t.Fatalf("provider upgrade: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+	assertProviderMutationStatusStderr(t, stdout, stderr, "Updated app alpha version constraint to 1.3.0", "Lockfile: "+lockPath)
 	cfg, err = config.Load(cfgPath)
 	if err != nil {
 		t.Fatalf("Load after upgrade: %v", err)
@@ -143,6 +219,14 @@ packages:
 	assertProviderLifecycleLockEntry(t, lockPath, "1.3.0", server.URL+"/"+metadata130)
 	if got := authorizedIndexRequests.Load(); got < 3 {
 		t.Fatalf("authorized index requests = %d, want at least 3", got)
+	}
+
+	stdout, stderr, err = runGestaltdStreamsWithEnv(env, "provider", "remove", "alpha", "--kind", "app", "--config", cfgPath, "--lockfile", lockPath, "--quiet")
+	if err != nil {
+		t.Fatalf("quiet provider remove: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+	if stdout != "" || stderr != "" {
+		t.Fatalf("quiet provider remove output = stdout:%q stderr:%q, want both empty", stdout, stderr)
 	}
 }
 
@@ -167,27 +251,17 @@ func TestE2EProviderAddExactSourceAndRejectsRepeatedConfig(t *testing.T) {
 		t.Fatalf("MetadataURL = %q", got)
 	}
 
+	out, err = runGestaltdResult("provider", "add", "github.com/acme/providers/alpha", "--config", cfgPath, "--repo", "local", "--name", "alpha", "--exact-source", "--no-lock")
+	if err == nil {
+		t.Fatalf("duplicate provider add succeeded: %s", out)
+	}
+	assertContains(t, out, "already exists")
+
 	out, err = runGestaltdResult("provider", "add", "github.com/acme/providers/alpha", "--config", cfgPath, "--config", otherCfgPath, "--repo", "local", "--name", "beta", "--no-lock")
 	if err == nil {
 		t.Fatalf("provider add with repeated --config succeeded: %s", out)
 	}
 	assertContains(t, out, "only one --config")
-}
-
-func TestE2EProviderAddRejectsExistingName(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "gestalt.yaml")
-	writeProviderLifecycleTestFile(t, cfgPath, "apiVersion: gestaltd.config/v8\napps:\n  alpha:\n    source: env\n")
-	indexURL := writeProviderLifecycleIndex(t, dir)
-
-	runGestaltd(t, "provider", "repo", "add", "local", indexURL, "--config", cfgPath)
-	out, err := runGestaltdResult("provider", "add", "github.com/acme/providers/alpha", "--config", cfgPath, "--repo", "local", "--name", "alpha", "--no-lock")
-	if err == nil {
-		t.Fatalf("provider add duplicate succeeded: %s", out)
-	}
-	assertContains(t, out, "already exists")
 }
 
 func TestE2EProviderListOfflineAndLockStatus(t *testing.T) {
@@ -545,26 +619,39 @@ func runGestaltd(t *testing.T, args ...string) string {
 	return out
 }
 
-func runGestaltdWithEnv(t *testing.T, env []string, args ...string) string {
-	t.Helper()
-	out, err := runGestaltdResultWithEnv(env, args...)
-	if err != nil {
-		t.Fatalf("gestaltd %s failed: %v\n%s", strings.Join(args, " "), err, out)
-	}
-	return out
-}
-
 func runGestaltdResult(args ...string) (string, error) {
-	return runGestaltdResultWithEnv(nil, args...)
+	cmd := gestaltdCommand(args...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
 }
 
-func runGestaltdResultWithEnv(env []string, args ...string) (string, error) {
+func runGestaltdStreamsWithEnv(env []string, args ...string) (string, string, error) {
 	cmd := gestaltdCommand(args...)
 	if len(env) > 0 {
 		cmd.Env = append(os.Environ(), env...)
 	}
-	out, err := cmd.CombinedOutput()
-	return string(out), err
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return stdout.String(), stderr.String(), err
+}
+
+func assertProviderMutationStatusStderr(t *testing.T, stdout, stderr string, want ...string) {
+	t.Helper()
+	if strings.TrimSpace(stdout) != "" {
+		t.Fatalf("provider mutation stdout = %q, want empty", stdout)
+	}
+	for _, part := range want {
+		assertContains(t, stderr, part)
+	}
+	assertContains(t, stderr, "Running provider configuration and lock preflight")
+	assertContains(t, stderr, "Provider configuration and lock preflight succeeded.")
+	for _, leaked := range []string{"gestaltd-provider-preflight-", "gestaltd-lock-", "wrote lockfile"} {
+		if strings.Contains(stderr, leaked) {
+			t.Fatalf("provider mutation stderr leaked %q: %s", leaked, stderr)
+		}
+	}
 }
 
 func assertProviderLifecycleLockEntry(t *testing.T, lockPath, version, source string) {

--- a/gestaltd/internal/daemon/provider_registry.go
+++ b/gestaltd/internal/daemon/provider_registry.go
@@ -109,7 +109,11 @@ func runProviderRepoAdd(args []string) error {
 	}
 	if len(configPaths) > 0 {
 		path := operator.ResolveConfigPaths(configPaths)[0]
-		return editProjectProviderRepository(path, name, repoURL, false)
+		if err := editProjectProviderRepository(path, name, repoURL, false); err != nil {
+			return err
+		}
+		providerCommandStatus("Added provider repository %q", name)
+		return nil
 	}
 	storePath := providerregistry.UserRepositoryStorePath()
 	store, err := providerregistry.ReadRepositoryStore(storePath)
@@ -120,7 +124,11 @@ func runProviderRepoAdd(args []string) error {
 		store.Repositories = make(map[string]providerregistry.Repository)
 	}
 	store.Repositories[name] = providerregistry.Repository{URL: repoURL}
-	return providerregistry.WriteRepositoryStore(storePath, store)
+	if err := providerregistry.WriteRepositoryStore(storePath, store); err != nil {
+		return err
+	}
+	providerCommandStatus("Added provider repository %q", name)
+	return nil
 }
 
 func runProviderRepoRemove(args []string) error {
@@ -136,15 +144,26 @@ func runProviderRepoRemove(args []string) error {
 	name := strings.TrimSpace(fs.Arg(0))
 	if len(configPaths) > 0 {
 		path := operator.ResolveConfigPaths(configPaths)[0]
-		return removeProjectProviderRepository(path, name)
+		if err := removeProjectProviderRepository(path, name); err != nil {
+			return err
+		}
+		providerCommandStatus("Removed provider repository %q", name)
+		return nil
 	}
 	storePath := providerregistry.UserRepositoryStorePath()
 	store, err := providerregistry.ReadRepositoryStore(storePath)
 	if err != nil {
 		return err
 	}
+	if _, ok := store.Repositories[name]; !ok {
+		return fmt.Errorf("provider repository %q not found", name)
+	}
 	delete(store.Repositories, name)
-	return providerregistry.WriteRepositoryStore(storePath, store)
+	if err := providerregistry.WriteRepositoryStore(storePath, store); err != nil {
+		return err
+	}
+	providerCommandStatus("Removed provider repository %q", name)
+	return nil
 }
 
 func runProviderRepoList(args []string) error {
@@ -186,23 +205,28 @@ func runProviderRepoUpdate(args []string) error {
 		return err
 	}
 	for _, repo := range repos {
+		activity := providerCommandActivity("Fetching provider repository %q", repo.Name)
 		index, err := providerregistry.FetchIndex(context.Background(), nil, repo.URL, repo.Token)
 		if err != nil {
+			activity.Clear()
 			return fmt.Errorf("update provider repo %s: %w", repo.Name, err)
 		}
 		data, err := yaml.Marshal(index)
 		if err != nil {
+			activity.Clear()
 			return err
 		}
 		path := filepath.Join(cacheDir, repo.Name+".yaml")
 		tmp := path + ".tmp"
 		if err := os.WriteFile(tmp, data, 0o600); err != nil {
+			activity.Clear()
 			return err
 		}
 		if err := os.Rename(tmp, path); err != nil {
+			activity.Clear()
 			return err
 		}
-		fmt.Printf("updated %s\n", repo.Name)
+		activity.Finish(fmt.Sprintf("Updated provider repository %q", repo.Name))
 	}
 	return nil
 }
@@ -221,10 +245,13 @@ func runProviderSearch(args []string) error {
 		return err
 	}
 	for _, repo := range filterProviderRepositories(repos, *repoName) {
+		activity := providerCommandActivity("Fetching provider repository %q", repo.Name)
 		index, err := providerregistry.FetchIndex(context.Background(), nil, repo.URL, repo.Token)
 		if err != nil {
+			activity.Clear()
 			return fmt.Errorf("search provider repo %s: %w", repo.Name, err)
 		}
+		activity.Finish(fmt.Sprintf("Fetched provider repository %q", repo.Name))
 		for _, pkg := range slices.Sorted(maps.Keys(index.Packages)) {
 			entry := index.Packages[pkg]
 			haystack := strings.ToLower(pkg + " " + entry.DisplayName + " " + entry.Description)
@@ -253,10 +280,13 @@ func runProviderInfo(args []string) error {
 		return err
 	}
 	for _, repo := range filterProviderRepositories(repos, *repoName) {
+		activity := providerCommandActivity("Fetching provider repository %q", repo.Name)
 		index, err := providerregistry.FetchIndex(context.Background(), nil, repo.URL, repo.Token)
 		if err != nil {
+			activity.Clear()
 			return fmt.Errorf("info provider repo %s: %w", repo.Name, err)
 		}
+		activity.Finish(fmt.Sprintf("Fetched provider repository %q", repo.Name))
 		entry, ok := index.Packages[pkg]
 		if !ok {
 			continue
@@ -336,7 +366,7 @@ func runProviderAdd(args []string) error {
 	if err != nil {
 		return err
 	}
-	resolved, err := (&providerregistry.Resolver{}).Resolve(context.Background(), providerregistry.ResolveRequest{
+	resolved, err := providerCommandResolver().Resolve(context.Background(), providerregistry.ResolveRequest{
 		Package:           fs.Arg(0),
 		VersionConstraint: *version,
 		RepositoryName:    *repoName,
@@ -388,7 +418,7 @@ func runProviderAdd(args []string) error {
 	if err := applyProviderEntry(doc, apiVersion, entryKind, entryName, resolved, *version, *repoName, writePackageSource, setValues); err != nil {
 		return err
 	}
-	preflight, err := preflightProviderConfigMutation(primary, root, *lockfilePath, *noLock)
+	preflight, err := runProviderMutationPreflight(primary, root, *lockfilePath, *noLock)
 	if err != nil {
 		return err
 	}
@@ -401,9 +431,9 @@ func runProviderAdd(args []string) error {
 			return err
 		}
 	}
-	fmt.Printf("Added %s %s\nPackage: %s\nRepository: %s\nVersion: %s\nConfig: %s\n", entryKind, entryName, resolved.Package, resolved.RepositoryName, resolved.Version, result.ConfigPath)
+	providerCommandStatus("Added %s %s; package %s; repository %q; version %s; config %s", entryKind, entryName, resolved.Package, resolved.RepositoryName, resolved.Version, result.ConfigPath)
 	if result.LockWritten {
-		fmt.Printf("Lockfile: %s\n", result.LockfilePath)
+		providerCommandStatus("Lockfile: %s", result.LockfilePath)
 	}
 	return nil
 }
@@ -434,7 +464,7 @@ func runProviderRemove(args []string) error {
 		return err
 	}
 	deleteKey(targets[0].node, fs.Arg(0))
-	preflight, err := preflightProviderConfigMutation(primary, root, *lockfilePath, *noLock)
+	preflight, err := runProviderMutationPreflight(primary, root, *lockfilePath, *noLock)
 	if err != nil {
 		return err
 	}
@@ -442,9 +472,9 @@ func runProviderRemove(args []string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Removed %s %s\nConfig: %s\n", targets[0].kind, fs.Arg(0), result.ConfigPath)
+	providerCommandStatus("Removed %s %s; config %s", targets[0].kind, fs.Arg(0), result.ConfigPath)
 	if result.LockWritten {
-		fmt.Printf("Lockfile: %s\n", result.LockfilePath)
+		providerCommandStatus("Lockfile: %s", result.LockfilePath)
 	}
 	return nil
 }
@@ -478,7 +508,7 @@ func runProviderUpgrade(args []string) error {
 		if err != nil {
 			return err
 		}
-		preflight, err := preflightProviderConfigMutation(primary, root, *lockfilePath, false)
+		preflight, err := runProviderMutationPreflight(primary, root, *lockfilePath, false)
 		if err != nil {
 			return err
 		}
@@ -486,17 +516,54 @@ func runProviderUpgrade(args []string) error {
 		if err != nil {
 			return err
 		}
-		fmt.Printf("Updated %s %s version constraint to %s\nConfig: %s\n", targetKind, fs.Arg(0), *version, result.ConfigPath)
+		providerCommandStatus("Updated %s %s version constraint to %s; config %s", targetKind, fs.Arg(0), *version, result.ConfigPath)
 		if result.LockWritten {
-			fmt.Printf("Lockfile: %s\n", result.LockfilePath)
+			providerCommandStatus("Lockfile: %s", result.LockfilePath)
 		}
 		return nil
 	}
-	if err := lockConfig(configPaths, *lockfilePath, "", false); err != nil {
+	providerCommandStatus("Refreshing provider lock state...")
+	if _, err := operatorLifecycleWithCLIProgress().LockAtPaths(operator.ResolveConfigPaths(configPaths), *lockfilePath, ""); err != nil {
 		return err
 	}
-	fmt.Println("Refreshed provider lock state")
+	providerCommandStatus("Provider lock refresh succeeded.")
 	return nil
+}
+
+func providerCommandResolver() *providerregistry.Resolver {
+	return &providerregistry.Resolver{
+		OnRepositoryFetch: func(repo providerregistry.NamedRepository) {
+			providerCommandStatus("Resolving provider package from repository %q", repo.Name)
+		},
+	}
+}
+
+func providerCommandStatus(format string, args ...any) {
+	currentCLIReporter().Status(fmt.Sprintf(format, args...))
+}
+
+func providerCommandActivity(format string, args ...any) *TerminalActivity {
+	return currentCLIReporter().Start(fmt.Sprintf(format, args...))
+}
+
+func runProviderMutationPreflight(configPath string, root *yaml.Node, lockfilePath string, noLock bool) (*providerMutationPreflight, error) {
+	var activity *TerminalActivity
+	if noLock {
+		activity = providerCommandActivity("Running provider configuration preflight")
+	} else {
+		activity = providerCommandActivity("Running provider configuration and lock preflight")
+	}
+	preflight, err := preflightProviderConfigMutation(configPath, root, lockfilePath, noLock)
+	if err != nil {
+		activity.Clear()
+		return nil, err
+	}
+	if noLock {
+		activity.Finish("Provider configuration preflight succeeded.")
+	} else {
+		activity.Finish("Provider configuration and lock preflight succeeded.")
+	}
+	return preflight, nil
 }
 
 func loadProviderRepositories(configPaths []string) ([]providerregistry.NamedRepository, error) {
@@ -603,9 +670,11 @@ func removeProjectProviderRepository(path, name string) error {
 	if err != nil {
 		return err
 	}
-	if repos := mappingValueNodeLocal(doc, "providerRepositories"); repos != nil {
-		deleteKey(repos, name)
+	repos := mappingValueNodeLocal(doc, "providerRepositories")
+	if repos == nil || mappingValueNodeLocal(repos, name) == nil {
+		return fmt.Errorf("provider repository %q not found", name)
 	}
+	deleteKey(repos, name)
 	return writeConfigDocument(path, root)
 }
 

--- a/gestaltd/internal/providerregistry/registry.go
+++ b/gestaltd/internal/providerregistry/registry.go
@@ -91,7 +91,8 @@ type ResolveRequest struct {
 }
 
 type Resolver struct {
-	Client *http.Client
+	Client            *http.Client
+	OnRepositoryFetch func(NamedRepository)
 }
 
 func ValidateRepositoryName(name string) error {
@@ -155,6 +156,9 @@ func (r *Resolver) Resolve(ctx context.Context, req ResolveRequest) (*ResolvedPa
 	var matches []ResolvedPackage
 	var errs []error
 	for _, repo := range repos {
+		if r != nil && r.OnRepositoryFetch != nil {
+			r.OnRepositoryFetch(repo)
+		}
 		index, err := FetchIndex(ctx, r.client(), repo.URL, repo.Token)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("%s: %w", repo.Name, err))

--- a/gestaltd/internal/providerregistry/registry_test.go
+++ b/gestaltd/internal/providerregistry/registry_test.go
@@ -117,3 +117,27 @@ func TestResolveHonorsExplicitRepositorySelection(t *testing.T) {
 		t.Fatalf("Resolve picked %q, want explicitly selected %q", resolved.RepositoryName, "fork")
 	}
 }
+
+func TestResolveReportsEachRepositoryBeforeFetching(t *testing.T) {
+	t.Parallel()
+	server := newIndexServer(t)
+	var fetched []string
+	resolver := &Resolver{
+		Client: server.Client(),
+		OnRepositoryFetch: func(repo NamedRepository) {
+			fetched = append(fetched, repo.Name)
+		},
+	}
+	if _, err := resolver.Resolve(context.Background(), ResolveRequest{
+		Package: testPackage,
+		Repositories: []NamedRepository{
+			{Name: "gestalt", URL: server.URL + "/canonical.yaml"},
+			{Name: "fork", URL: server.URL + "/mirror.yaml"},
+		},
+	}); err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+	if got, want := strings.Join(fetched, ","), "gestalt,fork"; got != want {
+		t.Fatalf("repositories reported = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Add concise provider registry command progress while keeping search and result output clean on stdout. Show mutation preflight and completion status without exposing internal scratch details.

Before:

```text
$ gestaltd provider repo update --config gestalt.yaml
updated local
```

After:

```text
$ gestaltd provider repo update --config gestalt.yaml
# stderr:
Fetching provider repository "local"
Updated provider repository "local"

# stdout:
(empty)
```