### PR TITLE
fix: re-root tunnel-proxied UI paths under app base path

### DIFF
--- a/gestaltd/services/providerdev/app_supervisor.go
+++ b/gestaltd/services/providerdev/app_supervisor.go
@@ -401,8 +401,28 @@ func (a *appManaged) frontendHandler() http.Handler {
 			http.Error(w, "dev server unavailable", http.StatusBadGateway)
 			return
 		}
+		ensureBasePathPrefix(r, a.target.BasePath)
 		proxy.ServeHTTP(w, r)
 	})
+}
+
+// ensureBasePathPrefix roots the request path at basePath, the prefix the dev
+// server is configured to serve under. Already-prefixed paths are unchanged.
+func ensureBasePathPrefix(r *http.Request, basePath string) {
+	base := "/" + strings.Trim(strings.TrimSpace(basePath), "/")
+	if base == "/" {
+		return
+	}
+	p := r.URL.Path
+	if p == base || strings.HasPrefix(p, base+"/") {
+		return
+	}
+	rest := strings.TrimPrefix(p, "/")
+	if rest == "" {
+		r.URL.Path = base + "/"
+		return
+	}
+	r.URL.Path = base + "/" + rest
 }
 
 func (a *appManaged) reverseProxy() (*httputil.ReverseProxy, error) {

--- a/gestaltd/services/providerdev/providerdev_test.go
+++ b/gestaltd/services/providerdev/providerdev_test.go
@@ -52,6 +52,55 @@ func TestSupervisorProxiesHTTP(t *testing.T) {
 	}
 }
 
+func TestSupervisorAppProxiesStrippedTunnelPath(t *testing.T) {
+	t.Parallel()
+	workdir := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	telemetry := telemetrynoop.New()
+	prepared, err := runtimehost.PrepareExternalProviderSockets(runtimehost.ProcessConfig{
+		ProviderName: "combo",
+		Telemetry:    telemetry,
+	})
+	if err != nil {
+		t.Fatalf("PrepareExternalProviderSockets: %v", err)
+	}
+	t.Cleanup(prepared.Cleanup)
+
+	sup, err := providerdev.Start(ctx, nil, nil)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(sup.Stop)
+
+	handle, err := sup.StartApp(ctx, providerdev.AppTarget{
+		Name:       "combo",
+		BasePath:   "/combo",
+		SocketPath: prepared.PluginSocket,
+		BaseEnv:    prepared.Env,
+		Commands: []providerdev.AppCommand{
+			{Workdir: workdir, Command: []string{buildTestdataBinary(t, "fakebackend")}, ReadyTimeout: 15 * time.Second},
+			{Workdir: workdir, Command: []string{buildFakeDevServer(t)}, ReadyTimeout: 15 * time.Second},
+		},
+	})
+	if err != nil {
+		t.Fatalf("StartApp: %v", err)
+	}
+
+	handler := handle.FrontendHandler()
+	waitForHandlerReady(t, handler, "/combo/")
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/src/main.tsx", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("tunnel asset path status = %d, want 200 (re-rooted under base)", rec.Code)
+	}
+	if got := rec.Body.String(); got != "dev-ok" {
+		t.Fatalf("tunnel asset body = %q, want dev-ok", got)
+	}
+}
+
 func TestSupervisorNotReadyReturns503(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
When the remote proxies UI traffic through the reverse tunnel, the request path is stripped twice before reaching the local dev handler: the remote proxy strips the app mount prefix, then the tunnel UI handler strips the /ui/{app} prefix. The dev handler forwarded the resulting root-relative path (/, /src/main.tsx) to the vite dev server as-is.

But the dev server runs with base set to the app mount path (via GESTALT_DEV_BASE_PATH), so it only serves under that prefix: / returned a 302 redirect to the base (an infinite redirect loop through the tunnel) and asset paths 404d.

frontendHandler now re-roots the incoming path under the app's BasePath before proxying, so the dev server always receives paths under its configured base. The rewrite is idempotent so already-prefixed direct local browser hits are unchanged.