### PR TITLE
Remove redundant gateway routing authorization check

### DIFF
--- a/gestaltd/services/apps/provider_test.go
+++ b/gestaltd/services/apps/provider_test.go
@@ -884,4 +884,3 @@ func TestRemoteProviderDeclaredWorkflowDefinitions(t *testing.T) {
 		t.Fatal("expected corrupt workflow_definition_specs to fail NewRemote")
 	}
 }
-

--- a/gestaltd/services/providergateway/gateway.go
+++ b/gestaltd/services/providergateway/gateway.go
@@ -10,7 +10,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/publicrpc"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
-	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -145,10 +144,6 @@ func (c *targetConn) Invoke(ctx context.Context, method string, args any, reply 
 		return err
 	}
 	transportPath = TransportPathDirect
-	if err := authorizeRoutingCall(ctx, c.gateway.authorization, c.gateway.users, c.target, method); err != nil {
-		recordProviderGatewayOperation(ctx, startedAt, err, metricReq, transportPath)
-		return err
-	}
 	invokeErr := endpoint.Conn.Invoke(ctx, method, args, reply, opts...)
 	recordProviderGatewayOperation(ctx, startedAt, invokeErr, metricReq, transportPath)
 	return invokeErr
@@ -165,10 +160,6 @@ func (c *targetConn) NewStream(ctx context.Context, desc *grpc.StreamDesc, metho
 		return nil, err
 	}
 	transportPath = TransportPathDirect
-	if err := authorizeRoutingCall(ctx, c.gateway.authorization, c.gateway.users, c.target, method); err != nil {
-		recordProviderGatewayOperation(ctx, startedAt, err, metricReq, transportPath)
-		return nil, err
-	}
 	stream, streamErr := endpoint.Conn.NewStream(ctx, desc, method, opts...)
 	recordProviderGatewayOperation(ctx, startedAt, streamErr, metricReq, transportPath)
 	return stream, streamErr
@@ -184,28 +175,6 @@ func metricRequest(target ProviderTarget, method string) ProviderGatewayRequest 
 	}
 }
 
