### PR TITLE
helm: default to RollingUpdate and stabilize Service ClusterIP

### DIFF
--- a/gestaltd/deploy/helm/gestaltd/templates/service.yaml
+++ b/gestaltd/deploy/helm/gestaltd/templates/service.yaml
@@ -6,6 +6,10 @@ metadata:
     {{- include "gestaltd.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.clusterIP }}
+  clusterIP: {{ . }}
+  {{- end }}
+  publishNotReadyAddresses: {{ .Values.service.publishNotReadyAddresses | default false }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/gestaltd/deploy/helm/gestaltd/values-local.yaml
+++ b/gestaltd/deploy/helm/gestaltd/values-local.yaml
@@ -15,3 +15,9 @@ config:
         source: https://github.com/valon-technologies/gestalt-providers/releases/download/indexeddb/relationaldb/v0.0.1-alpha.2/provider-release.yaml
         config:
           dsn: "sqlite:///data/gestalt.db"
+
+# Single replica on a ReadWriteOnce PVC: Recreate avoids a RollingUpdate surge
+# pod waiting on a PVC the old pod still holds. Shared multi-replica
+# environments use the chart default (RollingUpdate) instead.
+updateStrategy:
+  type: Recreate

--- a/gestaltd/deploy/helm/gestaltd/values.yaml
+++ b/gestaltd/deploy/helm/gestaltd/values.yaml
@@ -30,6 +30,15 @@ serviceAccount:
 service:
   type: ClusterIP
   port: 8080
+  # Pin a clusterIP to keep it stable across reinstalls. Without this, deleting
+  # and recreating the Service assigns a new ClusterIP, and clients that cache
+  # the resolved address (e.g. cloudflared) keep dialing the dead old IP until
+  # DNS re-resolves, extending 5xx past the actual rollout window.
+  clusterIP: ""
+  # Keep false so kube-proxy only routes to pods that pass readiness. This
+  # pairs with RollingUpdate (maxUnavailable: 0) to guarantee an endpoint is
+  # always available during deploys.
+  publishNotReadyAddresses: false
 
 managementService:
   enabled: false
@@ -74,7 +83,11 @@ persistence:
   size: 1Gi
 
 updateStrategy:
-  type: Recreate
+  # RollingUpdate keeps old pods serving until new ones pass readiness, so
+  # multi-replica shared environments (dev/stage/prod with DB-backed state and
+  # emptyDir volumes) deploy with no downtime. Single-replica local deploys that
+  # mount a ReadWriteOnce PVC should override this to Recreate.
+  type: RollingUpdate
   rollingUpdate:
     maxUnavailable: 0
     maxSurge: 1


### PR DESCRIPTION
## Summary
- Switch the gestaltd chart default rollout strategy from `Recreate` to `RollingUpdate` with `maxUnavailable: 0`, `maxSurge: 1`, so old pods keep serving until new ones pass readiness. The previous `Recreate` default killed all pods before starting new ones, leaving the `gestaltd` ClusterIP Service with zero ready endpoints on every deploy and causing the Cloudflare tunnel in front of it to return 502 for ~2 minutes.
- Pin the single-replica local profile (`values-local.yaml`) to `Recreate` explicitly, since its `ReadWriteOnce` PVC makes a `RollingUpdate` surge pod wait on a volume the old pod still holds.
- Expose `service.clusterIP` and `service.publishNotReadyAddresses` in the Service template and values. Pinning `clusterIP` keeps the address stable across reinstalls so clients that cache the resolved ClusterIP (e.g. `cloudflared`) don't keep dialing a dead old IP after the Service is recreated. `publishNotReadyAddresses` defaults to `false`, pairing with the `RollingUpdate` default so traffic only routes to ready pods.

## Test plan
- [x] `helm lint gestaltd/deploy/helm/gestaltd` passes
- [x] `helm template` renders `RollingUpdate` / `publishNotReadyAddresses: false` under base, `values-local`, `ci-values`, and `ci-values-preparation`
- [x] `values-local.yaml` renders `Recreate` (preserved behavior)
- [x] `service.clusterIP` is omitted when empty, rendered when set
- [ ] CI `validate-gestaltd` (`helm lint` + `helm template` matrix) passes