### PR TITLE
Fold revision history rollout design into main app registry docs

### DIFF
--- a/plans/app_registry/architecture/indexeddb.md
+++ b/plans/app_registry/architecture/indexeddb.md
@@ -63,6 +63,7 @@ app_version_change_requests      ← accepted version changes (append-only)
 app_version_install_locks        ← install admission lock per app
 gestaltd_source_version_state    ← Toolshed source version selected for rollout accounting
 app_rollouts                     ← current rollout per app
+app_version_rollout_outcomes     ← terminal rollout timing per change request
 app_instance_materializations    ← per-replica acknowledgement of fleet-known versions
 app_auto_deploy_settings         ← per-app auto-deploy policy
 ```
@@ -83,6 +84,7 @@ Access install services after bootstrap via `Result.Services` / `prepared.Servic
 Services.AppVersionChangeRequests   ← install prototype
 Services.GestaltdSourceVersionState ← current Toolshed source version and activation time
 Services.AppRollouts                ← rollout state
+Services.AppVersionRolloutOutcomes  ← terminal rollout timing per change request
 Services.AutoDeploySettings         ← per-app auto-deploy policy
 Services.DB                         ← underlying main-db handle
 ```
@@ -291,6 +293,49 @@ A terminal record may be replaced when the next version is admitted. A non-termi
 | `MarkFailed(ctx, app, version, failedAt)` | Record that the rollout missed its deadline. |
 
 **Admin exposure:** `Get` and `ListActive` back `GET /admin/api/v1/app-rollouts` and rollout summaries on `GET /admin/api/v1/registry-apps`. See [lifecycle.md](../operations/lifecycle.md#admin-observability-api).
+
+---
+
+## Store: `app_version_rollout_outcomes` (Terminal Rollout Timing)
+
+Persists when each admitted version finished or failed its fleet rollout. `app_version_change_requests` stays append-only; this sidecar supplies terminal `completed_at` or `failed_at` for revision-history rows after `app_rollouts` is replaced by a later admission.
+
+Primary key: `id` = change-request `id`.
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "app": "g-issues",
+  "version": "0.0.0-snapshot.gdef456",
+  "completed_at": "2026-07-24T20:45:08Z"
+}
+```
+
+or, on failure:
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "app": "g-issues",
+  "version": "0.0.0-snapshot.gdef456",
+  "failed_at": "2026-07-24T20:54:41Z"
+}
+```
+
+The catalog poller writes the row exactly once when `MarkCompleteForRollout` or `MarkFailedForRollout` succeeds, resolving the change request by `(app, version)` using the latest request for that `to_version` at transition time.
+
+### Service API
+
+`AppVersionRolloutOutcomeService` (`gestaltd/internal/coredata/app_version_rollout_outcomes.go`):
+
+| Method | Description |
+| --- | --- |
+| `Get(ctx, changeRequestID)` | Load one outcome by change-request `id`. |
+| `GetMany(ctx, changeRequestIDs)` | Batch-load outcomes for history enrichment. |
+| `RecordComplete(ctx, changeRequestID, app, version, completedAt)` | Persist a successful rollout end time. |
+| `RecordFailed(ctx, changeRequestID, app, version, failedAt)` | Persist a failed rollout end time. |
+
+**Admin exposure:** `GetMany` backs rollout duration fields on `GET /api/v1/apps/{app}/admin/registry/history`. See [lifecycle.md](../operations/lifecycle.md#revision-history).
 
 ---
 

--- a/plans/app_registry/one-pagers/readme.md
+++ b/plans/app_registry/one-pagers/readme.md
@@ -7,4 +7,4 @@ When a feature ships, fold operational detail into [operations/](../operations/)
 | One-pager | Summary | Status |
 | --- | --- | --- |
 | [auto-deploy.md](./auto-deploy.md) | Automatic fleet admission when a new snapshot is published | Shipped — [changelog 25](../project/changelog.md#changelog-25) |
-| [revision-history-rollout.md](./revision-history-rollout.md) | Rollout status and duration on the Revision history tab | Planned addendum |
+| [revision-history-rollout.md](./revision-history-rollout.md) | Rollout status and duration on the Revision history tab | Shipped — [changelog 26](../project/changelog.md#changelog-26) |

--- a/plans/app_registry/operations/admin.md
+++ b/plans/app_registry/operations/admin.md
@@ -96,7 +96,7 @@ Implemented in `gestalt-providers` (default `/apps` UI), not the embedded `/admi
 - Select a never-deployed version before `expiresAt` or a historical version before `expiresAt` as the fleet-wide desired version.
 - Show per-version `publishedAt`, linked source commit, triggering PR or commit, and publishing workflow run.
 - Show in-flight (**Publishing**) and recent failed (**Failed**) publishes with elapsed or total publish time. See [pending-publish.md](./pending-publish.md).
