### PR TITLE
Document fleet retention prune without retention.json

### DIFF
--- a/plans/app_registry/architecture/config.md
+++ b/plans/app_registry/architecture/config.md
@@ -32,7 +32,7 @@ appRegistries:
       deployedRetention: 720h
 ```
 
-See [retention.md](../operations/retention.md) for policy semantics and the `retention.json` overlay. `unusedRetention` applies to never-deployed versions. `deployedRetention` controls how long an inactive historical version can be selected again after it stops being desired. Each deactivation captures a fixed deadline; later config changes do not alter it. Audit metadata remains permanent after the deployability window closes.
+See [retention.md](../operations/retention.md) for policy semantics. `unusedRetention` applies to never-deployed versions using `publishedAt` from `index.json`. `deployedRetention` controls how long an inactive historical version can be selected again after it stops being desired; the deadline is recorded as `from_version_deployable_until` on the change-request chain. Each deactivation captures a fixed deadline; later config changes do not alter it. Audit metadata remains permanent after the deployability window closes.
 
 `gcs.bucket` accepts a bare bucket name or `gs://{bucket}`. Gestalt derives both URL forms:
 

--- a/plans/app_registry/architecture/models.md
+++ b/plans/app_registry/architecture/models.md
@@ -10,7 +10,6 @@ Immutable app archives live alongside published versions:
 
     apps/{app}/
     ├── index.json
-    ├── retention.json
     ├── pending.json
     ├── failed.json
     ├── versions/
@@ -22,12 +21,11 @@ Immutable app archives live alongside published versions:
 | Document | Path | Purpose |
 | --- | --- | --- |
 | **Index** | `apps/{app}/index.json` | Lightweight catalog of published versions |
-| **RetentionIndex** | `apps/{app}/retention.json` | Mutable usage timestamps for retention pruning. See [retention.md](../operations/retention.md). |
 | **PendingIndex** | `apps/{app}/pending.json` | In-flight publishes (not installable). See [pending-publish.md](../operations/pending-publish.md). |
 | **FailedIndex** | `apps/{app}/failed.json` | Recent failed publishes (not installable). See [pending-publish.md](../operations/pending-publish.md). |
 | **PublishedVersion** | `apps/{app}/versions/{version}.json` | Full metadata and install contract for one version |
 
-Document type is implied by path. Each JSON document has a root `schemaVersion` field, currently `1` for `Index`, `PendingIndex`, `FailedIndex`, `RetentionIndex`, and `PublishedVersion`. Readers should reject unsupported values; bump it when the JSON shape changes incompatibly.
+Document type is implied by path. Each JSON document has a root `schemaVersion` field, currently `1` for `Index`, `PendingIndex`, `FailedIndex`, and `PublishedVersion`. Readers should reject unsupported values; bump it when the JSON shape changes incompatibly.
 
 Implementation: `gestaltd/internal/appregistry/`.
 
