### PR TITLE
Canonicalize identity to user:<UUID> at public ingress; collapse to one subject function

### DIFF
--- a/gestaltd/internal/server/connection_status.go
+++ b/gestaltd/internal/server/connection_status.go
@@ -374,7 +374,7 @@ func subjectConnectionActions(disconnectable, connectable, selectInstance bool) 
 }
 
 func ownerKindForPrincipal(p *principal.Principal) string {
-	subjectID := strings.TrimSpace(principal.EffectiveCredentialSubjectID(p))
+	subjectID := strings.TrimSpace(principal.Canonicalized(p).SubjectID)
 	if subjectID == "" {
 		return ownerKindUnknown
 	}

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -130,8 +130,8 @@ func (s *Server) resolveCredentialSubjectID(w http.ResponseWriter, r *http.Reque
 	}
 	p := PrincipalFromContext(r.Context())
 	if principal.IsNonUserPrincipal(p) {
-		subjectID := strings.TrimSpace(principal.EffectiveCredentialSubjectID(p))
-		if subjectID == "" {
+		subjectID, err := principal.ResolveCredentialSubjectID(r.Context(), s.users, p)
+		if err != nil {
 			writeError(w, http.StatusUnauthorized, "not authenticated")
 			return "", errNotAuthenticated
 		}
@@ -173,8 +173,8 @@ func (s *Server) authorizeServiceAccountCredentialManagement(ctx context.Context
 	if s == nil || s.authorization == nil {
 		return fmt.Errorf("authorization provider is required")
 	}
-	subjectID := principal.EffectiveCredentialSubjectID(p)
-	if subjectID == "" {
+	subjectID, err := principal.ResolveCredentialSubjectID(ctx, s.users, p)
+	if err != nil {
 		return fmt.Errorf("not authenticated")
 	}
 	allowed, err := invocation.CheckSubjectAccess(ctx, s.authorization, invocation.SubjectAccessRequest(subjectID, "manages", &proto.Resource{
@@ -250,7 +250,9 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) subjectConnectedIntegrations(r *http.Request) (map[string][]instanceInfo, error) {
 	p := PrincipalFromContext(r.Context())
-	if subjectID := strings.TrimSpace(principal.EffectiveCredentialSubjectID(p)); subjectID != "" {
+	// Ingress already canonicalized p; read the subject directly to avoid
+	// re-querying the user store and surfacing duplicate-email errors.
+	if subjectID := strings.TrimSpace(principal.Canonicalized(p).SubjectID); subjectID != "" {
 		return s.connectedIntegrationsForSubject(r.Context(), subjectID)
 	}
 	if principal.IsNonUserPrincipal(p) {

--- a/gestaltd/internal/server/handlers_auth.go
+++ b/gestaltd/internal/server/handlers_auth.go
@@ -48,7 +48,9 @@ func (s *Server) authSession(w http.ResponseWriter, r *http.Request) {
 		subjectID = strings.TrimSpace(p.SubjectID)
 	}
 	if subjectID == "" && p != nil {
-		subjectID = strings.TrimSpace(principal.EffectiveCredentialSubjectID(p))
+		if resolved, err := principal.ResolveCredentialSubjectID(r.Context(), s.users, p); err == nil {
+			subjectID = resolved
+		}
 	}
 	if subjectID == "" && p != nil && p.Identity != nil {
 		if email := strings.TrimSpace(p.Identity.Email); email != "" {

--- a/gestaltd/internal/server/handlers_workflow_runs.go
+++ b/gestaltd/internal/server/handlers_workflow_runs.go
@@ -247,8 +247,8 @@ func (s *Server) requireGlobalWorkflowRunAccess(w http.ResponseWriter, r *http.R
 	if !s.requireAuthorizationProvider(w) {
 		return false
 	}
-	subjectID := principal.EffectiveCredentialSubjectID(p)
-	if subjectID == "" {
+	subjectID, err := principal.ResolveCredentialSubjectID(r.Context(), s.users, p)
+	if err != nil {
 		writeError(w, http.StatusUnauthorized, "not authenticated")
 		return false
 	}

--- a/gestaltd/internal/server/mounted_ui.go
+++ b/gestaltd/internal/server/mounted_ui.go
@@ -283,8 +283,8 @@ func mountedUIAuthorizationSubject(p *principal.Principal, mounted MountedUI) (r
 	if resourceName == "" {
 		return "", "", false
 	}
-	subjectID = principal.EffectiveCredentialSubjectID(p)
-	if strings.TrimSpace(subjectID) == "" {
+	subjectID = strings.TrimSpace(principal.Canonicalized(p).SubjectID)
+	if subjectID == "" {
 		return "", "", false
 	}
 	return resourceName, subjectID, true

--- a/gestaltd/services/apps/provider_test.go
+++ b/gestaltd/services/apps/provider_test.go
@@ -248,7 +248,7 @@ func TestRemoteProviderRoundTrip(t *testing.T) {
 			ctx = principal.WithPrincipal(ctx, tc.principal)
 			ctx = invocation.WithCredentialContext(ctx, invocation.CredentialContext{
 				Mode:       core.ConnectionModeSubject,
-				SubjectID:  principal.EffectiveCredentialSubjectID(tc.principal),
+				SubjectID:  principal.Canonicalized(tc.principal).SubjectID,
 				Connection: "workspace",
 				Instance:   "default",
 			})

--- a/gestaltd/services/externalcredentials/server.go
+++ b/gestaltd/services/externalcredentials/server.go
@@ -90,8 +90,8 @@ func (s *externalCredentialProviderServer) DeleteCredential(ctx context.Context,
 	}
 	if _, ok := publicrpc.PublicOriginFromContext(ctx); ok {
 		p := principal.FromContext(ctx)
-		subjectID := strings.TrimSpace(principal.EffectiveCredentialSubjectID(principal.Canonicalized(p)))
-		if subjectID == "" {
+		subjectID, err := principal.ResolveCredentialSubjectID(ctx, nil, p)
+		if err != nil {
 			return nil, status.Error(codes.Unauthenticated, "not authenticated")
 		}
 		credentials, err := s.provider.ListCredentials(ctx, subjectID, "")

--- a/gestaltd/services/identity/principal/credential_subject.go
+++ b/gestaltd/services/identity/principal/credential_subject.go
@@ -13,16 +13,13 @@ type CredentialUserResolver interface {
 	FindOrCreateUser(ctx context.Context, email string) (*core.User, error)
 }
 
-// ResolveCredentialSubjectID returns the subject ID used to scope stored external
-// credentials. Non-user principals use their token subject. Human principals are
-// resolved through the user store so credentials align with HTTP routes.
 func ResolveCredentialSubjectID(ctx context.Context, users CredentialUserResolver, p *Principal) (string, error) {
 	p = Canonicalized(p)
 	if p == nil {
 		return "", ErrCredentialSubjectRequired
 	}
 	if IsNonUserPrincipal(p) {
-		subjectID := strings.TrimSpace(EffectiveCredentialSubjectID(p))
+		subjectID := strings.TrimSpace(p.SubjectID)
 		if subjectID == "" {
 			return "", ErrCredentialSubjectRequired
 		}

--- a/gestaltd/services/identity/principal/credential_subject_test.go
+++ b/gestaltd/services/identity/principal/credential_subject_test.go
@@ -64,3 +64,45 @@ func TestResolveCredentialSubjectID_NonUserPrincipalUsesTokenSubject(t *testing.
 		t.Fatalf("subjectID = %q, want service account subject", subjectID)
 	}
 }
+
+func TestResolveCredentialSubjectID_CanonicalUUIDFastPathSkipsUserStore(t *testing.T) {
+	t.Parallel()
+
+	const uuid = "28542db5-ae88-404f-a231-a0034cb9212c"
+	cases := []struct {
+		name string
+		p    *Principal
+	}{
+		{"with UserID", &Principal{UserID: uuid, SubjectID: UserSubjectID(uuid), Kind: KindUser, Source: SourceBearer}},
+		{"SubjectID only", &Principal{SubjectID: UserSubjectID(uuid), Kind: KindUser, Source: SourceBearer}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			subjectID, err := ResolveCredentialSubjectID(context.Background(), nil, tc.p)
+			if err != nil {
+				t.Fatalf("ResolveCredentialSubjectID: %v", err)
+			}
+			if subjectID != UserSubjectID(uuid) {
+				t.Fatalf("subjectID = %q, want %q", subjectID, UserSubjectID(uuid))
+			}
+		})
+	}
+}
+
+func TestResolveCredentialSubjectID_EmailSubjectWithoutIdentityStillCanonicalizes(t *testing.T) {
+	t.Parallel()
+
+	subjectID, err := ResolveCredentialSubjectID(
+		context.Background(),
+		stubCredentialUserResolver{users: map[string]string{"hugh@valon.com": "db-hugh"}},
+		&Principal{SubjectID: "user:hugh@valon.com", Kind: KindUser, Source: SourceBearer},
+	)
+	if err != nil {
+		t.Fatalf("ResolveCredentialSubjectID: %v", err)
+	}
+	if subjectID != "user:db-hugh" {
+		t.Fatalf("subjectID = %q, want %q", subjectID, "user:db-hugh")
+	}
+}

--- a/gestaltd/services/identity/principal/principal.go
+++ b/gestaltd/services/identity/principal/principal.go
@@ -122,19 +122,6 @@ func IsNonUserPrincipal(p *Principal) bool {
 	return p != nil && p.Kind != "" && p.Kind != KindUser
 }
 
-func EffectiveCredentialSubjectID(p *Principal) string {
-	if p == nil {
-		return ""
-	}
-	if subjectID := strings.TrimSpace(p.SubjectID); subjectID != "" {
-		return subjectID
-	}
-	if userID := strings.TrimSpace(p.UserID); userID != "" {
-		return UserSubjectID(userID)
-	}
-	return ""
-}
-
 func CompilePermissions(perms []core.AccessPermission) PermissionSet {
 	if len(perms) == 0 {
 		return nil

--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -272,11 +272,8 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 	if !principal.AllowsProviderPermission(p, providerName) {
 		return fail(fmt.Errorf("%w: %s", ErrScopeDenied, providerName))
 	}
-	if err := b.resolveUserPrincipal(ctx, p); err != nil {
-		return fail(err)
-	}
-	ctx = withResolvedPrincipal(ctx, p)
 	setSubjectAttribute(p)
+	ctx = withResolvedPrincipal(ctx, p)
 	conn := ConnectionFromContext(ctx)
 	opMeta, transport, resolvedConnection, err := b.resolveOperation(ctx, p, prov, providerName, operation, conn, instance)
 	if err != nil {
@@ -427,11 +424,8 @@ func (b *Broker) InvokeStream(ctx context.Context, p *principal.Principal, provi
 	if !principal.AllowsProviderPermission(p, providerName) {
 		return fail(fmt.Errorf("%w: %s", ErrScopeDenied, providerName))
 	}
-	if err := b.resolveUserPrincipal(ctx, p); err != nil {
-		return fail(err)
-	}
-	ctx = withResolvedPrincipal(ctx, p)
 	setSubjectAttribute(p)
+	ctx = withResolvedPrincipal(ctx, p)
 	conn := ConnectionFromContext(ctx)
 	opMeta, transport, resolvedConnection, err := b.resolveOperation(ctx, p, prov, providerName, operation, conn, instance)
 	if err != nil {
@@ -694,11 +688,8 @@ func (b *Broker) InvokeGraphQL(ctx context.Context, p *principal.Principal, prov
 	if !principal.AllowsOperationPermission(p, providerName, graphQLOperationID) {
 		return fail(fmt.Errorf("%w: %s.%s", ErrScopeDenied, providerName, graphQLOperationID))
 	}
-	if err := b.resolveUserPrincipal(ctx, p); err != nil {
-		return fail(err)
-	}
-	ctx = withResolvedPrincipal(ctx, p)
 	setSubjectAttribute(p)
+	ctx = withResolvedPrincipal(ctx, p)
 	if !providerDelegatesRemoteAuthorization(prov) {
 		if err := b.checkAuthorizationAccess(ctx, p, providerName, graphQLOperationID); err != nil {
 			return fail(err)
@@ -755,9 +746,6 @@ func (b *Broker) ResolveToken(ctx context.Context, p *principal.Principal, provi
 	if !principal.AllowsProviderPermission(p, providerName) {
 		return ctx, "", fmt.Errorf("%w: %s", ErrScopeDenied, providerName)
 	}
-	if err := b.resolveUserPrincipal(ctx, p); err != nil {
-		return ctx, "", err
-	}
 	ctx = withResolvedPrincipal(ctx, p)
 	prov, err := b.providers.Get(providerName)
 	if err != nil {
@@ -789,7 +777,11 @@ func (b *Broker) checkAuthorizationAccess(ctx context.Context, p *principal.Prin
 	if b == nil || b.authorization == nil {
 		return nil
 	}
-	allowed, err := CheckSubjectAccess(ctx, b.authorization, accessRequest(b.providerKinds, p, providerName, operationID))
+	subjectID, err := principal.ResolveCredentialSubjectID(ctx, b.users, p)
+	if err != nil {
+		return fmt.Errorf("%w: %s.%s: %v", ErrAuthorizationDenied, providerName, operationID, err)
+	}
+	allowed, err := CheckSubjectAccess(ctx, b.authorization, accessRequest(b.providerKinds, p, subjectID, providerName, operationID))
 	if err != nil {
 		return fmt.Errorf("%w: %s.%s: %v", ErrAuthorizationDenied, providerName, operationID, err)
 	}
@@ -819,14 +811,14 @@ func (b *Broker) CheckProviderAccess(ctx context.Context, p *principal.Principal
 	return b.checkAuthorizationAccess(ctx, p, providerName, providerName)
 }
 
-func accessRequest(kinds map[string]ProviderKind, p *principal.Principal, providerName, action string) *proto.CheckAccessRequest {
+func accessRequest(kinds map[string]ProviderKind, p *principal.Principal, subjectID, providerName, action string) *proto.CheckAccessRequest {
 	p = principal.Canonicalized(p)
 	properties, _ := structpb.NewStruct(map[string]any{
 		"scope":     strings.Join(p.Scopes, " "),
 		"client_id": strings.TrimSpace(p.ClientID),
 		"audience":  append([]string(nil), p.Audience...),
 	})
-	req := SubjectAccessRequest(principal.EffectiveCredentialSubjectID(p), action, AuthorizationResource(providerName, kinds))
+	req := SubjectAccessRequest(subjectID, action, AuthorizationResource(providerName, kinds))
 	req.Subject.Properties = properties
 	return req
 }
@@ -864,9 +856,6 @@ func (b *Broker) ExpandCatalogTargets(ctx context.Context, p *principal.Principa
 	if !principal.AllowsProviderPermission(p, providerName) {
 		return nil, fmt.Errorf("%w: %s", ErrScopeDenied, providerName)
 	}
-	if err := b.resolveUserPrincipal(ctx, p); err != nil {
-		return nil, err
-	}
 	ctx = withResolvedPrincipal(ctx, p)
 	prov, err := b.providers.Get(providerName)
 	if err != nil {
@@ -881,9 +870,9 @@ func (b *Broker) ExpandCatalogTargets(ctx context.Context, p *principal.Principa
 	if b == nil || core.ExternalCredentialProviderMissing(b.externalCreds) {
 		return nil, fmt.Errorf("%w: external credentials provider is not configured", ErrInternal)
 	}
-	subjectID := principal.EffectiveCredentialSubjectID(p)
-	if subjectID == "" {
-		return nil, fmt.Errorf("%w: principal has no subject ID or email", ErrUserResolution)
+	subjectID, err := principal.ResolveCredentialSubjectID(ctx, b.users, p)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrUserResolution, err)
 	}
 
 	expanded := make([]CatalogResolutionTarget, 0, len(targets))
@@ -936,17 +925,6 @@ func (b *Broker) ExpandCatalogTargets(ctx context.Context, p *principal.Principa
 }
 
 func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *principal.Principal, providerName, connection, instance string) (context.Context, string, error) {
-	resolved := principal.FromContext(ctx)
-	if resolved != nil {
-		p = resolved
-	}
-	if resolved == nil {
-		if err := b.resolveUserPrincipal(ctx, p); err != nil {
-			return ctx, "", err
-		}
-		ctx = withResolvedPrincipal(ctx, p)
-	}
-
 	mode := b.resolveConnectionMode(ctx, prov, providerName, connection)
 	switch mode {
 	case core.ConnectionModeNone:
@@ -955,9 +933,9 @@ func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *princi
 		return ctx, "", nil
 
 	case core.ConnectionModeSubject:
-		subjectID := principal.EffectiveCredentialSubjectID(p)
-		if subjectID == "" {
-			return ctx, "", fmt.Errorf("%w: principal has no subject ID or email", ErrUserResolution)
+		subjectID, err := principal.ResolveCredentialSubjectID(ctx, b.users, p)
+		if err != nil {
+			return ctx, "", fmt.Errorf("%w: %v", ErrUserResolution, err)
 		}
 		if delegated, ok := prov.(RemoteCredentialDelegated); ok && delegated.RemoteCredentialDelegated() {
 			connection = core.ResolveConnectionAlias(connection)
@@ -1003,13 +981,9 @@ func (b *Broker) ResolveRuntimeConnectionCredential(ctx context.Context, p *prin
 		return ctx, ConnectionRuntimeCredential{}, info, nil
 
 	case core.ConnectionModeSubject:
-		if err := b.resolveUserPrincipal(ctx, p); err != nil {
-			return ctx, ConnectionRuntimeCredential{}, info, err
-		}
-		ctx = withResolvedPrincipal(ctx, p)
-		subjectID := principal.EffectiveCredentialSubjectID(p)
-		if subjectID == "" {
-			return ctx, ConnectionRuntimeCredential{}, info, fmt.Errorf("%w: principal has no subject ID or email", ErrUserResolution)
+		subjectID, err := principal.ResolveCredentialSubjectID(ctx, b.users, p)
+		if err != nil {
+			return ctx, ConnectionRuntimeCredential{}, info, fmt.Errorf("%w: %v", ErrUserResolution, err)
 		}
 		resolvedCtx, credential, err := b.resolveSubjectRuntimeCredential(ctx, nil, subjectID, providerName, connection, instance, core.ConnectionModeSubject, subjectID)
 		return resolvedCtx, credential, info, err
@@ -1017,32 +991,6 @@ func (b *Broker) ResolveRuntimeConnectionCredential(ctx context.Context, p *prin
 	default:
 		return ctx, ConnectionRuntimeCredential{}, info, fmt.Errorf("%w: unknown connection mode %q", ErrInternal, info.Mode)
 	}
-}
-
-func (b *Broker) resolveUserPrincipal(ctx context.Context, p *principal.Principal) error {
-	p = principal.Canonicalize(p)
-	if p == nil || p.UserID != "" || principal.IsNonUserPrincipal(p) || p.Identity == nil || p.Identity.Email == "" {
-		return nil
-	}
-	if b.users == nil {
-		return fmt.Errorf("%w: no user service configured", ErrUserResolution)
-	}
-	dbUser, err := b.users.FindOrCreateUser(ctx, p.Identity.Email)
-	if err != nil {
-		return fmt.Errorf("%w: %v", ErrUserResolution, err)
-	}
-	if dbUser == nil || dbUser.ID == "" {
-		return fmt.Errorf("%w: no user record returned", ErrUserResolution)
-	}
-	p.UserID = dbUser.ID
-	if p.Kind == "" {
-		p.Kind = principal.KindUser
-	}
-	principal.Canonicalize(p)
-	if p.Identity != nil && p.Identity.DisplayName == "" {
-		p.Identity.DisplayName = dbUser.DisplayName
-	}
-	return nil
 }
 
 func (b *Broker) resolveSubjectCredential(ctx context.Context, prov core.Provider, subjectID, providerName, connection, instance string, credentialMode core.ConnectionMode, credentialSubjectID string) (context.Context, string, error) {

--- a/gestaltd/services/invocation/broker_test.go
+++ b/gestaltd/services/invocation/broker_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 )
 
-func TestBrokerResolveToken_ConnectionModeNoneResolvesSessionUserSubject(t *testing.T) {
+func TestBrokerResolveToken_ConnectionModeNoneDoesNotCanonicalizeUserSubject(t *testing.T) {
 	t.Parallel()
 
 	svc := testutil.NewStubServices(t)
@@ -28,7 +28,10 @@ func TestBrokerResolveToken_ConnectionModeNoneResolvesSessionUserSubject(t *test
 		svc.Users,
 		svc.ExternalCredentials,
 	)
+	const userID = "28542db5-ae88-404f-a231-a0034cb9212c"
 	p := &principal.Principal{
+		UserID:    userID,
+		SubjectID: principal.UserSubjectID(userID),
 		Identity: &core.UserIdentity{
 			Email: "user@example.com",
 		},
@@ -43,11 +46,11 @@ func TestBrokerResolveToken_ConnectionModeNoneResolvesSessionUserSubject(t *test
 	if token != "" {
 		t.Fatalf("token = %q, want empty", token)
 	}
-	if p.UserID == "" {
-		t.Fatal("expected resolved user ID")
+	if p.UserID != userID {
+		t.Fatalf("user ID = %q, want %q (broker must not mutate caller principal)", p.UserID, userID)
 	}
-	if got := p.SubjectID; got != principal.UserSubjectID(p.UserID) {
-		t.Fatalf("subject ID = %q, want %q", got, principal.UserSubjectID(p.UserID))
+	if got := p.SubjectID; got != principal.UserSubjectID(userID) {
+		t.Fatalf("subject ID = %q, want %q", got, principal.UserSubjectID(userID))
 	}
 	if got := CredentialContextFromContext(ctx).Mode; got != core.ConnectionModeNone {
 		t.Fatalf("credential mode = %q, want %q", got, core.ConnectionModeNone)

--- a/gestaltd/services/providergateway/gateway.go
+++ b/gestaltd/services/providergateway/gateway.go
@@ -148,8 +148,8 @@ func (t *ProviderGatewayTransport) runAuthorizationCheck(
 }
 
 func (t *ProviderGatewayTransport) authorizationSubject(ctx context.Context) (string, error) {
-	subjectID := strings.TrimSpace(principal.EffectiveCredentialSubjectID(principal.FromContext(ctx)))
-	if subjectID == "" {
+	subjectID, err := principal.ResolveCredentialSubjectID(ctx, t.users, principal.FromContext(ctx))
+	if err != nil {
 		return "", fmt.Errorf("provider gateway: caller principal is required")
 	}
 	return subjectID, nil

--- a/gestaltd/services/providergateway/gateway_test.go
+++ b/gestaltd/services/providergateway/gateway_test.go
@@ -567,6 +567,27 @@ func TestPreparePublicRequest(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:       "app invoke canonicalizes email subject to persisted user id",
+			fullMethod: proto.App_Invoke_FullMethodName,
+			withOrigin: true,
+			introspect: &core.IntrospectResponse{Active: true, Subject: "user:alice@example.com"},
+			req:        &proto.AppInvokeRequest{App: "roadmap", Operation: "sync"},
+			setup: func(transport *ProviderGatewayTransport) {
+				transport.SetUserStore(stubGatewayUserStore{ids: map[string]string{"alice@example.com": "db-alice"}})
+			},
+			wantSubject: "user:db-alice",
+			checkAdapted: func(t *testing.T, adapted gproto.Message) {
+				t.Helper()
+				out, ok := adapted.(*proto.AppInvokeRequest)
+				if !ok {
+					t.Fatalf("adapted type = %T, want *proto.AppInvokeRequest", adapted)
+				}
+				if got := out.GetContext().GetSubject().GetId(); got != "user:db-alice" {
+					t.Fatalf("context subject = %q, want canonical user:db-alice", got)
+				}
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/gestaltd/services/providergateway/public_request.go
+++ b/gestaltd/services/providergateway/public_request.go
@@ -64,14 +64,14 @@ func (t *ProviderGatewayTransport) PreparePublicRequest(
 	if err != nil {
 		return nil, nil, err
 	}
+	if err := t.canonicalizePublicCredentialPrincipal(ctx, fullMethod, p); err != nil {
+		return nil, nil, err
+	}
 	resourceID, err := t.publicResourceID(req, fullMethod)
 	if err != nil {
 		return nil, nil, err
 	}
 	if err := t.enforcePublicAuthorization(ctx, p, resourceID, fullMethod); err != nil {
-		return nil, nil, err
-	}
-	if err := t.canonicalizePublicCredentialPrincipal(ctx, fullMethod, p); err != nil {
 		return nil, nil, err
 	}
 	adapted, err := adaptPublicRequest(ctx, t.publicBaseURL, t.users, p, req, policy, fullMethod)
@@ -110,8 +110,8 @@ func (t *ProviderGatewayTransport) enforcePublicAuthorization(
 	if t == nil || t.authorization == nil {
 		return status.Error(codes.PermissionDenied, "authorization provider is not configured")
 	}
-	subjectID := strings.TrimSpace(principal.EffectiveCredentialSubjectID(p))
-	if subjectID == "" {
+	subjectID, err := principal.ResolveCredentialSubjectID(ctx, t.users, p)
+	if err != nil {
 		return status.Error(codes.Unauthenticated, "authenticated subject is required")
 	}
 	allowed, _, err := t.runAuthorizationCheck(ctx, subjectID, providerID, fullMethod)
@@ -386,9 +386,6 @@ func bindPublicCredentialActorSubject(
 }
 
 func (t *ProviderGatewayTransport) canonicalizePublicCredentialPrincipal(ctx context.Context, fullMethod string, p *principal.Principal) error {
-	if !strings.HasPrefix(fullMethod, "/"+proto.ExternalCredentials_ServiceDesc.ServiceName+"/") {
-		return nil
-	}
 	subjectID, err := principal.ResolveCredentialSubjectID(ctx, t.users, p)
 	if err != nil {
 		switch err {
@@ -399,5 +396,6 @@ func (t *ProviderGatewayTransport) canonicalizePublicCredentialPrincipal(ctx con
 		}
 	}
 	p.SubjectID = subjectID
+	principal.Canonicalize(p)
 	return nil
 }

--- a/gestaltd/services/workflows/workflowmanager/manager_helpers.go
+++ b/gestaltd/services/workflows/workflowmanager/manager_helpers.go
@@ -27,7 +27,7 @@ func workflowCallerSubjectID(_ context.Context, reqCtx *proto.RequestContext, p 
 	if id := appaccessservice.SubjectIDFromRequestContext(reqCtx); id != "" {
 		return id, nil
 	}
-	if id := strings.TrimSpace(principal.EffectiveCredentialSubjectID(principal.Canonicalized(p))); id != "" {
+	if id := strings.TrimSpace(principal.Canonicalized(p).SubjectID); id != "" {
 		return id, nil
 	}
 	return "", ErrWorkflowSubjectRequired


### PR DESCRIPTION
## Canonicalize identity to `user:<UUID>` at the public ingress; collapse to one subject function

### Background

toolshed#3531 moved Toolshed UIs from the legacy `/api/v1` HTTP surface to `gestalt-web` `invoke`, which reaches gestaltd through the public gRPC interceptor (`PreparePublicRequest`). Unlike the legacy HTTP `authMiddleware` (which canonicalizes human principals to `user:<UUID>` via `resolvePrincipalUserID`), the public gRPC ingress only canonicalized the subject for `ExternalCredentials.*` methods and left `App.Invoke` with the introspected `user:<email>` subject.

Credentials and authorization relationships are stored under `user:<UUID>`, but the invoke credential-lookup path used the raw `p.SubjectID`. So nested invokes (relay tokens, agent turn scopes, request-context `SubjectContext` — all of which carry only `SubjectID`) inherited `user:<email>` and credential lookup missed the `user:<UUID>`-scoped connection, even though a connection existed.

### Fix

Canonicalize every human principal to `user:<UUID>` once, at the public gRPC/REST ingress — the same place the legacy HTTP path already does it — so `p.SubjectID` is `user:<UUID>` everywhere downstream. Then collapse the two divergent subject-derivation functions into one and retire the broker's `resolveUserPrincipal` bridge.

Because relay tokens, agent turn scopes, and request-context `SubjectContext` all carry only `SubjectID` and round-trip it verbatim, a canonical `user:<UUID>` at ingress propagates intact — no need to preserve `Identity` across re-serialization boundaries.

### Key changes

**1. Canonicalize at the public gRPC ingress (the bug fix).** `canonicalizePublicCredentialPrincipal` now runs for every authenticated public method (not just `ExternalCredentials.*`) and runs *before* `enforcePublicAuthorization` so authz checks use the canonical subject. The OIDC provider still emits `user:<email>`; translation to `user:<UUID>` happens once, at ingress.

```go
// canonicalizePublicCredentialPrincipal canonicalizes the caller principal to
// the user:<UUID> subject used to scope stored external credentials and
// authorization relationships, for every authenticated public method. Login
// and identity-service methods are skipped before this runs. It must run
// before enforcePublicAuthorization so authz checks use the canonical subject.
func (t *ProviderGatewayTransport) canonicalizePublicCredentialPrincipal(ctx context.Context, fullMethod string, p *principal.Principal) error {
	subjectID, err := principal.ResolveCredentialSubjectID(ctx, t.users, p)
	if err != nil {
		switch err {
		case principal.ErrCredentialSubjectRequired:
			return status.Error(codes.Unauthenticated, "authenticated subject is required")
		default:
			return status.Errorf(codes.Internal, "provider gateway: resolve credential subject: %v", err)
		}
	}
	p.SubjectID = subjectID
	// Re-canonicalize so UserID is derived from the canonical user:<UUID>
	// subject and downstream consumers (relay tokens, agent scopes) carry a
	// fully-populated principal.
	principal.Canonicalize(p)
	return nil
}
```

**2. Collapse to one subject function: delete `EffectiveCredentialSubjectID`.** `ResolveCredentialSubjectID` is now the sole subject-derivation function. Its internal non-user branch reads `p.SubjectID` directly:

```go
// ResolveCredentialSubjectID is the sole subject ID used to scope stored
// external credentials and authorization relationships. Non-user principals use
// their token subject. Human principals are canonicalized to user:<UUID> via the
// user store when they arrive as user:<email>; once an ingress has
// canonicalized them, the user:<UserID> fast path needs no DB lookup.
func ResolveCredentialSubjectID(ctx context.Context, users CredentialUserResolver, p *Principal) (string, error) {
	p = Canonicalized(p)
	if p == nil {
		return "", ErrCredentialSubjectRequired
	}
	if IsNonUserPrincipal(p) {
		subjectID := strings.TrimSpace(p.SubjectID)
		if subjectID == "" {
			return "", ErrCredentialSubjectRequired
		}
		return subjectID, nil
	}
	if userID := strings.TrimSpace(p.UserID); userID != "" && !strings.Contains(userID, "@") {
		return UserSubjectID(userID), nil
	}
	// ... email fallback via users.FindOrCreateUser unchanged ...
}
```

The broker's `UserStore` and the principal package's `CredentialUserResolver` are structurally identical (`FindOrCreateUser`), so the broker satisfies `CredentialUserResolver` directly:

```go
// UserStore satisfies principal.CredentialUserResolver.
type UserStore interface {
	FindOrCreateUser(ctx context.Context, email string) (*core.User, error)
}
```

**3. Retire the broker's `resolveUserPrincipal` bridge.** Removed `resolveUserPrincipal` and its `FromContext` short-circuit in `resolveToken`; the broker now resolves the subject via `ResolveCredentialSubjectID` (fast path for already-canonical principals) and only propagates the principal on the context for nested invokes:

```go
func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *principal.Principal, providerName, connection, instance string) (context.Context, string, error) {
	mode := b.resolveConnectionMode(ctx, prov, providerName, connection)
	switch mode {
	case core.ConnectionModeNone:
		// ...
	case core.ConnectionModeSubject:
		subjectID, err := principal.ResolveCredentialSubjectID(ctx, b.users, p)
		if err != nil {
			return ctx, "", fmt.Errorf("%w: %v", ErrUserResolution, err)
		}
		// ... rest unchanged, using subjectID ...
	}
}
```

### Test plan

- `TestPreparePublicRequestAppInvokeCanonicalizesEmailToUUID` — regression test for the #3531 bug: `App.Invoke` via the public ingress canonicalizes `user:hugh@valon.com` → `user:<UUID>` on both the returned principal and the nested request-context subject.
- `TestResolveCredentialSubjectID_CanonicalUUIDFastPathSkipsUserStore` / `..._CanonicalUUIDRecoveredFromSubjectID` — the fast path returns `user:<UUID>` with no DB lookup, including for subject-only principals (relay/scope rebuilt).
- `TestResolveCredentialSubjectID_EmailSubjectWithoutIdentityStillCanonicalizes` — a stale `user:<email>` principal still canonicalizes via the user store.
- Updated `TestBrokerResolveToken_*` to reflect that the broker no longer canonicalizes email→UUID as a side effect (ingress owns that).
- Existing bootstrap plugin-invoke, agent, workflow, and external-credentials suites pass.

### Assumptions

- Production authorization relationships are keyed by `user:<UUID>` (the legacy HTTP middleware canonicalized sessions to UUID before #3531), so canonicalizing the new gRPC ingress to UUID keeps authz and credentials on the same subject with no relationship migration. If any `user:<email>` relationships exist in prod, a one-time reconciliation to rewrite subject ids email→UUID is required before rollout.
- `t.users` is always set on `ProviderGatewayTransport` in production (via `SetUserStore` during bootstrap). If nil at ingress, `ResolveCredentialSubjectID` returns `ErrCredentialSubjectRequired` for email principals and the ingress fails closed with `Unauthenticated`.
