### PR TITLE
Document retention expiresAt model and fleet mirror writes

### DIFF
--- a/plans/app_registry/architecture/config.md
+++ b/plans/app_registry/architecture/config.md
@@ -32,7 +32,7 @@ appRegistries:
       deployedRetention: 720h
 ```
 
-See [retention.md](../operations/retention.md) for policy semantics and the `retention.json` overlay. On publish, `unusedRetention` is written as `expiresAt = publishedAt + unusedRetention`. When a version stops being desired, `deployedRetention` is written as `expiresAt = now + deployedRetention` at that transition. Redeploying clears `expiresAt`; a later deactivation overwrites it with a fresh `now + deployedRetention`. Config changes apply on the next write only, not retroactively to an existing `expiresAt`. Audit metadata remains permanent after the deployability window closes.
+See [retention.md](../operations/retention.md) for policy semantics and the `retention.json` overlay. Publish writes `expiresAt = publishedAt + unusedRetention`. Fleet selection clears `expiresAt` on the version that becomes desired and writes `expiresAt = now + deployedRetention` on the version that stops being desired. Audit metadata remains permanent after the redeploy window closes.
 
 `gcs.bucket` accepts a bare bucket name or `gs://{bucket}`. Gestalt derives both URL forms:
 

--- a/plans/app_registry/architecture/config.md
+++ b/plans/app_registry/architecture/config.md
@@ -32,7 +32,7 @@ appRegistries:
       deployedRetention: 720h
 ```
 
-See [retention.md](../operations/retention.md) for policy semantics and the `retention.json` overlay. `unusedRetention` is written as `expiresAt` on publish. `deployedRetention` is written as `expiresAt` when a version stops being desired. Each captured `expiresAt` is fixed; later config changes do not alter it. Audit metadata remains permanent after the deployability window closes.
+See [retention.md](../operations/retention.md) for policy semantics and the `retention.json` overlay. On publish, `unusedRetention` is written as `expiresAt = publishedAt + unusedRetention`. When a version stops being desired, `deployedRetention` is written as `expiresAt = now + deployedRetention` at that transition. Redeploying clears `expiresAt`; a later deactivation overwrites it with a fresh `now + deployedRetention`. Config changes apply on the next write only, not retroactively to an existing `expiresAt`. Audit metadata remains permanent after the deployability window closes.
 
 `gcs.bucket` accepts a bare bucket name or `gs://{bucket}`. Gestalt derives both URL forms:
 

--- a/plans/app_registry/architecture/config.md
+++ b/plans/app_registry/architecture/config.md
@@ -32,7 +32,7 @@ appRegistries:
       deployedRetention: 720h
 ```
 
-See [retention.md](../operations/retention.md) for policy semantics and the `retention.json` overlay. `unusedRetention` applies to never-deployed versions. `deployedRetention` controls how long an inactive historical version can be selected again after it stops being desired. Each deactivation captures a fixed deadline; later config changes do not alter it. Audit metadata remains permanent after the deployability window closes.
+See [retention.md](../operations/retention.md) for policy semantics and the `retention.json` overlay. `unusedRetention` is written as `expiresAt` on publish. `deployedRetention` is written as `expiresAt` when a version stops being desired. Each captured `expiresAt` is fixed; later config changes do not alter it. Audit metadata remains permanent after the deployability window closes.
 
 `gcs.bucket` accepts a bare bucket name or `gs://{bucket}`. Gestalt derives both URL forms:
 

--- a/plans/app_registry/architecture/indexeddb.md
+++ b/plans/app_registry/architecture/indexeddb.md
@@ -97,7 +97,7 @@ app_version_change_requests
   - to_version
   - actor
   - timestamp
-  - from_version_deployable_until # fixed deadline for the outgoing version; omitted on first install
+  - from_version_deployable_until # audit copy of outgoing expiresAt at transition; omitted on first install
   - metadata_json                  # install contract snapshot
 ```
 

--- a/plans/app_registry/architecture/indexeddb.md
+++ b/plans/app_registry/architecture/indexeddb.md
@@ -162,7 +162,7 @@ Primary key: `id` (UUID).
 
 `metadata_json` carries the immutable install contract and publication provenance snapshot used to project `AppInstallation` and revision-history responses. Legacy rows may omit `publication`.
 
-The low-level `POST …/add` and `POST …/upgrade` routes reject an already-known `to_version`. App-admin version selection may append the same `to_version` again when that historical version is still inside its configured redeploy window. After `deployableUntil`, selection returns **400** and no row is appended.
+The low-level `POST …/add` and `POST …/upgrade` routes reject an already-known `to_version`. App-admin version selection may append the same `to_version` again when that historical version is still before `expiresAt`. After `expiresAt`, selection returns **400** and no row is appended.
 
 ### Indexes
 

--- a/plans/app_registry/architecture/models.md
+++ b/plans/app_registry/architecture/models.md
@@ -279,9 +279,9 @@ Writes use the same optimistic-concurrency pattern as `pending.json`. `PruneFail
 
 **Path:** `apps/{app}/retention.json`
 
-Answers: _was this version deployed, when did it last stop being desired, and is it still eligible for historical redeployment?_
+Answers: _was this version deployed, and when does it expire from the registry?_
 
