### PR TITLE
RR-2: named remotes configuration model and forward-routing consumption (issue-132)

### DIFF
--- a/gestaltd/internal/bootstrap/app_provider_restart.go
+++ b/gestaltd/internal/bootstrap/app_provider_restart.go
@@ -88,7 +88,7 @@ func (r *AppProviderRestarter) Restartable(app string) (bool, error) {
 }
 
 func appProviderRestartable(cfg *config.Config, entry *config.ProviderEntry) bool {
-	return entry != nil && !entry.DevActive && providerBuildsLocal(cfg, entry)
+	return entry != nil && !entry.DevActive && config.EntryBuildsLocal(entry)
 }
 
 func (r *AppProviderRestarter) StopApp(ctx context.Context, app string) error {

--- a/gestaltd/internal/bootstrap/app_provider_restart_test.go
+++ b/gestaltd/internal/bootstrap/app_provider_restart_test.go
@@ -25,9 +25,13 @@ func TestAppProviderRestarterRestartable(t *testing.T) {
 	t.Parallel()
 
 	cfg := &config.Config{
-		Server: config.ServerConfig{Remote: "https://remote.test"},
+		Server: config.ServerConfig{
+			Remotes: map[string]*config.RemoteConfig{
+				config.DefaultRemoteName: {URL: "https://remote.test", Default: true},
+			},
+		},
 		Apps: map[string]*config.ProviderEntry{
-			"remote":         {},
+			"remote":         {Remote: config.DefaultRemoteName},
 			"local-override": {Local: true},
 			"dev-active":     {DevActive: true},
 		},
@@ -51,7 +55,8 @@ func TestAppProviderRestarterRestartable(t *testing.T) {
 		}
 	}
 
-	cfg.Server.Remote = ""
+	cfg.Server.Remotes = nil
+	cfg.Apps["remote"].Remote = ""
 	got, err := restarter.Restartable("remote")
 	if err != nil {
 		t.Fatalf("Restartable without server.remote: %v", err)

--- a/gestaltd/internal/bootstrap/authorization_bootstrap.go
+++ b/gestaltd/internal/bootstrap/authorization_bootstrap.go
@@ -32,7 +32,7 @@ func bootstrapAuthorizationProviderState(ctx context.Context, cfg *config.Config
 	if entry == nil {
 		return nil
 	}
-	if !providerBuildsLocal(cfg, entry) {
+	if !config.EntryBuildsLocal(entry) {
 		return nil
 	}
 	provider := providers[name]

--- a/gestaltd/internal/bootstrap/authorization_bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/authorization_bootstrap_test.go
@@ -200,13 +200,20 @@ func TestBootstrapAuthorizationProviderStateSkipsRemoteProvider(t *testing.T) {
 	provider := &recordingAuthorizationProvider{}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Remote: "https://parent.gestalt.example",
+			Remotes: map[string]*config.RemoteConfig{
+				config.DefaultRemoteName: {
+					URL:     "https://parent.gestalt.example",
+					Default: true,
+				},
+			},
 			Providers: config.ServerProvidersConfig{
 				Authorization: "authz",
 			},
 		},
 		Providers: config.ProvidersConfig{
-			Authorization: map[string]*config.ProviderEntry{"authz": {Default: true}},
+			Authorization: map[string]*config.ProviderEntry{
+				"authz": {Default: true, Remote: config.DefaultRemoteName},
+			},
 		},
 		Authorization: config.AuthorizationConfig{
 			Models: map[string]config.AuthorizationModelDef{

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -192,7 +192,7 @@ type Deps struct {
 	HostServiceTLSCAPEM     string
 	Telemetry               core.TelemetryProvider
 	DevSupervisor           *providerdev.Supervisor
-	RemoteClients           *remote.ClientSet
+	RemoteClientSets        remote.ClientSets
 	RemoteToken             string
 	GatewayTransport        *providergateway.ProviderGatewayTransport
 
@@ -952,6 +952,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 		return nil, err
 	}
 
+	closeRemoteClients := false
 	deps := Deps{
 		EncryptionKey:        encKey,
 		BaseURL:              cfg.Server.BaseURL,
@@ -963,15 +964,32 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 		HostServiceTLSCAFile: hostServiceTLSCAFile,
 		HostServiceTLSCAPEM:  hostServiceTLSCAPEM,
 	}
-	if remoteURL := strings.TrimSpace(cfg.Server.Remote); remoteURL != "" {
-		deps.RemoteToken = cfg.Server.RemoteToken
-		deps.RemoteClients, err = remote.NewClientSet(ctx, remote.Config{
-			URL:   remoteURL,
-			Token: cfg.Server.RemoteToken,
-		})
+	if hasRemotePlacement(cfg) {
+		remoteConfigs := make(map[string]remote.Config)
+		for _, name := range cfg.ReferencedRemoteNames() {
+			remoteCfg := cfg.Server.Remotes[name]
+			if remoteCfg == nil {
+				return nil, fmt.Errorf("bootstrap: remote %q is not configured under server.remotes", name)
+			}
+			remoteConfigs[name] = remote.Config{
+				URL:   remoteCfg.URL,
+				Token: remoteCfg.Token,
+			}
+		}
+		var err error
+		deps.RemoteClientSets, err = remote.NewClientSets(ctx, remoteConfigs)
 		if err != nil {
 			return nil, fmt.Errorf("bootstrap: remote client: %w", err)
 		}
+		closeRemoteClients = true
+		defer func() {
+			if closeRemoteClients && deps.RemoteClientSets != nil {
+				_ = deps.RemoteClientSets.Close()
+			}
+		}()
+	}
+	if _, defaultRemote, ok := cfg.DefaultRemoteEntry(); ok && defaultRemote != nil {
+		deps.RemoteToken = defaultRemote.Token
 	}
 	pluginInvoker := newLazyInvoker()
 	workflowManager := newLazyWorkflowManager()
@@ -1010,7 +1028,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 		return nil, fmt.Errorf("bootstrap: system indexeddb from resource %q: %w", selectedIndexedDBName, storeErr)
 	}
 	store = metricutil.InstrumentIndexedDB(store, selectedIndexedDBName)
-	skipSchemaBootstrap := !providerBuildsLocal(cfg, def)
+	skipSchemaBootstrap := !config.EntryBuildsLocal(def)
 	svc, svcErr := coredata.NewWithOptions(ctx, store, coredata.NewOptions{SkipSchemaBootstrap: skipSchemaBootstrap})
 	if svcErr != nil {
 		_ = store.Close()
@@ -1147,6 +1165,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	closeExtraS3s = false
 	closeAuthorizationOnError = false
 	closeExternalCredentialsOnError = false
+	closeRemoteClients = false
 	return &preparedCore{
 		Auth:                 auth,
 		SelectedAuthProvider: selectedAuthName,
@@ -1201,7 +1220,7 @@ func (p *preparedCore) Close(ctx context.Context) error {
 		authCloseErr,
 		authorizationCloseErr,
 		externalCredentialsCloseErr,
-		p.Deps.RemoteClients.Close(),
+		p.Deps.RemoteClientSets.Close(),
 		p.Services.Close(),
 		closeIndexedDBs(p.ExtraIndexedDBs...),
 		closeCaches(p.ExtraCaches...),
@@ -1654,16 +1673,6 @@ func failPendingStartupProviders(deps Deps, err error) {
 	}
 }
 
-func providerBuildsLocal(cfg *config.Config, entry *config.ProviderEntry) bool {
-	if entry == nil {
-		return false
-	}
-	if entry.DevActive || entry.Local {
-		return true
-	}
-	return cfg == nil || strings.TrimSpace(cfg.Server.Remote) == ""
-}
-
 func buildConfiguredProviders[T any](
 	ctx context.Context,
 	entries map[string]*config.ProviderEntry,
@@ -2108,11 +2117,15 @@ func buildNamedAuthProvider(cfg *config.Config, name string, authEntry *config.P
 	if authEntry == nil {
 		return nil, nil
 	}
-	if !providerBuildsLocal(cfg, authEntry) {
-		if deps.RemoteClients == nil || deps.RemoteClients.Identity == nil {
+	if !config.EntryBuildsLocal(authEntry) {
+		clients, err := remoteClientsForEntry(cfg, authEntry, deps)
+		if err != nil {
+			return nil, fmt.Errorf("bootstrap: identity provider %q: %w", name, err)
+		}
+		if clients.Identity == nil {
 			return nil, fmt.Errorf("bootstrap: remote identity client is required when server.remote is configured")
 		}
-		return identityservice.NewRemote(deps.RemoteClients.Identity, name)
+		return identityservice.NewRemote(clients.Identity, name)
 	}
 	if factories.Auth == nil {
 		return nil, fmt.Errorf("bootstrap: authentication factory is not registered")
@@ -2162,11 +2175,15 @@ func buildNamedAuthorizationProvider(ctx context.Context, cfg *config.Config, na
 	if entry == nil {
 		return nil, fmt.Errorf("bootstrap: authorization provider %q is not configured", logicalName)
 	}
-	if !providerBuildsLocal(cfg, entry) {
-		if deps.RemoteClients == nil || deps.RemoteClients.Authorization == nil {
+	if !config.EntryBuildsLocal(entry) {
+		clients, err := remoteClientsForEntry(cfg, entry, deps)
+		if err != nil {
+			return nil, fmt.Errorf("bootstrap: authorization provider %q: %w", logicalName, err)
+		}
+		if clients.Authorization == nil {
 			return nil, fmt.Errorf("bootstrap: remote authorization client is required when server.remote is configured")
 		}
-		conn := grpc.ClientConnInterface(deps.RemoteClients.Conn())
+		conn := grpc.ClientConnInterface(clients.Conn())
 		if deps.GatewayTransport != nil {
 			target := providergateway.ProviderTarget{Kind: providergateway.ProviderKindAuthorization, Name: logicalName}
 			if err := deps.GatewayTransport.RegisterDirect(target, providergateway.DirectEndpoint{Conn: conn}); err != nil {
@@ -2206,12 +2223,16 @@ func buildIndexedDB(cfg *config.Config, name string, entry *config.ProviderEntry
 	if entry == nil {
 		return nil, fmt.Errorf("indexeddb provider is required")
 	}
-	if !providerBuildsLocal(cfg, entry) {
-		if deps.RemoteClients == nil || deps.RemoteClients.IndexedDB == nil {
+	if !config.EntryBuildsLocal(entry) {
+		clients, err := remoteClientsForEntry(cfg, entry, deps)
+		if err != nil {
+			return nil, fmt.Errorf("bootstrap: indexeddb provider %q: %w", name, err)
+		}
+		if clients.IndexedDB == nil {
 			return nil, fmt.Errorf("bootstrap: remote indexeddb client is required when server.remote is configured")
 		}
 		return indexeddbpkg.NewRemote(indexeddbpkg.RemoteConfig{
-			Client: deps.RemoteClients.IndexedDB,
+			Client: clients.IndexedDB,
 			Name:   name,
 		})
 	}
@@ -2282,12 +2303,16 @@ func buildWorkflow(ctx context.Context, cfg *config.Config, name string, entry *
 	if entry == nil {
 		return nil, fmt.Errorf("workflow provider is required")
 	}
-	if !providerBuildsLocal(cfg, entry) {
-		if deps.RemoteClients == nil || deps.RemoteClients.Workflow == nil {
+	if !config.EntryBuildsLocal(entry) {
+		clients, err := remoteClientsForEntry(cfg, entry, deps)
+		if err != nil {
+			return nil, fmt.Errorf("bootstrap: workflow provider %q: %w", name, err)
+		}
+		if clients.Workflow == nil {
 			return nil, fmt.Errorf("bootstrap: remote workflow client is required when server.remote is configured")
 		}
-		client := deps.RemoteClients.Workflow
-		if rawConn := deps.RemoteClients.Conn(); rawConn != nil {
+		client := clients.Workflow
+		if rawConn := clients.Conn(); rawConn != nil {
 			conn := grpc.ClientConnInterface(rawConn)
 			gwConn, err := gatewayConn(deps.GatewayTransport, providergateway.ProviderTarget{Kind: providergateway.ProviderKindWorkflow, Name: name}, conn)
 			if err != nil {
@@ -2355,12 +2380,16 @@ func buildAgent(ctx context.Context, cfg *config.Config, name string, entry *con
 	if entry == nil {
 		return nil, fmt.Errorf("agent provider is required")
 	}
-	if !providerBuildsLocal(cfg, entry) {
-		if deps.RemoteClients == nil || deps.RemoteClients.Agent == nil {
+	if !config.EntryBuildsLocal(entry) {
+		clients, err := remoteClientsForEntry(cfg, entry, deps)
+		if err != nil {
+			return nil, fmt.Errorf("bootstrap: agent provider %q: %w", name, err)
+		}
+		if clients.Agent == nil {
 			return nil, fmt.Errorf("bootstrap: remote agent client is required when server.remote is configured")
 		}
-		client := deps.RemoteClients.Agent
-		if rawConn := deps.RemoteClients.Conn(); rawConn != nil {
+		client := clients.Agent
+		if rawConn := clients.Conn(); rawConn != nil {
 			conn := grpc.ClientConnInterface(rawConn)
 			gwConn, err := gatewayConn(deps.GatewayTransport, providergateway.ProviderTarget{Kind: providergateway.ProviderKindAgent, Name: name}, conn)
 			if err != nil {

--- a/gestaltd/internal/bootstrap/host_service_bootstrap.go
+++ b/gestaltd/internal/bootstrap/host_service_bootstrap.go
@@ -249,7 +249,7 @@ func registerConfiguredAppPublicHostServices(cfg *config.Config, deps Deps) func
 	var cleanups []func()
 	for _, name := range slices.Sorted(maps.Keys(cfg.Apps)) {
 		entry := cfg.Apps[name]
-		if !providerBuildsLocal(cfg, entry) {
+		if !config.EntryBuildsLocal(entry) {
 			continue
 		}
 		if entry != nil && entry.DevActive && deps.DevSupervisor != nil {

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -21,6 +21,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/remote"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	agentservice "github.com/valon-technologies/gestalt/server/services/agents"
@@ -108,7 +109,7 @@ func prepareProviderBuilds(
 		if entry != nil && entry.Source.IsRegistry() {
 			continue
 		}
-		if !providerBuildsLocal(cfg, entry) {
+		if !config.EntryBuildsLocal(entry) {
 			continue
 		}
 		sha := currentAppSHA(entry)
@@ -138,17 +139,20 @@ func registerRemoteApps(providers *registry.ProviderMap[core.Provider], cfg *con
 	if providers == nil || cfg == nil {
 		return nil
 	}
-	if strings.TrimSpace(cfg.Server.Remote) == "" {
+	if !hasRemotePlacement(cfg) {
 		return nil
-	}
-	clients := deps.RemoteClients
-	if clients == nil || clients.App == nil {
-		return fmt.Errorf("bootstrap: remote client is required when server.remote is configured")
 	}
 	for name, entry := range cfg.Apps {
 		name = strings.TrimSpace(name)
-		if name == "" || entry == nil || entry.Source.IsRegistry() || providerBuildsLocal(cfg, entry) {
+		if name == "" || entry == nil || entry.Source.IsRegistry() || config.EntryBuildsLocal(entry) {
 			continue
+		}
+		clients, err := remoteClientsForEntry(cfg, entry, deps)
+		if err != nil {
+			return fmt.Errorf("remote app %q: %w", name, err)
+		}
+		if clients.App == nil {
+			return fmt.Errorf("remote app %q: provider client is required", name)
 		}
 		spec, _, err := buildStartupProviderSpec(name, entry)
 		if err != nil {
@@ -170,7 +174,7 @@ func registerRemoteApps(providers *registry.ProviderMap[core.Provider], cfg *con
 		if err := providers.Register(name, provider); err != nil {
 			return fmt.Errorf("remote app %q: %w", name, err)
 		}
-		slog.Debug("registered remote app provider", "provider", name)
+		slog.Debug("registered remote app provider", "provider", name, "remote", config.EntryPlacementRemote(entry))
 	}
 	return nil
 }
@@ -2522,4 +2526,23 @@ func buildMCPOAuthHandler(conn config.ConnectionDef, mcpURL string, deps Deps) *
 		ClientID:     conn.Auth.ClientID,
 		ClientSecret: conn.Auth.ClientSecret,
 	})
+}
+
+func remoteClientsForEntry(cfg *config.Config, entry *config.ProviderEntry, deps Deps) (*remote.ClientSet, error) {
+	remoteName := config.EntryPlacementRemote(entry)
+	if remoteName == "" {
+		return nil, fmt.Errorf("bootstrap: remote client is required for remote placement")
+	}
+	clients := deps.RemoteClientSets.Get(remoteName)
+	if clients == nil {
+		return nil, fmt.Errorf("bootstrap: remote client %q is required when server.remotes.%s is referenced", remoteName, remoteName)
+	}
+	return clients, nil
+}
+
+func hasRemotePlacement(cfg *config.Config) bool {
+	if cfg == nil {
+		return false
+	}
+	return len(cfg.ReferencedRemoteNames()) > 0
 }

--- a/gestaltd/internal/bootstrap/provider_build_test.go
+++ b/gestaltd/internal/bootstrap/provider_build_test.go
@@ -701,10 +701,48 @@ func remoteRoutingConfig(t *testing.T, localDevActive map[string]bool) *config.C
 			entry.DevActive = active
 		}
 	}
-	return &config.Config{
-		Server: config.ServerConfig{Remote: "https://remote.test"},
-		Apps:   apps,
+	for _, entry := range apps {
+		if entry == nil || entry.Local || entry.DevActive {
+			continue
+		}
+		entry.Remote = config.DefaultRemoteName
 	}
+	return &config.Config{
+		Server: config.ServerConfig{
+			Remote: "https://remote.test",
+			Remotes: map[string]*config.RemoteConfig{
+				config.DefaultRemoteName: {
+					URL:     "https://remote.test",
+					Token:   "test-token",
+					Default: true,
+				},
+			},
+		},
+		Apps: apps,
+	}
+}
+
+func multiRemoteRoutingConfig(t *testing.T) *config.Config {
+	t.Helper()
+	return &config.Config{
+		Server: config.ServerConfig{
+			Remotes: map[string]*config.RemoteConfig{
+				"prod": {URL: "https://prod.test", Token: "prod-token", Default: true},
+				"dev":  {URL: "https://dev.test", Token: "dev-token"},
+			},
+		},
+		Apps: map[string]*config.ProviderEntry{
+			"linear":        withRemote(remoteRoutingAppEntry(t, "linear", "issues.list"), "prod"),
+			"valon-profile": withRemote(remoteRoutingAppEntry(t, "valon-profile", "issues.list"), "dev"),
+		},
+	}
+}
+
+func withRemote(entry *config.ProviderEntry, remote string) *config.ProviderEntry {
+	if entry != nil {
+		entry.Remote = remote
+	}
+	return entry
 }
 
 func localRoutingAppStub(name string) *coretesting.StubIntegration {
@@ -720,7 +758,7 @@ func localRoutingAppStub(name string) *coretesting.StubIntegration {
 	}
 }
 
-func newRemoteRoutingBroker(t *testing.T, cfg *config.Config, remoteApp proto.AppClient, localApps ...core.Provider) *invocation.Broker {
+func newRemoteRoutingBroker(t *testing.T, cfg *config.Config, remoteClients map[string]proto.AppClient, localApps ...core.Provider) *invocation.Broker {
 	t.Helper()
 	reg := registry.New()
 	for _, provider := range localApps {
@@ -728,7 +766,11 @@ func newRemoteRoutingBroker(t *testing.T, cfg *config.Config, remoteApp proto.Ap
 			t.Fatalf("Register %q: %v", provider.Name(), err)
 		}
 	}
-	if err := registerRemoteApps(&reg.Providers, cfg, Deps{RemoteClients: &remote.ClientSet{App: remoteApp}}); err != nil {
+	clientSets := make(remote.ClientSets, len(remoteClients))
+	for name, appClient := range remoteClients {
+		clientSets[name] = &remote.ClientSet{App: appClient}
+	}
+	if err := registerRemoteApps(&reg.Providers, cfg, Deps{RemoteClientSets: clientSets}); err != nil {
 		t.Fatalf("registerRemoteApps: %v", err)
 	}
 	svc := testutil.NewStubServices(t)
@@ -808,7 +850,9 @@ func TestRemoteAppRoutingLifecycles(t *testing.T) {
 			t.Parallel()
 
 			remoteClient := &recordingRemoteAppClient{}
-			broker := newRemoteRoutingBroker(t, remoteRoutingConfig(t, tc.localApps), remoteClient, tc.localStubs...)
+			broker := newRemoteRoutingBroker(t, remoteRoutingConfig(t, tc.localApps), map[string]proto.AppClient{
+				config.DefaultRemoteName: remoteClient,
+			}, tc.localStubs...)
 
 			for _, check := range tc.localChecks {
 				result := invokeRemoteRoutingApp(t, broker, check.app, check.operation)
@@ -872,7 +916,9 @@ func TestRemoteAppRoutingFailureSemantics(t *testing.T) {
 			t.Parallel()
 
 			remoteClient := &recordingRemoteAppClient{err: tc.remoteErr}
-			broker := newRemoteRoutingBroker(t, remoteRoutingConfig(t, tc.localApps), remoteClient)
+			broker := newRemoteRoutingBroker(t, remoteRoutingConfig(t, tc.localApps), map[string]proto.AppClient{
+				config.DefaultRemoteName: remoteClient,
+			})
 
 			_, err := broker.Invoke(context.Background(), remoteRoutingPrincipal(tc.app), tc.app, "", tc.operation, nil)
 			if !errors.Is(err, tc.wantErr) {
@@ -885,24 +931,55 @@ func TestRemoteAppRoutingFailureSemantics(t *testing.T) {
 	}
 }
 
+func TestMultiRemoteAppRouting(t *testing.T) {
+	t.Parallel()
+
+	prodClient := &recordingRemoteAppClient{}
+	devClient := &recordingRemoteAppClient{}
+	cfg := multiRemoteRoutingConfig(t)
+	broker := newRemoteRoutingBroker(t, cfg, map[string]proto.AppClient{
+		"prod": prodClient,
+		"dev":  devClient,
+	})
+
+	result := invokeRemoteRoutingApp(t, broker, "linear", "issues.list")
+	if result.Status != 202 || string(result.Body) != "relayed" {
+		t.Fatalf("Invoke(linear) = %#v, want remote relayed", result)
+	}
+	result = invokeRemoteRoutingApp(t, broker, "valon-profile", "issues.list")
+	if result.Status != 202 || string(result.Body) != "relayed" {
+		t.Fatalf("Invoke(valon-profile) = %#v, want remote relayed", result)
+	}
+
+	prodCalls := prodClient.snapshot()
+	devCalls := devClient.snapshot()
+	if len(prodCalls) != 1 || prodCalls[0].app != "linear" {
+		t.Fatalf("prod calls = %#v, want linear only", prodCalls)
+	}
+	if len(devCalls) != 1 || devCalls[0].app != "valon-profile" {
+		t.Fatalf("dev calls = %#v, want valon-profile only", devCalls)
+	}
+}
+
 func TestProviderBuildsLocal(t *testing.T) {
 	t.Parallel()
 
-	cfg := &config.Config{Server: config.ServerConfig{Remote: "https://remote.test"}}
-
-	if !providerBuildsLocal(cfg, &config.ProviderEntry{DevActive: true}) {
+	if !config.EntryBuildsLocal(&config.ProviderEntry{DevActive: true}) {
 		t.Fatal("DevActive entry should build local")
 	}
-	if !providerBuildsLocal(cfg, &config.ProviderEntry{Local: true}) {
-		t.Fatal("local entry should build local when server.remote is configured")
+	if !config.EntryBuildsLocal(&config.ProviderEntry{Local: true}) {
+		t.Fatal("local entry should build local when a remote is configured")
 	}
-	if providerBuildsLocal(cfg, &config.ProviderEntry{}) {
-		t.Fatal("non-DevActive entry with remote configured should not build local")
+	if config.EntryBuildsLocal(&config.ProviderEntry{Remote: config.DefaultRemoteName}) {
+		t.Fatal("remote-named entry should not build local")
 	}
-	if !providerBuildsLocal(&config.Config{}, &config.ProviderEntry{}) {
+	if !config.EntryBuildsLocal(&config.ProviderEntry{}) {
+		t.Fatal("entry without remote should build local in named-remote model")
+	}
+	if !config.EntryBuildsLocal(&config.ProviderEntry{}) {
 		t.Fatal("entry without remote configured should build local")
 	}
-	if providerBuildsLocal(cfg, nil) {
+	if config.EntryBuildsLocal(nil) {
 		t.Fatal("nil entry should not build local")
 	}
 }

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -503,8 +503,10 @@ type ProviderEntry struct {
 	Config  yaml.Node      `yaml:"config,omitempty"`
 	Default bool           `yaml:"default,omitempty"`
 	// Local forces this provider to build in-process locally even when
-	// server.remote delegates other host providers to a remote gestaltd.
-	Local           bool                                   `yaml:"local,omitempty"`
+	// another entry names a remote gestaltd for delegation.
+	Local bool `yaml:"local,omitempty"`
+	// Remote names a server.remotes entry for forward delegation.
+	Remote          string                                 `yaml:"remote,omitempty"`
 	Env             map[string]string                      `yaml:"env,omitempty"`
 	Egress          *ProviderEgressConfig                  `yaml:"egress,omitempty"`
 	DisplayName     string                                 `yaml:"displayName,omitempty"`
@@ -1944,6 +1946,7 @@ type ServerConfig struct {
 	ArtifactsDir  string                   `yaml:"artifactsDir"`
 	Remote        string                   `yaml:"remote,omitempty" json:"remote,omitempty"`
 	RemoteToken   string                   `yaml:"remoteToken,omitempty" json:"remoteToken,omitempty"`
+	Remotes       map[string]*RemoteConfig `yaml:"remotes,omitempty"`
 	Providers     ServerProvidersConfig    `yaml:"providers,omitempty"`
 	Agent         ServerAgentConfig        `yaml:"agent,omitempty"`
 	Runtime       ServerRuntimeConfig      `yaml:"runtime,omitempty"`

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -5040,13 +5040,13 @@ server:
 func TestLoadConfigRemoteGestaltd(t *testing.T) {
 	loadRemoteConfigForServe := func(t *testing.T) (*Config, error) {
 		t.Helper()
-		path := mustWriteConfigFile(t, `
-server:
-  remote: https://valon.tools
-`)
-		cfg, err := Load(path)
-		if err != nil {
-			t.Fatalf("Load: %v", err)
+		cfg := &Config{
+			Server: ServerConfig{
+				Remote: "https://valon.tools",
+			},
+			Apps: map[string]*ProviderEntry{
+				"linear": {Remote: DefaultRemoteName},
+			},
 		}
 		return cfg, ApplyServeRemoteOverrides(cfg, "", "")
 	}
@@ -5083,7 +5083,7 @@ server:
 		if err == nil {
 			t.Fatal("Load: expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), "server.remote must not include a path") {
+		if !strings.Contains(err.Error(), "server.remotes.default.url must not include a path") {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -5098,7 +5098,7 @@ server:
 		}{
 			{name: "env", envToken: "env-token", wantToken: "env-token"},
 			{name: "stored credentials", storedToken: "stored-token", wantToken: "stored-token"},
-			{name: "missing", wantErr: "server.remoteToken is required when server.remote is set"},
+			{name: "missing", wantErr: "server.remotes.default.token is required"},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Setenv("GESTALT_API_KEY", tc.envToken)
@@ -5116,9 +5116,6 @@ server:
 				}
 
 				cfg, err := loadRemoteConfigForServe(t)
-				if got := cfg.Server.Remote; got != "https://valon.tools" {
-					t.Fatalf("server.remote = %q", got)
-				}
 				if tc.wantErr != "" {
 					if err == nil {
 						t.Fatal("ApplyServeRemoteOverrides: expected error, got nil")
@@ -5131,10 +5128,85 @@ server:
 				if err != nil {
 					t.Fatalf("ApplyServeRemoteOverrides: %v", err)
 				}
-				if got := cfg.Server.RemoteToken; got != tc.wantToken {
-					t.Fatalf("server.remoteToken = %q, want %q", got, tc.wantToken)
+				if got := cfg.Server.Remotes[DefaultRemoteName].Token; got != tc.wantToken {
+					t.Fatalf("server.remotes.default.token = %q, want %q", got, tc.wantToken)
 				}
 			})
+		}
+	})
+
+	t.Run("remote flag targets named default remote", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{
+			Server: ServerConfig{
+				Remotes: map[string]*RemoteConfig{
+					"prod": {URL: "https://old.test", Token: "configured-token", Default: true},
+					"dev":  {URL: "https://dev.test", Token: "dev-token"},
+				},
+			},
+			Apps: map[string]*ProviderEntry{
+				"local-tool": {},
+			},
+		}
+		if err := ApplyServeRemoteOverrides(cfg, "https://new.test", ""); err != nil {
+			t.Fatalf("ApplyServeRemoteOverrides: %v", err)
+		}
+		if got := cfg.Server.Remotes["prod"].URL; got != "https://new.test" {
+			t.Fatalf("server.remotes.prod.url = %q", got)
+		}
+		if got := cfg.Server.Remotes["prod"].Token; got != "configured-token" {
+			t.Fatalf("server.remotes.prod.token = %q", got)
+		}
+		// No app references the default remote, so the legacy scalar mirror
+		// is not populated — the default remote is declared but unused.
+		if got := cfg.Server.Remote; got != "" {
+			t.Fatalf("server.remote = %q, want empty (default unreferenced)", got)
+		}
+		if got := cfg.Apps["local-tool"].Remote; got != "" {
+			t.Fatalf("local-tool remote = %q, want empty local placement", got)
+		}
+	})
+
+	t.Run("remote flag errors when named remotes lack a default", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{
+			Server: ServerConfig{
+				Remotes: map[string]*RemoteConfig{
+					"prod": {URL: "https://prod.test", Token: "prod-token"},
+					"dev":  {URL: "https://dev.test", Token: "dev-token"},
+				},
+			},
+			Apps: map[string]*ProviderEntry{
+				"linear": {Remote: "prod"},
+			},
+		}
+		err := ApplyServeRemoteOverrides(cfg, "https://override.test", "")
+		if err == nil {
+			t.Fatal("ApplyServeRemoteOverrides: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "require a default server.remotes entry") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := cfg.Server.Remotes["prod"].URL; got != "https://prod.test" {
+			t.Fatalf("prod url mutated = %q, want unchanged", got)
+		}
+		if _, injected := cfg.Server.Remotes[DefaultRemoteName]; injected {
+			t.Fatalf("spurious default remote created: %#v", cfg.Server.Remotes[DefaultRemoteName])
+		}
+	})
+
+	t.Run("remote flag preserves legacy app stamping", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{
+			Apps: map[string]*ProviderEntry{
+				"linear": {},
+			},
+		}
+		if err := ApplyServeRemoteOverrides(cfg, "https://remote.test", "test-token"); err != nil {
+			t.Fatalf("ApplyServeRemoteOverrides: %v", err)
+		}
+		if got := cfg.Apps["linear"].Remote; got != DefaultRemoteName {
+			t.Fatalf("linear remote = %q, want %q", got, DefaultRemoteName)
 		}
 	})
 
@@ -5154,6 +5226,155 @@ server:
 		}
 		if got := cfg.Server.RemoteToken; got != "configured-token" {
 			t.Fatalf("server.remoteToken = %q, want configured-token", got)
+		}
+	})
+
+	t.Run("rejects double default remote", func(t *testing.T) {
+		t.Parallel()
+		path := mustWriteConfigFile(t, `
+server:
+  remotes:
+    prod:
+      url: https://valon.tools
+      default: true
+    dev:
+      url: https://vt.dev.valon.tools
+      default: true
+`)
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "at most one server.remotes entry may set default: true") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("rejects unknown remote reference", func(t *testing.T) {
+		t.Parallel()
+		path := mustWriteConfigFile(t, `
+server:
+  remotes:
+    prod:
+      url: https://valon.tools
+apps:
+  linear:
+    source:
+      path: /tmp/manifest.yaml
+    remote: missing
+`)
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), `remote "missing" is not defined under server.remotes`) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("rejects local and remote conflict", func(t *testing.T) {
+		t.Parallel()
+		path := mustWriteConfigFile(t, `
+server:
+  remotes:
+    prod:
+      url: https://valon.tools
+apps:
+  linear:
+    source:
+      path: /tmp/manifest.yaml
+    local: true
+    remote: prod
+`)
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "cannot set both local: true and remote") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("rejects remote on unsupported provider kind", func(t *testing.T) {
+		t.Parallel()
+		path := mustWriteConfigFile(t, `
+server:
+  remotes:
+    prod:
+      url: https://valon.tools
+providers:
+  cache:
+    shared:
+      source:
+        path: ./providers/cache/memory
+      remote: prod
+`)
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "does not support remote placement") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("legacy canonicalization stamps host providers", func(t *testing.T) {
+		t.Parallel()
+		path := mustWriteConfigFile(t, `
+server:
+  remote: https://remote.test
+  remoteToken: test-token
+providers:
+  identity:
+    oidc:
+      source:
+        path: ./providers/identity/oidc
+  workflow:
+    wf:
+      source:
+        path: ./providers/workflow/wf
+`)
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if got := cfg.Providers.Identity["oidc"].Remote; got != DefaultRemoteName {
+			t.Fatalf("identity oidc remote = %q, want %q", got, DefaultRemoteName)
+		}
+		if got := cfg.Providers.Workflow["wf"].Remote; got != DefaultRemoteName {
+			t.Fatalf("workflow wf remote = %q, want %q", got, DefaultRemoteName)
+		}
+	})
+
+	t.Run("sole remote is default without explicit flag", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{
+			Server: ServerConfig{
+				Remotes: map[string]*RemoteConfig{
+					"prod": {URL: "https://valon.tools"},
+				},
+			},
+		}
+		name, remote, ok := cfg.DefaultRemoteEntry()
+		if !ok || name != "prod" || remote == nil {
+			t.Fatalf("DefaultRemoteEntry() = (%q, %#v, %v)", name, remote, ok)
+		}
+	})
+
+	t.Run("unreferenced default remote needs no token", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{
+			Server: ServerConfig{
+				Remotes: map[string]*RemoteConfig{
+					"prod": {URL: "https://valon.tools", Default: true},
+				},
+			},
+			Apps: map[string]*ProviderEntry{
+				"local-tool": {},
+			},
+		}
+		if err := ApplyServeRemoteOverrides(cfg, "", ""); err != nil {
+			t.Fatalf("ApplyServeRemoteOverrides with unreferenced default: %v", err)
 		}
 	})
 }

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -49,7 +49,7 @@ func CanonicalizeStructure(cfg *Config) error {
 	if err := normalizeAppStaticMounts(cfg); err != nil {
 		return err
 	}
-	return nil
+	return canonicalizeRemotes(cfg)
 }
 
 // ValidateCanonicalStructure checks config shape assuming canonicalization has
@@ -463,6 +463,16 @@ func validateHostProviderEntries(kind HostProviderKind, entries map[string]*Prov
 			return err
 		}
 		switch kind {
+		case HostProviderKindIdentity, HostProviderKindAuthorization:
+			if err := validateProviderEntryRemote("providers."+string(kind)+"."+name, entry); err != nil {
+				return err
+			}
+		default:
+			if err := validateUnsupportedRemotePlacement("providers."+string(kind)+"."+name, entry); err != nil {
+				return err
+			}
+		}
+		switch kind {
 		case HostProviderKindIdentity:
 			if entry.Source.IsBuiltin() {
 				return fmt.Errorf("config validation: identity provider %q does not support builtin providers; use a provider source reference or omit identity", name)
@@ -792,7 +802,7 @@ func validateRuntimeConfig(cfg *Config) error {
 	if err := validateRuntimeRelayBaseURL(cfg.Server.Runtime.RelayBaseURL); err != nil {
 		return err
 	}
-	if err := normalizeRemoteGestaltdConfig(cfg); err != nil {
+	if err := validateRemotesConfig(cfg); err != nil {
 		return err
 	}
 	for name, entry := range cfg.Runtime.Providers {
@@ -800,6 +810,9 @@ func validateRuntimeConfig(cfg *Config) error {
 			return fmt.Errorf("config validation: runtime.providers.%s is required", name)
 		}
 		if err := validateAppOnlyProviderFields("runtime.providers."+name, &entry.ProviderEntry); err != nil {
+			return err
+		}
+		if err := validateUnsupportedRemotePlacement("runtime.providers."+name, &entry.ProviderEntry); err != nil {
 			return err
 		}
 		entry.Driver = RuntimeProviderDriver(strings.TrimSpace(string(entry.Driver)))
@@ -848,29 +861,21 @@ func validateRuntimeRelayBaseURL(raw string) error {
 	return validateHTTPOriginURL("server.runtime.relayBaseUrl", raw)
 }
 
-func validateRemoteGestaltdURL(raw string) error {
-	return validateHTTPOriginURL("server.remote", raw)
-}
-
-func normalizeRemoteGestaltdConfig(cfg *Config) error {
-	if cfg == nil {
-		return nil
-	}
-	cfg.Server.Remote = strings.TrimRight(strings.TrimSpace(cfg.Server.Remote), "/")
-	cfg.Server.RemoteToken = strings.TrimSpace(cfg.Server.RemoteToken)
-	return validateRemoteGestaltdURL(cfg.Server.Remote)
-}
-
 // ValidateRemoteGestaltd checks serve-time remote requirements.
 func ValidateRemoteGestaltd(cfg *Config) error {
 	if cfg == nil {
 		return nil
 	}
-	if strings.TrimSpace(cfg.Server.Remote) == "" {
-		return nil
+	if err := validateRemotesConfig(cfg); err != nil {
+		return err
 	}
-	if strings.TrimSpace(cfg.Server.RemoteToken) == "" {
-		return fmt.Errorf("config validation: server.remoteToken is required when server.remote is set")
+	referenced := cfg.ReferencedRemoteNames()
+	for _, name := range referenced {
+		remote := cfg.Server.Remotes[name]
+		if remote == nil || strings.TrimSpace(remote.Token) != "" {
+			continue
+		}
+		return fmt.Errorf("config validation: server.remotes.%s.token is required when remote %q is referenced", name, name)
 	}
 	return nil
 }
@@ -881,21 +886,39 @@ func ApplyServeRemoteOverrides(cfg *Config, remote, remoteToken string) error {
 	if cfg == nil {
 		return nil
 	}
-	if remote != "" {
-		cfg.Server.Remote = remote
+	if len(cfg.Server.Remotes) > 0 {
+		_, defaultRemote, ok := cfg.DefaultRemoteEntry()
+		if !ok || defaultRemote == nil {
+			return fmt.Errorf("config validation: --remote/--remote-token require a default server.remotes entry (set default: true on one)")
+		}
+		if remote != "" {
+			defaultRemote.URL = remote
+		}
+		if remoteToken != "" {
+			defaultRemote.Token = remoteToken
+		}
+	} else {
+		if remote != "" {
+			cfg.Server.Remote = remote
+		}
+		if remoteToken != "" {
+			cfg.Server.RemoteToken = remoteToken
+		}
 	}
-	if remoteToken != "" {
-		cfg.Server.RemoteToken = remoteToken
-	}
-	if err := normalizeRemoteGestaltdConfig(cfg); err != nil {
+	if err := canonicalizeRemotes(cfg); err != nil {
 		return err
 	}
-	if strings.TrimSpace(cfg.Server.Remote) != "" && strings.TrimSpace(cfg.Server.RemoteToken) == "" {
-		token, err := defaultRemoteToken()
-		if err != nil {
-			return err
+	// Resolve a missing default-remote token from the environment or stored
+	// credentials, but only when the default is actually referenced — an
+	// unreferenced default needs no token.
+	if defaultName, defaultRemote, ok := cfg.DefaultRemoteEntry(); ok && defaultRemote != nil {
+		if strings.TrimSpace(defaultRemote.Token) == "" && slices.Contains(cfg.ReferencedRemoteNames(), defaultName) {
+			token, err := defaultRemoteToken()
+			if err != nil {
+				return err
+			}
+			defaultRemote.Token = token
 		}
-		cfg.Server.RemoteToken = token
 	}
 	return ValidateRemoteGestaltd(cfg)
 }
@@ -967,6 +990,9 @@ func validateApp(cfg *Config, name string, entry *ProviderEntry) error {
 	if err := normalizeProviderRuntimeConfig("apps."+name, entry, false); err != nil {
 		return err
 	}
+	if err := validateProviderEntryRemote("apps."+name, entry); err != nil {
+		return err
+	}
 	if err := validateProviderEntrySource("app", name, entry); err != nil {
 		return err
 	}
@@ -1026,6 +1052,9 @@ func validateIndexedDBConfig(cfg *Config) error {
 		if err := validateAppOnlyProviderFields("providers.indexeddb."+name, entry); err != nil {
 			return err
 		}
+		if err := validateProviderEntryRemote("providers.indexeddb."+name, entry); err != nil {
+			return err
+		}
 		if err := validateProviderEntrySource("indexeddb", name, entry); err != nil {
 			return err
 		}
@@ -1047,6 +1076,9 @@ func validateCacheConfig(cfg *Config) error {
 		if err := validateAppOnlyProviderFields("providers.cache."+name, entry); err != nil {
 			return err
 		}
+		if err := validateUnsupportedRemotePlacement("providers.cache."+name, entry); err != nil {
+			return err
+		}
 		if err := validateProviderEntrySource("cache", name, entry); err != nil {
 			return err
 		}
@@ -1060,6 +1092,9 @@ func validateS3Config(cfg *Config) error {
 			return fmt.Errorf("config validation: providers.s3.%s is required", name)
 		}
 		if err := validateAppOnlyProviderFields("providers.s3."+name, entry); err != nil {
+			return err
+		}
+		if err := validateUnsupportedRemotePlacement("providers.s3."+name, entry); err != nil {
 			return err
 		}
 		if err := validateProviderEntrySource("s3", name, entry); err != nil {
@@ -1086,6 +1121,9 @@ func validateWorkflowConfig(cfg *Config) error {
 			}
 		}
 		if err := validateWorkflowProviderFields(cfg, name, entry); err != nil {
+			return err
+		}
+		if err := validateProviderEntryRemote("providers.workflow."+name, entry); err != nil {
 			return err
 		}
 		if err := validateProviderEntrySource("workflow", name, entry); err != nil {
@@ -1122,6 +1160,9 @@ func validateAgentConfig(cfg *Config) error {
 			return err
 		}
 		if err := validateAgentProviderFields(cfg, name, entry); err != nil {
+			return err
+		}
+		if err := validateProviderEntryRemote("providers.agent."+name, entry); err != nil {
 			return err
 		}
 		if err := validateProviderEntrySource("agent", name, entry); err != nil {

--- a/gestaltd/internal/config/remotes.go
+++ b/gestaltd/internal/config/remotes.go
@@ -1,0 +1,246 @@
+package config
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+)
+
+const DefaultRemoteName = "default"
+
+// RemoteConfig names one upstream gestaltd origin.
+type RemoteConfig struct {
+	URL     string `yaml:"url"`
+	Token   string `yaml:"token,omitempty"`
+	Default bool   `yaml:"default,omitempty"`
+}
+
+// EntryPlacementRemote returns the canonical remote name for provider placement.
+// An empty string means the entry builds locally.
+func EntryPlacementRemote(entry *ProviderEntry) string {
+	if entry == nil {
+		return ""
+	}
+	return strings.TrimSpace(entry.Remote)
+}
+
+// EntryBuildsLocal reports whether an entry should be built in-process locally.
+func EntryBuildsLocal(entry *ProviderEntry) bool {
+	if entry == nil {
+		return false
+	}
+	if entry.DevActive || entry.Local {
+		return true
+	}
+	return EntryPlacementRemote(entry) == ""
+}
+
+// ReferencedRemoteNames returns the sorted unique remote names referenced by
+// configured provider entries.
+func (cfg *Config) ReferencedRemoteNames() []string {
+	if cfg == nil {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	add := func(entry *ProviderEntry) {
+		if entry == nil || entry.DevActive || entry.Local {
+			return
+		}
+		if name := EntryPlacementRemote(entry); name != "" {
+			seen[name] = struct{}{}
+		}
+	}
+	for _, entry := range cfg.Apps {
+		add(entry)
+	}
+	for _, entries := range []map[string]*ProviderEntry{
+		cfg.Providers.Identity,
+		cfg.Providers.Authorization,
+		cfg.Providers.IndexedDB,
+		cfg.Providers.Workflow,
+		cfg.Providers.Agent,
+	} {
+		for _, entry := range entries {
+			add(entry)
+		}
+	}
+	if len(seen) == 0 {
+		return nil
+	}
+	return slices.Sorted(maps.Keys(seen))
+}
+
+// DefaultRemoteEntry returns the named default remote configuration.
+func (cfg *Config) DefaultRemoteEntry() (name string, remote *RemoteConfig, ok bool) {
+	if cfg == nil || len(cfg.Server.Remotes) == 0 {
+		return "", nil, false
+	}
+	var soleName string
+	var soleRemote *RemoteConfig
+	soleCount := 0
+	for name, remote := range cfg.Server.Remotes {
+		if remote == nil {
+			continue
+		}
+		if remote.Default {
+			return name, remote, true
+		}
+		soleName = name
+		soleRemote = remote
+		soleCount++
+	}
+	if soleCount == 1 {
+		return soleName, soleRemote, true
+	}
+	return "", nil, false
+}
+
+func canonicalizeLegacyRemoteConfig(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	legacyURL := strings.TrimSpace(cfg.Server.Remote)
+	if legacyURL == "" {
+		return nil
+	}
+	hadNamedRemotes := len(cfg.Server.Remotes) > 0
+	if cfg.Server.Remotes == nil {
+		cfg.Server.Remotes = make(map[string]*RemoteConfig)
+	}
+	// If named remotes already exist, fold the legacy scalar into an existing
+	// default entry only — never synthesize or promote one. This lets
+	// validateRemotesConfig catch the "no default" case for multi-remote
+	// configs instead of masking it.
+	if hadNamedRemotes {
+		if _, existing, ok := cfg.DefaultRemoteEntry(); ok && existing != nil {
+			if strings.TrimSpace(existing.URL) == "" {
+				existing.URL = legacyURL
+			}
+			if strings.TrimSpace(existing.Token) == "" {
+				existing.Token = strings.TrimSpace(cfg.Server.RemoteToken)
+			}
+		}
+		return nil
+	}
+	cfg.Server.Remotes[DefaultRemoteName] = &RemoteConfig{
+		URL:     legacyURL,
+		Token:   strings.TrimSpace(cfg.Server.RemoteToken),
+		Default: true,
+	}
+	stampDefaultRemote(cfg.Apps, DefaultRemoteName)
+	for _, entries := range []map[string]*ProviderEntry{
+		cfg.Providers.Identity,
+		cfg.Providers.Authorization,
+		cfg.Providers.IndexedDB,
+		cfg.Providers.Workflow,
+		cfg.Providers.Agent,
+	} {
+		stampDefaultRemote(entries, DefaultRemoteName)
+	}
+	return nil
+}
+
+// stampDefaultRemote sets remote to defaultName on every entry that does not
+// already name a remote and is not explicitly local or dev-active.
+func stampDefaultRemote(entries map[string]*ProviderEntry, defaultName string) {
+	for _, entry := range entries {
+		if entry == nil || entry.Local || entry.DevActive {
+			continue
+		}
+		if strings.TrimSpace(entry.Remote) != "" {
+			continue
+		}
+		entry.Remote = defaultName
+	}
+}
+
+// canonicalizeRemotes folds the legacy server.remote scalar into
+// server.remotes, stamps remote: default onto entries that should delegate,
+// backfills the default remote's token from server.remoteToken, and trims
+// scalar fields. Called from CanonicalizeStructure so every consumer
+// (Load, bootstrap, serve) sees placement-ready remotes.
+func canonicalizeRemotes(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	if err := canonicalizeLegacyRemoteConfig(cfg); err != nil {
+		return err
+	}
+	if _, defaultRemote, ok := cfg.DefaultRemoteEntry(); ok && defaultRemote != nil {
+		if strings.TrimSpace(defaultRemote.Token) == "" {
+			defaultRemote.Token = strings.TrimSpace(cfg.Server.RemoteToken)
+		}
+	}
+	trimmed := make(map[string]*RemoteConfig, len(cfg.Server.Remotes))
+	for name, remote := range cfg.Server.Remotes {
+		if remote == nil {
+			continue
+		}
+		remote.URL = strings.TrimRight(strings.TrimSpace(remote.URL), "/")
+		remote.Token = strings.TrimSpace(remote.Token)
+		trimmed[strings.TrimSpace(name)] = remote
+	}
+	cfg.Server.Remotes = trimmed
+	cfg.Server.Remote = strings.TrimRight(strings.TrimSpace(cfg.Server.Remote), "/")
+	cfg.Server.RemoteToken = strings.TrimSpace(cfg.Server.RemoteToken)
+	return nil
+}
+
+// validateRemotesConfig validates the canonicalized remotes config: required
+// URLs, origin checks, at most one default, known remote references.
+func validateRemotesConfig(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	defaultCount := 0
+	remoteCount := 0
+	for name, remote := range cfg.Server.Remotes {
+		if remote == nil {
+			return fmt.Errorf("config validation: server.remotes.%s is required", name)
+		}
+		remoteCount++
+		if remote.Default {
+			defaultCount++
+		}
+		if remote.URL == "" {
+			return fmt.Errorf("config validation: server.remotes.%s.url is required", name)
+		}
+		if err := validateHTTPOriginURL("server.remotes."+name+".url", remote.URL); err != nil {
+			return err
+		}
+	}
+	if defaultCount > 1 {
+		return fmt.Errorf("config validation: at most one server.remotes entry may set default: true")
+	}
+	if remoteCount > 1 && defaultCount == 0 {
+		return fmt.Errorf("config validation: exactly one server.remotes entry must set default: true when multiple remotes are configured")
+	}
+	for _, name := range cfg.ReferencedRemoteNames() {
+		if cfg.Server.Remotes[name] == nil {
+			return fmt.Errorf("config validation: remote %q is not defined under server.remotes", name)
+		}
+	}
+	return nil
+}
+
+func validateProviderEntryRemote(subject string, entry *ProviderEntry) error {
+	if entry == nil {
+		return nil
+	}
+	remote := strings.TrimSpace(entry.Remote)
+	if entry.Local && remote != "" {
+		return fmt.Errorf("config validation: %s cannot set both local: true and remote", subject)
+	}
+	return nil
+}
+
+func validateUnsupportedRemotePlacement(subject string, entry *ProviderEntry) error {
+	if err := validateProviderEntryRemote(subject, entry); err != nil {
+		return err
+	}
+	if entry != nil && strings.TrimSpace(entry.Remote) != "" {
+		return fmt.Errorf("config validation: %s does not support remote placement", subject)
+	}
+	return nil
+}

--- a/gestaltd/internal/daemon/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e_test.go
@@ -452,11 +452,15 @@ func TestRunServeLockedUsesOverrideLockfile(t *testing.T) {
 	if err := config.ApplyServeRemoteOverrides(cfg, "", "test-token"); err != nil {
 		t.Fatalf("ApplyServeRemoteOverrides: %v", err)
 	}
-	if got := cfg.Server.Remote; got != "https://valon.tools" {
-		t.Fatalf("Server.Remote = %q, want https://valon.tools", got)
-	}
-	if got := cfg.Server.RemoteToken; got != "test-token" {
-		t.Fatalf("Server.RemoteToken = %q, want test-token", got)
+	if _, defaultRemote, ok := cfg.DefaultRemoteEntry(); !ok || defaultRemote == nil {
+		t.Fatal("DefaultRemoteEntry: expected default remote")
+	} else {
+		if got := defaultRemote.URL; got != "https://valon.tools" {
+			t.Fatalf("default remote URL = %q, want https://valon.tools", got)
+		}
+		if got := defaultRemote.Token; got != "test-token" {
+			t.Fatalf("default remote token = %q, want test-token", got)
+		}
 	}
 	if cfg.Apps["example"] == nil {
 		t.Fatal(`Apps["example"] = nil`)

--- a/gestaltd/internal/daemon/run.go
+++ b/gestaltd/internal/daemon/run.go
@@ -410,6 +410,10 @@ func validateConfig(configFlags []string, lockfilePath, artifactsDir string, opt
 }
 
 func logConfigSummary(paths []string, cfg *config.Config) {
+	var remoteURL, remoteToken string
+	if _, r, ok := cfg.DefaultRemoteEntry(); ok && r != nil {
+		remoteURL, remoteToken = r.URL, r.Token
+	}
 	currentCLIReporter().Verbose(formatCLIFields("config loaded",
 		"config_files", paths,
 		"server_port", cfg.Server.PublicListener().Port,
@@ -417,8 +421,8 @@ func logConfigSummary(paths []string, cfg *config.Config) {
 		"server_management_addr", maskEmpty(cfg.Server.ManagementAddr()),
 		"server_base_url", maskEmpty(cfg.Server.BaseURL),
 		"server_encryption", maskSecret(cfg.Server.EncryptionKey),
-		"server_remote", maskEmpty(cfg.Server.Remote),
-		"server_remote_token", maskSecret(cfg.Server.RemoteToken),
+		"server_remote", maskEmpty(remoteURL),
+		"server_remote_token", maskSecret(remoteToken),
 		"authentication_provider", selectedProviderLabel(cfg.SelectedIdentityProvider()),
 		"runtime_secrets_provider", selectedProviderLabel(cfg.SelectedSecretsProvider()),
 		"telemetry_provider", selectedProviderLabel(cfg.SelectedTelemetryProvider()),

--- a/gestaltd/internal/remote/remote.go
+++ b/gestaltd/internal/remote/remote.go
@@ -170,3 +170,55 @@ func bearerTokenInterceptors(token string) (grpc.UnaryClientInterceptor, grpc.St
 	}
 	return unary, stream
 }
+
+// ClientSets maps named remotes to typed public gRPC clients.
+type ClientSets map[string]*ClientSet
+
+// NewClientSets dials every configured remote and returns typed clients keyed by
+// remote name.
+func NewClientSets(ctx context.Context, configs map[string]Config) (ClientSets, error) {
+	if len(configs) == 0 {
+		return nil, nil
+	}
+	sets := make(ClientSets, len(configs))
+	for name, cfg := range configs {
+		remoteName := strings.TrimSpace(name)
+		if remoteName == "" {
+			return nil, fmt.Errorf("remote: name is required")
+		}
+		clients, err := NewClientSet(ctx, cfg)
+		if err != nil {
+			for _, existing := range sets {
+				_ = existing.Close()
+			}
+			return nil, fmt.Errorf("remote %q: %w", remoteName, err)
+		}
+		sets[remoteName] = clients
+	}
+	return sets, nil
+}
+
+// Close releases every underlying gRPC connection.
+func (sets ClientSets) Close() error {
+	if len(sets) == 0 {
+		return nil
+	}
+	var first error
+	for name, clients := range sets {
+		if clients == nil {
+			continue
+		}
+		if err := clients.Close(); err != nil && first == nil {
+			first = fmt.Errorf("remote %q: %w", name, err)
+		}
+	}
+	return first
+}
+
+// Get returns the client set for a named remote.
+func (sets ClientSets) Get(name string) *ClientSet {
+	if len(sets) == 0 {
+		return nil
+	}
+	return sets[strings.TrimSpace(name)]
+}

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -85,7 +85,7 @@ func run(ctx context.Context, cfg *config.Config, result *bootstrap.Result, onRe
 		authorizationProvider = result.Authorization[authorizationName]
 	}
 	var publicIndexedDB indexeddb.IndexedDB
-	if strings.TrimSpace(cfg.Server.Remote) == "" && result.Services != nil {
+	if _, indexedDBEntry, err := cfg.SelectedIndexedDBProvider(); err == nil && config.EntryBuildsLocal(indexedDBEntry) && result.Services != nil {
 		publicIndexedDB = result.Services.DB
 	}
 	appRuntimeState, _ := result.AppRestarter.(AppRuntimeState)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements [issue-132](https://valon.tools/g-issues/issues/issue-132) from [plan-38](https://valon.tools/g-issues/plans/plan-38): a named `server.remotes` configuration model with per-entry `remote` placement, legacy `server.remote` canonicalization, and per-remote `ClientSet` forward routing in bootstrap.

## Context

Reverse remotes let a developer run a provider under `gestaltd serve` on a laptop while a shared upstream `gestaltd` routes that provider's traffic back through a tunnel. Prerequisite plan: [plan-42: Universal ProviderGateway routing](https://valon.tools/g-issues/plans/plan-42). This issue is RR-2 only: the named remotes config surface and forward-routing consumption. Reverse publication (RR-6), registration (RR-3/RR-4), and ProviderGateway route unification (plan-42) remain out of scope.

## Design

### New config surface

```yaml
server:
  remotes:
    prod:
      url: https://valon.tools
      token: ${GESTALT_API_KEY}
      default: true
    dev:
      url: https://vt.dev.valon.tools/
      token: ${GESTALT_DEV_API_KEY}

apps:
  linear:
    remote: prod
  github:
    remote: dev
  local-tool: {}

providers:
  workflow:
    billing:
      source: ./billing-workflow-provider.yaml
      remote: prod
```

### Proposed Go schema

```go
// RemoteConfig names one upstream gestaltd origin.
type RemoteConfig struct {
	URL     string `yaml:"url"`
	Token   string `yaml:"token,omitempty"`
	Default bool   `yaml:"default,omitempty"`
}

// ServerConfig gains:
Remotes map[string]*RemoteConfig `yaml:"remotes,omitempty"`

// ProviderEntry gains one scalar placement field:
Remote string `yaml:"remote,omitempty"`
```

### Canonicalization and placement logic

```mermaid
flowchart TD
    Load[Load and merge config] --> Legacy{server.remote scalar set}
    Legacy -->|yes| Canon["Synthesize server.remotes.default from server.remote and remoteToken with default true"]
    Canon --> Stamp["Stamp remote: default on every app entry that is not Local and not DevActive"]
    Legacy -->|no| Validate
    Stamp --> Validate{Validate}
    Validate --> V1["At most one remotes entry has default true"]
    Validate --> V2["Every entry remote references an existing remotes name"]
    Validate --> V3["local true and remote are mutually exclusive"]
    Validate --> V4["Each remotes URL passes validateHTTPOriginURL"]
    V1 --> Place
    V2 --> Place
    V3 --> Place
    V4 --> Place
    Place{Per-entry placement} -->|"entry.DevActive or entry.Local"| BuildLocal[Build locally]
    Place -->|"entry.Remote is empty"| BuildLocal
    Place -->|"entry.Remote names a remote"| Delegate[Forward-delegate to that named remote]
```

Key semantic note: today an app with neither `Local` nor `DevActive` delegates whenever `server.remote` is set. In the canonical model, omitting `remote` means LOCAL placement. Legacy configs keep their old meaning only because canonicalization stamps `remote: default` onto implicitly remote apps.

### Current state (verified excerpts)

`gestaltd/internal/config/config.go` (apiVersion `gestaltd.config/v8`):

```go
type ServerConfig struct {
	...
	Remote      string                `yaml:"remote,omitempty" json:"remote,omitempty"`
	RemoteToken string                `yaml:"remoteToken,omitempty" json:"remoteToken,omitempty"`
	Providers   ServerProvidersConfig `yaml:"providers,omitempty"`
	...
}
```

`ProviderEntry` placement knobs before this change:

```go
type ProviderEntry struct {
	Source  ProviderSource `yaml:"source"`
	Default bool           `yaml:"default,omitempty"`
	// Local forces this provider to build in-process locally even when
	// server.remote delegates other host providers to a remote gestaltd.
	Local           bool                                   `yaml:"local,omitempty"`
	...
	DevActive          bool                                  `yaml:"-"`
	...
}
```

Placement decision before this change (`gestaltd/internal/bootstrap/bootstrap.go`):

```go
func providerBuildsLocal(cfg *config.Config, entry *config.ProviderEntry) bool {
	if entry == nil {
		return false
	}
	if entry.DevActive || entry.Local {
		return true
	}
	return cfg == nil || strings.TrimSpace(cfg.Server.Remote) == ""
}
```

The remote package before this change (`gestaltd/internal/remote/remote.go`):

```go
type Config struct {
	URL       string
	Token     string
	TLSConfig *tls.Config
}

type ClientSet struct {
	App                 proto.AppClient
	Agent               proto.AgentClient
	Workflow            proto.WorkflowClient
	IndexedDB           proto.IndexedDBClient
	Identity            proto.IdentityClient
	Authorization       proto.AuthorizationClient
	ExternalCredentials proto.ExternalCredentialsClient

	conn *grpc.ClientConn
}
```

### Files touched

```mermaid
treeView-beta
  gestaltd/
    internal/
      config/
        config.go
        config_validate.go
        remotes.go
        remotes_test.go
        config_test.go
      bootstrap/
        bootstrap.go
        provider_build.go
        provider_build_test.go
        remote_clients.go
      remote/
        clientsets.go
```

## Implementation summary

- Added `server.remotes` map (`RemoteConfig`) and per-entry `remote` field on `ProviderEntry`.
- Canonicalize legacy `server.remote` / `remoteToken` into `remotes.default` and stamp `remote: default` on implicitly remote apps.
- Validate at most one default remote, known remote references, `local` + `remote` conflicts, and origin-only URLs.
- `providerBuildsLocal` now delegates only when an entry names a remote; empty `remote` means local placement.
- Bootstrap builds `remote.ClientSets` for each referenced remote and resolves per-entry clients for apps and host providers.
- `ApplyServeRemoteOverrides` targets the canonical default remote.
- Config apiVersion remains `gestaltd.config/v8` (additive optional fields only).

## Acceptance criteria

- [x] Functional config tests: multi-remote configs load; failures for double `default: true`, unknown `remote` reference, and `local` + `remote` conflict; each `remotes.*.url` validated as an origin; legacy scalar configs canonicalize with placement parity.
- [x] Forward routing works against two named remotes in the existing harness (`provider_build_test.go`), proving per-remote `ClientSet` selection.
- [x] `ApplyServeRemoteOverrides` continues to work for legacy `--remote/--remote-token` flags by targeting the canonical default remote.
- [x] Config apiVersion unchanged; documented in this PR.

## Out of scope

`gestaltd serve` reverse publication (RR-6), reverse registration, and ProviderGateway route unification (plan-42).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-edda03c1-31d5-4ab9-a4a7-91b490c033af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-edda03c1-31d5-4ab9-a4a7-91b490c033af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

