### PR TITLE
Skip Identity service in enforcePublicAuthorization

### DIFF
--- a/gestaltd/services/providergateway/gateway_test.go
+++ b/gestaltd/services/providergateway/gateway_test.go
@@ -586,6 +586,8 @@ func TestPublicRequestOptionalProviderMatrix(t *testing.T) {
 
 	matrix := []struct {
 		name       string
+		fullMethod string
+		req        gproto.Message
 		identity   bool // configure an IdentityProvider
 		authz      any  // nil, *stubAuthorizationProvider (allowed/denied/failing)
 		introspect *core.IntrospectResponse
@@ -647,6 +649,16 @@ func TestPublicRequestOptionalProviderMatrix(t *testing.T) {
 			wantCode:   codes.OK,
 		},
 		{
+			name:       "identity service skips authorization",
+			fullMethod: proto.Identity_UserInfo_FullMethodName,
+			req:        &proto.UserInfoRequest{},
+			identity:   true,
+			authz:      &stubAuthorizationProvider{allowedResult: boolPtr(false)},
+			introspect: activeAlice,
+			token:      "test-token",
+			wantCode:   codes.OK,
+		},
+		{
 			name:       "both providers authenticated allowed",
 			identity:   true,
 			authz:      &stubAuthorizationProvider{allowedResult: boolPtr(true)},
@@ -669,6 +681,13 @@ func TestPublicRequestOptionalProviderMatrix(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
+			if tc.fullMethod == "" {
+				tc.fullMethod = proto.App_Invoke_FullMethodName
+			}
+			if tc.req == nil {
+				tc.req = &proto.AppInvokeRequest{App: "roadmap", Operation: "sync"}
+			}
+
 			transport := NewProviderGatewayTransport()
 			transport.SetPublicMethods(registry)
 			transport.SetPublicBaseURL("https://gestalt.example")
@@ -688,15 +707,14 @@ func TestPublicRequestOptionalProviderMatrix(t *testing.T) {
 				transport.SetAuthorizationProvider(authz)
 			}
 
-			fullMethod := proto.App_Invoke_FullMethodName
-			ctx := publicrpc.WithPublicOrigin(context.Background(), fullMethod)
+			ctx := publicrpc.WithPublicOrigin(context.Background(), tc.fullMethod)
 			pairs := []string{}
 			if tc.token != "" {
 				pairs = []string{"authorization", "Bearer " + tc.token}
 			}
 			ctx = metadata.NewIncomingContext(ctx, metadata.Pairs(pairs...))
 
-			_, _, err := transport.PreparePublicRequest(ctx, fullMethod, &proto.AppInvokeRequest{App: "roadmap", Operation: "sync"})
+			_, _, err := transport.PreparePublicRequest(ctx, tc.fullMethod, tc.req)
 			if tc.wantCode == codes.OK {
 				if err != nil {
 					t.Fatalf("PreparePublicRequest: %v", err)

--- a/gestaltd/services/providergateway/public_request.go
+++ b/gestaltd/services/providergateway/public_request.go
@@ -106,7 +106,7 @@ func (t *ProviderGatewayTransport) enforcePublicAuthorization(
 	providerID, fullMethod string,
 ) error {
 	service, _ := splitFullMethod(fullMethod)
-	if service == proto.App_ServiceDesc.ServiceName {
+	if service == proto.App_ServiceDesc.ServiceName || service == proto.Identity_ServiceDesc.ServiceName {
 		return nil
 	}
 	if t == nil || t.authorization == nil {


### PR DESCRIPTION
## Summary

- PR #2891 deleted the `publicIdentityServiceMethod` bypass from `enforcePublicAuthorization`
- PR #2901 restored a skip for the App service but not Identity
- When a local gestaltd relays identity requests to a remote server via `server.remote`, the remote gateway runs `enforcePublicAuthorization` on Identity service calls. Since there is no authz resource type for Identity, every identity method returns `PermissionDenied`, causing token validation to fail and mounted UI pages to return `failed to resolve user`

## Fix

Add `proto.Identity_ServiceDesc.ServiceName` to the service skip alongside App. Both services handle their own authentication — the broker does per-operation authz for App, and Identity methods authenticate via token introspection.

## Test plan

- [x] Folded `identity_service_skips_authorization` case into existing `TestPublicRequestOptionalProviderMatrix` — verifies `UserInfo` with a denying authz provider returns `OK`
- [x] Existing `TestPublicRequestLoginMethodsWithoutAuth` still passes
- [x] Existing `TestPreparePublicRequest` still passes
- [x] Full `providergateway` test suite passes