### PR TITLE
sdk/python: generate both sync and async public client methods

### DIFF
--- a/sdk/python/gestalt/public/generated/agent_client.py
+++ b/sdk/python/gestalt/public/generated/agent_client.py
@@ -35,7 +35,7 @@ from .metadata import (
     METHOD_AGENT_LIST_TURNS,
     METHOD_AGENT_UPDATE_SESSION,
 )
-from .unary_transport import UnaryTransport
+from .unary_transport import AsyncUnaryTransport, UnaryTransport
 
 
 class AgentClient:
@@ -166,5 +166,145 @@ class AgentClientREST(Protocol):
     ) -> ListAgentProviderTurnsResponse: ...
     def cancel_turn(self, request: CancelAgentProviderTurnRequest) -> AgentTurn: ...
     def list_turn_events(
+        self, request: ListAgentProviderTurnEventsRequest
+    ) -> ListAgentProviderTurnEventsResponse: ...
+
+
+class AsyncAgentClient:
+    """Agent is the authoritative agent data boundary. Read RPCs for
+    sessions, turns, turn events, and interactions should use provider-owned
+    control-plane state and should not require a live execution sandbox,
+    pod-level transport, or cached tunnel.
+
+    Async client for the public gestalt.provider.v1.Agent surface; methods are coroutines.
+    """
+
+    def __init__(self, transport: AsyncUnaryTransport) -> None:
+        self._transport = transport
+
+    async def create_session(
+        self, request: CreateAgentProviderSessionRequest
+    ) -> AgentSession:
+        wire = _agent_codec.to_wire_create_agent_provider_session_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_AGENT_CREATE_SESSION,
+            wire,
+            _agent_pb2.AgentSession,
+        )
+        return _agent_codec.from_wire_agent_session(wire_response)
+
+    async def get_session(
+        self, request: GetAgentProviderSessionRequest
+    ) -> AgentSession:
+        wire = _agent_codec.to_wire_get_agent_provider_session_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_AGENT_GET_SESSION,
+            wire,
+            _agent_pb2.AgentSession,
+        )
+        return _agent_codec.from_wire_agent_session(wire_response)
+
+    async def list_sessions(
+        self, request: ListAgentProviderSessionsRequest
+    ) -> ListAgentProviderSessionsResponse:
+        wire = _agent_codec.to_wire_list_agent_provider_sessions_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_AGENT_LIST_SESSIONS,
+            wire,
+            _agent_pb2.ListAgentProviderSessionsResponse,
+        )
+        return _agent_codec.from_wire_list_agent_provider_sessions_response(
+            wire_response
+        )
+
+    async def update_session(
+        self, request: UpdateAgentProviderSessionRequest
+    ) -> AgentSession:
+        wire = _agent_codec.to_wire_update_agent_provider_session_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_AGENT_UPDATE_SESSION,
+            wire,
+            _agent_pb2.AgentSession,
+        )
+        return _agent_codec.from_wire_agent_session(wire_response)
+
+    async def create_turn(self, request: CreateAgentProviderTurnRequest) -> AgentTurn:
+        wire = _agent_codec.to_wire_create_agent_provider_turn_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_AGENT_CREATE_TURN,
+            wire,
+            _agent_pb2.AgentTurn,
+        )
+        return _agent_codec.from_wire_agent_turn(wire_response)
+
+    async def get_turn(self, request: GetAgentProviderTurnRequest) -> AgentTurn:
+        wire = _agent_codec.to_wire_get_agent_provider_turn_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_AGENT_GET_TURN,
+            wire,
+            _agent_pb2.AgentTurn,
+        )
+        return _agent_codec.from_wire_agent_turn(wire_response)
+
+    async def list_turns(
+        self, request: ListAgentProviderTurnsRequest
+    ) -> ListAgentProviderTurnsResponse:
+        wire = _agent_codec.to_wire_list_agent_provider_turns_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_AGENT_LIST_TURNS,
+            wire,
+            _agent_pb2.ListAgentProviderTurnsResponse,
+        )
+        return _agent_codec.from_wire_list_agent_provider_turns_response(wire_response)
+
+    async def cancel_turn(self, request: CancelAgentProviderTurnRequest) -> AgentTurn:
+        wire = _agent_codec.to_wire_cancel_agent_provider_turn_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_AGENT_CANCEL_TURN,
+            wire,
+            _agent_pb2.AgentTurn,
+        )
+        return _agent_codec.from_wire_agent_turn(wire_response)
+
+    async def list_turn_events(
+        self, request: ListAgentProviderTurnEventsRequest
+    ) -> ListAgentProviderTurnEventsResponse:
+        wire = _agent_codec.to_wire_list_agent_provider_turn_events_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_AGENT_LIST_TURN_EVENTS,
+            wire,
+            _agent_pb2.ListAgentProviderTurnEventsResponse,
+        )
+        return _agent_codec.from_wire_list_agent_provider_turn_events_response(
+            wire_response
+        )
+
+
+class AsyncAgentClientREST(Protocol):
+    """REST-backed methods for the public gestalt.provider.v1.Agent surface."""
+
+    async def create_session(
+        self, request: CreateAgentProviderSessionRequest
+    ) -> AgentSession: ...
+    async def get_session(
+        self, request: GetAgentProviderSessionRequest
+    ) -> AgentSession: ...
+    async def list_sessions(
+        self, request: ListAgentProviderSessionsRequest
+    ) -> ListAgentProviderSessionsResponse: ...
+    async def update_session(
+        self, request: UpdateAgentProviderSessionRequest
+    ) -> AgentSession: ...
+    async def create_turn(
+        self, request: CreateAgentProviderTurnRequest
+    ) -> AgentTurn: ...
+    async def get_turn(self, request: GetAgentProviderTurnRequest) -> AgentTurn: ...
+    async def list_turns(
+        self, request: ListAgentProviderTurnsRequest
+    ) -> ListAgentProviderTurnsResponse: ...
+    async def cancel_turn(
+        self, request: CancelAgentProviderTurnRequest
+    ) -> AgentTurn: ...
+    async def list_turn_events(
         self, request: ListAgentProviderTurnEventsRequest
     ) -> ListAgentProviderTurnEventsResponse: ...

--- a/sdk/python/gestalt/public/generated/app_client.py
+++ b/sdk/python/gestalt/public/generated/app_client.py
@@ -12,7 +12,7 @@ from ..._gen.v1 import app_pb2 as _app_pb2
 from ._codec import app as _app_codec
 from .app import AppInvokeGraphQLRequest, AppInvokeRequest, OperationResult
 from .metadata import METHOD_APP_INVOKE, METHOD_APP_INVOKE_GRAPHQL
-from .unary_transport import UnaryTransport
+from .unary_transport import AsyncUnaryTransport, UnaryTransport
 
 
 class AppClient:
@@ -66,3 +66,60 @@ class AppClientREST(Protocol):
         self, request: AppInvokeGraphQLRequest
     ) -> OperationResult: ...
     def invoke_graphql_decoded(self, request: AppInvokeGraphQLRequest) -> Any: ...
+
+
+class AsyncAppClient:
+    """Async client for the public gestalt.provider.v1.App surface; methods are coroutines."""
+
+    def __init__(self, transport: AsyncUnaryTransport) -> None:
+        self._transport = transport
+
+    async def invoke_raw(self, request: AppInvokeRequest) -> OperationResult:
+        wire = _app_codec.to_wire_app_invoke_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_APP_INVOKE,
+            wire,
+            _app_pb2.OperationResult,
+        )
+        return _app_codec.from_wire_operation_result(wire_response)
+
+    async def invoke(self, request: AppInvokeRequest) -> Any:
+        """The result decodes with the standard JSON operation envelope semantics; envelope failures raise InvokeError."""
+        response = await self.invoke_raw(request)
+        return decode_app_result(
+            request.app, request.operation, response.status, response.body
+        )
+
+    async def invoke_graphql(self, request: AppInvokeGraphQLRequest) -> OperationResult:
+        wire = _app_codec.to_wire_app_invoke_graphql_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_APP_INVOKE_GRAPHQL,
+            wire,
+            _app_pb2.OperationResult,
+        )
+        return _app_codec.from_wire_operation_result(wire_response)
+
+    async def invoke_graphql_raw(
+        self, request: AppInvokeGraphQLRequest
+    ) -> OperationResult:
+        """Alias for invoke_graphql."""
+        return await self.invoke_graphql(request)
+
+    async def invoke_graphql_decoded(self, request: AppInvokeGraphQLRequest) -> Any:
+        """The result decodes with GraphQL envelope semantics; envelope failures raise InvokeError."""
+        response = await self.invoke_graphql(request)
+        return decode_graphql_result(request.app, response.status, response.body)
+
+
+class AsyncAppClientREST(Protocol):
+    """REST-backed methods for the public gestalt.provider.v1.App surface."""
+
+    async def invoke_raw(self, request: AppInvokeRequest) -> OperationResult: ...
+    async def invoke(self, request: AppInvokeRequest) -> Any: ...
+    async def invoke_graphql(
+        self, request: AppInvokeGraphQLRequest
+    ) -> OperationResult: ...
+    async def invoke_graphql_raw(
+        self, request: AppInvokeGraphQLRequest
+    ) -> OperationResult: ...
+    async def invoke_graphql_decoded(self, request: AppInvokeGraphQLRequest) -> Any: ...

--- a/sdk/python/gestalt/public/generated/authorization_client.py
+++ b/sdk/python/gestalt/public/generated/authorization_client.py
@@ -40,7 +40,7 @@ from .metadata import (
     METHOD_AUTHORIZATION_SET_ACTIVE_MODEL,
     METHOD_AUTHORIZATION_SET_AUTHORIZATION_STATE,
 )
-from .unary_transport import UnaryTransport
+from .unary_transport import AsyncUnaryTransport, UnaryTransport
 
 _empty: Any = _empty_pb2
 
@@ -181,5 +181,147 @@ class AuthorizationClientREST(Protocol):
         self, request: SetActiveModelRequest
     ) -> SetActiveModelResponse: ...
     def list_active_model_resource_types(
+        self, request: ListActiveModelResourceTypesRequest
+    ) -> ListActiveModelResourceTypesResponse: ...
+
+
+class AsyncAuthorizationClient:
+    """Async client for the public gestalt.provider.v1.Authorization surface; methods are coroutines."""
+
+    def __init__(self, transport: AsyncUnaryTransport) -> None:
+        self._transport = transport
+
+    async def check_access(self, request: CheckAccessRequest) -> CheckAccessResponse:
+        wire = _authorization_codec.to_wire_check_access_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_AUTHORIZATION_CHECK_ACCESS,
+            wire,
+            _authorization_pb2.CheckAccessResponse,
+        )
+        return _authorization_codec.from_wire_check_access_response(wire_response)
+
+    async def check_access_many(
+        self, request: CheckAccessManyRequest
+    ) -> CheckAccessManyResponse:
+        wire = _authorization_codec.to_wire_check_access_many_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_AUTHORIZATION_CHECK_ACCESS_MANY,
+            wire,
+            _authorization_pb2.CheckAccessManyResponse,
+        )
+        return _authorization_codec.from_wire_check_access_many_response(wire_response)
+
+    async def list_relationships(
+        self, request: ListRelationshipsRequest
+    ) -> ListRelationshipsResponse:
+        wire = _authorization_codec.to_wire_list_relationships_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_AUTHORIZATION_LIST_RELATIONSHIPS,
+            wire,
+            _authorization_pb2.ListRelationshipsResponse,
+        )
+        return _authorization_codec.from_wire_list_relationships_response(wire_response)
+
+    async def add_relationship(
+        self, request: AddRelationshipRequest
+    ) -> AddRelationshipResponse:
+        wire = _authorization_codec.to_wire_add_relationship_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_AUTHORIZATION_ADD_RELATIONSHIP,
+            wire,
+            _authorization_pb2.AddRelationshipResponse,
+        )
+        return _authorization_codec.from_wire_add_relationship_response(wire_response)
+
+    async def delete_relationship(
+        self, request: DeleteRelationshipRequest
+    ) -> DeleteRelationshipResponse:
+        wire = _authorization_codec.to_wire_delete_relationship_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_AUTHORIZATION_DELETE_RELATIONSHIP,
+            wire,
+            _authorization_pb2.DeleteRelationshipResponse,
+        )
+        return _authorization_codec.from_wire_delete_relationship_response(
+            wire_response
+        )
+
+    async def set_authorization_state(
+        self, request: SetAuthorizationStateRequest
+    ) -> SetAuthorizationStateResponse:
+        wire = _authorization_codec.to_wire_set_authorization_state_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_AUTHORIZATION_SET_AUTHORIZATION_STATE,
+            wire,
+            _authorization_pb2.SetAuthorizationStateResponse,
+        )
+        return _authorization_codec.from_wire_set_authorization_state_response(
+            wire_response
+        )
+
+    async def get_active_model_ref(self) -> GetActiveModelRefResponse:
+        wire = _empty.Empty()
+        wire_response = await self._transport.unary(
+            METHOD_AUTHORIZATION_GET_ACTIVE_MODEL_REF,
+            wire,
+            _authorization_pb2.GetActiveModelRefResponse,
+        )
+        return _authorization_codec.from_wire_get_active_model_ref_response(
+            wire_response
+        )
+
+    async def set_active_model(
+        self, request: SetActiveModelRequest
+    ) -> SetActiveModelResponse:
+        wire = _authorization_codec.to_wire_set_active_model_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_AUTHORIZATION_SET_ACTIVE_MODEL,
+            wire,
+            _authorization_pb2.SetActiveModelResponse,
+        )
+        return _authorization_codec.from_wire_set_active_model_response(wire_response)
+
+    async def list_active_model_resource_types(
+        self, request: ListActiveModelResourceTypesRequest
+    ) -> ListActiveModelResourceTypesResponse:
+        wire = _authorization_codec.to_wire_list_active_model_resource_types_request(
+            request
+        )
+        wire_response = await self._transport.unary(
+            METHOD_AUTHORIZATION_LIST_ACTIVE_MODEL_RESOURCE_TYPES,
+            wire,
+            _authorization_pb2.ListActiveModelResourceTypesResponse,
+        )
+        return _authorization_codec.from_wire_list_active_model_resource_types_response(
+            wire_response
+        )
+
+
+class AsyncAuthorizationClientREST(Protocol):
+    """REST-backed methods for the public gestalt.provider.v1.Authorization surface."""
+
+    async def check_access(
+        self, request: CheckAccessRequest
+    ) -> CheckAccessResponse: ...
+    async def check_access_many(
+        self, request: CheckAccessManyRequest
+    ) -> CheckAccessManyResponse: ...
+    async def list_relationships(
+        self, request: ListRelationshipsRequest
+    ) -> ListRelationshipsResponse: ...
+    async def add_relationship(
+        self, request: AddRelationshipRequest
+    ) -> AddRelationshipResponse: ...
+    async def delete_relationship(
+        self, request: DeleteRelationshipRequest
+    ) -> DeleteRelationshipResponse: ...
+    async def set_authorization_state(
+        self, request: SetAuthorizationStateRequest
+    ) -> SetAuthorizationStateResponse: ...
+    async def get_active_model_ref(self) -> GetActiveModelRefResponse: ...
+    async def set_active_model(
+        self, request: SetActiveModelRequest
+    ) -> SetActiveModelResponse: ...
+    async def list_active_model_resource_types(
         self, request: ListActiveModelResourceTypesRequest
     ) -> ListActiveModelResourceTypesResponse: ...

