### PR TITLE
bootstrap: wire workflow host service to the Raw authorization provider (ProviderGateway rollout Step 1)

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -160,21 +160,28 @@ func (m providerMetadata) descriptionOr(v string) string {
 type Deps struct {
 	// EncryptionKey is the derived 32-byte key from server.encryptionKey, not the
 	// raw config value.
-	EncryptionKey           []byte
-	BaseURL                 string
-	RuntimeRelayBaseURL     string
-	SecretManager           core.SecretManager
-	Services                *coredata.Services
-	SelectedIndexedDBName   string
-	IndexedDBs              map[string]indexeddb.IndexedDB
-	IndexedDBDefs           map[string]*config.ProviderEntry
-	IndexedDBFactory        IndexedDBFactory
-	Caches                  map[string]corecache.Cache
-	CacheDefs               map[string]*config.ProviderEntry
-	CacheFactory            CacheFactory
-	S3                      map[string]s3sdk.S3
-	Authentication          core.IdentityProvider
-	Authorization           core.AuthorizationProvider
+	EncryptionKey         []byte
+	BaseURL               string
+	RuntimeRelayBaseURL   string
+	SecretManager         core.SecretManager
+	Services              *coredata.Services
+	SelectedIndexedDBName string
+	IndexedDBs            map[string]indexeddb.IndexedDB
+	IndexedDBDefs         map[string]*config.ProviderEntry
+	IndexedDBFactory      IndexedDBFactory
+	Caches                map[string]corecache.Cache
+	CacheDefs             map[string]*config.ProviderEntry
+	CacheFactory          CacheFactory
+	S3                    map[string]s3sdk.S3
+	Authentication        core.IdentityProvider
+	Authorization         core.AuthorizationProvider
+	// AuthorizationInternal is the direct (Raw) authorization provider used for
+	// gestaltd's own enforcement checks (e.g. the workflow ProviderServer's
+	// requireWorkflowAccess/requireServiceAccountManagement), which must not be
+	// meta-checked by the provider gateway. Authorization above remains the
+	// gateway-guarded (Guarded) client for plugin-facing host services such as
+	// the authorization host service.
+	AuthorizationInternal   core.AuthorizationProvider
 	WorkflowRuntime         *workflowRuntime
 	AgentRuntime            *agentRuntime
 	AgentTurnScopes         *agentturnscope.Store
@@ -1102,6 +1109,17 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	}
 	if authorizationProvider != nil {
 		deps.Authorization = authorizationProvider
+	}
+	// AuthorizationInternal is the direct (Raw) instance for gestaltd's own
+	// enforcement checks; it bypasses the gateway meta-check that Authorization
+	// (Guarded) applies for plugin-facing host services.
+	_, internalAuthorizationProvider, err := selectedAuthorizationProviderInstance(cfg, authorizationProviders.Raw)
+	if err != nil {
+		_ = closeAuthProviders(authProviders)
+		return nil, err
+	}
+	if internalAuthorizationProvider != nil {
+		deps.AuthorizationInternal = internalAuthorizationProvider
 	}
 	closeExternalCredentialsOnError := true
 	defer func() {

--- a/gestaltd/internal/bootstrap/executable_app_test.go
+++ b/gestaltd/internal/bootstrap/executable_app_test.go
@@ -2802,9 +2802,10 @@ func newNestedInvokeHarness(t *testing.T, brokerOpts ...invocation.BrokerOption)
 	}
 
 	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), testRuntimePublicEndpointDeps(t, Deps{
-		EncryptionKey: secret,
-		AppInvocation: bridge,
-		Authorization: newAllowAllAuthorizationProvider(),
+		EncryptionKey:         secret,
+		AppInvocation:         bridge,
+		Authorization:         newAllowAllAuthorizationProvider(),
+		AuthorizationInternal: newAllowAllAuthorizationProvider(),
 	}))
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
@@ -2922,9 +2923,10 @@ func newGraphQLSurfaceInvokeHarness(t *testing.T, graphQLURL string, allowSurfac
 
 	secret := []byte("0123456789abcdef0123456789abcdef")
 	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), testRuntimePublicEndpointDeps(t, Deps{
-		EncryptionKey: secret,
-		AppInvocation: bridge,
-		Authorization: newAllowAllAuthorizationProvider(),
+		EncryptionKey:         secret,
+		AppInvocation:         bridge,
+		Authorization:         newAllowAllAuthorizationProvider(),
+		AuthorizationInternal: newAllowAllAuthorizationProvider(),
 	}))
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
@@ -3896,9 +3898,10 @@ func TestAppWorkflowManagerDefinitionLifecycleUsesRequestContext(t *testing.T) {
 
 	secret := []byte("0123456789abcdef0123456789abcdef")
 	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), testRuntimePublicEndpointDeps(t, Deps{
-		EncryptionKey:   secret,
-		WorkflowManager: manager,
-		Authorization:   newAllowAllAuthorizationProvider(),
+		EncryptionKey:         secret,
+		WorkflowManager:       manager,
+		Authorization:         newAllowAllAuthorizationProvider(),
+		AuthorizationInternal: newAllowAllAuthorizationProvider(),
 	}))
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
@@ -5999,11 +6002,12 @@ func TestRuntimePublicAppInvocationRelayRoundTripsThroughHostedApp(t *testing.T)
 	}
 
 	deps := Deps{
-		BaseURL:            relaySrv.URL,
-		EncryptionKey:      secret,
-		AppInvocation:      bridge,
-		PublicHostServices: publicHostServices,
-		Authorization:      newAllowAllAuthorizationProvider(),
+		BaseURL:               relaySrv.URL,
+		EncryptionKey:         secret,
+		AppInvocation:         bridge,
+		PublicHostServices:    publicHostServices,
+		Authorization:         newAllowAllAuthorizationProvider(),
+		AuthorizationInternal: newAllowAllAuthorizationProvider(),
 	}
 	deps.RuntimeRegistry = newRuntimeRegistry(cfg, factories.Runtime, deps)
 
