### PR TITLE
Add auto-deploy state and conditional registry reads

### DIFF
--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -82,6 +82,14 @@ type AppRollout struct {
 	FailedAt            time.Time
 }
 
+type AppAutoDeploySettings struct {
+	App             string
+	Enabled         bool
+	PendingVersion  string
+	LastSeenVersion string
+	LastError       string
+}
+
 type GestaltdSourceVersionState struct {
 	CurrentSourceVersion string
 	UpdatedAt            time.Time

--- a/gestaltd/internal/appregistry/reader.go
+++ b/gestaltd/internal/appregistry/reader.go
@@ -21,6 +21,12 @@ type RegistryReader struct {
 	HTTPClient *http.Client
 }
 
+type AppIndexFetchResult struct {
+	Index       *Index
+	ETag        string
+	NotModified bool
+}
+
 func (r *RegistryReader) client() *http.Client {
 	if r != nil && r.HTTPClient != nil {
 		return r.HTTPClient
@@ -131,6 +137,20 @@ func (r *RegistryReader) FetchRetentionIndex(ctx context.Context, publicRoot, ap
 
 // FetchAppIndex downloads apps/{app}/index.json from a registry public root.
 func (r *RegistryReader) FetchAppIndex(ctx context.Context, publicRoot, appName string) (*Index, error) {
+	result, err := r.FetchAppIndexConditional(ctx, publicRoot, appName, "")
+	if err != nil {
+		return nil, err
+	}
+	return result.Index, nil
+}
+
+// FetchAppIndexConditional downloads apps/{app}/index.json and optionally
+// sends an If-None-Match validator. A 304 response has NotModified set and no
+// decoded index.
+func (r *RegistryReader) FetchAppIndexConditional(
+	ctx context.Context,
+	publicRoot, appName, ifNoneMatch string,
+) (*AppIndexFetchResult, error) {
 	appName = strings.TrimSpace(appName)
 	if appName == "" {
 		return nil, fmt.Errorf("app name is required")
@@ -144,14 +164,40 @@ func (r *RegistryReader) FetchAppIndex(ctx context.Context, publicRoot, appName 
 	}
 
 	url := PublicURL(publicRoot, AppIndexPath(appName))
-	body, err := r.fetchJSON(ctx, url, true)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build app registry request: %w", err)
+	}
+	if ifNoneMatch = strings.TrimSpace(ifNoneMatch); ifNoneMatch != "" {
+		req.Header.Set("If-None-Match", ifNoneMatch)
+	}
+	resp, err := r.client().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch app registry document %s: %w", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch resp.StatusCode {
+	case http.StatusNotModified:
+		return &AppIndexFetchResult{NotModified: true}, nil
+	case http.StatusNotFound:
+		return &AppIndexFetchResult{Index: NewEmptyIndex()}, nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("fetch app registry document %s: unexpected status %s", url, resp.Status)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	if err != nil {
+		return nil, fmt.Errorf("read app registry document %s: %w", url, err)
+	}
+	index, err := DecodeIndex(body)
 	if err != nil {
 		return nil, err
 	}
-	if body == nil {
-		return NewEmptyIndex(), nil
-	}
-	return DecodeIndex(body)
+	return &AppIndexFetchResult{
+		Index: index,
+		ETag:  strings.TrimSpace(resp.Header.Get("ETag")),
+	}, nil
 }
 
 // FetchEntry downloads apps/{app}/versions/{version}.json from a registry public root.

--- a/gestaltd/internal/appregistry/reader_test.go
+++ b/gestaltd/internal/appregistry/reader_test.go
@@ -47,6 +47,101 @@ func TestRegistryReader_FetchAppIndex(t *testing.T) {
 	}
 }
 
+func TestRegistryReader_FetchAppIndexConditional(t *testing.T) {
+	t.Parallel()
+
+	const indexJSON = `{
+  "schemaVersion": 1,
+  "apps": {
+    "g-issues": {
+      "versions": {
+        "0.0.1": {
+          "metadata": "apps/g-issues/versions/0.0.1.json",
+          "publishedAt": "2026-07-10T02:00:00Z"
+        }
+      }
+    }
+  }
+}`
+
+	t.Run("not modified", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if got := r.Header.Get("If-None-Match"); got != `W/"current"` {
+				t.Errorf("If-None-Match = %q, want weak ETag", got)
+			}
+			w.WriteHeader(http.StatusNotModified)
+		}))
+		defer srv.Close()
+
+		result, err := (&RegistryReader{HTTPClient: srv.Client()}).
+			FetchAppIndexConditional(t.Context(), srv.URL, "g-issues", `W/"current"`)
+		if err != nil {
+			t.Fatalf("FetchAppIndexConditional: %v", err)
+		}
+		if !result.NotModified || result.Index != nil || result.ETag != "" {
+			t.Fatalf("result = %#v, want not modified", result)
+		}
+	})
+
+	t.Run("modified with etag", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if got := r.Header.Get("If-None-Match"); got != "" {
+				t.Errorf("If-None-Match = %q, want empty", got)
+			}
+			w.Header().Set("ETag", `"next"`)
+			_, _ = w.Write([]byte(indexJSON))
+		}))
+		defer srv.Close()
+
+		result, err := (&RegistryReader{HTTPClient: srv.Client()}).
+			FetchAppIndexConditional(t.Context(), srv.URL, "g-issues", "")
+		if err != nil {
+			t.Fatalf("FetchAppIndexConditional: %v", err)
+		}
+		if result.NotModified || result.ETag != `"next"` {
+			t.Fatalf("result = %#v", result)
+		}
+		versions := VersionsFromIndex(result.Index, "g-issues")
+		if len(versions) != 1 || versions[0].Version != "0.0.1" {
+			t.Fatalf("versions = %#v", versions)
+		}
+	})
+
+	t.Run("modified without etag", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(indexJSON))
+		}))
+		defer srv.Close()
+
+		result, err := (&RegistryReader{HTTPClient: srv.Client()}).
+			FetchAppIndexConditional(t.Context(), srv.URL, "g-issues", `"old"`)
+		if err != nil {
+			t.Fatalf("FetchAppIndexConditional: %v", err)
+		}
+		if result.NotModified || result.ETag != "" || result.Index == nil {
+			t.Fatalf("result = %#v", result)
+		}
+	})
+
+	t.Run("invalid json does not expose etag", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("ETag", `"bad"`)
+			_, _ = w.Write([]byte(`{`))
+		}))
+		defer srv.Close()
+
+		result, err := (&RegistryReader{HTTPClient: srv.Client()}).
+			FetchAppIndexConditional(t.Context(), srv.URL, "g-issues", "")
+		if err == nil || result != nil {
+			t.Fatalf("result, error = (%#v, %v), want decode error", result, err)
+		}
+	})
+}
+
 func TestVersionsFromIndex_SortsNewestFirst(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/config/app_registry_step12_test.go
+++ b/gestaltd/internal/config/app_registry_step12_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestRegistryOnlyAppSourceValidation(t *testing.T) {
@@ -79,6 +80,62 @@ server:
 			_, err := Load(path)
 			if err == nil || !strings.Contains(err.Error(), "must be a positive integer") {
 				t.Fatalf("Load error = %v", err)
+			}
+		})
+	}
+}
+
+func TestAppRegistryAutoDeployPollInterval(t *testing.T) {
+	t.Parallel()
+
+	t.Run("defaults to one minute", func(t *testing.T) {
+		t.Parallel()
+		path := mustWriteConfigFile(t, `server: {}`)
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		got, err := cfg.Server.AppRegistry.AutoDeployPollIntervalDuration()
+		if err != nil {
+			t.Fatalf("AutoDeployPollIntervalDuration: %v", err)
+		}
+		if got != time.Minute {
+			t.Fatalf("poll interval = %v, want %v", got, time.Minute)
+		}
+	})
+
+	t.Run("accepts explicit duration", func(t *testing.T) {
+		t.Parallel()
+		path := mustWriteConfigFile(t, `
+server:
+  appRegistry:
+    autoDeployPollInterval: 30s
+`)
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		got, err := cfg.Server.AppRegistry.AutoDeployPollIntervalDuration()
+		if err != nil {
+			t.Fatalf("AutoDeployPollIntervalDuration: %v", err)
+		}
+		if got != 30*time.Second {
+			t.Fatalf("poll interval = %v, want 30s", got)
+		}
+	})
+
+	for _, value := range []string{"0s", "-1s", "not-a-duration"} {
+		value := value
+		t.Run("rejects "+value, func(t *testing.T) {
+			t.Parallel()
+			path := mustWriteConfigFile(t, `
+server:
+  appRegistry:
+    autoDeployPollInterval: `+value+`
+`)
+			_, err := Load(path)
+			if err == nil || !strings.Contains(err.Error(), "server.appRegistry.autoDeployPollInterval") {
+				t.Fatalf("Load error = %v, want field-qualified validation error", err)
 			}
 		})
 	}

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1963,11 +1963,21 @@ type ServerAppRegistryConfig struct {
 	RestartDelay string `yaml:"restartDelay,omitempty"`
 	// MaxReconcileAttempts bounds failed convergence attempts per app/version.
 	// Omission defaults to DefaultAppRegistryMaxReconcileAttempts.
-	MaxReconcileAttempts    int  `yaml:"maxReconcileAttempts,omitempty"`
-	maxReconcileAttemptsSet bool `yaml:"-"`
+	MaxReconcileAttempts    int    `yaml:"maxReconcileAttempts,omitempty"`
+	AutoDeployPollInterval  string `yaml:"autoDeployPollInterval,omitempty"`
+	maxReconcileAttemptsSet bool   `yaml:"-"`
 }
 
 const DefaultAppRegistryMaxReconcileAttempts = 3
+const DefaultAppRegistryAutoDeployPollInterval = time.Minute
+
+func (c ServerAppRegistryConfig) AutoDeployPollIntervalDuration() (time.Duration, error) {
+	raw := strings.TrimSpace(c.AutoDeployPollInterval)
+	if raw == "" {
+		return DefaultAppRegistryAutoDeployPollInterval, nil
+	}
+	return ParseDuration(raw)
+}
 
 type serverAppRegistryConfigFields ServerAppRegistryConfig
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -243,10 +243,11 @@ func validateServerAppRegistry(cfg *Config) error {
 	attempts := cfg.Server.AppRegistry.MaxReconcileAttempts
 	if !cfg.Server.AppRegistry.maxReconcileAttemptsSet && attempts == 0 {
 		cfg.Server.AppRegistry.MaxReconcileAttempts = DefaultAppRegistryMaxReconcileAttempts
-		return nil
-	}
-	if attempts <= 0 {
+	} else if attempts <= 0 {
 		return fmt.Errorf("config validation: server.appRegistry.maxReconcileAttempts must be a positive integer")
+	}
+	if _, err := cfg.Server.AppRegistry.AutoDeployPollIntervalDuration(); err != nil {
+		return fmt.Errorf("config validation: server.appRegistry.autoDeployPollInterval: %w", err)
 	}
 	return nil
 }

--- a/gestaltd/internal/coredata/app_auto_deploy_settings.go
+++ b/gestaltd/internal/coredata/app_auto_deploy_settings.go
@@ -1,0 +1,144 @@
+package coredata
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	idb "github.com/valon-technologies/gestalt/sdk/go/indexeddb"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+)
+
+type AutoDeploySettingsService struct {
+	db    indexeddb.IndexedDB
+	store idb.ObjectStore
+}
+
+func NewAutoDeploySettingsService(ds indexeddb.IndexedDB) *AutoDeploySettingsService {
+	return &AutoDeploySettingsService{
+		db:    ds,
+		store: ds.ObjectStore(StoreAppAutoDeploySettings),
+	}
+}
+
+func (s *AutoDeploySettingsService) Get(ctx context.Context, app string) (*core.AppAutoDeploySettings, error) {
+	if s == nil {
+		return nil, fmt.Errorf("get app auto-deploy settings: service is not configured")
+	}
+	app = strings.TrimSpace(app)
+	if app == "" {
+		return nil, fmt.Errorf("get app auto-deploy settings: app is required")
+	}
+	rec, err := s.store.Get(ctx, app)
+	if err != nil {
+		if errors.Is(err, idb.ErrNotFound) {
+			return nil, core.ErrNotFound
+		}
+		return nil, fmt.Errorf("get app auto-deploy settings: %w", err)
+	}
+	return recordToAppAutoDeploySettings(rec), nil
+}
+
+func (s *AutoDeploySettingsService) ListEnabled(ctx context.Context) ([]*core.AppAutoDeploySettings, error) {
+	if s == nil {
+		return nil, fmt.Errorf("list enabled app auto-deploy settings: service is not configured")
+	}
+	recs, err := s.store.Index("by_enabled").GetAll(ctx, true)
+	if err != nil {
+		return nil, fmt.Errorf("list enabled app auto-deploy settings: %w", err)
+	}
+	out := make([]*core.AppAutoDeploySettings, 0, len(recs))
+	for _, rec := range recs {
+		out = append(out, recordToAppAutoDeploySettings(rec))
+	}
+	return out, nil
+}
+
+// Update atomically initializes or mutates one app's settings. A missing row
+// starts disabled with all progress fields empty.
+func (s *AutoDeploySettingsService) Update(
+	ctx context.Context,
+	app string,
+	update func(*core.AppAutoDeploySettings) error,
+) (*core.AppAutoDeploySettings, error) {
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("update app auto-deploy settings: service is not configured")
+	}
+	app = strings.TrimSpace(app)
+	if app == "" {
+		return nil, fmt.Errorf("update app auto-deploy settings: app is required")
+	}
+	if update == nil {
+		return nil, fmt.Errorf("update app auto-deploy settings: update function is required")
+	}
+
+	tx, err := s.db.Transaction(
+		ctx,
+		[]string{StoreAppAutoDeploySettings},
+		idb.TransactionReadwrite,
+		idb.TransactionOptions{},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("update app auto-deploy settings: begin transaction: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Abort(context.WithoutCancel(ctx))
+		}
+	}()
+
+	store := tx.ObjectStore(StoreAppAutoDeploySettings)
+	settings := &core.AppAutoDeploySettings{App: app}
+	rec, err := store.Get(ctx, app)
+	if err == nil {
+		settings = recordToAppAutoDeploySettings(rec)
+	} else if !errors.Is(err, idb.ErrNotFound) {
+		return nil, fmt.Errorf("update app auto-deploy settings: load current: %w", err)
+	}
+	if err := update(settings); err != nil {
+		return nil, err
+	}
+	settings.App = app
+	normalizeAppAutoDeploySettings(settings)
+	if err := store.Put(ctx, appAutoDeploySettingsRecord(settings)); err != nil {
+		return nil, fmt.Errorf("update app auto-deploy settings: write: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("update app auto-deploy settings: commit: %w", err)
+	}
+	committed = true
+	return settings, nil
+}
+
+func normalizeAppAutoDeploySettings(settings *core.AppAutoDeploySettings) {
+	settings.App = strings.TrimSpace(settings.App)
+	settings.PendingVersion = strings.TrimSpace(settings.PendingVersion)
+	settings.LastSeenVersion = strings.TrimSpace(settings.LastSeenVersion)
+	settings.LastError = strings.TrimSpace(settings.LastError)
+}
+
+func appAutoDeploySettingsRecord(settings *core.AppAutoDeploySettings) idb.Record {
+	return idb.Record{
+		"id":                settings.App,
+		"app":               settings.App,
+		"enabled":           settings.Enabled,
+		"pending_version":   settings.PendingVersion,
+		"last_seen_version": settings.LastSeenVersion,
+		"last_error":        settings.LastError,
+	}
+}
+
+func recordToAppAutoDeploySettings(rec idb.Record) *core.AppAutoDeploySettings {
+	enabled, _ := rec["enabled"].(bool)
+	return &core.AppAutoDeploySettings{
+		App:             recString(rec, "app"),
+		Enabled:         enabled,
+		PendingVersion:  recString(rec, "pending_version"),
+		LastSeenVersion: recString(rec, "last_seen_version"),
+		LastError:       recString(rec, "last_error"),
+	}
+}

