### PR TITLE
Document shipped runtime heartbeat operations

### DIFF
--- a/plans/app_registry/architecture/config.md
+++ b/plans/app_registry/architecture/config.md
@@ -165,6 +165,32 @@ server:
 
 `server.appRegistry.autoDeployPollInterval` is the poll interval for the background auto-deploy controller on enabled apps. It defaults to `1m` and must be a positive duration. Coalescing correctness does not depend on the interval; a longer interval only delays detection of new publishes.
 
+### Runtime Heartbeats and Rollout Mode
+
+```yaml
+server:
+  appRegistry:
+    heartbeatInterval: 15s
+    heartbeatTtl: 45s
+    healthyStabilityWindow: 1m
+    heartbeatRetention: 24h
+    rolloutMode: heartbeat
+```
+
+| Field | Default | Meaning |
+| --- | --- | --- |
+| `heartbeatInterval` | `15s` | Period between full per-process runtime snapshots; the first write occurs immediately after startup-provider initialization. |
+| `heartbeatTtl` | `45s` | Freshness lease used for current fleet membership and heartbeat rollout evaluation. |
+| `healthyStabilityWindow` | `1m` | Continuous healthy time required before a heartbeat rollout completes or a failed rollout records recovery. |
+| `heartbeatRetention` | `24h` | Age after which stale heartbeat rows are eligible for pruning. |
+| `rolloutMode` | `enrollment` | Completion algorithm for newly admitted or activation-retargeted rollouts: `enrollment` or `heartbeat`. |
+
+All durations must be positive. `heartbeatTtl` must be greater than `heartbeatInterval`, and `healthyStabilityWindow` must be greater than `heartbeatTtl`. These constraints ensure at least one missed heartbeat can be tolerated without allowing the stability decision to fit entirely inside one lease.
+
+The Gestalt default remains `enrollment` for compatibility, while Toolshed production explicitly sets `heartbeat` after operational verification. Changing the deploy config back to `enrollment` is the rollout-completion rollback switch; it does not disable heartbeat writes, current fleet projection, or recovery visibility. The selected mode is stored on each rollout, so activation must retarget an already-active rollout before that rollout adopts a changed mode.
+
+Cloud Run deployment orchestration separately supplies `minimum_healthy_instances` to `/activate`; it is not a static Gestalt config value. Heartbeat-mode activation requires a positive minimum. Current fleet state is `unknown` when the activated source or minimum basis is absent.
+
 ### Lockfile
 
 Registry-only apps appear in `gestalt.lock.json` with a registry binding and no baked artifacts:
@@ -188,7 +214,8 @@ Registry-only apps appear in `gestalt.lock.json` with a registry binding and no 
 <pre>
 ├── <a href="../project/changelog.md#changelog-01">01 — GCS Registry and Publish Command</a>
 ├── <a href="../project/changelog.md#changelog-12">12 — Complete Registry-Only Lifecycle</a>
-└── <a href="../project/changelog.md#changelog-25">25 — Auto-Deploy Published Snapshots</a>
+├── <a href="../project/changelog.md#changelog-25">25 — Auto-Deploy Published Snapshots</a>
+└── <a href="../project/changelog.md#changelog-27">27 — Runtime Heartbeats and Fleet State</a>
 </pre>
 
 ### Related Docs
@@ -197,6 +224,7 @@ Registry-only apps appear in `gestalt.lock.json` with a registry binding and no 
 ├── <a href="../readme.md">readme.md</a> — architecture and future work
 ├── <a href="../project/changelog.md">changelog.md</a> — implementation milestones and pull requests
 ├── <a href="../operations/lifecycle.md">lifecycle.md</a> — replica startup, background controller, admin HTTP API
+├── <a href="../one-pagers/runtime-heartbeats.md">runtime-heartbeats.md</a> — canonical heartbeat design
 ├── <a href="./models.md">models.md</a> — JSON documents stored in the registry bucket
 └── <a href="../operations/retention.md">retention.md</a> — version cleanup policy and retention config
 </pre>

--- a/plans/app_registry/architecture/indexeddb.md
+++ b/plans/app_registry/architecture/indexeddb.md
@@ -1,6 +1,6 @@
 # App Registry IndexedDB Install State
 
-Reference for the host IndexedDB stores used for app registry installation and per-replica convergence.
+Reference for the host IndexedDB stores used for app registry installation, per-replica convergence, runtime heartbeats, and recovery observations.
 
 The install HTTP API and installer append only to `app_version_change_requests`. Admin list/get endpoints project fleet-known versions from those requests.
 
@@ -27,7 +27,7 @@ Implementation:
 
 The ordered change requests are also the permanent **revision history** for an app. They are never removed by registry retention. The history API returns the raw transition sequence rather than the deduplicated fleet-known projection, so each accepted `from_version` → `to_version` change remains auditable, including repeated versions in upgrade and downgrade chains such as `v1 → v2 → v1`.
 
-IndexedDB stores accepted version changes and each replica's rollout progress. It does not store a single "current fleet version" or "currently running version."
+IndexedDB stores accepted version changes, rollout execution, each replica's historical progress, and one current runtime snapshot per process. It does not store a single authoritative "current fleet version": fleet state is derived from the desired change request, activated source/capacity, and fresh heartbeat rows.
 
 Gestalt derives the desired version from the latest change-request timestamp. If two requests have the same timestamp, it chooses the lexicographically greatest version string so every replica selects the same version. Bootstrap and polling both compare the requests using this rule; they do not assume that the first or last record returned by IndexedDB is the newest.
 
@@ -66,6 +66,8 @@ app_rollouts                     ← current rollout per app
 app_version_rollout_outcomes     ← terminal rollout timing per change request
 app_instance_materializations    ← per-replica acknowledgement of fleet-known versions
 app_auto_deploy_settings         ← per-app auto-deploy policy
+gestaltd_instance_heartbeats     ← current per-process runtime snapshots
+app_version_recovery_observations ← stable recovery facts for failed revisions
 ```
 
 Other host stores created at bootstrap include `users`, `managed_subjects`, `app_shas`, etc.
@@ -86,6 +88,8 @@ Services.GestaltdSourceVersionState ← current Toolshed source version and acti
 Services.AppRollouts                ← rollout state
 Services.AppVersionRolloutOutcomes  ← terminal rollout timing per change request
 Services.AutoDeploySettings         ← per-app auto-deploy policy
+Services.GestaltdInstanceHeartbeats ← per-process runtime snapshots
+Services.AppVersionRecoveryObservations ← immutable failed-rollout recovery facts
 Services.DB                         ← underlying main-db handle
 ```
 
@@ -227,9 +231,9 @@ Used by `POST …/add` and `POST …/upgrade` while each checks rollout admissio
 
 ---
 
-## Store: `gestaltd_source_version_state` (Rollout Source-Version Target)
+## Store: `gestaltd_source_version_state` (Activated Source and Capacity)
 
-Tracks the Toolshed `SOURCE_VERSION` that app rollouts use for cohort membership. Toolshed deployment orchestration is the only writer; a `gestaltd` process must not elect its own source version current.
+Tracks the Toolshed `SOURCE_VERSION` used for current fleet reads and rollout membership, plus the Cloud Run minimum capacity required for health. Toolshed deployment orchestration is the only writer; a `gestaltd` process must not elect its own source version current.
 
 Primary key: `id` = `gestaltd`.
 
