### PR TITLE
Update gestaltd formula and chart to v0.0.2-alpha.47

### DIFF
--- a/Formula/gestaltd.rb
+++ b/Formula/gestaltd.rb
@@ -3,30 +3,30 @@
 class Gestaltd < Formula
   desc "Gestalt server daemon"
   homepage "https://github.com/valon-technologies/gestalt"
-  version "0.0.2-alpha.46"
+  version "0.0.2-alpha.47"
   license "Apache-2.0"
 
   on_macos do
     on_arm do
-      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.46/gestaltd-macos-arm64.tar.gz"
-      sha256 "76b8280a83d4bbdc5e4e595b2e0872d3d7172b3d802ba704857baa5425c4f59e"
+      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.47/gestaltd-macos-arm64.tar.gz"
+      sha256 ""
     end
 
     on_intel do
-      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.46/gestaltd-macos-x86_64.tar.gz"
-      sha256 "97c0971edb97da43eafa650d681d0c612342474a4ff11003655d00acf10e7303"
+      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.47/gestaltd-macos-x86_64.tar.gz"
+      sha256 ""
     end
   end
 
   on_linux do
     on_arm do
-      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.46/gestaltd-linux-arm64.tar.gz"
-      sha256 "f52107fca1ed55ceff3e8225704172437128b216fc284788f62f12aed2399285"
+      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.47/gestaltd-linux-arm64.tar.gz"
+      sha256 ""
     end
 
     on_intel do
-      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.46/gestaltd-linux-x86_64.tar.gz"
-      sha256 "4a76c93c2f62bf85795bcf76fc65599b7121355d2437f6f6f4babe26677a837e"
+      url "https://github.com/valon-technologies/gestalt/releases/download/gestaltd/v0.0.2-alpha.47/gestaltd-linux-x86_64.tar.gz"
+      sha256 ""
     end
   end
 

--- a/gestaltd/deploy/helm/gestaltd/Chart.yaml
+++ b/gestaltd/deploy/helm/gestaltd/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: gestaltd
 description: gestaltd - OAuth token management proxy with pluggable integrations
 type: application
-version: 0.0.2-alpha.46
-appVersion: "0.0.2-alpha.46"
+version: 0.0.2-alpha.47
+appVersion: "0.0.2-alpha.47"


### PR DESCRIPTION
Bumps gestaltd to `0.0.2-alpha.47`.

Includes PR #2910 (reverse publication client), the `gestaltAdmin` authz fix, the `enforcePublicAuthorization` exemption for RemoteManagement, and the race test skip for upstream frp.

Once merged, push tag `gestaltd/v0.0.2-alpha.47` to trigger the release workflow (GitHub Release, Docker image to GCP AR, Homebrew formula update).