### PR TITLE
Document workflow target validation for app registry install admission

### DIFF
--- a/plans/app_registry/validation.md
+++ b/plans/app_registry/validation.md
@@ -18,6 +18,8 @@ Related docs:
 | Dependency version | Fleet-known version satisfies `requires.apps.{app}.version` | `dependency_version_unsatisfied` |
 | Dependency operations | Dependency published `interface` exposes required operations; `inputSchemaHash` matches when set | `dependency_operation_missing`, `dependency_operation_schema_mismatch`, `dependency_metadata_missing` |
 | Reverse dependents | No fleet-known app has a broken `requires.apps.{app}` on the candidate version or `interface` | `reverse_dependent_version_unsatisfied`, `reverse_dependent_operation_missing`, `reverse_dependent_operation_schema_mismatch`, `reverse_dependent_metadata_missing` |
+| Workflow target app | Each app step in the candidate's declared workflow definitions references a configured deploy app slot | `workflow_target_app_missing` |
+| Workflow target operation | Each app step references an operation published on the target app's `interface` (when metadata is available) | `workflow_target_operation_missing`, `workflow_target_operation_metadata_missing` |
 
 ## Validation errors
 
@@ -38,6 +40,9 @@ Each failure is an `InstallValidationError` with a stable `InstallValidationReas
 | `reverse_dependent_version_unsatisfied` | **400** | none | Candidate version does not satisfy a reverse dependent's version constraint |
 | `reverse_dependent_operation_missing` | **400** | none | Candidate `interface` missing an operation required by a reverse dependent |
 | `reverse_dependent_operation_schema_mismatch` | **400** | none | Candidate operation `inputSchemaHash` does not match a reverse dependent's requirement |
+| `workflow_target_app_missing` | **400** | none | Candidate declares a workflow app step whose `name` is not a key in deploy `config.apps` |
+| `workflow_target_operation_missing` | **400** | none | Workflow app step `operation` is not published on the target app's `interface` |
+| `workflow_target_operation_metadata_missing` | **400** | none | Operation check needed but the target app's fleet-known `versions/{version}.json` is missing |
 
 ### Non-validation failures during install
 
@@ -87,6 +92,33 @@ Dependency metadata is not fetched when the candidate declares only a version co
 
 When `config.yaml` pins a dependency app with a non-registry source (git, package, local, etc.), install validation skips presence checks for that app. Fleet-known registry versions are not required.
 
+## Workflow definition checks
+
+Apps can ship workflow definitions inside their published artifact. During `gestaltd provider package` / snapshot publish, those definitions are bundled with the app binary the same way operations and UI assets are. At runtime, gestaltd reads them from the started provider as `DeclaredWorkflowDefinitions` and registers them with the workflow manager.
+
+Install admission must validate those declarations **before** writing `app_version_change_requests`. Today bootstrap enforces workflow targets for config-managed `workflows.definitions` entries, but registry `add` / `upgrade` does not yet run the same checks — a broken packaged workflow can be fleet-admitted and only fails when gestaltd starts the app.
+
+### What gestalt inspects
+
+For each workflow definition declared by the candidate app:
+
+1. Walk every workflow step whose action is an app call (`steps[].app.name`, `steps[].app.operation`).
+2. Require `steps[].app.name` to match a key in deploy `config.apps` on the handling replica. This is the same configured app slot gestaltd uses at bootstrap (`workflow target app "gIssues" is not configured` when only `g-issues` exists).
+3. When the target app is fleet-known or deploy-pinned, require `steps[].app.operation` to exist on that target's published `interface`. Missing target metadata → `workflow_target_operation_metadata_missing`.
+
+Self-targets are allowed when the candidate app name matches the step target (for example, `g-issues` invoking `g-issues.handle_slack_event`).
+
+Workflow definitions are not part of today's `versions/{version}.json` contract (`interface`, `requires`, `compatibility` only). Install validation should extract them from the candidate artifact during admission — either by mounting the packaged app in a validation-only path or by copying workflow specs into registry metadata at publish time. Publish-time extraction is preferred so admission can fail fast without downloading archives.
+
+### Metadata fetch scope
+
+| Check | Uses deploy `config.apps` | Fetches target `versions/{version}.json` |
+|-------|---------------------------|------------------------------------------|
+| Workflow target app present | yes | no |
+| Workflow target operation | yes | yes, when the target is fleet-known — missing → `workflow_target_operation_metadata_missing` |
+
+Operation checks are skipped when the workflow step does not name a target operation or when the target app is deploy-pinned and has no fleet-known version with published metadata.
+
 ## Reverse dependents
 
 For each fleet-known app other than the candidate:
@@ -127,6 +159,8 @@ Fleet versions commonly use snapshot prereleases (`2.0.0-snapshot.gabc123`, `0.0
 | Dependency operations | Candidate requires slack operation `channels.list` with `inputSchemaHash: sha256:abc…` but the fleet-known slack version's published `interface` dropped that operation or changed the input schema. |
 | Reverse dependents (version) | Upgrading `slack` to `3.0.0` while fleet-known `g-issues` requires `slack: ^2.0.0`. |
 | Reverse dependents (operations) | Upgrading `slack` to a version that removes `postMessage` from its published `interface` while fleet-known `g-issues` still requires that operation. |
