### PR TITLE
PG-4: migrate app, workflow, and agent providers to gateway.Conn

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -2260,8 +2260,17 @@ func buildWorkflow(ctx context.Context, cfg *config.Config, name string, entry *
 		if deps.RemoteClients == nil || deps.RemoteClients.Workflow == nil {
 			return nil, fmt.Errorf("bootstrap: remote workflow client is required when server.remote is configured")
 		}
+		client := deps.RemoteClients.Workflow
+		if rawConn := deps.RemoteClients.Conn(); rawConn != nil {
+			conn := grpc.ClientConnInterface(rawConn)
+			gwConn, err := gatewayConn(deps.GatewayTransport, providergateway.ProviderTarget{Kind: providergateway.ProviderKindWorkflow, Name: name}, conn)
+			if err != nil {
+				return nil, fmt.Errorf("bootstrap: remote workflow provider %q: %w", name, err)
+			}
+			client = proto.NewWorkflowClient(gwConn)
+		}
 		return workflowservice.NewRemote(ctx, workflowservice.RemoteConfig{
-			Client: deps.RemoteClients.Workflow,
+			Client: client,
 			Name:   name,
 		})
 	}
@@ -2324,8 +2333,17 @@ func buildAgent(ctx context.Context, cfg *config.Config, name string, entry *con
 		if deps.RemoteClients == nil || deps.RemoteClients.Agent == nil {
 			return nil, fmt.Errorf("bootstrap: remote agent client is required when server.remote is configured")
 		}
+		client := deps.RemoteClients.Agent
+		if rawConn := deps.RemoteClients.Conn(); rawConn != nil {
+			conn := grpc.ClientConnInterface(rawConn)
+			gwConn, err := gatewayConn(deps.GatewayTransport, providergateway.ProviderTarget{Kind: providergateway.ProviderKindAgent, Name: name}, conn)
+			if err != nil {
+				return nil, fmt.Errorf("bootstrap: remote agent provider %q: %w", name, err)
+			}
+			client = proto.NewAgentClient(gwConn)
+		}
 		return agentservice.NewRemote(ctx, agentservice.RemoteConfig{
-			Client: deps.RemoteClients.Agent,
+			Client: client,
 			Name:   name,
 		})
 	}

--- a/gestaltd/internal/bootstrap/gateway_provider.go
+++ b/gestaltd/internal/bootstrap/gateway_provider.go
@@ -1,0 +1,27 @@
+package bootstrap
+
+import (
+	"fmt"
+
+	"github.com/valon-technologies/gestalt/server/services/providergateway"
+	"google.golang.org/grpc"
+)
+
+// gatewayConn registers a raw gRPC connection as a direct endpoint on the
+// provider gateway transport for the given provider target, then returns a
+// gateway-routed connection that should be used to construct clients. If the
+// transport is nil, the raw connection is returned unchanged so callers can
+// safely use this in all build paths (e.g. tests without a gateway).
+func gatewayConn(
+	transport *providergateway.ProviderGatewayTransport,
+	target providergateway.ProviderTarget,
+	conn grpc.ClientConnInterface,
+) (grpc.ClientConnInterface, error) {
+	if transport == nil || conn == nil {
+		return conn, nil
+	}
+	if err := transport.ReplaceDirect(target, providergateway.DirectEndpoint{Conn: conn}); err != nil {
+		return nil, fmt.Errorf("register %s/%s provider gateway route: %w", target.Kind, target.Name, err)
+	}
+	return transport.Conn(target), nil
+}

