### PR TITLE
Build TypeScript client package before deploying API docs

### DIFF
--- a/.github/workflows/deploy-gestalt-docs.yml
+++ b/.github/workflows/deploy-gestalt-docs.yml
@@ -62,6 +62,10 @@ jobs:
         working-directory: sdk/typescript
         run: bun install --frozen-lockfile
 
+      - name: Build TypeScript client package
+        working-directory: sdk/typescript
+        run: bun run build:client
+
       - name: Build TypeScript API docs
         working-directory: sdk/typescript
         run: |


### PR DESCRIPTION
## Summary
- Run `bun run build:client` in the Deploy Gestalt Docs workflow before `docs:build:deploy`
- Fixes TypeDoc failures looking for `@valon-technologies/gestalt/client` at `dist/client/index.d.ts`

## Context
`Build TypeScript SDK` already runs `bun run check` (which includes `build:client`) before `docs:build`, so SDK CI passes. The docs deploy workflow skipped that step and has been failing since the gestalt/client export started pointing at emitted `dist/` artifacts.

## Test plan
- [ ] `Deploy Gestalt Docs` workflow passes on this PR (or after merge to `main`)
- [ ] TypeScript API docs build step completes without `Cannot find module '@valon-technologies/gestalt/client'`


Made with [Cursor](https://cursor.com)