### PR TITLE
Add --header flag to gestalt invoke CLI

### DIFF
--- a/gestalt/Cargo.toml
+++ b/gestalt/Cargo.toml
@@ -3,5 +3,5 @@ resolver = "2"
 members = ["cli"]
 
 [workspace.package]
-version = "0.0.2-alpha.12"
+version = "0.0.2-alpha.13"
 edition = "2024"

--- a/gestalt/cli/Cargo.toml
+++ b/gestalt/cli/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "cookies", "json", "rustls"] }
-gestalt_sdk = { package = "gestalt-sdk", version = "0.0.1-alpha.25" }
+gestalt_sdk = { package = "gestalt-sdk", version = "0.0.1-alpha.26", path = "../../sdk/rust" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_urlencoded = "0.7"

--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -167,6 +167,10 @@ pub struct InvokeArgs {
     #[arg(long)]
     pub instance: Option<String>,
 
+    /// Outbound header override as key=value (repeatable)
+    #[arg(long = "header", value_parser = params::parse_header_entry)]
+    pub headers: Vec<params::HeaderEntry>,
+
     /// Select a sub-path from the response (e.g., "data.items")
     #[arg(long = "select")]
     pub select: Option<String>,

--- a/gestalt/cli/src/commands/invoke.rs
+++ b/gestalt/cli/src/commands/invoke.rs
@@ -5,7 +5,7 @@ use crate::catalog::{
     self, CatalogOperation, CatalogParameter, OperationsCatalog, ResolvedOperation,
 };
 use crate::output::{self, Format};
-use crate::params::{self, ParamEntry};
+use crate::params::{self, HeaderEntry, ParamEntry};
 
 use super::app_errors;
 
@@ -13,6 +13,7 @@ use super::app_errors;
 pub struct InvokeOptions<'a> {
     pub connection: Option<&'a str>,
     pub instance: Option<&'a str>,
+    pub headers: &'a [HeaderEntry],
     pub select: Option<&'a str>,
     pub input_file: Option<&'a str>,
 }
@@ -49,6 +50,7 @@ pub fn run(
             .as_ref()
             .map(|selector| selector.instance.as_str())
             .or(options.instance),
+        headers: options.headers,
         select: options.select,
         input_file: options.input_file,
     };
@@ -142,6 +144,7 @@ pub fn invoke(
             .as_ref()
             .map(|selector| selector.instance.as_str())
             .or(options.instance),
+        headers: options.headers,
         select: options.select,
         input_file: options.input_file,
     };
@@ -218,6 +221,7 @@ fn execute(
     .with_timeout(std::time::Duration::from_secs(60));
     let app_client = gestalt_sdk::public::generated::app_client::AppClient::new(transport);
 
+    let headers = params::assemble_headers(options.headers);
     let request = gestalt_sdk::public::generated::app::AppInvokeRequest {
         app: plugin.to_string(),
         operation: operation.to_string(),
@@ -228,6 +232,7 @@ fn execute(
         },
         connection: options.connection.unwrap_or_default().to_string(),
         instance: options.instance.unwrap_or_default().to_string(),
+        headers,
         ..Default::default()
     };
     let resp = app_client

--- a/gestalt/cli/src/main.rs
+++ b/gestalt/cli/src/main.rs
@@ -201,6 +201,7 @@ fn dispatch_app_command(
             params,
             connection,
             instance,
+            headers,
             select,
             input_file,
         }) => commands::invoke::run(
@@ -211,6 +212,7 @@ fn dispatch_app_command(
             commands::invoke::InvokeOptions {
                 connection: connection.as_deref(),
                 instance: instance.as_deref(),
+                headers: &headers,
                 select: select.as_deref(),
                 input_file: input_file.as_deref(),
             },

--- a/gestalt/cli/src/params.rs
+++ b/gestalt/cli/src/params.rs
@@ -16,6 +16,31 @@ pub struct ParamEntry {
     pub value: ParamValue,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HeaderEntry {
+    pub key: String,
+    pub value: String,
+}
+
+pub fn parse_header_entry(s: &str) -> Result<HeaderEntry, String> {
+    let pos = s.find('=').ok_or_else(|| format!("invalid header: no '=' found in '{s}'"))?;
+    let key = &s[..pos];
+    if key.is_empty() {
+        return Err(format!("invalid header: empty key in '{s}'"));
+    }
+    Ok(HeaderEntry {
+        key: key.to_string(),
+        value: s[pos + 1..].to_string(),
+    })
+}
+
+pub fn assemble_headers(entries: &[HeaderEntry]) -> BTreeMap<String, String> {
+    entries
+        .iter()
+        .map(|entry| (entry.key.clone(), entry.value.clone()))
+        .collect()
+}
+
 impl ParamValue {
     fn to_json(&self) -> serde_json::Value {
         match self {
@@ -133,4 +158,42 @@ pub fn merge_params(
         result.insert(k, v);
     }
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_header_entry_accepts_key_value() {
+        let entry = parse_header_entry("X-Tenant-Sid=TEN123").unwrap();
+        assert_eq!(
+            entry,
+            HeaderEntry {
+                key: "X-Tenant-Sid".to_string(),
+                value: "TEN123".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_header_entry_rejects_missing_equals() {
+        assert!(parse_header_entry("X-Tenant-Sid").is_err());
+    }
+
+    #[test]
+    fn assemble_headers_preserves_entries() {
+        let headers = assemble_headers(&[
+            HeaderEntry {
+                key: "X-Tenant-Sid".to_string(),
+                value: "TEN123".to_string(),
+            },
+            HeaderEntry {
+                key: "X-Other".to_string(),
+                value: "value".to_string(),
+            },
+        ]);
+        assert_eq!(headers.get("X-Tenant-Sid"), Some(&"TEN123".to_string()));
+        assert_eq!(headers.get("X-Other"), Some(&"value".to_string()));
+    }
 }

--- a/gestalt/cli/src/params.rs
+++ b/gestalt/cli/src/params.rs
@@ -23,7 +23,9 @@ pub struct HeaderEntry {
 }
 
 pub fn parse_header_entry(s: &str) -> Result<HeaderEntry, String> {
-    let pos = s.find('=').ok_or_else(|| format!("invalid header: no '=' found in '{s}'"))?;
+    let pos = s
+        .find('=')
+        .ok_or_else(|| format!("invalid header: no '=' found in '{s}'"))?;
     let key = &s[..pos];
     if key.is_empty() {
         return Err(format!("invalid header: empty key in '{s}'"));

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gestalt-sdk"
-version = "0.0.1-alpha.25"
+version = "0.0.1-alpha.26"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Add repeatable `--header key=value` flag to `gestalt invoke` / `gestalt app invoke`
- Forward header overrides to `AppInvokeRequest.headers` (e.g. `X-Tenant-Sid` for tenant-scoped Front Porch calls)
- Bump CLI to `v0.0.2-alpha.13` and Rust SDK to `v0.0.1-alpha.26`

## Test plan
- [x] `cargo test` in `gestalt/`
- [ ] After release: `gestalt invoke frontPorch vdsDataExportRuns --connection prod --header X-Tenant-Sid=TEN...`
- [ ] Verify `--instance` still works for credential selection where appropriate


Made with [Cursor](https://cursor.com)