### PR TITLE
PR 4: Add app-admin revision history API

### DIFF
--- a/gestaltd/internal/coredata/app_version_change_requests.go
+++ b/gestaltd/internal/coredata/app_version_change_requests.go
@@ -3,6 +3,7 @@ package coredata
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -12,6 +13,16 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 )
+
+const (
+	DefaultAppVersionChangeRequestPageLimit = 50
+	MaxAppVersionChangeRequestPageLimit     = 100
+)
+
+type AppVersionChangeRequestPage struct {
+	Requests   []*core.AppVersionChangeRequest
+	NextCursor string
+}
 
 type AppVersionChangeRequestService struct {
 	store idb.ObjectStore
@@ -89,6 +100,125 @@ func (s *AppVersionChangeRequestService) ListRequestsByApp(ctx context.Context, 
 		out = append(out, recordToAppVersionChangeRequest(rec))
 	}
 	return out, nil
+}
+
+func (s *AppVersionChangeRequestService) ListRequestsByAppPage(ctx context.Context, appName string, limit int, cursor string) (*AppVersionChangeRequestPage, error) {
+	requests, err := s.ListRequestsByApp(ctx, appName)
+	if err != nil {
+		return nil, err
+	}
+	sortChangeRequestsDesc(requests)
+
+	cursorTime, cursorID, err := parseAppVersionChangeRequestCursor(cursor)
+	if err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		limit = DefaultAppVersionChangeRequestPageLimit
+	}
+	if limit > MaxAppVersionChangeRequestPageLimit {
+		limit = MaxAppVersionChangeRequestPageLimit
+	}
+
+	filtered := make([]*core.AppVersionChangeRequest, 0, len(requests))
+	for _, request := range requests {
+		if request == nil {
+			continue
+		}
+		if !cursorTime.IsZero() && !changeRequestBeforeCursor(request, cursorTime, cursorID) {
+			continue
+		}
+		filtered = append(filtered, request)
+	}
+
+	page := &AppVersionChangeRequestPage{
+		Requests: filtered,
+	}
+	if len(filtered) > limit {
+		last := filtered[limit-1]
+		page.Requests = filtered[:limit]
+		page.NextCursor = formatAppVersionChangeRequestCursor(last.Timestamp, last.ID)
+	}
+	return page, nil
+}
+
+func (s *AppVersionChangeRequestService) LatestDesiredRevisionID(ctx context.Context, appName, desiredVersion string) (string, error) {
+	requests, err := s.ListRequestsByApp(ctx, appName)
+	if err != nil {
+		return "", err
+	}
+	return latestDesiredRevisionID(requests, desiredVersion), nil
+}
+
+func latestDesiredRevisionID(requests []*core.AppVersionChangeRequest, desiredVersion string) string {
+	desiredVersion = strings.TrimSpace(desiredVersion)
+	if desiredVersion == "" {
+		return ""
+	}
+	var latestID string
+	var latestTime time.Time
+	for _, request := range requests {
+		if request == nil || strings.TrimSpace(request.ToVersion) != desiredVersion {
+			continue
+		}
+		if latestID == "" || request.Timestamp.After(latestTime) ||
+			(request.Timestamp.Equal(latestTime) && request.ID > latestID) {
+			latestID = request.ID
+			latestTime = request.Timestamp
+		}
+	}
+	return latestID
+}
+
+func sortChangeRequestsDesc(requests []*core.AppVersionChangeRequest) {
+	sort.Slice(requests, func(i, j int) bool {
+		left := requests[i]
+		right := requests[j]
+		if left == nil {
+			return false
+		}
+		if right == nil {
+			return true
+		}
+		if left.Timestamp.Equal(right.Timestamp) {
+			return left.ID > right.ID
+		}
+		return left.Timestamp.After(right.Timestamp)
+	})
+}
+
+func parseAppVersionChangeRequestCursor(cursor string) (time.Time, string, error) {
+	cursor = strings.TrimSpace(cursor)
+	if cursor == "" {
+		return time.Time{}, "", nil
+	}
+	separator := strings.LastIndex(cursor, ":")
+	if separator <= 0 {
+		return time.Time{}, "", fmt.Errorf("invalid revision history cursor")
+	}
+	timestamp, err := time.Parse(time.RFC3339, cursor[:separator])
+	if err != nil {
+		return time.Time{}, "", fmt.Errorf("invalid revision history cursor: %w", err)
+	}
+	id := strings.TrimSpace(cursor[separator+1:])
+	if id == "" {
+		return time.Time{}, "", fmt.Errorf("invalid revision history cursor")
+	}
+	return timestamp.UTC(), id, nil
+}
+
+func formatAppVersionChangeRequestCursor(timestamp time.Time, id string) string {
+	return timestamp.UTC().Format(time.RFC3339) + ":" + strings.TrimSpace(id)
+}
+
+func changeRequestBeforeCursor(request *core.AppVersionChangeRequest, cursorTime time.Time, cursorID string) bool {
+	if request.Timestamp.After(cursorTime) {
+		return false
+	}
+	if request.Timestamp.Before(cursorTime) {
+		return true
+	}
+	return request.ID < cursorID
 }
 
 func (s *AppVersionChangeRequestService) HasKnownVersion(ctx context.Context, appName, version string) (bool, error) {

--- a/gestaltd/internal/server/handlers_app_admin_registry.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry.go
@@ -88,9 +88,9 @@ type appAdminRegistryVersionResponse struct {
 }
 
 type appAdminRegistryHistoryResponse struct {
-	App        string                       `json:"app"`
-	Revisions  []appAdminRegistryRevision   `json:"revisions"`
-	NextCursor string                       `json:"nextCursor,omitempty"`
+	App        string                     `json:"app"`
+	Revisions  []appAdminRegistryRevision `json:"revisions"`
+	NextCursor string                     `json:"nextCursor,omitempty"`
 }
 
 type appAdminRegistryRevision struct {
@@ -536,8 +536,8 @@ func parseAppAdminHistoryLimit(raw string) int {
 func publishedVersionSummaryMap(index *appregistry.Index, appName string) map[string]appregistry.VersionSummary {
 	summaries := appregistry.VersionsFromIndex(index, appName)
 	out := make(map[string]appregistry.VersionSummary, len(summaries))
-	for _, summary := range summaries {
-		out[summary.Version] = summary
+	for i := range summaries {
+		out[summaries[i].Version] = summaries[i]
 	}
 	return out
 }

--- a/gestaltd/internal/server/handlers_app_admin_registry.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -86,9 +87,31 @@ type appAdminRegistryVersionResponse struct {
 	Rollout        appAdminRollout `json:"rollout"`
 }
 
+type appAdminRegistryHistoryResponse struct {
+	App        string                       `json:"app"`
+	Revisions  []appAdminRegistryRevision   `json:"revisions"`
+	NextCursor string                       `json:"nextCursor,omitempty"`
+}
+
+type appAdminRegistryRevision struct {
+	ID              string                   `json:"id"`
+	Version         string                   `json:"version"`
+	PreviousVersion string                   `json:"previousVersion,omitempty"`
+	DeployedAt      string                   `json:"deployedAt"`
+	DeployedBy      string                   `json:"deployedBy,omitempty"`
+	SourceRef       string                   `json:"sourceRef,omitempty"`
+	SourceURL       string                   `json:"sourceUrl,omitempty"`
+	Publication     *appregistry.Publication `json:"publication,omitempty"`
+	DeploymentState string                   `json:"deploymentState,omitempty"`
+	DeployableUntil string                   `json:"deployableUntil,omitempty"`
+	Current         bool                     `json:"current,omitempty"`
+}
+
 func (s *Server) mountAppAdminRegistryRoutes(r chi.Router) {
 	r.With(s.pluginRouteAuthMiddleware("app"), s.appAdminAuthorizationMiddleware).
 		Get("/apps/{app}/admin/registry", s.getAppAdminRegistry)
+	r.With(s.pluginRouteAuthMiddleware("app"), s.appAdminAuthorizationMiddleware).
+		Get("/apps/{app}/admin/registry/history", s.getAppAdminRegistryHistory)
 	r.With(s.pluginRouteAuthMiddleware("app"), s.appAdminAuthorizationMiddleware).
 		Post("/apps/{app}/admin/registry/version", s.selectAppAdminRegistryVersion)
 }
@@ -250,6 +273,88 @@ func (s *Server) getAppAdminRegistry(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, response)
+}
+
+func (s *Server) getAppAdminRegistryHistory(w http.ResponseWriter, r *http.Request) {
+	app, registry, ok := s.appAdminRegistryConfig(w, r)
+	if !ok {
+		return
+	}
+	if s.appVersionChanges == nil {
+		writeError(w, http.StatusServiceUnavailable, "app registry installation services are unavailable")
+		return
+	}
+	limit := parseAppAdminHistoryLimit(r.URL.Query().Get("limit"))
+	cursor := strings.TrimSpace(r.URL.Query().Get("cursor"))
+	page, err := s.appVersionChanges.ListRequestsByAppPage(r.Context(), app.name, limit, cursor)
+	if err != nil {
+		if strings.Contains(err.Error(), "invalid revision history cursor") {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		writeError(w, http.StatusServiceUnavailable, "app registry installation services are unavailable")
+		return
+	}
+
+	publicRoot, err := registry.PublicURL()
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "app registry is unavailable")
+		return
+	}
+	reader := s.appRegistryReader
+	if reader == nil {
+		reader = &appregistry.RegistryReader{}
+	}
+	index, err := reader.FetchAppIndex(r.Context(), publicRoot, app.name)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "failed to fetch app registry index")
+		return
+	}
+	retentionIndex, err := reader.FetchRetentionIndex(r.Context(), publicRoot, app.name)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "failed to fetch app registry retention catalog")
+		return
+	}
+	policy, err := retentionPolicyFromRegistry(registry)
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "app registry is unavailable")
+		return
+	}
+
+	known, err := s.appVersionChanges.ListKnownVersionsByApp(r.Context(), app.name)
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "app registry installation services are unavailable")
+		return
+	}
+	desiredVersion := coredata.LatestKnownVersion(known)
+	currentRevisionID, err := s.appVersionChanges.LatestDesiredRevisionID(r.Context(), app.name, desiredVersion)
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "app registry installation services are unavailable")
+		return
+	}
+	publishedByVersion := publishedVersionSummaryMap(index, app.name)
+	now := time.Now().UTC()
+
+	revisions := make([]appAdminRegistryRevision, 0, len(page.Requests))
+	for _, request := range page.Requests {
+		if request == nil {
+			continue
+		}
+		revisions = append(revisions, appAdminRegistryRevisionFromRequest(
+			request,
+			desiredVersion,
+			currentRevisionID,
+			retentionIndex,
+			policy,
+			publishedByVersion,
+			now,
+		))
+	}
+	writeJSON(w, http.StatusOK, appAdminRegistryHistoryResponse{
+		App:        app.name,
+		Revisions:  revisions,
+		NextCursor: page.NextCursor,
+	})
 }
 
 func (s *Server) selectAppAdminRegistryVersion(w http.ResponseWriter, r *http.Request) {
@@ -414,4 +519,84 @@ func appAdminFailedVersionFromEntry(entry appregistry.FailedVersion) appAdminFai
 		version.PublishDurationSeconds = &seconds
 	}
 	return version
