### PR TITLE
Fix auto-deploy settings writes against relationaldb provider

### DIFF
--- a/gestaltd/internal/coredata/app_auto_deploy_settings.go
+++ b/gestaltd/internal/coredata/app_auto_deploy_settings.go
@@ -88,25 +88,8 @@ func (s *AutoDeploySettingsService) Update(
 		return nil, err
 	}
 
-	tx, err := s.db.Transaction(
-		ctx,
-		[]string{StoreAppAutoDeploySettings},
-		idb.TransactionReadwrite,
-		idb.TransactionOptions{},
-	)
-	if err != nil {
-		return nil, fmt.Errorf("update app auto-deploy settings: begin transaction: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Abort(context.WithoutCancel(ctx))
-		}
-	}()
-
-	store := tx.ObjectStore(StoreAppAutoDeploySettings)
 	settings := &core.AppAutoDeploySettings{App: app}
-	rec, err := store.Get(ctx, app)
+	rec, err := s.store.Get(ctx, app)
 	if err == nil {
 		settings = recordToAppAutoDeploySettings(rec)
 	} else if !errors.Is(err, idb.ErrNotFound) {
@@ -117,13 +100,9 @@ func (s *AutoDeploySettingsService) Update(
 	}
 	settings.App = app
 	normalizeAppAutoDeploySettings(settings)
-	if err := store.Put(ctx, appAutoDeploySettingsRecord(settings)); err != nil {
+	if err := s.store.Put(ctx, appAutoDeploySettingsRecord(settings)); err != nil {
 		return nil, fmt.Errorf("update app auto-deploy settings: write: %w", err)
 	}
-	if err := tx.Commit(ctx); err != nil {
-		return nil, fmt.Errorf("update app auto-deploy settings: commit: %w", err)
-	}
-	committed = true
 	return settings, nil
 }
 

--- a/sdk/go/indexeddb_transport_test.go
+++ b/sdk/go/indexeddb_transport_test.go
@@ -446,6 +446,38 @@ func TestTransport_TransactionReadCheckWriteCommit(t *testing.T) {
 	}
 }
 
+func TestTransport_TransactionGetMissingThenPut(t *testing.T) {
+	ctx := context.Background()
+	store := "tx_get_put_" + t.Name()
+	if _, err := testClient.CreateObjectStore(ctx, store, gestalt.ObjectStoreOptions{}); err != nil {
+		t.Fatalf("CreateObjectStore: %v", err)
+	}
+
+	tx, err := testClient.Transaction(ctx, []string{store}, gestalt.TransactionReadwrite, gestalt.TransactionOptions{})
+	if err != nil {
+		t.Fatalf("Transaction: %v", err)
+	}
+	defer tx.Abort(ctx)
+
+	if _, err := tx.ObjectStore(store).Get(ctx, "new-row"); !errors.Is(err, gestalt.ErrNotFound) {
+		t.Fatalf("tx Get missing = %v, want ErrNotFound", err)
+	}
+	if err := tx.ObjectStore(store).Put(ctx, gestalt.Record{"id": "new-row", "enabled": true}); err != nil {
+		t.Fatalf("tx Put after missing Get: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	got, err := testClient.ObjectStore(store).Get(ctx, "new-row")
+	if err != nil {
+		t.Fatalf("Get committed row: %v", err)
+	}
+	if got["enabled"] != true {
+		t.Fatalf("row = %#v, want enabled=true", got)
+	}
+}
+
 func TestTransport_TransactionAbortRollsBack(t *testing.T) {
 	ctx := context.Background()
 	store := "tx_abort_" + t.Name()

--- a/sdk/go/serve_indexeddb.go
+++ b/sdk/go/serve_indexeddb.go
@@ -317,6 +317,12 @@ func (s indexedDBProviderServer) Transaction(stream proto.IndexedDB_TransactionS
 				resp, opErr = executeIndexedDBOperation(stream.Context(), tx, body.Operation)
 			}
 			if opErr != nil {
+				if isReadTransactionOperation(body.Operation) && transactionNotFound(opErr) {
+					if err := stream.Send(&proto.TransactionServerMessage{Msg: &proto.TransactionServerMessage_Operation{Operation: transactionOperationError(body.Operation.GetRequestId(), opErr)}}); err != nil {
+						return err
+					}
+					continue
+				}
 				finished = true
 				abortErr := tx.Abort(stream.Context())
 				if err := stream.Send(&proto.TransactionServerMessage{Msg: &proto.TransactionServerMessage_Operation{Operation: transactionOperationError(body.Operation.GetRequestId(), opErr)}}); err != nil {
@@ -715,6 +721,29 @@ func isWriteTransactionOperation(op *proto.TransactionOperation) bool {
 	default:
 		return false
 	}
+}
+
+func isReadTransactionOperation(op *proto.TransactionOperation) bool {
+	switch op.GetOperation().(type) {
+	case *proto.TransactionOperation_Get, *proto.TransactionOperation_GetKey,
+		*proto.TransactionOperation_GetAll, *proto.TransactionOperation_GetAllKeys,
+		*proto.TransactionOperation_IndexGet, *proto.TransactionOperation_IndexGetKey,
+		*proto.TransactionOperation_IndexGetAll, *proto.TransactionOperation_IndexGetAllKeys,
+		*proto.TransactionOperation_Count, *proto.TransactionOperation_IndexCount:
+		return true
+	default:
+		return false
+	}
+}
+
+func transactionNotFound(err error) bool {
+	if errors.Is(err, ErrNotFound) {
+		return true
+	}
+	if st, ok := status.FromError(err); ok && st.Code() == codes.NotFound {
+		return true
+	}
+	return false
 }
 
 func drainIndexedDBTransaction(stream proto.IndexedDB_TransactionServer) error {


### PR DESCRIPTION
## Summary
- Use non-transactional read-then-put in `AutoDeploySettingsService.Update` so app-admin auto-deploy toggles work against the relationaldb provider subprocess
- Port gestalt #2978 to the SDK indexeddb provider transaction server (the path relationaldb actually uses)
- Add a transport regression test for Get-missing-then-Put in one transaction

Production was still returning 503 after gestaltd `50ea51949` because #2978/#2979 only fixed gestaltd's in-process indexeddb server, while toolshed's `main-db` talks to relationaldb via the SDK provider host.

## Test plan
- [x] `go test ./internal/coredata/... -run AutoDeploy`
- [x] `go test ./sdk/go/... -run Transaction`
- [x] `go test ./sdk/go/... -run TestTransport_TransactionGetMissingThenPut`


Made with [Cursor](https://cursor.com)