### PR TITLE
Capture sync build output on failure in quiet mode

### DIFF
--- a/gestaltd/internal/daemon/e2e/main_test.go
+++ b/gestaltd/internal/daemon/e2e/main_test.go
@@ -256,6 +256,120 @@ func TestE2ESyncDefaultSuccessIsQuiet(t *testing.T) {
 	}
 }
 
+func TestE2ESyncQuietFailedBuildShowsDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	indexedDBDir := setupIndexedDBProviderDir(t, dir)
+	buildScriptPath := filepath.Join(indexedDBDir, "build.sh")
+	if err := os.WriteFile(buildScriptPath, []byte("#!/bin/sh\nprintf 'QUIET_FAIL_STDOUT\\n'\nprintf 'QUIET_FAIL_STDERR\\n' >&2\nexit 1\n"), 0o755); err != nil {
+		t.Fatalf("write build script: %v", err)
+	}
+	indexedDBManifest := componentProviderManifestPath(t, indexedDBDir)
+	artifactsDir := filepath.Join(dir, "artifacts")
+	configPath := filepath.Join(dir, "config.yaml")
+	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v8
+server:
+  baseUrl: %s
+  encryptionKey: test-e2e-key
+  providers:
+    indexeddb: sqlite
+  artifactsDir: %s
+providers:
+  indexeddb:
+    sqlite:
+      source:
+        path: %s
+      config:
+        path: %q
+`, e2eLoopbackBaseURL(18080), artifactsDir, indexedDBManifest, filepath.Join(dir, "gestalt.db"))
+	if err := os.WriteFile(configPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	out, err := gestaltdCommand("lock", "--config", configPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd lock: %v\n%s", err, out)
+	}
+	if err := os.RemoveAll(filepath.Join(artifactsDir, "indexeddb", "sqlite")); err != nil {
+		t.Fatalf("remove prepared indexeddb provider: %v", err)
+	}
+
+	cmd := gestaltdCommand("--quiet", "sync", "--locked", "--config", configPath)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err == nil {
+		t.Fatalf("gestaltd sync --quiet unexpectedly succeeded\nstdout:\n%s\nstderr:\n%s", stdout.String(), stderr.String())
+	}
+	if got := stdout.String(); got != "" {
+		t.Fatalf("quiet failed sync stdout = %q, want empty", got)
+	}
+	errOut := stderr.String()
+	for _, want := range []string{"QUIET_FAIL_STDOUT", "QUIET_FAIL_STDERR"} {
+		if !strings.Contains(errOut, want) {
+			t.Fatalf("quiet failed sync stderr = %q, want %q\nstdout:\n%s", errOut, want, stdout.String())
+		}
+	}
+}
+
+func TestE2ESyncQuietJSONFailedBuildShowsDiagnosticsOnStderr(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	indexedDBDir := setupIndexedDBProviderDir(t, dir)
+	buildScriptPath := filepath.Join(indexedDBDir, "build.sh")
+	if err := os.WriteFile(buildScriptPath, []byte("#!/bin/sh\nprintf 'QUIET_JSON_FAIL_STDOUT\\n'\nprintf 'QUIET_JSON_FAIL_STDERR\\n' >&2\nexit 1\n"), 0o755); err != nil {
+		t.Fatalf("write build script: %v", err)
+	}
+	indexedDBManifest := componentProviderManifestPath(t, indexedDBDir)
+	artifactsDir := filepath.Join(dir, "artifacts")
+	configPath := filepath.Join(dir, "config.yaml")
+	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v8
+server:
+  baseUrl: %s
+  encryptionKey: test-e2e-key
+  providers:
+    indexeddb: sqlite
+  artifactsDir: %s
+providers:
+  indexeddb:
+    sqlite:
+      source:
+        path: %s
+      config:
+        path: %q
+`, e2eLoopbackBaseURL(18080), artifactsDir, indexedDBManifest, filepath.Join(dir, "gestalt.db"))
+	if err := os.WriteFile(configPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	out, err := gestaltdCommand("lock", "--config", configPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd lock: %v\n%s", err, out)
+	}
+	if err := os.RemoveAll(filepath.Join(artifactsDir, "indexeddb", "sqlite")); err != nil {
+		t.Fatalf("remove prepared indexeddb provider: %v", err)
+	}
+
+	cmd := gestaltdCommand("--quiet", "sync", "--locked", "--output-format=json", "--config", configPath)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err == nil {
+		t.Fatalf("gestaltd sync --quiet --output-format=json unexpectedly succeeded\nstdout:\n%s\nstderr:\n%s", stdout.String(), stderr.String())
+	}
+	if got := strings.TrimSpace(stdout.String()); got != "" {
+		t.Fatalf("quiet failed JSON sync stdout = %q, want empty\nstderr:\n%s", got, stderr.String())
+	}
+	errOut := stderr.String()
+	for _, want := range []string{"QUIET_JSON_FAIL_STDOUT", "QUIET_JSON_FAIL_STDERR"} {
+		if !strings.Contains(errOut, want) {
+			t.Fatalf("quiet failed JSON sync stderr = %q, want %q\nstdout:\n%s", errOut, want, stdout.String())
+		}
+	}
+}
+
 func TestE2ESyncJSONFailureLeavesStdoutEmpty(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/daemon/run.go
+++ b/gestaltd/internal/daemon/run.go
@@ -282,6 +282,16 @@ func runLock(args []string) error {
 	return lockConfig(configPaths, *lockfilePath, "", *check)
 }
 
+func syncBuildOutput(quiet bool, outputFormat string, verbose bool) providerpkg.CommandOutput {
+	if quiet {
+		return providerpkg.CommandOutputCaptureOnFailure(os.Stderr)
+	}
+	if outputFormat == syncOutputFormatJSON || verbose {
+		return providerpkg.CommandOutput{Stdout: os.Stderr, Stderr: os.Stderr}
+	}
+	return providerpkg.CommandOutput{Stdout: io.Discard, Stderr: io.Discard}
+}
+
 func runSync(args []string) error {
 	fs := flag.NewFlagSet("gestaltd sync", flag.ContinueOnError)
 	fs.Usage = func() { printSyncUsage(fs.Output()) }
@@ -319,10 +329,7 @@ func runSync(args []string) error {
 		metrics = operator.NewSyncMetricsRecorder()
 		observability.Recorder = metrics
 	}
-	observability.BuildOutput = providerpkg.CommandOutput{Stdout: io.Discard, Stderr: io.Discard}
-	if !quiet && (*outputFormat == syncOutputFormatJSON || verbose) {
-		observability.BuildOutput = providerpkg.CommandOutput{Stdout: os.Stderr, Stderr: os.Stderr}
-	}
+	observability.BuildOutput = syncBuildOutput(quiet, *outputFormat, verbose)
 	opts := operator.SyncOptions{
 		Locked:        *locked,
 		Parallelism:   *parallelism,

--- a/gestaltd/internal/daemon/run_sync_build_output_test.go
+++ b/gestaltd/internal/daemon/run_sync_build_output_test.go
@@ -1,0 +1,103 @@
+package daemon
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/services/apps/providerpkg"
+)
+
+func TestSyncBuildOutputPolicy(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name        string
+		quiet       bool
+		verbose     bool
+		format      string
+		wantStream  bool
+		wantCapture bool
+		wantDiscard bool
+	}{
+		{
+			name:        "verbose streams build output to stderr",
+			format:      syncOutputFormatText,
+			verbose:     true,
+			wantStream:  true,
+		},
+		{
+			name:       "json streams build output to stderr",
+			format:     syncOutputFormatJSON,
+			wantStream: true,
+		},
+		{
+			name:        "quiet text captures build output for failures",
+			quiet:       true,
+			format:      syncOutputFormatText,
+			wantCapture: true,
+		},
+		{
+			name:        "quiet json captures build output for failures",
+			quiet:       true,
+			format:      syncOutputFormatJSON,
+			wantCapture: true,
+		},
+		{
+			name:        "quiet verbose captures build output for failures",
+			quiet:       true,
+			verbose:     true,
+			format:      syncOutputFormatText,
+			wantCapture: true,
+		},
+		{
+			name:        "default text discards successful build chatter",
+			format:      syncOutputFormatText,
+			wantDiscard: true,
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := syncBuildOutput(tc.quiet, tc.format, tc.verbose)
+			switch {
+			case tc.wantStream:
+				if got.CaptureErrors != nil {
+					t.Fatalf("CaptureErrors = %v, want nil", got.CaptureErrors)
+				}
+				if got.Stdout != os.Stderr || got.Stderr != os.Stderr {
+					t.Fatalf("build output = %#v, want stderr streaming", got)
+				}
+			case tc.wantCapture:
+				if got.CaptureErrors != os.Stderr {
+					t.Fatalf("CaptureErrors = %v, want os.Stderr", got.CaptureErrors)
+				}
+				if got.Stdout != nil || got.Stderr != nil {
+					t.Fatalf("build output = %#v, want capture-only routing", got)
+				}
+			case tc.wantDiscard:
+				if got.CaptureErrors != nil {
+					t.Fatalf("CaptureErrors = %v, want nil", got.CaptureErrors)
+				}
+				if got.Stdout != io.Discard || got.Stderr != io.Discard {
+					t.Fatalf("build output = %#v, want io.Discard", got)
+				}
+			default:
+				t.Fatal("test case missing expectation")
+			}
+		})
+	}
+}
+
+func TestSyncBuildOutputQuietUsesProviderCapture(t *testing.T) {
+	t.Parallel()
+
+	got := syncBuildOutput(true, syncOutputFormatJSON, true)
+	if got.CaptureErrors == nil {
+		t.Fatal("quiet sync build output should capture failures")
+	}
+	if got.Stdout != nil || got.Stderr != nil {
+		t.Fatalf("quiet sync build output = %#v, want capture routing only", got)
+	}
+	_ = providerpkg.CommandOutput(got)
+}

