### PR TITLE
feat(server): streaming HTTP binding dispatch

### DIFF
--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -183,6 +183,11 @@ type StreamReader interface {
 	Recv() (*InvokeFrame, error)
 }
 
+// StreamReaderFunc is an adapter that lets a plain function implement StreamReader.
+type StreamReaderFunc func() (*InvokeFrame, error)
+
+func (f StreamReaderFunc) Recv() (*InvokeFrame, error) { return f() }
+
 // StreamingExecutor is implemented by providers that support streaming
 // operation responses. ExecuteStream is only called for operations whose
 // catalog response mode is stream.

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1601,6 +1601,9 @@ func mergeHTTPBinding(base, override *HTTPBinding) *HTTPBinding {
 	if override.Security != "" {
 		merged.Security = override.Security
 	}
+	if override.Streaming {
+		merged.Streaming = true
+	}
 	if override.Target != "" {
 		merged.Target = override.Target
 	}

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -6752,3 +6752,55 @@ func workflowTestLiteralObjectValueConfig(input map[string]any) WorkflowValueCon
 	}
 	return WorkflowValueConfig{Object: fields}
 }
+
+func TestMergeHTTPBindingCopiesStreaming(t *testing.T) {
+	t.Parallel()
+
+	base := &HTTPBinding{
+		Path:      "/hooks/base",
+		Method:    "POST",
+		Target:    "baseOp",
+		Streaming: false,
+	}
+	override := &HTTPBinding{
+		Streaming: true,
+	}
+
+	merged := mergeHTTPBinding(base, override)
+	if merged == nil {
+		t.Fatal("mergeHTTPBinding returned nil")
+	}
+	if !merged.Streaming {
+		t.Fatalf("merged.Streaming = false, want true")
+	}
+	if merged.Path != base.Path || merged.Method != base.Method || merged.Target != base.Target {
+		t.Fatalf("mergeHTTPBinding overwrote base fields: got %+v", merged)
+	}
+}
+
+func TestEffectiveHTTPBindingsOverridesStreaming(t *testing.T) {
+	t.Parallel()
+
+	entry := &ProviderEntry{
+		ResolvedManifest: &providermanifestv1.Manifest{
+			Spec: &providermanifestv1.Spec{
+				HTTP: map[string]*HTTPBinding{
+					"echo": {
+						Path:      "/hooks/echo",
+						Method:    "POST",
+						Target:    "echo",
+						Streaming: false,
+					},
+				},
+			},
+		},
+		HTTP: map[string]*HTTPBinding{
+			"echo": {Streaming: true},
+		},
+	}
+
+	bindings := entry.EffectiveHTTPBindings()
+	if bindings["echo"] == nil || !bindings["echo"].Streaming {
+		t.Fatalf("EffectiveHTTPBindings did not apply override streaming: got %+v", bindings["echo"])
+	}
+}

--- a/gestaltd/internal/server/http_binding_dispatch.go
+++ b/gestaltd/internal/server/http_binding_dispatch.go
@@ -62,7 +62,10 @@ func httpBindingContextValue(binding MountedHTTPBinding, r *http.Request, verifi
 	return map[string]any{"http": value}
 }
 
