### PR TITLE
Add app registry pending write path (PR 1)

### DIFF
--- a/gestaltd/internal/appregistry/pending.go
+++ b/gestaltd/internal/appregistry/pending.go
@@ -1,0 +1,417 @@
+package appregistry
+
+import (
+	"encoding/json"
+	"fmt"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/services/apps/source"
+)
+
+const (
+	PendingIndexSchemaVersion = 1
+	FailedIndexSchemaVersion  = 1
+
+	PendingFileName = "pending.json"
+	FailedFileName  = "failed.json"
+
+	PendingPhasePublishing = "publishing"
+
+	FailedReasonWorkflowFailed = "workflow_failed"
+	FailedReasonStale          = "stale"
+
+	PendingStaleAfter = 30 * time.Minute
+	FailedRetainFor   = 30 * 24 * time.Hour
+)
+
+type PendingIndex struct {
+	SchemaVersion int                       `json:"schemaVersion"`
+	App           string                    `json:"app"`
+	Pending       map[string]PendingVersion `json:"pending"`
+}
+
+type PendingVersion struct {
+	Version     string       `json:"version"`
+	SourceRef   string       `json:"sourceRef"`
+	Repository  string       `json:"repository,omitempty"`
+	StartedAt   time.Time    `json:"startedAt"`
+	UpdatedAt   time.Time    `json:"updatedAt"`
+	Phase       string       `json:"phase"`
+	Publication *Publication `json:"publication,omitempty"`
+}
+
+type FailedIndex struct {
+	SchemaVersion int                      `json:"schemaVersion"`
+	App           string                   `json:"app"`
+	Failed        map[string]FailedVersion `json:"failed"`
+}
+
+type FailedVersion struct {
+	Version     string       `json:"version"`
+	SourceRef   string       `json:"sourceRef"`
+	Repository  string       `json:"repository,omitempty"`
+	StartedAt   time.Time    `json:"startedAt"`
+	FailedAt    time.Time    `json:"failedAt"`
+	Reason      string       `json:"reason"`
+	Publication *Publication `json:"publication,omitempty"`
+}
+
+func AppPendingPath(appName string) string {
+	return path.Join("apps", appName, PendingFileName)
+}
+
+func AppFailedPath(appName string) string {
+	return path.Join("apps", appName, FailedFileName)
+}
+
+func NewEmptyPendingIndex(appName string) *PendingIndex {
+	return &PendingIndex{
+		SchemaVersion: PendingIndexSchemaVersion,
+		App:           strings.TrimSpace(appName),
+		Pending:       map[string]PendingVersion{},
+	}
+}
+
+func NewEmptyFailedIndex(appName string) *FailedIndex {
+	return &FailedIndex{
+		SchemaVersion: FailedIndexSchemaVersion,
+		App:           strings.TrimSpace(appName),
+		Failed:        map[string]FailedVersion{},
+	}
+}
+
+func DecodePendingIndex(data []byte) (*PendingIndex, error) {
+	var index PendingIndex
+	if err := json.Unmarshal(data, &index); err != nil {
+		return nil, fmt.Errorf("decode pending index: %w", err)
+	}
+	if err := validatePendingIndex(&index); err != nil {
+		return nil, err
+	}
+	return &index, nil
+}
+
+func DecodeFailedIndex(data []byte) (*FailedIndex, error) {
+	var index FailedIndex
+	if err := json.Unmarshal(data, &index); err != nil {
+		return nil, fmt.Errorf("decode failed index: %w", err)
+	}
+	if err := validateFailedIndex(&index); err != nil {
+		return nil, err
+	}
+	return &index, nil
+}
+
+func validatePendingIndex(index *PendingIndex) error {
+	if index == nil {
+		return fmt.Errorf("pending index is required")
+	}
+	if index.SchemaVersion != PendingIndexSchemaVersion {
+		return fmt.Errorf("unsupported pending index schema version %d", index.SchemaVersion)
+	}
+	if strings.TrimSpace(index.App) == "" {
+		return fmt.Errorf("pending index app is required")
+	}
+	if index.Pending == nil {
+		return fmt.Errorf("pending index pending map is required")
+	}
+	for version, entry := range index.Pending {
+		if err := validatePendingVersion(index.App, version, entry); err != nil {
+			return fmt.Errorf("pending index version %q: %w", version, err)
+		}
+	}
+	return nil
+}
+
+func validateFailedIndex(index *FailedIndex) error {
+	if index == nil {
+		return fmt.Errorf("failed index is required")
+	}
+	if index.SchemaVersion != FailedIndexSchemaVersion {
+		return fmt.Errorf("unsupported failed index schema version %d", index.SchemaVersion)
+	}
+	if strings.TrimSpace(index.App) == "" {
+		return fmt.Errorf("failed index app is required")
+	}
+	if index.Failed == nil {
+		return fmt.Errorf("failed index failed map is required")
+	}
+	for version, entry := range index.Failed {
+		if err := validateFailedVersion(index.App, version, entry); err != nil {
+			return fmt.Errorf("failed index version %q: %w", version, err)
+		}
+	}
+	return nil
+}
+
+func validatePendingVersion(appName, mapKey string, entry PendingVersion) error {
+	version := strings.TrimSpace(entry.Version)
+	if version == "" {
+		return fmt.Errorf("version is required")
+	}
+	if mapKey != version {
+		return fmt.Errorf("map key %q does not match version field %q", mapKey, version)
+	}
+	if err := source.ValidateVersion(version); err != nil {
+		return fmt.Errorf("version: %w", err)
+	}
+	if err := validateSourceRef(entry.SourceRef); err != nil {
+		return fmt.Errorf("sourceRef: %w", err)
+	}
+	if repository := strings.TrimSpace(entry.Repository); repository != "" {
+		if err := validateEntryRepository(repository, appName); err != nil {
+			return fmt.Errorf("repository: %w", err)
+		}
+	}
+	if entry.StartedAt.IsZero() {
+		return fmt.Errorf("startedAt is required")
+	}
+	if entry.UpdatedAt.IsZero() {
+		return fmt.Errorf("updatedAt is required")
+	}
+	if entry.Phase != PendingPhasePublishing {
+		return fmt.Errorf("phase must be %q", PendingPhasePublishing)
+	}
+	if err := validatePublication(entry.Publication); err != nil {
+		return fmt.Errorf("publication: %w", err)
+	}
+	return nil
+}
+
+func validateFailedVersion(appName, mapKey string, entry FailedVersion) error {
+	version := strings.TrimSpace(entry.Version)
+	if version == "" {
+		return fmt.Errorf("version is required")
+	}
+	if mapKey != version {
+		return fmt.Errorf("map key %q does not match version field %q", mapKey, version)
+	}
+	if err := source.ValidateVersion(version); err != nil {
+		return fmt.Errorf("version: %w", err)
+	}
+	if err := validateSourceRef(entry.SourceRef); err != nil {
+		return fmt.Errorf("sourceRef: %w", err)
+	}
+	if repository := strings.TrimSpace(entry.Repository); repository != "" {
+		if err := validateEntryRepository(repository, appName); err != nil {
+			return fmt.Errorf("repository: %w", err)
+		}
+	}
+	if entry.StartedAt.IsZero() {
+		return fmt.Errorf("startedAt is required")
+	}
+	if entry.FailedAt.IsZero() {
+		return fmt.Errorf("failedAt is required")
+	}
+	switch entry.Reason {
+	case FailedReasonWorkflowFailed, FailedReasonStale:
+	default:
+		return fmt.Errorf("reason must be %q or %q", FailedReasonWorkflowFailed, FailedReasonStale)
+	}
+	if err := validatePublication(entry.Publication); err != nil {
+		return fmt.Errorf("publication: %w", err)
+	}
+	return nil
+}
+
+func IndexContainsVersion(index *Index, appName, version string) bool {
+	if index == nil || len(index.Apps) == 0 {
+		return false
+	}
+	appVersions, ok := index.Apps[strings.TrimSpace(appName)]
+	if !ok {
+		return false
+	}
+	_, ok = appVersions.Versions[strings.TrimSpace(version)]
+	return ok
+}
+
+// PrunePendingIndex moves stale pending entries to failed and drops entries for
+// versions already published. exceptVersion is skipped so a concurrent pending
+// set can refresh that version without stale-pruning it first. The second return
+// value reports whether failed changed.
+func PrunePendingIndex(pending *PendingIndex, failed *FailedIndex, published *Index, now time.Time, exceptVersion string) (bool, bool) {
+	if pending == nil || len(pending.Pending) == 0 {
+		return false, false
+	}
+	exceptVersion = strings.TrimSpace(exceptVersion)
+	if failed == nil {
+		failed = NewEmptyFailedIndex(pending.App)
+	}
+	if failed.Failed == nil {
+		failed.Failed = map[string]FailedVersion{}
+	}
+	now = now.UTC()
+	pendingChanged := false
+	failedChanged := false
+	for version, entry := range pending.Pending {
+		if version == exceptVersion {
+			continue
+		}
+		if IndexContainsVersion(published, pending.App, version) {
+			delete(pending.Pending, version)
+			pendingChanged = true
+			continue
+		}
+		if now.Sub(entry.StartedAt.UTC()) > PendingStaleAfter {
+			failed.Failed[version] = failedVersionFromPending(entry, now, FailedReasonStale)
+			delete(pending.Pending, version)
+			pendingChanged = true
+			failedChanged = true
+		}
+	}
+	return pendingChanged, failedChanged
+}
+
+// PruneFailedIndex removes old or already-published failed entries.
+func PruneFailedIndex(failed *FailedIndex, published *Index, now time.Time) bool {
+	if failed == nil || len(failed.Failed) == 0 {
+		return false
+	}
+	now = now.UTC()
+	changed := false
+	for version, entry := range failed.Failed {
+		if IndexContainsVersion(published, failed.App, version) {
+			delete(failed.Failed, version)
+			changed = true
+			continue
+		}
+		if now.Sub(entry.FailedAt.UTC()) > FailedRetainFor {
+			delete(failed.Failed, version)
+			changed = true
+		}
+	}
+	return changed
+}
+
+func failedVersionFromPending(entry PendingVersion, failedAt time.Time, reason string) FailedVersion {
+	return FailedVersion{
+		Version:     entry.Version,
+		SourceRef:   entry.SourceRef,
+		Repository:  entry.Repository,
+		StartedAt:   entry.StartedAt.UTC(),
+		FailedAt:    failedAt.UTC(),
+		Reason:      reason,
+		Publication: clonePublication(entry.Publication),
+	}
+}
+
+// RemoveFailedVersion deletes one failed entry. The second return value reports
+// whether the version was present.
+func RemoveFailedVersion(index *FailedIndex, version string) bool {
+	if index == nil || index.Failed == nil {
+		return false
+	}
+	version = strings.TrimSpace(version)
+	if _, ok := index.Failed[version]; !ok {
+		return false
+	}
+	delete(index.Failed, version)
+	return true
+}
+
+// UpsertPendingVersion inserts or updates one pending version. startedAt is
+// preserved when the version already exists.
+func UpsertPendingVersion(index *PendingIndex, appName string, version PendingVersion, now time.Time) (*PendingIndex, bool) {
+	if index == nil {
+		index = NewEmptyPendingIndex(appName)
+	}
+	if index.Pending == nil {
+		index.Pending = map[string]PendingVersion{}
+	}
+	now = now.UTC()
+	version.Version = strings.TrimSpace(version.Version)
+	version.SourceRef = strings.ToLower(strings.TrimSpace(version.SourceRef))
+	version.Repository = strings.TrimSpace(version.Repository)
+	version.Phase = PendingPhasePublishing
+	version.UpdatedAt = now
+	if existing, ok := index.Pending[version.Version]; ok {
+		version.StartedAt = existing.StartedAt.UTC()
+	} else {
+		version.StartedAt = now
+	}
+	version.Publication = clonePublication(version.Publication)
+	index.Pending[version.Version] = version
+	return index, true
+}
+
+// RemovePendingVersion deletes one pending version. The second return value
+// reports whether the version was present.
+func RemovePendingVersion(index *PendingIndex, version string) (*PendingVersion, bool) {
+	if index == nil || index.Pending == nil {
+		return nil, false
+	}
+	version = strings.TrimSpace(version)
+	entry, ok := index.Pending[version]
+	if !ok {
+		return nil, false
+	}
+	delete(index.Pending, version)
+	return &entry, true
+}
+
+// RecordFailedVersion writes a failed entry from a removed pending version.
+func RecordFailedVersion(index *FailedIndex, appName string, pending PendingVersion, failedAt time.Time, reason string) (*FailedIndex, bool) {
+	if index == nil {
+		index = NewEmptyFailedIndex(appName)
+	}
+	if index.Failed == nil {
+		index.Failed = map[string]FailedVersion{}
+	}
+	version := strings.TrimSpace(pending.Version)
+	if _, exists := index.Failed[version]; exists {
+		return index, false
+	}
+	index.Failed[version] = failedVersionFromPending(pending, failedAt, reason)
+	return index, true
+}
+
+// PublishStartedAtFromPending returns the pending startedAt timestamp for a
+// version when present.
+func PublishStartedAtFromPending(index *PendingIndex, version string) (time.Time, bool) {
+	if index == nil || index.Pending == nil {
+		return time.Time{}, false
+	}
+	pending, ok := index.Pending[strings.TrimSpace(version)]
+	if !ok || pending.StartedAt.IsZero() {
+		return time.Time{}, false
+	}
+	return pending.StartedAt.UTC(), true
+}
+
+// ApplyPendingSet updates pending and failed catalogs for pending set. It clears
+// a prior failed entry, prunes other versions, and upserts the target version.
+func ApplyPendingSet(pending *PendingIndex, failed *FailedIndex, published *Index, appName string, version PendingVersion, now time.Time) (bool, bool) {
+	versionKey := strings.TrimSpace(version.Version)
+	now = now.UTC()
+
+	pendingChanged := false
+	failedChanged := RemoveFailedVersion(failed, versionKey)
+	prunedPending, prunedFailed := PrunePendingIndex(pending, failed, published, now, versionKey)
+	if prunedPending {
+		pendingChanged = true
+	}
+	if prunedFailed {
+		failedChanged = true
+	}
+	if PruneFailedIndex(failed, published, now) {
+		failedChanged = true
+	}
+	if IndexContainsVersion(published, appName, versionKey) {
+		if _, ok := RemovePendingVersion(pending, versionKey); ok {
+			pendingChanged = true
+		}
+		return pendingChanged, failedChanged
+	}
+	if entry, ok := pending.Pending[versionKey]; ok && now.Sub(entry.StartedAt.UTC()) > PendingStaleAfter {
+		if _, ok := RemovePendingVersion(pending, versionKey); ok {
+			pendingChanged = true
+		}
+	}
+	if _, changed := UpsertPendingVersion(pending, appName, version, now); changed {
+		pendingChanged = true
+	}
+	return pendingChanged, failedChanged
+}

