### PR TITLE
App registry step 20: responsive app admin polling docs

### DIFF
--- a/plans/app_registry/operations/admin.md
+++ b/plans/app_registry/operations/admin.md
@@ -95,7 +95,7 @@ Implemented in `gestalt-providers` (default `/apps` UI), not the embedded `/admi
 - Show the permanent, read-only deploy chain in a **Revision history** tab.
 - Show whether historical versions are still redeployable or permanently locked.
 - Legacy published versions without workflow metadata still link the commit and show **not recorded** for workflow/PR fields.
-- Disable deploy actions while a rollout is `enrolling` or `restarting`; refresh until terminal.
+- Disable deploy actions while a rollout is `enrolling` or `restarting`; poll registry state every **3s** and refresh until rollout is terminal.
 - Render access denied on **403** without leaking registry metadata.
 
 Selection is fleet-wide. It is not per-user or per-replica.
@@ -107,7 +107,7 @@ The page header shows the app name, **App management** label, registry binding, 
 - **Published snapshots** — pending, failed, and published entries in one newest-first list. A published row has **Deploy** when it is never deployed and before `publishedAt + unusedRetention`, or historical and before `deployableUntil`.
 - **Revision history** — accepted fleet version changes in reverse chronological order. This tab is always read-only.
 
-See [pending-publish.md](./pending-publish.md) for snapshot merge rules, polling, and timing labels.
+See [pending-publish.md](./pending-publish.md) for snapshot merge rules, **3s** registry polling during bootstrap and active publish/rollout, and live **Publishing** duration labels.
 
 ```text
 g-issues                                                                 App management

--- a/plans/app_registry/operations/pending-publish.md
+++ b/plans/app_registry/operations/pending-publish.md
@@ -54,13 +54,13 @@ Durations are computed at read/UI time — not stored as separate GCS fields. Fi
 
 | Row status | Start | End | Status label |
 | --- | --- | --- | --- |
-| **Publishing** | `startedAt` | now | `Publishing` + `for 4m` |
+| **Publishing** | `startedAt` | `liveNow` (client clock, 1s) | `Publishing` + `for 4m 12s` |
 | **Available** / **Expired** / **Deployed** / **Redeployable** / **Locked** | `publishStartedAt` | `publishedAt` | `Published in 4m 32s` |
 | **Failed** | `startedAt` | `failedAt` | `Failed after 35m` |
 
 `gestaltd app registry publish` reads `pending.json` and copies `PendingVersion.startedAt` into `publishStartedAt` on `versions/{version}.json` and `index.json`. The field is optional in the JSON schema so legacy entries and manual publishes that skipped `pending set` still decode.
 
-The app-admin API includes `publishingForSeconds` on pending rows and `publishDurationSeconds` on published and failed rows when start timestamps exist.
+The app-admin API includes `publishingForSeconds` on pending rows and `publishDurationSeconds` on published and failed rows when start timestamps exist. The app admin UI prefers `startedAt` + a client-side `liveNow` clock for in-flight **Publishing** labels so durations advance between registry polls; published and failed rows still use the static API fields.
 
 ## Self-Healing
 
