### PR TITLE
Skip App service in enforcePublicAuthorization

### DIFF
--- a/gestaltd/services/providergateway/gateway.go
+++ b/gestaltd/services/providergateway/gateway.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/publicrpc"
-	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
-	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -172,35 +170,5 @@ func metricRequest(target ProviderTarget, method string) ProviderGatewayRequest 
 		ProviderKind: target.Kind,
 		ServiceName:  service,
 		Operation:    operation,
-	}
-}
-
-func runAuthorizationCheck(
-	ctx context.Context,
-	authorization core.AuthorizationProvider,
-	subjectID string,
-	target ProviderTarget,
-) (bool, *proto.CheckAccessRequest, error) {
-	if authorization == nil {
-		return true, nil, nil
-	}
-	resource := &proto.Resource{Type: string(target.Kind), Id: strings.TrimSpace(target.Name)}
-	action := &proto.Action{Name: strings.TrimSpace(target.Name)}
-	req := invocation.SubjectAccessRequest(subjectID, action.GetName(), resource)
-	allowed, err := invocation.CheckSubjectAccess(ctx, authorization, req)
-	return allowed, req, err
-}
-
-func providerKindFromFullMethod(fullMethod string) ProviderKind {
-	service, _ := splitFullMethod(fullMethod)
-	switch service {
-	case proto.App_ServiceDesc.ServiceName:
-		return ProviderKindApp
-	case proto.Workflow_ServiceDesc.ServiceName:
-		return ProviderKindWorkflow
-	case proto.Agent_ServiceDesc.ServiceName:
-		return ProviderKindAgent
-	default:
-		return ProviderKind(service)
 	}
 }

--- a/gestaltd/services/providergateway/gateway_test.go
+++ b/gestaltd/services/providergateway/gateway_test.go
@@ -644,7 +644,7 @@ func TestPublicRequestOptionalProviderMatrix(t *testing.T) {
 			authz:      &stubAuthorizationProvider{allowedResult: boolPtr(false)},
 			introspect: activeAlice,
 			token:      "test-token",
-			wantCode:   codes.PermissionDenied,
+			wantCode:   codes.OK,
 		},
 		{
 			name:       "both providers authenticated allowed",
@@ -660,7 +660,7 @@ func TestPublicRequestOptionalProviderMatrix(t *testing.T) {
 			authz:      failingAuthz,
 			introspect: activeAlice,
 			token:      "test-token",
-			wantCode:   codes.Unavailable,
+			wantCode:   codes.OK,
 		},
 	}
 

--- a/gestaltd/services/providergateway/public_request.go
+++ b/gestaltd/services/providergateway/public_request.go
@@ -105,6 +105,10 @@ func (t *ProviderGatewayTransport) enforcePublicAuthorization(
 	p *principal.Principal,
 	providerID, fullMethod string,
 ) error {
+	service, _ := splitFullMethod(fullMethod)
+	if service == proto.App_ServiceDesc.ServiceName {
+		return nil
+	}
 	if t == nil || t.authorization == nil {
 		return nil
 	}
@@ -113,7 +117,10 @@ func (t *ProviderGatewayTransport) enforcePublicAuthorization(
 		return status.Error(codes.Unauthenticated, "authenticated subject is required")
 	}
 	target := ProviderTarget{Kind: providerKindFromFullMethod(fullMethod), Name: providerID}
-	allowed, _, err := runAuthorizationCheck(ctx, t.authorization, subjectID, target)
+	resource := &proto.Resource{Type: string(target.Kind), Id: strings.TrimSpace(target.Name)}
+	action := &proto.Action{Name: strings.TrimSpace(target.Name)}
+	req := invocation.SubjectAccessRequest(subjectID, action.GetName(), resource)
+	allowed, err := invocation.CheckSubjectAccess(ctx, t.authorization, req)
 	if err != nil {
 		return status.Error(codes.Unavailable, "authorization provider unavailable")
 	}
@@ -177,6 +184,20 @@ func publicIdentityLoginMethod(fullMethod string) bool {
 		return true
 	default:
 		return false
+	}
+}
+
+func providerKindFromFullMethod(fullMethod string) ProviderKind {
+	service, _ := splitFullMethod(fullMethod)
+	switch service {
+	case proto.App_ServiceDesc.ServiceName:
+		return ProviderKindApp
+	case proto.Workflow_ServiceDesc.ServiceName:
+		return ProviderKindWorkflow
+	case proto.Agent_ServiceDesc.ServiceName:
+		return ProviderKindAgent
+	default:
+		return ProviderKind(service)
 	}
 }
 


### PR DESCRIPTION
PR #2891 removed the App.Invoke/InvokeGraphQL skip from enforcePublicAuthorization, so all App service methods now go through runAuthorizationCheck with Type="app". The authz model has no "app" resource type (it uses per-app types like aiSpendTracker), so every app call returns "access denied".

Skip the entire App service in enforcePublicAuthorization. The broker handles per-operation CheckAccess for all App methods with correct resource-type resolution.