### PR TITLE
Implement app registry step 12

### DIFF
--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -47,13 +47,16 @@ type AppVersionChangeRequest struct {
 }
 
 type AppInstanceMaterialization struct {
-	InstanceID     string
-	App            string
-	Version        string
-	AcknowledgedAt time.Time
-	MaterializedAt time.Time
-	StoppedAt      time.Time
-	RestartedAt    time.Time
+	InstanceID       string
+	App              string
+	Version          string
+	AcknowledgedAt   time.Time
+	MaterializedAt   time.Time
+	StoppedAt        time.Time
+	RestartedAt      time.Time
+	AttemptCount     int
+	LastErrorAt      time.Time
+	LastErrorMessage string
 }
 
 type AppRolloutState string

--- a/gestaltd/internal/appregistry/errors.go
+++ b/gestaltd/internal/appregistry/errors.go
@@ -11,5 +11,14 @@ var ErrAppRolloutActive = errors.New("app already has an active rollout")
 // ErrAppVersionAlreadyInstalled means the requested app version is already in the catalog.
 var ErrAppVersionAlreadyInstalled = errors.New("app version is already installed")
 
+// ErrAppAlreadyAdded means add was used after the catalog already contained a version.
+var ErrAppAlreadyAdded = errors.New("app already has fleet-known versions")
+
+// ErrAppNotAdded means upgrade was used before the first catalog version was added.
+var ErrAppNotAdded = errors.New("app has no fleet-known versions")
+
+// ErrRegistrySourceMismatch means the request registry does not match deploy config.
+var ErrRegistrySourceMismatch = errors.New("app registry does not match configured source")
+
 // ErrInstallTimedOut means install work exceeded the bounded post-lock timeout.
 var ErrInstallTimedOut = errors.New("app version install timed out")

--- a/gestaltd/internal/appregistry/installer.go
+++ b/gestaltd/internal/appregistry/installer.go
@@ -46,7 +46,27 @@ type InstallOutput struct {
 	Installation *core.AppInstallation
 }
 
+type installMode int
+
+const (
+	installModeLegacy installMode = iota
+	installModeAdd
+	installModeUpgrade
+)
+
 func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOutput, error) {
+	return i.install(ctx, input, installModeLegacy)
+}
+
+func (i *Installer) Add(ctx context.Context, input InstallInput) (*InstallOutput, error) {
+	return i.install(ctx, input, installModeAdd)
+}
+
+func (i *Installer) Upgrade(ctx context.Context, input InstallInput) (*InstallOutput, error) {
+	return i.install(ctx, input, installModeUpgrade)
+}
+
+func (i *Installer) install(ctx context.Context, input InstallInput, mode installMode) (*InstallOutput, error) {
 	if i == nil {
 		return nil, fmt.Errorf("app registry installer is not configured")
 	}
@@ -90,6 +110,39 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 	if i.Rollouts == nil {
 		return nil, fmt.Errorf("app rollout service is not configured")
 	}
+	knownVersions, err := i.ChangeRequests.ListKnownVersionsByApp(installCtx, appName)
+	if err != nil {
+		return nil, fmt.Errorf("list known app versions: %w", err)
+	}
+	var configEntry *config.ProviderEntry
+	if i.ConfigApps != nil {
+		configEntry = i.ConfigApps[appName]
+	}
+	if mode != installModeLegacy && (configEntry == nil || !configEntry.Source.IsRegistry()) {
+		return nil, fmt.Errorf("%w: app %q is not registry-managed in deploy config", ErrRegistrySourceMismatch, appName)
+	}
+	if configEntry != nil && configEntry.Source.IsRegistry() &&
+		strings.TrimSpace(configEntry.Source.Registry) != registryName {
+		return nil, ErrRegistrySourceMismatch
+	}
+	var fromVersion string
+	switch mode {
+	case installModeAdd:
+		if len(knownVersions) != 0 {
+			return nil, ErrAppAlreadyAdded
+		}
+		fromVersion = "registry:first-install"
+	case installModeUpgrade:
+		if len(knownVersions) == 0 {
+			return nil, ErrAppNotAdded
+		}
+		fromVersion = coredata.LatestKnownVersion(knownVersions)
+	default:
+		fromVersion = resolveFromVersion(knownVersions, configEntry)
+		if fromVersion == "" {
+			return nil, fmt.Errorf("resolve from_version: no known fleet version and app is not pinned in config")
+		}
+	}
 	alreadyKnown, err := i.ChangeRequests.HasKnownVersion(installCtx, appName, version)
 	if err != nil {
 		return nil, fmt.Errorf("check known app version: %w", err)
@@ -103,19 +156,6 @@ func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOu
 		}
 	} else if !errors.Is(getErr, core.ErrNotFound) {
 		return nil, fmt.Errorf("check active app rollout: %w", getErr)
-	}
-
-	knownVersions, err := i.ChangeRequests.ListKnownVersionsByApp(installCtx, appName)
-	if err != nil {
-		return nil, fmt.Errorf("list known app versions: %w", err)
-	}
-	var configEntry *config.ProviderEntry
-	if i.ConfigApps != nil {
-		configEntry = i.ConfigApps[appName]
-	}
-	fromVersion := resolveFromVersion(knownVersions, configEntry)
-	if fromVersion == "" {
-		return nil, fmt.Errorf("resolve from_version: no known fleet version and app is not pinned in config")
 	}
 
 	reader := i.Reader

