### PR TITLE
Delete unused ProviderServerOption surface on authorization gRPC server

### DIFF
--- a/gestaltd/services/authorization/server.go
+++ b/gestaltd/services/authorization/server.go
@@ -16,16 +16,8 @@ type providerServer struct {
 	provider core.AuthorizationProvider
 }
 
-type ProviderServerOption func(*providerServer)
-
-func NewProviderServer(provider core.AuthorizationProvider, opts ...ProviderServerOption) proto.AuthorizationServer {
-	s := &providerServer{provider: provider}
-	for _, opt := range opts {
-		if opt != nil {
-			opt(s)
-		}
-	}
-	return s
+func NewProviderServer(provider core.AuthorizationProvider) proto.AuthorizationServer {
+	return &providerServer{provider: provider}
 }
 
 func (s *providerServer) CheckAccess(ctx context.Context, req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {


### PR DESCRIPTION
## What

Deletes the unused `ProviderServerOption` surface on `services/authorization/server.go`.

`NewProviderServer` accepted an `opts ...ProviderServerOption` variadic that no caller ever passed and no `With*` option ever populated. Both call sites (`internal/server/public_grpc.go`, `internal/bootstrap/host_service_bootstrap.go`) pass a single argument. The dead type and variadic are removed; `NewProviderServer` collapses to a direct constructor.

```diff
-type ProviderServerOption func(*providerServer)
-
-func NewProviderServer(provider core.AuthorizationProvider, opts ...ProviderServerOption) proto.AuthorizationServer {
-	s := &providerServer{provider: provider}
-	for _, opt := range opts {
-		if opt != nil {
-			opt(s)
-		}
-	}
-	return s
+func NewProviderServer(provider core.AuthorizationProvider) proto.AuthorizationServer {
+	return &providerServer{provider: provider}
 }
```

No behavior change. `EntryGRPC` stamping and the `requireProvider` guards are untouched. `services/authorization/server_test.go` still pins the `EntryGRPC` behavior.

Net: 2 insertions, 10 deletions.
