### PR TITLE
Add deployment-scoped OpenFGA authorization backend

### DIFF
--- a/gestaltd/go.mod
+++ b/gestaltd/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/hashicorp/yamux v0.1.1
 	github.com/landlock-lsm/go-landlock v0.8.1
 	github.com/mark3labs/mcp-go v0.54.0
+	github.com/openfga/go-sdk v0.8.2
 	github.com/pb33f/libopenapi v0.36.4
 	github.com/prometheus/client_golang v1.23.2
 	github.com/robfig/cron/v3 v3.0.1

--- a/gestaltd/go.sum
+++ b/gestaltd/go.sum
@@ -218,6 +218,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/onsi/gomega v1.36.3 h1:hID7cr8t3Wp26+cYnfcjR6HpJ00fdogN6dqZ1t6IylU=
 github.com/onsi/gomega v1.36.3/go.mod h1:8D9+Txp43QWKhM24yyOBEdpkzN8FvJyAwecBgsU4KU0=
+github.com/openfga/go-sdk v0.8.2 h1:eX2RJ7RD9sbxC4Oe8ZAFDZu6n/qYuO9SDrk7XAOE0Fg=
+github.com/openfga/go-sdk v0.8.2/go.mod h1:epiUE6IfG7Ezr3cYLepiUbCasChNowgP8AtJsN4HSpI=
 github.com/pb33f/jsonpath v0.8.2 h1:Ou4C7zjYClBm97dfZjDCjdZGusJoynv/vrtiEKNfj2Y=
 github.com/pb33f/jsonpath v0.8.2/go.mod h1:zBV5LJW4OQOPatmQE2QdKpGQJvhDTlE5IEj6ASaRNTo=
 github.com/pb33f/libopenapi v0.36.4 h1:oGDGjHpCyaj55RG0i0TLB3N3MEGIsGsM1aD7iInfZ8A=

--- a/gestaltd/go.sum
+++ b/gestaltd/go.sum
@@ -185,6 +185,8 @@ github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jarcoal/httpmock v1.4.1 h1:0Ju+VCFuARfFlhVXFc2HxlcQkfB+Xq12/EotHko+x2A=
+github.com/jarcoal/httpmock v1.4.1/go.mod h1:ftW1xULwo+j0R0JJkJIIi7UKigZUXCLLanykgjwBXL0=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jensneuse/diffview v1.0.0 h1:4b6FQJ7y3295JUHU3tRko6euyEboL825ZsXeZZM47Z4=

