### PR TITLE
Validate packaged workflow targets at app registry install time

### DIFF
--- a/gestaltd/internal/appregistry/install_validation_errors.go
+++ b/gestaltd/internal/appregistry/install_validation_errors.go
@@ -25,6 +25,10 @@ const (
 	InstallValidationReverseDependentVersionUnsatisfied InstallValidationReason = "reverse_dependent_version_unsatisfied"
 	InstallValidationReverseDependentOperationMissing   InstallValidationReason = "reverse_dependent_operation_missing"
 	InstallValidationReverseDependentOperationSchema    InstallValidationReason = "reverse_dependent_operation_schema_mismatch"
+
+	InstallValidationWorkflowTargetAppMissing              InstallValidationReason = "workflow_target_app_missing"
+	InstallValidationWorkflowTargetOperationMissing        InstallValidationReason = "workflow_target_operation_missing"
+	InstallValidationWorkflowTargetOperationMetadataMissing InstallValidationReason = "workflow_target_operation_metadata_missing"
 )
 
 // InstallValidationError is a typed install-time validation failure.

--- a/gestaltd/internal/appregistry/install_validation_errors.go
+++ b/gestaltd/internal/appregistry/install_validation_errors.go
@@ -26,8 +26,8 @@ const (
 	InstallValidationReverseDependentOperationMissing   InstallValidationReason = "reverse_dependent_operation_missing"
 	InstallValidationReverseDependentOperationSchema    InstallValidationReason = "reverse_dependent_operation_schema_mismatch"
 
-	InstallValidationWorkflowTargetAppMissing              InstallValidationReason = "workflow_target_app_missing"
-	InstallValidationWorkflowTargetOperationMissing        InstallValidationReason = "workflow_target_operation_missing"
+	InstallValidationWorkflowTargetAppMissing               InstallValidationReason = "workflow_target_app_missing"
+	InstallValidationWorkflowTargetOperationMissing         InstallValidationReason = "workflow_target_operation_missing"
 	InstallValidationWorkflowTargetOperationMetadataMissing InstallValidationReason = "workflow_target_operation_metadata_missing"
 )
 

--- a/gestaltd/internal/appregistry/install_validator.go
+++ b/gestaltd/internal/appregistry/install_validator.go
@@ -66,7 +66,7 @@ func (v *InstallValidator) Validate(ctx context.Context, input ValidateInput) er
 	if err := validateReverseDependents(ctx, v, input, knownByApp); err != nil {
 		return err
 	}
-	if err := validateWorkflowDefinitions(ctx, v, input.Entry.Workflows, knownByApp); err != nil {
+	if err := validateWorkflowDefinitions(ctx, v, input, knownByApp); err != nil {
 		return err
 	}
 	return nil

--- a/gestaltd/internal/appregistry/install_validator.go
+++ b/gestaltd/internal/appregistry/install_validator.go
@@ -66,6 +66,9 @@ func (v *InstallValidator) Validate(ctx context.Context, input ValidateInput) er
 	if err := validateReverseDependents(ctx, v, input, knownByApp); err != nil {
 		return err
 	}
+	if err := validateWorkflowDefinitions(ctx, v, input.Entry.Workflows, knownByApp); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/gestaltd/internal/appregistry/install_validator_test.go
+++ b/gestaltd/internal/appregistry/install_validator_test.go
@@ -448,6 +448,88 @@ func TestInstallValidator(t *testing.T) {
 			}
 		})
 	})
