### PR TITLE
Fix gestaltd dev to work without --config by marking auto-generated providers as local

### DIFF
--- a/gestaltd/internal/daemon/provider_local.go
+++ b/gestaltd/internal/daemon/provider_local.go
@@ -413,11 +413,13 @@ func writeProviderLocalBaseConfig(path, dbPath string) error {
 		"providers": map[string]any{
 			"externalCredentials": map[string]any{
 				config.DefaultProviderInstance: map[string]any{
+					"local":  true,
 					"source": providerLocalExternalCredentialsSourceConfig(),
 				},
 			},
 			"indexeddb": map[string]any{
 				providerLocalIndexedDBName: map[string]any{
+					"local":  true,
 					"source": providerLocalIndexedDBSourceConfig(),
 					"config": map[string]any{
 						"dsn": "sqlite://" + dbPath,

--- a/gestaltd/internal/daemon/provider_local_session_test.go
+++ b/gestaltd/internal/daemon/provider_local_session_test.go
@@ -211,3 +211,30 @@ func TestPrepareProviderLocalSessionLeavesAppWithoutUIUnmounted(t *testing.T) {
 		t.Fatalf("Apps[%q].Static = %#v, want nil", session.TargetKey, app.Static)
 	}
 }
+
+func TestWriteProviderLocalBaseConfigMarksIndexedDBLocal(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "base.yaml")
+	dbPath := filepath.Join(dir, "provider.db")
+	if err := writeProviderLocalBaseConfig(cfgPath, dbPath); err != nil {
+		t.Fatalf("writeProviderLocalBaseConfig: %v", err)
+	}
+
+	cfg, err := config.LoadPaths([]string{cfgPath})
+	if err != nil {
+		t.Fatalf("LoadPaths: %v", err)
+	}
+
+	name, entry, err := cfg.SelectedIndexedDBProvider()
+	if err != nil {
+		t.Fatalf("SelectedIndexedDBProvider: %v", err)
+	}
+	if entry == nil {
+		t.Fatalf("IndexedDB entry %q is nil", name)
+	}
+	if !entry.Local {
+		t.Fatalf("IndexedDB entry %q: Local = false, want true (prevents remote stamping in dev mode)", name)
+	}
+}

--- a/gestaltd/internal/operator/localconfig.go
+++ b/gestaltd/internal/operator/localconfig.go
@@ -120,6 +120,7 @@ server:
 providers:
   indexeddb:
     main:
+      local: true
       source: %s
       config:
         dsn: %q
@@ -156,10 +157,12 @@ server:
 providers:
   externalCredentials:
     default:
+      local: true
       source:
         path: %q
   indexeddb:
     main:
+      local: true
       source:
         path: %q
       config:


### PR DESCRIPTION
## Problem

`gestaltd dev valon-tools/apps/vds-forge` failed without `--config` args:

```
ERROR gestaltd exited error="bootstrap: bootstrap: system indexeddb from resource \"main\": ensure app_auto_deploy_settings store: rpc error: code = Internal desc = server closed the stream without sending trailers"
```

The auto-generated base config (`writeProviderLocalBaseConfig`) created IndexedDB and externalCredentials entries without `local: true`. When `dev` mode resolved the remote URL via `ApplyServeRemoteOverrides` and `canonicalizeRemotes` stamped all non-local entries with the default remote, the IndexedDB got placed on the remote gestaltd. Bootstrap then tried to create schema stores via a remote gRPC client that failed.

The workaround was `--config valon-tools/deploy/config.yaml --config valon-tools/deploy/local/config.yaml`, which explicitly sets `local: true` on the IndexedDB entry.

## Fix

Add `local: true` to the auto-generated provider entries in three config generators:

- `writeProviderLocalBaseConfig` (used by `gestaltd dev/serve <path>` without `--config`)
- `defaultManagedConfig` (used by bare `gestaltd` serve without config)
- `defaultLocalSourceConfig` (used when `GESTALT_PROVIDERS_DIR` is set)

This prevents `stampDefaultRemote` from delegating local SQLite databases to the remote gestaltd. With this fix, `gestaltd dev <path>` works with just `GESTALT_URL` and `GESTALT_API_KEY` environment variables — no `--config`, `--remote`, or `--remote-token` flags needed.

## Test

Added `TestWriteProviderLocalBaseConfigMarksIndexedDBLocal` to the existing `provider_local_session_test.go` — verifies the generated config's IndexedDB entry has `local: true` so it survives `canonicalizeRemotes` in dev mode.