### PR TITLE
Hygienize validation and serve startup output

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -382,7 +382,7 @@ func (r *Result) StartWorkflowProviders(ctx context.Context) error {
 				errs = append(errs, err)
 				continue
 			}
-			slog.InfoContext(ctx, "workflow provider started", "duration", time.Since(started).String())
+			slog.DebugContext(ctx, "workflow provider started", "duration", time.Since(started).String())
 		}
 	}
 	return errors.Join(errs...)
@@ -430,7 +430,7 @@ func runWorkflowConfigReconcileTask(ctx context.Context, task workflowConfigReco
 				continue
 			}
 		}
-		slog.InfoContext(ctx, "workflow config reconciled", "task", taskName)
+		slog.DebugContext(ctx, "workflow config reconciled", "task", taskName)
 		return
 	}
 }
@@ -1366,7 +1366,7 @@ func BootstrapWithOptions(ctx context.Context, cfg *config.Config, factories *Fa
 		go func() {
 			<-ready
 			startup.finish()
-			slog.InfoContext(ctx, "all ready-blocking app providers loaded", "count", len(noopBuilds.pending))
+			slog.DebugContext(ctx, "all ready-blocking app providers loaded", "count", len(noopBuilds.pending))
 		}()
 	})
 	if !opts.DeferAppProviderStartup {

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -83,7 +83,7 @@ func prepareProviderBuilds(
 		} else if err != nil {
 			return nil, fmt.Errorf("bootstrap: registering builtin %q: %w", builtin.Name(), err)
 		}
-		slog.Info("loaded builtin provider", "provider", builtin.Name(), "operations", catalogOperationCount(builtin.Catalog()))
+		slog.Debug("loaded builtin provider", "provider", builtin.Name(), "operations", catalogOperationCount(builtin.Catalog()))
 	}
 
 	builds := &preparedProviderBuilds{
@@ -153,7 +153,7 @@ func registerRemoteApps(providers *registry.ProviderMap[core.Provider], cfg *con
 		if err := providers.Register(name, provider); err != nil {
 			return fmt.Errorf("remote app %q: %w", name, err)
 		}
-		slog.Info("registered remote app provider", "provider", name)
+		slog.Debug("registered remote app provider", "provider", name)
 	}
 	return nil
 }
@@ -229,7 +229,7 @@ func (b *preparedProviderBuilds) Start(
 					pending.proxy.fail(err)
 					b.providers.Remove(pending.name)
 				}
-				slog.Info("frontend-only dev app; no backend provider registered", "provider", pending.name)
+				slog.Debug("frontend-only dev app; no backend provider registered", "provider", pending.name)
 				return
 			}
 			if err != nil {
@@ -297,7 +297,7 @@ func (b *preparedProviderBuilds) Start(
 				}
 				deps.AppWorkflowDeclarations.Set(pending.name, decls)
 			}
-			slog.Info("loaded provider", "provider", pending.name, "operations", catalogOperationCount(result.Provider.Catalog()))
+			slog.Debug("loaded provider", "provider", pending.name, "operations", catalogOperationCount(result.Provider.Catalog()))
 		}(pending)
 	}
 

