### PR TITLE
Document pending publish visibility for app registry admin

### DIFF
--- a/plans/app_registry/admin.md
+++ b/plans/app_registry/admin.md
@@ -7,6 +7,7 @@ Related docs:
 - [plan.md](./plan.md) — implementation path
 - [lifecycle.md](./lifecycle.md) — HTTP APIs, admission checks, and rollout behavior
 - [indexeddb.md](./indexeddb.md) — `app_rollouts`, `app_instance_materializations`, change-request projections
+- [pending-publish.md](./pending-publish.md) — in-flight publish visibility on app admin
 - [tests.md](./tests.md#admin-observability-tests) — observability HTTP and UI tests; [app version selection tests](./tests.md#app-version-selection-tests)
 
 ---
@@ -111,6 +112,8 @@ Implemented in `gestalt-providers` (default `/apps` UI), not the embedded
 - Legacy published versions without workflow metadata still link the commit and show **not recorded** for workflow/PR fields.
 - Disable the selector while a rollout is `enrolling` or `restarting`; refresh until terminal.
 - Render access denied on **403** without leaking registry metadata.
+- Show in-flight publishes with status **Publishing** while CI is running (planned).
+  See [pending-publish.md](./pending-publish.md).
 
 Selection is fleet-wide. It is not per-user or per-replica.
 

--- a/plans/app_registry/admin.md
+++ b/plans/app_registry/admin.md
@@ -151,6 +151,8 @@ disabled until that rollout reaches `complete` or `failed`.
 
 - Per-replica observed running version (runtime heartbeats)
 - Installing or upgrading from the embedded `/admin` UI
+- Publishing indicator on the embedded `/admin` registry list (app-scoped
+  `/apps/{app}/admin` only; see [pending-publish.md](./pending-publish.md))
 - Canceling or force-completing a rollout from either UI
 - Publishing versions from either UI
 - Granting or editing app authorization relationships

--- a/plans/app_registry/admin.md
+++ b/plans/app_registry/admin.md
@@ -112,9 +112,8 @@ Implemented in `gestalt-providers` (default `/apps` UI), not the embedded
 - Legacy published versions without workflow metadata still link the commit and show **not recorded** for workflow/PR fields.
 - Disable the selector while a rollout is `enrolling` or `restarting`; refresh until terminal.
 - Render access denied on **403** without leaking registry metadata.
-- Show in-flight publishes with status **Publishing** and recent failures with
-  status **Failed** while CI is running or after a failed attempt. See
-  [pending-publish.md](./pending-publish.md).
+- Show in-flight publishes (**Publishing**) and recent failed publishes
+  (**Failed**) in the snapshots table. See [pending-publish.md](./pending-publish.md).
 
 Selection is fleet-wide. It is not per-user or per-replica.
 

--- a/plans/app_registry/admin.md
+++ b/plans/app_registry/admin.md
@@ -111,7 +111,7 @@ Implemented in `gestalt-providers` (default `/apps` UI), not the embedded
 - Show per-version `publishedAt`, linked source commit, triggering PR or commit, and publishing workflow run.
 - Show publish duration on published rows when `publishStartedAt` is recorded (“Published in 4m 32s”).
 - Legacy published versions without workflow metadata still link the commit and show **not recorded** for workflow/PR fields.
-- Disable the selector while a rollout is `enrolling` or `restarting`; refresh until terminal.
+- Disable deploy actions while a rollout is `enrolling` or `restarting`; refresh until terminal.
 - Render access denied on **403** without leaking registry metadata.
 - Show in-flight publishes (**Publishing**) with elapsed time since `startedAt`, and recent failed publishes
   (**Failed**) with total time before failure. See [pending-publish.md](./pending-publish.md).
@@ -120,31 +120,65 @@ Selection is fleet-wide. It is not per-user or per-replica.
 
 ### App admin page
 
-```text
-┌─────────────────────────────────────────────────────────────┐
-│ g-issues                                      App management │
-│ registry: toolshed                                          │
-├─────────────────────────────────────────────────────────────┤
-│ Desired version                                             │
-│ [ 0.0.0-snapshot.gabc123                         ▾ ]         │
-│                                                             │
-│ Published 2026-07-22 15:00 · linux/amd64                    │
-│ Commit def456 · PR #3251 · workflow run                     │
-│                                                             │
-│                                      [ Select version ]      │
-└─────────────────────────────────────────────────────────────┘
-```
-
-During an active rollout:
+The page header shows the app name, **App management** label, and registry
+binding. Below that: current **Desired version**, then the **Published
+snapshots** table (pending, failed, and published entries in one newest-first
+list). Each row has **Deploy** in the action column unless selection is disabled
+or the row is not deployable.
 
 ```text
-│ Rollout enrolling: 0.0.0-snapshot.gdef456                  │
-│ [ 0.0.0-snapshot.gabc123                         ▾ ] disabled│
-│                                      [ Select version ] disabled
++-------------------------------------------------------------+
+| g-issues                               App management       |
+| registry: toolshed                                          |
++-------------------------------------------------------------+
+| Desired version: 0.0.0-snapshot.gabc123                     |
++-------------------------------------------------------------+
+| Published snapshots                                         |
+|                                                             |
+| Version                 Status       Timing       Action    |
+| ---------------------   ----------   -----------   -------- |
+| 0.0.0-snapshot.gnew     Publishing   for 4m       —         |
+|                         PR #3740 · workflow                 |
+| 0.0.0-snapshot.gdef456  Available    Jul 22 15:00  Deploy   |
+|                         in 4m 32s · PR #3251                |
+| 0.0.0-snapshot.gabc123  Deployed     Jul 21 12:00  —         |
+|                         PR #3200                              |
++-------------------------------------------------------------+
 ```
 
-After a successful selection, show the new rollout state and keep the selector
-disabled until that rollout reaches `complete` or `failed`.
+**Publishing** rows show elapsed time and provenance; **Deploy** is disabled.
+**Available** published rows show `publishedAt` and publish duration when
+`publishStartedAt` is recorded. **Deployed** marks the desired version.
+
+During an active rollout, disable deploy actions and show rollout state above the
+table:
+
+```text
++-------------------------------------------------------------+
+| g-issues                               App management       |
+| registry: toolshed                                          |
++-------------------------------------------------------------+
+| Desired version: 0.0.0-snapshot.gabc123                     |
+| Rollout enrolling: 0.0.0-snapshot.gdef456                   |
++-------------------------------------------------------------+
+| Published snapshots                                         |
+|                                                             |
+| Version                 Status       Timing       Action    |
+| ---------------------   ----------   -----------   -------- |
+| 0.0.0-snapshot.gdef456  Rolling out  Jul 22 15:00  disabled |
+| 0.0.0-snapshot.gabc123  Deployed     Jul 21 12:00  disabled |
++-------------------------------------------------------------+
+```
+
+A **Failed** row in the same table:
+
+```text
+| 0.0.0-snapshot.gdead    Failed       Jul 24 18:35   —         |
+|                         after 35m · Timed out · workflow    |
+```
+
+After a successful deploy selection, keep deploy actions disabled until the
+rollout reaches `complete` or `failed`.
 
 ---
 

--- a/plans/app_registry/admin.md
+++ b/plans/app_registry/admin.md
@@ -151,8 +151,6 @@ disabled until that rollout reaches `complete` or `failed`.
 
 - Per-replica observed running version (runtime heartbeats)
 - Installing or upgrading from the embedded `/admin` UI
-- Publishing indicator on the embedded `/admin` registry list (app-scoped
-  `/apps/{app}/admin` only; see [pending-publish.md](./pending-publish.md))
 - Canceling or force-completing a rollout from either UI
 - Publishing versions from either UI
 - Granting or editing app authorization relationships

--- a/plans/app_registry/admin.md
+++ b/plans/app_registry/admin.md
@@ -112,8 +112,9 @@ Implemented in `gestalt-providers` (default `/apps` UI), not the embedded
 - Legacy published versions without workflow metadata still link the commit and show **not recorded** for workflow/PR fields.
 - Disable the selector while a rollout is `enrolling` or `restarting`; refresh until terminal.
 - Render access denied on **403** without leaking registry metadata.
-- Show in-flight publishes with status **Publishing** while CI is running (planned).
-  See [pending-publish.md](./pending-publish.md).
+- Show in-flight publishes with status **Publishing** and recent failures with
+  status **Failed** while CI is running or after a failed attempt. See
+  [pending-publish.md](./pending-publish.md).
 
 Selection is fleet-wide. It is not per-user or per-replica.
 

--- a/plans/app_registry/admin.md
+++ b/plans/app_registry/admin.md
@@ -121,8 +121,11 @@ Selection is fleet-wide. It is not per-user or per-replica.
 The page header shows the app name, **App management** label, and registry
 binding. Below that: current **Desired version**, then the **Published
 snapshots** table (pending, failed, and published entries in one newest-first
-list). Each row has **Deploy** in the action column unless selection is disabled
-or the row is not deployable.
+list). When the same version appears in more than one catalog, apply
+**published** > **pending** > **failed** precedence — see
+[pending-publish.md — Merge rules](./pending-publish.md#app-admin-api). Each row
+has **Deploy** in the action column unless selection is disabled or the row is
+not deployable.
 
 ```text
 ┌─────────────────────────────────────────────────────────────┐

--- a/plans/app_registry/admin.md
+++ b/plans/app_registry/admin.md
@@ -109,11 +109,12 @@ Implemented in `gestalt-providers` (default `/apps` UI), not the embedded
 - **Manage app** on the `/apps` catalog when the caller can administer that app.
 - Select the fleet-wide desired version: first install, upgrade, or revert to an older published version.
 - Show per-version `publishedAt`, linked source commit, triggering PR or commit, and publishing workflow run.
+- Show publish duration on published rows when `publishStartedAt` is recorded (“Published in 4m 32s”).
 - Legacy published versions without workflow metadata still link the commit and show **not recorded** for workflow/PR fields.
 - Disable the selector while a rollout is `enrolling` or `restarting`; refresh until terminal.
 - Render access denied on **403** without leaking registry metadata.
-- Show in-flight publishes (**Publishing**) and recent failed publishes
-  (**Failed**) in the snapshots table. See [pending-publish.md](./pending-publish.md).
+- Show in-flight publishes (**Publishing**) with elapsed time since `startedAt`, and recent failed publishes
+  (**Failed**) with total time before failure. See [pending-publish.md](./pending-publish.md).
 
 Selection is fleet-wide. It is not per-user or per-replica.
 

--- a/plans/app_registry/admin.md
+++ b/plans/app_registry/admin.md
@@ -121,11 +121,9 @@ Selection is fleet-wide. It is not per-user or per-replica.
 The page header shows the app name, **App management** label, and registry
 binding. Below that: current **Desired version**, then the **Published
 snapshots** table (pending, failed, and published entries in one newest-first
-list). When the same version appears in more than one catalog, apply
-**published** > **pending** > **failed** precedence — see
-[pending-publish.md — Merge rules](./pending-publish.md#app-admin-api). Each row
-has **Deploy** in the action column unless selection is disabled or the row is
-not deployable.
+list). See [pending-publish.md](./pending-publish.md) for merge rules, polling,
+and timing labels. Each row has **Deploy** in the action column unless selection
+is disabled or the row is not deployable.
 
 ```text
 ┌─────────────────────────────────────────────────────────────┐

--- a/plans/app_registry/admin.md
+++ b/plans/app_registry/admin.md
@@ -109,12 +109,10 @@ Implemented in `gestalt-providers` (default `/apps` UI), not the embedded
 - **Manage app** on the `/apps` catalog when the caller can administer that app.
 - Select the fleet-wide desired version: first install, upgrade, or revert to an older published version.
 - Show per-version `publishedAt`, linked source commit, triggering PR or commit, and publishing workflow run.
-- Show publish duration on published rows when `publishStartedAt` is recorded (“Published in 4m 32s”).
+- Show in-flight (**Publishing**) and recent failed (**Failed**) publishes with elapsed or total publish time. See [pending-publish.md](./pending-publish.md).
 - Legacy published versions without workflow metadata still link the commit and show **not recorded** for workflow/PR fields.
 - Disable deploy actions while a rollout is `enrolling` or `restarting`; refresh until terminal.
 - Render access denied on **403** without leaking registry metadata.
-- Show in-flight publishes (**Publishing**) with elapsed time since `startedAt`, and recent failed publishes
-  (**Failed**) with total time before failure. See [pending-publish.md](./pending-publish.md).
 
 Selection is fleet-wide. It is not per-user or per-replica.
 
@@ -127,54 +125,50 @@ list). Each row has **Deploy** in the action column unless selection is disabled
 or the row is not deployable.
 
 ```text
-+-------------------------------------------------------------+
-| g-issues                               App management       |
-| registry: toolshed                                          |
-+-------------------------------------------------------------+
-| Desired version: 0.0.0-snapshot.gabc123                     |
-+-------------------------------------------------------------+
-| Published snapshots                                         |
-|                                                             |
-| Version                 Status       Timing       Action    |
-| ---------------------   ----------   -----------   -------- |
-| 0.0.0-snapshot.gnew     Publishing   for 4m       —         |
-|                         PR #3740 · workflow                 |
-| 0.0.0-snapshot.gdef456  Available    Jul 22 15:00  Deploy   |
-|                         in 4m 32s · PR #3251                |
-| 0.0.0-snapshot.gabc123  Deployed     Jul 21 12:00  —         |
-|                         PR #3200                              |
-+-------------------------------------------------------------+
+┌─────────────────────────────────────────────────────────────┐
+│ g-issues                               App management       │
+│ registry: toolshed                                          │
+├─────────────────────────────────────────────────────────────┤
+│ Desired version: 0.0.0-snapshot.gabc123                     │
+├─────────────────────────────────────────────────────────────┤
+│ Published snapshots                                         │
+│                                                             │
+│ Version                 Status       Published    Action    │
+│ 0.0.0-snapshot.g…       Publishing   for 4m       —         │
+│                                      PR #3740 · workflow    │
+│ 0.0.0-snapshot.g…       Available    Jul 22 15:00 Deploy    │
+│                                      in 4m 32s · PR #3251   │
+│ 0.0.0-snapshot.g…       Deployed     Jul 21 12:00 —         │
+│                                      PR #3200               │
+└─────────────────────────────────────────────────────────────┘
 ```
 
