### PR TITLE
fix: advertise static catalog in provider metadata for tunnel-proxied operations

### DIFF
--- a/gestaltd/services/apps/provider_client.go
+++ b/gestaltd/services/apps/provider_client.go
@@ -65,6 +65,7 @@ var (
 
 type integrationProviderSupport struct {
 	sessionCatalog      bool
+	staticCatalog       *catalog.Catalog
 	workflowDefinitions []*proto.WorkflowDefinitionSpec
 }
 
@@ -127,6 +128,9 @@ func NewRemote(ctx context.Context, client proto.AppProviderClient, spec StaticP
 		discovery:           spec.DiscoveryConfig,
 		workflowDefinitions: append([]*proto.WorkflowDefinitionSpec(nil), support.workflowDefinitions...),
 	}
+	if base.catalog == nil && support.staticCatalog != nil {
+		base.catalog = support.staticCatalog
+	}
 	for _, opt := range opts {
 		opt(base)
 	}
@@ -141,12 +145,17 @@ func getAppProviderSupportWithRetry(ctx context.Context, client proto.AppProvide
 	for {
 		meta, err := client.GetMetadata(ctx, &emptypb.Empty{})
 		if err == nil {
+			// Providers may legitimately advertise catalogs that fail
+			// Validate (e.g. icon-only with zero operations); treat those
+			// as absent rather than failing provider construction.
+			staticCat, _ := catalogFromProto(meta.GetStaticCatalog())
 			specs, decodeErr := decodeWorkflowDefinitionSpecs(meta.GetWorkflowDefinitionSpecs())
 			if decodeErr != nil {
 				return nil, decodeErr
 			}
 			return &integrationProviderSupport{
 				sessionCatalog:      meta.GetSupportsSessionCatalog(),
+				staticCatalog:       staticCat,
 				workflowDefinitions: specs,
 			}, nil
 		}

--- a/gestaltd/services/apps/provider_server.go
+++ b/gestaltd/services/apps/provider_server.go
@@ -32,6 +32,7 @@ func NewServer(provider core.Provider) proto.AppProviderServer {
 
 func (s *ProviderServer) GetMetadata(_ context.Context, _ *emptypb.Empty) (*proto.ProviderMetadata, error) {
 	return &proto.ProviderMetadata{
+		StaticCatalog:          catalogToProto(s.provider.Catalog()),
 		SupportsSessionCatalog: core.SupportsSessionCatalog(s.provider),
 	}, nil
 }

--- a/gestaltd/services/apps/provider_test.go
+++ b/gestaltd/services/apps/provider_test.go
@@ -84,6 +84,14 @@ func (p *roundTripProvider) Catalog() *catalog.Catalog {
 	}
 }
 
+type iconOnlyCatalogProvider struct {
+	roundTripProvider
+}
+
+func (p *iconOnlyCatalogProvider) Catalog() *catalog.Catalog {
+	return &catalog.Catalog{IconSVG: "<svg/>"}
+}
+
 func (p *roundTripProvider) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
 	subjectID := ""
 	subjectKind := ""
@@ -303,6 +311,53 @@ func TestRemoteProviderRoundTrip(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("static catalog source", func(t *testing.T) {
+		t.Parallel()
+
+		for _, tc := range []struct {
+			name   string
+			specOp string
+			wantOp string
+		}{
+			{name: "adopted from metadata", wantOp: "echo"},
+			{name: "spec takes precedence", specOp: "spec-only", wantOp: "spec-only"},
+		} {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				spec := roundTripStaticSpec()
+				if tc.specOp == "" {
+					spec.Catalog = nil
+				} else {
+					spec.Catalog.Operations[0].ID = tc.specOp
+				}
+				cataloged, err := NewRemote(context.Background(), client, spec, nil)
+				if err != nil {
+					t.Fatalf("NewRemote: %v", err)
+				}
+				cat := cataloged.Catalog()
+				if cat == nil || len(cat.Operations) != 1 || cat.Operations[0].ID != tc.wantOp {
+					t.Fatalf("unexpected catalog: %+v", cat)
+				}
+			})
+		}
+	})
+
+	t.Run("invalid metadata catalog ignored", func(t *testing.T) {
+		t.Parallel()
+
+		spec := roundTripStaticSpec()
+		spec.Catalog = nil
+		prov, err := NewRemote(context.Background(), newAppProviderClient(t, NewProviderServer(&iconOnlyCatalogProvider{})), spec, nil)
+		if err != nil {
+			t.Fatalf("NewRemote: %v", err)
+		}
+		if cat := prov.Catalog(); cat != nil {
+			t.Fatalf("expected invalid metadata catalog to be ignored, got %+v", cat)
+		}
+	})
 
 	t.Run("malformed principal", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
The remote builds a TunnelProxyProvider per request with only the provider name, so the local static catalog never reaches it. ResolveOperation then fell through to the session-catalog path, which defaults to the MCP surface and misses REST-only operations, returning 404 for tunnel-proxied app operations.

Have GetMetadata ship the provider's static catalog and let NewRemote adopt it when the caller supplied no catalog of its own; an explicit spec catalog still takes precedence. No proto changes.