### PR TITLE
Switch all CLI transports from gRPC to REST

### DIFF
--- a/gestalt/cli/Cargo.toml
+++ b/gestalt/cli/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "cookies", "json", "rustls"] }
-gestalt_sdk = { package = "gestalt-sdk", version = "0.0.1-alpha.24" }
+gestalt_sdk = { package = "gestalt-sdk", version = "0.0.1-alpha.25" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_urlencoded = "0.7"

--- a/gestalt/cli/src/commands/agents/requests.rs
+++ b/gestalt/cli/src/commands/agents/requests.rs
@@ -21,7 +21,7 @@ use gestalt_sdk::public::generated::agent::{
 };
 use gestalt_sdk::public::generated::app::AgentToolRef;
 use gestalt_sdk::public::generated::app_client::AgentClient;
-use gestalt_sdk::public::grpc_transport::{SyncGrpcTransport, dial_public_grpc};
+use gestalt_sdk::public::rest_transport::SyncRestTransport;
 use gestalt_sdk::rpc_support::GestaltError;
 
 use super::fields::decode_json;
@@ -35,12 +35,9 @@ use super::types::{AgentInteractionInfo, AgentSessionInfo, AgentTurnEventInfo, A
 pub(crate) const DEFAULT_SESSION_LIST_LIMIT: usize = 50;
 pub(crate) const INTERRUPT_CANCEL_REASON: &str = "operator interrupted";
 
-fn agent_client(api: &ApiClient) -> Result<AgentClient<SyncGrpcTransport>> {
-    let transport = SyncGrpcTransport::from_endpoint(
-        dial_public_grpc(api.base_url())?,
-        Arc::new(BearerAuth::new(api.token())),
-    )
-    .with_timeout(std::time::Duration::from_secs(30));
+fn agent_client(api: &ApiClient) -> Result<AgentClient<SyncRestTransport>> {
+    let transport = SyncRestTransport::new(api.base_url(), Arc::new(BearerAuth::new(api.token())))
+        .with_timeout(std::time::Duration::from_secs(30));
     Ok(AgentClient::new(transport))
 }
 

--- a/gestalt/cli/src/commands/authorization.rs
+++ b/gestalt/cli/src/commands/authorization.rs
@@ -16,10 +16,10 @@ use gestalt_sdk::public::generated::authorization::{
     ListActiveModelResourceTypesRequest, ListRelationshipsRequest, RelationshipFilter,
     RelationshipTarget, RelationshipTargetKind, Resource, Subject,
 };
-use gestalt_sdk::public::grpc_transport::SyncGrpcTransport;
+use gestalt_sdk::public::rest_transport::SyncRestTransport;
 
 pub fn dispatch(
-    authz: &AuthorizationClient<SyncGrpcTransport>,
+    authz: &AuthorizationClient<SyncRestTransport>,
     command: AuthorizationCommands,
     format: Format,
 ) -> Result<()> {

--- a/gestalt/cli/src/commands/invoke.rs
+++ b/gestalt/cli/src/commands/invoke.rs
@@ -211,8 +211,8 @@ fn execute(
         param_map = params::merge_params(file_map, param_map);
     }
 
-    let transport = gestalt_sdk::public::grpc_transport::SyncGrpcTransport::from_endpoint(
-        gestalt_sdk::public::grpc_transport::dial_public_grpc(client.base_url())?,
+    let transport = gestalt_sdk::public::rest_transport::SyncRestTransport::new(
+        client.base_url(),
         std::sync::Arc::new(gestalt_sdk::public::auth::BearerAuth::new(client.token())),
     )
     .with_timeout(std::time::Duration::from_secs(30));

--- a/gestalt/cli/src/commands/workflows.rs
+++ b/gestalt/cli/src/commands/workflows.rs
@@ -13,14 +13,14 @@ use gestalt_sdk::public::generated::workflow::{
     CancelWorkflowProviderRunRequest, GetWorkflowProviderRunRequest,
     ListWorkflowProviderRunsRequest, WorkflowRunStatus,
 };
-use gestalt_sdk::public::grpc_transport::SyncGrpcTransport;
+use gestalt_sdk::public::rest_transport::SyncRestTransport;
 
 use super::workflow_target::{target_app, target_operation};
 
 const EVENTS_PATH: &str = "/api/v1/workflow/events";
 
 pub fn list_runs(
-    client: &WorkflowClient<SyncGrpcTransport>,
+    client: &WorkflowClient<SyncRestTransport>,
     app: Option<&str>,
     status: Option<&str>,
     page_size: Option<u32>,
@@ -41,7 +41,7 @@ pub fn list_runs(
     Ok(())
 }
 
-pub fn get_run(client: &WorkflowClient<SyncGrpcTransport>, id: &str, format: Format) -> Result<()> {
+pub fn get_run(client: &WorkflowClient<SyncRestTransport>, id: &str, format: Format) -> Result<()> {
     let request = GetWorkflowProviderRunRequest {
         run_id: id.to_string(),
         ..Default::default()
@@ -54,7 +54,7 @@ pub fn get_run(client: &WorkflowClient<SyncGrpcTransport>, id: &str, format: For
 }
 
 pub fn cancel_run(
-    client: &WorkflowClient<SyncGrpcTransport>,
+    client: &WorkflowClient<SyncRestTransport>,
     id: &str,
     reason: Option<&str>,
     format: Format,
@@ -281,7 +281,7 @@ fn run_trigger_label(value: &Value) -> String {
 
 pub fn dispatch(
     api: &ApiClient,
-    workflow: &WorkflowClient<SyncGrpcTransport>,
+    workflow: &WorkflowClient<SyncRestTransport>,
     command: WorkflowCommands,
     format: Format,
 ) -> Result<()> {

--- a/gestalt/cli/src/main.rs
+++ b/gestalt/cli/src/main.rs
@@ -35,8 +35,8 @@ fn run() -> anyhow::Result<()> {
         },
         Commands::Authorization { command } => {
             let api = ApiClient::from_env(url)?;
-            let transport = gestalt_sdk::public::grpc_transport::SyncGrpcTransport::from_endpoint(
-                gestalt_sdk::public::grpc_transport::dial_public_grpc(api.base_url())?,
+            let transport = gestalt_sdk::public::rest_transport::SyncRestTransport::new(
+                api.base_url(),
                 std::sync::Arc::new(gestalt_sdk::public::auth::BearerAuth::new(api.token())),
             )
             .with_timeout(std::time::Duration::from_secs(30));
@@ -49,8 +49,8 @@ fn run() -> anyhow::Result<()> {
         Commands::Describe(args) => dispatch_app_command(AppCommands::Describe(args), url, format),
         Commands::Workflow { command } => {
             let api = ApiClient::from_env(url)?;
-            let transport = gestalt_sdk::public::grpc_transport::SyncGrpcTransport::from_endpoint(
-                gestalt_sdk::public::grpc_transport::dial_public_grpc(api.base_url())?,
+            let transport = gestalt_sdk::public::rest_transport::SyncRestTransport::new(
+                api.base_url(),
                 std::sync::Arc::new(gestalt_sdk::public::auth::BearerAuth::new(api.token())),
             )
             .with_timeout(std::time::Duration::from_secs(30));


### PR DESCRIPTION
## Summary

Replace `SyncGrpcTransport` with `SyncRestTransport` across all CLI commands — authorization, workflows, invoke, agents, and main dispatch. This makes the CLI work behind Cloudflare tunnels and HTTP/1.1-only proxies where gRPC (HTTP/2) is unavailable.

Net -3 lines. The only changes are import swaps and transport construction — all generated client types and method calls stay the same.

Bumps `gestalt-sdk` dependency to `0.0.1-alpha.25`, which adds REST annotations to `ListInteractions` and `ResolveInteraction` so all agent client methods are available over REST.

**Depends on #2916** being merged and the SDK published first.