-Mutable overlay used by retention pruning. Not installable metadata. See [retention.md](../operations/retention.md) for policy rules and cleanup scope.
+Mutable overlay used by retention pruning and fleet admission. Not installable metadata. See [retention.md](../operations/retention.md) for policy rules and cleanup scope.
 
 ```json
 {
@@ -289,10 +289,8 @@ Mutable overlay used by retention pruning. Not installable metadata. See [retent
   "versions": {
     "0.0.0-snapshot.gabc123": {
       "publishedAt": "2026-07-20T12:00:00Z",
-      "lastDeactivatedAt": "2026-07-22T14:00:00Z",
-      "deployableUntil": "2026-08-21T14:00:00Z",
-      "firstDeployedAt": "2026-07-22T14:00:00Z",
-      "everDeployed": true
+      "everDeployed": true,
+      "expiresAt": "2026-08-21T14:00:00Z"
     }
   }
 }
@@ -311,12 +309,11 @@ Mutable overlay used by retention pruning. Not installable metadata. See [retent
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `publishedAt` | RFC 3339 timestamp | yes | Starts the unused-version retention window. |
-| `lastDeactivatedAt` | RFC 3339 timestamp | no | Most recent time this version stopped being desired. Omitted while it has never been deactivated. |
-| `deployableUntil` | RFC 3339 timestamp | no | Historical-redeploy deadline captured as `lastDeactivatedAt + deployedRetention` for the current deactivation interval. Cleared while this version is desired. |
-| `firstDeployedAt` | RFC 3339 timestamp | no | First fleet admission. |
-| `everDeployed` | bool | yes | Sticky flag; once true, deploy-chain records and version metadata are permanently protected from pruning. |
-| `lockedAt` | RFC 3339 timestamp | no | Sticky timestamp recorded after `deployableUntil`; the version can no longer become desired. |
+| `publishedAt` | RFC 3339 timestamp | yes | Publication time. Starts the unused-version window on first publish. |
+| `everDeployed` | bool | yes | Sticky flag; once true, deploy-chain records and version metadata are permanently protected from full deletion. |
+| `expiresAt` | RFC 3339 timestamp | no | Single expiry clock. Set to `publishedAt + unusedRetention` on publish. Cleared while the version is desired. Set to `now + deployedRetention` when another version becomes desired. Omitted or cleared while active. Readers treat a missing `expiresAt` on a deployed version as still redeployable (lean keep). |
+
+Legacy rows may still carry `deployableUntil`; readers map it to `expiresAt` until the next write.
 
 ---
 

--- a/plans/app_registry/architecture/models.md
+++ b/plans/app_registry/architecture/models.md
@@ -311,7 +311,7 @@ Mutable overlay used by retention pruning and fleet admission. Not installable m
 | --- | --- | --- | --- |
 | `publishedAt` | RFC 3339 timestamp | yes | Publication time. Starts the unused-version window on first publish. |
 | `everDeployed` | bool | yes | Sticky flag; once true, deploy-chain records and version metadata are permanently protected from full deletion. |
-| `expiresAt` | RFC 3339 timestamp | no | Single expiry clock. Set to `publishedAt + unusedRetention` on publish. Cleared while the version is desired. Overwritten with `now + deployedRetention` each time another version becomes desired. Omitted or cleared while active. Readers treat a missing `expiresAt` on a deployed version as still redeployable (lean keep). |
+| `expiresAt` | RFC 3339 timestamp | no | Expiry clock for unused cleanup and historical redeploy. Set to `publishedAt + unusedRetention` on publish. Cleared while the version is desired. Overwritten with `now + deployedRetention` each time the version stops being desired. Omitted while desired. Readers treat omitted `expiresAt` on a deployed version as redeployable until the next mirror write. |
 
 Legacy rows may still carry `deployableUntil`; readers map it to `expiresAt` until the next write.
 

--- a/plans/app_registry/architecture/models.md
+++ b/plans/app_registry/architecture/models.md
@@ -311,7 +311,7 @@ Mutable overlay used by retention pruning and fleet admission. Not installable m
 | --- | --- | --- | --- |
 | `publishedAt` | RFC 3339 timestamp | yes | Publication time. Starts the unused-version window on first publish. |
 | `everDeployed` | bool | yes | Sticky flag; once true, deploy-chain records and version metadata are permanently protected from full deletion. |
-| `expiresAt` | RFC 3339 timestamp | no | Single expiry clock. Set to `publishedAt + unusedRetention` on publish. Cleared while the version is desired. Set to `now + deployedRetention` when another version becomes desired. Omitted or cleared while active. Readers treat a missing `expiresAt` on a deployed version as still redeployable (lean keep). |
+| `expiresAt` | RFC 3339 timestamp | no | Single expiry clock. Set to `publishedAt + unusedRetention` on publish. Cleared while the version is desired. Overwritten with `now + deployedRetention` each time another version becomes desired. Omitted or cleared while active. Readers treat a missing `expiresAt` on a deployed version as still redeployable (lean keep). |
 
 Legacy rows may still carry `deployableUntil`; readers map it to `expiresAt` until the next write.
 

--- a/plans/app_registry/operations/admin.md
+++ b/plans/app_registry/operations/admin.md
@@ -89,7 +89,7 @@ Implemented in `gestalt-providers` (default `/apps` UI), not the embedded `/admi
 ### Capabilities
 
 - **Manage app** on the `/apps` catalog when the caller can administer that app.
-- Select a never-deployed version before its unused-retention deadline or a historical version inside its redeploy window as the fleet-wide desired version.
+- Select a never-deployed version before `expiresAt` or a historical version before `expiresAt` as the fleet-wide desired version.
 - Show per-version `publishedAt`, linked source commit, triggering PR or commit, and publishing workflow run.
 - Show in-flight (**Publishing**) and recent failed (**Failed**) publishes with elapsed or total publish time. See [pending-publish.md](./pending-publish.md).
 - Show the permanent, read-only deploy chain in a **Revision history** tab.
@@ -105,7 +105,7 @@ Selection is fleet-wide. It is not per-user or per-replica.
 
 The page header shows the app name, **App management** label, registry binding, and current **Desired version**. Two tabs separate deployment from audit:
 
