### PR TITLE
Add app registry pending write path (PR 1)

### DIFF
--- a/gestaltd/internal/appregistry/pending.go
+++ b/gestaltd/internal/appregistry/pending.go
@@ -410,7 +410,8 @@ func ApplyPendingSet(pending *PendingIndex, failed *FailedIndex, published *Inde
 			pendingChanged = true
 		}
 	}
-	_, _ = UpsertPendingVersion(pending, appName, version, now)
-	pendingChanged = true
+	if _, changed := UpsertPendingVersion(pending, appName, version, now); changed {
+		pendingChanged = true
+	}
 	return pendingChanged, failedChanged
 }

--- a/gestaltd/internal/appregistry/pending.go
+++ b/gestaltd/internal/appregistry/pending.go
@@ -1,0 +1,350 @@
+package appregistry
+
+import (
+	"encoding/json"
+	"fmt"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/services/apps/source"
+)
+
+const (
+	PendingIndexSchemaVersion = 1
+	FailedIndexSchemaVersion  = 1
+
+	PendingFileName = "pending.json"
+	FailedFileName  = "failed.json"
+
+	PendingPhasePublishing = "publishing"
+
+	FailedReasonWorkflowFailed = "workflow_failed"
+	FailedReasonStale          = "stale"
+
+	PendingStaleAfter = 30 * time.Minute
+	FailedRetainFor   = 30 * 24 * time.Hour
+)
+
+type PendingIndex struct {
+	SchemaVersion int                       `json:"schemaVersion"`
+	App           string                    `json:"app"`
+	Pending       map[string]PendingVersion `json:"pending"`
+}
+
+type PendingVersion struct {
+	Version     string       `json:"version"`
+	SourceRef   string       `json:"sourceRef"`
+	Repository  string       `json:"repository,omitempty"`
+	StartedAt   time.Time    `json:"startedAt"`
+	UpdatedAt   time.Time    `json:"updatedAt"`
+	Phase       string       `json:"phase"`
+	Publication *Publication `json:"publication,omitempty"`
+}
+
+type FailedIndex struct {
+	SchemaVersion int                      `json:"schemaVersion"`
+	App           string                   `json:"app"`
+	Failed        map[string]FailedVersion `json:"failed"`
+}
+
+type FailedVersion struct {
+	Version     string       `json:"version"`
+	SourceRef   string       `json:"sourceRef"`
+	Repository  string       `json:"repository,omitempty"`
+	StartedAt   time.Time    `json:"startedAt"`
+	FailedAt    time.Time    `json:"failedAt"`
+	Reason      string       `json:"reason"`
+	Publication *Publication `json:"publication,omitempty"`
+}
+
+func AppPendingPath(appName string) string {
+	return path.Join("apps", appName, PendingFileName)
+}
+
+func AppFailedPath(appName string) string {
+	return path.Join("apps", appName, FailedFileName)
+}
+
+func NewEmptyPendingIndex(appName string) *PendingIndex {
+	return &PendingIndex{
+		SchemaVersion: PendingIndexSchemaVersion,
+		App:           strings.TrimSpace(appName),
+		Pending:       map[string]PendingVersion{},
+	}
+}
+
+func NewEmptyFailedIndex(appName string) *FailedIndex {
+	return &FailedIndex{
+		SchemaVersion: FailedIndexSchemaVersion,
+		App:           strings.TrimSpace(appName),
+		Failed:        map[string]FailedVersion{},
+	}
+}
+
+func DecodePendingIndex(data []byte) (*PendingIndex, error) {
+	var index PendingIndex
+	if err := json.Unmarshal(data, &index); err != nil {
+		return nil, fmt.Errorf("decode pending index: %w", err)
+	}
+	if err := validatePendingIndex(&index); err != nil {
+		return nil, err
+	}
+	return &index, nil
+}
+
+func DecodeFailedIndex(data []byte) (*FailedIndex, error) {
+	var index FailedIndex
+	if err := json.Unmarshal(data, &index); err != nil {
+		return nil, fmt.Errorf("decode failed index: %w", err)
+	}
+	if err := validateFailedIndex(&index); err != nil {
+		return nil, err
+	}
+	return &index, nil
+}
+
+func validatePendingIndex(index *PendingIndex) error {
+	if index == nil {
+		return fmt.Errorf("pending index is required")
+	}
+	if index.SchemaVersion != PendingIndexSchemaVersion {
+		return fmt.Errorf("unsupported pending index schema version %d", index.SchemaVersion)
+	}
+	if strings.TrimSpace(index.App) == "" {
+		return fmt.Errorf("pending index app is required")
+	}
+	if index.Pending == nil {
+		return fmt.Errorf("pending index pending map is required")
+	}
+	for version, entry := range index.Pending {
+		if err := validatePendingVersion(index.App, version, entry); err != nil {
+			return fmt.Errorf("pending index version %q: %w", version, err)
+		}
+	}
+	return nil
+}
+
+func validateFailedIndex(index *FailedIndex) error {
+	if index == nil {
+		return fmt.Errorf("failed index is required")
+	}
+	if index.SchemaVersion != FailedIndexSchemaVersion {
+		return fmt.Errorf("unsupported failed index schema version %d", index.SchemaVersion)
+	}
+	if strings.TrimSpace(index.App) == "" {
+		return fmt.Errorf("failed index app is required")
+	}
+	if index.Failed == nil {
+		return fmt.Errorf("failed index failed map is required")
+	}
+	for version, entry := range index.Failed {
+		if err := validateFailedVersion(index.App, version, entry); err != nil {
+			return fmt.Errorf("failed index version %q: %w", version, err)
+		}
+	}
+	return nil
+}
+
+func validatePendingVersion(appName, mapKey string, entry PendingVersion) error {
+	version := strings.TrimSpace(entry.Version)
+	if version == "" {
+		return fmt.Errorf("version is required")
+	}
+	if mapKey != version {
+		return fmt.Errorf("map key %q does not match version field %q", mapKey, version)
+	}
+	if err := source.ValidateVersion(version); err != nil {
+		return fmt.Errorf("version: %w", err)
+	}
+	if err := validateSourceRef(entry.SourceRef); err != nil {
+		return fmt.Errorf("sourceRef: %w", err)
+	}
+	if repository := strings.TrimSpace(entry.Repository); repository != "" {
+		if err := validateEntryRepository(repository, appName); err != nil {
+			return fmt.Errorf("repository: %w", err)
+		}
+	}
+	if entry.StartedAt.IsZero() {
+		return fmt.Errorf("startedAt is required")
+	}
+	if entry.UpdatedAt.IsZero() {
+		return fmt.Errorf("updatedAt is required")
+	}
+	if entry.Phase != PendingPhasePublishing {
+		return fmt.Errorf("phase must be %q", PendingPhasePublishing)
+	}
+	if err := validatePublication(entry.Publication); err != nil {
+		return fmt.Errorf("publication: %w", err)
+	}
+	return nil
+}
+
+func validateFailedVersion(appName, mapKey string, entry FailedVersion) error {
+	version := strings.TrimSpace(entry.Version)
+	if version == "" {
+		return fmt.Errorf("version is required")
+	}
+	if mapKey != version {
+		return fmt.Errorf("map key %q does not match version field %q", mapKey, version)
+	}
+	if err := source.ValidateVersion(version); err != nil {
+		return fmt.Errorf("version: %w", err)
+	}
+	if err := validateSourceRef(entry.SourceRef); err != nil {
+		return fmt.Errorf("sourceRef: %w", err)
+	}
+	if repository := strings.TrimSpace(entry.Repository); repository != "" {
+		if err := validateEntryRepository(repository, appName); err != nil {
+			return fmt.Errorf("repository: %w", err)
+		}
+	}
+	if entry.StartedAt.IsZero() {
+		return fmt.Errorf("startedAt is required")
+	}
+	if entry.FailedAt.IsZero() {
+		return fmt.Errorf("failedAt is required")
+	}
+	switch entry.Reason {
+	case FailedReasonWorkflowFailed, FailedReasonStale:
+	default:
+		return fmt.Errorf("reason must be %q or %q", FailedReasonWorkflowFailed, FailedReasonStale)
+	}
+	if err := validatePublication(entry.Publication); err != nil {
+		return fmt.Errorf("publication: %w", err)
+	}
+	return nil
+}
+
+func IndexContainsVersion(index *Index, appName, version string) bool {
+	if index == nil || len(index.Apps) == 0 {
+		return false
+	}
+	appVersions, ok := index.Apps[strings.TrimSpace(appName)]
+	if !ok {
+		return false
+	}
+	_, ok = appVersions.Versions[strings.TrimSpace(version)]
+	return ok
+}
+
+// PrunePendingIndex moves stale pending entries to failed and drops entries for
+// versions already published. The second return value reports whether failed
+// changed.
+func PrunePendingIndex(pending *PendingIndex, failed *FailedIndex, published *Index, now time.Time) (bool, bool) {
+	if pending == nil || len(pending.Pending) == 0 {
+		return false, false
+	}
+	if failed == nil {
+		failed = NewEmptyFailedIndex(pending.App)
+	}
+	if failed.Failed == nil {
+		failed.Failed = map[string]FailedVersion{}
+	}
+	now = now.UTC()
+	pendingChanged := false
+	failedChanged := false
+	for version, entry := range pending.Pending {
+		if IndexContainsVersion(published, pending.App, version) {
+			delete(pending.Pending, version)
+			pendingChanged = true
+			continue
+		}
+		if now.Sub(entry.UpdatedAt.UTC()) > PendingStaleAfter {
+			failed.Failed[version] = failedVersionFromPending(entry, now, FailedReasonStale)
+			delete(pending.Pending, version)
+			pendingChanged = true
+			failedChanged = true
+		}
+	}
+	return pendingChanged, failedChanged
+}
+
+// PruneFailedIndex removes old or already-published failed entries.
+func PruneFailedIndex(failed *FailedIndex, published *Index, now time.Time) bool {
+	if failed == nil || len(failed.Failed) == 0 {
+		return false
+	}
+	now = now.UTC()
+	changed := false
+	for version, entry := range failed.Failed {
+		if IndexContainsVersion(published, failed.App, version) {
+			delete(failed.Failed, version)
+			changed = true
+			continue
+		}
+		if now.Sub(entry.FailedAt.UTC()) > FailedRetainFor {
+			delete(failed.Failed, version)
+			changed = true
+		}
+	}
+	return changed
+}
+
+func failedVersionFromPending(entry PendingVersion, failedAt time.Time, reason string) FailedVersion {
+	return FailedVersion{
+		Version:     entry.Version,
+		SourceRef:   entry.SourceRef,
+		Repository:  entry.Repository,
+		StartedAt:   entry.StartedAt.UTC(),
+		FailedAt:    failedAt.UTC(),
+		Reason:      reason,
+		Publication: clonePublication(entry.Publication),
+	}
+}
+
+// UpsertPendingVersion inserts or updates one pending version. startedAt is
+// preserved when the version already exists.
+func UpsertPendingVersion(index *PendingIndex, appName string, version PendingVersion, now time.Time) (*PendingIndex, bool) {
+	if index == nil {
+		index = NewEmptyPendingIndex(appName)
+	}
+	if index.Pending == nil {
+		index.Pending = map[string]PendingVersion{}
+	}
+	now = now.UTC()
+	version.Version = strings.TrimSpace(version.Version)
+	version.SourceRef = strings.ToLower(strings.TrimSpace(version.SourceRef))
+	version.Repository = strings.TrimSpace(version.Repository)
+	version.Phase = PendingPhasePublishing
+	version.UpdatedAt = now
+	if existing, ok := index.Pending[version.Version]; ok {
+		version.StartedAt = existing.StartedAt.UTC()
+	} else {
+		version.StartedAt = now
+	}
+	version.Publication = clonePublication(version.Publication)
+	index.Pending[version.Version] = version
+	return index, true
+}
+
+// RemovePendingVersion deletes one pending version. The second return value
+// reports whether the version was present.
+func RemovePendingVersion(index *PendingIndex, version string) (*PendingVersion, bool) {
+	if index == nil || index.Pending == nil {
+		return nil, false
+	}
+	version = strings.TrimSpace(version)
+	entry, ok := index.Pending[version]
+	if !ok {
+		return nil, false
+	}
+	delete(index.Pending, version)
+	return &entry, true
+}
+
+// RecordFailedVersion writes a failed entry from a removed pending version.
+func RecordFailedVersion(index *FailedIndex, appName string, pending PendingVersion, failedAt time.Time, reason string) (*FailedIndex, bool) {
+	if index == nil {
+		index = NewEmptyFailedIndex(appName)
+	}
+	if index.Failed == nil {
+		index.Failed = map[string]FailedVersion{}
+	}
+	version := strings.TrimSpace(pending.Version)
+	if _, exists := index.Failed[version]; exists {
+		return index, false
+	}
+	index.Failed[version] = failedVersionFromPending(pending, failedAt, reason)
+	return index, true
+}

--- a/gestaltd/internal/appregistry/pending.go
+++ b/gestaltd/internal/appregistry/pending.go
@@ -229,12 +229,14 @@ func IndexContainsVersion(index *Index, appName, version string) bool {
 }
 
 // PrunePendingIndex moves stale pending entries to failed and drops entries for
