### PR TITLE
SDK-7: implement the generated Go public REST and gRPC SDK (issue-125)

### DIFF
--- a/sdk/go/publicclient/auth.go
+++ b/sdk/go/publicclient/auth.go
@@ -1,0 +1,51 @@
+package publicclient
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// Auth supplies credentials for public gestaltd requests.
+type Auth interface {
+	Apply(ctx context.Context, req *Request) error
+}
+
+// Request is outgoing HTTP metadata that Auth implementations may mutate.
+type Request struct {
+	Headers map[string]string
+}
+
+// TokenProvider returns a bearer token for one outbound call.
+type TokenProvider func(ctx context.Context) (string, error)
+
+type bearerAuth struct {
+	provider TokenProvider
+}
+
+// Bearer sends Authorization: Bearer <token> using provider on every call.
+func Bearer(provider TokenProvider) Auth {
+	return bearerAuth{provider: provider}
+}
+
+func (a bearerAuth) Apply(ctx context.Context, req *Request) error {
+	if a.provider == nil || req == nil {
+		return nil
+	}
+	token, err := a.provider(ctx)
+	if err != nil {
+		return fmt.Errorf("publicclient: bearer token: %w", err)
+	}
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return nil
+	}
+	if req.Headers == nil {
+		req.Headers = map[string]string{}
+	}
+	req.Headers["Authorization"] = "Bearer " + token
+	return nil
+}
+
+// Unauthenticated sends no credentials.
+func Unauthenticated() Auth { return nil }

--- a/sdk/go/publicclient/bound.go
+++ b/sdk/go/publicclient/bound.go
@@ -1,0 +1,93 @@
+package publicclient
+
+import (
+	"context"
+	"strings"
+
+	gestalt "github.com/valon-technologies/gestalt/sdk/go"
+	"github.com/valon-technologies/gestalt/sdk/go/internal/host"
+	"github.com/valon-technologies/gestalt/sdk/go/publicclient/generated"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	gproto "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+var connectPublicAppConns host.ConnPool
+
+// GestaltFromContext returns a gRPC client bound to the host-service relay.
+// It injects the provider request context and caller bearer token from ctx.
+// Bound access accepts no public address or auth configuration.
+func GestaltFromContext(ctx context.Context) (*Client, error) {
+	reqCtx := gestalt.RequestContextFromContext(ctx)
+
+	target, token, err := host.Target("app")
+	if err != nil {
+		return nil, err
+	}
+	conn, err := connectPublicAppConns.Conn(ctx, "gestalt-public", target, token, "")
+	if err != nil {
+		return nil, err
+	}
+	wrapped := &boundClientConn{
+		ClientConnInterface: conn,
+		RequestContext:      reqCtx,
+	}
+	grpcT := &grpcUnaryTransport{conn: wrapped}
+	return &Client{
+		App:       generated.NewAppClient(grpcT),
+		transport: grpcT,
+	}, nil
+}
+
+type boundClientConn struct {
+	grpc.ClientConnInterface
+	RequestContext *proto.RequestContext
+}
+
+func (c *boundClientConn) Invoke(
+	ctx context.Context,
+	method string,
+	args any,
+	reply any,
+	opts ...grpc.CallOption,
+) error {
+	injectRequestContext(args, c.RequestContext)
+	ctx = appendOutboundCallerBearer(ctx)
+	return c.ClientConnInterface.Invoke(ctx, method, args, reply, opts...)
+}
+
+func (c *boundClientConn) NewStream(
+	ctx context.Context,
+	desc *grpc.StreamDesc,
+	method string,
+	opts ...grpc.CallOption,
+) (grpc.ClientStream, error) {
+	ctx = appendOutboundCallerBearer(ctx)
+	return c.ClientConnInterface.NewStream(ctx, desc, method, opts...)
+}
+
+func appendOutboundCallerBearer(ctx context.Context) context.Context {
+	if token := strings.TrimSpace(gestalt.CallerBearerTokenFromIncomingContext(ctx)); token != "" {
+		return metadata.AppendToOutgoingContext(ctx, gestalt.CallerBearerTokenMetadataKey, token)
+	}
+	return gestalt.AppendIdentityCallMetadata(ctx)
+}
+
+func injectRequestContext(req any, boundCtx *proto.RequestContext) {
+	if boundCtx == nil {
+		return
+	}
+	msg, ok := req.(gproto.Message)
+	if !ok {
+		return
+	}
+	reflect := msg.ProtoReflect()
+	field := reflect.Descriptor().Fields().ByName("context")
+	if field == nil || reflect.Has(field) {
+		return
+	}
+	cloned, _ := gproto.Clone(boundCtx).(*proto.RequestContext)
+	reflect.Set(field, protoreflect.ValueOfMessage(cloned.ProtoReflect()))
+}

--- a/sdk/go/publicclient/client.go
+++ b/sdk/go/publicclient/client.go
@@ -1,0 +1,101 @@
+package publicclient
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/sdk/go/publicclient/generated"
+)
+
+// Transport selects the public Gestalt wire protocol.
+type Transport interface {
+	isTransport()
+}
+
+type restTransport struct{}
+
+// REST selects the browser-safe /api/v2 protobuf JSON surface.
+func REST() Transport { return restTransport{} }
+
+func (restTransport) isTransport() {}
+
+type grpcTransport struct{}
+
+// GRPC selects the public provider gRPC surface.
+func GRPC() Transport { return grpcTransport{} }
+
+func (grpcTransport) isTransport() {}
+
+// Options configures New.
+type Options struct {
+	Address   string
+	Transport Transport
+	Auth      Auth
+}
+
+// Client exposes the generated public App client over one transport.
+type Client struct {
+	App *generated.AppClient
+
+	transport interface {
+		Close() error
+	}
+}
+
+// New builds a public client for REST or external gRPC.
+func New(opts Options) (*Client, error) {
+	transport := opts.Transport
+	if transport == nil {
+		transport = REST()
+	}
+
+	switch transport.(type) {
+	case restTransport:
+		baseURL, err := normalizeAddress(opts.Address)
+		if err != nil {
+			return nil, err
+		}
+		rest := &restUnaryTransport{baseURL: baseURL, auth: opts.Auth, client: http.DefaultClient}
+		return &Client{
+			App:       generated.NewAppClient(rest),
+			transport: rest,
+		}, nil
+	case grpcTransport:
+		address := strings.TrimSpace(opts.Address)
+		if address == "" {
+			return nil, fmt.Errorf("publicclient: address is required for external gRPC (use GestaltFromContext for bound provider access)")
+		}
+		conn, err := dialPublicGRPC(address)
+		if err != nil {
+			return nil, err
+		}
+		grpcT := &grpcUnaryTransport{conn: conn, owned: conn, auth: opts.Auth}
+		return &Client{
+			App:       generated.NewAppClient(grpcT),
+			transport: grpcT,
+		}, nil
+	default:
+		return nil, fmt.Errorf("publicclient: unsupported transport %T", transport)
+	}
+}
+
+// Close releases transport resources when the client owns them.
+func (c *Client) Close() error {
+	if c == nil || c.transport == nil {
+		return nil
+	}
+	return c.transport.Close()
+}
+
+// NewRESTClientForTest constructs a REST client with a custom http.Client.
+func NewRESTClientForTest(baseURL string, auth Auth, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	rest := &restUnaryTransport{baseURL: baseURL, auth: auth, client: httpClient}
+	return &Client{
+		App:       generated.NewAppClient(rest),
+		transport: rest,
+	}
+}

