### PR TITLE
Fix Python SDK relay token for caller-capability services

### DIFF
--- a/sdk/python/gestalt/_api.py
+++ b/sdk/python/gestalt/_api.py
@@ -123,6 +123,7 @@ class Request:
     host: Host = dataclasses.field(default_factory=Host)
     agent_subject: Subject = dataclasses.field(default_factory=Subject)
     context: Any | None = None
+    relay_token: str = ""
 
     def connection_param(self, name: str) -> str | None:
         """Return a connection parameter by name if the host supplied it."""
@@ -135,7 +136,11 @@ class Request:
 
         from .app import App
 
-        return App.connect(context=self._native_context(), timeout=timeout)
+        return App.connect(
+            context=self._native_context(),
+            timeout=timeout,
+            relay_token=self.relay_token,
+        )
 
     def gestalt(self) -> "BoundGestaltClient":
         """Return the public Gestalt client bound to this request's relay context."""
@@ -150,7 +155,11 @@ class Request:
 
         from .agent import Agent
 
-        return Agent.connect(context=self._native_context(), timeout=timeout)
+        return Agent.connect(
+            context=self._native_context(),
+            timeout=timeout,
+            relay_token=self.relay_token,
+        )
 
     def workflows(self, *, timeout: float | None = None) -> "Workflow":
         from ._workflow import Workflow

--- a/sdk/python/gestalt/_runtime.py
+++ b/sdk/python/gestalt/_runtime.py
@@ -26,7 +26,10 @@ from ._catalog import catalog_to_proto
 from ._codec import authorization as _authorization_codec
 from ._codec import identity as _identity_codec
 from ._codec import s3 as _s3_codec
-from ._grpc_transport import INTERNAL_GRPC_MESSAGE_OPTIONS
+from ._grpc_transport import (
+    _HOST_SERVICE_RELAY_TOKEN_HEADER,
+    INTERNAL_GRPC_MESSAGE_OPTIONS,
+)
 from ._http_subject import HTTPSubjectRequest, HTTPSubjectResolutionError
 from ._operations import INTERNAL_ERROR_MESSAGE, JSON_CONTENT_TYPE
 from ._protocol import string_lists_from_proto_map
@@ -1427,7 +1430,7 @@ def _provider_servicer(*, app: App) -> Any:
                         message=request.params,
                         request=request,
                     ),
-                    _plugin_request(request),
+                    _plugin_request(request, _context),
                 )
             except Exception as error:
                 traceback.print_exception(error)
@@ -1451,7 +1454,7 @@ def _provider_servicer(*, app: App) -> Any:
             try:
                 subject = app.resolve_http_subject(
                     _http_subject_request(getattr(request, "request", None)),
-                    _plugin_request(request),
+                    _plugin_request(request, context),
                 )
             except HTTPSubjectResolutionError as error:
                 return app_pb2.ResolveHTTPSubjectResponse(
@@ -1483,7 +1486,7 @@ def _provider_servicer(*, app: App) -> Any:
                 )
 
             try:
-                catalog = app.catalog_for_request(_plugin_request(request))
+                catalog = app.catalog_for_request(_plugin_request(request, context))
             except Exception as error:
                 return context.abort(
                     grpc.StatusCode.UNKNOWN,
@@ -1896,7 +1899,7 @@ def _cache_servicer(*, provider: AppProvider) -> Any:
     return CacheServicer()
 
 
-def _plugin_request(request: Any) -> Request:
+def _plugin_request(request: Any, grpc_context: Any = None) -> Request:
     request_context = getattr(request, "context", None)
     tool_refs, tool_refs_set = _tool_refs_from_proto(request_context)
     return Request(
@@ -1912,7 +1915,23 @@ def _plugin_request(request: Any) -> Request:
         tool_refs_set=tool_refs_set,
         idempotency_key=getattr(request, "idempotency_key", "").strip(),
         context=request_context,
+        relay_token=_relay_token_from_context(grpc_context),
     )
+
+
+def _relay_token_from_context(grpc_context: Any) -> str:
+    if grpc_context is None:
+        return ""
+    get_metadata = getattr(grpc_context, "invocation_metadata", None)
+    if not callable(get_metadata):
+        return ""
+    try:
+        for key, value in get_metadata():
+            if key.lower() == _HOST_SERVICE_RELAY_TOKEN_HEADER:
+                return str(value).strip()
+    except (TypeError, AttributeError):
+        return ""
+    return ""
 
 
 def _http_subject_request(request: Any) -> HTTPSubjectRequest:

--- a/sdk/python/gestalt/_workflow.py
+++ b/sdk/python/gestalt/_workflow.py
@@ -31,7 +31,6 @@ from ._gen.v1 import workflow_pb2 as _pb
 from ._gen.v1 import workflow_pb2_grpc as _pb_grpc
 from ._grpc_transport import (
     ENV_HOST_SERVICE_SOCKET,
-    ENV_HOST_SERVICE_TOKEN,
     host_service_channel,
 )
 from ._protocol import (
@@ -2382,9 +2381,9 @@ class Workflow:
         target = os.environ.get(ENV_HOST_SERVICE_SOCKET, "")
         if not target:
             raise RuntimeError(f"workflow: {ENV_HOST_SERVICE_SOCKET} is not set")
-        relay_token = os.environ.get(ENV_HOST_SERVICE_TOKEN, "")
-
-        self._channel = host_service_channel("workflow", target, token=relay_token)
+        self._channel = host_service_channel(
+            "workflow", target, token=request.relay_token
+        )
         self._stub = pb_grpc.WorkflowStub(self._channel)
         self._timeout = timeout
         self._context = request.context

--- a/sdk/python/gestalt/agent.py
+++ b/sdk/python/gestalt/agent.py
@@ -16,7 +16,6 @@ from ._codec import support as _support
 from ._gen.v1 import agent_pb2_grpc as _agent_pb2_grpc
 from ._grpc_transport import (
     ENV_HOST_SERVICE_SOCKET,
-    ENV_HOST_SERVICE_TOKEN,
     host_service_channel,
 )
 from .app import AgentToolRef, OperationAnnotations, RequestContext
@@ -557,13 +556,13 @@ class Agent:
         *,
         context: RequestContext | None = None,
         timeout: float | None = None,
+        relay_token: str = "",
     ) -> Agent:
         target = os.environ.get(ENV_HOST_SERVICE_SOCKET, "")
         if not target:
             raise RuntimeError(f"{ENV_HOST_SERVICE_SOCKET} is not set")
-        token = os.environ.get(ENV_HOST_SERVICE_TOKEN, "")
         channel = host_service_channel(
-            "agent", target, token=token.strip(), binding=(name or "").strip()
+            "agent", target, token=relay_token.strip(), binding=(name or "").strip()
         )
         client = cls(channel, context=context, timeout=timeout)
         client._owns_channel = True

--- a/sdk/python/gestalt/app.py
+++ b/sdk/python/gestalt/app.py
@@ -16,7 +16,6 @@ from ._codec import support as _support
 from ._gen.v1 import app_pb2_grpc as _app_pb2_grpc
 from ._grpc_transport import (
     ENV_HOST_SERVICE_SOCKET,
-    ENV_HOST_SERVICE_TOKEN,
     host_service_channel,
 )
 from .invoke_support import decode_app_result
@@ -497,13 +496,13 @@ class App:
         *,
         context: RequestContext | None = None,
         timeout: float | None = None,
+        relay_token: str = "",
     ) -> App:
         target = os.environ.get(ENV_HOST_SERVICE_SOCKET, "")
         if not target:
             raise RuntimeError(f"{ENV_HOST_SERVICE_SOCKET} is not set")
-        token = os.environ.get(ENV_HOST_SERVICE_TOKEN, "")
         channel = host_service_channel(
-            "app", target, token=token.strip(), binding=(name or "").strip()
+            "app", target, token=relay_token.strip(), binding=(name or "").strip()
         )
         client = cls(channel, context=context, timeout=timeout)
         client._owns_channel = True

--- a/sdk/python/gestalt/public/bound.py
+++ b/sdk/python/gestalt/public/bound.py
@@ -12,7 +12,6 @@ from gestalt._api import native_request_context
 from gestalt._codec.app import to_wire_request_context
 from gestalt._grpc_transport import (
     ENV_HOST_SERVICE_SOCKET,
-    ENV_HOST_SERVICE_TOKEN,
     host_service_channel,
 )
 