--- a/sdk/python/gestalt/public/generated/external_credentials_client.py
+++ b/sdk/python/gestalt/public/generated/external_credentials_client.py
@@ -34,7 +34,7 @@ from .metadata import (
     METHOD_EXTERNAL_CREDENTIALS_UPSERT_CREDENTIAL,
     METHOD_EXTERNAL_CREDENTIALS_VALIDATE_CREDENTIAL_CONFIG,
 )
-from .unary_transport import UnaryTransport
+from .unary_transport import AsyncUnaryTransport, UnaryTransport
 
 _empty: Any = _empty_pb2
 
@@ -145,6 +145,123 @@ class ExternalCredentialsClient:
             request
         )
         wire_response = self._transport.unary(
+            METHOD_EXTERNAL_CREDENTIALS_EXCHANGE_CREDENTIAL,
+            wire,
+            _external_credential_pb2.ExchangeExternalCredentialResponse,
+        )
+        return (
+            _external_credential_codec.from_wire_exchange_external_credential_response(
+                wire_response
+            )
+        )
+
+
+class AsyncExternalCredentialsClient:
+    """Async client for the public gestalt.provider.v1.ExternalCredentials surface; methods are coroutines."""
+
+    def __init__(self, transport: AsyncUnaryTransport) -> None:
+        self._transport = transport
+
+    async def create_credential(
+        self, request: CreateExternalCredentialRequest
+    ) -> ExternalCredential:
+        wire = _external_credential_codec.to_wire_create_external_credential_request(
+            request
+        )
+        wire_response = await self._transport.unary(
+            METHOD_EXTERNAL_CREDENTIALS_CREATE_CREDENTIAL,
+            wire,
+            _external_credential_pb2.ExternalCredential,
+        )
+        return _external_credential_codec.from_wire_external_credential(wire_response)
+
+    async def upsert_credential(
+        self, request: UpsertExternalCredentialRequest
+    ) -> ExternalCredential:
+        wire = _external_credential_codec.to_wire_upsert_external_credential_request(
+            request
+        )
+        wire_response = await self._transport.unary(
+            METHOD_EXTERNAL_CREDENTIALS_UPSERT_CREDENTIAL,
+            wire,
+            _external_credential_pb2.ExternalCredential,
+        )
+        return _external_credential_codec.from_wire_external_credential(wire_response)
+
+    async def get_credential(
+        self, request: GetExternalCredentialRequest
+    ) -> ExternalCredential:
+        wire = _external_credential_codec.to_wire_get_external_credential_request(
+            request
+        )
+        wire_response = await self._transport.unary(
+            METHOD_EXTERNAL_CREDENTIALS_GET_CREDENTIAL,
+            wire,
+            _external_credential_pb2.ExternalCredential,
+        )
+        return _external_credential_codec.from_wire_external_credential(wire_response)
+
+    async def list_credentials(
+        self, request: ListExternalCredentialsRequest
+    ) -> ListExternalCredentialsResponse:
+        wire = _external_credential_codec.to_wire_list_external_credentials_request(
+            request
+        )
+        wire_response = await self._transport.unary(
+            METHOD_EXTERNAL_CREDENTIALS_LIST_CREDENTIALS,
+            wire,
+            _external_credential_pb2.ListExternalCredentialsResponse,
+        )
+        return _external_credential_codec.from_wire_list_external_credentials_response(
+            wire_response
+        )
+
+    async def delete_credential(self, request: DeleteExternalCredentialRequest) -> None:
+        wire = _external_credential_codec.to_wire_delete_external_credential_request(
+            request
+        )
+        await self._transport.unary(
+            METHOD_EXTERNAL_CREDENTIALS_DELETE_CREDENTIAL,
+            wire,
+            _empty.Empty,
+        )
+
+    async def validate_credential_config(
+        self, request: ValidateExternalCredentialConfigRequest
+    ) -> None:
+        wire = _external_credential_codec.to_wire_validate_external_credential_config_request(
+            request
+        )
+        await self._transport.unary(
+            METHOD_EXTERNAL_CREDENTIALS_VALIDATE_CREDENTIAL_CONFIG,
+            wire,
+            _empty.Empty,
+        )
+
+    async def resolve_credential(
+        self, request: ResolveExternalCredentialRequest
+    ) -> ResolveExternalCredentialResponse:
+        wire = _external_credential_codec.to_wire_resolve_external_credential_request(
+            request
+        )
+        wire_response = await self._transport.unary(
+            METHOD_EXTERNAL_CREDENTIALS_RESOLVE_CREDENTIAL,
+            wire,
+            _external_credential_pb2.ResolveExternalCredentialResponse,
+        )
+        return (
+            _external_credential_codec.from_wire_resolve_external_credential_response(
+                wire_response
+            )
+        )
+
+    async def exchange_credential(
+        self, request: ExchangeExternalCredentialRequest
+    ) -> ExchangeExternalCredentialResponse:
+        wire = _external_credential_codec.to_wire_exchange_external_credential_request(
+            request
+        )
+        wire_response = await self._transport.unary(
             METHOD_EXTERNAL_CREDENTIALS_EXCHANGE_CREDENTIAL,
             wire,
             _external_credential_pb2.ExchangeExternalCredentialResponse,

--- a/sdk/python/gestalt/public/generated/identity_client.py
+++ b/sdk/python/gestalt/public/generated/identity_client.py
@@ -33,7 +33,7 @@ from .metadata import (
     METHOD_IDENTITY_TOKEN,
     METHOD_IDENTITY_USER_INFO,
 )
-from .unary_transport import UnaryTransport
+from .unary_transport import AsyncUnaryTransport, UnaryTransport
 
 
 class IdentityClient:
@@ -119,3 +119,90 @@ class IdentityClientREST(Protocol):
     def list_grants(self, request: ListGrantsRequest) -> ListGrantsResponse: ...
     def get_grant(self, request: GetGrantRequest) -> GetGrantResponse: ...
     def revoke_grant(self, request: RevokeGrantRequest) -> RevokeGrantResponse: ...
+
+
+class AsyncIdentityClient:
+    """Identity models the shared Gestalt authentication protocol.
+
+    Async client for the public gestalt.provider.v1.Identity surface; methods are coroutines.
+    """
+
+    def __init__(self, transport: AsyncUnaryTransport) -> None:
+        self._transport = transport
+
+    async def authorize(self, request: AuthorizeRequest) -> AuthorizeResponse:
+        wire = _identity_codec.to_wire_authorize_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_IDENTITY_AUTHORIZE,
+            wire,
+            _identity_pb2.AuthorizeResponse,
+        )
+        return _identity_codec.from_wire_authorize_response(wire_response)
+
+    async def token(self, request: TokenRequest) -> TokenResponse:
+        wire = _identity_codec.to_wire_token_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_IDENTITY_TOKEN,
+            wire,
+            _identity_pb2.TokenResponse,
+        )
+        return _identity_codec.from_wire_token_response(wire_response)
+
+    async def introspect(self, request: IntrospectRequest) -> IntrospectResponse:
+        wire = _identity_codec.to_wire_introspect_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_IDENTITY_INTROSPECT,
+            wire,
+            _identity_pb2.IntrospectResponse,
+        )
+        return _identity_codec.from_wire_introspect_response(wire_response)
+
+    async def user_info(self, request: UserInfoRequest) -> UserInfoResponse:
+        wire = _identity_codec.to_wire_user_info_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_IDENTITY_USER_INFO,
+            wire,
+            _identity_pb2.UserInfoResponse,
+        )
+        return _identity_codec.from_wire_user_info_response(wire_response)
+
+    async def list_grants(self, request: ListGrantsRequest) -> ListGrantsResponse:
+        wire = _identity_codec.to_wire_list_grants_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_IDENTITY_LIST_GRANTS,
+            wire,
+            _identity_pb2.ListGrantsResponse,
+        )
+        return _identity_codec.from_wire_list_grants_response(wire_response)
+
+    async def get_grant(self, request: GetGrantRequest) -> GetGrantResponse:
+        wire = _identity_codec.to_wire_get_grant_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_IDENTITY_GET_GRANT,
+            wire,
+            _identity_pb2.GetGrantResponse,
+        )
+        return _identity_codec.from_wire_get_grant_response(wire_response)
+
+    async def revoke_grant(self, request: RevokeGrantRequest) -> RevokeGrantResponse:
+        wire = _identity_codec.to_wire_revoke_grant_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_IDENTITY_REVOKE_GRANT,
+            wire,
+            _identity_pb2.RevokeGrantResponse,
+        )
+        return _identity_codec.from_wire_revoke_grant_response(wire_response)
+
+
+class AsyncIdentityClientREST(Protocol):
+    """REST-backed methods for the public gestalt.provider.v1.Identity surface."""
+
+    async def authorize(self, request: AuthorizeRequest) -> AuthorizeResponse: ...
+    async def token(self, request: TokenRequest) -> TokenResponse: ...
+    async def introspect(self, request: IntrospectRequest) -> IntrospectResponse: ...
+    async def user_info(self, request: UserInfoRequest) -> UserInfoResponse: ...
+    async def list_grants(self, request: ListGrantsRequest) -> ListGrantsResponse: ...
+    async def get_grant(self, request: GetGrantRequest) -> GetGrantResponse: ...
+    async def revoke_grant(
+        self, request: RevokeGrantRequest
+    ) -> RevokeGrantResponse: ...

--- a/sdk/python/gestalt/public/generated/indexeddb_client.py
+++ b/sdk/python/gestalt/public/generated/indexeddb_client.py
@@ -49,7 +49,7 @@ from .metadata import (
     METHOD_INDEXED_DB_INDEX_GET_KEY,
     METHOD_INDEXED_DB_PUT,
 )
-from .unary_transport import UnaryTransport
+from .unary_transport import AsyncUnaryTransport, UnaryTransport
 
 _empty: Any = _empty_pb2
 
