### PR TITLE
Publish runtime heartbeats and project fleet health

### DIFF
--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -87,6 +87,38 @@ type GestaltdInstanceHeartbeat struct {
 	Apps          map[string]GestaltdInstanceAppHeartbeat
 }
 
+// RegistryAppRuntimeObservation is a coherent, local-only observation of a
+// configured registry app. DesiredVersion and ObservedAt are added by the
+// heartbeat writer because they come from coredata and the writer's clock.
+type RegistryAppRuntimeObservation struct {
+	State          GestaltdInstanceAppState
+	RunningVersion string
+	LastError      string
+}
+
+type AppFleetState string
+
+const (
+	AppFleetStateHealthy    AppFleetState = "healthy"
+	AppFleetStateConverging AppFleetState = "converging"
+	AppFleetStateDegraded   AppFleetState = "degraded"
+	AppFleetStateUnknown    AppFleetState = "unknown"
+)
+
+type AppFleetProjection struct {
+	App                     string
+	State                   AppFleetState
+	SourceVersion           string
+	DesiredVersion          string
+	MinimumHealthyInstances int
+	LiveInstances           int
+	RunningDesiredVersion   int
+	Mismatched              int
+	Errors                  int
+	HeartbeatTTL            time.Duration
+	EvaluatedAt             time.Time
+}
+
 type AppRolloutState string
 
 const (

--- a/gestaltd/internal/appregistry/fleet_state.go
+++ b/gestaltd/internal/appregistry/fleet_state.go
@@ -1,0 +1,193 @@
+package appregistry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
+)
+
+type FleetChangeRequests interface {
+	ListKnownVersionsByApp(context.Context, string) ([]*core.AppInstallation, error)
+}
+
+type FleetSourceVersions interface {
+	Get(context.Context) (*core.GestaltdSourceVersionState, error)
+}
+
+type FleetHeartbeats interface {
+	ListFreshBySourceVersion(context.Context, string, time.Time) ([]*core.GestaltdInstanceHeartbeat, error)
+}
+
+type FleetRollouts interface {
+	Get(context.Context, string) (*core.AppRollout, error)
+}
+
+type FleetProjector struct {
+	ChangeRequests FleetChangeRequests
+	SourceVersions FleetSourceVersions
+	Heartbeats     FleetHeartbeats
+	Rollouts       FleetRollouts
+	HeartbeatTTL   time.Duration
+	Now            func() time.Time
+}
+
+func (p *FleetProjector) Project(ctx context.Context, app string) (*core.AppFleetProjection, error) {
+	if p == nil || p.ChangeRequests == nil || p.SourceVersions == nil || p.Heartbeats == nil {
+		return nil, fmt.Errorf("fleet projector is not configured")
+	}
+	app = strings.TrimSpace(app)
+	if app == "" {
+		return nil, fmt.Errorf("fleet projector: app is required")
+	}
+	now := p.now()
+	ttl := p.HeartbeatTTL
+	if ttl <= 0 {
+		return nil, fmt.Errorf("fleet projector: heartbeat TTL must be positive")
+	}
+	known, err := p.ChangeRequests.ListKnownVersionsByApp(ctx, app)
+	if err != nil {
+		return nil, fmt.Errorf("project fleet state: load desired version: %w", err)
+	}
+	desiredVersion := coredata.LatestKnownVersion(known)
+
+	sourceState, err := p.SourceVersions.Get(ctx)
+	if err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			projection := EvaluateFleetState(FleetEvaluation{
+				App:            app,
+				DesiredVersion: desiredVersion,
+				Cutoff:         now.Add(-ttl),
+				EvaluatedAt:    now,
+			})
+			projection.HeartbeatTTL = ttl
+			return &projection, nil
+		}
+		return nil, fmt.Errorf("project fleet state: load source version: %w", err)
+	}
+	sourceVersion := strings.TrimSpace(sourceState.CurrentSourceVersion)
+	minimum := sourceState.MinimumHealthyInstances
+	var heartbeats []*core.GestaltdInstanceHeartbeat
+	if sourceVersion != "" {
+		heartbeats, err = p.Heartbeats.ListFreshBySourceVersion(ctx, sourceVersion, now.Add(-ttl))
+		if err != nil {
+			return nil, fmt.Errorf("project fleet state: load fresh heartbeats: %w", err)
+		}
+	}
+	var rollout *core.AppRollout
+	if p.Rollouts != nil {
+		rollout, err = p.Rollouts.Get(ctx, app)
+		if err != nil && !errors.Is(err, core.ErrNotFound) {
+			return nil, fmt.Errorf("project fleet state: load active rollout: %w", err)
+		}
+		if errors.Is(err, core.ErrNotFound) {
+			rollout = nil
+		}
+	}
+	projection := EvaluateFleetState(FleetEvaluation{
+		App:                     app,
+		DesiredVersion:          desiredVersion,
+		SourceVersion:           sourceVersion,
+		MinimumHealthyInstances: minimum,
+		Cutoff:                  now.Add(-ttl),
+		EvaluatedAt:             now,
+		Heartbeats:              heartbeats,
+		ActiveRollout:           rollout,
+	})
+	projection.HeartbeatTTL = ttl
+	return &projection, nil
+}
+
+type FleetEvaluation struct {
+	App                     string
+	DesiredVersion          string
+	SourceVersion           string
+	MinimumHealthyInstances int
+	Cutoff                  time.Time
+	EvaluatedAt             time.Time
+	Heartbeats              []*core.GestaltdInstanceHeartbeat
+	ActiveRollout           *core.AppRollout
+}
+
+// EvaluateFleetState is the pure projection used by current fleet-state reads.
+// Its explicit source, minimum, and cutoff inputs also allow a future rollout
+// evaluator to use values snapshotted at rollout admission.
+func EvaluateFleetState(input FleetEvaluation) core.AppFleetProjection {
+	app := strings.TrimSpace(input.App)
+	desiredVersion := strings.TrimSpace(input.DesiredVersion)
+	sourceVersion := strings.TrimSpace(input.SourceVersion)
+	evaluatedAt := input.EvaluatedAt.UTC()
+	projection := core.AppFleetProjection{
+		App:                     app,
+		State:                   core.AppFleetStateUnknown,
+		SourceVersion:           sourceVersion,
+		DesiredVersion:          desiredVersion,
+		MinimumHealthyInstances: input.MinimumHealthyInstances,
+		EvaluatedAt:             evaluatedAt,
+	}
+	if !input.Cutoff.IsZero() && !evaluatedAt.IsZero() {
+		projection.HeartbeatTTL = evaluatedAt.Sub(input.Cutoff.UTC())
+	}
+
+	for _, heartbeat := range input.Heartbeats {
+		if heartbeat == nil ||
+			strings.TrimSpace(heartbeat.SourceVersion) != sourceVersion ||
+			heartbeat.HeartbeatAt.Before(input.Cutoff) {
+			continue
+		}
+		projection.LiveInstances++
+		observation, ok := heartbeat.Apps[app]
+		if !ok {
+			projection.Errors++
+			continue
+		}
+		if observation.State == core.GestaltdInstanceAppStateRunning &&
+			strings.TrimSpace(observation.RunningVersion) == desiredVersion &&
+			desiredVersion != "" {
+			projection.RunningDesiredVersion++
+			continue
+		}
+		switch observation.State {
+		case core.GestaltdInstanceAppStateError, core.GestaltdInstanceAppStateUnknown:
+			projection.Errors++
+		default:
+			projection.Mismatched++
+		}
+	}
+
+	validBasis := desiredVersion != "" && sourceVersion != "" && input.MinimumHealthyInstances > 0
+	switch {
+	case !validBasis || projection.LiveInstances < input.MinimumHealthyInstances:
+		projection.State = core.AppFleetStateUnknown
+	case projection.RunningDesiredVersion == projection.LiveInstances:
+		projection.State = core.AppFleetStateHealthy
+	default:
+		projection.State = core.AppFleetStateDegraded
+	}
+	if validBasis && projection.State != core.AppFleetStateHealthy && rolloutMatches(input.ActiveRollout, app, desiredVersion, sourceVersion, evaluatedAt) {
+		projection.State = core.AppFleetStateConverging
+	}
+	return projection
+}
+
+func rolloutMatches(rollout *core.AppRollout, app, version, sourceVersion string, now time.Time) bool {
+	if rollout == nil ||
+		(rollout.State != core.AppRolloutStateEnrolling && rollout.State != core.AppRolloutStateRestarting) {
+		return false
+	}
+	return strings.TrimSpace(rollout.App) == app &&
+		strings.TrimSpace(rollout.Version) == version &&
+		strings.TrimSpace(rollout.TargetSourceVersion) == sourceVersion &&
+		rollout.Deadline.After(now)
+}
+
+func (p *FleetProjector) now() time.Time {
+	if p.Now != nil {
+		return p.Now().UTC()
+	}
+	return time.Now().UTC()
+}