--- a/gestaltd/services/apps/providerpkg/command_capture.go
+++ b/gestaltd/services/apps/providerpkg/command_capture.go
@@ -1,0 +1,71 @@
+package providerpkg
+
+import (
+	"bytes"
+	"io"
+)
+
+const defaultCommandCaptureLimit = 64 << 10
+
+type boundedCapture struct {
+	limit     int
+	buf       bytes.Buffer
+	truncated bool
+}
+
+func (c *boundedCapture) Write(p []byte) (int, error) {
+	if c.limit <= 0 {
+		return len(p), nil
+	}
+	remaining := c.limit - c.buf.Len()
+	if remaining <= 0 {
+		c.truncated = true
+		return len(p), nil
+	}
+	if len(p) > remaining {
+		c.truncated = true
+	}
+	_, _ = c.buf.Write(p[:min(len(p), remaining)])
+	return len(p), nil
+}
+
+type commandCaptureSession struct {
+	stdout *boundedCapture
+	stderr *boundedCapture
+	sink   io.Writer
+}
+
+func newCommandCaptureSession(sink io.Writer, limit int) *commandCaptureSession {
+	if limit <= 0 {
+		limit = defaultCommandCaptureLimit
+	}
+	return &commandCaptureSession{
+		stdout: &boundedCapture{limit: limit},
+		stderr: &boundedCapture{limit: limit},
+		sink:   sink,
+	}
+}
+
+func (s *commandCaptureSession) flush() {
+	if s == nil || s.sink == nil {
+		return
+	}
+	if s.stdout.buf.Len() > 0 {
+		_, _ = s.sink.Write(s.stdout.buf.Bytes())
+	}
+	if s.stderr.buf.Len() > 0 {
+		_, _ = s.sink.Write(s.stderr.buf.Bytes())
+	}
+}
+
+func phaseCommandWriters(output CommandOutput) (stdout, stderr io.Writer, finalize func(error)) {
+	if output.CaptureErrors != nil {
+		session := newCommandCaptureSession(output.CaptureErrors, output.CaptureLimit)
+		return session.stdout, session.stderr, func(err error) {
+			if err != nil {
+				session.flush()
+			}
+		}
+	}
+	return commandStdout(output), commandStderr(output), func(error) {}
+}