@@ -237,15 +241,16 @@ Primary key: `id` = `gestaltd`.
 {
   "id": "gestaltd",
   "current_source_version": "574fe7704ed67fc15d44f76698755bb94ad33d43",
+  "minimum_healthy_instances": 5,
   "updated_at": "2026-07-27T22:30:00Z"
 }
 ```
 
-The source version is the Toolshed commit SHA injected into each process as `SOURCE_VERSION`. `updated_at` records the last source change or explicit deployment retry.
+The source version is the Toolshed commit SHA injected into each process as `SOURCE_VERSION`. `minimum_healthy_instances` comes from the activated Cloud Run revision's minimum scale. `updated_at` records the last source/minimum change or explicit deployment retry.
 
-Toolshed calls the candidate's tagged `POST /activate?source_version={SOURCE_VERSION}` endpoint before shifting traffic. The handler rejects a source-version mismatch so an old revision reached through a stale URL cannot move the target backward. Activation atomically updates `current_source_version` and retargets active app rollouts with fresh timestamps. A repeated activation for the same source is idempotent.
+Toolshed calls the candidate's tagged `POST /activate?source_version={SOURCE_VERSION}&minimum_healthy_instances={MIN_SCALE}` endpoint before shifting traffic. The handler rejects a source-version mismatch and invalid capacity. Activation atomically updates both values and retargets active app rollouts with a fresh evaluation epoch. A repeated activation for the same values is idempotent.
 
-If deployment fails after activation, traffic rollback does not update this record. A workflow retry calls `POST /activate?source_version={SOURCE_VERSION}&retry=true`, updates `updated_at`, refreshes active rollout epochs, and reopens rollouts for this source that failed after the previous activation. The retry does not append another change request.
+If deployment fails after activation, rollback reactivates the restored revision and its minimum after traffic restoration. A workflow retry includes `retry=true`, updates `updated_at`, refreshes active rollout epochs, and may reopen rollouts for that source that failed after its previous activation. Neither operation appends another change request.
 
 ---
 
@@ -260,24 +265,28 @@ Primary key: `id` = `app`.
   "id": "g-issues",
   "app": "g-issues",
   "version": "0.0.0-snapshot.gabc123",
-  "state": "enrolling",
+  "state": "restarting",
+  "mode": "heartbeat",
   "target_source_version": "61885becf49a25a4a8c0063a4d9dd9643b28c2a6",
+  "minimum_healthy_instances": 5,
   "created_at": "2026-07-13T21:00:00Z",
   "enrollment_ends_at": "2026-07-13T21:02:00Z",
-  "deadline": "2026-07-13T21:15:00Z"
+  "deadline": "2026-07-13T21:15:00Z",
+  "healthy_since": "2026-07-13T21:03:00Z",
+  "heartbeat_evaluated_at": "2026-07-13T21:03:15Z"
 }
 ```
 
 States:
 
-- `enrolling` — replicas from `target_source_version` may join by acknowledging it.
-- `restarting` — the acknowledged cohort is frozen and is converging.
-- `complete` — the target cohort is non-empty and every member recorded `restarted_at`.
-- `failed` — the target cohort did not converge before the deadline, or remained empty.
+- `enrolling` — enrollment-mode replicas may join by acknowledging before the window closes.
+- `restarting` — providers are converging. In heartbeat mode this is the initial state and live membership is not frozen.
+- `complete` — the stored mode's completion condition remained satisfied.
+- `failed` — the stored mode did not satisfy completion before the deadline.
 
 A terminal record may be replaced when the next version is admitted. A non-terminal record causes `POST …/add` or `POST …/upgrade` for the same app to return **409 Conflict**. Terminal transitions record `completed_at` or `failed_at`.
 
-`target_source_version` determines cohort membership.
+`mode` is `enrollment` or `heartbeat`. Heartbeat rollouts snapshot `minimum_healthy_instances`; `healthy_since` is set while every fresh target-source heartbeat reports the rollout version and cleared on any regression. `heartbeat_evaluated_at` and `failure_summary` preserve the latest evaluation and structured deadline diagnostics. Activation retargeting resets these fields, the deadline, and the evaluation epoch.
 
 ### Service API
 
@@ -291,6 +300,7 @@ A terminal record may be replaced when the next version is admitted. A non-termi
 | `MarkRestarting(ctx, app, version)` | Freeze the acknowledged cohort after enrollment. |
 | `MarkComplete(ctx, app, version, completedAt)` | Record successful cohort convergence. |
 | `MarkFailed(ctx, app, version, failedAt)` | Record that the rollout missed its deadline. |