+| Workflow target app | Installing `g-issues` `0.0.0-snapshot.g…` whose packaged `slack_v2_smoke_test` workflow still targets app `gIssues` after deploy config renamed the slot to `g-issues`. Bootstrap fails with `workflow target app "gIssues" is not configured`; install admission should reject with `workflow_target_app_missing` instead. |
+| Workflow target operation | Installing an app whose workflow calls `slack.postMessage` while fleet-known `slack` no longer publishes that operation. |
 | Registry not configured | Fleet-known `g-issues` references registry `toolshed`, but gestaltd config has no `toolshed` entry — **502**, not **404**. |
 
 Other admission rules (registry binding, `add`/`upgrade` mode, duplicate version, active rollout, install lock) are enforced in `Installer.install` — see [lifecycle.md](./lifecycle.md).

--- a/plans/app_registry/validation.md
+++ b/plans/app_registry/validation.md
@@ -18,8 +18,8 @@ Related docs:
 | Dependency version | Fleet-known version satisfies `requires.apps.{app}.version` | `dependency_version_unsatisfied` |
 | Dependency operations | Dependency published `interface` exposes required operations; `inputSchemaHash` matches when set | `dependency_operation_missing`, `dependency_operation_schema_mismatch`, `dependency_metadata_missing` |
 | Reverse dependents | No fleet-known app has a broken `requires.apps.{app}` on the candidate version or `interface` | `reverse_dependent_version_unsatisfied`, `reverse_dependent_operation_missing`, `reverse_dependent_operation_schema_mismatch`, `reverse_dependent_metadata_missing` |
-| Workflow target app | Each app step in the candidate's declared workflow definitions references a configured deploy app slot | `workflow_target_app_missing` |
-| Workflow target operation | Each app step references an operation published on the target app's `interface` (when metadata is available) | `workflow_target_operation_missing`, `workflow_target_operation_metadata_missing` |
+| Workflow target app | Candidate `DeclaredWorkflowDefinitions` app-call steps vs deploy `config.apps` | `workflow_target_app_missing` |
+| Workflow target operation | App-call step `operation` vs target published `interface` | `workflow_target_operation_missing`, `workflow_target_operation_metadata_missing` |
 
 ## Validation errors
 