+}
+
+func parseAppAdminHistoryLimit(raw string) int {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return coredata.DefaultAppVersionChangeRequestPageLimit
+	}
+	limit, err := strconv.Atoi(raw)
+	if err != nil || limit <= 0 {
+		return coredata.DefaultAppVersionChangeRequestPageLimit
+	}
+	return limit
+}
+
+func publishedVersionSummaryMap(index *appregistry.Index, appName string) map[string]appregistry.VersionSummary {
+	summaries := appregistry.VersionsFromIndex(index, appName)
+	out := make(map[string]appregistry.VersionSummary, len(summaries))
+	for _, summary := range summaries {
+		out[summary.Version] = summary
+	}
+	return out
+}
+
+func appAdminRegistryRevisionFromRequest(
+	request *core.AppVersionChangeRequest,
+	desiredVersion string,
+	currentRevisionID string,
+	retention *appregistry.RetentionIndex,
+	policy appregistry.RetentionPolicy,
+	publishedByVersion map[string]appregistry.VersionSummary,
+	now time.Time,
+) appAdminRegistryRevision {
+	version := strings.TrimSpace(request.ToVersion)
+	revision := appAdminRegistryRevision{
+		ID:         request.ID,
+		Version:    version,
+		DeployedAt: formatAdminTime(request.Timestamp),
+		DeployedBy: strings.TrimSpace(request.Actor),
+		Current:    request.ID == currentRevisionID,
+	}
+	fromVersion := strings.TrimSpace(request.FromVersion)
+	if fromVersion != "" && fromVersion != appregistry.FirstInstallFromVersion {
+		revision.PreviousVersion = fromVersion
+	}
+
+	installation := coredata.InstallationFromChangeRequest(request)
+	sourceRef := ""
+	repository := ""
+	if installation != nil {
+		sourceRef = strings.TrimSpace(installation.SourceRef)
+	}
+	if summary, ok := publishedByVersion[version]; ok {
+		if sourceRef == "" {
+			sourceRef = strings.TrimSpace(summary.SourceRef)
+		}
+		repository = strings.TrimSpace(summary.Repository)
+		revision.Publication = summary.Publication
+	}
+	revision.SourceRef = sourceRef
+	revision.SourceURL = appVersionSourceURL(repository, sourceRef)
+
+	state, deployableUntil := appregistry.VersionDeploymentState(version, desiredVersion, retention, policy, now)
+	revision.DeploymentState = historyDeploymentState(state)
+	if deployableUntil != nil && !deployableUntil.IsZero() {
+		revision.DeployableUntil = formatAdminTime(*deployableUntil)
+	}
+	return revision
+}
+
+func historyDeploymentState(state string) string {
+	switch state {
+	case appregistry.DeploymentStateDesired:
+		return "desired"
+	case appregistry.DeploymentStateRedeployable:
+		return "redeployable"
+	case appregistry.DeploymentStateLocked:
+		return "locked"
+	default:
+		return state
+	}
 }

