### PR TITLE
Add per-request relay capability support to Python SDK

### DIFF
--- a/sdk/python/gestalt/_api.py
+++ b/sdk/python/gestalt/_api.py
@@ -123,6 +123,7 @@ class Request:
     host: Host = dataclasses.field(default_factory=Host)
     agent_subject: Subject = dataclasses.field(default_factory=Subject)
     context: Any | None = None
+    relay_token: str = ""
 
     def connection_param(self, name: str) -> str | None:
         """Return a connection parameter by name if the host supplied it."""
@@ -135,7 +136,7 @@ class Request:
 
         from .app import App
 
-        return App.connect(context=self._native_context(), timeout=timeout)
+        return App.connect(context=self._native_context(), timeout=timeout, relay_token=self.relay_token)
 
     def gestalt(self) -> "BoundGestaltClient":
         """Return the public Gestalt client bound to this request's relay context."""
@@ -150,7 +151,7 @@ class Request:
 
         from .agent import Agent
 
-        return Agent.connect(context=self._native_context(), timeout=timeout)
+        return Agent.connect(context=self._native_context(), timeout=timeout, relay_token=self.relay_token)
 
     def workflows(self, *, timeout: float | None = None) -> "Workflow":
         from ._workflow import Workflow

--- a/sdk/python/gestalt/_runtime.py
+++ b/sdk/python/gestalt/_runtime.py
@@ -1418,7 +1418,7 @@ def _provider_servicer(*, app: App) -> Any:
                 protocol_version=CURRENT_PROTOCOL_VERSION
             )
 
-        def Execute(self, request: Any, _context: Any) -> Any:
+        def Execute(self, request: Any, context: Any) -> Any:
             try:
                 result = app.execute(
                     request.operation,
@@ -1427,7 +1427,7 @@ def _provider_servicer(*, app: App) -> Any:
                         message=request.params,
                         request=request,
                     ),
-                    _plugin_request(request),
+                    _plugin_request(request, _relay_token_from_context(context)),
                 )
             except Exception as error:
                 traceback.print_exception(error)
@@ -1451,7 +1451,7 @@ def _provider_servicer(*, app: App) -> Any:
             try:
                 subject = app.resolve_http_subject(
                     _http_subject_request(getattr(request, "request", None)),
-                    _plugin_request(request),
+                    _plugin_request(request, _relay_token_from_context(context)),
                 )
             except HTTPSubjectResolutionError as error:
                 return app_pb2.ResolveHTTPSubjectResponse(
@@ -1483,7 +1483,7 @@ def _provider_servicer(*, app: App) -> Any:
                 )
 
             try:
-                catalog = app.catalog_for_request(_plugin_request(request))
+                catalog = app.catalog_for_request(_plugin_request(request, _relay_token_from_context(context)))
             except Exception as error:
                 return context.abort(
                     grpc.StatusCode.UNKNOWN,
@@ -1896,7 +1896,27 @@ def _cache_servicer(*, provider: AppProvider) -> Any:
     return CacheServicer()
 
 
-def _plugin_request(request: Any) -> Request:
+_RELAY_TOKEN_HEADER = "x-gestalt-host-service-relay-token"
+
+
+def _relay_token_from_context(context: Any) -> str:
+    """Extract the host-service relay token from incoming gRPC metadata."""
+    if context is None:
+        return ""
+    try:
+        metadata = context.invocation_metadata()
+    except Exception:
+        return ""
+    try:
+        for key, value in metadata:
+            if key.lower() == _RELAY_TOKEN_HEADER:
+                return value.strip()
+    except (TypeError, ValueError):
+        pass
+    return ""
+
+
+def _plugin_request(request: Any, relay_token: str = "") -> Request:
     request_context = getattr(request, "context", None)
     tool_refs, tool_refs_set = _tool_refs_from_proto(request_context)
     return Request(
@@ -1912,6 +1932,7 @@ def _plugin_request(request: Any) -> Request:
         tool_refs_set=tool_refs_set,
         idempotency_key=getattr(request, "idempotency_key", "").strip(),
         context=request_context,
+        relay_token=relay_token,
     )
 
 

--- a/sdk/python/gestalt/_workflow.py
+++ b/sdk/python/gestalt/_workflow.py
@@ -2382,7 +2382,7 @@ class Workflow:
         target = os.environ.get(ENV_HOST_SERVICE_SOCKET, "")
         if not target:
             raise RuntimeError(f"workflow: {ENV_HOST_SERVICE_SOCKET} is not set")
-        relay_token = os.environ.get(ENV_HOST_SERVICE_TOKEN, "")
+        relay_token = request.relay_token.strip() or os.environ.get(ENV_HOST_SERVICE_TOKEN, "")
 
         self._channel = host_service_channel("workflow", target, token=relay_token)
         self._stub = pb_grpc.WorkflowStub(self._channel)

--- a/sdk/python/gestalt/agent.py
+++ b/sdk/python/gestalt/agent.py
@@ -557,11 +557,12 @@ class Agent:
         *,
         context: RequestContext | None = None,
         timeout: float | None = None,
+        relay_token: str = "",
     ) -> Agent:
         target = os.environ.get(ENV_HOST_SERVICE_SOCKET, "")
         if not target:
             raise RuntimeError(f"{ENV_HOST_SERVICE_SOCKET} is not set")