+| `EvaluateHeartbeatRollout(ctx, rollout, evaluation)` | Transactionally advance/reset stability or complete/fail a heartbeat rollout, fenced by the rollout epoch. |
 
 **Admin exposure:** `Get` and `ListActive` back `GET /admin/api/v1/app-rollouts` and rollout summaries on `GET /admin/api/v1/registry-apps`. See [lifecycle.md](../operations/lifecycle.md#admin-observability-api).
 
@@ -336,6 +346,78 @@ The catalog poller writes the row exactly once when `MarkCompleteForRollout` or 
 | `RecordFailed(ctx, changeRequestID, app, version, failedAt)` | Persist a failed rollout end time. |
 
 **Admin exposure:** `GetMany` backs rollout duration fields on `GET /api/v1/apps/{app}/admin/registry/history`. See [lifecycle.md](../operations/lifecycle.md#revision-history).
+
+---
+
+## Store: `gestaltd_instance_heartbeats` (Per-Replica Runtime State)
+
+One row per process contains an atomic observation of every deploy-configured registry-only app. Primary key `id` and unique index `by_instance` both use the process-unique `instance_id`; source and timestamp indexes support fresh-fleet reads.
+
+```json
+{
+  "id": "8dfcdc5b-cea7-4869-a2e8-5a51d29e8996",
+  "instance_id": "8dfcdc5b-cea7-4869-a2e8-5a51d29e8996",
+  "source_version": "4f71afddf31d2c452ecd248779a04c905a7b9988",
+  "started_at": "2026-07-30T13:48:41Z",
+  "heartbeat_at": "2026-07-30T13:52:15Z",
+  "apps": {
+    "g-issues": {
+      "state": "running",
+      "desired_version": "0.0.0-snapshot.gd15d64d",
+      "running_version": "0.0.0-snapshot.gd15d64d",
+      "observed_at": "2026-07-30T13:52:15Z",
+      "last_error": ""
+    }
+  }
+}
+```
+
+The `apps` JSON value makes one heartbeat a coherent process snapshot. A configured app missing from the runtime snapshot is written as `unknown`; `desired_version` is diagnostic, while only `state: running` plus an exact `running_version` match is affirmative runtime evidence.
+
+Observation states are `running` (all runtime markers agree), `starting`, `not_running`, `error`, and `unknown`. `last_error` carries the latest diagnostic for an error/unknown observation. Collection is passive and never changes provider lifecycle state.
+
+Rows older than the configured retention are pruned for storage hygiene. Membership uses the shorter freshness lease and current source filter, so stale rows may remain available for diagnosis without affecting health.
+
+### Service API
+
+| Method | Description |
+| --- | --- |
+| `Upsert(ctx, heartbeat)` | Replace one process's full runtime snapshot. |
+| `List(ctx)` | List all retained rows for fresh/stale admin detail. |
+| `ListFreshBySourceVersion(ctx, source, cutoff)` | Load current candidates for fleet projection and rollout/recovery evaluation. |
+| `PruneBefore(ctx, cutoff)` | Delete rows older than retention. |
+
+---
+
+## Store: `app_version_recovery_observations` (Post-Failure Recovery)
+
+Persists one recovery fact keyed by change-request `id` when the still-desired version has a failed rollout outcome and later remains healthy for the configured stability window.
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "app": "g-issues",
+  "version": "0.0.0-snapshot.gdef456",
+  "recovered_at": "2026-07-30T13:52:15Z",
+  "source_version": "4f71afddf31d2c452ecd248779a04c905a7b9988",
+  "live_instances": 5,
+  "minimum_healthy_instances": 5
+}
+```
+
+`RecordIfCurrentFailed` fences the write against the current desired revision and its failed immutable outcome. Concurrent replica observers are idempotent. A recovery row does not mutate `app_version_rollout_outcomes`, `app_rollouts`, retention, or auto-deploy state.
+
+`Get`, `GetMany`, and `RecordIfCurrentFailed` back app-admin current state and revision-history recovery fields.
+
+---
+
+## Legacy RelationalDB Schema Compatibility
+
+RelationalDB requires exact object-store schema metadata equality at `CreateObjectStore`, but stores each complete record in `record_blob`. Runtime Heartbeats therefore keeps the deployed schema declarations for the existing `gestaltd_source_version_state` and `app_rollouts` stores unchanged.
+
+The new source-capacity and heartbeat-rollout fields are non-key, non-indexed record fields. Services read and write them in the full record blob even though they are intentionally absent from the declared column metadata. This permits old and new gestaltd revisions to bootstrap against the same stores during a rolling deployment. The two genuinely new stores, `gestaltd_instance_heartbeats` and `app_version_recovery_observations`, are still created normally.
+
+Do not add the non-indexed Runtime Heartbeats fields to those two existing schema declarations without an explicit mixed-version migration design. [gestalt#3015](https://github.com/valon-technologies/gestalt/pull/3015) added regression coverage for initial and repeated bootstrap plus field round trips under the legacy metadata.
 
 ---
 
@@ -457,7 +539,8 @@ Written by the background catalog poller (`gestaltd/internal/appregistry/poller.
 ├── <a href="../project/changelog.md#changelog-08">08 — Per-Replica Catalog Polling</a>
 ├── <a href="../project/changelog.md#changelog-09">09 — Coordinated Provider Restarts</a>
 ├── <a href="../project/changelog.md#changelog-15">15 — App-Scoped Version Selection</a>
-└── <a href="../project/changelog.md#changelog-25">25 — Auto-Deploy Published Snapshots</a>
+├── <a href="../project/changelog.md#changelog-25">25 — Auto-Deploy Published Snapshots</a>
+└── <a href="../project/changelog.md#changelog-27">27 — Runtime Heartbeats and Fleet State</a>
 </pre>
 
 ### Related Docs
@@ -468,5 +551,6 @@ Written by the background catalog poller (`gestaltd/internal/appregistry/poller.
 ├── <a href="../operations/lifecycle.md">lifecycle.md</a> — replica startup, background controller, admin HTTP API
 ├── <a href="./validation.md">validation.md</a> — install-time validation
 ├── <a href="../operations/admin.md">admin.md</a> — admin UI capabilities
+├── <a href="../one-pagers/runtime-heartbeats.md">runtime-heartbeats.md</a> — canonical design
 └── <a href="./models.md">models.md</a> — GCS registry entry JSON that change requests reference
 </pre>

--- a/plans/app_registry/operations/admin.md
+++ b/plans/app_registry/operations/admin.md
@@ -6,12 +6,14 @@ Operator-facing visibility for registry-only apps and app-scoped fleet version s
 
 Operators installing registry apps should answer these questions without reading pod logs or querying IndexedDB directly:
 
-| Question                          | Admin surface                 |
-| --------------------------------- | ----------------------------- |
-| Which apps are registry-only?     | Embedded admin apps list      |
-| What is the desired version?      | Desired version on app detail |
-| Is the rollout still in progress? | Rollout phase stepper (`/apps/{app}/admin`); rollout badge (embedded `/admin`) |
-| Which replicas have converged?    | Replica convergence table     |
+| Question                            | Admin surface                                                           |
+| ----------------------------------- | ----------------------------------------------------------------------- |
+| Which apps are registry-only?       | Embedded admin apps list                                                |
+| What is the desired version?        | Desired version on app detail                                           |
+| Is the rollout still in progress?   | Rollout phase stepper (`/apps/{app}/admin`); badge (embedded `/admin`)   |
+| Is the current fleet healthy?       | Heartbeat-derived fleet status on both admin surfaces                   |
+| What is each live replica serving?  | Fresh/stale replica observations on embedded app detail                 |
+| How far did enrollment convergence get? | Replica pool totals and rollout-progress API                        |
 
 App admins additionally select the fleet-wide desired version and inspect each candidate version's publication provenance.
 
@@ -26,8 +28,10 @@ Use the same names as [lifecycle.md](./lifecycle.md#runtime-version-invariants):
 - **Rollout** — fleet-wide execution record in `app_rollouts` (`enrolling` → `restarting` → `complete` | `failed`).
 - **Target source version** — Toolshed `SOURCE_VERSION` whose replicas determine the rollout outcome.
 - **Converged** — the poller recorded `restarted_at` for the replica and version. Rollout accounting, not proof the provider is still running that version.
+- **Current fleet state** — a read-time projection over fresh heartbeats for the activated source and desired version.
+- **Recovery** — an immutable observation that a failed desired-version rollout later became stably healthy.
 
-Label **converged** as rollout progress, not current runtime state.
+Label **converged** as rollout progress, not current runtime state. Never relabel a failed rollout as complete because the current fleet later becomes healthy.
 
 ---
 
@@ -49,38 +53,40 @@ The embedded shell at `/admin` keeps the Prometheus metrics viewer and adds an *
 
 ### Apps List (`/admin/registry`)
 
-| App      | Registry | Desired version     | Rollout  | Cohort        |
-| -------- | -------- | ------------------- | -------- | ------------- |
-| g-issues | toolshed | `0.0.0-snapshot.g…` | Complete | 3/3 restarted |
+| App      | Registry | Desired version     | Current fleet | Rollout  | Cohort        |
+| -------- | -------- | ------------------- | ------------- | -------- | ------------- |
+| g-issues | toolshed | `0.0.0-snapshot.g…` | Healthy · 5/5 | Complete | 3/3 restarted |
 
 Show configured registry-only apps even when the fleet catalog is empty (desired version "—", status "not installed").
 
-Auto-refresh every 10–15s while any listed rollout is non-terminal.
+Current fleet is `healthy` only when the live count meets the activated minimum and every fresh current-source replica reports the desired version. Show `converging`, `degraded`, or `unknown` independently from the rollout badge; insufficient fresh replicas is `unknown`, never healthy.
 
 ### App Detail (`/admin/registry/{app}`)
 
 1. **Summary** — registry binding, desired version, latest published version (if available), install metadata (`installedBy`, `installedAt`).
-2. **Rollout** — state badge, target source version, timestamps, enrollment deadline, failure reason when `failed`.
-3. **Replicas** — per-replica rollout progress (`instanceId`, `sourceVersion`, `inCohort`, acknowledged / materialized / stopped / restarted, `attemptCount`, last error). Group by source version and sort by `instanceId`.
+2. **Current fleet** — health, current source, minimum/live/running counts, heartbeat lease, and evaluation time.
+3. **Runtime replicas** — fresh observations first, with instance ID, source version, heartbeat age, state, running version, and error. Show expired and superseded-source rows separately as stale diagnostics.
+4. **Rollout** — execution status, target source, and timestamps. Keep its terminal historical outcome visually distinct from current fleet health.
+5. **Replica pool** — enrollment cohort totals for rollout-progress accounting. The API retains per-replica materialization details; the UI's per-replica table is the current runtime heartbeat view.
 
 ```text
 ┌─────────────────────────────────────────────────────────────┐
-│ g-issues                                    rollout: Complete │
+│ g-issues                              current fleet: Healthy │
 │ registry: toolshed                                            │
 ├─────────────────────────────────────────────────────────────┤
 │ Desired: 0.0.0-snapshot.gcd9d741…      installed 2026-07-21 … │
 │ Published latest: 0.0.0-snapshot.gcd9d741… (same)             │
 ├─────────────────────────────────────────────────────────────┤
-│ Replicas — source 61885be… (target)              3/3 restarted │
-│ instanceId                 mat.  restart  att  error           │
-│ gestaltd-…-ncnq6           ✓     ✓        0                    │
-│ gestaltd-…-hdnx2           ✓     ✓        0                    │
-│ gestaltd-…-smmq7           ✓     ✓        0                    │
-│ Source 574fe77… (superseded)                     1/3 restarted │
+│ Source 61885be… · 3/3 live · lease 45s                        │
+│ instanceId                 age   runtime   running version     │
+│ gestaltd-…-ncnq6           4s    Running   gcd9d741…           │
+│ gestaltd-…-hdnx2           9s    Running   gcd9d741…           │
+│ gestaltd-…-smmq7           12s   Running   gcd9d741…           │
+│ Stale: gestaltd-…-old · superseded source · process exited     │
 └─────────────────────────────────────────────────────────────┘
 ```
 
-The apps-list denominator includes only target-source-version replicas. Superseded source-version rows remain on app detail so an operator can explain Cloud Run overlap without treating terminated old revisions as rollout failures.
+Freshness is based on the configured lease, not the browser refresh time. Superseded-source and expired rows remain on app detail so an operator can explain Cloud Run overlap and replacement without counting them toward current health.
 
 ---
 
@@ -101,6 +107,7 @@ Implemented in `gestalt-providers` (default `/apps` UI), not the embedded `/admi
 - Legacy published versions without workflow metadata still link the commit and show **not recorded** for workflow/PR fields.
 - Disable deploy actions while a rollout is `enrolling` or `restarting`; poll registry state every **3s** and refresh until rollout is terminal.
 - Show rollout progress and the admitted version on the snapshots tab. See [Rollout phase stepper](#rollout-phase-stepper) and [Selected version row](#selected-version-row).
+- Show **Current fleet** separately from the rollout stepper, including minimum/live counts and source version. A healthy fleet after failure renders **Recovered after failed rollout** while the stepper remains **Failed**.
 - Toggle **Automatically deploy new snapshots** on `/apps/{app}/admin`. When enabled, new published snapshots are admitted across the fleet without a manual **Deploy** click. See [Auto-deploy toggle](#auto-deploy-toggle).
 - Render access denied on **403** without leaking registry metadata.
 
@@ -114,6 +121,21 @@ The page header shows the app name, **App management** label, registry binding, 
 - **Revision history** — accepted fleet version changes in reverse chronological order with rollout status and duration. This tab is always read-only.
 
 See [pending-publish.md](./pending-publish.md) for snapshot merge rules, **3s** registry polling during bootstrap and active publish/rollout, and live **Publishing** duration labels.
+
+### Current Fleet and Recovery
+
+The page header consumes `fleetState` from `GET /api/v1/apps/{app}/admin/registry` and renders it independently from `rollout`:
+
+```text
+Current fleet: Healthy · 5/5 running gcd9d741… on 61885be…
+Last rollout: Failed after 15m · Recovered Jul 30 at 13:52
+```
+
+- `healthy` means every fresh current-source replica reports the desired version and the activated minimum capacity is present.
+- `unknown` covers a missing source/minimum basis or too few fresh replicas.
+- `degraded` covers fresh errors, unknown observations, missing apps, or version mismatches; `converging` applies while a matching rollout is active before its deadline.
+- Recovery timing comes from `app_version_recovery_observations`. It does not alter the failed rollout row or its duration.
+- During mixed-version deploys, older clients may omit these fields; the UI keeps rollout presentation functional and waits for the next poll.
 
 ```text
 g-issues                                                                 App management
@@ -272,7 +294,6 @@ Legacy revisions admitted before rollout-outcome persistence omit rollout status
 
 ## Out of Scope
 
-- Per-replica observed running version (runtime heartbeats)
 - Installing or upgrading from the embedded `/admin` UI
 - Canceling or force-completing a rollout from either UI
 - Publishing versions from either UI
@@ -298,7 +319,8 @@ Legacy revisions admitted before rollout-outcome persistence omit rollout status
 ├── <a href="../project/changelog.md#changelog-18">18 — Revision History and Redeploy Windows</a>
 ├── <a href="../project/changelog.md#changelog-21">21 — Rollout Phase Stepper and Selected Version Row</a>
 ├── <a href="../project/changelog.md#changelog-25">25 — Auto-Deploy Published Snapshots</a>
-└── <a href="../project/changelog.md#changelog-26">26 — Revision History Rollout Visibility</a>
+├── <a href="../project/changelog.md#changelog-26">26 — Revision History Rollout Visibility</a>
+└── <a href="../project/changelog.md#changelog-27">27 — Runtime Heartbeats and Fleet State</a>
 </pre>
 
 ### Related Docs

--- a/plans/app_registry/operations/lifecycle.md
+++ b/plans/app_registry/operations/lifecycle.md
@@ -15,6 +15,8 @@ Implementation:
 - Artifact materializer — `gestaltd/internal/appregistry/materializer.go`
 - Registry mount resolver — `gestaltd/internal/appregistry/mount.go`
 - App provider restarter — `gestaltd/internal/bootstrap/app_provider_restart.go`
+- Runtime heartbeat writer and fleet projection — `gestaltd/internal/appregistry/heartbeat_writer.go`, `fleet_state.go`
+- Recovery observer — `gestaltd/internal/appregistry/recovery_observer.go`
 - Change request projections — `gestaltd/internal/coredata/app_version_change_requests_projection.go`
 - Rollout state — `gestaltd/internal/coredata/app_rollouts.go`
 
@@ -69,11 +71,12 @@ Bootstrap finishes its registry-app startup attempts before the catalog poller b
 1. Bootstrap materializes and starts the desired version without updating `app_rollouts` or `app_instance_materializations`; the poller owns those rollout-accounting writes.
 2. After the exact package is validated and its provider starts successfully, bootstrap records the app and version in this process's running-version map and local `active-version` marker. Static and runtime handlers may then serve that version. If provider startup fails, neither the running-version map nor the `active-version` marker may identify the requested version as running.
 3. After bootstrap has attempted every registry-only app, it marks startup-provider initialization complete. An individual registry app failure does not prevent this transition or block core server startup.
-4. The poller then starts and runs its first reconciliation pass immediately.
-5. The poller compares the desired version from `app_version_change_requests` with this process's provider registry and running-version map:
+4. The runtime heartbeat writer then publishes one full-process snapshot immediately and every configured heartbeat interval. It observes every registry-only app; it does not start, stop, materialize, or relabel providers.
+5. The poller starts and runs its first reconciliation pass immediately.
+6. The poller compares the desired version from `app_version_change_requests` with this process's provider registry and running-version map:
    - **Match** — the desired version is already running. The poller validates that version's local package and records its `materialized_at`, then sets `restarted_at` on every pending row without downloading superseded versions or restarting the app.
    - **Missing or different** — if another version is running, the poller stops it; then it starts the desired version and updates the rollout-progress rows. A historical `stopped_at` in `app_instance_materializations` does not prove that the provider is still absent, because those rows record previous rollout writes rather than current process state.
-6. An empty fleet-known projection leaves the app stopped and clears any stale running-version map entry and `active-version` marker.
+7. An empty fleet-known projection leaves the app stopped and clears any stale running-version map entry and `active-version` marker.
 
 A replica does not acknowledge a rollout while it is bootstrapping. If rollout enrollment closes before that replica starts polling, the replica is not part of the rollout cohort. Its first poll still reads the persisted change request and converges locally without reopening the terminal rollout.
 
@@ -89,23 +92,28 @@ The controller is **pull-based** and **local**: each replica reads `app_version_
 
 Only one rollout per app may be active across the fleet. `POST …/add` and `POST …/upgrade` hold the app-scoped install lock while they reject an existing `enrolling` or `restarting` rollout, validate the candidate, create the new rollout, and append its change request. Different apps may roll out concurrently.
 
-Rollout membership is scoped to one Toolshed source version. `SOURCE_VERSION` is the commit SHA already injected into every Cloud Run process. Keep `instance_id` process-unique; using one source version as the instance ID would collapse five replicas into one row and falsely report convergence after one process restarts.
+Rollout membership is scoped to one Toolshed source version. `SOURCE_VERSION` is the commit SHA injected into every Cloud Run process, while `instance_id` remains process-unique so each replica has its own heartbeat and rollout-progress records.
 
-Replica membership is discovered rather than configured:
+`server.appRegistry.rolloutMode` selects completion behavior for newly admitted or activation-retargeted rollouts:
 
-1. App admission snapshots the current `SOURCE_VERSION` into `app_rollouts.target_source_version`.
-2. The rollout remains `enrolling` for a bounded window of at least two poll intervals.
-3. Replicas with that source version join by writing `acknowledged_at` before `enrollment_ends_at` and download the rollout artifact during this window, recording `materialized_at` while the current provider keeps running.
-4. Replicas from another source version still reconcile the durable desired version, but they are not members of the target cohort and do not affect its outcome.
-5. After enrollment, the target cohort is frozen and the rollout becomes `restarting`.
-6. The rollout completes when the target cohort is non-empty and every member records `restarted_at`.
-7. The rollout fails if a target-cohort replica does not restart before the deadline, or if no target replica acknowledges before the deadline.
+- **`heartbeat`** — the shipped Toolshed setting. New rollouts start in `restarting`, snapshot `target_source_version` and `minimum_healthy_instances`, and complete from the live fleet rather than a frozen identity set.
+- **`enrollment`** — the compatibility and rollback setting. It retains the bounded `enrolling` window, frozen acknowledged cohort, and `restarted_at` completion semantics described by historical rollout records.
+
+In heartbeat mode:
+
+1. Every process writes one atomic `gestaltd_instance_heartbeats` snapshot immediately after startup-provider initialization and every **15 seconds** by default. Each configured registry app reports its observed state and running version from the provider registry, running-version map, and `active-version` marker.
+2. A heartbeat is live only when its source matches the rollout target and it is no older than the configured lease (**45 seconds** by default). A departed identity stops counting when its lease expires.
+3. The rollout is healthy only when at least its snapshotted minimum capacity is live and every fresh target-source replica reports `running` at the rollout version. A missing app, error, unknown state, or mismatched fresh replica blocks completion even when the fleet is above the minimum.
+4. Healthy state must remain continuous for the configured stability window (**60 seconds** by default). A regression clears `healthy_since`.
+5. The rollout completes after stable health, or fails at its deadline with the observed source, capacity, running, mismatch, and error counts. Transitions are fenced by the complete rollout epoch so concurrent or stale evaluators are idempotent.
+
+Replica identity is diagnostic rather than a required slot: after replica A expires, replacement B on the same target source can satisfy the minimum and complete the rollout once the entire fresh fleet is stable. `app_instance_materializations` continues to describe local reconciliation progress, but it does not decide heartbeat rollout completion.
 
 When the catalog poller transitions a rollout to `complete` or `failed`, it writes one `app_version_rollout_outcomes` row keyed by the latest change request for `(app, version)`. Duplicate writes for the same change-request `id` are ignored. The poller records an outcome only when the transition succeeds; no-op transitions on an already-terminal rollout do not write. Terminal durations on the revision-history API prefer this sidecar over the live `app_rollouts` record.
 
-This prevents a Cloud Run deployment from combining five old and five candidate processes into a ten-member cohort. When Cloud Run terminates the old deployment, those rows remain visible for diagnostics but do not block the candidate deployment from completing at `5/5 restarted`.
+Current fleet state and rollout outcome are separate facts. `fleetState` is evaluated at read time from fresh heartbeats for the currently activated source; `app_version_rollout_outcomes` is immutable history for one admission. A failed rollout remains failed even if the desired version later becomes healthy.
 
-Never declare success because any source-version cohort completed. The old source version could reach `5/5` while the promoted source version fails. Success is tied to `target_source_version`.
+For that case, the recovery observer requires the same continuous healthy stability window and records one `app_version_recovery_observations` row for the failed change-request ID. Recovery does not rewrite the outcome, append a change request, reset retention, or trigger auto-deploy.
 
 #### Target Source Version Selection
 
@@ -113,17 +121,17 @@ The replica handling the version-selection HTTP request does not choose the targ
 
 Toolshed deployment orchestration owns shared source-version state:
 
-1. After the candidate passes readiness, call `POST /activate?source_version={SOURCE_VERSION}` on its tagged management URL before shifting traffic. The candidate rejects the request unless the expected source version matches its local value. Activation atomically records that `SOURCE_VERSION` as current and retargets active app rollouts with a fresh enrollment epoch.
+1. After the candidate passes readiness, call `POST /activate?source_version={SOURCE_VERSION}&minimum_healthy_instances={MIN_SCALE}` on its tagged management URL before shifting traffic. The candidate rejects a source-version mismatch or non-positive minimum. Activation atomically records the source and Cloud Run minimum capacity and retargets active app rollouts with a fresh epoch.
 2. App admission reads the current source-version record while holding the app install lock and copies it to the rollout.
 3. Shift 100% traffic to the candidate.
 
-A repeated activation for the same source version is idempotent. If deployment fails after activation, rollback restores Cloud Run and Temporal traffic but does not restore the previous source-version record. Until the deployment is retried, a new app rollout may target the unavailable candidate and fail. Retrying the failed deployment calls `POST /activate?source_version={SOURCE_VERSION}&retry=true`; this refreshes active rollout epochs and reopens rollouts for that source version that failed since its previous activation before traffic is shifted again.
+A repeated activation for the same source and minimum is idempotent. Deployment rollback treats traffic and app-registry source state as one promotion unit: after restoring Cloud Run traffic, orchestration calls the restored revision's `/activate` endpoint with its own `SOURCE_VERSION`, minimum capacity, and `retry=true`. This prevents current fleet reads and new admissions from remaining pointed at the failed candidate. A deployment retry similarly refreshes the epoch and may reopen rollouts for that source that failed since its prior activation.
 
-If a new source version becomes current while an app rollout is active, retarget the rollout and open a fresh enrollment window. Rollout transitions are fenced by target source version and enrollment epoch so a poller that sampled the old rollout cannot complete, fail, or advance the new one. The desired app version and change request do not change. Materialization rows from the superseded source version remain diagnostic and have `inCohort: false`.
+If a new source version or minimum becomes current while an app rollout is active, activation retargets it, resets its deadline and health epoch, and applies the configured rollout mode. The desired app version and change request do not change. Materialization and heartbeat rows from superseded sources remain diagnostic but do not participate in current health or completion.
 
 Production rollout coordination requires `SOURCE_VERSION`. Local development may use a process-local value.
 
-Replicas that do not acknowledge before enrollment closes are not cohort members and do not block completion. A late target-source-version replica still converges locally but does not reopen a terminal rollout.
+Changing `rolloutMode` back to `enrollment` is the operational completion rollback switch; heartbeat and recovery data remain available. The mode is applied at admission or activation, so activation is required to retarget an already-active heartbeat rollout into enrollment semantics. Legacy enrollment rollouts otherwise retain their stored mode until terminal.
 
 Each pass:
 
@@ -170,6 +178,18 @@ Runtime handlers determine availability from the local provider registry, runnin
 ## Runtime
 
 The admin HTTP API is served under `/admin/api/v1` on the same listener as the other admin API (for example `/admin/api/v1/runtime/providers`). In deployments that split public and management listeners, call the management base URL.
+
+### Operational Verification
+
+After activation or replacement, verify the live system through the registry-app APIs rather than interpreting materialization timestamps as liveness:
+
+1. Confirm `fleetState.sourceVersion` equals the activated Cloud Run revision, `minimumHealthyInstances` equals its configured minimum scale, and `heartbeatTtlSeconds` is the expected lease.
+2. Observe for at least two lease windows. `liveInstances` must stay at or above the minimum, and every fresh replica must report the desired version; a replaced process should move to `staleReplicas` after the lease while its replacement appears in `freshReplicas`.
+3. Confirm the embedded and app-admin surfaces agree on current fleet state while preserving the separate rollout result and any recovery time.
+4. Before enabling heartbeat completion, ensure no app rollout is active. After enablement, exercise one registry-app rollout and verify stable-health completion does not depend on a departed instance ID.
+5. For rollback, confirm traffic returns to the previous revision and activation updates both `sourceVersion` and minimum capacity to that restored revision.
+
+The production rollout followed this sequence: [toolshed#3922](https://github.com/valon-technologies/toolshed/pull/3922) deployed heartbeat observability under enrollment semantics, [gestalt#3015](https://github.com/valon-technologies/gestalt/pull/3015) and [toolshed#3924](https://github.com/valon-technologies/toolshed/pull/3924) rolled forward schema-compatible binaries, and [toolshed#3925](https://github.com/valon-technologies/toolshed/pull/3925) enabled heartbeat completion after fleet verification.
 
 ### How to Invoke
 
@@ -487,12 +507,12 @@ IndexedDB read only. No GCS fetch.
 
 Read-only routes under `/admin/api/v1` with `gestaltAdmin` auth. UI wireframes: [admin.md](./admin.md#embedded-admin-ui-admin).
 
-These routes expose IndexedDB rollout state that the catalog poller already writes. They do not change install or convergence behavior.
+These routes expose rollout history and current heartbeat-derived fleet state. They do not change install or convergence behavior.
 
 | Method | Path | Description |
 | --- | --- | --- |
-| `GET` | `/admin/api/v1/registry-apps` | Registry-only apps from deploy config, merged with desired version and rollout summary |
-| `GET` | `/admin/api/v1/registry-apps/{app}` | One registry-only app: fleet-known versions, rollout, optional latest published registry version |
+| `GET` | `/admin/api/v1/registry-apps` | Registry-only apps from deploy config, merged with desired version, rollout summary, and current `fleetState` |
+| `GET` | `/admin/api/v1/registry-apps/{app}` | One registry-only app: fleet-known versions, rollout, current fleet state, fresh/stale replicas, and optional latest published version |
 | `GET` | `/admin/api/v1/app-rollouts` | List active and recent terminal rollouts |
 | `GET` | `/admin/api/v1/app-rollouts/{app}/materializations` | Per-replica rollout-progress rows for one `(app, version)` |
 
@@ -535,6 +555,7 @@ List deploy-configured registry-only apps (`source.registry`), merged with fleet
 | `rollout` | object | Current or most recent rollout for this app; omitted when none |
 | `rollout.targetSourceVersion` | string | Toolshed `SOURCE_VERSION` selected by deployment orchestration |
 | `cohort` | object | Counts over target-source-version materialization rows that acknowledged before `enrollmentEndsAt` |
+| `fleetState` | object | Current heartbeat-derived state, source, desired version, minimum/live/running counts, errors, lease, and evaluation time |
 
 Apps with no fleet-known version still appear when configured with `source.registry`. IndexedDB read only. No GCS fetch.
 
@@ -565,6 +586,8 @@ Detail view for one registry-only app. Same fields as one list element, plus:
 `knownVersions` lists fleet-known `(app, version)` pairs projected from `app_version_change_requests`.
 
 `latestPublished` is optional. The handler may fetch the registry index and return the newest `publishedAt` entry so operators can compare **published** vs **fleet-known** vs **converged**.
+
+`freshReplicas` contains observations within the lease for the current source. `staleReplicas` retains expired and superseded-source observations for diagnosis; neither stale category contributes to `fleetState` or rollout completion.
 
 **Response `404`** when `{app}` is not a registry-only app in deploy config.
 
@@ -707,6 +730,7 @@ Rules:
 
 - `{app}` must be deploy-configured with `source.registry`.
 - `knownVersions` comes from the change-request projection; `desiredVersion` is `LatestKnownVersion` and is omitted before first install.
+- `fleetState` is current heartbeat-derived state and is independent of `rollout`. `recovery`, when present, identifies a failed current revision that later reached stable fleet health.
 - `publishedVersions` comes from the registry index, newest `publishedAt` first. Each entry includes `publishedAt`, `sourceRef`, `sourceUrl`, and `publication` when recorded. Legacy versions may omit `publication`.
 - `publishedVersions[].deploymentState` is `available` for never-deployed versions before `expiresAt`, `expired` for never-deployed versions after `expiresAt` but before pruning, `desired` for the current version, `redeployable` for historical versions before `expiresAt`, or `locked` after `expiresAt`.
 - `deployableUntil` is returned for historical versions (mapped from `expiresAt`). The UI offers **Deploy** only for `available` and `redeployable`.
@@ -766,6 +790,7 @@ Rules:
 - `rolloutState` is `enrolling`, `restarting`, `complete`, or `failed`.
 - For active rollouts, project `rolloutState` from `app_rollouts` only on the current revision (`id` matches the latest change request). Older same-version rows do not inherit the live rollout.
 - For terminal rows, prefer the `app_version_rollout_outcomes` sidecar. Fall back to `app_rollouts` when the rollout record is still terminal and versions match.
+- A revision-level `recovery` is additive: it never changes `rolloutState: failed`. The history response's top-level `fleetState` describes the fleet now, not at the revision timestamp.
 - `rolloutForSeconds` is set only while state is `enrolling` or `restarting`.
 - `rolloutDurationSeconds`, `rolloutCompletedAt`, and `rolloutFailedAt` are set only for terminal states.
 - Legacy revisions without a stored outcome omit terminal duration fields.
@@ -962,7 +987,8 @@ Example:
 ├── <a href="../project/changelog.md#changelog-15">15 — App-Scoped Version Selection</a>
 ├── <a href="../project/changelog.md#changelog-17">17 — Version Retention and Cleanup</a>
 ├── <a href="../project/changelog.md#changelog-18">18 — Revision History and Redeploy Windows</a>
-└── <a href="../project/changelog.md#changelog-25">25 — Auto-Deploy Published Snapshots</a>
+├── <a href="../project/changelog.md#changelog-25">25 — Auto-Deploy Published Snapshots</a>
+└── <a href="../project/changelog.md#changelog-27">27 — Runtime Heartbeats and Fleet State</a>
 </pre>
 
 ### Related Docs

--- a/plans/app_registry/project/changelog.md
+++ b/plans/app_registry/project/changelog.md
@@ -324,8 +324,10 @@ Show in-flight and completed rollout timing on the **Revision history** tab on `
 
 **Tags:** [`admin.md`](../operations/admin.md) [`config.md`](../architecture/config.md) [`indexeddb.md`](../architecture/indexeddb.md) [`lifecycle.md`](../operations/lifecycle.md)
 
-Replace frozen process-identity enrollment with live, source-version-scoped replica heartbeats. Derive current fleet health from fresh observations of the provider registry, running-version map, and active-version marker; require the activated minimum replica count; allow replacement replicas to satisfy departed capacity; and preserve failed rollout outcomes while recording later recovery.
+Shipped live, source-version-scoped replica heartbeats and replacement-aware rollout completion. Current fleet health now comes from fresh observations of the provider registry, running-version map, and `active-version` marker; activation supplies minimum capacity; and a failed immutable rollout outcome may have a separate later recovery observation.
 
 **Design:** [runtime-heartbeats.md](../one-pagers/runtime-heartbeats.md)
 
-**Status:** Proposed
+**Merged:** [gestalt#3005](https://github.com/valon-technologies/gestalt/pull/3005) · [gestalt#3006](https://github.com/valon-technologies/gestalt/pull/3006) · [gestalt#3007](https://github.com/valon-technologies/gestalt/pull/3007) · [gestalt#3008](https://github.com/valon-technologies/gestalt/pull/3008) · [gestalt#3009](https://github.com/valon-technologies/gestalt/pull/3009) · schema hotfix [gestalt#3015](https://github.com/valon-technologies/gestalt/pull/3015) · [gestalt-providers#1221](https://github.com/valon-technologies/gestalt-providers/pull/1221) · [toolshed#3922](https://github.com/valon-technologies/toolshed/pull/3922) · [toolshed#3924](https://github.com/valon-technologies/toolshed/pull/3924) · [toolshed#3925](https://github.com/valon-technologies/toolshed/pull/3925)
+
+**Status:** Shipped. Toolshed first deployed heartbeat observability with enrollment completion and rollback reactivation, rolled forward the RelationalDB-compatible schema hotfix, verified current-source heartbeats and minimum capacity across multiple freshness windows, then enabled `rolloutMode: heartbeat` in an isolated config-only change. Restoring `rolloutMode: enrollment` remains the completion rollback switch.

--- a/plans/app_registry/project/tests.md
+++ b/plans/app_registry/project/tests.md
@@ -12,6 +12,8 @@ Reference for behavioral tests in the app registry plan.
 | `internal/appregistry` | `materializer_test.go` | 5 | Unit | — |
 | `internal/appregistry` | `mount_test.go` | 4 | Unit | — |
 | `internal/coredata` | `app_rollouts_test.go`, `app_version_install_locks_test.go` | 3 | Unit | [gestalt#2812](https://github.com/valon-technologies/gestalt/pull/2812) |
+| `internal/coredata` | heartbeat, recovery, source activation, and schema compatibility tests | — | Unit/integration | [gestalt#3005](https://github.com/valon-technologies/gestalt/pull/3005) · [gestalt#3009](https://github.com/valon-technologies/gestalt/pull/3009) · [gestalt#3015](https://github.com/valon-technologies/gestalt/pull/3015) |
+| `internal/appregistry` | `heartbeat_writer_test.go`, `fleet_state_test.go`, `recovery_observer_test.go`, `poller_heartbeat_test.go` | — | Unit | [gestalt#3006](https://github.com/valon-technologies/gestalt/pull/3006) · [gestalt#3008](https://github.com/valon-technologies/gestalt/pull/3008) · [gestalt#3009](https://github.com/valon-technologies/gestalt/pull/3009) |
 | `internal/bootstrap` | `app_provider_restart_test.go`, `app_provider_restart_mount_test.go`, `app_provider_lifecycle_test.go` | 8 | Unit/integration | [gestalt#2812](https://github.com/valon-technologies/gestalt/pull/2812) |
 | `internal/config`, `internal/operator`, `internal/appregistry`, `internal/bootstrap` | registry-only source tests | — | Unit/integration | — |
 | `internal/appregistry` | `install_validator_test.go`, `install_validation_errors_test.go` | — | Unit | [gestalt#2887](https://github.com/valon-technologies/gestalt/pull/2887) |
@@ -19,8 +21,8 @@ Reference for behavioral tests in the app registry plan.
 | `internal/server` | `handlers_app_admin_registry_test.go` | 4 | HTTP integration | [gestalt#2909](https://github.com/valon-technologies/gestalt/pull/2909) · [gestalt#2931](https://github.com/valon-technologies/gestalt/pull/2931) · [gestalt#2939](https://github.com/valon-technologies/gestalt/pull/2939) |
 | `internal/config` | `app_registry_retention_test.go` | 3 | Unit | [gestalt#2937](https://github.com/valon-technologies/gestalt/pull/2937) |
 | `internal/appregistry` | `retention_test.go`, `retention_prune_test.go` | 2 | Unit | [gestalt#2937](https://github.com/valon-technologies/gestalt/pull/2937) · [gestalt#2938](https://github.com/valon-technologies/gestalt/pull/2938) |
-| `gestalt-providers/app/default` | `e2e/app-admin-mock.spec.ts` | — | Playwright mock | [gestalt-providers#1142](https://github.com/valon-technologies/gestalt-providers/pull/1142) · [gestalt-providers#1163](https://github.com/valon-technologies/gestalt-providers/pull/1163) |
-| `services/ui/adminui` | registry UI smoke | — | Manual / browser | planned |
+| `gestalt-providers/app/default` | `e2e/app-admin-mock.spec.ts` | — | Playwright mock | [gestalt-providers#1142](https://github.com/valon-technologies/gestalt-providers/pull/1142) · [gestalt-providers#1163](https://github.com/valon-technologies/gestalt-providers/pull/1163) · [gestalt-providers#1221](https://github.com/valon-technologies/gestalt-providers/pull/1221) |
+| `services/ui/adminui` | fleet-state component and registry UI tests | — | Unit / build | [gestalt#3007](https://github.com/valon-technologies/gestalt/pull/3007) |
 
 Test fixture for install HTTP tests: `internal/appregistry/registrytest/fixture.go`
 
@@ -249,11 +251,63 @@ go test ./internal/appregistry -run 'Test(Installer|CatalogPollerRollout)' -coun
 ```
 
 - Install admission and app-scoped lock tests allow one active rollout per app while allowing different apps concurrently.
-- Poller tests cover enrollment, cohort completion, missed deadlines, and late-replica convergence.
+- Poller tests preserve enrollment-mode cohort completion and add heartbeat-mode completion behind the stored rollout mode.
 - Source-version-cohort tests use five old and five candidate processes. Both source versions acknowledge the app version, but only rows whose `source_version` matches `target_source_version` have `inCohort: true`; candidate convergence completes at `5/5` even when terminated old processes never restart.
 - Target-selection tests prove that an old revision handling an in-flight request cannot select itself, an empty target cohort cannot complete, and a completed old cohort cannot hide a target-cohort failure.
 - Activation tests require the caller's expected source version to match the handling revision, retarget an active rollout with a fresh enrollment epoch, and preserve the desired app version and change request. Same-source activation is idempotent; an explicit deployment retry refreshes active epochs and reopens failures recorded since the previous activation.
 - Identity tests require `SOURCE_VERSION` while instance IDs remain distinct within one source version.
+
+---
+
+## Runtime Heartbeat, Recovery, and Replacement Tests
+
+Run:
+
+```bash
+cd gestaltd
+go test ./internal/config/... -run TestAppRegistryHeartbeat -count=1
+go test ./internal/coredata/... -run 'Test(Heartbeat|GestaltdSourceVersion|RuntimeHeartbeatFields)' -count=1
+go test ./internal/appregistry/... -run 'Test(Heartbeat|Fleet|Recovery|CatalogPoller.*Heartbeat)' -count=1
+go test ./internal/server/... -run 'Test(AdminRegistryApps|AdminAppRollout|AppAdminRegistry.*Fleet|Activate)' -count=1
+```
+
+### Heartbeat Writer and Fleet Projection
+
+- The writer waits for startup-provider initialization, writes immediately, then writes at the configured interval without overlapping passes.
+- One row contains every configured registry-only app with one observation time. Provider registry, running-version map, and `active-version` marker agreement is required for `running`; missing runtime state is `unknown`.
+- Write failure logs and retries on the next interval. Retention pruning is coarse and independent from lease-based membership.
+- Projection filters by activated source and lease, requires the activated minimum, and counts every fresh autoscaled replica. Too few live rows is `unknown`; one fresh mismatch/error is `degraded`; only unanimous exact-version observations are `healthy`.
+- Config tests assert positive durations, `heartbeatTtl > heartbeatInterval`, `healthyStabilityWindow > heartbeatTtl`, valid rollout modes, and defaults of 15s / 45s / 1m / 24h.
+
+### Replacement-Aware Rollouts
+
+- Heartbeat admissions start in `restarting` and snapshot source, minimum, mode, deadline, and evaluation epoch.
+- A departed replica blocks only while its heartbeat is fresh. After lease expiry, a replacement on the target source can satisfy capacity; a fresh unhealthy replica still blocks completion above the minimum.
+- Continuous health sets `healthy_since`; regression clears it. Completion occurs only after the configured stability window.
+- Deadline failure persists structured capacity, running, mismatch, error, source, version, and evaluation fields.
+- Source/minimum activation retargeting resets stability and fences stale evaluators. Concurrent evaluators produce one terminal transition and one immutable outcome.
+- Enrollment-mode tests remain to support rollback and active legacy records.
+
+### Recovery Observations
+
+- A failed current desired revision records one recovery only after the fleet remains healthy for the stability window.
+- A newer desired revision, changed source/minimum, health regression, non-failed outcome, or missing capacity resets/blocks recovery.
+- Concurrent observers are idempotent. Recovery does not overwrite the failed rollout outcome or mutate retention and auto-deploy state.
+- App-admin registry and history responses expose `fleetState` and recovery separately from rollout fields; embedded detail separates fresh and stale replicas.
+
+### Legacy RelationalDB Schema Compatibility
+
+`TestRuntimeHeartbeatFieldsRoundTripWithLegacyStoreSchemas` models RelationalDB's exact metadata comparison. It proves that bootstrap retains deployed `gestaltd_source_version_state` and `app_rollouts` schemas while non-indexed Runtime Heartbeats fields round-trip through full record blobs, including after a second mixed-version bootstrap. The new heartbeat and recovery stores are still created.
+
+### Operational Verification
+
+The production sequence was deliberately split:
+
+1. [toolshed#3922](https://github.com/valon-technologies/toolshed/pull/3922) deployed writers, APIs, UIs, activation capacity, and rollback reactivation while keeping `rolloutMode: enrollment`.
+2. The schema issue was covered by [gestalt#3015](https://github.com/valon-technologies/gestalt/pull/3015), then [toolshed#3924](https://github.com/valon-technologies/toolshed/pull/3924) rolled forward the compatible binary without changing app snapshots or rollout mode.
+3. After current-source heartbeats and expected capacity were verified across multiple lease windows, [toolshed#3925](https://github.com/valon-technologies/toolshed/pull/3925) changed only `rolloutMode` to `heartbeat` and added a config assertion. Reverting that setting to `enrollment` is the completion rollback.
+
+For future deploys, verify source/minimum activation, fresh replica count and exact versions, stale expiry after replacement, independent rollout/recovery presentation, and restored-source reactivation on rollback.
 
 ---
 
@@ -646,5 +700,4 @@ Publish tests do not exercise real GCS uploads; upload-path tests use test stora
 - Retention prune GCS integration and install-lock concurrency tests
 - App-admin selection tests for expired, locked, downgrade, and concurrent admission paths
 - Multi-replica materialization acknowledgement E2E (see [planned section above](#planned-multi-replica-materialization-acknowledgement-e2e))
-- Per-replica **observed** running version heartbeats
 - Deployed verification that catalog restarts serve the newly mounted binary


### PR DESCRIPTION
## Summary
- fold shipped per-replica heartbeat, fleet-state, recovery, and replacement-aware rollout behavior into the app-registry operational references
- document activation capacity, rollback reactivation, enrollment fallback, RelationalDB legacy-schema compatibility, and production verification
- mark milestone 27 shipped with the merged Gestalt, provider, Toolshed, and schema-hotfix PRs while leaving the canonical one-pager unchanged

## Test plan
- [x] `go test ./...` from `gestaltd`
- [x] `npm ci && npm run build` from `docs`
- [x] internal Markdown link checks for all six changed files
- [x] authenticated verification of every linked private GitHub PR
- [x] `git diff --check`

Made with [Cursor](https://cursor.com)