+
+	t.Run("workflow_targets", func(t *testing.T) {
+		t.Parallel()
+
+		configApps := map[string]*config.ProviderEntry{
+			"g-issues": {Source: config.ProviderSource{Registry: "toolshed"}},
+			"slack":    {Source: config.ProviderSource{Registry: "toolshed"}},
+		}
+		workflowValidator := func(t *testing.T, svc *testutil.Services, entries map[string]appregistry.Entry) *appregistry.InstallValidator {
+			t.Helper()
+			validator := newValidator(t, svc, entries, "1.0.0")
+			validator.ConfigApps = configApps
+			return validator
+		}
+
+		t.Run("rejects_missing_target_app", func(t *testing.T) {
+			t.Parallel()
+			svc := testutil.NewStubServices(t)
+			validator := workflowValidator(t, svc, nil)
+			entry := baseEntry(func(e *appregistry.Entry) {
+				e.Workflows = appregistry.Workflows{
+					Definitions: []appregistry.WorkflowDefinitionRef{{
+						ID: "slack_v2_smoke_test",
+						Steps: []appregistry.WorkflowAppCallRef{{
+							App:       "gIssues",
+							Operation: "handle_slack_event",
+						}},
+					}},
+				}
+			})
+			err := validator.Validate(ctx, appregistry.ValidateInput{
+				Registry: "toolshed", App: "g-issues", Version: "1.0.0", Entry: &entry,
+			})
+			assertInstallValidationReason(t, err, appregistry.InstallValidationWorkflowTargetAppMissing)
+		})
+
+		t.Run("accepts_configured_self_target", func(t *testing.T) {
+			t.Parallel()
+			svc := testutil.NewStubServices(t)
+			validator := workflowValidator(t, svc, nil)
+			entry := baseEntry(func(e *appregistry.Entry) {
+				e.Workflows = appregistry.Workflows{
+					Definitions: []appregistry.WorkflowDefinitionRef{{
+						ID: "slack_v2_smoke_test",
+						Steps: []appregistry.WorkflowAppCallRef{{
+							App:       "g-issues",
+							Operation: "handle_slack_event",
+						}},
+					}},
+				}
+			})
+			if err := validator.Validate(ctx, appregistry.ValidateInput{
+				Registry: "toolshed", App: "g-issues", Version: "1.0.0", Entry: &entry,
+			}); err != nil {
+				t.Fatalf("Validate: %v", err)
+			}
+		})
+
+		t.Run("rejects_missing_target_operation", func(t *testing.T) {
+			t.Parallel()
+			svc := testutil.NewStubServices(t)
+			installFleetApp(t, svc, "slack", "2.0.0")
+			validator := workflowValidator(t, svc, map[string]appregistry.Entry{
+				"2.0.0": slackEntry(nil),
+			})
+			entry := baseEntry(func(e *appregistry.Entry) {
+				e.Workflows = appregistry.Workflows{
+					Definitions: []appregistry.WorkflowDefinitionRef{{
+						ID: "notify",
+						Steps: []appregistry.WorkflowAppCallRef{{
+							App:       "slack",
+							Operation: "postMessage",
+						}},
+					}},
+				}
+			})
+			err := validator.Validate(ctx, appregistry.ValidateInput{
+				Registry: "toolshed", App: "g-issues", Version: "1.0.0", Entry: &entry,
+			})
+			assertInstallValidationReason(t, err, appregistry.InstallValidationWorkflowTargetOperationMissing)
+		})
+	})
 }
 
 func TestInstaller_validation_failure_writes_nothing(t *testing.T) {

--- a/gestaltd/internal/appregistry/install_validator_test.go
+++ b/gestaltd/internal/appregistry/install_validator_test.go
@@ -489,6 +489,11 @@ func TestInstallValidator(t *testing.T) {
 			svc := testutil.NewStubServices(t)
 			validator := workflowValidator(t, svc, nil)
 			entry := baseEntry(func(e *appregistry.Entry) {
+				e.Interface = appregistry.Interface{
+					Operations: map[string]appregistry.OperationContract{
+						"handle_slack_event": {},
+					},
+				}
 				e.Workflows = appregistry.Workflows{
 					Definitions: []appregistry.WorkflowDefinitionRef{{
 						ID: "slack_v2_smoke_test",

--- a/gestaltd/internal/appregistry/install_validator_test.go
+++ b/gestaltd/internal/appregistry/install_validator_test.go
@@ -529,6 +529,39 @@ func TestInstallValidator(t *testing.T) {
 			})
 			assertInstallValidationReason(t, err, appregistry.InstallValidationWorkflowTargetOperationMissing)
 		})
+
+		t.Run("self_target_uses_candidate_interface", func(t *testing.T) {
+			t.Parallel()
+			svc := testutil.NewStubServices(t)
+			installFleetApp(t, svc, "g-issues", "0.9.0")
+			validator := workflowValidator(t, svc, map[string]appregistry.Entry{
+				"0.9.0": baseEntry(func(e *appregistry.Entry) {
+					e.Version = "0.9.0"
+					e.Interface = appregistry.Interface{Operations: map[string]appregistry.OperationContract{}}
+				}),
+			})
+			entry := baseEntry(func(e *appregistry.Entry) {
+				e.Interface = appregistry.Interface{
+					Operations: map[string]appregistry.OperationContract{
+						"handle_slack_event": {},
+					},
+				}
+				e.Workflows = appregistry.Workflows{
+					Definitions: []appregistry.WorkflowDefinitionRef{{
+						ID: "slack_v2_smoke_test",
+						Steps: []appregistry.WorkflowAppCallRef{{
+							App:       "g-issues",
+							Operation: "handle_slack_event",
+						}},
+					}},
+				}
+			})
+			if err := validator.Validate(ctx, appregistry.ValidateInput{
+				Registry: "toolshed", App: "g-issues", Version: "1.0.0", Entry: &entry,
+			}); err != nil {
+				t.Fatalf("Validate: %v", err)
+			}
+		})
 	})
 }
 

--- a/gestaltd/internal/appregistry/registry.go
+++ b/gestaltd/internal/appregistry/registry.go
@@ -53,6 +53,7 @@ type Entry struct {
 	Repository    string              `json:"repository"`
 	Artifacts     map[string]Artifact `json:"artifacts"`
 	Interface     Interface           `json:"interface,omitempty"`
+	Workflows     Workflows           `json:"workflows,omitempty"`
 	Requires      Requires            `json:"requires,omitempty"`
 	Compatibility Compatibility       `json:"compatibility,omitempty"`
 	PublishedAt   time.Time           `json:"publishedAt"`
@@ -225,6 +226,7 @@ func BuildEntry(input BuildEntryInput) (Entry, error) {
 		Repository:    repository,
 		Artifacts:     artifacts,
 		Interface:     InterfaceFromRelease(input.Release),
+		Workflows:     workflowsFromBuildInput(input),
 		Requires:      requires,
 		Compatibility: compatibility,
 		PublishedAt:   publishedAt.UTC(),
@@ -242,7 +244,15 @@ type BuildEntryInput struct {
 	ManifestPath string
 	Release      *providerrelease.Metadata
 	Artifacts    []PublishArtifact
+	Workflows    Workflows
 	PublishedAt  time.Time
+}
+
+func workflowsFromBuildInput(input BuildEntryInput) Workflows {
+	if len(input.Workflows.Definitions) > 0 {
+		return input.Workflows
+	}
+	return WorkflowsFromProviderRelease(input.Release)
 }
 
 func buildArtifacts(artifacts []PublishArtifact) (map[string]Artifact, error) {

--- a/gestaltd/internal/appregistry/workflow_validation.go
+++ b/gestaltd/internal/appregistry/workflow_validation.go
@@ -1,0 +1,179 @@
+package appregistry
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/providerrelease"
+	"github.com/valon-technologies/gestalt/server/internal/workflowwire"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+)
+
+// Workflows documents app-call steps declared by packaged workflow definitions.
+type Workflows struct {
+	Definitions []WorkflowDefinitionRef `json:"definitions,omitempty"`
+}
+
+// WorkflowDefinitionRef is one workflow definition and its app-call steps.
+type WorkflowDefinitionRef struct {
+	ID    string               `json:"id,omitempty"`
+	Steps []WorkflowAppCallRef `json:"steps,omitempty"`
+}
+
+// WorkflowAppCallRef names a workflow app-call target.
+type WorkflowAppCallRef struct {
+	App       string `json:"app"`
+	Operation string `json:"operation,omitempty"`
+}
+
+// WorkflowsFromDefinitionSpecs extracts app-call steps from provider workflow specs.
+func WorkflowsFromDefinitionSpecs(specs []*proto.WorkflowDefinitionSpec) (Workflows, error) {
+	if len(specs) == 0 {
+		return Workflows{}, nil
+	}
+	out := Workflows{Definitions: make([]WorkflowDefinitionRef, 0, len(specs))}
+	for i, specProto := range specs {
+		if specProto == nil {
+			return Workflows{}, fmt.Errorf("workflow definition[%d] is required", i)
+		}
+		spec, err := workflowwire.DefinitionSpecFromProto(specProto)
+		if err != nil {
+			return Workflows{}, fmt.Errorf("workflow definition %q: %w", strings.TrimSpace(specProto.GetId()), err)
+		}
+		if spec == nil {
+			continue
+		}
+		steps := workflowAppCallRefsFromTarget(spec.Target)
+		if len(steps) == 0 {
+			continue
+		}
+		out.Definitions = append(out.Definitions, WorkflowDefinitionRef{
+			ID:    strings.TrimSpace(specProto.GetId()),
+			Steps: steps,
+		})
+	}
+	return out, nil
+}
+
+// WorkflowsFromProviderRelease copies workflow metadata from provider release static validation.
+func WorkflowsFromProviderRelease(release *providerrelease.Metadata) Workflows {
+	if release == nil || release.StaticValidation == nil || release.StaticValidation.Workflows == nil {
+		return Workflows{}
+	}
+	defs := release.StaticValidation.Workflows.Definitions
+	if len(defs) == 0 {
+		return Workflows{}
+	}
+	out := Workflows{Definitions: make([]WorkflowDefinitionRef, 0, len(defs))}
+	for _, definition := range defs {
+		if len(definition.Steps) == 0 {
+			continue
+		}
+		steps := make([]WorkflowAppCallRef, 0, len(definition.Steps))
+		for _, step := range definition.Steps {
+			appName := strings.TrimSpace(step.App)
+			if appName == "" {
+				continue
+			}
+			steps = append(steps, WorkflowAppCallRef{
+				App:       appName,
+				Operation: strings.TrimSpace(step.Operation),
+			})
+		}
+		if len(steps) == 0 {
+			continue
+		}
+		out.Definitions = append(out.Definitions, WorkflowDefinitionRef{
+			ID:    strings.TrimSpace(definition.ID),
+			Steps: steps,
+		})
+	}
+	return out
+}
+
+func workflowAppCallRefsFromTarget(target coreworkflow.Target) []WorkflowAppCallRef {
+	if len(target.Steps) == 0 {
+		return nil
+	}
+	out := make([]WorkflowAppCallRef, 0, len(target.Steps))
+	for _, step := range target.Steps {
+		if step.App == nil {
+			continue
+		}
+		appName := strings.TrimSpace(step.App.Name)
+		if appName == "" {
+			continue
+		}
+		out = append(out, WorkflowAppCallRef{
+			App:       appName,
+			Operation: strings.TrimSpace(step.App.Operation),
+		})
+	}
+	return out
+}
+
+func validateWorkflowDefinitions(
+	ctx context.Context,
+	v *InstallValidator,
+	workflows Workflows,
+	knownByApp map[string]*core.AppInstallation,
+) error {
+	if len(workflows.Definitions) == 0 {
+		return nil
+	}
+	for _, definition := range workflows.Definitions {
+		definitionID := strings.TrimSpace(definition.ID)
+		for _, step := range definition.Steps {
+			targetApp := strings.TrimSpace(step.App)
+			if targetApp == "" {
+				continue
+			}
+			subject := workflowValidationSubject(definitionID, targetApp)
+			if !deployConfigAppConfigured(v.ConfigApps, targetApp) {
+				return installValidationError(
+					InstallValidationWorkflowTargetAppMissing,
+					fmt.Sprintf("%s: workflow target app %q is not configured", subject, targetApp),
+				)
+			}
+			operation := strings.TrimSpace(step.Operation)
+			if operation == "" {
+				continue
+			}
+			installation := knownByApp[targetApp]
+			if installation == nil {
+				continue
+			}
+			targetEntry, err := v.fetchPublishedEntry(ctx, installation.Registry, targetApp, installation.Version)
+			if err != nil {
+				return validationFetchError(InstallValidationWorkflowTargetOperationMetadataMissing, subject, err)
+			}
+			if _, ok := targetEntry.Interface.Operations[operation]; !ok {
+				return installValidationError(
+					InstallValidationWorkflowTargetOperationMissing,
+					fmt.Sprintf("%s: operation %s is not published", subject, operation),
+				)
+			}
+		}
+	}
+	return nil
+}
+
+func deployConfigAppConfigured(configApps map[string]*config.ProviderEntry, appName string) bool {
+	if configApps == nil {
+		return false
+	}
+	_, ok := configApps[appName]
+	return ok
+}
+
+func workflowValidationSubject(definitionID, targetApp string) string {
+	definitionID = strings.TrimSpace(definitionID)
+	if definitionID == "" {
+		return fmt.Sprintf("workflow target %s", targetApp)
+	}
+	return fmt.Sprintf("workflow %s", definitionID)
+}

--- a/gestaltd/internal/appregistry/workflow_validation.go
+++ b/gestaltd/internal/appregistry/workflow_validation.go
@@ -119,12 +119,18 @@ func workflowAppCallRefsFromTarget(target coreworkflow.Target) []WorkflowAppCall
 func validateWorkflowDefinitions(
 	ctx context.Context,
 	v *InstallValidator,
-	workflows Workflows,
+	input ValidateInput,
 	knownByApp map[string]*core.AppInstallation,
 ) error {
+	entry := input.Entry
+	if entry == nil {
+		return nil
+	}
+	workflows := entry.Workflows
 	if len(workflows.Definitions) == 0 {
 		return nil
 	}
+	candidateApp := strings.TrimSpace(input.App)
 	for _, definition := range workflows.Definitions {
 		definitionID := strings.TrimSpace(definition.ID)
 		for _, step := range definition.Steps {
@@ -141,6 +147,15 @@ func validateWorkflowDefinitions(
 			}
 			operation := strings.TrimSpace(step.Operation)
 			if operation == "" {
+				continue
+			}
+			if candidateApp != "" && targetApp == candidateApp {
+				if _, ok := entry.Interface.Operations[operation]; !ok {
+					return installValidationError(
+						InstallValidationWorkflowTargetOperationMissing,
+						fmt.Sprintf("%s: operation %s is not published", subject, operation),
+					)
+				}
 				continue
 			}
 			installation := knownByApp[targetApp]

--- a/gestaltd/internal/appregistry/workflow_validation_test.go
+++ b/gestaltd/internal/appregistry/workflow_validation_test.go
@@ -1,0 +1,43 @@
+package appregistry_test
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/appregistry"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+)
+
+func TestWorkflowsFromDefinitionSpecs(t *testing.T) {
+	t.Parallel()
+
+	workflows, err := appregistry.WorkflowsFromDefinitionSpecs([]*proto.WorkflowDefinitionSpec{
+		{
+			Id:    "slack_v2_smoke_test",
+			RunAs: "service_account:slack-v2-smoke-test",
+			Target: &proto.BoundWorkflowTarget{
+				Steps: []*proto.WorkflowStep{{
+					Id: "handle_slack_event",
+					Action: &proto.WorkflowStep_App{App: &proto.WorkflowStepAppCall{
+						Name:      "gIssues",
+						Operation: "handle_slack_event",
+					}},
+				}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("WorkflowsFromDefinitionSpecs: %v", err)
+	}
+	if len(workflows.Definitions) != 1 {
+		t.Fatalf("definitions = %#v", workflows.Definitions)
+	}
+	if workflows.Definitions[0].ID != "slack_v2_smoke_test" {
+		t.Fatalf("definition id = %q", workflows.Definitions[0].ID)
+	}
+	if len(workflows.Definitions[0].Steps) != 1 {
+		t.Fatalf("steps = %#v", workflows.Definitions[0].Steps)
+	}
+	if workflows.Definitions[0].Steps[0].App != "gIssues" || workflows.Definitions[0].Steps[0].Operation != "handle_slack_event" {
+		t.Fatalf("step = %#v", workflows.Definitions[0].Steps[0])
+	}
+}

--- a/gestaltd/internal/daemon/provider_release_finalize.go
+++ b/gestaltd/internal/daemon/provider_release_finalize.go
@@ -382,16 +382,34 @@ func staticValidationWorkflowsForRelease(manifest *providermanifestv1.Manifest, 
 	if providermanifestv1.NormalizeKind(manifest.Kind) != providermanifestv1.KindApp {
 		return nil, nil
 	}
+	var firstWorkflows *providerrelease.WorkflowDefinitions
+	var firstData []byte
+	firstPath := ""
+	found := false
 	for _, archive := range archives {
 		workflows, err := staticValidationWorkflowsFromArchive(archive)
 		if err != nil {
 			return nil, err
 		}
-		if workflows != nil {
-			return workflows, nil
+		if workflows == nil {
+			continue
+		}
+		data, err := yaml.Marshal(workflows)
+		if err != nil {
+			return nil, fmt.Errorf("encode static validation workflows from %s: %w", filepath.Base(archive.Path), err)
+		}
+		if !found {
+			firstData = data
+			firstWorkflows = workflows
+			firstPath = archive.Path
+			found = true
+			continue
+		}
+		if !bytes.Equal(bytes.TrimSpace(firstData), bytes.TrimSpace(data)) {
+			return nil, fmt.Errorf("static validation workflows in %s does not match %s", filepath.Base(archive.Path), filepath.Base(firstPath))
 		}
 	}
-	return nil, nil
+	return firstWorkflows, nil
 }
 
 func staticValidationWorkflowsFromArchive(archive releaseArchive) (*providerrelease.WorkflowDefinitions, error) {

--- a/gestaltd/internal/daemon/provider_release_finalize.go
+++ b/gestaltd/internal/daemon/provider_release_finalize.go
@@ -311,8 +311,8 @@ func buildProviderReleaseMetadata(manifest *providermanifestv1.Manifest, version
 		Runtime:       providerrelease.RuntimeForManifest(manifest.Kind, manifest),
 		Artifacts:     providerrelease.Artifacts{},
 		StaticValidation: &providerrelease.StaticValidation{
-			Manifest: staticManifest,
-			Catalog:  staticCatalog,
+			Manifest:  staticManifest,
+			Catalog:   staticCatalog,
 			Workflows: staticWorkflows,
 		},
 	}

--- a/gestaltd/internal/daemon/provider_release_finalize.go
+++ b/gestaltd/internal/daemon/provider_release_finalize.go
@@ -281,6 +281,10 @@ func buildProviderReleaseMetadata(manifest *providermanifestv1.Manifest, version
 	if err != nil {
 		return nil, err
 	}
+	staticWorkflows, err := staticValidationWorkflowsForRelease(manifest, archives)
+	if err != nil {
+		return nil, err
+	}
 	contractRaw, err := rawManifestBytesForRelease(archives, rawManifest)
 	if err != nil {
 		return nil, err
@@ -309,6 +313,7 @@ func buildProviderReleaseMetadata(manifest *providermanifestv1.Manifest, version
 		StaticValidation: &providerrelease.StaticValidation{
 			Manifest: staticManifest,
 			Catalog:  staticCatalog,
+			Workflows: staticWorkflows,
 		},
 	}
 	if len(requires.Apps) > 0 {
@@ -368,6 +373,41 @@ func staticValidationCatalogForRelease(manifest *providermanifestv1.Manifest, ar
 		}
 	}
 	return firstCatalog, nil
+}
+
+func staticValidationWorkflowsForRelease(manifest *providermanifestv1.Manifest, archives []releaseArchive) (*providerrelease.WorkflowDefinitions, error) {
+	if manifest == nil || len(archives) == 0 {
+		return nil, nil
+	}
+	if providermanifestv1.NormalizeKind(manifest.Kind) != providermanifestv1.KindApp {
+		return nil, nil
+	}
+	for _, archive := range archives {
+		workflows, err := staticValidationWorkflowsFromArchive(archive)
+		if err != nil {
+			return nil, err
+		}
+		if workflows != nil {
+			return workflows, nil
+		}
+	}
+	return nil, nil
+}
+
+func staticValidationWorkflowsFromArchive(archive releaseArchive) (*providerrelease.WorkflowDefinitions, error) {
+	tmpDir, err := os.MkdirTemp("", "gestalt-provider-release-workflows-*")
+	if err != nil {
+		return nil, fmt.Errorf("create static validation workflows temp dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+	if err := packageio.ExtractPackage(archive.Path, tmpDir); err != nil {
+		return nil, fmt.Errorf("extract static validation workflows source from %s: %w", filepath.Base(archive.Path), err)
+	}
+	workflows, err := packageio.ReadStaticWorkflows(tmpDir)
+	if err != nil {
+		return nil, err
+	}
+	return providerrelease.WorkflowDefinitionsFromStatic(workflows), nil
 }
 
 func staticValidationCatalogFromArchiveManifest(archive releaseArchive) (*catalog.Catalog, error) {

--- a/gestaltd/internal/providerrelease/release.go
+++ b/gestaltd/internal/providerrelease/release.go
@@ -49,6 +49,7 @@ type StaticValidation struct {
 	CatalogSessionOnly bool                         `yaml:"catalogSessionOnly,omitempty"`
 	Requires           *Requires                    `yaml:"requires,omitempty"`
 	Compatibility      *Compatibility               `yaml:"compatibility,omitempty"`
+	Workflows          *WorkflowDefinitions         `yaml:"workflows,omitempty"`
 }
 
 type staticValidationYAML struct {
@@ -57,6 +58,7 @@ type staticValidationYAML struct {
 	CatalogSessionOnly bool                          `yaml:"catalogSessionOnly,omitempty"`
 	Requires           *Requires                     `yaml:"requires,omitempty"`
 	Compatibility      *Compatibility                `yaml:"compatibility,omitempty"`
+	Workflows          *WorkflowDefinitions          `yaml:"workflows,omitempty"`
 }
 
 type staticValidationManifestYAML struct {
@@ -90,6 +92,7 @@ func (s StaticValidation) MarshalYAML() (any, error) {
 		CatalogSessionOnly: s.CatalogSessionOnly,
 		Requires:           s.Requires,
 		Compatibility:      s.Compatibility,
+		Workflows:          s.Workflows,
 	}, nil
 }
 

--- a/gestaltd/internal/providerrelease/workflows.go
+++ b/gestaltd/internal/providerrelease/workflows.go
@@ -1,0 +1,59 @@
+package providerrelease
+
+import (
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/services/apps/packageio"
+)
+
+// WorkflowDefinitions documents app-call steps declared by packaged workflow definitions.
+type WorkflowDefinitions struct {
+	Definitions []WorkflowDefinition `yaml:"definitions,omitempty"`
+}
+
+// WorkflowDefinition is one workflow definition and its app-call steps.
+type WorkflowDefinition struct {
+	ID    string            `yaml:"id,omitempty"`
+	Steps []WorkflowAppCall `yaml:"steps,omitempty"`
+}
+
+// WorkflowAppCall names a workflow app-call target.
+type WorkflowAppCall struct {
+	App       string `yaml:"app"`
+	Operation string `yaml:"operation,omitempty"`
+}
+
+// WorkflowDefinitionsFromStatic copies packaged workflow metadata into release form.
+func WorkflowDefinitionsFromStatic(static *packageio.StaticWorkflowDefinitions) *WorkflowDefinitions {
+	if static == nil || len(static.Definitions) == 0 {
+		return nil
+	}
+	out := &WorkflowDefinitions{Definitions: make([]WorkflowDefinition, 0, len(static.Definitions))}
+	for _, definition := range static.Definitions {
+		if len(definition.Steps) == 0 {
+			continue
+		}
+		steps := make([]WorkflowAppCall, 0, len(definition.Steps))
+		for _, step := range definition.Steps {
+			appName := strings.TrimSpace(step.App)
+			if appName == "" {
+				continue
+			}
+			steps = append(steps, WorkflowAppCall{
+				App:       appName,
+				Operation: strings.TrimSpace(step.Operation),
+			})
+		}
+		if len(steps) == 0 {
+			continue
+		}
+		out.Definitions = append(out.Definitions, WorkflowDefinition{
+			ID:    strings.TrimSpace(definition.ID),
+			Steps: steps,
+		})
+	}
+	if len(out.Definitions) == 0 {
+		return nil
+	}
+	return out
+}

--- a/gestaltd/services/apps/packageio/workflows.go
+++ b/gestaltd/services/apps/packageio/workflows.go
@@ -1,0 +1,54 @@
+package packageio
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+const StaticWorkflowsFile = "workflows.yaml"
+
+type StaticWorkflowDefinitions struct {
+	Definitions []StaticWorkflowDefinition `yaml:"definitions,omitempty"`
+}
+
+type StaticWorkflowDefinition struct {
+	ID    string                `yaml:"id,omitempty"`
+	Steps []StaticWorkflowAppCall `yaml:"steps,omitempty"`
+}
+
+type StaticWorkflowAppCall struct {
+	App       string `yaml:"app"`
+	Operation string `yaml:"operation,omitempty"`
+}
+
+func StaticWorkflowsPath(rootDir string) string {
+	if rootDir == "" {
+		return StaticWorkflowsFile
+	}
+	return filepath.Join(rootDir, StaticWorkflowsFile)
+}
+
+func ReadStaticWorkflows(rootDir string) (*StaticWorkflowDefinitions, error) {
+	workflowsPath := StaticWorkflowsPath(rootDir)
+	data, err := os.ReadFile(workflowsPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read static workflows %q: %w", workflowsPath, err)
+	}
+	var workflows StaticWorkflowDefinitions
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&workflows); err != nil {
+		return nil, fmt.Errorf("decode static workflows %q: %w", filepath.Base(workflowsPath), err)
+	}
+	if len(workflows.Definitions) == 0 {
+		return nil, nil
+	}
+	return &workflows, nil
+}

--- a/gestaltd/services/apps/packageio/workflows.go
+++ b/gestaltd/services/apps/packageio/workflows.go
@@ -16,7 +16,7 @@ type StaticWorkflowDefinitions struct {
 }
 
 type StaticWorkflowDefinition struct {
-	ID    string                `yaml:"id,omitempty"`
+	ID    string                  `yaml:"id,omitempty"`
 	Steps []StaticWorkflowAppCall `yaml:"steps,omitempty"`
 }
 

--- a/gestaltd/services/apps/providerpkg/source_prepare.go
+++ b/gestaltd/services/apps/providerpkg/source_prepare.go
@@ -149,8 +149,10 @@ func generateSourceStaticCatalog(manifestPath, rootDir string, manifest *provide
 	cmd := exec.Command(execution.Command, execution.Args...)
 	cmd.Dir = execution.Workdir
 	cmd.Env = mergePhaseEnv(os.Environ(), envMapToSlice(execution.Env))
-	cmd.Env = append(cmd.Env, envWriteCatalog+"="+catalogPath)
-	cmd.Env = append(cmd.Env, envWriteWorkflows+"="+staticWorkflowsPathForManifest(manifestPath))
+	cmd.Env = append(cmd.Env,
+		envWriteCatalog+"="+catalogPath,
+		envWriteWorkflows+"="+staticWorkflowsPathForManifest(manifestPath),
+	)
 	var output bytes.Buffer
 	cmd.Stdout = &output
 	cmd.Stderr = &output

--- a/gestaltd/services/apps/providerpkg/source_prepare.go
+++ b/gestaltd/services/apps/providerpkg/source_prepare.go
@@ -97,48 +97,92 @@ func ensureSourceStaticCatalog(manifestPath string, manifest *providermanifestv1
 	if err != nil {
 		return fmt.Errorf("resolve static catalog path %q: %w", catalogPath, err)
 	}
-	if _, err := os.Stat(absoluteCatalogPath); err == nil && !opts.RefreshExisting {
-		return nil
-	} else if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("stat static catalog %q: %w", StaticCatalogFile, err)
+	absoluteWorkflowsPath, err := filepath.Abs(StaticWorkflowsPath(rootDir))
+	if err != nil {
+		return fmt.Errorf("resolve static workflows path %q: %w", StaticWorkflowsFile, err)
 	}
-	if opts.RefreshExisting {
-		if err := os.Remove(absoluteCatalogPath); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("remove static catalog %q: %w", StaticCatalogFile, err)
-		}
-		if err := removeStaticWorkflows(rootDir); err != nil {
-			return err
-		}
-	}
-	if err := generateSourceStaticCatalog(manifestPath, rootDir, manifest, absoluteCatalogPath, opts); err != nil {
+
+	catalogExists, err := staticMetadataFileExists(absoluteCatalogPath)
+	if err != nil {
 		return err
 	}
-	if _, err := os.Stat(absoluteCatalogPath); err != nil {
-		if os.IsNotExist(err) && !StaticCatalogRequired(manifest) {
-			return nil
+	workflowsExists, err := staticMetadataFileExists(absoluteWorkflowsPath)
+	if err != nil {
+		return err
+	}
+
+	needCatalog := !catalogExists || opts.RefreshExisting
+	needWorkflows := !workflowsExists || opts.RefreshExisting
+	if !needCatalog && !needWorkflows {
+		return nil
+	}
+
+	if opts.RefreshExisting {
+		if needCatalog {
+			if err := os.Remove(absoluteCatalogPath); err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("remove static catalog %q: %w", StaticCatalogFile, err)
+			}
 		}
-		return fmt.Errorf("provider static catalog %q not found: %w", StaticCatalogFile, err)
+		if needWorkflows {
+			if err := removeStaticWorkflows(rootDir); err != nil {
+				return err
+			}
+		}
+	}
+
+	catalogOut := ""
+	if needCatalog {
+		catalogOut = absoluteCatalogPath
+	}
+	workflowsOut := ""
+	if needWorkflows {
+		workflowsOut = absoluteWorkflowsPath
+	}
+	if err := generateSourceStaticMetadata(manifestPath, manifest, catalogOut, workflowsOut, opts); err != nil {
+		return err
+	}
+	if needCatalog {
+		if _, err := os.Stat(absoluteCatalogPath); err != nil {
+			if os.IsNotExist(err) && !StaticCatalogRequired(manifest) {
+				return nil
+			}
+			return fmt.Errorf("provider static catalog %q not found: %w", StaticCatalogFile, err)
+		}
 	}
 	return nil
 }
 
-func generateSourceStaticCatalog(manifestPath, rootDir string, manifest *providermanifestv1.Manifest, catalogPath string, opts sourceCatalogOptions) error {
+func staticMetadataFileExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, fmt.Errorf("stat %q: %w", path, err)
+}
+
+func generateSourceStaticMetadata(manifestPath string, manifest *providermanifestv1.Manifest, catalogPath, workflowsPath string, opts sourceCatalogOptions) error {
 	if manifest != nil && manifest.Spec != nil && manifest.Spec.IsManifestBacked() {
+		return nil
+	}
+	if catalogPath == "" && workflowsPath == "" {
 		return nil
 	}
 	var resolved ResolvedSourceExecution
 	if HasMultipleSourceRuns(manifest) {
-		resolved = explicitRunExecution(rootDir, manifest)
+		resolved = explicitRunExecution(filepath.Dir(manifestPath), manifest)
 	} else {
 		var err error
 		resolved, err = resolveSourceExecution(manifestPath, manifest, providermanifestv1.KindApp, SourceBuildOptions{}, opts.SkipExplicitRun)
 		if err != nil {
-			return fmt.Errorf("prepare source provider for static catalog: %w", err)
+			return fmt.Errorf("prepare source provider for static metadata: %w", err)
 		}
 	}
 	if opts.SkipExplicitRun && resolved.Intent == SourceExecutionIntentPackagedEntrypoint {
 		if _, err := os.Stat(resolved.Command); err != nil && os.IsNotExist(err) && HasExplicitSourceRun(manifest) {
-			resolved = explicitRunExecution(rootDir, manifest)
+			resolved = explicitRunExecution(filepath.Dir(manifestPath), manifest)
 		}
 	}
 	execution := resolved.SourceExecution
@@ -149,19 +193,21 @@ func generateSourceStaticCatalog(manifestPath, rootDir string, manifest *provide
 	cmd := exec.Command(execution.Command, execution.Args...)
 	cmd.Dir = execution.Workdir
 	cmd.Env = mergePhaseEnv(os.Environ(), envMapToSlice(execution.Env))
-	cmd.Env = append(cmd.Env,
-		envWriteCatalog+"="+catalogPath,
-		envWriteWorkflows+"="+staticWorkflowsPathForManifest(manifestPath),
-	)
+	if catalogPath != "" {
+		cmd.Env = append(cmd.Env, envWriteCatalog+"="+catalogPath)
+	}
+	if workflowsPath != "" {
+		cmd.Env = append(cmd.Env, envWriteWorkflows+"="+workflowsPath)
+	}
 	var output bytes.Buffer
 	cmd.Stdout = &output
 	cmd.Stderr = &output
 	if err := cmd.Run(); err != nil {
 		msg := bytes.TrimSpace(output.Bytes())
 		if len(msg) == 0 {
-			return fmt.Errorf("generate static catalog: %w", err)
+			return fmt.Errorf("generate static provider metadata: %w", err)
 		}
-		return fmt.Errorf("generate static catalog: %w\n%s", err, msg)
+		return fmt.Errorf("generate static provider metadata: %w\n%s", err, msg)
 	}
 	return nil
 }

--- a/gestaltd/services/apps/providerpkg/source_prepare.go
+++ b/gestaltd/services/apps/providerpkg/source_prepare.go
@@ -106,6 +106,9 @@ func ensureSourceStaticCatalog(manifestPath string, manifest *providermanifestv1
 		if err := os.Remove(absoluteCatalogPath); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("remove static catalog %q: %w", StaticCatalogFile, err)
 		}
+		if err := removeStaticWorkflows(rootDir); err != nil {
+			return err
+		}
 	}
 	if err := generateSourceStaticCatalog(manifestPath, rootDir, manifest, absoluteCatalogPath, opts); err != nil {
 		return err
@@ -147,6 +150,7 @@ func generateSourceStaticCatalog(manifestPath, rootDir string, manifest *provide
 	cmd.Dir = execution.Workdir
 	cmd.Env = mergePhaseEnv(os.Environ(), envMapToSlice(execution.Env))
 	cmd.Env = append(cmd.Env, envWriteCatalog+"="+catalogPath)
+	cmd.Env = append(cmd.Env, envWriteWorkflows+"="+staticWorkflowsPathForManifest(manifestPath))
 	var output bytes.Buffer
 	cmd.Stdout = &output
 	cmd.Stderr = &output

--- a/gestaltd/services/apps/providerpkg/source_prepare_workflows_test.go
+++ b/gestaltd/services/apps/providerpkg/source_prepare_workflows_test.go
@@ -1,0 +1,55 @@
+package providerpkg
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+func TestEnsureSourceStaticCatalog_generatesWorkflowsWhenCatalogExists(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "catalog.yaml"), []byte("name: provider\noperations:\n  - id: echo\n    method: POST\n"), 0o644)
+	mustWriteFile(t, filepath.Join(dir, "run.sh"), []byte(`#!/bin/sh
+set -eu
+if [ -n "${GESTALT_APP_WRITE_CATALOG:-}" ]; then
+  printf 'name: provider\noperations:\n  - id: echo\n    method: POST\n' > "$GESTALT_APP_WRITE_CATALOG"
+fi
+if [ -n "${GESTALT_APP_WRITE_WORKFLOWS:-}" ]; then
+  cat > "$GESTALT_APP_WRITE_WORKFLOWS" <<'EOF'
+definitions:
+  - id: smoke_test
+    steps:
+      - app: g-issues
+        operation: handle_slack_event
+EOF
+fi
+`), 0o755)
+	manifestPath := mustWriteManifestData(t, dir, "manifest.yaml", mustManifestYAML(t, &providermanifestv1.Manifest{
+		Kind:    providermanifestv1.KindApp,
+		Source:  "github.com/testowner/apps/workflow-metadata",
+		Version: "0.0.1-alpha.1",
+		Run:     sourceRunCommand("sh", "./run.sh"),
+		Spec:    &providermanifestv1.Spec{},
+	}))
+
+	_, manifest, err := ReadSourceManifestFile(manifestPath)
+	if err != nil {
+		t.Fatalf("ReadSourceManifestFile: %v", err)
+	}
+	if err := ensureSourceStaticCatalog(manifestPath, manifest, sourceCatalogOptions{}); err != nil {
+		t.Fatalf("ensureSourceStaticCatalog: %v", err)
+	}
+	workflowsPath := StaticWorkflowsPath(dir)
+	data, err := os.ReadFile(workflowsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", workflowsPath, err)
+	}
+	if !strings.Contains(string(data), "handle_slack_event") {
+		t.Fatalf("workflows = %q, want generated workflow metadata", data)
+	}
+}

--- a/gestaltd/services/apps/providerpkg/workflows.go
+++ b/gestaltd/services/apps/providerpkg/workflows.go
@@ -3,7 +3,6 @@ package providerpkg
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/valon-technologies/gestalt/server/services/apps/packageio"
 )
@@ -27,8 +26,4 @@ func removeStaticWorkflows(rootDir string) error {
 		return fmt.Errorf("remove static workflows %q: %w", StaticWorkflowsFile, err)
 	}
 	return nil
-}
-
-func staticWorkflowsPathForManifest(manifestPath string) string {
-	return StaticWorkflowsPath(filepath.Dir(manifestPath))
 }

--- a/gestaltd/services/apps/providerpkg/workflows.go
+++ b/gestaltd/services/apps/providerpkg/workflows.go
@@ -1,0 +1,34 @@
+package providerpkg
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/valon-technologies/gestalt/server/services/apps/packageio"
+)
+
+const (
+	StaticWorkflowsFile = packageio.StaticWorkflowsFile
+	envWriteWorkflows   = "GESTALT_APP_WRITE_WORKFLOWS"
+)
+
+func StaticWorkflowsPath(rootDir string) string {
+	return packageio.StaticWorkflowsPath(rootDir)
+}
+
+func ReadStaticWorkflows(rootDir string) (*packageio.StaticWorkflowDefinitions, error) {
+	return packageio.ReadStaticWorkflows(rootDir)
+}
+
+func removeStaticWorkflows(rootDir string) error {
+	workflowsPath := StaticWorkflowsPath(rootDir)
+	if err := os.Remove(workflowsPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove static workflows %q: %w", StaticWorkflowsFile, err)
+	}
+	return nil
+}
+
+func staticWorkflowsPathForManifest(manifestPath string) string {
+	return StaticWorkflowsPath(filepath.Dir(manifestPath))
+}

--- a/plans/app_registry/plan.md
+++ b/plans/app_registry/plan.md
@@ -11,8 +11,6 @@ Related references:
 - [models.md](./models.md) — JSON document shapes stored in GCS
 - [service.md](./service.md) — Go package API for publish and validation
 
-Planned extensions are described under [Future work](#future-work).
-
 ## Registry Responsibilities
 
 App registries are responsible for:
@@ -265,66 +263,3 @@ Core recovery paths must not depend on dynamically installed apps.
 12. Registry-only app config and `add` / `upgrade` install routes. **Done.** See [config.md](./config.md#registry-only-app-source), [lifecycle.md](./lifecycle.md), [tests.md](./tests.md#registry-only-app-tests).
 13. Install-time validation before fleet accept: platform artifact, `gestaltd` compatibility, and declared app dependencies. No dedicated rollback API — revert via `upgrade` to an older published version. See [validation.md](./validation.md), [tests.md](./tests.md#install-time-validation-tests).
 14. Admin observability for registry-only apps: read APIs for rollouts and per-replica materializations, and an App Registry section in the `/admin` UI. **Done.** See [admin.md](./admin.md), [lifecycle.md](./lifecycle.md#admin-observability-api), [tests.md](./tests.md#admin-observability-tests).
-15. Packaged workflow targets in registry metadata and install-time validation. **In progress.** See [Future work](#future-work-packaged-workflows-in-registry-metadata).
-
-## Future work
-
-### Packaged workflows in registry metadata
-
-Packaged apps can declare workflow definitions in source (`workflows.ts` for TypeScript apps, provider declarations for Go). At bootstrap, gestaltd reads them from the started provider as `DeclaredWorkflowDefinitions` and registers them with the workflow manager. That is too late to catch bad workflow app targets before a version is admitted to the fleet.
-
-Install-time validation should not download artifacts or run providers. Like `interface` and `requires`, workflow install checks need a **registry contract** on `versions/{version}.json` that publish populates from the packaged app.
-
-#### Authoring vs registry contract
-
-| Layer | Role |
-|-------|------|
-| `workflows.ts` (or provider declarations) | Authoring — source of truth in the app repo |
-| `workflows.yaml` in the packaged artifact | Derived at package time — app-call steps only (`definitions[].steps[].app`, `operation`) |
-| `workflows` on `versions/{version}.json` | Install contract — copied from release metadata at publish |
-| `DeclaredWorkflowDefinitions` at bootstrap | Runtime registration — same declarations, after install |
-
-Config-managed `workflows.definitions` in deploy `config.yaml` stay separate: they are fleet-owned, validated at config load, and are not part of this registry field.
-
-#### Publish path
-
-Extend the existing static-metadata pipeline (same provider invocation that writes `catalog.yaml`):
-
-1. `gestaltd provider package` runs the built provider with `GESTALT_APP_WRITE_WORKFLOWS` when `workflows.yaml` is missing or stale, even if `catalog.yaml` already exists.
-2. `gestaltd provider release` / `gestaltd app publish` copies `workflows.yaml` into provider-release `staticValidation.workflows` and into the registry entry written by `gestaltd app publish`.
-3. Multi-platform publishes must carry identical workflow metadata across archives (same rule as static catalog).
-
-#### Install path
-
-Extend `InstallValidator` (see [validation.md](./validation.md)) to walk `entry.workflows` before `AppendRequest`:
-
-- Each app-call step `app` must match a deploy config app slot (`config.apps` key on the handling replica).
-- When the step names an operation and the target is fleet-known (or is the candidate app itself), require that operation on the target published `interface`. Self-targets use the candidate entry `interface`, not the previously fleet-known version.
-
-When `entry.workflows` is empty (versions published before this field existed), skip workflow checks for backward compatibility.
-
-#### Example registry entry
-
-```json
-{
-  "app": "g-issues",
-  "version": "0.0.0-snapshot.gXXXX",
-  "interface": { "operations": { "handle_slack_event": {} } },
-  "workflows": {
-    "definitions": [{
-      "id": "slack_v2_smoke_test",
-      "steps": [{ "app": "g-issues", "operation": "handle_slack_event" }]
-    }]
-  }
-}
-```
-
-#### Operational follow-up
-
-- **Republish** registry apps after the publish pipeline ships so existing snapshots gain `workflows` metadata; install validation is a no-op until then.
-- **Align app slot names** across deploy config (`g-issues`), workflow step targets, provider configuration, and UI bindings. The `g-issues` / `gIssues` rename showed that registry workflow validation catches stale targets only when names are inconsistent — consolidation reduces author error.
-- Update [models.md](./models.md) with the `workflows` field shape once the contract stabilizes.
-
-#### Failure example
-
-Installing `g-issues` whose packaged `slack_v2_smoke_test` workflow targets `gIssues` while deploy config only defines `g-issues` should return **400** `workflow_target_app_missing` before IndexedDB write, instead of failing at bootstrap with `workflow target app "gIssues" is not configured`.

--- a/plans/app_registry/plan.md
+++ b/plans/app_registry/plan.md
@@ -11,6 +11,8 @@ Related references:
 - [models.md](./models.md) — JSON document shapes stored in GCS
 - [service.md](./service.md) — Go package API for publish and validation
 
+Planned extensions are described under [Future work](#future-work).
+
 ## Registry Responsibilities
 
 App registries are responsible for:
@@ -263,3 +265,66 @@ Core recovery paths must not depend on dynamically installed apps.
 12. Registry-only app config and `add` / `upgrade` install routes. **Done.** See [config.md](./config.md#registry-only-app-source), [lifecycle.md](./lifecycle.md), [tests.md](./tests.md#registry-only-app-tests).
 13. Install-time validation before fleet accept: platform artifact, `gestaltd` compatibility, and declared app dependencies. No dedicated rollback API — revert via `upgrade` to an older published version. See [validation.md](./validation.md), [tests.md](./tests.md#install-time-validation-tests).
 14. Admin observability for registry-only apps: read APIs for rollouts and per-replica materializations, and an App Registry section in the `/admin` UI. **Done.** See [admin.md](./admin.md), [lifecycle.md](./lifecycle.md#admin-observability-api), [tests.md](./tests.md#admin-observability-tests).
+15. Packaged workflow targets in registry metadata and install-time validation. **In progress.** See [Future work](#future-work-packaged-workflows-in-registry-metadata).
+
+## Future work
+
+### Packaged workflows in registry metadata
+
+Packaged apps can declare workflow definitions in source (`workflows.ts` for TypeScript apps, provider declarations for Go). At bootstrap, gestaltd reads them from the started provider as `DeclaredWorkflowDefinitions` and registers them with the workflow manager. That is too late to catch bad workflow app targets before a version is admitted to the fleet.
+
+Install-time validation should not download artifacts or run providers. Like `interface` and `requires`, workflow install checks need a **registry contract** on `versions/{version}.json` that publish populates from the packaged app.
+
+#### Authoring vs registry contract
+
+| Layer | Role |
+|-------|------|
+| `workflows.ts` (or provider declarations) | Authoring — source of truth in the app repo |
+| `workflows.yaml` in the packaged artifact | Derived at package time — app-call steps only (`definitions[].steps[].app`, `operation`) |
+| `workflows` on `versions/{version}.json` | Install contract — copied from release metadata at publish |
+| `DeclaredWorkflowDefinitions` at bootstrap | Runtime registration — same declarations, after install |
+
+Config-managed `workflows.definitions` in deploy `config.yaml` stay separate: they are fleet-owned, validated at config load, and are not part of this registry field.
+
+#### Publish path
+
+Extend the existing static-metadata pipeline (same provider invocation that writes `catalog.yaml`):
+
+1. `gestaltd provider package` runs the built provider with `GESTALT_APP_WRITE_WORKFLOWS` when `workflows.yaml` is missing or stale, even if `catalog.yaml` already exists.
+2. `gestaltd provider release` / `gestaltd app publish` copies `workflows.yaml` into provider-release `staticValidation.workflows` and into the registry entry written by `gestaltd app publish`.
+3. Multi-platform publishes must carry identical workflow metadata across archives (same rule as static catalog).
+
+#### Install path
+
+Extend `InstallValidator` (see [validation.md](./validation.md)) to walk `entry.workflows` before `AppendRequest`:
+
+- Each app-call step `app` must match a deploy config app slot (`config.apps` key on the handling replica).
+- When the step names an operation and the target is fleet-known (or is the candidate app itself), require that operation on the target published `interface`. Self-targets use the candidate entry `interface`, not the previously fleet-known version.
+
+When `entry.workflows` is empty (versions published before this field existed), skip workflow checks for backward compatibility.
+
+#### Example registry entry
+
+```json
+{
+  "app": "g-issues",
+  "version": "0.0.0-snapshot.gXXXX",
+  "interface": { "operations": { "handle_slack_event": {} } },
+  "workflows": {
+    "definitions": [{
+      "id": "slack_v2_smoke_test",
+      "steps": [{ "app": "g-issues", "operation": "handle_slack_event" }]
+    }]
+  }
+}
+```
+
+#### Operational follow-up
+
+- **Republish** registry apps after the publish pipeline ships so existing snapshots gain `workflows` metadata; install validation is a no-op until then.
+- **Align app slot names** across deploy config (`g-issues`), workflow step targets, provider configuration, and UI bindings. The `g-issues` / `gIssues` rename showed that registry workflow validation catches stale targets only when names are inconsistent — consolidation reduces author error.
+- Update [models.md](./models.md) with the `workflows` field shape once the contract stabilizes.
+
+#### Failure example
+
+Installing `g-issues` whose packaged `slack_v2_smoke_test` workflow targets `gIssues` while deploy config only defines `g-issues` should return **400** `workflow_target_app_missing` before IndexedDB write, instead of failing at bootstrap with `workflow target app "gIssues" is not configured`.

--- a/sdk/go/serve.go
+++ b/sdk/go/serve.go
@@ -29,16 +29,24 @@ func ServeProvider[P any, PP interface {
 	Provider
 }](ctx context.Context, provider PP, router *Router[P]) error {
 	catalogPath := os.Getenv(envWriteCatalog)
-	if catalogPath != "" {
-		cat := router.Catalog()
-		if cat == nil {
-			cat = &Catalog{}
+	workflowsPath := os.Getenv(envWriteWorkflows)
+	if catalogPath != "" || workflowsPath != "" {
+		if catalogPath != "" {
+			cat := router.Catalog()
+			if cat == nil {
+				cat = &Catalog{}
+			}
+			if err := ensureOutputDir("catalog", catalogPath); err != nil {
+				return err
+			}
+			if err := writeCatalogYAML(cat, catalogPath); err != nil {
+				return err
+			}
 		}
-		if err := ensureOutputDir("catalog", catalogPath); err != nil {
-			return err
-		}
-		if err := writeCatalogYAML(cat, catalogPath); err != nil {
-			return err
+		if workflowsPath != "" {
+			if err := writeDeclaredWorkflowsYAML(provider, workflowsPath); err != nil {
+				return err
+			}
 		}
 		return nil
 	}

--- a/sdk/go/workflows_static.go
+++ b/sdk/go/workflows_static.go
@@ -1,0 +1,92 @@
+package gestalt
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const envWriteWorkflows = "GESTALT_APP_WRITE_WORKFLOWS"
+
+type staticWorkflowDefinitions struct {
+	Definitions []staticWorkflowDefinition `yaml:"definitions,omitempty"`
+}
+
+type staticWorkflowDefinition struct {
+	ID    string                 `yaml:"id,omitempty"`
+	Steps []staticWorkflowAppCall `yaml:"steps,omitempty"`
+}
+
+type staticWorkflowAppCall struct {
+	App       string `yaml:"app"`
+	Operation string `yaml:"operation,omitempty"`
+}
+
+func writeDeclaredWorkflowsYAML(provider any, path string) error {
+	decl, ok := provider.(interface {
+		DeclaredWorkflowDefinitions() ([]WorkflowDefinitionSpec, error)
+	})
+	if !ok {
+		return nil
+	}
+	specs, err := decl.DeclaredWorkflowDefinitions()
+	if err != nil {
+		return fmt.Errorf("declare workflow definitions: %w", err)
+	}
+	workflows := staticWorkflowDefinitionsFromSpecs(specs)
+	if len(workflows.Definitions) == 0 {
+		return nil
+	}
+	if err := ensureOutputDir("workflows", path); err != nil {
+		return err
+	}
+	data, err := yaml.Marshal(workflows)
+	if err != nil {
+		return fmt.Errorf("encode workflows yaml: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write workflows yaml %q: %w", path, err)
+	}
+	return nil
+}
+
+func staticWorkflowDefinitionsFromSpecs(specs []WorkflowDefinitionSpec) staticWorkflowDefinitions {
+	if len(specs) == 0 {
+		return staticWorkflowDefinitions{}
+	}
+	out := staticWorkflowDefinitions{Definitions: make([]staticWorkflowDefinition, 0, len(specs))}
+	for _, spec := range specs {
+		steps := staticWorkflowAppCallsFromTarget(spec.Target)
+		if len(steps) == 0 {
+			continue
+		}
+		out.Definitions = append(out.Definitions, staticWorkflowDefinition{
+			ID:    strings.TrimSpace(spec.ID),
+			Steps: steps,
+		})
+	}
+	return out
+}
+
+func staticWorkflowAppCallsFromTarget(target *BoundWorkflowTarget) []staticWorkflowAppCall {
+	if target == nil || len(target.Steps) == 0 {
+		return nil
+	}
+	out := make([]staticWorkflowAppCall, 0, len(target.Steps))
+	for _, step := range target.Steps {
+		if step.App == nil {
+			continue
+		}
+		appName := strings.TrimSpace(step.App.Name)
+		if appName == "" {
+			continue
+		}
+		out = append(out, staticWorkflowAppCall{
+			App:       appName,
+			Operation: strings.TrimSpace(step.App.Operation),
+		})
+	}
+	return out
+}

--- a/sdk/typescript/src/providers/runtime.ts
+++ b/sdk/typescript/src/providers/runtime.ts
@@ -127,6 +127,7 @@ import {
 import { CacheProvider, isCacheProvider } from "./cache.ts";
 import { SecretsProvider, isSecretsProvider } from "./secrets.ts";
 import { catalogToYaml, type Catalog } from "../catalog.ts";
+import { writeWorkflowsYaml } from "../workflows-static.ts";
 import {
   stringListsFromProto,
   stringListsToProto,
@@ -186,6 +187,10 @@ export const ENV_PROVIDER_PARENT_PID = "GESTALT_APP_PARENT_PID";
  * Environment variable used to request static catalog generation.
  */
 export const ENV_WRITE_CATALOG = "GESTALT_APP_WRITE_CATALOG";
+/**
+ * Environment variable used to request static workflow metadata generation.
+ */
+export const ENV_WRITE_WORKFLOWS = "GESTALT_APP_WRITE_WORKFLOWS";
 /**
  * Protocol version currently implemented by the TypeScript runtime.
  */
@@ -410,11 +415,17 @@ export async function runLoadedProvider(
   }
 
   const catalogPath = process.env[ENV_WRITE_CATALOG];
-  if (catalogPath) {
+  const workflowsPath = process.env[ENV_WRITE_WORKFLOWS];
+  if (catalogPath || workflowsPath) {
     if (!isAppProvider(provider)) {
-      throw new Error("static catalog generation is only supported for app providers");
+      throw new Error("static provider metadata generation is only supported for app providers");
     }
-    writeFileSync(catalogPath, catalogToYaml(provider.staticCatalog()), "utf8");
+    if (catalogPath) {
+      writeFileSync(catalogPath, catalogToYaml(provider.staticCatalog()), "utf8");
+    }
+    if (workflowsPath) {
+      writeWorkflowsYaml(workflowsPath, provider.declaredWorkflowSpecs());
+    }
     return;
   }
 

--- a/sdk/typescript/src/workflows-static.ts
+++ b/sdk/typescript/src/workflows-static.ts
@@ -1,0 +1,78 @@
+import { writeFileSync } from "node:fs";
+import YAML from "yaml";
+
+import type {
+  WorkflowDefinitionSpec,
+  WorkflowStep,
+  WorkflowStepAppCall,
+} from "./providers/workflow.ts";
+
+type StaticWorkflowDefinitions = {
+  definitions: Array<{
+    id?: string;
+    steps: Array<{
+      app: string;
+      operation?: string;
+    }>;
+  }>;
+};
+
+/**
+ * Serializes workflow app-call steps for provider packaging.
+ */
+export function workflowsToYaml(
+  specs: readonly WorkflowDefinitionSpec[],
+): string {
+  const definitions = specs
+    .map((spec) => ({
+      id: spec.id,
+      steps: workflowAppCallsFromTarget(spec.target),
+    }))
+    .filter((definition) => definition.steps.length > 0);
+  const payload: StaticWorkflowDefinitions = { definitions };
+  return YAML.stringify(payload);
+}
+
+/**
+ * Writes workflow app-call metadata to disk as YAML.
+ */
+export function writeWorkflowsYaml(
+  path: string,
+  specs: readonly WorkflowDefinitionSpec[],
+): void {
+  const yaml = workflowsToYaml(specs);
+  if (!yaml.trim()) {
+    return;
+  }
+  writeFileSync(path, yaml, "utf8");
+}
+
+function workflowAppCallsFromTarget(
+  target: WorkflowDefinitionSpec["target"],
+): Array<{ app: string; operation?: string }> {
+  if (!target?.steps?.length) {
+    return [];
+  }
+  const out: Array<{ app: string; operation?: string }> = [];
+  for (const step of target.steps) {
+    const appCall = workflowStepAppCall(step);
+    if (!appCall?.name?.trim()) {
+      continue;
+    }
+    out.push({
+      app: appCall.name.trim(),
+      operation: appCall.operation?.trim() || undefined,
+    });
+  }
+  return out;
+}
+
+function workflowStepAppCall(step: WorkflowStep): WorkflowStepAppCall | undefined {
+  if (step.app?.name) {
+    return step.app;
+  }
+  if (step.action?.case === "app") {
+    return step.action.value;
+  }
+  return undefined;
+}

--- a/sdk/typescript/src/workflows-static.ts
+++ b/sdk/typescript/src/workflows-static.ts
@@ -7,14 +7,18 @@ import type {
   WorkflowStepAppCall,
 } from "./providers/workflow.ts";
 
+type StaticWorkflowAppCall = {
+  app: string;
+  operation?: string;
+};
+
+type StaticWorkflowDefinition = {
+  id?: string;
+  steps: StaticWorkflowAppCall[];
+};
+
 type StaticWorkflowDefinitions = {
-  definitions: Array<{
-    id?: string;
-    steps: Array<{
-      app: string;
-      operation?: string;
-    }>;
-  }>;
+  definitions: StaticWorkflowDefinition[];
 };
 
 /**
@@ -23,12 +27,18 @@ type StaticWorkflowDefinitions = {
 export function workflowsToYaml(
   specs: readonly WorkflowDefinitionSpec[],
 ): string {
-  const definitions = specs
-    .map((spec) => ({
-      id: spec.id,
-      steps: workflowAppCallsFromTarget(spec.target),
-    }))
-    .filter((definition) => definition.steps.length > 0);
+  const definitions: StaticWorkflowDefinition[] = [];
+  for (const spec of specs) {
+    const steps = workflowAppCallsFromTarget(spec.target);
+    if (steps.length === 0) {
+      continue;
+    }
+    const definition: StaticWorkflowDefinition = { steps };
+    if (spec.id) {
+      definition.id = spec.id;
+    }
+    definitions.push(definition);
+  }
   const payload: StaticWorkflowDefinitions = { definitions };
   return YAML.stringify(payload);
 }
@@ -49,20 +59,22 @@ export function writeWorkflowsYaml(
 
 function workflowAppCallsFromTarget(
   target: WorkflowDefinitionSpec["target"],
-): Array<{ app: string; operation?: string }> {
+): StaticWorkflowAppCall[] {
   if (!target?.steps?.length) {
     return [];
   }
-  const out: Array<{ app: string; operation?: string }> = [];
+  const out: StaticWorkflowAppCall[] = [];
   for (const step of target.steps) {
     const appCall = workflowStepAppCall(step);
     if (!appCall?.name?.trim()) {
       continue;
     }
-    out.push({
-      app: appCall.name.trim(),
-      operation: appCall.operation?.trim() || undefined,
-    });
+    const entry: StaticWorkflowAppCall = { app: appCall.name.trim() };
+    const operation = appCall.operation?.trim();
+    if (operation) {
+      entry.operation = operation;
+    }
+    out.push(entry);
   }
   return out;
 }


### PR DESCRIPTION
## Summary
- Reject registry installs when packaged workflow app-call steps reference app slots missing from deploy `config.apps`, or when fleet-known targets do not publish the referenced operation.
- Copy workflow app-call metadata from `workflows.yaml` into provider release static validation and registry `versions/{version}.json` entries at publish time.
- Generate `workflows.yaml` during provider packaging via `GESTALT_APP_WRITE_WORKFLOWS` (Go and TypeScript SDKs), alongside existing static catalog generation.

## Test plan
- [x] `go test ./internal/appregistry/...`
- [x] `go test ./internal/providerrelease/...`
- [x] `go test ./services/apps/providerpkg/...`
- [x] `go test ./internal/daemon -run ProviderRelease`
- [ ] After merge and republish, installing a snapshot whose workflow still targets `gIssues` should fail with `workflow_target_app_missing` before IndexedDB admission

Stacked on #2892 (docs).


Made with [Cursor](https://cursor.com)