### PR TITLE
Force HTTP/1.1 ALPN in frpc WebSocket tunnel client

### DIFF
--- a/gestaltd/go.mod
+++ b/gestaltd/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/go-git/go-git/v5 v5.19.1
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/uuid v1.6.0
+	github.com/hashicorp/yamux v0.1.1
 	github.com/landlock-lsm/go-landlock v0.8.1
 	github.com/mark3labs/mcp-go v0.54.0
 	github.com/pb33f/libopenapi v0.36.4
@@ -58,7 +59,6 @@ require (
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
-	github.com/hashicorp/yamux v0.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect

--- a/gestaltd/internal/coredata/remote_registrations.go
+++ b/gestaltd/internal/coredata/remote_registrations.go
@@ -394,7 +394,11 @@ func (s *RemoteRegistrationService) ListByOwner(ctx context.Context, ownerSubjec
 
 	providerRecs, err := tx.ObjectStore(StoreRemoteProviders).Index("by_registration").GetAll(ctx, reg.ID)
 	if err != nil {
-		return nil, nil, fmt.Errorf("list remote registration by owner: %w", err)
+		if errors.Is(err, idb.ErrNotFound) {
+			providerRecs = nil
+		} else {
+			return nil, nil, fmt.Errorf("list remote registration by owner: %w", err)
+		}
 	}
 	providers := make([]*RemoteProvider, 0, len(providerRecs))
 	for _, rec := range providerRecs {
@@ -518,6 +522,9 @@ func removeRegistrationAndProviders(ctx context.Context, regStore, providerStore
 func deleteProvidersForRegistration(ctx context.Context, store idb.TransactionObjectStore, registrationID string) error {
 	recs, err := store.Index("by_registration").GetAll(ctx, registrationID)
 	if err != nil {
+		if errors.Is(err, idb.ErrNotFound) {
+			return nil
+		}
 		return err
 	}
 	for _, rec := range recs {

--- a/gestaltd/internal/tunnel/host.go
+++ b/gestaltd/internal/tunnel/host.go
@@ -56,7 +56,7 @@ func (c *wssConnector) Open() error {
 	cfg.MaxStreamWindowSize = 6 * 1024 * 1024
 	session, err := fmux.Client(conn, cfg)
 	if err != nil {
-		conn.Close()
+		_ = conn.Close()
 		return err
 	}
 	c.session = session
@@ -82,16 +82,20 @@ func (c *wssConnector) Close() error {
 }
 
 func (c *wssConnector) dial() (net.Conn, error) {
+	if err := c.ctx.Err(); err != nil {
+		return nil, fmt.Errorf("wss connector: %w", err)
+	}
 	host := c.cfg.ServerAddr
 	port := c.cfg.ServerPort
 	addr := net.JoinHostPort(host, fmt.Sprintf("%d", port))
 
-	rawConn, err := net.DialTimeout("tcp", addr, 10*time.Second)
+	d := net.Dialer{}
+	rawConn, err := d.DialContext(c.ctx, "tcp", addr)
 	if err != nil {
 		return nil, fmt.Errorf("wss connector: dial tcp: %w", err)
 	}
 
-	var conn net.Conn = rawConn
+	conn := rawConn
 	wsScheme := "ws"
 	if c.useTLS {
 		sn := c.cfg.Transport.TLS.ServerName
@@ -99,30 +103,35 @@ func (c *wssConnector) dial() (net.Conn, error) {
 			sn = host
 		}
 		tlsCfg := &tls.Config{
-			ServerName:         sn,
-			InsecureSkipVerify: true,
-			NextProtos:         []string{"http/1.1"},
+			ServerName: sn,
+			NextProtos: []string{"http/1.1"},
 		}
 		tlsConn := tls.Client(rawConn, tlsCfg)
 		if err := tlsConn.HandshakeContext(c.ctx); err != nil {
-			rawConn.Close()
+			_ = rawConn.Close()
 			return nil, fmt.Errorf("wss connector: tls handshake: %w", err)
 		}
 		conn = tlsConn
 		wsScheme = "wss"
 	}
 
-	wsURL := wsScheme + "://" + host + "/~!frp"
-	origin := "http://" + host
+	hostport := net.JoinHostPort(host, fmt.Sprintf("%d", port))
+	wsURL := wsScheme + "://" + hostport + "/~!frp"
+	origin := "http://" + hostport
 	wsCfg, err := websocket.NewConfig(wsURL, origin)
 	if err != nil {
-		conn.Close()
+		_ = conn.Close()
 		return nil, fmt.Errorf("wss connector: websocket config: %w", err)
+	}
+
+	if err := c.ctx.Err(); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("wss connector: %w", err)
 	}
 
 	wsConn, err := websocket.NewClient(wsCfg, conn)
 	if err != nil {
-		conn.Close()
+		_ = conn.Close()
 		return nil, fmt.Errorf("wss connector: websocket handshake: %w", err)
 	}
 	wsConn.PayloadType = websocket.BinaryFrame

--- a/gestaltd/internal/tunnel/host.go
+++ b/gestaltd/internal/tunnel/host.go
@@ -15,6 +15,8 @@ import (
 	frpproxy "github.com/fatedier/frp/client/proxy"
 	frpsource "github.com/fatedier/frp/pkg/config/source"
 	v1 "github.com/fatedier/frp/pkg/config/v1"
+	fmux "github.com/hashicorp/yamux"
+	"golang.org/x/net/websocket"
 )
 
 // HostConfig runs the local side: an embedded frpc proxying the tunnel host to
@@ -34,6 +36,97 @@ type Host struct {
 	inner      net.Listener
 	closed     bool
 	mu         sync.Mutex
+}
+
+type wssConnector struct {
+	ctx     context.Context
+	cfg     *v1.ClientCommonConfig
+	useTLS  bool
+	session *fmux.Session
+	conn    net.Conn
+}
+
+func (c *wssConnector) Open() error {
+	conn, err := c.dial()
+	if err != nil {
+		return err
+	}
+	cfg := fmux.DefaultConfig()
+	cfg.KeepAliveInterval = 30 * time.Second
+	cfg.MaxStreamWindowSize = 6 * 1024 * 1024
+	session, err := fmux.Client(conn, cfg)
+	if err != nil {
+		conn.Close()
+		return err
+	}
+	c.session = session
+	c.conn = conn
+	return nil
+}
+
+func (c *wssConnector) Connect() (net.Conn, error) {
+	if c.session != nil {
+		return c.session.OpenStream()
+	}
+	return c.dial()
+}
+
+func (c *wssConnector) Close() error {
+	if c.session != nil {
+		_ = c.session.Close()
+	}
+	if c.conn != nil {
+		_ = c.conn.Close()
+	}
+	return nil
+}
+
+func (c *wssConnector) dial() (net.Conn, error) {
+	host := c.cfg.ServerAddr
+	port := c.cfg.ServerPort
+	addr := net.JoinHostPort(host, fmt.Sprintf("%d", port))
+
+	rawConn, err := net.DialTimeout("tcp", addr, 10*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("wss connector: dial tcp: %w", err)
+	}
+
+	var conn net.Conn = rawConn
+	wsScheme := "ws"
+	if c.useTLS {
+		sn := c.cfg.Transport.TLS.ServerName
+		if sn == "" {
+			sn = host
+		}
+		tlsCfg := &tls.Config{
+			ServerName:         sn,
+			InsecureSkipVerify: true,
+			NextProtos:         []string{"http/1.1"},
+		}
+		tlsConn := tls.Client(rawConn, tlsCfg)
+		if err := tlsConn.HandshakeContext(c.ctx); err != nil {
+			rawConn.Close()
+			return nil, fmt.Errorf("wss connector: tls handshake: %w", err)
+		}
+		conn = tlsConn
+		wsScheme = "wss"
+	}
+
+	wsURL := wsScheme + "://" + host + "/~!frp"
+	origin := "http://" + host
+	wsCfg, err := websocket.NewConfig(wsURL, origin)
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("wss connector: websocket config: %w", err)
+	}
+
+	wsConn, err := websocket.NewClient(wsCfg, conn)
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("wss connector: websocket handshake: %w", err)
+	}
+	wsConn.PayloadType = websocket.BinaryFrame
+	return wsConn, nil
 }
 
 // StartHost starts the embedded frpc and the inner mTLS listener. The frpc
@@ -85,6 +178,7 @@ func StartHost(ctx context.Context, cfg HostConfig) (*Host, error) {
 	common := &v1.ClientCommonConfig{}
 	common.ServerAddr = hostFromURL(cfg.ServerURL)
 	common.ServerPort = portFromURL(cfg.ServerURL)
+	useTLS := isWssURL(cfg.ServerURL)
 	common.Transport.TCPMux = ptr(true)
 	if isWebsocketURL(cfg.ServerURL) {
 		common.Transport.Protocol = "websocket"
@@ -99,6 +193,9 @@ func StartHost(ctx context.Context, cfg HostConfig) (*Host, error) {
 	service, err := frpcclient.NewService(frpcclient.ServiceOptions{
 		Common:                 common,
 		ConfigSourceAggregator: frpsource.NewAggregator(configSource),
+		ConnectorCreator: func(ctx context.Context, cfg *v1.ClientCommonConfig) frpcclient.Connector {
+			return &wssConnector{ctx: ctx, cfg: cfg, useTLS: useTLS}
+		},
 	})
 	if err != nil {
 		_ = innerListener.Close()
@@ -171,6 +268,10 @@ func PeerIdentity(conn net.Conn) (string, bool) {
 func ptr[T any](v T) *T { return &v }
 
 // isWebsocketURL reports whether the URL uses ws:// or wss://.
+func isWssURL(rawURL string) bool {
+	return strings.HasPrefix(rawURL, "wss://")
+}
+
 func isWebsocketURL(rawURL string) bool {
 	return strings.HasPrefix(rawURL, "ws://") || strings.HasPrefix(rawURL, "wss://")
 }

--- a/gestaltd/internal/tunnel/server.go
+++ b/gestaltd/internal/tunnel/server.go
@@ -76,18 +76,21 @@ func StartServer(ctx context.Context) (*Server, error) {
 // as the public API.
 func (s *Server) HTTPHandler() http.Handler {
 	mux := http.NewServeMux()
-	mux.Handle(FrpsWebsocketPath, websocket.Handler(func(c *websocket.Conn) {
-		c.PayloadType = websocket.BinaryFrame
-		backend, err := net.Dial("tcp", s.controlAddr)
-		if err != nil {
-			return
-		}
-		defer func() { _ = backend.Close() }()
-		done := make(chan struct{}, 2)
-		go func() { _, _ = io.Copy(backend, c); done <- struct{}{} }()
-		go func() { _, _ = io.Copy(c, backend); done <- struct{}{} }()
-		<-done
-	}))
+	mux.Handle(FrpsWebsocketPath, websocket.Server{
+		Handler: func(c *websocket.Conn) {
+			c.PayloadType = websocket.BinaryFrame
+			backend, err := net.Dial("tcp", s.controlAddr)
+			if err != nil {
+				return
+			}
+			defer func() { _ = backend.Close() }()
+			done := make(chan struct{}, 2)
+			go func() { _, _ = io.Copy(backend, c); done <- struct{}{} }()
+			go func() { _, _ = io.Copy(c, backend); done <- struct{}{} }()
+			<-done
+		},
+		Handshake: func(_ *websocket.Config, _ *http.Request) error { return nil },
+	})
 	return mux
 }
 

--- a/gestaltd/internal/tunnel/server.go
+++ b/gestaltd/internal/tunnel/server.go
@@ -76,21 +76,18 @@ func StartServer(ctx context.Context) (*Server, error) {
 // as the public API.
 func (s *Server) HTTPHandler() http.Handler {
 	mux := http.NewServeMux()
-	mux.Handle(FrpsWebsocketPath, websocket.Server{
-		Handler: func(c *websocket.Conn) {
-			c.PayloadType = websocket.BinaryFrame
-			backend, err := net.Dial("tcp", s.controlAddr)
-			if err != nil {
-				return
-			}
-			defer func() { _ = backend.Close() }()
-			done := make(chan struct{}, 2)
-			go func() { _, _ = io.Copy(backend, c); done <- struct{}{} }()
-			go func() { _, _ = io.Copy(c, backend); done <- struct{}{} }()
-			<-done
-		},
-		Handshake: func(_ *websocket.Config, _ *http.Request) error { return nil },
-	})
+	mux.Handle(FrpsWebsocketPath, websocket.Handler(func(c *websocket.Conn) {
+		c.PayloadType = websocket.BinaryFrame
+		backend, err := net.Dial("tcp", s.controlAddr)
+		if err != nil {
+			return
+		}
+		defer func() { _ = backend.Close() }()
+		done := make(chan struct{}, 2)
+		go func() { _, _ = io.Copy(backend, c); done <- struct{}{} }()
+		go func() { _, _ = io.Copy(c, backend); done <- struct{}{} }()
+		<-done
+	}))
 	return mux
 }
 


### PR DESCRIPTION
## Problem

`gestaltd serve --remote` fails with `connect to server error: bad status` when connecting to the upstream frps through Cloudflare. Three issues:

1. **WebSocket Origin check (server-side, #2948 — merged)**: frps used `websocket.Handler` which rejects requests without an `Origin` header. frpc doesn't send one, so the upgrade fails with 403.
2. **HTTP/2 ALPN negotiation (client-side, this PR)**: frp creates its TLS config internally without setting `NextProtos`, so Cloudflare negotiates HTTP/2 via ALPN. WebSocket upgrades require HTTP/1.1, so the upgrade fails.
3. **IndexedDB GetAll returning ErrNotFound (server-side, this PR)**: The relational IndexedDB backend returns `ErrNotFound` when an index scan matches no records, but `deleteProvidersForRegistration` and `GetByOwnerSubject` expect an empty slice. This blocks `CreateRemote` on first registration.

## Fix

1. **Custom Connector** for the frpc service that dials TLS with `NextProtos: ["http/1.1"]` before performing the WebSocket handshake. This forces HTTP/1.1 negotiation with Cloudflare's edge. Handles both `ws://` (plain, for tests) and `wss://` (TLS, for production) URLs. Uses standard cert verification (system root CAs), not `InsecureSkipVerify`.

2. **Handle `ErrNotFound` from index `GetAll`** in `deleteProvidersForRegistration` and `GetByOwnerSubject` — treat as empty result per IndexedDB semantics.

## Review comments addressed

- **TLS verification**: Removed `InsecureSkipVerify: true`, using default cert verification with system root CAs.
- **IPv6 and port in WebSocket URL**: Using `net.JoinHostPort` for both the TCP dial and WebSocket URL/Origin, which brackets IPv6 and includes the port.
- **Server Origin check**: The no-op `Handshake` on the server side (PR #2948) is intentional — `/~!frp` is a tunnel transport endpoint, not a browser-facing WebSocket, and Cloudflare may alter headers.

## Testing

- `go test ./gestaltd/services/remotepublish/...` — all tests pass
- `go test ./gestaltd/internal/coredata/...` — all tests pass
- `go build ./gestaltd/internal/tunnel/... ./gestaltd/internal/coredata/...` — clean