### PR TITLE
Add rollout outcomes and revision history rollout fields

### DIFF
--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -91,6 +91,14 @@ type AppAutoDeploySettings struct {
 	LastFailedRolloutAt time.Time
 }
 
+type AppVersionRolloutOutcome struct {
+	ID          string
+	App         string
+	Version     string
+	CompletedAt time.Time
+	FailedAt    time.Time
+}
+
 type GestaltdSourceVersionState struct {
 	CurrentSourceVersion string
 	UpdatedAt            time.Time

--- a/gestaltd/internal/appregistry/poller.go
+++ b/gestaltd/internal/appregistry/poller.go
@@ -32,6 +32,7 @@ type CatalogPoller struct {
 	ChangeRequests       *coredata.AppVersionChangeRequestService
 	Materializations     *coredata.AppInstanceMaterializationService
 	Rollouts             *coredata.AppRolloutService
+	RolloutOutcomes      *coredata.AppVersionRolloutOutcomeService
 	AppMaterializer      *Materializer
 	AppRestarter         AppRestarter
 	InstanceID           string
@@ -59,6 +60,7 @@ type CatalogPollerConfig struct {
 	ChangeRequests       *coredata.AppVersionChangeRequestService
 	Materializations     *coredata.AppInstanceMaterializationService
 	Rollouts             *coredata.AppRolloutService
+	RolloutOutcomes      *coredata.AppVersionRolloutOutcomeService
 	AppMaterializer      *Materializer
 	AppRestarter         AppRestarter
 	InstanceID           string
@@ -78,6 +80,7 @@ func NewCatalogPoller(cfg CatalogPollerConfig) *CatalogPoller {
 		ChangeRequests:       cfg.ChangeRequests,
 		Materializations:     cfg.Materializations,
 		Rollouts:             cfg.Rollouts,
+		RolloutOutcomes:      cfg.RolloutOutcomes,
 		AppMaterializer:      cfg.AppMaterializer,
 		AppRestarter:         cfg.AppRestarter,
 		InstanceID:           strings.TrimSpace(cfg.InstanceID),
@@ -286,6 +289,7 @@ func (p *CatalogPoller) reconcileApp(ctx context.Context, instanceID, appName st
 				} else if err != nil {
 					return fmt.Errorf("fail rollout without accepted version %s@%s: %w", appName, version, err)
 				}
+				p.recordRolloutOutcome(ctx, rollout, time.Time{}, p.now())
 				p.notifyRolloutTerminal(appName)
 			}
 			return nil
@@ -554,6 +558,7 @@ func (p *CatalogPoller) updateRolloutOutcome(ctx context.Context, rollout *core.
 		} else if err != nil {
 			return false, fmt.Errorf("complete rollout %s@%s: %w", rollout.App, rollout.Version, err)
 		}
+		p.recordRolloutOutcome(ctx, rollout, p.now(), time.Time{})
 		p.notifyRolloutTerminal(rollout.App)
 		return true, nil
 	}
@@ -563,6 +568,7 @@ func (p *CatalogPoller) updateRolloutOutcome(ctx context.Context, rollout *core.
 		} else if err != nil {
 			return false, fmt.Errorf("fail rollout %s@%s: %w", rollout.App, rollout.Version, err)
 		}
+		p.recordRolloutOutcome(ctx, rollout, time.Time{}, p.now())
 		p.notifyRolloutTerminal(rollout.App)
 		return true, nil
 	}
@@ -572,6 +578,41 @@ func (p *CatalogPoller) updateRolloutOutcome(ctx context.Context, rollout *core.
 func (p *CatalogPoller) notifyRolloutTerminal(app string) {
 	if p != nil && p.OnRolloutTerminal != nil {
 		p.OnRolloutTerminal(strings.TrimSpace(app))
+	}
+}
+
+func (p *CatalogPoller) recordRolloutOutcome(ctx context.Context, rollout *core.AppRollout, completedAt, failedAt time.Time) {
+	if p == nil || p.RolloutOutcomes == nil || p.ChangeRequests == nil || rollout == nil {
+		return
+	}
+	changeRequestID, err := p.ChangeRequests.LatestRevisionIDForVersion(ctx, rollout.App, rollout.Version)
+	if err != nil || changeRequestID == "" {
+		slog.Warn("record rollout outcome: change request not found",
+			"app", rollout.App,
+			"version", rollout.Version,
+			"error", err,
+		)
+		return
+	}
+	switch {
+	case !completedAt.IsZero():
+		if err := p.RolloutOutcomes.RecordComplete(ctx, changeRequestID, rollout.App, rollout.Version, completedAt); err != nil {
+			slog.Warn("record rollout outcome: complete",
+				"app", rollout.App,
+				"version", rollout.Version,
+				"change_request_id", changeRequestID,
+				"error", err,
+			)
+		}
+	case !failedAt.IsZero():
+		if err := p.RolloutOutcomes.RecordFailed(ctx, changeRequestID, rollout.App, rollout.Version, failedAt); err != nil {
+			slog.Warn("record rollout outcome: failed",
+				"app", rollout.App,
+				"version", rollout.Version,
+				"change_request_id", changeRequestID,
+				"error", err,
+			)
+		}
 	}
 }
 

--- a/gestaltd/internal/coredata/app_version_change_requests.go
+++ b/gestaltd/internal/coredata/app_version_change_requests.go
@@ -150,6 +150,14 @@ func (s *AppVersionChangeRequestService) LatestDesiredRevisionID(ctx context.Con
 	return latestDesiredRevisionID(requests, desiredVersion), nil
 }
 
+func (s *AppVersionChangeRequestService) LatestRevisionIDForVersion(ctx context.Context, appName, version string) (string, error) {
+	requests, err := s.ListRequestsByApp(ctx, appName)
+	if err != nil {
+		return "", err
+	}
+	return latestDesiredRevisionID(requests, version), nil
+}
+
 func latestDesiredRevisionID(requests []*core.AppVersionChangeRequest, desiredVersion string) string {
 	desiredVersion = strings.TrimSpace(desiredVersion)
 	if desiredVersion == "" {

--- a/gestaltd/internal/coredata/app_version_rollout_outcomes.go
+++ b/gestaltd/internal/coredata/app_version_rollout_outcomes.go
@@ -1,0 +1,148 @@
+package coredata
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	idb "github.com/valon-technologies/gestalt/sdk/go/indexeddb"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+)
+
+type AppVersionRolloutOutcomeService struct {
+	db    indexeddb.IndexedDB
+	store idb.ObjectStore
+}
+
+func NewAppVersionRolloutOutcomeService(ds indexeddb.IndexedDB) *AppVersionRolloutOutcomeService {
+	return &AppVersionRolloutOutcomeService{
+		db:    ds,
+		store: ds.ObjectStore(StoreAppVersionRolloutOutcomes),
+	}
+}
+
+func (s *AppVersionRolloutOutcomeService) EnsureStore(ctx context.Context) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("ensure app version rollout outcomes store: service is not configured")
+	}
+	return ensureAppVersionRolloutOutcomesStore(ctx, s.db)
+}
+
+func (s *AppVersionRolloutOutcomeService) Get(ctx context.Context, changeRequestID string) (*core.AppVersionRolloutOutcome, error) {
+	if s == nil {
+		return nil, fmt.Errorf("get app version rollout outcome: service is not configured")
+	}
+	changeRequestID = strings.TrimSpace(changeRequestID)
+	if changeRequestID == "" {
+		return nil, fmt.Errorf("get app version rollout outcome: change request id is required")
+	}
+	rec, err := s.store.Get(ctx, changeRequestID)
+	if err != nil {
+		if errors.Is(err, idb.ErrNotFound) {
+			return nil, core.ErrNotFound
+		}
+		return nil, fmt.Errorf("get app version rollout outcome: %w", err)
+	}
+	return recordToAppVersionRolloutOutcome(rec), nil
+}
+
+func (s *AppVersionRolloutOutcomeService) GetMany(ctx context.Context, changeRequestIDs []string) (map[string]*core.AppVersionRolloutOutcome, error) {
+	if s == nil {
+		return nil, fmt.Errorf("get app version rollout outcomes: service is not configured")
+	}
+	out := make(map[string]*core.AppVersionRolloutOutcome, len(changeRequestIDs))
+	for _, id := range changeRequestIDs {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		outcome, err := s.Get(ctx, id)
+		if errors.Is(err, core.ErrNotFound) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		out[id] = outcome
+	}
+	return out, nil
+}
+
+func (s *AppVersionRolloutOutcomeService) RecordComplete(
+	ctx context.Context,
+	changeRequestID, app, version string,
+	completedAt time.Time,
+) error {
+	return s.record(ctx, changeRequestID, app, version, completedAt, time.Time{})
+}
+
+func (s *AppVersionRolloutOutcomeService) RecordFailed(
+	ctx context.Context,
+	changeRequestID, app, version string,
+	failedAt time.Time,
+) error {
+	return s.record(ctx, changeRequestID, app, version, time.Time{}, failedAt)
+}
+
+func (s *AppVersionRolloutOutcomeService) record(
+	ctx context.Context,
+	changeRequestID, app, version string,
+	completedAt, failedAt time.Time,
+) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("record app version rollout outcome: service is not configured")
+	}
+	changeRequestID = strings.TrimSpace(changeRequestID)
+	app = strings.TrimSpace(app)
+	version = strings.TrimSpace(version)
+	if changeRequestID == "" || app == "" || version == "" {
+		return fmt.Errorf("record app version rollout outcome: change request id, app, and version are required")
+	}
+	if completedAt.IsZero() == failedAt.IsZero() {
+		return fmt.Errorf("record app version rollout outcome: exactly one terminal timestamp is required")
+	}
+	if err := s.EnsureStore(ctx); err != nil {
+		return err
+	}
+	if _, err := s.Get(ctx, changeRequestID); err == nil {
+		return nil
+	} else if !errors.Is(err, core.ErrNotFound) {
+		return err
+	}
+	rec := idb.Record{
+		"id":      changeRequestID,
+		"app":     app,
+		"version": version,
+	}
+	if !completedAt.IsZero() {
+		rec["completed_at"] = completedAt.UTC().Truncate(time.Millisecond)
+	}
+	if !failedAt.IsZero() {
+		rec["failed_at"] = failedAt.UTC().Truncate(time.Millisecond)
+	}
+	if err := s.store.Add(ctx, rec); err != nil {
+		return fmt.Errorf("record app version rollout outcome: %w", err)
+	}
+	return nil
+}
+
+func recordToAppVersionRolloutOutcome(rec idb.Record) *core.AppVersionRolloutOutcome {
+	return &core.AppVersionRolloutOutcome{
+		ID:          recString(rec, "id"),
+		App:         recString(rec, "app"),
+		Version:     recString(rec, "version"),
+		CompletedAt: recTime(rec, "completed_at"),
+		FailedAt:    recTime(rec, "failed_at"),
+	}
+}
+
+func ensureAppVersionRolloutOutcomesStore(ctx context.Context, ds indexeddb.IndexedDB) error {
+	if _, err := ds.CreateObjectStore(ctx, StoreAppVersionRolloutOutcomes, AppVersionRolloutOutcomesSchema); err != nil {
+		return fmt.Errorf("ensure app_version_rollout_outcomes store: %w", err)
+	}
+	return nil
+}

