### PR TITLE
docs: specify app registry runtime invariants

### DIFF
--- a/plans/app_registry/config.md
+++ b/plans/app_registry/config.md
@@ -139,7 +139,7 @@ apps:
 | `static.mount`, visibility, and theme | Defines the URL, access policy, and theme for the app's UI. These remain unchanged across package upgrades. | Supplies the version-specific HTML, JavaScript, CSS, and other static assets served at that URL. |
 | `source.registry` | Defines the registry from which this app may be installed. | Must come from that registry. Catalog history associated with a different registry is not eligible to run. |
 
-Because no package exists during config loading, validation must not require a resolved provider manifest, operation catalog, or static root for a registry-only app. `server.artifactsDir` is resolved from config defaults and CLI overrides before materialization; registry source validation does not require that the raw YAML contain an explicit path.
+Because no package exists during config loading, validation must not require a resolved provider manifest, operation catalog, or static root for a registry-only app.
 
 `gestalt lock` and `gestalt sync` skip snapshot resolution and artifact download for registry-only apps. Runtime behavior — bootstrap, `add`, and `upgrade` — is documented in [lifecycle.md](./lifecycle.md).
 

--- a/plans/app_registry/config.md
+++ b/plans/app_registry/config.md
@@ -135,7 +135,7 @@ apps:
 
 | Gestalt YAML fields | Gestalt YAML responsibility | Registry package responsibility |
 |---------------------|----------------------------|---------------------------------|
-| `authorizationPolicy`, `indexeddb`, `mcp`, `http`, and `config` | Defines the app's capabilities and integration settings. These remain unchanged across package upgrades. | Runs within the configured capabilities and cannot override these settings. |
+| `authorizationPolicy`, `indexeddb`, `mcp`, `http`, and `config` | Defines the app's capabilities and integration settings. These remain unchanged across package upgrades. | None — controlled entirely by Gestalt YAML. |
 | `static.mount`, visibility, and theme | Defines the URL, access policy, and theme for the app's UI. These remain unchanged across package upgrades. | Supplies the version-specific HTML, JavaScript, CSS, and other static assets served at that URL. |
 | `source.registry` | Defines the registry from which this app may be installed. | Must come from that registry. Catalog history associated with a different registry is not eligible to run. |
 

--- a/plans/app_registry/config.md
+++ b/plans/app_registry/config.md
@@ -133,11 +133,11 @@ apps:
 
 `source.registry` is valid only for entries under `apps`; runtime-provider entries cannot use it. Across upgrades, the app's entry in the Gestalt YAML deploy configuration remains authoritative for how the app integrates with Gestalt. The registry package supplies the version-specific executable and static assets:
 
-| Deploy-time slot field | Registry package responsibility |
-|------------------------|---------------------------------|
-| `authorizationPolicy`, `indexeddb`, `mcp`, `http`, and `config` | The package runs within these configured capabilities; installing a package does not rewrite them. |
-| `static.mount`, visibility, and theme | The mount and policy are fixed at server construction. The selected package supplies the version-specific static bundle. |
-| `source.registry` | Every selected installation must name this same registry. Catalog history from another binding is not eligible to run. |
+| Gestalt YAML fields | Gestalt YAML responsibility | Registry package responsibility |
+|---------------------|----------------------------|---------------------------------|
+| `authorizationPolicy`, `indexeddb`, `mcp`, `http`, and `config` | Defines the app's capabilities and integration settings. These remain unchanged across package upgrades. | Runs within the configured capabilities and cannot override these settings. |
+| `static.mount`, visibility, and theme | Defines the URL, access policy, and theme for the app's UI. These remain unchanged across package upgrades. | Supplies the version-specific HTML, JavaScript, CSS, and other static assets served at that URL. |
+| `source.registry` | Defines the registry from which this app may be installed. | Must come from that registry. Catalog history associated with a different registry is not eligible to run. |
 
 Because no package exists during config loading, validation must not require a resolved provider manifest, operation catalog, or static root for a registry-only app. `server.artifactsDir` is resolved from config defaults and CLI overrides before materialization; registry source validation does not require that the raw YAML contain an explicit path.
 

--- a/plans/app_registry/config.md
+++ b/plans/app_registry/config.md
@@ -131,7 +131,7 @@ apps:
 |-------|---------|
 | `source.registry` | Registry name from `appRegistries`. Must name a configured entry. Mutually exclusive with `source.git`, `source.path`, and other source modes. |
 
-`source.registry` is valid only for entries under `apps`; runtime-provider entries cannot use it. The deploy entry remains the authoritative app-slot contract across upgrades:
+`source.registry` is valid only for entries under `apps`; runtime-provider entries cannot use it. Across upgrades, the app's entry in the Gestalt YAML deploy configuration remains authoritative for how the app integrates with Gestalt. The registry package supplies the version-specific executable and static assets:
 
 | Deploy-time slot field | Registry package responsibility |
 |------------------------|---------------------------------|

--- a/plans/app_registry/config.md
+++ b/plans/app_registry/config.md
@@ -143,6 +143,16 @@ Because no package exists during config loading, validation must not require a r
 
 `gestalt lock` and `gestalt sync` skip snapshot resolution and artifact download for registry-only apps. Runtime behavior — bootstrap, `add`, and `upgrade` — is documented in [lifecycle.md](./lifecycle.md).
 
+### Reconciliation retry limit
+
+```yaml
+server:
+  appRegistry:
+    maxReconcileAttempts: 3
+```
+
+`server.appRegistry.maxReconcileAttempts` is the maximum failed reconciliation attempts for one `(replica, app, desired version)`. It defaults to `3` and must be a positive integer. When the corresponding `app_instance_materializations.attempt_count` reaches this value, that replica stops retrying the desired version. A newly accepted desired version uses a new materialization row and starts with zero failed attempts. Increasing the configured limit allows rows below the new limit to resume retrying.
+
 ### Lockfile
 
 Registry-only apps appear in `gestalt.lock.json` with a registry binding and no baked artifacts:

--- a/plans/app_registry/config.md
+++ b/plans/app_registry/config.md
@@ -131,6 +131,16 @@ apps:
 |-------|---------|
 | `source.registry` | Registry name from `appRegistries`. Must name a configured entry. Mutually exclusive with `source.git`, `source.path`, and other source modes. |
 
+`source.registry` is valid only for entries under `apps`; runtime-provider entries cannot use it. The deploy entry remains the authoritative app-slot contract across upgrades:
+
+| Deploy-time slot field | Registry package responsibility |
+|------------------------|---------------------------------|
+| `authorizationPolicy`, `indexeddb`, `mcp`, `http`, and `config` | The package runs within these configured capabilities; installing a package does not rewrite them. |
+| `static.mount`, visibility, and theme | The mount and policy are fixed at server construction. The selected package supplies the version-specific static bundle. |
+| `source.registry` | Every selected installation must name this same registry. Catalog history from another binding is not eligible to run. |
+
+Because no package exists during config loading, validation must not require a resolved provider manifest, operation catalog, or static root for a registry-only app. `server.artifactsDir` is resolved from config defaults and CLI overrides before materialization; registry source validation does not require that the raw YAML contain an explicit path.
+
 `gestalt lock` and `gestalt sync` skip snapshot resolution and artifact download for registry-only apps. Runtime behavior — bootstrap, `add`, and `upgrade` — is documented in [lifecycle.md](./lifecycle.md).
 
 ### Lockfile

--- a/plans/app_registry/indexeddb.md
+++ b/plans/app_registry/indexeddb.md
@@ -31,9 +31,11 @@ Implementation:
 
 `AppInstallation` in `core/types.go` is the projected shape returned by admin HTTP and install handlers, not a direct IndexedDB row.
 
-There is **no persisted fleet head**, **no promotion**, and **no rollback** in the catalog model. `LatestKnownVersion` selects the greatest request `UpdatedAt`, with the lexicographically greatest version as the deterministic tie-break for equal timestamps. Bootstrap and polling use that same projection; storage iteration order is never version order.
+IndexedDB stores accepted version changes and each replica's rollout progress. It does not store a single "current fleet version" or "currently running version."
 
-Runtime activation is deliberately local and is not a new IndexedDB projection. A replica records which exact materialized version its provider is serving and couples that state to provider start/stop. This local state controls runtime/static availability, while `app_version_change_requests` remains fleet intent and `app_instance_materializations` remains convergence accounting.
+Gestalt derives the desired version from the latest change-request timestamp. If two requests have the same timestamp, it chooses the lexicographically greatest version string so every replica selects the same version. Bootstrap and polling both use this rule instead of relying on storage iteration order.
+
+Each Gestalt process separately tracks the version its provider is currently serving, using in-memory state and a local marker in the artifacts directory. This state is updated with provider start and stop. `app_instance_materializations` is not used for this because it contains historical progress for multiple versions and can become stale after a process exits or crashes.
 
 ---
 

