### PR TITLE
Fix gateway authorization to match broker resource/action shape

### DIFF
--- a/gestaltd/services/providergateway/gateway.go
+++ b/gestaltd/services/providergateway/gateway.go
@@ -195,7 +195,7 @@ func authorizeRoutingCall(ctx context.Context, authorization core.AuthorizationP
 	if err != nil {
 		return status.Error(codes.Unauthenticated, "provider gateway: caller principal is required")
 	}
-	allowed, req, checkErr := runAuthorizationCheck(ctx, authorization, subjectID, target.Name, fullMethod)
+	allowed, req, checkErr := runAuthorizationCheck(ctx, authorization, subjectID, target)
 	recordProviderGatewayAuthorizationCheck(ctx, allowed, principal.FromContext(ctx) != nil, req)
 	if checkErr != nil {
 		return status.Errorf(codes.Internal, "provider gateway: authorize: %v", checkErr)
@@ -209,16 +209,17 @@ func authorizeRoutingCall(ctx context.Context, authorization core.AuthorizationP
 func runAuthorizationCheck(
 	ctx context.Context,
 	authorization core.AuthorizationProvider,
-	subjectID, providerID, operation string,
+	subjectID string,
+	target ProviderTarget,
 ) (bool, *proto.CheckAccessRequest, error) {
 	if authorization == nil {
 		return true, nil, nil
 	}
-	resource, err := authorizationResource(providerID, operation)
+	resource, err := authorizationResource(target)
 	if err != nil {
 		return false, nil, err
 	}
-	action, err := authorizationAction(operation)
+	action, err := authorizationAction(target)
 	if err != nil {
 		return false, nil, err
 	}
@@ -235,28 +236,27 @@ func authorizationSubject(ctx context.Context, users principal.CredentialUserRes
 	return subjectID, nil
 }
 
-func authorizationResource(providerID, operation string) (*proto.Resource, error) {
-	providerID = strings.TrimSpace(providerID)
-	if providerID == "" {
-		return nil, fmt.Errorf("provider gateway: provider id is required")
-	}
-	resourceType := "provider"
-	if service, _ := splitFullMethod(operation); service == proto.Workflow_ServiceDesc.ServiceName {
-		resourceType = "workflow"
-	}
+func authorizationResource(target ProviderTarget) (*proto.Resource, error) {
 	return &proto.Resource{
-		Type: resourceType,
-		Id:   providerID,
+		Type: string(target.Kind),
+		Id:   strings.TrimSpace(target.Name),
 	}, nil
 }
 
-func authorizationAction(operation string) (*proto.Action, error) {
-	operation = strings.TrimSpace(operation)
-	if operation == "" {
-		return nil, fmt.Errorf("provider gateway: operation is required")
+func authorizationAction(target ProviderTarget) (*proto.Action, error) {
+	return &proto.Action{Name: strings.TrimSpace(target.Name)}, nil
+}
+
+func providerKindFromFullMethod(fullMethod string) ProviderKind {
+	service, _ := splitFullMethod(fullMethod)
+	switch service {
+	case proto.App_ServiceDesc.ServiceName:
+		return ProviderKindApp
+	case proto.Workflow_ServiceDesc.ServiceName:
+		return ProviderKindWorkflow
+	case proto.Agent_ServiceDesc.ServiceName:
+		return ProviderKindAgent
+	default:
+		return ProviderKind(service)
 	}
-	if service, method := splitFullMethod(operation); service == proto.Workflow_ServiceDesc.ServiceName {
-		return &proto.Action{Name: method}, nil
-	}
-	return &proto.Action{Name: operation}, nil
 }

--- a/gestaltd/services/providergateway/gateway_test.go
+++ b/gestaltd/services/providergateway/gateway_test.go
@@ -617,8 +617,8 @@ func TestRoutingGatewayRecordsMetrics(t *testing.T) {
 		"gd.allowed":               "false",
 		"gd.caller_token_provided": "true",
 		"gd.subject":               "subject/user:alice",
-		"gd.resource":              "provider/parity",
-		"gd.action":                "/test.Service/Echo",
+		"gd.resource":              "test/parity",
+		"gd.action":                "parity",
 		"gd.entry":                 "internal",
 	})
 }

--- a/gestaltd/services/providergateway/public_request.go
+++ b/gestaltd/services/providergateway/public_request.go
@@ -114,7 +114,8 @@ func (t *ProviderGatewayTransport) enforcePublicAuthorization(
 	if err != nil {
 		return status.Error(codes.Unauthenticated, "authenticated subject is required")
 	}
-	allowed, _, err := runAuthorizationCheck(ctx, t.authorization, subjectID, providerID, fullMethod)
+	target := ProviderTarget{Kind: providerKindFromFullMethod(fullMethod), Name: providerID}
+	allowed, _, err := runAuthorizationCheck(ctx, t.authorization, subjectID, target)
 	if err != nil {
 		return status.Errorf(codes.Internal, "provider gateway: authorize: %v", err)
 	}


### PR DESCRIPTION
## Summary

- PG-4 (#2869) introduced `authorizeRoutingCall` on the provider gateway, which checks `CheckAccess` on every provider call. But the resource and action it constructed were incompatible with the production authorization model.
- The gateway used `resource={type: "provider", id: name}` (hardcoded "provider" type) and `action="/gestalt.provider.v1.App/Invoke"` (the gRPC full method), while the broker uses `resource={type: kind, id: name}` (e.g. `type: "app"`) and `action=operationID` or `action=providerName`. Every app call returned 403 "provider gateway: unauthorized" because no grants matched the gateway shape.
- The gateway now uses `string(target.Kind)` as the resource type and `target.Name` as the action, matching the broker `CheckProviderAccess` shape. This is a provider-level access check at the transport layer; the broker still performs the finer-grained operation-level check.

## Test plan

- [x] `TestRoutingGatewayAuthorization` — gateway still calls CheckAccess and enforces allow/deny
- [x] `TestRoutingGatewayRecordsMetrics` — metric attributes updated to new resource/action shape
- [x] Full `providergateway` test suite passes
- [x] Full `server` and `bootstrap` test suites pass
- [x] `golangci-lint` clean
- [x] `go build ./gestaltd/...` passes