### PR TITLE
Fix initial source-version activation

### DIFF
--- a/gestaltd/internal/coredata/gestaltd_source_versions.go
+++ b/gestaltd/internal/coredata/gestaltd_source_versions.go
@@ -162,10 +162,12 @@ func (s *GestaltdSourceVersionService) Activate(
 
 	stateStore := tx.ObjectStore(StoreGestaltdSourceVersionState)
 	state := &core.GestaltdSourceVersionState{}
-	if rec, getErr := stateStore.Get(ctx, gestaltdSourceVersionStateID); getErr == nil {
-		state = recordToGestaltdSourceVersionState(rec)
-	} else if !errors.Is(getErr, idb.ErrNotFound) {
+	stateRecs, getErr := stateStore.GetAll(ctx, gestaltdSourceVersionStateID, 1)
+	if getErr != nil {
 		return nil, fmt.Errorf("activate gestaltd source version: load state: %w", getErr)
+	}
+	if len(stateRecs) > 0 {
+		state = recordToGestaltdSourceVersionState(stateRecs[0])
 	}
 	sourceChanged := strings.TrimSpace(state.CurrentSourceVersion) != sourceVersion
 	if sourceChanged || retry {


### PR DESCRIPTION
## Summary
- load the optional source-version state row with a bounded range read
- avoid aborting RPC-backed IndexedDB transactions on the expected initial missing row

## Test plan
- [x] `go test ./internal/coredata ./internal/server`
- [x] reproduced against the production relational IndexedDB provider

Made with [Cursor](https://cursor.com)