### PR TITLE
Fix app registry install metadata JSON marshaling

### DIFF
--- a/gestaltd/internal/coredata/convert.go
+++ b/gestaltd/internal/coredata/convert.go
@@ -94,12 +94,20 @@ func jsonValue(v any) any {
 		if len(value) == 0 {
 			return nil
 		}
-		return value
+		out := make(map[string]any, len(value))
+		for k, v := range value {
+			out[k] = v
+		}
+		return out
 	case map[string]any:
 		if len(value) == 0 {
 			return nil
 		}
-		return value
+		out := make(map[string]any, len(value))
+		for k, v := range value {
+			out[k] = jsonValue(v)
+		}
+		return out
 	default:
 		return v
 	}


### PR DESCRIPTION
## Summary
- Normalize nested `map[string]string` values (e.g. `artifact_checksums`) to `map[string]any` in `jsonValue` before writing `metadata_json` on app version change requests
- Fixes registry install (`POST /admin/api/v1/app-registries/.../install`) on relational IndexedDB backends (PlanetScale), which failed with `proto: invalid type: map[string]string`

## Test plan
- [x] `go test ./internal/server/... -run TestAdminAppRegistryInstall -count=1`
- [ ] Merge and bump valon-tools dev `GESTALTD_COMMIT_SHA`
- [ ] `POST …/g-issues/install` succeeds on vt.dev.valon.tools
- [ ] Step 8 catalog poller acks within 1 minute


Made with [Cursor](https://cursor.com)