@@ -43,8 +42,8 @@ def gestalt_from_request(
     target = os.environ.get(ENV_HOST_SERVICE_SOCKET, "").strip()
     if not target:
         raise RuntimeError(f"{ENV_HOST_SERVICE_SOCKET} is not set")
-    token = os.environ.get(ENV_HOST_SERVICE_TOKEN, "").strip()
-    channel = host_service_channel("app", target, token=token)
+    relay_token = getattr(request, "relay_token", "").strip()
+    channel = host_service_channel("app", target, token=relay_token)
     native = native_request_context(getattr(request, "context", None))
     wire_context = to_wire_request_context(native) if native is not None else None
     resolved_caller = caller_bearer_token.strip() or getattr(request, "token", "")

--- a/sdk/python/tests/test_agent_transport.py
+++ b/sdk/python/tests/test_agent_transport.py
@@ -24,7 +24,6 @@ from gestalt import (
     AGENT_SESSION_STATE_ACTIVE,
     AGENT_SESSION_STATE_ARCHIVED,
     ENV_HOST_SERVICE_SOCKET,
-    ENV_HOST_SERVICE_TOKEN,
     AgentInteraction,
     AgentMessage,
     AgentMessagePart,
@@ -552,7 +551,6 @@ def setUpModule() -> None:
 
     for env_name, value in {
         ENV_HOST_SERVICE_SOCKET: _host_socket,
-        ENV_HOST_SERVICE_TOKEN: "relay-token-py",
     }.items():
         _previous_envs[env_name] = os.environ.get(env_name)
         os.environ[env_name] = value
@@ -792,7 +790,8 @@ class AgentTransportTests(unittest.TestCase):
         request = Request(
             context=app_pb2.RequestContext(
                 subject=app_pb2.SubjectContext(id="user:request-agent")
-            )
+            ),
+            relay_token="relay-token-py",
         )
 
         manager = request.agent()
@@ -872,7 +871,7 @@ class AgentTransportTests(unittest.TestCase):
         )
 
     def test_agent_accepts_native_message_metadata(self) -> None:
-        manager = genagent.Agent.connect()
+        manager = genagent.Agent.connect(relay_token="relay-token-py")
         created_turn = manager.create_turn(
             session_id="session-managed-1",
             model="gpt-5.1",

--- a/sdk/python/tests/test_app_transport.py
+++ b/sdk/python/tests/test_app_transport.py
@@ -14,7 +14,6 @@ from google.protobuf import json_format
 
 from gestalt import (
     ENV_HOST_SERVICE_SOCKET,
-    ENV_HOST_SERVICE_TOKEN,
     InvokeError,
     Request,
 )
@@ -369,7 +368,7 @@ class AppTransportTests(unittest.TestCase):
             ],
         )
 