--- a/plans/app_registry/indexeddb.md
+++ b/plans/app_registry/indexeddb.md
@@ -31,7 +31,9 @@ Implementation:
 
 `AppInstallation` in `core/types.go` is the projected shape returned by admin HTTP and install handlers, not a direct IndexedDB row.
 
-There is **no fleet head**, **no promotion**, and **no rollback** in the step 6 catalog model. Activation and rollback are planned for later steps.
+There is **no persisted fleet head**, **no promotion**, and **no rollback** in the catalog model. `LatestKnownVersion` selects the greatest request `UpdatedAt`, with the lexicographically greatest version as the deterministic tie-break for equal timestamps. Bootstrap and polling use that same projection; storage iteration order is never version order.
+
+Runtime activation is deliberately local and is not a new IndexedDB projection. A replica records which exact materialized version its provider is serving and couples that state to provider start/stop. This local state controls runtime/static availability, while `app_version_change_requests` remains fleet intent and `app_instance_materializations` remains convergence accounting.
 
 ---
 
@@ -286,3 +288,5 @@ Primary key: `id` (UUID). Uniqueness for `(instance_id, app, version)` is enforc
 | `MarkRestarted(ctx, instanceID, app, version, restartedAt)` | Record when the app provider restart cycle completed for this fleet version. |
 
 Written by the background catalog poller (`gestaltd/internal/appregistry/poller.go`).
+
+These rows do not gate bootstrap and are not the source of truth for a provider's current local version. A replica may start the latest fleet-known version before it has a materialization row; the poller later records convergence without forcing another restart when that version is already running.

--- a/plans/app_registry/indexeddb.md
+++ b/plans/app_registry/indexeddb.md
@@ -291,4 +291,4 @@ Primary key: `id` (UUID). Uniqueness for `(instance_id, app, version)` is enforc
 
 Written by the background catalog poller (`gestaltd/internal/appregistry/poller.go`).
 
-These rows do not gate bootstrap and are not the source of truth for a provider's current local version. A replica may start the latest fleet-known version before it has a materialization row; the poller later records convergence without forcing another restart when that version is already running.
+`app_instance_materializations` rows are rollout-progress records; they do not decide which version a replica starts during boot. Bootstrap may start the latest fleet-known version without waiting for the poller to create or update one of these rows. When the poller runs later, it checks the version that is actually running. If the replica is already running that latest version, the poller records convergence without stopping and restarting the app again.

--- a/plans/app_registry/indexeddb.md
+++ b/plans/app_registry/indexeddb.md
@@ -33,7 +33,7 @@ Implementation:
 
 IndexedDB stores accepted version changes and each replica's rollout progress. It does not store a single "current fleet version" or "currently running version."
 
-Gestalt derives the desired version from the latest change-request timestamp. If two requests have the same timestamp, it chooses the lexicographically greatest version string so every replica selects the same version. Bootstrap and polling both use this rule instead of relying on storage iteration order.
+Gestalt derives the desired version from the latest change-request timestamp. If two requests have the same timestamp, it chooses the lexicographically greatest version string so every replica selects the same version. Bootstrap and polling both compare the requests using this rule; they do not assume that the first or last record returned by IndexedDB is the newest.
 
 Each Gestalt process separately tracks the version its provider is currently serving, using in-memory state and a local marker in the artifacts directory. This state is updated with provider start and stop. `app_instance_materializations` is not used for this because it contains historical progress for multiple versions and can become stale after a process exits or crashes.
 

--- a/plans/app_registry/indexeddb.md
+++ b/plans/app_registry/indexeddb.md
@@ -269,11 +269,16 @@ Primary key: `id` (UUID). Uniqueness for `(instance_id, app, version)` is enforc
   "acknowledged_at": "2026-07-13T21:00:00Z",
   "materialized_at": "2026-07-13T21:00:02Z",
   "stopped_at": "2026-07-13T21:00:05Z",