-- **Published snapshots** — pending, failed, and published entries in one newest-first list. A published row has **Deploy** when `expiresAt` has not passed (never deployed or historical).
+- **Published snapshots** — pending, failed, and published entries in one newest-first list. A published row has **Deploy** when the version is **Available** or **Redeployable**.
 - **Revision history** — accepted fleet version changes in reverse chronological order. This tab is always read-only.
 
 See [pending-publish.md](./pending-publish.md) for snapshot merge rules, **3s** registry polling during bootstrap and active publish/rollout, and live **Publishing** duration labels.
@@ -129,7 +129,7 @@ PR #3000 · Title | 0.0.0-snapshot.g… | Locked                  | Jun 10 09:00
 PR #2900 · Title | 0.0.0-snapshot.g… | Expired                 | Jun 01 09:00  | —
 ```
 
-Row timing labels: [pending-publish.md — Publish duration](./pending-publish.md#publish-duration). **Deploy** is unavailable on **Publishing**, **Failed**, **Deployed**, **Locked**, and **Expired** rows. **Deployed** marks the desired version. **Redeployable** shows the fixed deadline or remaining duration.
+Row timing labels: [pending-publish.md — Publish duration](./pending-publish.md#publish-duration). **Deploy** is unavailable on **Publishing**, **Failed**, **Deployed**, **Locked**, and **Expired** rows. **Deployed** marks the desired version. **Redeployable** shows the deadline or remaining duration.
 
 ### Rollout phase stepper
 

--- a/plans/app_registry/operations/admin.md
+++ b/plans/app_registry/operations/admin.md
@@ -105,7 +105,7 @@ Selection is fleet-wide. It is not per-user or per-replica.
 
 The page header shows the app name, **App management** label, registry binding, and current **Desired version**. Two tabs separate deployment from audit:
 
-- **Published snapshots** — pending, failed, and published entries in one newest-first list. A published row has **Deploy** when it is never deployed and before `publishedAt + unusedRetention`, or historical and before `deployableUntil`.
+- **Published snapshots** — pending, failed, and published entries in one newest-first list. A published row has **Deploy** when `expiresAt` has not passed (never deployed or historical).
 - **Revision history** — accepted fleet version changes in reverse chronological order. This tab is always read-only.
 
 See [pending-publish.md](./pending-publish.md) for snapshot merge rules, **3s** registry polling during bootstrap and active publish/rollout, and live **Publishing** duration labels.

--- a/plans/app_registry/operations/lifecycle.md
+++ b/plans/app_registry/operations/lifecycle.md
@@ -758,20 +758,20 @@ A request is accepted only when all checks pass:
 6. Reject when the selected version equals the current desired version with **400** and no writes.
 7. Resolve deployment state from `retention.json`:
    - accept a never-deployed published version only before `expiresAt`
-   - accept a historical version only before `expiresAt`, or when `expiresAt` is cleared (desired / lean keep)
+   - accept a historical version only before `expiresAt`, or when `expiresAt` is omitted on a previously deployed version
    - reject an expired never-deployed version or an expired historical version with **400** and no writes
 8. Fetch the published version from the configured registry and run install-time validation ([validation.md](../architecture/validation.md)).
 9. Create the rollout and append the change request (`add` on first selection; `upgrade` on later selections, including a downgrade or repeated version). The change request may record `from_version_deployable_until` for audit; admission does not read it.
-10. Mirror the transition into `retention.json` through `RetentionCatalog` (incoming: clear `expiresAt`; outgoing: set `expiresAt = now + deployedRetention`).
+10. Mirror the transition into `retention.json` (clear `expiresAt` on the version that becomes desired; set `expiresAt = now + deployedRetention` on the version that stops being desired).
 11. Release the install lock.
 
 The rollout check in step 5 is authoritative. Concurrent selection requests must recheck under the install lock so only one admission succeeds.
 
 #### Historical Redeployment and Locking
 
-When `v1 → v2` is accepted, `v1.expiresAt` is set to the transition time plus the configured `deployedRetention` (default 30 days). `v2` is desired, so `expiresAt` is cleared.
+When `v1 → v2` is accepted, `v1.expiresAt` is set to `now + deployedRetention` (default 30 days). `v2` is desired, so `expiresAt` is cleared.
 
-Selecting `v1` before its deadline appends a new `v2 → v1` request. The chain retains both transitions. When `v1` later stops being desired, it receives a new deadline. Once a deadline passes, the version is permanently locked and cannot be selected again, though every history event and its metadata remains visible.
+Selecting `v1` before `expiresAt` appends a new `v2 → v1` request. The chain retains both transitions. When `v1` later stops being desired, it receives a new `expiresAt`. Once `expiresAt` passes, the version is permanently locked and cannot be selected again, though every history event and its metadata remains visible.
 
 For a repeated version, reset per-replica materialization rows whose `acknowledged_at` predates the new rollout's `created_at`. Count cohort membership and convergence only from timestamps at or after the current rollout's `created_at`.
 

--- a/plans/app_registry/operations/lifecycle.md
+++ b/plans/app_registry/operations/lifecycle.md
@@ -671,8 +671,8 @@ Rules:
 - `{app}` must be deploy-configured with `source.registry`.
 - `knownVersions` comes from the change-request projection; `desiredVersion` is `LatestKnownVersion` and is omitted before first install.
 - `publishedVersions` comes from the registry index, newest `publishedAt` first. Each entry includes `publishedAt`, `sourceRef`, `sourceUrl`, and `publication` when recorded. Legacy versions may omit `publication`.
-- `publishedVersions[].deploymentState` is `available` for never-deployed versions before `publishedAt + unusedRetention`, `expired` for never-deployed versions after that deadline but before pruning, `desired` for the current version, `redeployable` for historical versions before `deployableUntil`, or `locked` after the deadline.
-- `deployableUntil` is returned for historical versions. The UI offers **Deploy** only for `available` and `redeployable`.
+- `publishedVersions[].deploymentState` is `available` for never-deployed versions before `expiresAt`, `expired` for never-deployed versions after `expiresAt` but before pruning, `desired` for the current version, `redeployable` for historical versions before `expiresAt`, or `locked` after `expiresAt`.
+- `deployableUntil` is returned for historical versions (mapped from `expiresAt`). The UI offers **Deploy** only for `available` and `redeployable`.
 - `pendingVersions` and `failedVersions` come from `pending.json` and `failed.json`. See [pending-publish.md](./pending-publish.md#read-path).
 - When the same version appears in more than one catalog, apply [merge rules](./pending-publish.md#app-admin-api).
 - `selectionDisabled` is true only while rollout state is `enrolling` or `restarting`.
@@ -716,7 +716,7 @@ Rules:
 - Sort by `(timestamp, id)` descending. The opaque cursor contains that pair; default `limit` is 50 and maximum is 100.
 - The first deployment omits `previousVersion` when stored `from_version` is `registry:first-install`.
 - `current` is true only for the latest request that produced `LatestKnownVersion`. Earlier requests remain historical even when they selected the same version.
-- `deploymentState` is the selected version's present-day eligibility: `desired`, `redeployable`, or `locked`. Repeated entries for the same version share the same value. Historical entries include `deployableUntil` when applicable.
+- `deploymentState` is the selected version's present-day eligibility: `desired`, `redeployable`, or `locked`. Repeated entries for the same version share the same value. Historical entries include `deployableUntil` (from `expiresAt`) when applicable.
 - `deployedAt`, `deployedBy`, source fields, and publication provenance come from the change request and its immutable `metadata_json` install-contract snapshot. New admissions snapshot publication provenance; legacy rows may omit it.
 - An app with no change requests returns `revisions: []`. The route has the same app-admin authorization and fail-closed behavior as the registry-state route.
 - The endpoint performs no writes and exposes no deploy action. Eligible historical versions are selected from Published snapshots.
@@ -756,20 +756,20 @@ A request is accepted only when all checks pass:
 4. Read the current rollout while holding the lock.
 5. Reject when rollout state is `enrolling` or `restarting` with **409**. No registry fetch, install-time validation, rollout creation, or change-request append occurs on this path. Terminal `complete` or `failed` rollouts do not block a new selection.
 6. Reject when the selected version equals the current desired version with **400** and no writes.
-7. Resolve deployment state from `retention.json` and the change-request chain:
-   - accept a never-deployed published version only before `publishedAt + unusedRetention`, even when scheduled pruning has not run
-   - accept a historical version only before `deployableUntil` and when `lockedAt` is unset
-   - reject an expired never-deployed version or an expired/locked historical version with **400** and no writes
+7. Resolve deployment state from `retention.json`:
+   - accept a never-deployed published version only before `expiresAt`
+   - accept a historical version only before `expiresAt`, or when `expiresAt` is cleared (desired / lean keep)
+   - reject an expired never-deployed version or an expired historical version with **400** and no writes
 8. Fetch the published version from the configured registry and run install-time validation ([validation.md](../architecture/validation.md)).
-9. Create the rollout and append the change request (`add` on first selection; `upgrade` on later selections, including a downgrade or repeated version). The request records the outgoing version's fixed `deployableUntil`; the append-only chain is authoritative for this deadline.
-10. Mirror the transition into `retention.json` for pruning. If that write fails, repair it from the change-request chain; do not lose or rewrite the accepted transition.
+9. Create the rollout and append the change request (`add` on first selection; `upgrade` on later selections, including a downgrade or repeated version). The change request may record `from_version_deployable_until` for audit; admission does not read it.
+10. Mirror the transition into `retention.json` through `RetentionCatalog` (incoming: clear `expiresAt`; outgoing: set `expiresAt = now + deployedRetention`).
 11. Release the install lock.
 
 The rollout check in step 5 is authoritative. Concurrent selection requests must recheck under the install lock so only one admission succeeds.
 
 #### Historical Redeployment and Locking
 
-When `v1 → v2` is accepted, `v1.lastDeactivatedAt` is the transition time and `v1.deployableUntil` is that time plus the configured `deployedRetention` (default 30 days). `v2` is desired, so no historical deadline runs for it.
+When `v1 → v2` is accepted, `v1.expiresAt` is set to the transition time plus the configured `deployedRetention` (default 30 days). `v2` is desired, so `expiresAt` is cleared.
 
 Selecting `v1` before its deadline appends a new `v2 → v1` request. The chain retains both transitions. When `v1` later stops being desired, it receives a new deadline. Once a deadline passes, the version is permanently locked and cannot be selected again, though every history event and its metadata remains visible.
 

--- a/plans/app_registry/operations/pending-publish.md
+++ b/plans/app_registry/operations/pending-publish.md
@@ -164,8 +164,8 @@ Wireframes and columns: [admin.md](./admin.md#app-admin-ui-appsappadmin).
 | **Deployed** | `version === desiredVersion` and no active rollout for this version |
 | **Redeployable** | Historical, not desired, and before `expiresAt` |
 | **Locked** | Historical and past `expiresAt` |
-| **Expired** | Never deployed and past `publishedAt + unusedRetention`, pending prune |
-| **Available** | Never deployed and before `publishedAt + unusedRetention` |
+| **Expired** | Never deployed and past `expiresAt`, pending prune |
+| **Available** | Never deployed and before `expiresAt` |
 
 **Available** and **Redeployable** rows expose **Deploy**. Rollout stepper and selected-version row affordance: [admin.md](./admin.md#rollout-phase-stepper). Revision history is read-only and appears on its own tab; see [admin.md](./admin.md#revision-history-tab).
 

--- a/plans/app_registry/operations/pending-publish.md
+++ b/plans/app_registry/operations/pending-publish.md
@@ -162,8 +162,8 @@ Wireframes and columns: [admin.md](./admin.md#app-admin-ui-appsappadmin).
 | **Publishing** | Entry from `pendingVersions` |
 | **Failed** | Entry from `failedVersions` |
 | **Deployed** | `version === desiredVersion` and no active rollout for this version |
-| **Redeployable** | Historical, not desired, and before `deployableUntil` |
-| **Locked** | Historical and past `deployableUntil` or `lockedAt` is set |
+| **Redeployable** | Historical, not desired, and before `expiresAt` |
+| **Locked** | Historical and past `expiresAt` |
 | **Expired** | Never deployed and past `publishedAt + unusedRetention`, pending prune |
 | **Available** | Never deployed and before `publishedAt + unusedRetention` |
 

--- a/plans/app_registry/operations/retention.md
+++ b/plans/app_registry/operations/retention.md
@@ -30,7 +30,7 @@ retention:
   deployedRetention: 720h
 ```
 
