### PR TITLE
fix: proxy registry apps to remote in dev mode with catalog passthrough

### DIFF
--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -144,7 +144,14 @@ func registerRemoteApps(providers *registry.ProviderMap[core.Provider], cfg *con
 	}
 	for name, entry := range cfg.Apps {
 		name = strings.TrimSpace(name)
-		if name == "" || entry == nil || entry.Source.IsRegistry() || config.EntryBuildsLocal(entry) {
+		if name == "" || entry == nil || config.EntryBuildsLocal(entry) {
+			continue
+		}
+		// In dev mode, registry-sourced apps that are not dev-active are
+		// proxied to the remote rather than downloaded and started locally.
+		// Outside dev mode, registry apps are managed by the app runtime
+		// lifecycle and do not need remote placement.
+		if entry.Source.IsRegistry() && !cfg.Server.Dev {
 			continue
 		}
 		clients, err := remoteClientsForEntry(cfg, entry, deps)
@@ -154,9 +161,17 @@ func registerRemoteApps(providers *registry.ProviderMap[core.Provider], cfg *con
 		if clients.App == nil {
 			return fmt.Errorf("remote app %q: provider client is required", name)
 		}
-		spec, _, err := buildStartupProviderSpec(name, entry)
-		if err != nil {
-			return fmt.Errorf("remote app %q: %w", name, err)
+		var spec appservice.StaticProviderSpec
+		if entry.Source.IsRegistry() {
+			// Registry apps in dev mode do not have a locally resolved
+			// manifest; the remote holds the full catalog and metadata.
+			spec = appservice.StaticProviderSpec{Name: name}
+		} else {
+			var err error
+			spec, _, err = buildStartupProviderSpec(name, entry)
+			if err != nil {
+				return fmt.Errorf("remote app %q: %w", name, err)
+			}
 		}
 		client := clients.App
 		if rawConn := clients.Conn(); rawConn != nil {

--- a/gestaltd/services/invocation/broker_test.go
+++ b/gestaltd/services/invocation/broker_test.go
@@ -372,6 +372,45 @@ func TestBrokerInvokeSkipsLocalAuthorizationForRemoteDelegatedApps(t *testing.T)
 	}
 }
 
+func TestBrokerInvokePassthroughForRemoteDelegatedProviderWithoutCatalog(t *testing.T) {
+	t.Parallel()
+
+	executed := false
+	provider := &remoteDelegatedAppStub{
+		StubIntegration: &coretesting.StubIntegration{
+			N:        "data-schema-explorer",
+			ConnMode: core.ConnectionModeNone,
+			ExecuteFn: func(_ context.Context, op string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				executed = true
+				if op != "get_schema" {
+					return nil, fmt.Errorf("unexpected operation %q", op)
+				}
+				return &core.OperationResult{Status: 200, Body: []byte(`{"tables":[]}`)}, nil
+			},
+		},
+	}
+	broker := NewBroker(
+		testutil.NewProviderRegistry(t, provider),
+		nil,
+		nil,
+	)
+
+	_, err := broker.Invoke(
+		context.Background(),
+		&principal.Principal{SubjectID: "user:u-123", Kind: principal.KindUser},
+		"data-schema-explorer",
+		"",
+		"get_schema",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if !executed {
+		t.Fatal("Execute was not called")
+	}
+}
+
 type remoteDelegatedAppStub struct {
 	*coretesting.StubIntegration
 }

--- a/gestaltd/services/invocation/catalog.go
+++ b/gestaltd/services/invocation/catalog.go
@@ -136,6 +136,10 @@ func ResolveOperation(ctx context.Context, prov core.Provider, provName string, 
 			catalogSource = "static"
 			return staticOp, OperationTransport(staticOp), "", nil
 		}
+		if delegated, ok := prov.(RemoteCredentialDelegated); ok && delegated.RemoteCredentialDelegated() {
+			catalogSource = "passthrough"
+			return catalog.CatalogOperation{ID: operation}, catalog.TransportApp, "", nil
+		}
 		return catalog.CatalogOperation{}, "", "", fmt.Errorf("%w: %q on provider %q", ErrOperationNotFound, operation, provName)
 	}
 


### PR DESCRIPTION
## Problem

When running `gestaltd dev` with `--remote`, cross-app invokes from the local provider fail with `provider not found` for registry-sourced apps that aren't dev-active. For example, vds-forge's submit page calls `data-schema-explorer.get_schema`, which errors because the local gestaltd only registers the apps passed as PATH args.

## Root Cause

`registerRemoteApps()` in `provider_build.go` skips registry apps unconditionally. In dev mode, these apps are supposed to run on the remote, but there's no proxy registered for them locally.

## Fix

Two changes, both local-side only:

1. **`registerRemoteApps()`**: Allow registry apps to receive remote placement when `cfg.Server.Dev` is true. Uses a minimal spec (name only) since the remote holds the full catalog.

2. **`ResolveOperation()`**: When a remote-delegated provider has no static catalog match and doesn't support session catalogs, return a passthrough `CatalogOperation` instead of `ErrOperationNotFound`. This lets the broker proceed with permission checks and invoke through the remote `AppClient.Invoke` path.

No remote-side changes needed.