### PR TITLE
gestalt-web alpha.2 browser ergonomics for Toolshed migration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,6 +143,7 @@ Release workflows use scoped tags:
 - Python SDK: `sdk/python/v<version>`
 - Rust SDK: `sdk/rust/v<version>`
 - TypeScript SDK: `sdk/typescript/v<version>`
+- TypeScript Web SDK: `sdk/typescript-web/v<version>`
 - Apps: `plugin/<plugin>/v<version>`
 
 Keep the bare semantic version aligned across artifacts when they are meant to ship together.

--- a/sdk/tools/sdkgen/internal/emit/ts/public_render.go
+++ b/sdk/tools/sdkgen/internal/emit/ts/public_render.go
@@ -110,6 +110,7 @@ func renderPublicTypes(view *publicsurface.View, paths PublicImports) string {
 
 	imports := map[string]map[string]bool{}
 	var blocks []string
+	useSparseInit := paths.FixedNativeModule != ""
 
 	for _, svc := range view.Services {
 		for _, m := range svc.PublicMethods {
@@ -124,21 +125,19 @@ func renderPublicTypes(view *publicsurface.View, paths PublicImports) string {
 				imports[base] = map[string]bool{}
 			}
 			imports[base][native] = true
-			if len(omit) == 0 {
-				blocks = append(blocks, fmt.Sprintf("export type %s = %s;", typeName, native))
-				continue
+			typeExpr := native
+			if len(omit) > 0 {
+				sort.Strings(omit)
+				quoted := make([]string, len(omit))
+				for i, name := range omit {
+					quoted[i] = fmt.Sprintf("%q", publicJSONFieldName(m.Input, name))
+				}
+				typeExpr = fmt.Sprintf("Omit<%s, %s>", native, strings.Join(quoted, " | "))
 			}
-			sort.Strings(omit)
-			quoted := make([]string, len(omit))
-			for i, name := range omit {
-				quoted[i] = fmt.Sprintf("%q", publicJSONFieldName(m.Input, name))
+			if useSparseInit {
+				typeExpr = fmt.Sprintf("Init<%s>", typeExpr)
 			}
-			blocks = append(blocks, fmt.Sprintf(
-				"export type %s = Omit<%s, %s>;",
-				typeName,
-				native,
-				strings.Join(quoted, " | "),
-			))
+			blocks = append(blocks, fmt.Sprintf("export type %s = %s;", typeName, typeExpr))
 		}
 	}
 
@@ -146,7 +145,10 @@ func renderPublicTypes(view *publicsurface.View, paths PublicImports) string {
 		names := sortedPublicKeys(imports[base])
 		fmt.Fprintf(&b, "import type { %s } from %s;\n", strings.Join(names, ", "), paths.nativeTypeImportQuoted(base))
 	}
-	if len(imports) > 0 {
+	if useSparseInit {
+		fmt.Fprintf(&b, "import type { Init } from %s;\n", paths.supportModuleQuoted("rpc_support.ts"))
+	}
+	if len(imports) > 0 || useSparseInit {
 		b.WriteString("\n")
 	}
 	b.WriteString(strings.Join(blocks, "\n\n"))
@@ -421,7 +423,7 @@ func renderPublicAppClientMethod(b *strings.Builder, svc *model.Service, m *mode
 		fmt.Fprintf(b, "  async %s<T = unknown>(request: %s, callOptions?: PublicUnaryCallOptions): Promise<T> {\n", methodKey, typeName)
 		appField := publicJSONResultAppField(m)
 		fmt.Fprintf(b, "    const response = await this.%sRaw(request, callOptions);\n", methodKey)
-		fmt.Fprintf(b, "    return decodeAppResult<T>(request.%s, request.operation, response);\n", appField)
+		fmt.Fprintf(b, "    return decodeAppResult<T>(request.%s ?? \"\", request.operation ?? \"\", response);\n", appField)
 		b.WriteString("  }\n\n")
 		return
 	}

--- a/sdk/tools/sdkgen/internal/emit/ts/public_render_test.go
+++ b/sdk/tools/sdkgen/internal/emit/ts/public_render_test.go
@@ -8,6 +8,99 @@ import (
 	"github.com/valon-technologies/gestalt/sdk/tools/sdkgen/internal/publicsurface"
 )
 
+func TestRenderPublicTypesWebUsesSparseInit(t *testing.T) {
+	t.Parallel()
+
+	input := &model.Message{
+		FullName:  "gestalt.provider.v1.AppInvokeRequest",
+		Name:      "AppInvokeRequest",
+		ProtoFile: "sdk/proto/v1/app.proto",
+		Fields: []*model.Field{
+			{Name: "app", JSONName: "app", Kind: model.KindScalar, Scalar: model.ScalarString},
+			{Name: "operation", JSONName: "operation", Kind: model.KindScalar, Scalar: model.ScalarString},
+			{Name: "connection", JSONName: "connection", Kind: model.KindScalar, Scalar: model.ScalarString},
+			{Name: "instance", JSONName: "instance", Kind: model.KindScalar, Scalar: model.ScalarString},
+			{Name: "idempotency_key", JSONName: "idempotencyKey", Kind: model.KindScalar, Scalar: model.ScalarString},
+			{Name: "credential_mode", JSONName: "credentialMode", Kind: model.KindScalar, Scalar: model.ScalarString},
+		},
+	}
+	graphqlInput := &model.Message{
+		FullName:  "gestalt.provider.v1.AppInvokeGraphQLRequest",
+		Name:      "AppInvokeGraphQLRequest",
+		ProtoFile: "sdk/proto/v1/app.proto",
+		Fields: []*model.Field{
+			{Name: "app", JSONName: "app", Kind: model.KindScalar, Scalar: model.ScalarString},
+			{Name: "query", JSONName: "query", Kind: model.KindScalar, Scalar: model.ScalarString},
+			{Name: "context", JSONName: "context", Kind: model.KindMessage},
+		},
+	}
+	view := &publicsurface.View{
+		Services: []*publicsurface.Service{{
+			Service: &model.Service{
+				FullName:  "gestalt.provider.v1.App",
+				Name:      "App",
+				ProtoFile: "sdk/proto/v1/app.proto",
+			},
+			PublicMethods: []*model.Method{
+				{
+					Name:  "Invoke",
+					Input: input,
+				},
+				{
+					Name:  "InvokeGraphQL",
+					Input: graphqlInput,
+				},
+			},
+		}},
+	}
+
+	out := renderPublicTypes(view, WebPublicImports())
+	for _, want := range []string{
+		`import type { Init } from "../runtime/rpc_support.ts"`,
+		"export type PublicAppInvokeRequest = Init<AppInvokeRequest>",
+		"export type PublicAppInvokeGraphQLRequest = Init<AppInvokeGraphQLRequest>",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in web public types:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "Partial<Pick<") {
+		t.Fatalf("web public types must not use field-specific Partial overrides:\n%s", out)
+	}
+}
+
+func TestRenderPublicTypesServerDoesNotUseSparseInit(t *testing.T) {
+	t.Parallel()
+
+	input := &model.Message{
+		FullName:  "gestalt.provider.v1.AppInvokeRequest",
+		Name:      "AppInvokeRequest",
+		ProtoFile: "sdk/proto/v1/app.proto",
+		Fields: []*model.Field{
+			{Name: "app", JSONName: "app", Kind: model.KindScalar, Scalar: model.ScalarString},
+			{Name: "operation", JSONName: "operation", Kind: model.KindScalar, Scalar: model.ScalarString},
+		},
+	}
+	view := &publicsurface.View{
+		Services: []*publicsurface.Service{{
+			Service: &model.Service{
+				FullName:  "gestalt.provider.v1.App",
+				Name:      "App",
+				ProtoFile: "sdk/proto/v1/app.proto",
+			},
+			PublicMethods: []*model.Method{{
+				Name:  "Invoke",
+				Input: input,
+			}},
+		}},
+	}
+
+	out := renderPublicTypes(view, ServerPublicImports())
+	if strings.Contains(out, "Init<") {
+		t.Fatalf("server public types must not use Init:\n%s", out)
+	}
+}
+
 func TestRenderPublicConvertersAlwaysEmitWireMessages(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/typescript-web/CHANGELOG.md
+++ b/sdk/typescript-web/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+## 0.0.1-alpha.2
+
+### Breaking changes
+
+- `InvokeError.code` is removed. Operation-envelope failures now expose
+  `InvokeError.reason` (the wire `error.code` value) alongside the inherited
+  `GestaltError.code` transport classification.
+
+### Added
+
+- `bindApp(client, app)` returns an app-scoped client that accepts only
+  `{ operation, params?, ... }` invoke requests.
+- Web public request types use sparse `Init<T>` construction so transport
+  metadata fields are optional on invoke and GraphQL requests.
+
+### Fixed
+
+- Sparse JSON sanitization before protobuf Struct encoding.
+- Hardened v2 session cookie lifting when `Authorization` is malformed.
+- Documented Vite proxy-token behavior for local development.

--- a/sdk/typescript-web/package.json
+++ b/sdk/typescript-web/package.json
@@ -52,7 +52,7 @@
   },
   "peerDependencies": {
     "typescript": "^5.9.0",
-    "vite": "^5.4.0 || ^6.0.0 || ^7.0.0"
+    "vite": "^5.4.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "peerDependenciesMeta": {
     "vite": {

--- a/sdk/typescript-web/src/client.ts
+++ b/sdk/typescript-web/src/client.ts
@@ -4,9 +4,15 @@
  * @module client
  */
 
+import type { JsonObject } from "@bufbuild/protobuf";
+
 import { normalizeAddress } from "./address.ts";
 import { AppClient } from "./client/generated/app_client.ts";
-import type { UnaryTransport } from "./client/generated/unary_transport.ts";
+import type { PublicAppInvokeRequest } from "./client/generated/types.ts";
+import type {
+  PublicUnaryCallOptions,
+  UnaryTransport,
+} from "./client/generated/unary_transport.ts";
 import { createRestUnaryTransport } from "./rest_transport.ts";
 
 export interface SessionAuth {
@@ -35,6 +41,29 @@ export interface GestaltClient {
   readonly address: string;
   readonly app: AppClient;
 }
+
+/** App-scoped invoke params: bind the app name once, pass only operation + params. */
+export type BoundAppInvokeRequest = Omit<PublicAppInvokeRequest, "app">;
+
+export interface BoundAppClient {
+  invoke<T = unknown>(
+    request: BoundAppInvokeRequest,
+    callOptions?: PublicUnaryCallOptions,
+  ): Promise<T>;
+}
+
+export function bindApp(client: GestaltClient, app: string): BoundAppClient {
+  return {
+    invoke<T>(
+      request: BoundAppInvokeRequest,
+      callOptions?: PublicUnaryCallOptions,
+    ): Promise<T> {
+      return client.app.invoke<T>({ ...request, app }, callOptions);
+    },
+  };
+}
+
+export type { JsonObject };
 
 export function session(): SessionAuth {
   return { kind: "session" };

--- a/sdk/typescript-web/src/client/generated/app_client.ts
+++ b/sdk/typescript-web/src/client/generated/app_client.ts
@@ -55,7 +55,11 @@ export class AppClient {
     callOptions?: PublicUnaryCallOptions,
   ): Promise<T> {
     const response = await this.invokeRaw(request, callOptions);
-    return decodeAppResult<T>(request.app, request.operation, response);
+    return decodeAppResult<T>(
+      request.app ?? "",
+      request.operation ?? "",
+      response,
+    );
   }
 
   async invokeGraphQL(

--- a/sdk/typescript-web/src/client/generated/types.ts
+++ b/sdk/typescript-web/src/client/generated/types.ts
@@ -10,13 +10,12 @@ import type {
   AppInvokeGraphQLRequest,
   AppInvokeRequest,
 } from "../runtime/native-types.ts";
+import type { Init } from "../runtime/rpc_support.ts";
 
-export type PublicAppInvokeRequest = Omit<
-  AppInvokeRequest,
-  "context" | "runAs"
+export type PublicAppInvokeRequest = Init<
+  Omit<AppInvokeRequest, "context" | "runAs">
 >;
 
-export type PublicAppInvokeGraphQLRequest = Omit<
-  AppInvokeGraphQLRequest,
-  "context"
+export type PublicAppInvokeGraphQLRequest = Init<
+  Omit<AppInvokeGraphQLRequest, "context">
 >;

--- a/sdk/typescript-web/src/index.ts
+++ b/sdk/typescript-web/src/index.ts
@@ -16,13 +16,17 @@
 
 export {
   bearer,
+  bindApp,
   createGestaltClient,
   session,
   unauthenticated,
   type Auth,
   type BearerAuth,
+  type BoundAppClient,
+  type BoundAppInvokeRequest,
   type ClientOptions,
   type GestaltClient,
+  type JsonObject,
   type SessionAuth,
   type Unauthenticated,
 } from "./client.ts";

--- a/sdk/typescript-web/tests/bind-app.test.ts
+++ b/sdk/typescript-web/tests/bind-app.test.ts
@@ -1,0 +1,85 @@
+import { expect, test } from "bun:test";
+
+import { bindApp, bearer, createGestaltClient } from "../src/client.ts";
+
+test("bindApp scopes invoke requests to one app name", async () => {
+  let requestUrl = "";
+  let body = "";
+  const client = createGestaltClient({
+    address: "https://gestalt.test",
+    auth: bearer(() => "token"),
+    fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
+      requestUrl = String(input);
+      body = typeof init?.body === "string" ? init.body : "";
+      return new Response(
+        JSON.stringify({
+          status: 200,
+          body: btoa(JSON.stringify({ status: "success", data: { ok: true } })),
+          headers: {},
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as unknown as typeof fetch,
+  });
+
+  const helloWorld = bindApp(client, "helloWorld");
+  await expect(
+    helloWorld.invoke({ operation: "greet", params: { name: "Ada" } }),
+  ).resolves.toEqual({ ok: true });
+  expect(requestUrl).toBe(
+    "https://gestalt.test/api/v2/app/helloWorld/operations/greet",
+  );
+  expect(JSON.parse(body)).toEqual({ params: { name: "Ada" } });
+});
+
+test("bindApp keeps the bound app when request carries an app field", async () => {
+  let requestUrl = "";
+  const client = createGestaltClient({
+    address: "https://gestalt.test",
+    auth: bearer(() => "token"),
+    fetch: (async (input: RequestInfo | URL) => {
+      requestUrl = String(input);
+      return new Response(
+        JSON.stringify({
+          status: 200,
+          body: btoa(JSON.stringify({ status: "success", data: true })),
+          headers: {},
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as unknown as typeof fetch,
+  });
+
+  const bound = bindApp(client, "correctApp");
+  await bound.invoke({
+    app: "wrongApp",
+    operation: "sync",
+  } as Parameters<typeof bound.invoke>[0]);
+  expect(requestUrl).toBe(
+    "https://gestalt.test/api/v2/app/correctApp/operations/sync",
+  );
+});
+
+test("PublicAppInvokeRequest omits optional transport metadata fields", async () => {
+  const client = createGestaltClient({
+    address: "https://gestalt.test",
+    auth: bearer(() => "token"),
+    fetch: (async () =>
+      new Response(
+        JSON.stringify({
+          status: 200,
+          body: btoa(JSON.stringify({ status: "success", data: true })),
+          headers: {},
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      )) as unknown as typeof fetch,
+  });
+
+  await expect(
+    client.app.invoke({
+      app: "example",
+      operation: "sync",
+      params: { ok: true },
+    }),
+  ).resolves.toBe(true);
+});

--- a/sdk/typescript-web/tests/client-conformance.test.ts
+++ b/sdk/typescript-web/tests/client-conformance.test.ts
@@ -81,8 +81,8 @@ test("REST transport surfaces platform errors from gateway responses", async () 
   });
 
   const request = create(AppInvokeRequestSchema, {
-    app: platformCase.publicRequest.app,
-    operation: platformCase.publicRequest.operation,
+    app: platformCase.publicRequest.app ?? "",
+    operation: platformCase.publicRequest.operation ?? "",
     params: platformCase.publicRequest.params ?? {},
     connection: "",
     instance: "",

--- a/sdk/typescript-web/tests/client-consumer.test.ts
+++ b/sdk/typescript-web/tests/client-consumer.test.ts
@@ -16,6 +16,13 @@ test("web client auth helpers are available", () => {
   expect(unauthenticated()).toEqual({ kind: "unauthenticated" });
 });
 
+test("package.json declares Vite 8 in peerDependencies", async () => {
+  const pkg = await Bun.file(
+    new URL("../package.json", import.meta.url),
+  ).json();
+  expect(pkg.peerDependencies.vite).toContain("^8.0.0");
+});
+
 test("generated AppClient and error types are exported from gestalt-web", () => {
   expect(AppClient).toBeDefined();
   expect(GestaltError).toBeDefined();

--- a/sdk/typescript-web/tests/rest-transport.test.ts
+++ b/sdk/typescript-web/tests/rest-transport.test.ts
@@ -1,5 +1,6 @@
 import { create } from "@bufbuild/protobuf";
 import { expect, test } from "bun:test";
+import type { JsonObject } from "@bufbuild/protobuf";
 
 import {
   AppInvokeRequestSchema,
@@ -579,4 +580,191 @@ test("createGestaltClient validates explicit addresses", () => {
       auth: unauthenticated(),
     }),
   ).toThrow(/http or https/);
+});
+
+test("REST transport omits undefined optional params from sparse JSON bodies", async () => {
+  const bodies: string[] = [];
+  const client = createGestaltClient({
+    address: "https://gestalt.test/",
+    auth: bearer(() => "token"),
+    fetch: (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      bodies.push(typeof init?.body === "string" ? init.body : "");
+      return new Response(
+        JSON.stringify({ status: 200, body: "", headers: {} }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as unknown as typeof fetch,
+  });
+
+  await client.app.invokeRaw({
+    app: "example",
+    operation: "list",
+    params: {
+      nested: { keep: true, drop: undefined },
+      cursor: undefined,
+      page: 1,
+    } as unknown as JsonObject,
+  });
+
+  expect(JSON.parse(bodies[0] ?? "{}")).toEqual({
+    params: { nested: { keep: true }, page: 1 },
+  });
+});
+
+test("REST transport maps 403 gateway errors to PermissionDenied", async () => {
+  const transport = createRestUnaryTransport({
+    baseUrl: "https://gestalt.test/",
+    auth: bearer(() => "token"),
+    fetch: (async () =>
+      new Response(
+        JSON.stringify({ error: "forbidden", code: "PermissionDenied" }),
+        { status: 403, headers: { "Content-Type": "application/json" } },
+      )) as unknown as typeof fetch,
+  });
+
+  const request = create(AppInvokeRequestSchema, {
+    app: "example",
+    operation: "sync",
+    params: {},
+    connection: "",
+    instance: "",
+    idempotencyKey: "",
+    credentialMode: "",
+  });
+
+  await expect(
+    transport.unary(
+      PUBLIC_METHODS.app.invoke,
+      request,
+      AppInvokeRequestSchema,
+      OperationResultSchema,
+    ),
+  ).rejects.toMatchObject({
+    name: "GestaltError",
+    code: GestaltErrorCode.PermissionDenied,
+    message: "forbidden",
+  });
+});
+
+test("REST transport maps offline fetch failures to Unavailable", async () => {
+  const transport = createRestUnaryTransport({
+    baseUrl: "https://gestalt.test/",
+    auth: bearer(() => "token"),
+    fetch: (async () => {
+      throw new TypeError("Failed to fetch");
+    }) as unknown as typeof fetch,
+  });
+
+  const request = create(AppInvokeRequestSchema, {
+    app: "example",
+    operation: "sync",
+    params: {},
+    connection: "",
+    instance: "",
+    idempotencyKey: "",
+    credentialMode: "",
+  });
+
+  await expect(
+    transport.unary(
+      PUBLIC_METHODS.app.invoke,
+      request,
+      AppInvokeRequestSchema,
+      OperationResultSchema,
+    ),
+  ).rejects.toMatchObject({
+    name: "GestaltError",
+    code: GestaltErrorCode.Unavailable,
+  });
+});
+
+test("REST transport rejects malformed success JSON bodies", async () => {
+  const transport = createRestUnaryTransport({
+    baseUrl: "https://gestalt.test/",
+    auth: bearer(() => "token"),
+    fetch: (async () =>
+      new Response("not-json", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })) as unknown as typeof fetch,
+  });
+
+  const request = create(AppInvokeRequestSchema, {
+    app: "example",
+    operation: "sync",
+    params: {},
+    connection: "",
+    instance: "",
+    idempotencyKey: "",
+    credentialMode: "",
+  });
+
+  await expect(
+    transport.unary(
+      PUBLIC_METHODS.app.invoke,
+      request,
+      AppInvokeRequestSchema,
+      OperationResultSchema,
+    ),
+  ).rejects.toThrow();
+});
+
+test("REST transport accepts empty 204 success responses", async () => {
+  const transport = createRestUnaryTransport({
+    baseUrl: "https://gestalt.test/",
+    auth: bearer(() => "token"),
+    fetch: (async () => new Response(null, { status: 204 })) as unknown as typeof fetch,
+  });
+
+  const request = create(AppInvokeRequestSchema, {
+    app: "example",
+    operation: "sync",
+    params: {},
+    connection: "",
+    instance: "",
+    idempotencyKey: "",
+    credentialMode: "",
+  });
+
+  await expect(
+    transport.unary(
+      PUBLIC_METHODS.app.invoke,
+      request,
+      AppInvokeRequestSchema,
+      OperationResultSchema,
+    ),
+  ).resolves.toMatchObject({ status: 0, body: new Uint8Array() });
+});
+
+test("invoke surfaces raw error details through InvokeError", async () => {
+  const client = createGestaltClient({
+    address: "https://gestalt.test",
+    auth: bearer(() => "token"),
+    fetch: (async () =>
+      new Response(
+        JSON.stringify({
+          status: 400,
+          body: btoa(
+            JSON.stringify({
+              status: "error",
+              error: { code: "validation_failed", message: "bad field" },
+            }),
+          ),
+          headers: {},
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      )) as unknown as typeof fetch,
+  });
+
+  await expect(
+    client.app.invoke({
+      app: "example",
+      operation: "sync",
+      params: {},
+    }),
+  ).rejects.toMatchObject({
+    name: "InvokeError",
+    reason: "validation_failed",
+    status: 400,
+  });
 });

--- a/sdk/typescript/src/client/generated/app_client.ts
+++ b/sdk/typescript/src/client/generated/app_client.ts
@@ -55,7 +55,11 @@ export class AppClient {
     callOptions?: PublicUnaryCallOptions,
   ): Promise<T> {
     const response = await this.invokeRaw(request, callOptions);
-    return decodeAppResult<T>(request.app, request.operation, response);
+    return decodeAppResult<T>(
+      request.app ?? "",
+      request.operation ?? "",
+      response,
+    );
   }
 
   async invokeGraphQL(


### PR DESCRIPTION
## Summary

- Make `connection`, `instance`, `idempotencyKey`, and `credentialMode` optional on `PublicAppInvokeRequest` for browser clients; sdkgen preserves the shape on regeneration.
- Add `bindApp(client, app)` so UIs invoke with only `{ operation, params }`.
- Expand REST transport contract tests (sparse JSON, 403, offline, malformed bodies, 204, invoke error details).
- Document alpha.2 in `sdk/typescript-web/CHANGELOG.md` and add `sdk/typescript-web/v<version>` to CONTRIBUTING release tags.

## Test plan

- [x] `bun run check` passes in `sdk/typescript-web`
- [x] `go test ./internal/emit/ts/...` passes for sdkgen web optional-field rendering
- [ ] After merge: tag `sdk/typescript-web/v0.0.1-alpha.2` and verify Release SDK workflow publishes to npm
- [ ] `npm view @valon-technologies/gestalt-web@0.0.1-alpha.2 version` returns alpha.2


Made with [Cursor](https://cursor.com)