-  "restarted_at": "2026-07-13T21:01:05Z"
+  "restarted_at": "2026-07-13T21:01:05Z",
+  "attempt_count": 1,
+  "last_error_at": "2026-07-13T21:00:30Z",
+  "last_error_message": "start provider: executable exited before registration"
 }
 ```
 
 `instance_id` defaults to the process hostname (`os.Hostname()`).
+
+`attempt_count` counts failed reconciliation attempts for this replica, app, and version. `last_error_at` and `last_error_message` retain the most recent failure for diagnosis, including after a later attempt succeeds. They do not determine whether the version is currently running.
 
 ### Service API
 
@@ -288,6 +293,7 @@ Primary key: `id` (UUID). Uniqueness for `(instance_id, app, version)` is enforc
 | `ListByAppVersion(ctx, app, version)` | List the replicas that acknowledged one rollout. |
 | `MarkStopped(ctx, instanceID, app, version, stoppedAt)` | Record when the app provider was stopped for this fleet version. |
 | `MarkRestarted(ctx, instanceID, app, version, restartedAt)` | Record when the app provider restart cycle completed for this fleet version. |
+| `RecordFailure(ctx, instanceID, app, version, failedAt, message)` | Atomically increment `attempt_count` and replace the last-error fields. |
 
 Written by the background catalog poller (`gestaltd/internal/appregistry/poller.go`).
 

--- a/plans/app_registry/indexeddb.md
+++ b/plans/app_registry/indexeddb.md
@@ -35,7 +35,7 @@ IndexedDB stores accepted version changes and each replica's rollout progress. I
 
 Gestalt derives the desired version from the latest change-request timestamp. If two requests have the same timestamp, it chooses the lexicographically greatest version string so every replica selects the same version. Bootstrap and polling both compare the requests using this rule; they do not assume that the first or last record returned by IndexedDB is the newest.
 
-Each Gestalt process separately tracks the version its provider is currently serving, using in-memory state and a local marker in the artifacts directory. This state is updated with provider start and stop. `app_instance_materializations` is not used for this because it contains historical progress for multiple versions and can become stale after a process exits or crashes.
+Each Gestalt process separately tracks the version its provider is currently serving. It uses an in-process running-version map and a local `active-version` marker in the artifacts directory, and updates both with provider start and stop. `app_instance_materializations` is not used for current runtime state because it contains historical rollout progress for multiple versions and can become stale after a process exits or crashes.
 
 ---
 

--- a/plans/app_registry/lifecycle.md
+++ b/plans/app_registry/lifecycle.md
@@ -70,7 +70,7 @@ Bootstrap finishes its registry-app startup attempts before the catalog poller b
 3. After bootstrap has attempted every registry-only app, it marks startup-provider initialization complete. An individual registry app failure does not prevent this transition or block core server startup.
 4. The poller then starts and runs its first reconciliation pass immediately.
 5. If the desired version is already running, the poller sets `restarted_at` on each pending `app_instance_materializations` row without stopping and restarting the app.
-6. A pending `app_instance_materializations` row may contain a historical `stopped_at` even though this process is now running a different version. In that case, the poller trusts the current process state: it stops the running provider before starting the desired version.
+6. To determine whether a provider is currently running and which version it serves, the poller uses this process's provider registry and running-version map. `app_instance_materializations` only says which rollout-progress writes were recorded previously. Therefore, a historical `stopped_at` does not prove that the provider is still absent. If local runtime state shows a version other than the desired version, the poller stops that provider, starts the desired version, and then updates the rollout-progress row.
 7. An empty fleet-known projection leaves the app stopped and clears stale local activation state.
 
 A replica does not acknowledge a rollout while it is bootstrapping. If rollout enrollment closes before that replica starts polling, the replica is not part of the rollout cohort. Its first poll still reads the persisted change request and converges locally without reopening the terminal rollout.

--- a/plans/app_registry/lifecycle.md
+++ b/plans/app_registry/lifecycle.md
@@ -108,7 +108,7 @@ Each pass:
 
 A provider is **restartable** when this replica builds it locally from the configured pin: `server.remote` is unset or the provider has `local: true`, and the provider is not running in dev mode. Remote and dev-mode providers are non-restartable.
 
-`StopApp` holds the per-app lifecycle lease until `StartApp` completes, preventing overlapping builds or replacements. Materialization of the same `(app, version)` is serialized; unrelated app versions may materialize concurrently.
+`StopApp` holds the per-app lifecycle lease until `StartApp` completes, preventing overlapping builds or replacements. On each replica, materialization is serialized per app: two versions of the same app cannot materialize concurrently, but different apps may.
 
 `StartApp(app, version)` is strict for registry-only apps:
 

--- a/plans/app_registry/lifecycle.md
+++ b/plans/app_registry/lifecycle.md
@@ -114,7 +114,7 @@ A provider is **restartable** when this replica builds it locally from the confi
 
 1. The materialized package must exist and pass package validation. Registry-only apps never fall back to an unresolved deploy-time provider entry.
 2. If a provider is already registered and the local running-version map says it is serving the requested version, `StartApp` may return success without rebuilding it. If the recorded version is missing or different, Gestalt must not relabel the existing provider as the requested version; it must stop the existing provider and start the requested version.
-3. Provider build, registration, and activation act as one observable transition. On failure, the provider must not remain registered as the requested version and static/runtime surfaces must not advertise it.
+3. If provider build, registration, or activation fails, Gestalt must clean up any partial state from that start attempt. The provider must not remain registered as the requested version, and static or runtime handlers must not serve it.
 4. Stopping or removing a provider clears its running-version and active-static state, including the already-absent-provider path.
 
 Failure and retry behavior:

--- a/plans/app_registry/lifecycle.md
+++ b/plans/app_registry/lifecycle.md
@@ -65,12 +65,12 @@ Bootstrap and the poller must both use `LatestKnownVersion` to select the same d
 
 Bootstrap finishes its registry-app startup attempts before the catalog poller begins:
 
-1. Bootstrap materializes and starts the desired fleet-known version without writing rollout or materialization progress.
+1. Bootstrap materializes and starts the desired fleet-known version without updating `app_rollouts` or `app_instance_materializations`; the poller owns those rollout-accounting writes.
 2. After the exact package is validated and its provider starts successfully, bootstrap records the app and version in this process's running-version map and local `active-version` marker. Static and runtime handlers may then serve that version. If provider startup fails, neither local state may identify the requested version as running.
 3. After bootstrap has attempted every registry-only app, it marks startup-provider initialization complete. An individual registry app failure does not prevent this transition or block core server startup.
 4. The poller then starts and runs its first reconciliation pass immediately.
-5. If the desired version is already running, the poller records pending progress as converged without stopping and restarting the app.
-6. If progress rows say the app was stopped but a different version is actually running, runtime state wins: the poller stops that provider before starting the desired version.
+5. If the desired version is already running, the poller sets `restarted_at` on each pending `app_instance_materializations` row without stopping and restarting the app.
+6. A pending `app_instance_materializations` row may contain a historical `stopped_at` even though this process is now running a different version. In that case, the poller trusts the current process state: it stops the running provider before starting the desired version.
 7. An empty fleet-known projection leaves the app stopped and clears stale local activation state.
 
 A replica does not acknowledge a rollout while it is bootstrapping. If rollout enrollment closes before that replica starts polling, the replica is not part of the rollout cohort. Its first poll still reads the persisted change request and converges locally without reopening the terminal rollout.

--- a/plans/app_registry/lifecycle.md
+++ b/plans/app_registry/lifecycle.md
@@ -113,7 +113,7 @@ A provider is **restartable** when this replica builds it locally from the confi
 `StartApp(app, version)` is strict for registry-only apps:
 
 1. The materialized package must exist and pass package validation. Registry-only apps never fall back to an unresolved deploy-time provider entry.
-2. If a provider is already registered, idempotent success is allowed only when its recorded running version equals `version`. Empty or different running-version state requires a real stop/start and must not be overwritten optimistically.
+2. If a provider is already registered and the local running-version map says it is serving the requested version, `StartApp` may return success without rebuilding it. If the recorded version is missing or different, Gestalt must not relabel the existing provider as the requested version; it must stop the existing provider and start the requested version.
 3. Provider build, registration, and activation act as one observable transition. On failure, the provider must not remain registered as the requested version and static/runtime surfaces must not advertise it.
 4. Stopping or removing a provider clears its running-version and active-static state, including the already-absent-provider path.
 

--- a/plans/app_registry/lifecycle.md
+++ b/plans/app_registry/lifecycle.md
@@ -126,11 +126,11 @@ A provider is **restartable** when this replica builds it locally from the confi
 
 Failure and retry behavior:
 
-1. If `Close` fails, the provider stays absent because it may be partially closed. Later polls retain the error; shutdown releases the lease.
-2. If writing `stopped_at` fails after stop, the next poll retries the write without stopping the absent provider again.
-3. If writing `restarted_at` fails after start, the next poll retries the write without rebuilding the running provider.
-4. A version discovered while the app is stopped joins the current cycle and inherits its original `stopped_at`.
-5. Replacing the local `active-version` marker preserves the prior valid marker if the replacement cannot be committed. Temporary files and backups may be cleaned only after replacement or restoration succeeds.
+1. Reconciliation operations are idempotent: materializing an already valid package, stopping an absent provider, starting the already-running desired version, and repeating a rollout-progress write must succeed without duplicating work.
+2. When an app reconciliation fails, the poller logs the error, increments an error metric, releases that app's lifecycle lease, and continues reconciling other apps. If stopping had begun, the failed app may remain unavailable until retry.
+3. On the next poll, reconciliation for that app starts again from the beginning and inspects the current provider registry, running-version map, `active-version` marker, and rollout-progress rows rather than relying on in-memory progress from the failed attempt.
+4. Updates to the local `active-version` marker are atomic. A failed replacement leaves the previous valid marker in place.
+5. If Gestalt cannot determine or clean up the local provider state safely, it marks the process unhealthy and terminates so the process supervisor can restart it. Registry, package-download, and IndexedDB failures use the per-app retry behavior instead.
 
 ### Runtime surfaces for registry-only app slots
 

--- a/plans/app_registry/lifecycle.md
+++ b/plans/app_registry/lifecycle.md
@@ -69,9 +69,10 @@ Bootstrap finishes its registry-app startup attempts before the catalog poller b
 2. After the exact package is validated and its provider starts successfully, bootstrap records the app and version in this process's running-version map and local `active-version` marker. Static and runtime handlers may then serve that version. If provider startup fails, neither local state may identify the requested version as running.
 3. After bootstrap has attempted every registry-only app, it marks startup-provider initialization complete. An individual registry app failure does not prevent this transition or block core server startup.
 4. The poller then starts and runs its first reconciliation pass immediately.
-5. If the desired version is already running, the poller sets `restarted_at` on each pending `app_instance_materializations` row without stopping and restarting the app.
-6. To determine whether a provider is currently running and which version it serves, the poller uses this process's provider registry and running-version map. `app_instance_materializations` only says which rollout-progress writes were recorded previously. Therefore, a historical `stopped_at` does not prove that the provider is still absent. If local runtime state shows a version other than the desired version, the poller stops that provider, starts the desired version, and then updates the rollout-progress row.
-7. An empty fleet-known projection leaves the app stopped and clears stale local activation state.
+5. The poller compares the desired version from `app_version_change_requests` with this process's provider registry and running-version map:
+   - **Match** — the desired version is already running, so the poller sets `restarted_at` on each pending `app_instance_materializations` row without restarting the app.
+   - **Missing or different** — if another version is running, the poller stops it; then it starts the desired version and updates the rollout-progress rows. A historical `stopped_at` in `app_instance_materializations` does not prove that the provider is still absent, because those rows record previous rollout writes rather than current process state.
+6. An empty fleet-known projection leaves the app stopped and clears stale local activation state.
 
 A replica does not acknowledge a rollout while it is bootstrapping. If rollout enrollment closes before that replica starts polling, the replica is not part of the rollout cohort. Its first poll still reads the persisted change request and converges locally without reopening the terminal rollout.
 

--- a/plans/app_registry/lifecycle.md
+++ b/plans/app_registry/lifecycle.md
@@ -57,6 +57,13 @@ The lifecycle uses four distinct states. They must not be treated as interchange
 - **Running** — this replica successfully built and registered the provider from that exact materialized package.
 - **Converged** — the poller recorded `restarted_at` for the replica and version. This is rollout accounting, not proof by itself that a provider is currently running.
 
+This document uses these names for local runtime state:
+
+- **Provider registry** — the in-process collection of providers available for operation invocation.
+- **Running-version map** — the in-process `app → version` record for registered registry-app providers.
+- **`active-version` marker** — the local file that selects the materialized static bundle for an app.
+- **Rollout-progress row** — an `app_instance_materializations` record; it describes previously recorded rollout work, not current provider state.
+
 Bootstrap and the poller must both use `LatestKnownVersion` to select the same desired installation. See [indexeddb.md](./indexeddb.md#accepted-changes-and-projections) for the version-ordering rule.
 
 `app_rollouts` and `app_instance_materializations` are not boot inputs. Bootstrap reads only deploy config and the fleet-known version projection. In particular, stale or missing convergence rows must not prevent a known registry app from starting.
@@ -66,13 +73,13 @@ Bootstrap and the poller must both use `LatestKnownVersion` to select the same d
 Bootstrap finishes its registry-app startup attempts before the catalog poller begins:
 
 1. Bootstrap materializes and starts the desired fleet-known version without updating `app_rollouts` or `app_instance_materializations`; the poller owns those rollout-accounting writes.
-2. After the exact package is validated and its provider starts successfully, bootstrap records the app and version in this process's running-version map and local `active-version` marker. Static and runtime handlers may then serve that version. If provider startup fails, neither local state may identify the requested version as running.
+2. After the exact package is validated and its provider starts successfully, bootstrap records the app and version in this process's running-version map and local `active-version` marker. Static and runtime handlers may then serve that version. If provider startup fails, neither the running-version map nor the `active-version` marker may identify the requested version as running.
 3. After bootstrap has attempted every registry-only app, it marks startup-provider initialization complete. An individual registry app failure does not prevent this transition or block core server startup.
 4. The poller then starts and runs its first reconciliation pass immediately.
 5. The poller compares the desired version from `app_version_change_requests` with this process's provider registry and running-version map:
    - **Match** — the desired version is already running, so the poller sets `restarted_at` on each pending `app_instance_materializations` row without restarting the app.
    - **Missing or different** — if another version is running, the poller stops it; then it starts the desired version and updates the rollout-progress rows. A historical `stopped_at` in `app_instance_materializations` does not prove that the provider is still absent, because those rows record previous rollout writes rather than current process state.
-6. An empty fleet-known projection leaves the app stopped and clears stale local activation state.
+6. An empty fleet-known projection leaves the app stopped and clears any stale running-version map entry and `active-version` marker.
 
 A replica does not acknowledge a rollout while it is bootstrapping. If rollout enrollment closes before that replica starts polling, the replica is not part of the rollout cohort. Its first poll still reads the persisted change request and converges locally without reopening the terminal rollout.
 
@@ -103,7 +110,7 @@ Each pass:
 1. Acknowledge each new `(app, version)` in `app_instance_materializations`.
 2. Group pending versions by app.
 3. Download and extract each pending registry artifact to the canonical `{artifactsDir}/registry-installed/{app}/{version}` path, recording `materialized_at` while the provider is still running. Re-validate that path on every pass; if the tree is missing or corrupt, re-download before `StopApp`.
-4. Stop and restart each restartable app once, recording `stopped_at` and `restarted_at` on every pending row. `StartApp` receives the driver fleet version and, when a complete registry install exists on disk, builds the provider from that materialized package instead of the deploy-time pin.
+4. Stop and restart each restartable app once, recording `stopped_at` and `restarted_at` on every pending row. `StartApp` receives the desired version selected by `LatestKnownVersion` and, when a complete registry install exists on disk, builds the provider from that materialized package instead of the deploy-time pin.
 5. Mark non-restartable apps converged without a local stop/start.
 
 A provider is **restartable** when this replica builds it locally from the configured pin: `server.remote` is unset or the provider has `local: true`, and the provider is not running in dev mode. Remote and dev-mode providers are non-restartable.
@@ -115,7 +122,7 @@ A provider is **restartable** when this replica builds it locally from the confi
 1. The materialized package must exist and pass package validation. Registry-only apps never fall back to an unresolved deploy-time provider entry.
 2. If a provider is already registered and the local running-version map says it is serving the requested version, `StartApp` may return success without rebuilding it. If the recorded version is missing or different, Gestalt must not relabel the existing provider as the requested version; it must stop the existing provider and start the requested version.
 3. If provider build, registration, or activation fails, Gestalt must clean up any partial state from that start attempt. The provider must not remain registered as the requested version, and static or runtime handlers must not serve it.
-4. Stopping or removing a provider clears its running-version and active-static state, including the already-absent-provider path.
+4. Stopping or removing a provider clears its running-version map entry and `active-version` marker, including when the provider was already absent.
 
 Failure and retry behavior:
 
@@ -123,17 +130,17 @@ Failure and retry behavior:
 2. If writing `stopped_at` fails after stop, the next poll retries the write without stopping the absent provider again.
 3. If writing `restarted_at` fails after start, the next poll retries the write without rebuilding the running provider.
 4. A version discovered while the app is stopped joins the current cycle and inherits its original `stopped_at`.
-5. Replacing local active-version state preserves the prior valid value if the replacement cannot be committed. Temporary files and backups may be cleaned only after replacement or restoration succeeds.
+5. Replacing the local `active-version` marker preserves the prior valid marker if the replacement cannot be committed. Temporary files and backups may be cleaned only after replacement or restoration succeeds.
 
 ### Runtime surfaces for registry-only app slots
 
 The HTTP server is constructed before registry packages are available. Registry-only app slots therefore must not require a deploy-time resolved manifest, static root, provider catalog, or running provider merely to construct the server.
 
-- **Static UI** — create the configured mount lazily. A request is served only when the app has a running version and the corresponding materialized package resolves a static bundle. The handler must reject a version change observed during resolution rather than mixing frontend and provider generations. Not-yet-running, stopping, or changing versions return **503 Service Unavailable**, not a permanent **404**. Deploy-config theme files are resolved independently of the package and remain available to the mount.
+- **Static UI** — create the configured mount lazily. A request is served only when the provider registry, running-version map, and `active-version` marker agree on the version, and that materialized package resolves a static bundle. The handler must reject a version change observed during resolution rather than mixing frontend and provider generations. Not-yet-running, stopping, or changing versions return **503 Service Unavailable**, not a permanent **404**. Deploy-config theme files are resolved independently of the package and remain available to the mount.
 - **HTTP bindings** — bindings declared in deploy config are mounted before the provider starts and do not require startup-time provider-catalog validation. Invocation may return unavailable until the provider is running. Package-only bindings cannot mutate the already-built HTTP router; registry-only apps that need mounted HTTP routes must declare those bindings in deploy config.
 - **MCP and generic operation invocation** — resolve against the currently registered provider. They become available after successful `StartApp` and unavailable immediately when the provider is removed.
 
-No surface may infer the running version from `app_instance_materializations`. Static serving uses local active/running state tied to provider lifecycle; convergence rows remain accounting records.
+No surface may infer the running version from `app_instance_materializations`. Static serving uses the local provider registry, running-version map, and `active-version` marker; rollout-progress rows remain accounting records.
 
 ## Runtime
 

--- a/plans/app_registry/lifecycle.md
+++ b/plans/app_registry/lifecycle.md
@@ -133,15 +133,17 @@ Failure and retry behavior:
 5. Updates to the local `active-version` marker are atomic. A failed replacement leaves the previous valid marker in place.
 6. If Gestalt cannot determine or clean up the local provider state safely, it marks the process unhealthy and terminates so the process supervisor can restart it.
 
-### Runtime surfaces for registry-only app slots
+### Runtime behavior of configured app surfaces
 
-The HTTP server is constructed before registry packages are available. Registry-only app slots therefore must not require a deploy-time resolved manifest, static root, provider catalog, or running provider merely to construct the server.
+A registry-only app does not have to expose a static UI, HTTP bindings, MCP, or any other particular surface. The following rules apply only to surfaces enabled for that app in the Gestalt YAML deploy configuration.
 
-- **Static UI** — create the configured mount lazily. A request is served only when the provider registry, running-version map, and `active-version` marker agree on the version, and that materialized package resolves a static bundle. The handler must reject a version change observed during resolution rather than mixing frontend and provider generations. Not-yet-running, stopping, or changing versions return **503 Service Unavailable**, not a permanent **404**. Deploy-config theme files are resolved independently of the package and remain available to the mount.
-- **HTTP bindings** — bindings declared in deploy config are mounted before the provider starts and do not require startup-time provider-catalog validation. Invocation may return unavailable until the provider is running. Package-only bindings cannot mutate the already-built HTTP router; registry-only apps that need mounted HTTP routes must declare those bindings in deploy config.
-- **MCP and generic operation invocation** — resolve against the currently registered provider. They become available after successful `StartApp` and unavailable immediately when the provider is removed.
+Gestalt constructs its HTTP server before it downloads or starts a registry package. Server construction must therefore succeed without a package manifest, operation catalog, static root, or running provider.
 
-No surface may infer the running version from `app_instance_materializations`. Static serving uses the local provider registry, running-version map, and `active-version` marker; rollout-progress rows remain accounting records.
+- **Static UI** — Gestalt creates the mount declared in YAML, but returns **503 Service Unavailable** until the provider registry, running-version map, and `active-version` marker agree on one version. It then serves the static bundle from that version's materialized package. If the version changes while a request is being resolved, Gestalt returns **503** rather than combining one version's UI with another version's provider. Theme files declared in YAML are resolved independently of the package.
+- **HTTP bindings** — Gestalt mounts routes declared in YAML when it constructs the server, without requiring the package's operation catalog. Requests may be unavailable until the provider starts. A package cannot add routes to the already-constructed server, so every required HTTP binding must be declared in YAML.
+- **MCP and operation invocation** — these resolve against the provider registry. They become available after `StartApp` registers the provider and unavailable when the provider is removed.
+
+Runtime handlers determine availability from the local provider registry, running-version map, and `active-version` marker. They never use `app_instance_materializations`, whose rows record rollout progress rather than current runtime state.
 
 ## Runtime
 

--- a/plans/app_registry/lifecycle.md
+++ b/plans/app_registry/lifecycle.md
@@ -66,7 +66,7 @@ Bootstrap and the poller must both use `LatestKnownVersion` to select the same d
 Bootstrap finishes its registry-app startup attempts before the catalog poller begins:
 
 1. Bootstrap materializes and starts the desired fleet-known version without writing rollout or materialization progress.
-2. A successful start publishes local running-version state only after the exact package has been validated and the provider is ready. A failed start must not advertise that version.
+2. After the exact package is validated and its provider starts successfully, bootstrap records the app and version in this process's running-version map and local `active-version` marker. Static and runtime handlers may then serve that version. If provider startup fails, neither local state may identify the requested version as running.
 3. After bootstrap has attempted every registry-only app, it marks startup-provider initialization complete. An individual registry app failure does not prevent this transition or block core server startup.
 4. The poller then starts and runs its first reconciliation pass immediately.
 5. If the desired version is already running, the poller records pending progress as converged without stopping and restarting the app.

--- a/plans/app_registry/lifecycle.md
+++ b/plans/app_registry/lifecycle.md
@@ -127,10 +127,11 @@ A provider is **restartable** when this replica builds it locally from the confi
 Failure and retry behavior:
 
 1. Reconciliation operations are idempotent: materializing an already valid package, stopping an absent provider, starting the already-running desired version, and repeating a rollout-progress write must succeed without duplicating work.
-2. When an app reconciliation fails, the poller logs the error, increments an error metric, releases that app's lifecycle lease, and continues reconciling other apps. If stopping had begun, the failed app may remain unavailable until retry.
-3. On the next poll, reconciliation for that app starts again from the beginning and inspects the current provider registry, running-version map, `active-version` marker, and rollout-progress rows rather than relying on in-memory progress from the failed attempt.
-4. Updates to the local `active-version` marker are atomic. A failed replacement leaves the previous valid marker in place.
-5. If Gestalt cannot determine or clean up the local provider state safely, it marks the process unhealthy and terminates so the process supervisor can restart it. Registry, package-download, and IndexedDB failures use the per-app retry behavior instead.
+2. When an app reconciliation fails, the poller calls `RecordFailure` on the desired version's `app_instance_materializations` row. This atomically increments `attempt_count` and stores `last_error_at` and `last_error_message`. The poller then releases that app's lifecycle lease and continues reconciling other apps. If the failure itself cannot be written to IndexedDB, the poller logs that write error.
+3. While `attempt_count` is below `server.appRegistry.maxReconcileAttempts`, the next poll retries that app from the beginning. It inspects the current provider registry, running-version map, `active-version` marker, and rollout-progress rows rather than relying on in-memory progress from the failed attempt. If stopping had begun, the app may remain unavailable until retry succeeds.
+4. When `attempt_count` reaches the configured maximum, the poller stops retrying that desired version on this replica. A newly accepted desired version gets a new row and a fresh attempt count. Increasing the configured maximum also permits retry when the stored count is below the new value.
+5. Updates to the local `active-version` marker are atomic. A failed replacement leaves the previous valid marker in place.
+6. If Gestalt cannot determine or clean up the local provider state safely, it marks the process unhealthy and terminates so the process supervisor can restart it.
 
 ### Runtime surfaces for registry-only app slots
 

--- a/plans/app_registry/lifecycle.md
+++ b/plans/app_registry/lifecycle.md
@@ -75,7 +75,7 @@ Bootstrap finishes its registry-app startup attempts before the catalog poller b
 
 A replica does not acknowledge a rollout while it is bootstrapping. If rollout enrollment closes before that replica starts polling, the replica is not part of the rollout cohort. Its first poll still reads the persisted change request and converges locally without reopening the terminal rollout.
 
-The selected installation's registry must match deploy `source.registry` before materialization or start. A registry rename does not authorize an old catalog entry from the previous binding. Binding mismatch leaves the app unavailable and clears stale activation state; it does not fall back to a deploy-time source.
+The selected installation's registry must match deploy `source.registry` before materialization or start.
 
 ## Polling
 

--- a/plans/app_registry/lifecycle.md
+++ b/plans/app_registry/lifecycle.md
@@ -48,6 +48,32 @@ At `StartAppProviders`, each registry-only app:
 
 The catalog poller still handles first install and upgrades on replicas that were skipped at boot or join after a rollout.
 
+### Runtime version invariants
+
+The lifecycle uses four distinct states. They must not be treated as interchangeable:
+
+- **Fleet-known** — an accepted `(app, version)` projected from `app_version_change_requests`.
+- **Materialized** — a complete, validated package exists at `{artifactsDir}/registry-installed/{app}/{version}` on this replica.
+- **Running** — this replica successfully built and registered the provider from that exact materialized package.
+- **Converged** — the poller recorded `restarted_at` for the replica and version. This is rollout accounting, not proof by itself that a provider is currently running.
+
+Both bootstrap and the poller select the same **driver installation**: the fleet-known installation with the greatest `UpdatedAt`. Equal timestamps are broken deterministically by version string, choosing the lexicographically greatest version. The tie-break is for deterministic ordering only; it is not semantic-version comparison. Neither path may select a driver from slice or map iteration order.
+
+`app_rollouts` and `app_instance_materializations` are not boot inputs. Bootstrap reads only deploy config and the fleet-known version projection. In particular, stale or missing convergence rows must not prevent a known registry app from starting.
+
+### Bootstrap-to-poller handoff
+
+Bootstrap and polling may observe the same fleet-known versions, so their handoff is explicit:
+
+1. Bootstrap materializes and starts the selected driver without writing rollout or materialization convergence.
+2. A successful start publishes local running-version state only after the exact package has been validated and the provider is ready. A failed start must not advertise that version.
+3. The poller may acknowledge and materialize while startup is in progress, but it must not replace a startup provider until startup-provider readiness is closed.
+4. If the poller observes that the selected driver is already running, it records all pending rows as restarted without an avoidable stop/start.
+5. If persisted rows say the app was stopped but a different version is actually running, runtime state wins: the poller stops that provider before starting the driver.
+6. An empty fleet-known projection leaves the app stopped and clears stale local activation state.
+
+The selected installation's registry must match deploy `source.registry` before materialization or start. A registry rename does not authorize an old catalog entry from the previous binding. Binding mismatch leaves the app unavailable and clears stale activation state; it does not fall back to a deploy-time source.
+
 ## Polling
 
 Every replica starts one background catalog controller during `gestaltd serve` startup: one reconcile pass immediately, then every **1 minute** on a single loop goroutine.
@@ -78,7 +104,14 @@ Each pass:
 
 A provider is **restartable** when this replica builds it locally from the configured pin: `server.remote` is unset or the provider has `local: true`, and the provider is not running in dev mode. Remote and dev-mode providers are non-restartable.
 
-App bootstrapping when `gestaltd` starts and catalog-driven restarts share the same per-app lifecycle lease. `StopApp` holds the lease until `StartApp` completes, preventing concurrent builds or replacements.
+App bootstrapping when `gestaltd` starts and catalog-driven restarts share the same per-app lifecycle lease. `StopApp` holds the lease until `StartApp` completes, preventing concurrent builds or replacements. Materialization of the same `(app, version)` is also serialized so bootstrap and polling cannot write the same destination concurrently; unrelated app versions may materialize concurrently.
+
+`StartApp(app, version)` is strict for registry-only apps:
+
+1. The materialized package must exist and pass package validation. Registry-only apps never fall back to an unresolved deploy-time provider entry.
+2. If a provider is already registered, idempotent success is allowed only when its recorded running version equals `version`. Empty or different running-version state requires a real stop/start and must not be overwritten optimistically.
+3. Provider build, registration, and activation act as one observable transition. On failure, the provider must not remain registered as the requested version and static/runtime surfaces must not advertise it.
+4. Stopping or removing a provider clears its running-version and active-static state, including the already-absent-provider path.
 
 Failure and retry behavior:
 
@@ -86,6 +119,17 @@ Failure and retry behavior:
 2. If writing `stopped_at` fails after stop, the next poll retries the write without stopping the absent provider again.
 3. If writing `restarted_at` fails after start, the next poll retries the write without rebuilding the running provider.
 4. A version discovered while the app is stopped joins the current cycle and inherits its original `stopped_at`.
+5. Replacing local active-version state preserves the prior valid value if the replacement cannot be committed. Temporary files and backups may be cleaned only after replacement or restoration succeeds.
+
+### Runtime surfaces for registry-only app slots
+
+The HTTP server is constructed before registry packages are available. Registry-only app slots therefore must not require a deploy-time resolved manifest, static root, provider catalog, or running provider merely to construct the server.
+
+- **Static UI** — create the configured mount lazily. A request is served only when the app has a running version and the corresponding materialized package resolves a static bundle. The handler must reject a version change observed during resolution rather than mixing frontend and provider generations. Not-yet-running, stopping, or changing versions return **503 Service Unavailable**, not a permanent **404**. Deploy-config theme files are resolved independently of the package and remain available to the mount.
+- **HTTP bindings** — bindings declared in deploy config are mounted before the provider starts and do not require startup-time provider-catalog validation. Invocation may return unavailable until the provider is running. Package-only bindings cannot mutate the already-built HTTP router; registry-only apps that need mounted HTTP routes must declare those bindings in deploy config.
+- **MCP and generic operation invocation** — resolve against the currently registered provider. They become available after successful `StartApp` and unavailable immediately when the provider is removed.
+
+No surface may infer the running version from `app_instance_materializations`. Static serving uses local active/running state tied to provider lifecycle; convergence rows remain accounting records.
 
 ## Runtime
 

--- a/plans/app_registry/lifecycle.md
+++ b/plans/app_registry/lifecycle.md
@@ -57,7 +57,7 @@ The lifecycle uses four distinct states. They must not be treated as interchange
 - **Running** — this replica successfully built and registered the provider from that exact materialized package.
 - **Converged** — the poller recorded `restarted_at` for the replica and version. This is rollout accounting, not proof by itself that a provider is currently running.
 
-Both bootstrap and the poller select the same **driver installation**: the fleet-known installation with the greatest `UpdatedAt`. Equal timestamps are broken deterministically by version string, choosing the lexicographically greatest version. The tie-break is for deterministic ordering only; it is not semantic-version comparison. Neither path may select a driver from slice or map iteration order.
+Bootstrap and the poller must both use `LatestKnownVersion` to select the same desired installation. See [indexeddb.md](./indexeddb.md#accepted-changes-and-projections) for the version-ordering rule.
 
 `app_rollouts` and `app_instance_materializations` are not boot inputs. Bootstrap reads only deploy config and the fleet-known version projection. In particular, stale or missing convergence rows must not prevent a known registry app from starting.
 

--- a/plans/app_registry/lifecycle.md
+++ b/plans/app_registry/lifecycle.md
@@ -61,22 +61,25 @@ Bootstrap and the poller must both use `LatestKnownVersion` to select the same d
 
 `app_rollouts` and `app_instance_materializations` are not boot inputs. Bootstrap reads only deploy config and the fleet-known version projection. In particular, stale or missing convergence rows must not prevent a known registry app from starting.
 
-### Bootstrap-to-poller handoff
+### Bootstrap before polling
 
-Bootstrap and polling may observe the same fleet-known versions, so their handoff is explicit:
+Bootstrap finishes its registry-app startup attempts before the catalog poller begins:
 
-1. Bootstrap materializes and starts the selected driver without writing rollout or materialization convergence.
+1. Bootstrap materializes and starts the desired fleet-known version without writing rollout or materialization progress.
 2. A successful start publishes local running-version state only after the exact package has been validated and the provider is ready. A failed start must not advertise that version.
-3. The poller may acknowledge and materialize while startup is in progress, but it must not replace a startup provider until startup-provider readiness is closed.
-4. If the poller observes that the selected driver is already running, it records all pending rows as restarted without an avoidable stop/start.
-5. If persisted rows say the app was stopped but a different version is actually running, runtime state wins: the poller stops that provider before starting the driver.
-6. An empty fleet-known projection leaves the app stopped and clears stale local activation state.
+3. After bootstrap has attempted every registry-only app, it marks startup-provider initialization complete. An individual registry app failure does not prevent this transition or block core server startup.
+4. The poller then starts and runs its first reconciliation pass immediately.
+5. If the desired version is already running, the poller records pending progress as converged without stopping and restarting the app.
+6. If progress rows say the app was stopped but a different version is actually running, runtime state wins: the poller stops that provider before starting the desired version.
+7. An empty fleet-known projection leaves the app stopped and clears stale local activation state.
+
+A replica does not acknowledge a rollout while it is bootstrapping. If rollout enrollment closes before that replica starts polling, the replica is not part of the rollout cohort. Its first poll still reads the persisted change request and converges locally without reopening the terminal rollout.
 
 The selected installation's registry must match deploy `source.registry` before materialization or start. A registry rename does not authorize an old catalog entry from the previous binding. Binding mismatch leaves the app unavailable and clears stale activation state; it does not fall back to a deploy-time source.
 
 ## Polling
 
-Every replica starts one background catalog controller during `gestaltd serve` startup: one reconcile pass immediately, then every **1 minute** on a single loop goroutine.
+After startup-provider initialization completes, every replica starts one background catalog controller: one reconcile pass immediately, then every **1 minute** on a single loop goroutine.
 
 The controller is **pull-based** and **local**: each replica reads `app_version_change_requests` (`ListAllKnownVersions`) and reconciles itself against fleet install state. No replica fans out install RPCs to peers.
 
@@ -104,7 +107,7 @@ Each pass:
 
 A provider is **restartable** when this replica builds it locally from the configured pin: `server.remote` is unset or the provider has `local: true`, and the provider is not running in dev mode. Remote and dev-mode providers are non-restartable.
 
-App bootstrapping when `gestaltd` starts and catalog-driven restarts share the same per-app lifecycle lease. `StopApp` holds the lease until `StartApp` completes, preventing concurrent builds or replacements. Materialization of the same `(app, version)` is also serialized so bootstrap and polling cannot write the same destination concurrently; unrelated app versions may materialize concurrently.
+`StopApp` holds the per-app lifecycle lease until `StartApp` completes, preventing overlapping builds or replacements. Materialization of the same `(app, version)` is serialized; unrelated app versions may materialize concurrently.
 
 `StartApp(app, version)` is strict for registry-only apps:
 

--- a/plans/app_registry/tests.md
+++ b/plans/app_registry/tests.md
@@ -244,6 +244,7 @@ go test ./internal/server/... -run 'RegistryApp|RegistryOnly' -count=1
 - Rejects `source.registry` combined with `source.git`, `source.path`, or other source modes.
 - Rejects `source.registry` outside the `apps` map.
 - Allows configured static and HTTP surfaces without a deploy-time resolved manifest, operation catalog, or static root.
+- Defaults `server.appRegistry.maxReconcileAttempts` to `3`, accepts positive overrides, and rejects zero or negative values.
 
 ### Add and upgrade
 
@@ -271,9 +272,12 @@ go test ./internal/server/... -run 'RegistryApp|RegistryOnly' -count=1
 - Build, registration, activation, and stop failures leave the provider registry, running-version map, and `active-version` marker consistent.
 - A stale stopped row cannot cause the poller to overwrite a different running provider without stopping it.
 - A version already started by bootstrap is marked converged by the poller without an extra restart.
-- A failed app reconciliation logs an error, increments a metric, releases its lifecycle lease, and does not prevent other apps from reconciling.
+- A failed app reconciliation atomically increments `attempt_count`, replaces `last_error_at` and `last_error_message`, releases its lifecycle lease, and does not prevent other apps from reconciling.
 - The next poll retries the failed app from the beginning; repeated materialize, stop, start-same-version, and rollout-progress operations are idempotent.
-- Unrecoverable local provider state marks Gestalt unhealthy and terminates the process, while registry, download, and IndexedDB failures remain per-app retries.
+- Stops retrying one desired version when its `attempt_count` reaches `server.appRegistry.maxReconcileAttempts`, which defaults to `3`.
+- A new desired-version row starts with zero attempts; increasing the configured limit resumes rows whose count is below the new limit.
+- Logs the error when `RecordFailure` itself cannot write to IndexedDB.
+- Unrecoverable local provider state marks Gestalt unhealthy and terminates the process.
 
 ### Runtime surfaces
 

--- a/plans/app_registry/tests.md
+++ b/plans/app_registry/tests.md
@@ -265,7 +265,7 @@ go test ./internal/server/... -run 'RegistryApp|RegistryOnly' -count=1
 
 ### Provider lifecycle and concurrency
 
-- Serializes materialization of the same `(app, version)` while allowing unrelated versions to materialize concurrently.
+- Serializes materialization per app on each replica, including different versions of the same app, while allowing different apps to materialize concurrently.
 - Starting an already-running exact version is idempotent; starting over a different or unknown recorded version does not relabel the existing provider.
 - A registry-only start requires the exact validated package and never falls back to a deploy-time provider build.
 - Build, registration, activation, and stop failures leave provider visibility, running-version state, and active-static state consistent.

--- a/plans/app_registry/tests.md
+++ b/plans/app_registry/tests.md
@@ -140,7 +140,7 @@ go test ./internal/bootstrap -run TestAppProviderRestarterStartApp -count=1
 
 ### `poller_materialize_test.go`
 
-- **`TestCatalogPollerStartAppPassesDriverVersion`** — the catalog poller passes the driver fleet version through to `StartApp`.
+- **`TestCatalogPollerStartAppPassesDriverVersion`** — the catalog poller passes the desired version selected by `LatestKnownVersion` to `StartApp`.
 
 ---
 
@@ -255,7 +255,7 @@ go test ./internal/server/... -run 'RegistryApp|RegistryOnly' -count=1
 
 - Starts the deterministic latest fleet-known version at `StartAppProviders`.
 - Uses the same latest-version ordering as the poller, including equal-timestamp tie-breaking.
-- Skips the app and clears stale local activation when the projection is empty.
+- Skips the app and clears any stale running-version map entry and `active-version` marker when the projection is empty.
 - Rejects a projected installation whose registry differs from deploy `source.registry`; it does not fall back to another source.
 - Does not gate startup on rollout or per-replica materialization rows.
 - Keeps core boot available when an individual registry app cannot materialize or start.
@@ -268,7 +268,7 @@ go test ./internal/server/... -run 'RegistryApp|RegistryOnly' -count=1
 - Serializes materialization per app on each replica, including different versions of the same app, while allowing different apps to materialize concurrently.
 - Starting an already-running exact version is idempotent; starting over a different or unknown recorded version does not relabel the existing provider.
 - A registry-only start requires the exact validated package and never falls back to a deploy-time provider build.
-- Build, registration, activation, and stop failures leave provider visibility, running-version state, and active-static state consistent.
+- Build, registration, activation, and stop failures leave the provider registry, running-version map, and `active-version` marker consistent.
 - A stale stopped row cannot cause the poller to overwrite a different running provider without stopping it.
 - A version already started by bootstrap is marked converged by the poller without an extra restart.
 
@@ -279,7 +279,7 @@ go test ./internal/server/... -run 'RegistryApp|RegistryOnly' -count=1
 - A concurrent version change cannot combine a static bundle from one version with a provider from another.
 - Static request handling does not block on a long-running provider lifecycle operation.
 - Deploy-config HTTP bindings mount without startup-time provider catalog lookup and become invocable after the provider starts.
-- Stopping or removing the provider immediately makes static, MCP, and operation surfaces unavailable and removes stale active state.
+- Stopping or removing the provider immediately makes static, MCP, and operation surfaces unavailable and clears its running-version map entry and `active-version` marker.
 
 ### Lock and sync
 

--- a/plans/app_registry/tests.md
+++ b/plans/app_registry/tests.md
@@ -259,10 +259,13 @@ go test ./internal/server/... -run 'RegistryApp|RegistryOnly' -count=1
 - Rejects a projected installation whose registry differs from deploy `source.registry`; it does not fall back to another source.
 - Does not gate startup on rollout or per-replica materialization rows.
 - Keeps core boot available when an individual registry app cannot materialize or start.
+- Does not start the catalog poller until all startup-provider initialization attempts finish.
+- Starts the poller's first reconciliation pass immediately after startup-provider initialization.
+- Allows a replica that missed rollout enrollment during bootstrap to converge locally without reopening the rollout.
 
 ### Provider lifecycle and concurrency
 
-- Bootstrap and polling serialize materialization of the same `(app, version)` while allowing unrelated versions to materialize concurrently.
+- Serializes materialization of the same `(app, version)` while allowing unrelated versions to materialize concurrently.
 - Starting an already-running exact version is idempotent; starting over a different or unknown recorded version does not relabel the existing provider.
 - A registry-only start requires the exact validated package and never falls back to a deploy-time provider build.
 - Build, registration, activation, and stop failures leave provider visibility, running-version state, and active-static state consistent.

--- a/plans/app_registry/tests.md
+++ b/plans/app_registry/tests.md
@@ -229,11 +229,11 @@ Run:
 
 ```bash
 cd gestaltd
