### PR TITLE
Harden v2 session cookie lifting when Authorization is malformed.

### DIFF
--- a/docs/content/client/web.mdx
+++ b/docs/content/client/web.mdx
@@ -51,8 +51,10 @@ directory at the configured mount path.
   `GESTALT_BUILD_STATIC` during preparation.
 - `gestaltd serve --locked` serves prepared `static/` artifacts; local `run:`
   commands enable hot reload through the gestaltd dev proxy.
-- App frontends call the same `/api/v1` and `/mcp` surfaces as the CLI; there
-  is no separate app-local browser API.
+- Browser app UIs use the Gestalt web SDK with `session()` and call app operations
+  on `/api/v2` with `credentials: "include"` (HttpOnly `session_token` cookie).
+- Management and login routes remain on `/api/v1`; MCP is available at `/mcp`.
+  There is no separate app-local browser API.
 
 For packaging and release, see
 [Applications](/applications) and

--- a/gestaltd/internal/server/public_rest.go
+++ b/gestaltd/internal/server/public_rest.go
@@ -29,7 +29,9 @@ func buildPublicGateway(cfg publicGRPCConfig) (*publicrpc.InProcessConn, http.Ha
 	return conn, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		token, err := requestBearerTokenPreferringHeader(r)
 		if err == nil && token != "" {
-			if headerToken, headerErr := requestBearerToken(r); headerErr == nil && headerToken == "" {
+			headerToken, _ := requestBearerToken(r)
+			// Preserve an explicit bearer; otherwise lift session_token when the header is absent or malformed.
+			if headerToken == "" {
 				r.Header.Set("Authorization", "Bearer "+token)
 			}
 		}

--- a/gestaltd/internal/server/public_rest_test.go
+++ b/gestaltd/internal/server/public_rest_test.go
@@ -257,6 +257,52 @@ func TestPublicRESTRouting(t *testing.T) {
 		}
 	})
 
+	t.Run("malformed authorization header with session cookie authenticates", func(t *testing.T) {
+		t.Parallel()
+
+		const cookieToken = "public-rest-cookie-token"
+		ts := startPublicRESTServer(t, server.RouteProfilePublic, func(cfg *server.Config) {
+			auth := authStubWithSessionTokenIntrospect(cookieToken, principal.UserSubjectID("cookie-user"), "example")
+			cfg.Auth = auth
+			cfg.PublicGatewayTransport.SetIdentityProvider(auth)
+			cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+				N:        "example",
+				ConnMode: core.ConnectionModeNone,
+				CatalogVal: &catalog.Catalog{
+					Name: "example",
+					Operations: []catalog.CatalogOperation{{
+						ID:     "sync",
+						Method: "POST",
+					}},
+				},
+				ExecuteFn: func(_ context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
+					return &core.OperationResult{Status: http.StatusOK, Body: []byte("ok")}, nil
+				},
+			})
+		})
+
+		req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/v2/app/example/operations/sync", bytes.NewReader([]byte(`{"params":{}}`)))
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "not-a-bearer-token")
+		req.AddCookie(&http.Cookie{Name: "session_token", Value: cookieToken})
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("POST invoke: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("ReadAll: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want %d (body=%s)", resp.StatusCode, http.StatusOK, string(body))
+		}
+	})
+
 	t.Run("explicit bearer wins over session cookie", func(t *testing.T) {
 		t.Parallel()
 

--- a/sdk/typescript-web/src/vite.js
+++ b/sdk/typescript-web/src/vite.js
@@ -44,6 +44,9 @@ function devBinding(port) {
 }
 
 const DEFAULT_DEV_API_PROXY_TARGET = "http://127.0.0.1:8080";
+// Injects a bearer on proxied /api/* requests when the browser did not send Authorization.
+// Unset this when testing browser session auth (session() + session_token cookie): v2 prefers
+// a valid bearer over the cookie, so a stale proxy token can mask cookie-based identity.
 const DEV_API_PROXY_TOKEN_ENV = "GESTALT_DEV_API_PROXY_TOKEN";
 
 /**


### PR DESCRIPTION
Lift session_token when the bearer header is absent or invalid without changing explicit bearer precedence, and document dev proxy token behavior.