### PR TITLE
Document publish duration for app registry admin

### DIFF
--- a/plans/app_registry/admin.md
+++ b/plans/app_registry/admin.md
@@ -111,7 +111,7 @@ Implemented in `gestalt-providers` (default `/apps` UI), not the embedded
 - Show per-version `publishedAt`, linked source commit, triggering PR or commit, and publishing workflow run.
 - Show publish duration on published rows when `publishStartedAt` is recorded (“Published in 4m 32s”).
 - Legacy published versions without workflow metadata still link the commit and show **not recorded** for workflow/PR fields.
-- Disable the selector while a rollout is `enrolling` or `restarting`; refresh until terminal.
+- Disable deploy actions while a rollout is `enrolling` or `restarting`; refresh until terminal.
 - Render access denied on **403** without leaking registry metadata.
 - Show in-flight publishes (**Publishing**) with elapsed time since `startedAt`, and recent failed publishes
   (**Failed**) with total time before failure. See [pending-publish.md](./pending-publish.md).
@@ -120,31 +120,65 @@ Selection is fleet-wide. It is not per-user or per-replica.
 
 ### App admin page
 
-```text
-┌─────────────────────────────────────────────────────────────┐
-│ g-issues                                      App management │
-│ registry: toolshed                                          │
-├─────────────────────────────────────────────────────────────┤
-│ Desired version                                             │
-│ [ 0.0.0-snapshot.gabc123                         ▾ ]         │
-│                                                             │
-│ Published 2026-07-22 15:00 · linux/amd64                    │
-│ Commit def456 · PR #3251 · workflow run                     │
-│                                                             │
-│                                      [ Select version ]      │
-└─────────────────────────────────────────────────────────────┘
-```
-
-During an active rollout:
+The page header shows the app name, **App management** label, and registry
+binding. Below that: current **Desired version**, then the **Published
+snapshots** table (pending, failed, and published entries in one newest-first
+list). Each row has **Deploy** in the action column unless selection is disabled
+or the row is not deployable.
 
 ```text
-│ Rollout enrolling: 0.0.0-snapshot.gdef456                  │
-│ [ 0.0.0-snapshot.gabc123                         ▾ ] disabled│
-│                                      [ Select version ] disabled
++-------------------------------------------------------------+
+| g-issues                               App management       |
+| registry: toolshed                                          |
++-------------------------------------------------------------+
+| Desired version: 0.0.0-snapshot.gabc123                     |
++-------------------------------------------------------------+
+| Published snapshots                                         |
+|                                                             |
+| Version                 Status       Timing       Action    |
+| ---------------------   ----------   -----------   -------- |
+| 0.0.0-snapshot.gnew     Publishing   for 4m       —         |
+|                         PR #3740 · workflow                 |
+| 0.0.0-snapshot.gdef456  Available    Jul 22 15:00  Deploy   |
+|                         in 4m 32s · PR #3251                |
+| 0.0.0-snapshot.gabc123  Deployed     Jul 21 12:00  —         |
+|                         PR #3200                              |
++-------------------------------------------------------------+
 ```
 
-After a successful selection, show the new rollout state and keep the selector
-disabled until that rollout reaches `complete` or `failed`.
+**Publishing** rows show elapsed time and provenance; **Deploy** is disabled.
+**Available** published rows show `publishedAt` and publish duration when
+`publishStartedAt` is recorded. **Deployed** marks the desired version.
+
+During an active rollout, disable deploy actions and show rollout state above the
+table:
+
+```text
++-------------------------------------------------------------+
+| g-issues                               App management       |
+| registry: toolshed                                          |
++-------------------------------------------------------------+
+| Desired version: 0.0.0-snapshot.gabc123                     |
+| Rollout enrolling: 0.0.0-snapshot.gdef456                   |
++-------------------------------------------------------------+
+| Published snapshots                                         |
+|                                                             |
+| Version                 Status       Timing       Action    |
+| ---------------------   ----------   -----------   -------- |
+| 0.0.0-snapshot.gdef456  Rolling out  Jul 22 15:00  disabled |
+| 0.0.0-snapshot.gabc123  Deployed     Jul 21 12:00  disabled |
++-------------------------------------------------------------+
+```
+
+A **Failed** row in the same table:
+
+```text
+| 0.0.0-snapshot.gdead    Failed       Jul 24 18:35   —         |
+|                         after 35m · Timed out · workflow    |
+```
+
+After a successful deploy selection, keep deploy actions disabled until the
+rollout reaches `complete` or `failed`.
 
 ---
 

--- a/plans/app_registry/admin.md
+++ b/plans/app_registry/admin.md
@@ -109,11 +109,12 @@ Implemented in `gestalt-providers` (default `/apps` UI), not the embedded
 - **Manage app** on the `/apps` catalog when the caller can administer that app.
 - Select the fleet-wide desired version: first install, upgrade, or revert to an older published version.
 - Show per-version `publishedAt`, linked source commit, triggering PR or commit, and publishing workflow run.