-    def test_tcp_target_token_env_is_forwarded(self) -> None:
+    def test_tcp_target_forwards_relay_token(self) -> None:
         tcp_server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
         app_pb2_grpc.add_AppServicer_to_server(
             _AppServicer(),
@@ -378,11 +377,9 @@ class AppTransportTests(unittest.TestCase):
         port = tcp_server.add_insecure_port("127.0.0.1:0")
         tcp_server.start()
         previous_socket = os.environ.get(ENV_HOST_SERVICE_SOCKET)
-        previous_token = os.environ.get(ENV_HOST_SERVICE_TOKEN)
         os.environ[ENV_HOST_SERVICE_SOCKET] = f"tcp://127.0.0.1:{port}"
-        os.environ[ENV_HOST_SERVICE_TOKEN] = "relay-token-python"
         try:
-            client = App.connect()
+            client = App.connect(relay_token="relay-token-python")
             response = client.invoke_raw(
                 AppInvokeRequest(app="github", operation="plain_text")
             )
@@ -395,10 +392,6 @@ class AppTransportTests(unittest.TestCase):
                 os.environ.pop(ENV_HOST_SERVICE_SOCKET, None)
             else:
                 os.environ[ENV_HOST_SERVICE_SOCKET] = previous_socket
-            if previous_token is None:
-                os.environ.pop(ENV_HOST_SERVICE_TOKEN, None)
-            else:
-                os.environ[ENV_HOST_SERVICE_TOKEN] = previous_token
             tcp_server.stop(grace=0).wait()
 
     def test_tcp_target_ignores_proxy_env(self) -> None:
@@ -410,15 +403,13 @@ class AppTransportTests(unittest.TestCase):
         port = tcp_server.add_insecure_port("127.0.0.1:0")
         tcp_server.start()
         previous_socket = os.environ.get(ENV_HOST_SERVICE_SOCKET)
-        previous_token = os.environ.get(ENV_HOST_SERVICE_TOKEN)
         previous_http_proxy = os.environ.get("http_proxy")
         previous_https_proxy = os.environ.get("https_proxy")
         os.environ[ENV_HOST_SERVICE_SOCKET] = f"tcp://127.0.0.1:{port}"
-        os.environ[ENV_HOST_SERVICE_TOKEN] = "relay-token-python"
         os.environ["http_proxy"] = "http://127.0.0.1:1"
         os.environ["https_proxy"] = "http://127.0.0.1:1"
         try:
-            client = App.connect()
+            client = App.connect(relay_token="relay-token-python")
             response = client.invoke_raw(
                 AppInvokeRequest(app="github", operation="plain_text")
             )
@@ -431,10 +422,6 @@ class AppTransportTests(unittest.TestCase):
                 os.environ.pop(ENV_HOST_SERVICE_SOCKET, None)
             else:
                 os.environ[ENV_HOST_SERVICE_SOCKET] = previous_socket
-            if previous_token is None:
-                os.environ.pop(ENV_HOST_SERVICE_TOKEN, None)
-            else:
-                os.environ[ENV_HOST_SERVICE_TOKEN] = previous_token
             if previous_http_proxy is None:
                 os.environ.pop("http_proxy", None)
             else:

--- a/sdk/python/tests/test_runtime.py
+++ b/sdk/python/tests/test_runtime.py
@@ -324,6 +324,30 @@ class RequestTests(unittest.TestCase):
         self.assertEqual(request.idempotency_key, "")
         self.assertIsNone(request.context)
 
+    def test_relay_token_defaults_to_empty(self) -> None:
+        request = Request()
+        self.assertEqual(request.relay_token, "")
+
+    def test_plugin_request_extracts_relay_token_from_grpc_metadata(self) -> None:
+        from gestalt._gen.v1 import app_pb2
+        from gestalt._runtime import _plugin_request
+
+        context = mock.Mock()
+        context.invocation_metadata = mock.Mock(
+            return_value=[("x-gestalt-host-service-relay-token", "invocation-token")]
+        )
+        request = _plugin_request(app_pb2.ExecuteRequest(operation="op"), context)
+
+        self.assertEqual(request.relay_token, "invocation-token")
+
+    def test_plugin_request_relay_token_empty_without_metadata(self) -> None:
+        from gestalt._gen.v1 import app_pb2
+        from gestalt._runtime import _plugin_request
+
+        request = _plugin_request(app_pb2.ExecuteRequest(operation="op"), None)
+
+        self.assertEqual(request.relay_token, "")
+
 
 class MainEntrypointTests(unittest.TestCase):
     def test_writes_catalog_when_env_is_set(self) -> None:

--- a/sdk/python/tests/test_workflow_transport.py
+++ b/sdk/python/tests/test_workflow_transport.py
@@ -12,7 +12,6 @@ import grpc
 
 from gestalt import (
     ENV_HOST_SERVICE_SOCKET,
-    ENV_HOST_SERVICE_TOKEN,
     BoundWorkflowTarget,
     Request,
     Workflow,
@@ -167,7 +166,6 @@ def setUpModule() -> None:
     _server.start()
 
     os.environ[ENV_HOST_SERVICE_SOCKET] = _socket_path
-    os.environ[ENV_HOST_SERVICE_TOKEN] = "relay-token-py"
 
 
 def tearDownModule() -> None:
@@ -197,7 +195,8 @@ class WorkflowTransportTests(unittest.TestCase):
             Request(
                 context=app_pb2.RequestContext(
                     subject=app_pb2.SubjectContext(id="user:workflow-direct")
-                )
+                ),
+                relay_token="relay-token-py",
             )
         ) as manager:
             delivered = manager.deliver_event(
@@ -232,6 +231,7 @@ class WorkflowTransportTests(unittest.TestCase):
                 subject=app_pb2.SubjectContext(id="user:workflow-request")
             ),
             idempotency_key="workflow-request-key-py",
+            relay_token="relay-token-py",
         )
 
         with request.workflows() as manager:


### PR DESCRIPTION
## Summary

- PR #2820 added caller-capability requirements for Workflow, App, Agent, and Identity host services in gestaltd. The TypeScript SDK was updated with `request.gestalt()` to pass a per-invocation relay token extracted from the incoming gRPC metadata, but the Python SDK was left reading the process-level `GESTALT_HOST_SERVICE_TOKEN` env var, which carries no Caller claims.
- This caused every Python provider callback to a caller-dependent service to fail with `StatusCode.UNAUTHENTICATED: invalid-host-service-relay-token`. The error was masked first by `Stream removed` (June 30) and then by the `TypeError` in the GitHub provider (two weeks), surfacing only after both were fixed.
- Extract the per-invocation relay token from the incoming gRPC metadata (`x-gestalt-host-service-relay-token` header) in the `Execute`/`ResolveHTTPSubject`/`GetSessionCatalog` handlers and store it on `Request.relay_token`. `Workflow`, `App`, `Agent`, and the bound gestalt client now use `request.relay_token` directly instead of reading the env var, matching the TypeScript SDK `request.gestalt()` pattern.

## Test plan

- [x] `uv run python -m pytest tests/` — 222 passed
- [x] New tests verify `_plugin_request` extracts the relay token from gRPC metadata
- [ ] Deploy to prod and verify webhook deliveries succeed (no more `invalid-host-service-relay-token`)

Generated with [Devin](https://devin.ai)