### PR TITLE
PG-8: delete dead app provider constructor

### DIFF
--- a/gestaltd/services/apps/process.go
+++ b/gestaltd/services/apps/process.go
@@ -9,79 +9,13 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
-	"github.com/valon-technologies/gestalt/server/services/egress"
-	"github.com/valon-technologies/gestalt/server/services/invocation"
-	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 )
 
-type ExecConfig struct {
-	Command       string
-	Args          []string
-	Workdir       string
-	Env           map[string]string
-	StaticSpec    StaticProviderSpec
-	Config        map[string]any
-	Egress        egress.Policy
-	HostBinary    string
-	Cleanup       func()
-	HostServices  []runtimehost.HostService
-	PublicBaseURL string
-	ProviderName  string
-	Telemetry     metricutil.TelemetryProviders
-}
-
-func NewExecutable(ctx context.Context, cfg ExecConfig) (core.Provider, error) {
-	process, err := runtimehost.StartAppProcess(ctx, cfg.processConfig())
-	if err != nil {
-		return nil, err
-	}
-
-	opts := []RemoteProviderOption{
-		WithCloser(process),
-		WithHostContext(cfg.PublicBaseURL),
-		WithCallerProvider(invocation.ProviderKindApp, cfg.StaticSpec.Name),
-	}
-	prov, err := NewRemote(
-		ctx,
-		proto.NewAppProviderClient(process.Conn()),
-		cfg.StaticSpec,
-		cfg.Config,
-		opts...,
-	)
-	if err != nil {
-		_ = process.Close()
-		return nil, err
-	}
-	return prov, nil
-}
-
-func (c ExecConfig) processConfig() runtimehost.ProcessConfig {
-	return runtimehost.ProcessConfig{
-		Command:      c.Command,
-		Args:         c.Args,
-		Workdir:      c.Workdir,
-		Env:          c.Env,
-		Egress:       cloneEgressPolicy(c.Egress),
-		HostBinary:   c.HostBinary,
-		Cleanup:      c.Cleanup,
-		HostServices: c.HostServices,
-		ProviderName: firstNonBlank(c.ProviderName, c.StaticSpec.Name),
-		Telemetry:    c.Telemetry,
-	}
-}
-
 func NewPluginTempDir(pattern string) (string, error) {
 	return runtimehost.NewPluginTempDir(pattern)
-}
-
-func cloneEgressPolicy(policy egress.Policy) egress.Policy {
-	return egress.Policy{
-		AllowedHosts:  append([]string(nil), policy.AllowedHosts...),
-		DefaultAction: policy.DefaultAction,
-	}
 }
 
 func ServeProvider(ctx context.Context, provider core.Provider) error {
@@ -125,13 +59,4 @@ func serveProvider(ctx context.Context, register func(*grpc.Server)) error {
 		return nil
 	}
 	return err
-}
-
-func firstNonBlank(values ...string) string {
-	for _, value := range values {
-		if trimmed := strings.TrimSpace(value); trimmed != "" {
-			return trimmed
-		}
-	}
-	return ""
 }

--- a/gestaltd/services/providergateway/gateway_test.go
+++ b/gestaltd/services/providergateway/gateway_test.go
@@ -2,8 +2,8 @@ package providergateway
 
 import (
 	"context"
-	"io"
 	"errors"
+	"io"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -443,12 +443,12 @@ func (c *stubStreamConn) NewStream(ctx context.Context, desc *grpc.StreamDesc, m
 
 type stubClientStream struct{}
 
-func (s *stubClientStream) Header() (metadata.MD, error)             { return nil, nil }
-func (s *stubClientStream) Trailer() metadata.MD                     { return nil }
-func (s *stubClientStream) CloseSend() error                          { return nil }
-func (s *stubClientStream) Context() context.Context                 { return context.Background() }
-func (s *stubClientStream) SendMsg(m any) error                      { return nil }
-func (s *stubClientStream) RecvMsg(m any) error                      { return io.EOF }
+func (s *stubClientStream) Header() (metadata.MD, error) { return nil, nil }
+func (s *stubClientStream) Trailer() metadata.MD         { return nil }
+func (s *stubClientStream) CloseSend() error             { return nil }
+func (s *stubClientStream) Context() context.Context     { return context.Background() }
+func (s *stubClientStream) SendMsg(m any) error          { return nil }
+func (s *stubClientStream) RecvMsg(m any) error          { return io.EOF }
 
 func TestRoutingInvokeForwardsToEndpoint(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Deletes `NewExecutable`, `ExecConfig`, `processConfig`, `firstNonBlank`, and a duplicate `cloneEgressPolicy` from `gestaltd/services/apps/process.go`. `NewExecutable` had zero callers in production or tests — all app providers go through `buildAppProvider` in bootstrap, which constructs on `gateway.Conn(target)`. The other deleted functions were only used by `NewExecutable`.

Also fixes a pre-existing gofmt issue in `gateway_test.go` (import ordering from the PG-4 merge).