--- a/gestaltd/internal/server/handlers_app_admin_registry_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry_test.go
@@ -2,15 +2,19 @@ package server_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/appregistry"
 	"github.com/valon-technologies/gestalt/server/internal/appregistry/registrytest"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	"github.com/valon-technologies/gestalt/server/internal/server"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
@@ -310,5 +314,145 @@ func TestAppAdminRegistryIncludesPendingAndFailedVersions(t *testing.T) {
 	}
 	if state.FailedVersions[0].PublishDurationSeconds == nil || state.FailedVersions[0].Reason != "stale" {
 		t.Fatalf("failedVersions = %#v", state.FailedVersions)
+	}
+}
+
+func TestAppAdminRegistryHistory(t *testing.T) {
+	t.Parallel()
+
+	fixture := registrytest.NewInstallFixture(t)
+	services := testutil.NewStubServices(t)
+	subjectID := principal.UserSubjectID("alice")
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(subjectID, "admin", "app", "g-issues"),
+		},
+	}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", subjectID, "")
+		cfg.Authorization = authz
+		cfg.Services = services
+		cfg.AppDefs = map[string]*config.ProviderEntry{
+			"g-issues": {Source: config.ProviderSource{Registry: "toolshed"}},
+		}
+		cfg.AppRegistries = map[string]config.AppRegistryConfig{"toolshed": fixture.Registry}
+		cfg.AppRegistryReader = fixture.Reader
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	firstAt := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	secondAt := time.Date(2026, 7, 24, 16, 42, 0, 0, time.UTC)
+	thirdAt := time.Date(2026, 7, 25, 9, 10, 0, 0, time.UTC)
+	otherVersion := "0.0.0-snapshot.gdef456"
+
+	appendHistoryRequest := func(fromVersion, toVersion string, at time.Time) string {
+		t.Helper()
+		request, err := services.AppVersionChangeRequests.AppendRequest(context.Background(), &core.AppVersionChangeRequest{
+			App:         "g-issues",
+			FromVersion: fromVersion,
+			ToVersion:   toVersion,
+			Actor:       "user:alice",
+			Timestamp:   at,
+			Metadata: coredata.ChangeRequestMetadata(&core.AppInstallation{
+				AppName:   "g-issues",
+				Version:   toVersion,
+				SourceRef: "abc123def456abc123def456abc123def456abcd",
+				Registry:  "toolshed",
+			}),
+		})
+		if err != nil {
+			t.Fatalf("AppendRequest: %v", err)
+		}
+		return request.ID
+	}
+
+	firstID := appendHistoryRequest(appregistry.FirstInstallFromVersion, fixture.Version, firstAt)
+	appendHistoryRequest(fixture.Version, otherVersion, secondAt)
+	thirdID := appendHistoryRequest(otherVersion, fixture.Version, thirdAt)
+
+	request, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/g-issues/admin/registry/history", nil)
+	request.Header.Set("Authorization", "Bearer alice-token")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET history: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("GET status = %d: %s", response.StatusCode, body)
+	}
+	var history struct {
+		Revisions []struct {
+			ID              string `json:"id"`
+			Version         string `json:"version"`
+			PreviousVersion string `json:"previousVersion"`
+			DeployedBy      string `json:"deployedBy"`
+			DeploymentState string `json:"deploymentState"`
+			Current         bool   `json:"current"`
+			Publication     struct {
+				WorkflowRunURL string `json:"workflowRunUrl"`
+			} `json:"publication"`
+		} `json:"revisions"`
+		NextCursor string `json:"nextCursor"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&history); err != nil {
+		t.Fatalf("decode history: %v", err)
+	}
+	if len(history.Revisions) != 3 {
+		t.Fatalf("revisions = %#v", history.Revisions)
+	}
+	if history.Revisions[0].ID != thirdID || history.Revisions[0].Version != fixture.Version ||
+		history.Revisions[0].PreviousVersion != otherVersion || !history.Revisions[0].Current ||
+		history.Revisions[0].DeploymentState != "desired" || history.Revisions[0].DeployedBy != "user:alice" {
+		t.Fatalf("newest revision = %#v", history.Revisions[0])
+	}
+	if history.Revisions[2].ID != firstID || history.Revisions[2].PreviousVersion != "" {
+		t.Fatalf("oldest revision = %#v", history.Revisions[2])
+	}
+	if history.Revisions[0].Publication.WorkflowRunURL == "" {
+		t.Fatalf("publication missing on newest revision: %#v", history.Revisions[0])
+	}
+
+	request, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/g-issues/admin/registry/history?limit=1", nil)
+	request.Header.Set("Authorization", "Bearer alice-token")
+	response, err = http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET history page 1: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("GET page 1 status = %d: %s", response.StatusCode, body)
+	}
+	var page1 struct {
+		Revisions  []struct{ ID string `json:"id"` } `json:"revisions"`
+		NextCursor string `json:"nextCursor"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&page1); err != nil {
+		t.Fatalf("decode page 1: %v", err)
+	}
+	if len(page1.Revisions) != 1 || page1.Revisions[0].ID != thirdID || page1.NextCursor == "" {
+		t.Fatalf("page1 = %#v", page1)
+	}
+
+	request, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/g-issues/admin/registry/history?limit=1&cursor="+page1.NextCursor, nil)
+	request.Header.Set("Authorization", "Bearer alice-token")
+	response, err = http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET history page 2: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("GET page 2 status = %d: %s", response.StatusCode, body)
+	}
+	var page2 struct {
+		Revisions []struct{ ID string `json:"id"` } `json:"revisions"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&page2); err != nil {
+		t.Fatalf("decode page 2: %v", err)
+	}
+	if len(page2.Revisions) != 1 || page2.Revisions[0].ID == thirdID {
+		t.Fatalf("page2 = %#v", page2)
 	}
 }

--- a/gestaltd/internal/server/handlers_app_admin_registry_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry_test.go
@@ -425,7 +425,9 @@ func TestAppAdminRegistryHistory(t *testing.T) {
 		t.Fatalf("GET page 1 status = %d: %s", response.StatusCode, body)
 	}
 	var page1 struct {
-		Revisions  []struct{ ID string `json:"id"` } `json:"revisions"`
+		Revisions []struct {
+			ID string `json:"id"`
+		} `json:"revisions"`
 		NextCursor string `json:"nextCursor"`
 	}
 	if err := json.NewDecoder(response.Body).Decode(&page1); err != nil {
@@ -447,7 +449,9 @@ func TestAppAdminRegistryHistory(t *testing.T) {
 		t.Fatalf("GET page 2 status = %d: %s", response.StatusCode, body)
 	}
 	var page2 struct {
-		Revisions []struct{ ID string `json:"id"` } `json:"revisions"`
+		Revisions []struct {
+			ID string `json:"id"`
+		} `json:"revisions"`
 	}
 	if err := json.NewDecoder(response.Body).Decode(&page2); err != nil {
 		t.Fatalf("decode page 2: %v", err)


### PR DESCRIPTION
## Summary
Retention plan **PR 4** — paginated deploy-chain API for app-admin revision history.

- Add `GET /api/v1/apps/{app}/admin/registry/history` backed by raw `app_version_change_requests`.
- Return `deployedBy`, publication provenance, present-day `deploymentState`, and opaque cursor pagination (default 50, max 100).
- Mark the latest request that produced the current desired version with `current`.

## Test plan
- [x] `go test ./internal/server/... -run TestAppAdminRegistryHistory`
- [ ] Verify history ordering, first-install omission, and pagination against a registry app with multiple deploys

Depends on retention PRs #2937 and #2938. UI ships in gestalt-providers PR 5 (#1163).