@@ -233,6 +233,192 @@ class IndexedDBClient:
     def index_delete(self, request: IndexQueryRequest) -> DeleteResponse:
         wire = _indexeddb_codec.to_wire_index_query_request(request)
         wire_response = self._transport.unary(
+            METHOD_INDEXED_DB_INDEX_DELETE,
+            wire,
+            _indexeddb_pb2.DeleteResponse,
+        )
+        return _indexeddb_codec.from_wire_delete_response(wire_response)
+
+
+class AsyncIndexedDBClient:
+    """IndexedDB models the shared Gestalt IndexedDB-provider protocol.
+
+    Async client for the public gestalt.provider.v1.IndexedDB surface; methods are coroutines.
+    """
+
+    def __init__(self, transport: AsyncUnaryTransport) -> None:
+        self._transport = transport
+
+    async def create_object_store(self, request: CreateObjectStoreRequest) -> None:
+        """Lifecycle"""
+        wire = _indexeddb_codec.to_wire_create_object_store_request(request)
+        await self._transport.unary(
+            METHOD_INDEXED_DB_CREATE_OBJECT_STORE,
+            wire,
+            _empty.Empty,
+        )
+
+    async def delete_object_store(self, request: DeleteObjectStoreRequest) -> None:
+        wire = _indexeddb_codec.to_wire_delete_object_store_request(request)
+        await self._transport.unary(
+            METHOD_INDEXED_DB_DELETE_OBJECT_STORE,
+            wire,
+            _empty.Empty,
+        )
+
+    async def create_index(self, request: CreateIndexRequest) -> None:
+        wire = _indexeddb_codec.to_wire_create_index_request(request)
+        await self._transport.unary(
+            METHOD_INDEXED_DB_CREATE_INDEX,
+            wire,
+            _empty.Empty,
+        )
+
+    async def delete_index(self, request: DeleteIndexRequest) -> None:
+        wire = _indexeddb_codec.to_wire_delete_index_request(request)
+        await self._transport.unary(
+            METHOD_INDEXED_DB_DELETE_INDEX,
+            wire,
+            _empty.Empty,
+        )
+
+    async def get(self, request: ObjectStoreRequest) -> RecordResponse:
+        """Primary key CRUD"""
+        wire = _indexeddb_codec.to_wire_object_store_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_INDEXED_DB_GET,
+            wire,
+            _indexeddb_pb2.RecordResponse,
+        )
+        return _indexeddb_codec.from_wire_record_response(wire_response)
+
+    async def get_key(self, request: ObjectStoreRequest) -> KeyResponse:
+        wire = _indexeddb_codec.to_wire_object_store_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_INDEXED_DB_GET_KEY,
+            wire,
+            _indexeddb_pb2.KeyResponse,
+        )
+        return _indexeddb_codec.from_wire_key_response(wire_response)
+
+    async def add(self, request: RecordRequest) -> None:
+        wire = _indexeddb_codec.to_wire_record_request(request)
+        await self._transport.unary(
+            METHOD_INDEXED_DB_ADD,
+            wire,
+            _empty.Empty,
+        )
+
+    async def put(self, request: RecordRequest) -> None:
+        wire = _indexeddb_codec.to_wire_record_request(request)
+        await self._transport.unary(
+            METHOD_INDEXED_DB_PUT,
+            wire,
+            _empty.Empty,
+        )
+
+    async def delete(self, request: ObjectStoreRequest) -> None:
+        wire = _indexeddb_codec.to_wire_object_store_request(request)
+        await self._transport.unary(
+            METHOD_INDEXED_DB_DELETE,
+            wire,
+            _empty.Empty,
+        )
+
+    async def clear(self, request: ObjectStoreNameRequest) -> None:
+        """Bulk operations (with optional query)"""
+        wire = _indexeddb_codec.to_wire_object_store_name_request(request)
+        await self._transport.unary(
+            METHOD_INDEXED_DB_CLEAR,
+            wire,
+            _empty.Empty,
+        )
+
+    async def get_all(self, request: ObjectStoreRangeRequest) -> RecordsResponse:
+        wire = _indexeddb_codec.to_wire_object_store_range_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_INDEXED_DB_GET_ALL,
+            wire,
+            _indexeddb_pb2.RecordsResponse,
+        )
+        return _indexeddb_codec.from_wire_records_response(wire_response)
+
+    async def get_all_keys(self, request: ObjectStoreRangeRequest) -> KeysResponse:
+        wire = _indexeddb_codec.to_wire_object_store_range_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_INDEXED_DB_GET_ALL_KEYS,
+            wire,
+            _indexeddb_pb2.KeysResponse,
+        )
+        return _indexeddb_codec.from_wire_keys_response(wire_response)
+
+    async def count(self, request: ObjectStoreRangeRequest) -> CountResponse:
+        wire = _indexeddb_codec.to_wire_object_store_range_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_INDEXED_DB_COUNT,
+            wire,
+            _indexeddb_pb2.CountResponse,
+        )
+        return _indexeddb_codec.from_wire_count_response(wire_response)
+
+    async def delete_range(self, request: ObjectStoreRangeRequest) -> DeleteResponse:
+        wire = _indexeddb_codec.to_wire_object_store_range_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_INDEXED_DB_DELETE_RANGE,
+            wire,
+            _indexeddb_pb2.DeleteResponse,
+        )
+        return _indexeddb_codec.from_wire_delete_response(wire_response)
+
+    async def index_get(self, request: IndexQueryRequest) -> RecordResponse:
+        """Index queries"""
+        wire = _indexeddb_codec.to_wire_index_query_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_INDEXED_DB_INDEX_GET,
+            wire,
+            _indexeddb_pb2.RecordResponse,
+        )
+        return _indexeddb_codec.from_wire_record_response(wire_response)
+
+    async def index_get_key(self, request: IndexQueryRequest) -> KeyResponse:
+        wire = _indexeddb_codec.to_wire_index_query_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_INDEXED_DB_INDEX_GET_KEY,
+            wire,
+            _indexeddb_pb2.KeyResponse,
+        )
+        return _indexeddb_codec.from_wire_key_response(wire_response)
+
+    async def index_get_all(self, request: IndexQueryRequest) -> RecordsResponse:
+        wire = _indexeddb_codec.to_wire_index_query_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_INDEXED_DB_INDEX_GET_ALL,
+            wire,
+            _indexeddb_pb2.RecordsResponse,
+        )
+        return _indexeddb_codec.from_wire_records_response(wire_response)
+
+    async def index_get_all_keys(self, request: IndexQueryRequest) -> KeysResponse:
+        wire = _indexeddb_codec.to_wire_index_query_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_INDEXED_DB_INDEX_GET_ALL_KEYS,
+            wire,
+            _indexeddb_pb2.KeysResponse,
+        )
+        return _indexeddb_codec.from_wire_keys_response(wire_response)
+
+    async def index_count(self, request: IndexQueryRequest) -> CountResponse:
+        wire = _indexeddb_codec.to_wire_index_query_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_INDEXED_DB_INDEX_COUNT,
+            wire,
+            _indexeddb_pb2.CountResponse,
+        )
+        return _indexeddb_codec.from_wire_count_response(wire_response)
+
+    async def index_delete(self, request: IndexQueryRequest) -> DeleteResponse:
+        wire = _indexeddb_codec.to_wire_index_query_request(request)
+        wire_response = await self._transport.unary(
             METHOD_INDEXED_DB_INDEX_DELETE,
             wire,
             _indexeddb_pb2.DeleteResponse,

--- a/sdk/python/gestalt/public/generated/unary_transport.py
+++ b/sdk/python/gestalt/public/generated/unary_transport.py
@@ -20,3 +20,12 @@ class UnaryTransport(Protocol):
         request: Message,
         response_type: type[ResponseT],
     ) -> ResponseT: ...
+
+
+class AsyncUnaryTransport(Protocol):
+    async def unary(
+        self,
+        method: Method,
+        request: Message,
+        response_type: type[ResponseT],
+    ) -> ResponseT: ...

--- a/sdk/python/gestalt/public/generated/workflow_client.py
+++ b/sdk/python/gestalt/public/generated/workflow_client.py
@@ -26,7 +26,7 @@ from .metadata import (
     METHOD_WORKFLOW_SIGNAL_RUN,
     METHOD_WORKFLOW_START_RUN,
 )
-from .unary_transport import UnaryTransport
+from .unary_transport import AsyncUnaryTransport, UnaryTransport
 from .workflow import (
     ApplyWorkflowProviderDefinitionRequest,
     CancelWorkflowProviderRunRequest,
@@ -265,5 +265,226 @@ class WorkflowClientREST(Protocol):
         self, request: SignalWorkflowProviderRunRequest
     ) -> SignalWorkflowRunResponse: ...
     def signal_or_start_run(
+        self, request: SignalOrStartWorkflowProviderRunRequest
+    ) -> SignalWorkflowRunResponse: ...
+
+
+class AsyncWorkflowClient:
+    """Async client for the public gestalt.provider.v1.Workflow surface; methods are coroutines."""
+
+    def __init__(self, transport: AsyncUnaryTransport) -> None:
+        self._transport = transport
+
+    async def apply_definition(
+        self, request: ApplyWorkflowProviderDefinitionRequest
+    ) -> WorkflowDefinition:
+        wire = _workflow_codec.to_wire_apply_workflow_provider_definition_request(
+            request
+        )
+        wire_response = await self._transport.unary(
+            METHOD_WORKFLOW_APPLY_DEFINITION,
+            wire,
+            _workflow_pb2.WorkflowDefinition,
+        )
+        return _workflow_codec.from_wire_workflow_definition(wire_response)
+
+    async def get_definition(
+        self, request: GetWorkflowProviderDefinitionRequest
+    ) -> WorkflowDefinition:
+        wire = _workflow_codec.to_wire_get_workflow_provider_definition_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_WORKFLOW_GET_DEFINITION,
+            wire,
+            _workflow_pb2.WorkflowDefinition,
+        )
+        return _workflow_codec.from_wire_workflow_definition(wire_response)
+
+    async def list_definitions(
+        self, request: ListWorkflowProviderDefinitionsRequest
+    ) -> ListWorkflowProviderDefinitionsResponse:
+        wire = _workflow_codec.to_wire_list_workflow_provider_definitions_request(
+            request
+        )
+        wire_response = await self._transport.unary(
+            METHOD_WORKFLOW_LIST_DEFINITIONS,
+            wire,
+            _workflow_pb2.ListWorkflowProviderDefinitionsResponse,
+        )
+        return _workflow_codec.from_wire_list_workflow_provider_definitions_response(
+            wire_response
+        )
+
+    async def set_definition_paused(
+        self, request: SetWorkflowProviderDefinitionPausedRequest
+    ) -> WorkflowDefinition:
+        wire = _workflow_codec.to_wire_set_workflow_provider_definition_paused_request(
+            request
+        )
+        wire_response = await self._transport.unary(
+            METHOD_WORKFLOW_SET_DEFINITION_PAUSED,
+            wire,
+            _workflow_pb2.WorkflowDefinition,
+        )
+        return _workflow_codec.from_wire_workflow_definition(wire_response)
+
+    async def set_activation_paused(
+        self, request: SetWorkflowProviderActivationPausedRequest
+    ) -> WorkflowDefinition:
+        wire = _workflow_codec.to_wire_set_workflow_provider_activation_paused_request(
+            request
+        )
+        wire_response = await self._transport.unary(
+            METHOD_WORKFLOW_SET_ACTIVATION_PAUSED,
+            wire,
+            _workflow_pb2.WorkflowDefinition,
+        )
+        return _workflow_codec.from_wire_workflow_definition(wire_response)
+
+    async def delete_definition(
+        self, request: DeleteWorkflowProviderDefinitionRequest
+    ) -> None:
+        wire = _workflow_codec.to_wire_delete_workflow_provider_definition_request(
+            request
+        )
+        await self._transport.unary(
+            METHOD_WORKFLOW_DELETE_DEFINITION,
+            wire,
+            _empty.Empty,
+        )
+
+    async def start_run(self, request: StartWorkflowProviderRunRequest) -> WorkflowRun:
+        wire = _workflow_codec.to_wire_start_workflow_provider_run_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_WORKFLOW_START_RUN,
+            wire,
+            _workflow_pb2.WorkflowRun,
+        )
+        return _workflow_codec.from_wire_workflow_run(wire_response)
+
+    async def list_runs(
+        self, request: ListWorkflowProviderRunsRequest
+    ) -> ListWorkflowProviderRunsResponse:
+        wire = _workflow_codec.to_wire_list_workflow_provider_runs_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_WORKFLOW_LIST_RUNS,
+            wire,
+            _workflow_pb2.ListWorkflowProviderRunsResponse,
+        )
+        return _workflow_codec.from_wire_list_workflow_provider_runs_response(
+            wire_response
+        )
+
+    async def get_run(self, request: GetWorkflowProviderRunRequest) -> WorkflowRun:
+        wire = _workflow_codec.to_wire_get_workflow_provider_run_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_WORKFLOW_GET_RUN,
+            wire,
+            _workflow_pb2.WorkflowRun,
+        )
+        return _workflow_codec.from_wire_workflow_run(wire_response)
+
+    async def get_run_events(
+        self, request: GetWorkflowProviderRunEventsRequest
+    ) -> GetWorkflowProviderRunEventsResponse:
+        wire = _workflow_codec.to_wire_get_workflow_provider_run_events_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_WORKFLOW_GET_RUN_EVENTS,
+            wire,
+            _workflow_pb2.GetWorkflowProviderRunEventsResponse,
+        )
+        return _workflow_codec.from_wire_get_workflow_provider_run_events_response(
+            wire_response
+        )
+
+    async def get_run_output(
+        self, request: GetWorkflowProviderRunOutputRequest
+    ) -> GetWorkflowProviderRunOutputResponse:
+        wire = _workflow_codec.to_wire_get_workflow_provider_run_output_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_WORKFLOW_GET_RUN_OUTPUT,
+            wire,
+            _workflow_pb2.GetWorkflowProviderRunOutputResponse,
+        )
+        return _workflow_codec.from_wire_get_workflow_provider_run_output_response(
+            wire_response
+        )
+
+    async def cancel_run(
+        self, request: CancelWorkflowProviderRunRequest
+    ) -> WorkflowRun:
+        wire = _workflow_codec.to_wire_cancel_workflow_provider_run_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_WORKFLOW_CANCEL_RUN,
+            wire,
+            _workflow_pb2.WorkflowRun,
+        )
+        return _workflow_codec.from_wire_workflow_run(wire_response)
+
+    async def signal_run(
+        self, request: SignalWorkflowProviderRunRequest
+    ) -> SignalWorkflowRunResponse:
+        wire = _workflow_codec.to_wire_signal_workflow_provider_run_request(request)
+        wire_response = await self._transport.unary(
+            METHOD_WORKFLOW_SIGNAL_RUN,
+            wire,
+            _workflow_pb2.SignalWorkflowRunResponse,
+        )
+        return _workflow_codec.from_wire_signal_workflow_run_response(wire_response)
+
+    async def signal_or_start_run(
+        self, request: SignalOrStartWorkflowProviderRunRequest
+    ) -> SignalWorkflowRunResponse:
+        wire = _workflow_codec.to_wire_signal_or_start_workflow_provider_run_request(
+            request
+        )
+        wire_response = await self._transport.unary(
+            METHOD_WORKFLOW_SIGNAL_OR_START_RUN,
+            wire,
+            _workflow_pb2.SignalWorkflowRunResponse,
+        )
+        return _workflow_codec.from_wire_signal_workflow_run_response(wire_response)
+
+
+class AsyncWorkflowClientREST(Protocol):
+    """REST-backed methods for the public gestalt.provider.v1.Workflow surface."""
+
+    async def apply_definition(
+        self, request: ApplyWorkflowProviderDefinitionRequest
+    ) -> WorkflowDefinition: ...
+    async def get_definition(
+        self, request: GetWorkflowProviderDefinitionRequest
+    ) -> WorkflowDefinition: ...
+    async def list_definitions(
+        self, request: ListWorkflowProviderDefinitionsRequest
+    ) -> ListWorkflowProviderDefinitionsResponse: ...
+    async def set_definition_paused(
+        self, request: SetWorkflowProviderDefinitionPausedRequest
+    ) -> WorkflowDefinition: ...
+    async def set_activation_paused(
+        self, request: SetWorkflowProviderActivationPausedRequest
+    ) -> WorkflowDefinition: ...
+    async def delete_definition(
+        self, request: DeleteWorkflowProviderDefinitionRequest
+    ) -> None: ...
+    async def start_run(
+        self, request: StartWorkflowProviderRunRequest
+    ) -> WorkflowRun: ...
+    async def list_runs(
+        self, request: ListWorkflowProviderRunsRequest
+    ) -> ListWorkflowProviderRunsResponse: ...
+    async def get_run(self, request: GetWorkflowProviderRunRequest) -> WorkflowRun: ...
+    async def get_run_events(
+        self, request: GetWorkflowProviderRunEventsRequest
+    ) -> GetWorkflowProviderRunEventsResponse: ...
+    async def get_run_output(
+        self, request: GetWorkflowProviderRunOutputRequest
+    ) -> GetWorkflowProviderRunOutputResponse: ...
+    async def cancel_run(
+        self, request: CancelWorkflowProviderRunRequest
+    ) -> WorkflowRun: ...
+    async def signal_run(
+        self, request: SignalWorkflowProviderRunRequest
+    ) -> SignalWorkflowRunResponse: ...
+    async def signal_or_start_run(
         self, request: SignalOrStartWorkflowProviderRunRequest
     ) -> SignalWorkflowRunResponse: ...

