### PR TITLE
Attach bootstrap principal to workflow config reconciliation

### DIFF
--- a/gestaltd/internal/bootstrap/workflow_app_definitions_test.go
+++ b/gestaltd/internal/bootstrap/workflow_app_definitions_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/workflowwire"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 )
 
 type fakeWorkflowProvider struct {
@@ -162,6 +163,79 @@ func testWorkflowReconcileEnv(t *testing.T) (*config.Config, *workflowRuntime, *
 	provider := &fakeWorkflowProvider{}
 	runtime.PublishProvider("temporal", provider)
 	return cfg, runtime, provider, newAppWorkflowDeclarations()
+}
+
+type principalCapturingProvider struct {
+	*fakeWorkflowProvider
+	getSubject    string
+	getOK         bool
+	applySubject  string
+	applyOK       bool
+	listSubject   string
+	listOK        bool
+	deleteSubject string
+	deleteOK      bool
+}
+
+func (p *principalCapturingProvider) GetDefinition(ctx context.Context, req *proto.GetWorkflowProviderDefinitionRequest) (*proto.WorkflowDefinition, error) {
+	if pp := principal.FromContext(ctx); pp != nil {
+		p.getSubject, p.getOK = pp.SubjectID, true
+	}
+	return p.fakeWorkflowProvider.GetDefinition(ctx, req)
+}
+
+func (p *principalCapturingProvider) ApplyDefinition(ctx context.Context, req *proto.ApplyWorkflowProviderDefinitionRequest) (*proto.WorkflowDefinition, error) {
+	if pp := principal.FromContext(ctx); pp != nil {
+		p.applySubject, p.applyOK = pp.SubjectID, true
+	}
+	return p.fakeWorkflowProvider.ApplyDefinition(ctx, req)
+}
+
+func (p *principalCapturingProvider) ListDefinitions(ctx context.Context, req *proto.ListWorkflowProviderDefinitionsRequest) (*proto.ListWorkflowProviderDefinitionsResponse, error) {
+	if pp := principal.FromContext(ctx); pp != nil {
+		p.listSubject, p.listOK = pp.SubjectID, true
+	}
+	return p.fakeWorkflowProvider.ListDefinitions(ctx, req)
+}
+
+func (p *principalCapturingProvider) DeleteDefinition(ctx context.Context, req *proto.DeleteWorkflowProviderDefinitionRequest) error {
+	if pp := principal.FromContext(ctx); pp != nil {
+		p.deleteSubject, p.deleteOK = pp.SubjectID, true
+	}
+	return p.fakeWorkflowProvider.DeleteDefinition(ctx, req)
+}
+
+func TestReconcileWorkflowConfigDefinitions_AttachesBootstrapPrincipal(t *testing.T) {
+	t.Parallel()
+
+	cfg, runtime, inner, decls := testWorkflowReconcileEnv(t)
+	provider := &principalCapturingProvider{fakeWorkflowProvider: inner}
+	runtime.providers["temporal"] = provider
+
+	if err := reconcileWorkflowConfigDefinitions(context.Background(), cfg, runtime, decls, nil); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	if !provider.getOK || provider.getSubject != workflowConfigOwnerSubjectID() {
+		t.Fatalf("GetDefinition principal = (%q, %v), want (%q, true)", provider.getSubject, provider.getOK, workflowConfigOwnerSubjectID())
+	}
+	if !provider.applyOK || provider.applySubject != workflowConfigOwnerSubjectID() {
+		t.Fatalf("ApplyDefinition principal = (%q, %v), want (%q, true)", provider.applySubject, provider.applyOK, workflowConfigOwnerSubjectID())
+	}
+	if !provider.listOK || provider.listSubject != workflowConfigOwnerSubjectID() {
+		t.Fatalf("ListDefinitions principal = (%q, %v), want (%q, true)", provider.listSubject, provider.listOK, workflowConfigOwnerSubjectID())
+	}
+	// DeleteDefinition runs only when a definition is removed. Remove the app
+	// config-managed backup definition from the config and reconcile again
+	// to trigger cleanup. App-managed definitions are protected from cleanup
+	// when their app stops reporting, so removing an app decl does not delete.
+	delete(cfg.Workflows.Definitions, "backup")
+	if err := reconcileWorkflowConfigDefinitions(context.Background(), cfg, runtime, decls, nil); err != nil {
+		t.Fatalf("reconcile cleanup: %v", err)
+	}
+	if !provider.deleteOK || provider.deleteSubject != workflowConfigOwnerSubjectID() {
+		t.Fatalf("DeleteDefinition principal = (%q, %v), want (%q, true)", provider.deleteSubject, provider.deleteOK, workflowConfigOwnerSubjectID())
+	}
 }
 
 func TestReconcileAppWorkflowDefinitions(t *testing.T) {

--- a/gestaltd/internal/bootstrap/workflow_config_definitions.go
+++ b/gestaltd/internal/bootstrap/workflow_config_definitions.go
@@ -15,6 +15,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/workflowwire"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -34,6 +35,7 @@ func reconcileWorkflowConfigDefinitions(ctx context.Context, cfg *config.Config,
 	if cfg == nil || runtime == nil {
 		return nil
 	}
+	ctx = principal.WithPrincipal(ctx, &principal.Principal{SubjectID: workflowConfigOwnerSubjectID()})
 	cfgDesired, err := desiredWorkflowConfigDefinitions(cfg)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

- PG-4 (#2869) routes all provider calls through the provider gateway, which enforces `authorizeRoutingCall` on every call. That requires a resolved credential subject from the context principal, but workflow config reconciliation runs at bootstrap with no request principal — every `GetDefinition`, `ApplyDefinition`, `ListDefinitions`, and `DeleteDefinition` failed with `provider gateway: caller principal is required`.
- Attach the `system:config` owner identity (the same subject already used for the `ApplyDefinition` request body and in agent bootstrap tests) to the context at the top of `reconcileWorkflowConfigDefinitions`. This covers the main reconcile loop and the cleanup pass, since cleanup receives the same derived context.
- No SDK bump needed in toolshed; the deployed gestaltd just needs to catch up to a pin that contains PG-4 plus this fix.

## Test plan

- [x] `TestReconcileWorkflowConfigDefinitions_AttachesBootstrapPrincipal` — verifies `system:config` principal reaches `GetDefinition`, `ApplyDefinition`, `ListDefinitions`, and `DeleteDefinition` (delete triggered by removing a config-managed definition)
- [x] Existing `workflow_app_definitions_test.go` tests (fake non-gateway provider) still pass
- [x] Full `gestaltd/internal/bootstrap` test suite passes
- [x] `providergateway` tests pass
- [x] `go build ./gestaltd/...` passes