### PR TITLE
Allow HTTP binding to override generic operation route for its own target

### DIFF
--- a/gestaltd/internal/server/http_bindings.go
+++ b/gestaltd/internal/server/http_bindings.go
@@ -90,7 +90,7 @@ func mountedHTTPBindingsFromEntries(entries map[string]*config.ProviderEntry, pr
 				if _, ok := operationIDs[target]; !ok {
 					return nil, fmt.Errorf("http binding %s.%s target %q is not in provider catalog", pluginName, bindingName, target)
 				}
-				if relativePathConflictsWithGenericOperation(relativePath, operationIDs) {
+				if relativePathConflictsWithGenericOperation(relativePath, target, operationIDs) {
 					return nil, fmt.Errorf("http binding %s.%s path %q conflicts with the generic operation route", pluginName, bindingName, binding.Path)
 				}
 			}
@@ -145,9 +145,12 @@ func mountedHTTPBindingPath(pluginName, relativePath string) string {
 	return base + relativePath
 }
 
-func relativePathConflictsWithGenericOperation(relativePath string, operationIDs map[string]struct{}) bool {
+func relativePathConflictsWithGenericOperation(relativePath, target string, operationIDs map[string]struct{}) bool {
 	trimmed := strings.Trim(strings.TrimSpace(relativePath), "/")
 	if trimmed == "" || strings.Contains(trimmed, "/") {
+		return false
+	}
+	if trimmed == target {
 		return false
 	}
 	_, ok := operationIDs[trimmed]

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -9826,6 +9826,48 @@ func TestHostedHTTPBinding_RejectsGenericOperationRouteConflicts(t *testing.T) {
 	}
 }
 
+func TestHostedHTTPBinding_AllowsOverrideOfGenericOperationRoute(t *testing.T) {
+	t.Parallel()
+
+	svc := testutil.NewStubServices(t)
+	providers := testutil.NewProviderRegistry(t, &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "llm",
+			ConnMode: core.ConnectionModeNone,
+		},
+		ops: []core.Operation{
+			{Name: "responses", Method: http.MethodPost},
+		},
+	})
+	cfg := server.Config{
+		Auth:        &coretesting.StubAuthProvider{N: "none"},
+		Services:    svc,
+		Providers:   providers,
+		Invoker:     invocation.NewBroker(providers, svc.Users, svc.ExternalCredentials),
+		StateSecret: []byte("0123456789abcdef0123456789abcdef"),
+		AppDefs: map[string]*config.ProviderEntry{
+			"llm": {
+				SecuritySchemes: map[string]*config.HTTPSecurityScheme{
+					"none": {Type: providermanifestv1.HTTPSecuritySchemeTypeNone},
+				},
+				HTTP: map[string]*config.HTTPBinding{
+					"responses": {
+						Path:      "/responses",
+						Method:    http.MethodPost,
+						Security:  "none",
+						Target:    "responses",
+						Streaming: true,
+					},
+				},
+			},
+		},
+	}
+
+	if _, err := server.New(cfg); err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+}
+
 func TestHostedHTTPBinding_AddsRequestHeadersToWorkflowContext(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- A binding whose relative path matches its own target operation is an intentional override of that operation's generic unary route (e.g. a streaming SSE binding), not an accidental collision. The conflict check now allows this case.
- Bindings whose path shadows a *different* operation's generic route are still rejected, preserving the existing ambiguity guard.
- Unblocks the `llm` proxy app whose streaming `/responses` binding targets the `responses` operation, which was rejected with `http binding llm.responses path "/responses" conflicts with the generic operation route`.

## Test plan

- [x] `TestHostedHTTPBinding_AllowsOverrideOfGenericOperationRoute` — streaming binding with `path: /responses`, `target: responses` succeeds in `server.New`
- [x] `TestHostedHTTPBinding_RejectsGenericOperationRouteConflicts` — non-streaming binding with `path: /status`, `target: handle_status` (different op) still rejected
- [x] `TestHTTPBindingStreaming` — streaming binding still flushes SSE chunks
- [x] `TestValidateMountedHTTPBindingRoutesRejectsCoreRouteNamespace` — core namespace rejection unchanged
- [x] Full `gestaltd/internal/server` test suite passes