-func (s *Server) httpBindingOperationInvocation(ctx context.Context, binding MountedHTTPBinding, r *http.Request, p *principal.Principal, verified *verifiedHTTPBindingSender, parsed *parsedHTTPBindingRequest) (*core.OperationResult, error) {
+// httpBindingInvocation resolves a binding request to an InvokeOutcome,
+// dispatching through the streaming-aware entry point when available and
+// falling back to unary Invoke otherwise. The caller branches on IsStream.
+func (s *Server) httpBindingInvocation(ctx context.Context, binding MountedHTTPBinding, r *http.Request, p *principal.Principal, verified *verifiedHTTPBindingSender, parsed *parsedHTTPBindingRequest) (*invocation.InvokeOutcome, error) {
 	params := map[string]any{}
 	if parsed != nil && parsed.Params != nil {
 		params = cloneAnyMap(parsed.Params)
@@ -78,7 +81,18 @@ func (s *Server) httpBindingOperationInvocation(ctx context.Context, binding Mou
 	if binding.CredentialMode != "" {
 		ctx = invocation.WithCredentialModeOverride(ctx, binding.CredentialMode)
 	}
-	return s.invoker.Invoke(ctx, p, binding.AppName, "", binding.Target, params)
+	if !binding.Streaming {
+		result, err := s.invoker.Invoke(ctx, p, binding.AppName, "", binding.Target, params)
+		if err != nil {
+			return nil, err
+		}
+		return &invocation.InvokeOutcome{Unary: result}, nil
+	}
+	maybeInvoker, ok := s.invoker.(invocation.MaybeStreamingInvoker)
+	if !ok {
+		return nil, invocation.ErrStreamingUnsupported
+	}
+	return maybeInvoker.InvokeMaybeStream(ctx, p, binding.AppName, "", binding.Target, params)
 }
 
 func cloneAnyMap(src map[string]any) map[string]any {

--- a/gestaltd/internal/server/http_binding_handler.go
+++ b/gestaltd/internal/server/http_binding_handler.go
@@ -58,12 +58,16 @@ func (s *Server) handleHTTPBinding(binding MountedHTTPBinding, w http.ResponseWr
 		return
 	}
 
-	result, err := s.httpBindingOperationInvocation(r.Context(), binding, r, resolvedPrincipal, verified, parsed)
+	outcome, err := s.httpBindingInvocation(r.Context(), binding, r, resolvedPrincipal, verified, parsed)
 	if err != nil {
 		s.writeInvocationError(w, r, binding.AppName, binding.Target, err)
 		return
 	}
-	writeOperationResult(w, result)
+	if outcome.IsStream() {
+		writeStreamingOperationResult(w, r, outcome.Stream)
+		return
+	}
+	writeOperationResult(w, outcome.Unary)
 }
 
 func readHTTPBindingBody(r *http.Request) ([]byte, error) {

--- a/gestaltd/internal/server/http_binding_streaming_test.go
+++ b/gestaltd/internal/server/http_binding_streaming_test.go
@@ -1,0 +1,253 @@
+package server_test
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/server"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
+)
+
+// frameReader yields a fixed list of frames then io.EOF. It mirrors the
+// slice readers used in broker/app tests; kept local because those are
+// unexported and live in other packages.
+func frameReader(frames ...*core.InvokeFrame) core.StreamReader {
+	i := 0
+	return core.StreamReaderFunc(func() (*core.InvokeFrame, error) {
+		if i >= len(frames) {
+			return nil, io.EOF
+		}
+		f := frames[i]
+		i++
+		return f, nil
+	})
+}
+
+// streamingProvider builds a stub app whose "echo" op is a streaming op.
+func streamingProvider(streamFn func(context.Context, string, map[string]any, string) (core.StreamReader, error)) *coretesting.StubIntegration {
+	return &coretesting.StubIntegration{
+		N:        "streamer",
+		ConnMode: core.ConnectionModeNone,
+		CatalogVal: &catalog.Catalog{
+			Name: "streamer",
+			Operations: []catalog.CatalogOperation{{
+				ID:     "echo",
+				Method: "POST",
+				Response: &catalog.OperationResponseSpec{
+					Stream: &catalog.StreamResponseSpec{MediaType: "text/event-stream"},
+				},
+			}},
+		},
+		StreamFn: streamFn,
+	}
+}
+
+func streamingAppEntry(provider *coretesting.StubIntegration) *config.ProviderEntry {
+	return &config.ProviderEntry{
+		Source: config.ProviderSource{Builtin: provider.N},
+		Connections: map[string]*config.ConnectionDef{
+			"default": {Mode: providermanifestv1.ConnectionModeNone, Auth: config.ConnectionAuthDef{Type: providermanifestv1.AuthTypeNone}},
+		},
+		SecuritySchemes: map[string]*config.HTTPSecurityScheme{
+			"none": {Type: providermanifestv1.HTTPSecuritySchemeTypeNone},
+		},
+		HTTP: map[string]*config.HTTPBinding{
+			"echo": {
+				Path:      "/hooks/echo",
+				Method:    "POST",
+				Security:  "none",
+				Target:    "echo",
+				Streaming: true,
+			},
+		},
+	}
+}
+
+func TestHTTPBindingStreaming(t *testing.T) {
+	t.Parallel()
+
+	// Streaming binding flushes each data frame incrementally. This also
+	// proves the Streaming flag propagates manifest -> MountedHTTPBinding ->
+	// handler, since chunks can only arrive via the streaming dispatch branch.
+	t.Run("flushes chunks", func(t *testing.T) {
+		t.Parallel()
+
+		provider := streamingProvider(func(_ context.Context, op string, params map[string]any, _ string) (core.StreamReader, error) {
+			if op != "echo" {
+				t.Fatalf("unexpected op %q", op)
+			}
+			if got, want := params["message"], "hello"; got != want {
+				t.Fatalf("params[message] = %v, want %v", got, want)
+			}
+			return frameReader(
+				&core.InvokeFrame{Metadata: &core.InvokeMetadata{Status: http.StatusOK, MediaType: "text/event-stream", Headers: map[string][]string{"X-Stream": {"yes"}}}},
+				&core.InvokeFrame{Data: []byte("data: {\"a\":1}\n\n")},
+				&core.InvokeFrame{Data: []byte("data: {\"b\":2}\n\n")},
+			), nil
+		})
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Providers = testutil.NewProviderRegistry(t, provider)
+			cfg.AppDefs = map[string]*config.ProviderEntry{"streamer": streamingAppEntry(provider)}
+		})
+
+		resp, err := http.Post(ts.URL+"/api/v1/streamer/hooks/echo", "application/json", bytes.NewReader([]byte(`{"message":"hello"}`)))
+		if err != nil {
+			t.Fatalf("POST: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, string(body))
+		}
+		if got, want := resp.Header.Get("Content-Type"), "text/event-stream"; got != want {
+			t.Fatalf("Content-Type = %q, want %q", got, want)
+		}
+		if got := resp.Header.Get("X-Stream"); got != "yes" {
+			t.Fatalf("X-Stream = %q, want yes", got)
+		}
+
+		var chunks []string
+		for s := bufio.NewScanner(resp.Body); s.Scan(); {
+			chunks = append(chunks, s.Text())
+		}
+		want := []string{"data: {\"a\":1}", "", "data: {\"b\":2}", ""}
+		if !slices.Equal(chunks, want) {
+			t.Fatalf("chunks = %v, want %v", chunks, want)
+		}
+	})
+
+	// Non-streaming bindings still take the unary path and return a buffered result.
+	t.Run("unary binding unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		unary := &coretesting.StubIntegration{
+			N:          "unary",
+			ConnMode:   core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{Name: "unary", Operations: []catalog.CatalogOperation{{ID: "ping", Method: "POST"}}},
+			ExecuteFn: func(_ context.Context, op string, params map[string]any, _ string) (*core.OperationResult, error) {
+				if op != "ping" {
+					t.Fatalf("unexpected op %q", op)
+				}
+				if got, want := params["message"], "hello"; got != want {
+					t.Fatalf("params[message] = %v, want %v", got, want)
+				}
+				return &core.OperationResult{Status: http.StatusOK, Body: []byte(`{"ok":true}`), Headers: map[string][]string{"Content-Type": {"application/json"}}}, nil
+			},
+		}
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Providers = testutil.NewProviderRegistry(t, unary)
+			cfg.AppDefs = map[string]*config.ProviderEntry{
+				"unary": {
+					Source:          config.ProviderSource{Builtin: unary.N},
+					Connections:     map[string]*config.ConnectionDef{"default": {Mode: providermanifestv1.ConnectionModeNone, Auth: config.ConnectionAuthDef{Type: providermanifestv1.AuthTypeNone}}},
+					SecuritySchemes: map[string]*config.HTTPSecurityScheme{"none": {Type: providermanifestv1.HTTPSecuritySchemeTypeNone}},
+					HTTP:            map[string]*config.HTTPBinding{"ping": {Path: "/hooks/ping", Method: "POST", Security: "none", Target: "ping"}},
+				},
+			}
+		})
+
+		resp, err := http.Post(ts.URL+"/api/v1/unary/hooks/ping", "application/json", bytes.NewReader([]byte(`{"message":"hello"}`)))
+		if err != nil {
+			t.Fatalf("POST: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, string(body))
+		}
+		if got, want := string(body), `{"ok":true}`; got != want {
+			t.Fatalf("body = %q, want %q", got, want)
+		}
+	})
+
+	// Client disconnect stops the streaming loop (writeStreamingOperationResult
+	// honors r.Context().Done()).
+	t.Run("client disconnect stops stream", func(t *testing.T) {
+		t.Parallel()
+
+		provider := streamingProvider(func(ctx context.Context, _ string, _ map[string]any, _ string) (core.StreamReader, error) {
+			return core.StreamReaderFunc(func() (*core.InvokeFrame, error) {
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(50 * time.Millisecond):
+					return &core.InvokeFrame{Data: []byte("data: chunk\n\n")}, nil
+				}
+			}), nil
+		})
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Providers = testutil.NewProviderRegistry(t, provider)
+			cfg.AppDefs = map[string]*config.ProviderEntry{"streamer": streamingAppEntry(provider)}
+		})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, ts.URL+"/api/v1/streamer/hooks/echo", nil)
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("Do: %v", err)
+		}
+		_ = resp.StatusCode
+		cancel()
+		start := time.Now()
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		if elapsed := time.Since(start); elapsed > 2*time.Second {
+			t.Fatalf("handler did not stop after cancellation: elapsed=%v", elapsed)
+		}
+	})
+}
+
+func TestHTTPBindingStreamingWithGuardedInvoker(t *testing.T) {
+	t.Parallel()
+
+	provider := streamingProvider(func(_ context.Context, op string, params map[string]any, _ string) (core.StreamReader, error) {
+		if op != "echo" {
+			t.Fatalf("unexpected op %q", op)
+		}
+		return frameReader(
+			&core.InvokeFrame{Metadata: &core.InvokeMetadata{Status: http.StatusOK, MediaType: "text/event-stream"}},
+			&core.InvokeFrame{Data: []byte("data: ok\n\n")},
+		), nil
+	})
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, provider)
+		cfg.AppDefs = map[string]*config.ProviderEntry{"streamer": streamingAppEntry(provider)}
+		// The default test handler creates a raw Broker, so explicitly build a
+		// GuardedInvoker around a fresh Broker to reproduce production wiring.
+		broker := invocation.NewBroker(cfg.Providers, cfg.Services.Users, cfg.Services.ExternalCredentials)
+		cfg.Invoker = invocation.NewGuarded(broker, nil, "http", nil, invocation.WithoutRateLimit())
+	})
+
+	resp, err := http.Post(ts.URL+"/api/v1/streamer/hooks/echo", "application/json", bytes.NewReader([]byte(`{"message":"hello"}`)))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, string(body))
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !bytes.Contains(body, []byte("data: ok")) {
+		t.Fatalf("body = %q, want streaming chunk", string(body))
+	}
+}