-- Show the permanent, read-only deploy chain in a **Revision history** tab.
+- Show the permanent, read-only deploy chain in a **Revision history** tab with rollout status and duration on each admission.
 - Show whether historical versions are still redeployable or permanently locked.
 - Legacy published versions without workflow metadata still link the commit and show **not recorded** for workflow/PR fields.
 - Disable deploy actions while a rollout is `enrolling` or `restarting`; poll registry state every **3s** and refresh until rollout is terminal.
@@ -111,7 +111,7 @@ Selection is fleet-wide. It is not per-user or per-replica.
 The page header shows the app name, **App management** label, registry binding, and current **Desired version**. Two tabs separate deployment from audit:
 
 - **Published snapshots** — pending, failed, and published entries in one newest-first list. A published row has **Deploy** when the version is **Available** or **Redeployable**.
-- **Revision history** — accepted fleet version changes in reverse chronological order. This tab is always read-only.
+- **Revision history** — accepted fleet version changes in reverse chronological order with rollout status and duration. This tab is always read-only.
 
 See [pending-publish.md](./pending-publish.md) for snapshot merge rules, **3s** registry polling during bootstrap and active publish/rollout, and live **Publishing** duration labels.
 
@@ -242,19 +242,31 @@ PR #3872 · Title | 0.0.0-snapshot.g… | Queued for deploy   | —
 
 The Revision history tab displays `app_version_change_requests` as an immutable deploy ledger. It is not built from the deduplicated `knownVersions` projection: every accepted transition appears exactly once, including upgrades and downgrades that revisit an earlier version.
 