@@ -172,9 +172,19 @@ Wireframes and columns: [admin.md](./admin.md#app-admin-ui-appsappadmin).
 
 Polling (`gestalt-providers`):
 
-- Every **12s** while `pendingVersions.length > 0`, rollout is non-terminal, or selection is disabled.
-- Every **12s** for **5 minutes** after page load (bootstrap window) so a CI-recorded pending row appears without manual refresh.
-- Do not poll solely because `failedVersions` is non-empty — failed rows load on page fetch.
+Per browser tab via `shouldPollAppAdminRegistry` in `polling.ts` and `useAppAdminRegistryQuery` (`refetchInterval`). Closing the tab stops refresh.
+
+| When | Registry refresh |
+| --- | --- |
+| **Bootstrap window** — first **5 minutes** after page load | `GET /api/v1/apps/{app}/admin/registry` every **3s** |
+| **Active publish or rollout** — `pendingVersions.length > 0`, rollout `enrolling` or `restarting`, or `selectionDisabled` | every **3s** |
+| **Idle** — past bootstrap window and no active signals | none until manual refresh or deploy |
+
+Constants: `APP_ADMIN_POLL_INTERVAL_MS = 3_000`, `APP_ADMIN_BOOTSTRAP_POLL_MS` for the bootstrap-window duration.
+
+Do not poll solely because `failedVersions` is non-empty — failed rows load on page fetch.
+
+`useLiveNow` (`hooks/use-live-now.ts`) ticks every **1s** while **Published snapshots** has at least one **Publishing** row (pauses when the tab is hidden). Pass `liveNow` into `snapshotStatusTimer` and `snapshotLastUpdatedLabel` so in-flight duration and last-update labels advance between polls without extra `gestaltd` requests.
 
 ## Safety and Invariants
 
@@ -194,7 +204,7 @@ Implementation:
 - `gestaltd app registry publish` CLI — `gestaltd/internal/daemon/app_registry_publish.go`, `gestaltd/internal/daemon/app_publish.go`
 - App-admin registry API — `gestaltd/internal/server/handlers_app_admin_registry.go`
 - Registry fetch — `gestaltd/internal/appregistry/reader.go`
-- App admin snapshots UI — `gestalt-providers/app/default` (`polling.ts`, `app-admin-snapshots-table.tsx`)
+- App admin snapshots UI — `gestalt-providers/app/default` (`polling.ts`, `lib/queries/app-admin.ts`, `hooks/use-live-now.ts`, `app-admin-snapshots-table.tsx`, `snapshot-rows.ts`)
 
 ## Shipped In
 
@@ -204,6 +214,8 @@ Implementation:
 - [gestalt-providers#1159](https://github.com/valon-technologies/gestalt-providers/pull/1159)–[#1161](https://github.com/valon-technologies/gestalt-providers/pull/1161) — app admin UI (pending/failed rows, polling, status column)
 - [toolshed#3782](https://github.com/valon-technologies/toolshed/pull/3782) · [toolshed#3790](https://github.com/valon-technologies/toolshed/pull/3790) · [toolshed#3792](https://github.com/valon-technologies/toolshed/pull/3792) — PR title recording from squash-merge commit subject
 - [gestalt-providers#1165](https://github.com/valon-technologies/gestalt-providers/pull/1165) — linked PR number with plain-text title in app admin tables
+- [gestalt-providers#1177](https://github.com/valon-technologies/gestalt-providers/pull/1177) — 3s registry polling during bootstrap and active publish/rollout
+- [gestalt-providers#1178](https://github.com/valon-technologies/gestalt-providers/pull/1178) — live **Publishing** duration labels via `useLiveNow`
 
 ---
 

--- a/plans/app_registry/project/changelog.md
+++ b/plans/app_registry/project/changelog.md
@@ -27,6 +27,7 @@ The `Completed` timestamp is the merge time of the PR that delivered the milesto
 | `17` | `🗓️ Jul 26 · 14:02` | `Version Retention and Cleanup` | [`config.md`](../architecture/config.md) [`models.md`](../architecture/models.md) [`retention.md`](../operations/retention.md) |
 | `18` | `🗓️ Jul 26 · 15:48` | `Revision History and Redeploy Windows` | [`admin.md`](../operations/admin.md) [`lifecycle.md`](../operations/lifecycle.md) [`retention.md`](../operations/retention.md) |
 | `19` | `🗓️ Jul 26 · 19:34` | `Publication PR Title Provenance` | [`models.md`](../architecture/models.md) [`pending-publish.md`](../operations/pending-publish.md) |
+| `20` | `🗓️ Jul 27 · 19:12` | `Responsive App Admin Registry Polling` | [`admin.md`](../operations/admin.md) [`pending-publish.md`](../operations/pending-publish.md) |
 
 ## Tag Glossary
 
@@ -234,3 +235,15 @@ Added paginated `GET …/admin/registry/history`, deployment-state projection fr
 Recorded `publication.triggerPullRequest.title` during publish and pending writes from the squash-merge commit subject on `main` (trailing `(#N)` removed).
 
 **Merged:** [toolshed#3782](https://github.com/valon-technologies/toolshed/pull/3782) · [toolshed#3790](https://github.com/valon-technologies/toolshed/pull/3790) · [toolshed#3792](https://github.com/valon-technologies/toolshed/pull/3792)
+
+<a id="changelog-20"></a>
+
+### 20 — Responsive App Admin Registry Polling
+
+**Tags:** [`admin.md`](../operations/admin.md) [`pending-publish.md`](../operations/pending-publish.md)
+
+Poll `GET /api/v1/apps/{app}/admin/registry` every **3s** (was **12s**) during the bootstrap window and while publish or rollout is active. Tick **Publishing** duration and last-update labels every **1s** client-side from `startedAt` via `useLiveNow`.
+
+**App UI:** [gestalt-providers#1177](https://github.com/valon-technologies/gestalt-providers/pull/1177) · [gestalt-providers#1178](https://github.com/valon-technologies/gestalt-providers/pull/1178)
+
+**Docs and deploy:** gestalt (this PR) · toolshed deploy bump for `apps.home`

--- a/plans/app_registry/project/tests.md
+++ b/plans/app_registry/project/tests.md
@@ -19,7 +19,7 @@ Reference for behavioral tests in the app registry plan.
 | `internal/server` | `handlers_app_admin_registry_test.go` | 4 | HTTP integration | [gestalt#2909](https://github.com/valon-technologies/gestalt/pull/2909) · [gestalt#2931](https://github.com/valon-technologies/gestalt/pull/2931) · [gestalt#2939](https://github.com/valon-technologies/gestalt/pull/2939) |
 | `internal/config` | `app_registry_retention_test.go` | 3 | Unit | [gestalt#2937](https://github.com/valon-technologies/gestalt/pull/2937) |
 | `internal/appregistry` | `retention_test.go`, `retention_prune_test.go` | 2 | Unit | [gestalt#2937](https://github.com/valon-technologies/gestalt/pull/2937) · [gestalt#2938](https://github.com/valon-technologies/gestalt/pull/2938) |
-| `gestalt-providers/app/default` | `e2e/app-admin-mock.spec.ts` | — | Playwright mock | [gestalt-providers#1142](https://github.com/valon-technologies/gestalt-providers/pull/1142) · [gestalt-providers#1163](https://github.com/valon-technologies/gestalt-providers/pull/1163) |
+| `gestalt-providers/app/default` | `e2e/app-admin-mock.spec.ts` | — | Playwright mock | [gestalt-providers#1142](https://github.com/valon-technologies/gestalt-providers/pull/1142) · [gestalt-providers#1163](https://github.com/valon-technologies/gestalt-providers/pull/1163) · [gestalt-providers#1177](https://github.com/valon-technologies/gestalt-providers/pull/1177) · [gestalt-providers#1178](https://github.com/valon-technologies/gestalt-providers/pull/1178) |
 | `services/ui/adminui` | registry UI smoke | — | Manual / browser | planned |
 
 Test fixture for install HTTP tests: `internal/appregistry/registrytest/fixture.go`
@@ -477,7 +477,7 @@ Not yet covered in gestalt server tests:
 
 ### Default App UI Tests (`gestalt-providers`)
 
-Implemented in [gestalt-providers#1142](https://github.com/valon-technologies/gestalt-providers/pull/1142), [gestalt-providers#1158](https://github.com/valon-technologies/gestalt-providers/pull/1158)–[#1163](https://github.com/valon-technologies/gestalt-providers/pull/1163), and [gestalt-providers#1165](https://github.com/valon-technologies/gestalt-providers/pull/1165).
+Implemented in [gestalt-providers#1142](https://github.com/valon-technologies/gestalt-providers/pull/1142), [gestalt-providers#1158](https://github.com/valon-technologies/gestalt-providers/pull/1158)–[#1163](https://github.com/valon-technologies/gestalt-providers/pull/1163), [gestalt-providers#1165](https://github.com/valon-technologies/gestalt-providers/pull/1165), [gestalt-providers#1177](https://github.com/valon-technologies/gestalt-providers/pull/1177), and [gestalt-providers#1178](https://github.com/valon-technologies/gestalt-providers/pull/1178).
 
 Run:
 
@@ -491,6 +491,8 @@ Covered behaviors:
 - **Manage app** appears only when `managementPath` is returned
 - published versions render newest first with desired version selected
 - pending, failed, and published rows share one snapshots table with status and timing labels
+- **Publishing** row appears within **6s** without manual refresh while registry polling is active ([gestalt-providers#1177](https://github.com/valon-technologies/gestalt-providers/pull/1177))
+- in-flight **Publishing** duration labels advance client-side between frozen registry poll responses ([gestalt-providers#1178](https://github.com/valon-technologies/gestalt-providers/pull/1178))
 - the Revision history tab loads lazily, renders newest-first transitions, paginates older rows, and shows **No deployments yet** for an empty chain
 - active rollout or **409** after a stale page disables deploy actions until rollout is terminal
 - successful selection renders the new active rollout with sentence-case rollout labels (`Enrolling`, `Complete`)


### PR DESCRIPTION
## Summary
- Document **3s** registry polling during bootstrap and active publish/rollout on `/apps/{app}/admin` (was 12s).
- Document `useLiveNow` client-side **Publishing** duration labels.
- Add changelog step **20** and extend tests index.

Supersedes the plan-only PR #2949 (folded into shipped docs; no `responsive-app-admin.md`).

Implementation already merged: gestalt-providers#1177, #1178.

## Test plan
- [x] Docs-only change
- [ ] Link toolshed deploy bump PR when filed


Made with [Cursor](https://cursor.com)