### PR TITLE
RR-1: origin-keyed credentials.json for CLI and gestaltd

### DIFF
--- a/gestalt/cli/src/api.rs
+++ b/gestalt/cli/src/api.rs
@@ -66,8 +66,8 @@ pub fn encode_path_segment(value: &str) -> String {
 }
 
 pub fn resolve_url(url_override: Option<&str>) -> Result<String> {
-    match find_configured_url(url_override)? {
-        Some(url) => Ok(url),
+    match find_configured_url_with_source(url_override)? {
+        Some((url, _)) => Ok(url),
         None => bail_no_url_configured(),
     }
 }
@@ -100,10 +100,6 @@ pub fn fetch_auth_info(base_url: &str) -> Result<AuthInfo> {
 
 pub fn server_auth_disabled(base_url: &str) -> Result<bool> {
     Ok(!fetch_auth_info(base_url)?.login_supported)
-}
-
-fn find_configured_url(url_override: Option<&str>) -> Result<Option<String>> {
-    Ok(find_configured_url_with_source(url_override)?.map(|(url, _)| url))
 }
 
 fn find_configured_url_with_source(url_override: Option<&str>) -> Result<Option<(String, String)>> {
@@ -205,13 +201,12 @@ impl std::error::Error for ApiError {}
 impl ApiClient {
     pub fn from_env(url_override: Option<&str>) -> Result<Self> {
         let env_api_key = std::env::var(ENV_API_KEY).ok().filter(|v| !v.is_empty());
+        let base_url = resolve_url(url_override)?;
         let stored_credentials = if env_api_key.is_none() {
-            CredentialStore::new()?.load()?
+            CredentialStore::new()?.load_for_origin(&base_url)?
         } else {
             None
         };
-
-        let base_url = resolve_url(url_override)?;
         let (token, source) = match env_api_key {
             Some(key) => (key, TokenSource::EnvVar),
             None => match stored_credentials.as_ref() {

--- a/gestalt/cli/src/commands/auth.rs
+++ b/gestalt/cli/src/commands/auth.rs
@@ -187,16 +187,19 @@ where
         .context("failed to mint CLI API token")?;
 
     let store = CredentialStore::new()?;
-    store.save(&Credentials {
-        api_token: token_result["token"]
-            .as_str()
-            .context("token response missing token field")?
-            .to_string(),
-        api_token_id: token_result["id"]
-            .as_str()
-            .context("token response missing id field")?
-            .to_string(),
-    })?;
+    store.save_for_origin(
+        &base_url,
+        &Credentials {
+            api_token: token_result["token"]
+                .as_str()
+                .context("token response missing token field")?
+                .to_string(),
+            api_token_id: token_result["id"]
+                .as_str()
+                .context("token response missing id field")?
+                .to_string(),
+        },
+    )?;
 
     let _ = send_browser_response(&stream, "Login successful", "You can close this tab.");
     output::print_success("Logged in successfully. Stored CLI API token.");
@@ -227,33 +230,66 @@ fn build_browser_response_html(title: &str, detail: &str) -> String {
     BROWSER_RESPONSE_PAGE.replace("__DATA__", &data)
 }
 
-pub fn logout() -> Result<()> {
+pub fn logout(url_override: Option<&str>) -> Result<()> {
     let store = CredentialStore::new()?;
-    match store.load() {
-        Ok(Some(creds)) => {
-            if let Ok(url) = api::resolve_url(None) {
-                let client = ApiClient::new(&url, &creds.api_token)?;
+    let mut removed = false;
+    let url_result = api::resolve_url(url_override);
+    if let Ok(url) = url_result.as_ref() {
+        match store.load_for_origin(url) {
+            Ok(Some(creds)) => {
+                let client = ApiClient::new(url, &creds.api_token)?;
                 if let Err(err) = client.revoke_api_token(&creds.api_token_id) {
                     output::print_warning(&format!(
                         "Failed to revoke stored CLI token {}: {}",
                         creds.api_token_id, err
                     ));
                 }
-            } else {
-                output::print_warning(&format!(
-                    "Stored CLI token {} has no configured server URL; removing it locally only.",
-                    creds.api_token_id
-                ));
+                store.delete_for_origin(url)?;
+                removed = true;
             }
+            Err(err) => {
+                output::print_warning(&format!(
+                    "Stored credentials could not be read; removing them locally without remote revoke: {}",
+                    err
+                ));
+                store.delete_file()?;
+                removed = true;
+            }
+            Ok(None) => {}
         }
-        Ok(None) => {}
-        Err(err) => output::print_warning(&format!(
-            "Stored credentials could not be read; removing them locally without remote revoke: {}",
-            err
-        )),
     }
-    store.delete()?;
-    output::print_success("Logged out. Credentials removed.");
+
+    if !removed {
+        match store.take_legacy_credentials_without_config_url() {
+            Ok(Some(_legacy)) => {
+                output::print_warning(
+                    "Legacy credentials have no configured server URL; removing locally without remote revoke.",
+                );
+                store.delete_file()?;
+                removed = true;
+            }
+            Err(err) => {
+                output::print_warning(&format!(
+                    "Stored credentials could not be read; removing them locally without remote revoke: {}",
+                    err
+                ));
+                store.delete_file()?;
+                removed = true;
+            }
+            Ok(None) if url_result.is_err() => {
+                output::print_warning(
+                    "No configured server URL; cannot determine which stored credentials to remove.",
+                );
+            }
+            Ok(None) => {}
+        }
+    }
+
+    if removed {
+        output::print_success("Logged out. Credentials removed.");
+    } else {
+        output::print_success("Logged out.");
+    }
     Ok(())
 }
 
@@ -266,9 +302,21 @@ pub fn status(url_override: Option<&str>, format: Format) -> Result<()> {
     });
 
     let has_env_key = api::env_api_key_is_set();
-    let (has_stored_credentials, stored_credentials_error) = match CredentialStore::new()?.load() {
-        Ok(Some(_)) => (true, None),
-        Ok(None) => (false, None),
+    let credential_origin = server_config
+        .as_ref()
+        .map(|(url, _)| crate::credentials::normalize_origin(url));
+    let (has_stored_credentials, stored_credentials_error) = match CredentialStore::new() {
+        Ok(store) => match &credential_origin {
+            Some(origin) => match store.load_for_origin(origin) {
+                Ok(Some(_)) => (true, None),
+                Ok(None) => (false, None),
+                Err(err) => (false, Some(err.to_string())),
+            },
+            None => match store.has_any_stored_credentials() {
+                Ok(has) => (has, None),
+                Err(err) => (false, Some(err.to_string())),
+            },
+        },
         Err(err) => (false, Some(err.to_string())),
     };
     let configured = has_env_key || has_stored_credentials;
@@ -297,6 +345,7 @@ pub fn status(url_override: Option<&str>, format: Format) -> Result<()> {
                 "source": source,
                 "envVarSet": has_env_key,
                 "storedCredentials": has_stored_credentials,
+                "credentialOrigin": credential_origin,
                 "serverUrl": server_url,
                 "urlSource": url_source,
                 "serverReachable": reachable,

--- a/gestalt/cli/src/credentials.rs
+++ b/gestalt/cli/src/credentials.rs
@@ -1,17 +1,32 @@
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+use crate::config::ConfigStore;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Credentials {
     pub api_token: String,
     pub api_token_id: String,
 }
 
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CredentialsFile {
+    #[serde(default)]
+    pub servers: BTreeMap<String, Credentials>,
+}
+
 pub struct CredentialStore {
     path: PathBuf,
+}
+
+enum RawCredentialsFile {
+    New(CredentialsFile),
+    Legacy(Credentials),
 }
 
 impl CredentialStore {
@@ -22,36 +37,183 @@ impl CredentialStore {
         })
     }
 
-    pub fn load(&self) -> Result<Option<Credentials>> {
-        match fs::read_to_string(&self.path) {
-            Ok(json) => {
-                let creds: Credentials =
-                    serde_json::from_str(&json).context("failed to parse credentials file")?;
-                Ok(Some(creds))
+    pub fn load_for_origin(&self, origin: &str) -> Result<Option<Credentials>> {
+        let origin = normalize_origin(origin);
+        let Some(raw) = self.read_raw()? else {
+            return Ok(None);
+        };
+        Ok(match raw {
+            RawCredentialsFile::New(file) => file
+                .servers
+                .get(&origin)
+                .filter(|creds| !creds.api_token.trim().is_empty())
+                .cloned(),
+            RawCredentialsFile::Legacy(legacy) => Self::legacy_for_origin(&legacy, &origin),
+        })
+    }
+
+    pub fn save_for_origin(&self, origin: &str, credentials: &Credentials) -> Result<()> {
+        let origin = normalize_origin(origin);
+        let mut file = match self.read_raw()? {
+            None => CredentialsFile::default(),
+            Some(raw) => match raw {
+                RawCredentialsFile::New(file) => file,
+                RawCredentialsFile::Legacy(legacy) => self.migrate_legacy_credentials(legacy)?,
+            },
+        };
+        file.servers.insert(origin, credentials.clone());
+        self.write_credentials_file(&file)
+    }
+
+    pub fn delete_for_origin(&self, origin: &str) -> Result<()> {
+        let origin = normalize_origin(origin);
+        let Some(raw) = self.read_raw()? else {
+            return Ok(());
+        };
+        match raw {
+            RawCredentialsFile::New(mut file) => {
+                if file.servers.is_empty() {
+                    return Ok(());
+                }
+                file.servers.remove(&origin);
+                if file.servers.is_empty() {
+                    self.delete_file()
+                } else {
+                    self.write_credentials_file(&file)
+                }
             }
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
-            Err(e) => Err(anyhow::anyhow!(e).context("failed to read credentials file")),
+            RawCredentialsFile::Legacy(legacy) => {
+                if Self::legacy_for_origin(&legacy, &origin).is_some() {
+                    self.delete_file()
+                } else {
+                    Ok(())
+                }
+            }
         }
     }
 
-    pub fn save(&self, credentials: &Credentials) -> Result<()> {
+    pub fn has_any_stored_credentials(&self) -> Result<bool> {
+        let Some(raw) = self.read_raw()? else {
+            return Ok(false);
+        };
+        Ok(match raw {
+            RawCredentialsFile::New(file) => file
+                .servers
+                .values()
+                .any(|creds| !creds.api_token.trim().is_empty()),
+            RawCredentialsFile::Legacy(_) => false,
+        })
+    }
+
+    fn legacy_for_origin(legacy: &Credentials, origin: &str) -> Option<Credentials> {
+        if legacy.api_token.trim().is_empty() {
+            return None;
+        }
+        let url = Self::configured_origin_url()?;
+        if normalize_origin(&url) == origin {
+            Some(legacy.clone())
+        } else {
+            None
+        }
+    }
+
+    fn migrate_legacy_credentials(&self, legacy: Credentials) -> Result<CredentialsFile> {
+        if legacy.api_token.trim().is_empty() {
+            return Err(anyhow::anyhow!(
+                "failed to parse credentials file: unrecognized credentials file format"
+            ));
+        }
+        let Some(url) = Self::configured_origin_url() else {
+            return Ok(CredentialsFile::default());
+        };
+        let origin = normalize_origin(&url);
+        let mut file = CredentialsFile::default();
+        file.servers.insert(origin, legacy);
+        self.write_credentials_file(&file)?;
+        Ok(file)
+    }
+
+    fn configured_origin_url() -> Option<String> {
+        let store = ConfigStore::new().ok()?;
+        store.get("url").ok().flatten()
+    }
+
+    pub fn take_legacy_credentials_without_config_url(&self) -> Result<Option<Credentials>> {
+        if Self::configured_origin_url().is_some() {
+            return Ok(None);
+        }
+        Ok(match self.read_raw()? {
+            Some(RawCredentialsFile::Legacy(legacy)) => Some(legacy),
+            _ => None,
+        })
+    }
+
+    fn read_raw(&self) -> Result<Option<RawCredentialsFile>> {
+        let json = match fs::read_to_string(&self.path) {
+            Ok(json) => json,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => return Err(anyhow::anyhow!(e).context("failed to read credentials file")),
+        };
+
+        let value: Value =
+            serde_json::from_str(&json).context("failed to parse credentials file")?;
+        if value.get("servers").is_some() {
+            let file: CredentialsFile =
+                serde_json::from_value(value).context("failed to parse credentials file")?;
+            return Ok(Some(RawCredentialsFile::New(file)));
+        }
+
+        let creds: Credentials =
+            serde_json::from_str(&json).context("failed to parse credentials file")?;
+        if creds.api_token.trim().is_empty() {
+            return Err(anyhow::anyhow!(
+                "failed to parse credentials file: unrecognized credentials file format"
+            ));
+        }
+        Ok(Some(RawCredentialsFile::Legacy(creds)))
+    }
+
+    fn write_credentials_file(&self, file: &CredentialsFile) -> Result<()> {
         if let Some(parent) = self.path.parent() {
             fs::create_dir_all(parent).context("failed to create config directory")?;
         }
 
-        let json =
-            serde_json::to_string_pretty(credentials).context("failed to serialize credentials")?;
+        let json = serde_json::to_string_pretty(file).context("failed to serialize credentials")?;
         write_secure(&self.path, json.as_bytes())?;
         Ok(())
     }
 
-    pub fn delete(&self) -> Result<()> {
+    pub fn delete_file(&self) -> Result<()> {
         match fs::remove_file(&self.path) {
             Ok(()) => Ok(()),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
             Err(e) => Err(anyhow::anyhow!(e).context("failed to delete credentials file")),
         }
     }
+}
+
+pub fn normalize_origin(origin: &str) -> String {
+    let normalized = crate::api::normalize_url(origin);
+    match url::Url::parse(&normalized) {
+        Ok(parsed) => {
+            let scheme = parsed.scheme().to_ascii_lowercase();
+            let Some(host) = parsed.host_str() else {
+                return normalized;
+            };
+            let host = host.to_ascii_lowercase();
+            let authority = match parsed.port() {
+                Some(port) if !is_default_origin_port(&scheme, port) => format!("{host}:{port}"),
+                _ => host,
+            };
+            let out = format!("{scheme}://{authority}");
+            out
+        }
+        Err(_) => normalized,
+    }
+}
+
+fn is_default_origin_port(scheme: &str, port: u16) -> bool {
+    matches!((scheme, port), ("https", 443) | ("http", 80))
 }
 
 #[cfg(unix)]

--- a/gestalt/cli/src/main.rs
+++ b/gestalt/cli/src/main.rs
@@ -22,7 +22,7 @@ fn run() -> anyhow::Result<()> {
     match command {
         Commands::Auth { command } => match command {
             AuthCommands::Login => commands::auth::login(url),
-            AuthCommands::Logout => commands::auth::logout(),
+            AuthCommands::Logout => commands::auth::logout(url),
             AuthCommands::Status => commands::auth::status(url, format),
             AuthCommands::Token { command } => dispatch_token_command(command, url, format),
         },

--- a/gestalt/cli/tests/auth_flow.rs
+++ b/gestalt/cli/tests/auth_flow.rs
@@ -34,6 +34,7 @@ fn test_auth_login_stores_credentials_and_serves_browser_callback_page() {
         std::env::set_var(gestalt::api::ENV_API_KEY, "env-token");
     }
     let server = spawn_login_server();
+    let base_url = server.base_url.clone();
     let browser = Arc::new(Mutex::new(None));
     let browser_handle = Arc::clone(&browser);
 
@@ -72,8 +73,14 @@ fn test_auth_login_stores_credentials_and_serves_browser_callback_page() {
     let credentials: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(credentials_path).unwrap()).unwrap();
     assert!(credentials.get("api_url").is_none());
-    assert_eq!(credentials["api_token"], "cli-long-secret");
-    assert_eq!(credentials["api_token_id"], "tok-long");
+    assert_eq!(
+        credentials["servers"][&base_url]["api_token"],
+        "cli-long-secret"
+    );
+    assert_eq!(
+        credentials["servers"][&base_url]["api_token_id"],
+        "tok-long"
+    );
 }
 
 #[test]
@@ -143,6 +150,156 @@ fn test_auth_logout_revokes_token_using_configured_url() {
 }
 
 #[test]
+fn test_auth_logout_uses_url_flag_for_per_origin_credentials() {
+    let mut token_server = Server::new();
+    let revoke = authed_json_mock!(
+        token_server,
+        Method::DELETE,
+        "/api/v1/tokens/tok-456",
+        StatusCode::OK
+    )
+    .with_body(r#"{"status":"ok"}"#)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    write_credentials(
+        home.path(),
+        serde_json::json!({
+            "servers": {
+                token_server.url(): {
+                    "api_token": TEST_TOKEN,
+                    "api_token_id": "tok-456",
+                },
+                "https://other.example.test": {
+                    "api_token": "other-token",
+                    "api_token_id": "other-id",
+                }
+            }
+        }),
+    );
+
+    cli_command(home.path())
+        .arg("--url")
+        .arg(token_server.url())
+        .args(["auth", "logout"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Logged out. Credentials removed."))
+        .stderr(predicate::str::contains("Failed to revoke stored CLI token").not());
+
+    revoke.assert();
+
+    let credentials: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(
+            home.path()
+                .join("xdg-config")
+                .join("gestalt")
+                .join("credentials.json"),
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        credentials["servers"]["https://other.example.test"]["api_token"],
+        "other-token"
+    );
+    assert!(credentials["servers"].get(token_server.url()).is_none());
+}
+
+#[test]
+fn test_auth_logout_clears_legacy_credentials_with_url_flag() {
+    let mut token_server = Server::new();
+    let revoke = authed_json_mock!(
+        token_server,
+        Method::DELETE,
+        "/api/v1/tokens/tok-legacy",
+        StatusCode::OK
+    )
+    .with_body(r#"{"status":"ok"}"#)
+    .expect(0)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    write_credentials(
+        home.path(),
+        serde_json::json!({
+            "api_token": TEST_TOKEN,
+            "api_token_id": "tok-legacy",
+        }),
+    );
+
+    cli_command(home.path())
+        .arg("--url")
+        .arg(token_server.url())
+        .args(["auth", "logout"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("without remote revoke"))
+        .stderr(predicate::str::contains("Logged out. Credentials removed."));
+
+    revoke.assert();
+    assert!(
+        !home
+            .path()
+            .join("xdg-config")
+            .join("gestalt")
+            .join("credentials.json")
+            .exists()
+    );
+}
+
+#[test]
+fn test_auth_logout_clears_orphaned_legacy_without_url() {
+    let home = tempfile::tempdir().unwrap();
+    write_credentials(
+        home.path(),
+        serde_json::json!({
+            "api_token": TEST_TOKEN,
+            "api_token_id": "tok-legacy",
+        }),
+    );
+
+    cli_command(home.path())
+        .args(["auth", "logout"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("without remote revoke"))
+        .stderr(predicate::str::contains("Logged out. Credentials removed."));
+
+    assert!(
+        !home
+            .path()
+            .join("xdg-config")
+            .join("gestalt")
+            .join("credentials.json")
+            .exists()
+    );
+}
+
+#[test]
+fn test_auth_logout_without_url_deletes_unreadable_credentials() {
+    let home = tempfile::tempdir().unwrap();
+    let credentials_path = home
+        .path()
+        .join("xdg-config")
+        .join("gestalt")
+        .join("credentials.json");
+    std::fs::create_dir_all(credentials_path.parent().unwrap()).unwrap();
+    std::fs::write(&credentials_path, "not-json").unwrap();
+
+    cli_command(home.path())
+        .args(["auth", "logout"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "removing them locally without remote revoke",
+        ))
+        .stderr(predicate::str::contains("Logged out. Credentials removed."));
+
+    assert!(!credentials_path.exists());
+}
+
+#[test]
 fn test_init_skips_login_when_server_auth_is_disabled() {
     let mut server = Server::new();
     let _auth_info = json_mock!(server, Method::GET, "/api/v1/auth/info", StatusCode::OK)
@@ -174,8 +331,12 @@ fn test_auth_status_reports_auth_disabled_before_stored_credentials() {
     write_credentials(
         home.path(),
         serde_json::json!({
-            "api_token": TEST_TOKEN,
-            "api_token_id": "tok-123",
+            "servers": {
+                server.url(): {
+                    "api_token": TEST_TOKEN,
+                    "api_token_id": "tok-123",
+                }
+            }
         }),
     );
 
@@ -197,8 +358,12 @@ fn test_auth_status_reports_unreachable_server() {
     write_credentials(
         home.path(),
         serde_json::json!({
-            "api_token": TEST_TOKEN,
-            "api_token_id": "tok-123",
+            "servers": {
+                "http://127.0.0.1:1": {
+                    "api_token": TEST_TOKEN,
+                    "api_token_id": "tok-123",
+                }
+            }
         }),
     );
 
@@ -248,4 +413,113 @@ fn test_auth_status_json_includes_server_fields() {
     assert_eq!(json["serverUrl"], serde_json::json!(server.url()));
     assert_eq!(json["urlSource"], serde_json::json!("--url flag"));
     assert_eq!(json["authenticated"], serde_json::json!(false));
+}
+
+#[test]
+fn test_auth_status_without_url_ignores_orphaned_legacy_credentials() {
+    let home = tempfile::tempdir().unwrap();
+    write_credentials(
+        home.path(),
+        serde_json::json!({
+            "api_token": "legacy-token",
+            "api_token_id": "legacy-id",
+        }),
+    );
+
+    let output = cli_command(home.path())
+        .args(["auth", "status", "--format", "json"])
+        .output()
+        .unwrap();
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["storedCredentials"], serde_json::json!(false));
+    assert_eq!(json["authenticated"], serde_json::json!(false));
+}
+
+#[test]
+fn test_auth_status_json_includes_credential_origin() {
+    let mut server = Server::new();
+    let _auth_info = json_mock!(server, Method::GET, "/api/v1/auth/info", StatusCode::OK)
+        .with_body(r#"{"loginSupported":true}"#)
+        .create();
+
+    let home = tempfile::tempdir().unwrap();
+    write_credentials(
+        home.path(),
+        serde_json::json!({
+            "servers": {
+                server.url(): {
+                    "api_token": TEST_TOKEN,
+                    "api_token_id": "tok-123",
+                }
+            }
+        }),
+    );
+
+    let output = cli_command(home.path())
+        .arg("--url")
+        .arg(server.url())
+        .args(["auth", "status", "--format", "json"])
+        .output()
+        .unwrap();
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["credentialOrigin"], serde_json::json!(server.url()));
+    assert_eq!(json["storedCredentials"], serde_json::json!(true));
+}
+
+#[test]
+fn test_auth_login_preserves_other_origin_credentials() {
+    let _lock = env_lock();
+    let tempdir = tempfile::tempdir().unwrap();
+    let _env = EnvGuard::new(tempdir.path());
+    let other_origin = "https://other.example.test";
+    write_credentials(
+        tempdir.path(),
+        serde_json::json!({
+            "servers": {
+                other_origin: {
+                    "api_token": "other-token",
+                    "api_token_id": "other-id",
+                }
+            }
+        }),
+    );
+
+    let server = spawn_login_server();
+    let base_url = server.base_url.clone();
+    let browser = Arc::new(Mutex::new(None));
+    let browser_handle = Arc::clone(&browser);
+
+    gestalt::commands::auth::login_with_browser_opener(Some(&server.base_url), |url| {
+        let url = url.to_string();
+        *browser_handle.lock().unwrap() = Some(std::thread::spawn(move || {
+            reqwest::blocking::get(url).unwrap();
+        }));
+        Ok(())
+    })
+    .unwrap();
+
+    browser
+        .lock()
+        .unwrap()
+        .take()
+        .expect("browser thread missing")
+        .join()
+        .unwrap();
+    server.handle.join().unwrap();
+
+    let credentials_path = gestalt::paths::gestalt_config_dir()
+        .unwrap()
+        .join("credentials.json");
+    let credentials: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(credentials_path).unwrap()).unwrap();
+    assert_eq!(
+        credentials["servers"][other_origin]["api_token"],
+        "other-token"
+    );
+    assert_eq!(
+        credentials["servers"][base_url]["api_token"],
+        "cli-long-secret"
+    );
 }

--- a/gestalt/cli/tests/config_resolution.rs
+++ b/gestalt/cli/tests/config_resolution.rs
@@ -10,13 +10,13 @@ fn test_cli_ignores_legacy_stored_credentials_api_url() {
         .create();
 
     let home = tempfile::tempdir().unwrap();
-    write_cli_credentials(
+    write_credentials(
         home.path(),
-        &format!(
-            r#"{{"api_url":"{}","api_token":"{}","api_token_id":"tok-123"}}"#,
-            server.url(),
-            TEST_TOKEN
-        ),
+        serde_json::json!({
+            "api_url": server.url(),
+            "api_token": TEST_TOKEN,
+            "api_token_id": "tok-123",
+        }),
     );
 
     cli_command(home.path())

--- a/gestalt/cli/tests/credentials_store.rs
+++ b/gestalt/cli/tests/credentials_store.rs
@@ -1,0 +1,272 @@
+mod support;
+
+use std::os::unix::fs::PermissionsExt;
+
+use gestalt::config::ConfigStore;
+use gestalt::credentials::{CredentialStore, Credentials, normalize_origin};
+use serde_json::Value;
+use support::{EnvGuard, env_lock};
+use tempfile::TempDir;
+
+struct TestStore {
+    store: CredentialStore,
+    credentials_path: std::path::PathBuf,
+    _dir: TempDir,
+    _env: EnvGuard,
+    _lock: std::sync::MutexGuard<'static, ()>,
+}
+
+impl TestStore {
+    fn new() -> Self {
+        let _lock = env_lock();
+        let dir = TempDir::new().unwrap();
+        let _env = EnvGuard::new(dir.path());
+        std::fs::create_dir_all(gestalt::paths::gestalt_config_dir().unwrap()).unwrap();
+        let store = CredentialStore::new().unwrap();
+        let credentials_path = gestalt::paths::gestalt_config_dir()
+            .unwrap()
+            .join("credentials.json");
+        Self {
+            store,
+            credentials_path,
+            _dir: dir,
+            _env,
+            _lock,
+        }
+    }
+
+    fn write_config_url(&self, url: &str) {
+        ConfigStore::new().unwrap().set("url", url).unwrap();
+    }
+
+    fn write_raw(&self, json: &str) {
+        std::fs::write(&self.credentials_path, json).unwrap();
+    }
+
+    fn read_raw_json(&self) -> Value {
+        serde_json::from_str(&std::fs::read_to_string(&self.credentials_path).unwrap()).unwrap()
+    }
+
+    fn permissions(&self) -> u32 {
+        std::fs::metadata(&self.credentials_path)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777
+    }
+}
+
+fn sample_credentials(token: &str) -> Credentials {
+    Credentials {
+        api_token: token.to_string(),
+        api_token_id: format!("{token}-id"),
+    }
+}
+
+#[test]
+fn round_trip_new_format() {
+    let test = TestStore::new();
+    let creds = sample_credentials("token-a");
+    test.store
+        .save_for_origin("https://origin-a.example.test", &creds)
+        .unwrap();
+
+    let loaded = test
+        .store
+        .load_for_origin("https://origin-a.example.test/")
+        .unwrap()
+        .unwrap();
+    assert_eq!(loaded, creds);
+
+    let json = test.read_raw_json();
+    assert_eq!(
+        json["servers"]["https://origin-a.example.test"]["api_token"],
+        "token-a"
+    );
+}
+
+#[test]
+fn per_origin_isolation() {
+    let test = TestStore::new();
+    test.store
+        .save_for_origin(
+            "https://origin-a.example.test",
+            &sample_credentials("prod-token"),
+        )
+        .unwrap();
+    test.store
+        .save_for_origin(
+            "https://origin-b.example.test",
+            &sample_credentials("dev-token"),
+        )
+        .unwrap();
+
+    assert_eq!(
+        test.store
+            .load_for_origin("https://origin-a.example.test")
+            .unwrap()
+            .unwrap()
+            .api_token,
+        "prod-token"
+    );
+    assert_eq!(
+        test.store
+            .load_for_origin("https://origin-b.example.test")
+            .unwrap()
+            .unwrap()
+            .api_token,
+        "dev-token"
+    );
+
+    test.store
+        .delete_for_origin("https://origin-a.example.test")
+        .unwrap();
+    assert!(
+        test.store
+            .load_for_origin("https://origin-a.example.test")
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(
+        test.store
+            .load_for_origin("https://origin-b.example.test")
+            .unwrap()
+            .unwrap()
+            .api_token,
+        "dev-token"
+    );
+}
+
+#[test]
+fn legacy_credentials_readable_without_migrating_on_load() {
+    let test = TestStore::new();
+    test.write_config_url("https://origin-a.example.test");
+    test.write_raw(r#"{"api_token":"legacy-token","api_token_id":"legacy-id"}"#);
+
+    let loaded = test
+        .store
+        .load_for_origin("https://origin-a.example.test")
+        .unwrap()
+        .unwrap();
+    assert_eq!(loaded.api_token, "legacy-token");
+    assert_eq!(
+        std::fs::read_to_string(&test.credentials_path).unwrap(),
+        r#"{"api_token":"legacy-token","api_token_id":"legacy-id"}"#
+    );
+
+    test.store
+        .save_for_origin("https://origin-a.example.test", &loaded)
+        .unwrap();
+
+    let json = test.read_raw_json();
+    assert!(json.get("api_token").is_none());
+    assert_eq!(
+        json["servers"]["https://origin-a.example.test"]["api_token"],
+        "legacy-token"
+    );
+    assert_eq!(test.permissions(), 0o600);
+}
+
+#[test]
+fn legacy_without_config_url_matches_nothing_and_preserves_file() {
+    let test = TestStore::new();
+    test.write_raw(r#"{"api_token":"legacy-token","api_token_id":"legacy-id"}"#);
+
+    assert!(
+        test.store
+            .load_for_origin("https://origin-a.example.test")
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(
+        std::fs::read_to_string(&test.credentials_path).unwrap(),
+        r#"{"api_token":"legacy-token","api_token_id":"legacy-id"}"#
+    );
+}
+
+#[test]
+fn save_for_origin_rewrites_legacy_without_config_url() {
+    let test = TestStore::new();
+    test.write_raw(r#"{"api_token":"legacy-token","api_token_id":"legacy-id"}"#);
+
+    test.store
+        .save_for_origin(
+            "https://origin-b.example.test",
+            &sample_credentials("dev-token"),
+        )
+        .unwrap();
+
+    let json = test.read_raw_json();
+    assert!(json.get("api_token").is_none());
+    assert_eq!(
+        json["servers"]["https://origin-b.example.test"]["api_token"],
+        "dev-token"
+    );
+    assert!(
+        json["servers"]
+            .get("https://origin-a.example.test")
+            .is_none()
+    );
+}
+
+#[test]
+fn origin_lookup_is_case_insensitive_for_host() {
+    let test = TestStore::new();
+    test.store
+        .save_for_origin(
+            "https://Origin-A.example.test",
+            &sample_credentials("token"),
+        )
+        .unwrap();
+
+    let loaded = test
+        .store
+        .load_for_origin("https://origin-a.example.test")
+        .unwrap()
+        .unwrap();
+    assert_eq!(loaded.api_token, "token");
+}
+
+#[test]
+fn normalize_origin_omits_default_ports_and_brackets_ipv6() {
+    assert_eq!(
+        normalize_origin("HTTPS://Origin-A.Example.Test/"),
+        "https://origin-a.example.test"
+    );
+    assert_eq!(
+        normalize_origin("https://origin-a.example.test:443/"),
+        "https://origin-a.example.test"
+    );
+    assert_eq!(normalize_origin("http://localhost:80"), "http://localhost");
+    assert_eq!(normalize_origin("http://[::1]:8080"), "http://[::1]:8080");
+}
+
+#[test]
+fn empty_server_token_is_ignored() {
+    let test = TestStore::new();
+    test.write_raw(
+        r#"{"servers":{"https://origin-a.example.test":{"api_token":"","api_token_id":"id"}}}"#,
+    );
+
+    assert!(
+        test.store
+            .load_for_origin("https://origin-a.example.test")
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[test]
+fn empty_legacy_credentials_are_rejected() {
+    let test = TestStore::new();
+    test.write_raw(r#"{"api_token":"","api_token_id":""}"#);
+
+    let err = test
+        .store
+        .load_for_origin("https://origin-a.example.test")
+        .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("unrecognized credentials file format")
+    );
+}

--- a/gestalt/cli/tests/support/mod.rs
+++ b/gestalt/cli/tests/support/mod.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 #![allow(unused_imports)]
+#![allow(unused_macros)]
 
 use std::ffi::OsString;
 use std::io::{BufRead, BufReader, Read};
@@ -305,12 +306,6 @@ pub(crate) fn cli_command_for_server(home: &Path, server: &Server) -> Command {
         .arg("--url")
         .arg(server.url());
     cmd
-}
-
-pub(crate) fn write_cli_credentials(home: &Path, json: &str) {
-    let path = credentials_path(home);
-    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
-    std::fs::write(path, json).unwrap();
 }
 
 pub(crate) fn catalog_body() -> &'static str {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -5037,12 +5038,27 @@ server:
 	})
 }
 
+func writeTestGestaltCredentials(t *testing.T, xdg string, payload any) {
+	t.Helper()
+	dir := filepath.Join(xdg, "gestalt")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	encoded, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "credentials.json"), encoded, 0o600); err != nil {
+		t.Fatalf("WriteFile credentials: %v", err)
+	}
+}
+
 func TestLoadConfigRemoteGestaltd(t *testing.T) {
 	loadRemoteConfigForServe := func(t *testing.T) (*Config, error) {
 		t.Helper()
 		path := mustWriteConfigFile(t, `
 server:
-  remote: https://valon.tools
+  remote: https://origin-a.example.test
 `)
 		cfg, err := Load(path)
 		if err != nil {
@@ -5105,18 +5121,18 @@ server:
 				xdg := t.TempDir()
 				t.Setenv("XDG_CONFIG_HOME", xdg)
 				if tc.storedToken != "" {
-					credentialsDir := filepath.Join(xdg, "gestalt")
-					if err := os.MkdirAll(credentialsDir, 0o755); err != nil {
-						t.Fatalf("MkdirAll: %v", err)
-					}
-					credentials := fmt.Sprintf(`{"api_token":%q,"api_token_id":"tok_1"}`, tc.storedToken)
-					if err := os.WriteFile(filepath.Join(credentialsDir, "credentials.json"), []byte(credentials), 0o600); err != nil {
-						t.Fatalf("WriteFile credentials: %v", err)
-					}
+					writeTestGestaltCredentials(t, xdg, gestaltCredentialsFile{
+						Servers: map[string]gestaltCredentials{
+							"https://origin-a.example.test": {
+								APIToken:   tc.storedToken,
+								APITokenID: "tok_1",
+							},
+						},
+					})
 				}
 
 				cfg, err := loadRemoteConfigForServe(t)
-				if got := cfg.Server.Remote; got != "https://valon.tools" {
+				if got := cfg.Server.Remote; got != "https://origin-a.example.test" {
 					t.Fatalf("server.remote = %q", got)
 				}
 				if tc.wantErr != "" {

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -6,7 +6,6 @@ import (
 	"maps"
 	"net"
 	"net/url"
-	"os"
 	"path"
 	"path/filepath"
 	"slices"
@@ -867,47 +866,13 @@ func ApplyServeRemoteOverrides(cfg *Config, remote, remoteToken string) error {
 		return err
 	}
 	if strings.TrimSpace(cfg.Server.Remote) != "" && strings.TrimSpace(cfg.Server.RemoteToken) == "" {
-		token, err := defaultRemoteToken()
+		token, err := defaultRemoteTokenForOrigin(cfg.Server.Remote)
 		if err != nil {
 			return err
 		}
 		cfg.Server.RemoteToken = token
 	}
 	return ValidateRemoteGestaltd(cfg)
-}
-
-func defaultRemoteToken() (string, error) {
-	if token := strings.TrimSpace(os.Getenv("GESTALT_API_KEY")); token != "" {
-		return token, nil
-	}
-	path := gestaltCredentialsPath()
-	if path == "" {
-		return "", nil
-	}
-	data, err := os.ReadFile(path)
-	if os.IsNotExist(err) {
-		return "", nil
-	}
-	if err != nil {
-		return "", fmt.Errorf("config validation: read Gestalt credentials: %w", err)
-	}
-	var creds struct {
-		APIToken string `json:"api_token"`
-	}
-	if err := json.Unmarshal(data, &creds); err != nil {
-		return "", fmt.Errorf("config validation: parse Gestalt credentials: %w", err)
-	}
-	return strings.TrimSpace(creds.APIToken), nil
-}
-
-func gestaltCredentialsPath() string {
-	if xdg := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")); xdg != "" {
-		return filepath.Join(xdg, "gestalt", "credentials.json")
-	}
-	if home, err := os.UserHomeDir(); err == nil {
-		return filepath.Join(home, ".config", "gestalt", "credentials.json")
-	}
-	return ""
 }
 
 func runtimeProviderUsesSource(entry *RuntimeProviderEntry) bool {

--- a/gestaltd/internal/config/gestalt_credentials.go
+++ b/gestaltd/internal/config/gestalt_credentials.go
@@ -1,0 +1,87 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type gestaltCredentials struct {
+	APIToken   string `json:"api_token"`
+	APITokenID string `json:"api_token_id"`
+}
+
+type gestaltCredentialsFile struct {
+	Servers map[string]gestaltCredentials `json:"servers"`
+}
+
+func defaultRemoteTokenForOrigin(origin string) (string, error) {
+	if token := strings.TrimSpace(os.Getenv("GESTALT_API_KEY")); token != "" {
+		return token, nil
+	}
+	normalizedOrigin := normalizeGestaltOrigin(origin)
+	if normalizedOrigin == "" {
+		return "", nil
+	}
+	path := gestaltCredentialsPath()
+	if path == "" {
+		return "", nil
+	}
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("config validation: read Gestalt credentials: %w", err)
+	}
+
+	var file gestaltCredentialsFile
+	if err := json.Unmarshal(data, &file); err != nil {
+		return "", fmt.Errorf("config validation: parse Gestalt credentials: %w", err)
+	}
+	if creds, ok := file.Servers[normalizedOrigin]; ok {
+		return strings.TrimSpace(creds.APIToken), nil
+	}
+	return "", nil
+}
+
+func normalizeGestaltOrigin(raw string) string {
+	trimmed := strings.TrimRight(strings.TrimSpace(raw), "/")
+	if trimmed == "" {
+		return ""
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return trimmed
+	}
+	scheme := strings.ToLower(parsed.Scheme)
+	hostname := strings.ToLower(parsed.Hostname())
+	if hostname == "" {
+		return trimmed
+	}
+	host := hostname
+	if strings.Contains(hostname, ":") {
+		host = "[" + hostname + "]"
+	}
+	if port := parsed.Port(); port != "" && !isDefaultGestaltOriginPort(scheme, port) {
+		host = host + ":" + port
+	}
+	return scheme + "://" + host
+}
+
+func isDefaultGestaltOriginPort(scheme, port string) bool {
+	return (scheme == "https" && port == "443") || (scheme == "http" && port == "80")
+}
+
+func gestaltCredentialsPath() string {
+	if xdg := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")); xdg != "" {
+		return filepath.Join(xdg, "gestalt", "credentials.json")
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		return filepath.Join(home, ".config", "gestalt", "credentials.json")
+	}
+	return ""
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Origin-keyed `credentials.json` for Rust CLI and read-only Go `gestaltd` lookup.

### Latest fix (read-only legacy on load)

- **`load_for_origin`** no longer migrates/writes legacy credentials on read-only paths (`auth status`, `ApiClient::from_env`). Legacy tokens are resolved in-memory via `config.json` URL match only.
- **Migration stays on write paths** (`save_for_origin` / login) via `migrate_legacy_credentials`.
- **`delete_for_origin`** deletes legacy files directly when the configured origin matches, without migrating first.
- Removed redundant `legacy_with_corrupt_config` unit test; updated legacy load test to assert file preservation until save.

### Design

| Component | Behavior |
|-----------|----------|
| Rust CLI | `servers` map keyed by normalized origin; legacy flat format migrates on **write** only |
| Go gestaltd | Read-only `servers` map lookup by normalized remote origin (no legacy fallback, no migration writer) |

Closes valon-technologies/gestalt#131 (RR-1).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-382ba850-9886-4c94-91b9-be60e568eff9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-382ba850-9886-4c94-91b9-be60e568eff9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

