### PR TITLE
Export Request.gestalt types from package root

### DIFF
--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -45,6 +45,11 @@ export {
   type SubjectInput,
 } from "./api.ts";
 export {
+  type BoundGestalt,
+  type BoundHostService,
+  type RequestGestaltOptions,
+} from "./bound-gestalt.ts";
+export {
   type JsonInput,
   type JsonObject,
   type JsonObjectInput,


### PR DESCRIPTION
## Summary
- Re-export `BoundGestalt`, `BoundHostService`, and `RequestGestaltOptions` from `src/index.ts` so consumers can import the public `Request.gestalt()` types without reaching into internal modules.
- Extend the existing package entrypoint compile-time test in `schema.test.ts` to import all three types.

## Test plan
- [x] `bun run check` in `sdk/typescript` (150 tests, typecheck clean)


Made with [Cursor](https://cursor.com)