### PR TITLE
Read deployability deadlines from change requests only

### DIFF
--- a/gestaltd/internal/appregistry/installer.go
+++ b/gestaltd/internal/appregistry/installer.go
@@ -198,8 +198,13 @@ func (i *Installer) install(ctx context.Context, input InstallInput, mode instal
 		return nil, fmt.Errorf("fetch retention index: %w", err)
 	}
 	currentDesired := coredata.LatestKnownVersion(knownVersions)
+	changeRequests, err := i.ChangeRequests.ListRequestsByApp(installCtx, appName)
+	if err != nil {
+		return nil, fmt.Errorf("list app version change requests: %w", err)
+	}
+	deadlines := DeployableUntilDeadlinesFromChangeRequests(changeRequests)
 	if mode == installModeSelect || mode == installModeUpgrade || mode == installModeAdd {
-		if err := VersionSelectable(version, currentDesired, retentionIndex, policy, i.now()); err != nil {
+		if err := VersionSelectable(version, currentDesired, retentionIndex, policy, i.now(), deadlines); err != nil {
 			return nil, err
 		}
 	}

--- a/gestaltd/internal/appregistry/installer.go
+++ b/gestaltd/internal/appregistry/installer.go
@@ -202,9 +202,9 @@ func (i *Installer) install(ctx context.Context, input InstallInput, mode instal
 	if err != nil {
 		return nil, fmt.Errorf("list app version change requests: %w", err)
 	}
-	deadlines := DeployableUntilDeadlinesFromChangeRequests(changeRequests)
+	chain := VersionDeploymentChainFromChangeRequests(changeRequests)
 	if mode == installModeSelect || mode == installModeUpgrade || mode == installModeAdd {
-		if err := VersionSelectable(version, currentDesired, retentionIndex, policy, i.now(), deadlines); err != nil {
+		if err := VersionSelectable(version, currentDesired, retentionIndex, policy, i.now(), chain); err != nil {
 			return nil, err
 		}
 	}

--- a/gestaltd/internal/appregistry/retention.go
+++ b/gestaltd/internal/appregistry/retention.go
@@ -195,10 +195,27 @@ func ApplyDesiredVersionTransition(index *RetentionIndex, fromVersion, toVersion
 	return changed
 }
 
-// VersionDeploymentDeadlines carries redeploy deadlines from the append-only
-// change-request chain. retention.json is the prune overlay and may lag; these
-// deadlines are authoritative for admission and admin deployment state.
+// VersionDeploymentChain carries fleet deployment facts from the append-only
+// change-request chain. Redeploy deadlines and deploy history are read only
+// from change requests; retention.json supplies publish timestamps, unused
+// retention, and sticky prune locks.
+type VersionDeploymentChain struct {
+	Deployed  map[string]struct{}
+	Deadlines VersionDeploymentDeadlines
+}
+
+// VersionDeploymentDeadlines maps a deactivated version to its fixed redeploy
+// deadline recorded as from_version_deployable_until on the change request.
 type VersionDeploymentDeadlines map[string]time.Time
+
+// VersionDeploymentChainFromChangeRequests projects deploy history and redeploy
+// deadlines from fleet change requests.
+func VersionDeploymentChainFromChangeRequests(requests []*core.AppVersionChangeRequest) VersionDeploymentChain {
+	return VersionDeploymentChain{
+		Deployed:  DeployedVersionsFromChangeRequests(requests),
+		Deadlines:   DeployableUntilDeadlinesFromChangeRequests(requests),
+	}
+}
 
 // DeployableUntilDeadlinesFromChangeRequests projects each outgoing version's
 // fixed redeploy deadline from fleet change requests.
@@ -237,28 +254,34 @@ func DeployableUntilDeadlinesFromChangeRequests(requests []*core.AppVersionChang
 }
 
 // VersionDeploymentState resolves present-day deployability for one published version.
-func VersionDeploymentState(version string, desiredVersion string, retention *RetentionIndex, policy RetentionPolicy, now time.Time, deadlines VersionDeploymentDeadlines) (state string, deployableUntil *time.Time) {
+func VersionDeploymentState(version string, desiredVersion string, retention *RetentionIndex, policy RetentionPolicy, now time.Time, chain VersionDeploymentChain) (state string, deployableUntil *time.Time) {
 	version = strings.TrimSpace(version)
 	desiredVersion = strings.TrimSpace(desiredVersion)
 	now = now.UTC()
 	if version == desiredVersion && version != "" {
 		return DeploymentStateDesired, nil
 	}
+	if chain.Deployed != nil {
+		if _, wasDeployed := chain.Deployed[version]; wasDeployed {
+			entry, _ := retentionVersion(retention, version)
+			if entry.LockedAt != nil && !entry.LockedAt.IsZero() {
+				return DeploymentStateLocked, chain.deployableUntil(version)
+			}
+			deadline := chain.deployableUntil(version)
+			if deadline != nil && now.Before(deadline.UTC()) {
+				return DeploymentStateRedeployable, cloneTimePtr(deadline)
+			}
+			if deadline != nil && !deadline.IsZero() {
+				return DeploymentStateLocked, cloneTimePtr(deadline)
+			}
+			return DeploymentStateLocked, nil
+		}
+	}
 	entry, ok := retentionVersion(retention, version)
 	if !ok {
 		return DeploymentStateAvailable, nil
 	}
 	if entry.LockedAt != nil && !entry.LockedAt.IsZero() {
-		return DeploymentStateLocked, effectiveDeployableUntil(version, entry, deadlines)
-	}
-	if entry.EverDeployed || deadlines.Has(version) {
-		deadline := effectiveDeployableUntil(version, entry, deadlines)
-		if deadline != nil && now.Before(deadline.UTC()) {
-			return DeploymentStateRedeployable, cloneTimePtr(deadline)
-		}
-		if deadline != nil && !deadline.IsZero() {
-			return DeploymentStateLocked, cloneTimePtr(deadline)
-		}
 		return DeploymentStateLocked, nil
 	}
 	unusedDeadline := entry.PublishedAt.UTC().Add(policy.UnusedRetention)
@@ -268,27 +291,20 @@ func VersionDeploymentState(version string, desiredVersion string, retention *Re
 	return DeploymentStateExpired, nil
 }
 
-func effectiveDeployableUntil(version string, entry RetentionVersion, deadlines VersionDeploymentDeadlines) *time.Time {
-	if entry.DeployableUntil != nil && !entry.DeployableUntil.IsZero() {
-		return cloneTimePtr(entry.DeployableUntil)
+func (c VersionDeploymentChain) deployableUntil(version string) *time.Time {
+	if len(c.Deadlines) == 0 {
+		return nil
 	}
-	if deadline, ok := deadlines[version]; ok && !deadline.IsZero() {
-		return cloneTimePtr(&deadline)
+	deadline, ok := c.Deadlines[strings.TrimSpace(version)]
+	if !ok || deadline.IsZero() {
+		return nil
 	}
-	return nil
-}
-
-func (d VersionDeploymentDeadlines) Has(version string) bool {
-	if len(d) == 0 {
-		return false
-	}
-	_, ok := d[strings.TrimSpace(version)]
-	return ok
+	return cloneTimePtr(&deadline)
 }
 
 // VersionSelectable reports whether a version may be admitted while holding the install lock.
-func VersionSelectable(version, desiredVersion string, retention *RetentionIndex, policy RetentionPolicy, now time.Time, deadlines VersionDeploymentDeadlines) error {
-	state, _ := VersionDeploymentState(version, desiredVersion, retention, policy, now, deadlines)
+func VersionSelectable(version, desiredVersion string, retention *RetentionIndex, policy RetentionPolicy, now time.Time, chain VersionDeploymentChain) error {
+	state, _ := VersionDeploymentState(version, desiredVersion, retention, policy, now, chain)
 	switch state {
 	case DeploymentStateAvailable, DeploymentStateRedeployable:
 		return nil

--- a/gestaltd/internal/appregistry/retention.go
+++ b/gestaltd/internal/appregistry/retention.go
@@ -195,21 +195,13 @@ func ApplyDesiredVersionTransition(index *RetentionIndex, fromVersion, toVersion
 	return changed
 }
 
-// VersionDeploymentChain carries fleet deployment facts from the append-only
-// change-request chain. Redeploy deadlines and deploy history are read only
-// from change requests; retention.json supplies publish timestamps, unused
-// retention, and sticky prune locks.
 type VersionDeploymentChain struct {
 	Deployed  map[string]struct{}
 	Deadlines VersionDeploymentDeadlines
 }
 
-// VersionDeploymentDeadlines maps a deactivated version to its fixed redeploy
-// deadline recorded as from_version_deployable_until on the change request.
 type VersionDeploymentDeadlines map[string]time.Time
 
-// VersionDeploymentChainFromChangeRequests projects deploy history and redeploy
-// deadlines from fleet change requests.
 func VersionDeploymentChainFromChangeRequests(requests []*core.AppVersionChangeRequest) VersionDeploymentChain {
 	return VersionDeploymentChain{
 		Deployed:  DeployedVersionsFromChangeRequests(requests),
@@ -217,8 +209,6 @@ func VersionDeploymentChainFromChangeRequests(requests []*core.AppVersionChangeR
 	}
 }
 
-// DeployableUntilDeadlinesFromChangeRequests projects each outgoing version's
-// fixed redeploy deadline from fleet change requests.
 func DeployableUntilDeadlinesFromChangeRequests(requests []*core.AppVersionChangeRequest) VersionDeploymentDeadlines {
 	deadlines := VersionDeploymentDeadlines{}
 	if len(requests) == 0 {

--- a/gestaltd/internal/appregistry/retention.go
+++ b/gestaltd/internal/appregistry/retention.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"path"
+	"sort"
 	"strings"
 	"time"
 
+	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/services/apps/source"
 )
 
@@ -193,8 +195,49 @@ func ApplyDesiredVersionTransition(index *RetentionIndex, fromVersion, toVersion
 	return changed
 }
 
+// VersionDeploymentDeadlines carries redeploy deadlines from the append-only
+// change-request chain. retention.json is the prune overlay and may lag; these
+// deadlines are authoritative for admission and admin deployment state.
+type VersionDeploymentDeadlines map[string]time.Time
+
+// DeployableUntilDeadlinesFromChangeRequests projects each outgoing version's
+// fixed redeploy deadline from fleet change requests.
+func DeployableUntilDeadlinesFromChangeRequests(requests []*core.AppVersionChangeRequest) VersionDeploymentDeadlines {
+	deadlines := VersionDeploymentDeadlines{}
+	if len(requests) == 0 {
+		return deadlines
+	}
+	sorted := append([]*core.AppVersionChangeRequest(nil), requests...)
+	sort.Slice(sorted, func(i, j int) bool {
+		left := sorted[i]
+		right := sorted[j]
+		if left == nil || right == nil {
+			return left != nil
+		}
+		if left.Timestamp.Equal(right.Timestamp) {
+			return strings.TrimSpace(left.ID) < strings.TrimSpace(right.ID)
+		}
+		return left.Timestamp.Before(right.Timestamp)
+	})
+	for _, request := range sorted {
+		if request == nil {
+			continue
+		}
+		fromVersion := strings.TrimSpace(request.FromVersion)
+		if fromVersion == "" || fromVersion == FirstInstallFromVersion {
+			continue
+		}
+		if request.FromVersionDeployableUntil == nil || request.FromVersionDeployableUntil.IsZero() {
+			continue
+		}
+		deadline := request.FromVersionDeployableUntil.UTC()
+		deadlines[fromVersion] = deadline
+	}
+	return deadlines
+}
+
 // VersionDeploymentState resolves present-day deployability for one published version.
-func VersionDeploymentState(version string, desiredVersion string, retention *RetentionIndex, policy RetentionPolicy, now time.Time) (state string, deployableUntil *time.Time) {
+func VersionDeploymentState(version string, desiredVersion string, retention *RetentionIndex, policy RetentionPolicy, now time.Time, deadlines VersionDeploymentDeadlines) (state string, deployableUntil *time.Time) {
 	version = strings.TrimSpace(version)
 	desiredVersion = strings.TrimSpace(desiredVersion)
 	now = now.UTC()
@@ -206,14 +249,15 @@ func VersionDeploymentState(version string, desiredVersion string, retention *Re
 		return DeploymentStateAvailable, nil
 	}
 	if entry.LockedAt != nil && !entry.LockedAt.IsZero() {
-		return DeploymentStateLocked, cloneTimePtr(entry.DeployableUntil)
+		return DeploymentStateLocked, effectiveDeployableUntil(version, entry, deadlines)
 	}
-	if entry.EverDeployed {
-		if entry.DeployableUntil != nil && now.Before(entry.DeployableUntil.UTC()) {
-			return DeploymentStateRedeployable, cloneTimePtr(entry.DeployableUntil)
+	if entry.EverDeployed || deadlines.Has(version) {
+		deadline := effectiveDeployableUntil(version, entry, deadlines)
+		if deadline != nil && now.Before(deadline.UTC()) {
+			return DeploymentStateRedeployable, cloneTimePtr(deadline)
 		}
-		if entry.DeployableUntil != nil && !entry.DeployableUntil.IsZero() {
-			return DeploymentStateLocked, cloneTimePtr(entry.DeployableUntil)
+		if deadline != nil && !deadline.IsZero() {
+			return DeploymentStateLocked, cloneTimePtr(deadline)
 		}
 		return DeploymentStateLocked, nil
 	}
@@ -224,9 +268,27 @@ func VersionDeploymentState(version string, desiredVersion string, retention *Re
 	return DeploymentStateExpired, nil
 }
 
+func effectiveDeployableUntil(version string, entry RetentionVersion, deadlines VersionDeploymentDeadlines) *time.Time {
+	if entry.DeployableUntil != nil && !entry.DeployableUntil.IsZero() {
+		return cloneTimePtr(entry.DeployableUntil)
+	}
+	if deadline, ok := deadlines[version]; ok && !deadline.IsZero() {
+		return cloneTimePtr(&deadline)
+	}
+	return nil
+}
+
+func (d VersionDeploymentDeadlines) Has(version string) bool {
+	if len(d) == 0 {
+		return false
+	}
+	_, ok := d[strings.TrimSpace(version)]
+	return ok
+}
+
 // VersionSelectable reports whether a version may be admitted while holding the install lock.
-func VersionSelectable(version, desiredVersion string, retention *RetentionIndex, policy RetentionPolicy, now time.Time) error {
-	state, _ := VersionDeploymentState(version, desiredVersion, retention, policy, now)
+func VersionSelectable(version, desiredVersion string, retention *RetentionIndex, policy RetentionPolicy, now time.Time, deadlines VersionDeploymentDeadlines) error {
+	state, _ := VersionDeploymentState(version, desiredVersion, retention, policy, now, deadlines)
 	switch state {
 	case DeploymentStateAvailable, DeploymentStateRedeployable:
 		return nil

--- a/gestaltd/internal/appregistry/retention_change_requests_test.go
+++ b/gestaltd/internal/appregistry/retention_change_requests_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/appregistry"
 )
 
-func TestVersionDeploymentState_fallsBackToChangeRequestDeadline(t *testing.T) {
+func TestVersionDeploymentState_usesChangeRequestDeadlineOnly(t *testing.T) {
 	t.Parallel()
 
 	const (
@@ -21,29 +21,62 @@ func TestVersionDeploymentState_fallsBackToChangeRequestDeadline(t *testing.T) {
 	index := appregistry.NewEmptyRetentionIndex()
 	appregistry.UpsertPublishedRetention(index, vOld, deployedAt.Add(-24*time.Hour))
 	index.Versions[vOld] = appregistry.RetentionVersion{
-		PublishedAt:     deployedAt.Add(-24 * time.Hour),
-		EverDeployed:    true,
-		FirstDeployedAt: ptrTime(deployedAt.Add(-24 * time.Hour)),
+		PublishedAt:       deployedAt.Add(-24 * time.Hour),
+		EverDeployed:      true,
+		FirstDeployedAt:   ptrTime(deployedAt.Add(-24 * time.Hour)),
+		LastDeactivatedAt: ptrTime(deployedAt),
 	}
 
-	deadlines := appregistry.DeployableUntilDeadlinesFromChangeRequests([]*core.AppVersionChangeRequest{
+	chain := appregistry.VersionDeploymentChainFromChangeRequests([]*core.AppVersionChangeRequest{
 		{
 			FromVersion:                vOld,
 			ToVersion:                  vCurrent,
 			Timestamp:                  deployedAt,
 			FromVersionDeployableUntil: ptrTime(deployableUntil),
 		},
+		{
+			FromVersion: "registry:first-install",
+			ToVersion:   vOld,
+			Timestamp:   deployedAt.Add(-24 * time.Hour),
+		},
 	})
 
 	state, until := appregistry.VersionDeploymentState(vOld, vCurrent, index, appregistry.RetentionPolicy{
 		UnusedRetention:   72 * time.Hour,
 		DeployedRetention: 720 * time.Hour,
-	}, deployedAt.Add(time.Minute), deadlines)
+	}, deployedAt.Add(time.Minute), chain)
 	if state != appregistry.DeploymentStateRedeployable {
 		t.Fatalf("outgoing version state = %q, want redeployable", state)
 	}
 	if until == nil || !until.Equal(deployableUntil) {
 		t.Fatalf("deployableUntil = %#v, want %s", until, deployableUntil)
+	}
+}
+
+func TestVersionDeploymentState_ignoresRetentionDeployableUntil(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 27, 20, 30, 0, 0, time.UTC)
+	retention := appregistry.NewEmptyRetentionIndex()
+	retention.Versions["v-old"] = appregistry.RetentionVersion{
+		PublishedAt:       now.Add(-48 * time.Hour),
+		EverDeployed:      true,
+		DeployableUntil:   ptrTime(now.Add(20 * 24 * time.Hour)),
+		LastDeactivatedAt: ptrTime(now.Add(-time.Hour)),
+	}
+	chain := appregistry.VersionDeploymentChain{
+		Deployed: map[string]struct{}{"v-old": {}},
+		Deadlines: map[string]time.Time{
+			"v-old": now.Add(-time.Hour),
+		},
+	}
+
+	state, _ := appregistry.VersionDeploymentState("v-old", "v-current", retention, appregistry.RetentionPolicy{
+		UnusedRetention:   72 * time.Hour,
+		DeployedRetention: 720 * time.Hour,
+	}, now, chain)
+	if state != appregistry.DeploymentStateLocked {
+		t.Fatalf("state = %q, want locked from change-request deadline", state)
 	}
 }
 

--- a/gestaltd/internal/appregistry/retention_change_requests_test.go
+++ b/gestaltd/internal/appregistry/retention_change_requests_test.go
@@ -1,0 +1,72 @@
+package appregistry_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/appregistry"
+)
+
+func TestVersionDeploymentState_fallsBackToChangeRequestDeadline(t *testing.T) {
+	t.Parallel()
+
+	const (
+		vOld     = "0.0.0-snapshot.g86f9e963e901d57fdc6a6f0c896380dde6dc7358"
+		vCurrent = "0.0.0-snapshot.gb32ef9983cfb32d8657315ec78f2e4eda8a976b4"
+	)
+	deployedAt := time.Date(2026, 7, 27, 20, 20, 12, 967000000, time.UTC)
+	deployableUntil := deployedAt.Add(720 * time.Hour)
+
+	index := appregistry.NewEmptyRetentionIndex()
+	appregistry.UpsertPublishedRetention(index, vOld, deployedAt.Add(-24*time.Hour))
+	index.Versions[vOld] = appregistry.RetentionVersion{
+		PublishedAt:     deployedAt.Add(-24 * time.Hour),
+		EverDeployed:    true,
+		FirstDeployedAt: ptrTime(deployedAt.Add(-24 * time.Hour)),
+	}
+
+	deadlines := appregistry.DeployableUntilDeadlinesFromChangeRequests([]*core.AppVersionChangeRequest{
+		{
+			FromVersion:                vOld,
+			ToVersion:                  vCurrent,
+			Timestamp:                  deployedAt,
+			FromVersionDeployableUntil: ptrTime(deployableUntil),
+		},
+	})
+
+	state, until := appregistry.VersionDeploymentState(vOld, vCurrent, index, appregistry.RetentionPolicy{
+		UnusedRetention:   72 * time.Hour,
+		DeployedRetention: 720 * time.Hour,
+	}, deployedAt.Add(time.Minute), deadlines)
+	if state != appregistry.DeploymentStateRedeployable {
+		t.Fatalf("outgoing version state = %q, want redeployable", state)
+	}
+	if until == nil || !until.Equal(deployableUntil) {
+		t.Fatalf("deployableUntil = %#v, want %s", until, deployableUntil)
+	}
+}
+
+func TestDeployableUntilDeadlinesFromChangeRequests_usesLatestDeactivation(t *testing.T) {
+	t.Parallel()
+
+	first := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	second := first.Add(24 * time.Hour)
+	deadlines := appregistry.DeployableUntilDeadlinesFromChangeRequests([]*core.AppVersionChangeRequest{
+		{
+			FromVersion:                "v1",
+			ToVersion:                  "v2",
+			Timestamp:                  first,
+			FromVersionDeployableUntil: ptrTime(first.Add(720 * time.Hour)),
+		},
+		{
+			FromVersion:                "v1",
+			ToVersion:                  "v3",
+			Timestamp:                  second,
+			FromVersionDeployableUntil: ptrTime(second.Add(720 * time.Hour)),
+		},
+	})
+	if got := deadlines["v1"]; !got.Equal(second.Add(720 * time.Hour)) {
+		t.Fatalf("deadline = %s, want %s", got, second.Add(720*time.Hour))
+	}
+}

--- a/gestaltd/internal/appregistry/retention_test.go
+++ b/gestaltd/internal/appregistry/retention_test.go
@@ -22,18 +22,24 @@ func TestVersionDeploymentState(t *testing.T) {
 		EverDeployed:      true,
 		FirstDeployedAt:   ptrTime(now.Add(-800 * time.Hour)),
 		LastDeactivatedAt: ptrTime(now.Add(-100 * time.Hour)),
-		DeployableUntil:   ptrTime(now.Add(-10 * time.Hour)),
+		DeployableUntil:   ptrTime(now.Add(30 * 24 * time.Hour)),
+	}
+	chain := appregistry.VersionDeploymentChain{
+		Deployed: map[string]struct{}{"v-old": {}},
+		Deadlines: map[string]time.Time{
+			"v-old": now.Add(-10 * time.Hour),
+		},
 	}
 
-	state, _ := appregistry.VersionDeploymentState("v-current", "v-current", retention, policy, now, nil)
+	state, _ := appregistry.VersionDeploymentState("v-current", "v-current", retention, policy, now, chain)
 	if state != appregistry.DeploymentStateDesired {
 		t.Fatalf("desired state = %q", state)
 	}
-	state, _ = appregistry.VersionDeploymentState("v-new", "v-current", retention, policy, now, nil)
+	state, _ = appregistry.VersionDeploymentState("v-new", "v-current", retention, policy, now, chain)
 	if state != appregistry.DeploymentStateExpired {
 		t.Fatalf("expired state = %q", state)
 	}
-	state, _ = appregistry.VersionDeploymentState("v-old", "v-current", retention, policy, now, nil)
+	state, _ = appregistry.VersionDeploymentState("v-old", "v-current", retention, policy, now, chain)
 	if state != appregistry.DeploymentStateLocked {
 		t.Fatalf("locked state = %q", state)
 	}

--- a/gestaltd/internal/appregistry/retention_test.go
+++ b/gestaltd/internal/appregistry/retention_test.go
@@ -25,15 +25,15 @@ func TestVersionDeploymentState(t *testing.T) {
 		DeployableUntil:   ptrTime(now.Add(-10 * time.Hour)),
 	}
 
-	state, _ := appregistry.VersionDeploymentState("v-current", "v-current", retention, policy, now)
+	state, _ := appregistry.VersionDeploymentState("v-current", "v-current", retention, policy, now, nil)
 	if state != appregistry.DeploymentStateDesired {
 		t.Fatalf("desired state = %q", state)
 	}
-	state, _ = appregistry.VersionDeploymentState("v-new", "v-current", retention, policy, now)
+	state, _ = appregistry.VersionDeploymentState("v-new", "v-current", retention, policy, now, nil)
 	if state != appregistry.DeploymentStateExpired {
 		t.Fatalf("expired state = %q", state)
 	}
-	state, _ = appregistry.VersionDeploymentState("v-old", "v-current", retention, policy, now)
+	state, _ = appregistry.VersionDeploymentState("v-old", "v-current", retention, policy, now, nil)
 	if state != appregistry.DeploymentStateLocked {
 		t.Fatalf("locked state = %q", state)
 	}

--- a/gestaltd/internal/server/handlers_app_admin_registry.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry.go
@@ -242,9 +242,9 @@ func (s *Server) getAppAdminRegistry(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusServiceUnavailable, "app registry installation services are unavailable")
 		return
 	}
-	deadlines := appregistry.DeployableUntilDeadlinesFromChangeRequests(changeRequests)
+	chain := appregistry.VersionDeploymentChainFromChangeRequests(changeRequests)
 	for i := range summaries {
-		published = append(published, appAdminPublishedVersionFromSummary(summaries[i], desiredVersion, retentionIndex, policy, now, deadlines))
+		published = append(published, appAdminPublishedVersionFromSummary(summaries[i], desiredVersion, retentionIndex, policy, now, chain))
 	}
 	pendingVersions := make([]appAdminPendingVersion, 0)
 	for _, entry := range appregistry.PendingVersionsForAdmin(pendingIndex, publishedKeys) {
@@ -343,7 +343,7 @@ func (s *Server) getAppAdminRegistryHistory(w http.ResponseWriter, r *http.Reque
 		writeError(w, http.StatusServiceUnavailable, "app registry installation services are unavailable")
 		return
 	}
-	deadlines := appregistry.DeployableUntilDeadlinesFromChangeRequests(allChangeRequests)
+	chain := appregistry.VersionDeploymentChainFromChangeRequests(allChangeRequests)
 	publishedByVersion := publishedVersionSummaryMap(index, app.name)
 	now := time.Now().UTC()
 
@@ -362,7 +362,7 @@ func (s *Server) getAppAdminRegistryHistory(w http.ResponseWriter, r *http.Reque
 			publishedByVersion,
 			actorLabels[strings.TrimSpace(request.Actor)],
 			now,
-			deadlines,
+			chain,
 		))
 	}
 	writeJSON(w, http.StatusOK, appAdminRegistryHistoryResponse{
@@ -469,7 +469,7 @@ func appVersionSourceURL(repository, sourceRef string) string {
 	return repository + "/commit/" + sourceRef
 }
 
-func appAdminPublishedVersionFromSummary(summary appregistry.VersionSummary, desiredVersion string, retention *appregistry.RetentionIndex, policy appregistry.RetentionPolicy, now time.Time, deadlines appregistry.VersionDeploymentDeadlines) appAdminPublishedVersion {
+func appAdminPublishedVersionFromSummary(summary appregistry.VersionSummary, desiredVersion string, retention *appregistry.RetentionIndex, policy appregistry.RetentionPolicy, now time.Time, chain appregistry.VersionDeploymentChain) appAdminPublishedVersion {
 	version := appAdminPublishedVersion{
 		Version:     summary.Version,
 		PublishedAt: formatAdminTime(summary.PublishedAt),
@@ -478,7 +478,7 @@ func appAdminPublishedVersionFromSummary(summary appregistry.VersionSummary, des
 		SourceURL:   appVersionSourceURL(summary.Repository, summary.SourceRef),
 		Publication: summary.Publication,
 	}
-	state, deployableUntil := appregistry.VersionDeploymentState(summary.Version, desiredVersion, retention, policy, now, deadlines)
+	state, deployableUntil := appregistry.VersionDeploymentState(summary.Version, desiredVersion, retention, policy, now, chain)
 	version.DeploymentState = state
 	if deployableUntil != nil && !deployableUntil.IsZero() {
 		version.DeployableUntil = formatAdminTime(*deployableUntil)
@@ -566,7 +566,7 @@ func appAdminRegistryRevisionFromRequest(
 	publishedByVersion map[string]appregistry.VersionSummary,
 	deployedBy string,
 	now time.Time,
-	deadlines appregistry.VersionDeploymentDeadlines,
+	chain appregistry.VersionDeploymentChain,
 ) appAdminRegistryRevision {
 	version := strings.TrimSpace(request.ToVersion)
 	revision := appAdminRegistryRevision{
@@ -597,7 +597,7 @@ func appAdminRegistryRevisionFromRequest(
 	revision.SourceRef = sourceRef
 	revision.SourceURL = appVersionSourceURL(repository, sourceRef)
 
-	state, deployableUntil := appregistry.VersionDeploymentState(version, desiredVersion, retention, policy, now, deadlines)
+	state, deployableUntil := appregistry.VersionDeploymentState(version, desiredVersion, retention, policy, now, chain)
 	revision.DeploymentState = historyDeploymentState(state)
 	if deployableUntil != nil && !deployableUntil.IsZero() {
 		revision.DeployableUntil = formatAdminTime(*deployableUntil)

--- a/gestaltd/internal/server/handlers_app_admin_registry.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry.go
@@ -237,8 +237,14 @@ func (s *Server) getAppAdminRegistry(w http.ResponseWriter, r *http.Request) {
 	summaries := appregistry.VersionsFromIndex(index, app.name)
 	published := make([]appAdminPublishedVersion, 0, len(summaries))
 	desiredVersion := coredata.LatestKnownVersion(known)
+	changeRequests, err := s.appVersionChanges.ListRequestsByApp(r.Context(), app.name)
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "app registry installation services are unavailable")
+		return
+	}
+	deadlines := appregistry.DeployableUntilDeadlinesFromChangeRequests(changeRequests)
 	for i := range summaries {
-		published = append(published, appAdminPublishedVersionFromSummary(summaries[i], desiredVersion, retentionIndex, policy, now))
+		published = append(published, appAdminPublishedVersionFromSummary(summaries[i], desiredVersion, retentionIndex, policy, now, deadlines))
 	}
 	pendingVersions := make([]appAdminPendingVersion, 0)
 	for _, entry := range appregistry.PendingVersionsForAdmin(pendingIndex, publishedKeys) {
@@ -332,6 +338,12 @@ func (s *Server) getAppAdminRegistryHistory(w http.ResponseWriter, r *http.Reque
 		writeError(w, http.StatusServiceUnavailable, "app registry installation services are unavailable")
 		return
 	}
+	allChangeRequests, err := s.appVersionChanges.ListRequestsByApp(r.Context(), app.name)
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "app registry installation services are unavailable")
+		return
+	}
+	deadlines := appregistry.DeployableUntilDeadlinesFromChangeRequests(allChangeRequests)
 	publishedByVersion := publishedVersionSummaryMap(index, app.name)
 	now := time.Now().UTC()
 
@@ -350,6 +362,7 @@ func (s *Server) getAppAdminRegistryHistory(w http.ResponseWriter, r *http.Reque
 			publishedByVersion,
 			actorLabels[strings.TrimSpace(request.Actor)],
 			now,
+			deadlines,
 		))
 	}
 	writeJSON(w, http.StatusOK, appAdminRegistryHistoryResponse{
@@ -456,7 +469,7 @@ func appVersionSourceURL(repository, sourceRef string) string {
 	return repository + "/commit/" + sourceRef
 }
 
-func appAdminPublishedVersionFromSummary(summary appregistry.VersionSummary, desiredVersion string, retention *appregistry.RetentionIndex, policy appregistry.RetentionPolicy, now time.Time) appAdminPublishedVersion {
+func appAdminPublishedVersionFromSummary(summary appregistry.VersionSummary, desiredVersion string, retention *appregistry.RetentionIndex, policy appregistry.RetentionPolicy, now time.Time, deadlines appregistry.VersionDeploymentDeadlines) appAdminPublishedVersion {
 	version := appAdminPublishedVersion{
 		Version:     summary.Version,
 		PublishedAt: formatAdminTime(summary.PublishedAt),
@@ -465,7 +478,7 @@ func appAdminPublishedVersionFromSummary(summary appregistry.VersionSummary, des
 		SourceURL:   appVersionSourceURL(summary.Repository, summary.SourceRef),
 		Publication: summary.Publication,
 	}
-	state, deployableUntil := appregistry.VersionDeploymentState(summary.Version, desiredVersion, retention, policy, now)
+	state, deployableUntil := appregistry.VersionDeploymentState(summary.Version, desiredVersion, retention, policy, now, deadlines)
 	version.DeploymentState = state
 	if deployableUntil != nil && !deployableUntil.IsZero() {
 		version.DeployableUntil = formatAdminTime(*deployableUntil)
@@ -553,6 +566,7 @@ func appAdminRegistryRevisionFromRequest(
 	publishedByVersion map[string]appregistry.VersionSummary,
 	deployedBy string,
 	now time.Time,
+	deadlines appregistry.VersionDeploymentDeadlines,
 ) appAdminRegistryRevision {
 	version := strings.TrimSpace(request.ToVersion)
 	revision := appAdminRegistryRevision{
@@ -583,7 +597,7 @@ func appAdminRegistryRevisionFromRequest(
 	revision.SourceRef = sourceRef
 	revision.SourceURL = appVersionSourceURL(repository, sourceRef)
 
-	state, deployableUntil := appregistry.VersionDeploymentState(version, desiredVersion, retention, policy, now)
+	state, deployableUntil := appregistry.VersionDeploymentState(version, desiredVersion, retention, policy, now, deadlines)
 	revision.DeploymentState = historyDeploymentState(state)
 	if deployableUntil != nil && !deployableUntil.IsZero() {
 		revision.DeployableUntil = formatAdminTime(*deployableUntil)


### PR DESCRIPTION
## Summary
- Use the change-request chain as the sole source for fleet deploy history and historical redeploy deadlines (`from_version_deployable_until`)
- `retention.json` remains authoritative only for `publishedAt`, unused retention (`72h`), and sticky `lockedAt` after prune
- Fixes premature **Locked** state when `retention.json` is stale or missing `deployableUntil` after a deploy (e.g. g-issues `g86f9e963`)

## Root cause
`VersionDeploymentState` treated `everDeployed=true` + missing `deployableUntil` in `retention.json` as immediately locked. `RetentionCatalog` is not wired in production, so `retention.json` often lags behind change requests.

## Test plan
- [x] `go test ./internal/appregistry ./internal/server`
- [x] `TestVersionDeploymentState` — chain-based redeployable/locked
- [x] `TestDeployableUntilDeadlinesFromChangeRequests` / `ignoresRetentionDeployableUntil`
- [ ] Deploy gestaltd with this build; confirm g-issues admin shows correct **Redeployable** / **Locked** states from change-request deadlines