### PR TITLE
Fix dev remote registry app invocation

### DIFF
--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -147,10 +147,6 @@ func registerRemoteApps(providers *registry.ProviderMap[core.Provider], cfg *con
 		if name == "" || entry == nil || config.EntryBuildsLocal(entry) {
 			continue
 		}
-		// In dev mode, registry-sourced apps that are not dev-active are
-		// proxied to the remote rather than downloaded and started locally.
-		// Outside dev mode, registry apps are managed by the app runtime
-		// lifecycle and do not need remote placement.
 		if entry.Source.IsRegistry() && !cfg.Server.Dev {
 			continue
 		}
@@ -163,9 +159,11 @@ func registerRemoteApps(providers *registry.ProviderMap[core.Provider], cfg *con
 		}
 		var spec appservice.StaticProviderSpec
 		if entry.Source.IsRegistry() {
-			// Registry apps in dev mode do not have a locally resolved
-			// manifest; the remote holds the full catalog and metadata.
-			spec = appservice.StaticProviderSpec{Name: name}
+			catalog, err := buildRemoteRegistryCatalog(name, entry.AllowedOperations)
+			if err != nil {
+				return err
+			}
+			spec = appservice.StaticProviderSpec{Name: name, Catalog: catalog}
 		} else {
 			var err error
 			spec, _, err = buildStartupProviderSpec(name, entry)
@@ -192,6 +190,38 @@ func registerRemoteApps(providers *registry.ProviderMap[core.Provider], cfg *con
 		slog.Debug("registered remote app provider", "provider", name, "remote", config.EntryPlacementRemote(entry))
 	}
 	return nil
+}
+
+func buildRemoteRegistryCatalog(appName string, allowedOperations map[string]*config.OperationOverride) (*catalog.Catalog, error) {
+	appName = strings.TrimSpace(appName)
+	keys := slices.Sorted(maps.Keys(allowedOperations))
+	normalizedKeys := make(map[string]string, len(keys))
+	for _, rawKey := range keys {
+		operationID := strings.TrimSpace(rawKey)
+		if operationID == "" {
+			return nil, fmt.Errorf("remote app %q allowedOperations key %q is blank", appName, rawKey)
+		}
+		operation := &catalog.Catalog{
+			Name: appName,
+			Operations: []catalog.CatalogOperation{{
+				ID:        operationID,
+				Transport: catalog.TransportApp,
+			}},
+		}
+		if err := operation.Validate(); err != nil {
+			return nil, fmt.Errorf("remote app %q allowedOperations key %q: %w", appName, rawKey, err)
+		}
+		if previous, exists := normalizedKeys[operationID]; exists {
+			return nil, fmt.Errorf("remote app %q allowedOperations key %q normalizes to duplicate operation %q from key %q", appName, rawKey, operationID, previous)
+		}
+		normalizedKeys[operationID] = rawKey
+	}
+	operationIDs := slices.Sorted(maps.Keys(normalizedKeys))
+	operations := make([]catalog.CatalogOperation, 0, len(operationIDs))
+	for _, operationID := range operationIDs {
+		operations = append(operations, catalog.CatalogOperation{ID: operationID, Transport: catalog.TransportApp})
+	}
+	return &catalog.Catalog{Name: appName, Operations: operations}, nil
 }
 
 func (b *preparedProviderBuilds) partition(categorize func(string, *config.ProviderEntry) AppStartupCategory) (noop, update *preparedProviderBuilds) {

--- a/gestaltd/internal/bootstrap/provider_build_test.go
+++ b/gestaltd/internal/bootstrap/provider_build_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -958,6 +959,171 @@ func TestMultiRemoteAppRouting(t *testing.T) {
 	}
 	if len(devCalls) != 1 || devCalls[0].app != "valon-profile" {
 		t.Fatalf("dev calls = %#v, want valon-profile only", devCalls)
+	}
+}
+
+func TestBuildRemoteRegistryCatalog(t *testing.T) {
+	t.Parallel()
+
+	cat, err := buildRemoteRegistryCatalog("data-schema-explorer", map[string]*config.OperationOverride{
+		" get_schema ":        nil,
+		"vds.schema_versions": nil,
+	})
+	if err != nil {
+		t.Fatalf("buildRemoteRegistryCatalog: %v", err)
+	}
+	if cat == nil || len(cat.Operations) != 2 {
+		t.Fatalf("catalog = %#v, want two operations", cat)
+	}
+	if got := []string{cat.Operations[0].ID, cat.Operations[1].ID}; !slices.Equal(got, []string{"get_schema", "vds.schema_versions"}) {
+		t.Fatalf("operation IDs = %v, want sorted trimmed IDs", got)
+	}
+	for _, operation := range cat.Operations {
+		if operation.Transport != catalog.TransportApp {
+			t.Fatalf("operation %q transport = %q, want %q", operation.ID, operation.Transport, catalog.TransportApp)
+		}
+	}
+
+	empty, err := buildRemoteRegistryCatalog("empty", nil)
+	if err != nil {
+		t.Fatalf("buildRemoteRegistryCatalog(empty): %v", err)
+	}
+	if empty == nil || len(empty.Operations) != 0 {
+		t.Fatalf("empty catalog = %#v, want non-nil empty catalog", empty)
+	}
+
+	for _, rawKey := range []string{"", "   ", "invalid operation"} {
+		rawKey := rawKey
+		t.Run(fmt.Sprintf("invalid %q", rawKey), func(t *testing.T) {
+			t.Parallel()
+			_, err := buildRemoteRegistryCatalog("data-schema-explorer", map[string]*config.OperationOverride{rawKey: nil})
+			if err == nil || !strings.Contains(err.Error(), "data-schema-explorer") || !strings.Contains(err.Error(), rawKey) {
+				t.Fatalf("error = %v, want app and offending key", err)
+			}
+		})
+	}
+}
+
+func TestRemoteRegistryAppRoutingUsesAllowlistAndConfiguredRemote(t *testing.T) {
+	t.Parallel()
+
+	prodClient := &recordingRemoteAppClient{}
+	devClient := &recordingRemoteAppClient{}
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Dev: true,
+			Remotes: map[string]*config.RemoteConfig{
+				"prod": {URL: "https://prod.test", Token: "prod-token", Default: true},
+				"dev":  {URL: "https://dev.test", Token: "dev-token"},
+			},
+		},
+		Apps: map[string]*config.ProviderEntry{
+			"data-schema-explorer": {
+				Source: config.ProviderSource{Registry: "toolshed"},
+				Remote: "prod",
+				AllowedOperations: map[string]*config.OperationOverride{
+					" get_schema ": nil,
+				},
+			},
+			"other-registry-app": {
+				Source: config.ProviderSource{Registry: "toolshed"},
+				Remote: "dev",
+				AllowedOperations: map[string]*config.OperationOverride{
+					"ping": nil,
+				},
+			},
+		},
+	}
+	reg := registry.New()
+	clientSets := remote.ClientSets{
+		"prod": {App: prodClient},
+		"dev":  {App: devClient},
+	}
+	if err := registerRemoteApps(&reg.Providers, cfg, Deps{RemoteClientSets: clientSets}); err != nil {
+		t.Fatalf("registerRemoteApps: %v", err)
+	}
+
+	for name, wantIDs := range map[string][]string{
+		"data-schema-explorer": {"get_schema"},
+		"other-registry-app":   {"ping"},
+	} {
+		provider, err := reg.Providers.Get(name)
+		if err != nil {
+			t.Fatalf("provider %q: %v", name, err)
+		}
+		cat := provider.Catalog()
+		if cat == nil || len(cat.Operations) != len(wantIDs) {
+			t.Fatalf("provider %q catalog = %#v, want %v", name, cat, wantIDs)
+		}
+		for i, wantID := range wantIDs {
+			if cat.Operations[i].ID != wantID || cat.Operations[i].Transport != catalog.TransportApp {
+				t.Fatalf("provider %q operation[%d] = %#v, want %q app transport", name, i, cat.Operations[i], wantID)
+			}
+		}
+	}
+
+	services := testutil.NewStubServices(t)
+	broker := invocation.NewBroker(&reg.Providers, services.Users, services.ExternalCredentials)
+	if _, err := broker.Invoke(context.Background(), remoteRoutingPrincipal(), "data-schema-explorer", "", "get_schema", nil); err != nil {
+		t.Fatalf("allowlisted Invoke: %v", err)
+	}
+	if _, err := broker.Invoke(context.Background(), remoteRoutingPrincipal(), "other-registry-app", "", "ping", nil); err != nil {
+		t.Fatalf("second configured remote Invoke: %v", err)
+	}
+	if _, err := broker.Invoke(context.Background(), remoteRoutingPrincipal(), "data-schema-explorer", "", "not-allowlisted", nil); !errors.Is(err, invocation.ErrOperationNotFound) {
+		t.Fatalf("non-allowlisted error = %v, want ErrOperationNotFound", err)
+	}
+	if got := len(prodClient.snapshot()); got != 1 {
+		t.Fatalf("prod remote calls = %d, want one allowlisted call", got)
+	}
+	if got := len(devClient.snapshot()); got != 1 {
+		t.Fatalf("dev remote calls = %d, want one configured call", got)
+	}
+}
+
+func TestRemoteRegistryAppRoutingPreservesNonDevelopmentAndLocalPlacement(t *testing.T) {
+	t.Parallel()
+
+	remoteClient := &recordingRemoteAppClient{}
+	for _, tc := range []struct {
+		name       string
+		dev        bool
+		devActive  bool
+		wantRemote bool
+	}{
+		{name: "non-development", dev: false, wantRemote: false},
+		{name: "active local", dev: true, devActive: true, wantRemote: false},
+		{name: "development remote", dev: true, wantRemote: true},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := &config.Config{
+				Server: config.ServerConfig{Dev: tc.dev},
+				Apps: map[string]*config.ProviderEntry{
+					"registry-app": {
+						Source:    config.ProviderSource{Registry: "toolshed"},
+						Remote:    config.DefaultRemoteName,
+						DevActive: tc.devActive,
+						AllowedOperations: map[string]*config.OperationOverride{
+							"ping": nil,
+						},
+					},
+				},
+			}
+			reg := registry.New()
+			clients := remote.ClientSets{config.DefaultRemoteName: {App: remoteClient}}
+			if err := registerRemoteApps(&reg.Providers, cfg, Deps{RemoteClientSets: clients}); err != nil {
+				t.Fatalf("registerRemoteApps: %v", err)
+			}
+			_, err := reg.Providers.Get("registry-app")
+			if tc.wantRemote && err != nil {
+				t.Fatalf("remote registry provider lookup: %v", err)
+			}
+			if !tc.wantRemote && !errors.Is(err, core.ErrNotFound) {
+				t.Fatalf("provider lookup error = %v, want not found", err)
+			}
+		})
 	}
 }
 

