### PR TITLE
Preserve default remote config on CLI override

### DIFF
--- a/gestaltd/internal/config/remotes.go
+++ b/gestaltd/internal/config/remotes.go
@@ -188,16 +188,24 @@ func ApplyServeRemoteOverrides(cfg *Config, remote, remoteToken string) error {
 	}
 
 	if remote != "" {
-		ensureDefaultRemote(cfg)
 		name := cfg.DefaultRemoteName()
 		if name == "" {
 			name = legacyDefaultRemoteName
 		}
+		entry := cfg.Server.Remotes[name]
+		if entry == nil {
+			entry = &RemoteConfig{}
+			if cfg.Server.Remotes == nil {
+				cfg.Server.Remotes = map[string]*RemoteConfig{}
+			}
+			cfg.Server.Remotes[name] = entry
+		}
+		entry.Default = true
 		url := strings.TrimRight(strings.TrimSpace(remote), "/")
 		if err := validateHTTPOriginURL("server.remotes."+name+".url", url); err != nil {
 			return err
 		}
-		cfg.Server.Remotes[name].URL = url
+		entry.URL = url
 	}
 
 	if len(cfg.Server.Remotes) == 0 {
@@ -240,19 +248,6 @@ func ApplyServeRemoteOverrides(cfg *Config, remote, remoteToken string) error {
 	}
 
 	return ValidateRemoteGestaltd(cfg)
-}
-
-func ensureDefaultRemote(cfg *Config) {
-	if cfg.Server.Remotes == nil {
-		cfg.Server.Remotes = map[string]*RemoteConfig{}
-	}
-	if cfg.DefaultRemoteName() == "" {
-		cfg.Server.Remotes[legacyDefaultRemoteName] = &RemoteConfig{Default: true}
-		return
-	}
-	if entry := cfg.Server.Remotes[cfg.DefaultRemoteName()]; entry != nil {
-		entry.Default = true
-	}
 }
 
 func defaultRemoteToken() (string, error) {

--- a/gestaltd/internal/config/remotes_test.go
+++ b/gestaltd/internal/config/remotes_test.go
@@ -284,6 +284,15 @@ func TestApplyServeRemoteOverrides(t *testing.T) {
 				tokenFlag:  "cli-token",
 				wantToken:  "cli-token",
 			},
+			{
+				name:       "remote flag promotes reserved default",
+				envToken:   "ambient-token",
+				remoteFlag: "https://new.test",
+				remotes: map[string]*RemoteConfig{
+					"default": {URL: "https://old.test", Token: "configured-token"},
+				},
+				wantToken: "configured-token",
+			},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Setenv("GESTALT_API_KEY", tc.envToken)


### PR DESCRIPTION
## Summary

- preserve an existing `server.remotes.default` entry when `--remote` promotes it
- remove the standalone `ensureDefaultRemote` helper and redundant branching
- cover promotion through the existing remote token-resolution table

## Root cause

The CLI override path replaced the reserved `default` map entry with a fresh `RemoteConfig` whenever no remote was selected as default. That discarded its configured token before fallback resolution.

## Validation

- `go test ./internal/config ./internal/bootstrap ./internal/daemon`
- `git diff --check`