### PR TITLE
Refresh app registry docs after retention and revision history

### DIFF
--- a/plans/app_registry/architecture/models.md
+++ b/plans/app_registry/architecture/models.md
@@ -391,7 +391,8 @@ Answers: _what exactly is this version — artifacts, operations, dependencies, 
     │   ├── workflowRunUrl
     │   ├── triggerPullRequest
     │   │   ├── number
-    │   │   └── url
+    │   │   ├── url
+    │   │   └── title
     │   └── triggerCommit
     │       ├── sha
     │       └── url

--- a/plans/app_registry/operations/admin.md
+++ b/plans/app_registry/operations/admin.md
@@ -50,7 +50,7 @@ The embedded shell at `/admin` keeps the Prometheus metrics viewer and adds an *
 
 | App      | Registry | Desired version     | Rollout  | Cohort        |
 | -------- | -------- | ------------------- | -------- | ------------- |
-| g-issues | toolshed | `0.0.0-snapshot.g…` | complete | 3/3 restarted |
+| g-issues | toolshed | `0.0.0-snapshot.g…` | Complete | 3/3 restarted |
 
 Show configured registry-only apps even when the fleet catalog is empty (desired version "—", status "not installed").
 
@@ -64,7 +64,7 @@ Auto-refresh every 10–15s while any listed rollout is non-terminal.
 
 ```text
 ┌─────────────────────────────────────────────────────────────┐
-│ g-issues                                    rollout: complete │
+│ g-issues                                    rollout: Complete │
 │ registry: toolshed                                          │
 ├─────────────────────────────────────────────────────────────┤
 │ Desired:  0.0.0-snapshot.gcd9d741…   installed 2026-07-21 …  │
@@ -137,7 +137,7 @@ g-issues                                                        App management
 registry: toolshed
 
 Desired version: 0.0.0-snapshot.gabc123
-Rollout enrolling: 0.0.0-snapshot.gdef456
+Rollout Enrolling: 0.0.0-snapshot.gdef456
 
 Published snapshots
 
@@ -197,7 +197,9 @@ Load the newest page when the tab opens and paginate older entries with a cursor
 <pre>
 ├── <a href="../project/changelog.md#changelog-14">14 — Fleet Admin Observability</a>
 ├── <a href="../project/changelog.md#changelog-15">15 — App-Scoped Version Selection</a>
-└── <a href="../project/changelog.md#changelog-16">16 — Pending and Failed Publish Visibility</a>
+├── <a href="../project/changelog.md#changelog-16">16 — Pending and Failed Publish Visibility</a>
+├── <a href="../project/changelog.md#changelog-17">17 — Version Retention and Cleanup</a>
+└── <a href="../project/changelog.md#changelog-18">18 — Revision History and Redeploy Windows</a>
 </pre>
 
 ### Related Docs
@@ -209,5 +211,5 @@ Load the newest page when the tab opens and paginate older entries with a cursor
 ├── <a href="../architecture/indexeddb.md">indexeddb.md</a> — app_rollouts, app_instance_materializations, change-request projections
 ├── <a href="./pending-publish.md">pending-publish.md</a> — in-flight publish visibility on app admin
 ├── <a href="./retention.md">retention.md</a> — version cleanup policy, redeploy windows, and revision-history preservation
-└── <a href="../project/tests.md#admin-observability-tests">tests.md</a> — observability HTTP and UI tests; <a href="../project/tests.md#app-version-selection-tests">app version selection tests</a>
+└── <a href="../project/tests.md#admin-observability-tests">tests.md</a> — observability HTTP and UI tests; <a href="../project/tests.md#app-version-selection-and-revision-history-tests">app version selection and revision history tests</a>
 </pre>

--- a/plans/app_registry/operations/admin.md
+++ b/plans/app_registry/operations/admin.md
@@ -110,22 +110,22 @@ The page header shows the app name, **App management** label, registry binding, 
 See [pending-publish.md](./pending-publish.md) for snapshot merge rules, polling, and timing labels.
 
 ```text
-g-issues                                                        App management
+g-issues                                                                 App management
 registry: toolshed
 
 Desired version: 0.0.0-snapshot.gabc123
 
 Published snapshots
 
