### PR TITLE
Remove unused gateway authorization metrics

### DIFF
--- a/gestaltd/services/providergateway/metrics.go
+++ b/gestaltd/services/providergateway/metrics.go
@@ -3,10 +3,8 @@ package providergateway
 import (
 	"context"
 	"strconv"
-	"strings"
 	"time"
 
-	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
@@ -22,33 +20,14 @@ var (
 	attrProviderGatewayTransportPath           = attribute.Key("gd.transport")
 	attrProviderGatewayEntry                   = attribute.Key("gd.entry")
 	attrProviderGatewayCallerPrincipalProvided = attribute.Key("gd.caller_token_provided")
-	attrProviderGatewayAuthorizationAllowed    = attribute.Key("gd.allowed")
-	attrProviderGatewayAuthorizationSubject    = attribute.Key("gd.subject")
-	attrProviderGatewayAuthorizationResource   = attribute.Key("gd.resource")
-	attrProviderGatewayAuthorizationAction     = attribute.Key("gd.action")
 
-	providerGatewayOperationMetrics    metricutil.MeterCache[providerGatewayMetrics]
-	providerGatewayAuthorizationChecks metricutil.MeterCache[providerGatewayAuthorizationMetrics]
+	providerGatewayOperationMetrics metricutil.MeterCache[providerGatewayMetrics]
 )
 
 type providerGatewayMetrics struct {
 	count      metric.Int64Counter
 	errorCount metric.Int64Counter
 	duration   metric.Float64Histogram
-}
-
-type providerGatewayAuthorizationMetrics struct {
-	count metric.Int64Counter
-}
-
-func newProviderGatewayAuthorizationMetrics(meter metric.Meter) providerGatewayAuthorizationMetrics {
-	return providerGatewayAuthorizationMetrics{
-		count: metricutil.NewInt64Counter(
-			meter,
-			"gestaltd.provider_gateway.authorization.count",
-			"Counts provider gateway authorization checks.",
-		),
-	}
 }
 
 func newProviderGatewayMetrics(meter metric.Meter) providerGatewayMetrics {
@@ -70,45 +49,6 @@ func newProviderGatewayMetrics(meter metric.Meter) providerGatewayMetrics {
 			"s",
 		),
 	}
-}
-
-func recordProviderGatewayAuthorizationCheck(ctx context.Context, allowed bool, callerPrincipalProvided bool, req *proto.CheckAccessRequest) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	metrics := providerGatewayAuthorizationChecks.Load(ctx, "gestaltd", newProviderGatewayAuthorizationMetrics)
-	attrs := []attribute.KeyValue{
-		attrProviderGatewayEntry.String(string(invocation.EntryFromContext(ctx))),
-		attrProviderGatewayCallerPrincipalProvided.String(strconv.FormatBool(callerPrincipalProvided)),
-		attrProviderGatewayAuthorizationAllowed.String(strconv.FormatBool(allowed)),
-		attrProviderGatewayAuthorizationSubject.String(metricutil.AttrValue(authorizationCheckSubjectValue(req))),
-		attrProviderGatewayAuthorizationResource.String(metricutil.AttrValue(authorizationCheckResourceValue(req))),
-		attrProviderGatewayAuthorizationAction.String(metricutil.AttrValue(authorizationCheckActionValue(req))),
-	}
-	metrics.count.Add(ctx, 1, metric.WithAttributes(attrs...))
-}
-
-func authorizationCheckSubjectValue(req *proto.CheckAccessRequest) string {
-	if req == nil || req.GetSubject() == nil {
-		return ""
-	}
-	subject := req.GetSubject()
-	return strings.TrimSpace(subject.GetType()) + "/" + strings.TrimSpace(subject.GetId())
-}
-
-func authorizationCheckResourceValue(req *proto.CheckAccessRequest) string {
-	if req == nil || req.GetResource() == nil {
-		return ""
-	}
-	resource := req.GetResource()
-	return strings.TrimSpace(resource.GetType()) + "/" + strings.TrimSpace(resource.GetId())
-}
-
-func authorizationCheckActionValue(req *proto.CheckAccessRequest) string {
-	if req == nil || req.GetAction() == nil {
-		return ""
-	}
-	return strings.TrimSpace(req.GetAction().GetName())
 }
 
 func recordProviderGatewayOperation(ctx context.Context, startedAt time.Time, err error, req ProviderGatewayRequest, transportPath TransportPath) {


### PR DESCRIPTION
PR #2896 removed authorizeRoutingCall from the gateway routing layer, which was the only caller of recordProviderGatewayAuthorizationCheck and its supporting metrics code. golangci-lint flags these as unused.

Removes: recordProviderGatewayAuthorizationCheck, providerGatewayAuthorizationMetrics type, newProviderGatewayAuthorizationMetrics, authorizationCheckSubjectValue, authorizationCheckResourceValue, authorizationCheckActionValue, and the associated attribute keys and meter cache.

Net: -60 lines.