--- a/sdk/go/publicclient/dial.go
+++ b/sdk/go/publicclient/dial.go
@@ -1,0 +1,69 @@
+package publicclient
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+func parsePublicURL(address string) (*url.URL, error) {
+	address = strings.TrimSpace(address)
+	if address == "" {
+		return nil, fmt.Errorf("publicclient: address is required")
+	}
+	parsed, err := url.Parse(address)
+	if err != nil {
+		return nil, fmt.Errorf("publicclient: invalid address %q: %w", address, err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return nil, fmt.Errorf("publicclient: invalid address %q", address)
+	}
+	switch strings.ToLower(parsed.Scheme) {
+	case "http", "https":
+	default:
+		return nil, fmt.Errorf("publicclient: unsupported address scheme %q", parsed.Scheme)
+	}
+	return parsed, nil
+}
+
+func normalizeAddress(address string) (string, error) {
+	parsed, err := parsePublicURL(address)
+	if err != nil {
+		return "", err
+	}
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return strings.TrimSuffix(parsed.String(), "/"), nil
+}
+
+func dialPublicGRPC(address string) (*grpc.ClientConn, error) {
+	parsed, err := parsePublicURL(address)
+	if err != nil {
+		return nil, err
+	}
+	var creds credentials.TransportCredentials
+	if strings.EqualFold(parsed.Scheme, "https") {
+		creds = credentials.NewTLS(nil)
+	} else {
+		creds = insecure.NewCredentials()
+	}
+	return grpc.NewClient(grpcTarget(parsed), grpc.WithTransportCredentials(creds))
+}
+
+func grpcTarget(parsed *url.URL) string {
+	host := parsed.Hostname()
+	port := parsed.Port()
+	if port == "" {
+		if strings.EqualFold(parsed.Scheme, "https") {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+	return net.JoinHostPort(host, port)
+}

--- a/sdk/go/publicclient/doc.go
+++ b/sdk/go/publicclient/doc.go
@@ -1,0 +1,15 @@
+// Package publicclient is the Go SDK for calling the public gestaltd API
+// over REST or gRPC.
+//
+// External callers configure an address, transport, and auth explicitly:
+//
+//	client, err := publicclient.New(publicclient.Options{
+//	    Address:   "https://valon.tools",
+//	    Transport: publicclient.GRPC(),
+//	    Auth:      publicclient.Bearer(func(ctx context.Context) (string, error) { ... }),
+//	})
+//
+// Provider handlers derive a bound gRPC client from request context instead:
+//
+//	client, err := publicclient.GestaltFromContext(ctx)
+package publicclient

--- a/sdk/go/publicclient/grpc_transport.go
+++ b/sdk/go/publicclient/grpc_transport.go
@@ -1,0 +1,66 @@
+package publicclient
+
+import (
+	"context"
+	"strings"
+
+	gestaltclient "github.com/valon-technologies/gestalt/sdk/go/client"
+	"github.com/valon-technologies/gestalt/sdk/go/publicclient/generated"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	gproto "google.golang.org/protobuf/proto"
+)
+
+type grpcUnaryTransport struct {
+	conn  grpc.ClientConnInterface
+	owned *grpc.ClientConn
+	auth  Auth
+}
+
+func (t *grpcUnaryTransport) Close() error {
+	if t == nil || t.owned == nil {
+		return nil
+	}
+	err := t.owned.Close()
+	t.owned = nil
+	t.conn = nil
+	return err
+}
+
+func (t *grpcUnaryTransport) Unary(
+	ctx context.Context,
+	method generated.Method,
+	request, response gproto.Message,
+) error {
+	if t == nil || t.conn == nil {
+		return &generated.GestaltError{
+			Code:    gestaltclient.GestaltErrorCodeInvalidArgument,
+			Message: "publicclient: gRPC transport is nil",
+		}
+	}
+	ctx, err := withAuthContext(ctx, t.auth)
+	if err != nil {
+		return err
+	}
+	if err := t.conn.Invoke(ctx, method.FullMethod, request, response); err != nil {
+		return gestaltclient.ToGestaltError(err)
+	}
+	return nil
+}
+
+func withAuthContext(ctx context.Context, auth Auth) (context.Context, error) {
+	if auth == nil {
+		return ctx, nil
+	}
+	meta := &Request{Headers: map[string]string{}}
+	if err := auth.Apply(ctx, meta); err != nil {
+		return nil, err
+	}
+	for key, value := range meta.Headers {
+		if value == "" {
+			continue
+		}
+		ctx = metadata.AppendToOutgoingContext(ctx, strings.ToLower(key), value)
+	}
+	return ctx, nil
+}

--- a/sdk/go/publicclient/rest_mapping.go
+++ b/sdk/go/publicclient/rest_mapping.go
@@ -1,0 +1,146 @@
+package publicclient
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	gestaltclient "github.com/valon-technologies/gestalt/sdk/go/client"
+	"github.com/valon-technologies/gestalt/sdk/go/publicclient/generated"
+)
+
+func buildRestPath(http generated.Method, fields map[string]any) (string, error) {
+	path := http.HTTPPath
+	for _, field := range http.HTTPPathFields {
+		value, ok := fieldValue(fields, field.Name, field.JSONName)
+		if !ok || value == nil {
+			return "", &generated.GestaltError{
+				Code:    gestaltclient.GestaltErrorCodeInvalidArgument,
+				Message: fmt.Sprintf("missing path parameter %s", field.Name),
+			}
+		}
+		if _, isObject := value.(map[string]any); isObject {
+			return "", &generated.GestaltError{
+				Code:    gestaltclient.GestaltErrorCodeInvalidArgument,
+				Message: fmt.Sprintf("path parameter %s must be scalar", field.Name),
+			}
+		}
+		placeholder := "{" + field.Name + "}"
+		path = strings.ReplaceAll(path, placeholder, url.PathEscape(fmt.Sprint(value)))
+	}
+	if strings.Contains(path, "{") {
+		return "", &generated.GestaltError{
+			Code:    gestaltclient.GestaltErrorCodeInvalidArgument,
+			Message: fmt.Sprintf("missing path parameter in %q", path),
+		}
+	}
+	return path, nil
+}
+
+func buildRestBody(http generated.Method, fields map[string]any) map[string]any {
+	switch strings.ToUpper(http.HTTPVerb) {
+	case "GET", "DELETE":
+		return nil
+	}
+	excluded := bodyExcludedFieldKeys(http)
+	body := make(map[string]any, len(fields))
+	for key, value := range fields {
+		if value == nil || excluded[key] {
+			continue
+		}
+		body[key] = value
+	}
+	return body
+}
+
+func buildRestQuery(http generated.Method, fields map[string]any) url.Values {
+	values := url.Values{}
+	for _, field := range http.HTTPQueryFields {
+		value, ok := fieldValue(fields, field.Name, field.JSONName)
+		if !ok || value == nil {
+			continue
+		}
+		encodeQueryValue(values, field.JSONName, value)
+	}
+	return values
+}
+
+func bodyExcludedFieldKeys(method generated.Method) map[string]bool {
+	keys := make(map[string]bool)
+	add := func(name string) {
+		if name == "" {
+			return
+		}
+		keys[name] = true
+		if camel := snakeToCamel(name); camel != name {
+			keys[camel] = true
+		}
+	}
+	for _, field := range append(method.HTTPPathFields, method.HTTPQueryFields...) {
+		add(field.Name)
+		if field.JSONName != "" {
+			keys[field.JSONName] = true
+		}
+	}
+	for _, name := range append(method.Fill, method.Reject...) {
+		add(name)
+	}
+	return keys
+}
+
+func snakeToCamel(name string) string {
+	parts := strings.Split(name, "_")
+	if len(parts) <= 1 {
+		return name
+	}
+	out := parts[0]
+	for _, part := range parts[1:] {
+		if part == "" {
+			continue
+		}
+		out += strings.ToUpper(part[:1]) + part[1:]
+	}
+	return out
+}
+
+func fieldValue(fields map[string]any, name, jsonName string) (any, bool) {
+	if jsonName != "" {
+		if value, ok := fields[jsonName]; ok {
+			return value, true
+		}
+	}
+	if value, ok := fields[name]; ok {
+		return value, true
+	}
+	return nil, false
+}
+
+func encodeQueryValue(values url.Values, key string, value any) {
+	switch typed := value.(type) {
+	case []any:
+		for _, item := range typed {
+			encodeQueryValue(values, key, item)
+		}
+	case []string:
+		for _, item := range typed {
+			values.Add(key, item)
+		}
+	case map[string]any:
+		for nestedKey, nestedValue := range typed {
+			encodeQueryValue(values, key+"."+nestedKey, nestedValue)
+		}
+	default:
+		values.Add(key, fmt.Sprint(value))
+	}
+}
+
+func joinURL(baseURL, path string) (string, error) {
+	base, err := url.Parse(strings.TrimRight(strings.TrimSpace(baseURL), "/"))
+	if err != nil || base.Scheme == "" || base.Host == "" {
+		return "", fmt.Errorf("publicclient: base URL is required")
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return base.Scheme + "://" + base.Host + strings.TrimSuffix(base.Path, "/") + path, nil
+}

--- a/sdk/go/publicclient/rest_transport.go
+++ b/sdk/go/publicclient/rest_transport.go
@@ -1,0 +1,215 @@
+package publicclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	gestaltclient "github.com/valon-technologies/gestalt/sdk/go/client"
+	"github.com/valon-technologies/gestalt/sdk/go/publicclient/generated"
+	gproto "google.golang.org/protobuf/encoding/protojson"
+	pb "google.golang.org/protobuf/proto"
+	"google.golang.org/grpc/codes"
+)
+
+var protoJSONMarshal = gproto.MarshalOptions{}
+var protoJSONUnmarshal = gproto.UnmarshalOptions{DiscardUnknown: true}
+
+type restUnaryTransport struct {
+	baseURL string
+	auth    Auth
+	client  *http.Client
+}
+
+func (t *restUnaryTransport) Close() error {
+	if t == nil || t.client == nil || t.client == http.DefaultClient {
+		return nil
+	}
+	t.client.CloseIdleConnections()
+	return nil
+}
+
+type gatewayErrorBody struct {
+	Error string `json:"error"`
+	Code  string `json:"code"`
+}
+
+func decodeGatewayError(status int, body []byte) error {
+	code := httpStatusToGestaltCode(status)
+	message := fmt.Sprintf("request failed with status %d", status)
+	if len(body) > 0 {
+		var payload gatewayErrorBody
+		if json.Unmarshal(body, &payload) == nil {
+			if payload.Error != "" {
+				message = payload.Error
+			}
+			if payload.Code != "" {
+				if parsed := codeFromString(payload.Code); parsed != gestaltclient.GestaltErrorCodeUnknown {
+					code = parsed
+				}
+			}
+		}
+	}
+	return &generated.GestaltError{Code: code, Message: message}
+}
+
+func codeFromString(raw string) generated.GestaltErrorCode {
+	for c := codes.OK; c <= codes.Unauthenticated; c++ {
+		if c.String() == raw {
+			return generated.GestaltErrorCode(c)
+		}
+	}
+	return gestaltclient.GestaltErrorCodeUnknown
+}
+
+func httpStatusToGestaltCode(status int) generated.GestaltErrorCode {
+	switch status {
+	case http.StatusBadRequest:
+		return gestaltclient.GestaltErrorCodeInvalidArgument
+	case http.StatusUnauthorized:
+		return gestaltclient.GestaltErrorCodeUnauthenticated
+	case http.StatusForbidden:
+		return gestaltclient.GestaltErrorCodePermissionDenied
+	case http.StatusNotFound:
+		return gestaltclient.GestaltErrorCodeNotFound
+	case http.StatusConflict:
+		return gestaltclient.GestaltErrorCodeAlreadyExists
+	case http.StatusPreconditionFailed:
+		return gestaltclient.GestaltErrorCodeFailedPrecondition
+	case 429:
+		return gestaltclient.GestaltErrorCodeResourceExhausted
+	case 499:
+		return gestaltclient.GestaltErrorCodeCanceled
+	case http.StatusInternalServerError:
+		return gestaltclient.GestaltErrorCodeInternal
+	case http.StatusNotImplemented:
+		return gestaltclient.GestaltErrorCodeUnimplemented
+	case http.StatusServiceUnavailable:
+		return gestaltclient.GestaltErrorCodeUnavailable
+	case http.StatusGatewayTimeout:
+		return gestaltclient.GestaltErrorCodeDeadlineExceeded
+	default:
+		return gestaltclient.GestaltErrorCodeUnknown
+	}
+}
+
+func (t *restUnaryTransport) Unary(
+	ctx context.Context,
+	method generated.Method,
+	request, response pb.Message,
+) error {
+	if t == nil {
+		return &generated.GestaltError{
+			Code:    gestaltclient.GestaltErrorCodeInvalidArgument,
+			Message: "publicclient: REST transport is nil",
+		}
+	}
+
+	requestMap, err := messageToJSONMap(request)
+	if err != nil {
+		return err
+	}
+	path, err := buildRestPath(method, requestMap)
+	if err != nil {
+		return err
+	}
+	target, err := joinURL(t.baseURL, path)
+	if err != nil {
+		return err
+	}
+	if query := buildRestQuery(method, requestMap).Encode(); query != "" {
+		target += "?" + query
+	}
+
+	var body io.Reader
+	switch strings.ToUpper(method.HTTPVerb) {
+	case http.MethodGet, http.MethodDelete:
+	default:
+		payload := buildRestBody(method, requestMap)
+		if payload != nil {
+			encoded, err := json.Marshal(payload)
+			if err != nil {
+				return err
+			}
+			body = bytes.NewReader(encoded)
+		}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method.HTTPVerb, target, body)
+	if err != nil {
+		return err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/json")
+	meta := &Request{Headers: map[string]string{}}
+	if t.auth != nil {
+		if err := t.auth.Apply(ctx, meta); err != nil {
+			return err
+		}
+	}
+	for key, value := range meta.Headers {
+		req.Header.Set(key, value)
+	}
+
+	resp, err := t.client.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			code := gestaltclient.GestaltErrorCodeCanceled
+			if ctx.Err() == context.DeadlineExceeded {
+				code = gestaltclient.GestaltErrorCodeDeadlineExceeded
+			}
+			return &generated.GestaltError{Code: code, Message: ctx.Err().Error()}
+		}
+		return &generated.GestaltError{
+			Code:    gestaltclient.GestaltErrorCodeUnavailable,
+			Message: err.Error(),
+		}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode >= 400 {
+		return decodeGatewayError(resp.StatusCode, raw)
+	}
+	if response == nil {
+		return nil
+	}
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return nil
+	}
+	if err := protoJSONUnmarshal.Unmarshal(raw, response); err != nil {
+		return &generated.GestaltError{
+			Code:    gestaltclient.GestaltErrorCodeInternal,
+			Message: "response body does not match the expected schema",
+		}
+	}
+	return nil
+}
+
+func messageToJSONMap(msg pb.Message) (map[string]any, error) {
+	if msg == nil {
+		return map[string]any{}, nil
+	}
+	data, err := protoJSONMarshal.Marshal(msg)
+	if err != nil {
+		return nil, err
+	}
+	var out map[string]any
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, err
+	}
+	if out == nil {
+		return map[string]any{}, nil
+	}
+	return out, nil
+}

