### PR TITLE
Allow generic artifacts in app registry publish

### DIFF
--- a/gestaltd/internal/daemon/provider_package.go
+++ b/gestaltd/internal/daemon/provider_package.go
@@ -266,11 +266,11 @@ func resolveReleaseBuild(root string, manifest *providermanifestv1.Manifest) (*p
 }
 
 func resolveReleaseBuildPlatforms(root string, manifest *providermanifestv1.Manifest, build *providerpkg.ResolvedSourceReleaseBuild, value string, explicit bool) ([]releasePlatform, error) {
-	if build == nil {
+	if build == nil && !explicit {
 		return nil, nil
 	}
 
-	buildRequired := build.Mode.RequiresPlatformBuild() || providerpkg.ReleaseRequiresBuild(manifest)
+	buildRequired := build != nil && (build.Mode.RequiresPlatformBuild() || providerpkg.ReleaseRequiresBuild(manifest))
 	if !buildRequired && !explicit {
 		return nil, nil
 	}

--- a/gestaltd/internal/daemon/provider_release_finalize.go
+++ b/gestaltd/internal/daemon/provider_release_finalize.go
@@ -206,7 +206,7 @@ func inspectReleaseArchive(archivePath string) (*providermanifestv1.Manifest, st
 	if err != nil {
 		return nil, "", fmt.Errorf("inspect release archive %s: %w", filepath.Base(archivePath), err)
 	}
-	target, err := releaseArchiveTargetFromManifest(manifest)
+	target, err := releaseArchiveTargetFromManifest(manifest, filepath.Base(archivePath))
 	if err != nil {
 		return nil, "", fmt.Errorf("release archive %s: %w", filepath.Base(archivePath), err)
 	}
@@ -226,7 +226,7 @@ func comparableProviderReleaseManifest(manifest *providermanifestv1.Manifest) ([
 	return json.Marshal(cloned)
 }
 
-func releaseArchiveTargetFromManifest(manifest *providermanifestv1.Manifest) (string, error) {
+func releaseArchiveTargetFromManifest(manifest *providermanifestv1.Manifest, archiveName string) (string, error) {
 	if manifest == nil {
 		return "", fmt.Errorf("manifest is required")
 	}
@@ -244,10 +244,45 @@ func releaseArchiveTargetFromManifest(manifest *providermanifestv1.Manifest) (st
 		}
 		target = candidate
 	}
-	if target == "" {
-		return providerrelease.GenericTarget, nil
+	if target != "" {
+		return target, nil
 	}
-	return target, nil
+
+	// Declarative and UI-only providers ship the same manifest on every platform;
+	// the archive filename carries the platform suffix produced by provider package.
+	if target, ok := releaseArchiveTargetFromName(manifest, archiveName); ok {
+		return target, nil
+	}
+	return providerrelease.GenericTarget, nil
+}
+
+func releaseArchiveTargetFromName(manifest *providermanifestv1.Manifest, archiveName string) (string, bool) {
+	if manifest == nil || strings.TrimSpace(manifest.Source) == "" || strings.TrimSpace(manifest.Version) == "" {
+		return "", false
+	}
+	src, err := source.Parse(manifest.Source)
+	if err != nil {
+		return "", false
+	}
+	appName := src.AppName()
+	base := strings.TrimSuffix(archiveName, ".tar.gz")
+	generic := fmt.Sprintf("gestalt-app-%s_v%s", appName, manifest.Version)
+	if base == generic {
+		return "", false
+	}
+	prefix := generic + "_"
+	if !strings.HasPrefix(base, prefix) {
+		return "", false
+	}
+	suffix := strings.TrimPrefix(base, prefix)
+	if strings.Count(suffix, "_") != 1 {
+		return "", false
+	}
+	platform := strings.ReplaceAll(suffix, "_", "/")
+	if _, _, err := packageio.ParsePlatformString(platform); err != nil {
+		return "", false
+	}
+	return platform, true
 }
 
 func writeProviderReleaseMetadata(dir string, manifest *providermanifestv1.Manifest, version string, archives []releaseArchive, rawManifest []byte, verbose bool) error {

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,11 +1,10 @@
-cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
 cloud.google.com/go v0.26.0 h1:e0WKqKTd5BnrG8aKH3J3h+QvEIQtSUcf2n5UZ5ZgLtQ=
+cloud.google.com/go/compute v1.63.0 h1:KsBourH0wajM4RhzwPwRMKbxHVdvzGsk7StvACoWXD8=
 cloud.google.com/go/compute v1.65.0 h1:K0a3NRvazE7sZn5qswwI6BtlaZv1fgR5wFop5LZCLz8=
 cyphar.com/go-pathrs v0.2.1/go.mod h1:y8f1EMG7r+hCuFf/rXsKqMJrJAUoADZGNh5/vZPKcGc=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 github.com/99designs/gqlgen v0.17.76/go.mod h1:miiU+PkAnTIDKMQ1BseUOIVeQHoiwYDZGCswoxl7xec=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0/go.mod h1:P4WPRUkOhJC13W//jWpyfJNDAIpvRbAUIYLX/4jtlE0=
-github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0/go.mod h1:RD2SsorTmYhF6HkTmDw7KmPYQk8OBYwTkuasChwv7R4=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.1.6/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
@@ -19,18 +18,14 @@ github.com/blevesearch/goleveldb v1.0.1/go.mod h1:WrU8ltZbIp0wAoig/MHbrPCXSOLpe7
 github.com/blevesearch/snowball v0.6.1/go.mod h1:ZF0IBg5vgpeoUhnMza2v0A/z8m1cWPlwhke08LpNusg=
 github.com/blevesearch/stempel v0.2.0/go.mod h1:wjeTHqQv+nQdbPuJ/YcvOjTInA2EIc6Ks1FoSUzSLvc=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
-github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2/go.mod h1:qwXFYgsP6T7XnJtbKlf1HP8AjxZZyzxMmc+Lq5GjlU4=
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/couchbase/ghistogram v0.1.0/go.mod h1:s1Jhy76zqfEecpNWJfWUiKZookAFaiGOEoyzgHt9i7k=
 github.com/couchbase/moss v0.2.0/go.mod h1:9MaHIaRuy9pvLPUJxB8sh8OrLfyDczECVL37grCIubs=
 github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/dnephin/pflag v1.0.7/go.mod h1:uxE91IoWURlOiTUIA8Mq5ZZkAv3dPUfZNaT80Zm7OQE=
 github.com/elazarl/goproxy v1.7.2/go.mod h1:82vkLNir0ALaW14Rc399OTTjyNREgmdL2cVoIbS6XaE=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
-github.com/envoyproxy/go-control-plane v0.14.0/go.mod h1:NcS5X47pLl/hfqxU70yPwL9ZMkUlwlKxtAohpi2wBEU=
-github.com/envoyproxy/go-control-plane/envoy v1.37.0/go.mod h1:DReE9MMrmecPy+YvQOAOHNYMALuowAnbjjEMkkWOi6A=
-github.com/envoyproxy/go-control-plane/ratelimit v0.1.0/go.mod h1:Wk+tMFAFbCXaJPzVVHnPgRKdUdwW/KdbRt94AzgRee4=
-github.com/envoyproxy/protoc-gen-validate v1.3.3/go.mod h1:TsndJ/ngyIdQRhMcVVGDDHINPLWB7C82oDArY51KfB0=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/gliderlabs/ssh v0.3.8/go.mod h1:xYoytBv1sV0aL3CavoDuJIQNURXkkfPA/wxQ1pL1fAU=
@@ -59,7 +54,6 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRW
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d/go.mod h1:lXfE4PvvTW5xOjO6Mba8zDPyw8M93B6AQ7frTGnMlA8=
 github.com/pjbgf/sha1cd v0.6.0/go.mod h1:lhpGlyHLpQZoxMv8HcgXvZEhcGs0PG/vsZnEJ7H0iCM=
-github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
 github.com/r3labs/sse/v2 v2.8.1/go.mod h1:Igau6Whc+F17QUgML1fYe1VPZzTV6EMCnYktEmkNJ7I=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
@@ -67,7 +61,6 @@ github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPO
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
 github.com/sosodev/duration v1.3.1/go.mod h1:RQIBBX0+fMLc/D9+Jb/fwvVmo0eZvDDEERAikUR6SDg=
-github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xIx7lEzqblHEs=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
@@ -80,7 +73,6 @@ github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtX
 github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 go.etcd.io/gofail v0.2.0/go.mod h1:nL3ILMGfkXTekKI3clMBNazKnjUZjYLKmBHzsVAnC1o=
 go.opentelemetry.io/contrib/detectors/gcp v1.42.0/go.mod h1:W9zQ439utxymRrXsUOzZbFX4JhLxXU4+ZnCt8GG7yA8=
-go.opentelemetry.io/contrib/detectors/gcp v1.43.0/go.mod h1:RyaZMFY7yi1kAs45S6mbFGz8O8rqB0dTY14uzvG4LCs=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=


### PR DESCRIPTION
## Summary
- Declarative and UI-only providers (e.g. `deployos`, `front-porch`, `front-porch-rest-api`) were being packaged as a single generic archive because `gestaltd provider package` ignored `--platform` when the manifest had no source build/run.
- `app registry publish` and the runtime install path both expect platform-specific artifacts (`linux/amd64`, `darwin/arm64`), so generic archives cannot be published or deployed.
- Make `provider package` honor explicit `--platform` for manifest-only apps: stage and emit one archive per requested platform with the existing `_<os>_<arch>.tar.gz` filename.
- Make release finalization derive the artifact target from the archive filename when the prepared manifest has no platform artifacts, so declarative packages map to the correct platform keys in `provider-release.yaml`.
- Keep `validateArtifactPlatform` strict: the registry still rejects `"generic"` artifact targets and the runtime still resolves artifacts by host `os/arch`.

## Test plan
- [x] Local `go build ./gestaltd/cmd/gestaltd` succeeds.
- [x] Local `gestaltd provider package --platform linux/amd64,darwin/arm64` for `front-porch` produces two archives.
- [x] Local `gestaltd app registry publish --dry-run` for those archives produces a publish plan with `linux/amd64` and `darwin/arm64` artifacts.
- [ ] Merge, wait for `cd.yml` to publish binaries for the merge commit SHA, then update toolshed's `GESTALTD_PINNED_SHA` and re-publish the six failing apps.

Generated with [Devin](https://devin.ai)