--- a/gestaltd/internal/coredata/app_version_rollout_outcomes_test.go
+++ b/gestaltd/internal/coredata/app_version_rollout_outcomes_test.go
@@ -1,0 +1,67 @@
+package coredata_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+)
+
+func TestAppVersionRolloutOutcomeServiceRecordCompleteIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	svc := testutil.NewStubServices(t).AppVersionRolloutOutcomes
+	ctx := context.Background()
+	completedAt := time.Date(2026, 7, 24, 20, 45, 8, 0, time.UTC)
+
+	if err := svc.RecordComplete(ctx, "req-1", "g-issues", "v2", completedAt); err != nil {
+		t.Fatalf("RecordComplete: %v", err)
+	}
+	if err := svc.RecordComplete(ctx, "req-1", "g-issues", "v2", completedAt.Add(time.Minute)); err != nil {
+		t.Fatalf("duplicate RecordComplete: %v", err)
+	}
+
+	outcome, err := svc.Get(ctx, "req-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if outcome.Version != "v2" || !outcome.CompletedAt.Equal(completedAt) || !outcome.FailedAt.IsZero() {
+		t.Fatalf("outcome = %#v", outcome)
+	}
+}
+
+func TestAppVersionRolloutOutcomeServiceRecordFailed(t *testing.T) {
+	t.Parallel()
+
+	svc := testutil.NewStubServices(t).AppVersionRolloutOutcomes
+	ctx := context.Background()
+	failedAt := time.Date(2026, 7, 24, 20, 54, 41, 0, time.UTC)
+
+	if err := svc.RecordFailed(ctx, "req-2", "g-issues", "v3", failedAt); err != nil {
+		t.Fatalf("RecordFailed: %v", err)
+	}
+
+	outcomes, err := svc.GetMany(ctx, []string{"req-2", "missing"})
+	if err != nil {
+		t.Fatalf("GetMany: %v", err)
+	}
+	if len(outcomes) != 1 {
+		t.Fatalf("outcomes = %#v", outcomes)
+	}
+	outcome := outcomes["req-2"]
+	if outcome.FailedAt != failedAt || !outcome.CompletedAt.IsZero() {
+		t.Fatalf("outcome = %#v", outcome)
+	}
+}
+
+func TestAppVersionRolloutOutcomeServiceGetMissing(t *testing.T) {
+	t.Parallel()
+
+	svc := testutil.NewStubServices(t).AppVersionRolloutOutcomes
+	_, err := svc.Get(context.Background(), "missing")
+	if err == nil || err != core.ErrNotFound {
+		t.Fatalf("Get error = %v, want ErrNotFound", err)
+	}
+}

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -15,6 +15,7 @@ const (
 	StoreAppRollouts                   = "app_rollouts"
 	StoreAppInstanceMaterializations   = "app_instance_materializations"
 	StoreAppAutoDeploySettings         = "app_auto_deploy_settings"
+	StoreAppVersionRolloutOutcomes     = "app_version_rollout_outcomes"
 	StoreRemoteRegistrations           = "remote_registrations"
 	StoreRemoteProviders               = "remote_providers"
 )
