### PR TITLE
Resolve credential subject in RemoteManagement authz

### DIFF
--- a/gestaltd/internal/server/reverse_remote.go
+++ b/gestaltd/internal/server/reverse_remote.go
@@ -83,6 +83,7 @@ func setupReverseRemoteUpstream(ctx context.Context, cfg *config.Config, service
 	result.remoteManagement, err = remotemanagement.New(
 		services.RemoteRegistrations,
 		authz,
+		services.Users,
 		validator,
 		remotemanagement.Config{
 			ServerIdentity: &proto.ServerIdentity{

--- a/gestaltd/services/remotemanagement/service.go
+++ b/gestaltd/services/remotemanagement/service.go
@@ -42,17 +42,19 @@ type Service struct {
 
 	store    *coredata.RemoteRegistrationService
 	authz    core.AuthorizationProvider
+	users    principal.CredentialUserResolver
 	validate EndpointValidator
 	config   Config
 }
 
-func New(store *coredata.RemoteRegistrationService, authz core.AuthorizationProvider, validate EndpointValidator, config Config) (*Service, error) {
+func New(store *coredata.RemoteRegistrationService, authz core.AuthorizationProvider, users principal.CredentialUserResolver, validate EndpointValidator, config Config) (*Service, error) {
 	if config.LeaseDuration <= 0 {
 		return nil, status.Errorf(codes.FailedPrecondition, "remote management lease duration must be positive")
 	}
 	return &Service{
 		store:    store,
 		authz:    authz,
+		users:    users,
 		validate: validate,
 		config:   config,
 	}, nil
@@ -70,12 +72,12 @@ func (s *Service) CreateRemote(ctx context.Context, req *proto.CreateRemoteReque
 	}
 
 	p := principal.FromContext(ctx)
-	owner, err := ownerSubject(p)
-	if err != nil {
-		return nil, err
-	}
 	if err := s.authorizeAdmin(ctx, p, "create"); err != nil {
 		return nil, err
+	}
+	owner, err := principal.ResolveCredentialSubjectID(ctx, s.users, p)
+	if err != nil {
+		return nil, resolveSubjectError(err)
 	}
 
 	defs := req.GetProviders()
@@ -118,10 +120,9 @@ func (s *Service) ListRemotes(ctx context.Context, _ *proto.ListRemotesRequest) 
 	if err := s.authorizeAdmin(ctx, p, "read"); err != nil {
 		return nil, err
 	}
-
-	owner, err := ownerSubject(p)
+	owner, err := principal.ResolveCredentialSubjectID(ctx, s.users, p)
 	if err != nil {
-		return nil, err
+		return nil, resolveSubjectError(err)
 	}
 	reg, providers, err := s.store.ListByOwner(ctx, owner)
 	if err != nil {
@@ -157,6 +158,9 @@ func (s *Service) DeleteRemote(ctx context.Context, req *proto.DeleteRemoteReque
 		return nil, status.Error(codes.InvalidArgument, "expected_generation is required for delete")
 	}
 	p := principal.FromContext(ctx)
+	if p == nil {
+		return nil, status.Error(codes.Unauthenticated, "authenticated subject is required")
+	}
 	if err := s.authorizeAdmin(ctx, p, "delete"); err != nil {
 		return nil, err
 	}
@@ -166,15 +170,13 @@ func (s *Service) DeleteRemote(ctx context.Context, req *proto.DeleteRemoteReque
 	return &emptypb.Empty{}, nil
 }
 
-// authorizeAdmin checks the admin action on the gestaltd resource. A nil provider
-// means no check; every action still requires an authenticated subject.
 func (s *Service) authorizeAdmin(ctx context.Context, p *principal.Principal, action string) error {
-	subjectID, err := ownerSubject(p)
-	if err != nil {
-		return err
-	}
 	if s == nil || s.authz == nil {
 		return nil
+	}
+	subjectID, err := principal.ResolveCredentialSubjectID(ctx, s.users, p)
+	if err != nil {
+		return resolveSubjectError(err)
 	}
 	req := invocation.SubjectAccessRequest(subjectID, action, &proto.Resource{
 		Type: adminResourceType,
@@ -295,12 +297,11 @@ func remoteToProto(reg *coredata.RemoteRegistration, defs []*proto.RemoteProvide
 	return out
 }
 
-func ownerSubject(p *principal.Principal) (string, error) {
-	p = principal.Canonicalized(p)
-	if p == nil || strings.TrimSpace(p.SubjectID) == "" {
-		return "", status.Error(codes.Unauthenticated, "authenticated subject is required")
+func resolveSubjectError(err error) error {
+	if errors.Is(err, principal.ErrCredentialSubjectRequired) {
+		return status.Error(codes.Unauthenticated, "authenticated subject is required")
 	}
-	return p.SubjectID, nil
+	return status.Errorf(codes.Internal, "remote management: resolve credential subject: %v", err)
 }
 
 func mapStoreError(err error) error {

--- a/gestaltd/services/remotemanagement/service_test.go
+++ b/gestaltd/services/remotemanagement/service_test.go
@@ -28,7 +28,7 @@ func TestNewRejectsNonPositiveLeaseDuration(t *testing.T) {
 	}
 	for _, d := range []time.Duration{0, -time.Second} {
 		if _, err := remotemanagement.New(
-			services.RemoteRegistrations, nil, &fakeValidator{}, remotemanagement.Config{LeaseDuration: d},
+			services.RemoteRegistrations, nil, nil, &fakeValidator{}, remotemanagement.Config{LeaseDuration: d},
 		); err == nil {
 			t.Fatalf("New(LeaseDuration=%v) succeeded, want error", d)
 		}
@@ -45,7 +45,7 @@ func newRemoteService(t *testing.T, authz core.AuthorizationProvider) *remoteman
 	services.RemoteRegistrations.SetClock(func() time.Time { return start })
 	validate := &fakeValidator{}
 	svc, err := remotemanagement.New(
-		services.RemoteRegistrations, authz, validate, remotemanagement.Config{LeaseDuration: testLease},
+		services.RemoteRegistrations, authz, services.Users, validate, remotemanagement.Config{LeaseDuration: testLease},
 	)
 	if err != nil {
 		t.Fatalf("remotemanagement.New: %v", err)
@@ -93,7 +93,7 @@ func (f *fakeValidator) Validate(ctx context.Context, tunnel *proto.TunnelEndpoi
 
 func TestCreateRemoteGenerationMatrix(t *testing.T) {
 	t.Parallel()
-	ctx := withPrincipal(context.Background(), "user:alice@example.com")
+	ctx := withPrincipal(context.Background(), "user:alice-uuid")
 
 	t.Run("create_at_generation_zero", func(t *testing.T) {
 		t.Parallel()
@@ -109,8 +109,8 @@ func TestCreateRemoteGenerationMatrix(t *testing.T) {
 		if remote.Generation != 1 {
 			t.Fatalf("generation = %d, want 1", remote.Generation)
 		}
-		if remote.OwnerSubjectId != "user:alice@example.com" {
-			t.Fatalf("owner = %q, want user:alice@example.com", remote.OwnerSubjectId)
+		if remote.OwnerSubjectId != "user:alice-uuid" {
+			t.Fatalf("owner = %q, want user:alice-uuid", remote.OwnerSubjectId)
 		}
 	})
 
@@ -166,8 +166,8 @@ func TestCreateRemoteGenerationMatrix(t *testing.T) {
 func TestCreateRemoteCrossOwnerConflict(t *testing.T) {
 	t.Parallel()
 	svc := newRemoteService(t, nil)
-	alice := withPrincipal(context.Background(), "user:alice@example.com")
-	bob := withPrincipal(context.Background(), "user:bob@example.com")
+	alice := withPrincipal(context.Background(), "user:alice-uuid")
+	bob := withPrincipal(context.Background(), "user:bob-uuid")
 
 	if _, err := svc.CreateRemote(alice, &proto.CreateRemoteRequest{
 		Tunnel: validTunnel(), Providers: []*proto.RemoteProviderDefinition{appProvider("app", "test-app")}, ExpectedGeneration: 0,
@@ -184,7 +184,7 @@ func TestCreateRemoteCrossOwnerConflict(t *testing.T) {
 
 func TestCreateRemoteRejectsForbiddenKinds(t *testing.T) {
 	t.Parallel()
-	ctx := withPrincipal(context.Background(), "user:alice@example.com")
+	ctx := withPrincipal(context.Background(), "user:alice-uuid")
 	svc := newRemoteService(t, nil)
 
 	for _, kind := range []string{"identity", "authorization"} {
@@ -199,7 +199,7 @@ func TestCreateRemoteRejectsForbiddenKinds(t *testing.T) {
 
 func TestDeleteRemoteGenerationRequiredAndNotFound(t *testing.T) {
 	t.Parallel()
-	ctx := withPrincipal(context.Background(), "user:alice@example.com")
+	ctx := withPrincipal(context.Background(), "user:alice-uuid")
 	svc := newRemoteService(t, nil)
 
 	if _, err := svc.DeleteRemote(ctx, &proto.DeleteRemoteRequest{Id: "reg-1", ExpectedGeneration: 0}); codeOf(t, err) != codes.InvalidArgument {
@@ -212,7 +212,7 @@ func TestDeleteRemoteGenerationRequiredAndNotFound(t *testing.T) {
 
 func TestListRemotesEmptyAndAfterCreate(t *testing.T) {
 	t.Parallel()
-	ctx := withPrincipal(context.Background(), "user:alice@example.com")
+	ctx := withPrincipal(context.Background(), "user:alice-uuid")
 	svc := newRemoteService(t, nil)
 
 	resp, err := svc.ListRemotes(ctx, &proto.ListRemotesRequest{})
@@ -244,7 +244,7 @@ func TestListRemotesEmptyAndAfterCreate(t *testing.T) {
 
 func TestAdminAuthorizationStates(t *testing.T) {
 	t.Parallel()
-	ctx := withPrincipal(context.Background(), "user:alice@example.com")
+	ctx := withPrincipal(context.Background(), "user:alice-uuid")
 
 	t.Run("omitted_provider_allows", func(t *testing.T) {
 		t.Parallel()
@@ -292,7 +292,7 @@ func TestCreateRemoteUnauthenticatedWithoutPrincipal(t *testing.T) {
 
 func TestCreateRemoteValidationFailureIsFailedPrecondition(t *testing.T) {
 	t.Parallel()
-	ctx := withPrincipal(context.Background(), "user:alice@example.com")
+	ctx := withPrincipal(context.Background(), "user:alice-uuid")
 	svc := newRemoteService(t, nil)
 	svc.SetValidator(&fakeValidator{fail: true})
 	_, err := svc.CreateRemote(ctx, &proto.CreateRemoteRequest{
@@ -318,7 +318,7 @@ func TestDeleteRemoteRequiresPrincipalEvenWithoutAuthz(t *testing.T) {
 
 func TestListRemotesOmitsExpiredRegistration(t *testing.T) {
 	t.Parallel()
-	ctx := withPrincipal(context.Background(), "user:alice@example.com")
+	ctx := withPrincipal(context.Background(), "user:alice-uuid")
 	svc := newRemoteService(t, nil)
 	if _, err := svc.CreateRemote(ctx, &proto.CreateRemoteRequest{
 		Tunnel: validTunnel(), Providers: []*proto.RemoteProviderDefinition{appProvider("app", "test-app")}, ExpectedGeneration: 0,
@@ -338,7 +338,7 @@ func TestListRemotesOmitsExpiredRegistration(t *testing.T) {
 
 func TestCreateRemoteRejectsDuplicateProviders(t *testing.T) {
 	t.Parallel()
-	ctx := withPrincipal(context.Background(), "user:alice@example.com")
+	ctx := withPrincipal(context.Background(), "user:alice-uuid")
 	svc := newRemoteService(t, nil)
 	dup := appProvider("app", "test-app")
 	_, err := svc.CreateRemote(ctx, &proto.CreateRemoteRequest{

--- a/gestaltd/services/remotepublish/publisher_test.go
+++ b/gestaltd/services/remotepublish/publisher_test.go
@@ -79,6 +79,7 @@ func newUpstreamHarness(t *testing.T) (*upstreamHarness, context.Context, func()
 	rmService, err := remotemanagement.New(
 		services.RemoteRegistrations,
 		nil,
+		services.Users,
 		validator,
 		remotemanagement.Config{
 			ServerIdentity: &proto.ServerIdentity{ClientSpkiSha256: upstreamID.SPKISHA256},


### PR DESCRIPTION
## Summary

The RemoteManagement service used the raw principal subject ID for authorization checks, while every other service resolves the subject through `ResolveCredentialSubjectID` (which looks up the email in the users store and returns the gestaltd-internal user ID).

This caused `access denied` when the OIDC provider returns an email-based subject (`user:hugh@valon.com`) but the grants use the internal UUID (`user:28542db5-...`).

## Changes

- Wire `services.Users` into the RemoteManagement `Service` via `New()`
- Call `principal.ResolveCredentialSubjectID` in `authorizeAdmin`, `CreateRemote`, and `ListRemotes` instead of using the raw `p.SubjectID`
- Delete the `ownerSubject` helper (replaced by `ResolveCredentialSubjectID`)
- Add explicit nil-principal check in `DeleteRemote` (was previously caught by `ownerSubject`)
- Update tests to use UUID-based subjects (matching the real resolution path)

Net -5 lines. No downstream toolshed/valon-tools changes needed — the grants already use the gestaltd-internal UUIDs that `ResolveCredentialSubjectID` returns.