### PR TITLE
Define service mesh architecture and lifecycle model

### DIFF
--- a/plans/service_mesh/plan.md
+++ b/plans/service_mesh/plan.md
@@ -1,0 +1,146 @@
+# Service Mesh Design
+
+## Overview
+
+The platform builds, distributes, installs, and runs services in a shared service mesh. A service package may include:
+
+- An MCP server and its operations
+- User interface (single-page app or SPA's)
+- Workflows
+- Dependency and migration metadata
+- Runtime and authorization requirements
+
+Organizations operate a deployment backed by one private registry and, optionally, additional public registries. The deployment exposes a catalog of installed services, operations, interfaces, workflows, and dependencies.
+
+## Architecture
+
+The runtime consists of:
+
+- **Control plane (`istiod`)**: manages mesh configuration and service routing.
+- **Ingress data plane**: receives traffic from the load balancer.
+- **Service data plane (`gestaltd`)**: runs alongside each service and mediates mesh traffic.
+- **Service runtime**: runs the service's server, interfaces, and workflows.
+
+Terraform deploys the GCP infrastructure, including the Valon Tools cluster, GitHub Actions cluster, networking, container infrastructure, and identity services.
+
+## Service Packages
+
+When first published, a registry assigns the service a UUID unique within that registry and associates it with a human-readable slug. Service references include both the registry and UUID. Each package version consists of a built OCI image and a service manifest for a specific platform. The service manifest contains:
+
+- The immutable OCI image reference and digest
+- Instructions for starting the MCP server and user interfaces
+- The MCP endpoint, operations, and input/output schemas
+- Included workflows and interfaces
+- Service and operation dependencies
+- Ordered pre-upgrade and rollback commands
+- Service-account and authorization requirements
+- Health and readiness endpoints
+- Configuration and secret requirements
+- Image signature and build provenance
+
+Upgrade commands may perform schema migrations, workflow changes, or other dependency updates. They should be idempotent and reversible where possible.
+
+## Registries
+
+Registries store versioned service packages and control who can discover or download them. A deployment may use private, organization-specific, and public registries, provided each implements the registry interface.
+
+Each registry exposes a catalog manifest listing its services. Each entry includes the registry-scoped service UUID, slug, available versions and platforms, service manifest location, and immutable OCI image reference and digest. The OCI image is the deployable artifact; a Dockerfile may be retained as optional source provenance but is not part of the runtime contract.
+
+A registry can be connected to a GitHub repository and configured to build from `main`, pull requests, or label-based rules. Service developers can also build and push packages directly.
+
+## Build and Publish
+
+1. `vt build <dir>` builds a service package from a source directory and its manifest.
+2. The build produces a platform-specific OCI image with an immutable digest.
+3. The package is published through the configured GitHub integration or with `--push <registry-url>`.
+4. The registry publishes the catalog and service manifests and points them to the built OCI image.
+
+`vt dev <url> <dir> <token>` injects a local service into an existing mesh for development. A development service runs with the developer's identity.
+
+## Installation
+
+Publishing a service does not install it. On first installation, an organization administrator selects a version and configures:
+
+- The identity used by workflows
+- The identity used by service operations
+- Whether an operation forwards the caller's identity
+- The service's authorized operations
+
+A service identity cannot initially exceed the installer’s authorization. Its relationships are assigned using the authorization model below.
+
+Installing or removing a service updates the runtime catalog without redeploying the service mesh.
+
+## Upgrades
+
+Before an upgrade, the platform verifies that required operations exist, dependencies are ready and not being upgraded, and the package defines valid pre-upgrade and rollback commands.
+
+The upgrade sequence is:
+
+1. Pull the new OCI image.
+2. Run the service's pre-upgrade commands in order.
+3. Start the new service version.
+4. Validate startup and the `/ready` endpoint.
+5. Shift traffic to the new version.
+
+The old version continues serving until the traffic shift. If an upgrade step fails, the platform stops the upgrade and records the failed command and error. An authorized administrator then resolves the failure and manually runs the declared rollback commands.
+
+After traffic shifts, traffic may return to the old version only when the package declares that rollback safe. Automatic rollback can be added later using the same commands and safety declaration.
+
+Workflows should continue running during an upgrade unless they call the service being upgraded. Service operations and interfaces may be unavailable during the traffic transition. The target is less than ten seconds of downtime.
+
+## Administration and Discovery
+
+An organization deployment provides:
+
+- A service catalog
+- An operation catalog
+- A user-interface catalog
+- A dependency graph
+- Service details, versions, workflows, identities, and authorization settings
+- API-key management
+- A development sandbox
+
+Organization administrators can connect registries and install, upgrade, or remove services. Service developers can build, publish, test, and invoke services. Service users see only the catalogs and tools available to them.
+
+Representative endpoints:
+
+- Deployment: `https://vt.valon.tools`
+- Private registry: `https://vt.valon.tools/registry`
+- Administration: `https://vt.valon.tools/admin`
+- Service administration: `https://vt.valon.tools/services/<service>/admin`
+
+## Invocation
+
+Authorized operations are available over the deployment endpoint and through the CLI:
+
+```sh
+vt invoke <url> <service> <operation> <args> <token>
+```
+
+Operation invocation uses MCP Streamable HTTP. Clients and services must support JSON-RPC over POST and the protocol's JSON and SSE response forms.
+
+## Authentication and Authorization
+
+- Users authenticate through an external identity provider, with organization-level SSO support.
+- Users can create API keys that act as their identity.
+- Users can create service accounts with a subset of their permissions.
+- Every installed service has an assigned identity.
+- Every operation can enforce authorization.
+
+Authorization uses a Zanzibar-style graph of relationship tuples. Each relationship definition declares whether it supports delegated assignments, persistent grants, both, or neither. The default is neither.
+
+- **Delegated assignment (`delegatable`)**: a relationship holder can create a derived assignment that cannot exceed or outlive its parent assignment.
+- **Persistent grant (`grantable`)**: a principal with the relationship-specific grant permission can create an independent assignment that remains until explicitly revoked.
+
+Assignments record their issuer, assignment mode, creation time, optional expiration, and optional parent assignment. Revoking a parent invalidates its delegated descendants, while an independent assignment through another path preserves access. Persistent grants require an explicit Zanzibar permission such as `can_grant_<relationship>`.
+
+## Mesh Deployment
+
+The mesh is redeployed only when changing mesh infrastructure, including:
+
+- The `istiod` snapshot
+- The `gestaltd` snapshot
+- Ingress
+- Egress
+
+Installing, upgrading, or removing services and adding or removing registries are runtime changes and do not require a mesh redeployment.

--- a/plans/service_mesh/plan.md
+++ b/plans/service_mesh/plan.md
@@ -1,16 +1,29 @@
 # Service Mesh Design
 
+## Contents
+
+- [Overview](#overview)
+- [Design Invariants](#design-invariants)
+- [Model](#identity-model)
+- [Publishing](#package-releases)
+- [Revisions](#durable-deployment-state)
+- [Runtime](#workflows)
+- [Authorization](#authentication-and-authorization)
+- [Implementation](#runtime-architecture)
+- [Assurance](#retention-and-audit)
+- [Glossary](#glossary)
+
 ## Overview
 
-The platform builds, distributes, installs, and runs services in a shared service mesh. A service release may include:
+The platform builds, distributes, installs, and runs packages in a shared service mesh. A package release may include:
 
 - An MCP server and its operations
 - One or more single-page user interfaces
 - Durable workflow definitions and workers
 - Dependency and migration metadata
-- Runtime, configuration, secret, network, and authorization requirements
+- Runtime, configuration, and authorization requirements
 
-An organization operates one deployment backed by a private registry and, optionally, additional trusted registries. The deployment exposes catalogs of installed services, callable operations, user interfaces, workflows, and dependencies.
+An organization operates one deployment backed by a private registry and, optionally, additional trusted registries. The deployment exposes catalogs of installed packages, callable operations, user interfaces, workflows, and dependencies.
 
 Publishing makes a release discoverable. Installation admits an immutable release into an organization. Canarying permits controlled, undiscoverable traffic, while promotion makes an installed revision primary and user-discoverable. These states are separate and must not be inferred from one another.
 
@@ -18,66 +31,48 @@ Publishing makes a release discoverable. Installation admits an immutable releas
 
 The following invariants apply to every implementation:
 
-1. A published release is immutable and identified by a digest.
+1. A published release is immutable and identified by its `releaseDigest`.
 2. A deployment records every accepted install, upgrade, rollback, and removal request in an append-only revision history.
-3. At most one lifecycle operation for an organization and canonical service identity is nonterminal at a time, including first installation.
-4. Request handlers record intent; reconcilers perform runtime work and resume safely after process failure.
+3. For each canonical package identity in an organization, only one revision operation — install, upgrade, rollback, or removal — may be in progress at a time.
+4. Durable revision requests record intent; revision controllers perform runtime work and resume safely after process failure.
 5. Published, admitted, materialized, running, ready, canary-callable, promoted, and converged are distinct states.
 6. A pre-promotion failure does not replace the last successfully promoted revision.
 7. Routing propagation is eventually consistent, so every revision that may receive traffic remains contract-compatible until propagation and draining finish. New contracts become visible only after routing convergence.
-8. Package metadata can request capabilities but cannot grant itself identity, authorization, secrets, ingress, or egress.
+8. Packages run only under organization-provisioned identities; requested capabilities require explicit grant or delegation and cannot be self-asserted by release metadata.
 9. Dynamic services cannot replace the identity, authorization, certificate, secret, registry-verification, audit, state-storage, or recovery components needed to administer the mesh.
 10. Every externally supplied manifest, image, schema, migration, and attestation is untrusted until its digest, signature, and policy are verified.
-
-## Runtime Architecture
-
-The runtime consists of:
-
-- **Istio control plane (`istiod`)**: distributes routing, policy, endpoint, and certificate configuration to the Istio data plane.
-- **Istio workload data plane**: Envoy sidecars mediate inbound and outbound workload traffic. Ambient mode, using mandatory node-level `ztunnel` proxies and optional L7 waypoint proxies, is a possible later deployment mode; a deployment uses one documented mode at a time.
-- **Ingress gateways**: separate Envoy data-plane proxies terminate external transport, remove untrusted identity headers, authenticate supported credentials, and route public and organization traffic.
-- **Egress gateways**: separate Envoy data-plane proxies enforce and audit declared external network access where direct egress cannot be safely allowed.
-- **Service supervisor (`gestaltd`)**: runs alongside one service installation, mediates application-level invocation and authorization, reports observed state, and manages the service process. It is not an Istio data-plane proxy and does not replace Envoy.
-- **Service runtime**: runs the service's MCP server, interfaces, and workflow workers.
-- **Lifecycle controllers**: reconcile durable install and rollout records into workloads, routing, catalogs, identities, and policy.
-
-Production uses Istio `PeerAuthentication` in `STRICT` mode for mesh mutual TLS, Istio `AuthorizationPolicy` for workload-to-workload policy, and Kubernetes `NetworkPolicy` for network reachability. The deployment installs explicit default-deny authorization and network policies; these mechanisms are not assumed to deny traffic merely because they are enabled. Service application ports are reachable only through the mesh data plane. Health and supervisor administration ports have explicit, minimal exceptions and are not exposed through public ingress.
-
-Established data-plane traffic continues using the last known configuration when `istiod` is unavailable. New lifecycle operations that require routing, certificates, policy, or registry verification fail closed until their control-plane dependencies recover.
-
-Terraform deploys the GCP infrastructure, including the Valon Tools cluster, GitHub Actions cluster, networking, container infrastructure, identity services, and deploy-pinned trusted components. Installing services does not mutate this trusted computing base.
 
 ## Identity Model
 
 The system keeps these identities separate:
 
 - **Registry identity**: immutable `registryId` plus its configured origin and trust-policy digest.
-- **Service identity**: permanent `(registryId, serviceId)` assigned when the service is reserved. A slug is a mutable display and discovery alias, never a security identifier.
-- **Release identity**: `(registryId, serviceId, version, releaseDigest)`.
-- **Installation identity**: an organization-scoped UUID representing one installed service.
+- **Package identity**: permanent `(registryId, packageId)` assigned when the package is reserved. A slug is a mutable display and discovery alias, never a security identifier.
+- **Release identity**: `(registryId, packageId, releaseVersion, releaseDigest)`.
+- **Installation identity**: an organization-scoped UUID representing one installed package.
 - **Workload identity**: an orchestrator-owned SPIFFE identity for one installation's runtime or migration job.
 - **Workflow identity**: the principal assigned to a workflow definition or execution.
 - **Actor identity**: the user, API grant, service account, or workflow that initiated an action.
 - **Effective subject**: the principal whose delegated authority an invocation exercises.
 
-Service IDs are never reused. Slug renames retain aliases and tombstones. Mirroring a service preserves its identity only through a signed mirror or transfer relationship; otherwise importing it creates a distinct service identity.
+Package IDs are never reused. Slug renames retain aliases and tombstones. Mirroring a package preserves its identity only through a signed mirror or transfer relationship; otherwise importing it creates a distinct package identity.
 
 Package authors cannot select workload identities. The orchestrator binds installations to Kubernetes service accounts and short-lived SPIFFE certificates. Trust domain, certificate lifetime, rotation, and compromise revocation are deployment policy.
 
-## Service Releases
+## Package Releases
 
-One service version has one platform-independent, signed release manifest. The release manifest is stored as an OCI artifact or another digest-addressed immutable object and references an OCI image index digest. The image index selects immutable image manifests for supported `os`, `architecture`, and optional `variant` tuples.
+Each `releaseVersion` has one platform-independent, signed release manifest. The release manifest is stored as an OCI artifact or another digest-addressed immutable object and references an OCI image index digest. The image index selects immutable image manifests for supported `os`, `architecture`, and optional `variant` tuples.
 
 Platform images may contain different binaries, but their operation contracts, dependencies, migrations, workflows, and requested capabilities must match the release manifest. A platform-specific release contract is not allowed.
 
 The release manifest contains:
 
-- Canonical registry and service IDs, slug, and version
+- Canonical registry and package IDs, slug, and `releaseVersion`
 - OCI image-index digest and supported platforms
 - Instructions for starting the MCP server, interfaces, and workflow workers
 - MCP endpoint, operations, and input/output schema digests
 - Included workflows and user interfaces
-- Required and optional service and operation dependencies
+- Required and optional package and operation dependencies
 - Ordered prepare, finalize, and compensating migration jobs
 - Rollback classification
 - Requested service-account, authorization, ingress, and egress capabilities
@@ -89,9 +84,9 @@ The release manifest contains:
 
 The manifest does not contain self-asserted signatures or provenance. Signatures and SLSA/in-toto provenance are detached attestations over the release and image digests, such as OCI referrers.
 
-The release digest is computed over the canonical manifest bytes and is carried by catalog entries, signatures, attestations, and installation records rather than by the hashed manifest itself.
+The `releaseDigest` is computed over the canonical manifest bytes and is carried by catalog entries, signatures, attestations, and installation records rather than by the hashed manifest itself.
 
-Versions follow a registry-defined, documented grammar and comparison order. A `(registryId, serviceId, version)` binds permanently to one release digest. A conflicting republish is rejected. An identical retry is idempotent and does not rewrite publication time or provenance. Mutable tags may aid discovery but are never installation inputs.
+`releaseVersion` values follow a registry-defined, documented grammar and comparison order. A `(registryId, packageId, releaseVersion)` binds permanently to one `releaseDigest`. A conflicting republish is rejected. An identical retry is idempotent and does not rewrite publication time or provenance. Mutable tags may aid discovery but are never installation inputs.
 
 ## Registries
 
@@ -101,7 +96,7 @@ Registries control who can publish, discover, or download releases. Each configu
 - Discovery, metadata, blob, and publication endpoints
 - Authentication and authorization scopes
 - Trusted signing identities and builders
-- Allowed service namespaces
+- Allowed package namespaces
 - Source repository and workflow constraints
 - Required provenance level
 - Whether direct developer publication is permitted
@@ -111,7 +106,7 @@ Connecting a registry does not trust every publisher in it. Catalogs and manifes
 
 The registry interface defines pagination, conditional reads, consistency guarantees, error codes, retries, rate limits, and authentication separately for catalog discovery, immutable metadata, blob pulls, and publication.
 
-A catalog contains paginated service and release summaries pointing to authoritative release-manifest digests. It does not duplicate the full release contract. Per-service indexes use monotonic revisions and compare-and-swap updates.
+A catalog contains paginated package and release summaries pointing to authoritative release-manifest digests. It does not duplicate the full release contract. Per-package indexes use monotonic revisions and compare-and-swap updates.
 
 Disconnecting a registry blocks new discovery and installation but preserves its identity and all historical records. Hard removal is rejected while any desired, running, redeployable, dependent, or in-progress revision references it. Rebinding to a mirror requires digest-equivalent content and signatures trusted by the deployment.
 
@@ -121,13 +116,13 @@ Disconnecting a registry blocks new discovery and installation but preserves its
 
 Publication is a recoverable transaction:
 
-1. Reserve `(serviceId, version)` and create a publish-attempt ID.
+1. Reserve `(packageId, releaseVersion)` and create a publish-attempt ID.
 2. Record a pending release with source and workflow provenance.
 3. Upload content-addressed image blobs and manifests.
 4. Validate all platform images and release contracts server-side.
 5. Create the immutable release manifest.
 6. Attach signatures and provenance attestations.
-7. Commit availability by compare-and-swap updating the service catalog last.
+7. Commit availability by compare-and-swap updating the package catalog last.
 8. Mark the attempt succeeded or failed.
 
 Pending and failed attempts are visible but never installable. Concurrent publishers cannot lose catalog updates. Stale attempts become failed, and orphaned content-addressed blobs are garbage-collected after a grace period.
@@ -136,16 +131,16 @@ Pending and failed attempts are visible but never installable. Concurrent publis
 
 The control plane persists:
 
-- **Service slots**: one organization-scoped slot keyed by canonical service identity, reserved before allocating an installation ID and used to fence concurrent first installs
-- **Revision requests**: append-only install, upgrade, rollback, and removal intent with actor, previous promoted revision, target release digest, approved capabilities, resolved dependencies, and timestamps
+- **Package slots**: one organization-scoped slot keyed by canonical package identity, reserved before allocating an installation ID and used to fence concurrent first installs
+- **Revision requests**: append-only install, upgrade, rollback, and removal intent with actor, previous promoted revision, target `releaseDigest`, approved capabilities, resolved dependencies, and timestamps
 - **Installation head**: last successfully promoted revision and current admitted candidate
-- **Lifecycle operation**: one generation-fenced state machine per installation
-- **Migration outcomes**: immutable status keyed by installation, release digest, and migration ID
+- **Revision operation**: one generation-fenced state machine per installation
+- **Migration outcomes**: immutable status keyed by installation, `releaseDigest`, and migration ID
 - **Workload observations**: materialized, started, ready, draining, stopped, and error state for each target replica
 - **Routing and catalog generation**: the promoted revision visible to callers
 - **Terminal outcomes**: completion or failure phase, duration, and reason
 
-Lifecycle records use optimistic concurrency and fencing tokens. A stale controller cannot mutate a newer generation after losing its lease. Retries are idempotent, and every external mutation has a stable idempotency key.
+Revision records use optimistic concurrency and fencing tokens. A stale controller cannot mutate a newer generation after losing its lease. Retries are idempotent, and every external mutation has a stable idempotency key.
 
 Each rollout targets one immutable runtime cohort identified by the infrastructure generation and `gestaltd` supervisor generation. Replicas enroll during a bounded epoch; the nonempty cohort is then frozen for promotion accounting. Scaling replicas that join later still converge but do not retroactively change the completed cohort. Observations include the rollout generation and enrollment epoch so stale or overlapping infrastructure cohorts cannot satisfy a newer rollout.
 
@@ -164,33 +159,33 @@ The runtime distinguishes:
 
 ## Installation
 
-Publishing does not install a service. An organization administrator selects an immutable release digest and binds:
+Publishing does not install a package. An organization administrator selects an immutable `releaseDigest` and binds:
 
-- Organization-owned service and workflow identities
+- Organization-owned package and workflow identities
 - Package-requested operations and capabilities to approved authorization relationships
 - Caller-delegation policy per operation
 - Typed configuration values and secret references
 - Ingress and egress requests to organization policy
 - Initial replica, resource, and availability settings
 
-The platform shows the requested-versus-approved capability diff before admission. An installer can use only identities for which they have `can_use` or `can_delegate`, and cannot convert temporary authority into an unrestricted persistent service grant. Sensitive capabilities may require a second approver.
+The platform shows the requested-versus-approved capability diff before admission. An installer can use only identities for which they have `can_use` or `can_delegate`, and cannot convert temporary authority into an unrestricted persistent package grant. Sensitive capabilities may require a second approver.
 
 Installation is a reconciled saga:
 
 1. Verify registry trust, release and image signatures, provenance, platform support, runtime compatibility, and schema versions.
 2. Resolve exact dependency revisions and operation-contract digests.
-3. Reserve the organization service slot and persist the revision request, approved capability snapshot, and fenced lifecycle operation.
+3. Reserve the organization package slot and persist the revision request, approved capability snapshot, and fenced revision operation.
 4. Provision the installation identity, workload identity, policy, configuration, and secret bindings.
 5. Materialize and start the initial workload without making it callable.
 6. Require readiness quorum and minimum healthy duration.
 7. Promote routing, wait for the frozen proxy cohort to acknowledge the routing generation, and drain any prior compatible route.
 8. Advance the callable catalog only after routing converges, then record convergence and the terminal outcome.
 
-Failures preserve the durable phase and diagnostics. The reconciler retries retryable phases within policy and compensates unpromoted resources when an administrator cancels the installation. A service is not callable until promotion succeeds.
+Failures preserve the durable phase and diagnostics. The revision controller retries retryable phases within policy and compensates unpromoted resources when an administrator cancels the installation. A package is not callable until promotion succeeds.
 
 ## Dependencies and Contracts
 
-Dependencies use canonical service identities, version ranges, and required operation contract digests. Dependencies may be required or optional. Admission records the exact revisions and contract digests selected.
+Dependencies use canonical package identities, `releaseVersion` ranges, and required operation contract digests. Dependencies may be required or optional. Admission records the exact revisions and contract digests selected.
 
 The platform validates:
 
@@ -198,12 +193,12 @@ The platform validates:
 - Required operations exist
 - Required input and output contracts match
 - The candidate remains compatible with existing reverse dependents
-- No conflicting lifecycle operation is active in the affected dependency subgraph
+- No conflicting revision operation is active in the affected dependency subgraph
 - Workflow calls reference compatible operation contracts
 
 JSON Schemas use one pinned dialect and canonical encoding before hashing. The first implementation requires exact schema digests. Semantic compatibility can be introduced only with documented contravariant input and covariant output rules.
 
-Validation reads a revisioned desired-state snapshot and commits with generation preconditions. For independent services, upgrades may proceed concurrently. Upgrades that affect the same dependency subgraph use deterministic locking or one atomic multi-service rollout plan. Dependency cycles are rejected until atomic rollout groups are implemented.
+Validation reads a revisioned desired-state snapshot and commits with generation preconditions. For independent packages, upgrades may proceed concurrently. Upgrades that affect the same dependency subgraph use deterministic locking or one atomic multi-package rollout plan. Dependency cycles are rejected until atomic rollout groups are implemented.
 
 ## Upgrades and Traffic Promotion
 
@@ -225,22 +220,22 @@ The rollout state machine is:
 
 Each phase has a timeout, retry policy, and terminal error taxonomy. Promotion requires nonempty frozen runtime and proxy cohorts and cannot be inferred from one ready instance. Routing changes define weight propagation, proxy acknowledgement, readiness quorum, connection draining, and behavior for MCP SSE streams. During partial routing propagation, both revisions support the promoted operation-contract digests.
 
-Failures before promotion produce a failed candidate and leave the prior promoted revision primary. Failures during soak after promotion mark the new revision degraded and trigger rollback when its rollback class permits; otherwise they require an audited forward fix. Finalization failure does not relabel the promoted revision as a failed candidate or route traffic implicitly: it records `promoted_with_finalization_error`, blocks the next lifecycle operation, and requires retry or an approved forward fix.
+Failures before promotion produce a failed candidate and leave the prior promoted revision primary. Failures during soak after promotion mark the new revision degraded and trigger rollback when its rollback class permits; otherwise they require an audited forward fix. Finalization failure does not relabel the promoted revision as a failed candidate or route traffic implicitly: it records `promoted_with_finalization_error`, blocks the next revision operation, and requires retry or an approved forward fix.
 
-The availability goal is zero planned downtime for services that satisfy the compatibility contract. Any supported operation that requires downtime declares and receives explicit administrator approval before admission; a vague downtime target is not sufficient.
+The availability goal is zero planned downtime for packages that satisfy the compatibility contract. Any supported operation that requires downtime declares and receives explicit administrator approval before admission; a vague downtime target is not sufficient.
 
 ## Migrations and Rollback
 
 Migrations are separately identified, digest-pinned jobs. Each declares:
 
-- Migration ID and release digest
+- Migration ID and `releaseDigest`
 - Prepare, finalize, or compensating phase
 - Dedicated workload identity and requested capabilities
 - Required secrets and network destinations
 - Timeout, resource limits, retry policy, and idempotency key
-- Compatibility with the prior and candidate service revisions
+- Compatibility with the prior and candidate package revisions
 
-Migration jobs run with least privilege and deny-by-default egress. They never run as the installer, lifecycle controller, or normal service identity. Attempt and completion records are durable.
+Migration jobs run with least privilege and deny-by-default egress. They never run as the installer, revision controller, or normal package identity. Attempt and completion records are durable.
 
 Each release declares one rollback class:
 
@@ -251,15 +246,7 @@ Each release declares one rollback class:
 
 Prepare migrations follow expand/contract rules and must remain compatible with the serving revision. Releases with a rollback-capable class defer destructive finalize migrations until the rollback window closes. A no-post-promotion-rollback release requires explicit approval before promotion and has no rollback window. A rollback command is not proof that data rollback is safe.
 
-Administrators initiate rollback through the same lifecycle controller. Manual shell execution cannot update lifecycle state. Automatic rollback may later invoke the same audited state machine when canary or soak gates fail.
-
-## Workflows
-
-Workflow definitions are immutable and versioned independently from service processes. Each execution records its workflow-definition digest, actor, workflow identity, and compatible service-operation contract revisions.
-
-Existing executions continue on workers that support their pinned definition until they complete, migrate, or reach a documented retirement policy. New executions use the promoted workflow catalog generation. Removal and incompatible upgrades must account for queued work, retries, timers, and long-running executions before workers are drained.
-
-Every workflow operation is authorized at execution time. `can_run_as` is required to select an organization-managed workflow identity. The original triggering actor remains in the audit and delegation chain.
+Administrators initiate rollback through the same revision controller. Manual shell execution cannot update revision state. Automatic rollback may later invoke the same audited state machine when canary or soak gates fail.
 
 ## Removal
 
@@ -270,35 +257,43 @@ Removal is a durable tombstoned revision, not deletion of a catalog row:
 3. Drain already-resolved requests, streams, workers, and queued work according to policy.
 4. Stop workloads and block ingress and egress.
 5. Revoke workload certificates, installation-owned assignments, delegated tokens, secret bindings, and runtime configuration.
-6. Apply service-data retention or destruction policy.
-7. Preserve the service tombstone and audit history.
+6. Apply package-data retention or destruction policy.
+7. Preserve the package tombstone and audit history.
 8. Garbage-collect runtime resources after the recovery window.
 
 Organization-owned persistent grants are not silently deleted; the removal UI distinguishes them from installation-owned grants. Reinstallation creates a new installation identity unless an explicit restore operation reactivates the tombstone within policy.
+
+## Workflows
+
+Workflow definitions are immutable and versioned independently from package processes. Each execution records its workflow-definition digest, actor, workflow identity, and compatible package-operation contract revisions.
+
+Existing executions continue on workers that support their pinned definition until they complete, migrate, or reach a documented retirement policy. New executions use the promoted workflow catalog generation. Removal and incompatible upgrades must account for queued work, retries, timers, and long-running executions before workers are drained.
+
+Every workflow operation is authorized at execution time. `can_run_as` is required to select an organization-managed workflow identity. The original triggering actor remains in the audit and delegation chain.
 
 ## Catalogs and Administration
 
 An organization deployment provides:
 
-- A service catalog
+- A package catalog
 - An operation catalog
 - A user-interface catalog
 - A workflow catalog
 - A dependency graph
-- Service revisions, rollout and migration status, identities, and authorization settings
+- Package revisions, rollout and migration status, identities, and authorization settings
 - API-grant management
 - A development sandbox
 
-Candidate metadata may be visible to administrators, but user-facing callable catalogs expose only contracts safe for the currently propagated routes. Routing is updated first because xDS propagation is asynchronous; newly added contracts become discoverable only after the frozen proxy cohort acknowledges the routing generation. Both revisions remain contract-compatible until old routes drain. Each invocation, including an SSE stream, resolves once and remains pinned to one service revision.
+Candidate metadata may be visible to administrators, but user-facing callable catalogs expose only contracts safe for the currently propagated routes. Routing is updated first because xDS propagation is asynchronous; newly added contracts become discoverable only after the frozen proxy cohort acknowledges the routing generation. Both revisions remain contract-compatible until old routes drain. Each invocation, including an SSE stream, resolves once and remains pinned to one package revision.
 
-Organization administrators can connect registries and install, upgrade, roll back, or remove services. Service developers can build, publish, test, and invoke services. Service users see only catalogs and operations authorized for them.
+Organization administrators can connect registries and install, upgrade, roll back, or remove packages. Package developers can build, publish, test, and invoke packages. Package users see only catalogs and operations authorized for them.
 
 Representative endpoints:
 
 - Deployment: `https://vt.valon.tools`
 - Private registry: `https://vt.valon.tools/registry`
 - Administration: `https://vt.valon.tools/admin`
-- Service administration: `https://vt.valon.tools/services/<service>/admin`
+- Package administration: `https://vt.valon.tools/packages/<package>/admin`
 
 Management APIs use a private listener or equivalent network restriction and require stronger authorization than user invocation endpoints.
 
@@ -307,23 +302,23 @@ Management APIs use a private listener or equivalent network restriction and req
 Authorized operations are available over the deployment endpoint and through the CLI:
 
 ```sh
-vt invoke --deployment <url> <service> <operation> --args <json>
+vt invoke --deployment <url> <package> <operation> --args <json>
 ```
 
 Authentication comes from an interactive session, keychain, environment, or standard input. Secrets and tokens are not positional command arguments.
 
-Operation invocation uses MCP Streamable HTTP. Clients and services support JSON-RPC over POST and the protocol's JSON and SSE response forms. The gateway enforces request size, timeout, rate, and stream-lifetime policy.
+Operation invocation uses MCP Streamable HTTP. Clients and packages support JSON-RPC over POST and the protocol's JSON and SSE response forms. The gateway enforces request size, timeout, rate, and stream-lifetime policy.
 
-Ingress strips externally supplied internal-identity headers. It exchanges user credentials for a short-lived, audience-bound internal invocation token containing the original actor, effective subject, immediate calling workload, delegation chain, target service and operation, issued/expiry times, nonce, and trace ID. Services never forward raw user bearer tokens or API keys.
+Ingress strips externally supplied internal-identity headers. It exchanges user credentials for a short-lived, audience-bound internal invocation token containing the original actor, effective subject, immediate calling workload, delegation chain, target package and operation, issued/expiry times, nonce, and trace ID. Packages never forward raw user bearer tokens or API keys.
 
 The authorization decision intersects:
 
 - The authenticated calling workload's permission to invoke the target
 - The effective subject's permission
-- The installed service's approved operation policy
+- The installed package's approved operation policy
 - Any operation-specific resource authorization
 
-Unknown identities, services, operations, policies, or authorization-provider outages deny access.
+Unknown identities, packages, operations, policies, or authorization-provider outages deny access.
 
 ## Authentication and Authorization
 
@@ -331,7 +326,7 @@ Unknown identities, services, operations, policies, or authorization-provider ou
 - API keys are named, expiring, scoped API grants that act on behalf of an owner. Only hashes are stored, plaintext is returned once, and empty scope does not mean unrestricted access.
 - Users create service accounts only with an attenuated subset of authority and explicit expiry or organization policy.
 - Every installation has organization-owned workload and workflow identities.
-- Every invocation is centrally authorized before dispatch; service-specific resource checks may further restrict it.
+- Every invocation is centrally authorized before dispatch; package-specific resource checks may further restrict it.
 - Production does not start in a fail-open mode when identity or authorization is unavailable.
 
 Authorization uses a Zanzibar-style graph. Relationship definitions declare whether they support delegated assignments, persistent grants, both, or neither. The default is neither.
@@ -341,7 +336,7 @@ Authorization uses a Zanzibar-style graph. Relationship definitions declare whet
 
 An assignment is a first-class record containing an immutable ID, organization, subject, relationship, resource, mode, issuer, creation and optional expiration, optional parent assignment, policy revision, and revocation state. Delegation has bounded depth, acyclic ancestry, transactional creation, and cascading invalidation. Independent valid paths preserve access after one path is revoked.
 
-Authorization caches and delegated invocation tokens have bounded lifetimes. Revocation has a documented maximum propagation time and applies to long-lived streams and each workflow step. Security events are written to an immutable audit sink outside service-controlled storage.
+Authorization caches and delegated invocation tokens have bounded lifetimes. Revocation has a documented maximum propagation time and applies to long-lived streams and each workflow step. Security events are written to an immutable audit sink outside package-controlled storage.
 
 ## Configuration, Secrets, Ingress, and Egress
 
@@ -353,15 +348,15 @@ Every endpoint is classified as public, organization-authenticated, mesh-interna
 
 ## Development Sandbox
 
-`vt dev` builds a local service and connects it only to an explicitly enabled per-user sandbox:
+`vt dev` builds a local package and connects it only to an explicitly enabled per-user sandbox:
 
 ```sh
 vt dev --deployment <url> <dir>
 ```
 
-Authentication uses the normal interactive or keychain flow. The platform issues a short-lived development workload identity distinct from the user's identity. Development routing is scoped to the developer or named test session and cannot take over a production service slug.
+Authentication uses the normal interactive or keychain flow. The platform issues a short-lived development workload identity distinct from the user's identity. Development routing is scoped to the developer or named test session and cannot take over a production package slug.
 
-Development services:
+Development packages:
 
 - Receive no production traffic by default
 - Cannot run migrations
@@ -369,6 +364,37 @@ Development services:
 - Cannot forward caller credentials
 - Use sandbox-scoped authorization and egress
 - Expire automatically and are audited on connect and disconnect
+
+## Runtime Architecture
+
+The runtime consists of:
+
+- **Istio control plane (`istiod`)**: distributes routing, policy, endpoint, and certificate configuration to the Istio data plane.
+- **Istio workload data plane**: Envoy sidecars mediate inbound and outbound workload traffic. Ambient mode, using mandatory node-level `ztunnel` proxies and optional L7 waypoint proxies, is a possible later deployment mode; a deployment uses one documented mode at a time.
+- **Ingress gateways**: separate Envoy data-plane proxies terminate external transport, remove untrusted identity headers, authenticate supported credentials, and route public and organization traffic.
+- **Egress gateways**: separate Envoy data-plane proxies enforce and audit declared external network access where direct egress cannot be safely allowed.
+- **Package supervisor (`gestaltd`)**: runs alongside one package installation, mediates application-level invocation and authorization, reports observed state, and manages the package process. It is not an Istio data-plane proxy and does not replace Envoy.
+- **Package runtime**: runs the package's MCP server, interfaces, and workflow workers.
+- **Revision controllers**: reconcile durable install and rollout records into workloads, routing, catalogs, identities, and policy.
+
+Production uses Istio `PeerAuthentication` in `STRICT` mode for mesh mutual TLS, Istio `AuthorizationPolicy` for workload-to-workload policy, and Kubernetes `NetworkPolicy` for network reachability. The deployment installs explicit default-deny authorization and network policies; these mechanisms are not assumed to deny traffic merely because they are enabled. Package application ports are reachable only through the mesh data plane. Health and supervisor administration ports have explicit, minimal exceptions and are not exposed through public ingress.
+
+Established data-plane traffic continues using the last known configuration when `istiod` is unavailable. New revision operations that require routing, certificates, policy, or registry verification fail closed until their control-plane dependencies recover.
+
+Terraform deploys the GCP infrastructure, including the Valon Tools cluster, GitHub Actions cluster, networking, container infrastructure, identity services, and deploy-pinned trusted components. Installing packages does not mutate this trusted computing base.
+
+## Mesh Deployment
+
+The mesh is redeployed only when changing deploy-pinned infrastructure, including:
+
+- `istiod` and Istio data-plane versions
+- `gestaltd` supervisor versions
+- Ingress and egress gateways
+- Identity, authorization, certificate, secret, audit, state-storage, registry-verification, or recovery services
+
+Package releases declare compatible `gestaltd` and mesh protocol ranges. Infrastructure rollouts account for old and new runtime cohorts before admitting a package release that requires new capabilities.
+
+Installing, upgrading, rolling back, or removing packages is a runtime change and does not require mesh redeployment. Connecting or disconnecting a registry is durable control-plane state and does not require redeployment, but changing registry trust roots remains a separately authorized and audited action.
 
 ## Retention and Audit
 
@@ -381,20 +407,7 @@ Immutable release metadata, attestations, and accepted revision history are reta
 
 OCI garbage collection is reference-aware because layers may be shared. Pruning is serialized with admission and rechecks eligibility immediately before deletion.
 
-Audit events include authentication, API-grant lifecycle, certificate issuance, authorization decisions, assignment mutation, delegated identity use, registry and trust-policy changes, publish/install/upgrade/rollback/removal, migration execution, secret access, ingress/egress denial, and development injection. Events include actor, effective subject, calling workload, target, policy revision, decision reason, trace ID, and release digest.
-
-## Mesh Deployment
-
-The mesh is redeployed only when changing deploy-pinned infrastructure, including:
-
-- `istiod` and Istio data-plane versions
-- `gestaltd` supervisor versions
-- Ingress and egress gateways
-- Identity, authorization, certificate, secret, audit, state-storage, registry-verification, or recovery services
-
-Service releases declare compatible `gestaltd` and mesh protocol ranges. Infrastructure rollouts account for old and new runtime cohorts before admitting a service release that requires new capabilities.
-
-Installing, upgrading, rolling back, or removing services is a runtime change and does not require mesh redeployment. Connecting or disconnecting a registry is durable control-plane state and does not require redeployment, but changing registry trust roots remains a separately authorized and audited action.
+Audit events include authentication, API-grant lifecycle, certificate issuance, authorization decisions, assignment mutation, delegated identity use, registry and trust-policy changes, publish/install/upgrade/rollback/removal, migration execution, secret access, ingress/egress denial, and development injection. Events include actor, effective subject, calling workload, target, policy revision, decision reason, trace ID, and `releaseDigest`.
 
 ## Required Verification
 
@@ -404,7 +417,7 @@ Before production use, automated tests cover:
 - Signature, provenance, trust-policy, platform, and runtime compatibility failures
 - Install and upgrade validation failures writing no admitted revision
 - Concurrent administrator and controller fencing
-- Controller failure and restart at every lifecycle phase
+- Controller failure and restart at every revision phase
 - Migration idempotency, lease loss, and incompatible rollback declarations
 - Dependency and reverse-dependent races
 - Canary failure, routing/catalog generation safety, draining, and SSE behavior
@@ -412,3 +425,35 @@ Before production use, automated tests cover:
 - Removal cleanup, tombstones, and retained workflow executions
 - Authorization outage, confused-deputy attempts, delegation attenuation, and revocation propagation
 - Multi-replica convergence and old/new infrastructure cohort overlap
+
+## Glossary
+
+**package identity**  
+Permanent `(registryId, packageId)` for a published package. Assigned when the package is reserved; never reused.
+
+**release**  
+Immutable, signed artifact for one `releaseVersion` of a package, identified by `releaseDigest`.
+
+**releaseVersion**  
+Registry-assigned label for one published release of a package. `(registryId, packageId, releaseVersion)` binds permanently to one `releaseDigest`.
+
+**releaseDigest**  
+Content hash of the canonical release manifest bytes. The authoritative install input; signatures and attestations bind to it.
+
+**revision**  
+One installed state of a package in an organization, backed by a specific `releaseDigest`.
+
+**revision request**  
+Durable intent to install, upgrade, rollback, or remove a package.
+
+**revision operation**  
+Generation-fenced state machine that executes one revision request.
+
+**revision controller**  
+Background worker that drives a revision operation to completion and resumes after failure.
+
+**rollout**  
+Staged path from admission through canarying and promotion for an install or upgrade candidate.
+
+**promotion**  
+Makes a revision primary for routing and user-facing catalogs.

--- a/plans/service_mesh/plan.md
+++ b/plans/service_mesh/plan.md
@@ -3,14 +3,13 @@
 ## Contents
 
 - [Overview](#overview)
-- [Design Invariants](#design-invariants)
-- [Model](#identity-model)
-- [Publishing](#package-releases)
-- [Revisions](#durable-deployment-state)
-- [Runtime](#workflows)
-- [Authorization](#authentication-and-authorization)
-- [Implementation](#runtime-architecture)
-- [Assurance](#retention-and-audit)
+- [Foundations](#foundations)
+- [Publishing and Distribution](#publishing-and-distribution)
+- [Package Revisions](#package-revisions)
+- [Runtime and Access](#runtime-and-access)
+- [Platform Architecture](#platform-architecture)
+- [Representative Request Lifecycles](#representative-request-lifecycles)
+- [Assurance](#assurance)
 - [Glossary](#glossary)
 
 ## Overview
@@ -19,15 +18,19 @@ The platform builds, distributes, installs, and runs packages in a shared servic
 
 - An MCP server and its operations
 - One or more single-page user interfaces
-- Durable workflow definitions and workers
+- Durable workflow definitions
 - Dependency and migration metadata
-- Runtime, configuration, and authorization requirements
+- Runtime and operation-authorization requirements
 
-An organization operates one deployment backed by a private registry and, optionally, additional trusted registries. The deployment exposes catalogs of installed packages, callable operations, user interfaces, workflows, and dependencies.
+A platform package supervisor runs beside each installed package, starts its MCP server, and reports its observed runtime state.
 
-Publishing makes a release discoverable. Installation admits an immutable release into an organization. Canarying permits controlled, undiscoverable traffic, while promotion makes an installed revision primary and user-discoverable. These states are separate and must not be inferred from one another.
+Each organization operates one deployment backed by a private registry and optional trusted registries. The deployment exposes catalogs of installed packages, callable operations, user interfaces, workflows, and dependencies.
 
-## Design Invariants
+Publishing makes a release discoverable. Installation admits an immutable release into an organization. Canarying permits controlled, undiscoverable traffic. Promotion makes an installed revision primary, and convergence then makes its contracts user-discoverable. These milestones are separate and must not be inferred from one another.
+
+## Foundations
+
+### Design Invariants
 
 The following invariants apply to every implementation:
 
@@ -35,157 +38,151 @@ The following invariants apply to every implementation:
 2. A deployment records every accepted install, upgrade, rollback, and removal request in an append-only revision history.
 3. For each canonical package identity in an organization, only one revision operation — install, upgrade, rollback, or removal — may be in progress at a time.
 4. Durable revision requests record intent; revision controllers perform runtime work and resume safely after process failure.
-5. Published, admitted, materialized, running, ready, canary-callable, promoted, and converged are distinct states.
+5. Registry publication, revision-operation phase, live workload health, routing promotion, and catalog convergence are tracked separately.
 6. A pre-promotion failure does not replace the last successfully promoted revision.
-7. Routing propagation is eventually consistent, so every revision that may receive traffic remains contract-compatible until propagation and draining finish. New contracts become visible only after routing convergence.
-8. Packages run only under organization-provisioned identities; requested capabilities require explicit grant or delegation and cannot be self-asserted by release metadata.
-9. Dynamic services cannot replace the identity, authorization, certificate, secret, registry-verification, audit, state-storage, or recovery components needed to administer the mesh.
-10. Every externally supplied manifest, image, schema, migration, and attestation is untrusted until its digest, signature, and policy are verified.
+7. Routing propagation is eventually consistent, so every revision that may receive traffic remains contract-compatible with operations referenced by installed reverse dependencies until propagation and draining finish. New contracts become visible only after routing convergence. A candidate may omit an operation when no installed package or retained workflow references it; stale or undeclared calls to that operation may fail after promotion.
+8. Packages run only under organization-provisioned identities; release metadata may define access requirements but cannot grant authority.
+9. Ordinary packages cannot replace components needed to administer the platform. Identity, authorization, workflow execution, secret management, registry verification, and audit may be implemented only by protected system packages; certificates, state storage, revision control, and recovery remain part of the bootstrap substrate.
+10. Every externally supplied manifest, image, schema, and migration is untrusted until its digest, signature, and policy are verified.
+11. Every authorization decision uses canonical identities and one immutable policy generation. Grants change only through explicit authorized actions; policy-model changes cannot silently delete or orphan them.
+12. Raw user credentials and caller-supplied identity fields never cross into package runtimes. Internal caller context is short-lived, signed, and bound to its intended audience and target.
 
-## Identity Model
+### Identity Model
 
 The system keeps these identities separate:
 
-- **Registry identity**: immutable `registryId` plus its configured origin and trust-policy digest.
+- **Registry identity**: deployment-scoped immutable `registryId` plus its configured origin. The identifier distinguishes registries within one platform deployment; it is not a global registry namespace.
 - **Package identity**: permanent `(registryId, packageId)` assigned when the package is reserved. A slug is a mutable display and discovery alias, never a security identifier.
 - **Release identity**: `(registryId, packageId, releaseVersion, releaseDigest)`.
 - **Installation identity**: an organization-scoped UUID representing one installed package.
-- **Workload identity**: an orchestrator-owned SPIFFE identity for one installation's runtime or migration job.
+- **Workload identity**: the installation principal used in authorization checks for one installation's runtime or migration job, bound at installation to an organization-managed Kubernetes service account.
 - **Workflow identity**: the principal assigned to a workflow definition or execution.
-- **Actor identity**: the user, API grant, service account, or workflow that initiated an action.
+- **Actor identity**: the user, API grant, platform service account, or workflow that initiated an action.
 - **Effective subject**: the principal whose delegated authority an invocation exercises.
 
-Package IDs are never reused. Slug renames retain aliases and tombstones. Mirroring a package preserves its identity only through a signed mirror or transfer relationship; otherwise importing it creates a distinct package identity.
+Authentication resolves a credential to one canonical principal before authorization. Gateways remove caller-supplied internal identity fields, and downstream services accept identity only from verified workload identity or signed internal context. Delegation keeps the actor and effective subject distinct throughout authorization and audit.
 
-Package authors cannot select workload identities. The orchestrator binds installations to Kubernetes service accounts and short-lived SPIFFE certificates. Trust domain, certificate lifetime, rotation, and compromise revocation are deployment policy.
+Package IDs are never reused. Slug renames retain aliases and tombstones. Content published under a different registry receives a distinct package identity, even when the release bytes are identical.
 
-## Package Releases
+Release metadata cannot name workload identities or Kubernetes service accounts. Runtime identities and authorization bindings are selected from organization-managed resources during installation.
 
-Each `releaseVersion` has one platform-independent, signed release manifest. The release manifest is stored as an OCI artifact or another digest-addressed immutable object and references an OCI image index digest. The image index selects immutable image manifests for supported `os`, `architecture`, and optional `variant` tuples.
+## Publishing and Distribution
 
-Platform images may contain different binaries, but their operation contracts, dependencies, migrations, workflows, and requested capabilities must match the release manifest. A platform-specific release contract is not allowed.
+### Package Releases
+
+Each `(packageId, releaseVersion)` has one signed release manifest and may support one or more `os`, `architecture`, and optional `variant` tuples. Stored by digest, the manifest references an OCI image index covering those platforms.
+
+Platform images may contain different binaries, but contracts, dependencies, migrations, workflow definitions, and operation access requirements are shared across all supported platforms.
 
 The release manifest contains:
 
 - Canonical registry and package IDs, slug, and `releaseVersion`
 - OCI image-index digest and supported platforms
-- Instructions for starting the MCP server, interfaces, and workflow workers
+- MCP server startup instructions and interface entry points
 - MCP endpoint, operations, and input/output schema digests
-- Included workflows and user interfaces
+- Included workflow definitions and user interfaces
 - Required and optional package and operation dependencies
 - Ordered prepare, finalize, and compensating migration jobs
-- Rollback classification
-- Requested service-account, authorization, ingress, and egress capabilities
-- Configuration and typed secret requirements
+- Required authorization relationships or roles for each operation
 - Startup, liveness, and readiness endpoints
-- Minimum and maximum supported `gestaltd` and mesh protocol versions
-- Source repository and revision
-- Subjects for detached signatures and build-provenance attestations
+- Minimum and maximum supported package-supervisor and mesh protocol versions
+- Optional source repository URL and source revision
 
-The manifest does not contain self-asserted signatures or provenance. Signatures and SLSA/in-toto provenance are detached attestations over the release and image digests, such as OCI referrers.
+The registry stores signatures separately from the manifest. Each signature identifies the exact release or image digest it covers.
 
-The `releaseDigest` is computed over the canonical manifest bytes and is carried by catalog entries, signatures, attestations, and installation records rather than by the hashed manifest itself.
+Source repository and revision are optional display metadata. Publication must support releases without either field; when present, catalogs and administration views may use them for links and context.
 
-`releaseVersion` values follow a registry-defined, documented grammar and comparison order. A `(registryId, packageId, releaseVersion)` binds permanently to one `releaseDigest`. A conflicting republish is rejected. An identical retry is idempotent and does not rewrite publication time or provenance. Mutable tags may aid discovery but are never installation inputs.
+The `releaseDigest` is the hash of the canonical manifest bytes. Catalog entries, signatures, and installation records carry it; the manifest does not.
 
-## Registries
+`releaseVersion` follows a documented registry grammar and comparison order. `(registryId, packageId, releaseVersion)` binds permanently to one `releaseDigest`: conflicting republishes fail, while identical retries are idempotent and preserve publication time and metadata. Mutable tags may aid discovery but are never installation inputs.
+
+### Registries
+
+The registry protocol is open and has no central creation or approval authority. Anyone may operate a registry using the reference creation tooling or an independent implementation that serves the required registry descriptor, APIs, and signature bundles. Each organization independently decides whether to connect to and trust that registry.
 
 Registries control who can publish, discover, or download releases. Each configured registry has:
 
-- An immutable `registryId`
+- An immutable `registryId` that is unique within the platform deployment
 - Discovery, metadata, blob, and publication endpoints
-- Authentication and authorization scopes
-- Trusted signing identities and builders
-- Allowed package namespaces
-- Source repository and workflow constraints
-- Required provenance level
-- Whether direct developer publication is permitted
-- A versioned trust-policy digest
+- Optional read credentials for discovery and download from a private registry
+- A registry trust policy binding each trusted public-key fingerprint to a publisher identity and the package IDs that key may sign
+- Whether local clients may publish directly
+- A policy revision incremented when trust or local publication rules change
 
-Connecting a registry does not trust every publisher in it. Catalogs and manifests remain untrusted until admission verifies their immutable digests, signatures, provenance, schema versions, and the deployment's registry policy.
+The registry's publisher policy controls which releases it accepts. Each connected organization's registry trust policy independently controls which of those releases the organization will admit and may be more restrictive. Registry connection credentials, when present, are read-only and are stored by the secret-management service. Publishers authenticate to the registry with their own user or CI credentials, which the platform does not retain. Artifact verification uses the registry trust policy and public trust material, not registry credentials.
 
-The registry interface defines pagination, conditional reads, consistency guarantees, error codes, retries, rate limits, and authentication separately for catalog discovery, immutable metadata, blob pulls, and publication.
+Connecting a registry does not trust its publishers. Catalogs and manifests remain untrusted until admission verifies digests, signatures, schema versions, and the registry trust policy.
 
-A catalog contains paginated package and release summaries pointing to authoritative release-manifest digests. It does not duplicate the full release contract. Per-package indexes use monotonic revisions and compare-and-swap updates.
+The registry provides distinct APIs for paginated discovery, reading immutable metadata and blobs, and authenticated publication.
 
-Disconnecting a registry blocks new discovery and installation but preserves its identity and all historical records. Hard removal is rejected while any desired, running, redeployable, dependent, or in-progress revision references it. Rebinding to a mirror requires digest-equivalent content and signatures trusted by the deployment.
+A registry catalog contains paginated package and release summaries that reference authoritative manifest digests, without duplicating release contracts. Per-package indexes use monotonic revisions and compare-and-swap updates.
 
-## Build and Publish
+Disconnecting a registry blocks discovery and installation but preserves its identity and history. Hard removal fails while any desired, running, redeployable, dependent, or in-progress revision references it. A replacement is a new registry; package identities do not carry over.
 
-`vt build <dir>` validates source metadata and builds an OCI image index and release manifest. The build records resolved source and material digests. Production publication requires attestations from a trusted builder; direct publication must satisfy the same policy.
+### Build and Publish
+
+`vt build <dir>` validates package metadata and builds an OCI image index and release manifest locally. Adding `--push` publishes the result to the selected registry:
+
+```sh
+vt build <dir> --push
+```
+
+Without `--push`, the command does not modify a registry.
 
 Publication is a recoverable transaction:
 
 1. Reserve `(packageId, releaseVersion)` and create a publish-attempt ID.
-2. Record a pending release with source and workflow provenance.
+2. Record a pending release with any optional source metadata.
 3. Upload content-addressed image blobs and manifests.
 4. Validate all platform images and release contracts server-side.
-5. Create the immutable release manifest.
-6. Attach signatures and provenance attestations.
-7. Commit availability by compare-and-swap updating the package catalog last.
+5. Store the immutable release manifest.
+6. Attach signatures.
+7. After all artifacts are stored, atomically add the release to the package catalog. Retry if another publisher changed the catalog first.
 8. Mark the attempt succeeded or failed.
 
 Pending and failed attempts are visible but never installable. Concurrent publishers cannot lose catalog updates. Stale attempts become failed, and orphaned content-addressed blobs are garbage-collected after a grace period.
 
-## Durable Deployment State
+## Package Revisions
+
+### Durable Deployment State
 
 The control plane persists:
 
 - **Package slots**: one organization-scoped slot keyed by canonical package identity, reserved before allocating an installation ID and used to fence concurrent first installs
-- **Revision requests**: append-only install, upgrade, rollback, and removal intent with actor, previous promoted revision, target `releaseDigest`, approved capabilities, resolved dependencies, and timestamps
+- **Revision requests**: append-only install, upgrade, rollback, and removal intent with actor, previous promoted revision, target `releaseDigest`, registry trust policy revision, approved authorization bindings, resolved dependencies, and timestamps
 - **Installation head**: last successfully promoted revision and current admitted candidate
-- **Revision operation**: one generation-fenced state machine per installation
+- **Revision operation**: one generation-fenced state machine per installation, including phase, candidate Kubernetes resources, deadlines, stability timestamp, and routing generation
 - **Migration outcomes**: immutable status keyed by installation, `releaseDigest`, and migration ID
-- **Workload observations**: materialized, started, ready, draining, stopped, and error state for each target replica
 - **Routing and catalog generation**: the promoted revision visible to callers
 - **Terminal outcomes**: completion or failure phase, duration, and reason
 
-Revision records use optimistic concurrency and fencing tokens. A stale controller cannot mutate a newer generation after losing its lease. Retries are idempotent, and every external mutation has a stable idempotency key.
+The revision-operation phase is the canonical lifecycle state. Image availability, process status, replica health, routing synchronization, and catalog generation are observations attached to that operation, not additional lifecycle states.
 
-Each rollout targets one immutable runtime cohort identified by the infrastructure generation and `gestaltd` supervisor generation. Replicas enroll during a bounded epoch; the nonempty cohort is then frozen for promotion accounting. Scaling replicas that join later still converge but do not retroactively change the completed cohort. Observations include the rollout generation and enrollment epoch so stale or overlapping infrastructure cohorts cannot satisfy a newer rollout.
+### Installation
 
-Routing convergence uses a separately frozen proxy cohort. In sidecar mode it contains every live ingress gateway plus the live sidecars of declared reverse-dependent caller workloads at the promotion epoch. `istiod` xDS status supplies proxy membership and acknowledgement of the target routing generation. A reverse-dependent replica that starts later cannot become ready until it receives at least that generation. Undeclared direct east-west invocation is denied, so it cannot bypass this cohort. Ambient mode must define the equivalent gateway, waypoint, and `ztunnel` cohort before it is supported.
+Publishing does not install a package. An authorized installer selects an immutable `releaseDigest` and binds:
 
-The runtime distinguishes:
-
-- **Published**: committed in a registry
-- **Admitted**: verified and accepted as a candidate by the organization
-- **Materialized**: image and immutable contract are available to a workload node
-- **Running**: the candidate process started
-- **Ready**: the candidate passes readiness and minimum healthy-duration checks
-- **Canary-callable**: an undiscoverable candidate receives a controlled subset of traffic for operations whose contracts exactly match the promoted revision
-- **Promoted**: routing selects the candidate as primary
-- **Converged**: the required workload cohort observes the promoted generation
-
-## Installation
-
-Publishing does not install a package. An organization administrator selects an immutable `releaseDigest` and binds:
-
-- Organization-owned package and workflow identities
-- Package-requested operations and capabilities to approved authorization relationships
+- An organization-managed Kubernetes service account for the installation's workload identity
+- Organization-managed workflow identities
+- Package-declared authorization relationships or roles for each operation
 - Caller-delegation policy per operation
-- Typed configuration values and secret references
-- Ingress and egress requests to organization policy
 - Initial replica, resource, and availability settings
 
-The platform shows the requested-versus-approved capability diff before admission. An installer can use only identities for which they have `can_use` or `can_delegate`, and cannot convert temporary authority into an unrestricted persistent package grant. Sensitive capabilities may require a second approver.
+Before admission, the platform shows package-declared operation access requirements and resulting authorization bindings. The installer — an organization administrator or package administrator with install authority — needs `service_account.assign` for each selected identity and `authorization.grant` for each relationship or role being granted.
 
 Installation is a reconciled saga:
 
-1. Verify registry trust, release and image signatures, provenance, platform support, runtime compatibility, and schema versions.
+1. Verify the registry identity and trust policy, release and image signatures, platform support, runtime compatibility, and schema versions.
 2. Resolve exact dependency revisions and operation-contract digests.
-3. Reserve the organization package slot and persist the revision request, approved capability snapshot, and fenced revision operation.
-4. Provision the installation identity, workload identity, policy, configuration, and secret bindings.
-5. Materialize and start the initial workload without making it callable.
-6. Require readiness quorum and minimum healthy duration.
-7. Promote routing, wait for the frozen proxy cohort to acknowledge the routing generation, and drain any prior compatible route.
-8. Advance the callable catalog only after routing converges, then record convergence and the terminal outcome.
+3. Reserve the organization package slot and persist the revision request, approved authorization snapshot, and fenced revision operation.
+4. Provision the installation, workload, and migration identities, authorization relationships, ambient data-plane enrollment, and required `AuthorizationPolicy` attachments.
+5. Hand the fenced operation to the revision controller, which follows the canonical phases in [Revision Rollouts](#revision-rollouts).
 
-Failures preserve the durable phase and diagnostics. The revision controller retries retryable phases within policy and compensates unpromoted resources when an administrator cancels the installation. A package is not callable until promotion succeeds.
+Failures preserve phase and diagnostics. The revision controller retries within policy and cleans up resources created for an unpromoted revision when an administrator cancels. Promotion, catalog exposure, and canary behavior follow the rules in Revision Rollouts.
 
-## Dependencies and Contracts
+### Dependencies and Contracts
 
-Dependencies use canonical package identities, `releaseVersion` ranges, and required operation contract digests. Dependencies may be required or optional. Admission records the exact revisions and contract digests selected.
+Dependencies specify canonical package identities, `releaseVersion` ranges, required or optional status, and operation-contract digests. Admission records the selected revisions and digests.
 
 The platform validates:
 
@@ -196,82 +193,128 @@ The platform validates:
 - No conflicting revision operation is active in the affected dependency subgraph
 - Workflow calls reference compatible operation contracts
 
-JSON Schemas use one pinned dialect and canonical encoding before hashing. The first implementation requires exact schema digests. Semantic compatibility can be introduced only with documented contravariant input and covariant output rules.
+All schemas use the same JSON Schema version and are normalized before hashing. Initially, schemas are compatible only when their hashes match.
 
-Validation reads a revisioned desired-state snapshot and commits with generation preconditions. For independent packages, upgrades may proceed concurrently. Upgrades that affect the same dependency subgraph use deterministic locking or one atomic multi-package rollout plan. Dependency cycles are rejected until atomic rollout groups are implemented.
+Declared dependencies and workflow references are the authoritative compatibility boundary for operation removal. A candidate may remove an operation when no installed package or retained workflow references it, including after accounting for other revisions in the same atomic rollout plan. External callers do not create an implicit dependency: callers using stale catalogs, cached operation names, or otherwise undeclared contracts may receive an operation-unavailable error after promotion.
 
-## Upgrades and Traffic Promotion
+Validation reads a revisioned desired-state snapshot and commits with generation preconditions. Independent packages may upgrade concurrently. Upgrades affecting the same dependency subgraph use deterministic locking or one atomic multi-package rollout plan. Cyclic dependencies may be upgraded sequentially when every intermediate state is compatible. Mutually dependent changes require an atomic rollout group.
 
-An upgrade never mutates the running revision in place. It creates a candidate generation while the last promoted revision continues serving.
+### Revision Rollouts
 
-The rollout state machine is:
+Upgrades use a Kubernetes-native blue/green rollout with optional Istio canary traffic. Each upgrade creates a candidate revision in a distinct immutable Kubernetes Deployment behind a revision-specific Service. The promoted and candidate Deployments may run together, so the serving Deployment is never restarted or mutated in place.
 
-1. **Admitted**: verify the release, policy, runtime compatibility, dependencies, reverse dependents, and rollback classification.
-2. **Staging**: pull and verify images for the target cohort.
-3. **Preparing**: run backward-compatible prepare migrations as fenced one-shot jobs.
-4. **Starting**: start candidate workloads with no production traffic.
-5. **Ready**: require a readiness quorum and minimum healthy duration.
-6. **Canarying**: route a configurable small traffic percentage for operations whose contracts exactly match the promoted revision; the candidate remains absent from user-facing catalogs.
-7. **Promoting**: make the candidate primary, wait for the frozen proxy cohort to acknowledge the routing generation, and only then expose newly added contracts in callable catalogs. Promotion is the boundary after which the candidate is the last successfully promoted revision.
-8. **Draining**: keep the prior revision available for in-flight requests and streams until their drain deadline.
-9. **Soaking**: observe the promoted revision for a configured period.
-10. **Finalizing**: run irreversible contract/finalize migrations only after the rollback window when required.
-11. **Complete**: record convergence and terminal timing.
+Revision records use optimistic concurrency and fencing tokens, preventing a controller that loses its lease from mutating a newer generation. Retries are idempotent; every external mutation has a stable idempotency key. For example, controller A may start an upgrade at generation 4, create the candidate Deployment, and then lose its lease. Controller B takes over at generation 5. Any later update from controller A is rejected, while controller B can safely retry the Deployment request without creating a duplicate.
 
-Each phase has a timeout, retry policy, and terminal error taxonomy. Promotion requires nonempty frozen runtime and proxy cohorts and cannot be inferred from one ready instance. Routing changes define weight propagation, proxy acknowledgement, readiness quorum, connection draining, and behavior for MCP SSE streams. During partial routing propagation, both revisions support the promoted operation-contract digests.
+Kubernetes and the package supervisor are the source of truth for live workload health. A candidate is ready only when Kubernetes has observed the Deployment generation, its required replicas are available, and package-supervisor readiness confirms the target `releaseDigest` for a stability window. Replacement pods and autoscaled replicas count by current readiness, not persistent identity.
 
-Failures before promotion produce a failed candidate and leave the prior promoted revision primary. Failures during soak after promotion mark the new revision degraded and trigger rollback when its rollback class permits; otherwise they require an audited forward fix. Finalization failure does not relabel the promoted revision as a failed candidate or route traffic implicitly: it records `promoted_with_finalization_error`, blocks the next revision operation, and requires retry or an approved forward fix.
+Istio routes traffic between revision-specific Services. Promotion converges when every currently live relevant ingress gateway and destination waypoint reports the target xDS generation and their Kubernetes Deployments remain available for a stability window. If the set of live routing proxies changes, the stability window resets. Packages may call other packages only through declared dependencies and mesh-managed routes. Direct or undeclared package-to-package calls are blocked.
 
-The availability goal is zero planned downtime for packages that satisfy the compatibility contract. Any supported operation that requires downtime declares and receives explicit administrator approval before admission; a vague downtime target is not sufficient.
+The control plane persists rollout intent and decisions, then reconstructs progress from Kubernetes, the package supervisor, and Istio after restart. Historical rollout outcomes remain immutable; current workload health is a separate live view.
 
-## Migrations and Rollback
+The canonical revision-operation phases are:
+
+1. **Admitted**: verify the release, policy, runtime compatibility, dependencies, and reverse dependents.
+2. **Preparing**: run backward-compatible prepare migrations as fenced one-shot jobs.
+3. **Starting**: create the revision-specific Deployment and Service with no production traffic.
+4. **Ready**: require Kubernetes availability and package-supervisor readiness for the configured stability window.
+5. **Canarying**: route a configurable small traffic percentage for operations whose contracts exactly match the promoted revision; the candidate remains absent from user-facing catalogs.
+6. **Promoting**: route primary traffic to the candidate, wait for live relevant proxies to remain synced to the routing generation, and then expose newly added contracts in callable catalogs. Promotion makes the candidate the last successfully promoted revision.
+7. **Draining**: keep the prior revision available for in-flight requests and streams until their drain deadline.
+8. **Observing**: monitor the promoted revision under production traffic for a configured period.
+9. **Finalizing**: run explicitly approved irreversible finalize migrations when required.
+10. **Complete**: record convergence and terminal timing.
+
+Canarying and Finalizing may be skipped when they do not apply. A failure or cancellation records a terminal outcome against the phase where the operation stopped rather than introducing another progression phase.
+
+Each phase has a timeout, retry policy, and terminal error taxonomy. Readiness requires the configured replica capacity, not a single ready pod. During routing propagation and draining, revisions follow the compatibility and operation-removal rules in [Dependencies and Contracts](#dependencies-and-contracts). Existing MCP SSE streams remain pinned to their original revision while the old revision drains, including streams for an operation omitted by the candidate.
+
+Pre-promotion failures mark the candidate failed and leave the prior revision primary. Failures during post-promotion observation mark the new revision degraded. Neither case triggers automatic rollback. Degraded or finalization-error states block the next revision operation until an administrator retries, initiates an approved rollback, or approves a forward fix. Finalization failure records `promoted_with_finalization_error`; it neither marks the promoted revision failed nor changes routing.
+
+Compatible packages target zero planned downtime. Any release requiring downtime must declare it and receive explicit administrator approval before admission.
+
+### Migrations and Rollback
 
 Migrations are separately identified, digest-pinned jobs. Each declares:
 
 - Migration ID and `releaseDigest`
 - Prepare, finalize, or compensating phase
-- Dedicated workload identity and requested capabilities
-- Required secrets and network destinations
+- Dedicated workload identity
 - Timeout, resource limits, retry policy, and idempotency key
 - Compatibility with the prior and candidate package revisions
 
-Migration jobs run with least privilege and deny-by-default egress. They never run as the installer, revision controller, or normal package identity. Attempt and completion records are durable.
+Migration jobs use least privilege and deny-by-default egress. They never run as the installer, revision controller, or installation's normal workload identity. Attempts and outcomes are durable.
 
-Each release declares one rollback class:
+The first version does not classify rollback safety in release metadata or initiate rollback automatically. Prepare migrations follow expand/contract rules and remain compatible with the serving revision. Destructive finalization requires separate administrator approval. Before manual rollback, an administrator must confirm data compatibility and select any required declared compensating migration; the platform does not infer rollback safety. Administrators may initiate an approved rollback through the revision controller; shell commands cannot update revision state.
 
-- **Traffic-only**: the previous revision can serve against the current data model
-- **Code and compatible data**: old code and schema remain mutually compatible
-- **Compensating migration required**: rollback requires a declared, verified job
-- **No post-promotion rollback**: an explicitly approved release cannot return traffic to the prior revision after promotion
-
-Prepare migrations follow expand/contract rules and must remain compatible with the serving revision. Releases with a rollback-capable class defer destructive finalize migrations until the rollback window closes. A no-post-promotion-rollback release requires explicit approval before promotion and has no rollback window. A rollback command is not proof that data rollback is safe.
-
-Administrators initiate rollback through the same revision controller. Manual shell execution cannot update revision state. Automatic rollback may later invoke the same audited state machine when canary or soak gates fail.
-
-## Removal
+### Removal
 
 Removal is a durable tombstoned revision, not deletion of a catalog row:
 
 1. Reject removal while required reverse dependents exist, unless they are removed in the same atomic plan.
 2. Promote a tombstone generation that removes callable catalog entries and prevents new invocation resolution.
-3. Drain already-resolved requests, streams, workers, and queued work according to policy.
-4. Stop workloads and block ingress and egress.
-5. Revoke workload certificates, installation-owned assignments, delegated tokens, secret bindings, and runtime configuration.
-6. Apply package-data retention or destruction policy.
+3. Drain resolved requests and streams, stop new workflow executions, and handle queued or running executions according to policy.
+4. Stop the removed package's runtime workloads, scale them to zero, and block any stale ingress or package-initiated egress.
+5. Revoke workload authorization bindings, installation-owned assignments, and delegated tokens.
+6. Apply package data retention or destruction policy.
 7. Preserve the package tombstone and audit history.
 8. Garbage-collect runtime resources after the recovery window.
 
-Organization-owned persistent grants are not silently deleted; the removal UI distinguishes them from installation-owned grants. Reinstallation creates a new installation identity unless an explicit restore operation reactivates the tombstone within policy.
+Removal preserves organization-owned grants and distinguishes them from installation-owned grants. Reinstallation creates a new installation identity unless an approved restore reactivates the tombstone.
 
-## Workflows
+## Runtime and Access
 
-Workflow definitions are immutable and versioned independently from package processes. Each execution records its workflow-definition digest, actor, workflow identity, and compatible package-operation contract revisions.
+### Authentication and Authorization
 
-Existing executions continue on workers that support their pinned definition until they complete, migrate, or reach a documented retirement policy. New executions use the promoted workflow catalog generation. Removal and incompatible upgrades must account for queued work, retries, timers, and long-running executions before workers are drained.
+The authorization service is the system of record for organization policy. It stores Zanzibar-style tuples used by management, user-invocation, workflow, and package-to-package authorization checks. Enforcement topology and mesh policy attachment are defined in [Runtime Architecture](#runtime-architecture).
 
-Every workflow operation is authorized at execution time. `can_run_as` is required to select an organization-managed workflow identity. The original triggering actor remains in the audit and delegation chain.
+- Users authenticate through an external identity provider with organization-level SSO, issuer and tenant allowlists, and session revocation.
+- API keys are named, expiring, scoped API grants that act on behalf of an owner. Only hashes are stored, plaintext is returned once, and empty scope does not mean unrestricted access.
+- `service_account.create` permits creating an organization-managed service account but grants it no authority.
+- `service_account.assign` permits binding a service account to a package runtime, workflow definition, or workflow execution but grants it no new authority.
+- `authorization.grant` permits granting a relationship or role and may be held only by a human subject. The grant cannot exceed the issuer's current authority, resource scope, conditions, or expiration.
+- Every installed package runtime uses an organization-owned workload identity; workflow definitions and executions use organization-owned workflow identities.
+- Every invocation is centrally authorized before dispatch; package-specific resource checks may further restrict it.
+- Production does not start in a fail-open mode when identity or authorization is unavailable.
 
-## Catalogs and Administration
+Each authorization grant wraps one relationship tuple and records an immutable ID, organization, human issuer, creation and optional expiration, source authority, and policy revision. Grant mutation creates a new record; revocation appends a revocation record rather than rewriting or deleting history. Revoking or narrowing the source authority invalidates dependent grants. Platform controllers may apply a recorded human-authorized grant but cannot originate one.
+
+The first implementation does not cache authorization decisions. Internal invocation tokens are short-lived, and every workflow step is authorized independently. Existing streams may continue until their configured lifetime expires. Security events go to an immutable audit sink outside package-controlled storage.
+
+### Authorization Model and Evaluation
+
+Authorization uses a provider-independent check protocol built around:
+
+- A canonical **subject** being evaluated, such as the effective subject, immediate caller workload, or management actor
+- An **action**, such as a package operation or administrative permission
+- A canonical **resource**, identified by a reserved platform type or a package-namespaced type
+
+The platform reserves resource types for registries, packages, releases, installations, revisions, workflows, identities, and authorization grants. Package-defined resource types are namespaced by canonical package identity and cannot use reserved names. Users and service accounts are subjects unless the requested action manages the identity itself.
+
+A decision returns allow or deny together with the immutable policy model ID and revision used to evaluate it. A batch form evaluates multiple checks against the same policy snapshot and has the same semantics as individual checks; catalogs and controllers use it to avoid per-item authorization calls.
+
+The authorization model defines resource types, relations, actions, and which relations satisfy each action. Relationship targets may be direct subjects, resources, or subject sets such as the members of a group. Subject-set traversal is cycle-safe. Package invocation uses the installation identity as the resource and the canonical operation ID as the action; package-specific checks may use a more specific package-owned resource.
+
+The authorization service stores the policy model and organization-managed grants in one authoritative runtime system. Platform bootstrap registers reserved resource types, while package admission registers namespaced resource types and operation requirements. Each model change produces an immutable, content-hashed generation. Grants may be revoked at any time. A policy-model change cannot remove or rename a resource type or relation referenced by active grants unless those grants are revoked or migrated in the same transaction. Grants are indexed by subject, relation, and resource so evaluation does not scan the complete relationship set.
+
+Credential scopes are an upper bound on authority: a relationship grant cannot restore access excluded by the authenticated credential. Missing subjects, actions, resources, policy models, or provider availability produce a denial.
+
+### Package Access Policy
+
+Release manifests define only the authorization relationships or roles required to invoke each operation. They do not declare configuration, secrets, ingress, or egress capabilities.
+
+Package upgrades cannot directly change organization-managed grants. A subject with appropriately scoped `authorization.grant` may update those grants within their delegated authority. An upgrade succeeds admission only when all required bindings and delegation approvals are present; otherwise it fails before rollout and may be retried after they are supplied.
+
+MCP endpoints are mesh-internal by default. External invocation uses the deployment ingress and the same authorization service. Direct package egress defaults to deny and is managed by deployment policy rather than release metadata.
+
+### Workflows
+
+Packages publish immutable workflow definitions, not workers. The revision controller registers promoted definitions with a workflow MCP service in the mesh. Each execution records its definition digest, actor, workflow identity, and compatible operation-contract digests.
+
+The workflow service runs each execution against its pinned definition until completion, migration, or documented retirement. New executions use the promoted workflow catalog generation. Removal and incompatible upgrades account for queued work, retries, timers, and long-running executions.
+
+Every workflow operation is authorized at execution. Selecting an organization-managed service account as a workflow identity requires `service_account.assign`. The triggering actor remains in the audit and delegation chain.
+
+### Catalogs and Administration
 
 An organization deployment provides:
 
@@ -281,12 +324,14 @@ An organization deployment provides:
 - A workflow catalog
 - A dependency graph
 - Package revisions, rollout and migration status, identities, and authorization settings
-- API-grant management
+- API grant management
 - A development sandbox
 
-Candidate metadata may be visible to administrators, but user-facing callable catalogs expose only contracts safe for the currently propagated routes. Routing is updated first because xDS propagation is asynchronous; newly added contracts become discoverable only after the frozen proxy cohort acknowledges the routing generation. Both revisions remain contract-compatible until old routes drain. Each invocation, including an SSE stream, resolves once and remains pinned to one package revision.
+Administrative catalogs may expose candidate metadata. Callable catalogs are keyed to the converged routing generation and expose new contracts only after the promotion and synchronization requirements in [Revision Rollouts](#revision-rollouts) are satisfied.
 
-Organization administrators can connect registries and install, upgrade, roll back, or remove packages. Package developers can build, publish, test, and invoke packages. Package users see only catalogs and operations authorized for them.
+Clients treat catalogs as snapshots. Invocation remains authoritative and may reject stale or undeclared operations under the rules in [Dependencies and Contracts](#dependencies-and-contracts).
+
+Organization administrators can connect registries and install, upgrade, roll back, or remove packages. Package administrators can perform revision and administration actions within their delegated package and authorization scope. Package developers can build, publish, test, and invoke packages. Package users see only catalogs and operations authorized for them.
 
 Representative endpoints:
 
@@ -295,9 +340,9 @@ Representative endpoints:
 - Administration: `https://vt.valon.tools/admin`
 - Package administration: `https://vt.valon.tools/packages/<package>/admin`
 
-Management APIs use a private listener or equivalent network restriction and require stronger authorization than user invocation endpoints.
+Management APIs require dedicated administrative permissions and should use a private listener or equivalent network controls where practical.
 
-## Invocation
+### Invocation
 
 Authorized operations are available over the deployment endpoint and through the CLI:
 
@@ -305,48 +350,29 @@ Authorized operations are available over the deployment endpoint and through the
 vt invoke --deployment <url> <package> <operation> --args <json>
 ```
 
-Authentication comes from an interactive session, keychain, environment, or standard input. Secrets and tokens are not positional command arguments.
+Authentication comes from an interactive session, keychain, environment, or standard input. Positional arguments never carry secrets or tokens.
 
-Operation invocation uses MCP Streamable HTTP. Clients and packages support JSON-RPC over POST and the protocol's JSON and SSE response forms. The gateway enforces request size, timeout, rate, and stream-lifetime policy.
+Invocation uses MCP Streamable HTTP: JSON-RPC over POST with JSON or SSE responses. The gateway enforces request size, timeout, rate, and stream lifetime.
 
-Ingress strips externally supplied internal-identity headers. It exchanges user credentials for a short-lived, audience-bound internal invocation token containing the original actor, effective subject, immediate calling workload, delegation chain, target package and operation, issued/expiry times, nonce, and trace ID. Packages never forward raw user bearer tokens or API keys.
+Ingress strips externally supplied internal-identity headers and exchanges user credentials for a short-lived, signed internal invocation token. The token is bound to its issuer, audience, target package, and operation and carries a unique ID, issuance, not-before, and expiry times, the original actor, effective subject, immediate caller workload identity, delegation chain, and trace ID. Signing keys rotate with an overlap window for in-flight requests. Packages never receive or forward raw user bearer tokens or API keys.
 
-The authorization decision intersects:
+Authorization is enforced at two surfaces:
 
-- The authenticated calling workload's permission to invoke the target
+- **Ingress gateway**: user invocation, catalogs, package administration, and package revision APIs. The gateway's `ext_authz` filter calls the authorization service before forwarding to control-plane or package services.
+- **Destination waypoint**: package-to-package MCP calls are checked before forwarding to the MCP server. Waypoint enforcement is described in [Runtime Architecture](#runtime-architecture).
+
+Both surfaces use one authorization service and relationship graph. Checks use the immediate caller workload identity, effective subject, target package, and operation for MCP traffic; management checks use the actor and requested revision or administration action.
+
+For MCP invocation, the authorization decision intersects:
+
+- The authenticated caller workload identity's permission to invoke the target
 - The effective subject's permission
-- The installed package's approved operation policy
+- The installed package's approved operation access policy
 - Any operation-specific resource authorization
 
-Unknown identities, packages, operations, policies, or authorization-provider outages deny access.
+Credential scope and every applicable relationship check must allow the request. The decision records the policy model ID and revision. Unknown identities, packages, operations, policies, or authorization-provider outages deny access.
 
-## Authentication and Authorization
-
-- Users authenticate through an external identity provider with organization-level SSO, issuer and tenant allowlists, and session revocation.
-- API keys are named, expiring, scoped API grants that act on behalf of an owner. Only hashes are stored, plaintext is returned once, and empty scope does not mean unrestricted access.
-- Users create service accounts only with an attenuated subset of authority and explicit expiry or organization policy.
-- Every installation has organization-owned workload and workflow identities.
-- Every invocation is centrally authorized before dispatch; package-specific resource checks may further restrict it.
-- Production does not start in a fail-open mode when identity or authorization is unavailable.
-
-Authorization uses a Zanzibar-style graph. Relationship definitions declare whether they support delegated assignments, persistent grants, both, or neither. The default is neither.
-
-- **Delegated assignment (`delegatable`)**: a holder with `can_delegate_<relationship>` may create a child assignment that cannot exceed or outlive its parent.
-- **Persistent grant (`grantable`)**: a principal with `can_grant_<relationship>` may create an independent assignment that remains until explicitly revoked.
-
-An assignment is a first-class record containing an immutable ID, organization, subject, relationship, resource, mode, issuer, creation and optional expiration, optional parent assignment, policy revision, and revocation state. Delegation has bounded depth, acyclic ancestry, transactional creation, and cascading invalidation. Independent valid paths preserve access after one path is revoked.
-
-Authorization caches and delegated invocation tokens have bounded lifetimes. Revocation has a documented maximum propagation time and applies to long-lived streams and each workflow step. Security events are written to an immutable audit sink outside package-controlled storage.
-
-## Configuration, Secrets, Ingress, and Egress
-
-Release manifests declare typed requirements, not concrete secret values or unrestricted secret names. Administrators bind them to organization-owned configuration and secret-manager objects. Secret access is granted only to the installation or migration workload identity and uses short-lived retrieval where possible.
-
-Capability expansion on upgrade requires renewed approval. Expansion includes new authorization relationships, identities, secrets, public routes, egress destinations, migration permissions, or caller delegation. Capability reduction may be automatically accepted under organization policy.
-
-Every endpoint is classified as public, organization-authenticated, mesh-internal, or management-only. Egress is deny-by-default and explicitly grants destination, port, protocol, TLS/SNI, DNS, and credential behavior.
-
-## Development Sandbox
+### Development Sandbox
 
 `vt dev` builds a local package and connects it only to an explicitly enabled per-user sandbox:
 
@@ -354,106 +380,218 @@ Every endpoint is classified as public, organization-authenticated, mesh-interna
 vt dev --deployment <url> <dir>
 ```
 
-Authentication uses the normal interactive or keychain flow. The platform issues a short-lived development workload identity distinct from the user's identity. Development routing is scoped to the developer or named test session and cannot take over a production package slug.
+Authentication uses the normal interactive or keychain flow. The platform assigns a short-lived development workload identity distinct from the user. Routes are scoped to the developer or named test session and cannot claim a production package slug.
 
 Development packages:
 
-- Receive no production traffic by default
+- Receive traffic only from their developer or explicitly named test sessions and never become the default production route
 - Cannot run migrations
-- Cannot access production secrets
-- Cannot forward caller credentials
-- Use sandbox-scoped authorization and egress
+- Cannot receive or forward raw caller credentials
+- Do not inherit the production workload's permissions
+- Use sandbox-scoped authorization
 - Expire automatically and are audited on connect and disconnect
 
-## Runtime Architecture
+## Platform Architecture
+
+### Deployment Tiers
+
+The platform separates deployment into three trust and lifecycle tiers:
+
+1. **Bootstrap substrate**: Kubernetes and Istio, the control-plane state store, revision controllers, certificate authority, and backup and recovery tooling. Terraform deploys these components before package APIs are available.
+2. **Protected system packages**: identity, authorization, secret management, registry verification, audit, and workflow execution. After the bootstrap substrate is healthy, revision controllers install and upgrade these services using signed releases and the normal immutable revision and rollout machinery.
+3. **Ordinary organization packages**: packages installed by authorized organization or package administrators and constrained by organization policy.
+
+Protected system packages have fixed canonical identities, trusted-signer allowlists, dedicated platform workload identities, protected names and routes, and platform-only revision permissions. They cannot grant themselves authority, be replaced by an ordinary package, or be removed through ordinary package APIs. Infrastructure configuration pins the initial system-package releases and bootstrap order; after identity and authorization are available, subsequent changes require normal platform authorization.
+
+The bootstrap substrate and protected system packages are both inside the platform availability boundary. If a required component in either tier is unavailable, the affected capability is counted as platform downtime even when some existing package traffic continues. For example, a registry-verification outage is publishing and installation downtime, while an identity or authorization outage may prevent new requests without immediately terminating established connections. An ordinary package failure counts as downtime for that package, not for the platform, unless a platform defect caused or spread the failure.
+
+### Trusted Platform Services
+
+The bootstrap substrate and protected system packages provide these trusted services:
+
+- **Identity service**: authenticates sessions and API grants, resolves canonical principals, manages organization service accounts, and issues short-lived internal invocation tokens.
+- **Authorization service**: stores immutable policy models, grants, assignments, and revocations and evaluates provider-independent and Envoy `ext_authz` checks.
+- **Secret-management service**: stores and rotates platform and connection credentials and releases secret material only to explicitly authorized workload identities.
+- **Registry-verification service**: retrieves registry metadata and verifies origins, manifests, digests, signatures, platform compatibility, and the registry trust policy before admission.
+- **Audit sink**: accepts append-only security, authorization, administration, and runtime events in storage that packages cannot control.
+- **Workflow service**: registers promoted package-defined workflows and runs pinned executions outside package runtimes.
+- **Control-plane state store**: a bootstrap-substrate service that durably stores registries, package slots, revision requests and operations, routing and catalog generations, migration outcomes, and recovery metadata.
+
+The Istio control plane provides the certificate authority and workload-certificate lifecycle. Backup and recovery tooling protects control-plane state and trusted-service configuration but does not sit on the request path.
+
+Each trusted service exposes a versioned typed API. Control-plane clients use shared libraries for workload authentication, canonical caller context, deadlines, bounded retries, idempotency keys, metrics, tracing, and audit metadata. Istio provides service discovery, mTLS, and network routing, so the first implementation does not add a generic control-plane proxy.
+
+### Runtime Architecture
+
+Production uses Istio ambient mode. `ztunnel` provides L4 transport security and workload identity, while waypoint proxies provide L7 routing and authorization. Sidecars are not planned for the first implementation.
 
 The runtime consists of:
 
-- **Istio control plane (`istiod`)**: distributes routing, policy, endpoint, and certificate configuration to the Istio data plane.
-- **Istio workload data plane**: Envoy sidecars mediate inbound and outbound workload traffic. Ambient mode, using mandatory node-level `ztunnel` proxies and optional L7 waypoint proxies, is a possible later deployment mode; a deployment uses one documented mode at a time.
-- **Ingress gateways**: separate Envoy data-plane proxies terminate external transport, remove untrusted identity headers, authenticate supported credentials, and route public and organization traffic.
-- **Egress gateways**: separate Envoy data-plane proxies enforce and audit declared external network access where direct egress cannot be safely allowed.
-- **Package supervisor (`gestaltd`)**: runs alongside one package installation, mediates application-level invocation and authorization, reports observed state, and manages the package process. It is not an Istio data-plane proxy and does not replace Envoy.
-- **Package runtime**: runs the package's MCP server, interfaces, and workflow workers.
-- **Revision controllers**: reconcile durable install and rollout records into workloads, routing, catalogs, identities, and policy.
+- **Istio control plane (`istiod`)**: distributes routing, policy, endpoint, and certificate configuration.
+- **`ztunnel`**: mandatory node proxies providing L4 transport security and workload identity.
+- **Waypoint proxies**: shared Envoy proxies providing L7 routing, telemetry, and authorization for destination Kubernetes Services.
+- **Ingress gateways**: terminate external transport, remove untrusted identity headers, authenticate credentials, enforce `ext_authz`, and route public and organization traffic.
+- **Egress gateways**: enforce and audit organization-declared external access that cannot safely use direct egress.
+- **Package supervisor (`gestaltd`)**: runs beside an installation, manages its process lifecycle and local invocation, and reports observed state. It is not an Istio proxy.
+- **Package runtime**: runs the package's MCP server and serves its interfaces.
+- **Protected system packages**: provide identity, authorization, secrets, registry verification, audit, and workflow execution as defined above.
+- **Control-plane state store**: provides durable state for trusted services and revision controllers as part of the bootstrap substrate.
+- **Revision controllers**: reconcile durable revision requests and rollout state into workloads, routing, catalogs, identities, and policy.
 
-Production uses Istio `PeerAuthentication` in `STRICT` mode for mesh mutual TLS, Istio `AuthorizationPolicy` for workload-to-workload policy, and Kubernetes `NetworkPolicy` for network reachability. The deployment installs explicit default-deny authorization and network policies; these mechanisms are not assumed to deny traffic merely because they are enabled. Package application ports are reachable only through the mesh data plane. Health and supervisor administration ports have explicit, minimal exceptions and are not exposed through public ingress.
+Revision controllers use trusted-service APIs and the Kubernetes API to create or update Deployments, Services, waypoint enrollment, routes, traffic weights, and `AuthorizationPolicy` resources. `istiod` watches the Kubernetes and Istio resources, translates the desired state into xDS configuration, and distributes it to ingress gateways, waypoints, and `ztunnel`. Proxies acknowledge the configuration they receive; revision controllers observe synchronization for the target routing generation before advancing callable catalogs.
 
-Established data-plane traffic continues using the last known configuration when `istiod` is unavailable. New revision operations that require routing, certificates, policy, or registry verification fail closed until their control-plane dependencies recover.
+Istio keeps workload endpoints, routing, certificates, and mesh-policy configuration synchronized. It does not own or synchronize package revision state, authorization grants, workflow executions, or catalogs. Those remain the responsibility of revision controllers and trusted platform services. Package operation invocations remain on the mesh data plane and use ingress or destination-waypoint authorization.
 
-Terraform deploys the GCP infrastructure, including the Valon Tools cluster, GitHub Actions cluster, networking, container infrastructure, identity services, and deploy-pinned trusted components. Installing packages does not mutate this trusted computing base.
+`ztunnel` cannot enforce L7 authorization. MCP, revision, and administration checks therefore run at ingress gateways or destination waypoints. Kubernetes Services exposing MCP servers enroll in a waypoint, where revision controllers attach `AuthorizationPolicy` `CUSTOM` rules.
 
-## Mesh Deployment
+Production uses `ztunnel` for transport security and L4 workload authorization, Kubernetes `NetworkPolicy` for reachability, and ingress or waypoint `ext_authz` for application authorization. Authorization checks fail closed on denial or outage. Only the mesh data plane can reach package application ports; health and supervisor administration ports have minimal explicit exceptions and no public ingress.
 
-The mesh is redeployed only when changing deploy-pinned infrastructure, including:
+If `istiod` is unavailable, established traffic uses its last configuration. New revision operations requiring routing or policy changes fail closed until dependencies recover.
 
-- `istiod` and Istio data-plane versions
-- `gestaltd` supervisor versions
-- Ingress and egress gateways
-- Identity, authorization, certificate, secret, audit, state-storage, registry-verification, or recovery services
+Terraform manages the bootstrap substrate, including clusters, networking, container infrastructure, state storage, revision controllers, certificate authority, and recovery tooling. Package installation does not mutate this substrate.
 
-Package releases declare compatible `gestaltd` and mesh protocol ranges. Infrastructure rollouts account for old and new runtime cohorts before admitting a package release that requires new capabilities.
+### Infrastructure and Service Rollouts
 
-Installing, upgrading, rolling back, or removing packages is a runtime change and does not require mesh redeployment. Connecting or disconnecting a registry is durable control-plane state and does not require redeployment, but changing registry trust roots remains a separately authorized and audited action.
+The mesh is redeployed only for changes to Istio or its trust and extension configuration, including:
 
-## Retention and Audit
+- `istiod`, `ztunnel`, and waypoint proxy versions
+- Ingress and egress gateway versions or deploy-pinned configuration
+- Istio certificate-authority and trust-domain configuration
+- Mesh-wide extension-provider and ambient-enrollment configuration
 
-Immutable release metadata, attestations, and accepted revision history are retained permanently or according to organization audit policy. Blob retention is separate:
+Protected system packages roll independently through the revision controller and do not require a mesh redeployment. Ordinary package revisions, registry connection changes, identity assignments, and authorization-binding updates likewise change runtime or control-plane state without redeploying the mesh. `gestaltd` supervisor updates roll with the workloads that use them.
 
-- Unused releases expire after a configurable window
-- Running, admitted, and rollback-eligible revisions retain all required blobs
-- Historical revisions retain blobs through a configurable recovery window
-- Expired historical blobs may be garbage-collected while metadata and audit history remain
+Bootstrap-substrate changes, including control-plane state migrations and backup or recovery tooling, use infrastructure rollouts but do not redeploy the mesh unless they also change an Istio item listed above. Package releases declare compatible `gestaltd` and mesh protocol ranges, and infrastructure rollouts account for overlapping old and new versions before admitting releases that require new features. Registry trust-root changes remain separately authorized and audited.
 
-OCI garbage collection is reference-aware because layers may be shared. Pruning is serialized with admission and rechecks eligibility immediately before deletion.
+## Representative Request Lifecycles
 
-Audit events include authentication, API-grant lifecycle, certificate issuance, authorization decisions, assignment mutation, delegated identity use, registry and trust-policy changes, publish/install/upgrade/rollback/removal, migration execution, secret access, ingress/egress denial, and development injection. Events include actor, effective subject, calling workload, target, policy revision, decision reason, trace ID, and `releaseDigest`.
+The following lifecycles show how representative registry, management, and data-plane requests move through the system.
 
-## Required Verification
+### Create a Registry
+
+Registry creation is a registry-side operation and is distinct from connecting that registry to an organization. The reference registry-creation service and CLI are convenience tools, not gatekeepers; operators may instead use the underlying libraries or build any compatible implementation.
+
+1. A registry operator uses the reference tooling or an independent implementation to provision a protocol-compatible registry and durable metadata store. The registry uses OCI 1.1 storage—Google Artifact Registry by default—for content-addressed images, manifests, and signature bundles.
+2. The registry generates one immutable `registryId`. The identifier scopes package and release identities and must be unique among registries connected to the same platform deployment.
+3. The operator configures discovery and download visibility, publisher authentication, who may create packages, and who may publish versions to each package. The reference tooling may also configure optional GitHub listeners or other publication triggers.
+4. The operator configures the registry's publisher policy by registering publisher identities, their public keys, and the package IDs each key may sign. The reference tooling may provision KMS-backed signing keys, but private keys remain publisher-controlled and are never stored by the registry.
+5. The registry publishes a descriptor matching the required schema, including its protocol version, `registryId`, API endpoints, and supported signature formats, through its well-known metadata endpoint.
+6. Readiness checks verify metadata and blob durability, digest validation, authentication, authorization, and signature enforcement before the registry accepts publication or discovery traffic.
+
+### Connect a Registry
+
+1. An organization administrator submits the registry's HTTPS origin, optional read credentials for a private registry, and a registry trust policy binding trusted publisher identities and public keys to package IDs.
+2. The ingress gateway authenticates the actor, removes untrusted identity headers, and calls the authorization service through `ext_authz`. The request proceeds only when the actor has the required registry-management permission.
+3. The registry-verification service connects through the permitted egress path and reads the registry's protocol version, immutable `registryId`, API endpoints, catalog, and signature bundles. Remote content remains untrusted.
+4. The control plane rejects a `registryId` already bound to a different origin or an origin already bound to a different `registryId`. It stores any read credentials through the secret-management service and persists the verified registry identity and initial registry trust policy revision.
+5. After verification succeeds, the control plane marks the registry connected and advances the registry catalog generation. Packages become discoverable, but each release must still pass admission checks before installation.
+6. The API returns the registry record and verification status. Failures preserve diagnostics without making the registry available for discovery or installation.
+
+### Publish a Package Release
+
+1. A developer or CI job authenticates directly to the registry with its own publishing credential and runs `vt build <dir> --push`.
+2. `vt` validates the package metadata, builds the platform images and OCI image index, creates the canonical release manifest, and calculates its `releaseDigest`.
+3. The registry authorizes the publisher to reserve `(packageId, releaseVersion)` and creates a recoverable publish-attempt ID. A version already bound to a different digest is rejected.
+4. `vt` uploads content-addressed image blobs, the image index, and the release manifest. The registry recalculates digests and validates platform images and release contracts before making anything discoverable.
+5. The publisher signs a statement containing the `registryId`, `packageId`, `releaseVersion`, `releaseDigest`, and image-index digest with an authorized KMS-backed key, then uploads the signature bundle.
+6. The registry verifies the signature and confirms under its publisher policy that the signing key may publish the package. It then atomically binds the version to the digest and adds the release to the package catalog.
+7. The registry returns the immutable `releaseDigest`. Failed or interrupted attempts remain non-installable and may be retried; publishing does not install or deploy the release.
+
+### Upgrade a Package
+
+1. An organization or package administrator selects a target `releaseDigest` for an installed package and submits a durable upgrade revision request with any approved identity or authorization changes.
+2. The ingress gateway authenticates and authorizes the actor. The control plane verifies any required `service_account.assign` and `authorization.grant` permissions.
+3. The control plane appends the revision request, verifies that no revision operation is active for the installation, and creates a generation-fenced revision operation. The API returns the operation ID so the client can observe progress asynchronously.
+4. The revision controller verifies the recorded registry trust policy revision, release and image signatures, platform and runtime compatibility, schemas, dependencies, reverse dependents, workflows, and migrations against the recorded desired-state snapshot.
+5. The controller runs declared prepare migrations, creates the immutable candidate Deployment and revision-specific Service, and applies ambient data-plane enrollment and the required `AuthorizationPolicy` attachments. The candidate initially receives no production traffic.
+6. After readiness remains stable, the controller may canary operations whose contracts exactly match the promoted revision. Promotion then updates primary routing and waits for every currently live relevant ingress gateway and destination waypoint to remain synchronized with the target xDS generation for the configured stability window.
+7. The callable catalogs advance only after routing converges. The previous revision drains pinned requests and streams while the controller observes the promoted revision and runs any separately approved finalization.
+8. The controller records the terminal outcome. A pre-promotion failure leaves the previously promoted revision primary.
+
+### Invoke a Package Operation
+
+1. An external caller sends an MCP Streamable HTTP request to the deployment endpoint with a session credential or API grant, the target package and operation, and JSON arguments.
+2. The ingress gateway authenticates the credential, removes untrusted internal-identity headers, applies request limits, and calls the authorization service through `ext_authz`.
+3. The authorization service evaluates the credential scope, immediate caller workload identity, effective subject, target installation, canonical operation ID, approved package access policy, and any operation-specific resource against one policy generation. An unknown target or denied check fails before dispatch.
+4. The gateway exchanges the external credential for a short-lived, signed internal invocation token bound to the target audience, package, and operation, then resolves the request to one callable revision. That resolution remains pinned for the lifetime of the invocation.
+5. The mesh routes the request to the selected revision-specific Service.
+6. The package supervisor dispatches the operation to the package runtime. The runtime returns one JSON-RPC response or opens an SSE stream; an open stream remains on the selected revision while that revision drains.
+7. The response returns through the mesh and ingress gateway. The platform records the authorization decision, policy model ID and revision, actor, effective subject, immediate caller workload identity, target, `releaseDigest`, internal token ID, trace ID, duration, and outcome.
+
+Package-to-package invocation does not pass through ingress. The calling package presents a platform-issued internal invocation token to the destination waypoint, which performs the corresponding workload and effective-subject authorization checks before revision routing and dispatch. Raw caller credentials are never forwarded.
+
+## Assurance
+
+### Retention and Audit
+
+Release metadata, accepted revision history, and audit events are retained according to applicable policy. Registries and platform-owned artifact storage retain blobs required by active revisions or the configured rollback window. Unreferenced blobs may be garbage-collected after a grace period; shared OCI layers are deleted only after references are rechecked.
+
+Authentication, authorization, registry, package-lifecycle, migration, secret-access, and network-policy events are written to the immutable audit sink with the actor, target, decision, relevant identifiers, trace ID, and outcome.
+
+### Required Verification
 
 Before production use, automated tests cover:
 
-- Create-only and atomic publication, concurrent publishers, and stale attempts
-- Signature, provenance, trust-policy, platform, and runtime compatibility failures
-- Install and upgrade validation failures writing no admitted revision
-- Concurrent administrator and controller fencing
-- Controller failure and restart at every revision phase
-- Migration idempotency, lease loss, and incompatible rollback declarations
-- Dependency and reverse-dependent races
-- Canary failure, routing/catalog generation safety, draining, and SSE behavior
-- Registry disconnection, mirror rebinding, and blob-prune concurrency
-- Removal cleanup, tombstones, and retained workflow executions
-- Authorization outage, confused-deputy attempts, delegation attenuation, and revocation propagation
-- Multi-replica convergence and old/new infrastructure cohort overlap
+- **Registry and release integrity**: atomic publication under retries and concurrency, signature and compatibility rejection, and safe disconnection and garbage collection
+- **Revision state machines**: validation failures, administrator, controller, and dependency races, restart at every phase, and migration idempotency and lease loss
+- **Rollout and recovery**: canary and promotion failures, routing and catalog convergence, draining and SSE behavior, rollback approval, removal, tombstones, retained workflows, autoscaling, and mixed versions
+- **Platform lifecycle**: bootstrap ordering and outages, protected identities and signers, ordinary-package replacement prevention, and independent infrastructure and system-package rollouts
+- **Authorization models**: deterministic policy publication, active-grant preservation, subject-set cycles, and parity between batch and individual checks
+- **Identity and delegation**: spoofing, claim validation, token expiration and rotation, `runAs`, confused-deputy prevention, attenuation, and revocation
+- **Fail-closed enforcement**: authorization outages, data-plane bypass attempts, and ingress or waypoint `ext_authz` failures
 
 ## Glossary
 
-**package identity**  
-Permanent `(registryId, packageId)` for a published package. Assigned when the package is reserved; never reused.
+**package identity**<br>
+Permanent `(registryId, packageId)` for a registry package. Assigned when the package is reserved; never reused.
 
-**release**  
+**release**<br>
 Immutable, signed artifact for one `releaseVersion` of a package, identified by `releaseDigest`.
 
-**releaseVersion**  
-Registry-assigned label for one published release of a package. `(registryId, packageId, releaseVersion)` binds permanently to one `releaseDigest`.
+**releaseVersion**<br>
+Registry-scoped version label for one published release of a package. `(registryId, packageId, releaseVersion)` binds permanently to one `releaseDigest`.
 
-**releaseDigest**  
-Content hash of the canonical release manifest bytes. The authoritative install input; signatures and attestations bind to it.
+**releaseDigest**<br>
+Content hash of the canonical release manifest bytes. The authoritative install input; signatures bind to it.
 
-**revision**  
+**revision**<br>
 One installed state of a package in an organization, backed by a specific `releaseDigest`.
 
-**revision request**  
+**revision request**<br>
 Durable intent to install, upgrade, rollback, or remove a package.
 
-**revision operation**  
+**revision operation**<br>
 Generation-fenced state machine that executes one revision request.
 
-**revision controller**  
+**revision controller**<br>
 Background worker that drives a revision operation to completion and resumes after failure.
 
-**rollout**  
-Staged path from admission through canarying and promotion for an install or upgrade candidate.
+**rollout**<br>
+Path from admission through readiness, optional canarying, and promotion for an install or upgrade candidate.
 
-**promotion**  
-Makes a revision primary for routing and user-facing catalogs.
+**promotion**<br>
+Makes a revision primary for routing; callable catalogs advance only after routing convergence.
+
+**authorization model**<br>
+Immutable, content-hashed definition of resource types, relations, actions, and allowed relationship targets used for one generation of authorization decisions.
+
+**relationship tuple**<br>
+An assignment of a subject, resource, or subject set to one relation on a resource.
+
+**internal invocation token**<br>
+Short-lived signed context that carries verified caller and delegation information and is bound to its intended audience, package, and operation.
+
+**bootstrap substrate**<br>
+Infrastructure that must exist before package APIs are available, including Kubernetes, Istio, control-plane state, revision controllers, certificate authority, and recovery tooling.
+
+**protected system package**<br>
+A trusted, signer-pinned package that uses normal revision rollouts but has a fixed platform identity and cannot be replaced or removed through ordinary package APIs.
+
+**waypoint**<br>
+Shared Envoy proxy that enforces L7 routing and authorization for Kubernetes Services exposing packages in ambient mode.
+
+**workflow service**<br>
+MCP service in the mesh that registers package-defined workflows and executes them outside package processes.
+
+**ztunnel**<br>
+Node-level ambient proxy that provides L4 transport security and workload identity for enrolled pods.

--- a/plans/service_mesh/plan.md
+++ b/plans/service_mesh/plan.md
@@ -2,105 +2,296 @@
 
 ## Overview
 
-The platform builds, distributes, installs, and runs services in a shared service mesh. A service package may include:
+The platform builds, distributes, installs, and runs services in a shared service mesh. A service release may include:
 
 - An MCP server and its operations
-- User interface (single-page app or SPA's)
-- Workflows
+- One or more single-page user interfaces
+- Durable workflow definitions and workers
 - Dependency and migration metadata
-- Runtime and authorization requirements
+- Runtime, configuration, secret, network, and authorization requirements
 
-Organizations operate a deployment backed by one private registry and, optionally, additional public registries. The deployment exposes a catalog of installed services, operations, interfaces, workflows, and dependencies.
+An organization operates one deployment backed by a private registry and, optionally, additional trusted registries. The deployment exposes catalogs of installed services, callable operations, user interfaces, workflows, and dependencies.
 
-## Architecture
+Publishing makes a release discoverable. Installation admits an immutable release into an organization. Canarying permits controlled, undiscoverable traffic, while promotion makes an installed revision primary and user-discoverable. These states are separate and must not be inferred from one another.
+
+## Design Invariants
+
+The following invariants apply to every implementation:
+
+1. A published release is immutable and identified by a digest.
+2. A deployment records every accepted install, upgrade, rollback, and removal request in an append-only revision history.
+3. At most one lifecycle operation for an organization and canonical service identity is nonterminal at a time, including first installation.
+4. Request handlers record intent; reconcilers perform runtime work and resume safely after process failure.
+5. Published, admitted, materialized, running, ready, canary-callable, promoted, and converged are distinct states.
+6. A pre-promotion failure does not replace the last successfully promoted revision.
+7. Routing propagation is eventually consistent, so every revision that may receive traffic remains contract-compatible until propagation and draining finish. New contracts become visible only after routing convergence.
+8. Package metadata can request capabilities but cannot grant itself identity, authorization, secrets, ingress, or egress.
+9. Dynamic services cannot replace the identity, authorization, certificate, secret, registry-verification, audit, state-storage, or recovery components needed to administer the mesh.
+10. Every externally supplied manifest, image, schema, migration, and attestation is untrusted until its digest, signature, and policy are verified.
+
+## Runtime Architecture
 
 The runtime consists of:
 
-- **Control plane (`istiod`)**: manages mesh configuration and service routing.
-- **Ingress data plane**: receives traffic from the load balancer.
-- **Service data plane (`gestaltd`)**: runs alongside each service and mediates mesh traffic.
-- **Service runtime**: runs the service's server, interfaces, and workflows.
+- **Istio control plane (`istiod`)**: distributes routing, policy, endpoint, and certificate configuration to the Istio data plane.
+- **Istio workload data plane**: Envoy sidecars mediate inbound and outbound workload traffic. Ambient mode, using mandatory node-level `ztunnel` proxies and optional L7 waypoint proxies, is a possible later deployment mode; a deployment uses one documented mode at a time.
+- **Ingress gateways**: separate Envoy data-plane proxies terminate external transport, remove untrusted identity headers, authenticate supported credentials, and route public and organization traffic.
+- **Egress gateways**: separate Envoy data-plane proxies enforce and audit declared external network access where direct egress cannot be safely allowed.
+- **Service supervisor (`gestaltd`)**: runs alongside one service installation, mediates application-level invocation and authorization, reports observed state, and manages the service process. It is not an Istio data-plane proxy and does not replace Envoy.
+- **Service runtime**: runs the service's MCP server, interfaces, and workflow workers.
+- **Lifecycle controllers**: reconcile durable install and rollout records into workloads, routing, catalogs, identities, and policy.
 
-Terraform deploys the GCP infrastructure, including the Valon Tools cluster, GitHub Actions cluster, networking, container infrastructure, and identity services.
+Production uses Istio `PeerAuthentication` in `STRICT` mode for mesh mutual TLS, Istio `AuthorizationPolicy` for workload-to-workload policy, and Kubernetes `NetworkPolicy` for network reachability. The deployment installs explicit default-deny authorization and network policies; these mechanisms are not assumed to deny traffic merely because they are enabled. Service application ports are reachable only through the mesh data plane. Health and supervisor administration ports have explicit, minimal exceptions and are not exposed through public ingress.
 
-## Service Packages
+Established data-plane traffic continues using the last known configuration when `istiod` is unavailable. New lifecycle operations that require routing, certificates, policy, or registry verification fail closed until their control-plane dependencies recover.
 
-When first published, a registry assigns the service a UUID unique within that registry and associates it with a human-readable slug. Service references include both the registry and UUID. Each package version consists of a built OCI image and a service manifest for a specific platform. The service manifest contains:
+Terraform deploys the GCP infrastructure, including the Valon Tools cluster, GitHub Actions cluster, networking, container infrastructure, identity services, and deploy-pinned trusted components. Installing services does not mutate this trusted computing base.
 
-- The immutable OCI image reference and digest
-- Instructions for starting the MCP server and user interfaces
-- The MCP endpoint, operations, and input/output schemas
-- Included workflows and interfaces
-- Service and operation dependencies
-- Ordered pre-upgrade and rollback commands
-- Service-account and authorization requirements
-- Health and readiness endpoints
-- Configuration and secret requirements
-- Image signature and build provenance
+## Identity Model
 
-Upgrade commands may perform schema migrations, workflow changes, or other dependency updates. They should be idempotent and reversible where possible.
+The system keeps these identities separate:
+
+- **Registry identity**: immutable `registryId` plus its configured origin and trust-policy digest.
+- **Service identity**: permanent `(registryId, serviceId)` assigned when the service is reserved. A slug is a mutable display and discovery alias, never a security identifier.
+- **Release identity**: `(registryId, serviceId, version, releaseDigest)`.
+- **Installation identity**: an organization-scoped UUID representing one installed service.
+- **Workload identity**: an orchestrator-owned SPIFFE identity for one installation's runtime or migration job.
+- **Workflow identity**: the principal assigned to a workflow definition or execution.
+- **Actor identity**: the user, API grant, service account, or workflow that initiated an action.
+- **Effective subject**: the principal whose delegated authority an invocation exercises.
+
+Service IDs are never reused. Slug renames retain aliases and tombstones. Mirroring a service preserves its identity only through a signed mirror or transfer relationship; otherwise importing it creates a distinct service identity.
+
+Package authors cannot select workload identities. The orchestrator binds installations to Kubernetes service accounts and short-lived SPIFFE certificates. Trust domain, certificate lifetime, rotation, and compromise revocation are deployment policy.
+
+## Service Releases
+
+One service version has one platform-independent, signed release manifest. The release manifest is stored as an OCI artifact or another digest-addressed immutable object and references an OCI image index digest. The image index selects immutable image manifests for supported `os`, `architecture`, and optional `variant` tuples.
+
+Platform images may contain different binaries, but their operation contracts, dependencies, migrations, workflows, and requested capabilities must match the release manifest. A platform-specific release contract is not allowed.
+
+The release manifest contains:
+
+- Canonical registry and service IDs, slug, and version
+- OCI image-index digest and supported platforms
+- Instructions for starting the MCP server, interfaces, and workflow workers
+- MCP endpoint, operations, and input/output schema digests
+- Included workflows and user interfaces
+- Required and optional service and operation dependencies
+- Ordered prepare, finalize, and compensating migration jobs
+- Rollback classification
+- Requested service-account, authorization, ingress, and egress capabilities
+- Configuration and typed secret requirements
+- Startup, liveness, and readiness endpoints
+- Minimum and maximum supported `gestaltd` and mesh protocol versions
+- Source repository and revision
+- Subjects for detached signatures and build-provenance attestations
+
+The manifest does not contain self-asserted signatures or provenance. Signatures and SLSA/in-toto provenance are detached attestations over the release and image digests, such as OCI referrers.
+
+The release digest is computed over the canonical manifest bytes and is carried by catalog entries, signatures, attestations, and installation records rather than by the hashed manifest itself.
+
+Versions follow a registry-defined, documented grammar and comparison order. A `(registryId, serviceId, version)` binds permanently to one release digest. A conflicting republish is rejected. An identical retry is idempotent and does not rewrite publication time or provenance. Mutable tags may aid discovery but are never installation inputs.
 
 ## Registries
 
-Registries store versioned service packages and control who can discover or download them. A deployment may use private, organization-specific, and public registries, provided each implements the registry interface.
+Registries control who can publish, discover, or download releases. Each configured registry has:
 
-Each registry exposes a catalog manifest listing its services. Each entry includes the registry-scoped service UUID, slug, available versions and platforms, service manifest location, and immutable OCI image reference and digest. The OCI image is the deployable artifact; a Dockerfile may be retained as optional source provenance but is not part of the runtime contract.
+- An immutable `registryId`
+- Discovery, metadata, blob, and publication endpoints
+- Authentication and authorization scopes
+- Trusted signing identities and builders
+- Allowed service namespaces
+- Source repository and workflow constraints
+- Required provenance level
+- Whether direct developer publication is permitted
+- A versioned trust-policy digest
 
-A registry can be connected to a GitHub repository and configured to build from `main`, pull requests, or label-based rules. Service developers can also build and push packages directly.
+Connecting a registry does not trust every publisher in it. Catalogs and manifests remain untrusted until admission verifies their immutable digests, signatures, provenance, schema versions, and the deployment's registry policy.
+
+The registry interface defines pagination, conditional reads, consistency guarantees, error codes, retries, rate limits, and authentication separately for catalog discovery, immutable metadata, blob pulls, and publication.
+
+A catalog contains paginated service and release summaries pointing to authoritative release-manifest digests. It does not duplicate the full release contract. Per-service indexes use monotonic revisions and compare-and-swap updates.
+
+Disconnecting a registry blocks new discovery and installation but preserves its identity and all historical records. Hard removal is rejected while any desired, running, redeployable, dependent, or in-progress revision references it. Rebinding to a mirror requires digest-equivalent content and signatures trusted by the deployment.
 
 ## Build and Publish
 
-1. `vt build <dir>` builds a service package from a source directory and its manifest.
-2. The build produces a platform-specific OCI image with an immutable digest.
-3. The package is published through the configured GitHub integration or with `--push <registry-url>`.
-4. The registry publishes the catalog and service manifests and points them to the built OCI image.
+`vt build <dir>` validates source metadata and builds an OCI image index and release manifest. The build records resolved source and material digests. Production publication requires attestations from a trusted builder; direct publication must satisfy the same policy.
 
-`vt dev <url> <dir> <token>` injects a local service into an existing mesh for development. A development service runs with the developer's identity.
+Publication is a recoverable transaction:
+
+1. Reserve `(serviceId, version)` and create a publish-attempt ID.
+2. Record a pending release with source and workflow provenance.
+3. Upload content-addressed image blobs and manifests.
+4. Validate all platform images and release contracts server-side.
+5. Create the immutable release manifest.
+6. Attach signatures and provenance attestations.
+7. Commit availability by compare-and-swap updating the service catalog last.
+8. Mark the attempt succeeded or failed.
+
+Pending and failed attempts are visible but never installable. Concurrent publishers cannot lose catalog updates. Stale attempts become failed, and orphaned content-addressed blobs are garbage-collected after a grace period.
+
+## Durable Deployment State
+
+The control plane persists:
+
+- **Service slots**: one organization-scoped slot keyed by canonical service identity, reserved before allocating an installation ID and used to fence concurrent first installs
+- **Revision requests**: append-only install, upgrade, rollback, and removal intent with actor, previous promoted revision, target release digest, approved capabilities, resolved dependencies, and timestamps
+- **Installation head**: last successfully promoted revision and current admitted candidate
+- **Lifecycle operation**: one generation-fenced state machine per installation
+- **Migration outcomes**: immutable status keyed by installation, release digest, and migration ID
+- **Workload observations**: materialized, started, ready, draining, stopped, and error state for each target replica
+- **Routing and catalog generation**: the promoted revision visible to callers
+- **Terminal outcomes**: completion or failure phase, duration, and reason
+
+Lifecycle records use optimistic concurrency and fencing tokens. A stale controller cannot mutate a newer generation after losing its lease. Retries are idempotent, and every external mutation has a stable idempotency key.
+
+Each rollout targets one immutable runtime cohort identified by the infrastructure generation and `gestaltd` supervisor generation. Replicas enroll during a bounded epoch; the nonempty cohort is then frozen for promotion accounting. Scaling replicas that join later still converge but do not retroactively change the completed cohort. Observations include the rollout generation and enrollment epoch so stale or overlapping infrastructure cohorts cannot satisfy a newer rollout.
+
+Routing convergence uses a separately frozen proxy cohort. In sidecar mode it contains every live ingress gateway plus the live sidecars of declared reverse-dependent caller workloads at the promotion epoch. `istiod` xDS status supplies proxy membership and acknowledgement of the target routing generation. A reverse-dependent replica that starts later cannot become ready until it receives at least that generation. Undeclared direct east-west invocation is denied, so it cannot bypass this cohort. Ambient mode must define the equivalent gateway, waypoint, and `ztunnel` cohort before it is supported.
+
+The runtime distinguishes:
+
+- **Published**: committed in a registry
+- **Admitted**: verified and accepted as a candidate by the organization
+- **Materialized**: image and immutable contract are available to a workload node
+- **Running**: the candidate process started
+- **Ready**: the candidate passes readiness and minimum healthy-duration checks
+- **Canary-callable**: an undiscoverable candidate receives a controlled subset of traffic for operations whose contracts exactly match the promoted revision
+- **Promoted**: routing selects the candidate as primary
+- **Converged**: the required workload cohort observes the promoted generation
 
 ## Installation
 
-Publishing a service does not install it. On first installation, an organization administrator selects a version and configures:
+Publishing does not install a service. An organization administrator selects an immutable release digest and binds:
 
-- The identity used by workflows
-- The identity used by service operations
-- Whether an operation forwards the caller's identity
-- The service's authorized operations
+- Organization-owned service and workflow identities
+- Package-requested operations and capabilities to approved authorization relationships
+- Caller-delegation policy per operation
+- Typed configuration values and secret references
+- Ingress and egress requests to organization policy
+- Initial replica, resource, and availability settings
 
-A service identity cannot initially exceed the installer’s authorization. Its relationships are assigned using the authorization model below.
+The platform shows the requested-versus-approved capability diff before admission. An installer can use only identities for which they have `can_use` or `can_delegate`, and cannot convert temporary authority into an unrestricted persistent service grant. Sensitive capabilities may require a second approver.
 
-Installing or removing a service updates the runtime catalog without redeploying the service mesh.
+Installation is a reconciled saga:
 
-## Upgrades
+1. Verify registry trust, release and image signatures, provenance, platform support, runtime compatibility, and schema versions.
+2. Resolve exact dependency revisions and operation-contract digests.
+3. Reserve the organization service slot and persist the revision request, approved capability snapshot, and fenced lifecycle operation.
+4. Provision the installation identity, workload identity, policy, configuration, and secret bindings.
+5. Materialize and start the initial workload without making it callable.
+6. Require readiness quorum and minimum healthy duration.
+7. Promote routing, wait for the frozen proxy cohort to acknowledge the routing generation, and drain any prior compatible route.
+8. Advance the callable catalog only after routing converges, then record convergence and the terminal outcome.
 
-Before an upgrade, the platform verifies that required operations exist, dependencies are ready and not being upgraded, and the package defines valid pre-upgrade and rollback commands.
+Failures preserve the durable phase and diagnostics. The reconciler retries retryable phases within policy and compensates unpromoted resources when an administrator cancels the installation. A service is not callable until promotion succeeds.
 
-The upgrade sequence is:
+## Dependencies and Contracts
 
-1. Pull the new OCI image.
-2. Run the service's pre-upgrade commands in order.
-3. Start the new service version.
-4. Validate startup and the `/ready` endpoint.
-5. Shift traffic to the new version.
+Dependencies use canonical service identities, version ranges, and required operation contract digests. Dependencies may be required or optional. Admission records the exact revisions and contract digests selected.
 
-The old version continues serving until the traffic shift. If an upgrade step fails, the platform stops the upgrade and records the failed command and error. An authorized administrator then resolves the failure and manually runs the declared rollback commands.
+The platform validates:
 
-After traffic shifts, traffic may return to the old version only when the package declares that rollback safe. Automatic rollback can be added later using the same commands and safety declaration.
+- Every required dependency has a promoted compatible revision
+- Required operations exist
+- Required input and output contracts match
+- The candidate remains compatible with existing reverse dependents
+- No conflicting lifecycle operation is active in the affected dependency subgraph
+- Workflow calls reference compatible operation contracts
 
-Workflows should continue running during an upgrade unless they call the service being upgraded. Service operations and interfaces may be unavailable during the traffic transition. The target is less than ten seconds of downtime.
+JSON Schemas use one pinned dialect and canonical encoding before hashing. The first implementation requires exact schema digests. Semantic compatibility can be introduced only with documented contravariant input and covariant output rules.
 
-## Administration and Discovery
+Validation reads a revisioned desired-state snapshot and commits with generation preconditions. For independent services, upgrades may proceed concurrently. Upgrades that affect the same dependency subgraph use deterministic locking or one atomic multi-service rollout plan. Dependency cycles are rejected until atomic rollout groups are implemented.
+
+## Upgrades and Traffic Promotion
+
+An upgrade never mutates the running revision in place. It creates a candidate generation while the last promoted revision continues serving.
+
+The rollout state machine is:
+
+1. **Admitted**: verify the release, policy, runtime compatibility, dependencies, reverse dependents, and rollback classification.
+2. **Staging**: pull and verify images for the target cohort.
+3. **Preparing**: run backward-compatible prepare migrations as fenced one-shot jobs.
+4. **Starting**: start candidate workloads with no production traffic.
+5. **Ready**: require a readiness quorum and minimum healthy duration.
+6. **Canarying**: route a configurable small traffic percentage for operations whose contracts exactly match the promoted revision; the candidate remains absent from user-facing catalogs.
+7. **Promoting**: make the candidate primary, wait for the frozen proxy cohort to acknowledge the routing generation, and only then expose newly added contracts in callable catalogs. Promotion is the boundary after which the candidate is the last successfully promoted revision.
+8. **Draining**: keep the prior revision available for in-flight requests and streams until their drain deadline.
+9. **Soaking**: observe the promoted revision for a configured period.
+10. **Finalizing**: run irreversible contract/finalize migrations only after the rollback window when required.
+11. **Complete**: record convergence and terminal timing.
+
+Each phase has a timeout, retry policy, and terminal error taxonomy. Promotion requires nonempty frozen runtime and proxy cohorts and cannot be inferred from one ready instance. Routing changes define weight propagation, proxy acknowledgement, readiness quorum, connection draining, and behavior for MCP SSE streams. During partial routing propagation, both revisions support the promoted operation-contract digests.
+
+Failures before promotion produce a failed candidate and leave the prior promoted revision primary. Failures during soak after promotion mark the new revision degraded and trigger rollback when its rollback class permits; otherwise they require an audited forward fix. Finalization failure does not relabel the promoted revision as a failed candidate or route traffic implicitly: it records `promoted_with_finalization_error`, blocks the next lifecycle operation, and requires retry or an approved forward fix.
+
+The availability goal is zero planned downtime for services that satisfy the compatibility contract. Any supported operation that requires downtime declares and receives explicit administrator approval before admission; a vague downtime target is not sufficient.
+
+## Migrations and Rollback
+
+Migrations are separately identified, digest-pinned jobs. Each declares:
+
+- Migration ID and release digest
+- Prepare, finalize, or compensating phase
+- Dedicated workload identity and requested capabilities
+- Required secrets and network destinations
+- Timeout, resource limits, retry policy, and idempotency key
+- Compatibility with the prior and candidate service revisions
+
+Migration jobs run with least privilege and deny-by-default egress. They never run as the installer, lifecycle controller, or normal service identity. Attempt and completion records are durable.
+
+Each release declares one rollback class:
+
+- **Traffic-only**: the previous revision can serve against the current data model
+- **Code and compatible data**: old code and schema remain mutually compatible
+- **Compensating migration required**: rollback requires a declared, verified job
+- **No post-promotion rollback**: an explicitly approved release cannot return traffic to the prior revision after promotion
+
+Prepare migrations follow expand/contract rules and must remain compatible with the serving revision. Releases with a rollback-capable class defer destructive finalize migrations until the rollback window closes. A no-post-promotion-rollback release requires explicit approval before promotion and has no rollback window. A rollback command is not proof that data rollback is safe.
+
+Administrators initiate rollback through the same lifecycle controller. Manual shell execution cannot update lifecycle state. Automatic rollback may later invoke the same audited state machine when canary or soak gates fail.
+
+## Workflows
+
+Workflow definitions are immutable and versioned independently from service processes. Each execution records its workflow-definition digest, actor, workflow identity, and compatible service-operation contract revisions.
+
+Existing executions continue on workers that support their pinned definition until they complete, migrate, or reach a documented retirement policy. New executions use the promoted workflow catalog generation. Removal and incompatible upgrades must account for queued work, retries, timers, and long-running executions before workers are drained.
+
+Every workflow operation is authorized at execution time. `can_run_as` is required to select an organization-managed workflow identity. The original triggering actor remains in the audit and delegation chain.
+
+## Removal
+
+Removal is a durable tombstoned revision, not deletion of a catalog row:
+
+1. Reject removal while required reverse dependents exist, unless they are removed in the same atomic plan.
+2. Promote a tombstone generation that removes callable catalog entries and prevents new invocation resolution.
+3. Drain already-resolved requests, streams, workers, and queued work according to policy.
+4. Stop workloads and block ingress and egress.
+5. Revoke workload certificates, installation-owned assignments, delegated tokens, secret bindings, and runtime configuration.
+6. Apply service-data retention or destruction policy.
+7. Preserve the service tombstone and audit history.
+8. Garbage-collect runtime resources after the recovery window.
+
+Organization-owned persistent grants are not silently deleted; the removal UI distinguishes them from installation-owned grants. Reinstallation creates a new installation identity unless an explicit restore operation reactivates the tombstone within policy.
+
+## Catalogs and Administration
 
 An organization deployment provides:
 
 - A service catalog
 - An operation catalog
 - A user-interface catalog
+- A workflow catalog
 - A dependency graph
-- Service details, versions, workflows, identities, and authorization settings
-- API-key management
+- Service revisions, rollout and migration status, identities, and authorization settings
+- API-grant management
 - A development sandbox
 
-Organization administrators can connect registries and install, upgrade, or remove services. Service developers can build, publish, test, and invoke services. Service users see only the catalogs and tools available to them.
+Candidate metadata may be visible to administrators, but user-facing callable catalogs expose only contracts safe for the currently propagated routes. Routing is updated first because xDS propagation is asynchronous; newly added contracts become discoverable only after the frozen proxy cohort acknowledges the routing generation. Both revisions remain contract-compatible until old routes drain. Each invocation, including an SSE stream, resolves once and remains pinned to one service revision.
+
+Organization administrators can connect registries and install, upgrade, roll back, or remove services. Service developers can build, publish, test, and invoke services. Service users see only catalogs and operations authorized for them.
 
 Representative endpoints:
 
@@ -109,38 +300,115 @@ Representative endpoints:
 - Administration: `https://vt.valon.tools/admin`
 - Service administration: `https://vt.valon.tools/services/<service>/admin`
 
+Management APIs use a private listener or equivalent network restriction and require stronger authorization than user invocation endpoints.
+
 ## Invocation
 
 Authorized operations are available over the deployment endpoint and through the CLI:
 
 ```sh
-vt invoke <url> <service> <operation> <args> <token>
+vt invoke --deployment <url> <service> <operation> --args <json>
 ```
 
-Operation invocation uses MCP Streamable HTTP. Clients and services must support JSON-RPC over POST and the protocol's JSON and SSE response forms.
+Authentication comes from an interactive session, keychain, environment, or standard input. Secrets and tokens are not positional command arguments.
+
+Operation invocation uses MCP Streamable HTTP. Clients and services support JSON-RPC over POST and the protocol's JSON and SSE response forms. The gateway enforces request size, timeout, rate, and stream-lifetime policy.
+
+Ingress strips externally supplied internal-identity headers. It exchanges user credentials for a short-lived, audience-bound internal invocation token containing the original actor, effective subject, immediate calling workload, delegation chain, target service and operation, issued/expiry times, nonce, and trace ID. Services never forward raw user bearer tokens or API keys.
+
+The authorization decision intersects:
+
+- The authenticated calling workload's permission to invoke the target
+- The effective subject's permission
+- The installed service's approved operation policy
+- Any operation-specific resource authorization
+
+Unknown identities, services, operations, policies, or authorization-provider outages deny access.
 
 ## Authentication and Authorization
 
-- Users authenticate through an external identity provider, with organization-level SSO support.
-- Users can create API keys that act as their identity.
-- Users can create service accounts with a subset of their permissions.
-- Every installed service has an assigned identity.
-- Every operation can enforce authorization.
+- Users authenticate through an external identity provider with organization-level SSO, issuer and tenant allowlists, and session revocation.
+- API keys are named, expiring, scoped API grants that act on behalf of an owner. Only hashes are stored, plaintext is returned once, and empty scope does not mean unrestricted access.
+- Users create service accounts only with an attenuated subset of authority and explicit expiry or organization policy.
+- Every installation has organization-owned workload and workflow identities.
+- Every invocation is centrally authorized before dispatch; service-specific resource checks may further restrict it.
+- Production does not start in a fail-open mode when identity or authorization is unavailable.
 
-Authorization uses a Zanzibar-style graph of relationship tuples. Each relationship definition declares whether it supports delegated assignments, persistent grants, both, or neither. The default is neither.
+Authorization uses a Zanzibar-style graph. Relationship definitions declare whether they support delegated assignments, persistent grants, both, or neither. The default is neither.
 
-- **Delegated assignment (`delegatable`)**: a relationship holder can create a derived assignment that cannot exceed or outlive its parent assignment.
-- **Persistent grant (`grantable`)**: a principal with the relationship-specific grant permission can create an independent assignment that remains until explicitly revoked.
+- **Delegated assignment (`delegatable`)**: a holder with `can_delegate_<relationship>` may create a child assignment that cannot exceed or outlive its parent.
+- **Persistent grant (`grantable`)**: a principal with `can_grant_<relationship>` may create an independent assignment that remains until explicitly revoked.
 
-Assignments record their issuer, assignment mode, creation time, optional expiration, and optional parent assignment. Revoking a parent invalidates its delegated descendants, while an independent assignment through another path preserves access. Persistent grants require an explicit Zanzibar permission such as `can_grant_<relationship>`.
+An assignment is a first-class record containing an immutable ID, organization, subject, relationship, resource, mode, issuer, creation and optional expiration, optional parent assignment, policy revision, and revocation state. Delegation has bounded depth, acyclic ancestry, transactional creation, and cascading invalidation. Independent valid paths preserve access after one path is revoked.
+
+Authorization caches and delegated invocation tokens have bounded lifetimes. Revocation has a documented maximum propagation time and applies to long-lived streams and each workflow step. Security events are written to an immutable audit sink outside service-controlled storage.
+
+## Configuration, Secrets, Ingress, and Egress
+
+Release manifests declare typed requirements, not concrete secret values or unrestricted secret names. Administrators bind them to organization-owned configuration and secret-manager objects. Secret access is granted only to the installation or migration workload identity and uses short-lived retrieval where possible.
+
+Capability expansion on upgrade requires renewed approval. Expansion includes new authorization relationships, identities, secrets, public routes, egress destinations, migration permissions, or caller delegation. Capability reduction may be automatically accepted under organization policy.
+
+Every endpoint is classified as public, organization-authenticated, mesh-internal, or management-only. Egress is deny-by-default and explicitly grants destination, port, protocol, TLS/SNI, DNS, and credential behavior.
+
+## Development Sandbox
+
+`vt dev` builds a local service and connects it only to an explicitly enabled per-user sandbox:
+
+```sh
+vt dev --deployment <url> <dir>
+```
+
+Authentication uses the normal interactive or keychain flow. The platform issues a short-lived development workload identity distinct from the user's identity. Development routing is scoped to the developer or named test session and cannot take over a production service slug.
+
+Development services:
+
+- Receive no production traffic by default
+- Cannot run migrations
+- Cannot access production secrets
+- Cannot forward caller credentials
+- Use sandbox-scoped authorization and egress
+- Expire automatically and are audited on connect and disconnect
+
+## Retention and Audit
+
+Immutable release metadata, attestations, and accepted revision history are retained permanently or according to organization audit policy. Blob retention is separate:
+
+- Unused releases expire after a configurable window
+- Running, admitted, and rollback-eligible revisions retain all required blobs
+- Historical revisions retain blobs through a configurable recovery window
+- Expired historical blobs may be garbage-collected while metadata and audit history remain
+
+OCI garbage collection is reference-aware because layers may be shared. Pruning is serialized with admission and rechecks eligibility immediately before deletion.
+
+Audit events include authentication, API-grant lifecycle, certificate issuance, authorization decisions, assignment mutation, delegated identity use, registry and trust-policy changes, publish/install/upgrade/rollback/removal, migration execution, secret access, ingress/egress denial, and development injection. Events include actor, effective subject, calling workload, target, policy revision, decision reason, trace ID, and release digest.
 
 ## Mesh Deployment
 
-The mesh is redeployed only when changing mesh infrastructure, including:
+The mesh is redeployed only when changing deploy-pinned infrastructure, including:
 
-- The `istiod` snapshot
-- The `gestaltd` snapshot
-- Ingress
-- Egress
+- `istiod` and Istio data-plane versions
+- `gestaltd` supervisor versions
+- Ingress and egress gateways
+- Identity, authorization, certificate, secret, audit, state-storage, registry-verification, or recovery services
 
-Installing, upgrading, or removing services and adding or removing registries are runtime changes and do not require a mesh redeployment.
+Service releases declare compatible `gestaltd` and mesh protocol ranges. Infrastructure rollouts account for old and new runtime cohorts before admitting a service release that requires new capabilities.
+
+Installing, upgrading, rolling back, or removing services is a runtime change and does not require mesh redeployment. Connecting or disconnecting a registry is durable control-plane state and does not require redeployment, but changing registry trust roots remains a separately authorized and audited action.
+
+## Required Verification
+
+Before production use, automated tests cover:
+
+- Create-only and atomic publication, concurrent publishers, and stale attempts
+- Signature, provenance, trust-policy, platform, and runtime compatibility failures
+- Install and upgrade validation failures writing no admitted revision
+- Concurrent administrator and controller fencing
+- Controller failure and restart at every lifecycle phase
+- Migration idempotency, lease loss, and incompatible rollback declarations
+- Dependency and reverse-dependent races
+- Canary failure, routing/catalog generation safety, draining, and SSE behavior
+- Registry disconnection, mirror rebinding, and blob-prune concurrency
+- Removal cleanup, tombstones, and retained workflow executions
+- Authorization outage, confused-deputy attempts, delegation attenuation, and revocation propagation
+- Multi-replica convergence and old/new infrastructure cohort overlap


### PR DESCRIPTION
## Summary
- define the package, registry, revision, rollout, workflow, and invocation lifecycles for the service mesh
- establish deployment tiers, workload identity, authorization, routing, migration, recovery, and audit boundaries
- document representative registry, upgrade, and invocation request flows with consistent terminology

## Test plan
- [x] `git diff --check -- plans/service_mesh/plan.md`
- [x] Documentation-only change; no runtime tests required

Made with [Cursor](https://cursor.com)