### PR TITLE
Expose pending/failed catalogs in app-admin registry API (PR 2)

### DIFF
--- a/gestaltd/internal/appregistry/admin_catalog.go
+++ b/gestaltd/internal/appregistry/admin_catalog.go
@@ -1,0 +1,90 @@
+package appregistry
+
+import (
+	"sort"
+	"time"
+)
+
+// PendingVersionsForAdmin returns pending versions not already published, newest
+// startedAt first.
+func PendingVersionsForAdmin(pending *PendingIndex, published map[string]struct{}) []PendingVersion {
+	if pending == nil || len(pending.Pending) == 0 {
+		return nil
+	}
+	out := make([]PendingVersion, 0, len(pending.Pending))
+	for version, entry := range pending.Pending {
+		if _, ok := published[version]; ok {
+			continue
+		}
+		out = append(out, entry)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].StartedAt.Equal(out[j].StartedAt) {
+			return out[i].Version > out[j].Version
+		}
+		return out[i].StartedAt.After(out[j].StartedAt)
+	})
+	return out
+}
+
+// FailedVersionsForAdmin returns failed versions not already published or
+// pending, newest failedAt first.
+func FailedVersionsForAdmin(failed *FailedIndex, published, pending map[string]struct{}) []FailedVersion {
+	if failed == nil || len(failed.Failed) == 0 {
+		return nil
+	}
+	out := make([]FailedVersion, 0, len(failed.Failed))
+	for version, entry := range failed.Failed {
+		if _, ok := published[version]; ok {
+			continue
+		}
+		if _, ok := pending[version]; ok {
+			continue
+		}
+		out = append(out, entry)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].FailedAt.Equal(out[j].FailedAt) {
+			return out[i].Version > out[j].Version
+		}
+		return out[i].FailedAt.After(out[j].FailedAt)
+	})
+	return out
+}
+
+// PublishedVersionKeys returns version keys present in a published app index.
+func PublishedVersionKeys(index *Index, appName string) map[string]struct{} {
+	if index == nil || len(index.Apps) == 0 {
+		return map[string]struct{}{}
+	}
+	appVersions, ok := index.Apps[appName]
+	if !ok || len(appVersions.Versions) == 0 {
+		return map[string]struct{}{}
+	}
+	out := make(map[string]struct{}, len(appVersions.Versions))
+	for version := range appVersions.Versions {
+		out[version] = struct{}{}
+	}
+	return out
+}
+
+// PendingVersionKeys returns version keys present in a pending catalog.
+func PendingVersionKeys(pending *PendingIndex) map[string]struct{} {
+	if pending == nil || len(pending.Pending) == 0 {
+		return map[string]struct{}{}
+	}
+	out := make(map[string]struct{}, len(pending.Pending))
+	for version := range pending.Pending {
+		out[version] = struct{}{}
+	}
+	return out
+}
+
+// DurationSecondsBetween returns whole seconds between start and end when start
+// is non-zero and end is after start.
+func DurationSecondsBetween(start, end time.Time) (int64, bool) {
+	if start.IsZero() || end.IsZero() || !end.After(start) {
+		return 0, false
+	}
+	return int64(end.Sub(start.UTC()).Seconds()), true
+}

