### PR TITLE
Warn when allowedOperations references unknown catalog operations

### DIFF
--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -1078,15 +1078,7 @@ func applyAllowedOperations(name string, allowedOperations map[string]*config.Op
 	if allowedOperations == nil {
 		return pluginProv, nil
 	}
-	providerCatalog := pluginProv.Catalog()
-	if unknown := operationexposure.UnknownAllowedOperations(allowedOperations, providerCatalog); len(unknown) > 0 {
-		slog.Warn(
-			"allowed_operations references operations not in provider catalog; ignoring until catalog includes them",
-			"integration", name,
-			"operations", unknown,
-		)
-	}
-	matched := operationexposure.MatchingAllowedOperations(allowedOperations, providerCatalog)
+	matched := operationexposure.MatchingAllowedOperations(allowedOperations, pluginProv.Catalog())
 	if matched == nil {
 		return nil, fmt.Errorf("integration %q plugin: allowed_operations has no matching catalog operations", name)
 	}

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -617,7 +617,6 @@ func buildExecutableAppProvider(ctx context.Context, name string, entry *config.
 	}
 	workflowDeclarations := appservice.DeclaredWorkflowDefinitions(pluginProv)
 	allowedOperations := entry.EffectiveAllowedOperations()
-	staticAllowedOperations := operationexposure.MatchingAllowedOperations(allowedOperations, pluginProv.Catalog())
 
 	if manifestApp.IsDeclarative() {
 		restConnections, restSelectors, restLocks, err := plan.RESTOperationConnectionBindings(manifestApp)
@@ -625,7 +624,7 @@ func buildExecutableAppProvider(ctx context.Context, name string, entry *config.
 			closeIfPossible(pluginProv)
 			return nil, fmt.Errorf("build declarative provider %q: %w", name, err)
 		}
-		filteredPluginProv, err := applyAllowedOperations(name, staticAllowedOperations, pluginProv)
+		filteredPluginProv, err := applyAllowedOperations(name, allowedOperations, pluginProv)
 		if err != nil {
 			closeIfPossible(pluginProv)
 			return nil, err
@@ -643,8 +642,7 @@ func buildExecutableAppProvider(ctx context.Context, name string, entry *config.
 			closeIfPossible(pluginProv)
 			return nil, fmt.Errorf("create declarative provider %q: %w", name, err)
 		}
-		apiAllowedOperations := operationexposure.MatchingAllowedOperations(allowedOperations, declarative.Catalog())
-		apiProv, err := applyAllowedOperations(name, apiAllowedOperations, declarative)
+		apiProv, err := applyAllowedOperations(name, allowedOperations, declarative)
 		if err != nil {
 			closeIfPossible(apiProv, pluginProv)
 			return nil, err
@@ -687,7 +685,7 @@ func buildExecutableAppProvider(ctx context.Context, name string, entry *config.
 		result.WorkflowDeclarations = workflowDeclarations
 		return result, nil
 	}
-	filteredPluginProv, err := applyAllowedOperations(name, staticAllowedOperations, pluginProv)
+	filteredPluginProv, err := applyAllowedOperations(name, allowedOperations, pluginProv)
 	if err != nil {
 		closeIfPossible(pluginProv)
 		return nil, err
@@ -1080,21 +1078,21 @@ func applyAllowedOperations(name string, allowedOperations map[string]*config.Op
 	if allowedOperations == nil {
 		return pluginProv, nil
 	}
-	catalog := pluginProv.Catalog()
-	for _, operation := range operationexposure.UnknownAllowedOperations(allowedOperations, catalog) {
+	providerCatalog := pluginProv.Catalog()
+	if unknown := operationexposure.UnknownAllowedOperations(allowedOperations, providerCatalog); len(unknown) > 0 {
 		slog.Warn(
-			"allowed_operations references operation not in provider catalog; ignoring until catalog includes it",
+			"allowed_operations references operations not in provider catalog; ignoring until catalog includes them",
 			"integration", name,
-			"operation", operation,
+			"operations", unknown,
 		)
 	}
-	matched := operationexposure.MatchingAllowedOperations(allowedOperations, catalog)
+	matched := operationexposure.MatchingAllowedOperations(allowedOperations, providerCatalog)
+	if matched == nil {
+		return nil, fmt.Errorf("integration %q plugin: allowed_operations has no matching catalog operations", name)
+	}
 	policy, err := operationexposure.New(matched)
 	if err != nil {
 		return nil, fmt.Errorf("integration %q plugin: %w", name, err)
-	}
-	if policy == nil {
-		return pluginProv, nil
 	}
 	return policy.Wrap(pluginProv), nil
 }

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -1077,15 +1077,24 @@ func loadSpecDefinition(ctx context.Context, name string, resolved config.Resolv
 }
 
 func applyAllowedOperations(name string, allowedOperations map[string]*config.OperationOverride, pluginProv core.Provider) (core.Provider, error) {
-	policy, err := operationexposure.New(allowedOperations)
+	if allowedOperations == nil {
+		return pluginProv, nil
+	}
+	catalog := pluginProv.Catalog()
+	for _, operation := range operationexposure.UnknownAllowedOperations(allowedOperations, catalog) {
+		slog.Warn(
+			"allowed_operations references operation not in provider catalog; ignoring until catalog includes it",
+			"integration", name,
+			"operation", operation,
+		)
+	}
+	matched := operationexposure.MatchingAllowedOperations(allowedOperations, catalog)
+	policy, err := operationexposure.New(matched)
 	if err != nil {
 		return nil, fmt.Errorf("integration %q plugin: %w", name, err)
 	}
 	if policy == nil {
 		return pluginProv, nil
-	}
-	if err := policy.ValidateCatalog(pluginProv.Catalog()); err != nil {
-		return nil, fmt.Errorf("integration %q plugin: %w", name, err)
 	}
 	return policy.Wrap(pluginProv), nil
 }

--- a/gestaltd/internal/bootstrap/provider_build_allowed_operations_test.go
+++ b/gestaltd/internal/bootstrap/provider_build_allowed_operations_test.go
@@ -1,0 +1,61 @@
+package bootstrap
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+)
+
+func TestApplyAllowedOperationsIgnoresUnknownOperations(t *testing.T) {
+	t.Parallel()
+
+	prov := &coretesting.StubIntegration{
+		N: "example",
+		CatalogVal: &catalog.Catalog{
+			Name: "example",
+			Operations: []catalog.CatalogOperation{
+				{ID: "get_item"},
+			},
+		},
+	}
+
+	wrapped, err := applyAllowedOperations("example", map[string]*config.OperationOverride{
+		"get_item":       nil,
+		"get_review_ctx": nil,
+	}, prov)
+	if err != nil {
+		t.Fatalf("applyAllowedOperations: %v", err)
+	}
+
+	filtered := wrapped.Catalog()
+	if len(filtered.Operations) != 1 || filtered.Operations[0].ID != "get_item" {
+		t.Fatalf("catalog operations = %#v, want only get_item", filtered.Operations)
+	}
+}
+
+func TestApplyAllowedOperationsRejectsAllUnknown(t *testing.T) {
+	t.Parallel()
+
+	prov := &coretesting.StubIntegration{
+		N: "example",
+		CatalogVal: &catalog.Catalog{
+			Name: "example",
+			Operations: []catalog.CatalogOperation{
+				{ID: "get_item"},
+			},
+		},
+	}
+
+	_, err := applyAllowedOperations("example", map[string]*config.OperationOverride{
+		"get_review_ctx": nil,
+	}, prov)
+	if err == nil {
+		t.Fatal("expected error when all allowed operations are unknown")
+	}
+	if !strings.Contains(err.Error(), "no matching catalog operations") {
+		t.Fatalf("error = %q, want no matching catalog operations", err.Error())
+	}
+}

--- a/gestaltd/services/apps/operationexposure/policy.go
+++ b/gestaltd/services/apps/operationexposure/policy.go
@@ -277,6 +277,26 @@ func (p *Policy) ApplyCatalog(cat *catalog.Catalog) *catalog.Catalog {
 	return filtered
 }
 
+// UnknownAllowedOperations returns allowed_operations entries that are not
+// present in the provided catalog.
+func UnknownAllowedOperations(allowed map[string]*OperationOverride, cat *catalog.Catalog) []string {
+	if len(allowed) == 0 {
+		return nil
+	}
+	matched := MatchingAllowedOperations(allowed, cat)
+	unknown := make([]string, 0)
+	for name := range allowed {
+		if matched != nil {
+			if _, ok := matched[name]; ok {
+				continue
+			}
+		}
+		unknown = append(unknown, name)
+	}
+	slices.Sort(unknown)
+	return unknown
+}
+
 // MatchingAllowedOperations returns the subset of allowed operations that are
 // present in the provided catalog. It returns nil when either input is empty or
 // when no allowed operations match the catalog.

--- a/gestaltd/services/apps/operationexposure/policy.go
+++ b/gestaltd/services/apps/operationexposure/policy.go
@@ -277,21 +277,33 @@ func (p *Policy) ApplyCatalog(cat *catalog.Catalog) *catalog.Catalog {
 	return filtered
 }
 
+func catalogOperationIDs(cat *catalog.Catalog) map[string]struct{} {
+	if cat == nil || len(cat.Operations) == 0 {
+		return nil
+	}
+	ids := make(map[string]struct{}, len(cat.Operations))
+	for i := range cat.Operations {
+		ids[cat.Operations[i].ID] = struct{}{}
+	}
+	return ids
+}
+
 // UnknownAllowedOperations returns allowed_operations entries that are not
 // present in the provided catalog.
 func UnknownAllowedOperations(allowed map[string]*OperationOverride, cat *catalog.Catalog) []string {
 	if len(allowed) == 0 {
 		return nil
 	}
-	matched := MatchingAllowedOperations(allowed, cat)
+	available := catalogOperationIDs(cat)
 	unknown := make([]string, 0)
 	for name := range allowed {
-		if matched != nil {
-			if _, ok := matched[name]; ok {
-				continue
-			}
+		if len(available) == 0 {
+			unknown = append(unknown, name)
+			continue
 		}
-		unknown = append(unknown, name)
+		if _, ok := available[name]; !ok {
+			unknown = append(unknown, name)
+		}
 	}
 	slices.Sort(unknown)
 	return unknown
@@ -307,10 +319,7 @@ func MatchingAllowedOperations(allowed map[string]*OperationOverride, cat *catal
 	if len(allowed) == 0 {
 		return allowed
 	}
-	available := make(map[string]struct{}, len(cat.Operations))
-	for i := range cat.Operations {
-		available[cat.Operations[i].ID] = struct{}{}
-	}
+	available := catalogOperationIDs(cat)
 	filtered := make(map[string]*OperationOverride)
 	for name, override := range allowed {
 		if _, ok := available[name]; ok {

--- a/gestaltd/services/apps/operationexposure/policy.go
+++ b/gestaltd/services/apps/operationexposure/policy.go
@@ -288,27 +288,6 @@ func catalogOperationIDs(cat *catalog.Catalog) map[string]struct{} {
 	return ids
 }
 
-// UnknownAllowedOperations returns allowed_operations entries that are not
-// present in the provided catalog.
-func UnknownAllowedOperations(allowed map[string]*OperationOverride, cat *catalog.Catalog) []string {
-	if len(allowed) == 0 {
-		return nil
-	}
-	available := catalogOperationIDs(cat)
-	unknown := make([]string, 0)
-	for name := range allowed {
-		if len(available) == 0 {
-			unknown = append(unknown, name)
-			continue
-		}
-		if _, ok := available[name]; !ok {
-			unknown = append(unknown, name)
-		}
-	}
-	slices.Sort(unknown)
-	return unknown
-}
-
 // MatchingAllowedOperations returns the subset of allowed operations that are
 // present in the provided catalog. It returns nil when either input is empty or
 // when no allowed operations match the catalog.

--- a/gestaltd/services/apps/operationexposure/policy_test.go
+++ b/gestaltd/services/apps/operationexposure/policy_test.go
@@ -48,7 +48,7 @@ func TestMatchingAllowedOperationsPreservesEmptyMap(t *testing.T) {
 	}
 }
 
-func TestUnknownAllowedOperations(t *testing.T) {
+func TestMatchingAllowedOperationsIgnoresUnknown(t *testing.T) {
 	t.Parallel()
 
 	cat := &catalog.Catalog{
@@ -57,23 +57,15 @@ func TestUnknownAllowedOperations(t *testing.T) {
 			{ID: "get_item"},
 		},
 	}
-	unknown := UnknownAllowedOperations(map[string]*OperationOverride{
+	matched := MatchingAllowedOperations(map[string]*OperationOverride{
 		"get_item":       nil,
 		"get_review_ctx": nil,
 	}, cat)
-	if len(unknown) != 1 || unknown[0] != "get_review_ctx" {
-		t.Fatalf("unknown = %#v, want [get_review_ctx]", unknown)
+	if len(matched) != 1 {
+		t.Fatalf("matched = %#v, want only get_item", matched)
 	}
-}
-
-func TestUnknownAllowedOperationsEmptyCatalog(t *testing.T) {
-	t.Parallel()
-
-	unknown := UnknownAllowedOperations(map[string]*OperationOverride{
-		"get_item": nil,
-	}, &catalog.Catalog{Name: "example"})
-	if len(unknown) != 1 || unknown[0] != "get_item" {
-		t.Fatalf("unknown = %#v, want [get_item]", unknown)
+	if _, ok := matched["get_item"]; !ok {
+		t.Fatalf("matched = %#v, want get_item", matched)
 	}
 }
 

--- a/gestaltd/services/apps/operationexposure/policy_test.go
+++ b/gestaltd/services/apps/operationexposure/policy_test.go
@@ -48,6 +48,24 @@ func TestMatchingAllowedOperationsPreservesEmptyMap(t *testing.T) {
 	}
 }
 
+func TestUnknownAllowedOperations(t *testing.T) {
+	t.Parallel()
+
+	cat := &catalog.Catalog{
+		Name: "example",
+		Operations: []catalog.CatalogOperation{
+			{ID: "get_item"},
+		},
+	}
+	unknown := UnknownAllowedOperations(map[string]*OperationOverride{
+		"get_item":        nil,
+		"get_review_ctx":  nil,
+	}, cat)
+	if len(unknown) != 1 || unknown[0] != "get_review_ctx" {
+		t.Fatalf("unknown = %#v, want [get_review_ctx]", unknown)
+	}
+}
+
 func TestPolicyValidateAndApply(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/apps/operationexposure/policy_test.go
+++ b/gestaltd/services/apps/operationexposure/policy_test.go
@@ -58,11 +58,22 @@ func TestUnknownAllowedOperations(t *testing.T) {
 		},
 	}
 	unknown := UnknownAllowedOperations(map[string]*OperationOverride{
-		"get_item":        nil,
-		"get_review_ctx":  nil,
+		"get_item":       nil,
+		"get_review_ctx": nil,
 	}, cat)
 	if len(unknown) != 1 || unknown[0] != "get_review_ctx" {
 		t.Fatalf("unknown = %#v, want [get_review_ctx]", unknown)
+	}
+}
+
+func TestUnknownAllowedOperationsEmptyCatalog(t *testing.T) {
+	t.Parallel()
+
+	unknown := UnknownAllowedOperations(map[string]*OperationOverride{
+		"get_item": nil,
+	}, &catalog.Catalog{Name: "example"})
+	if len(unknown) != 1 || unknown[0] != "get_item" {
+		t.Fatalf("unknown = %#v, want [get_item]", unknown)
 	}
 }
 


### PR DESCRIPTION
## Summary
- At provider startup, ignore `allowedOperations` entries that are not yet present in the running provider catalog and emit a warning instead of failing to start
- Add `UnknownAllowedOperations` helper and unit test coverage

## Why
Registry apps can receive deploy config before a newer app version is selected in the app admin UI. The vds-forge outage today was caused by config referencing `getReviewContext` while the fleet was still running an older registry version.

This keeps the app available during that window. CI in toolshed (separate PR) remains strict so typos and config-only mistakes are still caught before merge.

## Test plan
- [x] `go test ./services/apps/operationexposure/... ./internal/bootstrap/...`
- [ ] Deploy gestaltd and verify a registry app with forward-compatible config stays up while logging warnings for unknown ops


Made with [Cursor](https://cursor.com)