--- a/gestaltd/internal/appregistry/installer_step12_test.go
+++ b/gestaltd/internal/appregistry/installer_step12_test.go
@@ -1,0 +1,89 @@
+package appregistry_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/appregistry"
+	"github.com/valon-technologies/gestalt/server/internal/appregistry/registrytest"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+)
+
+func TestInstallerAddUsesFirstInstallSentinel(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	svc := testutil.NewStubServices(t)
+	fixture := registrytest.NewInstallFixture(t)
+	installer := newRegistryOnlyInstaller(svc, fixture)
+
+	if _, err := installer.Add(ctx, appregistry.InstallInput{
+		Registry: "toolshed",
+		App:      "g-issues",
+		Version:  fixture.Version,
+	}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	requests, err := svc.AppVersionChangeRequests.ListRequestsByApp(ctx, "g-issues")
+	if err != nil {
+		t.Fatalf("ListRequestsByApp: %v", err)
+	}
+	if len(requests) != 1 || requests[0].FromVersion != "registry:first-install" {
+		t.Fatalf("requests = %#v", requests)
+	}
+}
+
+func TestInstallerAddAndUpgradeRequireCorrectCatalogState(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	svc := testutil.NewStubServices(t)
+	fixture := registrytest.NewInstallFixture(t)
+	installer := newRegistryOnlyInstaller(svc, fixture)
+
+	if _, err := installer.Upgrade(ctx, appregistry.InstallInput{
+		Registry: "toolshed", App: "g-issues", Version: fixture.Version,
+	}); !errors.Is(err, appregistry.ErrAppNotAdded) {
+		t.Fatalf("Upgrade empty catalog error = %v", err)
+	}
+
+	now := time.Now().UTC()
+	installer.Now = func() time.Time { return now.Add(time.Second) }
+	if _, err := svc.AppVersionChangeRequests.AppendRequest(ctx, &core.AppVersionChangeRequest{
+		App: "g-issues", FromVersion: "registry:first-install", ToVersion: "0.9.0", Timestamp: now,
+	}); err != nil {
+		t.Fatalf("AppendRequest: %v", err)
+	}
+	if _, err := installer.Add(ctx, appregistry.InstallInput{
+		Registry: "toolshed", App: "g-issues", Version: fixture.Version,
+	}); !errors.Is(err, appregistry.ErrAppAlreadyAdded) {
+		t.Fatalf("Add populated catalog error = %v", err)
+	}
+	if _, err := installer.Upgrade(ctx, appregistry.InstallInput{
+		Registry: "toolshed", App: "g-issues", Version: fixture.Version,
+	}); err != nil {
+		t.Fatalf("Upgrade: %v", err)
+	}
+	requests, err := svc.AppVersionChangeRequests.ListRequestsByApp(ctx, "g-issues")
+	if err != nil {
+		t.Fatalf("ListRequestsByApp: %v", err)
+	}
+	if len(requests) != 2 || requests[1].FromVersion != "0.9.0" {
+		t.Fatalf("requests = %#v", requests)
+	}
+}
+
+func newRegistryOnlyInstaller(svc *testutil.Services, fixture registrytest.InstallFixture) *appregistry.Installer {
+	return &appregistry.Installer{
+		Registries: map[string]config.AppRegistryConfig{"toolshed": fixture.Registry},
+		ConfigApps: map[string]*config.ProviderEntry{
+			"g-issues": {Source: config.ProviderSource{Registry: "toolshed"}},
+		},
+		Reader:         fixture.Reader,
+		ChangeRequests: svc.AppVersionChangeRequests,
+		Locks:          svc.AppVersionInstallLocks,
+		Rollouts:       svc.AppRollouts,
+	}
+}

--- a/gestaltd/internal/appregistry/materializer.go
+++ b/gestaltd/internal/appregistry/materializer.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/config"
@@ -21,6 +22,8 @@ type Materializer struct {
 	Registries   map[string]config.AppRegistryConfig
 	Reader       *RegistryReader
 	ArtifactsDir string
+	mu           sync.Mutex
+	appLocks     map[string]*sync.Mutex
 }
 
 type MaterializationResult struct {
@@ -47,6 +50,9 @@ func (m *Materializer) Ensure(ctx context.Context, installation *core.AppInstall
 	if appName == "" || version == "" {
 		return nil, fmt.Errorf("installation app and version are required")
 	}
+	appLock := m.appLock(appName)
+	appLock.Lock()
+	defer appLock.Unlock()
 	if registryName == "" {
 		return nil, fmt.Errorf("installation registry is required")
 	}
@@ -95,6 +101,20 @@ func (m *Materializer) Ensure(ctx context.Context, installation *core.AppInstall
 		return nil, fmt.Errorf("materialize app artifact: %w", err)
 	}
 	return &MaterializationResult{Path: destDir, Changed: true}, nil
+}
+
+func (m *Materializer) appLock(app string) *sync.Mutex {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.appLocks == nil {
+		m.appLocks = make(map[string]*sync.Mutex)
+	}
+	if lock := m.appLocks[app]; lock != nil {
+		return lock
+	}
+	lock := &sync.Mutex{}
+	m.appLocks[app] = lock
+	return lock
 }
 
 func installedPackageReady(destDir, appName, version string) bool {

--- a/gestaltd/internal/appregistry/materializer.go
+++ b/gestaltd/internal/appregistry/materializer.go
@@ -103,6 +103,94 @@ func (m *Materializer) Ensure(ctx context.Context, installation *core.AppInstall
 	return &MaterializationResult{Path: destDir, Changed: true}, nil
 }
 
+// PruneSuperseded removes all locally materialized versions for an app except
+// keepVersion. An empty keepVersion removes every locally materialized version.
+func (m *Materializer) PruneSuperseded(app, keepVersion string) error {
+	if m == nil {
+		return fmt.Errorf("app registry materializer is not configured")
+	}
+	app = strings.TrimSpace(app)
+	keepVersion = strings.TrimSpace(keepVersion)
+	if app == "" {
+		return fmt.Errorf("app is required")
+	}
+	artifactsDir := strings.TrimSpace(m.ArtifactsDir)
+	if artifactsDir == "" {
+		return fmt.Errorf("artifacts directory is not configured")
+	}
+	appLock := m.appLock(app)
+	appLock.Lock()
+	defer appLock.Unlock()
+
+	appDir := filepath.Join(artifactsDir, RegistryInstallSubdir, app)
+	entries, err := readMaterializedAppDir(appDir)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if name == keepVersion || (keepVersion != "" && name == "active-version") {
+			continue
+		}
+		path := filepath.Join(appDir, name)
+		if err := os.RemoveAll(path); err != nil {
+			return fmt.Errorf("remove superseded materialized path %s: %w", path, err)
+		}
+	}
+	return nil
+}
+
+// SupersededPruned reports whether no locally materialized package other than
+// keepVersion remains for app.
+func (m *Materializer) SupersededPruned(app, keepVersion string) (bool, error) {
+	if m == nil {
+		return false, fmt.Errorf("app registry materializer is not configured")
+	}
+	app = strings.TrimSpace(app)
+	keepVersion = strings.TrimSpace(keepVersion)
+	if app == "" {
+		return false, fmt.Errorf("app is required")
+	}
+	artifactsDir := strings.TrimSpace(m.ArtifactsDir)
+	if artifactsDir == "" {
+		return false, fmt.Errorf("artifacts directory is not configured")
+	}
+	appLock := m.appLock(app)
+	appLock.Lock()
+	defer appLock.Unlock()
+
+	appDir := filepath.Join(artifactsDir, RegistryInstallSubdir, app)
+	entries, err := readMaterializedAppDir(appDir)
+	if err != nil {
+		return false, err
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if name != keepVersion && name != "active-version" {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func readMaterializedAppDir(appDir string) ([]os.DirEntry, error) {
+	info, err := os.Lstat(appDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("stat materialized app directory %s: %w", appDir, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("materialized app path %s is not a directory", appDir)
+	}
+	entries, err := os.ReadDir(appDir)
+	if err != nil {
+		return nil, fmt.Errorf("read materialized app directory %s: %w", appDir, err)
+	}
+	return entries, nil
+}
+
 func (m *Materializer) appLock(app string) *sync.Mutex {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/gestaltd/internal/appregistry/materializer_test.go
+++ b/gestaltd/internal/appregistry/materializer_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -13,6 +14,50 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/services/apps/packageio"
 )
+
+func TestMaterializer_serializes_same_app(t *testing.T) {
+	t.Parallel()
+	fixture := registrytest.NewInstallFixture(t)
+	materializer := &appregistry.Materializer{
+		Registries:   map[string]config.AppRegistryConfig{"toolshed": fixture.Registry},
+		Reader:       fixture.Reader,
+		ArtifactsDir: t.TempDir(),
+	}
+	installation := &core.AppInstallation{
+		AppName: "g-issues", Version: fixture.Version, Registry: "toolshed",
+	}
+
+	results := make(chan *appregistry.MaterializationResult, 2)
+	errs := make(chan error, 2)
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			result, err := materializer.Ensure(context.Background(), installation)
+			results <- result
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(results)
+	close(errs)
+
+	changed := 0
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("Ensure: %v", err)
+		}
+	}
+	for result := range results {
+		if result != nil && result.Changed {
+			changed++
+		}
+	}
+	if changed != 1 {
+		t.Fatalf("changed results = %d, want 1", changed)
+	}
+}
 
 func TestMaterializer_downloads_and_extracts_artifact(t *testing.T) {
 	t.Parallel()

--- a/gestaltd/internal/appregistry/materializer_test.go
+++ b/gestaltd/internal/appregistry/materializer_test.go
@@ -59,6 +59,50 @@ func TestMaterializer_serializes_same_app(t *testing.T) {
 	}
 }
 
+func TestMaterializerPruneSupersededRetainsOnlyDesiredVersion(t *testing.T) {
+	t.Parallel()
+	artifactsDir := t.TempDir()
+	appDir := filepath.Join(artifactsDir, appregistry.RegistryInstallSubdir, "g-issues")
+	desiredDir := filepath.Join(appDir, "v2")
+	oldDir := filepath.Join(appDir, "v1")
+	for _, path := range []string{desiredDir, oldDir} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s): %v", path, err)
+		}
+	}
+	marker := filepath.Join(appDir, "active-version")
+	if err := os.WriteFile(marker, []byte("v2\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(active-version): %v", err)
+	}
+	materializer := &appregistry.Materializer{ArtifactsDir: artifactsDir}
+
+	pruned, err := materializer.SupersededPruned("g-issues", "v2")
+	if err != nil {
+		t.Fatalf("SupersededPruned before cleanup: %v", err)
+	}
+	if pruned {
+		t.Fatal("SupersededPruned before cleanup = true, want false")
+	}
+	if err := materializer.PruneSuperseded("g-issues", "v2"); err != nil {
+		t.Fatalf("PruneSuperseded: %v", err)
+	}
+	for _, path := range []string{desiredDir, marker} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("retained path %s: %v", path, err)
+		}
+	}
+	if _, err := os.Stat(oldDir); !os.IsNotExist(err) {
+		t.Fatalf("old version stat error = %v, want not exist", err)
+	}
+	pruned, err = materializer.SupersededPruned("g-issues", "v2")
+	if err != nil {
+		t.Fatalf("SupersededPruned: %v", err)
+	}
+	if !pruned {
+		t.Fatal("SupersededPruned = false, want true")
+	}
+}
+
 func TestMaterializer_downloads_and_extracts_artifact(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/appregistry/poller.go
+++ b/gestaltd/internal/appregistry/poller.go
@@ -22,17 +22,19 @@ const (
 )
 
 type CatalogPoller struct {
-	ChangeRequests      *coredata.AppVersionChangeRequestService
-	Materializations    *coredata.AppInstanceMaterializationService
-	Rollouts            *coredata.AppRolloutService
-	AppMaterializer     *Materializer
-	AppRestarter        AppRestarter
-	InstanceID          string
-	Interval            time.Duration
-	RestartDelay        time.Duration
-	DisableRestartDelay bool
-	RestartReady        <-chan struct{}
-	Now                 func() time.Time
+	ChangeRequests       *coredata.AppVersionChangeRequestService
+	Materializations     *coredata.AppInstanceMaterializationService
+	Rollouts             *coredata.AppRolloutService
+	AppMaterializer      *Materializer
+	AppRestarter         AppRestarter
+	InstanceID           string
+	Interval             time.Duration
+	RestartDelay         time.Duration
+	DisableRestartDelay  bool
+	RestartReady         <-chan struct{}
+	BootstrapReady       <-chan struct{}
+	MaxReconcileAttempts int
+	Now                  func() time.Time
 
 	startOnce sync.Once
 	startMu   sync.Mutex
@@ -45,34 +47,38 @@ type CatalogPoller struct {
 }
 
 type CatalogPollerConfig struct {
-	ChangeRequests      *coredata.AppVersionChangeRequestService
-	Materializations    *coredata.AppInstanceMaterializationService
-	Rollouts            *coredata.AppRolloutService
-	AppMaterializer     *Materializer
-	AppRestarter        AppRestarter
-	InstanceID          string
-	Interval            time.Duration
-	RestartDelay        time.Duration
-	DisableRestartDelay bool
-	RestartReady        <-chan struct{}
-	Now                 func() time.Time
+	ChangeRequests       *coredata.AppVersionChangeRequestService
+	Materializations     *coredata.AppInstanceMaterializationService
+	Rollouts             *coredata.AppRolloutService
+	AppMaterializer      *Materializer
+	AppRestarter         AppRestarter
+	InstanceID           string
+	Interval             time.Duration
+	RestartDelay         time.Duration
+	DisableRestartDelay  bool
+	RestartReady         <-chan struct{}
+	BootstrapReady       <-chan struct{}
+	MaxReconcileAttempts int
+	Now                  func() time.Time
 }
 
 func NewCatalogPoller(cfg CatalogPollerConfig) *CatalogPoller {
 	return &CatalogPoller{
-		ChangeRequests:      cfg.ChangeRequests,
-		Materializations:    cfg.Materializations,
-		Rollouts:            cfg.Rollouts,
-		AppMaterializer:     cfg.AppMaterializer,
-		AppRestarter:        cfg.AppRestarter,
-		InstanceID:          strings.TrimSpace(cfg.InstanceID),
-		Interval:            cfg.Interval,
-		RestartDelay:        cfg.RestartDelay,
-		DisableRestartDelay: cfg.DisableRestartDelay,
-		RestartReady:        cfg.RestartReady,
-		Now:                 cfg.Now,
-		inflight:            make(map[string]struct{}),
-		stoppedAt:           make(map[string]time.Time),
+		ChangeRequests:       cfg.ChangeRequests,
+		Materializations:     cfg.Materializations,
+		Rollouts:             cfg.Rollouts,
+		AppMaterializer:      cfg.AppMaterializer,
+		AppRestarter:         cfg.AppRestarter,
+		InstanceID:           strings.TrimSpace(cfg.InstanceID),
+		Interval:             cfg.Interval,
+		RestartDelay:         cfg.RestartDelay,
+		DisableRestartDelay:  cfg.DisableRestartDelay,
+		RestartReady:         cfg.RestartReady,
+		BootstrapReady:       cfg.BootstrapReady,
+		MaxReconcileAttempts: cfg.MaxReconcileAttempts,
+		Now:                  cfg.Now,
+		inflight:             make(map[string]struct{}),
+		stoppedAt:            make(map[string]time.Time),
 	}
 }
 
@@ -126,6 +132,13 @@ func (p *CatalogPoller) Stop() {
 }
 
 func (p *CatalogPoller) loop(ctx context.Context) {
+	if p.BootstrapReady != nil {
+		select {
+		case <-ctx.Done():
+			return
+		case <-p.BootstrapReady:
+		}
+	}
 	p.runOnce(ctx)
 	ticker := time.NewTicker(p.pollInterval())
 	defer ticker.Stop()
@@ -157,6 +170,9 @@ func (p *CatalogPoller) ReconcileOnce(ctx context.Context) error {
 	if p.ChangeRequests == nil || p.Materializations == nil || p.Rollouts == nil {
 		return fmt.Errorf("app registry catalog poller is not configured")
 	}
+	if !channelReady(p.BootstrapReady) {
+		return nil
+	}
 	instanceID := strings.TrimSpace(p.InstanceID)
 	if instanceID == "" {
 		return fmt.Errorf("app registry catalog poller: instance id is required")
@@ -182,7 +198,7 @@ func (p *CatalogPoller) ReconcileOnce(ctx context.Context) error {
 	byApp := groupInstallationsByApp(known)
 	for appName, installations := range byApp {
 		if err := p.reconcileApp(ctx, instanceID, appName, installations, activeByApp[appName]); err != nil {
-			errs = append(errs, err)
+			errs = append(errs, p.recordFailure(ctx, instanceID, appName, installations, err))
 		}
 		delete(activeByApp, appName)
 	}
@@ -288,8 +304,34 @@ func (p *CatalogPoller) reconcileApp(ctx context.Context, instanceID, appName st
 		return nil
 	}
 
+	driverVersion := coredata.LatestKnownVersion(installations)
+	if driverVersion == "" {
+		return fmt.Errorf("select desired version for app %s", appName)
+	}
+	if acceptor, ok := p.AppRestarter.(interface {
+		AcceptsRegistry(string, string) bool
+	}); ok {
+		desired := findInstallation(installations, driverVersion)
+		if desired == nil || !acceptor.AcceptsRegistry(appName, desired.Registry) {
+			return fmt.Errorf("registry for %s@%s does not match configured source", appName, driverVersion)
+		}
+	}
+	if materialization, err := p.Materializations.Get(ctx, instanceID, appName, driverVersion); err == nil {
+		if materialization.AttemptCount >= p.maxReconcileAttempts() {
+			return nil
+		}
+	}
+
 	if p.AppRestarter == nil {
 		return nil
+	}
+
+	if inspector, ok := p.AppRestarter.(interface {
+		RunningVersion(string) (string, bool)
+	}); ok {
+		if running, found := inspector.RunningVersion(appName); found && running == driverVersion {
+			return p.markAllRestarted(ctx, instanceID, appName, pending, p.now())
+		}
 	}
 
 	restartable, err := p.AppRestarter.Restartable(appName)
@@ -319,11 +361,16 @@ func (p *CatalogPoller) reconcileApp(ctx context.Context, instanceID, appName st
 		return nil
 	}
 
-	driverVersion := strings.TrimSpace(pending[len(pending)-1].Version)
-
 	stoppedAt, alreadyStopped, err := p.earliestStoppedAt(ctx, instanceID, appName, pending)
 	if err != nil {
 		return err
+	}
+	if inspector, ok := p.AppRestarter.(interface {
+		RunningVersion(string) (string, bool)
+	}); ok {
+		if running, found := inspector.RunningVersion(appName); found && running != driverVersion {
+			alreadyStopped = false
+		}
 	}
 	if !alreadyStopped {
 		if err := p.AppRestarter.StopApp(ctx, appName); err != nil {
@@ -419,6 +466,18 @@ func (p *CatalogPoller) restartReady() bool {
 	}
 	select {
 	case <-p.RestartReady:
+		return true
+	default:
+		return false
+	}
+}
+
+func channelReady(ready <-chan struct{}) bool {
+	if ready == nil {
+		return true
+	}
+	select {
+	case <-ready:
 		return true
 	default:
 		return false
@@ -617,4 +676,22 @@ func (p *CatalogPoller) now() time.Time {
 		return p.Now().UTC().Truncate(time.Millisecond)
 	}
 	return time.Now().UTC().Truncate(time.Millisecond)
+}
+
+func (p *CatalogPoller) maxReconcileAttempts() int {
+	if p != nil && p.MaxReconcileAttempts > 0 {
+		return p.MaxReconcileAttempts
+	}
+	return 3
+}
+
+func (p *CatalogPoller) recordFailure(ctx context.Context, instanceID, appName string, installations []*core.AppInstallation, reconcileErr error) error {
+	version := coredata.LatestKnownVersion(installations)
+	if version == "" || p.Materializations == nil {
+		return reconcileErr
+	}
+	if _, err := p.Materializations.RecordFailure(ctx, instanceID, appName, version, p.now(), reconcileErr.Error()); err != nil {
+		return errors.Join(reconcileErr, fmt.Errorf("record reconciliation failure for %s@%s: %w", appName, version, err))
+	}
+	return reconcileErr
 }

--- a/gestaltd/internal/appregistry/poller.go
+++ b/gestaltd/internal/appregistry/poller.go
@@ -308,11 +308,14 @@ func (p *CatalogPoller) reconcileApp(ctx context.Context, instanceID, appName st
 	if driverVersion == "" {
 		return fmt.Errorf("select desired version for app %s", appName)
 	}
+	desired := findInstallation(installations, driverVersion)
+	if desired == nil {
+		return fmt.Errorf("find desired installation for app %s@%s", appName, driverVersion)
+	}
 	if acceptor, ok := p.AppRestarter.(interface {
 		AcceptsRegistry(string, string) bool
 	}); ok {
-		desired := findInstallation(installations, driverVersion)
-		if desired == nil || !acceptor.AcceptsRegistry(appName, desired.Registry) {
+		if !acceptor.AcceptsRegistry(appName, desired.Registry) {
 			return fmt.Errorf("registry for %s@%s does not match configured source", appName, driverVersion)
 		}
 	}
@@ -349,25 +352,32 @@ func (p *CatalogPoller) reconcileApp(ctx context.Context, instanceID, appName st
 			RunningVersion(string) (string, bool)
 		}); ok {
 			running, found := inspector.RunningVersion(appName)
-			materialized, err := p.pendingRegistryVersionsMaterialized(ctx, instanceID, pending)
+			materialized, err := p.desiredVersionMaterialized(ctx, instanceID, desired)
 			if err != nil {
 				return err
 			}
-			if found && running == driverVersion && materialized {
+			pruned, err := p.supersededPruned(appName, driverVersion)
+			if err != nil {
+				return err
+			}
+			if found && running == driverVersion && materialized && pruned {
 				return p.markAllRestarted(ctx, instanceID, appName, pending, p.now())
 			}
 		}
 		return nil
 	}
 
-	if err := p.ensurePendingMaterialized(ctx, instanceID, pending); err != nil {
-		return fmt.Errorf("materialize pending versions for app %s: %w", appName, err)
+	if err := p.ensureDesiredMaterialized(ctx, instanceID, desired); err != nil {
+		return fmt.Errorf("materialize desired version for app %s: %w", appName, err)
 	}
 
 	if inspector, ok := p.AppRestarter.(interface {
 		RunningVersion(string) (string, bool)
 	}); ok {
 		if running, found := inspector.RunningVersion(appName); found && running == driverVersion {
+			if err := p.pruneSuperseded(appName, driverVersion); err != nil {
+				return err
+			}
 			return p.markAllRestarted(ctx, instanceID, appName, pending, p.now())
 		}
 	}
@@ -414,6 +424,9 @@ func (p *CatalogPoller) reconcileApp(ctx context.Context, instanceID, appName st
 	if err := p.AppRestarter.StartApp(ctx, appName, driverVersion); err != nil {
 		return fmt.Errorf("start app %s for %s@%s: %w", appName, appName, driverVersion, err)
 	}
+	if err := p.pruneSuperseded(appName, driverVersion); err != nil {
+		return err
+	}
 	restartedAt := p.now()
 	if err := p.markAllRestarted(ctx, instanceID, appName, pending, restartedAt); err != nil {
 		return err
@@ -435,22 +448,21 @@ func (p *CatalogPoller) reconcileApp(ctx context.Context, instanceID, appName st
 	return nil
 }
 
-func (p *CatalogPoller) pendingRegistryVersionsMaterialized(ctx context.Context, instanceID string, pending []*core.AppInstallation) (bool, error) {
-	for _, installation := range pending {
-		if installation == nil || strings.TrimSpace(installation.Registry) == "" {
-			continue
-		}
-		appName := strings.TrimSpace(installation.AppName)
-		version := strings.TrimSpace(installation.Version)
-		materialization, err := p.Materializations.Get(ctx, instanceID, appName, version)
-		if err != nil {
-			return false, fmt.Errorf("load materialization for %s@%s: %w", appName, version, err)
-		}
-		if materialization.MaterializedAt.IsZero() {
-			return false, nil
-		}
+func (p *CatalogPoller) desiredVersionMaterialized(ctx context.Context, instanceID string, desired *core.AppInstallation) (bool, error) {
+	if desired == nil || strings.TrimSpace(desired.Registry) == "" {
+		return true, nil
 	}
-	return true, nil
+	appName := strings.TrimSpace(desired.AppName)
+	version := strings.TrimSpace(desired.Version)
+	materialization, err := p.Materializations.Get(ctx, instanceID, appName, version)
+	if err != nil {
+		return false, fmt.Errorf("load materialization for %s@%s: %w", appName, version, err)
+	}
+	if materialization.MaterializedAt.IsZero() || p.AppMaterializer == nil {
+		return false, nil
+	}
+	path := MaterializedPath(p.AppMaterializer.ArtifactsDir, appName, version)
+	return installedPackageReady(path, appName, version), nil
 }
 
 func findInstallation(installations []*core.AppInstallation, version string) *core.AppInstallation {
@@ -517,55 +529,63 @@ func channelReady(ready <-chan struct{}) bool {
 	}
 }
 
-func (p *CatalogPoller) ensurePendingMaterialized(ctx context.Context, instanceID string, pending []*core.AppInstallation) error {
-	if p == nil || len(pending) == 0 {
+func (p *CatalogPoller) ensureDesiredMaterialized(ctx context.Context, instanceID string, desired *core.AppInstallation) error {
+	if p == nil || desired == nil {
+		return nil
+	}
+	appName := strings.TrimSpace(desired.AppName)
+	version := strings.TrimSpace(desired.Version)
+	if appName == "" || version == "" || strings.TrimSpace(desired.Registry) == "" {
 		return nil
 	}
 	if p.AppMaterializer == nil {
-		for _, installation := range pending {
-			if installation != nil && strings.TrimSpace(installation.Registry) != "" {
-				return fmt.Errorf("app registry materializer is required for %s@%s", installation.AppName, installation.Version)
-			}
-		}
+		return fmt.Errorf("app registry materializer is required for %s@%s", appName, version)
+	}
+	materialization, err := p.Materializations.Get(ctx, instanceID, appName, version)
+	if err != nil {
+		return fmt.Errorf("load materialization for %s@%s: %w", appName, version, err)
+	}
+	result, err := p.AppMaterializer.Ensure(ctx, desired)
+	if err != nil {
+		return fmt.Errorf("materialize %s@%s: %w", appName, version, err)
+	}
+	if !result.Changed && !materialization.MaterializedAt.IsZero() {
 		return nil
 	}
-	for _, installation := range pending {
-		if installation == nil {
-			continue
-		}
-		appName := strings.TrimSpace(installation.AppName)
-		version := strings.TrimSpace(installation.Version)
-		if appName == "" || version == "" {
-			continue
-		}
-		if strings.TrimSpace(installation.Registry) == "" {
-			continue
-		}
-		materialization, err := p.Materializations.Get(ctx, instanceID, appName, version)
-		if err != nil {
-			return fmt.Errorf("load materialization for %s@%s: %w", appName, version, err)
-		}
-		result, err := p.AppMaterializer.Ensure(ctx, installation)
-		if err != nil {
-			return fmt.Errorf("materialize %s@%s: %w", appName, version, err)
-		}
-		if !result.Changed && !materialization.MaterializedAt.IsZero() {
-			continue
-		}
-		materializedAt := p.now()
-		if _, err := p.Materializations.MarkMaterialized(ctx, instanceID, appName, version, materializedAt); err != nil {
-			return fmt.Errorf("record materialization for %s@%s: %w", appName, version, err)
-		}
-		slog.Info(
-			"app registry catalog poller materialized app artifact",
-			"app", appName,
-			"version", version,
-			"instance_id", instanceID,
-			"materialized_path", result.Path,
-			"materialized_at", materializedAt,
-		)
+	materializedAt := p.now()
+	if _, err := p.Materializations.MarkMaterialized(ctx, instanceID, appName, version, materializedAt); err != nil {
+		return fmt.Errorf("record materialization for %s@%s: %w", appName, version, err)
+	}
+	slog.Info(
+		"app registry catalog poller materialized app artifact",
+		"app", appName,
+		"version", version,
+		"instance_id", instanceID,
+		"materialized_path", result.Path,
+		"materialized_at", materializedAt,
+	)
+	return nil
+}
+
+func (p *CatalogPoller) pruneSuperseded(appName, desiredVersion string) error {
+	if p == nil || p.AppMaterializer == nil {
+		return nil
+	}
+	if err := p.AppMaterializer.PruneSuperseded(appName, desiredVersion); err != nil {
+		return fmt.Errorf("prune superseded versions for app %s: %w", appName, err)
 	}
 	return nil
+}
+
+func (p *CatalogPoller) supersededPruned(appName, desiredVersion string) (bool, error) {
+	if p == nil || p.AppMaterializer == nil {
+		return true, nil
+	}
+	pruned, err := p.AppMaterializer.SupersededPruned(appName, desiredVersion)
+	if err != nil {
+		return false, fmt.Errorf("inspect superseded versions for app %s: %w", appName, err)
+	}
+	return pruned, nil
 }
 
 func (p *CatalogPoller) markCatalogConverged(ctx context.Context, instanceID, appName string, pending []*core.AppInstallation, convergedAt time.Time) error {

--- a/gestaltd/internal/appregistry/poller.go
+++ b/gestaltd/internal/appregistry/poller.go
@@ -316,10 +316,9 @@ func (p *CatalogPoller) reconcileApp(ctx context.Context, instanceID, appName st
 			return fmt.Errorf("registry for %s@%s does not match configured source", appName, driverVersion)
 		}
 	}
+	retryLimitReached := false
 	if materialization, err := p.Materializations.Get(ctx, instanceID, appName, driverVersion); err == nil {
-		if materialization.AttemptCount >= p.maxReconcileAttempts() {
-			return nil
-		}
+		retryLimitReached = materialization.AttemptCount >= p.maxReconcileAttempts()
 	}
 
 	if p.AppRestarter == nil {
@@ -342,6 +341,22 @@ func (p *CatalogPoller) reconcileApp(ctx context.Context, instanceID, appName st
 			"instance_id", instanceID,
 			"restarted_at", convergedAt,
 		)
+		return nil
+	}
+
+	if retryLimitReached {
+		if inspector, ok := p.AppRestarter.(interface {
+			RunningVersion(string) (string, bool)
+		}); ok {
+			running, found := inspector.RunningVersion(appName)
+			materialized, err := p.pendingRegistryVersionsMaterialized(ctx, instanceID, pending)
+			if err != nil {
+				return err
+			}
+			if found && running == driverVersion && materialized {
+				return p.markAllRestarted(ctx, instanceID, appName, pending, p.now())
+			}
+		}
 		return nil
 	}
 
@@ -418,6 +433,24 @@ func (p *CatalogPoller) reconcileApp(ctx context.Context, instanceID, appName st
 		"restarted_at", restartedAt,
 	)
 	return nil
+}
+
+func (p *CatalogPoller) pendingRegistryVersionsMaterialized(ctx context.Context, instanceID string, pending []*core.AppInstallation) (bool, error) {
+	for _, installation := range pending {
+		if installation == nil || strings.TrimSpace(installation.Registry) == "" {
+			continue
+		}
+		appName := strings.TrimSpace(installation.AppName)
+		version := strings.TrimSpace(installation.Version)
+		materialization, err := p.Materializations.Get(ctx, instanceID, appName, version)
+		if err != nil {
+			return false, fmt.Errorf("load materialization for %s@%s: %w", appName, version, err)
+		}
+		if materialization.MaterializedAt.IsZero() {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 func findInstallation(installations []*core.AppInstallation, version string) *core.AppInstallation {

--- a/gestaltd/internal/appregistry/poller.go
+++ b/gestaltd/internal/appregistry/poller.go
@@ -326,14 +326,6 @@ func (p *CatalogPoller) reconcileApp(ctx context.Context, instanceID, appName st
 		return nil
 	}
 
-	if inspector, ok := p.AppRestarter.(interface {
-		RunningVersion(string) (string, bool)
-	}); ok {
-		if running, found := inspector.RunningVersion(appName); found && running == driverVersion {
-			return p.markAllRestarted(ctx, instanceID, appName, pending, p.now())
-		}
-	}
-
 	restartable, err := p.AppRestarter.Restartable(appName)
 	if err != nil {
 		return fmt.Errorf("determine restart mode for app %s: %w", appName, err)
@@ -355,6 +347,14 @@ func (p *CatalogPoller) reconcileApp(ctx context.Context, instanceID, appName st
 
 	if err := p.ensurePendingMaterialized(ctx, instanceID, pending); err != nil {
 		return fmt.Errorf("materialize pending versions for app %s: %w", appName, err)
+	}
+
+	if inspector, ok := p.AppRestarter.(interface {
+		RunningVersion(string) (string, bool)
+	}); ok {
+		if running, found := inspector.RunningVersion(appName); found && running == driverVersion {
+			return p.markAllRestarted(ctx, instanceID, appName, pending, p.now())
+		}
 	}
 
 	if !p.restartReady() {

--- a/gestaltd/internal/appregistry/poller_materialize_test.go
+++ b/gestaltd/internal/appregistry/poller_materialize_test.go
@@ -2,6 +2,7 @@ package appregistry_test
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -21,6 +22,7 @@ type recordingAppRestarter struct {
 	startCalls     []string
 	startVersions  []string
 	runningVersion string
+	startErr       error
 }
 
 func (r *recordingAppRestarter) Restartable(app string) (bool, error) {
@@ -35,7 +37,7 @@ func (r *recordingAppRestarter) StopApp(_ context.Context, app string) error {
 func (r *recordingAppRestarter) StartApp(_ context.Context, app, version string) error {
 	r.startCalls = append(r.startCalls, app)
 	r.startVersions = append(r.startVersions, version)
-	return nil
+	return r.startErr
 }
 
 func (r *recordingAppRestarter) AbortRestarts() {}
@@ -217,9 +219,19 @@ func TestCatalogPollerStartAppPassesDriverVersion(t *testing.T) {
 	}
 }
 
-func TestCatalogPollerMaterializesPendingVersionsBeforeMarkingRunningVersionRestarted(t *testing.T) {
+func TestCatalogPollerRunningLatestSkipsSupersededMaterialization(t *testing.T) {
 	t.Parallel()
 	h := newPollerMaterializationHarness(t, "toolshed", true)
+	oldVersion := "0.0.0-snapshot.gold"
+	if _, err := h.services.AppVersionChangeRequests.AppendRequest(h.ctx, &core.AppVersionChangeRequest{
+		App:         "g-issues",
+		FromVersion: "previous",
+		ToVersion:   oldVersion,
+		Timestamp:   h.clock.Add(-time.Minute),
+		Metadata:    map[string]any{"registry": "toolshed"},
+	}); err != nil {
+		t.Fatalf("AppendRequest(old version): %v", err)
+	}
 	h.restarter.runningVersion = h.fixture.Version
 
 	if err := h.poller.ReconcileOnce(h.ctx); err != nil {
@@ -235,7 +247,72 @@ func TestCatalogPollerMaterializesPendingVersionsBeforeMarkingRunningVersionRest
 	if materialization.RestartedAt.IsZero() {
 		t.Fatal("RestartedAt is zero")
 	}
+	oldMaterialization, err := h.services.AppInstanceMaterializations.Get(h.ctx, "replica-a", "g-issues", oldVersion)
+	if err != nil {
+		t.Fatalf("Get old materialization: %v", err)
+	}
+	if !oldMaterialization.MaterializedAt.IsZero() {
+		t.Fatalf("old MaterializedAt = %v, want zero", oldMaterialization.MaterializedAt)
+	}
+	if oldMaterialization.RestartedAt.IsZero() {
+		t.Fatal("old RestartedAt is zero")
+	}
+	oldPath := appregistry.MaterializedPath(h.artifactsDir, "g-issues", oldVersion)
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Fatalf("old version stat error = %v, want not exist", err)
+	}
 	if len(h.restarter.stopCalls) != 0 || len(h.restarter.startCalls) != 0 {
 		t.Fatalf("unexpected restart calls: stop=%v start=%v", h.restarter.stopCalls, h.restarter.startCalls)
+	}
+}
+
+func TestCatalogPollerAtRetryLimitRecordsMaterializedRunningVersion(t *testing.T) {
+	t.Parallel()
+	h := newPollerMaterializationHarness(t, "toolshed", true)
+	h.poller.MaxReconcileAttempts = 1
+
+	if err := h.poller.ReconcileOnce(h.ctx); err != nil {
+		t.Fatalf("materialization pass: %v", err)
+	}
+	if _, err := h.services.AppInstanceMaterializations.RecordFailure(
+		h.ctx,
+		"replica-a",
+		"g-issues",
+		h.fixture.Version,
+		h.clock,
+		"prior start failure",
+	); err != nil {
+		t.Fatalf("RecordFailure: %v", err)
+	}
+	h.restarter.runningVersion = h.fixture.Version
+
+	if err := h.poller.ReconcileOnce(h.ctx); err != nil {
+		t.Fatalf("limited convergence pass: %v", err)
+	}
+	materialization := h.materialization(t)
+	if materialization.RestartedAt.IsZero() {
+		t.Fatal("RestartedAt is zero")
+	}
+	if len(h.restarter.stopCalls) != 0 || len(h.restarter.startCalls) != 0 {
+		t.Fatalf("unexpected restart calls: stop=%v start=%v", h.restarter.stopCalls, h.restarter.startCalls)
+	}
+}
+
+func TestCatalogPollerRetainsOldVersionUntilDesiredVersionStarts(t *testing.T) {
+	t.Parallel()
+	h := newPollerMaterializationHarness(t, "toolshed", true)
+	oldPath := appregistry.MaterializedPath(h.artifactsDir, "g-issues", "old")
+	if err := os.MkdirAll(oldPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll old version: %v", err)
+	}
+	h.restarter.startErr = errors.New("start failed")
+	close(h.restartReady)
+
+	err := h.poller.ReconcileOnce(h.ctx)
+	if err == nil || !strings.Contains(err.Error(), "start failed") {
+		t.Fatalf("ReconcileOnce error = %v, want start failure", err)
+	}
+	if _, err := os.Stat(oldPath); err != nil {
+		t.Fatalf("old version removed before desired start: %v", err)
 	}
 }

--- a/gestaltd/internal/appregistry/poller_materialize_test.go
+++ b/gestaltd/internal/appregistry/poller_materialize_test.go
@@ -17,9 +17,10 @@ import (
 )
 
 type recordingAppRestarter struct {
-	stopCalls     []string
-	startCalls    []string
-	startVersions []string
+	stopCalls      []string
+	startCalls     []string
+	startVersions  []string
+	runningVersion string
 }
 
 func (r *recordingAppRestarter) Restartable(app string) (bool, error) {
@@ -38,6 +39,10 @@ func (r *recordingAppRestarter) StartApp(_ context.Context, app, version string)
 }
 
 func (r *recordingAppRestarter) AbortRestarts() {}
+
+func (r *recordingAppRestarter) RunningVersion(string) (string, bool) {
+	return r.runningVersion, r.runningVersion != ""
+}
 
 type pollerMaterializationHarness struct {
 	ctx          context.Context
@@ -209,5 +214,28 @@ func TestCatalogPollerStartAppPassesDriverVersion(t *testing.T) {
 	}
 	if got := h.restarter.startVersions; len(got) != 1 || got[0] != h.fixture.Version {
 		t.Fatalf("startVersions = %#v, want [%q]", got, h.fixture.Version)
+	}
+}
+
+func TestCatalogPollerMaterializesPendingVersionsBeforeMarkingRunningVersionRestarted(t *testing.T) {
+	t.Parallel()
+	h := newPollerMaterializationHarness(t, "toolshed", true)
+	h.restarter.runningVersion = h.fixture.Version
+
+	if err := h.poller.ReconcileOnce(h.ctx); err != nil {
+		t.Fatalf("ReconcileOnce: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(h.materializedPath(), "manifest.yaml")); err != nil {
+		t.Fatalf("stat materialized manifest: %v", err)
+	}
+	materialization := h.materialization(t)
+	if materialization.MaterializedAt.IsZero() {
+		t.Fatal("MaterializedAt is zero")
+	}
+	if materialization.RestartedAt.IsZero() {
+		t.Fatal("RestartedAt is zero")
+	}
+	if len(h.restarter.stopCalls) != 0 || len(h.restarter.startCalls) != 0 {
+		t.Fatalf("unexpected restart calls: stop=%v start=%v", h.restarter.stopCalls, h.restarter.startCalls)
 	}
 }

--- a/gestaltd/internal/appregistry/poller_test.go
+++ b/gestaltd/internal/appregistry/poller_test.go
@@ -55,6 +55,44 @@ func (r *recordingAppRestarter) StartApp(_ context.Context, app, version string)
 
 func (r *recordingAppRestarter) AbortRestarts() {}
 
+func TestCatalogPollerStopsRetryingAtConfiguredLimit(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	services := testutil.NewStubServices(t)
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	appendRolloutFixture(t, services, "g-issues", "v1", now)
+	restarter := &recordingAppRestarter{startErr: errors.New("start failed")}
+	poller := NewCatalogPoller(CatalogPollerConfig{
+		ChangeRequests:       services.AppVersionChangeRequests,
+		Materializations:     services.AppInstanceMaterializations,
+		Rollouts:             services.AppRollouts,
+		AppRestarter:         restarter,
+		InstanceID:           "replica-a",
+		DisableRestartDelay:  true,
+		MaxReconcileAttempts: 2,
+		Now:                  func() time.Time { return now },
+	})
+
+	for attempt := 1; attempt <= 2; attempt++ {
+		if err := poller.ReconcileOnce(ctx); err == nil {
+			t.Fatalf("attempt %d unexpectedly succeeded", attempt)
+		}
+		row, err := services.AppInstanceMaterializations.Get(ctx, "replica-a", "g-issues", "v1")
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if row.AttemptCount != attempt || row.LastErrorMessage == "" {
+			t.Fatalf("attempt %d row = %#v", attempt, row)
+		}
+	}
+	if err := poller.ReconcileOnce(ctx); err != nil {
+		t.Fatalf("limited pass: %v", err)
+	}
+	if got := len(restarter.startCalls); got != 2 {
+		t.Fatalf("start calls = %d, want 2", got)
+	}
+}
+
 func TestCatalogPollerRolloutEnrollmentAndCompletion(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/appregistry/poller_test.go
+++ b/gestaltd/internal/appregistry/poller_test.go
@@ -108,7 +108,6 @@ func TestCatalogPollerAtRetryLimitRecordsObservedConvergence(t *testing.T) {
 		FromVersion: "previous",
 		ToVersion:   "v1",
 		Timestamp:   now,
-		Metadata:    map[string]any{"registry": "toolshed"},
 	}); err != nil {
 		t.Fatalf("AppendRequest: %v", err)
 	}
@@ -119,9 +118,6 @@ func TestCatalogPollerAtRetryLimitRecordsObservedConvergence(t *testing.T) {
 		AcknowledgedAt: now,
 	}); err != nil {
 		t.Fatalf("Acknowledge: %v", err)
-	}
-	if _, err := services.AppInstanceMaterializations.MarkMaterialized(ctx, "replica-a", "g-issues", "v1", now); err != nil {
-		t.Fatalf("MarkMaterialized: %v", err)
 	}
 	if _, err := services.AppInstanceMaterializations.RecordFailure(ctx, "replica-a", "g-issues", "v1", now, "prior failure"); err != nil {
 		t.Fatalf("RecordFailure: %v", err)

--- a/gestaltd/internal/appregistry/poller_test.go
+++ b/gestaltd/internal/appregistry/poller_test.go
@@ -22,6 +22,7 @@ type recordingAppRestarter struct {
 	restartable    map[string]bool
 	restartableErr error
 	afterStop      func()
+	runningVersion string
 }
 
 func (r *recordingAppRestarter) Restartable(app string) (bool, error) {
@@ -54,6 +55,10 @@ func (r *recordingAppRestarter) StartApp(_ context.Context, app, version string)
 }
 
 func (r *recordingAppRestarter) AbortRestarts() {}
+
+func (r *recordingAppRestarter) RunningVersion(string) (string, bool) {
+	return r.runningVersion, r.runningVersion != ""
+}
 
 func TestCatalogPollerStopsRetryingAtConfiguredLimit(t *testing.T) {
 	t.Parallel()
@@ -90,6 +95,60 @@ func TestCatalogPollerStopsRetryingAtConfiguredLimit(t *testing.T) {
 	}
 	if got := len(restarter.startCalls); got != 2 {
 		t.Fatalf("start calls = %d, want 2", got)
+	}
+}
+
+func TestCatalogPollerAtRetryLimitRecordsObservedConvergence(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	services := testutil.NewStubServices(t)
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	if _, err := services.AppVersionChangeRequests.AppendRequest(ctx, &core.AppVersionChangeRequest{
+		App:         "g-issues",
+		FromVersion: "previous",
+		ToVersion:   "v1",
+		Timestamp:   now,
+		Metadata:    map[string]any{"registry": "toolshed"},
+	}); err != nil {
+		t.Fatalf("AppendRequest: %v", err)
+	}
+	if _, err := services.AppInstanceMaterializations.Acknowledge(ctx, &core.AppInstanceMaterialization{
+		InstanceID:     "replica-a",
+		App:            "g-issues",
+		Version:        "v1",
+		AcknowledgedAt: now,
+	}); err != nil {
+		t.Fatalf("Acknowledge: %v", err)
+	}
+	if _, err := services.AppInstanceMaterializations.MarkMaterialized(ctx, "replica-a", "g-issues", "v1", now); err != nil {
+		t.Fatalf("MarkMaterialized: %v", err)
+	}
+	if _, err := services.AppInstanceMaterializations.RecordFailure(ctx, "replica-a", "g-issues", "v1", now, "prior failure"); err != nil {
+		t.Fatalf("RecordFailure: %v", err)
+	}
+	restarter := &recordingAppRestarter{runningVersion: "v1"}
+	poller := NewCatalogPoller(CatalogPollerConfig{
+		ChangeRequests:       services.AppVersionChangeRequests,
+		Materializations:     services.AppInstanceMaterializations,
+		Rollouts:             services.AppRollouts,
+		AppRestarter:         restarter,
+		InstanceID:           "replica-a",
+		MaxReconcileAttempts: 1,
+		Now:                  func() time.Time { return now },
+	})
+
+	if err := poller.ReconcileOnce(ctx); err != nil {
+		t.Fatalf("ReconcileOnce: %v", err)
+	}
+	row, err := services.AppInstanceMaterializations.Get(ctx, "replica-a", "g-issues", "v1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if row.RestartedAt.IsZero() {
+		t.Fatal("RestartedAt is zero")
+	}
+	if len(restarter.stopCalls) != 0 || len(restarter.startCalls) != 0 {
+		t.Fatalf("unexpected restart calls: stop=%v start=%v", restarter.stopCalls, restarter.startCalls)
 	}
 }
 

--- a/gestaltd/internal/bootstrap/app_provider_restart.go
+++ b/gestaltd/internal/bootstrap/app_provider_restart.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -36,9 +38,12 @@ type AppProviderRestarter struct {
 	authBuilds       []*preparedProviderBuilds
 	lifecycles       *appProviderLifecycles
 	registryResolver RegistryInstalledResolver
+	artifactsDir     string
+	fatal            func(error)
 	held             map[string]func()
 	closing          map[string]pendingProviderClose
 	closeFailures    map[string]error
+	runningVersions  map[string]string
 
 	lifecycleMu sync.Mutex
 }
@@ -50,6 +55,8 @@ type AppProviderRestarterConfig struct {
 	AuthBuilds       []*preparedProviderBuilds
 	Lifecycles       *appProviderLifecycles
 	RegistryResolver RegistryInstalledResolver
+	ArtifactsDir     string
+	Fatal            func(error)
 }
 
 func NewAppProviderRestarter(cfg AppProviderRestarterConfig) *AppProviderRestarter {
@@ -60,9 +67,12 @@ func NewAppProviderRestarter(cfg AppProviderRestarterConfig) *AppProviderRestart
 		authBuilds:       cfg.AuthBuilds,
 		lifecycles:       cfg.Lifecycles,
 		registryResolver: cfg.RegistryResolver,
+		artifactsDir:     strings.TrimSpace(cfg.ArtifactsDir),
+		fatal:            cfg.Fatal,
 		held:             make(map[string]func()),
 		closing:          make(map[string]pendingProviderClose),
 		closeFailures:    make(map[string]error),
+		runningVersions:  make(map[string]string),
 	}
 }
 
@@ -105,24 +115,35 @@ func (r *AppProviderRestarter) StopApp(ctx context.Context, app string) error {
 		return fmt.Errorf("stop app provider: wait for provider lifecycle: %w", err)
 	}
 	if pending, ok := r.closing[app]; ok {
-		return r.awaitProviderClose(ctx, app, pending)
+		err := r.awaitProviderClose(ctx, app, pending)
+		if err != nil {
+			r.releaseLifecycleLease(app)
+		}
+		return err
 	}
 	if closeErr, ok := r.closeFailures[app]; ok {
+		r.releaseLifecycleLease(app)
 		return fmt.Errorf("stop app provider %q: previous close failed: %w", app, closeErr)
 	}
 
 	provider, err := r.providers.Get(app)
 	if err != nil {
 		if errors.Is(err, core.ErrNotFound) {
+			r.clearRunningVersion(app)
 			return nil
 		}
 		r.releaseLifecycleLease(app)
 		return fmt.Errorf("stop app provider: %w", err)
 	}
 	r.providers.Remove(app)
+	r.clearRunningVersion(app)
 	pending := pendingProviderClose{provider: provider, done: closeProviderForRestart(provider)}
 	r.closing[app] = pending
-	return r.awaitProviderClose(ctx, app, pending)
+	err = r.awaitProviderClose(ctx, app, pending)
+	if err != nil {
+		r.releaseLifecycleLease(app)
+	}
+	return err
 }
 
 func (r *AppProviderRestarter) StartApp(ctx context.Context, app, version string) error {
@@ -149,10 +170,26 @@ func (r *AppProviderRestarter) StartApp(ctx context.Context, app, version string
 	if err := r.ensureLifecycleLease(ctx, app); err != nil {
 		return fmt.Errorf("start app provider: wait for provider lifecycle: %w", err)
 	}
+	defer r.releaseLifecycleLease(app)
 
-	if _, getErr := r.providers.Get(app); getErr == nil {
-		r.releaseLifecycleLease(app)
-		return nil
+	if provider, getErr := r.providers.Get(app); getErr == nil {
+		if runningVersion, ok := r.runningVersions[app]; ok && runningVersion == version {
+			r.releaseLifecycleLease(app)
+			return nil
+		}
+		if !entry.Source.IsRegistry() {
+			if _, tracked := r.runningVersions[app]; !tracked {
+				r.releaseLifecycleLease(app)
+				return nil
+			}
+		}
+		r.providers.Remove(app)
+		r.clearRunningVersion(app)
+		pending := pendingProviderClose{provider: provider, done: closeProviderForRestart(provider)}
+		r.closing[app] = pending
+		if err := r.awaitProviderClose(ctx, app, pending); err != nil {
+			return err
+		}
 	} else if !errors.Is(getErr, core.ErrNotFound) {
 		return fmt.Errorf("start app provider: %w", getErr)
 	}
@@ -182,6 +219,7 @@ func (r *AppProviderRestarter) StartApp(ctx context.Context, app, version string
 	}
 	if err := r.providers.Register(app, result.Provider); err != nil {
 		closeIfPossible(result.Provider)
+		r.clearRunningVersion(app)
 		return fmt.Errorf("start app provider %q: %w", app, err)
 	}
 	r.storeConnectionAuth(app, result)
@@ -192,8 +230,70 @@ func (r *AppProviderRestarter) StartApp(ctx context.Context, app, version string
 		}
 		r.deps.AppWorkflowDeclarations.Set(app, decls)
 	}
+	if version != "" {
+		if err := r.setRunningVersion(app, version); err != nil {
+			r.providers.Remove(app)
+			closeIfPossible(result.Provider)
+			r.clearRunningVersion(app)
+			return fmt.Errorf("start app provider %q: record running version: %w", app, err)
+		}
+	}
 	r.releaseLifecycleLease(app)
 	return nil
+}
+
+func (r *AppProviderRestarter) RunningVersion(app string) (string, bool) {
+	if r == nil {
+		return "", false
+	}
+	r.lifecycleMu.Lock()
+	defer r.lifecycleMu.Unlock()
+	version, ok := r.runningVersions[strings.TrimSpace(app)]
+	return version, ok && version != ""
+}
+
+func (r *AppProviderRestarter) AcceptsRegistry(app, registryName string) bool {
+	if r == nil || r.cfg == nil {
+		return false
+	}
+	entry := r.cfg.Apps[strings.TrimSpace(app)]
+	if entry == nil || !entry.Source.IsRegistry() {
+		return true
+	}
+	return strings.TrimSpace(entry.Source.Registry) == strings.TrimSpace(registryName)
+}
+
+func (r *AppProviderRestarter) setRunningVersion(app, version string) error {
+	app = strings.TrimSpace(app)
+	version = strings.TrimSpace(version)
+	if app == "" || version == "" {
+		return fmt.Errorf("app and version are required")
+	}
+	if r.artifactsDir != "" {
+		dir := filepath.Join(r.artifactsDir, "registry-installed", app)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+		marker := filepath.Join(dir, "active-version")
+		tmp := marker + ".tmp"
+		if err := os.WriteFile(tmp, []byte(version+"\n"), 0o644); err != nil {
+			return err
+		}
+		if err := os.Rename(tmp, marker); err != nil {
+			_ = os.Remove(tmp)
+			return err
+		}
+	}
+	r.runningVersions[app] = version
+	return nil
+}
+
+func (r *AppProviderRestarter) clearRunningVersion(app string) {
+	app = strings.TrimSpace(app)
+	delete(r.runningVersions, app)
+	if r.artifactsDir != "" && app != "" {
+		_ = os.Remove(filepath.Join(r.artifactsDir, "registry-installed", app, "active-version"))
+	}
 }
 
 func (r *AppProviderRestarter) AbortRestarts() {
@@ -253,9 +353,19 @@ func (r *AppProviderRestarter) awaitProviderClose(ctx context.Context, app strin
 			return nil
 		}
 		r.closeFailures[app] = err
-		return fmt.Errorf("stop app provider %q: %w", app, err)
+		closeErr := fmt.Errorf("stop app provider %q: %w", app, err)
+		r.reportFatal(closeErr)
+		return closeErr
 	case <-waitCtx.Done():
-		return fmt.Errorf("stop app provider %q: close did not finish: %w", app, waitCtx.Err())
+		closeErr := fmt.Errorf("stop app provider %q: close did not finish: %w", app, waitCtx.Err())
+		r.reportFatal(closeErr)
+		return closeErr
+	}
+}
+
+func (r *AppProviderRestarter) reportFatal(err error) {
+	if r != nil && r.fatal != nil && err != nil {
+		r.fatal(err)
 	}
 }
 
@@ -271,7 +381,13 @@ func (r *AppProviderRestarter) appEntry(app string) (*config.ProviderEntry, erro
 }
 
 func (r *AppProviderRestarter) resolveRegistryInstall(app string, entry *config.ProviderEntry, version string) (*config.ProviderEntry, error) {
-	if r == nil || r.registryResolver == nil {
+	if r == nil {
+		return entry, nil
+	}
+	if r.registryResolver == nil {
+		if entry != nil && entry.Source.IsRegistry() {
+			return nil, fmt.Errorf("mount registry installed app %q@%s: resolver is not configured", app, version)
+		}
 		return entry, nil
 	}
 	resolved, err := r.registryResolver.ResolveInstalledApp(app, entry, version)
@@ -280,6 +396,9 @@ func (r *AppProviderRestarter) resolveRegistryInstall(app string, entry *config.
 	}
 	if resolved == nil {
 		return nil, fmt.Errorf("mount registry installed app %q@%s: resolver returned nil provider entry", app, version)
+	}
+	if entry != nil && entry.Source.IsRegistry() && resolved.ResolvedManifest == nil {
+		return nil, fmt.Errorf("mount registry installed app %q@%s: materialized package is required", app, version)
 	}
 	return resolved, nil
 }

--- a/gestaltd/internal/bootstrap/app_provider_restart.go
+++ b/gestaltd/internal/bootstrap/app_provider_restart.go
@@ -45,7 +45,7 @@ type AppProviderRestarter struct {
 	closeFailures    map[string]error
 	runningVersions  map[string]string
 
-	lifecycleMu sync.Mutex
+	lifecycleMu sync.RWMutex
 }
 
 type AppProviderRestarterConfig struct {
@@ -130,6 +130,7 @@ func (r *AppProviderRestarter) StopApp(ctx context.Context, app string) error {
 	if err != nil {
 		if errors.Is(err, core.ErrNotFound) {
 			r.clearRunningVersion(app)
+			r.clearRuntimeBindings(app)
 			return nil
 		}
 		r.releaseLifecycleLease(app)
@@ -137,6 +138,7 @@ func (r *AppProviderRestarter) StopApp(ctx context.Context, app string) error {
 	}
 	r.providers.Remove(app)
 	r.clearRunningVersion(app)
+	r.clearRuntimeBindings(app)
 	pending := pendingProviderClose{provider: provider, done: closeProviderForRestart(provider)}
 	r.closing[app] = pending
 	err = r.awaitProviderClose(ctx, app, pending)
@@ -185,6 +187,7 @@ func (r *AppProviderRestarter) StartApp(ctx context.Context, app, version string
 		}
 		r.providers.Remove(app)
 		r.clearRunningVersion(app)
+		r.clearRuntimeBindings(app)
 		pending := pendingProviderClose{provider: provider, done: closeProviderForRestart(provider)}
 		r.closing[app] = pending
 		if err := r.awaitProviderClose(ctx, app, pending); err != nil {
@@ -222,6 +225,15 @@ func (r *AppProviderRestarter) StartApp(ctx context.Context, app, version string
 		r.clearRunningVersion(app)
 		return fmt.Errorf("start app provider %q: %w", app, err)
 	}
+	if version != "" {
+		if err := r.setRunningVersion(app, version); err != nil {
+			r.providers.Remove(app)
+			closeIfPossible(result.Provider)
+			r.clearRunningVersion(app)
+			r.clearRuntimeBindings(app)
+			return fmt.Errorf("start app provider %q: record running version: %w", app, err)
+		}
+	}
 	r.storeConnectionAuth(app, result)
 	if r.deps.AppWorkflowDeclarations != nil {
 		decls := result.WorkflowDeclarations
@@ -229,14 +241,6 @@ func (r *AppProviderRestarter) StartApp(ctx context.Context, app, version string
 			decls = []*proto.WorkflowDefinitionSpec{}
 		}
 		r.deps.AppWorkflowDeclarations.Set(app, decls)
-	}
-	if version != "" {
-		if err := r.setRunningVersion(app, version); err != nil {
-			r.providers.Remove(app)
-			closeIfPossible(result.Provider)
-			r.clearRunningVersion(app)
-			return fmt.Errorf("start app provider %q: record running version: %w", app, err)
-		}
 	}
 	r.releaseLifecycleLease(app)
 	return nil
@@ -246,10 +250,23 @@ func (r *AppProviderRestarter) RunningVersion(app string) (string, bool) {
 	if r == nil {
 		return "", false
 	}
-	r.lifecycleMu.Lock()
-	defer r.lifecycleMu.Unlock()
+	r.lifecycleMu.RLock()
+	defer r.lifecycleMu.RUnlock()
 	version, ok := r.runningVersions[strings.TrimSpace(app)]
 	return version, ok && version != ""
+}
+
+func (r *AppProviderRestarter) WithRunningVersion(app string, fn func(string) error) error {
+	if r == nil || fn == nil {
+		return fmt.Errorf("app runtime state is not configured")
+	}
+	r.lifecycleMu.RLock()
+	defer r.lifecycleMu.RUnlock()
+	version := strings.TrimSpace(r.runningVersions[strings.TrimSpace(app)])
+	if version == "" {
+		return fmt.Errorf("app %q has no running registry version", app)
+	}
+	return fn(version)
 }
 
 func (r *AppProviderRestarter) AcceptsRegistry(app, registryName string) bool {
@@ -406,5 +423,12 @@ func (r *AppProviderRestarter) resolveRegistryInstall(app string, entry *config.
 func (r *AppProviderRestarter) storeConnectionAuth(app string, result *ProviderBuildResult) {
 	for _, builds := range r.authBuilds {
 		builds.storeConnectionAuth(app, result)
+	}
+}
+
+func (r *AppProviderRestarter) clearRuntimeBindings(app string) {
+	r.storeConnectionAuth(app, &ProviderBuildResult{})
+	if r.deps.AppWorkflowDeclarations != nil {
+		r.deps.AppWorkflowDeclarations.Set(app, []*proto.WorkflowDefinitionSpec{})
 	}
 }

--- a/gestaltd/internal/bootstrap/app_provider_restart_test.go
+++ b/gestaltd/internal/bootstrap/app_provider_restart_test.go
@@ -169,6 +169,14 @@ func TestAppProviderRestarterStopQuarantinesProviderWhenCloseFails(t *testing.T)
 	if err := result.AppRestarter.StopApp(context.Background(), "restart-app"); !errors.Is(err, closeErr) {
 		t.Fatalf("StopApp error = %v, want %v", err, closeErr)
 	}
+	select {
+	case fatalErr := <-result.FatalAppProviderState:
+		if !errors.Is(fatalErr, closeErr) {
+			t.Fatalf("fatal error = %v, want %v", fatalErr, closeErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("unrecoverable provider state was not reported")
+	}
 	if _, err := result.Providers.Get("restart-app"); err == nil {
 		t.Fatal("partially closed provider was republished after failed StopApp")
 	}

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -238,41 +238,44 @@ func NewFactoryRegistry() *FactoryRegistry {
 }
 
 type Result struct {
-	Auth                   core.IdentityProvider
-	SelectedAuthProvider   string
-	AuthProviders          map[string]core.IdentityProvider
-	Authorization          map[string]core.AuthorizationProvider
-	Services               *coredata.Services
-	ExtraIndexedDBs        []indexeddb.IndexedDB
-	ExtraCaches            []corecache.Cache
-	S3                     map[string]s3sdk.S3
-	ExtraS3s               []s3sdk.S3
-	ExtraWorkflows         []coreworkflow.Provider
-	ExtraAgents            []coreagent.Provider
-	Providers              *registry.ProviderMap[core.Provider]
-	WorkflowControl        WorkflowControl
-	AgentControl           AgentControl
-	AgentManager           agentmanager.Service
-	StartupProvidersReady  <-chan struct{}
-	ProvidersReady         <-chan struct{}
-	ConnectionAuth         func() map[string]map[string]OAuthHandler
-	ManualConnectionAuth   func() map[string]map[string]ManualTokenExchanger
-	Invoker                invocation.Invoker
-	AppInvocation          invocation.Invoker
-	CapabilityLister       invocation.CapabilityLister
-	AuditSink              core.AuditSink
-	SecretManager          core.SecretManager
-	Telemetry              core.TelemetryProvider
-	Runtimes               RuntimeInspector
-	PublicHostServices     *runtimehost.PublicHostServiceRegistry
-	PublicGatewayTransport *providergateway.ProviderGatewayTransport
-	DevSupervisor          *providerdev.Supervisor
-	AppRestarter           interface {
+	Auth                    core.IdentityProvider
+	SelectedAuthProvider    string
+	AuthProviders           map[string]core.IdentityProvider
+	Authorization           map[string]core.AuthorizationProvider
+	Services                *coredata.Services
+	ExtraIndexedDBs         []indexeddb.IndexedDB
+	ExtraCaches             []corecache.Cache
+	S3                      map[string]s3sdk.S3
+	ExtraS3s                []s3sdk.S3
+	ExtraWorkflows          []coreworkflow.Provider
+	ExtraAgents             []coreagent.Provider
+	Providers               *registry.ProviderMap[core.Provider]
+	WorkflowControl         WorkflowControl
+	AgentControl            AgentControl
+	AgentManager            agentmanager.Service
+	StartupProvidersReady   <-chan struct{}
+	AppProvidersInitialized <-chan struct{}
+	ProvidersReady          <-chan struct{}
+	FatalAppProviderState   <-chan error
+	ConnectionAuth          func() map[string]map[string]OAuthHandler
+	ManualConnectionAuth    func() map[string]map[string]ManualTokenExchanger
+	Invoker                 invocation.Invoker
+	AppInvocation           invocation.Invoker
+	CapabilityLister        invocation.CapabilityLister
+	AuditSink               core.AuditSink
+	SecretManager           core.SecretManager
+	Telemetry               core.TelemetryProvider
+	Runtimes                RuntimeInspector
+	PublicHostServices      *runtimehost.PublicHostServiceRegistry
+	PublicGatewayTransport  *providergateway.ProviderGatewayTransport
+	DevSupervisor           *providerdev.Supervisor
+	AppRestarter            interface {
 		Restartable(string) (bool, error)
 		StopApp(context.Context, string) error
 		StartApp(context.Context, string, string) error
 		AbortRestarts()
 	}
+	RegistryAppStartup func(context.Context)
 
 	runtimeRegistry                     *runtimeRegistry
 	workflowConfigReconcileTasks        []workflowConfigReconcileTask
@@ -284,6 +287,8 @@ type Result struct {
 	auditClose                          func(context.Context) error
 	appHostServiceCleanup               func()
 	startAppProviders                   func()
+	appProvidersInitialized             chan struct{}
+	appProvidersInitializedOnce         sync.Once
 	activateAppProviders                func(context.Context)
 	startup                             *deferredProviders
 	deferred                            *deferredProviders
@@ -319,6 +324,14 @@ func (r *Result) StartAppProviders(ctx context.Context) error {
 			return fmt.Errorf("app provider startup interrupted: %w", ctx.Err())
 		}
 	}
+	if r.RegistryAppStartup != nil {
+		r.RegistryAppStartup(ctx)
+	}
+	r.appProvidersInitializedOnce.Do(func() {
+		if r.appProvidersInitialized != nil {
+			close(r.appProvidersInitialized)
+		}
+	})
 	r.startupWorkflowConfigReconcileOnce.Do(func() {
 		if r.startupWorkflowConfigReconcile != nil {
 			r.startupWorkflowConfigReconcileErr = r.startupWorkflowConfigReconcile(ctx)
@@ -1468,50 +1481,63 @@ func BootstrapWithOptions(ctx context.Context, cfg *config.Config, factories *Fa
 	closeAudit = false
 	closeWorkflowsOnError = false
 	closeAgentsOnError = false
+	fatalAppProviderState := make(chan error, 1)
+	var fatalAppProviderStateOnce sync.Once
+	appRestarter := NewAppProviderRestarter(AppProviderRestarterConfig{
+		Config:           cfg,
+		Deps:             prepared.Deps,
+		Providers:        providers,
+		AuthBuilds:       []*preparedProviderBuilds{noopBuilds, updateBuilds},
+		Lifecycles:       noopBuilds.lifecycles,
+		RegistryResolver: opts.RegistryResolver,
+		ArtifactsDir:     cfg.Server.ArtifactsDir,
+		Fatal: func(err error) {
+			fatalAppProviderStateOnce.Do(func() {
+				fatalAppProviderState <- err
+			})
+		},
+	})
+	appProvidersInitialized := make(chan struct{})
 	result := &Result{
-		Auth:                   prepared.Auth,
-		SelectedAuthProvider:   prepared.SelectedAuthProvider,
-		AuthProviders:          prepared.AuthProviders,
-		Authorization:          prepared.Authorization,
-		Services:               prepared.Services,
-		ExtraIndexedDBs:        prepared.ExtraIndexedDBs,
-		ExtraCaches:            prepared.ExtraCaches,
-		S3:                     prepared.Deps.S3,
-		ExtraS3s:               prepared.ExtraS3s,
-		ExtraWorkflows:         extraWorkflows,
-		ExtraAgents:            extraAgents,
-		Providers:              providers,
-		WorkflowControl:        prepared.Deps.WorkflowRuntime,
-		AgentControl:           prepared.Deps.AgentRuntime,
-		AgentManager:           prepared.Deps.AgentManager,
-		StartupProvidersReady:  startup.ready(),
-		ProvidersReady:         deferred.ready(),
-		ConnectionAuth:         connAuthResolver,
-		ManualConnectionAuth:   manualConnAuthResolver,
-		Invoker:                sharedInvoker,
-		AppInvocation:          pluginInvoker,
-		CapabilityLister:       sharedInvoker,
-		AuditSink:              audit,
-		SecretManager:          prepared.SecretManager,
-		Telemetry:              prepared.Telemetry,
-		Runtimes:               prepared.runtimeRegistry,
-		PublicHostServices:     publicHostServices,
-		PublicGatewayTransport: publicGatewayTransport,
-		DevSupervisor:          prepared.Deps.DevSupervisor,
-		AppRestarter: NewAppProviderRestarter(AppProviderRestarterConfig{
-			Config:           cfg,
-			Deps:             prepared.Deps,
-			Providers:        providers,
-			AuthBuilds:       []*preparedProviderBuilds{noopBuilds, updateBuilds},
-			Lifecycles:       noopBuilds.lifecycles,
-			RegistryResolver: opts.RegistryResolver,
-		}),
+		Auth:                           prepared.Auth,
+		SelectedAuthProvider:           prepared.SelectedAuthProvider,
+		AuthProviders:                  prepared.AuthProviders,
+		Authorization:                  prepared.Authorization,
+		Services:                       prepared.Services,
+		ExtraIndexedDBs:                prepared.ExtraIndexedDBs,
+		ExtraCaches:                    prepared.ExtraCaches,
+		S3:                             prepared.Deps.S3,
+		ExtraS3s:                       prepared.ExtraS3s,
+		ExtraWorkflows:                 extraWorkflows,
+		ExtraAgents:                    extraAgents,
+		Providers:                      providers,
+		WorkflowControl:                prepared.Deps.WorkflowRuntime,
+		AgentControl:                   prepared.Deps.AgentRuntime,
+		AgentManager:                   prepared.Deps.AgentManager,
+		StartupProvidersReady:          startup.ready(),
+		AppProvidersInitialized:        appProvidersInitialized,
+		ProvidersReady:                 deferred.ready(),
+		FatalAppProviderState:          fatalAppProviderState,
+		ConnectionAuth:                 connAuthResolver,
+		ManualConnectionAuth:           manualConnAuthResolver,
+		Invoker:                        sharedInvoker,
+		AppInvocation:                  pluginInvoker,
+		CapabilityLister:               sharedInvoker,
+		AuditSink:                      audit,
+		SecretManager:                  prepared.SecretManager,
+		Telemetry:                      prepared.Telemetry,
+		Runtimes:                       prepared.runtimeRegistry,
+		PublicHostServices:             publicHostServices,
+		PublicGatewayTransport:         publicGatewayTransport,
+		DevSupervisor:                  prepared.Deps.DevSupervisor,
+		AppRestarter:                   appRestarter,
 		runtimeRegistry:                prepared.runtimeRegistry,
 		workflowConfigReconcileTasks:   deferredWorkflowConfigReconcileTasks,
 		startupWorkflowConfigReconcile: startupWorkflowConfigReconcile,
 		auditClose:                     auditClose,
 		appHostServiceCleanup:          appHostServiceCleanup,
 		startAppProviders:              startAppProviders,
+		appProvidersInitialized:        appProvidersInitialized,
 		activateAppProviders:           activateAppProviders,
 		startup:                        startup,
 		deferred:                       deferred,

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -105,6 +105,9 @@ func prepareProviderBuilds(
 
 	for name := range cfg.Apps {
 		entry := cfg.Apps[name]
+		if entry != nil && entry.Source.IsRegistry() {
+			continue
+		}
 		if !providerBuildsLocal(cfg, entry) {
 			continue
 		}
@@ -144,7 +147,7 @@ func registerRemoteApps(providers *registry.ProviderMap[core.Provider], cfg *con
 	}
 	for name, entry := range cfg.Apps {
 		name = strings.TrimSpace(name)
-		if name == "" || entry == nil || providerBuildsLocal(cfg, entry) {
+		if name == "" || entry == nil || entry.Source.IsRegistry() || providerBuildsLocal(cfg, entry) {
 			continue
 		}
 		spec, _, err := buildStartupProviderSpec(name, entry)

--- a/gestaltd/internal/bootstrap/validate.go
+++ b/gestaltd/internal/bootstrap/validate.go
@@ -155,6 +155,9 @@ func buildProvidersStrict(ctx context.Context, cfg *config.Config, factories *Fa
 	var errs []error
 	for _, name := range names {
 		entry := cfg.Apps[name]
+		if entry != nil && entry.Source.IsRegistry() {
+			continue
+		}
 		result, err := buildProviderForValidation(ctx, name, entry, deps)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("integration %q: %w", name, err))

--- a/gestaltd/internal/config/app_registry_step12_test.go
+++ b/gestaltd/internal/config/app_registry_step12_test.go
@@ -1,0 +1,82 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRegistryOnlyAppSourceValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("accepts configured registry and defaults retries", func(t *testing.T) {
+		path := mustWriteConfigFile(t, `
+appRegistries:
+  toolshed:
+    kind: gcs
+    gcs:
+      bucket: test-registry
+apps:
+  g-issues:
+    source:
+      registry: toolshed
+server: {}
+`)
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if got := cfg.Apps["g-issues"].Source.Registry; got != "toolshed" {
+			t.Fatalf("source.registry = %q", got)
+		}
+		if got := cfg.Server.AppRegistry.MaxReconcileAttempts; got != DefaultAppRegistryMaxReconcileAttempts {
+			t.Fatalf("maxReconcileAttempts = %d", got)
+		}
+	})
+
+	for _, tc := range []struct {
+		name    string
+		source  string
+		wantErr string
+	}{
+		{"unknown registry", "registry: missing", `references unknown app registry "missing"`},
+		{"mixed source modes", "registry: toolshed\n      path: ./app", "mutually exclusive"},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			path := mustWriteConfigFile(t, `
+appRegistries:
+  toolshed:
+    kind: gcs
+    gcs:
+      bucket: test-registry
+apps:
+  g-issues:
+    source:
+      `+tc.source+`
+server: {}
+`)
+			_, err := Load(path)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("Load error = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestAppRegistryMaxReconcileAttemptsValidation(t *testing.T) {
+	t.Parallel()
+	for _, value := range []string{"0", "-1"} {
+		value := value
+		t.Run(value, func(t *testing.T) {
+			path := mustWriteConfigFile(t, `
+server:
+  appRegistry:
+    maxReconcileAttempts: `+value+`
+`)
+			_, err := Load(path)
+			if err == nil || !strings.Contains(err.Error(), "must be a positive integer") {
+				t.Fatalf("Load error = %v", err)
+			}
+		})
+	}
+}

--- a/gestaltd/internal/config/app_registry_step12_test.go
+++ b/gestaltd/internal/config/app_registry_step12_test.go
@@ -9,6 +9,7 @@ func TestRegistryOnlyAppSourceValidation(t *testing.T) {
 	t.Parallel()
 
 	t.Run("accepts configured registry and defaults retries", func(t *testing.T) {
+		t.Parallel()
 		path := mustWriteConfigFile(t, `
 appRegistries:
   toolshed:
@@ -43,6 +44,7 @@ server: {}
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			path := mustWriteConfigFile(t, `
 appRegistries:
   toolshed:
@@ -68,6 +70,7 @@ func TestAppRegistryMaxReconcileAttemptsValidation(t *testing.T) {
 	for _, value := range []string{"0", "-1"} {
 		value := value
 		t.Run(value, func(t *testing.T) {
+			t.Parallel()
 			path := mustWriteConfigFile(t, `
 server:
   appRegistry:

--- a/gestaltd/internal/config/app_validation.go
+++ b/gestaltd/internal/config/app_validation.go
@@ -10,6 +10,9 @@ func AppValidationConfig(cfg *Config) *appservice.ValidationConfig {
 		Apps: make(map[string]*appservice.ValidationApp, len(cfg.Apps)),
 	}
 	for name, entry := range cfg.Apps {
+		if entry != nil && entry.Source.IsRegistry() {
+			continue
+		}
 		validation.Apps[name] = AppValidationEntry(entry)
 	}
 	return validation

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -163,6 +163,7 @@ type ServerProvidersConfig struct {
 //   - Metadata: source: "https://.../provider-release.yaml"  -> ProviderSource{metadataURL: "..."}
 //   - GitHub:   source: {githubRelease: {repo, tag, asset}}  -> ProviderSource{GitHubRelease: ...}
 //   - Git:      source: {git: {repo, ref, path}} -> ProviderSource{Git: ...}
+//   - Registry: source: {registry: name} -> ProviderSource{Registry: "name"}
 //   - Local:    source: {path} or source: "./manifest.yaml"  -> ProviderSource{Path: "..."}
 //   - Local metadata: source: {path} or source: "./dist/provider-release.yaml"
 //     -> ProviderSource{metadataPath: "..."}
@@ -179,6 +180,7 @@ type ProviderSource struct {
 	unsupported         string                  `yaml:"-"`
 	GitHubRelease       *GitHubReleaseSourceDef `yaml:"githubRelease,omitempty"`
 	Git                 *GitSourceDef           `yaml:"git,omitempty"`
+	Registry            string                  `yaml:"registry,omitempty"`
 	Path                string                  `yaml:"path,omitempty"`
 	Auth                *SourceAuthDef          `yaml:"auth,omitempty"`
 }
@@ -190,6 +192,7 @@ type providerSourceYAML struct {
 	Version       string                  `yaml:"version,omitempty"`
 	GitHubRelease *GitHubReleaseSourceDef `yaml:"githubRelease,omitempty"`
 	Git           *GitSourceDef           `yaml:"git,omitempty"`
+	Registry      string                  `yaml:"registry,omitempty"`
 	Path          string                  `yaml:"path,omitempty"`
 	Auth          *SourceAuthDef          `yaml:"auth,omitempty"`
 }
@@ -233,6 +236,7 @@ func (s *ProviderSource) UnmarshalYAML(value *yaml.Node) error {
 		}
 		s.GitHubRelease = cloneGitHubReleaseSourceDef(raw.GitHubRelease)
 		s.Git = cloneGitSourceDef(raw.Git)
+		s.Registry = strings.TrimSpace(raw.Registry)
 		s.Path = strings.TrimSpace(raw.Path)
 		s.metadataURL = strings.TrimSpace(raw.URL)
 		s.packageRepo = strings.TrimSpace(raw.Repo)
@@ -247,6 +251,7 @@ func (s *ProviderSource) UnmarshalYAML(value *yaml.Node) error {
 	}
 	s.GitHubRelease = cloneGitHubReleaseSourceDef(raw.GitHubRelease)
 	s.Git = cloneGitSourceDef(raw.Git)
+	s.Registry = strings.TrimSpace(raw.Registry)
 	s.Path = strings.TrimSpace(raw.Path)
 	s.metadataURL = strings.TrimSpace(raw.URL)
 	s.packageRepo = strings.TrimSpace(raw.Repo)
@@ -284,6 +289,9 @@ func (s ProviderSource) MarshalYAML() (any, error) {
 			Auth: auth,
 		}, nil
 	}
+	if s.Registry != "" && s.Path == "" && s.metadataPath == "" && s.metadataURL == "" && s.packageName == "" && s.GitHubRelease == nil && s.Git == nil {
+		return providerSourceYAML{Registry: strings.TrimSpace(s.Registry)}, nil
+	}
 	if s.scalar != "" && s.Path == "" && s.metadataPath == "" && auth == nil {
 		return s.scalar, nil
 	}
@@ -297,6 +305,7 @@ func (s ProviderSource) MarshalYAML() (any, error) {
 		Version:       strings.TrimSpace(s.packageVersion),
 		GitHubRelease: cloneGitHubReleaseSourceDef(s.GitHubRelease),
 		Git:           cloneGitSourceDef(s.Git),
+		Registry:      strings.TrimSpace(s.Registry),
 		Path:          s.Path,
 		Auth:          auth,
 	}, nil
@@ -306,6 +315,7 @@ func (s ProviderSource) IsBuiltin() bool       { return s.Builtin != "" }
 func (s ProviderSource) IsMetadataURL() bool   { return s.metadataURL != "" }
 func (s ProviderSource) IsGitHubRelease() bool { return s.GitHubRelease != nil }
 func (s ProviderSource) IsGit() bool           { return s.Git != nil }
+func (s ProviderSource) IsRegistry() bool      { return strings.TrimSpace(s.Registry) != "" }
 func (s ProviderSource) IsPackage() bool       { return s.packageName != "" }
 func (s ProviderSource) IsLocal() bool         { return s.Path != "" }
 func (s ProviderSource) IsLocalMetadataPath() bool {
@@ -1948,6 +1958,24 @@ type ServerAppRegistryConfig struct {
 	// RestartDelay is empty in production for no intentional outage. Early
 	// rollout environments may set a duration such as "1m" for observation.
 	RestartDelay string `yaml:"restartDelay,omitempty"`
+	// MaxReconcileAttempts bounds failed convergence attempts per app/version.
+	// Omission defaults to DefaultAppRegistryMaxReconcileAttempts.
+	MaxReconcileAttempts    int  `yaml:"maxReconcileAttempts,omitempty"`
+	maxReconcileAttemptsSet bool `yaml:"-"`
+}
+
+const DefaultAppRegistryMaxReconcileAttempts = 3
+
+type serverAppRegistryConfigFields ServerAppRegistryConfig
+
+func (c *ServerAppRegistryConfig) UnmarshalYAML(value *yaml.Node) error {
+	var decoded serverAppRegistryConfigFields
+	if err := decodeYAMLNodeKnownFields(value, &decoded); err != nil {
+		return err
+	}
+	*c = ServerAppRegistryConfig(decoded)
+	c.maxReconcileAttemptsSet = mappingValueNode(value, "maxReconcileAttempts") != nil
+	return nil
 }
 
 type ServerAgentConfig struct{}

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -82,6 +82,9 @@ func ValidateCanonicalStructure(cfg *Config) error {
 	if err := validateAppRegistries(cfg); err != nil {
 		return err
 	}
+	if err := validateServerAppRegistry(cfg); err != nil {
+		return err
+	}
 
 	for _, collection := range []struct {
 		kind    HostProviderKind
@@ -221,6 +224,21 @@ func validateAppRegistryLocation(prefix, name string, registry AppRegistryConfig
 	}
 	if _, err := registry.PublicURL(); err != nil {
 		return fmt.Errorf("config validation: %s.%s: %w", prefix, name, err)
+	}
+	return nil
+}
+
+func validateServerAppRegistry(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	attempts := cfg.Server.AppRegistry.MaxReconcileAttempts
+	if !cfg.Server.AppRegistry.maxReconcileAttemptsSet && attempts == 0 {
+		cfg.Server.AppRegistry.MaxReconcileAttempts = DefaultAppRegistryMaxReconcileAttempts
+		return nil
+	}
+	if attempts <= 0 {
+		return fmt.Errorf("config validation: server.appRegistry.maxReconcileAttempts must be a positive integer")
 	}
 	return nil
 }
@@ -567,6 +585,9 @@ func validateProviderEntrySource(kind, name string, entry *ProviderEntry) error 
 	if src.IsGit() {
 		modeCount++
 	}
+	if src.IsRegistry() {
+		modeCount++
+	}
 	if src.IsPackage() {
 		modeCount++
 	}
@@ -578,6 +599,9 @@ func validateProviderEntrySource(kind, name string, entry *ProviderEntry) error 
 	}
 	if modeCount > 1 {
 		return fmt.Errorf("config validation: %s %q source.path and metadata URL sources are mutually exclusive", kind, name)
+	}
+	if src.IsRegistry() && kind != "app" {
+		return fmt.Errorf("config validation: %s %q source.registry is only supported on apps", kind, name)
 	}
 	if src.IsLocalMetadataPath() {
 		if path.Base(filepath.ToSlash(src.MetadataPath())) != "provider-release.yaml" {
@@ -945,6 +969,12 @@ func validateApp(cfg *Config, name string, entry *ProviderEntry) error {
 	}
 	if err := validateProviderEntrySource("app", name, entry); err != nil {
 		return err
+	}
+	if entry.Source.IsRegistry() {
+		registryName := strings.TrimSpace(entry.Source.Registry)
+		if _, ok := cfg.AppRegistries[registryName]; !ok {
+			return fmt.Errorf("config validation: apps.%s.source.registry references unknown app registry %q", name, registryName)
+		}
 	}
 	if err := validateAppRouteAuth(cfg, name, entry); err != nil {
 		return err

--- a/gestaltd/internal/coredata/app_instance_materializations.go
+++ b/gestaltd/internal/coredata/app_instance_materializations.go
@@ -15,11 +15,12 @@ import (
 )
 
 type AppInstanceMaterializationService struct {
+	db    indexeddb.IndexedDB
 	store idb.ObjectStore
 }
 
 func NewAppInstanceMaterializationService(ds indexeddb.IndexedDB) *AppInstanceMaterializationService {
-	return &AppInstanceMaterializationService{store: ds.ObjectStore(StoreAppInstanceMaterializations)}
+	return &AppInstanceMaterializationService{db: ds, store: ds.ObjectStore(StoreAppInstanceMaterializations)}
 }
 
 func (s *AppInstanceMaterializationService) HasAcknowledged(ctx context.Context, instanceID, app, version string) (bool, error) {
@@ -99,6 +100,7 @@ func (s *AppInstanceMaterializationService) Acknowledge(ctx context.Context, mat
 		"app":             app,
 		"version":         version,
 		"acknowledged_at": acknowledgedAt,
+		"attempt_count":   0,
 	}
 	if err := s.store.Add(ctx, rec); err != nil {
 		if errors.Is(err, idb.ErrAlreadyExists) {
@@ -149,6 +151,46 @@ func (s *AppInstanceMaterializationService) MarkRestarted(ctx context.Context, i
 	})
 }
 
+func (s *AppInstanceMaterializationService) RecordFailure(ctx context.Context, instanceID, app, version string, failedAt time.Time, message string) (*core.AppInstanceMaterialization, error) {
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("record app instance materialization failure: service is not configured")
+	}
+	tx, err := s.db.Transaction(ctx, []string{StoreAppInstanceMaterializations}, idb.TransactionReadwrite, idb.TransactionOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("record app instance materialization failure: begin transaction: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Abort(context.WithoutCancel(ctx))
+		}
+	}()
+	store := tx.ObjectStore(StoreAppInstanceMaterializations)
+	query := idb.Bound([]any{strings.TrimSpace(instanceID), strings.TrimSpace(app), strings.TrimSpace(version)}, []any{strings.TrimSpace(instanceID), strings.TrimSpace(app), strings.TrimSpace(version)}, false, false)
+	recs, err := store.Index("by_instance_app_version").GetAll(ctx, query)
+	if err != nil || len(recs) == 0 {
+		if err == nil {
+			err = idb.ErrNotFound
+		}
+		return nil, fmt.Errorf("record app instance materialization failure: load record: %w", err)
+	}
+	rec := recs[0]
+	rec["attempt_count"] = recordInt(rec, "attempt_count") + 1
+	if failedAt.IsZero() {
+		failedAt = time.Now()
+	}
+	rec["last_error_at"] = failedAt.UTC().Truncate(time.Millisecond)
+	rec["last_error_message"] = strings.TrimSpace(message)
+	if err := store.Put(ctx, rec); err != nil {
+		return nil, fmt.Errorf("record app instance materialization failure: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("record app instance materialization failure: commit: %w", err)
+	}
+	committed = true
+	return recordToAppInstanceMaterialization(rec), nil
+}
+
 func (s *AppInstanceMaterializationService) updateTimestamps(
 	ctx context.Context,
 	instanceID, app, version string,
@@ -193,12 +235,30 @@ func (s *AppInstanceMaterializationService) findByInstanceAppVersion(ctx context
 
 func recordToAppInstanceMaterialization(rec idb.Record) *core.AppInstanceMaterialization {
 	return &core.AppInstanceMaterialization{
-		InstanceID:     recString(rec, "instance_id"),
-		App:            recString(rec, "app"),
-		Version:        recString(rec, "version"),
-		AcknowledgedAt: recTime(rec, "acknowledged_at"),
-		MaterializedAt: recTime(rec, "materialized_at"),
-		StoppedAt:      recTime(rec, "stopped_at"),
-		RestartedAt:    recTime(rec, "restarted_at"),
+		InstanceID:       recString(rec, "instance_id"),
+		App:              recString(rec, "app"),
+		Version:          recString(rec, "version"),
+		AcknowledgedAt:   recTime(rec, "acknowledged_at"),
+		MaterializedAt:   recTime(rec, "materialized_at"),
+		StoppedAt:        recTime(rec, "stopped_at"),
+		RestartedAt:      recTime(rec, "restarted_at"),
+		AttemptCount:     recordInt(rec, "attempt_count"),
+		LastErrorAt:      recTime(rec, "last_error_at"),
+		LastErrorMessage: recString(rec, "last_error_message"),
+	}
+}
+
+func recordInt(rec idb.Record, key string) int {
+	switch value := rec[key].(type) {
+	case int:
+		return value
+	case int32:
+		return int(value)
+	case int64:
+		return int(value)
+	case float64:
+		return int(value)
+	default:
+		return 0
 	}
 }

--- a/gestaltd/internal/coredata/app_instance_materializations_failure_test.go
+++ b/gestaltd/internal/coredata/app_instance_materializations_failure_test.go
@@ -1,0 +1,36 @@
+package coredata_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+)
+
+func TestAppInstanceMaterializationRecordFailure(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	svc := testutil.NewStubServices(t)
+	if _, err := svc.AppInstanceMaterializations.Acknowledge(ctx, &core.AppInstanceMaterialization{
+		InstanceID: "replica-a", App: "g-issues", Version: "1.0.0",
+	}); err != nil {
+		t.Fatalf("Acknowledge: %v", err)
+	}
+	failedAt := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	for i := 1; i <= 2; i++ {
+		got, err := svc.AppInstanceMaterializations.RecordFailure(
+			ctx, "replica-a", "g-issues", "1.0.0", failedAt, "start failed",
+		)
+		if err != nil {
+			t.Fatalf("RecordFailure: %v", err)
+		}
+		if got.AttemptCount != i {
+			t.Fatalf("AttemptCount = %d, want %d", got.AttemptCount, i)
+		}
+		if got.LastErrorAt != failedAt || got.LastErrorMessage != "start failed" {
+			t.Fatalf("failure fields = %#v", got)
+		}
+	}
+}

--- a/gestaltd/internal/coredata/app_version_change_requests_projection.go
+++ b/gestaltd/internal/coredata/app_version_change_requests_projection.go
@@ -136,7 +136,10 @@ func LatestKnownVersion(installations []*core.AppInstallation) string {
 		if installation == nil {
 			continue
 		}
-		if latest == nil || installation.UpdatedAt.After(latest.UpdatedAt) {
+		if latest == nil ||
+			installation.UpdatedAt.After(latest.UpdatedAt) ||
+			(installation.UpdatedAt.Equal(latest.UpdatedAt) &&
+				strings.TrimSpace(installation.Version) > strings.TrimSpace(latest.Version)) {
 			latest = installation
 		}
 	}

--- a/gestaltd/internal/coredata/app_version_change_requests_projection_test.go
+++ b/gestaltd/internal/coredata/app_version_change_requests_projection_test.go
@@ -1,0 +1,24 @@
+package coredata_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
+)
+
+func TestLatestKnownVersionBreaksTimestampTiesLexicographically(t *testing.T) {
+	t.Parallel()
+	at := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	lower := &core.AppInstallation{Version: "1.0.0", UpdatedAt: at}
+	higher := &core.AppInstallation{Version: "2.0.0", UpdatedAt: at}
+	for _, installations := range [][]*core.AppInstallation{
+		{lower, higher},
+		{higher, lower},
+	} {
+		if got := coredata.LatestKnownVersion(installations); got != "2.0.0" {
+			t.Fatalf("LatestKnownVersion = %q, want 2.0.0", got)
+		}
+	}
+}

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -121,6 +121,9 @@ var AppInstanceMaterializationsSchema = idb.ObjectStoreOptions{
 		{Name: "materialized_at", Type: idb.TypeTime},
 		{Name: "stopped_at", Type: idb.TypeTime},
 		{Name: "restarted_at", Type: idb.TypeTime},
+		{Name: "attempt_count", Type: idb.TypeInt},
+		{Name: "last_error_at", Type: idb.TypeTime},
+		{Name: "last_error_message", Type: idb.TypeString},
 	},
 }
 

--- a/gestaltd/internal/operator/app_registry_step12_test.go
+++ b/gestaltd/internal/operator/app_registry_step12_test.go
@@ -1,0 +1,57 @@
+package operator
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRegistryOnlyAppLockAndSyncSkipArtifacts(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "gestalt.yaml")
+	lockPath := filepath.Join(dir, LockfileName)
+	artifactsDir := filepath.Join(dir, "artifacts")
+	configYAML := fmt.Sprintf(`
+apiVersion: gestaltd.config/v8
+%s
+appRegistries:
+  toolshed:
+    kind: gcs
+    gcs:
+      bucket: test-registry
+apps:
+  g-issues:
+    source:
+      registry: toolshed
+server:
+  providers:
+    indexeddb: sqlite
+  artifactsDir: %s
+  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`, requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")), filepath.ToSlash(artifactsDir))
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	lifecycle := NewLifecycle()
+	lock, err := lifecycle.LockAtPaths([]string{configPath}, lockPath, artifactsDir)
+	if err != nil {
+		t.Fatalf("LockAtPaths: %v", err)
+	}
+	entry := lock.Providers.App["g-issues"]
+	if entry.Source != "registry" || entry.SourceRef == nil ||
+		entry.SourceRef.Type != "registry" || entry.SourceRef.ResolvedGestaltRef != "toolshed" {
+		t.Fatalf("lock entry = %#v", entry)
+	}
+	if len(entry.Archives) != 0 {
+		t.Fatalf("archives = %#v", entry.Archives)
+	}
+	if err := lifecycle.SyncAtPathsOptions([]string{configPath}, lockPath, artifactsDir, SyncOptions{Locked: true}); err != nil {
+		t.Fatalf("SyncAtPathsOptions: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(artifactsDir, PreparedProvidersDir, "g-issues")); !os.IsNotExist(err) {
+		t.Fatalf("registry app artifact was materialized: %v", err)
+	}
+}

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -483,6 +483,10 @@ func (l *Lifecycle) prepareCommittedRuntimeLockFromLoadedConfig(ctx context.Cont
 		if !providerRequiresCommittedLock(entry) {
 			continue
 		}
+		if entry.Source.IsRegistry() {
+			lock.Providers.App[name] = registryOnlyLockEntry(entry)
+			continue
+		}
 		configMap, err := config.NodeToMap(entry.Config)
 		if err != nil {
 			return nil, fmt.Errorf("decode provider config for provider %q: %w", name, err)
@@ -633,6 +637,12 @@ func (l *Lifecycle) prepareRuntimeLockFromLoadedConfigWithSecretMode(ctx context
 	lock := newLockfile()
 	for name, entry := range cfg.Apps {
 		if entry == nil || !sourceBacked(entry) || entry.HasLocalSource() {
+			continue
+		}
+		if entry.Source.IsRegistry() {
+			if providerRequiresCommittedLock(entry) {
+				lock.Providers.App[name] = registryOnlyLockEntry(entry)
+			}
 			continue
 		}
 		configMap, err := config.NodeToMap(entry.Config)
@@ -1741,7 +1751,21 @@ type providerFingerprintInput struct {
 }
 
 func sourceBacked(entry *config.ProviderEntry) bool {
-	return entry != nil && (entry.HasRemoteSource() || entry.HasLocalSource() || entry.HasLocalReleaseSource())
+	return entry != nil && (entry.Source.IsRegistry() || entry.HasRemoteSource() || entry.HasLocalSource() || entry.HasLocalReleaseSource())
+}
+
+func registryOnlyLockEntry(entry *config.ProviderEntry) LockEntry {
+	registryName := ""
+	if entry != nil {
+		registryName = strings.TrimSpace(entry.Source.Registry)
+	}
+	return LockEntry{
+		Source: "registry",
+		SourceRef: &LockSourceRef{
+			Type:               "registry",
+			ResolvedGestaltRef: registryName,
+		},
+	}
 }
 
 func runtimeSourceBacked(entry *config.RuntimeProviderEntry) bool {
@@ -2378,6 +2402,13 @@ func lockFreshForConfig(cfg *config.Config, paths lifecyclePaths, lock *Lockfile
 }
 
 func lockEntryFresh(paths lifecyclePaths, kind, name string, provider *config.ProviderEntry, entry LockEntry, found bool, destDir string, opts lockFreshnessOptions) bool {
+	if provider != nil && provider.Source.IsRegistry() {
+		expected := registryOnlyLockEntry(provider)
+		return found && entry.Source == expected.Source && entry.SourceRef != nil &&
+			entry.SourceRef.Type == expected.SourceRef.Type &&
+			entry.SourceRef.ResolvedGestaltRef == expected.SourceRef.ResolvedGestaltRef &&
+			len(entry.Archives) == 0
+	}
 	if opts.RequireArtifacts {
 		return lockEntryMatches(paths, kind, name, provider, entry, found, destDir)
 	}
@@ -3424,7 +3455,7 @@ func effectiveCatalogsForCommittedLock(ctx context.Context, cfg *config.Config, 
 		Apps: make(map[string]*appservice.ValidationApp, len(cfg.Apps)),
 	}
 	for name, entry := range cfg.Apps {
-		if entry == nil {
+		if entry == nil || entry.Source.IsRegistry() {
 			continue
 		}
 		if _, locked := lock.Providers.App[name]; locked {
@@ -3589,7 +3620,7 @@ func (l *Lifecycle) applyStaticValidationProviders(ctx context.Context, paths li
 		return nil
 	}
 	for name, entry := range cfg.Apps {
-		if entry == nil {
+		if entry == nil || entry.Source.IsRegistry() {
 			continue
 		}
 		configMap, err := config.NodeToMap(entry.Config)
@@ -3856,7 +3887,7 @@ func (l *Lifecycle) resolveConfiguredPluginsWithOptions(paths lifecyclePaths, lo
 	}
 	l.prefetchLockedAppMaterializedCache(paths, lock, cfg, mode, opts.Parallelism)
 	for _, work := range ordered {
-		if work.entry.HasLocalSource() || work.entry.DevActive || !sourceBacked(work.entry) {
+		if work.entry.Source.IsRegistry() || work.entry.HasLocalSource() || work.entry.DevActive || !sourceBacked(work.entry) {
 			continue
 		}
 		if err := l.applyLockedProviderEntry(paths, lock, work.name, work.entry, work.configMap, mode); err != nil {
@@ -3896,7 +3927,7 @@ func (l *Lifecycle) resolveConfiguredAppStaticBindings(paths lifecyclePaths, wor
 }
 
 func materializeAppStaticRoot(paths lifecyclePaths, name string, entry *config.ProviderEntry) error {
-	if entry == nil || entry.Static == nil || entry.DevActive {
+	if entry == nil || entry.Static == nil || entry.DevActive || entry.Source.IsRegistry() {
 		return nil
 	}
 	if strings.TrimSpace(entry.ResolvedStaticRoot) != "" {

--- a/gestaltd/internal/server/app_registry_step12_test.go
+++ b/gestaltd/internal/server/app_registry_step12_test.go
@@ -1,0 +1,97 @@
+package server_test
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/appregistry/registrytest"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/server"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+func TestRegistryOnlyStaticSurfaceStartsUnavailable(t *testing.T) {
+	t.Parallel()
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.ArtifactsDir = t.TempDir()
+		cfg.AppDefs = map[string]*config.ProviderEntry{
+			"g-issues": {
+				Source: config.ProviderSource{Registry: "toolshed"},
+				Static: &config.AppStaticConfig{Mount: "/g-issues", Public: true},
+				SecuritySchemes: map[string]*config.HTTPSecurityScheme{
+					"none": {Type: providermanifestv1.HTTPSecuritySchemeTypeNone},
+				},
+				HTTP: map[string]*config.HTTPBinding{
+					"status": {
+						Path:     "/status",
+						Method:   http.MethodGet,
+						Security: "none",
+						Target:   "status",
+					},
+				},
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/g-issues")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 503: %s", resp.StatusCode, body)
+	}
+
+	httpResp, err := http.Get(ts.URL + "/api/v1/g-issues/status")
+	if err != nil {
+		t.Fatalf("GET HTTP binding: %v", err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+	if httpResp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("HTTP binding status = %d, want 503", httpResp.StatusCode)
+	}
+}
+
+func TestRegistryOnlyAddAndUpgradeRoutes(t *testing.T) {
+	t.Parallel()
+	fixture := registrytest.NewInstallFixture(t)
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.AppRegistries = map[string]config.AppRegistryConfig{"toolshed": fixture.Registry}
+		cfg.AppRegistryReader = fixture.Reader
+		cfg.AppDefs = map[string]*config.ProviderEntry{
+			"g-issues": {Source: config.ProviderSource{Registry: "toolshed"}},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	upgrade, err := http.Post(
+		ts.URL+"/admin/api/v1/app-registries/toolshed/apps/g-issues/upgrade",
+		"application/json",
+		bytes.NewBufferString(`{"version":"`+fixture.Version+`"}`),
+	)
+	if err != nil {
+		t.Fatalf("POST upgrade: %v", err)
+	}
+	_ = upgrade.Body.Close()
+	if upgrade.StatusCode != http.StatusBadRequest {
+		t.Fatalf("empty-catalog upgrade status = %d, want 400", upgrade.StatusCode)
+	}
+
+	add, err := http.Post(
+		ts.URL+"/admin/api/v1/app-registries/toolshed/apps/g-issues/add",
+		"application/json",
+		bytes.NewBufferString(`{"version":"`+fixture.Version+`"}`),
+	)
+	if err != nil {
+		t.Fatalf("POST add: %v", err)
+	}
+	_ = add.Body.Close()
+	if add.StatusCode != http.StatusOK {
+		t.Fatalf("add status = %d, want 200", add.StatusCode)
+	}
+}

--- a/gestaltd/internal/server/handlers_admin_app_install.go
+++ b/gestaltd/internal/server/handlers_admin_app_install.go
@@ -46,6 +46,8 @@ func (s *Server) mountAdminAppInstallReadRoutes(r chi.Router) {
 
 func (s *Server) mountAdminAppInstallWriteRoutes(r chi.Router) {
 	r.Post("/app-registries/{registry}/apps/{app}/install", s.installAdminAppRegistryApp)
+	r.Post("/app-registries/{registry}/apps/{app}/add", s.addAdminAppRegistryApp)
+	r.Post("/app-registries/{registry}/apps/{app}/upgrade", s.upgradeAdminAppRegistryApp)
 }
 
 func (s *Server) listAdminAppInstallations(w http.ResponseWriter, r *http.Request) {
@@ -96,6 +98,18 @@ func (s *Server) getAdminAppInstallation(w http.ResponseWriter, r *http.Request)
 }
 
 func (s *Server) installAdminAppRegistryApp(w http.ResponseWriter, r *http.Request) {
+	s.changeAdminAppRegistryApp(w, r, "install")
+}
+
+func (s *Server) addAdminAppRegistryApp(w http.ResponseWriter, r *http.Request) {
+	s.changeAdminAppRegistryApp(w, r, "add")
+}
+
+func (s *Server) upgradeAdminAppRegistryApp(w http.ResponseWriter, r *http.Request) {
+	s.changeAdminAppRegistryApp(w, r, "upgrade")
+}
+
+func (s *Server) changeAdminAppRegistryApp(w http.ResponseWriter, r *http.Request, mode string) {
 	if s.appRegistryInstaller == nil {
 		writeError(w, http.StatusServiceUnavailable, "app registry installer is unavailable")
 		return
@@ -134,12 +148,22 @@ func (s *Server) installAdminAppRegistryApp(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	result, err := s.appRegistryInstaller.Install(r.Context(), appregistry.InstallInput{
+	input := appregistry.InstallInput{
 		Registry: registryName,
 		App:      appName,
 		Version:  version,
 		Actor:    strings.TrimSpace(req.Actor),
-	})
+	}
+	var result *appregistry.InstallOutput
+	var err error
+	switch mode {
+	case "add":
+		result, err = s.appRegistryInstaller.Add(r.Context(), input)
+	case "upgrade":
+		result, err = s.appRegistryInstaller.Upgrade(r.Context(), input)
+	default:
+		result, err = s.appRegistryInstaller.Install(r.Context(), input)
+	}
 	if err != nil {
 		status := http.StatusBadGateway
 		switch {
@@ -157,6 +181,11 @@ func (s *Server) installAdminAppRegistryApp(w http.ResponseWriter, r *http.Reque
 			status = http.StatusConflict
 		case errors.Is(err, appregistry.ErrAppRolloutActive):
 			status = http.StatusConflict
+		case errors.Is(err, appregistry.ErrAppAlreadyAdded):
+			status = http.StatusConflict
+		case errors.Is(err, appregistry.ErrAppNotAdded),
+			errors.Is(err, appregistry.ErrRegistrySourceMismatch):
+			status = http.StatusBadRequest
 		case errors.Is(err, appregistry.ErrAppVersionAlreadyInstalled):
 			status = http.StatusBadRequest
 		case errors.Is(err, context.DeadlineExceeded):

--- a/gestaltd/internal/server/http_bindings.go
+++ b/gestaltd/internal/server/http_bindings.go
@@ -3,13 +3,16 @@ package server
 import (
 	"fmt"
 	"net/http"
+	"os"
 	stdpath "path"
+	"path/filepath"
 	"slices"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/internal/appregistry"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/apps/httpbinding"
@@ -61,9 +64,13 @@ func mountedHTTPBindingsFromEntries(entries map[string]*config.ProviderEntry, pr
 			}
 		}
 
-		operationIDs, err := providerOperationIDs(providers, pluginName)
-		if err != nil {
-			return nil, fmt.Errorf("resolve http bindings for %s: %w", pluginName, err)
+		var operationIDs map[string]struct{}
+		if !entry.Source.IsRegistry() {
+			var err error
+			operationIDs, err = providerOperationIDs(providers, pluginName)
+			if err != nil {
+				return nil, fmt.Errorf("resolve http bindings for %s: %w", pluginName, err)
+			}
 		}
 
 		bindingNames := make([]string, 0, len(bindings))
@@ -266,6 +273,10 @@ func (s *Server) mountHTTPBindingRoutes(r chi.Router) {
 	for i := range s.mountedHTTPBindings {
 		binding := &s.mountedHTTPBindings[i]
 		r.MethodFunc(binding.Method, binding.Path, func(w http.ResponseWriter, r *http.Request) {
+			if !s.registryAppRuntimeAvailable(binding.AppName) {
+				writeError(w, http.StatusServiceUnavailable, "app is unavailable")
+				return
+			}
 			metricutil.AddHTTPServerMetricDims(r.Context(), metricutil.HTTPMetricDims{
 				ProviderName:    binding.AppName,
 				OperationName:   binding.Target,
@@ -275,6 +286,21 @@ func (s *Server) mountHTTPBindingRoutes(r chi.Router) {
 			s.handleHTTPBinding(*binding, w, r)
 		})
 	}
+}
+
+func (s *Server) registryAppRuntimeAvailable(app string) bool {
+	entry := s.pluginDefs[strings.TrimSpace(app)]
+	if entry == nil || !entry.Source.IsRegistry() {
+		return true
+	}
+	if s.providers == nil || s.artifactsDir == "" {
+		return false
+	}
+	if _, err := s.providers.Get(app); err != nil {
+		return false
+	}
+	raw, err := os.ReadFile(filepath.Join(s.artifactsDir, appregistry.RegistryInstallSubdir, app, "active-version"))
+	return err == nil && strings.TrimSpace(string(raw)) != ""
 }
 
 func stdpathClean(pathValue string) string {

--- a/gestaltd/internal/server/http_bindings.go
+++ b/gestaltd/internal/server/http_bindings.go
@@ -273,34 +273,44 @@ func (s *Server) mountHTTPBindingRoutes(r chi.Router) {
 	for i := range s.mountedHTTPBindings {
 		binding := &s.mountedHTTPBindings[i]
 		r.MethodFunc(binding.Method, binding.Path, func(w http.ResponseWriter, r *http.Request) {
-			if !s.registryAppRuntimeAvailable(binding.AppName) {
+			if !s.withRegistryAppRuntime(binding.AppName, func() {
+				metricutil.AddHTTPServerMetricDims(r.Context(), metricutil.HTTPMetricDims{
+					ProviderName:    binding.AppName,
+					OperationName:   binding.Target,
+					HTTPBindingName: binding.Name,
+					Surface:         metricutil.InvocationSurfaceHTTPBinding,
+				})
+				s.handleHTTPBinding(*binding, w, r)
+			}) {
 				writeError(w, http.StatusServiceUnavailable, "app is unavailable")
-				return
 			}
-			metricutil.AddHTTPServerMetricDims(r.Context(), metricutil.HTTPMetricDims{
-				ProviderName:    binding.AppName,
-				OperationName:   binding.Target,
-				HTTPBindingName: binding.Name,
-				Surface:         metricutil.InvocationSurfaceHTTPBinding,
-			})
-			s.handleHTTPBinding(*binding, w, r)
 		})
 	}
 }
 
-func (s *Server) registryAppRuntimeAvailable(app string) bool {
+func (s *Server) withRegistryAppRuntime(app string, invoke func()) bool {
 	entry := s.pluginDefs[strings.TrimSpace(app)]
 	if entry == nil || !entry.Source.IsRegistry() {
+		invoke()
 		return true
 	}
-	if s.providers == nil || s.artifactsDir == "" {
+	if s.providers == nil || s.appRuntimeState == nil || s.artifactsDir == "" {
 		return false
 	}
-	if _, err := s.providers.Get(app); err != nil {
-		return false
-	}
-	raw, err := os.ReadFile(filepath.Join(s.artifactsDir, appregistry.RegistryInstallSubdir, app, "active-version"))
-	return err == nil && strings.TrimSpace(string(raw)) != ""
+	invoked := false
+	err := s.appRuntimeState.WithRunningVersion(app, func(version string) error {
+		if _, err := s.providers.Get(app); err != nil {
+			return err
+		}
+		raw, err := os.ReadFile(filepath.Join(s.artifactsDir, appregistry.RegistryInstallSubdir, app, "active-version"))
+		if err != nil || strings.TrimSpace(string(raw)) != version {
+			return fmt.Errorf("active version marker does not match running version")
+		}
+		invoked = true
+		invoke()
+		return nil
+	})
+	return err == nil && invoked
 }
 
 func stdpathClean(pathValue string) string {

--- a/gestaltd/internal/server/mounted_app_static.go
+++ b/gestaltd/internal/server/mounted_app_static.go
@@ -131,6 +131,7 @@ func registryAppStaticHandler(app, mount string, entry *config.ProviderEntry, pr
 		})
 		if err != nil && !served {
 			http.Error(w, "app unavailable", http.StatusServiceUnavailable)
+			return
 		}
 	})
 }

--- a/gestaltd/internal/server/mounted_app_static.go
+++ b/gestaltd/internal/server/mounted_app_static.go
@@ -6,14 +6,18 @@ import (
 	"html"
 	"net/http"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/appregistry"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/services/apps/registry"
 	"github.com/valon-technologies/gestalt/server/services/ui"
 )
 
-func mountedAppStaticsFromEntries(apps map[string]*config.ProviderEntry, devHandlerResolver func(string) http.Handler) ([]MountedUI, error) {
+func mountedAppStaticsFromEntries(apps map[string]*config.ProviderEntry, providers *registry.ProviderMap[core.Provider], artifactsDir string, devHandlerResolver func(string) http.Handler) ([]MountedUI, error) {
 	names := make([]string, 0, len(apps))
 	for name, entry := range apps {
 		if entry == nil || entry.Static == nil {
@@ -47,6 +51,19 @@ func mountedAppStaticsFromEntries(apps map[string]*config.ProviderEntry, devHand
 			})
 			continue
 		}
+		if entry.Source.IsRegistry() {
+			mounted = append(mounted, MountedUI{
+				Name:                mountedName,
+				Path:                mount,
+				AppName:             name,
+				AuthorizationPolicy: entry.AuthorizationPolicy,
+				AppLevelAuth:        !entry.Static.Public,
+				Handler:             registryAppStaticHandler(name, mount, entry, providers, artifactsDir),
+				ThemeStylesheet:     entry.ResolvedThemeStylesheet,
+				ThemeAssetsDir:      entry.ResolvedThemeAssetsDir,
+			})
+			continue
+		}
 
 		if strings.TrimSpace(entry.ResolvedStaticRoot) == "" {
 			return nil, fmt.Errorf("app %q static configured but asset root not resolved", name)
@@ -74,6 +91,47 @@ func mountedAppStaticsFromEntries(apps map[string]*config.ProviderEntry, devHand
 	}
 
 	return mounted, nil
+}
+
+func registryAppStaticHandler(app, mount string, entry *config.ProviderEntry, providers *registry.ProviderMap[core.Provider], artifactsDir string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if providers == nil || strings.TrimSpace(artifactsDir) == "" {
+			http.Error(w, "app unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		if _, err := providers.Get(app); err != nil {
+			http.Error(w, "app unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		marker := filepath.Join(artifactsDir, appregistry.RegistryInstallSubdir, app, "active-version")
+		raw, err := os.ReadFile(marker)
+		version := strings.TrimSpace(string(raw))
+		if err != nil || version == "" {
+			http.Error(w, "app unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		destDir := appregistry.MaterializedPath(artifactsDir, app, version)
+		resolved, err := appregistry.ResolveInstalledApp(app, entry, destDir, version)
+		if err != nil || strings.TrimSpace(resolved.ResolvedStaticRoot) == "" {
+			http.Error(w, "app unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		handler, err := ui.StaticHandler(ui.StaticConfig{
+			FS:           os.DirFS(resolved.ResolvedStaticRoot),
+			DynamicIndex: true,
+			RenderIndex:  injectBaseHref(mount),
+		})
+		if err != nil {
+			http.Error(w, "app unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		again, err := os.ReadFile(marker)
+		if err != nil || strings.TrimSpace(string(again)) != version {
+			http.Error(w, "app unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		handler.ServeHTTP(w, r)
+	})
 }
 
 func injectBaseHref(mount string) func([]byte) []byte {

--- a/gestaltd/internal/server/mounted_app_static.go
+++ b/gestaltd/internal/server/mounted_app_static.go
@@ -17,7 +17,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/ui"
 )
 
-func mountedAppStaticsFromEntries(apps map[string]*config.ProviderEntry, providers *registry.ProviderMap[core.Provider], artifactsDir string, devHandlerResolver func(string) http.Handler) ([]MountedUI, error) {
+func mountedAppStaticsFromEntries(apps map[string]*config.ProviderEntry, providers *registry.ProviderMap[core.Provider], artifactsDir string, runtimeState AppRuntimeState, devHandlerResolver func(string) http.Handler) ([]MountedUI, error) {
 	names := make([]string, 0, len(apps))
 	for name, entry := range apps {
 		if entry == nil || entry.Static == nil {
@@ -58,7 +58,7 @@ func mountedAppStaticsFromEntries(apps map[string]*config.ProviderEntry, provide
 				AppName:             name,
 				AuthorizationPolicy: entry.AuthorizationPolicy,
 				AppLevelAuth:        !entry.Static.Public,
-				Handler:             registryAppStaticHandler(name, mount, entry, providers, artifactsDir),
+				Handler:             registryAppStaticHandler(name, mount, entry, providers, artifactsDir, runtimeState),
 				ThemeStylesheet:     entry.ResolvedThemeStylesheet,
 				ThemeAssetsDir:      entry.ResolvedThemeAssetsDir,
 			})
@@ -93,44 +93,45 @@ func mountedAppStaticsFromEntries(apps map[string]*config.ProviderEntry, provide
 	return mounted, nil
 }
 
-func registryAppStaticHandler(app, mount string, entry *config.ProviderEntry, providers *registry.ProviderMap[core.Provider], artifactsDir string) http.Handler {
+func registryAppStaticHandler(app, mount string, entry *config.ProviderEntry, providers *registry.ProviderMap[core.Provider], artifactsDir string, runtimeState AppRuntimeState) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if providers == nil || strings.TrimSpace(artifactsDir) == "" {
+		if providers == nil || runtimeState == nil || strings.TrimSpace(artifactsDir) == "" {
 			http.Error(w, "app unavailable", http.StatusServiceUnavailable)
 			return
 		}
-		if _, err := providers.Get(app); err != nil {
-			http.Error(w, "app unavailable", http.StatusServiceUnavailable)
-			return
-		}
-		marker := filepath.Join(artifactsDir, appregistry.RegistryInstallSubdir, app, "active-version")
-		raw, err := os.ReadFile(marker)
-		version := strings.TrimSpace(string(raw))
-		if err != nil || version == "" {
-			http.Error(w, "app unavailable", http.StatusServiceUnavailable)
-			return
-		}
-		destDir := appregistry.MaterializedPath(artifactsDir, app, version)
-		resolved, err := appregistry.ResolveInstalledApp(app, entry, destDir, version)
-		if err != nil || strings.TrimSpace(resolved.ResolvedStaticRoot) == "" {
-			http.Error(w, "app unavailable", http.StatusServiceUnavailable)
-			return
-		}
-		handler, err := ui.StaticHandler(ui.StaticConfig{
-			FS:           os.DirFS(resolved.ResolvedStaticRoot),
-			DynamicIndex: true,
-			RenderIndex:  injectBaseHref(mount),
+		served := false
+		err := runtimeState.WithRunningVersion(app, func(version string) error {
+			if _, err := providers.Get(app); err != nil {
+				return err
+			}
+			marker := filepath.Join(artifactsDir, appregistry.RegistryInstallSubdir, app, "active-version")
+			raw, err := os.ReadFile(marker)
+			if err != nil || strings.TrimSpace(string(raw)) != version {
+				return fmt.Errorf("active version marker does not match running version")
+			}
+			destDir := appregistry.MaterializedPath(artifactsDir, app, version)
+			resolved, err := appregistry.ResolveInstalledApp(app, entry, destDir, version)
+			if err != nil {
+				return fmt.Errorf("resolve installed app: %w", err)
+			}
+			if strings.TrimSpace(resolved.ResolvedStaticRoot) == "" {
+				return fmt.Errorf("installed app %q has no static root", app)
+			}
+			handler, err := ui.StaticHandler(ui.StaticConfig{
+				FS:           os.DirFS(resolved.ResolvedStaticRoot),
+				DynamicIndex: true,
+				RenderIndex:  injectBaseHref(mount),
+			})
+			if err != nil {
+				return err
+			}
+			served = true
+			handler.ServeHTTP(w, r)
+			return nil
 		})
-		if err != nil {
+		if err != nil && !served {
 			http.Error(w, "app unavailable", http.StatusServiceUnavailable)
-			return
 		}
-		again, err := os.ReadFile(marker)
-		if err != nil || strings.TrimSpace(string(again)) != version {
-			http.Error(w, "app unavailable", http.StatusServiceUnavailable)
-			return
-		}
-		handler.ServeHTTP(w, r)
 	})
 }
 

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -18,6 +18,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/appregistry"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	gestaltmcp "github.com/valon-technologies/gestalt/server/services/apps/mcp"
 	"github.com/valon-technologies/gestalt/server/services/apps/source"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
@@ -129,6 +130,7 @@ func run(ctx context.Context, cfg *config.Config, result *bootstrap.Result, onRe
 		ArtifactsDir:  cfg.Server.ArtifactsDir,
 	}
 
+	result.RegistryAppStartup = registryAppStartup(cfg, result, nil)
 	if err := result.Start(ctx); err != nil {
 		return err
 	}
@@ -206,6 +208,62 @@ func run(ctx context.Context, cfg *config.Config, result *bootstrap.Result, onRe
 	}
 
 	return serveRuntime(ctx, cfg, connMaps, result, mcpInvoker, servers, mcpSlot, workflowProvidersReady, devSupervisor, onReady)
+}
+
+func registryAppStartup(cfg *config.Config, result *bootstrap.Result, reader *appregistry.RegistryReader) func(context.Context) {
+	return func(ctx context.Context) {
+		if cfg == nil || result == nil || result.Services == nil ||
+			result.Services.AppVersionChangeRequests == nil || result.AppRestarter == nil {
+			return
+		}
+		materializer := &appregistry.Materializer{
+			Registries:   cfg.AppRegistries,
+			ArtifactsDir: cfg.Server.ArtifactsDir,
+			Reader:       reader,
+		}
+		names := make([]string, 0, len(cfg.Apps))
+		for name := range cfg.Apps {
+			names = append(names, name)
+		}
+		slices.Sort(names)
+		for _, appName := range names {
+			entry := cfg.Apps[appName]
+			if entry == nil || !entry.Source.IsRegistry() {
+				continue
+			}
+			known, err := result.Services.AppVersionChangeRequests.ListKnownVersionsByApp(ctx, appName)
+			if err != nil {
+				slog.Warn("registry app bootstrap could not list known versions", "app", appName, "error", err)
+				continue
+			}
+			version := coredata.LatestKnownVersion(known)
+			if version == "" {
+				if err := result.AppRestarter.StopApp(ctx, appName); err != nil {
+					slog.Warn("registry app bootstrap could not clear stopped app", "app", appName, "error", err)
+				}
+				result.AppRestarter.AbortRestarts()
+				continue
+			}
+			var desired *core.AppInstallation
+			for _, installation := range known {
+				if installation != nil && strings.TrimSpace(installation.Version) == version {
+					desired = installation
+					break
+				}
+			}
+			if desired == nil || strings.TrimSpace(desired.Registry) != strings.TrimSpace(entry.Source.Registry) {
+				slog.Warn("registry app bootstrap rejected catalog registry mismatch", "app", appName, "version", version)
+				continue
+			}
+			if _, err := materializer.Ensure(ctx, desired); err != nil {
+				slog.Warn("registry app bootstrap could not materialize app", "app", appName, "version", version, "error", err)
+				continue
+			}
+			if err := result.AppRestarter.StartApp(ctx, appName, version); err != nil {
+				slog.Warn("registry app bootstrap could not start app", "app", appName, "version", version, "error", err)
+			}
+		}
+	}
 }
 
 type indexedDBPinger interface {
@@ -318,6 +376,8 @@ func serveRuntime(ctx context.Context, cfg *config.Config, connMaps bootstrap.Co
 		return fmt.Errorf("%s http server: %v", failure.name, failure.err)
 	case err := <-workflowErr:
 		return err
+	case err := <-result.FatalAppProviderState:
+		return fmt.Errorf("unrecoverable app provider state: %w", err)
 	case <-ctx.Done():
 		return nil
 	}
@@ -442,15 +502,17 @@ func startAppRegistryCatalogPoller(ctx context.Context, cfg *config.Config, resu
 		}
 	}
 	poller := appregistry.NewCatalogPoller(appregistry.CatalogPollerConfig{
-		ChangeRequests:      changeRequests,
-		Materializations:    materializations,
-		Rollouts:            rollouts,
-		AppMaterializer:     materializer,
-		AppRestarter:        result.AppRestarter,
-		InstanceID:          appregistry.ResolveInstanceID(),
-		RestartDelay:        restartDelay,
-		DisableRestartDelay: disableRestartDelay,
-		RestartReady:        result.StartupProvidersReady,
+		ChangeRequests:       changeRequests,
+		Materializations:     materializations,
+		Rollouts:             rollouts,
+		AppMaterializer:      materializer,
+		AppRestarter:         result.AppRestarter,
+		InstanceID:           appregistry.ResolveInstanceID(),
+		RestartDelay:         restartDelay,
+		DisableRestartDelay:  disableRestartDelay,
+		RestartReady:         result.AppProvidersInitialized,
+		BootstrapReady:       result.AppProvidersInitialized,
+		MaxReconcileAttempts: cfg.Server.AppRegistry.MaxReconcileAttempts,
 	})
 	poller.Start(ctx)
 	return poller

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -242,6 +242,8 @@ func registryAppStartup(cfg *config.Config, result *bootstrap.Result, reader *ap
 			if version == "" {
 				if err := result.AppRestarter.StopApp(ctx, appName); err != nil {
 					slog.Warn("registry app bootstrap could not clear stopped app", "app", appName, "error", err)
+				} else if err := materializer.PruneSuperseded(appName, ""); err != nil {
+					slog.Warn("registry app bootstrap could not remove stale packages", "app", appName, "error", err)
 				}
 				result.AppRestarter.AbortRestarts()
 				continue
@@ -263,6 +265,10 @@ func registryAppStartup(cfg *config.Config, result *bootstrap.Result, reader *ap
 			}
 			if err := result.AppRestarter.StartApp(ctx, appName, version); err != nil {
 				slog.Warn("registry app bootstrap could not start app", "app", appName, "version", version, "error", err)
+				continue
+			}
+			if err := materializer.PruneSuperseded(appName, version); err != nil {
+				slog.Warn("registry app bootstrap could not remove superseded packages", "app", appName, "version", version, "error", err)
 			}
 		}
 	}

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -88,6 +88,7 @@ func run(ctx context.Context, cfg *config.Config, result *bootstrap.Result, onRe
 	if strings.TrimSpace(cfg.Server.Remote) == "" && result.Services != nil {
 		publicIndexedDB = result.Services.DB
 	}
+	appRuntimeState, _ := result.AppRestarter.(AppRuntimeState)
 	baseConfig := Config{
 		Auth:                 result.Auth,
 		SelectedAuthProvider: result.SelectedAuthProvider,
@@ -126,8 +127,9 @@ func run(ctx context.Context, cfg *config.Config, result *bootstrap.Result, onRe
 			AuthorizationPolicy: cfg.Server.Admin.AuthorizationPolicy,
 			AllowedRoles:        append([]string(nil), cfg.Server.Admin.AllowedRoles...),
 		},
-		AppRegistries: cfg.AppRegistries,
-		ArtifactsDir:  cfg.Server.ArtifactsDir,
+		AppRegistries:   cfg.AppRegistries,
+		ArtifactsDir:    cfg.Server.ArtifactsDir,
+		AppRuntimeState: appRuntimeState,
 	}
 
 	result.RegistryAppStartup = registryAppStartup(cfg, result, nil)

--- a/gestaltd/internal/server/runtime_app_registry_test.go
+++ b/gestaltd/internal/server/runtime_app_registry_test.go
@@ -2,10 +2,13 @@ package server
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/appregistry"
 	"github.com/valon-technologies/gestalt/server/internal/appregistry/registrytest"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
@@ -53,12 +56,17 @@ func TestRegistryAppStartupMaterializesAndStartsKnownVersion(t *testing.T) {
 		t.Fatalf("AppendRequest: %v", err)
 	}
 	restarter := &startupRecordingRestarter{}
+	artifactsDir := t.TempDir()
+	oldPath := appregistry.MaterializedPath(artifactsDir, "g-issues", "old")
+	if err := os.MkdirAll(oldPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll old version: %v", err)
+	}
 	cfg := &config.Config{
 		AppRegistries: map[string]config.AppRegistryConfig{"toolshed": fixture.Registry},
 		Apps: map[string]*config.ProviderEntry{
 			"g-issues": {Source: config.ProviderSource{Registry: "toolshed"}},
 		},
-		Server: config.ServerConfig{ArtifactsDir: t.TempDir()},
+		Server: config.ServerConfig{ArtifactsDir: artifactsDir},
 	}
 	result := &bootstrap.Result{Services: services, AppRestarter: restarter}
 
@@ -67,15 +75,27 @@ func TestRegistryAppStartupMaterializesAndStartsKnownVersion(t *testing.T) {
 	if restarter.startedApp != "g-issues" || restarter.startedVersion != fixture.Version {
 		t.Fatalf("started = %s@%s", restarter.startedApp, restarter.startedVersion)
 	}
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Fatalf("old version stat error = %v, want not exist", err)
+	}
+	if _, err := os.Stat(filepath.Join(appregistry.MaterializedPath(artifactsDir, "g-issues", fixture.Version), "manifest.yaml")); err != nil {
+		t.Fatalf("desired manifest: %v", err)
+	}
 }
 
 func TestRegistryAppStartupStopsEmptyProjection(t *testing.T) {
 	t.Parallel()
 	restarter := &startupRecordingRestarter{}
+	artifactsDir := t.TempDir()
+	oldPath := appregistry.MaterializedPath(artifactsDir, "g-issues", "old")
+	if err := os.MkdirAll(oldPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll old version: %v", err)
+	}
 	cfg := &config.Config{
 		Apps: map[string]*config.ProviderEntry{
 			"g-issues": {Source: config.ProviderSource{Registry: "toolshed"}},
 		},
+		Server: config.ServerConfig{ArtifactsDir: artifactsDir},
 	}
 	result := &bootstrap.Result{Services: testutil.NewStubServices(t), AppRestarter: restarter}
 
@@ -83,5 +103,8 @@ func TestRegistryAppStartupStopsEmptyProjection(t *testing.T) {
 
 	if restarter.stoppedApp != "g-issues" {
 		t.Fatalf("stopped app = %q", restarter.stoppedApp)
+	}
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Fatalf("old version stat error = %v, want not exist", err)
 	}
 }

--- a/gestaltd/internal/server/runtime_app_registry_test.go
+++ b/gestaltd/internal/server/runtime_app_registry_test.go
@@ -1,0 +1,87 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/appregistry/registrytest"
+	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+)
+
+type startupRecordingRestarter struct {
+	startedApp     string
+	startedVersion string
+	stoppedApp     string
+}
+
+func (*startupRecordingRestarter) Restartable(string) (bool, error) { return true, nil }
+func (r *startupRecordingRestarter) StopApp(_ context.Context, app string) error {
+	r.stoppedApp = app
+	return nil
+}
+func (r *startupRecordingRestarter) StartApp(_ context.Context, app, version string) error {
+	r.startedApp = app
+	r.startedVersion = version
+	return nil
+}
+func (*startupRecordingRestarter) AbortRestarts() {}
+
+func TestRegistryAppStartupMaterializesAndStartsKnownVersion(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fixture := registrytest.NewInstallFixture(t)
+	services := testutil.NewStubServices(t)
+	installedAt := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	if _, err := services.AppVersionChangeRequests.AppendRequest(ctx, &core.AppVersionChangeRequest{
+		App:         "g-issues",
+		FromVersion: "registry:first-install",
+		ToVersion:   fixture.Version,
+		Timestamp:   installedAt,
+		Metadata: coredata.ChangeRequestMetadata(&core.AppInstallation{
+			AppName:     "g-issues",
+			Version:     fixture.Version,
+			Registry:    "toolshed",
+			InstalledAt: installedAt,
+			UpdatedAt:   installedAt,
+		}),
+	}); err != nil {
+		t.Fatalf("AppendRequest: %v", err)
+	}
+	restarter := &startupRecordingRestarter{}
+	cfg := &config.Config{
+		AppRegistries: map[string]config.AppRegistryConfig{"toolshed": fixture.Registry},
+		Apps: map[string]*config.ProviderEntry{
+			"g-issues": {Source: config.ProviderSource{Registry: "toolshed"}},
+		},
+		Server: config.ServerConfig{ArtifactsDir: t.TempDir()},
+	}
+	result := &bootstrap.Result{Services: services, AppRestarter: restarter}
+
+	registryAppStartup(cfg, result, fixture.Reader)(ctx)
+
+	if restarter.startedApp != "g-issues" || restarter.startedVersion != fixture.Version {
+		t.Fatalf("started = %s@%s", restarter.startedApp, restarter.startedVersion)
+	}
+}
+
+func TestRegistryAppStartupStopsEmptyProjection(t *testing.T) {
+	t.Parallel()
+	restarter := &startupRecordingRestarter{}
+	cfg := &config.Config{
+		Apps: map[string]*config.ProviderEntry{
+			"g-issues": {Source: config.ProviderSource{Registry: "toolshed"}},
+		},
+	}
+	result := &bootstrap.Result{Services: testutil.NewStubServices(t), AppRestarter: restarter}
+
+	registryAppStartup(cfg, result, nil)(context.Background())
+
+	if restarter.stoppedApp != "g-issues" {
+		t.Fatalf("stopped app = %q", restarter.stoppedApp)
+	}
+}

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -149,6 +149,7 @@ type Server struct {
 	appRegistries          map[string]config.AppRegistryConfig
 	appRegistryReader      *appregistry.RegistryReader
 	appRegistryInstaller   *appregistry.Installer
+	artifactsDir           string
 	routeProfile           RouteProfile
 	activateAppProviders   func(context.Context)
 }
@@ -263,7 +264,7 @@ func New(cfg Config) (*Server, error) {
 		return nil, fmt.Errorf("validate admin route: %w", err)
 	}
 	mountedUIs := append([]MountedUI(nil), cfg.MountedUIs...)
-	appStatics, err := mountedAppStaticsFromEntries(cfg.AppDefs, cfg.DevHandlerResolver)
+	appStatics, err := mountedAppStaticsFromEntries(cfg.AppDefs, cfg.Providers, cfg.ArtifactsDir, cfg.DevHandlerResolver)
 	if err != nil {
 		return nil, fmt.Errorf("resolve mounted app static handlers: %w", err)
 	}
@@ -392,6 +393,7 @@ func New(cfg Config) (*Server, error) {
 		appRegistries:          cloneAppRegistryConfig(cfg.AppRegistries),
 		appRegistryReader:      cfg.AppRegistryReader,
 		appRegistryInstaller:   newAppRegistryInstaller(cfg),
+		artifactsDir:           strings.TrimSpace(cfg.ArtifactsDir),
 		routeProfile:           cfg.RouteProfile,
 		activateAppProviders:   cfg.ActivateAppProviders,
 	}

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -89,6 +89,10 @@ type BuiltinAdminUIOptions struct {
 	LoginBase string
 }
 
+type AppRuntimeState interface {
+	WithRunningVersion(app string, fn func(version string) error) error
+}
+
 type Server struct {
 	router                 chi.Router
 	handler                http.Handler
@@ -150,6 +154,7 @@ type Server struct {
 	appRegistryReader      *appregistry.RegistryReader
 	appRegistryInstaller   *appregistry.Installer
 	artifactsDir           string
+	appRuntimeState        AppRuntimeState
 	routeProfile           RouteProfile
 	activateAppProviders   func(context.Context)
 }
@@ -204,6 +209,7 @@ type Config struct {
 	AppRegistries          map[string]config.AppRegistryConfig
 	AppRegistryReader      *appregistry.RegistryReader
 	ArtifactsDir           string
+	AppRuntimeState        AppRuntimeState
 	RouteProfile           RouteProfile
 	MeterProvider          metric.MeterProvider
 	TracerProvider         trace.TracerProvider
@@ -264,7 +270,7 @@ func New(cfg Config) (*Server, error) {
 		return nil, fmt.Errorf("validate admin route: %w", err)
 	}
 	mountedUIs := append([]MountedUI(nil), cfg.MountedUIs...)
-	appStatics, err := mountedAppStaticsFromEntries(cfg.AppDefs, cfg.Providers, cfg.ArtifactsDir, cfg.DevHandlerResolver)
+	appStatics, err := mountedAppStaticsFromEntries(cfg.AppDefs, cfg.Providers, cfg.ArtifactsDir, cfg.AppRuntimeState, cfg.DevHandlerResolver)
 	if err != nil {
 		return nil, fmt.Errorf("resolve mounted app static handlers: %w", err)
 	}
@@ -394,6 +400,7 @@ func New(cfg Config) (*Server, error) {
 		appRegistryReader:      cfg.AppRegistryReader,
 		appRegistryInstaller:   newAppRegistryInstaller(cfg),
 		artifactsDir:           strings.TrimSpace(cfg.ArtifactsDir),
+		appRuntimeState:        cfg.AppRuntimeState,
 		routeProfile:           cfg.RouteProfile,
 		activateAppProviders:   cfg.ActivateAppProviders,
 	}


### PR DESCRIPTION
## Summary
- Implements app registry step 12 (registry-only apps, add/upgrade routes, catalog poller, bootstrap startup, runtime invariants)
- Materializes and retains only `LatestKnownVersion`; superseded pending rows converge without download; old packages pruned after activation
- Retry limit applies to poller retries only; bootstrap and passive convergence unaffected

Stacked on docs clarification merged in #2878.

## Test plan
- [x] Focused unit tests for appregistry, server, bootstrap, config, operator, coredata
- [x] `go test -race` on appregistry and server packages
- [x] CI green on stacked PR


Made with [Cursor](https://cursor.com)