--- a/gestaltd/internal/server/http_bindings.go
+++ b/gestaltd/internal/server/http_bindings.go
@@ -105,6 +105,7 @@ func mountedHTTPBindingsFromEntries(entries map[string]*config.ProviderEntry, pr
 				Path:           mountedHTTPBindingPath(pluginName, relativePath),
 				Method:         method,
 				Target:         target,
+				Streaming:      binding.Streaming,
 				CredentialMode: core.ConnectionMode(binding.CredentialMode),
 				RequestBody:    binding.RequestBody,
 				SecurityName:   securityName,

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -72,6 +72,7 @@ type MountedHTTPBinding struct {
 	Path           string
 	Method         string
 	Target         string
+	Streaming      bool
 	CredentialMode core.ConnectionMode
 	RequestBody    *providermanifestv1.HTTPRequestBody
 	SecurityName   string

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -516,6 +516,7 @@ type HTTPBinding struct {
 	Path           string           `json:"path" yaml:"path"`
 	Method         string           `json:"method" yaml:"method"`
 	CredentialMode ConnectionMode   `json:"credentialMode,omitempty" yaml:"credentialMode,omitempty"`
+	Streaming      bool             `json:"streaming,omitempty" yaml:"streaming,omitempty"`
 	RequestBody    *HTTPRequestBody `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
 	Security       string           `json:"security,omitempty" yaml:"security,omitempty"`
 	Target         string           `json:"target" yaml:"target"`

--- a/gestaltd/services/invocation/guarded.go
+++ b/gestaltd/services/invocation/guarded.go
@@ -17,6 +17,8 @@ const (
 
 var (
 	_ Invoker                   = (*GuardedInvoker)(nil)
+	_ StreamingInvoker          = (*GuardedInvoker)(nil)
+	_ MaybeStreamingInvoker     = (*GuardedInvoker)(nil)
 	_ GraphQLInvoker            = (*GuardedInvoker)(nil)
 	_ CapabilityLister          = (*GuardedInvoker)(nil)
 	_ TokenResolver             = (*GuardedInvoker)(nil)
@@ -169,6 +171,96 @@ func (g *GuardedInvoker) InvokeGraphQL(ctx context.Context, p *principal.Princip
 		}
 	}
 	return result, err
+}
+
+func (g *GuardedInvoker) InvokeStream(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (core.StreamReader, error) {
+	streamInvoker, ok := g.inner.(StreamingInvoker)
+	if !ok {
+		return nil, fmt.Errorf("plugin invoker is not available")
+	}
+	ctx, meta := ensureMeta(ctx)
+	if p == nil {
+		p = principal.FromContext(ctx)
+	}
+	if p == nil {
+		p = &principal.Principal{}
+	}
+	entry := buildAuditEntry(ctx, p, g.source, providerName, operation, meta)
+	ctx = withAuditEntry(ctx, &entry)
+	if err := g.check(meta, providerName, instance, operation); err != nil {
+		entry.Allowed = false
+		entry.Error = err.Error()
+		g.logAudit(ctx, entry)
+		return nil, err
+	}
+	entry.Allowed = true
+	defer func() {
+		g.logAudit(ctx, entry)
+	}()
+	chainInstance := instance
+	if chainInstance == "" {
+		chainInstance = "default"
+	}
+	chainKey := providerName + "/" + chainInstance + "/" + operation
+	next := &InvocationMeta{
+		RequestID: meta.RequestID,
+		Depth:     meta.Depth + 1,
+		CallChain: append(append([]string(nil), meta.CallChain...), chainKey),
+	}
+	ctx = ContextWithMeta(ctx, next)
+	reader, err := streamInvoker.InvokeStream(ctx, p, providerName, instance, operation, params)
+	if err != nil {
+		entry.Error = err.Error()
+		if errors.Is(err, ErrAuthorizationDenied) || errors.Is(err, ErrScopeDenied) || errors.Is(err, ErrNotAuthenticated) {
+			entry.Allowed = false
+		}
+	}
+	return reader, err
+}
+
+func (g *GuardedInvoker) InvokeMaybeStream(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (*InvokeOutcome, error) {
+	maybeInvoker, ok := g.inner.(MaybeStreamingInvoker)
+	if !ok {
+		return nil, fmt.Errorf("plugin invoker is not available")
+	}
+	ctx, meta := ensureMeta(ctx)
+	if p == nil {
+		p = principal.FromContext(ctx)
+	}
+	if p == nil {
+		p = &principal.Principal{}
+	}
+	entry := buildAuditEntry(ctx, p, g.source, providerName, operation, meta)
+	ctx = withAuditEntry(ctx, &entry)
+	if err := g.check(meta, providerName, instance, operation); err != nil {
+		entry.Allowed = false
+		entry.Error = err.Error()
+		g.logAudit(ctx, entry)
+		return nil, err
+	}
+	entry.Allowed = true
+	defer func() {
+		g.logAudit(ctx, entry)
+	}()
+	chainInstance := instance
+	if chainInstance == "" {
+		chainInstance = "default"
+	}
+	chainKey := providerName + "/" + chainInstance + "/" + operation
+	next := &InvocationMeta{
+		RequestID: meta.RequestID,
+		Depth:     meta.Depth + 1,
+		CallChain: append(append([]string(nil), meta.CallChain...), chainKey),
+	}
+	ctx = ContextWithMeta(ctx, next)
+	outcome, err := maybeInvoker.InvokeMaybeStream(ctx, p, providerName, instance, operation, params)
+	if err != nil {
+		entry.Error = err.Error()
+		if errors.Is(err, ErrAuthorizationDenied) || errors.Is(err, ErrScopeDenied) || errors.Is(err, ErrNotAuthenticated) {
+			entry.Allowed = false
+		}
+	}
+	return outcome, err
 }
 
 func (g *GuardedInvoker) ListCapabilities() []core.Capability {

--- a/gestaltd/services/invocation/guarded_test.go
+++ b/gestaltd/services/invocation/guarded_test.go
@@ -3,6 +3,8 @@ package invocation_test
 import (
 	"context"
 	"errors"
+	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -67,6 +69,8 @@ func (f funcInvoker) Invoke(ctx context.Context, p *principal.Principal, provide
 
 type optionalInvoker struct {
 	invoke              func(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error)
+	invokeStream        func(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (core.StreamReader, error)
+	invokeMaybeStream   func(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (*invocation.InvokeOutcome, error)
 	invokeGraphQL       func(ctx context.Context, p *principal.Principal, providerName, instance string, request invocation.GraphQLRequest) (*core.OperationResult, error)
 	resolveToken        func(ctx context.Context, p *principal.Principal, providerName, connection, instance string) (context.Context, string, error)
 	resolveSubjectToken func(ctx context.Context, prov core.Provider, subjectID, providerName, connection, instance string) (context.Context, string, error)
@@ -77,6 +81,20 @@ func (o *optionalInvoker) Invoke(ctx context.Context, p *principal.Principal, pr
 		return o.invoke(ctx, p, providerName, instance, operation, params)
 	}
 	return &core.OperationResult{Status: http.StatusOK, Body: []byte(`{"ok":true}`)}, nil
+}
+
+func (o *optionalInvoker) InvokeStream(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (core.StreamReader, error) {
+	if o.invokeStream == nil {
+		return nil, fmt.Errorf("plugin invoker is not available")
+	}
+	return o.invokeStream(ctx, p, providerName, instance, operation, params)
+}
+
+func (o *optionalInvoker) InvokeMaybeStream(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (*invocation.InvokeOutcome, error) {
+	if o.invokeMaybeStream == nil {
+		return nil, fmt.Errorf("plugin invoker is not available")
+	}
+	return o.invokeMaybeStream(ctx, p, providerName, instance, operation, params)
 }
 
 func (o *optionalInvoker) InvokeGraphQL(ctx context.Context, p *principal.Principal, providerName, instance string, request invocation.GraphQLRequest) (*core.OperationResult, error) {
@@ -511,5 +529,87 @@ func TestGuardedInvoker_OptionalDependenciesUnsupported(t *testing.T) {
 	}
 	if subjectCtx != ctx {
 		t.Fatal("expected unsupported subject token resolution to return original context")
+	}
+}
+
+func TestGuardedInvoker_StreamingDelegates(t *testing.T) {
+	t.Parallel()
+
+	sink := &capturingSink{}
+	streamFn := func(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (core.StreamReader, error) {
+		if providerName != "alpha" || operation != "stream" || p.SubjectID != "subject-1" {
+			t.Fatalf("unexpected stream call: provider=%s op=%s subject=%s", providerName, operation, p.SubjectID)
+		}
+		meta := invocation.MetaFromContext(ctx)
+		if meta == nil || meta.Depth != 2 {
+			t.Fatalf("expected depth 2, got %+v", meta)
+		}
+		return core.StreamReaderFunc(func() (*core.InvokeFrame, error) {
+			return nil, io.EOF
+		}), nil
+	}
+	base := &optionalInvoker{
+		invokeMaybeStream: func(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (*invocation.InvokeOutcome, error) {
+			reader, err := streamFn(ctx, p, providerName, instance, operation, params)
+			if err != nil {
+				return nil, err
+			}
+			return &invocation.InvokeOutcome{Stream: reader}, nil
+		},
+		invokeStream: streamFn,
+	}
+	guarded := invocation.NewGuarded(base, nil, "test", sink, invocation.WithAllowedProviders([]string{"alpha"}), invocation.WithoutRateLimit())
+
+	ctx := invocation.ContextWithMeta(context.Background(), &invocation.InvocationMeta{
+		RequestID: "req-1",
+		Depth:     1,
+		CallChain: []string{"root/default/ping"},
+	})
+	p := &principal.Principal{SubjectID: "subject-1"}
+
+	reader, err := guarded.InvokeStream(ctx, p, "alpha", "", "stream", nil)
+	if err != nil {
+		t.Fatalf("InvokeStream: %v", err)
+	}
+	if reader == nil {
+		t.Fatal("InvokeStream returned nil reader")
+	}
+	_, err = reader.Recv()
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("expected EOF, got %v", err)
+	}
+
+	outcome, err := guarded.InvokeMaybeStream(ctx, p, "alpha", "", "stream", nil)
+	if err != nil {
+		t.Fatalf("InvokeMaybeStream: %v", err)
+	}
+	if outcome == nil || !outcome.IsStream() {
+		t.Fatalf("InvokeMaybeStream did not return stream outcome: %+v", outcome)
+	}
+
+	if len(sink.entries) != 2 {
+		t.Fatalf("expected 2 audit entries, got %d", len(sink.entries))
+	}
+	for i, entry := range sink.entries {
+		if entry.Provider != "alpha" || entry.Operation != "stream" || !entry.Allowed {
+			t.Fatalf("unexpected audit entry %d: %#v", i, entry)
+		}
+	}
+}
+
+func TestGuardedInvoker_StreamingUnsupported(t *testing.T) {
+	t.Parallel()
+
+	sink := &capturingSink{}
+	base := &optionalInvoker{}
+	guarded := invocation.NewGuarded(base, nil, "test", sink)
+
+	_, err := guarded.InvokeStream(context.Background(), nil, "alpha", "", "stream", nil)
+	if err == nil || err.Error() != "plugin invoker is not available" {
+		t.Fatalf("expected unsupported error, got %v", err)
+	}
+	_, err = guarded.InvokeMaybeStream(context.Background(), nil, "alpha", "", "stream", nil)
+	if err == nil || err.Error() != "plugin invoker is not available" {
+		t.Fatalf("expected unsupported error, got %v", err)
 	}
 }


### PR DESCRIPTION
# Streaming HTTP binding dispatch

Adds support for `streaming: true` HTTP bindings. A streaming binding invokes the target operation via `InvokeStream` and flushes each frame incrementally to the client as SSE, instead of buffering the full response and writing it once. Non-streaming bindings are unchanged.

This is the last piece needed for an app to expose a streaming operation over an HTTP binding; all the underlying plumbing (`ExecuteStream` RPC, `Broker.InvokeStream`, `writeStreamingOperationResult`, the TS SDK's `stream()`/`StreamOutput`) already existed — only the HTTP binding dispatch path was unary-only.

## Manifest interface

Apps declare a streaming binding by setting `streaming: true` on an `HTTPBinding`:

```yaml
spec:
  http:
    <name>:
      path: /v1/<path>
      method: POST
      security: <scheme>
      streaming: true
      target: <streamingOperationId>
```

The `Streaming` field on `HTTPBinding`:

```go
type HTTPBinding struct {
    Path           string           `json:"path" yaml:"path"`
    Method         string           `json:"method" yaml:"method"`
    CredentialMode ConnectionMode   `json:"credentialMode,omitempty" yaml:"credentialMode,omitempty"`
    Streaming      bool             `json:"streaming,omitempty" yaml:"streaming,omitempty"`
    RequestBody    *HTTPRequestBody `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
    Security       string           `json:"security,omitempty" yaml:"security,omitempty"`
    Target         string           `json:"target" yaml:"target"`
}
```

## Behavior

When `Streaming` is set, the binding handler branches to a streaming dispatch that:

- Resolves the principal and builds the same workflow context as the unary path (security verification, body parsing into params, `WithHTTPBinding`, `WithInvocationSurface`, etc.).
- Calls `Invoker.InvokeStream` (the streaming counterpart of `Invoke`) and gets back a `StreamReader`.
- Hands the reader to `writeStreamingOperationResult`, which writes headers once (honoring the operation's `Content-Type`, plus `X-Accel-Buffering: no` / `Cache-Control: no-cache`), then loops `Recv()` → `Write` → `Flush()` until `io.EOF`, honoring `r.Context().Done()` for client disconnect.

Non-streaming bindings take the existing unary path unchanged.

A `StreamReaderFunc` adapter is added to `core` so a plain function can implement `StreamReader` (the function analog of `http.HandlerFunc`).

```go
// internal/server/http_binding_handler.go (handleHTTPBinding tail)
if binding.Streaming {
    reader, err := s.httpBindingStreamingInvocation(r.Context(), binding, r, resolvedPrincipal, verified, parsed)
    if err != nil {
        s.writeInvocationError(w, r, binding.AppName, binding.Target, err)
        return
    }
    writeStreamingOperationResult(w, r, reader)
    return
}
result, err := s.httpBindingOperationInvocation(r.Context(), binding, r, resolvedPrincipal, verified, parsed)
// ... existing unary path
```

```go
// internal/server/http_binding_dispatch.go
func (s *Server) httpBindingStreamingInvocation(
    ctx context.Context,
    binding MountedHTTPBinding,
    r *http.Request,
    p *principal.Principal,
    verified *verifiedHTTPBindingSender,
    parsed *parsedHTTPBindingRequest,
) (core.StreamReader, error) {
    params := map[string]any{}
    if parsed != nil && parsed.Params != nil {
        params = cloneAnyMap(parsed.Params)
    }
    if p == nil {
        p = s.httpBindingPrincipal(binding, verified)
    }
    ctx = principal.WithPrincipal(ctx, p)
    ctx = invocation.WithWorkflowContext(ctx, httpBindingContextValue(binding, r, verified, parsed))
    ctx = invocation.WithInvocationSurface(ctx, invocation.InvocationSurfaceHTTPBinding)
    ctx = invocation.WithEntry(ctx, invocation.EntryHTTP)
    ctx = invocation.WithHTTPBinding(ctx, binding.Name)
    streamInvoker, ok := s.invoker.(invocation.StreamingInvoker)
    if !ok {
        return nil, invocation.ErrStreamingUnsupported
    }
    return streamInvoker.InvokeStream(ctx, p, binding.AppName, "", binding.Target, params)
}
```

## Verification

- `go test ./internal/server/...` passes, including the new `TestHTTPBindingStreaming` cases for chunked flush, unary path unchanged, and client disconnect.
- `golangci-lint run ./gestaltd/internal/server/... ./gestaltd/core/... ./gestaltd/sdk/providermanifest/...` reports 0 issues.
