### PR TITLE
fix(gestaltd): give each Cloud Run replica a unique instance ID

### DIFF
--- a/gestaltd/internal/appregistry/instance_id_test.go
+++ b/gestaltd/internal/appregistry/instance_id_test.go
@@ -48,6 +48,7 @@ func TestResolveInstanceIDEnvOverridesLocalhostHostname(t *testing.T) {
 }
 
 func TestResolveInstanceIDIsStableWithinProcess(t *testing.T) {
+	t.Parallel()
 	first := ResolveInstanceID()
 	second := ResolveInstanceID()
 	if first == "" || second == "" {

--- a/gestaltd/internal/appregistry/instance_id_test.go
+++ b/gestaltd/internal/appregistry/instance_id_test.go
@@ -1,0 +1,62 @@
+package appregistry
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestResolveInstanceIDFromEnv(t *testing.T) {
+	t.Parallel()
+	got := resolveInstanceID("replica-a", "localhost")
+	if got != "replica-a" {
+		t.Fatalf("resolveInstanceID() = %q, want replica-a", got)
+	}
+}
+
+func TestResolveInstanceIDFromHostname(t *testing.T) {
+	t.Parallel()
+	got := resolveInstanceID("", "gestaltd-6f57fd4c4b-bbzzk")
+	if got != "gestaltd-6f57fd4c4b-bbzzk" {
+		t.Fatalf("resolveInstanceID() = %q, want pod hostname", got)
+	}
+}
+
+func TestResolveInstanceIDIgnoresLocalhostHostname(t *testing.T) {
+	t.Parallel()
+	got := resolveInstanceID("", "localhost")
+	if _, err := uuid.Parse(got); err != nil {
+		t.Fatalf("resolveInstanceID(localhost) = %q, want UUID: %v", got, err)
+	}
+}
+
+func TestResolveInstanceIDGeneratesUUIDWhenHostnameMissing(t *testing.T) {
+	t.Parallel()
+	got := resolveInstanceID("", "")
+	if _, err := uuid.Parse(got); err != nil {
+		t.Fatalf("resolveInstanceID(empty) = %q, want UUID: %v", got, err)
+	}
+}
+
+func TestResolveInstanceIDEnvOverridesLocalhostHostname(t *testing.T) {
+	t.Parallel()
+	got := resolveInstanceID("cloud-run-replica-2", "localhost")
+	if got != "cloud-run-replica-2" {
+		t.Fatalf("resolveInstanceID() = %q, want explicit env override", got)
+	}
+}
+
+func TestResolveInstanceIDIsStableWithinProcess(t *testing.T) {
+	first := ResolveInstanceID()
+	second := ResolveInstanceID()
+	if first == "" || second == "" {
+		t.Fatal("ResolveInstanceID returned empty string")
+	}
+	if first != second {
+		t.Fatalf("ResolveInstanceID() = %q then %q, want stable value within process", first, second)
+	}
+	if strings.EqualFold(first, "localhost") {
+		t.Fatalf("ResolveInstanceID() = localhost, want generated identity")
+	}
+}

--- a/gestaltd/internal/appregistry/poller.go
+++ b/gestaltd/internal/appregistry/poller.go
@@ -19,6 +19,12 @@ import (
 const (
 	DefaultCatalogPollInterval = time.Minute
 	DefaultCatalogRestartDelay = time.Minute
+	instanceIDEnvVar           = "GESTALT_INSTANCE_ID"
+)
+
+var (
+	resolvedInstanceID     string
+	resolvedInstanceIDOnce sync.Once
 )
 
 type CatalogPoller struct {
@@ -83,12 +89,23 @@ func NewCatalogPoller(cfg CatalogPollerConfig) *CatalogPoller {
 }
 
 func ResolveInstanceID() string {
-	host, err := os.Hostname()
-	if err == nil {
-		host = strings.TrimSpace(host)
-		if host != "" {
-			return host
-		}
+	resolvedInstanceIDOnce.Do(func() {
+		host, _ := os.Hostname()
+		resolvedInstanceID = resolveInstanceID(os.Getenv(instanceIDEnvVar), host)
+	})
+	return resolvedInstanceID
+}
+
+func resolveInstanceID(instanceIDEnv, hostname string) string {
+	if v := strings.TrimSpace(instanceIDEnv); v != "" {
+		return v
+	}
+	host := strings.TrimSpace(hostname)
+	// Cloud Run (and some container runtimes) report localhost for every
+	// replica. A shared instance_id makes rollout convergence look fleet-wide
+	// while only one process actually restarts the registry app.
+	if host != "" && !strings.EqualFold(host, "localhost") {
+		return host
 	}
 	return uuid.NewString()
 }


### PR DESCRIPTION
## Summary
- Fix registry app rollout convergence on Cloud Run where every replica reports `localhost` as its hostname
- `ResolveInstanceID` now prefers `GESTALT_INSTANCE_ID`, then a non-`localhost` hostname (unchanged for Kubernetes), then a per-process UUID cached with `sync.Once`
- Add unit tests covering env override, pod hostname, localhost fallback, and process stability

## Context
On valon.tools (`minScale: 5`), all gestaltd replicas shared one materialization row because `os.Hostname()` returned `localhost`. Rollout looked fleet-wide complete after one replica restarted g-issues while ~80% of requests still hit processes serving 503.

## Test plan
- [x] `go test ./internal/appregistry -run ResolveInstanceID -count=1`
- [ ] After gestaltd publish + toolshed bump: re-enable `source.registry: toolshed` for g-issues and verify all Cloud Run replicas materialize with distinct instance IDs


Made with [Cursor](https://cursor.com)