@@ -154,6 +155,16 @@ var AppAutoDeploySettingsSchema = idb.ObjectStoreOptions{
 		{Name: "last_seen_version", Type: idb.TypeString},
 		{Name: "last_error", Type: idb.TypeString},
 		{Name: "last_failed_rollout_at", Type: idb.TypeTime},
+	},
+}
+
+var AppVersionRolloutOutcomesSchema = idb.ObjectStoreOptions{
+	Columns: []idb.ColumnDef{
+		{Name: "id", Type: idb.TypeString, PrimaryKey: true},
+		{Name: "app", Type: idb.TypeString, NotNull: true},
+		{Name: "version", Type: idb.TypeString, NotNull: true},
+		{Name: "completed_at", Type: idb.TypeTime},
+		{Name: "failed_at", Type: idb.TypeTime},
 	},
 }
 

--- a/gestaltd/internal/coredata/services.go
+++ b/gestaltd/internal/coredata/services.go
@@ -18,6 +18,7 @@ type Services struct {
 	AppRollouts                 *AppRolloutService
 	AppInstanceMaterializations *AppInstanceMaterializationService
 	AutoDeploySettings          *AutoDeploySettingsService
+	AppVersionRolloutOutcomes   *AppVersionRolloutOutcomeService
 	RemoteRegistrations         *RemoteRegistrationService
 	DB                          indexeddb.IndexedDB
 }
@@ -69,13 +70,16 @@ func NewWithOptions(ctx context.Context, ds indexeddb.IndexedDB, opts NewOptions
 		if _, err := ds.CreateObjectStore(ctx, StoreAppAutoDeploySettings, AppAutoDeploySettingsSchema); err != nil {
 			return nil, fmt.Errorf("create app_auto_deploy_settings store: %w", err)
 		}
+		if _, err := ds.CreateObjectStore(ctx, StoreAppVersionRolloutOutcomes, AppVersionRolloutOutcomesSchema); err != nil {
+			return nil, fmt.Errorf("create app_version_rollout_outcomes store: %w", err)
+		}
 		if _, err := ds.CreateObjectStore(ctx, StoreRemoteRegistrations, RemoteRegistrationsSchema); err != nil {
 			return nil, fmt.Errorf("create remote_registrations store: %w", err)
 		}
 		if _, err := ds.CreateObjectStore(ctx, StoreRemoteProviders, RemoteProvidersSchema); err != nil {
 			return nil, fmt.Errorf("create remote_providers store: %w", err)
 		}
-	} else if err := ensureAppAutoDeploySettingsStore(ctx, ds); err != nil {
+	} else if err := ensureDeferredAppRegistryStores(ctx, ds); err != nil {
 		return nil, err
 	}
 	users := NewUserService(ds)