-// versions already published. The second return value reports whether failed
-// changed.
-func PrunePendingIndex(pending *PendingIndex, failed *FailedIndex, published *Index, now time.Time) (bool, bool) {
+// versions already published. exceptVersion is skipped so a concurrent pending
+// set can refresh that version without stale-pruning it first. The second return
+// value reports whether failed changed.
+func PrunePendingIndex(pending *PendingIndex, failed *FailedIndex, published *Index, now time.Time, exceptVersion string) (bool, bool) {
 	if pending == nil || len(pending.Pending) == 0 {
 		return false, false
 	}
+	exceptVersion = strings.TrimSpace(exceptVersion)
 	if failed == nil {
 		failed = NewEmptyFailedIndex(pending.App)
 	}
@@ -245,6 +247,9 @@ func PrunePendingIndex(pending *PendingIndex, failed *FailedIndex, published *In
 	pendingChanged := false
 	failedChanged := false
 	for version, entry := range pending.Pending {
+		if version == exceptVersion {
+			continue
+		}
 		if IndexContainsVersion(published, pending.App, version) {
 			delete(pending.Pending, version)
 			pendingChanged = true
@@ -374,4 +379,41 @@ func PublishStartedAtFromPending(index *PendingIndex, version string) (time.Time
 		return time.Time{}, false
 	}
 	return pending.StartedAt.UTC(), true
+}
+
+// ApplyPendingSet updates pending and failed catalogs for pending set. It clears
+// a prior failed entry, prunes other versions, and upserts the target version.
+func ApplyPendingSet(pending *PendingIndex, failed *FailedIndex, published *Index, appName string, version PendingVersion, now time.Time) (bool, bool) {
+	versionKey := strings.TrimSpace(version.Version)
+	now = now.UTC()
+
+	pendingChanged := false
+	failedChanged := false
+	if RemoveFailedVersion(failed, versionKey) {
+		failedChanged = true
+	}
+	prunedPending, prunedFailed := PrunePendingIndex(pending, failed, published, now, versionKey)
+	if prunedPending {
+		pendingChanged = true
+	}
+	if prunedFailed {
+		failedChanged = true
+	}
+	if PruneFailedIndex(failed, published, now) {
+		failedChanged = true
+	}
+	if IndexContainsVersion(published, appName, versionKey) {
+		if _, ok := RemovePendingVersion(pending, versionKey); ok {
+			pendingChanged = true
+		}
+		return pendingChanged, failedChanged
+	}
+	if entry, ok := pending.Pending[versionKey]; ok && now.Sub(entry.StartedAt.UTC()) > PendingStaleAfter {
+		if _, ok := RemovePendingVersion(pending, versionKey); ok {
+			pendingChanged = true
+		}
+	}
+	_, _ = UpsertPendingVersion(pending, appName, version, now)
+	pendingChanged = true
+	return pendingChanged, failedChanged
 }

--- a/gestaltd/internal/appregistry/pending.go
+++ b/gestaltd/internal/appregistry/pending.go
@@ -348,3 +348,16 @@ func RecordFailedVersion(index *FailedIndex, appName string, pending PendingVers
 	index.Failed[version] = failedVersionFromPending(pending, failedAt, reason)
 	return index, true
 }
+
+// PublishStartedAtFromPending returns the pending startedAt timestamp for a
+// version when present.
+func PublishStartedAtFromPending(index *PendingIndex, version string) (time.Time, bool) {
+	if index == nil || index.Pending == nil {
+		return time.Time{}, false
+	}
+	pending, ok := index.Pending[strings.TrimSpace(version)]
+	if !ok || pending.StartedAt.IsZero() {
+		return time.Time{}, false
+	}
+	return pending.StartedAt.UTC(), true
+}

--- a/gestaltd/internal/appregistry/pending.go
+++ b/gestaltd/internal/appregistry/pending.go
@@ -22,7 +22,7 @@ const (
 	FailedReasonWorkflowFailed = "workflow_failed"
 	FailedReasonStale          = "stale"
 
-	PendingStaleAfter = 30 * time.Minute
+	PendingStaleAfter = 2 * time.Hour
 	FailedRetainFor   = 30 * 24 * time.Hour
 )
 
@@ -250,7 +250,7 @@ func PrunePendingIndex(pending *PendingIndex, failed *FailedIndex, published *In
 			pendingChanged = true
 			continue
 		}
-		if now.Sub(entry.UpdatedAt.UTC()) > PendingStaleAfter {
+		if now.Sub(entry.StartedAt.UTC()) > PendingStaleAfter {
 			failed.Failed[version] = failedVersionFromPending(entry, now, FailedReasonStale)
 			delete(pending.Pending, version)
 			pendingChanged = true
@@ -291,6 +291,20 @@ func failedVersionFromPending(entry PendingVersion, failedAt time.Time, reason s
 		Reason:      reason,
 		Publication: clonePublication(entry.Publication),
 	}
+}
+
+// RemoveFailedVersion deletes one failed entry. The second return value reports
+// whether the version was present.
+func RemoveFailedVersion(index *FailedIndex, version string) bool {
+	if index == nil || index.Failed == nil {
+		return false
+	}
+	version = strings.TrimSpace(version)
+	if _, ok := index.Failed[version]; !ok {
+		return false
+	}
+	delete(index.Failed, version)
+	return true
 }
 
 // UpsertPendingVersion inserts or updates one pending version. startedAt is

--- a/gestaltd/internal/appregistry/pending.go
+++ b/gestaltd/internal/appregistry/pending.go
@@ -22,7 +22,7 @@ const (
 	FailedReasonWorkflowFailed = "workflow_failed"
 	FailedReasonStale          = "stale"
 
-	PendingStaleAfter = 2 * time.Hour
+	PendingStaleAfter = 30 * time.Minute
 	FailedRetainFor   = 30 * 24 * time.Hour
 )
 

--- a/gestaltd/internal/appregistry/pending.go
+++ b/gestaltd/internal/appregistry/pending.go
@@ -388,10 +388,7 @@ func ApplyPendingSet(pending *PendingIndex, failed *FailedIndex, published *Inde
 	now = now.UTC()
 
 	pendingChanged := false
-	failedChanged := false
-	if RemoveFailedVersion(failed, versionKey) {
-		failedChanged = true
-	}
+	failedChanged := RemoveFailedVersion(failed, versionKey)
 	prunedPending, prunedFailed := PrunePendingIndex(pending, failed, published, now, versionKey)
 	if prunedPending {
 		pendingChanged = true

--- a/gestaltd/internal/appregistry/pending_test.go
+++ b/gestaltd/internal/appregistry/pending_test.go
@@ -10,7 +10,7 @@ func TestPrunePendingIndex_MovesStaleEntryToFailed(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 7, 24, 20, 0, 0, 0, time.UTC)
-	staleStartedAt := now.Add(-2*time.Hour - time.Minute)
+	staleStartedAt := now.Add(-31 * time.Minute)
 	pending := &PendingIndex{
 		SchemaVersion: PendingIndexSchemaVersion,
 		App:           "traffic-cop",
@@ -46,7 +46,7 @@ func TestPrunePendingIndex_KeepsInFlightEntryWithinStaleWindow(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 7, 24, 20, 0, 0, 0, time.UTC)
-	inFlightStartedAt := now.Add(-90 * time.Minute)
+	inFlightStartedAt := now.Add(-29 * time.Minute)
 	pending := &PendingIndex{
 		SchemaVersion: PendingIndexSchemaVersion,
 		App:           "traffic-cop",

--- a/gestaltd/internal/appregistry/pending_test.go
+++ b/gestaltd/internal/appregistry/pending_test.go
@@ -2,6 +2,7 @@ package appregistry
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 )
@@ -484,6 +485,7 @@ func TestUpsertAppIndex_CopiesPublishStartedAt(t *testing.T) {
 	t.Parallel()
 
 	startedAt := time.Date(2026, 7, 24, 19, 0, 0, 0, time.UTC)
+	publishStartedAt := startedAt
 	entry := Entry{
 		SchemaVersion:    EntrySchemaVersion,
 		App:              "traffic-cop",
@@ -492,7 +494,7 @@ func TestUpsertAppIndex_CopiesPublishStartedAt(t *testing.T) {
 		ManifestPath:     "apps/traffic-cop/manifest.yaml",
 		Repository:       "github.com/valon-technologies/valon-tools",
 		PublishedAt:      time.Date(2026, 7, 24, 19, 4, 32, 0, time.UTC),
-		PublishStartedAt: startedAt,
+		PublishStartedAt: &publishStartedAt,
 		Artifacts: map[string]Artifact{
 			"linux/amd64": {
 				URL:       "https://example.com/artifact.tar.gz",
@@ -507,7 +509,35 @@ func TestUpsertAppIndex_CopiesPublishStartedAt(t *testing.T) {
 		t.Fatalf("UpsertAppIndex() = changed %v, err %v", changed, err)
 	}
 	got := index.Apps["traffic-cop"].Versions["0.0.1"]
-	if !got.PublishStartedAt.Equal(startedAt) {
+	if got.PublishStartedAt == nil || !got.PublishStartedAt.Equal(startedAt) {
 		t.Fatalf("index publishStartedAt = %v, want %v", got.PublishStartedAt, startedAt)
+	}
+}
+
+func TestEntry_OmitsZeroPublishStartedAt(t *testing.T) {
+	t.Parallel()
+
+	entry := Entry{
+		SchemaVersion: EntrySchemaVersion,
+		App:           "traffic-cop",
+		Version:       "0.0.1",
+		SourceRef:     "651a5c30feb995c9364c38f63d0d5c3880bc2055",
+		ManifestPath:  "apps/traffic-cop/manifest.yaml",
+		Repository:    "github.com/valon-technologies/valon-tools",
+		PublishedAt:   time.Date(2026, 7, 24, 19, 4, 32, 0, time.UTC),
+		Artifacts: map[string]Artifact{
+			"linux/amd64": {
+				URL:       "https://example.com/artifact.tar.gz",
+				PublicURL: "https://example.com/artifact.tar.gz",
+				SHA256:    "deadbeef",
+			},
+		},
+	}
+	data, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("marshal entry: %v", err)
+	}
+	if strings.Contains(string(data), "publishStartedAt") {
+		t.Fatalf("entry JSON should omit publishStartedAt: %s", data)
 	}
 }

--- a/gestaltd/internal/appregistry/pending_test.go
+++ b/gestaltd/internal/appregistry/pending_test.go
@@ -1,0 +1,240 @@
+package appregistry
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestPrunePendingIndex_MovesStaleEntryToFailed(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 24, 20, 0, 0, 0, time.UTC)
+	staleUpdatedAt := now.Add(-31 * time.Minute)
+	pending := &PendingIndex{
+		SchemaVersion: PendingIndexSchemaVersion,
+		App:           "traffic-cop",
+		Pending: map[string]PendingVersion{
+			"0.0.0-snapshot.gabc123": {
+				Version:   "0.0.0-snapshot.gabc123",
+				SourceRef: "abc123def456abc123def456abc123def456abcd",
+				StartedAt: staleUpdatedAt,
+				UpdatedAt: staleUpdatedAt,
+				Phase:     PendingPhasePublishing,
+			},
+		},
+	}
+	failed := NewEmptyFailedIndex("traffic-cop")
+
+	pendingChanged, failedChanged := PrunePendingIndex(pending, failed, NewEmptyIndex(), now)
+	if !pendingChanged || !failedChanged {
+		t.Fatalf("pendingChanged=%v failedChanged=%v", pendingChanged, failedChanged)
+	}
+	if len(pending.Pending) != 0 {
+		t.Fatalf("pending = %#v", pending.Pending)
+	}
+	entry, ok := failed.Failed["0.0.0-snapshot.gabc123"]
+	if !ok {
+		t.Fatalf("failed = %#v", failed.Failed)
+	}
+	if entry.Reason != FailedReasonStale || !entry.FailedAt.Equal(now) {
+		t.Fatalf("failed entry = %#v", entry)
+	}
+}
+
+func TestPrunePendingIndex_DropsAlreadyPublishedVersion(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	pending := &PendingIndex{
+		SchemaVersion: PendingIndexSchemaVersion,
+		App:           "traffic-cop",
+		Pending: map[string]PendingVersion{
+			"0.0.0-snapshot.gabc123": {
+				Version:   "0.0.0-snapshot.gabc123",
+				SourceRef: "abc123def456abc123def456abc123def456abcd",
+				StartedAt: now,
+				UpdatedAt: now,
+				Phase:     PendingPhasePublishing,
+			},
+		},
+	}
+	published := &Index{
+		SchemaVersion: IndexSchemaVersion,
+		Apps: map[string]AppVersions{
+			"traffic-cop": {
+				Versions: map[string]IndexVersion{
+					"0.0.0-snapshot.gabc123": {
+						Metadata:    "apps/traffic-cop/versions/0.0.0-snapshot.gabc123.json",
+						PublishedAt: now,
+					},
+				},
+			},
+		},
+	}
+
+	pendingChanged, failedChanged := PrunePendingIndex(pending, NewEmptyFailedIndex("traffic-cop"), published, now)
+	if !pendingChanged || failedChanged {
+		t.Fatalf("pendingChanged=%v failedChanged=%v", pendingChanged, failedChanged)
+	}
+	if len(pending.Pending) != 0 {
+		t.Fatalf("pending = %#v", pending.Pending)
+	}
+}
+
+func TestPruneFailedIndex_RemovesOldAndPublishedEntries(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 24, 0, 0, 0, 0, time.UTC)
+	failed := &FailedIndex{
+		SchemaVersion: FailedIndexSchemaVersion,
+		App:           "traffic-cop",
+		Failed: map[string]FailedVersion{
+			"0.0.0-snapshot.gold": {
+				Version:   "0.0.0-snapshot.gold",
+				SourceRef: "abc123def456abc123def456abc123def456abcd",
+				StartedAt: now.Add(-40 * 24 * time.Hour),
+				FailedAt:  now.Add(-31 * 24 * time.Hour),
+				Reason:    FailedReasonWorkflowFailed,
+			},
+			"0.0.0-snapshot.gpublished": {
+				Version:   "0.0.0-snapshot.gpublished",
+				SourceRef: "def456def456def456def456def456def456def4",
+				StartedAt: now.Add(-time.Hour),
+				FailedAt:  now.Add(-time.Hour),
+				Reason:    FailedReasonWorkflowFailed,
+			},
+		},
+	}
+	published := &Index{
+		SchemaVersion: IndexSchemaVersion,
+		Apps: map[string]AppVersions{
+			"traffic-cop": {
+				Versions: map[string]IndexVersion{
+					"0.0.0-snapshot.gpublished": {
+						Metadata:    "apps/traffic-cop/versions/0.0.0-snapshot.gpublished.json",
+						PublishedAt: now,
+					},
+				},
+			},
+		},
+	}
+
+	if !PruneFailedIndex(failed, published, now) {
+		t.Fatal("expected prune to change failed index")
+	}
+	if len(failed.Failed) != 0 {
+		t.Fatalf("failed = %#v", failed.Failed)
+	}
+}
+
+func TestUpsertPendingVersion_PreservesStartedAt(t *testing.T) {
+	t.Parallel()
+
+	startedAt := time.Date(2026, 7, 24, 19, 0, 0, 0, time.UTC)
+	updatedAt := startedAt.Add(2 * time.Minute)
+	index := &PendingIndex{
+		SchemaVersion: PendingIndexSchemaVersion,
+		App:           "traffic-cop",
+		Pending: map[string]PendingVersion{
+			"0.0.0-snapshot.gabc123": {
+				Version:   "0.0.0-snapshot.gabc123",
+				SourceRef: "abc123def456abc123def456abc123def456abcd",
+				StartedAt: startedAt,
+				UpdatedAt: startedAt,
+				Phase:     PendingPhasePublishing,
+			},
+		},
+	}
+
+	updated, changed := UpsertPendingVersion(index, "traffic-cop", PendingVersion{
+		Version:   "0.0.0-snapshot.gabc123",
+		SourceRef: "abc123def456abc123def456abc123def456abcd",
+	}, updatedAt)
+	if !changed {
+		t.Fatal("expected upsert to report change")
+	}
+	entry := updated.Pending["0.0.0-snapshot.gabc123"]
+	if !entry.StartedAt.Equal(startedAt) || !entry.UpdatedAt.Equal(updatedAt) {
+		t.Fatalf("entry = %#v", entry)
+	}
+}
+
+func TestDecodePendingAndFailedIndexRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 24, 19, 0, 0, 0, time.UTC)
+	pending := &PendingIndex{
+		SchemaVersion: PendingIndexSchemaVersion,
+		App:           "traffic-cop",
+		Pending: map[string]PendingVersion{
+			"0.0.0-snapshot.gabc123": {
+				Version:    "0.0.0-snapshot.gabc123",
+				SourceRef:  "abc123def456abc123def456abc123def456abcd",
+				Repository: "github.com/valon-technologies/toolshed",
+				StartedAt:  now,
+				UpdatedAt:  now,
+				Phase:      PendingPhasePublishing,
+			},
+		},
+	}
+	pendingData, err := json.Marshal(pending)
+	if err != nil {
+		t.Fatalf("marshal pending: %v", err)
+	}
+	decodedPending, err := DecodePendingIndex(pendingData)
+	if err != nil {
+		t.Fatalf("DecodePendingIndex: %v", err)
+	}
+	if len(decodedPending.Pending) != 1 {
+		t.Fatalf("decoded pending = %#v", decodedPending.Pending)
+	}
+
+	failed := &FailedIndex{
+		SchemaVersion: FailedIndexSchemaVersion,
+		App:           "traffic-cop",
+		Failed: map[string]FailedVersion{
+			"0.0.0-snapshot.gabc123": {
+				Version:   "0.0.0-snapshot.gabc123",
+				SourceRef: "abc123def456abc123def456abc123def456abcd",
+				StartedAt: now,
+				FailedAt:  now.Add(time.Minute),
+				Reason:    FailedReasonStale,
+			},
+		},
+	}
+	failedData, err := json.Marshal(failed)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	decodedFailed, err := DecodeFailedIndex(failedData)
+	if err != nil {
+		t.Fatalf("DecodeFailedIndex: %v", err)
+	}
+	if len(decodedFailed.Failed) != 1 {
+		t.Fatalf("decoded failed = %#v", decodedFailed.Failed)
+	}
+}
+
+func TestRecordFailedVersion_IsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	pending := PendingVersion{
+		Version:   "0.0.0-snapshot.gabc123",
+		SourceRef: "abc123def456abc123def456abc123def456abcd",
+		StartedAt: now,
+		UpdatedAt: now,
+		Phase:     PendingPhasePublishing,
+	}
+	index := NewEmptyFailedIndex("traffic-cop")
+
+	updated, changed := RecordFailedVersion(index, "traffic-cop", pending, now, FailedReasonWorkflowFailed)
+	if !changed {
+		t.Fatal("expected first record to change failed index")
+	}
+	_, changed = RecordFailedVersion(updated, "traffic-cop", pending, now.Add(time.Minute), FailedReasonWorkflowFailed)
+	if changed {
+		t.Fatal("expected second record to be a no-op")
+	}
+}

--- a/gestaltd/internal/appregistry/pending_test.go
+++ b/gestaltd/internal/appregistry/pending_test.go
@@ -10,7 +10,7 @@ func TestPrunePendingIndex_MovesStaleEntryToFailed(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 7, 24, 20, 0, 0, 0, time.UTC)
-	staleUpdatedAt := now.Add(-31 * time.Minute)
+	staleStartedAt := now.Add(-2*time.Hour - time.Minute)
 	pending := &PendingIndex{
 		SchemaVersion: PendingIndexSchemaVersion,
 		App:           "traffic-cop",
@@ -18,8 +18,8 @@ func TestPrunePendingIndex_MovesStaleEntryToFailed(t *testing.T) {
 			"0.0.0-snapshot.gabc123": {
 				Version:   "0.0.0-snapshot.gabc123",
 				SourceRef: "abc123def456abc123def456abc123def456abcd",
-				StartedAt: staleUpdatedAt,
-				UpdatedAt: staleUpdatedAt,
+				StartedAt: staleStartedAt,
+				UpdatedAt: now.Add(-30 * time.Minute),
 				Phase:     PendingPhasePublishing,
 			},
 		},
@@ -39,6 +39,54 @@ func TestPrunePendingIndex_MovesStaleEntryToFailed(t *testing.T) {
 	}
 	if entry.Reason != FailedReasonStale || !entry.FailedAt.Equal(now) {
 		t.Fatalf("failed entry = %#v", entry)
+	}
+}
+
+func TestPrunePendingIndex_KeepsInFlightEntryWithinStaleWindow(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 24, 20, 0, 0, 0, time.UTC)
+	inFlightStartedAt := now.Add(-90 * time.Minute)
+	pending := &PendingIndex{
+		SchemaVersion: PendingIndexSchemaVersion,
+		App:           "traffic-cop",
+		Pending: map[string]PendingVersion{
+			"0.0.0-snapshot.gabc123": {
+				Version:   "0.0.0-snapshot.gabc123",
+				SourceRef: "abc123def456abc123def456abc123def456abcd",
+				StartedAt: inFlightStartedAt,
+				UpdatedAt: inFlightStartedAt,
+				Phase:     PendingPhasePublishing,
+			},
+		},
+	}
+	failed := NewEmptyFailedIndex("traffic-cop")
+
+	pendingChanged, failedChanged := PrunePendingIndex(pending, failed, NewEmptyIndex(), now)
+	if pendingChanged || failedChanged {
+		t.Fatalf("pendingChanged=%v failedChanged=%v", pendingChanged, failedChanged)
+	}
+	if len(pending.Pending) != 1 {
+		t.Fatalf("pending = %#v", pending.Pending)
+	}
+}
+
+func TestRemoveFailedVersion(t *testing.T) {
+	t.Parallel()
+
+	failed := &FailedIndex{
+		Failed: map[string]FailedVersion{
+			"0.0.1": {Version: "0.0.1"},
+		},
+	}
+	if !RemoveFailedVersion(failed, "0.0.1") {
+		t.Fatal("expected remove to succeed")
+	}
+	if len(failed.Failed) != 0 {
+		t.Fatalf("failed = %#v", failed.Failed)
+	}
+	if RemoveFailedVersion(failed, "0.0.1") {
+		t.Fatal("expected second remove to be a no-op")
 	}
 }
 

--- a/gestaltd/internal/appregistry/pending_test.go
+++ b/gestaltd/internal/appregistry/pending_test.go
@@ -26,7 +26,7 @@ func TestPrunePendingIndex_MovesStaleEntryToFailed(t *testing.T) {
 	}
 	failed := NewEmptyFailedIndex("traffic-cop")
 
-	pendingChanged, failedChanged := PrunePendingIndex(pending, failed, NewEmptyIndex(), now)
+	pendingChanged, failedChanged := PrunePendingIndex(pending, failed, NewEmptyIndex(), now, "")
 	if !pendingChanged || !failedChanged {
 		t.Fatalf("pendingChanged=%v failedChanged=%v", pendingChanged, failedChanged)
 	}
@@ -62,11 +62,182 @@ func TestPrunePendingIndex_KeepsInFlightEntryWithinStaleWindow(t *testing.T) {
 	}
 	failed := NewEmptyFailedIndex("traffic-cop")
 
-	pendingChanged, failedChanged := PrunePendingIndex(pending, failed, NewEmptyIndex(), now)
+	pendingChanged, failedChanged := PrunePendingIndex(pending, failed, NewEmptyIndex(), now, "")
 	if pendingChanged || failedChanged {
 		t.Fatalf("pendingChanged=%v failedChanged=%v", pendingChanged, failedChanged)
 	}
 	if len(pending.Pending) != 1 {
+		t.Fatalf("pending = %#v", pending.Pending)
+	}
+}
+
+func TestPrunePendingIndex_SkipsExceptVersion(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 24, 20, 0, 0, 0, time.UTC)
+	staleStartedAt := now.Add(-31 * time.Minute)
+	version := "0.0.0-snapshot.gabc123"
+	pending := &PendingIndex{
+		SchemaVersion: PendingIndexSchemaVersion,
+		App:           "traffic-cop",
+		Pending: map[string]PendingVersion{
+			version: {
+				Version:   version,
+				SourceRef: "abc123def456abc123def456abc123def456abcd",
+				StartedAt: staleStartedAt,
+				UpdatedAt: staleStartedAt,
+				Phase:     PendingPhasePublishing,
+			},
+		},
+	}
+	failed := NewEmptyFailedIndex("traffic-cop")
+
+	pendingChanged, failedChanged := PrunePendingIndex(pending, failed, NewEmptyIndex(), now, version)
+	if pendingChanged || failedChanged {
+		t.Fatalf("pendingChanged=%v failedChanged=%v", pendingChanged, failedChanged)
+	}
+	if len(pending.Pending) != 1 || len(failed.Failed) != 0 {
+		t.Fatalf("pending=%#v failed=%#v", pending.Pending, failed.Failed)
+	}
+}
+
+func TestApplyPendingSet_RetryDoesNotDuplicateStaleFailedEntry(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 24, 20, 0, 0, 0, time.UTC)
+	staleStartedAt := now.Add(-31 * time.Minute)
+	version := "0.0.0-snapshot.gabc123"
+	pending := &PendingIndex{
+		SchemaVersion: PendingIndexSchemaVersion,
+		App:           "traffic-cop",
+		Pending: map[string]PendingVersion{
+			version: {
+				Version:   version,
+				SourceRef: "abc123def456abc123def456abc123def456abcd",
+				StartedAt: staleStartedAt,
+				UpdatedAt: staleStartedAt,
+				Phase:     PendingPhasePublishing,
+			},
+		},
+	}
+	failed := NewEmptyFailedIndex("traffic-cop")
+
+	pendingChanged, failedChanged := ApplyPendingSet(
+		pending,
+		failed,
+		NewEmptyIndex(),
+		"traffic-cop",
+		PendingVersion{
+			Version:   version,
+			SourceRef: "abc123def456abc123def456abc123def456abcd",
+		},
+		now,
+	)
+	if !pendingChanged || failedChanged {
+		t.Fatalf("pendingChanged=%v failedChanged=%v", pendingChanged, failedChanged)
+	}
+	if _, ok := pending.Pending[version]; !ok {
+		t.Fatalf("pending = %#v", pending.Pending)
+	}
+	if _, ok := failed.Failed[version]; ok {
+		t.Fatalf("failed = %#v", failed.Failed)
+	}
+	if !pending.Pending[version].StartedAt.Equal(now) {
+		t.Fatalf("startedAt = %v, want fresh timestamp %v", pending.Pending[version].StartedAt, now)
+	}
+}
+
+func TestApplyPendingSet_SkipsUpsertForPublishedVersion(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 24, 20, 0, 0, 0, time.UTC)
+	version := "0.0.0-snapshot.gabc123"
+	pending := &PendingIndex{
+		SchemaVersion: PendingIndexSchemaVersion,
+		App:           "traffic-cop",
+		Pending: map[string]PendingVersion{
+			version: {
+				Version:   version,
+				SourceRef: "abc123def456abc123def456abc123def456abcd",
+				StartedAt: now.Add(-time.Hour),
+				UpdatedAt: now.Add(-time.Hour),
+				Phase:     PendingPhasePublishing,
+			},
+		},
+	}
+	failed := NewEmptyFailedIndex("traffic-cop")
+	published := &Index{
+		SchemaVersion: IndexSchemaVersion,
+		Apps: map[string]AppVersions{
+			"traffic-cop": {
+				Versions: map[string]IndexVersion{
+					version: {
+						Metadata:    "apps/traffic-cop/versions/" + version + ".json",
+						PublishedAt: now,
+					},
+				},
+			},
+		},
+	}
+
+	pendingChanged, failedChanged := ApplyPendingSet(
+		pending,
+		failed,
+		published,
+		"traffic-cop",
+		PendingVersion{
+			Version:   version,
+			SourceRef: "abc123def456abc123def456abc123def456abcd",
+		},
+		now,
+	)
+	if !pendingChanged || failedChanged {
+		t.Fatalf("pendingChanged=%v failedChanged=%v", pendingChanged, failedChanged)
+	}
+	if len(pending.Pending) != 0 {
+		t.Fatalf("pending = %#v", pending.Pending)
+	}
+}
+
+func TestApplyPendingSet_PersistsFailedPrune(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 24, 20, 0, 0, 0, time.UTC)
+	staleVersion := "0.0.0-snapshot.gstale"
+	activeVersion := "0.0.0-snapshot.gactive"
+	pending := &PendingIndex{
+		SchemaVersion: PendingIndexSchemaVersion,
+		App:           "traffic-cop",
+		Pending: map[string]PendingVersion{
+			staleVersion: {
+				Version:   staleVersion,
+				SourceRef: "abc123def456abc123def456abc123def456abcd",
+				StartedAt: now.Add(-31 * time.Minute),
+				UpdatedAt: now.Add(-31 * time.Minute),
+				Phase:     PendingPhasePublishing,
+			},
+		},
+	}
+	failed := NewEmptyFailedIndex("traffic-cop")
+
+	pendingChanged, failedChanged := ApplyPendingSet(
+		pending,
+		failed,
+		NewEmptyIndex(),
+		"traffic-cop",
+		PendingVersion{
+			Version:   activeVersion,
+			SourceRef: "def456def456def456def456def456def456def4",
+		},
+		now,
+	)
+	if !pendingChanged || !failedChanged {
+		t.Fatalf("pendingChanged=%v failedChanged=%v", pendingChanged, failedChanged)
+	}
+	if _, ok := failed.Failed[staleVersion]; !ok {
+		t.Fatalf("failed = %#v", failed.Failed)
+	}
+	if _, ok := pending.Pending[activeVersion]; !ok {
 		t.Fatalf("pending = %#v", pending.Pending)
 	}
 }
@@ -121,7 +292,7 @@ func TestPrunePendingIndex_DropsAlreadyPublishedVersion(t *testing.T) {
 		},
 	}
 
