### PR TITLE
test(publicrpc): update REST contract for agent interaction RPCs

### DIFF
--- a/gestaltd/internal/publicrpc/registry_test.go
+++ b/gestaltd/internal/publicrpc/registry_test.go
@@ -67,7 +67,9 @@ POST /api/v2/agent/sessions/{session_id}/turns /gestalt.provider.v1.Agent/Create
 GET /api/v2/agent/sessions/{session_id}/turns /gestalt.provider.v1.Agent/ListTurns
 GET /api/v2/agent/sessions/{session_id}/turns/{turn_id} /gestalt.provider.v1.Agent/GetTurn
 POST /api/v2/agent/sessions/{session_id}/turns/{turn_id}:cancel /gestalt.provider.v1.Agent/CancelTurn
+POST /api/v2/agent/turns/{turn_id}/interactions/{interaction_id}/resolve /gestalt.provider.v1.Agent/ResolveInteraction
 GET /api/v2/agent/sessions/{session_id}/turns/{turn_id}/events /gestalt.provider.v1.Agent/ListTurnEvents
+GET /api/v2/agent/turns/{turn_id}/interactions /gestalt.provider.v1.Agent/ListInteractions
 POST /api/v2/workflow/definitions:apply /gestalt.provider.v1.Workflow/ApplyDefinition
 GET /api/v2/workflow/definitions /gestalt.provider.v1.Workflow/ListDefinitions
 GET /api/v2/workflow/definitions/{definition_id} /gestalt.provider.v1.Workflow/GetDefinition


### PR DESCRIPTION
## Summary
- Update `TestRegistryDiscoversPublicMethods` expected routes after #2916 added public REST bindings for `ListInteractions` and `ResolveInteraction`.

## Why
This is a deterministic failure, not a flake: CD on main fails `validate / Go Tests` and `validate / Go Race Tests (rest)` because the hardcoded contract snapshot drifted from generated protos.

## Test plan
- [x] `go test ./internal/publicrpc -run TestRegistryDiscoversPublicMethods -count=1`


Made with [Cursor](https://cursor.com)