-go test ./internal/config/... -run RegistryOnly -count=1
+go test ./internal/config/... -run 'RegistryOnly|AppRegistry' -count=1
 go test ./internal/operator/... -run RegistryOnly -count=1
-go test ./internal/appregistry/... -run 'TestInstaller.*RegistryOnly|TestInstallerAdd|TestInstallerUpgrade' -count=1
+go test ./internal/appregistry/... -run 'TestInstaller.*RegistryOnly|TestInstallerAdd|TestInstallerUpgrade|TestCatalogPoller|TestMaterializer' -count=1
 go test ./internal/bootstrap/... -run RegistryOnly -count=1
-go test ./internal/coredata/... -run LatestKnown -count=1
+go test ./internal/coredata/... -run 'LatestKnown|AppInstanceMaterialization' -count=1
 go test ./internal/server/... -run 'RegistryApp|RegistryOnly' -count=1
 ```
 
@@ -269,18 +269,20 @@ go test ./internal/server/... -run 'RegistryApp|RegistryOnly' -count=1
 - Serializes materialization per app on each replica, including different versions of the same app, while allowing different apps to materialize concurrently.
 - Starting an already-running exact version is idempotent; starting over a different or unknown recorded version does not relabel the existing provider.
 - A registry-only start requires the exact validated package and never falls back to a deploy-time provider build.
-- Build, registration, activation, and stop failures leave the provider registry, running-version map, and `active-version` marker consistent.
+- Failures while building or registering a provider, updating its running-version map entry or `active-version` marker, or stopping it leave those three local runtime records consistent.
 - A stale stopped row cannot cause the poller to overwrite a different running provider without stopping it.
 - A version already started by bootstrap is marked converged by the poller without an extra restart.
 - A failed app reconciliation atomically increments `attempt_count`, replaces `last_error_at` and `last_error_message`, releases its lifecycle lease, and does not prevent other apps from reconciling.
 - The next poll retries the failed app from the beginning; repeated materialize, stop, start-same-version, and rollout-progress operations are idempotent.
 - Stops retrying one desired version when its `attempt_count` reaches `server.appRegistry.maxReconcileAttempts`, which defaults to `3`.
 - A new desired-version row starts with zero attempts; increasing the configured limit resumes rows whose count is below the new limit.
+- Successful convergence retains the row's previous `attempt_count`, `last_error_at`, and `last_error_message` for diagnosis.
 - Logs the error when `RecordFailure` itself cannot write to IndexedDB.
 - Unrecoverable local provider state marks Gestalt unhealthy and terminates the process.
 
 ### Runtime surfaces
 
+- Accepts a registry-only app with none of the optional static UI, HTTP, or MCP surfaces configured.
 - Server construction accepts a registry app with configured static and HTTP mounts before any package or provider exists.
 - Static requests return **503** while the provider is absent or changing, then serve the bundle for the exact running version.
 - A concurrent version change cannot combine a static bundle from one version with a provider from another.

--- a/plans/app_registry/tests.md
+++ b/plans/app_registry/tests.md
@@ -271,6 +271,9 @@ go test ./internal/server/... -run 'RegistryApp|RegistryOnly' -count=1
 - Build, registration, activation, and stop failures leave the provider registry, running-version map, and `active-version` marker consistent.
 - A stale stopped row cannot cause the poller to overwrite a different running provider without stopping it.
 - A version already started by bootstrap is marked converged by the poller without an extra restart.
+- A failed app reconciliation logs an error, increments a metric, releases its lifecycle lease, and does not prevent other apps from reconciling.
+- The next poll retries the failed app from the beginning; repeated materialize, stop, start-same-version, and rollout-progress operations are idempotent.
+- Unrecoverable local provider state marks Gestalt unhealthy and terminates the process, while registry, download, and IndexedDB failures remain per-app retries.
 
 ### Runtime surfaces
 

--- a/plans/app_registry/tests.md
+++ b/plans/app_registry/tests.md
@@ -233,6 +233,8 @@ go test ./internal/config/... -run RegistryOnly -count=1
 go test ./internal/operator/... -run RegistryOnly -count=1
 go test ./internal/appregistry/... -run 'TestInstaller.*RegistryOnly|TestInstallerAdd|TestInstallerUpgrade' -count=1
 go test ./internal/bootstrap/... -run RegistryOnly -count=1
+go test ./internal/coredata/... -run LatestKnown -count=1
+go test ./internal/server/... -run 'RegistryApp|RegistryOnly' -count=1
 ```
 
 ### Config validation