--- a/gestaltd/internal/coredata/app_auto_deploy_settings_test.go
+++ b/gestaltd/internal/coredata/app_auto_deploy_settings_test.go
@@ -1,0 +1,130 @@
+package coredata_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+)
+
+func TestAutoDeploySettingsService(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("missing settings", func(t *testing.T) {
+		t.Parallel()
+		svc := testutil.NewStubServices(t).AutoDeploySettings
+		if _, err := svc.Get(ctx, "g-issues"); !errors.Is(err, core.ErrNotFound) {
+			t.Fatalf("Get missing error = %v, want %v", err, core.ErrNotFound)
+		}
+	})
+
+	t.Run("update initializes and round trips", func(t *testing.T) {
+		t.Parallel()
+		svc := testutil.NewStubServices(t).AutoDeploySettings
+		got, err := svc.Update(ctx, " g-issues ", func(settings *core.AppAutoDeploySettings) error {
+			settings.Enabled = true
+			settings.PendingVersion = " v2 "
+			settings.LastSeenVersion = " v2 "
+			settings.LastError = " validation failed "
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("Update: %v", err)
+		}
+		if got.App != "g-issues" || !got.Enabled || got.PendingVersion != "v2" ||
+			got.LastSeenVersion != "v2" || got.LastError != "validation failed" {
+			t.Fatalf("updated settings = %#v", got)
+		}
+		stored, err := svc.Get(ctx, "g-issues")
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if *stored != *got {
+			t.Fatalf("stored settings = %#v, want %#v", stored, got)
+		}
+	})
+
+	t.Run("update clears fields and preserves app", func(t *testing.T) {
+		t.Parallel()
+		svc := testutil.NewStubServices(t).AutoDeploySettings
+		if _, err := svc.Update(ctx, "g-issues", func(settings *core.AppAutoDeploySettings) error {
+			settings.Enabled = true
+			settings.PendingVersion = "v2"
+			settings.LastError = "failed"
+			return nil
+		}); err != nil {
+			t.Fatalf("seed settings: %v", err)
+		}
+		got, err := svc.Update(ctx, "g-issues", func(settings *core.AppAutoDeploySettings) error {
+			settings.App = "different-app"
+			settings.Enabled = false
+			settings.PendingVersion = ""
+			settings.LastError = ""
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("Update: %v", err)
+		}
+		if got.App != "g-issues" || got.Enabled || got.PendingVersion != "" || got.LastError != "" {
+			t.Fatalf("updated settings = %#v", got)
+		}
+	})
+
+	t.Run("list enabled", func(t *testing.T) {
+		t.Parallel()
+		svc := testutil.NewStubServices(t).AutoDeploySettings
+		for app, enabled := range map[string]bool{
+			"g-issues": true,
+			"g-slack":  false,
+			"g-tasks":  true,
+		} {
+			if _, err := svc.Update(ctx, app, func(settings *core.AppAutoDeploySettings) error {
+				settings.Enabled = enabled
+				return nil
+			}); err != nil {
+				t.Fatalf("Update %s: %v", app, err)
+			}
+		}
+		got, err := svc.ListEnabled(ctx)
+		if err != nil {
+			t.Fatalf("ListEnabled: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("enabled settings = %#v, want two", got)
+		}
+		for _, settings := range got {
+			if !settings.Enabled || settings.App == "g-slack" {
+				t.Fatalf("enabled settings includes %#v", settings)
+			}
+		}
+	})
+
+	t.Run("validation and failed update", func(t *testing.T) {
+		t.Parallel()
+		svc := testutil.NewStubServices(t).AutoDeploySettings
+		if _, err := svc.Get(ctx, " "); err == nil {
+			t.Fatal("Get with empty app succeeded")
+		}
+		if _, err := svc.Update(ctx, "", func(*core.AppAutoDeploySettings) error { return nil }); err == nil {
+			t.Fatal("Update with empty app succeeded")
+		}
+		if _, err := svc.Update(ctx, "g-issues", nil); err == nil {
+			t.Fatal("Update with nil function succeeded")
+		}
+		wantErr := errors.New("stop")
+		if _, err := svc.Update(ctx, "g-issues", func(settings *core.AppAutoDeploySettings) error {
+			settings.Enabled = true
+			return fmt.Errorf("wrapped: %w", wantErr)
+		}); !errors.Is(err, wantErr) {
+			t.Fatalf("failed update error = %v, want %v", err, wantErr)
+		}
+		if _, err := svc.Get(ctx, "g-issues"); !errors.Is(err, core.ErrNotFound) {
+			t.Fatalf("Get after failed update error = %v, want %v", err, core.ErrNotFound)
+		}
+	})
+}

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -14,6 +14,7 @@ const (
 	StoreGestaltdSourceVersionState    = "gestaltd_source_version_state"
 	StoreAppRollouts                   = "app_rollouts"
 	StoreAppInstanceMaterializations   = "app_instance_materializations"
+	StoreAppAutoDeploySettings         = "app_auto_deploy_settings"
 	StoreRemoteRegistrations           = "remote_registrations"
 	StoreRemoteProviders               = "remote_providers"
 )
@@ -138,6 +139,20 @@ var AppInstanceMaterializationsSchema = idb.ObjectStoreOptions{
 		{Name: "attempt_count", Type: idb.TypeInt},
 		{Name: "last_error_at", Type: idb.TypeTime},
 		{Name: "last_error_message", Type: idb.TypeString},
+	},
+}
+
+var AppAutoDeploySettingsSchema = idb.ObjectStoreOptions{
+	Indexes: []idb.IndexSchema{
+		{Name: "by_enabled", KeyPath: []string{"enabled"}},
+	},
+	Columns: []idb.ColumnDef{
+		{Name: "id", Type: idb.TypeString, PrimaryKey: true},
+		{Name: "app", Type: idb.TypeString, NotNull: true, Unique: true},
+		{Name: "enabled", Type: idb.TypeBool, NotNull: true},
+		{Name: "pending_version", Type: idb.TypeString},
+		{Name: "last_seen_version", Type: idb.TypeString},
+		{Name: "last_error", Type: idb.TypeString},
 	},
 }
 

--- a/gestaltd/internal/coredata/services.go
+++ b/gestaltd/internal/coredata/services.go
@@ -17,6 +17,7 @@ type Services struct {
 	GestaltdSourceVersionState  *GestaltdSourceVersionService
 	AppRollouts                 *AppRolloutService
 	AppInstanceMaterializations *AppInstanceMaterializationService
+	AutoDeploySettings          *AutoDeploySettingsService
 	RemoteRegistrations         *RemoteRegistrationService
 	DB                          indexeddb.IndexedDB
 }
@@ -65,6 +66,9 @@ func NewWithOptions(ctx context.Context, ds indexeddb.IndexedDB, opts NewOptions
 		if _, err := ds.CreateObjectStore(ctx, StoreAppInstanceMaterializations, AppInstanceMaterializationsSchema); err != nil {
 			return nil, fmt.Errorf("create app_instance_materializations store: %w", err)
 		}
+		if _, err := ds.CreateObjectStore(ctx, StoreAppAutoDeploySettings, AppAutoDeploySettingsSchema); err != nil {
+			return nil, fmt.Errorf("create app_auto_deploy_settings store: %w", err)
+		}
 		if _, err := ds.CreateObjectStore(ctx, StoreRemoteRegistrations, RemoteRegistrationsSchema); err != nil {
 			return nil, fmt.Errorf("create remote_registrations store: %w", err)
 		}
@@ -79,6 +83,7 @@ func NewWithOptions(ctx context.Context, ds indexeddb.IndexedDB, opts NewOptions
 	gestaltdSourceVersions := NewGestaltdSourceVersionService(ds)
 	appRollouts := NewAppRolloutService(ds)
 	appInstanceMaterializations := NewAppInstanceMaterializationService(ds)
+	autoDeploySettings := NewAutoDeploySettingsService(ds)
 	remoteRegistrations := NewRemoteRegistrationService(ds)
 	return &Services{
 		ExternalCredentials:         nil,
@@ -89,6 +94,7 @@ func NewWithOptions(ctx context.Context, ds indexeddb.IndexedDB, opts NewOptions
 		GestaltdSourceVersionState:  gestaltdSourceVersions,
 		AppRollouts:                 appRollouts,
 		AppInstanceMaterializations: appInstanceMaterializations,
+		AutoDeploySettings:          autoDeploySettings,
 		RemoteRegistrations:         remoteRegistrations,
 		DB:                          ds,
 	}, nil

--- a/gestaltd/internal/coredata/services_test.go
+++ b/gestaltd/internal/coredata/services_test.go
@@ -248,6 +248,7 @@ func TestNew(t *testing.T) {
 			coredata.StoreAppVersionChangeRequests,
 			coredata.StoreAppVersionInstallLocks,
 			coredata.StoreAppRollouts,
+			coredata.StoreAppAutoDeploySettings,
 			coredata.StoreRemoteRegistrations,
 			coredata.StoreRemoteProviders,
 		} {


### PR DESCRIPTION
## Summary
- persist per-app auto-deploy settings in IndexedDB with atomic updates and enabled-app lookup
- add conditional registry index reads with ETag / `If-None-Match` and 304 handling
- add validated `server.appRegistry.autoDeployPollInterval` configuration with a one-minute default

This is PR 2 of the auto-deploy work described in #2970. It provides state and transport primitives only; HTTP routes and the background watcher follow in separate PRs based on this branch.

## Test plan
- [x] `go test ./internal/coredata ./internal/appregistry ./internal/config -count=1`
- [x] `GOWORK=off go test ./... -count=1`

Made with [Cursor](https://cursor.com)