--- a/gestaltd/internal/server/remote_app_invocation_test.go
+++ b/gestaltd/internal/server/remote_app_invocation_test.go
@@ -1,0 +1,255 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/publicrpc"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	appaccessservice "github.com/valon-technologies/gestalt/server/services/appaccess"
+	appservice "github.com/valon-technologies/gestalt/server/services/apps"
+	"github.com/valon-technologies/gestalt/server/services/apps/registry"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
+	"github.com/valon-technologies/gestalt/server/services/providergateway"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+type publicRemoteInvocationProvider struct {
+	mu           sync.Mutex
+	invokeCalls  int
+	graphQLCalls int
+	lastSubject  string
+	lastCaller   invocation.CallerProvider
+}
+
+func (p *publicRemoteInvocationProvider) Name() string        { return "data-schema-explorer" }
+func (p *publicRemoteInvocationProvider) DisplayName() string { return p.Name() }
+func (p *publicRemoteInvocationProvider) Description() string { return "test schema app" }
+func (p *publicRemoteInvocationProvider) ConnectionMode() core.ConnectionMode {
+	return core.ConnectionModeNone
+}
+func (p *publicRemoteInvocationProvider) AuthTypes() []string { return nil }
+func (p *publicRemoteInvocationProvider) ConnectionParamDefs() map[string]core.ConnectionParamDef {
+	return nil
+}
+func (p *publicRemoteInvocationProvider) CredentialFields() []core.CredentialFieldDef { return nil }
+func (p *publicRemoteInvocationProvider) DiscoveryConfig() *core.DiscoveryConfig      { return nil }
+func (p *publicRemoteInvocationProvider) ConnectionForOperation(string) string        { return "" }
+func (p *publicRemoteInvocationProvider) Catalog() *catalog.Catalog {
+	return &catalog.Catalog{
+		Name:       "data-schema-explorer",
+		Operations: []catalog.CatalogOperation{{ID: "get_schema", Transport: catalog.TransportApp}},
+	}
+}
+
+func (p *publicRemoteInvocationProvider) Execute(ctx context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
+	p.record(ctx, false)
+	return &core.OperationResult{Status: 200, Body: []byte(`{"schema":"current"}`)}, nil
+}
+
+func (p *publicRemoteInvocationProvider) InvokeGraphQL(ctx context.Context, _ core.GraphQLRequest, _ string) (*core.OperationResult, error) {
+	p.record(ctx, true)
+	return &core.OperationResult{Status: 200, Body: []byte(`{"schema":"graphql"}`)}, nil
+}
+
+func (p *publicRemoteInvocationProvider) record(ctx context.Context, graphQL bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if graphQL {
+		p.graphQLCalls++
+	} else {
+		p.invokeCalls++
+	}
+	if caller := invocation.CallerProviderFromContext(ctx); caller.Name != "" {
+		p.lastCaller = caller
+	}
+	if current := principal.FromContext(ctx); current != nil {
+		p.lastSubject = current.SubjectID
+	}
+}
+
+func (p *publicRemoteInvocationProvider) snapshot() (int, int, string, invocation.CallerProvider) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.invokeCalls, p.graphQLCalls, p.lastSubject, p.lastCaller
+}
+
+func TestDevRemoteAppInvocationUsesPublicGatewayContextAndAllowlist(t *testing.T) {
+	t.Parallel()
+
+	remoteProvider := &publicRemoteInvocationProvider{}
+	remoteRegistry := registry.New()
+	if err := remoteRegistry.Providers.Register(remoteProvider.Name(), remoteProvider); err != nil {
+		t.Fatalf("register remote provider: %v", err)
+	}
+	remoteServices := testutil.NewStubServices(t)
+	remoteBroker := invocation.NewBroker(&remoteRegistry.Providers, remoteServices.Users, remoteServices.ExternalCredentials)
+
+	identity := &coretesting.StubIdentityProvider{
+		IntrospectFn: func(context.Context, *core.IntrospectRequest) (*core.IntrospectResponse, error) {
+			return &core.IntrospectResponse{Active: true, Subject: "user:alice"}, nil
+		},
+	}
+	publicMethods, err := publicrpc.NewGeneratedRegistry()
+	if err != nil {
+		t.Fatalf("NewGeneratedRegistry: %v", err)
+	}
+	remoteTransport := providergateway.NewProviderGatewayTransport()
+	remoteTransport.SetIdentityProvider(identity)
+	remoteTransport.SetPublicMethods(publicMethods)
+	remoteTransport.SetPublicBaseURL("https://remote.test")
+	var ordinaryRequestWithoutContext atomic.Int32
+	var graphQLRequestWithoutContext atomic.Int32
+	publicServer := grpc.NewServer(grpc.ChainUnaryInterceptor(
+		func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+			switch request := req.(type) {
+			case *proto.AppInvokeRequest:
+				if request.GetContext() == nil {
+					ordinaryRequestWithoutContext.Add(1)
+				}
+			case *proto.AppInvokeGraphQLRequest:
+				if request.GetContext() == nil {
+					graphQLRequestWithoutContext.Add(1)
+				}
+			}
+			return handler(ctx, req)
+		},
+		publicPrepareUnaryInterceptor(remoteTransport),
+	))
+	publicrpc.RegisterPublicServers(publicServer, publicrpc.Servers{App: appaccessservice.NewServer(remoteBroker)})
+	remoteConn := newBufconnClientConn(t, publicServer, func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		return invoker(metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer test-token"), method, req, reply, cc, opts...)
+	})
+	remoteClient := proto.NewAppClient(remoteConn)
+
+	localRegistry := registry.New()
+	remoteProviderProxy := appservice.NewGestaltRemote(remoteClient, appservice.StaticProviderSpec{
+		Name: "data-schema-explorer",
+		Catalog: &catalog.Catalog{
+			Name: "data-schema-explorer",
+			Operations: []catalog.CatalogOperation{
+				{ID: "get_schema", Transport: catalog.TransportApp},
+				{ID: "graphql", Transport: catalog.TransportApp},
+			},
+		},
+		ConnectionMode: core.ConnectionModeNone,
+	})
+	if remoteProviderProxy == nil {
+		t.Fatal("NewGestaltRemote returned nil")
+	}
+	if err := localRegistry.Providers.Register("data-schema-explorer", remoteProviderProxy); err != nil {
+		t.Fatalf("register remote proxy: %v", err)
+	}
+	localServices := testutil.NewStubServices(t)
+	localBroker := invocation.NewBroker(&localRegistry.Providers, localServices.Users, localServices.ExternalCredentials)
+	localServer := grpc.NewServer()
+	proto.RegisterAppServer(localServer, appaccessservice.NewServer(localBroker))
+	localConn := newBufconnClientConn(t, localServer, nil)
+	localClient := proto.NewAppClient(localConn)
+
+	callerContext := principal.WithPrincipal(context.Background(), &principal.Principal{SubjectID: "user:alice", Kind: principal.KindUser})
+	callerContext = invocation.WithCallerProvider(callerContext, invocation.ProviderKindApp, "vds-forge")
+	requestContext, err := appaccessservice.RequestContextProto(callerContext, "", invocation.CallerProvider{Kind: invocation.ProviderKindApp, Name: "vds-forge"})
+	if err != nil {
+		t.Fatalf("RequestContextProto: %v", err)
+	}
+
+	response, err := localClient.Invoke(context.Background(), &proto.AppInvokeRequest{
+		App:       "data-schema-explorer",
+		Operation: "get_schema",
+		Context:   requestContext,
+	})
+	if err != nil {
+		t.Fatalf("local Invoke: %v", err)
+	}
+	if response.GetStatus() != 200 || string(response.GetBody()) != `{"schema":"current"}` {
+		t.Fatalf("local response = %+v, want current schema", response)
+	}
+
+	graphqlResponse, err := localClient.InvokeGraphQL(context.Background(), &proto.AppInvokeGraphQLRequest{
+		App:      "data-schema-explorer",
+		Document: "query Schema { schema }",
+		Context:  requestContext,
+	})
+	if err != nil {
+		t.Fatalf("local InvokeGraphQL: %v", err)
+	}
+	if graphqlResponse.GetStatus() != 200 || string(graphqlResponse.GetBody()) != `{"schema":"graphql"}` {
+		t.Fatalf("local GraphQL response = %+v, want graphql schema", graphqlResponse)
+	}
+
+	_, err = localClient.Invoke(context.Background(), &proto.AppInvokeRequest{
+		App:       "data-schema-explorer",
+		Operation: "not-allowlisted",
+		Context:   requestContext,
+	})
+	if status.Code(err) != codes.NotFound {
+		t.Fatalf("non-allowlisted error = %v, want NotFound", err)
+	}
+	emptyRemote := appservice.NewGestaltRemote(remoteClient, appservice.StaticProviderSpec{
+		Name:    "empty-remote-app",
+		Catalog: &catalog.Catalog{Name: "empty-remote-app"},
+	})
+	if emptyRemote == nil {
+		t.Fatal("NewGestaltRemote returned nil for empty catalog")
+	}
+	if _, err := emptyRemote.(core.GraphQLSurfaceInvoker).InvokeGraphQL(context.Background(), core.GraphQLRequest{Document: "query Schema { schema }"}, ""); !errors.Is(err, invocation.ErrOperationNotFound) {
+		t.Fatalf("empty-catalog GraphQL error = %v, want ErrOperationNotFound", err)
+	}
+	if ordinaryRequestWithoutContext.Load() != 1 || graphQLRequestWithoutContext.Load() != 1 {
+		t.Fatalf("outbound request context counts = ordinary %d graphql %d, want 1 each", ordinaryRequestWithoutContext.Load(), graphQLRequestWithoutContext.Load())
+	}
+	invokeCalls, graphQLCalls, subject, caller := remoteProvider.snapshot()
+	if invokeCalls != 1 || graphQLCalls != 1 {
+		t.Fatalf("remote provider calls = invoke %d graphql %d, want 1 each", invokeCalls, graphQLCalls)
+	}
+	if subject != "user:alice" || caller.Kind != invocation.ProviderKindApp || caller.Name != "gestaltd" {
+		t.Fatalf("remote identity = subject %q caller %#v, want user:alice app/gestaltd", subject, caller)
+	}
+
+	_, err = remoteClient.Invoke(context.Background(), &proto.AppInvokeRequest{
+		App:       "data-schema-explorer",
+		Operation: "get_schema",
+		Context:   &proto.RequestContext{Subject: &proto.SubjectContext{Id: "user:forged"}},
+	})
+	if status.Code(err) != codes.InvalidArgument || status.Convert(err).Message() != "context is server-filled" {
+		t.Fatalf("explicit context error = %v, want InvalidArgument context is server-filled", err)
+	}
+}
+
+func newBufconnClientConn(t *testing.T, server *grpc.Server, intercept grpc.UnaryClientInterceptor) *grpc.ClientConn {
+	t.Helper()
+	listener := bufconn.Listen(1024 * 1024)
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() {
+		server.Stop()
+		_ = listener.Close()
+	})
+	dialOptions := []grpc.DialOption{
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return listener.Dial() }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	}
+	if intercept != nil {
+		dialOptions = append(dialOptions, grpc.WithUnaryInterceptor(intercept))
+	}
+	conn, err := grpc.NewClient("passthrough:///bufnet", dialOptions...)
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -285,7 +285,7 @@ func registryAppStartup(cfg *config.Config, result *bootstrap.Result, reader *ap
 		slices.Sort(names)
 		for _, appName := range names {
 			entry := cfg.Apps[appName]
-			if entry == nil || !entry.Source.IsRegistry() {
+			if entry == nil || !entry.Source.IsRegistry() || !config.EntryBuildsLocal(entry) {
 				continue
 			}
 			known, err := result.Services.AppVersionChangeRequests.ListKnownVersionsByApp(ctx, appName)

--- a/gestaltd/internal/server/runtime_app_registry_test.go
+++ b/gestaltd/internal/server/runtime_app_registry_test.go
@@ -189,6 +189,51 @@ func TestRegistryAppStartupStopsEmptyProjection(t *testing.T) {
 	}
 }
 
+func TestRegistryAppStartupSkipsRemotePlacement(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fixture := registrytest.NewInstallFixture(t)
+	services := testutil.NewStubServices(t)
+	installedAt := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	if _, err := services.AppVersionChangeRequests.AppendRequest(ctx, &core.AppVersionChangeRequest{
+		App:         "g-issues",
+		FromVersion: "registry:first-install",
+		ToVersion:   fixture.Version,
+		Timestamp:   installedAt,
+		Metadata: coredata.ChangeRequestMetadata(&core.AppInstallation{
+			AppName:     "g-issues",
+			Version:     fixture.Version,
+			Registry:    "toolshed",
+			InstalledAt: installedAt,
+			UpdatedAt:   installedAt,
+		}),
+	}); err != nil {
+		t.Fatalf("AppendRequest: %v", err)
+	}
+	artifactsDir := t.TempDir()
+	restarter := &startupRecordingRestarter{}
+	cfg := &config.Config{
+		AppRegistries: map[string]config.AppRegistryConfig{"toolshed": fixture.Registry},
+		Apps: map[string]*config.ProviderEntry{
+			"g-issues": {
+				Source: config.ProviderSource{Registry: "toolshed"},
+				Remote: config.DefaultRemoteName,
+			},
+		},
+		Server: config.ServerConfig{ArtifactsDir: artifactsDir},
+	}
+	result := &bootstrap.Result{Services: services, AppRestarter: restarter}
+
+	registryAppStartup(cfg, result, fixture.Reader)(ctx)
+
+	if restarter.startedApp != "" || restarter.stoppedApp != "" {
+		t.Fatalf("remote registry lifecycle called restarter: started=%q stopped=%q", restarter.startedApp, restarter.stoppedApp)
+	}
+	if _, err := os.Stat(appregistry.MaterializedPath(artifactsDir, "g-issues", fixture.Version)); !os.IsNotExist(err) {
+		t.Fatalf("remote registry materialized package stat error = %v, want not exist", err)
+	}
+}
+
 func TestStartAppRegistryHeartbeatWriterUsesBootstrapReadiness(t *testing.T) {
 	t.Setenv("SOURCE_VERSION", "source-v3")
 	ctx, cancel := context.WithCancel(context.Background())

--- a/gestaltd/services/appaccess/app_server.go
+++ b/gestaltd/services/appaccess/app_server.go
@@ -270,7 +270,10 @@ func appStreamError(err error) error {
 		if errors.As(err, &recursionErr) {
 			return status.Error(codes.FailedPrecondition, recursionErr.Error())
 		}
-		return status.Error(codes.Internal, err.Error())
+		if st, ok := status.FromError(err); ok {
+			return st.Err()
+		}
+		return status.Error(codes.Unknown, fmt.Sprintf("app invocation failed: %v", err))
 	}
 }
 
@@ -295,7 +298,7 @@ func (s *AppServer) InvokeGraphQL(ctx context.Context, req *proto.AppInvokeGraph
 		InvokeGraphQL(context.Context, *principal.Principal, string, string, invocation.GraphQLRequest) (*core.OperationResult, error)
 	})
 	if !ok {
-		return nil, status.Error(codes.Unimplemented, "plugin graphql invocation is not available")
+		return nil, status.Error(codes.Unimplemented, "app graphql invocation is not available")
 	}
 
 	invokeCtx, instance, err := prepareInvocationSelectors(ctx, callCtx, req.GetConnection(), req.GetInstance())
@@ -673,7 +676,7 @@ func appOperationResult(result *core.OperationResult, err error) (*proto.Operati
 		return nil, invocationStatusError(err)
 	}
 	if result == nil {
-		return nil, status.Error(codes.Internal, "plugin invocation returned no result")
+		return nil, status.Error(codes.Internal, "app invocation returned no result")
 	}
 	return coreOperationResultToProto(result), nil
 }
