### PR TITLE
fix: build tunnel proxy providers per request, drop the cache

### DIFF
--- a/gestaltd/go.mod
+++ b/gestaltd/go.mod
@@ -42,7 +42,6 @@ require (
 	golang.org/x/mod v0.37.0
 	golang.org/x/net v0.56.0
 	golang.org/x/oauth2 v0.36.0
-	golang.org/x/sync v0.22.0
 	golang.org/x/time v0.15.0
 	google.golang.org/api v0.287.1
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260720155508-bb71a54f79dc
@@ -99,6 +98,7 @@ require (
 	github.com/wundergraph/go-arena v1.1.0 // indirect
 	github.com/xtaci/kcp-go/v5 v5.6.13 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.43.0 // indirect
+	golang.org/x/sync v0.22.0 // indirect
 	golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 // indirect
 	golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173 // indirect
 	google.golang.org/genproto v0.0.0-20260519071638-aa98bba5eb94 // indirect

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -218,7 +218,7 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 	seen := make(map[string]struct{}, len(names))
 	out := make([]integrationInfo, 0, len(names))
 	for _, name := range names {
-		prov, err := s.providers.Get(name)
+		prov, err := s.providers.GetWithContext(r.Context(), name)
 		if err != nil {
 			continue
 		}
@@ -423,7 +423,7 @@ func (s *Server) disconnectIntegration(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, ok := s.getProvider(w, name); !ok {
+	if _, ok := s.getProvider(r.Context(), w, name); !ok {
 		auditErr = errors.New("integration not found")
 		return
 	}
@@ -541,8 +541,8 @@ func (s *Server) disconnectIntegration(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "disconnected"})
 }
 
-func (s *Server) getProvider(w http.ResponseWriter, name string) (core.Provider, bool) {
-	prov, err := s.providers.Get(name)
+func (s *Server) getProvider(ctx context.Context, w http.ResponseWriter, name string) (core.Provider, bool) {
+	prov, err := s.providers.GetWithContext(ctx, name)
 	if err != nil {
 		if errors.Is(err, core.ErrNotFound) {
 			writeError(w, http.StatusNotFound, fmt.Sprintf("integration %q not found", name))
@@ -614,7 +614,7 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 	const operation = "operations.list"
 
 	name := chi.URLParam(r, "name")
-	prov, ok := s.getProvider(w, name)
+	prov, ok := s.getProvider(r.Context(), w, name)
 	if !ok {
 		return
 	}
@@ -694,7 +694,7 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 	operationName := chi.URLParam(r, "operation")
 
 	p := PrincipalFromContext(r.Context())
-	prov, ok := s.getProvider(w, providerName)
+	prov, ok := s.getProvider(r.Context(), w, providerName)
 	if !ok {
 		return
 	}

--- a/gestaltd/internal/server/handlers_connect.go
+++ b/gestaltd/internal/server/handlers_connect.go
@@ -56,7 +56,7 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	prov, manualConnection, err := s.resolveConnectionProvider(w, req.Integration, req.Connection)
+	prov, manualConnection, err := s.resolveConnectionProvider(r.Context(), w, req.Integration, req.Connection)
 	if err != nil {
 		auditErr = err
 		return
@@ -206,8 +206,8 @@ func (s *Server) exchangeManualCredential(ctx context.Context, req connectManual
 	}, nil
 }
 
-func (s *Server) resolveConnectionProvider(w http.ResponseWriter, integration, requestedConnection string) (core.Provider, string, error) {
-	prov, ok := s.getProvider(w, integration)
+func (s *Server) resolveConnectionProvider(ctx context.Context, w http.ResponseWriter, integration, requestedConnection string) (core.Provider, string, error) {
+	prov, ok := s.getProvider(ctx, w, integration)
 	if !ok {
 		return nil, "", errors.New("integration not found")
 	}

--- a/gestaltd/internal/server/handlers_oauth.go
+++ b/gestaltd/internal/server/handlers_oauth.go
@@ -44,7 +44,7 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 	}
 	providerName = req.Integration
 
-	prov, connection, err := s.resolveConnectionProvider(w, req.Integration, req.Connection)
+	prov, connection, err := s.resolveConnectionProvider(r.Context(), w, req.Integration, req.Connection)
 	if err != nil {
 		auditErr = err
 		return
@@ -211,7 +211,7 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	prov, _ := s.providers.Get(providerName)
+	prov, _ := s.providers.GetWithContext(r.Context(), providerName)
 	if prov != nil {
 		connectionMode = metricutil.NormalizeConnectionMode(prov.ConnectionMode())
 	}

--- a/gestaltd/internal/server/handlers_tokens.go
+++ b/gestaltd/internal/server/handlers_tokens.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -15,7 +16,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 )
 
-func (s *Server) validateCreateGrantRequest(req createTokenRequest) (string, error) {
+func (s *Server) validateCreateGrantRequest(ctx context.Context, req createTokenRequest) (string, error) {
 	if strings.TrimSpace(req.Name) == "" {
 		return "", errors.New("name is required")
 	}
@@ -25,7 +26,7 @@ func (s *Server) validateCreateGrantRequest(req createTokenRequest) (string, err
 	scope := strings.TrimSpace(req.Scopes)
 	for _, part := range strings.Fields(scope) {
 		appName, _, _ := strings.Cut(part, ":")
-		if _, err := s.providers.Get(appName); err != nil {
+		if _, err := s.providers.GetWithContext(ctx, appName); err != nil {
 			return "", fmt.Errorf("unknown scope %q", part)
 		}
 	}
@@ -75,7 +76,7 @@ func (s *Server) createAPIToken(w http.ResponseWriter, r *http.Request) {
 	}
 	auditTarget = apiTokenAuditTarget("", req.Name)
 
-	scope, err := s.validateCreateGrantRequest(req)
+	scope, err := s.validateCreateGrantRequest(r.Context(), req)
 	if err != nil {
 		auditErr = err
 		writeError(w, http.StatusBadRequest, err.Error())

--- a/gestaltd/internal/server/http_binding_subject.go
+++ b/gestaltd/internal/server/http_binding_subject.go
@@ -15,7 +15,7 @@ import (
 func (s *Server) resolveHTTPBindingPrincipal(ctx context.Context, binding MountedHTTPBinding, r *http.Request, verified *verifiedHTTPBindingSender, parsed *parsedHTTPBindingRequest) (*principal.Principal, error) {
 	bindingPrincipal := s.httpBindingPrincipal(binding, verified)
 
-	prov, err := s.providers.Get(binding.AppName)
+	prov, err := s.providers.GetWithContext(ctx, binding.AppName)
 	if err != nil {
 		return nil, err
 	}

--- a/gestaltd/internal/server/http_bindings.go
+++ b/gestaltd/internal/server/http_bindings.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -168,7 +169,7 @@ func providerOperationIDs(providers *registry.ProviderMap[core.Provider], plugin
 	if providers == nil {
 		return nil, nil
 	}
-	provider, err := providers.Get(pluginName)
+	provider, err := providers.GetWithContext(context.Background(), pluginName)
 	if err != nil {
 		return nil, err
 	}
@@ -299,7 +300,7 @@ func (s *Server) withRegistryAppRuntime(app string, invoke func()) bool {
 	}
 	invoked := false
 	err := s.appRuntimeState.WithRunningVersion(app, func(version string) error {
-		if _, err := s.providers.Get(app); err != nil {
+		if _, err := s.providers.GetWithContext(context.Background(), app); err != nil {
 			return err
 		}
 		raw, err := os.ReadFile(filepath.Join(s.artifactsDir, appregistry.RegistryInstallSubdir, app, "active-version"))

--- a/gestaltd/internal/server/mounted_app_static.go
+++ b/gestaltd/internal/server/mounted_app_static.go
@@ -101,7 +101,7 @@ func registryAppStaticHandler(app, mount string, entry *config.ProviderEntry, pr
 		}
 		served := false
 		err := runtimeState.WithRunningVersion(app, func(version string) error {
-			if _, err := providers.Get(app); err != nil {
+			if _, err := providers.GetWithContext(r.Context(), app); err != nil {
 				return err
 			}
 			marker := filepath.Join(artifactsDir, appregistry.RegistryInstallSubdir, app, "active-version")

--- a/gestaltd/internal/server/pending_connection.go
+++ b/gestaltd/internal/server/pending_connection.go
@@ -448,7 +448,7 @@ func (s *Server) selectPendingConnection(w http.ResponseWriter, r *http.Request)
 
 	tm := state.Credential
 	tm.MetadataJSON = merged
-	prov, ok := s.getProvider(w, state.Credential.Integration)
+	prov, ok := s.getProvider(r.Context(), w, state.Credential.Integration)
 	if !ok {
 		auditErr = errors.New("integration not found")
 		return

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -518,9 +518,6 @@ func (s *Server) Close() {
 	if s == nil {
 		return
 	}
-	if s.tunnelResolver != nil {
-		s.tunnelResolver.Close()
-	}
 	if s.publicGatewayConn != nil {
 		s.publicGatewayConn.Close()
 		s.publicGatewayConn = nil

--- a/gestaltd/internal/server/tunnel_resolver.go
+++ b/gestaltd/internal/server/tunnel_resolver.go
@@ -6,55 +6,31 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	coredata "github.com/valon-technologies/gestalt/server/internal/coredata"
 	"github.com/valon-technologies/gestalt/server/services/apps/registry"
 	"github.com/valon-technologies/gestalt/server/services/remotepublish"
-	"golang.org/x/sync/singleflight"
 )
 
-// TunnelResolverConfig holds the upstream-side tunnel dial parameters needed
-// to build tunnel proxy providers for remote-registered apps.
 type TunnelResolverConfig struct {
 	RemoteRegistrations *coredata.RemoteRegistrationService
 	ConnectAddr         string
 	ClientIdentity      tls.Certificate
 }
 
-// tunnelProviderResolver implements registry.RemoteResolver[core.Provider]. It
-// consults the RemoteRegistrationService for tunnel-registered apps and builds
-// (and caches) a tunnel proxy provider for each. Tunnel registrations always
-// take precedence over local providers (tunnel always wins).
-//
-// When a registration exists but proxy construction fails (e.g. the tunnel is
-// unreachable), ResolveProvider returns a non-ErrNotFound error so the caller
-// fails the request rather than silently falling back to a local provider.
 type tunnelProviderResolver struct {
-	cfg      TunnelResolverConfig
-	mu       sync.Mutex
-	cache    map[string]core.Provider
-	cacheGen map[string]uint64
-	group    singleflight.Group
+	cfg TunnelResolverConfig
 }
 
 func newTunnelProviderResolver(cfg TunnelResolverConfig) *tunnelProviderResolver {
 	if cfg.RemoteRegistrations == nil || strings.TrimSpace(cfg.ConnectAddr) == "" {
 		return nil
 	}
-	return &tunnelProviderResolver{
-		cfg:      cfg,
-		cache:    make(map[string]core.Provider),
-		cacheGen: make(map[string]uint64),
-	}
+	return &tunnelProviderResolver{cfg: cfg}
 }
 
-// ErrTunnelProviderUnavailable is returned when a tunnel registration exists
-// for an app but the proxy provider could not be built (e.g. tunnel is down).
-// It is distinct from core.ErrNotFound so ProviderMap.GetWithContext does not
-// silently fall back to a local provider.
 var ErrTunnelProviderUnavailable = fmt.Errorf("tunnel provider is registered but unavailable")
 
 func (r *tunnelProviderResolver) ResolveProvider(ctx context.Context, name string) (core.Provider, error) {
@@ -70,87 +46,31 @@ func (r *tunnelProviderResolver) ResolveProvider(ctx context.Context, name strin
 		return nil, core.ErrNotFound
 	}
 
-	// Fast path: return cached provider if the generation hasn't changed.
-	r.mu.Lock()
-	cached := r.cache[name]
-	cachedGen := r.cacheGen[name]
-	r.mu.Unlock()
+	buildCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
 
-	if cached != nil && cachedGen == reg.Generation {
-		return cached, nil
-	}
-
-	// Slow path: use singleflight so concurrent calls for the same app name
-	// share one proxy build, preventing duplicate gRPC connections and races
-	// where one goroutine closes a provider another just received.
-	val, err, _ := r.group.Do(name, func() (any, error) {
-		// Re-check the cache under the singleflight token; another caller in
-		// the same flight may have already built and cached the provider.
-		r.mu.Lock()
-		cached := r.cache[name]
-		cachedGen := r.cacheGen[name]
-		r.mu.Unlock()
-		if cached != nil && cachedGen == reg.Generation {
-			return cached, nil
-		}
-
-		buildCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
-		defer cancel()
-
-		provider, err := remotepublish.NewTunnelProxyProvider(buildCtx, remotepublish.TunnelProxyConfig{
-			AppName:        name,
-			TunnelHost:     reg.TunnelHost,
-			PinnedSPKI:     reg.ServerSPKISHA256,
-			ConnectAddr:    r.cfg.ConnectAddr,
-			ClientIdentity: r.cfg.ClientIdentity,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("%w: build proxy for %s: %v", ErrTunnelProviderUnavailable, name, err)
-		}
-
-		// Install the new provider and close the previous one (if any). The
-		// comparison is against the current cache entry, not the stale
-		// pre-build read, so we always close exactly the entry being replaced.
-		r.mu.Lock()
-		old := r.cache[name]
-		r.cache[name] = provider
-		r.cacheGen[name] = reg.Generation
-		r.mu.Unlock()
-
-		if old != nil && old != provider {
-			closeQuietly(old)
-		}
-
-		return provider, nil
+	provider, err := remotepublish.NewTunnelProxyProvider(buildCtx, remotepublish.TunnelProxyConfig{
+		AppName:        name,
+		TunnelHost:     reg.TunnelHost,
+		PinnedSPKI:     reg.ServerSPKISHA256,
+		ConnectAddr:    r.cfg.ConnectAddr,
+		ClientIdentity: r.cfg.ClientIdentity,
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: build proxy for %s: %v", ErrTunnelProviderUnavailable, name, err)
 	}
-	return val.(core.Provider), nil
+
+	context.AfterFunc(ctx, func() { closeQuietly(provider) })
+
+	return provider, nil
 }
 
-// HasRegistration checks whether a tunnel registration exists for the given app
-// name without building a proxy provider. Used by the UI proxy to decide
-// whether to proxy or serve local static assets.
 func (r *tunnelProviderResolver) HasRegistration(ctx context.Context, appName string) bool {
 	if r == nil || r.cfg.RemoteRegistrations == nil {
 		return false
 	}
 	_, _, err := r.cfg.RemoteRegistrations.ResolveProvider(ctx, "app", appName)
 	return err == nil
-}
-
-// Close shuts down all cached tunnel proxy providers.
-func (r *tunnelProviderResolver) Close() {
-	if r == nil {
-		return
-	}
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	for _, p := range r.cache {
-		closeQuietly(p)
-	}
-	r.cache = nil
 }
 
 func closeQuietly(p core.Provider) {

--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -2238,7 +2238,7 @@ func (m *Manager) resolveTool(ctx context.Context, p *principal.Principal, ref c
 	if appName == "" {
 		return coreagent.Tool{}, fmt.Errorf("%w: agent tool app is required", invocation.ErrProviderNotFound)
 	}
-	prov, err := m.providers.Get(appName)
+	prov, err := m.providers.GetWithContext(ctx, appName)
 	if err != nil {
 		if errors.Is(err, core.ErrNotFound) {
 			return coreagent.Tool{}, fmt.Errorf("%w: %q", invocation.ErrProviderNotFound, appName)
@@ -2462,7 +2462,7 @@ func (m *Manager) visitToolSearchCandidates(
 		if appName == "" {
 			continue
 		}
-		prov, err := m.providers.Get(appName)
+		prov, err := m.providers.GetWithContext(ctx, appName)
 		if err != nil {
 			if errors.Is(err, core.ErrNotFound) {
 				continue
@@ -2915,7 +2915,7 @@ func (m *Manager) authorizeToolRefs(ctx context.Context, p *principal.Principal,
 			}
 			continue
 		}
-		if _, err := m.providers.Get(appName); err != nil {
+		if _, err := m.providers.GetWithContext(ctx, appName); err != nil {
 			if errors.Is(err, core.ErrNotFound) {
 				return fmt.Errorf("%w: %q", invocation.ErrProviderNotFound, appName)
 			}

--- a/gestaltd/services/apps/mcp/handlers.go
+++ b/gestaltd/services/apps/mcp/handlers.go
@@ -11,7 +11,7 @@ func validateToolInvocation(ctx context.Context, cfg Config, provName, opName st
 	if cfg.InvocationValidator == nil || cfg.Providers == nil {
 		return nil
 	}
-	prov, err := cfg.Providers.Get(provName)
+	prov, err := cfg.Providers.GetWithContext(ctx, provName)
 	if err != nil {
 		return err
 	}

--- a/gestaltd/services/apps/mcp/stateless_http.go
+++ b/gestaltd/services/apps/mcp/stateless_http.go
@@ -175,7 +175,7 @@ func (h *StatelessHTTPHandler) listTools(ctx context.Context, req mcpgo.ListTool
 	p := principal.FromContext(ctx)
 	tools := make([]mcpgo.Tool, 0)
 	for _, provName := range h.providerNames {
-		prov, ok := h.provider(provName)
+		prov, ok := h.provider(ctx, provName)
 		if !ok {
 			continue
 		}
@@ -212,7 +212,7 @@ func (h *StatelessHTTPHandler) callTool(ctx context.Context, req mcpgo.CallToolR
 	if provName == "" {
 		return nil, fmt.Errorf("%w: %q", invocation.ErrOperationNotFound, req.Params.Name)
 	}
-	prov, ok := h.provider(provName)
+	prov, ok := h.provider(ctx, provName)
 	if !ok {
 		return nil, fmt.Errorf("%w: %q", core.ErrNotFound, provName)
 	}
@@ -317,7 +317,7 @@ func statelessToolMap(cfg Config, provName string, cat *catalog.Catalog) (map[st
 	return tools, refs
 }
 
-func (h *StatelessHTTPHandler) provider(provName string) (core.Provider, bool) {
+func (h *StatelessHTTPHandler) provider(ctx context.Context, provName string) (core.Provider, bool) {
 	if h.cfg.Providers == nil {
 		return nil, false
 	}
@@ -326,7 +326,7 @@ func (h *StatelessHTTPHandler) provider(provName string) (core.Provider, bool) {
 			return nil, false
 		}
 	}
-	prov, err := h.cfg.Providers.Get(provName)
+	prov, err := h.cfg.Providers.GetWithContext(ctx, provName)
 	return prov, err == nil && prov != nil
 }
 

--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -966,11 +966,11 @@ func providerDelegatesRemoteAuthorization(prov core.Provider) bool {
 	return ok && delegated.RemoteCredentialDelegated()
 }
 
-func (b *Broker) providerDelegatesRemoteAuthorization(providerName string) bool {
+func (b *Broker) providerDelegatesRemoteAuthorization(ctx context.Context, providerName string) bool {
 	if b == nil || b.providers == nil {
 		return false
 	}
-	provider, err := b.providers.Get(providerName) // no request context available
+	provider, err := b.providers.GetWithContext(ctx, providerName)
 	return err == nil && providerDelegatesRemoteAuthorization(provider)
 }
 
@@ -996,7 +996,7 @@ func (b *Broker) CheckOperationAccess(ctx context.Context, p *principal.Principa
 	if !principal.AllowsOperationPermission(p, providerName, operationID) {
 		return fmt.Errorf("%w: %s.%s", ErrAuthorizationDenied, providerName, operationID)
 	}
-	if b.providerDelegatesRemoteAuthorization(providerName) {
+	if b.providerDelegatesRemoteAuthorization(ctx, providerName) {
 		return nil
 	}
 	return b.checkAuthorizationAccess(ctx, p, providerName, operationID)
@@ -1006,7 +1006,7 @@ func (b *Broker) CheckProviderAccess(ctx context.Context, p *principal.Principal
 	if !principal.AllowsProviderPermission(p, providerName) {
 		return fmt.Errorf("%w: %s", ErrAuthorizationDenied, providerName)
 	}
-	if b.providerDelegatesRemoteAuthorization(providerName) {
+	if b.providerDelegatesRemoteAuthorization(ctx, providerName) {
 		return nil
 	}
 	return b.checkAuthorizationAccess(ctx, p, providerName, providerName)

--- a/gestaltd/services/remotepublish/tunnel_app_provider.go
+++ b/gestaltd/services/remotepublish/tunnel_app_provider.go
@@ -72,7 +72,7 @@ func (s *TunnelAppProviderServer) resolveServer(ctx context.Context) (proto.AppP
 	}
 	s.mu.Unlock()
 
-	prov, err := s.providers.Get(appName)
+	prov, err := s.providers.GetWithContext(ctx, appName)
 	if err != nil {
 		return nil, status.Errorf(codes.NotFound, "app %q not found", appName)
 	}

--- a/gestaltd/services/workflows/workflowmanager/manager_target.go
+++ b/gestaltd/services/workflows/workflowmanager/manager_target.go
@@ -135,7 +135,7 @@ func (m *Manager) resolveWorkflowStepApp(ctx context.Context, p *principal.Princ
 	if m == nil || m.providers == nil {
 		return coreworkflow.AppCall{}, fmt.Errorf("%w: workflow providers are not configured", invocation.ErrInternal)
 	}
-	prov, err := m.providers.Get(appName)
+	prov, err := m.providers.GetWithContext(ctx, appName)
 	if err != nil {
 		if errors.Is(err, core.ErrNotFound) {
 			return coreworkflow.AppCall{}, fmt.Errorf("%w: %q", invocation.ErrProviderNotFound, appName)


### PR DESCRIPTION
## Problem

When a developer restarts their local `gestaltd dev` session, app operations on the remote (e.g. `POST /api/v2/app/vds-forge/operations/getMe`) start returning `404 operation not found` — but the app **UI** keeps working.

## Root cause

The tunnel provider resolver cached a `TunnelProxyProvider` per app, keyed on the registration **generation**. That cache pins a long-lived gRPC connection over the tunnel. The generation counter only changes when the registration record itself is bumped — it does **not** capture connection liveness.

So when the dev session restarts (new frpc, new tunnel connection, same generation), the cached provider holds a **dead gRPC stream**. Its session-catalog fetch fails, so every operation resolves as "not found." The UI proxy is unaffected because it dials a fresh tunnel connection per request.

The asymmetry — UI works, API 404s — is exactly this: cached stale connection vs. per-request dial.

## Fix

`ResolveProvider` now builds a **fresh provider on every call**, so each operation runs on a live connection and self-heals across dev session restarts. This matches the proven behavior of the UI proxy.

Because the broker never closes resolved providers, the connection is closed via `context.AfterFunc` when the request that produced it finishes — no per-operation connection leak.

## What was removed

- The `cache`/`cacheGen` maps and generation bookkeeping
- The `singleflight` guard (only existed to dedupe concurrent cache builds)
- The resolver `Close` method and its call in `Server.Close`

Net **-56 lines**.

## Testing

- `internal/server`, `services/remotepublish`, and `services/apps/registry` packages all pass.
- Verified the failure mode live: after a dev-session restart, the cached provider returned "operation not found" while the registration generation stayed at 1 and the heartbeat stalled.