--- a/gestaltd/internal/appregistry/fleet_state_test.go
+++ b/gestaltd/internal/appregistry/fleet_state_test.go
@@ -1,0 +1,194 @@
+package appregistry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+)
+
+func TestEvaluateFleetState(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	cutoff := now.Add(-45 * time.Second)
+	healthy := func(id string, at time.Time) *core.GestaltdInstanceHeartbeat {
+		return heartbeatForFleet(id, "source", at, map[string]core.GestaltdInstanceAppHeartbeat{
+			"app": {State: core.GestaltdInstanceAppStateRunning, RunningVersion: "v2"},
+		})
+	}
+	activeRollout := &core.AppRollout{
+		App:                 "app",
+		Version:             "v2",
+		State:               core.AppRolloutStateRestarting,
+		TargetSourceVersion: "source",
+		Deadline:            now.Add(time.Minute),
+	}
+
+	tests := []struct {
+		name       string
+		minimum    int
+		heartbeats []*core.GestaltdInstanceHeartbeat
+		rollout    *core.AppRollout
+		wantState  core.AppFleetState
+		wantLive   int
+		wantRun    int
+		wantMis    int
+		wantErrors int
+	}{
+		{
+			name:    "source filtering and TTL boundary",
+			minimum: 1,
+			heartbeats: []*core.GestaltdInstanceHeartbeat{
+				healthy("boundary", cutoff),
+				heartbeatForFleet("old-source", "old", now, map[string]core.GestaltdInstanceAppHeartbeat{}),
+				healthy("stale", cutoff.Add(-time.Nanosecond)),
+			},
+			wantState: core.AppFleetStateHealthy,
+			wantLive:  1,
+			wantRun:   1,
+		},
+		{
+			name:       "insufficient capacity",
+			minimum:    2,
+			heartbeats: []*core.GestaltdInstanceHeartbeat{healthy("one", now)},
+			wantState:  core.AppFleetStateUnknown,
+			wantLive:   1,
+			wantRun:    1,
+		},
+		{
+			name:    "missing app observation",
+			minimum: 1,
+			heartbeats: []*core.GestaltdInstanceHeartbeat{
+				heartbeatForFleet("missing", "source", now, map[string]core.GestaltdInstanceAppHeartbeat{}),
+			},
+			wantState:  core.AppFleetStateDegraded,
+			wantLive:   1,
+			wantErrors: 1,
+		},
+		{
+			name:    "version mismatch and runtime error",
+			minimum: 2,
+			heartbeats: []*core.GestaltdInstanceHeartbeat{
+				heartbeatForFleet("mismatch", "source", now, map[string]core.GestaltdInstanceAppHeartbeat{
+					"app": {State: core.GestaltdInstanceAppStateRunning, RunningVersion: "v1"},
+				}),
+				heartbeatForFleet("error", "source", now, map[string]core.GestaltdInstanceAppHeartbeat{
+					"app": {State: core.GestaltdInstanceAppStateError, LastError: "failed"},
+				}),
+			},
+			wantState:  core.AppFleetStateDegraded,
+			wantLive:   2,
+			wantMis:    1,
+			wantErrors: 1,
+		},
+		{
+			name:       "autoscaling requires every replica healthy",
+			minimum:    2,
+			heartbeats: []*core.GestaltdInstanceHeartbeat{healthy("one", now), healthy("two", now), healthy("three", now)},
+			wantState:  core.AppFleetStateHealthy,
+			wantLive:   3,
+			wantRun:    3,
+		},
+		{
+			name:    "matching active rollout overlays converging",
+			minimum: 1,
+			heartbeats: []*core.GestaltdInstanceHeartbeat{
+				heartbeatForFleet("mismatch", "source", now, map[string]core.GestaltdInstanceAppHeartbeat{
+					"app": {State: core.GestaltdInstanceAppStateRunning, RunningVersion: "v1"},
+				}),
+			},
+			rollout:   activeRollout,
+			wantState: core.AppFleetStateConverging,
+			wantLive:  1,
+			wantMis:   1,
+		},
+		{
+			name:    "expired rollout does not overlay",
+			minimum: 1,
+			heartbeats: []*core.GestaltdInstanceHeartbeat{
+				heartbeatForFleet("mismatch", "source", now, map[string]core.GestaltdInstanceAppHeartbeat{
+					"app": {State: core.GestaltdInstanceAppStateRunning, RunningVersion: "v1"},
+				}),
+			},
+			rollout: &core.AppRollout{
+				App:                 "app",
+				Version:             "v2",
+				State:               core.AppRolloutStateRestarting,
+				TargetSourceVersion: "source",
+				Deadline:            now,
+			},
+			wantState: core.AppFleetStateDegraded,
+			wantLive:  1,
+			wantMis:   1,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := EvaluateFleetState(FleetEvaluation{
+				App:                     "app",
+				DesiredVersion:          "v2",
+				SourceVersion:           "source",
+				MinimumHealthyInstances: tc.minimum,
+				Cutoff:                  cutoff,
+				EvaluatedAt:             now,
+				Heartbeats:              tc.heartbeats,
+				ActiveRollout:           tc.rollout,
+			})
+			if got.State != tc.wantState ||
+				got.LiveInstances != tc.wantLive ||
+				got.RunningDesiredVersion != tc.wantRun ||
+				got.Mismatched != tc.wantMis ||
+				got.Errors != tc.wantErrors {
+				t.Fatalf("projection = %#v", got)
+			}
+		})
+	}
+}
+
+func TestEvaluateFleetStateRequiresDesiredSourceAndMinimum(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+	for _, tc := range []struct {
+		name    string
+		version string
+		source  string
+		minimum int
+	}{
+		{name: "missing desired", source: "source", minimum: 1},
+		{name: "missing source", version: "v2", minimum: 1},
+		{name: "missing minimum", version: "v2", source: "source"},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := EvaluateFleetState(FleetEvaluation{
+				App:                     "app",
+				DesiredVersion:          tc.version,
+				SourceVersion:           tc.source,
+				MinimumHealthyInstances: tc.minimum,
+				Cutoff:                  now.Add(-time.Minute),
+				EvaluatedAt:             now,
+			})
+			if got.State != core.AppFleetStateUnknown {
+				t.Fatalf("state = %q, want unknown", got.State)
+			}
+		})
+	}
+}
+
+func heartbeatForFleet(
+	instanceID string,
+	sourceVersion string,
+	heartbeatAt time.Time,
+	apps map[string]core.GestaltdInstanceAppHeartbeat,
+) *core.GestaltdInstanceHeartbeat {
+	return &core.GestaltdInstanceHeartbeat{
+		InstanceID:    instanceID,
+		SourceVersion: sourceVersion,
+		HeartbeatAt:   heartbeatAt,
+		Apps:          apps,
+	}
+}