--- a/gestaltd/internal/appregistry/admin_catalog_test.go
+++ b/gestaltd/internal/appregistry/admin_catalog_test.go
@@ -1,0 +1,61 @@
+package appregistry
+
+import (
+	"testing"
+	"time"
+)
+
+func TestPendingVersionsForAdmin_ExcludesPublishedAndSortsNewestFirst(t *testing.T) {
+	t.Parallel()
+
+	older := time.Date(2026, 7, 24, 18, 0, 0, 0, time.UTC)
+	newer := time.Date(2026, 7, 24, 19, 0, 0, 0, time.UTC)
+	pending := &PendingIndex{
+		Pending: map[string]PendingVersion{
+			"0.0.1": {Version: "0.0.1", StartedAt: older, UpdatedAt: older, Phase: PendingPhasePublishing},
+			"0.0.2": {Version: "0.0.2", StartedAt: newer, UpdatedAt: newer, Phase: PendingPhasePublishing},
+			"0.0.3": {Version: "0.0.3", StartedAt: newer, UpdatedAt: newer, Phase: PendingPhasePublishing},
+		},
+	}
+	published := map[string]struct{}{"0.0.3": {}}
+
+	got := PendingVersionsForAdmin(pending, published)
+	if len(got) != 2 || got[0].Version != "0.0.2" || got[1].Version != "0.0.1" {
+		t.Fatalf("pending versions = %#v", got)
+	}
+}
+
+func TestFailedVersionsForAdmin_ExcludesPublishedAndPending(t *testing.T) {
+	t.Parallel()
+
+	startedAt := time.Date(2026, 7, 24, 18, 0, 0, 0, time.UTC)
+	failedAt := startedAt.Add(35 * time.Minute)
+	failed := &FailedIndex{
+		Failed: map[string]FailedVersion{
+			"0.0.1": {Version: "0.0.1", StartedAt: startedAt, FailedAt: failedAt, Reason: FailedReasonStale},
+			"0.0.2": {Version: "0.0.2", StartedAt: startedAt, FailedAt: failedAt, Reason: FailedReasonWorkflowFailed},
+			"0.0.3": {Version: "0.0.3", StartedAt: startedAt, FailedAt: failedAt, Reason: FailedReasonWorkflowFailed},
+		},
+	}
+	published := map[string]struct{}{"0.0.2": {}}
+	pending := map[string]struct{}{"0.0.3": {}}
+
+	got := FailedVersionsForAdmin(failed, published, pending)
+	if len(got) != 1 || got[0].Version != "0.0.1" {
+		t.Fatalf("failed versions = %#v", got)
+	}
+}
+
+func TestDurationSecondsBetween(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 7, 24, 19, 0, 0, 0, time.UTC)
+	end := start.Add(4*time.Minute + 32*time.Second)
+	seconds, ok := DurationSecondsBetween(start, end)
+	if !ok || seconds != 272 {
+		t.Fatalf("DurationSecondsBetween() = (%d, %v), want (272, true)", seconds, ok)
+	}
+	if _, ok := DurationSecondsBetween(time.Time{}, end); ok {
+		t.Fatal("expected zero start to return false")
+	}
+}

--- a/gestaltd/internal/appregistry/reader.go
+++ b/gestaltd/internal/appregistry/reader.go
@@ -54,6 +54,56 @@ func (r *RegistryReader) fetchJSON(ctx context.Context, url string, notFoundEmpt
 	return body, nil
 }
 
