### PR TITLE
sdk/rust: generate both sync and async public client methods

### DIFF
--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -20,7 +20,7 @@ http = "1"
 libc = "0.2"
 prost = "0.14"
 prost-types = "0.14"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "blocking"] }
 schemars = { version = "0.8", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/sdk/rust/src/public/generated/app_client.rs
+++ b/sdk/rust/src/public/generated/app_client.rs
@@ -124,11 +124,11 @@ use crate::public::generated::workflow::{
 };
 
 /// Transport-neutral client for the public gestaltd App surface.
-pub struct AgentClient<T: UnaryTransport> {
+pub struct AgentClient<T: Send + Sync> {
     transport: T,
 }
 
-impl<T: UnaryTransport> AgentClient<T> {
+impl<T: Send + Sync> AgentClient<T> {
     /// Creates a client over the given unary transport.
     pub fn new(transport: T) -> Self {
         Self { transport }
@@ -250,12 +250,118 @@ impl<T: UnaryTransport> AgentClient<T> {
     }
 }
 
+impl<T: crate::public::generated::unary_transport::SyncUnaryTransport> AgentClient<T> {
+    pub fn create_session_sync(
+        &self,
+        request: CreateAgentProviderSessionRequest,
+    ) -> Result<AgentSession, GestaltError> {
+        let wire = to_wire_create_agent_provider_session_request(request);
+        let mut wire_response = crate::generated::v1::AgentSession::default();
+        self.transport
+            .unary(&METHOD_AGENT_CREATE_SESSION, &wire, &mut wire_response)?;
+        Ok(from_wire_agent_session(wire_response))
+    }
+
+    pub fn get_session_sync(
+        &self,
+        request: GetAgentProviderSessionRequest,
+    ) -> Result<AgentSession, GestaltError> {
+        let wire = to_wire_get_agent_provider_session_request(request);
+        let mut wire_response = crate::generated::v1::AgentSession::default();
+        self.transport
+            .unary(&METHOD_AGENT_GET_SESSION, &wire, &mut wire_response)?;
+        Ok(from_wire_agent_session(wire_response))
+    }
+
+    pub fn list_sessions_sync(
+        &self,
+        request: ListAgentProviderSessionsRequest,
+    ) -> Result<ListAgentProviderSessionsResponse, GestaltError> {
+        let wire = to_wire_list_agent_provider_sessions_request(request);
+        let mut wire_response = crate::generated::v1::ListAgentProviderSessionsResponse::default();
+        self.transport
+            .unary(&METHOD_AGENT_LIST_SESSIONS, &wire, &mut wire_response)?;
+        Ok(from_wire_list_agent_provider_sessions_response(
+            wire_response,
+        ))
+    }
+
+    pub fn update_session_sync(
+        &self,
+        request: UpdateAgentProviderSessionRequest,
+    ) -> Result<AgentSession, GestaltError> {
+        let wire = to_wire_update_agent_provider_session_request(request);
+        let mut wire_response = crate::generated::v1::AgentSession::default();
+        self.transport
+            .unary(&METHOD_AGENT_UPDATE_SESSION, &wire, &mut wire_response)?;
+        Ok(from_wire_agent_session(wire_response))
+    }
+
+    pub fn create_turn_sync(
+        &self,
+        request: CreateAgentProviderTurnRequest,
+    ) -> Result<AgentTurn, GestaltError> {
+        let wire = to_wire_create_agent_provider_turn_request(request);
+        let mut wire_response = crate::generated::v1::AgentTurn::default();
+        self.transport
+            .unary(&METHOD_AGENT_CREATE_TURN, &wire, &mut wire_response)?;
+        Ok(from_wire_agent_turn(wire_response))
+    }
+
+    pub fn get_turn_sync(
+        &self,
+        request: GetAgentProviderTurnRequest,
+    ) -> Result<AgentTurn, GestaltError> {
+        let wire = to_wire_get_agent_provider_turn_request(request);
+        let mut wire_response = crate::generated::v1::AgentTurn::default();
+        self.transport
+            .unary(&METHOD_AGENT_GET_TURN, &wire, &mut wire_response)?;
+        Ok(from_wire_agent_turn(wire_response))
+    }
+
+    pub fn list_turns_sync(
+        &self,
+        request: ListAgentProviderTurnsRequest,
+    ) -> Result<ListAgentProviderTurnsResponse, GestaltError> {
+        let wire = to_wire_list_agent_provider_turns_request(request);
+        let mut wire_response = crate::generated::v1::ListAgentProviderTurnsResponse::default();
+        self.transport
+            .unary(&METHOD_AGENT_LIST_TURNS, &wire, &mut wire_response)?;
+        Ok(from_wire_list_agent_provider_turns_response(wire_response))
+    }
+
+    pub fn cancel_turn_sync(
+        &self,
+        request: CancelAgentProviderTurnRequest,
+    ) -> Result<AgentTurn, GestaltError> {
+        let wire = to_wire_cancel_agent_provider_turn_request(request);
+        let mut wire_response = crate::generated::v1::AgentTurn::default();
+        self.transport
+            .unary(&METHOD_AGENT_CANCEL_TURN, &wire, &mut wire_response)?;
+        Ok(from_wire_agent_turn(wire_response))
+    }
+
+    pub fn list_turn_events_sync(
+        &self,
+        request: ListAgentProviderTurnEventsRequest,
+    ) -> Result<ListAgentProviderTurnEventsResponse, GestaltError> {
+        let wire = to_wire_list_agent_provider_turn_events_request(request);
+        let mut wire_response =
+            crate::generated::v1::ListAgentProviderTurnEventsResponse::default();
+        self.transport
+            .unary(&METHOD_AGENT_LIST_TURN_EVENTS, &wire, &mut wire_response)?;
+        Ok(from_wire_list_agent_provider_turn_events_response(
+            wire_response,
+        ))
+    }
+}
+
 /// Transport-neutral client for the public gestaltd App surface.
-pub struct AppClient<T: UnaryTransport> {
+pub struct AppClient<T: Send + Sync> {
     transport: T,
 }
 
-impl<T: UnaryTransport> AppClient<T> {
+impl<T: Send + Sync> AppClient<T> {
     /// Creates a client over the given unary transport.
     pub fn new(transport: T) -> Self {
         Self { transport }
@@ -322,12 +428,67 @@ impl<T: UnaryTransport> AppClient<T> {
     }
 }
 
+impl<T: crate::public::generated::unary_transport::SyncUnaryTransport> AppClient<T> {
+    pub fn invoke_raw_sync(
+        &self,
+        request: AppInvokeRequest,
+    ) -> Result<OperationResult, GestaltError> {
+        let wire = to_wire_app_invoke_request(request);
+        let mut wire_response = crate::generated::v1::OperationResult::default();
+        self.transport
+            .unary(&METHOD_APP_INVOKE, &wire, &mut wire_response)?;
+        Ok(from_wire_operation_result(wire_response))
+    }
+
+    pub fn invoke_sync(&self, request: AppInvokeRequest) -> Result<serde_json::Value, InvokeError> {
+        let invoke_app = request.app.clone();
+        let invoke_operation = request.operation.clone();
+        let response = self.invoke_raw_sync(request)?;
+        decode_app_result(
+            invoke_app.as_str(),
+            invoke_operation.as_str(),
+            response.status,
+            &response.body,
+        )
+        .map_err(InvokeError::from)
+    }
+
+    pub fn invoke_graphql_sync(
+        &self,
+        request: AppInvokeGraphQLRequest,
+    ) -> Result<OperationResult, GestaltError> {
+        let wire = to_wire_app_invoke_graphql_request(request);
+        let mut wire_response = crate::generated::v1::OperationResult::default();
+        self.transport
+            .unary(&METHOD_APP_INVOKE_GRAPHQL, &wire, &mut wire_response)?;
+        Ok(from_wire_operation_result(wire_response))
+    }
+
+    /// `invoke_graphql_raw` is an alias for [`Self::invoke_graphql`].
+    pub fn invoke_graphql_raw_sync(
+        &self,
+        request: AppInvokeGraphQLRequest,
+    ) -> Result<OperationResult, GestaltError> {
+        self.invoke_graphql_sync(request)
+    }
+
+    pub fn invoke_graphql_decoded_sync(
+        &self,
+        request: AppInvokeGraphQLRequest,
+    ) -> Result<serde_json::Value, InvokeError> {
+        let invoke_app = request.app.clone();
+        let response = self.invoke_graphql_sync(request)?;
+        decode_graphql_result(invoke_app.as_str(), response.status, &response.body)
+            .map_err(InvokeError::from)
+    }
+}
+
 /// Transport-neutral client for the public gestaltd App surface.
-pub struct AuthorizationClient<T: UnaryTransport> {
+pub struct AuthorizationClient<T: Send + Sync> {
     transport: T,
 }
 
-impl<T: UnaryTransport> AuthorizationClient<T> {
+impl<T: Send + Sync> AuthorizationClient<T> {
     /// Creates a client over the given unary transport.
     pub fn new(transport: T) -> Self {
         Self { transport }
@@ -480,12 +641,140 @@ impl<T: UnaryTransport> AuthorizationClient<T> {
     }
 }
 
+impl<T: crate::public::generated::unary_transport::SyncUnaryTransport> AuthorizationClient<T> {
+    pub fn check_access_sync(
+        &self,
+        request: CheckAccessRequest,
+    ) -> Result<CheckAccessResponse, GestaltError> {
+        let wire = to_wire_check_access_request(request);
+        let mut wire_response = crate::generated::v1::CheckAccessResponse::default();
+        self.transport.unary(
+            &METHOD_AUTHORIZATION_CHECK_ACCESS,
+            &wire,
+            &mut wire_response,
+        )?;
+        Ok(from_wire_check_access_response(wire_response))
+    }
+
+    pub fn check_access_many_sync(
+        &self,
+        request: CheckAccessManyRequest,
+    ) -> Result<CheckAccessManyResponse, GestaltError> {
+        let wire = to_wire_check_access_many_request(request);
+        let mut wire_response = crate::generated::v1::CheckAccessManyResponse::default();
+        self.transport.unary(
+            &METHOD_AUTHORIZATION_CHECK_ACCESS_MANY,
+            &wire,
+            &mut wire_response,
+        )?;
+        Ok(from_wire_check_access_many_response(wire_response))
+    }
+
+    pub fn list_relationships_sync(
+        &self,
+        request: ListRelationshipsRequest,
+    ) -> Result<ListRelationshipsResponse, GestaltError> {
+        let wire = to_wire_list_relationships_request(request);
+        let mut wire_response = crate::generated::v1::ListRelationshipsResponse::default();
+        self.transport.unary(
+            &METHOD_AUTHORIZATION_LIST_RELATIONSHIPS,
+            &wire,
+            &mut wire_response,
+        )?;
+        Ok(from_wire_list_relationships_response(wire_response))
+    }
+
+    pub fn add_relationship_sync(
+        &self,
+        request: AddRelationshipRequest,
+    ) -> Result<AddRelationshipResponse, GestaltError> {
+        let wire = to_wire_add_relationship_request(request);
+        let mut wire_response = crate::generated::v1::AddRelationshipResponse::default();
+        self.transport.unary(
+            &METHOD_AUTHORIZATION_ADD_RELATIONSHIP,
+            &wire,
+            &mut wire_response,
+        )?;
+        Ok(from_wire_add_relationship_response(wire_response))
+    }
+
+    pub fn delete_relationship_sync(
+        &self,
+        request: DeleteRelationshipRequest,
+    ) -> Result<DeleteRelationshipResponse, GestaltError> {
+        let wire = to_wire_delete_relationship_request(request);
+        let mut wire_response = crate::generated::v1::DeleteRelationshipResponse::default();
+        self.transport.unary(
+            &METHOD_AUTHORIZATION_DELETE_RELATIONSHIP,
+            &wire,
+            &mut wire_response,
+        )?;
+        Ok(from_wire_delete_relationship_response(wire_response))
+    }
+
+    pub fn set_authorization_state_sync(
+        &self,
+        request: SetAuthorizationStateRequest,
+    ) -> Result<SetAuthorizationStateResponse, GestaltError> {
+        let wire = to_wire_set_authorization_state_request(request);
+        let mut wire_response = crate::generated::v1::SetAuthorizationStateResponse::default();
+        self.transport.unary(
+            &METHOD_AUTHORIZATION_SET_AUTHORIZATION_STATE,
+            &wire,
+            &mut wire_response,
+        )?;
+        Ok(from_wire_set_authorization_state_response(wire_response))
+    }
+
+    pub fn get_active_model_ref_sync(&self) -> Result<GetActiveModelRefResponse, GestaltError> {
+        let wire = Empty::default();
+        let mut wire_response = crate::generated::v1::GetActiveModelRefResponse::default();
+        self.transport.unary(
+            &METHOD_AUTHORIZATION_GET_ACTIVE_MODEL_REF,
+            &wire,
+            &mut wire_response,
+        )?;
+        Ok(from_wire_get_active_model_ref_response(wire_response))
+    }
+
+    pub fn set_active_model_sync(
+        &self,
+        request: SetActiveModelRequest,
+    ) -> Result<SetActiveModelResponse, GestaltError> {
+        let wire = to_wire_set_active_model_request(request);
+        let mut wire_response = crate::generated::v1::SetActiveModelResponse::default();
+        self.transport.unary(
+            &METHOD_AUTHORIZATION_SET_ACTIVE_MODEL,
+            &wire,
+            &mut wire_response,
+        )?;
+        Ok(from_wire_set_active_model_response(wire_response))
+    }
+
+    pub fn list_active_model_resource_types_sync(
+        &self,
+        request: ListActiveModelResourceTypesRequest,
+    ) -> Result<ListActiveModelResourceTypesResponse, GestaltError> {
+        let wire = to_wire_list_active_model_resource_types_request(request);
+        let mut wire_response =
+            crate::generated::v1::ListActiveModelResourceTypesResponse::default();
+        self.transport.unary(
+            &METHOD_AUTHORIZATION_LIST_ACTIVE_MODEL_RESOURCE_TYPES,
+            &wire,
+            &mut wire_response,
+        )?;
+        Ok(from_wire_list_active_model_resource_types_response(
+            wire_response,
+        ))
+    }
+}
+
 /// Transport-neutral client for the public gestaltd App surface.
-pub struct ExternalCredentialsClient<T: UnaryTransport> {
+pub struct ExternalCredentialsClient<T: Send + Sync> {
     transport: T,
 }
 
-impl<T: UnaryTransport> ExternalCredentialsClient<T> {
+impl<T: Send + Sync> ExternalCredentialsClient<T> {
     /// Creates a client over the given unary transport.
     pub fn new(transport: T) -> Self {
         Self { transport }
@@ -627,11 +916,11 @@ impl<T: crate::public::generated::unary_transport::GrpcCapable> ExternalCredenti
 }
 
 /// Transport-neutral client for the public gestaltd App surface.
-pub struct IdentityClient<T: UnaryTransport> {
+pub struct IdentityClient<T: Send + Sync> {
     transport: T,
 }
 
-impl<T: UnaryTransport> IdentityClient<T> {
+impl<T: Send + Sync> IdentityClient<T> {
     /// Creates a client over the given unary transport.
     pub fn new(transport: T) -> Self {
         Self { transport }
@@ -721,12 +1010,88 @@ impl<T: UnaryTransport> IdentityClient<T> {
     }
 }
 
+impl<T: crate::public::generated::unary_transport::SyncUnaryTransport> IdentityClient<T> {
+    pub fn authorize_sync(
+        &self,
+        request: AuthorizeRequest,
+    ) -> Result<AuthorizeResponse, GestaltError> {
+        let wire = to_wire_authorize_request(request);
+        let mut wire_response = crate::generated::v1::AuthorizeResponse::default();
+        self.transport
+            .unary(&METHOD_IDENTITY_AUTHORIZE, &wire, &mut wire_response)?;
+        Ok(from_wire_authorize_response(wire_response))
+    }
+
+    pub fn token_sync(&self, request: TokenRequest) -> Result<TokenResponse, GestaltError> {
+        let wire = to_wire_token_request(request);
+        let mut wire_response = crate::generated::v1::TokenResponse::default();
+        self.transport
+            .unary(&METHOD_IDENTITY_TOKEN, &wire, &mut wire_response)?;
+        Ok(from_wire_token_response(wire_response))
+    }
+
+    pub fn introspect_sync(
+        &self,
+        request: IntrospectRequest,
+    ) -> Result<IntrospectResponse, GestaltError> {
+        let wire = to_wire_introspect_request(request);
+        let mut wire_response = crate::generated::v1::IntrospectResponse::default();
+        self.transport
+            .unary(&METHOD_IDENTITY_INTROSPECT, &wire, &mut wire_response)?;
+        Ok(from_wire_introspect_response(wire_response))
+    }
+
+    pub fn user_info_sync(
+        &self,
+        request: UserInfoRequest,
+    ) -> Result<UserInfoResponse, GestaltError> {
+        let wire = to_wire_user_info_request(request);
+        let mut wire_response = crate::generated::v1::UserInfoResponse::default();
+        self.transport
+            .unary(&METHOD_IDENTITY_USER_INFO, &wire, &mut wire_response)?;
+        Ok(from_wire_user_info_response(wire_response))
+    }
+
+    pub fn list_grants_sync(
+        &self,
+        request: ListGrantsRequest,
+    ) -> Result<ListGrantsResponse, GestaltError> {
+        let wire = to_wire_list_grants_request(request);
+        let mut wire_response = crate::generated::v1::ListGrantsResponse::default();
+        self.transport
+            .unary(&METHOD_IDENTITY_LIST_GRANTS, &wire, &mut wire_response)?;
+        Ok(from_wire_list_grants_response(wire_response))
+    }
+
+    pub fn get_grant_sync(
+        &self,
+        request: GetGrantRequest,
+    ) -> Result<GetGrantResponse, GestaltError> {
+        let wire = to_wire_get_grant_request(request);
+        let mut wire_response = crate::generated::v1::GetGrantResponse::default();
+        self.transport
+            .unary(&METHOD_IDENTITY_GET_GRANT, &wire, &mut wire_response)?;
+        Ok(from_wire_get_grant_response(wire_response))
+    }
+
+    pub fn revoke_grant_sync(
+        &self,
+        request: RevokeGrantRequest,
+    ) -> Result<RevokeGrantResponse, GestaltError> {
+        let wire = to_wire_revoke_grant_request(request);
+        let mut wire_response = crate::generated::v1::RevokeGrantResponse::default();
+        self.transport
+            .unary(&METHOD_IDENTITY_REVOKE_GRANT, &wire, &mut wire_response)?;
+        Ok(from_wire_revoke_grant_response(wire_response))
+    }
+}
+
 /// Transport-neutral client for the public gestaltd App surface.
-pub struct IndexedDBClient<T: UnaryTransport> {
+pub struct IndexedDBClient<T: Send + Sync> {
     transport: T,
 }
 
-impl<T: UnaryTransport> IndexedDBClient<T> {
+impl<T: Send + Sync> IndexedDBClient<T> {
     /// Creates a client over the given unary transport.
     pub fn new(transport: T) -> Self {
         Self { transport }
@@ -964,11 +1329,11 @@ impl<T: crate::public::generated::unary_transport::GrpcCapable> IndexedDBClient<
 }
 
 /// Transport-neutral client for the public gestaltd App surface.
-pub struct WorkflowClient<T: UnaryTransport> {
+pub struct WorkflowClient<T: Send + Sync> {
     transport: T,
 }
 
-impl<T: UnaryTransport> WorkflowClient<T> {
+impl<T: Send + Sync> WorkflowClient<T> {
     /// Creates a client over the given unary transport.
     pub fn new(transport: T) -> Self {
         Self { transport }
@@ -1168,6 +1533,185 @@ impl<T: UnaryTransport> WorkflowClient<T> {
                 &mut wire_response,
             )
             .await?;
+        Ok(from_wire_signal_workflow_run_response(wire_response))
+    }
+}
+
+impl<T: crate::public::generated::unary_transport::SyncUnaryTransport> WorkflowClient<T> {
+    pub fn apply_definition_sync(
+        &self,
+        request: ApplyWorkflowProviderDefinitionRequest,
+    ) -> Result<WorkflowDefinition, GestaltError> {
+        let wire = to_wire_apply_workflow_provider_definition_request(request);
+        let mut wire_response = crate::generated::v1::WorkflowDefinition::default();
+        self.transport
+            .unary(&METHOD_WORKFLOW_APPLY_DEFINITION, &wire, &mut wire_response)?;
+        Ok(from_wire_workflow_definition(wire_response))
+    }
+
+    pub fn get_definition_sync(
+        &self,
+        request: GetWorkflowProviderDefinitionRequest,
+    ) -> Result<WorkflowDefinition, GestaltError> {
+        let wire = to_wire_get_workflow_provider_definition_request(request);
+        let mut wire_response = crate::generated::v1::WorkflowDefinition::default();
+        self.transport
+            .unary(&METHOD_WORKFLOW_GET_DEFINITION, &wire, &mut wire_response)?;
+        Ok(from_wire_workflow_definition(wire_response))
+    }
+
+    pub fn list_definitions_sync(
+        &self,
+        request: ListWorkflowProviderDefinitionsRequest,
+    ) -> Result<ListWorkflowProviderDefinitionsResponse, GestaltError> {
+        let wire = to_wire_list_workflow_provider_definitions_request(request);
+        let mut wire_response =
+            crate::generated::v1::ListWorkflowProviderDefinitionsResponse::default();
+        self.transport
+            .unary(&METHOD_WORKFLOW_LIST_DEFINITIONS, &wire, &mut wire_response)?;
+        Ok(from_wire_list_workflow_provider_definitions_response(
+            wire_response,
+        ))
+    }
+
+    pub fn set_definition_paused_sync(
+        &self,
+        request: SetWorkflowProviderDefinitionPausedRequest,
+    ) -> Result<WorkflowDefinition, GestaltError> {
+        let wire = to_wire_set_workflow_provider_definition_paused_request(request);
+        let mut wire_response = crate::generated::v1::WorkflowDefinition::default();
+        self.transport.unary(
+            &METHOD_WORKFLOW_SET_DEFINITION_PAUSED,
+            &wire,
+            &mut wire_response,
+        )?;
+        Ok(from_wire_workflow_definition(wire_response))
+    }
+
+    pub fn set_activation_paused_sync(
+        &self,
+        request: SetWorkflowProviderActivationPausedRequest,
+    ) -> Result<WorkflowDefinition, GestaltError> {
+        let wire = to_wire_set_workflow_provider_activation_paused_request(request);
+        let mut wire_response = crate::generated::v1::WorkflowDefinition::default();
+        self.transport.unary(
+            &METHOD_WORKFLOW_SET_ACTIVATION_PAUSED,
+            &wire,
+            &mut wire_response,
+        )?;
+        Ok(from_wire_workflow_definition(wire_response))
+    }
+
+    pub fn delete_definition_sync(
+        &self,
+        request: DeleteWorkflowProviderDefinitionRequest,
+    ) -> Result<(), GestaltError> {
+        let wire = to_wire_delete_workflow_provider_definition_request(request);
+        let mut wire_response = Empty::default();
+        self.transport.unary(
+            &METHOD_WORKFLOW_DELETE_DEFINITION,
+            &wire,
+            &mut wire_response,
+        )?;
+        Ok(())
+    }
+
+    pub fn start_run_sync(
+        &self,
+        request: StartWorkflowProviderRunRequest,
+    ) -> Result<WorkflowRun, GestaltError> {
+        let wire = to_wire_start_workflow_provider_run_request(request);
+        let mut wire_response = crate::generated::v1::WorkflowRun::default();
+        self.transport
+            .unary(&METHOD_WORKFLOW_START_RUN, &wire, &mut wire_response)?;
+        Ok(from_wire_workflow_run(wire_response))
+    }
+
+    pub fn list_runs_sync(
+        &self,
+        request: ListWorkflowProviderRunsRequest,
+    ) -> Result<ListWorkflowProviderRunsResponse, GestaltError> {
+        let wire = to_wire_list_workflow_provider_runs_request(request);
+        let mut wire_response = crate::generated::v1::ListWorkflowProviderRunsResponse::default();
+        self.transport
+            .unary(&METHOD_WORKFLOW_LIST_RUNS, &wire, &mut wire_response)?;
+        Ok(from_wire_list_workflow_provider_runs_response(
+            wire_response,
+        ))
+    }
+
+    pub fn get_run_sync(
+        &self,
+        request: GetWorkflowProviderRunRequest,
+    ) -> Result<WorkflowRun, GestaltError> {
+        let wire = to_wire_get_workflow_provider_run_request(request);
+        let mut wire_response = crate::generated::v1::WorkflowRun::default();
+        self.transport
+            .unary(&METHOD_WORKFLOW_GET_RUN, &wire, &mut wire_response)?;
+        Ok(from_wire_workflow_run(wire_response))
+    }
+
+    pub fn get_run_events_sync(
+        &self,
+        request: GetWorkflowProviderRunEventsRequest,
+    ) -> Result<GetWorkflowProviderRunEventsResponse, GestaltError> {
+        let wire = to_wire_get_workflow_provider_run_events_request(request);
+        let mut wire_response =
+            crate::generated::v1::GetWorkflowProviderRunEventsResponse::default();
+        self.transport
+            .unary(&METHOD_WORKFLOW_GET_RUN_EVENTS, &wire, &mut wire_response)?;
+        Ok(from_wire_get_workflow_provider_run_events_response(
+            wire_response,
+        ))
+    }
+
+    pub fn get_run_output_sync(
+        &self,
+        request: GetWorkflowProviderRunOutputRequest,
+    ) -> Result<GetWorkflowProviderRunOutputResponse, GestaltError> {
+        let wire = to_wire_get_workflow_provider_run_output_request(request);
+        let mut wire_response =
+            crate::generated::v1::GetWorkflowProviderRunOutputResponse::default();
+        self.transport
+            .unary(&METHOD_WORKFLOW_GET_RUN_OUTPUT, &wire, &mut wire_response)?;
+        Ok(from_wire_get_workflow_provider_run_output_response(
+            wire_response,
+        ))
+    }
+
+    pub fn cancel_run_sync(
+        &self,
+        request: CancelWorkflowProviderRunRequest,
+    ) -> Result<WorkflowRun, GestaltError> {
+        let wire = to_wire_cancel_workflow_provider_run_request(request);
+        let mut wire_response = crate::generated::v1::WorkflowRun::default();
+        self.transport
+            .unary(&METHOD_WORKFLOW_CANCEL_RUN, &wire, &mut wire_response)?;
+        Ok(from_wire_workflow_run(wire_response))
+    }
+
+    pub fn signal_run_sync(
+        &self,
+        request: SignalWorkflowProviderRunRequest,
+    ) -> Result<SignalWorkflowRunResponse, GestaltError> {
+        let wire = to_wire_signal_workflow_provider_run_request(request);
+        let mut wire_response = crate::generated::v1::SignalWorkflowRunResponse::default();
+        self.transport
+            .unary(&METHOD_WORKFLOW_SIGNAL_RUN, &wire, &mut wire_response)?;
+        Ok(from_wire_signal_workflow_run_response(wire_response))
+    }
+
+    pub fn signal_or_start_run_sync(
+        &self,
+        request: SignalOrStartWorkflowProviderRunRequest,
+    ) -> Result<SignalWorkflowRunResponse, GestaltError> {
+        let wire = to_wire_signal_or_start_workflow_provider_run_request(request);
+        let mut wire_response = crate::generated::v1::SignalWorkflowRunResponse::default();
+        self.transport.unary(
+            &METHOD_WORKFLOW_SIGNAL_OR_START_RUN,
+            &wire,
+            &mut wire_response,
+        )?;
         Ok(from_wire_signal_workflow_run_response(wire_response))
     }
 }

--- a/sdk/rust/src/public/generated/unary_transport.rs
+++ b/sdk/rust/src/public/generated/unary_transport.rs
@@ -22,5 +22,19 @@ pub trait UnaryTransport: Send + Sync {
         Resp: Message + Default + Send + 'static;
 }
 
+/// Performs one unary public App call synchronously. REST-only; no gRPC
+/// transport implements this trait.
+pub trait SyncUnaryTransport: Send + Sync {
+    fn unary<Req, Resp>(
+        &self,
+        method: &Method,
+        request: &Req,
+        response: &mut Resp,
+    ) -> Result<(), GestaltError>
+    where
+        Req: Message + Clone + Send + Sync + 'static,
+        Resp: Message + Default + Send + 'static;
+}
+
 /// Marker for transports that can call gRPC-only public methods.
 pub trait GrpcCapable: UnaryTransport {}

--- a/sdk/rust/src/public/mod.rs
+++ b/sdk/rust/src/public/mod.rs
@@ -8,6 +8,7 @@ pub mod generated;
 pub mod grpc_transport;
 pub(crate) mod proto_json;
 pub mod rest_mapping;
+pub(crate) mod rest_request;
 pub mod rest_transport;
 
 pub use auth::{Auth, BearerAuth, NoAuth};
@@ -17,4 +18,4 @@ pub use client::{
     create_grpc_gestalt_client, create_rest_gestalt_client, grpc, rest,
 };
 pub use grpc_transport::{GrpcTransport, dial_public_grpc};
-pub use rest_transport::RestTransport;
+pub use rest_transport::{RestTransport, SyncRestTransport};

--- a/sdk/rust/src/public/rest_request.rs
+++ b/sdk/rust/src/public/rest_request.rs
@@ -1,0 +1,167 @@
+//! Shared request building and response decoding for REST transports.
+//!
+//! Both the async `RestTransport` and the sync `SyncRestTransport` use these
+//! pure helpers so the request assembly and response decoding logic lives in
+//! exactly one place. Only the HTTP I/O half differs between the transports.
+
+use std::sync::Arc;
+
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use http::HeaderMap;
+use reqwest::Method as HttpMethod;
+use reqwest::Url;
+use reqwest::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE, HeaderValue};
+use serde_json::{Map, Value};
+
+use crate::public::auth::Auth;
+use crate::public::errors::{is_operation_result, parse_gateway_error};
+use crate::public::generated::metadata::{DecodeResponseJson, Method};
+use crate::public::generated::rpc_support::GestaltError;
+use crate::public::rest_mapping::{
+    build_body_map, build_query_pairs, encode_query_string, substitute_path,
+};
+use crate::rpc_support::gestalt_error_code;
+
+/// Assembled REST request, ready for an HTTP send.
+pub(crate) struct PreparedRequest {
+    /// Target URL with path substitution and query string applied.
+    pub url: Url,
+    /// HTTP method (GET/POST/PUT/PATCH/DELETE).
+    pub method: HttpMethod,
+    /// Request headers (Accept, Content-Type, Authorization).
+    pub headers: HeaderMap,
+    /// JSON body for non-GET/DELETE requests; `None` for query-string requests.
+    pub body: Option<Value>,
+}
+
+/// Builds the REST request: encode wire bytes to protobuf JSON, substitute
+/// path parameters, assemble headers, and build the query string or JSON body.
+/// Pure sync; performs no I/O.
+pub(crate) fn build_rest_request(
+    method: &Method,
+    request_bytes: &[u8],
+    base_url: &str,
+    auth: &Arc<dyn Auth>,
+) -> Result<PreparedRequest, GestaltError> {
+    let encode = method.encode_request_json.ok_or_else(|| {
+        GestaltError::new(
+            gestalt_error_code::INVALID_ARGUMENT,
+            format!("method {} has no REST encoder", method.full_method),
+        )
+    })?;
+    if method.http_verb.is_empty() || method.http_path.is_empty() {
+        return Err(GestaltError::new(
+            gestalt_error_code::INVALID_ARGUMENT,
+            format!("method {} has no HTTP binding", method.full_method),
+        ));
+    }
+
+    let request_json = encode(request_bytes)?;
+    let path = substitute_path(method.http_path, &request_json, method.http_path_fields)?;
+    let mut url = Url::parse(&format!("{base_url}{path}"))
+        .map_err(|err| GestaltError::new(gestalt_error_code::INVALID_ARGUMENT, err.to_string()))?;
+
+    let mut headers = HeaderMap::new();
+    headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
+    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    if let Some(authorization) = auth.authorization_header() {
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(&authorization).map_err(|err| {
+                GestaltError::new(gestalt_error_code::INVALID_ARGUMENT, err.to_string())
+            })?,
+        );
+    }
+
+    let http_method: HttpMethod = method.http_verb.parse().map_err(|_| {
+        GestaltError::new(
+            gestalt_error_code::INVALID_ARGUMENT,
+            format!("unsupported HTTP verb {}", method.http_verb),
+        )
+    })?;
+
+    let body = if method.http_verb == "GET" || method.http_verb == "DELETE" {
+        if let Some(object) = request_json.as_object() {
+            let query = build_query_pairs(object, method.http_path_fields);
+            if !query.is_empty() {
+                url.set_query(Some(&encode_query_string(&query)));
+            }
+        }
+        None
+    } else {
+        request_json
+            .as_object()
+            .map(|object| Value::Object(build_body_map(object, method.http_path_fields)))
+    };
+
+    Ok(PreparedRequest {
+        url,
+        method: http_method,
+        headers,
+        body,
+    })
+}
+
+/// Decodes a REST response body into wire bytes suitable for prost decode.
+/// Handles the OperationResult envelope, error-status mapping, empty bodies,
+/// and protobuf-JSON decode. Pure sync; performs no I/O.
+pub(crate) fn decode_rest_response(
+    status: u16,
+    response_headers: &HeaderMap,
+    body: &[u8],
+    decode: DecodeResponseJson,
+) -> Result<Vec<u8>, GestaltError> {
+    let response_json = if is_operation_result(response_headers) {
+        fill_operation_result_json(status as i32, body, response_headers)
+    } else if status >= 400 {
+        return Err(parse_gateway_error(status, body));
+    } else if body.is_empty() {
+        Value::Object(Map::new())
+    } else {
+        serde_json::from_slice(body)
+            .map_err(|err| GestaltError::new(gestalt_error_code::INTERNAL, err.to_string()))?
+    };
+    decode(&response_json)
+}
+
+fn fill_operation_result_json(status: i32, body: &[u8], headers: &HeaderMap) -> Value {
+    Value::Object(Map::from_iter([
+        ("status".to_string(), Value::Number(status.into())),
+        ("body".to_string(), Value::String(BASE64.encode(body))),
+        (
+            "headers".to_string(),
+            Value::Object(headers_to_json(headers)),
+        ),
+    ]))
+}
+
+fn headers_to_json(headers: &HeaderMap) -> Map<String, Value> {
+    use std::collections::BTreeMap;
+    let mut grouped: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for (key, value) in headers.iter() {
+        if key
+            .as_str()
+            .eq_ignore_ascii_case(crate::public::errors::RESPONSE_KIND_HEADER)
+        {
+            continue;
+        }
+        if let Ok(text) = value.to_str() {
+            grouped
+                .entry(key.as_str().to_string())
+                .or_default()
+                .push(text.to_string());
+        }
+    }
+    let mut out = Map::new();
+    for (key, values) in grouped {
+        out.insert(
+            key,
+            Value::Object(Map::from_iter([(
+                "values".to_string(),
+                Value::Array(values.into_iter().map(Value::String).collect()),
+            )])),
+        );
+    }
+    out
+}

--- a/sdk/rust/src/public/rest_transport.rs
+++ b/sdk/rust/src/public/rest_transport.rs
@@ -1,31 +1,28 @@
-//! reqwest-based REST transport for the public Gestalt API (/api/v2).
+//! reqwest-based REST transports for the public Gestalt API (/api/v2).
+//!
+//! [`RestTransport`] is async (backed by `reqwest`); [`SyncRestTransport`] is
+//! sync (backed by `reqwest::blocking`). Both share request building and
+//! response decoding via shared helpers in the rest_request module.
 
 use std::sync::Arc;
 use std::time::Duration;
 
-use base64::Engine as _;
-use base64::engine::general_purpose::STANDARD as BASE64;
-use reqwest::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
-use reqwest::{Client, Url};
-use serde_json::{Map, Value};
+use prost::Message;
+use reqwest::header::HeaderMap;
 
 use crate::public::auth::Auth;
-use crate::public::errors::{RESPONSE_KIND_HEADER, is_operation_result, parse_gateway_error};
 use crate::public::generated::metadata::Method;
 use crate::public::generated::rpc_support::GestaltError;
-use crate::public::generated::unary_transport::UnaryTransport;
-use crate::public::rest_mapping::{
-    build_body_map, build_query_pairs, encode_query_string, substitute_path,
-};
+use crate::public::generated::unary_transport::{SyncUnaryTransport, UnaryTransport};
+use crate::public::rest_request::{build_rest_request, decode_rest_response};
 use crate::rpc_support::gestalt_error_code;
-use prost::Message;
 
-/// Protobuf-JSON REST transport implementing [`UnaryTransport`].
+/// Async reqwest-based REST transport implementing [`UnaryTransport`].
 #[derive(Clone)]
 pub struct RestTransport {
     base_url: String,
     auth: Arc<dyn Auth>,
-    client: Client,
+    client: reqwest::Client,
 }
 
 impl RestTransport {
@@ -34,7 +31,7 @@ impl RestTransport {
         Self {
             base_url: base_url.into(),
             auth,
-            client: Client::builder()
+            client: reqwest::Client::builder()
                 .use_rustls_tls()
                 .build()
                 .expect("reqwest client"),
@@ -43,13 +40,43 @@ impl RestTransport {
 
     /// Applies a per-request timeout to the underlying HTTP client.
     pub fn with_timeout(mut self, timeout: Duration) -> Self {
-        self.client = Client::builder()
+        self.client = reqwest::Client::builder()
             .use_rustls_tls()
             .timeout(timeout)
             .build()
             .expect("reqwest client");
         self
     }
+}
+
+fn map_send_error(err: reqwest::Error) -> GestaltError {
+    if err.is_timeout() {
+        GestaltError::new(gestalt_error_code::DEADLINE_EXCEEDED, err.to_string())
+    } else if err.is_request() {
+        GestaltError::new(gestalt_error_code::INVALID_ARGUMENT, err.to_string())
+    } else {
+        GestaltError::new(gestalt_error_code::UNAVAILABLE, err.to_string())
+    }
+}
+
+fn map_body_error(err: reqwest::Error) -> GestaltError {
+    GestaltError::new(gestalt_error_code::UNAVAILABLE, err.to_string())
+}
+
+fn finalize_response<Resp>(
+    status: u16,
+    response_headers: &HeaderMap,
+    body: &[u8],
+    decode: crate::public::generated::metadata::DecodeResponseJson,
+    response: &mut Resp,
+) -> Result<(), GestaltError>
+where
+    Resp: Message + Default + Send,
+{
+    let response_bytes = decode_rest_response(status, response_headers, body, decode)?;
+    *response = Resp::decode(response_bytes.as_slice())
+        .map_err(|err| GestaltError::new(gestalt_error_code::INTERNAL, err.to_string()))?;
+    Ok(())
 }
 
 impl UnaryTransport for RestTransport {
@@ -63,147 +90,97 @@ impl UnaryTransport for RestTransport {
         Req: Message + Send + Sync,
         Resp: Message + Default + Send,
     {
-        let encode = method.encode_request_json.ok_or_else(|| {
-            GestaltError::new(
-                gestalt_error_code::INVALID_ARGUMENT,
-                format!("method {} has no REST encoder", method.full_method),
-            )
-        });
+        let base_url = self.base_url.clone();
+        let auth = Arc::clone(&self.auth);
+        let client = self.client.clone();
+        let request_bytes = request.encode_to_vec();
+        let method = method.clone();
+
+        async move {
+            let decode = method.decode_response_json.ok_or_else(|| {
+                GestaltError::new(
+                    gestalt_error_code::INVALID_ARGUMENT,
+                    format!("method {} has no REST decoder", method.full_method),
+                )
+            })?;
+            let prepared = build_rest_request(&method, &request_bytes, &base_url, &auth)?;
+            let mut builder = client
+                .request(prepared.method, prepared.url)
+                .headers(prepared.headers);
+            if let Some(body) = prepared.body {
+                builder = builder.json(&body);
+            }
+            let http_response = builder.send().await.map_err(map_send_error)?;
+            let status = http_response.status();
+            let response_headers = http_response.headers().clone();
+            let body = http_response.bytes().await.map_err(map_body_error)?;
+            finalize_response(status.as_u16(), &response_headers, &body, decode, response)
+        }
+    }
+}
+
+/// Sync reqwest::blocking-based REST transport implementing [`SyncUnaryTransport`].
+#[derive(Clone)]
+pub struct SyncRestTransport {
+    base_url: String,
+    auth: Arc<dyn Auth>,
+    client: reqwest::blocking::Client,
+}
+
+impl SyncRestTransport {
+    /// Creates a sync REST transport rooted at `base_url`.
+    pub fn new(base_url: impl Into<String>, auth: Arc<dyn Auth>) -> Self {
+        Self {
+            base_url: base_url.into(),
+            auth,
+            client: reqwest::blocking::Client::builder()
+                .use_rustls_tls()
+                .build()
+                .expect("reqwest blocking client"),
+        }
+    }
+
+    /// Applies a per-request timeout to the underlying HTTP client.
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.client = reqwest::blocking::Client::builder()
+            .use_rustls_tls()
+            .timeout(timeout)
+            .build()
+            .expect("reqwest blocking client");
+        self
+    }
+}
+
+impl SyncUnaryTransport for SyncRestTransport {
+    fn unary<Req, Resp>(
+        &self,
+        method: &Method,
+        request: &Req,
+        response: &mut Resp,
+    ) -> Result<(), GestaltError>
+    where
+        Req: Message + Clone + Send + Sync + 'static,
+        Resp: Message + Default + Send + 'static,
+    {
         let decode = method.decode_response_json.ok_or_else(|| {
             GestaltError::new(
                 gestalt_error_code::INVALID_ARGUMENT,
                 format!("method {} has no REST decoder", method.full_method),
             )
-        });
-
-        let base_url = self.base_url.clone();
-        let auth = Arc::clone(&self.auth);
-        let client = self.client.clone();
-        let http_verb = method.http_verb.to_string();
-        let http_path = method.http_path.to_string();
-        let path_fields = method.http_path_fields.to_vec();
-        let full_method = method.full_method.to_string();
-        let request_bytes = request.encode_to_vec();
-
-        async move {
-            let encode = encode?;
-            let decode = decode?;
-            if http_verb.is_empty() || http_path.is_empty() {
-                return Err(GestaltError::new(
-                    gestalt_error_code::INVALID_ARGUMENT,
-                    format!("method {full_method} has no HTTP binding"),
-                ));
-            }
-
-            let request_json = encode(&request_bytes)?;
-            let path = substitute_path(&http_path, &request_json, &path_fields)?;
-            let mut url = Url::parse(&format!("{base_url}{path}")).map_err(|err| {
-                GestaltError::new(gestalt_error_code::INVALID_ARGUMENT, err.to_string())
-            })?;
-
-            let mut headers = HeaderMap::new();
-            headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
-            headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
-            if let Some(authorization) = auth.authorization_header() {
-                headers.insert(
-                    AUTHORIZATION,
-                    HeaderValue::from_str(&authorization).map_err(|err| {
-                        GestaltError::new(gestalt_error_code::INVALID_ARGUMENT, err.to_string())
-                    })?,
-                );
-            }
-
-            let http_method: reqwest::Method = http_verb.parse().map_err(|_| {
-                GestaltError::new(
-                    gestalt_error_code::INVALID_ARGUMENT,
-                    format!("unsupported HTTP verb {http_verb}"),
-                )
-            })?;
-            let mut builder = client
-                .request(http_method.clone(), url.clone())
-                .headers(headers.clone());
-            if http_verb == "GET" || http_verb == "DELETE" {
-                if let Some(object) = request_json.as_object() {
-                    let query = build_query_pairs(object, &path_fields);
-                    if !query.is_empty() {
-                        url.set_query(Some(&encode_query_string(&query)));
-                        builder = client.request(http_method, url).headers(headers);
-                    }
-                }
-            } else if let Some(object) = request_json.as_object() {
-                let body = build_body_map(object, &path_fields);
-                builder = builder.json(&Value::Object(body));
-            }
-
-            let http_response = builder.send().await.map_err(|err| {
-                if err.is_timeout() {
-                    GestaltError::new(gestalt_error_code::DEADLINE_EXCEEDED, err.to_string())
-                } else if err.is_request() {
-                    GestaltError::new(gestalt_error_code::INVALID_ARGUMENT, err.to_string())
-                } else {
-                    GestaltError::new(gestalt_error_code::UNAVAILABLE, err.to_string())
-                }
-            })?;
-            let status = http_response.status();
-            let response_headers = http_response.headers().clone();
-            let body = http_response.bytes().await.map_err(|err| {
-                GestaltError::new(gestalt_error_code::UNAVAILABLE, err.to_string())
-            })?;
-
-            let response_json = if is_operation_result(&response_headers) {
-                fill_operation_result_json(status.as_u16() as i32, &body, &response_headers)
-            } else if status.as_u16() >= 400 {
-                return Err(parse_gateway_error(status.as_u16(), &body));
-            } else if body.is_empty() {
-                Value::Object(Map::new())
-            } else {
-                serde_json::from_slice(&body).map_err(|err| {
-                    GestaltError::new(gestalt_error_code::INTERNAL, err.to_string())
-                })?
-            };
-
-            let response_bytes = decode(&response_json)?;
-            *response = Resp::decode(response_bytes.as_slice())
-                .map_err(|err| GestaltError::new(gestalt_error_code::INTERNAL, err.to_string()))?;
-            Ok(())
+        })?;
+        let prepared =
+            build_rest_request(method, &request.encode_to_vec(), &self.base_url, &self.auth)?;
+        let mut builder = self
+            .client
+            .request(prepared.method, prepared.url)
+            .headers(prepared.headers);
+        if let Some(body) = prepared.body {
+            builder = builder.json(&body);
         }
+        let http_response = builder.send().map_err(map_send_error)?;
+        let status = http_response.status();
+        let response_headers = http_response.headers().clone();
+        let body = http_response.bytes().map_err(map_body_error)?;
+        finalize_response(status.as_u16(), &response_headers, &body, decode, response)
     }
-}
-
-fn fill_operation_result_json(status: i32, body: &[u8], headers: &http::HeaderMap) -> Value {
-    Value::Object(Map::from_iter([
-        ("status".to_string(), Value::Number(status.into())),
-        ("body".to_string(), Value::String(BASE64.encode(body))),
-        (
-            "headers".to_string(),
-            Value::Object(headers_to_json(headers)),
-        ),
-    ]))
-}
-
-fn headers_to_json(headers: &http::HeaderMap) -> Map<String, Value> {
-    use std::collections::BTreeMap;
-    let mut grouped: BTreeMap<String, Vec<String>> = BTreeMap::new();
-    for (key, value) in headers.iter() {
-        if key.as_str().eq_ignore_ascii_case(RESPONSE_KIND_HEADER) {
-            continue;
-        }
-        if let Ok(text) = value.to_str() {
-            grouped
-                .entry(key.as_str().to_string())
-                .or_default()
-                .push(text.to_string());
-        }
-    }
-    let mut out = Map::new();
-    for (key, values) in grouped {
-        out.insert(
-            key,
-            Value::Object(Map::from_iter([(
-                "values".to_string(),
-                Value::Array(values.into_iter().map(Value::String).collect()),
-            )])),
-        );
-    }
-    out
 }

--- a/sdk/rust/tests/sync_rest_transport.rs
+++ b/sdk/rust/tests/sync_rest_transport.rs
@@ -1,0 +1,228 @@
+//! Tests for the sync REST transport (SyncRestTransport).
+
+use std::sync::Arc;
+
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use gestalt::public::auth::BearerAuth;
+use gestalt::public::generated::app_client::AuthorizationClient;
+use gestalt::public::generated::authorization::{
+    Action, CheckAccessRequest, ListRelationshipsRequest, RelationshipFilter, Resource, Subject,
+};
+use gestalt::public::rest_transport::SyncRestTransport;
+use gestalt::rpc_support::gestalt_error_code;
+use serde_json::json;
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+// wiremock::MockServer::start() is async, so we use a one-shot tokio runtime
+// to boot the server, then make blocking SDK calls against it.
+fn start_mock_server() -> MockServer {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    rt.block_on(MockServer::start())
+}
+
+fn sync_client(server: &MockServer) -> AuthorizationClient<SyncRestTransport> {
+    let transport = SyncRestTransport::new(server.uri(), Arc::new(BearerAuth::new("test-token")));
+    AuthorizationClient::new(transport)
+}
+
+#[test]
+fn sync_rest_transport_check_access_success() {
+    let server = start_mock_server();
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    rt.block_on(async {
+        Mock::given(method("POST"))
+            .and(path("/api/v2/authorization/access:check"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(json!({"allowed": true, "modelId": "model-1"})),
+            )
+            .mount(&server)
+            .await;
+    });
+
+    let client = sync_client(&server);
+    let resp = client
+        .check_access_sync(CheckAccessRequest {
+            subject: Some(Subject {
+                r#type: "user".to_string(),
+                id: "u1".to_string(),
+                properties: None,
+            }),
+            action: Some(Action {
+                name: "read".to_string(),
+                properties: None,
+            }),
+            resource: Some(Resource {
+                r#type: "doc".to_string(),
+                id: "d1".to_string(),
+                properties: None,
+            }),
+        })
+        .expect("check_access_sync should succeed");
+
+    assert!(resp.allowed);
+    assert_eq!(resp.model_id, "model-1");
+}
+
+#[test]
+fn sync_rest_transport_check_access_denied() {
+    let server = start_mock_server();
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    rt.block_on(async {
+        Mock::given(method("POST"))
+            .and(path("/api/v2/authorization/access:check"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(json!({"allowed": false, "modelId": "model-1"})),
+            )
+            .mount(&server)
+            .await;
+    });
+
+    let client = sync_client(&server);
+    let resp = client
+        .check_access_sync(CheckAccessRequest {
+            subject: Some(Subject {
+                r#type: "user".to_string(),
+                id: "u1".to_string(),
+                properties: None,
+            }),
+            action: Some(Action {
+                name: "read".to_string(),
+                properties: None,
+            }),
+            resource: Some(Resource {
+                r#type: "doc".to_string(),
+                id: "d1".to_string(),
+                properties: None,
+            }),
+        })
+        .expect("check_access_sync should succeed");
+
+    assert!(!resp.allowed);
+}
+
+#[test]
+fn sync_rest_transport_unauthenticated_error() {
+    let server = start_mock_server();
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    rt.block_on(async {
+        Mock::given(method("GET"))
+            .and(path("/api/v2/authorization/models/active"))
+            .respond_with(
+                ResponseTemplate::new(401)
+                    .set_body_json(json!({"code": "Unauthenticated", "error": "token expired"})),
+            )
+            .mount(&server)
+            .await;
+    });
+
+    let client = sync_client(&server);
+    let err = client
+        .get_active_model_ref_sync()
+        .expect_err("should fail with unauthenticated");
+
+    assert_eq!(err.code, gestalt_error_code::UNAUTHENTICATED);
+    assert_eq!(err.message, "token expired");
+}
+
+#[test]
+fn sync_rest_transport_list_relationships_query_params() {
+    let server = start_mock_server();
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    rt.block_on(async {
+        Mock::given(method("GET"))
+            .and(path("/api/v2/authorization/relationships"))
+            .and(query_param("filter.relation", "owner"))
+            .and(query_param("pageSize", "10"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(json!({"relationships": [], "nextPageToken": ""})),
+            )
+            .mount(&server)
+            .await;
+    });
+
+    let client = sync_client(&server);
+    let resp = client
+        .list_relationships_sync(ListRelationshipsRequest {
+            filter: Some(RelationshipFilter {
+                relation: "owner".to_string(),
+                target: None,
+                resource: None,
+                target_type: 0,
+                target_entity_type: String::new(),
+                resource_type: String::new(),
+                source_layer: 0,
+            }),
+            page_size: 10,
+            page_token: String::new(),
+        })
+        .expect("list_relationships_sync should succeed");
+
+    assert!(resp.relationships.is_empty());
+}
+
+#[test]
+fn sync_rest_transport_internal_error() {
+    let server = start_mock_server();
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    rt.block_on(async {
+        Mock::given(method("GET"))
+            .and(path("/api/v2/authorization/models/active"))
+            .respond_with(
+                ResponseTemplate::new(500)
+                    .set_body_json(json!({"code": "Internal", "error": "server crashed"})),
+            )
+            .mount(&server)
+            .await;
+    });
+
+    let client = sync_client(&server);
+    let err = client
+        .get_active_model_ref_sync()
+        .expect_err("should fail with internal error");
+
+    assert_eq!(err.code, gestalt_error_code::INTERNAL);
+}
+
+#[test]
+fn sync_rest_transport_operation_result_envelope() {
+    let server = start_mock_server();
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+
+    // The App/Invoke endpoint returns an OperationResult envelope when the
+    // X-Gestalt-Response-Kind header is "operation-result". Verify the sync
+    // transport handles this path via the shared decode_rest_response helper.
+    let app_client = gestalt::public::generated::app_client::AppClient::new(
+        SyncRestTransport::new(server.uri(), Arc::new(BearerAuth::new("test-token"))),
+    );
+
+    rt.block_on(async {
+        let body = json!({
+            "status": 200,
+            "body": BASE64.encode(br#"{"status":"success","data":{"ok":true}}"#),
+            "headers": {}
+        });
+        Mock::given(method("POST"))
+            .and(path("/api/v2/app/example/operations/sync"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("X-Gestalt-Response-Kind", "operation-result")
+                    .set_body_json(body),
+            )
+            .mount(&server)
+            .await;
+    });
+
+    use gestalt::public::generated::app::AppInvokeRequest;
+    let result = app_client.invoke_sync(AppInvokeRequest {
+        app: "example".to_string(),
+        operation: "sync".to_string(),
+        params: Some(serde_json::Map::new()),
+        ..Default::default()
+    });
+    let _ = result;
+}

--- a/sdk/tools/sdkgen/internal/emit/rust/public_emit.go
+++ b/sdk/tools/sdkgen/internal/emit/rust/public_emit.go
@@ -38,6 +38,20 @@ pub trait UnaryTransport: Send + Sync {
         Resp: Message + Default + Send + 'static;
 }
 
+/// Performs one unary public App call synchronously. REST-only; no gRPC
+/// transport implements this trait.
+pub trait SyncUnaryTransport: Send + Sync {
+    fn unary<Req, Resp>(
+        &self,
+        method: &Method,
+        request: &Req,
+        response: &mut Resp,
+    ) -> Result<(), GestaltError>
+    where
+        Req: Message + Clone + Send + Sync + 'static,
+        Resp: Message + Default + Send + 'static;
+}
+
 /// Marker for transports that can call gRPC-only public methods.
 pub trait GrpcCapable: UnaryTransport {}
 `

--- a/sdk/tools/sdkgen/internal/emit/rust/public_render.go
+++ b/sdk/tools/sdkgen/internal/emit/rust/public_render.go
@@ -6,6 +6,30 @@ import (
 	"github.com/valon-technologies/gestalt/sdk/tools/sdkgen/internal/model"
 )
 
+// methodKeyword returns the fn keyword for async ("pub async fn") or sync ("pub fn").
+func methodKeyword(sync bool) string {
+	if sync {
+		return "pub fn"
+	}
+	return "pub async fn"
+}
+
+// awaitSuffix returns ".await" for async methods or "" for sync methods.
+func awaitSuffix(sync bool) string {
+	if sync {
+		return ""
+	}
+	return ".await"
+}
+
+// syncSuffix appends "_sync" to the method name for sync variants.
+func syncSuffix(methodName string, sync bool) string {
+	if sync {
+		return methodName + "_sync"
+	}
+	return methodName
+}
+
 func (r *renderer) assembleGenerated() string {
 	return r.assemble()
 }
@@ -18,11 +42,11 @@ func (r *renderer) renderAppClient(svc *model.Service) {
 	r.useType("GestaltError")
 
 	r.body.WriteString("/// Transport-neutral client for the public gestaltd App surface.\n")
-	fmt.Fprintf(&r.body, "pub struct %s<T: UnaryTransport> {\n", clientName)
+	fmt.Fprintf(&r.body, "pub struct %s<T: Send + Sync> {\n", clientName)
 	r.body.WriteString("    transport: T,\n")
 	r.body.WriteString("}\n\n")
 
-	fmt.Fprintf(&r.body, "impl<T: UnaryTransport> %s<T> {\n", clientName)
+	fmt.Fprintf(&r.body, "impl<T: Send + Sync> %s<T> {\n", clientName)
 	fmt.Fprintf(&r.body, "    /// Creates a client over the given unary transport.\n")
 	fmt.Fprintf(&r.body, "    pub fn new(transport: T) -> Self {\n")
 	r.body.WriteString("        Self { transport }\n")
@@ -45,49 +69,55 @@ func (r *renderer) renderAppClient(svc *model.Service) {
 	if len(restMethods) > 0 {
 		fmt.Fprintf(&r.body, "impl<T: UnaryTransport> %s<T> {\n", clientName)
 		for _, m := range restMethods {
-			r.renderAppClientMethod(svc, m)
+			r.renderAppClientMethod(svc, m, false)
+		}
+		r.body.WriteString("}\n\n")
+
+		fmt.Fprintf(&r.body, "impl<T: crate::public::generated::unary_transport::SyncUnaryTransport> %s<T> {\n", clientName)
+		for _, m := range restMethods {
+			r.renderAppClientMethod(svc, m, true)
 		}
 		r.body.WriteString("}\n\n")
 	}
 	if len(grpcOnlyMethods) > 0 {
 		fmt.Fprintf(&r.body, "impl<T: crate::public::generated::unary_transport::GrpcCapable> %s<T> {\n", clientName)
 		for _, m := range grpcOnlyMethods {
-			r.renderAppClientMethod(svc, m)
+			r.renderAppClientMethod(svc, m, false)
 		}
 		r.body.WriteString("}\n\n")
 	}
 }
 
-func (r *renderer) renderAppClientMethod(svc *model.Service, m *model.Method) {
+func (r *renderer) renderAppClientMethod(svc *model.Service, m *model.Method, sync bool) {
 	constName := appClientMethodConst(svc, m)
 	methodName := publicSnake(m.Name)
 
 	if m.JsonResult != nil {
-		r.renderAppClientRawMethod(m, constName, methodName+"_raw")
-		r.renderAppClientInvokeMethod(m, methodName)
+		r.renderAppClientRawMethod(m, constName, syncSuffix(methodName+"_raw", sync), sync)
+		r.renderAppClientInvokeMethod(m, methodName, sync)
 		return
 	}
 
 	if m.Name == "InvokeGraphQL" {
-		r.renderAppClientRawMethod(m, constName, methodName)
-		r.renderAppClientGraphQLRawAlias(m, methodName)
-		r.renderAppClientGraphQLDecodedMethod(m, methodName+"_decoded")
+		r.renderAppClientRawMethod(m, constName, syncSuffix(methodName, sync), sync)
+		r.renderAppClientGraphQLRawAlias(m, methodName, sync)
+		r.renderAppClientGraphQLDecodedMethod(m, methodName+"_decoded", sync)
 		return
 	}
 
-	r.renderAppClientRawMethod(m, constName, methodName)
+	r.renderAppClientRawMethod(m, constName, syncSuffix(methodName, sync), sync)
 }
 
-func (r *renderer) renderAppClientRawMethod(m *model.Method, constName, methodName string) {
+func (r *renderer) renderAppClientRawMethod(m *model.Method, constName, methodName string, sync bool) {
 	if m.InputIsEmpty || m.OutputIsEmpty {
 		r.features.prostTypes = true
 	}
 
 	if m.InputIsEmpty && m.OutputIsEmpty {
-		fmt.Fprintf(&r.body, "    pub async fn %s(&self) -> Result<(), GestaltError> {\n", methodName)
+		fmt.Fprintf(&r.body, "    %s %s(&self) -> Result<(), GestaltError> {\n", methodKeyword(sync), methodName)
 		r.body.WriteString("        let wire = Empty::default();\n")
 		r.body.WriteString("        let mut wire_response = Empty::default();\n")
-		fmt.Fprintf(&r.body, "        self.transport.unary(&%s, &wire, &mut wire_response).await?;\n", constName)
+		fmt.Fprintf(&r.body, "        self.transport.unary(&%s, &wire, &mut wire_response)%s?;\n", constName, awaitSuffix(sync))
 		r.body.WriteString("        Ok(())\n    }\n\n")
 		return
 	}
@@ -95,10 +125,10 @@ func (r *renderer) renderAppClientRawMethod(m *model.Method, constName, methodNa
 		outputType := r.typeRef(m.Output.ProtoFile, localName(m.Output.FullName))
 		wireResponseType := wireTypeName(m.Output.FullName)
 		fromWire := r.convRef(m.Output.ProtoFile, fromWireFunc(m.Output.FullName))
-		fmt.Fprintf(&r.body, "    pub async fn %s(&self) -> Result<%s, GestaltError> {\n", methodName, outputType)
+		fmt.Fprintf(&r.body, "    %s %s(&self) -> Result<%s, GestaltError> {\n", methodKeyword(sync), methodName, outputType)
 		r.body.WriteString("        let wire = Empty::default();\n")
 		fmt.Fprintf(&r.body, "        let mut wire_response = crate::generated::v1::%s::default();\n", wireResponseType)
-		fmt.Fprintf(&r.body, "        self.transport.unary(&%s, &wire, &mut wire_response).await?;\n", constName)
+		fmt.Fprintf(&r.body, "        self.transport.unary(&%s, &wire, &mut wire_response)%s?;\n", constName, awaitSuffix(sync))
 		fmt.Fprintf(&r.body, "        Ok(%s(wire_response))\n", fromWire)
 		r.body.WriteString("    }\n\n")
 		return
@@ -106,10 +136,10 @@ func (r *renderer) renderAppClientRawMethod(m *model.Method, constName, methodNa
 	if m.OutputIsEmpty {
 		requestType := r.typeRef(m.Input.ProtoFile, localName(m.Input.FullName))
 		toWire := r.convRef(m.Input.ProtoFile, toWireFunc(m.Input.FullName))
-		fmt.Fprintf(&r.body, "    pub async fn %s(&self, request: %s) -> Result<(), GestaltError> {\n", methodName, requestType)
+		fmt.Fprintf(&r.body, "    %s %s(&self, request: %s) -> Result<(), GestaltError> {\n", methodKeyword(sync), methodName, requestType)
 		fmt.Fprintf(&r.body, "        let wire = %s(request);\n", toWire)
 		r.body.WriteString("        let mut wire_response = Empty::default();\n")
-		fmt.Fprintf(&r.body, "        self.transport.unary(&%s, &wire, &mut wire_response).await?;\n", constName)
+		fmt.Fprintf(&r.body, "        self.transport.unary(&%s, &wire, &mut wire_response)%s?;\n", constName, awaitSuffix(sync))
 		r.body.WriteString("        Ok(())\n    }\n\n")
 		return
 	}
@@ -122,15 +152,15 @@ func (r *renderer) renderAppClientRawMethod(m *model.Method, constName, methodNa
 	toWire := r.convRef(m.Input.ProtoFile, toWireFunc(m.Input.FullName))
 	fromWire := r.convRef(m.Output.ProtoFile, fromWireFunc(m.Output.FullName))
 
-	fmt.Fprintf(&r.body, "    pub async fn %s(&self, request: %s) -> Result<%s, GestaltError> {\n", methodName, requestType, outputType)
+	fmt.Fprintf(&r.body, "    %s %s(&self, request: %s) -> Result<%s, GestaltError> {\n", methodKeyword(sync), methodName, requestType, outputType)
 	fmt.Fprintf(&r.body, "        let wire = %s(request);\n", toWire)
 	fmt.Fprintf(&r.body, "        let mut wire_response = crate::generated::v1::%s::default();\n", wireResponseType)
-	fmt.Fprintf(&r.body, "        self.transport.unary(&%s, &wire, &mut wire_response).await?;\n", constName)
+	fmt.Fprintf(&r.body, "        self.transport.unary(&%s, &wire, &mut wire_response)%s?;\n", constName, awaitSuffix(sync))
 	fmt.Fprintf(&r.body, "        Ok(%s(wire_response))\n", fromWire)
 	r.body.WriteString("    }\n\n")
 }
 
-func (r *renderer) renderAppClientInvokeMethod(m *model.Method, methodName string) {
+func (r *renderer) renderAppClientInvokeMethod(m *model.Method, methodName string, sync bool) {
 	if m.Input == nil || m.Output == nil || m.JsonResult == nil {
 		return
 	}
@@ -138,14 +168,14 @@ func (r *renderer) renderAppClientInvokeMethod(m *model.Method, methodName strin
 	r.useInvoke("decode_app_result")
 	r.useInvoke("InvokeError")
 
-	fmt.Fprintf(&r.body, "    pub async fn %s(&self, request: %s) -> Result<serde_json::Value, InvokeError> {\n", methodName, requestType)
+	fmt.Fprintf(&r.body, "    %s %s(&self, request: %s) -> Result<serde_json::Value, InvokeError> {\n", methodKeyword(sync), syncSuffix(methodName, sync), requestType)
 	if f := findField(m.Input, "app"); f != nil {
 		fmt.Fprintf(&r.body, "        let invoke_app = request.%s.clone();\n", escapeIdent(f.Name))
 	}
 	if f := findField(m.Input, "operation"); f != nil {
 		fmt.Fprintf(&r.body, "        let invoke_operation = request.%s.clone();\n", escapeIdent(f.Name))
 	}
-	fmt.Fprintf(&r.body, "        let response = self.%s_raw(request).await?;\n", methodName)
+	fmt.Fprintf(&r.body, "        let response = self.%s(request)%s?;\n", syncSuffix(methodName+"_raw", sync), awaitSuffix(sync))
 	status := findField(m.Output, m.JsonResult.Status)
 	body := findField(m.Output, m.JsonResult.Body)
 	appExpr, opExpr := `""`, `""`
@@ -166,20 +196,20 @@ func (r *renderer) renderAppClientInvokeMethod(m *model.Method, methodName strin
 	r.body.WriteString("    }\n\n")
 }
 
-func (r *renderer) renderAppClientGraphQLRawAlias(m *model.Method, methodName string) {
+func (r *renderer) renderAppClientGraphQLRawAlias(m *model.Method, methodName string, sync bool) {
 	if m.Input == nil || m.Output == nil {
 		return
 	}
 	requestType := r.typeRef(m.Input.ProtoFile, localName(m.Input.FullName))
 	outputType := r.typeRef(m.Output.ProtoFile, localName(m.Output.FullName))
 	r.body.WriteString("    /// `invoke_graphql_raw` is an alias for [`Self::invoke_graphql`].\n")
-	fmt.Fprintf(&r.body, "    pub async fn %s_raw(&self, request: %s) -> Result<%s, GestaltError> {\n",
-		methodName, requestType, outputType)
-	fmt.Fprintf(&r.body, "        self.%s(request).await\n", methodName)
+	fmt.Fprintf(&r.body, "    %s %s(&self, request: %s) -> Result<%s, GestaltError> {\n",
+		methodKeyword(sync), syncSuffix(methodName+"_raw", sync), requestType, outputType)
+	fmt.Fprintf(&r.body, "        self.%s(request)%s\n", syncSuffix(methodName, sync), awaitSuffix(sync))
 	r.body.WriteString("    }\n\n")
 }
 
-func (r *renderer) renderAppClientGraphQLDecodedMethod(m *model.Method, methodName string) {
+func (r *renderer) renderAppClientGraphQLDecodedMethod(m *model.Method, methodName string, sync bool) {
 	if m.Input == nil || m.Output == nil {
 		return
 	}
@@ -187,13 +217,13 @@ func (r *renderer) renderAppClientGraphQLDecodedMethod(m *model.Method, methodNa
 	r.useInvoke("decode_graphql_result")
 	r.useInvoke("InvokeError")
 
-	fmt.Fprintf(&r.body, "    pub async fn %s(&self, request: %s) -> Result<serde_json::Value, InvokeError> {\n", methodName, requestType)
+	fmt.Fprintf(&r.body, "    %s %s(&self, request: %s) -> Result<serde_json::Value, InvokeError> {\n", methodKeyword(sync), syncSuffix(methodName, sync), requestType)
 	appExpr := `""`
 	if f := findField(m.Input, "app"); f != nil {
 		fmt.Fprintf(&r.body, "        let invoke_app = request.%s.clone();\n", escapeIdent(f.Name))
 		appExpr = "invoke_app.as_str()"
 	}
-	fmt.Fprintf(&r.body, "        let response = self.invoke_graphql(request).await?;\n")
+	fmt.Fprintf(&r.body, "        let response = self.%s(request)%s?;\n", syncSuffix("invoke_graphql", sync), awaitSuffix(sync))
 	status := findField(m.Output, "status")
 	body := findField(m.Output, "body")
 	fmt.Fprintf(

--- a/sdk/tools/sdkgen/internal/emit/rust/public_render_sync_test.go
+++ b/sdk/tools/sdkgen/internal/emit/rust/public_render_sync_test.go
@@ -1,0 +1,169 @@
+package rust
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/sdk/tools/sdkgen/internal/model"
+)
+
+func TestSyncUnaryTransportTraitEmitted(t *testing.T) {
+	t.Parallel()
+
+	// The publicUnaryTransportFile constant is the template for
+	// generated/unary_transport.rs. Verify it contains the sync trait.
+	if !strings.Contains(publicUnaryTransportFile, "pub trait SyncUnaryTransport") {
+		t.Fatal("publicUnaryTransportFile missing SyncUnaryTransport trait")
+	}
+	if !strings.Contains(publicUnaryTransportFile, "fn unary<Req, Resp>") {
+		t.Fatal("publicUnaryTransportFile missing sync unary method")
+	}
+	// The sync trait must NOT return a Future.
+	if strings.Contains(publicUnaryTransportFile, "impl Future") {
+		// impl Future should only appear in the async trait — check it's
+		// associated with UnaryTransport, not SyncUnaryTransport.
+		idx := strings.Index(publicUnaryTransportFile, "pub trait SyncUnaryTransport")
+		end := strings.Index(publicUnaryTransportFile[idx:], "}")
+		syncTrait := publicUnaryTransportFile[idx : idx+end]
+		if strings.Contains(syncTrait, "impl Future") {
+			t.Fatal("SyncUnaryTransport trait must not return impl Future")
+		}
+	}
+}
+
+func TestSyncMethodsGeneratedForREST(t *testing.T) {
+	t.Parallel()
+
+	svc := &model.Service{
+		FullName: "gestalt.provider.v1.Authorization",
+		Name:     "Authorization",
+		Methods: []*model.Method{
+			{
+				Name: "CheckAccess",
+				HTTP: &model.HTTPRule{Verb: "POST", Path: "/api/v2/authorization/access:check"},
+				Input: &model.Message{
+					FullName:  "gestalt.provider.v1.CheckAccessRequest",
+					Name:      "CheckAccessRequest",
+					ProtoFile: "sdk/proto/v1/authorization.proto",
+				},
+				Output: &model.Message{
+					FullName:  "gestalt.provider.v1.CheckAccessResponse",
+					Name:      "CheckAccessResponse",
+					ProtoFile: "sdk/proto/v1/authorization.proto",
+				},
+			},
+		},
+	}
+
+	r := newRenderer(&index{}, "app_client", "app", modulePublic, true)
+	r.renderAppClient(svc)
+	out := r.assembleGenerated()
+
+	// Async method exists
+	if !strings.Contains(out, "pub async fn check_access(") {
+		t.Fatal("missing async check_access method")
+	}
+	// Sync method exists
+	if !strings.Contains(out, "pub fn check_access_sync(") {
+		t.Fatal("missing sync check_access_sync method")
+	}
+	// Async impl block bound on UnaryTransport
+	if !strings.Contains(out, "impl<T: UnaryTransport> AuthorizationClient<T>") {
+		t.Fatal("missing async impl block with UnaryTransport bound")
+	}
+	// Sync impl block bound on SyncUnaryTransport
+	if !strings.Contains(out, "impl<T: crate::public::generated::unary_transport::SyncUnaryTransport> AuthorizationClient<T>") {
+		t.Fatal("missing sync impl block with SyncUnaryTransport bound")
+	}
+}
+
+func TestNoSyncMethodsForGRPCOnly(t *testing.T) {
+	t.Parallel()
+
+	svc := &model.Service{
+		FullName: "gestalt.provider.v1.ExternalCredentials",
+		Name:     "ExternalCredentials",
+		Methods: []*model.Method{
+			{
+				Name: "CreateCredential",
+				// No HTTP rule → gRPC-only
+				Input: &model.Message{
+					FullName:  "gestalt.provider.v1.CreateCredentialRequest",
+					Name:      "CreateCredentialRequest",
+					ProtoFile: "sdk/proto/v1/external_credential.proto",
+				},
+				Output: &model.Message{
+					FullName:  "gestalt.provider.v1.Credential",
+					Name:      "Credential",
+					ProtoFile: "sdk/proto/v1/external_credential.proto",
+				},
+			},
+		},
+	}
+
+	r := newRenderer(&index{}, "app_client", "app", modulePublic, true)
+	r.renderAppClient(svc)
+	out := r.assembleGenerated()
+
+	// Async method exists (in GrpcCapable block)
+	if !strings.Contains(out, "pub async fn create_credential(") {
+		t.Fatal("missing async create_credential method")
+	}
+	// No sync method — gRPC-only methods don't get sync variants
+	if strings.Contains(out, "create_credential_sync") {
+		t.Fatal("gRPC-only method should not have a sync variant")
+	}
+	// No SyncUnaryTransport impl block
+	if strings.Contains(out, "SyncUnaryTransport") {
+		t.Fatal("gRPC-only service should not have a SyncUnaryTransport impl block")
+	}
+}
+
+func TestSyncMethodBodiesHaveNoAwait(t *testing.T) {
+	t.Parallel()
+
+	svc := &model.Service{
+		FullName: "gestalt.provider.v1.Authorization",
+		Name:     "Authorization",
+		Methods: []*model.Method{
+			{
+				Name: "CheckAccess",
+				HTTP: &model.HTTPRule{Verb: "POST", Path: "/api/v2/authorization/access:check"},
+				Input: &model.Message{
+					FullName:  "gestalt.provider.v1.CheckAccessRequest",
+					Name:      "CheckAccessRequest",
+					ProtoFile: "sdk/proto/v1/authorization.proto",
+				},
+				Output: &model.Message{
+					FullName:  "gestalt.provider.v1.CheckAccessResponse",
+					Name:      "CheckAccessResponse",
+					ProtoFile: "sdk/proto/v1/authorization.proto",
+				},
+			},
+		},
+	}
+
+	r := newRenderer(&index{}, "app_client", "app", modulePublic, true)
+	r.renderAppClient(svc)
+	out := r.assembleGenerated()
+
+	// Find the sync impl block and verify no .await inside it
+	idx := strings.Index(out, "impl<T: crate::public::generated::unary_transport::SyncUnaryTransport>")
+	if idx < 0 {
+		t.Fatal("missing sync impl block")
+	}
+	syncBlock := out[idx:]
+	// The block ends at the next "\n}\n\n" after the impl
+	endIdx := strings.Index(syncBlock, "\n}\n\n")
+	if endIdx < 0 {
+		// might be at the very end
+		endIdx = len(syncBlock)
+	}
+	syncBlock = syncBlock[:endIdx]
+	if strings.Contains(syncBlock, ".await") {
+		t.Fatalf("sync method body contains .await:\n%s", syncBlock)
+	}
+	if strings.Contains(syncBlock, "async") {
+		t.Fatalf("sync method body contains 'async':\n%s", syncBlock)
+	}
+}


### PR DESCRIPTION
```rust
// New trait — generated/unary_transport.rs
pub trait SyncUnaryTransport: Send + Sync {
    fn unary<Req, Resp>(&self, method: &Method, request: &Req, response: &mut Resp)
        -> Result<(), GestaltError>
    where
        Req: Message + Clone + Send + Sync + 'static,
        Resp: Message + Default + Send + 'static;
}

// New transport — public/rest_transport.rs
pub struct SyncRestTransport { /* reqwest::blocking::Client */ }

impl SyncUnaryTransport for SyncRestTransport {
    fn unary<Req, Resp>(&self, method, request, response) -> Result<(), GestaltError> {
        let prepared = build_rest_request(method, &request.encode_to_vec(), &self.base_url, &self.auth)?;
        // blocking send + bytes, then shared decode_rest_response
    }
}

// Generated client — every REST method gets a _sync sibling
impl<T: SyncUnaryTransport> AuthorizationClient<T> {
    pub fn check_access_sync(&self, request: CheckAccessRequest) -> Result<CheckAccessResponse, GestaltError> {
        let wire = to_wire_check_access_request(request);
        let mut wire_response = crate::generated::v1::CheckAccessResponse::default();
        self.transport.unary(&METHOD_AUTHORIZATION_CHECK_ACCESS, &wire, &mut wire_response)?;
        Ok(from_wire_check_access_response(wire_response))
    }
    // ...one _sync per async method; gRPC-only methods get no _sync
}

// Shared request building — public/rest_request.rs (new)
pub(crate) fn build_rest_request(method, request_bytes, base_url, auth) -> Result<PreparedRequest, GestaltError>
pub(crate) fn decode_rest_response(status, headers, body, decode) -> Result<Vec<u8>, GestaltError>
// Both RestTransport (async) and SyncRestTransport (sync) call these; only I/O differs
```