+Fleet admission appends a change request immediately, but the version is not fleet-available until rollout reaches `complete`. Each row shows rollout status and duration labels that mirror the **Publishing** / **Published in** pattern on Published snapshots. See [pending-publish.md](./pending-publish.md#publish-duration) and [lifecycle.md](./lifecycle.md#revision-history).
+
+| Row status | Start | End | Status label |
+| --- | --- | --- | --- |
+| **Rolling out** | `deployedAt` | `liveNow` (client clock, 1s) | `Rolling out` + `for 2m 14s` |
+| **Available** | `deployedAt` | `rolloutCompletedAt` | `Available in 3m 08s` |
+| **Failed** | `deployedAt` | `rolloutFailedAt` | `Failed after 12m 41s` |
+
 ```text
 Revision history
 
-Deployed at  | Transition                    | Availability | Deployed by
------------- | ----------------------------- | ------------ | ---------------
-Jul 25 09:10 | gdef456 → gabc123 (downgrade) | Current      | alice@valon.com
-Jul 24 16:42 | gabc123 → gdef456 (upgrade)   | Redeployable | alice@valon.com
-Jul 21 12:00 | First deployment → gabc123    | Current      | bob@valon.com
+Deployed at  | Transition                    | Status                    | Deployed by
+------------ | ----------------------------- | ------------------------- | ---------------
+2 minutes ago| gabc123 → gdef456 (upgrade)   | Rolling out · for 2m 14s  | alice@valon.com
+Jul 24 16:42 | gdef456 → gabc123 (downgrade) | Available in 3m 08s       | alice@valon.com
+Jul 21 12:00 | First deployment → gabc123    | Available in 1m 52s       | bob@valon.com
 ```
 
-Each row links to the source commit and, when recorded, the triggering pull request and publish workflow. **Availability** shows the selected version's present-day state, so repeated entries for the same version have the same value. The current desired version is **Current**; other versions are **Redeployable** or **Locked**. Automatic admissions show **system:auto-deploy** as the deployer. The history tab itself has no deploy action because availability is an attribute of a version, not an individual event. Eligible selection remains on Published snapshots.
+Each row links to the source commit and, when recorded, the triggering pull request and publish workflow. The newest revision row shows **Rolling out** while `registry.rollout` is `enrolling` or `restarting` for the current admission. Older rows for the same version omit live rollout decoration. Terminal durations come from the `app_version_rollout_outcomes` sidecar when present. Automatic admissions show **system:auto-deploy** as the deployer; rollout status is independent of actor.
+
+Enable `useLiveNow` while the history table has at least one in-flight rollout row so **Rolling out** durations advance between registry polls. The parent registry query already polls every **3s** during active rollout; the history query does not need its own interval.
 
 Load the newest page when the tab opens and paginate older entries with a cursor. An empty deploy chain renders **No deployments yet**. Registry retention permanently preserves the chain and version metadata. Artifacts for locked revisions may be pruned; see [retention.md](./retention.md).
+
+Legacy revisions admitted before rollout-outcome persistence omit rollout status and duration; `deployedAt` only.
 
 ---
 
@@ -285,7 +297,8 @@ Load the newest page when the tab opens and paginate older entries with a cursor
 ├── <a href="../project/changelog.md#changelog-17">17 — Version Retention and Cleanup</a>
 ├── <a href="../project/changelog.md#changelog-18">18 — Revision History and Redeploy Windows</a>
 ├── <a href="../project/changelog.md#changelog-21">21 — Rollout Phase Stepper and Selected Version Row</a>
-└── <a href="../project/changelog.md#changelog-25">25 — Auto-Deploy Published Snapshots</a>
+├── <a href="../project/changelog.md#changelog-25">25 — Auto-Deploy Published Snapshots</a>
+└── <a href="../project/changelog.md#changelog-26">26 — Revision History Rollout Visibility</a>
 </pre>
 
 ### Related Docs

--- a/plans/app_registry/operations/lifecycle.md
+++ b/plans/app_registry/operations/lifecycle.md
@@ -101,6 +101,8 @@ Replica membership is discovered rather than configured:
 6. The rollout completes when the target cohort is non-empty and every member records `restarted_at`.
 7. The rollout fails if a target-cohort replica does not restart before the deadline, or if no target replica acknowledges before the deadline.
 
+When the catalog poller transitions a rollout to `complete` or `failed`, it writes one `app_version_rollout_outcomes` row keyed by the latest change request for `(app, version)`. Duplicate writes for the same change-request `id` are ignored. The poller records an outcome only when the transition succeeds; no-op transitions on an already-terminal rollout do not write. Terminal durations on the revision-history API prefer this sidecar over the live `app_rollouts` record.
+
 This prevents a Cloud Run deployment from combining five old and five candidate processes into a ten-member cohort. When Cloud Run terminates the old deployment, those rows remain visible for diagnostics but do not block the candidate deployment from completing at `5/5 restarted`.
 
 Never declare success because any source-version cohort completed. The old source version could reach `5/5` while the promoted source version fails. Success is tied to `target_source_version`.
@@ -714,6 +716,8 @@ Rules:
 
 #### Revision History
 
+<a id="revision-history"></a>
+
 `GET /api/v1/apps/{app}/admin/registry/history?limit=50&cursor=…` returns the append-only `app_version_change_requests` sequence in reverse chronological order.
 
 **Response `200`**
@@ -738,7 +742,12 @@ Rules:
         }
       },
       "deploymentState": "desired",
-      "current": true
+      "current": true,
+      "rolloutState": "restarting",
+      "rolloutForSeconds": 134,
+      "rolloutDurationSeconds": null,
+      "rolloutCompletedAt": null,
+      "rolloutFailedAt": null
     }
   ],
   "nextCursor": "2026-07-24T20:42:00Z:550e8400-e29b-41d4-a716-446655440000"
@@ -753,6 +762,13 @@ Rules:
 - `current` is true only for the latest request that produced `LatestKnownVersion`. Earlier requests remain historical even when they selected the same version.
 - `deploymentState` is the selected version's present-day eligibility: `desired`, `redeployable`, or `locked`. Repeated entries for the same version share the same value. Historical entries include `deployableUntil` (from `expiresAt`) when applicable.
 - `deployedAt`, `deployedBy`, source fields, and publication provenance come from the change request and its immutable `metadata_json` install-contract snapshot. New admissions snapshot publication provenance; legacy rows may omit it.