-Defaults are `72h` and `720h` when omitted. Each deactivation captures a fixed `expiresAt`; later config changes do not alter an already captured deadline or unlock an expired version. See [config.md](../architecture/config.md).
+Defaults are `72h` and `720h` when omitted. Each time a version stops being desired, the outgoing row gets `expiresAt = now + deployedRetention`. Becoming desired again clears `expiresAt`; a later deactivation overwrites it with a new deadline. Config changes take effect on the next publish or deactivation write, not on rows that already have an `expiresAt` until then. See [config.md](../architecture/config.md).
 
 ## Schema and Storage
 

--- a/plans/app_registry/operations/retention.md
+++ b/plans/app_registry/operations/retention.md
@@ -9,11 +9,11 @@ Published versions and artifacts accumulate in GCS indefinitely. Never-deployed 
 ## Goals
 
 - Configurable retention on each registry binding (`unusedRetention`, `deployedRetention`).
-- Mutable `retention.json` per app tracking deployment and lock state.
-- **Unused retention** (default `72h`) — delete published versions that were never deployed within the window after publication.
+- Mutable `retention.json` per app with a single expiry clock per version (`expiresAt`).
+- **Unused retention** (default `72h`) — on publish, set `expiresAt = publishedAt + unusedRetention`. Prune deletes never-deployed versions after `expiresAt` passes.
 - **Permanent deploy history** — permanently retain every deployed version's change requests and metadata, including upgrades and downgrades.
