### PR TITLE
Resolve app registry installs when config app key differs from registry app name

### DIFF
--- a/gestaltd/internal/appregistry/config_app.go
+++ b/gestaltd/internal/appregistry/config_app.go
@@ -1,0 +1,31 @@
+package appregistry
+
+import (
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+)
+
+func resolveConfigAppEntry(configApps map[string]*config.ProviderEntry, registryAppName string) *config.ProviderEntry {
+	registryAppName = strings.TrimSpace(registryAppName)
+	if registryAppName == "" || configApps == nil {
+		return nil
+	}
+	if entry := configApps[registryAppName]; entry != nil {
+		return entry
+	}
+	for _, entry := range configApps {
+		if entry == nil {
+			continue
+		}
+		if manifest := entry.ResolvedManifest; manifest != nil {
+			if appName, err := AppNameFromManifestSource(manifest.Source); err == nil && appName == registryAppName {
+				return entry
+			}
+			if strings.TrimSpace(manifest.DisplayName) == registryAppName {
+				return entry
+			}
+		}
+	}
+	return nil
+}

--- a/gestaltd/internal/appregistry/config_app_test.go
+++ b/gestaltd/internal/appregistry/config_app_test.go
@@ -1,0 +1,41 @@
+package appregistry
+
+import (
+	"testing"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+)
+
+func TestResolveConfigAppEntry_matches_registry_app_name_to_config_key(t *testing.T) {
+	t.Parallel()
+
+	entry := &config.ProviderEntry{
+		ResolvedManifest: &providermanifestv1.Manifest{
+			Source:      "github.com/valon-technologies/valon-tools/apps/g-issues",
+			DisplayName: "g-issues",
+		},
+	}
+	entry.Source.SetResolvedPackage("", "0.0.0-config")
+
+	got := resolveConfigAppEntry(map[string]*config.ProviderEntry{
+		"gIssues": entry,
+	}, "g-issues")
+	if got != entry {
+		t.Fatalf("resolveConfigAppEntry = %#v, want %#v", got, entry)
+	}
+}
+
+func TestResolveConfigAppEntry_prefers_direct_config_key_match(t *testing.T) {
+	t.Parallel()
+
+	entry := &config.ProviderEntry{}
+	entry.Source.SetResolvedPackage("", "0.0.0-config")
+
+	got := resolveConfigAppEntry(map[string]*config.ProviderEntry{
+		"g-issues": entry,
+	}, "g-issues")
+	if got != entry {
+		t.Fatalf("resolveConfigAppEntry = %#v, want %#v", got, entry)
+	}
+}

--- a/gestaltd/internal/appregistry/installer.go
+++ b/gestaltd/internal/appregistry/installer.go
@@ -95,7 +95,7 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 	}
 	var configEntry *config.ProviderEntry
 	if i.ConfigApps != nil {
-		configEntry = i.ConfigApps[appName]
+		configEntry = resolveConfigAppEntry(i.ConfigApps, appName)
 	}
 	fromVersion := resolveFromVersion(knownVersions, configEntry)
 	if fromVersion == "" {

--- a/gestaltd/internal/appregistry/installer_test.go
+++ b/gestaltd/internal/appregistry/installer_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/internal/appregistry"
 	"github.com/valon-technologies/gestalt/server/internal/appregistry/registrytest"
 	"github.com/valon-technologies/gestalt/server/internal/config"
@@ -181,4 +182,44 @@ func TestInstaller_records_from_version_on_first_install_and_upgrade(t *testing.
 	if requests[0].ToVersion != fixture.Version {
 		t.Fatalf("first to_version = %q, want %s", requests[0].ToVersion, fixture.Version)
 	}
+}
+
+func TestInstaller_resolves_config_entry_when_registry_app_name_differs_from_config_key(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc := testutil.NewStubServices(t)
+	fixture := registrytest.NewInstallFixture(t)
+
+	installer := &appregistry.Installer{
+		Registries: map[string]config.AppRegistryConfig{
+			"toolshed": fixture.Registry,
+		},
+		ConfigApps: map[string]*config.ProviderEntry{
+			"gIssues": configEntryWithManifestApp("g-issues", "0.0.0-config"),
+		},
+		Reader:         fixture.Reader,
+		ChangeRequests: svc.AppVersionChangeRequests,
+		Locks:          svc.AppVersionInstallLocks,
+	}
+
+	if _, err := installer.Install(ctx, appregistry.InstallInput{
+		Registry: "toolshed",
+		App:      "g-issues",
+		Version:  fixture.Version,
+		Actor:    "user:alice",
+	}); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+}
+
+func configEntryWithManifestApp(appName, version string) *config.ProviderEntry {
+	entry := &config.ProviderEntry{
+		ResolvedManifest: &providermanifestv1.Manifest{
+			Source:      "github.com/valon-technologies/valon-tools/apps/" + appName,
+			DisplayName: appName,
+		},
+	}
+	entry.Source.SetResolvedPackage("", version)
+	return entry
 }


### PR DESCRIPTION
## Summary
- Look up deploy config apps by registry app name when the direct `apps.<name>` config key does not match.
- Match pinned apps via manifest `source` (`apps/{app}`) or `displayName`, so first-time installs can resolve `from_version` from the config pin.

## Problem
Dev gestaltd deploy keys g-issues as `apps.gIssues`, but the registry/admin install API uses the published app id `g-issues`. The installer only checked `ConfigApps[appName]`, so first install failed with:

```
resolve from_version: no known fleet version and app is not pinned in config
```

## Approach
Prefer a gestalt installer fix over renaming deploy config keys, since config naming conventions may differ from published registry app ids across environments.

## Test plan
- [x] `go test ./gestaltd/internal/appregistry/... -count=1`
- [ ] After gestaltd deploy: `POST /admin/api/v1/app-registries/toolshed/apps/g-issues/install` succeeds on dev

## Follow-up
After merge, bump `GESTALTD_COMMIT_SHA` in valon-tools and deploy. Pair with valon-technologies/valon-tools#222 for admin API auth on dev/stage.


Made with [Cursor](https://cursor.com)