### PR TITLE
Remove unused gestaltd server test helpers blocking CI lint

### DIFF
--- a/gestaltd/internal/server/agent_test_helpers_test.go
+++ b/gestaltd/internal/server/agent_test_helpers_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 	"sync"
-	"testing"
 	"time"
 
 	"github.com/google/uuid"

--- a/gestaltd/internal/server/agent_test_helpers_test.go
+++ b/gestaltd/internal/server/agent_test_helpers_test.go
@@ -259,53 +259,6 @@ func (p *memoryAgentProvider) CreateTurn(_ context.Context, req *proto.CreateAge
 	return cloneTurn(turn), nil
 }
 
-func (p *memoryAgentProvider) capturedGetSessionRequests() []*proto.GetAgentProviderSessionRequest {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	return append([]*proto.GetAgentProviderSessionRequest(nil), p.getSessionRequests...)
-}
-
-func (p *memoryAgentProvider) capturedTurnRequests() []*proto.CreateAgentProviderTurnRequest {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	out := make([]*proto.CreateAgentProviderTurnRequest, 0, len(p.turnRequests))
-	for _, req := range p.turnRequests {
-		out = append(out, cloneCreateTurnRequest(req))
-	}
-	return out
-}
-
-func (p *memoryAgentProvider) capturedGetTurnRequests() []*proto.GetAgentProviderTurnRequest {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	return append([]*proto.GetAgentProviderTurnRequest(nil), p.getTurnRequests...)
-}
-
-func (p *memoryAgentProvider) capturedListSessionRequests() []*proto.ListAgentProviderSessionsRequest {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	out := make([]*proto.ListAgentProviderSessionsRequest, 0, len(p.listSessionRequests))
-	for _, req := range p.listSessionRequests {
-		out = append(out, cloneListSessionsRequest(req))
-	}
-	return out
-}
-
-func (p *memoryAgentProvider) capturedListTurnRequests() []*proto.ListAgentProviderTurnsRequest {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	out := make([]*proto.ListAgentProviderTurnsRequest, 0, len(p.listTurnRequests))
-	for _, req := range p.listTurnRequests {
-		out = append(out, cloneListTurnsRequest(req))
-	}
-	return out
-}
-
 func (p *memoryAgentProvider) GetTurn(_ context.Context, req *proto.GetAgentProviderTurnRequest) (*coreagent.Turn, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -604,35 +557,4 @@ func cloneInteraction(src *coreagent.Interaction) *coreagent.Interaction {
 	dst.Request = cloneMap(src.Request)
 	dst.Resolution = cloneMap(src.Resolution)
 	return &dst
-}
-
-func assertHTTPAgentEventDisplay(t *testing.T, event map[string]any, kind, phase, label, text string) {
-	t.Helper()
-	display, ok := event["display"].(map[string]any)
-	if !ok {
-		t.Fatalf("event display = %#v, want object", event["display"])
-	}
-	if display["kind"] != kind {
-		t.Fatalf("display kind = %#v, want %q", display["kind"], kind)
-	}
-	if display["phase"] != phase {
-		t.Fatalf("display phase = %#v, want %q", display["phase"], phase)
-	}
-	if label != "" && display["label"] != label {
-		t.Fatalf("display label = %#v, want %q", display["label"], label)
-	}
-	if text != "" && display["text"] != text {
-		t.Fatalf("display text = %#v, want %q", display["text"], text)
-	}
-}
-
-func findHTTPAgentEvent(t *testing.T, events []map[string]any, eventType string) map[string]any {
-	t.Helper()
-	for _, event := range events {
-		if event["type"] == eventType {
-			return event
-		}
-	}
-	t.Fatalf("events = %#v, want type %q", events, eventType)
-	return nil
 }

--- a/gestaltd/internal/server/tracing_test.go
+++ b/gestaltd/internal/server/tracing_test.go
@@ -197,28 +197,6 @@ func findSpan(spans tracetest.SpanStubs, name string) *tracetest.SpanStub {
 	return nil
 }
 
-func findSpanWithAttr(spans tracetest.SpanStubs, name string, key string, value string) *tracetest.SpanStub {
-	for i := range spans {
-		if spans[i].Name != name {
-			continue
-		}
-		for _, attr := range spans[i].Attributes {
-			if string(attr.Key) == key && attr.Value.AsString() == value {
-				return &spans[i]
-			}
-		}
-	}
-	return nil
-}
-
-func spanNames(spans tracetest.SpanStubs) []string {
-	names := make([]string, 0, len(spans))
-	for _, span := range spans {
-		names = append(names, span.Name)
-	}
-	return names
-}
-
 func findSpanPrefix(spans tracetest.SpanStubs, prefix string) *tracetest.SpanStub {
 	for i := range spans {
 		if strings.HasPrefix(spans[i].Name, prefix) {


### PR DESCRIPTION
## Summary
- Delete nine unused test helper functions in `agent_test_helpers_test.go` and `tracing_test.go` that golangci-lint flags as dead code
- Unblocks `CI (gestaltd)` and `CD (gestaltd)` on `main` after agent REST handler cleanup in #2861

## Context
These helpers were left behind when agent REST endpoint tests were removed. Tests still pass; lint is the only blocker.

This is intentionally scoped to the lint fix only (separate from #2862, which deletes additional agent REST surface area).

## Test plan
- [ ] `CI (gestaltd)` passes on this PR (especially `validate / Go Lint & Vet`)
- [ ] `validate / Go Tests` and race/e2e matrix still green


Made with [Cursor](https://cursor.com)