### PR TITLE
Ensure auto-deploy settings store exists before writes

### DIFF
--- a/gestaltd/internal/coredata/app_auto_deploy_settings.go
+++ b/gestaltd/internal/coredata/app_auto_deploy_settings.go
@@ -25,6 +25,15 @@ func NewAutoDeploySettingsService(ds indexeddb.IndexedDB) *AutoDeploySettingsSer
 	}
 }
 
+// EnsureStore idempotently creates the app_auto_deploy_settings object store.
+// Existing deployments may have started before the store was added to bootstrap.
+func (s *AutoDeploySettingsService) EnsureStore(ctx context.Context) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("ensure app auto-deploy settings store: service is not configured")
+	}
+	return ensureAppAutoDeploySettingsStore(ctx, s.db)
+}
+
 func (s *AutoDeploySettingsService) Get(ctx context.Context, app string) (*core.AppAutoDeploySettings, error) {
 	if s == nil {
 		return nil, fmt.Errorf("get app auto-deploy settings: service is not configured")
@@ -74,6 +83,9 @@ func (s *AutoDeploySettingsService) Update(
 	}
 	if update == nil {
 		return nil, fmt.Errorf("update app auto-deploy settings: update function is required")
+	}
+	if err := s.EnsureStore(ctx); err != nil {
+		return nil, err
 	}
 
 	tx, err := s.db.Transaction(

--- a/gestaltd/internal/coredata/app_auto_deploy_settings_test.go
+++ b/gestaltd/internal/coredata/app_auto_deploy_settings_test.go
@@ -24,6 +24,14 @@ func TestAutoDeploySettingsService(t *testing.T) {
 		}
 	})
 
+	t.Run("ensure store", func(t *testing.T) {
+		t.Parallel()
+		svc := testutil.NewStubServices(t).AutoDeploySettings
+		if err := svc.EnsureStore(ctx); err != nil {
+			t.Fatalf("EnsureStore: %v", err)
+		}
+	})
+
 	t.Run("update initializes and round trips", func(t *testing.T) {
 		t.Parallel()
 		svc := testutil.NewStubServices(t).AutoDeploySettings

--- a/gestaltd/internal/coredata/services.go
+++ b/gestaltd/internal/coredata/services.go
@@ -75,6 +75,8 @@ func NewWithOptions(ctx context.Context, ds indexeddb.IndexedDB, opts NewOptions
 		if _, err := ds.CreateObjectStore(ctx, StoreRemoteProviders, RemoteProvidersSchema); err != nil {
 			return nil, fmt.Errorf("create remote_providers store: %w", err)
 		}
+	} else if err := ensureAppAutoDeploySettingsStore(ctx, ds); err != nil {
+		return nil, err
 	}
 	users := NewUserService(ds)
 	managedSubjects := NewManagedSubjectService(ds)
@@ -106,4 +108,11 @@ func (s *Services) Ping(ctx context.Context) error {
 
 func (s *Services) Close() error {
 	return s.DB.Close()
+}
+
+func ensureAppAutoDeploySettingsStore(ctx context.Context, ds indexeddb.IndexedDB) error {
+	if _, err := ds.CreateObjectStore(ctx, StoreAppAutoDeploySettings, AppAutoDeploySettingsSchema); err != nil {
+		return fmt.Errorf("ensure app_auto_deploy_settings store: %w", err)
+	}
+	return nil
 }

--- a/gestaltd/internal/coredata/services_test.go
+++ b/gestaltd/internal/coredata/services_test.go
@@ -270,8 +270,12 @@ func TestNew(t *testing.T) {
 		if _, err := coredata.NewWithOptions(context.Background(), db, coredata.NewOptions{SkipSchemaBootstrap: true}); err != nil {
 			t.Fatalf("coredata.NewWithOptions: %v", err)
 		}
-		if len(db.createdStoreContexts()) != 0 {
-			t.Fatalf("CreateObjectStore calls = %d, want 0", len(db.createdStoreContexts()))
+		contexts := db.createdStoreContexts()
+		if len(contexts) != 1 {
+			t.Fatalf("CreateObjectStore calls = %d, want 1", len(contexts))
+		}
+		if _, ok := contexts[coredata.StoreAppAutoDeploySettings]; !ok {
+			t.Fatalf("CreateObjectStore calls = %v, want only %q", contexts, coredata.StoreAppAutoDeploySettings)
 		}
 	})
 

--- a/gestaltd/internal/server/handlers_app_admin_registry.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -316,6 +317,11 @@ func (s *Server) updateAppAdminRegistryAutoDeploy(w http.ResponseWriter, r *http
 		writeError(w, http.StatusServiceUnavailable, "app registry installation services are unavailable")
 		return
 	}
+	if err := s.autoDeploySettings.EnsureStore(r.Context()); err != nil {
+		slog.Error("app admin auto-deploy store unavailable", "app", app.name, "error", err)
+		writeError(w, http.StatusServiceUnavailable, "app registry installation services are unavailable")
+		return
+	}
 	var request appAdminRegistryAutoDeployRequest
 	decoder := json.NewDecoder(r.Body)
 	decoder.DisallowUnknownFields()
@@ -342,6 +348,7 @@ func (s *Server) updateAppAdminRegistryAutoDeploy(w http.ResponseWriter, r *http
 		return nil
 	})
 	if err != nil {
+		slog.Error("app admin auto-deploy update failed", "app", app.name, "error", err)
 		writeError(w, http.StatusServiceUnavailable, "app registry installation services are unavailable")
 		return
 	}


### PR DESCRIPTION
## Summary
- ensure `app_auto_deploy_settings` is created on startup even when schema bootstrap is skipped (remote IndexedDB)
- call `EnsureStore` before auto-deploy updates so toggles work on existing deployments
- log underlying errors when auto-deploy PUT fails (503 today with no detail)

Fixes production auto-deploy toggle returning "app registry installation services are unavailable".

## Test plan
- [x] `go test ./internal/coredata ./internal/server -run 'TestAutoDeploy|TestServices|TestAppAdminRegistryAutoDeploy' -count=1`

Made with [Cursor](https://cursor.com)