### PR TITLE
sdk/rust: generate sync gRPC client methods with SyncGrpcTransport

### DIFF
--- a/sdk/rust/src/public/generated/app_client.rs
+++ b/sdk/rust/src/public/generated/app_client.rs
@@ -915,6 +915,124 @@ impl<T: crate::public::generated::unary_transport::GrpcCapable> ExternalCredenti
     }
 }
 
+impl<T: crate::public::generated::unary_transport::SyncGrpcCapable> ExternalCredentialsClient<T> {
+    pub fn create_credential_sync(
+        &self,
+        request: CreateExternalCredentialRequest,
+    ) -> Result<ExternalCredential, GestaltError> {
+        let wire = to_wire_create_external_credential_request(request);
+        let mut wire_response = crate::generated::v1::ExternalCredential::default();
+        self.transport.unary(
+            &METHOD_EXTERNAL_CREDENTIALS_CREATE_CREDENTIAL,
+            &wire,
+            &mut wire_response,
+        )?;
+        Ok(from_wire_external_credential(wire_response))
+    }
+
+    pub fn upsert_credential_sync(
+        &self,
+        request: UpsertExternalCredentialRequest,
+    ) -> Result<ExternalCredential, GestaltError> {
+        let wire = to_wire_upsert_external_credential_request(request);
+        let mut wire_response = crate::generated::v1::ExternalCredential::default();
+        self.transport.unary(
+            &METHOD_EXTERNAL_CREDENTIALS_UPSERT_CREDENTIAL,
+            &wire,
+            &mut wire_response,
+        )?;
+        Ok(from_wire_external_credential(wire_response))
+    }
+
+    pub fn get_credential_sync(
+        &self,
+        request: GetExternalCredentialRequest,
+    ) -> Result<ExternalCredential, GestaltError> {
+        let wire = to_wire_get_external_credential_request(request);
+        let mut wire_response = crate::generated::v1::ExternalCredential::default();
+        self.transport.unary(
+            &METHOD_EXTERNAL_CREDENTIALS_GET_CREDENTIAL,
+            &wire,
+            &mut wire_response,
+        )?;
+        Ok(from_wire_external_credential(wire_response))
+    }
+
+    pub fn list_credentials_sync(
+        &self,
+        request: ListExternalCredentialsRequest,
+    ) -> Result<ListExternalCredentialsResponse, GestaltError> {
+        let wire = to_wire_list_external_credentials_request(request);
+        let mut wire_response = crate::generated::v1::ListExternalCredentialsResponse::default();
+        self.transport.unary(
+            &METHOD_EXTERNAL_CREDENTIALS_LIST_CREDENTIALS,
+            &wire,
+            &mut wire_response,
+        )?;
+        Ok(from_wire_list_external_credentials_response(wire_response))
+    }
+
+    pub fn delete_credential_sync(
+        &self,
+        request: DeleteExternalCredentialRequest,
+    ) -> Result<(), GestaltError> {
+        let wire = to_wire_delete_external_credential_request(request);
+        let mut wire_response = Empty::default();
+        self.transport.unary(
+            &METHOD_EXTERNAL_CREDENTIALS_DELETE_CREDENTIAL,
+            &wire,
+            &mut wire_response,
+        )?;
+        Ok(())
+    }
+
+    pub fn validate_credential_config_sync(
+        &self,
+        request: ValidateExternalCredentialConfigRequest,
+    ) -> Result<(), GestaltError> {
+        let wire = to_wire_validate_external_credential_config_request(request);
+        let mut wire_response = Empty::default();
+        self.transport.unary(
+            &METHOD_EXTERNAL_CREDENTIALS_VALIDATE_CREDENTIAL_CONFIG,
+            &wire,
+            &mut wire_response,
+        )?;
+        Ok(())
+    }
+
+    pub fn resolve_credential_sync(
+        &self,
+        request: ResolveExternalCredentialRequest,
+    ) -> Result<ResolveExternalCredentialResponse, GestaltError> {
+        let wire = to_wire_resolve_external_credential_request(request);
+        let mut wire_response = crate::generated::v1::ResolveExternalCredentialResponse::default();
+        self.transport.unary(
+            &METHOD_EXTERNAL_CREDENTIALS_RESOLVE_CREDENTIAL,
+            &wire,
+            &mut wire_response,
+        )?;
+        Ok(from_wire_resolve_external_credential_response(
+            wire_response,
+        ))
+    }
+
+    pub fn exchange_credential_sync(
+        &self,
+        request: ExchangeExternalCredentialRequest,
+    ) -> Result<ExchangeExternalCredentialResponse, GestaltError> {
+        let wire = to_wire_exchange_external_credential_request(request);
+        let mut wire_response = crate::generated::v1::ExchangeExternalCredentialResponse::default();
+        self.transport.unary(
+            &METHOD_EXTERNAL_CREDENTIALS_EXCHANGE_CREDENTIAL,
+            &wire,
+            &mut wire_response,
+        )?;
+        Ok(from_wire_exchange_external_credential_response(
+            wire_response,
+        ))
+    }
+}
+
 /// Transport-neutral client for the public gestaltd App surface.
 pub struct IdentityClient<T: Send + Sync> {
     transport: T,
@@ -1324,6 +1442,213 @@ impl<T: crate::public::generated::unary_transport::GrpcCapable> IndexedDBClient<
         self.transport
             .unary(&METHOD_INDEXED_D_B_INDEX_DELETE, &wire, &mut wire_response)
             .await?;
+        Ok(from_wire_delete_response(wire_response))
+    }
+}
+
+impl<T: crate::public::generated::unary_transport::SyncGrpcCapable> IndexedDBClient<T> {
+    pub fn create_object_store_sync(
+        &self,
+        request: CreateObjectStoreRequest,
+    ) -> Result<(), GestaltError> {
+        let wire = to_wire_create_object_store_request(request);
+        let mut wire_response = Empty::default();
+        self.transport.unary(
+            &METHOD_INDEXED_D_B_CREATE_OBJECT_STORE,
+            &wire,
+            &mut wire_response,
+        )?;
+        Ok(())
+    }
+
+    pub fn delete_object_store_sync(
+        &self,
+        request: DeleteObjectStoreRequest,
+    ) -> Result<(), GestaltError> {
+        let wire = to_wire_delete_object_store_request(request);
+        let mut wire_response = Empty::default();
+        self.transport.unary(
+            &METHOD_INDEXED_D_B_DELETE_OBJECT_STORE,
+            &wire,
+            &mut wire_response,
+        )?;
+        Ok(())
+    }
+
+    pub fn create_index_sync(&self, request: CreateIndexRequest) -> Result<(), GestaltError> {
+        let wire = to_wire_create_index_request(request);
+        let mut wire_response = Empty::default();
+        self.transport
+            .unary(&METHOD_INDEXED_D_B_CREATE_INDEX, &wire, &mut wire_response)?;
+        Ok(())
+    }
+
+    pub fn delete_index_sync(&self, request: DeleteIndexRequest) -> Result<(), GestaltError> {
+        let wire = to_wire_delete_index_request(request);
+        let mut wire_response = Empty::default();
+        self.transport
+            .unary(&METHOD_INDEXED_D_B_DELETE_INDEX, &wire, &mut wire_response)?;
+        Ok(())
+    }
+
+    pub fn get_sync(&self, request: ObjectStoreRequest) -> Result<RecordResponse, GestaltError> {
+        let wire = to_wire_object_store_request(request);
+        let mut wire_response = crate::generated::v1::RecordResponse::default();
+        self.transport
+            .unary(&METHOD_INDEXED_D_B_GET, &wire, &mut wire_response)?;
+        Ok(from_wire_record_response(wire_response))
+    }
+
+    pub fn get_key_sync(&self, request: ObjectStoreRequest) -> Result<KeyResponse, GestaltError> {
+        let wire = to_wire_object_store_request(request);
+        let mut wire_response = crate::generated::v1::KeyResponse::default();
+        self.transport
+            .unary(&METHOD_INDEXED_D_B_GET_KEY, &wire, &mut wire_response)?;
+        Ok(from_wire_key_response(wire_response))
+    }
+
+    pub fn add_sync(&self, request: RecordRequest) -> Result<(), GestaltError> {
+        let wire = to_wire_record_request(request);
+        let mut wire_response = Empty::default();
+        self.transport
+            .unary(&METHOD_INDEXED_D_B_ADD, &wire, &mut wire_response)?;
+        Ok(())
+    }
+
+    pub fn put_sync(&self, request: RecordRequest) -> Result<(), GestaltError> {
+        let wire = to_wire_record_request(request);
+        let mut wire_response = Empty::default();
+        self.transport
+            .unary(&METHOD_INDEXED_D_B_PUT, &wire, &mut wire_response)?;
+        Ok(())
+    }
+
+    pub fn delete_sync(&self, request: ObjectStoreRequest) -> Result<(), GestaltError> {
+        let wire = to_wire_object_store_request(request);
+        let mut wire_response = Empty::default();
+        self.transport
+            .unary(&METHOD_INDEXED_D_B_DELETE, &wire, &mut wire_response)?;
+        Ok(())
+    }
+
+    pub fn clear_sync(&self, request: ObjectStoreNameRequest) -> Result<(), GestaltError> {
+        let wire = to_wire_object_store_name_request(request);
+        let mut wire_response = Empty::default();
+        self.transport
+            .unary(&METHOD_INDEXED_D_B_CLEAR, &wire, &mut wire_response)?;
+        Ok(())
+    }
+
+    pub fn get_all_sync(
+        &self,
+        request: ObjectStoreRangeRequest,
+    ) -> Result<RecordsResponse, GestaltError> {
+        let wire = to_wire_object_store_range_request(request);
+        let mut wire_response = crate::generated::v1::RecordsResponse::default();
+        self.transport
+            .unary(&METHOD_INDEXED_D_B_GET_ALL, &wire, &mut wire_response)?;
+        Ok(from_wire_records_response(wire_response))
+    }
+
+    pub fn get_all_keys_sync(
+        &self,
+        request: ObjectStoreRangeRequest,
+    ) -> Result<KeysResponse, GestaltError> {
+        let wire = to_wire_object_store_range_request(request);
+        let mut wire_response = crate::generated::v1::KeysResponse::default();
+        self.transport
+            .unary(&METHOD_INDEXED_D_B_GET_ALL_KEYS, &wire, &mut wire_response)?;
+        Ok(from_wire_keys_response(wire_response))
+    }
+
+    pub fn count_sync(
+        &self,
+        request: ObjectStoreRangeRequest,
+    ) -> Result<CountResponse, GestaltError> {
+        let wire = to_wire_object_store_range_request(request);
+        let mut wire_response = crate::generated::v1::CountResponse::default();
+        self.transport
+            .unary(&METHOD_INDEXED_D_B_COUNT, &wire, &mut wire_response)?;
+        Ok(from_wire_count_response(wire_response))
+    }
+
+    pub fn delete_range_sync(
+        &self,
+        request: ObjectStoreRangeRequest,
+    ) -> Result<DeleteResponse, GestaltError> {
+        let wire = to_wire_object_store_range_request(request);
+        let mut wire_response = crate::generated::v1::DeleteResponse::default();
+        self.transport
+            .unary(&METHOD_INDEXED_D_B_DELETE_RANGE, &wire, &mut wire_response)?;
+        Ok(from_wire_delete_response(wire_response))
+    }
+
+    pub fn index_get_sync(
+        &self,
+        request: IndexQueryRequest,
+    ) -> Result<RecordResponse, GestaltError> {
+        let wire = to_wire_index_query_request(request);
+        let mut wire_response = crate::generated::v1::RecordResponse::default();
+        self.transport
+            .unary(&METHOD_INDEXED_D_B_INDEX_GET, &wire, &mut wire_response)?;
+        Ok(from_wire_record_response(wire_response))
+    }
+
+    pub fn index_get_key_sync(
+        &self,
+        request: IndexQueryRequest,
+    ) -> Result<KeyResponse, GestaltError> {
+        let wire = to_wire_index_query_request(request);
+        let mut wire_response = crate::generated::v1::KeyResponse::default();
+        self.transport
+            .unary(&METHOD_INDEXED_D_B_INDEX_GET_KEY, &wire, &mut wire_response)?;
+        Ok(from_wire_key_response(wire_response))
+    }
+
+    pub fn index_get_all_sync(
+        &self,
+        request: IndexQueryRequest,
+    ) -> Result<RecordsResponse, GestaltError> {
+        let wire = to_wire_index_query_request(request);
+        let mut wire_response = crate::generated::v1::RecordsResponse::default();
+        self.transport
+            .unary(&METHOD_INDEXED_D_B_INDEX_GET_ALL, &wire, &mut wire_response)?;
+        Ok(from_wire_records_response(wire_response))
+    }
+
+    pub fn index_get_all_keys_sync(
+        &self,
+        request: IndexQueryRequest,
+    ) -> Result<KeysResponse, GestaltError> {
+        let wire = to_wire_index_query_request(request);
+        let mut wire_response = crate::generated::v1::KeysResponse::default();
+        self.transport.unary(
+            &METHOD_INDEXED_D_B_INDEX_GET_ALL_KEYS,
+            &wire,
+            &mut wire_response,
+        )?;
+        Ok(from_wire_keys_response(wire_response))
+    }
+
+    pub fn index_count_sync(
+        &self,
+        request: IndexQueryRequest,
+    ) -> Result<CountResponse, GestaltError> {
+        let wire = to_wire_index_query_request(request);
+        let mut wire_response = crate::generated::v1::CountResponse::default();
+        self.transport
+            .unary(&METHOD_INDEXED_D_B_INDEX_COUNT, &wire, &mut wire_response)?;
+        Ok(from_wire_count_response(wire_response))
+    }
+
+    pub fn index_delete_sync(
+        &self,
+        request: IndexQueryRequest,
+    ) -> Result<DeleteResponse, GestaltError> {
+        let wire = to_wire_index_query_request(request);
+        let mut wire_response = crate::generated::v1::DeleteResponse::default();
+        self.transport
+            .unary(&METHOD_INDEXED_D_B_INDEX_DELETE, &wire, &mut wire_response)?;
         Ok(from_wire_delete_response(wire_response))
     }
 }

