### PR TITLE
Move gestaltd Helm dev defaults to values-local.yaml

### DIFF
--- a/.github/workflows/validate-gestaltd.yml
+++ b/.github/workflows/validate-gestaltd.yml
@@ -349,11 +349,18 @@ jobs:
         if: ${{ needs.resolve-ref.outputs.should_validate == 'true' }}
         run: helm lint gestaltd/deploy/helm/gestaltd
 
-      - name: Helm template (default chart profile)
+      - name: Helm template (local chart profile)
         if: ${{ needs.resolve-ref.outputs.should_validate == 'true' }}
         run: |
           helm template test-release gestaltd/deploy/helm/gestaltd \
+            -f gestaltd/deploy/helm/gestaltd/values-local.yaml \
             > /tmp/rendered-default.yaml
+
+      - name: Helm template (base chart profile)
+        if: ${{ needs.resolve-ref.outputs.should_validate == 'true' }}
+        run: |
+          helm template test-release gestaltd/deploy/helm/gestaltd \
+            > /tmp/rendered-base.yaml
 
       - name: Helm template (ingress)
         if: ${{ needs.resolve-ref.outputs.should_validate == 'true' }}
@@ -397,9 +404,13 @@ jobs:
         if: ${{ needs.resolve-ref.outputs.should_validate == 'true' }}
         run: kubeconform -strict -summary /tmp/rendered.yaml
 
-      - name: Validate Kubernetes schemas (default chart profile)
+      - name: Validate Kubernetes schemas (local chart profile)
         if: ${{ needs.resolve-ref.outputs.should_validate == 'true' }}
         run: kubeconform -strict -summary /tmp/rendered-default.yaml
+
+      - name: Validate Kubernetes schemas (base chart profile)
+        if: ${{ needs.resolve-ref.outputs.should_validate == 'true' }}
+        run: kubeconform -strict -summary /tmp/rendered-base.yaml
 
       - name: Validate Kubernetes schemas (ingress)
         if: ${{ needs.resolve-ref.outputs.should_validate == 'true' }}

--- a/docs/content/deploy/helm.mdx
+++ b/docs/content/deploy/helm.mdx
@@ -9,16 +9,31 @@ helm upgrade --install gestaltd \
   oci://ghcr.io/valon-technologies/charts/gestaltd \
   --namespace gestalt \
   --set image.tag=<version> \
-  -f values.yaml
+  -f values-local.yaml
 ```
 
-The default chart profile is for local or disposable testing only:
+The default chart profile is for local or disposable testing only. Pass
+`values-local.yaml` for the SQLite + static encryption key profile:
+
+```sh
+helm upgrade --install gestaltd \
+  oci://ghcr.io/valon-technologies/charts/gestaltd \
+  --namespace gestalt \
+  --set image.tag=<version> \
+  -f values-local.yaml
+```
+
+That local profile:
 
 - platform identity is omitted
 - SQLite uses a PVC mounted at `/data`
 - `server.encryptionKey` is a static dev-only value
 - one replica
 - no ingress
+
+The base chart `values.yaml` omits those dev-only scalar defaults so
+production overrides can supply structured values without Helm coalesce
+warnings.
 
 Before any shared or production deployment, set a real encryption key,
 configure identity, use a networked datastore, and set `server.baseUrl`

--- a/gestaltd/deploy/helm/gestaltd/values-local.yaml
+++ b/gestaltd/deploy/helm/gestaltd/values-local.yaml
@@ -1,0 +1,17 @@
+# Local development profile for the gestaltd Helm chart.
+#
+# The base values.yaml intentionally omits dev-only scalar defaults for fields
+# that production overrides supply as structured maps (encryptionKey, indexeddb
+# source/dsn). Use this file for local or disposable single-node installs:
+#
+#   helm upgrade --install gestaltd ./gestaltd/deploy/helm/gestaltd \
+#     -f gestaltd/deploy/helm/gestaltd/values-local.yaml
+config:
+  server:
+    encryptionKey: "dev-only-insecure-key-change-me"
+  providers:
+    indexeddb:
+      main:
+        source: https://github.com/valon-technologies/gestalt-providers/releases/download/indexeddb/relationaldb/v0.0.1-alpha.2/provider-release.yaml
+        config:
+          dsn: "sqlite:///data/gestalt.db"

--- a/gestaltd/deploy/helm/gestaltd/values.yaml
+++ b/gestaltd/deploy/helm/gestaltd/values.yaml
@@ -1,10 +1,14 @@
-# The default chart profile is for local development or trusted internal
-# clusters. It disables platform auth, uses the first-party relationaldb
-# provider with a SQLite DSN, and keeps a single replica so the chart boots
-# without extra secrets.
+# Base chart values for Kubernetes deployments.
 #
-# Configure OAuth/OIDC, server.encryptionKey, and a networked datastore
-# before using this chart in production.
+# This file intentionally omits dev-only scalar defaults for config fields that
+# production overrides usually supply as structured maps (for example
+# server.encryptionKey and indexeddb.main source/dsn). That avoids Helm
+# coalesce warnings when layering full production values on top of the chart.
+#
+# For local development with SQLite and a static encryption key, also pass
+# values-local.yaml. Configure OAuth/OIDC, server.encryptionKey, and a
+# networked datastore before using this chart in shared or production
+# environments.
 replicaCount: 1
 
 image:
@@ -89,24 +93,15 @@ config:
     # management:
     #   host: 0.0.0.0
     #   port: 9090
-    # Dev-only default so the default chart profile can boot. Override this with
-    # a secret value before production use.
-    encryptionKey: "dev-only-insecure-key-change-me"
+    # Set encryptionKey here or via values-local.yaml / production overrides.
     # baseUrl is optional for the default local/dev profile.
     # Set it to your public HTTPS URL when auth callbacks or external
     # integrations need it.
     # baseUrl: "${GESTALT_BASE_URL}"
     providers:
       indexeddb: main
-  providers:
-    indexeddb:
-      main:
-        # SQLite is appropriate for local development or single-instance
-        # deployments with mounted persistent storage at /data.
-        source: https://github.com/valon-technologies/gestalt-providers/releases/download/indexeddb/relationaldb/v0.0.1-alpha.2/provider-release.yaml
-        config:
-          dsn: "sqlite:///data/gestalt.db"
-    # Add apps.<name>.static mounts when you want to serve public static bundles.
+  # Configure indexeddb.main in values-local.yaml or production overrides.
+  providers: {}
 
 # Extra environment variables for the container. These are only required
 # when your config uses ${VAR} placeholders for auth, baseUrl, or


### PR DESCRIPTION
## Summary
- Remove dev-only scalar defaults (`encryptionKey`, indexeddb `source`/`dsn`) from the base gestaltd chart `values.yaml`
- Add `values-local.yaml` for the SQLite + static encryption key local profile
- Update Helm docs and CI to template/validate both base and local profiles

## Why
valon-tools deploys layer full production config (secret refs, git sources) on top of the chart. Helm coalesce warned when chart scalars tried to merge into those structured maps:

```
coalesce.go:289: warning: destination for gestaltd.config.server.encryptionKey is a table. Ignoring non-table value (dev-only-insecure-key-change-me)
```

Production values already won; this just removes the noisy warnings.

## Test plan
- [x] `helm lint gestaltd/deploy/helm/gestaltd`
- [x] `helm template` with `values-local.yaml` and base `values.yaml`
- [x] `valon-tools/scripts/deploy-gestaltd.sh stage --render-only` against local chart reports no coalesce warnings


Made with [Cursor](https://cursor.com)