### PR TITLE
Inject runtime app identity for mounted UIs

### DIFF
--- a/docs/content/applications.mdx
+++ b/docs/content/applications.mdx
@@ -828,9 +828,11 @@ serve TypeScript or JSX source at runtime — only the prepared `static/` bundle
 ### Relative asset references
 
 Use relative URLs in HTML, CSS, and JS (`./assets/app.js`, not `/assets/app.js`).
-Gestalt injects a `<base href="/{mount}/">` tag when serving mounted apps so
-relative references resolve under the mount path. Client routers should derive
-their base from `document.baseURI` rather than hard-coding `/`.
+Gestalt injects `<base href="/{mount}/">` and
+`<meta name="gestalt-app-name" content="{registered-key}">` when serving mounted
+apps. Use `base()` and `appApiBase()` from `@valon-technologies/gestalt/mount`
+for mount-relative links and self-app operation routes instead of hard-coding
+deployment keys or mount paths.
 
 During `build`, Gestalt sets `GESTALT_BUILD_STATIC` to an absolute path under
 `.gestalt/build-static/` in the manifest directory. Your build script must write
@@ -856,7 +858,8 @@ export default defineConfig({
 ```
 
 `gestalt()` sets `base` to a relative path, configures the dev server for
-`GESTALT_DEV_*` when gestaltd proxies local `run` commands, and proxies `/api/v1`
+`GESTALT_DEV_*` when gestaltd proxies local `run` commands, injects
+`gestalt-app-name` from `GESTALT_APP_NAME`, and proxies `/api/v1`
 to `GESTALT_BASE_URL` for two-origin local dev.
 
 Manual equivalent when not using the plugin:
@@ -910,8 +913,18 @@ apps:
 Only one app may mount at `/`.
 
 Gestalt serves static files from the prepared `static/` directory, applies SPA
-fallback (unknown paths under the mount return `index.html`), and injects
-`<base href>` into HTML responses when the document does not already define one.
+fallback (unknown paths under the mount return `index.html`), and injects host
+context into HTML responses:
+
+- `<meta name="gestalt-app-name" content="...">` with the registered deployment
+  key from `apps.<name>` (not the mount path, package directory, or manifest
+  source slug).
+- `<base href>` when the document does not already define one.
+
+`apps.<name>` is the runtime identity. The static `mount`, manifest `source`,
+and provider catalog `name` are separate concepts and must not be used to
+predict API routes in application code.
+
 Theme endpoints (`/theme.css`, `/theme/*`) are handled before the static file
 handler when `static.theme` is configured.
 
@@ -974,11 +987,16 @@ only after the app passes the configured authorization policy.
 
 The frontend can stay small because Gestalt already handles sessions, route
 authorization, and static asset serving. A mounted UI calls the app
-operations on the same origin:
+operations on the same origin using the registered app key injected by
+gestaltd:
 
-```js
-export async function saveItem(item) {
-  const response = await fetch("/api/v1/workspace_review/items.save", {
+```ts
+import { appApiBase } from "@valon-technologies/gestalt/mount";
+
+const API_BASE = appApiBase();
+
+export async function saveItem(item: unknown) {
+  const response = await fetch(`${API_BASE}/items.save`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(item),

--- a/gestaltd/internal/server/mounted_app_static.go
+++ b/gestaltd/internal/server/mounted_app_static.go
@@ -55,7 +55,7 @@ func mountedAppStaticsFromEntries(apps map[string]*config.ProviderEntry, devHand
 		handler, err := ui.StaticHandler(ui.StaticConfig{
 			FS:           os.DirFS(entry.ResolvedStaticRoot),
 			DynamicIndex: true,
-			RenderIndex:  injectBaseHref(mount),
+			RenderIndex:  injectAppContext(name, mount),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("app %q static: %w", name, err)
@@ -76,35 +76,69 @@ func mountedAppStaticsFromEntries(apps map[string]*config.ProviderEntry, devHand
 	return mounted, nil
 }
 
-func injectBaseHref(mount string) func([]byte) []byte {
+func injectAppContext(appName, mount string) func([]byte) []byte {
+	appName = strings.TrimSpace(appName)
 	mount = strings.TrimSpace(mount)
 	baseHref := "/"
 	if mount != "" && mount != "/" {
 		baseHref = mount + "/"
 	}
-	tag := []byte("<base href=\"" + html.EscapeString(baseHref) + "\">")
+	appMeta := []byte(
+		"<meta name=\"gestalt-app-name\" content=\"" + html.EscapeString(appName) + "\">",
+	)
+	baseTag := []byte("<base href=\"" + html.EscapeString(baseHref) + "\">")
+
 	return func(data []byte) []byte {
-		if hasHTMLBaseTag(data) {
-			return data
+		data = injectIntoHTMLHead(data, appMeta)
+		if !hasHTMLBaseTag(data) {
+			data = injectIntoHTMLHead(data, baseTag)
 		}
-		lower := bytes.ToLower(data)
-		if idx := bytes.Index(lower, []byte("<head>")); idx >= 0 {
-			insertAt := idx + len("<head>")
+		return data
+	}
+}
+
+func injectIntoHTMLHead(data, tag []byte) []byte {
+	lower := bytes.ToLower(data)
+	for searchFrom := 0; searchFrom < len(lower); {
+		headIdx := bytes.Index(lower[searchFrom:], []byte("<head"))
+		if headIdx < 0 {
+			break
+		}
+		headIdx += searchFrom
+		if insertAt, ok := htmlTagInsertAt(data, lower, headIdx); ok {
 			out := make([]byte, 0, len(data)+len(tag))
 			out = append(out, data[:insertAt]...)
 			out = append(out, tag...)
 			out = append(out, data[insertAt:]...)
 			return out
 		}
-		if idx := bytes.Index(lower, []byte("<html>")); idx >= 0 {
-			insertAt := idx + len("<html>")
+		searchFrom = headIdx + 5
+	}
+	if htmlIdx := bytes.Index(lower, []byte("<html")); htmlIdx >= 0 {
+		if insertAt, ok := htmlTagInsertAt(data, lower, htmlIdx); ok {
 			out := make([]byte, 0, len(data)+len(tag))
 			out = append(out, data[:insertAt]...)
 			out = append(out, tag...)
 			out = append(out, data[insertAt:]...)
 			return out
 		}
-		return append(append([]byte(nil), tag...), data...)
+	}
+	return append(append([]byte(nil), tag...), data...)
+}
+
+func htmlTagInsertAt(data, lower []byte, tagIdx int) (int, bool) {
+	if tagIdx+5 >= len(lower) {
+		return 0, false
+	}
+	switch lower[tagIdx+5] {
+	case '>', ' ', '\t', '\n', '\r':
+		closeIdx := bytes.IndexByte(data[tagIdx:], '>')
+		if closeIdx < 0 {
+			return 0, false
+		}
+		return tagIdx + closeIdx + 1, true
+	default:
+		return 0, false
 	}
 }
 

--- a/gestaltd/internal/server/mounted_app_static_test.go
+++ b/gestaltd/internal/server/mounted_app_static_test.go
@@ -1,0 +1,118 @@
+package server
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestInjectAppContext(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		appName string
+		mount   string
+		html    string
+		want    []string
+		notWant []string
+	}{
+		{
+			name:    "registered key and mount",
+			appName: "ciCd",
+			mount:   "/ci-cd",
+			html:    `<html><head lang="en"><title>CI</title></head><body></body></html>`,
+			want: []string{
+				`<meta name="gestalt-app-name" content="ciCd">`,
+				`<base href="/ci-cd/">`,
+			},
+		},
+		{
+			name:    "arbitrary alias unrelated to mount",
+			appName: "internalDeliveryDashboard",
+			mount:   "/ci-cd",
+			html:    "<html><head></head></html>",
+			want: []string{
+				`<meta name="gestalt-app-name" content="internalDeliveryDashboard">`,
+				`<base href="/ci-cd/">`,
+			},
+		},
+		{
+			name:    "root mount",
+			appName: "homeApp",
+			mount:   "/",
+			html:    "<html><head></head></html>",
+			want: []string{
+				`<meta name="gestalt-app-name" content="homeApp">`,
+				`<base href="/">`,
+			},
+		},
+		{
+			name:    "preserves existing base tag",
+			appName: "ciCd",
+			mount:   "/ci-cd",
+			html:    `<html><head><base href="/custom/"></head></html>`,
+			want: []string{
+				`<meta name="gestalt-app-name" content="ciCd">`,
+			},
+			notWant: []string{`<base href="/ci-cd/">`},
+		},
+		{
+			name:    "missing head falls back after html",
+			appName: "ciCd",
+			mount:   "/ci-cd",
+			html:    "<html><body></body></html>",
+			want: []string{
+				`<meta name="gestalt-app-name" content="ciCd">`,
+				`<base href="/ci-cd/">`,
+			},
+		},
+		{
+			name:    "html-sensitive app key is escaped",
+			appName: `app" onclick="alert(1)`,
+			mount:   "/apps",
+			html:    "<html><head></head></html>",
+			want: []string{
+				`<meta name="gestalt-app-name" content="app&#34; onclick=&#34;alert(1)">`,
+			},
+		},
+		{
+			name:    "skips header and injects into real head",
+			appName: "ciCd",
+			mount:   "/ci-cd",
+			html:    `<html><header>nav</header><head lang="en"></head><body></body></html>`,
+			want: []string{
+				`<meta name="gestalt-app-name" content="ciCd">`,
+				`<head lang="en">`,
+			},
+			notWant: []string{"<header><meta", `<header>nav</header><meta`},
+		},
+		{
+			name:    "html with attributes",
+			appName: "ciCd",
+			mount:   "/ci-cd",
+			html:    `<html lang="en"><body></body></html>`,
+			want: []string{
+				`<meta name="gestalt-app-name" content="ciCd">`,
+				`<html lang="en">`,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := string(injectAppContext(tc.appName, tc.mount)([]byte(tc.html)))
+			for _, want := range tc.want {
+				if !strings.Contains(got, want) {
+					t.Fatalf("output missing %q\ngot: %s", want, got)
+				}
+			}
+			for _, notWant := range tc.notWant {
+				if strings.Contains(got, notWant) {
+					t.Fatalf("output contains %q\ngot: %s", notWant, got)
+				}
+			}
+		})
+	}
+}

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -137,6 +137,20 @@ that need to classify GraphQL errors themselves.
 
 ## Runtime and build entrypoints
 
+Mounted browser UIs receive their registered deployment key from gestaltd via
+`<meta name="gestalt-app-name">`. Use the browser-only mount helpers for
+self-app API routes:
+
+```ts
+import { appApiBase, appName, base } from "@valon-technologies/gestalt/mount";
+
+const API_BASE = appApiBase();
+const mountPrefix = base();
+```
+
+Do not hard-code `/api/v1/{app}` paths or derive keys from mount paths,
+directory names, or manifest source slugs.
+
 Source-mode runtime:
 
 ```sh

--- a/sdk/typescript/scripts/run-tests.ts
+++ b/sdk/typescript/scripts/run-tests.ts
@@ -1,13 +1,18 @@
 import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 
-const S3_TRANSPORT_TEST = join("tests", "s3.transport.test.ts");
+const ISOLATED_TESTS = [
+  join("tests", "s3.transport.test.ts"),
+  join("tests", "indexeddb.transport.test.ts"),
+];
 
 const testFiles = (await collectTestFiles("tests"))
-  .filter((path) => path !== S3_TRANSPORT_TEST)
+  .filter((path) => !ISOLATED_TESTS.includes(path))
   .sort();
 
-await runBunTest([S3_TRANSPORT_TEST]);
+for (const path of ISOLATED_TESTS) {
+  await runBunTest([path]);
+}
 await runBunTest(testFiles);
 
 async function collectTestFiles(dir: string): Promise<string[]> {

--- a/sdk/typescript/src/mount.ts
+++ b/sdk/typescript/src/mount.ts
@@ -4,11 +4,46 @@
  * @module mount
  */
 
+const APP_NAME_META = "gestalt-app-name";
+
+/**
+ * Returns the exact app key under which gestaltd registered the mounted UI.
+ *
+ * Browser-only. Throws when gestaltd app metadata is unavailable.
+ */
+export function appName(): string {
+  if (typeof document === "undefined") {
+    throw new Error("appName() requires a browser document");
+  }
+
+  const meta = document.querySelector<HTMLMetaElement>(
+    `meta[name="${APP_NAME_META}"]`,
+  );
+  const name = meta?.content.trim();
+
+  if (!name) {
+    throw new Error(
+      'appName() requires <meta name="gestalt-app-name" content="..."> injected by gestaltd',
+    );
+  }
+
+  return name;
+}
+
+/**
+ * Returns the current app's operation API prefix.
+ *
+ * Example: "/api/v1/ciCd"
+ */
+export function appApiBase(): string {
+  return `/api/v1/${encodeURIComponent(appName())}`;
+}
+
 /**
  * Returns the base path for absolute links from application code.
  *
  * gestaltd injects a base element with an href attribute into the served
- * HTML (via `injectBaseHref`); this reads that element's path.
+ * HTML (via `injectAppContext`); this reads that element's path.
  */
 export function base(): string {
   if (typeof document === "undefined") {

--- a/sdk/typescript/src/vite.js
+++ b/sdk/typescript/src/vite.js
@@ -45,6 +45,20 @@ function devBinding(port) {
 
 const DEFAULT_DEV_API_PROXY_TARGET = "http://127.0.0.1:8080";
 const DEV_API_PROXY_TOKEN_ENV = "GESTALT_DEV_API_PROXY_TOKEN";
+const MANAGED_DEV_APP_NAME_ERROR =
+  "GESTALT_APP_NAME is required when GESTALT_DEV_PORT is set (managed gestaltd development)";
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function escapeHtmlAttribute(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
 
 /**
  * @param {string | undefined | null} value
@@ -93,6 +107,11 @@ function gestaltConfig(env, command) {
     return null;
   }
 
+  const appName = env.GESTALT_APP_NAME?.trim();
+  if (!appName) {
+    throw new Error(MANAGED_DEV_APP_NAME_ERROR);
+  }
+
   const port = parseDevPort(devPort);
   const base = normalizeBasePath(env.GESTALT_DEV_BASE_PATH);
   const binding = devBinding(port);
@@ -138,16 +157,25 @@ export function gestalt(options = {}) {
     transformIndexHtml: {
       order: "pre",
       handler(html) {
-        if (!env.GESTALT_DEV_PORT?.trim()) {
+        const devPort = env.GESTALT_DEV_PORT?.trim();
+        if (!devPort) {
           return html;
         }
-        const devBase = normalizeBasePath(env.GESTALT_DEV_BASE_PATH);
-        if (/<base\b/i.test(html)) {
-          return html;
+        const appName = env.GESTALT_APP_NAME?.trim();
+        if (!appName) {
+          throw new Error(MANAGED_DEV_APP_NAME_ERROR);
+        }
+        const injection = [
+          `<meta name="gestalt-app-name" content="${escapeHtmlAttribute(appName)}">`,
+        ];
+        if (!/<base\b/i.test(html)) {
+          injection.push(
+            `<base href="${escapeHtmlAttribute(normalizeBasePath(env.GESTALT_DEV_BASE_PATH))}">`,
+          );
         }
         return html.replace(
           /<head(\s[^>]*)?>/i,
-          (match) => `${match}<base href="${devBase}">`,
+          (match) => `${match}${injection.join("")}`,
         );
       },
     },

--- a/sdk/typescript/tests/indexeddb.transport.test.ts
+++ b/sdk/typescript/tests/indexeddb.transport.test.ts
@@ -9,6 +9,8 @@ import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:tes
 import {
   ENV_HOST_SERVICE_SOCKET,
   ENV_HOST_SERVICE_TOKEN,
+} from "../src/host-service.ts";
+import {
   IndexedDB,
   NotFoundError,
   AlreadyExistsError,
@@ -16,7 +18,7 @@ import {
   ColumnType,
   bound,
   only,
-} from "../src/index.ts";
+} from "../src/providers/indexeddb.ts";
 
 const REPO_ROOT = join(import.meta.dir, "..", "..", "..");
 const GESTALTD_DIR = join(REPO_ROOT, "gestaltd");

--- a/sdk/typescript/tests/mount.test.ts
+++ b/sdk/typescript/tests/mount.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 
-import { base } from "../src/mount.ts";
+import { appApiBase, appName, base } from "../src/mount.ts";
 
 type BaseElement = {
   tagName: string;
@@ -8,32 +8,48 @@ type BaseElement = {
   getAttribute?: (name: string) => string | null;
 };
 
-function installDocument(baseEl: BaseElement | null): void {
-  (globalThis as { document?: { querySelector(selector: string): BaseElement | null } }).document = {
+type MetaElement = {
+  tagName: string;
+  content: string;
+  getAttribute?: (name: string) => string | null;
+};
+
+function installDocument(
+  baseEl: BaseElement | null,
+  appMeta: MetaElement | null = null,
+): void {
+  (globalThis as {
+    document?: {
+      querySelector(selector: string): BaseElement | MetaElement | null;
+    };
+  }).document = {
     querySelector(selector: string) {
       if (selector === "base[href]") {
         return baseEl;
+      }
+      if (selector === 'meta[name="gestalt-app-name"]') {
+        return appMeta;
       }
       return null;
     },
   };
 }
 
-describe("base", () => {
+describe("mount", () => {
   afterEach(() => {
     delete (globalThis as { document?: unknown }).document;
   });
 
-  test("throws without a browser document", () => {
+  test("base throws without a browser document", () => {
     expect(() => base()).toThrow("base() requires a browser document");
   });
 
-  test("throws without a base href element", () => {
+  test("base throws without a base href element", () => {
     installDocument(null);
     expect(() => base()).toThrow("base() requires <base href> to be present in the document");
   });
 
-  test("returns the mount prefix without a trailing slash", () => {
+  test("base returns the mount prefix without a trailing slash", () => {
     installDocument({
       tagName: "BASE",
       href: "http://example.com/example-app/",
@@ -41,7 +57,7 @@ describe("base", () => {
     expect(base()).toBe("/example-app");
   });
 
-  test("resolves a relative base href from HTMLBaseElement.href", () => {
+  test("base resolves a relative base href from HTMLBaseElement.href", () => {
     installDocument({
       tagName: "BASE",
       href: "http://example.com/mounted-app/",
@@ -52,11 +68,47 @@ describe("base", () => {
     expect(base()).toBe("/mounted-app");
   });
 
-  test("returns empty string for a root mount", () => {
+  test("base returns empty string for a root mount", () => {
     installDocument({
       tagName: "BASE",
       href: "http://example.com/",
     });
     expect(base()).toBe("");
+  });
+
+  test("appName throws without a browser document", () => {
+    expect(() => appName()).toThrow("appName() requires a browser document");
+  });
+
+  test("appName throws without gestalt app metadata", () => {
+    installDocument(null, null);
+    expect(() => appName()).toThrow("gestalt-app-name");
+  });
+
+  test("appName throws for empty metadata content", () => {
+    installDocument(null, { tagName: "META", content: "   " });
+    expect(() => appName()).toThrow("gestalt-app-name");
+  });
+
+  test("appName and appApiBase use trimmed registered app key", () => {
+    installDocument(null, { tagName: "META", content: "  ci_cd  " });
+    expect(appName()).toBe("ci_cd");
+    expect(appApiBase()).toBe("/api/v1/ci_cd");
+  });
+
+  test("appApiBase uri-encodes app keys with reserved characters", () => {
+    installDocument(null, { tagName: "META", content: "app/with space" });
+    expect(appApiBase()).toBe("/api/v1/app%2Fwith%20space");
+  });
+
+  test("appApiBase does not derive identity from base href mount", () => {
+    installDocument(
+      {
+        tagName: "BASE",
+        href: "http://example.com/ci-cd/",
+      },
+      { tagName: "META", content: "ci_cd" },
+    );
+    expect(appApiBase()).toBe("/api/v1/ci_cd");
   });
 });

--- a/sdk/typescript/tests/vite-plugin.test.ts
+++ b/sdk/typescript/tests/vite-plugin.test.ts
@@ -95,6 +95,7 @@ describe("gestalt vite plugin", () => {
           gestalt({
             env: {
               GESTALT_DEV_PORT: "5173",
+              GESTALT_APP_NAME: "ciCd",
               GESTALT_DEV_BASE_PATH: "/example",
               GESTALT_BASE_URL: "http://127.0.0.1:65003",
             },
@@ -132,6 +133,7 @@ describe("gestalt vite plugin", () => {
           gestalt({
             env: {
               GESTALT_DEV_PORT: "5173",
+              GESTALT_APP_NAME: "ciCd",
               GESTALT_API_PROXY_TARGET: "http://127.0.0.1:9000",
             },
           }),
@@ -156,6 +158,7 @@ describe("gestalt vite plugin", () => {
           gestalt({
             env: {
               GESTALT_DEV_PORT: "5173",
+              GESTALT_APP_NAME: "ciCd",
               GESTALT_DEV_API_PROXY_TOKEN: "test-token",
             },
           }),
@@ -177,8 +180,6 @@ describe("gestalt vite plugin", () => {
       headers: { host: "127.0.0.1:5173" },
     });
     expect(authorization).toBe("Bearer test-token");
-
-    expect(authorization).toBe("Bearer test-token");
   });
 
   test("live dev server serves mount with foreign Host and injected base tag", async () => {
@@ -195,6 +196,7 @@ describe("gestalt vite plugin", () => {
       const port = await freePort();
       const env = {
         GESTALT_DEV_PORT: String(port),
+        GESTALT_APP_NAME: "ci_cd",
         GESTALT_DEV_BASE_PATH: basePath,
       };
       const server = await createViteServer({
@@ -211,6 +213,7 @@ describe("gestalt vite plugin", () => {
       expect(response.status).toBe(200);
       const html = await response.text();
       expect(html).toContain(wantBase);
+      expect(html).toContain('<meta name="gestalt-app-name" content="ci_cd">');
       await server.close();
       viteServers.pop();
     }
@@ -230,6 +233,52 @@ describe("gestalt vite plugin", () => {
     expect(html).not.toMatch(/\ssrc=["']\//);
     expect(html).not.toMatch(/\shref=["']\//);
     expect(html).toMatch(/\ssrc=["']\.\//);
+    expect(html).not.toContain("gestalt-app-name");
+  });
+
+  test("escapes app name in injected metadata", async () => {
+    const port = await freePort();
+    const env = {
+      GESTALT_DEV_PORT: String(port),
+      GESTALT_APP_NAME: 'app" onclick="alert(1)',
+      GESTALT_DEV_BASE_PATH: "/example",
+    };
+    const server = await createViteServer({
+      configFile: false,
+      root: fixtureRoot,
+      plugins: [gestalt({ env })],
+    });
+    viteServers.push(server);
+    await server.listen();
+
+    const response = await fetch(`http://127.0.0.1:${port}/example/`);
+    expect(response.status).toBe(200);
+    const html = await response.text();
+    expect(html).toContain(
+      '<meta name="gestalt-app-name" content="app&quot; onclick=&quot;alert(1)">',
+    );
+    expect(html).not.toContain('content="app" onclick="alert(1)"');
+    await server.close();
+    viteServers.pop();
+  });
+
+  test("GESTALT_DEV_PORT without GESTALT_APP_NAME is rejected", async () => {
+    await expect(
+      resolveConfig(
+        {
+          configFile: false,
+          root: fixtureRoot,
+          plugins: [
+            gestalt({
+              env: {
+                GESTALT_DEV_PORT: "5173",
+              },
+            }),
+          ],
+        },
+        "serve",
+      ),
+    ).rejects.toThrow("GESTALT_APP_NAME is required");
   });
 
   test("occupied port rejects with strictPort", async () => {
@@ -243,6 +292,7 @@ describe("gestalt vite plugin", () => {
         gestalt({
           env: {
             GESTALT_DEV_PORT: String(port),
+            GESTALT_APP_NAME: "ciCd",
             GESTALT_DEV_BASE_PATH: "/example",
           },
         }),


### PR DESCRIPTION
## Summary
- Inject `gestalt-app-name` metadata when serving mounted app HTML and in managed Vite dev
- Add `appName()` / `appApiBase()` browser helpers on `@valon-technologies/gestalt/mount`
- Pass `GESTALT_APP_NAME` to supervised dev commands and resolve empty app-owned workflow self-targets at bootstrap

## Test plan
- [x] `go test ./internal/server/... ./internal/bootstrap/... ./services/ui/... ./services/providerdev/...`
- [x] `bun run check` in `sdk/typescript`

Made with [Cursor](https://cursor.com)