@@ -717,6 +720,9 @@ func invocationStatusError(err error) error {
 		if errors.As(err, &recursionErr) {
 			return status.Error(codes.FailedPrecondition, recursionErr.Error())
 		}
-		return status.Error(codes.Unknown, fmt.Sprintf("plugin invocation failed: %v", err))
+		if st, ok := status.FromError(err); ok {
+			return st.Err()
+		}
+		return status.Error(codes.Unknown, fmt.Sprintf("app invocation failed: %v", err))
 	}
 }

--- a/gestaltd/services/appaccess/app_test.go
+++ b/gestaltd/services/appaccess/app_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -751,24 +752,26 @@ func TestInvokeFrameToProtoDataOnlyYieldsOneFrame(t *testing.T) {
 func TestAppStreamErrorMapsAllInvocationErrors(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name     string
-		err      error
-		wantCode codes.Code
+		name        string
+		err         error
+		wantCode    codes.Code
+		wantMessage string
 	}{
-		{"provider not found", invocation.ErrProviderNotFound, codes.NotFound},
-		{"operation not found", invocation.ErrOperationNotFound, codes.NotFound},
-		{"not authenticated", invocation.ErrNotAuthenticated, codes.Unauthenticated},
-		{"authorization denied", invocation.ErrAuthorizationDenied, codes.PermissionDenied},
-		{"scope denied", invocation.ErrScopeDenied, codes.PermissionDenied},
-		{"no credential", invocation.ErrNoCredential, codes.FailedPrecondition},
-		{"reconnect required", invocation.ErrReconnectRequired, codes.FailedPrecondition},
-		{"invalid invocation", invocation.ErrInvalidInvocation, codes.InvalidArgument},
-		{"streaming unsupported", invocation.ErrStreamingUnsupported, codes.FailedPrecondition},
-		{"ambiguous instance", invocation.ErrAmbiguousInstance, codes.Aborted},
-		{"max depth", &invocation.MaxDepthError{Depth: 5, Max: 4}, codes.ResourceExhausted},
-		{"rate limit", &invocation.RateLimitError{Provider: "foo"}, codes.ResourceExhausted},
-		{"recursion", &invocation.RecursionError{Provider: "foo", Operation: "bar"}, codes.FailedPrecondition},
-		{"unknown", assertErr("unknown"), codes.Internal},
+		{"provider not found", invocation.ErrProviderNotFound, codes.NotFound, ""},
+		{"operation not found", invocation.ErrOperationNotFound, codes.NotFound, ""},
+		{"not authenticated", invocation.ErrNotAuthenticated, codes.Unauthenticated, ""},
+		{"authorization denied", invocation.ErrAuthorizationDenied, codes.PermissionDenied, ""},
+		{"scope denied", invocation.ErrScopeDenied, codes.PermissionDenied, ""},
+		{"no credential", invocation.ErrNoCredential, codes.FailedPrecondition, ""},
+		{"reconnect required", invocation.ErrReconnectRequired, codes.FailedPrecondition, ""},
+		{"invalid invocation", invocation.ErrInvalidInvocation, codes.InvalidArgument, ""},
+		{"streaming unsupported", invocation.ErrStreamingUnsupported, codes.FailedPrecondition, ""},
+		{"ambiguous instance", invocation.ErrAmbiguousInstance, codes.Aborted, ""},
+		{"max depth", &invocation.MaxDepthError{Depth: 5, Max: 4}, codes.ResourceExhausted, ""},
+		{"rate limit", &invocation.RateLimitError{Provider: "foo"}, codes.ResourceExhausted, ""},
+		{"recursion", &invocation.RecursionError{Provider: "foo", Operation: "bar"}, codes.FailedPrecondition, ""},
+		{"unknown", assertErr("unknown"), codes.Unknown, "app invocation failed: unknown"},
+		{"grpc status", status.Error(codes.Unavailable, "upstream unavailable"), codes.Unavailable, "upstream unavailable"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -780,7 +783,47 @@ func TestAppStreamErrorMapsAllInvocationErrors(t *testing.T) {
 			if st.Code() != tc.wantCode {
 				t.Fatalf("got code %s, want %s", st.Code(), tc.wantCode)
 			}
+			if tc.wantMessage != "" && st.Message() != tc.wantMessage {
+				t.Fatalf("got message %q, want %q", st.Message(), tc.wantMessage)
+			}
 		})
+	}
+}
+
+func TestAppOperationResultPreservesGRPCStatusAndUsesAppWording(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		code    codes.Code
+		message string
+	}{
+		{name: "invalid argument", code: codes.InvalidArgument, message: "context is server-filled"},
+		{name: "internal", code: codes.Internal, message: "upstream exploded"},
+		{name: "unavailable", code: codes.Unavailable, message: "upstream unavailable"},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := appOperationResult(nil, status.Error(tc.code, tc.message))
+			if status.Code(err) != tc.code || status.Convert(err).Message() != tc.message {
+				t.Fatalf("error = %v, want %s %q", err, tc.code, tc.message)
+			}
+		})
+	}
+
+	_, err := appOperationResult(nil, assertErr("ordinary failure"))
+	if status.Code(err) != codes.Unknown || !strings.Contains(err.Error(), "app invocation failed: ordinary failure") {
+		t.Fatalf("ordinary error = %v, want Unknown app-invocation wording", err)
+	}
+
+	_, err = appOperationResult(nil, invocation.ErrOperationNotFound)
+	if status.Code(err) != codes.NotFound {
+		t.Fatalf("typed invocation error code = %s, want NotFound", status.Code(err))
+	}
+	_, err = appOperationResult(nil, nil)
+	if status.Code(err) != codes.Internal || status.Convert(err).Message() != "app invocation returned no result" {
+		t.Fatalf("nil result error = %v, want app wording", err)
 	}
 }
 

