### PR TITLE
Fix auto-deploy reconciliation after re-enable

### DIFF
--- a/gestaltd/internal/appregistry/autodeploy/controller.go
+++ b/gestaltd/internal/appregistry/autodeploy/controller.go
@@ -201,11 +201,15 @@ func (c *Controller) Reconcile(ctx context.Context, appName string) error {
 		}
 	}
 
+	ifNoneMatch := c.etags[appName]
+	if settings.LastSeenVersion == "" {
+		ifNoneMatch = ""
+	}
 	result, err := c.Reader.FetchAppIndexConditional(
 		ctx,
 		app.PublicRoot,
 		appName,
-		c.etags[appName],
+		ifNoneMatch,
 	)
 	if err != nil {
 		return err

--- a/gestaltd/internal/appregistry/autodeploy/controller_test.go
+++ b/gestaltd/internal/appregistry/autodeploy/controller_test.go
@@ -51,6 +51,56 @@ func TestControllerDetectsAndAdmitsNewestVersion(t *testing.T) {
 	}
 }
 
+func TestControllerReenableBypassesCachedETagWhenLastSeenVersionIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	services := testutil.NewStubServices(t)
+	enableAutoDeploy(t, services, "g-issues")
+	reader := &fakeReader{results: []*appregistry.AppIndexFetchResult{
+		{Index: testIndex("g-issues", "v2"), ETag: `"unchanged"`},
+		{Index: testIndex("g-issues", "v2"), ETag: `"unchanged"`},
+	}}
+	installer := &fakeInstaller{}
+	controller := testController(services, reader, installer)
+
+	if err := controller.Reconcile(t.Context(), "g-issues"); err != nil {
+		t.Fatalf("prime Reconcile: %v", err)
+	}
+
+	if _, err := services.AutoDeploySettings.Update(t.Context(), "g-issues", func(settings *core.AppAutoDeploySettings) error {
+		settings.Enabled = false
+		settings.PendingVersion = ""
+		return nil
+	}); err != nil {
+		t.Fatalf("disable auto-deploy: %v", err)
+	}
+	if _, err := services.AppVersionChangeRequests.AppendRequest(t.Context(), &core.AppVersionChangeRequest{
+		App:         "g-issues",
+		FromVersion: "v2",
+		ToVersion:   "v1",
+		Timestamp:   time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("record manual rollback: %v", err)
+	}
+	if _, err := services.AutoDeploySettings.Update(t.Context(), "g-issues", func(settings *core.AppAutoDeploySettings) error {
+		settings.Enabled = true
+		settings.LastSeenVersion = ""
+		return nil
+	}); err != nil {
+		t.Fatalf("re-enable auto-deploy: %v", err)
+	}
+
+	if err := controller.Reconcile(t.Context(), "g-issues"); err != nil {
+		t.Fatalf("Reconcile after re-enable: %v", err)
+	}
+	if len(reader.ifNoneMatch) != 2 || reader.ifNoneMatch[1] != "" {
+		t.Fatalf("If-None-Match values = %#v, want unconditional fetch after re-enable", reader.ifNoneMatch)
+	}
+	if len(installer.inputs) != 2 || installer.inputs[1].Version != "v2" {
+		t.Fatalf("install inputs = %#v, want latest admitted after re-enable", installer.inputs)
+	}
+}
+
 func TestControllerCoalescesDuringActiveRollout(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- force an unconditional registry index fetch when durable `LastSeenVersion` state is empty
- preserve normal ETag-based conditional requests after the latest version is persisted
- cover disable, manual rollback, and re-enable with an unchanged registry ETag

## Test plan
- [x] `cd gestaltd && go test ./internal/appregistry/autodeploy -count=1`
- [x] `cd gestaltd && go test ./...`
- [x] `cd gestaltd && go vet ./...`
- [x] `git diff --check`

Made with [Cursor](https://cursor.com)