-        token = os.environ.get(ENV_HOST_SERVICE_TOKEN, "")
+        token = relay_token.strip() or os.environ.get(ENV_HOST_SERVICE_TOKEN, "")
         channel = host_service_channel(
             "agent", target, token=token.strip(), binding=(name or "").strip()
         )

--- a/sdk/python/gestalt/app.py
+++ b/sdk/python/gestalt/app.py
@@ -493,11 +493,12 @@ class App:
         *,
         context: RequestContext | None = None,
         timeout: float | None = None,
+        relay_token: str = "",
     ) -> App:
         target = os.environ.get(ENV_HOST_SERVICE_SOCKET, "")
         if not target:
             raise RuntimeError(f"{ENV_HOST_SERVICE_SOCKET} is not set")
-        token = os.environ.get(ENV_HOST_SERVICE_TOKEN, "")
+        token = relay_token.strip() or os.environ.get(ENV_HOST_SERVICE_TOKEN, "")
         channel = host_service_channel(
             "app", target, token=token.strip(), binding=(name or "").strip()
         )

--- a/sdk/python/gestalt/public/bound.py
+++ b/sdk/python/gestalt/public/bound.py
@@ -43,7 +43,8 @@ def gestalt_from_request(
     target = os.environ.get(ENV_HOST_SERVICE_SOCKET, "").strip()
     if not target:
         raise RuntimeError(f"{ENV_HOST_SERVICE_SOCKET} is not set")
-    token = os.environ.get(ENV_HOST_SERVICE_TOKEN, "").strip()
+    relay_token = getattr(request, "relay_token", "").strip()
+    token = relay_token or os.environ.get(ENV_HOST_SERVICE_TOKEN, "").strip()
     channel = host_service_channel("app", target, token=token)
     native = native_request_context(getattr(request, "context", None))
     wire_context = to_wire_request_context(native) if native is not None else None

--- a/sdk/python/tests/test_runtime.py
+++ b/sdk/python/tests/test_runtime.py
@@ -323,6 +323,40 @@ class RequestTests(unittest.TestCase):
         self.assertEqual(request.workflow, {})
         self.assertEqual(request.idempotency_key, "")
         self.assertIsNone(request.context)
+        self.assertEqual(request.relay_token, "")
+
+    def test_relay_token_field_defaults_to_empty(self) -> None:
+        request = Request()
+        self.assertEqual(request.relay_token, "")
+
+    def test_relay_token_field_can_be_set(self) -> None:
+        request = Request(relay_token="test-capability-token")
+        self.assertEqual(request.relay_token, "test-capability-token")
+
+
+class RelayTokenExtractionTests(unittest.TestCase):
+    def test_extracts_relay_token_from_grpc_metadata(self) -> None:
+        from gestalt._runtime import _relay_token_from_context
+
+        class FakeContext:
+            def invocation_metadata(self):
+                return [("x-gestalt-host-service-relay-token", "cap-token-123")]
+
+        self.assertEqual(_relay_token_from_context(FakeContext()), "cap-token-123")
+
+    def test_returns_empty_when_no_relay_token_in_metadata(self) -> None:
+        from gestalt._runtime import _relay_token_from_context
+
+        class FakeContext:
+            def invocation_metadata(self):
+                return [("other-header", "value")]
+
+        self.assertEqual(_relay_token_from_context(FakeContext()), "")
+
+    def test_returns_empty_when_context_is_none(self) -> None:
+        from gestalt._runtime import _relay_token_from_context
+
+        self.assertEqual(_relay_token_from_context(None), "")
 
 
 class MainEntrypointTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Adds `relay_token` field to the `Request` dataclass in the Python SDK
- Extracts the per-request relay capability token from the `x-gestalt-host-service-relay-token` header in incoming gRPC metadata at the `Execute`, `ResolveHTTPSubject`, and `GetSessionCatalog` handler sites
- Threads the relay token through `App.connect`, `Agent.connect`, `Workflow.__init__`, and `gestalt_from_request` so caller-dependent host-service calls use the per-request capability token (with Caller claim) instead of the process-level env token (without Caller)
- Falls back to the env token when `relay_token` is empty, preserving backward compatibility

**Problem:** The deployed gestaltd enforces caller-capability requirements on `App.Invoke`, `Identity`, `Agent`, and `Workflow` RPCs. The process-level env token (`GESTALT_HOST_SERVICE_TOKEN`) has no `Caller` claim and is rejected with `invalid-host-service-relay-token`. Only the per-request capability token minted by `attachInvocationCapability` carries a `Caller`. The TypeScript SDK (alpha.83) already implements this via `request.gestalt()` and `RequestGestaltScope`. The Python SDK had no equivalent.

## Test plan

- [x] 224 Python SDK tests pass (219 existing + 5 new)
- [x] Go code compiles (no Go changes)
- [x] `Request.relay_token` field defaults to empty string
- [x] `_relay_token_from_context` extracts token from gRPC metadata
- [x] `_relay_token_from_context` returns empty when context is None or metadata is missing
- [x] `_relay_token_from_context` handles mock contexts gracefully (no crash)