### PR TITLE
Fix admin UI e2e test for React SPA shell

### DIFF
--- a/gestaltd/internal/daemon/e2e/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e/e2e_test.go
@@ -1845,7 +1845,7 @@ func TestE2EServeSplitManagementRoutes(t *testing.T) {
 			name:         "management serves admin ui",
 			url:          managementURL + "/admin/",
 			wantStatus:   http.StatusOK,
-			wantContains: "Prometheus telemetry",
+			wantContains: `id="root"`,
 		},
 	} {
 		tc := tc


### PR DESCRIPTION
## Summary
- Update `TestE2EServeSplitManagementRoutes/management_serves_admin_ui` to assert the React SPA shell (`id="root"`) instead of inline `"Prometheus telemetry"` copy from the old vanilla HTML admin page.

Fixes the `validate / Go E2E Tests (daemon)` failure on main CD after #2902.

## Test plan
- [ ] `go test ./gestaltd/internal/daemon/e2e/... -run TestE2EServeSplitManagementRoutes`

Made with [Cursor](https://cursor.com)