### PR TITLE
Bump CLI version to 0.0.2-alpha.12

### DIFF
--- a/gestalt/Cargo.toml
+++ b/gestalt/Cargo.toml
@@ -3,5 +3,5 @@ resolver = "2"
 members = ["cli"]
 
 [workspace.package]
-version = "0.0.2-alpha.11"
+version = "0.0.2-alpha.12"
 edition = "2024"


### PR DESCRIPTION
## Summary
- Bump gestalt CLI workspace version to `0.0.2-alpha.12` for a new release
- Ships the 60s app invoke timeout from #2920 to Homebrew/installer users

## Test plan
- [ ] Merge and tag `gestalt/v0.0.2-alpha.12` to trigger release workflow
- [ ] `brew upgrade valon-technologies/gestalt/gestalt` picks up alpha.12

Made with [Cursor](https://cursor.com)