### PR TITLE
Wake auto-deploy controller on toggle

### DIFF
--- a/gestaltd/internal/server/handlers_app_admin_registry.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry.go
@@ -345,6 +345,7 @@ func (s *Server) updateAppAdminRegistryAutoDeploy(w http.ResponseWriter, r *http
 		writeError(w, http.StatusServiceUnavailable, "app registry installation services are unavailable")
 		return
 	}
+	s.notifyAppAutoDeploy(app.name)
 	writeJSON(w, http.StatusOK, appAdminRegistryAutoDeployResponse{
 		App:        app.name,
 		AutoDeploy: appAdminAutoDeployFromCore(settings),
@@ -360,6 +361,17 @@ func appAdminAutoDeployFromCore(settings *core.AppAutoDeploySettings) appAdminAu
 		PendingVersion: settings.PendingVersion,
 		LastError:      settings.LastError,
 	}
+}
+
+func (s *Server) notifyAppAutoDeploy(app string) {
+	if s == nil || s.appAutoDeployNotify == nil {
+		return
+	}
+	app = strings.TrimSpace(app)
+	if app == "" {
+		return
+	}
+	s.appAutoDeployNotify(app)
 }
 
 func (s *Server) getAppAdminRegistryHistory(w http.ResponseWriter, r *http.Request) {

--- a/gestaltd/internal/server/handlers_app_admin_registry_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry_test.go
@@ -208,6 +208,63 @@ func TestAppAdminRegistryAutoDeploy(t *testing.T) {
 	update(`{"enabled":true} {}`, http.StatusBadRequest)
 }
 
+func TestAppAdminRegistryAutoDeployNotifies(t *testing.T) {
+	t.Parallel()
+
+	fixture := registrytest.NewInstallFixture(t)
+	services := testutil.NewStubServices(t)
+	subjectID := principal.UserSubjectID("alice")
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(subjectID, "admin", "app", "g-issues"),
+		},
+	}
+	notified := make(chan string, 1)
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", subjectID, "")
+		cfg.Authorization = authz
+		cfg.Services = services
+		cfg.AppDefs = map[string]*config.ProviderEntry{
+			"g-issues": {Source: config.ProviderSource{Registry: "toolshed"}},
+		}
+		cfg.AppRegistries = map[string]config.AppRegistryConfig{"toolshed": fixture.Registry}
+		cfg.AppRegistryReader = fixture.Reader
+		cfg.AppAutoDeployNotify = func(app string) {
+			select {
+			case notified <- app:
+			default:
+			}
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	request, _ := http.NewRequest(
+		http.MethodPut,
+		ts.URL+"/api/v1/apps/g-issues/admin/registry/auto-deploy",
+		bytes.NewBufferString(`{"enabled":true}`),
+	)
+	request.Header.Set("Authorization", "Bearer alice-token")
+	request.Header.Set("Content-Type", "application/json")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("PUT auto-deploy: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("PUT status = %d, want 200: %s", response.StatusCode, body)
+	}
+
+	select {
+	case app := <-notified:
+		if app != "g-issues" {
+			t.Fatalf("notified app = %q, want g-issues", app)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected auto-deploy notify after toggle update")
+	}
+}
+
 type appAdminAutoDeployTestResponse struct {
 	App        string `json:"app"`
 	AutoDeploy struct {

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -162,6 +162,7 @@ func run(ctx context.Context, cfg *config.Config, result *bootstrap.Result, gest
 	var onRolloutTerminal func(string)
 	if autoDeployController != nil {
 		onRolloutTerminal = autoDeployController.Notify
+		baseConfig.AppAutoDeployNotify = autoDeployController.Notify
 	}
 	catalogPoller := startAppRegistryCatalogPoller(ctx, cfg, result, restartDelay, disableRestartDelay, onRolloutTerminal)
 	if catalogPoller != nil {

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -161,6 +161,7 @@ type Server struct {
 	appRollouts            *coredata.AppRolloutService
 	appMaterializations    *coredata.AppInstanceMaterializationService
 	autoDeploySettings     *coredata.AutoDeploySettingsService
+	appAutoDeployNotify    func(string)
 	artifactsDir           string
 	sourceVersion          string
 	appRuntimeState        AppRuntimeState
@@ -229,6 +230,8 @@ type Config struct {
 	RemoteManagement       proto.RemoteManagementServer
 	FrpsHandler            http.Handler
 	FrpsConnectHandler     http.Handler
+	// AppAutoDeployNotify requests prompt auto-deploy reconciliation for an app.
+	AppAutoDeployNotify func(app string)
 }
 
 func New(cfg Config) (*Server, error) {
@@ -418,6 +421,7 @@ func New(cfg Config) (*Server, error) {
 		appRollouts:            cfg.Services.AppRollouts,
 		appMaterializations:    cfg.Services.AppInstanceMaterializations,
 		autoDeploySettings:     cfg.Services.AutoDeploySettings,
+		appAutoDeployNotify:    cfg.AppAutoDeployNotify,
 		artifactsDir:           strings.TrimSpace(cfg.ArtifactsDir),
 		sourceVersion:          strings.TrimSpace(cfg.SourceVersion),
 		appRuntimeState:        cfg.AppRuntimeState,


### PR DESCRIPTION
## Summary
- After a successful `PUT /api/v1/apps/{app}/admin/registry/auto-deploy`, notify the background auto-deploy controller to reconcile immediately
- Wire `autoDeployController.Notify` into the HTTP server via `Config.AppAutoDeployNotify`
- Matches the design doc: enabling should run coalescing once instead of waiting up to the 1-minute poll interval

## Test plan
- [x] `go test ./internal/server/... -run TestAppAdminRegistryAutoDeploy`
- [ ] Enable auto-deploy on g-issues — newest snapshot should queue/deploy without waiting for poll


Made with [Cursor](https://cursor.com)