-**Publishing** rows show elapsed time and provenance; **Deploy** is disabled.
-**Available** published rows show `publishedAt` and publish duration when
-`publishStartedAt` is recorded. **Deployed** marks the desired version.
+Row timing labels: [pending-publish.md — Publish duration](./pending-publish.md#publish-duration). **Deploy** is disabled on **Publishing** and **Failed** rows. **Deployed** marks the desired version.
 
 During an active rollout, disable deploy actions and show rollout state above the
 table:
 
 ```text
-+-------------------------------------------------------------+
-| g-issues                               App management       |
-| registry: toolshed                                          |
-+-------------------------------------------------------------+
-| Desired version: 0.0.0-snapshot.gabc123                     |
-| Rollout enrolling: 0.0.0-snapshot.gdef456                   |
-+-------------------------------------------------------------+
-| Published snapshots                                         |
-|                                                             |
-| Version                 Status       Timing       Action    |
-| ---------------------   ----------   -----------   -------- |
-| 0.0.0-snapshot.gdef456  Rolling out  Jul 22 15:00  disabled |
-| 0.0.0-snapshot.gabc123  Deployed     Jul 21 12:00  disabled |
-+-------------------------------------------------------------+
+┌─────────────────────────────────────────────────────────────┐
+│ g-issues                               App management       │
+│ registry: toolshed                                          │
+├─────────────────────────────────────────────────────────────┤
+│ Desired version: 0.0.0-snapshot.gabc123                     │
+│ Rollout enrolling: 0.0.0-snapshot.gdef456                   │
+├─────────────────────────────────────────────────────────────┤
+│ Published snapshots                                         │
+│                                                             │
+│ Version                 Status       Published    Action    │
+│ 0.0.0-snapshot.g…       Rolling out  Jul 22 15:00 disabled  │
+│ 0.0.0-snapshot.g…       Deployed     Jul 21 12:00 disabled  │
+└─────────────────────────────────────────────────────────────┘
 ```
 
 A **Failed** row in the same table:
 
 ```text
-| 0.0.0-snapshot.gdead    Failed       Jul 24 18:35   —         |
-|                         after 35m · Timed out · workflow    |
+│ 0.0.0-snapshot.g…       Failed       Jul 24 18:35 —         │
+│                                      after 35m · Timed out  │
 ```
 
 After a successful deploy selection, keep deploy actions disabled until the

--- a/plans/app_registry/config.md
+++ b/plans/app_registry/config.md
@@ -3,7 +3,7 @@
 Reference for app registry configuration in `gestaltd.yaml` / `config.yaml` from [gestalt#2709](https://github.com/valon-technologies/gestalt/pull/2709) commit 2.
 
 - **`appRegistries`** in deploy config — where `gestaltd` reads app metadata and artifacts at deploy/runtime
-- **`gestaltd app publish`** — takes `--bucket` on the CLI; no publisher config block
+- **`gestaltd app registry publish`** — takes `--bucket` on the CLI; no publisher config block. Replaces `gestaltd app publish`.
 
 This does **not** change the app author's `manifest.yaml`.
 
@@ -46,7 +46,7 @@ appRegistries:
 CI publishes with CLI flags only:
 
 ```bash
-gestaltd app publish \
+gestaltd app registry publish \
   --bucket gs://gestalt-app-registry \
   --app g-issues \
   --version 0.0.1 \
@@ -57,7 +57,7 @@ gestaltd app publish \
 - `--app` — app name; manifest must live at `apps/{app}/manifest.yaml` under the git root
 - `--bucket` — GCS bucket name or `gs://` URL for uploads; identifies the target registry for now
 
-Immutability is enforced by `gestaltd app publish` (create-only uploads, no silent overwrites) — not by config.
+Immutability is enforced by `gestaltd app registry publish` (create-only uploads, no silent overwrites) — not by config.
 
 Upload layout:
 
@@ -79,7 +79,7 @@ gestaltd provider package \
   --platform linux/amd64,darwin/arm64 \
   --output dist/
 
-gestaltd app publish \
+gestaltd app registry publish \
   --bucket gs://gestalt-app-registry \
   --app g-issues \
   --version "0.0.0-snapshot.g${COMMIT_SHA}" \
@@ -103,7 +103,7 @@ gestaltd provider package \
   --output dist/
 ```
 
-`gestaltd app publish` would then read `sourceRef` from the release archives and drop `--ref`. That binds version to commit at build time and removes the chance of a mismatched ref at upload.
+`gestaltd app registry publish` would then read `sourceRef` from the release archives and drop `--ref`. That binds version to commit at build time and removes the chance of a mismatched ref at upload.
 
 ---
 

--- a/plans/app_registry/lifecycle.md
+++ b/plans/app_registry/lifecycle.md
@@ -688,6 +688,12 @@ Rules:
 - `publishedVersions` comes from the registry index, newest `publishedAt` first.
   Each entry includes `publishedAt`, `sourceRef`, `sourceUrl`, and `publication`
   when recorded. Legacy versions may omit `publication`.
+- `pendingVersions` and `failedVersions` come from `pending.json` and
+  `failed.json`. See [pending-publish.md](./pending-publish.md#read-path).
+- When the same version appears in more than one catalog (race or missed cleanup),
+  apply merge precedence **published** > **pending** > **failed** before
+  returning the response. See
+  [pending-publish.md — Merge rules](./pending-publish.md#app-admin-api).
 - `selectionDisabled` is true only while rollout state is `enrolling` or
   `restarting`.
 

--- a/plans/app_registry/lifecycle.md
+++ b/plans/app_registry/lifecycle.md
@@ -277,7 +277,7 @@ Fetches `apps/{app}/index.json` from the configured registry's `publicUrl` and r
 | Parameter | Description |
 |-----------|-------------|
 | `registry` | Name of a configured registry (`appRegistries` key) |
-| `app` | Published app name (same rules as `gestaltd app publish --app`) |
+| `app` | Published app name (same rules as `gestaltd app registry publish --app`) |
 
 App names must match `providerregistry.ValidateRepositoryName`: lowercase letters, digits, dots, underscores, and hyphens only. Invalid names (including path traversal such as `..`) return `400`.
 

--- a/plans/app_registry/lifecycle.md
+++ b/plans/app_registry/lifecycle.md
@@ -690,10 +690,8 @@ Rules:
   when recorded. Legacy versions may omit `publication`.
 - `pendingVersions` and `failedVersions` come from `pending.json` and
   `failed.json`. See [pending-publish.md](./pending-publish.md#read-path).
-- When the same version appears in more than one catalog (race or missed cleanup),
-  apply merge precedence **published** > **pending** > **failed** before
-  returning the response. See
-  [pending-publish.md — Merge rules](./pending-publish.md#app-admin-api).
+- When the same version appears in more than one catalog, apply
+  [merge rules](./pending-publish.md#app-admin-api).
 - `selectionDisabled` is true only while rollout state is `enrolling` or
   `restarting`.
 

--- a/plans/app_registry/models.md
+++ b/plans/app_registry/models.md
@@ -281,7 +281,7 @@ Each key is a version string whose publish attempt failed.
 | `repository` | string | no | Source repository. Same format as `IndexVersion.repository`. |
 | `startedAt` | RFC 3339 timestamp | yes | When the pending record was created (copied from pending). |
 | `failedAt` | RFC 3339 timestamp | yes | When the failure was recorded (UTC). |
-| `reason` | string | yes | `workflow_failed` — CI called `pending fail`. `stale` — pending `updatedAt` exceeded 30 minutes during `PrunePendingIndex`. |
+| `reason` | string | yes | `workflow_failed` — CI called `pending fail`. `stale` — pending `startedAt` exceeded 2 hours during `PrunePendingIndex`. |
 | `publication` | object | no | Same `Publication` shape as `PublishedVersion.publication`. Copied from the pending row when present. |
 
 Writes use the same optimistic-concurrency pattern as `pending.json`.

--- a/plans/app_registry/models.md
+++ b/plans/app_registry/models.md
@@ -128,8 +128,10 @@ Each key in `versions` is a published version string (e.g. 0.0.0-snapshot.gabc12
 Answers: *which versions are currently being published for this app, and what
 provenance is known so far?*
 
-Mutable catalog updated by CI at publish start and cleared on success or failure.
-Pending versions are **not** installable. See [pending-publish.md](./pending-publish.md).
+Mutable catalog updated by CI at publish start. Removed on successful publish via
+`gestaltd app registry pending clear`, or recorded in `failed.json` via
+`gestaltd app registry pending fail` or stale prune. Pending versions are **not**
+installable. See [pending-publish.md](./pending-publish.md).
 
 ```json
 {
@@ -200,11 +202,9 @@ Each key in `pending` is a version string being published (e.g.
 | `publication` | object | no | Same `Publication` shape as `PublishedVersion.publication`. Written at pending start so the UI can link the workflow run immediately. |
 
 Writes use the same optimistic-concurrency pattern as `index.json` (read GCS
-generation, merge, upload with `if-generation-match`). The first `gestaltd app registry pending set` reconciles stuck pending entries
-and prunes old failed rows before writing (`updatedAt` older than 30 minutes →
-`failed.json` with `reason=stale`, version already in `index.json` → drop from
-pending only, failed entries older than 30 days → drop). See
-[pending-publish.md](./pending-publish.md#self-healing).
+generation, merge, upload with `if-generation-match`). `gestaltd app registry
+pending set` runs `PrunePendingIndex` and `PruneFailedIndex` before upserting.
+See [pending-publish.md](./pending-publish.md#self-healing).
 
 ---
 
@@ -214,9 +214,9 @@ pending only, failed entries older than 30 days → drop). See
 
 Answers: *which recent publish attempts failed for this app, and when?*
 
-Mutable catalog updated when a publish fails in CI or when a pending row goes
-stale. Failed versions are **not** installable. See
-[pending-publish.md](./pending-publish.md).
+Mutable catalog updated when CI calls `gestaltd app registry pending fail` or
+when `PrunePendingIndex` moves a stale pending entry. Failed versions are **not**
+installable. See [pending-publish.md](./pending-publish.md).
 
 ```json
 {
@@ -281,9 +281,10 @@ Each key is a version string whose publish attempt failed.
 | `reason` | string | yes | `workflow_failed` — CI called `pending fail`. `stale` — pending `updatedAt` exceeded 30 minutes during `PrunePendingIndex`. |
 | `publication` | object | no | Same `Publication` shape as `PublishedVersion.publication`. Copied from the pending row when present. |
 
-Writes use the same optimistic-concurrency pattern as `pending.json`. Entries
-older than **30 days** are removed on `gestaltd app registry pending set` via
-`PruneFailedIndex`.
+Writes use the same optimistic-concurrency pattern as `pending.json`.
+`PruneFailedIndex` removes entries older than 30 days on
+`gestaltd app registry pending set`. See
+[pending-publish.md](./pending-publish.md#prunefailedindex).
 
 ---
 

--- a/plans/app_registry/models.md
+++ b/plans/app_registry/models.md
@@ -52,6 +52,7 @@ Answers: *what versions exist, where is their metadata, which platforms were pub
           "metadata": "apps/g-issues/versions/0.0.0-snapshot.gabc123.json",
           "platforms": ["linux/amd64"],
           "publishedAt": "2026-07-09T12:00:00Z",
+          "publishStartedAt": "2026-07-09T11:55:28Z",
           "sourceRef": "abc123def456abc123def456abc123def456abcd",
           "repository": "github.com/valon-technologies/valon-tools",
           "publication": {
@@ -81,6 +82,7 @@ Nested objects are keyed by maps in JSON. Arrows show the Go type at each level 
             ├── metadata
             ├── platforms
             ├── publishedAt
+            ├── publishStartedAt
             ├── sourceRef
             ├── repository
             └── publication
@@ -115,6 +117,7 @@ Each key in `versions` is a published version string (e.g. 0.0.0-snapshot.gabc12
 | `metadata` | string | yes | Relative path to the full published version JSON, e.g. `apps/g-issues/versions/0.0.1.json`. |
 | `platforms` | string array | no | Build targets available for this version (see example JSON). Derived from published version artifact keys at publish time. |
 | `publishedAt` | RFC 3339 timestamp | yes | When this version was published (UTC). |
+| `publishStartedAt` | RFC 3339 timestamp | no | When the publish workflow recorded the version as pending (copied from `PendingVersion.startedAt` at upload time). Omitted on legacy publishes and when `pending set` was not called. Used with `publishedAt` to show total publish duration. |
 | `sourceRef` | string | no | Packaged commit SHA. Copied from `PublishedVersion.sourceRef`. |
 | `repository` | string | no | Source repository. Copied from `PublishedVersion.repository`. |
 | `publication` | object | no | Publish workflow provenance. Copied from `PublishedVersion.publication`. |
@@ -339,7 +342,8 @@ Answers: *what exactly is this version — artifacts, operations, dependencies, 
   "compatibility": {
     "minGestaltdVersion": "0.20.0"
   },
-  "publishedAt": "2026-07-09T12:00:00Z"
+  "publishedAt": "2026-07-09T12:00:00Z",
+  "publishStartedAt": "2026-07-09T11:55:28Z"
 }
 ```
 
@@ -353,6 +357,7 @@ Answers: *what exactly is this version — artifacts, operations, dependencies, 
     ├── manifestPath
     ├── repository
     ├── publishedAt
+    ├── publishStartedAt
     ├── publication
     │   ├── workflowRunUrl
     │   ├── triggerPullRequest
@@ -395,6 +400,7 @@ Answers: *what exactly is this version — artifacts, operations, dependencies, 
 | `requires` | object | no | Declared dependencies on other apps. Copied from the provider release `staticValidation.requires` block at publish time. |
 | `compatibility` | object | no | Runtime constraints, e.g. minimum `gestaltd` version. Copied from the provider release `staticValidation.compatibility` block at publish time. |
 | `publishedAt` | RFC 3339 timestamp | yes | When this version was published (UTC). |
+| `publishStartedAt` | RFC 3339 timestamp | no | When the publish workflow recorded the version as pending. Copied from `PendingVersion.startedAt` when `pending.json` contains this version at upload time. Omitted on legacy publishes. |
 
 #### `PublishedVersion.publication` · `Publication`
 

--- a/plans/app_registry/models.md
+++ b/plans/app_registry/models.md
@@ -139,7 +139,7 @@ Pending versions are **not** installable. See [pending-publish.md](./pending-pub
       "repository": "github.com/valon-technologies/toolshed",
       "startedAt": "2026-07-24T19:00:00Z",
       "updatedAt": "2026-07-24T19:04:12Z",
-      "phase": "packaging",
+      "phase": "publishing",
       "publication": {
         "workflowRunUrl": "https://github.com/valon-technologies/toolshed/actions/runs/123456789",
         "triggerPullRequest": {
@@ -193,12 +193,13 @@ Each key in `pending` is a version string being published (e.g.
 | `repository` | string | no | Source repository. Same format as `IndexVersion.repository`. |
 | `startedAt` | RFC 3339 timestamp | yes | When the pending record was created (UTC). |
 | `updatedAt` | RFC 3339 timestamp | yes | Last phase or metadata update (UTC). |
-| `phase` | string | yes | `packaging` or `publishing`. See [pending-publish.md](./pending-publish.md#phases). |
+| `phase` | string | yes | Always `publishing` while the version is pending. See [pending-publish.md](./pending-publish.md#phases). |
 | `publication` | object | no | Same `Publication` shape as `PublishedVersion.publication`. Written at pending start so the UI can link the workflow run immediately. |
 
 Writes use the same optimistic-concurrency pattern as `index.json` (read GCS
 generation, merge, upload with `if-generation-match`). The first
-`gestaltd app registry publish --pending` call removes stuck entries before writing
+`gestaltd app registry publish --pending publishing` call removes stuck entries
+before writing
 (`updatedAt` older than 30 minutes, or version already in `index.json`). See
 [pending-publish.md](./pending-publish.md#self-healing).
 

--- a/plans/app_registry/models.md
+++ b/plans/app_registry/models.md
@@ -6,13 +6,15 @@ For deploy reader config (`appRegistries`), see [config.md](./config.md). For br
 
 ## Overview
 
-The registry stores published release JSON plus a mutable pending catalog per app.
+The registry stores published release JSON plus mutable pending and failed
+catalogs per app.
 
 Immutable app archives live alongside published versions:
 
     apps/{app}/
     ├── index.json
     ├── pending.json
+    ├── failed.json
     ├── versions/
     │   └── {version}.json
     └── artifacts/
@@ -23,6 +25,7 @@ Immutable app archives live alongside published versions:
 |----------|------|---------|
 | **Index** | `apps/{app}/index.json` | Lightweight catalog of published versions |
 | **PendingIndex** | `apps/{app}/pending.json` | In-flight publishes (not installable). See [pending-publish.md](./pending-publish.md). |
+| **FailedIndex** | `apps/{app}/failed.json` | Recent failed publishes (not installable). See [pending-publish.md](./pending-publish.md). |
 | **PublishedVersion** | `apps/{app}/versions/{version}.json` | Full metadata and install contract for one version |
 
 Document type is implied by path. Each JSON document has a root `schemaVersion` field (currently `1` for index, pending index, and published version). Readers should reject unsupported values; bump it when the JSON shape changes incompatibly.
@@ -197,10 +200,90 @@ Each key in `pending` is a version string being published (e.g.
 | `publication` | object | no | Same `Publication` shape as `PublishedVersion.publication`. Written at pending start so the UI can link the workflow run immediately. |
 
 Writes use the same optimistic-concurrency pattern as `index.json` (read GCS
-generation, merge, upload with `if-generation-match`). The first
-`gestaltd app registry pending set` removes stuck entries before writing
-(`updatedAt` older than 30 minutes, or version already in `index.json`). See
+generation, merge, upload with `if-generation-match`). The first `gestaltd app registry pending set` reconciles stuck pending entries
+and prunes old failed rows before writing (`updatedAt` older than 30 minutes →
+`failed.json` with `reason=stale`, version already in `index.json` → drop from
+pending only, failed entries older than 30 days → drop). See
 [pending-publish.md](./pending-publish.md#self-healing).
+
+---
+
+## FailedIndex
+
+**Path:** `apps/{app}/failed.json`
+
+Answers: *which recent publish attempts failed for this app, and when?*
+
+Mutable catalog updated when a publish fails in CI or when a pending row goes
+stale. Failed versions are **not** installable. See
+[pending-publish.md](./pending-publish.md).
+
+```json
+{
+  "schemaVersion": 1,
+  "app": "traffic-cop",
+  "failed": {
+    "0.0.0-snapshot.gabc123def456abc123def456abc123def456abcd": {
+      "version": "0.0.0-snapshot.gabc123def456abc123def456abc123def456abcd",
+      "sourceRef": "abc123def456abc123def456abc123def456abcd",
+      "repository": "github.com/valon-technologies/toolshed",
+      "startedAt": "2026-07-24T19:00:00Z",
+      "failedAt": "2026-07-24T19:35:00Z",
+      "reason": "stale",
+      "publication": {
+        "workflowRunUrl": "https://github.com/valon-technologies/toolshed/actions/runs/123456789",
+        "triggerPullRequest": {
+          "number": 3740,
+          "url": "https://github.com/valon-technologies/toolshed/pull/3740",
+          "title": "Wire traffic-cop to app registry"
+        }
+      }
+    }
+  }
+}
+```
+
+### Object hierarchy
+
+    FailedIndex
+    ├── schemaVersion
+    ├── app
+    └── failed: map[version] to FailedVersion
+        ├── version
+        ├── sourceRef
+        ├── repository
+        ├── startedAt
+        ├── failedAt
+        ├── reason
+        └── publication
+
+### Fields
+
+#### Root · `FailedIndex`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `schemaVersion` | int | yes | Failed index document format version. Start at `1`. |
+| `app` | string | yes | App name. Must match the `{app}` path segment. |
+| `failed` | map | yes | Version string → `FailedVersion`. Empty map when there are no recent failures. |
+
+#### `FailedIndex.failed` · `FailedVersion`
+
+Each key is a version string whose publish attempt failed.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `version` | string | yes | Snapshot version that failed to publish. |
+| `sourceRef` | string | yes | Commit SHA the publish was building from. |
+| `repository` | string | no | Source repository. Same format as `IndexVersion.repository`. |
+| `startedAt` | RFC 3339 timestamp | yes | When the pending record was created (copied from pending). |
+| `failedAt` | RFC 3339 timestamp | yes | When the failure was recorded (UTC). |
+| `reason` | string | yes | `workflow_failed` — CI called `pending fail`. `stale` — pending `updatedAt` exceeded 30 minutes during `PrunePendingIndex`. |
+| `publication` | object | no | Same `Publication` shape as `PublishedVersion.publication`. Copied from the pending row when present. |
+
+Writes use the same optimistic-concurrency pattern as `pending.json`. Entries
+older than **30 days** are removed on `gestaltd app registry pending set` via
+`PruneFailedIndex`.
 
 ---
 

--- a/plans/app_registry/models.md
+++ b/plans/app_registry/models.md
@@ -25,7 +25,7 @@ Immutable app archives live alongside published versions:
 | **PendingIndex** | `apps/{app}/pending.json` | In-flight publishes (not installable). See [pending-publish.md](./pending-publish.md). |
 | **PublishedVersion** | `apps/{app}/versions/{version}.json` | Full metadata and install contract for one version |
 
-Document type is implied by path. Each JSON document has a root `schemaVersion` field (currently `1` for both index and published version). Readers should reject unsupported values; bump it when the JSON shape changes incompatibly.
+Document type is implied by path. Each JSON document has a root `schemaVersion` field (currently `1` for index, pending index, and published version). Readers should reject unsupported values; bump it when the JSON shape changes incompatibly.
 
 Implementation: `gestaltd/internal/appregistry/`.
 
@@ -115,6 +115,130 @@ Each key in `versions` is a published version string (e.g. 0.0.0-snapshot.gabc12
 | `sourceRef` | string | no | Packaged commit SHA. Copied from `PublishedVersion.sourceRef`. |
 | `repository` | string | no | Source repository. Copied from `PublishedVersion.repository`. |
 | `publication` | object | no | Publish workflow provenance. Copied from `PublishedVersion.publication`. |
+
+---
+
+## PendingIndex
+
+**Path:** `apps/{app}/pending.json`
+
+Answers: *which versions are currently being published for this app, and what
+provenance is known so far?*
+
+Mutable catalog updated by CI at publish start and cleared on success or failure.
+Pending versions are **not** installable. See [pending-publish.md](./pending-publish.md).
+
+`pending.json` is **not** the same shape as `index.json`. Both are version-keyed
+catalogs with shared provenance fields (`sourceRef`, `repository`, `publication`),
+but the root structure and per-version fields differ:
+
+| | `index.json` | `pending.json` |
+|---|--------------|----------------|
+| Root | `apps` map (multi-app) | `app` string + `pending` map |
+| Per-version key fields | `metadata`, `platforms`, `publishedAt` | `startedAt`, `updatedAt`, `phase` |
+| Meaning | Completed publish | In-flight publish |
+
+```json
+{
+  "schemaVersion": 1,
+  "app": "traffic-cop",
+  "pending": {
+    "0.0.0-snapshot.gabc123def456abc123def456abc123def456abcd": {
+      "version": "0.0.0-snapshot.gabc123def456abc123def456abc123def456abcd",
+      "sourceRef": "abc123def456abc123def456abc123def456abcd",
+      "repository": "github.com/valon-technologies/toolshed",
+      "startedAt": "2026-07-24T19:00:00Z",
+      "updatedAt": "2026-07-24T19:04:12Z",
+      "phase": "packaging",
+      "publication": {
+        "workflowRunUrl": "https://github.com/valon-technologies/toolshed/actions/runs/123456789",
+        "triggerPullRequest": {
+          "number": 3740,
+          "url": "https://github.com/valon-technologies/toolshed/pull/3740",
+          "title": "Wire traffic-cop to app registry"
+        }
+      }
+    }
+  }
+}
+```
+
+For comparison, the same app’s `index.json` entry for a **completed** publish
+looks like this (note `apps` nesting and `publishedAt` / `metadata` instead of
+`phase` / `startedAt`):
+
+```json
+{
+  "schemaVersion": 1,
+  "apps": {
+    "traffic-cop": {
+      "displayName": "traffic-cop",
+      "versions": {
+        "0.0.0-snapshot.gabc123def456abc123def456abc123def456abcd": {
+          "metadata": "apps/traffic-cop/versions/0.0.0-snapshot.gabc123def456abc123def456abc123def456abcd.json",
+          "platforms": ["linux/amd64", "darwin/arm64"],
+          "publishedAt": "2026-07-24T19:15:00Z",
+          "sourceRef": "abc123def456abc123def456abc123def456abcd",
+          "repository": "github.com/valon-technologies/toolshed",
+          "publication": {
+            "workflowRunUrl": "https://github.com/valon-technologies/toolshed/actions/runs/123456789",
+            "triggerPullRequest": {
+              "number": 3740,
+              "url": "https://github.com/valon-technologies/toolshed/pull/3740"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Object hierarchy
+
+    PendingIndex
+    ├── schemaVersion
+    ├── app
+    └── pending: map[version] to PendingVersion
+        ├── version
+        ├── sourceRef
+        ├── repository
+        ├── startedAt
+        ├── updatedAt
+        ├── phase
+        └── publication
+
+Unlike `Index`, `PendingIndex` does not use an `apps` map — the app name is
+implied by the path (`apps/traffic-cop/pending.json`).
+
+### Fields
+
+#### Root · `PendingIndex`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `schemaVersion` | int | yes | Pending index document format version. Start at `1`. |
+| `app` | string | yes | App name. Must match the `{app}` path segment. |
+| `pending` | map | yes | Version string → `PendingVersion`. Empty map when no publishes are in flight. |
+
+#### `PendingIndex.pending` · `PendingVersion`
+
+Each key in `pending` is a version string being published (e.g.
+`0.0.0-snapshot.gabc123`). The value is a `PendingVersion` summary.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `version` | string | yes | Snapshot version being published. Same semver rules as published versions. |
+| `sourceRef` | string | yes | Commit SHA the publish is building from. |
+| `repository` | string | no | Source repository. Same format as `IndexVersion.repository`. |
+| `startedAt` | RFC 3339 timestamp | yes | When the pending record was created (UTC). |
+| `updatedAt` | RFC 3339 timestamp | yes | Last phase or metadata update (UTC). |
+| `phase` | string | yes | `packaging` or `publishing`. See [pending-publish.md](./pending-publish.md#phases). |
+| `publication` | object | no | Same `Publication` shape as `PublishedVersion.publication`. Written at pending start so the UI can link the workflow run immediately. |
+
+Writes use the same optimistic-concurrency pattern as `index.json` (read GCS
+generation, merge, upload with `if-generation-match`). See
+[pending-publish.md](./pending-publish.md).
 
 ---
 

--- a/plans/app_registry/models.md
+++ b/plans/app_registry/models.md
@@ -197,9 +197,10 @@ Each key in `pending` is a version string being published (e.g.
 | `publication` | object | no | Same `Publication` shape as `PublishedVersion.publication`. Written at pending start so the UI can link the workflow run immediately. |
 
 Writes use the same optimistic-concurrency pattern as `index.json` (read GCS
-generation, merge, upload with `if-generation-match`). `pending begin` removes
-stuck entries before writing (`updatedAt` older than 30 minutes, or version
-already in `index.json`). See [pending-publish.md](./pending-publish.md#self-healing).
+generation, merge, upload with `if-generation-match`). The first
+`gestaltd app publish --pending` call removes stuck entries before writing
+(`updatedAt` older than 30 minutes, or version already in `index.json`). See
+[pending-publish.md](./pending-publish.md#self-healing).
 
 ---
 

--- a/plans/app_registry/models.md
+++ b/plans/app_registry/models.md
@@ -197,10 +197,9 @@ Each key in `pending` is a version string being published (e.g.
 | `publication` | object | no | Same `Publication` shape as `PublishedVersion.publication`. Written at pending start so the UI can link the workflow run immediately. |
 
 Writes use the same optimistic-concurrency pattern as `index.json` (read GCS
-generation, merge, upload with `if-generation-match`). `pending begin` and
-`pending prune` remove stuck entries before writing (`updatedAt` older than
-30 minutes, or version already in `index.json`). See
-[pending-publish.md](./pending-publish.md#self-healing).
+generation, merge, upload with `if-generation-match`). `pending begin` removes
+stuck entries before writing (`updatedAt` older than 30 minutes, or version
+already in `index.json`). See [pending-publish.md](./pending-publish.md#self-healing).
 
 ---
 

--- a/plans/app_registry/models.md
+++ b/plans/app_registry/models.md
@@ -281,7 +281,7 @@ Each key is a version string whose publish attempt failed.
 | `repository` | string | no | Source repository. Same format as `IndexVersion.repository`. |
 | `startedAt` | RFC 3339 timestamp | yes | When the pending record was created (copied from pending). |
 | `failedAt` | RFC 3339 timestamp | yes | When the failure was recorded (UTC). |
-| `reason` | string | yes | `workflow_failed` — CI called `pending fail`. `stale` — pending `startedAt` exceeded 2 hours during `PrunePendingIndex`. |
+| `reason` | string | yes | `workflow_failed` — CI called `pending fail`. `stale` — pending `startedAt` exceeded 30 minutes during `PrunePendingIndex`. |
 | `publication` | object | no | Same `Publication` shape as `PublishedVersion.publication`. Copied from the pending row when present. |
 
 Writes use the same optimistic-concurrency pattern as `pending.json`.

--- a/plans/app_registry/models.md
+++ b/plans/app_registry/models.md
@@ -128,16 +128,6 @@ provenance is known so far?*
 Mutable catalog updated by CI at publish start and cleared on success or failure.
 Pending versions are **not** installable. See [pending-publish.md](./pending-publish.md).
 
-`pending.json` is **not** the same shape as `index.json`. Both are version-keyed
-catalogs with shared provenance fields (`sourceRef`, `repository`, `publication`),
-but the root structure and per-version fields differ:
-
-| | `index.json` | `pending.json` |
-|---|--------------|----------------|
-| Root | `apps` map (multi-app) | `app` string + `pending` map |
-| Per-version key fields | `metadata`, `platforms`, `publishedAt` | `startedAt`, `updatedAt`, `phase` |
-| Meaning | Completed publish | In-flight publish |
-
 ```json
 {
   "schemaVersion": 1,
@@ -163,37 +153,6 @@ but the root structure and per-version fields differ:
 }
 ```
 
-For comparison, the same app’s `index.json` entry for a **completed** publish
-looks like this (note `apps` nesting and `publishedAt` / `metadata` instead of
-`phase` / `startedAt`):
-
-```json
-{
-  "schemaVersion": 1,
-  "apps": {
-    "traffic-cop": {
-      "displayName": "traffic-cop",
-      "versions": {
-        "0.0.0-snapshot.gabc123def456abc123def456abc123def456abcd": {
-          "metadata": "apps/traffic-cop/versions/0.0.0-snapshot.gabc123def456abc123def456abc123def456abcd.json",
-          "platforms": ["linux/amd64", "darwin/arm64"],
-          "publishedAt": "2026-07-24T19:15:00Z",
-          "sourceRef": "abc123def456abc123def456abc123def456abcd",
-          "repository": "github.com/valon-technologies/toolshed",
-          "publication": {
-            "workflowRunUrl": "https://github.com/valon-technologies/toolshed/actions/runs/123456789",
-            "triggerPullRequest": {
-              "number": 3740,
-              "url": "https://github.com/valon-technologies/toolshed/pull/3740"
-            }
-          }
-        }
-      }
-    }
-  }
-}
-```
-
 ### Object hierarchy
 
     PendingIndex
@@ -207,9 +166,6 @@ looks like this (note `apps` nesting and `publishedAt` / `metadata` instead of
         ├── updatedAt
         ├── phase
         └── publication
-
-Unlike `Index`, `PendingIndex` does not use an `apps` map — the app name is
-implied by the path (`apps/traffic-cop/pending.json`).
 
 ### Fields
 

--- a/plans/app_registry/models.md
+++ b/plans/app_registry/models.md
@@ -117,7 +117,7 @@ Each key in `versions` is a published version string (e.g. 0.0.0-snapshot.gabc12
 | `metadata` | string | yes | Relative path to the full published version JSON, e.g. `apps/g-issues/versions/0.0.1.json`. |
 | `platforms` | string array | no | Build targets available for this version (see example JSON). Derived from published version artifact keys at publish time. |
 | `publishedAt` | RFC 3339 timestamp | yes | When this version was published (UTC). |
-| `publishStartedAt` | RFC 3339 timestamp | no | When the publish workflow recorded the version as pending (copied from `PendingVersion.startedAt` at upload time). Omitted on legacy publishes and when `pending set` was not called. Used with `publishedAt` to show total publish duration. |
+| `publishStartedAt` | RFC 3339 timestamp | no | When CI recorded the version as pending. Copied from `PendingVersion.startedAt` at publish time. Present on CI publishes after `pending set`; omitted on legacy entries and manual publishes without a pending entry. See [pending-publish.md](./pending-publish.md#publish-duration). |
 | `sourceRef` | string | no | Packaged commit SHA. Copied from `PublishedVersion.sourceRef`. |
 | `repository` | string | no | Source repository. Copied from `PublishedVersion.repository`. |
 | `publication` | object | no | Publish workflow provenance. Copied from `PublishedVersion.publication`. |
@@ -400,7 +400,7 @@ Answers: *what exactly is this version — artifacts, operations, dependencies, 
 | `requires` | object | no | Declared dependencies on other apps. Copied from the provider release `staticValidation.requires` block at publish time. |
 | `compatibility` | object | no | Runtime constraints, e.g. minimum `gestaltd` version. Copied from the provider release `staticValidation.compatibility` block at publish time. |
 | `publishedAt` | RFC 3339 timestamp | yes | When this version was published (UTC). |
-| `publishStartedAt` | RFC 3339 timestamp | no | When the publish workflow recorded the version as pending. Copied from `PendingVersion.startedAt` when `pending.json` contains this version at upload time. Omitted on legacy publishes. |
+| `publishStartedAt` | RFC 3339 timestamp | no | When CI recorded the version as pending. Copied from `PendingVersion.startedAt` at publish time. Present on CI publishes after `pending set`; omitted on legacy entries and manual publishes without a pending entry. See [pending-publish.md](./pending-publish.md#publish-duration). |
 
 #### `PublishedVersion.publication` · `Publication`
 

--- a/plans/app_registry/models.md
+++ b/plans/app_registry/models.md
@@ -198,8 +198,9 @@ Each key in `pending` is a version string being published (e.g.
 
 Writes use the same optimistic-concurrency pattern as `index.json` (read GCS
 generation, merge, upload with `if-generation-match`). `pending begin` and
-`pending prune` remove stuck entries before writing (TTL exceeded, or version
-already in `index.json`). See [pending-publish.md](./pending-publish.md#self-healing).
+`pending prune` remove stuck entries before writing (`updatedAt` older than
+30 minutes, or version already in `index.json`). See
+[pending-publish.md](./pending-publish.md#self-healing).
 
 ---
 

--- a/plans/app_registry/models.md
+++ b/plans/app_registry/models.md
@@ -1,6 +1,6 @@
 # App Registry Models
 
-Reference for the JSON documents stored in a GCS app registry by `gestaltd app publish`.
+Reference for the JSON documents stored in a GCS app registry by `gestaltd app registry publish`.
 
 For deploy reader config (`appRegistries`), see [config.md](./config.md). For broader goals (runtime install, IndexedDB state, validation phases), see [plan.md](./plan.md). For the Go package API that reads and writes these documents, see [service.md](./service.md).
 
@@ -198,7 +198,7 @@ Each key in `pending` is a version string being published (e.g.
 
 Writes use the same optimistic-concurrency pattern as `index.json` (read GCS
 generation, merge, upload with `if-generation-match`). The first
-`gestaltd app publish --pending` call removes stuck entries before writing
+`gestaltd app registry publish --pending` call removes stuck entries before writing
 (`updatedAt` older than 30 minutes, or version already in `index.json`). See
 [pending-publish.md](./pending-publish.md#self-healing).
 

--- a/plans/app_registry/models.md
+++ b/plans/app_registry/models.md
@@ -198,8 +198,7 @@ Each key in `pending` is a version string being published (e.g.
 
 Writes use the same optimistic-concurrency pattern as `index.json` (read GCS
 generation, merge, upload with `if-generation-match`). The first
-`gestaltd app registry publish --pending publishing` call removes stuck entries
-before writing
+`gestaltd app registry pending set` removes stuck entries before writing
 (`updatedAt` older than 30 minutes, or version already in `index.json`). See
 [pending-publish.md](./pending-publish.md#self-healing).
 

--- a/plans/app_registry/models.md
+++ b/plans/app_registry/models.md
@@ -197,8 +197,9 @@ Each key in `pending` is a version string being published (e.g.
 | `publication` | object | no | Same `Publication` shape as `PublishedVersion.publication`. Written at pending start so the UI can link the workflow run immediately. |
 
 Writes use the same optimistic-concurrency pattern as `index.json` (read GCS
-generation, merge, upload with `if-generation-match`). See
-[pending-publish.md](./pending-publish.md).
+generation, merge, upload with `if-generation-match`). `pending begin` and
+`pending prune` remove stuck entries before writing (TTL exceeded, or version
+already in `index.json`). See [pending-publish.md](./pending-publish.md#self-healing).
 
 ---
 

--- a/plans/app_registry/models.md
+++ b/plans/app_registry/models.md
@@ -6,12 +6,13 @@ For deploy reader config (`appRegistries`), see [config.md](./config.md). For br
 
 ## Overview
 
-The registry stores two kinds of JSON per app.
+The registry stores published release JSON plus a mutable pending catalog per app.
 
 Immutable app archives live alongside published versions:
 
     apps/{app}/
     ├── index.json
+    ├── pending.json
     ├── versions/
     │   └── {version}.json
     └── artifacts/
@@ -21,6 +22,7 @@ Immutable app archives live alongside published versions:
 | Document | Path | Purpose |
 |----------|------|---------|
 | **Index** | `apps/{app}/index.json` | Lightweight catalog of published versions |
+| **PendingIndex** | `apps/{app}/pending.json` | In-flight publishes (not installable). See [pending-publish.md](./pending-publish.md). |
 | **PublishedVersion** | `apps/{app}/versions/{version}.json` | Full metadata and install contract for one version |
 
 Document type is implied by path. Each JSON document has a root `schemaVersion` field (currently `1` for both index and published version). Readers should reject unsupported values; bump it when the JSON shape changes incompatibly.

--- a/plans/app_registry/models.md
+++ b/plans/app_registry/models.md
@@ -153,6 +153,10 @@ Pending versions are **not** installable. See [pending-publish.md](./pending-pub
 }
 ```
 
+For comparison, the same app's `index.json` entry for a completed publish uses
+`apps` nesting and `publishedAt` / `metadata` instead of `phase` / `startedAt`.
+See [Index](#index).
+
 ### Object hierarchy
 
     PendingIndex

--- a/plans/app_registry/pending-publish.md
+++ b/plans/app_registry/pending-publish.md
@@ -84,9 +84,7 @@ writes: read generation, merge, upload with `if-generation-match`.
 |-------|---------|
 | `publishing` | Publish in progress — from workflow start through artifact upload and `index.json` update. |
 
-Record pending with `phase=publishing` at workflow start. There is no separate
-`packaging` phase; `gestaltd provider package` runs while the pending row already
-shows **Publishing**.
+Record pending with `phase=publishing` at workflow start.
 
 On failure, **remove** the pending
 entry in a workflow `always()` cleanup step. The workflow run URL remains the
@@ -365,8 +363,7 @@ Suggested order: 1 → 2 → 3 → 4 → 6 (CI can ship begin/end before UI) →
 CI and manual publishes use the registry command. Pending lifecycle uses the
 same command with `--pending publishing` or `--pending clear`.
 
-**Single phase:** Pending rows use `phase=publishing` from workflow start. No
-separate `packaging` phase.
+**Single phase:** Pending rows use `phase=publishing` from workflow start.
 
 **Workflow start:** `publish-app-registry.yml` should call
 `gestaltd app registry publish --pending publishing` as early as possible (once

--- a/plans/app_registry/pending-publish.md
+++ b/plans/app_registry/pending-publish.md
@@ -134,7 +134,8 @@ CI: publish-app-registry.yml
 ├─1. Resolve PACKAGE_VERSION + PROVIDER_REF
 │
 ├─2. gestaltd app registry pending begin
-│      → upsert pending.json (phase=packaging)
+│      → PrunePendingIndex (drop entries older than 30m or already in index.json)
+│      → upsert pending.json for this version (phase=packaging)
 │
 ├─3. Package artifacts (may take tens of minutes)
 │
@@ -153,39 +154,6 @@ immediately after so operators never depend on pending lingering post-success.
 
 On **failure**, an `always()` workflow step runs step 6 even when packaging or
 publish failed, so pending does not stick unless the cleanup step itself fails.
-
-### CLI surface (proposal)
-
-Add a subcommand group rather than overloading `gestaltd app publish`:
-
-```bash
-gestaltd app registry pending begin \
-  --bucket gs://… \
-  --app traffic-cop \
-  --version 0.0.0-snapshot.g… \
-  --ref abc123… \
-  --workflow-run-url … \
-  [--trigger-pr-number … --trigger-pr-url …]
-
-gestaltd app registry pending update \
-  --bucket gs://… \
-  --app traffic-cop \
-  --version 0.0.0-snapshot.g… \
-  --phase publishing
-
-gestaltd app registry pending end \
-  --bucket gs://… \
-  --app traffic-cop \
-  --version 0.0.0-snapshot.g…
-```
-
-`begin` prunes stuck entries before upserting (see [Self-healing](#self-healing)).
-`begin` is idempotent for the same `(app, version)`: refresh `updatedAt` and
-merge `publication` if re-run. `end` is idempotent if the version is already
-absent.
-
-Implementation reuses the index upload helper (generation-match retries) in
-`gestaltd/internal/daemon/app_publish.go`.
 
 ---
 

--- a/plans/app_registry/pending-publish.md
+++ b/plans/app_registry/pending-publish.md
@@ -10,8 +10,7 @@ Related docs:
 - [admin.md](./admin.md) — app admin UI capabilities
 - [service.md](./service.md) — Go publish/read helpers
 - [lifecycle.md](./lifecycle.md) — app-admin HTTP API
-
----
+- [tests.md](./tests.md#pending-catalog-write-path) — write-path and admin tests
 
 ## Problem
 
@@ -23,8 +22,6 @@ During CI (`publish-app-registry.yml`), operators see nothing on the admin page
 while a publish is running — even though the version string and workflow run are
 already known. There is no registry signal between “workflow started” and
 “index updated”.
-
----
 
 ## Goals
 
@@ -41,11 +38,11 @@ Operators on `/apps/{app}/admin` should be able to answer:
 | Did a recent publish fail? | Row with status **Failed** and `failedAt` |
 | Why did it fail? | `reason` on the failed entry (`workflow_failed` or `stale`) |
 
----
-
 ## Design summary
 
-Add mutable `pending.json` and `failed.json` catalogs in GCS per app.
+Add mutable `pending.json` and `failed.json` catalogs in GCS per app. Scope is
+app-scoped `/apps/{app}/admin` only — the embedded fleet `/admin` registry UI does
+not show publishing state.
 
 - **Start** — CI calls `gestaltd app registry pending set` when the publish
   workflow starts.
@@ -62,8 +59,6 @@ in the snapshots table.
 Pending and failed versions are **not** installable. Install-time validation
 continues to read only `versions/{version}.json` via the published index
 contract.
-
----
 
 ## Publish duration
 
@@ -88,8 +83,6 @@ The app-admin API may include `publishingForSeconds` on pending rows and
 `publishDurationSeconds` on published and failed rows. Omit these fields when the
 start timestamp is missing.
 
----
-
 ## GCS layout
 
 Extend the per-app registry tree:
@@ -109,8 +102,6 @@ apps/{app}/
 `pending.json` and `failed.json` are mutable catalogs (like `index.json`), not
 immutable release objects. Use the same optimistic-concurrency update pattern as
 index writes: read generation, merge, upload with `if-generation-match`.
-
----
 
 ## PendingIndex
 
@@ -132,8 +123,6 @@ On workflow failure, `gestaltd app registry pending fail` removes the pending
 entry and upserts `failed.json` with `failedAt` and `reason=workflow_failed`.
 The workflow run URL remains the failure audit trail.
 
----
-
 ## FailedIndex
 
 `failed.json` document shape, fields, and example:
@@ -145,8 +134,6 @@ The workflow run URL remains the failure audit trail.
 |----------|---------|
 | `workflow_failed` | CI called `gestaltd app registry pending fail` after packaging or publish failed |
 | `stale` | Pending `startedAt` was older than 30 minutes when `PrunePendingIndex` ran |
-
----
 
 ## Self-healing
 
@@ -197,8 +184,6 @@ Every app publish workflow self-heals stuck pending entries on the next merge to
 Prune is idempotent and safe to run concurrently with an in-flight publish:
 generation-match retries apply.
 
----
-
 ## Publish lifecycle
 
 ```text
@@ -236,24 +221,12 @@ entry to `failed.json` with `reason=stale`.
 
 ### CLI
 
-`gestaltd app registry` gains:
-
-```text
-gestaltd app registry pending set|clear|fail
-gestaltd app registry publish
-```
-
 `gestaltd app registry publish` replaces `gestaltd app publish` for immutable
-uploads only. `gestaltd app registry pending` owns the mutable `pending.json` and
-`failed.json` catalogs. Keep `gestaltd app publish` as a deprecated alias for
-`gestaltd app registry publish` during migration, then remove it.
-
-**`gestaltd app registry pending`** — write or update `pending.json` and
-`failed.json`. `pending set` runs `PrunePendingIndex` and `PruneFailedIndex`
-before upserting.
+uploads. `gestaltd app registry pending` owns `pending.json` and `failed.json`.
+Keep `gestaltd app publish` as a deprecated alias during migration.
 
 ```bash
-# Workflow start — record pending publish (prunes stuck entries first)
+# Workflow start
 gestaltd app registry pending set \
   --bucket gs://… \
   --app traffic-cop \
@@ -262,32 +235,19 @@ gestaltd app registry pending set \
   --workflow-run-url … \
   [--trigger-pr-number … --trigger-pr-url …]
 
-# Workflow end — success (idempotent)
+# Workflow end — success
 gestaltd app registry pending clear \
   --bucket gs://… \
   --app traffic-cop \
   --version 0.0.0-snapshot.g…
 
-# Workflow end — failure (idempotent)
+# Workflow end — failure
 gestaltd app registry pending fail \
   --bucket gs://… \
   --app traffic-cop \
   --version 0.0.0-snapshot.g…
-```
 
-`pending set` writes `phase=publishing`. It is idempotent for the same
-`(app, version)`: refresh `updatedAt` and merge `publication` on re-run.
-`pending clear` is idempotent when the version is already absent from pending.
-`pending fail` is idempotent when the version is already absent from pending; an
-existing `failed.json` entry is left unchanged.
-
-**`gestaltd app registry publish`** — upload artifacts and version metadata,
-update `index.json` only. Does not write `pending.json` or `failed.json`. Reads
-`pending.json` when present to copy `startedAt` into `publishStartedAt` on the
-uploaded version metadata and index entry. Same flags as today's
-`gestaltd app publish`; requires `--dist-dir`.
-
-```bash
+# After packaging
 gestaltd app registry publish \
   --bucket gs://… \
   --app traffic-cop \
@@ -298,18 +258,11 @@ gestaltd app registry publish \
   [publication flags]
 ```
 
-CI runs `gestaltd app registry pending set` at workflow start,
-`gestaltd app registry publish` after packaging, and
-`gestaltd app registry pending clear` or `gestaltd app registry pending fail` in
-`always()` at workflow end depending on outcome. Manual publishes can call
-`gestaltd app registry pending set` first and `gestaltd app registry pending
-clear` or `gestaltd app registry pending fail` afterward when they want admin
-UI visibility.
-
-Implementation extends `gestaltd/internal/daemon/app_publish.go` and reuses the
-index upload helper (generation-match retries).
-
----
+`pending set` writes `phase=publishing`. It is idempotent for the same
+`(app, version)`: refresh `updatedAt` and merge `publication` on re-run.
+`pending clear` and `pending fail` are idempotent when the version is already
+absent from pending. `pending fail` does not overwrite an existing `failed.json`
+entry.
 
 ## Read path
 
@@ -366,27 +319,18 @@ Extend `GET /api/v1/apps/{app}/admin/registry` response:
 
 Merge rules:
 
-- Each version appears in **at most one** of `pendingVersions`, `failedVersions`,
-  and `publishedVersions` in the API response and snapshots table.
-- **Precedence** (when a race or missed cleanup leaves duplicates in GCS):
-  **published** > **pending** > **failed**. Keep the highest-precedence row and
-  omit the others. Example: a version in both `pending.json` and `failed.json`
-  during a workflow retry surfaces as **Publishing**, not **Failed**.
+- Each version appears in at most one of `pendingVersions`, `failedVersions`, and
+  `publishedVersions`.
+- When catalogs disagree, precedence is **published** > **pending** > **failed**.
 - `pendingVersions` sorted by `startedAt` descending (newest first).
 - `failedVersions` sorted by `failedAt` descending (newest first).
-- Published rows may include `publishStartedAt`. Pending, published, and failed
-  rows may include computed duration fields. See [Publish duration](#publish-duration).
+- Published rows may include `publishStartedAt`. Duration fields: [Publish duration](#publish-duration).
 
 Install and upgrade handlers ignore `pending.json` and `failed.json` entirely.
 
----
-
 ## UI changes (`/apps/{app}/admin`)
 
-Update the snapshots table to render pending and failed entries alongside
-published entries (single newest-first list with a status column). Apply merge
-precedence (**published** > **pending** > **failed**) before choosing each row's
-status — see [Merge rules](#app-admin-api) above.
+Wireframes, columns, and row layout: [admin.md](./admin.md#app-admin-ui-appsappadmin).
 
 | Status | Condition |
 |--------|-----------|
@@ -396,32 +340,9 @@ status — see [Merge rules](#app-admin-api) above.
 | **Rolling out** | Active rollout for this version (unchanged) |
 | **Available** | Published, not desired (unchanged) |
 
-Pending entries:
-
-- Show PR / commit provenance when present (same columns as published)
-- **Published** column shows elapsed publish time from `startedAt`
-- **Action** column: Deploy disabled; optional “View workflow” link using
-  `publication.workflowRunUrl`
-
-Failed entries:
-
-- Show PR / commit provenance when present
-- **Published** column shows `failedAt`, total time before failure, and a reason
-  label (`workflow_failed` → “Workflow failed”, `stale` → “Timed out”)
-- **Action** column: Deploy disabled; “View workflow” when
-  `publication.workflowRunUrl` is present
-
-Published entries without `publishStartedAt` show `publishedAt` only. See
-[Publish duration](#publish-duration) for timing labels on all row types.
-
-Polling: extend `AppAdminPageClient` to poll every **12s** while
-`pendingVersions.length > 0` or fleet rollout is non-terminal. **Do not poll
-solely because `failedVersions` is non-empty** — failed rows are retained for
-30 days for visibility but are not in-flight; load them on page fetch and after
-deploy actions. Stop polling when no pending versions remain and rollout is
-terminal.
-
----
+Apply [merge rules](#app-admin-api) before assigning status. Poll every **12s**
+while `pendingVersions.length > 0` or fleet rollout is non-terminal. Do not poll
+solely because `failedVersions` is non-empty — load failed rows on page fetch.
 
 ## CI changes (`publish-app-registry.yml`)
 
@@ -439,8 +360,6 @@ In `toolshed` (and any repo using the shared workflow):
 Install `gestaltd` before step 1 (today it is installed only in the publish job;
 move or duplicate install earlier so pending can be recorded at workflow start).
 
----
-
 ## Safety and invariants
 
 | Invariant | Enforcement |
@@ -455,7 +374,14 @@ move or duplicate install earlier so pending can be recorded at workflow start).
 | Duplicate version across catalogs | API and UI apply **published** > **pending** > **failed** precedence; see [Merge rules](#app-admin-api) |
 | Old failed entries are pruned | `PruneFailedIndex` on `pending set`; 30-day `failedAt` threshold |
 
----
+Implementation:
+
+- Pending/failed types and prune — `gestaltd/internal/appregistry/pending.go`
+- `gestaltd app registry pending` CLI — `gestaltd/internal/daemon/app_registry_pending.go`
+- `gestaltd app registry publish` CLI — `gestaltd/internal/daemon/app_registry_publish.go`, `gestaltd/internal/daemon/app_publish.go`
+- App-admin registry API — `gestaltd/internal/server/handlers_app_admin_registry.go` (PR 2)
+- Registry fetch — `gestaltd/internal/appregistry/reader.go` (PR 2)
+- App admin snapshots UI — `gestalt-providers` (PR 4)
 
 ## Implementation path
 
@@ -494,9 +420,8 @@ Depends on **PR 1**. Exposes pending and failed catalog state to the admin page.
 
 - `FetchPendingIndex` and `FetchFailedIndex` in `gestaltd/internal/appregistry/`.
 - Extend `getAppAdminRegistry` with `pendingVersions[]` and `failedVersions[]`.
-- Apply merge precedence (**published** > **pending** > **failed**) when building
-  the response. Expose `publishStartedAt` and computed duration fields per
-  [Publish duration](#publish-duration).
+- Apply [merge rules](#app-admin-api). Expose `publishStartedAt` and computed
+  duration fields per [Publish duration](#publish-duration).
 - Tests: fetch helpers via `registrytest` HTTP fixture; handler returns pending
   and failed entries alongside published. Extend [tests.md](./tests.md).
 
@@ -519,39 +444,7 @@ operators get correct GCS state before the UI exists.
 Depends on **PR 2**. Completes admin visibility.
 
 - **Publishing** and **Failed** rows in the `gestalt-providers` app admin
-  snapshots table. Timing labels per [Publish duration](#publish-duration).
-- Poll every ~12s while any pending version exists or rollout is non-terminal.
-  Apply merge precedence (**published** > **pending** > **failed**) when building
-  the snapshots table.
+  snapshots table. See [admin.md](./admin.md#app-admin-ui-appsappadmin).
+- Poll while pending versions exist or rollout is non-terminal. Apply
+  [merge rules](#app-admin-api).
 - Manual / browser smoke per [tests.md](./tests.md) when implementing.
-
----
-
-## Decisions
-
-**Scope:** Pending publish visibility is **app-scoped only** — `/apps/{app}/admin`.
-The embedded fleet `/admin` registry list does not show a publishing indicator.
-
-**CLI:** `gestaltd app registry pending` (`set`, `clear`, `fail`) owns
-`pending.json` and `failed.json`. `gestaltd app registry publish` uploads
-immutable artifacts and `index.json` (replaces `gestaltd app publish`); it may
-read `pending.json` to copy `publishStartedAt` but does not mutate pending or
-failed catalogs. CI calls `pending clear` on success and `pending fail` on
-failure.
-
-**Failed retention:** `failed.json` entries are kept for **30 days**, then pruned
-on `pending set`. Stale pending (`startedAt` older than 30 minutes) records
-`failedAt` with `reason=stale`.
-
-**Single phase:** Pending entries use `phase=publishing` from workflow start.
-
-**Workflow start:** `publish-app-registry.yml` should call
-`gestaltd app registry pending set` as early as possible (once `PACKAGE_VERSION`,
-GCP auth, and `gestaltd` are available), not only when artifacts are ready.
-
-**Publish duration:** `publishStartedAt` on published registry objects; elapsed
-and total time derived at read/UI time. See [Publish duration](#publish-duration).
-
-**Catalog merge precedence:** When the same version appears in more than one GCS
-catalog, the app-admin API and snapshots table keep **published** over
-**pending** over **failed**. See [Merge rules](#app-admin-api).

--- a/plans/app_registry/pending-publish.md
+++ b/plans/app_registry/pending-publish.md
@@ -150,14 +150,70 @@ Do not add a `failed` phase in GCS for v1. On failure, **remove** the pending
 entry in a workflow `always()` cleanup step. The workflow run URL remains the
 failure audit trail.
 
-#### Stale pending
+#### Stale pending (read path)
 
-If CI crashes before cleanup, a pending row can linger. Readers should treat a
-pending entry as **stale** when `updatedAt` is older than a fixed TTL (proposal:
-**6 hours**). The API exposes `stale: true` on pending rows; the UI shows
-**Publishing (stale)** and still links the workflow run. A later successful
-publish for the same version removes the pending entry and adds the index row as
-today.
+If CI crashes before cleanup, a pending row can linger in `pending.json`.
+Readers treat a pending entry as **stale** when `updatedAt` is older than a
+fixed TTL (proposal: **6 hours**). The API exposes `stale: true` on pending
+rows; the UI shows **Publishing (stale)** and still links the workflow run.
+
+Stale labeling is for operator visibility only. It does not remove the GCS
+entry — see [Self-healing](#self-healing) below.
+
+#### Self-healing
+
+`gestaltd serve` reads `pending.json` over public HTTP and cannot write back to
+GCS. Self-healing therefore runs on the **publish write path** (CI and
+`gestaltd app registry pending` subcommands), which already hold bucket
+credentials.
+
+A shared `PrunePendingIndex` helper removes stuck entries from `pending.json`
+before any pending mutation. Prune criteria for each `pending.{version}` entry:
+
+| Condition | Action |
+|-----------|--------|
+| `updatedAt` older than TTL (default **6 hours**) | Remove — publish likely failed or cleanup never ran |
+| Same `version` already listed in `index.json` | Remove — publish succeeded but `pending end` did not run |
+| Otherwise | Keep |
+
+Prune uses the same optimistic-concurrency loop as `begin` / `end`: download
+`pending.json` generation, drop matching entries, upload with
+`if-generation-match`.
+
+**When prune runs:**
+
+1. **`pending begin`** — always prune before adding the new entry. Every app
+   publish workflow triggers this, so stuck rows are cleared on the next merge to
+   `main` for that app even without a dedicated janitor job.
+2. **`pending prune`** (new subcommand) — explicit sweep for one app or all
+   enrolled apps. Used by a scheduled CI workflow and for manual operator cleanup.
+
+```bash
+# Prune one app (typical scheduled / manual use)
+gestaltd app registry pending prune \
+  --bucket gs://… \
+  --app traffic-cop \
+  [--max-age 6h]
+
+# Prune every app that has a pending.json object (optional scheduled job)
+gestaltd app registry pending prune \
+  --bucket gs://… \
+  --all-apps \
+  [--max-age 6h]
+```
+
+`--all-apps` lists `apps/*/pending.json` via the GCS API (publisher credentials
+only; not used by `gestaltd serve`). For each object, load the sibling
+`index.json`, apply the prune rules, and upload only when the pending map changed.
+
+**Scheduled janitor (recommended):** add a low-frequency workflow in `toolshed`
+(e.g. daily) that runs `pending prune --all-apps` against the app registry
+bucket. This covers apps that have not had a merge (and thus no `pending begin`)
+in longer than the TTL.
+
+Prune is idempotent and safe to run concurrently with an in-flight publish:
+generation-match retries apply. An active publish refreshes `updatedAt` on each
+`begin` / `update`, so a healthy in-flight entry is not removed.
 
 ---
 
@@ -212,8 +268,15 @@ gestaltd app registry pending end \
   --bucket gs://… \
   --app traffic-cop \
   --version 0.0.0-snapshot.g…
+
+gestaltd app registry pending prune \
+  --bucket gs://… \
+  --app traffic-cop \
+  [--all-apps] \
+  [--max-age 6h]
 ```
 
+`begin` prunes stuck entries before upserting (see [Self-healing](#self-healing)).
 `begin` is idempotent for the same `(app, version)`: refresh `updatedAt` and
 merge `publication` if re-run. `end` is idempotent if the version is already
 absent.
@@ -318,6 +381,10 @@ In `toolshed` (and any repo using the shared workflow):
 The `begin` step needs the gestaltd binary — reuse the existing install step
 ordering (install gestaltd before pending begin).
 
+**Janitor:** add a scheduled workflow (e.g. daily) that runs
+`gestaltd app registry pending prune --all-apps` so stuck entries are removed
+even when an app has not published recently.
+
 ---
 
 ## Safety and invariants
@@ -329,6 +396,7 @@ ordering (install gestaltd before pending begin).
 | Published catalog remains immutable per version | `versions/{version}.json` and artifacts still uploaded with `if-generation-match=0` |
 | Public read stays HTTP GET | Single `pending.json` per app, no bucket listing |
 | Concurrent publishes for one app | Rare; `pending` map holds multiple versions. CI concurrency is per `(app, sha)`; different SHAs produce different version strings |
+| Stuck pending rows are removed | `PrunePendingIndex` on `pending begin` and `pending prune`; TTL + already-published checks |
 
 ---
 
@@ -336,13 +404,15 @@ ordering (install gestaltd before pending begin).
 
 1. **Models** — Add `PendingIndex` / `PendingVersion` to
    `gestaltd/internal/appregistry/`; document in [models.md](./models.md).
-2. **Write path** — `gestaltd app registry pending begin|update|end` with
-   generation-match retries (mirror index upsert).
+2. **Write path** — `gestaltd app registry pending begin|update|end|prune` with
+   generation-match retries (mirror index upsert). `begin` and `prune` call
+   `PrunePendingIndex`.
 3. **Read path** — `FetchPendingIndex`; unit tests with `registrytest` HTTP
    fixture.
 4. **App-admin API** — extend `getAppAdminRegistry`; stale TTL in handler.
 5. **UI** — pending rows + polling in `gestalt-providers` app admin table.
-6. **CI** — wire `publish-app-registry.yml` begin/update/end steps.
+6. **CI** — wire `publish-app-registry.yml` begin/update/end steps; add scheduled
+   `pending prune --all-apps` janitor workflow.
 7. **Tests** — see [tests.md](./tests.md) (add section when implementing).
 
 Suggested order: 1 → 2 → 3 → 4 → 6 (CI can ship begin/end before UI) → 5.
@@ -351,8 +421,7 @@ Suggested order: 1 → 2 → 3 → 4 → 6 (CI can ship begin/end before UI) →
 
 ## Open questions
 
-1. **TTL** — Is 6 hours the right stale threshold, or should stale pending hide
-   after 24h?
+1. **TTL** — Is 6 hours the right prune threshold?
 2. **Phase granularity** — Is `packaging` / `publishing` enough, or do we want
    per-platform sub-phases in v1?
 3. **Manual publish** — Should `gestaltd app publish` call `pending begin/end`
@@ -360,6 +429,8 @@ Suggested order: 1 → 2 → 3 → 4 → 6 (CI can ship begin/end before UI) →
    also appear in the admin UI?
 4. **Embedded `/admin`** — Should the fleet observability app list show a
    “publishing” indicator, or only the app-scoped `/apps/{app}/admin` page?
+5. **Janitor cadence** — Is daily `pending prune --all-apps` sufficient, or
+   should prune run more frequently?
 
 ---
 

--- a/plans/app_registry/pending-publish.md
+++ b/plans/app_registry/pending-publish.md
@@ -366,9 +366,12 @@ Extend `GET /api/v1/apps/{app}/admin/registry` response:
 
 Merge rules:
 
-- A version MUST NOT appear in more than one of `pendingVersions`,
-  `failedVersions`, and `publishedVersions`. If multiple exist (race or missed
-  cleanup), prefer **published**, then **pending**, then **failed**.
+- Each version appears in **at most one** of `pendingVersions`, `failedVersions`,
+  and `publishedVersions` in the API response and snapshots table.
+- **Precedence** (when a race or missed cleanup leaves duplicates in GCS):
+  **published** > **pending** > **failed**. Keep the highest-precedence row and
+  omit the others. Example: a version in both `pending.json` and `failed.json`
+  during a workflow retry surfaces as **Publishing**, not **Failed**.
 - `pendingVersions` sorted by `startedAt` descending (newest first).
 - `failedVersions` sorted by `failedAt` descending (newest first).
 - Published rows may include `publishStartedAt`. Pending, published, and failed
@@ -381,7 +384,9 @@ Install and upgrade handlers ignore `pending.json` and `failed.json` entirely.
 ## UI changes (`/apps/{app}/admin`)
 
 Update the snapshots table to render pending and failed entries alongside
-published entries (single newest-first list with a status column).
+published entries (single newest-first list with a status column). Apply merge
+precedence (**published** > **pending** > **failed**) before choosing each row's
+status — see [Merge rules](#app-admin-api) above.
 
 | Status | Condition |
 |--------|-----------|
@@ -447,6 +452,7 @@ move or duplicate install earlier so pending can be recorded at workflow start).
 | Concurrent publishes for one app | Rare; `pending` map holds multiple versions. CI concurrency is per `(app, sha)`; different SHAs produce different version strings |
 | Stuck pending entries become failed | `PrunePendingIndex` on `pending set`; 30-minute `startedAt` threshold writes `failedAt` with `reason=stale` |
 | Workflow retries clear prior failures | `pending set` removes `failed.{version}` for the version being upserted |
+| Duplicate version across catalogs | API and UI apply **published** > **pending** > **failed** precedence; see [Merge rules](#app-admin-api) |
 | Old failed entries are pruned | `PruneFailedIndex` on `pending set`; 30-day `failedAt` threshold |
 
 ---
@@ -488,7 +494,9 @@ Depends on **PR 1**. Exposes pending and failed catalog state to the admin page.
 
 - `FetchPendingIndex` and `FetchFailedIndex` in `gestaltd/internal/appregistry/`.
 - Extend `getAppAdminRegistry` with `pendingVersions[]` and `failedVersions[]`.
-- Expose `publishStartedAt` and computed duration fields per [Publish duration](#publish-duration).
+- Apply merge precedence (**published** > **pending** > **failed**) when building
+  the response. Expose `publishStartedAt` and computed duration fields per
+  [Publish duration](#publish-duration).
 - Tests: fetch helpers via `registrytest` HTTP fixture; handler returns pending
   and failed entries alongside published. Extend [tests.md](./tests.md).
 
@@ -513,7 +521,8 @@ Depends on **PR 2**. Completes admin visibility.
 - **Publishing** and **Failed** rows in the `gestalt-providers` app admin
   snapshots table. Timing labels per [Publish duration](#publish-duration).
 - Poll every ~12s while any pending version exists or rollout is non-terminal.
-  Prefer published entry when the same version appears in multiple lists.
+  Apply merge precedence (**published** > **pending** > **failed**) when building
+  the snapshots table.
 - Manual / browser smoke per [tests.md](./tests.md) when implementing.
 
 ---
@@ -542,3 +551,7 @@ GCP auth, and `gestaltd` are available), not only when artifacts are ready.
 
 **Publish duration:** `publishStartedAt` on published registry objects; elapsed
 and total time derived at read/UI time. See [Publish duration](#publish-duration).
+
+**Catalog merge precedence:** When the same version appears in more than one GCS
+catalog, the app-admin API and snapshots table keep **published** over
+**pending** over **failed**. See [Merge rules](#app-admin-api).

--- a/plans/app_registry/pending-publish.md
+++ b/plans/app_registry/pending-publish.md
@@ -37,13 +37,6 @@ Operators on `/apps/{app}/admin` should be able to answer:
 | Where is the CI run? | Link to `publication.workflowRunUrl` |
 | When did publish start? | `startedAt` on the pending row |
 
-Non-goals for this change:
-
-- Installing or deploying a pending version (must remain impossible)
-- Replacing GitHub Actions as the source of live step-level CI progress
-- Storing pending state in IndexedDB
-- Changing when `index.json` is updated (still last, on success only)
-
 ---
 
 ## Design summary

--- a/plans/app_registry/pending-publish.md
+++ b/plans/app_registry/pending-publish.md
@@ -471,11 +471,3 @@ on `pending set`. Stale pending (30 minutes without `updatedAt` refresh) records
 **Workflow start:** `publish-app-registry.yml` should call
 `gestaltd app registry pending set` as early as possible (once `PACKAGE_VERSION`,
 GCP auth, and `gestaltd` are available), not only when artifacts are ready.
-
----
-
-## Future work
-
-- Global pending index across apps for a registry-wide dashboard.
-- Webhook or Pub/Sub on `index.json` change to push updates to the UI instead
-  of polling.

--- a/plans/app_registry/pending-publish.md
+++ b/plans/app_registry/pending-publish.md
@@ -42,10 +42,10 @@ Operators on `/apps/{app}/admin` should be able to answer:
 ## Design summary
 
 Add a small **pending catalog** document in GCS per app. CI writes it when a
-publish starts and removes the entry when the publish finishes (success or
-failure). `gestaltd` reads it alongside `index.json` and exposes pending rows
-through the existing app-admin registry API. The UI merges pending and
-published rows in the snapshots table.
+publish starts and `pending clear` removes the entry when the workflow finishes
+(success or failure). `gestaltd` reads it alongside `index.json` and exposes
+pending rows through the existing app-admin registry API. The UI merges pending
+and published rows in the snapshots table.
 
 Pending versions are **not** installable. Install-time validation continues to
 read only `versions/{version}.json` via the published index contract.
@@ -86,9 +86,9 @@ writes: read generation, merge, upload with `if-generation-match`.
 
 Record pending with `phase=publishing` at workflow start.
 
-On failure, **remove** the pending
-entry in a workflow `always()` cleanup step. The workflow run URL remains the
-failure audit trail.
+On workflow end (success or failure), **remove** the pending entry with
+`gestaltd app registry pending clear` in an `always()` step. The workflow run
+URL remains the failure audit trail.
 
 ### Self-healing
 
@@ -137,21 +137,20 @@ CI: publish-app-registry.yml
 ├─3. Package artifacts (may take tens of minutes)
 │
 ├─4. gestaltd app registry publish --dist-dir … (artifacts + versions/{version}.json + index.json)
-│      → clear this version from pending.json on success
 │
-└─5. gestaltd app registry pending clear  (always() failure cleanup)
-       → remove version from pending.json if step 4 did not run
+└─5. gestaltd app registry pending clear  (always())
+       → remove this version from pending.json (success or failure)
 ```
 
 Today, `publish-app-registry.yml` runs `gestaltd app publish --dist-dir …` only.
 This proposal adds `gestaltd app registry pending` for steps 2 and 5, and migrates
 step 4 to `gestaltd app registry publish`.
 
-On **success**, step 4 clears pending after uploading. Order within step 4 is
-unchanged: `index.json` is still updated last.
+On **success**, step 4 uploads artifacts and updates `index.json` (unchanged
+order — index last). Step 5 clears pending.
 
-On **failure**, an `always()` workflow step runs step 5 even when packaging or
-publish failed, so pending does not stick unless the cleanup step itself fails.
+On **failure**, step 5 still runs via `always()`, so pending does not stick unless
+the cleanup step itself fails.
 
 ### CLI surface
 
@@ -179,7 +178,7 @@ gestaltd app registry pending set \
   --workflow-run-url … \
   [--trigger-pr-number … --trigger-pr-url …]
 
-# Failure cleanup
+# Workflow end — remove pending row (idempotent)
 gestaltd app registry pending clear \
   --bucket gs://… \
   --app traffic-cop \
@@ -190,9 +189,9 @@ gestaltd app registry pending clear \
 `(app, version)`: refresh `updatedAt` and merge `publication` if re-run.
 `pending clear` is idempotent if the version is already absent.
 
-**Publish** — upload artifacts and version metadata, update `index.json`, then
-remove this version from `pending.json` on success. Same flags as today's
-`gestaltd app publish`; requires `--dist-dir`.
+**Publish** — upload artifacts and version metadata, update `index.json` only.
+Does not read or write `pending.json`. Same flags as today's `gestaltd app
+publish`; requires `--dist-dir`.
 
 ```bash
 gestaltd app registry publish \
@@ -205,8 +204,9 @@ gestaltd app registry publish \
   [publication flags]
 ```
 
-CI runs `pending set` at workflow start and `registry publish` after packaging.
-Manual publishes can call `pending set` first when they want admin UI visibility.
+CI runs `pending set` at workflow start, `registry publish` after packaging,
+and `pending clear` in `always()` at workflow end. Manual publishes can call
+`pending set` first and `pending clear` after when they want admin UI visibility.
 
 Implementation extends `gestaltd/internal/daemon/app_publish.go` and reuses the
 index upload helper (generation-match retries).
@@ -301,9 +301,9 @@ In `toolshed` (and any repo using the shared workflow):
    to GCP and run `gestaltd app registry pending set` with the same publication
    flags used in the publish step.
 2. Keep the existing publish step, migrated to
-   `gestaltd app registry publish --dist-dir …` (clears pending on success).
-3. Add an `always()` step that runs `gestaltd app registry pending clear` when
-   the publish step did not succeed.
+   `gestaltd app registry publish --dist-dir …` (does not touch `pending.json`).
+3. Add an `always()` step that runs `gestaltd app registry pending clear` after
+   the publish job (success or failure).
 
 Install `gestaltd` before step 1 (today it is installed only in the publish job;
 move or duplicate install earlier so pending can be recorded at workflow start).
@@ -325,36 +325,75 @@ move or duplicate install earlier so pending can be recorded at workflow start).
 
 ## Implementation path
 
-1. **Models** — Add `PendingIndex` / `PendingVersion` to
-   `gestaltd/internal/appregistry/`; document in [models.md](./models.md).
-2. **Write path** — add `gestaltd app registry pending set|clear` and
-   `gestaltd app registry publish` (move publish logic from `gestaltd app
-   publish`). `pending set` calls `PrunePendingIndex`; `registry publish` clears
-   pending on success. Deprecate `gestaltd app publish`.
-3. **Read path** — `FetchPendingIndex`; unit tests with `registrytest` HTTP
-   fixture.
-4. **App-admin API** — extend `getAppAdminRegistry` with `pendingVersions`.
-5. **UI** — pending rows + polling in `gestalt-providers` app admin table.
-6. **CI** — add `gestaltd app registry pending set` at workflow start and
-   `pending clear` on failure; migrate publish step to
-   `gestaltd app registry publish`.
-7. **Tests** — see [tests.md](./tests.md) (add section when implementing).
+**Four PRs.** Merge in order below. CI can land after PR 1 and before the UI —
+`pending.json` is written and cleared in production before `/apps/{app}/admin`
+shows publishing rows.
 
-Suggested order: 1 → 2 → 3 → 4 → 6 (CI can ship begin/end before UI) → 5.
+```text
+PR 1 (gestalt) ──► PR 2 (gestalt) ──► PR 4 (gestalt)
+       │
+       └──────────► PR 3 (toolshed)
+```
+
+### PR 1 — Models and write path (`gestalt`)
+
+Foundation for everything else. Ship types and CLI first so CI can call the new
+commands.
+
+- Add `PendingIndex` / `PendingVersion` to `gestaltd/internal/appregistry/`
+  ([models.md](./models.md) already documents the shape).
+- Add `gestaltd app registry pending set|clear` and
+  `gestaltd app registry publish` (move logic from `gestaltd app publish`).
+- `pending set` calls `PrunePendingIndex` before upsert; `registry publish` does
+  not touch `pending.json`.
+- Deprecate `gestaltd app publish` (alias → `registry publish`).
+- Tests: pending write/prune/clear, deprecated alias. Add a [tests.md](./tests.md)
+  section for the write path.
+
+### PR 2 — Read path and app-admin API (`gestalt`)
+
+Depends on **PR 1**. Exposes pending state to the admin page.
+
+- `FetchPendingIndex` in `gestaltd/internal/appregistry/`.
+- Extend `getAppAdminRegistry` with `pendingVersions[]`.
+- Tests: `FetchPendingIndex` via `registrytest` HTTP fixture; handler returns
+  pending alongside published. Extend [tests.md](./tests.md).
+
+### PR 3 — CI (`toolshed`)
+
+Depends on **PR 1** merged and `gestaltd` available to the workflow (released
+binary or workflow install from `main`). Does **not** wait on PR 2 or PR 4 —
+operators get correct GCS state before the UI exists.
+
+- `gestaltd app registry pending set` at workflow start (after version + GCP
+  auth).
+- Migrate publish step to `gestaltd app registry publish`.
+- `gestaltd app registry pending clear` in `always()` at workflow end.
+- Install `gestaltd` early enough for step 1 (see [CI changes](#ci-changes-publish-app-registryyml)
+  above).
+
+### PR 4 — UI (`gestalt`)
+
+Depends on **PR 2**. Completes operator visibility.
+
+- Pending rows (**Publishing**) in the `gestalt-providers` app admin snapshots
+  table.
+- Poll every ~12s while any pending version exists; prefer published row when
+  the same version appears in both lists.
+- Manual / browser smoke per [tests.md](./tests.md) when implementing.
 
 ---
 
-## Open questions
-
-1. **Embedded `/admin`** — Should the fleet observability app list show a
-   “publishing” indicator, or only the app-scoped `/apps/{app}/admin` page?
-
 ## Decisions
+
+**Scope:** Pending publish visibility is **app-scoped only** — `/apps/{app}/admin`.
+The embedded fleet `/admin` registry list does not show a publishing indicator.
 
 **CLI surface:** Two commands under `gestaltd app registry`:
 
-- `pending set|clear` — mutable `pending.json` lifecycle
-- `publish` — immutable artifacts + `index.json` (replaces `gestaltd app publish`)
+- `pending set|clear` — mutable `pending.json` lifecycle (CI calls `clear` in
+  `always()` after publish)
+- `publish` — immutable artifacts + `index.json` only (replaces `gestaltd app publish`)
 
 **Single phase:** Pending rows use `phase=publishing` from workflow start.
 

--- a/plans/app_registry/pending-publish.md
+++ b/plans/app_registry/pending-publish.md
@@ -53,7 +53,7 @@ Add mutable `pending.json` and `failed.json` catalogs in GCS per app.
 - **Failure** — `gestaltd app registry pending fail` removes the pending entry
   and records `failedAt` in `failed.json`.
 - **Stale** — `PrunePendingIndex` on the next `pending set` moves entries whose
-  `updatedAt` is older than 30 minutes to `failed.json` with `reason=stale`.
+  `startedAt` is older than **2 hours** to `failed.json` with `reason=stale`.
 
 `gestaltd` reads both catalogs alongside `index.json` and exposes them through
 the app-admin registry API. The UI merges pending, failed, and published entries
@@ -144,7 +144,7 @@ The workflow run URL remains the failure audit trail.
 | `reason` | Meaning |
 |----------|---------|
 | `workflow_failed` | CI called `gestaltd app registry pending fail` after packaging or publish failed |
-| `stale` | Pending `updatedAt` was older than 30 minutes when `PrunePendingIndex` ran |
+| `stale` | Pending `startedAt` was older than 2 hours when `PrunePendingIndex` ran |
 
 ---
 
@@ -162,9 +162,14 @@ For each `pending.{version}` entry:
 
 | Condition | Action |
 |-----------|--------|
-| `updatedAt` older than **30 minutes** | Move to `failed.json` with `failedAt=now`, `reason=stale` |
+| `startedAt` older than **2 hours** | Move to `failed.json` with `failedAt=now`, `reason=stale` |
 | Same `version` already listed in `index.json` | Remove from pending only (publish succeeded; pending cleanup missed) |
 | Otherwise | Keep |
+
+Use `startedAt`, not `updatedAt`, for the stale threshold. Packaging can take
+tens of minutes and `updatedAt` is only refreshed when the same version re-runs
+`pending set`; concurrent publishes for one app (different snapshot versions) must
+not mark an in-flight run as stale while it is still within the window.
 
 ### `PruneFailedIndex`
 
@@ -176,9 +181,13 @@ For each `failed.{version}` entry:
 | Same `version` already listed in `index.json` | Remove |
 | Otherwise | Keep |
 
-The 30-minute pending threshold applies on `gestaltd app registry pending set`.
+The 2-hour pending threshold applies on `gestaltd app registry pending set`.
 Failed entries are retained for 30 days so operators can see recent failures on
 the admin page.
+
+`pending set` also **removes `failed.{version}`** for the version being upserted
+before prune helpers run, so a workflow retry does not leave the same version in
+both catalogs.
 
 `PrunePendingIndex` and `PruneFailedIndex` use the same optimistic-concurrency
 loop as other catalog writes: download generation, merge, upload with
@@ -201,6 +210,7 @@ CI: publish-app-registry.yml
 │
 ├─2. gestaltd app registry pending set
 │      (same --bucket/--app/--version/--ref/--workflow-run-url flags as step 4)
+│      → remove failed.{version} for this version (workflow retry)
 │      → PrunePendingIndex (stale → failed.json; already-published → drop)
 │      → PruneFailedIndex (drop entries older than 30 days or already published)
 │      → upsert pending.json for this version (phase=publishing)
@@ -360,7 +370,7 @@ Merge rules:
 
 - A version MUST NOT appear in more than one of `pendingVersions`,
   `failedVersions`, and `publishedVersions`. If multiple exist (race or missed
-  cleanup), prefer **published** and omit pending and failed.
+  cleanup), prefer **published**, then **pending**, then **failed**.
 - `pendingVersions` sorted by `startedAt` descending (newest first).
 - `failedVersions` sorted by `failedAt` descending (newest first).
 - Published rows may include `publishStartedAt`. Pending, published, and failed
@@ -402,8 +412,11 @@ Published entries without `publishStartedAt` show `publishedAt` only. See
 [Publish duration](#publish-duration) for timing labels on all row types.
 
 Polling: extend `AppAdminPageClient` to poll every **12s** while
-`pendingVersions.length > 0` or `failedVersions.length > 0`, not only during
-fleet rollout. Stop polling when idle.
+`pendingVersions.length > 0` or fleet rollout is non-terminal. **Do not poll
+solely because `failedVersions` is non-empty** — failed rows are retained for
+30 days for visibility but are not in-flight; load them on page fetch and after
+deploy actions. Stop polling when no pending versions remain and rollout is
+terminal.
 
 ---
 
@@ -434,7 +447,8 @@ move or duplicate install earlier so pending can be recorded at workflow start).
 | Published catalog remains immutable per version | `versions/{version}.json` and artifacts still uploaded with `if-generation-match=0` |
 | Public read stays HTTP GET | `pending.json` and `failed.json` per app, no bucket listing |
 | Concurrent publishes for one app | Rare; `pending` map holds multiple versions. CI concurrency is per `(app, sha)`; different SHAs produce different version strings |
-| Stuck pending entries become failed | `PrunePendingIndex` on `pending set`; 30-minute `updatedAt` threshold writes `failedAt` with `reason=stale` |
+| Stuck pending entries become failed | `PrunePendingIndex` on `pending set`; 2-hour `startedAt` threshold writes `failedAt` with `reason=stale` |
+| Workflow retries clear prior failures | `pending set` removes `failed.{version}` for the version being upserted |
 | Old failed entries are pruned | `PruneFailedIndex` on `pending set`; 30-day `failedAt` threshold |
 
 ---
@@ -462,8 +476,9 @@ Add types and CLI first so CI can call the new commands.
   not mutate pending). See [Publish duration](#publish-duration).
 - Add `gestaltd app registry pending set|clear|fail` and
   `gestaltd app registry publish` (move logic from `gestaltd app publish`).
-- `pending set` calls `PrunePendingIndex` and `PruneFailedIndex` before
-  upsert; stale pending → `failed.json`. `gestaltd app registry publish` does
+- `pending set` removes `failed.{version}` for the version being upserted, then
+  calls `PrunePendingIndex` and `PruneFailedIndex` before upsert; stale pending
+  (`startedAt` > 2 hours) → `failed.json`. `gestaltd app registry publish` does
   not touch `pending.json` or `failed.json`.
 - Deprecate `gestaltd app publish` (alias → `gestaltd app registry publish`).
 - Tests: pending write/prune/fail/clear, stale → failed, deprecated alias. Add a
@@ -499,8 +514,8 @@ Depends on **PR 2**. Completes admin visibility.
 
 - **Publishing** and **Failed** rows in the `gestalt-providers` app admin
   snapshots table. Timing labels per [Publish duration](#publish-duration).
-- Poll every ~12s while any pending or failed version exists; prefer published
-  entry when the same version appears in multiple lists.
+- Poll every ~12s while any pending version exists or rollout is non-terminal.
+  Prefer published entry when the same version appears in multiple lists.
 - Manual / browser smoke per [tests.md](./tests.md) when implementing.
 
 ---
@@ -518,7 +533,7 @@ failed catalogs. CI calls `pending clear` on success and `pending fail` on
 failure.
 
 **Failed retention:** `failed.json` entries are kept for **30 days**, then pruned
-on `pending set`. Stale pending (30 minutes without `updatedAt` refresh) records
+on `pending set`. Stale pending (`startedAt` older than 2 hours) records
 `failedAt` with `reason=stale`.
 
 **Single phase:** Pending entries use `phase=publishing` from workflow start.

--- a/plans/app_registry/pending-publish.md
+++ b/plans/app_registry/pending-publish.md
@@ -92,9 +92,8 @@ failure audit trail.
 ### Self-healing
 
 `gestaltd serve` reads `pending.json` over public HTTP and cannot write back to
-GCS. Self-healing runs on the **publish write path** (CI and
-`gestaltd app registry pending` subcommands), which already hold bucket
-credentials.
+GCS. Self-healing runs on the **`gestaltd app publish` write path** (CI and
+manual publishes), which already hold bucket credentials.
 
 A shared `PrunePendingIndex` helper removes stuck entries from `pending.json`
 before any pending mutation. Prune criteria for each `pending.{version}` entry:
@@ -102,27 +101,28 @@ before any pending mutation. Prune criteria for each `pending.{version}` entry:
 | Condition | Action |
 |-----------|--------|
 | `updatedAt` older than **30 minutes** | Remove — publish likely failed or cleanup never ran |
-| Same `version` already listed in `index.json` | Remove — publish succeeded but `pending end` did not run |
+| Same `version` already listed in `index.json` | Remove — publish succeeded but pending was not cleared |
 | Otherwise | Keep |
 
-The 30-minute threshold applies when `pending begin` runs.
+The 30-minute threshold applies on the first `gestaltd app publish --pending`
+call in a workflow.
 No `stale` field on the app-admin API — stuck rows are removed in GCS instead
 of surfaced as a separate UI state.
 
-`PrunePendingIndex` uses the same optimistic-concurrency loop as `begin` /
-`end`: download `pending.json` generation, drop matching entries, upload with
+`PrunePendingIndex` uses the same optimistic-concurrency loop as pending
+writes: download `pending.json` generation, drop matching entries, upload with
 `if-generation-match`.
 
-**`pending begin`** always prunes before adding the new entry. Every app publish
-workflow self-heals stuck pending rows older than 30 minutes, so orphaned entries
-are cleared on the next merge to `main` for that app.
+The first `gestaltd app publish --pending …` call in a workflow always prunes
+before upserting. Every app publish workflow self-heals stuck pending rows older
+than 30 minutes, so orphaned entries are cleared on the next merge to `main` for
+that app.
 
 Prune is idempotent and safe to run concurrently with an in-flight publish:
 generation-match retries apply. An active publish refreshes `updatedAt` on each
-`begin` / `update`, so a healthy in-flight entry is not removed. Workflows with
-packaging longer than 30 minutes should call `pending update` before the
-threshold elapses to refresh `updatedAt` (the step before `gestaltd app publish`
-already does this when entering the `publishing` phase).
+`--pending` call, so a healthy in-flight entry is not removed. Workflows with
+packaging longer than 30 minutes should run `gestaltd app publish --pending
+publishing` before the threshold elapses (step 4 below).
 
 ---
 
@@ -133,60 +133,82 @@ CI: publish-app-registry.yml
 │
 ├─1. Resolve PACKAGE_VERSION + PROVIDER_REF
 │
-├─2. gestaltd app registry pending begin
+├─2. gestaltd app publish --pending packaging
+│      (same --bucket/--app/--version/--ref/--workflow-run-url flags as step 5)
 │      → PrunePendingIndex (drop entries older than 30m or already in index.json)
 │      → upsert pending.json for this version (phase=packaging)
 │
 ├─3. Package artifacts (may take tens of minutes)
 │
-├─4. gestaltd app registry pending update --phase publishing
+├─4. gestaltd app publish --pending publishing
 │
-├─5. gestaltd app publish (artifacts + versions/{version}.json + index.json)
+├─5. gestaltd app publish --dist-dir … (artifacts + versions/{version}.json + index.json)
+│      → clear this version from pending.json on success
 │
-└─6. gestaltd app registry pending end  (also in failure cleanup)
-       → remove version from pending.json
+└─6. gestaltd app publish --pending clear  (always() failure cleanup)
+       → remove version from pending.json if step 5 did not run
 ```
 
-On **success**, step 6 runs after step 5. The admin UI should briefly show the
-version as published (index) rather than pending. Order within step 5 is
-unchanged: `index.json` is still updated last, but step 6 clears pending
-immediately after so operators never depend on pending lingering post-success.
+Today, `publish-app-registry.yml` already runs step 5 only (`gestaltd app
+publish` with `--dist-dir`). This proposal adds steps 2, 4, and 6 around the
+existing command — no new top-level CLI subcommands.
+
+On **success**, step 5 clears pending after uploading. Order within step 5 is
+unchanged: `index.json` is still updated last.
 
 On **failure**, an `always()` workflow step runs step 6 even when packaging or
 publish failed, so pending does not stick unless the cleanup step itself fails.
 
-### CLI surface (proposal)
+### CLI surface
 
-Add a subcommand group rather than overloading `gestaltd app publish`:
+Extend the existing `gestaltd app publish` command — no `gestaltd app registry`
+subcommands.
+
+**Pending-only** (no `--dist-dir`): write or update `pending.json` only.
 
 ```bash
-gestaltd app registry pending begin \
+# Workflow start — record pending publish (prunes stuck entries first)
+gestaltd app publish \
   --bucket gs://… \
   --app traffic-cop \
   --version 0.0.0-snapshot.g… \
   --ref abc123… \
   --workflow-run-url … \
-  [--trigger-pr-number … --trigger-pr-url …]
+  [--trigger-pr-number … --trigger-pr-url …] \
+  --pending packaging
 
-gestaltd app registry pending update \
+# Before artifact upload — refresh phase / updatedAt
+gestaltd app publish … --pending publishing
+
+# Failure cleanup
+gestaltd app publish … --pending clear
+```
+
+**Full publish** (existing behavior, extended): when `--dist-dir` is set,
+upload artifacts and version metadata, update `index.json`, then remove this
+version from `pending.json`.
+
+```bash
+gestaltd app publish \
   --bucket gs://… \
   --app traffic-cop \
   --version 0.0.0-snapshot.g… \
-  --phase publishing
-
-gestaltd app registry pending end \
-  --bucket gs://… \
-  --app traffic-cop \
-  --version 0.0.0-snapshot.g…
+  --ref abc123… \
+  --dist-dir "${RUNNER_TEMP}/app-dist" \
+  --workflow-run-url … \
+  [publication flags]
 ```
 
-`begin` runs `PrunePendingIndex` before upserting (see [Self-healing](#self-healing)).
-`begin` is idempotent for the same `(app, version)`: refresh `updatedAt` and
-merge `publication` if re-run. `end` is idempotent if the version is already
-absent.
+Manual and CI publishes use the same command. A local run with
+`--workflow-run-url` and `--pending packaging` at the start shows in the admin
+UI the same way as CI.
 
-Implementation reuses the index upload helper (generation-match retries) in
-`gestaltd/internal/daemon/app_publish.go`.
+`--pending` is idempotent for the same `(app, version)`: refresh `updatedAt` and
+merge `publication` if re-run. `--pending clear` is idempotent if the version is
+already absent.
+
+Implementation extends `gestaltd/internal/daemon/app_publish.go` and reuses the
+index upload helper (generation-match retries).
 
 ---
 
@@ -275,13 +297,17 @@ idle.
 In `toolshed` (and any repo using the shared workflow):
 
 1. After `Resolve package inputs` (when `PACKAGE_VERSION` is known), authenticate
-   to GCP and run `gestaltd app registry pending begin` with workflow/PR metadata.
-2. Immediately before `gestaltd app publish`, run `pending update --phase publishing`.
-3. Add a final job step (or `always()` step on the publish job) that runs
-   `gestaltd app registry pending end` for `PACKAGE_VERSION`.
+   to GCP and run `gestaltd app publish --pending packaging` with the same
+   publication flags used in the final publish step.
+2. Immediately before the existing publish step, run
+   `gestaltd app publish --pending publishing`.
+3. Keep the existing `gestaltd app publish --dist-dir …` step (clears pending on
+   success).
+4. Add an `always()` step that runs `gestaltd app publish --pending clear` when
+   the full publish step did not succeed.
 
-The `begin` step needs the gestaltd binary — reuse the existing install step
-ordering (install gestaltd before pending begin).
+Install `gestaltd` before step 1 (today it is installed only in the publish job;
+move or duplicate install earlier so step 2 can run at workflow start).
 
 ---
 
@@ -294,7 +320,7 @@ ordering (install gestaltd before pending begin).
 | Published catalog remains immutable per version | `versions/{version}.json` and artifacts still uploaded with `if-generation-match=0` |
 | Public read stays HTTP GET | Single `pending.json` per app, no bucket listing |
 | Concurrent publishes for one app | Rare; `pending` map holds multiple versions. CI concurrency is per `(app, sha)`; different SHAs produce different version strings |
-| Stuck pending rows are removed | `PrunePendingIndex` on `pending begin`; 30-minute `updatedAt` threshold + already-published checks |
+| Stuck pending rows are removed | `PrunePendingIndex` on first `gestaltd app publish --pending`; 30-minute `updatedAt` threshold + already-published checks |
 
 ---
 
@@ -302,14 +328,17 @@ ordering (install gestaltd before pending begin).
 
 1. **Models** — Add `PendingIndex` / `PendingVersion` to
    `gestaltd/internal/appregistry/`; document in [models.md](./models.md).
-2. **Write path** — `gestaltd app registry pending begin|update|end` with
-   generation-match retries (mirror index upsert). `begin` calls
-   `PrunePendingIndex`.
+2. **Write path** — extend `gestaltd app publish` with `--pending
+   packaging|publishing|clear`; generation-match retries (mirror index upsert).
+   First `--pending` call calls `PrunePendingIndex`; full publish clears pending
+   on success.
 3. **Read path** — `FetchPendingIndex`; unit tests with `registrytest` HTTP
    fixture.
 4. **App-admin API** — extend `getAppAdminRegistry` with `pendingVersions`.
 5. **UI** — pending rows + polling in `gestalt-providers` app admin table.
-6. **CI** — wire `publish-app-registry.yml` begin/update/end steps.
+6. **CI** — extend `publish-app-registry.yml` with early `--pending packaging`,
+   pre-upload `--pending publishing`, and failure `--pending clear` around the
+   existing `gestaltd app publish --dist-dir` step.
 7. **Tests** — see [tests.md](./tests.md) (add section when implementing).
 
 Suggested order: 1 → 2 → 3 → 4 → 6 (CI can ship begin/end before UI) → 5.
@@ -320,11 +349,19 @@ Suggested order: 1 → 2 → 3 → 4 → 6 (CI can ship begin/end before UI) →
 
 1. **Phase granularity** — Is `packaging` / `publishing` enough, or do we want
    per-platform sub-phases in v1?
-2. **Manual publish** — Should `gestaltd app publish` call `pending begin/end`
-   automatically when `--workflow-run-url` is set, so local/manual publishes
-   also appear in the admin UI?
-3. **Embedded `/admin`** — Should the fleet observability app list show a
+2. **Embedded `/admin`** — Should the fleet observability app list show a
    “publishing” indicator, or only the app-scoped `/apps/{app}/admin` page?
+
+## Decisions
+
+**CLI surface:** Extend `gestaltd app publish` only — no `gestaltd app registry`
+subcommands. CI and manual publishes use the same command.
+
+**Workflow start:** `publish-app-registry.yml` should call
+`gestaltd app publish --pending packaging` as early as possible (once
+`PACKAGE_VERSION`, GCP auth, and `gestaltd` are available), not only at the end
+when artifacts are ready. The final `gestaltd app publish --dist-dir …` step is
+unchanged and already what auto-publish uses today.
 
 ---
 

--- a/plans/app_registry/pending-publish.md
+++ b/plans/app_registry/pending-publish.md
@@ -6,7 +6,7 @@ is updated at the end of CI.
 Related docs:
 
 - [plan.md](./plan.md) — registry goals and implementation path
-- [models.md](./models.md) — index and published version JSON
+- [models.md](./models.md) — registry JSON documents, including [PendingIndex](./models.md#pendingindex)
 - [admin.md](./admin.md) — app admin UI capabilities
 - [service.md](./service.md) — Go publish/read helpers
 - [lifecycle.md](./lifecycle.md) — app-admin HTTP API
@@ -78,61 +78,12 @@ matches how `index.json` is already fetched.
 
 ---
 
-## `pending.json` model
+## PendingIndex
 
-**Path:** `apps/{app}/pending.json`
+`pending.json` document shape, fields, and example:
+[models.md — PendingIndex](./models.md#pendingindex).
 
-Answers: *which versions are currently being published for this app, and what
-provenance is known so far?*
-
-```json
-{
-  "schemaVersion": 1,
-  "app": "traffic-cop",
-  "pending": {
-    "0.0.0-snapshot.gabc123def456abc123def456abc123def456abcd": {
-      "version": "0.0.0-snapshot.gabc123def456abc123def456abc123def456abcd",
-      "sourceRef": "abc123def456abc123def456abc123def456abcd",
-      "repository": "github.com/valon-technologies/toolshed",
-      "startedAt": "2026-07-24T19:00:00Z",
-      "updatedAt": "2026-07-24T19:04:12Z",
-      "phase": "packaging",
-      "publication": {
-        "workflowRunUrl": "https://github.com/valon-technologies/toolshed/actions/runs/123456789",
-        "triggerPullRequest": {
-          "number": 3740,
-          "url": "https://github.com/valon-technologies/toolshed/pull/3740",
-          "title": "Wire traffic-cop to app registry"
-        }
-      }
-    }
-  }
-}
-```
-
-### Fields
-
-#### Root · `PendingIndex`
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `schemaVersion` | int | yes | Document format version. Start at `1`. |
-| `app` | string | yes | App name. Must match the `{app}` path segment. |
-| `pending` | map | yes | Version string → `PendingVersion`. Empty map when idle. |
-
-#### `pending.{version}` · `PendingVersion`
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `version` | string | yes | Snapshot version being published (same semver rules as published versions). |
-| `sourceRef` | string | yes | Commit SHA the publish is building from. |
-| `repository` | string | no | Source repository URL/host path. |
-| `startedAt` | RFC 3339 timestamp | yes | When the pending record was created (UTC). |
-| `updatedAt` | RFC 3339 timestamp | yes | Last phase or metadata update (UTC). |
-| `phase` | string | yes | `packaging` or `publishing`. See phases below. |
-| `publication` | object | no | Same `Publication` shape as [models.md](./models.md). Written at pending start so the UI can link the workflow run immediately. |
-
-#### Phases
+### Phases
 
 | Phase | Meaning |
 |-------|---------|
@@ -143,7 +94,7 @@ Do not add a `failed` phase in GCS for v1. On failure, **remove** the pending
 entry in a workflow `always()` cleanup step. The workflow run URL remains the
 failure audit trail.
 
-#### Stale pending (read path)
+### Stale pending (read path)
 
 If CI crashes before cleanup, a pending row can linger in `pending.json`.
 Readers treat a pending entry as **stale** when `updatedAt` is older than a
@@ -153,7 +104,7 @@ rows; the UI shows **Publishing (stale)** and still links the workflow run.
 Stale labeling is for operator visibility only. It does not remove the GCS
 entry — see [Self-healing](#self-healing) below.
 
-#### Self-healing
+### Self-healing
 
 `gestaltd serve` reads `pending.json` over public HTTP and cannot write back to
 GCS. Self-healing therefore runs on the **publish write path** (CI and

--- a/plans/app_registry/pending-publish.md
+++ b/plans/app_registry/pending-publish.md
@@ -71,11 +71,6 @@ apps/{app}/
 release object. Use the same optimistic-concurrency update pattern as index
 writes: read generation, merge, upload with `if-generation-match`.
 
-Alternative considered: one object per pending version at
-`apps/{app}/pending/{version}.json`. Rejected for v1 because the public HTTP
-reader cannot list a prefix without object names. A single `pending.json`
-matches how `index.json` is already fetched.
-
 ---
 
 ## PendingIndex

--- a/plans/app_registry/pending-publish.md
+++ b/plans/app_registry/pending-publish.md
@@ -1,0 +1,376 @@
+# Pending Publish Visibility
+
+Show in-flight app registry publishes on `/apps/{app}/admin` before `index.json`
+is updated at the end of CI.
+
+Related docs:
+
+- [plan.md](./plan.md) — registry goals and implementation path
+- [models.md](./models.md) — index and published version JSON
+- [admin.md](./admin.md) — app admin UI capabilities
+- [service.md](./service.md) — Go publish/read helpers
+- [lifecycle.md](./lifecycle.md) — app-admin HTTP API
+
+---
+
+## Problem
+
+Today the **Published snapshots** table only reflects versions listed in
+`apps/{app}/index.json`. That file is updated as the **last** step of
+`gestaltd app publish`, after packaging and artifact upload complete.
+
+During CI (`publish-app-registry.yml`), operators see nothing on the admin page
+while a publish is running — even though the version string and workflow run are
+already known. There is no registry signal between “workflow started” and
+“index updated”.
+
+Fleet deploy state (`desiredVersion`, rollout) lives in IndexedDB and is
+unrelated to publish progress. Pending publish visibility is a **registry read**
+concern only.
+
+---
+
+## Goals
+
+Operators on `/apps/{app}/admin` should be able to answer:
+
+| Question | Surface |
+|----------|---------|
+| Is a new snapshot being published right now? | Row with status **Publishing** |
+| Which commit / PR triggered it? | Pending row provenance (same fields as published rows where available) |
+| Where is the CI run? | Link to `publication.workflowRunUrl` |
+| When did publish start? | `startedAt` on the pending row |
+
+Non-goals for this change:
+
+- Installing or deploying a pending version (must remain impossible)
+- Replacing GitHub Actions as the source of live step-level CI progress
+- Storing pending state in IndexedDB
+- Changing when `index.json` is updated (still last, on success only)
+
+---
+
+## Design summary
+
+Add a small **pending catalog** document in GCS per app. CI writes it when a
+publish starts and removes the entry when the publish finishes (success or
+failure). `gestaltd` reads it alongside `index.json` and exposes pending rows
+through the existing app-admin registry API. The UI merges pending and
+published rows in the snapshots table.
+
+Pending versions are **not** installable. Install-time validation continues to
+read only `versions/{version}.json` via the published index contract.
+
+---
+
+## GCS layout
+
+Extend the per-app registry tree:
+
+```text
+apps/{app}/
+├── index.json
+├── pending.json          # new — in-flight publishes for this app
+├── versions/
+│   └── {version}.json
+└── artifacts/
+    └── {version}/
+        └── …
+```
+
+`pending.json` is a mutable catalog (like `index.json`), not an immutable
+release object. Use the same optimistic-concurrency update pattern as index
+writes: read generation, merge, upload with `if-generation-match`.
+
+Alternative considered: one object per pending version at
+`apps/{app}/pending/{version}.json`. Rejected for v1 because the public HTTP
+reader cannot list a prefix without object names. A single `pending.json`
+matches how `index.json` is already fetched.
+
+---
+
+## `pending.json` model
+
+**Path:** `apps/{app}/pending.json`
+
+Answers: *which versions are currently being published for this app, and what
+provenance is known so far?*
+
+```json
+{
+  "schemaVersion": 1,
+  "app": "traffic-cop",
+  "pending": {
+    "0.0.0-snapshot.gabc123def456abc123def456abc123def456abcd": {
+      "version": "0.0.0-snapshot.gabc123def456abc123def456abc123def456abcd",
+      "sourceRef": "abc123def456abc123def456abc123def456abcd",
+      "repository": "github.com/valon-technologies/toolshed",
+      "startedAt": "2026-07-24T19:00:00Z",
+      "updatedAt": "2026-07-24T19:04:12Z",
+      "phase": "packaging",
+      "publication": {
+        "workflowRunUrl": "https://github.com/valon-technologies/toolshed/actions/runs/123456789",
+        "triggerPullRequest": {
+          "number": 3740,
+          "url": "https://github.com/valon-technologies/toolshed/pull/3740",
+          "title": "Wire traffic-cop to app registry"
+        }
+      }
+    }
+  }
+}
+```
+
+### Fields
+
+#### Root · `PendingIndex`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `schemaVersion` | int | yes | Document format version. Start at `1`. |
+| `app` | string | yes | App name. Must match the `{app}` path segment. |
+| `pending` | map | yes | Version string → `PendingVersion`. Empty map when idle. |
+
+#### `pending.{version}` · `PendingVersion`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `version` | string | yes | Snapshot version being published (same semver rules as published versions). |
+| `sourceRef` | string | yes | Commit SHA the publish is building from. |
+| `repository` | string | no | Source repository URL/host path. |
+| `startedAt` | RFC 3339 timestamp | yes | When the pending record was created (UTC). |
+| `updatedAt` | RFC 3339 timestamp | yes | Last phase or metadata update (UTC). |
+| `phase` | string | yes | `packaging` or `publishing`. See phases below. |
+| `publication` | object | no | Same `Publication` shape as [models.md](./models.md). Written at pending start so the UI can link the workflow run immediately. |
+
+#### Phases
+
+| Phase | Meaning |
+|-------|---------|
+| `packaging` | `gestaltd provider package` / artifact build in progress. Pending record created at workflow start. |
+| `publishing` | Artifacts built; `gestaltd app publish` upload + index update in progress. Set immediately before the publish step. |
+
+Do not add a `failed` phase in GCS for v1. On failure, **remove** the pending
+entry in a workflow `always()` cleanup step. The workflow run URL remains the
+failure audit trail.
+
+#### Stale pending
+
+If CI crashes before cleanup, a pending row can linger. Readers should treat a
+pending entry as **stale** when `updatedAt` is older than a fixed TTL (proposal:
+**6 hours**). The API exposes `stale: true` on pending rows; the UI shows
+**Publishing (stale)** and still links the workflow run. A later successful
+publish for the same version removes the pending entry and adds the index row as
+today.
+
+---
+
+## Publish lifecycle
+
+```text
+CI: publish-app-registry.yml
+│
+├─1. Resolve PACKAGE_VERSION + PROVIDER_REF
+│
+├─2. gestaltd app registry pending begin
+│      → upsert pending.json (phase=packaging)
+│
+├─3. Package artifacts (may take tens of minutes)
+│
+├─4. gestaltd app registry pending update --phase publishing
+│
+├─5. gestaltd app publish (artifacts + versions/{version}.json + index.json)
+│
+└─6. gestaltd app registry pending end  (also in failure cleanup)
+       → remove version from pending.json
+```
+
+On **success**, step 6 runs after step 5. The admin UI should briefly show the
+version as published (index) rather than pending. Order within step 5 is
+unchanged: `index.json` is still updated last, but step 6 clears pending
+immediately after so operators never depend on pending lingering post-success.
+
+On **failure**, an `always()` workflow step runs step 6 even when packaging or
+publish failed, so pending does not stick unless the cleanup step itself fails.
+
+### CLI surface (proposal)
+
+Add a subcommand group rather than overloading `gestaltd app publish`:
+
+```bash
+gestaltd app registry pending begin \
+  --bucket gs://… \
+  --app traffic-cop \
+  --version 0.0.0-snapshot.g… \
+  --ref abc123… \
+  --workflow-run-url … \
+  [--trigger-pr-number … --trigger-pr-url …]
+
+gestaltd app registry pending update \
+  --bucket gs://… \
+  --app traffic-cop \
+  --version 0.0.0-snapshot.g… \
+  --phase publishing
+
+gestaltd app registry pending end \
+  --bucket gs://… \
+  --app traffic-cop \
+  --version 0.0.0-snapshot.g…
+```
+
+`begin` is idempotent for the same `(app, version)`: refresh `updatedAt` and
+merge `publication` if re-run. `end` is idempotent if the version is already
+absent.
+
+Implementation reuses the index upload helper (generation-match retries) in
+`gestaltd/internal/daemon/app_publish.go`.
+
+---
+
+## Read path
+
+### `RegistryReader`
+
+Add:
+
+```go
+func (r *RegistryReader) FetchPendingIndex(ctx context.Context, publicRoot, appName string) (*PendingIndex, error)
+```
+
+- HTTP GET `apps/{app}/pending.json`
+- Missing object → empty pending index (same as missing `index.json`)
+- Decode + validate `schemaVersion`
+
+### App-admin API
+
+Extend `GET /api/v1/apps/{app}/admin/registry` response:
+
+```json
+{
+  "app": "traffic-cop",
+  "registry": "toolshed",
+  "desiredVersion": "0.0.0-snapshot.g…",
+  "knownVersions": [ … ],
+  "publishedVersions": [ … ],
+  "pendingVersions": [
+    {
+      "version": "0.0.0-snapshot.g…",
+      "startedAt": "2026-07-24T19:00:00Z",
+      "updatedAt": "2026-07-24T19:04:12Z",
+      "phase": "packaging",
+      "sourceRef": "abc123…",
+      "sourceUrl": "https://github.com/…/commit/abc123…",
+      "publication": { … },
+      "stale": false
+    }
+  ],
+  "rollout": { … },
+  "selectionDisabled": false
+}
+```
+
+Merge rules:
+
+- A version MUST NOT appear in both `pendingVersions` and `publishedVersions`.
+  If both exist (race between index update and pending end), prefer **published**
+  and omit pending.
+- `pendingVersions` sorted by `startedAt` descending (newest first), matching
+  published sort order.
+
+Install and upgrade handlers ignore `pending.json` entirely.
+
+---
+
+## UI changes (`/apps/{app}/admin`)
+
+Update the snapshots table to render **pending** rows above published rows (or
+interleaved by `startedAt` / `publishedAt` — prefer single newest-first list
+with a status column).
+
+| Status | Condition |
+|--------|-----------|
+| **Publishing** | Row from `pendingVersions`, `stale=false` |
+| **Publishing (stale)** | Row from `pendingVersions`, `stale=true` |
+| **Deployed** | `version === desiredVersion` (unchanged) |
+| **Rolling out** | Active rollout for this version (unchanged) |
+| **Available** | Published, not desired (unchanged) |
+
+Pending rows:
+
+- Show PR / commit provenance when present (same columns as published)
+- **Published** column shows “In progress” or time since `startedAt`
+- **Action** column: Deploy disabled; optional “View workflow” link using
+  `publication.workflowRunUrl`
+- No deploy button for pending versions
+
+Polling: extend `AppAdminPageClient` to poll every **12s** while
+`pendingVersions.length > 0`, not only during fleet rollout. Stop polling when
+idle.
+
+---
+
+## CI changes (`publish-app-registry.yml`)
+
+In `toolshed` (and any repo using the shared workflow):
+
+1. After `Resolve package inputs` (when `PACKAGE_VERSION` is known), authenticate
+   to GCP and run `gestaltd app registry pending begin` with workflow/PR metadata.
+2. Immediately before `gestaltd app publish`, run `pending update --phase publishing`.
+3. Add a final job step (or `always()` step on the publish job) that runs
+   `gestaltd app registry pending end` for `PACKAGE_VERSION`.
+
+The `begin` step needs the gestaltd binary — reuse the existing install step
+ordering (install gestaltd before pending begin).
+
+---
+
+## Safety and invariants
+
+| Invariant | Enforcement |
+|-----------|-------------|
+| Pending versions are not installable | `Installer` / `InstallValidator` only read `versions/{version}.json` reached via published index entries |
+| Pending does not affect fleet state | No IndexedDB writes |
+| Published catalog remains immutable per version | `versions/{version}.json` and artifacts still uploaded with `if-generation-match=0` |
+| Public read stays HTTP GET | Single `pending.json` per app, no bucket listing |
+| Concurrent publishes for one app | Rare; `pending` map holds multiple versions. CI concurrency is per `(app, sha)`; different SHAs produce different version strings |
+
+---
+
+## Implementation path
+
+1. **Models** — Add `PendingIndex` / `PendingVersion` to
+   `gestaltd/internal/appregistry/`; document in [models.md](./models.md).
+2. **Write path** — `gestaltd app registry pending begin|update|end` with
+   generation-match retries (mirror index upsert).
+3. **Read path** — `FetchPendingIndex`; unit tests with `registrytest` HTTP
+   fixture.
+4. **App-admin API** — extend `getAppAdminRegistry`; stale TTL in handler.
+5. **UI** — pending rows + polling in `gestalt-providers` app admin table.
+6. **CI** — wire `publish-app-registry.yml` begin/update/end steps.
+7. **Tests** — see [tests.md](./tests.md) (add section when implementing).
+
+Suggested order: 1 → 2 → 3 → 4 → 6 (CI can ship begin/end before UI) → 5.
+
+---
+
+## Open questions
+
+1. **TTL** — Is 6 hours the right stale threshold, or should stale pending hide
+   after 24h?
+2. **Phase granularity** — Is `packaging` / `publishing` enough, or do we want
+   per-platform sub-phases in v1?
+3. **Manual publish** — Should `gestaltd app publish` call `pending begin/end`
+   automatically when `--workflow-run-url` is set, so local/manual publishes
+   also appear in the admin UI?
+4. **Embedded `/admin`** — Should the fleet observability app list show a
+   “publishing” indicator, or only the app-scoped `/apps/{app}/admin` page?
+
+---
+
+## Future work
+
+- Failed publish retention: optional `apps/{app}/failed/{version}.json` with
+  `failedAt` and `reason` instead of only relying on GitHub Actions history.
+- Global pending index across apps for a registry-wide dashboard.
+- Webhook or Pub/Sub on `index.json` change to push updates to the UI instead
+  of polling.

--- a/plans/app_registry/pending-publish.md
+++ b/plans/app_registry/pending-publish.md
@@ -36,8 +36,8 @@ Operators on `/apps/{app}/admin` should be able to answer:
 | Which commit / PR triggered it? | Pending entry provenance (same fields as published rows where available) |
 | Where is the CI run? | Link to `publication.workflowRunUrl` |
 | When did publish start? | `startedAt` on the pending entry |
-| How long has publish been running? | Elapsed time since `startedAt` on **Publishing** rows |
-| How long did publish take? | `publishedAt − publishStartedAt` on published rows; `failedAt − startedAt` on **Failed** rows |
+| How long has publish been running? | Elapsed time from `startedAt` on **Publishing** rows |
+| How long did publish take? | Total publish time on published and **Failed** rows |
 | Did a recent publish fail? | Row with status **Failed** and `failedAt` |
 | Why did it fail? | `reason` on the failed entry (`workflow_failed` or `stale`) |
 
@@ -57,31 +57,36 @@ Add mutable `pending.json` and `failed.json` catalogs in GCS per app.
 
 `gestaltd` reads both catalogs alongside `index.json` and exposes them through
 the app-admin registry API. The UI merges pending, failed, and published entries
-in the snapshots table and shows publish duration while in flight and after
-completion.
-
-### Publish duration
-
-Track how long a publish takes end to end:
-
-| State | Start anchor | End anchor | Display |
-|-------|--------------|------------|---------|
-| **Publishing** | `pending.startedAt` | now (UI clock) | “Publishing for 4m” |
-| **Published** | `publishStartedAt` | `publishedAt` | “Published in 4m 32s” |
-| **Failed** | `failed.startedAt` | `failed.failedAt` | “Failed after 35m” |
-
-`publishStartedAt` is written at upload time. `gestaltd app registry publish`
-reads the matching pending entry (if present) and copies `startedAt` into
-`publishStartedAt` on `versions/{version}.json` and `index.json`. When CI
-skipped `pending set`, or for legacy publishes, `publishStartedAt` is omitted and
-the UI shows only `publishedAt`.
-
-Duration is derived from timestamps — do not store a separate duration field in
-GCS.
+in the snapshots table.
 
 Pending and failed versions are **not** installable. Install-time validation
 continues to read only `versions/{version}.json` via the published index
 contract.
+
+---
+
+## Publish duration
+
+Show how long a publish has been running and how long it took to complete.
+Durations are derived from timestamps at read/UI time — not stored as separate
+GCS fields. Field definitions: [`publishStartedAt`](./models.md#publishedversion).
+
+| Row status | Start timestamp | End timestamp | UI label |
+|------------|-----------------|---------------|----------|
+| **Publishing** | `startedAt` | now | Publishing for 4m |
+| **Available** / **Deployed** | `publishStartedAt` | `publishedAt` | Published in 4m 32s |
+| **Failed** | `startedAt` | `failedAt` | Failed after 35m |
+
+`gestaltd app registry publish` reads `pending.json` when present and copies
+`PendingVersion.startedAt` into `publishStartedAt` on `versions/{version}.json`
+and `index.json`. CI publishes always run `pending set` first, so new registry
+entries include `publishStartedAt`. The field is **not required in the JSON
+schema** so readers tolerate legacy entries and manual publishes that skipped
+`pending set`; the UI shows `publishedAt` only when the start timestamp is absent.
+
+The app-admin API may include `publishingForSeconds` on pending rows and
+`publishDurationSeconds` on published and failed rows. Omit these fields when the
+start timestamp is missing.
 
 ---
 
@@ -323,24 +328,12 @@ Extend `GET /api/v1/apps/{app}/admin/registry` response:
   "registry": "toolshed",
   "desiredVersion": "0.0.0-snapshot.g…",
   "knownVersions": [ … ],
-  "publishedVersions": [
-    {
-      "version": "0.0.0-snapshot.g…",
-      "publishedAt": "2026-07-24T19:04:32Z",
-      "publishStartedAt": "2026-07-24T19:00:00Z",
-      "publishDurationSeconds": 272,
-      "platforms": ["linux/amd64"],
-      "sourceRef": "abc123…",
-      "sourceUrl": "https://github.com/…/commit/abc123…",
-      "publication": { … }
-    }
-  ],
+  "publishedVersions": [ … ],
   "pendingVersions": [
     {
       "version": "0.0.0-snapshot.g…",
       "startedAt": "2026-07-24T19:00:00Z",
       "updatedAt": "2026-07-24T19:04:12Z",
-      "publishingForSeconds": 252,
       "phase": "publishing",
       "sourceRef": "abc123…",
       "sourceUrl": "https://github.com/…/commit/abc123…",
@@ -352,7 +345,6 @@ Extend `GET /api/v1/apps/{app}/admin/registry` response:
       "version": "0.0.0-snapshot.g…",
       "startedAt": "2026-07-24T18:00:00Z",
       "failedAt": "2026-07-24T18:35:00Z",
-      "publishDurationSeconds": 2100,
       "reason": "stale",
       "sourceRef": "abc123…",
       "sourceUrl": "https://github.com/…/commit/abc123…",
@@ -371,9 +363,8 @@ Merge rules:
   cleanup), prefer **published** and omit pending and failed.
 - `pendingVersions` sorted by `startedAt` descending (newest first).
 - `failedVersions` sorted by `failedAt` descending (newest first).
-- `publishingForSeconds` on `pendingVersions` and `publishDurationSeconds` on
-  `publishedVersions` / `failedVersions` are computed at read time from the
-  timestamps above. Omit duration fields when the start anchor is missing.
+- Published rows may include `publishStartedAt`. Pending, published, and failed
+  rows may include computed duration fields. See [Publish duration](#publish-duration).
 
 Install and upgrade handlers ignore `pending.json` and `failed.json` entirely.
 
@@ -395,23 +386,20 @@ published entries (single newest-first list with a status column).
 Pending entries:
 
 - Show PR / commit provenance when present (same columns as published)
-- **Published** column shows elapsed publish time (for example “Publishing for
-  4m”) from `publishingForSeconds` or `startedAt`
+- **Published** column shows elapsed publish time from `startedAt`
 - **Action** column: Deploy disabled; optional “View workflow” link using
   `publication.workflowRunUrl`
-
-Published entries:
-
-- When `publishStartedAt` is present, show total publish time (for example
-  “Published in 4m 32s”) alongside `publishedAt`
-- Legacy rows without `publishStartedAt` show `publishedAt` only
 
 Failed entries:
 
 - Show PR / commit provenance when present
-- **Published** column shows `failedAt`, total time before failure (for example
-  “Failed after 35m”), and a reason label (`workflow_failed` → “Workflow
-  failed”, `stale` → “Timed out”)
+- **Published** column shows `failedAt`, total time before failure, and a reason
+  label (`workflow_failed` → “Workflow failed”, `stale` → “Timed out”)
+- **Action** column: Deploy disabled; “View workflow” when
+  `publication.workflowRunUrl` is present
+
+Published entries without `publishStartedAt` show `publishedAt` only. See
+[Publish duration](#publish-duration) for timing labels on all row types.
 
 Polling: extend `AppAdminPageClient` to poll every **12s** while
 `pendingVersions.length > 0` or `failedVersions.length > 0`, not only during
@@ -469,9 +457,9 @@ Add types and CLI first so CI can call the new commands.
 
 - Add `PendingIndex` / `PendingVersion` and `FailedIndex` / `FailedVersion` to
   `gestaltd/internal/appregistry/` ([models.md](./models.md) documents shapes).
-- Add optional `publishStartedAt` to `IndexVersion`, `PublishedVersion`, and the
-  publish upload path (read `pending.json` at publish time; do not mutate
-  pending).
+- Add `publishStartedAt` to `IndexVersion` and `PublishedVersion`. Set it in
+  `gestaltd app registry publish` by reading `pending.json` at upload time (do
+  not mutate pending). See [Publish duration](#publish-duration).
 - Add `gestaltd app registry pending set|clear|fail` and
   `gestaltd app registry publish` (move logic from `gestaltd app publish`).
 - `pending set` calls `PrunePendingIndex` and `PruneFailedIndex` before
@@ -487,8 +475,7 @@ Depends on **PR 1**. Exposes pending and failed catalog state to the admin page.
 
 - `FetchPendingIndex` and `FetchFailedIndex` in `gestaltd/internal/appregistry/`.
 - Extend `getAppAdminRegistry` with `pendingVersions[]` and `failedVersions[]`.
-- Include `publishStartedAt` on published rows and compute
-  `publishingForSeconds` / `publishDurationSeconds` at read time.
+- Expose `publishStartedAt` and computed duration fields per [Publish duration](#publish-duration).
 - Tests: fetch helpers via `registrytest` HTTP fixture; handler returns pending
   and failed entries alongside published. Extend [tests.md](./tests.md).
 
@@ -511,7 +498,7 @@ operators get correct GCS state before the UI exists.
 Depends on **PR 2**. Completes admin visibility.
 
 - **Publishing** and **Failed** rows in the `gestalt-providers` app admin
-  snapshots table, with elapsed and total publish duration labels.
+  snapshots table. Timing labels per [Publish duration](#publish-duration).
 - Poll every ~12s while any pending or failed version exists; prefer published
   entry when the same version appears in multiple lists.
 - Manual / browser smoke per [tests.md](./tests.md) when implementing.
@@ -540,6 +527,5 @@ on `pending set`. Stale pending (30 minutes without `updatedAt` refresh) records
 `gestaltd app registry pending set` as early as possible (once `PACKAGE_VERSION`,
 GCP auth, and `gestaltd` are available), not only when artifacts are ready.
 
-**Publish duration:** `publishStartedAt` is copied from pending at publish time
-and stored on published registry objects. Durations are derived at read/UI time,
-not stored as separate GCS fields.
+**Publish duration:** `publishStartedAt` on published registry objects; elapsed
+and total time derived at read/UI time. See [Publish duration](#publish-duration).

--- a/plans/app_registry/pending-publish.md
+++ b/plans/app_registry/pending-publish.md
@@ -105,44 +105,17 @@ before any pending mutation. Prune criteria for each `pending.{version}` entry:
 | Same `version` already listed in `index.json` | Remove — publish succeeded but `pending end` did not run |
 | Otherwise | Keep |
 
-The 30-minute threshold is the default for `pending begin` and `pending prune`.
+The 30-minute threshold applies when `pending begin` runs.
 No `stale` field on the app-admin API — stuck rows are removed in GCS instead
 of surfaced as a separate UI state.
 
-Prune uses the same optimistic-concurrency loop as `begin` / `end`: download
-`pending.json` generation, drop matching entries, upload with
+`PrunePendingIndex` uses the same optimistic-concurrency loop as `begin` /
+`end`: download `pending.json` generation, drop matching entries, upload with
 `if-generation-match`.
 
-**When prune runs:**
-
-1. **`pending begin`** — always prune before adding the new entry. Every app
-   publish workflow self-heals stuck pending rows older than 30 minutes, so
-   orphaned entries are cleared on the next merge to `main` for that app.
-2. **`pending prune`** (new subcommand) — explicit sweep for one app or all
-   enrolled apps. Used by a scheduled CI workflow and for manual operator cleanup.
-
-```bash
-# Prune one app (typical scheduled / manual use)
-gestaltd app registry pending prune \
-  --bucket gs://… \
-  --app traffic-cop \
-  [--max-age 30m]
-
-# Prune every app that has a pending.json object (optional scheduled job)
-gestaltd app registry pending prune \
-  --bucket gs://… \
-  --all-apps \
-  [--max-age 30m]
-```
-
-`--all-apps` lists `apps/*/pending.json` via the GCS API (publisher credentials
-only; not used by `gestaltd serve`). For each object, load the sibling
-`index.json`, apply the prune rules, and upload only when the pending map changed.
-
-**Scheduled janitor (recommended):** add a workflow in `toolshed` that runs
-`pending prune --all-apps` on a cadence shorter than the 30-minute threshold
-(e.g. every 15 minutes) so stuck entries are removed even when an app has not
-published recently.
+**`pending begin`** always prunes before adding the new entry. Every app publish
+workflow self-heals stuck pending rows older than 30 minutes, so orphaned entries
+are cleared on the next merge to `main` for that app.
 
 Prune is idempotent and safe to run concurrently with an in-flight publish:
 generation-match retries apply. An active publish refreshes `updatedAt` on each
@@ -204,12 +177,6 @@ gestaltd app registry pending end \
   --bucket gs://… \
   --app traffic-cop \
   --version 0.0.0-snapshot.g…
-
-gestaltd app registry pending prune \
-  --bucket gs://… \
-  --app traffic-cop \
-  [--all-apps] \
-  [--max-age 30m]
 ```
 
 `begin` prunes stuck entries before upserting (see [Self-healing](#self-healing)).
@@ -315,10 +282,6 @@ In `toolshed` (and any repo using the shared workflow):
 The `begin` step needs the gestaltd binary — reuse the existing install step
 ordering (install gestaltd before pending begin).
 
-**Janitor:** add a scheduled workflow (e.g. every 15 minutes) that runs
-`gestaltd app registry pending prune --all-apps` so stuck entries older than
-30 minutes are removed even when an app has not published recently.
-
 ---
 
 ## Safety and invariants
@@ -330,7 +293,7 @@ ordering (install gestaltd before pending begin).
 | Published catalog remains immutable per version | `versions/{version}.json` and artifacts still uploaded with `if-generation-match=0` |
 | Public read stays HTTP GET | Single `pending.json` per app, no bucket listing |
 | Concurrent publishes for one app | Rare; `pending` map holds multiple versions. CI concurrency is per `(app, sha)`; different SHAs produce different version strings |
-| Stuck pending rows are removed | `PrunePendingIndex` on `pending begin` and `pending prune`; 30-minute `updatedAt` threshold + already-published checks |
+| Stuck pending rows are removed | `PrunePendingIndex` on `pending begin`; 30-minute `updatedAt` threshold + already-published checks |
 
 ---
 
@@ -338,15 +301,14 @@ ordering (install gestaltd before pending begin).
 
 1. **Models** — Add `PendingIndex` / `PendingVersion` to
    `gestaltd/internal/appregistry/`; document in [models.md](./models.md).
-2. **Write path** — `gestaltd app registry pending begin|update|end|prune` with
-   generation-match retries (mirror index upsert). `begin` and `prune` call
+2. **Write path** — `gestaltd app registry pending begin|update|end` with
+   generation-match retries (mirror index upsert). `begin` calls
    `PrunePendingIndex`.
 3. **Read path** — `FetchPendingIndex`; unit tests with `registrytest` HTTP
    fixture.
 4. **App-admin API** — extend `getAppAdminRegistry` with `pendingVersions`.
 5. **UI** — pending rows + polling in `gestalt-providers` app admin table.
-6. **CI** — wire `publish-app-registry.yml` begin/update/end steps; add scheduled
-   `pending prune --all-apps` janitor workflow.
+6. **CI** — wire `publish-app-registry.yml` begin/update/end steps.
 7. **Tests** — see [tests.md](./tests.md) (add section when implementing).
 
 Suggested order: 1 → 2 → 3 → 4 → 6 (CI can ship begin/end before UI) → 5.
@@ -362,8 +324,6 @@ Suggested order: 1 → 2 → 3 → 4 → 6 (CI can ship begin/end before UI) →
    also appear in the admin UI?
 3. **Embedded `/admin`** — Should the fleet observability app list show a
    “publishing” indicator, or only the app-scoped `/apps/{app}/admin` page?
-4. **Janitor cadence** — Is every 15 minutes sufficient for `pending prune
-   --all-apps`, or should it run more frequently?
 
 ---
 

--- a/plans/app_registry/pending-publish.md
+++ b/plans/app_registry/pending-publish.md
@@ -93,8 +93,8 @@ failure audit trail.
 ### Self-healing
 
 `gestaltd serve` reads `pending.json` over public HTTP and cannot write back to
-GCS. Self-healing runs on the **`gestaltd app registry publish` write path** (CI and
-manual publishes), which already hold bucket credentials.
+GCS. Self-healing runs on the **`gestaltd app registry pending` write path** (CI),
+which already holds bucket credentials.
 
 A shared `PrunePendingIndex` helper removes stuck entries from `pending.json`
 before any pending mutation. Prune criteria for each `pending.{version}` entry:
@@ -105,8 +105,7 @@ before any pending mutation. Prune criteria for each `pending.{version}` entry:
 | Same `version` already listed in `index.json` | Remove — publish succeeded but pending was not cleared |
 | Otherwise | Keep |
 
-The 30-minute threshold applies on the first `gestaltd app registry publish
---pending publishing` call in a workflow.
+The 30-minute threshold applies on `gestaltd app registry pending set`.
 No `stale` field on the app-admin API — stuck rows are removed in GCS instead
 of surfaced as a separate UI state.
 
@@ -114,14 +113,12 @@ of surfaced as a separate UI state.
 writes: download `pending.json` generation, drop matching entries, upload with
 `if-generation-match`.
 
-The first `gestaltd app registry publish --pending publishing` call in a
-workflow always prunes before upserting. Every app publish workflow self-heals stuck pending rows older
-than 30 minutes, so orphaned entries are cleared on the next merge to `main` for
-that app.
+`gestaltd app registry pending set` always prunes before upserting. Every app
+publish workflow self-heals stuck pending rows older than 30 minutes, so
+orphaned entries are cleared on the next merge to `main` for that app.
 
 Prune is idempotent and safe to run concurrently with an in-flight publish:
-generation-match retries apply. An active publish refreshes `updatedAt` on each
-`--pending publishing` call, so a healthy in-flight entry is not removed.
+generation-match retries apply.
 
 ---
 
@@ -132,7 +129,7 @@ CI: publish-app-registry.yml
 │
 ├─1. Resolve PACKAGE_VERSION + PROVIDER_REF
 │
-├─2. gestaltd app registry publish --pending publishing
+├─2. gestaltd app registry pending set
 │      (same --bucket/--app/--version/--ref/--workflow-run-url flags as step 4)
 │      → PrunePendingIndex (drop entries older than 30m or already in index.json)
 │      → upsert pending.json for this version (phase=publishing)
@@ -142,13 +139,13 @@ CI: publish-app-registry.yml
 ├─4. gestaltd app registry publish --dist-dir … (artifacts + versions/{version}.json + index.json)
 │      → clear this version from pending.json on success
 │
-└─5. gestaltd app registry publish --pending clear  (always() failure cleanup)
+└─5. gestaltd app registry pending clear  (always() failure cleanup)
        → remove version from pending.json if step 4 did not run
 ```
 
 Today, `publish-app-registry.yml` runs `gestaltd app publish --dist-dir …` only.
-This proposal migrates to `gestaltd app registry publish` and adds steps 2 and 5
-for pending visibility (step 2 at workflow start).
+This proposal adds `gestaltd app registry pending` for steps 2 and 5, and migrates
+step 4 to `gestaltd app registry publish`.
 
 On **success**, step 4 clears pending after uploading. Order within step 4 is
 unchanged: `index.json` is still updated last.
@@ -158,37 +155,44 @@ publish failed, so pending does not stick unless the cleanup step itself fails.
 
 ### CLI surface
 
-Introduce `gestaltd app registry publish` to replace `gestaltd app publish`.
-Move publish implementation under `gestaltd app registry`; keep `gestaltd app
-publish` as a deprecated alias during migration, then remove it.
+Introduce two commands under `gestaltd app registry`:
 
 ```text
-gestaltd app registry publish [flags]
+gestaltd app registry pending set|clear
+gestaltd app registry publish
 ```
 
-Flags are unchanged from today's `gestaltd app publish`, plus `--pending
-publishing` and `--pending clear` for pending-only operations.
+`gestaltd app registry publish` replaces `gestaltd app publish` for immutable
+uploads only. `gestaltd app registry pending` owns the mutable `pending.json`
+lifecycle. Keep `gestaltd app publish` as a deprecated alias for `registry
+publish` during migration, then remove it.
 
-**Pending-only** (no `--dist-dir`): write or update `pending.json` only.
+**Pending** — write or update `pending.json` only.
 
 ```bash
 # Workflow start — record pending publish (prunes stuck entries first)
-gestaltd app registry publish \
+gestaltd app registry pending set \
   --bucket gs://… \
   --app traffic-cop \
   --version 0.0.0-snapshot.g… \
   --ref abc123… \
   --workflow-run-url … \
-  [--trigger-pr-number … --trigger-pr-url …] \
-  --pending publishing
+  [--trigger-pr-number … --trigger-pr-url …]
 
 # Failure cleanup
-gestaltd app registry publish … --pending clear
+gestaltd app registry pending clear \
+  --bucket gs://… \
+  --app traffic-cop \
+  --version 0.0.0-snapshot.g…
 ```
 
-**Full publish:** when `--dist-dir` is set, upload artifacts and version
-metadata, update `index.json`, then remove this version from `pending.json`.
-Same behavior as today's `gestaltd app publish`.
+`pending set` writes `phase=publishing`. It is idempotent for the same
+`(app, version)`: refresh `updatedAt` and merge `publication` if re-run.
+`pending clear` is idempotent if the version is already absent.
+
+**Publish** — upload artifacts and version metadata, update `index.json`, then
+remove this version from `pending.json` on success. Same flags as today's
+`gestaltd app publish`; requires `--dist-dir`.
 
 ```bash
 gestaltd app registry publish \
@@ -201,13 +205,8 @@ gestaltd app registry publish \
   [publication flags]
 ```
 
-Manual and CI publishes use the same command. A local run with
-`--workflow-run-url` and `--pending publishing` at the start shows in the admin
-UI the same way as CI.
-
-`--pending publishing` is idempotent for the same `(app, version)`: refresh
-`updatedAt` and merge `publication` if re-run. `--pending clear` is idempotent
-if the version is already absent.
+CI runs `pending set` at workflow start and `registry publish` after packaging.
+Manual publishes can call `pending set` first when they want admin UI visibility.
 
 Implementation extends `gestaltd/internal/daemon/app_publish.go` and reuses the
 index upload helper (generation-match retries).
@@ -299,12 +298,12 @@ idle.
 In `toolshed` (and any repo using the shared workflow):
 
 1. After `Resolve package inputs` (when `PACKAGE_VERSION` is known), authenticate
-   to GCP and run `gestaltd app registry publish --pending publishing` with the
-   same publication flags used in the final publish step.
+   to GCP and run `gestaltd app registry pending set` with the same publication
+   flags used in the publish step.
 2. Keep the existing publish step, migrated to
    `gestaltd app registry publish --dist-dir …` (clears pending on success).
-3. Add an `always()` step that runs `gestaltd app registry publish --pending clear`
-   when the full publish step did not succeed.
+3. Add an `always()` step that runs `gestaltd app registry pending clear` when
+   the publish step did not succeed.
 
 Install `gestaltd` before step 1 (today it is installed only in the publish job;
 move or duplicate install earlier so pending can be recorded at workflow start).
@@ -320,7 +319,7 @@ move or duplicate install earlier so pending can be recorded at workflow start).
 | Published catalog remains immutable per version | `versions/{version}.json` and artifacts still uploaded with `if-generation-match=0` |
 | Public read stays HTTP GET | Single `pending.json` per app, no bucket listing |
 | Concurrent publishes for one app | Rare; `pending` map holds multiple versions. CI concurrency is per `(app, sha)`; different SHAs produce different version strings |
-| Stuck pending rows are removed | `PrunePendingIndex` on first `--pending publishing`; 30-minute `updatedAt` threshold + already-published checks |
+| Stuck pending rows are removed | `PrunePendingIndex` on `pending set`; 30-minute `updatedAt` threshold + already-published checks |
 
 ---
 
@@ -328,18 +327,17 @@ move or duplicate install earlier so pending can be recorded at workflow start).
 
 1. **Models** — Add `PendingIndex` / `PendingVersion` to
    `gestaltd/internal/appregistry/`; document in [models.md](./models.md).
-2. **Write path** — add `gestaltd app registry publish` (move logic from
-   `gestaltd app publish`); support `--pending publishing|clear`.
-   Generation-match retries (mirror index upsert). First `--pending publishing`
-   call calls `PrunePendingIndex`; full publish clears pending on success.
-   Deprecate `gestaltd app publish`.
+2. **Write path** — add `gestaltd app registry pending set|clear` and
+   `gestaltd app registry publish` (move publish logic from `gestaltd app
+   publish`). `pending set` calls `PrunePendingIndex`; `registry publish` clears
+   pending on success. Deprecate `gestaltd app publish`.
 3. **Read path** — `FetchPendingIndex`; unit tests with `registrytest` HTTP
    fixture.
 4. **App-admin API** — extend `getAppAdminRegistry` with `pendingVersions`.
 5. **UI** — pending rows + polling in `gestalt-providers` app admin table.
-6. **CI** — migrate `publish-app-registry.yml` from `gestaltd app publish` to
-   `gestaltd app registry publish`; add `--pending publishing` at workflow start
-   and `--pending clear` on failure.
+6. **CI** — add `gestaltd app registry pending set` at workflow start and
+   `pending clear` on failure; migrate publish step to
+   `gestaltd app registry publish`.
 7. **Tests** — see [tests.md](./tests.md) (add section when implementing).
 
 Suggested order: 1 → 2 → 3 → 4 → 6 (CI can ship begin/end before UI) → 5.
@@ -353,16 +351,16 @@ Suggested order: 1 → 2 → 3 → 4 → 6 (CI can ship begin/end before UI) →
 
 ## Decisions
 
-**CLI surface:** `gestaltd app registry publish` replaces `gestaltd app publish`.
-CI and manual publishes use the registry command. Pending lifecycle uses the
-same command with `--pending publishing` or `--pending clear`.
+**CLI surface:** Two commands under `gestaltd app registry`:
+
+- `pending set|clear` — mutable `pending.json` lifecycle
+- `publish` — immutable artifacts + `index.json` (replaces `gestaltd app publish`)
 
 **Single phase:** Pending rows use `phase=publishing` from workflow start.
 
 **Workflow start:** `publish-app-registry.yml` should call
-`gestaltd app registry publish --pending publishing` as early as possible (once
-`PACKAGE_VERSION`, GCP auth, and `gestaltd` are available), not only at the end
-when artifacts are ready.
+`gestaltd app registry pending set` as early as possible (once `PACKAGE_VERSION`,
+GCP auth, and `gestaltd` are available), not only when artifacts are ready.
 
 ---
 

--- a/plans/app_registry/pending-publish.md
+++ b/plans/app_registry/pending-publish.md
@@ -6,7 +6,7 @@ is updated at the end of CI.
 Related docs:
 
 - [plan.md](./plan.md) — registry goals and implementation path
-- [models.md](./models.md) — registry JSON documents, including [PendingIndex](./models.md#pendingindex)
+- [models.md](./models.md) — registry JSON documents, including [PendingIndex](./models.md#pendingindex) and [FailedIndex](./models.md#failedindex)
 - [admin.md](./admin.md) — app admin UI capabilities
 - [service.md](./service.md) — Go publish/read helpers
 - [lifecycle.md](./lifecycle.md) — app-admin HTTP API
@@ -30,30 +30,36 @@ already known. There is no registry signal between “workflow started” and
 
 Operators on `/apps/{app}/admin` should be able to answer:
 
-| Question | Surface |
-|----------|---------|
+| Question | Admin surface |
+|----------|---------------|
 | Is a new snapshot being published right now? | Row with status **Publishing** |
-| Which commit / PR triggered it? | Pending row provenance (same fields as published rows where available) |
+| Which commit / PR triggered it? | Pending entry provenance (same fields as published rows where available) |
 | Where is the CI run? | Link to `publication.workflowRunUrl` |
-| When did publish start? | `startedAt` on the pending row |
+| When did publish start? | `startedAt` on the pending entry |
 | Did a recent publish fail? | Row with status **Failed** and `failedAt` |
-| Why did it fail? | `reason` on the failed row (`workflow_failed` or `stale`) |
+| Why did it fail? | `reason` on the failed entry (`workflow_failed` or `stale`) |
 
 ---
 
 ## Design summary
 
-Add mutable **pending** and **failed** catalog documents in GCS per app. CI
-writes pending when a publish starts. On success, `pending clear` removes the
-row. On workflow failure, `pending fail` records `failedAt` in `failed.json`.
-Stale pending rows (30 minutes without `updatedAt` refresh) are moved to
-`failed.json` with `reason=stale` on the next `pending set`. `gestaltd` reads
-both files alongside `index.json` and exposes rows through the app-admin
-registry API. The UI merges pending, failed, and published rows in the snapshots
-table.
+Add mutable `pending.json` and `failed.json` catalogs in GCS per app.
 
-Pending versions are **not** installable. Install-time validation continues to
-read only `versions/{version}.json` via the published index contract.
+- **Start** — CI calls `gestaltd app registry pending set` when the publish
+  workflow starts.
+- **Success** — `gestaltd app registry pending clear` removes the pending entry.
+- **Failure** — `gestaltd app registry pending fail` removes the pending entry
+  and records `failedAt` in `failed.json`.
+- **Stale** — `PrunePendingIndex` on the next `pending set` moves entries whose
+  `updatedAt` is older than 30 minutes to `failed.json` with `reason=stale`.
+
+`gestaltd` reads both catalogs alongside `index.json` and exposes them through
+the app-admin registry API. The UI merges pending, failed, and published entries
+in the snapshots table.
+
+Pending and failed versions are **not** installable. Install-time validation
+continues to read only `versions/{version}.json` via the published index
+contract.
 
 ---
 
@@ -64,8 +70,8 @@ Extend the per-app registry tree:
 ```text
 apps/{app}/
 ├── index.json
-├── pending.json          # in-flight publishes
-├── failed.json           # recent failed publishes
+├── pending.json
+├── failed.json
 ├── versions/
 │   └── {version}.json
 └── artifacts/
@@ -90,14 +96,16 @@ index writes: read generation, merge, upload with `if-generation-match`.
 |-------|---------|
 | `publishing` | Publish in progress — from workflow start through artifact upload and `index.json` update. |
 
-Record pending with `phase=publishing` at workflow start.
+Record `phase=publishing` at workflow start.
 
-On workflow **success**, `gestaltd app registry pending clear` removes the
-pending row (no failed record).
+On workflow success, `gestaltd app registry pending clear` removes the pending
+entry. No failed record is written.
 
-On workflow **failure**, `gestaltd app registry pending fail` removes the pending
-row and upserts `failed.json` with `failedAt` and `reason=workflow_failed`. The
-workflow run URL remains the failure audit trail.
+On workflow failure, `gestaltd app registry pending fail` removes the pending
+entry and upserts `failed.json` with `failedAt` and `reason=workflow_failed`.
+The workflow run URL remains the failure audit trail.
+
+---
 
 ## FailedIndex
 
@@ -108,18 +116,22 @@ workflow run URL remains the failure audit trail.
 
 | `reason` | Meaning |
 |----------|---------|
-| `workflow_failed` | CI called `pending fail` after packaging or publish failed |
+| `workflow_failed` | CI called `gestaltd app registry pending fail` after packaging or publish failed |
 | `stale` | Pending `updatedAt` was older than 30 minutes when `PrunePendingIndex` ran |
 
-### Self-healing
+---
+
+## Self-healing
 
 `gestaltd serve` reads `pending.json` and `failed.json` over public HTTP and
-cannot write back to GCS. Self-healing runs on the **`gestaltd app registry
+cannot write back to GCS. Prune helpers run on the **`gestaltd app registry
 pending` write path** (CI), which already holds bucket credentials.
 
-`gestaltd app registry pending set` always runs reconciliation before upserting:
+`gestaltd app registry pending set` always runs prune helpers before upserting.
 
-**`PrunePendingIndex`** — for each `pending.{version}` entry:
+### `PrunePendingIndex`
+
+For each `pending.{version}` entry:
 
 | Condition | Action |
 |-----------|--------|
@@ -127,7 +139,9 @@ pending` write path** (CI), which already holds bucket credentials.
 | Same `version` already listed in `index.json` | Remove from pending only (publish succeeded; pending cleanup missed) |
 | Otherwise | Keep |
 
-**`PruneFailedIndex`** — for each `failed.{version}` entry:
+### `PruneFailedIndex`
+
+For each `failed.{version}` entry:
 
 | Condition | Action |
 |-----------|--------|
@@ -136,14 +150,14 @@ pending` write path** (CI), which already holds bucket credentials.
 | Otherwise | Keep |
 
 The 30-minute pending threshold applies on `gestaltd app registry pending set`.
-Failed rows are retained for 30 days so operators can see recent failures on the
-admin page.
+Failed entries are retained for 30 days so operators can see recent failures on
+the admin page.
 
 `PrunePendingIndex` and `PruneFailedIndex` use the same optimistic-concurrency
 loop as other catalog writes: download generation, merge, upload with
 `if-generation-match`.
 
-Every app publish workflow self-heals stuck pending rows on the next merge to
+Every app publish workflow self-heals stuck pending entries on the next merge to
 `main` for that app.
 
 Prune is idempotent and safe to run concurrently with an in-flight publish:
@@ -169,25 +183,25 @@ CI: publish-app-registry.yml
 ├─4. gestaltd app registry publish --dist-dir … (artifacts + versions/{version}.json + index.json)
 │
 └─5. gestaltd app registry pending clear|fail  (always())
-       → success: pending clear (remove pending row)
-       → failure: pending fail (remove pending row, upsert failed.json)
+       → success: pending clear
+       → failure: pending fail
 ```
 
 Today, `publish-app-registry.yml` runs `gestaltd app publish --dist-dir …` only.
-This proposal adds `gestaltd app registry pending` for steps 2 and 5, migrates
-step 4 to `gestaltd app registry publish`, and records failures in
-`failed.json`.
+This plan adds `gestaltd app registry pending` for steps 2 and 5, migrates step
+4 to `gestaltd app registry publish`, and records failures in `failed.json`.
 
-On **success**, step 4 uploads artifacts and updates `index.json` (unchanged
-order — index last). Step 5 runs `pending clear`.
+On success, step 4 uploads artifacts and updates `index.json` (unchanged order
+— index last). Step 5 runs `gestaltd app registry pending clear`.
 
-On **failure**, step 5 runs `pending fail`, recording `failedAt` in
-`failed.json`. If step 5 itself fails, the next `pending set` for any version
-moves a stale pending row to `failed.json` with `reason=stale`.
+On failure, step 5 runs `gestaltd app registry pending fail`, recording
+`failedAt` in `failed.json`. If step 5 itself fails, the next
+`gestaltd app registry pending set` for any app version moves a stale pending
+entry to `failed.json` with `reason=stale`.
 
-### CLI surface
+### CLI
 
-Introduce two commands under `gestaltd app registry`:
+`gestaltd app registry` gains:
 
 ```text
 gestaltd app registry pending set|clear|fail
@@ -196,11 +210,12 @@ gestaltd app registry publish
 
 `gestaltd app registry publish` replaces `gestaltd app publish` for immutable
 uploads only. `gestaltd app registry pending` owns the mutable `pending.json` and
-`failed.json` lifecycle. Keep `gestaltd app publish` as a deprecated alias for
-`registry publish` during migration, then remove it.
+`failed.json` catalogs. Keep `gestaltd app publish` as a deprecated alias for
+`gestaltd app registry publish` during migration, then remove it.
 
-**Pending** — write or update `pending.json`; reconcile stale pending and old
-failed rows via `PrunePendingIndex` / `PruneFailedIndex` on `set` only.
+**`gestaltd app registry pending`** — write or update `pending.json` and
+`failed.json`. `pending set` runs `PrunePendingIndex` and `PruneFailedIndex`
+before upserting.
 
 ```bash
 # Workflow start — record pending publish (prunes stuck entries first)
@@ -212,13 +227,13 @@ gestaltd app registry pending set \
   --workflow-run-url … \
   [--trigger-pr-number … --trigger-pr-url …]
 
-# Workflow end — success: remove pending row (idempotent)
+# Workflow end — success (idempotent)
 gestaltd app registry pending clear \
   --bucket gs://… \
   --app traffic-cop \
   --version 0.0.0-snapshot.g…
 
-# Workflow end — failure: record failedAt and remove pending row (idempotent)
+# Workflow end — failure (idempotent)
 gestaltd app registry pending fail \
   --bucket gs://… \
   --app traffic-cop \
@@ -226,14 +241,15 @@ gestaltd app registry pending fail \
 ```
 
 `pending set` writes `phase=publishing`. It is idempotent for the same
-`(app, version)`: refresh `updatedAt` and merge `publication` if re-run.
-`pending clear` is idempotent if the version is already absent from pending.
-`pending fail` is idempotent if the version is already absent from pending (keeps
-an existing `failed.json` entry unchanged).
+`(app, version)`: refresh `updatedAt` and merge `publication` on re-run.
+`pending clear` is idempotent when the version is already absent from pending.
+`pending fail` is idempotent when the version is already absent from pending; an
+existing `failed.json` entry is left unchanged.
 
-**Publish** — upload artifacts and version metadata, update `index.json` only.
-Does not read or write `pending.json`. Same flags as today's `gestaltd app
-publish`; requires `--dist-dir`.
+**`gestaltd app registry publish`** — upload artifacts and version metadata,
+update `index.json` only. Does not read or write `pending.json` or
+`failed.json`. Same flags as today's `gestaltd app publish`; requires
+`--dist-dir`.
 
 ```bash
 gestaltd app registry publish \
@@ -246,10 +262,13 @@ gestaltd app registry publish \
   [publication flags]
 ```
 
-CI runs `pending set` at workflow start, `registry publish` after packaging, and
-`pending clear` or `pending fail` in `always()` at workflow end depending on
-outcome. Manual publishes can call `pending set` first and `pending clear` or
-`pending fail` after when they want admin UI visibility.
+CI runs `gestaltd app registry pending set` at workflow start,
+`gestaltd app registry publish` after packaging, and
+`gestaltd app registry pending clear` or `gestaltd app registry pending fail` in
+`always()` at workflow end depending on outcome. Manual publishes can call
+`gestaltd app registry pending set` first and `gestaltd app registry pending
+clear` or `gestaltd app registry pending fail` afterward when they want admin
+UI visibility.
 
 Implementation extends `gestaltd/internal/daemon/app_publish.go` and reuses the
 index upload helper (generation-match retries).
@@ -267,9 +286,9 @@ func (r *RegistryReader) FetchPendingIndex(ctx context.Context, publicRoot, appN
 func (r *RegistryReader) FetchFailedIndex(ctx context.Context, publicRoot, appName string) (*FailedIndex, error)
 ```
 
-- HTTP GET `apps/{app}/pending.json` / `apps/{app}/failed.json`
-- Missing object → empty index (same as missing `index.json`)
-- Decode + validate `schemaVersion`
+- HTTP GET `apps/{app}/pending.json` and `apps/{app}/failed.json`
+- Missing object → empty catalog (same as missing `index.json`)
+- Decode and validate `schemaVersion`
 
 ### App-admin API
 
@@ -323,33 +342,31 @@ Install and upgrade handlers ignore `pending.json` and `failed.json` entirely.
 
 ## UI changes (`/apps/{app}/admin`)
 
-Update the snapshots table to render **pending** and **failed** rows alongside
-published rows (single newest-first list with a status column).
+Update the snapshots table to render pending and failed entries alongside
+published entries (single newest-first list with a status column).
 
 | Status | Condition |
 |--------|-----------|
-| **Publishing** | Row from `pendingVersions` |
-| **Failed** | Row from `failedVersions` |
+| **Publishing** | Entry from `pendingVersions` |
+| **Failed** | Entry from `failedVersions` |
 | **Deployed** | `version === desiredVersion` (unchanged) |
 | **Rolling out** | Active rollout for this version (unchanged) |
 | **Available** | Published, not desired (unchanged) |
 
-Pending rows:
+Pending entries:
 
 - Show PR / commit provenance when present (same columns as published)
 - **Published** column shows “In progress” or time since `startedAt`
 - **Action** column: Deploy disabled; optional “View workflow” link using
   `publication.workflowRunUrl`
-- No deploy button for pending versions
 
-Failed rows:
+Failed entries:
 
 - Show PR / commit provenance when present
-- **Published** column shows `failedAt` (and optional reason label:
-  `workflow_failed` → “Workflow failed”, `stale` → “Timed out”)
+- **Published** column shows `failedAt` and a reason label (`workflow_failed` →
+  “Workflow failed”, `stale` → “Timed out”)
 - **Action** column: Deploy disabled; “View workflow” when
   `publication.workflowRunUrl` is present
-- No deploy button for failed versions
 
 Polling: extend `AppAdminPageClient` to poll every **12s** while
 `pendingVersions.length > 0` or `failedVersions.length > 0`, not only during
@@ -364,8 +381,9 @@ In `toolshed` (and any repo using the shared workflow):
 1. After `Resolve package inputs` (when `PACKAGE_VERSION` is known), authenticate
    to GCP and run `gestaltd app registry pending set` with the same publication
    flags used in the publish step.
-2. Keep the existing publish step, migrated to
-   `gestaltd app registry publish --dist-dir …` (does not touch `pending.json`).
+2. Migrate the existing publish step to
+   `gestaltd app registry publish --dist-dir …` (does not touch `pending.json`
+   or `failed.json`).
 3. Add an `always()` step that runs `gestaltd app registry pending clear` on
    success or `gestaltd app registry pending fail` on failure.
 
@@ -378,19 +396,19 @@ move or duplicate install earlier so pending can be recorded at workflow start).
 
 | Invariant | Enforcement |
 |-----------|-------------|
-| Pending versions are not installable | `Installer` / `InstallValidator` only read `versions/{version}.json` reached via published index entries |
-| Pending does not affect fleet state | No IndexedDB writes |
+| Pending and failed versions are not installable | `Installer` / `InstallValidator` only read `versions/{version}.json` reached via published index entries |
+| Pending and failed catalogs do not affect fleet state | No IndexedDB writes |
 | Published catalog remains immutable per version | `versions/{version}.json` and artifacts still uploaded with `if-generation-match=0` |
 | Public read stays HTTP GET | `pending.json` and `failed.json` per app, no bucket listing |
 | Concurrent publishes for one app | Rare; `pending` map holds multiple versions. CI concurrency is per `(app, sha)`; different SHAs produce different version strings |
-| Stuck pending rows become failed | `PrunePendingIndex` on `pending set`; 30-minute `updatedAt` threshold writes `failedAt` with `reason=stale` |
-| Old failed rows are pruned | `PruneFailedIndex` on `pending set`; 30-day `failedAt` threshold |
+| Stuck pending entries become failed | `PrunePendingIndex` on `pending set`; 30-minute `updatedAt` threshold writes `failedAt` with `reason=stale` |
+| Old failed entries are pruned | `PruneFailedIndex` on `pending set`; 30-day `failedAt` threshold |
 
 ---
 
 ## Implementation path
 
-**Four PRs.** Merge in order below. CI can land after PR 1 and before the UI —
+Four PRs. Merge in order below. CI can land after PR 1 and before the UI —
 `pending.json` is written and cleared in production before `/apps/{app}/admin`
 shows publishing rows.
 
@@ -402,28 +420,27 @@ PR 1 (gestalt) ──► PR 2 (gestalt) ──► PR 4 (gestalt)
 
 ### PR 1 — Models and write path (`gestalt`)
 
-Foundation for everything else. Ship types and CLI first so CI can call the new
-commands.
+Add types and CLI first so CI can call the new commands.
 
 - Add `PendingIndex` / `PendingVersion` and `FailedIndex` / `FailedVersion` to
   `gestaltd/internal/appregistry/` ([models.md](./models.md) documents shapes).
 - Add `gestaltd app registry pending set|clear|fail` and
   `gestaltd app registry publish` (move logic from `gestaltd app publish`).
 - `pending set` calls `PrunePendingIndex` and `PruneFailedIndex` before
-  upsert; stale pending → `failed.json`. `registry publish` does not touch
-  `pending.json` or `failed.json`.
-- Deprecate `gestaltd app publish` (alias → `registry publish`).
+  upsert; stale pending → `failed.json`. `gestaltd app registry publish` does
+  not touch `pending.json` or `failed.json`.
+- Deprecate `gestaltd app publish` (alias → `gestaltd app registry publish`).
 - Tests: pending write/prune/fail/clear, stale → failed, deprecated alias. Add a
   [tests.md](./tests.md) section for the write path.
 
 ### PR 2 — Read path and app-admin API (`gestalt`)
 
-Depends on **PR 1**. Exposes pending state to the admin page.
+Depends on **PR 1**. Exposes pending and failed catalog state to the admin page.
 
 - `FetchPendingIndex` and `FetchFailedIndex` in `gestaltd/internal/appregistry/`.
 - Extend `getAppAdminRegistry` with `pendingVersions[]` and `failedVersions[]`.
 - Tests: fetch helpers via `registrytest` HTTP fixture; handler returns pending
-  and failed alongside published. Extend [tests.md](./tests.md).
+  and failed entries alongside published. Extend [tests.md](./tests.md).
 
 ### PR 3 — CI (`toolshed`)
 
@@ -434,19 +451,19 @@ operators get correct GCS state before the UI exists.
 - `gestaltd app registry pending set` at workflow start (after version + GCP
   auth).
 - Migrate publish step to `gestaltd app registry publish`.
-- `gestaltd app registry pending clear` on success or `pending fail` on failure
-  in `always()` at workflow end.
+- `gestaltd app registry pending clear` on success or
+  `gestaltd app registry pending fail` on failure in `always()` at workflow end.
 - Install `gestaltd` early enough for step 1 (see [CI changes](#ci-changes-publish-app-registryyml)
   above).
 
 ### PR 4 — UI (`gestalt`)
 
-Depends on **PR 2**. Completes operator visibility.
+Depends on **PR 2**. Completes admin visibility.
 
-- Pending rows (**Publishing**) and failed rows (**Failed**) in the
-  `gestalt-providers` app admin snapshots table.
+- **Publishing** and **Failed** rows in the `gestalt-providers` app admin
+  snapshots table.
 - Poll every ~12s while any pending or failed version exists; prefer published
-  row when the same version appears in multiple lists.
+  entry when the same version appears in multiple lists.
 - Manual / browser smoke per [tests.md](./tests.md) when implementing.
 
 ---
@@ -456,17 +473,16 @@ Depends on **PR 2**. Completes operator visibility.
 **Scope:** Pending publish visibility is **app-scoped only** — `/apps/{app}/admin`.
 The embedded fleet `/admin` registry list does not show a publishing indicator.
 
-**CLI surface:** Two commands under `gestaltd app registry`:
-
-- `pending set|clear|fail` — mutable `pending.json` and `failed.json` lifecycle
-  (CI calls `clear` on success, `fail` on failure)
-- `publish` — immutable artifacts + `index.json` only (replaces `gestaltd app publish`)
+**CLI:** `gestaltd app registry pending` (`set`, `clear`, `fail`) owns
+`pending.json` and `failed.json`. `gestaltd app registry publish` uploads
+immutable artifacts and `index.json` only (replaces `gestaltd app publish`). CI
+calls `pending clear` on success and `pending fail` on failure.
 
 **Failed retention:** `failed.json` entries are kept for **30 days**, then pruned
 on `pending set`. Stale pending (30 minutes without `updatedAt` refresh) records
 `failedAt` with `reason=stale`.
 
-**Single phase:** Pending rows use `phase=publishing` from workflow start.
+**Single phase:** Pending entries use `phase=publishing` from workflow start.
 
 **Workflow start:** `publish-app-registry.yml` should call
 `gestaltd app registry pending set` as early as possible (once `PACKAGE_VERSION`,

--- a/plans/app_registry/pending-publish.md
+++ b/plans/app_registry/pending-publish.md
@@ -24,10 +24,6 @@ while a publish is running — even though the version string and workflow run a
 already known. There is no registry signal between “workflow started” and
 “index updated”.
 
-Fleet deploy state (`desiredVersion`, rollout) lives in IndexedDB and is
-unrelated to publish progress. Pending publish visibility is a **registry read**
-concern only.
-
 ---
 
 ## Goals

--- a/plans/app_registry/pending-publish.md
+++ b/plans/app_registry/pending-publish.md
@@ -85,7 +85,7 @@ writes: read generation, merge, upload with `if-generation-match`.
 | `packaging` | `gestaltd provider package` / artifact build in progress. Pending record created at workflow start. |
 | `publishing` | Artifacts built; `gestaltd app publish` upload + index update in progress. Set immediately before the publish step. |
 
-Do not add a `failed` phase in GCS for v1. On failure, **remove** the pending
+On failure, **remove** the pending
 entry in a workflow `always()` cleanup step. The workflow run URL remains the
 failure audit trail.
 

--- a/plans/app_registry/pending-publish.md
+++ b/plans/app_registry/pending-publish.md
@@ -36,16 +36,21 @@ Operators on `/apps/{app}/admin` should be able to answer:
 | Which commit / PR triggered it? | Pending row provenance (same fields as published rows where available) |
 | Where is the CI run? | Link to `publication.workflowRunUrl` |
 | When did publish start? | `startedAt` on the pending row |
+| Did a recent publish fail? | Row with status **Failed** and `failedAt` |
+| Why did it fail? | `reason` on the failed row (`workflow_failed` or `stale`) |
 
 ---
 
 ## Design summary
 
-Add a small **pending catalog** document in GCS per app. CI writes it when a
-publish starts and `pending clear` removes the entry when the workflow finishes
-(success or failure). `gestaltd` reads it alongside `index.json` and exposes
-pending rows through the existing app-admin registry API. The UI merges pending
-and published rows in the snapshots table.
+Add mutable **pending** and **failed** catalog documents in GCS per app. CI
+writes pending when a publish starts. On success, `pending clear` removes the
+row. On workflow failure, `pending fail` records `failedAt` in `failed.json`.
+Stale pending rows (30 minutes without `updatedAt` refresh) are moved to
+`failed.json` with `reason=stale` on the next `pending set`. `gestaltd` reads
+both files alongside `index.json` and exposes rows through the app-admin
+registry API. The UI merges pending, failed, and published rows in the snapshots
+table.
 
 Pending versions are **not** installable. Install-time validation continues to
 read only `versions/{version}.json` via the published index contract.
@@ -59,7 +64,8 @@ Extend the per-app registry tree:
 ```text
 apps/{app}/
 ├── index.json
-├── pending.json          # new — in-flight publishes for this app
+├── pending.json          # in-flight publishes
+├── failed.json           # recent failed publishes
 ├── versions/
 │   └── {version}.json
 └── artifacts/
@@ -67,9 +73,9 @@ apps/{app}/
         └── …
 ```
 
-`pending.json` is a mutable catalog (like `index.json`), not an immutable
-release object. Use the same optimistic-concurrency update pattern as index
-writes: read generation, merge, upload with `if-generation-match`.
+`pending.json` and `failed.json` are mutable catalogs (like `index.json`), not
+immutable release objects. Use the same optimistic-concurrency update pattern as
+index writes: read generation, merge, upload with `if-generation-match`.
 
 ---
 
@@ -86,36 +92,59 @@ writes: read generation, merge, upload with `if-generation-match`.
 
 Record pending with `phase=publishing` at workflow start.
 
-On workflow end (success or failure), **remove** the pending entry with
-`gestaltd app registry pending clear` in an `always()` step. The workflow run
-URL remains the failure audit trail.
+On workflow **success**, `gestaltd app registry pending clear` removes the
+pending row (no failed record).
+
+On workflow **failure**, `gestaltd app registry pending fail` removes the pending
+row and upserts `failed.json` with `failedAt` and `reason=workflow_failed`. The
+workflow run URL remains the failure audit trail.
+
+## FailedIndex
+
+`failed.json` document shape, fields, and example:
+[models.md — FailedIndex](./models.md#failedindex).
+
+### Failure reasons
+
+| `reason` | Meaning |
+|----------|---------|
+| `workflow_failed` | CI called `pending fail` after packaging or publish failed |
+| `stale` | Pending `updatedAt` was older than 30 minutes when `PrunePendingIndex` ran |
 
 ### Self-healing
 
-`gestaltd serve` reads `pending.json` over public HTTP and cannot write back to
-GCS. Self-healing runs on the **`gestaltd app registry pending` write path** (CI),
-which already holds bucket credentials.
+`gestaltd serve` reads `pending.json` and `failed.json` over public HTTP and
+cannot write back to GCS. Self-healing runs on the **`gestaltd app registry
+pending` write path** (CI), which already holds bucket credentials.
 
-A shared `PrunePendingIndex` helper removes stuck entries from `pending.json`
-before any pending mutation. Prune criteria for each `pending.{version}` entry:
+`gestaltd app registry pending set` always runs reconciliation before upserting:
+
+**`PrunePendingIndex`** — for each `pending.{version}` entry:
 
 | Condition | Action |
 |-----------|--------|
-| `updatedAt` older than **30 minutes** | Remove — publish likely failed or cleanup never ran |
-| Same `version` already listed in `index.json` | Remove — publish succeeded but pending was not cleared |
+| `updatedAt` older than **30 minutes** | Move to `failed.json` with `failedAt=now`, `reason=stale` |
+| Same `version` already listed in `index.json` | Remove from pending only (publish succeeded; pending cleanup missed) |
 | Otherwise | Keep |
 
-The 30-minute threshold applies on `gestaltd app registry pending set`.
-No `stale` field on the app-admin API — stuck rows are removed in GCS instead
-of surfaced as a separate UI state.
+**`PruneFailedIndex`** — for each `failed.{version}` entry:
 
-`PrunePendingIndex` uses the same optimistic-concurrency loop as pending
-writes: download `pending.json` generation, drop matching entries, upload with
+| Condition | Action |
+|-----------|--------|
+| `failedAt` older than **30 days** | Remove |
+| Same `version` already listed in `index.json` | Remove |
+| Otherwise | Keep |
+
+The 30-minute pending threshold applies on `gestaltd app registry pending set`.
+Failed rows are retained for 30 days so operators can see recent failures on the
+admin page.
+
+`PrunePendingIndex` and `PruneFailedIndex` use the same optimistic-concurrency
+loop as other catalog writes: download generation, merge, upload with
 `if-generation-match`.
 
-`gestaltd app registry pending set` always prunes before upserting. Every app
-publish workflow self-heals stuck pending rows older than 30 minutes, so
-orphaned entries are cleared on the next merge to `main` for that app.
+Every app publish workflow self-heals stuck pending rows on the next merge to
+`main` for that app.
 
 Prune is idempotent and safe to run concurrently with an in-flight publish:
 generation-match retries apply.
@@ -131,42 +160,47 @@ CI: publish-app-registry.yml
 │
 ├─2. gestaltd app registry pending set
 │      (same --bucket/--app/--version/--ref/--workflow-run-url flags as step 4)
-│      → PrunePendingIndex (drop entries older than 30m or already in index.json)
+│      → PrunePendingIndex (stale → failed.json; already-published → drop)
+│      → PruneFailedIndex (drop entries older than 30 days or already published)
 │      → upsert pending.json for this version (phase=publishing)
 │
 ├─3. Package artifacts (may take tens of minutes)
 │
 ├─4. gestaltd app registry publish --dist-dir … (artifacts + versions/{version}.json + index.json)
 │
-└─5. gestaltd app registry pending clear  (always())
-       → remove this version from pending.json (success or failure)
+└─5. gestaltd app registry pending clear|fail  (always())
+       → success: pending clear (remove pending row)
+       → failure: pending fail (remove pending row, upsert failed.json)
 ```
 
 Today, `publish-app-registry.yml` runs `gestaltd app publish --dist-dir …` only.
-This proposal adds `gestaltd app registry pending` for steps 2 and 5, and migrates
-step 4 to `gestaltd app registry publish`.
+This proposal adds `gestaltd app registry pending` for steps 2 and 5, migrates
+step 4 to `gestaltd app registry publish`, and records failures in
+`failed.json`.
 
 On **success**, step 4 uploads artifacts and updates `index.json` (unchanged
-order — index last). Step 5 clears pending.
+order — index last). Step 5 runs `pending clear`.
 
-On **failure**, step 5 still runs via `always()`, so pending does not stick unless
-the cleanup step itself fails.
+On **failure**, step 5 runs `pending fail`, recording `failedAt` in
+`failed.json`. If step 5 itself fails, the next `pending set` for any version
+moves a stale pending row to `failed.json` with `reason=stale`.
 
 ### CLI surface
 
 Introduce two commands under `gestaltd app registry`:
 
 ```text
-gestaltd app registry pending set|clear
+gestaltd app registry pending set|clear|fail
 gestaltd app registry publish
 ```
 
 `gestaltd app registry publish` replaces `gestaltd app publish` for immutable
-uploads only. `gestaltd app registry pending` owns the mutable `pending.json`
-lifecycle. Keep `gestaltd app publish` as a deprecated alias for `registry
-publish` during migration, then remove it.
+uploads only. `gestaltd app registry pending` owns the mutable `pending.json` and
+`failed.json` lifecycle. Keep `gestaltd app publish` as a deprecated alias for
+`registry publish` during migration, then remove it.
 
-**Pending** — write or update `pending.json` only.
+**Pending** — write or update `pending.json`; reconcile stale pending and old
+failed rows via `PrunePendingIndex` / `PruneFailedIndex` on `set` only.
 
 ```bash
 # Workflow start — record pending publish (prunes stuck entries first)
@@ -178,8 +212,14 @@ gestaltd app registry pending set \
   --workflow-run-url … \
   [--trigger-pr-number … --trigger-pr-url …]
 
-# Workflow end — remove pending row (idempotent)
+# Workflow end — success: remove pending row (idempotent)
 gestaltd app registry pending clear \
+  --bucket gs://… \
+  --app traffic-cop \
+  --version 0.0.0-snapshot.g…
+
+# Workflow end — failure: record failedAt and remove pending row (idempotent)
+gestaltd app registry pending fail \
   --bucket gs://… \
   --app traffic-cop \
   --version 0.0.0-snapshot.g…
@@ -187,7 +227,9 @@ gestaltd app registry pending clear \
 
 `pending set` writes `phase=publishing`. It is idempotent for the same
 `(app, version)`: refresh `updatedAt` and merge `publication` if re-run.
-`pending clear` is idempotent if the version is already absent.
+`pending clear` is idempotent if the version is already absent from pending.
+`pending fail` is idempotent if the version is already absent from pending (keeps
+an existing `failed.json` entry unchanged).
 
 **Publish** — upload artifacts and version metadata, update `index.json` only.
 Does not read or write `pending.json`. Same flags as today's `gestaltd app
@@ -204,9 +246,10 @@ gestaltd app registry publish \
   [publication flags]
 ```
 
-CI runs `pending set` at workflow start, `registry publish` after packaging,
-and `pending clear` in `always()` at workflow end. Manual publishes can call
-`pending set` first and `pending clear` after when they want admin UI visibility.
+CI runs `pending set` at workflow start, `registry publish` after packaging, and
+`pending clear` or `pending fail` in `always()` at workflow end depending on
+outcome. Manual publishes can call `pending set` first and `pending clear` or
+`pending fail` after when they want admin UI visibility.
 
 Implementation extends `gestaltd/internal/daemon/app_publish.go` and reuses the
 index upload helper (generation-match retries).
@@ -221,10 +264,11 @@ Add:
 
 ```go
 func (r *RegistryReader) FetchPendingIndex(ctx context.Context, publicRoot, appName string) (*PendingIndex, error)
+func (r *RegistryReader) FetchFailedIndex(ctx context.Context, publicRoot, appName string) (*FailedIndex, error)
 ```
 
-- HTTP GET `apps/{app}/pending.json`
-- Missing object → empty pending index (same as missing `index.json`)
+- HTTP GET `apps/{app}/pending.json` / `apps/{app}/failed.json`
+- Missing object → empty index (same as missing `index.json`)
 - Decode + validate `schemaVersion`
 
 ### App-admin API
@@ -249,6 +293,17 @@ Extend `GET /api/v1/apps/{app}/admin/registry` response:
       "publication": { … }
     }
   ],
+  "failedVersions": [
+    {
+      "version": "0.0.0-snapshot.g…",
+      "startedAt": "2026-07-24T18:00:00Z",
+      "failedAt": "2026-07-24T18:35:00Z",
+      "reason": "stale",
+      "sourceRef": "abc123…",
+      "sourceUrl": "https://github.com/…/commit/abc123…",
+      "publication": { … }
+    }
+  ],
   "rollout": { … },
   "selectionDisabled": false
 }
@@ -256,25 +311,25 @@ Extend `GET /api/v1/apps/{app}/admin/registry` response:
 
 Merge rules:
 
-- A version MUST NOT appear in both `pendingVersions` and `publishedVersions`.
-  If both exist (race between index update and pending end), prefer **published**
-  and omit pending.
-- `pendingVersions` sorted by `startedAt` descending (newest first), matching
-  published sort order.
+- A version MUST NOT appear in more than one of `pendingVersions`,
+  `failedVersions`, and `publishedVersions`. If multiple exist (race or missed
+  cleanup), prefer **published** and omit pending and failed.
+- `pendingVersions` sorted by `startedAt` descending (newest first).
+- `failedVersions` sorted by `failedAt` descending (newest first).
 
-Install and upgrade handlers ignore `pending.json` entirely.
+Install and upgrade handlers ignore `pending.json` and `failed.json` entirely.
 
 ---
 
 ## UI changes (`/apps/{app}/admin`)
 
-Update the snapshots table to render **pending** rows above published rows (or
-interleaved by `startedAt` / `publishedAt` — prefer single newest-first list
-with a status column).
+Update the snapshots table to render **pending** and **failed** rows alongside
+published rows (single newest-first list with a status column).
 
 | Status | Condition |
 |--------|-----------|
 | **Publishing** | Row from `pendingVersions` |
+| **Failed** | Row from `failedVersions` |
 | **Deployed** | `version === desiredVersion` (unchanged) |
 | **Rolling out** | Active rollout for this version (unchanged) |
 | **Available** | Published, not desired (unchanged) |
@@ -287,9 +342,18 @@ Pending rows:
   `publication.workflowRunUrl`
 - No deploy button for pending versions
 
+Failed rows:
+
+- Show PR / commit provenance when present
+- **Published** column shows `failedAt` (and optional reason label:
+  `workflow_failed` → “Workflow failed”, `stale` → “Timed out”)
+- **Action** column: Deploy disabled; “View workflow” when
+  `publication.workflowRunUrl` is present
+- No deploy button for failed versions
+
 Polling: extend `AppAdminPageClient` to poll every **12s** while
-`pendingVersions.length > 0`, not only during fleet rollout. Stop polling when
-idle.
+`pendingVersions.length > 0` or `failedVersions.length > 0`, not only during
+fleet rollout. Stop polling when idle.
 
 ---
 
@@ -302,8 +366,8 @@ In `toolshed` (and any repo using the shared workflow):
    flags used in the publish step.
 2. Keep the existing publish step, migrated to
    `gestaltd app registry publish --dist-dir …` (does not touch `pending.json`).
-3. Add an `always()` step that runs `gestaltd app registry pending clear` after
-   the publish job (success or failure).
+3. Add an `always()` step that runs `gestaltd app registry pending clear` on
+   success or `gestaltd app registry pending fail` on failure.
 
 Install `gestaltd` before step 1 (today it is installed only in the publish job;
 move or duplicate install earlier so pending can be recorded at workflow start).
@@ -317,9 +381,10 @@ move or duplicate install earlier so pending can be recorded at workflow start).
 | Pending versions are not installable | `Installer` / `InstallValidator` only read `versions/{version}.json` reached via published index entries |
 | Pending does not affect fleet state | No IndexedDB writes |
 | Published catalog remains immutable per version | `versions/{version}.json` and artifacts still uploaded with `if-generation-match=0` |
-| Public read stays HTTP GET | Single `pending.json` per app, no bucket listing |
+| Public read stays HTTP GET | `pending.json` and `failed.json` per app, no bucket listing |
 | Concurrent publishes for one app | Rare; `pending` map holds multiple versions. CI concurrency is per `(app, sha)`; different SHAs produce different version strings |
-| Stuck pending rows are removed | `PrunePendingIndex` on `pending set`; 30-minute `updatedAt` threshold + already-published checks |
+| Stuck pending rows become failed | `PrunePendingIndex` on `pending set`; 30-minute `updatedAt` threshold writes `failedAt` with `reason=stale` |
+| Old failed rows are pruned | `PruneFailedIndex` on `pending set`; 30-day `failedAt` threshold |
 
 ---
 
@@ -340,24 +405,25 @@ PR 1 (gestalt) ──► PR 2 (gestalt) ──► PR 4 (gestalt)
 Foundation for everything else. Ship types and CLI first so CI can call the new
 commands.
 
-- Add `PendingIndex` / `PendingVersion` to `gestaltd/internal/appregistry/`
-  ([models.md](./models.md) already documents the shape).
-- Add `gestaltd app registry pending set|clear` and
+- Add `PendingIndex` / `PendingVersion` and `FailedIndex` / `FailedVersion` to
+  `gestaltd/internal/appregistry/` ([models.md](./models.md) documents shapes).
+- Add `gestaltd app registry pending set|clear|fail` and
   `gestaltd app registry publish` (move logic from `gestaltd app publish`).
-- `pending set` calls `PrunePendingIndex` before upsert; `registry publish` does
-  not touch `pending.json`.
+- `pending set` calls `PrunePendingIndex` and `PruneFailedIndex` before
+  upsert; stale pending → `failed.json`. `registry publish` does not touch
+  `pending.json` or `failed.json`.
 - Deprecate `gestaltd app publish` (alias → `registry publish`).
-- Tests: pending write/prune/clear, deprecated alias. Add a [tests.md](./tests.md)
-  section for the write path.
+- Tests: pending write/prune/fail/clear, stale → failed, deprecated alias. Add a
+  [tests.md](./tests.md) section for the write path.
 
 ### PR 2 — Read path and app-admin API (`gestalt`)
 
 Depends on **PR 1**. Exposes pending state to the admin page.
 
-- `FetchPendingIndex` in `gestaltd/internal/appregistry/`.
-- Extend `getAppAdminRegistry` with `pendingVersions[]`.
-- Tests: `FetchPendingIndex` via `registrytest` HTTP fixture; handler returns
-  pending alongside published. Extend [tests.md](./tests.md).
+- `FetchPendingIndex` and `FetchFailedIndex` in `gestaltd/internal/appregistry/`.
+- Extend `getAppAdminRegistry` with `pendingVersions[]` and `failedVersions[]`.
+- Tests: fetch helpers via `registrytest` HTTP fixture; handler returns pending
+  and failed alongside published. Extend [tests.md](./tests.md).
 
 ### PR 3 — CI (`toolshed`)
 
@@ -368,7 +434,8 @@ operators get correct GCS state before the UI exists.
 - `gestaltd app registry pending set` at workflow start (after version + GCP
   auth).
 - Migrate publish step to `gestaltd app registry publish`.
-- `gestaltd app registry pending clear` in `always()` at workflow end.
+- `gestaltd app registry pending clear` on success or `pending fail` on failure
+  in `always()` at workflow end.
 - Install `gestaltd` early enough for step 1 (see [CI changes](#ci-changes-publish-app-registryyml)
   above).
 
@@ -376,10 +443,10 @@ operators get correct GCS state before the UI exists.
 
 Depends on **PR 2**. Completes operator visibility.
 
-- Pending rows (**Publishing**) in the `gestalt-providers` app admin snapshots
-  table.
-- Poll every ~12s while any pending version exists; prefer published row when
-  the same version appears in both lists.
+- Pending rows (**Publishing**) and failed rows (**Failed**) in the
+  `gestalt-providers` app admin snapshots table.
+- Poll every ~12s while any pending or failed version exists; prefer published
+  row when the same version appears in multiple lists.
 - Manual / browser smoke per [tests.md](./tests.md) when implementing.
 
 ---
@@ -391,9 +458,13 @@ The embedded fleet `/admin` registry list does not show a publishing indicator.
 
 **CLI surface:** Two commands under `gestaltd app registry`:
 
-- `pending set|clear` — mutable `pending.json` lifecycle (CI calls `clear` in
-  `always()` after publish)
+- `pending set|clear|fail` — mutable `pending.json` and `failed.json` lifecycle
+  (CI calls `clear` on success, `fail` on failure)
 - `publish` — immutable artifacts + `index.json` only (replaces `gestaltd app publish`)
+
+**Failed retention:** `failed.json` entries are kept for **30 days**, then pruned
+on `pending set`. Stale pending (30 minutes without `updatedAt` refresh) records
+`failedAt` with `reason=stale`.
 
 **Single phase:** Pending rows use `phase=publishing` from workflow start.
 
@@ -405,8 +476,6 @@ GCP auth, and `gestaltd` are available), not only when artifacts are ready.
 
 ## Future work
 
-- Failed publish retention: optional `apps/{app}/failed/{version}.json` with
-  `failedAt` and `reason` instead of only relying on GitHub Actions history.
 - Global pending index across apps for a registry-wide dashboard.
 - Webhook or Pub/Sub on `index.json` change to push updates to the UI instead
   of polling.

--- a/plans/app_registry/pending-publish.md
+++ b/plans/app_registry/pending-publish.md
@@ -82,8 +82,11 @@ writes: read generation, merge, upload with `if-generation-match`.
 
 | Phase | Meaning |
 |-------|---------|
-| `packaging` | `gestaltd provider package` / artifact build in progress. Pending record created at workflow start. |
-| `publishing` | Artifacts built; `gestaltd app registry publish` upload + index update in progress. Set immediately before the publish step. |
+| `publishing` | Publish in progress — from workflow start through artifact upload and `index.json` update. |
+
+Record pending with `phase=publishing` at workflow start. There is no separate
+`packaging` phase; `gestaltd provider package` runs while the pending row already
+shows **Publishing**.
 
 On failure, **remove** the pending
 entry in a workflow `always()` cleanup step. The workflow run URL remains the
@@ -104,8 +107,8 @@ before any pending mutation. Prune criteria for each `pending.{version}` entry:
 | Same `version` already listed in `index.json` | Remove — publish succeeded but pending was not cleared |
 | Otherwise | Keep |
 
-The 30-minute threshold applies on the first `gestaltd app registry publish --pending`
-call in a workflow.
+The 30-minute threshold applies on the first `gestaltd app registry publish
+--pending publishing` call in a workflow.
 No `stale` field on the app-admin API — stuck rows are removed in GCS instead
 of surfaced as a separate UI state.
 
@@ -113,16 +116,17 @@ of surfaced as a separate UI state.
 writes: download `pending.json` generation, drop matching entries, upload with
 `if-generation-match`.
 
-The first `gestaltd app registry publish --pending …` call in a workflow always prunes
-before upserting. Every app publish workflow self-heals stuck pending rows older
+The first `gestaltd app registry publish --pending publishing` call in a
+workflow always prunes before upserting. Every app publish workflow self-heals stuck pending rows older
 than 30 minutes, so orphaned entries are cleared on the next merge to `main` for
 that app.
 
 Prune is idempotent and safe to run concurrently with an in-flight publish:
 generation-match retries apply. An active publish refreshes `updatedAt` on each
-`--pending` call, so a healthy in-flight entry is not removed. Workflows with
-packaging longer than 30 minutes should run `gestaltd app registry publish --pending
-publishing` before the threshold elapses (step 4 below).
+`--pending publishing` call, so a healthy in-flight entry is not removed.
+Workflows with packaging longer than 30 minutes should run
+`gestaltd app registry publish --pending publishing` again before the full
+`--dist-dir` step to refresh `updatedAt`.
 
 ---
 
@@ -133,30 +137,28 @@ CI: publish-app-registry.yml
 │
 ├─1. Resolve PACKAGE_VERSION + PROVIDER_REF
 │
-├─2. gestaltd app registry publish --pending packaging
-│      (same --bucket/--app/--version/--ref/--workflow-run-url flags as step 5)
+├─2. gestaltd app registry publish --pending publishing
+│      (same --bucket/--app/--version/--ref/--workflow-run-url flags as step 4)
 │      → PrunePendingIndex (drop entries older than 30m or already in index.json)
-│      → upsert pending.json for this version (phase=packaging)
+│      → upsert pending.json for this version (phase=publishing)
 │
 ├─3. Package artifacts (may take tens of minutes)
 │
-├─4. gestaltd app registry publish --pending publishing
-│
-├─5. gestaltd app registry publish --dist-dir … (artifacts + versions/{version}.json + index.json)
+├─4. gestaltd app registry publish --dist-dir … (artifacts + versions/{version}.json + index.json)
 │      → clear this version from pending.json on success
 │
-└─6. gestaltd app registry publish --pending clear  (always() failure cleanup)
-       → remove version from pending.json if step 5 did not run
+└─5. gestaltd app registry publish --pending clear  (always() failure cleanup)
+       → remove version from pending.json if step 4 did not run
 ```
 
 Today, `publish-app-registry.yml` runs `gestaltd app publish --dist-dir …` only.
-This proposal migrates to `gestaltd app registry publish` and adds steps 2, 4,
-and 6 for pending visibility.
+This proposal migrates to `gestaltd app registry publish` and adds steps 2 and 5
+for pending visibility (step 2 at workflow start).
 
-On **success**, step 5 clears pending after uploading. Order within step 5 is
+On **success**, step 4 clears pending after uploading. Order within step 4 is
 unchanged: `index.json` is still updated last.
 
-On **failure**, an `always()` workflow step runs step 6 even when packaging or
+On **failure**, an `always()` workflow step runs step 5 even when packaging or
 publish failed, so pending does not stick unless the cleanup step itself fails.
 
 ### CLI surface
@@ -169,8 +171,8 @@ publish` as a deprecated alias during migration, then remove it.
 gestaltd app registry publish [flags]
 ```
 
-Flags are unchanged from today's `gestaltd app publish`, plus `--pending` for
-pending-only operations.
+Flags are unchanged from today's `gestaltd app publish`, plus `--pending
+publishing` and `--pending clear` for pending-only operations.
 
 **Pending-only** (no `--dist-dir`): write or update `pending.json` only.
 
@@ -183,9 +185,9 @@ gestaltd app registry publish \
   --ref abc123… \
   --workflow-run-url … \
   [--trigger-pr-number … --trigger-pr-url …] \
-  --pending packaging
+  --pending publishing
 
-# Before artifact upload — refresh phase / updatedAt
+# Optional — refresh updatedAt if packaging exceeds 30 minutes
 gestaltd app registry publish … --pending publishing
 
 # Failure cleanup
@@ -208,12 +210,12 @@ gestaltd app registry publish \
 ```
 
 Manual and CI publishes use the same command. A local run with
-`--workflow-run-url` and `--pending packaging` at the start shows in the admin
+`--workflow-run-url` and `--pending publishing` at the start shows in the admin
 UI the same way as CI.
 
-`--pending` is idempotent for the same `(app, version)`: refresh `updatedAt` and
-merge `publication` if re-run. `--pending clear` is idempotent if the version is
-already absent.
+`--pending publishing` is idempotent for the same `(app, version)`: refresh
+`updatedAt` and merge `publication` if re-run. `--pending clear` is idempotent
+if the version is already absent.
 
 Implementation extends `gestaltd/internal/daemon/app_publish.go` and reuses the
 index upload helper (generation-match retries).
@@ -250,7 +252,7 @@ Extend `GET /api/v1/apps/{app}/admin/registry` response:
       "version": "0.0.0-snapshot.g…",
       "startedAt": "2026-07-24T19:00:00Z",
       "updatedAt": "2026-07-24T19:04:12Z",
-      "phase": "packaging",
+      "phase": "publishing",
       "sourceRef": "abc123…",
       "sourceUrl": "https://github.com/…/commit/abc123…",
       "publication": { … }
@@ -305,17 +307,15 @@ idle.
 In `toolshed` (and any repo using the shared workflow):
 
 1. After `Resolve package inputs` (when `PACKAGE_VERSION` is known), authenticate
-   to GCP and run `gestaltd app registry publish --pending packaging` with the same
-   publication flags used in the final publish step.
-2. Immediately before the existing publish step, run
-   `gestaltd app registry publish --pending publishing`.
-3. Keep the existing `gestaltd app registry publish --dist-dir …` step (clears pending on
-   success).
-4. Add an `always()` step that runs `gestaltd app registry publish --pending clear` when
-   the full publish step did not succeed.
+   to GCP and run `gestaltd app registry publish --pending publishing` with the
+   same publication flags used in the final publish step.
+2. Keep the existing publish step, migrated to
+   `gestaltd app registry publish --dist-dir …` (clears pending on success).
+3. Add an `always()` step that runs `gestaltd app registry publish --pending clear`
+   when the full publish step did not succeed.
 
 Install `gestaltd` before step 1 (today it is installed only in the publish job;
-move or duplicate install earlier so step 2 can run at workflow start).
+move or duplicate install earlier so pending can be recorded at workflow start).
 
 ---
 
@@ -328,7 +328,7 @@ move or duplicate install earlier so step 2 can run at workflow start).
 | Published catalog remains immutable per version | `versions/{version}.json` and artifacts still uploaded with `if-generation-match=0` |
 | Public read stays HTTP GET | Single `pending.json` per app, no bucket listing |
 | Concurrent publishes for one app | Rare; `pending` map holds multiple versions. CI concurrency is per `(app, sha)`; different SHAs produce different version strings |
-| Stuck pending rows are removed | `PrunePendingIndex` on first `gestaltd app registry publish --pending`; 30-minute `updatedAt` threshold + already-published checks |
+| Stuck pending rows are removed | `PrunePendingIndex` on first `--pending publishing`; 30-minute `updatedAt` threshold + already-published checks |
 
 ---
 
@@ -337,17 +337,17 @@ move or duplicate install earlier so step 2 can run at workflow start).
 1. **Models** — Add `PendingIndex` / `PendingVersion` to
    `gestaltd/internal/appregistry/`; document in [models.md](./models.md).
 2. **Write path** — add `gestaltd app registry publish` (move logic from
-   `gestaltd app publish`); support `--pending packaging|publishing|clear`.
-   Generation-match retries (mirror index upsert). First `--pending` call calls
-   `PrunePendingIndex`; full publish clears pending on success. Deprecate
-   `gestaltd app publish`.
+   `gestaltd app publish`); support `--pending publishing|clear`.
+   Generation-match retries (mirror index upsert). First `--pending publishing`
+   call calls `PrunePendingIndex`; full publish clears pending on success.
+   Deprecate `gestaltd app publish`.
 3. **Read path** — `FetchPendingIndex`; unit tests with `registrytest` HTTP
    fixture.
 4. **App-admin API** — extend `getAppAdminRegistry` with `pendingVersions`.
 5. **UI** — pending rows + polling in `gestalt-providers` app admin table.
 6. **CI** — migrate `publish-app-registry.yml` from `gestaltd app publish` to
-   `gestaltd app registry publish`; add early `--pending packaging`, pre-upload
-   `--pending publishing`, and failure `--pending clear`.
+   `gestaltd app registry publish`; add `--pending publishing` at workflow start
+   and `--pending clear` on failure.
 7. **Tests** — see [tests.md](./tests.md) (add section when implementing).
 
 Suggested order: 1 → 2 → 3 → 4 → 6 (CI can ship begin/end before UI) → 5.
@@ -356,19 +356,20 @@ Suggested order: 1 → 2 → 3 → 4 → 6 (CI can ship begin/end before UI) →
 
 ## Open questions
 
-1. **Phase granularity** — Is `packaging` / `publishing` enough, or do we want
-   per-platform sub-phases in v1?
-2. **Embedded `/admin`** — Should the fleet observability app list show a
+1. **Embedded `/admin`** — Should the fleet observability app list show a
    “publishing” indicator, or only the app-scoped `/apps/{app}/admin` page?
 
 ## Decisions
 
 **CLI surface:** `gestaltd app registry publish` replaces `gestaltd app publish`.
 CI and manual publishes use the registry command. Pending lifecycle uses the
-same command with `--pending`.
+same command with `--pending publishing` or `--pending clear`.
+
+**Single phase:** Pending rows use `phase=publishing` from workflow start. No
+separate `packaging` phase.
 
 **Workflow start:** `publish-app-registry.yml` should call
-`gestaltd app registry publish --pending packaging` as early as possible (once
+`gestaltd app registry publish --pending publishing` as early as possible (once
 `PACKAGE_VERSION`, GCP auth, and `gestaltd` are available), not only at the end
 when artifacts are ready.
 

--- a/plans/app_registry/pending-publish.md
+++ b/plans/app_registry/pending-publish.md
@@ -122,9 +122,6 @@ that app.
 Prune is idempotent and safe to run concurrently with an in-flight publish:
 generation-match retries apply. An active publish refreshes `updatedAt` on each
 `--pending publishing` call, so a healthy in-flight entry is not removed.
-Workflows with packaging longer than 30 minutes should run
-`gestaltd app registry publish --pending publishing` again before the full
-`--dist-dir` step to refresh `updatedAt`.
 
 ---
 
@@ -184,9 +181,6 @@ gestaltd app registry publish \
   --workflow-run-url … \
   [--trigger-pr-number … --trigger-pr-url …] \
   --pending publishing
-
-# Optional — refresh updatedAt if packaging exceeds 30 minutes
-gestaltd app registry publish … --pending publishing
 
 # Failure cleanup
 gestaltd app registry publish … --pending clear

--- a/plans/app_registry/pending-publish.md
+++ b/plans/app_registry/pending-publish.md
@@ -53,7 +53,7 @@ Add mutable `pending.json` and `failed.json` catalogs in GCS per app.
 - **Failure** — `gestaltd app registry pending fail` removes the pending entry
   and records `failedAt` in `failed.json`.
 - **Stale** — `PrunePendingIndex` on the next `pending set` moves entries whose
-  `startedAt` is older than **2 hours** to `failed.json` with `reason=stale`.
+  `startedAt` is older than **30 minutes** to `failed.json` with `reason=stale`.
 
 `gestaltd` reads both catalogs alongside `index.json` and exposes them through
 the app-admin registry API. The UI merges pending, failed, and published entries
@@ -144,7 +144,7 @@ The workflow run URL remains the failure audit trail.
 | `reason` | Meaning |
 |----------|---------|
 | `workflow_failed` | CI called `gestaltd app registry pending fail` after packaging or publish failed |
-| `stale` | Pending `startedAt` was older than 2 hours when `PrunePendingIndex` ran |
+| `stale` | Pending `startedAt` was older than 30 minutes when `PrunePendingIndex` ran |
 
 ---
 
@@ -162,14 +162,12 @@ For each `pending.{version}` entry:
 
 | Condition | Action |
 |-----------|--------|
-| `startedAt` older than **2 hours** | Move to `failed.json` with `failedAt=now`, `reason=stale` |
+| `startedAt` older than **30 minutes** | Move to `failed.json` with `failedAt=now`, `reason=stale` |
 | Same `version` already listed in `index.json` | Remove from pending only (publish succeeded; pending cleanup missed) |
 | Otherwise | Keep |
 
-Use `startedAt`, not `updatedAt`, for the stale threshold. Packaging can take
-tens of minutes and `updatedAt` is only refreshed when the same version re-runs
-`pending set`; concurrent publishes for one app (different snapshot versions) must
-not mark an in-flight run as stale while it is still within the window.
+Use `startedAt`, not `updatedAt`, for the stale threshold. `updatedAt` is only
+refreshed when the same version re-runs `pending set`.
 
 ### `PruneFailedIndex`
 
@@ -181,7 +179,7 @@ For each `failed.{version}` entry:
 | Same `version` already listed in `index.json` | Remove |
 | Otherwise | Keep |
 
-The 2-hour pending threshold applies on `gestaltd app registry pending set`.
+The 30-minute pending threshold applies on `gestaltd app registry pending set`.
 Failed entries are retained for 30 days so operators can see recent failures on
 the admin page.
 
@@ -447,7 +445,7 @@ move or duplicate install earlier so pending can be recorded at workflow start).
 | Published catalog remains immutable per version | `versions/{version}.json` and artifacts still uploaded with `if-generation-match=0` |
 | Public read stays HTTP GET | `pending.json` and `failed.json` per app, no bucket listing |
 | Concurrent publishes for one app | Rare; `pending` map holds multiple versions. CI concurrency is per `(app, sha)`; different SHAs produce different version strings |
-| Stuck pending entries become failed | `PrunePendingIndex` on `pending set`; 2-hour `startedAt` threshold writes `failedAt` with `reason=stale` |
+| Stuck pending entries become failed | `PrunePendingIndex` on `pending set`; 30-minute `startedAt` threshold writes `failedAt` with `reason=stale` |
 | Workflow retries clear prior failures | `pending set` removes `failed.{version}` for the version being upserted |
 | Old failed entries are pruned | `PruneFailedIndex` on `pending set`; 30-day `failedAt` threshold |
 
@@ -478,7 +476,7 @@ Add types and CLI first so CI can call the new commands.
   `gestaltd app registry publish` (move logic from `gestaltd app publish`).
 - `pending set` removes `failed.{version}` for the version being upserted, then
   calls `PrunePendingIndex` and `PruneFailedIndex` before upsert; stale pending
-  (`startedAt` > 2 hours) → `failed.json`. `gestaltd app registry publish` does
+  (`startedAt` > 30 minutes) → `failed.json`. `gestaltd app registry publish` does
   not touch `pending.json` or `failed.json`.
 - Deprecate `gestaltd app publish` (alias → `gestaltd app registry publish`).
 - Tests: pending write/prune/fail/clear, stale → failed, deprecated alias. Add a
@@ -533,7 +531,7 @@ failed catalogs. CI calls `pending clear` on success and `pending fail` on
 failure.
 
 **Failed retention:** `failed.json` entries are kept for **30 days**, then pruned
-on `pending set`. Stale pending (`startedAt` older than 2 hours) records
+on `pending set`. Stale pending (`startedAt` older than 30 minutes) records
 `failedAt` with `reason=stale`.
 
 **Single phase:** Pending entries use `phase=publishing` from workflow start.

--- a/plans/app_registry/pending-publish.md
+++ b/plans/app_registry/pending-publish.md
@@ -36,6 +36,8 @@ Operators on `/apps/{app}/admin` should be able to answer:
 | Which commit / PR triggered it? | Pending entry provenance (same fields as published rows where available) |
 | Where is the CI run? | Link to `publication.workflowRunUrl` |
 | When did publish start? | `startedAt` on the pending entry |
+| How long has publish been running? | Elapsed time since `startedAt` on **Publishing** rows |
+| How long did publish take? | `publishedAt − publishStartedAt` on published rows; `failedAt − startedAt` on **Failed** rows |
 | Did a recent publish fail? | Row with status **Failed** and `failedAt` |
 | Why did it fail? | `reason` on the failed entry (`workflow_failed` or `stale`) |
 
@@ -55,7 +57,27 @@ Add mutable `pending.json` and `failed.json` catalogs in GCS per app.
 
 `gestaltd` reads both catalogs alongside `index.json` and exposes them through
 the app-admin registry API. The UI merges pending, failed, and published entries
-in the snapshots table.
+in the snapshots table and shows publish duration while in flight and after
+completion.
+
+### Publish duration
+
+Track how long a publish takes end to end:
+
+| State | Start anchor | End anchor | Display |
+|-------|--------------|------------|---------|
+| **Publishing** | `pending.startedAt` | now (UI clock) | “Publishing for 4m” |
+| **Published** | `publishStartedAt` | `publishedAt` | “Published in 4m 32s” |
+| **Failed** | `failed.startedAt` | `failed.failedAt` | “Failed after 35m” |
+
+`publishStartedAt` is written at upload time. `gestaltd app registry publish`
+reads the matching pending entry (if present) and copies `startedAt` into
+`publishStartedAt` on `versions/{version}.json` and `index.json`. When CI
+skipped `pending set`, or for legacy publishes, `publishStartedAt` is omitted and
+the UI shows only `publishedAt`.
+
+Duration is derived from timestamps — do not store a separate duration field in
+GCS.
 
 Pending and failed versions are **not** installable. Install-time validation
 continues to read only `versions/{version}.json` via the published index
@@ -247,9 +269,10 @@ gestaltd app registry pending fail \
 existing `failed.json` entry is left unchanged.
 
 **`gestaltd app registry publish`** — upload artifacts and version metadata,
-update `index.json` only. Does not read or write `pending.json` or
-`failed.json`. Same flags as today's `gestaltd app publish`; requires
-`--dist-dir`.
+update `index.json` only. Does not write `pending.json` or `failed.json`. Reads
+`pending.json` when present to copy `startedAt` into `publishStartedAt` on the
+uploaded version metadata and index entry. Same flags as today's
+`gestaltd app publish`; requires `--dist-dir`.
 
 ```bash
 gestaltd app registry publish \
@@ -300,12 +323,24 @@ Extend `GET /api/v1/apps/{app}/admin/registry` response:
   "registry": "toolshed",
   "desiredVersion": "0.0.0-snapshot.g…",
   "knownVersions": [ … ],
-  "publishedVersions": [ … ],
+  "publishedVersions": [
+    {
+      "version": "0.0.0-snapshot.g…",
+      "publishedAt": "2026-07-24T19:04:32Z",
+      "publishStartedAt": "2026-07-24T19:00:00Z",
+      "publishDurationSeconds": 272,
+      "platforms": ["linux/amd64"],
+      "sourceRef": "abc123…",
+      "sourceUrl": "https://github.com/…/commit/abc123…",
+      "publication": { … }
+    }
+  ],
   "pendingVersions": [
     {
       "version": "0.0.0-snapshot.g…",
       "startedAt": "2026-07-24T19:00:00Z",
       "updatedAt": "2026-07-24T19:04:12Z",
+      "publishingForSeconds": 252,
       "phase": "publishing",
       "sourceRef": "abc123…",
       "sourceUrl": "https://github.com/…/commit/abc123…",
@@ -317,6 +352,7 @@ Extend `GET /api/v1/apps/{app}/admin/registry` response:
       "version": "0.0.0-snapshot.g…",
       "startedAt": "2026-07-24T18:00:00Z",
       "failedAt": "2026-07-24T18:35:00Z",
+      "publishDurationSeconds": 2100,
       "reason": "stale",
       "sourceRef": "abc123…",
       "sourceUrl": "https://github.com/…/commit/abc123…",
@@ -335,6 +371,9 @@ Merge rules:
   cleanup), prefer **published** and omit pending and failed.
 - `pendingVersions` sorted by `startedAt` descending (newest first).
 - `failedVersions` sorted by `failedAt` descending (newest first).
+- `publishingForSeconds` on `pendingVersions` and `publishDurationSeconds` on
+  `publishedVersions` / `failedVersions` are computed at read time from the
+  timestamps above. Omit duration fields when the start anchor is missing.
 
 Install and upgrade handlers ignore `pending.json` and `failed.json` entirely.
 
@@ -356,17 +395,23 @@ published entries (single newest-first list with a status column).
 Pending entries:
 
 - Show PR / commit provenance when present (same columns as published)
-- **Published** column shows “In progress” or time since `startedAt`
+- **Published** column shows elapsed publish time (for example “Publishing for
+  4m”) from `publishingForSeconds` or `startedAt`
 - **Action** column: Deploy disabled; optional “View workflow” link using
   `publication.workflowRunUrl`
+
+Published entries:
+
+- When `publishStartedAt` is present, show total publish time (for example
+  “Published in 4m 32s”) alongside `publishedAt`
+- Legacy rows without `publishStartedAt` show `publishedAt` only
 
 Failed entries:
 
 - Show PR / commit provenance when present
-- **Published** column shows `failedAt` and a reason label (`workflow_failed` →
-  “Workflow failed”, `stale` → “Timed out”)
-- **Action** column: Deploy disabled; “View workflow” when
-  `publication.workflowRunUrl` is present
+- **Published** column shows `failedAt`, total time before failure (for example
+  “Failed after 35m”), and a reason label (`workflow_failed` → “Workflow
+  failed”, `stale` → “Timed out”)
 
 Polling: extend `AppAdminPageClient` to poll every **12s** while
 `pendingVersions.length > 0` or `failedVersions.length > 0`, not only during
@@ -424,6 +469,9 @@ Add types and CLI first so CI can call the new commands.
 
 - Add `PendingIndex` / `PendingVersion` and `FailedIndex` / `FailedVersion` to
   `gestaltd/internal/appregistry/` ([models.md](./models.md) documents shapes).
+- Add optional `publishStartedAt` to `IndexVersion`, `PublishedVersion`, and the
+  publish upload path (read `pending.json` at publish time; do not mutate
+  pending).
 - Add `gestaltd app registry pending set|clear|fail` and
   `gestaltd app registry publish` (move logic from `gestaltd app publish`).
 - `pending set` calls `PrunePendingIndex` and `PruneFailedIndex` before
@@ -439,6 +487,8 @@ Depends on **PR 1**. Exposes pending and failed catalog state to the admin page.
 
 - `FetchPendingIndex` and `FetchFailedIndex` in `gestaltd/internal/appregistry/`.
 - Extend `getAppAdminRegistry` with `pendingVersions[]` and `failedVersions[]`.
+- Include `publishStartedAt` on published rows and compute
+  `publishingForSeconds` / `publishDurationSeconds` at read time.
 - Tests: fetch helpers via `registrytest` HTTP fixture; handler returns pending
   and failed entries alongside published. Extend [tests.md](./tests.md).
 
@@ -461,7 +511,7 @@ operators get correct GCS state before the UI exists.
 Depends on **PR 2**. Completes admin visibility.
 
 - **Publishing** and **Failed** rows in the `gestalt-providers` app admin
-  snapshots table.
+  snapshots table, with elapsed and total publish duration labels.
 - Poll every ~12s while any pending or failed version exists; prefer published
   entry when the same version appears in multiple lists.
 - Manual / browser smoke per [tests.md](./tests.md) when implementing.
@@ -475,8 +525,10 @@ The embedded fleet `/admin` registry list does not show a publishing indicator.
 
 **CLI:** `gestaltd app registry pending` (`set`, `clear`, `fail`) owns
 `pending.json` and `failed.json`. `gestaltd app registry publish` uploads
-immutable artifacts and `index.json` only (replaces `gestaltd app publish`). CI
-calls `pending clear` on success and `pending fail` on failure.
+immutable artifacts and `index.json` (replaces `gestaltd app publish`); it may
+read `pending.json` to copy `publishStartedAt` but does not mutate pending or
+failed catalogs. CI calls `pending clear` on success and `pending fail` on
+failure.
 
 **Failed retention:** `failed.json` entries are kept for **30 days**, then pruned
 on `pending set`. Stale pending (30 minutes without `updatedAt` refresh) records
@@ -487,3 +539,7 @@ on `pending set`. Stale pending (30 minutes without `updatedAt` refresh) records
 **Workflow start:** `publish-app-registry.yml` should call
 `gestaltd app registry pending set` as early as possible (once `PACKAGE_VERSION`,
 GCP auth, and `gestaltd` are available), not only when artifacts are ready.
+
+**Publish duration:** `publishStartedAt` is copied from pending at publish time
+and stored on published registry objects. Durations are derived at read/UI time,
+not stored as separate GCS fields.

--- a/plans/app_registry/pending-publish.md
+++ b/plans/app_registry/pending-publish.md
@@ -89,20 +89,10 @@ On failure, **remove** the pending
 entry in a workflow `always()` cleanup step. The workflow run URL remains the
 failure audit trail.
 
-### Stale pending (read path)
-
-If CI crashes before cleanup, a pending row can linger in `pending.json`.
-Readers treat a pending entry as **stale** when `updatedAt` is older than a
-fixed TTL (proposal: **6 hours**). The API exposes `stale: true` on pending
-rows; the UI shows **Publishing (stale)** and still links the workflow run.
-
-Stale labeling is for operator visibility only. It does not remove the GCS
-entry — see [Self-healing](#self-healing) below.
-
 ### Self-healing
 
 `gestaltd serve` reads `pending.json` over public HTTP and cannot write back to
-GCS. Self-healing therefore runs on the **publish write path** (CI and
+GCS. Self-healing runs on the **publish write path** (CI and
 `gestaltd app registry pending` subcommands), which already hold bucket
 credentials.
 
@@ -111,9 +101,13 @@ before any pending mutation. Prune criteria for each `pending.{version}` entry:
 
 | Condition | Action |
 |-----------|--------|
-| `updatedAt` older than TTL (default **6 hours**) | Remove — publish likely failed or cleanup never ran |
+| `updatedAt` older than **30 minutes** | Remove — publish likely failed or cleanup never ran |
 | Same `version` already listed in `index.json` | Remove — publish succeeded but `pending end` did not run |
 | Otherwise | Keep |
+
+The 30-minute threshold is the default for `pending begin` and `pending prune`.
+No `stale` field on the app-admin API — stuck rows are removed in GCS instead
+of surfaced as a separate UI state.
 
 Prune uses the same optimistic-concurrency loop as `begin` / `end`: download
 `pending.json` generation, drop matching entries, upload with
@@ -122,8 +116,8 @@ Prune uses the same optimistic-concurrency loop as `begin` / `end`: download
 **When prune runs:**
 
 1. **`pending begin`** — always prune before adding the new entry. Every app
-   publish workflow triggers this, so stuck rows are cleared on the next merge to
-   `main` for that app even without a dedicated janitor job.
+   publish workflow self-heals stuck pending rows older than 30 minutes, so
+   orphaned entries are cleared on the next merge to `main` for that app.
 2. **`pending prune`** (new subcommand) — explicit sweep for one app or all
    enrolled apps. Used by a scheduled CI workflow and for manual operator cleanup.
 
@@ -132,27 +126,30 @@ Prune uses the same optimistic-concurrency loop as `begin` / `end`: download
 gestaltd app registry pending prune \
   --bucket gs://… \
   --app traffic-cop \
-  [--max-age 6h]
+  [--max-age 30m]
 
 # Prune every app that has a pending.json object (optional scheduled job)
 gestaltd app registry pending prune \
   --bucket gs://… \
   --all-apps \
-  [--max-age 6h]
+  [--max-age 30m]
 ```
 
 `--all-apps` lists `apps/*/pending.json` via the GCS API (publisher credentials
 only; not used by `gestaltd serve`). For each object, load the sibling
 `index.json`, apply the prune rules, and upload only when the pending map changed.
 
-**Scheduled janitor (recommended):** add a low-frequency workflow in `toolshed`
-(e.g. daily) that runs `pending prune --all-apps` against the app registry
-bucket. This covers apps that have not had a merge (and thus no `pending begin`)
-in longer than the TTL.
+**Scheduled janitor (recommended):** add a workflow in `toolshed` that runs
+`pending prune --all-apps` on a cadence shorter than the 30-minute threshold
+(e.g. every 15 minutes) so stuck entries are removed even when an app has not
+published recently.
 
 Prune is idempotent and safe to run concurrently with an in-flight publish:
 generation-match retries apply. An active publish refreshes `updatedAt` on each
-`begin` / `update`, so a healthy in-flight entry is not removed.
+`begin` / `update`, so a healthy in-flight entry is not removed. Workflows with
+packaging longer than 30 minutes should call `pending update` before the
+threshold elapses to refresh `updatedAt` (the step before `gestaltd app publish`
+already does this when entering the `publishing` phase).
 
 ---
 
@@ -212,7 +209,7 @@ gestaltd app registry pending prune \
   --bucket gs://… \
   --app traffic-cop \
   [--all-apps] \
-  [--max-age 6h]
+  [--max-age 30m]
 ```
 
 `begin` prunes stuck entries before upserting (see [Self-healing](#self-healing)).
@@ -258,8 +255,7 @@ Extend `GET /api/v1/apps/{app}/admin/registry` response:
       "phase": "packaging",
       "sourceRef": "abc123…",
       "sourceUrl": "https://github.com/…/commit/abc123…",
-      "publication": { … },
-      "stale": false
+      "publication": { … }
     }
   ],
   "rollout": { … },
@@ -287,8 +283,7 @@ with a status column).
 
 | Status | Condition |
 |--------|-----------|
-| **Publishing** | Row from `pendingVersions`, `stale=false` |
-| **Publishing (stale)** | Row from `pendingVersions`, `stale=true` |
+| **Publishing** | Row from `pendingVersions` |
 | **Deployed** | `version === desiredVersion` (unchanged) |
 | **Rolling out** | Active rollout for this version (unchanged) |
 | **Available** | Published, not desired (unchanged) |
@@ -320,9 +315,9 @@ In `toolshed` (and any repo using the shared workflow):
 The `begin` step needs the gestaltd binary — reuse the existing install step
 ordering (install gestaltd before pending begin).
 
-**Janitor:** add a scheduled workflow (e.g. daily) that runs
-`gestaltd app registry pending prune --all-apps` so stuck entries are removed
-even when an app has not published recently.
+**Janitor:** add a scheduled workflow (e.g. every 15 minutes) that runs
+`gestaltd app registry pending prune --all-apps` so stuck entries older than
+30 minutes are removed even when an app has not published recently.
 
 ---
 
@@ -335,7 +330,7 @@ even when an app has not published recently.
 | Published catalog remains immutable per version | `versions/{version}.json` and artifacts still uploaded with `if-generation-match=0` |
 | Public read stays HTTP GET | Single `pending.json` per app, no bucket listing |
 | Concurrent publishes for one app | Rare; `pending` map holds multiple versions. CI concurrency is per `(app, sha)`; different SHAs produce different version strings |
-| Stuck pending rows are removed | `PrunePendingIndex` on `pending begin` and `pending prune`; TTL + already-published checks |
+| Stuck pending rows are removed | `PrunePendingIndex` on `pending begin` and `pending prune`; 30-minute `updatedAt` threshold + already-published checks |
 
 ---
 
@@ -348,7 +343,7 @@ even when an app has not published recently.
    `PrunePendingIndex`.
 3. **Read path** — `FetchPendingIndex`; unit tests with `registrytest` HTTP
    fixture.
-4. **App-admin API** — extend `getAppAdminRegistry`; stale TTL in handler.
+4. **App-admin API** — extend `getAppAdminRegistry` with `pendingVersions`.
 5. **UI** — pending rows + polling in `gestalt-providers` app admin table.
 6. **CI** — wire `publish-app-registry.yml` begin/update/end steps; add scheduled
    `pending prune --all-apps` janitor workflow.
@@ -360,16 +355,15 @@ Suggested order: 1 → 2 → 3 → 4 → 6 (CI can ship begin/end before UI) →
 
 ## Open questions
 
-1. **TTL** — Is 6 hours the right prune threshold?
-2. **Phase granularity** — Is `packaging` / `publishing` enough, or do we want
+1. **Phase granularity** — Is `packaging` / `publishing` enough, or do we want
    per-platform sub-phases in v1?
-3. **Manual publish** — Should `gestaltd app publish` call `pending begin/end`
+2. **Manual publish** — Should `gestaltd app publish` call `pending begin/end`
    automatically when `--workflow-run-url` is set, so local/manual publishes
    also appear in the admin UI?
-4. **Embedded `/admin`** — Should the fleet observability app list show a
+3. **Embedded `/admin`** — Should the fleet observability app list show a
    “publishing” indicator, or only the app-scoped `/apps/{app}/admin` page?
-5. **Janitor cadence** — Is daily `pending prune --all-apps` sufficient, or
-   should prune run more frequently?
+4. **Janitor cadence** — Is every 15 minutes sufficient for `pending prune
+   --all-apps`, or should it run more frequently?
 
 ---
 

--- a/plans/app_registry/pending-publish.md
+++ b/plans/app_registry/pending-publish.md
@@ -17,7 +17,7 @@ Related docs:
 
 Today the **Published snapshots** table only reflects versions listed in
 `apps/{app}/index.json`. That file is updated as the **last** step of
-`gestaltd app publish`, after packaging and artifact upload complete.
+`gestaltd app registry publish`, after packaging and artifact upload complete.
 
 During CI (`publish-app-registry.yml`), operators see nothing on the admin page
 while a publish is running — even though the version string and workflow run are
@@ -83,7 +83,7 @@ writes: read generation, merge, upload with `if-generation-match`.
 | Phase | Meaning |
 |-------|---------|
 | `packaging` | `gestaltd provider package` / artifact build in progress. Pending record created at workflow start. |
-| `publishing` | Artifacts built; `gestaltd app publish` upload + index update in progress. Set immediately before the publish step. |
+| `publishing` | Artifacts built; `gestaltd app registry publish` upload + index update in progress. Set immediately before the publish step. |
 
 On failure, **remove** the pending
 entry in a workflow `always()` cleanup step. The workflow run URL remains the
@@ -92,7 +92,7 @@ failure audit trail.
 ### Self-healing
 
 `gestaltd serve` reads `pending.json` over public HTTP and cannot write back to
-GCS. Self-healing runs on the **`gestaltd app publish` write path** (CI and
+GCS. Self-healing runs on the **`gestaltd app registry publish` write path** (CI and
 manual publishes), which already hold bucket credentials.
 
 A shared `PrunePendingIndex` helper removes stuck entries from `pending.json`
@@ -104,7 +104,7 @@ before any pending mutation. Prune criteria for each `pending.{version}` entry:
 | Same `version` already listed in `index.json` | Remove — publish succeeded but pending was not cleared |
 | Otherwise | Keep |
 
-The 30-minute threshold applies on the first `gestaltd app publish --pending`
+The 30-minute threshold applies on the first `gestaltd app registry publish --pending`
 call in a workflow.
 No `stale` field on the app-admin API — stuck rows are removed in GCS instead
 of surfaced as a separate UI state.
@@ -113,7 +113,7 @@ of surfaced as a separate UI state.
 writes: download `pending.json` generation, drop matching entries, upload with
 `if-generation-match`.
 
-The first `gestaltd app publish --pending …` call in a workflow always prunes
+The first `gestaltd app registry publish --pending …` call in a workflow always prunes
 before upserting. Every app publish workflow self-heals stuck pending rows older
 than 30 minutes, so orphaned entries are cleared on the next merge to `main` for
 that app.
@@ -121,7 +121,7 @@ that app.
 Prune is idempotent and safe to run concurrently with an in-flight publish:
 generation-match retries apply. An active publish refreshes `updatedAt` on each
 `--pending` call, so a healthy in-flight entry is not removed. Workflows with
-packaging longer than 30 minutes should run `gestaltd app publish --pending
+packaging longer than 30 minutes should run `gestaltd app registry publish --pending
 publishing` before the threshold elapses (step 4 below).
 
 ---
@@ -133,25 +133,25 @@ CI: publish-app-registry.yml
 │
 ├─1. Resolve PACKAGE_VERSION + PROVIDER_REF
 │
-├─2. gestaltd app publish --pending packaging
+├─2. gestaltd app registry publish --pending packaging
 │      (same --bucket/--app/--version/--ref/--workflow-run-url flags as step 5)
 │      → PrunePendingIndex (drop entries older than 30m or already in index.json)
 │      → upsert pending.json for this version (phase=packaging)
 │
 ├─3. Package artifacts (may take tens of minutes)
 │
-├─4. gestaltd app publish --pending publishing
+├─4. gestaltd app registry publish --pending publishing
 │
-├─5. gestaltd app publish --dist-dir … (artifacts + versions/{version}.json + index.json)
+├─5. gestaltd app registry publish --dist-dir … (artifacts + versions/{version}.json + index.json)
 │      → clear this version from pending.json on success
 │
-└─6. gestaltd app publish --pending clear  (always() failure cleanup)
+└─6. gestaltd app registry publish --pending clear  (always() failure cleanup)
        → remove version from pending.json if step 5 did not run
 ```
 
-Today, `publish-app-registry.yml` already runs step 5 only (`gestaltd app
-publish` with `--dist-dir`). This proposal adds steps 2, 4, and 6 around the
-existing command — no new top-level CLI subcommands.
+Today, `publish-app-registry.yml` runs `gestaltd app publish --dist-dir …` only.
+This proposal migrates to `gestaltd app registry publish` and adds steps 2, 4,
+and 6 for pending visibility.
 
 On **success**, step 5 clears pending after uploading. Order within step 5 is
 unchanged: `index.json` is still updated last.
@@ -161,14 +161,22 @@ publish failed, so pending does not stick unless the cleanup step itself fails.
 
 ### CLI surface
 
-Extend the existing `gestaltd app publish` command — no `gestaltd app registry`
-subcommands.
+Introduce `gestaltd app registry publish` to replace `gestaltd app publish`.
+Move publish implementation under `gestaltd app registry`; keep `gestaltd app
+publish` as a deprecated alias during migration, then remove it.
+
+```text
+gestaltd app registry publish [flags]
+```
+
+Flags are unchanged from today's `gestaltd app publish`, plus `--pending` for
+pending-only operations.
 
 **Pending-only** (no `--dist-dir`): write or update `pending.json` only.
 
 ```bash
 # Workflow start — record pending publish (prunes stuck entries first)
-gestaltd app publish \
+gestaltd app registry publish \
   --bucket gs://… \
   --app traffic-cop \
   --version 0.0.0-snapshot.g… \
@@ -178,18 +186,18 @@ gestaltd app publish \
   --pending packaging
 
 # Before artifact upload — refresh phase / updatedAt
-gestaltd app publish … --pending publishing
+gestaltd app registry publish … --pending publishing
 
 # Failure cleanup
-gestaltd app publish … --pending clear
+gestaltd app registry publish … --pending clear
 ```
 
-**Full publish** (existing behavior, extended): when `--dist-dir` is set,
-upload artifacts and version metadata, update `index.json`, then remove this
-version from `pending.json`.
+**Full publish:** when `--dist-dir` is set, upload artifacts and version
+metadata, update `index.json`, then remove this version from `pending.json`.
+Same behavior as today's `gestaltd app publish`.
 
 ```bash
-gestaltd app publish \
+gestaltd app registry publish \
   --bucket gs://… \
   --app traffic-cop \
   --version 0.0.0-snapshot.g… \
@@ -297,13 +305,13 @@ idle.
 In `toolshed` (and any repo using the shared workflow):
 
 1. After `Resolve package inputs` (when `PACKAGE_VERSION` is known), authenticate
-   to GCP and run `gestaltd app publish --pending packaging` with the same
+   to GCP and run `gestaltd app registry publish --pending packaging` with the same
    publication flags used in the final publish step.
 2. Immediately before the existing publish step, run
-   `gestaltd app publish --pending publishing`.
-3. Keep the existing `gestaltd app publish --dist-dir …` step (clears pending on
+   `gestaltd app registry publish --pending publishing`.
+3. Keep the existing `gestaltd app registry publish --dist-dir …` step (clears pending on
    success).
-4. Add an `always()` step that runs `gestaltd app publish --pending clear` when
+4. Add an `always()` step that runs `gestaltd app registry publish --pending clear` when
    the full publish step did not succeed.
 
 Install `gestaltd` before step 1 (today it is installed only in the publish job;
@@ -320,7 +328,7 @@ move or duplicate install earlier so step 2 can run at workflow start).
 | Published catalog remains immutable per version | `versions/{version}.json` and artifacts still uploaded with `if-generation-match=0` |
 | Public read stays HTTP GET | Single `pending.json` per app, no bucket listing |
 | Concurrent publishes for one app | Rare; `pending` map holds multiple versions. CI concurrency is per `(app, sha)`; different SHAs produce different version strings |
-| Stuck pending rows are removed | `PrunePendingIndex` on first `gestaltd app publish --pending`; 30-minute `updatedAt` threshold + already-published checks |
+| Stuck pending rows are removed | `PrunePendingIndex` on first `gestaltd app registry publish --pending`; 30-minute `updatedAt` threshold + already-published checks |
 
 ---
 
@@ -328,17 +336,18 @@ move or duplicate install earlier so step 2 can run at workflow start).
 
 1. **Models** — Add `PendingIndex` / `PendingVersion` to
    `gestaltd/internal/appregistry/`; document in [models.md](./models.md).
-2. **Write path** — extend `gestaltd app publish` with `--pending
-   packaging|publishing|clear`; generation-match retries (mirror index upsert).
-   First `--pending` call calls `PrunePendingIndex`; full publish clears pending
-   on success.
+2. **Write path** — add `gestaltd app registry publish` (move logic from
+   `gestaltd app publish`); support `--pending packaging|publishing|clear`.
+   Generation-match retries (mirror index upsert). First `--pending` call calls
+   `PrunePendingIndex`; full publish clears pending on success. Deprecate
+   `gestaltd app publish`.
 3. **Read path** — `FetchPendingIndex`; unit tests with `registrytest` HTTP
    fixture.
 4. **App-admin API** — extend `getAppAdminRegistry` with `pendingVersions`.
 5. **UI** — pending rows + polling in `gestalt-providers` app admin table.
-6. **CI** — extend `publish-app-registry.yml` with early `--pending packaging`,
-   pre-upload `--pending publishing`, and failure `--pending clear` around the
-   existing `gestaltd app publish --dist-dir` step.
+6. **CI** — migrate `publish-app-registry.yml` from `gestaltd app publish` to
+   `gestaltd app registry publish`; add early `--pending packaging`, pre-upload
+   `--pending publishing`, and failure `--pending clear`.
 7. **Tests** — see [tests.md](./tests.md) (add section when implementing).
 
 Suggested order: 1 → 2 → 3 → 4 → 6 (CI can ship begin/end before UI) → 5.
@@ -354,14 +363,14 @@ Suggested order: 1 → 2 → 3 → 4 → 6 (CI can ship begin/end before UI) →
 
 ## Decisions
 
-**CLI surface:** Extend `gestaltd app publish` only — no `gestaltd app registry`
-subcommands. CI and manual publishes use the same command.
+**CLI surface:** `gestaltd app registry publish` replaces `gestaltd app publish`.
+CI and manual publishes use the registry command. Pending lifecycle uses the
+same command with `--pending`.
 
 **Workflow start:** `publish-app-registry.yml` should call
-`gestaltd app publish --pending packaging` as early as possible (once
+`gestaltd app registry publish --pending packaging` as early as possible (once
 `PACKAGE_VERSION`, GCP auth, and `gestaltd` are available), not only at the end
-when artifacts are ready. The final `gestaltd app publish --dist-dir …` step is
-unchanged and already what auto-publish uses today.
+when artifacts are ready.
 
 ---
 

--- a/plans/app_registry/pending-publish.md
+++ b/plans/app_registry/pending-publish.md
@@ -155,6 +155,39 @@ immediately after so operators never depend on pending lingering post-success.
 On **failure**, an `always()` workflow step runs step 6 even when packaging or
 publish failed, so pending does not stick unless the cleanup step itself fails.
 
+### CLI surface (proposal)
+
+Add a subcommand group rather than overloading `gestaltd app publish`:
+
+```bash
+gestaltd app registry pending begin \
+  --bucket gs://… \
+  --app traffic-cop \
+  --version 0.0.0-snapshot.g… \
+  --ref abc123… \
+  --workflow-run-url … \
+  [--trigger-pr-number … --trigger-pr-url …]
+
+gestaltd app registry pending update \
+  --bucket gs://… \
+  --app traffic-cop \
+  --version 0.0.0-snapshot.g… \
+  --phase publishing
+
+gestaltd app registry pending end \
+  --bucket gs://… \
+  --app traffic-cop \
+  --version 0.0.0-snapshot.g…
+```
+
+`begin` runs `PrunePendingIndex` before upserting (see [Self-healing](#self-healing)).
+`begin` is idempotent for the same `(app, version)`: refresh `updatedAt` and
+merge `publication` if re-run. `end` is idempotent if the version is already
+absent.
+
+Implementation reuses the index upload helper (generation-match retries) in
+`gestaltd/internal/daemon/app_publish.go`.
+
 ---
 
 ## Read path

--- a/plans/app_registry/plan.md
+++ b/plans/app_registry/plan.md
@@ -42,7 +42,7 @@ Each published version should include immutable metadata and artifact references
 
 `config.yaml` defines where Gestalt **reads** installable apps (`appRegistries`). That is the deploy/runtime reader config.
 
-CI **publishes** with CLI flags — `gestaltd app publish --bucket BUCKET` — not a publisher block in config. Immutability is enforced by the publish command. See [config.md](./config.md).
+CI **publishes** with CLI flags — `gestaltd app registry publish --bucket BUCKET` — not a publisher block in config. Immutability is enforced by the publish command. See [config.md](./config.md).
 
 Registries may be public or private. A private registry may require credentials or a configured secrets provider.
 
@@ -59,7 +59,7 @@ appRegistries:
 Publish example (CI workflow):
 
 ```bash
-gestaltd app publish \
+gestaltd app registry publish \
   --bucket gs://gitlab-peach-street-gestalt-app-registry \
   --app g-issues \
   --version 0.0.1 \
@@ -67,7 +67,7 @@ gestaltd app publish \
   --dist-dir dist/
 ```
 
-`gestaltd app publish` writes immutable objects under `apps/{app}/` in the bucket:
+`gestaltd app registry publish` writes immutable objects under `apps/{app}/` in the bucket:
 
 ```text
 apps/{app}/
@@ -203,7 +203,7 @@ Store schema and service API: [indexeddb.md](./indexeddb.md#store-app_version_ch
 
 Validation should happen in two phases.
 
-At publish time, `gestaltd provider package`, `gestaltd provider publish`, or `gestaltd app publish` should validate the app version before writing it to the registry.
+At publish time, `gestaltd provider package`, `gestaltd provider publish`, or `gestaltd app registry publish` should validate the app version before writing it to the registry.
 
 Publish-time validation should ensure:
 
@@ -249,7 +249,7 @@ Core recovery paths must not depend on dynamically installed apps.
 
 ## Implementation Path
 
-1. Prototype a GCS registry and publish a single app there (`publish-app-registry.yml` + `gestaltd app publish --bucket`).
+1. Prototype a GCS registry and publish a single app there (`publish-app-registry.yml` + `gestaltd app registry publish --bucket`).
 2. Use a parallel path to `publish-app-snapshot.yml` so normal app publishing is not interrupted.
 3. Start with publishing `g-issues`.
 4. Prototype a Gestalt endpoint that lists available versions in configured registries. See [lifecycle.md](./lifecycle.md).
@@ -283,7 +283,7 @@ Install validation should read workflow app-call targets from `versions/{version
 At publish time:
 
 - derive `workflows.yaml` during `gestaltd provider package` (`GESTALT_APP_WRITE_WORKFLOWS`), including when `catalog.yaml` already exists
-- copy app-call steps into the registry entry at `gestaltd app publish`
+- copy app-call steps into the registry entry at `gestaltd app registry publish`
 - require identical workflow metadata across platform archives (same rule as static catalog)
 
 At install time, validate `entry.workflows` before `AppendRequest` — see [validation.md](./validation.md). Config-managed `workflows.definitions` stay separate and are validated at config load.

--- a/plans/app_registry/plan.md
+++ b/plans/app_registry/plan.md
@@ -270,9 +270,9 @@ Core recovery paths must not depend on dynamically installed apps.
 ### Pending publish visibility
 
 Show in-flight CI publishes on `/apps/{app}/admin` before `index.json` is
-updated. Add a mutable `apps/{app}/pending.json` in GCS, CI begin/update/end
-hooks, and pending rows in the app-admin API and snapshots table. See
-[pending-publish.md](./pending-publish.md).
+updated. Add mutable `apps/{app}/pending.json` and `apps/{app}/failed.json` in
+GCS, CI lifecycle hooks, and pending/failed rows in the app-admin API and
+snapshots table. See [pending-publish.md](./pending-publish.md).
 
 ### Packaged workflow metadata
 

--- a/plans/app_registry/plan.md
+++ b/plans/app_registry/plan.md
@@ -269,10 +269,10 @@ Core recovery paths must not depend on dynamically installed apps.
 
 ### Pending publish visibility
 
-Show in-flight CI publishes on `/apps/{app}/admin` before `index.json` is
-updated. Add mutable `apps/{app}/pending.json` and `apps/{app}/failed.json` in
-GCS, CI lifecycle hooks, and pending/failed rows in the app-admin API and
-snapshots table. See [pending-publish.md](./pending-publish.md).
+Show in-flight and recently failed CI publishes on `/apps/{app}/admin` before
+and after `index.json` is updated. Add mutable `apps/{app}/pending.json` and
+`apps/{app}/failed.json` in GCS, CI lifecycle hooks, and pending/failed rows in
+the app-admin API and snapshots table. See [pending-publish.md](./pending-publish.md).
 
 ### Packaged workflow metadata
 

--- a/plans/app_registry/plan.md
+++ b/plans/app_registry/plan.md
@@ -267,6 +267,13 @@ Core recovery paths must not depend on dynamically installed apps.
 
 ## Future work
 
+### Pending publish visibility
+
+Show in-flight CI publishes on `/apps/{app}/admin` before `index.json` is
+updated. Add a mutable `apps/{app}/pending.json` in GCS, CI begin/update/end
+hooks, and pending rows in the app-admin API and snapshots table. See
+[pending-publish.md](./pending-publish.md).
+
 ### Packaged workflow metadata
 
 Packaged apps declare workflow definitions in provider source. Bootstrap registers them from `DeclaredWorkflowDefinitions` after install — too late to reject a bad version before fleet accept.

--- a/plans/app_registry/plan.md
+++ b/plans/app_registry/plan.md
@@ -271,8 +271,9 @@ Core recovery paths must not depend on dynamically installed apps.
 
 Show in-flight and recently failed CI publishes on `/apps/{app}/admin` before
 and after `index.json` is updated. Add mutable `apps/{app}/pending.json` and
-`apps/{app}/failed.json` in GCS, CI lifecycle hooks, and pending/failed rows in
-the app-admin API and snapshots table. See [pending-publish.md](./pending-publish.md).
+`apps/{app}/failed.json` in GCS, CI lifecycle hooks, pending/failed rows in the
+app-admin API and snapshots table, and publish duration on in-flight and
+completed publishes. See [pending-publish.md](./pending-publish.md).
 
 ### Packaged workflow metadata
 

--- a/plans/app_registry/plan.md
+++ b/plans/app_registry/plan.md
@@ -271,9 +271,8 @@ Core recovery paths must not depend on dynamically installed apps.
 
 Show in-flight and recently failed CI publishes on `/apps/{app}/admin` before
 and after `index.json` is updated. Add mutable `apps/{app}/pending.json` and
-`apps/{app}/failed.json` in GCS, CI lifecycle hooks, pending/failed rows in the
-app-admin API and snapshots table, and publish duration on in-flight and
-completed publishes. See [pending-publish.md](./pending-publish.md).
+`apps/{app}/failed.json` in GCS, CI lifecycle hooks, and pending/failed rows in
+the app-admin API and snapshots table. See [pending-publish.md](./pending-publish.md).
 
 ### Packaged workflow metadata
 

--- a/plans/app_registry/service.md
+++ b/plans/app_registry/service.md
@@ -1,6 +1,6 @@
 # `gestaltd/internal/appregistry/registry.go`
 
-Public interface for the app registry package as introduced in [gestalt#2709](https://github.com/valon-technologies/gestalt/pull/2709) commit 1. JSON shapes are defined in [models.md](./models.md). Deploy reader config is in [config.md](./config.md); `gestaltd app publish` passes `--bucket` on the CLI.
+Public interface for the app registry package as introduced in [gestalt#2709](https://github.com/valon-technologies/gestalt/pull/2709) commit 1. JSON shapes are defined in [models.md](./models.md). Deploy reader config is in [config.md](./config.md); `gestaltd app registry publish` passes `--bucket` on the CLI.
 
 ## PublishedVersion construction
 

--- a/plans/app_registry/tests.md
+++ b/plans/app_registry/tests.md
@@ -72,6 +72,38 @@ Expected plan fields:
 
 ---
 
+## Pending catalog write path
+
+Planned in pending publish PR 1. See [pending-publish.md](./pending-publish.md#pr-1--models-and-write-path-gestalt).
+
+Run:
+
+```bash
+cd gestaltd
+go test ./internal/appregistry -run 'Pending|Prune|Record|Upsert|DecodePending|PublishStartedAt' -count=1
+go test ./internal/daemon/e2e/app_publish -run 'AppRegistryPublish|AppPublish' -count=1
+```
+
+### `internal/appregistry/pending_test.go`
+
+- **`TestPrunePendingIndex_MovesStaleEntryToFailed`** — pending `startedAt` older than 30 minutes moves to `failed.json` with `reason=stale`.
+- **`TestPrunePendingIndex_KeepsInFlightEntryWithinStaleWindow`** — in-flight pending younger than 30 minutes is not stale-pruned.
+- **`TestPrunePendingIndex_DropsAlreadyPublishedVersion`** — pending entry is removed when the version is already in `index.json`.
+- **`TestPruneFailedIndex_RemovesOldAndPublishedEntries`** — failed entries older than 30 days or already published are pruned.
+- **`TestUpsertPendingVersion_PreservesStartedAt`** — `pending set` refresh keeps the original `startedAt`.
+- **`TestRecordFailedVersion_IsIdempotent`** — `pending fail` does not overwrite an existing failed entry.
+- **`TestDecodePendingAndFailedIndexRoundTrip`** — JSON encode/decode validates catalog shapes.
+- **`TestRemoveFailedVersion`** — `pending set` clears a prior `failed.{version}` on workflow retry.
+- **`TestPublishStartedAtFromPending`** — publish reads `startedAt` from a matching pending entry.
+- **`TestUpsertAppIndex_CopiesPublishStartedAt`** — published index entries copy `publishStartedAt` from the version metadata.
+
+### `internal/daemon/e2e/app_publish/app_publish_test.go`
+
+- **`TestRun_AppRegistryPublishDryRunMatchesDeprecatedAlias`** — `gestaltd app registry publish --dry-run` emits the same plan as the deprecated `gestaltd app publish` command.
+- **`TestRun_AppPublishUploadsAndRetriesIndexWithProgress`** — deprecated `gestaltd app publish` prints a stderr deprecation warning.
+
+---
+
 ## Add and upgrade HTTP integration
 
 Added in [gestalt#2730](https://github.com/valon-technologies/gestalt/pull/2730) (`POST …/install`). Registry-only apps use separate `add` and `upgrade` routes — see [lifecycle.md](./lifecycle.md#post-adminapiv1app-registriesregistryappsappadd).

--- a/plans/app_registry/tests.md
+++ b/plans/app_registry/tests.md
@@ -36,7 +36,7 @@ Test fixture for install HTTP tests: `internal/appregistry/registrytest/fixture.
 
 ## Publish dry-run E2E
 
-Added in [gestalt#2709](https://github.com/valon-technologies/gestalt/pull/2709) (GCS app registry + `gestaltd app publish`).
+Added in [gestalt#2709](https://github.com/valon-technologies/gestalt/pull/2709) (GCS app registry + `gestaltd app registry publish`).
 
 Run:
 
@@ -45,7 +45,7 @@ cd gestaltd
 go test ./internal/daemon/e2e/appregistry -count=1
 ```
 
-This is a **behavioral** test: the compiled `gestaltd` binary runs as a subprocess through `provider package` → `app publish --dry-run`. No real GCS uploads.
+This is a **behavioral** test: the compiled `gestaltd` binary runs as a subprocess through `provider package` → `app registry publish --dry-run`. No real GCS uploads.
 
 `--dry-run` always prints a JSON plan (`gestaltd.app.publish.plan.v1`) to stdout.
 
@@ -58,7 +58,7 @@ Flow:
 1. Create a temp app fixture at `apps/release-test/` (`newAppRegistryPublishFixture`)
 2. Initialize a git repo (`initProviderPublishGitRepo`)
 3. Run `gestaltd provider package --version … --output dist/`
-4. Run `gestaltd app publish --bucket gs://gestalt-app-registry --app release-test --version … --ref … --dist-dir dist/ --dry-run`
+4. Run `gestaltd app registry publish --bucket gs://gestalt-app-registry --app release-test --version … --ref … --dist-dir dist/ --dry-run`
 5. Decode and assert the JSON plan
 
 Expected plan fields:


### PR DESCRIPTION
## Summary
- Add `plans/app_registry/pending-publish.md` describing a GCS `pending.json` catalog, CI begin/update/end hooks, and app-admin API/UI changes for in-flight snapshot publishes
- Link the new plan from `plan.md`, `admin.md`, and `models.md`

## Test plan
- [x] Docs only — review plan structure and cross-links


Made with [Cursor](https://cursor.com)