--- a/gestaltd/internal/bootstrap/authorization_bootstrap.go
+++ b/gestaltd/internal/bootstrap/authorization_bootstrap.go
@@ -21,6 +21,10 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
+type authorizationStateBootstrapper interface {
+	BootstrapAuthorizationState(context.Context, *proto.AuthorizationModel, []*proto.Relationship) error
+}
+
 func bootstrapAuthorizationProviderState(ctx context.Context, cfg *config.Config, providers map[string]core.AuthorizationProvider) error {
 	if len(providers) == 0 {
 		return nil
@@ -43,16 +47,25 @@ func bootstrapAuthorizationProviderState(ctx context.Context, cfg *config.Config
 	if err != nil {
 		return fmt.Errorf("bootstrap: authorization provider %q: %w", name, err)
 	}
+	staticRelationships, err := staticAuthorizationRelationships(cfg.Authorization)
+	if err != nil {
+		return fmt.Errorf("bootstrap: authorization provider %q: %w", name, err)
+	}
+	if bootstrapper, ok := provider.(authorizationStateBootstrapper); ok {
+		if err := stampAuthorizationModel(model, time.Now()); err != nil {
+			return fmt.Errorf("bootstrap: authorization provider %q: %w", name, err)
+		}
+		if err := bootstrapper.BootstrapAuthorizationState(ctx, model, staticRelationships); err != nil {
+			return fmt.Errorf("bootstrap: authorization provider %q: bootstrap authorization state: %w", name, err)
+		}
+		return nil
+	}
 	runtimeResourceTypes, err := listRuntimeAuthorizationModelResourceTypes(ctx, provider)
 	if err != nil {
 		return fmt.Errorf("bootstrap: authorization provider %q: %w", name, err)
 	}
 	model.ResourceTypes = mergedAuthorizationModelResourceTypes(model.GetResourceTypes(), runtimeResourceTypes)
 	if err := stampAuthorizationModel(model, time.Now()); err != nil {
-		return fmt.Errorf("bootstrap: authorization provider %q: %w", name, err)
-	}
-	staticRelationships, err := staticAuthorizationRelationships(cfg.Authorization)
-	if err != nil {
 		return fmt.Errorf("bootstrap: authorization provider %q: %w", name, err)
 	}
 	runtimeRelationships, err := listRuntimeAuthorizationRelationships(ctx, provider)

--- a/gestaltd/internal/bootstrap/authorization_bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/authorization_bootstrap_test.go
@@ -150,6 +150,65 @@ func TestBootstrapAuthorizationProviderStatePreservesRuntimeRelationships(t *tes
 	}
 }
 
+func TestBootstrapAuthorizationProviderStateHardCutoverSkipsRuntimeReconciliation(t *testing.T) {
+	t.Parallel()
+
+	provider := &cutoverAuthorizationProvider{recordingAuthorizationProvider: &recordingAuthorizationProvider{
+		listResourceTypePages: []*proto.ListActiveModelResourceTypesResponse{{
+			ResourceTypes: []*proto.AuthorizationModelResourceType{testAuthorizationResourceType("legacy", proto.SourceLayer_SOURCE_LAYER_RUNTIME)},
+		}},
+		listRelationshipsPages: []*proto.ListRelationshipsResponse{{
+			Relationships: []*proto.Relationship{testAuthorizationRelationship("user:legacy", "viewer", "github", "repo-1", proto.SourceLayer_SOURCE_LAYER_RUNTIME)},
+		}},
+	}}
+	cfg := &config.Config{
+		Server: config.ServerConfig{Providers: config.ServerProvidersConfig{Authorization: "authz"}},
+		Providers: config.ProvidersConfig{
+			Authorization: map[string]*config.ProviderEntry{"authz": {Default: true}},
+		},
+		Authorization: config.AuthorizationConfig{
+			Models: map[string]config.AuthorizationModelDef{
+				"default": {
+					ResourceTypes: map[string]config.AuthorizationResourceTypeDef{
+						"github": {
+							Relations: map[string]config.AuthorizationRelationDef{
+								"viewer": {SubjectTypes: []string{"subject"}},
+							},
+						},
+					},
+				},
+			},
+			Relationships: []config.AuthorizationRelationshipDef{{
+				Subject:  config.AuthorizationSubjectDef{Type: "subject", ID: "user:static"},
+				Relation: "viewer",
+				Resource: config.AuthorizationResourceDef{Type: "github", ID: "repo-1"},
+			}},
+		},
+	}
+
+	if err := bootstrapAuthorizationProviderState(context.Background(), cfg, map[string]core.AuthorizationProvider{"authz": provider}); err != nil {
+		t.Fatalf("bootstrapAuthorizationProviderState: %v", err)
+	}
+	if provider.bootstrapModel == nil {
+		t.Fatal("BootstrapAuthorizationState was not called")
+	}
+	if got, want := len(provider.bootstrapModel.GetResourceTypes()), 1; got != want {
+		t.Fatalf("bootstrapped resource types = %d, want %d static resource type", got, want)
+	}
+	if got, want := len(provider.bootstrapRelationships), 1; got != want {
+		t.Fatalf("bootstrapped relationships = %d, want %d static relationship", got, want)
+	}
+	if got := provider.bootstrapRelationships[0].GetTuple().GetTarget().GetSubject().GetId(); got != "user:static" {
+		t.Fatalf("bootstrapped subject = %q, want static subject", got)
+	}
+	if provider.setAuthorizationState != nil {
+		t.Fatal("SetAuthorizationState should not be called for a hard-cutover provider")
+	}
+	if len(provider.resourceTypeRequests) != 0 || len(provider.listRequests) != 0 {
+		t.Fatalf("runtime state was read during hard cutover: resource type requests=%d relationship requests=%d", len(provider.resourceTypeRequests), len(provider.listRequests))
+	}
+}
+
 func TestStaticAuthorizationModelCarriesResourceTypeDefaultRole(t *testing.T) {
 	t.Parallel()
 
@@ -351,6 +410,21 @@ type recordingAuthorizationProvider struct {
 	listRequests           []*proto.ListRelationshipsRequest
 	resourceTypeRequests   []*proto.ListActiveModelResourceTypesRequest
 	setAuthorizationState  *proto.SetAuthorizationStateRequest
+}
+
+type cutoverAuthorizationProvider struct {
+	*recordingAuthorizationProvider
+	bootstrapModel         *proto.AuthorizationModel
+	bootstrapRelationships []*proto.Relationship
+}
+
+func (p *cutoverAuthorizationProvider) BootstrapAuthorizationState(_ context.Context, model *proto.AuthorizationModel, relationships []*proto.Relationship) error {
+	p.bootstrapModel = gproto.Clone(model).(*proto.AuthorizationModel)
+	p.bootstrapRelationships = make([]*proto.Relationship, 0, len(relationships))
+	for _, relationship := range relationships {
+		p.bootstrapRelationships = append(p.bootstrapRelationships, gproto.Clone(relationship).(*proto.Relationship))
+	}
+	return nil
 }
 
 func (p *recordingAuthorizationProvider) CheckAccess(context.Context, *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -2182,11 +2182,7 @@ func buildNamedAuthorizationProvider(ctx context.Context, cfg *config.Config, na
 		if !config.EntryBuildsLocal(entry) {
 			return nil, fmt.Errorf("bootstrap: built-in openfga authorization provider %q must build locally", logicalName)
 		}
-		var legacyDB indexeddb.IndexedDB
-		if deps.SelectedIndexedDBName != "" {
-			legacyDB = deps.IndexedDBs[deps.SelectedIndexedDBName]
-		}
-		provider, err := authorizationservice.NewOpenFGA(entry.Config, legacyDB)
+		provider, err := authorizationservice.NewOpenFGA(entry.Config)
 		if err != nil {
 			return nil, fmt.Errorf("bootstrap: authorization provider %q: %w", logicalName, err)
 		}

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -2178,6 +2178,20 @@ func buildNamedAuthorizationProvider(ctx context.Context, cfg *config.Config, na
 	if entry == nil {
 		return nil, fmt.Errorf("bootstrap: authorization provider %q is not configured", logicalName)
 	}
+	if strings.EqualFold(strings.TrimSpace(entry.Source.Builtin), "openfga") {
+		if !config.EntryBuildsLocal(entry) {
+			return nil, fmt.Errorf("bootstrap: built-in openfga authorization provider %q must build locally", logicalName)
+		}
+		var legacyDB indexeddb.IndexedDB
+		if deps.SelectedIndexedDBName != "" {
+			legacyDB = deps.IndexedDBs[deps.SelectedIndexedDBName]
+		}
+		provider, err := authorizationservice.NewOpenFGA(entry.Config, legacyDB)
+		if err != nil {
+			return nil, fmt.Errorf("bootstrap: authorization provider %q: %w", logicalName, err)
+		}
+		return provider, nil
+	}
 	if !config.EntryBuildsLocal(entry) {
 		clients, err := remoteClientsForEntry(cfg, entry, deps)
 		if err != nil {

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -3448,6 +3448,8 @@ func isLocalReleaseMetadataPath(value string) bool {
 
 func isBuiltinScalarSource(kind, source string) bool {
 	switch kind {
+	case string(HostProviderKindAuthorization):
+		return strings.EqualFold(strings.TrimSpace(source), "openfga")
 	case providermanifestv1.KindSecrets:
 		switch source {
 		case "env", "file":

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -5796,6 +5796,8 @@ providers:
 }
 
 func TestAuthorizationOpenFGAScalarSourceIsBuiltin(t *testing.T) {
+	t.Parallel()
+
 	var source ProviderSource
 	if err := yaml.Unmarshal([]byte("openfga\n"), &source); err != nil {
 		t.Fatalf("unmarshal source: %v", err)

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -5795,6 +5795,17 @@ providers:
 	}
 }
 
+func TestAuthorizationOpenFGAScalarSourceIsBuiltin(t *testing.T) {
+	var source ProviderSource
+	if err := yaml.Unmarshal([]byte("openfga\n"), &source); err != nil {
+		t.Fatalf("unmarshal source: %v", err)
+	}
+	normalizeProviderSource(string(HostProviderKindAuthorization), &source)
+	if !source.IsBuiltin() || source.Builtin != "openfga" {
+		t.Fatalf("source = %#v, want openfga builtin", source)
+	}
+}
+
 func TestLoadConfigProviderPackageSourceValidation(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -524,11 +524,16 @@ func validateHostProviderEntries(kind HostProviderKind, entries map[string]*Prov
 				return err
 			}
 		case HostProviderKindAuthorization:
-			if entry.Source.IsBuiltin() {
+			if entry.Source.IsBuiltin() && !strings.EqualFold(strings.TrimSpace(entry.Source.Builtin), "openfga") {
 				return fmt.Errorf("config validation: authorization provider %q does not support builtin providers; use a provider source reference or omit authorization", name)
 			}
-			if err := validateProviderEntrySource("authorization", name, entry); err != nil {
-				return err
+			if !entry.Source.IsBuiltin() {
+				if err := validateProviderEntrySource("authorization", name, entry); err != nil {
+					return err
+				}
+			}
+			if strings.EqualFold(strings.TrimSpace(entry.Source.Builtin), "openfga") && strings.TrimSpace(entry.Remote) != "" {
+				return fmt.Errorf("config validation: authorization provider %q openfga backend cannot use remote placement", name)
 			}
 		case HostProviderKindExternalCredentials:
 			if entry.Source.IsBuiltin() {

--- a/gestaltd/services/authorization/openfga.go
+++ b/gestaltd/services/authorization/openfga.go
@@ -1078,11 +1078,11 @@ func cloneModelRef(in *proto.AuthorizationModelRef) *proto.AuthorizationModelRef
 	if in == nil {
 		return nil
 	}
-	out := *in
+	out := &proto.AuthorizationModelRef{Id: in.Id, Version: in.Version}
 	if in.CreatedAt != nil {
 		out.CreatedAt = timestamppb.New(in.CreatedAt.AsTime())
 	}
-	return &out
+	return out
 }
 
 func cloneResourceType(in *proto.AuthorizationModelResourceType) *proto.AuthorizationModelResourceType {

--- a/gestaltd/services/authorization/openfga.go
+++ b/gestaltd/services/authorization/openfga.go
@@ -316,10 +316,18 @@ func (p *openFGA) SetActiveModel(_ context.Context, req *proto.SetActiveModelReq
 	if req == nil || req.Model == nil {
 		return nil, status.Error(codes.InvalidArgument, "model is required")
 	}
+	codec, err := newFGACodec(req.Model)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "model: %v", err)
+	}
+	model := cloneModel(req.Model)
+	ref := &proto.AuthorizationModelRef{Id: model.Id, Version: model.Version, CreatedAt: timestamppb.New(time.Now().UTC())}
 	p.mu.Lock()
-	p.modelRef = &proto.AuthorizationModelRef{Id: req.Model.Id, Version: req.Model.Version, CreatedAt: timestamppb.New(time.Now().UTC())}
+	p.model = model
+	p.modelRef = ref
+	p.codec = codec
 	p.mu.Unlock()
-	return &proto.SetActiveModelResponse{Model: cloneModelRef(p.modelRef)}, nil
+	return &proto.SetActiveModelResponse{Model: cloneModelRef(ref)}, nil
 }
 
 func (p *openFGA) ListActiveModelResourceTypes(_ context.Context, req *proto.ListActiveModelResourceTypesRequest) (*proto.ListActiveModelResourceTypesResponse, error) {
@@ -406,7 +414,11 @@ func (p *openFGA) ListRelationships(ctx context.Context, req *proto.ListRelation
 			pageToken = parsed
 		}
 	}
-	tuples, err := p.readAllTuples(ctx, codec.readFilter(filter))
+	readFilter, err := codec.readFilter(filter)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "relationship filter: %v", err)
+	}
+	tuples, err := p.readAllTuples(ctx, readFilter)
 	if err != nil {
 		return nil, err
 	}
@@ -682,12 +694,16 @@ func (c *fgaCodec) checkTuple(subject *proto.Subject, permission string, resourc
 	if objectType == "" {
 		return openfga.TupleKey{}, fmt.Errorf("unknown resource type %q", resource.Type)
 	}
-	return openfga.TupleKey{User: c.subjectUser(subject), Relation: permission, Object: objectType + ":" + resource.Id}, nil
+	user, err := c.subjectUser(subject)
+	if err != nil {
+		return openfga.TupleKey{}, err
+	}
+	return openfga.TupleKey{User: user, Relation: permission, Object: objectType + ":" + resource.Id}, nil
 }
 
 func (c *fgaCodec) targetUser(target *proto.RelationshipTarget) (string, error) {
 	if subject := target.GetSubject(); subject != nil {
-		return c.subjectUser(subject), nil
+		return c.subjectUser(subject)
 	}
 	if resource := target.GetResource(); resource != nil {
 		typeName := c.types[resource.Type]
@@ -707,13 +723,20 @@ func (c *fgaCodec) targetUser(target *proto.RelationshipTarget) (string, error) 
 	return "", fmt.Errorf("relationship target is required")
 }
 
-func (c *fgaCodec) subjectUser(subject *proto.Subject) string {
-	return c.types[subject.Type] + ":" + subject.Id
+func (c *fgaCodec) subjectUser(subject *proto.Subject) (string, error) {
+	if subject == nil {
+		return "", fmt.Errorf("subject is required")
+	}
+	typeName := c.types[subject.Type]
+	if typeName == "" {
+		return "", fmt.Errorf("unknown subject type %q", subject.Type)
+	}
+	return typeName + ":" + subject.Id, nil
 }
 
-func (c *fgaCodec) readFilter(filter *proto.RelationshipFilter) *openfga.ReadRequestTupleKey {
+func (c *fgaCodec) readFilter(filter *proto.RelationshipFilter) (*openfga.ReadRequestTupleKey, error) {
 	if filter == nil {
-		return nil
+		return nil, nil
 	}
 	key := &openfga.ReadRequestTupleKey{}
 	if filter.Resource != nil {
@@ -721,6 +744,13 @@ func (c *fgaCodec) readFilter(filter *proto.RelationshipFilter) *openfga.ReadReq
 			value := objectType + ":" + filter.Resource.Id
 			key.Object = &value
 		}
+	}
+	if filter.Target != nil {
+		value, err := c.targetUser(filter.Target)
+		if err != nil {
+			return nil, err
+		}
+		key.User = &value
 	}
 	// OpenFGA's Read API only accepts exact object IDs, not a type prefix.
 	// Leave resource-type-only filtering unbounded and apply it locally after
@@ -730,7 +760,10 @@ func (c *fgaCodec) readFilter(filter *proto.RelationshipFilter) *openfga.ReadReq
 			key.Relation = &relation
 		}
 	}
-	return key
+	if !key.HasObject() && !key.HasRelation() && !key.HasUser() {
+		return nil, nil
+	}
+	return key, nil
 }
 
 func (c *fgaCodec) relationsForFilter(filter *proto.RelationshipFilter) string {

--- a/gestaltd/services/authorization/openfga.go
+++ b/gestaltd/services/authorization/openfga.go
@@ -1,0 +1,1113 @@
+package authorization
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	openfga "github.com/openfga/go-sdk"
+	"github.com/openfga/go-sdk/credentials"
+	indexeddb "github.com/valon-technologies/gestalt/sdk/go/indexeddb"
+	"github.com/valon-technologies/gestalt/server/core"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	gproto "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"gopkg.in/yaml.v3"
+)
+
+// OpenFGAConfig configures the deployment-scoped built-in OpenFGA backend.
+// Values may already have been resolved from Gestalt secret references.
+type OpenFGAConfig struct {
+	APIURL       string `yaml:"apiUrl"`
+	StoreID      string `yaml:"storeId"`
+	TokenIssuer  string `yaml:"tokenIssuer"`
+	Audience     string `yaml:"audience"`
+	ClientID     string `yaml:"clientId"`
+	ClientSecret string `yaml:"clientSecret"`
+	Scopes       string `yaml:"scopes,omitempty"`
+}
+
+type openFGA struct {
+	mu sync.RWMutex
+
+	client  *openfga.APIClient
+	storeID string
+
+	model    *proto.AuthorizationModel
+	modelRef *proto.AuthorizationModelRef
+	codec    *fgaCodec
+	meta     map[string]*proto.Relationship
+	legacyDB indexeddb.Database
+	legacy   []*proto.Relationship
+}
+
+type fgaCodec struct {
+	model       *proto.AuthorizationModel
+	types       map[string]string
+	relations   map[string]string
+	permissions map[string]string
+	reverse     map[string]string
+}
+
+func NewOpenFGA(node yaml.Node, databases ...indexeddb.Database) (core.AuthorizationProvider, error) {
+	var cfg OpenFGAConfig
+	if err := node.Decode(&cfg); err != nil {
+		return nil, fmt.Errorf("openfga authorization: decode config: %w", err)
+	}
+	for name, value := range map[string]string{
+		"apiUrl": cfg.APIURL, "storeId": cfg.StoreID, "tokenIssuer": cfg.TokenIssuer,
+		"audience": cfg.Audience, "clientId": cfg.ClientID, "clientSecret": cfg.ClientSecret,
+	} {
+		if strings.TrimSpace(value) == "" {
+			return nil, fmt.Errorf("openfga authorization: %s is required", name)
+		}
+	}
+	creds, err := credentials.NewCredentials(credentials.Credentials{
+		Method: credentials.CredentialsMethodClientCredentials,
+		Config: &credentials.Config{
+			ClientCredentialsApiTokenIssuer: cfg.TokenIssuer,
+			ClientCredentialsApiAudience:    cfg.Audience,
+			ClientCredentialsClientId:       cfg.ClientID,
+			ClientCredentialsClientSecret:   cfg.ClientSecret,
+			ClientCredentialsScopes:         cfg.Scopes,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("openfga authorization: credentials: %w", err)
+	}
+	apiCfg, err := openfga.NewConfiguration(openfga.Configuration{
+		ApiUrl:      strings.TrimRight(strings.TrimSpace(cfg.APIURL), "/"),
+		Credentials: creds,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("openfga authorization: client config: %w", err)
+	}
+	provider := &openFGA{
+		client:  openfga.NewAPIClient(apiCfg),
+		storeID: strings.TrimSpace(cfg.StoreID),
+		meta:    make(map[string]*proto.Relationship),
+	}
+	if len(databases) > 0 && databases[0] != nil {
+		provider.legacyDB = databases[0]
+		provider.legacy, _ = loadLegacyRelationships(context.Background(), databases[0])
+	}
+	return provider, nil
+}
+
+func (p *openFGA) Ping(ctx context.Context) error {
+	if p == nil || p.client == nil {
+		return status.Error(codes.FailedPrecondition, "openfga authorization is not configured")
+	}
+	_, _, err := p.client.OpenFgaApi.GetStore(ctx, p.storeID).Execute()
+	if err != nil {
+		return status.Errorf(codes.Unavailable, "openfga store health: %v", err)
+	}
+	if err := p.syncLegacyRelationships(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *openFGA) Close() error { return nil }
+
+func (p *openFGA) CheckAccess(ctx context.Context, req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
+	if req == nil || req.Subject == nil || req.Resource == nil || req.Action == nil {
+		return nil, status.Error(codes.InvalidArgument, "subject, action, and resource are required")
+	}
+	p.mu.RLock()
+	model := p.model
+	codec := p.codec
+	modelID := ""
+	if p.modelRef != nil {
+		modelID = p.modelRef.Id
+	}
+	p.mu.RUnlock()
+	if model == nil || codec == nil {
+		return nil, status.Error(codes.FailedPrecondition, "openfga authorization model is not configured")
+	}
+	if scope := subjectScope(req.Subject); scope != "" && !scopeAllows(scope, req.Resource.Type, req.Action.Name) {
+		return &proto.CheckAccessResponse{Allowed: false, ModelId: modelID}, nil
+	}
+	resourceType := findResourceType(model, req.Resource.Type)
+	if resourceType == nil {
+		return &proto.CheckAccessResponse{Allowed: false, ModelId: modelID}, nil
+	}
+	action := findAction(resourceType, req.Action.Name)
+	if action == nil {
+		action = findAction(resourceType, "*")
+	}
+	if action == nil {
+		return &proto.CheckAccessResponse{Allowed: false, ModelId: modelID}, nil
+	}
+	permission := codec.permissions[resourceType.Name+"\x00"+action.Name]
+	if permission == "" {
+		return &proto.CheckAccessResponse{Allowed: false, ModelId: modelID}, nil
+	}
+	key, err := codec.checkTuple(req.Subject, permission, req.Resource)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "authorization check: %v", err)
+	}
+	check := openfga.NewCheckRequest(*openfga.NewCheckRequestTupleKey(key.User, key.Relation, key.Object))
+	check.SetAuthorizationModelId(codec.model.Id)
+	if defaultRole := strings.TrimSpace(resourceType.DefaultRole); defaultRole != "" && contains(action.Relations, defaultRole) {
+		role := codec.relations[resourceType.Name+"\x00"+defaultRole]
+		if role != "" {
+			wildcard := openfga.NewTupleKey(codec.subjectWildcard(req.Subject.Type), role, key.Object)
+			check.SetContextualTuples(openfga.ContextualTupleKeys{TupleKeys: []openfga.TupleKey{*wildcard}})
+		}
+	}
+	response, _, err := p.client.OpenFgaApi.Check(ctx, p.storeID).Body(*check).Execute()
+	if err != nil {
+		return nil, status.Errorf(codes.Unavailable, "openfga check: %v", err)
+	}
+	return &proto.CheckAccessResponse{Allowed: response.GetAllowed(), ModelId: modelID}, nil
+}
+
+func (p *openFGA) CheckAccessMany(ctx context.Context, req *proto.CheckAccessManyRequest) (*proto.CheckAccessManyResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "request is required")
+	}
+	decisions := make([]*proto.CheckAccessResponse, 0, len(req.Requests))
+	for _, item := range req.Requests {
+		decision, err := p.CheckAccess(ctx, item)
+		if err != nil {
+			return nil, err
+		}
+		decisions = append(decisions, decision)
+	}
+	return &proto.CheckAccessManyResponse{Decisions: decisions}, nil
+}
+
+func (p *openFGA) AddRelationship(ctx context.Context, req *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {
+	if req == nil || req.Relationship == nil || req.Relationship.Tuple == nil {
+		return nil, status.Error(codes.InvalidArgument, "relationship is required")
+	}
+	p.mu.RLock()
+	codec := p.codec
+	p.mu.RUnlock()
+	if codec == nil {
+		return nil, status.Error(codes.FailedPrecondition, "openfga authorization model is not configured")
+	}
+	key, err := codec.relationshipTuple(req.Relationship.Tuple)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "relationship: %v", err)
+	}
+	duplicate := "ignore"
+	writes := openfga.WriteRequest{Writes: openfga.NewWriteRequestWrites([]openfga.TupleKey{key}), AuthorizationModelId: stringPtr(codec.model.Id)}
+	writes.Writes.OnDuplicate = &duplicate
+	if _, _, err := p.client.OpenFgaApi.Write(ctx, p.storeID).Body(writes).Execute(); err != nil {
+		return nil, status.Errorf(codes.Unavailable, "openfga relationship write: %v", err)
+	}
+	copy := cloneRelationship(req.Relationship)
+	if copy.SourceLayer == proto.SourceLayer_SOURCE_LAYER_UNSPECIFIED {
+		copy.SourceLayer = proto.SourceLayer_SOURCE_LAYER_RUNTIME
+	}
+	p.mu.Lock()
+	p.meta[tupleKey(copy.Tuple)] = copy
+	p.mu.Unlock()
+	return &proto.AddRelationshipResponse{Relationship: copy}, nil
+}
+
+func (p *openFGA) DeleteRelationship(ctx context.Context, req *proto.DeleteRelationshipRequest) (*proto.DeleteRelationshipResponse, error) {
+	if req == nil || req.RelationshipTuple == nil {
+		return nil, status.Error(codes.InvalidArgument, "relationship tuple is required")
+	}
+	p.mu.RLock()
+	codec := p.codec
+	p.mu.RUnlock()
+	if codec == nil {
+		return nil, status.Error(codes.FailedPrecondition, "openfga authorization model is not configured")
+	}
+	key, err := codec.relationshipTuple(req.RelationshipTuple)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "relationship: %v", err)
+	}
+	missing := "ignore"
+	deletes := openfga.WriteRequest{Deletes: openfga.NewWriteRequestDeletes([]openfga.TupleKeyWithoutCondition{{User: key.User, Relation: key.Relation, Object: key.Object}}), AuthorizationModelId: stringPtr(codec.model.Id)}
+	deletes.Deletes.OnMissing = &missing
+	if _, _, err := p.client.OpenFgaApi.Write(ctx, p.storeID).Body(deletes).Execute(); err != nil {
+		return nil, status.Errorf(codes.Unavailable, "openfga relationship delete: %v", err)
+	}
+	p.mu.Lock()
+	delete(p.meta, tupleKey(req.RelationshipTuple))
+	p.mu.Unlock()
+	return &proto.DeleteRelationshipResponse{}, nil
+}
+
+func (p *openFGA) SetAuthorizationState(ctx context.Context, req *proto.SetAuthorizationStateRequest) (*proto.SetAuthorizationStateResponse, error) {
+	if req == nil || req.Model == nil {
+		return nil, status.Error(codes.InvalidArgument, "model is required")
+	}
+	codec, err := newFGACodec(req.Model)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "compile authorization model: %v", err)
+	}
+	modelRequest, err := codec.modelRequest()
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "compile openfga model: %v", err)
+	}
+	modelResponse, _, err := p.client.OpenFgaApi.WriteAuthorizationModel(ctx, p.storeID).Body(modelRequest).Execute()
+	if err != nil {
+		return nil, status.Errorf(codes.Unavailable, "openfga write authorization model: %v", err)
+	}
+	codec.model.Id = modelResponse.GetAuthorizationModelId()
+	if err := p.replaceTuples(ctx, codec, req.Relationships); err != nil {
+		return nil, err
+	}
+	ref := &proto.AuthorizationModelRef{Id: req.Model.Id, Version: req.Model.Version, CreatedAt: timestamppb.New(time.Now().UTC())}
+	p.mu.Lock()
+	p.model = cloneModel(req.Model)
+	p.modelRef = ref
+	p.codec = codec
+	p.meta = make(map[string]*proto.Relationship, len(req.Relationships))
+	for _, relationship := range req.Relationships {
+		if relationship != nil && relationship.Tuple != nil {
+			copy := cloneRelationship(relationship)
+			if copy.SourceLayer == proto.SourceLayer_SOURCE_LAYER_UNSPECIFIED {
+				copy.SourceLayer = proto.SourceLayer_SOURCE_LAYER_RUNTIME
+			}
+			p.meta[tupleKey(copy.Tuple)] = copy
+		}
+	}
+	p.mu.Unlock()
+	return &proto.SetAuthorizationStateResponse{ActiveModel: ref}, nil
+}
+
+func (p *openFGA) GetActiveModelRef(context.Context) (*proto.GetActiveModelRefResponse, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if p.modelRef == nil {
+		return nil, status.Error(codes.NotFound, "active authorization model is not set")
+	}
+	return &proto.GetActiveModelRefResponse{Model: cloneModelRef(p.modelRef)}, nil
+}
+
+func (p *openFGA) SetActiveModel(_ context.Context, req *proto.SetActiveModelRequest) (*proto.SetActiveModelResponse, error) {
+	if req == nil || req.Model == nil {
+		return nil, status.Error(codes.InvalidArgument, "model is required")
+	}
+	p.mu.Lock()
+	p.modelRef = &proto.AuthorizationModelRef{Id: req.Model.Id, Version: req.Model.Version, CreatedAt: timestamppb.New(time.Now().UTC())}
+	p.mu.Unlock()
+	return &proto.SetActiveModelResponse{Model: cloneModelRef(p.modelRef)}, nil
+}
+
+func (p *openFGA) ListActiveModelResourceTypes(_ context.Context, req *proto.ListActiveModelResourceTypesRequest) (*proto.ListActiveModelResourceTypesResponse, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if p.model == nil {
+		return nil, status.Error(codes.NotFound, "active authorization model is not set")
+	}
+	name := ""
+	pageSize := 100
+	pageToken := 0
+	if req != nil {
+		if req.Filter != nil {
+			name = strings.TrimSpace(req.Filter.Name)
+		}
+		if req.PageSize > 0 {
+			pageSize = int(req.PageSize)
+		}
+		if req.PageToken != "" {
+			parsed, err := strconv.Atoi(req.PageToken)
+			if err != nil || parsed < 0 {
+				return nil, status.Error(codes.InvalidArgument, "page token is invalid")
+			}
+			pageToken = parsed
+		}
+	}
+	items := make([]*proto.AuthorizationModelResourceType, 0, len(p.model.ResourceTypes))
+	for _, item := range p.model.ResourceTypes {
+		if name == "" || item.GetName() == name {
+			items = append(items, item)
+		}
+	}
+	if pageToken > len(items) {
+		pageToken = len(items)
+	}
+	end := min(pageToken+pageSize, len(items))
+	response := &proto.ListActiveModelResourceTypesResponse{ModelId: p.model.Id}
+	for _, item := range items[pageToken:end] {
+		response.ResourceTypes = append(response.ResourceTypes, cloneResourceType(item))
+	}
+	if end < len(items) {
+		response.NextPageToken = strconv.Itoa(end)
+	}
+	return response, nil
+}
+
+func (p *openFGA) ListRelationships(ctx context.Context, req *proto.ListRelationshipsRequest) (*proto.ListRelationshipsResponse, error) {
+	p.mu.RLock()
+	codec := p.codec
+	model := p.model
+	meta := make(map[string]*proto.Relationship, len(p.meta))
+	for key, value := range p.meta {
+		meta[key] = cloneRelationship(value)
+	}
+	p.mu.RUnlock()
+	if codec == nil || model == nil {
+		if legacy, ok := p.legacyRelationships(req); ok {
+			return &proto.ListRelationshipsResponse{Relationships: legacy}, nil
+		}
+		return nil, status.Error(codes.FailedPrecondition, "openfga authorization model is not configured")
+	}
+	filter := (*proto.RelationshipFilter)(nil)
+	pageSize := 100
+	pageToken := 0
+	if req != nil {
+		filter = req.Filter
+		if req.PageSize < 0 {
+			return nil, status.Error(codes.InvalidArgument, "page size must be non-negative")
+		}
+		if req.PageSize > 0 {
+			pageSize = int(req.PageSize)
+		}
+		if req.PageToken != "" {
+			parsed, err := strconv.Atoi(req.PageToken)
+			if err != nil || parsed < 0 {
+				return nil, status.Error(codes.InvalidArgument, "page token is invalid")
+			}
+			pageToken = parsed
+		}
+	}
+	tuples, err := p.readAllTuples(ctx, codec.readFilter(filter))
+	if err != nil {
+		return nil, err
+	}
+	items := make([]*proto.Relationship, 0, len(tuples))
+	for _, tuple := range tuples {
+		relationship, err := codec.relationshipFromTuple(tuple.Key, model, meta)
+		if err != nil || !relationshipMatches(filter, relationship) {
+			continue
+		}
+		items = append(items, relationship)
+	}
+	sort.Slice(items, func(i, j int) bool { return tupleKey(items[i].Tuple) < tupleKey(items[j].Tuple) })
+	if pageToken > len(items) {
+		pageToken = len(items)
+	}
+	end := min(pageToken+pageSize, len(items))
+	out := &proto.ListRelationshipsResponse{}
+	for _, item := range items[pageToken:end] {
+		out.Relationships = append(out.Relationships, item)
+	}
+	if end < len(items) {
+		out.NextPageToken = strconv.Itoa(end)
+	}
+	return out, nil
+}
+
+func (p *openFGA) legacyRelationships(req *proto.ListRelationshipsRequest) ([]*proto.Relationship, bool) {
+	p.mu.RLock()
+	loaded := p.legacy != nil
+	legacy := make([]*proto.Relationship, 0, len(p.legacy))
+	for _, relationship := range p.legacy {
+		if relationshipMatches(req.GetFilter(), relationship) {
+			legacy = append(legacy, cloneRelationship(relationship))
+		}
+	}
+	p.mu.RUnlock()
+	if !loaded {
+		return nil, false
+	}
+	sort.Slice(legacy, func(i, j int) bool { return tupleKey(legacy[i].Tuple) < tupleKey(legacy[j].Tuple) })
+	return legacy, true
+}
+
+func (p *openFGA) syncLegacyRelationships(ctx context.Context) error {
+	p.mu.RLock()
+	db := p.legacyDB
+	codec := p.codec
+	model := p.model
+	legacy := append([]*proto.Relationship(nil), p.legacy...)
+	p.mu.RUnlock()
+	if db == nil || codec == nil || model == nil {
+		return nil
+	}
+	latest, err := loadLegacyRelationships(ctx, db)
+	if err != nil {
+		return err
+	}
+	if len(latest) == 0 {
+		latest = legacy
+	}
+	for _, relationship := range latest {
+		if relationship == nil || relationship.Tuple == nil {
+			continue
+		}
+		key, err := codec.relationshipTuple(relationship.Tuple)
+		if err != nil {
+			continue
+		}
+		duplicate := "ignore"
+		body := openfga.WriteRequest{Writes: openfga.NewWriteRequestWrites([]openfga.TupleKey{key}), AuthorizationModelId: stringPtr(codec.model.Id)}
+		body.Writes.OnDuplicate = &duplicate
+		if _, _, err := p.client.OpenFgaApi.Write(ctx, p.storeID).Body(body).Execute(); err != nil {
+			return status.Errorf(codes.Unavailable, "openfga legacy relationship sync: %v", err)
+		}
+		p.mu.Lock()
+		p.meta[tupleKey(relationship.Tuple)] = cloneRelationship(relationship)
+		p.mu.Unlock()
+	}
+	p.mu.Lock()
+	p.legacy = latest
+	p.mu.Unlock()
+	return nil
+}
+
+func (p *openFGA) readAllTuples(ctx context.Context, filter *openfga.ReadRequestTupleKey) ([]openfga.Tuple, error) {
+	var tuples []openfga.Tuple
+	continuation := ""
+	for {
+		request := openfga.ReadRequest{PageSize: int32Ptr(100)}
+		if filter != nil {
+			request.TupleKey = filter
+		}
+		if continuation != "" {
+			request.ContinuationToken = stringPtr(continuation)
+		}
+		response, _, err := p.client.OpenFgaApi.Read(ctx, p.storeID).Body(request).Execute()
+		if err != nil {
+			return nil, status.Errorf(codes.Unavailable, "openfga read relationships: %v", err)
+		}
+		tuples = append(tuples, response.GetTuples()...)
+		continuation = response.GetContinuationToken()
+		if continuation == "" {
+			return tuples, nil
+		}
+	}
+}
+
+func (p *openFGA) replaceTuples(ctx context.Context, codec *fgaCodec, relationships []*proto.Relationship) error {
+	desired := make(map[string]openfga.TupleKey, len(relationships))
+	for _, relationship := range relationships {
+		if relationship == nil || relationship.Tuple == nil {
+			continue
+		}
+		key, err := codec.relationshipTuple(relationship.Tuple)
+		if err != nil {
+			return status.Errorf(codes.InvalidArgument, "relationship: %v", err)
+		}
+		desired[key.User+"\x00"+key.Relation+"\x00"+key.Object] = key
+	}
+	readTuples, err := p.readAllTuples(ctx, nil)
+	if err != nil {
+		return err
+	}
+	var deletes []openfga.TupleKeyWithoutCondition
+	for _, tuple := range readTuples {
+		key := tuple.Key.User + "\x00" + tuple.Key.Relation + "\x00" + tuple.Key.Object
+		if _, ok := desired[key]; !ok {
+			deletes = append(deletes, openfga.TupleKeyWithoutCondition{User: tuple.Key.User, Relation: tuple.Key.Relation, Object: tuple.Key.Object})
+		}
+	}
+	keys := make([]openfga.TupleKey, 0, len(desired))
+	for _, key := range desired {
+		keys = append(keys, key)
+	}
+	for start := 0; start < len(keys) || start < len(deletes); start += 100 {
+		endWrites := min(start+100, len(keys))
+		endDeletes := min(start+100, len(deletes))
+		body := openfga.WriteRequest{AuthorizationModelId: stringPtr(codec.model.Id)}
+		if start < len(keys) {
+			duplicate := "ignore"
+			body.Writes = openfga.NewWriteRequestWrites(keys[start:endWrites])
+			body.Writes.OnDuplicate = &duplicate
+		}
+		if start < len(deletes) {
+			missing := "ignore"
+			body.Deletes = openfga.NewWriteRequestDeletes(deletes[start:endDeletes])
+			body.Deletes.OnMissing = &missing
+		}
+		if _, _, err := p.client.OpenFgaApi.Write(ctx, p.storeID).Body(body).Execute(); err != nil {
+			return status.Errorf(codes.Unavailable, "openfga replace relationships: %v", err)
+		}
+	}
+	return nil
+}
+
+func newFGACodec(model *proto.AuthorizationModel) (*fgaCodec, error) {
+	codec := &fgaCodec{model: cloneModel(model), types: map[string]string{}, relations: map[string]string{}, permissions: map[string]string{}, reverse: map[string]string{}}
+	for _, resourceType := range model.GetResourceTypes() {
+		if resourceType == nil || strings.TrimSpace(resourceType.Name) == "" {
+			continue
+		}
+		encoded := stableFGAName("t_", resourceType.Name)
+		if previous := codec.reverse[encoded]; previous != "" && previous != resourceType.Name {
+			return nil, fmt.Errorf("type encoding collision between %q and %q", previous, resourceType.Name)
+		}
+		codec.types[resourceType.Name] = encoded
+		codec.reverse[encoded] = resourceType.Name
+		if strings.TrimSpace(resourceType.DefaultRole) != "" {
+			codec.addType("subject")
+		}
+		for _, relation := range resourceType.Relations {
+			if relation == nil {
+				continue
+			}
+			for _, allowed := range relation.AllowedTargets {
+				if allowed == nil {
+					continue
+				}
+				switch {
+				case allowed.GetSubjectType() != "":
+					codec.addType(allowed.GetSubjectType())
+				case allowed.GetResourceType() != "":
+					codec.addType(allowed.GetResourceType())
+				case allowed.GetSubjectSetType() != nil:
+					codec.addType(allowed.GetSubjectSetType().ResourceType)
+				}
+			}
+			codec.relations[resourceType.Name+"\x00"+relation.Name] = stableFGAName("r_", resourceType.Name+"\x00"+relation.Name)
+		}
+		for _, action := range resourceType.Actions {
+			if action == nil {
+				continue
+			}
+			codec.permissions[resourceType.Name+"\x00"+action.Name] = stableFGAName("p_", resourceType.Name+"\x00"+action.Name)
+		}
+	}
+	return codec, nil
+}
+
+func (c *fgaCodec) addType(logical string) {
+	logical = strings.TrimSpace(logical)
+	if logical == "" || c.types[logical] != "" {
+		return
+	}
+	encoded := stableFGAName("t_", logical)
+	c.types[logical] = encoded
+	c.reverse[encoded] = logical
+}
+
+func (c *fgaCodec) modelRequest() (openfga.WriteAuthorizationModelRequest, error) {
+	definitions := make([]openfga.TypeDefinition, 0, len(c.types))
+	defined := make(map[string]struct{}, len(c.model.ResourceTypes))
+	for _, resourceType := range c.model.ResourceTypes {
+		if resourceType == nil {
+			continue
+		}
+		relations := map[string]openfga.Userset{}
+		metadata := map[string]openfga.RelationMetadata{}
+		for _, relation := range resourceType.Relations {
+			if relation == nil {
+				continue
+			}
+			refs := make([]openfga.RelationReference, 0, len(relation.AllowedTargets)+1)
+			for _, target := range relation.AllowedTargets {
+				if target == nil {
+					continue
+				}
+				switch {
+				case target.GetSubjectType() != "":
+					refs = append(refs, openfga.RelationReference{Type: c.types[target.GetSubjectType()]})
+				case target.GetResourceType() != "":
+					refs = append(refs, openfga.RelationReference{Type: c.types[target.GetResourceType()]})
+				case target.GetSubjectSetType() != nil:
+					set := target.GetSubjectSetType()
+					relationName := c.relations[set.ResourceType+"\x00"+set.Relation]
+					refs = append(refs, openfga.RelationReference{Type: c.types[set.ResourceType], Relation: stringPtr(relationName)})
+				}
+			}
+			if strings.TrimSpace(resourceType.DefaultRole) == strings.TrimSpace(relation.Name) {
+				refs = append(refs, openfga.RelationReference{Type: c.types["subject"], Wildcard: &map[string]interface{}{}})
+			}
+			direct := map[string]interface{}{}
+			relations[c.relations[resourceType.Name+"\x00"+relation.Name]] = openfga.Userset{This: &direct}
+			metadata[c.relations[resourceType.Name+"\x00"+relation.Name]] = openfga.RelationMetadata{DirectlyRelatedUserTypes: &refs}
+		}
+		for _, action := range resourceType.Actions {
+			if action == nil {
+				continue
+			}
+			children := make([]openfga.Userset, 0, len(action.Relations))
+			for _, relation := range action.Relations {
+				role := c.relations[resourceType.Name+"\x00"+relation]
+				if role == "" {
+					continue
+				}
+				object := c.types[resourceType.Name]
+				children = append(children, openfga.Userset{ComputedUserset: &openfga.ObjectRelation{Object: &object, Relation: &role}})
+			}
+			if len(children) == 1 {
+				relations[c.permissions[resourceType.Name+"\x00"+action.Name]] = children[0]
+			} else if len(children) > 1 {
+				relations[c.permissions[resourceType.Name+"\x00"+action.Name]] = openfga.Userset{Union: &openfga.Usersets{Child: children}}
+			}
+		}
+		typeName := c.types[resourceType.Name]
+		definitions = append(definitions, openfga.TypeDefinition{Type: typeName, Relations: &relations, Metadata: &openfga.Metadata{Relations: &metadata}})
+		defined[resourceType.Name] = struct{}{}
+	}
+	logicalTypes := make([]string, 0, len(c.types))
+	for logical := range c.types {
+		if _, ok := defined[logical]; !ok {
+			logicalTypes = append(logicalTypes, logical)
+		}
+	}
+	sort.Strings(logicalTypes)
+	for _, logical := range logicalTypes {
+		relations := map[string]openfga.Userset{}
+		definitions = append(definitions, openfga.TypeDefinition{Type: c.types[logical], Relations: &relations})
+	}
+	return openfga.WriteAuthorizationModelRequest{TypeDefinitions: definitions, SchemaVersion: "1.1"}, nil
+}
+
+func (c *fgaCodec) relationshipTuple(tuple *proto.RelationshipTuple) (openfga.TupleKey, error) {
+	if tuple == nil || tuple.Resource == nil || tuple.Target == nil {
+		return openfga.TupleKey{}, fmt.Errorf("resource and target are required")
+	}
+	objectType := c.types[tuple.Resource.Type]
+	role := c.relations[tuple.Resource.Type+"\x00"+tuple.Relation]
+	if objectType == "" || role == "" {
+		return openfga.TupleKey{}, fmt.Errorf("unknown resource type or relation")
+	}
+	user, err := c.targetUser(tuple.Target)
+	if err != nil {
+		return openfga.TupleKey{}, err
+	}
+	return openfga.TupleKey{User: user, Relation: role, Object: objectType + ":" + tuple.Resource.Id}, nil
+}
+
+func (c *fgaCodec) checkTuple(subject *proto.Subject, permission string, resource *proto.Resource) (openfga.TupleKey, error) {
+	if subject == nil || resource == nil {
+		return openfga.TupleKey{}, fmt.Errorf("subject and resource are required")
+	}
+	objectType := c.types[resource.Type]
+	if objectType == "" {
+		return openfga.TupleKey{}, fmt.Errorf("unknown resource type %q", resource.Type)
+	}
+	return openfga.TupleKey{User: c.subjectUser(subject), Relation: permission, Object: objectType + ":" + resource.Id}, nil
+}
+
+func (c *fgaCodec) targetUser(target *proto.RelationshipTarget) (string, error) {
+	if subject := target.GetSubject(); subject != nil {
+		return c.subjectUser(subject), nil
+	}
+	if resource := target.GetResource(); resource != nil {
+		typeName := c.types[resource.Type]
+		if typeName == "" {
+			return "", fmt.Errorf("unknown target resource type %q", resource.Type)
+		}
+		return typeName + ":" + resource.Id, nil
+	}
+	if set := target.GetSubjectSet(); set != nil && set.Resource != nil {
+		typeName := c.types[set.Resource.Type]
+		relation := c.relations[set.Resource.Type+"\x00"+set.Relation]
+		if typeName == "" || relation == "" {
+			return "", fmt.Errorf("unknown subject set resource type or relation")
+		}
+		return typeName + ":" + set.Resource.Id + "#" + relation, nil
+	}
+	return "", fmt.Errorf("relationship target is required")
+}
+
+func (c *fgaCodec) subjectUser(subject *proto.Subject) string {
+	return c.types[subject.Type] + ":" + subject.Id
+}
+
+func (c *fgaCodec) subjectWildcard(subjectType string) string {
+	return c.types[subjectType] + ":*"
+}
+
+func (c *fgaCodec) readFilter(filter *proto.RelationshipFilter) *openfga.ReadRequestTupleKey {
+	if filter == nil {
+		return nil
+	}
+	key := &openfga.ReadRequestTupleKey{}
+	if filter.Resource != nil {
+		if objectType := c.types[filter.Resource.Type]; objectType != "" {
+			value := objectType + ":" + filter.Resource.Id
+			key.Object = &value
+		}
+	}
+	// OpenFGA's Read API only accepts exact object IDs, not a type prefix.
+	// Leave resource-type-only filtering unbounded and apply it locally after
+	// reading the tuples.
+	if filter.Relation != "" {
+		if relation := c.relationsForFilter(filter); relation != "" {
+			key.Relation = &relation
+		}
+	}
+	return key
+}
+
+func (c *fgaCodec) relationsForFilter(filter *proto.RelationshipFilter) string {
+	if filter.Resource == nil {
+		return ""
+	}
+	return c.relations[filter.Resource.Type+"\x00"+filter.Relation]
+}
+
+func (c *fgaCodec) relationshipFromTuple(key openfga.TupleKey, model *proto.AuthorizationModel, meta map[string]*proto.Relationship) (*proto.Relationship, error) {
+	objectType, objectID, ok := splitFGAObject(key.Object)
+	if !ok {
+		return nil, fmt.Errorf("invalid object %q", key.Object)
+	}
+	resourceType := c.reverse[objectType]
+	relation := c.logicalRelation(resourceType, key.Relation)
+	if resourceType == "" || relation == "" {
+		return nil, fmt.Errorf("unknown encoded tuple")
+	}
+	target, err := c.targetFromUser(key.User, resourceType, relation, model)
+	if err != nil {
+		return nil, err
+	}
+	tuple := &proto.RelationshipTuple{Resource: &proto.Resource{Type: resourceType, Id: objectID}, Relation: relation, Target: target}
+	if existing := meta[tupleKey(tuple)]; existing != nil {
+		return cloneRelationship(existing), nil
+	}
+	return &proto.Relationship{Tuple: tuple, SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME}, nil
+}
+
+func (c *fgaCodec) logicalRelation(resourceType, encoded string) string {
+	for key, value := range c.relations {
+		if strings.HasPrefix(key, resourceType+"\x00") && value == encoded {
+			return strings.TrimPrefix(key, resourceType+"\x00")
+		}
+	}
+	return ""
+}
+
+func (c *fgaCodec) targetFromUser(user, resourceType, relation string, model *proto.AuthorizationModel) (*proto.RelationshipTarget, error) {
+	if strings.Contains(user, "#") {
+		parts := strings.SplitN(user, "#", 2)
+		setType, setID, ok := splitFGAObject(parts[0])
+		if !ok {
+			return nil, fmt.Errorf("invalid subject set %q", user)
+		}
+		return &proto.RelationshipTarget{Kind: &proto.RelationshipTarget_SubjectSet{SubjectSet: &proto.SubjectSet{Resource: &proto.Resource{Type: c.reverse[setType], Id: setID}, Relation: c.logicalRelation(c.reverse[setType], parts[1])}}}, nil
+	}
+	typeName, id, ok := splitFGAObject(user)
+	if !ok {
+		return nil, fmt.Errorf("invalid target %q", user)
+	}
+	logicalType := c.reverse[typeName]
+	if targetLooksLikeResource(model, resourceType, relation, logicalType) {
+		return &proto.RelationshipTarget{Kind: &proto.RelationshipTarget_Resource{Resource: &proto.Resource{Type: logicalType, Id: id}}}, nil
+	}
+	return &proto.RelationshipTarget{Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{Type: logicalType, Id: id}}}, nil
+}
+
+func stableFGAName(prefix, value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return prefix + hex.EncodeToString(sum[:])[:26]
+}
+
+type legacyRelationship struct {
+	Tuple       *legacyRelationshipTuple `json:"tuple"`
+	Properties  map[string]any           `json:"properties,omitempty"`
+	SourceLayer json.RawMessage          `json:"source_layer"`
+}
+
+type legacyRelationshipTuple struct {
+	Target   *legacyRelationshipTarget `json:"target"`
+	Relation string                    `json:"relation"`
+	Resource *legacyEntity             `json:"resource"`
+}
+
+type legacyRelationshipTarget struct {
+	Subject    *legacyEntity     `json:"subject,omitempty"`
+	Resource   *legacyEntity     `json:"resource,omitempty"`
+	SubjectSet *legacySubjectSet `json:"subject_set,omitempty"`
+}
+
+type legacySubjectSet struct {
+	Resource *legacyEntity `json:"resource"`
+	Relation string        `json:"relation"`
+}
+
+type legacyEntity struct {
+	Type       string         `json:"type"`
+	ID         string         `json:"id"`
+	Properties map[string]any `json:"properties,omitempty"`
+}
+
+func loadLegacyRelationships(ctx context.Context, db indexeddb.Database) ([]*proto.Relationship, error) {
+	if db == nil {
+		return nil, nil
+	}
+	records, err := db.ObjectStore("authz_relationships").GetAll(ctx, nil)
+	if err != nil {
+		return nil, nil
+	}
+	relationships := make([]*proto.Relationship, 0, len(records))
+	for _, record := range records {
+		data, err := json.Marshal(record["value"])
+		if err != nil {
+			return nil, fmt.Errorf("decode legacy relationship: %w", err)
+		}
+		var stored legacyRelationship
+		if err := json.Unmarshal(data, &stored); err != nil {
+			return nil, fmt.Errorf("decode legacy relationship: %w", err)
+		}
+		relationship, err := legacyRelationshipToProto(&stored)
+		if err != nil {
+			return nil, err
+		}
+		relationships = append(relationships, relationship)
+	}
+	return relationships, nil
+}
+
+func legacyRelationshipToProto(stored *legacyRelationship) (*proto.Relationship, error) {
+	if stored == nil || stored.Tuple == nil || stored.Tuple.Resource == nil || stored.Tuple.Target == nil {
+		return nil, fmt.Errorf("legacy relationship is incomplete")
+	}
+	target := &proto.RelationshipTarget{}
+	switch {
+	case stored.Tuple.Target.Subject != nil:
+		entity := stored.Tuple.Target.Subject
+		target.Kind = &proto.RelationshipTarget_Subject{Subject: &proto.Subject{Type: entity.Type, Id: entity.ID, Properties: legacyProperties(entity.Properties)}}
+	case stored.Tuple.Target.Resource != nil:
+		entity := stored.Tuple.Target.Resource
+		target.Kind = &proto.RelationshipTarget_Resource{Resource: &proto.Resource{Type: entity.Type, Id: entity.ID, Properties: legacyProperties(entity.Properties)}}
+	case stored.Tuple.Target.SubjectSet != nil && stored.Tuple.Target.SubjectSet.Resource != nil:
+		entity := stored.Tuple.Target.SubjectSet.Resource
+		target.Kind = &proto.RelationshipTarget_SubjectSet{SubjectSet: &proto.SubjectSet{Resource: &proto.Resource{Type: entity.Type, Id: entity.ID, Properties: legacyProperties(entity.Properties)}, Relation: stored.Tuple.Target.SubjectSet.Relation}}
+	default:
+		return nil, fmt.Errorf("legacy relationship target is incomplete")
+	}
+	resource := stored.Tuple.Resource
+	return &proto.Relationship{
+		Tuple:       &proto.RelationshipTuple{Target: target, Relation: stored.Tuple.Relation, Resource: &proto.Resource{Type: resource.Type, Id: resource.ID, Properties: legacyProperties(resource.Properties)}},
+		Properties:  legacyProperties(stored.Properties),
+		SourceLayer: legacySourceLayer(stored.SourceLayer),
+	}, nil
+}
+
+func legacyProperties(properties map[string]any) *structpb.Struct {
+	if len(properties) == 0 {
+		return nil
+	}
+	value, err := structpb.NewStruct(properties)
+	if err != nil {
+		return nil
+	}
+	return value
+}
+
+func legacySourceLayer(raw json.RawMessage) proto.SourceLayer {
+	var value string
+	if json.Unmarshal(raw, &value) == nil {
+		switch strings.TrimSpace(value) {
+		case "static_config", "staticconfig":
+			return proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG
+		case "runtime":
+			return proto.SourceLayer_SOURCE_LAYER_RUNTIME
+		}
+	}
+	var number int32
+	if json.Unmarshal(raw, &number) == nil {
+		return proto.SourceLayer(number)
+	}
+	return proto.SourceLayer_SOURCE_LAYER_UNSPECIFIED
+}
+
+func splitFGAObject(value string) (string, string, bool) {
+	parts := strings.SplitN(value, ":", 2)
+	if len(parts) != 2 {
+		return "", "", false
+	}
+	return parts[0], parts[1], parts[0] != "" && parts[1] != ""
+}
+
+func tupleKey(tuple *proto.RelationshipTuple) string {
+	if tuple == nil || tuple.Resource == nil || tuple.Target == nil {
+		return ""
+	}
+	target := ""
+	if subject := tuple.Target.GetSubject(); subject != nil {
+		target = "subject:" + subject.Type + ":" + subject.Id
+	} else if resource := tuple.Target.GetResource(); resource != nil {
+		target = "resource:" + resource.Type + ":" + resource.Id
+	} else if set := tuple.Target.GetSubjectSet(); set != nil && set.Resource != nil {
+		target = "set:" + set.Resource.Type + ":" + set.Resource.Id + "#" + set.Relation
+	}
+	return tuple.Resource.Type + "\x00" + tuple.Resource.Id + "\x00" + tuple.Relation + "\x00" + target
+}
+
+func relationshipMatches(filter *proto.RelationshipFilter, relationship *proto.Relationship) bool {
+	if filter == nil || relationship == nil || relationship.Tuple == nil {
+		return relationship != nil
+	}
+	tuple := relationship.Tuple
+	if filter.Target != nil && !gproto.Equal(filter.Target, tuple.Target) {
+		return false
+	}
+	if filter.Relation != "" && filter.Relation != tuple.Relation {
+		return false
+	}
+	if filter.ResourceType != "" && (tuple.Resource == nil || filter.ResourceType != tuple.Resource.Type) {
+		return false
+	}
+	if filter.Resource != nil && (tuple.Resource == nil || filter.Resource.Type != tuple.Resource.Type || filter.Resource.Id != tuple.Resource.Id) {
+		return false
+	}
+	if filter.SourceLayer != proto.SourceLayer_SOURCE_LAYER_UNSPECIFIED && relationship.SourceLayer != filter.SourceLayer {
+		return false
+	}
+	if filter.TargetType != proto.RelationshipTargetType_RELATIONSHIP_TARGET_TYPE_UNSPECIFIED {
+		if targetType(relationship.Tuple.Target) != filter.TargetType {
+			return false
+		}
+	}
+	if filter.TargetEntityType != "" && targetEntityType(relationship.Tuple.Target) != filter.TargetEntityType {
+		return false
+	}
+	return true
+}
+
+func targetLooksLikeResource(model *proto.AuthorizationModel, resourceType, relation, targetType string) bool {
+	for _, item := range model.ResourceTypes {
+		if item == nil || item.Name != resourceType {
+			continue
+		}
+		for _, rel := range item.Relations {
+			if rel == nil || rel.Name != relation {
+				continue
+			}
+			for _, allowed := range rel.AllowedTargets {
+				if allowed.GetResourceType() == targetType {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func targetType(target *proto.RelationshipTarget) proto.RelationshipTargetType {
+	switch {
+	case target.GetSubject() != nil:
+		return proto.RelationshipTargetType_RELATIONSHIP_TARGET_TYPE_SUBJECT
+	case target.GetResource() != nil:
+		return proto.RelationshipTargetType_RELATIONSHIP_TARGET_TYPE_RESOURCE
+	case target.GetSubjectSet() != nil:
+		return proto.RelationshipTargetType_RELATIONSHIP_TARGET_TYPE_SUBJECT_SET
+	default:
+		return proto.RelationshipTargetType_RELATIONSHIP_TARGET_TYPE_UNSPECIFIED
+	}
+}
+
+func targetEntityType(target *proto.RelationshipTarget) string {
+	if target.GetSubject() != nil {
+		return target.GetSubject().Type
+	}
+	if target.GetResource() != nil {
+		return target.GetResource().Type
+	}
+	if target.GetSubjectSet() != nil && target.GetSubjectSet().Resource != nil {
+		return target.GetSubjectSet().Resource.Type
+	}
+	return ""
+}
+
+func subjectScope(subject *proto.Subject) string {
+	if subject == nil || subject.Properties == nil {
+		return ""
+	}
+	value, ok := subject.Properties.Fields["scope"]
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(value.GetStringValue())
+}
+
+func scopeAllows(scope, providerName, operationName string) bool {
+	for _, token := range strings.Fields(scope) {
+		if token == providerName || token == providerName+":"+operationName {
+			return true
+		}
+	}
+	return false
+}
+
+func findResourceType(model *proto.AuthorizationModel, name string) *proto.AuthorizationModelResourceType {
+	for _, resourceType := range model.ResourceTypes {
+		if resourceType != nil && resourceType.Name == name {
+			return resourceType
+		}
+	}
+	return nil
+}
+
+func findAction(resourceType *proto.AuthorizationModelResourceType, name string) *proto.ModelAction {
+	for _, action := range resourceType.Actions {
+		if action != nil && action.Name == name {
+			return action
+		}
+	}
+	return nil
+}
+
+func contains(values []string, value string) bool {
+	for _, item := range values {
+		if item == value {
+			return true
+		}
+	}
+	return false
+}
+
+func cloneRelationship(in *proto.Relationship) *proto.Relationship {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	if in.Tuple != nil {
+		tuple := *in.Tuple
+		out.Tuple = &tuple
+	}
+	return &out
+}
+
+func cloneModel(in *proto.AuthorizationModel) *proto.AuthorizationModel {
+	if in == nil {
+		return nil
+	}
+	model := *in
+	model.ResourceTypes = append([]*proto.AuthorizationModelResourceType(nil), in.ResourceTypes...)
+	return &model
+}
+
+func cloneModelRef(in *proto.AuthorizationModelRef) *proto.AuthorizationModelRef {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	if in.CreatedAt != nil {
+		out.CreatedAt = timestamppb.New(in.CreatedAt.AsTime())
+	}
+	return &out
+}
+
+func cloneResourceType(in *proto.AuthorizationModelResourceType) *proto.AuthorizationModelResourceType {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
+}
+
+func stringPtr(value string) *string { return &value }
+func int32Ptr(value int32) *int32    { return &value }
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// Ensure the compatibility implementation keeps the existing provider contract.
+var _ core.AuthorizationProvider = (*openFGA)(nil)

--- a/gestaltd/services/authorization/openfga.go
+++ b/gestaltd/services/authorization/openfga.go
@@ -289,7 +289,11 @@ func (p *openFGA) setAuthorizationState(ctx context.Context, req *proto.SetAutho
 	p.model = cloneModel(req.Model)
 	p.modelRef = ref
 	p.codec = codec
-	p.meta = make(map[string]*proto.Relationship, len(req.Relationships))
+	if replace {
+		p.meta = make(map[string]*proto.Relationship, len(req.Relationships))
+	} else if p.meta == nil {
+		p.meta = make(map[string]*proto.Relationship)
+	}
 	for _, relationship := range req.Relationships {
 		if relationship != nil && relationship.Tuple != nil {
 			copy := cloneRelationship(relationship)

--- a/gestaltd/services/authorization/openfga.go
+++ b/gestaltd/services/authorization/openfga.go
@@ -1064,21 +1064,14 @@ func cloneRelationship(in *proto.Relationship) *proto.Relationship {
 	if in == nil {
 		return nil
 	}
-	out := *in
-	if in.Tuple != nil {
-		tuple := *in.Tuple
-		out.Tuple = &tuple
-	}
-	return &out
+	return gproto.Clone(in).(*proto.Relationship)
 }
 
 func cloneModel(in *proto.AuthorizationModel) *proto.AuthorizationModel {
 	if in == nil {
 		return nil
 	}
-	model := *in
-	model.ResourceTypes = append([]*proto.AuthorizationModelResourceType(nil), in.ResourceTypes...)
-	return &model
+	return gproto.Clone(in).(*proto.AuthorizationModel)
 }
 
 func cloneModelRef(in *proto.AuthorizationModelRef) *proto.AuthorizationModelRef {
@@ -1096,8 +1089,7 @@ func cloneResourceType(in *proto.AuthorizationModelResourceType) *proto.Authoriz
 	if in == nil {
 		return nil
 	}
-	out := *in
-	return &out
+	return gproto.Clone(in).(*proto.AuthorizationModelResourceType)
 }
 
 func stringPtr(value string) *string { return &value }

--- a/gestaltd/services/authorization/openfga.go
+++ b/gestaltd/services/authorization/openfga.go
@@ -125,7 +125,7 @@ func (p *openFGA) CheckAccess(ctx context.Context, req *proto.CheckAccessRequest
 	if model == nil || codec == nil {
 		return nil, status.Error(codes.FailedPrecondition, "openfga authorization model is not configured")
 	}
-	if scope := subjectScope(req.Subject); scope != "" && !scopeAllows(scope, req.Resource.Type, req.Action.Name) {
+	if scope := subjectScope(req.Subject); scope != "" && !scopeAllows(scope, req.Resource.Id, req.Action.Name) {
 		return &proto.CheckAccessResponse{Allowed: false, ModelId: modelID}, nil
 	}
 	resourceType := findResourceType(model, req.Resource.Type)
@@ -312,22 +312,15 @@ func (p *openFGA) GetActiveModelRef(context.Context) (*proto.GetActiveModelRefRe
 	return &proto.GetActiveModelRefResponse{Model: cloneModelRef(p.modelRef)}, nil
 }
 
-func (p *openFGA) SetActiveModel(_ context.Context, req *proto.SetActiveModelRequest) (*proto.SetActiveModelResponse, error) {
+func (p *openFGA) SetActiveModel(ctx context.Context, req *proto.SetActiveModelRequest) (*proto.SetActiveModelResponse, error) {
 	if req == nil || req.Model == nil {
 		return nil, status.Error(codes.InvalidArgument, "model is required")
 	}
-	codec, err := newFGACodec(req.Model)
+	state, err := p.setAuthorizationState(ctx, &proto.SetAuthorizationStateRequest{Model: req.Model}, false)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "model: %v", err)
+		return nil, err
 	}
-	model := cloneModel(req.Model)
-	ref := &proto.AuthorizationModelRef{Id: model.Id, Version: model.Version, CreatedAt: timestamppb.New(time.Now().UTC())}
-	p.mu.Lock()
-	p.model = model
-	p.modelRef = ref
-	p.codec = codec
-	p.mu.Unlock()
-	return &proto.SetActiveModelResponse{Model: cloneModelRef(ref)}, nil
+	return &proto.SetActiveModelResponse{Model: cloneModelRef(state.ActiveModel)}, nil
 }
 
 func (p *openFGA) ListActiveModelResourceTypes(_ context.Context, req *proto.ListActiveModelResourceTypesRequest) (*proto.ListActiveModelResourceTypesResponse, error) {

--- a/gestaltd/services/authorization/openfga.go
+++ b/gestaltd/services/authorization/openfga.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"sort"
 	"strconv"
@@ -14,13 +13,11 @@ import (
 
 	openfga "github.com/openfga/go-sdk"
 	"github.com/openfga/go-sdk/credentials"
-	indexeddb "github.com/valon-technologies/gestalt/sdk/go/indexeddb"
 	"github.com/valon-technologies/gestalt/server/core"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	gproto "google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"gopkg.in/yaml.v3"
 )
@@ -47,7 +44,6 @@ type openFGA struct {
 	modelRef *proto.AuthorizationModelRef
 	codec    *fgaCodec
 	meta     map[string]*proto.Relationship
-	legacy   []*proto.Relationship
 }
 
 type fgaCodec struct {
@@ -58,7 +54,7 @@ type fgaCodec struct {
 	reverse     map[string]string
 }
 
-func NewOpenFGA(node yaml.Node, databases ...indexeddb.Database) (core.AuthorizationProvider, error) {
+func NewOpenFGA(node yaml.Node) (core.AuthorizationProvider, error) {
 	var cfg OpenFGAConfig
 	if err := node.Decode(&cfg); err != nil {
 		return nil, fmt.Errorf("openfga authorization: decode config: %w", err)
@@ -91,15 +87,11 @@ func NewOpenFGA(node yaml.Node, databases ...indexeddb.Database) (core.Authoriza
 	if err != nil {
 		return nil, fmt.Errorf("openfga authorization: client config: %w", err)
 	}
-	provider := &openFGA{
+	return &openFGA{
 		client:  openfga.NewAPIClient(apiCfg),
 		storeID: strings.TrimSpace(cfg.StoreID),
 		meta:    make(map[string]*proto.Relationship),
-	}
-	if len(databases) > 0 && databases[0] != nil {
-		provider.legacy, _ = loadLegacyRelationships(context.Background(), databases[0])
-	}
-	return provider, nil
+	}, nil
 }
 
 func (p *openFGA) Ping(ctx context.Context) error {
@@ -240,6 +232,22 @@ func (p *openFGA) DeleteRelationship(ctx context.Context, req *proto.DeleteRelat
 }
 
 func (p *openFGA) SetAuthorizationState(ctx context.Context, req *proto.SetAuthorizationStateRequest) (*proto.SetAuthorizationStateResponse, error) {
+	return p.setAuthorizationState(ctx, req, true)
+}
+
+// BootstrapAuthorizationState publishes the configured authorization model and
+// ensures its static relationships exist without reconciling the OpenFGA tuple
+// store. OpenFGA is authoritative for runtime relationships after cutover, so
+// startup must never delete or recreate them from another backend.
+func (p *openFGA) BootstrapAuthorizationState(ctx context.Context, model *proto.AuthorizationModel, relationships []*proto.Relationship) error {
+	_, err := p.setAuthorizationState(ctx, &proto.SetAuthorizationStateRequest{
+		Model:         model,
+		Relationships: relationships,
+	}, false)
+	return err
+}
+
+func (p *openFGA) setAuthorizationState(ctx context.Context, req *proto.SetAuthorizationStateRequest, replace bool) (*proto.SetAuthorizationStateResponse, error) {
 	if req == nil || req.Model == nil {
 		return nil, status.Error(codes.InvalidArgument, "model is required")
 	}
@@ -256,7 +264,7 @@ func (p *openFGA) SetAuthorizationState(ctx context.Context, req *proto.SetAutho
 		return nil, status.Errorf(codes.Unavailable, "openfga write authorization model: %v", err)
 	}
 	codec.model.Id = modelResponse.GetAuthorizationModelId()
-	if err := p.replaceTuples(ctx, codec, req.Relationships); err != nil {
+	if err := p.writeAuthorizationRelationships(ctx, codec, req.Relationships, replace); err != nil {
 		return nil, err
 	}
 	ref := &proto.AuthorizationModelRef{Id: req.Model.Id, Version: req.Model.Version, CreatedAt: timestamppb.New(time.Now().UTC())}
@@ -264,10 +272,6 @@ func (p *openFGA) SetAuthorizationState(ctx context.Context, req *proto.SetAutho
 	p.model = cloneModel(req.Model)
 	p.modelRef = ref
 	p.codec = codec
-	// The legacy store is only a bootstrap input. Once the OpenFGA state is
-	// active, retaining it would allow a later fallback to resurrect deleted
-	// relationships.
-	p.legacy = nil
 	p.meta = make(map[string]*proto.Relationship, len(req.Relationships))
 	for _, relationship := range req.Relationships {
 		if relationship != nil && relationship.Tuple != nil {
@@ -355,9 +359,6 @@ func (p *openFGA) ListRelationships(ctx context.Context, req *proto.ListRelation
 	}
 	p.mu.RUnlock()
 	if codec == nil || model == nil {
-		if legacy, ok := p.legacyRelationships(req); ok {
-			return &proto.ListRelationshipsResponse{Relationships: legacy}, nil
-		}
 		return nil, status.Error(codes.FailedPrecondition, "openfga authorization model is not configured")
 	}
 	filter := (*proto.RelationshipFilter)(nil)
@@ -403,23 +404,6 @@ func (p *openFGA) ListRelationships(ctx context.Context, req *proto.ListRelation
 	return out, nil
 }
 
-func (p *openFGA) legacyRelationships(req *proto.ListRelationshipsRequest) ([]*proto.Relationship, bool) {
-	p.mu.RLock()
-	loaded := p.legacy != nil
-	legacy := make([]*proto.Relationship, 0, len(p.legacy))
-	for _, relationship := range p.legacy {
-		if relationshipMatches(req.GetFilter(), relationship) {
-			legacy = append(legacy, cloneRelationship(relationship))
-		}
-	}
-	p.mu.RUnlock()
-	if !loaded {
-		return nil, false
-	}
-	sort.Slice(legacy, func(i, j int) bool { return tupleKey(legacy[i].Tuple) < tupleKey(legacy[j].Tuple) })
-	return legacy, true
-}
-
 func (p *openFGA) readAllTuples(ctx context.Context, filter *openfga.ReadRequestTupleKey) ([]openfga.Tuple, error) {
 	var tuples []openfga.Tuple
 	continuation := ""
@@ -443,7 +427,7 @@ func (p *openFGA) readAllTuples(ctx context.Context, filter *openfga.ReadRequest
 	}
 }
 
-func (p *openFGA) replaceTuples(ctx context.Context, codec *fgaCodec, relationships []*proto.Relationship) error {
+func (p *openFGA) writeAuthorizationRelationships(ctx context.Context, codec *fgaCodec, relationships []*proto.Relationship, replace bool) error {
 	desired := make(map[string]openfga.TupleKey, len(relationships))
 	for _, relationship := range relationships {
 		if relationship == nil || relationship.Tuple == nil {
@@ -455,15 +439,17 @@ func (p *openFGA) replaceTuples(ctx context.Context, codec *fgaCodec, relationsh
 		}
 		desired[key.User+"\x00"+key.Relation+"\x00"+key.Object] = key
 	}
-	readTuples, err := p.readAllTuples(ctx, nil)
-	if err != nil {
-		return err
-	}
 	var deletes []openfga.TupleKeyWithoutCondition
-	for _, tuple := range readTuples {
-		key := tuple.Key.User + "\x00" + tuple.Key.Relation + "\x00" + tuple.Key.Object
-		if _, ok := desired[key]; !ok {
-			deletes = append(deletes, openfga.TupleKeyWithoutCondition{User: tuple.Key.User, Relation: tuple.Key.Relation, Object: tuple.Key.Object})
+	if replace {
+		readTuples, err := p.readAllTuples(ctx, nil)
+		if err != nil {
+			return err
+		}
+		for _, tuple := range readTuples {
+			key := tuple.Key.User + "\x00" + tuple.Key.Relation + "\x00" + tuple.Key.Object
+			if _, ok := desired[key]; !ok {
+				deletes = append(deletes, openfga.TupleKeyWithoutCondition{User: tuple.Key.User, Relation: tuple.Key.Relation, Object: tuple.Key.Object})
+			}
 		}
 	}
 	keys := make([]openfga.TupleKey, 0, len(desired))
@@ -483,7 +469,7 @@ func (p *openFGA) replaceTuples(ctx context.Context, codec *fgaCodec, relationsh
 			body.Deletes.OnMissing = &missing
 		}
 		if _, _, err := p.client.OpenFgaApi.Write(ctx, p.storeID).Body(body).Execute(); err != nil {
-			return status.Errorf(codes.Unavailable, "openfga replace relationships: %v", err)
+			return status.Errorf(codes.Unavailable, "openfga write relationships: %v", err)
 		}
 	}
 	return nil
@@ -781,116 +767,6 @@ func (c *fgaCodec) targetFromUser(user, resourceType, relation string, model *pr
 func stableFGAName(prefix, value string) string {
 	sum := sha256.Sum256([]byte(value))
 	return prefix + hex.EncodeToString(sum[:])[:26]
-}
-
-type legacyRelationship struct {
-	Tuple       *legacyRelationshipTuple `json:"tuple"`
-	Properties  map[string]any           `json:"properties,omitempty"`
-	SourceLayer json.RawMessage          `json:"source_layer"`
-}
-
-type legacyRelationshipTuple struct {
-	Target   *legacyRelationshipTarget `json:"target"`
-	Relation string                    `json:"relation"`
-	Resource *legacyEntity             `json:"resource"`
-}
-
-type legacyRelationshipTarget struct {
-	Subject    *legacyEntity     `json:"subject,omitempty"`
-	Resource   *legacyEntity     `json:"resource,omitempty"`
-	SubjectSet *legacySubjectSet `json:"subject_set,omitempty"`
-}
-
-type legacySubjectSet struct {
-	Resource *legacyEntity `json:"resource"`
-	Relation string        `json:"relation"`
-}
-
-type legacyEntity struct {
-	Type       string         `json:"type"`
-	ID         string         `json:"id"`
-	Properties map[string]any `json:"properties,omitempty"`
-}
-
-func loadLegacyRelationships(ctx context.Context, db indexeddb.Database) ([]*proto.Relationship, error) {
-	if db == nil {
-		return nil, nil
-	}
-	records, err := db.ObjectStore("authz_relationships").GetAll(ctx, nil)
-	if err != nil {
-		return nil, fmt.Errorf("read legacy relationships: %w", err)
-	}
-	relationships := make([]*proto.Relationship, 0, len(records))
-	for _, record := range records {
-		data, err := json.Marshal(record["value"])
-		if err != nil {
-			return nil, fmt.Errorf("decode legacy relationship: %w", err)
-		}
-		var stored legacyRelationship
-		if err := json.Unmarshal(data, &stored); err != nil {
-			return nil, fmt.Errorf("decode legacy relationship: %w", err)
-		}
-		relationship, err := legacyRelationshipToProto(&stored)
-		if err != nil {
-			return nil, err
-		}
-		relationships = append(relationships, relationship)
-	}
-	return relationships, nil
-}
-
-func legacyRelationshipToProto(stored *legacyRelationship) (*proto.Relationship, error) {
-	if stored == nil || stored.Tuple == nil || stored.Tuple.Resource == nil || stored.Tuple.Target == nil {
-		return nil, fmt.Errorf("legacy relationship is incomplete")
-	}
-	target := &proto.RelationshipTarget{}
-	switch {
-	case stored.Tuple.Target.Subject != nil:
-		entity := stored.Tuple.Target.Subject
-		target.Kind = &proto.RelationshipTarget_Subject{Subject: &proto.Subject{Type: entity.Type, Id: entity.ID, Properties: legacyProperties(entity.Properties)}}
-	case stored.Tuple.Target.Resource != nil:
-		entity := stored.Tuple.Target.Resource
-		target.Kind = &proto.RelationshipTarget_Resource{Resource: &proto.Resource{Type: entity.Type, Id: entity.ID, Properties: legacyProperties(entity.Properties)}}
-	case stored.Tuple.Target.SubjectSet != nil && stored.Tuple.Target.SubjectSet.Resource != nil:
-		entity := stored.Tuple.Target.SubjectSet.Resource
-		target.Kind = &proto.RelationshipTarget_SubjectSet{SubjectSet: &proto.SubjectSet{Resource: &proto.Resource{Type: entity.Type, Id: entity.ID, Properties: legacyProperties(entity.Properties)}, Relation: stored.Tuple.Target.SubjectSet.Relation}}
-	default:
-		return nil, fmt.Errorf("legacy relationship target is incomplete")
-	}
-	resource := stored.Tuple.Resource
-	return &proto.Relationship{
-		Tuple:       &proto.RelationshipTuple{Target: target, Relation: stored.Tuple.Relation, Resource: &proto.Resource{Type: resource.Type, Id: resource.ID, Properties: legacyProperties(resource.Properties)}},
-		Properties:  legacyProperties(stored.Properties),
-		SourceLayer: legacySourceLayer(stored.SourceLayer),
-	}, nil
-}
-
-func legacyProperties(properties map[string]any) *structpb.Struct {
-	if len(properties) == 0 {
-		return nil
-	}
-	value, err := structpb.NewStruct(properties)
-	if err != nil {
-		return nil
-	}
-	return value
-}
-
-func legacySourceLayer(raw json.RawMessage) proto.SourceLayer {
-	var value string
-	if json.Unmarshal(raw, &value) == nil {
-		switch strings.TrimSpace(value) {
-		case "static_config", "staticconfig":
-			return proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG
-		case "runtime":
-			return proto.SourceLayer_SOURCE_LAYER_RUNTIME
-		}
-	}
-	var number int32
-	if json.Unmarshal(raw, &number) == nil {
-		return proto.SourceLayer(number)
-	}
-	return proto.SourceLayer_SOURCE_LAYER_UNSPECIFIED
 }
 
 func splitFGAObject(value string) (string, string, bool) {

--- a/gestaltd/services/authorization/openfga.go
+++ b/gestaltd/services/authorization/openfga.go
@@ -98,7 +98,10 @@ func (p *openFGA) Ping(ctx context.Context) error {
 	if p == nil || p.client == nil {
 		return status.Error(codes.FailedPrecondition, "openfga authorization is not configured")
 	}
-	_, _, err := p.client.OpenFgaApi.GetStore(ctx, p.storeID).Execute()
+	_, httpResponse, err := p.client.OpenFgaApi.GetStore(ctx, p.storeID).Execute()
+	if httpResponse != nil && httpResponse.Body != nil {
+		_ = httpResponse.Body.Close()
+	}
 	if err != nil {
 		return status.Errorf(codes.Unavailable, "openfga store health: %v", err)
 	}
@@ -153,7 +156,10 @@ func (p *openFGA) CheckAccess(ctx context.Context, req *proto.CheckAccessRequest
 			check.SetContextualTuples(openfga.ContextualTupleKeys{TupleKeys: []openfga.TupleKey{*wildcard}})
 		}
 	}
-	response, _, err := p.client.OpenFgaApi.Check(ctx, p.storeID).Body(*check).Execute()
+	response, httpResponse, err := p.client.OpenFgaApi.Check(ctx, p.storeID).Body(*check).Execute()
+	if httpResponse != nil && httpResponse.Body != nil {
+		_ = httpResponse.Body.Close()
+	}
 	if err != nil {
 		return nil, status.Errorf(codes.Unavailable, "openfga check: %v", err)
 	}
@@ -192,7 +198,11 @@ func (p *openFGA) AddRelationship(ctx context.Context, req *proto.AddRelationshi
 	duplicate := "ignore"
 	writes := openfga.WriteRequest{Writes: openfga.NewWriteRequestWrites([]openfga.TupleKey{key}), AuthorizationModelId: stringPtr(codec.model.Id)}
 	writes.Writes.OnDuplicate = &duplicate
-	if _, _, err := p.client.OpenFgaApi.Write(ctx, p.storeID).Body(writes).Execute(); err != nil {
+	_, httpResponse, err := p.client.OpenFgaApi.Write(ctx, p.storeID).Body(writes).Execute()
+	if httpResponse != nil && httpResponse.Body != nil {
+		_ = httpResponse.Body.Close()
+	}
+	if err != nil {
 		return nil, status.Errorf(codes.Unavailable, "openfga relationship write: %v", err)
 	}
 	copy := cloneRelationship(req.Relationship)
@@ -222,7 +232,11 @@ func (p *openFGA) DeleteRelationship(ctx context.Context, req *proto.DeleteRelat
 	missing := "ignore"
 	deletes := openfga.WriteRequest{Deletes: openfga.NewWriteRequestDeletes([]openfga.TupleKeyWithoutCondition{{User: key.User, Relation: key.Relation, Object: key.Object}}), AuthorizationModelId: stringPtr(codec.model.Id)}
 	deletes.Deletes.OnMissing = &missing
-	if _, _, err := p.client.OpenFgaApi.Write(ctx, p.storeID).Body(deletes).Execute(); err != nil {
+	_, httpResponse, err := p.client.OpenFgaApi.Write(ctx, p.storeID).Body(deletes).Execute()
+	if httpResponse != nil && httpResponse.Body != nil {
+		_ = httpResponse.Body.Close()
+	}
+	if err != nil {
 		return nil, status.Errorf(codes.Unavailable, "openfga relationship delete: %v", err)
 	}
 	p.mu.Lock()
@@ -259,7 +273,10 @@ func (p *openFGA) setAuthorizationState(ctx context.Context, req *proto.SetAutho
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "compile openfga model: %v", err)
 	}
-	modelResponse, _, err := p.client.OpenFgaApi.WriteAuthorizationModel(ctx, p.storeID).Body(modelRequest).Execute()
+	modelResponse, httpResponse, err := p.client.OpenFgaApi.WriteAuthorizationModel(ctx, p.storeID).Body(modelRequest).Execute()
+	if httpResponse != nil && httpResponse.Body != nil {
+		_ = httpResponse.Body.Close()
+	}
 	if err != nil {
 		return nil, status.Errorf(codes.Unavailable, "openfga write authorization model: %v", err)
 	}
@@ -415,7 +432,10 @@ func (p *openFGA) readAllTuples(ctx context.Context, filter *openfga.ReadRequest
 		if continuation != "" {
 			request.ContinuationToken = stringPtr(continuation)
 		}
-		response, _, err := p.client.OpenFgaApi.Read(ctx, p.storeID).Body(request).Execute()
+		response, httpResponse, err := p.client.OpenFgaApi.Read(ctx, p.storeID).Body(request).Execute()
+		if httpResponse != nil && httpResponse.Body != nil {
+			_ = httpResponse.Body.Close()
+		}
 		if err != nil {
 			return nil, status.Errorf(codes.Unavailable, "openfga read relationships: %v", err)
 		}
@@ -468,7 +488,11 @@ func (p *openFGA) writeAuthorizationRelationships(ctx context.Context, codec *fg
 			body.Deletes = openfga.NewWriteRequestDeletes(batch.deletes)
 			body.Deletes.OnMissing = &missing
 		}
-		if _, _, err := p.client.OpenFgaApi.Write(ctx, p.storeID).Body(body).Execute(); err != nil {
+		_, httpResponse, err := p.client.OpenFgaApi.Write(ctx, p.storeID).Body(body).Execute()
+		if httpResponse != nil && httpResponse.Body != nil {
+			_ = httpResponse.Body.Close()
+		}
+		if err != nil {
 			return status.Errorf(codes.Unavailable, "openfga write relationships: %v", err)
 		}
 	}

--- a/gestaltd/services/authorization/openfga.go
+++ b/gestaltd/services/authorization/openfga.go
@@ -143,19 +143,19 @@ func (p *openFGA) CheckAccess(ctx context.Context, req *proto.CheckAccessRequest
 	if permission == "" {
 		return &proto.CheckAccessResponse{Allowed: false, ModelId: modelID}, nil
 	}
+	// Match the IndexedDB provider's compatibility contract: DefaultRole is
+	// an implicit grant for actions that include it. Scope and action checks
+	// above still apply, so a scoped subject can deny the request before this
+	// compatibility grant is considered.
+	if defaultRole := strings.TrimSpace(resourceType.DefaultRole); defaultRole != "" && contains(action.Relations, defaultRole) {
+		return &proto.CheckAccessResponse{Allowed: true, ModelId: modelID}, nil
+	}
 	key, err := codec.checkTuple(req.Subject, permission, req.Resource)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "authorization check: %v", err)
 	}
 	check := openfga.NewCheckRequest(*openfga.NewCheckRequestTupleKey(key.User, key.Relation, key.Object))
 	check.SetAuthorizationModelId(codec.model.Id)
-	if defaultRole := strings.TrimSpace(resourceType.DefaultRole); defaultRole != "" && contains(action.Relations, defaultRole) {
-		role := codec.relations[resourceType.Name+"\x00"+defaultRole]
-		if role != "" {
-			wildcard := openfga.NewTupleKey(codec.subjectWildcard(req.Subject.Type), role, key.Object)
-			check.SetContextualTuples(openfga.ContextualTupleKeys{TupleKeys: []openfga.TupleKey{*wildcard}})
-		}
-	}
 	response, httpResponse, err := p.client.OpenFgaApi.Check(ctx, p.storeID).Body(*check).Execute()
 	if httpResponse != nil && httpResponse.Body != nil {
 		_ = httpResponse.Body.Close()
@@ -329,11 +329,13 @@ func (p *openFGA) ListActiveModelResourceTypes(_ context.Context, req *proto.Lis
 		return nil, status.Error(codes.NotFound, "active authorization model is not set")
 	}
 	name := ""
+	sourceLayer := proto.SourceLayer_SOURCE_LAYER_UNSPECIFIED
 	pageSize := 100
 	pageToken := 0
 	if req != nil {
 		if req.Filter != nil {
 			name = strings.TrimSpace(req.Filter.Name)
+			sourceLayer = req.Filter.SourceLayer
 		}
 		if req.PageSize > 0 {
 			pageSize = int(req.PageSize)
@@ -348,9 +350,16 @@ func (p *openFGA) ListActiveModelResourceTypes(_ context.Context, req *proto.Lis
 	}
 	items := make([]*proto.AuthorizationModelResourceType, 0, len(p.model.ResourceTypes))
 	for _, item := range p.model.ResourceTypes {
-		if name == "" || item.GetName() == name {
-			items = append(items, item)
+		if item == nil {
+			continue
 		}
+		if name != "" && item.GetName() != name {
+			continue
+		}
+		if sourceLayer != proto.SourceLayer_SOURCE_LAYER_UNSPECIFIED && item.GetSourceLayer() != sourceLayer {
+			continue
+		}
+		items = append(items, item)
 	}
 	if pageToken > len(items) {
 		pageToken = len(items)
@@ -607,9 +616,6 @@ func (c *fgaCodec) modelRequest() (openfga.WriteAuthorizationModelRequest, error
 					refs = append(refs, openfga.RelationReference{Type: c.types[set.ResourceType], Relation: stringPtr(relationName)})
 				}
 			}
-			if strings.TrimSpace(resourceType.DefaultRole) == strings.TrimSpace(relation.Name) {
-				refs = append(refs, openfga.RelationReference{Type: c.types["subject"], Wildcard: &map[string]interface{}{}})
-			}
 			direct := map[string]interface{}{}
 			relations[c.relations[resourceType.Name+"\x00"+relation.Name]] = openfga.Userset{This: &direct}
 			metadata[c.relations[resourceType.Name+"\x00"+relation.Name]] = openfga.RelationMetadata{DirectlyRelatedUserTypes: &refs}
@@ -703,10 +709,6 @@ func (c *fgaCodec) targetUser(target *proto.RelationshipTarget) (string, error) 
 
 func (c *fgaCodec) subjectUser(subject *proto.Subject) string {
 	return c.types[subject.Type] + ":" + subject.Id
-}
-
-func (c *fgaCodec) subjectWildcard(subjectType string) string {
-	return c.types[subjectType] + ":*"
 }
 
 func (c *fgaCodec) readFilter(filter *proto.RelationshipFilter) *openfga.ReadRequestTupleKey {

--- a/gestaltd/services/authorization/openfga.go
+++ b/gestaltd/services/authorization/openfga.go
@@ -335,7 +335,7 @@ func (p *openFGA) ListActiveModelResourceTypes(_ context.Context, req *proto.Lis
 	if pageToken > len(items) {
 		pageToken = len(items)
 	}
-	end := min(pageToken+pageSize, len(items))
+	end := minInt(pageToken+pageSize, len(items))
 	response := &proto.ListActiveModelResourceTypesResponse{ModelId: p.model.Id}
 	for _, item := range items[pageToken:end] {
 		response.ResourceTypes = append(response.ResourceTypes, cloneResourceType(item))
@@ -396,11 +396,8 @@ func (p *openFGA) ListRelationships(ctx context.Context, req *proto.ListRelation
 	if pageToken > len(items) {
 		pageToken = len(items)
 	}
-	end := min(pageToken+pageSize, len(items))
-	out := &proto.ListRelationshipsResponse{}
-	for _, item := range items[pageToken:end] {
-		out.Relationships = append(out.Relationships, item)
-	}
+	end := minInt(pageToken+pageSize, len(items))
+	out := &proto.ListRelationshipsResponse{Relationships: append([]*proto.Relationship(nil), items[pageToken:end]...)}
 	if end < len(items) {
 		out.NextPageToken = strconv.Itoa(end)
 	}
@@ -516,8 +513,8 @@ func (p *openFGA) replaceTuples(ctx context.Context, codec *fgaCodec, relationsh
 		keys = append(keys, key)
 	}
 	for start := 0; start < len(keys) || start < len(deletes); start += 100 {
-		endWrites := min(start+100, len(keys))
-		endDeletes := min(start+100, len(deletes))
+		endWrites := minInt(start+100, len(keys))
+		endDeletes := minInt(start+100, len(deletes))
 		body := openfga.WriteRequest{AuthorizationModelId: stringPtr(codec.model.Id)}
 		if start < len(keys) {
 			duplicate := "ignore"
@@ -839,7 +836,7 @@ func loadLegacyRelationships(ctx context.Context, db indexeddb.Database) ([]*pro
 	}
 	records, err := db.ObjectStore("authz_relationships").GetAll(ctx, nil)
 	if err != nil {
-		return nil, nil
+		return nil, fmt.Errorf("read legacy relationships: %w", err)
 	}
 	relationships := make([]*proto.Relationship, 0, len(records))
 	for _, record := range records {
@@ -1094,7 +1091,7 @@ func cloneResourceType(in *proto.AuthorizationModelResourceType) *proto.Authoriz
 
 func stringPtr(value string) *string { return &value }
 func int32Ptr(value int32) *int32    { return &value }
-func min(a, b int) int {
+func minInt(a, b int) int {
 	if a < b {
 		return a
 	}

--- a/gestaltd/services/authorization/openfga.go
+++ b/gestaltd/services/authorization/openfga.go
@@ -47,7 +47,6 @@ type openFGA struct {
 	modelRef *proto.AuthorizationModelRef
 	codec    *fgaCodec
 	meta     map[string]*proto.Relationship
-	legacyDB indexeddb.Database
 	legacy   []*proto.Relationship
 }
 
@@ -98,7 +97,6 @@ func NewOpenFGA(node yaml.Node, databases ...indexeddb.Database) (core.Authoriza
 		meta:    make(map[string]*proto.Relationship),
 	}
 	if len(databases) > 0 && databases[0] != nil {
-		provider.legacyDB = databases[0]
 		provider.legacy, _ = loadLegacyRelationships(context.Background(), databases[0])
 	}
 	return provider, nil
@@ -111,9 +109,6 @@ func (p *openFGA) Ping(ctx context.Context) error {
 	_, _, err := p.client.OpenFgaApi.GetStore(ctx, p.storeID).Execute()
 	if err != nil {
 		return status.Errorf(codes.Unavailable, "openfga store health: %v", err)
-	}
-	if err := p.syncLegacyRelationships(ctx); err != nil {
-		return err
 	}
 	return nil
 }
@@ -269,6 +264,10 @@ func (p *openFGA) SetAuthorizationState(ctx context.Context, req *proto.SetAutho
 	p.model = cloneModel(req.Model)
 	p.modelRef = ref
 	p.codec = codec
+	// The legacy store is only a bootstrap input. Once the OpenFGA state is
+	// active, retaining it would allow a later fallback to resurrect deleted
+	// relationships.
+	p.legacy = nil
 	p.meta = make(map[string]*proto.Relationship, len(req.Relationships))
 	for _, relationship := range req.Relationships {
 		if relationship != nil && relationship.Tuple != nil {
@@ -421,47 +420,6 @@ func (p *openFGA) legacyRelationships(req *proto.ListRelationshipsRequest) ([]*p
 	return legacy, true
 }
 
-func (p *openFGA) syncLegacyRelationships(ctx context.Context) error {
-	p.mu.RLock()
-	db := p.legacyDB
-	codec := p.codec
-	model := p.model
-	legacy := append([]*proto.Relationship(nil), p.legacy...)
-	p.mu.RUnlock()
-	if db == nil || codec == nil || model == nil {
-		return nil
-	}
-	latest, err := loadLegacyRelationships(ctx, db)
-	if err != nil {
-		return err
-	}
-	if len(latest) == 0 {
-		latest = legacy
-	}
-	for _, relationship := range latest {
-		if relationship == nil || relationship.Tuple == nil {
-			continue
-		}
-		key, err := codec.relationshipTuple(relationship.Tuple)
-		if err != nil {
-			continue
-		}
-		duplicate := "ignore"
-		body := openfga.WriteRequest{Writes: openfga.NewWriteRequestWrites([]openfga.TupleKey{key}), AuthorizationModelId: stringPtr(codec.model.Id)}
-		body.Writes.OnDuplicate = &duplicate
-		if _, _, err := p.client.OpenFgaApi.Write(ctx, p.storeID).Body(body).Execute(); err != nil {
-			return status.Errorf(codes.Unavailable, "openfga legacy relationship sync: %v", err)
-		}
-		p.mu.Lock()
-		p.meta[tupleKey(relationship.Tuple)] = cloneRelationship(relationship)
-		p.mu.Unlock()
-	}
-	p.mu.Lock()
-	p.legacy = latest
-	p.mu.Unlock()
-	return nil
-}
-
 func (p *openFGA) readAllTuples(ctx context.Context, filter *openfga.ReadRequestTupleKey) ([]openfga.Tuple, error) {
 	var tuples []openfga.Tuple
 	continuation := ""
@@ -512,18 +470,16 @@ func (p *openFGA) replaceTuples(ctx context.Context, codec *fgaCodec, relationsh
 	for _, key := range desired {
 		keys = append(keys, key)
 	}
-	for start := 0; start < len(keys) || start < len(deletes); start += 100 {
-		endWrites := minInt(start+100, len(keys))
-		endDeletes := minInt(start+100, len(deletes))
+	for _, batch := range fgaWriteBatches(keys, deletes, 100) {
 		body := openfga.WriteRequest{AuthorizationModelId: stringPtr(codec.model.Id)}
-		if start < len(keys) {
+		if len(batch.writes) > 0 {
 			duplicate := "ignore"
-			body.Writes = openfga.NewWriteRequestWrites(keys[start:endWrites])
+			body.Writes = openfga.NewWriteRequestWrites(batch.writes)
 			body.Writes.OnDuplicate = &duplicate
 		}
-		if start < len(deletes) {
+		if len(batch.deletes) > 0 {
 			missing := "ignore"
-			body.Deletes = openfga.NewWriteRequestDeletes(deletes[start:endDeletes])
+			body.Deletes = openfga.NewWriteRequestDeletes(batch.deletes)
 			body.Deletes.OnMissing = &missing
 		}
 		if _, _, err := p.client.OpenFgaApi.Write(ctx, p.storeID).Body(body).Execute(); err != nil {
@@ -531,6 +487,31 @@ func (p *openFGA) replaceTuples(ctx context.Context, codec *fgaCodec, relationsh
 		}
 	}
 	return nil
+}
+
+type fgaWriteBatch struct {
+	writes  []openfga.TupleKey
+	deletes []openfga.TupleKeyWithoutCondition
+}
+
+func fgaWriteBatches(writes []openfga.TupleKey, deletes []openfga.TupleKeyWithoutCondition, limit int) []fgaWriteBatch {
+	if limit <= 0 {
+		return nil
+	}
+	batches := make([]fgaWriteBatch, 0, (len(writes)+len(deletes)+limit-1)/limit)
+	writeIndex, deleteIndex := 0, 0
+	for writeIndex < len(writes) || deleteIndex < len(deletes) {
+		remaining := limit
+		writeEnd := minInt(writeIndex+remaining, len(writes))
+		remaining -= writeEnd - writeIndex
+		deleteEnd := minInt(deleteIndex+remaining, len(deletes))
+		batches = append(batches, fgaWriteBatch{
+			writes:  writes[writeIndex:writeEnd],
+			deletes: deletes[deleteIndex:deleteEnd],
+		})
+		writeIndex, deleteIndex = writeEnd, deleteEnd
+	}
+	return batches
 }
 
 func newFGACodec(model *proto.AuthorizationModel) (*fgaCodec, error) {
@@ -633,8 +614,9 @@ func (c *fgaCodec) modelRequest() (openfga.WriteAuthorizationModelRequest, error
 				if role == "" {
 					continue
 				}
-				object := c.types[resourceType.Name]
-				children = append(children, openfga.Userset{ComputedUserset: &openfga.ObjectRelation{Object: &object, Relation: &role}})
+				// A computed userset is evaluated on the current object. OpenFGA's
+				// model language requires the object field to be omitted here.
+				children = append(children, openfga.Userset{ComputedUserset: &openfga.ObjectRelation{Relation: &role}})
 			}
 			if len(children) == 1 {
 				relations[c.permissions[resourceType.Name+"\x00"+action.Name]] = children[0]

--- a/gestaltd/services/authorization/openfga_test.go
+++ b/gestaltd/services/authorization/openfga_test.go
@@ -305,6 +305,110 @@ func TestOpenFGAListActiveModelResourceTypesFiltersSourceLayerBeforePagination(t
 	}
 }
 
+func TestOpenFGASetActiveModelUpdatesModelAndCodec(t *testing.T) {
+	t.Parallel()
+
+	oldModel := &proto.AuthorizationModel{Id: "old-model", ResourceTypes: []*proto.AuthorizationModelResourceType{{Name: "old-resource"}}}
+	oldCodec, err := newFGACodec(oldModel)
+	if err != nil {
+		t.Fatalf("newFGACodec(oldModel): %v", err)
+	}
+	provider := &openFGA{
+		model:    oldModel,
+		modelRef: &proto.AuthorizationModelRef{Id: oldModel.Id},
+		codec:    oldCodec,
+	}
+	newModel := &proto.AuthorizationModel{Id: "new-model", Version: "v2", ResourceTypes: []*proto.AuthorizationModelResourceType{{Name: "new-resource"}}}
+
+	response, err := provider.SetActiveModel(t.Context(), &proto.SetActiveModelRequest{Model: newModel})
+	if err != nil {
+		t.Fatalf("SetActiveModel: %v", err)
+	}
+	if response.GetModel().GetId() != newModel.Id || response.GetModel().GetVersion() != newModel.Version {
+		t.Fatalf("active model ref = %#v, want id/version %q/%q", response.GetModel(), newModel.Id, newModel.Version)
+	}
+	listed, err := provider.ListActiveModelResourceTypes(t.Context(), &proto.ListActiveModelResourceTypesRequest{})
+	if err != nil {
+		t.Fatalf("ListActiveModelResourceTypes: %v", err)
+	}
+	if len(listed.ResourceTypes) != 1 || listed.ResourceTypes[0].GetName() != "new-resource" || listed.GetModelId() != newModel.Id {
+		t.Fatalf("active resource types = %#v (model %q), want new-resource (model %q)", listed.ResourceTypes, listed.GetModelId(), newModel.Id)
+	}
+	if _, ok := provider.codec.types["new-resource"]; !ok {
+		t.Fatalf("active codec does not contain new model resource type: %#v", provider.codec.types)
+	}
+	if _, ok := provider.codec.types["old-resource"]; ok {
+		t.Fatalf("active codec retained old model resource type: %#v", provider.codec.types)
+	}
+}
+
+func TestFGACodecReadFilterUsesValidOpenFGAFields(t *testing.T) {
+	t.Parallel()
+
+	model := &proto.AuthorizationModel{ResourceTypes: []*proto.AuthorizationModelResourceType{{
+		Name:      "document",
+		Relations: []*proto.ModelRelation{{Name: "viewer", AllowedTargets: []*proto.ModelAllowedTarget{{Kind: &proto.ModelAllowedTarget_SubjectType{SubjectType: "subject"}}}}},
+	}}}
+	codec, err := newFGACodec(model)
+	if err != nil {
+		t.Fatalf("newFGACodec: %v", err)
+	}
+
+	metadataOnly, err := codec.readFilter(&proto.RelationshipFilter{SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME})
+	if err != nil {
+		t.Fatalf("metadata-only readFilter: %v", err)
+	}
+	if metadataOnly != nil {
+		t.Fatalf("metadata-only readFilter = %#v, want nil unbounded filter", metadataOnly)
+	}
+
+	resourceAndRelation, err := codec.readFilter(&proto.RelationshipFilter{
+		Resource: &proto.Resource{Type: "document", Id: "doc-1"},
+		Relation: "viewer",
+	})
+	if err != nil {
+		t.Fatalf("resource/relation readFilter: %v", err)
+	}
+	if resourceAndRelation.GetObject() != codec.types["document"]+":doc-1" || resourceAndRelation.GetRelation() != codec.relations["document\x00viewer"] || resourceAndRelation.HasUser() {
+		t.Fatalf("resource/relation readFilter = %#v, want exact object/relation only", resourceAndRelation)
+	}
+
+	target, err := codec.readFilter(&proto.RelationshipFilter{Target: &proto.RelationshipTarget{Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{Type: "subject", Id: "user:alice"}}}})
+	if err != nil {
+		t.Fatalf("target readFilter: %v", err)
+	}
+	if target.GetUser() != codec.types["subject"]+":user:alice" || target.HasObject() || target.HasRelation() {
+		t.Fatalf("target readFilter = %#v, want exact user only", target)
+	}
+
+	_, err = codec.readFilter(&proto.RelationshipFilter{Target: &proto.RelationshipTarget{Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{Type: "unknown", Id: "user:alice"}}}})
+	if err == nil || !strings.Contains(err.Error(), "unknown subject type") {
+		t.Fatalf("unknown subject target error = %v, want unknown subject type", err)
+	}
+}
+
+func TestFGACodecRejectsUnknownSubjectType(t *testing.T) {
+	t.Parallel()
+
+	model := &proto.AuthorizationModel{ResourceTypes: []*proto.AuthorizationModelResourceType{{
+		Name:      "document",
+		Relations: []*proto.ModelRelation{{Name: "viewer", AllowedTargets: []*proto.ModelAllowedTarget{{Kind: &proto.ModelAllowedTarget_SubjectType{SubjectType: "subject"}}}}},
+	}}}
+	codec, err := newFGACodec(model)
+	if err != nil {
+		t.Fatalf("newFGACodec: %v", err)
+	}
+	tuple := &proto.RelationshipTuple{
+		Resource: &proto.Resource{Type: "document", Id: "doc-1"},
+		Relation: "viewer",
+		Target:   &proto.RelationshipTarget{Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{Type: "unknown", Id: "user:alice"}}},
+	}
+	_, err = codec.relationshipTuple(tuple)
+	if err == nil || !strings.Contains(err.Error(), "unknown subject type") {
+		t.Fatalf("relationshipTuple error = %v, want unknown subject type", err)
+	}
+}
+
 func TestFGAWriteBatchesRespectCombinedLimit(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/authorization/openfga_test.go
+++ b/gestaltd/services/authorization/openfga_test.go
@@ -1,0 +1,64 @@
+package authorization
+
+import (
+	"strings"
+	"testing"
+
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+)
+
+func TestNewFGACodecPreservesGraphTargetsAndStableNames(t *testing.T) {
+	model := &proto.AuthorizationModel{ResourceTypes: []*proto.AuthorizationModelResourceType{
+		{
+			Name:        "workspace.document",
+			DefaultRole: "viewer",
+			Relations: []*proto.ModelRelation{
+				{Name: "viewer", AllowedTargets: []*proto.ModelAllowedTarget{
+					{Kind: &proto.ModelAllowedTarget_SubjectType{SubjectType: "subject"}},
+					{Kind: &proto.ModelAllowedTarget_SubjectSetType{SubjectSetType: &proto.SubjectSetType{ResourceType: "group", Relation: "member"}}},
+				}},
+			},
+			Actions: []*proto.ModelAction{{Name: "read", Relations: []string{"viewer"}}},
+		},
+		{Name: "group", Relations: []*proto.ModelRelation{{Name: "member", AllowedTargets: []*proto.ModelAllowedTarget{{Kind: &proto.ModelAllowedTarget_SubjectType{SubjectType: "subject"}}}}}},
+	}}
+
+	codec, err := newFGACodec(model)
+	if err != nil {
+		t.Fatalf("newFGACodec: %v", err)
+	}
+	if !strings.HasPrefix(codec.types["workspace.document"], "t_") || !strings.HasPrefix(codec.relations["workspace.document\x00viewer"], "r_") || !strings.HasPrefix(codec.permissions["workspace.document\x00read"], "p_") {
+		t.Fatalf("unexpected encoded names: types=%#v relations=%#v permissions=%#v", codec.types, codec.relations, codec.permissions)
+	}
+	request, err := codec.modelRequest()
+	if err != nil {
+		t.Fatalf("modelRequest: %v", err)
+	}
+	if len(request.TypeDefinitions) != 3 {
+		t.Fatalf("type definitions = %d, want 3 resource/subject-set definitions", len(request.TypeDefinitions))
+	}
+	if len(request.TypeDefinitions[0].GetRelations()) != 2 {
+		t.Fatalf("first type relations = %#v, want viewer/read", request.TypeDefinitions[0].GetRelations())
+	}
+	metadata := request.TypeDefinitions[0].GetMetadata()
+	viewer := metadata.GetRelations()[codec.relations["workspace.document\x00viewer"]]
+	directTypes := viewer.GetDirectlyRelatedUserTypes()
+	if got := directTypes[1].GetType(); got != codec.types["group"] {
+		t.Fatalf("subject-set relation type = %q, want encoded group type %q", got, codec.types["group"])
+	}
+	if got := directTypes[2].GetType(); got != codec.types["subject"] {
+		t.Fatalf("default wildcard type = %q, want encoded subject type %q", got, codec.types["subject"])
+	}
+}
+
+func TestSplitFGAObjectRejectsMalformedValues(t *testing.T) {
+	for _, value := range []string{"", "missing-separator", ":id", "type:"} {
+		if _, _, ok := splitFGAObject(value); ok {
+			t.Fatalf("splitFGAObject(%q) accepted malformed value", value)
+		}
+	}
+	logicalType, id, ok := splitFGAObject("type:id:with-colon")
+	if !ok || logicalType != "type" || id != "id:with-colon" {
+		t.Fatalf("splitFGAObject returned (%q, %q, %v)", logicalType, id, ok)
+	}
+}

--- a/gestaltd/services/authorization/openfga_test.go
+++ b/gestaltd/services/authorization/openfga_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestNewFGACodecPreservesGraphTargetsAndStableNames(t *testing.T) {
+	t.Parallel()
+
 	model := &proto.AuthorizationModel{ResourceTypes: []*proto.AuthorizationModelResourceType{
 		{
 			Name:        "workspace.document",
@@ -52,6 +54,8 @@ func TestNewFGACodecPreservesGraphTargetsAndStableNames(t *testing.T) {
 }
 
 func TestSplitFGAObjectRejectsMalformedValues(t *testing.T) {
+	t.Parallel()
+
 	for _, value := range []string{"", "missing-separator", ":id", "type:"} {
 		if _, _, ok := splitFGAObject(value); ok {
 			t.Fatalf("splitFGAObject(%q) accepted malformed value", value)

--- a/gestaltd/services/authorization/openfga_test.go
+++ b/gestaltd/services/authorization/openfga_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	openfga "github.com/openfga/go-sdk"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 )
 
@@ -50,6 +51,42 @@ func TestNewFGACodecPreservesGraphTargetsAndStableNames(t *testing.T) {
 	}
 	if got := directTypes[2].GetType(); got != codec.types["subject"] {
 		t.Fatalf("default wildcard type = %q, want encoded subject type %q", got, codec.types["subject"])
+	}
+	permission := request.TypeDefinitions[0].GetRelations()[codec.permissions["workspace.document\x00read"]]
+	computed, ok := permission.GetComputedUsersetOk()
+	if !ok {
+		t.Fatalf("read permission = %#v, want computed userset", permission)
+	}
+	if got := computed.GetObject(); got != "" {
+		t.Fatalf("computed userset object = %q, want empty same-object reference", got)
+	}
+	if got := computed.GetRelation(); got != codec.relations["workspace.document\x00viewer"] {
+		t.Fatalf("computed userset relation = %q, want encoded viewer relation %q", got, codec.relations["workspace.document\x00viewer"])
+	}
+}
+
+func TestFGAWriteBatchesRespectCombinedLimit(t *testing.T) {
+	t.Parallel()
+
+	writes := make([]openfga.TupleKey, 75)
+	deletes := make([]openfga.TupleKeyWithoutCondition, 80)
+	batches := fgaWriteBatches(writes, deletes, 100)
+	if len(batches) != 2 {
+		t.Fatalf("batches = %d, want 2", len(batches))
+	}
+	for i, batch := range batches {
+		if got := len(batch.writes) + len(batch.deletes); got > 100 {
+			t.Fatalf("batch %d contains %d operations, want at most 100", i, got)
+		}
+	}
+	if got := len(batches[0].writes); got != 75 {
+		t.Fatalf("first batch writes = %d, want 75", got)
+	}
+	if got := len(batches[0].deletes); got != 25 {
+		t.Fatalf("first batch deletes = %d, want 25", got)
+	}
+	if got := len(batches[1].deletes); got != 55 {
+		t.Fatalf("second batch deletes = %d, want 55", got)
 	}
 }
 

--- a/gestaltd/services/authorization/openfga_test.go
+++ b/gestaltd/services/authorization/openfga_test.go
@@ -350,7 +350,21 @@ func TestOpenFGASetActiveModelUpdatesModelAndCodec(t *testing.T) {
 		model:    oldModel,
 		modelRef: &proto.AuthorizationModelRef{Id: oldModel.Id},
 		codec:    oldCodec,
+		meta:     make(map[string]*proto.Relationship),
 	}
+	metadataRelationship := &proto.Relationship{
+		SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME,
+		Properties: func() *structpb.Struct {
+			value, _ := structpb.NewStruct(map[string]any{"source": "existing"})
+			return value
+		}(),
+		Tuple: &proto.RelationshipTuple{
+			Resource: &proto.Resource{Type: "old-resource", Id: "old-1"},
+			Relation: "viewer",
+			Target:   &proto.RelationshipTarget{Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{Type: "subject", Id: "user:alice"}}},
+		},
+	}
+	provider.meta[tupleKey(metadataRelationship.Tuple)] = metadataRelationship
 	newModel := &proto.AuthorizationModel{Id: "new-model", Version: "v2", ResourceTypes: []*proto.AuthorizationModelResourceType{{Name: "new-resource"}}}
 
 	response, err := provider.SetActiveModel(t.Context(), &proto.SetActiveModelRequest{Model: newModel})
@@ -375,6 +389,9 @@ func TestOpenFGASetActiveModelUpdatesModelAndCodec(t *testing.T) {
 	}
 	if provider.codec.model.Id != "remote-model-id" {
 		t.Fatalf("active codec model id = %q, want remote OpenFGA model id", provider.codec.model.Id)
+	}
+	if got := provider.meta[tupleKey(metadataRelationship.Tuple)]; got == nil || got.GetSourceLayer() != metadataRelationship.GetSourceLayer() || got.GetProperties().GetFields()["source"].GetStringValue() != "existing" {
+		t.Fatalf("relationship metadata after SetActiveModel = %#v, want existing metadata preserved", got)
 	}
 }
 

--- a/gestaltd/services/authorization/openfga_test.go
+++ b/gestaltd/services/authorization/openfga_test.go
@@ -4,11 +4,13 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
 	openfga "github.com/openfga/go-sdk"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func TestBootstrapAuthorizationStateOnlyWritesConfiguredRelationships(t *testing.T) {
@@ -112,11 +114,14 @@ func TestNewFGACodecPreservesGraphTargetsAndStableNames(t *testing.T) {
 	metadata := request.TypeDefinitions[0].GetMetadata()
 	viewer := metadata.GetRelations()[codec.relations["workspace.document\x00viewer"]]
 	directTypes := viewer.GetDirectlyRelatedUserTypes()
+	if len(directTypes) != 2 {
+		t.Fatalf("viewer direct types = %#v, want configured subject and group types only", directTypes)
+	}
+	if got := directTypes[0].GetType(); got != codec.types["subject"] {
+		t.Fatalf("subject relation type = %q, want encoded subject type %q", got, codec.types["subject"])
+	}
 	if got := directTypes[1].GetType(); got != codec.types["group"] {
 		t.Fatalf("subject-set relation type = %q, want encoded group type %q", got, codec.types["group"])
-	}
-	if got := directTypes[2].GetType(); got != codec.types["subject"] {
-		t.Fatalf("default wildcard type = %q, want encoded subject type %q", got, codec.types["subject"])
 	}
 	permission := request.TypeDefinitions[0].GetRelations()[codec.permissions["workspace.document\x00read"]]
 	computed, ok := permission.GetComputedUsersetOk()
@@ -128,6 +133,168 @@ func TestNewFGACodecPreservesGraphTargetsAndStableNames(t *testing.T) {
 	}
 	if got := computed.GetRelation(); got != codec.relations["workspace.document\x00viewer"] {
 		t.Fatalf("computed userset relation = %q, want encoded viewer relation %q", got, codec.relations["workspace.document\x00viewer"])
+	}
+}
+
+func TestOpenFGADefaultRoleCompatibility(t *testing.T) {
+	var checkRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		checkRequests++
+		if r.URL.Path != "/stores/test-store/check" {
+			http.Error(w, "unexpected request", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"allowed":false}`))
+	}))
+	t.Cleanup(server.Close)
+
+	clientConfig, err := openfga.NewConfiguration(openfga.Configuration{ApiUrl: server.URL})
+	if err != nil {
+		t.Fatalf("NewConfiguration: %v", err)
+	}
+	model := &proto.AuthorizationModel{Id: "model-id", ResourceTypes: []*proto.AuthorizationModelResourceType{{
+		Name:        "document",
+		DefaultRole: "viewer",
+		Relations: []*proto.ModelRelation{
+			{Name: "viewer", AllowedTargets: []*proto.ModelAllowedTarget{{Kind: &proto.ModelAllowedTarget_SubjectType{SubjectType: "subject"}}}},
+			{Name: "editor", AllowedTargets: []*proto.ModelAllowedTarget{{Kind: &proto.ModelAllowedTarget_SubjectType{SubjectType: "subject"}}}},
+		},
+		Actions: []*proto.ModelAction{
+			{Name: "read", Relations: []string{"viewer"}},
+			{Name: "edit", Relations: []string{"editor"}},
+		},
+	}}}
+	codec, err := newFGACodec(model)
+	if err != nil {
+		t.Fatalf("newFGACodec: %v", err)
+	}
+	provider := &openFGA{
+		client:   openfga.NewAPIClient(clientConfig),
+		storeID:  "test-store",
+		model:    model,
+		modelRef: &proto.AuthorizationModelRef{Id: "model-id"},
+		codec:    codec,
+		meta:     make(map[string]*proto.Relationship),
+	}
+	request := func(action string, subject *proto.Subject) *proto.CheckAccessRequest {
+		return &proto.CheckAccessRequest{
+			Subject:  subject,
+			Resource: &proto.Resource{Type: "document", Id: "doc-1"},
+			Action:   &proto.Action{Name: action},
+		}
+	}
+	subject := &proto.Subject{Type: "subject", Id: "user:alice"}
+
+	allowed, err := provider.CheckAccess(t.Context(), request("read", subject))
+	if err != nil {
+		t.Fatalf("default-role CheckAccess: %v", err)
+	}
+	if !allowed.GetAllowed() {
+		t.Fatal("default-role action denied, want allowed")
+	}
+	if checkRequests != 0 {
+		t.Fatalf("default-role action made %d OpenFGA checks, want 0", checkRequests)
+	}
+
+	denied, err := provider.CheckAccess(t.Context(), request("edit", subject))
+	if err != nil {
+		t.Fatalf("non-default-role CheckAccess: %v", err)
+	}
+	if denied.GetAllowed() {
+		t.Fatal("action excluding defaultRole allowed, want denied")
+	}
+	if checkRequests != 1 {
+		t.Fatalf("non-default-role action made %d OpenFGA checks, want 1", checkRequests)
+	}
+
+	scopedSubject := &proto.Subject{Type: "subject", Id: "user:alice", Properties: func() *structpb.Struct {
+		value, err := structpb.NewStruct(map[string]any{"scope": "other:operation"})
+		if err != nil {
+			t.Fatalf("NewStruct: %v", err)
+		}
+		return value
+	}()}
+	scopeDenied, err := provider.CheckAccess(t.Context(), request("read", scopedSubject))
+	if err != nil {
+		t.Fatalf("scoped default-role CheckAccess: %v", err)
+	}
+	if scopeDenied.GetAllowed() {
+		t.Fatal("scope-denied default-role action allowed, want denied")
+	}
+	if checkRequests != 1 {
+		t.Fatalf("scope-denied action made %d OpenFGA checks, want 1", checkRequests)
+	}
+}
+
+func TestOpenFGAListActiveModelResourceTypesFiltersSourceLayerBeforePagination(t *testing.T) {
+	model := &proto.AuthorizationModel{Id: "model-id", ResourceTypes: []*proto.AuthorizationModelResourceType{
+		{Name: "static-alpha", SourceLayer: proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG},
+		{Name: "runtime-alpha", SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME},
+		{Name: "static-beta", SourceLayer: proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG},
+		{Name: "runtime-beta", SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME},
+	}}
+	provider := &openFGA{model: model}
+
+	tests := []struct {
+		name      string
+		filter    *proto.AuthorizationModelResourceTypeFilter
+		pageSize  int32
+		pageToken string
+		wantNames []string
+		wantNext  string
+	}{
+		{
+			name:      "static-only",
+			filter:    &proto.AuthorizationModelResourceTypeFilter{SourceLayer: proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG},
+			wantNames: []string{"static-alpha", "static-beta"},
+		},
+		{
+			name:      "runtime-only",
+			filter:    &proto.AuthorizationModelResourceTypeFilter{SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME},
+			wantNames: []string{"runtime-alpha", "runtime-beta"},
+		},
+		{
+			name:      "combined-name-and-layer",
+			filter:    &proto.AuthorizationModelResourceTypeFilter{Name: "runtime-beta", SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME},
+			wantNames: []string{"runtime-beta"},
+		},
+		{
+			name:      "pagination-after-filtering",
+			filter:    &proto.AuthorizationModelResourceTypeFilter{SourceLayer: proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG},
+			pageSize:  1,
+			wantNames: []string{"static-alpha"},
+			wantNext:  "1",
+		},
+		{
+			name:      "pagination-second-page",
+			filter:    &proto.AuthorizationModelResourceTypeFilter{SourceLayer: proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG},
+			pageSize:  1,
+			pageToken: "1",
+			wantNames: []string{"static-beta"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response, err := provider.ListActiveModelResourceTypes(t.Context(), &proto.ListActiveModelResourceTypesRequest{
+				Filter:    test.filter,
+				PageSize:  test.pageSize,
+				PageToken: test.pageToken,
+			})
+			if err != nil {
+				t.Fatalf("ListActiveModelResourceTypes: %v", err)
+			}
+			gotNames := make([]string, 0, len(response.ResourceTypes))
+			for _, resourceType := range response.ResourceTypes {
+				gotNames = append(gotNames, resourceType.GetName())
+			}
+			if !reflect.DeepEqual(gotNames, test.wantNames) {
+				t.Fatalf("resource types = %#v, want %#v", gotNames, test.wantNames)
+			}
+			if response.NextPageToken != test.wantNext {
+				t.Fatalf("next page token = %q, want %q", response.NextPageToken, test.wantNext)
+			}
+		})
 	}
 }
 

--- a/gestaltd/services/authorization/openfga_test.go
+++ b/gestaltd/services/authorization/openfga_test.go
@@ -137,6 +137,8 @@ func TestNewFGACodecPreservesGraphTargetsAndStableNames(t *testing.T) {
 }
 
 func TestOpenFGADefaultRoleCompatibility(t *testing.T) {
+	t.Parallel()
+
 	var checkRequests int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		checkRequests++
@@ -228,6 +230,8 @@ func TestOpenFGADefaultRoleCompatibility(t *testing.T) {
 }
 
 func TestOpenFGAListActiveModelResourceTypesFiltersSourceLayerBeforePagination(t *testing.T) {
+	t.Parallel()
+
 	model := &proto.AuthorizationModel{Id: "model-id", ResourceTypes: []*proto.AuthorizationModelResourceType{
 		{Name: "static-alpha", SourceLayer: proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG},
 		{Name: "runtime-alpha", SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME},
@@ -275,7 +279,10 @@ func TestOpenFGAListActiveModelResourceTypesFiltersSourceLayerBeforePagination(t
 		},
 	}
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			response, err := provider.ListActiveModelResourceTypes(t.Context(), &proto.ListActiveModelResourceTypesRequest{
 				Filter:    test.filter,
 				PageSize:  test.pageSize,

--- a/gestaltd/services/authorization/openfga_test.go
+++ b/gestaltd/services/authorization/openfga_test.go
@@ -227,6 +227,24 @@ func TestOpenFGADefaultRoleCompatibility(t *testing.T) {
 	if checkRequests != 1 {
 		t.Fatalf("scope-denied action made %d OpenFGA checks, want 1", checkRequests)
 	}
+
+	nameScopedSubject := &proto.Subject{Type: "subject", Id: "user:alice", Properties: func() *structpb.Struct {
+		value, err := structpb.NewStruct(map[string]any{"scope": "doc-1:read"})
+		if err != nil {
+			t.Fatalf("NewStruct: %v", err)
+		}
+		return value
+	}()}
+	nameScoped, err := provider.CheckAccess(t.Context(), request("read", nameScopedSubject))
+	if err != nil {
+		t.Fatalf("resource-name scoped CheckAccess: %v", err)
+	}
+	if !nameScoped.GetAllowed() {
+		t.Fatal("resource-name scoped default-role action denied, want allowed")
+	}
+	if checkRequests != 1 {
+		t.Fatalf("resource-name scoped action made %d OpenFGA checks, want 1", checkRequests)
+	}
 }
 
 func TestOpenFGAListActiveModelResourceTypesFiltersSourceLayerBeforePagination(t *testing.T) {
@@ -308,12 +326,27 @@ func TestOpenFGAListActiveModelResourceTypesFiltersSourceLayerBeforePagination(t
 func TestOpenFGASetActiveModelUpdatesModelAndCodec(t *testing.T) {
 	t.Parallel()
 
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/stores/test-store/authorization-models" {
+			http.Error(w, "unexpected request", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"authorization_model_id":"remote-model-id"}`))
+	}))
+	t.Cleanup(server.Close)
+	clientConfig, err := openfga.NewConfiguration(openfga.Configuration{ApiUrl: server.URL})
+	if err != nil {
+		t.Fatalf("NewConfiguration: %v", err)
+	}
 	oldModel := &proto.AuthorizationModel{Id: "old-model", ResourceTypes: []*proto.AuthorizationModelResourceType{{Name: "old-resource"}}}
 	oldCodec, err := newFGACodec(oldModel)
 	if err != nil {
 		t.Fatalf("newFGACodec(oldModel): %v", err)
 	}
 	provider := &openFGA{
+		client:   openfga.NewAPIClient(clientConfig),
+		storeID:  "test-store",
 		model:    oldModel,
 		modelRef: &proto.AuthorizationModelRef{Id: oldModel.Id},
 		codec:    oldCodec,
@@ -339,6 +372,9 @@ func TestOpenFGASetActiveModelUpdatesModelAndCodec(t *testing.T) {
 	}
 	if _, ok := provider.codec.types["old-resource"]; ok {
 		t.Fatalf("active codec retained old model resource type: %#v", provider.codec.types)
+	}
+	if provider.codec.model.Id != "remote-model-id" {
+		t.Fatalf("active codec model id = %q, want remote OpenFGA model id", provider.codec.model.Id)
 	}
 }
 

--- a/gestaltd/services/authorization/openfga_test.go
+++ b/gestaltd/services/authorization/openfga_test.go
@@ -1,12 +1,78 @@
 package authorization
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	openfga "github.com/openfga/go-sdk"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 )
+
+func TestBootstrapAuthorizationStateOnlyWritesConfiguredRelationships(t *testing.T) {
+	t.Parallel()
+
+	var paths []string
+	var writeBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/stores/test-store/authorization-models":
+			_, _ = w.Write([]byte(`{"authorization_model_id":"model-id"}`))
+		case "/stores/test-store/write":
+			if err := json.NewDecoder(r.Body).Decode(&writeBody); err != nil {
+				t.Errorf("decode write request: %v", err)
+			}
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			http.Error(w, "unexpected request", http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	cfg, err := openfga.NewConfiguration(openfga.Configuration{ApiUrl: server.URL})
+	if err != nil {
+		t.Fatalf("NewConfiguration: %v", err)
+	}
+	provider := &openFGA{
+		client:  openfga.NewAPIClient(cfg),
+		storeID: "test-store",
+		meta:    make(map[string]*proto.Relationship),
+	}
+	model := &proto.AuthorizationModel{Id: "logical-id", Version: "1", ResourceTypes: []*proto.AuthorizationModelResourceType{{
+		Name: "repository",
+		Relations: []*proto.ModelRelation{{
+			Name: "viewer",
+			AllowedTargets: []*proto.ModelAllowedTarget{{
+				Kind: &proto.ModelAllowedTarget_SubjectType{SubjectType: "subject"},
+			}},
+		}},
+	}}}
+	relationship := &proto.Relationship{Tuple: &proto.RelationshipTuple{
+		Target: &proto.RelationshipTarget{Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{
+			Type: "subject",
+			Id:   "user:alice",
+		}}},
+		Relation: "viewer",
+		Resource: &proto.Resource{Type: "repository", Id: "repo-1"},
+	}}
+
+	if err := provider.BootstrapAuthorizationState(t.Context(), model, []*proto.Relationship{relationship}); err != nil {
+		t.Fatalf("BootstrapAuthorizationState: %v", err)
+	}
+	if got, want := strings.Join(paths, ","), "/stores/test-store/authorization-models,/stores/test-store/write"; got != want {
+		t.Fatalf("request paths = %q, want %q", got, want)
+	}
+	if _, ok := writeBody["deletes"]; ok {
+		t.Fatalf("bootstrap write unexpectedly contains deletes: %#v", writeBody)
+	}
+	if _, ok := writeBody["writes"]; !ok {
+		t.Fatalf("bootstrap write does not contain configured relationships: %#v", writeBody)
+	}
+}
 
 func TestNewFGACodecPreservesGraphTargetsAndStableNames(t *testing.T) {
 	t.Parallel()

--- a/go.work.sum
+++ b/go.work.sum
@@ -52,6 +52,8 @@ github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D
 github.com/mdempsky/unconvert v0.0.0-20250216222326-4a038b3d31f5/go.mod h1:mVCHGHs8r8jnrZ2ammcv8ySbhG2+rEPXegFmdNA51GI=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
+github.com/openfga/go-sdk v0.8.2 h1:eX2RJ7RD9sbxC4Oe8ZAFDZu6n/qYuO9SDrk7XAOE0Fg=
+github.com/openfga/go-sdk v0.8.2/go.mod h1:epiUE6IfG7Ezr3cYLepiUbCasChNowgP8AtJsN4HSpI=
 github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d/go.mod h1:lXfE4PvvTW5xOjO6Mba8zDPyw8M93B6AQ7frTGnMlA8=
 github.com/pjbgf/sha1cd v0.6.0/go.mod h1:lhpGlyHLpQZoxMv8HcgXvZEhcGs0PG/vsZnEJ7H0iCM=
 github.com/r3labs/sse/v2 v2.8.1/go.mod h1:Igau6Whc+F17QUgML1fYe1VPZzTV6EMCnYktEmkNJ7I=


### PR DESCRIPTION
## Summary

- Add an opt-in built-in OpenFGA authorization backend to Gestalt.
- Preserve the existing authorization provider contract so Toolshed and existing deployments continue to work unchanged unless they explicitly select the builtin.
- Compile Gestalt authorization models into stable OpenFGA type/relation/action names, including graph targets, wildcard default roles, relationship reads/writes, checks, pagination, and model diagnostics.
- Make OpenFGA a hard cutover: remove all IndexedDB loading, conversion, fallback, and synchronization code from the builtin.
- On startup, publish the current static authorization model and idempotently add the relationships from static config. Startup never reads runtime relationships and never deletes or replaces tuples already in OpenFGA, so OpenFGA mutations survive restarts.
- Keep the openfga scalar authorization source local while leaving remote/plugin authorization validation unchanged.

This intentionally is not a live migration. Existing runtime grants in IndexedDB are not imported. If they are needed, export/import them separately before selecting OpenFGA. Removing a relationship from static config also does not delete its existing OpenFGA tuple; after cutover, deletions should be performed through OpenFGA/Gestalt relationship mutation.

The deployment selector is intentionally not changed here. The prior valon-tools deployment PR is already closed and obsolete because its target deployment infrastructure was removed from valon-tools main; this PR alone does not change the active provider in any deployment. Auth0/OpenFGA infrastructure is being handled separately.

## Validation

- `go test ./internal/bootstrap ./services/authorization`
- `go vet ./internal/bootstrap ./services/authorization`
- provider-level HTTP regression test verifies bootstrap writes the model and configured tuples without tuple reads or deletes
- `git diff --check`

`go test ./...` is currently blocked locally by the pre-existing missing `github.com/go-sql-driver/mysql` module imported by `cmd/reseed-fp-cred`; no unrelated dependency change is included here.