@@ -240,6 +242,8 @@ go test ./internal/bootstrap/... -run RegistryOnly -count=1
 - Accepts `source.registry` when the name matches a configured `appRegistries` entry.
 - Rejects an unknown registry name.
 - Rejects `source.registry` combined with `source.git`, `source.path`, or other source modes.
+- Rejects `source.registry` outside the `apps` map.
+- Allows configured static and HTTP surfaces without a deploy-time resolved manifest, operation catalog, or static root.
 
 ### Add and upgrade
 
@@ -249,8 +253,30 @@ go test ./internal/bootstrap/... -run RegistryOnly -count=1
 
 ### Bootstrap startup
 
-- Starts a registry-only app at `StartAppProviders` when `ListKnownVersionsByApp` returns a fleet-known version.
-- Skips the app when the projection is empty.
+- Starts the deterministic latest fleet-known version at `StartAppProviders`.
+- Uses the same latest-version ordering as the poller, including equal-timestamp tie-breaking.
+- Skips the app and clears stale local activation when the projection is empty.
+- Rejects a projected installation whose registry differs from deploy `source.registry`; it does not fall back to another source.
+- Does not gate startup on rollout or per-replica materialization rows.
+- Keeps core boot available when an individual registry app cannot materialize or start.
+
+### Provider lifecycle and concurrency
+
+- Bootstrap and polling serialize materialization of the same `(app, version)` while allowing unrelated versions to materialize concurrently.
+- Starting an already-running exact version is idempotent; starting over a different or unknown recorded version does not relabel the existing provider.
+- A registry-only start requires the exact validated package and never falls back to a deploy-time provider build.
+- Build, registration, activation, and stop failures leave provider visibility, running-version state, and active-static state consistent.
+- A stale stopped row cannot cause the poller to overwrite a different running provider without stopping it.
+- A version already started by bootstrap is marked converged by the poller without an extra restart.
+
+### Runtime surfaces
+
+- Server construction accepts a registry app with configured static and HTTP mounts before any package or provider exists.
+- Static requests return **503** while the provider is absent or changing, then serve the bundle for the exact running version.
+- A concurrent version change cannot combine a static bundle from one version with a provider from another.
+- Static request handling does not block on a long-running provider lifecycle operation.
+- Deploy-config HTTP bindings mount without startup-time provider catalog lookup and become invocable after the provider starts.
+- Stopping or removing the provider immediately makes static, MCP, and operation surfaces unavailable and removes stale active state.
 
 ### Lock and sync
 