+- Omit rollout fields when no rollout exists for the revision and no outcome sidecar is stored.
+- `rolloutState` is `enrolling`, `restarting`, `complete`, or `failed`.
+- For active rollouts, project `rolloutState` from `app_rollouts` only on the current revision (`id` matches the latest change request). Older same-version rows do not inherit the live rollout.
+- For terminal rows, prefer the `app_version_rollout_outcomes` sidecar. Fall back to `app_rollouts` when the rollout record is still terminal and versions match.
+- `rolloutForSeconds` is set only while state is `enrolling` or `restarting`.
+- `rolloutDurationSeconds`, `rolloutCompletedAt`, and `rolloutFailedAt` are set only for terminal states.
+- Legacy revisions without a stored outcome omit terminal duration fields.
 - An app with no change requests returns `revisions: []`. The route has the same app-admin authorization and fail-closed behavior as the registry-state route.
 - The endpoint performs no writes and exposes no deploy action. Eligible historical versions are selected from Published snapshots.
 

--- a/plans/app_registry/project/changelog.md
+++ b/plans/app_registry/project/changelog.md
@@ -303,3 +303,17 @@ App admins opt registry-only apps into automatic fleet admission when a new snap
 **Design:** [gestalt#2970](https://github.com/valon-technologies/gestalt/pull/2970)
 
 **Merged:** [gestalt#2971](https://github.com/valon-technologies/gestalt/pull/2971) · [gestalt#2972](https://github.com/valon-technologies/gestalt/pull/2972) · [gestalt#2973](https://github.com/valon-technologies/gestalt/pull/2973) · [gestalt#2974](https://github.com/valon-technologies/gestalt/pull/2974) · [gestalt#2976](https://github.com/valon-technologies/gestalt/pull/2976) · [gestalt#2977](https://github.com/valon-technologies/gestalt/pull/2977) · [gestalt#2981](https://github.com/valon-technologies/gestalt/pull/2981) · [gestalt-providers#1197](https://github.com/valon-technologies/gestalt-providers/pull/1197) · [gestalt-providers#1200](https://github.com/valon-technologies/gestalt-providers/pull/1200) · [gestalt-providers#1201](https://github.com/valon-technologies/gestalt-providers/pull/1201) · [toolshed#3864](https://github.com/valon-technologies/toolshed/pull/3864) · [toolshed#3867](https://github.com/valon-technologies/toolshed/pull/3867) · [toolshed#3859](https://github.com/valon-technologies/toolshed/pull/3859) · [gestalt#2984](https://github.com/valon-technologies/gestalt/pull/2984)
+
+<a id="changelog-26"></a>
+
+### 26 — Revision History Rollout Visibility
+
+**Tags:** [`admin.md`](../operations/admin.md) [`indexeddb.md`](../architecture/indexeddb.md) [`lifecycle.md`](../operations/lifecycle.md)
+
+Show in-flight and completed rollout timing on the **Revision history** tab on `/apps/{app}/admin`. Persist terminal rollout end times in `app_version_rollout_outcomes` so historical rows keep their duration after `app_rollouts` is replaced. The history API joins live rollout state only on the current revision; terminal rows prefer the outcome sidecar.
+
+**Design:** [gestalt#2986](https://github.com/valon-technologies/gestalt/pull/2986)
+
+**Merged:** [gestalt#2989](https://github.com/valon-technologies/gestalt/pull/2989) · [gestalt-providers#1206](https://github.com/valon-technologies/gestalt-providers/pull/1206) · [toolshed#3874](https://github.com/valon-technologies/toolshed/pull/3874)
+
+**Deploy:** toolshed `GESTALTD_PINNED_SHA` → `e770552fb` ([Deploy Valon Tools](https://github.com/valon-technologies/toolshed/actions/workflows/deploy-valon-tools.yml))

--- a/plans/app_registry/project/tests.md
+++ b/plans/app_registry/project/tests.md
@@ -494,6 +494,8 @@ Covered behaviors:
 - published versions render newest first with desired version selected
 - pending, failed, and published rows share one snapshots table with status and timing labels
 - the Revision history tab loads lazily, renders newest-first transitions, paginates older rows, and shows **No deployments yet** for an empty chain
+- revision history shows **Rolling out**, **Available**, and **Failed** rollout status with duration labels on matching rows
+- revision history omits live rollout status from older same-version rows when a version is re-admitted
 - active rollout or **409** after a stale page disables deploy actions until rollout is terminal
 - **403** renders access denied without registry metadata
 - publication labels link only the PR number; titles render as plain muted text when present
@@ -573,6 +575,64 @@ Covered behaviors:
 - failed auto-deploy `PUT` shows an error line under the switch
 - **Queued for deploy** appears on the pending snapshot row during an active rollout while auto-deploy is enabled
 - revision history renders `system:auto-deploy` as the deployer for automatic admissions
+
+---
+
+## Revision History Rollout Tests
+
+API: [lifecycle.md](../operations/lifecycle.md#revision-history). UI: [admin.md](../operations/admin.md#revision-history-tab).
+
+### Gestalt Coredata Tests (`app_version_rollout_outcomes_test.go`)
+
+Implemented in [gestalt#2989](https://github.com/valon-technologies/gestalt/pull/2989).
+
+Run:
+
+```bash
+cd gestaltd
+go test ./internal/coredata/... -run TestAppVersionRolloutOutcome -count=1
+```
+
+| Test | Expected behavior |
+| --- | --- |
+| `TestAppVersionRolloutOutcomeServiceRecordCompleteIsIdempotent` | `RecordComplete` persists and repeated writes are idempotent |
+| `TestAppVersionRolloutOutcomeServiceRecordFailed` | `RecordFailed` persists and `Get` returns `failed_at` |
+| `TestAppVersionRolloutOutcomeServiceGetMissing` | `Get` returns `ErrNotFound` when no outcome exists |
+
+### Gestalt Handler Tests (`handlers_app_admin_registry_test.go`)
+
+Implemented in [gestalt#2989](https://github.com/valon-technologies/gestalt/pull/2989).
+
+Run:
+
+```bash
+cd gestaltd
+go test ./internal/server/... -run TestAppAdminRegistryHistory -count=1
+```
+
+| Test | Expected behavior |
+| --- | --- |
+| `TestAppAdminRegistryHistoryActiveRolloutFields` | Current revision includes live `rolloutState` and `rolloutForSeconds` |
+| `TestAppAdminRegistryHistoryStoredRolloutOutcomeFields` | Terminal duration comes from the outcome sidecar |
+| `TestAppAdminRegistryHistoryIgnoresLiveRolloutForOlderSameVersion` | Older same-version row omits live rollout state |
+| `TestAppAdminRegistryHistoryPrefersStoredOutcomeOverLiveRollout` | Stored terminal outcome wins over live `app_rollouts` |
+
+### Default App UI Tests (`gestalt-providers`)
+
+Implemented in [gestalt-providers#1206](https://github.com/valon-technologies/gestalt-providers/pull/1206).
+
+Run:
+
+```bash
+cd gestalt-providers/app/default
+npm run test:e2e -- e2e/app-admin-mock.spec.ts -g "rollout status"
+```
+
+Covered behaviors:
+
+- revision history **Status** column shows **Rolling out** with a live timer during active rollout
+- terminal rows show **Available** with **Available in** duration
+- older same-version revision omits rollout status when a version is re-admitted
 
 ---
 


### PR DESCRIPTION
## Summary
Fold operational detail from [revision-history-rollout.md](plans/app_registry/one-pagers/revision-history-rollout.md) into the main app registry docs:

- **admin.md** — Revision history **Status** column, rollout duration labels, live polling behavior
- **lifecycle.md** — History API rollout fields, outcome sidecar write rules, current-revision live join
- **indexeddb.md** — `app_version_rollout_outcomes` store and service
- **tests.md** — Coredata, handler, and Playwright test coverage
- **changelog.md** — Milestone 26 with merged PR links

Keeps the one-pager as the canonical design reference.

Implements gestalt PR 5 from the revision-history-rollout addendum.

## Test plan
- [x] Docs-only change; no code changes


Made with [Cursor](https://cursor.com)