### PR TITLE
Remove unused startRawHost after tunnel test deletion

### DIFF
--- a/gestaltd/internal/tunnel/host.go
+++ b/gestaltd/internal/tunnel/host.go
@@ -196,38 +196,3 @@ func splitHostPort(rawURL string) (string, int) {
 	_, _ = fmt.Sscanf(portStr, "%d", &port)
 	return host, port
 }
-
-// startRawHost starts frpc forwarding to the given backend listener without
-// wrapping it in inner TLS. Test-only; used to isolate relay issues.
-func startRawHost(ctx context.Context, cfg HostConfig, backend net.Listener) (*Host, error) {
-	proxyCfg := &v1.TCPMuxProxyConfig{}
-	proxyCfg.Name = cfg.Identity.TunnelHost
-	proxyCfg.Type = string(v1.ProxyTypeTCPMUX)
-	proxyCfg.LocalIP = "127.0.0.1"
-	proxyCfg.LocalPort = backend.Addr().(*net.TCPAddr).Port
-	proxyCfg.Multiplexer = string(v1.TCPMultiplexerHTTPConnect)
-	proxyCfg.CustomDomains = []string{cfg.Identity.TunnelHost}
-
-	common := &v1.ClientCommonConfig{}
-	common.ServerAddr = hostFromURL(cfg.ServerURL)
-	common.ServerPort = portFromURL(cfg.ServerURL)
-	common.Transport.TCPMux = ptr(true)
-	if isWebsocketURL(cfg.ServerURL) {
-		common.Transport.Protocol = "websocket"
-	}
-
-	configSource := frpsource.NewConfigSource()
-	if err := configSource.ReplaceAll([]v1.ProxyConfigurer{proxyCfg}, nil); err != nil {
-		return nil, fmt.Errorf("tunnel host: set proxy config: %w", err)
-	}
-
-	service, err := frpcclient.NewService(frpcclient.ServiceOptions{
-		Common:                 common,
-		ConfigSourceAggregator: frpsource.NewAggregator(configSource),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("tunnel host: frpc service: %w", err)
-	}
-	go func() { _ = service.Run(ctx) }()
-	return &Host{frpService: service, inner: backend}, nil
-}

--- a/go.work.sum
+++ b/go.work.sum
@@ -96,6 +96,7 @@ golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.42.0/go.mod h1:Dq/D+snpsbazcBG5+F9Q1n2rXV8Ma+71xEjTRufARgY=
+golang.org/x/term v0.44.0/go.mod h1:7ze4MdzUzLXpSAoFP1H0bOI9aXDqveSvatT5vKcFh2Y=
 golang.org/x/text v0.32.0/go.mod h1:o/rUWzghvpD5TXrTIBuJU77MTaN0ljMWE47kxGJQ7jY=
 golang.org/x/text v0.34.0/go.mod h1:homfLqTYRFyVYemLBFl5GgL/DWEiH5wcsQ5gSh1yziA=
 golang.org/x/text v0.36.0/go.mod h1:NIdBknypM8iqVmPiuco0Dh6P5Jcdk8lJL0CUebqK164=


### PR DESCRIPTION
PR #2899 removed the tunnel integration tests but left startRawHost in host.go, which was only called from those tests. golangci-lint flags it as unused.