### PR TITLE
Add app registry retention models and write path

### DIFF
--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -37,13 +37,14 @@ type AppInstallation struct {
 }
 
 type AppVersionChangeRequest struct {
-	ID          string
-	App         string
-	FromVersion string
-	ToVersion   string
-	Actor       string
-	Timestamp   time.Time
-	Metadata    map[string]any
+	ID                          string
+	App                         string
+	FromVersion                 string
+	ToVersion                   string
+	Actor                       string
+	Timestamp                   time.Time
+	FromVersionDeployableUntil  *time.Time
+	Metadata                    map[string]any
 }
 
 type AppInstanceMaterialization struct {

--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -37,14 +37,14 @@ type AppInstallation struct {
 }
 
 type AppVersionChangeRequest struct {
-	ID                          string
-	App                         string
-	FromVersion                 string
-	ToVersion                   string
-	Actor                       string
-	Timestamp                   time.Time
-	FromVersionDeployableUntil  *time.Time
-	Metadata                    map[string]any
+	ID                         string
+	App                        string
+	FromVersion                string
+	ToVersion                  string
+	Actor                      string
+	Timestamp                  time.Time
+	FromVersionDeployableUntil *time.Time
+	Metadata                   map[string]any
 }
 
 type AppInstanceMaterialization struct {

--- a/gestaltd/internal/appregistry/errors.go
+++ b/gestaltd/internal/appregistry/errors.go
@@ -28,3 +28,9 @@ var ErrAppRegistryNotConfigured = errors.New("app registry is not configured")
 
 // ErrInstallTimedOut means install work exceeded the bounded post-lock timeout.
 var ErrInstallTimedOut = errors.New("app version install timed out")
+
+// ErrAppVersionExpired means a never-deployed version is past unused retention.
+var ErrAppVersionExpired = errors.New("app version is expired")
+
+// ErrAppVersionLocked means a historical version is permanently locked.
+var ErrAppVersionLocked = errors.New("app version is permanently locked")

--- a/gestaltd/internal/appregistry/installer.go
+++ b/gestaltd/internal/appregistry/installer.go
@@ -26,14 +26,15 @@ const (
 const installWorkTimeoutBuffer = 30 * time.Second
 
 type Installer struct {
-	Registries      map[string]config.AppRegistryConfig
-	ConfigApps      map[string]*config.ProviderEntry
-	Reader          *RegistryReader
-	ChangeRequests  *coredata.AppVersionChangeRequestService
-	Locks           *coredata.AppVersionInstallLockService
-	Rollouts        *coredata.AppRolloutService
-	GestaltdVersion string
-	Now             func() time.Time
+	Registries       map[string]config.AppRegistryConfig
+	ConfigApps       map[string]*config.ProviderEntry
+	Reader           *RegistryReader
+	ChangeRequests   *coredata.AppVersionChangeRequestService
+	Locks            *coredata.AppVersionInstallLockService
+	Rollouts         *coredata.AppRolloutService
+	RetentionCatalog RetentionCatalogStore
+	GestaltdVersion  string
+	Now              func() time.Time
 }
 
 type InstallInput struct {
@@ -180,6 +181,29 @@ func (i *Installer) install(ctx context.Context, input InstallInput, mode instal
 	if reader == nil {
 		reader = &RegistryReader{}
 	}
+	registryConfig, ok := i.Registries[registryName]
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrAppRegistryNotConfigured, registryName)
+	}
+	policy, err := retentionPolicyFromConfig(registryConfig)
+	if err != nil {
+		return nil, err
+	}
+	publicRoot, err := registryConfig.PublicURL()
+	if err != nil {
+		return nil, fmt.Errorf("resolve registry public URL: %w", err)
+	}
+	retentionIndex, err := reader.FetchRetentionIndex(installCtx, publicRoot, appName)
+	if err != nil {
+		return nil, fmt.Errorf("fetch retention index: %w", err)
+	}
+	currentDesired := coredata.LatestKnownVersion(knownVersions)
+	if mode == installModeSelect || mode == installModeUpgrade || mode == installModeAdd {
+		if err := VersionSelectable(version, currentDesired, retentionIndex, policy, i.now()); err != nil {
+			return nil, err
+		}
+	}
+
 	source, err := fetchConfiguredRegistryEntry(installCtx, i.Registries, reader, registryName, appName, version)
 	if err != nil {
 		return nil, err
@@ -194,6 +218,11 @@ func (i *Installer) install(ctx context.Context, input InstallInput, mode instal
 	checksums := artifactChecksumsFromEntry(*entry)
 
 	requestedAt := i.now()
+	var fromVersionDeployableUntil *time.Time
+	if fromVersion != "" && fromVersion != FirstInstallFromVersion {
+		deadline := requestedAt.Add(policy.DeployedRetention)
+		fromVersionDeployableUntil = &deadline
+	}
 	known := &core.AppInstallation{
 		AppName:            appName,
 		Version:            version,
@@ -221,17 +250,19 @@ func (i *Installer) install(ctx context.Context, input InstallInput, mode instal
 	}
 
 	addedRequest, err := i.ChangeRequests.AppendRequest(installCtx, &core.AppVersionChangeRequest{
-		App:         appName,
-		FromVersion: fromVersion,
-		ToVersion:   version,
-		Actor:       actor,
-		Timestamp:   requestedAt,
-		Metadata:    coredata.ChangeRequestMetadata(known),
+		App:                        appName,
+		FromVersion:                fromVersion,
+		ToVersion:                  version,
+		Actor:                      actor,
+		Timestamp:                  requestedAt,
+		FromVersionDeployableUntil: fromVersionDeployableUntil,
+		Metadata:                   coredata.ChangeRequestMetadata(known),
 	})
 	if err != nil {
 		_, _ = i.Rollouts.MarkFailed(context.WithoutCancel(installCtx), appName, version, i.now())
 		return nil, fmt.Errorf("append change request: %w", err)
 	}
+	i.mirrorRetentionTransition(installCtx, registryName, appName, fromVersion, version, policy, requestedAt)
 
 	return &InstallOutput{
 		Installation: coredata.InstallationFromChangeRequest(addedRequest),
@@ -282,4 +313,27 @@ func installWorkTimeout(lockTTL time.Duration) time.Duration {
 		return lockTTL
 	}
 	return lockTTL - installWorkTimeoutBuffer
+}
+
+func retentionPolicyFromConfig(registry config.AppRegistryConfig) (RetentionPolicy, error) {
+	unused, deployed, err := registry.RetentionPolicy()
+	if err != nil {
+		return RetentionPolicy{}, err
+	}
+	return RetentionPolicy{
+		UnusedRetention:   unused,
+		DeployedRetention: deployed,
+	}, nil
+}
+
+func (i *Installer) mirrorRetentionTransition(ctx context.Context, registryName, appName, fromVersion, toVersion string, policy RetentionPolicy, now time.Time) {
+	if i == nil || i.RetentionCatalog == nil {
+		return
+	}
+	_ = i.RetentionCatalog.MutateRetention(ctx, registryName, appName, func(index *RetentionIndex) (bool, error) {
+		if index == nil {
+			return false, nil
+		}
+		return ApplyDesiredVersionTransition(index, fromVersion, toVersion, policy, now), nil
+	})
 }

--- a/gestaltd/internal/appregistry/reader.go
+++ b/gestaltd/internal/appregistry/reader.go
@@ -104,6 +104,31 @@ func (r *RegistryReader) FetchFailedIndex(ctx context.Context, publicRoot, appNa
 	return DecodeFailedIndex(body)
 }
 
+// FetchRetentionIndex downloads apps/{app}/retention.json from a registry public root.
+func (r *RegistryReader) FetchRetentionIndex(ctx context.Context, publicRoot, appName string) (*RetentionIndex, error) {
+	appName = strings.TrimSpace(appName)
+	if appName == "" {
+		return nil, fmt.Errorf("app name is required")
+	}
+	if err := providerregistry.ValidateRepositoryName(appName); err != nil {
+		return nil, err
+	}
+	publicRoot = strings.TrimRight(strings.TrimSpace(publicRoot), "/")
+	if publicRoot == "" {
+		return nil, fmt.Errorf("registry public URL is required")
+	}
+
+	url := PublicURL(publicRoot, AppRetentionPath(appName))
+	body, err := r.fetchJSON(ctx, url, true)
+	if err != nil {
+		return nil, err
+	}
+	if body == nil {
+		return NewEmptyRetentionIndex(), nil
+	}
+	return DecodeRetentionIndex(body)
+}
+
 // FetchAppIndex downloads apps/{app}/index.json from a registry public root.
 func (r *RegistryReader) FetchAppIndex(ctx context.Context, publicRoot, appName string) (*Index, error) {
 	appName = strings.TrimSpace(appName)

--- a/gestaltd/internal/appregistry/retention.go
+++ b/gestaltd/internal/appregistry/retention.go
@@ -14,9 +14,9 @@ const (
 	RetentionIndexSchemaVersion = 1
 	RetentionFileName           = "retention.json"
 
-	DefaultUnusedRetention    = 72 * time.Hour
-	DefaultDeployedRetention  = 720 * time.Hour
-	FirstInstallFromVersion   = "registry:first-install"
+	DefaultUnusedRetention   = 72 * time.Hour
+	DefaultDeployedRetention = 720 * time.Hour
+	FirstInstallFromVersion  = "registry:first-install"
 )
 
 const (
@@ -28,7 +28,7 @@ const (
 )
 
 type RetentionIndex struct {
-	SchemaVersion int                        `json:"schemaVersion"`
+	SchemaVersion int                         `json:"schemaVersion"`
 	Versions      map[string]RetentionVersion `json:"versions"`
 }
 

--- a/gestaltd/internal/appregistry/retention.go
+++ b/gestaltd/internal/appregistry/retention.go
@@ -1,0 +1,313 @@
+package appregistry
+
+import (
+	"encoding/json"
+	"fmt"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/services/apps/source"
+)
+
+const (
+	RetentionIndexSchemaVersion = 1
+	RetentionFileName           = "retention.json"
+
+	DefaultUnusedRetention    = 72 * time.Hour
+	DefaultDeployedRetention  = 720 * time.Hour
+	FirstInstallFromVersion   = "registry:first-install"
+)
+
+const (
+	DeploymentStateAvailable    = "available"
+	DeploymentStateExpired      = "expired"
+	DeploymentStateDesired      = "desired"
+	DeploymentStateRedeployable = "redeployable"
+	DeploymentStateLocked       = "locked"
+)
+
+type RetentionIndex struct {
+	SchemaVersion int                        `json:"schemaVersion"`
+	Versions      map[string]RetentionVersion `json:"versions"`
+}
+
+type RetentionVersion struct {
+	PublishedAt       time.Time  `json:"publishedAt"`
+	LastDeactivatedAt *time.Time `json:"lastDeactivatedAt,omitempty"`
+	DeployableUntil   *time.Time `json:"deployableUntil,omitempty"`
+	FirstDeployedAt   *time.Time `json:"firstDeployedAt,omitempty"`
+	EverDeployed      bool       `json:"everDeployed"`
+	LockedAt          *time.Time `json:"lockedAt,omitempty"`
+}
+
+type RetentionPolicy struct {
+	UnusedRetention   time.Duration
+	DeployedRetention time.Duration
+}
+
+func DefaultRetentionPolicy() RetentionPolicy {
+	return RetentionPolicy{
+		UnusedRetention:   DefaultUnusedRetention,
+		DeployedRetention: DefaultDeployedRetention,
+	}
+}
+
+func AppRetentionPath(appName string) string {
+	return path.Join("apps", appName, RetentionFileName)
+}
+
+func NewEmptyRetentionIndex() *RetentionIndex {
+	return &RetentionIndex{
+		SchemaVersion: RetentionIndexSchemaVersion,
+		Versions:      map[string]RetentionVersion{},
+	}
+}
+
+func DecodeRetentionIndex(data []byte) (*RetentionIndex, error) {
+	var index RetentionIndex
+	if err := json.Unmarshal(data, &index); err != nil {
+		return nil, fmt.Errorf("decode retention index: %w", err)
+	}
+	if err := validateRetentionIndex(&index); err != nil {
+		return nil, err
+	}
+	return &index, nil
+}
+
+func validateRetentionIndex(index *RetentionIndex) error {
+	if index == nil {
+		return fmt.Errorf("retention index is required")
+	}
+	if index.SchemaVersion != RetentionIndexSchemaVersion {
+		return fmt.Errorf("unsupported retention index schema version %d", index.SchemaVersion)
+	}
+	if index.Versions == nil {
+		return fmt.Errorf("retention index versions map is required")
+	}
+	for version, entry := range index.Versions {
+		if err := validateRetentionVersion(version, entry); err != nil {
+			return fmt.Errorf("retention index version %q: %w", version, err)
+		}
+	}
+	return nil
+}
+
+func validateRetentionVersion(mapKey string, entry RetentionVersion) error {
+	version := strings.TrimSpace(mapKey)
+	if version == "" {
+		return fmt.Errorf("version is required")
+	}
+	if err := source.ValidateVersion(version); err != nil {
+		return fmt.Errorf("version: %w", err)
+	}
+	if entry.PublishedAt.IsZero() {
+		return fmt.Errorf("publishedAt is required")
+	}
+	if entry.LastDeactivatedAt != nil && entry.LastDeactivatedAt.IsZero() {
+		return fmt.Errorf("lastDeactivatedAt must not be zero")
+	}
+	if entry.DeployableUntil != nil && entry.DeployableUntil.IsZero() {
+		return fmt.Errorf("deployableUntil must not be zero")
+	}
+	if entry.FirstDeployedAt != nil && entry.FirstDeployedAt.IsZero() {
+		return fmt.Errorf("firstDeployedAt must not be zero")
+	}
+	if entry.LockedAt != nil && entry.LockedAt.IsZero() {
+		return fmt.Errorf("lockedAt must not be zero")
+	}
+	return nil
+}
+
+// UpsertPublishedRetention records a newly published version in the retention overlay.
+func UpsertPublishedRetention(index *RetentionIndex, version string, publishedAt time.Time) bool {
+	if index == nil {
+		return false
+	}
+	if index.Versions == nil {
+		index.Versions = map[string]RetentionVersion{}
+	}
+	version = strings.TrimSpace(version)
+	publishedAt = publishedAt.UTC()
+	if existing, ok := index.Versions[version]; ok {
+		if existing.PublishedAt.Equal(publishedAt) {
+			return false
+		}
+		existing.PublishedAt = publishedAt
+		index.Versions[version] = existing
+		return true
+	}
+	index.Versions[version] = RetentionVersion{
+		PublishedAt:  publishedAt,
+		EverDeployed: false,
+	}
+	return true
+}
+
+// ApplyDesiredVersionTransition mirrors a fleet admission into retention.json.
+func ApplyDesiredVersionTransition(index *RetentionIndex, fromVersion, toVersion string, policy RetentionPolicy, now time.Time) bool {
+	if index == nil {
+		return false
+	}
+	if index.Versions == nil {
+		index.Versions = map[string]RetentionVersion{}
+	}
+	now = now.UTC()
+	changed := false
+
+	fromVersion = strings.TrimSpace(fromVersion)
+	toVersion = strings.TrimSpace(toVersion)
+	if fromVersion != "" && fromVersion != FirstInstallFromVersion {
+		entry, ok := index.Versions[fromVersion]
+		if !ok {
+			entry = RetentionVersion{PublishedAt: now, EverDeployed: true}
+		}
+		entry.EverDeployed = true
+		if entry.FirstDeployedAt == nil || entry.FirstDeployedAt.IsZero() {
+			firstDeployed := now
+			entry.FirstDeployedAt = &firstDeployed
+		}
+		deactivated := now
+		entry.LastDeactivatedAt = &deactivated
+		deadline := now.Add(policy.DeployedRetention)
+		entry.DeployableUntil = &deadline
+		index.Versions[fromVersion] = entry
+		changed = true
+	}
+
+	if toVersion != "" {
+		entry, ok := index.Versions[toVersion]
+		if !ok {
+			entry = RetentionVersion{PublishedAt: now}
+		}
+		entry.EverDeployed = true
+		if entry.FirstDeployedAt == nil || entry.FirstDeployedAt.IsZero() {
+			firstDeployed := now
+			entry.FirstDeployedAt = &firstDeployed
+		}
+		entry.LastDeactivatedAt = nil
+		entry.DeployableUntil = nil
+		index.Versions[toVersion] = entry
+		changed = true
+	}
+	return changed
+}
+
+// VersionDeploymentState resolves present-day deployability for one published version.
+func VersionDeploymentState(version string, desiredVersion string, retention *RetentionIndex, policy RetentionPolicy, now time.Time) (state string, deployableUntil *time.Time) {
+	version = strings.TrimSpace(version)
+	desiredVersion = strings.TrimSpace(desiredVersion)
+	now = now.UTC()
+	if version == desiredVersion && version != "" {
+		return DeploymentStateDesired, nil
+	}
+	entry, ok := retentionVersion(retention, version)
+	if !ok {
+		return DeploymentStateAvailable, nil
+	}
+	if entry.LockedAt != nil && !entry.LockedAt.IsZero() {
+		return DeploymentStateLocked, cloneTimePtr(entry.DeployableUntil)
+	}
+	if entry.EverDeployed {
+		if entry.DeployableUntil != nil && now.Before(entry.DeployableUntil.UTC()) {
+			return DeploymentStateRedeployable, cloneTimePtr(entry.DeployableUntil)
+		}
+		if entry.DeployableUntil != nil && !entry.DeployableUntil.IsZero() {
+			return DeploymentStateLocked, cloneTimePtr(entry.DeployableUntil)
+		}
+		return DeploymentStateLocked, nil
+	}
+	unusedDeadline := entry.PublishedAt.UTC().Add(policy.UnusedRetention)
+	if now.Before(unusedDeadline) {
+		return DeploymentStateAvailable, nil
+	}
+	return DeploymentStateExpired, nil
+}
+
+// VersionSelectable reports whether a version may be admitted while holding the install lock.
+func VersionSelectable(version, desiredVersion string, retention *RetentionIndex, policy RetentionPolicy, now time.Time) error {
+	state, _ := VersionDeploymentState(version, desiredVersion, retention, policy, now)
+	switch state {
+	case DeploymentStateAvailable, DeploymentStateRedeployable:
+		return nil
+	case DeploymentStateDesired:
+		return ErrAppVersionAlreadyInstalled
+	case DeploymentStateExpired:
+		return ErrAppVersionExpired
+	case DeploymentStateLocked:
+		return ErrAppVersionLocked
+	default:
+		return ErrAppVersionExpired
+	}
+}
+
+func retentionVersion(index *RetentionIndex, version string) (RetentionVersion, bool) {
+	if index == nil || index.Versions == nil {
+		return RetentionVersion{}, false
+	}
+	entry, ok := index.Versions[strings.TrimSpace(version)]
+	return entry, ok
+}
+
+// DeployedVersionsFromRetention returns versions marked everDeployed in retention.json.
+func DeployedVersionsFromRetention(index *RetentionIndex) map[string]struct{} {
+	out := map[string]struct{}{}
+	if index == nil || len(index.Versions) == 0 {
+		return out
+	}
+	for version, entry := range index.Versions {
+		if entry.EverDeployed {
+			out[version] = struct{}{}
+		}
+	}
+	return out
+}
+
+// LockExpiredVersions sets lockedAt on historical versions whose deployableUntil passed.
+func LockExpiredVersions(index *RetentionIndex, desiredVersion string, now time.Time) bool {
+	if index == nil || len(index.Versions) == 0 {
+		return false
+	}
+	now = now.UTC()
+	desiredVersion = strings.TrimSpace(desiredVersion)
+	changed := false
+	for version, entry := range index.Versions {
+		if version == desiredVersion {
+			continue
+		}
+		if entry.LockedAt != nil && !entry.LockedAt.IsZero() {
+			continue
+		}
+		if !entry.EverDeployed || entry.DeployableUntil == nil {
+			continue
+		}
+		if !now.Before(entry.DeployableUntil.UTC()) {
+			lockedAt := now
+			entry.LockedAt = &lockedAt
+			index.Versions[version] = entry
+			changed = true
+		}
+	}
+	return changed
+}
+
+// RemoveRetentionVersion deletes one retention row.
+func RemoveRetentionVersion(index *RetentionIndex, version string) bool {
+	if index == nil || index.Versions == nil {
+		return false
+	}
+	version = strings.TrimSpace(version)
+	if _, ok := index.Versions[version]; !ok {
+		return false
+	}
+	delete(index.Versions, version)
+	return true
+}
+
+// UnusedVersionExpired reports whether a never-deployed version is past unused retention.
+func UnusedVersionExpired(entry RetentionVersion, policy RetentionPolicy, now time.Time) bool {
+	if entry.EverDeployed {
+		return false
+	}
+	return !now.UTC().Before(entry.PublishedAt.UTC().Add(policy.UnusedRetention))
+}

--- a/gestaltd/internal/appregistry/retention_store.go
+++ b/gestaltd/internal/appregistry/retention_store.go
@@ -1,0 +1,82 @@
+package appregistry
+
+import (
+	"context"
+	"sync"
+)
+
+// RetentionCatalogStore mutates apps/{app}/retention.json with optimistic concurrency.
+type RetentionCatalogStore interface {
+	MutateRetention(ctx context.Context, registryName, appName string, mutate func(*RetentionIndex) (bool, error)) error
+}
+type MemoryRetentionCatalogStore struct {
+	mu      sync.Mutex
+	indices map[string]*RetentionIndex
+}
+
+func NewMemoryRetentionCatalogStore() *MemoryRetentionCatalogStore {
+	return &MemoryRetentionCatalogStore{
+		indices: map[string]*RetentionIndex{},
+	}
+}
+
+func retentionCatalogKey(registryName, appName string) string {
+	return registryName + "/" + appName
+}
+
+func (s *MemoryRetentionCatalogStore) MutateRetention(_ context.Context, registryName, appName string, mutate func(*RetentionIndex) (bool, error)) error {
+	if s == nil {
+		return nil
+	}
+	key := retentionCatalogKey(registryName, appName)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	index := s.indices[key]
+	if index == nil {
+		index = NewEmptyRetentionIndex()
+	} else {
+		index = cloneRetentionIndex(index)
+	}
+	changed, err := mutate(index)
+	if err != nil {
+		return err
+	}
+	if !changed {
+		return nil
+	}
+	s.indices[key] = index
+	return nil
+}
+
+func (s *MemoryRetentionCatalogStore) Get(registryName, appName string) *RetentionIndex {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return cloneRetentionIndex(s.indices[retentionCatalogKey(registryName, appName)])
+}
+
+func cloneRetentionIndex(index *RetentionIndex) *RetentionIndex {
+	if index == nil {
+		return NewEmptyRetentionIndex()
+	}
+	out := &RetentionIndex{
+		SchemaVersion: index.SchemaVersion,
+		Versions:      make(map[string]RetentionVersion, len(index.Versions)),
+	}
+	for version, entry := range index.Versions {
+		out.Versions[version] = cloneRetentionVersion(entry)
+	}
+	return out
+}
+
+func cloneRetentionVersion(entry RetentionVersion) RetentionVersion {
+	out := entry
+	out.PublishedAt = entry.PublishedAt.UTC()
+	out.LastDeactivatedAt = cloneTimePtr(entry.LastDeactivatedAt)
+	out.DeployableUntil = cloneTimePtr(entry.DeployableUntil)
+	out.FirstDeployedAt = cloneTimePtr(entry.FirstDeployedAt)
+	out.LockedAt = cloneTimePtr(entry.LockedAt)
+	return out
+}

--- a/gestaltd/internal/appregistry/retention_test.go
+++ b/gestaltd/internal/appregistry/retention_test.go
@@ -1,0 +1,86 @@
+package appregistry_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/appregistry"
+)
+
+func TestVersionDeploymentState(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	policy := appregistry.RetentionPolicy{
+		UnusedRetention:   72 * time.Hour,
+		DeployedRetention: 720 * time.Hour,
+	}
+	retention := appregistry.NewEmptyRetentionIndex()
+	appregistry.UpsertPublishedRetention(retention, "v-new", now.Add(-96*time.Hour))
+	retention.Versions["v-old"] = appregistry.RetentionVersion{
+		PublishedAt:     now.Add(-800 * time.Hour),
+		EverDeployed:    true,
+		FirstDeployedAt: ptrTime(now.Add(-800 * time.Hour)),
+		LastDeactivatedAt: ptrTime(now.Add(-100 * time.Hour)),
+		DeployableUntil:   ptrTime(now.Add(-10 * time.Hour)),
+	}
+
+	state, _ := appregistry.VersionDeploymentState("v-current", "v-current", retention, policy, now)
+	if state != appregistry.DeploymentStateDesired {
+		t.Fatalf("desired state = %q", state)
+	}
+	state, _ = appregistry.VersionDeploymentState("v-new", "v-current", retention, policy, now)
+	if state != appregistry.DeploymentStateExpired {
+		t.Fatalf("expired state = %q", state)
+	}
+	state, _ = appregistry.VersionDeploymentState("v-old", "v-current", retention, policy, now)
+	if state != appregistry.DeploymentStateLocked {
+		t.Fatalf("locked state = %q", state)
+	}
+}
+
+func TestEvaluateRetentionPrune(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	policy := appregistry.RetentionPolicy{UnusedRetention: 72 * time.Hour, DeployedRetention: 720 * time.Hour}
+	index := appregistry.NewEmptyIndex()
+	index.Apps["g-issues"] = appregistry.AppVersions{
+		Versions: map[string]appregistry.IndexVersion{
+			"v-unused": {PublishedAt: now.Add(-96 * time.Hour)},
+			"v-old":    {PublishedAt: now.Add(-800 * time.Hour)},
+		},
+	}
+	retention := appregistry.NewEmptyRetentionIndex()
+	appregistry.UpsertPublishedRetention(retention, "v-unused", now.Add(-96*time.Hour))
+	retention.Versions["v-old"] = appregistry.RetentionVersion{
+		PublishedAt:       now.Add(-800 * time.Hour),
+		EverDeployed:      true,
+		DeployableUntil:   ptrTime(now.Add(-1 * time.Hour)),
+		FirstDeployedAt:   ptrTime(now.Add(-800 * time.Hour)),
+		LastDeactivatedAt: ptrTime(now.Add(-40 * 24 * time.Hour)),
+	}
+
+	actions := appregistry.EvaluateRetentionPrune(index, retention, "g-issues", "v-current", map[string]struct{}{"v-old": {}}, policy, now)
+	if len(actions) < 2 {
+		t.Fatalf("actions = %#v", actions)
+	}
+}
+
+func TestDeployedVersionsFromChangeRequests(t *testing.T) {
+	t.Parallel()
+
+	versions := appregistry.DeployedVersionsFromChangeRequests([]*core.AppVersionChangeRequest{
+		{FromVersion: appregistry.FirstInstallFromVersion, ToVersion: "v1"},
+		{FromVersion: "v1", ToVersion: "v2"},
+	})
+	if _, ok := versions["v1"]; !ok || len(versions) != 2 {
+		t.Fatalf("versions = %#v", versions)
+	}
+}
+
+func ptrTime(value time.Time) *time.Time {
+	value = value.UTC()
+	return &value
+}

--- a/gestaltd/internal/appregistry/retention_test.go
+++ b/gestaltd/internal/appregistry/retention_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/appregistry"
 )
 
@@ -19,9 +18,9 @@ func TestVersionDeploymentState(t *testing.T) {
 	retention := appregistry.NewEmptyRetentionIndex()
 	appregistry.UpsertPublishedRetention(retention, "v-new", now.Add(-96*time.Hour))
 	retention.Versions["v-old"] = appregistry.RetentionVersion{
-		PublishedAt:     now.Add(-800 * time.Hour),
-		EverDeployed:    true,
-		FirstDeployedAt: ptrTime(now.Add(-800 * time.Hour)),
+		PublishedAt:       now.Add(-800 * time.Hour),
+		EverDeployed:      true,
+		FirstDeployedAt:   ptrTime(now.Add(-800 * time.Hour)),
 		LastDeactivatedAt: ptrTime(now.Add(-100 * time.Hour)),
 		DeployableUntil:   ptrTime(now.Add(-10 * time.Hour)),
 	}
@@ -37,46 +36,6 @@ func TestVersionDeploymentState(t *testing.T) {
 	state, _ = appregistry.VersionDeploymentState("v-old", "v-current", retention, policy, now)
 	if state != appregistry.DeploymentStateLocked {
 		t.Fatalf("locked state = %q", state)
-	}
-}
-
-func TestEvaluateRetentionPrune(t *testing.T) {
-	t.Parallel()
-
-	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
-	policy := appregistry.RetentionPolicy{UnusedRetention: 72 * time.Hour, DeployedRetention: 720 * time.Hour}
-	index := appregistry.NewEmptyIndex()
-	index.Apps["g-issues"] = appregistry.AppVersions{
-		Versions: map[string]appregistry.IndexVersion{
-			"v-unused": {PublishedAt: now.Add(-96 * time.Hour)},
-			"v-old":    {PublishedAt: now.Add(-800 * time.Hour)},
-		},
-	}
-	retention := appregistry.NewEmptyRetentionIndex()
-	appregistry.UpsertPublishedRetention(retention, "v-unused", now.Add(-96*time.Hour))
-	retention.Versions["v-old"] = appregistry.RetentionVersion{
-		PublishedAt:       now.Add(-800 * time.Hour),
-		EverDeployed:      true,
-		DeployableUntil:   ptrTime(now.Add(-1 * time.Hour)),
-		FirstDeployedAt:   ptrTime(now.Add(-800 * time.Hour)),
-		LastDeactivatedAt: ptrTime(now.Add(-40 * 24 * time.Hour)),
-	}
-
-	actions := appregistry.EvaluateRetentionPrune(index, retention, "g-issues", "v-current", map[string]struct{}{"v-old": {}}, policy, now)
-	if len(actions) < 2 {
-		t.Fatalf("actions = %#v", actions)
-	}
-}
-
-func TestDeployedVersionsFromChangeRequests(t *testing.T) {
-	t.Parallel()
-
-	versions := appregistry.DeployedVersionsFromChangeRequests([]*core.AppVersionChangeRequest{
-		{FromVersion: appregistry.FirstInstallFromVersion, ToVersion: "v1"},
-		{FromVersion: "v1", ToVersion: "v2"},
-	})
-	if _, ok := versions["v1"]; !ok || len(versions) != 2 {
-		t.Fatalf("versions = %#v", versions)
 	}
 }
 

--- a/gestaltd/internal/config/app_registry_config.go
+++ b/gestaltd/internal/config/app_registry_config.go
@@ -3,17 +3,31 @@ package config
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
 
 const AppRegistryKindGCS = "gcs"
 
-const defaultGCSAppRegistryPublicURLPrefix = "https://storage.googleapis.com/"
+const (
+	defaultGCSAppRegistryPublicURLPrefix = "https://storage.googleapis.com/"
+	defaultAppRegistryUnusedRetention    = 72 * time.Hour
+	defaultAppRegistryDeployedRetention  = 720 * time.Hour
+)
 
 type AppRegistryConfig struct {
-	Kind string                `yaml:"kind,omitempty"`
-	GCS  *AppRegistryGCSConfig `yaml:"gcs,omitempty"`
+	Kind      string                      `yaml:"kind,omitempty"`
+	GCS       *AppRegistryGCSConfig       `yaml:"gcs,omitempty"`
+	Retention *AppRegistryRetentionConfig `yaml:"retention,omitempty"`
+}
+
+type AppRegistryRetentionConfig struct {
+	UnusedRetention   string `yaml:"unusedRetention,omitempty"`
+	DeployedRetention string `yaml:"deployedRetention,omitempty"`
+
+	unusedRetentionSet   bool
+	deployedRetentionSet bool
 }
 
 type AppRegistryGCSConfig struct {
@@ -21,8 +35,9 @@ type AppRegistryGCSConfig struct {
 }
 
 type appRegistryConfigYAML struct {
-	Kind string                `yaml:"kind,omitempty"`
-	GCS  *AppRegistryGCSConfig `yaml:"gcs,omitempty"`
+	Kind      string                      `yaml:"kind,omitempty"`
+	GCS       *AppRegistryGCSConfig       `yaml:"gcs,omitempty"`
+	Retention *AppRegistryRetentionConfig `yaml:"retention,omitempty"`
 }
 
 func (c *AppRegistryConfig) UnmarshalYAML(value *yaml.Node) error {
@@ -47,7 +62,67 @@ func (c *AppRegistryConfig) UnmarshalYAML(value *yaml.Node) error {
 	}
 	c.Kind = raw.Kind
 	c.GCS = raw.GCS
+	c.Retention = raw.Retention
 	return nil
+}
+
+func (c *AppRegistryRetentionConfig) UnmarshalYAML(value *yaml.Node) error {
+	if value == nil {
+		return nil
+	}
+	var raw struct {
+		UnusedRetention   string `yaml:"unusedRetention,omitempty"`
+		DeployedRetention string `yaml:"deployedRetention,omitempty"`
+	}
+	if err := decodeYAMLNodeKnownFields(value, &raw); err != nil {
+		return err
+	}
+	if strings.TrimSpace(raw.UnusedRetention) != "" {
+		c.UnusedRetention = strings.TrimSpace(raw.UnusedRetention)
+		c.unusedRetentionSet = true
+	}
+	if strings.TrimSpace(raw.DeployedRetention) != "" {
+		c.DeployedRetention = strings.TrimSpace(raw.DeployedRetention)
+		c.deployedRetentionSet = true
+	}
+	return nil
+}
+
+// UnusedRetentionDuration returns the configured unused snapshot retention window.
+func (c AppRegistryConfig) UnusedRetentionDuration() (time.Duration, error) {
+	if c.Retention == nil || strings.TrimSpace(c.Retention.UnusedRetention) == "" {
+		return defaultAppRegistryUnusedRetention, nil
+	}
+	duration, err := ParseDuration(strings.TrimSpace(c.Retention.UnusedRetention))
+	if err != nil {
+		return 0, fmt.Errorf("retention.unusedRetention: %w", err)
+	}
+	return duration, nil
+}
+
+// DeployedRetentionDuration returns the configured historical redeploy window.
+func (c AppRegistryConfig) DeployedRetentionDuration() (time.Duration, error) {
+	if c.Retention == nil || strings.TrimSpace(c.Retention.DeployedRetention) == "" {
+		return defaultAppRegistryDeployedRetention, nil
+	}
+	duration, err := ParseDuration(strings.TrimSpace(c.Retention.DeployedRetention))
+	if err != nil {
+		return 0, fmt.Errorf("retention.deployedRetention: %w", err)
+	}
+	return duration, nil
+}
+
+// RetentionPolicy returns both retention durations for one registry binding.
+func (c AppRegistryConfig) RetentionPolicy() (unused, deployed time.Duration, err error) {
+	unused, err = c.UnusedRetentionDuration()
+	if err != nil {
+		return 0, 0, err
+	}
+	deployed, err = c.DeployedRetentionDuration()
+	if err != nil {
+		return 0, 0, err
+	}
+	return unused, deployed, nil
 }
 
 func (c *AppRegistryGCSConfig) UnmarshalYAML(value *yaml.Node) error {

--- a/gestaltd/internal/config/app_registry_retention_test.go
+++ b/gestaltd/internal/config/app_registry_retention_test.go
@@ -1,0 +1,81 @@
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAppRegistryRetentionDefaults(t *testing.T) {
+	t.Parallel()
+
+	registry, err := NewGCSAppRegistry("gestalt-app-registry")
+	if err != nil {
+		t.Fatalf("NewGCSAppRegistry: %v", err)
+	}
+	unused, err := registry.UnusedRetentionDuration()
+	if err != nil {
+		t.Fatalf("UnusedRetentionDuration: %v", err)
+	}
+	if unused != 72*time.Hour {
+		t.Fatalf("unused = %v", unused)
+	}
+	deployed, err := registry.DeployedRetentionDuration()
+	if err != nil {
+		t.Fatalf("DeployedRetentionDuration: %v", err)
+	}
+	if deployed != 720*time.Hour {
+		t.Fatalf("deployed = %v", deployed)
+	}
+}
+
+func TestAppRegistryRetentionValidation(t *testing.T) {
+	t.Parallel()
+
+	path := mustWriteConfigFile(t, `
+appRegistries:
+  toolshed:
+    kind: gcs
+    gcs:
+      bucket: gs://gestalt-app-registry
+    retention:
+      unusedRetention: 48h
+      deployedRetention: 30d
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	unused, err := cfg.AppRegistries["toolshed"].UnusedRetentionDuration()
+	if err != nil {
+		t.Fatalf("UnusedRetentionDuration: %v", err)
+	}
+	if unused != 48*time.Hour {
+		t.Fatalf("unused = %v", unused)
+	}
+	deployed, err := cfg.AppRegistries["toolshed"].DeployedRetentionDuration()
+	if err != nil {
+		t.Fatalf("DeployedRetentionDuration: %v", err)
+	}
+	if deployed != 30*24*time.Hour {
+		t.Fatalf("deployed = %v", deployed)
+	}
+}
+
+func TestAppRegistryRetentionRejectsInvalidDuration(t *testing.T) {
+	t.Parallel()
+
+	path := mustWriteConfigFile(t, `
+appRegistries:
+  toolshed:
+    kind: gcs
+    gcs:
+      bucket: gs://gestalt-app-registry
+    retention:
+      unusedRetention: not-a-duration
+`)
+	_, err := Load(path)
+	if err == nil || !strings.Contains(err.Error(), "retention.unusedRetention") {
+		t.Fatalf("Load error = %v", err)
+	}
+}

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -225,6 +225,14 @@ func validateAppRegistryLocation(prefix, name string, registry AppRegistryConfig
 	if _, err := registry.PublicURL(); err != nil {
 		return fmt.Errorf("config validation: %s.%s: %w", prefix, name, err)
 	}
+	if registry.Retention != nil {
+		if _, err := registry.UnusedRetentionDuration(); err != nil {
+			return fmt.Errorf("config validation: %s.%s: %w", prefix, name, err)
+		}
+		if _, err := registry.DeployedRetentionDuration(); err != nil {
+			return fmt.Errorf("config validation: %s.%s: %w", prefix, name, err)
+		}
+	}
 	return nil
 }
 

--- a/gestaltd/internal/coredata/app_version_change_requests.go
+++ b/gestaltd/internal/coredata/app_version_change_requests.go
@@ -58,6 +58,9 @@ func (s *AppVersionChangeRequestService) AppendRequest(ctx context.Context, requ
 		"timestamp":     timestamp,
 		"metadata_json": jsonValue(request.Metadata),
 	}
+	if request.FromVersionDeployableUntil != nil && !request.FromVersionDeployableUntil.IsZero() {
+		rec["from_version_deployable_until"] = request.FromVersionDeployableUntil.UTC().Truncate(time.Millisecond)
+	}
 	if err := s.store.Add(ctx, rec); err != nil {
 		return nil, fmt.Errorf("append app version change request: %w", err)
 	}
@@ -108,13 +111,18 @@ func (s *AppVersionChangeRequestService) HasKnownVersion(ctx context.Context, ap
 }
 
 func recordToAppVersionChangeRequest(rec idb.Record) *core.AppVersionChangeRequest {
+	var deployableUntil *time.Time
+	if value := recTime(rec, "from_version_deployable_until"); !value.IsZero() {
+		deployableUntil = &value
+	}
 	return &core.AppVersionChangeRequest{
-		ID:          recString(rec, "id"),
-		App:         recString(rec, "app"),
-		FromVersion: recString(rec, "from_version"),
-		ToVersion:   recString(rec, "to_version"),
-		Actor:       recString(rec, "actor"),
-		Timestamp:   recTime(rec, "timestamp"),
-		Metadata:    recAnyMap(rec, "metadata_json"),
+		ID:                         recString(rec, "id"),
+		App:                        recString(rec, "app"),
+		FromVersion:                recString(rec, "from_version"),
+		ToVersion:                  recString(rec, "to_version"),
+		Actor:                      recString(rec, "actor"),
+		Timestamp:                  recTime(rec, "timestamp"),
+		FromVersionDeployableUntil: deployableUntil,
+		Metadata:                   recAnyMap(rec, "metadata_json"),
 	}
 }

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -72,6 +72,7 @@ var AppVersionChangeRequestsSchema = idb.ObjectStoreOptions{
 		{Name: "to_version", Type: idb.TypeString, NotNull: true},
 		{Name: "actor", Type: idb.TypeString},
 		{Name: "timestamp", Type: idb.TypeTime, NotNull: true},
+		{Name: "from_version_deployable_until", Type: idb.TypeTime},
 		{Name: "metadata_json", Type: idb.TypeJSON},
 	},
 }

--- a/gestaltd/internal/daemon/app_publish.go
+++ b/gestaltd/internal/daemon/app_publish.go
@@ -526,7 +526,10 @@ func uploadAppPublishPlan(plan appPublishPlan, sourceRef string) error {
 	if err := uploadAppPublishImmutableObjects(plan, sourceRef); err != nil {
 		return err
 	}
-	return uploadAppRegistryIndex(plan, sourceRef)
+	if err := uploadAppRegistryIndex(plan, sourceRef); err != nil {
+		return err
+	}
+	return uploadAppRegistryRetention(plan, sourceRef)
 }
 
 func uploadAppPublishImmutableObjects(plan appPublishPlan, sourceRef string) error {
@@ -654,6 +657,54 @@ func uploadAppRegistryIndex(plan appPublishPlan, sourceRef string) error {
 		return nil
 	}
 	return fmt.Errorf("update %s: exceeded retry limit after concurrent index updates", indexPath)
+}
+
+func uploadAppRegistryRetention(plan appPublishPlan, sourceRef string) error {
+	storageRoot := strings.TrimSuffix(plan.IndexObject.StorageURL, appregistry.AppIndexPath(plan.AppName))
+	retentionPath := appregistry.StorageURL(storageRoot, appregistry.AppRetentionPath(plan.AppName))
+	progress := startCommandProgress("Updating app registry retention catalog")
+	for attempt := 1; attempt <= appPublishIndexUpdateAttempts; attempt++ {
+		if attempt > 1 {
+			progress.status("App registry retention catalog changed concurrently; retrying attempt %d/%d", attempt, appPublishIndexUpdateAttempts)
+		}
+		generation, existing, err := downloadAppRegistryObject(retentionPath)
+		if err != nil {
+			return err
+		}
+		var index *appregistry.RetentionIndex
+		if len(existing) == 0 {
+			index = appregistry.NewEmptyRetentionIndex()
+		} else {
+			index, err = appregistry.DecodeRetentionIndex(existing)
+			if err != nil {
+				return fmt.Errorf("decode existing retention index: %w", err)
+			}
+		}
+		if !appregistry.UpsertPublishedRetention(index, plan.Version, plan.Entry.PublishedAt) {
+			progress.done("App registry retention catalog unchanged")
+			return nil
+		}
+		data, err := json.MarshalIndent(index, "", "  ")
+		if err != nil {
+			return err
+		}
+		tmpPath, err := writeTempJSON("gestalt-app-retention-*", append(data, '\n'))
+		if err != nil {
+			return err
+		}
+		if err := uploadAppRegistryIndexFile(tmpPath, retentionPath, sourceRef, generation); err != nil {
+			_ = os.Remove(tmpPath)
+			if appPublishPreconditionFailed(err) && attempt < appPublishIndexUpdateAttempts {
+				continue
+			}
+			return err
+		}
+		_ = os.Remove(tmpPath)
+		progress.done("Updated app registry retention catalog")
+		_, _ = fmt.Fprintf(os.Stdout, "updated %s\n", retentionPath)
+		return nil
+	}
+	return fmt.Errorf("update %s: exceeded retry limit after concurrent retention updates", retentionPath)
 }
 
 func uploadAppRegistryIndexFile(localPath, storageURL, sourceRef string, generation int64) error {

--- a/gestaltd/internal/server/handlers_app_admin_registry.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry.go
@@ -42,6 +42,9 @@ type appAdminPublishedVersion struct {
 	SourceRef              string                   `json:"sourceRef,omitempty"`
 	SourceURL              string                   `json:"sourceUrl,omitempty"`
 	Publication            *appregistry.Publication `json:"publication,omitempty"`
+	DeploymentState        string                   `json:"deploymentState,omitempty"`
+	DeployableUntil        string                   `json:"deployableUntil,omitempty"`
+	Current                bool                     `json:"current,omitempty"`
 }
 
 type appAdminPendingVersion struct {
@@ -195,13 +198,24 @@ func (s *Server) getAppAdminRegistry(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadGateway, "failed to fetch app registry failed catalog")
 		return
 	}
+	retentionIndex, err := reader.FetchRetentionIndex(r.Context(), publicRoot, app.name)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "failed to fetch app registry retention catalog")
+		return
+	}
+	policy, err := retentionPolicyFromRegistry(registry)
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "app registry is unavailable")
+		return
+	}
 	now := time.Now().UTC()
 	publishedKeys := appregistry.PublishedVersionKeys(index, app.name)
 	pendingKeys := appregistry.PendingVersionKeys(pendingIndex)
 	summaries := appregistry.VersionsFromIndex(index, app.name)
 	published := make([]appAdminPublishedVersion, 0, len(summaries))
+	desiredVersion := coredata.LatestKnownVersion(known)
 	for i := range summaries {
-		published = append(published, appAdminPublishedVersionFromSummary(summaries[i]))
+		published = append(published, appAdminPublishedVersionFromSummary(summaries[i], desiredVersion, retentionIndex, policy, now))
 	}
 	pendingVersions := make([]appAdminPendingVersion, 0)
 	for _, entry := range appregistry.PendingVersionsForAdmin(pendingIndex, publishedKeys) {
@@ -218,7 +232,7 @@ func (s *Server) getAppAdminRegistry(w http.ResponseWriter, r *http.Request) {
 	response := appAdminRegistryResponse{
 		App:               app.name,
 		Registry:          app.registry,
-		DesiredVersion:    coredata.LatestKnownVersion(known),
+		DesiredVersion:    desiredVersion,
 		KnownVersions:     knownVersions,
 		PublishedVersions: published,
 		PendingVersions:   pendingVersions,
@@ -306,7 +320,9 @@ func writeAppAdminRegistryInstallError(w http.ResponseWriter, err error) {
 	status := http.StatusBadGateway
 	switch {
 	case errors.Is(err, appregistry.ErrAppVersionAlreadyInstalled),
-		errors.Is(err, appregistry.ErrInstallValidationFailed):
+		errors.Is(err, appregistry.ErrInstallValidationFailed),
+		errors.Is(err, appregistry.ErrAppVersionExpired),
+		errors.Is(err, appregistry.ErrAppVersionLocked):
 		status = http.StatusBadRequest
 	case errors.Is(err, appregistry.ErrRegistryDocumentNotFound):
 		status = http.StatusNotFound
@@ -333,7 +349,7 @@ func appVersionSourceURL(repository, sourceRef string) string {
 	return repository + "/commit/" + sourceRef
 }
 
-func appAdminPublishedVersionFromSummary(summary appregistry.VersionSummary) appAdminPublishedVersion {
+func appAdminPublishedVersionFromSummary(summary appregistry.VersionSummary, desiredVersion string, retention *appregistry.RetentionIndex, policy appregistry.RetentionPolicy, now time.Time) appAdminPublishedVersion {
 	version := appAdminPublishedVersion{
 		Version:     summary.Version,
 		PublishedAt: formatAdminTime(summary.PublishedAt),
@@ -342,6 +358,12 @@ func appAdminPublishedVersionFromSummary(summary appregistry.VersionSummary) app
 		SourceURL:   appVersionSourceURL(summary.Repository, summary.SourceRef),
 		Publication: summary.Publication,
 	}
+	state, deployableUntil := appregistry.VersionDeploymentState(summary.Version, desiredVersion, retention, policy, now)
+	version.DeploymentState = state
+	if deployableUntil != nil && !deployableUntil.IsZero() {
+		version.DeployableUntil = formatAdminTime(*deployableUntil)
+	}
+	version.Current = summary.Version == desiredVersion && desiredVersion != ""
 	if summary.PublishStartedAt != nil && !summary.PublishStartedAt.IsZero() {
 		version.PublishStartedAt = formatAdminTime(*summary.PublishStartedAt)
 		if seconds, ok := appregistry.DurationSecondsBetween(*summary.PublishStartedAt, summary.PublishedAt); ok {
@@ -349,6 +371,17 @@ func appAdminPublishedVersionFromSummary(summary appregistry.VersionSummary) app
 		}
 	}
 	return version
+}
+
+func retentionPolicyFromRegistry(registry config.AppRegistryConfig) (appregistry.RetentionPolicy, error) {
+	unused, deployed, err := registry.RetentionPolicy()
+	if err != nil {
+		return appregistry.RetentionPolicy{}, err
+	}
+	return appregistry.RetentionPolicy{
+		UnusedRetention:   unused,
+		DeployedRetention: deployed,
+	}, nil
 }
 
 func appAdminPendingVersionFromEntry(entry appregistry.PendingVersion, now time.Time) appAdminPendingVersion {


### PR DESCRIPTION
## Summary
- Add `RetentionIndex` and retention policy config on `appRegistries` (`unusedRetention`, `deployedRetention`).
- Upsert `retention.json` during publish and mirror fleet version transitions from the installer.
- Record fixed `from_version_deployable_until` on change requests and expose `deploymentState` on app-admin published versions.

## Test plan
- [x] `go test ./internal/appregistry/... ./internal/config/... ./internal/server/...`
- [ ] Verify publish writes `retention.json` in a dry-run publish harness
- [ ] Verify app-admin registry state returns `deploymentState` for published versions


Made with [Cursor](https://cursor.com)