@@ -6752,11 +6756,12 @@ func TestRuntimePublicWorkflowManagerRelayRoundTripsThroughHostedApp(t *testing.
 	testutil.CloseOnCleanup(t, relaySrv)
 
 	deps := Deps{
-		BaseURL:            relaySrv.URL,
-		EncryptionKey:      secret,
-		WorkflowManager:    manager,
-		PublicHostServices: publicHostServices,
-		Authorization:      newAllowAllAuthorizationProvider(),
+		BaseURL:               relaySrv.URL,
+		EncryptionKey:         secret,
+		WorkflowManager:       manager,
+		PublicHostServices:    publicHostServices,
+		Authorization:         newAllowAllAuthorizationProvider(),
+		AuthorizationInternal: newAllowAllAuthorizationProvider(),
 	}
 	deps.RuntimeRegistry = newRuntimeRegistry(cfg, factories.Runtime, deps)
 

--- a/gestaltd/internal/bootstrap/host_service_bootstrap.go
+++ b/gestaltd/internal/bootstrap/host_service_bootstrap.go
@@ -474,7 +474,7 @@ func buildWorkflowProviderHostService(appName string, deps Deps) runtimehost.Hos
 			proto.RegisterWorkflowServer(srv, workflowservice.NewProviderServer(
 				appName,
 				manager,
-				deps.Authorization,
+				deps.AuthorizationInternal,
 				opts...,
 			))
 		},

