### PR TITLE
SDK-1: stabilize the public REST gateway contract

### DIFF
--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -14,7 +14,7 @@ Workflow and Agent providers never appear in paths. Mutations carry `provider` o
 
 `POST /api/v2/identity/authorize` and `POST /api/v2/identity/token` are unauthenticated. Every other `/api/v2` route requires `Authorization: Bearer <token>`.
 
-App `Invoke` and `InvokeGraphQL` forward the provider's raw HTTP status, headers, and body instead of JSON-encoding `OperationResult`.
+App `Invoke` and `InvokeGraphQL` return an outer HTTP 200 with a protobuf-JSON `OperationResult` envelope; the provider's status, headers, and body remain inside that envelope. Gateway, authentication, authorization, routing, and serialization failures use outer non-2xx canonical errors.
 
 | Service | Example routes |
 | --- | --- |

--- a/gestaltd/internal/server/middleware.go
+++ b/gestaltd/internal/server/middleware.go
@@ -128,8 +128,27 @@ func (s *Server) securityHeadersMiddleware(next http.Handler) http.Handler {
 
 var errInvalidAuthorizationHeader = errors.New("invalid authorization header format")
 
+func requestBearerTokenPreferringHeader(r *http.Request) (string, error) {
+	token, err := requestBearerToken(r)
+	if err == nil && token != "" {
+		return token, nil
+	}
+	if err != nil && !errors.Is(err, errInvalidAuthorizationHeader) {
+		return "", err
+	}
+	if c, err := r.Cookie(sessionCookieName); err == nil {
+		if token := strings.TrimSpace(c.Value); token != "" {
+			return token, nil
+		}
+	}
+	if err != nil {
+		return "", err
+	}
+	return "", nil
+}
+
 func requestBearerToken(r *http.Request) (string, error) {
-	header := r.Header.Get("Authorization")
+	header := strings.TrimSpace(r.Header.Get("Authorization"))
 	if header == "" {
 		return "", nil
 	}

--- a/gestaltd/internal/server/public_rest.go
+++ b/gestaltd/internal/server/public_rest.go
@@ -2,26 +2,13 @@ package server
 
 import (
 	"context"
-	"errors"
 	"net/http"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/valon-technologies/gestalt/server/internal/publicrpc"
-	gestaltproto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"google.golang.org/grpc"
-	gproto "google.golang.org/protobuf/proto"
+	"google.golang.org/grpc/status"
 )
-
-var errRESTResponseWritten = errors.New("rest response written")
-
-// preservedSecurityResponseHeaders are installed by securityHeadersMiddleware and must
-// survive App OperationResult passthrough.
-var preservedSecurityResponseHeaders = []string{
-	"Content-Security-Policy",
-	"X-Content-Type-Options",
-	"X-Frame-Options",
-	"Strict-Transport-Security",
-}
 
 func buildPublicGateway(cfg publicGRPCConfig) (*publicrpc.InProcessConn, http.Handler, error) {
 	if cfg.Transport == nil || cfg.Invoker == nil {
@@ -34,15 +21,20 @@ func buildPublicGateway(cfg publicGRPCConfig) (*publicrpc.InProcessConn, http.Ha
 	if err != nil {
 		return nil, nil, err
 	}
-	mux := runtime.NewServeMux(
-		runtime.WithForwardResponseOption(forwardOperationResult),
-		runtime.WithErrorHandler(publicRESTErrorHandler),
-	)
+	mux := runtime.NewServeMux(runtime.WithErrorHandler(publicRESTErrorHandler))
 	if err := publicrpc.RegisterRESTGateway(context.Background(), mux, conn.ClientConn(), servers); err != nil {
 		conn.Close()
 		return nil, nil, err
 	}
-	return conn, mux, nil
+	return conn, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token, err := requestBearerTokenPreferringHeader(r)
+		if err == nil && token != "" {
+			if headerToken, headerErr := requestBearerToken(r); headerErr == nil && headerToken == "" {
+				r.Header.Set("Authorization", "Bearer "+token)
+			}
+		}
+		mux.ServeHTTP(w, r)
+	}), nil
 }
 
 func buildPublicServers(cfg publicGRPCConfig) publicrpc.Servers {
@@ -70,58 +62,14 @@ func buildPublicServers(cfg publicGRPCConfig) publicrpc.Servers {
 	return servers
 }
 
-func forwardOperationResult(_ context.Context, w http.ResponseWriter, resp gproto.Message) error {
-	result, ok := resp.(*gestaltproto.OperationResult)
-	if !ok {
-		return nil
+func publicRESTErrorHandler(_ context.Context, _ *runtime.ServeMux, _ runtime.Marshaler, w http.ResponseWriter, _ *http.Request, err error) {
+	st := status.Convert(err)
+	httpStatus := runtime.HTTPStatusFromCode(st.Code())
+	if httpStatus == 0 {
+		httpStatus = http.StatusInternalServerError
 	}
-	writeProtoOperationResult(w, result)
-	return errRESTResponseWritten
-}
-
-func writeProtoOperationResult(w http.ResponseWriter, result *gestaltproto.OperationResult) {
-	if w == nil || result == nil {
-		return
-	}
-	headers := w.Header()
-	preserved := make(map[string][]string, len(preservedSecurityResponseHeaders))
-	for _, name := range preservedSecurityResponseHeaders {
-		if values := headers.Values(name); len(values) > 0 {
-			preserved[name] = append([]string(nil), values...)
-		}
-	}
-	headers.Del("Content-Type") // grpc-gateway's default response type.
-	for name, values := range result.GetHeaders() {
-		if values == nil {
-			continue
-		}
-		for i, value := range values.GetValues() {
-			if i == 0 {
-				headers.Set(name, value)
-			} else {
-				headers.Add(name, value)
-			}
-		}
-	}
-	for name, values := range preserved {
-		headers.Del(name)
-		for _, value := range values {
-			headers.Add(name, value)
-		}
-	}
-	statusCode := int(result.GetStatus())
-	if statusCode == 0 {
-		statusCode = http.StatusOK
-	}
-	w.WriteHeader(statusCode)
-	if body := result.GetBody(); len(body) > 0 {
-		_, _ = w.Write(body)
-	}
-}
-
-func publicRESTErrorHandler(ctx context.Context, mux *runtime.ServeMux, marshaler runtime.Marshaler, w http.ResponseWriter, r *http.Request, err error) {
-	if errors.Is(err, errRESTResponseWritten) {
-		return
-	}
-	runtime.DefaultHTTPErrorHandler(ctx, mux, marshaler, w, r, err)
+	writeJSON(w, httpStatus, apiErrorResponse{
+		Error: st.Message(),
+		Code:  st.Code().String(),
+	})
 }

--- a/gestaltd/internal/server/public_rest_test.go
+++ b/gestaltd/internal/server/public_rest_test.go
@@ -3,6 +3,8 @@ package server_test
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +16,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/publicrpc"
 	"github.com/valon-technologies/gestalt/server/internal/server"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/providergateway"
 )
 
@@ -91,7 +94,7 @@ func TestPublicRESTRouting(t *testing.T) {
 		}
 	})
 
-	t.Run("app invoke forwards raw HTTP", func(t *testing.T) {
+	t.Run("app invoke returns an OperationResult envelope", func(t *testing.T) {
 		t.Parallel()
 
 		ts := startPublicRESTServer(t, server.RouteProfilePublic, func(cfg *server.Config) {
@@ -134,17 +137,37 @@ func TestPublicRESTRouting(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ReadAll: %v", err)
 		}
-		if resp.StatusCode != http.StatusTeapot {
-			t.Fatalf("status = %d, want %d (body=%s)", resp.StatusCode, http.StatusTeapot, string(body))
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want %d (body=%s)", resp.StatusCode, http.StatusOK, string(body))
 		}
-		if got := string(body); got != "teapot" {
-			t.Fatalf("body = %q, want %q", got, "teapot")
+		var payload struct {
+			Status  int    `json:"status"`
+			Body    string `json:"body"`
+			Headers map[string]struct {
+				Values []string `json:"values"`
+			} `json:"headers"`
 		}
-		if got := resp.Header.Get("X-Example"); got != "rest-v2" {
-			t.Fatalf("X-Example = %q, want %q", got, "rest-v2")
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("OperationResult JSON = %q: %v", string(body), err)
 		}
-		if got := resp.Header.Get("Content-Type"); got != "text/plain" {
-			t.Fatalf("Content-Type = %q, want %q", got, "text/plain")
+		if payload.Status != http.StatusTeapot {
+			t.Fatalf("OperationResult.status = %d, want %d", payload.Status, http.StatusTeapot)
+		}
+		decodedBody, err := base64.StdEncoding.DecodeString(payload.Body)
+		if err != nil {
+			t.Fatalf("OperationResult.body = %q: %v", payload.Body, err)
+		}
+		if got := string(decodedBody); got != "teapot" {
+			t.Fatalf("OperationResult.body = %q, want %q", got, "teapot")
+		}
+		if got := payload.Headers["X-Example"].Values; len(got) != 1 || got[0] != "rest-v2" {
+			t.Fatalf("OperationResult X-Example = %#v, want [rest-v2]", got)
+		}
+		if got := payload.Headers["Content-Type"].Values; len(got) != 1 || got[0] != "text/plain" {
+			t.Fatalf("OperationResult Content-Type = %#v, want [text/plain]", got)
+		}
+		if got := resp.Header.Get("Content-Type"); got != "application/json" {
+			t.Fatalf("Content-Type = %q, want application/json", got)
 		}
 		if got := resp.Header.Get("X-Content-Type-Options"); got != "nosniff" {
 			t.Fatalf("X-Content-Type-Options = %q, want %q", got, "nosniff")
@@ -153,7 +176,139 @@ func TestPublicRESTRouting(t *testing.T) {
 			t.Fatalf("X-Frame-Options = %q, want %q", got, "SAMEORIGIN")
 		}
 		if got := resp.Header.Get("Content-Security-Policy"); got == "" {
-			t.Fatal("Content-Security-Policy missing after App raw HTTP passthrough")
+			t.Fatal("Content-Security-Policy missing from OperationResult response")
+		}
+	})
+
+	t.Run("gateway failures use canonical errors", func(t *testing.T) {
+		t.Parallel()
+
+		ts := startPublicRESTServer(t, server.RouteProfilePublic, nil)
+		resp, err := http.Get(ts.URL + "/api/v2/identity/userinfo")
+		if err != nil {
+			t.Fatalf("GET /api/v2/identity/userinfo: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("ReadAll: %v", err)
+		}
+		var payload struct {
+			Error string `json:"error"`
+			Code  string `json:"code"`
+		}
+		if err := json.Unmarshal(body, &payload); err != nil || payload.Error == "" {
+			t.Fatalf("body = %q, want canonical error JSON", string(body))
+		}
+		if payload.Code != "Unauthenticated" {
+			t.Fatalf("code = %q, want Unauthenticated", payload.Code)
+		}
+	})
+
+	t.Run("session cookie authenticates app invoke", func(t *testing.T) {
+		t.Parallel()
+
+		const cookieToken = "public-rest-cookie-token"
+		ts := startPublicRESTServer(t, server.RouteProfilePublic, func(cfg *server.Config) {
+			auth := authStubWithSessionTokenIntrospect(cookieToken, principal.UserSubjectID("cookie-user"), "example")
+			cfg.Auth = auth
+			cfg.PublicGatewayTransport.SetIdentityProvider(auth)
+			cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+				N:        "example",
+				ConnMode: core.ConnectionModeNone,
+				CatalogVal: &catalog.Catalog{
+					Name: "example",
+					Operations: []catalog.CatalogOperation{{
+						ID:     "sync",
+						Method: "POST",
+					}},
+				},
+				ExecuteFn: func(_ context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
+					return &core.OperationResult{Status: http.StatusOK, Body: []byte("ok")}, nil
+				},
+			})
+		})
+
+		for _, authorization := range []string{"", "   "} {
+			req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/v2/app/example/operations/sync", bytes.NewReader([]byte(`{"params":{}}`)))
+			if err != nil {
+				t.Fatalf("NewRequest: %v", err)
+			}
+			req.Header.Set("Content-Type", "application/json")
+			if authorization != "" {
+				req.Header.Set("Authorization", authorization)
+			}
+			req.AddCookie(&http.Cookie{Name: "session_token", Value: cookieToken})
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("POST invoke authorization=%q: %v", authorization, err)
+			}
+			func() {
+				defer func() { _ = resp.Body.Close() }()
+				if resp.StatusCode != http.StatusOK {
+					body, _ := io.ReadAll(resp.Body)
+					t.Fatalf("authorization=%q status = %d, want %d (body=%s)", authorization, resp.StatusCode, http.StatusOK, string(body))
+				}
+			}()
+		}
+	})
+
+	t.Run("explicit bearer wins over session cookie", func(t *testing.T) {
+		t.Parallel()
+
+		const cookieToken = "public-rest-cookie-token"
+		ts := startPublicRESTServer(t, server.RouteProfilePublic, func(cfg *server.Config) {
+			auth := testAuthStubWithIntrospect(func(_ context.Context, token string) (*core.IntrospectResponse, error) {
+				if token == cookieToken {
+					return testIntrospectActive(principal.UserSubjectID("cookie-user"), "wrong-scope"), nil
+				}
+				userID, scope, ok := parseScopedTestBearerToken(token)
+				if !ok {
+					return &core.IntrospectResponse{Active: false}, nil
+				}
+				return testIntrospectActive(principal.UserSubjectID(userID), scope), nil
+			})
+			cfg.Auth = auth
+			cfg.PublicGatewayTransport.SetIdentityProvider(auth)
+			cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+				N:        "example",
+				ConnMode: core.ConnectionModeNone,
+				CatalogVal: &catalog.Catalog{
+					Name: "example",
+					Operations: []catalog.CatalogOperation{{
+						ID:     "sync",
+						Method: "POST",
+					}},
+				},
+				ExecuteFn: func(_ context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
+					return &core.OperationResult{Status: http.StatusTeapot, Body: []byte("teapot")}, nil
+				},
+			})
+		})
+
+		req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/v2/app/example/operations/sync", bytes.NewReader([]byte(`{"params":{}}`)))
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.AddCookie(&http.Cookie{Name: "session_token", Value: cookieToken})
+		req.Header.Set("Authorization", "Bearer "+publicRESTTestBearer("example"))
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("POST invoke: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("ReadAll: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want %d (body=%s)", resp.StatusCode, http.StatusOK, string(body))
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Implements issue-119 and the REST contract in [plan-28](https://valon.tools/g-issues/plans/plan-28).

## Contract

```mermaid
sequenceDiagram
    participant Browser
    participant REST as Public REST gateway
    participant GRPC as Public gRPC service
    participant App as App provider

    Browser->>REST: request + bearer or session cookie
    REST->>GRPC: annotated protobuf request + trusted auth metadata
    GRPC->>App: authorized App.Invoke
    App-->>GRPC: OperationResult
    GRPC-->>REST: OperationResult
    REST-->>Browser: HTTP 200 + protobuf JSON envelope
    REST-->>Browser: outer non-2xx canonical error on gateway failure
```

Provider status, headers, and body remain inside the `OperationResult` envelope. There is no response marker, raw HTTP passthrough, or provider-header forwarding. An explicit bearer takes precedence over `session_token`; the cookie remains HttpOnly.

## Test plan

- [x] `go test ./internal/server`
