### PR TITLE
Fix CLI imports for SDK 0.0.1-alpha.25 and switch to REST transport

### DIFF
--- a/gestalt/cli/Cargo.toml
+++ b/gestalt/cli/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "cookies", "json", "rustls"] }
-gestalt_sdk = { package = "gestalt-sdk", version = "0.0.1-alpha.24" }
+gestalt_sdk = { package = "gestalt-sdk", version = "0.0.1-alpha.25" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_urlencoded = "0.7"

--- a/gestalt/cli/src/commands/agents/requests.rs
+++ b/gestalt/cli/src/commands/agents/requests.rs
@@ -11,17 +11,17 @@ use crate::cli::{
 use crate::output::{self, Format};
 use crate::params;
 
-use gestalt_sdk::public::auth::BearerAuth;
-use gestalt_sdk::public::generated::agent::agent_execution_status::*;
-use gestalt_sdk::public::generated::agent::agent_message_part_type::*;
-use gestalt_sdk::public::generated::agent::agent_session_state::*;
-use gestalt_sdk::public::generated::agent::{
+use gestalt_sdk::agent::agent_execution_status::*;
+use gestalt_sdk::agent::agent_message_part_type::*;
+use gestalt_sdk::agent::agent_session_state::*;
+use gestalt_sdk::agent::{
     AgentCatalogToolConfig, AgentExecutionStatus, AgentMessage, AgentMessagePart, AgentOutput,
     AgentSessionState, AgentTextOutput, AgentToolConfig, AgentToolConfigSource,
 };
-use gestalt_sdk::public::generated::app::AgentToolRef;
+use gestalt_sdk::app::AgentToolRef;
+use gestalt_sdk::public::auth::BearerAuth;
 use gestalt_sdk::public::generated::app_client::AgentClient;
-use gestalt_sdk::public::grpc_transport::{SyncGrpcTransport, dial_public_grpc};
+use gestalt_sdk::public::rest_transport::SyncRestTransport;
 use gestalt_sdk::rpc_support::GestaltError;
 
 use super::fields::decode_json;
@@ -35,12 +35,9 @@ use super::types::{AgentInteractionInfo, AgentSessionInfo, AgentTurnEventInfo, A
 pub(crate) const DEFAULT_SESSION_LIST_LIMIT: usize = 50;
 pub(crate) const INTERRUPT_CANCEL_REASON: &str = "operator interrupted";
 
-fn agent_client(api: &ApiClient) -> Result<AgentClient<SyncGrpcTransport>> {
-    let transport = SyncGrpcTransport::from_endpoint(
-        dial_public_grpc(api.base_url())?,
-        Arc::new(BearerAuth::new(api.token())),
-    )
-    .with_timeout(std::time::Duration::from_secs(30));
+fn agent_client(api: &ApiClient) -> Result<AgentClient<SyncRestTransport>> {
+    let transport = SyncRestTransport::new(api.base_url(), Arc::new(BearerAuth::new(api.token())))
+        .with_timeout(std::time::Duration::from_secs(30));
     Ok(AgentClient::new(transport))
 }
 
@@ -516,9 +513,9 @@ fn build_create_turn_request(
         timeout_seconds: args.timeout_seconds.unwrap_or(0),
         messages: build_messages(&args.system, &args.messages),
         output: Some(AgentOutput {
-            kind: Some(
-                gestalt_sdk::public::generated::agent::AgentOutputKind::Text(AgentTextOutput {}),
-            ),
+            kind: Some(gestalt_sdk::agent::AgentOutputKind::Text(
+                AgentTextOutput {},
+            )),
         }),
         ..Default::default()
     };

--- a/gestalt/cli/src/commands/authorization.rs
+++ b/gestalt/cli/src/commands/authorization.rs
@@ -7,19 +7,19 @@ use crate::cli::{
 };
 use crate::output::{self, Format};
 
-use gestalt_sdk::public::generated::app_client::AuthorizationClient;
-use gestalt_sdk::public::generated::authorization::source_layer::{
+use gestalt_sdk::authorization::source_layer::{
     SOURCE_LAYER_RUNTIME, SOURCE_LAYER_STATIC_CONFIG, SOURCE_LAYER_UNSPECIFIED,
 };
-use gestalt_sdk::public::generated::authorization::{
+use gestalt_sdk::authorization::{
     Action, AuthorizationModelResourceTypeFilter, CheckAccessRequest,
     ListActiveModelResourceTypesRequest, ListRelationshipsRequest, RelationshipFilter,
     RelationshipTarget, RelationshipTargetKind, Resource, Subject,
 };
-use gestalt_sdk::public::grpc_transport::SyncGrpcTransport;
+use gestalt_sdk::public::generated::app_client::AuthorizationClient;
+use gestalt_sdk::public::rest_transport::SyncRestTransport;
 
 pub fn dispatch(
-    authz: &AuthorizationClient<SyncGrpcTransport>,
+    authz: &AuthorizationClient<SyncRestTransport>,
     command: AuthorizationCommands,
     format: Format,
 ) -> Result<()> {

--- a/gestalt/cli/src/commands/invoke.rs
+++ b/gestalt/cli/src/commands/invoke.rs
@@ -211,8 +211,8 @@ fn execute(
         param_map = params::merge_params(file_map, param_map);
     }
 
-    let transport = gestalt_sdk::public::grpc_transport::SyncGrpcTransport::from_endpoint(
-        gestalt_sdk::public::grpc_transport::dial_public_grpc(client.base_url())?,
+    let transport = gestalt_sdk::public::rest_transport::SyncRestTransport::new(
+        client.base_url(),
         std::sync::Arc::new(gestalt_sdk::public::auth::BearerAuth::new(client.token())),
     )
     .with_timeout(std::time::Duration::from_secs(30));

--- a/gestalt/cli/src/commands/tokens.rs
+++ b/gestalt/cli/src/commands/tokens.rs
@@ -4,11 +4,9 @@ use std::sync::Arc;
 use crate::api::ApiClient;
 use crate::output::{self, Format};
 
+use gestalt_sdk::identity::{GetGrantRequest, ListGrantsRequest, RevokeGrantRequest, TokenRequest};
 use gestalt_sdk::public::auth::BearerAuth;
 use gestalt_sdk::public::generated::app_client::IdentityClient;
-use gestalt_sdk::public::generated::identity::{
-    GetGrantRequest, ListGrantsRequest, RevokeGrantRequest, TokenRequest,
-};
 use gestalt_sdk::public::rest_transport::SyncRestTransport;
 
 const GRANT_TYPE_TOKEN_EXCHANGE: &str = "urn:ietf:params:oauth:grant-type:token-exchange";

--- a/gestalt/cli/src/commands/workflows.rs
+++ b/gestalt/cli/src/commands/workflows.rs
@@ -11,16 +11,17 @@ use crate::params::{self, ParamEntry};
 use gestalt_sdk::public::generated::app_client::WorkflowClient;
 use gestalt_sdk::public::generated::workflow::{
     CancelWorkflowProviderRunRequest, GetWorkflowProviderRunRequest,
-    ListWorkflowProviderRunsRequest, WorkflowRunStatus,
+    ListWorkflowProviderRunsRequest,
 };
-use gestalt_sdk::public::grpc_transport::SyncGrpcTransport;
+use gestalt_sdk::public::rest_transport::SyncRestTransport;
+use gestalt_sdk::workflow::WorkflowRunStatus;
 
 use super::workflow_target::{target_app, target_operation};
 
 const EVENTS_PATH: &str = "/api/v1/workflow/events";
 
 pub fn list_runs(
-    client: &WorkflowClient<SyncGrpcTransport>,
+    client: &WorkflowClient<SyncRestTransport>,
     app: Option<&str>,
     status: Option<&str>,
     page_size: Option<u32>,
@@ -41,7 +42,7 @@ pub fn list_runs(
     Ok(())
 }
 
-pub fn get_run(client: &WorkflowClient<SyncGrpcTransport>, id: &str, format: Format) -> Result<()> {
+pub fn get_run(client: &WorkflowClient<SyncRestTransport>, id: &str, format: Format) -> Result<()> {
     let request = GetWorkflowProviderRunRequest {
         run_id: id.to_string(),
         ..Default::default()
@@ -54,7 +55,7 @@ pub fn get_run(client: &WorkflowClient<SyncGrpcTransport>, id: &str, format: For
 }
 
 pub fn cancel_run(
-    client: &WorkflowClient<SyncGrpcTransport>,
+    client: &WorkflowClient<SyncRestTransport>,
     id: &str,
     reason: Option<&str>,
     format: Format,
@@ -91,7 +92,7 @@ pub fn deliver_event(
 }
 
 fn parse_run_status(value: Option<&str>) -> WorkflowRunStatus {
-    use gestalt_sdk::public::generated::workflow::workflow_run_status::*;
+    use gestalt_sdk::workflow::workflow_run_status::*;
     match value.map(str::trim).filter(|v| !v.is_empty()) {
         Some("pending") => WORKFLOW_RUN_STATUS_PENDING,
         Some("running") => WORKFLOW_RUN_STATUS_RUNNING,
@@ -281,7 +282,7 @@ fn run_trigger_label(value: &Value) -> String {
 
 pub fn dispatch(
     api: &ApiClient,
-    workflow: &WorkflowClient<SyncGrpcTransport>,
+    workflow: &WorkflowClient<SyncRestTransport>,
     command: WorkflowCommands,
     format: Format,
 ) -> Result<()> {

--- a/gestalt/cli/src/main.rs
+++ b/gestalt/cli/src/main.rs
@@ -35,8 +35,8 @@ fn run() -> anyhow::Result<()> {
         },
         Commands::Authorization { command } => {
             let api = ApiClient::from_env(url)?;
-            let transport = gestalt_sdk::public::grpc_transport::SyncGrpcTransport::from_endpoint(
-                gestalt_sdk::public::grpc_transport::dial_public_grpc(api.base_url())?,
+            let transport = gestalt_sdk::public::rest_transport::SyncRestTransport::new(
+                api.base_url(),
                 std::sync::Arc::new(gestalt_sdk::public::auth::BearerAuth::new(api.token())),
             )
             .with_timeout(std::time::Duration::from_secs(30));
@@ -49,8 +49,8 @@ fn run() -> anyhow::Result<()> {
         Commands::Describe(args) => dispatch_app_command(AppCommands::Describe(args), url, format),
         Commands::Workflow { command } => {
             let api = ApiClient::from_env(url)?;
-            let transport = gestalt_sdk::public::grpc_transport::SyncGrpcTransport::from_endpoint(
-                gestalt_sdk::public::grpc_transport::dial_public_grpc(api.base_url())?,
+            let transport = gestalt_sdk::public::rest_transport::SyncRestTransport::new(
+                api.base_url(),
                 std::sync::Arc::new(gestalt_sdk::public::auth::BearerAuth::new(api.token())),
             )
             .with_timeout(std::time::Duration::from_secs(30));


### PR DESCRIPTION
## Summary

PR #2916 published SDK `0.0.1-alpha.25` which reorganized the generated module layout (identity, authorization, agent, workflow types moved between `crate::*` and `crate::public::generated::*`). The CLI's imports were not updated, breaking the build on main.

This PR:
- Fixes all CLI imports to match the new SDK layout (request types from `public::generated::*`, native types from root modules)
- Bumps `gestalt-sdk` dep to `0.0.1-alpha.25`
- Replaces `SyncGrpcTransport` with `SyncRestTransport` across all commands, so the CLI works behind Cloudflare tunnels and HTTP/1.1-only proxies

Net -2 lines. Supersedes #2917.