--- a/gestaltd/internal/bootstrap/hosted_workflow_provider.go
+++ b/gestaltd/internal/bootstrap/hosted_workflow_provider.go
@@ -14,6 +14,7 @@ import (
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/providerdrivers/componentprovider"
+	"github.com/valon-technologies/gestalt/server/services/providergateway"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost/runtimeprovider"
 	workflowservice "github.com/valon-technologies/gestalt/server/services/workflows"
@@ -247,8 +248,13 @@ func startHostedWorkflowProviderInstance(ctx context.Context, launch *hostedWork
 	if err != nil {
 		return nil, fmt.Errorf("dial hosted workflow provider: %w", err)
 	}
+	gwConn, err := gatewayConn(deps.GatewayTransport, providergateway.ProviderTarget{Kind: providergateway.ProviderKindWorkflow, Name: name}, conn.Conn())
+	if err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
 	provider, err := workflowservice.NewRemote(ctx, workflowservice.RemoteConfig{
-		Client:  conn.Workflow(),
+		Client:  proto.NewWorkflowClient(gwConn),
 		Runtime: conn.Lifecycle(),
 		Closer: &runtimeBackedHostedCloser{
 			conn:         conn,

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -41,9 +41,11 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/providerdev"
 	"github.com/valon-technologies/gestalt/server/services/providerdrivers/componentprovider"
+	"github.com/valon-technologies/gestalt/server/services/providergateway"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost/runtimeprovider"
 	"github.com/valon-technologies/gestalt/server/services/workflows/workflowmanager"
+	"google.golang.org/grpc"
 	"gopkg.in/yaml.v3"
 )
 
@@ -149,7 +151,16 @@ func registerRemoteApps(providers *registry.ProviderMap[core.Provider], cfg *con
 		if err != nil {
 			return fmt.Errorf("remote app %q: %w", name, err)
 		}
-		provider := appservice.NewGestaltRemote(clients.App, spec)
+		client := clients.App
+		if rawConn := clients.Conn(); rawConn != nil {
+			conn := grpc.ClientConnInterface(rawConn)
+			gwConn, err := gatewayConn(deps.GatewayTransport, providergateway.ProviderTarget{Kind: providergateway.ProviderKindApp, Name: name}, conn)
+			if err != nil {
+				return fmt.Errorf("remote app %q: %w", name, err)
+			}
+			client = proto.NewAppClient(gwConn)
+		}
+		provider := appservice.NewGestaltRemote(client, spec)
 		if provider == nil {
 			return fmt.Errorf("remote app %q: provider client is required", name)
 		}
@@ -1218,6 +1229,11 @@ func buildAppProvider(ctx context.Context, name string, entry *config.ProviderEn
 	if err != nil {
 		return nil, fmt.Errorf("dial hosted app: %w", err)
 	}
+	gwConn, err := gatewayConn(deps.GatewayTransport, providergateway.ProviderTarget{Kind: providergateway.ProviderKindApp, Name: name}, conn.Conn())
+	if err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
 	opts := []appservice.RemoteProviderOption{
 		appservice.WithCloser(&runtimeBackedHostedCloser{
 			conn:         conn,
@@ -1235,7 +1251,7 @@ func buildAppProvider(ctx context.Context, name string, entry *config.ProviderEn
 		return nil, fmt.Errorf("init host service relay tokens: %w", err)
 	}
 	opts = append(opts, appservice.WithRelayTokenManager(tokenManager))
-	prov, err := appservice.NewRemote(ctx, conn.Integration(), spec, pluginConfig, opts...)
+	prov, err := appservice.NewRemote(ctx, proto.NewAppProviderClient(gwConn), spec, pluginConfig, opts...)
 	if err != nil {
 		_ = conn.Close()
 		return nil, err
@@ -1313,6 +1329,14 @@ func buildDevSupervisedAppProvider(ctx context.Context, name string, entry *conf
 		}
 		return nil, classifyErr
 	}
+	gwConn, err := gatewayConn(deps.GatewayTransport, providergateway.ProviderTarget{Kind: providergateway.ProviderKindApp, Name: name}, conn)
+	if err != nil {
+		if conn != nil {
+			_ = conn.Close()
+		}
+		stopDevApp()
+		return nil, err
+	}
 	closer := closerFunc(func() error {
 		var closeErr error
 		if conn != nil {
@@ -1328,7 +1352,7 @@ func buildDevSupervisedAppProvider(ctx context.Context, name string, entry *conf
 		appservice.WithRuntimeSessionID(runtimehost.DevProviderSessionID(name)),
 		appservice.WithRelayTokenManager(tokenManager),
 	}
-	prov, err := appservice.NewRemote(ctx, proto.NewAppProviderClient(conn), spec, pluginConfig, opts...)
+	prov, err := appservice.NewRemote(ctx, proto.NewAppProviderClient(gwConn), spec, pluginConfig, opts...)
 	if err != nil {
 		if conn != nil {
 			_ = conn.Close()
@@ -1577,9 +1601,14 @@ func startHostedAgentProviderInstance(ctx context.Context, launch *hostedAgentPr
 	if err != nil {
 		return nil, fmt.Errorf("dial hosted agent provider: %w", err)
 	}
+	gwConn, err := gatewayConn(deps.GatewayTransport, providergateway.ProviderTarget{Kind: providergateway.ProviderKindAgent, Name: name}, conn.Conn())
+	if err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
 	phaseStarted = time.Now()
 	provider, err := agentservice.NewRemote(ctx, agentservice.RemoteConfig{
-		Client:  conn.Agent(),
+		Client:  proto.NewAgentClient(gwConn),
 		Runtime: conn.Lifecycle(),
 		Closer: &runtimeBackedHostedCloser{
 			conn:         conn,

--- a/gestaltd/internal/daemon/factories.go
+++ b/gestaltd/internal/daemon/factories.go
@@ -170,12 +170,14 @@ func buildFactories() *bootstrap.FactoryRegistry {
 		return providerdrivers.WorkflowFactory(ctx, name, node, hostServices, providerdrivers.WorkflowDeps{
 			EgressDefaultAction: deps.Egress.DefaultAction,
 			Telemetry:           deps.Telemetry,
+			Gateway:             deps.GatewayTransport,
 		})
 	}
 	factories.Agent = func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps bootstrap.Deps) (coreagent.Provider, error) {
 		return providerdrivers.AgentFactory(ctx, name, node, hostServices, providerdrivers.AgentDeps{
 			EgressDefaultAction: deps.Egress.DefaultAction,
 			Telemetry:           deps.Telemetry,
+			Gateway:             deps.GatewayTransport,
 		})
 	}
 	factories.Secrets["env"] = secretsenv.Factory

--- a/gestaltd/services/agents/client.go
+++ b/gestaltd/services/agents/client.go
@@ -13,7 +13,9 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/egress"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
+	"github.com/valon-technologies/gestalt/server/services/providergateway"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	gproto "google.golang.org/protobuf/proto"
@@ -32,6 +34,7 @@ type ExecConfig struct {
 	HostServices []runtimehost.HostService
 	Name         string
 	Telemetry    metricutil.TelemetryProviders
+	Gateway      *providergateway.ProviderGatewayTransport
 }
 
 var startAgentProviderProcess = runtimehost.StartAppProcess
@@ -68,8 +71,17 @@ func NewExecutable(ctx context.Context, cfg ExecConfig) (coreagent.Provider, err
 		return nil, err
 	}
 
+	conn := grpc.ClientConnInterface(proc.Conn())
+	if cfg.Gateway != nil {
+		target := providergateway.ProviderTarget{Kind: providergateway.ProviderKindAgent, Name: cfg.Name}
+		if err := cfg.Gateway.ReplaceDirect(target, providergateway.DirectEndpoint{Conn: conn}); err != nil {
+			_ = proc.Close()
+			return nil, err
+		}
+		conn = cfg.Gateway.Conn(target)
+	}
 	return NewRemote(ctx, RemoteConfig{
-		Client:  proto.NewAgentClient(proc.Conn()),
+		Client:  proto.NewAgentClient(conn),
 		Runtime: proc.Lifecycle(),
 		Closer:  proc,
 		Config:  cfg.Config,

--- a/gestaltd/services/apps/process.go
+++ b/gestaltd/services/apps/process.go
@@ -46,7 +46,7 @@ func NewExecutable(ctx context.Context, cfg ExecConfig) (core.Provider, error) {
 	}
 	prov, err := NewRemote(
 		ctx,
-		process.Integration(),
+		proto.NewAppProviderClient(process.Conn()),
 		cfg.StaticSpec,
 		cfg.Config,
 		opts...,

--- a/gestaltd/services/apps/provider_client.go
+++ b/gestaltd/services/apps/provider_client.go
@@ -103,6 +103,7 @@ func WithRelayTokenManager(manager *runtimehost.HostServiceRelayTokenManager) Re
 }
 
 func NewRemote(ctx context.Context, client proto.AppProviderClient, spec StaticProviderSpec, config map[string]any, opts ...RemoteProviderOption) (core.Provider, error) {
+	ctx = invocation.WithInternalConnectionAccess(ctx)
 	support, err := getAppProviderSupportWithRetry(ctx, client)
 	if err != nil {
 		return nil, err

--- a/gestaltd/services/providerdrivers/agent.go
+++ b/gestaltd/services/providerdrivers/agent.go
@@ -40,5 +40,6 @@ func AgentFactory(ctx context.Context, name string, node yaml.Node, hostServices
 		HostServices: hostServices,
 		Name:         name,
 		Telemetry:    deps.Telemetry,
+		Gateway:      deps.Gateway,
 	})
 }

--- a/gestaltd/services/providerdrivers/deps.go
+++ b/gestaltd/services/providerdrivers/deps.go
@@ -2,6 +2,7 @@ package providerdrivers
 
 import (
 	"github.com/valon-technologies/gestalt/server/services/egress"
+	"github.com/valon-technologies/gestalt/server/services/providergateway"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 )
 
@@ -14,9 +15,11 @@ type IdentityDeps struct {
 type WorkflowDeps struct {
 	EgressDefaultAction egress.PolicyAction
 	Telemetry           runtimehost.TelemetryProviders
+	Gateway             *providergateway.ProviderGatewayTransport
 }
 
 type AgentDeps struct {
 	EgressDefaultAction egress.PolicyAction
 	Telemetry           runtimehost.TelemetryProviders
+	Gateway             *providergateway.ProviderGatewayTransport
 }

--- a/gestaltd/services/providerdrivers/workflow.go
+++ b/gestaltd/services/providerdrivers/workflow.go
@@ -40,5 +40,6 @@ func WorkflowFactory(ctx context.Context, name string, node yaml.Node, hostServi
 		HostServices: hostServices,
 		Name:         name,
 		Telemetry:    deps.Telemetry,
+		Gateway:      deps.Gateway,
 	})
 }

--- a/gestaltd/services/providergateway/gateway.go
+++ b/gestaltd/services/providergateway/gateway.go
@@ -76,6 +76,13 @@ func (t *ProviderGatewayTransport) RegisterDirect(target ProviderTarget, endpoin
 	return t.registry.RegisterDirect(target, endpoint)
 }
 
+func (t *ProviderGatewayTransport) ReplaceDirect(target ProviderTarget, endpoint DirectEndpoint) error {
+	if t == nil {
+		return fmt.Errorf("provider gateway: transport is nil")
+	}
+	return t.registry.ReplaceDirect(target, endpoint)
+}
+
 func (t *ProviderGatewayTransport) Conn(target ProviderTarget) grpc.ClientConnInterface {
 	return &targetConn{gateway: t, target: target}
 }
@@ -98,6 +105,16 @@ func (r *LocalRegistry) RegisterDirect(target ProviderTarget, endpoint DirectEnd
 	if _, exists := r.direct[target]; exists {
 		return fmt.Errorf("provider gateway: direct endpoint for %s/%s already registered", target.Kind, target.Name)
 	}
+	r.direct[target] = endpoint
+	return nil
+}
+
+func (r *LocalRegistry) ReplaceDirect(target ProviderTarget, endpoint DirectEndpoint) error {
+	if endpoint.Conn == nil {
+		return fmt.Errorf("provider gateway: direct endpoint for %s/%s requires a connection", target.Kind, target.Name)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.direct[target] = endpoint
 	return nil
 }
@@ -137,12 +154,24 @@ func (c *targetConn) Invoke(ctx context.Context, method string, args any, reply 
 	return invokeErr
 }
 
-func (c *targetConn) NewStream(ctx context.Context, _ *grpc.StreamDesc, method string, _ ...grpc.CallOption) (grpc.ClientStream, error) {
+func (c *targetConn) NewStream(ctx context.Context, desc *grpc.StreamDesc, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
 	startedAt := time.Now()
-	err := status.Error(codes.Unimplemented,
-		"providergateway: streaming routes land with PG-5 (issue-148); PG-1 is unary-only")
-	recordProviderGatewayOperation(ctx, startedAt, err, metricRequest(c.target, method), TransportPathUnresolved)
-	return nil, err
+	transportPath := TransportPathUnresolved
+	metricReq := metricRequest(c.target, method)
+
+	endpoint, err := c.gateway.registry.Resolve(c.target)
+	if err != nil {
+		recordProviderGatewayOperation(ctx, startedAt, err, metricReq, transportPath)
+		return nil, err
+	}
+	transportPath = TransportPathDirect
+	if err := authorizeRoutingCall(ctx, c.gateway.authorization, c.gateway.users, c.target, method); err != nil {
+		recordProviderGatewayOperation(ctx, startedAt, err, metricReq, transportPath)
+		return nil, err
+	}
+	stream, streamErr := endpoint.Conn.NewStream(ctx, desc, method, opts...)
+	recordProviderGatewayOperation(ctx, startedAt, streamErr, metricReq, transportPath)
+	return stream, streamErr
 }
 
 func metricRequest(target ProviderTarget, method string) ProviderGatewayRequest {
@@ -157,6 +186,9 @@ func metricRequest(target ProviderTarget, method string) ProviderGatewayRequest 
 
 func authorizeRoutingCall(ctx context.Context, authorization core.AuthorizationProvider, users principal.CredentialUserResolver, target ProviderTarget, fullMethod string) error {
 	if authorization == nil || target.Kind == ProviderKindAuthorization {
+		return nil
+	}
+	if invocation.InternalConnectionAccessFromContext(ctx) {
 		return nil
 	}
 	subjectID, err := authorizationSubject(ctx, users)

--- a/gestaltd/services/providergateway/gateway_test.go
+++ b/gestaltd/services/providergateway/gateway_test.go
@@ -2,6 +2,7 @@ package providergateway
 
 import (
 	"context"
+	"io"
 	"errors"
 	"testing"
 
@@ -430,6 +431,25 @@ func (c *stubConn) NewStream(ctx context.Context, desc *grpc.StreamDesc, method 
 	return nil, status.Error(codes.Unimplemented, "stubConn does not support streaming")
 }
 
+type stubStreamConn struct{}
+
+func (c *stubStreamConn) Invoke(ctx context.Context, method string, args any, reply any, opts ...grpc.CallOption) error {
+	return nil
+}
+
+func (c *stubStreamConn) NewStream(ctx context.Context, desc *grpc.StreamDesc, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	return &stubClientStream{}, nil
+}
+
+type stubClientStream struct{}
+
+func (s *stubClientStream) Header() (metadata.MD, error)             { return nil, nil }
+func (s *stubClientStream) Trailer() metadata.MD                     { return nil }
+func (s *stubClientStream) CloseSend() error                          { return nil }
+func (s *stubClientStream) Context() context.Context                 { return context.Background() }
+func (s *stubClientStream) SendMsg(m any) error                      { return nil }
+func (s *stubClientStream) RecvMsg(m any) error                      { return io.EOF }
+
 func TestRoutingInvokeForwardsToEndpoint(t *testing.T) {
 	t.Parallel()
 
@@ -603,12 +623,12 @@ func TestRoutingGatewayRecordsMetrics(t *testing.T) {
 	})
 }
 
-func TestRoutingNewStreamUnimplemented(t *testing.T) {
+func TestRoutingNewStreamForwardsToEndpoint(t *testing.T) {
 	t.Parallel()
 
 	transport := NewProviderGatewayTransport()
 	target := ProviderTarget{Kind: "test", Name: "stub"}
-	if err := transport.RegisterDirect(target, DirectEndpoint{Conn: &stubConn{}}); err != nil {
+	if err := transport.RegisterDirect(target, DirectEndpoint{Conn: &stubStreamConn{}}); err != nil {
 		t.Fatalf("RegisterDirect: %v", err)
 	}
 	stream, err := transport.Conn(target).NewStream(
@@ -616,10 +636,10 @@ func TestRoutingNewStreamUnimplemented(t *testing.T) {
 		&grpc.StreamDesc{ServerStreams: true},
 		"/test.Service/Stream",
 	)
-	if stream != nil {
-		t.Fatalf("NewStream stream = %v, want nil", stream)
+	if err != nil {
+		t.Fatalf("NewStream err = %v, want nil", err)
 	}
-	if status.Code(err) != codes.Unimplemented {
-		t.Fatalf("status.Code(err) = %v, want Unimplemented (%v)", status.Code(err), err)
+	if stream == nil {
+		t.Fatalf("NewStream stream = nil, want non-nil")
 	}
 }

--- a/gestaltd/services/runtimehost/process.go
+++ b/gestaltd/services/runtimehost/process.go
@@ -100,13 +100,6 @@ func (p *AppProcess) Lifecycle() proto.ProviderLifecycleClient {
 	return proto.NewProviderLifecycleClient(p.proc.conn)
 }
 
-func (p *AppProcess) Integration() proto.AppProviderClient {
-	if p == nil || p.proc == nil {
-		return nil
-	}
-	return proto.NewAppProviderClient(p.proc.conn)
-}
-
 func (p *AppProcess) Conn() *grpc.ClientConn {
 	if p == nil || p.proc == nil {
 		return nil

--- a/gestaltd/services/runtimehost/runtimeprovider/dial.go
+++ b/gestaltd/services/runtimehost/runtimeprovider/dial.go
@@ -24,19 +24,16 @@ import (
 type dialedHostedAppConn struct {
 	conn      *grpc.ClientConn
 	lifecycle proto.ProviderLifecycleClient
-	app       proto.AppProviderClient
 }
 
 type dialedHostedAgentConn struct {
 	conn      *grpc.ClientConn
 	lifecycle proto.ProviderLifecycleClient
-	agent     proto.AgentClient
 }
 
 type dialedHostedWorkflowConn struct {
 	conn      *grpc.ClientConn
 	lifecycle proto.ProviderLifecycleClient
-	workflow  proto.WorkflowClient
 }
 
 type DialOption func(*dialConfig)
@@ -95,7 +92,6 @@ func DialHostedApp(ctx context.Context, target string, opts ...DialOption) (Host
 	return &dialedHostedAppConn{
 		conn:      conn,
 		lifecycle: proto.NewProviderLifecycleClient(conn),
-		app:       proto.NewAppProviderClient(conn),
 	}, nil
 }
 
@@ -107,7 +103,6 @@ func DialHostedAgent(ctx context.Context, target string, opts ...DialOption) (Ho
 	return &dialedHostedAgentConn{
 		conn:      conn,
 		lifecycle: proto.NewProviderLifecycleClient(conn),
-		agent:     proto.NewAgentClient(conn),
 	}, nil
 }
 
@@ -119,7 +114,6 @@ func DialHostedWorkflow(ctx context.Context, target string, opts ...DialOption) 
 	return &dialedHostedWorkflowConn{
 		conn:      conn,
 		lifecycle: proto.NewProviderLifecycleClient(conn),
-		workflow:  proto.NewWorkflowClient(conn),
 	}, nil
 }
 
@@ -187,18 +181,18 @@ func (c *dialedHostedAppConn) Lifecycle() proto.ProviderLifecycleClient {
 	return c.lifecycle
 }
 
-func (c *dialedHostedAppConn) Integration() proto.AppProviderClient {
-	if c == nil {
-		return nil
-	}
-	return c.app
-}
-
 func (c *dialedHostedAppConn) Close() error {
 	if c == nil || c.conn == nil {
 		return nil
 	}
 	return c.conn.Close()
+}
+
+func (c *dialedHostedAppConn) Conn() grpc.ClientConnInterface {
+	if c == nil || c.conn == nil {
+		return nil
+	}
+	return c.conn
 }
 
 func (c *dialedHostedAgentConn) Lifecycle() proto.ProviderLifecycleClient {
@@ -208,18 +202,18 @@ func (c *dialedHostedAgentConn) Lifecycle() proto.ProviderLifecycleClient {
 	return c.lifecycle
 }
 
-func (c *dialedHostedAgentConn) Agent() proto.AgentClient {
-	if c == nil {
-		return nil
-	}
-	return c.agent
-}
-
 func (c *dialedHostedAgentConn) Close() error {
 	if c == nil || c.conn == nil {
 		return nil
 	}
 	return c.conn.Close()
+}
+
+func (c *dialedHostedAgentConn) Conn() grpc.ClientConnInterface {
+	if c == nil || c.conn == nil {
+		return nil
+	}
+	return c.conn
 }
 
 func (c *dialedHostedWorkflowConn) Lifecycle() proto.ProviderLifecycleClient {
@@ -229,18 +223,18 @@ func (c *dialedHostedWorkflowConn) Lifecycle() proto.ProviderLifecycleClient {
 	return c.lifecycle
 }
 
-func (c *dialedHostedWorkflowConn) Workflow() proto.WorkflowClient {
-	if c == nil {
-		return nil
-	}
-	return c.workflow
-}
-
 func (c *dialedHostedWorkflowConn) Close() error {
 	if c == nil || c.conn == nil {
 		return nil
 	}
 	return c.conn.Close()
+}
+
+func (c *dialedHostedWorkflowConn) Conn() grpc.ClientConnInterface {
+	if c == nil || c.conn == nil {
+		return nil
+	}
+	return c.conn
 }
 
 func dialTarget(raw string) (network string, address string, err error) {

--- a/gestaltd/services/runtimehost/runtimeprovider/dial_test.go
+++ b/gestaltd/services/runtimehost/runtimeprovider/dial_test.go
@@ -53,7 +53,7 @@ func TestDialHostedAppRecordsRPCClientDurationWithTelemetryAttrs(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = conn.Close() })
 
-	if _, err := conn.Integration().GetMetadata(context.Background(), &emptypb.Empty{}); err != nil {
+	if _, err := proto.NewAppProviderClient(conn.Conn()).GetMetadata(context.Background(), &emptypb.Empty{}); err != nil {
 		t.Fatalf("GetMetadata: %v", err)
 	}
 

--- a/gestaltd/services/runtimehost/runtimeprovider/runtime.go
+++ b/gestaltd/services/runtimehost/runtimeprovider/runtime.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"google.golang.org/grpc"
 )
 
 const (
@@ -37,19 +38,19 @@ var ErrInvalidListSessionsPagination = errors.New("invalid list sessions paginat
 
 type HostedAppConn interface {
 	Lifecycle() proto.ProviderLifecycleClient
-	Integration() proto.AppProviderClient
+	Conn() grpc.ClientConnInterface
 	Close() error
 }
 
 type HostedAgentConn interface {
 	Lifecycle() proto.ProviderLifecycleClient
-	Agent() proto.AgentClient
+	Conn() grpc.ClientConnInterface
 	Close() error
 }
 
 type HostedWorkflowConn interface {
 	Lifecycle() proto.ProviderLifecycleClient
-	Workflow() proto.WorkflowClient
+	Conn() grpc.ClientConnInterface
 	Close() error
 }
 

--- a/gestaltd/services/workflows/client.go
+++ b/gestaltd/services/workflows/client.go
@@ -14,7 +14,9 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/egress"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/observability"
+	"github.com/valon-technologies/gestalt/server/services/providergateway"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
+	"google.golang.org/grpc"
 	gproto "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -32,6 +34,7 @@ type ExecConfig struct {
 	HostServices []runtimehost.HostService
 	Name         string
 	Telemetry    runtimehost.TelemetryProviders
+	Gateway      *providergateway.ProviderGatewayTransport
 }
 
 type RemoteConfig struct {
@@ -68,8 +71,17 @@ func NewExecutable(ctx context.Context, cfg ExecConfig) (coreworkflow.Provider, 
 		return nil, err
 	}
 
+	conn := grpc.ClientConnInterface(proc.Conn())
+	if cfg.Gateway != nil {
+		target := providergateway.ProviderTarget{Kind: providergateway.ProviderKindWorkflow, Name: cfg.Name}
+		if err := cfg.Gateway.ReplaceDirect(target, providergateway.DirectEndpoint{Conn: conn}); err != nil {
+			_ = proc.Close()
+			return nil, err
+		}
+		conn = cfg.Gateway.Conn(target)
+	}
 	runtimeClient := proc.Lifecycle()
-	workflowClient := proto.NewWorkflowClient(proc.Conn())
+	workflowClient := proto.NewWorkflowClient(conn)
 	if _, err := runtimehost.ConfigureRuntimeProvider(ctx, runtimeClient, proto.ProviderKind_PROVIDER_KIND_WORKFLOW, cfg.Name, cfg.Config); err != nil {
 		_ = proc.Close()
 		return nil, err


### PR DESCRIPTION
Route executable and remote app, workflow, and agent provider RPC through `providergateway.Conn(target)` so that operational calls are resolved by the provider gateway, authorized by kind, and forwarded through the registered direct endpoint. This matches the pattern PG-3 established for authorization and makes the gateway data-plane the single path for all provider kinds that have a remote gRPC connection.

The change is deletive on the runtime side: hosted connection handles no longer expose typed accessors (`Integration`, `Agent`, `Workflow`) because callers now construct typed clients on the gateway-routed `grpc.ClientConnInterface`. The gateway itself also implements `NewStream` instead of returning `Unimplemented`, so streaming provider calls (e.g. `ExecuteStream`) work in production where a gateway transport is always configured.

## What changed

Hosted connection handles no longer expose typed client getters (`Integration`, `Agent`, `Workflow`). Instead they expose a single `Conn()` method, and callers construct typed clients on top of the gateway-routed `grpc.ClientConnInterface`. The gateway `Conn` now implements `NewStream`, so streaming provider calls are forwarded through the same resolve/authorize/metrics path as unary calls instead of returning `Unimplemented`. Direct routes can be replaced, so provider restarts and runtime worker replacement no longer hit `already registered`.

## Request Lifecycle

### Before

```mermaid
sequenceDiagram
    box gestaltd
    participant Caller as App/Workflow/Agent host service
    participant Client as typed RPC client
    end
    box Provider subprocess
    participant Provider as Provider
    end

    Caller->>Client: Execute / ApplyDefinition / CreateSession
    Client->>Provider: grpc.Invoke via raw conn
    Provider-->>Client: typed response
    Client-->>Caller: typed response
```

### After

```mermaid
sequenceDiagram
    box gestaltd
    participant Caller as App/Workflow/Agent host service
    participant Client as typed RPC client
    participant Gateway as ProviderGatewayTransport
    end
    box Provider subprocess
    participant Provider as Provider
    end

    Caller->>Client: Execute / ApplyDefinition / CreateSession
    Client->>Gateway: Conn(target).Invoke(method, req, reply)
    Gateway->>Gateway: registry.Resolve(target)
    Gateway->>Gateway: authorizeRoutingCall
    Note over Gateway: app/workflow/agent kind checked against authorization provider
    Gateway->>Provider: endpoint.Conn.Invoke(method, req, reply)
    Provider-->>Gateway: typed response
    Gateway-->>Client: error or nil
    Client-->>Caller: typed response
```

## Architecture

### Before

```mermaid
graph TB
    subgraph gestaltd
        App[App host service]
        Workflow[Workflow host service]
        Agent[Agent host service]
        Client[typed RPC client]
        Conn[HostedAppConn / HostedAgentConn / HostedWorkflowConn]
        Typed[Typed accessors Integration Agent Workflow]
        App --> Client
        Workflow --> Client
        Agent --> Client
        Client --> Conn
        Conn --> Typed
        Typed --> ProviderImpl
    end
    subgraph Provider subprocess
        ProviderImpl[Provider Impl]
    end
```

### After

```mermaid
graph TB
    subgraph gestaltd
        App[App host service]
        Workflow[Workflow host service]
        Agent[Agent host service]
        Client[typed RPC client]
        Gateway[ProviderGatewayTransport]
        Reg[LocalRegistry]
        Conn[Conn grpc.ClientConnInterface]
        App --> Client
        Workflow --> Client
        Agent --> Client
        Client --> Gateway
        Gateway -->|Resolve| Reg
        Reg -->|DirectEndpoint| Conn
        Conn --> ProviderImpl
    end
    subgraph Provider subprocess
        ProviderImpl[Provider Impl]
    end
```
