### PR TITLE
Report lockfile destination

### DIFF
--- a/gestaltd/internal/daemon/e2e/main_test.go
+++ b/gestaltd/internal/daemon/e2e/main_test.go
@@ -232,16 +232,27 @@ func TestE2ESyncDefaultSuccessReportsProgressAndQuietSuppressesIt(t *testing.T) 
 		t.Fatalf("write build script: %v", err)
 	}
 	configPath := writeE2EConfig(t, dir, appDir, 18080)
+	lockPath := filepath.Join(dir, "gestalt.lock.json")
 
-	out, err := gestaltdCommand("lock", "--config", configPath).CombinedOutput()
+	out, err := gestaltdCommand("lock", "--config", configPath, "--lockfile", lockPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("gestaltd lock: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "Lockfile written to "+lockPath) {
+		t.Fatalf("lock output missing destination %q:\n%s", lockPath, out)
+	}
+	out, err = gestaltdCommand("lock", "--check", "--config", configPath, "--lockfile", lockPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd lock --check: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "Lockfile is up to date: "+lockPath) {
+		t.Fatalf("lock --check output missing current status for %q:\n%s", lockPath, out)
 	}
 	if err := os.RemoveAll(filepath.Join(dir, "providers", "example")); err != nil {
 		t.Fatalf("remove prepared provider: %v", err)
 	}
 
-	cmd := gestaltdCommand("sync", "--locked", "--config", configPath)
+	cmd := gestaltdCommand("sync", "--locked", "--config", configPath, "--lockfile", lockPath)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -263,7 +274,7 @@ func TestE2ESyncDefaultSuccessReportsProgressAndQuietSuppressesIt(t *testing.T) 
 	if err := os.RemoveAll(filepath.Join(dir, "providers", "example")); err != nil {
 		t.Fatalf("remove prepared provider for quiet sync: %v", err)
 	}
-	quiet := gestaltdCommand("sync", "--quiet", "--locked", "--config", configPath)
+	quiet := gestaltdCommand("sync", "--quiet", "--locked", "--config", configPath, "--lockfile", lockPath)
 	stdout.Reset()
 	stderr.Reset()
 	quiet.Stdout = &stdout

--- a/gestaltd/internal/daemon/lifecycle.go
+++ b/gestaltd/internal/daemon/lifecycle.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
@@ -81,6 +82,10 @@ func formatLifecycleProgressComplete(event operator.LifecycleProgressEvent) stri
 		return "Lockfile not required"
 	case event.Status == operator.LifecycleProgressNoop:
 		return "No artifact changes needed"
+	case event.Operation == operator.LifecycleOperationLock && event.Phase == operator.LifecyclePhaseLock && event.Reason == "written":
+		return fmt.Sprintf("Lockfile written to %s", event.Path)
+	case event.Operation == operator.LifecycleOperationLock && event.Phase == operator.LifecyclePhaseLock && event.Reason == "current":
+		return fmt.Sprintf("Lockfile is up to date: %s", event.Path)
 	case event.Operation == operator.LifecycleOperationLock && event.Phase == operator.LifecyclePhaseLock:
 		return "Lockfile ready"
 	case event.Operation == operator.LifecycleOperationSync && event.Phase == operator.LifecyclePhaseComplete:

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -278,6 +278,8 @@ func (l *Lifecycle) lockAtPaths(configPaths []string, lockfilePath, artifactsDir
 			Phase:     LifecyclePhaseLock,
 			Status:    LifecycleProgressCompleted,
 			Subject:   "lockfile",
+			Reason:    "written",
+			Path:      paths.lockfilePath,
 		})
 	}
 	return normalizeLockfile(lock), nil
@@ -315,7 +317,7 @@ func (l *Lifecycle) CheckLockAtPaths(configPaths []string, lockfilePath, artifac
 		}
 		return fmt.Errorf("lockfile is out of date; run `%s`", formatLockCommand(paths))
 	}
-	l.emitProgress(LifecycleProgressEvent{Operation: LifecycleOperationLock, Phase: LifecyclePhaseLock, Status: LifecycleProgressCompleted, Subject: "lockfile"})
+	l.emitProgress(LifecycleProgressEvent{Operation: LifecycleOperationLock, Phase: LifecyclePhaseLock, Status: LifecycleProgressCompleted, Subject: "lockfile", Reason: "current", Path: paths.lockfilePath})
 	return nil
 }
 

--- a/gestaltd/internal/operator/progress.go
+++ b/gestaltd/internal/operator/progress.go
@@ -30,8 +30,8 @@ const (
 	LifecycleProgressNoop      LifecycleProgressStatus = "noop"
 )
 
-// LifecycleProgressEvent deliberately contains summaries rather than raw
-// paths, URLs, cache keys, or subprocess output.
+// LifecycleProgressEvent contains concise operation state. A completed write
+// may include its output path.
 type LifecycleProgressEvent struct {
 	Operation LifecycleProgressOperation
 	Phase     LifecycleProgressPhase
@@ -39,6 +39,7 @@ type LifecycleProgressEvent struct {
 
 	Subject string
 	Reason  string
+	Path    string
 }
 
 func (l *Lifecycle) emitProgress(event LifecycleProgressEvent) {


### PR DESCRIPTION
## Lock lifecycle

```mermaid
sequenceDiagram
    participant Developer
    participant CLI as gestaltd
    participant Lifecycle
    participant Lockfile

    Developer->>CLI: lock [--check]
    CLI->>Lifecycle: resolve lock state
    Lifecycle->>Lockfile: write or compare
    alt write
        Lifecycle-->>Developer: written destination
    else check
        Lifecycle-->>Developer: current destination
    end
```

## Output

Before:

```text
Resolving lockfile
Lockfile ready
```

After:

```text
Resolving lockfile
Lockfile written to /path/gestalt.lock.json

# --check: Lockfile is up to date: /path/gestalt.lock.json
```

Makes the lock outcome and destination explicit without changing read-only sync or serve messaging. This gives developers a directly actionable confirmation when a configured lockfile path is written or checked.