### PR TITLE
Normalize provider errors before NotFound check in transaction handler

### DIFF
--- a/gestaltd/services/indexeddb/server.go
+++ b/gestaltd/services/indexeddb/server.go
@@ -441,9 +441,10 @@ func (s *indexedDBServer) Transaction(stream proto.IndexedDB_TransactionServer) 
 		case *proto.TransactionClientMessage_Operation:
 			resp, opErr := s.executeTransactionOperation(stream.Context(), tx, body.Operation)
 			if opErr != nil {
-				if isReadOperation(body.Operation) && errors.Is(opErr, idb.ErrNotFound) && !isTransactionStoreDenied(opErr) {
+				normalizedErr := idb.RPCError(opErr)
+				if isReadOperation(body.Operation) && errors.Is(normalizedErr, idb.ErrNotFound) && !isTransactionStoreDenied(opErr) {
 					if err := stream.Send(&proto.TransactionServerMessage{
-						Msg: &proto.TransactionServerMessage_Operation{Operation: transactionOperationError(body.Operation.GetRequestId(), opErr)},
+						Msg: &proto.TransactionServerMessage_Operation{Operation: transactionOperationError(body.Operation.GetRequestId(), normalizedErr)},
 					}); err != nil {
 						return err
 					}


### PR DESCRIPTION
## Problem

PR #2978 added a check in the transaction handler to keep the stream open after `ErrNotFound` from read operations. But the check used `errors.Is(opErr, idb.ErrNotFound)`, while the relationaldb provider returns `status.Error(codes.NotFound, "not found")` for missing keys — a gRPC status error, not `idb.ErrNotFound`. The `errors.Is` check always failed, so the handler fell through to the abort path even for read operations.

## Fix

Map `opErr` through `idb.RPCError` before the `errors.Is` check. `RPCError` converts `codes.NotFound` to `idb.ErrNotFound`, so the check succeeds. The normalized error is also sent to the client so it receives a consistent `ErrNotFound`.