### PR TITLE
Add provider package and release progress

### DIFF
--- a/gestaltd/internal/daemon/app_publish.go
+++ b/gestaltd/internal/daemon/app_publish.go
@@ -117,7 +117,7 @@ func runAppPublish(args []string) (err error) {
 	if manifestApp != strings.TrimSpace(*appName) {
 		return fmt.Errorf("%s: manifest source app %q does not match --app %q; update manifest source or pass the matching --app name", manifestPath, manifestApp, strings.TrimSpace(*appName))
 	}
-	releaseManifest, releaseVersion, releaseArchives, err := collectReleaseArchivesFromDirs([]string(distDirs), *version)
+	releaseManifest, releaseVersion, releaseArchives, err := collectReleaseArchivesFromDirsWithProgress([]string(distDirs), *version)
 	if err != nil {
 		return err
 	}
@@ -345,6 +345,7 @@ func buildAppPublishPlan(input appPublishPlanInput) (appPublishPlan, error) {
 
 	publishArtifacts := make([]appregistry.PublishArtifact, 0, len(sortedArchives))
 	artifactObjects := make([]appPublishObject, 0, len(sortedArchives))
+	hashProgress := startCommandProgress("Hashing %d app publish files", len(sortedArchives)+1)
 	for _, archive := range sortedArchives {
 		filename := filepath.Base(archive.Path)
 		rel := path.Join(artifactPrefix, filename)
@@ -395,6 +396,7 @@ func buildAppPublishPlan(input appPublishPlanInput) (appPublishPlan, error) {
 	if err != nil {
 		return appPublishPlan{}, err
 	}
+	hashProgress.done("Hashed %d app publish files", len(sortedArchives)+1)
 
 	indexRel := layout.IndexPath
 	return appPublishPlan{
@@ -439,6 +441,8 @@ func writeTempJSON(pattern string, data []byte) (string, error) {
 }
 
 func preflightAppPublishPlan(plan appPublishPlan) error {
+	objectCount := len(plan.ArtifactObjects) + 2 // artifacts, entry metadata, and the app index
+	progress := startCommandProgress("Checking %d remote app objects before upload", objectCount)
 	if err := preflightAppRegistryIndex(plan); err != nil {
 		return err
 	}
@@ -447,6 +451,7 @@ func preflightAppPublishPlan(plan appPublishPlan) error {
 			return err
 		}
 	}
+	progress.done("Checked %d remote app objects", objectCount)
 	return nil
 }
 
@@ -495,24 +500,44 @@ func uploadAppPublishPlan(plan appPublishPlan, sourceRef string) error {
 }
 
 func uploadAppPublishImmutableObjects(plan appPublishPlan, sourceRef string) error {
+	objectCount := len(plan.ArtifactObjects) + 1
+	progress := startCommandProgress("Uploading %d immutable app objects", objectCount)
+	stdoutLines := make([]string, 0, objectCount)
 	for _, object := range plan.ArtifactObjects {
-		if err := uploadAppPublishObjectIfNeeded(object, sourceRef); err != nil {
+		line, err := uploadAppPublishObjectIfNeeded(object, sourceRef)
+		if err != nil {
 			return err
 		}
+		if line != "" {
+			stdoutLines = append(stdoutLines, line)
+		}
 	}
-	return uploadAppPublishObjectIfNeeded(plan.EntryObject, sourceRef)
-}
-
-func uploadAppPublishObjectIfNeeded(object appPublishObject, sourceRef string) error {
-	matches, err := appPublishObjectMatchesExisting(object)
+	line, err := uploadAppPublishObjectIfNeeded(plan.EntryObject, sourceRef)
 	if err != nil {
 		return err
 	}
-	if matches {
-		_, _ = fmt.Fprintf(os.Stdout, "skipped existing %s\n", object.StorageURL)
-		return nil
+	if line != "" {
+		stdoutLines = append(stdoutLines, line)
 	}
-	return uploadAppPublishObject(object, sourceRef)
+	progress.done("Processed %d immutable app objects", objectCount)
+	for _, line := range stdoutLines {
+		_, _ = fmt.Fprintln(os.Stdout, line)
+	}
+	return nil
+}
+
+func uploadAppPublishObjectIfNeeded(object appPublishObject, sourceRef string) (string, error) {
+	matches, err := appPublishObjectMatchesExisting(object)
+	if err != nil {
+		return "", err
+	}
+	if matches {
+		return fmt.Sprintf("skipped existing %s", object.StorageURL), nil
+	}
+	if err := uploadAppPublishObject(object, sourceRef); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("uploaded %s", object.StorageURL), nil
 }
 
 func appPublishObjectMatchesExisting(object appPublishObject) (bool, error) {
@@ -544,13 +569,16 @@ func uploadAppPublishObject(object appPublishObject, sourceRef string) error {
 	if _, err := runProviderPublishCommand("gcloud", "storage", "cp", "--if-generation-match=0", "--custom-metadata="+metadata, object.LocalPath, object.StorageURL); err != nil {
 		return err
 	}
-	_, _ = fmt.Fprintf(os.Stdout, "uploaded %s\n", object.StorageURL)
 	return nil
 }
 
 func uploadAppRegistryIndex(plan appPublishPlan, sourceRef string) error {
 	indexPath := plan.IndexObject.StorageURL
+	progress := startCommandProgress("Updating app registry index")
 	for attempt := 1; attempt <= appPublishIndexUpdateAttempts; attempt++ {
+		if attempt > 1 {
+			progress.status("App registry index changed concurrently; retrying attempt %d/%d", attempt, appPublishIndexUpdateAttempts)
+		}
 		generation, existing, err := downloadAppRegistryObject(indexPath)
 		if err != nil {
 			return err
@@ -570,6 +598,7 @@ func uploadAppRegistryIndex(plan appPublishPlan, sourceRef string) error {
 			return err
 		}
 		if !changed {
+			progress.done("App registry index unchanged")
 			_, _ = fmt.Fprintf(os.Stdout, "skipped unchanged index for %s %s\n", plan.AppName, plan.Version)
 			return nil
 		}
@@ -584,11 +613,13 @@ func uploadAppRegistryIndex(plan appPublishPlan, sourceRef string) error {
 		if err := uploadAppRegistryIndexFile(tmpPath, indexPath, sourceRef, generation); err != nil {
 			_ = os.Remove(tmpPath)
 			if appPublishPreconditionFailed(err) && attempt < appPublishIndexUpdateAttempts {
+				progress.status("App registry index update conflict; retrying")
 				continue
 			}
 			return err
 		}
 		_ = os.Remove(tmpPath)
+		progress.done("Updated app registry index")
 		_, _ = fmt.Fprintf(os.Stdout, "updated %s\n", indexPath)
 		return nil
 	}

--- a/gestaltd/internal/daemon/cli_output.go
+++ b/gestaltd/internal/daemon/cli_output.go
@@ -8,6 +8,48 @@ import (
 	"time"
 )
 
+type commandProgress struct {
+	activity *TerminalActivity
+	started  time.Time
+}
+
+func startCommandProgress(format string, args ...any) *commandProgress {
+	activity := currentCLIReporter().Start(fmt.Sprintf(format, args...) + "...")
+	return &commandProgress{activity: activity, started: activity.started}
+}
+
+func (p *commandProgress) done(format string, args ...any) {
+	if p == nil {
+		return
+	}
+	message := fmt.Sprintf(format, args...) + " in " + elapsedSince(p.started)
+	if p.activity != nil {
+		p.activity.Finish(message)
+		p.activity = nil
+		return
+	}
+	currentCLIReporter().Status(message)
+}
+
+func progressStatus(format string, args ...any) {
+	currentCLIReporter().Status(fmt.Sprintf(format, args...))
+}
+
+func (p *commandProgress) status(format string, args ...any) {
+	if p == nil {
+		return
+	}
+	if p.activity != nil {
+		p.activity.Clear()
+		p.activity = nil
+	}
+	currentCLIReporter().Status(fmt.Sprintf(format, args...))
+}
+
+func elapsedSince(start time.Time) string {
+	return time.Since(start).Round(time.Millisecond).String()
+}
+
 const (
 	defaultActivityDelay    = 200 * time.Millisecond
 	defaultActivityInterval = 100 * time.Millisecond
@@ -224,6 +266,7 @@ type TerminalActivity struct {
 	reporter *TerminalReporter
 	state    *activityState
 	once     sync.Once
+	started  time.Time
 }
 
 // NewTerminalReporter creates a reporter writing to output. Callers should
@@ -243,23 +286,25 @@ func (r *TerminalReporter) Start(message string) *TerminalActivity {
 	if r.active != nil {
 		r.finishLocked(r.active, "")
 	}
+	now := time.Now()
 	state := &activityState{
 		message: strings.TrimSpace(message),
 		stop:    make(chan struct{}),
 	}
 	r.active = state
+	activity := &TerminalActivity{reporter: r, state: state, started: now}
 	if r.policy.Quiet {
-		return &TerminalActivity{reporter: r, state: state}
+		return activity
 	}
 	if !r.policy.Interactive || r.policy.NoProgress {
 		r.writeStableLocked(state.message)
 		state.started = true
-		return &TerminalActivity{reporter: r, state: state}
+		return activity
 	}
 	state.timer = time.AfterFunc(r.policy.ActivityDelay, func() {
 		r.activate(state)
 	})
-	return &TerminalActivity{reporter: r, state: state}
+	return activity
 }
 
 func (r *TerminalReporter) activate(state *activityState) {

--- a/gestaltd/internal/daemon/e2e/app_publish/app_publish_test.go
+++ b/gestaltd/internal/daemon/e2e/app_publish/app_publish_test.go
@@ -2,7 +2,10 @@ package app_publish
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -20,7 +23,7 @@ func TestRun_AppPublishDryRunPlansVersionedRegistryUploads(t *testing.T) {
 		"--output", outputDir,
 	)
 
-	out, err := runAppCommandResult(rootDir,
+	stdout, stderr, err := runAppCommandStreams(rootDir,
 		"publish",
 		"--bucket", "gs://gestalt-app-registry",
 		"--app", releaseTestAppName,
@@ -30,7 +33,7 @@ func TestRun_AppPublishDryRunPlansVersionedRegistryUploads(t *testing.T) {
 		"--dry-run",
 	)
 	if err != nil {
-		t.Fatalf("app publish failed: %v\n%s", err, out)
+		t.Fatalf("app publish failed: %v\nstdout=%s\nstderr=%s", err, stdout, stderr)
 	}
 	var plan struct {
 		Schema      string `json:"schema"`
@@ -46,8 +49,15 @@ func TestRun_AppPublishDryRunPlansVersionedRegistryUploads(t *testing.T) {
 			StorageURL string `json:"storageUrl"`
 		} `json:"indexObject"`
 	}
-	if err := json.Unmarshal(out, &plan); err != nil {
-		t.Fatalf("decode app publish plan: %v\n%s", err, out)
+	if err := json.Unmarshal(stdout, &plan); err != nil {
+		t.Fatalf("decode app publish plan: %v\nstdout=%s\nstderr=%s", err, stdout, stderr)
+	}
+	if strings.Contains(string(stdout), "[progress]") {
+		t.Fatalf("progress leaked into app publish JSON stdout: %s", stdout)
+	}
+	if !strings.Contains(string(stderr), "Inspecting and hashing 1 release archives") ||
+		!strings.Contains(string(stderr), "Hashing 2 app publish files") {
+		t.Fatalf("app publish progress missing from stderr: %s", stderr)
 	}
 	if plan.Schema != "gestaltd.app.publish.plan.v1" {
 		t.Fatalf("schema = %q", plan.Schema)
@@ -70,5 +80,87 @@ func TestRun_AppPublishDryRunPlansVersionedRegistryUploads(t *testing.T) {
 	wantIndex := "gs://gestalt-app-registry/apps/" + releaseTestAppName + "/index.json"
 	if plan.IndexObject.StorageURL != wantIndex {
 		t.Fatalf("indexObject.storageUrl = %q, want %q", plan.IndexObject.StorageURL, wantIndex)
+	}
+}
+
+func TestRun_AppPublishUploadsAndRetriesIndexWithProgress(t *testing.T) {
+	rootDir := t.TempDir()
+	pluginDir := newAppRegistryPublishFixture(t, rootDir)
+	initProviderPublishGitRepo(t, rootDir, "https://github.com/testowner/apps.git")
+	outputDir := t.TempDir()
+	const version = "0.0.0-snapshot.g651a5c30feb995c9364c38f63d0d5c3880bc2055"
+	const ref = "651a5c30feb995c9364c38f63d0d5c3880bc2055"
+	runProviderPackageCommand(t, pluginDir,
+		"--version", version,
+		"--output", outputDir,
+	)
+
+	binDir := t.TempDir()
+	statePath := filepath.Join(t.TempDir(), "index-first-update.failed")
+	fakeGcloud := filepath.Join(binDir, "gcloud")
+	if err := os.WriteFile(fakeGcloud, []byte(`#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = "storage" ] && [ "$2" = "objects" ] && [ "$3" = "describe" ]; then
+  if [[ "$4" == */index.json ]]; then
+    if [ -e "`+statePath+`" ]; then
+      printf '{"generation":"8"}\n'
+    else
+      printf '{"generation":"7"}\n'
+    fi
+    exit 0
+  fi
+  echo "not found" >&2
+  exit 1
+fi
+if [ "$1" = "storage" ] && [ "$2" = "cat" ]; then
+  printf '{"schemaVersion":1,"apps":{}}\n'
+  exit 0
+fi
+if [ "$1" = "storage" ] && [ "$2" = "cp" ]; then
+  if [[ "$5" == */index.json ]] && [ ! -e "`+statePath+`" ]; then
+    touch "`+statePath+`"
+    echo "precondition failed" >&2
+    exit 1
+  fi
+  exit 0
+fi
+echo "unexpected gcloud command" >&2
+exit 1
+`), 0o755); err != nil {
+		t.Fatalf("write fake gcloud: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	stdout, stderr, err := runAppCommandStreams(rootDir,
+		"publish",
+		"--bucket", "gs://gestalt-app-registry",
+		"--app", releaseTestAppName,
+		"--version", version,
+		"--ref", ref,
+		"--dist-dir", outputDir,
+	)
+	if err != nil {
+		t.Fatalf("app publish failed: %v\nstdout=%s\nstderr=%s", err, stdout, stderr)
+	}
+	gotStdout := string(stdout)
+	gotStderr := string(stderr)
+	for _, want := range []string{"uploaded gs://gestalt-app-registry/", "updated gs://gestalt-app-registry/apps/release-test/index.json"} {
+		if !strings.Contains(gotStdout, want) {
+			t.Fatalf("app publish stdout missing %q:\n%s", want, gotStdout)
+		}
+	}
+	for _, want := range []string{
+		"Checking 3 remote app objects before upload",
+		"Uploading 2 immutable app objects",
+		"Updating app registry index",
+		"App registry index update conflict; retrying",
+		"App registry index changed concurrently; retrying attempt 2/5",
+	} {
+		if !strings.Contains(gotStderr, want) {
+			t.Fatalf("app publish stderr missing %q:\n%s", want, gotStderr)
+		}
+	}
+	if strings.Contains(gotStderr, "not found") || strings.Contains(gotStderr, "precondition failed") {
+		t.Fatalf("raw gcloud diagnostics leaked into normal stderr:\n%s", gotStderr)
 	}
 }

--- a/gestaltd/internal/daemon/e2e/app_publish/helpers_test.go
+++ b/gestaltd/internal/daemon/e2e/app_publish/helpers_test.go
@@ -24,10 +24,14 @@ func gestaltdCommand(args ...string) *exec.Cmd {
 	return exec.Command(gestaltdBin, args...)
 }
 
-func runAppCommandResult(workDir string, args ...string) ([]byte, error) {
+func runAppCommandStreams(workDir string, args ...string) ([]byte, []byte, error) {
 	cmd := gestaltdCommand(append([]string{"app"}, args...)...)
 	cmd.Dir = workDir
-	return cmd.CombinedOutput()
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return stdout.Bytes(), stderr.Bytes(), err
 }
 
 func runProviderPackageCommand(t *testing.T, pluginDir string, args ...string) {

--- a/gestaltd/internal/daemon/e2e/provider_publish_test.go
+++ b/gestaltd/internal/daemon/e2e/provider_publish_test.go
@@ -93,7 +93,7 @@ providerSnapshotRepositories:
 		t.Fatalf("write config: %v", err)
 	}
 
-	out, err := runProviderCommandResult(pluginDir,
+	stdout, stderr, err := runProviderCommandStreams(pluginDir,
 		"publish",
 		"--config", configPath,
 		"--repo", "valon",
@@ -105,11 +105,18 @@ providerSnapshotRepositories:
 		"--format", "json",
 	)
 	if err != nil {
-		t.Fatalf("provider publish failed: %v\n%s", err, out)
+		t.Fatalf("provider publish failed: %v\nstdout=%s\nstderr=%s", err, stdout, stderr)
 	}
 	var plan providerPublishPlan
-	if err := json.Unmarshal(out, &plan); err != nil {
-		t.Fatalf("dry-run JSON did not parse: %v\n%s", err, out)
+	if err := json.Unmarshal(stdout, &plan); err != nil {
+		t.Fatalf("dry-run JSON did not parse: %v\nstdout=%s\nstderr=%s", err, stdout, stderr)
+	}
+	if strings.Contains(string(stdout), "[progress]") {
+		t.Fatalf("progress leaked into provider publish JSON stdout: %s", stdout)
+	}
+	if !strings.Contains(string(stderr), "Inspecting and hashing 1 release archives") ||
+		!strings.Contains(string(stderr), "Hashing 2 publish files") {
+		t.Fatalf("provider publish progress missing from stderr: %s", stderr)
 	}
 	if plan.Schema != providerPublishPlanSchema {
 		t.Fatalf("schema = %q, want %q", plan.Schema, providerPublishPlanSchema)
@@ -398,6 +405,82 @@ exit 1
 	}
 	if archiveUpload >= metadataUpload {
 		t.Fatalf("uploads are not phased archive -> metadata:\n%s", got)
+	}
+}
+
+func TestRun_ProviderPackageReleaseProgressStaysOnStderr(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		release     bool
+		version     string
+		stdoutWant  string
+		stderrWants []string
+	}{
+		{
+			name:       "package",
+			version:    "0.0.1-progress.1",
+			stdoutWant: "gestalt-app-ui-test_v0.0.1-progress.1.tar.gz",
+			stderrWants: []string{
+				"Discovering provider source",
+				"Validating provider source manifest",
+				"Building and hashing provider contents for generic archive",
+				"Built and hashed provider contents for generic archive",
+				"Assembling provider archive",
+				"Assembled provider archive",
+				"Generated 1 provider archive(s)",
+			},
+		},
+		{
+			name:       "release",
+			release:    true,
+			version:    "0.0.1-progress.2",
+			stdoutWant: "provider-release.yaml",
+			stderrWants: []string{
+				"Discovering release archives",
+				"Inspecting and hashing 1 release archives",
+				"Validating provider release metadata",
+				"Generated provider-release.yaml with 1 artifact(s)",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			pluginDir := newUIReleaseFixture(t, t.TempDir())
+			outputDir := t.TempDir()
+			if tc.release {
+				runProviderPackageCommand(t, pluginDir,
+					"--version", tc.version,
+					"--output", outputDir,
+				)
+			}
+			args := []string{"package", "--version", tc.version}
+			if tc.release {
+				args = []string{"release", "--dist-dir", outputDir, "--version", tc.version}
+			} else {
+				args = append(args, "--output", outputDir)
+			}
+			stdout, stderr, err := runProviderCommandStreams(pluginDir, args...)
+			if err != nil {
+				t.Fatalf("provider %s failed: %v\nstdout=%s\nstderr=%s", tc.name, err, stdout, stderr)
+			}
+			for _, want := range tc.stderrWants {
+				if strings.Contains(string(stdout), want) {
+					t.Fatalf("provider %s progress leaked into stdout: %s", tc.name, stdout)
+				}
+				if !strings.Contains(string(stderr), want) {
+					t.Fatalf("provider %s stderr missing %q: %s", tc.name, want, stderr)
+				}
+			}
+			if want := "created " + filepath.Join(outputDir, tc.stdoutWant); !strings.Contains(string(stdout), want) {
+				t.Fatalf("provider %s stdout missing %q: %s", tc.name, want, stdout)
+			}
+		})
 	}
 }
 

--- a/gestaltd/internal/daemon/e2e/provider_release_helpers_test.go
+++ b/gestaltd/internal/daemon/e2e/provider_release_helpers_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"bytes"
 	"context"
 	"flag"
 	"fmt"
@@ -64,6 +65,17 @@ func runProviderCommandResult(pluginDir string, args ...string) ([]byte, error) 
 	cmd := gestaltdCommand(cmdArgs...)
 	cmd.Dir = pluginDir
 	return cmd.CombinedOutput()
+}
+
+func runProviderCommandStreams(pluginDir string, args ...string) ([]byte, []byte, error) {
+	cmdArgs := append([]string{"provider"}, args...)
+	cmd := gestaltdCommand(cmdArgs...)
+	cmd.Dir = pluginDir
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return stdout.Bytes(), stderr.Bytes(), err
 }
 
 // runProviderPackageAndReleaseCommandResult keeps archive-creation tests focused

--- a/gestaltd/internal/daemon/provider_package.go
+++ b/gestaltd/internal/daemon/provider_package.go
@@ -46,6 +46,7 @@ func runProviderPackage(args []string) (err error) {
 		return fmt.Errorf("invalid --version: %w", err)
 	}
 
+	discoveryProgress := startCommandProgress("Discovering provider source")
 	manifestPath, err := providerpkg.FindManifestFile(".")
 	if err != nil {
 		return err
@@ -55,6 +56,9 @@ func runProviderPackage(args []string) (err error) {
 		return fmt.Errorf("resolve manifest path: %w", err)
 	}
 	sourceDir := filepath.Dir(manifestPath)
+	discoveryProgress.done("Discovered provider source manifest %s", filepath.Base(manifestPath))
+
+	validationProgress := startCommandProgress("Validating provider source manifest")
 	catalogSnapshot, err := snapshotSourceStaticCatalog(sourceDir)
 	if err != nil {
 		return err
@@ -97,20 +101,26 @@ func runProviderPackage(args []string) (err error) {
 	if err := removeStalePackageArchives(*outputDir, appName, releaseArchiveTargets(buildPlatforms)); err != nil {
 		return err
 	}
+	validationProgress.done("Validated provider source manifest for %s", appName)
 
+	archiveCount := 0
 	if len(buildPlatforms) > 0 {
 		for _, platform := range buildPlatforms {
+			platformName := providerpkg.PlatformString(platform.GOOS, platform.GOARCH)
 			_, err := buildPlatformArchive(manifestPath, appName, *version, platform, *outputDir)
 			if err != nil {
-				return fmt.Errorf("build %s: %w", providerpkg.PlatformString(platform.GOOS, platform.GOARCH), err)
+				return fmt.Errorf("build %s: %w", platformName, err)
 			}
+			archiveCount++
 		}
 	} else {
 		_, err := buildSourceArchive(manifestPath, appName, *version, *outputDir)
 		if err != nil {
 			return err
 		}
+		archiveCount++
 	}
+	progressStatus("Generated %d provider archive(s) in %s", archiveCount, *outputDir)
 
 	return nil
 }
@@ -295,7 +305,8 @@ func expandReleasePlatformValue(value string) (string, error) {
 
 func buildPlatformArchive(manifestPath, appName, version string, platform releasePlatform, outputDir string) (string, error) {
 	archiveName := platformArchiveName(appName, version, platform)
-	return createReleaseArchive(outputDir, archiveName, func(stagingDir string) (*providerpkg.StagedPreparedInstall, error) {
+	platformName := providerpkg.PlatformString(platform.GOOS, platform.GOARCH)
+	return createReleaseArchive(outputDir, archiveName, "platform "+platformName, func(stagingDir string) (*providerpkg.StagedPreparedInstall, error) {
 		return providerpkg.StageSourcePreparedInstallDir(manifestPath, stagingDir, providerpkg.StageSourcePreparedInstallOptions{
 			VersionOverride: version,
 			AppName:         appName,
@@ -305,13 +316,14 @@ func buildPlatformArchive(manifestPath, appName, version string, platform releas
 	})
 }
 
-func createReleaseArchive(outputDir, archiveName string, prepare func(stagingDir string) (*providerpkg.StagedPreparedInstall, error)) (string, error) {
+func createReleaseArchive(outputDir, archiveName, buildLabel string, prepare func(stagingDir string) (*providerpkg.StagedPreparedInstall, error)) (string, error) {
 	stagingDir, err := os.MkdirTemp("", "gestalt-release-*")
 	if err != nil {
 		return "", err
 	}
 	defer func() { _ = os.RemoveAll(stagingDir) }()
 
+	buildProgress := startCommandProgress("Building and hashing provider contents for %s", buildLabel)
 	staged, err := prepare(stagingDir)
 	if err != nil {
 		return "", err
@@ -319,10 +331,13 @@ func createReleaseArchive(outputDir, archiveName string, prepare func(stagingDir
 	if err := validateStagedReleaseCatalog(staged); err != nil {
 		return "", err
 	}
+	buildProgress.done("Built and hashed provider contents for %s", buildLabel)
 	archivePath := filepath.Join(outputDir, archiveName)
+	assemblyProgress := startCommandProgress("Assembling provider archive %s", archiveName)
 	if err := providerpkg.CreatePackageFromDir(stagingDir, archivePath); err != nil {
 		return "", err
 	}
+	assemblyProgress.done("Assembled provider archive %s", archiveName)
 
 	_, _ = fmt.Fprintf(os.Stdout, "created %s\n", archivePath)
 	return archivePath, nil
@@ -351,7 +366,7 @@ func currentReleasePlatform() string {
 
 func buildSourceArchive(manifestPath, appName, version, outputDir string) (string, error) {
 	archiveName := fmt.Sprintf("gestalt-app-%s_v%s.tar.gz", appName, version)
-	return createReleaseArchive(outputDir, archiveName, func(stagingDir string) (*providerpkg.StagedPreparedInstall, error) {
+	return createReleaseArchive(outputDir, archiveName, "generic archive", func(stagingDir string) (*providerpkg.StagedPreparedInstall, error) {
 		return providerpkg.StageSourcePreparedInstallDir(manifestPath, stagingDir, providerpkg.StageSourcePreparedInstallOptions{
 			VersionOverride: version,
 		})

--- a/gestaltd/internal/daemon/provider_publish.go
+++ b/gestaltd/internal/daemon/provider_publish.go
@@ -127,7 +127,7 @@ func runProviderPublish(args []string) (err error) {
 	if err != nil {
 		return fmt.Errorf("read --manifest: %w", err)
 	}
-	releaseManifest, releaseVersion, releaseArchives, err := collectReleaseArchivesFromDirs([]string(distDirs), *version)
+	releaseManifest, releaseVersion, releaseArchives, err := collectReleaseArchivesFromDirsWithProgress([]string(distDirs), *version)
 	if err != nil {
 		return err
 	}
@@ -144,10 +144,12 @@ func runProviderPublish(args []string) (err error) {
 		return fmt.Errorf("write release metadata: %w", err)
 	}
 
+	hashProgress := startCommandProgress("Hashing %d publish files", len(releaseArchives)+1)
 	files, sourceInfo, err := providerPublishFiles(repo, *manifestPath, sourceRef, releaseArchives, tmpDir)
 	if err != nil {
 		return err
 	}
+	hashProgress.done("Hashed %d publish files", len(files))
 	if *dryRun {
 		if *format == providerPublishFormatJSON {
 			return printProviderPublishPlanJSON(*repoName, sourceInfo, *version, files)
@@ -361,6 +363,7 @@ func newProviderPublishPlan(publishRepository string, sourceInfo providerPublish
 }
 
 func preflightProviderPublishFiles(files []providerPublishFile) error {
+	progress := startCommandProgress("Checking %d remote objects before upload", len(files))
 	for _, file := range files {
 		if err := validateProviderPublishMetadataFile(file); err != nil {
 			return err
@@ -373,6 +376,7 @@ func preflightProviderPublishFiles(files []providerPublishFile) error {
 			return fmt.Errorf("%s already exists; %s", file.StorageURL, republishCorruptObjectGuidance)
 		}
 	}
+	progress.done("Checked %d remote objects", len(files))
 	return nil
 }
 
@@ -387,15 +391,17 @@ func validateProviderPublishMetadataFile(file providerPublishFile) error {
 }
 
 func uploadProviderPublishFiles(files []providerPublishFile, sourceRef string) error {
-	for _, kind := range []string{providerPublishFileKindArchive, providerPublishFileKindMetadata} {
-		for _, file := range files {
-			if file.Kind != kind {
-				continue
-			}
-			if err := uploadProviderPublishFile(file, sourceRef); err != nil {
-				return err
-			}
+	progress := startCommandProgress("Uploading %d publish files", len(files))
+	uploaded := make([]string, 0, len(files))
+	for _, file := range files {
+		if err := uploadProviderPublishFile(file, sourceRef); err != nil {
+			return err
 		}
+		uploaded = append(uploaded, file.StorageURL)
+	}
+	progress.done("Uploaded %d publish files", len(files))
+	for _, storageURL := range uploaded {
+		_, _ = fmt.Fprintf(os.Stdout, "uploaded %s\n", storageURL)
 	}
 	return nil
 }
@@ -405,7 +411,6 @@ func uploadProviderPublishFile(file providerPublishFile, sourceRef string) error
 	if _, err := runProviderPublishCommand("gcloud", "storage", "cp", "--if-generation-match=0", "--custom-metadata="+metadata, file.LocalPath, file.StorageURL); err != nil {
 		return err
 	}
-	_, _ = fmt.Fprintf(os.Stdout, "uploaded %s\n", file.StorageURL)
 	return nil
 }
 

--- a/gestaltd/internal/daemon/provider_release_finalize.go
+++ b/gestaltd/internal/daemon/provider_release_finalize.go
@@ -40,13 +40,23 @@ func runProviderRelease(args []string) (err error) {
 		}
 	}
 
-	releaseManifest, releaseVersion, releaseArchives, err := collectReleaseArchives(*distDir, *version)
+	discoveryProgress := startCommandProgress("Discovering release archives in %s", *distDir)
+	archivePaths, err := releaseArchivePathsInDirs([]string{*distDir})
 	if err != nil {
 		return err
 	}
-	if err := writeProviderReleaseMetadata(*distDir, releaseManifest, releaseVersion, releaseArchives, nil, true); err != nil {
+	discoveryProgress.done("Discovered %d release archives", len(archivePaths))
+	releaseManifest, releaseVersion, releaseArchives, err := collectReleaseArchivePathsWithProgress(archivePaths, *version)
+	if err != nil {
+		return err
+	}
+	validationProgress := startCommandProgress("Validating provider release metadata")
+	if err := writeProviderReleaseMetadata(*distDir, releaseManifest, releaseVersion, releaseArchives, nil, false); err != nil {
 		return fmt.Errorf("write release metadata: %w", err)
 	}
+	validationProgress.done("Validated provider release metadata for %s", releaseVersion)
+	_, _ = fmt.Fprintf(os.Stdout, "created %s\n", filepath.Join(*distDir, providerrelease.MetadataFile))
+	progressStatus("Generated %s with %d artifact(s) in %s", providerrelease.MetadataFile, len(releaseArchives), *distDir)
 
 	return nil
 }
@@ -68,19 +78,45 @@ func collectReleaseArchives(distDir, versionGuard string) (*providermanifestv1.M
 }
 
 func collectReleaseArchivesFromDirs(distDirs []string, versionGuard string) (*providermanifestv1.Manifest, string, []releaseArchive, error) {
+	archivePaths, err := releaseArchivePathsInDirs(distDirs)
+	if err != nil {
+		return nil, "", nil, err
+	}
+	return collectReleaseArchivePaths(archivePaths, versionGuard)
+}
+
+func collectReleaseArchivesFromDirsWithProgress(distDirs []string, versionGuard string) (*providermanifestv1.Manifest, string, []releaseArchive, error) {
+	archivePaths, err := releaseArchivePathsInDirs(distDirs)
+	if err != nil {
+		return nil, "", nil, err
+	}
+	return collectReleaseArchivePathsWithProgress(archivePaths, versionGuard)
+}
+
+func collectReleaseArchivePathsWithProgress(archivePaths []string, versionGuard string) (*providermanifestv1.Manifest, string, []releaseArchive, error) {
+	progress := startCommandProgress("Inspecting and hashing %d release archives", len(archivePaths))
+	manifest, version, archives, err := collectReleaseArchivePaths(archivePaths, versionGuard)
+	if err != nil {
+		return nil, "", nil, err
+	}
+	progress.done("Inspected and hashed %d release archives", len(archives))
+	return manifest, version, archives, nil
+}
+
+func releaseArchivePathsInDirs(distDirs []string) ([]string, error) {
 	var archivePaths []string
 	for _, distDir := range distDirs {
 		paths, err := releaseArchivePathsInDir(distDir)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, err
 		}
 		archivePaths = append(archivePaths, paths...)
 	}
 	sort.Strings(archivePaths)
 	if len(archivePaths) == 0 {
-		return nil, "", nil, fmt.Errorf("no .tar.gz release archives found in %s", strings.Join(distDirs, ", "))
+		return nil, fmt.Errorf("no .tar.gz release archives found in %s", strings.Join(distDirs, ", "))
 	}
-	return collectReleaseArchivePaths(archivePaths, versionGuard)
+	return archivePaths, nil
 }
 
 func releaseArchivePathsInDir(distDir string) ([]string, error) {


### PR DESCRIPTION
Add concise package and release phase progress on stderr while preserving archive and metadata stdout contracts. Cover successful and failing flows with focused daemon E2E.

Before:

```text
$ gestaltd provider package --version 1.2.3
created <archive-path>
```

After:

```text
$ gestaltd provider package --version 1.2.3
# stderr:
Discovering provider source...
Validating provider source manifest...
Building and hashing provider contents for generic archive...
Assembling provider archive <archive-name>...
Generated 1 provider archive(s) in <dist-dir>

# stdout:
created <archive-path>
```