### PR TITLE
[app registry] coordinate provider restarts across replicas

### DIFF
--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -54,6 +54,26 @@ type AppInstanceMaterialization struct {
 	RestartedAt    time.Time
 }
 
+type AppRolloutState string
+
+const (
+	AppRolloutStateEnrolling  AppRolloutState = "enrolling"
+	AppRolloutStateRestarting AppRolloutState = "restarting"
+	AppRolloutStateComplete   AppRolloutState = "complete"
+	AppRolloutStateFailed     AppRolloutState = "failed"
+)
+
+type AppRollout struct {
+	App              string
+	Version          string
+	State            AppRolloutState
+	CreatedAt        time.Time
+	EnrollmentEndsAt time.Time
+	Deadline         time.Time
+	CompletedAt      time.Time
+	FailedAt         time.Time
+}
+
 type ExternalCredentialGrant struct {
 	AccessToken       string
 	RefreshToken      string

--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -50,6 +50,8 @@ type AppInstanceMaterialization struct {
 	App            string
 	Version        string
 	AcknowledgedAt time.Time
+	StoppedAt      time.Time
+	RestartedAt    time.Time
 }
 
 type ExternalCredentialGrant struct {

--- a/gestaltd/internal/appregistry/errors.go
+++ b/gestaltd/internal/appregistry/errors.go
@@ -2,8 +2,11 @@ package appregistry
 
 import "errors"
 
-// ErrInstallVersionLocked means another instance is already installing this app version.
-var ErrInstallVersionLocked = errors.New("app version install already in progress")
+// ErrInstallVersionLocked means another instance is admitting a rollout for this app.
+var ErrInstallVersionLocked = errors.New("app rollout admission already in progress")
+
+// ErrAppRolloutActive means the app already has an enrolling or restarting rollout.
+var ErrAppRolloutActive = errors.New("app already has an active rollout")
 
 // ErrAppVersionAlreadyInstalled means the requested app version is already in the catalog.
 var ErrAppVersionAlreadyInstalled = errors.New("app version is already installed")

--- a/gestaltd/internal/appregistry/installer.go
+++ b/gestaltd/internal/appregistry/installer.go
@@ -16,6 +16,11 @@ import (
 
 const RegistryInstallSubdir = "registry-installed"
 
+const (
+	DefaultRolloutEnrollmentWindow = 2 * DefaultCatalogPollInterval
+	DefaultRolloutTimeout          = 15 * time.Minute
+)
+
 // installWorkTimeoutBuffer keeps bounded install work inside the lock TTL so
 // another instance cannot steal an expired lock while this attempt is still running.
 const installWorkTimeoutBuffer = 30 * time.Second
@@ -26,6 +31,7 @@ type Installer struct {
 	Reader         *RegistryReader
 	ChangeRequests *coredata.AppVersionChangeRequestService
 	Locks          *coredata.AppVersionInstallLockService
+	Rollouts       *coredata.AppRolloutService
 	Now            func() time.Time
 }
 
@@ -81,12 +87,22 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 	if i.ChangeRequests == nil {
 		return nil, fmt.Errorf("app version change request service is not configured")
 	}
+	if i.Rollouts == nil {
+		return nil, fmt.Errorf("app rollout service is not configured")
+	}
 	alreadyKnown, err := i.ChangeRequests.HasKnownVersion(installCtx, appName, version)
 	if err != nil {
 		return nil, fmt.Errorf("check known app version: %w", err)
 	}
 	if alreadyKnown {
 		return nil, ErrAppVersionAlreadyInstalled
+	}
+	if current, getErr := i.Rollouts.Get(installCtx, appName); getErr == nil {
+		if current.State == core.AppRolloutStateEnrolling || current.State == core.AppRolloutStateRestarting {
+			return nil, ErrAppRolloutActive
+		}
+	} else if !errors.Is(getErr, core.ErrNotFound) {
+		return nil, fmt.Errorf("check active app rollout: %w", getErr)
 	}
 
 	knownVersions, err := i.ChangeRequests.ListKnownVersionsByApp(installCtx, appName)
@@ -144,6 +160,20 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 		InstalledAt:        requestedAt,
 		UpdatedAt:          requestedAt,
 	}
+	_, err = i.Rollouts.Create(installCtx, &core.AppRollout{
+		App:              appName,
+		Version:          version,
+		State:            core.AppRolloutStateEnrolling,
+		CreatedAt:        requestedAt,
+		EnrollmentEndsAt: requestedAt.Add(DefaultRolloutEnrollmentWindow),
+		Deadline:         requestedAt.Add(DefaultRolloutTimeout),
+	})
+	if err != nil {
+		if errors.Is(err, coredata.ErrAppRolloutActive) {
+			return nil, ErrAppRolloutActive
+		}
+		return nil, fmt.Errorf("create app rollout: %w", err)
+	}
 
 	addedRequest, err := i.ChangeRequests.AppendRequest(installCtx, &core.AppVersionChangeRequest{
 		App:         appName,
@@ -154,6 +184,7 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 		Metadata:    coredata.ChangeRequestMetadata(known, ""),
 	})
 	if err != nil {
+		_, _ = i.Rollouts.MarkFailed(context.WithoutCancel(installCtx), appName, version, i.now())
 		return nil, fmt.Errorf("append change request: %w", err)
 	}
 

--- a/gestaltd/internal/appregistry/installer_test.go
+++ b/gestaltd/internal/appregistry/installer_test.go
@@ -8,7 +8,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/appregistry"
 	"github.com/valon-technologies/gestalt/server/internal/appregistry/registrytest"
 	"github.com/valon-technologies/gestalt/server/internal/config"
@@ -37,6 +39,7 @@ func TestInstaller_does_not_record_change_request_on_failure(t *testing.T) {
 		Reader:         registrytest.NewReaderForServer(t, registrySrv.URL),
 		ChangeRequests: svc.AppVersionChangeRequests,
 		Locks:          svc.AppVersionInstallLocks,
+		Rollouts:       svc.AppRollouts,
 	}
 
 	_, err = installer.Install(ctx, appregistry.InstallInput{
@@ -76,6 +79,7 @@ func TestInstaller_does_not_materialize_locally(t *testing.T) {
 		Reader:         fixture.Reader,
 		ChangeRequests: svc.AppVersionChangeRequests,
 		Locks:          svc.AppVersionInstallLocks,
+		Rollouts:       svc.AppRollouts,
 	}
 
 	_, err := installer.Install(ctx, appregistry.InstallInput{
@@ -113,6 +117,7 @@ func TestInstaller_rejects_already_installed_version(t *testing.T) {
 		Reader:         fixture.Reader,
 		ChangeRequests: svc.AppVersionChangeRequests,
 		Locks:          svc.AppVersionInstallLocks,
+		Rollouts:       svc.AppRollouts,
 	}
 
 	input := appregistry.InstallInput{
@@ -131,6 +136,58 @@ func TestInstaller_rejects_already_installed_version(t *testing.T) {
 	}
 	if !errors.Is(err, appregistry.ErrAppVersionAlreadyInstalled) {
 		t.Fatalf("install error = %v, want %v", err, appregistry.ErrAppVersionAlreadyInstalled)
+	}
+}
+
+func TestInstaller_creates_one_active_rollout_per_app(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc := testutil.NewStubServices(t)
+	fixture := registrytest.NewInstallFixture(t)
+	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	installer := &appregistry.Installer{
+		Registries: map[string]config.AppRegistryConfig{
+			"toolshed": fixture.Registry,
+		},
+		ConfigApps: map[string]*config.ProviderEntry{
+			"g-issues": configEntryWithResolvedVersion("0.0.0-config"),
+		},
+		Reader:         fixture.Reader,
+		ChangeRequests: svc.AppVersionChangeRequests,
+		Locks:          svc.AppVersionInstallLocks,
+		Rollouts:       svc.AppRollouts,
+		Now:            func() time.Time { return now },
+	}
+
+	if _, err := installer.Install(ctx, appregistry.InstallInput{
+		Registry: "toolshed",
+		App:      "g-issues",
+		Version:  fixture.Version,
+	}); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	rollout, err := svc.AppRollouts.Get(ctx, "g-issues")
+	if err != nil {
+		t.Fatalf("Get rollout: %v", err)
+	}
+	if rollout.Version != fixture.Version || rollout.State != core.AppRolloutStateEnrolling {
+		t.Fatalf("rollout = %#v", rollout)
+	}
+	if rollout.EnrollmentEndsAt != now.Add(appregistry.DefaultRolloutEnrollmentWindow) {
+		t.Fatalf("EnrollmentEndsAt = %v", rollout.EnrollmentEndsAt)
+	}
+	if rollout.Deadline != now.Add(appregistry.DefaultRolloutTimeout) {
+		t.Fatalf("Deadline = %v", rollout.Deadline)
+	}
+
+	_, err = installer.Install(ctx, appregistry.InstallInput{
+		Registry: "toolshed",
+		App:      "g-issues",
+		Version:  "another-version",
+	})
+	if !errors.Is(err, appregistry.ErrAppRolloutActive) {
+		t.Fatalf("second install error = %v, want %v", err, appregistry.ErrAppRolloutActive)
 	}
 }
 
@@ -157,6 +214,7 @@ func TestInstaller_records_from_version_on_first_install_and_upgrade(t *testing.
 		Reader:         fixture.Reader,
 		ChangeRequests: svc.AppVersionChangeRequests,
 		Locks:          svc.AppVersionInstallLocks,
+		Rollouts:       svc.AppRollouts,
 	}
 
 	if _, err := installer.Install(ctx, appregistry.InstallInput{

--- a/gestaltd/internal/appregistry/poller.go
+++ b/gestaltd/internal/appregistry/poller.go
@@ -24,6 +24,7 @@ const (
 type CatalogPoller struct {
 	ChangeRequests      *coredata.AppVersionChangeRequestService
 	Materializations    *coredata.AppInstanceMaterializationService
+	Rollouts            *coredata.AppRolloutService
 	AppRestarter        AppRestarter
 	InstanceID          string
 	Interval            time.Duration
@@ -39,11 +40,13 @@ type CatalogPoller struct {
 	passMu    sync.Mutex
 	mu        sync.Mutex
 	inflight  map[string]struct{}
+	stoppedAt map[string]time.Time
 }
 
 type CatalogPollerConfig struct {
 	ChangeRequests      *coredata.AppVersionChangeRequestService
 	Materializations    *coredata.AppInstanceMaterializationService
+	Rollouts            *coredata.AppRolloutService
 	AppRestarter        AppRestarter
 	InstanceID          string
 	Interval            time.Duration
@@ -57,6 +60,7 @@ func NewCatalogPoller(cfg CatalogPollerConfig) *CatalogPoller {
 	return &CatalogPoller{
 		ChangeRequests:      cfg.ChangeRequests,
 		Materializations:    cfg.Materializations,
+		Rollouts:            cfg.Rollouts,
 		AppRestarter:        cfg.AppRestarter,
 		InstanceID:          strings.TrimSpace(cfg.InstanceID),
 		Interval:            cfg.Interval,
@@ -65,6 +69,7 @@ func NewCatalogPoller(cfg CatalogPollerConfig) *CatalogPoller {
 		RestartReady:        cfg.RestartReady,
 		Now:                 cfg.Now,
 		inflight:            make(map[string]struct{}),
+		stoppedAt:           make(map[string]time.Time),
 	}
 }
 
@@ -80,7 +85,7 @@ func ResolveInstanceID() string {
 }
 
 func (p *CatalogPoller) Start(ctx context.Context) {
-	if p == nil || p.ChangeRequests == nil || p.Materializations == nil {
+	if p == nil || p.ChangeRequests == nil || p.Materializations == nil || p.Rollouts == nil {
 		return
 	}
 	p.startOnce.Do(func() {
@@ -146,7 +151,7 @@ func (p *CatalogPoller) ReconcileOnce(ctx context.Context) error {
 	if p == nil {
 		return nil
 	}
-	if p.ChangeRequests == nil || p.Materializations == nil {
+	if p.ChangeRequests == nil || p.Materializations == nil || p.Rollouts == nil {
 		return fmt.Errorf("app registry catalog poller is not configured")
 	}
 	instanceID := strings.TrimSpace(p.InstanceID)
@@ -159,9 +164,27 @@ func (p *CatalogPoller) ReconcileOnce(ctx context.Context) error {
 		return fmt.Errorf("list catalog known versions: %w", err)
 	}
 
+	active, err := p.Rollouts.ListActive(ctx)
+	if err != nil {
+		return fmt.Errorf("list active app rollouts: %w", err)
+	}
+	activeByApp := make(map[string]*core.AppRollout, len(active))
+	for _, rollout := range active {
+		if rollout != nil && strings.TrimSpace(rollout.App) != "" {
+			activeByApp[strings.TrimSpace(rollout.App)] = rollout
+		}
+	}
+
 	var errs []error
-	for appName, installations := range groupInstallationsByApp(known) {
-		if err := p.reconcileApp(ctx, instanceID, appName, installations); err != nil {
+	byApp := groupInstallationsByApp(known)
+	for appName, installations := range byApp {
+		if err := p.reconcileApp(ctx, instanceID, appName, installations, activeByApp[appName]); err != nil {
+			errs = append(errs, err)
+		}
+		delete(activeByApp, appName)
+	}
+	for appName, rollout := range activeByApp {
+		if err := p.reconcileApp(ctx, instanceID, appName, nil, rollout); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -196,15 +219,53 @@ func groupInstallationsByApp(known []*core.AppInstallation) map[string][]*core.A
 	return byApp
 }
 
-func (p *CatalogPoller) reconcileApp(ctx context.Context, instanceID, appName string, installations []*core.AppInstallation) error {
+func (p *CatalogPoller) reconcileApp(ctx context.Context, instanceID, appName string, installations []*core.AppInstallation, rollout *core.AppRollout) error {
 	appName = strings.TrimSpace(appName)
-	if appName == "" || len(installations) == 0 {
+	if appName == "" {
 		return nil
 	}
 	if !p.beginInflight(appName) {
 		return nil
 	}
 	defer p.endInflight(appName)
+
+	if rollout != nil {
+		version := strings.TrimSpace(rollout.Version)
+		if findInstallation(installations, version) == nil {
+			if !p.now().Before(rollout.Deadline) {
+				if _, err := p.Rollouts.MarkFailed(ctx, appName, version, p.now()); err != nil {
+					return fmt.Errorf("fail rollout without accepted version %s@%s: %w", appName, version, err)
+				}
+			}
+			return nil
+		}
+		if _, err := p.ensureAcknowledged(ctx, instanceID, appName, version); err != nil {
+			return err
+		}
+		if rollout.State == core.AppRolloutStateEnrolling {
+			if p.now().Before(rollout.EnrollmentEndsAt) {
+				return nil
+			}
+			var err error
+			rollout, err = p.Rollouts.MarkRestarting(ctx, appName, version)
+			if err != nil {
+				return fmt.Errorf("start rollout restart phase for %s@%s: %w", appName, version, err)
+			}
+		}
+		if rollout.State == core.AppRolloutStateRestarting {
+			terminal, err := p.updateRolloutOutcome(ctx, rollout)
+			if err != nil {
+				return err
+			}
+			if terminal {
+				rollout = nil
+			}
+		}
+	}
+
+	if len(installations) == 0 {
+		return nil
+	}
 
 	pending := make([]*core.AppInstallation, 0, len(installations))
 	for _, installation := range installations {
@@ -261,7 +322,7 @@ func (p *CatalogPoller) reconcileApp(ctx context.Context, instanceID, appName st
 		if err := p.AppRestarter.StopApp(ctx, appName); err != nil {
 			return fmt.Errorf("stop app %s for %s@%s: %w", appName, appName, driverVersion, err)
 		}
-		stoppedAt = p.now()
+		stoppedAt = p.rememberStoppedAt(appName, p.now())
 		slog.Info(
 			"app registry catalog poller stopped app provider",
 			"app", appName,
@@ -288,6 +349,12 @@ func (p *CatalogPoller) reconcileApp(ctx context.Context, instanceID, appName st
 	if err := p.markAllRestarted(ctx, instanceID, appName, pending, restartedAt); err != nil {
 		return err
 	}
+	p.forgetStoppedAt(appName)
+	if rollout != nil && rollout.State == core.AppRolloutStateRestarting {
+		if _, err := p.updateRolloutOutcome(ctx, rollout); err != nil {
+			return err
+		}
+	}
 	slog.Info(
 		"app registry catalog poller restarted app provider",
 		"app", appName,
@@ -297,6 +364,46 @@ func (p *CatalogPoller) reconcileApp(ctx context.Context, instanceID, appName st
 		"restarted_at", restartedAt,
 	)
 	return nil
+}
+
+func findInstallation(installations []*core.AppInstallation, version string) *core.AppInstallation {
+	version = strings.TrimSpace(version)
+	for _, installation := range installations {
+		if installation != nil && strings.TrimSpace(installation.Version) == version {
+			return installation
+		}
+	}
+	return nil
+}
+
+func (p *CatalogPoller) updateRolloutOutcome(ctx context.Context, rollout *core.AppRollout) (bool, error) {
+	materializations, err := p.Materializations.ListByAppVersion(ctx, rollout.App, rollout.Version)
+	if err != nil {
+		return false, fmt.Errorf("list rollout cohort for %s@%s: %w", rollout.App, rollout.Version, err)
+	}
+	converged := true
+	for _, materialization := range materializations {
+		if !materialization.AcknowledgedAt.Before(rollout.EnrollmentEndsAt) {
+			continue
+		}
+		if materialization.RestartedAt.IsZero() || materialization.RestartedAt.After(rollout.Deadline) {
+			converged = false
+			break
+		}
+	}
+	if converged {
+		if _, err := p.Rollouts.MarkComplete(ctx, rollout.App, rollout.Version, p.now()); err != nil {
+			return false, fmt.Errorf("complete rollout %s@%s: %w", rollout.App, rollout.Version, err)
+		}
+		return true, nil
+	}
+	if !p.now().Before(rollout.Deadline) {
+		if _, err := p.Rollouts.MarkFailed(ctx, rollout.App, rollout.Version, p.now()); err != nil {
+			return false, fmt.Errorf("fail rollout %s@%s: %w", rollout.App, rollout.Version, err)
+		}
+		return true, nil
+	}
+	return false, nil
 }
 
 func (p *CatalogPoller) restartReady() bool {
@@ -316,8 +423,7 @@ func (p *CatalogPoller) markCatalogConverged(ctx context.Context, instanceID, ap
 }
 
 func (p *CatalogPoller) earliestStoppedAt(ctx context.Context, instanceID, appName string, pending []*core.AppInstallation) (time.Time, bool, error) {
-	var earliest time.Time
-	found := false
+	earliest, found := p.localStoppedAt(appName)
 	for _, installation := range pending {
 		version := strings.TrimSpace(installation.Version)
 		if version == "" {
@@ -336,6 +442,29 @@ func (p *CatalogPoller) earliestStoppedAt(ctx context.Context, instanceID, appNa
 		}
 	}
 	return earliest, found, nil
+}
+
+func (p *CatalogPoller) localStoppedAt(app string) (time.Time, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	value, ok := p.stoppedAt[app]
+	return value, ok
+}
+
+func (p *CatalogPoller) rememberStoppedAt(app string, value time.Time) time.Time {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if existing, ok := p.stoppedAt[app]; ok {
+		return existing
+	}
+	p.stoppedAt[app] = value
+	return value
+}
+
+func (p *CatalogPoller) forgetStoppedAt(app string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.stoppedAt, app)
 }
 
 func (p *CatalogPoller) markPendingStopped(ctx context.Context, instanceID, appName string, pending []*core.AppInstallation, stoppedAt time.Time) error {

--- a/gestaltd/internal/appregistry/poller.go
+++ b/gestaltd/internal/appregistry/poller.go
@@ -2,9 +2,11 @@ package appregistry
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -14,37 +16,55 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
 )
 
-const DefaultCatalogPollInterval = time.Minute
+const (
+	DefaultCatalogPollInterval = time.Minute
+	DefaultCatalogRestartDelay = time.Minute
+)
 
 type CatalogPoller struct {
-	ChangeRequests   *coredata.AppVersionChangeRequestService
-	Materializations *coredata.AppInstanceMaterializationService
-	InstanceID       string
-	Interval         time.Duration
-	Now              func() time.Time
+	ChangeRequests      *coredata.AppVersionChangeRequestService
+	Materializations    *coredata.AppInstanceMaterializationService
+	AppRestarter        AppRestarter
+	InstanceID          string
+	Interval            time.Duration
+	RestartDelay        time.Duration
+	DisableRestartDelay bool
+	RestartReady        <-chan struct{}
+	Now                 func() time.Time
 
 	startOnce sync.Once
+	startMu   sync.Mutex
+	cancel    context.CancelFunc
+	done      chan struct{}
 	passMu    sync.Mutex
 	mu        sync.Mutex
 	inflight  map[string]struct{}
 }
 
 type CatalogPollerConfig struct {
-	ChangeRequests   *coredata.AppVersionChangeRequestService
-	Materializations *coredata.AppInstanceMaterializationService
-	InstanceID       string
-	Interval         time.Duration
-	Now              func() time.Time
+	ChangeRequests      *coredata.AppVersionChangeRequestService
+	Materializations    *coredata.AppInstanceMaterializationService
+	AppRestarter        AppRestarter
+	InstanceID          string
+	Interval            time.Duration
+	RestartDelay        time.Duration
+	DisableRestartDelay bool
+	RestartReady        <-chan struct{}
+	Now                 func() time.Time
 }
 
 func NewCatalogPoller(cfg CatalogPollerConfig) *CatalogPoller {
 	return &CatalogPoller{
-		ChangeRequests:   cfg.ChangeRequests,
-		Materializations: cfg.Materializations,
-		InstanceID:       strings.TrimSpace(cfg.InstanceID),
-		Interval:         cfg.Interval,
-		Now:              cfg.Now,
-		inflight:         make(map[string]struct{}),
+		ChangeRequests:      cfg.ChangeRequests,
+		Materializations:    cfg.Materializations,
+		AppRestarter:        cfg.AppRestarter,
+		InstanceID:          strings.TrimSpace(cfg.InstanceID),
+		Interval:            cfg.Interval,
+		RestartDelay:        cfg.RestartDelay,
+		DisableRestartDelay: cfg.DisableRestartDelay,
+		RestartReady:        cfg.RestartReady,
+		Now:                 cfg.Now,
+		inflight:            make(map[string]struct{}),
 	}
 }
 
@@ -67,8 +87,34 @@ func (p *CatalogPoller) Start(ctx context.Context) {
 		if strings.TrimSpace(p.InstanceID) == "" {
 			p.InstanceID = ResolveInstanceID()
 		}
-		go p.loop(ctx)
+		loopCtx, cancel := context.WithCancel(ctx)
+		p.startMu.Lock()
+		p.cancel = cancel
+		p.done = make(chan struct{})
+		p.startMu.Unlock()
+		go func() {
+			defer close(p.done)
+			p.loop(loopCtx)
+		}()
 	})
+}
+
+func (p *CatalogPoller) Stop() {
+	if p == nil {
+		return
+	}
+	p.startMu.Lock()
+	cancel := p.cancel
+	done := p.done
+	p.startMu.Unlock()
+	if cancel == nil || done == nil {
+		return
+	}
+	cancel()
+	<-done
+	if p.AppRestarter != nil {
+		p.AppRestarter.AbortRestarts()
+	}
 }
 
 func (p *CatalogPoller) loop(ctx context.Context) {
@@ -80,7 +126,7 @@ func (p *CatalogPoller) loop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			p.runOnce(context.WithoutCancel(ctx))
+			p.runOnce(ctx)
 		}
 	}
 }
@@ -113,48 +159,234 @@ func (p *CatalogPoller) ReconcileOnce(ctx context.Context) error {
 		return fmt.Errorf("list catalog known versions: %w", err)
 	}
 
-	var firstErr error
-	for _, installation := range known {
-		if err := p.reconcileInstallation(ctx, instanceID, installation); err != nil && firstErr == nil {
-			firstErr = err
+	var errs []error
+	for appName, installations := range groupInstallationsByApp(known) {
+		if err := p.reconcileApp(ctx, instanceID, appName, installations); err != nil {
+			errs = append(errs, err)
 		}
 	}
-	return firstErr
+	return errors.Join(errs...)
 }
 
-func (p *CatalogPoller) reconcileInstallation(ctx context.Context, instanceID string, installation *core.AppInstallation) error {
-	if installation == nil {
-		return nil
+func groupInstallationsByApp(known []*core.AppInstallation) map[string][]*core.AppInstallation {
+	byApp := make(map[string][]*core.AppInstallation)
+	for _, installation := range known {
+		if installation == nil {
+			continue
+		}
+		appName := strings.TrimSpace(installation.AppName)
+		if appName == "" {
+			continue
+		}
+		byApp[appName] = append(byApp[appName], installation)
 	}
-	appName := strings.TrimSpace(installation.AppName)
-	version := strings.TrimSpace(installation.Version)
-	if appName == "" || version == "" {
-		return nil
+	for appName := range byApp {
+		sort.Slice(byApp[appName], func(i, j int) bool {
+			left := byApp[appName][i]
+			right := byApp[appName][j]
+			if left == nil || right == nil {
+				return left != nil
+			}
+			if !left.UpdatedAt.Equal(right.UpdatedAt) {
+				return left.UpdatedAt.Before(right.UpdatedAt)
+			}
+			return left.Version < right.Version
+		})
 	}
-	key := appName + "\x00" + version
-	if !p.beginInflight(key) {
-		return nil
-	}
-	defer p.endInflight(key)
+	return byApp
+}
 
-	alreadyAcked, err := p.Materializations.HasAcknowledged(ctx, instanceID, appName, version)
+func (p *CatalogPoller) reconcileApp(ctx context.Context, instanceID, appName string, installations []*core.AppInstallation) error {
+	appName = strings.TrimSpace(appName)
+	if appName == "" || len(installations) == 0 {
+		return nil
+	}
+	if !p.beginInflight(appName) {
+		return nil
+	}
+	defer p.endInflight(appName)
+
+	pending := make([]*core.AppInstallation, 0, len(installations))
+	for _, installation := range installations {
+		version := strings.TrimSpace(installation.Version)
+		if version == "" {
+			continue
+		}
+		materialization, err := p.ensureAcknowledged(ctx, instanceID, appName, version)
+		if err != nil {
+			return err
+		}
+		if materialization.RestartedAt.IsZero() {
+			pending = append(pending, installation)
+		}
+	}
+	if len(pending) == 0 {
+		return nil
+	}
+
+	if p.AppRestarter == nil {
+		return nil
+	}
+
+	restartable, err := p.AppRestarter.Restartable(appName)
 	if err != nil {
-		return fmt.Errorf("check ack for %s@%s: %w", appName, version, err)
+		return fmt.Errorf("determine restart mode for app %s: %w", appName, err)
 	}
-	if alreadyAcked {
+	if !restartable {
+		convergedAt := p.now()
+		if err := p.markCatalogConverged(ctx, instanceID, appName, pending, convergedAt); err != nil {
+			return err
+		}
+		slog.Info(
+			"app registry catalog poller marked non-local app converged",
+			"app", appName,
+			"pending_versions", len(pending),
+			"instance_id", instanceID,
+			"restarted_at", convergedAt,
+		)
 		return nil
 	}
 
+	if !p.restartReady() {
+		return nil
+	}
+
+	driverVersion := strings.TrimSpace(pending[len(pending)-1].Version)
+
+	stoppedAt, alreadyStopped, err := p.earliestStoppedAt(ctx, instanceID, appName, pending)
+	if err != nil {
+		return err
+	}
+	if !alreadyStopped {
+		if err := p.AppRestarter.StopApp(ctx, appName); err != nil {
+			return fmt.Errorf("stop app %s for %s@%s: %w", appName, appName, driverVersion, err)
+		}
+		stoppedAt = p.now()
+		slog.Info(
+			"app registry catalog poller stopped app provider",
+			"app", appName,
+			"version", driverVersion,
+			"pending_versions", len(pending),
+			"instance_id", instanceID,
+			"stopped_at", stoppedAt,
+		)
+	}
+	if err := p.markPendingStopped(ctx, instanceID, appName, pending, stoppedAt); err != nil {
+		return err
+	}
+
+	if delay := p.restartDelay(); delay > 0 {
+		if p.now().Sub(stoppedAt) < delay {
+			return nil
+		}
+	}
+
+	if err := p.AppRestarter.StartApp(ctx, appName); err != nil {
+		return fmt.Errorf("start app %s for %s@%s: %w", appName, appName, driverVersion, err)
+	}
+	restartedAt := p.now()
+	if err := p.markAllRestarted(ctx, instanceID, appName, pending, restartedAt); err != nil {
+		return err
+	}
+	slog.Info(
+		"app registry catalog poller restarted app provider",
+		"app", appName,
+		"version", driverVersion,
+		"pending_versions", len(pending),
+		"instance_id", instanceID,
+		"restarted_at", restartedAt,
+	)
+	return nil
+}
+
+func (p *CatalogPoller) restartReady() bool {
+	if p == nil || p.RestartReady == nil {
+		return true
+	}
+	select {
+	case <-p.RestartReady:
+		return true
+	default:
+		return false
+	}
+}
+
+func (p *CatalogPoller) markCatalogConverged(ctx context.Context, instanceID, appName string, pending []*core.AppInstallation, convergedAt time.Time) error {
+	return p.markAllRestarted(ctx, instanceID, appName, pending, convergedAt)
+}
+
+func (p *CatalogPoller) earliestStoppedAt(ctx context.Context, instanceID, appName string, pending []*core.AppInstallation) (time.Time, bool, error) {
+	var earliest time.Time
+	found := false
+	for _, installation := range pending {
+		version := strings.TrimSpace(installation.Version)
+		if version == "" {
+			continue
+		}
+		materialization, err := p.Materializations.Get(ctx, instanceID, appName, version)
+		if err != nil {
+			return time.Time{}, false, fmt.Errorf("load materialization for %s@%s: %w", appName, version, err)
+		}
+		if materialization.StoppedAt.IsZero() {
+			continue
+		}
+		if !found || materialization.StoppedAt.Before(earliest) {
+			earliest = materialization.StoppedAt
+			found = true
+		}
+	}
+	return earliest, found, nil
+}
+
+func (p *CatalogPoller) markPendingStopped(ctx context.Context, instanceID, appName string, pending []*core.AppInstallation, stoppedAt time.Time) error {
+	for _, installation := range pending {
+		version := strings.TrimSpace(installation.Version)
+		if version == "" {
+			continue
+		}
+		materialization, err := p.Materializations.Get(ctx, instanceID, appName, version)
+		if err != nil {
+			return fmt.Errorf("load materialization for %s@%s: %w", appName, version, err)
+		}
+		if !materialization.StoppedAt.IsZero() {
+			continue
+		}
+		if _, err := p.Materializations.MarkStopped(ctx, instanceID, appName, version, stoppedAt); err != nil {
+			return fmt.Errorf("record stop for %s@%s: %w", appName, version, err)
+		}
+	}
+	return nil
+}
+
+func (p *CatalogPoller) markAllRestarted(ctx context.Context, instanceID, appName string, pending []*core.AppInstallation, restartedAt time.Time) error {
+	for _, installation := range pending {
+		version := strings.TrimSpace(installation.Version)
+		materialization, err := p.Materializations.Get(ctx, instanceID, appName, version)
+		if err != nil {
+			return fmt.Errorf("load materialization for %s@%s: %w", appName, version, err)
+		}
+		if !materialization.RestartedAt.IsZero() {
+			continue
+		}
+		if _, err := p.Materializations.MarkRestarted(ctx, instanceID, appName, version, restartedAt); err != nil {
+			return fmt.Errorf("record restart for %s@%s: %w", appName, version, err)
+		}
+	}
+	return nil
+}
+
+func (p *CatalogPoller) ensureAcknowledged(ctx context.Context, instanceID, appName, version string) (*core.AppInstanceMaterialization, error) {
 	acknowledgedAt := p.now()
-	if _, err := p.Materializations.Acknowledge(ctx, &core.AppInstanceMaterialization{
+	materialization, err := p.Materializations.Acknowledge(ctx, &core.AppInstanceMaterialization{
 		InstanceID:     instanceID,
 		App:            appName,
 		Version:        version,
 		AcknowledgedAt: acknowledgedAt,
-	}); err != nil {
-		return fmt.Errorf("acknowledge %s@%s: %w", appName, version, err)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("acknowledge %s@%s: %w", appName, version, err)
 	}
-	return nil
+	return materialization, nil
 }
 
 func (p *CatalogPoller) beginInflight(key string) bool {
@@ -181,6 +413,16 @@ func (p *CatalogPoller) pollInterval() time.Duration {
 		return p.Interval
 	}
 	return DefaultCatalogPollInterval
+}
+
+func (p *CatalogPoller) restartDelay() time.Duration {
+	if p == nil || p.DisableRestartDelay {
+		return 0
+	}
+	if p.RestartDelay > 0 {
+		return p.RestartDelay
+	}
+	return DefaultCatalogRestartDelay
 }
 
 func (p *CatalogPoller) now() time.Time {

--- a/gestaltd/internal/appregistry/poller_test.go
+++ b/gestaltd/internal/appregistry/poller_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 )
 
@@ -18,6 +20,7 @@ type recordingAppRestarter struct {
 	startErr       error
 	restartable    map[string]bool
 	restartableErr error
+	afterStop      func()
 }
 
 func (r *recordingAppRestarter) Restartable(app string) (bool, error) {
@@ -37,6 +40,9 @@ func (r *recordingAppRestarter) Restartable(app string) (bool, error) {
 
 func (r *recordingAppRestarter) StopApp(_ context.Context, app string) error {
 	r.stopCalls = append(r.stopCalls, app)
+	if r.stopErr == nil && r.afterStop != nil {
+		r.afterStop()
+	}
 	return r.stopErr
 }
 
@@ -46,6 +52,231 @@ func (r *recordingAppRestarter) StartApp(_ context.Context, app string) error {
 }
 
 func (r *recordingAppRestarter) AbortRestarts() {}
+
+func TestCatalogPollerRolloutEnrollmentAndCompletion(t *testing.T) {
+	t.Parallel()
+
+	services := testutil.NewStubServices(t)
+	start := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	clock := start
+	appendRolloutFixture(t, services, "g-issues", "v1", start)
+	createRolloutFixture(t, services, "g-issues", "v1", start)
+	restarter := &recordingAppRestarter{}
+	poller := NewCatalogPoller(CatalogPollerConfig{
+		ChangeRequests:      services.AppVersionChangeRequests,
+		Materializations:    services.AppInstanceMaterializations,
+		Rollouts:            services.AppRollouts,
+		AppRestarter:        restarter,
+		InstanceID:          "replica-a",
+		DisableRestartDelay: true,
+		Now:                 func() time.Time { return clock },
+	})
+
+	if err := poller.ReconcileOnce(context.Background()); err != nil {
+		t.Fatalf("enrollment pass: %v", err)
+	}
+	if len(restarter.stopCalls) != 0 || len(restarter.startCalls) != 0 {
+		t.Fatalf("restart calls during enrollment: stop=%v start=%v", restarter.stopCalls, restarter.startCalls)
+	}
+	rollout, err := services.AppRollouts.Get(context.Background(), "g-issues")
+	if err != nil {
+		t.Fatalf("Get enrolling rollout: %v", err)
+	}
+	if rollout.State != core.AppRolloutStateEnrolling {
+		t.Fatalf("state = %q, want enrolling", rollout.State)
+	}
+
+	clock = start.Add(2 * time.Minute)
+	if err := poller.ReconcileOnce(context.Background()); err != nil {
+		t.Fatalf("restart pass: %v", err)
+	}
+	rollout, err = services.AppRollouts.Get(context.Background(), "g-issues")
+	if err != nil {
+		t.Fatalf("Get completed rollout: %v", err)
+	}
+	if rollout.State != core.AppRolloutStateComplete {
+		t.Fatalf("state = %q, want complete", rollout.State)
+	}
+	if len(restarter.stopCalls) != 1 || len(restarter.startCalls) != 1 {
+		t.Fatalf("restart calls: stop=%v start=%v", restarter.stopCalls, restarter.startCalls)
+	}
+}
+
+func TestCatalogPollerRolloutWaitsForEveryEnrolledReplica(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	services := testutil.NewStubServices(t)
+	start := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	clock := start
+	appendRolloutFixture(t, services, "g-issues", "v1", start)
+	createRolloutFixture(t, services, "g-issues", "v1", start)
+	if _, err := services.AppInstanceMaterializations.Acknowledge(ctx, &core.AppInstanceMaterialization{
+		InstanceID:     "replica-b",
+		App:            "g-issues",
+		Version:        "v1",
+		AcknowledgedAt: start.Add(time.Minute),
+	}); err != nil {
+		t.Fatalf("Acknowledge replica-b: %v", err)
+	}
+	poller := NewCatalogPoller(CatalogPollerConfig{
+		ChangeRequests:      services.AppVersionChangeRequests,
+		Materializations:    services.AppInstanceMaterializations,
+		Rollouts:            services.AppRollouts,
+		AppRestarter:        &recordingAppRestarter{},
+		InstanceID:          "replica-a",
+		DisableRestartDelay: true,
+		Now:                 func() time.Time { return clock },
+	})
+	if err := poller.ReconcileOnce(ctx); err != nil {
+		t.Fatalf("enrollment pass: %v", err)
+	}
+	clock = start.Add(2 * time.Minute)
+	if err := poller.ReconcileOnce(ctx); err != nil {
+		t.Fatalf("replica-a restart pass: %v", err)
+	}
+	rollout, err := services.AppRollouts.Get(ctx, "g-issues")
+	if err != nil {
+		t.Fatalf("Get restarting rollout: %v", err)
+	}
+	if rollout.State != core.AppRolloutStateRestarting {
+		t.Fatalf("state = %q, want restarting", rollout.State)
+	}
+	if _, err := services.AppInstanceMaterializations.MarkRestarted(ctx, "replica-b", "g-issues", "v1", clock.Add(time.Second)); err != nil {
+		t.Fatalf("MarkRestarted replica-b: %v", err)
+	}
+	clock = clock.Add(2 * time.Second)
+	if err := poller.ReconcileOnce(ctx); err != nil {
+		t.Fatalf("completion pass: %v", err)
+	}
+	rollout, err = services.AppRollouts.Get(ctx, "g-issues")
+	if err != nil {
+		t.Fatalf("Get completed rollout: %v", err)
+	}
+	if rollout.State != core.AppRolloutStateComplete {
+		t.Fatalf("state = %q, want complete", rollout.State)
+	}
+}
+
+func TestCatalogPollerRolloutFailsWhenEnrolledReplicaMissesDeadline(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	services := testutil.NewStubServices(t)
+	start := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	clock := start
+	appendRolloutFixture(t, services, "g-issues", "v1", start)
+	createRolloutFixture(t, services, "g-issues", "v1", start)
+	if _, err := services.AppInstanceMaterializations.Acknowledge(ctx, &core.AppInstanceMaterialization{
+		InstanceID:     "replica-b",
+		App:            "g-issues",
+		Version:        "v1",
+		AcknowledgedAt: start.Add(time.Minute),
+	}); err != nil {
+		t.Fatalf("Acknowledge replica-b: %v", err)
+	}
+	poller := NewCatalogPoller(CatalogPollerConfig{
+		ChangeRequests:      services.AppVersionChangeRequests,
+		Materializations:    services.AppInstanceMaterializations,
+		Rollouts:            services.AppRollouts,
+		AppRestarter:        &recordingAppRestarter{},
+		InstanceID:          "replica-a",
+		DisableRestartDelay: true,
+		Now:                 func() time.Time { return clock },
+	})
+	if err := poller.ReconcileOnce(ctx); err != nil {
+		t.Fatalf("enrollment pass: %v", err)
+	}
+	clock = start.Add(15 * time.Minute)
+	if err := poller.ReconcileOnce(ctx); err != nil {
+		t.Fatalf("deadline pass: %v", err)
+	}
+	rollout, err := services.AppRollouts.Get(ctx, "g-issues")
+	if err != nil {
+		t.Fatalf("Get failed rollout: %v", err)
+	}
+	if rollout.State != core.AppRolloutStateFailed {
+		t.Fatalf("state = %q, want failed", rollout.State)
+	}
+}
+
+func TestCatalogPollerLateReplicaConvergesWithoutReopeningRollout(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	services := testutil.NewStubServices(t)
+	start := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	clock := start
+	appendRolloutFixture(t, services, "g-issues", "v1", start)
+	createRolloutFixture(t, services, "g-issues", "v1", start)
+	firstRestarter := &recordingAppRestarter{}
+	first := NewCatalogPoller(CatalogPollerConfig{
+		ChangeRequests:      services.AppVersionChangeRequests,
+		Materializations:    services.AppInstanceMaterializations,
+		Rollouts:            services.AppRollouts,
+		AppRestarter:        firstRestarter,
+		InstanceID:          "replica-a",
+		DisableRestartDelay: true,
+		Now:                 func() time.Time { return clock },
+	})
+	if err := first.ReconcileOnce(ctx); err != nil {
+		t.Fatalf("enrollment pass: %v", err)
+	}
+	clock = start.Add(2 * time.Minute)
+	if err := first.ReconcileOnce(ctx); err != nil {
+		t.Fatalf("completion pass: %v", err)
+	}
+
+	lateRestarter := &recordingAppRestarter{}
+	late := NewCatalogPoller(CatalogPollerConfig{
+		ChangeRequests:      services.AppVersionChangeRequests,
+		Materializations:    services.AppInstanceMaterializations,
+		Rollouts:            services.AppRollouts,
+		AppRestarter:        lateRestarter,
+		InstanceID:          "replica-b",
+		DisableRestartDelay: true,
+		Now:                 func() time.Time { return clock },
+	})
+	if err := late.ReconcileOnce(ctx); err != nil {
+		t.Fatalf("late replica pass: %v", err)
+	}
+	if len(lateRestarter.stopCalls) != 1 || len(lateRestarter.startCalls) != 1 {
+		t.Fatalf("late restart calls: stop=%v start=%v", lateRestarter.stopCalls, lateRestarter.startCalls)
+	}
+	rollout, err := services.AppRollouts.Get(ctx, "g-issues")
+	if err != nil {
+		t.Fatalf("Get rollout: %v", err)
+	}
+	if rollout.State != core.AppRolloutStateComplete {
+		t.Fatalf("state = %q, want complete", rollout.State)
+	}
+}
+
+func appendRolloutFixture(t *testing.T, services *coredata.Services, app, version string, at time.Time) {
+	t.Helper()
+	if _, err := services.AppVersionChangeRequests.AppendRequest(context.Background(), &core.AppVersionChangeRequest{
+		App:         app,
+		FromVersion: "previous",
+		ToVersion:   version,
+		Timestamp:   at,
+	}); err != nil {
+		t.Fatalf("AppendRequest: %v", err)
+	}
+}
+
+func createRolloutFixture(t *testing.T, services *coredata.Services, app, version string, at time.Time) {
+	t.Helper()
+	if _, err := services.AppRollouts.Create(context.Background(), &core.AppRollout{
+		App:              app,
+		Version:          version,
+		State:            core.AppRolloutStateEnrolling,
+		CreatedAt:        at,
+		EnrollmentEndsAt: at.Add(2 * time.Minute),
+		Deadline:         at.Add(15 * time.Minute),
+	}); err != nil {
+		t.Fatalf("Create rollout: %v", err)
+	}
+}
 
 func TestCatalogPollerReconcileOnceAcknowledgesAndRestarts(t *testing.T) {
 	t.Parallel()
@@ -67,6 +298,7 @@ func TestCatalogPollerReconcileOnceAcknowledgesAndRestarts(t *testing.T) {
 	poller := NewCatalogPoller(CatalogPollerConfig{
 		ChangeRequests:      services.AppVersionChangeRequests,
 		Materializations:    services.AppInstanceMaterializations,
+		Rollouts:            services.AppRollouts,
 		AppRestarter:        restarter,
 		InstanceID:          "replica-a",
 		DisableRestartDelay: true,
@@ -128,6 +360,7 @@ func TestCatalogPollerReconcileOnceWaitsForRestartDelay(t *testing.T) {
 	poller := NewCatalogPoller(CatalogPollerConfig{
 		ChangeRequests:   services.AppVersionChangeRequests,
 		Materializations: services.AppInstanceMaterializations,
+		Rollouts:         services.AppRollouts,
 		AppRestarter:     restarter,
 		InstanceID:       "replica-a",
 		Now:              func() time.Time { return clock },
@@ -160,6 +393,67 @@ func TestCatalogPollerReconcileOnceWaitsForRestartDelay(t *testing.T) {
 	}
 }
 
+func TestCatalogPollerReconcileOncePreservesDelayAfterStoppedAtWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	services := testutil.NewStubServices(t)
+	db, ok := services.DB.(*coretesting.StubIndexedDB)
+	if !ok {
+		t.Fatalf("DB type = %T", services.DB)
+	}
+	start := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	clock := start
+	if _, err := services.AppVersionChangeRequests.AppendRequest(context.Background(), &core.AppVersionChangeRequest{
+		App:         "g-issues",
+		FromVersion: "previous",
+		ToVersion:   "v1",
+		Timestamp:   start,
+	}); err != nil {
+		t.Fatalf("AppendRequest: %v", err)
+	}
+	restarter := &recordingAppRestarter{
+		afterStop: func() { db.Err = errors.New("stopped_at write failed") },
+	}
+	poller := NewCatalogPoller(CatalogPollerConfig{
+		ChangeRequests:   services.AppVersionChangeRequests,
+		Materializations: services.AppInstanceMaterializations,
+		Rollouts:         services.AppRollouts,
+		AppRestarter:     restarter,
+		InstanceID:       "replica-a",
+		RestartDelay:     time.Minute,
+		Now:              func() time.Time { return clock },
+	})
+
+	if err := poller.ReconcileOnce(context.Background()); err == nil || !strings.Contains(err.Error(), "stopped_at write failed") {
+		t.Fatalf("first ReconcileOnce error = %v", err)
+	}
+	db.Err = nil
+	clock = start.Add(30 * time.Second)
+	if err := poller.ReconcileOnce(context.Background()); err != nil {
+		t.Fatalf("retry ReconcileOnce: %v", err)
+	}
+	if len(restarter.stopCalls) != 1 {
+		t.Fatalf("stopCalls = %v, want one stop", restarter.stopCalls)
+	}
+	if len(restarter.startCalls) != 0 {
+		t.Fatalf("startCalls = %v, want none before original delay", restarter.startCalls)
+	}
+	materialization, err := services.AppInstanceMaterializations.Get(context.Background(), "replica-a", "g-issues", "v1")
+	if err != nil {
+		t.Fatalf("Get materialization: %v", err)
+	}
+	if materialization.StoppedAt != start {
+		t.Fatalf("StoppedAt = %v, want %v", materialization.StoppedAt, start)
+	}
+	clock = start.Add(time.Minute)
+	if err := poller.ReconcileOnce(context.Background()); err != nil {
+		t.Fatalf("restart ReconcileOnce: %v", err)
+	}
+	if len(restarter.startCalls) != 1 {
+		t.Fatalf("startCalls = %v, want one start", restarter.startCalls)
+	}
+}
+
 func TestCatalogPollerReconcileOncePropagatesRestartErrors(t *testing.T) {
 	t.Parallel()
 
@@ -179,6 +473,7 @@ func TestCatalogPollerReconcileOncePropagatesRestartErrors(t *testing.T) {
 	poller := NewCatalogPoller(CatalogPollerConfig{
 		ChangeRequests:      services.AppVersionChangeRequests,
 		Materializations:    services.AppInstanceMaterializations,
+		Rollouts:            services.AppRollouts,
 		AppRestarter:        restarter,
 		InstanceID:          "replica-a",
 		DisableRestartDelay: true,
@@ -231,6 +526,7 @@ func TestCatalogPollerReconcileOnceRestartsOnceForMultipleVersions(t *testing.T)
 	poller := NewCatalogPoller(CatalogPollerConfig{
 		ChangeRequests:      services.AppVersionChangeRequests,
 		Materializations:    services.AppInstanceMaterializations,
+		Rollouts:            services.AppRollouts,
 		AppRestarter:        restarter,
 		InstanceID:          "replica-a",
 		DisableRestartDelay: true,
@@ -288,6 +584,7 @@ func TestCatalogPollerReconcileOnceRetriesStartAfterRecordedStop(t *testing.T) {
 	poller := NewCatalogPoller(CatalogPollerConfig{
 		ChangeRequests:      services.AppVersionChangeRequests,
 		Materializations:    services.AppInstanceMaterializations,
+		Rollouts:            services.AppRollouts,
 		AppRestarter:        restarter,
 		InstanceID:          "replica-a",
 		DisableRestartDelay: true,
@@ -332,6 +629,7 @@ func TestCatalogPollerReconcileOnceDoesNotResetRestartDelayForNewVersion(t *test
 	poller := NewCatalogPoller(CatalogPollerConfig{
 		ChangeRequests:   services.AppVersionChangeRequests,
 		Materializations: services.AppInstanceMaterializations,
+		Rollouts:         services.AppRollouts,
 		AppRestarter:     restarter,
 		InstanceID:       "replica-a",
 		RestartDelay:     time.Minute,
@@ -404,6 +702,7 @@ func TestCatalogPollerReconcileOnceDefersRestartUntilProvidersReady(t *testing.T
 	poller := NewCatalogPoller(CatalogPollerConfig{
 		ChangeRequests:      services.AppVersionChangeRequests,
 		Materializations:    services.AppInstanceMaterializations,
+		Rollouts:            services.AppRollouts,
 		AppRestarter:        restarter,
 		InstanceID:          "replica-a",
 		DisableRestartDelay: true,
@@ -462,6 +761,7 @@ func TestCatalogPollerReconcileOnceDoesNotConvergeWithoutAppRestarter(t *testing
 	poller := NewCatalogPoller(CatalogPollerConfig{
 		ChangeRequests:      services.AppVersionChangeRequests,
 		Materializations:    services.AppInstanceMaterializations,
+		Rollouts:            services.AppRollouts,
 		InstanceID:          "replica-a",
 		DisableRestartDelay: true,
 		Now:                 func() time.Time { return now },
@@ -504,6 +804,7 @@ func TestCatalogPollerReconcileOnceMarksNonLocalAppsConverged(t *testing.T) {
 	poller := NewCatalogPoller(CatalogPollerConfig{
 		ChangeRequests:   services.AppVersionChangeRequests,
 		Materializations: services.AppInstanceMaterializations,
+		Rollouts:         services.AppRollouts,
 		AppRestarter:     restarter,
 		InstanceID:       "replica-a",
 		RestartDelay:     time.Minute,
@@ -547,6 +848,7 @@ func TestCatalogPollerReconcileOnceDoesNotConvergeWhenRestartModeFails(t *testin
 	poller := NewCatalogPoller(CatalogPollerConfig{
 		ChangeRequests:      services.AppVersionChangeRequests,
 		Materializations:    services.AppInstanceMaterializations,
+		Rollouts:            services.AppRollouts,
 		AppRestarter:        restarter,
 		InstanceID:          "replica-a",
 		DisableRestartDelay: true,
@@ -584,6 +886,7 @@ func TestCatalogPollerReconcileOnceReportsEveryFailingApp(t *testing.T) {
 	poller := NewCatalogPoller(CatalogPollerConfig{
 		ChangeRequests:   services.AppVersionChangeRequests,
 		Materializations: services.AppInstanceMaterializations,
+		Rollouts:         services.AppRollouts,
 		AppRestarter:     &recordingAppRestarter{restartableErr: errors.New("restart mode failed")},
 		InstanceID:       "replica-a",
 		Now:              func() time.Time { return now },

--- a/gestaltd/internal/appregistry/poller_test.go
+++ b/gestaltd/internal/appregistry/poller_test.go
@@ -1,0 +1,596 @@
+package appregistry
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+)
+
+type recordingAppRestarter struct {
+	stopCalls      []string
+	startCalls     []string
+	stopErr        error
+	startErr       error
+	restartable    map[string]bool
+	restartableErr error
+}
+
+func (r *recordingAppRestarter) Restartable(app string) (bool, error) {
+	if r == nil {
+		return false, nil
+	}
+	if r.restartableErr != nil {
+		return false, r.restartableErr
+	}
+	if r.restartable != nil {
+		if restartable, ok := r.restartable[app]; ok {
+			return restartable, nil
+		}
+	}
+	return true, nil
+}
+
+func (r *recordingAppRestarter) StopApp(_ context.Context, app string) error {
+	r.stopCalls = append(r.stopCalls, app)
+	return r.stopErr
+}
+
+func (r *recordingAppRestarter) StartApp(_ context.Context, app string) error {
+	r.startCalls = append(r.startCalls, app)
+	return r.startErr
+}
+
+func (r *recordingAppRestarter) AbortRestarts() {}
+
+func TestCatalogPollerReconcileOnceAcknowledgesAndRestarts(t *testing.T) {
+	t.Parallel()
+
+	services := testutil.NewStubServices(t)
+	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	clock := now
+
+	if _, err := services.AppVersionChangeRequests.AppendRequest(context.Background(), &core.AppVersionChangeRequest{
+		App:         "g-issues",
+		FromVersion: "0.0.0-snapshot.gdeadbeef",
+		ToVersion:   "0.0.0-snapshot.gabc123",
+		Timestamp:   now,
+	}); err != nil {
+		t.Fatalf("AppendRequest: %v", err)
+	}
+
+	restarter := &recordingAppRestarter{}
+	poller := NewCatalogPoller(CatalogPollerConfig{
+		ChangeRequests:      services.AppVersionChangeRequests,
+		Materializations:    services.AppInstanceMaterializations,
+		AppRestarter:        restarter,
+		InstanceID:          "replica-a",
+		DisableRestartDelay: true,
+		Now:                 func() time.Time { return clock },
+	})
+
+	if err := poller.ReconcileOnce(context.Background()); err != nil {
+		t.Fatalf("first ReconcileOnce: %v", err)
+	}
+	if got := restarter.stopCalls; len(got) != 1 || got[0] != "g-issues" {
+		t.Fatalf("stopCalls after first pass = %#v, want [g-issues]", got)
+	}
+	if got := restarter.startCalls; len(got) != 1 || got[0] != "g-issues" {
+		t.Fatalf("startCalls after first pass = %#v, want [g-issues]", got)
+	}
+
+	materialization, err := services.AppInstanceMaterializations.Get(context.Background(), "replica-a", "g-issues", "0.0.0-snapshot.gabc123")
+	if err != nil {
+		t.Fatalf("Get materialization: %v", err)
+	}
+	if materialization.AcknowledgedAt != now {
+		t.Fatalf("AcknowledgedAt = %v, want %v", materialization.AcknowledgedAt, now)
+	}
+	if materialization.StoppedAt != now {
+		t.Fatalf("StoppedAt = %v, want %v", materialization.StoppedAt, now)
+	}
+	if materialization.RestartedAt != now {
+		t.Fatalf("RestartedAt = %v, want %v", materialization.RestartedAt, now)
+	}
+
+	if err := poller.ReconcileOnce(context.Background()); err != nil {
+		t.Fatalf("second ReconcileOnce: %v", err)
+	}
+	if got := len(restarter.stopCalls); got != 1 {
+		t.Fatalf("stopCalls after second pass = %d, want 1", got)
+	}
+	if got := len(restarter.startCalls); got != 1 {
+		t.Fatalf("startCalls after second pass = %d, want 1", got)
+	}
+}
+
+func TestCatalogPollerReconcileOnceWaitsForRestartDelay(t *testing.T) {
+	t.Parallel()
+
+	services := testutil.NewStubServices(t)
+	start := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	clock := start
+
+	if _, err := services.AppVersionChangeRequests.AppendRequest(context.Background(), &core.AppVersionChangeRequest{
+		App:         "g-issues",
+		FromVersion: "0.0.0-snapshot.gdeadbeef",
+		ToVersion:   "0.0.0-snapshot.gabc123",
+		Timestamp:   start,
+	}); err != nil {
+		t.Fatalf("AppendRequest: %v", err)
+	}
+
+	restarter := &recordingAppRestarter{}
+	poller := NewCatalogPoller(CatalogPollerConfig{
+		ChangeRequests:   services.AppVersionChangeRequests,
+		Materializations: services.AppInstanceMaterializations,
+		AppRestarter:     restarter,
+		InstanceID:       "replica-a",
+		Now:              func() time.Time { return clock },
+	})
+
+	if err := poller.ReconcileOnce(context.Background()); err != nil {
+		t.Fatalf("first ReconcileOnce: %v", err)
+	}
+	if got := restarter.stopCalls; len(got) != 1 || got[0] != "g-issues" {
+		t.Fatalf("stopCalls after first pass = %#v, want [g-issues]", got)
+	}
+	if got := restarter.startCalls; len(got) != 0 {
+		t.Fatalf("startCalls after first pass = %#v, want none", got)
+	}
+
+	clock = start.Add(30 * time.Second)
+	if err := poller.ReconcileOnce(context.Background()); err != nil {
+		t.Fatalf("second ReconcileOnce: %v", err)
+	}
+	if got := len(restarter.startCalls); got != 0 {
+		t.Fatalf("startCalls after partial delay = %d, want 0", got)
+	}
+
+	clock = start.Add(time.Minute)
+	if err := poller.ReconcileOnce(context.Background()); err != nil {
+		t.Fatalf("third ReconcileOnce: %v", err)
+	}
+	if got := restarter.startCalls; len(got) != 1 || got[0] != "g-issues" {
+		t.Fatalf("startCalls after delay elapsed = %#v, want [g-issues]", got)
+	}
+}
+
+func TestCatalogPollerReconcileOncePropagatesRestartErrors(t *testing.T) {
+	t.Parallel()
+
+	services := testutil.NewStubServices(t)
+	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+
+	if _, err := services.AppVersionChangeRequests.AppendRequest(context.Background(), &core.AppVersionChangeRequest{
+		App:         "g-issues",
+		FromVersion: "0.0.0-snapshot.gdeadbeef",
+		ToVersion:   "0.0.0-snapshot.gabc123",
+		Timestamp:   now,
+	}); err != nil {
+		t.Fatalf("AppendRequest: %v", err)
+	}
+
+	restarter := &recordingAppRestarter{startErr: errors.New("start failed")}
+	poller := NewCatalogPoller(CatalogPollerConfig{
+		ChangeRequests:      services.AppVersionChangeRequests,
+		Materializations:    services.AppInstanceMaterializations,
+		AppRestarter:        restarter,
+		InstanceID:          "replica-a",
+		DisableRestartDelay: true,
+		Now:                 func() time.Time { return now },
+	})
+
+	err := poller.ReconcileOnce(context.Background())
+	if err == nil || err.Error() != `start app g-issues for g-issues@0.0.0-snapshot.gabc123: start failed` {
+		t.Fatalf("ReconcileOnce error = %v, want start failure", err)
+	}
+
+	materialization, getErr := services.AppInstanceMaterializations.Get(context.Background(), "replica-a", "g-issues", "0.0.0-snapshot.gabc123")
+	if getErr != nil {
+		t.Fatalf("Get materialization: %v", getErr)
+	}
+	if materialization.StoppedAt.IsZero() {
+		t.Fatal("expected stopped_at to be recorded before start failure")
+	}
+	if !materialization.RestartedAt.IsZero() {
+		t.Fatal("expected restarted_at to remain unset after start failure")
+	}
+}
+
+func TestCatalogPollerReconcileOnceRestartsOnceForMultipleVersions(t *testing.T) {
+	t.Parallel()
+
+	services := testutil.NewStubServices(t)
+	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+
+	requests := []struct {
+		from    string
+		to      string
+		updated time.Time
+	}{
+		{"0.0.0-snapshot.g111111", "0.0.0-snapshot.g222222", now},
+		{"0.0.0-snapshot.g222222", "0.0.0-snapshot.g333333", now.Add(time.Minute)},
+	}
+	for _, req := range requests {
+		if _, err := services.AppVersionChangeRequests.AppendRequest(context.Background(), &core.AppVersionChangeRequest{
+			App:         "g-issues",
+			FromVersion: req.from,
+			ToVersion:   req.to,
+			Timestamp:   req.updated,
+		}); err != nil {
+			t.Fatalf("AppendRequest(%s): %v", req.to, err)
+		}
+	}
+
+	restarter := &recordingAppRestarter{}
+	poller := NewCatalogPoller(CatalogPollerConfig{
+		ChangeRequests:      services.AppVersionChangeRequests,
+		Materializations:    services.AppInstanceMaterializations,
+		AppRestarter:        restarter,
+		InstanceID:          "replica-a",
+		DisableRestartDelay: true,
+		Now:                 func() time.Time { return now },
+	})
+
+	if err := poller.ReconcileOnce(context.Background()); err != nil {
+		t.Fatalf("ReconcileOnce: %v", err)
+	}
+	if got := len(restarter.stopCalls); got != 1 {
+		t.Fatalf("stopCalls = %d, want 1", got)
+	}
+	if got := len(restarter.startCalls); got != 1 {
+		t.Fatalf("startCalls = %d, want 1", got)
+	}
+
+	for _, version := range []string{"0.0.0-snapshot.g222222", "0.0.0-snapshot.g333333"} {
+		materialization, err := services.AppInstanceMaterializations.Get(context.Background(), "replica-a", "g-issues", version)
+		if err != nil {
+			t.Fatalf("Get materialization for %s: %v", version, err)
+		}
+		if materialization.RestartedAt != now {
+			t.Fatalf("RestartedAt for %s = %v, want %v", version, materialization.RestartedAt, now)
+		}
+	}
+}
+
+func TestCatalogPollerReconcileOnceRetriesStartAfterRecordedStop(t *testing.T) {
+	t.Parallel()
+
+	services := testutil.NewStubServices(t)
+	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+
+	if _, err := services.AppVersionChangeRequests.AppendRequest(context.Background(), &core.AppVersionChangeRequest{
+		App:         "g-issues",
+		FromVersion: "0.0.0-snapshot.gdeadbeef",
+		ToVersion:   "0.0.0-snapshot.gabc123",
+		Timestamp:   now,
+	}); err != nil {
+		t.Fatalf("AppendRequest: %v", err)
+	}
+
+	if _, err := services.AppInstanceMaterializations.Acknowledge(context.Background(), &core.AppInstanceMaterialization{
+		InstanceID:     "replica-a",
+		App:            "g-issues",
+		Version:        "0.0.0-snapshot.gabc123",
+		AcknowledgedAt: now,
+	}); err != nil {
+		t.Fatalf("Acknowledge: %v", err)
+	}
+	if _, err := services.AppInstanceMaterializations.MarkStopped(context.Background(), "replica-a", "g-issues", "0.0.0-snapshot.gabc123", now); err != nil {
+		t.Fatalf("MarkStopped: %v", err)
+	}
+	restarter := &recordingAppRestarter{}
+	poller := NewCatalogPoller(CatalogPollerConfig{
+		ChangeRequests:      services.AppVersionChangeRequests,
+		Materializations:    services.AppInstanceMaterializations,
+		AppRestarter:        restarter,
+		InstanceID:          "replica-a",
+		DisableRestartDelay: true,
+		Now:                 func() time.Time { return now },
+	})
+
+	if err := poller.ReconcileOnce(context.Background()); err != nil {
+		t.Fatalf("ReconcileOnce: %v", err)
+	}
+	if got := len(restarter.stopCalls); got != 0 {
+		t.Fatalf("stopCalls = %d, want 0", got)
+	}
+	if got := len(restarter.startCalls); got != 1 || restarter.startCalls[0] != "g-issues" {
+		t.Fatalf("startCalls = %#v, want [g-issues]", restarter.startCalls)
+	}
+
+	materialization, err := services.AppInstanceMaterializations.Get(context.Background(), "replica-a", "g-issues", "0.0.0-snapshot.gabc123")
+	if err != nil {
+		t.Fatalf("Get materialization: %v", err)
+	}
+	if materialization.RestartedAt != now {
+		t.Fatalf("RestartedAt = %v, want %v", materialization.RestartedAt, now)
+	}
+}
+func TestCatalogPollerReconcileOnceDoesNotResetRestartDelayForNewVersion(t *testing.T) {
+	t.Parallel()
+
+	services := testutil.NewStubServices(t)
+	start := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	clock := start
+
+	if _, err := services.AppVersionChangeRequests.AppendRequest(context.Background(), &core.AppVersionChangeRequest{
+		App:         "g-issues",
+		FromVersion: "0.0.0-snapshot.g111111",
+		ToVersion:   "0.0.0-snapshot.g222222",
+		Timestamp:   start,
+	}); err != nil {
+		t.Fatalf("AppendRequest v1: %v", err)
+	}
+
+	restarter := &recordingAppRestarter{}
+	poller := NewCatalogPoller(CatalogPollerConfig{
+		ChangeRequests:   services.AppVersionChangeRequests,
+		Materializations: services.AppInstanceMaterializations,
+		AppRestarter:     restarter,
+		InstanceID:       "replica-a",
+		RestartDelay:     time.Minute,
+		Now:              func() time.Time { return clock },
+	})
+
+	if err := poller.ReconcileOnce(context.Background()); err != nil {
+		t.Fatalf("first ReconcileOnce: %v", err)
+	}
+	if got := len(restarter.stopCalls); got != 1 {
+		t.Fatalf("stopCalls after first pass = %d, want 1", got)
+	}
+
+	if _, err := services.AppVersionChangeRequests.AppendRequest(context.Background(), &core.AppVersionChangeRequest{
+		App:         "g-issues",
+		FromVersion: "0.0.0-snapshot.g222222",
+		ToVersion:   "0.0.0-snapshot.g333333",
+		Timestamp:   start.Add(30 * time.Second),
+	}); err != nil {
+		t.Fatalf("AppendRequest v2: %v", err)
+	}
+
+	clock = start.Add(45 * time.Second)
+	if err := poller.ReconcileOnce(context.Background()); err != nil {
+		t.Fatalf("second ReconcileOnce: %v", err)
+	}
+	if got := len(restarter.stopCalls); got != 1 {
+		t.Fatalf("stopCalls after new version = %d, want 1", got)
+	}
+	if got := len(restarter.startCalls); got != 0 {
+		t.Fatalf("startCalls after new version = %d, want 0", got)
+	}
+
+	clock = start.Add(time.Minute)
+	if err := poller.ReconcileOnce(context.Background()); err != nil {
+		t.Fatalf("third ReconcileOnce: %v", err)
+	}
+	if got := len(restarter.startCalls); got != 1 {
+		t.Fatalf("startCalls after delay elapsed = %d, want 1", got)
+	}
+
+	for _, version := range []string{"0.0.0-snapshot.g222222", "0.0.0-snapshot.g333333"} {
+		materialization, err := services.AppInstanceMaterializations.Get(context.Background(), "replica-a", "g-issues", version)
+		if err != nil {
+			t.Fatalf("Get materialization for %s: %v", version, err)
+		}
+		if materialization.StoppedAt != start {
+			t.Fatalf("StoppedAt for %s = %v, want %v", version, materialization.StoppedAt, start)
+		}
+	}
+}
+
+func TestCatalogPollerReconcileOnceDefersRestartUntilProvidersReady(t *testing.T) {
+	t.Parallel()
+
+	services := testutil.NewStubServices(t)
+	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	restartReady := make(chan struct{})
+
+	if _, err := services.AppVersionChangeRequests.AppendRequest(context.Background(), &core.AppVersionChangeRequest{
+		App:         "g-issues",
+		FromVersion: "0.0.0-snapshot.gdeadbeef",
+		ToVersion:   "0.0.0-snapshot.gabc123",
+		Timestamp:   now,
+	}); err != nil {
+		t.Fatalf("AppendRequest: %v", err)
+	}
+
+	restarter := &recordingAppRestarter{}
+	poller := NewCatalogPoller(CatalogPollerConfig{
+		ChangeRequests:      services.AppVersionChangeRequests,
+		Materializations:    services.AppInstanceMaterializations,
+		AppRestarter:        restarter,
+		InstanceID:          "replica-a",
+		DisableRestartDelay: true,
+		RestartReady:        restartReady,
+		Now:                 func() time.Time { return now },
+	})
+
+	if err := poller.ReconcileOnce(context.Background()); err != nil {
+		t.Fatalf("ReconcileOnce before providers ready: %v", err)
+	}
+	if got := len(restarter.stopCalls); got != 0 {
+		t.Fatalf("stopCalls before providers ready = %d, want 0", got)
+	}
+	if got := len(restarter.startCalls); got != 0 {
+		t.Fatalf("startCalls before providers ready = %d, want 0", got)
+	}
+
+	materialization, err := services.AppInstanceMaterializations.Get(context.Background(), "replica-a", "g-issues", "0.0.0-snapshot.gabc123")
+	if err != nil {
+		t.Fatalf("Get materialization: %v", err)
+	}
+	if materialization.AcknowledgedAt != now {
+		t.Fatalf("AcknowledgedAt = %v, want %v", materialization.AcknowledgedAt, now)
+	}
+	if !materialization.RestartedAt.IsZero() {
+		t.Fatalf("RestartedAt = %v, want zero before providers ready", materialization.RestartedAt)
+	}
+
+	close(restartReady)
+	if err := poller.ReconcileOnce(context.Background()); err != nil {
+		t.Fatalf("ReconcileOnce after providers ready: %v", err)
+	}
+	if got := len(restarter.stopCalls); got != 1 || restarter.stopCalls[0] != "g-issues" {
+		t.Fatalf("stopCalls after providers ready = %#v, want [g-issues]", restarter.stopCalls)
+	}
+	if got := len(restarter.startCalls); got != 1 || restarter.startCalls[0] != "g-issues" {
+		t.Fatalf("startCalls after providers ready = %#v, want [g-issues]", restarter.startCalls)
+	}
+}
+
+func TestCatalogPollerReconcileOnceDoesNotConvergeWithoutAppRestarter(t *testing.T) {
+	t.Parallel()
+
+	services := testutil.NewStubServices(t)
+	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+
+	if _, err := services.AppVersionChangeRequests.AppendRequest(context.Background(), &core.AppVersionChangeRequest{
+		App:         "g-issues",
+		FromVersion: "0.0.0-snapshot.gdeadbeef",
+		ToVersion:   "0.0.0-snapshot.gabc123",
+		Timestamp:   now,
+	}); err != nil {
+		t.Fatalf("AppendRequest: %v", err)
+	}
+
+	poller := NewCatalogPoller(CatalogPollerConfig{
+		ChangeRequests:      services.AppVersionChangeRequests,
+		Materializations:    services.AppInstanceMaterializations,
+		InstanceID:          "replica-a",
+		DisableRestartDelay: true,
+		Now:                 func() time.Time { return now },
+	})
+
+	if err := poller.ReconcileOnce(context.Background()); err != nil {
+		t.Fatalf("ReconcileOnce: %v", err)
+	}
+
+	materialization, err := services.AppInstanceMaterializations.Get(context.Background(), "replica-a", "g-issues", "0.0.0-snapshot.gabc123")
+	if err != nil {
+		t.Fatalf("Get materialization: %v", err)
+	}
+	if materialization.AcknowledgedAt != now {
+		t.Fatalf("AcknowledgedAt = %v, want %v", materialization.AcknowledgedAt, now)
+	}
+	if !materialization.RestartedAt.IsZero() {
+		t.Fatalf("RestartedAt = %v, want zero without AppRestarter", materialization.RestartedAt)
+	}
+}
+
+func TestCatalogPollerReconcileOnceMarksNonLocalAppsConverged(t *testing.T) {
+	t.Parallel()
+
+	services := testutil.NewStubServices(t)
+	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+
+	if _, err := services.AppVersionChangeRequests.AppendRequest(context.Background(), &core.AppVersionChangeRequest{
+		App:         "remote-app",
+		FromVersion: "1.0.0",
+		ToVersion:   "1.0.1",
+		Timestamp:   now,
+	}); err != nil {
+		t.Fatalf("AppendRequest: %v", err)
+	}
+
+	restarter := &recordingAppRestarter{
+		restartable: map[string]bool{"remote-app": false},
+	}
+	poller := NewCatalogPoller(CatalogPollerConfig{
+		ChangeRequests:   services.AppVersionChangeRequests,
+		Materializations: services.AppInstanceMaterializations,
+		AppRestarter:     restarter,
+		InstanceID:       "replica-a",
+		RestartDelay:     time.Minute,
+		Now:              func() time.Time { return now },
+	})
+
+	if err := poller.ReconcileOnce(context.Background()); err != nil {
+		t.Fatalf("ReconcileOnce: %v", err)
+	}
+	if got := len(restarter.stopCalls); got != 0 {
+		t.Fatalf("stopCalls = %d, want 0", got)
+	}
+	if got := len(restarter.startCalls); got != 0 {
+		t.Fatalf("startCalls = %d, want 0", got)
+	}
+
+	materialization, err := services.AppInstanceMaterializations.Get(context.Background(), "replica-a", "remote-app", "1.0.1")
+	if err != nil {
+		t.Fatalf("Get materialization: %v", err)
+	}
+	if materialization.RestartedAt != now {
+		t.Fatalf("RestartedAt = %v, want %v", materialization.RestartedAt, now)
+	}
+}
+
+func TestCatalogPollerReconcileOnceDoesNotConvergeWhenRestartModeFails(t *testing.T) {
+	t.Parallel()
+
+	services := testutil.NewStubServices(t)
+	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	if _, err := services.AppVersionChangeRequests.AppendRequest(context.Background(), &core.AppVersionChangeRequest{
+		App:         "unknown-app",
+		FromVersion: "0.9.0",
+		ToVersion:   "1.0.0",
+		Timestamp:   now,
+	}); err != nil {
+		t.Fatalf("AppendRequest: %v", err)
+	}
+
+	restarter := &recordingAppRestarter{restartableErr: errors.New("app is not configured")}
+	poller := NewCatalogPoller(CatalogPollerConfig{
+		ChangeRequests:      services.AppVersionChangeRequests,
+		Materializations:    services.AppInstanceMaterializations,
+		AppRestarter:        restarter,
+		InstanceID:          "replica-a",
+		DisableRestartDelay: true,
+		Now:                 func() time.Time { return now },
+	})
+
+	err := poller.ReconcileOnce(context.Background())
+	if err == nil || err.Error() != "determine restart mode for app unknown-app: app is not configured" {
+		t.Fatalf("ReconcileOnce error = %v, want restart mode failure", err)
+	}
+	materialization, getErr := services.AppInstanceMaterializations.Get(context.Background(), "replica-a", "unknown-app", "1.0.0")
+	if getErr != nil {
+		t.Fatalf("Get materialization: %v", getErr)
+	}
+	if !materialization.RestartedAt.IsZero() {
+		t.Fatalf("RestartedAt = %v, want zero", materialization.RestartedAt)
+	}
+}
+
+func TestCatalogPollerReconcileOnceReportsEveryFailingApp(t *testing.T) {
+	t.Parallel()
+
+	services := testutil.NewStubServices(t)
+	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	for _, app := range []string{"app-a", "app-b"} {
+		if _, err := services.AppVersionChangeRequests.AppendRequest(context.Background(), &core.AppVersionChangeRequest{
+			App:         app,
+			FromVersion: "0.9.0",
+			ToVersion:   "1.0.0",
+			Timestamp:   now,
+		}); err != nil {
+			t.Fatalf("AppendRequest(%s): %v", app, err)
+		}
+	}
+	poller := NewCatalogPoller(CatalogPollerConfig{
+		ChangeRequests:   services.AppVersionChangeRequests,
+		Materializations: services.AppInstanceMaterializations,
+		AppRestarter:     &recordingAppRestarter{restartableErr: errors.New("restart mode failed")},
+		InstanceID:       "replica-a",
+		Now:              func() time.Time { return now },
+	})
+
+	err := poller.ReconcileOnce(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "app-a") || !strings.Contains(err.Error(), "app-b") {
+		t.Fatalf("ReconcileOnce error = %v, want both app failures", err)
+	}
+}

--- a/gestaltd/internal/appregistry/restarter.go
+++ b/gestaltd/internal/appregistry/restarter.go
@@ -1,0 +1,12 @@
+package appregistry
+
+import "context"
+
+// AppRestarter stops and starts a configured app provider during fleet install
+// convergence. Step 9 exercises restart plumbing only; later steps swap binaries.
+type AppRestarter interface {
+	Restartable(app string) (bool, error)
+	StopApp(ctx context.Context, app string) error
+	StartApp(ctx context.Context, app string) error
+	AbortRestarts()
+}

--- a/gestaltd/internal/bootstrap/app_provider_lifecycle.go
+++ b/gestaltd/internal/bootstrap/app_provider_lifecycle.go
@@ -1,0 +1,28 @@
+package bootstrap
+
+import (
+	"context"
+	"strings"
+	"sync"
+)
+
+// appProviderLifecycles serializes initial activation and catalog-driven
+// restart work for each app.
+type appProviderLifecycles struct {
+	gates sync.Map
+}
+
+func (l *appProviderLifecycles) acquire(ctx context.Context, app string) (func(), error) {
+	if l == nil {
+		return func() {}, nil
+	}
+	gateValue, _ := l.gates.LoadOrStore(strings.TrimSpace(app), make(chan struct{}, 1))
+	gate := gateValue.(chan struct{})
+	select {
+	case gate <- struct{}{}:
+		var once sync.Once
+		return func() { once.Do(func() { <-gate }) }, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}

--- a/gestaltd/internal/bootstrap/app_provider_lifecycle_test.go
+++ b/gestaltd/internal/bootstrap/app_provider_lifecycle_test.go
@@ -1,0 +1,38 @@
+package bootstrap
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestAppProviderLifecycleSerializesOneApp(t *testing.T) {
+	t.Parallel()
+
+	lifecycles := &appProviderLifecycles{}
+	releaseFirst, err := lifecycles.acquire(context.Background(), "g-issues")
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	acquiredSecond := make(chan func(), 1)
+	go func() {
+		release, acquireErr := lifecycles.acquire(context.Background(), "g-issues")
+		if acquireErr == nil {
+			acquiredSecond <- release
+		}
+	}()
+
+	select {
+	case <-acquiredSecond:
+		t.Fatal("second lifecycle acquired before first released")
+	case <-time.After(25 * time.Millisecond):
+	}
+	releaseFirst()
+
+	select {
+	case releaseSecond := <-acquiredSecond:
+		releaseSecond()
+	case <-time.After(time.Second):
+		t.Fatal("second lifecycle did not acquire after release")
+	}
+}

--- a/gestaltd/internal/bootstrap/app_provider_restart.go
+++ b/gestaltd/internal/bootstrap/app_provider_restart.go
@@ -1,0 +1,263 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/apps/registry"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
+	"github.com/valon-technologies/gestalt/server/services/providerdev"
+)
+
+const providerStopTimeout = 10 * time.Second
+
+type pendingProviderClose struct {
+	provider core.Provider
+	done     <-chan error
+}
+
+type AppProviderRestarter struct {
+	cfg           *config.Config
+	deps          Deps
+	providers     *registry.ProviderMap[core.Provider]
+	authBuilds    []*preparedProviderBuilds
+	lifecycles    *appProviderLifecycles
+	held          map[string]func()
+	closing       map[string]pendingProviderClose
+	closeFailures map[string]error
+
+	lifecycleMu sync.Mutex
+}
+
+type AppProviderRestarterConfig struct {
+	Config     *config.Config
+	Deps       Deps
+	Providers  *registry.ProviderMap[core.Provider]
+	AuthBuilds []*preparedProviderBuilds
+	Lifecycles *appProviderLifecycles
+}
+
+func NewAppProviderRestarter(cfg AppProviderRestarterConfig) *AppProviderRestarter {
+	return &AppProviderRestarter{
+		cfg:           cfg.Config,
+		deps:          cfg.Deps,
+		providers:     cfg.Providers,
+		authBuilds:    cfg.AuthBuilds,
+		lifecycles:    cfg.Lifecycles,
+		held:          make(map[string]func()),
+		closing:       make(map[string]pendingProviderClose),
+		closeFailures: make(map[string]error),
+	}
+}
+
+func (r *AppProviderRestarter) Restartable(app string) (bool, error) {
+	if r == nil {
+		return false, fmt.Errorf("app provider restarter is not configured")
+	}
+	entry, err := r.appEntry(app)
+	if err != nil {
+		return false, err
+	}
+	return appProviderRestartable(r.cfg, entry), nil
+}
+
+func appProviderRestartable(cfg *config.Config, entry *config.ProviderEntry) bool {
+	return entry != nil && !entry.DevActive && providerBuildsLocal(cfg, entry)
+}
+
+func (r *AppProviderRestarter) StopApp(ctx context.Context, app string) error {
+	if r == nil {
+		return fmt.Errorf("stop app provider: restarter is not configured")
+	}
+	app = strings.TrimSpace(app)
+	if app == "" {
+		return fmt.Errorf("stop app provider: app is required")
+	}
+	entry, err := r.appEntry(app)
+	if err != nil {
+		return err
+	}
+	if !appProviderRestartable(r.cfg, entry) {
+		return fmt.Errorf("stop app provider: %q is not catalog-restartable", app)
+	}
+	if r.providers == nil {
+		return fmt.Errorf("stop app provider: provider registry is not configured")
+	}
+	r.lifecycleMu.Lock()
+	defer r.lifecycleMu.Unlock()
+	if err := r.ensureLifecycleLease(ctx, app); err != nil {
+		return fmt.Errorf("stop app provider: wait for provider lifecycle: %w", err)
+	}
+	if pending, ok := r.closing[app]; ok {
+		return r.awaitProviderClose(ctx, app, pending)
+	}
+	if closeErr, ok := r.closeFailures[app]; ok {
+		return fmt.Errorf("stop app provider %q: previous close failed: %w", app, closeErr)
+	}
+
+	provider, err := r.providers.Get(app)
+	if err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			return nil
+		}
+		r.releaseLifecycleLease(app)
+		return fmt.Errorf("stop app provider: %w", err)
+	}
+	r.providers.Remove(app)
+	pending := pendingProviderClose{provider: provider, done: closeProviderForRestart(provider)}
+	r.closing[app] = pending
+	return r.awaitProviderClose(ctx, app, pending)
+}
+
+func (r *AppProviderRestarter) StartApp(ctx context.Context, app string) error {
+	if r == nil {
+		return fmt.Errorf("start app provider: restarter is not configured")
+	}
+	app = strings.TrimSpace(app)
+	if app == "" {
+		return fmt.Errorf("start app provider: app is required")
+	}
+	entry, err := r.appEntry(app)
+	if err != nil {
+		return err
+	}
+	if !appProviderRestartable(r.cfg, entry) {
+		return fmt.Errorf("start app provider: %q is not catalog-restartable", app)
+	}
+	if r.providers == nil {
+		return fmt.Errorf("start app provider: provider registry is not configured")
+	}
+	r.lifecycleMu.Lock()
+	defer r.lifecycleMu.Unlock()
+	if err := r.ensureLifecycleLease(ctx, app); err != nil {
+		return fmt.Errorf("start app provider: wait for provider lifecycle: %w", err)
+	}
+
+	if _, getErr := r.providers.Get(app); getErr == nil {
+		r.releaseLifecycleLease(app)
+		return nil
+	} else if !errors.Is(getErr, core.ErrNotFound) {
+		return fmt.Errorf("start app provider: %w", getErr)
+	}
+
+	buildCtx, cancel := context.WithTimeout(ctx, providerInstallTimeout)
+	defer cancel()
+	buildCtx = invocation.WithCallerProvider(buildCtx, invocation.ProviderKindApp, app)
+	result, err := buildProvider(buildCtx, app, entry, r.deps)
+	if errors.Is(err, providerdev.ErrFrontendOnlyDevApp) {
+		r.storeConnectionAuth(app, &ProviderBuildResult{})
+		if r.deps.AppWorkflowDeclarations != nil {
+			r.deps.AppWorkflowDeclarations.Set(app, []*proto.WorkflowDefinitionSpec{})
+		}
+		r.releaseLifecycleLease(app)
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("start app provider %q: %w", app, err)
+	}
+	if err := validateProviderConnectionMode(app, result.Provider.ConnectionMode()); err != nil {
+		closeIfPossible(result.Provider)
+		return fmt.Errorf("start app provider %q: %w", app, err)
+	}
+	if err := r.providers.Register(app, result.Provider); err != nil {
+		closeIfPossible(result.Provider)
+		return fmt.Errorf("start app provider %q: %w", app, err)
+	}
+	r.storeConnectionAuth(app, result)
+	if r.deps.AppWorkflowDeclarations != nil {
+		decls := result.WorkflowDeclarations
+		if decls == nil {
+			decls = []*proto.WorkflowDefinitionSpec{}
+		}
+		r.deps.AppWorkflowDeclarations.Set(app, decls)
+	}
+	r.releaseLifecycleLease(app)
+	return nil
+}
+
+func (r *AppProviderRestarter) AbortRestarts() {
+	if r == nil {
+		return
+	}
+	r.lifecycleMu.Lock()
+	defer r.lifecycleMu.Unlock()
+	for app := range r.held {
+		r.releaseLifecycleLease(app)
+	}
+}
+
+func (r *AppProviderRestarter) ensureLifecycleLease(ctx context.Context, app string) error {
+	if _, ok := r.held[app]; ok {
+		return nil
+	}
+	if r.lifecycles == nil {
+		r.held[app] = func() {}
+		return nil
+	}
+	release, err := r.lifecycles.acquire(ctx, app)
+	if err != nil {
+		return err
+	}
+	r.held[app] = release
+	return nil
+}
+
+func (r *AppProviderRestarter) releaseLifecycleLease(app string) {
+	release, ok := r.held[app]
+	if !ok {
+		return
+	}
+	delete(r.held, app)
+	release()
+}
+
+func closeProviderForRestart(provider core.Provider) <-chan error {
+	done := make(chan error, 1)
+	closer, ok := provider.(interface{ Close() error })
+	if !ok {
+		done <- nil
+		return done
+	}
+	go func() { done <- closer.Close() }()
+	return done
+}
+
+func (r *AppProviderRestarter) awaitProviderClose(ctx context.Context, app string, pending pendingProviderClose) error {
+	waitCtx, cancel := context.WithTimeout(ctx, providerStopTimeout)
+	defer cancel()
+	select {
+	case err := <-pending.done:
+		delete(r.closing, app)
+		if err == nil {
+			return nil
+		}
+		r.closeFailures[app] = err
+		return fmt.Errorf("stop app provider %q: %w", app, err)
+	case <-waitCtx.Done():
+		return fmt.Errorf("stop app provider %q: close did not finish: %w", app, waitCtx.Err())
+	}
+}
+
+func (r *AppProviderRestarter) appEntry(app string) (*config.ProviderEntry, error) {
+	if r.cfg == nil || r.cfg.Apps == nil {
+		return nil, fmt.Errorf("app %q is not configured", app)
+	}
+	entry := r.cfg.Apps[app]
+	if entry == nil {
+		return nil, fmt.Errorf("app %q is not configured", app)
+	}
+	return entry, nil
+}
+
+func (r *AppProviderRestarter) storeConnectionAuth(app string, result *ProviderBuildResult) {
+	for _, builds := range r.authBuilds {
+		builds.storeConnectionAuth(app, result)
+	}
+}

--- a/gestaltd/internal/bootstrap/app_provider_restart_test.go
+++ b/gestaltd/internal/bootstrap/app_provider_restart_test.go
@@ -1,0 +1,212 @@
+package bootstrap_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+type restartCloseFailureProvider struct {
+	coretesting.StubIntegration
+	err error
+}
+
+func (p *restartCloseFailureProvider) Close() error { return p.err }
+
+func TestAppProviderRestarterRestartable(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{Remote: "https://remote.test"},
+		Apps: map[string]*config.ProviderEntry{
+			"remote":         {},
+			"local-override": {Local: true},
+			"dev-active":     {DevActive: true},
+		},
+	}
+	restarter := bootstrap.NewAppProviderRestarter(bootstrap.AppProviderRestarterConfig{Config: cfg})
+
+	for _, tc := range []struct {
+		app  string
+		want bool
+	}{
+		{app: "remote", want: false},
+		{app: "local-override", want: true},
+		{app: "dev-active", want: false},
+	} {
+		got, err := restarter.Restartable(tc.app)
+		if err != nil {
+			t.Fatalf("Restartable(%q): %v", tc.app, err)
+		}
+		if got != tc.want {
+			t.Errorf("Restartable(%q) = %v, want %v", tc.app, got, tc.want)
+		}
+	}
+
+	cfg.Server.Remote = ""
+	got, err := restarter.Restartable("remote")
+	if err != nil {
+		t.Fatalf("Restartable without server.remote: %v", err)
+	}
+	if !got {
+		t.Error("packaged app should be restartable when server.remote is unset")
+	}
+}
+
+func TestAppProviderRestarterStopAppNoOpsWhenProviderMissing(t *testing.T) {
+	t.Parallel()
+
+	srv := newRestartTestOpenAPIServer(t)
+	cfg := restartTestConfig(srv.URL)
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, validFactories())
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	t.Cleanup(func() { _ = result.Close(context.Background()) })
+
+	select {
+	case <-result.ProvidersReady:
+	case <-time.After(5 * time.Second):
+		t.Fatal("providers did not become ready")
+	}
+
+	result.Providers.Remove("restart-app")
+	if err := result.AppRestarter.StopApp(context.Background(), "restart-app"); err != nil {
+		t.Fatalf("StopApp: %v", err)
+	}
+}
+
+func TestAppProviderRestarterStartAppRegistersMissingProvider(t *testing.T) {
+	t.Parallel()
+
+	srv := newRestartTestOpenAPIServer(t)
+	cfg := restartTestConfig(srv.URL)
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, validFactories())
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	t.Cleanup(func() { _ = result.Close(context.Background()) })
+
+	select {
+	case <-result.ProvidersReady:
+	case <-time.After(5 * time.Second):
+		t.Fatal("providers did not become ready")
+	}
+
+	result.Providers.Remove("restart-app")
+	if err := result.AppRestarter.StartApp(context.Background(), "restart-app"); err != nil {
+		t.Fatalf("StartApp: %v", err)
+	}
+	if _, err := result.Providers.Get("restart-app"); err != nil {
+		t.Fatalf("Get after StartApp: %v", err)
+	}
+	if err := result.AppRestarter.StartApp(context.Background(), "restart-app"); err != nil {
+		t.Fatalf("second StartApp: %v", err)
+	}
+}
+
+func TestAppProviderRestarterStopRemovesProviderAndStartRestoresIt(t *testing.T) {
+	t.Parallel()
+
+	srv := newRestartTestOpenAPIServer(t)
+	result, err := bootstrap.Bootstrap(context.Background(), restartTestConfig(srv.URL), validFactories())
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	t.Cleanup(func() { _ = result.Close(context.Background()) })
+
+	select {
+	case <-result.ProvidersReady:
+	case <-time.After(5 * time.Second):
+		t.Fatal("providers did not become ready")
+	}
+
+	if err := result.AppRestarter.StopApp(context.Background(), "restart-app"); err != nil {
+		t.Fatalf("StopApp: %v", err)
+	}
+	if _, err := result.Providers.Get("restart-app"); err == nil {
+		t.Fatal("provider remains registered after StopApp")
+	}
+	if err := result.AppRestarter.StartApp(context.Background(), "restart-app"); err != nil {
+		t.Fatalf("StartApp: %v", err)
+	}
+	if _, err := result.Providers.Get("restart-app"); err != nil {
+		t.Fatalf("Get after StartApp: %v", err)
+	}
+}
+
+func TestAppProviderRestarterStopQuarantinesProviderWhenCloseFails(t *testing.T) {
+	t.Parallel()
+
+	srv := newRestartTestOpenAPIServer(t)
+	result, err := bootstrap.Bootstrap(context.Background(), restartTestConfig(srv.URL), validFactories())
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	t.Cleanup(func() { _ = result.Close(context.Background()) })
+
+	select {
+	case <-result.ProvidersReady:
+	case <-time.After(5 * time.Second):
+		t.Fatal("providers did not become ready")
+	}
+
+	closeErr := errors.New("close failed")
+	provider := &restartCloseFailureProvider{err: closeErr}
+	if err := result.Providers.Replace("restart-app", provider); err != nil {
+		t.Fatalf("Replace: %v", err)
+	}
+	if err := result.AppRestarter.StopApp(context.Background(), "restart-app"); !errors.Is(err, closeErr) {
+		t.Fatalf("StopApp error = %v, want %v", err, closeErr)
+	}
+	if _, err := result.Providers.Get("restart-app"); err == nil {
+		t.Fatal("partially closed provider was republished after failed StopApp")
+	}
+	if err := result.AppRestarter.StopApp(context.Background(), "restart-app"); !errors.Is(err, closeErr) {
+		t.Fatalf("second StopApp error = %v, want retained close failure", err)
+	}
+}
+
+func newRestartTestOpenAPIServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"openapi":"3.0.0",
+			"info":{"title":"restart-app","version":"1.0.0"},
+			"paths":{"/status":{"get":{"operationId":"status","responses":{"200":{"description":"ok"}}}}}
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func restartTestConfig(openAPIURL string) *config.Config {
+	cfg := validConfig()
+	cfg.Apps = map[string]*config.ProviderEntry{
+		"restart-app": {
+			ResolvedManifest: &providermanifestv1.Manifest{
+				Spec: &providermanifestv1.Spec{
+					DefaultConnection: config.AppConnectionName,
+					Connections: map[string]*providermanifestv1.ManifestConnectionDef{
+						config.AppConnectionName: {Mode: providermanifestv1.ConnectionModeNone},
+					},
+					Surfaces: &providermanifestv1.ProviderSurfaces{
+						OpenAPI: &providermanifestv1.OpenAPISurface{Document: openAPIURL, BaseURL: openAPIURL},
+					},
+				},
+			},
+		},
+	}
+	return cfg
+}

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -273,6 +273,12 @@ type Result struct {
 	PublicGatewayTransport *providergateway.ProviderGatewayTransport
 	CallerTokenIssuer      *providergateway.CallerTokenIssuer
 	DevSupervisor          *providerdev.Supervisor
+	AppRestarter           interface {
+		Restartable(string) (bool, error)
+		StopApp(context.Context, string) error
+		StartApp(context.Context, string) error
+		AbortRestarts()
+	}
 
 	runtimeRegistry                     *runtimeRegistry
 	workflowConfigReconcileTasks        []workflowConfigReconcileTask
@@ -1478,36 +1484,43 @@ func BootstrapWithOptions(ctx context.Context, cfg *config.Config, factories *Fa
 	closeWorkflowsOnError = false
 	closeAgentsOnError = false
 	result := &Result{
-		Auth:                           prepared.Auth,
-		SelectedAuthProvider:           prepared.SelectedAuthProvider,
-		AuthProviders:                  prepared.AuthProviders,
-		Authorization:                  prepared.Authorization,
-		Services:                       prepared.Services,
-		ExtraIndexedDBs:                prepared.ExtraIndexedDBs,
-		ExtraCaches:                    prepared.ExtraCaches,
-		S3:                             prepared.Deps.S3,
-		ExtraS3s:                       prepared.ExtraS3s,
-		ExtraWorkflows:                 extraWorkflows,
-		ExtraAgents:                    extraAgents,
-		Providers:                      providers,
-		WorkflowControl:                prepared.Deps.WorkflowRuntime,
-		AgentControl:                   prepared.Deps.AgentRuntime,
-		AgentManager:                   prepared.Deps.AgentManager,
-		StartupProvidersReady:          startup.ready(),
-		ProvidersReady:                 deferred.ready(),
-		ConnectionAuth:                 connAuthResolver,
-		ManualConnectionAuth:           manualConnAuthResolver,
-		Invoker:                        sharedInvoker,
-		AppInvocation:                  pluginInvoker,
-		CapabilityLister:               sharedInvoker,
-		AuditSink:                      audit,
-		SecretManager:                  prepared.SecretManager,
-		Telemetry:                      prepared.Telemetry,
-		Runtimes:                       prepared.runtimeRegistry,
-		PublicHostServices:             publicHostServices,
-		PublicGatewayTransport:         publicGatewayTransport,
-		CallerTokenIssuer:              prepared.CallerTokenIssuer,
-		DevSupervisor:                  prepared.Deps.DevSupervisor,
+		Auth:                   prepared.Auth,
+		SelectedAuthProvider:   prepared.SelectedAuthProvider,
+		AuthProviders:          prepared.AuthProviders,
+		Authorization:          prepared.Authorization,
+		Services:               prepared.Services,
+		ExtraIndexedDBs:        prepared.ExtraIndexedDBs,
+		ExtraCaches:            prepared.ExtraCaches,
+		S3:                     prepared.Deps.S3,
+		ExtraS3s:               prepared.ExtraS3s,
+		ExtraWorkflows:         extraWorkflows,
+		ExtraAgents:            extraAgents,
+		Providers:              providers,
+		WorkflowControl:        prepared.Deps.WorkflowRuntime,
+		AgentControl:           prepared.Deps.AgentRuntime,
+		AgentManager:           prepared.Deps.AgentManager,
+		StartupProvidersReady:  startup.ready(),
+		ProvidersReady:         deferred.ready(),
+		ConnectionAuth:         connAuthResolver,
+		ManualConnectionAuth:   manualConnAuthResolver,
+		Invoker:                sharedInvoker,
+		AppInvocation:          pluginInvoker,
+		CapabilityLister:       sharedInvoker,
+		AuditSink:              audit,
+		SecretManager:          prepared.SecretManager,
+		Telemetry:              prepared.Telemetry,
+		Runtimes:               prepared.runtimeRegistry,
+		PublicHostServices:     publicHostServices,
+		PublicGatewayTransport: publicGatewayTransport,
+		CallerTokenIssuer:      prepared.CallerTokenIssuer,
+		DevSupervisor:          prepared.Deps.DevSupervisor,
+		AppRestarter: NewAppProviderRestarter(AppProviderRestarterConfig{
+			Config:     cfg,
+			Deps:       prepared.Deps,
+			Providers:  providers,
+			AuthBuilds: []*preparedProviderBuilds{noopBuilds, updateBuilds},
+			Lifecycles: noopBuilds.lifecycles,
+		}),
 		runtimeRegistry:                prepared.runtimeRegistry,
 		workflowConfigReconcileTasks:   deferredWorkflowConfigReconcileTasks,
 		startupWorkflowConfigReconcile: startupWorkflowConfigReconcile,

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -58,7 +58,9 @@ type pendingProviderBuild struct {
 
 type preparedProviderBuilds struct {
 	providers      *registry.ProviderMap[core.Provider]
+	lifecycles     *appProviderLifecycles
 	pending        []pendingProviderBuild
+	authMu         sync.RWMutex
 	connAuth       map[string]map[string]OAuthHandler
 	manualConnAuth map[string]map[string]ManualTokenExchanger
 	errs           []error
@@ -88,6 +90,7 @@ func prepareProviderBuilds(
 
 	builds := &preparedProviderBuilds{
 		providers:      &reg.Providers,
+		lifecycles:     &appProviderLifecycles{},
 		connAuth:       connAuth,
 		manualConnAuth: manualConnAuth,
 	}
@@ -162,12 +165,14 @@ func (b *preparedProviderBuilds) partition(categorize func(string, *config.Provi
 	prepErrs := append([]error(nil), b.errs...)
 	noop = &preparedProviderBuilds{
 		providers:      b.providers,
+		lifecycles:     b.lifecycles,
 		connAuth:       make(map[string]map[string]OAuthHandler),
 		manualConnAuth: make(map[string]map[string]ManualTokenExchanger),
 		errs:           prepErrs,
 	}
 	update = &preparedProviderBuilds{
 		providers:      b.providers,
+		lifecycles:     b.lifecycles,
 		connAuth:       make(map[string]map[string]OAuthHandler),
 		manualConnAuth: make(map[string]map[string]ManualTokenExchanger),
 		errs:           prepErrs,
@@ -195,13 +200,13 @@ func (b *preparedProviderBuilds) Start(
 				if b == nil {
 					return nil
 				}
-				return b.connAuth
+				return b.connectionAuthSnapshot()
 			},
 			func() map[string]map[string]ManualTokenExchanger {
 				if b == nil {
 					return nil
 				}
-				return b.manualConnAuth
+				return b.manualConnectionAuthSnapshot()
 			},
 			func() []error {
 				if b == nil {
@@ -212,7 +217,6 @@ func (b *preparedProviderBuilds) Start(
 	}
 
 	buildErrs := append([]error(nil), b.errs...)
-	var connMu sync.Mutex
 	var errMu sync.Mutex
 	var wg sync.WaitGroup
 
@@ -223,6 +227,25 @@ func (b *preparedProviderBuilds) Start(
 		go func(pending pendingProviderBuild) {
 			defer wg.Done()
 			buildCtx := invocation.WithCallerProvider(installCtx, invocation.ProviderKindApp, pending.name)
+			release, err := b.lifecycles.acquire(buildCtx, pending.name)
+			if err != nil {
+				if pending.proxy != nil && b.pendingProxyOwnsProvider(pending) {
+					pending.proxy.fail(err)
+					b.providers.Remove(pending.name)
+				}
+				errMu.Lock()
+				buildErrs = append(buildErrs, fmt.Errorf("integration %q: wait for provider lifecycle: %w", pending.name, err))
+				errMu.Unlock()
+				return
+			}
+			defer release()
+			if pending.proxy != nil {
+				current, getErr := b.providers.Get(pending.name)
+				if getErr != nil || current != pending.proxy {
+					slog.Debug("skipping superseded deferred provider activation", "provider", pending.name)
+					return
+				}
+			}
 			result, err := builder(buildCtx, pending.name, pending.entry, deps)
 			if errors.Is(err, providerdev.ErrFrontendOnlyDevApp) {
 				if pending.proxy != nil {
@@ -277,16 +300,7 @@ func (b *preparedProviderBuilds) Start(
 					return
 				}
 			}
-			if len(result.ConnectionAuth) > 0 {
-				connMu.Lock()
-				b.connAuth[pending.name] = result.ConnectionAuth
-				connMu.Unlock()
-			}
-			if len(result.ManualConnectionAuth) > 0 {
-				connMu.Lock()
-				b.manualConnAuth[pending.name] = result.ManualConnectionAuth
-				connMu.Unlock()
-			}
+			b.storeConnectionAuth(pending.name, result)
 			if b.onInstalled != nil && pending.sha != "" {
 				b.onInstalled(pending.name, pending.sha)
 			}
@@ -309,11 +323,11 @@ func (b *preparedProviderBuilds) Start(
 
 	resolver := func() map[string]map[string]OAuthHandler {
 		<-ready
-		return b.connAuth
+		return b.connectionAuthSnapshot()
 	}
 	manualResolver := func() map[string]map[string]ManualTokenExchanger {
 		<-ready
-		return b.manualConnAuth
+		return b.manualConnectionAuthSnapshot()
 	}
 	errResolver := func() []error {
 		<-ready
@@ -322,6 +336,47 @@ func (b *preparedProviderBuilds) Start(
 		return append([]error(nil), buildErrs...)
 	}
 	return ready, resolver, manualResolver, errResolver
+}
+
+func (b *preparedProviderBuilds) storeConnectionAuth(name string, result *ProviderBuildResult) {
+	if b == nil || result == nil {
+		return
+	}
+	b.authMu.Lock()
+	defer b.authMu.Unlock()
+	if len(result.ConnectionAuth) == 0 {
+		delete(b.connAuth, name)
+	} else {
+		b.connAuth[name] = result.ConnectionAuth
+	}
+	if len(result.ManualConnectionAuth) == 0 {
+		delete(b.manualConnAuth, name)
+	} else {
+		b.manualConnAuth[name] = result.ManualConnectionAuth
+	}
+}
+
+func (b *preparedProviderBuilds) pendingProxyOwnsProvider(pending pendingProviderBuild) bool {
+	current, err := b.providers.Get(pending.name)
+	return err == nil && current == pending.proxy
+}
+
+func (b *preparedProviderBuilds) connectionAuthSnapshot() map[string]map[string]OAuthHandler {
+	if b == nil {
+		return nil
+	}
+	b.authMu.RLock()
+	defer b.authMu.RUnlock()
+	return maps.Clone(b.connAuth)
+}
+
+func (b *preparedProviderBuilds) manualConnectionAuthSnapshot() map[string]map[string]ManualTokenExchanger {
+	if b == nil {
+		return nil
+	}
+	b.authMu.RLock()
+	defer b.authMu.RUnlock()
+	return maps.Clone(b.manualConnAuth)
 }
 
 func newProviderActivation(

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1936,7 +1936,15 @@ type ServerConfig struct {
 	Runtime       ServerRuntimeConfig      `yaml:"runtime,omitempty"`
 	Egress        EgressConfig             `yaml:"egress,omitempty"`
 	Admin         AdminConfig              `yaml:"admin,omitempty"`
+	AppRegistry   ServerAppRegistryConfig  `yaml:"appRegistry,omitempty"`
 	AutoActivate  *bool                    `yaml:"autoActivate,omitempty"`
+}
+
+// TODO(app-registry-step-9): Remove this temporary rollout configuration after step 9 is complete.
+type ServerAppRegistryConfig struct {
+	// RestartDelay is empty in production for no intentional outage. Early
+	// rollout environments may set a duration such as "1m" for observation.
+	RestartDelay string `yaml:"restartDelay,omitempty"`
 }
 
 type ServerAgentConfig struct{}

--- a/gestaltd/internal/coredata/app_instance_materializations.go
+++ b/gestaltd/internal/coredata/app_instance_materializations.go
@@ -47,6 +47,26 @@ func (s *AppInstanceMaterializationService) Get(ctx context.Context, instanceID,
 	return recordToAppInstanceMaterialization(rec), nil
 }
 
+func (s *AppInstanceMaterializationService) ListByAppVersion(ctx context.Context, app, version string) ([]*core.AppInstanceMaterialization, error) {
+	if s == nil {
+		return nil, fmt.Errorf("list app instance materializations: service is not configured")
+	}
+	app = strings.TrimSpace(app)
+	version = strings.TrimSpace(version)
+	if app == "" || version == "" {
+		return nil, fmt.Errorf("list app instance materializations: app and version are required")
+	}
+	recs, err := s.store.Index("by_app_version").GetAll(ctx, []any{app, version})
+	if err != nil {
+		return nil, fmt.Errorf("list app instance materializations: %w", err)
+	}
+	out := make([]*core.AppInstanceMaterialization, 0, len(recs))
+	for _, rec := range recs {
+		out = append(out, recordToAppInstanceMaterialization(rec))
+	}
+	return out, nil
+}
+
 func (s *AppInstanceMaterializationService) Acknowledge(ctx context.Context, materialization *core.AppInstanceMaterialization) (*core.AppInstanceMaterialization, error) {
 	if s == nil {
 		return nil, fmt.Errorf("acknowledge app instance materialization: service is not configured")

--- a/gestaltd/internal/coredata/app_instance_materializations.go
+++ b/gestaltd/internal/coredata/app_instance_materializations.go
@@ -36,6 +36,17 @@ func (s *AppInstanceMaterializationService) HasAcknowledged(ctx context.Context,
 	return true, nil
 }
 
+func (s *AppInstanceMaterializationService) Get(ctx context.Context, instanceID, app, version string) (*core.AppInstanceMaterialization, error) {
+	if s == nil {
+		return nil, fmt.Errorf("get app instance materialization: service is not configured")
+	}
+	rec, err := s.findByInstanceAppVersion(ctx, instanceID, app, version)
+	if err != nil {
+		return nil, fmt.Errorf("get app instance materialization: %w", err)
+	}
+	return recordToAppInstanceMaterialization(rec), nil
+}
+
 func (s *AppInstanceMaterializationService) Acknowledge(ctx context.Context, materialization *core.AppInstanceMaterialization) (*core.AppInstanceMaterialization, error) {
 	if s == nil {
 		return nil, fmt.Errorf("acknowledge app instance materialization: service is not configured")
@@ -82,6 +93,49 @@ func (s *AppInstanceMaterializationService) Acknowledge(ctx context.Context, mat
 	return recordToAppInstanceMaterialization(rec), nil
 }
 
+func (s *AppInstanceMaterializationService) MarkStopped(ctx context.Context, instanceID, app, version string, stoppedAt time.Time) (*core.AppInstanceMaterialization, error) {
+	return s.updateTimestamps(ctx, instanceID, app, version, func(rec idb.Record) idb.Record {
+		if stoppedAt.IsZero() {
+			stoppedAt = time.Now().UTC().Truncate(time.Millisecond)
+		} else {
+			stoppedAt = stoppedAt.UTC().Truncate(time.Millisecond)
+		}
+		rec["stopped_at"] = stoppedAt
+		return rec
+	})
+}
+
+func (s *AppInstanceMaterializationService) MarkRestarted(ctx context.Context, instanceID, app, version string, restartedAt time.Time) (*core.AppInstanceMaterialization, error) {
+	return s.updateTimestamps(ctx, instanceID, app, version, func(rec idb.Record) idb.Record {
+		if restartedAt.IsZero() {
+			restartedAt = time.Now().UTC().Truncate(time.Millisecond)
+		} else {
+			restartedAt = restartedAt.UTC().Truncate(time.Millisecond)
+		}
+		rec["restarted_at"] = restartedAt
+		return rec
+	})
+}
+
+func (s *AppInstanceMaterializationService) updateTimestamps(
+	ctx context.Context,
+	instanceID, app, version string,
+	mutate func(idb.Record) idb.Record,
+) (*core.AppInstanceMaterialization, error) {
+	if s == nil {
+		return nil, fmt.Errorf("update app instance materialization: service is not configured")
+	}
+	rec, err := s.findByInstanceAppVersion(ctx, instanceID, app, version)
+	if err != nil {
+		return nil, fmt.Errorf("update app instance materialization: %w", err)
+	}
+	rec = mutate(rec)
+	if err := s.store.Put(ctx, rec); err != nil {
+		return nil, fmt.Errorf("update app instance materialization: %w", err)
+	}
+	return recordToAppInstanceMaterialization(rec), nil
+}
+
 func (s *AppInstanceMaterializationService) findByInstanceAppVersion(ctx context.Context, instanceID, app, version string) (idb.Record, error) {
 	instanceID = strings.TrimSpace(instanceID)
 	app = strings.TrimSpace(app)
@@ -111,5 +165,7 @@ func recordToAppInstanceMaterialization(rec idb.Record) *core.AppInstanceMateria
 		App:            recString(rec, "app"),
 		Version:        recString(rec, "version"),
 		AcknowledgedAt: recTime(rec, "acknowledged_at"),
+		StoppedAt:      recTime(rec, "stopped_at"),
+		RestartedAt:    recTime(rec, "restarted_at"),
 	}
 }

--- a/gestaltd/internal/coredata/app_rollouts.go
+++ b/gestaltd/internal/coredata/app_rollouts.go
@@ -1,0 +1,252 @@
+package coredata
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	idb "github.com/valon-technologies/gestalt/sdk/go/indexeddb"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+)
+
+var (
+	ErrAppRolloutActive          = errors.New("app rollout is active")
+	ErrAppRolloutVersionMismatch = errors.New("app rollout version does not match")
+)
+
+type AppRolloutService struct {
+	db    indexeddb.IndexedDB
+	store idb.ObjectStore
+}
+
+func NewAppRolloutService(ds indexeddb.IndexedDB) *AppRolloutService {
+	return &AppRolloutService{db: ds, store: ds.ObjectStore(StoreAppRollouts)}
+}
+
+func (s *AppRolloutService) Get(ctx context.Context, app string) (*core.AppRollout, error) {
+	if s == nil {
+		return nil, fmt.Errorf("get app rollout: service is not configured")
+	}
+	app = strings.TrimSpace(app)
+	if app == "" {
+		return nil, fmt.Errorf("get app rollout: app is required")
+	}
+	rec, err := s.store.Get(ctx, app)
+	if err != nil {
+		if errors.Is(err, idb.ErrNotFound) {
+			return nil, core.ErrNotFound
+		}
+		return nil, fmt.Errorf("get app rollout: %w", err)
+	}
+	return recordToAppRollout(rec), nil
+}
+
+func (s *AppRolloutService) Create(ctx context.Context, rollout *core.AppRollout) (*core.AppRollout, error) {
+	if s == nil {
+		return nil, fmt.Errorf("create app rollout: service is not configured")
+	}
+	if err := validateAppRollout(rollout); err != nil {
+		return nil, fmt.Errorf("create app rollout: %w", err)
+	}
+	rollout = normalizeAppRollout(rollout)
+	tx, err := s.db.Transaction(ctx, []string{StoreAppRollouts}, idb.TransactionReadwrite, idb.TransactionOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("create app rollout: begin transaction: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Abort(context.WithoutCancel(ctx))
+		}
+	}()
+	store := tx.ObjectStore(StoreAppRollouts)
+	existing, err := store.GetAll(ctx, rollout.App, 1)
+	switch {
+	case err != nil:
+		return nil, fmt.Errorf("create app rollout: load current rollout: %w", err)
+	case len(existing) > 0:
+		if isActiveRolloutState(recordToAppRollout(existing[0]).State) {
+			return nil, ErrAppRolloutActive
+		}
+		if err := store.Put(ctx, appRolloutRecord(rollout)); err != nil {
+			return nil, fmt.Errorf("create app rollout: replace terminal rollout: %w", err)
+		}
+	default:
+		if err := store.Add(ctx, appRolloutRecord(rollout)); err != nil {
+			if errors.Is(err, idb.ErrAlreadyExists) {
+				return nil, ErrAppRolloutActive
+			}
+			return nil, fmt.Errorf("create app rollout: %w", err)
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("create app rollout: commit: %w", err)
+	}
+	committed = true
+	return rollout, nil
+}
+
+func (s *AppRolloutService) ListActive(ctx context.Context) ([]*core.AppRollout, error) {
+	if s == nil {
+		return nil, fmt.Errorf("list active app rollouts: service is not configured")
+	}
+	recs, err := s.store.GetAll(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list active app rollouts: %w", err)
+	}
+	out := make([]*core.AppRollout, 0, len(recs))
+	for _, rec := range recs {
+		rollout := recordToAppRollout(rec)
+		if isActiveRolloutState(rollout.State) {
+			out = append(out, rollout)
+		}
+	}
+	return out, nil
+}
+
+func (s *AppRolloutService) MarkRestarting(ctx context.Context, app, version string) (*core.AppRollout, error) {
+	return s.transition(ctx, app, version, core.AppRolloutStateRestarting, time.Time{})
+}
+
+func (s *AppRolloutService) MarkComplete(ctx context.Context, app, version string, completedAt time.Time) (*core.AppRollout, error) {
+	return s.transition(ctx, app, version, core.AppRolloutStateComplete, completedAt)
+}
+
+func (s *AppRolloutService) MarkFailed(ctx context.Context, app, version string, failedAt time.Time) (*core.AppRollout, error) {
+	return s.transition(ctx, app, version, core.AppRolloutStateFailed, failedAt)
+}
+
+func (s *AppRolloutService) transition(ctx context.Context, app, version string, state core.AppRolloutState, at time.Time) (*core.AppRollout, error) {
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("transition app rollout: service is not configured")
+	}
+	app = strings.TrimSpace(app)
+	version = strings.TrimSpace(version)
+	if app == "" || version == "" {
+		return nil, fmt.Errorf("transition app rollout: app and version are required")
+	}
+	tx, err := s.db.Transaction(ctx, []string{StoreAppRollouts}, idb.TransactionReadwrite, idb.TransactionOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("transition app rollout: begin transaction: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Abort(context.WithoutCancel(ctx))
+		}
+	}()
+	store := tx.ObjectStore(StoreAppRollouts)
+	rec, err := store.Get(ctx, app)
+	if err != nil {
+		return nil, fmt.Errorf("transition app rollout: load current rollout: %w", err)
+	}
+	rollout := recordToAppRollout(rec)
+	if strings.TrimSpace(rollout.Version) != version {
+		return nil, ErrAppRolloutVersionMismatch
+	}
+	if rollout.State == state {
+		if err := tx.Commit(ctx); err != nil {
+			return nil, fmt.Errorf("transition app rollout: commit: %w", err)
+		}
+		committed = true
+		return rollout, nil
+	}
+	if !isActiveRolloutState(rollout.State) {
+		if err := tx.Commit(ctx); err != nil {
+			return nil, fmt.Errorf("transition app rollout: commit: %w", err)
+		}
+		committed = true
+		return rollout, nil
+	}
+	rollout.State = state
+	switch state {
+	case core.AppRolloutStateComplete:
+		rollout.CompletedAt = normalizedRolloutTime(at)
+	case core.AppRolloutStateFailed:
+		rollout.FailedAt = normalizedRolloutTime(at)
+	case core.AppRolloutStateRestarting:
+	default:
+		return nil, fmt.Errorf("transition app rollout: invalid target state %q", state)
+	}
+	if err := store.Put(ctx, appRolloutRecord(rollout)); err != nil {
+		return nil, fmt.Errorf("transition app rollout: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("transition app rollout: commit: %w", err)
+	}
+	committed = true
+	return rollout, nil
+}
+
+func validateAppRollout(rollout *core.AppRollout) error {
+	if rollout == nil {
+		return fmt.Errorf("record is required")
+	}
+	if strings.TrimSpace(rollout.App) == "" || strings.TrimSpace(rollout.Version) == "" {
+		return fmt.Errorf("app and version are required")
+	}
+	if rollout.State != core.AppRolloutStateEnrolling {
+		return fmt.Errorf("initial state must be %q", core.AppRolloutStateEnrolling)
+	}
+	if rollout.CreatedAt.IsZero() || !rollout.EnrollmentEndsAt.After(rollout.CreatedAt) || !rollout.Deadline.After(rollout.EnrollmentEndsAt) {
+		return fmt.Errorf("created_at, enrollment_ends_at, and deadline must be ordered")
+	}
+	return nil
+}
+
+func normalizeAppRollout(rollout *core.AppRollout) *core.AppRollout {
+	copy := *rollout
+	copy.App = strings.TrimSpace(copy.App)
+	copy.Version = strings.TrimSpace(copy.Version)
+	copy.CreatedAt = normalizedRolloutTime(copy.CreatedAt)
+	copy.EnrollmentEndsAt = normalizedRolloutTime(copy.EnrollmentEndsAt)
+	copy.Deadline = normalizedRolloutTime(copy.Deadline)
+	return &copy
+}
+
+func normalizedRolloutTime(value time.Time) time.Time {
+	if value.IsZero() {
+		value = time.Now()
+	}
+	return value.UTC().Truncate(time.Millisecond)
+}
+
+func isActiveRolloutState(state core.AppRolloutState) bool {
+	return state == core.AppRolloutStateEnrolling || state == core.AppRolloutStateRestarting
+}
+
+func appRolloutRecord(rollout *core.AppRollout) idb.Record {
+	rec := idb.Record{
+		"id":                 rollout.App,
+		"app":                rollout.App,
+		"version":            rollout.Version,
+		"state":              string(rollout.State),
+		"created_at":         rollout.CreatedAt,
+		"enrollment_ends_at": rollout.EnrollmentEndsAt,
+		"deadline":           rollout.Deadline,
+	}
+	if !rollout.CompletedAt.IsZero() {
+		rec["completed_at"] = rollout.CompletedAt
+	}
+	if !rollout.FailedAt.IsZero() {
+		rec["failed_at"] = rollout.FailedAt
+	}
+	return rec
+}
+
+func recordToAppRollout(rec idb.Record) *core.AppRollout {
+	return &core.AppRollout{
+		App:              recString(rec, "app"),
+		Version:          recString(rec, "version"),
+		State:            core.AppRolloutState(recString(rec, "state")),
+		CreatedAt:        recTime(rec, "created_at"),
+		EnrollmentEndsAt: recTime(rec, "enrollment_ends_at"),
+		Deadline:         recTime(rec, "deadline"),
+		CompletedAt:      recTime(rec, "completed_at"),
+		FailedAt:         recTime(rec, "failed_at"),
+	}
+}

--- a/gestaltd/internal/coredata/app_rollouts_test.go
+++ b/gestaltd/internal/coredata/app_rollouts_test.go
@@ -1,0 +1,154 @@
+package coredata_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+)
+
+func TestAppRolloutService(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	start := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	newRollout := func(app, version string) *core.AppRollout {
+		return &core.AppRollout{
+			App:              app,
+			Version:          version,
+			State:            core.AppRolloutStateEnrolling,
+			CreatedAt:        start,
+			EnrollmentEndsAt: start.Add(2 * time.Minute),
+			Deadline:         start.Add(15 * time.Minute),
+		}
+	}
+
+	t.Run("one_active_rollout_per_app", func(t *testing.T) {
+		t.Parallel()
+		svc := testutil.NewStubServices(t)
+		if _, err := svc.AppRollouts.Create(ctx, newRollout("g-issues", "v1")); err != nil {
+			t.Fatalf("Create v1: %v", err)
+		}
+		if _, err := svc.AppRollouts.Create(ctx, newRollout("g-issues", "v2")); !errors.Is(err, coredata.ErrAppRolloutActive) {
+			t.Fatalf("Create v2 error = %v, want %v", err, coredata.ErrAppRolloutActive)
+		}
+		if _, err := svc.AppRollouts.Create(ctx, newRollout("g-slack", "v1")); err != nil {
+			t.Fatalf("Create different app: %v", err)
+		}
+	})
+
+	t.Run("concurrent_creates_admit_one_version", func(t *testing.T) {
+		t.Parallel()
+		svc := testutil.NewStubServices(t)
+		startCreate := make(chan struct{})
+		errs := make(chan error, 2)
+		var wg sync.WaitGroup
+		for _, version := range []string{"v1", "v2"} {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-startCreate
+				_, err := svc.AppRollouts.Create(ctx, newRollout("g-issues", version))
+				errs <- err
+			}()
+		}
+		close(startCreate)
+		wg.Wait()
+		close(errs)
+		succeeded := 0
+		blocked := 0
+		for err := range errs {
+			switch {
+			case err == nil:
+				succeeded++
+			case errors.Is(err, coredata.ErrAppRolloutActive):
+				blocked++
+			default:
+				t.Fatalf("Create error = %v", err)
+			}
+		}
+		if succeeded != 1 || blocked != 1 {
+			t.Fatalf("succeeded = %d, blocked = %d; want 1 each", succeeded, blocked)
+		}
+	})
+
+	t.Run("terminal_rollout_can_be_replaced", func(t *testing.T) {
+		t.Parallel()
+		svc := testutil.NewStubServices(t)
+		if _, err := svc.AppRollouts.Create(ctx, newRollout("g-issues", "v1")); err != nil {
+			t.Fatalf("Create v1: %v", err)
+		}
+		if _, err := svc.AppRollouts.MarkRestarting(ctx, "g-issues", "v1"); err != nil {
+			t.Fatalf("MarkRestarting: %v", err)
+		}
+		if _, err := svc.AppRollouts.MarkComplete(ctx, "g-issues", "v1", start.Add(time.Minute)); err != nil {
+			t.Fatalf("MarkComplete: %v", err)
+		}
+		if _, err := svc.AppRollouts.Create(ctx, newRollout("g-issues", "v2")); err != nil {
+			t.Fatalf("Create v2: %v", err)
+		}
+		got, err := svc.AppRollouts.Get(ctx, "g-issues")
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if got.Version != "v2" || got.State != core.AppRolloutStateEnrolling {
+			t.Fatalf("rollout = %#v, want v2 enrolling", got)
+		}
+	})
+
+	t.Run("list_active_excludes_terminal", func(t *testing.T) {
+		t.Parallel()
+		svc := testutil.NewStubServices(t)
+		if _, err := svc.AppRollouts.Create(ctx, newRollout("g-issues", "v1")); err != nil {
+			t.Fatalf("Create g-issues: %v", err)
+		}
+		if _, err := svc.AppRollouts.Create(ctx, newRollout("g-slack", "v1")); err != nil {
+			t.Fatalf("Create g-slack: %v", err)
+		}
+		if _, err := svc.AppRollouts.MarkFailed(ctx, "g-slack", "v1", start.Add(15*time.Minute)); err != nil {
+			t.Fatalf("MarkFailed: %v", err)
+		}
+		active, err := svc.AppRollouts.ListActive(ctx)
+		if err != nil {
+			t.Fatalf("ListActive: %v", err)
+		}
+		if len(active) != 1 || active[0].App != "g-issues" {
+			t.Fatalf("active = %#v, want g-issues only", active)
+		}
+	})
+}
+
+func TestAppInstanceMaterializationServiceListByAppVersion(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc := testutil.NewStubServices(t)
+	for _, instanceID := range []string{"replica-a", "replica-b"} {
+		if _, err := svc.AppInstanceMaterializations.Acknowledge(ctx, &core.AppInstanceMaterialization{
+			InstanceID: instanceID,
+			App:        "g-issues",
+			Version:    "v1",
+		}); err != nil {
+			t.Fatalf("Acknowledge(%s): %v", instanceID, err)
+		}
+	}
+	if _, err := svc.AppInstanceMaterializations.Acknowledge(ctx, &core.AppInstanceMaterialization{
+		InstanceID: "replica-c",
+		App:        "g-issues",
+		Version:    "v2",
+	}); err != nil {
+		t.Fatalf("Acknowledge other version: %v", err)
+	}
+	got, err := svc.AppInstanceMaterializations.ListByAppVersion(ctx, "g-issues", "v1")
+	if err != nil {
+		t.Fatalf("ListByAppVersion: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("materializations = %#v, want 2", got)
+	}
+}

--- a/gestaltd/internal/coredata/app_version_install_locks.go
+++ b/gestaltd/internal/coredata/app_version_install_locks.go
@@ -30,7 +30,7 @@ func NewAppVersionInstallLockService(ds indexeddb.IndexedDB) *AppVersionInstallL
 	return &AppVersionInstallLockService{store: ds.ObjectStore(StoreAppVersionInstallLocks)}
 }
 
-// Acquire claims the fleet-wide install lock for one app version. The lock expires
+// Acquire claims the fleet-wide install admission lock for one app. The lock expires
 // after ttl so crashed instances do not block installs forever.
 func (s *AppVersionInstallLockService) Acquire(ctx context.Context, app, version, holder string, ttl time.Duration) error {
 	if s == nil {
@@ -51,7 +51,14 @@ func (s *AppVersionInstallLockService) Acquire(ctx context.Context, app, version
 
 	now := time.Now().UTC().Truncate(time.Millisecond)
 	expiresAt := now.Add(ttl)
-	key := appVersionInstallLockKey(app, version)
+	key := appVersionInstallLockKey(app)
+	owned, err := s.clearStaleAndCheckAppLocks(ctx, key, app, holder, now)
+	if err != nil {
+		return err
+	}
+	if owned {
+		return nil
+	}
 
 	if err := s.tryAddLock(ctx, key, app, version, holder, now, expiresAt); err == nil {
 		return nil
@@ -90,6 +97,32 @@ func (s *AppVersionInstallLockService) Acquire(ctx context.Context, app, version
 	}
 }
 
+// clearStaleAndCheckAppLocks preserves admission safety while databases may
+// still contain version-scoped rows written before locks became app-scoped.
+func (s *AppVersionInstallLockService) clearStaleAndCheckAppLocks(ctx context.Context, key, app, holder string, now time.Time) (bool, error) {
+	recs, err := s.store.GetAll(ctx, nil)
+	if err != nil {
+		return false, fmt.Errorf("acquire app version install lock: list existing: %w", err)
+	}
+	for _, rec := range recs {
+		current := recordToAppVersionInstallLock(rec)
+		if strings.TrimSpace(current.App) != app {
+			continue
+		}
+		recordID := recString(rec, "id")
+		if current.ExpiresAt.After(now) {
+			if recordID == key && current.Holder == holder {
+				return true, nil
+			}
+			return false, ErrAppVersionInstallLockHeld
+		}
+		if err := s.store.Delete(ctx, recordID); err != nil && !errors.Is(err, idb.ErrNotFound) {
+			return false, fmt.Errorf("acquire app version install lock: delete stale: %w", err)
+		}
+	}
+	return false, nil
+}
+
 // Release drops the install lock when the holder still owns it.
 func (s *AppVersionInstallLockService) Release(ctx context.Context, app, version, holder string) error {
 	if s == nil {
@@ -102,7 +135,7 @@ func (s *AppVersionInstallLockService) Release(ctx context.Context, app, version
 		return nil
 	}
 
-	key := appVersionInstallLockKey(app, version)
+	key := appVersionInstallLockKey(app)
 	existing, err := s.store.Get(ctx, key)
 	if errors.Is(err, idb.ErrNotFound) {
 		return nil
@@ -154,8 +187,8 @@ func (s *AppVersionInstallLockService) putLock(ctx context.Context, key, app, ve
 	return nil
 }
 
-func appVersionInstallLockKey(app, version string) string {
-	return strings.TrimSpace(app) + "\x00" + strings.TrimSpace(version)
+func appVersionInstallLockKey(app string) string {
+	return strings.TrimSpace(app)
 }
 
 func recordToAppVersionInstallLock(rec idb.Record) AppVersionInstallLock {

--- a/gestaltd/internal/coredata/app_version_install_locks_test.go
+++ b/gestaltd/internal/coredata/app_version_install_locks_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	idb "github.com/valon-technologies/gestalt/sdk/go/indexeddb"
+
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 )
@@ -58,15 +60,47 @@ func TestAppVersionInstallLockService(t *testing.T) {
 		}
 	})
 
-	t.Run("different_versions_install_in_parallel", func(t *testing.T) {
+	t.Run("different_versions_of_one_app_are_serialized", func(t *testing.T) {
 		t.Parallel()
 
 		svc := testutil.NewStubServices(t)
 		if err := svc.AppVersionInstallLocks.Acquire(ctx, "g-issues", "0.0.1", "holder-a", time.Minute); err != nil {
 			t.Fatalf("Acquire v1: %v", err)
 		}
-		if err := svc.AppVersionInstallLocks.Acquire(ctx, "g-issues", "0.0.2", "holder-b", time.Minute); err != nil {
-			t.Fatalf("Acquire v2: %v", err)
+		if err := svc.AppVersionInstallLocks.Acquire(ctx, "g-issues", "0.0.2", "holder-b", time.Minute); err != coredata.ErrAppVersionInstallLockHeld {
+			t.Fatalf("Acquire v2 error = %v, want %v", err, coredata.ErrAppVersionInstallLockHeld)
+		}
+	})
+
+	t.Run("different_apps_install_in_parallel", func(t *testing.T) {
+		t.Parallel()
+
+		svc := testutil.NewStubServices(t)
+		if err := svc.AppVersionInstallLocks.Acquire(ctx, "g-issues", "0.0.1", "holder-a", time.Minute); err != nil {
+			t.Fatalf("Acquire g-issues: %v", err)
+		}
+		if err := svc.AppVersionInstallLocks.Acquire(ctx, "g-slack", "0.0.1", "holder-b", time.Minute); err != nil {
+			t.Fatalf("Acquire g-slack: %v", err)
+		}
+	})
+
+	t.Run("active_legacy_version_scoped_lock_blocks_app", func(t *testing.T) {
+		t.Parallel()
+
+		svc := testutil.NewStubServices(t)
+		now := time.Now().UTC()
+		if err := svc.DB.ObjectStore(coredata.StoreAppVersionInstallLocks).Add(ctx, idb.Record{
+			"id":          "g-issues\x000.0.1",
+			"app":         "g-issues",
+			"version":     "0.0.1",
+			"holder":      "legacy-holder",
+			"acquired_at": now,
+			"expires_at":  now.Add(time.Minute),
+		}); err != nil {
+			t.Fatalf("Add legacy lock: %v", err)
+		}
+		if err := svc.AppVersionInstallLocks.Acquire(ctx, "g-issues", "0.0.2", "holder-b", time.Minute); err != coredata.ErrAppVersionInstallLockHeld {
+			t.Fatalf("Acquire error = %v, want %v", err, coredata.ErrAppVersionInstallLockHeld)
 		}
 	})
 }

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -100,6 +100,8 @@ var AppInstanceMaterializationsSchema = idb.ObjectStoreOptions{
 		{Name: "app", Type: idb.TypeString, NotNull: true},
 		{Name: "version", Type: idb.TypeString, NotNull: true},
 		{Name: "acknowledged_at", Type: idb.TypeTime, NotNull: true},
+		{Name: "stopped_at", Type: idb.TypeTime},
+		{Name: "restarted_at", Type: idb.TypeTime},
 	},
 }
 

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -11,6 +11,7 @@ const (
 	StoreAppSHAs                       = "app_shas"
 	StoreAppVersionChangeRequests      = "app_version_change_requests"
 	StoreAppVersionInstallLocks        = "app_version_install_locks"
+	StoreAppRollouts                   = "app_rollouts"
 	StoreAppInstanceMaterializations   = "app_instance_materializations"
 )
 
@@ -85,6 +86,23 @@ var AppVersionInstallLocksSchema = idb.ObjectStoreOptions{
 		{Name: "holder", Type: idb.TypeString, NotNull: true},
 		{Name: "acquired_at", Type: idb.TypeTime, NotNull: true},
 		{Name: "expires_at", Type: idb.TypeTime, NotNull: true},
+	},
+}
+
+var AppRolloutsSchema = idb.ObjectStoreOptions{
+	Indexes: []idb.IndexSchema{
+		{Name: "by_state", KeyPath: []string{"state"}},
+	},
+	Columns: []idb.ColumnDef{
+		{Name: "id", Type: idb.TypeString, PrimaryKey: true},
+		{Name: "app", Type: idb.TypeString, NotNull: true, Unique: true},
+		{Name: "version", Type: idb.TypeString, NotNull: true},
+		{Name: "state", Type: idb.TypeString, NotNull: true},
+		{Name: "created_at", Type: idb.TypeTime, NotNull: true},
+		{Name: "enrollment_ends_at", Type: idb.TypeTime, NotNull: true},
+		{Name: "deadline", Type: idb.TypeTime, NotNull: true},
+		{Name: "completed_at", Type: idb.TypeTime},
+		{Name: "failed_at", Type: idb.TypeTime},
 	},
 }
 

--- a/gestaltd/internal/coredata/services.go
+++ b/gestaltd/internal/coredata/services.go
@@ -14,6 +14,7 @@ type Services struct {
 	ManagedSubjects             *ManagedSubjectService
 	AppVersionChangeRequests    *AppVersionChangeRequestService
 	AppVersionInstallLocks      *AppVersionInstallLockService
+	AppRollouts                 *AppRolloutService
 	AppInstanceMaterializations *AppInstanceMaterializationService
 	DB                          indexeddb.IndexedDB
 }
@@ -53,6 +54,9 @@ func NewWithOptions(ctx context.Context, ds indexeddb.IndexedDB, opts NewOptions
 		if _, err := ds.CreateObjectStore(ctx, StoreAppVersionInstallLocks, AppVersionInstallLocksSchema); err != nil {
 			return nil, fmt.Errorf("create app_version_install_locks store: %w", err)
 		}
+		if _, err := ds.CreateObjectStore(ctx, StoreAppRollouts, AppRolloutsSchema); err != nil {
+			return nil, fmt.Errorf("create app_rollouts store: %w", err)
+		}
 		if _, err := ds.CreateObjectStore(ctx, StoreAppInstanceMaterializations, AppInstanceMaterializationsSchema); err != nil {
 			return nil, fmt.Errorf("create app_instance_materializations store: %w", err)
 		}
@@ -61,6 +65,7 @@ func NewWithOptions(ctx context.Context, ds indexeddb.IndexedDB, opts NewOptions
 	managedSubjects := NewManagedSubjectService(ds)
 	appVersionChangeRequests := NewAppVersionChangeRequestService(ds)
 	appVersionInstallLocks := NewAppVersionInstallLockService(ds)
+	appRollouts := NewAppRolloutService(ds)
 	appInstanceMaterializations := NewAppInstanceMaterializationService(ds)
 	return &Services{
 		ExternalCredentials:         nil,
@@ -68,6 +73,7 @@ func NewWithOptions(ctx context.Context, ds indexeddb.IndexedDB, opts NewOptions
 		ManagedSubjects:             managedSubjects,
 		AppVersionChangeRequests:    appVersionChangeRequests,
 		AppVersionInstallLocks:      appVersionInstallLocks,
+		AppRollouts:                 appRollouts,
 		AppInstanceMaterializations: appInstanceMaterializations,
 		DB:                          ds,
 	}, nil

--- a/gestaltd/internal/coredata/services_test.go
+++ b/gestaltd/internal/coredata/services_test.go
@@ -247,6 +247,7 @@ func TestNew(t *testing.T) {
 			coredata.StoreUsers,
 			coredata.StoreAppVersionChangeRequests,
 			coredata.StoreAppVersionInstallLocks,
+			coredata.StoreAppRollouts,
 		} {
 			if _, ok := contexts[store]; !ok {
 				t.Fatalf("NewWithContext did not create store %q", store)

--- a/gestaltd/internal/server/handlers_admin_app_install.go
+++ b/gestaltd/internal/server/handlers_admin_app_install.go
@@ -155,6 +155,8 @@ func (s *Server) installAdminAppRegistryApp(w http.ResponseWriter, r *http.Reque
 			status = http.StatusNotFound
 		case errors.Is(err, appregistry.ErrInstallVersionLocked):
 			status = http.StatusConflict
+		case errors.Is(err, appregistry.ErrAppRolloutActive):
+			status = http.StatusConflict
 		case errors.Is(err, appregistry.ErrAppVersionAlreadyInstalled):
 			status = http.StatusBadRequest
 		case errors.Is(err, context.DeadlineExceeded):
@@ -194,7 +196,7 @@ func adminAppInstallationFromCore(installation *core.AppInstallation) adminAppIn
 }
 
 func newAppRegistryInstaller(cfg Config) *appregistry.Installer {
-	if cfg.Services == nil || cfg.Services.AppVersionChangeRequests == nil || cfg.Services.AppVersionInstallLocks == nil {
+	if cfg.Services == nil || cfg.Services.AppVersionChangeRequests == nil || cfg.Services.AppVersionInstallLocks == nil || cfg.Services.AppRollouts == nil {
 		return nil
 	}
 	reader := cfg.AppRegistryReader
@@ -207,5 +209,6 @@ func newAppRegistryInstaller(cfg Config) *appregistry.Installer {
 		Reader:         reader,
 		ChangeRequests: cfg.Services.AppVersionChangeRequests,
 		Locks:          cfg.Services.AppVersionInstallLocks,
+		Rollouts:       cfg.Services.AppRollouts,
 	}
 }

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -429,12 +429,14 @@ func startAppRegistryCatalogPoller(ctx context.Context, result *bootstrap.Result
 	}
 	changeRequests := result.Services.AppVersionChangeRequests
 	materializations := result.Services.AppInstanceMaterializations
-	if changeRequests == nil || materializations == nil {
+	rollouts := result.Services.AppRollouts
+	if changeRequests == nil || materializations == nil || rollouts == nil {
 		return nil
 	}
 	poller := appregistry.NewCatalogPoller(appregistry.CatalogPollerConfig{
 		ChangeRequests:      changeRequests,
 		Materializations:    materializations,
+		Rollouts:            rollouts,
 		AppRestarter:        result.AppRestarter,
 		InstanceID:          appregistry.ResolveInstanceID(),
 		RestartDelay:        restartDelay,

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -51,6 +51,10 @@ func run(ctx context.Context, cfg *config.Config, result *bootstrap.Result, onRe
 	if err != nil {
 		return err
 	}
+	restartDelay, disableRestartDelay, err := appRegistryRestartDelay(cfg)
+	if err != nil {
+		return err
+	}
 
 	if cfg.Server.BaseURL != "" {
 		slog.Debug("gestaltd base URL configured",
@@ -130,7 +134,10 @@ func run(ctx context.Context, cfg *config.Config, result *bootstrap.Result, onRe
 	if err := result.Start(ctx); err != nil {
 		return err
 	}
-	startAppRegistryCatalogPoller(ctx, result)
+	catalogPoller := startAppRegistryCatalogPoller(ctx, result, restartDelay, disableRestartDelay)
+	if catalogPoller != nil {
+		defer catalogPoller.Stop()
+	}
 
 	publicConfig := baseConfig
 	if managementAddr == "" {
@@ -416,18 +423,39 @@ func (h *switchableHandler) Set(handler http.Handler) {
 	h.mu.Unlock()
 }
 
-func startAppRegistryCatalogPoller(ctx context.Context, result *bootstrap.Result) {
+func startAppRegistryCatalogPoller(ctx context.Context, result *bootstrap.Result, restartDelay time.Duration, disableRestartDelay bool) *appregistry.CatalogPoller {
 	if result == nil || result.Services == nil {
-		return
+		return nil
 	}
 	changeRequests := result.Services.AppVersionChangeRequests
 	materializations := result.Services.AppInstanceMaterializations
 	if changeRequests == nil || materializations == nil {
-		return
+		return nil
 	}
-	appregistry.NewCatalogPoller(appregistry.CatalogPollerConfig{
-		ChangeRequests:   changeRequests,
-		Materializations: materializations,
-		InstanceID:       appregistry.ResolveInstanceID(),
-	}).Start(ctx)
+	poller := appregistry.NewCatalogPoller(appregistry.CatalogPollerConfig{
+		ChangeRequests:      changeRequests,
+		Materializations:    materializations,
+		AppRestarter:        result.AppRestarter,
+		InstanceID:          appregistry.ResolveInstanceID(),
+		RestartDelay:        restartDelay,
+		DisableRestartDelay: disableRestartDelay,
+		RestartReady:        result.StartupProvidersReady,
+	})
+	poller.Start(ctx)
+	return poller
+}
+
+func appRegistryRestartDelay(cfg *config.Config) (time.Duration, bool, error) {
+	if cfg == nil {
+		return 0, true, nil
+	}
+	raw := strings.TrimSpace(cfg.Server.AppRegistry.RestartDelay)
+	if raw == "" {
+		return 0, true, nil
+	}
+	delay, err := config.ParseDuration(raw)
+	if err != nil {
+		return 0, false, fmt.Errorf("server.appRegistry.restartDelay: %w", err)
+	}
+	return delay, false, nil
 }

--- a/gestaltd/internal/server/runtime_test.go
+++ b/gestaltd/internal/server/runtime_test.go
@@ -23,6 +23,36 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
+func TestAppRegistryRestartDelay(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name        string
+		raw         string
+		want        time.Duration
+		wantDisable bool
+		wantErr     bool
+	}{
+		{name: "production default", wantDisable: true},
+		{name: "early rollout", raw: "1m", want: time.Minute},
+		{name: "explicit zero is invalid", raw: "0s", wantErr: true},
+		{name: "invalid", raw: "later", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := &config.Config{}
+			cfg.Server.AppRegistry.RestartDelay = tc.raw
+			got, disabled, err := appRegistryRestartDelay(cfg)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("appRegistryRestartDelay error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if got != tc.want || disabled != tc.wantDisable {
+				t.Fatalf("appRegistryRestartDelay = (%v, %v), want (%v, %v)", got, disabled, tc.want, tc.wantDisable)
+			}
+		})
+	}
+}
+
 func TestHTTPCatalogConnectionMapUsesAPIConnection(t *testing.T) {
 	t.Parallel()
 

--- a/plans/app_registry/indexeddb.md
+++ b/plans/app_registry/indexeddb.md
@@ -193,9 +193,9 @@ Used by `POST …/install` before change request write; released on success or f
 
 ---
 
-## Store: `app_instance_materializations` (per-replica ack)
+## Store: `app_instance_materializations` (per-replica convergence)
 
-Records that one gestaltd replica observed a fleet-known `(app, version)` from `app_version_change_requests`.
+Records one replica's acknowledgement and restart progress for a fleet-known `(app, version)`.
 
 Primary key: `id` (UUID). Uniqueness for `(instance_id, app, version)` is enforced by the `by_instance_app_version` index.
 
@@ -205,7 +205,9 @@ Primary key: `id` (UUID). Uniqueness for `(instance_id, app, version)` is enforc
   "instance_id": "cloud-run-revision-pod",
   "app": "g-issues",
   "version": "0.0.0-snapshot.gabc123",
-  "acknowledged_at": "2026-07-13T21:00:00Z"
+  "acknowledged_at": "2026-07-13T21:00:00Z",
+  "stopped_at": "2026-07-13T21:00:05Z",
+  "restarted_at": "2026-07-13T21:01:05Z"
 }
 ```
 
@@ -218,6 +220,9 @@ Primary key: `id` (UUID). Uniqueness for `(instance_id, app, version)` is enforc
 | Method | Description |
 |--------|-------------|
 | `HasAcknowledged(ctx, instanceID, app, version)` | Whether this replica already acked the pair. |
+| `Get(ctx, instanceID, app, version)` | Load the per-replica materialization row. |
 | `Acknowledge(ctx, materialization)` | Insert ack row; idempotent if already present. |
+| `MarkStopped(ctx, instanceID, app, version, stoppedAt)` | Record when the app provider was stopped for this fleet version. |
+| `MarkRestarted(ctx, instanceID, app, version, restartedAt)` | Record when the app provider restart cycle completed for this fleet version. |
 
 Written by the background catalog poller (`gestaltd/internal/appregistry/poller.go`).

--- a/plans/app_registry/indexeddb.md
+++ b/plans/app_registry/indexeddb.md
@@ -20,11 +20,11 @@ Implementation:
 
 ---
 
-## Source of truth vs projections
+## Accepted changes and projections
 
 | Layer | Store / API | Role |
 |-------|-------------|------|
-| **Source of truth** | `app_version_change_requests` | Append-only fleet change requests per app (`from_version` → `to_version`) |
+| **Stored records** | `app_version_change_requests` | Append-only accepted version changes per app (`from_version` → `to_version`) |
 | **Materialized views** | `ListKnownVersionsByApp`, `ListAllKnownVersions` | Computed in Go from change requests |
 
 **Known versions** — one projected entry per `(app, to_version)` pair from the latest change request for that pair. Failed validation rejects the install HTTP request; no row is written.
@@ -57,7 +57,7 @@ When `SkipSchemaBootstrap` is false (default for a **local** main-db provider), 
 App registry stores:
 
 ```text
-app_version_change_requests      ← source of truth (append-only)
+app_version_change_requests      ← accepted version changes (append-only)
 app_version_install_locks        ← fleet install lock per (app, version)
 app_instance_materializations    ← per-replica ack of fleet-known versions
 ```
@@ -81,7 +81,7 @@ Services.DB                         ← underlying main-db handle
 
 ---
 
-## Store: `app_version_change_requests` (source of truth)
+## Store: `app_version_change_requests` (accepted version changes)
 
 Append-only fleet requests to move one app from `from_version` to `to_version`. `from_version` is required on every row. The installer resolves it from the latest fleet-known `to_version`, or falls back to the app's pinned version in `config.yaml` / `gestalt.lock.json` when the app has not been installed via the registry yet.
 
@@ -160,15 +160,15 @@ Projection helpers live in `app_version_change_requests_projection.go`.
 
 ---
 
-## Store: `app_version_install_locks` (fleet install lock)
+## Store: `app_version_install_locks` (install admission lock)
 
-Short-lived lock rows that ensure only one `gestaltd` instance installs a given `(app, version)` at a time.
+Short-lived lock rows that serialize install admission for one app across the fleet. The version remains diagnostic metadata, but the lock key is app-scoped so two versions of the same app cannot be admitted concurrently.
 
-Primary key: `id` = `app` + `\x00` + `version`.
+Primary key: `id` = `app`.
 
 ```json
 {
-  "id": "g-issues\u00000.0.0-snapshot.gabc123",
+  "id": "g-issues",
   "app": "g-issues",
   "version": "0.0.0-snapshot.gabc123",
   "holder": "550e8400-e29b-41d4-a716-446655440000",
@@ -186,10 +186,53 @@ Primary key: `id` = `app` + `\x00` + `version`.
 
 | Method | Description |
 |--------|-------------|
-| `Acquire(ctx, app, version, holder, ttl)` | Claim lock; returns `ErrAppVersionInstallLockHeld` if another holder owns a non-expired lock |
+| `Acquire(ctx, app, version, holder, ttl)` | Claim the app-scoped lock; returns `ErrAppVersionInstallLockHeld` if another holder owns a non-expired lock |
 | `Release(ctx, app, version, holder)` | Drop lock when this holder still owns it |
 
-Used by `POST …/install` before change request write; released on success or failure.
+Used by `POST …/install` while it checks rollout admission and appends the change request; released on success or failure.
+
+---
+
+## Store: `app_rollouts` (current rollout per app)
+
+Tracks the current fleet rollout for each app. `app_version_change_requests` records accepted version changes; `app_rollouts` records their fleet-wide execution and outcome. The app-scoped primary key allows only one active rollout per app.
+
+Primary key: `id` = `app`.
+
+```json
+{
+  "id": "g-issues",
+  "app": "g-issues",
+  "version": "0.0.0-snapshot.gabc123",
+  "state": "enrolling",
+  "created_at": "2026-07-13T21:00:00Z",
+  "enrollment_ends_at": "2026-07-13T21:02:00Z",
+  "deadline": "2026-07-13T21:15:00Z"
+}
+```
+
+States:
+
+- `enrolling` — replicas may join the rollout by acknowledging it.
+- `restarting` — the acknowledged cohort is frozen and is converging.
+- `complete` — every enrolled replica recorded `restarted_at`.
+- `failed` — the cohort did not converge before the deadline.
+
+A terminal record may be replaced when the next version is admitted. A non-terminal record causes `POST …/install` for the same app to return **409 Conflict**.
+Terminal transitions record `completed_at` or `failed_at`.
+
+### Service API
+
+`AppRolloutService` (`gestaltd/internal/coredata/app_rollouts.go`):
+
+| Method | Description |
+|--------|-------------|
+| `Get(ctx, app)` | Load the current rollout for one app. |
+| `Create(ctx, rollout)` | Create a rollout when the current record is absent or terminal. |
+| `ListActive(ctx)` | List rollouts in `enrolling` or `restarting`. |
+| `MarkRestarting(ctx, app, version)` | Freeze the acknowledged cohort after enrollment. |
+| `MarkComplete(ctx, app, version, completedAt)` | Record successful cohort convergence. |
+| `MarkFailed(ctx, app, version, failedAt)` | Record that the rollout missed its deadline. |
 
 ---
 
@@ -222,6 +265,7 @@ Primary key: `id` (UUID). Uniqueness for `(instance_id, app, version)` is enforc
 | `HasAcknowledged(ctx, instanceID, app, version)` | Whether this replica already acked the pair. |
 | `Get(ctx, instanceID, app, version)` | Load the per-replica materialization row. |
 | `Acknowledge(ctx, materialization)` | Insert ack row; idempotent if already present. |
+| `ListByAppVersion(ctx, app, version)` | List the replicas that acknowledged one rollout. |
 | `MarkStopped(ctx, instanceID, app, version, stoppedAt)` | Record when the app provider was stopped for this fleet version. |
 | `MarkRestarted(ctx, instanceID, app, version, restartedAt)` | Record when the app provider restart cycle completed for this fleet version. |
 

--- a/plans/app_registry/indexeddb.md
+++ b/plans/app_registry/indexeddb.md
@@ -58,7 +58,8 @@ App registry stores:
 
 ```text
 app_version_change_requests      ← accepted version changes (append-only)
-app_version_install_locks        ← fleet install lock per (app, version)
+app_version_install_locks        ← install admission lock per app
+app_rollouts                     ← current rollout per app
 app_instance_materializations    ← per-replica ack of fleet-known versions
 ```
 
@@ -76,6 +77,7 @@ Access install services after bootstrap via `Result.Services` / `prepared.Servic
 
 ```text
 Services.AppVersionChangeRequests   ← install prototype
+Services.AppRollouts                ← rollout state
 Services.DB                         ← underlying main-db handle
 ```
 
@@ -218,8 +220,7 @@ States:
 - `complete` — every enrolled replica recorded `restarted_at`.
 - `failed` — the cohort did not converge before the deadline.
 
-A terminal record may be replaced when the next version is admitted. A non-terminal record causes `POST …/install` for the same app to return **409 Conflict**.
-Terminal transitions record `completed_at` or `failed_at`.
+A terminal record may be replaced when the next version is admitted. A non-terminal record causes `POST …/install` for the same app to return **409 Conflict**. Terminal transitions record `completed_at` or `failed_at`.
 
 ### Service API
 

--- a/plans/app_registry/lifecycle.md
+++ b/plans/app_registry/lifecycle.md
@@ -22,10 +22,11 @@ Implementation:
 - Catalog poller — `gestaltd/internal/appregistry/poller.go`
 - App provider restarter — `gestaltd/internal/bootstrap/app_provider_restart.go`
 - Change request projections — `gestaltd/internal/coredata/app_version_change_requests_projection.go`
+- Rollout state — `gestaltd/internal/coredata/app_rollouts.go`
 
 ## Startup
 
-`coredata.NewWithOptions` — idempotently create host stores, including `app_version_change_requests` and `app_version_install_locks`. Bootstrap does not write change requests; the store starts empty until an install.
+`coredata.NewWithOptions` — idempotently create host stores, including `app_version_change_requests`, `app_version_install_locks`, and `app_rollouts`. Bootstrap does not write change requests or rollouts; the stores start empty until an install.
 
 When `gestaltd serve` starts:
 

--- a/plans/app_registry/lifecycle.md
+++ b/plans/app_registry/lifecycle.md
@@ -42,6 +42,20 @@ Every replica starts one background catalog controller during `gestaltd serve` s
 
 The controller is **pull-based** and **local**: each replica reads `app_version_change_requests` (`ListAllKnownVersions`) and reconciles itself against fleet install state. No replica fans out install RPCs to peers.
 
+### Rollout admission and completion
+
+Only one rollout per app may be active across the fleet. `POST …/install` holds the app-scoped install lock while it rejects an existing `enrolling` or `restarting` rollout, validates the candidate, creates the new rollout, and appends its change request. Different apps may roll out concurrently.
+
+Replica membership is discovered rather than configured:
+
+1. The rollout remains `enrolling` for a bounded window of at least two poll intervals.
+2. Replicas join by writing `acknowledged_at` before `enrollment_ends_at`.
+3. After enrollment, the cohort is frozen and the rollout becomes `restarting`.
+4. The rollout completes when every cohort member records `restarted_at`.
+5. The rollout fails if an acknowledged replica does not restart before the deadline.
+
+Replicas that do not acknowledge before enrollment closes are not cohort members and do not block completion. A late replica still converges locally but does not reopen a terminal rollout.
+
 Each pass:
 
 1. Acknowledge each new `(app, version)` in `app_instance_materializations`.

--- a/plans/app_registry/lifecycle.md
+++ b/plans/app_registry/lifecycle.md
@@ -20,6 +20,7 @@ Implementation:
 - Registry fetcher — `gestaltd/internal/appregistry/reader.go`
 - Registry installer — `gestaltd/internal/appregistry/installer.go`
 - Catalog poller — `gestaltd/internal/appregistry/poller.go`
+- App provider restarter — `gestaltd/internal/bootstrap/app_provider_restart.go`
 - Change request projections — `gestaltd/internal/coredata/app_version_change_requests_projection.go`
 
 ## Startup
@@ -37,15 +38,27 @@ Install is HTTP-triggered for fleet declaration. On startup, gestaltd does not b
 
 ## Polling
 
-Every replica runs one background catalog controller after `gestaltd serve` is up: one reconcile pass at startup, then every **1 minute** on a single loop goroutine.
+Every replica starts one background catalog controller during `gestaltd serve` startup: one reconcile pass immediately, then every **1 minute** on a single loop goroutine.
 
 The controller is **pull-based** and **local**: each replica reads `app_version_change_requests` (`ListAllKnownVersions`) and reconciles itself against fleet install state. No replica fans out install RPCs to peers.
 
-Each pass, for every known `(app, version)` this replica has not yet acknowledged, write a per-instance row in `app_instance_materializations`.
+Each pass:
 
-Later steps add download, restart, and binary mount. See [plan.md](./plan.md) steps 9–11.
+1. Acknowledge each new `(app, version)` in `app_instance_materializations`.
+2. Group pending versions by app.
+3. Stop and restart each restartable app once, recording `stopped_at` and `restarted_at` on every pending row.
+4. Mark non-restartable apps converged without a local stop/start.
 
-Skip pairs already acknowledged on this replica. If a reconcile pass is still running when the next tick fires, skip the tick. Use per-`(app, version)` inflight guards within a pass.
+A provider is **restartable** when this replica builds it locally from the configured pin: `server.remote` is unset or the provider has `local: true`, and the provider is not running in dev mode. Remote and dev-mode providers are non-restartable.
+
+App bootstrapping when `gestaltd` starts and catalog-driven restarts share the same per-app lifecycle lease. `StopApp` holds the lease until `StartApp` completes, preventing concurrent builds or replacements.
+
+Failure and retry behavior:
+
+1. If `Close` fails, the provider stays absent because it may be partially closed. Later polls retain the error; shutdown releases the lease.
+2. If writing `stopped_at` fails after stop, the next poll retries the write without stopping the absent provider again.
+3. If writing `restarted_at` fails after start, the next poll retries the write without rebuilding the running provider.
+4. A version discovered while the app is stopped joins the current cycle and inherits its original `stopped_at`.
 
 ## Runtime
 

--- a/plans/app_registry/tests.md
+++ b/plans/app_registry/tests.md
@@ -18,6 +18,8 @@ Related docs:
 |---------|------|-------|-------|-----|
 | `internal/daemon/e2e/appregistry` | `appregistry_test.go` | 1 | E2E (CLI) | [gestalt#2709](https://github.com/valon-technologies/gestalt/pull/2709) |
 | `internal/server` | `handlers_admin_app_install_test.go` | 3 | HTTP integration | [gestalt#2730](https://github.com/valon-technologies/gestalt/pull/2730) |
+| `internal/appregistry` | `poller_test.go` | 11 | Unit | [gestalt#2812](https://github.com/valon-technologies/gestalt/pull/2812) |
+| `internal/bootstrap` | `app_provider_restart_test.go`, `app_provider_lifecycle_test.go` | 6 | Unit/integration | [gestalt#2812](https://github.com/valon-technologies/gestalt/pull/2812) |
 
 Test fixture for install HTTP tests: `internal/appregistry/registrytest/fixture.go`
 
@@ -98,7 +100,45 @@ End-to-end test for fleet install convergence across replicas. Replaces isolated
 4. Poll each replica's `app_instance_materializations` (or a future admin list endpoint) until every replica has an ack row for `(app, version)`.
 5. Assert ack timestamps are recent and `instance_id` values are distinct per replica.
 
-**Not in scope for the first cut:** artifact download, provider restart, or mount swap — ack-only convergence.
+**Not in scope for the first cut:** artifact download or mount swap — ack + restart-only convergence.
+
+---
+
+## Catalog restart tests
+
+Run:
+
+```bash
+cd gestaltd
+go test ./internal/appregistry -run TestCatalogPoller -count=1
+go test ./internal/bootstrap -run 'TestAppProvider(Restarter|Lifecycle)' -count=1
+```
+
+### `poller_test.go`
+
+- **`TestCatalogPollerReconcileOnceAcknowledgesAndRestarts`** — with the delay explicitly disabled, one reconcile pass acks, stops, and starts the configured app.
+- **`TestCatalogPollerReconcileOnceWaitsForRestartDelay`** — an unset `RestartDelay` uses the one-minute default and defers start until `stopped_at + RestartDelay`.
+- **`TestCatalogPollerReconcileOncePropagatesRestartErrors`** — start failures leave `restarted_at` unset after `stopped_at` was recorded.
+- **`TestCatalogPollerReconcileOnceRestartsOnceForMultipleVersions`** — multiple unrestarted fleet versions for one app trigger one stop/start cycle and mark every pending row restarted.
+- **`TestCatalogPollerReconcileOnceRetriesStartAfterRecordedStop`** — a later pass resumes at `StartApp` when `stopped_at` is already persisted.
+- **`TestCatalogPollerReconcileOnceDefersRestartUntilProvidersReady`** — ack proceeds while `RestartReady` is open; stop/start wait until startup providers load.
+- **`TestCatalogPollerReconcileOnceDoesNotResetRestartDelayForNewVersion`** — a newly fleet-known version during the restart delay does not stop again or push back `StartApp`.
+- **`TestCatalogPollerReconcileOnceDoesNotConvergeWithoutAppRestarter`** — without `AppRestarter`, ack runs but restart timestamps stay unset.
+- **`TestCatalogPollerReconcileOnceMarksNonLocalAppsConverged`** — non-local apps are acked and marked converged without stop/start.
+- **`TestCatalogPollerReconcileOnceDoesNotConvergeWhenRestartModeFails`** — an unconfigured app is not mistaken for a non-local app and remains pending.
+- **`TestCatalogPollerReconcileOnceReportsEveryFailingApp`** — errors from multiple apps are joined instead of hiding all but one.
+
+### `app_provider_restart_test.go`
+
+- **`TestAppProviderRestarterRestartable`** — only stable, locally managed providers are catalog-restartable; remote and dev-active providers converge without a local restart.
+- **`TestAppProviderRestarterStopAppNoOpsWhenProviderMissing`** — stop succeeds when a config-local app was removed from `ProviderMap` after a failed build.
+- **`TestAppProviderRestarterStartAppRegistersMissingProvider`** — start registers a missing local app and a repeated start is idempotent.
+- **`TestAppProviderRestarterStopRemovesProviderAndStartRestoresIt`** — stop removes the closed provider and start registers a fresh one.
+- **`TestAppProviderRestarterStopQuarantinesProviderWhenCloseFails`** — a provider whose close fails remains absent and subsequent stop attempts preserve the terminal error.
+
+### `app_provider_lifecycle_test.go`
+
+- **`TestAppProviderLifecycleSerializesOneApp`** — lazy activation and restart work for one app cannot overlap.
 
 ---
 

--- a/plans/app_registry/tests.md
+++ b/plans/app_registry/tests.md
@@ -18,7 +18,8 @@ Related docs:
 |---------|------|-------|-------|-----|
 | `internal/daemon/e2e/appregistry` | `appregistry_test.go` | 1 | E2E (CLI) | [gestalt#2709](https://github.com/valon-technologies/gestalt/pull/2709) |
 | `internal/server` | `handlers_admin_app_install_test.go` | 3 | HTTP integration | [gestalt#2730](https://github.com/valon-technologies/gestalt/pull/2730) |
-| `internal/appregistry` | `poller_test.go` | 11 | Unit | [gestalt#2812](https://github.com/valon-technologies/gestalt/pull/2812) |
+| `internal/appregistry` | `poller_test.go` | 16 | Unit | [gestalt#2812](https://github.com/valon-technologies/gestalt/pull/2812) |
+| `internal/coredata` | `app_rollouts_test.go`, `app_version_install_locks_test.go` | 3 | Unit | [gestalt#2812](https://github.com/valon-technologies/gestalt/pull/2812) |
 | `internal/bootstrap` | `app_provider_restart_test.go`, `app_provider_lifecycle_test.go` | 6 | Unit/integration | [gestalt#2812](https://github.com/valon-technologies/gestalt/pull/2812) |
 
 Test fixture for install HTTP tests: `internal/appregistry/registrytest/fixture.go`
@@ -118,6 +119,7 @@ go test ./internal/bootstrap -run 'TestAppProvider(Restarter|Lifecycle)' -count=
 
 - **`TestCatalogPollerReconcileOnceAcknowledgesAndRestarts`** — with the delay explicitly disabled, one reconcile pass acks, stops, and starts the configured app.
 - **`TestCatalogPollerReconcileOnceWaitsForRestartDelay`** — an unset `RestartDelay` uses the one-minute default and defers start until `stopped_at + RestartDelay`.
+- **`TestCatalogPollerReconcileOncePreservesDelayAfterStoppedAtWriteFailure`** — retrying a failed `stopped_at` write preserves the original stop time without stopping again.
 - **`TestCatalogPollerReconcileOncePropagatesRestartErrors`** — start failures leave `restarted_at` unset after `stopped_at` was recorded.
 - **`TestCatalogPollerReconcileOnceRestartsOnceForMultipleVersions`** — multiple unrestarted fleet versions for one app trigger one stop/start cycle and mark every pending row restarted.
 - **`TestCatalogPollerReconcileOnceRetriesStartAfterRecordedStop`** — a later pass resumes at `StartApp` when `stopped_at` is already persisted.
@@ -142,13 +144,18 @@ go test ./internal/bootstrap -run 'TestAppProvider(Restarter|Lifecycle)' -count=
 
 ---
 
-## [PLANNED] Rollout coordination tests
+## Rollout coordination tests
 
-- Concurrent installs for two versions of one app admit only one rollout.
-- Different apps may have active rollouts concurrently.
-- Enrollment freezes the replicas that acknowledged before the cutoff.
-- A rollout completes only after every enrolled replica records `restarted_at`.
-- Missing acknowledgements do not block completion; an acknowledged replica that misses the deadline fails the rollout.
+Run:
+
+```bash
+cd gestaltd
+go test ./internal/coredata -run 'Test(AppRollout|AppInstanceMaterialization|AppVersionInstallLock)' -count=1
+go test ./internal/appregistry -run 'Test(Installer|CatalogPollerRollout)' -count=1
+```
+
+- Install admission and app-scoped lock tests allow one active rollout per app while allowing different apps concurrently.
+- Poller tests cover enrollment, cohort completion, missed deadlines, and late-replica convergence.
 
 ---
 

--- a/plans/app_registry/tests.md
+++ b/plans/app_registry/tests.md
@@ -142,6 +142,16 @@ go test ./internal/bootstrap -run 'TestAppProvider(Restarter|Lifecycle)' -count=
 
 ---
 
+## [PLANNED] Rollout coordination tests
+
+- Concurrent installs for two versions of one app admit only one rollout.
+- Different apps may have active rollouts concurrently.
+- Enrollment freezes the replicas that acknowledged before the cutoff.
+- A rollout completes only after every enrolled replica records `restarted_at`.
+- Missing acknowledgements do not block completion; an acknowledged replica that misses the deadline fails the rollout.
+
+---
+
 ## What is not covered yet
 
 Publish tests validate **CLI dry-run behavior** only. Install HTTP tests cover the happy path, 404 on missing version, and get-by-app — but not:


### PR DESCRIPTION
## Description

Implements app-registry step 9 and enforces one active rollout per app across the fleet. Replicas enroll dynamically, coalesce pending versions into one local provider restart, and persist cohort completion or failure without a configured replica count.