-- **Historical redeploy window** (default `720h`, or 30 days) — after a version stops being desired, allow it to be selected again until its fixed `deployableUntil` deadline. After the deadline it is permanently locked.
-- Keep artifacts while a version is desired or historically redeployable. Locked historical versions may have artifacts pruned, while their index summary, version metadata, retention row, and change requests remain.
+- **Historical redeploy window** (default `720h`, or 30 days) — when a version stops being desired, set `expiresAt = now + deployedRetention`. While desired, clear `expiresAt`. After `expiresAt` passes the version is permanently locked.
+- Keep artifacts while a version is desired or before `expiresAt`. Locked historical versions may have artifacts pruned; index summary, version metadata, retention row, and change requests remain.
 - `gestaltd app registry retention prune` to delete eligible versions from GCS.
 - Scheduled prune from the **deploy reader** side (not publish CI).
 - A read-only **Revision history** tab on `/apps/{app}/admin` backed by the append-only deploy chain.
@@ -30,7 +30,7 @@ retention:
   deployedRetention: 720h
 ```
 
-Defaults are `72h` and `720h` when omitted. The configured deployed duration is captured as a fixed deadline for each deactivation interval. Redeploying and later deactivating a version creates a new deadline; config changes do not alter an already captured deadline or unlock an expired version. See [config.md](../architecture/config.md).
+Defaults are `72h` and `720h` when omitted. Each deactivation captures a fixed `expiresAt`; later config changes do not alter an already captured deadline or unlock an expired version. See [config.md](../architecture/config.md).
 
 ## Schema and Storage
 
@@ -50,16 +50,16 @@ apps/{app}/
 
 | Action | Owner | What |
 | --- | --- | --- |
-| Publish | **Publisher** (`gestaltd app registry publish`) | Upsert `retention.json` with `publishedAt` and `everDeployed = false` |
-| Fleet selection | **Reader** (`POST …/admin/registry/version`; low-level `POST …/add` and `POST …/upgrade` for initial admission) | Set `everDeployed = true`, set `firstDeployedAt` when absent, and clear the incoming version's historical deadline while desired |
-| Desired version changes | **Reader** | On the outgoing version, set `lastDeactivatedAt = now` and `deployableUntil = now + deployedRetention`; on the incoming version, clear its active deadline |
-| Lock historical version | **Scheduled prune job** (`gestaltd app registry retention prune`) | Once `deployableUntil` passes, set sticky `lockedAt`; future config changes do not unlock it |
-| Delete unused version | **Scheduled prune job** (`gestaltd app registry retention prune`) | Remove a never-deployed expired version from `index.json`, `retention.json`, `versions/{version}.json`, and `artifacts/{version}/` |
-| Prune locked artifact | **Scheduled prune job** (`gestaltd app registry retention prune`) | Remove `artifacts/{version}/` only; retain index summary, version metadata, retention row, and change requests |
+| Publish | **Publisher** (`gestaltd app registry publish`) | Upsert `retention.json` with `publishedAt`, `everDeployed = false`, and `expiresAt = publishedAt + unusedRetention` |
+| Fleet selection | **Reader** (`POST …/admin/registry/version`; low-level `POST …/add` and `POST …/upgrade` for initial admission) | On the incoming version: set `everDeployed = true` and clear `expiresAt`. On the outgoing version: set `everDeployed = true` and `expiresAt = now + deployedRetention` |
+| Delete unused version | **Scheduled prune job** (`gestaltd app registry retention prune`) | Remove a never-deployed version whose `expiresAt` has passed from `index.json`, `retention.json`, `versions/{version}.json`, and `artifacts/{version}/` |
+| Prune locked artifact | **Scheduled prune job** (`gestaltd app registry retention prune`) | Remove `artifacts/{version}/` only when `everDeployed` and `expiresAt` has passed; retain index summary, version metadata, retention row, and change requests |
 
-Admission checks the selected version while holding the app-scoped install lock. A historical version is eligible only when it is not locked and the request arrives before `deployableUntil`. Selecting it appends another change request and makes it desired; when it later stops being desired, it receives a new deadline based on the configured `deployedRetention`.
+Admission checks the selected version while holding the app-scoped install lock. State is resolved from `retention.json` only. A version is eligible when it is desired, or when `expiresAt` is unset, or when the request arrives before `expiresAt`. Selecting a historical version appends another change request and makes it desired; when it later stops being desired, it receives a new `expiresAt` based on the configured `deployedRetention`.
 
-Prune acquires the same app-scoped install lock used by version selection and holds it while evaluating and mutating that app's registry objects. It cross-checks `retention.json` against `app_version_change_requests` before fully deleting any version. If either source says the version was deployed, only locked artifacts may be removed. Prune never modifies `pending.json`, `failed.json`, version metadata for deployed versions, or change requests.
+`gestaltd serve` wires `RetentionCatalog` so fleet selection mirrors transitions into GCS `retention.json` on every accepted admission.
+
+Prune acquires the same app-scoped install lock used by version selection and holds it while evaluating and mutating that app's registry objects. It evaluates eligibility from `expiresAt` only. Before destructive work it re-reads `retention.json` for the target version; if `expiresAt` was cleared or extended (for example a concurrent redeploy), skip that action and lean toward keeping the version. Prune cross-checks `everDeployed` against `app_version_change_requests` before fully deleting any version. Prune never modifies `pending.json`, `failed.json`, version metadata for deployed versions, or change requests.
 
 ```bash
 gestaltd app registry retention prune \