--- a/plans/app_registry/tests.md
+++ b/plans/app_registry/tests.md
@@ -239,61 +239,37 @@ go test ./internal/server/... -run 'RegistryApp|RegistryOnly' -count=1
 
 ### Config validation
 
-- Accepts `source.registry` when the name matches a configured `appRegistries` entry.
-- Rejects an unknown registry name.
-- Rejects `source.registry` combined with `source.git`, `source.path`, or other source modes.
-- Rejects `source.registry` outside the `apps` map.
-- Allows configured static and HTTP surfaces without a deploy-time resolved manifest, operation catalog, or static root.
+- Accepts a registry-only app without package-derived metadata; rejects an unknown registry, use outside `apps`, or combination with another source mode.
 - Defaults `server.appRegistry.maxReconcileAttempts` to `3`, accepts positive overrides, and rejects zero or negative values.
 
 ### Add and upgrade
 
-- **`add`** — accepts the first fleet-known version when `ListKnownVersionsByApp` is empty; returns **409** when the app is already in the catalog.
-- **`upgrade`** — accepts a new version when the app has fleet-known versions; sets `from_version` to `LatestKnownVersion`; returns **400** when the catalog is empty.
-- **`add`** records `from_version: "registry:first-install"` server-side (audit only; not a runnable version). See [lifecycle.md](./lifecycle.md#post-adminapiv1app-registriesregistryappsappadd).
+- **`add`** accepts only an empty catalog, records server-written `from_version: "registry:first-install"`, and returns **409** when a version is already known.
+- **`upgrade`** requires a non-empty catalog, sets `from_version` to `LatestKnownVersion`, and returns **400** when the catalog is empty.
 
 ### Bootstrap startup
 
-- Starts the deterministic latest fleet-known version at `StartAppProviders`.
-- Uses the same latest-version ordering as the poller, including equal-timestamp tie-breaking.
-- Skips the app and clears any stale running-version map entry and `active-version` marker when the projection is empty.
-- Rejects a projected installation whose registry differs from deploy `source.registry`; it does not fall back to another source.
-- Does not gate startup on rollout or per-replica materialization rows.
-- Keeps core boot available when an individual registry app cannot materialize or start.
-- Does not start the catalog poller until all startup-provider initialization attempts finish.
-- Starts the poller's first reconciliation pass immediately after startup-provider initialization.
-- Allows a replica that missed rollout enrollment during bootstrap to converge locally without reopening the rollout.
+- Starts the same deterministic latest version as the poller only when its registry matches `source.registry`; an empty projection leaves the app stopped and clears any stale running-version map entry and `active-version` marker.
+- Attempts every registry app without consulting rollout-progress rows, keeps core boot available after an individual failure, and starts the poller only after all startup attempts finish.
+- A replica that misses rollout enrollment during bootstrap converges on its first poll without reopening the terminal rollout.
 
 ### Provider lifecycle and concurrency
 
-- Serializes materialization per app on each replica, including different versions of the same app, while allowing different apps to materialize concurrently.
-- Starting an already-running exact version is idempotent; starting over a different or unknown recorded version does not relabel the existing provider.
-- A registry-only start requires the exact validated package and never falls back to a deploy-time provider build.
-- Failures while building or registering a provider, updating its running-version map entry or `active-version` marker, or stopping it leave those three local runtime records consistent.
-- A stale stopped row cannot cause the poller to overwrite a different running provider without stopping it.
-- A version already started by bootstrap is marked converged by the poller without an extra restart.
-- A failed app reconciliation atomically increments `attempt_count`, replaces `last_error_at` and `last_error_message`, releases its lifecycle lease, and does not prevent other apps from reconciling.
-- The next poll retries the failed app from the beginning; repeated materialize, stop, start-same-version, and rollout-progress operations are idempotent.
-- Stops retrying one desired version when its `attempt_count` reaches `server.appRegistry.maxReconcileAttempts`, which defaults to `3`.
-- A new desired-version row starts with zero attempts; increasing the configured limit resumes rows whose count is below the new limit.
-- Successful convergence retains the row's previous `attempt_count`, `last_error_at`, and `last_error_message` for diagnosis.
-- Logs the error when `RecordFailure` itself cannot write to IndexedDB.
+- Serializes materialization per app on each replica while allowing different apps to materialize concurrently.
+- Starting the already-running desired version is idempotent. A different or unknown version is stopped and replaced; any failed start cleans up the provider registry, running-version map, and `active-version` marker.
+- A version already started by bootstrap is marked restarted without another restart, while a historical `stopped_at` cannot hide a different provider that is actually running.
+- A failed reconciliation durably records its error, releases the app lease, and does not block other apps. Retries are idempotent and stop at the configured limit; a newly accepted version starts with a fresh attempt count.
 - Unrecoverable local provider state marks Gestalt unhealthy and terminates the process.
 
 ### Runtime surfaces
 
-- Accepts a registry-only app with none of the optional static UI, HTTP, or MCP surfaces configured.
-- Server construction accepts a registry app with configured static and HTTP mounts before any package or provider exists.
-- Static requests return **503** while the provider is absent or changing, then serve the bundle for the exact running version.
-- A concurrent version change cannot combine a static bundle from one version with a provider from another.
-- Static request handling does not block on a long-running provider lifecycle operation.
-- Deploy-config HTTP bindings mount without startup-time provider catalog lookup and become invocable after the provider starts.
-- Stopping or removing the provider immediately makes static, MCP, and operation surfaces unavailable and clears its running-version map entry and `active-version` marker.
+- Server construction accepts both a backend-only registry app and configured static or HTTP surfaces before any package or provider exists.
+- Static requests return **503** until the provider registry, running-version map, and `active-version` marker agree on one version, and also during a concurrent version change.
+- YAML-declared HTTP bindings mount before provider startup and become invocable afterward; stopping the provider makes all configured surfaces unavailable and clears its running-version map entry and `active-version` marker.
 
 ### Lock and sync
 
-- `gestalt lock` and `gestalt sync` omit snapshot resolution and artifact download for registry-only apps.
-- Lockfile entries record the registry binding only — see [config.md](./config.md#lockfile).
+- `gestalt lock` and `gestalt sync` omit artifact resolution for registry-only apps and record only the registry binding.
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up to #2868 that makes the registry-only app lifecycle contract explicit. The existing plan specified the broad bootstrap and poller flow, but left the relationship between fleet intent, local provider state, runtime routing, convergence accounting, and failure handling ambiguous.

This documents:
- deterministic desired-version selection shared by bootstrap and polling
- a sequential model where bootstrap attempts registry-app startup before polling begins
- late convergence for replicas that miss rollout enrollment while booting
- strict provider start, activation, cleanup, and per-app materialization semantics
- bounded per-version reconciliation retries with durable failure details
- lazy static and HTTP surface behavior before a provider is running
- precise local runtime state versus IndexedDB fleet intent and rollout-progress records
- required tests for failure and version-skew cases

## Testing

Documentation-only change. Verified with `git diff --check`.