### PR TITLE
Document app registry version retention policy

### DIFF
--- a/plans/app_registry/admin.md
+++ b/plans/app_registry/admin.md
@@ -8,6 +8,7 @@ Related docs:
 - [lifecycle.md](./lifecycle.md) — HTTP APIs, admission checks, and rollout behavior
 - [indexeddb.md](./indexeddb.md) — `app_rollouts`, `app_instance_materializations`, change-request projections
 - [pending-publish.md](./pending-publish.md) — in-flight publish visibility on app admin
+- [retention.md](./retention.md) — version cleanup policy and optional retention UI
 - [tests.md](./tests.md#admin-observability-tests) — observability HTTP and UI tests; [app version selection tests](./tests.md#app-version-selection-tests)
 
 ---

--- a/plans/app_registry/config.md
+++ b/plans/app_registry/config.md
@@ -37,8 +37,8 @@ appRegistries:
       bucket: gs://gestalt-app-registry
     retention:
       default:
-        unusedRetention: 72h    # 3 days — never-deployed versions
-        deployedRetention: 168h # 7 days — ever-deployed versions since last use
+        unusedRetention: 72h
+        deployedRetention: 168h
 ```
 
 See [retention.md](./retention.md) for policy semantics, per-app overrides, and

--- a/plans/app_registry/config.md
+++ b/plans/app_registry/config.md
@@ -12,6 +12,7 @@ Related docs:
 - [plan.md](./plan.md) — product goals
 - [lifecycle.md](./lifecycle.md) — replica startup, background controller, admin HTTP API
 - [models.md](./models.md) — JSON documents stored in the registry bucket
+- [retention.md](./retention.md) — version cleanup policy and `retention` config
 - [service.md](./service.md) — Go API for building those documents
 
 Implementation: `gestaltd/internal/config/` (`AppRegistryConfig`, `validateAppRegistries`).
@@ -34,7 +35,14 @@ appRegistries:
     kind: gcs
     gcs:
       bucket: gs://gestalt-app-registry
+    retention:
+      default:
+        unusedRetention: 72h    # 3 days — never-deployed versions
+        deployedRetention: 168h # 7 days — ever-deployed versions since last use
 ```
+
+See [retention.md](./retention.md) for policy semantics, per-app overrides, and
+the `retention.json` overlay.
 
 `gcs.bucket` accepts a bare bucket name or `gs://{bucket}`. Gestalt derives both URL forms:
 

--- a/plans/app_registry/config.md
+++ b/plans/app_registry/config.md
@@ -36,13 +36,12 @@ appRegistries:
     gcs:
       bucket: gs://gestalt-app-registry
     retention:
-      default:
-        unusedRetention: 72h
-        deployedRetention: 168h
+      unusedRetention: 72h
+      deployedRetention: 168h
 ```
 
-See [retention.md](./retention.md) for policy semantics, per-app overrides, and
-the `retention.json` overlay.
+See [retention.md](./retention.md) for policy semantics and the `retention.json`
+overlay.
 
 `gcs.bucket` accepts a bare bucket name or `gs://{bucket}`. Gestalt derives both URL forms:
 

--- a/plans/app_registry/models.md
+++ b/plans/app_registry/models.md
@@ -13,6 +13,7 @@ Immutable app archives live alongside published versions:
 
     apps/{app}/
     ├── index.json
+    ├── retention.json
     ├── pending.json
     ├── failed.json
     ├── versions/
@@ -24,6 +25,7 @@ Immutable app archives live alongside published versions:
 | Document | Path | Purpose |
 |----------|------|---------|
 | **Index** | `apps/{app}/index.json` | Lightweight catalog of published versions |
+| **RetentionIndex** | `apps/{app}/retention.json` | Mutable usage timestamps for retention pruning. See [retention.md](./retention.md). |
 | **PendingIndex** | `apps/{app}/pending.json` | In-flight publishes (not installable). See [pending-publish.md](./pending-publish.md). |
 | **FailedIndex** | `apps/{app}/failed.json` | Recent failed publishes (not installable). See [pending-publish.md](./pending-publish.md). |
 | **PublishedVersion** | `apps/{app}/versions/{version}.json` | Full metadata and install contract for one version |
@@ -288,6 +290,50 @@ Writes use the same optimistic-concurrency pattern as `pending.json`.
 `PruneFailedIndex` removes entries older than 30 days on
 `gestaltd app registry pending set`. See
 [pending-publish.md](./pending-publish.md#prunefailedindex).
+
+---
+
+## RetentionIndex
+
+**Path:** `apps/{app}/retention.json`
+
+Answers: *when was each published version last used, has it ever been deployed,
+and is it operator-pinned?*
+
+Mutable overlay used by retention pruning. Not installable metadata. See
+[retention.md](./retention.md) for policy rules and cleanup scope.
+
+```json
+{
+  "schemaVersion": 1,
+  "versions": {
+    "0.0.0-snapshot.gabc123": {
+      "lastUsedAt": "2026-07-22T14:00:00Z",
+      "firstDeployedAt": "2026-07-22T14:00:00Z",
+      "everDeployed": true,
+      "pinned": false
+    }
+  }
+}
+```
+
+### Fields
+
+#### Root · `RetentionIndex`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `schemaVersion` | int | yes | Retention overlay format version. Currently `1`. |
+| `versions` | map | yes | Version string → `RetentionVersion`. |
+
+#### `RetentionIndex.versions` · `RetentionVersion`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `lastUsedAt` | RFC 3339 timestamp | yes | Last qualifying fleet use; initialized to `publishedAt` on publish. |
+| `firstDeployedAt` | RFC 3339 timestamp | no | First fleet admission. |
+| `everDeployed` | bool | yes | Sticky flag; once true, deployed retention applies. |
+| `pinned` | bool | no | Operator pin; default `false`. |
 
 ---
 

--- a/plans/app_registry/models.md
+++ b/plans/app_registry/models.md
@@ -297,8 +297,7 @@ Writes use the same optimistic-concurrency pattern as `pending.json`.
 
 **Path:** `apps/{app}/retention.json`
 
-Answers: *when was each published version last used, was it ever fleet-known,
-and is it operator-pinned?*
+Answers: *when was each published version last used, and was it ever fleet-known?*
 
 Mutable overlay used by retention pruning. Not installable metadata. See
 [retention.md](./retention.md) for policy rules and cleanup scope.
@@ -310,8 +309,7 @@ Mutable overlay used by retention pruning. Not installable metadata. See
     "0.0.0-snapshot.gabc123": {
       "lastUsedAt": "2026-07-22T14:00:00Z",
       "firstDeployedAt": "2026-07-22T14:00:00Z",
-      "everDeployed": true,
-      "pinned": false
+      "everDeployed": true
     }
   }
 }
@@ -333,7 +331,6 @@ Mutable overlay used by retention pruning. Not installable metadata. See
 | `lastUsedAt` | RFC 3339 timestamp | yes | Last fleet use; initialized to `publishedAt` on publish. |
 | `firstDeployedAt` | RFC 3339 timestamp | no | First fleet admission. |
 | `everDeployed` | bool | yes | Sticky flag; once true, deployed retention applies. |
-| `pinned` | bool | no | Operator pin; default `false`. |
 
 ---
 

--- a/plans/app_registry/models.md
+++ b/plans/app_registry/models.md
@@ -297,7 +297,7 @@ Writes use the same optimistic-concurrency pattern as `pending.json`.
 
 **Path:** `apps/{app}/retention.json`
 
-Answers: *when was each published version last used, has it ever been deployed,
+Answers: *when was each published version last used, was it ever fleet-known,
 and is it operator-pinned?*
 
 Mutable overlay used by retention pruning. Not installable metadata. See
@@ -330,7 +330,7 @@ Mutable overlay used by retention pruning. Not installable metadata. See
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `lastUsedAt` | RFC 3339 timestamp | yes | Last qualifying fleet use; initialized to `publishedAt` on publish. |
+| `lastUsedAt` | RFC 3339 timestamp | yes | Last fleet use; initialized to `publishedAt` on publish. |
 | `firstDeployedAt` | RFC 3339 timestamp | no | First fleet admission. |
 | `everDeployed` | bool | yes | Sticky flag; once true, deployed retention applies. |
 | `pinned` | bool | no | Operator pin; default `false`. |

