### PR TITLE
Restore app-admin auto-deploy API lost in PR 2973 merge

### DIFF
--- a/gestaltd/internal/server/handlers_app_admin_registry.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry.go
@@ -30,8 +30,15 @@ type appAdminRegistryResponse struct {
 	PendingVersions   []appAdminPendingVersion   `json:"pendingVersions,omitempty"`
 	FailedVersions    []appAdminFailedVersion    `json:"failedVersions,omitempty"`
 	Rollout           *appAdminRollout           `json:"rollout,omitempty"`
+	AutoDeploy        appAdminAutoDeploy         `json:"autoDeploy"`
 	SelectionDisabled bool                       `json:"selectionDisabled"`
 	DisabledReason    string                     `json:"disabledReason,omitempty"`
+}
+
+type appAdminAutoDeploy struct {
+	Enabled        bool   `json:"enabled"`
+	PendingVersion string `json:"pendingVersion,omitempty"`
+	LastError      string `json:"lastError,omitempty"`
 }
 
 type appAdminPublishedVersion struct {
@@ -80,6 +87,15 @@ type appAdminRegistryVersionRequest struct {
 	Version string `json:"version"`
 }
 
+type appAdminRegistryAutoDeployRequest struct {
+	Enabled *bool `json:"enabled"`
+}
+
+type appAdminRegistryAutoDeployResponse struct {
+	App        string             `json:"app"`
+	AutoDeploy appAdminAutoDeploy `json:"autoDeploy"`
+}
+
 type appAdminRegistryVersionResponse struct {
 	App            string          `json:"app"`
 	Registry       string          `json:"registry"`
@@ -115,6 +131,8 @@ func (s *Server) mountAppAdminRegistryRoutes(r chi.Router) {
 		Get("/apps/{app}/admin/registry/history", s.getAppAdminRegistryHistory)
 	r.With(s.pluginRouteAuthMiddleware("app"), s.appAdminAuthorizationMiddleware).
 		Post("/apps/{app}/admin/registry/version", s.selectAppAdminRegistryVersion)
+	r.With(s.pluginRouteAuthMiddleware("app"), s.appAdminAuthorizationMiddleware).
+		Put("/apps/{app}/admin/registry/auto-deploy", s.updateAppAdminRegistryAutoDeploy)
 }
 
 func (s *Server) appAdminAuthorizationMiddleware(next http.Handler) http.Handler {
@@ -189,7 +207,15 @@ func (s *Server) getAppAdminRegistry(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if s.appVersionChanges == nil || s.appRollouts == nil {
+	if s.appVersionChanges == nil || s.appRollouts == nil || s.autoDeploySettings == nil {
+		writeError(w, http.StatusServiceUnavailable, "app registry installation services are unavailable")
+		return
+	}
+	autoDeploy := appAdminAutoDeploy{}
+	settings, err := s.autoDeploySettings.Get(r.Context(), app.name)
+	if err == nil {
+		autoDeploy = appAdminAutoDeployFromCore(settings)
+	} else if !errors.Is(err, core.ErrNotFound) {
 		writeError(w, http.StatusServiceUnavailable, "app registry installation services are unavailable")
 		return
 	}
@@ -261,6 +287,7 @@ func (s *Server) getAppAdminRegistry(w http.ResponseWriter, r *http.Request) {
 		PublishedVersions: published,
 		PendingVersions:   pendingVersions,
 		FailedVersions:    failedVersions,
+		AutoDeploy:        autoDeploy,
 	}
 	rollout, err := s.appRollouts.Get(r.Context(), app.name)
 	if err == nil {
@@ -278,6 +305,61 @@ func (s *Server) getAppAdminRegistry(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, response)
+}
+
+func (s *Server) updateAppAdminRegistryAutoDeploy(w http.ResponseWriter, r *http.Request) {
+	app, _, ok := s.appAdminRegistryConfig(w, r)
+	if !ok {
+		return
+	}
+	if s.autoDeploySettings == nil {
+		writeError(w, http.StatusServiceUnavailable, "app registry installation services are unavailable")
+		return
+	}
+	var request appAdminRegistryAutoDeployRequest
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&request); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if request.Enabled == nil {
+		writeError(w, http.StatusBadRequest, "enabled is required")
+		return
+	}
+	settings, err := s.autoDeploySettings.Update(r.Context(), app.name, func(settings *core.AppAutoDeploySettings) error {
+		settings.Enabled = *request.Enabled
+		if settings.Enabled {
+			settings.LastError = ""
+			settings.LastSeenVersion = ""
+		} else {
+			settings.PendingVersion = ""
+		}
+		return nil
+	})
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "app registry installation services are unavailable")
+		return
+	}
+	writeJSON(w, http.StatusOK, appAdminRegistryAutoDeployResponse{
+		App:        app.name,
+		AutoDeploy: appAdminAutoDeployFromCore(settings),
+	})
+}
+
+func appAdminAutoDeployFromCore(settings *core.AppAutoDeploySettings) appAdminAutoDeploy {
+	if settings == nil {
+		return appAdminAutoDeploy{}
+	}
+	return appAdminAutoDeploy{
+		Enabled:        settings.Enabled,
+		PendingVersion: settings.PendingVersion,
+		LastError:      settings.LastError,
+	}
 }
 
 func (s *Server) getAppAdminRegistryHistory(w http.ResponseWriter, r *http.Request) {

--- a/gestaltd/internal/server/handlers_app_admin_registry_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry_test.go
@@ -83,6 +83,9 @@ func TestAppAdminRegistrySelectAndRead(t *testing.T) {
 		DesiredVersion    string `json:"desiredVersion"`
 		SelectionDisabled bool   `json:"selectionDisabled"`
 		DisabledReason    string `json:"disabledReason"`
+		AutoDeploy        struct {
+			Enabled bool `json:"enabled"`
+		} `json:"autoDeploy"`
 		PublishedVersions []struct {
 			SourceRef   string `json:"sourceRef"`
 			SourceURL   string `json:"sourceUrl"`
@@ -97,9 +100,152 @@ func TestAppAdminRegistrySelectAndRead(t *testing.T) {
 	if state.DesiredVersion != fixture.Version || !state.SelectionDisabled || state.DisabledReason != "rollout in progress" {
 		t.Fatalf("registry state = %#v", state)
 	}
+	if state.AutoDeploy.Enabled {
+		t.Fatalf("autoDeploy = %#v, want disabled default", state.AutoDeploy)
+	}
 	if len(state.PublishedVersions) != 1 || state.PublishedVersions[0].SourceRef == "" ||
 		state.PublishedVersions[0].SourceURL == "" || state.PublishedVersions[0].Publication.WorkflowRunURL == "" {
 		t.Fatalf("published versions = %#v", state.PublishedVersions)
+	}
+}
+
+func TestAppAdminRegistryAutoDeploy(t *testing.T) {
+	t.Parallel()
+
+	fixture := registrytest.NewInstallFixture(t)
+	services := testutil.NewStubServices(t)
+	if _, err := services.AutoDeploySettings.Update(context.Background(), "g-issues", func(settings *core.AppAutoDeploySettings) error {
+		settings.PendingVersion = "v2"
+		settings.LastSeenVersion = "v1"
+		settings.LastError = "previous failure"
+		return nil
+	}); err != nil {
+		t.Fatalf("seed auto-deploy settings: %v", err)
+	}
+	subjectID := principal.UserSubjectID("alice")
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(subjectID, "admin", "app", "g-issues"),
+		},
+	}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", subjectID, "")
+		cfg.Authorization = authz
+		cfg.Services = services
+		cfg.AppDefs = map[string]*config.ProviderEntry{
+			"g-issues": {Source: config.ProviderSource{Registry: "toolshed"}},
+		}
+		cfg.AppRegistries = map[string]config.AppRegistryConfig{"toolshed": fixture.Registry}
+		cfg.AppRegistryReader = fixture.Reader
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	update := func(body string, wantStatus int) appAdminAutoDeployTestResponse {
+		t.Helper()
+		request, _ := http.NewRequest(
+			http.MethodPut,
+			ts.URL+"/api/v1/apps/g-issues/admin/registry/auto-deploy",
+			bytes.NewBufferString(body),
+		)
+		request.Header.Set("Authorization", "Bearer alice-token")
+		request.Header.Set("Content-Type", "application/json")
+		response, err := http.DefaultClient.Do(request)
+		if err != nil {
+			t.Fatalf("PUT auto-deploy: %v", err)
+		}
+		defer func() { _ = response.Body.Close() }()
+		if response.StatusCode != wantStatus {
+			responseBody, _ := io.ReadAll(response.Body)
+			t.Fatalf("PUT status = %d, want %d: %s", response.StatusCode, wantStatus, responseBody)
+		}
+		var decoded appAdminAutoDeployTestResponse
+		if wantStatus == http.StatusOK {
+			if err := json.NewDecoder(response.Body).Decode(&decoded); err != nil {
+				t.Fatalf("decode PUT response: %v", err)
+			}
+		}
+		return decoded
+	}
+
+	enabled := update(`{"enabled":true}`, http.StatusOK)
+	if enabled.App != "g-issues" || !enabled.AutoDeploy.Enabled ||
+		enabled.AutoDeploy.PendingVersion != "v2" || enabled.AutoDeploy.LastError != "" {
+		t.Fatalf("enabled response = %#v", enabled)
+	}
+	stored, err := services.AutoDeploySettings.Get(context.Background(), "g-issues")
+	if err != nil {
+		t.Fatalf("Get enabled settings: %v", err)
+	}
+	if stored.LastSeenVersion != "" {
+		t.Fatalf("lastSeenVersion = %q, want reset on enable", stored.LastSeenVersion)
+	}
+
+	request, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/g-issues/admin/registry", nil)
+	request.Header.Set("Authorization", "Bearer alice-token")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET registry state: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		responseBody, _ := io.ReadAll(response.Body)
+		t.Fatalf("GET status = %d: %s", response.StatusCode, responseBody)
+	}
+	var state appAdminAutoDeployTestResponse
+	if err := json.NewDecoder(response.Body).Decode(&state); err != nil {
+		t.Fatalf("decode GET response: %v", err)
+	}
+	if !state.AutoDeploy.Enabled || state.AutoDeploy.PendingVersion != "v2" || state.AutoDeploy.LastError != "" {
+		t.Fatalf("GET autoDeploy = %#v", state.AutoDeploy)
+	}
+
+	disabled := update(`{"enabled":false}`, http.StatusOK)
+	if disabled.AutoDeploy.Enabled || disabled.AutoDeploy.PendingVersion != "" {
+		t.Fatalf("disabled response = %#v", disabled)
+	}
+	update(`{}`, http.StatusBadRequest)
+	update(`{"enabled":true,"unexpected":true}`, http.StatusBadRequest)
+	update(`{"enabled":true} {}`, http.StatusBadRequest)
+}
+
+type appAdminAutoDeployTestResponse struct {
+	App        string `json:"app"`
+	AutoDeploy struct {
+		Enabled        bool   `json:"enabled"`
+		PendingVersion string `json:"pendingVersion"`
+		LastError      string `json:"lastError"`
+	} `json:"autoDeploy"`
+}
+
+func TestAppAdminRegistryAutoDeployRequiresAppAdmin(t *testing.T) {
+	t.Parallel()
+
+	fixture := registrytest.NewInstallFixture(t)
+	subjectID := principal.UserSubjectID("alice")
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", subjectID, "")
+		cfg.Authorization = &serverTestAuthorizationProvider{}
+		cfg.AppDefs = map[string]*config.ProviderEntry{
+			"g-issues": {Source: config.ProviderSource{Registry: "toolshed"}},
+		}
+		cfg.AppRegistries = map[string]config.AppRegistryConfig{"toolshed": fixture.Registry}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	request, _ := http.NewRequest(
+		http.MethodPut,
+		ts.URL+"/api/v1/apps/g-issues/admin/registry/auto-deploy",
+		bytes.NewBufferString(`{"enabled":true}`),
+	)
+	request.Header.Set("Authorization", "Bearer alice-token")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("PUT auto-deploy: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("status = %d, want 403: %s", response.StatusCode, body)
 	}
 }
 

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -160,6 +160,7 @@ type Server struct {
 	gestaltdSourceVersions *coredata.GestaltdSourceVersionService
 	appRollouts            *coredata.AppRolloutService
 	appMaterializations    *coredata.AppInstanceMaterializationService
+	autoDeploySettings     *coredata.AutoDeploySettingsService
 	artifactsDir           string
 	sourceVersion          string
 	appRuntimeState        AppRuntimeState
@@ -416,6 +417,7 @@ func New(cfg Config) (*Server, error) {
 		gestaltdSourceVersions: cfg.Services.GestaltdSourceVersionState,
 		appRollouts:            cfg.Services.AppRollouts,
 		appMaterializations:    cfg.Services.AppInstanceMaterializations,
+		autoDeploySettings:     cfg.Services.AutoDeploySettings,
 		artifactsDir:           strings.TrimSpace(cfg.ArtifactsDir),
 		sourceVersion:          strings.TrimSpace(cfg.SourceVersion),
 		appRuntimeState:        cfg.AppRuntimeState,


### PR DESCRIPTION
## Summary
- Re-applies the app-admin auto-deploy API from #2972 that was dropped when #2973 merged
- Restores `PUT /api/v1/apps/{app}/admin/registry/auto-deploy` and `autoDeploy` projection on `GET …/registry`

## Test plan
- [x] `go test ./internal/server/... -run 'AutoDeploy|AppAdminRegistry'`


Made with [Cursor](https://cursor.com)