### PR TITLE
Materialize rollout artifacts during enrollment

### DIFF
--- a/gestaltd/internal/appregistry/poller.go
+++ b/gestaltd/internal/appregistry/poller.go
@@ -248,6 +248,7 @@ func (p *CatalogPoller) reconcileApp(ctx context.Context, instanceID, appName st
 	}
 	defer p.endInflight(appName)
 
+	restartBlocked := false
 	if rollout != nil {
 		version := strings.TrimSpace(rollout.Version)
 		if findInstallation(installations, version) == nil {
@@ -263,12 +264,13 @@ func (p *CatalogPoller) reconcileApp(ctx context.Context, instanceID, appName st
 		}
 		if rollout.State == core.AppRolloutStateEnrolling {
 			if p.now().Before(rollout.EnrollmentEndsAt) {
-				return nil
-			}
-			var err error
-			rollout, err = p.Rollouts.MarkRestarting(ctx, appName, version)
-			if err != nil {
-				return fmt.Errorf("start rollout restart phase for %s@%s: %w", appName, version, err)
+				restartBlocked = true
+			} else {
+				var err error
+				rollout, err = p.Rollouts.MarkRestarting(ctx, appName, version)
+				if err != nil {
+					return fmt.Errorf("start rollout restart phase for %s@%s: %w", appName, version, err)
+				}
 			}
 		}
 		if rollout.State == core.AppRolloutStateRestarting {
@@ -337,6 +339,9 @@ func (p *CatalogPoller) reconcileApp(ctx context.Context, instanceID, appName st
 		return fmt.Errorf("determine restart mode for app %s: %w", appName, err)
 	}
 	if !restartable {
+		if restartBlocked {
+			return nil
+		}
 		convergedAt := p.now()
 		if err := p.markCatalogConverged(ctx, instanceID, appName, pending, convergedAt); err != nil {
 			return err
@@ -348,6 +353,14 @@ func (p *CatalogPoller) reconcileApp(ctx context.Context, instanceID, appName st
 			"instance_id", instanceID,
 			"restarted_at", convergedAt,
 		)
+		return nil
+	}
+
+	if err := p.ensureDesiredMaterialized(ctx, instanceID, desired); err != nil {
+		return fmt.Errorf("materialize desired version for app %s: %w", appName, err)
+	}
+
+	if restartBlocked {
 		return nil
 	}
 
@@ -369,10 +382,6 @@ func (p *CatalogPoller) reconcileApp(ctx context.Context, instanceID, appName st
 			}
 		}
 		return nil
-	}
-
-	if err := p.ensureDesiredMaterialized(ctx, instanceID, desired); err != nil {
-		return fmt.Errorf("materialize desired version for app %s: %w", appName, err)
 	}
 
 	if inspector, ok := p.AppRestarter.(interface {

--- a/gestaltd/internal/appregistry/poller_materialize_test.go
+++ b/gestaltd/internal/appregistry/poller_materialize_test.go
@@ -140,6 +140,56 @@ func TestCatalogPollerMaterializesBeforeStop(t *testing.T) {
 	}
 }
 
+func TestCatalogPollerRolloutMaterializesDuringEnrollment(t *testing.T) {
+	t.Parallel()
+	h := newPollerMaterializationHarness(t, "toolshed", true)
+	start := h.clock
+	if _, err := h.services.AppRollouts.Create(h.ctx, &core.AppRollout{
+		App:              "g-issues",
+		Version:          h.fixture.Version,
+		State:            core.AppRolloutStateEnrolling,
+		CreatedAt:        start,
+		EnrollmentEndsAt: start.Add(2 * time.Minute),
+		Deadline:         start.Add(15 * time.Minute),
+	}); err != nil {
+		t.Fatalf("Create rollout: %v", err)
+	}
+
+	if err := h.poller.ReconcileOnce(h.ctx); err != nil {
+		t.Fatalf("enrollment pass: %v", err)
+	}
+	if len(h.restarter.stopCalls) != 0 || len(h.restarter.startCalls) != 0 {
+		t.Fatalf("restart calls during enrollment: stop=%v start=%v", h.restarter.stopCalls, h.restarter.startCalls)
+	}
+	materialization := h.materialization(t)
+	if materialization.MaterializedAt != start {
+		t.Fatalf("MaterializedAt = %v, want %v", materialization.MaterializedAt, start)
+	}
+	if !materialization.RestartedAt.IsZero() {
+		t.Fatalf("RestartedAt = %v, want zero during enrollment", materialization.RestartedAt)
+	}
+	rollout, err := h.services.AppRollouts.Get(h.ctx, "g-issues")
+	if err != nil {
+		t.Fatalf("Get rollout: %v", err)
+	}
+	if rollout.State != core.AppRolloutStateEnrolling {
+		t.Fatalf("state = %q, want enrolling", rollout.State)
+	}
+
+	close(h.restartReady)
+	h.clock = start.Add(2 * time.Minute)
+	if err := h.poller.ReconcileOnce(h.ctx); err != nil {
+		t.Fatalf("restart pass: %v", err)
+	}
+	if len(h.restarter.stopCalls) != 1 || len(h.restarter.startCalls) != 1 {
+		t.Fatalf("restart calls after enrollment: stop=%v start=%v", h.restarter.stopCalls, h.restarter.startCalls)
+	}
+	materialization = h.materialization(t)
+	if materialization.RestartedAt.IsZero() {
+		t.Fatal("RestartedAt is zero after enrollment")
+	}
+}
+
 func TestCatalogPollerDoesNotStopWithoutMaterializer(t *testing.T) {
 	t.Parallel()
 	h := newPollerMaterializationHarness(t, "toolshed", false)

--- a/plans/app_registry/lifecycle.md
+++ b/plans/app_registry/lifecycle.md
@@ -102,7 +102,7 @@ Only one rollout per app may be active across the fleet. `POST …/add` and `POS
 Replica membership is discovered rather than configured:
 
 1. The rollout remains `enrolling` for a bounded window of at least two poll intervals.
-2. Replicas join by writing `acknowledged_at` before `enrollment_ends_at`.
+2. Replicas join by writing `acknowledged_at` before `enrollment_ends_at` and download the rollout artifact during this window, recording `materialized_at` while the current provider keeps running.
 3. After enrollment, the cohort is frozen and the rollout becomes `restarting`.
 4. The rollout completes when every cohort member records `restarted_at`.
 5. The rollout fails if an acknowledged replica does not restart before the deadline.
@@ -113,8 +113,8 @@ Each pass:
 
 1. Acknowledge each new `(app, version)` in `app_instance_materializations`.
 2. Group pending versions by app and select one desired version with `LatestKnownVersion`.
-3. Download and extract only the desired registry artifact to the canonical `{artifactsDir}/registry-installed/{app}/{desiredVersion}` path, recording `materialized_at` on that version's row while the provider is still running. Superseded pending rows remain without `materialized_at`. Re-validate the desired path on every pass; if the tree is missing or corrupt, re-download it before `StopApp`.
-4. Stop and restart each restartable app once, recording `stopped_at` and `restarted_at` on every pending row. These timestamps mean the replica reconciled past those catalog changes; they do not mean every superseded version ran. `StartApp` receives the desired version and builds the provider from that materialized package instead of the deploy-time pin.
+3. Download and extract only the desired registry artifact to the canonical `{artifactsDir}/registry-installed/{app}/{desiredVersion}` path, recording `materialized_at` on that version's row while the provider is still running. During an active rollout's enrollment window, replicas materialize but do not stop or restart until enrollment closes. Superseded pending rows remain without `materialized_at`. Re-validate the desired path on every pass; if the tree is missing or corrupt, re-download it before `StopApp`.
+4. After enrollment closes, stop and restart each restartable app once, recording `stopped_at` and `restarted_at` on every pending row. These timestamps mean the replica reconciled past those catalog changes; they do not mean every superseded version ran. `StartApp` receives the desired version and builds the provider from that materialized package instead of the deploy-time pin.
 5. After the desired version is active, remove older registry-installed package directories for that app.
 6. Mark non-restartable apps converged without a local stop/start.
 

--- a/plans/app_registry/tests.md
+++ b/plans/app_registry/tests.md
@@ -169,6 +169,7 @@ go test ./internal/appregistry -run 'TestMaterializer|TestCatalogPollerMateriali
 ### `poller_materialize_test.go`
 
 - **`TestCatalogPollerMaterializesBeforeStop`** — records `materialized_at` and creates the canonical on-disk artifact before `StopApp`, including while `RestartReady` is still open.
+- **`TestCatalogPollerRolloutMaterializesDuringEnrollment`** — during an active rollout's enrollment window, records `materialized_at` without stop/start; restarts only after enrollment closes.
 - **`TestCatalogPollerSkipsMaterializationForLegacyNonRegistryVersion`** — allows pre-registry catalog rows to retain restart-only convergence when a materializer is configured.
 - **`TestCatalogPollerRematerializesWhenArtifactMissing`** — re-downloads when IndexedDB shows materialization complete but the on-disk tree was removed.
 


### PR DESCRIPTION
## Summary
- During an active rollout's enrollment window, replicas acknowledge the rollout and download the desired registry artifact (recording `materialized_at`) while the current provider keeps running.
- Stop/restart and convergence writes remain gated until enrollment closes, preserving cohort discovery before any replica serves the new version.
- Documents the split enrollment behavior in `lifecycle.md` and adds `TestCatalogPollerRolloutMaterializesDuringEnrollment`.

## Test plan
- [x] `go test ./internal/appregistry/...`
- [x] `TestCatalogPollerRolloutMaterializesDuringEnrollment` — materializes during enrollment, no stop/start until window closes
- [x] Existing rollout enrollment/completion tests still pass


Made with [Cursor](https://cursor.com)