### PR TITLE
Document install-time validation learnings from step 13

### DIFF
--- a/plans/app_registry/models.md
+++ b/plans/app_registry/models.md
@@ -230,11 +230,20 @@ Copied from the provider release `staticValidation.requires` block at publish ti
 
 #### `PublishedVersion.requires.apps` · `AppRequirement`
 
-Each key in `apps` is a dependency app name (e.g. `slack`). The value describes what this app needs from that dependency.
+Each key in `apps` identifies a dependency app. The value describes what this app needs from that dependency.
+
+**Key format.** Keys are copied verbatim from manifest `dependencies.apps` at publish time. They may be either:
+
+| Form | Example |
+|------|---------|
+| Short fleet app name | `slack` |
+| Full manifest source address | `github.com/valon-technologies/valon-tools/apps/slack` |
+
+Fleet catalog entries, deploy config app slots, and registry object paths (`apps/{app}/…`) always use the **short name** (`slack`). Install-time validation normalizes source-address keys to the short name before fleet lookup and reverse-dependent matching. New manifests should prefer short names for readability, but both forms are valid in published JSON.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `version` | string | no | Semver constraint on the dependency app, e.g. ^1.4.0. |
+| `version` | string | no | Semver constraint on the dependency app, e.g. ^1.4.0. Matched against fleet-known versions using snapshot-aware rules — see [validation.md](./validation.md#semver-constraint-matching). |
 | `operations` | map | no | Operation id → `OperationRequirement`. See below. |
 
 #### `PublishedVersion.requires.apps.{app}.operations` · `OperationRequirement`

--- a/plans/app_registry/tests.md
+++ b/plans/app_registry/tests.md
@@ -278,42 +278,86 @@ go test ./internal/server/... -run 'RegistryApp|RegistryOnly' -count=1
 
 ## Install-time validation tests
 
-Planned. Checks: [validation.md](./validation.md).
-
-Run (once implemented):
+Implemented in gestaltd. Checks: [validation.md](./validation.md).
 
 ```bash
 cd gestaltd
-go test ./internal/appregistry/... -run TestInstallValidator -count=1
-go test ./internal/server/... -run TestAdminAppRegistryInstall -count=1
+go test ./internal/appregistry/... -run 'TestInstallValidator|TestInstaller_validation_failure|TestInstallValidationReasonFrom|TestRequirement' -count=1
+go test ./internal/providerregistry/... -run TestVersionSatisfiesFleetConstraint -count=1
+go test ./internal/server/... -run TestAdminAppRegistryInstall/validation_failure -count=1
 ```
 
-### `install_validator_test.go` (planned)
+### `install_validator_test.go`
 
-One table-driven test, `TestInstallValidator`, with stub fleet catalog and synthetic `Entry` documents:
+Table-driven `TestInstallValidator` with stub fleet catalog (`AppVersionChangeRequests`) and synthetic `Entry` documents served over `httptest`.
+
+| Subtest | Reason code | Covers |
+|---------|-------------|--------|
+| `accepts_satisfied_dependencies` | — | Happy path: fleet-known dependency version and published `interface` satisfy declared `requires` (version + operation + `inputSchemaHash`) |
+| `accepts_snapshot_dependency_version` | — | Fleet-known dependency at `2.0.0-snapshot.*` satisfies candidate `requires` at `^2.0.0` |
+| `accepts_source_address_dependency_key` | — | Candidate `requires.apps` key is a full manifest source address (`github.com/…/apps/slack`); validator resolves to short fleet name `slack` |
+| `rejects_missing_platform_artifact` | `platform_artifact_missing` | Candidate `entry.Artifacts` has no artifact for gestaltd host platform |
+| `rejects_incompatible_gestaltd` | `gestaltd_version_incompatible` | `entry.compatibility.minGestaltdVersion` above `InstallValidator.GestaltdVersion` |
+| `accepts_ci_gestaltd_version` | — | `minGestaltdVersion` check skipped for CI build stamp `0.0.0-ci+g…` |
+| `rejects_incomplete_platform_artifact` | `platform_artifact_missing` | Platform key exists but artifact URL or SHA256 is incomplete (detail preserved from `resolveRegistryArtifact`) |
+| `rejects_unsatisfied_dependency/missing_dependency_app` | `dependency_not_installed` | Declared dependency has no fleet-known version |
+| `rejects_unsatisfied_dependency/version_outside_range` | `dependency_version_unsatisfied` | Fleet-known dependency version outside declared semver constraint |
+| `rejects_unsatisfied_dependency/missing_required_operation` | `dependency_operation_missing` | Fleet-known dependency published `interface` does not expose a required operation |
+| `rejects_broken_reverse_dependent` | `reverse_dependent_operation_missing` | Fleet-known dependent requires an operation the candidate `interface` does not publish |
+| `accepts_snapshot_reverse_dependent_version` | — | Upgrading dependency to `2.0.0-snapshot.*` satisfies reverse dependent `requires` at `^2.0.0` |
+| `rejects_reverse_dependent_version_constraint` | `reverse_dependent_version_unsatisfied` | Candidate version outside reverse dependent's declared semver constraint (short app key) |
+| `rejects_reverse_dependent_source_address_version_constraint` | `reverse_dependent_version_unsatisfied` | Same as above when dependent `requires.apps` key is a full source address |
+| `ignores_unrelated_reverse_dependent_missing_metadata` | — | Fleet-known app with missing published entry does not block install of an unrelated candidate |
+| `returns_registry_not_configured_for_reverse_dependent` | — | Missing registry config during reverse-dependent fetch returns `ErrAppRegistryNotConfigured` (HTTP **502**), not **404** |
+
+`TestInstaller_validation_failure_writes_nothing` — validation failure before `Rollouts.Create` / `AppendRequest`; asserts no rollout or change-request rows were written.
+
+### `requirement_app_test.go`
+
+| Test | Covers |
+|------|--------|
+| `TestRequirementAppName` | Short name (`slack`) and source address (`github.com/…/apps/slack`) both normalize to `slack` |
+| `TestRequirementForApp` | Reverse lookup finds a requirement keyed by source address when queried by short name |
+
+### `install_validation_errors_test.go`
+
+| Test | Covers |
+|------|--------|
+| `TestInstallValidationReasonFrom` | `InstallValidationReasonFrom` returns stable reason codes; failures wrap `ErrInstallValidationFailed` |
+
+### `providerregistry/registry_test.go`
+
+| Test | Covers |
+|------|--------|
+| `TestVersionSatisfiesFleetConstraint` | Snapshot versions match release constraints on `major.minor.patch`; prerelease constraints stay strict; release versions behave like `VersionSatisfiesConstraint` |
+
+### `handlers_admin_app_install_test.go`
 
 | Subtest | Covers |
 |---------|--------|
-| `accepts_satisfied_dependencies` | Happy path when catalog, entry, and dependency metadata align |
-| `rejects_missing_platform_artifact` | No artifact for host platform |
-| `rejects_incompatible_gestaltd` | `minGestaltdVersion` above running server version |
-| `rejects_unsatisfied_dependency` | Missing dependency app, version outside declared range, or required operation absent from published `interface` |
-| `rejects_broken_reverse_dependent` | Another fleet-known app's `requires.apps.{app}` would break on the candidate `interface` |
+| `validation_failure` | `POST …/add` with `minGestaltdVersion` above `cfg.GestaltdVersion` returns **400** and writes nothing to IndexedDB. `upgrade` shares the same `Installer.install` path. HTTP tests must set `cfg.GestaltdVersion` explicitly. |
 
-### `handlers_admin_app_install_test.go` (extend)
+### Not covered yet
 
-Add one HTTP case to the existing install test file (same harness as today):
-
-- **`validation_failure`** on `POST …/upgrade` — inject a validator failure, assert **400**, and assert no `app_rollouts` or `app_version_change_requests` rows were created. `add` shares the same `Installer.install` path, so it does not need a separate case.
+| Gap | Reason code / behavior |
+|-----|------------------------|
+| `gestaltd_version_invalid` | Candidate declares unparseable `minGestaltdVersion` |
+| `gestaltd_version_unknown` | Running gestaltd version is not semver (and not `dev` / `(devel)` / `0.0.0-ci+g…`) |
+| `dependency_metadata_missing` | Operation check needed but fleet-known dependency `versions/{version}.json` is missing |
+| `dependency_operation_schema_mismatch` | Dependency operation `inputSchemaHash` does not match |
+| `reverse_dependent_metadata_missing` | Reverse check needed but fleet-known dependent published entry is missing |
+| `reverse_dependent_operation_schema_mismatch` | Candidate operation `inputSchemaHash` does not match reverse dependent requirement |
+| Deploy-pinned dependency skip | Candidate `requires.apps.{app}` satisfied by non-registry `config.yaml` provider |
+| Registry transport during validation | Network/transport failure while fetching dependency or reverse-dependent metadata → **502** |
 
 ---
 
 ## What is not covered yet
 
-Publish tests validate **CLI dry-run behavior** only. Install HTTP tests cover the happy path, 404 on missing version, and get-by-app — but not:
+Publish tests validate **CLI dry-run behavior** only. Install HTTP tests cover the happy path, 404 on missing version, get-by-app, and one validation-failure case — but not:
 
 - Real GCS upload integration
 - Re-install idempotency (no duplicate change request)
-- Install-time validation failure modes
+- Full install-time validation reason-code matrix (see [install-time validation tests](#install-time-validation-tests))
 - Multi-replica materialization ack E2E (see [PLANNED] section above)
 - Deployed verification that catalog restarts serve the newly mounted binary

--- a/plans/app_registry/validation.md
+++ b/plans/app_registry/validation.md
@@ -1,6 +1,6 @@
 # Install-Time Validation
 
-Checks on `POST …/add` and `POST …/upgrade` after the registry entry is fetched and before `Rollouts.Create` and `AppendRequest`. Failure returns **400** and writes nothing to IndexedDB.
+Checks on `POST …/add` and `POST …/upgrade` after the registry entry is fetched and before `Rollouts.Create` and `AppendRequest`. Validation failures return **400**, write nothing to IndexedDB, and wrap `ErrInstallValidationFailed` with a stable **reason** code (see below).
 
 Related docs:
 
@@ -8,30 +8,131 @@ Related docs:
 - [models.md](./models.md) — `requires` and `compatibility` on published version JSON
 - [tests.md](./tests.md#install-time-validation-tests) — tests
 
-Implementation (planned): `gestaltd/internal/appregistry/install_validator.go`; called from `installer.go` before `Rollouts.Create`.
+Implementation: `gestaltd/internal/appregistry/install_validator.go` and `install_validation_errors.go`; called from `installer.go` before `Rollouts.Create`.
 
 ## Checks
 
-| Check | Source | Failure |
-|-------|--------|---------|
-| Platform artifact | `entry.Artifacts` for gestaltd host OS/arch (e.g. `linux/amd64`) | **400** — no artifact for platform |
-| Gestalt version | `entry.compatibility.minGestaltdVersion` vs running `gestaltd` (when set) | **400** — gestaltd too old |
-| Dependency present | Each `entry.requires.apps` entry has a fleet-known version, or a deploy-pinned non-registry provider | **400** |
-| Dependency version | Fleet-known version satisfies `requires.apps.{app}.version` | **400** |
-| Dependency operations | Dependency published `interface` exposes each required operation; `inputSchemaHash` matches when set | **400** |
-| Reverse dependents | No other fleet-known app has a `requires.apps.{app}` entry broken by the candidate `interface` | **400** |
+| Check | Source | Reason code |
+|-------|--------|-------------|
+| Platform artifact | `entry.Artifacts` for gestaltd host OS/arch | `platform_artifact_missing` |
+| Gestalt version | `entry.compatibility.minGestaltdVersion` vs running gestaltd | `gestaltd_version_incompatible`, `gestaltd_version_invalid`, `gestaltd_version_unknown` |
+| Dependency present | Each `entry.requires.apps` entry has a fleet-known version, or a deploy-pinned non-registry provider | `dependency_not_installed` |
+| Dependency version | Fleet-known version satisfies `requires.apps.{app}.version` | `dependency_version_unsatisfied` |
+| Dependency operations | Dependency published `interface` exposes required operations; `inputSchemaHash` matches when set | `dependency_operation_missing`, `dependency_operation_schema_mismatch`, `dependency_metadata_missing` |
+| Reverse dependents | No fleet-known app has a broken `requires.apps.{app}` on the candidate **version** or `interface` | `reverse_dependent_version_unsatisfied`, `reverse_dependent_operation_missing`, `reverse_dependent_operation_schema_mismatch`, `reverse_dependent_metadata_missing` |
+
+## Validation errors
+
+Each failure is an `InstallValidationError` with a stable `InstallValidationReason`. Programmatic callers use `InstallValidationReasonFrom(err)`. The admin API returns the full string in the `error` field.
+
+| Reason | HTTP | IndexedDB | When |
+|--------|------|-----------|------|
+| `platform_artifact_missing` | **400** | none | Candidate `entry.Artifacts` has no usable artifact for the gestaltd host platform (missing platform key, URL, or SHA256 — detail comes from `resolveRegistryArtifact`) |
+| `gestaltd_version_incompatible` | **400** | none | Running gestaltd is older than `entry.compatibility.minGestaltdVersion` |
+| `gestaltd_version_invalid` | **400** | none | Candidate declares an unparseable `minGestaltdVersion` |
+| `gestaltd_version_unknown` | **400** | none | Running gestaltd version is not semver and not a skipped non-production stamp (see below) |
+| `dependency_not_installed` | **400** | none | Candidate `requires.apps.{app}` but app has no fleet-known version and is not deploy-pinned |
+| `dependency_version_unsatisfied` | **400** | none | Fleet-known dependency version does not satisfy the candidate's version constraint |
+| `dependency_metadata_missing` | **400** | none | Operation check needed but fleet-known dependency's `versions/{version}.json` is missing |
+| `dependency_operation_missing` | **400** | none | Dependency published `interface` does not expose a required operation |
+| `dependency_operation_schema_mismatch` | **400** | none | Dependency operation `inputSchemaHash` does not match |
+| `reverse_dependent_metadata_missing` | **400** | none | Reverse check needed but a fleet-known dependent's published entry is missing |
+| `reverse_dependent_version_unsatisfied` | **400** | none | Candidate version does not satisfy a reverse dependent's version constraint |
+| `reverse_dependent_operation_missing` | **400** | none | Candidate `interface` missing an operation required by a reverse dependent |
+| `reverse_dependent_operation_schema_mismatch` | **400** | none | Candidate operation `inputSchemaHash` does not match a reverse dependent's requirement |
+
+### Non-validation failures during install
+
+These are **not** `InstallValidationError` and are enforced outside `InstallValidator`:
+
+| Situation | HTTP | IndexedDB |
+|-----------|------|-----------|
+| Candidate `versions/{version}.json` not found (installer fetch) | **404** | none |
+| Registry transport / infra error fetching candidate | **502** | none |
+| Registry named in a fleet-known installation is missing from gestaltd config (`ErrAppRegistryNotConfigured`) | **502** | none |
+| Active rollout, install lock, duplicate version, `add`/`upgrade` mode mismatch | **409** / **400** | none — see [lifecycle.md](./lifecycle.md) |
+
+Do **not** map validation-time registry/config failures to **404** just because the error text contains “registry not found”. Only the candidate's own missing `versions/{version}.json` should surface as **404**.
+
+## Implementation contracts
+
+These behaviors are easy to miss when implementing from the checks table alone.
+
+### Running gestaltd version
+
+`minGestaltdVersion` is compared to `server.Config.GestaltdVersion` (ldflags-injected build version wired through `gestaltd serve` → `Installer.GestaltdVersion`). Do **not** use `debug.ReadBuildInfo()` as the production source.
+
+Checks are **skipped** (treated as incomparable) when the running version is:
+
+| Stamp | Example |
+|-------|---------|
+| Local dev build | `dev` |
+| Go toolchain devel | `(devel)` |
+| CI image stamp | `0.0.0-ci+g<sha12>` from `resolve-gestaltd-ref.yml` |
+
+HTTP and unit tests that exercise `gestaltd_version_incompatible` must set `GestaltdVersion` explicitly; leaving it unset falls back to `dev` and skips the check.
+
+### `requires.apps` key normalization
+
+Published `requires.apps` keys are copied verbatim from manifest `dependencies.apps`. Keys may be **short fleet names** (`slack`) or **full manifest source addresses** (`github.com/org/repo/apps/slack`). Fleet catalog, config, and registry paths always use the short name.
+
+Install validation normalizes keys to the short name before fleet lookup (forward checks) and before matching reverse dependents. See [models.md](./models.md).
+
+### Metadata fetch scope
+
+| Check | Uses fleet-known version from IndexedDB | Fetches `versions/{version}.json` |
+|-------|----------------------------------------|-----------------------------------|
+| Dependency present | yes | no |
+| Dependency version | yes | no |
+| Dependency operations / `inputSchemaHash` | yes | yes — missing → `dependency_metadata_missing` |
+| Reverse dependents | scans all fleet-known apps | yes, per dependent — see below |
+
+Do not fetch dependency metadata when the candidate only declares a version constraint and no operations.
+
+### Reverse dependents
+
+For each fleet-known app other than the candidate:
+
+1. Fetch the dependent's published entry.
+2. If the dependent's `requires.apps` does not reference the candidate (after key normalization), skip.
+3. If it does, validate the candidate **version** against the dependent's version constraint and the candidate `interface` against required operations / hashes.
+
+**Missing published metadata:**
+
+| Case | Behavior |
+|------|----------|
+| Fleet-known app unrelated to the candidate; published entry missing | Skip — cannot evaluate a reverse requirement without metadata |
+| Fleet-known dependent requires the candidate; published entry missing | **400** `reverse_dependent_metadata_missing` when the fetch error is `ErrRegistryDocumentNotFound` |
+| Registry not configured for a dependent's installation | **502** `ErrAppRegistryNotConfigured` — not **404** |
+
+Reverse-dependent operation failures must attribute the missing operation to the **candidate** (`reverse dependent g-issues requires candidate slack: operation postMessage is not published`), not to the dependent.
+
+### Semver constraint matching
+
+Fleet versions commonly use snapshot prereleases (`2.0.0-snapshot.gabc123`, `0.0.0-snapshot.gabc123`). Masterminds semver excludes prereleases by default, so install validation uses release-line matching:
+
+- Compare the fleet version's `major.minor.patch` against release constraints such as `^2.0.0`.
+- `2.0.0-snapshot.*` satisfies `^2.0.0`; `0.0.0-snapshot.*` does **not** satisfy `^1.4.0` or `^2.0.0`.
+- When the **constraint** itself contains prerelease terms (for example `^2.0.0-beta`), matching stays strict — no release-line fallback.
+
+### Deploy-pinned dependencies
+
+When `config.yaml` pins a dependency app with a non-registry source (git, package, local, etc.), install validation skips presence checks for that app. Fleet-known registry versions are not required.
 
 ## Failure examples
 
 | Check | Example |
 |-------|---------|
 | Platform artifact | Upgrading `g-issues` to a version published with only `darwin/arm64` while gestaltd runs on `linux/amd64` in Kubernetes. |
+| Platform artifact (incomplete) | Candidate has a `linux/amd64` artifact entry but `sha256` is empty. |
 | Gestalt version | Candidate sets `compatibility.minGestaltdVersion: "0.7.0"` but the handling replica is running gestaltd `0.6.2`. |
 | Dependency present | Candidate `requires.apps.slack` but `slack` has no fleet-known version and is not a deploy-pinned provider in `config.yaml`. |
+| Dependency present (source address key) | Candidate `requires.apps["github.com/org/repo/apps/slack"]` with fleet-known `slack` at `2.0.0` — passes after key normalization. |
 | Dependency version | Candidate requires `slack` at `^2.0.0` but the fleet-known slack version is `1.4.0`. |
+| Dependency version (snapshot) | Candidate requires `slack` at `^2.0.0` and fleet-known slack is `2.0.0-snapshot.gabc123`. |
 | Dependency operations | Candidate requires slack operation `channels.list` with `inputSchemaHash: sha256:abc…` but the fleet-known slack version's published `interface` dropped that operation or changed the input schema. |
-| Reverse dependents | Upgrading `slack` to a version that removes `postMessage` from its published `interface` while fleet-known `g-issues` still declares `requires.apps.slack.operations` including `postMessage`. |
-
-Registry-only dependencies are validated against the fleet-known version's published metadata (`versions/{version}.json`).
+| Reverse dependents (version) | Upgrading `slack` to `3.0.0` while fleet-known `g-issues` requires `slack: ^2.0.0`. |
+| Reverse dependents (operations) | Upgrading `slack` to a version that removes `postMessage` from its published `interface` while fleet-known `g-issues` still requires that operation. |
+| Registry not configured | Fleet-known `g-issues` references registry `toolshed`, but gestaltd config has no `toolshed` entry — **502**, not **404**. |
 
 Other admission rules (registry binding, `add`/`upgrade` mode, duplicate version, active rollout, install lock) are enforced in `Installer.install` — see [lifecycle.md](./lifecycle.md).


### PR DESCRIPTION
## Summary
- Expand `validation.md` with implementation contracts discovered during step 13: gestaltd version wiring, `requires.apps` key normalization, semver/snapshot matching, metadata fetch scope, reverse-dependent behavior, and the 400/404/502 error taxonomy.
- Update `models.md` to document that `requires.apps` keys may be short names or full manifest source addresses.
- Replace the planned install-time validation test matrix in `tests.md` with the implemented subtests and remaining coverage gaps.

## Test plan
- [x] Docs-only change; review for accuracy against `gestaltd/internal/appregistry/install_validator.go`
- [ ] Cross-check with merged step 13 implementation PR (#2887) when landing


Made with [Cursor](https://cursor.com)