### PR TITLE
fix: match PATH overlay to registry app keys by source name

### DIFF
--- a/gestaltd/internal/daemon/provider_local.go
+++ b/gestaltd/internal/daemon/provider_local.go
@@ -713,11 +713,27 @@ func matchingPluginKeys(plugins map[string]*config.ProviderEntry, targetManifest
 
 	var matches []string
 	for name, entry := range plugins {
-		if !providerEntryMatchesTarget(entry, targetCanonical) {
-			continue
+		if providerEntryMatchesTarget(entry, targetCanonical) {
+			matches = append(matches, name)
 		}
-		matches = append(matches, name)
 	}
+
+	if len(matches) == 0 {
+		if _, manifest, err := providerpkg.ReadSourceManifestFile(targetManifestPath); err == nil && manifest != nil {
+			if src, err := source.Parse(manifest.Source); err == nil {
+				appName := strings.TrimSpace(src.AppName())
+				sanitized := sanitizeDerivedPluginKey(appName)
+				for _, candidate := range []string{appName, sanitized} {
+					if candidate != "" {
+						if _, ok := plugins[candidate]; ok && !slices.Contains(matches, candidate) {
+							matches = append(matches, candidate)
+						}
+					}
+				}
+			}
+		}
+	}
+
 	slices.Sort(matches)
 	return matches, nil
 }


### PR DESCRIPTION
`matchingPluginKeys` only matched local and git sources by path. Registry apps (`source: {registry: ...}`) never matched, so resolution fell through to `derivedPluginKey` which sanitizes hyphens to underscores (`ci-cd` -> `ci_cd`). The overlay was written under `ci_cd`, creating a new app entry instead of overriding the existing `ci-cd`. The original `ci-cd` kept its registry source and returned 503 from `registryAppStaticHandler`.

Now `matchingPluginKeys` also tries name-based matching when no path-based matches are found: it reads the target manifest source app name and checks it and its sanitized form against config keys. This lets PATH arguments override registry apps regardless of hyphen/underscore naming conventions.