### PR TITLE
feat(sdk/typescript): expose gestalt() in HTTPSubjectResolutionContext

### DIFF
--- a/sdk/typescript/src/api.ts
+++ b/sdk/typescript/src/api.ts
@@ -281,3 +281,6 @@ export function errorMessage(error: unknown): string {
   }
   return String(error);
 }
+
+
+export { type BoundGestalt, type RequestGestaltOptions } from "./bound-gestalt.ts";

--- a/sdk/typescript/src/http-subject.ts
+++ b/sdk/typescript/src/http-subject.ts
@@ -1,8 +1,10 @@
 import type {
   Access,
+  BoundGestalt,
   Credential,
   Host,
   MaybePromise,
+  RequestGestaltOptions,
   Subject,
   SubjectInput,
 } from "./api.ts";
@@ -35,6 +37,10 @@ export interface HTTPSubjectResolutionContext {
   access: Access;
   host: Host;
   workflow: Record<string, unknown>;
+  /**
+   * Returns the bound Gestalt client for nested host-service calls.
+   */
+  gestalt(options?: RequestGestaltOptions): Promise<BoundGestalt>;
 }
 
 /**
@@ -107,6 +113,7 @@ export function cloneHTTPSubjectResolutionContext(
     host: {
       ...input.host,
     },
+    gestalt: input.gestalt,
     workflow: {
       ...input.workflow,
     },

--- a/sdk/typescript/src/providers/runtime.ts
+++ b/sdk/typescript/src/providers/runtime.ts
@@ -224,7 +224,11 @@ export type LoadedProvider =
 type ProviderRuntimeEntry = {
   isProvider: (value: unknown) => value is LoadedProvider;
   protoKind: ProtoProviderKind;
-  registerService: (router: ConnectRouter, provider: LoadedProvider) => void;
+  registerService: (
+    router: ConnectRouter,
+    provider: LoadedProvider,
+    context?: HandlerContext,
+  ) => void;
 };
 
 const PROVIDER_RUNTIME_ENTRIES: Partial<
@@ -669,13 +673,25 @@ export function createProviderService(
         closeRequestGestaltScope(providerReq);
       }
     },
-    async resolveHTTPSubject(request: ProtoResolveHTTPSubjectRequest) {
-      let subject;
+    async resolveHTTPSubject(request: ProtoResolveHTTPSubjectRequest, context: HandlerContext) {
+      const { ctx, close } = providerHTTPSubjectResolutionContext(
+        request.context,
+        context.requestHeader.get(HOST_SERVICE_RELAY_TOKEN_HEADER)?.trim() ?? "",
+      );
       try {
-        subject = await provider.resolveHTTPSubject(
+        const subject = await provider.resolveHTTPSubject(
           providerHTTPSubjectRequest(request.request),
-          providerHTTPSubjectResolutionContext(request.context),
+          ctx,
         );
+        return create(ResolveHTTPSubjectResponseSchema, subject
+          ? {
+              subject: {
+                id: subject.id,
+                email: subject.email ?? "",
+                displayName: subject.displayName ?? "",
+              },
+            }
+          : {});
       } catch (error) {
         if (error instanceof HTTPSubjectResolutionError) {
           return create(ResolveHTTPSubjectResponseSchema, {
@@ -687,16 +703,9 @@ export function createProviderService(
           `resolve http subject: ${errorMessage(error)}`,
           Code.Unknown,
         );
+      } finally {
+        close();
       }
-      return create(ResolveHTTPSubjectResponseSchema, subject
-        ? {
-            subject: {
-              id: subject.id,
-              email: subject.email ?? "",
-              displayName: subject.displayName ?? "",
-            },
-          }
-        : {});
     },
     async getSessionCatalog(request: GetSessionCatalogRequest, context: HandlerContext) {
       const providerReq = providerRequest(
@@ -986,12 +995,14 @@ function providerRequest(
   requestContext?: ProtoRequestContext,
   idempotencyKey = "",
   rpc?: HandlerContext,
+  capability = "",
 ): Request {
   const credential = requestContext?.credential;
   const access = requestContext?.access;
   const host = requestContext?.host;
-  const invocationCapability =
-    rpc?.requestHeader.get(HOST_SERVICE_RELAY_TOKEN_HEADER)?.trim() ?? "";
+  const invocationCapability = capability.trim() !== ""
+    ? capability
+    : rpc?.requestHeader.get(HOST_SERVICE_RELAY_TOKEN_HEADER)?.trim() ?? "";
   return attachRequestHelpers({
     token,
     connectionParams: {
@@ -1076,14 +1087,26 @@ function providerHTTPSubjectRequest(
 
 function providerHTTPSubjectResolutionContext(
   requestContext?: ProtoRequestContext,
-): HTTPSubjectResolutionContext {
-  const request = providerRequest("", {}, requestContext);
+  invocationCapability?: string,
+): { ctx: HTTPSubjectResolutionContext; close(): void } {
+  const request = providerRequest(
+    "",
+    {},
+    requestContext,
+    "",
+    undefined,
+    invocationCapability,
+  );
   return {
-    subject: request.subject,
-    credential: request.credential,
-    access: request.access,
-    host: request.host,
-    workflow: request.workflow,
+    ctx: {
+      subject: request.subject,
+      credential: request.credential,
+      access: request.access,
+      host: request.host,
+      workflow: request.workflow,
+      gestalt: request.gestalt,
+    },
+    close: () => closeRequestGestaltScope(request),
   };
 }
 

--- a/sdk/typescript/tests/runtime.test.ts
+++ b/sdk/typescript/tests/runtime.test.ts
@@ -733,6 +733,35 @@ test("integration provider closes gestalt transport scope after execute and sess
     );
     expect(transportCreations).toBe(1);
     expect(transportCloses).toBe(1);
+
+    transportCreations = 0;
+    transportCloses = 0;
+
+    const resolveSubjectApp = defineApp({
+      async resolveHTTPSubject(_request, context) {
+        await context.gestalt();
+        return { id: "user:test" };
+      },
+      operations: [
+        {
+          id: "noop",
+          handler() {
+            return { ok: true };
+          },
+        },
+      ],
+    });
+    const resolveService = createProviderService(resolveSubjectApp);
+    await (resolveService.resolveHTTPSubject as any)(
+      create(ResolveHTTPSubjectRequestSchema, {
+        request: create(HTTPSubjectRequestSchema, {
+          binding: "command",
+        }),
+      }),
+      relayContext,
+    );
+    expect(transportCreations).toBe(1);
+    expect(transportCloses).toBe(1);
   } finally {
     createTransport.mockRestore();
     if (previousSocket === undefined) {
@@ -857,6 +886,12 @@ test("integration provider service resolves hosted HTTP subjects through the app
         },
       }),
     }),
+    {
+      requestHeader: {
+        get: (name: string) =>
+          name === HOST_SERVICE_RELAY_TOKEN_HEADER ? "relay-token" : undefined,
+      },
+    } as HandlerContext,
   );
   expect(resolved.subject).toMatchObject({
     id: "user:user-456",
@@ -912,6 +947,7 @@ test("integration provider service resolves hosted HTTP subjects through the app
         binding: "command",
       },
     },
+    gestalt: expect.any(Function),
   });
 
   const fallback = await (service.resolveHTTPSubject as any)(
@@ -920,6 +956,12 @@ test("integration provider service resolves hosted HTTP subjects through the app
         binding: "events",
       }),
     }),
+    {
+      requestHeader: {
+        get: (name: string) =>
+          name === HOST_SERVICE_RELAY_TOKEN_HEADER ? "relay-token" : undefined,
+      },
+    } as HandlerContext,
   );
   expect(fallback.subject).toBeUndefined();
 
@@ -943,6 +985,12 @@ test("integration provider service resolves hosted HTTP subjects through the app
         binding: "command",
       }),
     }),
+    {
+      requestHeader: {
+        get: (name: string) =>
+          name === HOST_SERVICE_RELAY_TOKEN_HEADER ? "relay-token" : undefined,
+      },
+    } as HandlerContext,
   );
   expect(rejected.rejectStatus).toBe(403);
   expect(rejected.rejectMessage).toBe("unmapped slack subject");
@@ -968,6 +1016,12 @@ test("integration provider service resolves hosted HTTP subjects through the app
           binding: "command",
         }),
       }),
+      {
+        requestHeader: {
+          get: (name: string) =>
+            name === HOST_SERVICE_RELAY_TOKEN_HEADER ? "relay-token" : undefined,
+        },
+      } as HandlerContext,
     ),
     Code.Unknown,
   );


### PR DESCRIPTION
## Summary

Extend the TypeScript SDK's `HTTPSubjectResolutionContext` so that `resolveHTTPSubject` hooks can call host services (e.g. `identity.introspect`). This lets an app reject unauthenticated HTTP binding requests with a real 401 before the operation runs, and lets the operation execute as the resolved Valon user instead of the generic `system:http_binding:*` subject.

## New interface

```ts
export interface HTTPSubjectResolutionContext {
  subject: Subject;
  credential: Credential;
  access: Access;
  host: Host;
  workflow: Record<string, unknown>;
  /**
   * Returns the bound Gestalt client for nested host-service calls.
   */
  gestalt(options?: RequestGestaltOptions): Promise<BoundGestalt>;
}
```

## Runtime forwarding

`resolveHTTPSubject` is now a per-request handler that receives the incoming gRPC `HandlerContext`, reads the host-service relay token from `requestHeader.get("x-gestalt-host-service-relay-token")`, and passes it into `providerRequest`. This matches how `execute` and `getSessionCatalog` already build `request.gestalt()`:

```ts
async resolveHTTPSubject(request: ProtoResolveHTTPSubjectRequest, context: HandlerContext) {
  const { ctx, close } = providerHTTPSubjectResolutionContext(
    request.context,
    context.requestHeader.get(HOST_SERVICE_RELAY_TOKEN_HEADER)?.trim() ?? "",
  );
  try {
    const subject = await provider.resolveHTTPSubject(
      providerHTTPSubjectRequest(request.request),
      ctx,
    );
    return create(ResolveHTTPSubjectResponseSchema, subject ? { ... } : {});
  } catch (error) { ... }
  finally {
    close(); // closes the request gestalt transport scope
  }
}
```

The `providerHTTPSubjectResolutionContext` helper returns both the context and a `close()` callback so the transport scope is cleaned up after the hook runs, matching `execute` and `getSessionCatalog`.

## Consumer usage (llm app)

```ts
export const provider = defineApp({
  name: "llm",
  // ...
  async resolveHTTPSubject(req, ctx) {
    const token = bearer(req.headers.authorization);
    if (!token) throw httpSubjectError(401, "missing bearer token");
    const g = await ctx.gestalt();
    const r = await g.identity.introspect(token, "access_token");
    if (!r.active) throw httpSubjectError(401, "invalid token");
    return { id: r.subject };
  },
  operations: [
    operation({
      id: "responses",
      output: stream({ mediaType: "text/event-stream" }),
      async handler(input) { /* no auth here */ },
    }),
  ],
});
```

## Verification

- `bun run test` passes (162 tests).
- `bun run typecheck` passes.
- New test confirms the gestalt transport scope is closed after `resolveHTTPSubject` calls `ctx.gestalt()`.
