### PR TITLE
Release CLI 0.0.2-alpha.11

### DIFF
--- a/gestalt/Cargo.toml
+++ b/gestalt/Cargo.toml
@@ -3,5 +3,5 @@ resolver = "2"
 members = ["cli"]
 
 [workspace.package]
-version = "0.0.2-alpha.10"
+version = "0.0.2-alpha.11"
 edition = "2024"


### PR DESCRIPTION
Bump CLI version to `0.0.2-alpha.11`.

Includes:
- REST transport for all CLI commands (no more gRPC dependency)
- SDK 0.0.1-alpha.25 with REST annotations for agent interaction RPCs
- Fixed imports for the reorganized SDK module layout

Once merged, push tag `gestalt/v0.0.2-alpha.11` to trigger the release workflow.