--- a/gestaltd/internal/appregistry/pending_test.go
+++ b/gestaltd/internal/appregistry/pending_test.go
@@ -1,0 +1,543 @@
+package appregistry
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPrunePendingIndex_MovesStaleEntryToFailed(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 24, 20, 0, 0, 0, time.UTC)
+	staleStartedAt := now.Add(-31 * time.Minute)
+	pending := &PendingIndex{
+		SchemaVersion: PendingIndexSchemaVersion,
+		App:           "traffic-cop",
+		Pending: map[string]PendingVersion{
+			"0.0.0-snapshot.gabc123": {
+				Version:   "0.0.0-snapshot.gabc123",
+				SourceRef: "abc123def456abc123def456abc123def456abcd",
+				StartedAt: staleStartedAt,
+				UpdatedAt: now.Add(-30 * time.Minute),
+				Phase:     PendingPhasePublishing,
+			},
+		},
+	}
+	failed := NewEmptyFailedIndex("traffic-cop")
+
+	pendingChanged, failedChanged := PrunePendingIndex(pending, failed, NewEmptyIndex(), now, "")
+	if !pendingChanged || !failedChanged {
+		t.Fatalf("pendingChanged=%v failedChanged=%v", pendingChanged, failedChanged)
+	}
+	if len(pending.Pending) != 0 {
+		t.Fatalf("pending = %#v", pending.Pending)
+	}
+	entry, ok := failed.Failed["0.0.0-snapshot.gabc123"]
+	if !ok {
+		t.Fatalf("failed = %#v", failed.Failed)
+	}
+	if entry.Reason != FailedReasonStale || !entry.FailedAt.Equal(now) {
+		t.Fatalf("failed entry = %#v", entry)
+	}
+}
+
+func TestPrunePendingIndex_KeepsInFlightEntryWithinStaleWindow(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 24, 20, 0, 0, 0, time.UTC)
+	inFlightStartedAt := now.Add(-29 * time.Minute)
+	pending := &PendingIndex{
+		SchemaVersion: PendingIndexSchemaVersion,
+		App:           "traffic-cop",
+		Pending: map[string]PendingVersion{
+			"0.0.0-snapshot.gabc123": {
+				Version:   "0.0.0-snapshot.gabc123",
+				SourceRef: "abc123def456abc123def456abc123def456abcd",
+				StartedAt: inFlightStartedAt,
+				UpdatedAt: inFlightStartedAt,
+				Phase:     PendingPhasePublishing,
+			},
+		},
+	}
+	failed := NewEmptyFailedIndex("traffic-cop")
+
+	pendingChanged, failedChanged := PrunePendingIndex(pending, failed, NewEmptyIndex(), now, "")
+	if pendingChanged || failedChanged {
+		t.Fatalf("pendingChanged=%v failedChanged=%v", pendingChanged, failedChanged)
+	}
+	if len(pending.Pending) != 1 {
+		t.Fatalf("pending = %#v", pending.Pending)
+	}
+}
+
+func TestPrunePendingIndex_SkipsExceptVersion(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 24, 20, 0, 0, 0, time.UTC)
+	staleStartedAt := now.Add(-31 * time.Minute)
+	version := "0.0.0-snapshot.gabc123"
+	pending := &PendingIndex{
+		SchemaVersion: PendingIndexSchemaVersion,
+		App:           "traffic-cop",
+		Pending: map[string]PendingVersion{
+			version: {
+				Version:   version,
+				SourceRef: "abc123def456abc123def456abc123def456abcd",
+				StartedAt: staleStartedAt,
+				UpdatedAt: staleStartedAt,
+				Phase:     PendingPhasePublishing,
+			},
+		},
+	}
+	failed := NewEmptyFailedIndex("traffic-cop")
+
+	pendingChanged, failedChanged := PrunePendingIndex(pending, failed, NewEmptyIndex(), now, version)
+	if pendingChanged || failedChanged {
+		t.Fatalf("pendingChanged=%v failedChanged=%v", pendingChanged, failedChanged)
+	}
+	if len(pending.Pending) != 1 || len(failed.Failed) != 0 {
+		t.Fatalf("pending=%#v failed=%#v", pending.Pending, failed.Failed)
+	}
+}
+
+func TestApplyPendingSet_RetryDoesNotDuplicateStaleFailedEntry(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 24, 20, 0, 0, 0, time.UTC)
+	staleStartedAt := now.Add(-31 * time.Minute)
+	version := "0.0.0-snapshot.gabc123"
+	pending := &PendingIndex{
+		SchemaVersion: PendingIndexSchemaVersion,
+		App:           "traffic-cop",
+		Pending: map[string]PendingVersion{
+			version: {
+				Version:   version,
+				SourceRef: "abc123def456abc123def456abc123def456abcd",
+				StartedAt: staleStartedAt,
+				UpdatedAt: staleStartedAt,
+				Phase:     PendingPhasePublishing,
+			},
+		},
+	}
+	failed := NewEmptyFailedIndex("traffic-cop")
+
+	pendingChanged, failedChanged := ApplyPendingSet(
+		pending,
+		failed,
+		NewEmptyIndex(),
+		"traffic-cop",
+		PendingVersion{
+			Version:   version,
+			SourceRef: "abc123def456abc123def456abc123def456abcd",
+		},
+		now,
+	)
+	if !pendingChanged || failedChanged {
+		t.Fatalf("pendingChanged=%v failedChanged=%v", pendingChanged, failedChanged)
+	}
+	if _, ok := pending.Pending[version]; !ok {
+		t.Fatalf("pending = %#v", pending.Pending)
+	}
+	if _, ok := failed.Failed[version]; ok {
+		t.Fatalf("failed = %#v", failed.Failed)
+	}
+	if !pending.Pending[version].StartedAt.Equal(now) {
+		t.Fatalf("startedAt = %v, want fresh timestamp %v", pending.Pending[version].StartedAt, now)
+	}
+}
+
+func TestApplyPendingSet_SkipsUpsertForPublishedVersion(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 24, 20, 0, 0, 0, time.UTC)
+	version := "0.0.0-snapshot.gabc123"
+	pending := &PendingIndex{
+		SchemaVersion: PendingIndexSchemaVersion,
+		App:           "traffic-cop",
+		Pending: map[string]PendingVersion{
+			version: {
+				Version:   version,
+				SourceRef: "abc123def456abc123def456abc123def456abcd",
+				StartedAt: now.Add(-time.Hour),
+				UpdatedAt: now.Add(-time.Hour),
+				Phase:     PendingPhasePublishing,
+			},
+		},
+	}
+	failed := NewEmptyFailedIndex("traffic-cop")
+	published := &Index{
+		SchemaVersion: IndexSchemaVersion,
+		Apps: map[string]AppVersions{
+			"traffic-cop": {
+				Versions: map[string]IndexVersion{
+					version: {
+						Metadata:    "apps/traffic-cop/versions/" + version + ".json",
+						PublishedAt: now,
+					},
+				},
+			},
+		},
+	}
+
+	pendingChanged, failedChanged := ApplyPendingSet(
+		pending,
+		failed,
+		published,
+		"traffic-cop",
+		PendingVersion{
+			Version:   version,
+			SourceRef: "abc123def456abc123def456abc123def456abcd",
+		},
+		now,
+	)
+	if !pendingChanged || failedChanged {
+		t.Fatalf("pendingChanged=%v failedChanged=%v", pendingChanged, failedChanged)
+	}
+	if len(pending.Pending) != 0 {
+		t.Fatalf("pending = %#v", pending.Pending)
+	}
+}
+
+func TestApplyPendingSet_PersistsFailedPrune(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 24, 20, 0, 0, 0, time.UTC)
+	staleVersion := "0.0.0-snapshot.gstale"
+	activeVersion := "0.0.0-snapshot.gactive"
+	pending := &PendingIndex{
+		SchemaVersion: PendingIndexSchemaVersion,
+		App:           "traffic-cop",
+		Pending: map[string]PendingVersion{
+			staleVersion: {
+				Version:   staleVersion,
+				SourceRef: "abc123def456abc123def456abc123def456abcd",
+				StartedAt: now.Add(-31 * time.Minute),
+				UpdatedAt: now.Add(-31 * time.Minute),
+				Phase:     PendingPhasePublishing,
+			},
+		},
+	}
+	failed := NewEmptyFailedIndex("traffic-cop")
+
+	pendingChanged, failedChanged := ApplyPendingSet(
+		pending,
+		failed,
+		NewEmptyIndex(),
+		"traffic-cop",
+		PendingVersion{
+			Version:   activeVersion,
+			SourceRef: "def456def456def456def456def456def456def4",
+		},
+		now,
+	)
+	if !pendingChanged || !failedChanged {
+		t.Fatalf("pendingChanged=%v failedChanged=%v", pendingChanged, failedChanged)
+	}
+	if _, ok := failed.Failed[staleVersion]; !ok {
+		t.Fatalf("failed = %#v", failed.Failed)
+	}
+	if _, ok := pending.Pending[activeVersion]; !ok {
+		t.Fatalf("pending = %#v", pending.Pending)
+	}
+}
+
+func TestRemoveFailedVersion(t *testing.T) {
+	t.Parallel()
+
+	failed := &FailedIndex{
+		Failed: map[string]FailedVersion{
+			"0.0.1": {Version: "0.0.1"},
+		},
+	}
+	if !RemoveFailedVersion(failed, "0.0.1") {
+		t.Fatal("expected remove to succeed")
+	}
+	if len(failed.Failed) != 0 {
+		t.Fatalf("failed = %#v", failed.Failed)
+	}
+	if RemoveFailedVersion(failed, "0.0.1") {
+		t.Fatal("expected second remove to be a no-op")
+	}
+}
+
+func TestPrunePendingIndex_DropsAlreadyPublishedVersion(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	pending := &PendingIndex{
+		SchemaVersion: PendingIndexSchemaVersion,
+		App:           "traffic-cop",
+		Pending: map[string]PendingVersion{
+			"0.0.0-snapshot.gabc123": {
+				Version:   "0.0.0-snapshot.gabc123",
+				SourceRef: "abc123def456abc123def456abc123def456abcd",
+				StartedAt: now,
+				UpdatedAt: now,
+				Phase:     PendingPhasePublishing,
+			},
+		},
+	}
+	published := &Index{
+		SchemaVersion: IndexSchemaVersion,
+		Apps: map[string]AppVersions{
+			"traffic-cop": {
+				Versions: map[string]IndexVersion{
+					"0.0.0-snapshot.gabc123": {
+						Metadata:    "apps/traffic-cop/versions/0.0.0-snapshot.gabc123.json",
+						PublishedAt: now,
+					},
+				},
+			},
+		},
+	}
+
+	pendingChanged, failedChanged := PrunePendingIndex(pending, NewEmptyFailedIndex("traffic-cop"), published, now, "")
+	if !pendingChanged || failedChanged {
+		t.Fatalf("pendingChanged=%v failedChanged=%v", pendingChanged, failedChanged)
+	}
+	if len(pending.Pending) != 0 {
+		t.Fatalf("pending = %#v", pending.Pending)
+	}
+}
+
+func TestPruneFailedIndex_RemovesOldAndPublishedEntries(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 24, 0, 0, 0, 0, time.UTC)
+	failed := &FailedIndex{
+		SchemaVersion: FailedIndexSchemaVersion,
+		App:           "traffic-cop",
+		Failed: map[string]FailedVersion{
+			"0.0.0-snapshot.gold": {
+				Version:   "0.0.0-snapshot.gold",
+				SourceRef: "abc123def456abc123def456abc123def456abcd",
+				StartedAt: now.Add(-40 * 24 * time.Hour),
+				FailedAt:  now.Add(-31 * 24 * time.Hour),
+				Reason:    FailedReasonWorkflowFailed,
+			},
+			"0.0.0-snapshot.gpublished": {
+				Version:   "0.0.0-snapshot.gpublished",
+				SourceRef: "def456def456def456def456def456def456def4",
+				StartedAt: now.Add(-time.Hour),
+				FailedAt:  now.Add(-time.Hour),
+				Reason:    FailedReasonWorkflowFailed,
+			},
+		},
+	}
+	published := &Index{
+		SchemaVersion: IndexSchemaVersion,
+		Apps: map[string]AppVersions{
+			"traffic-cop": {
+				Versions: map[string]IndexVersion{
+					"0.0.0-snapshot.gpublished": {
+						Metadata:    "apps/traffic-cop/versions/0.0.0-snapshot.gpublished.json",
+						PublishedAt: now,
+					},
+				},
+			},
+		},
+	}
+
+	if !PruneFailedIndex(failed, published, now) {
+		t.Fatal("expected prune to change failed index")
+	}
+	if len(failed.Failed) != 0 {
+		t.Fatalf("failed = %#v", failed.Failed)
+	}
+}
+
+func TestUpsertPendingVersion_PreservesStartedAt(t *testing.T) {
+	t.Parallel()
+
+	startedAt := time.Date(2026, 7, 24, 19, 0, 0, 0, time.UTC)
+	updatedAt := startedAt.Add(2 * time.Minute)
+	index := &PendingIndex{
+		SchemaVersion: PendingIndexSchemaVersion,
+		App:           "traffic-cop",
+		Pending: map[string]PendingVersion{
+			"0.0.0-snapshot.gabc123": {
+				Version:   "0.0.0-snapshot.gabc123",
+				SourceRef: "abc123def456abc123def456abc123def456abcd",
+				StartedAt: startedAt,
+				UpdatedAt: startedAt,
+				Phase:     PendingPhasePublishing,
+			},
+		},
+	}
+
+	updated, changed := UpsertPendingVersion(index, "traffic-cop", PendingVersion{
+		Version:   "0.0.0-snapshot.gabc123",
+		SourceRef: "abc123def456abc123def456abc123def456abcd",
+	}, updatedAt)
+	if !changed {
+		t.Fatal("expected upsert to report change")
+	}
+	entry := updated.Pending["0.0.0-snapshot.gabc123"]
+	if !entry.StartedAt.Equal(startedAt) || !entry.UpdatedAt.Equal(updatedAt) {
+		t.Fatalf("entry = %#v", entry)
+	}
+}
+
+func TestDecodePendingAndFailedIndexRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 24, 19, 0, 0, 0, time.UTC)
+	pending := &PendingIndex{
+		SchemaVersion: PendingIndexSchemaVersion,
+		App:           "traffic-cop",
+		Pending: map[string]PendingVersion{
+			"0.0.0-snapshot.gabc123": {
+				Version:    "0.0.0-snapshot.gabc123",
+				SourceRef:  "abc123def456abc123def456abc123def456abcd",
+				Repository: "github.com/valon-technologies/toolshed",
+				StartedAt:  now,
+				UpdatedAt:  now,
+				Phase:      PendingPhasePublishing,
+			},
+		},
+	}
+	pendingData, err := json.Marshal(pending)
+	if err != nil {
+		t.Fatalf("marshal pending: %v", err)
+	}
+	decodedPending, err := DecodePendingIndex(pendingData)
+	if err != nil {
+		t.Fatalf("DecodePendingIndex: %v", err)
+	}
+	if len(decodedPending.Pending) != 1 {
+		t.Fatalf("decoded pending = %#v", decodedPending.Pending)
+	}
+
+	failed := &FailedIndex{
+		SchemaVersion: FailedIndexSchemaVersion,
+		App:           "traffic-cop",
+		Failed: map[string]FailedVersion{
+			"0.0.0-snapshot.gabc123": {
+				Version:   "0.0.0-snapshot.gabc123",
+				SourceRef: "abc123def456abc123def456abc123def456abcd",
+				StartedAt: now,
+				FailedAt:  now.Add(time.Minute),
+				Reason:    FailedReasonStale,
+			},
+		},
+	}
+	failedData, err := json.Marshal(failed)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	decodedFailed, err := DecodeFailedIndex(failedData)
+	if err != nil {
+		t.Fatalf("DecodeFailedIndex: %v", err)
+	}
+	if len(decodedFailed.Failed) != 1 {
+		t.Fatalf("decoded failed = %#v", decodedFailed.Failed)
+	}
+}
+
+func TestRecordFailedVersion_IsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	pending := PendingVersion{
+		Version:   "0.0.0-snapshot.gabc123",
+		SourceRef: "abc123def456abc123def456abc123def456abcd",
+		StartedAt: now,
+		UpdatedAt: now,
+		Phase:     PendingPhasePublishing,
+	}
+	index := NewEmptyFailedIndex("traffic-cop")
+
+	updated, changed := RecordFailedVersion(index, "traffic-cop", pending, now, FailedReasonWorkflowFailed)
+	if !changed {
+		t.Fatal("expected first record to change failed index")
+	}
+	_, changed = RecordFailedVersion(updated, "traffic-cop", pending, now.Add(time.Minute), FailedReasonWorkflowFailed)
+	if changed {
+		t.Fatal("expected second record to be a no-op")
+	}
+}
+
+func TestPublishStartedAtFromPending(t *testing.T) {
+	t.Parallel()
+
+	startedAt := time.Date(2026, 7, 24, 19, 0, 0, 0, time.UTC)
+	index := &PendingIndex{
+		Pending: map[string]PendingVersion{
+			"0.0.1": {Version: "0.0.1", StartedAt: startedAt},
+		},
+	}
+
+	got, ok := PublishStartedAtFromPending(index, "0.0.1")
+	if !ok || !got.Equal(startedAt) {
+		t.Fatalf("PublishStartedAtFromPending() = (%v, %v), want (%v, true)", got, ok, startedAt)
+	}
+	if _, ok := PublishStartedAtFromPending(index, "missing"); ok {
+		t.Fatal("expected missing version to return false")
+	}
+	if _, ok := PublishStartedAtFromPending(nil, "0.0.1"); ok {
+		t.Fatal("expected nil index to return false")
+	}
+}
+
+func TestUpsertAppIndex_CopiesPublishStartedAt(t *testing.T) {
+	t.Parallel()
+
+	startedAt := time.Date(2026, 7, 24, 19, 0, 0, 0, time.UTC)
+	publishStartedAt := startedAt
+	entry := Entry{
+		SchemaVersion:    EntrySchemaVersion,
+		App:              "traffic-cop",
+		Version:          "0.0.1",
+		SourceRef:        "651a5c30feb995c9364c38f63d0d5c3880bc2055",
+		ManifestPath:     "apps/traffic-cop/manifest.yaml",
+		Repository:       "github.com/valon-technologies/valon-tools",
+		PublishedAt:      time.Date(2026, 7, 24, 19, 4, 32, 0, time.UTC),
+		PublishStartedAt: &publishStartedAt,
+		Artifacts: map[string]Artifact{
+			"linux/amd64": {
+				URL:       "https://example.com/artifact.tar.gz",
+				PublicURL: "https://example.com/artifact.tar.gz",
+				SHA256:    "deadbeef",
+			},
+		},
+	}
+
+	index, changed, err := UpsertAppIndex(NewEmptyIndex(), entry, "apps/traffic-cop/versions/0.0.1.json", "", "")
+	if err != nil || !changed {
+		t.Fatalf("UpsertAppIndex() = changed %v, err %v", changed, err)
+	}
+	got := index.Apps["traffic-cop"].Versions["0.0.1"]
+	if got.PublishStartedAt == nil || !got.PublishStartedAt.Equal(startedAt) {
+		t.Fatalf("index publishStartedAt = %v, want %v", got.PublishStartedAt, startedAt)
+	}
+}
+
+func TestEntry_OmitsZeroPublishStartedAt(t *testing.T) {
+	t.Parallel()
+
+	entry := Entry{
+		SchemaVersion: EntrySchemaVersion,
+		App:           "traffic-cop",
+		Version:       "0.0.1",
+		SourceRef:     "651a5c30feb995c9364c38f63d0d5c3880bc2055",
+		ManifestPath:  "apps/traffic-cop/manifest.yaml",
+		Repository:    "github.com/valon-technologies/valon-tools",
+		PublishedAt:   time.Date(2026, 7, 24, 19, 4, 32, 0, time.UTC),
+		Artifacts: map[string]Artifact{
+			"linux/amd64": {
+				URL:       "https://example.com/artifact.tar.gz",
+				PublicURL: "https://example.com/artifact.tar.gz",
+				SHA256:    "deadbeef",
+			},
+		},
+	}
+	data, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("marshal entry: %v", err)
+	}
+	if strings.Contains(string(data), "publishStartedAt") {
+		t.Fatalf("entry JSON should omit publishStartedAt: %s", data)
+	}
+}

