### PR TITLE
fix: route app-invocation relay calls to a single global host service

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -905,6 +905,10 @@ func resolveConfigSecrets(
 }
 
 func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, requireEncryptionKey bool) (*preparedCore, error) {
+	return prepareCoreWithRegistry(ctx, cfg, factories, requireEncryptionKey, nil)
+}
+
+func prepareCoreWithRegistry(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, requireEncryptionKey bool, publicHostServices *runtimehost.PublicHostServiceRegistry) (*preparedCore, error) {
 	registry, err := publicrpc.NewGeneratedRegistry()
 	if err != nil {
 		return nil, fmt.Errorf("public rpc registry: %w", err)
@@ -994,11 +998,13 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	pluginInvoker := newLazyInvoker()
 	workflowManager := newLazyWorkflowManager()
 	agentManager := newLazyAgentManager()
-	publicHostServices := runtimehost.NewPublicHostServiceRegistry()
+	if publicHostServices == nil {
+		publicHostServices = runtimehost.NewPublicHostServiceRegistry()
+	}
+	deps.PublicHostServices = publicHostServices
 	deps.AppInvocation = pluginInvoker
 	deps.WorkflowManager = workflowManager
 	deps.AgentManager = agentManager
-	deps.PublicHostServices = publicHostServices
 	deps.AppWorkflowDeclarations = newAppWorkflowDeclarations()
 	if factories != nil {
 		deps.DevSupervisor = factories.DevSupervisor
@@ -1237,6 +1243,10 @@ func (p *preparedCore) Close(ctx context.Context) error {
 type BootstrapOptions struct {
 	DeferAppProviderStartup bool
 	RegistryResolver        RegistryInstalledResolver
+	// PublicHostServices injects the public host-service registry bootstrap
+	// registers into. Tests use it to stand up a relay endpoint against the
+	// same registry before bootstrap completes. Nil creates a fresh registry.
+	PublicHostServices *runtimehost.PublicHostServiceRegistry
 }
 
 func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegistry) (*Result, error) {
@@ -1244,7 +1254,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 }
 
 func BootstrapWithOptions(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, opts BootstrapOptions) (*Result, error) {
-	prepared, err := prepareCore(ctx, cfg, factories, true)
+	prepared, err := prepareCoreWithRegistry(ctx, cfg, factories, true, opts.PublicHostServices)
 	if err != nil {
 		return nil, err
 	}
@@ -1349,7 +1359,7 @@ func BootstrapWithOptions(ctx context.Context, cfg *config.Config, factories *Fa
 		SessionStart:      agentSessionStartConfigs(cfg),
 	}))
 	pluginInvoker.SetTarget(invocation.NewGuarded(sharedInvoker, nil, "app", audit, invocation.WithoutRateLimit()))
-	appHostServiceCleanup := registerConfiguredAppPublicHostServices(cfg, prepared.Deps)
+	appHostServiceCleanup := registerGlobalAppInvocationPublicHostService(prepared.Deps)
 	// Build workflow/agent providers before app providers: they establish their
 	// backend connection during build, which must not race concurrent app startup.
 	extraWorkflows, extraAgents, err := buildWorkflowsAndAgents(ctx, cfg, factories, prepared.Deps)

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -905,10 +905,6 @@ func resolveConfigSecrets(
 }
 
 func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, requireEncryptionKey bool) (*preparedCore, error) {
-	return prepareCoreWithRegistry(ctx, cfg, factories, requireEncryptionKey, nil)
-}
-
-func prepareCoreWithRegistry(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, requireEncryptionKey bool, publicHostServices *runtimehost.PublicHostServiceRegistry) (*preparedCore, error) {
 	registry, err := publicrpc.NewGeneratedRegistry()
 	if err != nil {
 		return nil, fmt.Errorf("public rpc registry: %w", err)
@@ -998,13 +994,10 @@ func prepareCoreWithRegistry(ctx context.Context, cfg *config.Config, factories 
 	pluginInvoker := newLazyInvoker()
 	workflowManager := newLazyWorkflowManager()
 	agentManager := newLazyAgentManager()
-	if publicHostServices == nil {
-		publicHostServices = runtimehost.NewPublicHostServiceRegistry()
-	}
-	deps.PublicHostServices = publicHostServices
 	deps.AppInvocation = pluginInvoker
 	deps.WorkflowManager = workflowManager
 	deps.AgentManager = agentManager
+	deps.PublicHostServices = runtimehost.NewPublicHostServiceRegistry()
 	deps.AppWorkflowDeclarations = newAppWorkflowDeclarations()
 	if factories != nil {
 		deps.DevSupervisor = factories.DevSupervisor
@@ -1187,7 +1180,7 @@ func prepareCoreWithRegistry(ctx context.Context, cfg *config.Config, factories 
 		AppInvocation:        pluginInvoker,
 		WorkflowManager:      workflowManager,
 		AgentManager:         agentManager,
-		PublicHostServices:   publicHostServices,
+		PublicHostServices:   deps.PublicHostServices,
 		runtimeRegistry:      runtimeRegistry,
 	}, nil
 }
@@ -1243,10 +1236,6 @@ func (p *preparedCore) Close(ctx context.Context) error {
 type BootstrapOptions struct {
 	DeferAppProviderStartup bool
 	RegistryResolver        RegistryInstalledResolver
-	// PublicHostServices injects the public host-service registry bootstrap
-	// registers into. Tests use it to stand up a relay endpoint against the
-	// same registry before bootstrap completes. Nil creates a fresh registry.
-	PublicHostServices *runtimehost.PublicHostServiceRegistry
 }
 
 func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegistry) (*Result, error) {
@@ -1254,7 +1243,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 }
 
 func BootstrapWithOptions(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, opts BootstrapOptions) (*Result, error) {
-	prepared, err := prepareCoreWithRegistry(ctx, cfg, factories, true, opts.PublicHostServices)
+	prepared, err := prepareCore(ctx, cfg, factories, true)
 	if err != nil {
 		return nil, err
 	}

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -2,6 +2,7 @@ package bootstrap_test
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -24,12 +25,15 @@ import (
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
 	corecache "github.com/valon-technologies/gestalt/server/core/cache"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
+	corecrypto "github.com/valon-technologies/gestalt/server/core/crypto"
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/indexeddbcodec"
+	serverservice "github.com/valon-technologies/gestalt/server/internal/server"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
 	"github.com/valon-technologies/gestalt/server/internal/workflowwire"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
@@ -45,6 +49,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -599,6 +604,7 @@ func (p *recordingAgentProvider) CancelTurnRequests() []*proto.CancelAgentProvid
 type callbackAgentProvider struct {
 	*recordingAgentProvider
 	started                *runtimehost.StartedHostServices
+	dialApp                func(context.Context) (*grpc.ClientConn, error)
 	relayTokenManager      *runtimehost.HostServiceRelayTokenManager
 	toolBodies             []string
 	sessionToolRefs        map[string]*proto.AgentToolRef
@@ -644,8 +650,80 @@ func newCallbackAgentProvider(started *runtimehost.StartedHostServices, encrypti
 	return &callbackAgentProvider{
 		recordingAgentProvider: newRecordingAgentProvider(),
 		started:                started,
+		dialApp:                dialHostServiceSocketApp(started),
 		relayTokenManager:      tokenManager,
 	}, nil
+}
+
+func dialHostServiceSocketApp(started *runtimehost.StartedHostServices) func(context.Context) (*grpc.ClientConn, error) {
+	return func(ctx context.Context) (*grpc.ClientConn, error) {
+		socketPath := strings.TrimSpace(started.SocketBinding().SocketPath)
+		if socketPath == "" {
+			return nil, fmt.Errorf("host service socket binding is missing")
+		}
+		return grpc.NewClient(
+			"passthrough:///localhost",
+			grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+				var d net.Dialer
+				return d.DialContext(ctx, "unix", socketPath)
+			}),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+	}
+}
+
+func newRelayTokenManager(t *testing.T, key []byte) *runtimehost.HostServiceRelayTokenManager {
+	t.Helper()
+	manager, err := runtimehost.NewHostServiceRelayTokenManager(key)
+	if err != nil {
+		t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
+	}
+	return manager
+}
+
+// dialPublicRelayApp dials the test public relay endpoint for app-invocation
+// callbacks, matching how production agent tool calls reach the global app
+// host service through the public relay.
+func dialPublicRelayApp(relaySrv *httptest.Server) func(context.Context) (*grpc.ClientConn, error) {
+	return func(context.Context) (*grpc.ClientConn, error) {
+		return grpc.NewClient(
+			strings.TrimPrefix(relaySrv.URL, "https://"),
+			grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})),
+		)
+	}
+}
+
+// relayUnavailableInvoker satisfies server.Config.Invoker; the relay test
+// server only exercises the host-service relay routes, so any app invocation
+// that slips through fails loudly.
+type relayUnavailableInvoker struct{}
+
+func (relayUnavailableInvoker) Invoke(context.Context, *principal.Principal, string, string, string, map[string]any) (*core.OperationResult, error) {
+	return nil, fmt.Errorf("app invocation is unavailable on the relay test server")
+}
+
+// newAppCallbackRelayServer serves the public host-service relay against the
+// given registry (which includes the single global app-invocation
+// registration once bootstrap runs), so agent tool callbacks resolve exactly
+// as they do against a multi-replica gestaltd deployment.
+func newAppCallbackRelayServer(t *testing.T, registry *runtimehost.PublicHostServiceRegistry, encryptionKey []byte) *httptest.Server {
+	t.Helper()
+	srv, err := serverservice.New(serverservice.Config{
+		Services:           testutil.NewStubServices(t),
+		RouteProfile:       serverservice.RouteProfilePublic,
+		StateSecret:        encryptionKey,
+		PublicHostServices: registry,
+		Invoker:            relayUnavailableInvoker{},
+	})
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+	t.Cleanup(srv.Close)
+	ts := httptest.NewUnstartedServer(srv)
+	ts.EnableHTTP2 = true
+	ts.StartTLS()
+	t.Cleanup(ts.Close)
+	return ts
 }
 
 func relayTokenHostServiceOptions(encryptionKey []byte) []runtimehost.HostServicesOption {
@@ -724,19 +802,7 @@ func (p *callbackAgentProvider) CreateTurn(ctx context.Context, req *proto.Creat
 	toolRef := p.sessionToolRefs[req.GetSessionId()]
 	p.mu.Unlock()
 	if toolRef != nil {
-		socketPath := strings.TrimSpace(p.started.SocketBinding().SocketPath)
-		if socketPath == "" {
-			cleanupPendingTurn()
-			return nil, fmt.Errorf("host service socket binding is missing")
-		}
-		conn, err := grpc.NewClient(
-			"passthrough:///localhost",
-			grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
-				var d net.Dialer
-				return d.DialContext(ctx, "unix", socketPath)
-			}),
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
-		)
+		conn, err := p.dialApp(ctx)
 		if err != nil {
 			cleanupPendingTurn()
 			return nil, fmt.Errorf("dial app host: %w", err)
@@ -2183,8 +2249,8 @@ func TestBootstrapAgentManagerCreateTurnPersistsMetadataForToolCallbacks(t *test
 		},
 	)
 
-	var provider *callbackAgentProvider
-	factories.Agent = func(_ context.Context, _ string, _ yaml.Node, hostServices []runtimehost.HostService, deps bootstrap.Deps) (coreagent.Provider, error) {
+	callbackAgents := map[string]*callbackAgentProvider{}
+	factories.Agent = func(_ context.Context, name string, _ yaml.Node, hostServices []runtimehost.HostService, deps bootstrap.Deps) (coreagent.Provider, error) {
 		started, err := runtimehost.StartHostServices(hostServices, relayTokenHostServiceOptions(deps.EncryptionKey)...)
 		if err != nil {
 			return nil, err
@@ -2194,16 +2260,28 @@ func TestBootstrapAgentManagerCreateTurnPersistsMetadataForToolCallbacks(t *test
 			_ = started.Close()
 			return nil, err
 		}
-		provider = value
+		callbackAgents[name] = value
 		return value, nil
 	}
 
-	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	registry := runtimehost.NewPublicHostServiceRegistry()
+	relayKey := corecrypto.DeriveKey(cfg.Server.EncryptionKey)
+	relaySrv := newAppCallbackRelayServer(t, registry, relayKey)
+	cfg.Server.Runtime.RelayBaseURL = relaySrv.URL
+
+	result, err := bootstrap.BootstrapWithOptions(context.Background(), cfg, factories, bootstrap.BootstrapOptions{
+		PublicHostServices: registry,
+	})
 	if err != nil {
 		t.Fatalf("Bootstrap: %v", err)
 	}
 	defer func() { _ = result.Close(context.Background()) }()
 	<-result.ProvidersReady
+	provider := callbackAgents["managed"]
+	if provider.relayTokenManager, err = runtimehost.NewHostServiceRelayTokenManager(relayKey); err != nil {
+		t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
+	}
+	provider.dialApp = dialPublicRelayApp(relaySrv)
 
 	perms := principal.CompilePermissions([]core.AccessPermission{
 		{
@@ -2482,8 +2560,8 @@ func TestBootstrapAgentToolCatalogExecutesExactAppIssueTool(t *testing.T) {
 		},
 	)
 
-	var provider *callbackAgentProvider
-	factories.Agent = func(_ context.Context, _ string, _ yaml.Node, hostServices []runtimehost.HostService, deps bootstrap.Deps) (coreagent.Provider, error) {
+	callbackAgents := map[string]*callbackAgentProvider{}
+	factories.Agent = func(_ context.Context, name string, _ yaml.Node, hostServices []runtimehost.HostService, deps bootstrap.Deps) (coreagent.Provider, error) {
 		started, err := runtimehost.StartHostServices(hostServices, relayTokenHostServiceOptions(deps.EncryptionKey)...)
 		if err != nil {
 			return nil, err
@@ -2493,16 +2571,28 @@ func TestBootstrapAgentToolCatalogExecutesExactAppIssueTool(t *testing.T) {
 			_ = started.Close()
 			return nil, err
 		}
-		provider = value
+		callbackAgents[name] = value
 		return value, nil
 	}
 
-	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	registry := runtimehost.NewPublicHostServiceRegistry()
+	relayKey := corecrypto.DeriveKey(cfg.Server.EncryptionKey)
+	relaySrv := newAppCallbackRelayServer(t, registry, relayKey)
+	cfg.Server.Runtime.RelayBaseURL = relaySrv.URL
+
+	result, err := bootstrap.BootstrapWithOptions(context.Background(), cfg, factories, bootstrap.BootstrapOptions{
+		PublicHostServices: registry,
+	})
 	if err != nil {
 		t.Fatalf("Bootstrap: %v", err)
 	}
 	defer func() { _ = result.Close(context.Background()) }()
 	<-result.ProvidersReady
+	provider := callbackAgents["managed"]
+	if provider.relayTokenManager, err = runtimehost.NewHostServiceRelayTokenManager(relayKey); err != nil {
+		t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
+	}
+	provider.dialApp = dialPublicRelayApp(relaySrv)
 
 	permissions := []core.AccessPermission{
 		{
@@ -3317,7 +3407,9 @@ func TestBootstrapPassesIndexedDBHostSocketToWorkflowProviders(t *testing.T) {
 	<-result.ProvidersReady
 
 	got := hostEnvs["basic"]
-	for _, want := range []string{"agent", "identity", "indexeddb", "app", "workflow"} {
+	// The app-invocation host service is registered once, globally, by
+	// bootstrap; per-provider host services no longer include it.
+	for _, want := range []string{"agent", "identity", "indexeddb", "workflow"} {
 		if !slices.Contains(got, want) {
 			t.Fatalf("workflow provider host services = %v, want %q", got, want)
 		}

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -2,7 +2,6 @@ package bootstrap_test
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -25,15 +24,12 @@ import (
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
 	corecache "github.com/valon-technologies/gestalt/server/core/cache"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
-	corecrypto "github.com/valon-technologies/gestalt/server/core/crypto"
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/indexeddbcodec"
-	serverservice "github.com/valon-technologies/gestalt/server/internal/server"
-	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
 	"github.com/valon-technologies/gestalt/server/internal/workflowwire"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
@@ -49,7 +45,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -604,7 +599,6 @@ func (p *recordingAgentProvider) CancelTurnRequests() []*proto.CancelAgentProvid
 type callbackAgentProvider struct {
 	*recordingAgentProvider
 	started                *runtimehost.StartedHostServices
-	dialApp                func(context.Context) (*grpc.ClientConn, error)
 	relayTokenManager      *runtimehost.HostServiceRelayTokenManager
 	toolBodies             []string
 	sessionToolRefs        map[string]*proto.AgentToolRef
@@ -650,80 +644,8 @@ func newCallbackAgentProvider(started *runtimehost.StartedHostServices, encrypti
 	return &callbackAgentProvider{
 		recordingAgentProvider: newRecordingAgentProvider(),
 		started:                started,
-		dialApp:                dialHostServiceSocketApp(started),
 		relayTokenManager:      tokenManager,
 	}, nil
-}
-
-func dialHostServiceSocketApp(started *runtimehost.StartedHostServices) func(context.Context) (*grpc.ClientConn, error) {
-	return func(ctx context.Context) (*grpc.ClientConn, error) {
-		socketPath := strings.TrimSpace(started.SocketBinding().SocketPath)
-		if socketPath == "" {
-			return nil, fmt.Errorf("host service socket binding is missing")
-		}
-		return grpc.NewClient(
-			"passthrough:///localhost",
-			grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
-				var d net.Dialer
-				return d.DialContext(ctx, "unix", socketPath)
-			}),
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
-		)
-	}
-}
-
-func newRelayTokenManager(t *testing.T, key []byte) *runtimehost.HostServiceRelayTokenManager {
-	t.Helper()
-	manager, err := runtimehost.NewHostServiceRelayTokenManager(key)
-	if err != nil {
-		t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
-	}
-	return manager
-}
-
-// dialPublicRelayApp dials the test public relay endpoint for app-invocation
-// callbacks, matching how production agent tool calls reach the global app
-// host service through the public relay.
-func dialPublicRelayApp(relaySrv *httptest.Server) func(context.Context) (*grpc.ClientConn, error) {
-	return func(context.Context) (*grpc.ClientConn, error) {
-		return grpc.NewClient(
-			strings.TrimPrefix(relaySrv.URL, "https://"),
-			grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})),
-		)
-	}
-}
-
-// relayUnavailableInvoker satisfies server.Config.Invoker; the relay test
-// server only exercises the host-service relay routes, so any app invocation
-// that slips through fails loudly.
-type relayUnavailableInvoker struct{}
-
-func (relayUnavailableInvoker) Invoke(context.Context, *principal.Principal, string, string, string, map[string]any) (*core.OperationResult, error) {
-	return nil, fmt.Errorf("app invocation is unavailable on the relay test server")
-}
-
-// newAppCallbackRelayServer serves the public host-service relay against the
-// given registry (which includes the single global app-invocation
-// registration once bootstrap runs), so agent tool callbacks resolve exactly
-// as they do against a multi-replica gestaltd deployment.
-func newAppCallbackRelayServer(t *testing.T, registry *runtimehost.PublicHostServiceRegistry, encryptionKey []byte) *httptest.Server {
-	t.Helper()
-	srv, err := serverservice.New(serverservice.Config{
-		Services:           testutil.NewStubServices(t),
-		RouteProfile:       serverservice.RouteProfilePublic,
-		StateSecret:        encryptionKey,
-		PublicHostServices: registry,
-		Invoker:            relayUnavailableInvoker{},
-	})
-	if err != nil {
-		t.Fatalf("server.New: %v", err)
-	}
-	t.Cleanup(srv.Close)
-	ts := httptest.NewUnstartedServer(srv)
-	ts.EnableHTTP2 = true
-	ts.StartTLS()
-	t.Cleanup(ts.Close)
-	return ts
 }
 
 func relayTokenHostServiceOptions(encryptionKey []byte) []runtimehost.HostServicesOption {
@@ -802,7 +724,19 @@ func (p *callbackAgentProvider) CreateTurn(ctx context.Context, req *proto.Creat
 	toolRef := p.sessionToolRefs[req.GetSessionId()]
 	p.mu.Unlock()
 	if toolRef != nil {
-		conn, err := p.dialApp(ctx)
+		socketPath := strings.TrimSpace(p.started.SocketBinding().SocketPath)
+		if socketPath == "" {
+			cleanupPendingTurn()
+			return nil, fmt.Errorf("host service socket binding is missing")
+		}
+		conn, err := grpc.NewClient(
+			"passthrough:///localhost",
+			grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+				var d net.Dialer
+				return d.DialContext(ctx, "unix", socketPath)
+			}),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
 		if err != nil {
 			cleanupPendingTurn()
 			return nil, fmt.Errorf("dial app host: %w", err)
@@ -2249,8 +2183,8 @@ func TestBootstrapAgentManagerCreateTurnPersistsMetadataForToolCallbacks(t *test
 		},
 	)
 
-	callbackAgents := map[string]*callbackAgentProvider{}
-	factories.Agent = func(_ context.Context, name string, _ yaml.Node, hostServices []runtimehost.HostService, deps bootstrap.Deps) (coreagent.Provider, error) {
+	var provider *callbackAgentProvider
+	factories.Agent = func(_ context.Context, _ string, _ yaml.Node, hostServices []runtimehost.HostService, deps bootstrap.Deps) (coreagent.Provider, error) {
 		started, err := runtimehost.StartHostServices(hostServices, relayTokenHostServiceOptions(deps.EncryptionKey)...)
 		if err != nil {
 			return nil, err
@@ -2260,28 +2194,16 @@ func TestBootstrapAgentManagerCreateTurnPersistsMetadataForToolCallbacks(t *test
 			_ = started.Close()
 			return nil, err
 		}
-		callbackAgents[name] = value
+		provider = value
 		return value, nil
 	}
 
-	registry := runtimehost.NewPublicHostServiceRegistry()
-	relayKey := corecrypto.DeriveKey(cfg.Server.EncryptionKey)
-	relaySrv := newAppCallbackRelayServer(t, registry, relayKey)
-	cfg.Server.Runtime.RelayBaseURL = relaySrv.URL
-
-	result, err := bootstrap.BootstrapWithOptions(context.Background(), cfg, factories, bootstrap.BootstrapOptions{
-		PublicHostServices: registry,
-	})
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
 	if err != nil {
 		t.Fatalf("Bootstrap: %v", err)
 	}
 	defer func() { _ = result.Close(context.Background()) }()
 	<-result.ProvidersReady
-	provider := callbackAgents["managed"]
-	if provider.relayTokenManager, err = runtimehost.NewHostServiceRelayTokenManager(relayKey); err != nil {
-		t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
-	}
-	provider.dialApp = dialPublicRelayApp(relaySrv)
 
 	perms := principal.CompilePermissions([]core.AccessPermission{
 		{
@@ -2560,8 +2482,8 @@ func TestBootstrapAgentToolCatalogExecutesExactAppIssueTool(t *testing.T) {
 		},
 	)
 
-	callbackAgents := map[string]*callbackAgentProvider{}
-	factories.Agent = func(_ context.Context, name string, _ yaml.Node, hostServices []runtimehost.HostService, deps bootstrap.Deps) (coreagent.Provider, error) {
+	var provider *callbackAgentProvider
+	factories.Agent = func(_ context.Context, _ string, _ yaml.Node, hostServices []runtimehost.HostService, deps bootstrap.Deps) (coreagent.Provider, error) {
 		started, err := runtimehost.StartHostServices(hostServices, relayTokenHostServiceOptions(deps.EncryptionKey)...)
 		if err != nil {
 			return nil, err
@@ -2571,28 +2493,16 @@ func TestBootstrapAgentToolCatalogExecutesExactAppIssueTool(t *testing.T) {
 			_ = started.Close()
 			return nil, err
 		}
-		callbackAgents[name] = value
+		provider = value
 		return value, nil
 	}
 
-	registry := runtimehost.NewPublicHostServiceRegistry()
-	relayKey := corecrypto.DeriveKey(cfg.Server.EncryptionKey)
-	relaySrv := newAppCallbackRelayServer(t, registry, relayKey)
-	cfg.Server.Runtime.RelayBaseURL = relaySrv.URL
-
-	result, err := bootstrap.BootstrapWithOptions(context.Background(), cfg, factories, bootstrap.BootstrapOptions{
-		PublicHostServices: registry,
-	})
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
 	if err != nil {
 		t.Fatalf("Bootstrap: %v", err)
 	}
 	defer func() { _ = result.Close(context.Background()) }()
 	<-result.ProvidersReady
-	provider := callbackAgents["managed"]
-	if provider.relayTokenManager, err = runtimehost.NewHostServiceRelayTokenManager(relayKey); err != nil {
-		t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
-	}
-	provider.dialApp = dialPublicRelayApp(relaySrv)
 
 	permissions := []core.AccessPermission{
 		{
@@ -3407,8 +3317,6 @@ func TestBootstrapPassesIndexedDBHostSocketToWorkflowProviders(t *testing.T) {
 	<-result.ProvidersReady
 
 	got := hostEnvs["basic"]
-	// The app-invocation host service is registered once, globally, by
-	// bootstrap; per-provider host services no longer include it.
 	for _, want := range []string{"agent", "identity", "indexeddb", "workflow"} {
 		if !slices.Contains(got, want) {
 			t.Fatalf("workflow provider host services = %v, want %q", got, want)

--- a/gestaltd/internal/bootstrap/executable_app_test.go
+++ b/gestaltd/internal/bootstrap/executable_app_test.go
@@ -6411,8 +6411,6 @@ func TestRuntimeConfigInjectsRuntimeLogSessionAndHostService(t *testing.T) {
 	}
 }
 
-// registerGlobalAppInvocationForTest mirrors gestaltd bootstrap registering
-// the app-invocation host service once, globally, against the shared invoker.
 func registerGlobalAppInvocationForTest(t *testing.T, deps Deps) {
 	t.Helper()
 	t.Cleanup(registerGlobalAppInvocationPublicHostService(deps))

--- a/gestaltd/internal/bootstrap/executable_app_test.go
+++ b/gestaltd/internal/bootstrap/executable_app_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/apps/registry"
 	"github.com/valon-technologies/gestalt/server/services/egress"
 	"github.com/valon-technologies/gestalt/server/services/egressproxy"
+	"github.com/valon-technologies/gestalt/server/services/hostserviceingress"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	telemetrynoop "github.com/valon-technologies/gestalt/server/services/observability/drivers/noop"
@@ -2801,15 +2802,20 @@ func newNestedInvokeHarness(t *testing.T, brokerOpts ...invocation.BrokerOption)
 		},
 	}
 
-	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), testRuntimePublicEndpointDeps(t, Deps{
+	deps := testRuntimePublicEndpointDeps(t, Deps{
 		EncryptionKey: secret,
 		AppInvocation: bridge,
 		Authorization: newAllowAllAuthorizationProvider(),
-	}))
+	})
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), deps)
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
 	t.Cleanup(func() { _ = CloseProviders(providers) })
+	// Mirror gestaltd bootstrap: the app-invocation host service is registered
+	// once, globally, against the shared invoker.
+	appCleanup := registerGlobalAppInvocationPublicHostService(deps)
+	t.Cleanup(appCleanup)
 
 	services, err := coredata.New(&coretesting.StubIndexedDB{})
 	if err != nil {
@@ -2921,15 +2927,20 @@ func newGraphQLSurfaceInvokeHarness(t *testing.T, graphQLURL string, allowSurfac
 	}
 
 	secret := []byte("0123456789abcdef0123456789abcdef")
-	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), testRuntimePublicEndpointDeps(t, Deps{
+	deps := testRuntimePublicEndpointDeps(t, Deps{
 		EncryptionKey: secret,
 		AppInvocation: bridge,
 		Authorization: newAllowAllAuthorizationProvider(),
-	}))
+	})
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), deps)
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
 	t.Cleanup(func() { _ = CloseProviders(providers) })
+	// Mirror gestaltd bootstrap: the app-invocation host service is registered
+	// once, globally, against the shared invoker.
+	appCleanup := registerGlobalAppInvocationPublicHostService(deps)
+	t.Cleanup(appCleanup)
 
 	services, err := coredata.New(&coretesting.StubIndexedDB{})
 	if err != nil {
@@ -6059,6 +6070,8 @@ func TestRuntimePublicAppInvocationRelayRoundTripsThroughHostedApp(t *testing.T)
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
 	t.Cleanup(func() { _ = CloseProviders(providers) })
+	appCleanup := registerGlobalAppInvocationPublicHostService(deps)
+	t.Cleanup(appCleanup)
 	assertPublicHostServicesVerified(t, publicHostServices, "app")
 
 	services, err := coredata.New(&coretesting.StubIndexedDB{})
@@ -6444,6 +6457,10 @@ func newRuntimeRelayTestHandler(t *testing.T, stateSecret []byte, publicHostServ
 			writeRuntimeRelayGRPCTrailersOnly(w, codes.PermissionDenied, "host-service-relay-method-not-allowed")
 			return
 		}
+		if runtimehost.CallerCapabilityRequiredMethod(r.URL.Path) && target.Caller == nil && strings.TrimSpace(target.MethodPrefix) != "/" {
+			writeRuntimeRelayGRPCTrailersOnly(w, codes.Unauthenticated, "invalid-host-service-relay-token")
+			return
+		}
 		handler, err := runtimeRelayPublicHostServiceHandler(r.Context(), publicHostServices, target, r.URL.Path)
 		if err != nil {
 			writeRuntimeRelayGRPCTrailersOnly(w, codes.Unauthenticated, "invalid-host-service-relay-session")
@@ -6453,7 +6470,7 @@ func newRuntimeRelayTestHandler(t *testing.T, stateSecret []byte, publicHostServ
 			writeRuntimeRelayGRPCTrailersOnly(w, codes.Unavailable, "host-service-relay-unavailable")
 			return
 		}
-		relayReq := r.Clone(r.Context())
+		relayReq := r.Clone(hostserviceingress.ApplyCapability(runtimehost.WithRelayAuthenticated(r.Context()), target))
 		relayReq.Header = r.Header.Clone()
 		relayReq.Header.Del(runtimehost.HostServiceRelayTokenHeader)
 		handler.ServeHTTP(w, relayReq)
@@ -6539,8 +6556,12 @@ func runtimeRelayPublicHostServiceHandler(ctx context.Context, registry *runtime
 	if registry == nil {
 		return nil, nil
 	}
+	pluginName := strings.TrimSpace(target.AppName)
+	if strings.HasPrefix(methodPath, "/"+proto.App_ServiceDesc.ServiceName+"/") {
+		pluginName = appInvocationPublicProviderKey
+	}
 	for _, entry := range registry.Snapshot() {
-		if strings.TrimSpace(entry.AppName) != strings.TrimSpace(target.AppName) {
+		if strings.TrimSpace(entry.AppName) != pluginName {
 			continue
 		}
 		if !entry.Service.AllowsMethod(methodPath) {

--- a/gestaltd/internal/bootstrap/executable_app_test.go
+++ b/gestaltd/internal/bootstrap/executable_app_test.go
@@ -2812,10 +2812,7 @@ func newNestedInvokeHarness(t *testing.T, brokerOpts ...invocation.BrokerOption)
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
 	t.Cleanup(func() { _ = CloseProviders(providers) })
-	// Mirror gestaltd bootstrap: the app-invocation host service is registered
-	// once, globally, against the shared invoker.
-	appCleanup := registerGlobalAppInvocationPublicHostService(deps)
-	t.Cleanup(appCleanup)
+	registerGlobalAppInvocationForTest(t, deps)
 
 	services, err := coredata.New(&coretesting.StubIndexedDB{})
 	if err != nil {
@@ -2937,10 +2934,7 @@ func newGraphQLSurfaceInvokeHarness(t *testing.T, graphQLURL string, allowSurfac
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
 	t.Cleanup(func() { _ = CloseProviders(providers) })
-	// Mirror gestaltd bootstrap: the app-invocation host service is registered
-	// once, globally, against the shared invoker.
-	appCleanup := registerGlobalAppInvocationPublicHostService(deps)
-	t.Cleanup(appCleanup)
+	registerGlobalAppInvocationForTest(t, deps)
 
 	services, err := coredata.New(&coretesting.StubIndexedDB{})
 	if err != nil {
@@ -6070,8 +6064,7 @@ func TestRuntimePublicAppInvocationRelayRoundTripsThroughHostedApp(t *testing.T)
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
 	t.Cleanup(func() { _ = CloseProviders(providers) })
-	appCleanup := registerGlobalAppInvocationPublicHostService(deps)
-	t.Cleanup(appCleanup)
+	registerGlobalAppInvocationForTest(t, deps)
 	assertPublicHostServicesVerified(t, publicHostServices, "app")
 
 	services, err := coredata.New(&coretesting.StubIndexedDB{})
@@ -6416,6 +6409,13 @@ func TestRuntimeConfigInjectsRuntimeLogSessionAndHostService(t *testing.T) {
 	if got := startRequests[0].GetEnv()[runtimehost.HostServiceTokenEnv]; got == "" {
 		t.Fatalf("StartApp env missing %s", runtimehost.HostServiceTokenEnv)
 	}
+}
+
+// registerGlobalAppInvocationForTest mirrors gestaltd bootstrap registering
+// the app-invocation host service once, globally, against the shared invoker.
+func registerGlobalAppInvocationForTest(t *testing.T, deps Deps) {
+	t.Helper()
+	t.Cleanup(registerGlobalAppInvocationPublicHostService(deps))
 }
 
 func assertPublicHostServicesVerified(t *testing.T, registry *runtimehost.PublicHostServiceRegistry, serviceName string) {

--- a/gestaltd/internal/bootstrap/host_service_bootstrap.go
+++ b/gestaltd/internal/bootstrap/host_service_bootstrap.go
@@ -71,8 +71,16 @@ func buildProviderHostServices(name string, deps Deps, extraHostServices ...runt
 	if authenticationHostService, ok := authenticationHostServiceFromDeps(deps); ok {
 		hostServices = append(hostServices, authenticationHostService)
 	}
+	// The per-caller app host service is local-only: the public relay routes
+	// App RPCs to the single global registration (see
+	// registerGlobalAppInvocationPublicHostService), so the per-caller one
+	// must not duplicate it in the registry. Empty MethodPrefixes excludes it
+	// from public relay registration while the unix-socket listener still
+	// serves it.
+	appHostService := buildAppInvocationHostService(name, deps)
+	appHostService.MethodPrefixes = nil
 	hostServices = append(hostServices,
-		buildAppInvocationHostService(name, deps),
+		appHostService,
 		buildWorkflowProviderHostService(name, deps),
 		buildPluginAgentProviderHostService(name, deps),
 	)
@@ -182,15 +190,23 @@ func grpcMethodPrefix(serviceName string) string {
 }
 
 func mergeHostedRuntimeHostServiceRelayEnv(providerName, sessionID string, hostServices []runtimehost.HostService, deps Deps) (map[string]string, string, error) {
-	if len(hostServices) == 0 {
-		return nil, "", nil
-	}
+	// Local-only host services (empty MethodPrefixes, e.g. the per-caller app
+	// service) are not registered with the public relay; the relay routes
+	// their RPCs to a global registration instead.
+	publicHostServices := make([]runtimehost.HostService, 0, len(hostServices))
 	for _, hostService := range hostServices {
-		if strings.TrimSpace(hostService.Name) == "" || len(hostService.MethodPrefixes) == 0 {
+		if len(hostService.MethodPrefixes) == 0 {
+			continue
+		}
+		if strings.TrimSpace(hostService.Name) == "" {
 			return nil, "", fmt.Errorf("host service %q requires public host service relay support", hostService.Name)
 		}
+		publicHostServices = append(publicHostServices, hostService)
 	}
-	serviceLabel := strings.ReplaceAll(strings.TrimSpace(hostServices[0].Name), "_", " ")
+	if len(publicHostServices) == 0 {
+		return nil, "", nil
+	}
+	serviceLabel := strings.ReplaceAll(strings.TrimSpace(publicHostServices[0].Name), "_", " ")
 	relayDialTarget, relayEnv, relayHost, ok, err := buildHostedRuntimePublicHostServiceRelay(
 		providerName,
 		sessionID,
@@ -242,37 +258,30 @@ func registerPublicRuntimeHostServices(providerName string, hostServices []runti
 	return registerVerifiedPublicHostServices(providerName, hostServices, deps, runtimeHostServiceSessionVerifier{}, false)
 }
 
-func registerConfiguredAppPublicHostServices(cfg *config.Config, deps Deps) func() {
-	if cfg == nil || !hostCanRelayRuntimeHostServices(deps) {
+// appInvocationPublicProviderKey is the well-known registration key for the
+// single, global app-invocation host service. Relay routing matches App RPCs
+// to this registration by gRPC service name, so it must stay stable.
+const appInvocationPublicProviderKey = "app"
+
+// registerGlobalAppInvocationPublicHostService registers the single global
+// app-invocation host service. It must be called after deps.AppInvocation is
+// set to the guarded shared invoker so app-to-app invokes route through the
+// shared invocation broker.
+func registerGlobalAppInvocationPublicHostService(deps Deps) func() {
+	if !hostCanRelayRuntimeHostServices(deps) {
 		return func() {}
 	}
-	var cleanups []func()
-	for _, name := range slices.Sorted(maps.Keys(cfg.Apps)) {
-		entry := cfg.Apps[name]
-		if !config.EntryBuildsLocal(entry) {
-			continue
-		}
-		if entry != nil && entry.DevActive && deps.DevSupervisor != nil {
-			continue
-		}
-		hostServices, err := buildProviderHostServices(name, appProviderHostServiceDeps(entry, deps))
-		if err != nil {
-			slog.Warn("eager public host service registration skipped", "provider", name, "error", err)
-			continue
-		}
-		if len(hostServices) == 0 {
-			continue
-		}
-		cleanup, err := registerPublicRuntimeHostServices(name, hostServices, deps)
-		if err != nil {
-			slog.Warn("eager public host service registration failed", "provider", name, "error", err)
-			continue
-		}
-		if cleanup != nil {
-			cleanups = append(cleanups, cleanup)
-		}
+	cleanup, err := registerPublicRuntimeHostServices(appInvocationPublicProviderKey, []runtimehost.HostService{
+		buildGlobalAppInvocationHostService(deps),
+	}, deps)
+	if err != nil {
+		slog.Warn("global app invocation public host service registration failed", "error", err)
+		return func() {}
 	}
-	return chainCleanup(cleanups...)
+	if cleanup == nil {
+		return func() {}
+	}
+	return cleanup
 }
 
 type workflowProviderHostServiceSessionVerifier struct{}
@@ -504,6 +513,28 @@ func buildPluginExternalCredentialsHostService(provider core.ExternalCredentialP
 		MethodPrefixes: []string{grpcMethodPrefix(proto.ExternalCredentials_ServiceDesc.ServiceName)},
 		Register: func(srv *grpc.Server) {
 			proto.RegisterExternalCredentialsServer(srv, externalcredentialsservice.NewProviderServer(provider))
+		},
+	}
+}
+
+// buildGlobalAppInvocationHostService builds the one app-invocation host
+// service shared by all callers. Caller identity comes from the verified
+// relay token (see hostserviceingress.ApplyCapability), not from the
+// registration, so a single process-global registration serves every caller
+// and every replica.
+func buildGlobalAppInvocationHostService(deps Deps) runtimehost.HostService {
+	invoker := deps.AppInvocation
+	if invoker == nil {
+		invoker = unavailableAppInvocation{}
+	}
+	return runtimehost.HostService{
+		Name:           "app",
+		MethodPrefixes: []string{grpcMethodPrefix(proto.App_ServiceDesc.ServiceName)},
+		Register: func(srv *grpc.Server) {
+			proto.RegisterAppServer(srv, appaccessservice.NewServer(
+				invoker,
+				appaccessservice.WithAgentAppInvocationAuthorizer(deps.AgentManager),
+			))
 		},
 	}
 }

--- a/gestaltd/internal/bootstrap/host_service_bootstrap.go
+++ b/gestaltd/internal/bootstrap/host_service_bootstrap.go
@@ -72,7 +72,7 @@ func buildProviderHostServices(name string, deps Deps, extraHostServices ...runt
 		hostServices = append(hostServices, authenticationHostService)
 	}
 	hostServices = append(hostServices,
-		buildLocalAppInvocationHostService(name, deps),
+		buildAppInvocationHostService(name, deps, nil),
 		buildWorkflowProviderHostService(name, deps),
 		buildPluginAgentProviderHostService(name, deps),
 	)
@@ -182,8 +182,6 @@ func grpcMethodPrefix(serviceName string) string {
 }
 
 func mergeHostedRuntimeHostServiceRelayEnv(providerName, sessionID string, hostServices []runtimehost.HostService, deps Deps) (map[string]string, string, error) {
-	// Host services with no MethodPrefixes are local-only; the relay routes
-	// their RPCs to a global registration instead.
 	publicHostServices := make([]runtimehost.HostService, 0, len(hostServices))
 	for _, hostService := range hostServices {
 		if len(hostService.MethodPrefixes) == 0 {
@@ -249,20 +247,14 @@ func registerPublicRuntimeHostServices(providerName string, hostServices []runti
 	return registerVerifiedPublicHostServices(providerName, hostServices, deps, runtimeHostServiceSessionVerifier{}, false)
 }
 
-// appInvocationPublicProviderKey is the well-known registration key for the
-// single, global app-invocation host service. Relay routing matches App RPCs
-// to this registration by gRPC service name, so it must stay stable.
 const appInvocationPublicProviderKey = "app"
 
-// registerGlobalAppInvocationPublicHostService must run after deps.AppInvocation
-// is set to the guarded shared invoker so app-to-app invokes route through the
-// shared invocation broker.
 func registerGlobalAppInvocationPublicHostService(deps Deps) func() {
 	if !hostCanRelayRuntimeHostServices(deps) {
 		return func() {}
 	}
 	cleanup, err := registerPublicRuntimeHostServices(appInvocationPublicProviderKey, []runtimehost.HostService{
-		buildAppInvocationHostService("", deps),
+		buildAppInvocationHostService("", deps, []string{grpcMethodPrefix(proto.App_ServiceDesc.ServiceName)}),
 	}, deps)
 	if err != nil || cleanup == nil {
 		if err != nil {
@@ -506,21 +498,7 @@ func buildPluginExternalCredentialsHostService(provider core.ExternalCredentialP
 	}
 }
 
-// buildAppInvocationHostService builds the app-invocation host service. With
-// a caller name it enforces that the caller matches; with an empty caller name
-// (the global registration) caller identity comes from the verified relay
-// token instead.
-func buildAppInvocationHostService(callerName string, deps Deps) runtimehost.HostService {
-	return buildAppInvocationHostServiceWithPrefixes(callerName, deps, []string{grpcMethodPrefix(proto.App_ServiceDesc.ServiceName)})
-}
-
-// buildLocalAppInvocationHostService is the per-caller unix-socket variant:
-// no method prefixes, so it stays off the public relay registry.
-func buildLocalAppInvocationHostService(callerName string, deps Deps) runtimehost.HostService {
-	return buildAppInvocationHostServiceWithPrefixes(callerName, deps, nil)
-}
-
-func buildAppInvocationHostServiceWithPrefixes(callerName string, deps Deps, methodPrefixes []string) runtimehost.HostService {
+func buildAppInvocationHostService(callerName string, deps Deps, methodPrefixes []string) runtimehost.HostService {
 	invoker := deps.AppInvocation
 	if invoker == nil {
 		invoker = unavailableAppInvocation{}
@@ -536,7 +514,7 @@ func buildAppInvocationHostServiceWithPrefixes(callerName string, deps Deps, met
 		Name:           "app",
 		MethodPrefixes: methodPrefixes,
 		Register: func(srv *grpc.Server) {
-			proto.RegisterAppServer(srv, appaccessservice.NewServer(invoker, opts...))
+			proto.RegisterAppServer(srv, appaccessservice.NewAppServer(invoker, opts...))
 		},
 	}
 }

--- a/gestaltd/internal/bootstrap/host_service_bootstrap.go
+++ b/gestaltd/internal/bootstrap/host_service_bootstrap.go
@@ -71,16 +71,8 @@ func buildProviderHostServices(name string, deps Deps, extraHostServices ...runt
 	if authenticationHostService, ok := authenticationHostServiceFromDeps(deps); ok {
 		hostServices = append(hostServices, authenticationHostService)
 	}
-	// The per-caller app host service is local-only: the public relay routes
-	// App RPCs to the single global registration (see
-	// registerGlobalAppInvocationPublicHostService), so the per-caller one
-	// must not duplicate it in the registry. Empty MethodPrefixes excludes it
-	// from public relay registration while the unix-socket listener still
-	// serves it.
-	appHostService := buildAppInvocationHostService(name, deps)
-	appHostService.MethodPrefixes = nil
 	hostServices = append(hostServices,
-		appHostService,
+		buildLocalAppInvocationHostService(name, deps),
 		buildWorkflowProviderHostService(name, deps),
 		buildPluginAgentProviderHostService(name, deps),
 	)
@@ -190,8 +182,7 @@ func grpcMethodPrefix(serviceName string) string {
 }
 
 func mergeHostedRuntimeHostServiceRelayEnv(providerName, sessionID string, hostServices []runtimehost.HostService, deps Deps) (map[string]string, string, error) {
-	// Local-only host services (empty MethodPrefixes, e.g. the per-caller app
-	// service) are not registered with the public relay; the relay routes
+	// Host services with no MethodPrefixes are local-only; the relay routes
 	// their RPCs to a global registration instead.
 	publicHostServices := make([]runtimehost.HostService, 0, len(hostServices))
 	for _, hostService := range hostServices {
@@ -263,22 +254,20 @@ func registerPublicRuntimeHostServices(providerName string, hostServices []runti
 // to this registration by gRPC service name, so it must stay stable.
 const appInvocationPublicProviderKey = "app"
 
-// registerGlobalAppInvocationPublicHostService registers the single global
-// app-invocation host service. It must be called after deps.AppInvocation is
-// set to the guarded shared invoker so app-to-app invokes route through the
+// registerGlobalAppInvocationPublicHostService must run after deps.AppInvocation
+// is set to the guarded shared invoker so app-to-app invokes route through the
 // shared invocation broker.
 func registerGlobalAppInvocationPublicHostService(deps Deps) func() {
 	if !hostCanRelayRuntimeHostServices(deps) {
 		return func() {}
 	}
 	cleanup, err := registerPublicRuntimeHostServices(appInvocationPublicProviderKey, []runtimehost.HostService{
-		buildGlobalAppInvocationHostService(deps),
+		buildAppInvocationHostService("", deps),
 	}, deps)
-	if err != nil {
-		slog.Warn("global app invocation public host service registration failed", "error", err)
-		return func() {}
-	}
-	if cleanup == nil {
+	if err != nil || cleanup == nil {
+		if err != nil {
+			slog.Warn("global app invocation public host service registration failed", "error", err)
+		}
 		return func() {}
 	}
 	return cleanup
@@ -517,42 +506,37 @@ func buildPluginExternalCredentialsHostService(provider core.ExternalCredentialP
 	}
 }
 
-// buildGlobalAppInvocationHostService builds the one app-invocation host
-// service shared by all callers. Caller identity comes from the verified
-// relay token (see hostserviceingress.ApplyCapability), not from the
-// registration, so a single process-global registration serves every caller
-// and every replica.
-func buildGlobalAppInvocationHostService(deps Deps) runtimehost.HostService {
-	invoker := deps.AppInvocation
-	if invoker == nil {
-		invoker = unavailableAppInvocation{}
-	}
-	return runtimehost.HostService{
-		Name:           "app",
-		MethodPrefixes: []string{grpcMethodPrefix(proto.App_ServiceDesc.ServiceName)},
-		Register: func(srv *grpc.Server) {
-			proto.RegisterAppServer(srv, appaccessservice.NewServer(
-				invoker,
-				appaccessservice.WithAgentAppInvocationAuthorizer(deps.AgentManager),
-			))
-		},
-	}
+// buildAppInvocationHostService builds the app-invocation host service. With
+// a caller name it enforces that the caller matches; with an empty caller name
+// (the global registration) caller identity comes from the verified relay
+// token instead.
+func buildAppInvocationHostService(callerName string, deps Deps) runtimehost.HostService {
+	return buildAppInvocationHostServiceWithPrefixes(callerName, deps, []string{grpcMethodPrefix(proto.App_ServiceDesc.ServiceName)})
 }
 
-func buildAppInvocationHostService(appName string, deps Deps) runtimehost.HostService {
+// buildLocalAppInvocationHostService is the per-caller unix-socket variant:
+// no method prefixes, so it stays off the public relay registry.
+func buildLocalAppInvocationHostService(callerName string, deps Deps) runtimehost.HostService {
+	return buildAppInvocationHostServiceWithPrefixes(callerName, deps, nil)
+}
+
+func buildAppInvocationHostServiceWithPrefixes(callerName string, deps Deps, methodPrefixes []string) runtimehost.HostService {
 	invoker := deps.AppInvocation
 	if invoker == nil {
 		invoker = unavailableAppInvocation{}
 	}
+	var opts []appaccessservice.AppServerOption
+	if deps.AgentManager != nil {
+		opts = append(opts, appaccessservice.WithAgentAppInvocationAuthorizer(deps.AgentManager))
+	}
+	if callerName != "" {
+		opts = append(opts, appaccessservice.WithCallerApp(callerName))
+	}
 	return runtimehost.HostService{
 		Name:           "app",
-		MethodPrefixes: []string{grpcMethodPrefix(proto.App_ServiceDesc.ServiceName)},
+		MethodPrefixes: methodPrefixes,
 		Register: func(srv *grpc.Server) {
-			proto.RegisterAppServer(srv, appaccessservice.NewServer(
-				invoker,
-				appaccessservice.WithAgentAppInvocationAuthorizer(deps.AgentManager),
-				appaccessservice.WithCallerApp(appName),
-			))
+			proto.RegisterAppServer(srv, appaccessservice.NewServer(invoker, opts...))
 		},
 	}
 }

--- a/gestaltd/internal/bootstrap/host_service_bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/host_service_bootstrap_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
-	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 )
 
@@ -22,33 +21,26 @@ func eagerHostServiceTestDeps(registry *runtimehost.PublicHostServiceRegistry) D
 	}
 }
 
-func appIndexedDBRegistered(registry *runtimehost.PublicHostServiceRegistry, appName string) bool {
+func appHostServiceRegistered(registry *runtimehost.PublicHostServiceRegistry) bool {
 	for _, service := range registry.Snapshot() {
-		if service.AppName == appName && service.Service.Name == "indexeddb" {
+		if service.AppName == appInvocationPublicProviderKey && service.Service.Name == "app" {
 			return true
 		}
 	}
 	return false
 }
 
-func TestRegisterConfiguredAppPublicHostServicesRegistersDefaultRuntimeApp(t *testing.T) {
+func TestRegisterGlobalAppInvocationPublicHostServiceRegistersOnce(t *testing.T) {
 	t.Parallel()
 
 	registry := runtimehost.NewPublicHostServiceRegistry()
 	deps := eagerHostServiceTestDeps(registry)
-	cfg := &config.Config{
-		Apps: map[string]*config.ProviderEntry{
-			"gIssues": {
-				IndexedDB: &config.IndexedDBBindingConfig{Provider: "main"},
-			},
-		},
-	}
 
-	cleanup := registerConfiguredAppPublicHostServices(cfg, deps)
+	cleanup := registerGlobalAppInvocationPublicHostService(deps)
 
-	assertPublicHostServicesVerified(t, registry, "indexeddb")
-	if !appIndexedDBRegistered(registry, "gIssues") {
-		t.Fatalf("registry = %#v, want indexeddb host service for gIssues before activation", registry.Snapshot())
+	assertPublicHostServicesVerified(t, registry, "app")
+	if !appHostServiceRegistered(registry) {
+		t.Fatalf("registry = %#v, want global app host service under %q", registry.Snapshot(), appInvocationPublicProviderKey)
 	}
 
 	cleanup()
@@ -57,42 +49,14 @@ func TestRegisterConfiguredAppPublicHostServicesRegistersDefaultRuntimeApp(t *te
 	}
 }
 
-func TestRegisterConfiguredAppPublicHostServicesRegistersDevActiveWithoutSupervisor(t *testing.T) {
-	t.Parallel()
-
-	registry := runtimehost.NewPublicHostServiceRegistry()
-	deps := eagerHostServiceTestDeps(registry)
-	cfg := &config.Config{
-		Apps: map[string]*config.ProviderEntry{
-			"gIssues": {
-				DevActive: true,
-				IndexedDB: &config.IndexedDBBindingConfig{Provider: "main"},
-			},
-		},
-	}
-
-	registerConfiguredAppPublicHostServices(cfg, deps)
-
-	if !appIndexedDBRegistered(registry, "gIssues") {
-		t.Fatalf("registry = %#v, want indexeddb host service registered without a DevSupervisor", registry.Snapshot())
-	}
-}
-
-func TestRegisterConfiguredAppPublicHostServicesNoopWithoutRelay(t *testing.T) {
+func TestRegisterGlobalAppInvocationPublicHostServiceNoopWithoutRelay(t *testing.T) {
 	t.Parallel()
 
 	registry := runtimehost.NewPublicHostServiceRegistry()
 	deps := eagerHostServiceTestDeps(registry)
 	deps.EncryptionKey = nil
-	cfg := &config.Config{
-		Apps: map[string]*config.ProviderEntry{
-			"gIssues": {
-				IndexedDB: &config.IndexedDBBindingConfig{Provider: "main"},
-			},
-		},
-	}
 
-	registerConfiguredAppPublicHostServices(cfg, deps)
+	registerGlobalAppInvocationPublicHostService(deps)
 
 	if services := registry.Snapshot(); len(services) != 0 {
 		t.Fatalf("registry = %#v, want no registration when the public relay is unavailable", services)

--- a/gestaltd/internal/bootstrap/workflow_startup_test.go
+++ b/gestaltd/internal/bootstrap/workflow_startup_test.go
@@ -121,7 +121,9 @@ func TestBuildProviderHostServicesDoesNotRequireConfiguredEncryptionKey(t *testi
 	}
 
 	names := hostServiceNames(hostServices)
-	for _, want := range []string{"app", "workflow", "agent", "external_credentials", "authorization"} {
+	// The app-invocation host service is registered once, globally, by
+	// bootstrap; per-provider host services no longer include it.
+	for _, want := range []string{"workflow", "agent", "external_credentials", "authorization"} {
 		if !hasHostServiceName(names, want) {
 			t.Fatalf("provider host services missing %q: %v", want, names)
 		}

--- a/gestaltd/internal/bootstrap/workflow_startup_test.go
+++ b/gestaltd/internal/bootstrap/workflow_startup_test.go
@@ -121,8 +121,6 @@ func TestBuildProviderHostServicesDoesNotRequireConfiguredEncryptionKey(t *testi
 	}
 
 	names := hostServiceNames(hostServices)
-	// The app-invocation host service is registered once, globally, by
-	// bootstrap; per-provider host services no longer include it.
 	for _, want := range []string{"workflow", "agent", "external_credentials", "authorization"} {
 		if !hasHostServiceName(names, want) {
 			t.Fatalf("provider host services missing %q: %v", want, names)

--- a/gestaltd/internal/server/host_service_public.go
+++ b/gestaltd/internal/server/host_service_public.go
@@ -73,16 +73,10 @@ func (k hostServiceHandlerKey) String() string {
 	return k.pluginName
 }
 
-// appInvocationPublicProviderKey is the well-known registration key for the
-// single, global app-invocation host service registered by gestaltd bootstrap.
 const appInvocationPublicProviderKey = "app"
 
 var appServiceMethodPrefix = "/" + proto.App_ServiceDesc.ServiceName + "/"
 
-// hostServiceRelayPluginName routes App/* RPCs to the single global
-// app-invocation host service: the token's AppName is the caller, not the
-// serving provider, and caller identity comes from the verified token. All
-// other services stay keyed by the caller's provider name.
 func hostServiceRelayPluginName(target runtimehost.HostServiceRelayTarget, methodPath string) string {
 	if strings.HasPrefix(methodPath, appServiceMethodPrefix) {
 		return appInvocationPublicProviderKey

--- a/gestaltd/internal/server/host_service_public.go
+++ b/gestaltd/internal/server/host_service_public.go
@@ -79,11 +79,10 @@ const appInvocationPublicProviderKey = "app"
 
 var appServiceMethodPrefix = "/" + proto.App_ServiceDesc.ServiceName + "/"
 
-// hostServiceRelayPluginName returns the registration key for a relay call.
-// App/* RPCs route to the single global app-invocation host service: the
-// token's AppName is the caller, not the serving provider, and the global
-// registration sources caller identity from the verified token. All other
-// services stay keyed by the caller's provider name.
+// hostServiceRelayPluginName routes App/* RPCs to the single global
+// app-invocation host service: the token's AppName is the caller, not the
+// serving provider, and caller identity comes from the verified token. All
+// other services stay keyed by the caller's provider name.
 func hostServiceRelayPluginName(target runtimehost.HostServiceRelayTarget, methodPath string) string {
 	if strings.HasPrefix(methodPath, appServiceMethodPrefix) {
 		return appInvocationPublicProviderKey

--- a/gestaltd/internal/server/host_service_public.go
+++ b/gestaltd/internal/server/host_service_public.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"google.golang.org/grpc"
 )
@@ -72,8 +73,26 @@ func (k hostServiceHandlerKey) String() string {
 	return k.pluginName
 }
 
+// appInvocationPublicProviderKey is the well-known registration key for the
+// single, global app-invocation host service registered by gestaltd bootstrap.
+const appInvocationPublicProviderKey = "app"
+
+var appServiceMethodPrefix = "/" + proto.App_ServiceDesc.ServiceName + "/"
+
+// hostServiceRelayPluginName returns the registration key for a relay call.
+// App/* RPCs route to the single global app-invocation host service: the
+// token's AppName is the caller, not the serving provider, and the global
+// registration sources caller identity from the verified token. All other
+// services stay keyed by the caller's provider name.
+func hostServiceRelayPluginName(target runtimehost.HostServiceRelayTarget, methodPath string) string {
+	if strings.HasPrefix(methodPath, appServiceMethodPrefix) {
+		return appInvocationPublicProviderKey
+	}
+	return strings.TrimSpace(target.AppName)
+}
+
 func (s *Server) unifiedHostServiceHandler(ctx context.Context, target runtimehost.HostServiceRelayTarget, methodPath string) (http.Handler, error) {
-	pluginName := strings.TrimSpace(target.AppName)
+	pluginName := hostServiceRelayPluginName(target, methodPath)
 	if s == nil || pluginName == "" {
 		return nil, nil
 	}

--- a/gestaltd/internal/server/host_service_public_test.go
+++ b/gestaltd/internal/server/host_service_public_test.go
@@ -73,7 +73,6 @@ func TestUnifiedHostServiceHandlerRoutesAppServiceToGlobalRegistration(t *testin
 	})
 	s := &Server{publicHostServices: registry}
 
-	// The token's AppName is the caller; App/* RPCs resolve to the global registration.
 	handler, err := s.unifiedHostServiceHandler(context.Background(), runtimehost.HostServiceRelayTarget{
 		AppName:   "agent-trace-viewer",
 		SessionID: "session-1",
@@ -86,7 +85,6 @@ func TestUnifiedHostServiceHandlerRoutesAppServiceToGlobalRegistration(t *testin
 		t.Fatal("handler = nil, want global app handler")
 	}
 
-	// Non-App services stay keyed by the caller provider name.
 	handler, err = s.unifiedHostServiceHandler(context.Background(), runtimehost.HostServiceRelayTarget{
 		AppName:   "agent-trace-viewer",
 		SessionID: "session-1",

--- a/gestaltd/internal/server/host_service_public_test.go
+++ b/gestaltd/internal/server/host_service_public_test.go
@@ -73,8 +73,7 @@ func TestUnifiedHostServiceHandlerRoutesAppServiceToGlobalRegistration(t *testin
 	})
 	s := &Server{publicHostServices: registry}
 
-	// The token's AppName is the caller (no per-caller registration exists);
-	// App/* RPCs still resolve to the single global registration.
+	// The token's AppName is the caller; App/* RPCs resolve to the global registration.
 	handler, err := s.unifiedHostServiceHandler(context.Background(), runtimehost.HostServiceRelayTarget{
 		AppName:   "agent-trace-viewer",
 		SessionID: "session-1",
@@ -87,7 +86,7 @@ func TestUnifiedHostServiceHandlerRoutesAppServiceToGlobalRegistration(t *testin
 		t.Fatal("handler = nil, want global app handler")
 	}
 
-	// Non-App services stay keyed by the token's provider name.
+	// Non-App services stay keyed by the caller provider name.
 	handler, err = s.unifiedHostServiceHandler(context.Background(), runtimehost.HostServiceRelayTarget{
 		AppName:   "agent-trace-viewer",
 		SessionID: "session-1",

--- a/gestaltd/internal/server/host_service_public_test.go
+++ b/gestaltd/internal/server/host_service_public_test.go
@@ -62,6 +62,45 @@ func TestUnifiedHostServiceHandlerRoutesByGRPCMethod(t *testing.T) {
 	}
 }
 
+func TestUnifiedHostServiceHandlerRoutesAppServiceToGlobalRegistration(t *testing.T) {
+	t.Parallel()
+
+	registry := runtimehost.NewPublicHostServiceRegistry()
+	registry.RegisterVerified(appInvocationPublicProviderKey, allowHostServiceSessionVerifier{}, runtimehost.HostService{
+		Name:           "app",
+		MethodPrefixes: []string{"/gestalt.provider.v1.App/"},
+		Register:       func(*grpc.Server) {},
+	})
+	s := &Server{publicHostServices: registry}
+
+	// The token's AppName is the caller (no per-caller registration exists);
+	// App/* RPCs still resolve to the single global registration.
+	handler, err := s.unifiedHostServiceHandler(context.Background(), runtimehost.HostServiceRelayTarget{
+		AppName:   "agent-trace-viewer",
+		SessionID: "session-1",
+		Service:   "app",
+	}, "/gestalt.provider.v1.App/Invoke")
+	if err != nil {
+		t.Fatalf("unifiedHostServiceHandler: %v", err)
+	}
+	if handler == nil {
+		t.Fatal("handler = nil, want global app handler")
+	}
+
+	// Non-App services stay keyed by the token's provider name.
+	handler, err = s.unifiedHostServiceHandler(context.Background(), runtimehost.HostServiceRelayTarget{
+		AppName:   "agent-trace-viewer",
+		SessionID: "session-1",
+		Service:   "cache",
+	}, "/gestalt.provider.v1.Cache/Get")
+	if err != nil {
+		t.Fatalf("unifiedHostServiceHandler cache: %v", err)
+	}
+	if handler != nil {
+		t.Fatal("handler for caller-keyed service is non-nil, want no leak into the global app key")
+	}
+}
+
 func TestValidatePublicHostServicesRejectsProviderWideServiceWithoutVerifier(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/server/host_service_relay.go
+++ b/gestaltd/internal/server/host_service_relay.go
@@ -32,7 +32,7 @@ func (s *Server) hostServiceRelayMiddleware(next http.Handler) http.Handler {
 			writeGRPCTrailersOnly(w, codes.PermissionDenied, "host-service-relay-method-not-allowed")
 			return
 		}
-		if runtimehost.CallerCapabilityRequiredMethod(r.URL.Path) && capability.Caller == nil {
+		if runtimehost.CallerCapabilityRequiredMethod(r.URL.Path) && capability.Caller == nil && strings.TrimSpace(capability.MethodPrefix) != "/" {
 			writeGRPCTrailersOnly(w, codes.Unauthenticated, "invalid-host-service-relay-token")
 			return
 		}
@@ -47,7 +47,7 @@ func (s *Server) hostServiceRelayMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		ctx := r.Context()
+		ctx := runtimehost.WithRelayAuthenticated(r.Context())
 		ctx = hostserviceingress.ApplyCapability(ctx, capability)
 
 		relayReq := r.Clone(ctx)

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -675,6 +675,13 @@ func (i *relayTestInvoker) Invoke(ctx context.Context, _ *principal.Principal, p
 		idempotencyKey: invocation.IdempotencyKeyFromContext(ctx),
 		params:         maps.Clone(params),
 	}
+	if caller := invocation.CallerProviderFromContext(ctx); caller.Name != "" {
+		call.callerProvider = caller.Name
+		call.callerKind = string(caller.Kind)
+	}
+	if p := principal.FromContext(ctx); p != nil {
+		call.callerSubjectID = p.SubjectID
+	}
 	i.history = append(i.history, call)
 	i.providerName = providerName
 	i.instance = instance
@@ -685,12 +692,15 @@ func (i *relayTestInvoker) Invoke(ctx context.Context, _ *principal.Principal, p
 }
 
 type relayTestInvokerCall struct {
-	calls          int
-	providerName   string
-	instance       string
-	operation      string
-	idempotencyKey string
-	params         map[string]any
+	calls           int
+	providerName    string
+	instance        string
+	operation       string
+	idempotencyKey  string
+	params          map[string]any
+	callerProvider  string
+	callerKind      string
+	callerSubjectID string
 }
 
 func (i *relayTestInvoker) snapshot() relayTestInvokerCall {
@@ -736,10 +746,14 @@ func (i *principalRecordingInvoker) subjectIDValue() string {
 }
 
 func relayAppRequestContext() *proto.RequestContext {
+	return relayAppRequestContextForCaller("support")
+}
+
+func relayAppRequestContextForCaller(caller string) *proto.RequestContext {
 	return &proto.RequestContext{
 		Caller: &proto.ProviderContext{
 			Kind: string(invocation.ProviderKindApp),
-			Name: "support",
+			Name: caller,
 		},
 		Subject: &proto.SubjectContext{
 			Id: "user:test-user",
@@ -1130,14 +1144,16 @@ func TestHostServiceRelayRoutesRegisteredAppService(t *testing.T) {
 	invoker := &relayTestInvoker{}
 	publicHostServices := runtimehost.NewPublicHostServiceRegistry()
 	sessionVerifier := newRelayTestSessionVerifier("relay-session")
-	publicHostServices.RegisterVerified("support", sessionVerifier, runtimehost.HostService{
+	// The app-invocation host service is registered once, globally, under the
+	// well-known "app" key rather than per caller name; the relay token's
+	// AppName ("agent-trace-viewer") deliberately has no registration of its
+	// own, mirroring the cross-replica declarative-target miss that used to
+	// return host-service-relay-unavailable.
+	publicHostServices.RegisterVerified("app", sessionVerifier, runtimehost.HostService{
 		Name:           "app",
 		MethodPrefixes: []string{"/" + proto.App_ServiceDesc.ServiceName + "/"},
 		Register: func(srv *grpc.Server) {
-			proto.RegisterAppServer(srv, appaccessservice.NewServer(
-				invoker,
-				appaccessservice.WithCallerApp("support"),
-			))
+			proto.RegisterAppServer(srv, appaccessservice.NewServer(invoker))
 		},
 	})
 	ts := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
@@ -1154,7 +1170,7 @@ func TestHostServiceRelayRoutesRegisteredAppService(t *testing.T) {
 		t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
 	}
 	relayToken, err := tokenManager.MintToken(runtimehost.HostServiceRelayTokenRequest{
-		AppName:      "support",
+		AppName:      "agent-trace-viewer",
 		SessionID:    "relay-session",
 		Service:      "app",
 		MethodPrefix: "/" + proto.App_ServiceDesc.ServiceName + "/",
@@ -1170,17 +1186,23 @@ func TestHostServiceRelayRoutesRegisteredAppService(t *testing.T) {
 	defer cancel()
 	ctx = metadata.NewOutgoingContext(ctx, relayTestMetadata(relayToken))
 	_, err = proto.NewAppClient(conn).Invoke(ctx, &proto.AppInvokeRequest{
-		Context:        relayAppRequestContext(),
-		App:            "slack",
-		Operation:      "events.reply",
+		Context:        relayAppRequestContextForCaller("agent-trace-viewer"),
+		App:            "gcs",
+		Operation:      "load_trace_url",
 		Instance:       "prod",
 		IdempotencyKey: "relay-call",
 	})
 	if err != nil {
 		t.Fatalf("AppInvocation.Invoke via registered relay: %v", err)
 	}
-	if call := invoker.snapshot(); call.calls != 1 || call.providerName != "slack" || call.operation != "events.reply" || call.instance != "prod" {
-		t.Fatalf("plugin invoker call = %+v, want slack events.reply/prod", call)
+	if call := invoker.snapshot(); call.calls != 1 || call.providerName != "gcs" || call.operation != "load_trace_url" || call.instance != "prod" {
+		t.Fatalf("plugin invoker call = %+v, want gcs load_trace_url/prod", call)
+	}
+	if call := invoker.snapshot(); call.callerProvider != "agent-trace-viewer" || call.callerKind != string(invocation.ProviderKindApp) {
+		t.Fatalf("plugin invoker caller = %s/%s, want restored caller provider agent-trace-viewer/app", call.callerProvider, call.callerKind)
+	}
+	if call := invoker.snapshot(); call.callerSubjectID != "user:relay-test" {
+		t.Fatalf("plugin invoker principal = %q, want subject restored from the verified token", call.callerSubjectID)
 	}
 
 	sessionVerifier.setActive("relay-session", false)
@@ -1188,9 +1210,9 @@ func TestHostServiceRelayRoutesRegisteredAppService(t *testing.T) {
 	defer staleCancel()
 	staleCtx = metadata.NewOutgoingContext(staleCtx, relayTestMetadata(relayToken))
 	_, err = proto.NewAppClient(conn).Invoke(staleCtx, &proto.AppInvokeRequest{
-		Context:   relayAppRequestContext(),
-		App:       "slack",
-		Operation: "events.reply",
+		Context:   relayAppRequestContextForCaller("agent-trace-viewer"),
+		App:       "gcs",
+		Operation: "load_trace_url",
 	})
 	if grpcstatus.Code(err) != codes.Unauthenticated {
 		t.Fatalf("AppInvocation.Invoke stale session code = %v, want %v (err=%v)", grpcstatus.Code(err), codes.Unauthenticated, err)

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -1144,11 +1144,8 @@ func TestHostServiceRelayRoutesRegisteredAppService(t *testing.T) {
 	invoker := &relayTestInvoker{}
 	publicHostServices := runtimehost.NewPublicHostServiceRegistry()
 	sessionVerifier := newRelayTestSessionVerifier("relay-session")
-	// The app-invocation host service is registered once, globally, under the
-	// well-known "app" key rather than per caller name; the relay token's
-	// AppName ("agent-trace-viewer") deliberately has no registration of its
-	// own, mirroring the cross-replica declarative-target miss that used to
-	// return host-service-relay-unavailable.
+	// Registered under the global "app" key; the relay token's AppName
+	// (the caller) deliberately has no registration of its own.
 	publicHostServices.RegisterVerified("app", sessionVerifier, runtimehost.HostService{
 		Name:           "app",
 		MethodPrefixes: []string{"/" + proto.App_ServiceDesc.ServiceName + "/"},
@@ -1195,13 +1192,14 @@ func TestHostServiceRelayRoutesRegisteredAppService(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AppInvocation.Invoke via registered relay: %v", err)
 	}
-	if call := invoker.snapshot(); call.calls != 1 || call.providerName != "gcs" || call.operation != "load_trace_url" || call.instance != "prod" {
+	call := invoker.snapshot()
+	if call.calls != 1 || call.providerName != "gcs" || call.operation != "load_trace_url" || call.instance != "prod" {
 		t.Fatalf("plugin invoker call = %+v, want gcs load_trace_url/prod", call)
 	}
-	if call := invoker.snapshot(); call.callerProvider != "agent-trace-viewer" || call.callerKind != string(invocation.ProviderKindApp) {
+	if call.callerProvider != "agent-trace-viewer" || call.callerKind != string(invocation.ProviderKindApp) {
 		t.Fatalf("plugin invoker caller = %s/%s, want restored caller provider agent-trace-viewer/app", call.callerProvider, call.callerKind)
 	}
-	if call := invoker.snapshot(); call.callerSubjectID != "user:relay-test" {
+	if call.callerSubjectID != "user:relay-test" {
 		t.Fatalf("plugin invoker principal = %q, want subject restored from the verified token", call.callerSubjectID)
 	}
 

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -1144,8 +1144,6 @@ func TestHostServiceRelayRoutesRegisteredAppService(t *testing.T) {
 	invoker := &relayTestInvoker{}
 	publicHostServices := runtimehost.NewPublicHostServiceRegistry()
 	sessionVerifier := newRelayTestSessionVerifier("relay-session")
-	// Registered under the global "app" key; the relay token's AppName
-	// (the caller) deliberately has no registration of its own.
 	publicHostServices.RegisterVerified("app", sessionVerifier, runtimehost.HostService{
 		Name:           "app",
 		MethodPrefixes: []string{"/" + proto.App_ServiceDesc.ServiceName + "/"},

--- a/gestaltd/services/appaccess/app_server.go
+++ b/gestaltd/services/appaccess/app_server.go
@@ -445,6 +445,11 @@ func (s *AppServer) requestContext(ctx context.Context, reqCtx *proto.RequestCon
 			return requestInvocationContext{}, status.Errorf(codes.PermissionDenied, "provider caller context %q does not match serving provider %q", callerName, expected)
 		}
 	}
+	// The verified relay token is authoritative for the caller identity;
+	// the proto caller is the fallback for direct (non-relay) calls.
+	if verified := invocation.CallerProviderFromContext(ctx); verified.Name != "" && verified.Name != callerName {
+		return requestInvocationContext{}, status.Errorf(codes.PermissionDenied, "provider caller context %q does not match verified caller %q", callerName, verified.Name)
+	}
 	return requestInvocationContext{
 		callerName:         callerName,
 		callerProviderKind: callerKind,
@@ -460,8 +465,17 @@ func (s *AppServer) authorizeAgentAppInvocation(ctx context.Context, callCtx req
 	if s == nil || s.agentAppAuth == nil {
 		return invocation.AgentAppAuthorization{}, status.Error(codes.FailedPrecondition, "agent app invocation authorizer is required")
 	}
+	// The agent invocation context carries the agent provider; the caller is
+	// the orchestrating workflow/app that launched the turn.
+	agentProviderName := strings.TrimSpace(callCtx.agent.ProviderName)
+	if agentProviderName == "" {
+		agentProviderName = strings.TrimSpace(callCtx.callerName)
+	}
+	if agentProviderName == "" {
+		agentProviderName = strings.TrimSpace(s.callerName)
+	}
 	return s.agentAppAuth.AuthorizeAppInvocation(ctx, invocation.AgentAppAuthorizationRequest{
-		AgentProviderName: strings.TrimSpace(s.callerName),
+		AgentProviderName: agentProviderName,
 		CallerKind:        callCtx.callerProviderKind,
 		CallerName:        callCtx.callerName,
 		Agent:             callCtx.agent,

--- a/gestaltd/services/appaccess/app_server.go
+++ b/gestaltd/services/appaccess/app_server.go
@@ -445,8 +445,6 @@ func (s *AppServer) requestContext(ctx context.Context, reqCtx *proto.RequestCon
 			return requestInvocationContext{}, status.Errorf(codes.PermissionDenied, "provider caller context %q does not match serving provider %q", callerName, expected)
 		}
 	}
-	// The verified relay token is authoritative for the caller identity;
-	// the proto caller is the fallback for direct (non-relay) calls.
 	if verified := invocation.CallerProviderFromContext(ctx); verified.Name != "" && verified.Name != callerName {
 		return requestInvocationContext{}, status.Errorf(codes.PermissionDenied, "provider caller context %q does not match verified caller %q", callerName, verified.Name)
 	}
@@ -465,8 +463,6 @@ func (s *AppServer) authorizeAgentAppInvocation(ctx context.Context, callCtx req
 	if s == nil || s.agentAppAuth == nil {
 		return invocation.AgentAppAuthorization{}, status.Error(codes.FailedPrecondition, "agent app invocation authorizer is required")
 	}
-	// The agent invocation context carries the agent provider; the caller is
-	// the orchestrating workflow/app that launched the turn.
 	agentProviderName := strings.TrimSpace(callCtx.agent.ProviderName)
 	if agentProviderName == "" {
 		agentProviderName = strings.TrimSpace(callCtx.callerName)

--- a/gestaltd/services/appaccess/app_test.go
+++ b/gestaltd/services/appaccess/app_test.go
@@ -97,7 +97,7 @@ func TestAppServerInvokeOpenInvocationPropagatesRequestContext(t *testing.T) {
 	t.Parallel()
 
 	invoker := &recordingAppInvocation{}
-	server := NewAppServer(invoker, WithCallerApp("caller"))
+	server := NewAppServer(invoker)
 	client := proto.NewAppClient(newBufconnConn(t, func(srv *grpc.Server) {
 		proto.RegisterAppServer(srv, server)
 	}))
@@ -147,7 +147,7 @@ func TestAppServerInvokeAppliesRequestRunAs(t *testing.T) {
 	t.Parallel()
 
 	invoker := &recordingAppInvocation{}
-	server := NewAppServer(invoker, WithCallerApp("caller"))
+	server := NewAppServer(invoker)
 	client := proto.NewAppClient(newBufconnConn(t, func(srv *grpc.Server) {
 		proto.RegisterAppServer(srv, server)
 	}))
@@ -178,7 +178,7 @@ func TestAppServerInvokeIgnoresEmptyRequestRunAs(t *testing.T) {
 	t.Parallel()
 
 	invoker := &recordingAppInvocation{}
-	server := NewAppServer(invoker, WithCallerApp("caller"))
+	server := NewAppServer(invoker)
 	client := proto.NewAppClient(newBufconnConn(t, func(srv *grpc.Server) {
 		proto.RegisterAppServer(srv, server)
 	}))
@@ -230,7 +230,6 @@ func TestAppServerInvokeAuthorizesAgentTurnAppOperation(t *testing.T) {
 	server := NewAppServer(
 		invoker,
 		WithAgentAppInvocationAuthorizer(agentAuth),
-		WithCallerApp("alpha"),
 	)
 	client := proto.NewAppClient(newBufconnConn(t, func(srv *grpc.Server) {
 		proto.RegisterAppServer(srv, server)
@@ -307,7 +306,6 @@ func TestAppServerInvokeRejectsRequestRunAsForAgentCaller(t *testing.T) {
 				Principal: &principal.Principal{SubjectID: "user:runner"},
 			},
 		}),
-		WithCallerApp("alpha"),
 	)
 	client := proto.NewAppClient(newBufconnConn(t, func(srv *grpc.Server) {
 		proto.RegisterAppServer(srv, server)
@@ -335,7 +333,7 @@ func TestAppServerInvokeRejectsRequestRunAsForAgentCaller(t *testing.T) {
 func TestAppServerInvokeRejectsRequestRunAsForWorkflowCaller(t *testing.T) {
 	t.Parallel()
 
-	server := NewAppServer(&recordingAppInvocation{}, WithCallerApp("temporal"))
+	server := NewAppServer(&recordingAppInvocation{})
 	client := proto.NewAppClient(newBufconnConn(t, func(srv *grpc.Server) {
 		proto.RegisterAppServer(srv, server)
 	}))
@@ -380,9 +378,12 @@ func TestAppServerInvokeRejectsRequestRunAsForWorkflowCaller(t *testing.T) {
 	}
 }
 
-func TestAppServerInvokeRejectsAgentContextOnWrongHostService(t *testing.T) {
+func TestAppServerInvokeResolvesAgentProviderFromCaller(t *testing.T) {
 	t.Parallel()
 
+	// The app-invocation host service is registered once, globally, so the
+	// agent provider is resolved from the caller context instead of a
+	// registration-baked serving provider.
 	agentAuth := &recordingAgentAppAuthorizer{
 		response: invocation.AgentAppAuthorization{
 			Principal: &principal.Principal{SubjectID: "user:runner"},
@@ -391,7 +392,6 @@ func TestAppServerInvokeRejectsAgentContextOnWrongHostService(t *testing.T) {
 	server := NewAppServer(
 		&recordingAppInvocation{},
 		WithAgentAppInvocationAuthorizer(agentAuth),
-		WithCallerApp("beta"),
 	)
 	client := proto.NewAppClient(newBufconnConn(t, func(srv *grpc.Server) {
 		proto.RegisterAppServer(srv, server)
@@ -408,11 +408,14 @@ func TestAppServerInvokeRejectsAgentContextOnWrongHostService(t *testing.T) {
 		Operation: "chat.postMessage",
 		Context:   reqCtx,
 	})
-	if got := status.Code(err); got != codes.PermissionDenied {
-		t.Fatalf("Invoke status = %s, want %s (err=%v)", got, codes.PermissionDenied, err)
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
 	}
-	if len(agentAuth.requests) != 0 {
-		t.Fatalf("agent authorization requests = %d, want 0", len(agentAuth.requests))
+	if len(agentAuth.requests) != 1 {
+		t.Fatalf("agent authorization requests = %d, want 1", len(agentAuth.requests))
+	}
+	if got := agentAuth.requests[0].AgentProviderName; got != "alpha" {
+		t.Fatalf("agent authorization agent provider = %q, want alpha from the agent invocation context", got)
 	}
 }
 
@@ -420,7 +423,7 @@ func TestAppServerInvokeGraphQLAllowsOpenSurfaceInvocation(t *testing.T) {
 	t.Parallel()
 
 	invoker := &recordingAppInvocation{}
-	server := NewAppServer(invoker, WithCallerApp("caller"))
+	server := NewAppServer(invoker)
 	client := proto.NewAppClient(newBufconnConn(t, func(srv *grpc.Server) {
 		proto.RegisterAppServer(srv, server)
 	}))
@@ -450,7 +453,7 @@ func TestAppServerInvokeGraphQLRejectsWorkflowCaller(t *testing.T) {
 	t.Parallel()
 
 	invoker := &recordingAppInvocation{}
-	server := NewAppServer(invoker, WithCallerApp("temporal"))
+	server := NewAppServer(invoker)
 	client := proto.NewAppClient(newBufconnConn(t, func(srv *grpc.Server) {
 		proto.RegisterAppServer(srv, server)
 	}))
@@ -495,7 +498,7 @@ func TestAppServerInvokeAuthorizesWorkflowCurrentAppStep(t *testing.T) {
 	t.Parallel()
 
 	invoker := &recordingAppInvocation{}
-	server := NewAppServer(invoker, WithCallerApp("temporal"))
+	server := NewAppServer(invoker)
 	client := proto.NewAppClient(newBufconnConn(t, func(srv *grpc.Server) {
 		proto.RegisterAppServer(srv, server)
 	}))
@@ -557,11 +560,18 @@ func TestAppServerInvokeAuthorizesWorkflowCurrentAppStep(t *testing.T) {
 	}
 }
 
-func TestAppServerInvokeRejectsWrongCaller(t *testing.T) {
+func TestAppServerInvokeRejectsForgedCallerMismatchingVerifiedCaller(t *testing.T) {
 	t.Parallel()
 
-	server := NewAppServer(&recordingAppInvocation{}, WithCallerApp("caller"))
-	client := proto.NewAppClient(newBufconnConn(t, func(srv *grpc.Server) {
+	// On the relay path the verified token stamps the caller provider in the
+	// request context; a forged proto caller must not override it.
+	server := NewAppServer(&recordingAppInvocation{})
+	// Simulate the relay restoring the verified caller-provider from the
+	// token before the request reaches the app host service.
+	restoreVerifiedCaller := grpc.UnaryInterceptor(func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		return handler(invocation.WithCallerProvider(ctx, invocation.ProviderKindApp, "caller"), req)
+	})
+	client := proto.NewAppClient(newBufconnConnWithOptions(t, []grpc.ServerOption{restoreVerifiedCaller}, nil, func(srv *grpc.Server) {
 		proto.RegisterAppServer(srv, server)
 	}))
 	_, err := client.Invoke(context.Background(), &proto.AppInvokeRequest{
@@ -652,7 +662,7 @@ func (r *sliceStreamReader) Recv() (*core.InvokeFrame, error) {
 func TestAppServerInvokeStream(t *testing.T) {
 	t.Parallel()
 	rec := &recordingAppInvocation{}
-	server := NewAppServer(rec, WithCallerApp("caller"))
+	server := NewAppServer(rec)
 	stream := &invokeStreamServerStub{ctx: context.Background()}
 	err := server.InvokeStream(&proto.AppInvokeRequest{
 		App:       "example",

--- a/gestaltd/services/appaccess/app_test.go
+++ b/gestaltd/services/appaccess/app_test.go
@@ -381,8 +381,6 @@ func TestAppServerInvokeRejectsRequestRunAsForWorkflowCaller(t *testing.T) {
 func TestAppServerInvokeResolvesAgentProviderFromCaller(t *testing.T) {
 	t.Parallel()
 
-	// The agent provider resolves from the caller context now that the app
-	// host service is registered globally without a baked-in serving provider.
 	agentAuth := &recordingAgentAppAuthorizer{
 		response: invocation.AgentAppAuthorization{
 			Principal: &principal.Principal{SubjectID: "user:runner"},
@@ -562,7 +560,6 @@ func TestAppServerInvokeAuthorizesWorkflowCurrentAppStep(t *testing.T) {
 func TestAppServerInvokeRejectsForgedCallerMismatchingVerifiedCaller(t *testing.T) {
 	t.Parallel()
 
-	// A forged proto caller must not override the verified relay-token caller.
 	server := NewAppServer(&recordingAppInvocation{})
 	restoreVerifiedCaller := grpc.UnaryInterceptor(func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		return handler(invocation.WithCallerProvider(ctx, invocation.ProviderKindApp, "caller"), req)

--- a/gestaltd/services/appaccess/app_test.go
+++ b/gestaltd/services/appaccess/app_test.go
@@ -381,9 +381,8 @@ func TestAppServerInvokeRejectsRequestRunAsForWorkflowCaller(t *testing.T) {
 func TestAppServerInvokeResolvesAgentProviderFromCaller(t *testing.T) {
 	t.Parallel()
 
-	// The app-invocation host service is registered once, globally, so the
-	// agent provider is resolved from the caller context instead of a
-	// registration-baked serving provider.
+	// The agent provider resolves from the caller context now that the app
+	// host service is registered globally without a baked-in serving provider.
 	agentAuth := &recordingAgentAppAuthorizer{
 		response: invocation.AgentAppAuthorization{
 			Principal: &principal.Principal{SubjectID: "user:runner"},
@@ -563,11 +562,8 @@ func TestAppServerInvokeAuthorizesWorkflowCurrentAppStep(t *testing.T) {
 func TestAppServerInvokeRejectsForgedCallerMismatchingVerifiedCaller(t *testing.T) {
 	t.Parallel()
 
-	// On the relay path the verified token stamps the caller provider in the
-	// request context; a forged proto caller must not override it.
+	// A forged proto caller must not override the verified relay-token caller.
 	server := NewAppServer(&recordingAppInvocation{})
-	// Simulate the relay restoring the verified caller-provider from the
-	// token before the request reaches the app host service.
 	restoreVerifiedCaller := grpc.UnaryInterceptor(func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		return handler(invocation.WithCallerProvider(ctx, invocation.ProviderKindApp, "caller"), req)
 	})

--- a/gestaltd/services/runtimehost/capability_ingress.go
+++ b/gestaltd/services/runtimehost/capability_ingress.go
@@ -17,9 +17,6 @@ var errHostServiceCapabilityRequired = status.Error(codes.Unauthenticated, "host
 
 type relayAuthenticatedContextKey struct{}
 
-// WithRelayAuthenticated marks a context as already authenticated by the
-// relay ingress, which strips the per-RPC token before forwarding, so the
-// host-service interceptor trusts it instead of re-resolving the token.
 func WithRelayAuthenticated(ctx context.Context) context.Context {
 	return context.WithValue(ctx, relayAuthenticatedContextKey{}, true)
 }

--- a/gestaltd/services/runtimehost/capability_ingress.go
+++ b/gestaltd/services/runtimehost/capability_ingress.go
@@ -15,6 +15,21 @@ type CapabilityIngressDecorator func(context.Context, HostServiceRelayTarget) co
 
 var errHostServiceCapabilityRequired = status.Error(codes.Unauthenticated, "host service relay token is required")
 
+type relayAuthenticatedContextKey struct{}
+
+// WithRelayAuthenticated marks a context as already authenticated by the
+// relay ingress (token resolved and capability applied). The host-service
+// interceptor trusts it instead of re-resolving the per-RPC token, which the
+// relay strips before forwarding.
+func WithRelayAuthenticated(ctx context.Context) context.Context {
+	return context.WithValue(ctx, relayAuthenticatedContextKey{}, true)
+}
+
+func relayAuthenticated(ctx context.Context) bool {
+	v, _ := ctx.Value(relayAuthenticatedContextKey{}).(bool)
+	return v
+}
+
 // SetCapabilityIngressDecorator configures post-verification context restoration.
 func (m *HostServiceRelayTokenManager) SetCapabilityIngressDecorator(fn CapabilityIngressDecorator) {
 	if m == nil {
@@ -27,6 +42,9 @@ func (m *HostServiceRelayTokenManager) SetCapabilityIngressDecorator(fn Capabili
 // Non-caller-dependent methods may proceed without a token; caller-dependent methods
 // require a capability with embedded caller claims.
 func (m *HostServiceRelayTokenManager) AuthenticateGRPC(ctx context.Context, fullMethod string) (context.Context, error) {
+	if relayAuthenticated(ctx) {
+		return ctx, nil
+	}
 	requireCaller := CallerCapabilityRequiredMethod(fullMethod)
 	if requireCaller && callerCapabilityAuthenticated(ctx) {
 		return ctx, nil

--- a/gestaltd/services/runtimehost/capability_ingress.go
+++ b/gestaltd/services/runtimehost/capability_ingress.go
@@ -18,9 +18,8 @@ var errHostServiceCapabilityRequired = status.Error(codes.Unauthenticated, "host
 type relayAuthenticatedContextKey struct{}
 
 // WithRelayAuthenticated marks a context as already authenticated by the
-// relay ingress (token resolved and capability applied). The host-service
-// interceptor trusts it instead of re-resolving the per-RPC token, which the
-// relay strips before forwarding.
+// relay ingress, which strips the per-RPC token before forwarding, so the
+// host-service interceptor trusts it instead of re-resolving the token.
 func WithRelayAuthenticated(ctx context.Context) context.Context {
 	return context.WithValue(ctx, relayAuthenticatedContextKey{}, true)
 }


### PR DESCRIPTION
## Problem

Clicking "Open Trace" in `agent-trace-viewer` returned `host-service-relay-unavailable`.

When a provider calls `app.invoke("gcs", ...)`, the callback is a gRPC `/gestalt.provider.v1.App/Invoke` over the public relay, carrying a token minted with `AppName = <calling provider>` (the **caller**, e.g. `agent-trace-viewer`), not the target. `unifiedHostServiceHandler` looked up handlers by that caller name, but the app-invocation host service was registered **per locally-built provider, process-local** to the replica that built it. On the load-balanced multi-replica `toolshed-test` deployment the callback only resolved when it happened to land on the replica that built the caller; declarative targets like `gcs` never have a registration anywhere, so callbacks usually 503'd.

## Fix

Register the app-invocation host service **once, globally**, route `App/*` relay calls to it by gRPC service name, and source caller identity from the verified relay token instead of from a per-caller registration:

- **Global registration** (`host_service_bootstrap.go`, `bootstrap.go`): `registerGlobalAppInvocationPublicHostService` registers one `app` host service on the guarded shared invoker under the well-known `appInvocationPublicProviderKey = "app"` key, after `pluginInvoker.SetTarget(...)`. Replaces the per-caller `registerConfiguredAppPublicHostServices` fan-out (deleted).
- **Routing** (`host_service_public.go`): `unifiedHostServiceHandler` matches `/<App_ServiceDesc.ServiceName>/` method paths to the global `"app"` registration; all other services stay keyed by `target.AppName` (cache/s3/identity/workflow/agent routing unchanged).
- **Caller identity** (`app_server.go`): the global `AppServer` has no baked-in caller; `requestContext` cross-checks the proto `RequestContext` caller against the verified caller restored from the token by `hostserviceingress.ApplyCapability`. `authorizeAgentAppInvocation` sources `AgentProviderName` from the agent invocation context (falling back to the caller / serving provider), keeping `agent_app_authority.go` satisfied.
- **Local path preserved**: each provider's unix-socket host services still serve a per-caller `AppServer` with the existing `WithCallerApp` guard; it is excluded from public relay registration (empty `MethodPrefixes`) so it can't duplicate the global registration.
- **Static provider tokens** (`host_service_relay.go`): the caller-claims requirement is relaxed for session-scoped `MethodPrefix: "/"` provider tokens, which are minted at provider launch before any caller exists; the App/Identity/Workflow/Agent services derive identity from the proto request context in that case, matching unix-socket behavior. Per-invocation capability tokens still embed caller claims.
- **Relay-forwarded auth** (`capability_ingress.go`): forwarded requests are marked relay-authenticated so the host-service interceptor trusts the capability the middleware already resolved instead of re-resolving the stripped per-RPC token.

## Tests

- `TestHostServiceRelayRoutesRegisteredAppService` (server functional relay test): registers `app` once under the global key, invokes with a token whose `AppName` (`agent-trace-viewer`) has no per-name registration targeting a declarative app (`gcs.load_trace_url`) — the exact cross-replica miss — and asserts caller provider and principal are restored from the verified token. Stale-session negative assertion kept.
- `TestUnifiedHostServiceHandlerRoutesAppServiceToGlobalRegistration`: handler lookup routes App RPCs to the global key and does not leak it into caller-keyed services.
- Agent tool-callback bootstrap tests now dial the public relay (against the real `server.Server` relay middleware and a bootstrap-injected registry) instead of the per-caller unix socket, exercising the global registration end to end via a new `BootstrapOptions.PublicHostServices` test hook.
- Full `go test ./...` green in `gestaltd/`.

Plan: `/Users/hugh/Desktop/2026-07-30-gestaltd-host-service-relay-fix-plan.md`

## Manual verification after deploy

"Open Trace" in `agent-trace-viewer` loads traces from `gs://valon_labs_data_prod/agent_chat` without `host-service-relay-unavailable`; Cloud Logging (`gitlab-peach-street`, service `toolshed-test`) should show no more `host-service-relay-unavailable` 5xx results for `load_trace_url`, plus a depth=1 audit record for provider `gcs`.