--- a/gestaltd/internal/daemon/e2e/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e/e2e_test.go
@@ -417,7 +417,7 @@ func TestE2EProviderValidateStaticApp(t *testing.T) {
 	staticApp := setupStaticAppDir(t, dir)
 	setAppManifestSource(t, staticApp.AppDir, "github.com/test/ui/roadmap.review")
 
-	cmd := gestaltdCommand("provider", "validate", "--path", staticApp.ManifestPath)
+	cmd := gestaltdCommand("provider", "validate", "--verbose", "--path", staticApp.ManifestPath)
 	cmd.Env = append(os.Environ(),
 		"GESTALT_PROVIDERS_DIR="+providersDir,
 		"GOTELEMETRY=off",
@@ -493,7 +493,7 @@ apps:
 				t.Fatalf("write config: %v", err)
 			}
 
-			cmd := gestaltdCommand("provider", "validate", "--path", appDir, "--config", cfgPath)
+			cmd := gestaltdCommand("provider", "validate", "--verbose", "--path", appDir, "--config", cfgPath)
 			cmd.Env = append(os.Environ(),
 				"GESTALT_PROVIDERS_DIR="+providersDir,
 				"GOTELEMETRY=off",

--- a/gestaltd/internal/daemon/provider_local.go
+++ b/gestaltd/internal/daemon/provider_local.go
@@ -8,7 +8,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"log/slog"
 	"net"
 	"net/url"
 	"os"
@@ -111,9 +110,9 @@ func runProviderValidate(args []string) error {
 	logProviderLocalSummary("provider validated", session)
 	logConfigSummary(result.Paths, result.Config)
 	for _, warning := range result.Warnings {
-		slog.Warn(warning)
+		currentCLIReporter().Warning(warning)
 	}
-	slog.Info("config ok")
+	currentCLIReporter().Status("config ok")
 	return nil
 }
 
@@ -139,8 +138,9 @@ func runServeProviderLocal(opts providerLocalCommandOptions) error {
 	}
 	session.PublicURL = providerLocalPublicURL(env.Config)
 	session.AdminURL = strings.TrimRight(session.PublicURL, "/") + "/admin/"
-	logProviderLocalSummary("local provider ready", session)
-	return runServer(env)
+	return runServerWithReady(env, func() {
+		logProviderLocalSummary("local provider ready", session)
+	})
 }
 
 func buildProviderLocalTargetOverlay(sessionDir string, index int, opts providerLocalCommandOptions, path string, port int, configPathsSoFar []string) (*providerLocalTargetOverlay, error) {
@@ -505,14 +505,7 @@ func providerLocalExternalCredentialsSourceConfig() any {
 }
 
 func providerLocalPublicURL(cfg *config.Config) string {
-	if cfg == nil {
-		return ""
-	}
-	addr := cfg.Server.PublicAddr()
-	if addr == "" {
-		return ""
-	}
-	return (&url.URL{Scheme: "http", Host: addr}).String()
+	return canonicalPublicURL(cfg)
 }
 
 func providerLocalBaseURL(port int) string {
@@ -545,14 +538,14 @@ func logProviderLocalSummary(message string, session *providerLocalSession) {
 	if len(publicUIPaths) == 0 {
 		publicUIPaths = nil
 	}
-	args := []any{
+	detailArgs := []any{
 		"config_files", session.ConfigPaths,
 		"public_url", session.PublicURL,
 		"admin_url", session.AdminURL,
 		"mounted_ui_paths", publicUIPaths,
 	}
 	if session.Locked || len(session.DevAppKeys) > 0 || len(session.TargetKeys) > 0 {
-		args = append(args,
+		detailArgs = append(detailArgs,
 			"dev_app_keys", session.DevAppKeys,
 			"target_keys", session.TargetKeys,
 			"artifacts_dir", session.ArtifactsDir,
@@ -560,14 +553,19 @@ func logProviderLocalSummary(message string, session *providerLocalSession) {
 		)
 	}
 	if session.ManifestPath != "" {
-		args = append(args,
+		detailArgs = append(detailArgs,
 			"kind", session.Kind,
 			"manifest", session.ManifestPath,
 			"auto_mounted_ui_path", session.AutoMountedUIPath,
 			"app", session.TargetKey,
 		)
 	}
-	slog.Info(message, args...)
+	if strings.Contains(message, "ready") {
+		currentCLIReporter().Status(message + ": " + session.PublicURL)
+	} else {
+		currentCLIReporter().Status(message)
+	}
+	currentCLIReporter().Verbose(formatCLIFields(message+" details", detailArgs...))
 }
 
 func reserveLocalPort() (int, error) {

--- a/gestaltd/internal/daemon/run.go
+++ b/gestaltd/internal/daemon/run.go
@@ -4,8 +4,8 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"log/slog"
 	"net"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -176,7 +176,9 @@ func runServeCommand(name string, usage func(io.Writer), args []string, opts ser
 		env.Close()
 		return err
 	}
-	return runServer(env)
+	return runServerWithReady(env, func() {
+		currentCLIReporter().Status("gestaltd ready: " + canonicalPublicURL(env.Config))
+	})
 }
 
 type serveProviderLocalOptions struct {
@@ -228,9 +230,9 @@ func flagIntValue(flag *int) int {
 	return *flag
 }
 
-func runServer(env *bootstrapEnv) error {
+func runServerWithReady(env *bootstrapEnv, onReady func()) error {
 	defer env.Close()
-	return server.Run(env.Ctx, env.Config, env.Result)
+	return server.RunWithReady(env.Ctx, env.Config, env.Result, onReady)
 }
 
 const maxServePortScan = 100
@@ -259,7 +261,7 @@ func resolveServePort(cfg *config.Config, portFlag int) error {
 		}
 		_ = l.Close()
 		if candidate != requested {
-			slog.Info("gestaltd port in use; using next free port", "requested", requested, "actual", candidate)
+			currentCLIReporter().Warning(fmt.Sprintf("gestaltd port in use; using next free port (requested %d, using %d)", requested, candidate))
 		}
 		cfg.Server.Public.Port = candidate
 		return nil
@@ -412,14 +414,14 @@ func validateConfig(configFlags []string, lockfilePath, artifactsDir string, opt
 
 	logConfigSummary(result.Paths, result.Config)
 	for _, w := range result.Warnings {
-		slog.Warn(w)
+		currentCLIReporter().Warning(w)
 	}
-	slog.Info("config ok")
+	currentCLIReporter().Status("config ok")
 	return nil
 }
 
 func logConfigSummary(paths []string, cfg *config.Config) {
-	slog.Info("config loaded",
+	currentCLIReporter().Verbose(formatCLIFields("config loaded",
 		"config_files", paths,
 		"server_port", cfg.Server.PublicListener().Port,
 		"server_public_addr", cfg.Server.PublicAddr(),
@@ -431,14 +433,23 @@ func logConfigSummary(paths []string, cfg *config.Config) {
 		"authentication_provider", selectedProviderLabel(cfg.SelectedIdentityProvider()),
 		"runtime_secrets_provider", selectedProviderLabel(cfg.SelectedSecretsProvider()),
 		"telemetry_provider", selectedProviderLabel(cfg.SelectedTelemetryProvider()),
-	)
+	))
 
 	for name, entry := range cfg.Apps {
 		if entry != nil {
-			slog.Info("integration configured", "integration", name, "type", "app")
+			currentCLIReporter().Verbose(formatCLIFields("integration configured", "integration", name, "type", "app"))
 		}
 	}
 
+}
+
+func formatCLIFields(message string, args ...any) string {
+	var builder strings.Builder
+	builder.WriteString(message)
+	for i := 0; i+1 < len(args); i += 2 {
+		fmt.Fprintf(&builder, " %v=%v", args[i], args[i+1])
+	}
+	return builder.String()
 }
 
 func providerEntryLabel(entry *config.ProviderEntry) string {
@@ -475,6 +486,46 @@ func maskEmpty(s string) string {
 		return "(not set)"
 	}
 	return s
+}
+
+func canonicalPublicURL(cfg *config.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	listener := cfg.Server.PublicListener()
+	if baseURL := strings.TrimRight(strings.TrimSpace(cfg.Server.BaseURL), "/"); baseURL != "" {
+		if updated := loopbackBaseURLWithPort(baseURL, listener.Port); updated != "" {
+			return updated
+		}
+		return baseURL
+	}
+	host := strings.TrimSpace(listener.Host)
+	if host == "" || host == "0.0.0.0" || host == "::" || host == "[::]" {
+		host = "localhost"
+	}
+	return "http://" + net.JoinHostPort(host, strconv.Itoa(listener.Port))
+}
+
+func loopbackBaseURLWithPort(raw string, port int) string {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Host == "" {
+		return ""
+	}
+	host := parsed.Hostname()
+	if !actionableLoopbackHost(host) {
+		return ""
+	}
+	parsed.Host = net.JoinHostPort("localhost", strconv.Itoa(port))
+	return strings.TrimRight(parsed.String(), "/")
+}
+
+func actionableLoopbackHost(host string) bool {
+	switch strings.TrimSpace(host) {
+	case "", "localhost", "127.0.0.1", "::1":
+		return true
+	default:
+		return false
+	}
 }
 
 func printMainUsage(w io.Writer) {
@@ -519,6 +570,7 @@ func printServeUsage(w io.Writer) {
 	writeUsageLine(w, "the fleet loads pinned artifacts while PATH UIs with a manifest run: block hot-reload.")
 	writeUsageLine(w, "Without --config, PATH arguments run an isolated synthesized baseline (unlocked).")
 	writeUsageLine(w, "Local UIs with a manifest run: block are proxied to a hot-reload dev server automatically.")
+	writeUsageLine(w, "Dev app commands must bind GESTALT_DEV_PORT exactly; automatic framework port fallback is not supported.")
 	writeUsageLine(w, "For production, use --locked --no-sync to trust the committed lockfile and prebuilt")
 	writeUsageLine(w, "artifacts without materialization or staleness checks.")
 	writeUsageLine(w, "Use --locked alone when artifacts may need to be materialized at startup.")

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -34,6 +34,16 @@ func httpCatalogConnectionMap(connMaps bootstrap.ConnectionMaps) map[string]stri
 }
 
 func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) error {
+	return run(ctx, cfg, result, nil)
+}
+
+// RunWithReady is like Run but invokes onReady after all configured public
+// listeners have been bound and the HTTP serving goroutines have started.
+func RunWithReady(ctx context.Context, cfg *config.Config, result *bootstrap.Result, onReady func()) error {
+	return run(ctx, cfg, result, onReady)
+}
+
+func run(ctx context.Context, cfg *config.Config, result *bootstrap.Result, onReady func()) error {
 	httpInvoker := invocation.NewGuarded(result.Invoker, result.CapabilityLister, "http", result.AuditSink, invocation.WithoutRateLimit())
 	mcpInvoker := invocation.NewGuarded(result.Invoker, result.CapabilityLister, "mcp", result.AuditSink, invocation.WithoutRateLimit())
 
@@ -43,7 +53,7 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 	}
 
 	if cfg.Server.BaseURL != "" {
-		slog.Info("gestaltd base URL configured",
+		slog.Debug("gestaltd base URL configured",
 			"base_url", cfg.Server.BaseURL,
 			"auth_callback", cfg.Server.BaseURL+config.AuthCallbackPath,
 			"integration_callback", cfg.Server.BaseURL+config.IntegrationCallbackPath,
@@ -157,14 +167,13 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 		if cfg.Server.Admin.AuthorizationPolicy != "" {
 			slog.Warn(
 				"management listener serves /metrics without Gestalt auth; /admin requires Gestalt session auth and server.admin policy access",
-				"addr", managementAddr,
 			)
 		} else {
 			slog.Warn(
 				"management listener serves /admin and /metrics without Gestalt auth; protect server.management with private networking or an internal reverse proxy",
-				"addr", managementAddr,
 			)
 		}
+		slog.Debug("management listener address", "addr", managementAddr)
 
 		managementConfig := baseConfig
 		managementConfig.RouteProfile = RouteProfileManagement
@@ -191,7 +200,7 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 		})
 	}
 
-	return serveRuntime(ctx, cfg, connMaps, result, mcpInvoker, servers, mcpSlot, workflowProvidersReady, devSupervisor)
+	return serveRuntime(ctx, cfg, connMaps, result, mcpInvoker, servers, mcpSlot, workflowProvidersReady, devSupervisor, onReady)
 }
 
 type indexedDBPinger interface {
@@ -218,7 +227,7 @@ func runtimeReadinessStatus(workflowProvidersReady <-chan struct{}, services ind
 	}
 }
 
-func serveRuntime(ctx context.Context, cfg *config.Config, connMaps bootstrap.ConnectionMaps, result *bootstrap.Result, mcpInvoker invocation.Invoker, servers []namedHTTPServer, mcpSlot *switchableHandler, workflowProvidersReady chan<- struct{}, devSupervisor *providerdev.Supervisor) error {
+func serveRuntime(ctx context.Context, cfg *config.Config, connMaps bootstrap.ConnectionMaps, result *bootstrap.Result, mcpInvoker invocation.Invoker, servers []namedHTTPServer, mcpSlot *switchableHandler, workflowProvidersReady chan<- struct{}, devSupervisor *providerdev.Supervisor, readyCallback func()) error {
 	if devSupervisor != nil {
 		defer devSupervisor.Stop()
 	}
@@ -244,11 +253,14 @@ func serveRuntime(ctx context.Context, cfg *config.Config, connMaps bootstrap.Co
 	for _, entry := range bound {
 		entry := entry
 		go func() {
-			slog.Info("gestaltd listening", "listener", entry.name, "addr", entry.listener.Addr())
+			slog.Debug("gestaltd listening", "listener", entry.name, "addr", entry.listener.Addr())
 			if err := entry.server.Serve(entry.listener); err != nil && err != http.ErrServerClosed {
 				listenErr <- namedListenFailure{name: entry.name, err: err}
 			}
 		}()
+	}
+	if readyCallback != nil {
+		readyCallback()
 	}
 
 	defer func() {
@@ -276,7 +288,7 @@ func serveRuntime(ctx context.Context, cfg *config.Config, connMaps bootstrap.Co
 		close(workflowProvidersReady)
 
 		result.StartWorkflowConfigReconciliation(ctx)
-		slog.Info("workflow providers ready", "count", len(result.ExtraWorkflows))
+		slog.Debug("workflow providers ready", "count", len(result.ExtraWorkflows))
 
 		mcpHandler, err := newMCPHandler(cfg, connMaps, result, mcpInvoker)
 		if err != nil {
@@ -284,11 +296,11 @@ func serveRuntime(ctx context.Context, cfg *config.Config, connMaps bootstrap.Co
 			return
 		}
 		mcpSlot.Set(mcpHandler)
-		slog.Info("MCP endpoint enabled", "path", "/mcp")
+		slog.Debug("MCP endpoint enabled", "path", "/mcp")
 
 		select {
 		case <-result.ProvidersReady:
-			slog.InfoContext(ctx, "all deferred app providers ready")
+			slog.DebugContext(ctx, "all deferred app providers ready")
 		case <-ctx.Done():
 		}
 	}()

--- a/gestaltd/internal/server/runtime_test.go
+++ b/gestaltd/internal/server/runtime_test.go
@@ -118,7 +118,7 @@ func TestServeRuntimeReadyAfterWorkflowProvidersStart(t *testing.T) {
 	serveDone := make(chan struct{})
 	go func() {
 		defer close(serveDone)
-		_ = serveRuntime(ctx, &config.Config{}, bootstrap.ConnectionMaps{}, result, nil, servers, &switchableHandler{}, workflowProvidersReady, nil)
+		_ = serveRuntime(ctx, &config.Config{}, bootstrap.ConnectionMaps{}, result, nil, servers, &switchableHandler{}, workflowProvidersReady, nil, nil)
 	}()
 
 	select {

--- a/gestaltd/services/providerdev/app_supervisor.go
+++ b/gestaltd/services/providerdev/app_supervisor.go
@@ -67,6 +67,7 @@ type appManaged struct {
 	target AppTarget
 	port   int
 	cancel context.CancelFunc
+	logger *slog.Logger
 
 	frontendReady     chan struct{}
 	frontendReadyOnce sync.Once
@@ -87,6 +88,7 @@ type appCommandProc struct {
 	cmd     *exec.Cmd
 	done    chan struct{}
 	waitErr error
+	output  *childOutput
 }
 
 func AppTargetForEntry(name string, entry *config.ProviderEntry) (AppTarget, error) {
@@ -156,6 +158,7 @@ func (s *Supervisor) StartApp(ctx context.Context, target AppTarget) (*AppHandle
 		target:        target,
 		port:          port,
 		cancel:        appCancel,
+		logger:        s.logger,
 		frontendReady: make(chan struct{}),
 		allExited:     make(chan struct{}),
 	}
@@ -211,7 +214,9 @@ func (s *Supervisor) runAppCommand(ctx context.Context, proc *appCommandProc, co
 		}
 		if err := proc.start(ctx, command); err != nil {
 			if s.logger != nil {
-				s.logger.Warn("dev app command failed to start", "app", proc.parent.target.Name, "command", proc.index, "error", err)
+				args := []any{"app", proc.parent.target.Name, "command", proc.index, "error", err}
+				args = append(args, childFailureLogArgs(proc.currentOutput())...)
+				s.logger.Warn("dev app command failed to start", args...)
 			}
 		} else {
 			waitErr := proc.wait()
@@ -219,7 +224,9 @@ func (s *Supervisor) runAppCommand(ctx context.Context, proc *appCommandProc, co
 				return
 			}
 			if waitErr != nil && s.logger != nil {
-				s.logger.Warn("dev app command exited", "app", proc.parent.target.Name, "command", proc.index, "error", waitErr)
+				args := []any{"app", proc.parent.target.Name, "command", proc.index, "error", waitErr}
+				args = append(args, childFailureLogArgs(proc.currentOutput())...)
+				s.logger.Warn("dev app command exited", args...)
 			}
 		}
 		timer := time.NewTimer(backoff)
@@ -253,8 +260,9 @@ func (p *appCommandProc) start(ctx context.Context, command AppCommand) error {
 	cmd.Dir = command.Workdir
 	cmd.Env = devAppCommandEnv(p.parent.port, p.parent.target, command.Env)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	cmd.Stdout = os.Stderr
-	cmd.Stderr = os.Stderr
+	output := newChildOutput(p.parent.logger, "app", p.parent.target.Name, strconv.Itoa(p.index))
+	cmd.Stdout, cmd.Stderr = output.writers()
+	p.output = output
 	if err := cmd.Start(); err != nil {
 		return err
 	}
@@ -325,7 +333,7 @@ func (a *appManaged) probeFrontendReadiness(ctx context.Context, logger *slog.Lo
 			a.ready.Store(true)
 			a.frontendReadyOnce.Do(func() { close(a.frontendReady) })
 			if logger != nil && !loggedReady {
-				logger.Info("dev app frontend ready", "app", a.target.Name, "port", a.port)
+				logger.Debug("dev app frontend ready", "app", a.target.Name, "port", a.port)
 				loggedReady = true
 			}
 		} else {
@@ -335,7 +343,15 @@ func (a *appManaged) probeFrontendReadiness(ctx context.Context, logger *slog.Lo
 		if !warned && time.Now().After(deadline) {
 			warned = true
 			if logger != nil {
-				logger.Warn("dev app frontend readiness timeout; continuing probe", "app", a.target.Name)
+				args := []any{"app", a.target.Name}
+				for i, proc := range a.commandProcs() {
+					if output := proc.currentOutput(); output != nil {
+						if tail := output.tail(); tail != "" {
+							args = append(args, fmt.Sprintf("command_%d_output_tail", i), "\n"+tail)
+						}
+					}
+				}
+				logger.Warn("dev app frontend readiness timeout; continuing probe", args...)
 			}
 		}
 		timer := time.NewTimer(devReadinessProbeTick)
@@ -346,6 +362,18 @@ func (a *appManaged) probeFrontendReadiness(ctx context.Context, logger *slog.Lo
 		case <-timer.C:
 		}
 	}
+}
+
+func (a *appManaged) commandProcs() []*appCommandProc {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return append([]*appCommandProc(nil), a.procs...)
+}
+
+func (p *appCommandProc) currentOutput() *childOutput {
+	p.parent.mu.Lock()
+	defer p.parent.mu.Unlock()
+	return p.output
 }
 
 func maxReadyTimeout(commands []AppCommand) time.Duration {

--- a/gestaltd/services/providerdev/child_output.go
+++ b/gestaltd/services/providerdev/child_output.go
@@ -1,0 +1,138 @@
+package providerdev
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+)
+
+const (
+	childOutputTailLimit = 16 << 10
+	childDebugLineLimit  = 4 << 10
+)
+
+// boundedOutput keeps only the most recent child output so a noisy dev server
+// cannot grow gestaltd's memory without bound.
+type boundedOutput struct {
+	mu         sync.Mutex
+	buf        []byte
+	wasTrimmed bool
+}
+
+func (b *boundedOutput) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(p) >= childOutputTailLimit {
+		b.buf = append(b.buf[:0], p[len(p)-childOutputTailLimit:]...)
+		b.wasTrimmed = true
+		return len(p), nil
+	}
+	b.buf = append(b.buf, p...)
+	if len(b.buf) > childOutputTailLimit {
+		b.buf = append([]byte(nil), b.buf[len(b.buf)-childOutputTailLimit:]...)
+		b.wasTrimmed = true
+	}
+	return len(p), nil
+}
+
+func (b *boundedOutput) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.buf) == 0 {
+		return ""
+	}
+	value := string(b.buf)
+	if b.wasTrimmed {
+		return "[…child output truncated…]\n" + value
+	}
+	return value
+}
+
+type childOutput struct {
+	stdout      *boundedOutput
+	stderr      *boundedOutput
+	logger      *slog.Logger
+	identity    string
+	identityKey string
+	command     string
+}
+
+func newChildOutput(logger *slog.Logger, identityKey, identity, command string) *childOutput {
+	output := &childOutput{
+		stdout:      &boundedOutput{},
+		stderr:      &boundedOutput{},
+		logger:      logger,
+		identityKey: identityKey,
+		identity:    identity,
+		command:     command,
+	}
+	return output
+}
+
+func (o *childOutput) writers() (io.Writer, io.Writer) {
+	return &childOutputWriter{logger: o.logger, identityKey: o.identityKey, identity: o.identity, command: o.command, stream: "stdout", tail: o.stdout},
+		&childOutputWriter{logger: o.logger, identityKey: o.identityKey, identity: o.identity, command: o.command, stream: "stderr", tail: o.stderr}
+}
+
+func (o *childOutput) tail() string {
+	var parts []string
+	if stdout := strings.TrimSpace(o.stdout.String()); stdout != "" {
+		parts = append(parts, "stdout:\n"+stdout)
+	}
+	if stderr := strings.TrimSpace(o.stderr.String()); stderr != "" {
+		parts = append(parts, "stderr:\n"+stderr)
+	}
+	return strings.Join(parts, "\n")
+}
+
+type childOutputWriter struct {
+	logger      *slog.Logger
+	identityKey string
+	identity    string
+	command     string
+	stream      string
+	tail        *boundedOutput
+	buf         []byte
+}
+
+func (w *childOutputWriter) Write(p []byte) (int, error) {
+	_, _ = w.tail.Write(p)
+	if w.logger == nil || !w.logger.Enabled(context.Background(), slog.LevelDebug) {
+		return len(p), nil
+	}
+	w.buf = append(w.buf, p...)
+	for {
+		idx := bytes.IndexByte(w.buf, '\n')
+		if idx < 0 {
+			break
+		}
+		w.logLine(strings.TrimRight(string(w.buf[:idx]), "\r"))
+		w.buf = w.buf[idx+1:]
+	}
+	if len(w.buf) > childDebugLineLimit {
+		w.logLine(string(w.buf[:childDebugLineLimit]) + "…")
+		w.buf = w.buf[:0]
+	}
+	return len(p), nil
+}
+
+func (w *childOutputWriter) logLine(line string) {
+	if strings.TrimSpace(line) == "" {
+		return
+	}
+	w.logger.Debug("dev child output", w.identityKey, w.identity, "command", w.command, "stream", w.stream, "line", line)
+}
+
+func childFailureLogArgs(output *childOutput) []any {
+	if output == nil {
+		return nil
+	}
+	if tail := output.tail(); tail != "" {
+		return []any{"output_tail", fmt.Sprintf("\n%s", tail)}
+	}
+	return nil
+}

--- a/gestaltd/services/providerdev/supervisor.go
+++ b/gestaltd/services/providerdev/supervisor.go
@@ -1,7 +1,6 @@
 package providerdev
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"log/slog"
@@ -12,7 +11,6 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -56,6 +54,7 @@ type managedProc struct {
 	cmd       *exec.Cmd
 	done      chan struct{}
 	waitErr   error
+	output    *childOutput
 }
 
 func (t Target) procKey() string {
@@ -168,14 +167,18 @@ func (s *Supervisor) runProc(ctx context.Context, proc *managedProc) {
 			return
 		}
 		if err := proc.start(ctx, s.logger); err != nil {
-			s.logger.Warn("dev process failed to start", "provider", proc.target.Name, "error", err)
+			args := []any{"provider", proc.target.Name, "error", err}
+			args = append(args, childFailureLogArgs(proc.currentOutput())...)
+			s.logger.Warn("dev process failed to start", args...)
 		} else {
 			waitErr := proc.wait()
 			if ctx.Err() != nil {
 				return
 			}
 			if waitErr != nil {
-				s.logger.Warn("dev process exited", "provider", proc.target.Name, "error", waitErr)
+				args := []any{"provider", proc.target.Name, "error", waitErr}
+				args = append(args, childFailureLogArgs(proc.currentOutput())...)
+				s.logger.Warn("dev process exited", args...)
 			}
 		}
 		proc.ready.Store(false)
@@ -247,10 +250,9 @@ func (p *managedProc) start(ctx context.Context, logger *slog.Logger) error {
 	cmd.Dir = p.target.Workdir
 	cmd.Env = devCommandEnv(port, p.target)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	stdout := newPrefixedLineWriter(logger, p.target.Name, "stdout")
-	stderr := newPrefixedLineWriter(logger, p.target.Name, "stderr")
-	cmd.Stdout = stdout
-	cmd.Stderr = stderr
+	output := newChildOutput(logger, "provider", p.target.Name, "provider")
+	cmd.Stdout, cmd.Stderr = output.writers()
+	p.output = output
 
 	if err := cmd.Start(); err != nil {
 		return err
@@ -283,12 +285,14 @@ func (p *managedProc) probeReadiness(ctx context.Context, logger *slog.Logger, p
 		if err == nil {
 			_ = conn.Close()
 			p.ready.Store(true)
-			logger.Info("dev process ready", "provider", p.target.Name, "port", port)
+			logger.Debug("dev process ready", "provider", p.target.Name, "port", port)
 			return
 		}
 		if !warned && time.Now().After(deadline) {
 			warned = true
-			logger.Warn("dev process readiness timeout; continuing probe", "provider", p.target.Name, "timeout", p.target.ReadyTimeout)
+			args := []any{"provider", p.target.Name, "timeout", p.target.ReadyTimeout}
+			args = append(args, childFailureLogArgs(p.currentOutput())...)
+			logger.Warn("dev process readiness timeout; continuing probe", args...)
 		}
 		timer := time.NewTimer(devReadinessProbeTick)
 		select {
@@ -301,6 +305,12 @@ func (p *managedProc) probeReadiness(ctx context.Context, logger *slog.Logger, p
 		case <-timer.C:
 		}
 	}
+}
+
+func (p *managedProc) currentOutput() *childOutput {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.output
 }
 
 func (p *managedProc) wait() error {
@@ -337,6 +347,9 @@ func (p *managedProc) stop() {
 // devCommandEnv builds the child process environment. GESTALT_DEV,
 // GESTALT_DEV_PORT, and GESTALT_DEV_BASE_PATH are reserved contract
 // variables and are appended last so manifest dev.env cannot override them.
+// A dev child must bind GESTALT_DEV_PORT exactly; automatic fallback to a
+// different framework-selected port cannot be discovered generically and
+// leaves the public proxy unavailable.
 func devCommandEnv(port int, target Target) []string {
 	env := append([]string(nil), os.Environ()...)
 	for key, value := range target.Env {
@@ -361,31 +374,4 @@ func reserveLocalPort() (int, error) {
 		return 0, fmt.Errorf("reserve local dev port: unexpected listener address type")
 	}
 	return addr.Port, nil
-}
-
-type prefixedLineWriter struct {
-	logger   *slog.Logger
-	provider string
-	stream   string
-	buf      []byte
-}
-
-func newPrefixedLineWriter(logger *slog.Logger, provider, stream string) *prefixedLineWriter {
-	return &prefixedLineWriter{logger: logger, provider: provider, stream: stream}
-}
-
-func (w *prefixedLineWriter) Write(p []byte) (int, error) {
-	w.buf = append(w.buf, p...)
-	for {
-		idx := bytes.IndexByte(w.buf, '\n')
-		if idx < 0 {
-			break
-		}
-		line := strings.TrimRight(string(w.buf[:idx]), "\r")
-		w.buf = w.buf[idx+1:]
-		if line != "" {
-			w.logger.Info(line, "provider", w.provider, "stream", w.stream)
-		}
-	}
-	return len(p), nil
 }


### PR DESCRIPTION
Keep normal validation and serve startup output concise, including the canonical public URL, while retaining warnings in quiet mode. Route configuration, provider, and internal readiness details behind verbose or debug output with focused coverage.

Before:

```text
$ gestaltd validate --config gestalt.yaml
time=... level=INFO msg="config loaded" ...
time=... level=INFO msg="integration configured" integration=demo type=app
time=... level=INFO msg="config ok"

$ gestaltd serve --config gestalt.yaml
time=... level=INFO msg="gestaltd listening" listener=public addr=0.0.0.0:18080
```

After:

```text
$ gestaltd validate --config gestalt.yaml
config ok

$ gestaltd serve --config gestalt.yaml
gestaltd ready: http://localhost:18080
```