--- a/gestaltd/services/apps/providerpkg/command_capture_test.go
+++ b/gestaltd/services/apps/providerpkg/command_capture_test.go
@@ -1,0 +1,80 @@
+package providerpkg
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPhaseCommandWritersCaptureOnFailure(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "manifest.yaml")
+	if err := os.WriteFile(manifestPath, []byte("source: test\nkind: app\nversion: 1.0.0\n"), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	buildScript := filepath.Join(dir, "build.sh")
+	if err := os.WriteFile(buildScript, []byte("#!/bin/sh\nprintf 'BUILD_DIAG_STDOUT\\n' >&1\nprintf 'BUILD_DIAG_STDERR\\n' >&2\nexit 1\n"), 0o755); err != nil {
+		t.Fatalf("write build script: %v", err)
+	}
+
+	var captured bytes.Buffer
+	opts := SourceBuildOptions{
+		Output: CommandOutputCaptureOnFailure(&captured),
+	}
+	err := runSourcePhase(manifestPath, "build", "", []string{"sh", "./build.sh"}, nil, opts)
+	if err == nil {
+		t.Fatal("runSourcePhase() error = nil, want failure")
+	}
+	if !strings.Contains(err.Error(), "run build.command") {
+		t.Fatalf("runSourcePhase() error = %v, want wrapped build failure", err)
+	}
+	got := captured.String()
+	for _, want := range []string{"BUILD_DIAG_STDOUT", "BUILD_DIAG_STDERR"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("captured output = %q, want %q", got, want)
+		}
+	}
+}
+
+func TestPhaseCommandWritersCaptureOnSuccessDiscards(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "manifest.yaml")
+	if err := os.WriteFile(manifestPath, []byte("source: test\nkind: app\nversion: 1.0.0\n"), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	buildScript := filepath.Join(dir, "build.sh")
+	if err := os.WriteFile(buildScript, []byte("#!/bin/sh\nprintf 'BUILD_CHATTER\\n'\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write build script: %v", err)
+	}
+
+	var captured bytes.Buffer
+	opts := SourceBuildOptions{
+		Output: CommandOutputCaptureOnFailure(&captured),
+	}
+	if err := runSourcePhase(manifestPath, "build", "", []string{"sh", "./build.sh"}, nil, opts); err != nil {
+		t.Fatalf("runSourcePhase() error = %v", err)
+	}
+	if got := captured.String(); got != "" {
+		t.Fatalf("captured output = %q, want empty on success", got)
+	}
+}
+
+func TestBoundedCaptureTruncates(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	capture := newCommandCaptureSession(&buf, 8)
+	if _, err := capture.stdout.Write([]byte("1234567890")); err != nil {
+		t.Fatalf("write stdout: %v", err)
+	}
+	capture.flush()
+	if got := buf.String(); got != "12345678" {
+		t.Fatalf("truncated capture = %q, want %q", got, "12345678")
+	}
+}

