### PR TITLE
Build startup catalog for all manifest-backed providers

### DIFF
--- a/gestaltd/internal/bootstrap/executable_app_test.go
+++ b/gestaltd/internal/bootstrap/executable_app_test.go
@@ -3060,6 +3060,53 @@ func TestBuildStartupProviderSpecPreservesStaticCatalogConnectionRouting(t *test
 	if got, ok := operationRouting.connections["versions.list"]; ok {
 		t.Fatalf("versions.list connection = %q, want no static connection so the selected connection can apply", got)
 	}
+
+	manifest = &providermanifestv1.Manifest{
+		Source:      "gqlapp",
+		DisplayName: "GraphQL App",
+		Spec: &providermanifestv1.Spec{
+			Connections: map[string]*providermanifestv1.ManifestConnectionDef{
+				"dev":  {Mode: providermanifestv1.ConnectionModeNone},
+				"prod": {Mode: providermanifestv1.ConnectionModeNone},
+			},
+			Surfaces: &providermanifestv1.ProviderSurfaces{
+				GraphQL: &providermanifestv1.GraphQLSurface{URL: "https://{graphql_host}/graphql"},
+			},
+			AllowedOperations: map[string]*providermanifestv1.ManifestOperationOverride{
+				"items": {
+					Alias: "items.list",
+					GraphQL: &providermanifestv1.ManifestGraphQLOperation{
+						OperationName: "ItemsQuery",
+						Document:      "query ItemsQuery { items { id name } }",
+					},
+				},
+				"status": {
+					GraphQL: &providermanifestv1.ManifestGraphQLOperation{
+						OperationName: "StatusQuery",
+						Document:      "query StatusQuery { status }",
+					},
+				},
+			},
+		},
+	}
+
+	spec, _, err = buildStartupProviderSpec("gqlapp", &config.ProviderEntry{ResolvedManifest: manifest})
+	if err != nil {
+		t.Fatalf("buildStartupProviderSpec graphql allowedOps: %v", err)
+	}
+	if spec.Catalog == nil {
+		t.Fatal("expected startup catalog for GraphQL allowedOperations manifest, got nil")
+	}
+	ids := make(map[string]bool, len(spec.Catalog.Operations))
+	for i := range spec.Catalog.Operations {
+		ids[spec.Catalog.Operations[i].ID] = true
+	}
+	if !ids["items.list"] {
+		t.Errorf("catalog missing aliased operation %q; have %v", "items.list", ids)
+	}
+	if !ids["status"] {
+		t.Errorf("catalog missing operation %q; have %v", "status", ids)
+	}
 }
 
 func TestBuildStartupProviderSpecMCPOnlyManifestHasNoStartupCatalog(t *testing.T) {

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -452,23 +452,32 @@ func buildStartupProviderSpec(name string, entry *config.ProviderEntry) (appserv
 	if err != nil {
 		return appservice.StaticProviderSpec{}, startupOperationRouting{}, err
 	}
-	if spec.Catalog == nil && manifestApp.IsDeclarative() {
-		declarative, err := appservice.NewDeclarativeProvider(
-			manifest,
-			nil,
-			appservice.WithDeclarativeMetadataOverrides(meta.displayName, meta.description, meta.iconSVG),
-			appservice.WithDeclarativeConnectionMode(plan.ConnectionMode()),
-			appservice.WithDeclarativeOperationConnections(restConnections, restSelectors, restLocks),
-		)
-		if err != nil {
-			return appservice.StaticProviderSpec{}, startupOperationRouting{}, err
+	if spec.Catalog == nil && manifestApp.IsManifestBacked() {
+		var dp *appservice.DeclarativeProvider
+		if manifestApp.IsDeclarative() {
+			var err error
+			dp, err = appservice.NewDeclarativeProvider(
+				manifest,
+				nil,
+				appservice.WithDeclarativeMetadataOverrides(meta.displayName, meta.description, meta.iconSVG),
+				appservice.WithDeclarativeConnectionMode(plan.ConnectionMode()),
+				appservice.WithDeclarativeOperationConnections(restConnections, restSelectors, restLocks),
+			)
+			if err != nil {
+				return appservice.StaticProviderSpec{}, startupOperationRouting{}, err
+			}
+			spec.Catalog = dp.Catalog()
+		} else if resolved, ok := plan.ResolvedSurface(config.SpecSurfaceGraphQL); ok {
+			if def, err := loadSpecDefinition(context.Background(), name, resolved, entry.EffectiveAllowedOperations()); err == nil && def != nil && len(def.Operations) > 0 {
+				spec.Catalog = declarative.CatalogFromDefinition(def)
+			}
 		}
-		spec.Catalog = declarative.Catalog()
-		return spec, startupOperationRouting{
-			connections:    operationConnectionsForCatalog(spec.Catalog, plan, restConnections),
-			resolver:       declarative,
-			overridePolicy: declarative,
-		}, nil
+		routing := startupOperationRouting{connections: operationConnectionsForCatalog(spec.Catalog, plan, restConnections)}
+		if dp != nil {
+			routing.resolver = dp
+			routing.overridePolicy = dp
+		}
+		return spec, routing, nil
 	}
 	return spec, startupOperationRouting{connections: operationConnectionsForCatalog(spec.Catalog, plan, restConnections)}, nil
 }


### PR DESCRIPTION
## Summary

- `buildStartupProviderSpec` only built a catalog for REST-surface (`IsDeclarative`) providers, leaving GraphQL/OpenAPI/MCP-surface (`IsSpecLoaded`) providers with a nil catalog at startup
- When `server.remote` is configured, spec-loaded providers are registered as `gestaltRemoteProvider` instances with that nil catalog, so `ResolveOperation` rejects every operation with `ErrOperationNotFound` before the relay ever fires
- Replace the `IsDeclarative`-only branch with a single `IsManifestBacked` branch that builds a catalog from whatever manifest surfaces are locally parseable

## Root cause

The startup provider spec builder had one branch for building a catalog from the manifest, gated on `IsDeclarative()` (REST surface with operations). frontPorch and ~40 other apps use `surfaces.graphql` with `allowedOperations`, so they are `IsSpecLoaded()` not `IsDeclarative()`. That branch is skipped, `spec.Catalog` stays nil, and the `gestaltRemoteProvider` is registered with a nil catalog. `ResolveOperation` then rejects every operation with `ErrOperationNotFound` before the relay ever fires.

The async `buildProvider` path does not have this bug because it calls `buildSpecLoadedProvider` -> `loadSpecDefinition` -> `graphql.StaticAllowedOperationsDefinition`, which correctly builds a `declarative.Definition` from the manifest. The startup path simply never called that code for spec-loaded providers.

## Fix

Replace the `IsDeclarative`-only branch with a single `IsManifestBacked` branch that calls `buildManifestStartupCatalog`. This helper dispatches to existing primitives: REST operations via `NewDeclarativeProvider` (also provides the connection resolver), GraphQL static `allowedOperations` via `loadSpecDefinition` + `CatalogFromDefinition`. Both are pure manifest parsing. OpenAPI and MCP require network I/O and are deferred to the async build path.

## Test plan

- [x] Folded GraphQL `allowedOperations` assertions into existing `TestBuildStartupProviderSpecPreservesStaticCatalogConnectionRouting`
- [x] Existing `TestBootstrapCanDeferAppProviderStartup` still passes (OpenAPI deferred)
- [x] Existing `TestBuildStartupProviderSpecMCPOnlyManifestHasNoStartupCatalog` still passes
- [x] Full `internal/bootstrap` test suite passes
- [x] Verified locally: dashboard `tenants.list` returns data instead of 502