### PR TITLE
fix: null registry in PATH overlay source override

### DIFF
--- a/gestaltd/internal/daemon/provider_local.go
+++ b/gestaltd/internal/daemon/provider_local.go
@@ -469,6 +469,7 @@ func providerLocalSourceOverride(manifestPath string) map[string]any {
 		"url":           nil,
 		"githubRelease": nil,
 		"git":           nil,
+		"registry":      nil,
 		"auth":          nil,
 	}
 }


### PR DESCRIPTION
When a PATH argument overrides an app source, the overlay config sets `source.path` but did not null out `source.registry`. After YAML deep-merge, both `Path` and `Registry` are set, so `IsRegistry()` returns true. This caused `mountedAppStaticsFromEntries` to use the registry static handler instead of the dev handler for dev-active apps, resulting in 503 "app unavailable" when serving a registry app via a local PATH override.