### PR TITLE
gestaltd: expose live fleet replicas on app-admin registry

### DIFF
--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -105,6 +105,30 @@ const (
 	AppFleetStateUnknown    AppFleetState = "unknown"
 )
 
+// AppFleetReplicaClass is the counter bucket a live replica contributes to in
+// AppFleetProjection. It is assigned in the same pass as the aggregates so
+// replica rows and counts cannot disagree.
+type AppFleetReplicaClass string
+
+const (
+	AppFleetReplicaClassOnDesired  AppFleetReplicaClass = "on_desired"
+	AppFleetReplicaClassMismatched AppFleetReplicaClass = "mismatched"
+	AppFleetReplicaClassError      AppFleetReplicaClass = "error"
+)
+
+// AppFleetReplicaObservation is one live process observation for a single app
+// on the current source version (within the heartbeat freshness lease).
+type AppFleetReplicaObservation struct {
+	InstanceID             string
+	StartedAt              time.Time
+	HeartbeatAt            time.Time
+	AppState               GestaltdInstanceAppState
+	RunningVersion         string
+	ObservedDesiredVersion string
+	LastError              string
+	Class                  AppFleetReplicaClass
+}
+
 type AppFleetProjection struct {
 	App                     string
 	State                   AppFleetState
@@ -117,6 +141,7 @@ type AppFleetProjection struct {
 	Errors                  int
 	HeartbeatTTL            time.Duration
 	EvaluatedAt             time.Time
+	Replicas                []AppFleetReplicaObservation
 }
 
 type AppRolloutState string

--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -118,6 +118,8 @@ const (
 
 // AppFleetReplicaObservation is one live process observation for a single app
 // on the current source version (within the heartbeat freshness lease).
+// Class is assigned in the same EvaluateFleetState pass as the aggregate
+// counters so replica rows and counts cannot disagree.
 type AppFleetReplicaObservation struct {
 	InstanceID             string
 	StartedAt              time.Time
@@ -125,6 +127,7 @@ type AppFleetReplicaObservation struct {
 	AppState               GestaltdInstanceAppState
 	RunningVersion         string
 	ObservedDesiredVersion string
+	ObservedAt             time.Time
 	LastError              string
 	Class                  AppFleetReplicaClass
 }

--- a/gestaltd/internal/appregistry/fleet_state.go
+++ b/gestaltd/internal/appregistry/fleet_state.go
@@ -140,23 +140,40 @@ func EvaluateFleetState(input FleetEvaluation) core.AppFleetProjection {
 			continue
 		}
 		projection.LiveInstances++
+		replica := core.AppFleetReplicaObservation{
+			InstanceID:  strings.TrimSpace(heartbeat.InstanceID),
+			StartedAt:   heartbeat.StartedAt.UTC(),
+			HeartbeatAt: heartbeat.HeartbeatAt.UTC(),
+			AppState:    core.GestaltdInstanceAppStateUnknown,
+			Class:       core.AppFleetReplicaClassError,
+		}
 		observation, ok := heartbeat.Apps[app]
 		if !ok {
 			projection.Errors++
+			projection.Replicas = append(projection.Replicas, replica)
 			continue
 		}
+		replica.AppState = observation.State
+		replica.RunningVersion = strings.TrimSpace(observation.RunningVersion)
+		replica.ObservedDesiredVersion = strings.TrimSpace(observation.DesiredVersion)
+		replica.LastError = strings.TrimSpace(observation.LastError)
 		if observation.State == core.GestaltdInstanceAppStateRunning &&
-			strings.TrimSpace(observation.RunningVersion) == desiredVersion &&
+			replica.RunningVersion == desiredVersion &&
 			desiredVersion != "" {
+			replica.Class = core.AppFleetReplicaClassOnDesired
 			projection.RunningDesiredVersion++
+			projection.Replicas = append(projection.Replicas, replica)
 			continue
 		}
 		switch observation.State {
 		case core.GestaltdInstanceAppStateError, core.GestaltdInstanceAppStateUnknown:
+			replica.Class = core.AppFleetReplicaClassError
 			projection.Errors++
 		default:
+			replica.Class = core.AppFleetReplicaClassMismatched
 			projection.Mismatched++
 		}
+		projection.Replicas = append(projection.Replicas, replica)
 	}
 
 	validBasis := desiredVersion != "" && sourceVersion != "" && input.MinimumHealthyInstances > 0

--- a/gestaltd/internal/appregistry/fleet_state.go
+++ b/gestaltd/internal/appregistry/fleet_state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -156,6 +157,7 @@ func EvaluateFleetState(input FleetEvaluation) core.AppFleetProjection {
 		replica.AppState = observation.State
 		replica.RunningVersion = strings.TrimSpace(observation.RunningVersion)
 		replica.ObservedDesiredVersion = strings.TrimSpace(observation.DesiredVersion)
+		replica.ObservedAt = observation.ObservedAt.UTC()
 		replica.LastError = strings.TrimSpace(observation.LastError)
 		if observation.State == core.GestaltdInstanceAppStateRunning &&
 			replica.RunningVersion == desiredVersion &&
@@ -175,6 +177,7 @@ func EvaluateFleetState(input FleetEvaluation) core.AppFleetProjection {
 		}
 		projection.Replicas = append(projection.Replicas, replica)
 	}
+	sortFleetReplicas(projection.Replicas)
 
 	validBasis := desiredVersion != "" && sourceVersion != "" && input.MinimumHealthyInstances > 0
 	switch {
@@ -189,6 +192,17 @@ func EvaluateFleetState(input FleetEvaluation) core.AppFleetProjection {
 		projection.State = core.AppFleetStateConverging
 	}
 	return projection
+}
+
+// sortFleetReplicas makes live replica order stable for API consumers:
+// newest heartbeat first, then instance id.
+func sortFleetReplicas(replicas []core.AppFleetReplicaObservation) {
+	slices.SortFunc(replicas, func(a, b core.AppFleetReplicaObservation) int {
+		if byHeartbeat := b.HeartbeatAt.Compare(a.HeartbeatAt); byHeartbeat != 0 {
+			return byHeartbeat
+		}
+		return strings.Compare(a.InstanceID, b.InstanceID)
+	})
 }
 
 func rolloutMatches(rollout *core.AppRollout, app, version, sourceVersion string, now time.Time) bool {

--- a/gestaltd/internal/appregistry/fleet_state_test.go
+++ b/gestaltd/internal/appregistry/fleet_state_test.go
@@ -168,6 +168,57 @@ func TestEvaluateFleetState(t *testing.T) {
 	}
 }
 
+func TestEvaluateFleetStateReplicaIdentityAndOrder(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	cutoff := now.Add(-45 * time.Second)
+	older := now.Add(-10 * time.Second)
+	newer := now.Add(-2 * time.Second)
+
+	got := EvaluateFleetState(FleetEvaluation{
+		App:                     "app",
+		DesiredVersion:          "v2",
+		SourceVersion:           "source",
+		MinimumHealthyInstances: 2,
+		Cutoff:                  cutoff,
+		EvaluatedAt:             now,
+		Heartbeats: []*core.GestaltdInstanceHeartbeat{
+			heartbeatForFleet("error", "source", older, map[string]core.GestaltdInstanceAppHeartbeat{
+				"app": {
+					State:      core.GestaltdInstanceAppStateError,
+					LastError:  "failed",
+					ObservedAt: older,
+				},
+			}),
+			heartbeatForFleet("mismatch", "source", newer, map[string]core.GestaltdInstanceAppHeartbeat{
+				"app": {
+					State:          core.GestaltdInstanceAppStateRunning,
+					DesiredVersion: "v2",
+					RunningVersion: "v1",
+					ObservedAt:     newer,
+				},
+			}),
+		},
+	})
+	if len(got.Replicas) != 2 {
+		t.Fatalf("replicas = %#v", got.Replicas)
+	}
+	// Newest heartbeat first, then instance id.
+	if got.Replicas[0].InstanceID != "mismatch" ||
+		got.Replicas[0].Class != core.AppFleetReplicaClassMismatched ||
+		got.Replicas[0].RunningVersion != "v1" ||
+		got.Replicas[0].ObservedDesiredVersion != "v2" ||
+		!got.Replicas[0].ObservedAt.Equal(newer) {
+		t.Fatalf("replicas[0] = %#v", got.Replicas[0])
+	}
+	if got.Replicas[1].InstanceID != "error" ||
+		got.Replicas[1].Class != core.AppFleetReplicaClassError ||
+		got.Replicas[1].LastError != "failed" ||
+		!got.Replicas[1].ObservedAt.Equal(older) {
+		t.Fatalf("replicas[1] = %#v", got.Replicas[1])
+	}
+}
+
 func TestEvaluateFleetStateRequiresDesiredSourceAndMinimum(t *testing.T) {
 	t.Parallel()
 	now := time.Now().UTC()

--- a/gestaltd/internal/appregistry/fleet_state_test.go
+++ b/gestaltd/internal/appregistry/fleet_state_test.go
@@ -144,6 +144,26 @@ func TestEvaluateFleetState(t *testing.T) {
 				got.Errors != tc.wantErrors {
 				t.Fatalf("projection = %#v", got)
 			}
+			if len(got.Replicas) != got.LiveInstances {
+				t.Fatalf("replicas len = %d, liveInstances = %d", len(got.Replicas), got.LiveInstances)
+			}
+			var onDesired, mismatched, errors int
+			for _, replica := range got.Replicas {
+				switch replica.Class {
+				case core.AppFleetReplicaClassOnDesired:
+					onDesired++
+				case core.AppFleetReplicaClassMismatched:
+					mismatched++
+				case core.AppFleetReplicaClassError:
+					errors++
+				default:
+					t.Fatalf("unexpected replica class %q in %#v", replica.Class, replica)
+				}
+			}
+			if onDesired != got.RunningDesiredVersion || mismatched != got.Mismatched || errors != got.Errors {
+				t.Fatalf("replica class counts on=%d mis=%d err=%d; aggregates run=%d mis=%d err=%d",
+					onDesired, mismatched, errors, got.RunningDesiredVersion, got.Mismatched, got.Errors)
+			}
 		})
 	}
 }

