### PR TITLE
Document app registry install-time validation (step 13)

### DIFF
--- a/plans/app_registry/lifecycle.md
+++ b/plans/app_registry/lifecycle.md
@@ -475,7 +475,7 @@ Errors use the standard gestaltd admin API error envelope (`error` field).
 | `400` | Missing path param; invalid `app` name; invalid JSON body; missing `version`; unsupported registry `kind` (non-`gcs`); app version already installed; `upgrade` called when the app has no fleet-known versions; **install-time validation failed** |
 | `404` | Unknown `registry` name; published version not found; no known versions for `{app}`; no `appRegistries` configured |
 | `409` | Another instance is already installing this `(app, version)` (install lock held and not expired); `add` called when the app already has fleet-known versions |
-| `502` | Published version fetch failed; failed to append `change request` record; upstream fetch of `apps/{app}/index.json` failed (network, non-2xx other than 404, invalid JSON) |
+| `502` | Published version fetch failed; registry fetch failed during install validation; registry named in a fleet-known installation is missing from gestaltd config; failed to append `change request` record; upstream fetch of `apps/{app}/index.json` failed (network, non-2xx other than 404, invalid JSON) |
 | `500` | Registry `publicUrl` could not be derived from config; unexpected catalog projection failure |
 | `503` | Version catalog service or installer not configured |
 

--- a/plans/app_registry/models.md
+++ b/plans/app_registry/models.md
@@ -226,15 +226,15 @@ Copied from the provider release `staticValidation.requires` block at publish ti
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `apps` | map | no | Dependency app name → `AppRequirement`. See below. |
+| `apps` | map | no | Dependency app key → `AppRequirement`. See below. |
 
 #### `PublishedVersion.requires.apps` · `AppRequirement`
 
