### PR TITLE
Keep transaction stream open after NotFound/AlreadyExists

### DIFF
--- a/gestaltd/rpc/indexeddb/client.go
+++ b/gestaltd/rpc/indexeddb/client.go
@@ -2,6 +2,7 @@ package indexeddb
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -481,6 +482,10 @@ func (tx *hostTx) sendOperation(op *proto.TransactionOperation) (*proto.Transact
 		return nil, tx.failLocked(fmt.Errorf("indexeddb: response request id %d does not match %d", opResp.GetRequestId(), op.GetRequestId()))
 	}
 	if err := rpcStatusErr(opResp.GetError()); err != nil {
+		if errors.Is(err, idb.ErrNotFound) && isReadOperation(op) {
+			tx.mu.Unlock()
+			return nil, err
+		}
 		tx.done = true
 		tx.err = err
 		tx.mu.Unlock()
@@ -489,6 +494,19 @@ func (tx *hostTx) sendOperation(op *proto.TransactionOperation) (*proto.Transact
 	}
 	tx.mu.Unlock()
 	return opResp, nil
+}
+
+func isReadOperation(op *proto.TransactionOperation) bool {
+	switch op.GetOperation().(type) {
+	case *proto.TransactionOperation_Get, *proto.TransactionOperation_GetKey,
+		*proto.TransactionOperation_GetAll, *proto.TransactionOperation_GetAllKeys,
+		*proto.TransactionOperation_IndexGet, *proto.TransactionOperation_IndexGetKey,
+		*proto.TransactionOperation_IndexGetAll, *proto.TransactionOperation_IndexGetAllKeys,
+		*proto.TransactionOperation_Count, *proto.TransactionOperation_IndexCount:
+		return true
+	default:
+		return false
+	}
 }
 
 func (tx *hostTx) failLocked(err error) error {

--- a/gestaltd/services/indexeddb/server.go
+++ b/gestaltd/services/indexeddb/server.go
@@ -441,6 +441,14 @@ func (s *indexedDBServer) Transaction(stream proto.IndexedDB_TransactionServer) 
 		case *proto.TransactionClientMessage_Operation:
 			resp, opErr := s.executeTransactionOperation(stream.Context(), tx, body.Operation)
 			if opErr != nil {
+				if isReadOperation(body.Operation) && errors.Is(opErr, idb.ErrNotFound) && !isTransactionStoreDenied(opErr) {
+					if err := stream.Send(&proto.TransactionServerMessage{
+						Msg: &proto.TransactionServerMessage_Operation{Operation: transactionOperationError(body.Operation.GetRequestId(), opErr)},
+					}); err != nil {
+						return err
+					}
+					continue
+				}
 				finished = true
 				abortErr := tx.Abort(stream.Context())
 				if err := stream.Send(&proto.TransactionServerMessage{
@@ -480,6 +488,19 @@ func (s *indexedDBServer) Transaction(stream proto.IndexedDB_TransactionServer) 
 	}
 }
 
+func isReadOperation(op *proto.TransactionOperation) bool {
+	switch op.GetOperation().(type) {
+	case *proto.TransactionOperation_Get, *proto.TransactionOperation_GetKey,
+		*proto.TransactionOperation_GetAll, *proto.TransactionOperation_GetAllKeys,
+		*proto.TransactionOperation_IndexGet, *proto.TransactionOperation_IndexGetKey,
+		*proto.TransactionOperation_IndexGetAll, *proto.TransactionOperation_IndexGetAllKeys,
+		*proto.TransactionOperation_Count, *proto.TransactionOperation_IndexCount:
+		return true
+	default:
+		return false
+	}
+}
+
 func drainTransactionStream(stream proto.IndexedDB_TransactionServer) error {
 	for {
 		_, err := stream.Recv()
@@ -492,6 +513,12 @@ func drainTransactionStream(stream proto.IndexedDB_TransactionServer) error {
 	}
 }
 
+var errTransactionStoreDenied = errors.New("indexeddb: transaction store denied")
+
+func isTransactionStoreDenied(err error) bool {
+	return errors.Is(err, errTransactionStoreDenied)
+}
+
 func (s *indexedDBServer) transactionStores(stores []string) ([]string, error) {
 	if len(stores) == 0 {
 		return nil, idb.ErrInvalidTransaction
@@ -499,7 +526,7 @@ func (s *indexedDBServer) transactionStores(stores []string) ([]string, error) {
 	out := make([]string, len(stores))
 	for i, store := range stores {
 		if err := s.ensureAllowedStore(store); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: %w", errTransactionStoreDenied, err)
 		}
 		out[i] = s.storeName(store)
 	}
@@ -508,7 +535,7 @@ func (s *indexedDBServer) transactionStores(stores []string) ([]string, error) {
 
 func (s *indexedDBServer) transactionObjectStore(tx idb.Transaction, name string) (idb.TransactionObjectStore, error) {
 	if err := s.ensureAllowedStore(name); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %w", errTransactionStoreDenied, err)
 	}
 	return tx.ObjectStore(s.storeName(name)), nil
 }


### PR DESCRIPTION
## Problem

The gRPC transaction client and server both killed the transaction on **any** operation error, including `ErrNotFound` from a `Get` on an empty store. Per the [W3C IndexedDB spec](https://www.w3.org/TR/IndexedDB/#object-store-interface), `get()` on a missing key is a successful operation that returns `undefined` — the transaction stays alive and subsequent operations work normally.

**Client** (`hostTx.sendOperation`): set `tx.done = true` and closed the gRPC stream on `NotFound`. The next operation (e.g. `Put`) failed with `indexeddb: not found` because `sendOperation` saw `tx.done == true` and returned the stale error without sending anything.

**Server** (`indexedDBServer.Transaction`): aborted the underlying transaction and sent an `Abort` message after any operation error. Even if the client kept the stream open, the next `Recv` would see the `Abort` instead of an operation response.

This caused the reverse tunnel publication (`gestaltd serve --remote`) to fail with:
```
reverse publication failed: create remote on default: remote management datastore: replace remote registration: store registration: indexeddb: not found
```

The `Replace` method in `remote_registrations.go` calls `getRegistrationByID` (which expects `ErrNotFound` on an empty store and returns `nil, nil`), then calls `Put` on the same transaction. With the stream killed by the `Get`, the `Put` never reached the provider.

## Fix

Both sides now treat `ErrNotFound` from **read operations** (`Get`, `GetKey`, `GetAll`, `GetAllKeys`, `IndexGet*`, `Count`) as a non-fatal per-operation result:

- **Server**: sends the error response and continues the stream loop (does not abort)
- **Client**: returns the error without setting `tx.done` or closing the stream

`ErrNotFound` from **write operations** (`Put`, `Add`, `Delete`) and all other errors (`ErrAlreadyExists`, `Internal`, `FailedPrecondition`, etc.) still abort the transaction as before.

### Allowlist/scope denials

`ErrNotFound` is also used by `ensureAllowedStore` for allowlist denials and by `transactionObjectStore` for out-of-scope store access. To prevent these from being treated as non-fatal, the server wraps allowlist/scope errors with an `errTransactionStoreDenied` sentinel. The transaction handler checks `!isTransactionStoreDenied(opErr)` before continuing the stream, so a `Get` on a disallowed or out-of-scope store still aborts the transaction. The sentinel wraps `idb.ErrNotFound`, so the client still sees `ErrNotFound` for these cases (preserving existing test expectations).

## Testing

- `TestStubTransactionAbortsOnOperationError` — passes (constraint violation from `Add` aborts)
- `TestIndexedDBServerRejectsStoresOutsideAllowlist/transaction_aborts_on_disallowed_store_mid_flight` — passes (`ErrNotFound` from `Put` on disallowed store aborts; `errTransactionStoreDenied` wrapper prevents `Get` on disallowed store from being non-fatal)
- `TestIndexedDBTransactionPreservesSentinelErrors` — passes
- All `rpc/indexeddb`, `services/indexeddb`, and `core/testing` tests pass