### PR TITLE
App registry step 12: implement registry-only app lifecycle

### DIFF
--- a/gestaltd/internal/appregistry/errors.go
+++ b/gestaltd/internal/appregistry/errors.go
@@ -11,5 +11,14 @@ var ErrAppRolloutActive = errors.New("app already has an active rollout")
 // ErrAppVersionAlreadyInstalled means the requested app version is already in the catalog.
 var ErrAppVersionAlreadyInstalled = errors.New("app version is already installed")
 
+// ErrAppCatalogNotEmpty means add was requested for an app already known to the fleet.
+var ErrAppCatalogNotEmpty = errors.New("app already has fleet-known versions")
+
+// ErrAppCatalogEmpty means upgrade was requested before the app was added.
+var ErrAppCatalogEmpty = errors.New("app has no fleet-known versions")
+
+// ErrAppRegistryBinding means the request does not match the app's deploy-time registry source.
+var ErrAppRegistryBinding = errors.New("app registry binding does not match deploy config")
+
 // ErrInstallTimedOut means install work exceeded the bounded post-lock timeout.
 var ErrInstallTimedOut = errors.New("app version install timed out")

--- a/gestaltd/internal/appregistry/installer.go
+++ b/gestaltd/internal/appregistry/installer.go
@@ -46,7 +46,30 @@ type InstallOutput struct {
 	Installation *core.AppInstallation
 }
 
+type installMode int
+
+const (
+	installModeLegacy installMode = iota
+	installModeAdd
+	installModeUpgrade
+)
+
+const RegistryFirstInstallVersion = "registry:first-install"
+
+func (i *Installer) Add(ctx context.Context, input InstallInput) (*InstallOutput, error) {
+	return i.install(ctx, input, installModeAdd)
+}
+
+func (i *Installer) Upgrade(ctx context.Context, input InstallInput) (*InstallOutput, error) {
+	return i.install(ctx, input, installModeUpgrade)
+}
+
+// Install preserves the pre-registry-only behavior for internal callers.
 func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOutput, error) {
+	return i.install(ctx, input, installModeLegacy)
+}
+
+func (i *Installer) install(ctx context.Context, input InstallInput, mode installMode) (*InstallOutput, error) {
 	if i == nil {
 		return nil, fmt.Errorf("app registry installer is not configured")
 	}
@@ -65,6 +88,12 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 	}
 	if err := providerregistry.ValidateRepositoryName(appName); err != nil {
 		return nil, fmt.Errorf("invalid app name: %w", err)
+	}
+	if mode != installModeLegacy {
+		configEntry := i.ConfigApps[appName]
+		if configEntry == nil || !configEntry.Source.IsRegistry() || strings.TrimSpace(configEntry.Source.Registry) != registryName {
+			return nil, ErrAppRegistryBinding
+		}
 	}
 
 	if i.Locks != nil {
@@ -90,6 +119,32 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 	if i.Rollouts == nil {
 		return nil, fmt.Errorf("app rollout service is not configured")
 	}
+	knownVersions, err := i.ChangeRequests.ListKnownVersionsByApp(installCtx, appName)
+	if err != nil {
+		return nil, fmt.Errorf("list known app versions: %w", err)
+	}
+	var fromVersion string
+	switch mode {
+	case installModeAdd:
+		if len(knownVersions) != 0 {
+			return nil, ErrAppCatalogNotEmpty
+		}
+		fromVersion = RegistryFirstInstallVersion
+	case installModeUpgrade:
+		if len(knownVersions) == 0 {
+			return nil, ErrAppCatalogEmpty
+		}
+		fromVersion = coredata.LatestKnownVersion(knownVersions)
+	default:
+		var configEntry *config.ProviderEntry
+		if i.ConfigApps != nil {
+			configEntry = i.ConfigApps[appName]
+		}
+		fromVersion = resolveFromVersion(knownVersions, configEntry)
+		if fromVersion == "" {
+			return nil, fmt.Errorf("resolve from_version: no known fleet version and app is not pinned in config")
+		}
+	}
 	alreadyKnown, err := i.ChangeRequests.HasKnownVersion(installCtx, appName, version)
 	if err != nil {
 		return nil, fmt.Errorf("check known app version: %w", err)
@@ -103,19 +158,6 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 		}
 	} else if !errors.Is(getErr, core.ErrNotFound) {
 		return nil, fmt.Errorf("check active app rollout: %w", getErr)
-	}
-
-	knownVersions, err := i.ChangeRequests.ListKnownVersionsByApp(installCtx, appName)
-	if err != nil {
-		return nil, fmt.Errorf("list known app versions: %w", err)
-	}
-	var configEntry *config.ProviderEntry
-	if i.ConfigApps != nil {
-		configEntry = i.ConfigApps[appName]
-	}
-	fromVersion := resolveFromVersion(knownVersions, configEntry)
-	if fromVersion == "" {
-		return nil, fmt.Errorf("resolve from_version: no known fleet version and app is not pinned in config")
 	}
 
 	reader := i.Reader

--- a/gestaltd/internal/appregistry/installer_test.go
+++ b/gestaltd/internal/appregistry/installer_test.go
@@ -209,7 +209,7 @@ func TestInstaller_records_from_version_on_first_install_and_upgrade(t *testing.
 			"toolshed": fixture.Registry,
 		},
 		ConfigApps: map[string]*config.ProviderEntry{
-			"g-issues": configEntryWithResolvedVersion("0.0.0-config"),
+			"g-issues": {Source: config.ProviderSource{Registry: "toolshed"}},
 		},
 		Reader:         fixture.Reader,
 		ChangeRequests: svc.AppVersionChangeRequests,
@@ -217,7 +217,7 @@ func TestInstaller_records_from_version_on_first_install_and_upgrade(t *testing.
 		Rollouts:       svc.AppRollouts,
 	}
 
