### PR TITLE
Add runtime heartbeat state foundation

### DIFF
--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -61,6 +61,32 @@ type AppInstanceMaterialization struct {
 	LastErrorMessage string
 }
 
+type GestaltdInstanceAppState string
+
+const (
+	GestaltdInstanceAppStateRunning    GestaltdInstanceAppState = "running"
+	GestaltdInstanceAppStateStarting   GestaltdInstanceAppState = "starting"
+	GestaltdInstanceAppStateNotRunning GestaltdInstanceAppState = "not_running"
+	GestaltdInstanceAppStateError      GestaltdInstanceAppState = "error"
+	GestaltdInstanceAppStateUnknown    GestaltdInstanceAppState = "unknown"
+)
+
+type GestaltdInstanceAppHeartbeat struct {
+	State          GestaltdInstanceAppState `json:"state"`
+	DesiredVersion string                   `json:"desired_version,omitempty"`
+	RunningVersion string                   `json:"running_version,omitempty"`
+	ObservedAt     time.Time                `json:"observed_at"`
+	LastError      string                   `json:"last_error,omitempty"`
+}
+
+type GestaltdInstanceHeartbeat struct {
+	InstanceID    string
+	SourceVersion string
+	StartedAt     time.Time
+	HeartbeatAt   time.Time
+	Apps          map[string]GestaltdInstanceAppHeartbeat
+}
+
 type AppRolloutState string
 
 const (
@@ -99,9 +125,20 @@ type AppVersionRolloutOutcome struct {
 	FailedAt    time.Time
 }
 
+type AppVersionRecoveryObservation struct {
+	ID                      string
+	App                     string
+	Version                 string
+	RecoveredAt             time.Time
+	SourceVersion           string
+	LiveInstances           int
+	MinimumHealthyInstances int
+}
+
 type GestaltdSourceVersionState struct {
-	CurrentSourceVersion string
-	UpdatedAt            time.Time
+	CurrentSourceVersion    string
+	MinimumHealthyInstances int
+	UpdatedAt               time.Time
 }
 
 type ExternalCredentialGrant struct {

--- a/gestaltd/internal/config/app_registry_heartbeat_config_test.go
+++ b/gestaltd/internal/config/app_registry_heartbeat_config_test.go
@@ -16,7 +16,7 @@ func TestAppRegistryHeartbeatConfigDefaults(t *testing.T) {
 	}
 	assertAppRegistryDuration(t, "heartbeat interval", cfg.Server.AppRegistry.HeartbeatIntervalDuration, 15*time.Second)
 	assertAppRegistryDuration(t, "heartbeat TTL", cfg.Server.AppRegistry.HeartbeatTTLDuration, 45*time.Second)
-	assertAppRegistryDuration(t, "healthy stability window", cfg.Server.AppRegistry.HealthyStabilityWindowDuration, 30*time.Second)
+	assertAppRegistryDuration(t, "healthy stability window", cfg.Server.AppRegistry.HealthyStabilityWindowDuration, 60*time.Second)
 	assertAppRegistryDuration(t, "heartbeat retention", cfg.Server.AppRegistry.HeartbeatRetentionDuration, 24*time.Hour)
 	if cfg.Server.AppRegistry.RolloutMode != AppRegistryRolloutModeEnrollment {
 		t.Fatalf("rollout mode = %q, want %q", cfg.Server.AppRegistry.RolloutMode, AppRegistryRolloutModeEnrollment)
@@ -31,7 +31,7 @@ server:
   appRegistry:
     heartbeatInterval: 10s
     heartbeatTtl: 35s
-    healthyStabilityWindow: 20s
+    healthyStabilityWindow: 50s
     heartbeatRetention: 12h
     rolloutMode: heartbeat
 `)
@@ -41,7 +41,7 @@ server:
 	}
 	assertAppRegistryDuration(t, "heartbeat interval", cfg.Server.AppRegistry.HeartbeatIntervalDuration, 10*time.Second)
 	assertAppRegistryDuration(t, "heartbeat TTL", cfg.Server.AppRegistry.HeartbeatTTLDuration, 35*time.Second)
-	assertAppRegistryDuration(t, "healthy stability window", cfg.Server.AppRegistry.HealthyStabilityWindowDuration, 20*time.Second)
+	assertAppRegistryDuration(t, "healthy stability window", cfg.Server.AppRegistry.HealthyStabilityWindowDuration, 50*time.Second)
 	assertAppRegistryDuration(t, "heartbeat retention", cfg.Server.AppRegistry.HeartbeatRetentionDuration, 12*time.Hour)
 	if cfg.Server.AppRegistry.RolloutMode != AppRegistryRolloutModeHeartbeat {
 		t.Fatalf("rollout mode = %q, want heartbeat", cfg.Server.AppRegistry.RolloutMode)
@@ -60,6 +60,8 @@ func TestAppRegistryHeartbeatConfigValidation(t *testing.T) {
 		{name: "ttl positive", config: "heartbeatTtl: -1s", wantErr: "heartbeatTtl"},
 		{name: "ttl exceeds interval", config: "heartbeatInterval: 15s\n    heartbeatTtl: 15s", wantErr: "must be greater than heartbeatInterval"},
 		{name: "stability positive", config: "healthyStabilityWindow: 0s", wantErr: "healthyStabilityWindow"},
+		{name: "stability equals ttl", config: "heartbeatTtl: 45s\n    healthyStabilityWindow: 45s", wantErr: "must be greater than heartbeatTtl"},
+		{name: "stability shorter than ttl", config: "heartbeatTtl: 45s\n    healthyStabilityWindow: 30s", wantErr: "must be greater than heartbeatTtl"},
 		{name: "retention positive", config: "heartbeatRetention: invalid", wantErr: "heartbeatRetention"},
 		{name: "rollout mode", config: "rolloutMode: other", wantErr: "rolloutMode"},
 	} {

--- a/gestaltd/internal/config/app_registry_heartbeat_config_test.go
+++ b/gestaltd/internal/config/app_registry_heartbeat_config_test.go
@@ -1,0 +1,87 @@
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAppRegistryHeartbeatConfigDefaults(t *testing.T) {
+	t.Parallel()
+
+	path := mustWriteConfigFile(t, `server: {}`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	assertAppRegistryDuration(t, "heartbeat interval", cfg.Server.AppRegistry.HeartbeatIntervalDuration, 15*time.Second)
+	assertAppRegistryDuration(t, "heartbeat TTL", cfg.Server.AppRegistry.HeartbeatTTLDuration, 45*time.Second)
+	assertAppRegistryDuration(t, "healthy stability window", cfg.Server.AppRegistry.HealthyStabilityWindowDuration, 30*time.Second)
+	assertAppRegistryDuration(t, "heartbeat retention", cfg.Server.AppRegistry.HeartbeatRetentionDuration, 24*time.Hour)
+	if cfg.Server.AppRegistry.RolloutMode != AppRegistryRolloutModeEnrollment {
+		t.Fatalf("rollout mode = %q, want %q", cfg.Server.AppRegistry.RolloutMode, AppRegistryRolloutModeEnrollment)
+	}
+}
+
+func TestAppRegistryHeartbeatConfigAcceptsExplicitValues(t *testing.T) {
+	t.Parallel()
+
+	path := mustWriteConfigFile(t, `
+server:
+  appRegistry:
+    heartbeatInterval: 10s
+    heartbeatTtl: 35s
+    healthyStabilityWindow: 20s
+    heartbeatRetention: 12h
+    rolloutMode: heartbeat
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	assertAppRegistryDuration(t, "heartbeat interval", cfg.Server.AppRegistry.HeartbeatIntervalDuration, 10*time.Second)
+	assertAppRegistryDuration(t, "heartbeat TTL", cfg.Server.AppRegistry.HeartbeatTTLDuration, 35*time.Second)
+	assertAppRegistryDuration(t, "healthy stability window", cfg.Server.AppRegistry.HealthyStabilityWindowDuration, 20*time.Second)
+	assertAppRegistryDuration(t, "heartbeat retention", cfg.Server.AppRegistry.HeartbeatRetentionDuration, 12*time.Hour)
+	if cfg.Server.AppRegistry.RolloutMode != AppRegistryRolloutModeHeartbeat {
+		t.Fatalf("rollout mode = %q, want heartbeat", cfg.Server.AppRegistry.RolloutMode)
+	}
+}
+
+func TestAppRegistryHeartbeatConfigValidation(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		config  string
+		wantErr string
+	}{
+		{name: "interval positive", config: "heartbeatInterval: 0s", wantErr: "heartbeatInterval"},
+		{name: "ttl positive", config: "heartbeatTtl: -1s", wantErr: "heartbeatTtl"},
+		{name: "ttl exceeds interval", config: "heartbeatInterval: 15s\n    heartbeatTtl: 15s", wantErr: "must be greater than heartbeatInterval"},
+		{name: "stability positive", config: "healthyStabilityWindow: 0s", wantErr: "healthyStabilityWindow"},
+		{name: "retention positive", config: "heartbeatRetention: invalid", wantErr: "heartbeatRetention"},
+		{name: "rollout mode", config: "rolloutMode: other", wantErr: "rolloutMode"},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path := mustWriteConfigFile(t, "server:\n  appRegistry:\n    "+tc.config+"\n")
+			_, err := Load(path)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("Load error = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func assertAppRegistryDuration(t *testing.T, name string, load func() (time.Duration, error), want time.Duration) {
+	t.Helper()
+	got, err := load()
+	if err != nil {
+		t.Fatalf("%s: %v", name, err)
+	}
+	if got != want {
+		t.Fatalf("%s = %v, want %v", name, got, want)
+	}
+}

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1966,18 +1966,58 @@ type ServerAppRegistryConfig struct {
 	RestartDelay string `yaml:"restartDelay,omitempty"`
 	// MaxReconcileAttempts bounds failed convergence attempts per app/version.
 	// Omission defaults to DefaultAppRegistryMaxReconcileAttempts.
-	MaxReconcileAttempts    int    `yaml:"maxReconcileAttempts,omitempty"`
-	AutoDeployPollInterval  string `yaml:"autoDeployPollInterval,omitempty"`
-	maxReconcileAttemptsSet bool   `yaml:"-"`
+	MaxReconcileAttempts    int                    `yaml:"maxReconcileAttempts,omitempty"`
+	AutoDeployPollInterval  string                 `yaml:"autoDeployPollInterval,omitempty"`
+	HeartbeatInterval       string                 `yaml:"heartbeatInterval,omitempty"`
+	HeartbeatTTL            string                 `yaml:"heartbeatTtl,omitempty"`
+	HealthyStabilityWindow  string                 `yaml:"healthyStabilityWindow,omitempty"`
+	HeartbeatRetention      string                 `yaml:"heartbeatRetention,omitempty"`
+	RolloutMode             AppRegistryRolloutMode `yaml:"rolloutMode,omitempty"`
+	maxReconcileAttemptsSet bool                   `yaml:"-"`
 }
 
 const DefaultAppRegistryMaxReconcileAttempts = 3
 const DefaultAppRegistryAutoDeployPollInterval = time.Minute
+const DefaultAppRegistryHeartbeatInterval = 15 * time.Second
+const DefaultAppRegistryHeartbeatTTL = 45 * time.Second
+const DefaultAppRegistryHealthyStabilityWindow = 30 * time.Second
+const DefaultAppRegistryHeartbeatRetention = 24 * time.Hour
+
+type AppRegistryRolloutMode string
+
+const (
+	AppRegistryRolloutModeEnrollment AppRegistryRolloutMode = "enrollment"
+	AppRegistryRolloutModeHeartbeat  AppRegistryRolloutMode = "heartbeat"
+)
 
 func (c ServerAppRegistryConfig) AutoDeployPollIntervalDuration() (time.Duration, error) {
 	raw := strings.TrimSpace(c.AutoDeployPollInterval)
 	if raw == "" {
 		return DefaultAppRegistryAutoDeployPollInterval, nil
+	}
+	return ParseDuration(raw)
+}
+
+func (c ServerAppRegistryConfig) HeartbeatIntervalDuration() (time.Duration, error) {
+	return appRegistryDuration(c.HeartbeatInterval, DefaultAppRegistryHeartbeatInterval)
+}
+
+func (c ServerAppRegistryConfig) HeartbeatTTLDuration() (time.Duration, error) {
+	return appRegistryDuration(c.HeartbeatTTL, DefaultAppRegistryHeartbeatTTL)
+}
+
+func (c ServerAppRegistryConfig) HealthyStabilityWindowDuration() (time.Duration, error) {
+	return appRegistryDuration(c.HealthyStabilityWindow, DefaultAppRegistryHealthyStabilityWindow)
+}
+
+func (c ServerAppRegistryConfig) HeartbeatRetentionDuration() (time.Duration, error) {
+	return appRegistryDuration(c.HeartbeatRetention, DefaultAppRegistryHeartbeatRetention)
+}
+
+func appRegistryDuration(raw string, defaultValue time.Duration) (time.Duration, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return defaultValue, nil
 	}
 	return ParseDuration(raw)
 }

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1980,7 +1980,7 @@ const DefaultAppRegistryMaxReconcileAttempts = 3
 const DefaultAppRegistryAutoDeployPollInterval = time.Minute
 const DefaultAppRegistryHeartbeatInterval = 15 * time.Second
 const DefaultAppRegistryHeartbeatTTL = 45 * time.Second
-const DefaultAppRegistryHealthyStabilityWindow = 30 * time.Second
+const DefaultAppRegistryHealthyStabilityWindow = 60 * time.Second
 const DefaultAppRegistryHeartbeatRetention = 24 * time.Hour
 
 type AppRegistryRolloutMode string

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -249,6 +249,36 @@ func validateServerAppRegistry(cfg *Config) error {
 	if _, err := cfg.Server.AppRegistry.AutoDeployPollIntervalDuration(); err != nil {
 		return fmt.Errorf("config validation: server.appRegistry.autoDeployPollInterval: %w", err)
 	}
+	heartbeatInterval, err := cfg.Server.AppRegistry.HeartbeatIntervalDuration()
+	if err != nil {
+		return fmt.Errorf("config validation: server.appRegistry.heartbeatInterval: %w", err)
+	}
+	heartbeatTTL, err := cfg.Server.AppRegistry.HeartbeatTTLDuration()
+	if err != nil {
+		return fmt.Errorf("config validation: server.appRegistry.heartbeatTtl: %w", err)
+	}
+	if heartbeatTTL <= heartbeatInterval {
+		return fmt.Errorf("config validation: server.appRegistry.heartbeatTtl must be greater than heartbeatInterval")
+	}
+	if _, err := cfg.Server.AppRegistry.HealthyStabilityWindowDuration(); err != nil {
+		return fmt.Errorf("config validation: server.appRegistry.healthyStabilityWindow: %w", err)
+	}
+	if _, err := cfg.Server.AppRegistry.HeartbeatRetentionDuration(); err != nil {
+		return fmt.Errorf("config validation: server.appRegistry.heartbeatRetention: %w", err)
+	}
+	cfg.Server.AppRegistry.RolloutMode = AppRegistryRolloutMode(strings.TrimSpace(string(cfg.Server.AppRegistry.RolloutMode)))
+	if cfg.Server.AppRegistry.RolloutMode == "" {
+		cfg.Server.AppRegistry.RolloutMode = AppRegistryRolloutModeEnrollment
+	}
+	switch cfg.Server.AppRegistry.RolloutMode {
+	case AppRegistryRolloutModeEnrollment, AppRegistryRolloutModeHeartbeat:
+	default:
+		return fmt.Errorf(
+			"config validation: server.appRegistry.rolloutMode must be %q or %q",
+			AppRegistryRolloutModeEnrollment,
+			AppRegistryRolloutModeHeartbeat,
+		)
+	}
 	return nil
 }
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -260,8 +260,12 @@ func validateServerAppRegistry(cfg *Config) error {
 	if heartbeatTTL <= heartbeatInterval {
 		return fmt.Errorf("config validation: server.appRegistry.heartbeatTtl must be greater than heartbeatInterval")
 	}
-	if _, err := cfg.Server.AppRegistry.HealthyStabilityWindowDuration(); err != nil {
+	healthyStabilityWindow, err := cfg.Server.AppRegistry.HealthyStabilityWindowDuration()
+	if err != nil {
 		return fmt.Errorf("config validation: server.appRegistry.healthyStabilityWindow: %w", err)
+	}
+	if healthyStabilityWindow <= heartbeatTTL {
+		return fmt.Errorf("config validation: server.appRegistry.healthyStabilityWindow must be greater than heartbeatTtl")
 	}
 	if _, err := cfg.Server.AppRegistry.HeartbeatRetentionDuration(); err != nil {
 		return fmt.Errorf("config validation: server.appRegistry.heartbeatRetention: %w", err)

--- a/gestaltd/internal/coredata/app_version_recovery_observations.go
+++ b/gestaltd/internal/coredata/app_version_recovery_observations.go
@@ -1,0 +1,126 @@
+package coredata
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	idb "github.com/valon-technologies/gestalt/sdk/go/indexeddb"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+)
+
+type AppVersionRecoveryObservationService struct {
+	store idb.ObjectStore
+}
+
+func NewAppVersionRecoveryObservationService(ds indexeddb.IndexedDB) *AppVersionRecoveryObservationService {
+	return &AppVersionRecoveryObservationService{store: ds.ObjectStore(StoreAppVersionRecoveryObservations)}
+}
+
+func (s *AppVersionRecoveryObservationService) Get(ctx context.Context, changeRequestID string) (*core.AppVersionRecoveryObservation, error) {
+	if s == nil {
+		return nil, fmt.Errorf("get app version recovery observation: service is not configured")
+	}
+	changeRequestID = strings.TrimSpace(changeRequestID)
+	if changeRequestID == "" {
+		return nil, fmt.Errorf("get app version recovery observation: change request id is required")
+	}
+	rec, err := s.store.Get(ctx, changeRequestID)
+	if err != nil {
+		if errors.Is(err, idb.ErrNotFound) {
+			return nil, core.ErrNotFound
+		}
+		return nil, fmt.Errorf("get app version recovery observation: %w", err)
+	}
+	return recordToAppVersionRecoveryObservation(rec), nil
+}
+
+func (s *AppVersionRecoveryObservationService) GetMany(ctx context.Context, changeRequestIDs []string) (map[string]*core.AppVersionRecoveryObservation, error) {
+	if s == nil {
+		return nil, fmt.Errorf("get app version recovery observations: service is not configured")
+	}
+	out := make(map[string]*core.AppVersionRecoveryObservation, len(changeRequestIDs))
+	for _, id := range changeRequestIDs {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		observation, err := s.Get(ctx, id)
+		if errors.Is(err, core.ErrNotFound) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		out[id] = observation
+	}
+	return out, nil
+}
+
+// Record persists the first recovery observation for a change request. Later
+// calls return the original observation without rewriting the historical fact.
+func (s *AppVersionRecoveryObservationService) Record(ctx context.Context, observation *core.AppVersionRecoveryObservation) (*core.AppVersionRecoveryObservation, error) {
+	if s == nil {
+		return nil, fmt.Errorf("record app version recovery observation: service is not configured")
+	}
+	rec, normalized, err := appVersionRecoveryObservationRecord(observation)
+	if err != nil {
+		return nil, fmt.Errorf("record app version recovery observation: %w", err)
+	}
+	if err := s.store.Add(ctx, rec); err != nil {
+		if errors.Is(err, idb.ErrAlreadyExists) {
+			return s.Get(ctx, normalized.ID)
+		}
+		return nil, fmt.Errorf("record app version recovery observation: %w", err)
+	}
+	return normalized, nil
+}
+
+func appVersionRecoveryObservationRecord(observation *core.AppVersionRecoveryObservation) (idb.Record, *core.AppVersionRecoveryObservation, error) {
+	if observation == nil {
+		return nil, nil, fmt.Errorf("record is required")
+	}
+	normalized := &core.AppVersionRecoveryObservation{
+		ID:                      strings.TrimSpace(observation.ID),
+		App:                     strings.TrimSpace(observation.App),
+		Version:                 strings.TrimSpace(observation.Version),
+		RecoveredAt:             observation.RecoveredAt.UTC().Truncate(time.Millisecond),
+		SourceVersion:           strings.TrimSpace(observation.SourceVersion),
+		LiveInstances:           observation.LiveInstances,
+		MinimumHealthyInstances: observation.MinimumHealthyInstances,
+	}
+	if normalized.ID == "" || normalized.App == "" || normalized.Version == "" || normalized.SourceVersion == "" {
+		return nil, nil, fmt.Errorf("change request id, app, version, and source version are required")
+	}
+	if observation.RecoveredAt.IsZero() {
+		return nil, nil, fmt.Errorf("recovered at is required")
+	}
+	if normalized.LiveInstances < 0 || normalized.MinimumHealthyInstances < 0 {
+		return nil, nil, fmt.Errorf("instance counts must not be negative")
+	}
+	return idb.Record{
+		"id":                        normalized.ID,
+		"app":                       normalized.App,
+		"version":                   normalized.Version,
+		"recovered_at":              normalized.RecoveredAt,
+		"source_version":            normalized.SourceVersion,
+		"live_instances":            normalized.LiveInstances,
+		"minimum_healthy_instances": normalized.MinimumHealthyInstances,
+	}, normalized, nil
+}
+
+func recordToAppVersionRecoveryObservation(rec idb.Record) *core.AppVersionRecoveryObservation {
+	return &core.AppVersionRecoveryObservation{
+		ID:                      recString(rec, "id"),
+		App:                     recString(rec, "app"),
+		Version:                 recString(rec, "version"),
+		RecoveredAt:             recTime(rec, "recovered_at"),
+		SourceVersion:           recString(rec, "source_version"),
+		LiveInstances:           recordInt(rec, "live_instances"),
+		MinimumHealthyInstances: recordInt(rec, "minimum_healthy_instances"),
+	}
+}

--- a/gestaltd/internal/coredata/app_version_recovery_observations_test.go
+++ b/gestaltd/internal/coredata/app_version_recovery_observations_test.go
@@ -1,0 +1,70 @@
+package coredata_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+)
+
+func TestAppVersionRecoveryObservationServiceRecordsFirstObservation(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc := testutil.NewStubServices(t).AppVersionRecoveryObservations
+	recoveredAt := time.Date(2026, 7, 30, 13, 52, 15, 123456789, time.UTC)
+	first := &core.AppVersionRecoveryObservation{
+		ID:                      " request-1 ",
+		App:                     " g-issues ",
+		Version:                 " v2 ",
+		RecoveredAt:             recoveredAt,
+		SourceVersion:           " source-a ",
+		LiveInstances:           5,
+		MinimumHealthyInstances: 5,
+	}
+	recorded, err := svc.Record(ctx, first)
+	if err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+	if recorded.ID != "request-1" || recorded.RecoveredAt.Nanosecond() != 123000000 {
+		t.Fatalf("recorded observation = %#v", recorded)
+	}
+
+	duplicate := *first
+	duplicate.RecoveredAt = recoveredAt.Add(time.Hour)
+	duplicate.LiveInstances = 8
+	recorded, err = svc.Record(ctx, &duplicate)
+	if err != nil {
+		t.Fatalf("duplicate Record: %v", err)
+	}
+	if !recorded.RecoveredAt.Equal(recoveredAt.Truncate(time.Millisecond)) || recorded.LiveInstances != 5 {
+		t.Fatalf("duplicate rewrote observation: %#v", recorded)
+	}
+}
+
+func TestAppVersionRecoveryObservationServiceGetMany(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc := testutil.NewStubServices(t).AppVersionRecoveryObservations
+	if _, err := svc.Record(ctx, &core.AppVersionRecoveryObservation{
+		ID:                      "request-1",
+		App:                     "g-issues",
+		Version:                 "v2",
+		RecoveredAt:             time.Date(2026, 7, 30, 13, 52, 15, 0, time.UTC),
+		SourceVersion:           "source-a",
+		LiveInstances:           5,
+		MinimumHealthyInstances: 5,
+	}); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+	got, err := svc.GetMany(ctx, []string{"request-1", "missing"})
+	if err != nil {
+		t.Fatalf("GetMany: %v", err)
+	}
+	if len(got) != 1 || got["request-1"].Version != "v2" {
+		t.Fatalf("observations = %#v", got)
+	}
+}

--- a/gestaltd/internal/coredata/gestaltd_instance_heartbeats.go
+++ b/gestaltd/internal/coredata/gestaltd_instance_heartbeats.go
@@ -1,0 +1,178 @@
+package coredata
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	idb "github.com/valon-technologies/gestalt/sdk/go/indexeddb"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+)
+
+type GestaltdInstanceHeartbeatService struct {
+	store idb.ObjectStore
+}
+
+func NewGestaltdInstanceHeartbeatService(ds indexeddb.IndexedDB) *GestaltdInstanceHeartbeatService {
+	return &GestaltdInstanceHeartbeatService{store: ds.ObjectStore(StoreGestaltdInstanceHeartbeats)}
+}
+
+func (s *GestaltdInstanceHeartbeatService) Get(ctx context.Context, instanceID string) (*core.GestaltdInstanceHeartbeat, error) {
+	if s == nil {
+		return nil, fmt.Errorf("get gestaltd instance heartbeat: service is not configured")
+	}
+	instanceID = strings.TrimSpace(instanceID)
+	if instanceID == "" {
+		return nil, fmt.Errorf("get gestaltd instance heartbeat: instance id is required")
+	}
+	rec, err := s.store.Get(ctx, instanceID)
+	if err != nil {
+		if errors.Is(err, idb.ErrNotFound) {
+			return nil, core.ErrNotFound
+		}
+		return nil, fmt.Errorf("get gestaltd instance heartbeat: %w", err)
+	}
+	return recordToGestaltdInstanceHeartbeat(rec), nil
+}
+
+func (s *GestaltdInstanceHeartbeatService) List(ctx context.Context) ([]*core.GestaltdInstanceHeartbeat, error) {
+	if s == nil {
+		return nil, fmt.Errorf("list gestaltd instance heartbeats: service is not configured")
+	}
+	recs, err := s.store.GetAll(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list gestaltd instance heartbeats: %w", err)
+	}
+	return recordsToGestaltdInstanceHeartbeats(recs), nil
+}
+
+func (s *GestaltdInstanceHeartbeatService) ListBySourceVersion(ctx context.Context, sourceVersion string) ([]*core.GestaltdInstanceHeartbeat, error) {
+	if s == nil {
+		return nil, fmt.Errorf("list gestaltd instance heartbeats by source version: service is not configured")
+	}
+	sourceVersion = strings.TrimSpace(sourceVersion)
+	if sourceVersion == "" {
+		return nil, fmt.Errorf("list gestaltd instance heartbeats by source version: source version is required")
+	}
+	recs, err := s.store.Index("by_source_version").GetAll(ctx, sourceVersion)
+	if err != nil {
+		return nil, fmt.Errorf("list gestaltd instance heartbeats by source version: %w", err)
+	}
+	return recordsToGestaltdInstanceHeartbeats(recs), nil
+}
+
+func (s *GestaltdInstanceHeartbeatService) Upsert(ctx context.Context, heartbeat *core.GestaltdInstanceHeartbeat) (*core.GestaltdInstanceHeartbeat, error) {
+	if s == nil {
+		return nil, fmt.Errorf("upsert gestaltd instance heartbeat: service is not configured")
+	}
+	rec, normalized, err := gestaltdInstanceHeartbeatRecord(heartbeat)
+	if err != nil {
+		return nil, fmt.Errorf("upsert gestaltd instance heartbeat: %w", err)
+	}
+	if err := s.store.Put(ctx, rec); err != nil {
+		return nil, fmt.Errorf("upsert gestaltd instance heartbeat: %w", err)
+	}
+	return normalized, nil
+}
+
+func (s *GestaltdInstanceHeartbeatService) Delete(ctx context.Context, instanceID string) error {
+	if s == nil {
+		return fmt.Errorf("delete gestaltd instance heartbeat: service is not configured")
+	}
+	instanceID = strings.TrimSpace(instanceID)
+	if instanceID == "" {
+		return fmt.Errorf("delete gestaltd instance heartbeat: instance id is required")
+	}
+	if err := s.store.Delete(ctx, instanceID); err != nil {
+		return fmt.Errorf("delete gestaltd instance heartbeat: %w", err)
+	}
+	return nil
+}
+
+func gestaltdInstanceHeartbeatRecord(heartbeat *core.GestaltdInstanceHeartbeat) (idb.Record, *core.GestaltdInstanceHeartbeat, error) {
+	if heartbeat == nil {
+		return nil, nil, fmt.Errorf("record is required")
+	}
+	normalized := &core.GestaltdInstanceHeartbeat{
+		InstanceID:    strings.TrimSpace(heartbeat.InstanceID),
+		SourceVersion: strings.TrimSpace(heartbeat.SourceVersion),
+		StartedAt:     normalizedHeartbeatTime(heartbeat.StartedAt),
+		HeartbeatAt:   normalizedHeartbeatTime(heartbeat.HeartbeatAt),
+		Apps:          cloneHeartbeatApps(heartbeat.Apps),
+	}
+	if normalized.InstanceID == "" || normalized.SourceVersion == "" {
+		return nil, nil, fmt.Errorf("instance id and source version are required")
+	}
+	if heartbeat.StartedAt.IsZero() || heartbeat.HeartbeatAt.IsZero() {
+		return nil, nil, fmt.Errorf("started at and heartbeat at are required")
+	}
+	if normalized.HeartbeatAt.Before(normalized.StartedAt) {
+		return nil, nil, fmt.Errorf("heartbeat at must not be before started at")
+	}
+	if normalized.Apps == nil {
+		normalized.Apps = map[string]core.GestaltdInstanceAppHeartbeat{}
+	}
+	return idb.Record{
+		"id":             normalized.InstanceID,
+		"instance_id":    normalized.InstanceID,
+		"source_version": normalized.SourceVersion,
+		"started_at":     normalized.StartedAt,
+		"heartbeat_at":   normalized.HeartbeatAt,
+		"apps":           heartbeatAppsJSONValue(normalized.Apps),
+	}, normalized, nil
+}
+
+func normalizedHeartbeatTime(value time.Time) time.Time {
+	return value.UTC().Truncate(time.Millisecond)
+}
+
+func heartbeatAppsJSONValue(apps map[string]core.GestaltdInstanceAppHeartbeat) any {
+	encoded, err := json.Marshal(apps)
+	if err != nil {
+		return map[string]any{}
+	}
+	var value map[string]any
+	if err := json.Unmarshal(encoded, &value); err != nil {
+		return map[string]any{}
+	}
+	return value
+}
+
+func cloneHeartbeatApps(apps map[string]core.GestaltdInstanceAppHeartbeat) map[string]core.GestaltdInstanceAppHeartbeat {
+	if apps == nil {
+		return nil
+	}
+	out := make(map[string]core.GestaltdInstanceAppHeartbeat, len(apps))
+	for app, observation := range apps {
+		observation.ObservedAt = normalizedHeartbeatTime(observation.ObservedAt)
+		out[app] = observation
+	}
+	return out
+}
+
+func recordToGestaltdInstanceHeartbeat(rec idb.Record) *core.GestaltdInstanceHeartbeat {
+	apps := make(map[string]core.GestaltdInstanceAppHeartbeat)
+	if raw := recJSON(rec, "apps"); len(raw) > 0 {
+		_ = json.Unmarshal(raw, &apps)
+	}
+	return &core.GestaltdInstanceHeartbeat{
+		InstanceID:    recString(rec, "instance_id"),
+		SourceVersion: recString(rec, "source_version"),
+		StartedAt:     recTime(rec, "started_at"),
+		HeartbeatAt:   recTime(rec, "heartbeat_at"),
+		Apps:          apps,
+	}
+}
+
+func recordsToGestaltdInstanceHeartbeats(recs []idb.Record) []*core.GestaltdInstanceHeartbeat {
+	out := make([]*core.GestaltdInstanceHeartbeat, 0, len(recs))
+	for _, rec := range recs {
+		out = append(out, recordToGestaltdInstanceHeartbeat(rec))
+	}
+	return out
+}

--- a/gestaltd/internal/coredata/gestaltd_instance_heartbeats_test.go
+++ b/gestaltd/internal/coredata/gestaltd_instance_heartbeats_test.go
@@ -1,0 +1,111 @@
+package coredata_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+)
+
+func TestGestaltdInstanceHeartbeatServiceRoundTripAndReplace(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc := testutil.NewStubServices(t).GestaltdInstanceHeartbeats
+	startedAt := time.Date(2026, 7, 30, 13, 48, 41, 123456789, time.UTC)
+	firstHeartbeatAt := startedAt.Add(15 * time.Second)
+	heartbeat := &core.GestaltdInstanceHeartbeat{
+		InstanceID:    " instance-1 ",
+		SourceVersion: " source-a ",
+		StartedAt:     startedAt,
+		HeartbeatAt:   firstHeartbeatAt,
+		Apps: map[string]core.GestaltdInstanceAppHeartbeat{
+			"g-issues": {
+				State:          core.GestaltdInstanceAppStateRunning,
+				DesiredVersion: "v2",
+				RunningVersion: "v2",
+				ObservedAt:     firstHeartbeatAt,
+			},
+		},
+	}
+
+	stored, err := svc.Upsert(ctx, heartbeat)
+	if err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	if stored.InstanceID != "instance-1" || stored.SourceVersion != "source-a" {
+		t.Fatalf("stored heartbeat = %#v", stored)
+	}
+	if stored.HeartbeatAt.Nanosecond() != 123000000 {
+		t.Fatalf("heartbeat timestamp = %v, want millisecond precision", stored.HeartbeatAt)
+	}
+
+	heartbeat.HeartbeatAt = firstHeartbeatAt.Add(15 * time.Second)
+	heartbeat.Apps["g-issues"] = core.GestaltdInstanceAppHeartbeat{
+		State:          core.GestaltdInstanceAppStateStarting,
+		DesiredVersion: "v3",
+		ObservedAt:     heartbeat.HeartbeatAt,
+	}
+	if _, err := svc.Upsert(ctx, heartbeat); err != nil {
+		t.Fatalf("replacement Upsert: %v", err)
+	}
+
+	got, err := svc.Get(ctx, "instance-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !got.HeartbeatAt.Equal(heartbeat.HeartbeatAt.UTC().Truncate(time.Millisecond)) {
+		t.Fatalf("heartbeat at = %v, want %v", got.HeartbeatAt, heartbeat.HeartbeatAt)
+	}
+	if app := got.Apps["g-issues"]; app.State != core.GestaltdInstanceAppStateStarting || app.DesiredVersion != "v3" {
+		t.Fatalf("app observation = %#v", app)
+	}
+	all, err := svc.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("heartbeats = %d, want one row per instance", len(all))
+	}
+}
+
+func TestGestaltdInstanceHeartbeatServiceListsBySourceVersion(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc := testutil.NewStubServices(t).GestaltdInstanceHeartbeats
+	now := time.Date(2026, 7, 30, 14, 0, 0, 0, time.UTC)
+	for _, heartbeat := range []*core.GestaltdInstanceHeartbeat{
+		{InstanceID: "instance-a", SourceVersion: "source-a", StartedAt: now, HeartbeatAt: now, Apps: map[string]core.GestaltdInstanceAppHeartbeat{}},
+		{InstanceID: "instance-b", SourceVersion: "source-b", StartedAt: now, HeartbeatAt: now, Apps: map[string]core.GestaltdInstanceAppHeartbeat{}},
+	} {
+		if _, err := svc.Upsert(ctx, heartbeat); err != nil {
+			t.Fatalf("Upsert(%s): %v", heartbeat.InstanceID, err)
+		}
+	}
+	got, err := svc.ListBySourceVersion(ctx, "source-a")
+	if err != nil {
+		t.Fatalf("ListBySourceVersion: %v", err)
+	}
+	if len(got) != 1 || got[0].InstanceID != "instance-a" {
+		t.Fatalf("heartbeats = %#v", got)
+	}
+}
+
+func TestGestaltdInstanceHeartbeatServiceValidatesRecord(t *testing.T) {
+	t.Parallel()
+
+	svc := testutil.NewStubServices(t).GestaltdInstanceHeartbeats
+	now := time.Now()
+	_, err := svc.Upsert(context.Background(), &core.GestaltdInstanceHeartbeat{
+		InstanceID:    "instance-a",
+		SourceVersion: "source-a",
+		StartedAt:     now,
+		HeartbeatAt:   now.Add(-time.Second),
+	})
+	if err == nil {
+		t.Fatal("Upsert error = nil, want invalid timestamp error")
+	}
+}

