### PR TITLE
Accept WebSocket connections without Origin header on frps

### DIFF
--- a/gestaltd/internal/tunnel/server.go
+++ b/gestaltd/internal/tunnel/server.go
@@ -76,18 +76,21 @@ func StartServer(ctx context.Context) (*Server, error) {
 // as the public API.
 func (s *Server) HTTPHandler() http.Handler {
 	mux := http.NewServeMux()
-	mux.Handle(FrpsWebsocketPath, websocket.Handler(func(c *websocket.Conn) {
-		c.PayloadType = websocket.BinaryFrame
-		backend, err := net.Dial("tcp", s.controlAddr)
-		if err != nil {
-			return
-		}
-		defer func() { _ = backend.Close() }()
-		done := make(chan struct{}, 2)
-		go func() { _, _ = io.Copy(backend, c); done <- struct{}{} }()
-		go func() { _, _ = io.Copy(c, backend); done <- struct{}{} }()
-		<-done
-	}))
+	mux.Handle(FrpsWebsocketPath, websocket.Server{
+		Handler: func(c *websocket.Conn) {
+			c.PayloadType = websocket.BinaryFrame
+			backend, err := net.Dial("tcp", s.controlAddr)
+			if err != nil {
+				return
+			}
+			defer func() { _ = backend.Close() }()
+			done := make(chan struct{}, 2)
+			go func() { _, _ = io.Copy(backend, c); done <- struct{}{} }()
+			go func() { _, _ = io.Copy(c, backend); done <- struct{}{} }()
+			<-done
+		},
+		Handshake: func(_ *websocket.Config, _ *http.Request) error { return nil },
+	})
 	return mux
 }
 


### PR DESCRIPTION
## Problem

`gestaltd serve --remote` fails with `connect to server error: bad status` when connecting to the upstream frps through Cloudflare. The REST publisher fix (#2947) resolved the `ListRemotes` gRPC issue, but the frp tunnel connection itself fails.

## Root Cause

The frps WebSocket handler at `/~!frp` used `websocket.Handler` from `golang.org/x/net/websocket`, which applies the default `checkOrigin` handshake. This rejects requests without an `Origin` header with 403. The frpc WebSocket client does not send an `Origin` header (it's not a browser), so the upgrade is rejected. Through Cloudflare this surfaces as 502 Bad Gateway / "bad status".

Verified: a WebSocket upgrade to `http://gestaltd.gestalt:8080/~!frp` from inside the cluster returns 403 without an `Origin` header, and 101 with one.

## Fix

Switch from `websocket.Handler` to `websocket.Server` with a no-op `Handshake` function. The `/~!frp` endpoint is a tunnel transport for frpc clients, not a browser-facing WebSocket, so origin validation is unnecessary.

## Testing

- `go build ./gestaltd/internal/tunnel/...` — clean
- `go test ./gestaltd/services/remotepublish/...` — all tests pass