### PR TITLE
Fix gestaltd E2E tests after per-platform source builds

### DIFF
--- a/gestaltd/internal/daemon/e2e/provider_package_edge_test.go
+++ b/gestaltd/internal/daemon/e2e/provider_package_edge_test.go
@@ -73,7 +73,7 @@ func TestRun_ProviderPackageAndReleaseStagesAppStaticBundle(t *testing.T) {
 			if len(metadata.Artifacts) != 1 {
 				t.Fatalf("release metadata artifacts = %+v, want 1 entry", metadata.Artifacts)
 			}
-			artifact := providerReleaseArtifactForTarget(t, metadata, providerrelease.GenericTarget)
+			artifact := providerReleaseArtifactForTarget(t, metadata, providerpkg.PlatformString(runtime.GOOS, runtime.GOARCH))
 			if got := artifact.Path; got != archiveName {
 				t.Fatalf("release metadata artifact path = %q, want %q", got, archiveName)
 			}

--- a/gestaltd/internal/daemon/e2e/provider_package_test.go
+++ b/gestaltd/internal/daemon/e2e/provider_package_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
-	"github.com/valon-technologies/gestalt/server/internal/providerrelease"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
@@ -610,7 +609,7 @@ func TestRun_ProviderPackageAndReleaseCopiesUISupportFiles(t *testing.T) {
 	if metadata.Kind != providermanifestv1.KindApp {
 		t.Fatalf("release metadata kind = %q, want %q", metadata.Kind, providermanifestv1.KindApp)
 	}
-	uiArtifact := providerReleaseArtifactForTarget(t, metadata, providerrelease.GenericTarget)
+	uiArtifact := providerReleaseArtifactForTarget(t, metadata, providerpkg.PlatformString(runtime.GOOS, runtime.GOARCH))
 	uiDigest, err := providerpkg.ArchiveDigest(filepath.Join(outputDir, archiveName))
 	if err != nil {
 		t.Fatalf("hash ui archive: %v", err)


### PR DESCRIPTION
## Summary
- #2980 made `gestaltd provider package --platform <os/arch>` produce per-platform archives for all apps, including source-built apps whose build only produces a static bundle.
- The provider-release metadata now records the artifact under the platform key (e.g. `linux/amd64`) instead of the generic target.
- Update the affected E2E tests to look up artifacts by `providerpkg.PlatformString(runtime.GOOS, runtime.GOARCH)` so they pass against the new metadata shape.

## Test plan
- [x] `go test ./gestaltd/internal/daemon/e2e -count=1` passes.
- [x] `go test ./gestaltd/internal/daemon/e2e/app_publish -count=1` passes.

Generated with [Devin](https://devin.ai)