### PR TITLE
Fix admin UI white screen (missing base href)

### DIFF
--- a/gestaltd/services/ui/adminui/adminui_test.go
+++ b/gestaltd/services/ui/adminui/adminui_test.go
@@ -32,6 +32,7 @@ func TestEmbeddedHandlerServesAppRegistryRoutes(t *testing.T) {
 	html := string(body)
 	for _, want := range []string{
 		`brandHref: "/workplace"`,
+		`<base href="/admin/"`,
 		`id="root"`,
 		`/admin/assets/app.js`,
 		`__GESTALT_ADMIN__`,

--- a/gestaltd/services/ui/adminui/out/index.html
+++ b/gestaltd/services/ui/adminui/out/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <base href="/admin/" />
     <title>Gestalt Admin</title>
     <script>
       window.__GESTALT_ADMIN__ = {

--- a/gestaltd/services/ui/adminui/ui/index.html
+++ b/gestaltd/services/ui/adminui/ui/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <base href="/admin/" />
     <title>Gestalt Admin</title>
     <script>
       window.__GESTALT_ADMIN__ = {


### PR DESCRIPTION
## Summary
- Add `<base href="/admin/" />` to the gestaltd admin UI shell so `@valon-technologies/gestalt-web/mount` `base()` can resolve the router basepath.
- Without this tag, `createRouter({ basepath: base() })` throws at module load and the page stays blank after #2902.

## Test plan
- [ ] `go test ./gestaltd/services/ui/adminui/...`
- [ ] Open `/admin/registry` after deploy and confirm the registry table renders

Made with [Cursor](https://cursor.com)