--- a/gestaltd/internal/appregistry/heartbeat_writer.go
+++ b/gestaltd/internal/appregistry/heartbeat_writer.go
@@ -1,0 +1,257 @@
+package appregistry
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
+)
+
+type HeartbeatService interface {
+	Upsert(context.Context, *core.GestaltdInstanceHeartbeat) (*core.GestaltdInstanceHeartbeat, error)
+	PruneBefore(context.Context, time.Time) (int, error)
+}
+
+type HeartbeatChangeRequests interface {
+	ListAllKnownVersions(context.Context) ([]*core.AppInstallation, error)
+}
+
+type RuntimeSnapshotter interface {
+	SnapshotRegistryApps() map[string]core.RegistryAppRuntimeObservation
+}
+
+type HeartbeatWriter struct {
+	Heartbeats     HeartbeatService
+	ChangeRequests HeartbeatChangeRequests
+	ConfiguredApps map[string]*config.ProviderEntry
+	Runtime        RuntimeSnapshotter
+	InstanceID     string
+	SourceVersion  string
+	Ready          <-chan struct{}
+	Interval       time.Duration
+	Retention      time.Duration
+	Now            func() time.Time
+	NewTicker      func(time.Duration) (<-chan time.Time, func())
+
+	startOnce sync.Once
+	stateMu   sync.Mutex
+	cancel    context.CancelFunc
+	done      chan struct{}
+	startedAt time.Time
+	nextPrune time.Time
+	passMu    sync.Mutex
+}
+
+type HeartbeatWriterConfig struct {
+	Heartbeats     HeartbeatService
+	ChangeRequests HeartbeatChangeRequests
+	ConfiguredApps map[string]*config.ProviderEntry
+	Runtime        RuntimeSnapshotter
+	InstanceID     string
+	SourceVersion  string
+	Ready          <-chan struct{}
+	Interval       time.Duration
+	Retention      time.Duration
+	Now            func() time.Time
+	NewTicker      func(time.Duration) (<-chan time.Time, func())
+}
+
+func NewHeartbeatWriter(cfg HeartbeatWriterConfig) *HeartbeatWriter {
+	return &HeartbeatWriter{
+		Heartbeats:     cfg.Heartbeats,
+		ChangeRequests: cfg.ChangeRequests,
+		ConfiguredApps: cfg.ConfiguredApps,
+		Runtime:        cfg.Runtime,
+		InstanceID:     strings.TrimSpace(cfg.InstanceID),
+		SourceVersion:  strings.TrimSpace(cfg.SourceVersion),
+		Ready:          cfg.Ready,
+		Interval:       cfg.Interval,
+		Retention:      cfg.Retention,
+		Now:            cfg.Now,
+		NewTicker:      cfg.NewTicker,
+	}
+}
+
+func (w *HeartbeatWriter) Start(ctx context.Context) {
+	if w == nil || w.Heartbeats == nil || w.ChangeRequests == nil || w.Runtime == nil {
+		return
+	}
+	w.startOnce.Do(func() {
+		if w.InstanceID == "" {
+			w.InstanceID = ResolveInstanceID()
+		}
+		loopCtx, cancel := context.WithCancel(ctx)
+		w.stateMu.Lock()
+		w.cancel = cancel
+		w.done = make(chan struct{})
+		// started_at is the heartbeat subsystem start, not an operating-system
+		// process birth time. No reliable process-start source exists here.
+		w.startedAt = w.now()
+		w.stateMu.Unlock()
+		go func() {
+			defer close(w.done)
+			w.loop(loopCtx)
+		}()
+	})
+}
+
+func (w *HeartbeatWriter) Stop() {
+	if w == nil {
+		return
+	}
+	w.stateMu.Lock()
+	cancel := w.cancel
+	done := w.done
+	w.stateMu.Unlock()
+	if cancel == nil || done == nil {
+		return
+	}
+	cancel()
+	<-done
+}
+
+func (w *HeartbeatWriter) loop(ctx context.Context) {
+	if w.Ready != nil {
+		select {
+		case <-ctx.Done():
+			return
+		case <-w.Ready:
+		}
+	}
+	w.writeAndLog(ctx)
+	ticks, stop := w.newTicker(w.interval())
+	defer stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticks:
+			w.writeAndLog(ctx)
+		}
+	}
+}
+
+func (w *HeartbeatWriter) writeAndLog(ctx context.Context) {
+	if err := w.WriteOnce(ctx); err != nil && ctx.Err() == nil {
+		slog.Warn("runtime heartbeat write failed", "instance_id", w.InstanceID, "error", err)
+	}
+}
+
+func (w *HeartbeatWriter) WriteOnce(ctx context.Context) error {
+	if w == nil || w.Heartbeats == nil || w.ChangeRequests == nil || w.Runtime == nil {
+		return fmt.Errorf("runtime heartbeat writer is not configured")
+	}
+	if w.InstanceID == "" || w.SourceVersion == "" {
+		return fmt.Errorf("runtime heartbeat writer requires instance id and source version")
+	}
+	w.passMu.Lock()
+	defer w.passMu.Unlock()
+
+	now := w.now()
+	w.stateMu.Lock()
+	if w.startedAt.IsZero() {
+		w.startedAt = now
+	}
+	startedAt := w.startedAt
+	w.stateMu.Unlock()
+
+	known, err := w.ChangeRequests.ListAllKnownVersions(ctx)
+	if err != nil {
+		return fmt.Errorf("list desired app versions: %w", err)
+	}
+	desiredByApp := make(map[string]string)
+	knownByApp := make(map[string][]*core.AppInstallation)
+	for _, installation := range known {
+		if installation == nil {
+			continue
+		}
+		app := strings.TrimSpace(installation.AppName)
+		knownByApp[app] = append(knownByApp[app], installation)
+	}
+	for app, installations := range knownByApp {
+		desiredByApp[app] = coredata.LatestKnownVersion(installations)
+	}
+
+	runtime := w.Runtime.SnapshotRegistryApps()
+	apps := make(map[string]core.GestaltdInstanceAppHeartbeat)
+	for app, entry := range w.ConfiguredApps {
+		if entry == nil || !entry.Source.IsRegistry() {
+			continue
+		}
+		observation, ok := runtime[app]
+		if !ok {
+			observation = core.RegistryAppRuntimeObservation{
+				State:     core.GestaltdInstanceAppStateUnknown,
+				LastError: "configured registry app was absent from runtime snapshot",
+			}
+		}
+		apps[app] = core.GestaltdInstanceAppHeartbeat{
+			State:          observation.State,
+			DesiredVersion: desiredByApp[app],
+			RunningVersion: observation.RunningVersion,
+			ObservedAt:     now,
+			LastError:      observation.LastError,
+		}
+	}
+	if _, err := w.Heartbeats.Upsert(ctx, &core.GestaltdInstanceHeartbeat{
+		InstanceID:    w.InstanceID,
+		SourceVersion: w.SourceVersion,
+		StartedAt:     startedAt,
+		HeartbeatAt:   now,
+		Apps:          apps,
+	}); err != nil {
+		return fmt.Errorf("upsert runtime heartbeat: %w", err)
+	}
+
+	if w.Retention > 0 && w.pruneDue(now) {
+		if _, err := w.Heartbeats.PruneBefore(ctx, now.Add(-w.Retention)); err != nil {
+			return fmt.Errorf("prune runtime heartbeats: %w", err)
+		}
+	}
+	return nil
+}
+
+func (w *HeartbeatWriter) pruneDue(now time.Time) bool {
+	w.stateMu.Lock()
+	defer w.stateMu.Unlock()
+	if !w.nextPrune.IsZero() && now.Before(w.nextPrune) {
+		return false
+	}
+	cadence := w.Retention / 4
+	if cadence <= 0 || cadence > time.Hour {
+		cadence = time.Hour
+	}
+	if cadence < w.interval() {
+		cadence = w.interval()
+	}
+	w.nextPrune = now.Add(cadence)
+	return true
+}
+
+func (w *HeartbeatWriter) interval() time.Duration {
+	if w.Interval > 0 {
+		return w.Interval
+	}
+	return config.DefaultAppRegistryHeartbeatInterval
+}
+
+func (w *HeartbeatWriter) now() time.Time {
+	if w.Now != nil {
+		return w.Now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func (w *HeartbeatWriter) newTicker(interval time.Duration) (<-chan time.Time, func()) {
+	if w.NewTicker != nil {
+		return w.NewTicker(interval)
+	}
+	ticker := time.NewTicker(interval)
+	return ticker.C, ticker.Stop
+}

--- a/gestaltd/internal/appregistry/heartbeat_writer_test.go
+++ b/gestaltd/internal/appregistry/heartbeat_writer_test.go
@@ -1,0 +1,213 @@
+package appregistry
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+)
+
+type recordingHeartbeatService struct {
+	mu        sync.Mutex
+	attempts  int
+	failures  int
+	writes    []*core.GestaltdInstanceHeartbeat
+	pruneCuts []time.Time
+}
+
+func (s *recordingHeartbeatService) Upsert(_ context.Context, heartbeat *core.GestaltdInstanceHeartbeat) (*core.GestaltdInstanceHeartbeat, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.attempts++
+	if s.failures > 0 {
+		s.failures--
+		return nil, errors.New("write failed")
+	}
+	copy := *heartbeat
+	copy.Apps = make(map[string]core.GestaltdInstanceAppHeartbeat, len(heartbeat.Apps))
+	for app, observation := range heartbeat.Apps {
+		copy.Apps[app] = observation
+	}
+	s.writes = append(s.writes, &copy)
+	return &copy, nil
+}
+
+func (s *recordingHeartbeatService) PruneBefore(_ context.Context, cutoff time.Time) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pruneCuts = append(s.pruneCuts, cutoff)
+	return 0, nil
+}
+
+func (s *recordingHeartbeatService) counts() (int, int, int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.attempts, len(s.writes), len(s.pruneCuts)
+}
+
+type staticHeartbeatChanges struct {
+	known []*core.AppInstallation
+}
+
+func (s staticHeartbeatChanges) ListAllKnownVersions(context.Context) ([]*core.AppInstallation, error) {
+	return s.known, nil
+}
+
+type staticRuntimeSnapshot map[string]core.RegistryAppRuntimeObservation
+
+func (s staticRuntimeSnapshot) SnapshotRegistryApps() map[string]core.RegistryAppRuntimeObservation {
+	return s
+}
+
+type testHeartbeatClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (c *testHeartbeatClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *testHeartbeatClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	c.now = c.now.Add(d)
+	c.mu.Unlock()
+}
+
+func TestHeartbeatWriterWaitsForReadyThenWritesImmediatelyAndPeriodically(t *testing.T) {
+	t.Parallel()
+	ready := make(chan struct{})
+	ticks := make(chan time.Time, 2)
+	service := &recordingHeartbeatService{}
+	clock := &testHeartbeatClock{now: time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)}
+	writer := NewHeartbeatWriter(HeartbeatWriterConfig{
+		Heartbeats:     service,
+		ChangeRequests: staticHeartbeatChanges{},
+		ConfiguredApps: map[string]*config.ProviderEntry{"app": {Source: config.ProviderSource{Registry: "toolshed"}}},
+		Runtime:        staticRuntimeSnapshot{"app": {State: core.GestaltdInstanceAppStateNotRunning}},
+		InstanceID:     "instance",
+		SourceVersion:  "source",
+		Ready:          ready,
+		Interval:       15 * time.Second,
+		Retention:      24 * time.Hour,
+		Now:            clock.Now,
+		NewTicker: func(interval time.Duration) (<-chan time.Time, func()) {
+			if interval != 15*time.Second {
+				t.Fatalf("ticker interval = %v", interval)
+			}
+			return ticks, func() {}
+		},
+	})
+	writer.Start(context.Background())
+	t.Cleanup(writer.Stop)
+
+	time.Sleep(20 * time.Millisecond)
+	if attempts, _, _ := service.counts(); attempts != 0 {
+		t.Fatalf("attempts before ready = %d, want 0", attempts)
+	}
+	close(ready)
+	waitForHeartbeatCounts(t, service, 1, 1)
+
+	clock.Advance(15 * time.Second)
+	ticks <- clock.Now()
+	waitForHeartbeatCounts(t, service, 2, 2)
+	writer.Stop()
+}
+
+func TestHeartbeatWriterRetriesAfterFailedWriteAndPrunesCoarsely(t *testing.T) {
+	t.Parallel()
+	ready := make(chan struct{})
+	close(ready)
+	ticks := make(chan time.Time, 3)
+	service := &recordingHeartbeatService{failures: 1}
+	clock := &testHeartbeatClock{now: time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)}
+	writer := NewHeartbeatWriter(HeartbeatWriterConfig{
+		Heartbeats:     service,
+		ChangeRequests: staticHeartbeatChanges{},
+		ConfiguredApps: map[string]*config.ProviderEntry{},
+		Runtime:        staticRuntimeSnapshot{},
+		InstanceID:     "instance",
+		SourceVersion:  "source",
+		Ready:          ready,
+		Interval:       15 * time.Second,
+		Retention:      24 * time.Hour,
+		Now:            clock.Now,
+		NewTicker: func(time.Duration) (<-chan time.Time, func()) {
+			return ticks, func() {}
+		},
+	})
+	writer.Start(context.Background())
+	t.Cleanup(writer.Stop)
+	waitForHeartbeatCounts(t, service, 1, 0)
+
+	clock.Advance(15 * time.Second)
+	ticks <- clock.Now()
+	waitForHeartbeatCounts(t, service, 2, 1)
+	_, _, prunes := service.counts()
+	if prunes != 1 {
+		t.Fatalf("prunes after successful retry = %d, want 1", prunes)
+	}
+
+	clock.Advance(15 * time.Second)
+	ticks <- clock.Now()
+	waitForHeartbeatCounts(t, service, 3, 2)
+	_, _, prunes = service.counts()
+	if prunes != 1 {
+		t.Fatalf("prunes on next heartbeat = %d, want coarse cadence", prunes)
+	}
+}
+
+func TestHeartbeatWriterWritesRegistryAppsWithOneDesiredVersionLoad(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	service := &recordingHeartbeatService{}
+	writer := NewHeartbeatWriter(HeartbeatWriterConfig{
+		Heartbeats: service,
+		ChangeRequests: staticHeartbeatChanges{known: []*core.AppInstallation{
+			{AppName: "app", Version: "v1", UpdatedAt: now.Add(-time.Hour)},
+			{AppName: "app", Version: "v2", UpdatedAt: now},
+		}},
+		ConfiguredApps: map[string]*config.ProviderEntry{
+			"app":    {Source: config.ProviderSource{Registry: "toolshed"}},
+			"legacy": {},
+		},
+		Runtime: staticRuntimeSnapshot{
+			"app": {State: core.GestaltdInstanceAppStateRunning, RunningVersion: "v2"},
+		},
+		InstanceID:    "instance",
+		SourceVersion: "source",
+		Now:           func() time.Time { return now },
+	})
+	if err := writer.WriteOnce(context.Background()); err != nil {
+		t.Fatalf("WriteOnce: %v", err)
+	}
+	service.mu.Lock()
+	defer service.mu.Unlock()
+	got := service.writes[0]
+	if len(got.Apps) != 1 {
+		t.Fatalf("apps = %#v, want registry app only", got.Apps)
+	}
+	if got.Apps["app"].DesiredVersion != "v2" || got.Apps["app"].RunningVersion != "v2" {
+		t.Fatalf("app observation = %#v", got.Apps["app"])
+	}
+}
+
+func waitForHeartbeatCounts(t *testing.T, service *recordingHeartbeatService, attempts, writes int) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		gotAttempts, gotWrites, _ := service.counts()
+		if gotAttempts >= attempts && gotWrites >= writes {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	gotAttempts, gotWrites, _ := service.counts()
+	t.Fatalf("heartbeat counts = attempts %d, writes %d; want at least %d, %d", gotAttempts, gotWrites, attempts, writes)
+}

