### PR TITLE
[gestaltd] start app providers after listener binds

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -258,6 +258,7 @@ type Result struct {
 	WorkflowControl        WorkflowControl
 	AgentControl           AgentControl
 	AgentManager           agentmanager.Service
+	StartupProvidersReady  <-chan struct{}
 	ProvidersReady         <-chan struct{}
 	ConnectionAuth         func() map[string]map[string]OAuthHandler
 	ManualConnectionAuth   func() map[string]map[string]ManualTokenExchanger
@@ -276,12 +277,54 @@ type Result struct {
 	runtimeRegistry                     *runtimeRegistry
 	workflowConfigReconcileTasks        []workflowConfigReconcileTask
 	workflowConfigReconcileTasksStarted bool
+	startupWorkflowConfigReconcile      func(context.Context) error
+	startupWorkflowConfigReconcileOnce  sync.Once
+	startupWorkflowConfigReconcileErr   error
+	startupOperations                   sync.WaitGroup
 	auditClose                          func(context.Context) error
 	appHostServiceCleanup               func()
+	startAppProviders                   func()
 	activateAppProviders                func(context.Context)
+	startup                             *deferredProviders
 	deferred                            *deferredProviders
 	mu                                  sync.Mutex
 	closed                              bool
+}
+
+// StartAppProviders starts app providers that are required during normal
+// server startup. Daemons may defer this until after their public listener is
+// bound so hosted apps can call back through the public host-service relay
+// while they configure.
+func (r *Result) StartAppProviders(ctx context.Context) error {
+	if r == nil || r.startAppProviders == nil {
+		return nil
+	}
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return fmt.Errorf("bootstrap result already closed")
+	}
+	if r.startup != nil {
+		r.startup.markActivating()
+	}
+	r.startupOperations.Add(1)
+	ready := r.StartupProvidersReady
+	r.mu.Unlock()
+	defer r.startupOperations.Done()
+	r.startAppProviders()
+	if ready != nil {
+		select {
+		case <-ready:
+		case <-ctx.Done():
+			return fmt.Errorf("app provider startup interrupted: %w", ctx.Err())
+		}
+	}
+	r.startupWorkflowConfigReconcileOnce.Do(func() {
+		if r.startupWorkflowConfigReconcile != nil {
+			r.startupWorkflowConfigReconcileErr = r.startupWorkflowConfigReconcile(ctx)
+		}
+	})
+	return r.startupWorkflowConfigReconcileErr
 }
 
 func (r *Result) ActivateAppProviders(ctx context.Context) {
@@ -401,6 +444,13 @@ func (r *Result) Close(ctx context.Context) error {
 	defer r.mu.Unlock()
 	if r.closed {
 		return nil
+	}
+	// StartAppProviders continues past provider readiness to reconcile workflow
+	// declarations. Wait for that entire operation before closing its runtime
+	// dependencies.
+	r.startupOperations.Wait()
+	if r.startup != nil {
+		r.startup.waitReady()
 	}
 	if r.deferred != nil {
 		r.deferred.waitReady()
@@ -1163,7 +1213,15 @@ func (p *preparedCore) Close(ctx context.Context) error {
 	return errors.Join(errs...)
 }
 
+type BootstrapOptions struct {
+	DeferAppProviderStartup bool
+}
+
 func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegistry) (*Result, error) {
+	return BootstrapWithOptions(ctx, cfg, factories, BootstrapOptions{})
+}
+
+func BootstrapWithOptions(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, opts BootstrapOptions) (*Result, error) {
 	prepared, err := prepareCore(ctx, cfg, factories, true)
 	if err != nil {
 		return nil, err
@@ -1188,17 +1246,15 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	}
 	providers := providerBuilds.providers
 	var (
-		noopReady              <-chan struct{}
 		connAuthResolver       func() map[string]map[string]OAuthHandler
 		manualConnAuthResolver func() map[string]map[string]ManualTokenExchanger
 	)
+	startup := newDeferredProviders()
 	deferred := newDeferredProviders()
 	closeProviders := true
 	defer func() {
 		if closeProviders {
-			if noopReady != nil {
-				<-noopReady
-			}
+			startup.waitReady()
 			deferred.waitReady()
 			_ = CloseProviders(providers)
 		}
@@ -1301,18 +1357,26 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		}
 	}
 
-	var noopConnAuth func() map[string]map[string]OAuthHandler
-	var noopManualConnAuth func() map[string]map[string]ManualTokenExchanger
-	noopReady, noopConnAuth, noopManualConnAuth, _ = noopBuilds.Start(ctx, prepared.Deps, buildProvider)
-	select {
-	case <-noopReady:
-	case <-ctx.Done():
-		return nil, fmt.Errorf("app provider startup interrupted: %w", ctx.Err())
+	startStartupProviders := newProviderActivation(ctx, noopBuilds, prepared.Deps, buildProvider, func(
+		ready <-chan struct{},
+		connAuth func() map[string]map[string]OAuthHandler,
+		manualConnAuth func() map[string]map[string]ManualTokenExchanger,
+	) {
+		startup.set(connAuth, manualConnAuth)
+		go func() {
+			<-ready
+			startup.finish()
+			slog.InfoContext(ctx, "all ready-blocking app providers loaded", "count", len(noopBuilds.pending))
+		}()
+	})
+	if !opts.DeferAppProviderStartup {
+		startStartupProviders()
+		select {
+		case <-startup.ready():
+		case <-ctx.Done():
+			return nil, fmt.Errorf("app provider startup interrupted: %w", ctx.Err())
+		}
 	}
-	slog.InfoContext(ctx, "all ready-blocking app providers loaded", "count", len(noopBuilds.pending))
-
-	noopAuth := noopConnAuth()
-	noopManualAuth := noopManualConnAuth()
 
 	startDeferredProviders := newProviderActivation(ctx, updateBuilds, prepared.Deps, buildProvider, func(
 		ready <-chan struct{},
@@ -1326,17 +1390,24 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		}()
 	})
 	activateAppProviders := func(context.Context) { startDeferredProviders() }
-	if autoActivate {
+	if autoActivate && !opts.DeferAppProviderStartup {
 		startDeferredProviders()
+	}
+	startAppProviders := func() {
+		startStartupProviders()
+		if autoActivate {
+			startDeferredProviders()
+		}
 	}
 
 	connAuthResolver = func() map[string]map[string]OAuthHandler {
+		a := startup.connectionAuth()
 		b := deferred.connectionAuth()
 		if len(b) == 0 {
-			return noopAuth
+			return a
 		}
-		merged := make(map[string]map[string]OAuthHandler, len(noopAuth)+len(b))
-		for k, v := range noopAuth {
+		merged := make(map[string]map[string]OAuthHandler, len(a)+len(b))
+		for k, v := range a {
 			merged[k] = v
 		}
 		for k, v := range b {
@@ -1345,12 +1416,13 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		return merged
 	}
 	manualConnAuthResolver = func() map[string]map[string]ManualTokenExchanger {
+		a := startup.manualConnectionAuth()
 		b := deferred.manualConnectionAuth()
 		if len(b) == 0 {
-			return noopManualAuth
+			return a
 		}
-		merged := make(map[string]map[string]ManualTokenExchanger, len(noopManualAuth)+len(b))
-		for k, v := range noopManualAuth {
+		merged := make(map[string]map[string]ManualTokenExchanger, len(a)+len(b))
+		for k, v := range a {
 			merged[k] = v
 		}
 		for k, v := range b {
@@ -1373,17 +1445,26 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		slog.Warn("skipping deferred app workflow declaration reconcile: no default workflow provider configured")
 	}
 	runtimePlacedWorkflowProviders := runtimePlacedWorkflowProviderNames(cfg)
+	var startupWorkflowConfigReconcile func(context.Context) error
 	if len(runtimePlacedWorkflowProviders) > 0 {
 		localWorkflowProviders := func(providerName string) bool {
 			_, runtimePlaced := runtimePlacedWorkflowProviders[strings.TrimSpace(providerName)]
 			return !runtimePlaced
 		}
-		if err := reconcileWorkflowConfig(ctx, localWorkflowProviders); err != nil {
-			return nil, err
+		startupWorkflowConfigReconcile = func(ctx context.Context) error {
+			return reconcileWorkflowConfig(ctx, localWorkflowProviders)
 		}
 		deferredWorkflowConfigReconcileTasks = append(deferredWorkflowConfigReconcileTasks, runtimeWorkflowConfigReconcileTasks(prepared.Deps.WorkflowRuntime, runtimePlacedWorkflowProviders, reconcileWorkflowConfig)...)
-	} else if err := reconcileWorkflowConfig(ctx, nil); err != nil {
-		return nil, err
+	} else {
+		startupWorkflowConfigReconcile = func(ctx context.Context) error {
+			return reconcileWorkflowConfig(ctx, nil)
+		}
+	}
+	if !opts.DeferAppProviderStartup {
+		if err := startupWorkflowConfigReconcile(ctx); err != nil {
+			return nil, err
+		}
+		startupWorkflowConfigReconcile = nil
 	}
 
 	publicGatewayTransport, err := buildPublicGatewayTransport(cfg, prepared.Auth, prepared.Authorization, prepared.Services.Users)
@@ -1397,41 +1478,45 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	closeWorkflowsOnError = false
 	closeAgentsOnError = false
 	result := &Result{
-		Auth:                         prepared.Auth,
-		SelectedAuthProvider:         prepared.SelectedAuthProvider,
-		AuthProviders:                prepared.AuthProviders,
-		Authorization:                prepared.Authorization,
-		Services:                     prepared.Services,
-		ExtraIndexedDBs:              prepared.ExtraIndexedDBs,
-		ExtraCaches:                  prepared.ExtraCaches,
-		S3:                           prepared.Deps.S3,
-		ExtraS3s:                     prepared.ExtraS3s,
-		ExtraWorkflows:               extraWorkflows,
-		ExtraAgents:                  extraAgents,
-		Providers:                    providers,
-		WorkflowControl:              prepared.Deps.WorkflowRuntime,
-		AgentControl:                 prepared.Deps.AgentRuntime,
-		AgentManager:                 prepared.Deps.AgentManager,
-		ProvidersReady:               deferred.ready(),
-		ConnectionAuth:               connAuthResolver,
-		ManualConnectionAuth:         manualConnAuthResolver,
-		Invoker:                      sharedInvoker,
-		AppInvocation:                pluginInvoker,
-		CapabilityLister:             sharedInvoker,
-		AuditSink:                    audit,
-		SecretManager:                prepared.SecretManager,
-		Telemetry:                    prepared.Telemetry,
-		Runtimes:                     prepared.runtimeRegistry,
-		PublicHostServices:           publicHostServices,
-		PublicGatewayTransport:       publicGatewayTransport,
-		CallerTokenIssuer:            prepared.CallerTokenIssuer,
-		DevSupervisor:                prepared.Deps.DevSupervisor,
-		runtimeRegistry:              prepared.runtimeRegistry,
-		workflowConfigReconcileTasks: deferredWorkflowConfigReconcileTasks,
-		auditClose:                   auditClose,
-		appHostServiceCleanup:        appHostServiceCleanup,
-		activateAppProviders:         activateAppProviders,
-		deferred:                     deferred,
+		Auth:                           prepared.Auth,
+		SelectedAuthProvider:           prepared.SelectedAuthProvider,
+		AuthProviders:                  prepared.AuthProviders,
+		Authorization:                  prepared.Authorization,
+		Services:                       prepared.Services,
+		ExtraIndexedDBs:                prepared.ExtraIndexedDBs,
+		ExtraCaches:                    prepared.ExtraCaches,
+		S3:                             prepared.Deps.S3,
+		ExtraS3s:                       prepared.ExtraS3s,
+		ExtraWorkflows:                 extraWorkflows,
+		ExtraAgents:                    extraAgents,
+		Providers:                      providers,
+		WorkflowControl:                prepared.Deps.WorkflowRuntime,
+		AgentControl:                   prepared.Deps.AgentRuntime,
+		AgentManager:                   prepared.Deps.AgentManager,
+		StartupProvidersReady:          startup.ready(),
+		ProvidersReady:                 deferred.ready(),
+		ConnectionAuth:                 connAuthResolver,
+		ManualConnectionAuth:           manualConnAuthResolver,
+		Invoker:                        sharedInvoker,
+		AppInvocation:                  pluginInvoker,
+		CapabilityLister:               sharedInvoker,
+		AuditSink:                      audit,
+		SecretManager:                  prepared.SecretManager,
+		Telemetry:                      prepared.Telemetry,
+		Runtimes:                       prepared.runtimeRegistry,
+		PublicHostServices:             publicHostServices,
+		PublicGatewayTransport:         publicGatewayTransport,
+		CallerTokenIssuer:              prepared.CallerTokenIssuer,
+		DevSupervisor:                  prepared.Deps.DevSupervisor,
+		runtimeRegistry:                prepared.runtimeRegistry,
+		workflowConfigReconcileTasks:   deferredWorkflowConfigReconcileTasks,
+		startupWorkflowConfigReconcile: startupWorkflowConfigReconcile,
+		auditClose:                     auditClose,
+		appHostServiceCleanup:          appHostServiceCleanup,
+		startAppProviders:              startAppProviders,
+		activateAppProviders:           activateAppProviders,
+		startup:                        startup,
+		deferred:                       deferred,
 	}
 	for _, pending := range updateBuilds.pending {
 		if pending.proxy != nil {

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -5318,6 +5318,68 @@ func TestBootstrapAllowsAppConfiguredWithBothOpenAPIAndGraphQLAPISurfaces(t *tes
 	}
 }
 
+func TestBootstrapCanDeferAppProviderStartup(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"openapi":"3.0.0",
+			"info":{"title":"deferred","version":"1.0.0"},
+			"paths":{"/status":{"get":{"operationId":"status","responses":{"200":{"description":"ok"}}}}}
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := validConfig()
+	cfg.Apps = map[string]*config.ProviderEntry{
+		"deferred": {
+			ResolvedManifest: &providermanifestv1.Manifest{
+				Spec: &providermanifestv1.Spec{
+					DefaultConnection: config.AppConnectionName,
+					Connections: map[string]*providermanifestv1.ManifestConnectionDef{
+						config.AppConnectionName: {Mode: providermanifestv1.ConnectionModeNone},
+					},
+					Surfaces: &providermanifestv1.ProviderSurfaces{
+						OpenAPI: &providermanifestv1.OpenAPISurface{Document: srv.URL, BaseURL: srv.URL},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := bootstrap.BootstrapWithOptions(context.Background(), cfg, validFactories(), bootstrap.BootstrapOptions{
+		DeferAppProviderStartup: true,
+	})
+	if err != nil {
+		t.Fatalf("BootstrapWithOptions: %v", err)
+	}
+	t.Cleanup(func() { _ = result.Close(context.Background()) })
+
+	if got := requests.Load(); got != 0 {
+		t.Fatalf("app provider requests before startup = %d, want 0", got)
+	}
+	select {
+	case <-result.StartupProvidersReady:
+		t.Fatal("startup providers became ready before StartAppProviders")
+	default:
+	}
+
+	if err := result.StartAppProviders(context.Background()); err != nil {
+		t.Fatalf("StartAppProviders: %v", err)
+	}
+	select {
+	case <-result.StartupProvidersReady:
+	case <-time.After(5 * time.Second):
+		t.Fatal("startup providers did not become ready")
+	}
+	if got := requests.Load(); got == 0 {
+		t.Fatal("app provider did not load its OpenAPI document after startup")
+	}
+}
+
 func TestBootstrapNoIntegrations(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/gestaltd/internal/bootstrap/provider_activation_test.go
+++ b/gestaltd/internal/bootstrap/provider_activation_test.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -9,6 +10,118 @@ import (
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 )
+
+func TestResultStartAppProvidersReconcilesAfterProvidersReady(t *testing.T) {
+	t.Parallel()
+
+	startup := newDeferredProviders()
+	release := make(chan struct{})
+	var started atomic.Bool
+	var reconciled atomic.Int32
+	wantErr := errors.New("reconcile failed")
+	result := &Result{
+		StartupProvidersReady: startup.ready(),
+		startup:               startup,
+		startAppProviders: func() {
+			if !started.CompareAndSwap(false, true) {
+				return
+			}
+			startup.set(nil, nil)
+			go func() {
+				<-release
+				startup.finish()
+			}()
+		},
+		startupWorkflowConfigReconcile: func(context.Context) error {
+			reconciled.Add(1)
+			return wantErr
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- result.StartAppProviders(context.Background()) }()
+
+	select {
+	case err := <-done:
+		t.Fatalf("StartAppProviders returned before providers were ready: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	if got := reconciled.Load(); got != 0 {
+		t.Fatalf("workflow reconciliations before providers were ready = %d, want 0", got)
+	}
+
+	close(release)
+	select {
+	case err := <-done:
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("StartAppProviders error = %v, want %v", err, wantErr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("StartAppProviders did not finish after providers became ready")
+	}
+	if got := reconciled.Load(); got != 1 {
+		t.Fatalf("workflow reconciliations = %d, want 1", got)
+	}
+	if err := result.StartAppProviders(context.Background()); !errors.Is(err, wantErr) {
+		t.Fatalf("second StartAppProviders error = %v, want %v", err, wantErr)
+	}
+	if got := reconciled.Load(); got != 1 {
+		t.Fatalf("workflow reconciliations after second start = %d, want 1", got)
+	}
+}
+
+func TestResultStartupOperationsWaitForWorkflowReconcile(t *testing.T) {
+	t.Parallel()
+
+	startup := newDeferredProviders()
+	startup.finish()
+	reconcileStarted := make(chan struct{})
+	reconcileRelease := make(chan struct{})
+	result := &Result{
+		StartupProvidersReady: startup.ready(),
+		startup:               startup,
+		startAppProviders:     func() {},
+		startupWorkflowConfigReconcile: func(context.Context) error {
+			close(reconcileStarted)
+			<-reconcileRelease
+			return nil
+		},
+	}
+
+	startDone := make(chan error, 1)
+	go func() { startDone <- result.StartAppProviders(context.Background()) }()
+	select {
+	case <-reconcileStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("workflow reconciliation did not start")
+	}
+
+	waitDone := make(chan struct{})
+	go func() {
+		result.startupOperations.Wait()
+		close(waitDone)
+	}()
+	select {
+	case <-waitDone:
+		t.Fatal("startup operation completed while workflow reconciliation was running")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(reconcileRelease)
+	select {
+	case err := <-startDone:
+		if err != nil {
+			t.Fatalf("StartAppProviders: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("StartAppProviders did not finish")
+	}
+	select {
+	case <-waitDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("startup operation wait did not finish after reconciliation")
+	}
+}
 
 func TestNewProviderActivationStartsProvidersOnce(t *testing.T) {
 	t.Parallel()

--- a/gestaltd/internal/daemon/factories.go
+++ b/gestaltd/internal/daemon/factories.go
@@ -59,7 +59,9 @@ func setupBootstrapWithConfigPathsContext(ctx context.Context, stop context.Canc
 	}
 	factories.DevSupervisor = devSupervisor
 
-	result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+	result, err := bootstrap.BootstrapWithOptions(ctx, cfg, factories, bootstrap.BootstrapOptions{
+		DeferAppProviderStartup: true,
+	})
 	if err != nil {
 		if devSupervisor != nil {
 			devSupervisor.Stop()

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -263,6 +263,12 @@ func serveRuntime(ctx context.Context, cfg *config.Config, connMaps bootstrap.Co
 
 	workflowErr := make(chan error, 1)
 	go func() {
+		if err := result.StartAppProviders(ctx); err != nil {
+			if ctx.Err() == nil {
+				workflowErr <- err
+			}
+			return
+		}
 		if err := result.StartWorkflowProviders(ctx); err != nil {
 			workflowErr <- err
 			return


### PR DESCRIPTION
## Description

Defer daemon app-provider activation until the public socket is bound so hosted apps can use the host-service relay during configuration. Wait for required apps and reconcile their workflow declarations before starting workflow providers or becoming ready.