### PR TITLE
Fix writable registry artifacts and admin API authorization

### DIFF
--- a/gestaltd/deploy/helm/gestaltd/templates/deployment.yaml
+++ b/gestaltd/deploy/helm/gestaltd/templates/deployment.yaml
@@ -179,7 +179,6 @@ spec:
               readOnly: true
             - name: gestaltd-state
               mountPath: /etc/gestaltd-state
-              readOnly: true
             {{- else }}
             - name: config
               mountPath: /etc/gestaltd/config.yaml

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1131,7 +1131,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 		Auth:                 auth,
 		SelectedAuthProvider: selectedAuthName,
 		AuthProviders:        authProviders,
-		Authorization:        authorizationProviders.Guarded,
+		Authorization:        authorizationProviders.Raw,
 		Services:             svc,
 		ExtraIndexedDBs:      extraIndexedDBs,
 		ExtraCaches:          extraCaches,

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -1932,8 +1932,8 @@ func TestBootstrapAuthorizationProviderStateUsesProviderGatewayTransport(t *test
 	if guardedProvider.setAuthorizationState != nil {
 		t.Fatal("guarded authorization provider unexpectedly received SetAuthorizationState")
 	}
-	if result.Authorization["authz"] != guardedProvider {
-		t.Fatal("bootstrapped authorization provider is not the guarded runtime authorization provider")
+	if result.Authorization["authz"] != rawProvider {
+		t.Fatal("bootstrapped authorization provider is not the raw runtime authorization provider")
 	}
 	if transportGateway != guardedProvider.transport {
 		t.Fatal("guarded authorization provider was not built with the runtime provider gateway")

--- a/gestaltd/internal/server/mounted_ui.go
+++ b/gestaltd/internal/server/mounted_ui.go
@@ -226,7 +226,7 @@ func (s *Server) authorizeMountedResource(
 		return nil, false
 	}
 
-	access, allowed, err := s.authorizeMountedAppAccess(r.Context(), p, mounted)
+	access, allowed, err := s.authorizeMountedAppAccess(principal.WithPrincipal(r.Context(), p), p, mounted)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to authorize app access")
 		return nil, false


### PR DESCRIPTION
## Summary
- Remove the read-only mount on `/etc/gestaltd-state` in the gestaltd Helm chart when preparation is enabled, so app registry materialization can write under `artifacts/registry-installed`.
- Route server-internal authorization checks (admin UI/API role checks, user-facing `/api/v1/authorization/*`) through the raw authorization provider instead of the guarded provider-gateway client.
- Pass the authenticated principal into the admin authorization context before calling `ListRelationships` / `ListActiveModelResourceTypes`.

## Root cause (auth)
PR #2820 enabled provider-gateway authorization enforcement: guarded authorization RPCs now require a caller principal and `CheckAccess` permission to invoke the authorization provider itself. Server-internal admin role checks were calling the guarded client without bypassing that gate, causing `500 {"error":"failed to authorize app access"}` and `provider gateway: unauthorized` on `/api/v1/authorization/*`.

## Test plan
- [x] `go test ./internal/bootstrap/... -run Authorization`
- [x] `go test ./internal/server/... -run 'AdminAPI|AdminApp'`
- [ ] Deploy to valon-tools dev and verify `POST /admin/api/v1/app-registries/toolshed/apps/g-issues/install` succeeds with API token
- [ ] Verify registry materialization writes manifests under `/etc/gestaltd-state/artifacts/registry-installed/` without manual `kubectl patch`


Made with [Cursor](https://cursor.com)