### PR TITLE
Resolve revision history deployedBy to subject email.

### DIFF
--- a/gestaltd/internal/server/handlers_app_admin_registry.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry.go
@@ -336,6 +336,7 @@ func (s *Server) getAppAdminRegistryHistory(w http.ResponseWriter, r *http.Reque
 	now := time.Now().UTC()
 
 	revisions := make([]appAdminRegistryRevision, 0, len(page.Requests))
+	actorLabels := s.resolveRevisionActorLabels(r.Context(), page.Requests)
 	for _, request := range page.Requests {
 		if request == nil {
 			continue
@@ -347,6 +348,7 @@ func (s *Server) getAppAdminRegistryHistory(w http.ResponseWriter, r *http.Reque
 			retentionIndex,
 			policy,
 			publishedByVersion,
+			actorLabels[strings.TrimSpace(request.Actor)],
 			now,
 		))
 	}
@@ -549,6 +551,7 @@ func appAdminRegistryRevisionFromRequest(
 	retention *appregistry.RetentionIndex,
 	policy appregistry.RetentionPolicy,
 	publishedByVersion map[string]appregistry.VersionSummary,
+	deployedBy string,
 	now time.Time,
 ) appAdminRegistryRevision {
 	version := strings.TrimSpace(request.ToVersion)
@@ -556,7 +559,7 @@ func appAdminRegistryRevisionFromRequest(
 		ID:         request.ID,
 		Version:    version,
 		DeployedAt: formatAdminTime(request.Timestamp),
-		DeployedBy: strings.TrimSpace(request.Actor),
+		DeployedBy: deployedBy,
 		Current:    request.ID == currentRevisionID,
 	}
 	fromVersion := strings.TrimSpace(request.FromVersion)
@@ -598,5 +601,66 @@ func historyDeploymentState(state string) string {
 		return "locked"
 	default:
 		return state
+	}
+}
+
+func (s *Server) resolveRevisionActorLabels(ctx context.Context, requests []*core.AppVersionChangeRequest) map[string]string {
+	labels := make(map[string]string)
+	if s == nil {
+		return labels
+	}
+	seen := make(map[string]struct{})
+	for _, request := range requests {
+		if request == nil {
+			continue
+		}
+		actor := strings.TrimSpace(request.Actor)
+		if actor == "" {
+			continue
+		}
+		if _, ok := seen[actor]; ok {
+			continue
+		}
+		seen[actor] = struct{}{}
+		labels[actor] = s.resolveRevisionActorLabel(ctx, actor)
+	}
+	return labels
+}
+
+func (s *Server) resolveRevisionActorLabel(ctx context.Context, actor string) string {
+	actor = strings.TrimSpace(actor)
+	if actor == "" {
+		return ""
+	}
+	kind, id, ok := core.ParseSubjectID(actor)
+	if !ok {
+		return actor
+	}
+	switch kind {
+	case string(principal.KindUser):
+		if strings.Contains(id, "@") {
+			return id
+		}
+		if s.users != nil {
+			user, err := s.users.GetUser(ctx, id)
+			if err == nil && user != nil {
+				if email := strings.TrimSpace(user.Email); email != "" {
+					return email
+				}
+			}
+		}
+		return id
+	case coredata.ManagedSubjectKindServiceAccount:
+		if s.managedSubjects != nil {
+			subject, err := s.managedSubjects.GetManagedSubject(ctx, actor)
+			if err == nil && subject != nil {
+				if displayName := strings.TrimSpace(subject.DisplayName); displayName != "" {
+					return displayName
+				}
+			}
+		}
+		return id
+	default:
+		return id
 	}
 }

--- a/gestaltd/internal/server/handlers_app_admin_registry_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry_test.go
@@ -322,6 +322,8 @@ func TestAppAdminRegistryHistory(t *testing.T) {
 
 	fixture := registrytest.NewInstallFixture(t)
 	services := testutil.NewStubServices(t)
+	alice := seedUser(t, services, "alice@valon.com")
+	aliceActor := principal.UserSubjectID(alice.ID)
 	subjectID := principal.UserSubjectID("alice")
 	authz := &serverTestAuthorizationProvider{
 		relationships: []*proto.Relationship{
@@ -351,7 +353,7 @@ func TestAppAdminRegistryHistory(t *testing.T) {
 			App:         "g-issues",
 			FromVersion: fromVersion,
 			ToVersion:   toVersion,
-			Actor:       "user:alice",
+			Actor:       aliceActor,
 			Timestamp:   at,
 			Metadata: coredata.ChangeRequestMetadata(&core.AppInstallation{
 				AppName:   "g-issues",
@@ -403,7 +405,7 @@ func TestAppAdminRegistryHistory(t *testing.T) {
 	}
 	if history.Revisions[0].ID != thirdID || history.Revisions[0].Version != fixture.Version ||
 		history.Revisions[0].PreviousVersion != otherVersion || !history.Revisions[0].Current ||
-		history.Revisions[0].DeploymentState != "desired" || history.Revisions[0].DeployedBy != "user:alice" {
+		history.Revisions[0].DeploymentState != "desired" || history.Revisions[0].DeployedBy != "alice@valon.com" {
 		t.Fatalf("newest revision = %#v", history.Revisions[0])
 	}
 	if history.Revisions[2].ID != firstID || history.Revisions[2].PreviousVersion != "" {


### PR DESCRIPTION
## Summary
- Resolve `deployedBy` in `GET /api/v1/apps/{app}/admin/registry/history` from stored `user:{uuid}` actors to the persisted user email.
- Fall back to the subject id suffix for legacy rows and managed-subject display names for service accounts.

## Test plan
- [ ] `go test ./gestaltd/internal/server -run TestAppAdminRegistryHistory`
- [ ] Deploy gestaltd pin bump and confirm revision history shows email instead of UUID.


Made with [Cursor](https://cursor.com)