--- a/sdk/rust/src/public/generated/unary_transport.rs
+++ b/sdk/rust/src/public/generated/unary_transport.rs
@@ -22,8 +22,8 @@ pub trait UnaryTransport: Send + Sync {
         Resp: Message + Default + Send + 'static;
 }
 
-/// Performs one unary public App call synchronously. REST-only; no gRPC
-/// transport implements this trait.
+/// Performs one unary public App call synchronously. REST methods use
+/// SyncRestTransport; gRPC-only methods use SyncGrpcTransport.
 pub trait SyncUnaryTransport: Send + Sync {
     fn unary<Req, Resp>(
         &self,
@@ -38,3 +38,6 @@ pub trait SyncUnaryTransport: Send + Sync {
 
 /// Marker for transports that can call gRPC-only public methods.
 pub trait GrpcCapable: UnaryTransport {}
+
+/// Marker for sync transports that can call gRPC-only public methods.
+pub trait SyncGrpcCapable: SyncUnaryTransport {}

--- a/sdk/rust/src/public/grpc_transport.rs
+++ b/sdk/rust/src/public/grpc_transport.rs
@@ -1,4 +1,8 @@
-//! tonic-based gRPC transport for the public Gestalt API.
+//! tonic-based gRPC transports for the public Gestalt API.
+//!
+//! [`GrpcTransport`] is async (backed by `tonic`); [`SyncGrpcTransport`] is
+//! sync (backed by `tonic` driven via `tokio::runtime::Runtime::block_on`).
+//! Both share the inner unary call logic via a private `unary_grpc_call` helper.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -15,7 +19,9 @@ use crate::codec::host_service::HostServiceChannel;
 use crate::public::auth::Auth;
 use crate::public::generated::metadata::Method;
 use crate::public::generated::rpc_support::GestaltError;
-use crate::public::generated::unary_transport::{GrpcCapable, UnaryTransport};
+use crate::public::generated::unary_transport::{
+    GrpcCapable, SyncGrpcCapable, SyncUnaryTransport, UnaryTransport,
+};
 use crate::rpc_support::gestalt_error_code;
 
 type AuthChannel = InterceptedService<Channel, AuthInterceptor>;
@@ -74,44 +80,102 @@ impl UnaryTransport for GrpcTransport {
         let path = method.full_method.to_string();
         let request = request.clone();
 
-        async move {
-            let path: PathAndQuery = path.parse().map_err(|err: http::uri::InvalidUri| {
-                GestaltError::new(gestalt_error_code::INVALID_ARGUMENT, err.to_string())
-            })?;
-            let mut tonic_request = Request::new(request);
-            if let Some(timeout) = timeout {
-                tonic_request.set_timeout(timeout);
-            }
-
-            let codec = ProstCodec::<Req, Resp>::default();
-            let wire_response = match service {
-                GrpcService::Public(channel) => {
-                    let mut client = Grpc::new(channel);
-                    client.ready().await.map_err(grpc_ready_error)?;
-                    client
-                        .unary(tonic_request, path, codec)
-                        .await
-                        .map_err(GestaltError::from)?
-                        .into_inner()
-                }
-                GrpcService::Bound(channel) => {
-                    let mut client = Grpc::new(channel);
-                    client.ready().await.map_err(grpc_ready_error)?;
-                    client
-                        .unary(tonic_request, path, codec)
-                        .await
-                        .map_err(GestaltError::from)?
-                        .into_inner()
-                }
-            };
-
-            *response = wire_response;
-            Ok(())
-        }
+        async move { unary_grpc_call(&service, &path, request, timeout, response).await }
     }
 }
 
 impl GrpcCapable for GrpcTransport {}
+
+/// Sync gRPC transport implementing [`SyncUnaryTransport`] and
+/// [`SyncGrpcCapable`] for the full public surface.
+///
+/// Wraps `tonic`'s async unary calls in `tokio::runtime::Runtime::block_on`.
+/// Like [`crate::public::rest_transport::SyncRestTransport`], this panics if
+/// called from within an async runtime — callers in async context should use
+/// [`GrpcTransport`] instead.
+pub struct SyncGrpcTransport {
+    service: GrpcService,
+    runtime: tokio::runtime::Runtime,
+    timeout: Option<Duration>,
+}
+
+impl SyncGrpcTransport {
+    /// Creates a sync gRPC transport over an established public channel.
+    ///
+    /// The channel's background IO driver must outlive this transport — i.e.,
+    /// the channel must have been created on a tokio runtime that is still
+    /// running. For the common case of dialing from a sync entry point, use
+    /// [`SyncGrpcTransport::from_endpoint`] instead, which dials inside the
+    /// transport's own runtime.
+    pub fn new(channel: Channel, auth: Arc<dyn Auth>) -> Self {
+        Self::from_service(GrpcService::Public(auth_channel(channel, auth)))
+    }
+
+    /// Creates a sync gRPC transport by dialing the given endpoint inside the
+    /// transport's own tokio runtime. This is the recommended entry point for
+    /// sync callers: the channel's background IO driver is spawned on the
+    /// transport's runtime, so it stays alive for the lifetime of the
+    /// transport.
+    pub fn from_endpoint(endpoint: tonic::transport::Endpoint, auth: Arc<dyn Auth>) -> Self {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime");
+        let _guard = runtime.enter();
+        let channel = endpoint.connect_lazy();
+        Self {
+            service: GrpcService::Public(auth_channel(channel, auth)),
+            runtime,
+            timeout: None,
+        }
+    }
+
+    /// Creates a sync gRPC transport over the provider host-service relay.
+    #[allow(dead_code)]
+    pub(crate) fn from_host_service(channel: HostServiceChannel) -> Self {
+        Self::from_service(GrpcService::Bound(channel))
+    }
+
+    fn from_service(service: GrpcService) -> Self {
+        Self {
+            service,
+            runtime: tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .expect("tokio runtime"),
+            timeout: None,
+        }
+    }
+
+    /// Applies a per-request deadline to unary calls.
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = Some(timeout);
+        self
+    }
+}
+
+impl SyncUnaryTransport for SyncGrpcTransport {
+    fn unary<Req, Resp>(
+        &self,
+        method: &Method,
+        request: &Req,
+        response: &mut Resp,
+    ) -> Result<(), GestaltError>
+    where
+        Req: Message + Clone + Send + Sync + 'static,
+        Resp: Message + Default + Send + 'static,
+    {
+        let service = self.service.clone();
+        let timeout = self.timeout;
+        let path = method.full_method.to_string();
+        let request = request.clone();
+        let _guard = self.runtime.enter();
+        self.runtime
+            .block_on(unary_grpc_call(&service, &path, request, timeout, response))
+    }
+}
+
+impl SyncGrpcCapable for SyncGrpcTransport {}
 
 fn grpc_ready_error(err: tonic::transport::Error) -> GestaltError {
     GestaltError::new(gestalt_error_code::UNAVAILABLE, err.to_string())
@@ -163,4 +227,51 @@ impl tonic::service::Interceptor for AuthInterceptor {
 
 fn transport_error(err: tonic::transport::Error) -> GestaltError {
     GestaltError::new(gestalt_error_code::UNAVAILABLE, err.to_string())
+}
+
+/// Shared inner async unary call logic for both [`GrpcTransport`] (async) and
+/// [`SyncGrpcTransport`] (sync via `block_on`).
+async fn unary_grpc_call<Req, Resp>(
+    service: &GrpcService,
+    path: &str,
+    request: Req,
+    timeout: Option<Duration>,
+    response: &mut Resp,
+) -> Result<(), GestaltError>
+where
+    Req: Message + Send + Sync + 'static,
+    Resp: Message + Default + Send + 'static,
+{
+    let path: PathAndQuery = path.parse().map_err(|err: http::uri::InvalidUri| {
+        GestaltError::new(gestalt_error_code::INVALID_ARGUMENT, err.to_string())
+    })?;
+    let mut tonic_request = Request::new(request);
+    if let Some(timeout) = timeout {
+        tonic_request.set_timeout(timeout);
+    }
+
+    let codec = ProstCodec::<Req, Resp>::default();
+    let wire_response = match service {
+        GrpcService::Public(channel) => {
+            let mut client = Grpc::new(channel.clone());
+            client.ready().await.map_err(grpc_ready_error)?;
+            client
+                .unary(tonic_request, path, codec)
+                .await
+                .map_err(GestaltError::from)?
+                .into_inner()
+        }
+        GrpcService::Bound(channel) => {
+            let mut client = Grpc::new(channel.clone());
+            client.ready().await.map_err(grpc_ready_error)?;
+            client
+                .unary(tonic_request, path, codec)
+                .await
+                .map_err(GestaltError::from)?
+                .into_inner()
+        }
+    };
+
+    *response = wire_response;
+    Ok(())
 }

--- a/sdk/rust/src/public/mod.rs
+++ b/sdk/rust/src/public/mod.rs
@@ -17,5 +17,5 @@ pub use client::{
     GestaltClient, GrpcGestaltClient, RestGestaltClient, Transport, create_gestalt_client,
     create_grpc_gestalt_client, create_rest_gestalt_client, grpc, rest,
 };
-pub use grpc_transport::{GrpcTransport, dial_public_grpc};
+pub use grpc_transport::{GrpcTransport, SyncGrpcTransport, dial_public_grpc};
 pub use rest_transport::{RestTransport, SyncRestTransport};

--- a/sdk/rust/tests/sync_grpc_transport.rs
+++ b/sdk/rust/tests/sync_grpc_transport.rs
@@ -1,0 +1,226 @@
+//! Tests for the sync gRPC transport (SyncGrpcTransport).
+
+use std::sync::Arc;
+
+use gestalt::public::auth::NoAuth;
+use gestalt::public::generated::app_client::ExternalCredentialsClient;
+use gestalt::public::generated::external_credential::{
+    CreateExternalCredentialRequest, ExternalCredential,
+};
+use gestalt::public::grpc_transport::SyncGrpcTransport;
+use gestalt::rpc_support::gestalt_error_code;
+
+#[path = "../src/generated.rs"]
+mod generated;
+
+use generated::v1::external_credentials_server::{ExternalCredentials, ExternalCredentialsServer};
+use generated::v1::{
+    CreateExternalCredentialRequest as WireCreateRequest,
+    DeleteExternalCredentialRequest as WireDeleteRequest,
+    ExchangeExternalCredentialRequest as WireExchangeRequest,
+    ExchangeExternalCredentialResponse as WireExchangeResponse,
+    ExternalCredential as WireCredential, GetExternalCredentialRequest as WireGetRequest,
+    ListExternalCredentialsRequest as WireListRequest,
+    ListExternalCredentialsResponse as WireListResponse,
+    ResolveExternalCredentialRequest as WireResolveRequest,
+    ResolveExternalCredentialResponse as WireResolveResponse,
+    UpsertExternalCredentialRequest as WireUpsertRequest,
+    ValidateExternalCredentialConfigRequest as WireValidateRequest,
+};
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::transport::Server;
+use tonic::{Request, Response, Status};
+
+struct StubExternalCredentials;
+
+#[tonic::async_trait]
+impl ExternalCredentials for StubExternalCredentials {
+    async fn create_credential(
+        &self,
+        _request: Request<WireCreateRequest>,
+    ) -> Result<Response<WireCredential>, Status> {
+        Ok(Response::new(WireCredential {
+            id: "cred-1".into(),
+            subject: "user-1".into(),
+            ..Default::default()
+        }))
+    }
+
+    async fn upsert_credential(
+        &self,
+        _request: Request<WireUpsertRequest>,
+    ) -> Result<Response<WireCredential>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn get_credential(
+        &self,
+        _request: Request<WireGetRequest>,
+    ) -> Result<Response<WireCredential>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn list_credentials(
+        &self,
+        _request: Request<WireListRequest>,
+    ) -> Result<Response<WireListResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn delete_credential(
+        &self,
+        _request: Request<WireDeleteRequest>,
+    ) -> Result<Response<()>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn validate_credential_config(
+        &self,
+        _request: Request<WireValidateRequest>,
+    ) -> Result<Response<()>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn resolve_credential(
+        &self,
+        _request: Request<WireResolveRequest>,
+    ) -> Result<Response<WireResolveResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn exchange_credential(
+        &self,
+        _request: Request<WireExchangeRequest>,
+    ) -> Result<Response<WireExchangeResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+}
+
+struct StubUnauthenticated;
+
+#[tonic::async_trait]
+impl ExternalCredentials for StubUnauthenticated {
+    async fn create_credential(
+        &self,
+        _request: Request<WireCreateRequest>,
+    ) -> Result<Response<WireCredential>, Status> {
+        Err(Status::unauthenticated("missing bearer"))
+    }
+
+    async fn upsert_credential(
+        &self,
+        _request: Request<WireUpsertRequest>,
+    ) -> Result<Response<WireCredential>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn get_credential(
+        &self,
+        _request: Request<WireGetRequest>,
+    ) -> Result<Response<WireCredential>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn list_credentials(
+        &self,
+        _request: Request<WireListRequest>,
+    ) -> Result<Response<WireListResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn delete_credential(
+        &self,
+        _request: Request<WireDeleteRequest>,
+    ) -> Result<Response<()>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn validate_credential_config(
+        &self,
+        _request: Request<WireValidateRequest>,
+    ) -> Result<Response<()>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn resolve_credential(
+        &self,
+        _request: Request<WireResolveRequest>,
+    ) -> Result<Response<WireResolveResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn exchange_credential(
+        &self,
+        _request: Request<WireExchangeRequest>,
+    ) -> Result<Response<WireExchangeResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+}
+
+// Boot a tonic gRPC server on a one-shot tokio runtime, then return the
+// address. The server runs in a background thread for the lifetime of the
+// returned guard.
+struct ServerGuard {
+    _runtime: tokio::runtime::Runtime,
+    addr: std::net::SocketAddr,
+}
+
+fn start_server<S: ExternalCredentials + 'static>(service: S) -> ServerGuard {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+    let listener = runtime
+        .block_on(tokio::net::TcpListener::bind("127.0.0.1:0"))
+        .expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    runtime.spawn(async move {
+        Server::builder()
+            .add_service(ExternalCredentialsServer::new(service))
+            .serve_with_incoming(TcpListenerStream::new(listener))
+            .await
+            .expect("serve");
+    });
+    ServerGuard {
+        _runtime: runtime,
+        addr,
+    }
+}
+
+fn sync_client(guard: &ServerGuard) -> ExternalCredentialsClient<SyncGrpcTransport> {
+    let endpoint = tonic::transport::Endpoint::from_shared(format!("http://{}", guard.addr))
+        .expect("endpoint");
+    let transport = SyncGrpcTransport::from_endpoint(endpoint, Arc::new(NoAuth));
+    ExternalCredentialsClient::new(transport)
+}
+
+#[test]
+fn sync_grpc_transport_create_credential_success() {
+    let guard = start_server(StubExternalCredentials);
+    let client = sync_client(&guard);
+
+    let response = client
+        .create_credential_sync(CreateExternalCredentialRequest {
+            credential: Some(ExternalCredential {
+                id: "req-1".to_string(),
+                subject: "user-1".to_string(),
+                ..Default::default()
+            }),
+        })
+        .expect("create_credential_sync should succeed");
+
+    assert_eq!(response.id, "cred-1");
+    assert_eq!(response.subject, "user-1");
+}
+
+#[test]
+fn sync_grpc_transport_maps_unauthenticated_error() {
+    let guard = start_server(StubUnauthenticated);
+    let client = sync_client(&guard);
+
+    let err = client
+        .create_credential_sync(CreateExternalCredentialRequest::default())
+        .expect_err("create_credential_sync should fail");
+
+    assert_eq!(err.code, gestalt_error_code::UNAUTHENTICATED);
+}

--- a/sdk/tools/sdkgen/internal/emit/rust/public_emit.go
+++ b/sdk/tools/sdkgen/internal/emit/rust/public_emit.go
@@ -38,8 +38,8 @@ pub trait UnaryTransport: Send + Sync {
         Resp: Message + Default + Send + 'static;
 }
 
-/// Performs one unary public App call synchronously. REST-only; no gRPC
-/// transport implements this trait.
+/// Performs one unary public App call synchronously. REST methods use
+/// SyncRestTransport; gRPC-only methods use SyncGrpcTransport.
 pub trait SyncUnaryTransport: Send + Sync {
     fn unary<Req, Resp>(
         &self,
@@ -54,6 +54,9 @@ pub trait SyncUnaryTransport: Send + Sync {
 
 /// Marker for transports that can call gRPC-only public methods.
 pub trait GrpcCapable: UnaryTransport {}
+
+/// Marker for sync transports that can call gRPC-only public methods.
+pub trait SyncGrpcCapable: SyncUnaryTransport {}
 `
 
 // EmitPublic renders the public gestaltd Rust client under sdk/rust/src/public.

--- a/sdk/tools/sdkgen/internal/emit/rust/public_render.go
+++ b/sdk/tools/sdkgen/internal/emit/rust/public_render.go
@@ -85,6 +85,12 @@ func (r *renderer) renderAppClient(svc *model.Service) {
 			r.renderAppClientMethod(svc, m, false)
 		}
 		r.body.WriteString("}\n\n")
+
+		fmt.Fprintf(&r.body, "impl<T: crate::public::generated::unary_transport::SyncGrpcCapable> %s<T> {\n", clientName)
+		for _, m := range grpcOnlyMethods {
+			r.renderAppClientMethod(svc, m, true)
+		}
+		r.body.WriteString("}\n\n")
 	}
 }
 

--- a/sdk/tools/sdkgen/internal/emit/rust/public_render_sync_test.go
+++ b/sdk/tools/sdkgen/internal/emit/rust/public_render_sync_test.go
@@ -77,7 +77,7 @@ func TestSyncMethodsGeneratedForREST(t *testing.T) {
 	}
 }
 
-func TestNoSyncMethodsForGRPCOnly(t *testing.T) {
+func TestSyncMethodsGeneratedForGRPCOnly(t *testing.T) {
 	t.Parallel()
 
 	svc := &model.Service{
@@ -109,13 +109,21 @@ func TestNoSyncMethodsForGRPCOnly(t *testing.T) {
 	if !strings.Contains(out, "pub async fn create_credential(") {
 		t.Fatal("missing async create_credential method")
 	}
-	// No sync method — gRPC-only methods don't get sync variants
-	if strings.Contains(out, "create_credential_sync") {
-		t.Fatal("gRPC-only method should not have a sync variant")
+	// Sync method exists (in SyncGrpcCapable block)
+	if !strings.Contains(out, "pub fn create_credential_sync(") {
+		t.Fatal("missing sync create_credential_sync method")
 	}
-	// No SyncUnaryTransport impl block
-	if strings.Contains(out, "SyncUnaryTransport") {
-		t.Fatal("gRPC-only service should not have a SyncUnaryTransport impl block")
+	// Async impl block bound on GrpcCapable
+	if !strings.Contains(out, "impl<T: crate::public::generated::unary_transport::GrpcCapable> ExternalCredentialsClient<T>") {
+		t.Fatal("missing async impl block with GrpcCapable bound")
+	}
+	// Sync impl block bound on SyncGrpcCapable
+	if !strings.Contains(out, "impl<T: crate::public::generated::unary_transport::SyncGrpcCapable> ExternalCredentialsClient<T>") {
+		t.Fatal("missing sync impl block with SyncGrpcCapable bound")
+	}
+	// SyncGrpcCapable trait is in the transport template
+	if !strings.Contains(publicUnaryTransportFile, "pub trait SyncGrpcCapable: SyncUnaryTransport") {
+		t.Fatal("publicUnaryTransportFile missing SyncGrpcCapable trait")
 	}
 }
 


### PR DESCRIPTION
## Summary

The Rust SDK had sync variants (`*_sync`) only for REST methods. 28 gRPC-only methods across `ExternalCredentials` (8) and `IndexedDB` (20) were async-only, constrained on `GrpcCapable: UnaryTransport` (async). The `SyncUnaryTransport` trait was explicitly documented "REST-only; no gRPC transport implements this trait."

This PR closes that gap: adds a `SyncGrpcCapable` trait, generates `*_sync` variants for gRPC-only methods, and ships a `SyncGrpcTransport` that wraps `tonic`'s async calls in `tokio::runtime::Runtime::block_on` — the same approach `SyncRestTransport` uses with `reqwest::blocking`. Python has no gap (both sync and async gRPC already work for all methods) and is not touched.

## High-level interface

```rust
// sdk/rust/src/public/generated/unary_transport.rs
pub trait SyncUnaryTransport: Send + Sync {
    fn unary<Req, Resp>(&self, method: &Method, request: &Req, response: &mut Resp)
        -> Result<(), GestaltError>
    where Req: Message + Clone + Send + Sync + 'static, Resp: Message + Default + Send + 'static;
}

/// Marker for sync transports that can call gRPC-only public methods.
pub trait SyncGrpcCapable: SyncUnaryTransport {}

// Generated client — gRPC-only methods now get a sync block too
impl<T: GrpcCapable> ExternalCredentialsClient<T> {
    pub async fn create_credential(&self, request: CreateExternalCredentialRequest) -> Result<ExternalCredential, GestaltError> { ... }
}
impl<T: SyncGrpcCapable> ExternalCredentialsClient<T> {
    pub fn create_credential_sync(&self, request: CreateExternalCredentialRequest) -> Result<ExternalCredential, GestaltError> { ... }
}

// sdk/rust/src/public/grpc_transport.rs
pub struct SyncGrpcTransport { service: GrpcService, runtime: tokio::runtime::Runtime, timeout: Option<Duration> }

impl SyncGrpcTransport {
    /// For channels created on an existing runtime.
    pub fn new(channel: Channel, auth: Arc<dyn Auth>) -> Self { ... }

    /// Recommended for sync callers: dials inside the transport's own runtime.
    pub fn from_endpoint(endpoint: tonic::transport::Endpoint, auth: Arc<dyn Auth>) -> Self { ... }

    pub fn with_timeout(mut self, timeout: Duration) -> Self { ... }
}

impl SyncUnaryTransport for SyncGrpcTransport {
    fn unary<Req, Resp>(&self, method: &Method, request: &Req, response: &mut Resp) -> Result<(), GestaltError> {
        let _guard = self.runtime.enter();
        self.runtime.block_on(unary_grpc_call(&self.service, &path, request, timeout, response))
    }
}

impl SyncGrpcCapable for SyncGrpcTransport {}
```

## Key changes

### Generator — `sdk/tools/sdkgen/internal/emit/rust/`

- `public_emit.go`: added `SyncGrpcCapable: SyncUnaryTransport` trait to the `unary_transport.rs` template. Updated `SyncUnaryTransport` doc from "REST-only" to "REST methods use SyncRestTransport; gRPC-only methods use SyncGrpcTransport."
- `public_render.go`: after the existing `impl<T: GrpcCapable>` block (async gRPC-only), added a fourth `impl<T: SyncGrpcCapable>` block emitting `*_sync` variants for the same gRPC-only methods.
- `public_render_sync_test.go`: replaced `TestNoSyncMethodsForGRPCOnly` (which asserted no sync gRPC) with `TestSyncMethodsGeneratedForGRPCOnly` — asserts `create_credential_sync` is emitted in a `SyncGrpcCapable` block.

### Transport — `sdk/rust/src/public/grpc_transport.rs`

- Extracted the inner async gRPC call logic into a shared `async fn unary_grpc_call` that both `GrpcTransport` (async) and `SyncGrpcTransport` (via `block_on`) call. Mirrors the `rest_request.rs` extraction.
- Added `SyncGrpcTransport` owning a `tokio::runtime::Runtime`. Two constructors: `new(channel, auth)` for channels created on an existing runtime, and `from_endpoint(endpoint, auth)` which dials inside the transport's own runtime (recommended for sync callers — the channel's background IO driver is spawned on the transport's runtime).
- `impl SyncUnaryTransport for SyncGrpcTransport`: calls `self.runtime.enter()` then `self.runtime.block_on(unary_grpc_call(...))`. Panics if called from within an async runtime — same constraint as `SyncRestTransport`.
- `impl SyncGrpcCapable for SyncGrpcTransport {}`.

### Exports — `sdk/rust/src/public/mod.rs`

- `pub use grpc_transport::{GrpcTransport, SyncGrpcTransport, dial_public_grpc};`

## Test plan

- **Generator unit test**: `TestSyncMethodsGeneratedForGRPCOnly` — asserts `create_credential_sync` is emitted in a `SyncGrpcCapable` block, sync body has no `.await`. Existing `TestSyncMethodsGeneratedForREST` and `TestSyncMethodBodiesHaveNoAwait` unchanged.
- **Transport integration test** (`sdk/rust/tests/sync_grpc_transport.rs`): stands up a tonic `ExternalCredentialsServer` on a one-shot tokio runtime, calls `create_credential_sync` via `SyncGrpcTransport::from_endpoint`, verifies the response. Tests the `UNAUTHENTICATED` error path maps to `GestaltError` with the right code.
- All existing Rust tests pass. `cargo clippy --tests` clean. `sdkgen --check` no drift.

## Assumptions

- **`block_on` approach**: `SyncGrpcTransport` owns a `tokio::runtime::Runtime` and calls `block_on` on tonic's async unary calls. Consistent with `SyncRestTransport` (which uses `reqwest::blocking`, also panics from async context). `tonic` is async-only — no blocking API exists.
- **`from_endpoint` is the recommended constructor** for sync callers: it creates the channel inside the transport's own runtime, so tonic's background IO driver is spawned on the correct runtime. `new(channel, auth)` is for cases where the caller already has a running runtime.
- **No new dependencies** — `tokio` with `rt-multi-thread` is already in `Cargo.toml`.
- **Python is not touched** — both sync and async gRPC already work for all methods.