--- a/gestaltd/internal/coredata/gestaltd_source_versions.go
+++ b/gestaltd/internal/coredata/gestaltd_source_versions.go
@@ -131,6 +131,7 @@ func (s *GestaltdSourceVersionService) Activate(
 	retry bool,
 	enrollmentWindow time.Duration,
 	rolloutTimeout time.Duration,
+	minimumHealthyInstances ...int,
 ) (*core.GestaltdSourceVersionState, error) {
 	if s == nil || s.db == nil {
 		return nil, fmt.Errorf("activate gestaltd source version: service is not configured")
@@ -142,6 +143,16 @@ func (s *GestaltdSourceVersionService) Activate(
 	at = normalizedSourceVersionTime(at)
 	if enrollmentWindow <= 0 || rolloutTimeout <= enrollmentWindow {
 		return nil, fmt.Errorf("activate gestaltd source version: invalid rollout windows")
+	}
+	if len(minimumHealthyInstances) > 1 {
+		return nil, fmt.Errorf("activate gestaltd source version: minimum healthy instances may only be provided once")
+	}
+	minimumHealthy := 0
+	if len(minimumHealthyInstances) == 1 {
+		minimumHealthy = minimumHealthyInstances[0]
+	}
+	if minimumHealthy < 0 {
+		return nil, fmt.Errorf("activate gestaltd source version: minimum healthy instances must not be negative")
 	}
 
 	tx, err := s.db.Transaction(
@@ -170,6 +181,7 @@ func (s *GestaltdSourceVersionService) Activate(
 		state = recordToGestaltdSourceVersionState(stateRecs[0])
 	}
 	sourceChanged := strings.TrimSpace(state.CurrentSourceVersion) != sourceVersion
+	minimumChanged := state.MinimumHealthyInstances != minimumHealthy
 	if sourceChanged || retry {
 		rolloutStore := tx.ObjectStore(StoreAppRollouts)
 		recs, listErr := rolloutStore.GetAll(ctx, nil)
@@ -202,7 +214,8 @@ func (s *GestaltdSourceVersionService) Activate(
 	}
 
 	state.CurrentSourceVersion = sourceVersion
-	if sourceChanged || retry || state.UpdatedAt.IsZero() {
+	state.MinimumHealthyInstances = minimumHealthy
+	if sourceChanged || minimumChanged || retry || state.UpdatedAt.IsZero() {
 		state.UpdatedAt = at
 	}
 	if err := stateStore.Put(ctx, gestaltdSourceVersionStateRecord(state)); err != nil {
@@ -224,15 +237,17 @@ func normalizedSourceVersionTime(value time.Time) time.Time {
 
 func gestaltdSourceVersionStateRecord(state *core.GestaltdSourceVersionState) idb.Record {
 	return idb.Record{
-		"id":                     gestaltdSourceVersionStateID,
-		"current_source_version": strings.TrimSpace(state.CurrentSourceVersion),
-		"updated_at":             normalizedSourceVersionTime(state.UpdatedAt),
+		"id":                        gestaltdSourceVersionStateID,
+		"current_source_version":    strings.TrimSpace(state.CurrentSourceVersion),
+		"minimum_healthy_instances": state.MinimumHealthyInstances,
+		"updated_at":                normalizedSourceVersionTime(state.UpdatedAt),
 	}
 }
 
 func recordToGestaltdSourceVersionState(rec idb.Record) *core.GestaltdSourceVersionState {
 	return &core.GestaltdSourceVersionState{
-		CurrentSourceVersion: recString(rec, "current_source_version"),
-		UpdatedAt:            recTime(rec, "updated_at"),
+		CurrentSourceVersion:    recString(rec, "current_source_version"),
+		MinimumHealthyInstances: recordInt(rec, "minimum_healthy_instances"),
+		UpdatedAt:               recTime(rec, "updated_at"),
 	}
 }

--- a/gestaltd/internal/coredata/gestaltd_source_versions.go
+++ b/gestaltd/internal/coredata/gestaltd_source_versions.go
@@ -147,11 +147,12 @@ func (s *GestaltdSourceVersionService) Activate(
 	if len(minimumHealthyInstances) > 1 {
 		return nil, fmt.Errorf("activate gestaltd source version: minimum healthy instances may only be provided once")
 	}
-	minimumHealthy := 0
-	if len(minimumHealthyInstances) == 1 {
-		minimumHealthy = minimumHealthyInstances[0]
+	minimumProvided := len(minimumHealthyInstances) == 1
+	requestedMinimumHealthy := 0
+	if minimumProvided {
+		requestedMinimumHealthy = minimumHealthyInstances[0]
 	}
-	if minimumHealthy < 0 {
+	if requestedMinimumHealthy < 0 {
 		return nil, fmt.Errorf("activate gestaltd source version: minimum healthy instances must not be negative")
 	}
 
@@ -181,8 +182,12 @@ func (s *GestaltdSourceVersionService) Activate(
 		state = recordToGestaltdSourceVersionState(stateRecs[0])
 	}
 	sourceChanged := strings.TrimSpace(state.CurrentSourceVersion) != sourceVersion
-	minimumChanged := state.MinimumHealthyInstances != minimumHealthy
-	if sourceChanged || retry {
+	effectiveMinimumHealthy := requestedMinimumHealthy
+	if !minimumProvided && !sourceChanged {
+		effectiveMinimumHealthy = state.MinimumHealthyInstances
+	}
+	minimumChanged := state.MinimumHealthyInstances != effectiveMinimumHealthy
+	if sourceChanged || minimumChanged || retry {
 		rolloutStore := tx.ObjectStore(StoreAppRollouts)
 		recs, listErr := rolloutStore.GetAll(ctx, nil)
 		if listErr != nil {
@@ -190,7 +195,7 @@ func (s *GestaltdSourceVersionService) Activate(
 		}
 		for _, rec := range recs {
 			rollout := recordToAppRollout(rec)
-			retarget := sourceChanged && isActiveRolloutState(rollout.State)
+			retarget := (sourceChanged || minimumChanged) && isActiveRolloutState(rollout.State)
 			if retry && strings.TrimSpace(rollout.TargetSourceVersion) == sourceVersion {
 				retarget = isActiveRolloutState(rollout.State) ||
 					(rollout.State == core.AppRolloutStateFailed &&
@@ -214,7 +219,7 @@ func (s *GestaltdSourceVersionService) Activate(
 	}
 
 	state.CurrentSourceVersion = sourceVersion
-	state.MinimumHealthyInstances = minimumHealthy
+	state.MinimumHealthyInstances = effectiveMinimumHealthy
 	if sourceChanged || minimumChanged || retry || state.UpdatedAt.IsZero() {
 		state.UpdatedAt = at
 	}

--- a/gestaltd/internal/coredata/gestaltd_source_versions_test.go
+++ b/gestaltd/internal/coredata/gestaltd_source_versions_test.go
@@ -158,3 +158,69 @@ func TestGestaltdSourceVersionRetryReopensFailuresSinceActivation(t *testing.T) 
 		t.Fatalf("older rollout state = %q, want failed", older.State)
 	}
 }
+
+func TestGestaltdSourceVersionActivationPersistsMinimumHealthyInstances(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	services := testutil.NewStubServices(t)
+	start := time.Date(2026, 7, 30, 18, 0, 0, 0, time.UTC)
+	state, err := services.GestaltdSourceVersionState.Activate(
+		ctx,
+		"source-a",
+		start,
+		false,
+		2*time.Minute,
+		15*time.Minute,
+		5,
+	)
+	if err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	if state.MinimumHealthyInstances != 5 {
+		t.Fatalf("minimum healthy instances = %d, want 5", state.MinimumHealthyInstances)
+	}
+	stored, err := services.GestaltdSourceVersionState.Get(ctx)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if stored.MinimumHealthyInstances != 5 {
+		t.Fatalf("stored minimum healthy instances = %d, want 5", stored.MinimumHealthyInstances)
+	}
+
+	retryAt := start.Add(time.Minute)
+	retried, err := services.GestaltdSourceVersionState.Activate(
+		ctx,
+		"source-a",
+		retryAt,
+		true,
+		2*time.Minute,
+		15*time.Minute,
+		7,
+	)
+	if err != nil {
+		t.Fatalf("retry Activate: %v", err)
+	}
+	if retried.MinimumHealthyInstances != 7 || !retried.UpdatedAt.Equal(retryAt) {
+		t.Fatalf("retried state = %#v", retried)
+	}
+}
+
+func TestGestaltdSourceVersionActivationWithoutMinimumRemainsCompatible(t *testing.T) {
+	t.Parallel()
+
+	state, err := testutil.NewStubServices(t).GestaltdSourceVersionState.Activate(
+		context.Background(),
+		"source-a",
+		time.Date(2026, 7, 30, 18, 0, 0, 0, time.UTC),
+		false,
+		2*time.Minute,
+		15*time.Minute,
+	)
+	if err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	if state.MinimumHealthyInstances != 0 {
+		t.Fatalf("minimum healthy instances = %d, want zero when unspecified", state.MinimumHealthyInstances)
+	}
+}

--- a/gestaltd/internal/coredata/gestaltd_source_versions_test.go
+++ b/gestaltd/internal/coredata/gestaltd_source_versions_test.go
@@ -206,6 +206,100 @@ func TestGestaltdSourceVersionActivationPersistsMinimumHealthyInstances(t *testi
 	}
 }
 
+func TestGestaltdSourceVersionActivationPreservesOmittedMinimumOnSameSource(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	services := testutil.NewStubServices(t)
+	start := time.Date(2026, 7, 30, 18, 0, 0, 0, time.UTC)
+	if _, err := services.GestaltdSourceVersionState.Activate(
+		ctx, "source-a", start, false, 2*time.Minute, 15*time.Minute, 5,
+	); err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+
+	unchanged, err := services.GestaltdSourceVersionState.Activate(
+		ctx, "source-a", start.Add(time.Minute), false, 2*time.Minute, 15*time.Minute,
+	)
+	if err != nil {
+		t.Fatalf("same-source Activate: %v", err)
+	}
+	if unchanged.MinimumHealthyInstances != 5 || !unchanged.UpdatedAt.Equal(start) {
+		t.Fatalf("same-source state = %#v", unchanged)
+	}
+
+	retryAt := start.Add(2 * time.Minute)
+	retried, err := services.GestaltdSourceVersionState.Activate(
+		ctx, "source-a", retryAt, true, 2*time.Minute, 15*time.Minute,
+	)
+	if err != nil {
+		t.Fatalf("same-source retry Activate: %v", err)
+	}
+	if retried.MinimumHealthyInstances != 5 || !retried.UpdatedAt.Equal(retryAt) {
+		t.Fatalf("retry state = %#v", retried)
+	}
+}
+
+func TestGestaltdSourceVersionMinimumChangeRetargetsOnlyActiveRollouts(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	services := testutil.NewStubServices(t)
+	start := time.Date(2026, 7, 30, 18, 0, 0, 0, time.UTC)
+	if _, err := services.GestaltdSourceVersionState.Activate(
+		ctx, "source-a", start, false, 2*time.Minute, 15*time.Minute, 5,
+	); err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	for _, app := range []string{"active-app", "terminal-app"} {
+		if _, err := services.GestaltdSourceVersionState.CreateAppRollout(ctx, &core.AppRollout{
+			App:              app,
+			Version:          "v2",
+			State:            core.AppRolloutStateEnrolling,
+			CreatedAt:        start.Add(time.Minute),
+			EnrollmentEndsAt: start.Add(3 * time.Minute),
+			Deadline:         start.Add(16 * time.Minute),
+		}); err != nil {
+			t.Fatalf("Create rollout %s: %v", app, err)
+		}
+	}
+	completedAt := start.Add(2 * time.Minute)
+	terminalBefore, err := services.AppRollouts.MarkComplete(ctx, "terminal-app", "v2", completedAt)
+	if err != nil {
+		t.Fatalf("MarkComplete terminal rollout: %v", err)
+	}
+
+	changedAt := start.Add(5 * time.Minute)
+	state, err := services.GestaltdSourceVersionState.Activate(
+		ctx, "source-a", changedAt, false, 2*time.Minute, 15*time.Minute, 7,
+	)
+	if err != nil {
+		t.Fatalf("change minimum Activate: %v", err)
+	}
+	if state.MinimumHealthyInstances != 7 || !state.UpdatedAt.Equal(changedAt) {
+		t.Fatalf("changed state = %#v", state)
+	}
+	active, err := services.AppRollouts.Get(ctx, "active-app")
+	if err != nil {
+		t.Fatalf("Get active rollout: %v", err)
+	}
+	if active.State != core.AppRolloutStateEnrolling ||
+		!active.CreatedAt.Equal(changedAt) ||
+		!active.EnrollmentEndsAt.Equal(changedAt.Add(2*time.Minute)) ||
+		!active.Deadline.Equal(changedAt.Add(15*time.Minute)) {
+		t.Fatalf("retargeted active rollout = %#v", active)
+	}
+	terminalAfter, err := services.AppRollouts.Get(ctx, "terminal-app")
+	if err != nil {
+		t.Fatalf("Get terminal rollout: %v", err)
+	}
+	if terminalAfter.State != core.AppRolloutStateComplete ||
+		!terminalAfter.CreatedAt.Equal(terminalBefore.CreatedAt) ||
+		!terminalAfter.CompletedAt.Equal(terminalBefore.CompletedAt) {
+		t.Fatalf("terminal rollout changed = %#v", terminalAfter)
+	}
+}
+
 func TestGestaltdSourceVersionActivationWithoutMinimumRemainsCompatible(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -5,19 +5,21 @@ import (
 )
 
 const (
-	StoreUsers                         = "users"
-	StoreManagedSubjects               = "managed_subjects"
-	StoreAuthorizationDynamicFragments = "authz_dynamic_fragments"
-	StoreAppSHAs                       = "app_shas"
-	StoreAppVersionChangeRequests      = "app_version_change_requests"
-	StoreAppVersionInstallLocks        = "app_version_install_locks"
-	StoreGestaltdSourceVersionState    = "gestaltd_source_version_state"
-	StoreAppRollouts                   = "app_rollouts"
-	StoreAppInstanceMaterializations   = "app_instance_materializations"
-	StoreAppAutoDeploySettings         = "app_auto_deploy_settings"
-	StoreAppVersionRolloutOutcomes     = "app_version_rollout_outcomes"
-	StoreRemoteRegistrations           = "remote_registrations"
-	StoreRemoteProviders               = "remote_providers"
+	StoreUsers                          = "users"
+	StoreManagedSubjects                = "managed_subjects"
+	StoreAuthorizationDynamicFragments  = "authz_dynamic_fragments"
+	StoreAppSHAs                        = "app_shas"
+	StoreAppVersionChangeRequests       = "app_version_change_requests"
+	StoreAppVersionInstallLocks         = "app_version_install_locks"
+	StoreGestaltdSourceVersionState     = "gestaltd_source_version_state"
+	StoreAppRollouts                    = "app_rollouts"
+	StoreAppInstanceMaterializations    = "app_instance_materializations"
+	StoreAppAutoDeploySettings          = "app_auto_deploy_settings"
+	StoreAppVersionRolloutOutcomes      = "app_version_rollout_outcomes"
+	StoreGestaltdInstanceHeartbeats     = "gestaltd_instance_heartbeats"
+	StoreAppVersionRecoveryObservations = "app_version_recovery_observations"
+	StoreRemoteRegistrations            = "remote_registrations"
+	StoreRemoteProviders                = "remote_providers"
 )
 
 var AppSHAsSchema = idb.ObjectStoreOptions{
@@ -99,6 +101,7 @@ var GestaltdSourceVersionStateSchema = idb.ObjectStoreOptions{
 	Columns: []idb.ColumnDef{
 		{Name: "id", Type: idb.TypeString, PrimaryKey: true},
 		{Name: "current_source_version", Type: idb.TypeString},
+		{Name: "minimum_healthy_instances", Type: idb.TypeInt},
 		{Name: "updated_at", Type: idb.TypeTime, NotNull: true},
 	},
 }
@@ -165,6 +168,39 @@ var AppVersionRolloutOutcomesSchema = idb.ObjectStoreOptions{
 		{Name: "version", Type: idb.TypeString, NotNull: true},
 		{Name: "completed_at", Type: idb.TypeTime},
 		{Name: "failed_at", Type: idb.TypeTime},
+	},
+}
+
+var GestaltdInstanceHeartbeatsSchema = idb.ObjectStoreOptions{
+	Indexes: []idb.IndexSchema{
+		{Name: "by_instance", KeyPath: []string{"instance_id"}, Unique: true},
+		{Name: "by_source_version", KeyPath: []string{"source_version"}},
+		{Name: "by_heartbeat_at", KeyPath: []string{"heartbeat_at"}},
+		{Name: "by_source_version_heartbeat_at", KeyPath: []string{"source_version", "heartbeat_at"}},
+	},
+	Columns: []idb.ColumnDef{
+		{Name: "id", Type: idb.TypeString, PrimaryKey: true},
+		{Name: "instance_id", Type: idb.TypeString, NotNull: true, Unique: true},
+		{Name: "source_version", Type: idb.TypeString, NotNull: true},
+		{Name: "started_at", Type: idb.TypeTime, NotNull: true},
+		{Name: "heartbeat_at", Type: idb.TypeTime, NotNull: true},
+		{Name: "apps", Type: idb.TypeJSON, NotNull: true},
+	},
+}
+
+var AppVersionRecoveryObservationsSchema = idb.ObjectStoreOptions{
+	Indexes: []idb.IndexSchema{
+		{Name: "by_app", KeyPath: []string{"app"}},
+		{Name: "by_app_version", KeyPath: []string{"app", "version"}},
+	},
+	Columns: []idb.ColumnDef{
+		{Name: "id", Type: idb.TypeString, PrimaryKey: true},
+		{Name: "app", Type: idb.TypeString, NotNull: true},
+		{Name: "version", Type: idb.TypeString, NotNull: true},
+		{Name: "recovered_at", Type: idb.TypeTime, NotNull: true},
+		{Name: "source_version", Type: idb.TypeString, NotNull: true},
+		{Name: "live_instances", Type: idb.TypeInt, NotNull: true},
+		{Name: "minimum_healthy_instances", Type: idb.TypeInt, NotNull: true},
 	},
 }
 

--- a/gestaltd/internal/coredata/services.go
+++ b/gestaltd/internal/coredata/services.go
@@ -9,18 +9,20 @@ import (
 )
 
 type Services struct {
-	Users                       *UserService
-	ExternalCredentials         core.ExternalCredentialProvider
-	ManagedSubjects             *ManagedSubjectService
-	AppVersionChangeRequests    *AppVersionChangeRequestService
-	AppVersionInstallLocks      *AppVersionInstallLockService
-	GestaltdSourceVersionState  *GestaltdSourceVersionService
-	AppRollouts                 *AppRolloutService
-	AppInstanceMaterializations *AppInstanceMaterializationService
-	AutoDeploySettings          *AutoDeploySettingsService
-	AppVersionRolloutOutcomes   *AppVersionRolloutOutcomeService
-	RemoteRegistrations         *RemoteRegistrationService
-	DB                          indexeddb.IndexedDB
+	Users                          *UserService
+	ExternalCredentials            core.ExternalCredentialProvider
+	ManagedSubjects                *ManagedSubjectService
+	AppVersionChangeRequests       *AppVersionChangeRequestService
+	AppVersionInstallLocks         *AppVersionInstallLockService
+	GestaltdSourceVersionState     *GestaltdSourceVersionService
+	AppRollouts                    *AppRolloutService
+	AppInstanceMaterializations    *AppInstanceMaterializationService
+	AutoDeploySettings             *AutoDeploySettingsService
+	AppVersionRolloutOutcomes      *AppVersionRolloutOutcomeService
+	GestaltdInstanceHeartbeats     *GestaltdInstanceHeartbeatService
+	AppVersionRecoveryObservations *AppVersionRecoveryObservationService
+	RemoteRegistrations            *RemoteRegistrationService
+	DB                             indexeddb.IndexedDB
 }
 
 // NewOptions configures coredata bootstrap behavior.
@@ -73,6 +75,12 @@ func NewWithOptions(ctx context.Context, ds indexeddb.IndexedDB, opts NewOptions
 		if _, err := ds.CreateObjectStore(ctx, StoreAppVersionRolloutOutcomes, AppVersionRolloutOutcomesSchema); err != nil {
 			return nil, fmt.Errorf("create app_version_rollout_outcomes store: %w", err)
 		}
+		if _, err := ds.CreateObjectStore(ctx, StoreGestaltdInstanceHeartbeats, GestaltdInstanceHeartbeatsSchema); err != nil {
+			return nil, fmt.Errorf("create gestaltd_instance_heartbeats store: %w", err)
+		}
+		if _, err := ds.CreateObjectStore(ctx, StoreAppVersionRecoveryObservations, AppVersionRecoveryObservationsSchema); err != nil {
+			return nil, fmt.Errorf("create app_version_recovery_observations store: %w", err)
+		}
 		if _, err := ds.CreateObjectStore(ctx, StoreRemoteRegistrations, RemoteRegistrationsSchema); err != nil {
 			return nil, fmt.Errorf("create remote_registrations store: %w", err)
 		}
@@ -91,20 +99,24 @@ func NewWithOptions(ctx context.Context, ds indexeddb.IndexedDB, opts NewOptions
 	appInstanceMaterializations := NewAppInstanceMaterializationService(ds)
 	autoDeploySettings := NewAutoDeploySettingsService(ds)
 	appVersionRolloutOutcomes := NewAppVersionRolloutOutcomeService(ds)
+	gestaltdInstanceHeartbeats := NewGestaltdInstanceHeartbeatService(ds)
+	appVersionRecoveryObservations := NewAppVersionRecoveryObservationService(ds)
 	remoteRegistrations := NewRemoteRegistrationService(ds)
 	return &Services{
-		ExternalCredentials:         nil,
-		Users:                       users,
-		ManagedSubjects:             managedSubjects,
-		AppVersionChangeRequests:    appVersionChangeRequests,
-		AppVersionInstallLocks:      appVersionInstallLocks,
-		GestaltdSourceVersionState:  gestaltdSourceVersions,
-		AppRollouts:                 appRollouts,
-		AppInstanceMaterializations: appInstanceMaterializations,
-		AutoDeploySettings:          autoDeploySettings,
-		AppVersionRolloutOutcomes:   appVersionRolloutOutcomes,
-		RemoteRegistrations:         remoteRegistrations,
-		DB:                          ds,
+		ExternalCredentials:            nil,
+		Users:                          users,
+		ManagedSubjects:                managedSubjects,
+		AppVersionChangeRequests:       appVersionChangeRequests,
+		AppVersionInstallLocks:         appVersionInstallLocks,
+		GestaltdSourceVersionState:     gestaltdSourceVersions,
+		AppRollouts:                    appRollouts,
+		AppInstanceMaterializations:    appInstanceMaterializations,
+		AutoDeploySettings:             autoDeploySettings,
+		AppVersionRolloutOutcomes:      appVersionRolloutOutcomes,
+		GestaltdInstanceHeartbeats:     gestaltdInstanceHeartbeats,
+		AppVersionRecoveryObservations: appVersionRecoveryObservations,
+		RemoteRegistrations:            remoteRegistrations,
+		DB:                             ds,
 	}, nil
 }
 
@@ -123,12 +135,32 @@ func ensureDeferredAppRegistryStores(ctx context.Context, ds indexeddb.IndexedDB
 	if err := ensureAppVersionRolloutOutcomesStore(ctx, ds); err != nil {
 		return err
 	}
+	if err := ensureGestaltdInstanceHeartbeatsStore(ctx, ds); err != nil {
+		return err
+	}
+	if err := ensureAppVersionRecoveryObservationsStore(ctx, ds); err != nil {
+		return err
+	}
 	return nil
 }
 
 func ensureAppAutoDeploySettingsStore(ctx context.Context, ds indexeddb.IndexedDB) error {
 	if _, err := ds.CreateObjectStore(ctx, StoreAppAutoDeploySettings, AppAutoDeploySettingsSchema); err != nil {
 		return fmt.Errorf("ensure app_auto_deploy_settings store: %w", err)
+	}
+	return nil
+}
+
+func ensureGestaltdInstanceHeartbeatsStore(ctx context.Context, ds indexeddb.IndexedDB) error {
+	if _, err := ds.CreateObjectStore(ctx, StoreGestaltdInstanceHeartbeats, GestaltdInstanceHeartbeatsSchema); err != nil {
+		return fmt.Errorf("ensure gestaltd_instance_heartbeats store: %w", err)
+	}
+	return nil
+}
+
+func ensureAppVersionRecoveryObservationsStore(ctx context.Context, ds indexeddb.IndexedDB) error {
+	if _, err := ds.CreateObjectStore(ctx, StoreAppVersionRecoveryObservations, AppVersionRecoveryObservationsSchema); err != nil {
+		return fmt.Errorf("ensure app_version_recovery_observations store: %w", err)
 	}
 	return nil
 }

--- a/gestaltd/internal/coredata/services_test.go
+++ b/gestaltd/internal/coredata/services_test.go
@@ -250,6 +250,8 @@ func TestNew(t *testing.T) {
 			coredata.StoreAppRollouts,
 			coredata.StoreAppAutoDeploySettings,
 			coredata.StoreAppVersionRolloutOutcomes,
+			coredata.StoreGestaltdInstanceHeartbeats,
+			coredata.StoreAppVersionRecoveryObservations,
 			coredata.StoreRemoteRegistrations,
 			coredata.StoreRemoteProviders,
 		} {
@@ -272,12 +274,14 @@ func TestNew(t *testing.T) {
 			t.Fatalf("coredata.NewWithOptions: %v", err)
 		}
 		contexts := db.createdStoreContexts()
-		if len(contexts) != 2 {
-			t.Fatalf("CreateObjectStore calls = %d, want 2", len(contexts))
+		if len(contexts) != 4 {
+			t.Fatalf("CreateObjectStore calls = %d, want 4", len(contexts))
 		}
 		for _, store := range []string{
 			coredata.StoreAppAutoDeploySettings,
 			coredata.StoreAppVersionRolloutOutcomes,
+			coredata.StoreGestaltdInstanceHeartbeats,
+			coredata.StoreAppVersionRecoveryObservations,
 		} {
 			if _, ok := contexts[store]; !ok {
 				t.Fatalf("CreateObjectStore calls = %v, want %q", contexts, store)

--- a/gestaltd/internal/server/handlers_activate.go
+++ b/gestaltd/internal/server/handlers_activate.go
@@ -20,19 +20,19 @@ func (s *Server) activateAppProvidersHandler(w http.ResponseWriter, r *http.Requ
 		writeError(w, http.StatusBadRequest, "retry must be true when provided")
 		return
 	}
-	minimumHealthyInstances := 0
+	var minimumHealthyInstances []int
 	if query.Has("minimum_healthy_instances") {
 		values := query["minimum_healthy_instances"]
 		if len(values) != 1 {
 			writeError(w, http.StatusBadRequest, "minimum_healthy_instances must be provided once")
 			return
 		}
-		var err error
-		minimumHealthyInstances, err = strconv.Atoi(strings.TrimSpace(values[0]))
-		if err != nil || minimumHealthyInstances <= 0 {
+		minimumHealthy, err := strconv.Atoi(strings.TrimSpace(values[0]))
+		if err != nil || minimumHealthy <= 0 {
 			writeError(w, http.StatusBadRequest, "minimum_healthy_instances must be a positive integer")
 			return
 		}
+		minimumHealthyInstances = []int{minimumHealthy}
 	}
 	if s.sourceVersion != "" {
 		expectedSourceVersion := strings.TrimSpace(query.Get("source_version"))
@@ -55,7 +55,7 @@ func (s *Server) activateAppProvidersHandler(w http.ResponseWriter, r *http.Requ
 			retryParam == "true",
 			appregistry.DefaultRolloutEnrollmentWindow,
 			appregistry.DefaultRolloutTimeout,
-			minimumHealthyInstances,
+			minimumHealthyInstances...,
 		)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())

--- a/gestaltd/internal/server/handlers_activate.go
+++ b/gestaltd/internal/server/handlers_activate.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
@@ -13,13 +14,28 @@ func (s *Server) mountActivateRoute(r chi.Router) {
 }
 
 func (s *Server) activateAppProvidersHandler(w http.ResponseWriter, r *http.Request) {
-	retryParam := strings.TrimSpace(r.URL.Query().Get("retry"))
+	query := r.URL.Query()
+	retryParam := strings.TrimSpace(query.Get("retry"))
 	if retryParam != "" && retryParam != "true" {
 		writeError(w, http.StatusBadRequest, "retry must be true when provided")
 		return
 	}
+	minimumHealthyInstances := 0
+	if query.Has("minimum_healthy_instances") {
+		values := query["minimum_healthy_instances"]
+		if len(values) != 1 {
+			writeError(w, http.StatusBadRequest, "minimum_healthy_instances must be provided once")
+			return
+		}
+		var err error
+		minimumHealthyInstances, err = strconv.Atoi(strings.TrimSpace(values[0]))
+		if err != nil || minimumHealthyInstances <= 0 {
+			writeError(w, http.StatusBadRequest, "minimum_healthy_instances must be a positive integer")
+			return
+		}
+	}
 	if s.sourceVersion != "" {
-		expectedSourceVersion := strings.TrimSpace(r.URL.Query().Get("source_version"))
+		expectedSourceVersion := strings.TrimSpace(query.Get("source_version"))
 		if expectedSourceVersion == "" {
 			writeError(w, http.StatusBadRequest, "source_version is required")
 			return
@@ -39,6 +55,7 @@ func (s *Server) activateAppProvidersHandler(w http.ResponseWriter, r *http.Requ
 			retryParam == "true",
 			appregistry.DefaultRolloutEnrollmentWindow,
 			appregistry.DefaultRolloutTimeout,
+			minimumHealthyInstances,
 		)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())

--- a/gestaltd/internal/server/handlers_activate_test.go
+++ b/gestaltd/internal/server/handlers_activate_test.go
@@ -213,3 +213,43 @@ func TestActivateEndpointValidatesMinimumHealthyInstances(t *testing.T) {
 		}
 	}
 }
+
+func TestActivateEndpointPreservesMinimumWhenRetryOmitsParameter(t *testing.T) {
+	t.Parallel()
+
+	var services *coredata.Services
+	start := time.Date(2026, 7, 30, 18, 0, 0, 0, time.UTC)
+	srv := newTestServer(t, func(cfg *server.Config) {
+		cfg.SourceVersion = "source-a"
+		cfg.Now = func() time.Time { return start.Add(time.Minute) }
+		services = cfg.Services
+		if _, err := services.GestaltdSourceVersionState.Activate(
+			context.Background(),
+			"source-a",
+			start,
+			false,
+			appregistry.DefaultRolloutEnrollmentWindow,
+			appregistry.DefaultRolloutTimeout,
+			5,
+		); err != nil {
+			t.Fatalf("seed source version: %v", err)
+		}
+	})
+	testutil.CloseOnCleanup(t, srv)
+
+	resp, err := http.Post(srv.URL+"/activate?source_version=source-a&retry=true", "", nil)
+	if err != nil {
+		t.Fatalf("POST /activate: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	state, err := services.GestaltdSourceVersionState.Get(context.Background())
+	if err != nil {
+		t.Fatalf("Get source version state: %v", err)
+	}
+	if state.MinimumHealthyInstances != 5 {
+		t.Fatalf("minimum healthy instances = %d, want 5", state.MinimumHealthyInstances)
+	}
+}

--- a/gestaltd/internal/server/handlers_activate_test.go
+++ b/gestaltd/internal/server/handlers_activate_test.go
@@ -120,7 +120,7 @@ func TestActivateEndpointPromotesSourceVersionAndRetargetsRollout(t *testing.T) 
 	})
 	testutil.CloseOnCleanup(t, srv)
 
-	resp, err := http.Post(srv.URL+"/activate?source_version=source-new", "", nil)
+	resp, err := http.Post(srv.URL+"/activate?source_version=source-new&minimum_healthy_instances=5", "", nil)
 	if err != nil {
 		t.Fatalf("POST /activate: %v", err)
 	}
@@ -141,6 +141,13 @@ func TestActivateEndpointPromotesSourceVersionAndRetargetsRollout(t *testing.T) 
 	}
 	if current != "source-new" {
 		t.Fatalf("current source version = %q, want source-new", current)
+	}
+	state, err := services.GestaltdSourceVersionState.Get(context.Background())
+	if err != nil {
+		t.Fatalf("Get source version state: %v", err)
+	}
+	if state.MinimumHealthyInstances != 5 {
+		t.Fatalf("minimum healthy instances = %d, want 5", state.MinimumHealthyInstances)
 	}
 	if calls.Load() != 1 {
 		t.Fatalf("activation calls = %d, want 1", calls.Load())
@@ -186,5 +193,23 @@ func TestActivateEndpointRejectsInvalidRetry(t *testing.T) {
 	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+func TestActivateEndpointValidatesMinimumHealthyInstances(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServer(t)
+	testutil.CloseOnCleanup(t, srv)
+
+	for _, value := range []string{"", "0", "-1", "1.5", "many&minimum_healthy_instances=2"} {
+		resp, err := http.Post(srv.URL+"/activate?minimum_healthy_instances="+value, "", nil)
+		if err != nil {
+			t.Fatalf("POST /activate with %q: %v", value, err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("minimum_healthy_instances=%q status = %d, want %d", value, resp.StatusCode, http.StatusBadRequest)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- add persisted per-instance heartbeat and app-version recovery observation stores and services
- record minimum healthy capacity with source-version activation while preserving compatibility for omitted values
- add heartbeat rollout configuration, safe defaults, and activation API support

## Test plan
- [x] `go test ./...` from `gestaltd`
- [x] `gofmt`
- [x] `git diff --check`

Made with [Cursor](https://cursor.com)