--- a/gestaltd/internal/appregistry/reader.go
+++ b/gestaltd/internal/appregistry/reader.go
@@ -126,7 +126,8 @@ func VersionsFromIndex(index *Index, appName string) []VersionSummary {
 		return []VersionSummary{}
 	}
 	out := make([]VersionSummary, 0, len(appVersions.Versions))
-	for version, summary := range appVersions.Versions {
+	for version := range appVersions.Versions {
+		summary := appVersions.Versions[version]
 		out = append(out, VersionSummary{
 			Version:     version,
 			Metadata:    summary.Metadata,

--- a/gestaltd/internal/appregistry/registry.go
+++ b/gestaltd/internal/appregistry/registry.go
@@ -39,27 +39,29 @@ type AppVersions struct {
 }
 
 type IndexVersion struct {
-	Metadata    string       `json:"metadata"`
-	Platforms   []string     `json:"platforms,omitempty"`
-	PublishedAt time.Time    `json:"publishedAt"`
-	SourceRef   string       `json:"sourceRef,omitempty"`
-	Repository  string       `json:"repository,omitempty"`
-	Publication *Publication `json:"publication,omitempty"`
+	Metadata         string       `json:"metadata"`
+	Platforms        []string     `json:"platforms,omitempty"`
+	PublishedAt      time.Time    `json:"publishedAt"`
+	PublishStartedAt *time.Time   `json:"publishStartedAt,omitempty"`
+	SourceRef        string       `json:"sourceRef,omitempty"`
+	Repository       string       `json:"repository,omitempty"`
+	Publication      *Publication `json:"publication,omitempty"`
 }
 
 type Entry struct {
-	SchemaVersion int                 `json:"schemaVersion"`
-	App           string              `json:"app"`
-	Version       string              `json:"version"`
-	SourceRef     string              `json:"sourceRef"`
-	ManifestPath  string              `json:"manifestPath"`
-	Repository    string              `json:"repository"`
-	Publication   *Publication        `json:"publication,omitempty"`
-	Artifacts     map[string]Artifact `json:"artifacts"`
-	Interface     Interface           `json:"interface,omitempty"`
-	Requires      Requires            `json:"requires,omitempty"`
-	Compatibility Compatibility       `json:"compatibility,omitempty"`
-	PublishedAt   time.Time           `json:"publishedAt"`
+	SchemaVersion    int                 `json:"schemaVersion"`
+	App              string              `json:"app"`
+	Version          string              `json:"version"`
+	SourceRef        string              `json:"sourceRef"`
+	ManifestPath     string              `json:"manifestPath"`
+	Repository       string              `json:"repository"`
+	Publication      *Publication        `json:"publication,omitempty"`
+	Artifacts        map[string]Artifact `json:"artifacts"`
+	Interface        Interface           `json:"interface,omitempty"`
+	Requires         Requires            `json:"requires,omitempty"`
+	Compatibility    Compatibility       `json:"compatibility,omitempty"`
+	PublishedAt      time.Time           `json:"publishedAt"`
+	PublishStartedAt *time.Time          `json:"publishStartedAt,omitempty"`
 }
 
 type Publication struct {
@@ -159,6 +161,11 @@ func AppNameFromManifestSource(source string) (string, error) {
 	return appName, err
 }
 
+func RepositoryFromManifestSource(source string) (string, error) {
+	_, repository, err := parseAppSource(source)
+	return repository, err
+}
+
 // RequirementAppName normalizes a requires.apps map key to the short fleet app name.
 // Manifest dependencies may use full source addresses (github.com/acme/apps/base)
 // while fleet catalog entries use short names (base).
@@ -251,6 +258,10 @@ func BuildEntry(input BuildEntryInput) (Entry, error) {
 		Compatibility: compatibility,
 		PublishedAt:   publishedAt.UTC(),
 	}
+	if !input.PublishStartedAt.IsZero() {
+		startedAt := input.PublishStartedAt.UTC()
+		entry.PublishStartedAt = &startedAt
+	}
 	if err := validateEntry(&entry); err != nil {
 		return Entry{}, err
 	}
@@ -258,14 +269,15 @@ func BuildEntry(input BuildEntryInput) (Entry, error) {
 }
 
 type BuildEntryInput struct {
-	Manifest     *providermanifestv1.Manifest
-	Version      string
-	SourceRef    string
-	ManifestPath string
-	Publication  *Publication
-	Release      *providerrelease.Metadata
-	Artifacts    []PublishArtifact
-	PublishedAt  time.Time
+	Manifest         *providermanifestv1.Manifest
+	Version          string
+	SourceRef        string
+	ManifestPath     string
+	Publication      *Publication
+	Release          *providerrelease.Metadata
+	Artifacts        []PublishArtifact
+	PublishedAt      time.Time
+	PublishStartedAt time.Time
 }
 
 func buildArtifacts(artifacts []PublishArtifact) (map[string]Artifact, error) {
@@ -362,10 +374,12 @@ func requiresFromProviderRelease(requires providerrelease.Requires) Requires {
 }
 
 // EntriesEqualIgnoringPublishedAt reports whether two entries are identical except
-// for publishedAt, which is ignored for idempotent republish checks.
+// for publishedAt and publishStartedAt, which are ignored for idempotent republish checks.
 func EntriesEqualIgnoringPublishedAt(a, b Entry) bool {
 	a.PublishedAt = time.Time{}
 	b.PublishedAt = time.Time{}
+	a.PublishStartedAt = nil
+	b.PublishStartedAt = nil
 	aData, err := json.Marshal(a)
 	if err != nil {
 		return false
@@ -454,7 +468,8 @@ func validateIndex(index *Index) error {
 		if len(app.Versions) == 0 {
 			return fmt.Errorf("app registry index app %q has no versions", appName)
 		}
-		for version, release := range app.Versions {
+		for version := range app.Versions {
+			release := app.Versions[version]
 			if err := source.ValidateVersion(version); err != nil {
 				return fmt.Errorf("app registry index app %q version %q is invalid: %w", appName, version, err)
 			}
@@ -572,7 +587,7 @@ func UpsertAppIndex(index *Index, entry Entry, metadataPath string, displayName,
 	applyAppIndexAppMetadata(&app, displayName, description)
 	platforms := artifactPlatforms(entry.Artifacts)
 	sort.Strings(platforms)
-	app.Versions[entry.Version] = IndexVersion{
+	indexVersion := IndexVersion{
 		Metadata:    strings.TrimSpace(metadataPath),
 		Platforms:   platforms,
 		PublishedAt: entry.PublishedAt.UTC(),
@@ -580,6 +595,11 @@ func UpsertAppIndex(index *Index, entry Entry, metadataPath string, displayName,
 		Repository:  strings.TrimSpace(entry.Repository),
 		Publication: clonePublication(entry.Publication),
 	}
+	if entry.PublishStartedAt != nil && !entry.PublishStartedAt.IsZero() {
+		startedAt := entry.PublishStartedAt.UTC()
+		indexVersion.PublishStartedAt = &startedAt
+	}
+	app.Versions[entry.Version] = indexVersion
 	index.Apps[appName] = app
 	if err := validateIndex(index); err != nil {
 		return nil, false, err

--- a/gestaltd/internal/config/app_registry_config.go
+++ b/gestaltd/internal/config/app_registry_config.go
@@ -37,7 +37,7 @@ func (c *AppRegistryConfig) UnmarshalYAML(value *yaml.Node) error {
 			case "publicUrl":
 				return fmt.Errorf("app registry publicUrl is derived from gcs.bucket")
 			case "publish":
-				return fmt.Errorf("app registry publish targets are passed to gestaltd app publish via --bucket")
+				return fmt.Errorf("app registry publish targets are passed to gestaltd app registry publish via --bucket")
 			}
 		}
 	}

--- a/gestaltd/internal/daemon/app.go
+++ b/gestaltd/internal/daemon/app.go
@@ -7,6 +7,8 @@ import (
 	"os"
 )
 
+const appPublishDeprecatedMessage = "gestaltd app publish is deprecated; use gestaltd app registry publish"
+
 func runApp(args []string) error {
 	if len(args) == 0 {
 		printAppUsage(os.Stderr)
@@ -17,7 +19,10 @@ func runApp(args []string) error {
 	case "-h", "--help", "help":
 		printAppUsage(os.Stderr)
 		return flag.ErrHelp
+	case "registry":
+		return runAppRegistry(args[1:])
 	case "publish":
+		_, _ = fmt.Fprintln(os.Stderr, appPublishDeprecatedMessage)
 		return runAppPublish(args[1:])
 	default:
 		return fmt.Errorf("unknown app command %q", args[0])
@@ -29,5 +34,6 @@ func printAppUsage(w io.Writer) {
 	writeUsageLine(w, "  gestaltd app <command> [flags]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Commands:")
-	writeUsageLine(w, "  publish     Publish an installable app version to a configured app registry")
+	writeUsageLine(w, "  registry    Manage app registry catalogs and publishes")
+	writeUsageLine(w, "  publish     Deprecated alias for registry publish")
 }

--- a/gestaltd/internal/daemon/app_publish.go
+++ b/gestaltd/internal/daemon/app_publish.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/valon-technologies/gestalt/server/internal/appregistry"
 	"github.com/valon-technologies/gestalt/server/internal/config"
@@ -62,9 +63,13 @@ type appPublishObject struct {
 	SHA256     string `json:"sha256,omitempty"`
 }
 
-func runAppPublish(args []string) (err error) {
-	fs := flag.NewFlagSet("gestaltd app publish", flag.ContinueOnError)
-	fs.Usage = func() { printAppPublishUsage(fs.Output()) }
+func runAppPublish(args []string) error {
+	return runAppPublishCommand("gestaltd app publish", printAppPublishUsage, args)
+}
+
+func runAppPublishCommand(commandName string, usage func(io.Writer), args []string) error {
+	fs := flag.NewFlagSet(commandName, flag.ContinueOnError)
+	fs.Usage = func() { usage(fs.Output()) }
 	bucket := fs.String("bucket", "", "GCS bucket name for registry uploads")
 	appName := fs.String("app", "", "app name under apps/{app}/manifest.yaml")
 	version := fs.String("version", "", "semantic version guard")
@@ -168,18 +173,21 @@ func runAppPublish(args []string) (err error) {
 		return err
 	}
 
+	publishStartedAt := loadAppRegistryPublishStartedAt(registry, strings.TrimSpace(*appName), strings.TrimSpace(*version))
+
 	plan, err := buildAppPublishPlan(appPublishPlanInput{
-		Registry:     registry,
-		DisplayName:  sourceManifest.DisplayName,
-		Description:  sourceManifest.Description,
-		Version:      *version,
-		SourceRef:    sourceRef,
-		ManifestPath: sourceInfo.ManifestPath,
-		Publication:  publication,
-		Manifest:     sourceManifest,
-		Release:      releaseMetadata,
-		Archives:     releaseArchives,
-		MetadataPath: filepath.Join(tmpDir, providerrelease.MetadataFile),
+		Registry:         registry,
+		DisplayName:      sourceManifest.DisplayName,
+		Description:      sourceManifest.Description,
+		Version:          *version,
+		SourceRef:        sourceRef,
+		ManifestPath:     sourceInfo.ManifestPath,
+		Publication:      publication,
+		Manifest:         sourceManifest,
+		Release:          releaseMetadata,
+		Archives:         releaseArchives,
+		MetadataPath:     filepath.Join(tmpDir, providerrelease.MetadataFile),
+		PublishStartedAt: publishStartedAt,
 	})
 	if err != nil {
 		return err
@@ -326,17 +334,18 @@ func gitRootFromWorkingDirectory() (string, error) {
 }
 
 type appPublishPlanInput struct {
-	Registry     config.AppRegistryConfig
-	DisplayName  string
-	Description  string
-	Version      string
-	SourceRef    string
-	ManifestPath string
-	Publication  *appregistry.Publication
-	Manifest     *providermanifestv1.Manifest
-	Release      *providerrelease.Metadata
-	Archives     []releaseArchive
-	MetadataPath string
+	Registry         config.AppRegistryConfig
+	DisplayName      string
+	Description      string
+	Version          string
+	SourceRef        string
+	ManifestPath     string
+	Publication      *appregistry.Publication
+	Manifest         *providermanifestv1.Manifest
+	Release          *providerrelease.Metadata
+	Archives         []releaseArchive
+	MetadataPath     string
+	PublishStartedAt time.Time
 }
 
 func buildAppPublishPlan(input appPublishPlanInput) (appPublishPlan, error) {
@@ -391,13 +400,14 @@ func buildAppPublishPlan(input appPublishPlanInput) (appPublishPlan, error) {
 	}
 
 	entry, err := appregistry.BuildEntry(appregistry.BuildEntryInput{
-		Manifest:     input.Manifest,
-		Version:      input.Version,
-		SourceRef:    input.SourceRef,
-		ManifestPath: input.ManifestPath,
-		Publication:  input.Publication,
-		Release:      input.Release,
-		Artifacts:    publishArtifacts,
+		Manifest:         input.Manifest,
+		Version:          input.Version,
+		SourceRef:        input.SourceRef,
+		ManifestPath:     input.ManifestPath,
+		Publication:      input.Publication,
+		Release:          input.Release,
+		Artifacts:        publishArtifacts,
+		PublishStartedAt: input.PublishStartedAt,
 	})
 	if err != nil {
 		return appPublishPlan{}, err
@@ -670,6 +680,27 @@ func appPublishPreconditionFailed(err error) bool {
 	return strings.Contains(text, "precondition") ||
 		strings.Contains(text, "generation") ||
 		strings.Contains(text, "412")
+}
+
+func loadAppRegistryPublishStartedAt(registry config.AppRegistryConfig, appName, version string) time.Time {
+	storageRoot, err := registry.StorageURL()
+	if err != nil {
+		return time.Time{}
+	}
+	pendingURL := appregistry.StorageURL(storageRoot, appregistry.AppPendingPath(appName))
+	_, pendingData, err := downloadAppRegistryObject(pendingURL)
+	if err != nil || len(pendingData) == 0 {
+		return time.Time{}
+	}
+	pending, err := appregistry.DecodePendingIndex(pendingData)
+	if err != nil {
+		return time.Time{}
+	}
+	startedAt, ok := appregistry.PublishStartedAtFromPending(pending, version)
+	if !ok {
+		return time.Time{}
+	}
+	return startedAt
 }
 
 func downloadAppRegistryObject(storageURL string) (int64, []byte, error) {

--- a/gestaltd/internal/daemon/app_registry.go
+++ b/gestaltd/internal/daemon/app_registry.go
@@ -1,0 +1,36 @@
+package daemon
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+)
+
+func runAppRegistry(args []string) error {
+	if len(args) == 0 {
+		printAppRegistryUsage(os.Stderr)
+		return flag.ErrHelp
+	}
+
+	switch args[0] {
+	case "-h", "--help", "help":
+		printAppRegistryUsage(os.Stderr)
+		return flag.ErrHelp
+	case "publish":
+		return runAppRegistryPublish(args[1:])
+	case "pending":
+		return runAppRegistryPending(args[1:])
+	default:
+		return fmt.Errorf("unknown app registry command %q", args[0])
+	}
+}
+
+func printAppRegistryUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd app registry <command> [flags]")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Commands:")
+	writeUsageLine(w, "  publish     Publish an installable app version to a GCS app registry bucket")
+	writeUsageLine(w, "  pending     Record or clear in-flight publish state in pending.json and failed.json")
+}

--- a/gestaltd/internal/daemon/app_registry_pending.go
+++ b/gestaltd/internal/daemon/app_registry_pending.go
@@ -1,0 +1,371 @@
+package daemon
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/internal/appregistry"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/providerregistry"
+)
+
+const appRegistryCatalogUpdateAttempts = 5
+
+type appRegistryPendingFlags struct {
+	bucket           *string
+	appName          *string
+	version          *string
+	ref              *string
+	workflowRunURL   *string
+	triggerPRNumber  *int
+	triggerPRURL     *string
+	triggerPRTitle   *string
+	triggerCommitSHA *string
+	triggerCommitURL *string
+}
+
+func newAppRegistryPendingFlags(fs *flag.FlagSet) appRegistryPendingFlags {
+	return appRegistryPendingFlags{
+		bucket:           fs.String("bucket", "", "GCS bucket name for registry uploads"),
+		appName:          fs.String("app", "", "app name under apps/{app}/manifest.yaml"),
+		version:          fs.String("version", "", "semantic version guard"),
+		ref:              fs.String("ref", "", "full source commit SHA"),
+		workflowRunURL:   fs.String("workflow-run-url", "", "GitHub Actions workflow run URL"),
+		triggerPRNumber:  fs.Int("trigger-pr-number", 0, "pull request number that triggered publication"),
+		triggerPRURL:     fs.String("trigger-pr-url", "", "pull request URL that triggered publication"),
+		triggerPRTitle:   fs.String("trigger-pr-title", "", "pull request title that triggered publication"),
+		triggerCommitSHA: fs.String("trigger-commit-sha", "", "commit SHA that triggered publication"),
+		triggerCommitURL: fs.String("trigger-commit-url", "", "commit URL that triggered publication"),
+	}
+}
+
+func runAppRegistryPending(args []string) error {
+	if len(args) == 0 {
+		printAppRegistryPendingUsage(os.Stderr)
+		return flag.ErrHelp
+	}
+
+	switch args[0] {
+	case "-h", "--help", "help":
+		printAppRegistryPendingUsage(os.Stderr)
+		return flag.ErrHelp
+	case "set":
+		return runAppRegistryPendingSet(args[1:])
+	case "clear":
+		return runAppRegistryPendingClear(args[1:])
+	case "fail":
+		return runAppRegistryPendingFail(args[1:])
+	default:
+		return fmt.Errorf("unknown app registry pending command %q", args[0])
+	}
+}
+
+func runAppRegistryPendingSet(args []string) error {
+	fs := flag.NewFlagSet("gestaltd app registry pending set", flag.ContinueOnError)
+	fs.Usage = func() { printAppRegistryPendingSetUsage(fs.Output()) }
+	flags := newAppRegistryPendingFlags(fs)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() > 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	appName, sourceRef, registry, publication, err := parseAppRegistryPendingWriteFlags(flags, true)
+	if err != nil {
+		return err
+	}
+
+	manifestPath, err := resolveAppPublishManifest(appName)
+	if err != nil {
+		return err
+	}
+	_, sourceManifest, err := readAppPublishManifest(manifestPath)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", manifestPath, err)
+	}
+	manifestApp, err := appregistry.AppNameFromManifestSource(sourceManifest.Source)
+	if err != nil {
+		return fmt.Errorf("%s: invalid manifest source: %w", manifestPath, err)
+	}
+	if manifestApp != appName {
+		return fmt.Errorf("%s: manifest source app %q does not match --app %q", manifestPath, manifestApp, appName)
+	}
+	if err := appregistry.ValidatePublishInput(sourceManifest, *flags.version, sourceRef); err != nil {
+		return err
+	}
+	repository, err := appregistry.RepositoryFromManifestSource(sourceManifest.Source)
+	if err != nil {
+		return fmt.Errorf("%s: invalid manifest source: %w", manifestPath, err)
+	}
+
+	now := time.Now().UTC()
+	pendingVersion := appregistry.PendingVersion{
+		Version:     *flags.version,
+		SourceRef:   sourceRef,
+		Repository:  repository,
+		Publication: publication,
+	}
+
+	return mutateAppRegistryPendingCatalog(registry, appName, sourceRef, func(state *appRegistryPendingCatalogState) error {
+		pendingChanged, failedChanged := appregistry.ApplyPendingSet(
+			state.pending,
+			state.failed,
+			state.published,
+			appName,
+			pendingVersion,
+			now,
+		)
+		if pendingChanged {
+			state.pendingChanged = true
+		}
+		if failedChanged {
+			state.failedChanged = true
+		}
+		return nil
+	})
+}
+
+func runAppRegistryPendingClear(args []string) error {
+	fs := flag.NewFlagSet("gestaltd app registry pending clear", flag.ContinueOnError)
+	fs.Usage = func() { printAppRegistryPendingClearUsage(fs.Output()) }
+	flags := newAppRegistryPendingFlags(fs)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() > 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	appName, sourceRef, registry, _, err := parseAppRegistryPendingWriteFlags(flags, false)
+	if err != nil {
+		return err
+	}
+
+	return mutateAppRegistryPendingCatalog(registry, appName, sourceRef, func(state *appRegistryPendingCatalogState) error {
+		if _, ok := appregistry.RemovePendingVersion(state.pending, *flags.version); ok {
+			state.pendingChanged = true
+		}
+		return nil
+	})
+}
+
+func runAppRegistryPendingFail(args []string) error {
+	fs := flag.NewFlagSet("gestaltd app registry pending fail", flag.ContinueOnError)
+	fs.Usage = func() { printAppRegistryPendingFailUsage(fs.Output()) }
+	flags := newAppRegistryPendingFlags(fs)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() > 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	appName, sourceRef, registry, _, err := parseAppRegistryPendingWriteFlags(flags, false)
+	if err != nil {
+		return err
+	}
+
+	now := time.Now().UTC()
+	return mutateAppRegistryPendingCatalog(registry, appName, sourceRef, func(state *appRegistryPendingCatalogState) error {
+		removed, ok := appregistry.RemovePendingVersion(state.pending, *flags.version)
+		if !ok {
+			return nil
+		}
+		state.pendingChanged = true
+		if updated, changed := appregistry.RecordFailedVersion(state.failed, appName, *removed, now, appregistry.FailedReasonWorkflowFailed); changed {
+			state.failed = updated
+			state.failedChanged = true
+		}
+		return nil
+	})
+}
+
+func parseAppRegistryPendingWriteFlags(flags appRegistryPendingFlags, requireRef bool) (appName, sourceRef string, registry config.AppRegistryConfig, publication *appregistry.Publication, err error) {
+	if strings.TrimSpace(*flags.bucket) == "" {
+		return "", "", config.AppRegistryConfig{}, nil, fmt.Errorf("--bucket is required")
+	}
+	appName = strings.TrimSpace(*flags.appName)
+	if appName == "" {
+		return "", "", config.AppRegistryConfig{}, nil, fmt.Errorf("--app is required")
+	}
+	if err := providerregistry.ValidateRepositoryName(appName); err != nil {
+		return "", "", config.AppRegistryConfig{}, nil, fmt.Errorf("--app: %w", err)
+	}
+	if strings.TrimSpace(*flags.version) == "" {
+		return "", "", config.AppRegistryConfig{}, nil, fmt.Errorf("--version is required")
+	}
+	sourceRef = strings.ToLower(strings.TrimSpace(*flags.ref))
+	if requireRef {
+		if !fullGitSHARe.MatchString(sourceRef) {
+			return "", "", config.AppRegistryConfig{}, nil, fmt.Errorf("--ref must be a 40-character commit SHA")
+		}
+		publication, err = appPublishPublication(
+			*flags.workflowRunURL,
+			*flags.triggerPRNumber,
+			*flags.triggerPRURL,
+			*flags.triggerPRTitle,
+			*flags.triggerCommitSHA,
+			*flags.triggerCommitURL,
+		)
+		if err != nil {
+			return "", "", config.AppRegistryConfig{}, nil, err
+		}
+	}
+	registry, err = config.NewGCSAppRegistry(*flags.bucket)
+	if err != nil {
+		return "", "", config.AppRegistryConfig{}, nil, fmt.Errorf("--bucket: %w", err)
+	}
+	return appName, sourceRef, registry, publication, nil
+}
+
+type appRegistryPendingCatalogState struct {
+	pending        *appregistry.PendingIndex
+	failed         *appregistry.FailedIndex
+	published      *appregistry.Index
+	pendingGen     int64
+	failedGen      int64
+	pendingChanged bool
+	failedChanged  bool
+}
+
+func mutateAppRegistryPendingCatalog(registry config.AppRegistryConfig, appName, sourceRef string, mutate func(*appRegistryPendingCatalogState) error) error {
+	storageRoot, err := registry.StorageURL()
+	if err != nil {
+		return err
+	}
+	pendingURL := appregistry.StorageURL(storageRoot, appregistry.AppPendingPath(appName))
+	failedURL := appregistry.StorageURL(storageRoot, appregistry.AppFailedPath(appName))
+	indexURL := appregistry.StorageURL(storageRoot, appregistry.AppIndexPath(appName))
+
+	for attempt := 1; attempt <= appRegistryCatalogUpdateAttempts; attempt++ {
+		if attempt > 1 {
+			startCommandProgress("").status("App registry pending catalog changed concurrently; retrying attempt %d/%d", attempt, appRegistryCatalogUpdateAttempts)
+		}
+		state, err := loadAppRegistryPendingCatalog(pendingURL, failedURL, indexURL, appName)
+		if err != nil {
+			return err
+		}
+		state.pendingChanged = false
+		state.failedChanged = false
+		if err := mutate(state); err != nil {
+			return err
+		}
+		if !state.pendingChanged && !state.failedChanged {
+			return nil
+		}
+		if state.pendingChanged {
+			if err := uploadAppRegistryCatalogDocument(pendingURL, sourceRef, state.pendingGen, state.pending); err != nil {
+				if appPublishPreconditionFailed(err) && attempt < appRegistryCatalogUpdateAttempts {
+					continue
+				}
+				return err
+			}
+		}
+		if state.failedChanged {
+			if err := uploadAppRegistryCatalogDocument(failedURL, sourceRef, state.failedGen, state.failed); err != nil {
+				if appPublishPreconditionFailed(err) && attempt < appRegistryCatalogUpdateAttempts {
+					continue
+				}
+				return err
+			}
+		}
+		if state.pendingChanged {
+			_, _ = fmt.Fprintf(os.Stdout, "updated %s\n", pendingURL)
+		}
+		if state.failedChanged {
+			_, _ = fmt.Fprintf(os.Stdout, "updated %s\n", failedURL)
+		}
+		return nil
+	}
+	return fmt.Errorf("update pending catalog for %s: exceeded retry limit after concurrent updates", appName)
+}
+
+func loadAppRegistryPendingCatalog(pendingURL, failedURL, indexURL, appName string) (*appRegistryPendingCatalogState, error) {
+	pendingGen, pendingData, err := downloadAppRegistryObject(pendingURL)
+	if err != nil {
+		return nil, err
+	}
+	failedGen, failedData, err := downloadAppRegistryObject(failedURL)
+	if err != nil {
+		return nil, err
+	}
+	_, indexData, err := downloadAppRegistryObject(indexURL)
+	if err != nil {
+		return nil, err
+	}
+
+	state := &appRegistryPendingCatalogState{}
+	if len(pendingData) == 0 {
+		state.pending = appregistry.NewEmptyPendingIndex(appName)
+	} else {
+		state.pending, err = appregistry.DecodePendingIndex(pendingData)
+		if err != nil {
+			return nil, fmt.Errorf("decode pending catalog: %w", err)
+		}
+	}
+	if len(failedData) == 0 {
+		state.failed = appregistry.NewEmptyFailedIndex(appName)
+	} else {
+		state.failed, err = appregistry.DecodeFailedIndex(failedData)
+		if err != nil {
+			return nil, fmt.Errorf("decode failed catalog: %w", err)
+		}
+	}
+	if len(indexData) == 0 {
+		state.published = appregistry.NewEmptyIndex()
+	} else {
+		state.published, err = appregistry.DecodeIndex(indexData)
+		if err != nil {
+			return nil, fmt.Errorf("decode published index: %w", err)
+		}
+	}
+	state.pendingGen = pendingGen
+	state.failedGen = failedGen
+	return state, nil
+}
+
+func uploadAppRegistryCatalogDocument(storageURL, sourceRef string, generation int64, document any) error {
+	data, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmpPath, err := writeTempJSON("gestalt-app-catalog-*", append(data, '\n'))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.Remove(tmpPath) }()
+	if err := uploadAppRegistryIndexFile(tmpPath, storageURL, sourceRef, generation); err != nil {
+		return err
+	}
+	return nil
+}
+
+func printAppRegistryPendingUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd app registry pending <command> [flags]")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Commands:")
+	writeUsageLine(w, "  set     Record an in-flight publish in pending.json")
+	writeUsageLine(w, "  clear   Remove a pending publish on success")
+	writeUsageLine(w, "  fail    Record a failed publish in failed.json")
+}
+
+func printAppRegistryPendingSetUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd app registry pending set --bucket BUCKET --app APP --version VERSION --ref SHA [publication flags]")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Prune stuck pending and old failed entries, then upsert pending.json for VERSION.")
+}
+
+func printAppRegistryPendingClearUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd app registry pending clear --bucket BUCKET --app APP --version VERSION")
+}
+
+func printAppRegistryPendingFailUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd app registry pending fail --bucket BUCKET --app APP --version VERSION")
+}

--- a/gestaltd/internal/daemon/app_registry_publish.go
+++ b/gestaltd/internal/daemon/app_registry_publish.go
@@ -1,0 +1,32 @@
+package daemon
+
+import (
+	"io"
+)
+
+func runAppRegistryPublish(args []string) error {
+	return runAppPublishCommand("gestaltd app registry publish", printAppRegistryPublishUsage, args)
+}
+
+func printAppRegistryPublishUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd app registry publish --bucket BUCKET --app APP --version VERSION --ref SHA --dist-dir DIR [--dist-dir DIR...] [publication flags]")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Publish an installable app version to a GCS app registry bucket.")
+	writeUsageLine(w, "Resolves the source manifest at apps/{app}/manifest.yaml under the git root.")
+	writeUsageLine(w, "Builds immutable version metadata and artifacts under apps/{app}/ in the bucket.")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Flags:")
+	writeUsageLine(w, "  --app        App name (manifest at apps/{app}/manifest.yaml)")
+	writeUsageLine(w, "  --bucket     GCS bucket name or gs:// URL")
+	writeUsageLine(w, "  --dist-dir   Directory containing release archives (repeatable)")
+	writeUsageLine(w, "  --dry-run    Print the upload plan as JSON without writing")
+	writeUsageLine(w, "  --ref        Full source commit SHA")
+	writeUsageLine(w, "  --workflow-run-url      Publishing GitHub Actions run")
+	writeUsageLine(w, "  --trigger-pr-number     Triggering pull request number")
+	writeUsageLine(w, "  --trigger-pr-url        Triggering pull request URL")
+	writeUsageLine(w, "  --trigger-pr-title      Triggering pull request title")
+	writeUsageLine(w, "  --trigger-commit-sha    Triggering commit SHA")
+	writeUsageLine(w, "  --trigger-commit-url    Triggering commit URL")
+	writeUsageLine(w, "  --version    Semantic version guard")
+}

--- a/gestaltd/internal/daemon/e2e/app_publish/app_publish_test.go
+++ b/gestaltd/internal/daemon/e2e/app_publish/app_publish_test.go
@@ -15,6 +15,7 @@ func TestRun_AppPublishDryRunPlansVersionedRegistryUploads(t *testing.T) {
 	rootDir := t.TempDir()
 	pluginDir := newAppRegistryPublishFixture(t, rootDir)
 	initProviderPublishGitRepo(t, rootDir, "https://github.com/testowner/apps.git")
+	fakeGcloudEnv := installFakeGcloudForAppPublishDryRun(t)
 	outputDir := t.TempDir()
 	const version = "0.0.0-snapshot.g651a5c30feb995c9364c38f63d0d5c3880bc2055"
 	const ref = "651a5c30feb995c9364c38f63d0d5c3880bc2055"
@@ -23,7 +24,7 @@ func TestRun_AppPublishDryRunPlansVersionedRegistryUploads(t *testing.T) {
 		"--output", outputDir,
 	)
 
-	stdout, stderr, err := runAppCommandStreams(rootDir,
+	stdout, stderr, err := runAppCommandStreamsWithEnv(rootDir, fakeGcloudEnv,
 		"publish",
 		"--bucket", "gs://gestalt-app-registry",
 		"--app", releaseTestAppName,
@@ -162,5 +163,51 @@ exit 1
 	}
 	if strings.Contains(gotStderr, "not found") || strings.Contains(gotStderr, "precondition failed") {
 		t.Fatalf("raw gcloud diagnostics leaked into normal stderr:\n%s", gotStderr)
+	}
+	if !strings.Contains(gotStderr, "gestaltd app publish is deprecated; use gestaltd app registry publish") {
+		t.Fatalf("app publish stderr missing deprecation warning:\n%s", gotStderr)
+	}
+}
+
+func TestRun_AppRegistryPublishDryRunMatchesDeprecatedAlias(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	pluginDir := newAppRegistryPublishFixture(t, rootDir)
+	initProviderPublishGitRepo(t, rootDir, "https://github.com/testowner/apps.git")
+	fakeGcloudEnv := installFakeGcloudForAppPublishDryRun(t)
+	outputDir := t.TempDir()
+	const version = "0.0.0-snapshot.g651a5c30feb995c9364c38f63d0d5c3880bc2055"
+	const ref = "651a5c30feb995c9364c38f63d0d5c3880bc2055"
+	runProviderPackageCommand(t, pluginDir,
+		"--version", version,
+		"--output", outputDir,
+	)
+
+	stdout, stderr, err := runAppCommandStreamsWithEnv(rootDir, fakeGcloudEnv,
+		"registry", "publish",
+		"--bucket", "gs://gestalt-app-registry",
+		"--app", releaseTestAppName,
+		"--version", version,
+		"--ref", ref,
+		"--dist-dir", outputDir,
+		"--dry-run",
+	)
+	if err != nil {
+		t.Fatalf("app registry publish failed: %v\nstdout=%s\nstderr=%s", err, stdout, stderr)
+	}
+	if strings.Contains(string(stderr), "gestaltd app publish is deprecated") {
+		t.Fatalf("registry publish should not print deprecation warning:\n%s", stderr)
+	}
+	var plan struct {
+		Schema  string `json:"schema"`
+		AppName string `json:"appName"`
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(stdout, &plan); err != nil {
+		t.Fatalf("decode app registry publish plan: %v\nstdout=%s\nstderr=%s", err, stdout, stderr)
+	}
+	if plan.Schema != "gestaltd.app.publish.plan.v1" || plan.AppName != releaseTestAppName || plan.Version != version {
+		t.Fatalf("plan = %#v", plan)
 	}
 }

--- a/gestaltd/internal/daemon/e2e/app_publish/helpers_test.go
+++ b/gestaltd/internal/daemon/e2e/app_publish/helpers_test.go
@@ -20,13 +20,43 @@ const (
 	releaseTestSource  = "github.com/testowner/apps/apps/release-test"
 )
 
+func installFakeGcloudForAppPublishDryRun(t *testing.T) []string {
+	t.Helper()
+
+	binDir := t.TempDir()
+	fakeGcloud := filepath.Join(binDir, "gcloud")
+	if err := os.WriteFile(fakeGcloud, []byte(`#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = "storage" ] && [ "$2" = "objects" ] && [ "$3" = "describe" ]; then
+  echo "not found" >&2
+  exit 1
+fi
+echo "unexpected gcloud command: $*" >&2
+exit 1
+`), 0o755); err != nil {
+		t.Fatalf("write fake gcloud: %v", err)
+	}
+	return []string{"PATH=" + binDir + string(os.PathListSeparator) + os.Getenv("PATH")}
+}
+
 func gestaltdCommand(args ...string) *exec.Cmd {
 	return exec.Command(gestaltdBin, args...)
 }
 
 func runAppCommandStreams(workDir string, args ...string) ([]byte, []byte, error) {
-	cmd := gestaltdCommand(append([]string{"app"}, args...)...)
+	return runAppCommandStreamsWithEnv(workDir, nil, args...)
+}
+
+func runAppCommandStreamsWithEnv(workDir string, extraEnv []string, args ...string) ([]byte, []byte, error) {
+	return runGestaltdCommandStreams(workDir, extraEnv, append([]string{"app"}, args...)...)
+}
+
+func runGestaltdCommandStreams(workDir string, extraEnv []string, args ...string) ([]byte, []byte, error) {
+	cmd := gestaltdCommand(args...)
 	cmd.Dir = workDir
+	if len(extraEnv) > 0 {
+		cmd.Env = append(os.Environ(), extraEnv...)
+	}
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr


### PR DESCRIPTION
## Summary
- Add `pending.json` / `failed.json` catalog types and GCS mutation helpers
- Add `gestaltd app registry pending` and `gestaltd app registry publish` CLI commands
- Replaces direct `app publish` usage for registry workflows

## Test plan
- [x] `go test ./internal/appregistry -run Pending`
- [ ] CI green on main

## Dependencies
Requires docs from #2927 (merged).

Supersedes #2930 (which targeted the docs branch).

Made with [Cursor](https://cursor.com)