--- a/gestaltd/internal/bootstrap/host_service_bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/host_service_bootstrap_test.go
@@ -1,12 +1,21 @@
 package bootstrap
 
 import (
+	"context"
+	"net"
 	"testing"
 
+	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
 )
 
 func eagerHostServiceTestDeps(registry *runtimehost.PublicHostServiceRegistry) Deps {
@@ -96,5 +105,141 @@ func TestRegisterConfiguredAppPublicHostServicesNoopWithoutRelay(t *testing.T) {
 
 	if services := registry.Snapshot(); len(services) != 0 {
 		t.Fatalf("registry = %#v, want no registration when the public relay is unavailable", services)
+	}
+}
+
+// checkAccessRecordingAuthorizationProvider is a sentinel authorization
+// provider that records CheckAccess calls so tests can assert which provider
+// instance a host service consulted. It embeds core.AuthorizationProvider for
+// forward compatibility with the full interface surface.
+type checkAccessRecordingAuthorizationProvider struct {
+	core.AuthorizationProvider
+	name          string
+	checkAccesses []*proto.CheckAccessRequest
+}
+
+func (p *checkAccessRecordingAuthorizationProvider) CheckAccess(_ context.Context, req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
+	p.checkAccesses = append(p.checkAccesses, req)
+	return &proto.CheckAccessResponse{Allowed: true}, nil
+}
+
+func (p *checkAccessRecordingAuthorizationProvider) CheckAccessCount() int {
+	return len(p.checkAccesses)
+}
+
+func (p *checkAccessRecordingAuthorizationProvider) Close() error { return nil }
+
+func (p *checkAccessRecordingAuthorizationProvider) Ping(context.Context) error { return nil }
+
+// withHostServiceClient registers a host service on an in-memory gRPC server
+// and invokes fn with a fresh client. The server is torn down when fn returns.
+func withHostServiceClient[T any](t *testing.T, hostService runtimehost.HostService, newClient func(grpc.ClientConnInterface) T, fn func(T)) {
+	t.Helper()
+	if hostService.Register == nil {
+		t.Fatalf("host service %q has no Register func", hostService.Name)
+	}
+
+	lis := bufconn.Listen(1024 * 1024)
+	srv := grpc.NewServer()
+	hostService.Register(srv)
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(func() {
+		srv.Stop()
+		_ = lis.Close()
+	})
+
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return lis.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	fn(newClient(conn))
+}
+
+// TestBuildProviderHostServicesWiresAuthorizationSplit asserts the provider
+// gateway enforcement split: the plugin-facing authorization host service
+// receives the Guarded (gateway-guarded) authorization provider, while the
+// plugin-facing workflow ProviderServer receives the Raw (direct) provider so
+// gestaltd's own requireWorkflowAccess/requireServiceAccountManagement checks
+// are never meta-checked by the gateway.
+func TestBuildProviderHostServicesWiresAuthorizationSplit(t *testing.T) {
+	t.Parallel()
+
+	guarded := &checkAccessRecordingAuthorizationProvider{name: "guarded"}
+	raw := &checkAccessRecordingAuthorizationProvider{name: "raw"}
+
+	hostServices, err := buildProviderHostServices("testapp", Deps{
+		Authorization:         guarded,
+		AuthorizationInternal: raw,
+		Services: &coredata.Services{
+			ExternalCredentials: coretesting.NewStubExternalCredentialProvider(),
+		},
+	})
+	if err != nil {
+		t.Fatalf("buildProviderHostServices: %v", err)
+	}
+
+	names := hostServiceNames(hostServices)
+	if !hasHostServiceName(names, "authorization") {
+		t.Fatalf("provider host services missing %q: %v", "authorization", names)
+	}
+	if !hasHostServiceName(names, "workflow") {
+		t.Fatalf("provider host services missing %q: %v", "workflow", names)
+	}
+	var authorizationHostService, workflowHostService runtimehost.HostService
+	for _, hostService := range hostServices {
+		switch hostService.Name {
+		case "authorization":
+			authorizationHostService = hostService
+		case "workflow":
+			workflowHostService = hostService
+		}
+	}
+
+	ctx := context.Background()
+
+	// The authorization host service must consult the Guarded provider.
+	withHostServiceClient(t, authorizationHostService, proto.NewAuthorizationClient, func(client proto.AuthorizationClient) {
+		if _, err := client.CheckAccess(ctx, invocation.SubjectAccessRequest(
+			"user:test", "check", &proto.Resource{Type: "provider", Id: "indexeddb"},
+		)); err != nil {
+			t.Fatalf("authorization CheckAccess: %v", err)
+		}
+	})
+	if guarded.CheckAccessCount() != 1 {
+		t.Fatalf("guarded authorization provider CheckAccess count = %d, want 1; the authorization host service must use the Guarded (gateway-guarded) provider", guarded.CheckAccessCount())
+	}
+	if raw.CheckAccessCount() != 0 {
+		t.Fatalf("raw authorization provider CheckAccess count = %d, want 0; the authorization host service must not consult the Raw provider", raw.CheckAccessCount())
+	}
+
+	// The workflow host service must consult the Raw provider for its own
+	// enforcement checks. ListRuns runs requireWorkflowAccess (which calls
+	// CheckAccess on the wired provider) before reaching the (unavailable)
+	// workflow manager, so the RPC may fail afterwards; only the recording
+	// matters here.
+	withHostServiceClient(t, workflowHostService, proto.NewWorkflowClient, func(client proto.WorkflowClient) {
+		_, _ = client.ListRuns(ctx, &proto.ListWorkflowProviderRunsRequest{
+			Provider: "testapp",
+			Context: &proto.RequestContext{
+				Caller: &proto.ProviderContext{
+					Kind: string(invocation.ProviderKindApp),
+					Name: "testapp",
+				},
+				Subject: &proto.SubjectContext{Id: "user:test"},
+			},
+		})
+	})
+	if raw.CheckAccessCount() != 1 {
+		t.Fatalf("raw authorization provider CheckAccess count = %d, want 1; the workflow host service must use the Raw (direct) provider for its own enforcement checks", raw.CheckAccessCount())
+	}
+	if guarded.CheckAccessCount() != 1 {
+		t.Fatalf("guarded authorization provider CheckAccess count = %d, want 1; the workflow host service must not meta-check via the Guarded provider", guarded.CheckAccessCount())
 	}
 }


### PR DESCRIPTION
## Summary

Step 1 of the ProviderGateway enforcement rollout. Splits the bootstrap authorization wiring so the plugin-facing workflow `ProviderServer` uses the direct (Raw) authorization provider for gestaltd's own enforcement checks, while the authorization host service keeps the gateway-guarded (Guarded) client.

## Context

- #2842 collapsed the six hand-rolled `CheckAccess` sites onto shared helpers and deleted `/api/v1/authorization/*`.
- #2840 moved the CLI to `/api/v2`.
- #2820 (Jul 17) flipped `ProviderGatewayTransport.Authorize` from `return true, nil` (true shadow) to `return allowed, nil`. **Enforcement is already ON in code on main**, and it replaced the CallerToken subject mechanism with `principal.FromContext` plus the capability relay.
- Production valon.tools still runs a pre-#2820 gestaltd image, so prod behavior is still shadow. Datadog (`gestaltd.provider_gateway.authorization.count`, 30d): **26.9M `gd.allowed:false` vs 39 `gd.allowed:true`**.
- The Guarded (gateway-wrapped) authorization client backs two things: the **authorization host service** (plugins calling Authorization RPCs; the intended security boundary) and the **plugin-facing workflow `ProviderServer`** (`host_service_bootstrap.go:477`). The latter is a wiring bug: `requireWorkflowAccess` / `requireServiceAccountManagement` are gestaltd's *own* enforcement checks, and meta-checking them violates the non-recursion principle. The public-surface workflow server already correctly uses the Raw provider.

Net without this fix: the next routine gestaltd release flips hard enforcement with a near-100% deny rate on the guarded paths, including gestaltd's own workflow enforcement checks.

## Changes (all in `gestaltd/internal/bootstrap`)

- `bootstrap.go`: add `Deps.AuthorizationInternal` (`core.AuthorizationProvider`) next to `Deps.Authorization`, with a comment documenting the split — `Authorization` is the gateway-guarded (Guarded) client for plugin-facing host services; `AuthorizationInternal` is the direct (Raw) client for gestaltd's own enforcement checks.
- `bootstrap.go` (`prepareCore`): populate `Deps.AuthorizationInternal` via the existing `selectedAuthorizationProviderInstance(cfg, authorizationProviders.Raw)` helper, mirroring the Guarded selection.
- `host_service_bootstrap.go`: `buildWorkflowProviderHostService` passes `deps.AuthorizationInternal` into `workflowservice.NewProviderServer` instead of `deps.Authorization`. `authorizationHostServiceFromDeps` stays on `deps.Authorization` (Guarded); that meta-check is the intended plugin boundary.

No provider-gateway surface changes. No behavior change on shadow-era builds; on post-#2820 builds this removes only the meta-check in front of the workflow server's own `CheckAccess` calls (the real workflow authorization check is unchanged). Nil stays nil: if no authorization provider is configured, the workflow server already errors `FailedPrecondition`.

## Tests

- Added `TestBuildProviderHostServicesWiresAuthorizationSplit`: a bootstrap-level assertion that the authorization host service consults the Guarded provider and the workflow host service consults the Raw provider, using sentinel recording providers and in-memory gRPC RPCs (`CheckAccess` for authorization, `ListRuns` for workflow, which runs `requireWorkflowAccess` → `CheckAccess` before the manager call). Verified the test **fails** when the workflow host service is wired back to the Guarded provider.
- Updated five `executable_app_test.go` `Deps` literals that built hosted apps with a single allow-all provider to also set `AuthorizationInternal`, so the workflow host service keeps receiving an allow-all provider. These pinned the old single-provider wiring.

## Verification

```
go build ./...
go test ./internal/bootstrap/... ./services/workflows/... ./services/providergateway/... ./internal/server/...
go vet ./...
```

All green from `gestaltd/`.

## Release caveat

⚠️ **This fix alone does NOT make a gestaltd release safe.** Plugin callbacks to the authorization host service still hard-enforce on post-#2820 builds, and the authorization model grants almost nobody access to the authorization provider resource (`provider/indexeddb` in prod). **Hold gestaltd releases to valon-tools until Step 2/3 are decided** (meta-check policy + seed grants, then stage bake with fresh signal).

## Out of scope (documented for planning)

Steps 2-5 of the rollout (meta-check policy/seed grants, stage bake, prod release, post-enforcement cleanup) are intentionally not implemented here. This PR is Step 1 only.
