### PR TITLE
Make gestaltd Helm chart deployment strategy configurable

### DIFF
--- a/gestaltd/deploy/helm/gestaltd/templates/deployment.yaml
+++ b/gestaltd/deploy/helm/gestaltd/templates/deployment.yaml
@@ -13,12 +13,21 @@ spec:
   {{- end }}
   {{- $updateStrategy := .Values.updateStrategy | default dict }}
   {{- $strategyType := default "Recreate" $updateStrategy.type }}
+  {{- $rollingUpdate := default dict $updateStrategy.rollingUpdate }}
   strategy:
     type: {{ $strategyType }}
     {{- if eq $strategyType "RollingUpdate" }}
     rollingUpdate:
-      maxUnavailable: {{ default 0 $updateStrategy.rollingUpdate.maxUnavailable }}
-      maxSurge: {{ default 1 $updateStrategy.rollingUpdate.maxSurge }}
+      {{- if hasKey $rollingUpdate "maxUnavailable" }}
+      maxUnavailable: {{ $rollingUpdate.maxUnavailable }}
+      {{- else }}
+      maxUnavailable: 0
+      {{- end }}
+      {{- if hasKey $rollingUpdate "maxSurge" }}
+      maxSurge: {{ $rollingUpdate.maxSurge }}
+      {{- else }}
+      maxSurge: 1
+      {{- end }}
     {{- end }}
   selector:
     matchLabels:

--- a/gestaltd/deploy/helm/gestaltd/templates/deployment.yaml
+++ b/gestaltd/deploy/helm/gestaltd/templates/deployment.yaml
@@ -11,8 +11,15 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  {{- $updateStrategy := .Values.updateStrategy | default dict }}
+  {{- $strategyType := default "Recreate" $updateStrategy.type }}
   strategy:
-    type: Recreate
+    type: {{ $strategyType }}
+    {{- if eq $strategyType "RollingUpdate" }}
+    rollingUpdate:
+      maxUnavailable: {{ default 0 $updateStrategy.rollingUpdate.maxUnavailable }}
+      maxSurge: {{ default 1 $updateStrategy.rollingUpdate.maxSurge }}
+    {{- end }}
   selector:
     matchLabels:
       {{- include "gestaltd.selectorLabels" . | nindent 6 }}

--- a/gestaltd/deploy/helm/gestaltd/values.yaml
+++ b/gestaltd/deploy/helm/gestaltd/values.yaml
@@ -69,9 +69,6 @@ persistence:
     - ReadWriteOnce
   size: 1Gi
 
-# Deployment rollout strategy. Use Recreate when persistence is enabled so a
-# single-replica pod can remount ReadWriteOnce volumes. Use RollingUpdate for
-# external datastores without PVCs to avoid gateway gaps during upgrades.
 updateStrategy:
   type: Recreate
   rollingUpdate:

--- a/gestaltd/deploy/helm/gestaltd/values.yaml
+++ b/gestaltd/deploy/helm/gestaltd/values.yaml
@@ -69,6 +69,15 @@ persistence:
     - ReadWriteOnce
   size: 1Gi
 
+# Deployment rollout strategy. Use Recreate when persistence is enabled so a
+# single-replica pod can remount ReadWriteOnce volumes. Use RollingUpdate for
+# external datastores without PVCs to avoid gateway gaps during upgrades.
+updateStrategy:
+  type: Recreate
+  rollingUpdate:
+    maxUnavailable: 0
+    maxSurge: 1
+
 # Mounted as /etc/gestaltd/config.yaml. The app expands ${ENV_VAR}
 # placeholders at startup, so secrets can be injected via extraEnv when
 # you enable OAuth/OIDC or an external datastore below.


### PR DESCRIPTION
## Summary
- Add `updateStrategy` chart values (`type`, `rollingUpdate.maxUnavailable`, `rollingUpdate.maxSurge`).
- Default remains `Recreate` for the local/persistence-backed chart profile.
- Template renders `RollingUpdate` rollingUpdate fields only when type is `RollingUpdate`.

## Why
valon-tools was post-rendering rendered manifests to swap `Recreate` → `RollingUpdate`. Strategy should live in chart values instead.

## Test plan
- [x] `helm template test .` → `Recreate`
- [x] `helm template test . --set updateStrategy.type=RollingUpdate` → `RollingUpdate` with maxSurge 1 / maxUnavailable 0

## Follow-up
After merge, bump `GESTALTD_COMMIT_SHA` in valon-tools before merging valon-technologies/valon-tools#225.


Made with [Cursor](https://cursor.com)