### PR TITLE
Switch reverse publisher to REST transport

### DIFF
--- a/gestaltd/services/remotepublish/publisher.go
+++ b/gestaltd/services/remotepublish/publisher.go
@@ -12,9 +12,10 @@ import (
 	"google.golang.org/grpc"
 
 	gestaltclient "github.com/valon-technologies/gestalt/sdk/go/client"
+	"github.com/valon-technologies/gestalt/sdk/go/publicclient"
+	"github.com/valon-technologies/gestalt/sdk/go/publicclient/generated"
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/config"
-	"github.com/valon-technologies/gestalt/server/internal/remote"
 	"github.com/valon-technologies/gestalt/server/internal/tunnel"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"github.com/valon-technologies/gestalt/server/services/apps/registry"
@@ -28,19 +29,22 @@ type RemoteClient interface {
 }
 
 type remoteClient struct {
-	rm   *gestaltclient.RemoteManagement
-	conn *grpc.ClientConn
+	rm *generated.RemoteManagementClient
 }
 
-func newRemoteClient(ctx context.Context, remoteCfg *config.RemoteConfig) (*remoteClient, error) {
-	conn, err := remote.Dial(ctx, remote.Config{
-		URL:   remoteCfg.URL,
-		Token: remoteCfg.Token,
-	})
+func newRemoteClient(_ context.Context, remoteCfg *config.RemoteConfig) (*remoteClient, error) {
+	token := strings.TrimSpace(remoteCfg.Token)
+	var auth publicclient.Auth
+	if token != "" {
+		auth = publicclient.Bearer(func(_ context.Context) (string, error) { return token, nil })
+	}
+	transport, err := publicclient.NewRESTTransport(remoteCfg.URL, auth)
 	if err != nil {
 		return nil, err
 	}
-	return &remoteClient{rm: gestaltclient.NewRemoteManagement(conn), conn: conn}, nil
+	return &remoteClient{
+		rm: generated.NewRemoteManagementClient(transport),
+	}, nil
 }
 
 func (c *remoteClient) ListRemotes(ctx context.Context, req *gestaltclient.ListRemotesRequest) (*gestaltclient.ListRemotesResponse, error) {
@@ -56,10 +60,7 @@ func (c *remoteClient) DeleteRemote(ctx context.Context, req *gestaltclient.Dele
 }
 
 func (c *remoteClient) Close() error {
-	if c == nil || c.conn == nil {
-		return nil
-	}
-	return c.conn.Close()
+	return nil
 }
 
 type PublicationGroup struct {

--- a/gestaltd/services/remotepublish/publisher_test.go
+++ b/gestaltd/services/remotepublish/publisher_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/durationpb"
 
@@ -16,6 +17,7 @@ import (
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	coredata "github.com/valon-technologies/gestalt/server/internal/coredata"
+	"github.com/valon-technologies/gestalt/server/internal/publicrpc"
 	"github.com/valon-technologies/gestalt/server/internal/tunnel"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"github.com/valon-technologies/gestalt/server/services/apps/registry"
@@ -31,8 +33,9 @@ type upstreamHarness struct {
 	remoteCfg *config.RemoteConfig
 	providers *registry.ProviderMap[core.Provider]
 	frps      *tunnel.Server
-	grpcLn    net.Listener
-	grpcSrv   *grpc.Server
+	conn      *publicrpc.InProcessConn
+	httpLn    net.Listener
+	httpSrv   *http.Server
 }
 
 func newUpstreamHarness(t *testing.T) (*upstreamHarness, context.Context, func()) {
@@ -100,20 +103,39 @@ func newUpstreamHarness(t *testing.T) (*upstreamHarness, context.Context, func()
 		ctx = principal.WithPrincipal(ctx, &principal.Principal{SubjectID: "user:alice@example.com"})
 		return handler(ctx, req)
 	}))
-	proto.RegisterRemoteManagementServer(grpcSrv, rmService)
+	publicrpc.RegisterPublicServers(grpcSrv, publicrpc.Servers{
+		RemoteManagement: rmService,
+	})
+	conn, err := publicrpc.NewInProcessConn(grpcSrv)
+	if err != nil {
+		cancel()
+		frps.Close()
+		t.Fatalf("in-process conn: %v", err)
+	}
+	mux := runtime.NewServeMux()
+	if err := publicrpc.RegisterRESTGateway(context.Background(), mux, conn.ClientConn(), publicrpc.Servers{
+		RemoteManagement: rmService,
+	}); err != nil {
+		conn.Close()
+		cancel()
+		frps.Close()
+		t.Fatalf("register REST gateway: %v", err)
+	}
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
+		conn.Close()
 		cancel()
 		frps.Close()
 		t.Fatalf("upstream listen: %v", err)
 	}
-	go func() { _ = grpcSrv.Serve(ln) }()
+	httpSrv := &http.Server{Handler: mux}
+	go func() { _ = httpSrv.Serve(ln) }()
 
 	providers := registry.New()
 	if err := providers.Providers.Register("test-app", &mockProvider{name: "test-app"}); err != nil {
 		cancel()
 		frps.Close()
-		grpcSrv.GracefulStop()
+		conn.Close()
 		t.Fatalf("register provider: %v", err)
 	}
 
@@ -125,12 +147,14 @@ func newUpstreamHarness(t *testing.T) (*upstreamHarness, context.Context, func()
 		},
 		providers: &providers.Providers,
 		frps:      frps,
-		grpcLn:    ln,
-		grpcSrv:   grpcSrv,
+		conn:      conn,
+		httpLn:    ln,
+		httpSrv:   httpSrv,
 	}
 
 	cleanup := func() {
-		grpcSrv.GracefulStop()
+		_ = httpSrv.Close()
+		conn.Close()
 		_ = frpsHTTP.Close()
 		frps.Close()
 		cancel()

--- a/sdk/go/publicclient/rest_transport.go
+++ b/sdk/go/publicclient/rest_transport.go
@@ -204,3 +204,12 @@ func (t *restUnaryTransport) ServerStream(
 		Message: fmt.Sprintf("publicclient: method %s is not available on the REST transport; use a gRPC client", method.FullMethod),
 	}
 }
+
+// NewRESTTransport creates a REST transport for generated clients.
+func NewRESTTransport(baseURL string, auth Auth) (generated.Transport, error) {
+	normalized, err := normalizeAddress(baseURL)
+	if err != nil {
+		return nil, err
+	}
+	return &restUnaryTransport{baseURL: normalized, auth: auth, client: http.DefaultClient}, nil
+}


### PR DESCRIPTION
## Problem

`gestaltd serve --remote` fails with `server closed the stream without sending trailers` when the upstream is behind a Cloudflare tunnel with an HTTP/1.1 origin. The publisher's remote client used gRPC (HTTP/2) to call `ListRemotes`, `CreateRemote`, and `DeleteRemote`, but gRPC cannot traverse an HTTP/1.1 tunnel.

This is the same root cause as the CLI gRPC issue fixed in #2915/#2918, now applied to the reverse publication client.

## Fix

Replace the gRPC dial (`remote.Dial` → `grpc.ClientConn`) with `publicclient.NewRESTTransport` + `generated.RemoteManagementClient`. The publisher now makes standard HTTP REST calls to `/api/v2/remotes`, which work through Cloudflare tunnels.

### Changes

- `gestaltd/services/remotepublish/publisher.go` — `remoteClient` now wraps `generated.RemoteManagementClient` over a REST transport instead of a gRPC connection. Bearer token auth is preserved. `Close()` is a no-op (no gRPC conn to close).
- `sdk/go/publicclient/rest_transport.go` — add `NewRESTTransport(baseURL, auth)` constructor for generated clients not covered by `RestClient` (e.g. `RemoteManagementClient`).
- `gestaltd/services/remotepublish/publisher_test.go` — test harness now serves REST via grpc-gateway (`publicrpc.NewInProcessConn` + `RegisterRESTGateway` + `http.Serve`) instead of a raw gRPC listener, matching the production REST path.

## Testing

- `go test ./gestaltd/services/remotepublish/...` — all tests pass
- `go build ./gestaltd/services/remotepublish/... ./sdk/go/publicclient/...` — clean
- `go vet ./gestaltd/services/remotepublish/... ./sdk/go/publicclient/...` — clean