### PR TITLE
Add changelog addendum for retention expiresAt deploy

### DIFF
--- a/plans/app_registry/project/changelog.md
+++ b/plans/app_registry/project/changelog.md
@@ -29,7 +29,7 @@ The `Completed` timestamp is the merge time of the PR that delivered the milesto
 | `19` | `🗓️ Jul 26 · 19:34` | `Publication PR Title Provenance` | [`models.md`](../architecture/models.md) [`pending-publish.md`](../operations/pending-publish.md) |
 | `20` | `🗓️ Jul 27 · 19:12` | `Responsive App Admin Registry Polling` | [`admin.md`](../operations/admin.md) [`pending-publish.md`](../operations/pending-publish.md) |
 | `21` | `🗓️ Jul 27 · 20:59` | `Rollout Phase Stepper and Selected Version Row` | [`admin.md`](../operations/admin.md) [`pending-publish.md`](../operations/pending-publish.md) |
-| `23` | `🗓️ Jul 27` | `Retention expiresAt and Fleet Mirror` | [`models.md`](../architecture/models.md) [`retention.md`](../operations/retention.md) [`lifecycle.md`](../operations/lifecycle.md) |
+| `23` | `🗓️ Jul 27 · 22:36` | `Retention expiresAt and Fleet Mirror` | [`models.md`](../architecture/models.md) [`retention.md`](../operations/retention.md) [`lifecycle.md`](../operations/lifecycle.md) |
 
 ## Tag Glossary
 
@@ -271,3 +271,9 @@ Replace the rollout text banner with a three-phase stepper on `/apps/{app}/admin
 **Tags:** [`models.md`](../architecture/models.md) [`retention.md`](../operations/retention.md) [`lifecycle.md`](../operations/lifecycle.md)
 
 Simplify `retention.json` to `publishedAt`, `everDeployed`, and `expiresAt`. Publish writes `expiresAt = publishedAt + unusedRetention`. Fleet selection clears `expiresAt` on the version that becomes desired and writes `expiresAt = now + deployedRetention` on the version that stops being desired. Prune evaluates `expiresAt` only and re-reads the catalog before destructive work.
+
+**Merged:** [gestalt#2963](https://github.com/valon-technologies/gestalt/pull/2963) · [gestalt#2964](https://github.com/valon-technologies/gestalt/pull/2964)
+
+**Addendum:** Review follow-ups on [gestalt#2964](https://github.com/valon-technologies/gestalt/pull/2964) — prune re-read checks only the target version entry (local deletions are not clobbered), the shared GCS client initializes with `context.Background()`, create-if-absent uses `DoesNotExist`, and mirror writes use `context.WithoutCancel`.
+
+**Deploy:** toolshed `GESTALTD_PINNED_SHA` → `a7c4d0c48` ([Deploy Valon Tools](https://github.com/valon-technologies/toolshed/actions/runs/30311971673))


### PR DESCRIPTION
## Summary
- Addendum to changelog **23 — Retention expiresAt and Fleet Mirror**
- Records [gestalt#2963](https://github.com/valon-technologies/gestalt/pull/2963) and [gestalt#2964](https://github.com/valon-technologies/gestalt/pull/2964) merge
- Documents review follow-ups on #2964 (prune race re-read, GCS mirror client/create preconditions)
- Records toolshed deploy pin `GESTALTD_PINNED_SHA` → `a7c4d0c48`

## Test plan
- [x] Changelog links and wording review

Made with [Cursor](https://cursor.com)