@@ -272,51 +270,6 @@ Each key is a version string whose publish attempt failed.
 | `publication` | object | no | Same `Publication` shape as `PublishedVersion.publication`. Copied from the pending row when present. |
 
 Writes use the same optimistic-concurrency pattern as `pending.json`. `PruneFailedIndex` removes entries older than 30 days on `gestaltd app registry pending set`. See [pending-publish.md](../operations/pending-publish.md#self-healing).
-
----
-
-## RetentionIndex
-
-**Path:** `apps/{app}/retention.json`
-
-Answers: _was this version deployed, when did it last stop being desired, and is it still eligible for historical redeployment?_
-
-Mutable overlay used by retention pruning. Not installable metadata. See [retention.md](../operations/retention.md) for policy rules and cleanup scope.
-
-```json
-{
-  "schemaVersion": 1,
-  "versions": {
-    "0.0.0-snapshot.gabc123": {
-      "publishedAt": "2026-07-20T12:00:00Z",
-      "lastDeactivatedAt": "2026-07-22T14:00:00Z",
-      "deployableUntil": "2026-08-21T14:00:00Z",
-      "firstDeployedAt": "2026-07-22T14:00:00Z",
-      "everDeployed": true
-    }
-  }
-}
-```
-
-### Fields
-
-#### Root · `RetentionIndex`
-
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `schemaVersion` | int | yes | Retention overlay format version. Currently `1`. |
-| `versions` | map | yes | Version string → `RetentionVersion`. |
-
-#### `RetentionIndex.versions` · `RetentionVersion`
-
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `publishedAt` | RFC 3339 timestamp | yes | Starts the unused-version retention window. |
-| `lastDeactivatedAt` | RFC 3339 timestamp | no | Most recent time this version stopped being desired. Omitted while it has never been deactivated. |
-| `deployableUntil` | RFC 3339 timestamp | no | Historical-redeploy deadline captured as `lastDeactivatedAt + deployedRetention` for the current deactivation interval. Cleared while this version is desired. |
-| `firstDeployedAt` | RFC 3339 timestamp | no | First fleet admission. |
-| `everDeployed` | bool | yes | Sticky flag; once true, deploy-chain records and version metadata are permanently protected from pruning. |
-| `lockedAt` | RFC 3339 timestamp | no | Sticky timestamp recorded after `deployableUntil`; the version can no longer become desired. |
 
 ---
 

--- a/plans/app_registry/operations/lifecycle.md
+++ b/plans/app_registry/operations/lifecycle.md
@@ -671,7 +671,7 @@ Rules:
 - `{app}` must be deploy-configured with `source.registry`.
 - `knownVersions` comes from the change-request projection; `desiredVersion` is `LatestKnownVersion` and is omitted before first install.
 - `publishedVersions` comes from the registry index, newest `publishedAt` first. Each entry includes `publishedAt`, `sourceRef`, `sourceUrl`, and `publication` when recorded. Legacy versions may omit `publication`.
-- `publishedVersions[].deploymentState` is `available` for never-deployed versions before `publishedAt + unusedRetention`, `expired` for never-deployed versions after that deadline but before pruning, `desired` for the current version, `redeployable` for historical versions before `deployableUntil`, or `locked` after the deadline.
+- `publishedVersions[].deploymentState` is `available` for never-deployed versions before `publishedAt + unusedRetention`, `expired` for never-deployed versions after that deadline but before pruning, `desired` for the current version, `redeployable` for historical versions before `deployableUntil`, or `locked` after the deadline. Never-deployed eligibility reads `publishedAt` from `index.json`; historical eligibility reads `from_version_deployable_until` on the change-request chain.
 - `deployableUntil` is returned for historical versions. The UI offers **Deploy** only for `available` and `redeployable`.
 - `pendingVersions` and `failedVersions` come from `pending.json` and `failed.json`. See [pending-publish.md](./pending-publish.md#read-path).
 - When the same version appears in more than one catalog, apply [merge rules](./pending-publish.md#app-admin-api).
@@ -756,20 +756,19 @@ A request is accepted only when all checks pass:
 4. Read the current rollout while holding the lock.
 5. Reject when rollout state is `enrolling` or `restarting` with **409**. No registry fetch, install-time validation, rollout creation, or change-request append occurs on this path. Terminal `complete` or `failed` rollouts do not block a new selection.
 6. Reject when the selected version equals the current desired version with **400** and no writes.
-7. Resolve deployment state from `retention.json` and the change-request chain:
+7. Resolve deployment state from `index.json` and the change-request chain:
    - accept a never-deployed published version only before `publishedAt + unusedRetention`, even when scheduled pruning has not run
-   - accept a historical version only before `deployableUntil` and when `lockedAt` is unset
+   - accept a historical version only before `deployableUntil` on the change-request chain
    - reject an expired never-deployed version or an expired/locked historical version with **400** and no writes
 8. Fetch the published version from the configured registry and run install-time validation ([validation.md](../architecture/validation.md)).
-9. Create the rollout and append the change request (`add` on first selection; `upgrade` on later selections, including a downgrade or repeated version). The request records the outgoing version's fixed `deployableUntil`; the append-only chain is authoritative for this deadline.
-10. Mirror the transition into `retention.json` for pruning. If that write fails, repair it from the change-request chain; do not lose or rewrite the accepted transition.
-11. Release the install lock.
+9. Create the rollout and append the change request (`add` on first selection; `upgrade` on later selections, including a downgrade or repeated version). The request records the outgoing version's fixed `deployableUntil` as `from_version_deployable_until`; the append-only change-request chain is authoritative for this deadline.
+10. Release the install lock.
 
 The rollout check in step 5 is authoritative. Concurrent selection requests must recheck under the install lock so only one admission succeeds.
 
 #### Historical Redeployment and Locking
 
-When `v1 → v2` is accepted, `v1.lastDeactivatedAt` is the transition time and `v1.deployableUntil` is that time plus the configured `deployedRetention` (default 30 days). `v2` is desired, so no historical deadline runs for it.
+When `v1 → v2` is accepted, the change request records `from_version_deployable_until` for `v1` at transition time plus the configured `deployedRetention` (default 30 days). `v2` is desired, so no historical deadline runs for it.
 
 Selecting `v1` before its deadline appends a new `v2 → v1` request. The chain retains both transitions. When `v1` later stops being desired, it receives a new deadline. Once a deadline passes, the version is permanently locked and cannot be selected again, though every history event and its metadata remains visible.
 

--- a/plans/app_registry/operations/retention.md
+++ b/plans/app_registry/operations/retention.md
@@ -9,13 +9,12 @@ Published versions and artifacts accumulate in GCS indefinitely. Never-deployed 
 ## Goals
 
 - Configurable retention on each registry binding (`unusedRetention`, `deployedRetention`).
-- Mutable `retention.json` per app tracking deployment and lock state.
 - **Unused retention** (default `72h`) — delete published versions that were never deployed within the window after publication.
 - **Permanent deploy history** — permanently retain every deployed version's change requests and metadata, including upgrades and downgrades.
 - **Historical redeploy window** (default `720h`, or 30 days) — after a version stops being desired, allow it to be selected again until its fixed `deployableUntil` deadline. After the deadline it is permanently locked.
-- Keep artifacts while a version is desired or historically redeployable. Locked historical versions may have artifacts pruned, while their index summary, version metadata, retention row, and change requests remain.
-- `gestaltd app registry retention prune` to delete eligible versions from GCS.
-- Scheduled prune from the **deploy reader** side (not publish CI).
+- Keep artifacts while a version is desired or historically redeployable. Locked historical versions may have artifacts pruned, while their index summary, version metadata, and change requests remain.
+- `gestaltd app registry retention prune` to delete eligible versions from GCS, one app at a time.
+- Scheduled prune from the **gestaltd fleet** with fleet IndexedDB access (not publish CI or bucket-only jobs).
 - A read-only **Revision history** tab on `/apps/{app}/admin` backed by the append-only deploy chain.
 
 Fleet admission permanently changes a version from unused to deployed. Publishing alone does not count. The deploy chain may contain the same version more than once, for example `v1 → v2 → v1`; each accepted transition is a separate revision-history event.
@@ -37,45 +36,57 @@ Defaults are `72h` and `720h` when omitted. The configured deployed duration is 
 ```text
 apps/{app}/
 ├── index.json
-├── retention.json
 ├── pending.json
 ├── failed.json
 ├── versions/{version}.json
 └── artifacts/{version}/…
 ```
 
-`retention.json` is a mutable catalog. Shape and fields: [models.md — RetentionIndex](../architecture/models.md#retentionindex). Updates use the same optimistic-concurrency pattern as `index.json` (`if-generation-match`).
+Retention policy reads from two existing sources:
+
+| Source | Location | Used for |
+| --- | --- | --- |
+| **Published catalog** | `index.json` | `publishedAt` for never-deployed versions |
+| **Deploy chain** | `app_version_change_requests` | fleet deploy history and `from_version_deployable_until` |
+
+There is no separate `retention.json` overlay. Legacy `retention.json` objects in GCS are ignored.
 
 ## Who Writes and Who Deletes
 
 | Action | Owner | What |
 | --- | --- | --- |
-| Publish | **Publisher** (`gestaltd app registry publish`) | Upsert `retention.json` with `publishedAt` and `everDeployed = false` |
-| Fleet selection | **Reader** (`POST …/admin/registry/version`; low-level `POST …/add` and `POST …/upgrade` for initial admission) | Set `everDeployed = true`, set `firstDeployedAt` when absent, and clear the incoming version's historical deadline while desired |
-| Desired version changes | **Reader** | On the outgoing version, set `lastDeactivatedAt = now` and `deployableUntil = now + deployedRetention`; on the incoming version, clear its active deadline |
-| Lock historical version | **Scheduled prune job** (`gestaltd app registry retention prune`) | Once `deployableUntil` passes, set sticky `lockedAt`; future config changes do not unlock it |
-| Delete unused version | **Scheduled prune job** (`gestaltd app registry retention prune`) | Remove a never-deployed expired version from `index.json`, `retention.json`, `versions/{version}.json`, and `artifacts/{version}/` |
-| Prune locked artifact | **Scheduled prune job** (`gestaltd app registry retention prune`) | Remove `artifacts/{version}/` only; retain index summary, version metadata, retention row, and change requests |
+| Publish | **Publisher** (`gestaltd app registry publish`) | Upsert `index.json` with `publishedAt` for the new version |
+| Fleet selection | **Reader** (`POST …/admin/registry/version`; low-level `POST …/add` and `POST …/upgrade`) | Append a change request with `from_version_deployable_until` for the outgoing version |
+| Delete unused version | **Scheduled prune job** (`gestaltd app registry retention prune`) | Remove a never-deployed expired version from `index.json`, `versions/{version}.json`, and `artifacts/{version}/` |
+| Prune locked artifact | **Scheduled prune job** (`gestaltd app registry retention prune`) | Remove `artifacts/{version}/` only; retain index summary, version metadata, and change requests |
 
-Admission checks the selected version while holding the app-scoped install lock. A historical version is eligible only when it is not locked and the request arrives before `deployableUntil`. Selecting it appends another change request and makes it desired; when it later stops being desired, it receives a new deadline based on the configured `deployedRetention`.
+Admission checks the selected version while holding the app-scoped install lock. A historical version is eligible only when the request arrives before `deployableUntil`. The reader resolves that deadline from `from_version_deployable_until` on the append-only change-request chain. See [indexeddb.md](../architecture/indexeddb.md). Selecting it appends another change request and makes it desired; when it later stops being desired, it receives a new deadline based on the configured `deployedRetention`.
 
-Prune acquires the same app-scoped install lock used by version selection and holds it while evaluating and mutating that app's registry objects. It cross-checks `retention.json` against `app_version_change_requests` before fully deleting any version. If either source says the version was deployed, only locked artifacts may be removed. Prune never modifies `pending.json`, `failed.json`, version metadata for deployed versions, or change requests.
+Prune runs on the gestaltd fleet with `--config`, reads the deploy chain from IndexedDB, and mutates GCS. It acquires the same app-scoped install lock used by version selection and holds it while evaluating and mutating that app's `index.json`. Prune never modifies `pending.json`, `failed.json`, version metadata for deployed versions, or change requests.
 
 ```bash
 gestaltd app registry retention prune \
-  --bucket gs://… \
+  --config /path/to/deploy/config.yaml \
   --app g-issues \
   [--dry-run]
 ```
 
-Run on a schedule from the deploy reader. Toolshed runs [app-registry-retention-prune.yml](https://github.com/valon-technologies/toolshed/blob/main/.github/workflows/app-registry-retention-prune.yml) daily for every registry-only app in `valon-tools/deploy/config.yaml`, invoking `gestaltd app registry retention prune --bucket … --app …` with the pinned gestaltd release. Do not run from `gestaltd serve` request handlers or from publish CI.
+`--app` is required. Run one invocation per registry-only app. Schedule from the gestaltd fleet (for example a host cron job or Kubernetes CronJob with deploy config and IndexedDB access). Do not run from `gestaltd serve` request handlers or from publish CI.
+
+### Concurrency
+
+Prune is safe under concurrent publish, selection, and other prune attempts for the same app:
+
+1. **Install lock** — prune claims the app-scoped install lock before reading the deploy chain or mutating GCS, the same lock used by version selection.
+2. **Optimistic concurrency on `index.json`** — writes use `if-generation-match` and retry when another writer updates the catalog first.
+3. **Deploy-chain cross-check** — a version present in `app_version_change_requests` is never fully deleted, even when `index.json` is stale.
 
 ## Retention States
 
 | State | Deployable | Cleanup |
 | --- | --- | --- |
 | Never deployed, younger than `unusedRetention` | yes | none |
-| Never deployed, window expired | no | delete index entry, metadata, artifact, and retention row |
+| Never deployed, window expired | no | delete index entry, metadata, and artifact |
 | Current desired version | already active | retain all objects; no historical deadline runs |
 | Historical, before `deployableUntil` | yes | retain all objects |
 | Historical, deadline expired | no, permanently locked | retain deploy history and metadata; artifact may be deleted |
@@ -85,9 +96,9 @@ The Revision history tab always shows deployed transitions, including locked ver
 
 ## Shipped In
 
-- [gestalt#2937](https://github.com/valon-technologies/gestalt/pull/2937) — `RetentionIndex`, config validation, and reader-side transition writes
+- [gestalt#2937](https://github.com/valon-technologies/gestalt/pull/2937) — retention config validation (original `retention.json` model; superseded by fleet prune)
 - [gestalt#2938](https://github.com/valon-technologies/gestalt/pull/2938) — `gestaltd app registry retention prune`
-- [toolshed#3786](https://github.com/valon-technologies/toolshed/pull/3786) — daily scheduled prune for registry-only apps
+- [toolshed#3786](https://github.com/valon-technologies/toolshed/pull/3786) — daily scheduled prune for registry-only apps (bucket-only; superseded by fleet prune)
 - [gestalt#2939](https://github.com/valon-technologies/gestalt/pull/2939) — revision history API and deployment-state projection
 - [gestalt#2941](https://github.com/valon-technologies/gestalt/pull/2941) — `deployedBy` email resolution
 - [gestalt-providers#1163](https://github.com/valon-technologies/gestalt-providers/pull/1163) — Revision history tab on app admin
@@ -100,14 +111,15 @@ The Revision history tab always shows deployed transitions, including locked ver
 
 <pre>
 ├── <a href="../project/changelog.md#changelog-17">17 — Version Retention and Cleanup</a>
-└── <a href="../project/changelog.md#changelog-18">18 — Revision History and Redeploy Windows</a>
+├── <a href="../project/changelog.md#changelog-18">18 — Revision History and Redeploy Windows</a>
+└── <a href="../project/changelog.md#changelog-22">22 — Fleet Retention Prune</a>
 </pre>
 
 ### Related Docs
 
 <pre>
 ├── <a href="../architecture/config.md">config.md</a> — retention fields on appRegistries
-├── <a href="../architecture/models.md#retentionindex">models.md</a> — RetentionIndex
+├── <a href="../architecture/indexeddb.md">indexeddb.md</a> — deploy chain and redeploy deadlines
 ├── <a href="./lifecycle.md">lifecycle.md</a> — app-admin version selection and low-level fleet admission
 └── <a href="./pending-publish.md">pending-publish.md</a> — pending.json / failed.json pruning
 </pre>

--- a/plans/app_registry/project/changelog.md
+++ b/plans/app_registry/project/changelog.md
@@ -29,6 +29,7 @@ The `Completed` timestamp is the merge time of the PR that delivered the milesto
 | `19` | `🗓️ Jul 26 · 19:34` | `Publication PR Title Provenance` | [`models.md`](../architecture/models.md) [`pending-publish.md`](../operations/pending-publish.md) |
 | `20` | `🗓️ Jul 27 · 19:12` | `Responsive App Admin Registry Polling` | [`admin.md`](../operations/admin.md) [`pending-publish.md`](../operations/pending-publish.md) |
 | `21` | `🗓️ Jul 27 · 20:59` | `Rollout Phase Stepper and Selected Version Row` | [`admin.md`](../operations/admin.md) [`pending-publish.md`](../operations/pending-publish.md) |
+| `22` | — | `Fleet Retention Prune` | [`indexeddb.md`](../architecture/indexeddb.md) [`lifecycle.md`](../operations/lifecycle.md) [`retention.md`](../operations/retention.md) |
 
 ## Tag Glossary
 
@@ -262,3 +263,13 @@ Replace the rollout text banner with a three-phase stepper on `/apps/{app}/admin
 **App UI:** [gestalt-providers#1184](https://github.com/valon-technologies/gestalt-providers/pull/1184)
 
 **Deploy:** [toolshed#3824](https://github.com/valon-technologies/toolshed/pull/3824) — bump `apps.home` snapshot to `0d5f672`
+
+<a id="changelog-22"></a>
+
+### 22 — Fleet Retention Prune
+
+**Tags:** [`indexeddb.md`](../architecture/indexeddb.md) [`lifecycle.md`](../operations/lifecycle.md) [`retention.md`](../operations/retention.md)
+
+Remove `retention.json`. Prune, deployment-state projection, and admission read `publishedAt` from `index.json` and deploy history from `app_version_change_requests`. `gestaltd app registry retention prune` requires `--config` and `--app`, runs on the gestaltd fleet with IndexedDB access, and uses the install lock plus optimistic `index.json` concurrency for race safety.
+
+**Merged:** (pending)

--- a/plans/app_registry/project/tests.md
+++ b/plans/app_registry/project/tests.md
@@ -429,7 +429,7 @@ go test ./internal/appregistry/... -run 'TestVersionDeploymentState|TestEvaluate
 
 ### `retention_prune_test.go`
 
-- **`TestEvaluateRetentionPrune`** — never-deployed versions past `unusedRetention` are eligible for full deletion; locked historical versions may have artifacts pruned while index and retention rows remain; deployed versions are cross-checked against the change-request chain.
+- **`TestEvaluateRetentionPrune`** — never-deployed versions past `unusedRetention` are eligible for full deletion; locked historical versions may have artifacts pruned while index rows and version metadata remain; deployed versions are cross-checked against the change-request chain.
 
 ### `app_registry_retention_test.go`
 

--- a/plans/app_registry/readme.md
+++ b/plans/app_registry/readme.md
@@ -39,7 +39,7 @@ App registries:
   - publication metadata
 - Allow registry-only apps to be installed.
 - Allow Gestalt to validate app dependencies before fleet admission.
-- Enforce unused and deployed retention windows through `retention.json` and scheduled prune. See [retention.md](./operations/retention.md).
+- Enforce unused and deployed retention windows from `index.json`, the deploy chain, and fleet-scheduled prune. See [retention.md](./operations/retention.md).
 
 The registry is a versioned contract registry for installable apps, not only an artifact bucket.
 


### PR DESCRIPTION
## Summary
- Remove `retention.json` from the retention model; policy reads `publishedAt` from `index.json` and deploy history from `change requests`
- Document fleet-scheduled `gestaltd app registry retention prune --config … --app …` (per app, with install lock and optimistic `index.json` concurrency)
- Add changelog **22 — Fleet Retention Prune**

## Stack
- Docs-only PR; implementation follows in a stacked PR

## Test plan
- [x] Docs review for consistency across retention, lifecycle, models, config, and readme


Made with [Cursor](https://cursor.com)