### PR TITLE
Increase MCP upstream and app invoke timeouts to 60 seconds

### DIFF
--- a/gestalt/cli/src/commands/invoke.rs
+++ b/gestalt/cli/src/commands/invoke.rs
@@ -215,7 +215,7 @@ fn execute(
         gestalt_sdk::public::grpc_transport::dial_public_grpc(client.base_url())?,
         std::sync::Arc::new(gestalt_sdk::public::auth::BearerAuth::new(client.token())),
     )
-    .with_timeout(std::time::Duration::from_secs(30));
+    .with_timeout(std::time::Duration::from_secs(60));
     let app_client = gestalt_sdk::public::generated::app_client::AppClient::new(transport);
 
     let request = gestalt_sdk::public::generated::app::AppInvokeRequest {

--- a/gestaltd/services/apps/mcpupstream/upstream.go
+++ b/gestaltd/services/apps/mcpupstream/upstream.go
@@ -20,7 +20,7 @@ import (
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 )
 
-const httpTimeout = 30 * time.Second
+const httpTimeout = 60 * time.Second
 
 var (
 	_ core.Provider               = (*Upstream)(nil)


### PR DESCRIPTION
## Summary
- Bump the gestaltd MCP upstream HTTP client timeout from 30s to 60s so hosted MCP tools (e.g. PlanetScale Insights) can complete multi-metric queries.
- Bump the gestalt CLI `app invoke` gRPC deadline from 30s to 60s so callers do not hit `Timeout expired` before gestaltd finishes.
- Aligns both limits with the existing 60s `/api/v1` route timeout in gestaltd.

## Context
PlanetScale `planetscale_get_insights` with default `sort_by=all` often takes 30–35s on prod. The prior 30s client timeouts caused flaky `Timeout expired` errors even when PlanetScale was still processing the request.

## Test plan
- [x] `go test ./gestaltd/services/apps/mcpupstream/...`
- [ ] Deploy gestaltd and verify `gestalt app invoke planetscale planetscale_get_insights` succeeds without limit on prod tag queries
- [ ] Rebuild/install gestalt CLI to pick up the 60s invoke deadline


Made with [Cursor](https://cursor.com)