-Pull request       | Snapshot               | Status                   | Last update    | Action
------------------- | ---------------------- | ------------------------ | -------------- | --------
-PR #3740 · Title   | 0.0.0-snapshot.g…     | Publishing · for 4m      | 4 minutes ago  | —
-PR #3251 · Title   | 0.0.0-snapshot.g…     | Available                | Jul 22 15:00   | Deploy
-                    |                        | Published in 4m 32s      |                |
-PR #3200 · Title   | 0.0.0-snapshot.g…     | Deployed                 | Jul 21 12:00   | —
-PR #3100 · Title   | 0.0.0-snapshot.g…     | Redeployable · 12d left  | Jul 18 09:00   | Deploy
-PR #3000 · Title   | 0.0.0-snapshot.g…     | Locked                   | Jun 10 09:00   | —
-PR #2900 · Title   | 0.0.0-snapshot.g…     | Expired                  | Jun 01 09:00   | —
+Pull request     | Snapshot          | Status                  | Last update   | Action
+---------------- | ----------------- | ----------------------- | ------------- | ------
+PR #3740 · Title | 0.0.0-snapshot.g… | Publishing · for 4m     | 4 minutes ago | —
+PR #3251 · Title | 0.0.0-snapshot.g… | Available               | Jul 22 15:00  | Deploy
+                 |                   | Published in 4m 32s     |               |
+PR #3200 · Title | 0.0.0-snapshot.g… | Deployed                | Jul 21 12:00  | —
+PR #3100 · Title | 0.0.0-snapshot.g… | Redeployable · 12d left | Jul 18 09:00  | Deploy
+PR #3000 · Title | 0.0.0-snapshot.g… | Locked                  | Jun 10 09:00  | —
+PR #2900 · Title | 0.0.0-snapshot.g… | Expired                 | Jun 01 09:00  | —
 ```
 
 Row timing labels: [pending-publish.md — Publish duration](./pending-publish.md#publish-duration). **Deploy** is unavailable on **Publishing**, **Failed**, **Deployed**, **Locked**, and **Expired** rows. **Deployed** marks the desired version. **Redeployable** shows the fixed deadline or remaining duration.
@@ -133,7 +133,7 @@ Row timing labels: [pending-publish.md — Publish duration](./pending-publish.m
 During an active rollout, disable deploy actions and show rollout state above the table:
 
 ```text
-g-issues                                                        App management
+g-issues                                                                 App management
 registry: toolshed
 
 Desired version: 0.0.0-snapshot.gabc123
@@ -141,19 +141,19 @@ Rollout Enrolling: 0.0.0-snapshot.gdef456
 
 Published snapshots
 
-Pull request       | Snapshot               | Status       | Last update   | Action
------------------- | ---------------------- | ------------ | ------------- | --------
-PR #3251 · Title   | 0.0.0-snapshot.g…     | Rolling out  | Jul 22 15:00  | disabled
-PR #3200 · Title   | 0.0.0-snapshot.g…     | Deployed     | Jul 21 12:00  | disabled
+Pull request     | Snapshot          | Status      | Last update  | Action
+---------------- | ----------------- | ----------- | ------------ | --------
+PR #3251 · Title | 0.0.0-snapshot.g… | Rolling out | Jul 22 15:00 | disabled
+PR #3200 · Title | 0.0.0-snapshot.g… | Deployed    | Jul 21 12:00 | disabled
 ```
 
 A **Failed** row in the same table:
 
 ```text
-Pull request       | Snapshot               | Status            | Last update   | Action
------------------- | ---------------------- | ----------------- | ------------- | ------
-PR #3740 · Title   | 0.0.0-snapshot.g…     | Failed            | Jul 24 18:35  | —
-                    |                        | Failed after 35m  |               |
+Pull request     | Snapshot          | Status           | Last update  | Action
+---------------- | ----------------- | ---------------- | ------------ | ------
+PR #3740 · Title | 0.0.0-snapshot.g… | Failed           | Jul 24 18:35 | —
+                 |                   | Failed after 35m |              |
 ```
 
 After a successful deploy selection, keep deploy actions disabled until the rollout reaches `complete` or `failed`.
@@ -165,11 +165,11 @@ The Revision history tab displays `app_version_change_requests` as an immutable 
 ```text
 Revision history
 
-Deployed at    | Transition                           | Availability  | Deployed by
--------------- | ------------------------------------ | ------------- | ----------------
-Jul 25 09:10   | gdef456 → gabc123 (downgrade)       | Current       | alice@valon.com
-Jul 24 16:42   | gabc123 → gdef456 (upgrade)         | Redeployable  | alice@valon.com
-Jul 21 12:00   | First deployment → gabc123          | Current       | bob@valon.com
+Deployed at  | Transition                    | Availability | Deployed by
+------------ | ----------------------------- | ------------ | ---------------
+Jul 25 09:10 | gdef456 → gabc123 (downgrade) | Current      | alice@valon.com
+Jul 24 16:42 | gabc123 → gdef456 (upgrade)   | Redeployable | alice@valon.com
+Jul 21 12:00 | First deployment → gabc123    | Current      | bob@valon.com
 ```
 
 Each row links to the source commit and, when recorded, the triggering pull request and publish workflow. **Availability** shows the selected version's present-day state, so repeated entries for the same version have the same value. The current desired version is **Current**; other versions are **Redeployable** or **Locked**. The history tab itself has no deploy action because availability is an attribute of a version, not an individual event. Eligible selection remains on Published snapshots.

--- a/plans/app_registry/operations/admin.md
+++ b/plans/app_registry/operations/admin.md
@@ -65,16 +65,16 @@ Auto-refresh every 10–15s while any listed rollout is non-terminal.
 ```text
 ┌─────────────────────────────────────────────────────────────┐
 │ g-issues                                    rollout: Complete │
-│ registry: toolshed                                          │
+│ registry: toolshed                                            │
 ├─────────────────────────────────────────────────────────────┤
-│ Desired:  0.0.0-snapshot.gcd9d741…   installed 2026-07-21 …  │
-│ Published latest: 0.0.0-snapshot.gcd9d741… (same)           │
+│ Desired: 0.0.0-snapshot.gcd9d741…      installed 2026-07-21 … │
+│ Published latest: 0.0.0-snapshot.gcd9d741… (same)             │
 ├─────────────────────────────────────────────────────────────┤