-Each key in `apps` is a dependency app name (e.g. `slack`). The value describes what this app needs from that dependency.
+Each key in `apps` identifies a dependency app. Keys are copied verbatim from manifest `dependencies.apps` at publish time. A key may be a short fleet app name (`slack`) or a full manifest source address (`github.com/valon-technologies/valon-tools/apps/slack`). Fleet catalog entries, deploy config app slots, and registry object paths (`apps/{app}/…`) always use the short name. Install-time validation normalizes source-address keys before fleet lookup and reverse-dependent matching — see [validation.md](./validation.md#requiresapps-keys).
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `version` | string | no | Semver constraint on the dependency app, e.g. ^1.4.0. |
+| `version` | string | no | Semver constraint on the dependency app, e.g. ^1.4.0. Matched against fleet-known versions using snapshot-aware rules — see [validation.md](./validation.md#semver-constraint-matching). |
 | `operations` | map | no | Operation id → `OperationRequirement`. See below. |
 
 #### `PublishedVersion.requires.apps.{app}.operations` · `OperationRequirement`

--- a/plans/app_registry/tests.md
+++ b/plans/app_registry/tests.md
@@ -25,7 +25,7 @@ Related docs:
 | `internal/coredata` | `app_rollouts_test.go`, `app_version_install_locks_test.go` | 3 | Unit | [gestalt#2812](https://github.com/valon-technologies/gestalt/pull/2812) |
 | `internal/bootstrap` | `app_provider_restart_test.go`, `app_provider_restart_mount_test.go`, `app_provider_lifecycle_test.go` | 8 | Unit/integration | [gestalt#2812](https://github.com/valon-technologies/gestalt/pull/2812) |
 | `internal/config`, `internal/operator`, `internal/appregistry`, `internal/bootstrap` | registry-only source tests | — | Unit/integration | — |
-| `internal/appregistry` | `install_validator_test.go` | — | Unit | planned |
+| `internal/appregistry` | `install_validator_test.go`, `install_validation_errors_test.go` | — | Unit | planned |
 
 Test fixture for install HTTP tests: `internal/appregistry/registrytest/fixture.go`
 
@@ -284,36 +284,79 @@ Run (once implemented):
 
 ```bash
 cd gestaltd
-go test ./internal/appregistry/... -run TestInstallValidator -count=1
-go test ./internal/server/... -run TestAdminAppRegistryInstall -count=1
+go test ./internal/appregistry/... -run 'TestInstallValidator|TestInstaller_validation_failure|TestInstallValidationReasonFrom' -count=1
+go test ./internal/providerregistry/... -run TestVersionSatisfiesFleetConstraint -count=1
+go test ./internal/server/... -run TestAdminAppRegistryInstall/validation_failure -count=1
 ```
 
-### `install_validator_test.go` (planned)
+### `install_validator_test.go`
 
-One table-driven test, `TestInstallValidator`, with stub fleet catalog and synthetic `Entry` documents:
+Table-driven `TestInstallValidator` with stub fleet catalog (`AppVersionChangeRequests`) and synthetic `Entry` documents served over `httptest`.
+
+| Subtest | Reason code | Covers |
+|---------|-------------|--------|
+| `accepts_dependencies/release_with_operations` | — | Happy path: fleet-known dependency version and published `interface` satisfy declared `requires` (version + operation + `inputSchemaHash`) |
+| `accepts_dependencies/snapshot_version` | — | Fleet-known dependency at `2.0.0-snapshot.*` satisfies candidate `requires` at `^2.0.0` |
+| `accepts_dependencies/source_address_key` | — | Candidate `requires.apps` key is a full manifest source address (`github.com/…/apps/slack`); validator resolves to short fleet name `slack` |
+| `rejects_platform_artifact/missing_host_platform` | `platform_artifact_missing` | Candidate `entry.Artifacts` has no artifact for gestaltd host platform |
+| `rejects_platform_artifact/incomplete_sha256` | `platform_artifact_missing` | Platform key exists but artifact URL or SHA256 is incomplete (detail preserved from `resolveRegistryArtifact`) |
+| `gestaltd_version/incompatible` | `gestaltd_version_incompatible` | `entry.compatibility.minGestaltdVersion` above `InstallValidator.GestaltdVersion` |
+| `gestaltd_version/ci_stamp_skipped` | — | `minGestaltdVersion` check skipped for CI build stamp `0.0.0-ci+g…` |
+| `rejects_unsatisfied_dependency/missing_dependency_app` | `dependency_not_installed` | Declared dependency has no fleet-known version |
+| `rejects_unsatisfied_dependency/version_outside_range` | `dependency_version_unsatisfied` | Fleet-known dependency version outside declared semver constraint |
+| `rejects_unsatisfied_dependency/missing_required_operation` | `dependency_operation_missing` | Fleet-known dependency published `interface` does not expose a required operation |
+| `reverse_dependents/operation_missing` | `reverse_dependent_operation_missing` | Fleet-known dependent requires an operation the candidate `interface` does not publish |
+| `reverse_dependents/snapshot_version_accepted` | — | Upgrading dependency to `2.0.0-snapshot.*` satisfies reverse dependent `requires` at `^2.0.0` |
+| `reverse_dependents/version_outside_range` | `reverse_dependent_version_unsatisfied` | Candidate version outside reverse dependent's declared semver constraint (short app key) |
+| `reverse_dependents/version_outside_range_source_address_key` | `reverse_dependent_version_unsatisfied` | Same as above when dependent `requires.apps` key is a full source address |
+| `reverse_dependent_infra/ignores_unrelated_missing_metadata` | — | Fleet-known app with missing published entry does not block install of an unrelated candidate |
+| `reverse_dependent_infra/registry_not_configured` | — | Missing registry config during reverse-dependent fetch returns `ErrAppRegistryNotConfigured` (HTTP **502**), not **404** |
+
+`TestInstaller_validation_failure_writes_nothing` — validation failure before `Rollouts.Create` / `AppendRequest`; asserts no rollout or change-request rows were written.
+
+Source-address `requires.apps` keys are covered by `accepts_dependencies/source_address_key` and `reverse_dependents/version_outside_range_source_address_key`.
+
+### `install_validation_errors_test.go`
+
+| Test | Covers |
+|------|--------|
+| `TestInstallValidationReasonFrom` | `InstallValidationReasonFrom` returns stable reason codes; failures wrap `ErrInstallValidationFailed` |
+
+### `providerregistry/registry_test.go`
+
+| Test | Covers |
+|------|--------|
+| `TestVersionSatisfiesFleetConstraint` | Snapshot versions match release constraints on `major.minor.patch`; prerelease constraints stay strict; release versions behave like `VersionSatisfiesConstraint` |
+
+### `handlers_admin_app_install_test.go`
 
 | Subtest | Covers |
 |---------|--------|
-| `accepts_satisfied_dependencies` | Happy path when catalog, entry, and dependency metadata align |
-| `rejects_missing_platform_artifact` | No artifact for host platform |
-| `rejects_incompatible_gestaltd` | `minGestaltdVersion` above running server version |
-| `rejects_unsatisfied_dependency` | Missing dependency app, version outside declared range, or required operation absent from published `interface` |
-| `rejects_broken_reverse_dependent` | Another fleet-known app's `requires.apps.{app}` would break on the candidate `interface` |
+| `validation_failure` | `POST …/add` with `minGestaltdVersion` above `cfg.GestaltdVersion` returns **400** and writes nothing to IndexedDB. `upgrade` shares the same `Installer.install` path. |
 
-### `handlers_admin_app_install_test.go` (extend)
+### Not covered yet
 
-Add one HTTP case to the existing install test file (same harness as today):
-
-- **`validation_failure`** on `POST …/upgrade` — inject a validator failure, assert **400**, and assert no `app_rollouts` or `app_version_change_requests` rows were created. `add` shares the same `Installer.install` path, so it does not need a separate case.
+| Gap | Reason code / behavior |
+|-----|------------------------|
+| `gestaltd_version_invalid` | Candidate declares unparseable `minGestaltdVersion` |
+| `gestaltd_version_unknown` | Running gestaltd version is not semver (and not `dev` / `(devel)` / `0.0.0-ci+g…`) |
+| `dependency_metadata_missing` | Operation check needed but fleet-known dependency `versions/{version}.json` is missing |
+| `dependency_operation_schema_mismatch` | Dependency operation `inputSchemaHash` does not match |
+| `reverse_dependent_metadata_missing` | Reverse check needed but fleet-known dependent published entry is missing |
+| `reverse_dependent_operation_schema_mismatch` | Candidate operation `inputSchemaHash` does not match reverse dependent requirement |
+| Deploy-pinned dependency skip | Candidate `requires.apps.{app}` satisfied by non-registry `config.yaml` provider |
+| `dev` / `(devel)` / CI gestaltd skip | `minGestaltdVersion` check skipped when running version is non-production (`dev`, `(devel)`, `0.0.0-ci+g…`) |
+| Registry transport vs validation HTTP split | Missing published metadata → **400**; registry fetch/transport failure → **502** |
+| Skip dependency fetch when no operations | Version-only `requires` does not fetch dependency `versions/{version}.json` |
 
 ---
 
 ## What is not covered yet
 
-Publish tests validate **CLI dry-run behavior** only. Install HTTP tests cover the happy path, 404 on missing version, and get-by-app — but not:
+Publish tests validate **CLI dry-run behavior** only. Install HTTP tests cover the happy path, 404 on missing version, get-by-app, and one validation-failure case — but not:
 
 - Real GCS upload integration
 - Re-install idempotency (no duplicate change request)
-- Install-time validation failure modes
+- Full install-time validation reason-code matrix (see [install-time validation tests](#install-time-validation-tests))
 - Multi-replica materialization ack E2E (see [PLANNED] section above)
 - Deployed verification that catalog restarts serve the newly mounted binary

--- a/plans/app_registry/validation.md
+++ b/plans/app_registry/validation.md
@@ -1,6 +1,6 @@
 # Install-Time Validation
 
-Checks on `POST …/add` and `POST …/upgrade` after the registry entry is fetched and before `Rollouts.Create` and `AppendRequest`. Failure returns **400** and writes nothing to IndexedDB.
+Checks on `POST …/add` and `POST …/upgrade` after the registry entry is fetched and before `Rollouts.Create` and `AppendRequest`. Validation failures return **400**, write nothing to IndexedDB, and wrap `ErrInstallValidationFailed` with a stable **reason** code (see below).
 
 Related docs:
 
@@ -8,30 +8,125 @@ Related docs:
 - [models.md](./models.md) — `requires` and `compatibility` on published version JSON
 - [tests.md](./tests.md#install-time-validation-tests) — tests
 
-Implementation (planned): `gestaltd/internal/appregistry/install_validator.go`; called from `installer.go` before `Rollouts.Create`.
-
 ## Checks
 
-| Check | Source | Failure |
-|-------|--------|---------|
-| Platform artifact | `entry.Artifacts` for gestaltd host OS/arch (e.g. `linux/amd64`) | **400** — no artifact for platform |
-| Gestalt version | `entry.compatibility.minGestaltdVersion` vs running `gestaltd` (when set) | **400** — gestaltd too old |
-| Dependency present | Each `entry.requires.apps` entry has a fleet-known version, or a deploy-pinned non-registry provider | **400** |
-| Dependency version | Fleet-known version satisfies `requires.apps.{app}.version` | **400** |
-| Dependency operations | Dependency published `interface` exposes each required operation; `inputSchemaHash` matches when set | **400** |
-| Reverse dependents | No other fleet-known app has a `requires.apps.{app}` entry broken by the candidate `interface` | **400** |
+| Check | Source | Reason code |
+|-------|--------|-------------|
+| Platform artifact | `entry.Artifacts` for gestaltd host OS/arch | `platform_artifact_missing` |
+| gestaltd version | `entry.compatibility.minGestaltdVersion` vs running gestaltd | `gestaltd_version_incompatible`, `gestaltd_version_invalid`, `gestaltd_version_unknown` |
+| Dependency present | Each `entry.requires.apps` entry has a fleet-known version, or a deploy-pinned non-registry provider | `dependency_not_installed` |
+| Dependency version | Fleet-known version satisfies `requires.apps.{app}.version` | `dependency_version_unsatisfied` |
+| Dependency operations | Dependency published `interface` exposes required operations; `inputSchemaHash` matches when set | `dependency_operation_missing`, `dependency_operation_schema_mismatch`, `dependency_metadata_missing` |
+| Reverse dependents | No fleet-known app has a broken `requires.apps.{app}` on the candidate version or `interface` | `reverse_dependent_version_unsatisfied`, `reverse_dependent_operation_missing`, `reverse_dependent_operation_schema_mismatch`, `reverse_dependent_metadata_missing` |
+
+## Validation errors
+
+Each failure is an `InstallValidationError` with a stable `InstallValidationReason`. Programmatic callers use `InstallValidationReasonFrom(err)`. The admin API returns the full string in the `error` field.
+
+| Reason | HTTP | IndexedDB | When |
+|--------|------|-----------|------|
+| `platform_artifact_missing` | **400** | none | Candidate `entry.Artifacts` has no usable artifact for the gestaltd host platform (missing platform key, URL, or SHA256) |
+| `gestaltd_version_incompatible` | **400** | none | Running gestaltd is older than `entry.compatibility.minGestaltdVersion` |
+| `gestaltd_version_invalid` | **400** | none | Candidate declares an unparseable `minGestaltdVersion` |
+| `gestaltd_version_unknown` | **400** | none | Running gestaltd version is not semver and not a skipped non-production stamp (see [Running gestaltd version](#running-gestaltd-version)) |
+| `dependency_not_installed` | **400** | none | Candidate `requires.apps.{app}` but app has no fleet-known version and is not deploy-pinned |
+| `dependency_version_unsatisfied` | **400** | none | Fleet-known dependency version does not satisfy the candidate's version constraint |
+| `dependency_metadata_missing` | **400** | none | Operation check needed but fleet-known dependency's `versions/{version}.json` is missing |
+| `dependency_operation_missing` | **400** | none | Dependency published `interface` does not expose a required operation |
+| `dependency_operation_schema_mismatch` | **400** | none | Dependency operation `inputSchemaHash` does not match |
+| `reverse_dependent_metadata_missing` | **400** | none | Reverse check needed but a fleet-known dependent's published entry is missing |
+| `reverse_dependent_version_unsatisfied` | **400** | none | Candidate version does not satisfy a reverse dependent's version constraint |
+| `reverse_dependent_operation_missing` | **400** | none | Candidate `interface` missing an operation required by a reverse dependent |
+| `reverse_dependent_operation_schema_mismatch` | **400** | none | Candidate operation `inputSchemaHash` does not match a reverse dependent's requirement |
+
+### Non-validation failures during install
+
+These are **not** `InstallValidationError` and are enforced outside `InstallValidator`:
+
+| Situation | HTTP | IndexedDB |
+|-----------|------|-----------|
+| Candidate `versions/{version}.json` not found (installer fetch) | **404** | none |
+| Registry transport or infra error fetching the candidate | **502** | none |
+| Registry named in a fleet-known installation is missing from gestaltd config (`ErrAppRegistryNotConfigured`) | **502** | none |
+| Active rollout, install lock, duplicate version, `add`/`upgrade` mode mismatch | **409** / **400** | none — see [lifecycle.md](./lifecycle.md) |
+
+Missing dependency or reverse-dependent `versions/{version}.json` documents during validation return **400** (or are skipped when the dependent is unrelated). They must not map to **404** just because the error text contains “registry not found”. Only the candidate's own missing version document surfaces **404** — see [lifecycle.md](./lifecycle.md#errors).
+
+## Running gestaltd version
+
+`minGestaltdVersion` is compared to `server.Config.GestaltdVersion` (ldflags-injected build version wired through `gestaltd serve` → `Installer.GestaltdVersion`).
+
+The check is skipped when the running version is a non-production stamp:
+
+| Stamp | Example |
+|-------|---------|
+| Local dev build | `dev` |
+| Go toolchain devel | `(devel)` |
+| CI image stamp | `0.0.0-ci+g<sha12>` |
+
+HTTP and unit tests that exercise `gestaltd_version_incompatible` must set `GestaltdVersion` explicitly. When unset, the validator falls back to `dev` and skips the check.
+
+## Dependency checks
+
+### `requires.apps` keys
+
+Published `requires.apps` keys are copied verbatim from manifest `dependencies.apps`. Keys may be short fleet names (`slack`) or full manifest source addresses (`github.com/org/repo/apps/slack`). Fleet catalog, deploy config app slots, and registry object paths (`apps/{app}/…`) always use the short name. Install validation normalizes source-address keys to the short name before fleet lookup and reverse-dependent matching. See [models.md](./models.md).
+
+### Metadata fetch scope
+
+| Check | Uses fleet-known version from IndexedDB | Fetches `versions/{version}.json` |
+|-------|----------------------------------------|-----------------------------------|
+| Dependency present | yes | no |
+| Dependency version | yes | no |
+| Dependency operations / `inputSchemaHash` | yes | yes — missing → `dependency_metadata_missing` |
+| Reverse dependents | scans all fleet-known apps | yes, per dependent |
+
+Dependency metadata is not fetched when the candidate declares only a version constraint and no operations.
+
+### Deploy-pinned dependencies
+
+When `config.yaml` pins a dependency app with a non-registry source (git, package, local, etc.), install validation skips presence checks for that app. Fleet-known registry versions are not required.
+
+## Reverse dependents
+
+For each fleet-known app other than the candidate:
+
+1. Fetch the dependent's published entry.
+2. If the dependent's `requires.apps` does not reference the candidate (after key normalization), skip.
+3. Otherwise validate the candidate version against the dependent's version constraint and the candidate `interface` against required operations and `inputSchemaHash` values.
+
+Missing published metadata:
+
+| Case | Behavior |
+|------|----------|
+| Fleet-known app unrelated to the candidate; published entry missing | Skip |
+| Fleet-known dependent requires the candidate; published entry missing | **400** `reverse_dependent_metadata_missing` |
+| Registry not configured for a dependent's installation | **502** `ErrAppRegistryNotConfigured` |
+
+Reverse-dependent operation failures attribute the missing operation to the candidate (for example, `reverse dependent g-issues requires candidate slack: operation postMessage is not published`).
+
+## Semver constraint matching
+
+Fleet versions commonly use snapshot prereleases (`2.0.0-snapshot.gabc123`, `0.0.0-snapshot.gabc123`). Masterminds semver excludes prereleases by default, so install validation compares the fleet version's `major.minor.patch` release line against constraints such as `^2.0.0`:
+
+- `2.0.0-snapshot.*` satisfies `^2.0.0`.
+- `0.0.0-snapshot.*` does not satisfy `^1.4.0` or `^2.0.0`.
+- When the constraint itself contains prerelease terms (for example `^2.0.0-beta`), matching stays strict with no release-line fallback.
 
 ## Failure examples
 
 | Check | Example |
 |-------|---------|
 | Platform artifact | Upgrading `g-issues` to a version published with only `darwin/arm64` while gestaltd runs on `linux/amd64` in Kubernetes. |
-| Gestalt version | Candidate sets `compatibility.minGestaltdVersion: "0.7.0"` but the handling replica is running gestaltd `0.6.2`. |
+| Platform artifact (incomplete) | Candidate has a `linux/amd64` artifact entry but `sha256` is empty. |
+| gestaltd version | Candidate sets `compatibility.minGestaltdVersion: "0.7.0"` but the handling replica is running gestaltd `0.6.2`. |
 | Dependency present | Candidate `requires.apps.slack` but `slack` has no fleet-known version and is not a deploy-pinned provider in `config.yaml`. |
+| Dependency present (source address key) | Candidate `requires.apps["github.com/org/repo/apps/slack"]` with fleet-known `slack` at `2.0.0`. |
 | Dependency version | Candidate requires `slack` at `^2.0.0` but the fleet-known slack version is `1.4.0`. |
+| Dependency version (snapshot) | Candidate requires `slack` at `^2.0.0` and fleet-known slack is `2.0.0-snapshot.gabc123`. |
 | Dependency operations | Candidate requires slack operation `channels.list` with `inputSchemaHash: sha256:abc…` but the fleet-known slack version's published `interface` dropped that operation or changed the input schema. |
-| Reverse dependents | Upgrading `slack` to a version that removes `postMessage` from its published `interface` while fleet-known `g-issues` still declares `requires.apps.slack.operations` including `postMessage`. |
-
-Registry-only dependencies are validated against the fleet-known version's published metadata (`versions/{version}.json`).
+| Reverse dependents (version) | Upgrading `slack` to `3.0.0` while fleet-known `g-issues` requires `slack: ^2.0.0`. |
+| Reverse dependents (operations) | Upgrading `slack` to a version that removes `postMessage` from its published `interface` while fleet-known `g-issues` still requires that operation. |
+| Registry not configured | Fleet-known `g-issues` references registry `toolshed`, but gestaltd config has no `toolshed` entry — **502**, not **404**. |
 
 Other admission rules (registry binding, `add`/`upgrade` mode, duplicate version, active rollout, install lock) are enforced in `Installer.install` — see [lifecycle.md](./lifecycle.md).


### PR DESCRIPTION
## Summary
- Expand `validation.md` with reason codes, HTTP/IndexedDB behavior, and install-time validation contracts (gestaltd version, dependency keys, fetch scope, reverse dependents, semver matching).
- Update `models.md` for `requires.apps` key formats and snapshot-aware version constraints.
- Document the install-time validation test matrix in `tests.md` and align `lifecycle.md` error taxonomy.

Implementation follows in #2887 (stacked on this branch).

## Test plan
- [x] Docs-only change
- [ ] Review against planned implementation in #2887

Made with [Cursor](https://cursor.com)