-	pendingChanged, failedChanged := PrunePendingIndex(pending, NewEmptyFailedIndex("traffic-cop"), published, now)
+	pendingChanged, failedChanged := PrunePendingIndex(pending, NewEmptyFailedIndex("traffic-cop"), published, now, "")
 	if !pendingChanged || failedChanged {
 		t.Fatalf("pendingChanged=%v failedChanged=%v", pendingChanged, failedChanged)
 	}

--- a/gestaltd/internal/appregistry/pending_test.go
+++ b/gestaltd/internal/appregistry/pending_test.go
@@ -238,3 +238,57 @@ func TestRecordFailedVersion_IsIdempotent(t *testing.T) {
 		t.Fatal("expected second record to be a no-op")
 	}
 }
+
+func TestPublishStartedAtFromPending(t *testing.T) {
+	t.Parallel()
+
+	startedAt := time.Date(2026, 7, 24, 19, 0, 0, 0, time.UTC)
+	index := &PendingIndex{
+		Pending: map[string]PendingVersion{
+			"0.0.1": {Version: "0.0.1", StartedAt: startedAt},
+		},
+	}
+
+	got, ok := PublishStartedAtFromPending(index, "0.0.1")
+	if !ok || !got.Equal(startedAt) {
+		t.Fatalf("PublishStartedAtFromPending() = (%v, %v), want (%v, true)", got, ok, startedAt)
+	}
+	if _, ok := PublishStartedAtFromPending(index, "missing"); ok {
+		t.Fatal("expected missing version to return false")
+	}
+	if _, ok := PublishStartedAtFromPending(nil, "0.0.1"); ok {
+		t.Fatal("expected nil index to return false")
+	}
+}
+
+func TestUpsertAppIndex_CopiesPublishStartedAt(t *testing.T) {
+	t.Parallel()
+
+	startedAt := time.Date(2026, 7, 24, 19, 0, 0, 0, time.UTC)
+	entry := Entry{
+		SchemaVersion:    EntrySchemaVersion,
+		App:              "traffic-cop",
+		Version:          "0.0.1",
+		SourceRef:        "651a5c30feb995c9364c38f63d0d5c3880bc2055",
+		ManifestPath:     "apps/traffic-cop/manifest.yaml",
+		Repository:       "github.com/valon-technologies/valon-tools",
+		PublishedAt:      time.Date(2026, 7, 24, 19, 4, 32, 0, time.UTC),
+		PublishStartedAt: startedAt,
+		Artifacts: map[string]Artifact{
+			"linux/amd64": {
+				URL:       "https://example.com/artifact.tar.gz",
+				PublicURL: "https://example.com/artifact.tar.gz",
+				SHA256:    "deadbeef",
+			},
+		},
+	}
+
+	index, changed, err := UpsertAppIndex(NewEmptyIndex(), entry, "apps/traffic-cop/versions/0.0.1.json", "", "")
+	if err != nil || !changed {
+		t.Fatalf("UpsertAppIndex() = changed %v, err %v", changed, err)
+	}
+	got := index.Apps["traffic-cop"].Versions["0.0.1"]
+	if !got.PublishStartedAt.Equal(startedAt) {
+		t.Fatalf("index publishStartedAt = %v, want %v", got.PublishStartedAt, startedAt)
+	}
+}

--- a/gestaltd/internal/appregistry/reader.go
+++ b/gestaltd/internal/appregistry/reader.go
@@ -126,7 +126,8 @@ func VersionsFromIndex(index *Index, appName string) []VersionSummary {
 		return []VersionSummary{}
 	}
 	out := make([]VersionSummary, 0, len(appVersions.Versions))