--- a/gestaltd/internal/server/handlers_app_admin_registry.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry.go
@@ -87,16 +87,28 @@ type appAdminRollout struct {
 }
 
 type appAdminFleetState struct {
-	State                   string `json:"state"`
-	SourceVersion           string `json:"sourceVersion,omitempty"`
-	DesiredVersion          string `json:"desiredVersion,omitempty"`
-	MinimumHealthyInstances int    `json:"minimumHealthyInstances"`
-	LiveInstances           int    `json:"liveInstances"`
-	RunningDesiredVersion   int    `json:"runningDesiredVersion"`
-	Mismatched              int    `json:"mismatched"`
-	Errors                  int    `json:"errors"`
-	HeartbeatTTLSeconds     int64  `json:"heartbeatTtlSeconds"`
-	EvaluatedAt             string `json:"evaluatedAt"`
+	State                   string                 `json:"state"`
+	SourceVersion           string                 `json:"sourceVersion,omitempty"`
+	DesiredVersion          string                 `json:"desiredVersion,omitempty"`
+	MinimumHealthyInstances int                    `json:"minimumHealthyInstances"`
+	LiveInstances           int                    `json:"liveInstances"`
+	RunningDesiredVersion   int                    `json:"runningDesiredVersion"`
+	Mismatched              int                    `json:"mismatched"`
+	Errors                  int                    `json:"errors"`
+	HeartbeatTTLSeconds     int64                  `json:"heartbeatTtlSeconds"`
+	EvaluatedAt             string                 `json:"evaluatedAt"`
+	Replicas                []appAdminFleetReplica `json:"replicas,omitempty"`
+}
+
+type appAdminFleetReplica struct {
+	InstanceID             string `json:"instanceId"`
+	StartedAt              string `json:"startedAt,omitempty"`
+	HeartbeatAt            string `json:"heartbeatAt"`
+	AppState               string `json:"appState"`
+	RunningVersion         string `json:"runningVersion,omitempty"`
+	ObservedDesiredVersion string `json:"observedDesiredVersion,omitempty"`
+	LastError              string `json:"lastError,omitempty"`
+	Class                  string `json:"class"`
 }
 
 type appAdminRecovery struct {
@@ -431,7 +443,27 @@ func (s *Server) projectAppAdminFleetState(ctx context.Context, app string) (*ap
 	if projection == nil {
 		return nil, nil
 	}
-	return &appAdminFleetState{
+	return appAdminFleetStateFromProjection(projection), nil
+}
+
+func appAdminFleetStateFromProjection(projection *core.AppFleetProjection) *appAdminFleetState {
+	if projection == nil {
+		return nil
+	}
+	replicas := make([]appAdminFleetReplica, 0, len(projection.Replicas))
+	for _, replica := range projection.Replicas {
+		replicas = append(replicas, appAdminFleetReplica{
+			InstanceID:             replica.InstanceID,
+			StartedAt:              formatAdminTime(replica.StartedAt),
+			HeartbeatAt:            formatAdminTime(replica.HeartbeatAt),
+			AppState:               string(replica.AppState),
+			RunningVersion:         replica.RunningVersion,
+			ObservedDesiredVersion: replica.ObservedDesiredVersion,
+			LastError:              replica.LastError,
+			Class:                  string(replica.Class),
+		})
+	}
+	out := &appAdminFleetState{
 		State:                   string(projection.State),
 		SourceVersion:           projection.SourceVersion,
 		DesiredVersion:          projection.DesiredVersion,
@@ -442,7 +474,11 @@ func (s *Server) projectAppAdminFleetState(ctx context.Context, app string) (*ap
 		Errors:                  projection.Errors,
 		HeartbeatTTLSeconds:     int64(projection.HeartbeatTTL / time.Second),
 		EvaluatedAt:             formatAdminTime(projection.EvaluatedAt),
-	}, nil
+	}
+	if len(replicas) > 0 {
+		out.Replicas = replicas
+	}
+	return out
 }
 
 func appAdminRecoveryFromCore(observation *core.AppVersionRecoveryObservation) *appAdminRecovery {

--- a/gestaltd/internal/server/handlers_app_admin_registry.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry.go
@@ -451,7 +451,8 @@ func appAdminFleetStateFromProjection(projection *core.AppFleetProjection) *appA
 		return nil
 	}
 	replicas := make([]appAdminFleetReplica, 0, len(projection.Replicas))
-	for _, replica := range projection.Replicas {
+	for i := range projection.Replicas {
+		replica := &projection.Replicas[i]
 		replicas = append(replicas, appAdminFleetReplica{
 			InstanceID:             replica.InstanceID,
 			StartedAt:              formatAdminTime(replica.StartedAt),

--- a/gestaltd/internal/server/handlers_app_admin_registry.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry.go
@@ -107,6 +107,7 @@ type appAdminFleetReplica struct {
 	AppState               string `json:"appState"`
 	RunningVersion         string `json:"runningVersion,omitempty"`
 	ObservedDesiredVersion string `json:"observedDesiredVersion,omitempty"`
+	ObservedAt             string `json:"observedAt,omitempty"`
 	LastError              string `json:"lastError,omitempty"`
 	Class                  string `json:"class"`
 }
@@ -460,6 +461,7 @@ func appAdminFleetStateFromProjection(projection *core.AppFleetProjection) *appA
 			AppState:               string(replica.AppState),
 			RunningVersion:         replica.RunningVersion,
 			ObservedDesiredVersion: replica.ObservedDesiredVersion,
+			ObservedAt:             formatAdminTime(replica.ObservedAt),
 			LastError:              replica.LastError,
 			Class:                  string(replica.Class),
 		})

--- a/gestaltd/internal/server/handlers_app_admin_registry_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry_test.go
@@ -947,10 +947,14 @@ func TestAppAdminRegistryFleetStateAndRecoveryResponseShapes(t *testing.T) {
 			RunningDesiredVersion   int    `json:"runningDesiredVersion"`
 			EvaluatedAt             string `json:"evaluatedAt"`
 			Replicas                []struct {
-				InstanceID     string `json:"instanceId"`
-				AppState       string `json:"appState"`
-				RunningVersion string `json:"runningVersion"`
-				Class          string `json:"class"`
+				InstanceID             string `json:"instanceId"`
+				StartedAt              string `json:"startedAt"`
+				HeartbeatAt            string `json:"heartbeatAt"`
+				AppState               string `json:"appState"`
+				RunningVersion         string `json:"runningVersion"`
+				ObservedDesiredVersion string `json:"observedDesiredVersion"`
+				ObservedAt             string `json:"observedAt"`
+				Class                  string `json:"class"`
 			} `json:"replicas"`
 		} `json:"fleetState"`
 		Recovery struct {
@@ -968,11 +972,16 @@ func TestAppAdminRegistryFleetStateAndRecoveryResponseShapes(t *testing.T) {
 		current.FleetState.EvaluatedAt == "" {
 		t.Fatalf("current registry state = %#v", current)
 	}
-	if len(current.FleetState.Replicas) != 1 ||
-		current.FleetState.Replicas[0].InstanceID != "instance-a" ||
-		current.FleetState.Replicas[0].AppState != "running" ||
-		current.FleetState.Replicas[0].RunningVersion != fixture.Version ||
-		current.FleetState.Replicas[0].Class != "on_desired" {
+	replica := current.FleetState.Replicas
+	if len(replica) != 1 ||
+		replica[0].InstanceID != "instance-a" ||
+		replica[0].StartedAt != deployedAt.UTC().Format(time.RFC3339) ||
+		replica[0].HeartbeatAt != now.Add(-5*time.Second).UTC().Format(time.RFC3339) ||
+		replica[0].AppState != "running" ||
+		replica[0].RunningVersion != fixture.Version ||
+		replica[0].ObservedDesiredVersion != fixture.Version ||
+		replica[0].ObservedAt != now.Add(-5*time.Second).UTC().Format(time.RFC3339) ||
+		replica[0].Class != "on_desired" {
 		t.Fatalf("current fleet replicas = %#v", current.FleetState.Replicas)
 	}
 	if current.Recovery.RecoveredAt != recoveredAt.Format(time.RFC3339) ||

--- a/gestaltd/internal/server/handlers_app_admin_registry_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry_test.go
@@ -946,6 +946,12 @@ func TestAppAdminRegistryFleetStateAndRecoveryResponseShapes(t *testing.T) {
 			LiveInstances           int    `json:"liveInstances"`
 			RunningDesiredVersion   int    `json:"runningDesiredVersion"`
 			EvaluatedAt             string `json:"evaluatedAt"`
+			Replicas                []struct {
+				InstanceID     string `json:"instanceId"`
+				AppState       string `json:"appState"`
+				RunningVersion string `json:"runningVersion"`
+				Class          string `json:"class"`
+			} `json:"replicas"`
 		} `json:"fleetState"`
 		Recovery struct {
 			RecoveredAt   string `json:"recoveredAt"`
@@ -961,6 +967,13 @@ func TestAppAdminRegistryFleetStateAndRecoveryResponseShapes(t *testing.T) {
 		current.FleetState.RunningDesiredVersion != 1 ||
 		current.FleetState.EvaluatedAt == "" {
 		t.Fatalf("current registry state = %#v", current)
+	}
+	if len(current.FleetState.Replicas) != 1 ||
+		current.FleetState.Replicas[0].InstanceID != "instance-a" ||
+		current.FleetState.Replicas[0].AppState != "running" ||
+		current.FleetState.Replicas[0].RunningVersion != fixture.Version ||
+		current.FleetState.Replicas[0].Class != "on_desired" {
+		t.Fatalf("current fleet replicas = %#v", current.FleetState.Replicas)
 	}
 	if current.Recovery.RecoveredAt != recoveredAt.Format(time.RFC3339) ||
 		current.Recovery.SourceVersion != "source-a" {


### PR DESCRIPTION
## Summary

`GET /api/v1/apps/{app}/admin/registry` now returns `fleetState.replicas`: live per-instance observations on the current source version, classified in the same `EvaluateFleetState` pass as the aggregate counters.

## Why / context

Versions needs a real replica tree (snapshot → processes). Aggregates alone cannot name instances or nest them under running versions. Inventing rows from `liveInstances` would lie about identity. Heartbeats already carry per-instance data; the projector was discarding it after counting.

Platform-admin `freshReplicas` / `staleReplicas` stay on their separate diagnostic contract (all sources, stale rows, source status). This PR owns the live fleet classification path Versions consumes — not a second reclassification of heartbeats.

## What changed

- `AppFleetProjection.Replicas` populated while counting (`on_desired` / `mismatched` / `error`), including `ObservedAt`
- Stable replica order: newest `heartbeatAt`, then `instanceId`
- App-admin JSON maps those rows as `fleetState.replicas`
- Additive / backward compatible (`omitempty` when empty)

## Validation

- [x] Automated: `go test ./internal/appregistry/ ./internal/server/ -run 'Fleet|AppAdminRegistryFleet|ReplicaIdentity'`
- [ ] Not run: visual PR demo — API-only change; no UI surface in gestalt
- CI re-running on HEAD after rebase + review fixes

## Reviewer focus

- Class assignment must stay identical to counter increments (`len(replicas) == liveInstances`)
- Admin DTO should remain a pure projection of `AppFleetReplicaObservation` (no second classification path)
- Do not merge this JSON shape with platform-admin diagnostic replicas in this PR

## Rollout / compatibility

Deploy gestaltd before relying on the providers Versions UI replica chips. Older clients ignore the new field.

## Evidence / demo

Shape (abridged):

```json
{
  "fleetState": {
    "state": "healthy",
    "liveInstances": 1,
    "runningDesiredVersion": 1,
    "replicas": [
      {
        "instanceId": "instance-a",
        "appState": "running",
        "runningVersion": "<desired>",
        "observedAt": "2026-…",
        "class": "on_desired"
      }
    ]
  }
}
```

Covered by `TestAppAdminRegistryFleetStateAndRecoveryResponseShapes` and `TestEvaluateFleetStateReplicaIdentityAndOrder`.