+// FetchPendingIndex downloads apps/{app}/pending.json from a registry public root.
+func (r *RegistryReader) FetchPendingIndex(ctx context.Context, publicRoot, appName string) (*PendingIndex, error) {
+	appName = strings.TrimSpace(appName)
+	if appName == "" {
+		return nil, fmt.Errorf("app name is required")
+	}
+	if err := providerregistry.ValidateRepositoryName(appName); err != nil {
+		return nil, err
+	}
+	publicRoot = strings.TrimRight(strings.TrimSpace(publicRoot), "/")
+	if publicRoot == "" {
+		return nil, fmt.Errorf("registry public URL is required")
+	}
+
+	url := PublicURL(publicRoot, AppPendingPath(appName))
+	body, err := r.fetchJSON(ctx, url, true)
+	if err != nil {
+		return nil, err
+	}
+	if body == nil {
+		return NewEmptyPendingIndex(appName), nil
+	}
+	return DecodePendingIndex(body)
+}
+
+// FetchFailedIndex downloads apps/{app}/failed.json from a registry public root.
+func (r *RegistryReader) FetchFailedIndex(ctx context.Context, publicRoot, appName string) (*FailedIndex, error) {
+	appName = strings.TrimSpace(appName)
+	if appName == "" {
+		return nil, fmt.Errorf("app name is required")
+	}
+	if err := providerregistry.ValidateRepositoryName(appName); err != nil {
+		return nil, err
+	}
+	publicRoot = strings.TrimRight(strings.TrimSpace(publicRoot), "/")
+	if publicRoot == "" {
+		return nil, fmt.Errorf("registry public URL is required")
+	}
+
+	url := PublicURL(publicRoot, AppFailedPath(appName))
+	body, err := r.fetchJSON(ctx, url, true)
+	if err != nil {
+		return nil, err
+	}
+	if body == nil {
+		return NewEmptyFailedIndex(appName), nil
+	}
+	return DecodeFailedIndex(body)
+}
+
 // FetchAppIndex downloads apps/{app}/index.json from a registry public root.
 func (r *RegistryReader) FetchAppIndex(ctx context.Context, publicRoot, appName string) (*Index, error) {
 	appName = strings.TrimSpace(appName)
@@ -107,13 +157,14 @@ func (r *RegistryReader) FetchEntry(ctx context.Context, publicRoot, appName, ve
 
 // VersionSummary is a lightweight view of one published app version from an index.
 type VersionSummary struct {
-	Version     string       `json:"version"`
-	Metadata    string       `json:"metadata"`
-	Platforms   []string     `json:"platforms,omitempty"`
-	PublishedAt time.Time    `json:"publishedAt"`
-	SourceRef   string       `json:"sourceRef,omitempty"`
-	Repository  string       `json:"repository,omitempty"`
-	Publication *Publication `json:"publication,omitempty"`
+	Version          string       `json:"version"`
+	Metadata         string       `json:"metadata"`
+	Platforms        []string     `json:"platforms,omitempty"`
+	PublishedAt      time.Time    `json:"publishedAt"`
+	PublishStartedAt *time.Time   `json:"publishStartedAt,omitempty"`
+	SourceRef        string       `json:"sourceRef,omitempty"`
+	Repository       string       `json:"repository,omitempty"`
+	Publication      *Publication `json:"publication,omitempty"`
 }
 
 // VersionsFromIndex returns version summaries for appName, newest first.
@@ -129,13 +180,14 @@ func VersionsFromIndex(index *Index, appName string) []VersionSummary {
 	for version := range appVersions.Versions {
 		summary := appVersions.Versions[version]
 		out = append(out, VersionSummary{
-			Version:     version,
-			Metadata:    summary.Metadata,
-			Platforms:   append([]string(nil), summary.Platforms...),
-			PublishedAt: summary.PublishedAt.UTC(),
-			SourceRef:   summary.SourceRef,
-			Repository:  summary.Repository,
-			Publication: clonePublication(summary.Publication),
+			Version:          version,
+			Metadata:         summary.Metadata,
+			Platforms:        append([]string(nil), summary.Platforms...),
+			PublishedAt:      summary.PublishedAt.UTC(),
+			PublishStartedAt: cloneTimePtr(summary.PublishStartedAt),
+			SourceRef:        summary.SourceRef,
+			Repository:       summary.Repository,
+			Publication:      clonePublication(summary.Publication),
 		})
 	}
 	sortVersionsNewestFirst(out)

--- a/gestaltd/internal/appregistry/reader_test.go
+++ b/gestaltd/internal/appregistry/reader_test.go
@@ -148,3 +148,58 @@ func TestVersionsFromIndex_RoundTripsPublishedAt(t *testing.T) {
 		t.Fatalf("publishedAt json = %s", got)
 	}
 }
+
+func TestRegistryReader_FetchPendingIndex(t *testing.T) {
+	t.Parallel()
+
+	pendingJSON := `{
+  "schemaVersion": 1,
+  "app": "g-issues",
+  "pending": {
+    "0.0.2": {
+      "version": "0.0.2",
+      "sourceRef": "abc123def456abc123def456abc123def456abcd",
+      "startedAt": "2026-07-24T19:00:00Z",
+      "updatedAt": "2026-07-24T19:04:12Z",
+      "phase": "publishing"
+    }
+  }
+}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/apps/g-issues/pending.json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(pendingJSON))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	reader := &RegistryReader{HTTPClient: srv.Client()}
+	index, err := reader.FetchPendingIndex(t.Context(), srv.URL, "g-issues")
+	if err != nil {
+		t.Fatalf("FetchPendingIndex: %v", err)
+	}
+	if len(index.Pending) != 1 || index.Pending["0.0.2"].Phase != PendingPhasePublishing {
+		t.Fatalf("pending = %#v", index.Pending)
+	}
+}
+
+func TestRegistryReader_FetchFailedIndex_NotFoundReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	reader := &RegistryReader{HTTPClient: srv.Client()}
+	index, err := reader.FetchFailedIndex(t.Context(), srv.URL, "g-issues")
+	if err != nil {
+		t.Fatalf("FetchFailedIndex: %v", err)
+	}
+	if index == nil || len(index.Failed) != 0 {
+		t.Fatalf("failed = %#v, want empty catalog", index)
+	}
+}

--- a/gestaltd/internal/appregistry/registry.go
+++ b/gestaltd/internal/appregistry/registry.go
@@ -743,6 +743,14 @@ func clonePublication(value *Publication) *Publication {
 	return &out
 }
 
+func cloneTimePtr(value *time.Time) *time.Time {
+	if value == nil || value.IsZero() {
+		return nil
+	}
+	cloned := value.UTC()
+	return &cloned
+}
+
 func CatalogOperationContracts(cat *catalog.Catalog) map[string]OperationContract {
 	if cat == nil {
 		return nil

--- a/gestaltd/internal/appregistry/registrytest/fixture.go
+++ b/gestaltd/internal/appregistry/registrytest/fixture.go
@@ -27,6 +27,14 @@ type InstallFixture struct {
 	Version      string
 	SHA256       string
 	ArchiveBytes []byte
+	indexJSON    []byte
+	entryJSON    []byte
+}
+
+// CatalogDocuments holds optional pending and failed catalog JSON for test readers.
+type CatalogDocuments struct {
+	PendingJSON []byte
+	FailedJSON  []byte
 }
 
 // NewInstallFixture builds a mock GCS registry with one installable app version.
@@ -171,7 +179,47 @@ func NewInstallFixture(t *testing.T) InstallFixture {
 		Version:      version,
 		SHA256:       archiveSHA,
 		ArchiveBytes: archiveBytes,
+		indexJSON:    indexJSON,
+		entryJSON:    entryJSON,
 	}
+}
+
+// NewReaderWithCatalogs returns a reader backed by the install fixture plus
+// optional pending and failed catalog documents.
+func NewReaderWithCatalogs(t *testing.T, fixture InstallFixture, catalogs CatalogDocuments) *appregistry.RegistryReader {
+	t.Helper()
+
+	registrySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/" + Bucket + "/apps/g-issues/index.json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(fixture.indexJSON)
+		case "/" + Bucket + "/apps/g-issues/versions/" + fixture.Version + ".json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(fixture.entryJSON)
+		case "/" + Bucket + "/apps/g-issues/artifacts/" + fixture.Version + "/artifact.tar.gz":
+			w.Header().Set("Content-Type", "application/gzip")
+			_, _ = w.Write(fixture.ArchiveBytes)
+		case "/" + Bucket + "/apps/g-issues/pending.json":
+			if len(catalogs.PendingJSON) == 0 {
+				http.NotFound(w, r)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(catalogs.PendingJSON)
+		case "/" + Bucket + "/apps/g-issues/failed.json":
+			if len(catalogs.FailedJSON) == 0 {
+				http.NotFound(w, r)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(catalogs.FailedJSON)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(registrySrv.Close)
+	return NewReaderForServer(t, registrySrv.URL)
 }
 
 // NewReaderForServer returns a reader that rewrites GCS public URLs to a test server.

--- a/gestaltd/internal/server/handlers_app_admin_registry.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry.go
@@ -200,8 +200,8 @@ func (s *Server) getAppAdminRegistry(w http.ResponseWriter, r *http.Request) {
 	pendingKeys := appregistry.PendingVersionKeys(pendingIndex)
 	summaries := appregistry.VersionsFromIndex(index, app.name)
 	published := make([]appAdminPublishedVersion, 0, len(summaries))
-	for _, summary := range summaries {
-		published = append(published, appAdminPublishedVersionFromSummary(summary))
+	for i := range summaries {
+		published = append(published, appAdminPublishedVersionFromSummary(summaries[i]))
 	}
 	pendingVersions := make([]appAdminPendingVersion, 0)
 	for _, entry := range appregistry.PendingVersionsForAdmin(pendingIndex, publishedKeys) {

--- a/gestaltd/internal/server/handlers_app_admin_registry.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
@@ -25,18 +26,44 @@ type appAdminRegistryResponse struct {
 	DesiredVersion    string                     `json:"desiredVersion,omitempty"`
 	KnownVersions     []adminAppInstallationInfo `json:"knownVersions"`
 	PublishedVersions []appAdminPublishedVersion `json:"publishedVersions"`
+	PendingVersions   []appAdminPendingVersion   `json:"pendingVersions,omitempty"`
+	FailedVersions    []appAdminFailedVersion    `json:"failedVersions,omitempty"`
 	Rollout           *appAdminRollout           `json:"rollout,omitempty"`
 	SelectionDisabled bool                       `json:"selectionDisabled"`
 	DisabledReason    string                     `json:"disabledReason,omitempty"`
 }
 
 type appAdminPublishedVersion struct {
-	Version     string                   `json:"version"`
-	PublishedAt string                   `json:"publishedAt"`
-	Platforms   []string                 `json:"platforms,omitempty"`
-	SourceRef   string                   `json:"sourceRef,omitempty"`
-	SourceURL   string                   `json:"sourceUrl,omitempty"`
-	Publication *appregistry.Publication `json:"publication,omitempty"`
+	Version                string                   `json:"version"`
+	PublishedAt            string                   `json:"publishedAt"`
+	PublishStartedAt       string                   `json:"publishStartedAt,omitempty"`
+	PublishDurationSeconds *int64                   `json:"publishDurationSeconds,omitempty"`
+	Platforms              []string                 `json:"platforms,omitempty"`
+	SourceRef              string                   `json:"sourceRef,omitempty"`
+	SourceURL              string                   `json:"sourceUrl,omitempty"`
+	Publication            *appregistry.Publication `json:"publication,omitempty"`
+}
+
+type appAdminPendingVersion struct {
+	Version              string                   `json:"version"`
+	StartedAt            string                   `json:"startedAt"`
+	UpdatedAt            string                   `json:"updatedAt"`
+	Phase                string                   `json:"phase"`
+	PublishingForSeconds *int64                   `json:"publishingForSeconds,omitempty"`
+	SourceRef            string                   `json:"sourceRef,omitempty"`
+	SourceURL            string                   `json:"sourceUrl,omitempty"`
+	Publication          *appregistry.Publication `json:"publication,omitempty"`
+}
+
+type appAdminFailedVersion struct {
+	Version                string                   `json:"version"`
+	StartedAt              string                   `json:"startedAt"`
+	FailedAt               string                   `json:"failedAt"`
+	Reason                 string                   `json:"reason"`
+	PublishDurationSeconds *int64                   `json:"publishDurationSeconds,omitempty"`
+	SourceRef              string                   `json:"sourceRef,omitempty"`
+	SourceURL              string                   `json:"sourceUrl,omitempty"`
+	Publication            *appregistry.Publication `json:"publication,omitempty"`
 }
 
 type appAdminRollout struct {
@@ -158,17 +185,31 @@ func (s *Server) getAppAdminRegistry(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadGateway, "failed to fetch app registry index")
 		return
 	}
+	pendingIndex, err := reader.FetchPendingIndex(r.Context(), publicRoot, app.name)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "failed to fetch app registry pending catalog")
+		return
+	}
+	failedIndex, err := reader.FetchFailedIndex(r.Context(), publicRoot, app.name)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "failed to fetch app registry failed catalog")
+		return
+	}
+	now := time.Now().UTC()
+	publishedKeys := appregistry.PublishedVersionKeys(index, app.name)
+	pendingKeys := appregistry.PendingVersionKeys(pendingIndex)
 	summaries := appregistry.VersionsFromIndex(index, app.name)
 	published := make([]appAdminPublishedVersion, 0, len(summaries))
 	for _, summary := range summaries {
-		published = append(published, appAdminPublishedVersion{
-			Version:     summary.Version,
-			PublishedAt: formatAdminTime(summary.PublishedAt),
-			Platforms:   append([]string(nil), summary.Platforms...),
-			SourceRef:   summary.SourceRef,
-			SourceURL:   appVersionSourceURL(summary.Repository, summary.SourceRef),
-			Publication: summary.Publication,
-		})
+		published = append(published, appAdminPublishedVersionFromSummary(summary))
+	}
+	pendingVersions := make([]appAdminPendingVersion, 0)
+	for _, entry := range appregistry.PendingVersionsForAdmin(pendingIndex, publishedKeys) {
+		pendingVersions = append(pendingVersions, appAdminPendingVersionFromEntry(entry, now))
+	}
+	failedVersions := make([]appAdminFailedVersion, 0)
+	for _, entry := range appregistry.FailedVersionsForAdmin(failedIndex, publishedKeys, pendingKeys) {
+		failedVersions = append(failedVersions, appAdminFailedVersionFromEntry(entry))
 	}
 	knownVersions := make([]adminAppInstallationInfo, 0, len(known))
 	for _, installation := range known {
@@ -180,6 +221,8 @@ func (s *Server) getAppAdminRegistry(w http.ResponseWriter, r *http.Request) {
 		DesiredVersion:    coredata.LatestKnownVersion(known),
 		KnownVersions:     knownVersions,
 		PublishedVersions: published,
+		PendingVersions:   pendingVersions,
+		FailedVersions:    failedVersions,
 	}
 	rollout, err := s.appRollouts.Get(r.Context(), app.name)
 	if err == nil {
@@ -288,4 +331,54 @@ func appVersionSourceURL(repository, sourceRef string) string {
 		repository = "https://" + repository
 	}
 	return repository + "/commit/" + sourceRef
+}
+
+func appAdminPublishedVersionFromSummary(summary appregistry.VersionSummary) appAdminPublishedVersion {
+	version := appAdminPublishedVersion{
+		Version:     summary.Version,
+		PublishedAt: formatAdminTime(summary.PublishedAt),
+		Platforms:   append([]string(nil), summary.Platforms...),
+		SourceRef:   summary.SourceRef,
+		SourceURL:   appVersionSourceURL(summary.Repository, summary.SourceRef),
+		Publication: summary.Publication,
+	}
+	if summary.PublishStartedAt != nil && !summary.PublishStartedAt.IsZero() {
+		version.PublishStartedAt = formatAdminTime(*summary.PublishStartedAt)
+		if seconds, ok := appregistry.DurationSecondsBetween(*summary.PublishStartedAt, summary.PublishedAt); ok {
+			version.PublishDurationSeconds = &seconds
+		}
+	}
+	return version
+}
+
+func appAdminPendingVersionFromEntry(entry appregistry.PendingVersion, now time.Time) appAdminPendingVersion {
+	version := appAdminPendingVersion{
+		Version:     entry.Version,
+		StartedAt:   formatAdminTime(entry.StartedAt),
+		UpdatedAt:   formatAdminTime(entry.UpdatedAt),
+		Phase:       entry.Phase,
+		SourceRef:   entry.SourceRef,
+		SourceURL:   appVersionSourceURL(entry.Repository, entry.SourceRef),
+		Publication: entry.Publication,
+	}
+	if seconds, ok := appregistry.DurationSecondsBetween(entry.StartedAt, now); ok {
+		version.PublishingForSeconds = &seconds
+	}
+	return version
+}
+
+func appAdminFailedVersionFromEntry(entry appregistry.FailedVersion) appAdminFailedVersion {
+	version := appAdminFailedVersion{
+		Version:     entry.Version,
+		StartedAt:   formatAdminTime(entry.StartedAt),
+		FailedAt:    formatAdminTime(entry.FailedAt),
+		Reason:      entry.Reason,
+		SourceRef:   entry.SourceRef,
+		SourceURL:   appVersionSourceURL(entry.Repository, entry.SourceRef),
+		Publication: entry.Publication,
+	}
+	if seconds, ok := appregistry.DurationSecondsBetween(entry.StartedAt, entry.FailedAt); ok {
+		version.PublishDurationSeconds = &seconds
+	}
+	return version
 }

--- a/gestaltd/internal/server/handlers_app_admin_registry_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry_test.go
@@ -209,3 +209,106 @@ func TestListAppsIncludesManagementPathForAppAdmin(t *testing.T) {
 		t.Fatalf("apps = %#v", apps)
 	}
 }
+
+func TestAppAdminRegistryIncludesPendingAndFailedVersions(t *testing.T) {
+	t.Parallel()
+
+	fixture := registrytest.NewInstallFixture(t)
+	subjectID := principal.UserSubjectID("alice")
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(subjectID, "admin", "app", "g-issues"),
+		},
+	}
+	reader := registrytest.NewReaderWithCatalogs(t, fixture, registrytest.CatalogDocuments{
+		PendingJSON: []byte(`{
+  "schemaVersion": 1,
+  "app": "g-issues",
+  "pending": {
+    "0.0.0-snapshot.gpending": {
+      "version": "0.0.0-snapshot.gpending",
+      "sourceRef": "abc123def456abc123def456abc123def456abcd",
+      "repository": "github.com/valon-technologies/valon-tools",
+      "startedAt": "2026-07-24T19:00:00Z",
+      "updatedAt": "2026-07-24T19:04:12Z",
+      "phase": "publishing"
+    },
+    "` + fixture.Version + `": {
+      "version": "` + fixture.Version + `",
+      "sourceRef": "abc123def456abc123def456abc123def456abcd",
+      "startedAt": "2026-07-24T19:00:00Z",
+      "updatedAt": "2026-07-24T19:04:12Z",
+      "phase": "publishing"
+    }
+  }
+}`),
+		FailedJSON: []byte(`{
+  "schemaVersion": 1,
+  "app": "g-issues",
+  "failed": {
+    "0.0.0-snapshot.gfailed": {
+      "version": "0.0.0-snapshot.gfailed",
+      "sourceRef": "abc123def456abc123def456abc123def456abcd",
+      "repository": "github.com/valon-technologies/valon-tools",
+      "startedAt": "2026-07-24T18:00:00Z",
+      "failedAt": "2026-07-24T18:35:00Z",
+      "reason": "stale"
+    }
+  }
+}`),
+	})
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", subjectID, "")
+		cfg.Authorization = authz
+		cfg.AppDefs = map[string]*config.ProviderEntry{
+			"g-issues": {Source: config.ProviderSource{Registry: "toolshed"}},
+		}
+		cfg.AppRegistries = map[string]config.AppRegistryConfig{"toolshed": fixture.Registry}
+		cfg.AppRegistryReader = reader
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	request, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/g-issues/admin/registry", nil)
+	request.Header.Set("Authorization", "Bearer alice-token")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET registry state: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("GET status = %d: %s", response.StatusCode, body)
+	}
+	var state struct {
+		PublishedVersions []struct {
+			Version string `json:"version"`
+		} `json:"publishedVersions"`
+		PendingVersions []struct {
+			Version              string `json:"version"`
+			PublishingForSeconds *int64 `json:"publishingForSeconds"`
+		} `json:"pendingVersions"`
+		FailedVersions []struct {
+			Version                string `json:"version"`
+			Reason                 string `json:"reason"`
+			PublishDurationSeconds *int64 `json:"publishDurationSeconds"`
+		} `json:"failedVersions"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&state); err != nil {
+		t.Fatalf("decode GET response: %v", err)
+	}
+	if len(state.PublishedVersions) != 1 || state.PublishedVersions[0].Version != fixture.Version {
+		t.Fatalf("publishedVersions = %#v", state.PublishedVersions)
+	}
+	if len(state.PendingVersions) != 1 || state.PendingVersions[0].Version != "0.0.0-snapshot.gpending" {
+		t.Fatalf("pendingVersions = %#v", state.PendingVersions)
+	}
+	if state.PendingVersions[0].PublishingForSeconds == nil {
+		t.Fatalf("pendingVersions missing publishingForSeconds: %#v", state.PendingVersions)
+	}
+	if len(state.FailedVersions) != 1 || state.FailedVersions[0].Version != "0.0.0-snapshot.gfailed" {
+		t.Fatalf("failedVersions = %#v", state.FailedVersions)
+	}
+	if state.FailedVersions[0].PublishDurationSeconds == nil || state.FailedVersions[0].Reason != "stale" {
+		t.Fatalf("failedVersions = %#v", state.FailedVersions)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `FetchPendingIndex` and `FetchFailedIndex` registry reader helpers
- Extend `GET /api/v1/apps/{app}/admin/registry` with `pendingVersions` and `failedVersions`
- Apply published > pending > failed merge precedence and duration fields

## Test plan
- [x] `go test ./internal/appregistry/... ./internal/server/...`
- [ ] CI green on gestaltd validate workflow


Made with [Cursor](https://cursor.com)