-	for version, summary := range appVersions.Versions {
+	for version := range appVersions.Versions {
+		summary := appVersions.Versions[version]
 		out = append(out, VersionSummary{
 			Version:     version,
 			Metadata:    summary.Metadata,

--- a/gestaltd/internal/appregistry/registry.go
+++ b/gestaltd/internal/appregistry/registry.go
@@ -49,16 +49,16 @@ type IndexVersion struct {
 }
 
 type Entry struct {
-	SchemaVersion int                 `json:"schemaVersion"`
-	App           string              `json:"app"`
-	Version       string              `json:"version"`
-	SourceRef     string              `json:"sourceRef"`
-	ManifestPath  string              `json:"manifestPath"`
-	Repository    string              `json:"repository"`
-	Publication   *Publication        `json:"publication,omitempty"`
-	Artifacts     map[string]Artifact `json:"artifacts"`
-	Interface     Interface           `json:"interface,omitempty"`
-	Requires      Requires            `json:"requires,omitempty"`
+	SchemaVersion    int                 `json:"schemaVersion"`
+	App              string              `json:"app"`
+	Version          string              `json:"version"`
+	SourceRef        string              `json:"sourceRef"`
+	ManifestPath     string              `json:"manifestPath"`
+	Repository       string              `json:"repository"`
+	Publication      *Publication        `json:"publication,omitempty"`
+	Artifacts        map[string]Artifact `json:"artifacts"`
+	Interface        Interface           `json:"interface,omitempty"`
+	Requires         Requires            `json:"requires,omitempty"`
 	Compatibility    Compatibility       `json:"compatibility,omitempty"`
 	PublishedAt      time.Time           `json:"publishedAt"`
 	PublishStartedAt time.Time           `json:"publishStartedAt,omitempty"`
@@ -268,15 +268,15 @@ func BuildEntry(input BuildEntryInput) (Entry, error) {
 }
 
 type BuildEntryInput struct {
-	Manifest     *providermanifestv1.Manifest
-	Version      string
-	SourceRef    string
-	ManifestPath string
-	Publication  *Publication
-	Release      *providerrelease.Metadata
-	Artifacts         []PublishArtifact
-	PublishedAt       time.Time
-	PublishStartedAt  time.Time
+	Manifest         *providermanifestv1.Manifest
+	Version          string
+	SourceRef        string
+	ManifestPath     string
+	Publication      *Publication
+	Release          *providerrelease.Metadata
+	Artifacts        []PublishArtifact
+	PublishedAt      time.Time
+	PublishStartedAt time.Time
 }
 
 func buildArtifacts(artifacts []PublishArtifact) (map[string]Artifact, error) {
@@ -467,7 +467,8 @@ func validateIndex(index *Index) error {
 		if len(app.Versions) == 0 {
 			return fmt.Errorf("app registry index app %q has no versions", appName)
 		}
-		for version, release := range app.Versions {
+		for version := range app.Versions {
+			release := app.Versions[version]
 			if err := source.ValidateVersion(version); err != nil {
 				return fmt.Errorf("app registry index app %q version %q is invalid: %w", appName, version, err)
 			}

--- a/gestaltd/internal/appregistry/registry.go
+++ b/gestaltd/internal/appregistry/registry.go
@@ -159,6 +159,11 @@ func AppNameFromManifestSource(source string) (string, error) {
 	return appName, err
 }
 
+func RepositoryFromManifestSource(source string) (string, error) {
+	_, repository, err := parseAppSource(source)
+	return repository, err
+}
+
 // RequirementAppName normalizes a requires.apps map key to the short fleet app name.
 // Manifest dependencies may use full source addresses (github.com/acme/apps/base)
 // while fleet catalog entries use short names (base).

--- a/gestaltd/internal/appregistry/registry.go
+++ b/gestaltd/internal/appregistry/registry.go
@@ -39,12 +39,13 @@ type AppVersions struct {
 }
 
 type IndexVersion struct {
-	Metadata    string       `json:"metadata"`
-	Platforms   []string     `json:"platforms,omitempty"`
-	PublishedAt time.Time    `json:"publishedAt"`
-	SourceRef   string       `json:"sourceRef,omitempty"`
-	Repository  string       `json:"repository,omitempty"`
-	Publication *Publication `json:"publication,omitempty"`
+	Metadata         string       `json:"metadata"`
+	Platforms        []string     `json:"platforms,omitempty"`
+	PublishedAt      time.Time    `json:"publishedAt"`
+	PublishStartedAt time.Time    `json:"publishStartedAt,omitempty"`
+	SourceRef        string       `json:"sourceRef,omitempty"`
+	Repository       string       `json:"repository,omitempty"`
+	Publication      *Publication `json:"publication,omitempty"`
 }
 
 type Entry struct {
@@ -58,8 +59,9 @@ type Entry struct {
 	Artifacts     map[string]Artifact `json:"artifacts"`
 	Interface     Interface           `json:"interface,omitempty"`
 	Requires      Requires            `json:"requires,omitempty"`
-	Compatibility Compatibility       `json:"compatibility,omitempty"`
-	PublishedAt   time.Time           `json:"publishedAt"`
+	Compatibility    Compatibility       `json:"compatibility,omitempty"`
+	PublishedAt      time.Time           `json:"publishedAt"`
+	PublishStartedAt time.Time           `json:"publishStartedAt,omitempty"`
 }
 
 type Publication struct {
@@ -256,6 +258,9 @@ func BuildEntry(input BuildEntryInput) (Entry, error) {
 		Compatibility: compatibility,
 		PublishedAt:   publishedAt.UTC(),
 	}
+	if !input.PublishStartedAt.IsZero() {
+		entry.PublishStartedAt = input.PublishStartedAt.UTC()
+	}
 	if err := validateEntry(&entry); err != nil {
 		return Entry{}, err
 	}
@@ -269,8 +274,9 @@ type BuildEntryInput struct {
 	ManifestPath string
 	Publication  *Publication
 	Release      *providerrelease.Metadata
-	Artifacts    []PublishArtifact
-	PublishedAt  time.Time
+	Artifacts         []PublishArtifact
+	PublishedAt       time.Time
+	PublishStartedAt  time.Time
 }
 
 func buildArtifacts(artifacts []PublishArtifact) (map[string]Artifact, error) {
@@ -367,10 +373,12 @@ func requiresFromProviderRelease(requires providerrelease.Requires) Requires {
 }
 
 // EntriesEqualIgnoringPublishedAt reports whether two entries are identical except
-// for publishedAt, which is ignored for idempotent republish checks.
+// for publishedAt and publishStartedAt, which are ignored for idempotent republish checks.
 func EntriesEqualIgnoringPublishedAt(a, b Entry) bool {
 	a.PublishedAt = time.Time{}
 	b.PublishedAt = time.Time{}
+	a.PublishStartedAt = time.Time{}
+	b.PublishStartedAt = time.Time{}
 	aData, err := json.Marshal(a)
 	if err != nil {
 		return false
@@ -578,12 +586,13 @@ func UpsertAppIndex(index *Index, entry Entry, metadataPath string, displayName,
 	platforms := artifactPlatforms(entry.Artifacts)
 	sort.Strings(platforms)
 	app.Versions[entry.Version] = IndexVersion{
-		Metadata:    strings.TrimSpace(metadataPath),
-		Platforms:   platforms,
-		PublishedAt: entry.PublishedAt.UTC(),
-		SourceRef:   strings.TrimSpace(entry.SourceRef),
-		Repository:  strings.TrimSpace(entry.Repository),
-		Publication: clonePublication(entry.Publication),
+		Metadata:         strings.TrimSpace(metadataPath),
+		Platforms:        platforms,
+		PublishedAt:      entry.PublishedAt.UTC(),
+		PublishStartedAt: entry.PublishStartedAt.UTC(),
+		SourceRef:        strings.TrimSpace(entry.SourceRef),
+		Repository:       strings.TrimSpace(entry.Repository),
+		Publication:      clonePublication(entry.Publication),
 	}
 	index.Apps[appName] = app
 	if err := validateIndex(index); err != nil {

--- a/gestaltd/internal/appregistry/registry.go
+++ b/gestaltd/internal/appregistry/registry.go
@@ -42,7 +42,7 @@ type IndexVersion struct {
 	Metadata         string       `json:"metadata"`
 	Platforms        []string     `json:"platforms,omitempty"`
 	PublishedAt      time.Time    `json:"publishedAt"`
-	PublishStartedAt *time.Time    `json:"publishStartedAt,omitempty"`
+	PublishStartedAt *time.Time   `json:"publishStartedAt,omitempty"`
 	SourceRef        string       `json:"sourceRef,omitempty"`
 	Repository       string       `json:"repository,omitempty"`
 	Publication      *Publication `json:"publication,omitempty"`

--- a/gestaltd/internal/appregistry/registry.go
+++ b/gestaltd/internal/appregistry/registry.go
@@ -42,7 +42,7 @@ type IndexVersion struct {
 	Metadata         string       `json:"metadata"`
 	Platforms        []string     `json:"platforms,omitempty"`
 	PublishedAt      time.Time    `json:"publishedAt"`
-	PublishStartedAt time.Time    `json:"publishStartedAt,omitempty"`
+	PublishStartedAt *time.Time    `json:"publishStartedAt,omitempty"`
 	SourceRef        string       `json:"sourceRef,omitempty"`
 	Repository       string       `json:"repository,omitempty"`
 	Publication      *Publication `json:"publication,omitempty"`
@@ -61,7 +61,7 @@ type Entry struct {
 	Requires         Requires            `json:"requires,omitempty"`
 	Compatibility    Compatibility       `json:"compatibility,omitempty"`
 	PublishedAt      time.Time           `json:"publishedAt"`
-	PublishStartedAt time.Time           `json:"publishStartedAt,omitempty"`
+	PublishStartedAt *time.Time          `json:"publishStartedAt,omitempty"`
 }
 
 type Publication struct {
@@ -259,7 +259,8 @@ func BuildEntry(input BuildEntryInput) (Entry, error) {
 		PublishedAt:   publishedAt.UTC(),
 	}
 	if !input.PublishStartedAt.IsZero() {
-		entry.PublishStartedAt = input.PublishStartedAt.UTC()
+		startedAt := input.PublishStartedAt.UTC()
+		entry.PublishStartedAt = &startedAt
 	}
 	if err := validateEntry(&entry); err != nil {
 		return Entry{}, err
@@ -377,8 +378,8 @@ func requiresFromProviderRelease(requires providerrelease.Requires) Requires {
 func EntriesEqualIgnoringPublishedAt(a, b Entry) bool {
 	a.PublishedAt = time.Time{}
 	b.PublishedAt = time.Time{}
-	a.PublishStartedAt = time.Time{}
-	b.PublishStartedAt = time.Time{}
+	a.PublishStartedAt = nil
+	b.PublishStartedAt = nil
 	aData, err := json.Marshal(a)
 	if err != nil {
 		return false
@@ -586,15 +587,19 @@ func UpsertAppIndex(index *Index, entry Entry, metadataPath string, displayName,
 	applyAppIndexAppMetadata(&app, displayName, description)
 	platforms := artifactPlatforms(entry.Artifacts)
 	sort.Strings(platforms)
-	app.Versions[entry.Version] = IndexVersion{
-		Metadata:         strings.TrimSpace(metadataPath),
-		Platforms:        platforms,
-		PublishedAt:      entry.PublishedAt.UTC(),
-		PublishStartedAt: entry.PublishStartedAt.UTC(),
-		SourceRef:        strings.TrimSpace(entry.SourceRef),
-		Repository:       strings.TrimSpace(entry.Repository),
-		Publication:      clonePublication(entry.Publication),
+	indexVersion := IndexVersion{
+		Metadata:    strings.TrimSpace(metadataPath),
+		Platforms:   platforms,
+		PublishedAt: entry.PublishedAt.UTC(),
+		SourceRef:   strings.TrimSpace(entry.SourceRef),
+		Repository:  strings.TrimSpace(entry.Repository),
+		Publication: clonePublication(entry.Publication),
 	}
+	if entry.PublishStartedAt != nil && !entry.PublishStartedAt.IsZero() {
+		startedAt := entry.PublishStartedAt.UTC()
+		indexVersion.PublishStartedAt = &startedAt
+	}
+	app.Versions[entry.Version] = indexVersion
 	index.Apps[appName] = app
 	if err := validateIndex(index); err != nil {
 		return nil, false, err

--- a/gestaltd/internal/config/app_registry_config.go
+++ b/gestaltd/internal/config/app_registry_config.go
@@ -37,7 +37,7 @@ func (c *AppRegistryConfig) UnmarshalYAML(value *yaml.Node) error {
 			case "publicUrl":
 				return fmt.Errorf("app registry publicUrl is derived from gcs.bucket")
 			case "publish":
-				return fmt.Errorf("app registry publish targets are passed to gestaltd app publish via --bucket")
+				return fmt.Errorf("app registry publish targets are passed to gestaltd app registry publish via --bucket")
 			}
 		}
 	}

--- a/gestaltd/internal/daemon/app.go
+++ b/gestaltd/internal/daemon/app.go
@@ -7,6 +7,8 @@ import (
 	"os"
 )
 
+const appPublishDeprecatedMessage = "gestaltd app publish is deprecated; use gestaltd app registry publish"
+
 func runApp(args []string) error {
 	if len(args) == 0 {
 		printAppUsage(os.Stderr)
@@ -17,7 +19,10 @@ func runApp(args []string) error {
 	case "-h", "--help", "help":
 		printAppUsage(os.Stderr)
 		return flag.ErrHelp
+	case "registry":
+		return runAppRegistry(args[1:])
 	case "publish":
+		_, _ = fmt.Fprintln(os.Stderr, appPublishDeprecatedMessage)
 		return runAppPublish(args[1:])
 	default:
 		return fmt.Errorf("unknown app command %q", args[0])
@@ -29,5 +34,6 @@ func printAppUsage(w io.Writer) {
 	writeUsageLine(w, "  gestaltd app <command> [flags]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Commands:")
-	writeUsageLine(w, "  publish     Publish an installable app version to a configured app registry")
+	writeUsageLine(w, "  registry    Manage app registry catalogs and publishes")
+	writeUsageLine(w, "  publish     Deprecated alias for registry publish")
 }

--- a/gestaltd/internal/daemon/app_publish.go
+++ b/gestaltd/internal/daemon/app_publish.go
@@ -173,10 +173,7 @@ func runAppPublishCommand(commandName string, usage func(io.Writer), args []stri
 		return err
 	}
 
-	publishStartedAt, err := loadAppRegistryPublishStartedAt(registry, strings.TrimSpace(*appName), strings.TrimSpace(*version))
-	if err != nil {
-		return err
-	}
+	publishStartedAt := loadAppRegistryPublishStartedAt(registry, strings.TrimSpace(*appName), strings.TrimSpace(*version))
 
 	plan, err := buildAppPublishPlan(appPublishPlanInput{
 		Registry:         registry,
@@ -685,28 +682,25 @@ func appPublishPreconditionFailed(err error) bool {
 		strings.Contains(text, "412")
 }
 
-func loadAppRegistryPublishStartedAt(registry config.AppRegistryConfig, appName, version string) (time.Time, error) {
+func loadAppRegistryPublishStartedAt(registry config.AppRegistryConfig, appName, version string) time.Time {
 	storageRoot, err := registry.StorageURL()
 	if err != nil {
-		return time.Time{}, err
+		return time.Time{}
 	}
 	pendingURL := appregistry.StorageURL(storageRoot, appregistry.AppPendingPath(appName))
 	_, pendingData, err := downloadAppRegistryObject(pendingURL)
-	if err != nil {
-		return time.Time{}, err
-	}
-	if len(pendingData) == 0 {
-		return time.Time{}, nil
+	if err != nil || len(pendingData) == 0 {
+		return time.Time{}
 	}
 	pending, err := appregistry.DecodePendingIndex(pendingData)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("decode pending catalog: %w", err)
+		return time.Time{}
 	}
 	startedAt, ok := appregistry.PublishStartedAtFromPending(pending, version)
 	if !ok {
-		return time.Time{}, nil
+		return time.Time{}
 	}
-	return startedAt, nil
+	return startedAt
 }
 
 func downloadAppRegistryObject(storageURL string) (int64, []byte, error) {

--- a/gestaltd/internal/daemon/app_publish.go
+++ b/gestaltd/internal/daemon/app_publish.go
@@ -62,9 +62,13 @@ type appPublishObject struct {
 	SHA256     string `json:"sha256,omitempty"`
 }
 
-func runAppPublish(args []string) (err error) {
-	fs := flag.NewFlagSet("gestaltd app publish", flag.ContinueOnError)
-	fs.Usage = func() { printAppPublishUsage(fs.Output()) }
+func runAppPublish(args []string) error {
+	return runAppPublishCommand("gestaltd app publish", printAppPublishUsage, args)
+}
+
+func runAppPublishCommand(commandName string, usage func(io.Writer), args []string) error {
+	fs := flag.NewFlagSet(commandName, flag.ContinueOnError)
+	fs.Usage = func() { usage(fs.Output()) }
 	bucket := fs.String("bucket", "", "GCS bucket name for registry uploads")
 	appName := fs.String("app", "", "app name under apps/{app}/manifest.yaml")
 	version := fs.String("version", "", "semantic version guard")

--- a/gestaltd/internal/daemon/app_publish.go
+++ b/gestaltd/internal/daemon/app_publish.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/valon-technologies/gestalt/server/internal/appregistry"
 	"github.com/valon-technologies/gestalt/server/internal/config"
@@ -172,18 +173,24 @@ func runAppPublishCommand(commandName string, usage func(io.Writer), args []stri
 		return err
 	}
 
+	publishStartedAt, err := loadAppRegistryPublishStartedAt(registry, strings.TrimSpace(*appName), strings.TrimSpace(*version))
+	if err != nil {
+		return err
+	}
+
 	plan, err := buildAppPublishPlan(appPublishPlanInput{
-		Registry:     registry,
-		DisplayName:  sourceManifest.DisplayName,
-		Description:  sourceManifest.Description,
-		Version:      *version,
-		SourceRef:    sourceRef,
-		ManifestPath: sourceInfo.ManifestPath,
-		Publication:  publication,
-		Manifest:     sourceManifest,
-		Release:      releaseMetadata,
-		Archives:     releaseArchives,
-		MetadataPath: filepath.Join(tmpDir, providerrelease.MetadataFile),
+		Registry:         registry,
+		DisplayName:      sourceManifest.DisplayName,
+		Description:      sourceManifest.Description,
+		Version:          *version,
+		SourceRef:        sourceRef,
+		ManifestPath:     sourceInfo.ManifestPath,
+		Publication:      publication,
+		Manifest:         sourceManifest,
+		Release:          releaseMetadata,
+		Archives:         releaseArchives,
+		MetadataPath:     filepath.Join(tmpDir, providerrelease.MetadataFile),
+		PublishStartedAt: publishStartedAt,
 	})
 	if err != nil {
 		return err
@@ -330,17 +337,18 @@ func gitRootFromWorkingDirectory() (string, error) {
 }
 
 type appPublishPlanInput struct {
-	Registry     config.AppRegistryConfig
-	DisplayName  string
-	Description  string
-	Version      string
-	SourceRef    string
-	ManifestPath string
-	Publication  *appregistry.Publication
-	Manifest     *providermanifestv1.Manifest
-	Release      *providerrelease.Metadata
-	Archives     []releaseArchive
-	MetadataPath string
+	Registry         config.AppRegistryConfig
+	DisplayName      string
+	Description      string
+	Version          string
+	SourceRef        string
+	ManifestPath     string
+	Publication      *appregistry.Publication
+	Manifest         *providermanifestv1.Manifest
+	Release          *providerrelease.Metadata
+	Archives         []releaseArchive
+	MetadataPath     string
+	PublishStartedAt time.Time
 }
 
 func buildAppPublishPlan(input appPublishPlanInput) (appPublishPlan, error) {
@@ -395,13 +403,14 @@ func buildAppPublishPlan(input appPublishPlanInput) (appPublishPlan, error) {
 	}
 
 	entry, err := appregistry.BuildEntry(appregistry.BuildEntryInput{
-		Manifest:     input.Manifest,
-		Version:      input.Version,
-		SourceRef:    input.SourceRef,
-		ManifestPath: input.ManifestPath,
-		Publication:  input.Publication,
-		Release:      input.Release,
-		Artifacts:    publishArtifacts,
+		Manifest:         input.Manifest,
+		Version:          input.Version,
+		SourceRef:        input.SourceRef,
+		ManifestPath:     input.ManifestPath,
+		Publication:      input.Publication,
+		Release:          input.Release,
+		Artifacts:        publishArtifacts,
+		PublishStartedAt: input.PublishStartedAt,
 	})
 	if err != nil {
 		return appPublishPlan{}, err
@@ -674,6 +683,30 @@ func appPublishPreconditionFailed(err error) bool {
 	return strings.Contains(text, "precondition") ||
 		strings.Contains(text, "generation") ||
 		strings.Contains(text, "412")
+}
+
+func loadAppRegistryPublishStartedAt(registry config.AppRegistryConfig, appName, version string) (time.Time, error) {
+	storageRoot, err := registry.StorageURL()
+	if err != nil {
+		return time.Time{}, err
+	}
+	pendingURL := appregistry.StorageURL(storageRoot, appregistry.AppPendingPath(appName))
+	_, pendingData, err := downloadAppRegistryObject(pendingURL)
+	if err != nil {
+		return time.Time{}, err
+	}
+	if len(pendingData) == 0 {
+		return time.Time{}, nil
+	}
+	pending, err := appregistry.DecodePendingIndex(pendingData)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("decode pending catalog: %w", err)
+	}
+	startedAt, ok := appregistry.PublishStartedAtFromPending(pending, version)
+	if !ok {
+		return time.Time{}, nil
+	}
+	return startedAt, nil
 }
 
 func downloadAppRegistryObject(storageURL string) (int64, []byte, error) {

--- a/gestaltd/internal/daemon/app_registry.go
+++ b/gestaltd/internal/daemon/app_registry.go
@@ -1,0 +1,36 @@
+package daemon
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+)
+
+func runAppRegistry(args []string) error {
+	if len(args) == 0 {
+		printAppRegistryUsage(os.Stderr)
+		return flag.ErrHelp
+	}
+
+	switch args[0] {
+	case "-h", "--help", "help":
+		printAppRegistryUsage(os.Stderr)
+		return flag.ErrHelp
+	case "publish":
+		return runAppRegistryPublish(args[1:])
+	case "pending":
+		return runAppRegistryPending(args[1:])
+	default:
+		return fmt.Errorf("unknown app registry command %q", args[0])
+	}
+}
+
+func printAppRegistryUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd app registry <command> [flags]")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Commands:")
+	writeUsageLine(w, "  publish     Publish an installable app version to a GCS app registry bucket")
+	writeUsageLine(w, "  pending     Record or clear in-flight publish state in pending.json and failed.json")
+}

--- a/gestaltd/internal/daemon/app_registry_pending.go
+++ b/gestaltd/internal/daemon/app_registry_pending.go
@@ -256,16 +256,16 @@ func mutateAppRegistryPendingCatalog(registry config.AppRegistryConfig, appName,
 		if !state.pendingChanged && !state.failedChanged {
 			return nil
 		}
-		if state.failedChanged {
-			if err := uploadAppRegistryCatalogDocument(failedURL, sourceRef, state.failedGen, state.failed); err != nil {
+		if state.pendingChanged {
+			if err := uploadAppRegistryCatalogDocument(pendingURL, sourceRef, state.pendingGen, state.pending); err != nil {
 				if appPublishPreconditionFailed(err) && attempt < appRegistryCatalogUpdateAttempts {
 					continue
 				}
 				return err
 			}
 		}
-		if state.pendingChanged {
-			if err := uploadAppRegistryCatalogDocument(pendingURL, sourceRef, state.pendingGen, state.pending); err != nil {
+		if state.failedChanged {
+			if err := uploadAppRegistryCatalogDocument(failedURL, sourceRef, state.failedGen, state.failed); err != nil {
 				if appPublishPreconditionFailed(err) && attempt < appRegistryCatalogUpdateAttempts {
 					continue
 				}

--- a/gestaltd/internal/daemon/app_registry_pending.go
+++ b/gestaltd/internal/daemon/app_registry_pending.go
@@ -112,8 +112,16 @@ func runAppRegistryPendingSet(args []string) error {
 	}
 
 	return mutateAppRegistryPendingCatalog(registry, appName, sourceRef, func(state *appRegistryPendingCatalogState) error {
-		appregistry.PrunePendingIndex(state.pending, state.failed, state.published, now)
-		appregistry.PruneFailedIndex(state.failed, state.published, now)
+		if appregistry.RemoveFailedVersion(state.failed, *flags.version) {
+			state.failedChanged = true
+		}
+		pendingPruned, failedPruned := appregistry.PrunePendingIndex(state.pending, state.failed, state.published, now)
+		if pendingPruned {
+			state.pendingChanged = true
+		}
+		if appregistry.PruneFailedIndex(state.failed, state.published, now) || failedPruned {
+			state.failedChanged = true
+		}
 		state.pending, _ = appregistry.UpsertPendingVersion(state.pending, appName, pendingVersion, now)
 		state.pendingChanged = true
 		return nil

--- a/gestaltd/internal/daemon/app_registry_pending.go
+++ b/gestaltd/internal/daemon/app_registry_pending.go
@@ -17,14 +17,14 @@ import (
 const appRegistryCatalogUpdateAttempts = 5
 
 type appRegistryPendingFlags struct {
-	bucket         *string
-	appName        *string
-	version        *string
-	ref            *string
-	workflowRunURL *string
-	triggerPRNumber *int
-	triggerPRURL   *string
-	triggerPRTitle *string
+	bucket           *string
+	appName          *string
+	version          *string
+	ref              *string
+	workflowRunURL   *string
+	triggerPRNumber  *int
+	triggerPRURL     *string
+	triggerPRTitle   *string
 	triggerCommitSHA *string
 	triggerCommitURL *string
 }

--- a/gestaltd/internal/daemon/app_registry_pending.go
+++ b/gestaltd/internal/daemon/app_registry_pending.go
@@ -1,0 +1,361 @@
+package daemon
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/internal/appregistry"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/providerregistry"
+)
+
+const appRegistryCatalogUpdateAttempts = 5
+
+type appRegistryPendingFlags struct {
+	bucket         *string
+	appName        *string
+	version        *string
+	ref            *string
+	workflowRunURL *string
+	triggerPRNumber *int
+	triggerPRURL   *string
+	triggerPRTitle *string
+	triggerCommitSHA *string
+	triggerCommitURL *string
+}
+
+func newAppRegistryPendingFlags(fs *flag.FlagSet) appRegistryPendingFlags {
+	return appRegistryPendingFlags{
+		bucket:           fs.String("bucket", "", "GCS bucket name for registry uploads"),
+		appName:          fs.String("app", "", "app name under apps/{app}/manifest.yaml"),
+		version:          fs.String("version", "", "semantic version guard"),
+		ref:              fs.String("ref", "", "full source commit SHA"),
+		workflowRunURL:   fs.String("workflow-run-url", "", "GitHub Actions workflow run URL"),
+		triggerPRNumber:  fs.Int("trigger-pr-number", 0, "pull request number that triggered publication"),
+		triggerPRURL:     fs.String("trigger-pr-url", "", "pull request URL that triggered publication"),
+		triggerPRTitle:   fs.String("trigger-pr-title", "", "pull request title that triggered publication"),
+		triggerCommitSHA: fs.String("trigger-commit-sha", "", "commit SHA that triggered publication"),
+		triggerCommitURL: fs.String("trigger-commit-url", "", "commit URL that triggered publication"),
+	}
+}
+
+func runAppRegistryPending(args []string) error {
+	if len(args) == 0 {
+		printAppRegistryPendingUsage(os.Stderr)
+		return flag.ErrHelp
+	}
+
+	switch args[0] {
+	case "-h", "--help", "help":
+		printAppRegistryPendingUsage(os.Stderr)
+		return flag.ErrHelp
+	case "set":
+		return runAppRegistryPendingSet(args[1:])
+	case "clear":
+		return runAppRegistryPendingClear(args[1:])
+	case "fail":
+		return runAppRegistryPendingFail(args[1:])
+	default:
+		return fmt.Errorf("unknown app registry pending command %q", args[0])
+	}
+}
+
+func runAppRegistryPendingSet(args []string) error {
+	fs := flag.NewFlagSet("gestaltd app registry pending set", flag.ContinueOnError)
+	fs.Usage = func() { printAppRegistryPendingSetUsage(fs.Output()) }
+	flags := newAppRegistryPendingFlags(fs)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() > 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	appName, sourceRef, registry, publication, err := parseAppRegistryPendingWriteFlags(flags, true)
+	if err != nil {
+		return err
+	}
+
+	manifestPath, err := resolveAppPublishManifest(appName)
+	if err != nil {
+		return err
+	}
+	_, sourceManifest, err := readAppPublishManifest(manifestPath)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", manifestPath, err)
+	}
+	manifestApp, err := appregistry.AppNameFromManifestSource(sourceManifest.Source)
+	if err != nil {
+		return fmt.Errorf("%s: invalid manifest source: %w", manifestPath, err)
+	}
+	if manifestApp != appName {
+		return fmt.Errorf("%s: manifest source app %q does not match --app %q", manifestPath, manifestApp, appName)
+	}
+	if err := appregistry.ValidatePublishInput(sourceManifest, *flags.version, sourceRef); err != nil {
+		return err
+	}
+	repository, err := appregistry.RepositoryFromManifestSource(sourceManifest.Source)
+	if err != nil {
+		return fmt.Errorf("%s: invalid manifest source: %w", manifestPath, err)
+	}
+
+	now := time.Now().UTC()
+	pendingVersion := appregistry.PendingVersion{
+		Version:     *flags.version,
+		SourceRef:   sourceRef,
+		Repository:  repository,
+		Publication: publication,
+	}
+
+	return mutateAppRegistryPendingCatalog(registry, appName, sourceRef, func(state *appRegistryPendingCatalogState) error {
+		appregistry.PrunePendingIndex(state.pending, state.failed, state.published, now)
+		appregistry.PruneFailedIndex(state.failed, state.published, now)
+		state.pending, _ = appregistry.UpsertPendingVersion(state.pending, appName, pendingVersion, now)
+		state.pendingChanged = true
+		return nil
+	})
+}
+
+func runAppRegistryPendingClear(args []string) error {
+	fs := flag.NewFlagSet("gestaltd app registry pending clear", flag.ContinueOnError)
+	fs.Usage = func() { printAppRegistryPendingClearUsage(fs.Output()) }
+	flags := newAppRegistryPendingFlags(fs)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() > 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	appName, sourceRef, registry, _, err := parseAppRegistryPendingWriteFlags(flags, false)
+	if err != nil {
+		return err
+	}
+
+	return mutateAppRegistryPendingCatalog(registry, appName, sourceRef, func(state *appRegistryPendingCatalogState) error {
+		if _, ok := appregistry.RemovePendingVersion(state.pending, *flags.version); ok {
+			state.pendingChanged = true
+		}
+		return nil
+	})
+}
+
+func runAppRegistryPendingFail(args []string) error {
+	fs := flag.NewFlagSet("gestaltd app registry pending fail", flag.ContinueOnError)
+	fs.Usage = func() { printAppRegistryPendingFailUsage(fs.Output()) }
+	flags := newAppRegistryPendingFlags(fs)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() > 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	appName, sourceRef, registry, _, err := parseAppRegistryPendingWriteFlags(flags, false)
+	if err != nil {
+		return err
+	}
+
+	now := time.Now().UTC()
+	return mutateAppRegistryPendingCatalog(registry, appName, sourceRef, func(state *appRegistryPendingCatalogState) error {
+		removed, ok := appregistry.RemovePendingVersion(state.pending, *flags.version)
+		if !ok {
+			return nil
+		}
+		state.pendingChanged = true
+		if updated, changed := appregistry.RecordFailedVersion(state.failed, appName, *removed, now, appregistry.FailedReasonWorkflowFailed); changed {
+			state.failed = updated
+			state.failedChanged = true
+		}
+		return nil
+	})
+}
+
+func parseAppRegistryPendingWriteFlags(flags appRegistryPendingFlags, requireRef bool) (appName, sourceRef string, registry config.AppRegistryConfig, publication *appregistry.Publication, err error) {
+	if strings.TrimSpace(*flags.bucket) == "" {
+		return "", "", config.AppRegistryConfig{}, nil, fmt.Errorf("--bucket is required")
+	}
+	appName = strings.TrimSpace(*flags.appName)
+	if appName == "" {
+		return "", "", config.AppRegistryConfig{}, nil, fmt.Errorf("--app is required")
+	}
+	if err := providerregistry.ValidateRepositoryName(appName); err != nil {
+		return "", "", config.AppRegistryConfig{}, nil, fmt.Errorf("--app: %w", err)
+	}
+	if strings.TrimSpace(*flags.version) == "" {
+		return "", "", config.AppRegistryConfig{}, nil, fmt.Errorf("--version is required")
+	}
+	sourceRef = strings.ToLower(strings.TrimSpace(*flags.ref))
+	if requireRef {
+		if !fullGitSHARe.MatchString(sourceRef) {
+			return "", "", config.AppRegistryConfig{}, nil, fmt.Errorf("--ref must be a 40-character commit SHA")
+		}
+		publication, err = appPublishPublication(
+			*flags.workflowRunURL,
+			*flags.triggerPRNumber,
+			*flags.triggerPRURL,
+			*flags.triggerPRTitle,
+			*flags.triggerCommitSHA,
+			*flags.triggerCommitURL,
+		)
+		if err != nil {
+			return "", "", config.AppRegistryConfig{}, nil, err
+		}
+	}
+	registry, err = config.NewGCSAppRegistry(*flags.bucket)
+	if err != nil {
+		return "", "", config.AppRegistryConfig{}, nil, fmt.Errorf("--bucket: %w", err)
+	}
+	return appName, sourceRef, registry, publication, nil
+}
+
+type appRegistryPendingCatalogState struct {
+	pending        *appregistry.PendingIndex
+	failed         *appregistry.FailedIndex
+	published      *appregistry.Index
+	pendingGen     int64
+	failedGen      int64
+	pendingChanged bool
+	failedChanged  bool
+}
+
+func mutateAppRegistryPendingCatalog(registry config.AppRegistryConfig, appName, sourceRef string, mutate func(*appRegistryPendingCatalogState) error) error {
+	storageRoot, err := registry.StorageURL()
+	if err != nil {
+		return err
+	}
+	pendingURL := appregistry.StorageURL(storageRoot, appregistry.AppPendingPath(appName))
+	failedURL := appregistry.StorageURL(storageRoot, appregistry.AppFailedPath(appName))
+	indexURL := appregistry.StorageURL(storageRoot, appregistry.AppIndexPath(appName))
+
+	for attempt := 1; attempt <= appRegistryCatalogUpdateAttempts; attempt++ {
+		if attempt > 1 {
+			startCommandProgress("").status("App registry pending catalog changed concurrently; retrying attempt %d/%d", attempt, appRegistryCatalogUpdateAttempts)
+		}
+		state, err := loadAppRegistryPendingCatalog(pendingURL, failedURL, indexURL, appName)
+		if err != nil {
+			return err
+		}
+		state.pendingChanged = false
+		state.failedChanged = false
+		if err := mutate(state); err != nil {
+			return err
+		}
+		if !state.pendingChanged && !state.failedChanged {
+			return nil
+		}
+		if state.failedChanged {
+			if err := uploadAppRegistryCatalogDocument(failedURL, sourceRef, state.failedGen, state.failed); err != nil {
+				if appPublishPreconditionFailed(err) && attempt < appRegistryCatalogUpdateAttempts {
+					continue
+				}
+				return err
+			}
+		}
+		if state.pendingChanged {
+			if err := uploadAppRegistryCatalogDocument(pendingURL, sourceRef, state.pendingGen, state.pending); err != nil {
+				if appPublishPreconditionFailed(err) && attempt < appRegistryCatalogUpdateAttempts {
+					continue
+				}
+				return err
+			}
+		}
+		if state.pendingChanged {
+			_, _ = fmt.Fprintf(os.Stdout, "updated %s\n", pendingURL)
+		}
+		if state.failedChanged {
+			_, _ = fmt.Fprintf(os.Stdout, "updated %s\n", failedURL)
+		}
+		return nil
+	}
+	return fmt.Errorf("update pending catalog for %s: exceeded retry limit after concurrent updates", appName)
+}
+
+func loadAppRegistryPendingCatalog(pendingURL, failedURL, indexURL, appName string) (*appRegistryPendingCatalogState, error) {
+	pendingGen, pendingData, err := downloadAppRegistryObject(pendingURL)
+	if err != nil {
+		return nil, err
+	}
+	failedGen, failedData, err := downloadAppRegistryObject(failedURL)
+	if err != nil {
+		return nil, err
+	}
+	_, indexData, err := downloadAppRegistryObject(indexURL)
+	if err != nil {
+		return nil, err
+	}
+
+	state := &appRegistryPendingCatalogState{}
+	if len(pendingData) == 0 {
+		state.pending = appregistry.NewEmptyPendingIndex(appName)
+	} else {
+		state.pending, err = appregistry.DecodePendingIndex(pendingData)
+		if err != nil {
+			return nil, fmt.Errorf("decode pending catalog: %w", err)
+		}
+	}
+	if len(failedData) == 0 {
+		state.failed = appregistry.NewEmptyFailedIndex(appName)
+	} else {
+		state.failed, err = appregistry.DecodeFailedIndex(failedData)
+		if err != nil {
+			return nil, fmt.Errorf("decode failed catalog: %w", err)
+		}
+	}
+	if len(indexData) == 0 {
+		state.published = appregistry.NewEmptyIndex()
+	} else {
+		state.published, err = appregistry.DecodeIndex(indexData)
+		if err != nil {
+			return nil, fmt.Errorf("decode published index: %w", err)
+		}
+	}
+	state.pendingGen = pendingGen
+	state.failedGen = failedGen
+	return state, nil
+}
+
+func uploadAppRegistryCatalogDocument(storageURL, sourceRef string, generation int64, document any) error {
+	data, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmpPath, err := writeTempJSON("gestalt-app-catalog-*", append(data, '\n'))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.Remove(tmpPath) }()
+	if err := uploadAppRegistryIndexFile(tmpPath, storageURL, sourceRef, generation); err != nil {
+		return err
+	}
+	return nil
+}
+
+func printAppRegistryPendingUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd app registry pending <command> [flags]")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Commands:")
+	writeUsageLine(w, "  set     Record an in-flight publish in pending.json")
+	writeUsageLine(w, "  clear   Remove a pending publish on success")
+	writeUsageLine(w, "  fail    Record a failed publish in failed.json")
+}
+
+func printAppRegistryPendingSetUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd app registry pending set --bucket BUCKET --app APP --version VERSION --ref SHA [publication flags]")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Prune stuck pending and old failed entries, then upsert pending.json for VERSION.")
+}
+
+func printAppRegistryPendingClearUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd app registry pending clear --bucket BUCKET --app APP --version VERSION")
+}
+
+func printAppRegistryPendingFailUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd app registry pending fail --bucket BUCKET --app APP --version VERSION")
+}

--- a/gestaltd/internal/daemon/app_registry_pending.go
+++ b/gestaltd/internal/daemon/app_registry_pending.go
@@ -112,18 +112,20 @@ func runAppRegistryPendingSet(args []string) error {
 	}
 
 	return mutateAppRegistryPendingCatalog(registry, appName, sourceRef, func(state *appRegistryPendingCatalogState) error {
-		if appregistry.RemoveFailedVersion(state.failed, *flags.version) {
-			state.failedChanged = true
-		}
-		pendingPruned, failedPruned := appregistry.PrunePendingIndex(state.pending, state.failed, state.published, now)
-		if pendingPruned {
+		pendingChanged, failedChanged := appregistry.ApplyPendingSet(
+			state.pending,
+			state.failed,
+			state.published,
+			appName,
+			pendingVersion,
+			now,
+		)
+		if pendingChanged {
 			state.pendingChanged = true
 		}
-		if appregistry.PruneFailedIndex(state.failed, state.published, now) || failedPruned {
+		if failedChanged {
 			state.failedChanged = true
 		}
-		state.pending, _ = appregistry.UpsertPendingVersion(state.pending, appName, pendingVersion, now)
-		state.pendingChanged = true
 		return nil
 	})
 }

--- a/gestaltd/internal/daemon/app_registry_publish.go
+++ b/gestaltd/internal/daemon/app_registry_publish.go
@@ -1,0 +1,32 @@
+package daemon
+
+import (
+	"io"
+)
+
+func runAppRegistryPublish(args []string) error {
+	return runAppPublishCommand("gestaltd app registry publish", printAppRegistryPublishUsage, args)
+}
+
+func printAppRegistryPublishUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd app registry publish --bucket BUCKET --app APP --version VERSION --ref SHA --dist-dir DIR [--dist-dir DIR...] [publication flags]")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Publish an installable app version to a GCS app registry bucket.")
+	writeUsageLine(w, "Resolves the source manifest at apps/{app}/manifest.yaml under the git root.")
+	writeUsageLine(w, "Builds immutable version metadata and artifacts under apps/{app}/ in the bucket.")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Flags:")
+	writeUsageLine(w, "  --app        App name (manifest at apps/{app}/manifest.yaml)")
+	writeUsageLine(w, "  --bucket     GCS bucket name or gs:// URL")
+	writeUsageLine(w, "  --dist-dir   Directory containing release archives (repeatable)")
+	writeUsageLine(w, "  --dry-run    Print the upload plan as JSON without writing")
+	writeUsageLine(w, "  --ref        Full source commit SHA")
+	writeUsageLine(w, "  --workflow-run-url      Publishing GitHub Actions run")
+	writeUsageLine(w, "  --trigger-pr-number     Triggering pull request number")
+	writeUsageLine(w, "  --trigger-pr-url        Triggering pull request URL")
+	writeUsageLine(w, "  --trigger-pr-title      Triggering pull request title")
+	writeUsageLine(w, "  --trigger-commit-sha    Triggering commit SHA")
+	writeUsageLine(w, "  --trigger-commit-url    Triggering commit URL")
+	writeUsageLine(w, "  --version    Semantic version guard")
+}

--- a/gestaltd/internal/daemon/e2e/app_publish/app_publish_test.go
+++ b/gestaltd/internal/daemon/e2e/app_publish/app_publish_test.go
@@ -10,11 +10,10 @@ import (
 )
 
 func TestRun_AppPublishDryRunPlansVersionedRegistryUploads(t *testing.T) {
-	t.Parallel()
-
 	rootDir := t.TempDir()
 	pluginDir := newAppRegistryPublishFixture(t, rootDir)
 	initProviderPublishGitRepo(t, rootDir, "https://github.com/testowner/apps.git")
+	installFakeGcloudForAppPublishDryRun(t)
 	outputDir := t.TempDir()
 	const version = "0.0.0-snapshot.g651a5c30feb995c9364c38f63d0d5c3880bc2055"
 	const ref = "651a5c30feb995c9364c38f63d0d5c3880bc2055"
@@ -169,11 +168,10 @@ exit 1
 }
 
 func TestRun_AppRegistryPublishDryRunMatchesDeprecatedAlias(t *testing.T) {
-	t.Parallel()
-
 	rootDir := t.TempDir()
 	pluginDir := newAppRegistryPublishFixture(t, rootDir)
 	initProviderPublishGitRepo(t, rootDir, "https://github.com/testowner/apps.git")
+	installFakeGcloudForAppPublishDryRun(t)
 	outputDir := t.TempDir()
 	const version = "0.0.0-snapshot.g651a5c30feb995c9364c38f63d0d5c3880bc2055"
 	const ref = "651a5c30feb995c9364c38f63d0d5c3880bc2055"

--- a/gestaltd/internal/daemon/e2e/app_publish/app_publish_test.go
+++ b/gestaltd/internal/daemon/e2e/app_publish/app_publish_test.go
@@ -163,4 +163,49 @@ exit 1
 	if strings.Contains(gotStderr, "not found") || strings.Contains(gotStderr, "precondition failed") {
 		t.Fatalf("raw gcloud diagnostics leaked into normal stderr:\n%s", gotStderr)
 	}
+	if !strings.Contains(gotStderr, "gestaltd app publish is deprecated; use gestaltd app registry publish") {
+		t.Fatalf("app publish stderr missing deprecation warning:\n%s", gotStderr)
+	}
+}
+
+func TestRun_AppRegistryPublishDryRunMatchesDeprecatedAlias(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	pluginDir := newAppRegistryPublishFixture(t, rootDir)
+	initProviderPublishGitRepo(t, rootDir, "https://github.com/testowner/apps.git")
+	outputDir := t.TempDir()
+	const version = "0.0.0-snapshot.g651a5c30feb995c9364c38f63d0d5c3880bc2055"
+	const ref = "651a5c30feb995c9364c38f63d0d5c3880bc2055"
+	runProviderPackageCommand(t, pluginDir,
+		"--version", version,
+		"--output", outputDir,
+	)
+
+	stdout, stderr, err := runAppCommandStreams(rootDir,
+		"registry", "publish",
+		"--bucket", "gs://gestalt-app-registry",
+		"--app", releaseTestAppName,
+		"--version", version,
+		"--ref", ref,
+		"--dist-dir", outputDir,
+		"--dry-run",
+	)
+	if err != nil {
+		t.Fatalf("app registry publish failed: %v\nstdout=%s\nstderr=%s", err, stdout, stderr)
+	}
+	if strings.Contains(string(stderr), "gestaltd app publish is deprecated") {
+		t.Fatalf("registry publish should not print deprecation warning:\n%s", stderr)
+	}
+	var plan struct {
+		Schema  string `json:"schema"`
+		AppName string `json:"appName"`
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(stdout, &plan); err != nil {
+		t.Fatalf("decode app registry publish plan: %v\nstdout=%s\nstderr=%s", err, stdout, stderr)
+	}
+	if plan.Schema != "gestaltd.app.publish.plan.v1" || plan.AppName != releaseTestAppName || plan.Version != version {
+		t.Fatalf("plan = %#v", plan)
+	}
 }

--- a/gestaltd/internal/daemon/e2e/app_publish/app_publish_test.go
+++ b/gestaltd/internal/daemon/e2e/app_publish/app_publish_test.go
@@ -10,10 +10,12 @@ import (
 )
 
 func TestRun_AppPublishDryRunPlansVersionedRegistryUploads(t *testing.T) {
+	t.Parallel()
+
 	rootDir := t.TempDir()
 	pluginDir := newAppRegistryPublishFixture(t, rootDir)
 	initProviderPublishGitRepo(t, rootDir, "https://github.com/testowner/apps.git")
-	installFakeGcloudForAppPublishDryRun(t)
+	fakeGcloudEnv := installFakeGcloudForAppPublishDryRun(t)
 	outputDir := t.TempDir()
 	const version = "0.0.0-snapshot.g651a5c30feb995c9364c38f63d0d5c3880bc2055"
 	const ref = "651a5c30feb995c9364c38f63d0d5c3880bc2055"
@@ -22,7 +24,7 @@ func TestRun_AppPublishDryRunPlansVersionedRegistryUploads(t *testing.T) {
 		"--output", outputDir,
 	)
 
-	stdout, stderr, err := runAppCommandStreams(rootDir,
+	stdout, stderr, err := runAppCommandStreamsWithEnv(rootDir, fakeGcloudEnv,
 		"publish",
 		"--bucket", "gs://gestalt-app-registry",
 		"--app", releaseTestAppName,
@@ -168,10 +170,12 @@ exit 1
 }
 
 func TestRun_AppRegistryPublishDryRunMatchesDeprecatedAlias(t *testing.T) {
+	t.Parallel()
+
 	rootDir := t.TempDir()
 	pluginDir := newAppRegistryPublishFixture(t, rootDir)
 	initProviderPublishGitRepo(t, rootDir, "https://github.com/testowner/apps.git")
-	installFakeGcloudForAppPublishDryRun(t)
+	fakeGcloudEnv := installFakeGcloudForAppPublishDryRun(t)
 	outputDir := t.TempDir()
 	const version = "0.0.0-snapshot.g651a5c30feb995c9364c38f63d0d5c3880bc2055"
 	const ref = "651a5c30feb995c9364c38f63d0d5c3880bc2055"
@@ -180,7 +184,7 @@ func TestRun_AppRegistryPublishDryRunMatchesDeprecatedAlias(t *testing.T) {
 		"--output", outputDir,
 	)
 
-	stdout, stderr, err := runAppCommandStreams(rootDir,
+	stdout, stderr, err := runAppCommandStreamsWithEnv(rootDir, fakeGcloudEnv,
 		"registry", "publish",
 		"--bucket", "gs://gestalt-app-registry",
 		"--app", releaseTestAppName,

--- a/gestaltd/internal/daemon/e2e/app_publish/helpers_test.go
+++ b/gestaltd/internal/daemon/e2e/app_publish/helpers_test.go
@@ -20,7 +20,7 @@ const (
 	releaseTestSource  = "github.com/testowner/apps/apps/release-test"
 )
 
-func installFakeGcloudForAppPublishDryRun(t *testing.T) {
+func installFakeGcloudForAppPublishDryRun(t *testing.T) []string {
 	t.Helper()
 
 	binDir := t.TempDir()
@@ -36,7 +36,7 @@ exit 1
 `), 0o755); err != nil {
 		t.Fatalf("write fake gcloud: %v", err)
 	}
-	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return []string{"PATH=" + binDir + string(os.PathListSeparator) + os.Getenv("PATH")}
 }
 
 func gestaltdCommand(args ...string) *exec.Cmd {
@@ -44,12 +44,19 @@ func gestaltdCommand(args ...string) *exec.Cmd {
 }
 
 func runAppCommandStreams(workDir string, args ...string) ([]byte, []byte, error) {
-	return runGestaltdCommandStreams(workDir, append([]string{"app"}, args...)...)
+	return runAppCommandStreamsWithEnv(workDir, nil, args...)
 }
 
-func runGestaltdCommandStreams(workDir string, args ...string) ([]byte, []byte, error) {
+func runAppCommandStreamsWithEnv(workDir string, extraEnv []string, args ...string) ([]byte, []byte, error) {
+	return runGestaltdCommandStreams(workDir, extraEnv, append([]string{"app"}, args...)...)
+}
+
+func runGestaltdCommandStreams(workDir string, extraEnv []string, args ...string) ([]byte, []byte, error) {
 	cmd := gestaltdCommand(args...)
 	cmd.Dir = workDir
+	if len(extraEnv) > 0 {
+		cmd.Env = append(os.Environ(), extraEnv...)
+	}
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/gestaltd/internal/daemon/e2e/app_publish/helpers_test.go
+++ b/gestaltd/internal/daemon/e2e/app_publish/helpers_test.go
@@ -25,7 +25,11 @@ func gestaltdCommand(args ...string) *exec.Cmd {
 }
 
 func runAppCommandStreams(workDir string, args ...string) ([]byte, []byte, error) {
-	cmd := gestaltdCommand(append([]string{"app"}, args...)...)
+	return runGestaltdCommandStreams(workDir, append([]string{"app"}, args...)...)
+}
+
+func runGestaltdCommandStreams(workDir string, args ...string) ([]byte, []byte, error) {
+	cmd := gestaltdCommand(args...)
 	cmd.Dir = workDir
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/gestaltd/internal/daemon/e2e/app_publish/helpers_test.go
+++ b/gestaltd/internal/daemon/e2e/app_publish/helpers_test.go
@@ -20,6 +20,25 @@ const (
 	releaseTestSource  = "github.com/testowner/apps/apps/release-test"
 )
 
+func installFakeGcloudForAppPublishDryRun(t *testing.T) {
+	t.Helper()
+
+	binDir := t.TempDir()
+	fakeGcloud := filepath.Join(binDir, "gcloud")
+	if err := os.WriteFile(fakeGcloud, []byte(`#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = "storage" ] && [ "$2" = "objects" ] && [ "$3" = "describe" ]; then
+  echo "not found" >&2
+  exit 1
+fi
+echo "unexpected gcloud command: $*" >&2
+exit 1
+`), 0o755); err != nil {
+		t.Fatalf("write fake gcloud: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
 func gestaltdCommand(args ...string) *exec.Cmd {
 	return exec.Command(gestaltdBin, args...)
 }

--- a/plans/app_registry/admin.md
+++ b/plans/app_registry/admin.md
@@ -121,8 +121,11 @@ Selection is fleet-wide. It is not per-user or per-replica.
 The page header shows the app name, **App management** label, and registry
 binding. Below that: current **Desired version**, then the **Published
 snapshots** table (pending, failed, and published entries in one newest-first
-list). Each row has **Deploy** in the action column unless selection is disabled
-or the row is not deployable.
+list). When the same version appears in more than one catalog, apply
+**published** > **pending** > **failed** precedence — see
+[pending-publish.md — Merge rules](./pending-publish.md#app-admin-api). Each row
+has **Deploy** in the action column unless selection is disabled or the row is
+not deployable.
 
 ```text
 ┌─────────────────────────────────────────────────────────────┐

--- a/plans/app_registry/admin.md
+++ b/plans/app_registry/admin.md
@@ -121,11 +121,9 @@ Selection is fleet-wide. It is not per-user or per-replica.
 The page header shows the app name, **App management** label, and registry
 binding. Below that: current **Desired version**, then the **Published
 snapshots** table (pending, failed, and published entries in one newest-first
-list). When the same version appears in more than one catalog, apply
-**published** > **pending** > **failed** precedence — see
-[pending-publish.md — Merge rules](./pending-publish.md#app-admin-api). Each row
-has **Deploy** in the action column unless selection is disabled or the row is
-not deployable.
+list). See [pending-publish.md](./pending-publish.md) for merge rules, polling,
+and timing labels. Each row has **Deploy** in the action column unless selection
+is disabled or the row is not deployable.
 
 ```text
 ┌─────────────────────────────────────────────────────────────┐

--- a/plans/app_registry/lifecycle.md
+++ b/plans/app_registry/lifecycle.md
@@ -688,6 +688,12 @@ Rules:
 - `publishedVersions` comes from the registry index, newest `publishedAt` first.
   Each entry includes `publishedAt`, `sourceRef`, `sourceUrl`, and `publication`
   when recorded. Legacy versions may omit `publication`.
+- `pendingVersions` and `failedVersions` come from `pending.json` and
+  `failed.json`. See [pending-publish.md](./pending-publish.md#read-path).
+- When the same version appears in more than one catalog (race or missed cleanup),
+  apply merge precedence **published** > **pending** > **failed** before
+  returning the response. See
+  [pending-publish.md — Merge rules](./pending-publish.md#app-admin-api).
 - `selectionDisabled` is true only while rollout state is `enrolling` or
   `restarting`.
 

--- a/plans/app_registry/lifecycle.md
+++ b/plans/app_registry/lifecycle.md
@@ -690,10 +690,8 @@ Rules:
   when recorded. Legacy versions may omit `publication`.
 - `pendingVersions` and `failedVersions` come from `pending.json` and
   `failed.json`. See [pending-publish.md](./pending-publish.md#read-path).
-- When the same version appears in more than one catalog (race or missed cleanup),
-  apply merge precedence **published** > **pending** > **failed** before
-  returning the response. See
-  [pending-publish.md — Merge rules](./pending-publish.md#app-admin-api).
+- When the same version appears in more than one catalog, apply
+  [merge rules](./pending-publish.md#app-admin-api).
 - `selectionDisabled` is true only while rollout state is `enrolling` or
   `restarting`.
 

--- a/plans/app_registry/models.md
+++ b/plans/app_registry/models.md
@@ -281,7 +281,7 @@ Each key is a version string whose publish attempt failed.
 | `repository` | string | no | Source repository. Same format as `IndexVersion.repository`. |
 | `startedAt` | RFC 3339 timestamp | yes | When the pending record was created (copied from pending). |
 | `failedAt` | RFC 3339 timestamp | yes | When the failure was recorded (UTC). |
-| `reason` | string | yes | `workflow_failed` — CI called `pending fail`. `stale` — pending `startedAt` exceeded 2 hours during `PrunePendingIndex`. |
+| `reason` | string | yes | `workflow_failed` — CI called `pending fail`. `stale` — pending `startedAt` exceeded 30 minutes during `PrunePendingIndex`. |
 | `publication` | object | no | Same `Publication` shape as `PublishedVersion.publication`. Copied from the pending row when present. |
 
 Writes use the same optimistic-concurrency pattern as `pending.json`.

--- a/plans/app_registry/pending-publish.md
+++ b/plans/app_registry/pending-publish.md
@@ -10,8 +10,7 @@ Related docs:
 - [admin.md](./admin.md) — app admin UI capabilities
 - [service.md](./service.md) — Go publish/read helpers
 - [lifecycle.md](./lifecycle.md) — app-admin HTTP API
-
----
+- [tests.md](./tests.md#pending-catalog-write-path) — write-path and admin tests
 
 ## Problem
 
@@ -23,8 +22,6 @@ During CI (`publish-app-registry.yml`), operators see nothing on the admin page
 while a publish is running — even though the version string and workflow run are
 already known. There is no registry signal between “workflow started” and
 “index updated”.
-
----
 
 ## Goals
 
@@ -41,11 +38,11 @@ Operators on `/apps/{app}/admin` should be able to answer:
 | Did a recent publish fail? | Row with status **Failed** and `failedAt` |
 | Why did it fail? | `reason` on the failed entry (`workflow_failed` or `stale`) |
 
----
-
 ## Design summary
 
-Add mutable `pending.json` and `failed.json` catalogs in GCS per app.
+Add mutable `pending.json` and `failed.json` catalogs in GCS per app. Scope is
+app-scoped `/apps/{app}/admin` only — the embedded fleet `/admin` registry UI does
+not show publishing state.
 
 - **Start** — CI calls `gestaltd app registry pending set` when the publish
   workflow starts.
@@ -62,8 +59,6 @@ in the snapshots table.
 Pending and failed versions are **not** installable. Install-time validation
 continues to read only `versions/{version}.json` via the published index
 contract.
-
----
 
 ## Publish duration
 
@@ -88,8 +83,6 @@ The app-admin API may include `publishingForSeconds` on pending rows and
 `publishDurationSeconds` on published and failed rows. Omit these fields when the
 start timestamp is missing.
 
----
-
 ## GCS layout
 
 Extend the per-app registry tree:
@@ -109,8 +102,6 @@ apps/{app}/
 `pending.json` and `failed.json` are mutable catalogs (like `index.json`), not
 immutable release objects. Use the same optimistic-concurrency update pattern as
 index writes: read generation, merge, upload with `if-generation-match`.
-
----
 
 ## PendingIndex
 
@@ -132,8 +123,6 @@ On workflow failure, `gestaltd app registry pending fail` removes the pending
 entry and upserts `failed.json` with `failedAt` and `reason=workflow_failed`.
 The workflow run URL remains the failure audit trail.
 
----
-
 ## FailedIndex
 
 `failed.json` document shape, fields, and example:
@@ -145,8 +134,6 @@ The workflow run URL remains the failure audit trail.
 |----------|---------|
 | `workflow_failed` | CI called `gestaltd app registry pending fail` after packaging or publish failed |
 | `stale` | Pending `startedAt` was older than 30 minutes when `PrunePendingIndex` ran |
-
----
 
 ## Self-healing
 
@@ -197,8 +184,6 @@ Every app publish workflow self-heals stuck pending entries on the next merge to
 Prune is idempotent and safe to run concurrently with an in-flight publish:
 generation-match retries apply.
 
----
-
 ## Publish lifecycle
 
 ```text
@@ -236,24 +221,12 @@ entry to `failed.json` with `reason=stale`.
 
 ### CLI
 
-`gestaltd app registry` gains:
-
-```text
-gestaltd app registry pending set|clear|fail
-gestaltd app registry publish
-```
-
 `gestaltd app registry publish` replaces `gestaltd app publish` for immutable
-uploads only. `gestaltd app registry pending` owns the mutable `pending.json` and
-`failed.json` catalogs. Keep `gestaltd app publish` as a deprecated alias for
-`gestaltd app registry publish` during migration, then remove it.
-
-**`gestaltd app registry pending`** — write or update `pending.json` and
-`failed.json`. `pending set` runs `PrunePendingIndex` and `PruneFailedIndex`
-before upserting.
+uploads. `gestaltd app registry pending` owns `pending.json` and `failed.json`.
+Keep `gestaltd app publish` as a deprecated alias during migration.
 
 ```bash
-# Workflow start — record pending publish (prunes stuck entries first)
+# Workflow start
 gestaltd app registry pending set \
   --bucket gs://… \
   --app traffic-cop \
@@ -262,32 +235,19 @@ gestaltd app registry pending set \
   --workflow-run-url … \
   [--trigger-pr-number … --trigger-pr-url …]
 
-# Workflow end — success (idempotent)
+# Workflow end — success
 gestaltd app registry pending clear \
   --bucket gs://… \
   --app traffic-cop \
   --version 0.0.0-snapshot.g…
 
-# Workflow end — failure (idempotent)
+# Workflow end — failure
 gestaltd app registry pending fail \
   --bucket gs://… \
   --app traffic-cop \
   --version 0.0.0-snapshot.g…
-```
 
-`pending set` writes `phase=publishing`. It is idempotent for the same
-`(app, version)`: refresh `updatedAt` and merge `publication` on re-run.
-`pending clear` is idempotent when the version is already absent from pending.
-`pending fail` is idempotent when the version is already absent from pending; an
-existing `failed.json` entry is left unchanged.
-
-**`gestaltd app registry publish`** — upload artifacts and version metadata,
-update `index.json` only. Does not write `pending.json` or `failed.json`. Reads
-`pending.json` when present to copy `startedAt` into `publishStartedAt` on the
-uploaded version metadata and index entry. Same flags as today's
-`gestaltd app publish`; requires `--dist-dir`.
-
-```bash
+# After packaging
 gestaltd app registry publish \
   --bucket gs://… \
   --app traffic-cop \
@@ -298,18 +258,11 @@ gestaltd app registry publish \
   [publication flags]
 ```
 
-CI runs `gestaltd app registry pending set` at workflow start,
-`gestaltd app registry publish` after packaging, and
-`gestaltd app registry pending clear` or `gestaltd app registry pending fail` in
-`always()` at workflow end depending on outcome. Manual publishes can call
-`gestaltd app registry pending set` first and `gestaltd app registry pending
-clear` or `gestaltd app registry pending fail` afterward when they want admin
-UI visibility.
-
-Implementation extends `gestaltd/internal/daemon/app_publish.go` and reuses the
-index upload helper (generation-match retries).
-
----
+`pending set` writes `phase=publishing`. It is idempotent for the same
+`(app, version)`: refresh `updatedAt` and merge `publication` on re-run.
+`pending clear` and `pending fail` are idempotent when the version is already
+absent from pending. `pending fail` does not overwrite an existing `failed.json`
+entry.
 
 ## Read path
 
@@ -366,27 +319,18 @@ Extend `GET /api/v1/apps/{app}/admin/registry` response:
 
 Merge rules:
 
-- Each version appears in **at most one** of `pendingVersions`, `failedVersions`,
-  and `publishedVersions` in the API response and snapshots table.
-- **Precedence** (when a race or missed cleanup leaves duplicates in GCS):
-  **published** > **pending** > **failed**. Keep the highest-precedence row and
-  omit the others. Example: a version in both `pending.json` and `failed.json`
-  during a workflow retry surfaces as **Publishing**, not **Failed**.
+- Each version appears in at most one of `pendingVersions`, `failedVersions`, and
+  `publishedVersions`.
+- When catalogs disagree, precedence is **published** > **pending** > **failed**.
 - `pendingVersions` sorted by `startedAt` descending (newest first).
 - `failedVersions` sorted by `failedAt` descending (newest first).
-- Published rows may include `publishStartedAt`. Pending, published, and failed
-  rows may include computed duration fields. See [Publish duration](#publish-duration).
+- Published rows may include `publishStartedAt`. Duration fields: [Publish duration](#publish-duration).
 
 Install and upgrade handlers ignore `pending.json` and `failed.json` entirely.
 
----
-
 ## UI changes (`/apps/{app}/admin`)
 
-Update the snapshots table to render pending and failed entries alongside
-published entries (single newest-first list with a status column). Apply merge
-precedence (**published** > **pending** > **failed**) before choosing each row's
-status — see [Merge rules](#app-admin-api) above.
+Wireframes, columns, and row layout: [admin.md](./admin.md#app-admin-ui-appsappadmin).
 
 | Status | Condition |
 |--------|-----------|
@@ -396,32 +340,9 @@ status — see [Merge rules](#app-admin-api) above.
 | **Rolling out** | Active rollout for this version (unchanged) |
 | **Available** | Published, not desired (unchanged) |
 
-Pending entries:
-
-- Show PR / commit provenance when present (same columns as published)
-- **Published** column shows elapsed publish time from `startedAt`
-- **Action** column: Deploy disabled; optional “View workflow” link using
-  `publication.workflowRunUrl`
-
-Failed entries:
-
-- Show PR / commit provenance when present
-- **Published** column shows `failedAt`, total time before failure, and a reason
-  label (`workflow_failed` → “Workflow failed”, `stale` → “Timed out”)
-- **Action** column: Deploy disabled; “View workflow” when
-  `publication.workflowRunUrl` is present
-
-Published entries without `publishStartedAt` show `publishedAt` only. See
-[Publish duration](#publish-duration) for timing labels on all row types.
-
-Polling: extend `AppAdminPageClient` to poll every **12s** while
-`pendingVersions.length > 0` or fleet rollout is non-terminal. **Do not poll
-solely because `failedVersions` is non-empty** — failed rows are retained for
-30 days for visibility but are not in-flight; load them on page fetch and after
-deploy actions. Stop polling when no pending versions remain and rollout is
-terminal.
-
----
+Apply [merge rules](#app-admin-api) before assigning status. Poll every **12s**
+while `pendingVersions.length > 0` or fleet rollout is non-terminal. Do not poll
+solely because `failedVersions` is non-empty — load failed rows on page fetch.
 
 ## CI changes (`publish-app-registry.yml`)
 
@@ -439,8 +360,6 @@ In `toolshed` (and any repo using the shared workflow):
 Install `gestaltd` before step 1 (today it is installed only in the publish job;
 move or duplicate install earlier so pending can be recorded at workflow start).
 
----
-
 ## Safety and invariants
 
 | Invariant | Enforcement |
@@ -455,7 +374,14 @@ move or duplicate install earlier so pending can be recorded at workflow start).
 | Duplicate version across catalogs | API and UI apply **published** > **pending** > **failed** precedence; see [Merge rules](#app-admin-api) |
 | Old failed entries are pruned | `PruneFailedIndex` on `pending set`; 30-day `failedAt` threshold |
 
----
+Implementation:
+
+- Pending/failed types and prune — `gestaltd/internal/appregistry/pending.go`
+- `gestaltd app registry pending` CLI — `gestaltd/internal/daemon/app_registry_pending.go`
+- `gestaltd app registry publish` CLI — `gestaltd/internal/daemon/app_registry_publish.go`, `gestaltd/internal/daemon/app_publish.go`
+- App-admin registry API — `gestaltd/internal/server/handlers_app_admin_registry.go` (PR 2)
+- Registry fetch — `gestaltd/internal/appregistry/reader.go` (PR 2)
+- App admin snapshots UI — `gestalt-providers` (PR 4)
 
 ## Implementation path
 
@@ -494,9 +420,8 @@ Depends on **PR 1**. Exposes pending and failed catalog state to the admin page.
 
 - `FetchPendingIndex` and `FetchFailedIndex` in `gestaltd/internal/appregistry/`.
 - Extend `getAppAdminRegistry` with `pendingVersions[]` and `failedVersions[]`.
-- Apply merge precedence (**published** > **pending** > **failed**) when building
-  the response. Expose `publishStartedAt` and computed duration fields per
-  [Publish duration](#publish-duration).
+- Apply [merge rules](#app-admin-api). Expose `publishStartedAt` and computed
+  duration fields per [Publish duration](#publish-duration).
 - Tests: fetch helpers via `registrytest` HTTP fixture; handler returns pending
   and failed entries alongside published. Extend [tests.md](./tests.md).
 
@@ -519,39 +444,7 @@ operators get correct GCS state before the UI exists.
 Depends on **PR 2**. Completes admin visibility.
 
 - **Publishing** and **Failed** rows in the `gestalt-providers` app admin
-  snapshots table. Timing labels per [Publish duration](#publish-duration).
-- Poll every ~12s while any pending version exists or rollout is non-terminal.
-  Apply merge precedence (**published** > **pending** > **failed**) when building
-  the snapshots table.
+  snapshots table. See [admin.md](./admin.md#app-admin-ui-appsappadmin).
+- Poll while pending versions exist or rollout is non-terminal. Apply
+  [merge rules](#app-admin-api).
 - Manual / browser smoke per [tests.md](./tests.md) when implementing.
-
----
-
-## Decisions
-
-**Scope:** Pending publish visibility is **app-scoped only** — `/apps/{app}/admin`.
-The embedded fleet `/admin` registry list does not show a publishing indicator.
-
-**CLI:** `gestaltd app registry pending` (`set`, `clear`, `fail`) owns
-`pending.json` and `failed.json`. `gestaltd app registry publish` uploads
-immutable artifacts and `index.json` (replaces `gestaltd app publish`); it may
-read `pending.json` to copy `publishStartedAt` but does not mutate pending or
-failed catalogs. CI calls `pending clear` on success and `pending fail` on
-failure.
-
-**Failed retention:** `failed.json` entries are kept for **30 days**, then pruned
-on `pending set`. Stale pending (`startedAt` older than 30 minutes) records
-`failedAt` with `reason=stale`.
-
-**Single phase:** Pending entries use `phase=publishing` from workflow start.
-
-**Workflow start:** `publish-app-registry.yml` should call
-`gestaltd app registry pending set` as early as possible (once `PACKAGE_VERSION`,
-GCP auth, and `gestaltd` are available), not only when artifacts are ready.
-
-**Publish duration:** `publishStartedAt` on published registry objects; elapsed
-and total time derived at read/UI time. See [Publish duration](#publish-duration).
-
-**Catalog merge precedence:** When the same version appears in more than one GCS
-catalog, the app-admin API and snapshots table keep **published** over
-**pending** over **failed**. See [Merge rules](#app-admin-api).

--- a/plans/app_registry/pending-publish.md
+++ b/plans/app_registry/pending-publish.md
@@ -366,9 +366,12 @@ Extend `GET /api/v1/apps/{app}/admin/registry` response:
 
 Merge rules:
 
-- A version MUST NOT appear in more than one of `pendingVersions`,
-  `failedVersions`, and `publishedVersions`. If multiple exist (race or missed
-  cleanup), prefer **published**, then **pending**, then **failed**.
+- Each version appears in **at most one** of `pendingVersions`, `failedVersions`,
+  and `publishedVersions` in the API response and snapshots table.
+- **Precedence** (when a race or missed cleanup leaves duplicates in GCS):
+  **published** > **pending** > **failed**. Keep the highest-precedence row and
+  omit the others. Example: a version in both `pending.json` and `failed.json`
+  during a workflow retry surfaces as **Publishing**, not **Failed**.
 - `pendingVersions` sorted by `startedAt` descending (newest first).
 - `failedVersions` sorted by `failedAt` descending (newest first).
 - Published rows may include `publishStartedAt`. Pending, published, and failed
@@ -381,7 +384,9 @@ Install and upgrade handlers ignore `pending.json` and `failed.json` entirely.
 ## UI changes (`/apps/{app}/admin`)
 
 Update the snapshots table to render pending and failed entries alongside
-published entries (single newest-first list with a status column).
+published entries (single newest-first list with a status column). Apply merge
+precedence (**published** > **pending** > **failed**) before choosing each row's
+status — see [Merge rules](#app-admin-api) above.
 
 | Status | Condition |
 |--------|-----------|
@@ -447,6 +452,7 @@ move or duplicate install earlier so pending can be recorded at workflow start).
 | Concurrent publishes for one app | Rare; `pending` map holds multiple versions. CI concurrency is per `(app, sha)`; different SHAs produce different version strings |
 | Stuck pending entries become failed | `PrunePendingIndex` on `pending set`; 30-minute `startedAt` threshold writes `failedAt` with `reason=stale` |
 | Workflow retries clear prior failures | `pending set` removes `failed.{version}` for the version being upserted |
+| Duplicate version across catalogs | API and UI apply **published** > **pending** > **failed** precedence; see [Merge rules](#app-admin-api) |
 | Old failed entries are pruned | `PruneFailedIndex` on `pending set`; 30-day `failedAt` threshold |
 
 ---
@@ -488,7 +494,9 @@ Depends on **PR 1**. Exposes pending and failed catalog state to the admin page.
 
 - `FetchPendingIndex` and `FetchFailedIndex` in `gestaltd/internal/appregistry/`.
 - Extend `getAppAdminRegistry` with `pendingVersions[]` and `failedVersions[]`.
-- Expose `publishStartedAt` and computed duration fields per [Publish duration](#publish-duration).
+- Apply merge precedence (**published** > **pending** > **failed**) when building
+  the response. Expose `publishStartedAt` and computed duration fields per
+  [Publish duration](#publish-duration).
 - Tests: fetch helpers via `registrytest` HTTP fixture; handler returns pending
   and failed entries alongside published. Extend [tests.md](./tests.md).
 
@@ -513,7 +521,8 @@ Depends on **PR 2**. Completes admin visibility.
 - **Publishing** and **Failed** rows in the `gestalt-providers` app admin
   snapshots table. Timing labels per [Publish duration](#publish-duration).
 - Poll every ~12s while any pending version exists or rollout is non-terminal.
-  Prefer published entry when the same version appears in multiple lists.
+  Apply merge precedence (**published** > **pending** > **failed**) when building
+  the snapshots table.
 - Manual / browser smoke per [tests.md](./tests.md) when implementing.
 
 ---
@@ -542,3 +551,7 @@ GCP auth, and `gestaltd` are available), not only when artifacts are ready.
 
 **Publish duration:** `publishStartedAt` on published registry objects; elapsed
 and total time derived at read/UI time. See [Publish duration](#publish-duration).
+
+**Catalog merge precedence:** When the same version appears in more than one GCS
+catalog, the app-admin API and snapshots table keep **published** over
+**pending** over **failed**. See [Merge rules](#app-admin-api).

--- a/plans/app_registry/pending-publish.md
+++ b/plans/app_registry/pending-publish.md
@@ -53,7 +53,7 @@ Add mutable `pending.json` and `failed.json` catalogs in GCS per app.
 - **Failure** — `gestaltd app registry pending fail` removes the pending entry
   and records `failedAt` in `failed.json`.
 - **Stale** — `PrunePendingIndex` on the next `pending set` moves entries whose
-  `startedAt` is older than **2 hours** to `failed.json` with `reason=stale`.
+  `startedAt` is older than **30 minutes** to `failed.json` with `reason=stale`.
 
 `gestaltd` reads both catalogs alongside `index.json` and exposes them through
 the app-admin registry API. The UI merges pending, failed, and published entries
@@ -144,7 +144,7 @@ The workflow run URL remains the failure audit trail.
 | `reason` | Meaning |
 |----------|---------|
 | `workflow_failed` | CI called `gestaltd app registry pending fail` after packaging or publish failed |
-| `stale` | Pending `startedAt` was older than 2 hours when `PrunePendingIndex` ran |
+| `stale` | Pending `startedAt` was older than 30 minutes when `PrunePendingIndex` ran |
 
 ---
 
@@ -162,14 +162,12 @@ For each `pending.{version}` entry:
 
 | Condition | Action |
 |-----------|--------|
-| `startedAt` older than **2 hours** | Move to `failed.json` with `failedAt=now`, `reason=stale` |
+| `startedAt` older than **30 minutes** | Move to `failed.json` with `failedAt=now`, `reason=stale` |
 | Same `version` already listed in `index.json` | Remove from pending only (publish succeeded; pending cleanup missed) |
 | Otherwise | Keep |
 
-Use `startedAt`, not `updatedAt`, for the stale threshold. Packaging can take
-tens of minutes and `updatedAt` is only refreshed when the same version re-runs
-`pending set`; concurrent publishes for one app (different snapshot versions) must
-not mark an in-flight run as stale while it is still within the window.
+Use `startedAt`, not `updatedAt`, for the stale threshold. `updatedAt` is only
+refreshed when the same version re-runs `pending set`.
 
 ### `PruneFailedIndex`
 
@@ -181,7 +179,7 @@ For each `failed.{version}` entry:
 | Same `version` already listed in `index.json` | Remove |
 | Otherwise | Keep |
 
-The 2-hour pending threshold applies on `gestaltd app registry pending set`.
+The 30-minute pending threshold applies on `gestaltd app registry pending set`.
 Failed entries are retained for 30 days so operators can see recent failures on
 the admin page.
 
@@ -447,7 +445,7 @@ move or duplicate install earlier so pending can be recorded at workflow start).
 | Published catalog remains immutable per version | `versions/{version}.json` and artifacts still uploaded with `if-generation-match=0` |
 | Public read stays HTTP GET | `pending.json` and `failed.json` per app, no bucket listing |
 | Concurrent publishes for one app | Rare; `pending` map holds multiple versions. CI concurrency is per `(app, sha)`; different SHAs produce different version strings |
-| Stuck pending entries become failed | `PrunePendingIndex` on `pending set`; 2-hour `startedAt` threshold writes `failedAt` with `reason=stale` |
+| Stuck pending entries become failed | `PrunePendingIndex` on `pending set`; 30-minute `startedAt` threshold writes `failedAt` with `reason=stale` |
 | Workflow retries clear prior failures | `pending set` removes `failed.{version}` for the version being upserted |
 | Old failed entries are pruned | `PruneFailedIndex` on `pending set`; 30-day `failedAt` threshold |
 
@@ -478,7 +476,7 @@ Add types and CLI first so CI can call the new commands.
   `gestaltd app registry publish` (move logic from `gestaltd app publish`).
 - `pending set` removes `failed.{version}` for the version being upserted, then
   calls `PrunePendingIndex` and `PruneFailedIndex` before upsert; stale pending
-  (`startedAt` > 2 hours) → `failed.json`. `gestaltd app registry publish` does
+  (`startedAt` > 30 minutes) → `failed.json`. `gestaltd app registry publish` does
   not touch `pending.json` or `failed.json`.
 - Deprecate `gestaltd app publish` (alias → `gestaltd app registry publish`).
 - Tests: pending write/prune/fail/clear, stale → failed, deprecated alias. Add a
@@ -533,7 +531,7 @@ failed catalogs. CI calls `pending clear` on success and `pending fail` on
 failure.
 
 **Failed retention:** `failed.json` entries are kept for **30 days**, then pruned
-on `pending set`. Stale pending (`startedAt` older than 2 hours) records
+on `pending set`. Stale pending (`startedAt` older than 30 minutes) records
 `failedAt` with `reason=stale`.
 
 **Single phase:** Pending entries use `phase=publishing` from workflow start.

--- a/plans/app_registry/tests.md
+++ b/plans/app_registry/tests.md
@@ -80,7 +80,7 @@ Run:
 
 ```bash
 cd gestaltd
-go test ./internal/appregistry -run 'Pending|Prune|Record|Upsert|DecodePending' -count=1
+go test ./internal/appregistry -run 'Pending|Prune|Record|Upsert|DecodePending|PublishStartedAt' -count=1
 go test ./internal/daemon/e2e/app_publish -run 'AppRegistryPublish|AppPublish' -count=1
 ```
 
@@ -92,6 +92,8 @@ go test ./internal/daemon/e2e/app_publish -run 'AppRegistryPublish|AppPublish' -
 - **`TestUpsertPendingVersion_PreservesStartedAt`** — `pending set` refresh keeps the original `startedAt`.
 - **`TestRecordFailedVersion_IsIdempotent`** — `pending fail` does not overwrite an existing failed entry.
 - **`TestDecodePendingAndFailedIndexRoundTrip`** — JSON encode/decode validates catalog shapes.
+- **`TestPublishStartedAtFromPending`** — publish reads `startedAt` from a matching pending entry.
+- **`TestUpsertAppIndex_CopiesPublishStartedAt`** — published index entries copy `publishStartedAt` from the version metadata.
 
 ### `internal/daemon/e2e/app_publish/app_publish_test.go`
 

--- a/plans/app_registry/tests.md
+++ b/plans/app_registry/tests.md
@@ -72,6 +72,34 @@ Expected plan fields:
 
 ---
 
+## Pending catalog write path
+
+Planned in pending publish PR 1. See [pending-publish.md](./pending-publish.md#pr-1--models-and-write-path-gestalt).
+
+Run:
+
+```bash
+cd gestaltd
+go test ./internal/appregistry -run 'Pending|Prune|Record|Upsert|DecodePending' -count=1
+go test ./internal/daemon/e2e/app_publish -run 'AppRegistryPublish|AppPublish' -count=1
+```
+
+### `internal/appregistry/pending_test.go`
+
+- **`TestPrunePendingIndex_MovesStaleEntryToFailed`** — pending `updatedAt` older than 30 minutes moves to `failed.json` with `reason=stale`.
+- **`TestPrunePendingIndex_DropsAlreadyPublishedVersion`** — pending entry is removed when the version is already in `index.json`.
+- **`TestPruneFailedIndex_RemovesOldAndPublishedEntries`** — failed entries older than 30 days or already published are pruned.
+- **`TestUpsertPendingVersion_PreservesStartedAt`** — `pending set` refresh keeps the original `startedAt`.
+- **`TestRecordFailedVersion_IsIdempotent`** — `pending fail` does not overwrite an existing failed entry.
+- **`TestDecodePendingAndFailedIndexRoundTrip`** — JSON encode/decode validates catalog shapes.
+
+### `internal/daemon/e2e/app_publish/app_publish_test.go`
+
+- **`TestRun_AppRegistryPublishDryRunMatchesDeprecatedAlias`** — `gestaltd app registry publish --dry-run` emits the same plan as the deprecated `gestaltd app publish` command.
+- **`TestRun_AppPublishUploadsAndRetriesIndexWithProgress`** — deprecated `gestaltd app publish` prints a stderr deprecation warning.
+
+---
+
 ## Add and upgrade HTTP integration
 
 Added in [gestalt#2730](https://github.com/valon-technologies/gestalt/pull/2730) (`POST …/install`). Registry-only apps use separate `add` and `upgrade` routes — see [lifecycle.md](./lifecycle.md#post-adminapiv1app-registriesregistryappsappadd).

--- a/plans/app_registry/tests.md
+++ b/plans/app_registry/tests.md
@@ -86,8 +86,8 @@ go test ./internal/daemon/e2e/app_publish -run 'AppRegistryPublish|AppPublish' -
 
 ### `internal/appregistry/pending_test.go`
 
-- **`TestPrunePendingIndex_MovesStaleEntryToFailed`** — pending `startedAt` older than 2 hours moves to `failed.json` with `reason=stale`.
-- **`TestPrunePendingIndex_KeepsInFlightEntryWithinStaleWindow`** — in-flight pending younger than 2 hours is not stale-pruned.
+- **`TestPrunePendingIndex_MovesStaleEntryToFailed`** — pending `startedAt` older than 30 minutes moves to `failed.json` with `reason=stale`.
+- **`TestPrunePendingIndex_KeepsInFlightEntryWithinStaleWindow`** — in-flight pending younger than 30 minutes is not stale-pruned.
 - **`TestPrunePendingIndex_DropsAlreadyPublishedVersion`** — pending entry is removed when the version is already in `index.json`.
 - **`TestPruneFailedIndex_RemovesOldAndPublishedEntries`** — failed entries older than 30 days or already published are pruned.
 - **`TestUpsertPendingVersion_PreservesStartedAt`** — `pending set` refresh keeps the original `startedAt`.

--- a/plans/app_registry/tests.md
+++ b/plans/app_registry/tests.md
@@ -86,12 +86,14 @@ go test ./internal/daemon/e2e/app_publish -run 'AppRegistryPublish|AppPublish' -
 
 ### `internal/appregistry/pending_test.go`
 
-- **`TestPrunePendingIndex_MovesStaleEntryToFailed`** — pending `updatedAt` older than 30 minutes moves to `failed.json` with `reason=stale`.
+- **`TestPrunePendingIndex_MovesStaleEntryToFailed`** — pending `startedAt` older than 2 hours moves to `failed.json` with `reason=stale`.
+- **`TestPrunePendingIndex_KeepsInFlightEntryWithinStaleWindow`** — in-flight pending younger than 2 hours is not stale-pruned.
 - **`TestPrunePendingIndex_DropsAlreadyPublishedVersion`** — pending entry is removed when the version is already in `index.json`.
 - **`TestPruneFailedIndex_RemovesOldAndPublishedEntries`** — failed entries older than 30 days or already published are pruned.
 - **`TestUpsertPendingVersion_PreservesStartedAt`** — `pending set` refresh keeps the original `startedAt`.
 - **`TestRecordFailedVersion_IsIdempotent`** — `pending fail` does not overwrite an existing failed entry.
 - **`TestDecodePendingAndFailedIndexRoundTrip`** — JSON encode/decode validates catalog shapes.
+- **`TestRemoveFailedVersion`** — `pending set` clears a prior `failed.{version}` on workflow retry.
 - **`TestPublishStartedAtFromPending`** — publish reads `startedAt` from a matching pending entry.
 - **`TestUpsertAppIndex_CopiesPublishStartedAt`** — published index entries copy `publishStartedAt` from the version metadata.
 


### PR DESCRIPTION
## Summary
- Add `PendingIndex` / `FailedIndex` types with prune helpers and `gestaltd app registry pending set|clear|fail`
- Add `gestaltd app registry publish` (immutable uploads only); deprecate `gestaltd app publish`
- Copy `pending.startedAt` into `publishStartedAt` on published version metadata and `index.json` at publish time (read-only `pending.json` access)
- Unit and e2e tests per [pending-publish.md PR 1](plans/app_registry/pending-publish.md#pr-1--models-and-write-path-gestalt)

## Test plan
- [x] `go test ./internal/appregistry -run 'Pending|Prune|Record|Upsert|DecodePending|PublishStartedAt' -count=1`
- [x] `go test ./internal/daemon/e2e/app_publish -count=1`


Made with [Cursor](https://cursor.com)