+- Show publish duration on published rows when `publishStartedAt` is recorded (“Published in 4m 32s”).
 - Legacy published versions without workflow metadata still link the commit and show **not recorded** for workflow/PR fields.
 - Disable the selector while a rollout is `enrolling` or `restarting`; refresh until terminal.
 - Render access denied on **403** without leaking registry metadata.
-- Show in-flight publishes (**Publishing**) and recent failed publishes
-  (**Failed**) in the snapshots table. See [pending-publish.md](./pending-publish.md).
+- Show in-flight publishes (**Publishing**) with elapsed time since `startedAt`, and recent failed publishes
+  (**Failed**) with total time before failure. See [pending-publish.md](./pending-publish.md).
 
 Selection is fleet-wide. It is not per-user or per-replica.
 

--- a/plans/app_registry/admin.md
+++ b/plans/app_registry/admin.md
@@ -109,12 +109,10 @@ Implemented in `gestalt-providers` (default `/apps` UI), not the embedded
 - **Manage app** on the `/apps` catalog when the caller can administer that app.
 - Select the fleet-wide desired version: first install, upgrade, or revert to an older published version.
 - Show per-version `publishedAt`, linked source commit, triggering PR or commit, and publishing workflow run.
-- Show publish duration on published rows when `publishStartedAt` is recorded (“Published in 4m 32s”).
+- Show in-flight (**Publishing**) and recent failed (**Failed**) publishes with elapsed or total publish time. See [pending-publish.md](./pending-publish.md).
 - Legacy published versions without workflow metadata still link the commit and show **not recorded** for workflow/PR fields.
 - Disable deploy actions while a rollout is `enrolling` or `restarting`; refresh until terminal.
 - Render access denied on **403** without leaking registry metadata.
-- Show in-flight publishes (**Publishing**) with elapsed time since `startedAt`, and recent failed publishes
-  (**Failed**) with total time before failure. See [pending-publish.md](./pending-publish.md).
 
 Selection is fleet-wide. It is not per-user or per-replica.
 
@@ -127,54 +125,50 @@ list). Each row has **Deploy** in the action column unless selection is disabled
 or the row is not deployable.
 
 ```text
-+-------------------------------------------------------------+
-| g-issues                               App management       |
-| registry: toolshed                                          |
-+-------------------------------------------------------------+
-| Desired version: 0.0.0-snapshot.gabc123                     |
-+-------------------------------------------------------------+
-| Published snapshots                                         |
-|                                                             |
-| Version                 Status       Timing       Action    |
-| ---------------------   ----------   -----------   -------- |
-| 0.0.0-snapshot.gnew     Publishing   for 4m       —         |
-|                         PR #3740 · workflow                 |
-| 0.0.0-snapshot.gdef456  Available    Jul 22 15:00  Deploy   |
-|                         in 4m 32s · PR #3251                |
-| 0.0.0-snapshot.gabc123  Deployed     Jul 21 12:00  —         |
-|                         PR #3200                              |
-+-------------------------------------------------------------+
+┌─────────────────────────────────────────────────────────────┐
+│ g-issues                               App management       │
+│ registry: toolshed                                          │
+├─────────────────────────────────────────────────────────────┤
+│ Desired version: 0.0.0-snapshot.gabc123                     │
+├─────────────────────────────────────────────────────────────┤
+│ Published snapshots                                         │
+│                                                             │
+│ Version                 Status       Published    Action    │
+│ 0.0.0-snapshot.g…       Publishing   for 4m       —         │
+│                                      PR #3740 · workflow    │
+│ 0.0.0-snapshot.g…       Available    Jul 22 15:00 Deploy    │
+│                                      in 4m 32s · PR #3251   │
+│ 0.0.0-snapshot.g…       Deployed     Jul 21 12:00 —         │
+│                                      PR #3200               │
+└─────────────────────────────────────────────────────────────┘
 ```
 
