### PR TITLE
PG-3: route authorization RPC through gateway.Conn

### DIFF
--- a/gestaltd/internal/bootstrap/authorization_bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/authorization_bootstrap_test.go
@@ -2,6 +2,8 @@ package bootstrap
 
 import (
 	"context"
+	"log/slog"
+	"net/http"
 	"reflect"
 	"strconv"
 	"testing"
@@ -14,7 +16,10 @@ import (
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/providerdrivers"
+	"github.com/valon-technologies/gestalt/server/services/providergateway"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 	gproto "google.golang.org/protobuf/proto"
 	"gopkg.in/yaml.v3"
 )
@@ -267,7 +272,7 @@ config:
 	if err != nil {
 		t.Fatalf("buildAuthorizationProviders: %v", err)
 	}
-	if providers.Raw["indexeddb"] == nil {
+	if providers["indexeddb"] == nil {
 		t.Fatal("raw authorization provider was not built")
 	}
 	if capturedName != "indexeddb" {
@@ -549,3 +554,82 @@ func TestProviderAuthorizationKindsSkipsDedicatedAppResourceTypes(t *testing.T) 
 		t.Fatalf("assistant kind = %v, want agent", got["assistant"])
 	}
 }
+
+func TestBootstrapAuthorizationProviderReceivesSharedGatewayTransport(t *testing.T) {
+	t.Parallel()
+
+	var capturedTransport *providergateway.ProviderGatewayTransport
+	factories := &FactoryRegistry{
+		Auth: func(context.Context, string, yaml.Node, []runtimehost.HostService, Deps) (core.IdentityProvider, error) {
+			return &coretesting.StubAuthProvider{}, nil
+		},
+		Authorization: func(_ context.Context, _ string, _ yaml.Node, _ []runtimehost.HostService, deps Deps) (providerdrivers.AuthorizationBuildResult, error) {
+			capturedTransport = deps.GatewayTransport
+			return providerdrivers.AuthorizationBuildResult{Raw: &recordingAuthorizationProvider{}}, nil
+		},
+	}
+	factories.Secrets = map[string]SecretManagerFactory{
+		"stub": func(yaml.Node) (core.SecretManager, error) {
+			return &coretesting.StubSecretManager{Secrets: map[string]string{}}, nil
+		},
+	}
+	factories.Telemetry = map[string]TelemetryFactory{
+		"noop": func(yaml.Node) (core.TelemetryProvider, error) {
+			return telemetrynoopProvider{}, nil
+		},
+	}
+	factories.IndexedDB = func(yaml.Node) (indexeddb.IndexedDB, error) {
+		return &coretesting.StubIndexedDB{}, nil
+	}
+	factories.ExternalCredentials = func(context.Context, string, yaml.Node, []runtimehost.HostService, Deps) (core.ExternalCredentialProvider, error) {
+		return coretesting.NewStubExternalCredentialProvider(), nil
+	}
+
+	cfg := &config.Config{
+		Providers: config.ProvidersConfig{
+			Identity: map[string]*config.ProviderEntry{
+				"default": {
+					Source: config.NewMetadataSource("https://example.invalid/auth/oidc/v0.0.1/provider-release.yaml"),
+					Config: yaml.Node{Kind: yaml.MappingNode},
+				},
+			},
+			Secrets: map[string]*config.ProviderEntry{
+				"default": {Source: config.ProviderSource{Builtin: "stub"}},
+			},
+			Telemetry: map[string]*config.ProviderEntry{
+				"default": {Source: config.ProviderSource{Builtin: "noop"}},
+			},
+			IndexedDB: map[string]*config.ProviderEntry{
+				"main": {Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.2/provider-release.yaml")},
+			},
+			Authorization: map[string]*config.ProviderEntry{
+				"authz": {Config: yaml.Node{Kind: yaml.MappingNode}},
+			},
+		},
+		Server: config.ServerConfig{
+			Providers:     config.ServerProvidersConfig{IndexedDB: "main"},
+			EncryptionKey: "test-key",
+		},
+	}
+
+	result, err := Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	t.Cleanup(func() { _ = result.Close(context.Background()) })
+
+	if capturedTransport == nil {
+		t.Fatal("factory did not receive a GatewayTransport in Deps")
+	}
+	if result.PublicGatewayTransport != capturedTransport {
+		t.Fatal("factory GatewayTransport is not the same instance as the public transport")
+	}
+}
+
+type telemetrynoopProvider struct{}
+
+func (telemetrynoopProvider) Logger() *slog.Logger                 { return slog.Default() }
+func (telemetrynoopProvider) PrometheusHandler() http.Handler      { return nil }
+func (telemetrynoopProvider) MeterProvider() metric.MeterProvider  { return nil }
+func (telemetrynoopProvider) TracerProvider() trace.TracerProvider { return nil }
+func (telemetrynoopProvider) Shutdown(context.Context) error       { return nil }

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -194,6 +194,7 @@ type Deps struct {
 	DevSupervisor           *providerdev.Supervisor
 	RemoteClients           *remote.ClientSet
 	RemoteToken             string
+	GatewayTransport        *providergateway.ProviderGatewayTransport
 
 	hostedAgentPoolClock hostedAgentPoolClock
 }
@@ -754,7 +755,6 @@ type preparedCore struct {
 	SelectedAuthProvider string
 	AuthProviders        map[string]core.IdentityProvider
 	Authorization        map[string]core.AuthorizationProvider
-	AuthorizationConns   map[string]grpc.ClientConnInterface
 	Services             *coredata.Services
 	ExtraIndexedDBs      []indexeddb.IndexedDB
 	ExtraCaches          []corecache.Cache
@@ -892,9 +892,17 @@ func resolveConfigSecrets(
 }
 
 func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, requireEncryptionKey bool) (*preparedCore, error) {
+	registry, err := publicrpc.NewGeneratedRegistry()
+	if err != nil {
+		return nil, fmt.Errorf("public rpc registry: %w", err)
+	}
+	gatewayTransport := providergateway.NewProviderGatewayTransport()
+	gatewayTransport.SetPublicMethods(registry)
+
 	if err := ResolveConfigSecrets(ctx, cfg, factories); err != nil {
 		return nil, err
 	}
+	gatewayTransport.SetPublicBaseURL(cfg.Server.BaseURL)
 	sm, err := buildRuntimeSecretManager(cfg, factories)
 	if err != nil {
 		return nil, err
@@ -1077,6 +1085,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	}
 	auth := authProviders[selectedAuthName]
 	deps.Authentication = auth
+	deps.GatewayTransport = gatewayTransport
 
 	authorizationProviders, err := buildAuthorizationProviders(ctx, cfg, factories, deps)
 	if err != nil {
@@ -1086,14 +1095,14 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	closeAuthorizationOnError := true
 	defer func() {
 		if closeAuthorizationOnError {
-			_ = closeAuthorizationProviders(authorizationProviders.Raw)
+			_ = closeAuthorizationProviders(authorizationProviders)
 		}
 	}()
-	if err := bootstrapAuthorizationProviderState(ctx, cfg, authorizationProviders.Raw); err != nil {
+	if err := bootstrapAuthorizationProviderState(ctx, cfg, authorizationProviders); err != nil {
 		_ = closeAuthProviders(authProviders)
 		return nil, err
 	}
-	_, authorizationProvider, err := selectedAuthorizationProviderInstance(cfg, authorizationProviders.Raw)
+	_, authorizationProvider, err := selectedAuthorizationProviderInstance(cfg, authorizationProviders)
 	if err != nil {
 		_ = closeAuthProviders(authProviders)
 		return nil, err
@@ -1129,8 +1138,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 		Auth:                 auth,
 		SelectedAuthProvider: selectedAuthName,
 		AuthProviders:        authProviders,
-		Authorization:        authorizationProviders.Raw,
-		AuthorizationConns:   authorizationProviders.Conns,
+		Authorization:        authorizationProviders,
 		Services:             svc,
 		ExtraIndexedDBs:      extraIndexedDBs,
 		ExtraCaches:          extraCaches,
@@ -1449,19 +1457,10 @@ func BootstrapWithOptions(ctx context.Context, cfg *config.Config, factories *Fa
 		startupWorkflowConfigReconcile = nil
 	}
 
-	publicGatewayTransport, err := buildPublicGatewayTransport(
-		cfg,
-		prepared.Auth,
-		prepared.Authorization,
-		prepared.Services.Users,
-	)
-	if err != nil {
-		return nil, err
-	}
-	if publicGatewayTransport != nil {
-		if err := registerAuthorizationGatewayRoutes(publicGatewayTransport, cfg, prepared.AuthorizationConns); err != nil {
-			return nil, err
-		}
+	publicGatewayTransport := prepared.Deps.GatewayTransport
+	wirePublicGatewayTransport(publicGatewayTransport, cfg, prepared.Auth, prepared.Authorization, prepared.Services.Users)
+	if prepared.Auth == nil {
+		publicGatewayTransport = nil
 	}
 
 	closeProviders = false
@@ -2111,70 +2110,70 @@ func buildNamedAuthProvider(cfg *config.Config, name string, authEntry *config.P
 	return auth, nil
 }
 
-type authorizationProviderSets struct {
-	Raw   map[string]core.AuthorizationProvider
-	Conns map[string]grpc.ClientConnInterface
-}
-
-func buildAuthorizationProviders(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, deps Deps) (authorizationProviderSets, error) {
+func buildAuthorizationProviders(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, deps Deps) (map[string]core.AuthorizationProvider, error) {
 	if len(cfg.Providers.Authorization) == 0 {
-		return authorizationProviderSets{}, nil
+		return nil, nil
 	}
 	name, entry, err := cfg.SelectedAuthorizationProvider()
 	if err != nil {
-		return authorizationProviderSets{}, err
+		return nil, err
 	}
 	if entry == nil {
-		return authorizationProviderSets{}, nil
+		return nil, nil
 	}
-	providers, err := buildNamedAuthorizationProvider(ctx, cfg, name, entry, factories, deps)
+	provider, err := buildNamedAuthorizationProvider(ctx, cfg, name, entry, factories, deps)
 	if err != nil {
-		return authorizationProviderSets{}, err
+		return nil, err
 	}
-	return authorizationProviderSets{
-		Raw:   map[string]core.AuthorizationProvider{name: providers.Raw},
-		Conns: map[string]grpc.ClientConnInterface{name: providers.Conn},
-	}, nil
+	return map[string]core.AuthorizationProvider{name: provider}, nil
 }
 
-func buildNamedAuthorizationProvider(ctx context.Context, cfg *config.Config, name string, entry *config.ProviderEntry, factories *FactoryRegistry, deps Deps) (providerdrivers.AuthorizationBuildResult, error) {
+func buildNamedAuthorizationProvider(ctx context.Context, cfg *config.Config, name string, entry *config.ProviderEntry, factories *FactoryRegistry, deps Deps) (core.AuthorizationProvider, error) {
 	logicalName := strings.TrimSpace(name)
 	if logicalName == "" {
 		logicalName = "authorization"
 	}
 	if entry == nil {
-		return providerdrivers.AuthorizationBuildResult{}, fmt.Errorf("bootstrap: authorization provider %q is not configured", logicalName)
+		return nil, fmt.Errorf("bootstrap: authorization provider %q is not configured", logicalName)
 	}
 	if !providerBuildsLocal(cfg, entry) {
 		if deps.RemoteClients == nil || deps.RemoteClients.Authorization == nil {
-			return providerdrivers.AuthorizationBuildResult{}, fmt.Errorf("bootstrap: remote authorization client is required when server.remote is configured")
+			return nil, fmt.Errorf("bootstrap: remote authorization client is required when server.remote is configured")
 		}
-		provider, err := authorizationservice.NewRemote(deps.RemoteClients.Authorization, logicalName)
+		conn := grpc.ClientConnInterface(deps.RemoteClients.Conn())
+		if deps.GatewayTransport != nil {
+			target := providergateway.ProviderTarget{Kind: providergateway.ProviderKindAuthorization, Name: logicalName}
+			if err := deps.GatewayTransport.RegisterDirect(target, providergateway.DirectEndpoint{Conn: conn}); err != nil {
+				return nil, fmt.Errorf("bootstrap: authorization provider %q: %w", logicalName, err)
+			}
+			conn = deps.GatewayTransport.Conn(target)
+		}
+		provider, err := authorizationservice.NewRemote(conn, logicalName)
 		if err != nil {
-			return providerdrivers.AuthorizationBuildResult{}, fmt.Errorf("bootstrap: authorization provider %q: %w", logicalName, err)
+			return nil, fmt.Errorf("bootstrap: authorization provider %q: %w", logicalName, err)
 		}
-		return providerdrivers.AuthorizationBuildResult{Raw: provider, Conn: nil}, nil
+		return provider, nil
 	}
 	if factories.Authorization == nil {
-		return providerdrivers.AuthorizationBuildResult{}, fmt.Errorf("bootstrap: authorization factory is not registered")
+		return nil, fmt.Errorf("bootstrap: authorization factory is not registered")
 	}
 	node := entry.Config
 	if !config.IsComponentRuntimeConfigNode(node) {
 		var err error
 		node, err = config.BuildComponentRuntimeConfigNode(logicalName, providermanifestv1.KindAuthorization, entry, entry.Config)
 		if err != nil {
-			return providerdrivers.AuthorizationBuildResult{}, fmt.Errorf("bootstrap: authorization provider %q: %w", logicalName, err)
+			return nil, fmt.Errorf("bootstrap: authorization provider %q: %w", logicalName, err)
 		}
 	}
 	hostServices, err := buildProviderHostServices(logicalName, deps)
 	if err != nil {
-		return providerdrivers.AuthorizationBuildResult{}, fmt.Errorf("bootstrap: authorization provider %q: %w", logicalName, err)
+		return nil, fmt.Errorf("bootstrap: authorization provider %q: %w", logicalName, err)
 	}
-	provider, err := factories.Authorization(ctx, logicalName, node, hostServices, deps)
+	result, err := factories.Authorization(ctx, logicalName, node, hostServices, deps)
 	if err != nil {
-		return providerdrivers.AuthorizationBuildResult{}, fmt.Errorf("bootstrap: authorization provider %q: %w", logicalName, err)
+		return nil, fmt.Errorf("bootstrap: authorization provider %q: %w", logicalName, err)
 	}
-	return provider, nil
+	return result.Raw, nil
 }
 
 func buildIndexedDB(cfg *config.Config, name string, entry *config.ProviderEntry, factories *FactoryRegistry, deps Deps) (indexeddb.IndexedDB, error) {
@@ -2365,30 +2364,23 @@ func buildAgent(ctx context.Context, cfg *config.Config, name string, entry *con
 	return tracked, nil
 }
 
-func buildPublicGatewayTransport(
+func wirePublicGatewayTransport(
+	transport *providergateway.ProviderGatewayTransport,
 	cfg *config.Config,
 	auth core.IdentityProvider,
 	authorization map[string]core.AuthorizationProvider,
 	users providergateway.UserStore,
-) (*providergateway.ProviderGatewayTransport, error) {
-	if auth == nil {
-		return nil, nil
+) {
+	if transport == nil || auth == nil {
+		return
 	}
-	registry, err := publicrpc.NewGeneratedRegistry()
-	if err != nil {
-		return nil, fmt.Errorf("public rpc registry: %w", err)
-	}
-	transport := providergateway.NewProviderGatewayTransport()
 	transport.SetIdentityProvider(auth)
 	transport.SetUserStore(users)
-	transport.SetPublicMethods(registry)
 	if cfg != nil {
 		if name, _, err := cfg.SelectedAuthorizationProvider(); err == nil && name != "" && authorization != nil {
 			transport.SetAuthorizationProvider(authorization[name])
 		}
-		transport.SetPublicBaseURL(cfg.Server.BaseURL)
 	}
-	return transport, nil
 }
 
 func ProviderAuthorizationKinds(cfg *config.Config) map[string]invocation.ProviderKind {
@@ -2410,23 +2402,4 @@ func ProviderAuthorizationKinds(cfg *config.Config) map[string]invocation.Provid
 		kinds[name] = invocation.ProviderKindAgent
 	}
 	return kinds
-}
-
-func registerAuthorizationGatewayRoutes(
-	transport *providergateway.ProviderGatewayTransport,
-	cfg *config.Config,
-	conns map[string]grpc.ClientConnInterface,
-) error {
-	name, entry, _ := cfg.SelectedAuthorizationProvider()
-	if entry == nil || name == "" {
-		return nil
-	}
-	conn, ok := conns[name]
-	if !ok || conn == nil {
-		return nil
-	}
-	return transport.RegisterDirect(
-		providergateway.ProviderTarget{Kind: providergateway.ProviderKindAuthorization, Name: name},
-		providergateway.DirectEndpoint{Conn: conn},
-	)
 }

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -1900,7 +1900,7 @@ func TestBootstrapAuthorizationProviderStateUsesProviderGatewayTransport(t *test
 	factories.Authorization = func(_ context.Context, _ string, _ yaml.Node, _ []runtimehost.HostService, _ bootstrap.Deps) (providerdrivers.AuthorizationBuildResult, error) {
 		provider := &bootstrapTransportRecordingAuthorizationProvider{}
 		built = append(built, provider)
-		return providerdrivers.AuthorizationBuildResult{Raw: provider, Conn: &stubGatewayConn{}}, nil
+		return providerdrivers.AuthorizationBuildResult{Raw: provider}, nil
 	}
 
 	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
@@ -1919,16 +1919,6 @@ func TestBootstrapAuthorizationProviderStateUsesProviderGatewayTransport(t *test
 	if result.Authorization["authz"] != provider {
 		t.Fatal("bootstrapped authorization provider is not the runtime authorization provider")
 	}
-}
-
-type stubGatewayConn struct{}
-
-func (stubGatewayConn) Invoke(context.Context, string, any, any, ...grpc.CallOption) error {
-	return status.Error(codes.Unimplemented, "stubGatewayConn")
-}
-
-func (stubGatewayConn) NewStream(context.Context, *grpc.StreamDesc, string, ...grpc.CallOption) (grpc.ClientStream, error) {
-	return nil, status.Error(codes.Unimplemented, "stubGatewayConn")
 }
 
 func TestBootstrapResultClosesExtraCaches(t *testing.T) {

--- a/gestaltd/internal/daemon/factories.go
+++ b/gestaltd/internal/daemon/factories.go
@@ -154,7 +154,7 @@ func buildFactories() *bootstrap.FactoryRegistry {
 		})
 	}
 	factories.Authorization = func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps bootstrap.Deps) (providerdrivers.AuthorizationBuildResult, error) {
-		result, err := providerdrivers.AuthorizationFactory(ctx, name, node, hostServices, providerdrivers.AuthorizationDeps{})
+		result, err := providerdrivers.AuthorizationFactory(ctx, name, node, hostServices, providerdrivers.AuthorizationDeps{Gateway: deps.GatewayTransport})
 		if err != nil {
 			return providerdrivers.AuthorizationBuildResult{}, err
 		}

--- a/gestaltd/internal/remote/remote.go
+++ b/gestaltd/internal/remote/remote.go
@@ -86,6 +86,13 @@ func (c *ClientSet) Close() error {
 	return conn.Close()
 }
 
+// Conn returns the underlying gRPC connection to the remote gestaltd instance.
+func (c *ClientSet) Conn() *grpc.ClientConn {
+	if c == nil {
+		return nil
+	}
+	return c.conn
+}
 func clientSetFromConn(conn *grpc.ClientConn) *ClientSet {
 	return &ClientSet{
 		App:                 proto.NewAppClient(conn),

--- a/gestaltd/services/authorization/client.go
+++ b/gestaltd/services/authorization/client.go
@@ -102,14 +102,23 @@ func (e *Executable) Close() error {
 	return e.err
 }
 
-func NewFromExecutable(exec *Executable, cfg ExecConfig) (core.AuthorizationProvider, error) {
+func NewFromExecutable(exec io.Closer, conn grpc.ClientConnInterface) (core.AuthorizationProvider, error) {
 	if exec == nil {
 		return nil, fmt.Errorf("authorization executable is required")
 	}
-	client := rpcauthorization.NewConn(exec.Conn(), rpcauthorization.Options{
+	if conn == nil {
+		return nil, fmt.Errorf("authorization connection is required")
+	}
+	var runtime proto.ProviderLifecycleClient
+	if e, ok := exec.(interface {
+		Runtime() proto.ProviderLifecycleClient
+	}); ok {
+		runtime = e.Runtime()
+	}
+	client := rpcauthorization.NewConn(conn, rpcauthorization.Options{
 		UnaryTimeout: runtimehost.ProviderRPCTimeout,
 	})
-	return &remoteAuthorizationProvider{Client: client, runtime: exec.Runtime(), closer: exec}, nil
+	return &remoteAuthorizationProvider{Client: client, runtime: runtime, closer: exec}, nil
 }
 
 func NewExecutable(ctx context.Context, cfg ExecConfig) (core.AuthorizationProvider, error) {
@@ -117,7 +126,7 @@ func NewExecutable(ctx context.Context, cfg ExecConfig) (core.AuthorizationProvi
 	if err != nil {
 		return nil, err
 	}
-	provider, err := NewFromExecutable(exec, cfg)
+	provider, err := NewFromExecutable(exec, exec.Conn())
 	if err != nil {
 		_ = exec.Close()
 		return nil, err
@@ -125,21 +134,25 @@ func NewExecutable(ctx context.Context, cfg ExecConfig) (core.AuthorizationProvi
 	return provider, nil
 }
 
-// NewRemote returns an authorization provider backed by a public gRPC client.
-func NewRemote(client proto.AuthorizationClient, name string) (core.AuthorizationProvider, error) {
-	if client == nil {
-		return nil, fmt.Errorf("authorization provider client is required")
+// NewRemote returns an authorization provider backed by a public gRPC connection.
+func NewRemote(conn grpc.ClientConnInterface, name string) (core.AuthorizationProvider, error) {
+	if conn == nil {
+		return nil, fmt.Errorf("authorization provider connection is required")
 	}
 	name = strings.TrimSpace(name)
 	if name == "" {
 		return nil, fmt.Errorf("authorization provider name is required")
 	}
+	client := proto.NewAuthorizationClient(conn)
 	return rpcauthorization.NewClient(client, rpcauthorization.Options{
 		UnaryTimeout: runtimehost.ProviderRPCTimeout,
 	}), nil
 }
 
 func (r *remoteAuthorizationProvider) Ping(ctx context.Context) error {
+	if r == nil || r.runtime == nil {
+		return nil
+	}
 	ctx, cancel := runtimehost.ProviderCallContext(ctx)
 	defer cancel()
 	_, err := r.runtime.HealthCheck(ctx, &emptypb.Empty{})

--- a/gestaltd/services/providerdrivers/authorization.go
+++ b/gestaltd/services/providerdrivers/authorization.go
@@ -8,19 +8,20 @@ import (
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	authorizationservice "github.com/valon-technologies/gestalt/server/services/authorization"
 	"github.com/valon-technologies/gestalt/server/services/providerdrivers/componentprovider"
+	"github.com/valon-technologies/gestalt/server/services/providergateway"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
-	"google.golang.org/grpc"
 	"gopkg.in/yaml.v3"
 )
 
-type AuthorizationDeps struct{}
-
-type AuthorizationBuildResult struct {
-	Raw  core.AuthorizationProvider
-	Conn grpc.ClientConnInterface
+type AuthorizationDeps struct {
+	Gateway *providergateway.ProviderGatewayTransport
 }
 
-func AuthorizationFactory(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, _ AuthorizationDeps) (AuthorizationBuildResult, error) {
+type AuthorizationBuildResult struct {
+	Raw core.AuthorizationProvider
+}
+
+func AuthorizationFactory(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps AuthorizationDeps) (AuthorizationBuildResult, error) {
 	var cfg componentprovider.YAMLConfig
 	if err := node.Decode(&cfg); err != nil {
 		return AuthorizationBuildResult{}, fmt.Errorf("authorization provider: parsing config: %w", err)
@@ -54,14 +55,25 @@ func AuthorizationFactory(ctx context.Context, name string, node yaml.Node, host
 		return AuthorizationBuildResult{}, err
 	}
 
-	raw, err := authorizationservice.NewFromExecutable(exec, execCfg)
+	if deps.Gateway != nil {
+		target := providergateway.ProviderTarget{Kind: providergateway.ProviderKindAuthorization, Name: name}
+		if err := deps.Gateway.RegisterDirect(target, providergateway.DirectEndpoint{Conn: exec.Conn()}); err != nil {
+			_ = exec.Close()
+			return AuthorizationBuildResult{}, err
+		}
+		raw, err := authorizationservice.NewFromExecutable(exec, deps.Gateway.Conn(target))
+		if err != nil {
+			_ = exec.Close()
+			return AuthorizationBuildResult{}, err
+		}
+		return AuthorizationBuildResult{Raw: raw}, nil
+	}
+
+	raw, err := authorizationservice.NewFromExecutable(exec, exec.Conn())
 	if err != nil {
 		_ = exec.Close()
 		return AuthorizationBuildResult{}, err
 	}
 
-	return AuthorizationBuildResult{
-		Raw:  raw,
-		Conn: exec.Conn(),
-	}, nil
+	return AuthorizationBuildResult{Raw: raw}, nil
 }


### PR DESCRIPTION
Migrates the authorization RPC client to route through `gateway.Conn(target)` instead of using `exec.Conn()` directly. The `ProviderGatewayTransport` is created early in bootstrap and shared with the authorization factory via `Deps.GatewayTransport`. The factory registers the executable connection as a `DirectEndpoint` and builds the RPC client on `gateway.Conn(target)`. After `prepareCore`, the same transport is wired with identity/users/auth/publicMethods for the public surface. The remote authorization branch also routes through the gateway when a transport is available.

## Request Lifecycle

### Before

```mermaid
sequenceDiagram
    box gestaltd
    participant HostSvc as Authorization host service
    participant Client as RPC Client
    end
    box Provider subprocess
    participant Provider as Authorization Provider
    end

    HostSvc->>Client: provider.CheckAccess(ctx, req)
    Client->>Provider: grpc.CheckAccess via exec.Conn()
    Provider-->>Client: typed response
    Client-->>HostSvc: typed response
```

### After

```mermaid
sequenceDiagram
    box gestaltd
    participant HostSvc as Authorization host service
    participant Client as RPC Client
    participant Gateway as ProviderGatewayTransport
    end
    box Provider subprocess
    participant Provider as Authorization Provider
    end

    HostSvc->>Client: provider.CheckAccess(ctx, req)
    Client->>Gateway: Conn(target).Invoke(method, req, reply)
    Gateway->>Gateway: registry.Resolve(target)
    Note over Gateway: authorization-kind exempt by ProviderKind
    Gateway->>Provider: endpoint.Conn.Invoke(method, req, reply)
    Provider-->>Gateway: typed response
    Gateway-->>Client: error or nil
    Client-->>HostSvc: typed response
```