--- a/sdk/go/publicclient/rest_transport_test.go
+++ b/sdk/go/publicclient/rest_transport_test.go
@@ -1,0 +1,338 @@
+package publicclient_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	gestaltclient "github.com/valon-technologies/gestalt/sdk/go/client"
+	"github.com/valon-technologies/gestalt/sdk/go/publicclient"
+	"github.com/valon-technologies/gestalt/sdk/go/publicclient/generated"
+)
+
+type restCall struct {
+	method        string
+	path          string
+	authorization string
+	body          string
+}
+
+func TestRESTTransportMappingAndGatewayErrors(t *testing.T) {
+	var calls []restCall
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		body, _ := io.ReadAll(r.Body)
+		calls = append(calls, restCall{
+			method:        r.Method,
+			path:          r.URL.Path,
+			authorization: auth,
+			body:          string(body),
+		})
+		if auth == "Bearer bad" {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"unauthorized","code":"Unauthenticated"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"status":200,"body":"eyJzdGF0dXMiOiJzdWNjZXNzIiwiZGF0YSI6eyJvayI6dHJ1ZX19","headers":{"X-Example":{"values":["rest-v2"]}}}`))
+	}))
+	defer server.Close()
+
+	client := publicclient.NewRESTClientForTest(server.URL, publicclient.Bearer(func(context.Context) (string, error) {
+		return "token-123", nil
+	}), server.Client())
+	defer func() { _ = client.Close() }()
+
+	got, err := client.App.Invoke(context.Background(), &generated.AppInvokeRequest{
+		App:            "example",
+		Operation:      "sync",
+		Params:         map[string]any{"ok": true},
+		IdempotencyKey: "key-1",
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("calls = %d, want 1", len(calls))
+	}
+	if calls[0].method != http.MethodPost {
+		t.Fatalf("method = %q", calls[0].method)
+	}
+	if calls[0].path != "/api/v2/app/example/operations/sync" {
+		t.Fatalf("path = %q", calls[0].path)
+	}
+	if calls[0].authorization != "Bearer token-123" {
+		t.Fatalf("authorization = %q", calls[0].authorization)
+	}
+	var body map[string]any
+	if err := json.Unmarshal([]byte(calls[0].body), &body); err != nil {
+		t.Fatalf("body json: %v", err)
+	}
+	if body["params"].(map[string]any)["ok"] != true || body["idempotencyKey"] != "key-1" {
+		t.Fatalf("body = %#v", body)
+	}
+	if got.(map[string]any)["ok"] != true {
+		t.Fatalf("result = %#v", got)
+	}
+
+	clientBad := publicclient.NewRESTClientForTest(server.URL, publicclient.Bearer(func(context.Context) (string, error) {
+		return "bad", nil
+	}), server.Client())
+	defer func() { _ = clientBad.Close() }()
+	_, err = clientBad.App.Invoke(context.Background(), &generated.AppInvokeRequest{
+		App:       "example",
+		Operation: "sync",
+	})
+	var gerr *generated.GestaltError
+	if !errors.As(err, &gerr) {
+		t.Fatalf("error = %v, want *generated.GestaltError", err)
+	}
+	if gerr.Code != gestaltclient.GestaltErrorCodeUnauthenticated {
+		t.Fatalf("code = %v", gerr.Code)
+	}
+}
+
+func TestBearerRotationEvaluatedPerCall(t *testing.T) {
+	token := "first"
+	var authorizations []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authorizations = append(authorizations, r.Header.Get("Authorization"))
+		_, _ = w.Write([]byte(`{"status":200,"body":"","headers":{}}`))
+	}))
+	defer server.Close()
+
+	client := publicclient.NewRESTClientForTest(server.URL, publicclient.Bearer(func(context.Context) (string, error) {
+		return token, nil
+	}), server.Client())
+	defer func() { _ = client.Close() }()
+
+	request := &generated.AppInvokeRequest{App: "example", Operation: "sync"}
+	if _, err := client.App.Invoke(context.Background(), request); err != nil {
+		t.Fatalf("first invoke: %v", err)
+	}
+	token = "second"
+	if _, err := client.App.Invoke(context.Background(), request); err != nil {
+		t.Fatalf("second invoke: %v", err)
+	}
+	if len(authorizations) != 2 || authorizations[0] != "Bearer first" || authorizations[1] != "Bearer second" {
+		t.Fatalf("authorizations = %#v", authorizations)
+	}
+}
+
+func TestUnauthenticatedOmitsAuthorizationHeader(t *testing.T) {
+	var authorization string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authorization = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"status":200,"body":"","headers":{}}`))
+	}))
+	defer server.Close()
+
+	client := publicclient.NewRESTClientForTest(server.URL, publicclient.Unauthenticated(), server.Client())
+	defer func() { _ = client.Close() }()
+	if _, err := client.App.Invoke(context.Background(), &generated.AppInvokeRequest{
+		App: "example", Operation: "sync",
+	}); err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if authorization != "" {
+		t.Fatalf("authorization = %q, want empty", authorization)
+	}
+}
+
+func TestNewRequiresValidAddress(t *testing.T) {
+	_, err := publicclient.New(publicclient.Options{
+		Address:   "",
+		Transport: publicclient.REST(),
+		Auth:      publicclient.Unauthenticated(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "address is required") {
+		t.Fatalf("error = %v", err)
+	}
+
+	_, err = publicclient.New(publicclient.Options{
+		Address:   "not-a-url",
+		Transport: publicclient.REST(),
+		Auth:      publicclient.Unauthenticated(),
+	})
+	if err == nil {
+		t.Fatal("expected invalid address error")
+	}
+
+	_, err = publicclient.New(publicclient.Options{
+		Transport: publicclient.GRPC(),
+		Auth:      publicclient.Unauthenticated(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "address is required") {
+		t.Fatalf("gRPC error = %v", err)
+	}
+
+	_, err = publicclient.New(publicclient.Options{
+		Address:   "ftp://example.com",
+		Transport: publicclient.GRPC(),
+		Auth:      publicclient.Unauthenticated(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "unsupported address scheme") {
+		t.Fatalf("unsupported scheme error = %v", err)
+	}
+}
+
+func TestBearerProviderReceivesContext(t *testing.T) {
+	var seen context.Context
+	auth := publicclient.Bearer(func(ctx context.Context) (string, error) {
+		seen = ctx
+		return "token", nil
+	})
+	req := &publicclient.Request{Headers: map[string]string{}}
+	ctx := context.WithValue(context.Background(), struct{}{}, "marker")
+	if err := auth.Apply(ctx, req); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if seen != ctx {
+		t.Fatal("token provider did not receive call context")
+	}
+}
+
+func TestRESTTransportSharedConformanceCases(t *testing.T) {
+	cases := loadClientCases(t)
+	for _, tc := range cases {
+		t.Run(tc.ID, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch tc.ID {
+				case "invoke_success":
+					body, err := base64.StdEncoding.DecodeString(tc.Response.OperationResult.BodyBase64)
+					if err != nil {
+						t.Fatalf("decode body: %v", err)
+					}
+					_, _ = w.Write([]byte(`{"status":200,"body":"` + base64.StdEncoding.EncodeToString(body) + `","headers":{}}`))
+				case "platform_error":
+					w.WriteHeader(http.StatusUnauthorized)
+					_, _ = w.Write([]byte(`{"error":"Not authenticated","code":"Unauthenticated"}`))
+				}
+			}))
+			defer server.Close()
+
+			client := publicclient.NewRESTClientForTest(server.URL, publicclient.Bearer(func(context.Context) (string, error) {
+				return "token", nil
+			}), server.Client())
+			defer func() { _ = client.Close() }()
+
+			request := &generated.AppInvokeRequest{
+				App:       tc.PublicRequest["app"].(string),
+				Operation: tc.PublicRequest["operation"].(string),
+			}
+			if params, ok := tc.PublicRequest["params"].(map[string]any); ok {
+				request.Params = params
+			}
+
+			switch tc.ID {
+			case "invoke_success":
+				got, err := client.App.Invoke(context.Background(), request)
+				if err != nil {
+					t.Fatalf("Invoke: %v", err)
+				}
+				if !jsonEqual(got, tc.Expect.Result) {
+					t.Fatalf("result = %#v, want %#v", got, tc.Expect.Result)
+				}
+			case "platform_error":
+				_, err := client.App.Invoke(context.Background(), request)
+				var gerr *generated.GestaltError
+				if !errors.As(err, &gerr) {
+					t.Fatalf("error = %v, want *generated.GestaltError", err)
+				}
+				if int32(gerr.Code) != tc.Expect.GestaltError.Code || gerr.Message != tc.Expect.GestaltError.Message {
+					t.Fatalf("GestaltError = %+v", gerr)
+				}
+			}
+		})
+	}
+}
+
+func TestContextCancellation(t *testing.T) {
+	block := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		<-block
+	}))
+	defer server.Close()
+	defer close(block)
+
+	client := publicclient.NewRESTClientForTest(server.URL, publicclient.Unauthenticated(), server.Client())
+	defer func() { _ = client.Close() }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		cancel()
+	}()
+
+	_, err := client.App.Invoke(ctx, &generated.AppInvokeRequest{App: "example", Operation: "sync"})
+	var gerr *generated.GestaltError
+	if !errors.As(err, &gerr) {
+		t.Fatalf("error = %v, want *generated.GestaltError", err)
+	}
+	if gerr.Code != gestaltclient.GestaltErrorCodeCanceled {
+		t.Fatalf("code = %v", gerr.Code)
+	}
+}
+
+func TestGestaltFromContextRequiresHostEnvironment(t *testing.T) {
+	_, err := publicclient.GestaltFromContext(context.Background())
+	if err == nil {
+		t.Fatal("expected GestaltFromContext to fail outside provider host")
+	}
+}
+
+func TestPublicBearerAuthIsSeparateTypeFromCallerProof(t *testing.T) {
+	publicAuth := publicclient.Bearer(func(context.Context) (string, error) { return "public", nil })
+	req := &publicclient.Request{Headers: map[string]string{}}
+	if err := publicAuth.Apply(context.Background(), req); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if req.Headers["Authorization"] != "Bearer public" {
+		t.Fatalf("headers = %#v", req.Headers)
+	}
+	if strings.Contains(req.Headers["Authorization"], "caller") {
+		t.Fatal("public bearer must not carry caller proof semantics")
+	}
+}
+
+type clientCase struct {
+	ID            string         `json:"id"`
+	PublicRequest map[string]any `json:"publicRequest"`
+	Response      struct {
+		OperationResult *struct {
+			BodyBase64 string `json:"bodyBase64"`
+		} `json:"operationResult"`
+	} `json:"response"`
+	Expect struct {
+		Result       any `json:"result"`
+		GestaltError *struct {
+			Code    int32  `json:"code"`
+			Message string `json:"message"`
+		} `json:"gestaltError"`
+	} `json:"expect"`
+}
+
+func loadClientCases(t *testing.T) []clientCase {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("..", "..", "testdata", "public_conformance", "client_cases.json"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	var cases []clientCase
+	if err := json.Unmarshal(data, &cases); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+	return cases
+}
+
+func jsonEqual(left, right any) bool {
+	leftBytes, _ := json.Marshal(left)
+	rightBytes, _ := json.Marshal(right)
+	return string(leftBytes) == string(rightBytes)
+}

--- a/sdk/go/request_clients.go
+++ b/sdk/go/request_clients.go
@@ -7,6 +7,11 @@ import (
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 )
 
+// RequestContextFromContext returns the host-attached wire request context.
+func RequestContextFromContext(ctx context.Context) *proto.RequestContext {
+	return requestContextFromContext(ctx)
+}
+
 // AppFromContext returns the generated app-invocation client carrying the
 // current provider request's context as the client default. It dials the
 // "app" host service advertised through the GESTALT_HOST_SERVICE_SOCKET


### PR DESCRIPTION
## Summary

Implements **issue-125** (SDK-7): the handwritten Go `publicclient` transport layer on top of the SDK-2 generated App client.

- Adds external `publicclient.New` with required `Address`, `REST()` / `GRPC()` transport selection, and `Bearer` / `Unauthenticated` auth (evaluated per call).
- Implements REST (`net/http` + protobuf JSON) and gRPC (`generated` stubs) `UnaryTransport` backends sharing one `GestaltError` model.
- Adds bound provider access via `publicclient.GestaltFromContext(ctx)` (no public address/auth options; injects request context + caller bearer relay metadata).
- Exports `gestalt.RequestContextFromContext` for bound client wiring.
- Adds transport conformance, auth rotation, cancellation, address validation, and gateway error tests.

Closes issue-125.

## Dependency graph (from issue-125)

```mermaid
flowchart TD
    G["SDK-1: REST gateway contract"] --> M["SDK-2: App-only sdkgen model"]
    M --> T["SDK-3: gestalt and gestalt-web boundaries"]
    G --> W["SDK-4: gestalt-web REST SDK"]
    M --> W
    T --> W
    G --> N["SDK-5: gestalt server-side clients"]
    M --> N
    G --> B["SDK-6: Bound relay and caller proof"]
    M --> GO["SDK-7: Go SDK"]
    M --> PY["SDK-8: Python SDK"]
    M --> RS["SDK-9: Rust SDK"]
    W --> GI["SDK-10: Migrate gIssues to gestalt-web"]
    W --> X["SDK-11: Expand public services"]
    N --> X
    B --> X
    GO --> X
    PY --> X
    RS --> X
```

This PR is **SDK-7**. It depends on SDK-2 and may proceed in parallel with the Python, Rust, and TypeScript runtime issues.

## SDK responsibility split (from issue-125)

```mermaid
flowchart LR
    APP["Generated App client"] --> U["Go unary transport"]
    U --> HTTP["net/http REST"]
    U --> GRPC["generated gRPC stubs"]
    HTTP --> D["gestaltd"]
    GRPC --> D
```

## High-level interfaces (from issue-125)

External public factory:

```go
client, err := publicclient.New(publicclient.Options{
    Address:   "https://valon.tools",
    Transport: publicclient.GRPC(),
    Auth:      publicclient.Bearer(tokenProvider),
})
if err != nil {
    return err
}
defer client.Close()

result, err := client.App.Invoke(ctx, &generated.AppInvokeRequest{
    App:       "gIssues",
    Operation: "plans.get",
    Params:    params,
})
```

Bound provider access (no public address/auth configuration):

```go
client, err := publicclient.GestaltFromContext(ctx)
```

## Test plan

- [x] `cd sdk/go && go test ./...`
- [x] REST transport conformance against `sdk/testdata/public_conformance/client_cases.json`
- [x] Bearer rotation, unauthenticated auth, cancellation, and address validation tests
- [ ] CI green on PR
- [ ] `sdkgen --check` (local buf version pin may differ; CI is source of truth)


Made with [Cursor](https://cursor.com)