-**Publishing** rows show elapsed time and provenance; **Deploy** is disabled.
-**Available** published rows show `publishedAt` and publish duration when
-`publishStartedAt` is recorded. **Deployed** marks the desired version.
+Row timing labels: [pending-publish.md — Publish duration](./pending-publish.md#publish-duration). **Deploy** is disabled on **Publishing** and **Failed** rows. **Deployed** marks the desired version.
 
 During an active rollout, disable deploy actions and show rollout state above the
 table:
 
 ```text
-+-------------------------------------------------------------+
-| g-issues                               App management       |
-| registry: toolshed                                          |
-+-------------------------------------------------------------+
-| Desired version: 0.0.0-snapshot.gabc123                     |
-| Rollout enrolling: 0.0.0-snapshot.gdef456                   |
-+-------------------------------------------------------------+
-| Published snapshots                                         |
-|                                                             |
-| Version                 Status       Timing       Action    |
-| ---------------------   ----------   -----------   -------- |
-| 0.0.0-snapshot.gdef456  Rolling out  Jul 22 15:00  disabled |
-| 0.0.0-snapshot.gabc123  Deployed     Jul 21 12:00  disabled |
-+-------------------------------------------------------------+
+┌─────────────────────────────────────────────────────────────┐
+│ g-issues                               App management       │
+│ registry: toolshed                                          │
+├─────────────────────────────────────────────────────────────┤
+│ Desired version: 0.0.0-snapshot.gabc123                     │
+│ Rollout enrolling: 0.0.0-snapshot.gdef456                   │
+├─────────────────────────────────────────────────────────────┤
+│ Published snapshots                                         │
+│                                                             │
+│ Version                 Status       Published    Action    │
+│ 0.0.0-snapshot.g…       Rolling out  Jul 22 15:00 disabled  │
+│ 0.0.0-snapshot.g…       Deployed     Jul 21 12:00 disabled  │
+└─────────────────────────────────────────────────────────────┘
 ```
 
 A **Failed** row in the same table:
 
 ```text
-| 0.0.0-snapshot.gdead    Failed       Jul 24 18:35   —         |
-|                         after 35m · Timed out · workflow    |
+│ 0.0.0-snapshot.g…       Failed       Jul 24 18:35 —         │
+│                                      after 35m · Timed out  │
 ```
 
 After a successful deploy selection, keep deploy actions disabled until the

--- a/plans/app_registry/models.md
+++ b/plans/app_registry/models.md
@@ -52,6 +52,7 @@ Answers: *what versions exist, where is their metadata, which platforms were pub
           "metadata": "apps/g-issues/versions/0.0.0-snapshot.gabc123.json",
           "platforms": ["linux/amd64"],
           "publishedAt": "2026-07-09T12:00:00Z",
+          "publishStartedAt": "2026-07-09T11:55:28Z",
           "sourceRef": "abc123def456abc123def456abc123def456abcd",
           "repository": "github.com/valon-technologies/valon-tools",
           "publication": {
@@ -81,6 +82,7 @@ Nested objects are keyed by maps in JSON. Arrows show the Go type at each level 
             ├── metadata
             ├── platforms
             ├── publishedAt
+            ├── publishStartedAt
             ├── sourceRef
             ├── repository
             └── publication
@@ -115,6 +117,7 @@ Each key in `versions` is a published version string (e.g. 0.0.0-snapshot.gabc12
 | `metadata` | string | yes | Relative path to the full published version JSON, e.g. `apps/g-issues/versions/0.0.1.json`. |
 | `platforms` | string array | no | Build targets available for this version (see example JSON). Derived from published version artifact keys at publish time. |
 | `publishedAt` | RFC 3339 timestamp | yes | When this version was published (UTC). |
+| `publishStartedAt` | RFC 3339 timestamp | no | When the publish workflow recorded the version as pending (copied from `PendingVersion.startedAt` at upload time). Omitted on legacy publishes and when `pending set` was not called. Used with `publishedAt` to show total publish duration. |
 | `sourceRef` | string | no | Packaged commit SHA. Copied from `PublishedVersion.sourceRef`. |
 | `repository` | string | no | Source repository. Copied from `PublishedVersion.repository`. |
 | `publication` | object | no | Publish workflow provenance. Copied from `PublishedVersion.publication`. |
@@ -339,7 +342,8 @@ Answers: *what exactly is this version — artifacts, operations, dependencies, 
   "compatibility": {
     "minGestaltdVersion": "0.20.0"
   },
-  "publishedAt": "2026-07-09T12:00:00Z"
+  "publishedAt": "2026-07-09T12:00:00Z",
+  "publishStartedAt": "2026-07-09T11:55:28Z"
 }
 ```
 
@@ -353,6 +357,7 @@ Answers: *what exactly is this version — artifacts, operations, dependencies, 
     ├── manifestPath
     ├── repository
     ├── publishedAt
+    ├── publishStartedAt
     ├── publication
     │   ├── workflowRunUrl
     │   ├── triggerPullRequest
@@ -395,6 +400,7 @@ Answers: *what exactly is this version — artifacts, operations, dependencies, 
 | `requires` | object | no | Declared dependencies on other apps. Copied from the provider release `staticValidation.requires` block at publish time. |
 | `compatibility` | object | no | Runtime constraints, e.g. minimum `gestaltd` version. Copied from the provider release `staticValidation.compatibility` block at publish time. |
 | `publishedAt` | RFC 3339 timestamp | yes | When this version was published (UTC). |
+| `publishStartedAt` | RFC 3339 timestamp | no | When the publish workflow recorded the version as pending. Copied from `PendingVersion.startedAt` when `pending.json` contains this version at upload time. Omitted on legacy publishes. |
 
 #### `PublishedVersion.publication` · `Publication`
 

--- a/plans/app_registry/models.md
+++ b/plans/app_registry/models.md
@@ -117,7 +117,7 @@ Each key in `versions` is a published version string (e.g. 0.0.0-snapshot.gabc12
 | `metadata` | string | yes | Relative path to the full published version JSON, e.g. `apps/g-issues/versions/0.0.1.json`. |
 | `platforms` | string array | no | Build targets available for this version (see example JSON). Derived from published version artifact keys at publish time. |
 | `publishedAt` | RFC 3339 timestamp | yes | When this version was published (UTC). |
-| `publishStartedAt` | RFC 3339 timestamp | no | When the publish workflow recorded the version as pending (copied from `PendingVersion.startedAt` at upload time). Omitted on legacy publishes and when `pending set` was not called. Used with `publishedAt` to show total publish duration. |
+| `publishStartedAt` | RFC 3339 timestamp | no | When CI recorded the version as pending. Copied from `PendingVersion.startedAt` at publish time. Present on CI publishes after `pending set`; omitted on legacy entries and manual publishes without a pending entry. See [pending-publish.md](./pending-publish.md#publish-duration). |
 | `sourceRef` | string | no | Packaged commit SHA. Copied from `PublishedVersion.sourceRef`. |
 | `repository` | string | no | Source repository. Copied from `PublishedVersion.repository`. |
 | `publication` | object | no | Publish workflow provenance. Copied from `PublishedVersion.publication`. |
@@ -400,7 +400,7 @@ Answers: *what exactly is this version — artifacts, operations, dependencies, 
 | `requires` | object | no | Declared dependencies on other apps. Copied from the provider release `staticValidation.requires` block at publish time. |
 | `compatibility` | object | no | Runtime constraints, e.g. minimum `gestaltd` version. Copied from the provider release `staticValidation.compatibility` block at publish time. |
 | `publishedAt` | RFC 3339 timestamp | yes | When this version was published (UTC). |
-| `publishStartedAt` | RFC 3339 timestamp | no | When the publish workflow recorded the version as pending. Copied from `PendingVersion.startedAt` when `pending.json` contains this version at upload time. Omitted on legacy publishes. |
+| `publishStartedAt` | RFC 3339 timestamp | no | When CI recorded the version as pending. Copied from `PendingVersion.startedAt` at publish time. Present on CI publishes after `pending set`; omitted on legacy entries and manual publishes without a pending entry. See [pending-publish.md](./pending-publish.md#publish-duration). |
 
 #### `PublishedVersion.publication` · `Publication`
 

--- a/plans/app_registry/pending-publish.md
+++ b/plans/app_registry/pending-publish.md
@@ -36,8 +36,8 @@ Operators on `/apps/{app}/admin` should be able to answer:
 | Which commit / PR triggered it? | Pending entry provenance (same fields as published rows where available) |
 | Where is the CI run? | Link to `publication.workflowRunUrl` |
 | When did publish start? | `startedAt` on the pending entry |
-| How long has publish been running? | Elapsed time since `startedAt` on **Publishing** rows |
-| How long did publish take? | `publishedAt − publishStartedAt` on published rows; `failedAt − startedAt` on **Failed** rows |
+| How long has publish been running? | Elapsed time from `startedAt` on **Publishing** rows |
+| How long did publish take? | Total publish time on published and **Failed** rows |
 | Did a recent publish fail? | Row with status **Failed** and `failedAt` |
 | Why did it fail? | `reason` on the failed entry (`workflow_failed` or `stale`) |
 
@@ -57,31 +57,36 @@ Add mutable `pending.json` and `failed.json` catalogs in GCS per app.
 
 `gestaltd` reads both catalogs alongside `index.json` and exposes them through
 the app-admin registry API. The UI merges pending, failed, and published entries
-in the snapshots table and shows publish duration while in flight and after
-completion.
-
-### Publish duration
-
-Track how long a publish takes end to end:
-
-| State | Start anchor | End anchor | Display |
-|-------|--------------|------------|---------|
-| **Publishing** | `pending.startedAt` | now (UI clock) | “Publishing for 4m” |
-| **Published** | `publishStartedAt` | `publishedAt` | “Published in 4m 32s” |
-| **Failed** | `failed.startedAt` | `failed.failedAt` | “Failed after 35m” |
-
-`publishStartedAt` is written at upload time. `gestaltd app registry publish`
-reads the matching pending entry (if present) and copies `startedAt` into
-`publishStartedAt` on `versions/{version}.json` and `index.json`. When CI
-skipped `pending set`, or for legacy publishes, `publishStartedAt` is omitted and
-the UI shows only `publishedAt`.
-
-Duration is derived from timestamps — do not store a separate duration field in
-GCS.
+in the snapshots table.
 
 Pending and failed versions are **not** installable. Install-time validation
 continues to read only `versions/{version}.json` via the published index
 contract.
+
+---
+
+## Publish duration
+
+Show how long a publish has been running and how long it took to complete.
+Durations are derived from timestamps at read/UI time — not stored as separate
+GCS fields. Field definitions: [`publishStartedAt`](./models.md#publishedversion).
+
+| Row status | Start timestamp | End timestamp | UI label |
+|------------|-----------------|---------------|----------|
+| **Publishing** | `startedAt` | now | Publishing for 4m |
+| **Available** / **Deployed** | `publishStartedAt` | `publishedAt` | Published in 4m 32s |
+| **Failed** | `startedAt` | `failedAt` | Failed after 35m |
+
+`gestaltd app registry publish` reads `pending.json` when present and copies
+`PendingVersion.startedAt` into `publishStartedAt` on `versions/{version}.json`
+and `index.json`. CI publishes always run `pending set` first, so new registry
+entries include `publishStartedAt`. The field is **not required in the JSON
+schema** so readers tolerate legacy entries and manual publishes that skipped
+`pending set`; the UI shows `publishedAt` only when the start timestamp is absent.
+
+The app-admin API may include `publishingForSeconds` on pending rows and
+`publishDurationSeconds` on published and failed rows. Omit these fields when the
+start timestamp is missing.
 
 ---
 
@@ -323,24 +328,12 @@ Extend `GET /api/v1/apps/{app}/admin/registry` response:
   "registry": "toolshed",
   "desiredVersion": "0.0.0-snapshot.g…",
   "knownVersions": [ … ],
-  "publishedVersions": [
-    {
-      "version": "0.0.0-snapshot.g…",
-      "publishedAt": "2026-07-24T19:04:32Z",
-      "publishStartedAt": "2026-07-24T19:00:00Z",
-      "publishDurationSeconds": 272,
-      "platforms": ["linux/amd64"],
-      "sourceRef": "abc123…",
-      "sourceUrl": "https://github.com/…/commit/abc123…",
-      "publication": { … }
-    }
-  ],
+  "publishedVersions": [ … ],
   "pendingVersions": [
     {
       "version": "0.0.0-snapshot.g…",
       "startedAt": "2026-07-24T19:00:00Z",
       "updatedAt": "2026-07-24T19:04:12Z",
-      "publishingForSeconds": 252,
       "phase": "publishing",
       "sourceRef": "abc123…",
       "sourceUrl": "https://github.com/…/commit/abc123…",
@@ -352,7 +345,6 @@ Extend `GET /api/v1/apps/{app}/admin/registry` response:
       "version": "0.0.0-snapshot.g…",
       "startedAt": "2026-07-24T18:00:00Z",
       "failedAt": "2026-07-24T18:35:00Z",
-      "publishDurationSeconds": 2100,
       "reason": "stale",
       "sourceRef": "abc123…",
       "sourceUrl": "https://github.com/…/commit/abc123…",
@@ -371,9 +363,8 @@ Merge rules:
   cleanup), prefer **published** and omit pending and failed.
 - `pendingVersions` sorted by `startedAt` descending (newest first).
 - `failedVersions` sorted by `failedAt` descending (newest first).
-- `publishingForSeconds` on `pendingVersions` and `publishDurationSeconds` on
-  `publishedVersions` / `failedVersions` are computed at read time from the
-  timestamps above. Omit duration fields when the start anchor is missing.
+- Published rows may include `publishStartedAt`. Pending, published, and failed
+  rows may include computed duration fields. See [Publish duration](#publish-duration).
 
 Install and upgrade handlers ignore `pending.json` and `failed.json` entirely.
 
@@ -395,23 +386,20 @@ published entries (single newest-first list with a status column).
 Pending entries:
 
 - Show PR / commit provenance when present (same columns as published)
-- **Published** column shows elapsed publish time (for example “Publishing for
-  4m”) from `publishingForSeconds` or `startedAt`
+- **Published** column shows elapsed publish time from `startedAt`
 - **Action** column: Deploy disabled; optional “View workflow” link using
   `publication.workflowRunUrl`
-
-Published entries:
-
-- When `publishStartedAt` is present, show total publish time (for example
-  “Published in 4m 32s”) alongside `publishedAt`
-- Legacy rows without `publishStartedAt` show `publishedAt` only
 
 Failed entries:
 
 - Show PR / commit provenance when present
-- **Published** column shows `failedAt`, total time before failure (for example
-  “Failed after 35m”), and a reason label (`workflow_failed` → “Workflow
-  failed”, `stale` → “Timed out”)
+- **Published** column shows `failedAt`, total time before failure, and a reason
+  label (`workflow_failed` → “Workflow failed”, `stale` → “Timed out”)
+- **Action** column: Deploy disabled; “View workflow” when
+  `publication.workflowRunUrl` is present
+
+Published entries without `publishStartedAt` show `publishedAt` only. See
+[Publish duration](#publish-duration) for timing labels on all row types.
 
 Polling: extend `AppAdminPageClient` to poll every **12s** while
 `pendingVersions.length > 0` or `failedVersions.length > 0`, not only during
@@ -469,9 +457,9 @@ Add types and CLI first so CI can call the new commands.
 
 - Add `PendingIndex` / `PendingVersion` and `FailedIndex` / `FailedVersion` to
   `gestaltd/internal/appregistry/` ([models.md](./models.md) documents shapes).
-- Add optional `publishStartedAt` to `IndexVersion`, `PublishedVersion`, and the
-  publish upload path (read `pending.json` at publish time; do not mutate
-  pending).
+- Add `publishStartedAt` to `IndexVersion` and `PublishedVersion`. Set it in
+  `gestaltd app registry publish` by reading `pending.json` at upload time (do
+  not mutate pending). See [Publish duration](#publish-duration).
 - Add `gestaltd app registry pending set|clear|fail` and
   `gestaltd app registry publish` (move logic from `gestaltd app publish`).
 - `pending set` calls `PrunePendingIndex` and `PruneFailedIndex` before
@@ -487,8 +475,7 @@ Depends on **PR 1**. Exposes pending and failed catalog state to the admin page.
 
 - `FetchPendingIndex` and `FetchFailedIndex` in `gestaltd/internal/appregistry/`.
 - Extend `getAppAdminRegistry` with `pendingVersions[]` and `failedVersions[]`.
-- Include `publishStartedAt` on published rows and compute
-  `publishingForSeconds` / `publishDurationSeconds` at read time.
+- Expose `publishStartedAt` and computed duration fields per [Publish duration](#publish-duration).
 - Tests: fetch helpers via `registrytest` HTTP fixture; handler returns pending
   and failed entries alongside published. Extend [tests.md](./tests.md).
 
@@ -511,7 +498,7 @@ operators get correct GCS state before the UI exists.
 Depends on **PR 2**. Completes admin visibility.
 
 - **Publishing** and **Failed** rows in the `gestalt-providers` app admin
-  snapshots table, with elapsed and total publish duration labels.
+  snapshots table. Timing labels per [Publish duration](#publish-duration).
 - Poll every ~12s while any pending or failed version exists; prefer published
   entry when the same version appears in multiple lists.
 - Manual / browser smoke per [tests.md](./tests.md) when implementing.
@@ -540,6 +527,5 @@ on `pending set`. Stale pending (30 minutes without `updatedAt` refresh) records
 `gestaltd app registry pending set` as early as possible (once `PACKAGE_VERSION`,
 GCP auth, and `gestaltd` are available), not only when artifacts are ready.
 
-**Publish duration:** `publishStartedAt` is copied from pending at publish time
-and stored on published registry objects. Durations are derived at read/UI time,
-not stored as separate GCS fields.
+**Publish duration:** `publishStartedAt` on published registry objects; elapsed
+and total time derived at read/UI time. See [Publish duration](#publish-duration).

--- a/plans/app_registry/pending-publish.md
+++ b/plans/app_registry/pending-publish.md
@@ -36,6 +36,8 @@ Operators on `/apps/{app}/admin` should be able to answer:
 | Which commit / PR triggered it? | Pending entry provenance (same fields as published rows where available) |
 | Where is the CI run? | Link to `publication.workflowRunUrl` |
 | When did publish start? | `startedAt` on the pending entry |
+| How long has publish been running? | Elapsed time since `startedAt` on **Publishing** rows |
+| How long did publish take? | `publishedAt − publishStartedAt` on published rows; `failedAt − startedAt` on **Failed** rows |
 | Did a recent publish fail? | Row with status **Failed** and `failedAt` |
 | Why did it fail? | `reason` on the failed entry (`workflow_failed` or `stale`) |
 
@@ -55,7 +57,27 @@ Add mutable `pending.json` and `failed.json` catalogs in GCS per app.
 
 `gestaltd` reads both catalogs alongside `index.json` and exposes them through
 the app-admin registry API. The UI merges pending, failed, and published entries
-in the snapshots table.
+in the snapshots table and shows publish duration while in flight and after
+completion.
+
+### Publish duration
+
+Track how long a publish takes end to end:
+
+| State | Start anchor | End anchor | Display |
+|-------|--------------|------------|---------|
+| **Publishing** | `pending.startedAt` | now (UI clock) | “Publishing for 4m” |
+| **Published** | `publishStartedAt` | `publishedAt` | “Published in 4m 32s” |
+| **Failed** | `failed.startedAt` | `failed.failedAt` | “Failed after 35m” |
+
+`publishStartedAt` is written at upload time. `gestaltd app registry publish`
+reads the matching pending entry (if present) and copies `startedAt` into
+`publishStartedAt` on `versions/{version}.json` and `index.json`. When CI
+skipped `pending set`, or for legacy publishes, `publishStartedAt` is omitted and
+the UI shows only `publishedAt`.
+
+Duration is derived from timestamps — do not store a separate duration field in
+GCS.
 
 Pending and failed versions are **not** installable. Install-time validation
 continues to read only `versions/{version}.json` via the published index
@@ -247,9 +269,10 @@ gestaltd app registry pending fail \
 existing `failed.json` entry is left unchanged.
 
 **`gestaltd app registry publish`** — upload artifacts and version metadata,
-update `index.json` only. Does not read or write `pending.json` or
-`failed.json`. Same flags as today's `gestaltd app publish`; requires
-`--dist-dir`.
+update `index.json` only. Does not write `pending.json` or `failed.json`. Reads
+`pending.json` when present to copy `startedAt` into `publishStartedAt` on the
+uploaded version metadata and index entry. Same flags as today's
+`gestaltd app publish`; requires `--dist-dir`.
 
 ```bash
 gestaltd app registry publish \
@@ -300,12 +323,24 @@ Extend `GET /api/v1/apps/{app}/admin/registry` response:
   "registry": "toolshed",
   "desiredVersion": "0.0.0-snapshot.g…",
   "knownVersions": [ … ],
-  "publishedVersions": [ … ],
+  "publishedVersions": [
+    {
+      "version": "0.0.0-snapshot.g…",
+      "publishedAt": "2026-07-24T19:04:32Z",
+      "publishStartedAt": "2026-07-24T19:00:00Z",
+      "publishDurationSeconds": 272,
+      "platforms": ["linux/amd64"],
+      "sourceRef": "abc123…",
+      "sourceUrl": "https://github.com/…/commit/abc123…",
+      "publication": { … }
+    }
+  ],
   "pendingVersions": [
     {
       "version": "0.0.0-snapshot.g…",
       "startedAt": "2026-07-24T19:00:00Z",
       "updatedAt": "2026-07-24T19:04:12Z",
+      "publishingForSeconds": 252,
       "phase": "publishing",
       "sourceRef": "abc123…",
       "sourceUrl": "https://github.com/…/commit/abc123…",
@@ -317,6 +352,7 @@ Extend `GET /api/v1/apps/{app}/admin/registry` response:
       "version": "0.0.0-snapshot.g…",
       "startedAt": "2026-07-24T18:00:00Z",
       "failedAt": "2026-07-24T18:35:00Z",
+      "publishDurationSeconds": 2100,
       "reason": "stale",
       "sourceRef": "abc123…",
       "sourceUrl": "https://github.com/…/commit/abc123…",
@@ -335,6 +371,9 @@ Merge rules:
   cleanup), prefer **published** and omit pending and failed.
 - `pendingVersions` sorted by `startedAt` descending (newest first).
 - `failedVersions` sorted by `failedAt` descending (newest first).
+- `publishingForSeconds` on `pendingVersions` and `publishDurationSeconds` on
+  `publishedVersions` / `failedVersions` are computed at read time from the
+  timestamps above. Omit duration fields when the start anchor is missing.
 
 Install and upgrade handlers ignore `pending.json` and `failed.json` entirely.
 
@@ -356,17 +395,23 @@ published entries (single newest-first list with a status column).
 Pending entries:
 
 - Show PR / commit provenance when present (same columns as published)
-- **Published** column shows “In progress” or time since `startedAt`
+- **Published** column shows elapsed publish time (for example “Publishing for
+  4m”) from `publishingForSeconds` or `startedAt`
 - **Action** column: Deploy disabled; optional “View workflow” link using
   `publication.workflowRunUrl`
+
+Published entries:
+
+- When `publishStartedAt` is present, show total publish time (for example
+  “Published in 4m 32s”) alongside `publishedAt`
+- Legacy rows without `publishStartedAt` show `publishedAt` only
 
 Failed entries:
 
 - Show PR / commit provenance when present
-- **Published** column shows `failedAt` and a reason label (`workflow_failed` →
-  “Workflow failed”, `stale` → “Timed out”)
-- **Action** column: Deploy disabled; “View workflow” when
-  `publication.workflowRunUrl` is present
+- **Published** column shows `failedAt`, total time before failure (for example
+  “Failed after 35m”), and a reason label (`workflow_failed` → “Workflow
+  failed”, `stale` → “Timed out”)
 
 Polling: extend `AppAdminPageClient` to poll every **12s** while
 `pendingVersions.length > 0` or `failedVersions.length > 0`, not only during
@@ -424,6 +469,9 @@ Add types and CLI first so CI can call the new commands.
 
 - Add `PendingIndex` / `PendingVersion` and `FailedIndex` / `FailedVersion` to
   `gestaltd/internal/appregistry/` ([models.md](./models.md) documents shapes).
+- Add optional `publishStartedAt` to `IndexVersion`, `PublishedVersion`, and the
+  publish upload path (read `pending.json` at publish time; do not mutate
+  pending).
 - Add `gestaltd app registry pending set|clear|fail` and
   `gestaltd app registry publish` (move logic from `gestaltd app publish`).
 - `pending set` calls `PrunePendingIndex` and `PruneFailedIndex` before
@@ -439,6 +487,8 @@ Depends on **PR 1**. Exposes pending and failed catalog state to the admin page.
 
 - `FetchPendingIndex` and `FetchFailedIndex` in `gestaltd/internal/appregistry/`.
 - Extend `getAppAdminRegistry` with `pendingVersions[]` and `failedVersions[]`.
+- Include `publishStartedAt` on published rows and compute
+  `publishingForSeconds` / `publishDurationSeconds` at read time.
 - Tests: fetch helpers via `registrytest` HTTP fixture; handler returns pending
   and failed entries alongside published. Extend [tests.md](./tests.md).
 
@@ -461,7 +511,7 @@ operators get correct GCS state before the UI exists.
 Depends on **PR 2**. Completes admin visibility.
 
 - **Publishing** and **Failed** rows in the `gestalt-providers` app admin
-  snapshots table.
+  snapshots table, with elapsed and total publish duration labels.
 - Poll every ~12s while any pending or failed version exists; prefer published
   entry when the same version appears in multiple lists.
 - Manual / browser smoke per [tests.md](./tests.md) when implementing.
@@ -475,8 +525,10 @@ The embedded fleet `/admin` registry list does not show a publishing indicator.
 
 **CLI:** `gestaltd app registry pending` (`set`, `clear`, `fail`) owns
 `pending.json` and `failed.json`. `gestaltd app registry publish` uploads
-immutable artifacts and `index.json` only (replaces `gestaltd app publish`). CI
-calls `pending clear` on success and `pending fail` on failure.
+immutable artifacts and `index.json` (replaces `gestaltd app publish`); it may
+read `pending.json` to copy `publishStartedAt` but does not mutate pending or
+failed catalogs. CI calls `pending clear` on success and `pending fail` on
+failure.
 
 **Failed retention:** `failed.json` entries are kept for **30 days**, then pruned
 on `pending set`. Stale pending (30 minutes without `updatedAt` refresh) records
@@ -487,3 +539,7 @@ on `pending set`. Stale pending (30 minutes without `updatedAt` refresh) records
 **Workflow start:** `publish-app-registry.yml` should call
 `gestaltd app registry pending set` as early as possible (once `PACKAGE_VERSION`,
 GCP auth, and `gestaltd` are available), not only when artifacts are ready.
+
+**Publish duration:** `publishStartedAt` is copied from pending at publish time
+and stored on published registry objects. Durations are derived at read/UI time,
+not stored as separate GCS fields.

--- a/plans/app_registry/plan.md
+++ b/plans/app_registry/plan.md
@@ -271,8 +271,9 @@ Core recovery paths must not depend on dynamically installed apps.
 
 Show in-flight and recently failed CI publishes on `/apps/{app}/admin` before
 and after `index.json` is updated. Add mutable `apps/{app}/pending.json` and
-`apps/{app}/failed.json` in GCS, CI lifecycle hooks, and pending/failed rows in
-the app-admin API and snapshots table. See [pending-publish.md](./pending-publish.md).
+`apps/{app}/failed.json` in GCS, CI lifecycle hooks, pending/failed rows in the
+app-admin API and snapshots table, and publish duration on in-flight and
+completed publishes. See [pending-publish.md](./pending-publish.md).
 
 ### Packaged workflow metadata
 

--- a/plans/app_registry/plan.md
+++ b/plans/app_registry/plan.md
@@ -271,9 +271,8 @@ Core recovery paths must not depend on dynamically installed apps.
 
 Show in-flight and recently failed CI publishes on `/apps/{app}/admin` before
 and after `index.json` is updated. Add mutable `apps/{app}/pending.json` and
-`apps/{app}/failed.json` in GCS, CI lifecycle hooks, pending/failed rows in the
-app-admin API and snapshots table, and publish duration on in-flight and
-completed publishes. See [pending-publish.md](./pending-publish.md).
+`apps/{app}/failed.json` in GCS, CI lifecycle hooks, and pending/failed rows in
+the app-admin API and snapshots table. See [pending-publish.md](./pending-publish.md).
 
 ### Packaged workflow metadata
 


### PR DESCRIPTION
## Summary
- Add **publish duration** to the pending-publish plan: elapsed time while **Publishing**, total time on published rows, and time-before-failure on **Failed** rows.
- Introduce optional `publishStartedAt` on `IndexVersion` and `PublishedVersion`, copied from `pending.startedAt` at `gestaltd app registry publish` time (read-only pending access).
- Document derived API fields `publishingForSeconds` and `publishDurationSeconds`, plus UI labels (“Publishing for 4m”, “Published in 4m 32s”).

Stacked on #2927.

## Test plan
- [ ] Review plan/docs only — no code changes in this PR


Made with [Cursor](https://cursor.com)