-func authorizeRoutingCall(ctx context.Context, authorization core.AuthorizationProvider, users principal.CredentialUserResolver, target ProviderTarget, fullMethod string) error {
-	if authorization == nil || target.Kind == ProviderKindAuthorization {
-		return nil
-	}
-	if invocation.InternalConnectionAccessFromContext(ctx) {
-		return nil
-	}
-	subjectID, err := authorizationSubject(ctx, users)
-	if err != nil {
-		return status.Error(codes.Unauthenticated, "provider gateway: caller principal is required")
-	}
-	allowed, req, checkErr := runAuthorizationCheck(ctx, authorization, subjectID, target)
-	recordProviderGatewayAuthorizationCheck(ctx, allowed, principal.FromContext(ctx) != nil, req)
-	if checkErr != nil {
-		return status.Errorf(codes.Internal, "provider gateway: authorize: %v", checkErr)
-	}
-	if !allowed {
-		return status.Error(codes.PermissionDenied, "provider gateway: unauthorized")
-	}
-	return nil
-}
-
 func runAuthorizationCheck(
 	ctx context.Context,
 	authorization core.AuthorizationProvider,
@@ -215,36 +184,11 @@ func runAuthorizationCheck(
 	if authorization == nil {
 		return true, nil, nil
 	}
-	resource, err := authorizationResource(target)
-	if err != nil {
-		return false, nil, err
-	}
-	action, err := authorizationAction(target)
-	if err != nil {
-		return false, nil, err
-	}
+	resource := &proto.Resource{Type: string(target.Kind), Id: strings.TrimSpace(target.Name)}
+	action := &proto.Action{Name: strings.TrimSpace(target.Name)}
 	req := invocation.SubjectAccessRequest(subjectID, action.GetName(), resource)
 	allowed, err := invocation.CheckSubjectAccess(ctx, authorization, req)
 	return allowed, req, err
-}
-
-func authorizationSubject(ctx context.Context, users principal.CredentialUserResolver) (string, error) {
-	subjectID, err := principal.ResolveCredentialSubjectID(ctx, users, principal.FromContext(ctx))
-	if err != nil {
-		return "", fmt.Errorf("provider gateway: caller principal is required")
-	}
-	return subjectID, nil
-}
-
-func authorizationResource(target ProviderTarget) (*proto.Resource, error) {
-	return &proto.Resource{
-		Type: string(target.Kind),
-		Id:   strings.TrimSpace(target.Name),
-	}, nil
-}
-
-func authorizationAction(target ProviderTarget) (*proto.Action, error) {
-	return &proto.Action{Name: strings.TrimSpace(target.Name)}, nil
 }
 
 func providerKindFromFullMethod(fullMethod string) ProviderKind {

--- a/gestaltd/services/providergateway/gateway_test.go
+++ b/gestaltd/services/providergateway/gateway_test.go
@@ -491,88 +491,25 @@ func TestRoutingGatewayAuthorization(t *testing.T) {
 	parityTarget := ProviderTarget{Kind: "test", Name: "parity"}
 	authzTarget := ProviderTarget{Kind: ProviderKindAuthorization, Name: "authz-primary"}
 
-	tests := []struct {
-		name        string
-		target      ProviderTarget
-		principal   *principal.Principal
-		allowed     *bool
-		wantCode    codes.Code
-		wantCalled  bool
-		wantSuccess bool
-	}{
-		{
-			name:        "authorization kind exempt from meta-check",
-			target:      authzTarget,
-			principal:   &principal.Principal{SubjectID: "user:alice"},
-			allowed:     boolPtr(false),
-			wantCode:    codes.OK,
-			wantCalled:  false,
-			wantSuccess: true,
-		},
-		{
-			name:        "non-authorization kind denied",
-			target:      parityTarget,
-			principal:   &principal.Principal{SubjectID: "user:alice"},
-			allowed:     boolPtr(false),
-			wantCode:    codes.PermissionDenied,
-			wantCalled:  true,
-			wantSuccess: false,
-		},
-		{
-			name:        "non-authorization kind allowed",
-			target:      parityTarget,
-			principal:   &principal.Principal{SubjectID: "user:alice"},
-			allowed:     boolPtr(true),
-			wantCode:    codes.OK,
-			wantCalled:  true,
-			wantSuccess: true,
-		},
-		{
-			name:       "no principal unauthenticated",
-			target:     parityTarget,
-			principal:  nil,
-			allowed:    boolPtr(true),
-			wantCode:   codes.Unauthenticated,
-			wantCalled: false,
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
+	for _, target := range []ProviderTarget{parityTarget, authzTarget} {
+		transport := NewProviderGatewayTransport()
+		connCalled := false
+		conn := &stubConn{invoke: func(_ context.Context, _ string, _ any, reply any, _ ...grpc.CallOption) error {
+			connCalled = true
+			return nil
+		}}
+		if err := transport.RegisterDirect(target, DirectEndpoint{Conn: conn}); err != nil {
+			t.Fatalf("RegisterDirect(%s): %v", target.Name, err)
+		}
+		transport.SetAuthorizationProvider(&stubAuthorizationProvider{allowedResult: boolPtr(false)})
 
-			transport := NewProviderGatewayTransport()
-			connCalled := false
-			conn := &stubConn{invoke: func(_ context.Context, _ string, _ any, reply any, _ ...grpc.CallOption) error {
-				connCalled = true
-				return nil
-			}}
-			for _, target := range []ProviderTarget{parityTarget, authzTarget} {
-				if err := transport.RegisterDirect(target, DirectEndpoint{Conn: conn}); err != nil {
-					t.Fatalf("RegisterDirect(%s): %v", target.Name, err)
-				}
-			}
-			authorization := &stubAuthorizationProvider{allowedResult: tc.allowed}
-			transport.SetAuthorizationProvider(authorization)
-
-			ctx := context.Background()
-			if tc.principal != nil {
-				ctx = principal.WithPrincipal(ctx, tc.principal)
-			}
-			err := transport.Conn(tc.target).Invoke(ctx, "/test.Service/Echo", nil, nil)
-
-			if tc.wantCalled && !authorization.called {
-				t.Fatal("authorization provider was not called")
-			}
-			if !tc.wantCalled && authorization.called {
-				t.Fatal("authorization provider was unexpectedly called")
-			}
-			if status.Code(err) != tc.wantCode {
-				t.Fatalf("status.Code(err) = %v, want %v (%v)", status.Code(err), tc.wantCode, err)
-			}
-			if tc.wantSuccess && !connCalled {
-				t.Fatal("endpoint connection was not invoked")
-			}
-		})
+		err := transport.Conn(target).Invoke(context.Background(), "/test.Service/Echo", nil, nil)
+		if err != nil {
+			t.Fatalf("Invoke(%s): %v", target.Name, err)
+		}
+		if !connCalled {
+			t.Fatal("endpoint connection was not invoked")
+		}
 	}
 }
 
@@ -587,13 +524,11 @@ func TestRoutingGatewayRecordsMetrics(t *testing.T) {
 	if err := transport.RegisterDirect(target, DirectEndpoint{Conn: &stubConn{}}); err != nil {
 		t.Fatalf("RegisterDirect: %v", err)
 	}
-	authorization := &stubAuthorizationProvider{allowedResult: boolPtr(false)}
-	transport.SetAuthorizationProvider(authorization)
 	authCtx := principal.WithPrincipal(ctx, &principal.Principal{SubjectID: "user:alice"})
 
 	err := transport.Conn(target).Invoke(authCtx, "/test.Service/Echo", nil, nil)
-	if status.Code(err) != codes.PermissionDenied {
-		t.Fatalf("status.Code(err) = %v, want PermissionDenied", status.Code(err))
+	if err != nil {
+		t.Fatalf("Invoke err = %v, want nil", err)
 	}
 
 	rm := metrictest.CollectMetrics(t, metrics.Reader)
@@ -604,22 +539,6 @@ func TestRoutingGatewayRecordsMetrics(t *testing.T) {
 		"gd.transport":             "direct",
 		"gd.entry":                 "internal",
 		"gd.caller_token_provided": "true",
-	})
-	metrictest.RequireInt64Sum(t, rm, "gestaltd.provider_gateway.operation.error_count", 1, map[string]string{
-		"gd.provider_id":           "parity",
-		"gd.provider_kind":         "test",
-		"gd.operation":             "Echo",
-		"gd.transport":             "direct",
-		"gd.entry":                 "internal",
-		"gd.caller_token_provided": "true",
-	})
-	metrictest.RequireInt64Sum(t, rm, "gestaltd.provider_gateway.authorization.count", 1, map[string]string{
-		"gd.allowed":               "false",
-		"gd.caller_token_provided": "true",
-		"gd.subject":               "subject/user:alice",
-		"gd.resource":              "test/parity",
-		"gd.action":                "parity",
-		"gd.entry":                 "internal",
 	})
 }
 


### PR DESCRIPTION
## Problem

Every app with a dedicated authz resource type (e.g. `aiSpendTracker`, `paConfigurationRegistry`, `talentTeam`) returns `403 provider gateway: unauthorized` on all operations, even for admin users and despite `defaultRole: viewer` on the resource type.

## Root cause

PR #2875 added a `CheckAccess` call to the gateway routing layer (`authorizeRoutingCall` in `targetConn.Invoke`/`NewStream`). This check was redundant with the broker, which already runs `checkAuthorizationAccess` on every `Invoke` call before it reaches the gateway conn. The gateway check also constructed resources incorrectly — it used `string(target.Kind)` (`"app"`) as the resource type, but the authz model defines per-app resource types like `aiSpendTracker`. The broker handles this with a fallback for apps with dedicated resource types (excluded from the `providerKinds` map); the gateway did not, so `findModelResourceType(model, "app")` returned nil and every such app was denied.

## Fix

**Delete the redundant routing-level authorization check.** The gateway routing layer should route, not authorize:

- **Apps**: The broker already does a finer-grained per-operation `CheckAccess` on every `Invoke`/`InvokeGraphQL` call, with correct resource-type resolution. `enforcePublicAuthorization` handles the public request path and already skips the authz check for `App.Invoke` and `App.InvokeGraphQL`.
- **Workflows**: `enforcePublicAuthorization` checks with `Type: "workflow"` (matches the authz model) and the workflow manager `requireWorkflowAccess` does its own `CheckAccess`. Two independent working checks remain.
- **Agents**: `enforcePublicAuthorization` runs `CheckAccess` with `Type: "agent"` — there is no `"agent"` resource type in the authz model, so this check was already broken before this change. The gateway routing check had the same bug. Removing it does not change the agent security posture. (Pre-existing issue: agent methods need an `"agent"` resource type in the authz model or a skip in `enforcePublicAuthorization`.)

**Net: -138 lines.** No new branching, no duplicated resource-type logic.

## Testing

- `go build ./gestaltd/services/providergateway/...` — passes
- `go test ./gestaltd/services/providergateway/...` — passes
- `go test ./gestaltd/internal/bootstrap/...` — passes
- `gofmt` — clean