@@ -40,9 +40,9 @@ Each failure is an `InstallValidationError` with a stable `InstallValidationReas
 | `reverse_dependent_version_unsatisfied` | **400** | none | Candidate version does not satisfy a reverse dependent's version constraint |
 | `reverse_dependent_operation_missing` | **400** | none | Candidate `interface` missing an operation required by a reverse dependent |
 | `reverse_dependent_operation_schema_mismatch` | **400** | none | Candidate operation `inputSchemaHash` does not match a reverse dependent's requirement |
-| `workflow_target_app_missing` | **400** | none | Candidate declares a workflow app step whose `name` is not a key in deploy `config.apps` |
-| `workflow_target_operation_missing` | **400** | none | Workflow app step `operation` is not published on the target app's `interface` |
-| `workflow_target_operation_metadata_missing` | **400** | none | Operation check needed but the target app's fleet-known `versions/{version}.json` is missing |
+| `workflow_target_app_missing` | **400** | none | Workflow app step `name` is not a deploy config app slot |
+| `workflow_target_operation_missing` | **400** | none | Target published `interface` does not expose the workflow app step `operation` |
+| `workflow_target_operation_metadata_missing` | **400** | none | Operation check needed but fleet-known target's `versions/{version}.json` is missing |
 
 ### Non-validation failures during install
 
@@ -92,33 +92,6 @@ Dependency metadata is not fetched when the candidate declares only a version co
 
 When `config.yaml` pins a dependency app with a non-registry source (git, package, local, etc.), install validation skips presence checks for that app. Fleet-known registry versions are not required.
 
-## Workflow definition checks
-
-Apps can ship workflow definitions inside their published artifact. During `gestaltd provider package` / snapshot publish, those definitions are bundled with the app binary the same way operations and UI assets are. At runtime, gestaltd reads them from the started provider as `DeclaredWorkflowDefinitions` and registers them with the workflow manager.
-
-Install admission must validate those declarations **before** writing `app_version_change_requests`. Today bootstrap enforces workflow targets for config-managed `workflows.definitions` entries, but registry `add` / `upgrade` does not yet run the same checks — a broken packaged workflow can be fleet-admitted and only fails when gestaltd starts the app.
-
-### What gestalt inspects
-
-For each workflow definition declared by the candidate app:
-
-1. Walk every workflow step whose action is an app call (`steps[].app.name`, `steps[].app.operation`).
-2. Require `steps[].app.name` to match a key in deploy `config.apps` on the handling replica. This is the same configured app slot gestaltd uses at bootstrap (`workflow target app "gIssues" is not configured` when only `g-issues` exists).
-3. When the target app is fleet-known or deploy-pinned, require `steps[].app.operation` to exist on that target's published `interface`. Missing target metadata → `workflow_target_operation_metadata_missing`.
-
-Self-targets are allowed when the candidate app name matches the step target (for example, `g-issues` invoking `g-issues.handle_slack_event`).
-
-Workflow definitions are not part of today's `versions/{version}.json` contract (`interface`, `requires`, `compatibility` only). Install validation should extract them from the candidate artifact during admission — either by mounting the packaged app in a validation-only path or by copying workflow specs into registry metadata at publish time. Publish-time extraction is preferred so admission can fail fast without downloading archives.
-
-### Metadata fetch scope
-
-| Check | Uses deploy `config.apps` | Fetches target `versions/{version}.json` |
-|-------|---------------------------|------------------------------------------|
-| Workflow target app present | yes | no |
-| Workflow target operation | yes | yes, when the target is fleet-known — missing → `workflow_target_operation_metadata_missing` |
-
-Operation checks are skipped when the workflow step does not name a target operation or when the target app is deploy-pinned and has no fleet-known version with published metadata.
-
 ## Reverse dependents
 
 For each fleet-known app other than the candidate:
@@ -136,6 +109,29 @@ Missing published metadata:
 | Registry not configured for a dependent's installation | **502** `ErrAppRegistryNotConfigured` |
 
 Reverse-dependent operation failures attribute the missing operation to the candidate (for example, `reverse dependent g-issues requires candidate slack: operation postMessage is not published`).
+
+## Workflow definition checks
+
+Published app artifacts can declare workflow definitions. At startup, gestaltd reads them from the started provider as `DeclaredWorkflowDefinitions` and registers them with the workflow manager. Config-managed `workflows.definitions` entries are validated during config load; packaged app workflow declarations are not, so `InstallValidator` must validate them before `AppendRequest`.
+
+Workflow definitions are not part of the `versions/{version}.json` contract (`interface`, `requires`, `compatibility` only). Install validation loads them from the candidate artifact or from workflow metadata copied into the registry entry at publish time.
+
+For each workflow definition declared by the candidate:
+
+1. Walk every app-call step (`steps[].app.name`, `steps[].app.operation`).
+2. Require `steps[].app.name` to match a deploy config app slot (`config.apps` key on the handling replica).
+3. When the target app is fleet-known or deploy-pinned, require `steps[].app.operation` to exist on that target's published `interface`.
+
+Self-targets are allowed when the step names the candidate app (for example, `g-issues` calling `g-issues.handle_slack_event`).
+
+### Metadata fetch scope
+
+| Check | Uses deploy config `config.apps` | Fetches `versions/{version}.json` |
+|-------|----------------------------------|-------------------------------------|
+| Workflow target app | yes | no |
+| Workflow target operation | yes | yes, when the target is fleet-known — missing → `workflow_target_operation_metadata_missing` |
+
+Operation metadata is not fetched when the workflow step omits `operation` or when the target app is deploy-pinned with no fleet-known version.
 
 ## Semver constraint matching
 
@@ -159,8 +155,8 @@ Fleet versions commonly use snapshot prereleases (`2.0.0-snapshot.gabc123`, `0.0
 | Dependency operations | Candidate requires slack operation `channels.list` with `inputSchemaHash: sha256:abc…` but the fleet-known slack version's published `interface` dropped that operation or changed the input schema. |
 | Reverse dependents (version) | Upgrading `slack` to `3.0.0` while fleet-known `g-issues` requires `slack: ^2.0.0`. |
 | Reverse dependents (operations) | Upgrading `slack` to a version that removes `postMessage` from its published `interface` while fleet-known `g-issues` still requires that operation. |
-| Workflow target app | Installing `g-issues` `0.0.0-snapshot.g…` whose packaged `slack_v2_smoke_test` workflow still targets app `gIssues` after deploy config renamed the slot to `g-issues`. Bootstrap fails with `workflow target app "gIssues" is not configured`; install admission should reject with `workflow_target_app_missing` instead. |
-| Workflow target operation | Installing an app whose workflow calls `slack.postMessage` while fleet-known `slack` no longer publishes that operation. |
+| Workflow target app | Installing `g-issues` whose packaged `slack_v2_smoke_test` workflow targets `gIssues` while deploy config only defines `g-issues`. |
+| Workflow target operation | Installing an app whose workflow calls `slack.postMessage` while fleet-known `slack` no longer publishes that operation in `interface`. |
 | Registry not configured | Fleet-known `g-issues` references registry `toolshed`, but gestaltd config has no `toolshed` entry — **502**, not **404**. |
 
 Other admission rules (registry binding, `add`/`upgrade` mode, duplicate version, active rollout, install lock) are enforced in `Installer.install` — see [lifecycle.md](./lifecycle.md).


### PR DESCRIPTION
## Summary
- Extend `plans/app_registry/validation.md` with install-time checks for packaged workflow app targets and operations.
- Document what gestaltd should inspect (`steps[].app.name` against deploy `config.apps`, operations against target `interface`) and the current bootstrap-only enforcement gap.
- Add the `g-issues` / `gIssues` rename failure as a concrete example.

## Test plan
- [x] Docs-only change; no code or tests required.


Made with [Cursor](https://cursor.com)