--- a/gestaltd/internal/bootstrap/app_provider_restart.go
+++ b/gestaltd/internal/bootstrap/app_provider_restart.go
@@ -256,6 +256,92 @@ func (r *AppProviderRestarter) RunningVersion(app string) (string, bool) {
 	return version, ok && version != ""
 }
 
+// SnapshotRegistryApps observes all configured registry apps at one lifecycle
+// instant. ProviderMap.List is deliberately used instead of Get: Get may resolve
+// a remote tunnel, while runtime heartbeats must describe only this process.
+//
+// StartApp and StopApp hold lifecycleMu for their full transition, so a
+// partially-started provider is intentionally unobservable. The snapshot
+// reports only running, not_running, error, or unknown rather than inventing a
+// "starting" state that this synchronization model cannot observe.
+func (r *AppProviderRestarter) SnapshotRegistryApps() map[string]core.RegistryAppRuntimeObservation {
+	if r == nil {
+		return nil
+	}
+	r.lifecycleMu.RLock()
+	defer r.lifecycleMu.RUnlock()
+
+	localProviders := make(map[string]struct{})
+	if r.providers != nil {
+		for _, name := range r.providers.List() {
+			localProviders[name] = struct{}{}
+		}
+	}
+	observations := make(map[string]core.RegistryAppRuntimeObservation)
+	if r.cfg == nil {
+		return observations
+	}
+	for app, entry := range r.cfg.Apps {
+		if entry == nil || !entry.Source.IsRegistry() {
+			continue
+		}
+		_, registered := localProviders[app]
+		runningVersion := strings.TrimSpace(r.runningVersions[app])
+		activeVersion, markerErr := r.activeVersionMarker(app)
+		switch {
+		case markerErr != nil:
+			observations[app] = core.RegistryAppRuntimeObservation{
+				State:     core.GestaltdInstanceAppStateUnknown,
+				LastError: markerErr.Error(),
+			}
+		case !registered && runningVersion == "" && activeVersion == "":
+			observations[app] = core.RegistryAppRuntimeObservation{
+				State: core.GestaltdInstanceAppStateNotRunning,
+			}
+		case !registered:
+			observations[app] = core.RegistryAppRuntimeObservation{
+				State:     core.GestaltdInstanceAppStateError,
+				LastError: "local provider is not registered but runtime version state remains",
+			}
+		case runningVersion == "":
+			observations[app] = core.RegistryAppRuntimeObservation{
+				State:     core.GestaltdInstanceAppStateError,
+				LastError: "local provider is registered without a running version",
+			}
+		case activeVersion == "":
+			observations[app] = core.RegistryAppRuntimeObservation{
+				State:     core.GestaltdInstanceAppStateError,
+				LastError: "local provider is registered without an active-version marker",
+			}
+		case runningVersion != activeVersion:
+			observations[app] = core.RegistryAppRuntimeObservation{
+				State:     core.GestaltdInstanceAppStateError,
+				LastError: fmt.Sprintf("running version %q does not match active-version marker %q", runningVersion, activeVersion),
+			}
+		default:
+			observations[app] = core.RegistryAppRuntimeObservation{
+				State:          core.GestaltdInstanceAppStateRunning,
+				RunningVersion: runningVersion,
+			}
+		}
+	}
+	return observations
+}
+
+func (r *AppProviderRestarter) activeVersionMarker(app string) (string, error) {
+	if r.artifactsDir == "" {
+		return "", nil
+	}
+	value, err := os.ReadFile(filepath.Join(r.artifactsDir, "registry-installed", app, "active-version"))
+	if errors.Is(err, os.ErrNotExist) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("read active-version marker: %w", err)
+	}
+	return strings.TrimSpace(string(value)), nil
+}
+
 func (r *AppProviderRestarter) WithRunningVersion(app string, fn func(string) error) error {
 	if r == nil || fn == nil {
 		return fmt.Errorf("app runtime state is not configured")

--- a/gestaltd/internal/bootstrap/app_provider_runtime_snapshot_test.go
+++ b/gestaltd/internal/bootstrap/app_provider_runtime_snapshot_test.go
@@ -1,0 +1,118 @@
+package bootstrap
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/services/apps/registry"
+)
+
+func TestAppProviderRestarterSnapshotRegistryAppsRequiresRuntimeAgreement(t *testing.T) {
+	t.Parallel()
+	artifactsDir := t.TempDir()
+	providerRegistry := registry.New()
+	if err := providerRegistry.Providers.Register("running", &coretesting.StubIntegration{}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := providerRegistry.Providers.Register("mismatch", &coretesting.StubIntegration{}); err != nil {
+		t.Fatalf("Register mismatch: %v", err)
+	}
+	writeActiveVersionMarker(t, artifactsDir, "running", "v2")
+	writeActiveVersionMarker(t, artifactsDir, "mismatch", "v1")
+	restarter := NewAppProviderRestarter(AppProviderRestarterConfig{
+		Config: &config.Config{Apps: map[string]*config.ProviderEntry{
+			"running":  {Source: config.ProviderSource{Registry: "toolshed"}},
+			"mismatch": {Source: config.ProviderSource{Registry: "toolshed"}},
+			"legacy":   {},
+		}},
+		Providers:    &providerRegistry.Providers,
+		ArtifactsDir: artifactsDir,
+	})
+	restarter.runningVersions["running"] = "v2"
+	restarter.runningVersions["mismatch"] = "v2"
+
+	got := restarter.SnapshotRegistryApps()
+	if len(got) != 2 {
+		t.Fatalf("snapshot = %#v, want registry apps only", got)
+	}
+	if got["running"].State != core.GestaltdInstanceAppStateRunning || got["running"].RunningVersion != "v2" {
+		t.Fatalf("running = %#v", got["running"])
+	}
+	if got["mismatch"].State != core.GestaltdInstanceAppStateError {
+		t.Fatalf("mismatch = %#v, want error", got["mismatch"])
+	}
+}
+
+func TestAppProviderRestarterSnapshotSerializesWithLifecycleMutation(t *testing.T) {
+	t.Parallel()
+	restarter := NewAppProviderRestarter(AppProviderRestarterConfig{
+		Config: &config.Config{Apps: map[string]*config.ProviderEntry{
+			"app": {Source: config.ProviderSource{Registry: "toolshed"}},
+		}},
+	})
+	restarter.lifecycleMu.Lock()
+	done := make(chan struct{})
+	go func() {
+		_ = restarter.SnapshotRegistryApps()
+		close(done)
+	}()
+	select {
+	case <-done:
+		t.Fatal("snapshot completed while lifecycle write lock was held")
+	case <-time.After(20 * time.Millisecond):
+	}
+	restarter.lifecycleMu.Unlock()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("snapshot did not resume after lifecycle write lock release")
+	}
+}
+
+type snapshotRemoteResolver struct {
+	calls atomic.Int32
+}
+
+func (r *snapshotRemoteResolver) ResolveProvider(context.Context, string) (core.Provider, error) {
+	r.calls.Add(1)
+	return &coretesting.StubIntegration{}, nil
+}
+
+func TestAppProviderRestarterSnapshotUsesLocalProviderMembershipOnly(t *testing.T) {
+	t.Parallel()
+	providerRegistry := registry.New()
+	resolver := &snapshotRemoteResolver{}
+	providerRegistry.Providers.SetRemoteResolver(resolver)
+	restarter := NewAppProviderRestarter(AppProviderRestarterConfig{
+		Config: &config.Config{Apps: map[string]*config.ProviderEntry{
+			"app": {Source: config.ProviderSource{Registry: "toolshed"}},
+		}},
+		Providers: &providerRegistry.Providers,
+	})
+
+	got := restarter.SnapshotRegistryApps()
+	if resolver.calls.Load() != 0 {
+		t.Fatalf("remote resolver calls = %d, want 0", resolver.calls.Load())
+	}
+	if got["app"].State != core.GestaltdInstanceAppStateNotRunning {
+		t.Fatalf("app = %#v, want local not_running", got["app"])
+	}
+}
+
+func writeActiveVersionMarker(t *testing.T, artifactsDir, app, version string) {
+	t.Helper()
+	dir := filepath.Join(artifactsDir, "registry-installed", app)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "active-version"), []byte(version+"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -275,6 +275,9 @@ type Result struct {
 		StartApp(context.Context, string, string) error
 		AbortRestarts()
 	}
+	AppRuntimeSnapshotter interface {
+		SnapshotRegistryApps() map[string]core.RegistryAppRuntimeObservation
+	}
 	RegistryAppStartup func(context.Context)
 
 	runtimeRegistry                     *runtimeRegistry
@@ -1550,6 +1553,7 @@ func BootstrapWithOptions(ctx context.Context, cfg *config.Config, factories *Fa
 		PublicGatewayTransport:         publicGatewayTransport,
 		DevSupervisor:                  prepared.Deps.DevSupervisor,
 		AppRestarter:                   appRestarter,
+		AppRuntimeSnapshotter:          appRestarter,
 		runtimeRegistry:                prepared.runtimeRegistry,
 		workflowConfigReconcileTasks:   deferredWorkflowConfigReconcileTasks,
 		startupWorkflowConfigReconcile: startupWorkflowConfigReconcile,

--- a/gestaltd/internal/coredata/gestaltd_instance_heartbeats.go
+++ b/gestaltd/internal/coredata/gestaltd_instance_heartbeats.go
@@ -15,11 +15,15 @@ import (
 )
 
 type GestaltdInstanceHeartbeatService struct {
+	db    indexeddb.IndexedDB
 	store idb.ObjectStore
 }
 
 func NewGestaltdInstanceHeartbeatService(ds indexeddb.IndexedDB) *GestaltdInstanceHeartbeatService {
-	return &GestaltdInstanceHeartbeatService{store: ds.ObjectStore(StoreGestaltdInstanceHeartbeats)}
+	return &GestaltdInstanceHeartbeatService{
+		db:    ds,
+		store: ds.ObjectStore(StoreGestaltdInstanceHeartbeats),
+	}
 }
 
 func (s *GestaltdInstanceHeartbeatService) Get(ctx context.Context, instanceID string) (*core.GestaltdInstanceHeartbeat, error) {
@@ -66,6 +70,32 @@ func (s *GestaltdInstanceHeartbeatService) ListBySourceVersion(ctx context.Conte
 	return recordsToGestaltdInstanceHeartbeats(recs), nil
 }
 
+func (s *GestaltdInstanceHeartbeatService) ListFreshBySourceVersion(
+	ctx context.Context,
+	sourceVersion string,
+	cutoff time.Time,
+) ([]*core.GestaltdInstanceHeartbeat, error) {
+	if s == nil {
+		return nil, fmt.Errorf("list fresh gestaltd instance heartbeats: service is not configured")
+	}
+	sourceVersion = strings.TrimSpace(sourceVersion)
+	if sourceVersion == "" {
+		return nil, fmt.Errorf("list fresh gestaltd instance heartbeats: source version is required")
+	}
+	cutoff = cutoff.UTC()
+	query := idb.Bound(
+		[]any{sourceVersion, cutoff},
+		[]any{sourceVersion, indexedDBMaxTime},
+		false,
+		false,
+	)
+	recs, err := s.store.Index("by_source_version_heartbeat_at").GetAll(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("list fresh gestaltd instance heartbeats: %w", err)
+	}
+	return recordsToGestaltdInstanceHeartbeats(recs), nil
+}
+
 func (s *GestaltdInstanceHeartbeatService) Upsert(ctx context.Context, heartbeat *core.GestaltdInstanceHeartbeat) (*core.GestaltdInstanceHeartbeat, error) {
 	if s == nil {
 		return nil, fmt.Errorf("upsert gestaltd instance heartbeat: service is not configured")
@@ -92,6 +122,48 @@ func (s *GestaltdInstanceHeartbeatService) Delete(ctx context.Context, instanceI
 		return fmt.Errorf("delete gestaltd instance heartbeat: %w", err)
 	}
 	return nil
+}
+
+func (s *GestaltdInstanceHeartbeatService) PruneBefore(ctx context.Context, cutoff time.Time) (int, error) {
+	if s == nil || s.db == nil {
+		return 0, fmt.Errorf("prune gestaltd instance heartbeats: service is not configured")
+	}
+	tx, err := s.db.Transaction(
+		ctx,
+		[]string{StoreGestaltdInstanceHeartbeats},
+		idb.TransactionReadwrite,
+		idb.TransactionOptions{},
+	)
+	if err != nil {
+		return 0, fmt.Errorf("prune gestaltd instance heartbeats: begin transaction: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Abort(context.WithoutCancel(ctx))
+		}
+	}()
+	store := tx.ObjectStore(StoreGestaltdInstanceHeartbeats)
+	recs, err := store.Index("by_heartbeat_at").GetAll(ctx, idb.UpperBound(cutoff.UTC(), true))
+	if err != nil {
+		return 0, fmt.Errorf("prune gestaltd instance heartbeats: list expired rows: %w", err)
+	}
+	pruned := 0
+	for _, rec := range recs {
+		instanceID := recString(rec, "instance_id")
+		if instanceID == "" {
+			continue
+		}
+		if err := store.Delete(ctx, instanceID); err != nil && !errors.Is(err, idb.ErrNotFound) {
+			return pruned, fmt.Errorf("prune gestaltd instance heartbeats: delete %q: %w", instanceID, err)
+		}
+		pruned++
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return pruned, fmt.Errorf("prune gestaltd instance heartbeats: commit: %w", err)
+	}
+	committed = true
+	return pruned, nil
 }
 
 func gestaltdInstanceHeartbeatRecord(heartbeat *core.GestaltdInstanceHeartbeat) (idb.Record, *core.GestaltdInstanceHeartbeat, error) {

--- a/gestaltd/internal/coredata/gestaltd_instance_heartbeats_test.go
+++ b/gestaltd/internal/coredata/gestaltd_instance_heartbeats_test.go
@@ -94,6 +94,43 @@ func TestGestaltdInstanceHeartbeatServiceListsBySourceVersion(t *testing.T) {
 	}
 }
 
+func TestGestaltdInstanceHeartbeatServiceListsFreshAndPrunesByIndexedTime(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	svc := testutil.NewStubServices(t).GestaltdInstanceHeartbeats
+	now := time.Date(2026, 7, 30, 14, 0, 0, 0, time.UTC)
+	for _, heartbeat := range []*core.GestaltdInstanceHeartbeat{
+		{InstanceID: "boundary", SourceVersion: "source-a", StartedAt: now.Add(-time.Hour), HeartbeatAt: now.Add(-45 * time.Second), Apps: map[string]core.GestaltdInstanceAppHeartbeat{}},
+		{InstanceID: "stale", SourceVersion: "source-a", StartedAt: now.Add(-time.Hour), HeartbeatAt: now.Add(-46 * time.Second), Apps: map[string]core.GestaltdInstanceAppHeartbeat{}},
+		{InstanceID: "other", SourceVersion: "source-b", StartedAt: now.Add(-time.Hour), HeartbeatAt: now, Apps: map[string]core.GestaltdInstanceAppHeartbeat{}},
+	} {
+		if _, err := svc.Upsert(ctx, heartbeat); err != nil {
+			t.Fatalf("Upsert(%s): %v", heartbeat.InstanceID, err)
+		}
+	}
+	fresh, err := svc.ListFreshBySourceVersion(ctx, "source-a", now.Add(-45*time.Second))
+	if err != nil {
+		t.Fatalf("ListFreshBySourceVersion: %v", err)
+	}
+	if len(fresh) != 1 || fresh[0].InstanceID != "boundary" {
+		t.Fatalf("fresh heartbeats = %#v", fresh)
+	}
+	pruned, err := svc.PruneBefore(ctx, now.Add(-45*time.Second))
+	if err != nil {
+		t.Fatalf("PruneBefore: %v", err)
+	}
+	if pruned != 1 {
+		t.Fatalf("pruned = %d, want 1", pruned)
+	}
+	all, err := svc.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("remaining heartbeats = %#v", all)
+	}
+}
+
 func TestGestaltdInstanceHeartbeatServiceValidatesRecord(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -175,6 +175,13 @@ func run(ctx context.Context, cfg *config.Config, result *bootstrap.Result, gest
 	if catalogPoller != nil {
 		defer catalogPoller.Stop()
 	}
+	heartbeatWriter, err := startAppRegistryHeartbeatWriter(ctx, cfg, result)
+	if err != nil {
+		return err
+	}
+	if heartbeatWriter != nil {
+		defer heartbeatWriter.Stop()
+	}
 
 	publicConfig := baseConfig
 	if managementAddr == "" {
@@ -580,6 +587,44 @@ func startAppRegistryCatalogPoller(
 	})
 	poller.Start(ctx)
 	return poller
+}
+
+func startAppRegistryHeartbeatWriter(
+	ctx context.Context,
+	cfg *config.Config,
+	result *bootstrap.Result,
+) (*appregistry.HeartbeatWriter, error) {
+	if cfg == nil || result == nil || result.Services == nil ||
+		result.Services.GestaltdInstanceHeartbeats == nil ||
+		result.Services.AppVersionChangeRequests == nil ||
+		result.AppRuntimeSnapshotter == nil {
+		return nil, nil
+	}
+	sourceVersion := appregistry.ResolveSourceVersion()
+	if sourceVersion == "" {
+		return nil, nil
+	}
+	interval, err := cfg.Server.AppRegistry.HeartbeatIntervalDuration()
+	if err != nil {
+		return nil, fmt.Errorf("server.appRegistry.heartbeatInterval: %w", err)
+	}
+	retention, err := cfg.Server.AppRegistry.HeartbeatRetentionDuration()
+	if err != nil {
+		return nil, fmt.Errorf("server.appRegistry.heartbeatRetention: %w", err)
+	}
+	writer := appregistry.NewHeartbeatWriter(appregistry.HeartbeatWriterConfig{
+		Heartbeats:     result.Services.GestaltdInstanceHeartbeats,
+		ChangeRequests: result.Services.AppVersionChangeRequests,
+		ConfiguredApps: cfg.Apps,
+		Runtime:        result.AppRuntimeSnapshotter,
+		InstanceID:     appregistry.ResolveInstanceID(),
+		SourceVersion:  sourceVersion,
+		Ready:          result.AppProvidersInitialized,
+		Interval:       interval,
+		Retention:      retention,
+	})
+	writer.Start(ctx)
+	return writer, nil
 }
 
 func startAppRegistryAutoDeployController(

--- a/gestaltd/internal/server/runtime_app_registry_test.go
+++ b/gestaltd/internal/server/runtime_app_registry_test.go
@@ -34,6 +34,14 @@ func (r *startupRecordingRestarter) StartApp(_ context.Context, app, version str
 }
 func (*startupRecordingRestarter) AbortRestarts() {}
 
+type serverRuntimeSnapshotter struct{}
+
+func (serverRuntimeSnapshotter) SnapshotRegistryApps() map[string]core.RegistryAppRuntimeObservation {
+	return map[string]core.RegistryAppRuntimeObservation{
+		"g-issues": {State: core.GestaltdInstanceAppStateNotRunning},
+	}
+}
+
 func TestRegistryAppStartupMaterializesAndStartsKnownVersion(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -107,4 +115,47 @@ func TestRegistryAppStartupStopsEmptyProjection(t *testing.T) {
 	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
 		t.Fatalf("old version stat error = %v, want not exist", err)
 	}
+}
+
+func TestStartAppRegistryHeartbeatWriterUsesBootstrapReadiness(t *testing.T) {
+	t.Setenv("SOURCE_VERSION", "source-v3")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	services := testutil.NewStubServices(t)
+	ready := make(chan struct{})
+	cfg := &config.Config{
+		Apps: map[string]*config.ProviderEntry{
+			"g-issues": {Source: config.ProviderSource{Registry: "toolshed"}},
+		},
+	}
+	result := &bootstrap.Result{
+		Services:                services,
+		AppProvidersInitialized: ready,
+		AppRuntimeSnapshotter:   serverRuntimeSnapshotter{},
+	}
+	writer, err := startAppRegistryHeartbeatWriter(ctx, cfg, result)
+	if err != nil {
+		t.Fatalf("startAppRegistryHeartbeatWriter: %v", err)
+	}
+	if writer == nil {
+		t.Fatal("writer = nil")
+	}
+	t.Cleanup(writer.Stop)
+	time.Sleep(20 * time.Millisecond)
+	if heartbeats, err := services.GestaltdInstanceHeartbeats.List(ctx); err != nil || len(heartbeats) != 0 {
+		t.Fatalf("heartbeats before ready = %#v, err %v", heartbeats, err)
+	}
+	close(ready)
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		heartbeats, listErr := services.GestaltdInstanceHeartbeats.List(ctx)
+		if listErr == nil && len(heartbeats) == 1 {
+			if heartbeats[0].SourceVersion != "source-v3" {
+				t.Fatalf("source version = %q", heartbeats[0].SourceVersion)
+			}
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("heartbeat was not written after bootstrap readiness")
 }


### PR DESCRIPTION
## Summary
- publish coherent per-replica registry-app runtime snapshots after provider initialization
- derive current fleet health from fresh current-source heartbeats and minimum capacity
- add indexed heartbeat queries, coarse retention pruning, and runtime lifecycle wiring

## Test plan
- [x] `go test ./...` from `gestaltd`
- [x] `gofmt`
- [x] `git diff --check`

Made with [Cursor](https://cursor.com)