--- a/plans/app_registry/plan.md
+++ b/plans/app_registry/plan.md
@@ -278,10 +278,11 @@ the app-admin API and snapshots table. See [pending-publish.md](./pending-publis
 ### Version retention and cleanup
 
 Automatically delete published versions that are no longer needed, with
-configurable **default retention** windows: unused versions after 3 days (default),
-ever-deployed versions after 7 days idle since last qualifying use (timer resets
-on reuse). Add `apps/{app}/retention.json`, fleet usage tracking on install, and
-`gestaltd app registry retention prune`. See [retention.md](./retention.md).
+configurable **default retention** windows: unused snapshots after 3 days
+(default), previously fleet-known snapshots after 7 days idle since last fleet
+use (timer resets on reuse). Add `apps/{app}/retention.json`, fleet-use
+tracking on install, and reader-owned `gestaltd app registry retention prune`.
+See [retention.md](./retention.md).
 
 ### Packaged workflow metadata
 

--- a/plans/app_registry/plan.md
+++ b/plans/app_registry/plan.md
@@ -9,6 +9,7 @@ Related references:
 - [validation.md](./validation.md) — install-time validation before fleet accept
 - [admin.md](./admin.md) — admin UI capabilities
 - [models.md](./models.md) — JSON document shapes stored in GCS
+- [retention.md](./retention.md) — version cleanup and default retention policy
 - [service.md](./service.md) — Go package API for publish and validation
 
 ## Registry Responsibilities
@@ -273,6 +274,14 @@ Show in-flight and recently failed CI publishes on `/apps/{app}/admin` before
 and after `index.json` is updated. Add mutable `apps/{app}/pending.json` and
 `apps/{app}/failed.json` in GCS, CI lifecycle hooks, and pending/failed rows in
 the app-admin API and snapshots table. See [pending-publish.md](./pending-publish.md).
+
+### Version retention and cleanup
+
+Automatically delete published versions that are no longer needed, with
+configurable **default retention** windows: unused versions after 3 days (default),
+ever-deployed versions after 7 days idle since last qualifying use (timer resets
+on reuse). Add `apps/{app}/retention.json`, fleet usage tracking on install, and
+`gestaltd app registry retention prune`. See [retention.md](./retention.md).
 
 ### Packaged workflow metadata
 

--- a/plans/app_registry/retention.md
+++ b/plans/app_registry/retention.md
@@ -132,8 +132,8 @@ appRegistries:
       bucket: gitlab-peach-street-gestalt-app-registry
     retention:
       default:
-        unusedRetention: 72h    # 3 days
-        deployedRetention: 168h   # 7 days
+        unusedRetention: 72h
+        deployedRetention: 168h
       apps:
         g-issues:
           unusedRetention: 48h    # optional per-app override

--- a/plans/app_registry/retention.md
+++ b/plans/app_registry/retention.md
@@ -1,288 +1,271 @@
-# App Registry Version Retention
+# Published Version Retention
 
-Automatic cleanup of published app registry versions that are no longer needed,
-with configurable **default retention** windows.
+Delete published app registry versions that are no longer needed, using
+configurable **default retention** windows on the deploy reader registry binding.
 
 Related docs:
 
 - [plan.md](./plan.md) — registry goals and implementation path
-- [models.md](./models.md) — `index.json` and published version documents
-- [config.md](./config.md) — deploy reader config and registry bindings
-- [lifecycle.md](./lifecycle.md) — fleet-known versions, rollouts, and desired version
+- [config.md](./config.md) — `appRegistries` and `retention` fields
+- [models.md](./models.md) — registry JSON documents, including [RetentionIndex](./models.md#retentionindex)
+- [lifecycle.md](./lifecycle.md) — fleet-known versions, rollouts, and `POST …/add` / `POST …/upgrade`
 - [indexeddb.md](./indexeddb.md) — `app_version_change_requests` projection
-- [admin.md](./admin.md) — app admin snapshots UI
-- [pending-publish.md](./pending-publish.md) — pending/failed catalog pruning (separate concern)
+- [admin.md](./admin.md) — **Published snapshots** table on `/apps/{app}/admin`
+- [pending-publish.md](./pending-publish.md) — `pending.json` / `failed.json` pruning (separate concern)
 - [service.md](./service.md) — Go publish/read helpers
-- [tests.md](./tests.md) — test plan additions (future)
+- [tests.md](./tests.md) — retention tests (future)
 
 ## Problem
 
-Published versions and their artifacts accumulate indefinitely in GCS. Each CI
-publish adds immutable `versions/{version}.json` entries and platform archives
-under `artifacts/{version}/`.
+Each CI publish adds immutable `versions/{version}.json` entries and platform
+archives under `artifacts/{version}/`. Nothing removes them today.
 
-Most snapshots are never selected for fleet install. Even versions that were
-deployed once are often superseded quickly. Without retention, operators must
-manually curate the bucket or accept unbounded storage and a noisy admin
-snapshots table.
+Most published snapshots are never fleet-known. Even versions that were desired
+once are often superseded quickly. Without retention, operators must manually
+curate the bucket or accept unbounded storage and a noisy **Published snapshots**
+table on `/apps/{app}/admin`.
 
 ## Goals
 
-Operators should be able to configure a **default retention policy** per registry
-(or per app) so gestaltd can delete eligible versions safely.
+Operators should configure a **default retention policy** per registry (with
+optional per-app overrides) so `gestaltd` can delete eligible published versions
+safely.
 
-The initial policy has two configurable windows:
+| Question | Answer |
+|----------|--------|
+| How long do we keep snapshots nobody installed? | **Unused retention** — default **3 days** (`unusedRetention: 72h`) |
+| How long do we keep snapshots that were fleet-known before? | **Deployed retention** — default **7 days** (`deployedRetention: 168h`) since last fleet use |
+| What resets the idle timer? | Fleet admission (`POST …/add`, `POST …/upgrade`), becoming **desired version**, or an operator pin |
+| What must never be deleted? | **Desired version**, active rollout target, pending publish, operator pin, last published version when the fleet catalog is empty |
 
-| Rule | Default | Meaning |
-|------|---------|---------|
-| **Unused retention** | 3 days | Delete a version that has **never been deployed** and has had **no qualifying use** for this long. |
-| **Deployed retention** | 7 days | Delete a version that **has been deployed before** when it has had **no qualifying use** for this long. |
+Publishing alone does **not** count as fleet use. A snapshot can sit in
+`index.json` without ever becoming fleet-known.
 
-**Qualifying use** resets the retention clock for that version. Deploying a
-version counts as use and also marks it as *ever deployed*.
+## Design summary
 
-Retention must never delete versions that are still required for safe fleet
-operation (current desired version, active rollout target, in-flight publish).
+Add mutable `retention.json` per app in GCS. Scope is registry bucket cleanup —
+not local replica artifact directories (those are already trimmed per replica in
+[lifecycle.md](./lifecycle.md#startup)).
 
-## Definitions
+| Actor | Responsibility |
+|-------|----------------|
+| **Publisher** (`gestaltd app registry publish`) | Append `index.json`, upload immutable version metadata and artifacts, upsert `retention.json` with `lastUsedAt = publishedAt` and `everDeployed = false` |
+| **Reader** (`gestaltd serve` install handlers) | On fleet admission, bump `lastUsedAt` and set `everDeployed` on first admission |
+| **Reader** (`gestaltd app registry retention prune`) | Evaluate policy, consult fleet state, delete eligible published versions from GCS |
 
-### Published version
+Retention policy and prune decisions are **reader-owned**. The publisher only
+seeds retention metadata at publish time. Prune must read deploy config
+(`appRegistries.*.retention`) and fleet state (`desiredVersion`, active
+rollouts) before deleting anything.
 
-A version listed in `apps/{app}/index.json` with a corresponding
-`versions/{version}.json` and artifact objects. Pending and failed catalog
-entries are out of scope for this document; see [pending-publish.md](./pending-publish.md).
+Two idle windows apply per published version:
 
-### Used (qualifying use)
+| Window | Default | Applies when |
+|--------|---------|--------------|
+| **Unused retention** | `72h` | `everDeployed` is false |
+| **Deployed retention** | `168h` | `everDeployed` is true |
 
-A version is **used** at time `T` when any of the following occur:
+At prune time, compare `now - lastUsedAt` against the applicable window.
+`lastUsedAt` falls back to `publishedAt` from `index.json` when absent.
+
+`gestaltd app registry retention prune` removes eligible versions from
+`index.json`, `retention.json`, `versions/{version}.json`, and
+`artifacts/{version}/`. It does **not** touch `pending.json` or `failed.json`.
+
+## Retention policy
+
+### Fleet use
+
+A version is **used** when any of the following occur:
 
 1. **Fleet admission** — a change request is appended with `to_version` equal to
-   this version (`POST …/add` or `POST …/upgrade`). This includes the first
-   install and every re-select of the same version.
+   this version (`POST …/add` or `POST …/upgrade`). Includes first install and
+   every re-select of the same version.
 2. **Desired version** — the version becomes `LatestKnownVersion` for the app
    (including when a rollout completes and the version remains desired).
-3. **Operator retention touch** — an explicit CLI/API call extends retention for
-   a pinned version (optional escape hatch; see [Protected versions](#protected-versions)).
+3. **Operator pin** — `retention.pinned: true` on the overlay entry (optional
+   escape hatch; see [Protected versions](#protected-versions)).
 
-Each qualifying use updates `lastUsedAt` for `(app, version)` in the retention
-overlay (see [Retention overlay](#retention-overlay)).
+Each fleet use updates `lastUsedAt` for `(app, version)` in `retention.json`.
 
-Publishing alone does **not** count as use. A snapshot can exist in the registry
-without ever being fleet-known.
+### Previously fleet-known
 
-### Deployed (ever deployed)
+`everDeployed` is set on first fleet admission and remains true for the lifetime
+of the published version. `firstDeployedAt` records that first admission.
+Previously fleet-known versions use **deployed retention** even after they are
+no longer desired.
 
-A version is **ever deployed** after the first qualifying use that admits it to
-the fleet catalog (rule 1 above). The flag is sticky: once set, the version
-follows **deployed retention** even if it is later superseded.
+### Examples (defaults)
 
-`firstDeployedAt` is recorded on first admission. `lastUsedAt` continues to
-advance on every subsequent qualifying use.
+| Version history | `everDeployed` | `lastUsedAt` | Window | Eligible now? |
+|-----------------|----------------|--------------|--------|---------------|
+| Published 4 days ago, never fleet-known | false | `publishedAt` (4d ago) | unused (`72h`) | yes |
+| Published yesterday, never fleet-known | false | yesterday | unused (`72h`) | no |
+| Fleet-known 10 days ago, idle since | true | 10d ago | deployed (`168h`) | yes |
+| Fleet-known 10 days ago, re-selected yesterday | true | yesterday | deployed (`168h`) | no |
 
-### Retention clock
-
-For each published `(app, version)`, retention evaluation uses:
-
-- `lastUsedAt` — timestamp of the most recent qualifying use; if absent, fall
-  back to `publishedAt` from the index entry.
-- `everDeployed` — whether the version was fleet-admitted at least once.
-
-At evaluation time `now`:
-
-```text
-if everDeployed:
-    eligible when (now - lastUsedAt) >= deployedRetention
-else:
-    eligible when (now - lastUsedAt) >= unusedRetention
-```
-
-Defaults: `unusedRetention = 3 days`, `deployedRetention = 7 days`. Both are
-configurable.
-
-### Examples
-
-| Version history | `everDeployed` | `lastUsedAt` | Policy | Eligible at `now` (defaults) |
-|-----------------|----------------|--------------|--------|------------------------------|
-| Published 4 days ago, never selected | false | `publishedAt` (4d ago) | unused (3d) | yes |
-| Published yesterday, never selected | false | yesterday | unused (3d) | no |
-| Deployed 10 days ago, never touched since | true | 10d ago | deployed (7d) | yes |
-| Deployed 10 days ago, re-selected yesterday | true | yesterday | deployed (7d) | no |
-| Published 5 days ago, deployed 5 days ago, idle since | true | 5d ago | deployed (7d) | no |
-| Published 5 days ago, deployed 5 days ago, idle since | true | 8d ago | deployed (7d) | yes |
-
-## Default retention policy
-
-**Default retention** is the registry-wide baseline. Per-app overrides may
-tighten or relax either window without changing the semantics above.
-
-### Config
+## Config
 
 Retention is configured on the deploy reader registry binding
-(`appRegistries.{name}`). It governs cleanup for apps published to that registry
-bucket, not local replica artifact directories (those are already trimmed per
-replica in [lifecycle.md](./lifecycle.md#startup)).
+(`appRegistries.{name}`). Field definitions and validation:
+[config.md](./config.md).
 
 ```yaml
-apiVersion: gestaltd.config/v8
-
 appRegistries:
   toolshed:
     kind: gcs
     gcs:
-      bucket: gitlab-peach-street-gestalt-app-registry
+      bucket: gs://gestalt-app-registry
     retention:
       default:
         unusedRetention: 72h
         deployedRetention: 168h
       apps:
         g-issues:
-          unusedRetention: 48h    # optional per-app override
-          deployedRetention: 336h # optional per-app override (14 days)
+          unusedRetention: 48h
+          deployedRetention: 336h
 ```
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `retention.default.unusedRetention` | duration | `72h` | Delete never-deployed versions after this idle period. |
-| `retention.default.deployedRetention` | duration | `168h` | Delete ever-deployed versions after this idle period since last use. |
-| `retention.apps.{app}` | object | — | Optional per-app overrides for either field. |
-
-Durations use Go `time.ParseDuration` syntax (`72h`, `168h`, `30m`). Validation
-rejects zero, negative, or `deployedRetention < unusedRetention` when both are
-set at the same scope (deployed grace must be at least as long as unused).
-
-### Precedence
-
-For app `g-issues` on registry `toolshed`:
+Precedence for app `g-issues` on registry `toolshed`:
 
 1. `retention.apps.g-issues.{field}` when set
 2. else `retention.default.{field}`
 3. else built-in default (`72h` / `168h`)
 
-## Protected versions
+Durations use Go `time.ParseDuration` syntax. Validation rejects zero,
+negative values, and `deployedRetention < unusedRetention` at the same scope.
 
-Retention must **not** delete a version while any of the following hold:
+## GCS layout
 
-| Guard | Reason |
-|-------|--------|
-| `version === desiredVersion` | Fleet is pinned to this version. |
-| Active rollout with `version` as target (`enrolling` or `restarting`) | Install in flight. |
-| Pending catalog entry for `version` | Publish not finished. See [pending-publish.md](./pending-publish.md). |
-| `retention.pinned: true` in overlay | Operator pin (optional; bypass until unpinned). |
-| Last published version for the app when `knownVersions` is empty | Prevent bricking a fresh app with no alternatives. |
-
-Protected versions remain in `index.json` until the guard clears and the
-retention clock elapses.
-
-## Retention overlay
-
-Usage timestamps are mutable fleet/registry metadata. They must not be written
-into immutable `versions/{version}.json`.
-
-Add a per-app overlay document:
+Extend the per-app registry tree:
 
 ```text
 apps/{app}/
 ├── index.json
-├── retention.json          # new
+├── retention.json
 ├── pending.json
 ├── failed.json
-└── …
+├── versions/
+│   └── {version}.json
+└── artifacts/
+    └── {version}/
+        └── …
 ```
 
-### `retention.json`
+`retention.json` is a mutable catalog (like `index.json`), not an immutable
+release object. Document shape, fields, and example:
+[models.md — RetentionIndex](./models.md#retentionindex).
 
-```json
-{
-  "schemaVersion": 1,
-  "versions": {
-    "0.0.0-snapshot.gabc123": {
-      "lastUsedAt": "2026-07-22T14:00:00Z",
-      "firstDeployedAt": "2026-07-22T14:00:00Z",
-      "everDeployed": true,
-      "pinned": false
-    },
-    "0.0.0-snapshot.gdef456": {
-      "lastUsedAt": "2026-07-24T09:00:00Z",
-      "everDeployed": false,
-      "pinned": false
-    }
-  }
-}
-```
+Use the same optimistic-concurrency update pattern as other catalog writes:
+read generation, merge, upload with `if-generation-match`.
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `schemaVersion` | int | yes | Currently `1`. |
-| `versions` | map | yes | Version string → `RetentionVersion`. |
-| `versions.{v}.lastUsedAt` | RFC 3339 | yes | Last qualifying use; initialized to `publishedAt` on first index write if absent. |
-| `versions.{v}.firstDeployedAt` | RFC 3339 | no | First fleet admission. |
-| `versions.{v}.everDeployed` | bool | yes | Sticky flag set on first admission. |
-| `versions.{v}.pinned` | bool | no | Operator pin; default `false`. |
+## Write path
 
-`gestaltd app registry publish` appends the version to `index.json` and upserts
-`retention.json` with `lastUsedAt = publishedAt`, `everDeployed = false`.
+### Publish (`gestaltd app registry publish`)
 
-Fleet install handlers update the overlay when appending change requests:
+After uploading `versions/{version}.json` and artifacts, append the version to
+`index.json` and upsert `retention.json`:
 
-- set `lastUsedAt = now`
+- `lastUsedAt = publishedAt`
+- `everDeployed = false`
+
+Publish does not evaluate retention or delete older versions.
+
+### Fleet admission (`POST …/add`, `POST …/upgrade`)
+
+After validation and `AppendRequest`, update `retention.json` for the admitted
+version:
+
+- `lastUsedAt = now`
 - on first admission: `everDeployed = true`, `firstDeployedAt = now`
 
-## Cleanup
+Install handlers do not delete registry objects. Deletion is confined to
+`gestaltd app registry retention prune`.
 
-### Command
+## Prune path
+
+### `gestaltd app registry retention prune`
 
 ```bash
 gestaltd app registry retention prune \
-  --bucket gs://gitlab-peach-street-gestalt-app-registry \
+  --bucket gs://… \
   --app g-issues \
   [--dry-run]
 ```
 
-`prune` loads deploy config (for retention durations and registry name),
-reads `index.json` and `retention.json`, consults fleet state
-(`desiredVersion`, active rollouts, known versions), and deletes eligible
-versions.
-
-### Delete scope
+`prune` loads deploy config (retention durations), reads `index.json` and
+`retention.json`, consults fleet state (`desiredVersion`, active rollouts,
+known versions), and deletes eligible published versions.
 
 For each eligible version, remove:
 
 1. `apps/{app}/versions/{version}.json`
 2. `apps/{app}/artifacts/{version}/` (all platform objects)
-3. The `versions.{version}` entry from `index.json`
-4. The `versions.{version}` entry from `retention.json`
+3. `versions.{version}` from `index.json`
+4. `versions.{version}` from `retention.json`
 
-Use the same optimistic concurrency pattern as `pending set` / index updates
-(read generation, `if-generation-match` on upload).
+Prune is idempotent and safe to re-run. Deleting an already-removed version is
+a no-op.
 
 ### Scheduler
 
-Run retention prune on a schedule per registry (for example daily via
-toolshed/GitHub Actions or a gestaltd cron job). Prune is safe to re-run;
-deleting an already-removed version is a no-op.
+Run retention prune on a schedule from the **deploy reader** side — for example
+a `gestaltd` cron job with deploy config and fleet API access. Prune requires
+fleet guards; publish CI alone is not sufficient.
 
-Recommended order per app:
+Do not run retention prune from `gestaltd serve` request handlers. Like
+[pending-publish.md](./pending-publish.md#self-healing), catalog mutation runs
+on an explicit CLI path with bucket credentials.
+
+Recommended order per app when both run:
 
 1. `gestaltd app registry pending set` prune helpers (existing)
 2. `gestaltd app registry retention prune` (this feature)
 
+## Protected versions
+
+Retention must **not** delete a version while any guard holds:
+
+| Guard | Reason |
+|-------|--------|
+| `version === desiredVersion` | Fleet is pinned to this version |
+| Active rollout with `version` as target (`enrolling` or `restarting`) | Install in flight |
+| Entry in `pending.json` for `version` | Publish not finished. See [pending-publish.md](./pending-publish.md). |
+| `retention.pinned: true` | Operator pin until unpinned |
+| Last published version when `knownVersions` is empty | Prevent bricking a fresh app with no alternatives |
+
+Protected versions remain in `index.json` until the guard clears and the idle
+window elapses.
+
+## Relationship to pending/failed pruning
+
+| Mechanism | Catalog | Threshold | Owner | Purpose |
+|-----------|---------|-----------|-------|---------|
+| `PrunePendingIndex` | `pending.json` | 30 minutes `startedAt` | Publisher (CI `pending set`) | Stale in-flight publishes → `failed.json` |
+| `PruneFailedIndex` | `failed.json` | 30 days `failedAt` | Publisher (CI `pending set`) | Old failed publish records |
+| **Retention prune** | `index.json` + artifacts | configurable idle windows | Reader (`retention prune`) | Remove unused published versions |
+
+Pending/failed pruning does not remove installable published versions.
+Retention prune does not touch `pending.json` or `failed.json`.
+
 ## Admin UI
 
 `/apps/{app}/admin` continues to list published versions from `index.json`.
-Deleted versions disappear on the next poll.
+Deleted versions disappear on the next poll. Wireframes and columns:
+[admin.md](./admin.md#app-admin-ui-appsappadmin).
 
 Optional follow-ups (not required for v1):
 
-- Show `lastUsedAt` in the **Last update** column or a dedicated column when the
-  API exposes retention metadata.
-- Badge versions nearing expiry (`expires in 1d`).
+- Expose `lastUsedAt`, `everDeployed`, and computed `retainsUntil` on the
+  app-admin registry API.
+- Show retention metadata in the **Last update** column or a dedicated column.
 - Pin/unpin control writing `retention.pinned`.
 
 ## Safety and invariants
 
 | Invariant | Enforcement |
 |-----------|-------------|
-| Immutable published contract per version | `versions/{version}.json` is never mutated; retention only deletes whole versions |
+| Published contract per version stays immutable until delete | `versions/{version}.json` is never mutated; retention deletes whole versions only |
 | Fleet cannot install a deleted version | Install validation reads `index.json`; missing entry → 400 |
 | Desired version is never deleted | Prune skips when `version === desiredVersion` |
 | Active rollout target is never deleted | Prune skips non-terminal rollouts for that version |
@@ -290,58 +273,53 @@ Optional follow-ups (not required for v1):
 | Deployed grace ≥ unused grace | Config validation at load |
 | Retention metadata survives publish | `retention.json` upsert on publish; overlay outlives individual prune passes |
 
+Implementation:
+
+- Retention types and prune — `gestaltd/internal/appregistry/retention.go`
+- `gestaltd app registry retention` CLI — `gestaltd/internal/daemon/app_registry_retention.go`
+- Overlay writes on publish — `gestaltd/internal/daemon/app_registry_publish.go`
+- Overlay writes on admission — `gestaltd/internal/server/handlers_admin_app_install.go`
+- Config validation — `gestaltd/internal/config/`
+
 ## Implementation path
 
-Suggested PR stack:
+Four PRs. Merge in order below.
 
-### PR 1 — Models and overlay write path (`gestalt`)
+```text
+PR 1 (gestalt) ──► PR 2 (gestalt) ──► PR 4 (gestalt-providers, optional)
+       │
+       └──────────► PR 3 (deploy scheduler)
+```
 
-- Add `RetentionIndex` / `RetentionVersion` types in
-  `gestaltd/internal/appregistry/`.
-- Document shapes in [models.md](./models.md#retentionindex).
+### PR 1 — Models and write path (`gestalt`)
+
+- Add `RetentionIndex` / `RetentionVersion` to `gestaltd/internal/appregistry/`
+  ([models.md](./models.md#retentionindex) documents shapes).
 - `gestaltd app registry publish` initializes `retention.json` for the new version.
-- Install handlers (`POST …/add`, `POST …/upgrade`) bump `lastUsedAt` and set
-  `everDeployed` on first admission.
-- Config validation for `appRegistries.*.retention` in
-  `gestaltd/internal/config/`.
-- Tests: overlay upsert, admission bumps, config validation.
+- Install handlers bump `lastUsedAt` and set `everDeployed` on first admission.
+- Config validation for `appRegistries.*.retention` in `gestaltd/internal/config/`.
+- Tests: overlay upsert, admission bumps, config validation. Extend
+  [tests.md](./tests.md).
 
 ### PR 2 — Prune command (`gestalt`)
+
+Depends on **PR 1**.
 
 - `gestaltd app registry retention prune` with `--dry-run`.
 - Fleet guard queries (desired version, rollout state).
 - GCS delete of version metadata, artifacts, and index/retention entries.
 - Tests: eligibility matrix, protected versions, dry-run.
 
-### PR 3 — Scheduler (`toolshed` or ops)
+### PR 3 — Scheduler (deploy / ops)
 
-- Scheduled workflow (daily) calling `retention prune` per app in
-  `.github/valon-tools-app-registry-apps.yaml`.
-- Dry-run reporting in CI logs before enabling destructive mode.
+Depends on **PR 2**. Run from the reader side with deploy config and fleet access.
+
+- Scheduled job (daily) calling `retention prune` per registry-only app.
+- Dry-run reporting in logs before enabling destructive mode.
 
 ### PR 4 — Admin API/UI (optional)
 
-- Expose `lastUsedAt`, `everDeployed`, and computed `retainsUntil` on app-admin
-  registry responses.
-- UI column or tooltip for retention status.
+Depends on **PR 2**.
 
-## Relationship to other pruning
-
-| Mechanism | Catalog | Threshold | Purpose |
-|-----------|---------|-----------|---------|
-| `PrunePendingIndex` | `pending.json` | 30 minutes `startedAt` | Stale in-flight publishes → `failed.json` |
-| `PruneFailedIndex` | `failed.json` | 30 days `failedAt` | Old failed publish records |
-| **Retention prune** | `index.json` + artifacts | configurable unused/deployed idle | Remove unused published versions |
-
-Pending/failed pruning does not remove installable published versions.
-Retention prune does not touch `pending.json` or `failed.json`.
-
-## Open questions
-
-1. **Cross-registry apps** — retention is per registry bucket; fleet state is
-   global per deploy. Prune must resolve the registry name from deploy config
-   for each app.
-2. **Minimum catalog size** — whether to retain at least *N* newest published
-   versions regardless of age (not in v1; can add `minVersions: 5` later).
-3. **Audit log** — whether to write deletion events to structured logs or a
-   `apps/{app}/retention-audit.jsonl` before object removal.
+- Expose retention metadata on `GET /api/v1/apps/{app}/admin/registry`.
+- Optional UI column or tooltip on `/apps/{app}/admin`. See [admin.md](./admin.md).

--- a/plans/app_registry/retention.md
+++ b/plans/app_registry/retention.md
@@ -1,0 +1,347 @@
+# App Registry Version Retention
+
+Automatic cleanup of published app registry versions that are no longer needed,
+with configurable **default retention** windows.
+
+Related docs:
+
+- [plan.md](./plan.md) — registry goals and implementation path
+- [models.md](./models.md) — `index.json` and published version documents
+- [config.md](./config.md) — deploy reader config and registry bindings
+- [lifecycle.md](./lifecycle.md) — fleet-known versions, rollouts, and desired version
+- [indexeddb.md](./indexeddb.md) — `app_version_change_requests` projection
+- [admin.md](./admin.md) — app admin snapshots UI
+- [pending-publish.md](./pending-publish.md) — pending/failed catalog pruning (separate concern)
+- [service.md](./service.md) — Go publish/read helpers
+- [tests.md](./tests.md) — test plan additions (future)
+
+## Problem
+
+Published versions and their artifacts accumulate indefinitely in GCS. Each CI
+publish adds immutable `versions/{version}.json` entries and platform archives
+under `artifacts/{version}/`.
+
+Most snapshots are never selected for fleet install. Even versions that were
+deployed once are often superseded quickly. Without retention, operators must
+manually curate the bucket or accept unbounded storage and a noisy admin
+snapshots table.
+
+## Goals
+
+Operators should be able to configure a **default retention policy** per registry
+(or per app) so gestaltd can delete eligible versions safely.
+
+The initial policy has two configurable windows:
+
+| Rule | Default | Meaning |
+|------|---------|---------|
+| **Unused retention** | 3 days | Delete a version that has **never been deployed** and has had **no qualifying use** for this long. |
+| **Deployed retention** | 7 days | Delete a version that **has been deployed before** when it has had **no qualifying use** for this long. |
+
+**Qualifying use** resets the retention clock for that version. Deploying a
+version counts as use and also marks it as *ever deployed*.
+
+Retention must never delete versions that are still required for safe fleet
+operation (current desired version, active rollout target, in-flight publish).
+
+## Definitions
+
+### Published version
+
+A version listed in `apps/{app}/index.json` with a corresponding
+`versions/{version}.json` and artifact objects. Pending and failed catalog
+entries are out of scope for this document; see [pending-publish.md](./pending-publish.md).
+
+### Used (qualifying use)
+
+A version is **used** at time `T` when any of the following occur:
+
+1. **Fleet admission** — a change request is appended with `to_version` equal to
+   this version (`POST …/add` or `POST …/upgrade`). This includes the first
+   install and every re-select of the same version.
+2. **Desired version** — the version becomes `LatestKnownVersion` for the app
+   (including when a rollout completes and the version remains desired).
+3. **Operator retention touch** — an explicit CLI/API call extends retention for
+   a pinned version (optional escape hatch; see [Protected versions](#protected-versions)).
+
+Each qualifying use updates `lastUsedAt` for `(app, version)` in the retention
+overlay (see [Retention overlay](#retention-overlay)).
+
+Publishing alone does **not** count as use. A snapshot can exist in the registry
+without ever being fleet-known.
+
+### Deployed (ever deployed)
+
+A version is **ever deployed** after the first qualifying use that admits it to
+the fleet catalog (rule 1 above). The flag is sticky: once set, the version
+follows **deployed retention** even if it is later superseded.
+
+`firstDeployedAt` is recorded on first admission. `lastUsedAt` continues to
+advance on every subsequent qualifying use.
+
+### Retention clock
+
+For each published `(app, version)`, retention evaluation uses:
+
+- `lastUsedAt` — timestamp of the most recent qualifying use; if absent, fall
+  back to `publishedAt` from the index entry.
+- `everDeployed` — whether the version was fleet-admitted at least once.
+
+At evaluation time `now`:
+
+```text
+if everDeployed:
+    eligible when (now - lastUsedAt) >= deployedRetention
+else:
+    eligible when (now - lastUsedAt) >= unusedRetention
+```
+
+Defaults: `unusedRetention = 3 days`, `deployedRetention = 7 days`. Both are
+configurable.
+
+### Examples
+
+| Version history | `everDeployed` | `lastUsedAt` | Policy | Eligible at `now` (defaults) |
+|-----------------|----------------|--------------|--------|------------------------------|
+| Published 4 days ago, never selected | false | `publishedAt` (4d ago) | unused (3d) | yes |
+| Published yesterday, never selected | false | yesterday | unused (3d) | no |
+| Deployed 10 days ago, never touched since | true | 10d ago | deployed (7d) | yes |
+| Deployed 10 days ago, re-selected yesterday | true | yesterday | deployed (7d) | no |
+| Published 5 days ago, deployed 5 days ago, idle since | true | 5d ago | deployed (7d) | no |
+| Published 5 days ago, deployed 5 days ago, idle since | true | 8d ago | deployed (7d) | yes |
+
+## Default retention policy
+
+**Default retention** is the registry-wide baseline. Per-app overrides may
+tighten or relax either window without changing the semantics above.
+
+### Config
+
+Retention is configured on the deploy reader registry binding
+(`appRegistries.{name}`). It governs cleanup for apps published to that registry
+bucket, not local replica artifact directories (those are already trimmed per
+replica in [lifecycle.md](./lifecycle.md#startup)).
+
+```yaml
+apiVersion: gestaltd.config/v8
+
+appRegistries:
+  toolshed:
+    kind: gcs
+    gcs:
+      bucket: gitlab-peach-street-gestalt-app-registry
+    retention:
+      default:
+        unusedRetention: 72h    # 3 days
+        deployedRetention: 168h   # 7 days
+      apps:
+        g-issues:
+          unusedRetention: 48h    # optional per-app override
+          deployedRetention: 336h # optional per-app override (14 days)
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `retention.default.unusedRetention` | duration | `72h` | Delete never-deployed versions after this idle period. |
+| `retention.default.deployedRetention` | duration | `168h` | Delete ever-deployed versions after this idle period since last use. |
+| `retention.apps.{app}` | object | — | Optional per-app overrides for either field. |
+
+Durations use Go `time.ParseDuration` syntax (`72h`, `168h`, `30m`). Validation
+rejects zero, negative, or `deployedRetention < unusedRetention` when both are
+set at the same scope (deployed grace must be at least as long as unused).
+
+### Precedence
+
+For app `g-issues` on registry `toolshed`:
+
+1. `retention.apps.g-issues.{field}` when set
+2. else `retention.default.{field}`
+3. else built-in default (`72h` / `168h`)
+
+## Protected versions
+
+Retention must **not** delete a version while any of the following hold:
+
+| Guard | Reason |
+|-------|--------|
+| `version === desiredVersion` | Fleet is pinned to this version. |
+| Active rollout with `version` as target (`enrolling` or `restarting`) | Install in flight. |
+| Pending catalog entry for `version` | Publish not finished. See [pending-publish.md](./pending-publish.md). |
+| `retention.pinned: true` in overlay | Operator pin (optional; bypass until unpinned). |
+| Last published version for the app when `knownVersions` is empty | Prevent bricking a fresh app with no alternatives. |
+
+Protected versions remain in `index.json` until the guard clears and the
+retention clock elapses.
+
+## Retention overlay
+
+Usage timestamps are mutable fleet/registry metadata. They must not be written
+into immutable `versions/{version}.json`.
+
+Add a per-app overlay document:
+
+```text
+apps/{app}/
+├── index.json
+├── retention.json          # new
+├── pending.json
+├── failed.json
+└── …
+```
+
+### `retention.json`
+
+```json
+{
+  "schemaVersion": 1,
+  "versions": {
+    "0.0.0-snapshot.gabc123": {
+      "lastUsedAt": "2026-07-22T14:00:00Z",
+      "firstDeployedAt": "2026-07-22T14:00:00Z",
+      "everDeployed": true,
+      "pinned": false
+    },
+    "0.0.0-snapshot.gdef456": {
+      "lastUsedAt": "2026-07-24T09:00:00Z",
+      "everDeployed": false,
+      "pinned": false
+    }
+  }
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `schemaVersion` | int | yes | Currently `1`. |
+| `versions` | map | yes | Version string → `RetentionVersion`. |
+| `versions.{v}.lastUsedAt` | RFC 3339 | yes | Last qualifying use; initialized to `publishedAt` on first index write if absent. |
+| `versions.{v}.firstDeployedAt` | RFC 3339 | no | First fleet admission. |
+| `versions.{v}.everDeployed` | bool | yes | Sticky flag set on first admission. |
+| `versions.{v}.pinned` | bool | no | Operator pin; default `false`. |
+
+`gestaltd app registry publish` appends the version to `index.json` and upserts
+`retention.json` with `lastUsedAt = publishedAt`, `everDeployed = false`.
+
+Fleet install handlers update the overlay when appending change requests:
+
+- set `lastUsedAt = now`
+- on first admission: `everDeployed = true`, `firstDeployedAt = now`
+
+## Cleanup
+
+### Command
+
+```bash
+gestaltd app registry retention prune \
+  --bucket gs://gitlab-peach-street-gestalt-app-registry \
+  --app g-issues \
+  [--dry-run]
+```
+
+`prune` loads deploy config (for retention durations and registry name),
+reads `index.json` and `retention.json`, consults fleet state
+(`desiredVersion`, active rollouts, known versions), and deletes eligible
+versions.
+
+### Delete scope
+
+For each eligible version, remove:
+
+1. `apps/{app}/versions/{version}.json`
+2. `apps/{app}/artifacts/{version}/` (all platform objects)
+3. The `versions.{version}` entry from `index.json`
+4. The `versions.{version}` entry from `retention.json`
+
+Use the same optimistic concurrency pattern as `pending set` / index updates
+(read generation, `if-generation-match` on upload).
+
+### Scheduler
+
+Run retention prune on a schedule per registry (for example daily via
+toolshed/GitHub Actions or a gestaltd cron job). Prune is safe to re-run;
+deleting an already-removed version is a no-op.
+
+Recommended order per app:
+
+1. `gestaltd app registry pending set` prune helpers (existing)
+2. `gestaltd app registry retention prune` (this feature)
+
+## Admin UI
+
+`/apps/{app}/admin` continues to list published versions from `index.json`.
+Deleted versions disappear on the next poll.
+
+Optional follow-ups (not required for v1):
+
+- Show `lastUsedAt` in the **Last update** column or a dedicated column when the
+  API exposes retention metadata.
+- Badge versions nearing expiry (`expires in 1d`).
+- Pin/unpin control writing `retention.pinned`.
+
+## Safety and invariants
+
+| Invariant | Enforcement |
+|-----------|-------------|
+| Immutable published contract per version | `versions/{version}.json` is never mutated; retention only deletes whole versions |
+| Fleet cannot install a deleted version | Install validation reads `index.json`; missing entry → 400 |
+| Desired version is never deleted | Prune skips when `version === desiredVersion` |
+| Active rollout target is never deleted | Prune skips non-terminal rollouts for that version |
+| Pending publish is never deleted | Prune skips versions present in `pending.json` |
+| Deployed grace ≥ unused grace | Config validation at load |
+| Retention metadata survives publish | `retention.json` upsert on publish; overlay outlives individual prune passes |
+
+## Implementation path
+
+Suggested PR stack:
+
+### PR 1 — Models and overlay write path (`gestalt`)
+
+- Add `RetentionIndex` / `RetentionVersion` types in
+  `gestaltd/internal/appregistry/`.
+- Document shapes in [models.md](./models.md#retentionindex).
+- `gestaltd app registry publish` initializes `retention.json` for the new version.
+- Install handlers (`POST …/add`, `POST …/upgrade`) bump `lastUsedAt` and set
+  `everDeployed` on first admission.
+- Config validation for `appRegistries.*.retention` in
+  `gestaltd/internal/config/`.
+- Tests: overlay upsert, admission bumps, config validation.
+
+### PR 2 — Prune command (`gestalt`)
+
+- `gestaltd app registry retention prune` with `--dry-run`.
+- Fleet guard queries (desired version, rollout state).
+- GCS delete of version metadata, artifacts, and index/retention entries.
+- Tests: eligibility matrix, protected versions, dry-run.
+
+### PR 3 — Scheduler (`toolshed` or ops)
+
+- Scheduled workflow (daily) calling `retention prune` per app in
+  `.github/valon-tools-app-registry-apps.yaml`.
+- Dry-run reporting in CI logs before enabling destructive mode.
+
+### PR 4 — Admin API/UI (optional)
+
+- Expose `lastUsedAt`, `everDeployed`, and computed `retainsUntil` on app-admin
+  registry responses.
+- UI column or tooltip for retention status.
+
+## Relationship to other pruning
+
+| Mechanism | Catalog | Threshold | Purpose |
+|-----------|---------|-----------|---------|
+| `PrunePendingIndex` | `pending.json` | 30 minutes `startedAt` | Stale in-flight publishes → `failed.json` |
+| `PruneFailedIndex` | `failed.json` | 30 days `failedAt` | Old failed publish records |
+| **Retention prune** | `index.json` + artifacts | configurable unused/deployed idle | Remove unused published versions |
+
+Pending/failed pruning does not remove installable published versions.
+Retention prune does not touch `pending.json` or `failed.json`.
+
+## Open questions
+
+1. **Cross-registry apps** — retention is per registry bucket; fleet state is
+   global per deploy. Prune must resolve the registry name from deploy config
+   for each app.
+2. **Minimum catalog size** — whether to retain at least *N* newest published
+   versions regardless of age (not in v1; can add `minVersions: 5` later).
+3. **Audit log** — whether to write deletion events to structured logs or a
+   `apps/{app}/retention-audit.jsonl` before object removal.

--- a/plans/app_registry/retention.md
+++ b/plans/app_registry/retention.md
@@ -1,143 +1,56 @@
 # Published Version Retention
 
 Delete published app registry versions that are no longer needed, using
-configurable **default retention** windows on the deploy reader registry binding.
+configurable retention windows on `appRegistries`.
 
 Related docs:
 
-- [plan.md](./plan.md) — registry goals and implementation path
-- [config.md](./config.md) — `appRegistries` and `retention` fields
-- [models.md](./models.md) — registry JSON documents, including [RetentionIndex](./models.md#retentionindex)
-- [lifecycle.md](./lifecycle.md) — fleet-known versions, rollouts, and `POST …/add` / `POST …/upgrade`
-- [indexeddb.md](./indexeddb.md) — `app_version_change_requests` projection
-- [admin.md](./admin.md) — **Published snapshots** table on `/apps/{app}/admin`
-- [pending-publish.md](./pending-publish.md) — `pending.json` / `failed.json` pruning (separate concern)
-- [service.md](./service.md) — Go publish/read helpers
-- [tests.md](./tests.md) — retention tests (future)
+- [config.md](./config.md) — `retention` fields on `appRegistries`
+- [models.md](./models.md) — [RetentionIndex](./models.md#retentionindex)
+- [lifecycle.md](./lifecycle.md) — fleet admission (`POST …/add`, `POST …/upgrade`)
+- [pending-publish.md](./pending-publish.md) — `pending.json` / `failed.json` pruning
 
 ## Problem
 
-Each CI publish adds immutable `versions/{version}.json` entries and platform
-archives under `artifacts/{version}/`. Nothing removes them today.
-
-Most published snapshots are never fleet-known. Even versions that were desired
-once are often superseded quickly. Without retention, operators must manually
-curate the bucket or accept unbounded storage and a noisy **Published snapshots**
-table on `/apps/{app}/admin`.
+Published versions and artifacts accumulate in GCS indefinitely. Most snapshots
+are never fleet-known; many that were desired once are superseded quickly.
 
 ## Goals
 
-Operators should configure a **default retention policy** per registry (with
-optional per-app overrides) so `gestaltd` can delete eligible published versions
-safely.
+- Configurable **default retention** on each registry binding (`unusedRetention`,
+  `deployedRetention`), with optional per-app overrides.
+- Mutable `retention.json` per app tracking `lastUsedAt`, `everDeployed`, and
+  optional `pinned`.
+- **Unused retention** (default `72h`) — delete published versions that were
+  never fleet-known and idle longer than the window.
+- **Deployed retention** (default `168h`) — delete previously fleet-known versions
+  idle longer than the window since last fleet use. Timer resets on reuse.
+- `gestaltd app registry retention prune` to delete eligible versions from GCS.
+- Scheduled prune from the **deploy reader** side (not publish CI).
+- Optional: retention metadata on the app-admin registry API and `/apps/{app}/admin`.
 
-| Question | Answer |
-|----------|--------|
-| How long do we keep snapshots nobody installed? | **Unused retention** — default **3 days** (`unusedRetention: 72h`) |
-| How long do we keep snapshots that were fleet-known before? | **Deployed retention** — default **7 days** (`deployedRetention: 168h`) since last fleet use |
-| What resets the idle timer? | Fleet admission (`POST …/add`, `POST …/upgrade`), becoming **desired version**, or an operator pin |
-| What must never be deleted? | **Desired version**, active rollout target, pending publish, operator pin, last published version when the fleet catalog is empty |
-
-Publishing alone does **not** count as fleet use. A snapshot can sit in
-`index.json` without ever becoming fleet-known.
-
-## Design summary
-
-Add mutable `retention.json` per app in GCS. Scope is registry bucket cleanup —
-not local replica artifact directories (those are already trimmed per replica in
-[lifecycle.md](./lifecycle.md#startup)).
-
-| Actor | Responsibility |
-|-------|----------------|
-| **Publisher** (`gestaltd app registry publish`) | Append `index.json`, upload immutable version metadata and artifacts, upsert `retention.json` with `lastUsedAt = publishedAt` and `everDeployed = false` |
-| **Reader** (`gestaltd serve` install handlers) | On fleet admission, bump `lastUsedAt` and set `everDeployed` on first admission |
-| **Reader** (`gestaltd app registry retention prune`) | Evaluate policy, consult fleet state, delete eligible published versions from GCS |
-
-Retention policy and prune decisions are **reader-owned**. The publisher only
-seeds retention metadata at publish time. Prune must read deploy config
-(`appRegistries.*.retention`) and fleet state (`desiredVersion`, active
-rollouts) before deleting anything.
-
-Two idle windows apply per published version:
-
-| Window | Default | Applies when |
-|--------|---------|--------------|
-| **Unused retention** | `72h` | `everDeployed` is false |
-| **Deployed retention** | `168h` | `everDeployed` is true |
-
-At prune time, compare `now - lastUsedAt` against the applicable window.
-`lastUsedAt` falls back to `publishedAt` from `index.json` when absent.
-
-`gestaltd app registry retention prune` removes eligible versions from
-`index.json`, `retention.json`, `versions/{version}.json`, and
-`artifacts/{version}/`. It does **not** touch `pending.json` or `failed.json`.
-
-## Retention policy
-
-### Fleet use
-
-A version is **used** when any of the following occur:
-
-1. **Fleet admission** — a change request is appended with `to_version` equal to
-   this version (`POST …/add` or `POST …/upgrade`). Includes first install and
-   every re-select of the same version.
-2. **Desired version** — the version becomes `LatestKnownVersion` for the app
-   (including when a rollout completes and the version remains desired).
-3. **Operator pin** — `retention.pinned: true` on the overlay entry (optional
-   escape hatch; see [Protected versions](#protected-versions)).
-
-Each fleet use updates `lastUsedAt` for `(app, version)` in `retention.json`.
-
-### Previously fleet-known
-
-`everDeployed` is set on first fleet admission and remains true for the lifetime
-of the published version. `firstDeployedAt` records that first admission.
-Previously fleet-known versions use **deployed retention** even after they are
-no longer desired.
-
-### Examples (defaults)
-
-| Version history | `everDeployed` | `lastUsedAt` | Window | Eligible now? |
-|-----------------|----------------|--------------|--------|---------------|
-| Published 4 days ago, never fleet-known | false | `publishedAt` (4d ago) | unused (`72h`) | yes |
-| Published yesterday, never fleet-known | false | yesterday | unused (`72h`) | no |
-| Fleet-known 10 days ago, idle since | true | 10d ago | deployed (`168h`) | yes |
-| Fleet-known 10 days ago, re-selected yesterday | true | yesterday | deployed (`168h`) | no |
+Fleet use is fleet admission, becoming **desired version**, or an operator pin.
+Publishing alone does not count.
 
 ## Config
 
-Retention is configured on the deploy reader registry binding
-(`appRegistries.{name}`). Field definitions and validation:
-[config.md](./config.md).
+On `appRegistries.{name}`:
 
 ```yaml
-appRegistries:
-  toolshed:
-    kind: gcs
-    gcs:
-      bucket: gs://gestalt-app-registry
-    retention:
-      default:
-        unusedRetention: 72h
-        deployedRetention: 168h
-      apps:
-        g-issues:
-          unusedRetention: 48h
-          deployedRetention: 336h
+retention:
+  default:
+    unusedRetention: 72h
+    deployedRetention: 168h
+  apps:
+    g-issues:
+      unusedRetention: 48h
+      deployedRetention: 336h
 ```
 
-Precedence for app `g-issues` on registry `toolshed`:
+Precedence: `retention.apps.{app}` → `retention.default` → built-in (`72h` /
+`168h`). See [config.md](./config.md).
 
-1. `retention.apps.g-issues.{field}` when set
-2. else `retention.default.{field}`
-3. else built-in default (`72h` / `168h`)
-
-Durations use Go `time.ParseDuration` syntax. Validation rejects zero,
-negative values, and `deployedRetention < unusedRetention` at the same scope.
-
-## GCS layout
-
-Extend the per-app registry tree:
+## Schema and storage
 
 ```text
 apps/{app}/
@@ -145,46 +58,25 @@ apps/{app}/
 ├── retention.json
 ├── pending.json
 ├── failed.json
-├── versions/
-│   └── {version}.json
-└── artifacts/
-    └── {version}/
-        └── …
+├── versions/{version}.json
+└── artifacts/{version}/…
 ```
 
-`retention.json` is a mutable catalog (like `index.json`), not an immutable
-release object. Document shape, fields, and example:
-[models.md — RetentionIndex](./models.md#retentionindex).
+`retention.json` is a mutable catalog. Shape and fields:
+[models.md — RetentionIndex](./models.md#retentionindex). Updates use the same
+optimistic-concurrency pattern as `index.json` (`if-generation-match`).
 
-Use the same optimistic-concurrency update pattern as other catalog writes:
-read generation, merge, upload with `if-generation-match`.
+## Who writes and who deletes
 
-## Write path
+| Action | Owner | What |
+|--------|-------|------|
+| Publish | **Publisher** (`gestaltd app registry publish`) | Upsert `retention.json`: `lastUsedAt = publishedAt`, `everDeployed = false` |
+| Fleet admission | **Reader** (`POST …/add`, `POST …/upgrade`) | Bump `lastUsedAt`; on first admission set `everDeployed = true`, `firstDeployedAt = now` |
+| Delete | **Reader** (`gestaltd app registry retention prune`) | Remove eligible versions from `index.json`, `retention.json`, `versions/{version}.json`, and `artifacts/{version}/` |
 
-### Publish (`gestaltd app registry publish`)
-
-After uploading `versions/{version}.json` and artifacts, append the version to
-`index.json` and upsert `retention.json`:
-
-- `lastUsedAt = publishedAt`
-- `everDeployed = false`
-
-Publish does not evaluate retention or delete older versions.
-
-### Fleet admission (`POST …/add`, `POST …/upgrade`)
-
-After validation and `AppendRequest`, update `retention.json` for the admitted
-version:
-
-- `lastUsedAt = now`
-- on first admission: `everDeployed = true`, `firstDeployedAt = now`
-
-Install handlers do not delete registry objects. Deletion is confined to
-`gestaltd app registry retention prune`.
-
-## Prune path
-
-### `gestaltd app registry retention prune`
+Prune loads deploy config (`appRegistries.*.retention`) and fleet state
+(`desiredVersion`, active rollouts) before deleting. It does not touch
+`pending.json` or `failed.json`.
 
 ```bash
 gestaltd app registry retention prune \
@@ -193,133 +85,24 @@ gestaltd app registry retention prune \
   [--dry-run]
 ```
 
-`prune` loads deploy config (retention durations), reads `index.json` and
-`retention.json`, consults fleet state (`desiredVersion`, active rollouts,
-known versions), and deletes eligible published versions.
-
-For each eligible version, remove:
-
-1. `apps/{app}/versions/{version}.json`
-2. `apps/{app}/artifacts/{version}/` (all platform objects)
-3. `versions.{version}` from `index.json`
-4. `versions.{version}` from `retention.json`
-
-Prune is idempotent and safe to re-run. Deleting an already-removed version is
-a no-op.
-
-### Scheduler
-
-Run retention prune on a schedule from the **deploy reader** side — for example
-a `gestaltd` cron job with deploy config and fleet API access. Prune requires
-fleet guards; publish CI alone is not sufficient.
-
-Do not run retention prune from `gestaltd serve` request handlers. Like
-[pending-publish.md](./pending-publish.md#self-healing), catalog mutation runs
-on an explicit CLI path with bucket credentials.
-
-Recommended order per app when both run:
-
-1. `gestaltd app registry pending set` prune helpers (existing)
-2. `gestaltd app registry retention prune` (this feature)
+Run on a schedule from the deploy reader (for example a daily `gestaltd` cron).
+Do not run from `gestaltd serve` request handlers.
 
 ## Protected versions
 
-Retention must **not** delete a version while any guard holds:
+Do not delete while any guard holds:
 
-| Guard | Reason |
-|-------|--------|
-| `version === desiredVersion` | Fleet is pinned to this version |
-| Active rollout with `version` as target (`enrolling` or `restarting`) | Install in flight |
-| Entry in `pending.json` for `version` | Publish not finished. See [pending-publish.md](./pending-publish.md). |
-| `retention.pinned: true` | Operator pin until unpinned |
-| Last published version when `knownVersions` is empty | Prevent bricking a fresh app with no alternatives |
-
-Protected versions remain in `index.json` until the guard clears and the idle
-window elapses.
-
-## Relationship to pending/failed pruning
-
-| Mechanism | Catalog | Threshold | Owner | Purpose |
-|-----------|---------|-----------|-------|---------|
-| `PrunePendingIndex` | `pending.json` | 30 minutes `startedAt` | Publisher (CI `pending set`) | Stale in-flight publishes → `failed.json` |
-| `PruneFailedIndex` | `failed.json` | 30 days `failedAt` | Publisher (CI `pending set`) | Old failed publish records |
-| **Retention prune** | `index.json` + artifacts | configurable idle windows | Reader (`retention prune`) | Remove unused published versions |
-
-Pending/failed pruning does not remove installable published versions.
-Retention prune does not touch `pending.json` or `failed.json`.
-
-## Admin UI
-
-`/apps/{app}/admin` continues to list published versions from `index.json`.
-Deleted versions disappear on the next poll. Wireframes and columns:
-[admin.md](./admin.md#app-admin-ui-appsappadmin).
-
-Optional follow-ups (not required for v1):
-
-- Expose `lastUsedAt`, `everDeployed`, and computed `retainsUntil` on the
-  app-admin registry API.
-- Show retention metadata in the **Last update** column or a dedicated column.
-- Pin/unpin control writing `retention.pinned`.
-
-## Safety and invariants
-
-| Invariant | Enforcement |
-|-----------|-------------|
-| Published contract per version stays immutable until delete | `versions/{version}.json` is never mutated; retention deletes whole versions only |
-| Fleet cannot install a deleted version | Install validation reads `index.json`; missing entry → 400 |
-| Desired version is never deleted | Prune skips when `version === desiredVersion` |
-| Active rollout target is never deleted | Prune skips non-terminal rollouts for that version |
-| Pending publish is never deleted | Prune skips versions present in `pending.json` |
-| Deployed grace ≥ unused grace | Config validation at load |
-| Retention metadata survives publish | `retention.json` upsert on publish; overlay outlives individual prune passes |
-
-Implementation:
-
-- Retention types and prune — `gestaltd/internal/appregistry/retention.go`
-- `gestaltd app registry retention` CLI — `gestaltd/internal/daemon/app_registry_retention.go`
-- Overlay writes on publish — `gestaltd/internal/daemon/app_registry_publish.go`
-- Overlay writes on admission — `gestaltd/internal/server/handlers_admin_app_install.go`
-- Config validation — `gestaltd/internal/config/`
+| Guard | |
+|-------|---|
+| `version === desiredVersion` | |
+| Active rollout target (`enrolling` or `restarting`) | |
+| Entry in `pending.json` | |
+| `retention.pinned: true` | |
+| Last published version when `knownVersions` is empty | |
 
 ## Implementation path
 
-Four PRs. Merge in order below.
-
-```text
-PR 1 (gestalt) ──► PR 2 (gestalt) ──► PR 4 (gestalt-providers, optional)
-       │
-       └──────────► PR 3 (deploy scheduler)
-```
-
-### PR 1 — Models and write path (`gestalt`)
-
-- Add `RetentionIndex` / `RetentionVersion` to `gestaltd/internal/appregistry/`
-  ([models.md](./models.md#retentionindex) documents shapes).
-- `gestaltd app registry publish` initializes `retention.json` for the new version.
-- Install handlers bump `lastUsedAt` and set `everDeployed` on first admission.
-- Config validation for `appRegistries.*.retention` in `gestaltd/internal/config/`.
-- Tests: overlay upsert, admission bumps, config validation. Extend
-  [tests.md](./tests.md).
-
-### PR 2 — Prune command (`gestalt`)
-
-Depends on **PR 1**.
-
-- `gestaltd app registry retention prune` with `--dry-run`.
-- Fleet guard queries (desired version, rollout state).
-- GCS delete of version metadata, artifacts, and index/retention entries.
-- Tests: eligibility matrix, protected versions, dry-run.
-
-### PR 3 — Scheduler (deploy / ops)
-
-Depends on **PR 2**. Run from the reader side with deploy config and fleet access.
-
-- Scheduled job (daily) calling `retention prune` per registry-only app.
-- Dry-run reporting in logs before enabling destructive mode.
-
-### PR 4 — Admin API/UI (optional)
-
-Depends on **PR 2**.
-
-- Expose retention metadata on `GET /api/v1/apps/{app}/admin/registry`.
-- Optional UI column or tooltip on `/apps/{app}/admin`. See [admin.md](./admin.md).
+1. **PR 1 — Models and write path** (`gestalt`) — `RetentionIndex`, config validation, publish and install handler updates.
+2. **PR 2 — Prune command** (`gestalt`) — `gestaltd app registry retention prune` with `--dry-run` and fleet guards.
+3. **PR 3 — Scheduler** (deploy / ops) — scheduled `retention prune` per registry-only app.
+4. **PR 4 — Admin API/UI** (optional) — retention fields on app-admin registry API and `/apps/{app}/admin`.

--- a/plans/app_registry/retention.md
+++ b/plans/app_registry/retention.md
@@ -19,8 +19,7 @@ are never fleet-known; many that were desired once are superseded quickly.
 
 - Configurable retention on each registry binding (`unusedRetention`,
   `deployedRetention`).
-- Mutable `retention.json` per app tracking `lastUsedAt`, `everDeployed`, and
-  optional `pinned`.
+- Mutable `retention.json` per app tracking `lastUsedAt` and `everDeployed`.
 - **Unused retention** (default `72h`) — delete published versions that were
   never fleet-known and idle longer than the window.
 - **Deployed retention** (default `168h`) — delete previously fleet-known versions
@@ -29,8 +28,8 @@ are never fleet-known; many that were desired once are superseded quickly.
 - Scheduled prune from the **deploy reader** side (not publish CI).
 - Optional: retention metadata on the app-admin registry API and `/apps/{app}/admin`.
 
-Fleet use is fleet admission, becoming **desired version**, or an operator pin.
-Publishing alone does not count.
+Fleet use is fleet admission or becoming **desired version**. Publishing alone
+does not count.
 
 ## Config
 
@@ -91,7 +90,6 @@ Do not delete while any guard holds:
 | `version === desiredVersion` | |
 | Active rollout target (`enrolling` or `restarting`) | |
 | Entry in `pending.json` | |
-| `retention.pinned: true` | |
 | Last published version when `knownVersions` is empty | |
 
 ## Implementation path

--- a/plans/app_registry/retention.md
+++ b/plans/app_registry/retention.md
@@ -17,8 +17,8 @@ are never fleet-known; many that were desired once are superseded quickly.
 
 ## Goals
 
-- Configurable **default retention** on each registry binding (`unusedRetention`,
-  `deployedRetention`), with optional per-app overrides.
+- Configurable retention on each registry binding (`unusedRetention`,
+  `deployedRetention`).
 - Mutable `retention.json` per app tracking `lastUsedAt`, `everDeployed`, and
   optional `pinned`.
 - **Unused retention** (default `72h`) — delete published versions that were
@@ -38,17 +38,11 @@ On `appRegistries.{name}`:
 
 ```yaml
 retention:
-  default:
-    unusedRetention: 72h
-    deployedRetention: 168h
-  apps:
-    g-issues:
-      unusedRetention: 48h
-      deployedRetention: 336h
+  unusedRetention: 72h
+  deployedRetention: 168h
 ```
 
-Precedence: `retention.apps.{app}` → `retention.default` → built-in (`72h` /
-`168h`). See [config.md](./config.md).
+Defaults: `72h` / `168h` when omitted. See [config.md](./config.md).
 
 ## Schema and storage
 


### PR DESCRIPTION
## Summary
- Add `plans/app_registry/retention.md` describing configurable default retention for published registry versions
- Unused versions: delete after 3 days without qualifying use (configurable via `unusedRetention`)
- Ever-deployed versions: delete after 7 days idle since last use; timer resets on reuse (configurable via `deployedRetention`)
- Document `retention.json` overlay, protected versions, `gestaltd app registry retention prune`, and a suggested implementation path
- Cross-link from `plan.md`, `config.md`, `models.md`, and `admin.md`

## Test plan
- [x] Docs-only change; review policy semantics and config examples in `retention.md`
- [ ] Confirm links resolve across `plans/app_registry/` docs


Made with [Cursor](https://cursor.com)