### PR TITLE
style: gofmt provider_test.go trailing newline

### DIFF
--- a/gestaltd/services/apps/provider_test.go
+++ b/gestaltd/services/apps/provider_test.go
@@ -884,4 +884,3 @@ func TestRemoteProviderDeclaredWorkflowDefinitions(t *testing.T) {
 		t.Fatal("expected corrupt workflow_definition_specs to fail NewRemote")
 	}
 }
-


### PR DESCRIPTION
Fixes a gofmt failure on main from #2880: an extra trailing blank line in `provider_test.go`. One-line fix.