--- a/gestaltd/services/apps/provider_client.go
+++ b/gestaltd/services/apps/provider_client.go
@@ -567,6 +567,10 @@ func NewGestaltRemote(client proto.AppClient, spec StaticProviderSpec) core.Prov
 
 func (p *gestaltRemoteProvider) RemoteCredentialDelegated() bool { return true }
 
+func (p *gestaltRemoteProvider) ResolveStaticOperationForRequest(_ context.Context, operation string) (catalog.CatalogOperation, bool) {
+	return catalog.OperationByID(p.spec.Catalog, strings.TrimSpace(operation))
+}
+
 func (p *gestaltRemoteProvider) Execute(ctx context.Context, operation string, params map[string]any, _ string) (*core.OperationResult, error) {
 	paramsStruct, err := protoutil.StructFromMap(params)
 	if err != nil {
@@ -588,6 +592,9 @@ func (p *gestaltRemoteProvider) Execute(ctx context.Context, operation string, p
 }
 
 func (p *gestaltRemoteProvider) InvokeGraphQL(ctx context.Context, request core.GraphQLRequest, _ string) (*core.OperationResult, error) {
+	if !p.graphQLAllowed() {
+		return nil, fmt.Errorf("%w: %s.graphql", invocation.ErrOperationNotFound, p.spec.Name)
+	}
 	variables, err := protoutil.StructFromMap(request.Variables)
 	if err != nil {
 		return nil, err
@@ -605,6 +612,14 @@ func (p *gestaltRemoteProvider) InvokeGraphQL(ctx context.Context, request core.
 		return nil, remoteProviderExecuteError(err)
 	}
 	return remoteOperationResult(resp), nil
+}
+
+func (p *gestaltRemoteProvider) graphQLAllowed() bool {
+	if _, ok := catalog.OperationByID(p.spec.Catalog, "graphql"); ok {
+		return true
+	}
+	_, ok := catalog.OperationByID(p.spec.Catalog, "graphql.execute")
+	return ok
 }
 
 func remoteAppInvokeSelectors(ctx context.Context) (connection, instance string) {

--- a/gestaltd/services/invocation/catalog.go
+++ b/gestaltd/services/invocation/catalog.go
@@ -123,18 +123,20 @@ func ResolveOperation(ctx context.Context, prov core.Provider, provName string, 
 	}
 
 	staticOp, staticOK := CatalogOperation(providerCatalog(prov), operation)
-	if staticOK {
-		if resolver, ok := prov.(requestStaticOperationResolver); ok {
-			if op, ok := resolver.ResolveStaticOperationForRequest(ctx, operation); ok {
-				catalogSource = "static"
-				return op, OperationTransport(op), "", nil
-			}
+	staticResolver, hasStaticResolver := prov.(requestStaticOperationResolver)
+	if staticOK && hasStaticResolver {
+		if op, ok := staticResolver.ResolveStaticOperationForRequest(ctx, operation); ok {
+			catalogSource = "static"
+			return op, OperationTransport(op), "", nil
 		}
 	}
 	if !core.SupportsSessionCatalog(prov) {
 		if staticOK {
 			catalogSource = "static"
 			return staticOp, OperationTransport(staticOp), "", nil
+		}
+		if hasStaticResolver {
+			return catalog.CatalogOperation{}, "", "", fmt.Errorf("%w: %q on provider %q", ErrOperationNotFound, operation, provName)
 		}
 		if delegated, ok := prov.(RemoteCredentialDelegated); ok && delegated.RemoteCredentialDelegated() {
 			catalogSource = "passthrough"

--- a/gestaltd/services/providerdev/app_supervisor.go
+++ b/gestaltd/services/providerdev/app_supervisor.go
@@ -317,20 +317,36 @@ func (a *appManaged) probeFrontendReadiness(ctx context.Context, logger *slog.Lo
 	if strings.TrimSpace(a.target.BasePath) == "" {
 		return
 	}
-	deadline := time.Now().Add(maxReadyTimeout(a.target.Commands))
 	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(a.port))
+	a.probeFrontendReadinessWith(ctx, logger, func() (net.Conn, error) {
+		return net.DialTimeout("tcp", addr, time.Second)
+	})
+}
+
+func (a *appManaged) probeFrontendReadinessWith(ctx context.Context, logger *slog.Logger, probe func() (net.Conn, error)) {
+	a.probeFrontendReadinessUntil(ctx, logger, time.Now().Add(maxReadyTimeout(a.target.Commands)), probe)
+}
+
+func (a *appManaged) probeFrontendReadinessUntil(ctx context.Context, logger *slog.Logger, deadline time.Time, probe func() (net.Conn, error)) {
 	warned := false
 	loggedReady := false
+	readyBeforeDeadline := false
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		default:
 		}
-		conn, err := net.DialTimeout("tcp", addr, time.Second)
+		conn, err := probe()
 		if err == nil {
-			_ = conn.Close()
+			if conn != nil {
+				_ = conn.Close()
+			}
+			now := time.Now()
 			a.ready.Store(true)
+			if now.Before(deadline) {
+				readyBeforeDeadline = true
+			}
 			a.frontendReadyOnce.Do(func() { close(a.frontendReady) })
 			if logger != nil && !loggedReady {
 				logger.Debug("dev app frontend ready", "app", a.target.Name, "port", a.port)
@@ -342,7 +358,7 @@ func (a *appManaged) probeFrontendReadiness(ctx context.Context, logger *slog.Lo
 		}
 		if !warned && time.Now().After(deadline) {
 			warned = true
-			if logger != nil {
+			if !readyBeforeDeadline && logger != nil {
 				args := []any{"app", a.target.Name}
 				for i, proc := range a.commandProcs() {
 					if output := proc.currentOutput(); output != nil {

--- a/gestaltd/services/providerdev/app_supervisor_test.go
+++ b/gestaltd/services/providerdev/app_supervisor_test.go
@@ -1,0 +1,89 @@
+package providerdev
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"net"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestProbeFrontendReadinessTimeoutBehavior(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name            string
+		initiallyReady  bool
+		readyOnAttempt  int32
+		loseReadiness   bool
+		wantWarnings    int
+		wantReadyAtStop bool
+	}{
+		{name: "ready before deadline then disconnects", initiallyReady: true, loseReadiness: true, wantWarnings: 0, wantReadyAtStop: false},
+		{name: "never ready", wantWarnings: 1, wantReadyAtStop: false},
+		{name: "ready after deadline", readyOnAttempt: 2, wantWarnings: 1, wantReadyAtStop: true},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var available atomic.Bool
+			available.Store(tc.initiallyReady)
+			var attempts atomic.Int32
+			app := &appManaged{
+				target: AppTarget{
+					Name:     tc.name,
+					BasePath: "/" + strings.ReplaceAll(tc.name, " ", "-"),
+					Commands: []AppCommand{{ReadyTimeout: 50 * time.Millisecond}},
+				},
+				frontendReady: make(chan struct{}),
+			}
+			var logs bytes.Buffer
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			done := make(chan struct{})
+			go func() {
+				app.probeFrontendReadinessUntil(ctx, slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})), time.Now().Add(50*time.Millisecond), func() (net.Conn, error) {
+					if tc.readyOnAttempt > 0 && attempts.Add(1) >= tc.readyOnAttempt {
+						conn, _ := net.Pipe()
+						return conn, nil
+					}
+					if available.Load() {
+						conn, _ := net.Pipe()
+						return conn, nil
+					}
+					return nil, errors.New("frontend unavailable")
+				})
+				close(done)
+			}()
+
+			if tc.initiallyReady || tc.readyOnAttempt > 0 {
+				select {
+				case <-app.frontendReady:
+				case <-time.After(time.Second):
+					t.Fatal("frontend did not become ready")
+				}
+			}
+			if tc.loseReadiness {
+				available.Store(false)
+			}
+			time.Sleep(350 * time.Millisecond)
+			cancel()
+			select {
+			case <-done:
+			case <-time.After(time.Second):
+				t.Fatal("readiness probe did not stop")
+			}
+			if got := strings.Count(logs.String(), "dev app frontend readiness timeout"); got != tc.wantWarnings {
+				t.Fatalf("startup timeout warnings = %d, want %d; logs=%s", got, tc.wantWarnings, logs.String())
+			}
+			if got := app.ready.Load(); got != tc.wantReadyAtStop {
+				t.Fatalf("frontend ready = %v, want %v", got, tc.wantReadyAtStop)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Stop forwarding client-supplied `RequestContext` from remote ordinary and GraphQL app invocations.
- Build deterministic remote registry catalogs from configured `allowedOperations`, including local rejection for empty/non-allowlisted operations.
- Make development placement explicit, skip lifecycle work for remotely placed registry apps, and correct frontend readiness timeout tracking.
- Preserve gRPC statuses and use app-specific invocation wording for unary and streaming errors.
- Add regression coverage for gateway context handling, identity propagation, routing, catalogs, lifecycle, readiness, GraphQL, and error mapping.

## Root cause

The experimental remote provider forwarded `AppInvokeRequest.Context` to the public gateway, even though that field is server-filled. The gateway rejected the nested invocation with `InvalidArgument: context is server-filled`; the deployed route obscured it as a trailer-less `Internal` error.

The clean `origin/main` baseline already had no wildcard catalog fallback; this branch keeps that behavior absent and supplies explicit catalogs for remote registry proxies.

## Validation

- `go test ./...`
- `go test -race ./services/providergateway ./services/apps ./services/invocation ./internal/bootstrap ./internal/server ./services/providerdev ./services/appaccess`
- `go vet ./...`
- `go test -timeout=15m ./internal/daemon/e2e/...`
- `golangci-lint run ./...`
- Built `/tmp/gestaltd-dev-remote-fix` from commit `db7532308`.

The exact local reproduction reached local provider startup, but remote publication returned HTTP 403 in the current environment. Direct/public trailer-matrix testing was not run because the configured GKE credentials require interactive reauthentication; no infrastructure change is included.