### PR TITLE
Plan responsive app admin polling (app registry step 20)

### DIFF
--- a/plans/app_registry/operations/responsive-app-admin.md
+++ b/plans/app_registry/operations/responsive-app-admin.md
@@ -110,11 +110,12 @@ This plan PR ([gestalt#2949](https://github.com/valon-technologies/gestalt/pull/
 | --- | --- | --- | --- |
 | **1** | `gestalt-providers` | 3s registry polling | `polling.ts`, `lib/queries/app-admin.ts`, `e2e/app-admin-mock.spec.ts` |
 | **2** | `gestalt-providers` | Live **Publishing** duration labels | `hooks/use-live-now.ts`, `app-admin-snapshots-table.tsx`, `snapshot-rows.ts` |
-| **3** | `gestalt` | App registry docs for step **20** | `pending-publish.md`, `admin.md`, `changelog.md`, `tests.md`, `responsive-app-admin.md` (Shipped In) |
+| **3** | `toolshed` | Deploy bump | `valon-tools/deploy/config.yaml` — `apps.home.source.git.ref` to the merged `gestalt-providers` commit |
+| **4** | `gestalt` | App registry docs for step **20** | `pending-publish.md`, `admin.md`, `changelog.md`, `tests.md`, `responsive-app-admin.md` (Shipped In) |
 
-**Merge order:** **1** and **2** may land in either order or as one `gestalt-providers` PR if the diff stays small. Merge **3** after **1** and **2** so the shipped polling interval and `useLiveNow` behavior match the docs.
+**Merge order:** **1** and **2** may land in either order or as one `gestalt-providers` PR if the diff stays small. Merge **3** after **1** and **2** so production serves the new default app UI. Merge **4** last so shipped docs match the deployed behavior.
 
-No `gestaltd` or `toolshed` changes — the app-admin API and GCS layout are unchanged.
+No `gestaltd` changes — the app-admin API and GCS layout are unchanged.
 
 ### PR 1 — `gestalt-providers` (registry polling)
 
@@ -130,11 +131,17 @@ No `gestaltd` or `toolshed` changes — the app-admin API and GCS layout are unc
 - `snapshot-rows.ts` — **Publishing** duration from `startedAt` + `liveNow` (not `publishingForSeconds`)
 - Optional E2E: duration label advances between frozen registry responses
 
-### PR 3 — `gestalt` (documentation)
+### PR 3 — `toolshed` (deploy bump)
+
+- Bump `apps.home.source.git.ref` in `valon-tools/deploy/config.yaml` to the `gestalt-providers` commit that includes **1** and **2**
+- `apps.home` is the default `/apps` shell that serves `/apps/{app}/admin` for registry-only apps such as `g-issues`
+- No workflow or registry publish changes — UI-only deploy pin
+
+### PR 4 — `gestalt` (documentation)
 
 - [pending-publish.md](./pending-publish.md) — polling bullets (**3s** bootstrap and active)
 - [admin.md](./admin.md) — refresh-until-terminal wording
-- [changelog.md](../project/changelog.md) — step **20** entry with links to PRs **1**–**3**
+- [changelog.md](../project/changelog.md) — step **20** entry with links to PRs **1**–**4**
 - [tests.md](../project/tests.md) — UI polling and live-clock coverage
 - [responsive-app-admin.md](./responsive-app-admin.md) — add **Shipped In**; remove planned-only wording
 
@@ -154,7 +161,7 @@ See [Implementation PRs](#implementation-prs) **1** and **2**.
 
 ### Docs (on ship)
 
-See [Implementation PRs](#implementation-prs) **3**.
+See [Implementation PRs](#implementation-prs) **4**.
 
 ---
 

--- a/plans/app_registry/operations/responsive-app-admin.md
+++ b/plans/app_registry/operations/responsive-app-admin.md
@@ -90,19 +90,22 @@ The page holds one **registry snapshot**. The server returns facts; the UI deriv
 
 #### Poll mode
 
-Derived after every fetch from the snapshot plus one local value (`bootstrapPollUntilMs`, 5 minutes after page load):
+Per open tab only — closing the tab stops all polling. There is no server-side idle state.
 
-| Mode | Condition | Poll |
+| What you see | Mode | Background refresh |
 | --- | --- | --- |
-| **Stopped** | Past bootstrap and no active signals | none |
-| **Bootstrap** | Within bootstrap window, no active signals | full, 12s |
-| **Active** | Any active signal below | status, 3s |
+| Page just opened; waiting to see if a publish starts | **Landing** | Full snapshot every **12s** (first 5 minutes) |
+| A publish, rollout, or deploy lock is in progress | **Active** | Lightweight status every **3s**; **Publishing · for …** ticks every **1s** locally |
+| Quiet page — nothing moving, been open > 5 minutes | **Quiet** | None — table is static until you refresh or click Deploy |
+| Tab closed | — | Nothing runs |
 
-**Active signals** (from the API response, not a separate mode field):
+**Landing** ends after 5 minutes or as soon as an active signal appears (whichever comes first).
 
-- `pendingVersions.length > 0`
-- `rollout.state` is `enrolling` or `restarting`
-- `selectionDisabled` is `true` (server sets this when rollout is active)
+**Active signals** (from the API — not a mode field on the app):
+
+- A row is **Publishing** (`pendingVersions` non-empty)
+- Rollout banner shows **Enrolling** or **Restarting**
+- Deploy buttons are disabled (`selectionDisabled`)
 
 #### Escalation
 
@@ -121,9 +124,9 @@ After escalation, recompute poll mode from the updated snapshot.
 
 ### 2. Polling implementation
 
-Constants: `POLL_INTERVAL_ACTIVE_MS = 3_000`, `POLL_INTERVAL_IDLE_MS = 12_000`.
+Constants: `POLL_INTERVAL_ACTIVE_MS = 3_000`, `POLL_INTERVAL_LANDING_MS = 12_000` (rename from `POLL_INTERVAL_IDLE_MS`).
 
-Implement `computePollMode` and `shouldEscalateToFullRegistry` in `gestalt-providers/app/default/src/features/registry/polling.ts`. Replace the chained `setTimeout` in `AppAdminPageClient.tsx` with `setInterval` (or React Query `refetchInterval`) keyed on poll mode.
+Implement `computePollMode` (`landing` | `active` | `quiet`) and `shouldEscalateToFullRegistry` in `gestalt-providers/app/default/src/features/registry/polling.ts`. Keep `APP_ADMIN_BOOTSTRAP_POLL_MS` as the landing-window duration (internal name; user-facing docs say **landing**).
 
 Pause polling when `document.visibilityState === "hidden"`; catch up once when visible again.
 
@@ -245,7 +248,7 @@ function mergeAppAdminRegistryStatus(
 
 | Test | Asserts |
 | --- | --- |
-| `computePollMode` | `active` with pending; `bootstrap` within 5 min only; `stopped` otherwise |
+| `computePollMode` | `active` with pending/rollout; `landing` within 5 min only; `quiet` otherwise |
 | `shouldEscalateToFullRegistry` | pending cleared, new failed, terminal rollout, desired version change |
 | `snapshotStatusTimer` with advancing `now` | `for 59s` → `for 1m` → `for 1m 1s` without new API data |
 

--- a/plans/app_registry/operations/responsive-app-admin.md
+++ b/plans/app_registry/operations/responsive-app-admin.md
@@ -102,22 +102,59 @@ For **Publishing** rows, prefer `startedAt` + `liveNow` over `publishingForSecon
 
 ---
 
+## Implementation PRs
+
+This plan PR ([gestalt#2949](https://github.com/valon-technologies/gestalt/pull/2949)) is docs only. Ship step **20** with the PRs below.
+
+| # | Repo | Scope | Touches |
+| --- | --- | --- | --- |
+| **1** | `gestalt-providers` | 3s registry polling | `polling.ts`, `lib/queries/app-admin.ts`, `e2e/app-admin-mock.spec.ts` |
+| **2** | `gestalt-providers` | Live **Publishing** duration labels | `hooks/use-live-now.ts`, `app-admin-snapshots-table.tsx`, `snapshot-rows.ts` |
+| **3** | `gestalt` | App registry docs for step **20** | `pending-publish.md`, `admin.md`, `changelog.md`, `tests.md`, `responsive-app-admin.md` (Shipped In) |
+
+**Merge order:** **1** and **2** may land in either order or as one `gestalt-providers` PR if the diff stays small. Merge **3** after **1** and **2** so the shipped polling interval and `useLiveNow` behavior match the docs.
+
+No `gestaltd` or `toolshed` changes — the app-admin API and GCS layout are unchanged.
+
+### PR 1 — `gestalt-providers` (registry polling)
+
+- Add `APP_ADMIN_POLL_INTERVAL_MS = 3_000` in `polling.ts`
+- Replace the local `12_000` constant in `lib/queries/app-admin.ts` with the shared export
+- `useAppAdminRegistryQuery` `refetchInterval` unchanged except interval value
+- E2E: `polls for pending publish without manual refresh` timeout **15s → 6s**
+
+### PR 2 — `gestalt-providers` (live duration labels)
+
+- Add `useLiveNow` in `hooks/use-live-now.ts`
+- `app-admin-snapshots-table.tsx` — enable while any `pending` row exists; pass `liveNow` to formatters
+- `snapshot-rows.ts` — **Publishing** duration from `startedAt` + `liveNow` (not `publishingForSeconds`)
+- Optional E2E: duration label advances between frozen registry responses
+
+### PR 3 — `gestalt` (documentation)
+
+- [pending-publish.md](./pending-publish.md) — polling bullets (**3s** bootstrap and active)
+- [admin.md](./admin.md) — refresh-until-terminal wording
+- [changelog.md](../project/changelog.md) — step **20** entry with links to PRs **1**–**3**
+- [tests.md](../project/tests.md) — UI polling and live-clock coverage
+- [responsive-app-admin.md](./responsive-app-admin.md) — add **Shipped In**; remove planned-only wording
+
+Optional follow-up (not required for step **20**):
+
+| Repo | Scope |
+| --- | --- |
+| `gestalt-providers` | Pause registry polling when `document.visibilityState === "hidden"` |
+
+---
+
 ## Implementation
 
 ### `gestalt-providers`
 
-- `APP_ADMIN_POLL_INTERVAL_MS = 3_000` in `polling.ts`; wire through `useAppAdminRegistryQuery` (`refetchInterval`)
-- `useLiveNow` — `hooks/use-live-now.ts`
-- `app-admin-snapshots-table.tsx` — pass `liveNow` into duration formatters
-- `snapshot-rows.ts` — pending duration from `startedAt` + `liveNow`
-- `e2e/app-admin-mock.spec.ts` — pending visibility timeout **15s → 6s**
+See [Implementation PRs](#implementation-prs) **1** and **2**.
 
 ### Docs (on ship)
 
-- [pending-publish.md](./pending-publish.md) — polling bullets (**3s** bootstrap and active)
-- [admin.md](./admin.md) — refresh-until-terminal wording
-- [changelog.md](../project/changelog.md) — step `20`
-- [tests.md](../project/tests.md) — UI polling tests
+See [Implementation PRs](#implementation-prs) **3**.
 
 ---
 

--- a/plans/app_registry/operations/responsive-app-admin.md
+++ b/plans/app_registry/operations/responsive-app-admin.md
@@ -1,0 +1,345 @@
+# Responsive App Admin Polling
+
+Plan for changelog step **20**. Improves `/apps/{app}/admin` responsiveness during publish and rollout without changing GCS write paths or install behavior.
+
+**Status:** planned (not shipped)
+
+## Problem
+
+Today the app admin UI polls `GET /api/v1/apps/{app}/admin/registry` every **12 seconds** while publish or rollout is active. Each request makes gestaltd fetch four GCS documents (`index.json`, `pending.json`, `failed.json`, `retention.json`) plus IndexedDB reads for fleet state.
+
+Two UX gaps follow:
+
+1. **Slow publish visibility** — a CI-recorded pending row can take up to ~12s to appear after page load, and publish completion can take another ~12s to flip from **Publishing** to **Available**.
+2. **Frozen duration labels** — `Publishing · for 4m` only updates when the next poll returns. `publishingForSeconds` is computed server-side at request time, so the label jumps in 12-second steps even though `startedAt` is already on the row.
+
+Scope is `/apps/{app}/admin` only. The embedded fleet `/admin/registry` UI is out of scope for this milestone unless we later reuse the same polling helpers.
+
+## Goals
+
+| Goal | Target |
+| --- | --- |
+| Pending row appears after CI `pending set` | ≤ **3s** after page load (p95) |
+| Publish completion reflected in snapshots table | ≤ **3s** after `pending clear` + `index.json` update |
+| Publish-duration label | Updates every **1s** locally while a row is **Publishing** |
+| GCS reads per active poll | **1–2** objects instead of **4** |
+
+## Non-Goals
+
+- Push notifications (SSE, WebSocket, GCS Pub/Sub)
+- Server-side caching of registry documents
+- Faster catalog poller (replica convergence remains ~1 minute)
+- Embedded `/admin/registry` list auto-refresh (still one-shot today)
+- Polling solely because `failedVersions` is non-empty (unchanged)
+
+---
+
+## Design
+
+### 1. Lightweight status endpoint
+
+Add a read-only app-admin route that returns only the mutable publish catalogs and fleet control state gestaltd already derives for the full registry response.
+
+```
+GET /api/v1/apps/{app}/admin/registry/status
+```
+
+**Auth:** same middleware as `GET …/admin/registry` (`app` plugin route + `admin` on `app/{app}`).
+
+**GCS fetches:**
+
+| Document | Fetch |
+| --- | --- |
+| `pending.json` | yes |
+| `failed.json` | yes |
+| `index.json` | no |
+| `retention.json` | no |
+
+**IndexedDB reads:**
+
+| Store | Fields |
+| --- | --- |
+| `app_version_change_requests` | `desiredVersion` (via `LatestKnownVersion`) |
+| `app_rollouts` | active rollout `version` + `state` |
+| — | `selectionDisabled` / `disabledReason` (same rules as full handler) |
+
+**Response shape:**
+
+```json
+{
+  "pendingVersions": [ /* same row shape as full registry */ ],
+  "failedVersions": [ /* same row shape as full registry */ ],
+  "desiredVersion": "0.0.0-snapshot.gabc123",
+  "rollout": { "version": "…", "state": "enrolling" },
+  "selectionDisabled": false,
+  "disabledReason": ""
+}
+```
+
+Reuse the existing `appAdminPendingVersion` / `appAdminFailedVersion` structs and admin-catalog merge helpers from `handlers_app_admin_registry.go`. Do not duplicate merge precedence logic in the UI.
+
+**When the UI uses each endpoint:**
+
+| Situation | Endpoint | Interval |
+| --- | --- | --- |
+| Initial page load | `GET …/admin/registry` (full) | once |
+| After deploy selection | full | once, then active polling |
+| Active publish (`pendingVersions.length > 0`) | status | **3s** |
+| Active rollout or `selectionDisabled` (no pending) | status | **3s** |
+| Bootstrap window (first 5 minutes, idle) | full | **12s** |
+| Otherwise | none | — |
+
+**Escalation to full registry:**
+
+The status endpoint cannot produce published snapshot rows (deployment state, `deployableUntil`, publication metadata on completed versions). The UI must call the full registry endpoint when:
+
+1. A `pendingVersions` entry disappears (publish succeeded or was pruned to failed).
+2. A new `failedVersions` entry appears that was not in the previous status snapshot (stale prune or workflow failure during an active session).
+3. Rollout reaches a terminal state (`complete` or `failed`).
+4. `desiredVersion` changes (deploy succeeded).
+
+After escalation, resume status polling if the new state is still active; otherwise stop.
+
+```text
+status poll (3s)
+  ├── pending cleared     → full registry → merge published row
+  ├── new failed version  → full registry → merge failed row
+  ├── rollout terminal    → full registry → unlock Deploy
+  └── desiredVersion Δ    → full registry → refresh Deployed badge
+```
+
+### 2. Adaptive polling intervals
+
+Replace the single `POLL_INTERVAL_MS = 12_000` with two constants:
+
+| Constant | Value | Used when |
+| --- | ---: | --- |
+| `POLL_INTERVAL_ACTIVE_MS` | `3_000` | `shouldPollAppAdminRegistry` is true **and** at least one active trigger is present (pending, rollout, or `selectionDisabled`) |
+| `POLL_INTERVAL_IDLE_MS` | `12_000` | bootstrap window only (no pending / rollout / selection lock) |
+
+Update `shouldPollAppAdminRegistry` in `gestalt-providers/app/default/src/features/registry/polling.ts`:
+
+```ts
+export function appAdminPollIntervalMs(
+  registry: AppAdminRegistryResponse,
+  bootstrapPollUntilMs: number,
+  now = Date.now(),
+): number | null {
+  if (!shouldPollAppAdminRegistry(registry, bootstrapPollUntilMs, now)) return null;
+  const active =
+    (registry.pendingVersions?.length ?? 0) > 0 ||
+    registry.selectionDisabled ||
+    (registry.rollout && isActiveRegistryRollout(registry.rollout.state));
+  return active ? POLL_INTERVAL_ACTIVE_MS : POLL_INTERVAL_IDLE_MS;
+}
+```
+
+**Polling implementation:** replace the chained `setTimeout` in `AppAdminPageClient.tsx` (effect re-schedules only after `registry` changes) with a single `setInterval` (or React Query `refetchInterval`) keyed on the computed interval. Clear the timer on unmount and when polling stops.
+
+**Status vs full during active poll:**
+
+```ts
+const endpoint =
+  (registry.pendingVersions?.length ?? 0) > 0 ||
+  registry.rollout ||
+  registry.selectionDisabled
+    ? getAppAdminRegistryStatus
+    : getAppAdminRegistry; // bootstrap-only path
+```
+
+During bootstrap with no active signals, keep fetching the full registry at 12s so a not-yet-visible pending row still resolves without requiring the operator to refresh.
+
+Pause polling while `document.visibilityState === "hidden"`; run one catch-up fetch when the tab becomes visible again.
+
+### 3. Continuous duration labels (local clock)
+
+Separate **data freshness** (3s / 12s polls) from **display freshness** (1s local tick).
+
+**Principle:** server fields name *when* something started; the UI computes *how long ago* from `startedAt` + client `now`. Stop sending `publishingForSeconds` on status responses once the UI owns the live clock (keep on full registry for backward compatibility during rollout).
+
+**Hook:** `useLiveNow({ enabled, intervalMs = 1_000 })`
+
+- `enabled` when the snapshots table has at least one `pending` row, or optionally when any `formatRegistryTimeAgo` label is shown and the page is visible.
+- Returns `now` (ms) updated every second via `setInterval`.
+- Clears interval when `enabled` is false or the tab is hidden.
+- Uses `document.visibilityState` to avoid background timers.
+
+**Wire into existing formatters** — `snapshotStatusTimer` and `snapshotLastUpdatedLabel` already accept an optional `now` argument in `snapshot-rows.ts`. Pass `liveNow` from the table (or a parent provider) instead of defaulting to `Date.now()` only at render time without a tick.
+
+```ts
+// app-admin-snapshots-table.tsx
+const liveNow = useLiveNow({
+  enabled: rows.some((row) => row.kind === "pending"),
+});
+
+const statusTimer = snapshotStatusTimer(row, liveNow);
+const lastUpdated = snapshotLastUpdatedLabel(row, liveNow);
+```
+
+**Display rules:**
+
+| Row | Label | Source |
+| --- | --- | --- |
+| **Publishing** | `for 4m 12s` | `durationSecondsBetween(pending.startedAt, liveNow)` |
+| **Available** (published) | `Published in 4m 32s` | static (`publishDurationSeconds` or `publishStartedAt` → `publishedAt`) |
+| **Failed** | `Failed after 35m` | static |
+| **Last update** (pending) | `4 minutes ago` | `formatRegistryTimeAgo(pending.updatedAt, liveNow)` — ticks during publish |
+
+Published and failed duration sublabels stay static; only in-flight publish labels and pending last-update relatives need the live clock.
+
+**Do not** add a 1s poll to gestaltd. The continuous look is entirely client-side.
+
+---
+
+## API Summary
+
+| Route | GCS | IndexedDB | Purpose |
+| --- | --- | --- | --- |
+| `GET …/admin/registry` | index, pending, failed, retention | desired, rollout | Full snapshots + deploy actions |
+| `GET …/admin/registry/status` | pending, failed | desired, rollout, selection | Active polling |
+| `GET …/admin/registry/history` | index, retention | change requests | Unchanged (lazy tab load) |
+| `POST …/admin/registry/version` | index (validation) | write | Unchanged |
+
+Document the status route in [lifecycle.md](./lifecycle.md#app-admin-version-selection) alongside the existing app-admin registry handlers.
+
+---
+
+## UI State Machine
+
+```text
+[load] ──full──► registry state
+                    │
+        ┌───────────┴───────────┐
+        │ shouldPoll?           │
+        └───────────┬───────────┘
+                    │ yes
+        ┌───────────▼───────────┐
+        │ pick interval         │
+        │  3s active / 12s boot │
+        └───────────┬───────────┘
+                    │
+        ┌───────────▼───────────┐
+        │ pick endpoint         │
+        │  status vs full       │
+        └───────────┬───────────┘
+                    │
+        ┌───────────▼───────────┐
+        │ merge or escalate     │
+        └───────────┬───────────┘
+                    │
+        ┌───────────▼───────────┐
+        │ live clock (1s)       │
+        │ if pending rows       │
+        └───────────────────────┘
+```
+
+**Merge helper** (`mergeAppAdminRegistryStatus`):
+
+```ts
+function mergeAppAdminRegistryStatus(
+  current: AppAdminRegistryResponse,
+  status: AppAdminRegistryStatusResponse,
+): AppAdminRegistryResponse {
+  return {
+    ...current,
+    pendingVersions: status.pendingVersions,
+    failedVersions: status.failedVersions,
+    desiredVersion: status.desiredVersion,
+    rollout: status.rollout,
+    selectionDisabled: status.selectionDisabled,
+    disabledReason: status.disabledReason,
+  };
+}
+```
+
+Compare previous and next status to detect escalation triggers before merging.
+
+---
+
+## Implementation Checklist
+
+### gestalt
+
+- [ ] `GET /api/v1/apps/{app}/admin/registry/status` handler in `handlers_app_admin_registry.go`
+- [ ] Mount route in `mountAppAdminRegistryRoutes`
+- [ ] Unit tests: empty pending, pending rows with `publishingForSeconds`, failed merge precedence, rollout + `selectionDisabled` flags, 403/404 parity with full handler
+- [ ] Lifecycle doc: request/response shapes and GCS read set
+
+### gestalt-providers
+
+- [ ] `getAppAdminRegistryStatus` in `lib/api.ts` + `AppAdminRegistryStatusResponse` type
+- [ ] `appAdminPollIntervalMs`, `mergeAppAdminRegistryStatus`, escalation detector in `polling.ts`
+- [ ] `useLiveNow` hook (e.g. `hooks/use-live-now.ts`)
+- [ ] Refactor `AppAdminPageClient.tsx`: interval polling, status/full selection, escalation, visibility pause
+- [ ] Pass `liveNow` into `AppAdminSnapshotsTable` → `snapshotStatusTimer` / `snapshotLastUpdatedLabel`
+- [ ] Update `e2e/app-admin-mock.spec.ts`: pending visibility timeout **15s → 5s**; add live-clock unit test for `snapshotStatusTimer`
+
+### docs (on ship)
+
+- [ ] [pending-publish.md](./pending-publish.md) — polling section
+- [ ] [admin.md](./admin.md) — app admin capabilities / timing
+- [ ] [changelog.md](../project/changelog.md) — step `20`
+- [ ] [tests.md](../project/tests.md) — status endpoint + UI tests
+
+---
+
+## Tests
+
+### Server (`handlers_app_admin_registry_test.go`)
+
+| Test | Asserts |
+| --- | --- |
+| `TestGetAppAdminRegistryStatus/pending_only` | Returns pending rows; does not call `FetchAppIndex` / `FetchRetentionIndex` (mock reader records fetch paths) |
+| `TestGetAppAdminRegistryStatus/merge_precedence` | Published version in index suppresses pending/failed of same version when handler is tested with fixture that has both |
+| `TestGetAppAdminRegistryStatus/rollout_and_selection` | IndexedDB rollout and `selectionDisabled` match full handler |
+| `TestGetAppAdminRegistryStatus/forbidden` | **403** without registry metadata leak |
+
+### UI unit
+
+| Test | Asserts |
+| --- | --- |
+| `appAdminPollIntervalMs` | `3000` with pending; `12000` during bootstrap only; `null` when idle |
+| `shouldEscalateToFullRegistry` | pending cleared, new failed, terminal rollout, desired version change |
+| `snapshotStatusTimer` with advancing `now` | `for 59s` → `for 1m` → `for 1m 1s` without new API data |
+
+### E2E (`app-admin-mock.spec.ts`)
+
+| Test | Asserts |
+| --- | --- |
+| `polls status endpoint during publish` | Route mock distinguishes `…/registry/status` from full `…/registry`; pending row within **5s** |
+| `escalates to full registry when publish completes` | After pending cleared in status mock, full endpoint called and **Available** row appears |
+| `publishing timer ticks between polls` | With frozen API, label changes over 2s (unit-level Playwright or component test) |
+
+---
+
+## Rollout / Safety
+
+| Invariant | Preserved how |
+| --- | --- |
+| Pending/failed not installable | Install handlers unchanged |
+| Published > pending > failed | Same server-side merge on status endpoint |
+| No GCS writes from `gestaltd serve` | Status is read-only |
+| Failed rows on first load | Initial full fetch still includes `failedVersions`; status polls do not start solely for failed |
+
+Deploy gestalt (new route) before or with gestalt-providers (UI). Old UI against new gestalt: works (ignores unknown route). New UI against old gestalt: status calls return **404** — ship together or gate UI on route probe.
+
+---
+
+## Future Work (out of scope)
+
+- IndexedDB-only status variant during rollout (zero GCS) when no pending/failed catalogs are relevant
+- Short TTL registry cache in gestaltd to allow sub-second polling without GCS amplification
+- SSE push on `pending set` / rollout transitions
+- Embedded `/admin/registry` adaptive polling (align with [admin.md](./admin.md#apps-list-adminregistry))
+
+---
+
+## Related Docs
+
+<pre>
+├── <a href="../project/changelog.md">changelog.md</a> — step 20 (on ship)
+├── <a href="./pending-publish.md">pending-publish.md</a> — publish catalogs and current 12s polling
+├── <a href="./admin.md">admin.md</a> — app admin UI wireframes
+├── <a href="./lifecycle.md">lifecycle.md</a> — app-admin HTTP APIs
+└── <a href="../project/tests.md">tests.md</a> — test index (extend on ship)
+</pre>

--- a/plans/app_registry/operations/responsive-app-admin.md
+++ b/plans/app_registry/operations/responsive-app-admin.md
@@ -1,150 +1,168 @@
-# Responsive App Admin Polling
+# App Admin Registry Polling
 
-Plan for changelog step **20**. Improves `/apps/{app}/admin` responsiveness during publish and rollout without changing GCS write paths, install behavior, or the app-admin API.
+Faster registry refresh and live publish-duration labels on `/apps/{app}/admin` during CI publish and fleet rollout.
 
-**Status:** planned (not shipped)
+## Overview
 
-## Problem
+Today `gestalt-providers` polls `GET /api/v1/apps/{app}/admin/registry` every **12 seconds** while publish or rollout is active. Each request makes `gestaltd serve` fetch `index.json`, `pending.json`, `failed.json`, and `retention.json` from GCS, plus IndexedDB reads for fleet state.
 
-Today the app admin UI polls `GET /api/v1/apps/{app}/admin/registry` every **12 seconds** while publish or rollout is active.
+Two operator-visible gaps follow:
 
-Two UX gaps follow:
-
-1. **Slow updates** — a pending row or publish completion can take up to ~12s to appear or flip status.
+1. **Slow table updates** — a CI-recorded **Publishing** row or a completed publish can take up to ~12s to appear or change status.
 2. **Frozen duration labels** — `Publishing · for 4m` only updates on poll. `publishingForSeconds` is computed server-side at request time, so the label jumps in 12-second steps even though `startedAt` is already on the row.
 
-Scope is `/apps/{app}/admin` only. The embedded fleet `/admin` registry UI is out of scope unless we later reuse the same polling helpers.
+Scope is `/apps/{app}/admin` only — the embedded fleet `/admin` registry UI does not show publishing state and is out of scope unless it later reuses the same helpers.
+
+Planned changelog step: **20**. See [changelog.md](../project/changelog.md).
 
 ## Goals
 
-| Goal | Target |
-| --- | --- |
-| Pending row appears after CI `pending set` | ≤ **3s** after page load (p95) |
-| Publish completion reflected in snapshots table | ≤ **3s** after `pending clear` + `index.json` update |
-| Publish-duration label | Updates every **1s** locally while a row is **Publishing** |
+- Poll `GET /api/v1/apps/{app}/admin/registry` every **3s** while the bootstrap window is open or publish/rollout is active (today: **12s**).
+- Show a **Publishing** row within **3s** (p95) after CI `pending set` when an operator already has the page open.
+- Reflect publish completion in **Published snapshots** within **3s** after `pending clear` and `index.json` update.
+- Tick **Publishing** duration labels every **1s** client-side from `startedAt`, without additional `gestaltd` requests.
 
 ## Non-Goals
 
-- New app-admin API routes (keep `GET …/admin/registry` for all polls)
+- New app-admin API routes
 - Push notifications (SSE, WebSocket, GCS Pub/Sub)
 - Server-side caching of registry documents
 - Faster catalog poller (replica convergence remains ~1 minute)
 - Embedded `/admin/registry` list auto-refresh (still one-shot today)
-- Polling solely because `failedVersions` is non-empty (unchanged)
+- Polling solely because `failedVersions` is non-empty (unchanged; see [pending-publish.md](./pending-publish.md))
 
 ---
 
-## Design
+## App-Admin API
 
-All polls use the existing endpoint:
+No API changes. All polls continue to use:
 
-```
-GET /api/v1/apps/{app}/admin/registry
-```
+`GET /api/v1/apps/{app}/admin/registry`
 
-Separate **data freshness** (poll cadence) from **display freshness** (local 1s clock for duration labels).
-
-### Poll mode
-
-Per open tab only — closing the tab stops all polling. There is no server-side idle state. The UI derives mode from the latest registry response plus one local value (`landingPollUntilMs`, 5 minutes after page load).
-
-| What you see | Mode | Background refresh |
-| --- | --- | --- |
-| Page just opened; waiting to see if a publish starts | **Landing** | `GET …/admin/registry` every **3s** (first 5 minutes) |
-| A publish, rollout, or deploy lock is in progress | **Active** | `GET …/admin/registry` every **3s** |
-| Quiet page — nothing moving, been open > 5 minutes | **Quiet** | None — table is static until you refresh or click Deploy |
-| Tab closed | — | Nothing runs |
-
-**Landing** ends after 5 minutes unless an active signal keeps polling beyond that window.
-
-Whenever the UI is polling (landing or active), use the same interval — **3s**. Landing and active differ only in *why* polling continues past the first response, not in cadence.
-
-**Active signals** (from the registry response — not a mode field on the app):
-
-- A row is **Publishing** (`pendingVersions` non-empty)
-- Rollout banner shows **Enrolling** or **Restarting**
-- Deploy buttons are disabled (`selectionDisabled`)
-
-Implement `computePollMode(registry, landingPollUntilMs)` → `landing` | `active` | `quiet` in `gestalt-providers/app/default/src/features/registry/polling.ts`.
-
-Constants: `APP_ADMIN_POLL_INTERVAL_MS = 3_000` whenever `shouldPollAppAdminRegistry` is true. Keep `APP_ADMIN_BOOTSTRAP_POLL_MS` as the landing-window duration (internal constant name).
-
-Wire the interval through `useAppAdminRegistryQuery` (`refetchInterval` in `lib/queries/app-admin.ts`). Pause polling when `document.visibilityState === "hidden"`; catch up once when visible again.
-
-### Continuous duration labels (local clock)
-
-Server fields name *when* something started; the UI computes *how long* from `startedAt` + client `now`. Ignore `publishingForSeconds` for display once the live clock is wired (field may remain on the API).
-
-**Hook:** `useLiveNow({ enabled, intervalMs = 1_000 })`
-
-- `enabled` when the snapshots table has at least one `pending` row.
-- Clears when no pending rows or tab is hidden.
-
-Pass `liveNow` into `snapshotStatusTimer` and `snapshotLastUpdatedLabel` in `snapshot-rows.ts` (both already accept an optional `now`).
-
-| Row | Label | Source |
-| --- | --- | --- |
-| **Publishing** | `for 4m 12s` | `durationSecondsBetween(pending.startedAt, liveNow)` |
-| **Available** (published) | `Published in 4m 32s` | static |
-| **Failed** | `Failed after 35m` | static |
-| **Last update** (pending) | `4 minutes ago` | `formatRegistryTimeAgo(pending.updatedAt, liveNow)` |
-
-**Do not** add a 1s poll to gestaltd. The continuous look is entirely client-side.
+Response shapes and merge rules: [pending-publish.md — App-Admin API](./pending-publish.md#app-admin-api). Wireframes and status labels: [admin.md — App Admin UI](./admin.md#app-admin-ui-appsappadmin).
 
 ---
 
-## Implementation Checklist
+## UI (`/apps/{app}/admin`)
 
-### gestalt-providers
+Implemented in `gestalt-providers` (`polling.ts`, `lib/queries/app-admin.ts`, `app-admin-snapshots-table.tsx`, `snapshot-rows.ts`).
 
-- [ ] `APP_ADMIN_POLL_INTERVAL_MS = 3_000` in `polling.ts`; wire through `useAppAdminRegistryQuery` (`refetchInterval`)
-- [ ] `useLiveNow` in `hooks/use-live-now.ts`
-- [ ] Pass `liveNow` into `AppAdminSnapshotsTable` → `snapshotStatusTimer` / `snapshotLastUpdatedLabel`
-- [ ] Pending duration from `startedAt` + `liveNow` (not stale `publishingForSeconds` from last poll)
-- [ ] E2E: pending visibility timeout **15s → 6s**
-- [ ] Pause registry polling when tab is hidden (optional follow-up)
+Separate **registry refresh** (poll cadence) from **duration display** (local 1s clock).
 
-### docs (on ship)
+### Polling
 
-- [ ] [pending-publish.md](./pending-publish.md) — polling section (3s while landing or active)
-- [ ] [admin.md](./admin.md) — app admin timing
-- [ ] [changelog.md](../project/changelog.md) — step `20`
-- [ ] [tests.md](../project/tests.md) — UI polling tests
+Polling is per browser tab. Closing the tab stops all refresh. `gestaltd` does not track a server-side poll mode.
+
+The UI already derives whether to poll from `shouldPollAppAdminRegistry` in `polling.ts` plus `APP_ADMIN_BOOTSTRAP_POLL_MS` (**5 minutes** after page load). This plan changes only the interval and duration-label behavior.
+
+| When | Registry refresh |
+| --- | --- |
+| **Bootstrap window** — first **5 minutes** after page load, no active signals yet | `GET /api/v1/apps/{app}/admin/registry` every **3s** |
+| **Active publish or rollout** — see signals below | every **3s** |
+| **Idle** — past bootstrap window and no active signals | none until manual refresh or deploy |
+| Tab closed | none |
+
+**Bootstrap window** ends after **5 minutes** unless an active signal keeps polling beyond that window.
+
+**Active signals** (from the registry response — not a field on the app):
+
+- `pendingVersions.length > 0`
+- `rollout.state` is `enrolling` or `restarting` (non-terminal rollout)
+- `selectionDisabled` is `true` (deploy actions locked while rollout is active)
+
+Planned constants:
+
+- `APP_ADMIN_POLL_INTERVAL_MS = 3_000` whenever `shouldPollAppAdminRegistry` returns true (today: `12_000` in `lib/queries/app-admin.ts`)
+- keep `APP_ADMIN_BOOTSTRAP_POLL_MS` for the bootstrap-window duration
+
+Wire `APP_ADMIN_POLL_INTERVAL_MS` through `useAppAdminRegistryQuery` (`refetchInterval`). Optional follow-up: pause polling when `document.visibilityState === "hidden"` and catch up once when visible again.
+
+Do not poll solely because `failedVersions` is non-empty — failed rows load on the initial page fetch.
+
+### Publish duration labels
+
+Durations are computed at read/UI time — not stored as separate GCS fields. Baseline rules: [pending-publish.md — Publish Duration](./pending-publish.md#publish-duration).
+
+This milestone adds a client-side clock so in-flight labels advance between registry polls:
+
+| Row status | Label | Source after this change |
+| --- | --- | --- |
+| **Publishing** | `Publishing` + `for 4m 12s` | `durationSecondsBetween(pending.startedAt, liveNow)` |
+| **Publishing** last update | `4 minutes ago` | `formatRegistryTimeAgo(pending.updatedAt, liveNow)` |
+| **Available** / **Deployed** / etc. | `Published in 4m 32s` | unchanged — static from `publishDurationSeconds` or `publishStartedAt` → `publishedAt` |
+| **Failed** | `Failed after 35m` | unchanged — static from `failedAt` − `startedAt` |
+
+Add `useLiveNow` in `hooks/use-live-now.ts`:
+
+- `enabled` when **Published snapshots** has at least one `pending` row
+- tick every **1s**; pause when the tab is hidden
+- pass `liveNow` into `snapshotStatusTimer` and `snapshotLastUpdatedLabel` (both already accept an optional `now` in `snapshot-rows.ts`)
+
+For **Publishing** rows, prefer `startedAt` + `liveNow` over `publishingForSeconds` from the last poll. Do not add a 1s poll to `gestaltd`.
+
+---
+
+## Implementation
+
+### `gestalt-providers`
+
+- `APP_ADMIN_POLL_INTERVAL_MS = 3_000` in `polling.ts`; wire through `useAppAdminRegistryQuery` (`refetchInterval`)
+- `useLiveNow` — `hooks/use-live-now.ts`
+- `app-admin-snapshots-table.tsx` — pass `liveNow` into duration formatters
+- `snapshot-rows.ts` — pending duration from `startedAt` + `liveNow`
+- `e2e/app-admin-mock.spec.ts` — pending visibility timeout **15s → 6s**
+
+### Docs (on ship)
+
+- [pending-publish.md](./pending-publish.md) — polling bullets (**3s** bootstrap and active)
+- [admin.md](./admin.md) — refresh-until-terminal wording
+- [changelog.md](../project/changelog.md) — step `20`
+- [tests.md](../project/tests.md) — UI polling tests
 
 ---
 
 ## Tests
 
-### UI unit
+Run app-admin E2E from `gestalt-providers/app/default`:
 
-| Test | Asserts |
+```bash
+cd gestalt-providers/app/default
+npm run test:e2e -- e2e/app-admin-mock.spec.ts
+```
+
+| Area | Asserts |
 | --- | --- |
-| `snapshotStatusTimer` with advancing `now` | `for 59s` → `for 1m` → `for 1m 1s` without new API data (add when app-default has a unit test runner) |
-
-### E2E (`app-admin-mock.spec.ts`)
-
-| Test | Asserts |
-| --- | --- |
-| `polls for pending publish without manual refresh` | Pending row within **6s** |
-| `publishing timer ticks between polls` | Optional: frozen pending `startedAt`, label advances over 2s |
+| `app-admin-mock.spec.ts` | **Publishing** row within **6s** without manual refresh |
+| `snapshot-rows.ts` | `for 59s` → `for 1m` → `for 1m 1s` with advancing `now` (add when app-default has a unit test runner) |
+| `app-admin-mock.spec.ts` (optional) | frozen pending `startedAt`; duration label advances over 2s between registry polls |
 
 ---
 
-## Future Work (out of scope)
+## Future Work
 
-- Lightweight `GET …/admin/registry/status` to reduce GCS reads per poll
-- Short TTL registry cache in gestaltd
-- SSE push on `pending set` / rollout transitions
+- Lightweight `GET /api/v1/apps/{app}/admin/registry/status` to reduce GCS reads per poll
+- Short TTL registry cache in `gestaltd`
+- SSE push on `pending set` or rollout transitions
 - Embedded `/admin/registry` adaptive polling (align with [admin.md](./admin.md#apps-list-adminregistry))
 
 ---
 
-## Related Docs
+## Appendix
+
+### Related Changelogs
 
 <pre>
-├── <a href="../project/changelog.md">changelog.md</a> — step 20 (on ship)
+├── <a href="../project/changelog.md#changelog-16">16 — Pending and Failed Publish Visibility</a>
+└── <a href="../project/changelog.md">changelog.md</a> — step 20 (on ship)
+</pre>
+
+### Related Docs
+
+<pre>
+├── <a href="../readme.md">readme.md</a> — registry architecture and future work
+├── <a href="../project/changelog.md">changelog.md</a> — implementation milestones and pull requests
 ├── <a href="./pending-publish.md">pending-publish.md</a> — publish catalogs and current 12s polling
-├── <a href="./admin.md">admin.md</a> — app admin UI wireframes
-├── <a href="./lifecycle.md">lifecycle.md</a> — app-admin HTTP APIs
+├── <a href="./admin.md">admin.md</a> — app admin UI capabilities
+├── <a href="./lifecycle.md">lifecycle.md</a> — app-admin HTTP API
 └── <a href="../project/tests.md">tests.md</a> — test index (extend on ship)
 </pre>

--- a/plans/app_registry/operations/responsive-app-admin.md
+++ b/plans/app_registry/operations/responsive-app-admin.md
@@ -1,19 +1,19 @@
 # Responsive App Admin Polling
 
-Plan for changelog step **20**. Improves `/apps/{app}/admin` responsiveness during publish and rollout without changing GCS write paths or install behavior.
+Plan for changelog step **20**. Improves `/apps/{app}/admin` responsiveness during publish and rollout without changing GCS write paths, install behavior, or the app-admin API.
 
 **Status:** planned (not shipped)
 
 ## Problem
 
-Today the app admin UI polls `GET /api/v1/apps/{app}/admin/registry` every **12 seconds** while publish or rollout is active. Each request makes gestaltd fetch four GCS documents (`index.json`, `pending.json`, `failed.json`, `retention.json`) plus IndexedDB reads for fleet state.
+Today the app admin UI polls `GET /api/v1/apps/{app}/admin/registry` every **12 seconds** while publish or rollout is active.
 
 Two UX gaps follow:
 
-1. **Slow publish visibility** — a CI-recorded pending row can take up to ~12s to appear after page load, and publish completion can take another ~12s to flip from **Publishing** to **Available**.
-2. **Frozen duration labels** — `Publishing · for 4m` only updates when the next poll returns. `publishingForSeconds` is computed server-side at request time, so the label jumps in 12-second steps even though `startedAt` is already on the row.
+1. **Slow updates** — a pending row or publish completion can take up to ~12s to appear or flip status.
+2. **Frozen duration labels** — `Publishing · for 4m` only updates on poll. `publishingForSeconds` is computed server-side at request time, so the label jumps in 12-second steps even though `startedAt` is already on the row.
 
-Scope is `/apps/{app}/admin` only. The embedded fleet `/admin/registry` UI is out of scope for this milestone unless we later reuse the same polling helpers.
+Scope is `/apps/{app}/admin` only. The embedded fleet `/admin` registry UI is out of scope unless we later reuse the same polling helpers.
 
 ## Goals
 
@@ -22,10 +22,10 @@ Scope is `/apps/{app}/admin` only. The embedded fleet `/admin/registry` UI is ou
 | Pending row appears after CI `pending set` | ≤ **3s** after page load (p95) |
 | Publish completion reflected in snapshots table | ≤ **3s** after `pending clear` + `index.json` update |
 | Publish-duration label | Updates every **1s** locally while a row is **Publishing** |
-| GCS reads per active poll | **1–2** objects instead of **4** |
 
 ## Non-Goals
 
+- New app-admin API routes (keep `GET …/admin/registry` for all polls)
 - Push notifications (SSE, WebSocket, GCS Pub/Sub)
 - Server-side caching of registry documents
 - Faster catalog poller (replica convergence remains ~1 minute)
@@ -36,249 +36,102 @@ Scope is `/apps/{app}/admin` only. The embedded fleet `/admin/registry` UI is ou
 
 ## Design
 
-### 1. Lightweight status endpoint
-
-Add a read-only app-admin route that returns only the mutable publish catalogs and fleet control state gestaltd already derives for the full registry response.
+All polls use the existing endpoint:
 
 ```
-GET /api/v1/apps/{app}/admin/registry/status
+GET /api/v1/apps/{app}/admin/registry
 ```
 
-**Auth:** same middleware as `GET …/admin/registry` (`app` plugin route + `admin` on `app/{app}`).
+Separate **data freshness** (poll cadence) from **display freshness** (local 1s clock for duration labels).
 
-**GCS fetches:**
+### Poll mode
 
-| Document | Fetch |
-| --- | --- |
-| `pending.json` | yes |
-| `failed.json` | yes |
-| `index.json` | no |
-| `retention.json` | no |
-
-**IndexedDB reads:**
-
-| Store | Fields |
-| --- | --- |
-| `app_version_change_requests` | `desiredVersion` (via `LatestKnownVersion`) |
-| `app_rollouts` | active rollout `version` + `state` |
-| — | `selectionDisabled` / `disabledReason` (same rules as full handler) |
-
-**Response shape:**
-
-```json
-{
-  "pendingVersions": [ /* same row shape as full registry */ ],
-  "failedVersions": [ /* same row shape as full registry */ ],
-  "desiredVersion": "0.0.0-snapshot.gabc123",
-  "rollout": { "version": "…", "state": "enrolling" },
-  "selectionDisabled": false,
-  "disabledReason": ""
-}
-```
-
-Reuse the existing `appAdminPendingVersion` / `appAdminFailedVersion` structs and admin-catalog merge helpers from `handlers_app_admin_registry.go`. Do not duplicate merge precedence logic in the UI.
-
-### UI lifecycle
-
-The page holds one **registry snapshot**. The server returns facts; the UI derives polling mode and escalation — there is no `pollingMode` on the app.
-
-| Layer | Endpoint | When |
-| --- | --- | --- |
-| **Full** | `GET …/admin/registry` | Page load, deploy click, **escalation** |
-| **Status** | `GET …/admin/registry/status` | **Active** poll mode (3s) |
-| **Local clock** | — | Pending rows only (1s; uses `startedAt`) |
-
-#### Poll mode
-
-Per open tab only — closing the tab stops all polling. There is no server-side idle state.
+Per open tab only — closing the tab stops all polling. There is no server-side idle state. The UI derives mode from the latest registry response plus one local value (`landingPollUntilMs`, 5 minutes after page load).
 
 | What you see | Mode | Background refresh |
 | --- | --- | --- |
-| Page just opened; waiting to see if a publish starts | **Landing** | Full snapshot every **12s** (first 5 minutes) |
-| A publish, rollout, or deploy lock is in progress | **Active** | Lightweight status every **3s**; **Publishing · for …** ticks every **1s** locally |
+| Page just opened; waiting to see if a publish starts | **Landing** | `GET …/admin/registry` every **12s** (first 5 minutes) |
+| A publish, rollout, or deploy lock is in progress | **Active** | `GET …/admin/registry` every **3s** |
 | Quiet page — nothing moving, been open > 5 minutes | **Quiet** | None — table is static until you refresh or click Deploy |
 | Tab closed | — | Nothing runs |
 
 **Landing** ends after 5 minutes or as soon as an active signal appears (whichever comes first).
 
-**Active signals** (from the API — not a mode field on the app):
+**Active signals** (from the registry response — not a mode field on the app):
 
 - A row is **Publishing** (`pendingVersions` non-empty)
 - Rollout banner shows **Enrolling** or **Restarting**
 - Deploy buttons are disabled (`selectionDisabled`)
 
-#### Escalation
+Implement `computePollMode(registry, landingPollUntilMs)` → `landing` | `active` | `quiet` in `gestalt-providers/app/default/src/features/registry/polling.ts`.
 
-**Escalation** is not a poll mode. It is a one-time **full** fetch during **active** status polling when the status response changes in a way status alone cannot reflect in the table (published rows, deploy buttons, **Deployed** badge).
+Constants: `POLL_INTERVAL_ACTIVE_MS = 3_000`, `POLL_INTERVAL_LANDING_MS = 12_000`. Keep `APP_ADMIN_BOOTSTRAP_POLL_MS` as the landing-window duration (internal constant name).
 
-Compare the new status response to the previous one. Escalate if any of:
+Replace the chained `setTimeout` in `AppAdminPageClient.tsx` with `setInterval` (or React Query `refetchInterval`) keyed on poll mode. Pause polling when `document.visibilityState === "hidden"`; catch up once when visible again.
 
-| Diff | Example |
-| --- | --- |
-| Pending version removed | Publish completed |
-| New failed version | Workflow failed or stale prune |
-| Rollout became terminal | `enrolling`/`restarting` → `complete`/`failed` |
-| `desiredVersion` changed | Deploy landed |
+### Continuous duration labels (local clock)
 
-After escalation, recompute poll mode from the updated snapshot.
-
-### 2. Polling implementation
-
-Constants: `POLL_INTERVAL_ACTIVE_MS = 3_000`, `POLL_INTERVAL_LANDING_MS = 12_000` (rename from `POLL_INTERVAL_IDLE_MS`).
-
-Implement `computePollMode` (`landing` | `active` | `quiet`) and `shouldEscalateToFullRegistry` in `gestalt-providers/app/default/src/features/registry/polling.ts`. Keep `APP_ADMIN_BOOTSTRAP_POLL_MS` as the landing-window duration (internal name; user-facing docs say **landing**).
-
-Pause polling when `document.visibilityState === "hidden"`; catch up once when visible again.
-
-### 3. Continuous duration labels (local clock)
-
-Separate **data freshness** (3s / 12s polls) from **display freshness** (1s local tick).
-
-**Principle:** server fields name *when* something started; the UI computes *how long ago* from `startedAt` + client `now`. Stop sending `publishingForSeconds` on status responses once the UI owns the live clock (keep on full registry for backward compatibility during rollout).
+Server fields name *when* something started; the UI computes *how long* from `startedAt` + client `now`. Ignore `publishingForSeconds` for display once the live clock is wired (field may remain on the API).
 
 **Hook:** `useLiveNow({ enabled, intervalMs = 1_000 })`
 
-- `enabled` when the snapshots table has at least one `pending` row, or optionally when any `formatRegistryTimeAgo` label is shown and the page is visible.
-- Returns `now` (ms) updated every second via `setInterval`.
-- Clears interval when `enabled` is false or the tab is hidden.
-- Uses `document.visibilityState` to avoid background timers.
+- `enabled` when the snapshots table has at least one `pending` row.
+- Clears when no pending rows or tab is hidden.
 
-**Wire into existing formatters** — `snapshotStatusTimer` and `snapshotLastUpdatedLabel` already accept an optional `now` argument in `snapshot-rows.ts`. Pass `liveNow` from the table (or a parent provider) instead of defaulting to `Date.now()` only at render time without a tick.
-
-```ts
-// app-admin-snapshots-table.tsx
-const liveNow = useLiveNow({
-  enabled: rows.some((row) => row.kind === "pending"),
-});
-
-const statusTimer = snapshotStatusTimer(row, liveNow);
-const lastUpdated = snapshotLastUpdatedLabel(row, liveNow);
-```
-
-**Display rules:**
+Pass `liveNow` into `snapshotStatusTimer` and `snapshotLastUpdatedLabel` in `snapshot-rows.ts` (both already accept an optional `now`).
 
 | Row | Label | Source |
 | --- | --- | --- |
 | **Publishing** | `for 4m 12s` | `durationSecondsBetween(pending.startedAt, liveNow)` |
-| **Available** (published) | `Published in 4m 32s` | static (`publishDurationSeconds` or `publishStartedAt` → `publishedAt`) |
+| **Available** (published) | `Published in 4m 32s` | static |
 | **Failed** | `Failed after 35m` | static |
-| **Last update** (pending) | `4 minutes ago` | `formatRegistryTimeAgo(pending.updatedAt, liveNow)` — ticks during publish |
-
-Published and failed duration sublabels stay static; only in-flight publish labels and pending last-update relatives need the live clock.
+| **Last update** (pending) | `4 minutes ago` | `formatRegistryTimeAgo(pending.updatedAt, liveNow)` |
 
 **Do not** add a 1s poll to gestaltd. The continuous look is entirely client-side.
 
 ---
 
-## API Summary
-
-| Route | GCS | IndexedDB | Purpose |
-| --- | --- | --- | --- |
-| `GET …/admin/registry` | index, pending, failed, retention | desired, rollout | Full snapshots + deploy actions |
-| `GET …/admin/registry/status` | pending, failed | desired, rollout, selection | Active polling |
-| `GET …/admin/registry/history` | index, retention | change requests | Unchanged (lazy tab load) |
-| `POST …/admin/registry/version` | index (validation) | write | Unchanged |
-
-Document the status route in [lifecycle.md](./lifecycle.md#app-admin-version-selection) alongside the existing app-admin registry handlers.
-
----
-
-## Client helpers
-
-**`mergeAppAdminRegistryStatus`** — apply a status response onto the current full snapshot (pending, failed, rollout, selection fields only). Run `shouldEscalateToFullRegistry` before merge; on escalation, fetch full instead.
-
-```ts
-function mergeAppAdminRegistryStatus(
-  current: AppAdminRegistryResponse,
-  status: AppAdminRegistryStatusResponse,
-): AppAdminRegistryResponse {
-  return {
-    ...current,
-    pendingVersions: status.pendingVersions,
-    failedVersions: status.failedVersions,
-    desiredVersion: status.desiredVersion,
-    rollout: status.rollout,
-    selectionDisabled: status.selectionDisabled,
-    disabledReason: status.disabledReason,
-  };
-}
-```
-
----
-
 ## Implementation Checklist
-
-### gestalt
-
-- [ ] `GET /api/v1/apps/{app}/admin/registry/status` handler in `handlers_app_admin_registry.go`
-- [ ] Mount route in `mountAppAdminRegistryRoutes`
-- [ ] Unit tests: empty pending, pending rows with `publishingForSeconds`, failed merge precedence, rollout + `selectionDisabled` flags, 403/404 parity with full handler
-- [ ] Lifecycle doc: request/response shapes and GCS read set
 
 ### gestalt-providers
 
-- [ ] `getAppAdminRegistryStatus` in `lib/api.ts` + `AppAdminRegistryStatusResponse` type
-- [ ] `computePollMode`, `shouldEscalateToFullRegistry`, `mergeAppAdminRegistryStatus` in `polling.ts`
+- [ ] `computePollMode` in `polling.ts`
 - [ ] `useLiveNow` hook (e.g. `hooks/use-live-now.ts`)
-- [ ] Refactor `AppAdminPageClient.tsx`: interval polling, status/full selection, escalation, visibility pause
+- [ ] Refactor `AppAdminPageClient.tsx`: interval polling by mode, visibility pause
 - [ ] Pass `liveNow` into `AppAdminSnapshotsTable` → `snapshotStatusTimer` / `snapshotLastUpdatedLabel`
-- [ ] Update `e2e/app-admin-mock.spec.ts`: pending visibility timeout **15s → 5s**; add live-clock unit test for `snapshotStatusTimer`
+- [ ] Update `e2e/app-admin-mock.spec.ts`: pending visibility timeout **15s → 5s**; live-clock unit test for `snapshotStatusTimer`
 
 ### docs (on ship)
 
-- [ ] [pending-publish.md](./pending-publish.md) — polling section
-- [ ] [admin.md](./admin.md) — app admin capabilities / timing
+- [ ] [pending-publish.md](./pending-publish.md) — polling section (3s active / 12s landing)
+- [ ] [admin.md](./admin.md) — app admin timing
 - [ ] [changelog.md](../project/changelog.md) — step `20`
-- [ ] [tests.md](../project/tests.md) — status endpoint + UI tests
+- [ ] [tests.md](../project/tests.md) — UI polling tests
 
 ---
 
 ## Tests
-
-### Server (`handlers_app_admin_registry_test.go`)
-
-| Test | Asserts |
-| --- | --- |
-| `TestGetAppAdminRegistryStatus/pending_only` | Returns pending rows; does not call `FetchAppIndex` / `FetchRetentionIndex` (mock reader records fetch paths) |
-| `TestGetAppAdminRegistryStatus/merge_precedence` | Published version in index suppresses pending/failed of same version when handler is tested with fixture that has both |
-| `TestGetAppAdminRegistryStatus/rollout_and_selection` | IndexedDB rollout and `selectionDisabled` match full handler |
-| `TestGetAppAdminRegistryStatus/forbidden` | **403** without registry metadata leak |
 
 ### UI unit
 
 | Test | Asserts |
 | --- | --- |
 | `computePollMode` | `active` with pending/rollout; `landing` within 5 min only; `quiet` otherwise |
-| `shouldEscalateToFullRegistry` | pending cleared, new failed, terminal rollout, desired version change |
 | `snapshotStatusTimer` with advancing `now` | `for 59s` → `for 1m` → `for 1m 1s` without new API data |
 
 ### E2E (`app-admin-mock.spec.ts`)
 
 | Test | Asserts |
 | --- | --- |
-| `polls status endpoint during publish` | Route mock distinguishes `…/registry/status` from full `…/registry`; pending row within **5s** |
-| `escalates to full registry when publish completes` | After pending cleared in status mock, full endpoint called and **Available** row appears |
-| `publishing timer ticks between polls` | With frozen API, label changes over 2s (unit-level Playwright or component test) |
-
----
-
-## Rollout / Safety
-
-| Invariant | Preserved how |
-| --- | --- |
-| Pending/failed not installable | Install handlers unchanged |
-| Published > pending > failed | Same server-side merge on status endpoint |
-| No GCS writes from `gestaltd serve` | Status is read-only |
-| Failed rows on first load | Initial full fetch still includes `failedVersions`; status polls do not start solely for failed |
-
-Deploy gestalt (new route) before or with gestalt-providers (UI). Old UI against new gestalt: works (ignores unknown route). New UI against old gestalt: status calls return **404** — ship together or gate UI on route probe.
+| `polls registry during publish` | Pending row within **5s** without manual refresh |
+| `publishing timer ticks between polls` | With frozen API, label changes over 2s |
 
 ---
 
 ## Future Work (out of scope)
 
-- IndexedDB-only status variant during rollout (zero GCS) when no pending/failed catalogs are relevant
-- Short TTL registry cache in gestaltd to allow sub-second polling without GCS amplification
+- Lightweight `GET …/admin/registry/status` to reduce GCS reads per poll
+- Short TTL registry cache in gestaltd
 - SSE push on `pending set` / rollout transitions
 - Embedded `/admin/registry` adaptive polling (align with [admin.md](./admin.md#apps-list-adminregistry))
 

--- a/plans/app_registry/operations/responsive-app-admin.md
+++ b/plans/app_registry/operations/responsive-app-admin.md
@@ -67,9 +67,9 @@ Whenever the UI is polling (landing or active), use the same interval — **3s**
 
 Implement `computePollMode(registry, landingPollUntilMs)` → `landing` | `active` | `quiet` in `gestalt-providers/app/default/src/features/registry/polling.ts`.
 
-Constants: `POLL_INTERVAL_MS = 3_000` whenever `shouldPollAppAdminRegistry` is true. Keep `APP_ADMIN_BOOTSTRAP_POLL_MS` as the landing-window duration (internal constant name).
+Constants: `APP_ADMIN_POLL_INTERVAL_MS = 3_000` whenever `shouldPollAppAdminRegistry` is true. Keep `APP_ADMIN_BOOTSTRAP_POLL_MS` as the landing-window duration (internal constant name).
 
-Replace the chained `setTimeout` in `AppAdminPageClient.tsx` with `setInterval` (or React Query `refetchInterval`) keyed on poll mode. Pause polling when `document.visibilityState === "hidden"`; catch up once when visible again.
+Wire the interval through `useAppAdminRegistryQuery` (`refetchInterval` in `lib/queries/app-admin.ts`). Pause polling when `document.visibilityState === "hidden"`; catch up once when visible again.
 
 ### Continuous duration labels (local clock)
 
@@ -97,11 +97,11 @@ Pass `liveNow` into `snapshotStatusTimer` and `snapshotLastUpdatedLabel` in `sna
 
 ### gestalt-providers
 
-- [x] `APP_ADMIN_POLL_INTERVAL_MS = 3_000` in `polling.ts`; wired through `useAppAdminRegistryQuery` (`refetchInterval`)
-- [x] `useLiveNow` in `hooks/use-live-now.ts`
-- [x] Pass `liveNow` into `AppAdminSnapshotsTable` → `snapshotStatusTimer` / `snapshotLastUpdatedLabel`
-- [x] Pending duration from `startedAt` + `liveNow` (not stale `publishingForSeconds` from last poll)
-- [x] E2E: pending visibility timeout **15s → 6s**
+- [ ] `APP_ADMIN_POLL_INTERVAL_MS = 3_000` in `polling.ts`; wire through `useAppAdminRegistryQuery` (`refetchInterval`)
+- [ ] `useLiveNow` in `hooks/use-live-now.ts`
+- [ ] Pass `liveNow` into `AppAdminSnapshotsTable` → `snapshotStatusTimer` / `snapshotLastUpdatedLabel`
+- [ ] Pending duration from `startedAt` + `liveNow` (not stale `publishingForSeconds` from last poll)
+- [ ] E2E: pending visibility timeout **15s → 6s**
 - [ ] Pause registry polling when tab is hidden (optional follow-up)
 
 ### docs (on ship)
@@ -127,6 +127,7 @@ Pass `liveNow` into `snapshotStatusTimer` and `snapshotLastUpdatedLabel` in `sna
 | --- | --- |
 | `polls for pending publish without manual refresh` | Pending row within **6s** |
 | `publishing timer ticks between polls` | Optional: frozen pending `startedAt`, label advances over 2s |
+
 ---
 
 ## Future Work (out of scope)

--- a/plans/app_registry/operations/responsive-app-admin.md
+++ b/plans/app_registry/operations/responsive-app-admin.md
@@ -50,12 +50,14 @@ Per open tab only — closing the tab stops all polling. There is no server-side
 
 | What you see | Mode | Background refresh |
 | --- | --- | --- |
-| Page just opened; waiting to see if a publish starts | **Landing** | `GET …/admin/registry` every **12s** (first 5 minutes) |
+| Page just opened; waiting to see if a publish starts | **Landing** | `GET …/admin/registry` every **3s** (first 5 minutes) |
 | A publish, rollout, or deploy lock is in progress | **Active** | `GET …/admin/registry` every **3s** |
 | Quiet page — nothing moving, been open > 5 minutes | **Quiet** | None — table is static until you refresh or click Deploy |
 | Tab closed | — | Nothing runs |
 
-**Landing** ends after 5 minutes or as soon as an active signal appears (whichever comes first).
+**Landing** ends after 5 minutes unless an active signal keeps polling beyond that window.
+
+Whenever the UI is polling (landing or active), use the same interval — **3s**. Landing and active differ only in *why* polling continues past the first response, not in cadence.
 
 **Active signals** (from the registry response — not a mode field on the app):
 
@@ -65,7 +67,7 @@ Per open tab only — closing the tab stops all polling. There is no server-side
 
 Implement `computePollMode(registry, landingPollUntilMs)` → `landing` | `active` | `quiet` in `gestalt-providers/app/default/src/features/registry/polling.ts`.
 
-Constants: `POLL_INTERVAL_ACTIVE_MS = 3_000`, `POLL_INTERVAL_LANDING_MS = 12_000`. Keep `APP_ADMIN_BOOTSTRAP_POLL_MS` as the landing-window duration (internal constant name).
+Constants: `POLL_INTERVAL_MS = 3_000` whenever `shouldPollAppAdminRegistry` is true. Keep `APP_ADMIN_BOOTSTRAP_POLL_MS` as the landing-window duration (internal constant name).
 
 Replace the chained `setTimeout` in `AppAdminPageClient.tsx` with `setInterval` (or React Query `refetchInterval`) keyed on poll mode. Pause polling when `document.visibilityState === "hidden"`; catch up once when visible again.
 
@@ -103,7 +105,7 @@ Pass `liveNow` into `snapshotStatusTimer` and `snapshotLastUpdatedLabel` in `sna
 
 ### docs (on ship)
 
-- [ ] [pending-publish.md](./pending-publish.md) — polling section (3s active / 12s landing)
+- [ ] [pending-publish.md](./pending-publish.md) — polling section (3s while landing or active)
 - [ ] [admin.md](./admin.md) — app admin timing
 - [ ] [changelog.md](../project/changelog.md) — step `20`
 - [ ] [tests.md](../project/tests.md) — UI polling tests

--- a/plans/app_registry/operations/responsive-app-admin.md
+++ b/plans/app_registry/operations/responsive-app-admin.md
@@ -78,35 +78,61 @@ GET /api/v1/apps/{app}/admin/registry/status
 
 Reuse the existing `appAdminPendingVersion` / `appAdminFailedVersion` structs and admin-catalog merge helpers from `handlers_app_admin_registry.go`. Do not duplicate merge precedence logic in the UI.
 
-**When the UI uses each endpoint:**
+### UI lifecycle
 
-| Situation | Endpoint | Interval |
+The page keeps one **registry snapshot** in memory (published rows, pending, rollout, deploy buttons). Two APIs feed it:
+
+| API | Purpose | Poll cadence |
 | --- | --- | --- |
-| Initial page load | `GET …/admin/registry` (full) | once |
-| After deploy selection | full | once, then active polling |
-| Active publish (`pendingVersions.length > 0`) | status | **3s** |
-| Active rollout or `selectionDisabled` (no pending) | status | **3s** |
-| Bootstrap window (first 5 minutes, idle) | full | **12s** |
-| Otherwise | none | — |
+| **Full** `GET …/admin/registry` | Complete snapshot — what is published, deployable, and locked | On load, after deploy, and on **escalation** |
+| **Status** `GET …/admin/registry/status` | In-flight state only — pending, failed, rollout, desired version | Every **3s** while something is moving |
+| **Local clock** | Smooth duration labels (`Publishing · for 4m 12s`) | Every **1s** while a pending row exists (no server call) |
 
-**Escalation to full registry:**
-
-The status endpoint cannot produce published snapshot rows (deployment state, `deployableUntil`, publication metadata on completed versions). The UI must call the full registry endpoint when:
-
-1. A `pendingVersions` entry disappears (publish succeeded or was pruned to failed).
-2. A new `failedVersions` entry appears that was not in the previous status snapshot (stale prune or workflow failure during an active session).
-3. Rollout reaches a terminal state (`complete` or `failed`).
-4. `desiredVersion` changes (deploy succeeded).
-
-After escalation, resume status polling if the new state is still active; otherwise stop.
+**Mental model:** load the full snapshot once, watch cheaply with status while publish or rollout is active, and reload full when status tells you the table needs new published data or deploy rules.
 
 ```text
-status poll (3s)
-  ├── pending cleared     → full registry → merge published row
-  ├── new failed version  → full registry → merge failed row
-  ├── rollout terminal    → full registry → unlock Deploy
-  └── desiredVersion Δ    → full registry → refresh Deployed badge
+open page ──► full (once)
+                 │
+     ┌───────────┴────────────┐
+     │                        │
+  idle (<5 min)            active
+  full every 12s           status every 3s
+  (bootstrap watch)        + 1s local timer if publishing
+     │                        │
+     └───────────┬────────────┘
+                 │
+         escalation? ──yes──► full (once) ──► resume or stop polling
+                 │
+                no
+                 │
+            keep current mode
 ```
+
+| Phase | What happens |
+| --- | --- |
+| **Land** | Full fetch; render table; start 5-minute bootstrap watch |
+| **Bootstrap** (first 5 minutes, nothing active) | Full every **12s** — catches a CI pending row that appears after you opened the page |
+| **Active publish** (`pendingVersions.length > 0`) | Status every **3s**; local clock ticks **Publishing · for …** every **1s** |
+| **Active rollout** or deploy locked (`selectionDisabled`) | Status every **3s**; rollout banner and disabled Deploy buttons stay current |
+| **After deploy click** | Full once (fresh rollout + lock state), then status every **3s** |
+| **Idle** (no pending, no rollout, past bootstrap) | Stop polling |
+
+#### Escalation
+
+**Escalation** is a one-time full registry fetch triggered when a status poll detects that the snapshots table needs data the status endpoint does not carry — published version metadata, deployment state (`Available` / `Redeployable` / `Locked`), `deployableUntil`, and deploy-button eligibility.
+
+Status polling answers “is something still in flight?” Full registry answers “what does the table show now?”
+
+Escalate (call full, replace snapshot) when status reports any of:
+
+| Trigger | Why full is required |
+| --- | --- |
+| A `pendingVersions` entry disappears | Publish finished or was pruned — build the **Available** or remove the **Publishing** row |
+| A new `failedVersions` entry appears | Surface the **Failed** row with full provenance |
+| Rollout reaches `complete` or `failed` | Re-enable Deploy and refresh rollout badges |
+| `desiredVersion` changes | Update which row is **Deployed** |
+
+After escalation, return to the current polling mode: status every 3s if still active, bootstrap full every 12s if within the window, otherwise stop.
 
 ### 2. Adaptive polling intervals
 

--- a/plans/app_registry/operations/responsive-app-admin.md
+++ b/plans/app_registry/operations/responsive-app-admin.md
@@ -15,6 +15,8 @@ Scope is `/apps/{app}/admin` only — the embedded fleet `/admin` registry UI do
 
 Planned changelog step: **20**. See [changelog.md](../project/changelog.md).
 
+This file is **plan-only** for [gestalt#2949](https://github.com/valon-technologies/gestalt/pull/2949). On ship, fold its content into [pending-publish.md](./pending-publish.md), [admin.md](./admin.md), [changelog.md](../project/changelog.md), and [tests.md](../project/tests.md), then delete this file and remove the link from [readme.md](../readme.md).
+
 ## Goals
 
 - Poll `GET /api/v1/apps/{app}/admin/registry` every **3s** while the bootstrap window is open or publish/rollout is active (today: **12s**).
@@ -110,10 +112,10 @@ This plan PR ([gestalt#2949](https://github.com/valon-technologies/gestalt/pull/
 | --- | --- | --- | --- |
 | **1** | `gestalt-providers` | 3s registry polling | `polling.ts`, `lib/queries/app-admin.ts`, `e2e/app-admin-mock.spec.ts` |
 | **2** | `gestalt-providers` | Live **Publishing** duration labels | `hooks/use-live-now.ts`, `app-admin-snapshots-table.tsx`, `snapshot-rows.ts` |
-| **3** | `toolshed` | Deploy bump | `valon-tools/deploy/config.yaml` — `apps.home.source.git.ref` to the merged `gestalt-providers` commit |
-| **4** | `gestalt` | App registry docs for step **20** | `pending-publish.md`, `admin.md`, `changelog.md`, `tests.md`, `responsive-app-admin.md` (Shipped In) |
+| **3** | `gestalt` | App registry docs for step **20** | Fold this plan into `pending-publish.md`, `admin.md`, `changelog.md`, `tests.md`; delete `responsive-app-admin.md` |
+| **4** | `toolshed` | Deploy bump | `valon-tools/deploy/config.yaml` — `apps.home.source.git.ref` to the merged `gestalt-providers` commit |
 
-**Merge order:** **1** and **2** may land in either order or as one `gestalt-providers` PR if the diff stays small. Merge **3** after **1** and **2** so production serves the new default app UI. Merge **4** last so shipped docs match the deployed behavior.
+**Merge order:** **1** and **2** may land in either order or as one `gestalt-providers` PR if the diff stays small. Merge **3** after **1** and **2** so shipped docs match the implementation. Merge **4** after **1** and **2** so production serves the new default app UI (**3** and **4** may land in either order).
 
 No `gestaltd` changes — the app-admin API and GCS layout are unchanged.
 
@@ -131,19 +133,21 @@ No `gestaltd` changes — the app-admin API and GCS layout are unchanged.
 - `snapshot-rows.ts` — **Publishing** duration from `startedAt` + `liveNow` (not `publishingForSeconds`)
 - Optional E2E: duration label advances between frozen registry responses
 
-### PR 3 — `toolshed` (deploy bump)
+### PR 3 — `gestalt` (documentation)
+
+Fold this plan into the existing app registry docs, then remove this file:
+
+- [pending-publish.md](./pending-publish.md) — polling interval (**3s** bootstrap and active), `useLiveNow` / publish-duration behavior
+- [admin.md](./admin.md) — refresh-until-terminal wording on `/apps/{app}/admin`
+- [changelog.md](../project/changelog.md) — step **20** entry with links to PRs **1**–**4**
+- [tests.md](../project/tests.md) — UI polling and live-clock coverage
+- Delete [responsive-app-admin.md](./responsive-app-admin.md) and remove its link from [readme.md](../readme.md)
+
+### PR 4 — `toolshed` (deploy bump)
 
 - Bump `apps.home.source.git.ref` in `valon-tools/deploy/config.yaml` to the `gestalt-providers` commit that includes **1** and **2**
 - `apps.home` is the default `/apps` shell that serves `/apps/{app}/admin` for registry-only apps such as `g-issues`
 - No workflow or registry publish changes — UI-only deploy pin
-
-### PR 4 — `gestalt` (documentation)
-
-- [pending-publish.md](./pending-publish.md) — polling bullets (**3s** bootstrap and active)
-- [admin.md](./admin.md) — refresh-until-terminal wording
-- [changelog.md](../project/changelog.md) — step **20** entry with links to PRs **1**–**4**
-- [tests.md](../project/tests.md) — UI polling and live-clock coverage
-- [responsive-app-admin.md](./responsive-app-admin.md) — add **Shipped In**; remove planned-only wording
 
 Optional follow-up (not required for step **20**):
 
@@ -161,7 +165,7 @@ See [Implementation PRs](#implementation-prs) **1** and **2**.
 
 ### Docs (on ship)
 
-See [Implementation PRs](#implementation-prs) **4**.
+See [Implementation PRs](#implementation-prs) **3**.
 
 ---
 

--- a/plans/app_registry/operations/responsive-app-admin.md
+++ b/plans/app_registry/operations/responsive-app-admin.md
@@ -80,102 +80,52 @@ Reuse the existing `appAdminPendingVersion` / `appAdminFailedVersion` structs an
 
 ### UI lifecycle
 
-The page keeps one **registry snapshot** in memory (published rows, pending, rollout, deploy buttons). Two APIs feed it:
+The page holds one **registry snapshot**. The server returns facts; the UI derives polling mode and escalation — there is no `pollingMode` on the app.
 
-| API | Purpose | Poll cadence |
+| Layer | Endpoint | When |
 | --- | --- | --- |
-| **Full** `GET …/admin/registry` | Complete snapshot — what is published, deployable, and locked | On load, after deploy, and on **escalation** |
-| **Status** `GET …/admin/registry/status` | In-flight state only — pending, failed, rollout, desired version | Every **3s** while something is moving |
-| **Local clock** | Smooth duration labels (`Publishing · for 4m 12s`) | Every **1s** while a pending row exists (no server call) |
+| **Full** | `GET …/admin/registry` | Page load, deploy click, **escalation** |
+| **Status** | `GET …/admin/registry/status` | **Active** poll mode (3s) |
+| **Local clock** | — | Pending rows only (1s; uses `startedAt`) |
 
-**Mental model:** load the full snapshot once, watch cheaply with status while publish or rollout is active, and reload full when status tells you the table needs new published data or deploy rules.
+#### Poll mode
 
-```text
-open page ──► full (once)
-                 │
-     ┌───────────┴────────────┐
-     │                        │
-  idle (<5 min)            active
-  full every 12s           status every 3s
-  (bootstrap watch)        + 1s local timer if publishing
-     │                        │
-     └───────────┬────────────┘
-                 │
-         escalation? ──yes──► full (once) ──► resume or stop polling
-                 │
-                no
-                 │
-            keep current mode
-```
+Derived after every fetch from the snapshot plus one local value (`bootstrapPollUntilMs`, 5 minutes after page load):
 
-| Phase | What happens |
-| --- | --- |
-| **Land** | Full fetch; render table; start 5-minute bootstrap watch |
-| **Bootstrap** (first 5 minutes, nothing active) | Full every **12s** — catches a CI pending row that appears after you opened the page |
-| **Active publish** (`pendingVersions.length > 0`) | Status every **3s**; local clock ticks **Publishing · for …** every **1s** |
-| **Active rollout** or deploy locked (`selectionDisabled`) | Status every **3s**; rollout banner and disabled Deploy buttons stay current |
-| **After deploy click** | Full once (fresh rollout + lock state), then status every **3s** |
-| **Idle** (no pending, no rollout, past bootstrap) | Stop polling |
+| Mode | Condition | Poll |
+| --- | --- | --- |
+| **Stopped** | Past bootstrap and no active signals | none |
+| **Bootstrap** | Within bootstrap window, no active signals | full, 12s |
+| **Active** | Any active signal below | status, 3s |
+
+**Active signals** (from the API response, not a separate mode field):
+
+- `pendingVersions.length > 0`
+- `rollout.state` is `enrolling` or `restarting`
+- `selectionDisabled` is `true` (server sets this when rollout is active)
 
 #### Escalation
 
-**Escalation** is a one-time full registry fetch triggered when a status poll detects that the snapshots table needs data the status endpoint does not carry — published version metadata, deployment state (`Available` / `Redeployable` / `Locked`), `deployableUntil`, and deploy-button eligibility.
+**Escalation** is not a poll mode. It is a one-time **full** fetch during **active** status polling when the status response changes in a way status alone cannot reflect in the table (published rows, deploy buttons, **Deployed** badge).
 
-Status polling answers “is something still in flight?” Full registry answers “what does the table show now?”
+Compare the new status response to the previous one. Escalate if any of:
 
-Escalate (call full, replace snapshot) when status reports any of:
-
-| Trigger | Why full is required |
+| Diff | Example |
 | --- | --- |
-| A `pendingVersions` entry disappears | Publish finished or was pruned — build the **Available** or remove the **Publishing** row |
-| A new `failedVersions` entry appears | Surface the **Failed** row with full provenance |
-| Rollout reaches `complete` or `failed` | Re-enable Deploy and refresh rollout badges |
-| `desiredVersion` changes | Update which row is **Deployed** |
+| Pending version removed | Publish completed |
+| New failed version | Workflow failed or stale prune |
+| Rollout became terminal | `enrolling`/`restarting` → `complete`/`failed` |
+| `desiredVersion` changed | Deploy landed |
 
-After escalation, return to the current polling mode: status every 3s if still active, bootstrap full every 12s if within the window, otherwise stop.
+After escalation, recompute poll mode from the updated snapshot.
 
-### 2. Adaptive polling intervals
+### 2. Polling implementation
 
-Replace the single `POLL_INTERVAL_MS = 12_000` with two constants:
+Constants: `POLL_INTERVAL_ACTIVE_MS = 3_000`, `POLL_INTERVAL_IDLE_MS = 12_000`.
 
-| Constant | Value | Used when |
-| --- | ---: | --- |
-| `POLL_INTERVAL_ACTIVE_MS` | `3_000` | `shouldPollAppAdminRegistry` is true **and** at least one active trigger is present (pending, rollout, or `selectionDisabled`) |
-| `POLL_INTERVAL_IDLE_MS` | `12_000` | bootstrap window only (no pending / rollout / selection lock) |
+Implement `computePollMode` and `shouldEscalateToFullRegistry` in `gestalt-providers/app/default/src/features/registry/polling.ts`. Replace the chained `setTimeout` in `AppAdminPageClient.tsx` with `setInterval` (or React Query `refetchInterval`) keyed on poll mode.
 
-Update `shouldPollAppAdminRegistry` in `gestalt-providers/app/default/src/features/registry/polling.ts`:
-
-```ts
-export function appAdminPollIntervalMs(
-  registry: AppAdminRegistryResponse,
-  bootstrapPollUntilMs: number,
-  now = Date.now(),
-): number | null {
-  if (!shouldPollAppAdminRegistry(registry, bootstrapPollUntilMs, now)) return null;
-  const active =
-    (registry.pendingVersions?.length ?? 0) > 0 ||
-    registry.selectionDisabled ||
-    (registry.rollout && isActiveRegistryRollout(registry.rollout.state));
-  return active ? POLL_INTERVAL_ACTIVE_MS : POLL_INTERVAL_IDLE_MS;
-}
-```
-
-**Polling implementation:** replace the chained `setTimeout` in `AppAdminPageClient.tsx` (effect re-schedules only after `registry` changes) with a single `setInterval` (or React Query `refetchInterval`) keyed on the computed interval. Clear the timer on unmount and when polling stops.
-
-**Status vs full during active poll:**
-
-```ts
-const endpoint =
-  (registry.pendingVersions?.length ?? 0) > 0 ||
-  registry.rollout ||
-  registry.selectionDisabled
-    ? getAppAdminRegistryStatus
-    : getAppAdminRegistry; // bootstrap-only path
-```
-
-During bootstrap with no active signals, keep fetching the full registry at 12s so a not-yet-visible pending row still resolves without requiring the operator to refresh.
-
-Pause polling while `document.visibilityState === "hidden"`; run one catch-up fetch when the tab becomes visible again.
+Pause polling when `document.visibilityState === "hidden"`; catch up once when visible again.
 
 ### 3. Continuous duration labels (local clock)
 
@@ -230,36 +180,9 @@ Document the status route in [lifecycle.md](./lifecycle.md#app-admin-version-sel
 
 ---
 
-## UI State Machine
+## Client helpers
 
-```text
-[load] ──full──► registry state
-                    │
-        ┌───────────┴───────────┐
-        │ shouldPoll?           │
-        └───────────┬───────────┘
-                    │ yes
-        ┌───────────▼───────────┐
-        │ pick interval         │
-        │  3s active / 12s boot │
-        └───────────┬───────────┘
-                    │
-        ┌───────────▼───────────┐
-        │ pick endpoint         │
-        │  status vs full       │
-        └───────────┬───────────┘
-                    │
-        ┌───────────▼───────────┐
-        │ merge or escalate     │
-        └───────────┬───────────┘
-                    │
-        ┌───────────▼───────────┐
-        │ live clock (1s)       │
-        │ if pending rows       │
-        └───────────────────────┘
-```
-
-**Merge helper** (`mergeAppAdminRegistryStatus`):
+**`mergeAppAdminRegistryStatus`** — apply a status response onto the current full snapshot (pending, failed, rollout, selection fields only). Run `shouldEscalateToFullRegistry` before merge; on escalation, fetch full instead.
 
 ```ts
 function mergeAppAdminRegistryStatus(
@@ -278,8 +201,6 @@ function mergeAppAdminRegistryStatus(
 }
 ```
 
-Compare previous and next status to detect escalation triggers before merging.
-
 ---
 
 ## Implementation Checklist
@@ -294,7 +215,7 @@ Compare previous and next status to detect escalation triggers before merging.
 ### gestalt-providers
 
 - [ ] `getAppAdminRegistryStatus` in `lib/api.ts` + `AppAdminRegistryStatusResponse` type
-- [ ] `appAdminPollIntervalMs`, `mergeAppAdminRegistryStatus`, escalation detector in `polling.ts`
+- [ ] `computePollMode`, `shouldEscalateToFullRegistry`, `mergeAppAdminRegistryStatus` in `polling.ts`
 - [ ] `useLiveNow` hook (e.g. `hooks/use-live-now.ts`)
 - [ ] Refactor `AppAdminPageClient.tsx`: interval polling, status/full selection, escalation, visibility pause
 - [ ] Pass `liveNow` into `AppAdminSnapshotsTable` → `snapshotStatusTimer` / `snapshotLastUpdatedLabel`
@@ -324,7 +245,7 @@ Compare previous and next status to detect escalation triggers before merging.
 
 | Test | Asserts |
 | --- | --- |
-| `appAdminPollIntervalMs` | `3000` with pending; `12000` during bootstrap only; `null` when idle |
+| `computePollMode` | `active` with pending; `bootstrap` within 5 min only; `stopped` otherwise |
 | `shouldEscalateToFullRegistry` | pending cleared, new failed, terminal rollout, desired version change |
 | `snapshotStatusTimer` with advancing `now` | `for 59s` → `for 1m` → `for 1m 1s` without new API data |
 

--- a/plans/app_registry/operations/responsive-app-admin.md
+++ b/plans/app_registry/operations/responsive-app-admin.md
@@ -97,11 +97,12 @@ Pass `liveNow` into `snapshotStatusTimer` and `snapshotLastUpdatedLabel` in `sna
 
 ### gestalt-providers
 
-- [ ] `computePollMode` in `polling.ts`
-- [ ] `useLiveNow` hook (e.g. `hooks/use-live-now.ts`)
-- [ ] Refactor `AppAdminPageClient.tsx`: interval polling by mode, visibility pause
-- [ ] Pass `liveNow` into `AppAdminSnapshotsTable` → `snapshotStatusTimer` / `snapshotLastUpdatedLabel`
-- [ ] Update `e2e/app-admin-mock.spec.ts`: pending visibility timeout **15s → 5s**; live-clock unit test for `snapshotStatusTimer`
+- [x] `APP_ADMIN_POLL_INTERVAL_MS = 3_000` in `polling.ts`; wired through `useAppAdminRegistryQuery` (`refetchInterval`)
+- [x] `useLiveNow` in `hooks/use-live-now.ts`
+- [x] Pass `liveNow` into `AppAdminSnapshotsTable` → `snapshotStatusTimer` / `snapshotLastUpdatedLabel`
+- [x] Pending duration from `startedAt` + `liveNow` (not stale `publishingForSeconds` from last poll)
+- [x] E2E: pending visibility timeout **15s → 6s**
+- [ ] Pause registry polling when tab is hidden (optional follow-up)
 
 ### docs (on ship)
 
@@ -118,16 +119,14 @@ Pass `liveNow` into `snapshotStatusTimer` and `snapshotLastUpdatedLabel` in `sna
 
 | Test | Asserts |
 | --- | --- |
-| `computePollMode` | `active` with pending/rollout; `landing` within 5 min only; `quiet` otherwise |
-| `snapshotStatusTimer` with advancing `now` | `for 59s` → `for 1m` → `for 1m 1s` without new API data |
+| `snapshotStatusTimer` with advancing `now` | `for 59s` → `for 1m` → `for 1m 1s` without new API data (add when app-default has a unit test runner) |
 
 ### E2E (`app-admin-mock.spec.ts`)
 
 | Test | Asserts |
 | --- | --- |
-| `polls registry during publish` | Pending row within **5s** without manual refresh |
-| `publishing timer ticks between polls` | With frozen API, label changes over 2s |
-
+| `polls for pending publish without manual refresh` | Pending row within **6s** |
+| `publishing timer ticks between polls` | Optional: frozen pending `startedAt`, label advances over 2s |
 ---
 
 ## Future Work (out of scope)

--- a/plans/app_registry/readme.md
+++ b/plans/app_registry/readme.md
@@ -16,6 +16,7 @@ app_registry/
 │   ├── <a href="./operations/admin.md">admin.md</a>
 │   ├── <a href="./operations/lifecycle.md">lifecycle.md</a>
 │   ├── <a href="./operations/pending-publish.md">pending-publish.md</a>
+│   ├── <a href="./operations/responsive-app-admin.md">responsive-app-admin.md</a>
 │   └── <a href="./operations/retention.md">retention.md</a>
 └── project/
     ├── <a href="./project/changelog.md">changelog.md</a>


### PR DESCRIPTION
## Summary

Docs-only plan for app registry changelog step **20** — faster `/apps/{app}/admin` registry refresh and live **Publishing** duration labels. No `gestaltd` or API changes.

- Add [`operations/responsive-app-admin.md`](plans/app_registry/operations/responsive-app-admin.md) (plan-only; folded into other docs on ship)
- Link from [`plans/app_registry/readme.md`](plans/app_registry/readme.md)

## Implementation PRs (after this merges)

| # | Repo | Scope |
| --- | --- | --- |
| **1** | `gestalt-providers` | 3s registry polling (`polling.ts`, `lib/queries/app-admin.ts`, e2e) |
| **2** | `gestalt-providers` | Live **Publishing** duration labels (`useLiveNow`, snapshots table, `snapshot-rows.ts`) |
| **3** | `gestalt` | Fold plan into `pending-publish.md`, `admin.md`, `changelog.md`, `tests.md`; delete `responsive-app-admin.md` |
| **4** | `toolshed` | Bump `apps.home.source.git.ref` in `valon-tools/deploy/config.yaml` |

**1** and **2** may ship together or separately. **3** and **4** after **1**/**2** (either order).

Optional follow-up: pause polling when the browser tab is hidden.

## Test plan

- [ ] Review plan vocabulary and scope against existing app registry docs
- [ ] Confirm implementation PR split is workable
- [ ] Approve before opening implementation PRs