-	if _, err := installer.Install(ctx, appregistry.InstallInput{
+	if _, err := installer.Add(ctx, appregistry.InstallInput{
 		Registry: "toolshed",
 		App:      "g-issues",
 		Version:  fixture.Version,
@@ -233,10 +233,84 @@ func TestInstaller_records_from_version_on_first_install_and_upgrade(t *testing.
 	if len(requests) != 1 {
 		t.Fatalf("requests = %#v", requests)
 	}
-	if requests[0].FromVersion != "0.0.0-config" {
-		t.Fatalf("first from_version = %q, want 0.0.0-config", requests[0].FromVersion)
+	if requests[0].FromVersion != appregistry.RegistryFirstInstallVersion {
+		t.Fatalf("first from_version = %q, want %q", requests[0].FromVersion, appregistry.RegistryFirstInstallVersion)
 	}
 	if requests[0].ToVersion != fixture.Version {
 		t.Fatalf("first to_version = %q, want %s", requests[0].ToVersion, fixture.Version)
+	}
+
+	if _, err := svc.AppRollouts.MarkComplete(ctx, "g-issues", fixture.Version, time.Now()); err != nil {
+		t.Fatalf("MarkComplete: %v", err)
+	}
+	nextVersion := "0.0.0-snapshot.gdef456"
+	installer.Reader = fixture.NewDigestMismatchReader(t, nextVersion)
+	if _, err := installer.Upgrade(ctx, appregistry.InstallInput{
+		Registry: "toolshed",
+		App:      "g-issues",
+		Version:  nextVersion,
+		Actor:    "user:alice",
+	}); err != nil {
+		t.Fatalf("upgrade: %v", err)
+	}
+	requests, err = svc.AppVersionChangeRequests.ListRequestsByApp(ctx, "g-issues")
+	if err != nil {
+		t.Fatalf("ListRequestsByApp after upgrade: %v", err)
+	}
+	if len(requests) != 2 {
+		t.Fatalf("requests after upgrade = %#v", requests)
+	}
+	var upgradeRequest *core.AppVersionChangeRequest
+	for _, request := range requests {
+		if request.ToVersion == nextVersion {
+			upgradeRequest = request
+			break
+		}
+	}
+	if upgradeRequest == nil || upgradeRequest.FromVersion != fixture.Version {
+		t.Fatalf("upgrade request = %#v, want from_version %q", upgradeRequest, fixture.Version)
+	}
+}
+
+func TestInstaller_add_and_upgrade_enforce_catalog_state(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc := testutil.NewStubServices(t)
+	fixture := registrytest.NewInstallFixture(t)
+	installer := &appregistry.Installer{
+		Registries: map[string]config.AppRegistryConfig{"toolshed": fixture.Registry},
+		ConfigApps: map[string]*config.ProviderEntry{
+			"g-issues": {Source: config.ProviderSource{Registry: "toolshed"}},
+		},
+		Reader:         fixture.Reader,
+		ChangeRequests: svc.AppVersionChangeRequests,
+		Locks:          svc.AppVersionInstallLocks,
+		Rollouts:       svc.AppRollouts,
+	}
+	input := appregistry.InstallInput{Registry: "toolshed", App: "g-issues", Version: fixture.Version}
+
+	if _, err := installer.Upgrade(ctx, input); !errors.Is(err, appregistry.ErrAppCatalogEmpty) {
+		t.Fatalf("upgrade empty catalog error = %v, want %v", err, appregistry.ErrAppCatalogEmpty)
+	}
+	if _, err := installer.Add(ctx, input); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if _, err := installer.Add(ctx, input); !errors.Is(err, appregistry.ErrAppCatalogNotEmpty) {
+		t.Fatalf("add non-empty catalog error = %v, want %v", err, appregistry.ErrAppCatalogNotEmpty)
+	}
+}
+
+func TestInstaller_add_requires_deploy_registry_binding(t *testing.T) {
+	t.Parallel()
+
+	installer := &appregistry.Installer{}
+	_, err := installer.Add(t.Context(), appregistry.InstallInput{
+		Registry: "toolshed",
+		App:      "g-issues",
+		Version:  "1.0.0",
+	})
+	if !errors.Is(err, appregistry.ErrAppRegistryBinding) {
+		t.Fatalf("Add error = %v, want %v", err, appregistry.ErrAppRegistryBinding)
 	}
 }

--- a/gestaltd/internal/appregistry/materializer.go
+++ b/gestaltd/internal/appregistry/materializer.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/config"
@@ -21,11 +22,24 @@ type Materializer struct {
 	Registries   map[string]config.AppRegistryConfig
 	Reader       *RegistryReader
 	ArtifactsDir string
+
+	mu    sync.Mutex
+	locks map[string]*materializationLock
+}
+
+type materializationLock struct {
+	mu   sync.Mutex
+	refs int
 }
 
 type MaterializationResult struct {
 	Path    string
 	Changed bool
+}
+
+func (m *Materializer) MaterializeApp(ctx context.Context, installation *core.AppInstallation) error {
+	_, err := m.Ensure(ctx, installation)
+	return err
 }
 
 // MaterializedPath returns the on-disk directory for one installed app version.
@@ -54,6 +68,8 @@ func (m *Materializer) Ensure(ctx context.Context, installation *core.AppInstall
 	if artifactsDir == "" {
 		return nil, fmt.Errorf("artifacts directory is not configured")
 	}
+	unlock := m.lockMaterialization(appName + "\x00" + version)
+	defer unlock()
 
 	destDir := MaterializedPath(artifactsDir, appName, version)
 	if installedPackageReady(destDir, appName, version) {
@@ -95,6 +111,31 @@ func (m *Materializer) Ensure(ctx context.Context, installation *core.AppInstall
 		return nil, fmt.Errorf("materialize app artifact: %w", err)
 	}
 	return &MaterializationResult{Path: destDir, Changed: true}, nil
+}
+
+func (m *Materializer) lockMaterialization(key string) func() {
+	m.mu.Lock()
+	if m.locks == nil {
+		m.locks = make(map[string]*materializationLock)
+	}
+	lock := m.locks[key]
+	if lock == nil {
+		lock = &materializationLock{}
+		m.locks[key] = lock
+	}
+	lock.refs++
+	m.mu.Unlock()
+
+	lock.mu.Lock()
+	return func() {
+		lock.mu.Unlock()
+		m.mu.Lock()
+		lock.refs--
+		if lock.refs == 0 {
+			delete(m.locks, key)
+		}
+		m.mu.Unlock()
+	}
 }
 
 func installedPackageReady(destDir, appName, version string) bool {

--- a/gestaltd/internal/appregistry/materializer_lock_test.go
+++ b/gestaltd/internal/appregistry/materializer_lock_test.go
@@ -1,0 +1,50 @@
+package appregistry
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMaterializerLocksOnlyMatchingAppVersion(t *testing.T) {
+	t.Parallel()
+
+	materializer := &Materializer{}
+	unlockFirst := materializer.lockMaterialization("app-a\x001.0.0")
+	firstLocked := true
+	t.Cleanup(func() {
+		if firstLocked {
+			unlockFirst()
+		}
+	})
+
+	differentAcquired := make(chan func(), 1)
+	go func() {
+		differentAcquired <- materializer.lockMaterialization("app-b\x001.0.0")
+	}()
+	select {
+	case unlock := <-differentAcquired:
+		unlock()
+	case <-time.After(time.Second):
+		t.Fatal("different app version was blocked")
+	}
+
+	sameAcquired := make(chan func(), 1)
+	go func() {
+		sameAcquired <- materializer.lockMaterialization("app-a\x001.0.0")
+	}()
+	select {
+	case unlock := <-sameAcquired:
+		unlock()
+		t.Fatal("matching app version was not serialized")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	unlockFirst()
+	firstLocked = false
+	select {
+	case unlock := <-sameAcquired:
+		unlock()
+	case <-time.After(time.Second):
+		t.Fatal("matching app version remained blocked after unlock")
+	}
+}

--- a/gestaltd/internal/appregistry/mount.go
+++ b/gestaltd/internal/appregistry/mount.go
@@ -1,10 +1,12 @@
 package appregistry
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
@@ -18,6 +20,8 @@ type MountService struct {
 	ArtifactsDir string
 }
 
+const activeVersionFile = "active-version"
+
 // ResolveInstalledApp returns a provider entry backed by the requested
 // registry install. The deploy-time entry is returned unchanged when no local
 // install exists, which preserves restart-only convergence for legacy rows.
@@ -26,6 +30,105 @@ func (m *MountService) ResolveInstalledApp(name string, entry *config.ProviderEn
 		return entry, nil
 	}
 	return ResolveInstalledAppIfPresent(name, entry, m.ArtifactsDir, version)
+}
+
+// ActivateInstalledApp atomically records the locally running version used by
+// dynamic registry static mounts.
+func (m *MountService) ActivateInstalledApp(name, version string) error {
+	if m == nil {
+		return fmt.Errorf("registry mount service is not configured")
+	}
+	name = strings.TrimSpace(name)
+	version = strings.TrimSpace(version)
+	if name == "" || version == "" {
+		return fmt.Errorf("app name and version are required")
+	}
+	destDir := MaterializedPath(m.ArtifactsDir, name, version)
+	if err := operator.ValidateInstalledPublishedPackage(destDir, name, version); err != nil {
+		return fmt.Errorf("validate active registry app %q@%s: %w", name, version, err)
+	}
+	appDir := filepath.Dir(destDir)
+	if err := os.MkdirAll(appDir, 0o755); err != nil {
+		return fmt.Errorf("create registry app directory: %w", err)
+	}
+	temp, err := os.CreateTemp(appDir, activeVersionFile+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create active registry version marker: %w", err)
+	}
+	tempPath := temp.Name()
+	defer func() { _ = os.Remove(tempPath) }()
+	if _, err := temp.WriteString(version + "\n"); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("write active registry version marker: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return fmt.Errorf("close active registry version marker: %w", err)
+	}
+	activePath := filepath.Join(appDir, activeVersionFile)
+	if err := replaceActiveVersionMarker(tempPath, activePath); err != nil {
+		return fmt.Errorf("activate registry app version: %w", err)
+	}
+	return nil
+}
+
+func replaceActiveVersionMarker(tempPath, activePath string) error {
+	return replaceActiveVersionMarkerForOS(tempPath, activePath, runtime.GOOS)
+}
+
+func replaceActiveVersionMarkerForOS(tempPath, activePath, goos string) error {
+	if goos != "windows" {
+		return os.Rename(tempPath, activePath)
+	}
+	backup, err := os.CreateTemp(filepath.Dir(activePath), activeVersionFile+".backup-*")
+	if err != nil {
+		return err
+	}
+	backupPath := backup.Name()
+	if err := backup.Close(); err != nil {
+		_ = os.Remove(backupPath)
+		return err
+	}
+	if err := os.Remove(backupPath); err != nil {
+		return err
+	}
+
+	movedExisting := false
+	if err := os.Rename(activePath, backupPath); err == nil {
+		movedExisting = true
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	if err := os.Rename(tempPath, activePath); err != nil {
+		if movedExisting {
+			restoreErr := os.Rename(backupPath, activePath)
+			return errors.Join(err, restoreErr)
+		}
+		return err
+	}
+	if movedExisting {
+		_ = os.Remove(backupPath)
+	}
+	return nil
+}
+
+func (m *MountService) DeactivateInstalledApp(name string) error {
+	if m == nil {
+		return nil
+	}
+	path := filepath.Join(strings.TrimSpace(m.ArtifactsDir), RegistryInstallSubdir, strings.TrimSpace(name), activeVersionFile)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("deactivate registry app version: %w", err)
+	}
+	return nil
+}
+
+func ActiveInstalledVersion(artifactsDir, name string) (string, error) {
+	path := filepath.Join(strings.TrimSpace(artifactsDir), RegistryInstallSubdir, strings.TrimSpace(name), activeVersionFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
 }
 
 // ResolveInstalledAppIfPresent returns an entry backed by a materialized

--- a/gestaltd/internal/appregistry/mount_test.go
+++ b/gestaltd/internal/appregistry/mount_test.go
@@ -70,6 +70,40 @@ func TestResolveInstalledApp_returns_isolated_provider_entry(t *testing.T) {
 	}
 }
 
+func TestMountServiceActivateInstalledAppRecordsActiveVersion(t *testing.T) {
+	t.Parallel()
+
+	fixture := registrytest.NewInstallFixture(t)
+	artifactsDir := t.TempDir()
+	materializer := &appregistry.Materializer{
+		Registries:   map[string]config.AppRegistryConfig{"toolshed": fixture.Registry},
+		Reader:       fixture.Reader,
+		ArtifactsDir: artifactsDir,
+	}
+	if _, err := materializer.Ensure(t.Context(), &core.AppInstallation{
+		AppName: "g-issues", Version: fixture.Version, Registry: "toolshed",
+	}); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	mounts := &appregistry.MountService{ArtifactsDir: artifactsDir}
+	if err := mounts.ActivateInstalledApp("g-issues", fixture.Version); err != nil {
+		t.Fatalf("ActivateInstalledApp: %v", err)
+	}
+	version, err := appregistry.ActiveInstalledVersion(artifactsDir, "g-issues")
+	if err != nil {
+		t.Fatalf("ActiveInstalledVersion: %v", err)
+	}
+	if version != fixture.Version {
+		t.Fatalf("active version = %q, want %q", version, fixture.Version)
+	}
+	if err := mounts.DeactivateInstalledApp("g-issues"); err != nil {
+		t.Fatalf("DeactivateInstalledApp: %v", err)
+	}
+	if _, err := appregistry.ActiveInstalledVersion(artifactsDir, "g-issues"); !os.IsNotExist(err) {
+		t.Fatalf("active marker after deactivation error = %v, want not exist", err)
+	}
+}
+
 func TestResolveInstalledAppIfPresent_uses_deploy_entry_when_install_missing(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/appregistry/poller.go
+++ b/gestaltd/internal/appregistry/poller.go
@@ -234,7 +234,7 @@ func (p *CatalogPoller) reconcileApp(ctx context.Context, instanceID, appName st
 
 	if rollout != nil {
 		version := strings.TrimSpace(rollout.Version)
-		if findInstallation(installations, version) == nil {
+		if coredata.KnownInstallationByVersion(installations, version) == nil {
 			if !p.now().Before(rollout.Deadline) {
 				if _, err := p.Rollouts.MarkFailed(ctx, appName, version, p.now()); err != nil {
 					return fmt.Errorf("fail rollout without accepted version %s@%s: %w", appName, version, err)
@@ -311,6 +311,16 @@ func (p *CatalogPoller) reconcileApp(ctx context.Context, instanceID, appName st
 		return nil
 	}
 
+	driverVersion := coredata.LatestKnownVersion(pending)
+	driverInstallation := coredata.KnownInstallationByVersion(pending, driverVersion)
+	if driverInstallation == nil {
+		return fmt.Errorf("resolve driver installation for app %s", appName)
+	}
+	if validator, ok := p.AppRestarter.(appRegistryBindingValidator); ok {
+		if err := validator.ValidateRegistryBinding(appName, driverInstallation.Registry); err != nil {
+			return fmt.Errorf("validate registry binding for app %s: %w", appName, err)
+		}
+	}
 	if err := p.ensurePendingMaterialized(ctx, instanceID, pending); err != nil {
 		return fmt.Errorf("materialize pending versions for app %s: %w", appName, err)
 	}
@@ -319,11 +329,39 @@ func (p *CatalogPoller) reconcileApp(ctx context.Context, instanceID, appName st
 		return nil
 	}
 
-	driverVersion := strings.TrimSpace(pending[len(pending)-1].Version)
+	runningVersion := ""
+	running := false
+	if reporter, ok := p.AppRestarter.(appRunningVersionReporter); ok {
+		runningVersion, running = reporter.RunningVersion(appName)
+	}
+	if running && strings.TrimSpace(runningVersion) == driverVersion {
+		restartedAt := p.now()
+		if err := p.markAllRestarted(ctx, instanceID, appName, pending, restartedAt); err != nil {
+			return err
+		}
+		p.forgetStoppedAt(appName)
+		if rollout != nil && rollout.State == core.AppRolloutStateRestarting {
+			if _, err := p.updateRolloutOutcome(ctx, rollout); err != nil {
+				return err
+			}
+		}
+		slog.Info(
+			"app registry catalog poller observed app provider already running",
+			"app", appName,
+			"version", driverVersion,
+			"pending_versions", len(pending),
+			"instance_id", instanceID,
+			"restarted_at", restartedAt,
+		)
+		return nil
+	}
 
 	stoppedAt, alreadyStopped, err := p.earliestStoppedAt(ctx, instanceID, appName, pending)
 	if err != nil {
 		return err
+	}
+	if alreadyStopped && running && strings.TrimSpace(runningVersion) != driverVersion {
+		alreadyStopped = false
 	}
 	if !alreadyStopped {
 		if err := p.AppRestarter.StopApp(ctx, appName); err != nil {
@@ -373,16 +411,6 @@ func (p *CatalogPoller) reconcileApp(ctx context.Context, instanceID, appName st
 	return nil
 }
 
-func findInstallation(installations []*core.AppInstallation, version string) *core.AppInstallation {
-	version = strings.TrimSpace(version)
-	for _, installation := range installations {
-		if installation != nil && strings.TrimSpace(installation.Version) == version {
-			return installation
-		}
-	}
-	return nil
-}
-
 func (p *CatalogPoller) updateRolloutOutcome(ctx context.Context, rollout *core.AppRollout) (bool, error) {
 	materializations, err := p.Materializations.ListByAppVersion(ctx, rollout.App, rollout.Version)
 	if err != nil {
@@ -423,6 +451,14 @@ func (p *CatalogPoller) restartReady() bool {
 	default:
 		return false
 	}
+}
+
+type appRunningVersionReporter interface {
+	RunningVersion(app string) (string, bool)
+}
+
+type appRegistryBindingValidator interface {
+	ValidateRegistryBinding(app, registry string) error
 }
 
 func (p *CatalogPoller) ensurePendingMaterialized(ctx context.Context, instanceID string, pending []*core.AppInstallation) error {

--- a/gestaltd/internal/appregistry/poller_test.go
+++ b/gestaltd/internal/appregistry/poller_test.go
@@ -55,6 +55,16 @@ func (r *recordingAppRestarter) StartApp(_ context.Context, app, version string)
 
 func (r *recordingAppRestarter) AbortRestarts() {}
 
+type versionReportingAppRestarter struct {
+	*recordingAppRestarter
+	runningVersion string
+	running        bool
+}
+
+func (r *versionReportingAppRestarter) RunningVersion(string) (string, bool) {
+	return r.runningVersion, r.running
+}
+
 func TestCatalogPollerRolloutEnrollmentAndCompletion(t *testing.T) {
 	t.Parallel()
 
@@ -611,6 +621,87 @@ func TestCatalogPollerReconcileOnceRetriesStartAfterRecordedStop(t *testing.T) {
 		t.Fatalf("RestartedAt = %v, want %v", materialization.RestartedAt, now)
 	}
 }
+
+func TestCatalogPollerRecordsAlreadyRunningVersionWithoutRestart(t *testing.T) {
+	t.Parallel()
+
+	services := testutil.NewStubServices(t)
+	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	version := "0.0.0-snapshot.gabc123"
+	if _, err := services.AppVersionChangeRequests.AppendRequest(context.Background(), &core.AppVersionChangeRequest{
+		App: "g-issues", FromVersion: "registry:first-install", ToVersion: version, Timestamp: now,
+	}); err != nil {
+		t.Fatalf("AppendRequest: %v", err)
+	}
+	recording := &recordingAppRestarter{}
+	restarter := &versionReportingAppRestarter{
+		recordingAppRestarter: recording,
+		runningVersion:        version,
+		running:               true,
+	}
+	poller := NewCatalogPoller(CatalogPollerConfig{
+		ChangeRequests: services.AppVersionChangeRequests, Materializations: services.AppInstanceMaterializations,
+		Rollouts: services.AppRollouts, AppRestarter: restarter, InstanceID: "replica-a",
+		DisableRestartDelay: true, Now: func() time.Time { return now },
+	})
+
+	if err := poller.ReconcileOnce(context.Background()); err != nil {
+		t.Fatalf("ReconcileOnce: %v", err)
+	}
+	if len(recording.stopCalls) != 0 || len(recording.startCalls) != 0 {
+		t.Fatalf("restart calls: stop=%v start=%v, want none", recording.stopCalls, recording.startCalls)
+	}
+	materialization, err := services.AppInstanceMaterializations.Get(context.Background(), "replica-a", "g-issues", version)
+	if err != nil {
+		t.Fatalf("Get materialization: %v", err)
+	}
+	if materialization.RestartedAt != now {
+		t.Fatalf("RestartedAt = %v, want %v", materialization.RestartedAt, now)
+	}
+}
+
+func TestCatalogPollerStopsRunningOldVersionDespiteRecordedStop(t *testing.T) {
+	t.Parallel()
+
+	services := testutil.NewStubServices(t)
+	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	version := "0.0.0-snapshot.gnew"
+	if _, err := services.AppVersionChangeRequests.AppendRequest(context.Background(), &core.AppVersionChangeRequest{
+		App: "g-issues", FromVersion: "0.0.0-snapshot.gold", ToVersion: version, Timestamp: now,
+	}); err != nil {
+		t.Fatalf("AppendRequest: %v", err)
+	}
+	if _, err := services.AppInstanceMaterializations.Acknowledge(context.Background(), &core.AppInstanceMaterialization{
+		InstanceID: "replica-a", App: "g-issues", Version: version, AcknowledgedAt: now,
+	}); err != nil {
+		t.Fatalf("Acknowledge: %v", err)
+	}
+	if _, err := services.AppInstanceMaterializations.MarkStopped(context.Background(), "replica-a", "g-issues", version, now); err != nil {
+		t.Fatalf("MarkStopped: %v", err)
+	}
+	recording := &recordingAppRestarter{}
+	restarter := &versionReportingAppRestarter{
+		recordingAppRestarter: recording,
+		runningVersion:        "0.0.0-snapshot.gold",
+		running:               true,
+	}
+	poller := NewCatalogPoller(CatalogPollerConfig{
+		ChangeRequests: services.AppVersionChangeRequests, Materializations: services.AppInstanceMaterializations,
+		Rollouts: services.AppRollouts, AppRestarter: restarter, InstanceID: "replica-a",
+		DisableRestartDelay: true, Now: func() time.Time { return now },
+	})
+
+	if err := poller.ReconcileOnce(context.Background()); err != nil {
+		t.Fatalf("ReconcileOnce: %v", err)
+	}
+	if len(recording.stopCalls) != 1 || len(recording.startCalls) != 1 {
+		t.Fatalf("restart calls: stop=%v start=%v, want one each", recording.stopCalls, recording.startCalls)
+	}
+	if got := recording.startVersions; len(got) != 1 || got[0] != version {
+		t.Fatalf("startVersions = %v, want [%s]", got, version)
+	}
+}
+
 func TestCatalogPollerReconcileOnceDoesNotResetRestartDelayForNewVersion(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/bootstrap/app_provider_restart.go
+++ b/gestaltd/internal/bootstrap/app_provider_restart.go
@@ -24,6 +24,14 @@ type RegistryInstalledResolver interface {
 	ResolveInstalledApp(app string, entry *config.ProviderEntry, version string) (*config.ProviderEntry, error)
 }
 
+type registryInstalledActivator interface {
+	ActivateInstalledApp(app, version string) error
+}
+
+type registryInstalledDeactivator interface {
+	DeactivateInstalledApp(app string) error
+}
+
 type pendingProviderClose struct {
 	provider core.Provider
 	done     <-chan error
@@ -39,6 +47,7 @@ type AppProviderRestarter struct {
 	held             map[string]func()
 	closing          map[string]pendingProviderClose
 	closeFailures    map[string]error
+	runningVersions  map[string]string
 
 	lifecycleMu sync.Mutex
 }
@@ -63,6 +72,7 @@ func NewAppProviderRestarter(cfg AppProviderRestarterConfig) *AppProviderRestart
 		held:             make(map[string]func()),
 		closing:          make(map[string]pendingProviderClose),
 		closeFailures:    make(map[string]error),
+		runningVersions:  make(map[string]string),
 	}
 }
 
@@ -77,8 +87,46 @@ func (r *AppProviderRestarter) Restartable(app string) (bool, error) {
 	return appProviderRestartable(r.cfg, entry), nil
 }
 
+func (r *AppProviderRestarter) RunningVersion(app string) (string, bool) {
+	if r == nil {
+		return "", false
+	}
+	app = strings.TrimSpace(app)
+	r.lifecycleMu.Lock()
+	defer r.lifecycleMu.Unlock()
+	version, ok := r.runningVersions[app]
+	if !ok || r.providers == nil {
+		return "", false
+	}
+	if _, err := r.providers.Get(app); err != nil {
+		delete(r.runningVersions, app)
+		return "", false
+	}
+	return version, true
+}
+
+func (r *AppProviderRestarter) ValidateRegistryBinding(app, registryName string) error {
+	entry, err := r.appEntry(strings.TrimSpace(app))
+	if err != nil {
+		return err
+	}
+	configuredRegistry := strings.TrimSpace(entry.Source.Registry)
+	if !entry.Source.IsRegistry() {
+		return nil
+	}
+	if configuredRegistry != strings.TrimSpace(registryName) {
+		return fmt.Errorf(
+			"app %q registry binding %q does not match deploy config %q",
+			app,
+			strings.TrimSpace(registryName),
+			configuredRegistry,
+		)
+	}
+	return nil
+}
+
 func appProviderRestartable(cfg *config.Config, entry *config.ProviderEntry) bool {
-	return entry != nil && !entry.DevActive && providerBuildsLocal(cfg, entry)
+	return entry != nil && !entry.DevActive && (entry.Source.IsRegistry() || providerBuildsLocal(cfg, entry))
 }
 
 func (r *AppProviderRestarter) StopApp(ctx context.Context, app string) error {
@@ -114,15 +162,37 @@ func (r *AppProviderRestarter) StopApp(ctx context.Context, app string) error {
 	provider, err := r.providers.Get(app)
 	if err != nil {
 		if errors.Is(err, core.ErrNotFound) {
+			delete(r.runningVersions, app)
+			if err := r.deactivateRegistryInstall(app, entry); err != nil {
+				return err
+			}
 			return nil
 		}
 		r.releaseLifecycleLease(app)
 		return fmt.Errorf("stop app provider: %w", err)
 	}
+	if err := r.deactivateRegistryInstall(app, entry); err != nil {
+		return err
+	}
 	r.providers.Remove(app)
+	delete(r.runningVersions, app)
 	pending := pendingProviderClose{provider: provider, done: closeProviderForRestart(provider)}
 	r.closing[app] = pending
 	return r.awaitProviderClose(ctx, app, pending)
+}
+
+func (r *AppProviderRestarter) DeactivateApp(_ context.Context, app string) error {
+	if r == nil {
+		return nil
+	}
+	entry, err := r.appEntry(strings.TrimSpace(app))
+	if err != nil {
+		return err
+	}
+	r.lifecycleMu.Lock()
+	defer r.lifecycleMu.Unlock()
+	delete(r.runningVersions, app)
+	return r.deactivateRegistryInstall(app, entry)
 }
 
 func (r *AppProviderRestarter) StartApp(ctx context.Context, app, version string) error {
@@ -151,6 +221,12 @@ func (r *AppProviderRestarter) StartApp(ctx context.Context, app, version string
 	}
 
 	if _, getErr := r.providers.Get(app); getErr == nil {
+		if entry.Source.IsRegistry() && r.runningVersions[app] != version {
+			return fmt.Errorf("start app provider %q: provider is already running version %q, not %q", app, r.runningVersions[app], version)
+		}
+		if err := r.activateRegistryInstall(app, entry, version); err != nil {
+			return err
+		}
 		r.releaseLifecycleLease(app)
 		return nil
 	} else if !errors.Is(getErr, core.ErrNotFound) {
@@ -180,9 +256,17 @@ func (r *AppProviderRestarter) StartApp(ctx context.Context, app, version string
 		closeIfPossible(result.Provider)
 		return fmt.Errorf("start app provider %q: %w", app, err)
 	}
+	if err := r.activateRegistryInstall(app, entry, version); err != nil {
+		closeIfPossible(result.Provider)
+		return err
+	}
 	if err := r.providers.Register(app, result.Provider); err != nil {
 		closeIfPossible(result.Provider)
-		return fmt.Errorf("start app provider %q: %w", app, err)
+		deactivateErr := r.deactivateRegistryInstall(app, entry)
+		return errors.Join(fmt.Errorf("start app provider %q: %w", app, err), deactivateErr)
+	}
+	if entry.Source.IsRegistry() {
+		r.runningVersions[app] = version
 	}
 	r.storeConnectionAuth(app, result)
 	if r.deps.AppWorkflowDeclarations != nil {
@@ -282,6 +366,34 @@ func (r *AppProviderRestarter) resolveRegistryInstall(app string, entry *config.
 		return nil, fmt.Errorf("mount registry installed app %q@%s: resolver returned nil provider entry", app, version)
 	}
 	return resolved, nil
+}
+
+func (r *AppProviderRestarter) activateRegistryInstall(app string, entry *config.ProviderEntry, version string) error {
+	if r == nil || entry == nil || !entry.Source.IsRegistry() || strings.TrimSpace(version) == "" {
+		return nil
+	}
+	activator, ok := r.registryResolver.(registryInstalledActivator)
+	if !ok {
+		return nil
+	}
+	if err := activator.ActivateInstalledApp(app, version); err != nil {
+		return fmt.Errorf("activate registry installed app %q@%s: %w", app, version, err)
+	}
+	return nil
+}
+
+func (r *AppProviderRestarter) deactivateRegistryInstall(app string, entry *config.ProviderEntry) error {
+	if r == nil || entry == nil || !entry.Source.IsRegistry() {
+		return nil
+	}
+	deactivator, ok := r.registryResolver.(registryInstalledDeactivator)
+	if !ok {
+		return nil
+	}
+	if err := deactivator.DeactivateInstalledApp(app); err != nil {
+		return fmt.Errorf("deactivate registry installed app %q: %w", app, err)
+	}
+	return nil
 }
 
 func (r *AppProviderRestarter) storeConnectionAuth(app string, result *ProviderBuildResult) {

--- a/gestaltd/internal/bootstrap/app_provider_restart_test.go
+++ b/gestaltd/internal/bootstrap/app_provider_restart_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/apps/registry"
 )
 
 type restartCloseFailureProvider struct {
@@ -20,6 +21,19 @@ type restartCloseFailureProvider struct {
 }
 
 func (p *restartCloseFailureProvider) Close() error { return p.err }
+
+type recordingRegistryResolver struct {
+	activations int
+}
+
+func (r *recordingRegistryResolver) ResolveInstalledApp(_ string, entry *config.ProviderEntry, _ string) (*config.ProviderEntry, error) {
+	return entry, nil
+}
+
+func (r *recordingRegistryResolver) ActivateInstalledApp(_, _ string) error {
+	r.activations++
+	return nil
+}
 
 func TestAppProviderRestarterRestartable(t *testing.T) {
 	t.Parallel()
@@ -30,6 +44,7 @@ func TestAppProviderRestarterRestartable(t *testing.T) {
 			"remote":         {},
 			"local-override": {Local: true},
 			"dev-active":     {DevActive: true},
+			"registry":       {Source: config.ProviderSource{Registry: "toolshed"}},
 		},
 	}
 	restarter := bootstrap.NewAppProviderRestarter(bootstrap.AppProviderRestarterConfig{Config: cfg})
@@ -41,6 +56,7 @@ func TestAppProviderRestarterRestartable(t *testing.T) {
 		{app: "remote", want: false},
 		{app: "local-override", want: true},
 		{app: "dev-active", want: false},
+		{app: "registry", want: true},
 	} {
 		got, err := restarter.Restartable(tc.app)
 		if err != nil {
@@ -58,6 +74,26 @@ func TestAppProviderRestarterRestartable(t *testing.T) {
 	}
 	if !got {
 		t.Error("packaged app should be restartable when server.remote is unset")
+	}
+}
+
+func TestAppProviderRestarterDoesNotActivateRegistryMountForLegacyCatalogVersion(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{Apps: map[string]*config.ProviderEntry{"legacy": {}}}
+	providers := registry.New()
+	if err := providers.Providers.Register("legacy", &coretesting.StubIntegration{N: "legacy"}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	resolver := &recordingRegistryResolver{}
+	restarter := bootstrap.NewAppProviderRestarter(bootstrap.AppProviderRestarterConfig{
+		Config: cfg, Providers: &providers.Providers, RegistryResolver: resolver,
+	})
+	if err := restarter.StartApp(t.Context(), "legacy", "legacy-version"); err != nil {
+		t.Fatalf("StartApp: %v", err)
+	}
+	if resolver.activations != 0 {
+		t.Fatalf("registry activations = %d, want 0", resolver.activations)
 	}
 }
 

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -254,7 +254,9 @@ type Result struct {
 	AgentControl           AgentControl
 	AgentManager           agentmanager.Service
 	StartupProvidersReady  <-chan struct{}
+	RegistryProvidersReady <-chan struct{}
 	ProvidersReady         <-chan struct{}
+	RegistryMaterializer   RegistryAppMaterializer
 	ConnectionAuth         func() map[string]map[string]OAuthHandler
 	ManualConnectionAuth   func() map[string]map[string]ManualTokenExchanger
 	Invoker                invocation.Invoker
@@ -284,6 +286,9 @@ type Result struct {
 	auditClose                          func(context.Context) error
 	appHostServiceCleanup               func()
 	startAppProviders                   func()
+	startRegistryAppProviders           func(context.Context) error
+	registryProvidersReady              chan struct{}
+	registryProvidersReadyOnce          sync.Once
 	activateAppProviders                func(context.Context)
 	startup                             *deferredProviders
 	deferred                            *deferredProviders
@@ -318,6 +323,18 @@ func (r *Result) StartAppProviders(ctx context.Context) error {
 		case <-ctx.Done():
 			return fmt.Errorf("app provider startup interrupted: %w", ctx.Err())
 		}
+	}
+	var registryStartErr error
+	if r.startRegistryAppProviders != nil {
+		registryStartErr = r.startRegistryAppProviders(ctx)
+	}
+	r.registryProvidersReadyOnce.Do(func() {
+		if r.registryProvidersReady != nil {
+			close(r.registryProvidersReady)
+		}
+	})
+	if registryStartErr != nil {
+		slog.WarnContext(ctx, "one or more registry app providers failed to start; core services remain available", "error", registryStartErr)
 	}
 	r.startupWorkflowConfigReconcileOnce.Do(func() {
 		if r.startupWorkflowConfigReconcile != nil {
@@ -1205,6 +1222,7 @@ func (p *preparedCore) Close(ctx context.Context) error {
 type BootstrapOptions struct {
 	DeferAppProviderStartup bool
 	RegistryResolver        RegistryInstalledResolver
+	RegistryMaterializer    RegistryAppMaterializer
 }
 
 func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegistry) (*Result, error) {
@@ -1468,6 +1486,7 @@ func BootstrapWithOptions(ctx context.Context, cfg *config.Config, factories *Fa
 	closeAudit = false
 	closeWorkflowsOnError = false
 	closeAgentsOnError = false
+	registryProvidersReady := make(chan struct{})
 	result := &Result{
 		Auth:                   prepared.Auth,
 		SelectedAuthProvider:   prepared.SelectedAuthProvider,
@@ -1485,7 +1504,9 @@ func BootstrapWithOptions(ctx context.Context, cfg *config.Config, factories *Fa
 		AgentControl:           prepared.Deps.AgentRuntime,
 		AgentManager:           prepared.Deps.AgentManager,
 		StartupProvidersReady:  startup.ready(),
+		RegistryProvidersReady: registryProvidersReady,
 		ProvidersReady:         deferred.ready(),
+		RegistryMaterializer:   opts.RegistryMaterializer,
 		ConnectionAuth:         connAuthResolver,
 		ManualConnectionAuth:   manualConnAuthResolver,
 		Invoker:                sharedInvoker,
@@ -1512,9 +1533,14 @@ func BootstrapWithOptions(ctx context.Context, cfg *config.Config, factories *Fa
 		auditClose:                     auditClose,
 		appHostServiceCleanup:          appHostServiceCleanup,
 		startAppProviders:              startAppProviders,
+		registryProvidersReady:         registryProvidersReady,
 		activateAppProviders:           activateAppProviders,
 		startup:                        startup,
 		deferred:                       deferred,
+	}
+	registryMaterializer := opts.RegistryMaterializer
+	result.startRegistryAppProviders = func(ctx context.Context) error {
+		return startRegistryOnlyAppProviders(ctx, cfg, prepared.Services.AppVersionChangeRequests, registryMaterializer, result.AppRestarter)
 	}
 	for _, pending := range updateBuilds.pending {
 		if pending.proxy != nil {

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -105,7 +105,7 @@ func prepareProviderBuilds(
 
 	for name := range cfg.Apps {
 		entry := cfg.Apps[name]
-		if !providerBuildsLocal(cfg, entry) {
+		if entry == nil || entry.Source.IsRegistry() || !providerBuildsLocal(cfg, entry) {
 			continue
 		}
 		sha := currentAppSHA(entry)
@@ -144,7 +144,7 @@ func registerRemoteApps(providers *registry.ProviderMap[core.Provider], cfg *con
 	}
 	for name, entry := range cfg.Apps {
 		name = strings.TrimSpace(name)
-		if name == "" || entry == nil || providerBuildsLocal(cfg, entry) {
+		if name == "" || entry == nil || entry.Source.IsRegistry() || providerBuildsLocal(cfg, entry) {
 			continue
 		}
 		spec, _, err := buildStartupProviderSpec(name, entry)

--- a/gestaltd/internal/bootstrap/provider_build_test.go
+++ b/gestaltd/internal/bootstrap/provider_build_test.go
@@ -75,6 +75,26 @@ func (p closeRecordingWorkflowProvider) Close() error {
 	return nil
 }
 
+func TestPrepareProviderBuildsExcludesRegistryOnlyApps(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Apps: map[string]*config.ProviderEntry{
+			"g-issues": {Source: config.ProviderSource{Registry: "toolshed"}},
+		},
+	}
+	builds, err := prepareProviderBuilds(cfg, NewFactoryRegistry(), Deps{})
+	if err != nil {
+		t.Fatalf("prepareProviderBuilds: %v", err)
+	}
+	if len(builds.pending) != 0 {
+		t.Fatalf("pending builds = %#v, want none", builds.pending)
+	}
+	if _, err := builds.providers.Get("g-issues"); !errors.Is(err, core.ErrNotFound) {
+		t.Fatalf("registry provider lookup error = %v, want not found", err)
+	}
+}
+
 func TestPreparedProviderBuildsStartAfterHostServiceTargetsAvailable(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/bootstrap/registry_app_startup.go
+++ b/gestaltd/internal/bootstrap/registry_app_startup.go
@@ -1,0 +1,89 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
+)
+
+type RegistryAppMaterializer interface {
+	MaterializeApp(context.Context, *core.AppInstallation) error
+}
+
+type registryAppStarter interface {
+	StartApp(context.Context, string, string) error
+}
+
+type registryAppDeactivator interface {
+	DeactivateApp(context.Context, string) error
+}
+
+func startRegistryOnlyAppProviders(
+	ctx context.Context,
+	cfg *config.Config,
+	changeRequests *coredata.AppVersionChangeRequestService,
+	materializer RegistryAppMaterializer,
+	starter registryAppStarter,
+) error {
+	if cfg == nil || changeRequests == nil {
+		return nil
+	}
+	var errs []error
+	for _, appName := range slices.Sorted(maps.Keys(cfg.Apps)) {
+		entry := cfg.Apps[appName]
+		if entry == nil || !entry.Source.IsRegistry() {
+			continue
+		}
+		known, err := changeRequests.ListKnownVersionsByApp(ctx, appName)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("start registry app %q: list known versions: %w", appName, err))
+			continue
+		}
+		version := coredata.LatestKnownVersion(known)
+		if version == "" {
+			if deactivator, ok := starter.(registryAppDeactivator); ok {
+				if err := deactivator.DeactivateApp(ctx, appName); err != nil {
+					errs = append(errs, fmt.Errorf("start registry app %q: clear stale activation: %w", appName, err))
+				}
+			}
+			continue
+		}
+		installation := coredata.KnownInstallationByVersion(known, version)
+		if installation == nil {
+			errs = append(errs, fmt.Errorf("start registry app %q: latest known version %q is unavailable", appName, version))
+			continue
+		}
+		if configuredRegistry := strings.TrimSpace(entry.Source.Registry); strings.TrimSpace(installation.Registry) != configuredRegistry {
+			if deactivator, ok := starter.(registryAppDeactivator); ok {
+				if err := deactivator.DeactivateApp(ctx, appName); err != nil {
+					errs = append(errs, fmt.Errorf("start registry app %q: clear mismatched activation: %w", appName, err))
+				}
+			}
+			errs = append(errs, fmt.Errorf("start registry app %q: known version %q belongs to registry %q, want %q", appName, version, installation.Registry, configuredRegistry))
+			continue
+		}
+		if materializer == nil {
+			errs = append(errs, fmt.Errorf("start registry app %q: app registry materializer is not configured", appName))
+			continue
+		}
+		if err := materializer.MaterializeApp(ctx, installation); err != nil {
+			errs = append(errs, fmt.Errorf("start registry app %q@%s: %w", appName, version, err))
+			continue
+		}
+		if starter == nil {
+			errs = append(errs, fmt.Errorf("start registry app %q: app provider restarter is not configured", appName))
+			continue
+		}
+		if err := starter.StartApp(ctx, appName, version); err != nil {
+			errs = append(errs, fmt.Errorf("start registry app %q@%s: %w", appName, version, err))
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/gestaltd/internal/bootstrap/registry_app_startup_test.go
+++ b/gestaltd/internal/bootstrap/registry_app_startup_test.go
@@ -1,0 +1,194 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+)
+
+type startupMaterializerStub struct {
+	installations []*core.AppInstallation
+}
+
+func (s *startupMaterializerStub) MaterializeApp(_ context.Context, installation *core.AppInstallation) error {
+	s.installations = append(s.installations, installation)
+	return nil
+}
+
+type startupAppStarterStub struct {
+	app         string
+	version     string
+	deactivated string
+}
+
+func (s *startupAppStarterStub) StartApp(_ context.Context, app, version string) error {
+	s.app = app
+	s.version = version
+	return nil
+}
+
+func (s *startupAppStarterStub) DeactivateApp(_ context.Context, app string) error {
+	s.deactivated = app
+	return nil
+}
+
+func registryOnlyStartupConfig() *config.Config {
+	return &config.Config{
+		Apps: map[string]*config.ProviderEntry{
+			"g-issues": {Source: config.ProviderSource{Registry: "toolshed"}},
+		},
+	}
+}
+
+func TestStartRegistryOnlyAppProvidersSkipsEmptyCatalog(t *testing.T) {
+	t.Parallel()
+
+	services := testutil.NewStubServices(t)
+	materializer := &startupMaterializerStub{}
+	starter := &startupAppStarterStub{}
+	if err := startRegistryOnlyAppProviders(t.Context(), registryOnlyStartupConfig(), services.AppVersionChangeRequests, materializer, starter); err != nil {
+		t.Fatalf("startRegistryOnlyAppProviders: %v", err)
+	}
+	if len(materializer.installations) != 0 || starter.app != "" {
+		t.Fatalf("empty catalog materialized %#v and started %q", materializer.installations, starter.app)
+	}
+	if starter.deactivated != "g-issues" {
+		t.Fatalf("deactivated app = %q, want g-issues", starter.deactivated)
+	}
+}
+
+func TestStartRegistryOnlyAppProvidersMaterializesAndStartsLatestKnownVersion(t *testing.T) {
+	t.Parallel()
+
+	services := testutil.NewStubServices(t)
+	older := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	newer := older.Add(time.Minute)
+	for _, request := range []*core.AppVersionChangeRequest{
+		{
+			App:         "g-issues",
+			FromVersion: "registry:first-install",
+			ToVersion:   "1.0.0",
+			Timestamp:   older,
+			Metadata: coredata.ChangeRequestMetadata(&core.AppInstallation{
+				AppName: "g-issues", Version: "1.0.0", Registry: "toolshed", UpdatedAt: older,
+			}),
+		},
+		{
+			App:         "g-issues",
+			FromVersion: "1.0.0",
+			ToVersion:   "2.0.0",
+			Timestamp:   newer,
+			Metadata: coredata.ChangeRequestMetadata(&core.AppInstallation{
+				AppName: "g-issues", Version: "2.0.0", Registry: "toolshed", UpdatedAt: newer,
+			}),
+		},
+	} {
+		if _, err := services.AppVersionChangeRequests.AppendRequest(t.Context(), request); err != nil {
+			t.Fatalf("AppendRequest: %v", err)
+		}
+	}
+
+	materializer := &startupMaterializerStub{}
+	starter := &startupAppStarterStub{}
+	if err := startRegistryOnlyAppProviders(t.Context(), registryOnlyStartupConfig(), services.AppVersionChangeRequests, materializer, starter); err != nil {
+		t.Fatalf("startRegistryOnlyAppProviders: %v", err)
+	}
+	if len(materializer.installations) != 1 || materializer.installations[0].Version != "2.0.0" {
+		t.Fatalf("materialized installations = %#v", materializer.installations)
+	}
+	if starter.app != "g-issues" || starter.version != "2.0.0" {
+		t.Fatalf("started %q@%q", starter.app, starter.version)
+	}
+}
+
+func TestStartRegistryOnlyAppProvidersDeactivatesMismatchedRegistry(t *testing.T) {
+	t.Parallel()
+
+	services := testutil.NewStubServices(t)
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	if _, err := services.AppVersionChangeRequests.AppendRequest(t.Context(), &core.AppVersionChangeRequest{
+		App:         "g-issues",
+		FromVersion: "registry:first-install",
+		ToVersion:   "1.0.0",
+		Timestamp:   now,
+		Metadata: coredata.ChangeRequestMetadata(&core.AppInstallation{
+			AppName: "g-issues", Version: "1.0.0", Registry: "old-registry", UpdatedAt: now,
+		}),
+	}); err != nil {
+		t.Fatalf("AppendRequest: %v", err)
+	}
+
+	materializer := &startupMaterializerStub{}
+	starter := &startupAppStarterStub{}
+	err := startRegistryOnlyAppProviders(t.Context(), registryOnlyStartupConfig(), services.AppVersionChangeRequests, materializer, starter)
+	if err == nil {
+		t.Fatal("startRegistryOnlyAppProviders error = nil, want registry mismatch")
+	}
+	if starter.deactivated != "g-issues" {
+		t.Fatalf("deactivated app = %q, want g-issues", starter.deactivated)
+	}
+	if len(materializer.installations) != 0 || starter.app != "" {
+		t.Fatalf("mismatched catalog materialized %#v and started %q", materializer.installations, starter.app)
+	}
+}
+
+func TestResultStartAppProvidersClosesRegistryReadinessAfterRegistryStartup(t *testing.T) {
+	t.Parallel()
+
+	startupReady := make(chan struct{})
+	close(startupReady)
+	registryReady := make(chan struct{})
+	registryStarted := false
+	result := &Result{
+		StartupProvidersReady:  startupReady,
+		RegistryProvidersReady: registryReady,
+		startAppProviders:      func() {},
+		startRegistryAppProviders: func(context.Context) error {
+			registryStarted = true
+			return nil
+		},
+		registryProvidersReady: registryReady,
+	}
+	if err := result.StartAppProviders(t.Context()); err != nil {
+		t.Fatalf("StartAppProviders: %v", err)
+	}
+	if !registryStarted {
+		t.Fatal("registry providers were not started")
+	}
+	select {
+	case <-result.RegistryProvidersReady:
+	default:
+		t.Fatal("registry provider readiness remained open")
+	}
+}
+
+func TestResultStartAppProvidersDoesNotFailCoreBootForRegistryAppFailure(t *testing.T) {
+	t.Parallel()
+
+	startupReady := make(chan struct{})
+	close(startupReady)
+	registryReady := make(chan struct{})
+	result := &Result{
+		StartupProvidersReady:  startupReady,
+		RegistryProvidersReady: registryReady,
+		startAppProviders:      func() {},
+		startRegistryAppProviders: func(context.Context) error {
+			return errors.New("registry app failed")
+		},
+		registryProvidersReady: registryReady,
+	}
+	if err := result.StartAppProviders(t.Context()); err != nil {
+		t.Fatalf("StartAppProviders returned registry app failure: %v", err)
+	}
+	select {
+	case <-result.RegistryProvidersReady:
+	default:
+		t.Fatal("registry provider readiness remained open after failure")
+	}
+}

--- a/gestaltd/internal/config/app_validation.go
+++ b/gestaltd/internal/config/app_validation.go
@@ -10,6 +10,9 @@ func AppValidationConfig(cfg *Config) *appservice.ValidationConfig {
 		Apps: make(map[string]*appservice.ValidationApp, len(cfg.Apps)),
 	}
 	for name, entry := range cfg.Apps {
+		if entry != nil && entry.Source.IsRegistry() {
+			continue
+		}
 		validation.Apps[name] = AppValidationEntry(entry)
 	}
 	return validation

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -163,6 +163,7 @@ type ServerProvidersConfig struct {
 //   - Metadata: source: "https://.../provider-release.yaml"  -> ProviderSource{metadataURL: "..."}
 //   - GitHub:   source: {githubRelease: {repo, tag, asset}}  -> ProviderSource{GitHubRelease: ...}
 //   - Git:      source: {git: {repo, ref, path}} -> ProviderSource{Git: ...}
+//   - Registry: source: {registry: "name"} -> ProviderSource{Registry: "name"}
 //   - Local:    source: {path} or source: "./manifest.yaml"  -> ProviderSource{Path: "..."}
 //   - Local metadata: source: {path} or source: "./dist/provider-release.yaml"
 //     -> ProviderSource{metadataPath: "..."}
@@ -179,6 +180,7 @@ type ProviderSource struct {
 	unsupported         string                  `yaml:"-"`
 	GitHubRelease       *GitHubReleaseSourceDef `yaml:"githubRelease,omitempty"`
 	Git                 *GitSourceDef           `yaml:"git,omitempty"`
+	Registry            string                  `yaml:"registry,omitempty"`
 	Path                string                  `yaml:"path,omitempty"`
 	Auth                *SourceAuthDef          `yaml:"auth,omitempty"`
 }
@@ -190,6 +192,7 @@ type providerSourceYAML struct {
 	Version       string                  `yaml:"version,omitempty"`
 	GitHubRelease *GitHubReleaseSourceDef `yaml:"githubRelease,omitempty"`
 	Git           *GitSourceDef           `yaml:"git,omitempty"`
+	Registry      string                  `yaml:"registry,omitempty"`
 	Path          string                  `yaml:"path,omitempty"`
 	Auth          *SourceAuthDef          `yaml:"auth,omitempty"`
 }
@@ -233,6 +236,7 @@ func (s *ProviderSource) UnmarshalYAML(value *yaml.Node) error {
 		}
 		s.GitHubRelease = cloneGitHubReleaseSourceDef(raw.GitHubRelease)
 		s.Git = cloneGitSourceDef(raw.Git)
+		s.Registry = strings.TrimSpace(raw.Registry)
 		s.Path = strings.TrimSpace(raw.Path)
 		s.metadataURL = strings.TrimSpace(raw.URL)
 		s.packageRepo = strings.TrimSpace(raw.Repo)
@@ -247,6 +251,7 @@ func (s *ProviderSource) UnmarshalYAML(value *yaml.Node) error {
 	}
 	s.GitHubRelease = cloneGitHubReleaseSourceDef(raw.GitHubRelease)
 	s.Git = cloneGitSourceDef(raw.Git)
+	s.Registry = strings.TrimSpace(raw.Registry)
 	s.Path = strings.TrimSpace(raw.Path)
 	s.metadataURL = strings.TrimSpace(raw.URL)
 	s.packageRepo = strings.TrimSpace(raw.Repo)
@@ -284,6 +289,9 @@ func (s ProviderSource) MarshalYAML() (any, error) {
 			Auth: auth,
 		}, nil
 	}
+	if s.Registry != "" && s.Path == "" && s.metadataPath == "" && s.metadataURL == "" && s.packageName == "" && s.GitHubRelease == nil && s.Git == nil {
+		return providerSourceYAML{Registry: strings.TrimSpace(s.Registry)}, nil
+	}
 	if s.scalar != "" && s.Path == "" && s.metadataPath == "" && auth == nil {
 		return s.scalar, nil
 	}
@@ -297,6 +305,7 @@ func (s ProviderSource) MarshalYAML() (any, error) {
 		Version:       strings.TrimSpace(s.packageVersion),
 		GitHubRelease: cloneGitHubReleaseSourceDef(s.GitHubRelease),
 		Git:           cloneGitSourceDef(s.Git),
+		Registry:      strings.TrimSpace(s.Registry),
 		Path:          s.Path,
 		Auth:          auth,
 	}, nil
@@ -306,6 +315,7 @@ func (s ProviderSource) IsBuiltin() bool       { return s.Builtin != "" }
 func (s ProviderSource) IsMetadataURL() bool   { return s.metadataURL != "" }
 func (s ProviderSource) IsGitHubRelease() bool { return s.GitHubRelease != nil }
 func (s ProviderSource) IsGit() bool           { return s.Git != nil }
+func (s ProviderSource) IsRegistry() bool      { return strings.TrimSpace(s.Registry) != "" }
 func (s ProviderSource) IsPackage() bool       { return s.packageName != "" }
 func (s ProviderSource) IsLocal() bool         { return s.Path != "" }
 func (s ProviderSource) IsLocalMetadataPath() bool {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -143,6 +143,101 @@ func singletonProviderEntry(entry *ProviderEntry) map[string]*ProviderEntry {
 	}
 }
 
+func TestLoadConfigRegistryOnlyAppSource(t *testing.T) {
+	t.Parallel()
+
+	path := mustWriteConfigFile(t, `
+apiVersion: gestaltd.config/v8
+appRegistries:
+  toolshed:
+    kind: gcs
+    gcs:
+      bucket: gestalt-app-registry
+apps:
+  g-issues:
+    source:
+      registry: toolshed
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := cfg.Apps["g-issues"].Source.Registry; got != "toolshed" {
+		t.Fatalf("source.registry = %q, want toolshed", got)
+	}
+}
+
+func TestLoadConfigRegistryOnlyAppRejectsUnknownRegistry(t *testing.T) {
+	t.Parallel()
+
+	path := mustWriteConfigFile(t, `
+apiVersion: gestaltd.config/v8
+apps:
+  g-issues:
+    source:
+      registry: missing
+`)
+	if _, err := Load(path); err == nil || !strings.Contains(err.Error(), `unknown app registry "missing"`) {
+		t.Fatalf("Load error = %v, want unknown registry", err)
+	}
+}
+
+func TestLoadConfigRegistryOnlyAppRejectsMixedSources(t *testing.T) {
+	t.Parallel()
+
+	path := mustWriteConfigFile(t, `
+apiVersion: gestaltd.config/v8
+appRegistries:
+  toolshed:
+    kind: gcs
+    gcs:
+      bucket: gestalt-app-registry
+apps:
+  g-issues:
+    source:
+      registry: toolshed
+      path: ./manifest.yaml
+`)
+	if _, err := Load(path); err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("Load error = %v, want mutually exclusive sources", err)
+	}
+}
+
+func TestRegistrySourceRejectedOnLocalRuntimeProvider(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Runtime: RuntimeConfig{
+			Providers: map[string]*RuntimeProviderEntry{
+				"local": {
+					Driver: RuntimeProviderDriverLocal,
+					ProviderEntry: ProviderEntry{
+						Source: ProviderSource{Registry: "toolshed"},
+					},
+				},
+			},
+		},
+	}
+	if err := validateRuntimeConfig(cfg); err == nil || !strings.Contains(err.Error(), "source is not supported") {
+		t.Fatalf("validateRuntimeConfig error = %v, want unsupported source", err)
+	}
+}
+
+func TestAppValidationConfigOmitsRegistryOnlyApps(t *testing.T) {
+	t.Parallel()
+
+	validation := AppValidationConfig(&Config{Apps: map[string]*ProviderEntry{
+		"registry": {Source: ProviderSource{Registry: "toolshed"}},
+		"pinned":   {},
+	}})
+	if _, ok := validation.Apps["registry"]; ok {
+		t.Fatal("registry-only app was included in static app validation")
+	}
+	if _, ok := validation.Apps["pinned"]; !ok {
+		t.Fatal("pinned app was omitted from static app validation")
+	}
+}
+
 func TestLoadConfigProviderLocalFlag(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -567,6 +567,9 @@ func validateProviderEntrySource(kind, name string, entry *ProviderEntry) error 
 	if src.IsGit() {
 		modeCount++
 	}
+	if src.IsRegistry() {
+		modeCount++
+	}
 	if src.IsPackage() {
 		modeCount++
 	}
@@ -578,6 +581,9 @@ func validateProviderEntrySource(kind, name string, entry *ProviderEntry) error 
 	}
 	if modeCount > 1 {
 		return fmt.Errorf("config validation: %s %q source.path and metadata URL sources are mutually exclusive", kind, name)
+	}
+	if src.IsRegistry() && kind != "app" {
+		return fmt.Errorf("config validation: %s %q source.registry is only supported on apps", kind, name)
 	}
 	if src.IsLocalMetadataPath() {
 		if path.Base(filepath.ToSlash(src.MetadataPath())) != "provider-release.yaml" {
@@ -918,6 +924,7 @@ func runtimeProviderUsesSource(entry *RuntimeProviderEntry) bool {
 		entry.Source.IsMetadataURL() ||
 		entry.Source.IsGitHubRelease() ||
 		entry.Source.IsGit() ||
+		entry.Source.IsRegistry() ||
 		entry.Source.IsLocalMetadataPath() ||
 		entry.Source.IsLocal() ||
 		entry.Source.UnsupportedURL() != ""
@@ -945,6 +952,12 @@ func validateApp(cfg *Config, name string, entry *ProviderEntry) error {
 	}
 	if err := validateProviderEntrySource("app", name, entry); err != nil {
 		return err
+	}
+	if entry.Source.IsRegistry() {
+		registryName := strings.TrimSpace(entry.Source.Registry)
+		if _, ok := cfg.AppRegistries[registryName]; !ok {
+			return fmt.Errorf("config validation: app %q source.registry references unknown app registry %q", name, registryName)
+		}
 	}
 	if err := validateAppRouteAuth(cfg, name, entry); err != nil {
 		return err

--- a/gestaltd/internal/coredata/app_version_change_requests_projection.go
+++ b/gestaltd/internal/coredata/app_version_change_requests_projection.go
@@ -131,12 +131,14 @@ func LatestKnownVersion(installations []*core.AppInstallation) string {
 	if len(installations) == 0 {
 		return ""
 	}
-	latest := installations[0]
-	for _, installation := range installations[1:] {
+	var latest *core.AppInstallation
+	for _, installation := range installations {
 		if installation == nil {
 			continue
 		}
-		if latest == nil || installation.UpdatedAt.After(latest.UpdatedAt) {
+		if latest == nil ||
+			installation.UpdatedAt.After(latest.UpdatedAt) ||
+			(installation.UpdatedAt.Equal(latest.UpdatedAt) && installation.Version > latest.Version) {
 			latest = installation
 		}
 	}
@@ -144,6 +146,16 @@ func LatestKnownVersion(installations []*core.AppInstallation) string {
 		return ""
 	}
 	return strings.TrimSpace(latest.Version)
+}
+
+func KnownInstallationByVersion(installations []*core.AppInstallation, version string) *core.AppInstallation {
+	version = strings.TrimSpace(version)
+	for _, installation := range installations {
+		if installation != nil && strings.TrimSpace(installation.Version) == version {
+			return installation
+		}
+	}
+	return nil
 }
 
 func stringMeta(metadata map[string]any, key string) string {

--- a/gestaltd/internal/coredata/app_version_change_requests_projection_test.go
+++ b/gestaltd/internal/coredata/app_version_change_requests_projection_test.go
@@ -1,0 +1,21 @@
+package coredata
+
+import (
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+)
+
+func TestLatestKnownVersionBreaksTimestampTiesByVersion(t *testing.T) {
+	t.Parallel()
+
+	updatedAt := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	installations := []*core.AppInstallation{
+		{Version: "1.0.0", UpdatedAt: updatedAt},
+		{Version: "2.0.0", UpdatedAt: updatedAt},
+	}
+	if got := LatestKnownVersion(installations); got != "2.0.0" {
+		t.Fatalf("LatestKnownVersion = %q, want 2.0.0", got)
+	}
+}

--- a/gestaltd/internal/daemon/factories.go
+++ b/gestaltd/internal/daemon/factories.go
@@ -62,12 +62,18 @@ func setupBootstrapWithConfigPathsContext(ctx context.Context, stop context.Canc
 	factories.DevSupervisor = devSupervisor
 
 	var registryResolver bootstrap.RegistryInstalledResolver
+	var registryMaterializer bootstrap.RegistryAppMaterializer
 	if strings.TrimSpace(cfg.Server.ArtifactsDir) != "" && len(cfg.AppRegistries) > 0 {
 		registryResolver = &appregistry.MountService{ArtifactsDir: cfg.Server.ArtifactsDir}
+		registryMaterializer = &appregistry.Materializer{
+			Registries:   cfg.AppRegistries,
+			ArtifactsDir: cfg.Server.ArtifactsDir,
+		}
 	}
 	result, err := bootstrap.BootstrapWithOptions(ctx, cfg, factories, bootstrap.BootstrapOptions{
 		DeferAppProviderStartup: true,
 		RegistryResolver:        registryResolver,
+		RegistryMaterializer:    registryMaterializer,
 	})
 	if err != nil {
 		if devSupervisor != nil {

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -483,6 +483,10 @@ func (l *Lifecycle) prepareCommittedRuntimeLockFromLoadedConfig(ctx context.Cont
 		if !providerRequiresCommittedLock(entry) {
 			continue
 		}
+		if entry.Source.IsRegistry() {
+			lock.Providers.App[name] = registryOnlyLockEntry(entry)
+			continue
+		}
 		configMap, err := config.NodeToMap(entry.Config)
 		if err != nil {
 			return nil, fmt.Errorf("decode provider config for provider %q: %w", name, err)
@@ -632,7 +636,16 @@ func (l *Lifecycle) prepareRuntimeLockFromLoadedConfigWithSecretMode(ctx context
 
 	lock := newLockfile()
 	for name, entry := range cfg.Apps {
-		if entry == nil || !sourceBacked(entry) || entry.HasLocalSource() {
+		if entry == nil {
+			continue
+		}
+		if entry.Source.IsRegistry() {
+			if providerRequiresCommittedLock(entry) {
+				lock.Providers.App[name] = registryOnlyLockEntry(entry)
+			}
+			continue
+		}
+		if !sourceBacked(entry) || entry.HasLocalSource() {
 			continue
 		}
 		configMap, err := config.NodeToMap(entry.Config)
@@ -1744,6 +1757,20 @@ func sourceBacked(entry *config.ProviderEntry) bool {
 	return entry != nil && (entry.HasRemoteSource() || entry.HasLocalSource() || entry.HasLocalReleaseSource())
 }
 
+func registryOnlyLockEntry(entry *config.ProviderEntry) LockEntry {
+	registryName := ""
+	if entry != nil {
+		registryName = strings.TrimSpace(entry.Source.Registry)
+	}
+	return LockEntry{
+		Source: "registry",
+		SourceRef: &LockSourceRef{
+			Type:               "registry",
+			ResolvedGestaltRef: registryName,
+		},
+	}
+}
+
 func runtimeSourceBacked(entry *config.RuntimeProviderEntry) bool {
 	return entry != nil && sourceBacked(&entry.ProviderEntry)
 }
@@ -1752,7 +1779,7 @@ func providerRequiresCommittedLock(entry *config.ProviderEntry) bool {
 	if entry == nil || entry.DevActive {
 		return false
 	}
-	return sourceBacked(entry) && !entry.HasLocalSource()
+	return entry.Source.IsRegistry() || (sourceBacked(entry) && !entry.HasLocalSource())
 }
 
 func runtimeRequiresCommittedLock(entry *config.RuntimeProviderEntry) bool {
@@ -1812,7 +1839,9 @@ func lockEntriesForKind(lock *Lockfile, kind config.HostProviderKind) map[string
 }
 
 func configHasProviderLoading(cfg *config.Config) bool {
-	return configHasMatchingProviderEntry(cfg, sourceBacked)
+	return configHasMatchingProviderEntry(cfg, func(entry *config.ProviderEntry) bool {
+		return sourceBacked(entry) || (entry != nil && entry.Source.IsRegistry())
+	})
 }
 
 func configRequiresCommittedLock(cfg *config.Config) bool {
@@ -2663,6 +2692,9 @@ func lockEntryMatches(paths lifecyclePaths, kind, name string, providerEntry *co
 	if !lockEntryMetadataMatches(paths, kind, name, providerEntry, entry, found) {
 		return false
 	}
+	if providerEntry != nil && providerEntry.Source.IsRegistry() {
+		return true
+	}
 	if len(entry.Archives) > 0 {
 		platform := providerpkg.CurrentPlatformString()
 		_, resolvedKey, ok := resolveArchiveForPlatform(entry, platform)
@@ -2712,6 +2744,12 @@ func lockEntryMatches(paths lifecyclePaths, kind, name string, providerEntry *co
 func lockEntryMetadataMatches(paths lifecyclePaths, kind, name string, providerEntry *config.ProviderEntry, entry LockEntry, found bool) bool {
 	if !found {
 		return false
+	}
+	if providerEntry != nil && providerEntry.Source.IsRegistry() {
+		return entry.Source == "registry" &&
+			entry.SourceRef != nil &&
+			entry.SourceRef.Type == "registry" &&
+			entry.SourceRef.ResolvedGestaltRef == strings.TrimSpace(providerEntry.Source.Registry)
 	}
 	fingerprintMatches, err := lockEntryFingerprintMatchesProvider(name, providerEntry, paths.configDir, entry)
 	if err != nil || !fingerprintMatches {
@@ -3409,7 +3447,7 @@ func validateResolvedStructureForCommittedLock(paths lifecyclePaths, cfg *config
 		Apps: make(map[string]*config.ProviderEntry),
 	}
 	for name, entry := range cfg.Apps {
-		if providerRequiresCommittedLock(entry) {
+		if providerRequiresCommittedLock(entry) && !entry.Source.IsRegistry() {
 			validation.Apps[name] = entry
 		}
 	}
@@ -3424,7 +3462,7 @@ func effectiveCatalogsForCommittedLock(ctx context.Context, cfg *config.Config, 
 		Apps: make(map[string]*appservice.ValidationApp, len(cfg.Apps)),
 	}
 	for name, entry := range cfg.Apps {
-		if entry == nil {
+		if entry == nil || entry.Source.IsRegistry() {
 			continue
 		}
 		if _, locked := lock.Providers.App[name]; locked {
@@ -3856,7 +3894,7 @@ func (l *Lifecycle) resolveConfiguredPluginsWithOptions(paths lifecyclePaths, lo
 	}
 	l.prefetchLockedAppMaterializedCache(paths, lock, cfg, mode, opts.Parallelism)
 	for _, work := range ordered {
-		if work.entry.HasLocalSource() || work.entry.DevActive || !sourceBacked(work.entry) {
+		if work.entry.HasLocalSource() || work.entry.DevActive || work.entry.Source.IsRegistry() || !sourceBacked(work.entry) {
 			continue
 		}
 		if err := l.applyLockedProviderEntry(paths, lock, work.name, work.entry, work.configMap, mode); err != nil {
@@ -3887,6 +3925,9 @@ func (l *Lifecycle) resolveConfiguredAppStaticBindings(paths lifecyclePaths, wor
 		}
 		if err := resolveAppStaticTheme(paths, item.name, entry); err != nil {
 			return err
+		}
+		if entry.Source.IsRegistry() {
+			continue
 		}
 		if err := materializeAppStaticRoot(paths, item.name, entry); err != nil {
 			return err

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -41,6 +41,57 @@ const (
 	testBinary  = "fake-binary-content"
 )
 
+func TestLifecycleRegistryOnlyAppLockSyncContract(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	artifactsDir := filepath.Join(dir, "artifacts")
+	lockfilePath := filepath.Join(dir, LockfileName)
+	configPath := filepath.Join(dir, "gestaltd.yaml")
+	configYAML := fmt.Sprintf(`
+apiVersion: gestaltd.config/v8
+%s
+server:
+  providers:
+    indexeddb: sqlite
+  artifactsDir: %s
+  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+appRegistries:
+  toolshed:
+    kind: gcs
+    gcs:
+      bucket: gestalt-app-registry
+apps:
+  g-issues:
+    static:
+      mount: /g-issues
+    source:
+      registry: toolshed
+`, requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")), filepath.ToSlash(artifactsDir))
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	lc := NewLifecycle()
+	lock, err := lc.LockAtPaths([]string{configPath}, lockfilePath, artifactsDir)
+	if err != nil {
+		t.Fatalf("LockAtPaths: %v", err)
+	}
+	entry := lock.Providers.App["g-issues"]
+	if entry.Source != "registry" || entry.SourceRef == nil || entry.SourceRef.Type != "registry" || entry.SourceRef.ResolvedGestaltRef != "toolshed" {
+		t.Fatalf("registry lock entry = %#v", entry)
+	}
+	if entry.ArtifactManifest != "" || entry.Executable != "" || len(entry.Archives) != 0 {
+		t.Fatalf("registry lock entry contains baked artifacts: %#v", entry)
+	}
+	if err := lc.SyncAtPathsOptions([]string{configPath}, lockfilePath, artifactsDir, SyncOptions{Locked: true}); err != nil {
+		t.Fatalf("SyncAtPathsOptions: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(artifactsDir, PreparedProvidersDir, "g-issues")); !os.IsNotExist(err) {
+		t.Fatalf("registry-only app artifact path should not exist, stat error = %v", err)
+	}
+}
+
 func TestLifecycleGitSourceBuildLockSyncContract(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/operator/sync_observability.go
+++ b/gestaltd/internal/operator/sync_observability.go
@@ -106,7 +106,7 @@ func (l *Lifecycle) materializedCacheRequestsForProviders(paths lifecyclePaths, 
 	var requests []materializedCacheRequest
 	for _, name := range slices.Sorted(maps.Keys(entries)) {
 		entry := entries[name]
-		if !providerRequiresCommittedLock(entry) {
+		if !providerRequiresCommittedLock(entry) || entry.Source.IsRegistry() {
 			continue
 		}
 		lockEntry, ok := lockEntries[name]
@@ -234,7 +234,7 @@ func preparedArtifactRoots(paths lifecyclePaths, cfg *config.Config) []PreparedA
 	}
 	var roots []PreparedArtifactRoot
 	for name, entry := range cfg.Apps {
-		if entry != nil {
+		if entry != nil && !entry.Source.IsRegistry() {
 			roots = append(roots, PreparedArtifactRoot{
 				Subject: "provider " + strconv.Quote(name),
 				Kind:    providermanifestv1.KindApp,

--- a/gestaltd/internal/server/handlers_admin_app_install.go
+++ b/gestaltd/internal/server/handlers_admin_app_install.go
@@ -45,7 +45,8 @@ func (s *Server) mountAdminAppInstallReadRoutes(r chi.Router) {
 }
 
 func (s *Server) mountAdminAppInstallWriteRoutes(r chi.Router) {
-	r.Post("/app-registries/{registry}/apps/{app}/install", s.installAdminAppRegistryApp)
+	r.Post("/app-registries/{registry}/apps/{app}/add", s.addAdminAppRegistryApp)
+	r.Post("/app-registries/{registry}/apps/{app}/upgrade", s.upgradeAdminAppRegistryApp)
 }
 
 func (s *Server) listAdminAppInstallations(w http.ResponseWriter, r *http.Request) {
@@ -95,7 +96,15 @@ func (s *Server) getAdminAppInstallation(w http.ResponseWriter, r *http.Request)
 	writeJSON(w, http.StatusOK, out)
 }
 
-func (s *Server) installAdminAppRegistryApp(w http.ResponseWriter, r *http.Request) {
+func (s *Server) addAdminAppRegistryApp(w http.ResponseWriter, r *http.Request) {
+	s.changeAdminAppRegistryApp(w, r, true)
+}
+
+func (s *Server) upgradeAdminAppRegistryApp(w http.ResponseWriter, r *http.Request) {
+	s.changeAdminAppRegistryApp(w, r, false)
+}
+
+func (s *Server) changeAdminAppRegistryApp(w http.ResponseWriter, r *http.Request, add bool) {
 	if s.appRegistryInstaller == nil {
 		writeError(w, http.StatusServiceUnavailable, "app registry installer is unavailable")
 		return
@@ -134,12 +143,19 @@ func (s *Server) installAdminAppRegistryApp(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	result, err := s.appRegistryInstaller.Install(r.Context(), appregistry.InstallInput{
+	input := appregistry.InstallInput{
 		Registry: registryName,
 		App:      appName,
 		Version:  version,
 		Actor:    strings.TrimSpace(req.Actor),
-	})
+	}
+	var result *appregistry.InstallOutput
+	var err error
+	if add {
+		result, err = s.appRegistryInstaller.Add(r.Context(), input)
+	} else {
+		result, err = s.appRegistryInstaller.Upgrade(r.Context(), input)
+	}
 	if err != nil {
 		status := http.StatusBadGateway
 		switch {
@@ -157,6 +173,12 @@ func (s *Server) installAdminAppRegistryApp(w http.ResponseWriter, r *http.Reque
 			status = http.StatusConflict
 		case errors.Is(err, appregistry.ErrAppRolloutActive):
 			status = http.StatusConflict
+		case errors.Is(err, appregistry.ErrAppCatalogNotEmpty):
+			status = http.StatusConflict
+		case errors.Is(err, appregistry.ErrAppCatalogEmpty):
+			status = http.StatusBadRequest
+		case errors.Is(err, appregistry.ErrAppRegistryBinding):
+			status = http.StatusBadRequest
 		case errors.Is(err, appregistry.ErrAppVersionAlreadyInstalled):
 			status = http.StatusBadRequest
 		case errors.Is(err, context.DeadlineExceeded):

--- a/gestaltd/internal/server/handlers_admin_app_install_test.go
+++ b/gestaltd/internal/server/handlers_admin_app_install_test.go
@@ -16,13 +16,13 @@ import (
 
 func appRegistryTestAppDefs(version string) map[string]*config.ProviderEntry {
 	entry := &config.ProviderEntry{}
-	entry.Source.SetResolvedPackage("", version)
+	entry.Source.Registry = "toolshed"
 	return map[string]*config.ProviderEntry{
 		"g-issues": entry,
 	}
 }
 
-func TestAdminAppRegistryInstall(t *testing.T) {
+func TestAdminAppRegistryAdd(t *testing.T) {
 	t.Parallel()
 
 	t.Run("installs_and_lists_known_version", func(t *testing.T) {
@@ -41,7 +41,7 @@ func TestAdminAppRegistryInstall(t *testing.T) {
 		testutil.CloseOnCleanup(t, ts)
 
 		body := []byte(`{"version":"` + fixture.Version + `","actor":"user:alice"}`)
-		resp, err := http.Post(ts.URL+"/admin/api/v1/app-registries/toolshed/apps/g-issues/install", "application/json", bytes.NewReader(body))
+		resp, err := http.Post(ts.URL+"/admin/api/v1/app-registries/toolshed/apps/g-issues/add", "application/json", bytes.NewReader(body))
 		if err != nil {
 			t.Fatalf("POST install: %v", err)
 		}
@@ -111,7 +111,7 @@ func TestAdminAppRegistryInstall(t *testing.T) {
 		testutil.CloseOnCleanup(t, ts)
 
 		body := []byte(`{"version":"missing-version"}`)
-		resp, err := http.Post(ts.URL+"/admin/api/v1/app-registries/toolshed/apps/g-issues/install", "application/json", bytes.NewReader(body))
+		resp, err := http.Post(ts.URL+"/admin/api/v1/app-registries/toolshed/apps/g-issues/add", "application/json", bytes.NewReader(body))
 		if err != nil {
 			t.Fatalf("POST install: %v", err)
 		}
@@ -138,7 +138,7 @@ func TestAdminAppRegistryInstall(t *testing.T) {
 		testutil.CloseOnCleanup(t, ts)
 
 		body := []byte(`{"version":"` + fixture.Version + `"}`)
-		first, err := http.Post(ts.URL+"/admin/api/v1/app-registries/toolshed/apps/g-issues/install", "application/json", bytes.NewReader(body))
+		first, err := http.Post(ts.URL+"/admin/api/v1/app-registries/toolshed/apps/g-issues/add", "application/json", bytes.NewReader(body))
 		if err != nil {
 			t.Fatalf("POST first install: %v", err)
 		}
@@ -147,14 +147,14 @@ func TestAdminAppRegistryInstall(t *testing.T) {
 			t.Fatalf("first install status = %d", first.StatusCode)
 		}
 
-		second, err := http.Post(ts.URL+"/admin/api/v1/app-registries/toolshed/apps/g-issues/install", "application/json", bytes.NewReader(body))
+		second, err := http.Post(ts.URL+"/admin/api/v1/app-registries/toolshed/apps/g-issues/add", "application/json", bytes.NewReader(body))
 		if err != nil {
 			t.Fatalf("POST second install: %v", err)
 		}
 		defer func() { _ = second.Body.Close() }()
-		if second.StatusCode != http.StatusBadRequest {
+		if second.StatusCode != http.StatusConflict {
 			raw, _ := io.ReadAll(second.Body)
-			t.Fatalf("second install status = %d, want 400: %s", second.StatusCode, raw)
+			t.Fatalf("second add status = %d, want 409: %s", second.StatusCode, raw)
 		}
 	})
 
@@ -174,7 +174,7 @@ func TestAdminAppRegistryInstall(t *testing.T) {
 		testutil.CloseOnCleanup(t, ts)
 
 		installBody := []byte(`{"version":"` + fixture.Version + `"}`)
-		installResp, err := http.Post(ts.URL+"/admin/api/v1/app-registries/toolshed/apps/g-issues/install", "application/json", bytes.NewReader(installBody))
+		installResp, err := http.Post(ts.URL+"/admin/api/v1/app-registries/toolshed/apps/g-issues/add", "application/json", bytes.NewReader(installBody))
 		if err != nil {
 			t.Fatalf("POST install: %v", err)
 		}
@@ -203,4 +203,53 @@ func TestAdminAppRegistryInstall(t *testing.T) {
 			t.Fatalf("installation = %#v", installations[0])
 		}
 	})
+}
+
+func TestAdminAppRegistryUpgradeRejectsEmptyCatalog(t *testing.T) {
+	t.Parallel()
+
+	fixture := registrytest.NewInstallFixture(t)
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.AppRegistries = map[string]config.AppRegistryConfig{
+			"toolshed": fixture.Registry,
+		}
+		cfg.AppRegistryReader = fixture.Reader
+		cfg.AppDefs = appRegistryTestAppDefs("")
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := []byte(`{"version":"` + fixture.Version + `"}`)
+	resp, err := http.Post(ts.URL+"/admin/api/v1/app-registries/toolshed/apps/g-issues/upgrade", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST upgrade: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("upgrade status = %d, want 400: %s", resp.StatusCode, raw)
+	}
+}
+
+func TestRegistryOnlyStaticMountStartsBeforeFirstAdd(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.ArtifactsDir = t.TempDir()
+		cfg.AppDefs = map[string]*config.ProviderEntry{
+			"g-issues": {
+				Source: config.ProviderSource{Registry: "toolshed"},
+				Static: &config.AppStaticConfig{Mount: "/g-issues"},
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/g-issues/")
+	if err != nil {
+		t.Fatalf("GET registry static mount: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 before first add", resp.StatusCode)
+	}
 }

--- a/gestaltd/internal/server/http_bindings.go
+++ b/gestaltd/internal/server/http_bindings.go
@@ -61,9 +61,13 @@ func mountedHTTPBindingsFromEntries(entries map[string]*config.ProviderEntry, pr
 			}
 		}
 
-		operationIDs, err := providerOperationIDs(providers, pluginName)
-		if err != nil {
-			return nil, fmt.Errorf("resolve http bindings for %s: %w", pluginName, err)
+		var operationIDs map[string]struct{}
+		if !entry.Source.IsRegistry() {
+			var err error
+			operationIDs, err = providerOperationIDs(providers, pluginName)
+			if err != nil {
+				return nil, fmt.Errorf("resolve http bindings for %s: %w", pluginName, err)
+			}
 		}
 
 		bindingNames := make([]string, 0, len(bindings))

--- a/gestaltd/internal/server/http_bindings_test.go
+++ b/gestaltd/internal/server/http_bindings_test.go
@@ -4,6 +4,9 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 )
 
 func TestValidateMountedHTTPBindingRoutesRejectsCoreRouteNamespace(t *testing.T) {
@@ -22,5 +25,32 @@ func TestValidateMountedHTTPBindingRoutesRejectsCoreRouteNamespace(t *testing.T)
 	}
 	if got := err.Error(); !strings.Contains(got, `conflicts with core route namespace "/api/v1/tokens"`) {
 		t.Fatalf("error = %q, want tokens namespace conflict", got)
+	}
+}
+
+func TestMountedHTTPBindingsAllowsRegistryAppBeforeStartup(t *testing.T) {
+	t.Parallel()
+
+	bindings, err := mountedHTTPBindingsFromEntries(map[string]*config.ProviderEntry{
+		"g-issues": {
+			Source: config.ProviderSource{Registry: "toolshed"},
+			SecuritySchemes: map[string]*config.HTTPSecurityScheme{
+				"none": {Type: providermanifestv1.HTTPSecuritySchemeTypeNone},
+			},
+			HTTP: map[string]*config.HTTPBinding{
+				"status": {
+					Path:     "/status",
+					Method:   http.MethodGet,
+					Security: "none",
+					Target:   "status",
+				},
+			},
+		},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("mountedHTTPBindingsFromEntries: %v", err)
+	}
+	if len(bindings) != 1 {
+		t.Fatalf("bindings = %d, want 1", len(bindings))
 	}
 }

--- a/gestaltd/internal/server/mounted_app_static.go
+++ b/gestaltd/internal/server/mounted_app_static.go
@@ -8,12 +8,21 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"sync"
 
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/appregistry"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	providerregistry "github.com/valon-technologies/gestalt/server/services/apps/registry"
 	"github.com/valon-technologies/gestalt/server/services/ui"
 )
 
-func mountedAppStaticsFromEntries(apps map[string]*config.ProviderEntry, devHandlerResolver func(string) http.Handler) ([]MountedUI, error) {
+func mountedAppStaticsFromEntries(
+	apps map[string]*config.ProviderEntry,
+	devHandlerResolver func(string) http.Handler,
+	artifactsDir string,
+	providers *providerregistry.ProviderMap[core.Provider],
+) ([]MountedUI, error) {
 	names := make([]string, 0, len(apps))
 	for name, entry := range apps {
 		if entry == nil || entry.Static == nil {
@@ -48,6 +57,20 @@ func mountedAppStaticsFromEntries(apps map[string]*config.ProviderEntry, devHand
 			continue
 		}
 
+		if entry.Source.IsRegistry() {
+			mounted = append(mounted, MountedUI{
+				Name:                mountedName,
+				Path:                mount,
+				AppName:             name,
+				AuthorizationPolicy: entry.AuthorizationPolicy,
+				AppLevelAuth:        !entry.Static.Public,
+				Handler:             registryAppStaticHandler(name, mount, entry, artifactsDir, providers),
+				ThemeStylesheet:     entry.ResolvedThemeStylesheet,
+				ThemeAssetsDir:      entry.ResolvedThemeAssetsDir,
+			})
+			continue
+		}
+
 		if strings.TrimSpace(entry.ResolvedStaticRoot) == "" {
 			return nil, fmt.Errorf("app %q static configured but asset root not resolved", name)
 		}
@@ -74,6 +97,74 @@ func mountedAppStaticsFromEntries(apps map[string]*config.ProviderEntry, devHand
 	}
 
 	return mounted, nil
+}
+
+func registryAppStaticHandler(
+	appName string,
+	mount string,
+	entry *config.ProviderEntry,
+	artifactsDir string,
+	providers *providerregistry.ProviderMap[core.Provider],
+) http.Handler {
+	var mu sync.Mutex
+	var activeVersion string
+	var activeHandler http.Handler
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		version, err := appregistry.ActiveInstalledVersion(artifactsDir, appName)
+		if os.IsNotExist(err) || version == "" {
+			http.Error(w, "registry app is not installed", http.StatusNotFound)
+			return
+		}
+		if err != nil {
+			http.Error(w, "registry app installation is unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		if providers == nil {
+			http.Error(w, "registry app is not running", http.StatusServiceUnavailable)
+			return
+		}
+		if _, err := providers.Get(appName); err != nil {
+			http.Error(w, "registry app is not running", http.StatusServiceUnavailable)
+			return
+		}
+		confirmedVersion, err := appregistry.ActiveInstalledVersion(artifactsDir, appName)
+		if err != nil || confirmedVersion != version {
+			http.Error(w, "registry app version changed during request", http.StatusServiceUnavailable)
+			return
+		}
+		mu.Lock()
+		if version == activeVersion && activeHandler != nil {
+			handler := activeHandler
+			mu.Unlock()
+			handler.ServeHTTP(w, r)
+			return
+		}
+		resolved, err := appregistry.ResolveInstalledApp(
+			appName,
+			entry,
+			appregistry.MaterializedPath(artifactsDir, appName, version),
+			version,
+		)
+		if err != nil {
+			mu.Unlock()
+			http.Error(w, "registry app artifacts are unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		handler, err := ui.StaticHandler(ui.StaticConfig{
+			FS:           os.DirFS(resolved.ResolvedStaticRoot),
+			DynamicIndex: true,
+			RenderIndex:  injectBaseHref(mount),
+		})
+		if err != nil {
+			mu.Unlock()
+			http.Error(w, "registry app static handler is unavailable", http.StatusInternalServerError)
+			return
+		}
+		activeVersion = version
+		activeHandler = handler
+		mu.Unlock()
+		handler.ServeHTTP(w, r)
+	})
 }
 
 func injectBaseHref(mount string) func([]byte) []byte {

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -432,7 +432,10 @@ func startAppRegistryCatalogPoller(ctx context.Context, cfg *config.Config, resu
 		return nil
 	}
 	var materializer *appregistry.Materializer
-	if cfg != nil && len(cfg.AppRegistries) > 0 {
+	if shared, ok := result.RegistryMaterializer.(*appregistry.Materializer); ok {
+		materializer = shared
+	}
+	if materializer == nil && cfg != nil && len(cfg.AppRegistries) > 0 {
 		artifactsDir := strings.TrimSpace(cfg.Server.ArtifactsDir)
 		if artifactsDir != "" {
 			materializer = &appregistry.Materializer{
@@ -450,7 +453,7 @@ func startAppRegistryCatalogPoller(ctx context.Context, cfg *config.Config, resu
 		InstanceID:          appregistry.ResolveInstanceID(),
 		RestartDelay:        restartDelay,
 		DisableRestartDelay: disableRestartDelay,
-		RestartReady:        result.StartupProvidersReady,
+		RestartReady:        result.RegistryProvidersReady,
 	})
 	poller.Start(ctx)
 	return poller

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -263,7 +263,7 @@ func New(cfg Config) (*Server, error) {
 		return nil, fmt.Errorf("validate admin route: %w", err)
 	}
 	mountedUIs := append([]MountedUI(nil), cfg.MountedUIs...)
-	appStatics, err := mountedAppStaticsFromEntries(cfg.AppDefs, cfg.DevHandlerResolver)
+	appStatics, err := mountedAppStaticsFromEntries(cfg.AppDefs, cfg.DevHandlerResolver, cfg.ArtifactsDir, cfg.Providers)
 	if err != nil {
 		return nil, fmt.Errorf("resolve mounted app static handlers: %w", err)
 	}


### PR DESCRIPTION
## Summary
- add validated `source.registry` app config and registry-only lock/sync entries without baked artifacts
- split registry admission into `add` and `upgrade` flows with fleet-catalog `from_version` semantics
- bootstrap registry-only providers from the latest known version, sharing materialization with the poller and activating version-synchronized static mounts

## Stack
- Depends on #2868 (`app-registry-step12-docs`)

## Testing
- `cd gestaltd && go test ./...`