### PR TITLE
Collapse the Guarded/Raw authorization provider split

### DIFF
--- a/gestaltd/internal/bootstrap/authorization_bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/authorization_bootstrap_test.go
@@ -246,7 +246,7 @@ config:
 			capturedName = name
 			capturedHostServices = append([]runtimehost.HostService(nil), hostServices...)
 			provider := &recordingAuthorizationProvider{}
-			return providerdrivers.AuthorizationBuildResult{Raw: provider, Guarded: provider}, nil
+			return providerdrivers.AuthorizationBuildResult{Raw: provider}, nil
 		},
 	}
 	cfg := &config.Config{
@@ -268,9 +268,6 @@ config:
 	providers, err := buildAuthorizationProviders(context.Background(), cfg, factories, deps)
 	if err != nil {
 		t.Fatalf("buildAuthorizationProviders: %v", err)
-	}
-	if providers.Guarded["indexeddb"] == nil {
-		t.Fatal("guarded authorization provider was not built")
 	}
 	if providers.Raw["indexeddb"] == nil {
 		t.Fatal("raw authorization provider was not built")

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1088,14 +1088,14 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	closeAuthorizationOnError := true
 	defer func() {
 		if closeAuthorizationOnError {
-			_ = closeAuthorizationProviders(authorizationProviders.Guarded)
+			_ = closeAuthorizationProviders(authorizationProviders.Raw)
 		}
 	}()
 	if err := bootstrapAuthorizationProviderState(ctx, cfg, authorizationProviders.Raw); err != nil {
 		_ = closeAuthProviders(authProviders)
 		return nil, err
 	}
-	_, authorizationProvider, err := selectedAuthorizationProviderInstance(cfg, authorizationProviders.Guarded)
+	_, authorizationProvider, err := selectedAuthorizationProviderInstance(cfg, authorizationProviders.Raw)
 	if err != nil {
 		_ = closeAuthProviders(authProviders)
 		return nil, err
@@ -2106,8 +2106,7 @@ func buildNamedAuthProvider(cfg *config.Config, name string, authEntry *config.P
 }
 
 type authorizationProviderSets struct {
-	Raw     map[string]core.AuthorizationProvider
-	Guarded map[string]core.AuthorizationProvider
+	Raw map[string]core.AuthorizationProvider
 }
 
 func buildAuthorizationProviders(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, deps Deps) (authorizationProviderSets, error) {
@@ -2126,8 +2125,7 @@ func buildAuthorizationProviders(ctx context.Context, cfg *config.Config, factor
 		return authorizationProviderSets{}, err
 	}
 	return authorizationProviderSets{
-		Raw:     map[string]core.AuthorizationProvider{name: providers.Raw},
-		Guarded: map[string]core.AuthorizationProvider{name: providers.Guarded},
+		Raw: map[string]core.AuthorizationProvider{name: providers.Raw},
 	}, nil
 }
 
@@ -2147,7 +2145,7 @@ func buildNamedAuthorizationProvider(ctx context.Context, cfg *config.Config, na
 		if err != nil {
 			return providerdrivers.AuthorizationBuildResult{}, fmt.Errorf("bootstrap: authorization provider %q: %w", logicalName, err)
 		}
-		return providerdrivers.AuthorizationBuildResult{Raw: provider, Guarded: provider}, nil
+		return providerdrivers.AuthorizationBuildResult{Raw: provider}, nil
 	}
 	if factories.Authorization == nil {
 		return providerdrivers.AuthorizationBuildResult{}, fmt.Errorf("bootstrap: authorization factory is not registered")

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -1900,12 +1900,9 @@ func TestBootstrapAuthorizationProviderStateUsesProviderGatewayTransport(t *test
 		return &coretesting.StubSecretManager{Secrets: map[string]string{}}, nil
 	}
 	factories.Authorization = func(_ context.Context, _ string, _ yaml.Node, _ []runtimehost.HostService, deps bootstrap.Deps) (providerdrivers.AuthorizationBuildResult, error) {
-		raw := &bootstrapTransportRecordingAuthorizationProvider{transport: deps.ProviderTransport}
-		guardedTransport := providergateway.NewProviderGatewayTransport()
-		guardedTransport.SetAuthorizationProvider(raw)
-		guarded := &bootstrapTransportRecordingAuthorizationProvider{transport: guardedTransport}
-		built = append(built, raw, guarded)
-		return providerdrivers.AuthorizationBuildResult{Raw: raw, Guarded: guarded}, nil
+		provider := &bootstrapTransportRecordingAuthorizationProvider{transport: deps.ProviderTransport}
+		built = append(built, provider)
+		return providerdrivers.AuthorizationBuildResult{Raw: provider}, nil
 	}
 
 	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
@@ -1914,29 +1911,18 @@ func TestBootstrapAuthorizationProviderStateUsesProviderGatewayTransport(t *test
 	}
 	t.Cleanup(func() { _ = result.Close(context.Background()) })
 
-	if len(built) != 2 {
-		t.Fatalf("authorization providers built = %d, want 2", len(built))
+	if len(built) != 1 {
+		t.Fatalf("authorization providers built = %d, want 1", len(built))
 	}
-	rawProvider := built[0]
-	guardedProvider := built[1]
-	if _, ok := rawProvider.transport.(providergateway.DirectTransport); !ok {
-		t.Fatalf("raw authorization provider transport = %T, want providergateway.DirectTransport", rawProvider.transport)
+	provider := built[0]
+	if _, ok := provider.transport.(providergateway.DirectTransport); !ok {
+		t.Fatalf("authorization provider transport = %T, want providergateway.DirectTransport", provider.transport)
 	}
-	transportGateway, ok := guardedProvider.transport.(*providergateway.ProviderGatewayTransport)
-	if !ok {
-		t.Fatalf("guarded authorization provider transport = %T, want *providergateway.ProviderGatewayTransport", guardedProvider.transport)
+	if provider.setAuthorizationState == nil {
+		t.Fatal("authorization provider did not receive SetAuthorizationState")
 	}
-	if rawProvider.setAuthorizationState == nil {
-		t.Fatal("raw authorization provider did not receive SetAuthorizationState")
-	}
-	if guardedProvider.setAuthorizationState != nil {
-		t.Fatal("guarded authorization provider unexpectedly received SetAuthorizationState")
-	}
-	if result.Authorization["authz"] != rawProvider {
-		t.Fatal("bootstrapped authorization provider is not the raw runtime authorization provider")
-	}
-	if transportGateway != guardedProvider.transport {
-		t.Fatal("guarded authorization provider was not built with the runtime provider gateway")
+	if result.Authorization["authz"] != provider {
+		t.Fatal("bootstrapped authorization provider is not the runtime authorization provider")
 	}
 }
 

--- a/gestaltd/services/providerdrivers/authorization.go
+++ b/gestaltd/services/providerdrivers/authorization.go
@@ -18,8 +18,7 @@ type AuthorizationDeps struct {
 }
 
 type AuthorizationBuildResult struct {
-	Raw     core.AuthorizationProvider
-	Guarded core.AuthorizationProvider
+	Raw core.AuthorizationProvider
 }
 
 func AuthorizationFactory(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps AuthorizationDeps) (AuthorizationBuildResult, error) {
@@ -67,18 +66,7 @@ func AuthorizationFactory(ctx context.Context, name string, node yaml.Node, host
 		return AuthorizationBuildResult{}, err
 	}
 
-	gatewayTransport := providergateway.NewProviderGatewayTransport()
-	gatewayTransport.SetAuthorizationProvider(raw)
-
-	execCfg.Transport = gatewayTransport
-	guarded, err := authorizationservice.NewFromExecutable(exec, execCfg)
-	if err != nil {
-		_ = exec.Close()
-		return AuthorizationBuildResult{}, err
-	}
-
 	return AuthorizationBuildResult{
-		Raw:     raw,
-		Guarded: guarded,
+		Raw: raw,
 	}, nil
 }


### PR DESCRIPTION
## Summary

The Guarded authorization provider variant added a per-RPC meta-check ("may this subject call `CheckAccess` on `provider/indexeddb`?") in front of every call through the authorization host service. Datadog showed it produced ~129,800 denials / 7d with 28 allows: ~99k because no principal was in context (the authorization host-service ingress never restores one — Authorization is not in `callerCapabilityRequiredServicePrefixes`), ~31k because the model grants nobody access to the Authorization service resource. The broker and public surface already used the Raw (direct) provider; only the authorization host service was on the Guarded path.

This change collapses the Guarded/Raw split: the authorization host service now uses the Raw (DirectTransport) provider, identical to how the broker, public surface, and all other host services (indexeddb, cache, s3) already work. The `ProviderGatewayTransport`, its `Authorize`/`Invoke`/`shadowAuthorizationCheck` methods, the `Transport` interface, `DirectTransport`, all types, and all metrics are **preserved unchanged** for the in-flight PG-1 general-purpose gateway to build on. The public-surface gate (`enforcePublicAuthorization`) is untouched.

## What changed

**`providerdrivers/authorization.go`** — stop building the Guarded variant. Delete the `gatewayTransport` construction and second `NewFromExecutable` call. Return `AuthorizationBuildResult{Raw: raw}` only. Remove the `Guarded` field from `AuthorizationBuildResult`.

```go
// BEFORE
type AuthorizationBuildResult struct {
    Raw     core.AuthorizationProvider
    Guarded core.AuthorizationProvider
}
// builds raw (DirectTransport) + guarded (NewProviderGatewayTransport wrapping raw)
```

```go
// AFTER — single provider; no Guarded variant.
type AuthorizationBuildResult struct {
    Raw core.AuthorizationProvider
}
// builds one provider via NewFromExecutable with DirectTransport; returns {Raw: raw}
```

**`internal/bootstrap/bootstrap.go`** — `deps.Authorization` and `prepared.Authorization` both source from the single Raw map. Remove the `Guarded` field from `authorizationProviderSets`. The error-path close defer now closes the Raw providers (which carry the shared executable lifecycle).

```go
// BEFORE
type authorizationProviderSets struct {
    Raw     map[string]core.AuthorizationProvider
    Guarded map[string]core.AuthorizationProvider
}
// deps.Authorization = selected(Guarded); prepared.Authorization = Raw
```

```go
// AFTER — single map; deps.Authorization and prepared.Authorization resolve to the same instance.
type authorizationProviderSets struct {
    Raw map[string]core.AuthorizationProvider
}
// deps.Authorization = selected(Raw); prepared.Authorization = Raw (same map)
```

## What was NOT changed

- `providergateway/` package (gateway.go, types.go, context.go, metrics.go, public_request.go) — completely untouched. The `Transport` interface, `DirectTransport`, `ProviderGatewayTransport` with `Authorize`/`Invoke`/`shadowAuthorizationCheck`, all request/response types, and all metrics stay for PG-1.
- `rpc/authorization/` (client.go, conn.go) — untouched. The RPC client still uses the `Transport` interface; the Raw provider passes `DirectTransport`.
- `services/authorization/` (client.go, server.go) — untouched. `ExecConfig.Transport` stays.
- `internal/daemon/factories.go` — untouched. `AuthorizationDeps{Transport: deps.ProviderTransport}` stays.
- Public-surface gate (`enforcePublicAuthorization`) — untouched. It already exempts `App.Invoke`/`App.InvokeGraphQL` and gates all other providers.

## Request lifecycle — before

```mermaid
sequenceDiagram
    participant Plugin
    participant Relay as Host-Service Relay
    participant AuthServer as Authorization providerServer
    participant Guarded as Guarded Client
    participant Gateway as ProviderGatewayTransport
    participant IndexedDB as IndexedDB Auth Provider

    Plugin->>Relay: CheckAccess (no caller capability for Authorization)
    Note over Relay: Authorization not in callerCapabilityRequiredServicePrefixes<br/>ApplyCapability does NOT run<br/>principal NOT restored
    Relay->>AuthServer: CheckAccess(ctx)
    AuthServer->>Guarded: provider.CheckAccess(gatewayContext(ctx))
    Guarded->>Gateway: transport.Invoke(ProviderGatewayRequest)
    Gateway->>Gateway: Authorize → shadowAuthorizationCheck → authorizationSubject
    Note over Gateway: principal.FromContext(ctx) == nil<br/>ERROR: "caller principal is required"
    Gateway-->>Guarded: allowed=false
    Guarded-->>AuthServer: error "provider gateway: unauthorized"
    AuthServer-->>Plugin: error "provider gateway: unauthorized"
    Note over Plugin: CheckAccess NEVER reaches IndexedDB provider
```

## Request lifecycle — after

```mermaid
sequenceDiagram
    participant Plugin
    participant Relay as Host-Service Relay
    participant AuthServer as Authorization providerServer
    participant Client as RPC Client (DirectTransport)
    participant IndexedDB as IndexedDB Auth Provider

    Plugin->>Relay: CheckAccess (no caller capability for Authorization)
    Note over Relay: Authorization not in callerCapabilityRequiredServicePrefixes<br/>ApplyCapability does NOT run
    Relay->>AuthServer: CheckAccess(ctx)
    AuthServer->>Client: provider.CheckAccess(gatewayContext(ctx))
    Client->>IndexedDB: transport.Invoke → DirectTransport → next → grpc.CheckAccess
    IndexedDB-->>Client: CheckAccessResponse
    Client-->>AuthServer: CheckAccessResponse
    AuthServer-->>Plugin: CheckAccessResponse
    Note over Plugin: No meta-check. Direct call to IndexedDB provider.<br/>Boundary is the host-service capability ingress (relay token).
```

## Architecture — before

```mermaid
graph TB
    subgraph "AuthorizationFactory"
        AF[AuthorizationFactory]
        AF -->|DirectTransport| Raw[Raw Provider]
        AF -->|NewProviderGatewayTransport<br/>wrapping Raw| Guarded[Guarded Provider]
    end

    subgraph "Bootstrap"
        RawMap[authorizationProviders.Raw]
        GuardedMap[authorizationProviders.Guarded]
        Raw --> RawMap
        Guarded --> GuardedMap
        DepsAuth[deps.Authorization<br/>from Guarded map]
        PreparedAuth[prepared.Authorization<br/>from Raw map]
        GuardedMap --> DepsAuth
        RawMap --> PreparedAuth
    end

    subgraph "Host Services"
        AuthHostSvc[Authorization Host Service<br/>uses Guarded → meta-check]
        DepsAuth --> AuthHostSvc
    end

    subgraph "Other consumers (unchanged)"
        Broker[Broker<br/>uses Raw]
        Public[Public Transport<br/>uses Raw]
        PreparedAuth --> Broker
        PreparedAuth --> Public
    end
```

## Architecture — after

```mermaid
graph TB
    subgraph "AuthorizationFactory"
        AF[AuthorizationFactory]
        AF -->|DirectTransport| Raw[Raw Provider]
    end

    subgraph "Bootstrap"
        RawMap[authorizationProviders.Raw<br/>single map]
        Raw --> RawMap
        DepsAuth[deps.Authorization<br/>from Raw map]
        PreparedAuth[prepared.Authorization<br/>from Raw map]
        RawMap --> DepsAuth
        RawMap --> PreparedAuth
    end

    subgraph "Host Services"
        AuthHostSvc[Authorization Host Service<br/>uses Raw → direct, no meta-check]
        DepsAuth --> AuthHostSvc
    end

    subgraph "Other consumers (unchanged)"
        Broker[Broker<br/>uses Raw]
        Public[Public Transport<br/>uses Raw]
        PreparedAuth --> Broker
        PreparedAuth --> Public
    end

    Note1["No Guarded variant.<br/>ProviderGatewayTransport, Transport interface,<br/>DirectTransport, metrics all preserved<br/>for PG-1 general-purpose gateway."]
```

## Testing

- `go build ./...` and `go test ./...` pass clean.
- Updated `authorization_bootstrap_test.go`: removed `providers.Guarded` assertion; factory stub returns `{Raw: provider}`.
- Updated `bootstrap_test.go`: `TestBootstrapAuthorizationProviderStateUsesProviderGatewayTransport` builds one provider (`len(built) == 1`), asserts `result.Authorization["authz"]` is that provider with `DirectTransport`.
- `providergateway/` tests unchanged (package untouched).

## Relationship to other PRs

- Supersedes **PR #2848** (`codex/pg-workflow-raw-provider`), which added `AuthorizationInternal` (Raw) alongside `Authorization` (Guarded) — fixing only the workflow host service. This PR collapses the split entirely, fixing both the workflow and authorization host services.
- **PR #2857** (closed) was too aggressive — it deleted the `Transport` interface, `DirectTransport`, types, and metrics that PG-1 needs. This PR preserves all of them.
- **PG-1** (`cursor/pg1-providergateway-direct-route-fa45`, in-flight) introduces a general-purpose ProviderGateway that gates all provider kinds. This PR is compatible: the `ProviderGatewayTransport` and all types PG-1 depends on are preserved.

## Metrics impact

`gestaltd.provider_gateway.authorization.count` and `gestaltd.provider_gateway.operation.*` metrics continue to emit from the `DirectTransport` path (they record all transport operations, not just the Guarded meta-check). The denials attributed to the Guarded meta-check path will drop to zero.

## Release caveat

This change does NOT make a gestaltd release safe by itself — the public-surface `enforcePublicAuthorization` path (unchanged here) still hard-enforces on post-#2820 builds, and the model grants almost nobody access. The approved kill-switch (`server.providerGateway.enforcement: shadow|enforce`, separate branch) gates that path and composes cleanly with this change.