--- a/sdk/python/gestalt/public/grpc_transport.py
+++ b/sdk/python/gestalt/public/grpc_transport.py
@@ -96,8 +96,8 @@ class AsyncGrpcUnaryTransport:
 
         call = self._channel.unary_unary(
             method.full_method,
-            request_serializer=request.SerializeToString,
-            response_deserializer=response_type.FromString,
+            request_serializer=lambda r: r.SerializeToString(),
+            response_deserializer=lambda b: response_type.FromString(b),
         )(request, metadata=metadata or None)
         try:
             return await call

--- a/sdk/python/gestalt/public/grpc_transport.py
+++ b/sdk/python/gestalt/public/grpc_transport.py
@@ -1,4 +1,8 @@
-"""grpcio transport for the public Gestalt API."""
+"""grpcio transports for the public Gestalt API.
+
+``GrpcUnaryTransport`` is sync (backed by ``grpc.Channel``);
+``AsyncGrpcUnaryTransport`` is async (backed by ``grpc.aio.Channel``).
+"""
 
 from __future__ import annotations
 
@@ -6,11 +10,13 @@ from typing import TypeVar
 from urllib.parse import urlparse
 
 import grpc
+import grpc.aio
 from google.protobuf.message import Message
 
 from gestalt._codec.support import call_unary
 from gestalt._grpc_transport import insecure_internal_channel, secure_internal_channel
 from gestalt.public.generated.metadata import Method
+from gestalt.rpc_support import GestaltError, GestaltErrorCode
 
 from .auth import AuthProvider
 
@@ -61,3 +67,60 @@ def grpc_channel_from_address(address: str) -> grpc.Channel:
     if parsed.scheme == "https":
         return secure_internal_channel(target)
     return insecure_internal_channel(target)
+
+
+class AsyncGrpcUnaryTransport:
+    """Async gRPC transport implementing the generated AsyncUnaryTransport protocol."""
+
+    def __init__(
+        self,
+        channel: grpc.aio.Channel,
+        auth: AuthProvider,
+        *,
+        owns_channel: bool = False,
+    ) -> None:
+        self._channel = channel
+        self._auth = auth
+        self._owns_channel = owns_channel
+
+    async def unary(
+        self,
+        method: Method,
+        request: Message,
+        response_type: type[ResponseT],
+    ) -> ResponseT:
+        metadata: list[tuple[str, str]] = []
+        authorization = self._auth.authorization_header()
+        if authorization:
+            metadata.append(("authorization", authorization))
+
+        call = self._channel.unary_unary(
+            method.full_method,
+            request_serializer=request.SerializeToString,
+            response_deserializer=response_type.FromString,
+        )(request, metadata=metadata or None)
+        try:
+            return await call
+        except grpc.aio.AioRpcError as error:
+            # AioRpcError is not a grpc.Call subclass, so to_gestalt_error
+            # (which checks grpc.Call) cannot map it directly. Build the
+            # GestaltError from the status code and details here.
+            code = error.code()
+            numeric = code.value[0] if code is not None else GestaltErrorCode.UNKNOWN
+            raise GestaltError(int(numeric), str(error.details() or "")) from error
+
+    async def close(self) -> None:
+        if self._owns_channel:
+            await self._channel.close()
+
+
+def async_grpc_channel_from_address(address: str) -> grpc.aio.Channel:
+    """Return an async gRPC channel for the given address."""
+    parsed = urlparse(address)
+    target = parsed.netloc
+    if parsed.scheme == "https":
+        return grpc.aio.secure_channel(
+            target,
+            grpc.ssl_channel_credentials(),
+        )
+    return grpc.aio.insecure_channel(target)

--- a/sdk/python/gestalt/public/grpc_transport.py
+++ b/sdk/python/gestalt/public/grpc_transport.py
@@ -14,7 +14,11 @@ import grpc.aio
 from google.protobuf.message import Message
 
 from gestalt._codec.support import call_unary
-from gestalt._grpc_transport import insecure_internal_channel, secure_internal_channel
+from gestalt._grpc_transport import (
+    _INTERNAL_CHANNEL_OPTIONS,
+    insecure_internal_channel,
+    secure_internal_channel,
+)
 from gestalt.public.generated.metadata import Method
 from gestalt.rpc_support import GestaltError, GestaltErrorCode
 
@@ -115,12 +119,18 @@ class AsyncGrpcUnaryTransport:
 
 
 def async_grpc_channel_from_address(address: str) -> grpc.aio.Channel:
-    """Return an async gRPC channel for the given address."""
+    """Return an async gRPC channel for the given address.
+
+    Applies the same internal channel options as the sync path
+    (grpc.enable_http_proxy=0 and 64MB message-size limits) so async
+    callers don't diverge from grpc_channel_from_address.
+    """
     parsed = urlparse(address)
     target = parsed.netloc
     if parsed.scheme == "https":
         return grpc.aio.secure_channel(
             target,
             grpc.ssl_channel_credentials(),
+            options=_INTERNAL_CHANNEL_OPTIONS,
         )
-    return grpc.aio.insecure_channel(target)
+    return grpc.aio.insecure_channel(target, options=_INTERNAL_CHANNEL_OPTIONS)