--- a/gestaltd/services/apps/providerpkg/command_output.go
+++ b/gestaltd/services/apps/providerpkg/command_output.go
@@ -8,6 +8,16 @@ import (
 type CommandOutput struct {
 	Stdout io.Writer
 	Stderr io.Writer
+	// CaptureErrors captures bounded child stdout/stderr and writes the capture
+	// to this writer only when the command fails. Successful commands discard it.
+	CaptureErrors io.Writer
+	// CaptureLimit is the per-stream byte cap when CaptureErrors is set. Zero uses
+	// defaultCommandCaptureLimit.
+	CaptureLimit int
+}
+
+func CommandOutputCaptureOnFailure(sink io.Writer) CommandOutput {
+	return CommandOutput{CaptureErrors: sink}
 }
 
 func commandStdout(output CommandOutput) io.Writer {

--- a/gestaltd/services/apps/providerpkg/source_build.go
+++ b/gestaltd/services/apps/providerpkg/source_build.go
@@ -262,11 +262,14 @@ func runSourcePhase(manifestPath, label, workdir string, command, envOverrides [
 	cmd := exec.Command(command[0], command[1:]...)
 	cmd.Dir = phaseWorkdir
 	cmd.Env = mergePhaseEnv(sourceBuildEnv(os.Environ(), opts), envOverrides)
-	cmd.Stdout = commandStdout(opts.Output)
-	cmd.Stderr = commandStderr(opts.Output)
+	stdout, stderr, finalize := phaseCommandWriters(opts.Output)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 	if err := cmd.Run(); err != nil {
+		finalize(err)
 		return fmt.Errorf("run %s.command: %w", label, err)
 	}
+	finalize(nil)
 	return nil
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes `--quiet` sync dropping actionable compiler/build diagnostics on failed source builds.

Previously, quiet mode always routed child build stdout/stderr to `io.Discard`, even when `--verbose` or `--output-format=json` would otherwise stream build output to stderr. Failed builds surfaced only as opaque `exit status 1` errors.

## Approach

- **`CommandOutput.CaptureErrors`**: bounded per-stream capture (64 KiB default) used by `runSourcePhase`
- On **success**, captured output is discarded (no build chatter in quiet mode)
- On **failure**, captured stdout/stderr are flushed to stderr
- **Non-quiet verbose/JSON** behavior unchanged: build output still streams live to stderr; JSON stdout stays clean on success

## Tests

- `TestSyncBuildOutputPolicy` — quiet (including quiet+JSON) uses capture; verbose/JSON stream; default discards
- `command_capture_test.go` — capture flush on failure, discard on success, truncation
- `TestE2ESyncQuietFailedBuildShowsDiagnostics` / `TestE2ESyncQuietJSONFailedBuildShowsDiagnosticsOnStderr` — e2e indexeddb build failure with diagnostics on stderr

Stacked on #2792 (`codex/gestaltd-cli-output-contract`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96f98965-1ddb-4847-964c-139b403f2be6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96f98965-1ddb-4847-964c-139b403f2be6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