@@ -72,14 +72,16 @@ Run on a schedule from the deploy reader. Toolshed runs [app-registry-retention-
 
 ## Retention States
 
-| State | Deployable | Cleanup |
-| --- | --- | --- |
-| Never deployed, younger than `unusedRetention` | yes | none |
-| Never deployed, window expired | no | delete index entry, metadata, artifact, and retention row |
-| Current desired version | already active | retain all objects; no historical deadline runs |
-| Historical, before `deployableUntil` | yes | retain all objects |
-| Historical, deadline expired | no, permanently locked | retain deploy history and metadata; artifact may be deleted |
-| Active rollout target | yes | retain all objects regardless of other clocks |
+| State | `expiresAt` | Deployable | Cleanup |
+| --- | --- | --- | --- |
+| Never deployed, before expiry | `publishedAt + unusedRetention` | yes | none |
+| Never deployed, expired | past | no | delete index entry, metadata, artifact, and retention row |
+| Current desired version | cleared | already active | retain all objects |
+| Historical, before expiry | `deactivation + deployedRetention` | yes | retain all objects |
+| Historical, expired | past | no, permanently locked | retain deploy history and metadata; artifact may be deleted |
+| Active rollout target | cleared | yes | retain all objects regardless of other clocks |
+
+The admin API still exposes `deployableUntil` for UI compatibility; it is mapped from `expiresAt` for historical versions.
 
 The Revision history tab always shows deployed transitions, including locked versions. Deployment controls live on Published snapshots and expose **Deploy** only for unexpired never-deployed or still-redeployable versions. See [admin.md](./admin.md#revision-history-tab) and [lifecycle.md](./lifecycle.md#revision-history).
 
@@ -100,7 +102,8 @@ The Revision history tab always shows deployed transitions, including locked ver
 
 <pre>
 ├── <a href="../project/changelog.md#changelog-17">17 — Version Retention and Cleanup</a>
-└── <a href="../project/changelog.md#changelog-18">18 — Revision History and Redeploy Windows</a>
+├── <a href="../project/changelog.md#changelog-18">18 — Revision History and Redeploy Windows</a>
+└── <a href="../project/changelog.md#changelog-23">23 — Retention expiresAt and Fleet Mirror</a>
 </pre>
 
 ### Related Docs

--- a/plans/app_registry/operations/retention.md
+++ b/plans/app_registry/operations/retention.md
@@ -30,7 +30,7 @@ retention:
   deployedRetention: 720h
 ```
 
-Defaults are `72h` and `720h` when omitted. Each time a version stops being desired, the outgoing row gets `expiresAt = now + deployedRetention`. Becoming desired again clears `expiresAt`; a later deactivation overwrites it with a new deadline. Config changes take effect on the next publish or deactivation write, not on rows that already have an `expiresAt` until then. See [config.md](../architecture/config.md).
+Defaults are `72h` and `720h` when omitted. When a version stops being desired, the outgoing version receives `expiresAt = now + deployedRetention`. Becoming desired again clears `expiresAt`; a later transition overwrites it with a new deadline. Config changes apply on the next publish or fleet-selection write, not retroactively. See [config.md](../architecture/config.md).
 
 ## Schema and Storage
 
@@ -51,15 +51,15 @@ apps/{app}/
 | Action | Owner | What |
 | --- | --- | --- |
 | Publish | **Publisher** (`gestaltd app registry publish`) | Upsert `retention.json` with `publishedAt`, `everDeployed = false`, and `expiresAt = publishedAt + unusedRetention` |
-| Fleet selection | **Reader** (`POST …/admin/registry/version`; low-level `POST …/add` and `POST …/upgrade` for initial admission) | On the incoming version: set `everDeployed = true` and clear `expiresAt`. On the outgoing version: set `everDeployed = true` and `expiresAt = now + deployedRetention` |
+| Fleet selection | **Reader** (`POST …/admin/registry/version`; low-level `POST …/add` and `POST …/upgrade` for initial admission) | On the version that becomes desired: set `everDeployed = true` and clear `expiresAt`. On the version that stops being desired: set `everDeployed = true` and `expiresAt = now + deployedRetention` |
 | Delete unused version | **Scheduled prune job** (`gestaltd app registry retention prune`) | Remove a never-deployed version whose `expiresAt` has passed from `index.json`, `retention.json`, `versions/{version}.json`, and `artifacts/{version}/` |
 | Prune locked artifact | **Scheduled prune job** (`gestaltd app registry retention prune`) | Remove `artifacts/{version}/` only when `everDeployed` and `expiresAt` has passed; retain index summary, version metadata, retention row, and change requests |
 
-Admission checks the selected version while holding the app-scoped install lock. State is resolved from `retention.json` only. A version is eligible when it is desired, or when `expiresAt` is unset, or when the request arrives before `expiresAt`. Selecting a historical version appends another change request and makes it desired; when it later stops being desired, it receives a new `expiresAt` based on the configured `deployedRetention`.
+Admission checks the selected version while holding the app-scoped install lock. State is resolved from `retention.json` only. A version is eligible when `expiresAt` is unset or still in the future. Selecting a historical version appends another change request and makes it desired; when it later stops being desired, it receives `expiresAt = now + deployedRetention`.
 
-`gestaltd serve` wires `RetentionCatalog` so fleet selection mirrors transitions into GCS `retention.json` on every accepted admission.
+Fleet selection mirrors each accepted transition into `retention.json` on the deploy reader.
 
-Prune acquires the same app-scoped install lock used by version selection and holds it while evaluating and mutating that app's registry objects. It evaluates eligibility from `expiresAt` only. Before destructive work it re-reads `retention.json` for the target version; if `expiresAt` was cleared or extended (for example a concurrent redeploy), skip that action and lean toward keeping the version. Prune cross-checks `everDeployed` against `app_version_change_requests` before fully deleting any version. Prune never modifies `pending.json`, `failed.json`, version metadata for deployed versions, or change requests.
+Prune acquires the same app-scoped install lock used by version selection and holds it while evaluating and mutating that app's registry objects. It evaluates eligibility from `expiresAt` only. Before destructive work, prune re-reads `retention.json` for the target version; if `expiresAt` was cleared or extended (for example by a concurrent redeploy), skip that action. Prune cross-checks `everDeployed` against `app_version_change_requests` before fully deleting any version. Prune never modifies `pending.json`, `failed.json`, version metadata for deployed versions, or change requests.
 
 ```bash
 gestaltd app registry retention prune \
@@ -77,11 +77,11 @@ Run on a schedule from the deploy reader. Toolshed runs [app-registry-retention-
 | Never deployed, before expiry | `publishedAt + unusedRetention` | yes | none |
 | Never deployed, expired | past | no | delete index entry, metadata, artifact, and retention row |
 | Current desired version | cleared | already active | retain all objects |
-| Historical, before expiry | `deactivation + deployedRetention` | yes | retain all objects |
+| Historical, before expiry | `now + deployedRetention` at last transition | yes | retain all objects |
 | Historical, expired | past | no, permanently locked | retain deploy history and metadata; artifact may be deleted |
 | Active rollout target | cleared | yes | retain all objects regardless of other clocks |
 
-The admin API still exposes `deployableUntil` for UI compatibility; it is mapped from `expiresAt` for historical versions.
+The admin API still exposes `deployableUntil` for historical versions; it is mapped from `expiresAt`.
 
 The Revision history tab always shows deployed transitions, including locked versions. Deployment controls live on Published snapshots and expose **Deploy** only for unexpired never-deployed or still-redeployable versions. See [admin.md](./admin.md#revision-history-tab) and [lifecycle.md](./lifecycle.md#revision-history).
 

--- a/plans/app_registry/project/changelog.md
+++ b/plans/app_registry/project/changelog.md
@@ -29,6 +29,7 @@ The `Completed` timestamp is the merge time of the PR that delivered the milesto
 | `19` | `🗓️ Jul 26 · 19:34` | `Publication PR Title Provenance` | [`models.md`](../architecture/models.md) [`pending-publish.md`](../operations/pending-publish.md) |
 | `20` | `🗓️ Jul 27 · 19:12` | `Responsive App Admin Registry Polling` | [`admin.md`](../operations/admin.md) [`pending-publish.md`](../operations/pending-publish.md) |
 | `21` | `🗓️ Jul 27 · 20:59` | `Rollout Phase Stepper and Selected Version Row` | [`admin.md`](../operations/admin.md) [`pending-publish.md`](../operations/pending-publish.md) |
+| `23` | `🗓️ Jul 27` | `Retention expiresAt and Fleet Mirror` | [`models.md`](../architecture/models.md) [`retention.md`](../operations/retention.md) [`lifecycle.md`](../operations/lifecycle.md) |
 
 ## Tag Glossary
 
@@ -262,3 +263,11 @@ Replace the rollout text banner with a three-phase stepper on `/apps/{app}/admin
 **App UI:** [gestalt-providers#1184](https://github.com/valon-technologies/gestalt-providers/pull/1184)
 
 **Deploy:** [toolshed#3824](https://github.com/valon-technologies/toolshed/pull/3824) — bump `apps.home` snapshot to `0d5f672`
+
+<a id="changelog-23"></a>
+
+### 23 — Retention expiresAt and Fleet Mirror
+
+**Tags:** [`models.md`](../architecture/models.md) [`retention.md`](../operations/retention.md) [`lifecycle.md`](../operations/lifecycle.md)
+
+Simplify `retention.json` to `publishedAt`, `everDeployed`, and `expiresAt`. Publish sets `expiresAt` from `unusedRetention`; fleet selection clears it on the incoming version and sets it on the outgoing version from `deployedRetention`. Wire `RetentionCatalog` in `gestaltd serve` so deploy mirrors reach GCS. Prune evaluates `expiresAt` only and re-reads before destructive work to avoid races with redeploy.

--- a/plans/app_registry/project/changelog.md
+++ b/plans/app_registry/project/changelog.md
@@ -270,4 +270,4 @@ Replace the rollout text banner with a three-phase stepper on `/apps/{app}/admin
 
 **Tags:** [`models.md`](../architecture/models.md) [`retention.md`](../operations/retention.md) [`lifecycle.md`](../operations/lifecycle.md)
 
-Simplify `retention.json` to `publishedAt`, `everDeployed`, and `expiresAt`. Publish sets `expiresAt` from `unusedRetention`; fleet selection clears it on the incoming version and sets it on the outgoing version from `deployedRetention`. Wire `RetentionCatalog` in `gestaltd serve` so deploy mirrors reach GCS. Prune evaluates `expiresAt` only and re-reads before destructive work to avoid races with redeploy.
+Simplify `retention.json` to `publishedAt`, `everDeployed`, and `expiresAt`. Publish writes `expiresAt = publishedAt + unusedRetention`. Fleet selection clears `expiresAt` on the version that becomes desired and writes `expiresAt = now + deployedRetention` on the version that stops being desired. Prune evaluates `expiresAt` only and re-reads the catalog before destructive work.

--- a/plans/app_registry/project/tests.md
+++ b/plans/app_registry/project/tests.md
@@ -425,7 +425,7 @@ go test ./internal/appregistry/... -run 'TestVersionDeploymentState|TestEvaluate
 
 ### `retention_test.go`
 
-- **`TestVersionDeploymentState`** — desired version returns `desired`; never-deployed expired versions return `expired`; historical versions before `expiresAt` return `redeployable`; after `expiresAt` return `locked`; missing `expiresAt` on deployed versions lean toward `redeployable`.
+- **`TestVersionDeploymentState`** — desired version returns `desired`; never-deployed expired versions return `expired`; historical versions before `expiresAt` return `redeployable`; after `expiresAt` return `locked`; omitted `expiresAt` on deployed versions is treated as redeployable.
 
 ### `retention_prune_test.go`
 

--- a/plans/app_registry/project/tests.md
+++ b/plans/app_registry/project/tests.md
@@ -425,11 +425,11 @@ go test ./internal/appregistry/... -run 'TestVersionDeploymentState|TestEvaluate
 
 ### `retention_test.go`
 
-- **`TestVersionDeploymentState`** — desired version returns `desired`; never-deployed expired versions return `expired`; historical versions before `deployableUntil` return `redeployable`; after the deadline return `locked`.
+- **`TestVersionDeploymentState`** — desired version returns `desired`; never-deployed expired versions return `expired`; historical versions before `expiresAt` return `redeployable`; after `expiresAt` return `locked`; missing `expiresAt` on deployed versions lean toward `redeployable`.
 
 ### `retention_prune_test.go`
 
-- **`TestEvaluateRetentionPrune`** — never-deployed versions past `unusedRetention` are eligible for full deletion; locked historical versions may have artifacts pruned while index and retention rows remain; deployed versions are cross-checked against the change-request chain.
+- **`TestEvaluateRetentionPrune`** — never-deployed versions past `expiresAt` are eligible for full deletion; historical versions past `expiresAt` may have artifacts pruned while index and retention rows remain; deployed versions are cross-checked against the change-request chain; re-read skips actions when `expiresAt` was cleared.
 
 ### `app_registry_retention_test.go`
 

--- a/plans/app_registry/readme.md
+++ b/plans/app_registry/readme.md
@@ -39,7 +39,7 @@ App registries:
   - publication metadata
 - Allow registry-only apps to be installed.
 - Allow Gestalt to validate app dependencies before fleet admission.
-- Enforce unused and deployed retention windows through `retention.json` and scheduled prune. See [retention.md](./operations/retention.md).
+- Enforce unused and deployed retention windows through `retention.json` (`expiresAt`), fleet mirror on selection, and scheduled prune. See [retention.md](./operations/retention.md).
 
 The registry is a versioned contract registry for installable apps, not only an artifact bucket.
 

--- a/plans/app_registry/readme.md
+++ b/plans/app_registry/readme.md
@@ -39,7 +39,7 @@ App registries:
   - publication metadata
 - Allow registry-only apps to be installed.
 - Allow Gestalt to validate app dependencies before fleet admission.
-- Enforce unused and deployed retention windows through `retention.json` (`expiresAt`), fleet mirror on selection, and scheduled prune. See [retention.md](./operations/retention.md).
+- Enforce unused and deployed retention windows through `retention.json`, fleet-selection mirror writes, and scheduled prune. See [retention.md](./operations/retention.md).
 
 The registry is a versioned contract registry for installable apps, not only an artifact bucket.
 


### PR DESCRIPTION
## Summary
- Replace `deployableUntil` / `lockedAt` with a single `expiresAt` clock in `retention.json` docs.
- Document publish → deploy → prune lifecycle: publish sets `expiresAt`, deploy clears it on incoming and sets it on outgoing, prune evaluates `expiresAt` only.
- Document `RetentionCatalog` mirroring on fleet selection and prune race handling (re-read before delete, lean keep).
- Add changelog entry #23 and update lifecycle, models, config, admin, and tests docs.

## Test plan
- [ ] Review `plans/app_registry/operations/retention.md` for lifecycle accuracy
- [ ] Confirm `models.md` RetentionVersion fields match intended implementation
- [ ] Verify lifecycle admission steps read `retention.json` only (not change requests)


Made with [Cursor](https://cursor.com)