-│ Replicas                                                    │
-│ instanceId               mat.   restart   attempts  error   │
-│ gestaltd-…-ncnq6         ✓     ✓         0                   │
-│ gestaltd-…-hdnx2         ✓     ✓         0                   │
-│ gestaltd-…-smmq7         ✓     ✓         0                   │
+│ Replicas                                                      │
+│ instanceId                 mat.  restart  att  error          │
+│ gestaltd-…-ncnq6           ✓     ✓        0                   │
+│ gestaltd-…-hdnx2           ✓     ✓        0                   │
+│ gestaltd-…-smmq7           ✓     ✓        0                   │
 └─────────────────────────────────────────────────────────────┘
 ```
 

--- a/plans/app_registry/operations/lifecycle.md
+++ b/plans/app_registry/operations/lifecycle.md
@@ -827,7 +827,9 @@ Example:
 ├── <a href="../project/changelog.md#changelog-11">11 — Mount the Registry-Installed Package</a>
 ├── <a href="../project/changelog.md#changelog-12">12 — Complete Registry-Only Lifecycle</a>
 ├── <a href="../project/changelog.md#changelog-14">14 — Fleet Admin Observability</a>
-└── <a href="../project/changelog.md#changelog-15">15 — App-Scoped Version Selection</a>
+├── <a href="../project/changelog.md#changelog-15">15 — App-Scoped Version Selection</a>
+├── <a href="../project/changelog.md#changelog-17">17 — Version Retention and Cleanup</a>
+└── <a href="../project/changelog.md#changelog-18">18 — Revision History and Redeploy Windows</a>
 </pre>
 
 ### Related Docs

--- a/plans/app_registry/operations/pending-publish.md
+++ b/plans/app_registry/operations/pending-publish.md
@@ -93,7 +93,9 @@ metadata
 
 `record-pending` lets `/apps/{app}/admin` show **Publishing** while `darwin-python` and the main `publish` job still run. The publish job calls `pending set` again before packaging so `updatedAt` and publication metadata stay current.
 
-Publication flags (`--workflow-run-url`, `--trigger-pr-number`, `--trigger-pr-url`, `--trigger-pr-title`, or commit trigger fields) are built by `.github/scripts/write_app_registry_publication_args.sh` and passed to both `pending set` and `gestaltd app registry publish`.
+Publication flags (`--workflow-run-url`, `--trigger-pr-number`, `--trigger-pr-url`, `--trigger-pr-title`, or commit trigger fields) are built by [toolshed `.github/scripts/write_app_registry_publication_args.sh`](https://github.com/valon-technologies/toolshed/blob/main/.github/scripts/write_app_registry_publication_args.sh) and passed to both `pending set` and `gestaltd app registry publish`.
+
+The script prefers `gh pr view` for `triggerPullRequest.title`. When that call fails under CI token policy, it falls back to the squash-merge commit subject with the trailing `(#N)` suffix removed. Legacy published versions may still have PR number and URL without a title.
 
 `gestaltd app registry publish` does not touch `pending.json` or `failed.json`. `gestaltd app publish` remains a deprecated alias.
 
@@ -200,6 +202,8 @@ Implementation:
 - [gestalt#2931](https://github.com/valon-technologies/gestalt/pull/2931) — read path and app-admin API
 - [toolshed#3775](https://github.com/valon-technologies/toolshed/pull/3775) — `record-pending` job and CI lifecycle
 - [gestalt-providers#1159](https://github.com/valon-technologies/gestalt-providers/pull/1159)–[#1161](https://github.com/valon-technologies/gestalt-providers/pull/1161) — app admin UI (pending/failed rows, polling, status column)
+- [toolshed#3782](https://github.com/valon-technologies/toolshed/pull/3782) · [toolshed#3790](https://github.com/valon-technologies/toolshed/pull/3790) · [toolshed#3792](https://github.com/valon-technologies/toolshed/pull/3792) — PR title recording and squash-merge fallback
+- [gestalt-providers#1165](https://github.com/valon-technologies/gestalt-providers/pull/1165) — linked PR number with plain-text title in app admin tables
 
 ---
 
@@ -208,7 +212,8 @@ Implementation:
 ### Related Changelogs
 
 <pre>
-└── <a href="../project/changelog.md#changelog-16">16 — Pending and Failed Publish Visibility</a>
+├── <a href="../project/changelog.md#changelog-16">16 — Pending and Failed Publish Visibility</a>
+└── <a href="../project/changelog.md#changelog-19">19 — Publication PR Title Provenance</a>
 </pre>
 
 ### Related Docs

--- a/plans/app_registry/operations/pending-publish.md
+++ b/plans/app_registry/operations/pending-publish.md
@@ -95,7 +95,7 @@ metadata
 
 Publication flags (`--workflow-run-url`, `--trigger-pr-number`, `--trigger-pr-url`, `--trigger-pr-title`, or commit trigger fields) are built by [toolshed `.github/scripts/write_app_registry_publication_args.sh`](https://github.com/valon-technologies/toolshed/blob/main/.github/scripts/write_app_registry_publication_args.sh) and passed to both `pending set` and `gestaltd app registry publish`.
 
-The script prefers `gh pr view` for `triggerPullRequest.title`. When that call fails under CI token policy, it falls back to the squash-merge commit subject with the trailing `(#N)` suffix removed. Legacy published versions may still have PR number and URL without a title.
+The script derives `triggerPullRequest.title` from the squash-merge commit subject on `main`, with the trailing `(#N)` suffix removed. Legacy published versions may still have PR number and URL without a title.
 
 `gestaltd app registry publish` does not touch `pending.json` or `failed.json`. `gestaltd app publish` remains a deprecated alias.
 
@@ -202,7 +202,7 @@ Implementation:
 - [gestalt#2931](https://github.com/valon-technologies/gestalt/pull/2931) — read path and app-admin API
 - [toolshed#3775](https://github.com/valon-technologies/toolshed/pull/3775) — `record-pending` job and CI lifecycle
 - [gestalt-providers#1159](https://github.com/valon-technologies/gestalt-providers/pull/1159)–[#1161](https://github.com/valon-technologies/gestalt-providers/pull/1161) — app admin UI (pending/failed rows, polling, status column)
-- [toolshed#3782](https://github.com/valon-technologies/toolshed/pull/3782) · [toolshed#3790](https://github.com/valon-technologies/toolshed/pull/3790) · [toolshed#3792](https://github.com/valon-technologies/toolshed/pull/3792) — PR title recording and squash-merge fallback
+- [toolshed#3782](https://github.com/valon-technologies/toolshed/pull/3782) · [toolshed#3790](https://github.com/valon-technologies/toolshed/pull/3790) · [toolshed#3792](https://github.com/valon-technologies/toolshed/pull/3792) — PR title recording from squash-merge commit subject
 - [gestalt-providers#1165](https://github.com/valon-technologies/gestalt-providers/pull/1165) — linked PR number with plain-text title in app admin tables
 
 ---

--- a/plans/app_registry/operations/retention.md
+++ b/plans/app_registry/operations/retention.md
@@ -68,7 +68,7 @@ gestaltd app registry retention prune \
   [--dry-run]
 ```
 
-Run on a schedule from the deploy reader (for example a daily `gestaltd` cron). Do not run from `gestaltd serve` request handlers.
+Run on a schedule from the deploy reader. Toolshed runs [app-registry-retention-prune.yml](https://github.com/valon-technologies/toolshed/blob/main/.github/workflows/app-registry-retention-prune.yml) daily for every registry-only app in `valon-tools/deploy/config.yaml`, invoking `gestaltd app registry retention prune --bucket … --app …` with the pinned gestaltd release. Do not run from `gestaltd serve` request handlers or from publish CI.
 
 ## Retention States
 
@@ -83,13 +83,14 @@ Run on a schedule from the deploy reader (for example a daily `gestaltd` cron). 
 
 The Revision history tab always shows deployed transitions, including locked versions. Deployment controls live on Published snapshots and expose **Deploy** only for unexpired never-deployed or still-redeployable versions. See [admin.md](./admin.md#revision-history-tab) and [lifecycle.md](./lifecycle.md#revision-history).
 
-## Implementation Path
+## Shipped In
 
-1. **PR 1 — Models and write path** (`gestalt`) — `RetentionIndex`, config validation, desired-version transition updates, and fixed redeploy deadlines.
-2. **PR 2 — Prune command** (`gestalt`) — `gestaltd app registry retention prune` with `--dry-run`, app-scoped install locking, unused deletion, historical locking/artifact cleanup, and change-request cross-checks.
-3. **PR 3 — Scheduler** (deploy / ops) — scheduled `retention prune` per registry-only app.
-4. **PR 4 — Revision history API** (`gestalt`) — paginated deploy-chain API with `deployedBy` and deployment-state projection.
-5. **PR 5 — Revision history UI** (`gestalt-providers`) — read-only Revision history tab on the app-admin page.
+- [gestalt#2937](https://github.com/valon-technologies/gestalt/pull/2937) — `RetentionIndex`, config validation, and reader-side transition writes
+- [gestalt#2938](https://github.com/valon-technologies/gestalt/pull/2938) — `gestaltd app registry retention prune`
+- [toolshed#3786](https://github.com/valon-technologies/toolshed/pull/3786) — daily scheduled prune for registry-only apps
+- [gestalt#2939](https://github.com/valon-technologies/gestalt/pull/2939) — revision history API and deployment-state projection
+- [gestalt#2941](https://github.com/valon-technologies/gestalt/pull/2941) — `deployedBy` email resolution
+- [gestalt-providers#1163](https://github.com/valon-technologies/gestalt-providers/pull/1163) — Revision history tab on app admin
 
 ---
 
@@ -98,7 +99,8 @@ The Revision history tab always shows deployed transitions, including locked ver
 ### Related Changelogs
 
 <pre>
-└── None — planned work
+├── <a href="../project/changelog.md#changelog-17">17 — Version Retention and Cleanup</a>
+└── <a href="../project/changelog.md#changelog-18">18 — Revision History and Redeploy Windows</a>
 </pre>
 
 ### Related Docs

--- a/plans/app_registry/project/changelog.md
+++ b/plans/app_registry/project/changelog.md
@@ -24,6 +24,9 @@ The `Completed` timestamp is the merge time of the PR that delivered the milesto
 | `14` | `🗓️ Jul 22 · 15:51` | `Fleet Admin Observability` | [`admin.md`](../operations/admin.md) [`lifecycle.md`](../operations/lifecycle.md) |
 | `15` | `🗓️ Jul 23 · 16:33` | `App-Scoped Version Selection` | [`admin.md`](../operations/admin.md) [`indexeddb.md`](../architecture/indexeddb.md) [`lifecycle.md`](../operations/lifecycle.md) |
 | `16` | `🗓️ Jul 26 · 00:18` | `Pending and Failed Publish Visibility` | [`admin.md`](../operations/admin.md) [`models.md`](../architecture/models.md) [`pending-publish.md`](../operations/pending-publish.md) |
+| `17` | `🗓️ Jul 26 · 14:02` | `Version Retention and Cleanup` | [`config.md`](../architecture/config.md) [`models.md`](../architecture/models.md) [`retention.md`](../operations/retention.md) |
+| `18` | `🗓️ Jul 26 · 15:48` | `Revision History and Redeploy Windows` | [`admin.md`](../operations/admin.md) [`lifecycle.md`](../operations/lifecycle.md) [`retention.md`](../operations/retention.md) |
+| `19` | `🗓️ Jul 26 · 19:34` | `Publication PR Title Provenance` | [`models.md`](../architecture/models.md) [`pending-publish.md`](../operations/pending-publish.md) |
 
 ## Tag Glossary
 
@@ -33,6 +36,7 @@ The `Completed` timestamp is the merge time of the PR that delivered the milesto
 - [`lifecycle.md`](../operations/lifecycle.md)
 - [`models.md`](../architecture/models.md)
 - [`pending-publish.md`](../operations/pending-publish.md)
+- [`retention.md`](../operations/retention.md)
 - [`validation.md`](../architecture/validation.md)
 
 ---
@@ -200,3 +204,33 @@ Added `pending.json` and `failed.json`, CI lifecycle commands, early pending rec
 **Registry and CI:** [gestalt#2927](https://github.com/valon-technologies/gestalt/pull/2927) · [gestalt#2932](https://github.com/valon-technologies/gestalt/pull/2932) · [gestalt#2931](https://github.com/valon-technologies/gestalt/pull/2931) · [toolshed#3772](https://github.com/valon-technologies/toolshed/pull/3772) · [toolshed#3775](https://github.com/valon-technologies/toolshed/pull/3775)
 
 **App UI:** [gestalt-providers#1158](https://github.com/valon-technologies/gestalt-providers/pull/1158) · [gestalt-providers#1159](https://github.com/valon-technologies/gestalt-providers/pull/1159) · [gestalt-providers#1160](https://github.com/valon-technologies/gestalt-providers/pull/1160) · [gestalt-providers#1161](https://github.com/valon-technologies/gestalt-providers/pull/1161) · [gestalt-providers#1162](https://github.com/valon-technologies/gestalt-providers/pull/1162)
+
+<a id="changelog-17"></a>
+
+### 17 — Version Retention and Cleanup
+
+**Tags:** [`config.md`](../architecture/config.md) [`models.md`](../architecture/models.md) [`retention.md`](../operations/retention.md)
+
+Added `retention.json`, config validation for `unusedRetention` and `deployedRetention`, reader-side transition updates on fleet selection, `gestaltd app registry retention prune`, and a daily scheduled prune workflow for registry-only apps in toolshed.
+
+**Merged:** [gestalt#2937](https://github.com/valon-technologies/gestalt/pull/2937) · [gestalt#2938](https://github.com/valon-technologies/gestalt/pull/2938) · [toolshed#3786](https://github.com/valon-technologies/toolshed/pull/3786)
+
+<a id="changelog-18"></a>
+
+### 18 — Revision History and Redeploy Windows
+
+**Tags:** [`admin.md`](../operations/admin.md) [`lifecycle.md`](../operations/lifecycle.md) [`retention.md`](../operations/retention.md)
+
+Added paginated `GET …/admin/registry/history`, deployment-state projection from `retention.json`, subject-email `deployedBy` labels, and the read-only Revision history tab on `/apps/{app}/admin`. Published snapshots now expose `available`, `redeployable`, `locked`, and `expired` states with `deployableUntil`.
+
+**Merged:** [gestalt#2939](https://github.com/valon-technologies/gestalt/pull/2939) · [gestalt#2941](https://github.com/valon-technologies/gestalt/pull/2941) · [gestalt-providers#1163](https://github.com/valon-technologies/gestalt-providers/pull/1163) · [gestalt-providers#1164](https://github.com/valon-technologies/gestalt-providers/pull/1164) · [gestalt-providers#1165](https://github.com/valon-technologies/gestalt-providers/pull/1165) · [gestalt-providers#1166](https://github.com/valon-technologies/gestalt-providers/pull/1166)
+
+<a id="changelog-19"></a>
+
+### 19 — Publication PR Title Provenance
+
+**Tags:** [`models.md`](../architecture/models.md) [`pending-publish.md`](../operations/pending-publish.md)
+
+Recorded `publication.triggerPullRequest.title` during publish and pending writes. When `gh pr view` is unavailable in CI, toolshed falls back to the squash-merge commit subject before `(#N)`.
+
+**Merged:** [toolshed#3782](https://github.com/valon-technologies/toolshed/pull/3782) · [toolshed#3790](https://github.com/valon-technologies/toolshed/pull/3790) · [toolshed#3792](https://github.com/valon-technologies/toolshed/pull/3792)

--- a/plans/app_registry/project/changelog.md
+++ b/plans/app_registry/project/changelog.md
@@ -231,6 +231,6 @@ Added paginated `GET …/admin/registry/history`, deployment-state projection fr
 
 **Tags:** [`models.md`](../architecture/models.md) [`pending-publish.md`](../operations/pending-publish.md)
 
-Recorded `publication.triggerPullRequest.title` during publish and pending writes. When `gh pr view` is unavailable in CI, toolshed falls back to the squash-merge commit subject before `(#N)`.
+Recorded `publication.triggerPullRequest.title` during publish and pending writes from the squash-merge commit subject on `main` (trailing `(#N)` removed).
 
 **Merged:** [toolshed#3782](https://github.com/valon-technologies/toolshed/pull/3782) · [toolshed#3790](https://github.com/valon-technologies/toolshed/pull/3790) · [toolshed#3792](https://github.com/valon-technologies/toolshed/pull/3792)

--- a/plans/app_registry/project/tests.md
+++ b/plans/app_registry/project/tests.md
@@ -16,6 +16,10 @@ Reference for behavioral tests in the app registry plan.
 | `internal/config`, `internal/operator`, `internal/appregistry`, `internal/bootstrap` | registry-only source tests | — | Unit/integration | — |
 | `internal/appregistry` | `install_validator_test.go`, `install_validation_errors_test.go` | — | Unit | [gestalt#2887](https://github.com/valon-technologies/gestalt/pull/2887) |
 | `internal/server` | `handlers_admin_app_rollout_test.go` | — | HTTP integration | [gestalt#2890](https://github.com/valon-technologies/gestalt/pull/2890) |
+| `internal/server` | `handlers_app_admin_registry_test.go` | 4 | HTTP integration | [gestalt#2909](https://github.com/valon-technologies/gestalt/pull/2909) · [gestalt#2931](https://github.com/valon-technologies/gestalt/pull/2931) · [gestalt#2939](https://github.com/valon-technologies/gestalt/pull/2939) |
+| `internal/config` | `app_registry_retention_test.go` | 3 | Unit | [gestalt#2937](https://github.com/valon-technologies/gestalt/pull/2937) |
+| `internal/appregistry` | `retention_test.go`, `retention_prune_test.go` | 2 | Unit | [gestalt#2937](https://github.com/valon-technologies/gestalt/pull/2937) · [gestalt#2938](https://github.com/valon-technologies/gestalt/pull/2938) |
+| `gestalt-providers/app/default` | `e2e/app-admin-mock.spec.ts` | — | Playwright mock | [gestalt-providers#1142](https://github.com/valon-technologies/gestalt-providers/pull/1142) · [gestalt-providers#1163](https://github.com/valon-technologies/gestalt-providers/pull/1163) |
 | `services/ui/adminui` | registry UI smoke | — | Manual / browser | planned |
 
 Test fixture for install HTTP tests: `internal/appregistry/registrytest/fixture.go`
@@ -403,59 +407,69 @@ Manual or Playwright-style check against a local multi-replica harness:
 
 1. Open `/admin/registry` while authenticated as a `gestaltAdmin` user.
 2. Confirm `g-issues` appears with desired version after `POST …/add`.
-3. Watch rollout badge transition `enrolling` → `restarting` → `complete` and replica rows populate.
+3. Watch rollout badge transition `Enrolling` → `Restarting` → `Complete` and replica rows populate.
 
 ---
 
-## Planned Retention Tests
+## Retention Tests
 
-Policy: [retention.md](../operations/retention.md).
+Policy: [retention.md](../operations/retention.md). Implemented in [gestalt#2937](https://github.com/valon-technologies/gestalt/pull/2937) and [gestalt#2938](https://github.com/valon-technologies/gestalt/pull/2938).
 
-- A never-deployed version older than `unusedRetention` is eligible for pruning and its index entry, metadata, artifact objects, and retention row are removed.
-- The current desired version and active rollout target retain all objects regardless of age.
-- A historical version whose `deployableUntil` deadline has not passed retains its artifact and remains selectable.
-- A historical version after `deployableUntil` becomes permanently locked; its artifact may be removed, but its index summary, version metadata, retention row, and change requests remain.
-- A deployed version is never fully deleted even when `retention.json` is missing or incorrectly says `everDeployed: false`; the change-request chain is the fail-safe.
-- Changing `deployedRetention` does not alter a deadline already captured on a transition or unlock a version whose deadline passed.
-- Prune acquires the app-scoped install lock and cannot delete or lock a version concurrently with selection for the same app.
-- Pruning never modifies change requests, pending/failed catalogs, or another app's objects.
-- `--dry-run` reports the same eligibility decisions without writes.
+Run:
+
+```bash
+cd gestaltd
+go test ./internal/config/... -run TestAppRegistryRetention -count=1
+go test ./internal/appregistry/... -run 'TestVersionDeploymentState|TestEvaluateRetentionPrune' -count=1
+```
+
+### `retention_test.go`
+
+- **`TestVersionDeploymentState`** — desired version returns `desired`; never-deployed expired versions return `expired`; historical versions before `deployableUntil` return `redeployable`; after the deadline return `locked`.
+
+### `retention_prune_test.go`
+
+- **`TestEvaluateRetentionPrune`** — never-deployed versions past `unusedRetention` are eligible for full deletion; locked historical versions may have artifacts pruned while index and retention rows remain; deployed versions are cross-checked against the change-request chain.
+
+### `app_registry_retention_test.go`
+
+- Default `unusedRetention` / `deployedRetention` values and validation for registry config overlays.
+
+Scheduled prune behavior in production is exercised by [toolshed#3786](https://github.com/valon-technologies/toolshed/pull/3786). End-to-end GCS prune integration is not yet covered in gestalt tests.
 
 ---
 
-## Planned App Version Selection Tests
+## App Version Selection and Revision History Tests
 
 API: [lifecycle.md](../operations/lifecycle.md#app-admin-version-selection). UI: [admin.md](../operations/admin.md#app-admin-ui-appsappadmin).
 
-### Gestalt API Tests
+### Gestalt API Tests (`handlers_app_admin_registry_test.go`)
 
-Add focused server tests for:
+Implemented in [gestalt#2909](https://github.com/valon-technologies/gestalt/pull/2909), [gestalt#2931](https://github.com/valon-technologies/gestalt/pull/2931), and [gestalt#2939](https://github.com/valon-technologies/gestalt/pull/2939).
+
+Run:
+
+```bash
+cd gestaltd
+go test ./internal/server/... -run TestAppAdminRegistry -count=1
+```
 
 | Test | Expected behavior |
 | --- | --- |
-| Unauthenticated read/write | **401** |
-| Non-user principal | **403** |
-| User without `admin` on `app/{app}` | **403** |
-| Global `gestaltAdmin` without app admin | **403** |
-| Authorization provider unavailable | **503**; fail closed |
-| App admin reads registry state | **200** with desired, fleet-known, published (including provenance), and rollout fields |
-| Snapshot-pinned or unknown app | **404** |
-| Rollout admission | Active `enrolling` / `restarting` rollout: GET sets `selectionDisabled`; POST returns **409** before registry fetch, validation, rollout creation, or change-request append; terminal `complete` / `failed` rollout leaves selection enabled |
-| First selection | Uses add semantics and appends the first change request |
-| Upgrade | Appends a change request; stored actor is the authenticated user subject |
-| Downgrade within redeploy window | Appends a repeated-version change request and makes the historical version desired |
-| Select expired never-deployed version before prune | **400** based on `publishedAt + unusedRetention`; no writes |
-| Select expired historical version | **400** and no writes |
-| Select current desired version | **400** and no writes |
-| Validation failure | Existing typed validation error; no rollout or change request |
-| Concurrent selections | Exactly one passes admission; the other returns **409** |
-| Revision history ordering | Returns every raw change request by `(timestamp, id)` descending, including repeated versions |
-| Revision history pagination | Applies the opaque cursor without gaps or duplicate rows; default 50, maximum 100 |
-| Revision history availability | Repeated entries for one version share its present-day `deploymentState` and `deployableUntil` |
-| First deployment history | Omits `previousVersion` for the `registry:first-install` sentinel |
-| Revision history authorization | Uses the same **401**, **403**, and **503** fail-closed behavior as registry state |
+| `TestAppAdminRegistrySelectAndRead` | App admin can select a published version, starts rollout, and reads registry state with `selectionDisabled` while rollout is active |
+| `TestAppAdminRegistryFailsClosed` | Unauthenticated, unauthorized, and missing-authorization-provider requests fail closed |
+| `TestAppAdminRegistryIncludesPendingAndFailedVersions` | Registry state merges pending and failed catalogs with published versions |
+| `TestAppAdminRegistryHistory` | History returns raw change requests newest-first, paginates with opaque cursor, omits `previousVersion` for first install, resolves `deployedBy` to subject email, and projects publication metadata from the registry index |
 
-The downgrade test seeds `v1 → v2`, selects `v1` before its deadline, and asserts the chain becomes `v1 → v2 → v1`. The expired-version test advances past the fixed deadline and rejects before registry fetch, validation, rollout creation, or change-request append.
+Not yet covered in gestalt server tests:
+
+| Gap | Expected behavior |
+| --- | --- |
+| Downgrade within redeploy window | Appends a repeated-version change request and makes the historical version desired |
+| Select expired never-deployed / locked historical version | **400** before registry fetch, validation, rollout creation, or change-request append |
+| Select current desired version | **400** and no writes |
+| Concurrent selections | Exactly one passes admission; the other returns **409** |
+| Validation failure on selection | Typed validation error; no rollout or change request |
 
 `POST …/registry/version` rejects unknown fields (including `actor`, `registry`, and `fromVersion`).
 
@@ -463,19 +477,31 @@ The downgrade test seeds `v1 → v2`, selects `v1` before its deadline, and asse
 
 ### Default App UI Tests (`gestalt-providers`)
 
-Add route/component tests for:
+Implemented in [gestalt-providers#1142](https://github.com/valon-technologies/gestalt-providers/pull/1142), [gestalt-providers#1158](https://github.com/valon-technologies/gestalt-providers/pull/1158)–[#1163](https://github.com/valon-technologies/gestalt-providers/pull/1163), and [gestalt-providers#1165](https://github.com/valon-technologies/gestalt-providers/pull/1165).
+
+Run:
+
+```bash
+cd gestalt-providers/app/default
+npm run test:e2e -- e2e/app-admin-mock.spec.ts
+```
+
+Covered behaviors:
 
 - **Manage app** appears only when `managementPath` is returned
 - published versions render newest first with desired version selected
-- expired never-deployed snapshots show **Expired** without a deploy action, even before scheduled pruning removes them
-- historical snapshots show **Redeployable** with a deadline and a deploy action, or **Locked** without one
-- version detail shows `publishedAt`, linked commit, trigger PR or commit, and workflow run; legacy entries without `publication` link the commit and show **not recorded** for workflow/PR
-- the Revision history tab loads lazily, renders newest-first transitions, preserves repeated upgrade/downgrade entries, gives repeated versions the same present-day availability, and paginates older rows
-- revision history renders **First deployment** for the sentinel and **No deployments yet** for an empty chain
-- no desired version renders first-install copy
-- active rollout or **409** after a stale page disables the selector and submit button until rollout is terminal
-- successful selection renders the new active rollout
+- pending, failed, and published rows share one snapshots table with status and timing labels
+- the Revision history tab loads lazily, renders newest-first transitions, paginates older rows, and shows **No deployments yet** for an empty chain
+- active rollout or **409** after a stale page disables deploy actions until rollout is terminal
+- successful selection renders the new active rollout with sentence-case rollout labels (`Enrolling`, `Complete`)
 - **403** renders access denied without registry metadata
+- publication labels link only the PR number; titles render as plain muted text when present
+
+Not yet covered in Playwright mocks:
+
+- expired never-deployed snapshots show **Expired** without a deploy action
+- historical snapshots show **Redeployable** with a deadline and deploy action, or **Locked** without one
+- legacy published versions without `publication` show **not recorded** for workflow/PR fields
 
 ### Manual Smoke
 
@@ -490,6 +516,8 @@ Publish tests do not exercise real GCS uploads; upload-path tests use test stora
 - Real GCS upload integration
 - Re-install idempotency (no duplicate change request)
 - Full install-time validation reason-code matrix (see [install-time validation tests](#install-time-validation-tests))
+- Retention prune GCS integration and install-lock concurrency tests
+- App-admin selection tests for expired, locked, downgrade, and concurrent admission paths
 - Multi-replica materialization acknowledgement E2E (see [planned section above](#planned-multi-replica-materialization-acknowledgement-e2e))
 - Per-replica **observed** running version heartbeats
 - Deployed verification that catalog restarts serve the newly mounted binary

--- a/plans/app_registry/readme.md
+++ b/plans/app_registry/readme.md
@@ -39,6 +39,7 @@ App registries:
   - publication metadata
 - Allow registry-only apps to be installed.
 - Allow Gestalt to validate app dependencies before fleet admission.
+- Enforce unused and deployed retention windows through `retention.json` and scheduled prune. See [retention.md](./operations/retention.md).
 
 The registry is a versioned contract registry for installable apps, not only an artifact bucket.
 
@@ -161,10 +162,6 @@ Each replica materializes the latest desired registry version under `{artifactsD
 A dynamic app failure does not prevent Gestalt from serving core functionality. Operators can select a historical version during the configured redeploy window (30 days by default) after it last stopped being desired. After that window it is permanently locked and recovery requires a new publish. Core recovery paths do not depend on registry-only apps.
 
 ## Future Work
-
-### Version Retention and Cleanup
-
-Automatically delete never-deployed snapshots after 3 days by default. Retain the complete deploy chain and deployed version metadata permanently. Keep historical versions redeployable for 30 days after they stop being desired, then lock them and allow artifact cleanup. Add `apps/{app}/retention.json`, deactivation tracking, reader-owned `gestaltd app registry retention prune`, and a Revision history tab on the app-admin page. See [retention.md](./operations/retention.md).
 
 ### Packaged Workflow Metadata
 


### PR DESCRIPTION
## Summary
- Mark version retention, scheduled prune, revision history, and PR title provenance as shipped in the changelog and topic docs.
- Remove the retention feature from `readme.md` future work; keep packaged workflow metadata as the remaining planned item.
- Replace planned retention/selection test sections with the current implemented coverage and remaining gaps.

Reopened for review after #2942 was merged prematurely and reverted on `main`.

## Test plan
- [ ] Read `plans/app_registry/project/changelog.md` steps 17–19 and confirm linked PRs match merged work
- [ ] Confirm `retention.md` no longer lists an implementation path for already-shipped work
- [ ] Spot-check `tests.md` run commands against current gestalt/gestalt-providers test files


Made with [Cursor](https://cursor.com)