@@ -86,6 +90,7 @@ func NewWithOptions(ctx context.Context, ds indexeddb.IndexedDB, opts NewOptions
 	appRollouts := NewAppRolloutService(ds)
 	appInstanceMaterializations := NewAppInstanceMaterializationService(ds)
 	autoDeploySettings := NewAutoDeploySettingsService(ds)
+	appVersionRolloutOutcomes := NewAppVersionRolloutOutcomeService(ds)
 	remoteRegistrations := NewRemoteRegistrationService(ds)
 	return &Services{
 		ExternalCredentials:         nil,
@@ -97,6 +102,7 @@ func NewWithOptions(ctx context.Context, ds indexeddb.IndexedDB, opts NewOptions
 		AppRollouts:                 appRollouts,
 		AppInstanceMaterializations: appInstanceMaterializations,
 		AutoDeploySettings:          autoDeploySettings,
+		AppVersionRolloutOutcomes:   appVersionRolloutOutcomes,
 		RemoteRegistrations:         remoteRegistrations,
 		DB:                          ds,
 	}, nil
@@ -108,6 +114,16 @@ func (s *Services) Ping(ctx context.Context) error {
 
 func (s *Services) Close() error {
 	return s.DB.Close()
+}
+
+func ensureDeferredAppRegistryStores(ctx context.Context, ds indexeddb.IndexedDB) error {
+	if err := ensureAppAutoDeploySettingsStore(ctx, ds); err != nil {
+		return err
+	}
+	if err := ensureAppVersionRolloutOutcomesStore(ctx, ds); err != nil {
+		return err
+	}
+	return nil
 }
 
 func ensureAppAutoDeploySettingsStore(ctx context.Context, ds indexeddb.IndexedDB) error {

--- a/gestaltd/internal/coredata/services_test.go
+++ b/gestaltd/internal/coredata/services_test.go
@@ -249,6 +249,7 @@ func TestNew(t *testing.T) {
 			coredata.StoreAppVersionInstallLocks,
 			coredata.StoreAppRollouts,
 			coredata.StoreAppAutoDeploySettings,
+			coredata.StoreAppVersionRolloutOutcomes,
 			coredata.StoreRemoteRegistrations,
 			coredata.StoreRemoteProviders,
 		} {
@@ -271,11 +272,16 @@ func TestNew(t *testing.T) {
 			t.Fatalf("coredata.NewWithOptions: %v", err)
 		}
 		contexts := db.createdStoreContexts()
-		if len(contexts) != 1 {
-			t.Fatalf("CreateObjectStore calls = %d, want 1", len(contexts))
+		if len(contexts) != 2 {
+			t.Fatalf("CreateObjectStore calls = %d, want 2", len(contexts))
 		}
-		if _, ok := contexts[coredata.StoreAppAutoDeploySettings]; !ok {
-			t.Fatalf("CreateObjectStore calls = %v, want only %q", contexts, coredata.StoreAppAutoDeploySettings)
+		for _, store := range []string{
+			coredata.StoreAppAutoDeploySettings,
+			coredata.StoreAppVersionRolloutOutcomes,
+		} {
+			if _, ok := contexts[store]; !ok {
+				t.Fatalf("CreateObjectStore calls = %v, want %q", contexts, store)
+			}
 		}
 	})
 

--- a/gestaltd/internal/server/handlers_app_admin_registry.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry.go
@@ -112,17 +112,22 @@ type appAdminRegistryHistoryResponse struct {
 }
 
 type appAdminRegistryRevision struct {
-	ID              string                   `json:"id"`
-	Version         string                   `json:"version"`
-	PreviousVersion string                   `json:"previousVersion,omitempty"`
-	DeployedAt      string                   `json:"deployedAt"`
-	DeployedBy      string                   `json:"deployedBy,omitempty"`
-	SourceRef       string                   `json:"sourceRef,omitempty"`
-	SourceURL       string                   `json:"sourceUrl,omitempty"`
-	Publication     *appregistry.Publication `json:"publication,omitempty"`
-	DeploymentState string                   `json:"deploymentState,omitempty"`
-	DeployableUntil string                   `json:"deployableUntil,omitempty"`
-	Current         bool                     `json:"current,omitempty"`
+	ID                     string                   `json:"id"`
+	Version                string                   `json:"version"`
+	PreviousVersion        string                   `json:"previousVersion,omitempty"`
+	DeployedAt             string                   `json:"deployedAt"`
+	DeployedBy             string                   `json:"deployedBy,omitempty"`
+	SourceRef              string                   `json:"sourceRef,omitempty"`
+	SourceURL              string                   `json:"sourceUrl,omitempty"`
+	Publication            *appregistry.Publication `json:"publication,omitempty"`
+	DeploymentState        string                   `json:"deploymentState,omitempty"`
+	DeployableUntil        string                   `json:"deployableUntil,omitempty"`
+	Current                bool                     `json:"current,omitempty"`
+	RolloutState           string                   `json:"rolloutState,omitempty"`
+	RolloutForSeconds      *int64                   `json:"rolloutForSeconds,omitempty"`
+	RolloutDurationSeconds *int64                   `json:"rolloutDurationSeconds,omitempty"`
+	RolloutCompletedAt     string                   `json:"rolloutCompletedAt,omitempty"`
+	RolloutFailedAt        string                   `json:"rolloutFailedAt,omitempty"`
 }
 
 func (s *Server) mountAppAdminRegistryRoutes(r chi.Router) {
@@ -441,13 +446,40 @@ func (s *Server) getAppAdminRegistryHistory(w http.ResponseWriter, r *http.Reque
 	publishedByVersion := publishedVersionSummaryMap(index, app.name)
 	now := time.Now().UTC()
 
+	var rollout *core.AppRollout
+	if s.appRollouts != nil {
+		currentRollout, rolloutErr := s.appRollouts.Get(r.Context(), app.name)
+		if rolloutErr == nil {
+			rollout = currentRollout
+		} else if !errors.Is(rolloutErr, core.ErrNotFound) {
+			writeError(w, http.StatusServiceUnavailable, "app registry installation services are unavailable")
+			return
+		}
+	}
+
+	changeRequestIDs := make([]string, 0, len(page.Requests))
+	for _, request := range page.Requests {
+		if request != nil && strings.TrimSpace(request.ID) != "" {
+			changeRequestIDs = append(changeRequestIDs, request.ID)
+		}
+	}
+	outcomesByID := map[string]*core.AppVersionRolloutOutcome{}
+	if s.appRolloutOutcomes != nil && len(changeRequestIDs) > 0 {
+		var outcomesErr error
+		outcomesByID, outcomesErr = s.appRolloutOutcomes.GetMany(r.Context(), changeRequestIDs)
+		if outcomesErr != nil {
+			writeError(w, http.StatusServiceUnavailable, "app registry installation services are unavailable")
+			return
+		}
+	}
+
 	revisions := make([]appAdminRegistryRevision, 0, len(page.Requests))
 	actorLabels := s.resolveRevisionActorLabels(r.Context(), page.Requests)
 	for _, request := range page.Requests {
 		if request == nil {
 			continue
 		}
-		revisions = append(revisions, appAdminRegistryRevisionFromRequest(
+		revision := appAdminRegistryRevisionFromRequest(
 			request,
 			desiredVersion,
 			currentRevisionID,
@@ -456,7 +488,9 @@ func (s *Server) getAppAdminRegistryHistory(w http.ResponseWriter, r *http.Reque
 			publishedByVersion,
 			actorLabels[strings.TrimSpace(request.Actor)],
 			now,
-		))
+		)
+		applyRevisionRolloutFields(&revision, request, rollout, outcomesByID[request.ID], now)
+		revisions = append(revisions, revision)
 	}
 	writeJSON(w, http.StatusOK, appAdminRegistryHistoryResponse{
 		App:        app.name,
@@ -701,6 +735,70 @@ func appAdminRegistryRevisionFromRequest(
 		revision.DeployableUntil = formatAdminTime(*deployableUntil)
 	}
 	return revision
+}
+
+func applyRevisionRolloutFields(
+	revision *appAdminRegistryRevision,
+	request *core.AppVersionChangeRequest,
+	rollout *core.AppRollout,
+	outcome *core.AppVersionRolloutOutcome,
+	now time.Time,
+) {
+	if revision == nil || request == nil {
+		return
+	}
+	version := strings.TrimSpace(request.ToVersion)
+	if version == "" {
+		return
+	}
+
+	var state core.AppRolloutState
+	var completedAt, failedAt time.Time
+
+	if rollout != nil && strings.TrimSpace(rollout.Version) == version {
+		state = rollout.State
+		completedAt = rollout.CompletedAt
+		failedAt = rollout.FailedAt
+	}
+	if outcome != nil {
+		if !outcome.CompletedAt.IsZero() {
+			completedAt = outcome.CompletedAt
+			state = core.AppRolloutStateComplete
+		}
+		if !outcome.FailedAt.IsZero() {
+			failedAt = outcome.FailedAt
+			state = core.AppRolloutStateFailed
+		}
+	}
+	if state == "" {
+		return
+	}
+
+	revision.RolloutState = string(state)
+	switch state {
+	case core.AppRolloutStateEnrolling, core.AppRolloutStateRestarting:
+		if seconds := rolloutDurationSeconds(request.Timestamp, now); seconds != nil {
+			revision.RolloutForSeconds = seconds
+		}
+	case core.AppRolloutStateComplete:
+		if !completedAt.IsZero() {
+			revision.RolloutCompletedAt = formatAdminTime(completedAt)
+			revision.RolloutDurationSeconds = rolloutDurationSeconds(request.Timestamp, completedAt)
+		}
+	case core.AppRolloutStateFailed:
+		if !failedAt.IsZero() {
+			revision.RolloutFailedAt = formatAdminTime(failedAt)
+			revision.RolloutDurationSeconds = rolloutDurationSeconds(request.Timestamp, failedAt)
+		}
+	}
+}
+
+func rolloutDurationSeconds(start, end time.Time) *int64 {
+	if start.IsZero() || end.IsZero() || end.Before(start) {
+		return nil
+	}
+	seconds := int64(end.Sub(start).Round(time.Second) / time.Second)
+	return &seconds
 }
 
 func historyDeploymentState(state string) string {

--- a/gestaltd/internal/server/handlers_app_admin_registry_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry_test.go
@@ -665,3 +665,152 @@ func TestAppAdminRegistryHistory(t *testing.T) {
 		t.Fatalf("page2 = %#v", page2)
 	}
 }
+
+func TestAppAdminRegistryHistoryRolloutFields(t *testing.T) {
+	t.Parallel()
+
+	fixture := registrytest.NewInstallFixture(t)
+	services := testutil.NewStubServices(t)
+	alice := seedUser(t, services, "alice@valon.com")
+	aliceActor := principal.UserSubjectID(alice.ID)
+	subjectID := principal.UserSubjectID("alice")
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(subjectID, "admin", "app", "g-issues"),
+		},
+	}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", subjectID, "")
+		cfg.Authorization = authz
+		cfg.Services = services
+		cfg.AppDefs = map[string]*config.ProviderEntry{
+			"g-issues": {Source: config.ProviderSource{Registry: "toolshed"}},
+		}
+		cfg.AppRegistries = map[string]config.AppRegistryConfig{"toolshed": fixture.Registry}
+		cfg.AppRegistryReader = fixture.Reader
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	appendRevision := func(t *testing.T, version string, deployedAt time.Time) *core.AppVersionChangeRequest {
+		t.Helper()
+		request, err := services.AppVersionChangeRequests.AppendRequest(context.Background(), &core.AppVersionChangeRequest{
+			App:         "g-issues",
+			FromVersion: appregistry.FirstInstallFromVersion,
+			ToVersion:   version,
+			Actor:       aliceActor,
+			Timestamp:   deployedAt,
+			Metadata: coredata.ChangeRequestMetadata(&core.AppInstallation{
+				AppName:   "g-issues",
+				Version:   version,
+				SourceRef: "abc123def456abc123def456abc123def456abcd",
+				Registry:  "toolshed",
+			}),
+		})
+		if err != nil {
+			t.Fatalf("AppendRequest: %v", err)
+		}
+		return request
+	}
+
+	getHistory := func(t *testing.T) []struct {
+		ID                     string `json:"id"`
+		RolloutState           string `json:"rolloutState"`
+		RolloutForSeconds      *int64 `json:"rolloutForSeconds"`
+		RolloutDurationSeconds *int64 `json:"rolloutDurationSeconds"`
+		RolloutCompletedAt     string `json:"rolloutCompletedAt"`
+	} {
+		t.Helper()
+		httpRequest, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/g-issues/admin/registry/history", nil)
+		httpRequest.Header.Set("Authorization", "Bearer alice-token")
+		response, err := http.DefaultClient.Do(httpRequest)
+		if err != nil {
+			t.Fatalf("GET history: %v", err)
+		}
+		defer func() { _ = response.Body.Close() }()
+		if response.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(response.Body)
+			t.Fatalf("GET status = %d: %s", response.StatusCode, body)
+		}
+		var history struct {
+			Revisions []struct {
+				ID                     string `json:"id"`
+				RolloutState           string `json:"rolloutState"`
+				RolloutForSeconds      *int64 `json:"rolloutForSeconds"`
+				RolloutDurationSeconds *int64 `json:"rolloutDurationSeconds"`
+				RolloutCompletedAt     string `json:"rolloutCompletedAt"`
+			} `json:"revisions"`
+		}
+		if err := json.NewDecoder(response.Body).Decode(&history); err != nil {
+			t.Fatalf("decode history: %v", err)
+		}
+		return history.Revisions
+	}
+
+	t.Run("active rollout", func(t *testing.T) {
+		deployedAt := time.Date(2026, 7, 25, 9, 20, 0, 0, time.UTC)
+		request := appendRevision(t, fixture.Version, deployedAt)
+		if _, err := services.AppRollouts.Create(context.Background(), &core.AppRollout{
+			App:              "g-issues",
+			Version:          fixture.Version,
+			State:            core.AppRolloutStateEnrolling,
+			CreatedAt:        deployedAt,
+			EnrollmentEndsAt: deployedAt.Add(2 * time.Minute),
+			Deadline:         deployedAt.Add(15 * time.Minute),
+		}); err != nil {
+			t.Fatalf("Create rollout: %v", err)
+		}
+
+		revisions := getHistory(t)
+		if len(revisions) != 1 || revisions[0].ID != request.ID {
+			t.Fatalf("revisions = %#v", revisions)
+		}
+		if revisions[0].RolloutState != "enrolling" {
+			t.Fatalf("rolloutState = %q, want enrolling", revisions[0].RolloutState)
+		}
+		if revisions[0].RolloutForSeconds == nil || *revisions[0].RolloutForSeconds < 0 {
+			t.Fatalf("rolloutForSeconds = %#v", revisions[0].RolloutForSeconds)
+		}
+		if revisions[0].RolloutDurationSeconds != nil {
+			t.Fatalf("rolloutDurationSeconds = %#v, want nil", revisions[0].RolloutDurationSeconds)
+		}
+	})
+
+	t.Run("stored outcome", func(t *testing.T) {
+		deployedAt := time.Date(2026, 7, 25, 9, 10, 0, 0, time.UTC)
+		request := appendRevision(t, "0.0.0-snapshot.gother", deployedAt)
+		completedAt := deployedAt.Add(3*time.Minute + 8*time.Second)
+		if err := services.AppVersionRolloutOutcomes.RecordComplete(context.Background(), request.ID, "g-issues", "0.0.0-snapshot.gother", completedAt); err != nil {
+			t.Fatalf("RecordComplete: %v", err)
+		}
+
+		revisions := getHistory(t)
+		if len(revisions) != 2 {
+			t.Fatalf("revisions = %#v", revisions)
+		}
+		var stored struct {
+			ID                     string `json:"id"`
+			RolloutState           string `json:"rolloutState"`
+			RolloutForSeconds      *int64 `json:"rolloutForSeconds"`
+			RolloutDurationSeconds *int64 `json:"rolloutDurationSeconds"`
+			RolloutCompletedAt     string `json:"rolloutCompletedAt"`
+		}
+		for _, revision := range revisions {
+			if revision.ID == request.ID {
+				stored = revision
+				break
+			}
+		}
+		if stored.ID == "" {
+			t.Fatalf("stored revision missing from %#v", revisions)
+		}
+		if stored.RolloutState != "complete" {
+			t.Fatalf("rolloutState = %q, want complete", stored.RolloutState)
+		}
+		if stored.RolloutDurationSeconds == nil || *stored.RolloutDurationSeconds != 188 {
+			t.Fatalf("rolloutDurationSeconds = %#v, want 188", stored.RolloutDurationSeconds)
+		}
+		if stored.RolloutCompletedAt == "" {
+			t.Fatalf("rolloutCompletedAt missing")
+		}
+	})
+}

--- a/gestaltd/internal/server/handlers_app_admin_registry_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry_test.go
@@ -666,7 +666,7 @@ func TestAppAdminRegistryHistory(t *testing.T) {
 	}
 }
 
-func TestAppAdminRegistryHistoryRolloutFields(t *testing.T) {
+func TestAppAdminRegistryHistoryActiveRolloutFields(t *testing.T) {
 	t.Parallel()
 
 	fixture := registrytest.NewInstallFixture(t)
@@ -691,126 +691,150 @@ func TestAppAdminRegistryHistoryRolloutFields(t *testing.T) {
 	})
 	testutil.CloseOnCleanup(t, ts)
 
-	appendRevision := func(t *testing.T, version string, deployedAt time.Time) *core.AppVersionChangeRequest {
-		t.Helper()
-		request, err := services.AppVersionChangeRequests.AppendRequest(context.Background(), &core.AppVersionChangeRequest{
-			App:         "g-issues",
-			FromVersion: appregistry.FirstInstallFromVersion,
-			ToVersion:   version,
-			Actor:       aliceActor,
-			Timestamp:   deployedAt,
-			Metadata: coredata.ChangeRequestMetadata(&core.AppInstallation{
-				AppName:   "g-issues",
-				Version:   version,
-				SourceRef: "abc123def456abc123def456abc123def456abcd",
-				Registry:  "toolshed",
-			}),
-		})
-		if err != nil {
-			t.Fatalf("AppendRequest: %v", err)
-		}
-		return request
-	}
-
-	getHistory := func(t *testing.T) []struct {
-		ID                     string `json:"id"`
-		RolloutState           string `json:"rolloutState"`
-		RolloutForSeconds      *int64 `json:"rolloutForSeconds"`
-		RolloutDurationSeconds *int64 `json:"rolloutDurationSeconds"`
-		RolloutCompletedAt     string `json:"rolloutCompletedAt"`
-	} {
-		t.Helper()
-		httpRequest, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/g-issues/admin/registry/history", nil)
-		httpRequest.Header.Set("Authorization", "Bearer alice-token")
-		response, err := http.DefaultClient.Do(httpRequest)
-		if err != nil {
-			t.Fatalf("GET history: %v", err)
-		}
-		defer func() { _ = response.Body.Close() }()
-		if response.StatusCode != http.StatusOK {
-			body, _ := io.ReadAll(response.Body)
-			t.Fatalf("GET status = %d: %s", response.StatusCode, body)
-		}
-		var history struct {
-			Revisions []struct {
-				ID                     string `json:"id"`
-				RolloutState           string `json:"rolloutState"`
-				RolloutForSeconds      *int64 `json:"rolloutForSeconds"`
-				RolloutDurationSeconds *int64 `json:"rolloutDurationSeconds"`
-				RolloutCompletedAt     string `json:"rolloutCompletedAt"`
-			} `json:"revisions"`
-		}
-		if err := json.NewDecoder(response.Body).Decode(&history); err != nil {
-			t.Fatalf("decode history: %v", err)
-		}
-		return history.Revisions
-	}
-
-	t.Run("active rollout", func(t *testing.T) {
-		deployedAt := time.Date(2026, 7, 25, 9, 20, 0, 0, time.UTC)
-		request := appendRevision(t, fixture.Version, deployedAt)
-		if _, err := services.AppRollouts.Create(context.Background(), &core.AppRollout{
-			App:              "g-issues",
-			Version:          fixture.Version,
-			State:            core.AppRolloutStateEnrolling,
-			CreatedAt:        deployedAt,
-			EnrollmentEndsAt: deployedAt.Add(2 * time.Minute),
-			Deadline:         deployedAt.Add(15 * time.Minute),
-		}); err != nil {
-			t.Fatalf("Create rollout: %v", err)
-		}
-
-		revisions := getHistory(t)
-		if len(revisions) != 1 || revisions[0].ID != request.ID {
-			t.Fatalf("revisions = %#v", revisions)
-		}
-		if revisions[0].RolloutState != "enrolling" {
-			t.Fatalf("rolloutState = %q, want enrolling", revisions[0].RolloutState)
-		}
-		if revisions[0].RolloutForSeconds == nil || *revisions[0].RolloutForSeconds < 0 {
-			t.Fatalf("rolloutForSeconds = %#v", revisions[0].RolloutForSeconds)
-		}
-		if revisions[0].RolloutDurationSeconds != nil {
-			t.Fatalf("rolloutDurationSeconds = %#v, want nil", revisions[0].RolloutDurationSeconds)
-		}
+	deployedAt := time.Date(2026, 7, 25, 9, 20, 0, 0, time.UTC)
+	request, err := services.AppVersionChangeRequests.AppendRequest(context.Background(), &core.AppVersionChangeRequest{
+		App:         "g-issues",
+		FromVersion: appregistry.FirstInstallFromVersion,
+		ToVersion:   fixture.Version,
+		Actor:       aliceActor,
+		Timestamp:   deployedAt,
+		Metadata: coredata.ChangeRequestMetadata(&core.AppInstallation{
+			AppName:   "g-issues",
+			Version:   fixture.Version,
+			SourceRef: "abc123def456abc123def456abc123def456abcd",
+			Registry:  "toolshed",
+		}),
 	})
+	if err != nil {
+		t.Fatalf("AppendRequest: %v", err)
+	}
+	if _, err := services.AppRollouts.Create(context.Background(), &core.AppRollout{
+		App:              "g-issues",
+		Version:          fixture.Version,
+		State:            core.AppRolloutStateEnrolling,
+		CreatedAt:        deployedAt,
+		EnrollmentEndsAt: deployedAt.Add(2 * time.Minute),
+		Deadline:         deployedAt.Add(15 * time.Minute),
+	}); err != nil {
+		t.Fatalf("Create rollout: %v", err)
+	}
 
-	t.Run("stored outcome", func(t *testing.T) {
-		deployedAt := time.Date(2026, 7, 25, 9, 10, 0, 0, time.UTC)
-		request := appendRevision(t, "0.0.0-snapshot.gother", deployedAt)
-		completedAt := deployedAt.Add(3*time.Minute + 8*time.Second)
-		if err := services.AppVersionRolloutOutcomes.RecordComplete(context.Background(), request.ID, "g-issues", "0.0.0-snapshot.gother", completedAt); err != nil {
-			t.Fatalf("RecordComplete: %v", err)
-		}
-
-		revisions := getHistory(t)
-		if len(revisions) != 2 {
-			t.Fatalf("revisions = %#v", revisions)
-		}
-		var stored struct {
+	httpRequest, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/g-issues/admin/registry/history", nil)
+	httpRequest.Header.Set("Authorization", "Bearer alice-token")
+	response, err := http.DefaultClient.Do(httpRequest)
+	if err != nil {
+		t.Fatalf("GET history: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("GET status = %d: %s", response.StatusCode, body)
+	}
+	var history struct {
+		Revisions []struct {
 			ID                     string `json:"id"`
 			RolloutState           string `json:"rolloutState"`
 			RolloutForSeconds      *int64 `json:"rolloutForSeconds"`
 			RolloutDurationSeconds *int64 `json:"rolloutDurationSeconds"`
-			RolloutCompletedAt     string `json:"rolloutCompletedAt"`
+		} `json:"revisions"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&history); err != nil {
+		t.Fatalf("decode history: %v", err)
+	}
+	if len(history.Revisions) != 1 || history.Revisions[0].ID != request.ID {
+		t.Fatalf("revisions = %#v", history.Revisions)
+	}
+	if history.Revisions[0].RolloutState != "enrolling" {
+		t.Fatalf("rolloutState = %q, want enrolling", history.Revisions[0].RolloutState)
+	}
+	if history.Revisions[0].RolloutForSeconds == nil || *history.Revisions[0].RolloutForSeconds < 0 {
+		t.Fatalf("rolloutForSeconds = %#v", history.Revisions[0].RolloutForSeconds)
+	}
+	if history.Revisions[0].RolloutDurationSeconds != nil {
+		t.Fatalf("rolloutDurationSeconds = %#v, want nil", history.Revisions[0].RolloutDurationSeconds)
+	}
+}
+
+func TestAppAdminRegistryHistoryStoredRolloutOutcomeFields(t *testing.T) {
+	t.Parallel()
+
+	fixture := registrytest.NewInstallFixture(t)
+	services := testutil.NewStubServices(t)
+	alice := seedUser(t, services, "alice@valon.com")
+	aliceActor := principal.UserSubjectID(alice.ID)
+	subjectID := principal.UserSubjectID("alice")
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(subjectID, "admin", "app", "g-issues"),
+		},
+	}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", subjectID, "")
+		cfg.Authorization = authz
+		cfg.Services = services
+		cfg.AppDefs = map[string]*config.ProviderEntry{
+			"g-issues": {Source: config.ProviderSource{Registry: "toolshed"}},
 		}
-		for _, revision := range revisions {
-			if revision.ID == request.ID {
-				stored = revision
-				break
-			}
-		}
-		if stored.ID == "" {
-			t.Fatalf("stored revision missing from %#v", revisions)
-		}
-		if stored.RolloutState != "complete" {
-			t.Fatalf("rolloutState = %q, want complete", stored.RolloutState)
-		}
-		if stored.RolloutDurationSeconds == nil || *stored.RolloutDurationSeconds != 188 {
-			t.Fatalf("rolloutDurationSeconds = %#v, want 188", stored.RolloutDurationSeconds)
-		}
-		if stored.RolloutCompletedAt == "" {
-			t.Fatalf("rolloutCompletedAt missing")
-		}
+		cfg.AppRegistries = map[string]config.AppRegistryConfig{"toolshed": fixture.Registry}
+		cfg.AppRegistryReader = fixture.Reader
 	})
+	testutil.CloseOnCleanup(t, ts)
+
+	deployedAt := time.Date(2026, 7, 25, 9, 10, 0, 0, time.UTC)
+	request, err := services.AppVersionChangeRequests.AppendRequest(context.Background(), &core.AppVersionChangeRequest{
+		App:         "g-issues",
+		FromVersion: appregistry.FirstInstallFromVersion,
+		ToVersion:   "0.0.0-snapshot.gother",
+		Actor:       aliceActor,
+		Timestamp:   deployedAt,
+		Metadata: coredata.ChangeRequestMetadata(&core.AppInstallation{
+			AppName:   "g-issues",
+			Version:   "0.0.0-snapshot.gother",
+			SourceRef: "abc123def456abc123def456abc123def456abcd",
+			Registry:  "toolshed",
+		}),
+	})
+	if err != nil {
+		t.Fatalf("AppendRequest: %v", err)
+	}
+	completedAt := deployedAt.Add(3*time.Minute + 8*time.Second)
+	if err := services.AppVersionRolloutOutcomes.RecordComplete(context.Background(), request.ID, "g-issues", "0.0.0-snapshot.gother", completedAt); err != nil {
+		t.Fatalf("RecordComplete: %v", err)
+	}
+
+	httpRequest, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/g-issues/admin/registry/history", nil)
+	httpRequest.Header.Set("Authorization", "Bearer alice-token")
+	response, err := http.DefaultClient.Do(httpRequest)
+	if err != nil {
+		t.Fatalf("GET history: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("GET status = %d: %s", response.StatusCode, body)
+	}
+	var history struct {
+		Revisions []struct {
+			ID                     string `json:"id"`
+			RolloutState           string `json:"rolloutState"`
+			RolloutDurationSeconds *int64 `json:"rolloutDurationSeconds"`
+			RolloutCompletedAt     string `json:"rolloutCompletedAt"`
+		} `json:"revisions"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&history); err != nil {
+		t.Fatalf("decode history: %v", err)
+	}
+	if len(history.Revisions) != 1 || history.Revisions[0].ID != request.ID {
+		t.Fatalf("revisions = %#v", history.Revisions)
+	}
+	revision := history.Revisions[0]
+	if revision.RolloutState != "complete" {
+		t.Fatalf("rolloutState = %q, want complete", revision.RolloutState)
+	}
+	if revision.RolloutDurationSeconds == nil || *revision.RolloutDurationSeconds != 188 {
+		t.Fatalf("rolloutDurationSeconds = %#v, want 188", revision.RolloutDurationSeconds)
+	}
+	if revision.RolloutCompletedAt == "" {
+		t.Fatalf("rolloutCompletedAt missing")
+	}
 }

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -555,6 +555,7 @@ func startAppRegistryCatalogPoller(
 		ChangeRequests:       changeRequests,
 		Materializations:     materializations,
 		Rollouts:             rollouts,
+		RolloutOutcomes:      result.Services.AppVersionRolloutOutcomes,
 		AppMaterializer:      materializer,
 		AppRestarter:         result.AppRestarter,
 		InstanceID:           appregistry.ResolveInstanceID(),

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -161,6 +161,7 @@ type Server struct {
 	appRollouts            *coredata.AppRolloutService
 	appMaterializations    *coredata.AppInstanceMaterializationService
 	autoDeploySettings     *coredata.AutoDeploySettingsService
+	appRolloutOutcomes     *coredata.AppVersionRolloutOutcomeService
 	appAutoDeployNotify    func(string)
 	artifactsDir           string
 	sourceVersion          string
@@ -421,6 +422,7 @@ func New(cfg Config) (*Server, error) {
 		appRollouts:            cfg.Services.AppRollouts,
 		appMaterializations:    cfg.Services.AppInstanceMaterializations,
 		autoDeploySettings:     cfg.Services.AutoDeploySettings,
+		appRolloutOutcomes:     cfg.Services.AppVersionRolloutOutcomes,
 		appAutoDeployNotify:    cfg.AppAutoDeployNotify,
 		artifactsDir:           strings.TrimSpace(cfg.ArtifactsDir),
 		sourceVersion:          strings.TrimSpace(cfg.SourceVersion),


### PR DESCRIPTION
## Summary
- Add `app_version_rollout_outcomes` IndexedDB store and service to persist terminal rollout timing per change request.
- Record outcomes from the catalog poller when rollouts reach `complete` or `failed`.
- Extend `GET /api/v1/apps/{app}/admin/registry/history` with `rolloutState`, `rolloutForSeconds`, `rolloutDurationSeconds`, `rolloutCompletedAt`, and `rolloutFailedAt`.

Implements gestalt PR 2 from [revision-history-rollout.md](plans/app_registry/one-pagers/revision-history-rollout.md).

## Test plan
- [x] `go test ./internal/coredata/... -run TestAppVersionRolloutOutcome`
- [x] `go test ./internal/server/... -run TestAppAdminRegistryHistory`


Made with [Cursor](https://cursor.com)