--- a/sdk/python/gestalt/public/rest_request.py
+++ b/sdk/python/gestalt/public/rest_request.py
@@ -1,0 +1,146 @@
+"""Shared request building and response decoding for REST transports.
+
+Both the sync ``RestUnaryTransport`` and the async ``AsyncRestUnaryTransport``
+use these pure helpers so request assembly and response decoding live in one
+place. Only the HTTP I/O half differs between the transports.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+from google.protobuf import json_format
+from google.protobuf.message import Message
+
+from gestalt._gen.v1 import app_pb2 as _app_pb2
+from gestalt.rpc_support import GestaltError, GestaltErrorCode
+
+from .auth import AuthProvider
+from .errors import is_operation_result, parse_gateway_error
+from .generated.metadata import Method
+from .rest_mapping import (
+    build_rest_body,
+    build_rest_path,
+    build_rest_query,
+    encode_query_string,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedRestRequest:
+    """Assembled REST request, ready for an HTTP send."""
+
+    verb: str
+    url: str
+    headers: dict[str, str]
+    params: str | None
+    json_body: dict[str, Any] | None
+
+
+def build_rest_request(
+    method: Method,
+    request: Message,
+    base_url: str,
+    auth: AuthProvider,
+) -> PreparedRestRequest:
+    """Build the REST request: serialize to protobuf-JSON, substitute path
+    parameters, assemble headers, and build the query string or JSON body.
+
+    Pure; performs no I/O.
+    """
+    if not method.http_verb or not method.http_path:
+        raise ValueError(f"method {method.full_method} has no HTTP binding")
+
+    request_json: dict[str, Any] = json_format.MessageToDict(
+        request,
+        preserving_proto_field_name=False,
+    )
+    path = build_rest_path(method, request_json)
+    url = f"{base_url}{path}"
+    headers: dict[str, str] = {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+    authorization = auth.authorization_header()
+    if authorization:
+        headers["Authorization"] = authorization
+
+    params: str | None = None
+    json_body: dict[str, Any] | None = None
+    if method.http_verb in {"GET", "DELETE"}:
+        query = build_rest_query(method, request_json)
+        if query:
+            params = encode_query_string(query)
+    else:
+        json_body = build_rest_body(method, request_json)
+
+    return PreparedRestRequest(
+        verb=method.http_verb,
+        url=url,
+        headers=headers,
+        params=params,
+        json_body=json_body,
+    )
+
+
+def decode_rest_response(
+    response_type: type[Message],
+    status_code: int,
+    content: bytes,
+    headers: dict[str, str],
+) -> Message:
+    """Decode a REST response body into a protobuf message.
+
+    Handles the OperationResult envelope, error-status mapping, empty bodies,
+    and protobuf-JSON decode. Pure; performs no I/O.
+    """
+    if is_operation_result(headers):
+        return _fill_operation_result(response_type, status_code, content, headers)
+
+    if status_code >= 400:
+        raise parse_gateway_error(status_code, content)
+    if not content.strip():
+        return response_type()
+    message = response_type()
+    json_format.Parse(content, message)
+    return message
+
+
+def map_httpx_error(err: Exception) -> GestaltError:
+    """Map an httpx transport error to a GestaltError with the right code."""
+    if isinstance(err, httpx.TimeoutException):
+        return GestaltError(
+            GestaltErrorCode.DEADLINE_EXCEEDED,
+            str(err) or "request deadline exceeded",
+        )
+    return GestaltError(GestaltErrorCode.UNAVAILABLE, str(err))
+
+
+def _fill_operation_result(
+    response_type: type[Message],
+    status_code: int,
+    body: bytes,
+    headers: dict[str, str],
+) -> Message:
+    message = response_type()
+    if not isinstance(message, _app_pb2.OperationResult):
+        if not body.strip():
+            return message
+        json_format.Parse(body, message)
+        return message
+
+    header_values: dict[str, list[str]] = {}
+    for key, value in headers.items():
+        if key.lower() == "x-gestalt-response-kind":
+            continue
+        header_values.setdefault(key, []).append(value)
+
+    message.status = status_code
+    message.body = body
+    message.headers.clear()
+    for key, values in header_values.items():
+        entry = message.headers[key]
+        entry.values.extend(values)
+    return message

--- a/sdk/python/gestalt/public/rest_transport.py
+++ b/sdk/python/gestalt/public/rest_transport.py
@@ -158,7 +158,7 @@ class AsyncRestUnaryTransport:
             ),
         )
 
-    async def aclose(self) -> None:
+    async def close(self) -> None:
         if self._owns_client and self._owned_client is not None:
             await self._owned_client.aclose()
             self._owned_client = None

--- a/sdk/python/gestalt/public/rest_transport.py
+++ b/sdk/python/gestalt/public/rest_transport.py
@@ -1,4 +1,9 @@
-"""httpx-based REST transport for the public Gestalt API (/api/v2)."""
+"""httpx-based REST transports for the public Gestalt API (/api/v2).
+
+``RestUnaryTransport`` is sync (backed by ``httpx.Client``);
+``AsyncRestUnaryTransport`` is async (backed by ``httpx.AsyncClient``). Both
+share request building and response decoding via ``rest_request``.
+"""
 
 from __future__ import annotations
 
@@ -6,20 +11,14 @@ from collections.abc import Mapping
 from typing import Any, Protocol, TypeVar, cast
 
 import httpx
-from google.protobuf import json_format
 from google.protobuf.message import Message
 
-from gestalt._gen.v1 import app_pb2 as _app_pb2
-from gestalt.rpc_support import GestaltError, GestaltErrorCode
-
 from .auth import AuthProvider
-from .errors import is_operation_result, parse_gateway_error
 from .generated.metadata import Method
-from .rest_mapping import (
-    build_rest_body,
-    build_rest_path,
-    build_rest_query,
-    encode_query_string,
+from .rest_request import (
+    build_rest_request,
+    decode_rest_response,
+    map_httpx_error,
 )
 
 ResponseT = TypeVar("ResponseT", bound=Message)
@@ -27,6 +26,19 @@ ResponseT = TypeVar("ResponseT", bound=Message)
 
 class HttpClient(Protocol):
     def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+        params: str | None = None,
+        json: dict[str, Any] | None = None,
+        timeout: float | None = None,
+    ) -> httpx.Response: ...
+
+
+class AsyncHttpClient(Protocol):
+    async def request(
         self,
         method: str,
         url: str,
@@ -65,71 +77,29 @@ class RestUnaryTransport:
         request: Message,
         response_type: type[ResponseT],
     ) -> ResponseT:
-        if not method.http_verb or not method.http_path:
-            raise ValueError(f"method {method.full_method} has no HTTP binding")
-
-        request_json: dict[str, Any] = json_format.MessageToDict(
-            request,
-            preserving_proto_field_name=False,
-        )
-        path = build_rest_path(method, request_json)
-        url = f"{self._base_url}{path}"
-        headers = {
-            "Accept": "application/json",
-            "Content-Type": "application/json",
-        }
-        authorization = self._auth.authorization_header()
-        if authorization:
-            headers["Authorization"] = authorization
-
-        params: str | None = None
-        json_body: dict[str, Any] | None = None
-        if method.http_verb in {"GET", "DELETE"}:
-            query = build_rest_query(method, request_json)
-            if query:
-                params = encode_query_string(query)
-        else:
-            json_body = build_rest_body(method, request_json)
-
+        prepared = build_rest_request(method, request, self._base_url, self._auth)
         client = self._client or self._owned_client
         if client is None:
             raise RuntimeError("REST transport client is not available")
 
         try:
             response = client.request(
-                method.http_verb,
-                url,
-                headers=headers,
-                params=params,
-                json=json_body,
+                prepared.verb,
+                prepared.url,
+                headers=prepared.headers,
+                params=prepared.params,
+                json=prepared.json_body,
             )
-        except httpx.TimeoutException as err:
-            raise GestaltError(
-                GestaltErrorCode.DEADLINE_EXCEEDED,
-                str(err) or "request deadline exceeded",
-            ) from err
-        except httpx.HTTPError as err:
-            raise GestaltError(GestaltErrorCode.UNAVAILABLE, str(err)) from err
+        except (httpx.TimeoutException, httpx.HTTPError) as err:
+            raise map_httpx_error(err) from err
 
         header_map = {key: value for key, value in response.headers.items()}
-        if is_operation_result(header_map):
-            return cast(
-                ResponseT,
-                _fill_operation_result(
-                    response_type,
-                    response.status_code,
-                    response.content,
-                    header_map,
-                ),
-            )
-
-        if response.status_code >= 400:
-            raise parse_gateway_error(response.status_code, response.content)
-        if not response.content.strip():
-            return response_type()
-        message = response_type()
-        json_format.Parse(response.content, message)
-        return message
+        return cast(
+            ResponseT,
+            decode_rest_response(
+                response_type, response.status_code, response.content, header_map
+            ),
+        )
 
     def close(self) -> None:
         if self._owns_client and self._owned_client is not None:
@@ -137,29 +107,58 @@ class RestUnaryTransport:
             self._owned_client = None
 
 
-def _fill_operation_result(
-    response_type: type[Message],
-    status_code: int,
-    body: bytes,
-    headers: dict[str, str],
-) -> Message:
-    message = response_type()
-    if not isinstance(message, _app_pb2.OperationResult):
-        if not body.strip():
-            return message
-        json_format.Parse(body, message)
-        return message
+class AsyncRestUnaryTransport:
+    """Async protobuf-JSON REST transport implementing the generated AsyncUnaryTransport protocol."""
 
-    header_values: dict[str, list[str]] = {}
-    for key, value in headers.items():
-        if key.lower() == "x-gestalt-response-kind":
-            continue
-        header_values.setdefault(key, []).append(value)
+    def __init__(
+        self,
+        base_url: str,
+        auth: AuthProvider,
+        *,
+        client: AsyncHttpClient | None = None,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._auth = auth
+        self._client = client
+        self._owns_client = client is None
+        self._owned_client: httpx.AsyncClient | None = None
+        if self._owns_client:
+            self._owned_client = httpx.AsyncClient(
+                verify=True,
+                transport=httpx.AsyncHTTPTransport(retries=0),
+            )
 
-    message.status = status_code
-    message.body = body
-    message.headers.clear()
-    for key, values in header_values.items():
-        entry = message.headers[key]
-        entry.values.extend(values)
-    return message
+    async def unary(
+        self,
+        method: Method,
+        request: Message,
+        response_type: type[ResponseT],
+    ) -> ResponseT:
+        prepared = build_rest_request(method, request, self._base_url, self._auth)
+        client = self._client or self._owned_client
+        if client is None:
+            raise RuntimeError("async REST transport client is not available")
+
+        try:
+            response = await client.request(
+                prepared.verb,
+                prepared.url,
+                headers=prepared.headers,
+                params=prepared.params,
+                json=prepared.json_body,
+            )
+        except (httpx.TimeoutException, httpx.HTTPError) as err:
+            raise map_httpx_error(err) from err
+
+        header_map = {key: value for key, value in response.headers.items()}
+        return cast(
+            ResponseT,
+            decode_rest_response(
+                response_type, response.status_code, response.content, header_map
+            ),
+        )
+
+    async def aclose(self) -> None:
+        if self._owns_client and self._owned_client is not None:
+            await self._owned_client.aclose()
+            self._owned_client = None

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -26,11 +26,15 @@ dependencies = [
 [dependency-groups]
 dev = [
   "pytest>=9.0.3",
+  "pytest-asyncio>1",
   "ruff==0.15.14",
   "sphinx==8.1.3",
   "ty==0.0.38",
   "vulture==2.16.0",
 ]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
 
 [tool.setuptools.packages.find]
 include = ["gestalt*"]

--- a/sdk/python/tests/test_public_async_grpc_transport.py
+++ b/sdk/python/tests/test_public_async_grpc_transport.py
@@ -125,3 +125,13 @@ async def test_async_channel_applies_internal_options() -> None:
             "localhost:8080",
             options=_INTERNAL_CHANNEL_OPTIONS,
         )
+
+
+async def test_async_grpc_transport_close_releases_owned_channel() -> None:
+    """AsyncGrpcUnaryTransport.close() must close the channel when owns_channel=True."""
+    channel = grpc.aio.insecure_channel("127.0.0.1:1")
+    transport = AsyncGrpcUnaryTransport(
+        channel, bearer(lambda: "token"), owns_channel=True
+    )
+    await transport.close()
+    # Channel state after close is SHUTDOWN; accessing it should not raise.

--- a/sdk/python/tests/test_public_async_grpc_transport.py
+++ b/sdk/python/tests/test_public_async_grpc_transport.py
@@ -1,0 +1,99 @@
+"""Async gRPC transport tests for the public Gestalt Python client."""
+
+from __future__ import annotations
+
+import json
+from concurrent import futures
+
+import grpc
+import grpc.aio
+from grpc.aio import server as aio_server
+
+from gestalt._gen.v1 import app_pb2, app_pb2_grpc
+from gestalt.public.auth import bearer
+from gestalt.public.generated.metadata import METHOD_APP_INVOKE
+from gestalt.public.grpc_transport import AsyncGrpcUnaryTransport
+from gestalt.rpc_support import GestaltError, GestaltErrorCode
+
+
+class _AsyncAppServicer(app_pb2_grpc.AppServicer):
+    async def Invoke(self, request, context):
+        metadata = dict(context.invocation_metadata())
+        if metadata.get("authorization") != "Bearer secret":
+            await context.abort(grpc.StatusCode.UNAUTHENTICATED, "missing bearer")
+        return app_pb2.OperationResult(
+            status=200,
+            body=json.dumps({"status": "success", "data": {"ok": True}}).encode(),
+        )
+
+    async def InvokeGraphQL(self, request, context):
+        await context.abort(grpc.StatusCode.UNIMPLEMENTED, "not implemented")
+
+
+async def test_async_grpc_transport_sends_bearer_metadata() -> None:
+    server = aio_server(futures.ThreadPoolExecutor(max_workers=1))
+    app_pb2_grpc.add_AppServicer_to_server(_AsyncAppServicer(), server)
+    port = server.add_insecure_port("127.0.0.1:0")
+    await server.start()
+    try:
+        channel = grpc.aio.insecure_channel(f"127.0.0.1:{port}")
+        try:
+            transport = AsyncGrpcUnaryTransport(channel, bearer(lambda: "secret"))
+            request = app_pb2.AppInvokeRequest(app="example", operation="sync")
+            response = await transport.unary(
+                METHOD_APP_INVOKE,
+                request,
+                app_pb2.OperationResult,
+            )
+            assert response.status == 200
+        finally:
+            await channel.close()
+    finally:
+        await server.stop(grace=None)
+
+
+async def test_async_grpc_transport_maps_rpc_errors() -> None:
+    server = aio_server(futures.ThreadPoolExecutor(max_workers=1))
+    app_pb2_grpc.add_AppServicer_to_server(_AsyncAppServicer(), server)
+    port = server.add_insecure_port("127.0.0.1:0")
+    await server.start()
+    try:
+        channel = grpc.aio.insecure_channel(f"127.0.0.1:{port}")
+        try:
+            transport = AsyncGrpcUnaryTransport(channel, bearer(lambda: ""))
+            request = app_pb2.AppInvokeRequest(app="example", operation="sync")
+            try:
+                await transport.unary(
+                    METHOD_APP_INVOKE, request, app_pb2.OperationResult
+                )
+                assert False, "expected GestaltError"
+            except GestaltError as err:
+                assert err.code == GestaltErrorCode.UNAUTHENTICATED
+        finally:
+            await channel.close()
+    finally:
+        await server.stop(grace=None)
+
+
+async def test_async_generated_client_invoke() -> None:
+    """The generated AsyncAppClient drives the async gRPC transport end-to-end."""
+    from gestalt.public.generated.app import AppInvokeRequest
+    from gestalt.public.generated.app_client import AsyncAppClient
+
+    server = aio_server(futures.ThreadPoolExecutor(max_workers=1))
+    app_pb2_grpc.add_AppServicer_to_server(_AsyncAppServicer(), server)
+    port = server.add_insecure_port("127.0.0.1:0")
+    await server.start()
+    try:
+        channel = grpc.aio.insecure_channel(f"127.0.0.1:{port}")
+        try:
+            transport = AsyncGrpcUnaryTransport(channel, bearer(lambda: "secret"))
+            client = AsyncAppClient(transport)
+            response = await client.invoke_raw(
+                AppInvokeRequest(app="example", operation="sync")
+            )
+            assert response.status == 200
+        finally:
+            await channel.close()
+    finally:
+        await server.stop(grace=None)

--- a/sdk/python/tests/test_public_async_grpc_transport.py
+++ b/sdk/python/tests/test_public_async_grpc_transport.py
@@ -97,3 +97,31 @@ async def test_async_generated_client_invoke() -> None:
             await channel.close()
     finally:
         await server.stop(grace=None)
+
+
+async def test_async_channel_applies_internal_options() -> None:
+    """async_grpc_channel_from_address must pass the same internal channel
+    options (proxy disable + 64MB message limits) as the sync path."""
+    from unittest import mock
+
+    from gestalt._grpc_transport import _INTERNAL_CHANNEL_OPTIONS
+    from gestalt.public.grpc_transport import async_grpc_channel_from_address
+
+    with (
+        mock.patch("gestalt.public.grpc_transport.grpc.aio.secure_channel") as secure,
+        mock.patch(
+            "gestalt.public.grpc_transport.grpc.aio.insecure_channel"
+        ) as insecure,
+    ):
+        async_grpc_channel_from_address("https://valon.tools")
+        secure.assert_called_once_with(
+            "valon.tools",
+            mock.ANY,
+            options=_INTERNAL_CHANNEL_OPTIONS,
+        )
+
+        async_grpc_channel_from_address("http://localhost:8080")
+        insecure.assert_called_once_with(
+            "localhost:8080",
+            options=_INTERNAL_CHANNEL_OPTIONS,
+        )

--- a/sdk/python/tests/test_public_async_rest_transport.py
+++ b/sdk/python/tests/test_public_async_rest_transport.py
@@ -1,0 +1,206 @@
+"""Async REST transport tests for the public Gestalt Python client."""
+
+from __future__ import annotations
+
+import json as json_module
+from collections.abc import Mapping
+from typing import Any
+
+import httpx
+from google.protobuf import json_format
+
+from gestalt._gen.v1 import app_pb2
+from gestalt.public.auth import bearer, unauthenticated
+from gestalt.public.generated.metadata import METHOD_APP_INVOKE
+from gestalt.public.rest_transport import AsyncRestUnaryTransport
+from gestalt.rpc_support import GestaltError, GestaltErrorCode
+
+
+class _AsyncRecordingTransport:
+    """Async httpx-like client that records each call and delegates to a handler."""
+
+    def __init__(self, handler) -> None:
+        self._handler = handler
+        self.calls: list[dict[str, Any]] = []
+
+    async def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+        params: str | None = None,
+        json: dict[str, Any] | None = None,
+        timeout: float | None = None,
+    ) -> httpx.Response:
+        self.calls.append(
+            {
+                "method": method,
+                "url": url,
+                "headers": dict(headers or {}),
+                "params": params,
+                "json": json,
+                "timeout": timeout,
+            }
+        )
+        return self._handler(
+            method, url, headers=headers, params=params, json=json, timeout=timeout
+        )
+
+
+async def test_async_rest_transport_maps_requests_and_gateway_errors() -> None:
+    calls: list[dict[str, Any]] = []
+
+    def handler(method, url, *, headers=None, params=None, json=None, **kwargs):
+        calls.append(
+            {
+                "method": method,
+                "url": url,
+                "authorization": (headers or {}).get("Authorization"),
+                "json": json,
+            }
+        )
+        return httpx.Response(
+            200,
+            headers={"Content-Type": "application/json"},
+            content=json_format.MessageToJson(
+                app_pb2.OperationResult(
+                    status=418,
+                    body=b"teapot",
+                    headers={"X-Example": app_pb2.StringList(values=["rest-v2"])},
+                )
+            ).encode(),
+        )
+
+    client = _AsyncRecordingTransport(handler)
+    transport = AsyncRestUnaryTransport(
+        "https://gestalt.test/",
+        bearer(lambda: "token-123"),
+        client=client,
+    )
+    request = app_pb2.AppInvokeRequest(
+        app="example",
+        operation="sync",
+        idempotency_key="key-1",
+    )
+    request.params["ok"] = True
+    response = await transport.unary(
+        METHOD_APP_INVOKE,
+        request,
+        app_pb2.OperationResult,
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["method"] == "POST"
+    assert calls[0]["url"] == "https://gestalt.test/api/v2/app/example/operations/sync"
+    assert calls[0]["authorization"] == "Bearer token-123"
+    assert calls[0]["json"] == {"params": {"ok": True}, "idempotencyKey": "key-1"}
+    assert response.status == 418
+    assert response.body == b"teapot"
+
+    # Gateway error path: 401 maps to UNAUTHENTICATED.
+    def gateway_handler(*_args, **_kwargs):
+        return httpx.Response(
+            401,
+            content=json_module.dumps(
+                {"error": "unauthorized", "code": "Unauthenticated"}
+            ).encode(),
+        )
+
+    gateway_client = _AsyncRecordingTransport(gateway_handler)
+    gateway_transport = AsyncRestUnaryTransport(
+        "https://gestalt.test/",
+        bearer(lambda: "token"),
+        client=gateway_client,
+    )
+    try:
+        await gateway_transport.unary(
+            METHOD_APP_INVOKE,
+            request,
+            app_pb2.OperationResult,
+        )
+        assert False, "expected GestaltError"
+    except GestaltError as err:
+        assert err.code == GestaltErrorCode.UNAUTHENTICATED
+        assert err.message == "unauthorized"
+
+
+async def test_async_bearer_rotation_is_evaluated_per_invocation() -> None:
+    token = {"value": "first"}
+    authorizations: list[str | None] = []
+
+    def handler(_method, _url, *, headers=None, **_kwargs):
+        authorizations.append((headers or {}).get("Authorization"))
+        return httpx.Response(
+            200,
+            content=json_module.dumps(
+                {"status": 200, "body": "", "headers": {}}
+            ).encode(),
+        )
+
+    transport = AsyncRestUnaryTransport(
+        "https://gestalt.test/",
+        bearer(lambda: token["value"]),
+        client=_AsyncRecordingTransport(handler),
+    )
+    request = app_pb2.AppInvokeRequest(app="example", operation="sync")
+    await transport.unary(METHOD_APP_INVOKE, request, app_pb2.OperationResult)
+    token["value"] = "second"
+    await transport.unary(METHOD_APP_INVOKE, request, app_pb2.OperationResult)
+    assert authorizations == ["Bearer first", "Bearer second"]
+
+
+async def test_async_unauthenticated_auth_omits_authorization_header() -> None:
+    seen: list[str | None] = []
+
+    def handler(_method, _url, *, headers=None, **_kwargs):
+        seen.append((headers or {}).get("Authorization"))
+        return httpx.Response(
+            200,
+            content=json_module.dumps(
+                {"status": 200, "body": "", "headers": {}}
+            ).encode(),
+        )
+
+    transport = AsyncRestUnaryTransport(
+        "https://gestalt.test/",
+        unauthenticated(),
+        client=_AsyncRecordingTransport(handler),
+    )
+    request = app_pb2.AppInvokeRequest(app="example", operation="sync")
+    await transport.unary(METHOD_APP_INVOKE, request, app_pb2.OperationResult)
+    assert seen[0] is None
+
+
+async def test_async_generated_client_check_access() -> None:
+    """The generated AsyncAuthorizationClient drives the async transport end-to-end."""
+    from gestalt.public.generated.authorization import (
+        Action,
+        CheckAccessRequest,
+        Resource,
+        Subject,
+    )
+    from gestalt.public.generated.authorization_client import AsyncAuthorizationClient
+
+    def handler(method, url, *, headers=None, json=None, **kwargs):
+        return httpx.Response(
+            200,
+            headers={"Content-Type": "application/json"},
+            content=json_module.dumps({"allowed": True, "modelId": "model-1"}).encode(),
+        )
+
+    transport = AsyncRestUnaryTransport(
+        "https://gestalt.test/",
+        bearer(lambda: "token"),
+        client=_AsyncRecordingTransport(handler),
+    )
+    client = AsyncAuthorizationClient(transport)
+    resp = await client.check_access(
+        CheckAccessRequest(
+            subject=Subject(type="user", id="u1"),
+            action=Action(name="read"),
+            resource=Resource(type="doc", id="d1"),
+        )
+    )
+    assert resp.allowed is True
+    assert resp.model_id == "model-1"

--- a/sdk/python/tests/test_public_async_rest_transport.py
+++ b/sdk/python/tests/test_public_async_rest_transport.py
@@ -204,3 +204,15 @@ async def test_async_generated_client_check_access() -> None:
     )
     assert resp.allowed is True
     assert resp.model_id == "model-1"
+
+
+async def test_async_rest_transport_close_releases_owned_client() -> None:
+    """AsyncRestUnaryTransport.close() must release the owned httpx.AsyncClient."""
+
+    transport = AsyncRestUnaryTransport(
+        "https://gestalt.test/",
+        bearer(lambda: "token"),
+    )
+    assert transport._owned_client is not None
+    await transport.close()
+    assert transport._owned_client is None

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -49,6 +49,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -214,6 +223,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
     { name = "sphinx" },
     { name = "ty" },
@@ -239,6 +249,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">1" },
     { name = "ruff", specifier = "==0.15.14" },
     { name = "sphinx", specifier = "==8.1.3" },
     { name = "ty", specifier = "==0.0.38" },
@@ -711,6 +722,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]

--- a/sdk/tools/sdkgen/internal/emit/python/public_render.go
+++ b/sdk/tools/sdkgen/internal/emit/python/public_render.go
@@ -28,36 +28,87 @@ class UnaryTransport(Protocol):
         request: Message,
         response_type: type[ResponseT],
     ) -> ResponseT: ...
+
+
+class AsyncUnaryTransport(Protocol):
+    async def unary(
+        self,
+        method: Method,
+        request: Message,
+        response_type: type[ResponseT],
+    ) -> ResponseT: ...
 `
+
+// defKeyword returns the method prefix for async ("async def") or sync ("def").
+func defKeyword(isAsync bool) string {
+	if isAsync {
+		return "async def"
+	}
+	return "def"
+}
+
+// awaitPrefix returns "await " for async transport calls or "" for sync.
+func awaitPrefix(isAsync bool) string {
+	if isAsync {
+		return "await "
+	}
+	return ""
+}
+
+// asyncClientName returns the async sibling class name ("Async" + base) or the
+// sync class name unchanged.
+func asyncClientName(base string, isAsync bool) string {
+	if isAsync {
+		return "Async" + base
+	}
+	return base
+}
 
 func (r *renderer) assembleGenerated() string {
 	return r.assemble()
 }
 
 func (r *renderer) renderAppClient(svc *model.Service) {
+	// Render the sync client (UnaryTransport) then the async client
+	// (AsyncUnaryTransport) as sibling classes in the same file. The two
+	// share method bodies; only the def keyword and await prefix differ.
+	r.renderAppClientFlavor(svc, false)
+	r.renderAppClientFlavor(svc, true)
+}
+
+func (r *renderer) renderAppClientFlavor(svc *model.Service, isAsync bool) {
 	r.features.unaryTransport = true
 	r.features.wire = true
-	fmt.Fprintf(&r.body, "class %sClient:\n", localName(svc.FullName))
+	r.features.asyncTransport = r.features.asyncTransport || isAsync
+	clientName := asyncClientName(localName(svc.FullName)+"Client", isAsync)
+	fmt.Fprintf(&r.body, "class %s:\n", clientName)
 	doc := fmt.Sprintf("Transport-neutral client for the public %s surface.", svc.FullName)
+	if isAsync {
+		doc = fmt.Sprintf("Async client for the public %s surface; methods are coroutines.", svc.FullName)
+	}
 	if svc.Doc != "" {
 		doc = svc.Doc + "\n\n" + doc
 	}
 	r.writeDocstring("    ", doc)
 	r.body.WriteString("\n")
-	r.body.WriteString("    def __init__(self, transport: UnaryTransport) -> None:\n")
+	transportType := "UnaryTransport"
+	if isAsync {
+		transportType = "AsyncUnaryTransport"
+	}
+	fmt.Fprintf(&r.body, "    def __init__(self, transport: %s) -> None:\n", transportType)
 	r.body.WriteString("        self._transport = transport\n\n")
 
 	for _, m := range svc.Methods {
 		if m.Stream != model.Unary {
 			continue
 		}
-		r.renderAppClientMethod(svc, m)
+		r.renderAppClientMethod(svc, m, isAsync)
 	}
-	r.renderAppRESTClientProtocol(svc)
+	r.renderAppRESTClientProtocol(svc, isAsync)
 }
 
-func (r *renderer) renderAppRESTClientProtocol(svc *model.Service) {
-	clientName := localName(svc.FullName) + "Client"
+func (r *renderer) renderAppRESTClientProtocol(svc *model.Service, isAsync bool) {
+	clientName := asyncClientName(localName(svc.FullName)+"Client", isAsync)
 	protocolName := clientName + "REST"
 	var restMethods []*model.Method
 	for _, m := range svc.Methods {
@@ -72,43 +123,45 @@ func (r *renderer) renderAppRESTClientProtocol(svc *model.Service) {
 	fmt.Fprintf(&r.body, "class %s(Protocol):\n", protocolName)
 	r.writeDocstring("    ", fmt.Sprintf("REST-backed methods for the public %s surface.", svc.FullName))
 	for _, m := range restMethods {
-		r.renderAppRESTProtocolMethod(m)
+		r.renderAppRESTProtocolMethod(m, isAsync)
 	}
 	r.body.WriteString("\n")
 }
 
-func (r *renderer) renderAppClientMethod(svc *model.Service, m *model.Method) {
+func (r *renderer) renderAppClientMethod(svc *model.Service, m *model.Method, isAsync bool) {
 	constName := appClientMethodConst(svc, m)
 	methodName := pyName(snakeCase(m.Name))
 
 	if m.JsonResult != nil {
-		r.renderAppClientRawMethod(m, constName, methodName+"_raw")
-		r.renderAppClientInvokeMethod(m, methodName)
+		r.renderAppClientRawMethod(m, constName, methodName+"_raw", isAsync)
+		r.renderAppClientInvokeMethod(m, methodName, isAsync)
 		return
 	}
 
 	if m.Name == "InvokeGraphQL" {
-		r.renderAppClientRawMethod(m, constName, methodName)
-		r.renderAppClientGraphQLRawAlias(m, methodName)
-		r.renderAppClientGraphQLDecodedMethod(m, methodName+"_decoded")
+		r.renderAppClientRawMethod(m, constName, methodName, isAsync)
+		r.renderAppClientGraphQLRawAlias(m, methodName, isAsync)
+		r.renderAppClientGraphQLDecodedMethod(m, methodName+"_decoded", isAsync)
 		return
 	}
 
-	r.renderAppClientRawMethod(m, constName, methodName)
+	r.renderAppClientRawMethod(m, constName, methodName, isAsync)
 }
 
-func (r *renderer) renderAppClientRawMethod(m *model.Method, constName, methodName string) {
+func (r *renderer) renderAppClientRawMethod(m *model.Method, constName, methodName string, isAsync bool) {
 	r.useMetadataMethod(constName)
 	r.features.wire = true
 	if m.InputIsEmpty || m.OutputIsEmpty {
 		r.features.emptyPb = true
 	}
+	kw := defKeyword(isAsync)
+	await := awaitPrefix(isAsync)
 
 	if m.InputIsEmpty && m.OutputIsEmpty {
-		fmt.Fprintf(&r.body, "    def %s(self) -> None:\n", methodName)
+		fmt.Fprintf(&r.body, "    %s %s(self) -> None:\n", kw, methodName)
 		r.writeMethodDoc(m)
 		r.body.WriteString("        wire = _empty.Empty()\n")
-		r.body.WriteString("        self._transport.unary(\n")
+		r.body.WriteString("        " + await + "self._transport.unary(\n")
 		fmt.Fprintf(&r.body, "            %s,\n", constName)
 		r.body.WriteString("            wire,\n")
 		r.body.WriteString("            _empty.Empty,\n")
@@ -119,10 +172,10 @@ func (r *renderer) renderAppClientRawMethod(m *model.Method, constName, methodNa
 		outputType := r.messageType(m.Output.FullName)
 		wireOutputType := r.wireModule() + "." + localName(m.Output.FullName)
 		fromWire := r.codecRef(m.Output.ProtoFile, fromWireFunc(m.Output.FullName))
-		fmt.Fprintf(&r.body, "    def %s(self) -> %s:\n", methodName, outputType)
+		fmt.Fprintf(&r.body, "    %s %s(self) -> %s:\n", kw, methodName, outputType)
 		r.writeMethodDoc(m)
 		r.body.WriteString("        wire = _empty.Empty()\n")
-		r.body.WriteString("        wire_response = self._transport.unary(\n")
+		r.body.WriteString("        wire_response = " + await + "self._transport.unary(\n")
 		fmt.Fprintf(&r.body, "            %s,\n", constName)
 		r.body.WriteString("            wire,\n")
 		fmt.Fprintf(&r.body, "            %s,\n", wireOutputType)
@@ -133,10 +186,10 @@ func (r *renderer) renderAppClientRawMethod(m *model.Method, constName, methodNa
 	if m.OutputIsEmpty {
 		requestType := r.messageType(m.Input.FullName)
 		toWire := r.codecRef(m.Input.ProtoFile, toWireFunc(m.Input.FullName))
-		fmt.Fprintf(&r.body, "    def %s(self, request: %s) -> None:\n", methodName, requestType)
+		fmt.Fprintf(&r.body, "    %s %s(self, request: %s) -> None:\n", kw, methodName, requestType)
 		r.writeMethodDoc(m)
 		fmt.Fprintf(&r.body, "        wire = %s(request)\n", toWire)
-		r.body.WriteString("        self._transport.unary(\n")
+		r.body.WriteString("        " + await + "self._transport.unary(\n")
 		fmt.Fprintf(&r.body, "            %s,\n", constName)
 		r.body.WriteString("            wire,\n")
 		r.body.WriteString("            _empty.Empty,\n")
@@ -152,10 +205,10 @@ func (r *renderer) renderAppClientRawMethod(m *model.Method, constName, methodNa
 	toWire := r.codecRef(m.Input.ProtoFile, toWireFunc(m.Input.FullName))
 	fromWire := r.codecRef(m.Output.ProtoFile, fromWireFunc(m.Output.FullName))
 
-	fmt.Fprintf(&r.body, "    def %s(self, request: %s) -> %s:\n", methodName, requestType, outputType)
+	fmt.Fprintf(&r.body, "    %s %s(self, request: %s) -> %s:\n", kw, methodName, requestType, outputType)
 	r.writeMethodDoc(m)
 	fmt.Fprintf(&r.body, "        wire = %s(request)\n", toWire)
-	fmt.Fprintf(&r.body, "        wire_response = self._transport.unary(\n")
+	fmt.Fprintf(&r.body, "        wire_response = %sself._transport.unary(\n", await)
 	fmt.Fprintf(&r.body, "            %s,\n", constName)
 	fmt.Fprintf(&r.body, "            wire,\n")
 	fmt.Fprintf(&r.body, "            %s,\n", wireOutputType)
@@ -163,15 +216,17 @@ func (r *renderer) renderAppClientRawMethod(m *model.Method, constName, methodNa
 	fmt.Fprintf(&r.body, "        return %s(wire_response)\n\n", fromWire)
 }
 
-func (r *renderer) renderAppClientInvokeMethod(m *model.Method, methodName string) {
+func (r *renderer) renderAppClientInvokeMethod(m *model.Method, methodName string, isAsync bool) {
 	if m.Input == nil || m.Output == nil || m.JsonResult == nil {
 		return
 	}
 	requestType := r.messageType(m.Input.FullName)
 	r.features.anyType = true
 	r.useInvoke("decode_app_result")
+	kw := defKeyword(isAsync)
+	await := awaitPrefix(isAsync)
 
-	fmt.Fprintf(&r.body, "    def %s(self, request: %s) -> Any:\n", methodName, requestType)
+	fmt.Fprintf(&r.body, "    %s %s(self, request: %s) -> Any:\n", kw, methodName, requestType)
 	doc := m.Doc
 	if doc == "" {
 		doc = "The result decodes with the standard JSON operation envelope semantics; envelope failures raise InvokeError."
@@ -179,7 +234,7 @@ func (r *renderer) renderAppClientInvokeMethod(m *model.Method, methodName strin
 		doc += "\n\nThe result decodes with the standard JSON operation envelope semantics; envelope failures raise InvokeError."
 	}
 	r.writeDocstring("        ", doc)
-	fmt.Fprintf(&r.body, "        response = self.%s_raw(request)\n", methodName)
+	fmt.Fprintf(&r.body, "        response = %sself.%s_raw(request)\n", await, methodName)
 	status := findField(m.Output, m.JsonResult.Status)
 	body := findField(m.Output, m.JsonResult.Body)
 	fmt.Fprintf(
@@ -192,26 +247,28 @@ func (r *renderer) renderAppClientInvokeMethod(m *model.Method, methodName strin
 	)
 }
 
-func (r *renderer) renderAppClientGraphQLRawAlias(m *model.Method, methodName string) {
+func (r *renderer) renderAppClientGraphQLRawAlias(m *model.Method, methodName string, isAsync bool) {
 	if m.Input == nil || m.Output == nil {
 		return
 	}
 	requestType := r.messageType(m.Input.FullName)
 	outputType := r.messageType(m.Output.FullName)
-	fmt.Fprintf(&r.body, "    def %s_raw(self, request: %s) -> %s:\n", methodName, requestType, outputType)
+	fmt.Fprintf(&r.body, "    %s %s_raw(self, request: %s) -> %s:\n", defKeyword(isAsync), methodName, requestType, outputType)
 	r.body.WriteString("        \"\"\"Alias for invoke_graphql.\"\"\"\n")
-	fmt.Fprintf(&r.body, "        return self.%s(request)\n\n", methodName)
+	fmt.Fprintf(&r.body, "        return "+awaitPrefix(isAsync)+"self.%s(request)\n\n", methodName)
 }
 
-func (r *renderer) renderAppClientGraphQLDecodedMethod(m *model.Method, methodName string) {
+func (r *renderer) renderAppClientGraphQLDecodedMethod(m *model.Method, methodName string, isAsync bool) {
 	if m.Input == nil || m.Output == nil {
 		return
 	}
 	requestType := r.messageType(m.Input.FullName)
 	r.features.anyType = true
 	r.useInvoke("decode_graphql_result")
+	kw := defKeyword(isAsync)
+	await := awaitPrefix(isAsync)
 
-	fmt.Fprintf(&r.body, "    def %s(self, request: %s) -> Any:\n", methodName, requestType)
+	fmt.Fprintf(&r.body, "    %s %s(self, request: %s) -> Any:\n", kw, methodName, requestType)
 	doc := m.Doc
 	if doc == "" {
 		doc = "The result decodes with GraphQL envelope semantics; envelope failures raise InvokeError."
@@ -219,7 +276,7 @@ func (r *renderer) renderAppClientGraphQLDecodedMethod(m *model.Method, methodNa
 		doc += "\n\nThe result decodes with GraphQL envelope semantics; envelope failures raise InvokeError."
 	}
 	r.writeDocstring("        ", doc)
-	fmt.Fprintf(&r.body, "        response = self.invoke_graphql(request)\n")
+	fmt.Fprintf(&r.body, "        response = %sself.invoke_graphql(request)\n", await)
 	status := findField(m.Output, "status")
 	body := findField(m.Output, "body")
 	fmt.Fprintf(
@@ -231,50 +288,51 @@ func (r *renderer) renderAppClientGraphQLDecodedMethod(m *model.Method, methodNa
 	)
 }
 
-func (r *renderer) renderAppRESTProtocolMethod(m *model.Method) {
+func (r *renderer) renderAppRESTProtocolMethod(m *model.Method, isAsync bool) {
 	if m.JsonResult != nil {
-		r.renderAppRESTProtocolSignature(m, pyName(snakeCase(m.Name))+"_raw", false)
-		r.renderAppRESTProtocolSignature(m, pyName(snakeCase(m.Name)), true)
+		r.renderAppRESTProtocolSignature(m, pyName(snakeCase(m.Name))+"_raw", false, isAsync)
+		r.renderAppRESTProtocolSignature(m, pyName(snakeCase(m.Name)), true, isAsync)
 		return
 	}
 	if m.Name == "InvokeGraphQL" {
-		r.renderAppRESTProtocolSignature(m, pyName(snakeCase(m.Name)), false)
-		r.renderAppRESTProtocolSignature(m, pyName(snakeCase(m.Name))+"_raw", false)
-		r.renderAppRESTProtocolSignature(m, pyName(snakeCase(m.Name))+"_decoded", true)
+		r.renderAppRESTProtocolSignature(m, pyName(snakeCase(m.Name)), false, isAsync)
+		r.renderAppRESTProtocolSignature(m, pyName(snakeCase(m.Name))+"_raw", false, isAsync)
+		r.renderAppRESTProtocolSignature(m, pyName(snakeCase(m.Name))+"_decoded", true, isAsync)
 		return
 	}
-	r.renderAppRESTProtocolSignature(m, pyName(snakeCase(m.Name)), false)
+	r.renderAppRESTProtocolSignature(m, pyName(snakeCase(m.Name)), false, isAsync)
 }
 
-func (r *renderer) renderAppRESTProtocolSignature(m *model.Method, methodName string, decoded bool) {
+func (r *renderer) renderAppRESTProtocolSignature(m *model.Method, methodName string, decoded bool, isAsync bool) {
+	kw := defKeyword(isAsync)
 	if m.InputIsEmpty && m.OutputIsEmpty {
-		fmt.Fprintf(&r.body, "    def %s(self) -> None: ...\n", methodName)
+		fmt.Fprintf(&r.body, "    %s %s(self) -> None: ...\n", kw, methodName)
 		return
 	}
 	if decoded {
 		requestType := r.messageType(m.Input.FullName)
 		r.features.anyType = true
-		fmt.Fprintf(&r.body, "    def %s(self, request: %s) -> Any: ...\n", methodName, requestType)
+		fmt.Fprintf(&r.body, "    %s %s(self, request: %s) -> Any: ...\n", kw, methodName, requestType)
 		return
 	}
 	if m.InputIsEmpty {
 		outputType := r.messageType(m.Output.FullName)
-		fmt.Fprintf(&r.body, "    def %s(self) -> %s: ...\n", methodName, outputType)
+		fmt.Fprintf(&r.body, "    %s %s(self) -> %s: ...\n", kw, methodName, outputType)
 		return
 	}
 	if m.OutputIsEmpty {
 		requestType := r.messageType(m.Input.FullName)
-		fmt.Fprintf(&r.body, "    def %s(self, request: %s) -> None: ...\n", methodName, requestType)
+		fmt.Fprintf(&r.body, "    %s %s(self, request: %s) -> None: ...\n", kw, methodName, requestType)
 		return
 	}
 	requestType := r.messageType(m.Input.FullName)
 	if m.JsonResult != nil && methodName == pyName(snakeCase(m.Name)) {
 		r.features.anyType = true
-		fmt.Fprintf(&r.body, "    def %s(self, request: %s) -> Any: ...\n", methodName, requestType)
+		fmt.Fprintf(&r.body, "    %s %s(self, request: %s) -> Any: ...\n", kw, methodName, requestType)
 		return
 	}
 	outputType := r.messageType(m.Output.FullName)
-	fmt.Fprintf(&r.body, "    def %s(self, request: %s) -> %s: ...\n", methodName, requestType, outputType)
+	fmt.Fprintf(&r.body, "    %s %s(self, request: %s) -> %s: ...\n", kw, methodName, requestType, outputType)
 }
 
 func appClientMethodConst(svc *model.Service, m *model.Method) string {

--- a/sdk/tools/sdkgen/internal/emit/python/public_render_async_test.go
+++ b/sdk/tools/sdkgen/internal/emit/python/public_render_async_test.go
@@ -1,0 +1,212 @@
+package python
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/sdk/tools/sdkgen/internal/model"
+)
+
+// asyncTestIndex builds an index populated with the request and response
+// messages referenced by the test services below.
+func asyncTestIndex(msgs ...*model.Message) *index {
+	idx := &index{
+		messages: map[string]*model.Message{},
+		enums:    map[string]*model.Enum{},
+		taken:    map[string]bool{},
+	}
+	for _, m := range msgs {
+		idx.messages[m.FullName] = m
+	}
+	return idx
+}
+
+func TestAsyncUnaryTransportProtocolEmitted(t *testing.T) {
+	t.Parallel()
+
+	if !strings.Contains(unaryTransportFile, "class AsyncUnaryTransport(Protocol)") {
+		t.Fatal("unaryTransportFile missing AsyncUnaryTransport protocol")
+	}
+	if !strings.Contains(unaryTransportFile, "async def unary") {
+		t.Fatal("unaryTransportFile missing async unary method")
+	}
+}
+
+func TestAsyncClientGeneratedForREST(t *testing.T) {
+	t.Parallel()
+
+	req := &model.Message{
+		FullName:  "gestalt.provider.v1.CheckAccessRequest",
+		Name:      "CheckAccessRequest",
+		ProtoFile: "sdk/proto/v1/authorization.proto",
+	}
+	resp := &model.Message{
+		FullName:  "gestalt.provider.v1.CheckAccessResponse",
+		Name:      "CheckAccessResponse",
+		ProtoFile: "sdk/proto/v1/authorization.proto",
+	}
+	svc := &model.Service{
+		FullName: "gestalt.provider.v1.Authorization",
+		Name:     "Authorization",
+		Methods: []*model.Method{
+			{
+				Name: "CheckAccess",
+				HTTP: &model.HTTPRule{Verb: "POST", Path: "/api/v2/authorization/access:check"},
+				Input:  req,
+				Output: resp,
+			},
+		},
+	}
+
+	r := newRenderer(asyncTestIndex(req, resp), "authorization_client", "authorization", modulePublic)
+	r.publicClient = true
+	r.renderAppClient(svc)
+	out := r.assembleGenerated()
+
+	// Sync class and method exist (unchanged).
+	if !strings.Contains(out, "class AuthorizationClient:") {
+		t.Fatal("missing sync AuthorizationClient class")
+	}
+	if !strings.Contains(out, "def check_access(self, request: CheckAccessRequest)") {
+		t.Fatal("missing sync check_access method")
+	}
+	// Async class and method exist.
+	if !strings.Contains(out, "class AsyncAuthorizationClient:") {
+		t.Fatal("missing AsyncAuthorizationClient class")
+	}
+	if !strings.Contains(out, "async def check_access(self, request: CheckAccessRequest)") {
+		t.Fatal("missing async check_access method")
+	}
+	// Async transport import present.
+	if !strings.Contains(out, "from .unary_transport import AsyncUnaryTransport") {
+		t.Fatal("missing AsyncUnaryTransport import")
+	}
+	// Async method body must await the transport.
+	if !strings.Contains(out, "await self._transport.unary(") {
+		t.Fatal("async method body missing await on transport.unary")
+	}
+}
+
+func TestAsyncClientGeneratedForGRPCOnly(t *testing.T) {
+	t.Parallel()
+
+	req := &model.Message{
+		FullName:  "gestalt.provider.v1.CreateCredentialRequest",
+		Name:      "CreateCredentialRequest",
+		ProtoFile: "sdk/proto/v1/external_credential.proto",
+	}
+	resp := &model.Message{
+		FullName:  "gestalt.provider.v1.Credential",
+		Name:      "Credential",
+		ProtoFile: "sdk/proto/v1/external_credential.proto",
+	}
+	svc := &model.Service{
+		FullName: "gestalt.provider.v1.ExternalCredentials",
+		Name:     "ExternalCredentials",
+		Methods: []*model.Method{
+			{
+				Name:   "CreateCredential",
+				Input:  req,
+				Output: resp,
+				// No HTTP rule -> gRPC-only.
+			},
+		},
+	}
+
+	r := newRenderer(asyncTestIndex(req, resp), "external_credentials_client", "external_credentials", modulePublic)
+	r.publicClient = true
+	r.renderAppClient(svc)
+	out := r.assembleGenerated()
+
+	// Async gRPC-only methods DO get an async variant (unlike Rust's sync PR,
+	// where gRPC-only methods got no _sync sibling — here async gRPC is in scope).
+	if !strings.Contains(out, "class AsyncExternalCredentialsClient:") {
+		t.Fatal("missing AsyncExternalCredentialsClient class")
+	}
+	if !strings.Contains(out, "async def create_credential(") {
+		t.Fatal("missing async create_credential method")
+	}
+}
+
+func TestSyncClientUnchangedByAsyncAddition(t *testing.T) {
+	t.Parallel()
+
+	req := &model.Message{
+		FullName:  "gestalt.provider.v1.CheckAccessRequest",
+		Name:      "CheckAccessRequest",
+		ProtoFile: "sdk/proto/v1/authorization.proto",
+	}
+	resp := &model.Message{
+		FullName:  "gestalt.provider.v1.CheckAccessResponse",
+		Name:      "CheckAccessResponse",
+		ProtoFile: "sdk/proto/v1/authorization.proto",
+	}
+	svc := &model.Service{
+		FullName: "gestalt.provider.v1.Authorization",
+		Name:     "Authorization",
+		Methods: []*model.Method{
+			{
+				Name: "CheckAccess",
+				HTTP: &model.HTTPRule{Verb: "POST", Path: "/api/v2/authorization/access:check"},
+				Input:  req,
+				Output: resp,
+			},
+		},
+	}
+
+	r := newRenderer(asyncTestIndex(req, resp), "authorization_client", "authorization", modulePublic)
+	r.publicClient = true
+	r.renderAppClient(svc)
+	out := r.assembleGenerated()
+
+	// Sync method body must NOT contain await.
+	idx := strings.Index(out, "def check_access(self, request:")
+	end := strings.Index(out[idx:], "\n\n")
+	syncMethod := out[idx : idx+end]
+	if strings.Contains(syncMethod, "await") {
+		t.Fatal("sync check_access method body must not contain await")
+	}
+	// Sync class constructor uses UnaryTransport, not AsyncUnaryTransport.
+	if !strings.Contains(out, "def __init__(self, transport: UnaryTransport) -> None:") {
+		t.Fatal("sync client constructor must use UnaryTransport")
+	}
+}
+
+func TestAsyncRESTProtocolEmitted(t *testing.T) {
+	t.Parallel()
+
+	req := &model.Message{
+		FullName:  "gestalt.provider.v1.CheckAccessRequest",
+		Name:      "CheckAccessRequest",
+		ProtoFile: "sdk/proto/v1/authorization.proto",
+	}
+	resp := &model.Message{
+		FullName:  "gestalt.provider.v1.CheckAccessResponse",
+		Name:      "CheckAccessResponse",
+		ProtoFile: "sdk/proto/v1/authorization.proto",
+	}
+	svc := &model.Service{
+		FullName: "gestalt.provider.v1.Authorization",
+		Name:     "Authorization",
+		Methods: []*model.Method{
+			{
+				Name: "CheckAccess",
+				HTTP: &model.HTTPRule{Verb: "POST", Path: "/api/v2/authorization/access:check"},
+				Input:  req,
+				Output: resp,
+			},
+		},
+	}
+
+	r := newRenderer(asyncTestIndex(req, resp), "authorization_client", "authorization", modulePublic)
+	r.publicClient = true
+	r.renderAppClient(svc)
+	out := r.assembleGenerated()
+
+	if !strings.Contains(out, "class AsyncAuthorizationClientREST(Protocol):") {
+		t.Fatal("missing AsyncAuthorizationClientREST protocol")
+	}
+	if !strings.Contains(out, "async def check_access(self, request: CheckAccessRequest) -> CheckAccessResponse: ...") {
+		t.Fatal("missing async REST protocol method signature")
+	}
+}

--- a/sdk/tools/sdkgen/internal/emit/python/render.go
+++ b/sdk/tools/sdkgen/internal/emit/python/render.go
@@ -51,6 +51,7 @@ type features struct {
 	crossCodec  map[string]bool            // codec: sibling codec module bases referenced
 	metadataMethods map[string]bool        // public client: METHOD_* constants from metadata
 	unaryTransport  bool                   // public client: UnaryTransport from unary_transport
+	asyncTransport  bool                   // public client: AsyncUnaryTransport from unary_transport
 	jsonFormat      bool                   // public client: google.protobuf.json_format
 	protocol        bool                   // public client: typing.Protocol for REST projections
 }
@@ -1225,6 +1226,9 @@ func (r *renderer) localImports() string {
 	}
 	if r.features.unaryTransport {
 		b.WriteString("from .unary_transport import UnaryTransport\n")
+	}
+	if r.features.asyncTransport {
+		b.WriteString("from .unary_transport import AsyncUnaryTransport\n")
 	}
 	if r.features.jsonFormat {
 		b.WriteString("from google.protobuf import json_format\n")

--- a/sdk/tools/sdkgen/internal/emit/python/render.go
+++ b/sdk/tools/sdkgen/internal/emit/python/render.go
@@ -1224,11 +1224,15 @@ func (r *renderer) localImports() string {
 	if len(r.features.metadataMethods) > 0 {
 		locals = append(locals, localImport{module: ".metadata", lines: fromImport(".metadata", sortedKeys(r.features.metadataMethods))})
 	}
-	if r.features.unaryTransport {
-		b.WriteString("from .unary_transport import UnaryTransport\n")
-	}
-	if r.features.asyncTransport {
-		b.WriteString("from .unary_transport import AsyncUnaryTransport\n")
+	if r.features.unaryTransport || r.features.asyncTransport {
+		var names []string
+		if r.features.asyncTransport {
+			names = append(names, "AsyncUnaryTransport")
+		}
+		if r.features.unaryTransport {
+			names = append(names, "UnaryTransport")
+		}
+		locals = append(locals, localImport{module: ".unary_transport", lines: fromImport(".unary_transport", names)})
 	}
 	if r.features.jsonFormat {
 		b.WriteString("from google.protobuf import json_format\n")


### PR DESCRIPTION
## Summary

Adds an async surface to the Python SDK, mirroring what #2841 did for Rust. Generated clients get `Async*` siblings (`AsyncAuthorizationClient`, `AsyncAppClient`, etc.) over a new `AsyncUnaryTransport` protocol, backed by `AsyncRestUnaryTransport` (`httpx.AsyncClient`) and `AsyncGrpcUnaryTransport` (`grpc.aio`). Pure request/response helpers are extracted so sync and async REST transports share one implementation. The sync surface is unchanged.

Scope: separate `Async*` client classes (not `_async` suffix on one class), both async REST and async gRPC, transport + client classes only (no top-level `create_async_gestalt_client` factory — that's a follow-up).

## High-level interfaces across all language SDKs

The sync/async split is added only where a language has two real, mutually-incompatible I/O runtimes. Rust and Python qualify; Go and TypeScript do not.

### Python (this PR) — sync stays, async added

```python
# sdk/python/gestalt/public/generated/unary_transport.py
class UnaryTransport(Protocol):
    def unary(self, method: Method, request: Message, response_type: type[ResponseT]) -> ResponseT: ...

class AsyncUnaryTransport(Protocol):
    async def unary(self, method: Method, request: Message, response_type: type[ResponseT]) -> ResponseT: ...

# sdk/python/gestalt/public/generated/authorization_client.py
class AuthorizationClient:
    def __init__(self, transport: UnaryTransport) -> None: ...
    def check_access(self, request: CheckAccessRequest) -> CheckAccessResponse: ...

class AsyncAuthorizationClient:
    def __init__(self, transport: AsyncUnaryTransport) -> None: ...
    async def check_access(self, request: CheckAccessRequest) -> CheckAccessResponse: ...

# sdk/python/gestalt/public/rest_transport.py
class RestUnaryTransport:
    def __init__(self, base_url: str, auth: AuthProvider, *, client: HttpClient | None = None) -> None: ...
    def unary(self, method: Method, request: Message, response_type: type[ResponseT]) -> ResponseT: ...

class AsyncRestUnaryTransport:
    def __init__(self, base_url: str, auth: AuthProvider, *, client: AsyncHttpClient | None = None) -> None: ...
    async def unary(self, method: Method, request: Message, response_type: type[ResponseT]) -> ResponseT: ...

# sdk/python/gestalt/public/grpc_transport.py
class GrpcUnaryTransport:
    def __init__(self, channel: grpc.Channel, auth: AuthProvider) -> None: ...
    def unary(self, method: Method, request: Message, response_type: type[ResponseT]) -> ResponseT: ...

class AsyncGrpcUnaryTransport:
    def __init__(self, channel: grpc.aio.Channel, auth: AuthProvider) -> None: ...
    async def unary(self, method: Method, request: Message, response_type: type[ResponseT]) -> ResponseT: ...
```

### Rust (merged in #2841) — async stays, sync added

```rust
pub trait UnaryTransport: Send + Sync {
    fn unary<Req, Resp>(&self, method: &Method, request: &Req, response: &mut Resp)
        -> impl Future<Output = Result<(), GestaltError>> + Send
    where Req: Message + Send + Sync, Resp: Message + Default + Send;
}

pub trait SyncUnaryTransport: Send + Sync {
    fn unary<Req, Resp>(&self, method: &Method, request: &Req, response: &mut Resp)
        -> Result<(), GestaltError>
    where Req: Message + Clone + Send + Sync + 'static, Resp: Message + Default + Send + 'static;
}

// One struct, two impl blocks constrained on different traits.
impl<T: UnaryTransport> AuthorizationClient<T> {
    pub async fn check_access(&self, request: CheckAccessRequest) -> Result<CheckAccessResponse, GestaltError> { ... }
}
impl<T: SyncUnaryTransport> AuthorizationClient<T> {
    pub fn check_access_sync(&self, request: CheckAccessRequest) -> Result<CheckAccessResponse, GestaltError> { ... }
}
```

### Go — synchronous only, goroutines are the concurrency model (no change)

```go
type UnaryTransport interface {
    Unary(ctx context.Context, method Method, request, response gproto.Message) error
}

type AuthorizationClient struct { transport UnaryTransport }
func (c *AuthorizationClient) CheckAccess(ctx context.Context, request *CheckAccessRequest) (*CheckAccessResponse, error)
// No async sibling: concurrency = `go client.CheckAccess(ctx, req)`, cancellation = ctx.
```

### TypeScript — async only, the JS runtime has no blocking I/O (no change)

```typescript
export interface UnaryTransport {
  unary<Output extends Message>(method: PublicMethod, request: Message, requestSchema: DescMessage, responseSchema: DescMessage, callOptions?: PublicUnaryCallOptions): Promise<Output>;
}

export class AuthorizationClient {
  constructor(private readonly transport: UnaryTransport) {}
  async checkAccess(request: CheckAccessRequest, callOptions?: PublicUnaryCallOptions): Promise<CheckAccessResponse>
}
// No sync sibling: the runtime is single-threaded event-loop; sync network I/O is infeasible.
```

## Key changes

### Generator (`sdk/tools/sdkgen/internal/emit/python/`)

- `public_render.go`: threads an `isAsync bool` through all render functions via three helpers (`defKeyword`, `awaitPrefix`, `asyncClientName`). `renderAppClient` now renders both the sync class and an `Async*` sibling class in one pass. Every method gets an `async def` variant with `await self._transport.unary(...)`. gRPC-only methods get async variants too (unlike Rust's sync PR, where gRPC-only methods got no `_sync` sibling — here async gRPC is in scope).
- `render.go`: adds `asyncTransport` feature flag and wires the `AsyncUnaryTransport` import.
- `public_render_async_test.go` (new): 5 generator unit tests — async protocol emitted, async REST client generated, async gRPC-only client generated, sync client unchanged (no `await` in sync bodies), async REST protocol emitted.

### Transport (`sdk/python/gestalt/public/`)

- `rest_request.py` (new): shared pure helpers `build_rest_request` and `decode_rest_response` extracted so sync and async transports differ only in I/O. Mirrors Rust's `rest_request.rs`.
- `rest_transport.py`: `RestUnaryTransport` refactored to use shared helpers (behavior unchanged); `AsyncRestUnaryTransport` added over `httpx.AsyncClient` with `async def unary`. `AsyncHttpClient` protocol mirrors `HttpClient`.
- `grpc_transport.py`: `AsyncGrpcUnaryTransport` added over `grpc.aio.Channel` with `async def unary`. `async_grpc_channel_from_address` helper for `grpc.aio.insecure_channel`/`secure_channel`. `AioRpcError` (not a `grpc.Call` subclass) is mapped to `GestaltError` directly in the async transport.

### Dev dependencies (`sdk/python/pyproject.toml`)

- Added `pytest-asyncio>1` to dev deps (the `>1` bound is required for compatibility with the repo's `pytest>=9.0.3` pin; older `pytest-asyncio<1` requires `pytest<9`).
- `[tool.pytest.ini_options]` with `asyncio_mode = "auto"`.

### Tests

- `test_public_async_rest_transport.py` (new): 4 async tests — request mapping + gateway errors, bearer rotation, unauthenticated auth, generated `AsyncAuthorizationClient` end-to-end.
- `test_public_async_grpc_transport.py` (new): 3 async tests — bearer metadata, RPC error mapping, generated `AsyncAppClient` end-to-end against a `grpc.aio.Server`.

## Test plan

- Generator unit tests: 5 new tests in `public_render_async_test.go` — all pass.
- Python integration tests: 7 new async tests + 216 existing tests — all pass.
- `sdkgen --check`: no drift.
- `ruff check` + `ruff format`: clean.
- Go `sdkgen` tests: all pass.

## Assumptions

- Separate `Async*` client classes mirror `httpx.Client`/`AsyncClient` and `grpc`/`grpc.aio`.
- Async gRPC is in scope for this PR (diverging from Rust's REST-only sync scope); `grpc.aio` ships with the already-pinned `grpcio>=1.80.0,<2`.
- No top-level `create_async_gestalt_client` factory in this PR; callers construct transports/clients directly. A unified async factory is a follow-up.
- Shared REST helpers extracted to `rest_request.py` before adding the async transport, exactly as Rust's PR extracted `rest_request.rs`.
