### PR TITLE
Document service mesh architecture and prototypes

### DIFF
--- a/plans/service_mesh/plan.md
+++ b/plans/service_mesh/plan.md
@@ -13,7 +13,7 @@
 
 ## Overview
 
-The platform builds, distributes, installs, and runs packages in a shared service mesh. A package release may include:
+The platform builds, distributes, installs, and runs packages in a shared mesh. A release may include:
 
 - An MCP server and its operations
 - One or more single-page user interfaces
@@ -21,66 +21,64 @@ The platform builds, distributes, installs, and runs packages in a shared servic
 - Dependency and migration metadata
 - Per-operation authorization relationship or role requirements
 
-The platform supports the following roles and workflows.
-
 ### Organization Administrator
 
-An organization administrator can:
+An organization administrator:
 
-- Operate one deployment with a private registry and administration surfaces, such as `https://vt.valon.tools`, `/registry`, and `/admin`.
-- Pull trusted releases into the private registry by canonical package ID and release version, supplying upstream read credentials at import time.
-- Browse installed apps as a graph, including operations, UIs, workflows, dependencies, versions, identities, and authorization.
-- Open an app administration page, change its version, or install and remove it.
+- Operates a deployment with one private registry and administration surfaces such as `https://vt.valon.tools`, `/registry`, and `/admin`.
+- Imports trusted releases by canonical package ID and version, supplying upstream read credentials per import.
+- Browses installed apps as a graph of operations, UIs, workflows, dependencies, versions, identities, and authorization.
+- Installs, updates, and removes apps.
 
 ### Package Publisher
 
-A publisher can:
+A publisher:
 
-- Define package metadata, operations, dependencies, workflows, UIs, and migration jobs in `package.yaml`.
-- Run `vt build <dir>` to validate the package and build a release bundle locally, or pass `--push` to publish it to the deployment registry.
-- Run `vt dev --deployment <url> <dir>` to test a package in an isolated, user-scoped mesh sandbox before publishing it.
+- Defines package metadata, operations, dependencies, workflows, UIs, and migrations in `package.yaml`.
+- Runs `vt build <dir>` to validate and build locally, with `--push` to publish.
+- Runs `vt dev --deployment <url> <dir>` in an isolated user sandbox.
 
 ### Package Administrator
 
-A package administrator can:
+A package administrator:
 
-- Inspect an app and its deployment details.
-- Manage an app's desired release version within the administrator's package-scoped authority.
-- Promote releases from the private registry manually or through deployment rules.
-- Perform the first installation that admits a package into the mesh.
-- Select organization-managed identities for runtimes, migrations, and workflows.
-- Decide whether an operation runs only as its workload identity or may exercise explicitly delegated caller authority.
-- Bind each permission as either a durable grant or delegated authority.
+- Inspects app deployment details.
+- Manages desired release versions within package-scoped authority.
+- Promotes releases manually or through deployment rules.
+- Performs the first installation.
+- Selects organization-managed identities for runtimes, migrations, and workflows.
+- Chooses workload-only or delegated caller authority per operation.
+- Binds permissions as durable grants or delegated authority.
 
-A durable grant cannot exceed the human issuer's authority when created and remains until it is explicitly revoked, expires, or is invalidated by a policy migration. Delegated authority is bounded by the subject's current authority and narrows immediately when that authority is lost.
+A durable grant cannot exceed its human issuer's authority and lasts until revocation, expiration, or invalidation by policy migration. Delegated authority tracks the subject's current authority.
 
-Package administration and publishing are independent roles, although the same person may hold both. Publishing, installation, and promotion remain separate actions.
+Publishing and package administration are independent roles. Publishing, installation, and promotion are separate actions.
 
 ### Package User
 
-A package user can:
+A package user:
 
-- Open a deployment and browse only the apps, operations, UIs, and workflows they are authorized to see.
-- Launch an app UI or invoke an operation through MCP Streamable HTTP or `vt invoke`.
-- Manage their API grants and use a development sandbox when authorized.
-- Use these capabilities without access to organization or app administration surfaces.
+- Browses authorized apps, operations, UIs, and workflows.
+- Launches app UIs and invokes operations through MCP Streamable HTTP or `vt invoke`.
+- Manages API grants and authorized development sandboxes.
+- Has no organization or app administration access.
 
 ## Registries
 
-The registry protocol is open. Anyone may operate a compatible registry; there is no central creation or approval authority.
+The registry protocol is open and has no central authority.
 
 ### Deployment Registry
 
-Each deployment has exactly one deployment registry, also called its private registry, and uses it as the sole package catalog and artifact source. Installation, upgrade, rollback, and recovery never fetch directly from an external registry.
+Each deployment has one private registry as its sole catalog and artifact source. Installation, upgrade, rollback, and recovery never fetch externally.
 
 Releases enter through:
 
-- **Push**: an authorized publisher uploads a release created for the deployment registry. Publication credentials authorize only the permitted package and release actions.
-- **Pull-through import**: an administrator specifies a canonical package ID, release version, and upstream read credentials at import time. The registry resolves the source registry from the package ID, verifies the release, and stores the complete release locally before exposing it.
+- **Push**: an authorized publisher uploads a release. Credentials are scoped to permitted package and release actions.
+- **Pull-through import**: an administrator supplies a canonical package ID, version, and upstream read credentials. The registry resolves, verifies, and stores the complete release before exposure.
 
 ### Build
 
-Publishers create releases from a source directory with `vt build <dir>`. For example:
+`vt build <dir>` creates a release from a source directory:
 
 ```text
 g-issues/
@@ -96,7 +94,7 @@ g-issues/
     └── admin-console/
 ```
 
-`package.yaml` defines the package name, version, operations, dependencies, workflows, UIs, migration jobs, and authorization requirements. Runtime and migration code must be Bun applications; packages do not supply Dockerfiles or custom container images. Workflow definitions and operation schemas are referenced by `package.yaml` rather than requiring separate source directories. `vt build g-issues/` validates the package, installs dependencies from the frozen Bun lockfile, builds digest-addressed Bun application artifacts locally, and writes a logical release bundle.
+`package.yaml` defines package metadata, operations, dependencies, workflows, UIs, migrations, and authorization. It references workflow definitions and operation schemas; no fixed directories are required. Runtime and migration code must be Bun applications; packages cannot supply images or Dockerfiles. `vt build` validates the package, installs from the frozen lockfile, builds digest-addressed artifacts, and writes the release bundle.
 
 ### Example Release Bundle
 
@@ -116,28 +114,28 @@ g-issues@2.3.1
     └── admin-console.tar.gz
 ```
 
-A UI-only or workflow-only package omits the runtime Bun app.
+UI-only or workflow-only packages omit the runtime.
 
 ```sh
 vt build <dir>
 vt build <dir> --push
 ```
 
-Without `--push`, `vt build` writes the release bundle locally and needs no deployment credentials. With `--push`, it uploads the release bundle to the deployment registry after building.
+Without `--push`, the build is local and needs no deployment credentials. `--push` uploads the completed bundle.
 
 ### CLI Authentication
 
-`vt build <dir> --push` authenticates to the deployment registry before upload. The CLI resolves credentials in this order:
+For `--push`, the CLI resolves credentials in this order:
 
 1. `VT_API_KEY` environment variable
 2. A session stored in the OS keychain from a prior `vt auth login`
 3. Interactive `vt auth login` if no credential is available
 
-`--push` is idempotent: retrying the same release after interruption resumes or completes the existing attempt instead of creating a duplicate catalog entry.
+`--push` is idempotent and resumes interrupted uploads.
 
 ### Stored Content and Backing Services
 
-Google Cloud Storage stores the immutable release bundle: runtime and migration Bun app artifacts, UI bundles, workflow definitions, schemas, the canonical release manifest, and detached signatures. Each artifact is stored under its SHA-256 digest. Uploads use generation-match preconditions so an existing digest cannot be overwritten; bucket retention and versioning provide additional recovery and immutability safeguards.
+Cloud Storage holds immutable release bundles and detached signatures by SHA-256 digest. Generation-match preconditions prevent overwrite; retention and versioning support recovery.
 
 The registry service tracks catalog and control-plane metadata separately from Cloud Storage:
 
@@ -148,13 +146,13 @@ The registry service tracks catalog and control-plane metadata separately from C
 
 ### Identity and Trust
 
-Each registry controls discovery, download, and publication access. The deployment registry authorizes its readers and publishers; upstream registries enforce their own policies. Pull-through import uses read-only credentials supplied for that import operation.
+Each registry controls discovery, download, and publication. Pull-through imports use per-operation read-only credentials.
 
 Each registry has a stable `registryId` derived from its root public key.
 
 ### Pull-through Imports
 
-An administrator specifies a canonical package ID, release version, and upstream read credentials at import time. The canonical package ID encodes the source registry; no standing upstream source configuration is required. The import grants read access only for that operation; installation still requires the organization's trust policy to accept the release signature. The registry verifies the complete release, then atomically adds it to the local catalog; failed imports remain invisible. Imported releases keep their source identity, signatures, and digest.
+The canonical package ID identifies the source registry, so no standing upstream configuration is required. The registry uses per-import credentials, verifies the complete release, then atomically exposes it. Failed imports remain hidden. Installation separately enforces organization trust policy. Imported releases retain source identity, signatures, and digest.
 
 ## Publishing and Distribution
 
@@ -183,21 +181,21 @@ An administrator specifies a canonical package ID, release version, and upstream
 
 #### Verification
 
-When the registry receives a push request, it authenticates the publisher, verifies signatures, digests, and contracts, and rejects conflicting republications of the same `releaseVersion`. A `releaseVersion` follows a documented grammar and binds permanently to one `releaseDigest`. Only after those checks succeed does the registry expose the release in the catalog.
+On push, the registry authenticates the publisher, verifies signatures, digests, and contracts, and rejects conflicting `releaseVersion` republications. `releaseVersion` follows a documented grammar and permanently binds to one `releaseDigest`. Exposure follows successful verification.
 
-Pull-through import has its own validation before copying an external release locally; installation is a separate check that re-verifies the selected `releaseDigest` before admitting a package into the mesh.
+Import validates before copying. Installation re-verifies the selected `releaseDigest`.
 
 ### First Installation
 
-First installation admits a cataloged release into the mesh. Installation of `g-issues@2.3.1` proceeds as follows:
+First installation admits a cataloged release:
 
 1. **Select a release.** A package administrator chooses the app and an immutable `releaseDigest` from the registry catalog.
 2. **Review the contract.** The platform shows declared operations, dependencies, workflows, UIs, migrations, and required authorization relationships.
 3. **Bind identities.** The administrator selects organization-managed service accounts for the runtime, migration jobs, and workflows when the release includes them.
 4. **Configure operation authority.** For each operation, the administrator decides whether it runs only as the workload identity or may exercise delegated caller authority, and binds permissions as durable grants or delegated authority.
 5. **Approve admission.** The administrator confirms the bindings. This requires `service_account.assign` for each identity and `authorization.grant` for each relationship or role being granted.
-6. **Verify and prepare.** The control plane re-verifies the `releaseDigest`, resolves dependencies, reserves the package slot, binds identities, provisions mesh routes and policies, and then runs prepare migrations.
-7. **Roll out.** For releases with a runtime, the revision controller creates runtime workloads. It stages UI and workflow artifacts and promotes the revision once readiness checks converge. The app then appears in user-facing catalogs and becomes invocable.
+6. **Verify and prepare.** The control plane re-verifies the `releaseDigest`, resolves dependencies, reserves the package slot, binds identities, provisions waypoint routes and mesh policies, and then runs prepare migrations.
+7. **Roll out.** The revision controller creates runtime workloads when present, stages UI and workflow artifacts, and promotes after readiness converges.
 
 ## Package Revisions
 
@@ -205,17 +203,17 @@ First installation admits a cataloged release into the mesh. Installation of `g-
 
 The control plane persists:
 
-- **Package slots**: one organization-scoped slot keyed by canonical package identity, reserved before allocating an installation ID and used to fence concurrent first installs
+- **Package slots**: organization-scoped slots keyed by canonical package identity, reserved before installation ID allocation to fence concurrent first installs
 - **Revision requests**: append-only records of install, upgrade, rollback, and removal intent, including the actor, previous promoted revision, target release or tombstone, deployment-registry catalog generation and applicable trust-policy revision, approved authorization bindings, resolved dependencies, and timestamps
 - **Installation head**: last successfully promoted revision and current admitted candidate
-- **Revision operation**: one generation-fenced state machine per installation, including phase, candidate Kubernetes resources, deadlines, stability timestamp, and routing generation
+- **Revision operation**: one generation-fenced state machine per installation with phase, candidate resources, deadlines, stability timestamp, and routing generation
 - **Migration outcomes**: immutable status keyed by installation, `releaseDigest`, and migration ID
 - **Routing and catalog generations**: independent operation-routing, package, operation, UI, and workflow generations committed for the promoted revision
 - **Terminal outcomes**: completion or failure phase, duration, and reason
 
 ### Installation Reconciliation
 
-Publishing does not install a package. An authorized installer selects an immutable `releaseDigest` and supplies the following bindings and settings:
+An installer selects an immutable `releaseDigest` and supplies:
 
 - An organization-managed Kubernetes service account when the release has a runtime or migration
 - Organization-managed workflow identities
@@ -223,21 +221,21 @@ Publishing does not install a package. An authorized installer selects an immuta
 - Caller-delegation policy per operation
 - Initial replica, resource, and availability settings when the release has a runtime
 
-Installation is a reconciled saga:
+Installation uses a reconciled saga:
 
-1. Verify that the release is complete in the deployment registry, then verify its source registry identity, applicable trust policy, release signature, referenced artifact digests, platform support, runtime compatibility, and schema versions.
+1. Verify registry completeness, source identity, trust policy, signatures, digests, platform support, runtime compatibility, and schema versions.
 2. Resolve exact dependency revisions and operation-contract digests.
 3. Reserve the organization package slot and persist the revision request, approved authorization snapshot, and fenced revision operation.
-4. Bind the installation to any required runtime, migration, and workflow identities, authorization relationships, ambient data-plane enrollment, and `AuthorizationPolicy` attachments.
+4. Bind identities, authorization, ambient and waypoint enrollment, L4 bypass policy, and waypoint `AuthorizationPolicy` attachments.
 5. Hand the fenced operation to the revision controller, which follows the canonical phases in [Revision Rollouts](#revision-rollouts).
 
-Failures preserve phase and diagnostics. The revision controller retries within policy and cleans up resources created for an unpromoted revision when an administrator cancels the operation. Promotion, catalog exposure, and canary behavior follow the rules in Revision Rollouts.
+Failures preserve phase and diagnostics. The controller retries within policy and cleans up unpromoted resources after cancellation.
 
 ### Dependencies and Contracts
 
-Dependencies specify canonical package identities, `releaseVersion` ranges, whether they are required or optional, and operation-contract digests. Admission records the selected revisions and digests.
+Dependencies specify package identity, version range, requirement level, and operation-contract digests. Admission records resolved revisions and digests.
 
-The platform validates:
+Admission validates:
 
 - Every required dependency has a promoted compatible revision
 - Required operations exist
@@ -246,18 +244,18 @@ The platform validates:
 - No conflicting revision operation is active in the affected dependency subgraph
 - Workflow calls reference compatible operation contracts
 
-All schemas use the same JSON Schema version and are normalized before hashing. Initially, schemas are compatible only when their hashes match.
+Schemas share one JSON Schema version and are normalized before hashing. Initially, compatibility requires equal hashes.
 
 ### Revision Rollouts
 
-Runtime upgrades use Kubernetes blue/green rollouts. Each candidate revision runs in a distinct immutable Deployment behind a revision-specific Service, and the serving Deployment is never restarted or mutated in place. Promotion advances the promoted head and all catalog generations in one state-store transaction only after routing, UI, and workflow prerequisites converge for a stability window. Failure before that commit restores prior routing without advancing any generation. Convergence is verified from Kubernetes workload health, per-proxy routing-status reports, and ambient enrollment gates.
+Runtime upgrades use blue/green rollouts. Each revision has an immutable Deployment and Service; serving Deployments are never mutated. Promotion atomically advances the promoted head and catalog generations after routing, UI, and workflow checks pass for a stability window. Pre-commit failure restores routing without advancing generations. Checks cover workload health, Gateway API route status, waypoint configuration distribution, and ambient enrollment.
 
-The canonical revision-operation phases are:
+Phases:
 
 1. **Admitted**: validate release, policy, compatibility, and dependencies.
 2. **Preparing**: run fenced, backward-compatible prepare migrations.
 3. **Starting**: create runtime resources and stage candidate UI and workflow artifacts.
-4. **Ready**: hold every applicable check for the stability window.
+4. **Ready**: require every applicable check to pass for the stability window.
 5. **Canarying**: send limited traffic only for contracts identical to the promoted revision, without catalog exposure.
 6. **Promoting**: execute the convergence and atomic commit protocol above.
 7. **Draining**: enforce the pinned-session and hard-deadline protocol below.
@@ -265,55 +263,55 @@ The canonical revision-operation phases are:
 9. **Finalizing**: run separately approved irreversible migrations.
 10. **Complete**: record convergence and timing.
 
-The prior revision drains pinned sessions and MCP SSE streams until a hard deadline while new sessions route only to the promoted revision. Pre-promotion failure leaves the prior revision primary; post-promotion failure marks the new revision degraded without automatic rollback—the next revision operation waits for an administrator retry, an approved rollback, or a forward fix.
+Existing MCP SSE connections remain pinned until closure or deadline. Stateful follow-ups carry a signed session token and revision header; `ext_authz` validates the token before the waypoint routes by header. New sessions follow controller-owned weights. Pre-promotion failure retains the prior revision. Post-promotion failure marks the new revision degraded and requires retry, approved rollback, or forward fix.
 
 ### Migrations and Rollback
 
-Migrations are separately identified, digest-pinned jobs. Each declares:
+Each digest-pinned migration declares:
 
 - Migration ID and `releaseDigest`
 - Phase—the revision lifecycle stage in which the job runs
-  - **Prepare** — runs before promotion while the prior revision may still serve traffic. Changes must be backward-compatible with the serving revision (the expand phase of an expand/contract migration).
-  - **Finalize** — runs after promotion once the candidate is primary. These migrations may be irreversible; destructive jobs require separate administrator approval (the contract phase of an expand/contract migration).
-  - **Compensating** — runs on approved rollback to reverse or repair data changes from prior migrations when returning to an earlier revision.
+  - **Prepare** — backward-compatible changes before promotion.
+  - **Finalize** — potentially irreversible changes after promotion; destructive jobs require separate approval.
+  - **Compensating** — data reversal or repair during approved rollback.
 - Dedicated workload identity
 - Timeout, resource limits, retry policy, and idempotency key
 - Compatibility with the prior and candidate package revisions
 
-In the expand phase of an expand/contract migration, the schema changes remain compatible with the serving revision. The contract phase removes the obsolete schema only after the new revision is primary.
+Expand changes remain compatible with the serving revision. Contract changes remove obsolete schema only after promotion.
 
 ## Runtime and Access
 
 ### Authentication and Authorization
 
-The authorization service is the system of record for organization policy. It stores Zanzibar-style tuples used by management, user-invocation, workflow, and package-to-package authorization checks. Enforcement topology and mesh policy attachment are defined in [Runtime Architecture](#runtime-architecture).
+The authorization service is the system of record for organization policy, stored as Zanzibar-style tuples for management, user, workflow, and package calls.
 
 - Users authenticate through an external identity provider with organization-level SSO, issuer and tenant allowlists, and session revocation.
-- API keys are credentials for named, expiring, scoped API grants that act on behalf of an owner. Only hashes are stored; plaintext is returned only once, and an empty scope does not mean unrestricted access.
+- API keys are credentials for named, expiring, scoped grants that act for an owner. Only hashes are stored; plaintext is returned once. Empty scope grants nothing.
 - `service_account.create` permits creating an organization-managed service account but grants it no authority.
 - `service_account.assign` permits binding a service account to a package runtime, workflow definition, or workflow execution but grants it no new authority.
-- `authorization.grant` permits granting a relationship or role and may be held only by a human subject. The grant cannot exceed the issuer's current authority, resource scope, conditions, or expiration.
+- `authorization.grant` is human-only and cannot exceed the issuer's authority, resource scope, conditions, or expiration.
 - Every installed package runtime uses an organization-owned workload identity. Workflow definitions are bound to organization-owned workflow identities that the workflow service uses for execution.
 - Every invocation is centrally authorized before dispatch; package-specific resource checks may further restrict it.
-- Production does not start in a fail-open mode when identity or authorization is unavailable.
+- Production fails closed when identity or authorization is unavailable.
 
 ### Authorization Model and Evaluation
 
-Authorization uses a provider-independent check protocol built around:
+Authorization checks include:
 
 - A canonical **subject** being evaluated, such as the effective subject, immediate caller workload, or management actor
 - An **action**, such as a package operation or administrative permission
 - A canonical **resource**, identified by a reserved platform type or a package-namespaced type
 
-The platform reserves resource types for registries, packages, releases, installations, revisions, workflows, identities, and authorization grants. Packages register namespaced resource types at admission and cannot use reserved names.
+The platform reserves registry, package, release, installation, revision, workflow, identity, and authorization-grant types. Packages register namespaced types at admission.
 
 ### Package Access Policy
 
-Release manifests define only the authorization relationships or roles required to invoke each operation. MCP endpoints are mesh-internal by default. External invocation uses the deployment ingress and the same authorization service. Direct package egress defaults to deny and is managed by deployment policy rather than release metadata.
+Release manifests declare required relationships or roles per operation. MCP endpoints are mesh-internal. Every invocation passes through the destination waypoint. Ambient L4 policy and `NetworkPolicy` block waypoint bypass; the Bun wrapper rejects requests without signed internal caller context. External calls use deployment ingress and the same authorization service. Deployment policy controls default-deny egress.
 
 ### Workflows
 
-Packages publish immutable workflow definitions that the revision controller registers with a mesh workflow service. Each execution is pinned to its definition and operation-contract digests until completion, migration, or retirement, while new executions use the promoted catalog generation.
+The controller registers immutable workflow definitions. Executions remain pinned to definition and contract digests until completion, migration, or retirement; new executions use the promoted catalog generation.
 
 ### User Interfaces
 
@@ -338,7 +336,7 @@ Users connect a package to an external service through the CLI:
 vt connect <package>
 ```
 
-The CLI opens a browser-based login flow. After the user authenticates and grants access, the platform syncs the resulting external credentials into its secret-management service for the package connection.
+The CLI opens browser login, then stores granted credentials in the secret-management service.
 
 TODO: Define provider discovery, requested scopes and consent, callback handling, credential storage and rotation, revocation, and package access to connected credentials.
 
@@ -350,93 +348,99 @@ Authorized operations are available over the deployment endpoint and through the
 vt invoke --deployment <url> <package> <operation> --args <json>
 ```
 
-Authentication comes from an interactive session, keychain, environment, or standard input. Positional arguments never carry secrets or tokens.
+Authentication comes from a session, keychain, environment, or standard input. Positional arguments never carry secrets.
 
-Invocation uses MCP Streamable HTTP: JSON-RPC over POST with JSON or SSE responses. The gateway enforces request size, timeout, rate, and stream lifetime.
+MCP Streamable HTTP requests carry reserved installation and operation headers; stateful requests also carry a revision header and signed session token. Ingress authenticates external callers, strips caller-supplied internal-context headers, validates routing headers, and issues a short-lived caller token bound to that metadata. Workloads obtain equivalent tokens internally.
 
-Ingress strips external identity and routing fields, authenticates the credential, and exchanges it for a short-lived signed caller token; it neither parses MCP nor authorizes operations. The token is bound to its issuer, waypoint audience, target installation, and raw envelope hash. It carries a unique ID; issuance, not-before, and expiry times; actor and effective subject; credential and delegation upper bounds; optional browser-capability claims; a delegation chain; and a trace ID. After authorization, the destination waypoint replaces the caller token with a signed internal caller context containing only the claims the runtime needs.
+The waypoint calls `ext_authz`, then routes by header to a revision Service. Authorization validates tokens, operation access, and quota, then returns signed internal caller context. Invalid requests never reach the runtime.
+
+The Bun wrapper verifies context, operation/body agreement, and schema before dispatch. Ingress enforces external limits; waypoint policy controls transport; the wrapper enforces payload and argument-dependent authorization.
 
 ### Development Sandbox
 
-`vt dev` builds a local package and connects it only to an explicitly enabled per-user sandbox:
+`vt dev` connects a local build to an enabled per-user sandbox:
 
 ```sh
 vt dev --deployment <url> <dir>
 ```
 
-Authentication uses the normal interactive or keychain flow. The platform assigns a short-lived development workload identity distinct from the user. Routes are scoped to the developer or named test session and cannot claim a production package slug.
+The platform assigns a short-lived development workload identity. Routes are scoped to the developer or test session and cannot claim production slugs.
 
 Development packages:
 
-- Receive traffic only from their developer or explicitly named test sessions and never become the default production route
+- Receive traffic only from their developer or named test sessions and never become the production default
 - Cannot run migrations
 - Cannot receive or forward raw caller credentials
 - Do not inherit the production workload's permissions
 - Use sandbox-scoped authorization
 - Expire automatically and are audited upon connection and disconnection
 
-The first implementation has one production deployment profile: Kubernetes with Istio ambient mode and the protected platform services described below. `vt build` may run locally, but there is no production runtime for standalone laptops or VMs, unauthenticated operation, or operation outside the mesh. The development sandbox is a capability of a connected deployment rather than a second local control plane.
+Production runs only on Kubernetes with self-managed Istio ambient. Pinned Helm releases install base CRDs, `istiod`, ambient CNI, and `ztunnel`; managed Google Cloud Service Mesh lacks the required data plane. There is no laptop or VM production profile. Development sandboxes use the connected deployment.
 
 ## Platform Architecture
 
 ### Deployment Tiers
 
-The platform separates deployment into three trust and lifecycle tiers:
+Deployment has three trust tiers:
 
-1. **Bootstrap substrate**: Kubernetes and Istio, the Google Cloud Storage artifact bucket, the control-plane state store, revision controllers, certificate authority, and backup and recovery tooling. Terraform provisions or deploys these components before package APIs are available.
-2. **Protected system packages**: identity, authorization, secret management, registry verification, audit, and workflow execution. After the bootstrap substrate is healthy, revision controllers install and upgrade these services using signed releases and the normal immutable revision and rollout machinery.
-3. **Ordinary organization packages**: packages installed by authorized organization or package administrators and constrained by organization policy.
+1. **Bootstrap substrate**: Kubernetes, Istio ambient, artifact storage, state store, revision controllers, certificate authority, and recovery tooling. Terraform provisions these before package APIs.
+2. **Protected system packages**: ingress authentication, identity, authorization, secrets, registry verification, audit, and workflows. After bootstrap, controllers deploy signed releases through normal revision machinery.
+3. **Organization packages**: administrator-installed packages constrained by organization policy.
 
-The bootstrap substrate and protected system packages are both inside the platform availability boundary. If a required component in either tier is unavailable, the affected capability is counted as platform downtime even when some existing package traffic continues. An ordinary package failure counts as downtime for that package, not for the platform, unless a platform defect caused or propagated the failure.
+Bootstrap and protected services are inside the platform availability boundary. Their failure is platform downtime for affected capabilities. Organization package failure affects only that package unless caused or spread by the platform.
 
 ### Trusted Platform Services
 
-The bootstrap substrate and protected system packages provide these trusted services:
-
-- **Identity service**: authenticates sessions and API grants, resolves canonical principals, manages organization service accounts, issues caller tokens, and manages signing keys for internal caller contexts and session wrappers.
-- **Authorization service**: stores immutable policy models, grants, assignments, and revocations and evaluates provider-independent and Envoy `ext_authz` checks.
-- **Secret-management service**: stores and rotates platform and connection credentials and releases secret material only to explicitly authorized workload identities.
-- **Registry-verification service**: validates the deployment registry and pull-through imports identified by canonical package ID. Before catalog exposure and admission, it verifies manifests, digests, signatures, platform compatibility, trust policy, and local artifact completeness.
+- **Identity service**: authenticates sessions and API keys, resolves principals, manages service accounts, and issues signed caller and session tokens.
+- **Authorization service**: stores immutable policy models, grants, assignments, and revocations; evaluates provider-independent and Envoy `ext_authz` checks; and signs the internal caller contexts forwarded to package runtimes.
+- **Secret-management service**: stores and rotates credentials and releases them only to authorized workload identities.
+- **Registry-verification service**: verifies manifests, digests, signatures, compatibility, trust policy, and artifact completeness before exposure and admission.
 - **Audit sink**: writes append-only security, authorization, administration, and runtime events to storage that packages cannot control.
-- **Workflow service**: registers promoted package-defined workflows and runs pinned executions outside package runtimes.
-- **Control-plane state store**: a bootstrap-substrate service that durably stores deployment-registry state, import attempts and provenance, package slots, revision requests and operations, routing and catalog generations, migration outcomes, and recovery metadata.
+- **Workflow service**: registers promoted workflows and runs pinned executions outside package runtimes.
+- **Control-plane state store**: stores registry state, import provenance, package slots, revision state, generations, migrations, and recovery metadata.
 
 ### Runtime Architecture
 
-Production uses Istio ambient mode. Package Pods have no mesh or application proxy sidecar; they expose MCP and health endpoints directly. Every package runtime and migration executes as a Bun application in a platform-owned, unprivileged Bun container image; publishers cannot provide arbitrary images or Dockerfiles. The runtime combines `istiod`, mandatory node-level `ztunnel`, shared destination and ingress waypoints, gateways, these standardized Bun application containers, protected services, the state store, and revision controllers. Revision controllers reconcile durable state into Deployments, Services, waypoint enrollment, Gateway API routes, signed cluster-selection configuration, and `AuthorizationPolicy`; `istiod` distributes the resulting xDS configuration. `istiod` owns endpoint, routing, certificate, and mesh-policy distribution—not revision state, grants, workflows, or catalogs.
+Production uses self-managed Istio ambient with shared destination waypoints and no Pod sidecars. Runtimes and migrations use a platform-owned, unprivileged Bun image. The runtime wrapper owns MCP and health listeners, verifies caller context and operation/body agreement, validates schemas, dispatches package code, reports health, emits telemetry, and drains. Migrations use a non-serving entry point.
+
+The platform runtime includes `istiod`, node-level `ztunnel`, ingress, destination waypoints, Bun containers, protected services, state store, and revision controllers. Controllers reconcile durable state into workloads, Services, enrollment, routes, and policies. `istiod` distributes endpoints, routes, identities, certificates, and policies but does not own revisions, grants, workflows, or catalogs.
 
 **`ztunnel` configures (L4):**
 
-- mTLS and identity-based L4 `AuthorizationPolicy` on workload ports, including bypass prevention for direct Pod IP or revision Service access
-- Ambient workload enrollment, policy-generation binding, and readiness gating until the current generation is loaded
+- mTLS and identity-based L4 policy, including direct Pod and revision Service bypass prevention
+- Workload enrollment and readiness gating on policy generation
 - L4 telemetry and audit for connection, byte, policy-denial, and bypass events
 
-`ztunnel` cannot enforce L7 policy, decode MCP, select revision backends, or run `ext_authz` authorization checks.
+`ztunnel` cannot enforce L7 policy, select revision backends, or run `ext_authz` authorization checks.
 
-**Waypoints configure (L7):**
+**Destination waypoints configure and enforce L7 behavior:**
 
-- Gateway API `HTTPRoute` resources, waypoint enrollment, and protected extensions (MCP decoder, `ext_authz`, cluster selector, session wrapper, routing-status reporter, and audit adapter)
-- MCP decoding, authorization, and operation-specific revision routing via decoder metadata and signed generation-fenced routing tables—not caller headers or `HTTPRoute` matching
-- Signed session routing wrappers for SSE pinning, plus L7 request, MCP outcome, and trace telemetry
+- Gateway API routing by installation, operation, and optional session revision to revision-specific Services
+- Provider-independent operation authorization through `CUSTOM` `AuthorizationPolicy` and `ext_authz`
+- Weighted routing and signed session-route validation
+- L7 telemetry and transport policy
+- Rate or quota enforcement through `ext_authz`
 
-Ingress authenticates external credentials and mints caller tokens; the destination waypoint decodes and authorizes MCP requests. Health probes use a separate protected port with only the minimum necessary policy exception. `NetworkPolicy` provides reachability enforcement alongside ambient policy. Authorization fails closed; health ports have no public ingress. If a required security event cannot be delivered or durably buffered, the affected request fails closed. If `istiod` is unavailable, established traffic uses its last configuration; new revision operations requiring routing or policy changes fail closed until dependencies recover.
+Waypoints do not decode MCP or use custom Envoy, Wasm, or `TrafficExtension` filters. They trust metadata approved by `ext_authz`; the Bun wrapper enforces metadata/body agreement.
+
+Ingress authenticates and mints caller tokens; waypoints authorize and route; the wrapper verifies internal context and body agreement. Health probes use a protected, non-public port. `NetworkPolicy` supplements ambient policy. Authorization and required security-event delivery or buffering fail closed. Without `istiod`, existing traffic uses cached configuration while configuration-dependent revision operations stop.
 
 ### Infrastructure and Service Rollouts
 
-The mesh is redeployed only for changes to Istio or its trust and extension configuration, including:
+Mesh redeployment is limited to:
 
-- `istiod`, `ztunnel`, and waypoint proxy versions
-- Ingress and egress gateway versions or deployment-pinned configuration
+- `istiod`, ambient CNI, and `ztunnel` versions
+- Destination waypoint and optional Istio ingress or egress gateway versions
 - Istio certificate-authority and trust-domain configuration
-- Mesh-wide extension-provider and ambient-enrollment configuration
+- Mesh-wide ambient-enrollment and L4 policy configuration
 
-Protected system packages roll independently through the revision controller and do not require a mesh redeployment. Ordinary package revisions, registry trust-policy changes, identity assignments, and authorization-binding updates likewise change runtime or control-plane state without redeploying the mesh.
+Protected and organization packages roll independently. Package revisions, registry trust, identity, and authorization changes do not redeploy the mesh.
 
-Bootstrap-substrate changes, including control-plane state migrations and backup or recovery tooling, use infrastructure rollouts but do not redeploy the mesh unless they also change an Istio item listed above. Package releases declare supported MCP and Bun versions. Infrastructure pins Kubernetes, Istio, Envoy, the platform Bun container image, the shared MCP extension, session-token format, authorization adapter, and routing-status extension versions and accounts for overlapping old and new versions before admitting releases that require new features. Registry trust-root changes remain separately authorized and audited.
+Bootstrap changes use infrastructure rollouts and redeploy the mesh only when changing an item above. Releases declare supported MCP and Bun versions. Infrastructure pins Kubernetes, Istio, Envoy, the Bun image, routing contract, token formats, and routing schema, with version overlap before admitting dependent releases. Registry trust-root changes require separate authorization and audit.
 
 ## Representative Request Lifecycles
 
-The following representative lifecycles remain to be specified:
+To specify:
 
 - Provision the deployment registry
 - Import a package release through pull-through
@@ -462,12 +466,13 @@ The following representative lifecycles remain to be specified:
 | Revision | Installed release or removal tombstone |
 | Revision operation | Fenced execution of durable revision intent |
 | Promotion | Atomic commit advancing the promoted head and catalog generations |
-| Routing generation | Durable correlation of one routing decision, its resources, proxy set, and observations |
+| Routing generation | Durable correlation of waypoint routing state, selected revision Services, route and proxy convergence, and observations |
 | Service account | Organization-managed non-human principal that may be assigned to runtimes, migrations, or workflows |
 | Workload identity | Runtime identity materialized from an assigned service account and enforced by Kubernetes and the mesh |
 | Workflow identity | Identity bound to a workflow definition and used by the workflow service for executions |
-| Caller token | Signed pre-authorization context presented only to a destination waypoint |
+| Caller token | Signed pre-authorization context presented only to an authorized destination waypoint |
 | Internal caller context | Signed post-authorization context forwarded to a runtime |
+| Bun runtime wrapper | Platform-owned runtime layer that verifies internal caller context, validates schemas, and dispatches publisher package code |
 | Protected system package | Signer-pinned platform package unavailable to ordinary package APIs |
-| Waypoint | Shared Envoy proxy for MCP authorization, revision routing, sessions, and telemetry |
+| Waypoint | Shared ambient Envoy proxy that authorizes declared invocation metadata and routes requests to revision-specific Services using standard Gateway API configuration |
 | `ztunnel` | Node-level ambient proxy for L4 security and workload identity |

--- a/plans/service_mesh/plan.md
+++ b/plans/service_mesh/plan.md
@@ -1,0 +1,146 @@
+# Service Mesh Design
+
+## Overview
+
+The platform builds, distributes, installs, and runs services in a shared service mesh. A service package may include:
+
+- An MCP server and its operations
+- User interface (single-page app or SPA's)
+- Workflows
+- Dependency and migration metadata
+- Runtime and authorization requirements
+
+Organizations operate a deployment backed by one private registry and, optionally, additional public registries. The deployment exposes a catalog of installed services, operations, interfaces, workflows, and dependencies.
+
+## Architecture
+
+The runtime consists of:
+
+- **Control plane (`istiod`)**: manages mesh configuration and service routing.
+- **Ingress data plane**: receives traffic from the load balancer.
+- **Service data plane (`gestaltd`)**: runs alongside each service and mediates mesh traffic.
+- **Service runtime**: runs the service's server, interfaces, and workflows.
+
+Terraform deploys the GCP infrastructure, including the Valon Tools cluster, GitHub Actions cluster, networking, container infrastructure, and identity services.
+
+## Service Packages
+
+When first published, a registry assigns the service a UUID unique within that registry and associates it with a human-readable slug. Service references include both the registry and UUID. Each package version consists of a built OCI image and a service manifest for a specific platform. The service manifest contains:
+
+- The immutable OCI image reference and digest
+- Instructions for starting the MCP server and user interfaces
+- The MCP endpoint, operations, and input/output schemas
+- Included workflows and interfaces
+- Service and operation dependencies
+- Ordered pre-upgrade and rollback commands
+- Service-account and authorization requirements
+- Health and readiness endpoints
+- Configuration and secret requirements
+- Image signature and build provenance
+
+Upgrade commands may perform schema migrations, workflow changes, or other dependency updates. They should be idempotent and reversible where possible.
+
+## Registries
+
+Registries store versioned service packages and control who can discover or download them. A deployment may use private, organization-specific, and public registries, provided each implements the registry interface.
+
+Each registry exposes a catalog manifest listing its services. Each entry includes the registry-scoped service UUID, slug, available versions and platforms, service manifest location, and immutable OCI image reference and digest. The OCI image is the deployable artifact; a Dockerfile may be retained as optional source provenance but is not part of the runtime contract.
+
+A registry can be connected to a GitHub repository and configured to build from `main`, pull requests, or label-based rules. Service developers can also build and push packages directly.
+
+## Build and Publish
+
+1. `vt build <dir>` builds a service package from a source directory and its manifest.
+2. The build produces a platform-specific OCI image with an immutable digest.
+3. The package is published through the configured GitHub integration or with `--push <registry-url>`.
+4. The registry publishes the catalog and service manifests and points them to the built OCI image.
+
+`vt dev <url> <dir> <token>` injects a local service into an existing mesh for development. A development service runs with the developer's identity.
+
+## Installation
+
+Publishing a service does not install it. On first installation, an organization administrator selects a version and configures:
+
+- The identity used by workflows
+- The identity used by service operations
+- Whether an operation forwards the caller's identity
+- The service's authorized operations
+
+A service identity cannot initially exceed the installer’s authorization. Its relationships are assigned using the authorization model below.
+
+Installing or removing a service updates the runtime catalog without redeploying the service mesh.
+
+## Upgrades
+
+Before an upgrade, the platform verifies that required operations exist, dependencies are ready and not being upgraded, and the package defines valid pre-upgrade and rollback commands.
+
+The upgrade sequence is:
+
+1. Pull the new OCI image.
+2. Run the service's pre-upgrade commands in order.
+3. Start the new service version.
+4. Validate startup and the `/ready` endpoint.
+5. Shift traffic to the new version.
+
+The old version continues serving until the traffic shift. If an upgrade step fails, the platform stops the upgrade and records the failed command and error. An authorized administrator then resolves the failure and manually runs the declared rollback commands.
+
+After traffic shifts, traffic may return to the old version only when the package declares that rollback safe. Automatic rollback can be added later using the same commands and safety declaration.
+
+Workflows should continue running during an upgrade unless they call the service being upgraded. Service operations and interfaces may be unavailable during the traffic transition. The target is less than ten seconds of downtime.
+
+## Administration and Discovery
+
+An organization deployment provides:
+
+- A service catalog
+- An operation catalog
+- A user-interface catalog
+- A dependency graph
+- Service details, versions, workflows, identities, and authorization settings
+- API-key management
+- A development sandbox
+
+Organization administrators can connect registries and install, upgrade, or remove services. Service developers can build, publish, test, and invoke services. Service users see only the catalogs and tools available to them.
+
+Representative endpoints:
+
+- Deployment: `https://vt.valon.tools`
+- Private registry: `https://vt.valon.tools/registry`
+- Administration: `https://vt.valon.tools/admin`
+- Service administration: `https://vt.valon.tools/services/<service>/admin`
+
+## Invocation
+
+Authorized operations are available over the deployment endpoint and through the CLI:
+
+```sh
+vt invoke <url> <service> <operation> <args> <token>
+```
+
+Operation invocation uses MCP Streamable HTTP. Clients and services must support JSON-RPC over POST and the protocol's JSON and SSE response forms.
+
+## Authentication and Authorization
+
+- Users authenticate through an external identity provider, with organization-level SSO support.
+- Users can create API keys that act as their identity.
+- Users can create service accounts with a subset of their permissions.
+- Every installed service has an assigned identity.
+- Every operation can enforce authorization.
+
+Authorization uses a Zanzibar-style graph of relationship tuples. Each relationship definition declares whether it supports delegated assignments, persistent grants, both, or neither. The default is neither.
+
+- **Delegated assignment (`delegatable`)**: a relationship holder can create a derived assignment that cannot exceed or outlive its parent assignment.
+- **Persistent grant (`grantable`)**: a principal with the relationship-specific grant permission can create an independent assignment that remains until explicitly revoked.
+
+Assignments record their issuer, assignment mode, creation time, optional expiration, and optional parent assignment. Revoking a parent invalidates its delegated descendants, while an independent assignment through another path preserves access. Persistent grants require an explicit Zanzibar permission such as `can_grant_<relationship>`.
+
+## Mesh Deployment
+
+The mesh is redeployed only when changing mesh infrastructure, including:
+
+- The `istiod` snapshot
+- The `gestaltd` snapshot
+- Ingress
+- Egress
+
+Installing, upgrading, or removing services and adding or removing registries are runtime changes and do not require a mesh redeployment.

--- a/plans/service_mesh/plan.md
+++ b/plans/service_mesh/plan.md
@@ -31,8 +31,7 @@ The platform should enable the following user experiences.
 An organization administrator can:
 
 - Operate one deployment, private registry, and administration surface, such as `https://vt.valon.tools`, `/registry`, and `/admin`.
-- Configure source automation to build and publish packages from GitHub branches, pull requests, or label-based rules.
-- Configure read-only upstream registry sources and pull trusted releases into the private registry.
+- Pull trusted releases into the private registry by canonical package ID and release version, supplying upstream read credentials at import time.
 - Browse installed apps as a graph, including operations, UIs, workflows, dependencies, versions, identities, and authorization.
 - Open an app administration page, change its version, or install and remove it.
 
@@ -41,11 +40,8 @@ An organization administrator can:
 A publisher can:
 
 - Define package metadata, operations, dependencies, workflows, UIs, and migration jobs in a source manifest.
-- Run `vt build <dir>` and optionally push the result directly to the deployment registry.
-- Use repository automation instead of pushing manually.
+- Run `vt build <dir>` to validate the package and build a release bundle locally, or add `--push` to publish it to the deployment registry.
 - Run `vt dev --deployment <url> <dir>` to test a package in an isolated, user-scoped mesh sandbox before publishing it.
-
-Migration jobs should be retry-safe and reversible where practical. Explicitly approved one-time jobs are supported when idempotency is impossible; their durable outcome prevents accidental re-execution.
 
 ### Package Administrator
 
@@ -53,7 +49,6 @@ A package administrator can:
 
 - Inspect an app and its deployment details.
 - Manage its desired version within their package-scoped authority.
-- Invoke any app operation they are authorized to use.
 - Promote releases from the private registry manually or through deployment rules.
 - Perform the first installation that admits a package into the mesh.
 - Select organization-managed identities for runtimes, migrations, and workflows.
@@ -84,7 +79,7 @@ Each deployment has exactly one registry and uses it as the sole package catalog
 Releases enter through:
 
 - **Push**: an authorized publisher uploads a release created for the deployment registry. Publication credentials grant only the permitted package and release actions.
-- **Pull-through import**: an administrator imports an external release using read-only upstream authorization. The registry verifies and stores the complete release locally before exposing it.
+- **Pull-through import**: an administrator specifies a canonical package ID, release version, and upstream read credentials at import time. The registry resolves the source registry from the package ID, verifies the release, and stores the complete release locally before exposing it.
 
 ### Build
 
@@ -126,12 +121,13 @@ g-issues@2.3.1
 A UI-only or workflow-only package omits the runtime image.
 
 ```sh
+vt build <dir>
 vt build <dir> --push
 ```
 
-#### CLI authentication
+Without `--push`, `vt build` writes the release bundle locally and needs no deployment credentials. With `--push`, it uploads to the deployment registry after building.
 
-`vt build <dir>` without `--push` needs no deployment credentials.
+#### CLI authentication
 
 `vt build <dir> --push` authenticates to the deployment registry before upload. The CLI resolves credentials in this order:
 
@@ -139,7 +135,7 @@ vt build <dir> --push
 2. A session stored in the OS keychain from a prior `vt auth login`
 3. Interactive `vt auth login` if no credential is available
 
-`--push` is safe to run idempotently: retrying the same release after interruption resumes or completes the existing attempt instead of creating a duplicate catalog entry. Pending and failed attempts are visible but never installable. Concurrent publishers cannot lose catalog updates. Stale attempts become failed, and orphaned content-addressed blobs are garbage-collected after a grace period.
+`--push` is safe to run idempotently: retrying the same release after interruption resumes or completes the existing attempt instead of creating a duplicate catalog entry.
 
 ### Stored Content and Backing Services
 
@@ -147,31 +143,26 @@ Google Artifact Registry stores the immutable release bundle: runtime and migrat
 
 The registry service also tracks metadata that Artifact Registry does not provide on its own:
 
-- Package IDs, slugs, version indexes, and tombstones
+- Canonical package IDs, slugs, version indexes, and tombstones
 - Publication and import attempts, including pending and failed state
 - Catalog indexes that map `(package, version)` to `releaseDigest`
-- Trusted upstream registries and which publishers we accept from them
-- Import history, including where a release came from and whether the copy completed
-
-Upstream read credentials live in the secret-management service, and signing keys live in KMS; neither is stored with package artifacts.
+- Import history, including source registry identity, release provenance, and whether the copy completed
 
 ### Identity and Trust
 
 Every registry is responsible for permissioning who can pull from it and who can publish to it.
 
-The deployment registry controls read access for discovery and download, and write access for authorized publishers. Upstream registries do the same on their side; pull-through import uses read-only credentials supplied for that one-time operation.
+The deployment registry controls read access for discovery and download, and write access for authorized publishers. Upstream registries do the same on their side; pull-through import uses read-only credentials supplied for that import operation.
 
 Each registry has a stable `registryId` derived from its root public key.
 
 ### Pull-through Imports
 
-Upstream access is a one-time import that grants read access only; installation still requires organization trust in the release signature. An administrator import verifies the complete release, then atomically adds it to the local catalog; failed imports remain invisible. Imported releases keep their source identity, signatures, and digest.
+An administrator specifies a canonical package ID, release version, and upstream read credentials at import time. The canonical package ID encodes the source registry; no standing upstream source configuration is required. The import grants read access only for that operation; installation still requires organization trust in the release signature. The registry verifies the complete release, then atomically adds it to the local catalog; failed imports remain invisible. Imported releases keep their source identity, signatures, and digest.
 
 ## Publishing and Distribution
 
 ### Package Releases
-
-Each `(registryId, packageId, releaseVersion)` has one canonical release manifest with detached signatures. Runtime and migration binaries may vary by platform; manifest contracts do not.
 
 `release_manifest.json` must declare:
 
@@ -179,7 +170,7 @@ Each `(registryId, packageId, releaseVersion)` has one canonical release manifes
 - Digest references for every artifact produced by `vt build`
 - MCP operations with input and output schema digests
 - Required and optional package and operation dependencies
-- Ordered prepare, finalize, and compensating migration jobs
+- Ordered migration jobs
 - Required authorization relationships or roles for each operation
 - Supported MCP protocol versions
 - Runtime startup instructions and probe contract for releases that include a runtime
@@ -197,7 +188,7 @@ Each `(registryId, packageId, releaseVersion)` has one canonical release manifes
 
 When the registry receives a push request, it authenticates the publisher, verifies signatures, digests, and contracts, and rejects conflicting republications of the same `releaseVersion`. A `releaseVersion` follows a documented grammar and binds permanently to one `releaseDigest`. Only after those checks succeed does the registry expose the release in the catalog.
 
-Pull-through import has its own validation before copying an external release locally; installation is a separate check that re-verifies the selected `releaseDigest` before admitting a package into the mesh.
+Pull-through import has its own validation before copying an external release locally; installation is a separate check that re-verifies the selected `releaseDigest` before admitting a package into the **mesh**.
 
 ### First Installation
 
@@ -210,8 +201,6 @@ A release in the registry catalog is not yet running in the mesh. The first inst
 5. **Approve admission.** The administrator confirms the bindings. This requires `service_account.assign` for each identity and `authorization.grant` for each relationship or role being granted.
 6. **Verify and prepare.** The control plane re-verifies the `releaseDigest`, resolves dependencies, reserves the package slot, runs prepare migrations, and provisions identities, mesh routes, and policies.
 7. **Roll out.** The revision controller creates runtime workloads when needed, stages UI and workflow artifacts, and promotes the revision once readiness checks converge. The app then appears in user-facing catalogs and becomes invocable.
-
-Releases without a runtime skip workload creation but still register workflows, UIs, and catalog entries through the same path. See [Installation](#installation) and [Revision Rollouts](#revision-rollouts) for the durable state machine and promotion rules.
 
 ## Package Revisions
 
@@ -227,8 +216,6 @@ The control plane persists:
 - **Routing and catalog generations**: independent operation-routing, package, operation, UI, and workflow generations committed for the promoted revision
 - **Terminal outcomes**: completion or failure phase, duration, and reason
 
-The revision-operation phase is the canonical lifecycle state. Image availability, process status, replica health, routing synchronization, and catalog generation are observations attached to that operation, not additional lifecycle states.
-
 ### Installation
 
 Publishing does not install a package. An authorized installer selects an immutable `releaseDigest` and binds:
@@ -238,8 +225,6 @@ Publishing does not install a package. An authorized installer selects an immuta
 - Package-declared authorization relationships or roles for each operation
 - Caller-delegation policy per operation
 - Initial replica, resource, and availability settings when the release has a runtime
-
-Before admission, the platform shows package-declared operation access requirements and resulting authorization bindings. The installer — an organization administrator or package administrator with install authority — needs `service_account.assign` for each selected identity and `authorization.grant` for each relationship or role being granted.
 
 Installation is a reconciled saga:
 
@@ -266,33 +251,9 @@ The platform validates:
 
 All schemas use the same JSON Schema version and are normalized before hashing. Initially, schemas are compatible only when their hashes match.
 
-Declared dependencies and workflow references are the authoritative compatibility boundary for operation removal. A candidate may remove an operation when no installed package or workflow definition or execution retained by policy references it, including after accounting for other revisions in the same atomic rollout group. External callers do not create an implicit dependency: callers using stale catalogs, cached operation names, or otherwise undeclared contracts may receive an operation-unavailable error after promotion.
-
-Validation reads a revisioned desired-state snapshot and commits with generation preconditions. Independent packages may upgrade concurrently. Upgrades affecting the same dependency subgraph use deterministic locking or one atomic rollout group. Cyclic dependencies may be upgraded sequentially when every intermediate state is compatible. Mutually dependent changes require an atomic rollout group.
-
-An atomic rollout group is one durable request containing candidates for multiple package slots, one desired-state snapshot, and one lock order. Admission validates compatibility across the complete before-and-after graph. Controllers may prepare, start, and canary members independently. All members' routing intents and external registration prerequisites converge first; promoted heads and package, operation, UI, and workflow catalog generations then commit in one generation-fenced state-store transaction. A pre-commit failure restores routing for every member and advances none of their promoted heads.
-
 ### Revision Rollouts
 
-Releases with an MCP runtime use a Kubernetes-native blue/green rollout with optional Istio canary traffic. Each runtime upgrade creates a candidate revision in a distinct immutable Kubernetes Deployment behind a revision-specific Service. The promoted and candidate Deployments may run together, so the serving Deployment is never restarted or mutated in place. Runtime-less releases use the same durable revision state machine without creating runtime Deployments or Services.
-
-Revision operations use optimistic concurrency and fencing tokens, so a controller that loses its lease cannot mutate a newer generation. Retries are idempotent, and every external mutation has a stable idempotency key.
-
-For runtime releases, Kubernetes is the source of truth for live workload health and configured image identity. A runtime candidate is ready only when Kubernetes has observed the Deployment generation, its required replicas are available, each Pod specification is pinned to the expected platform-manifest digest resolved from the admitted image index, ambient enrollment and policy readiness gates are true, and runtime probes and synthetic MCP contract checks remain successful for a stability window. Replacement pods and autoscaled replicas count by current readiness, not persistent identity.
-
-Before promotion, the interface service verifies and stages every UI bundle, while the workflow service registers each definition as candidate-only and acknowledges its digest. These records remain absent from user catalogs. A release without a runtime reaches Ready after artifact verification and applicable UI and workflow acknowledgements; it skips runtime resource creation, Canarying, runtime routing, Draining, and runtime observation.
-
-Each installation with an MCP runtime has one stable frontend Service and revision-specific backend Services. Gateway API `HTTPRoute` resources establish the package route, while a protected waypoint cluster-selector extension applies the admitted operation-specific revision weights after MCP decoding and authorization. Callers never address a revision Service directly. Packages may call other packages only through declared dependencies and these mesh-managed routes. Direct or undeclared package-to-package calls are blocked.
-
-The controller assigns each routing change a durable `routingGeneration` and records the exact Kubernetes resource UIDs, generations, waypoint cluster-selection configuration, and desired route and policy hashes that implement it. Infrastructure installs a protected routing-status extension in every ingress gateway and waypoint; the extension exposes, over an mTLS-protected administration endpoint, the routing generations and configuration hashes currently loaded by that proxy. This extension and endpoint are versioned with the pinned Istio/Envoy build and covered by infrastructure conformance tests.
-
-The relevant data-plane set is a persisted membership snapshot of available ingress gateways, destination waypoints, and destination-node `ztunnel` instances selected for those resources. Convergence requires accepted and resolved Gateway API status, ready route backends, every gateway and waypoint report matching the desired hashes, ambient status confirming workload enrollment and policy generation on every relevant `ztunnel`, and authenticated allow-path and direct-bypass probes. The controller does not infer application convergence from one global Istio xDS version. Data-plane replacement, loss of availability, or membership change resets the stability window. A bounded timeout fails the phase and leaves enough recorded evidence for deterministic retry or restoration.
-
-Gateway and waypoint readiness is gated on the routing-status extension reporting either the current committed generation or an active generation-fenced rollout generation authorized for that proxy and route. Destination workload readiness is separately gated on ambient enrollment and the current or fenced `ztunnel` policy generation. During promotion, the data plane may remain ready on the fenced candidate generation while convergence is observed. Immediately after the promotion commit, only the newly committed generation satisfies readiness. New or restarted gateways, waypoints, and `ztunnel` instances cannot enter traffic-serving membership until they report the then-current committed generation, so data-plane churn after promotion cannot reintroduce stale routing or bypass policy.
-
-Promotion has one commit point. For runtime releases, the controller first writes primary routing intent while the previous revision remains the persisted promoted head. After routing converges and all UI-serving and workflow-registration acknowledgements remain valid for the stability window, one state-store transaction updates the promoted revision and the relevant routing, package, operation, UI, and workflow generations. Only that transaction constitutes successful promotion. If a prerequisite fails before the transaction, the controller restores previous routing and external registrations and confirms their convergence; it does not advance the promoted head or any catalog generation.
-
-The control plane persists rollout intent and decisions, then reconstructs progress from Kubernetes, Istio, and protected platform services after restart. Historical rollout outcomes remain immutable; current workload health is a separate live view.
+Runtime upgrades use Kubernetes blue/green rollouts: each candidate revision runs in a distinct immutable Deployment behind a revision-specific Service, and the serving Deployment is never restarted or mutated in place. Promotion advances the promoted head and all catalog generations in one state-store transaction only after routing, UI, and workflow prerequisites converge for a stability window; failure before that commit restores prior routing without advancing any generation. Convergence is verified from Kubernetes workload health, per-proxy routing-status reports, and ambient enrollment gates.
 
 The canonical revision-operation phases are:
 
@@ -307,35 +268,21 @@ The canonical revision-operation phases are:
 9. **Finalizing**: run separately approved irreversible migrations.
 10. **Complete**: record convergence and timing.
 
-Inapplicable runtime, canary, drain, observation, and finalization work is skipped. Failure or cancellation is a terminal outcome attached to the stopping phase, not another progression phase.
-
-Each phase has a timeout, retry policy, and terminal error taxonomy. Readiness requires the configured replica capacity, not a single ready pod. During routing propagation and draining, revisions follow the compatibility and operation-removal rules in [Dependencies and Contracts](#dependencies-and-contracts). The prior revision Service remains available for pinned sessions while new session routing targets only the promoted revision. One termination-grace interval before the hard drain deadline, the controller starts Pod deletion and publishes a protected draining cluster containing the terminating Pod endpoints. The waypoint cluster selector admits only valid pinned-session tokens to that cluster and does not depend on normal Service endpoint discovery retaining terminating endpoints. Kubernetes force-terminates any remaining process at the deadline, after which the controller removes the drain cluster and prior revision resources. Existing MCP SSE streams remain pinned to their original revision while the old revision drains, including streams for an operation omitted by the candidate.
-
-Pre-promotion failures mark the candidate failed and leave the prior revision primary. Failures during post-promotion observation mark the new revision degraded. Neither case triggers automatic rollback. Degraded or finalization-error states block the next revision operation until an administrator retries, initiates an approved rollback, or approves a forward fix. Finalization failure records `promoted_with_finalization_error`; it neither marks the promoted revision failed nor changes routing.
-
-Compatible packages target zero planned downtime. Any release requiring downtime must declare it and receive explicit administrator approval before admission.
+The prior revision drains pinned sessions and MCP SSE streams until a hard deadline while new sessions route only to the promoted revision. Pre-promotion failure leaves the prior revision primary; post-promotion failure marks the new revision degraded without automatic rollback—the next revision operation waits for administrator retry, approved rollback, or forward fix.
 
 ### Migrations and Rollback
 
 Migrations are separately identified, digest-pinned jobs. Each declares:
 
 - Migration ID and `releaseDigest`
-- Prepare, finalize, or compensating phase
+- Phase: which revision lifecycle stage runs the job
+  - **Prepare** — runs before promotion while the prior revision may still serve traffic. Changes must be backward-compatible with the serving revision (expand/contract expand).
+  - **Finalize** — runs after promotion once the candidate is primary. May be irreversible; destructive jobs require separate administrator approval (expand/contract contract).
+  - **Compensating** — runs on approved rollback to reverse or repair data changes from prior migrations when returning to an earlier revision.
+
 - Dedicated workload identity
 - Timeout, resource limits, retry policy, and idempotency key
 - Compatibility with the prior and candidate package revisions
-
-Migration jobs use least privilege and deny-by-default egress. They never run as the installer, revision controller, or installation's normal workload identity. Attempts and outcomes are durable.
-
-The first version does not classify rollback safety in release metadata or initiate rollback automatically. Prepare migrations follow expand/contract rules and remain compatible with the serving revision. Destructive finalization requires separate administrator approval. Before manual rollback, an administrator must confirm data compatibility and select any required declared compensating migration; the platform does not infer rollback safety. Administrators may initiate an approved rollback through the revision controller; shell commands cannot update revision state.
-
-### Removal
-
-Removal is a durable tombstoned revision, not catalog-row deletion. Admission rejects it while required reverse dependents exist unless the same atomic rollout group removes them. Preparing records workflow-retirement and data-retention decisions. Starting stages tombstone generations and candidate interface and workflow retirement changes; Ready confirms their acknowledgements. Promoting atomically commits package, operation, UI, and workflow tombstones, disables interface launches, unregisters workflows, stops new executions, and prevents new invocation resolution.
-
-Draining applies the normal hard deadline to resolved runtime requests and streams; workflow executions follow their recorded finish, retire, or migrate policy. Finalizing removes runtime workloads, blocks stale ingress and package egress, revokes installation-owned bindings, assignments, and delegated tokens, and performs approved data retention or destruction. Complete preserves the tombstone and audit history; runtime-resource garbage collection follows the recovery window. Canarying and Observing are skipped.
-
-Organization-owned grants survive removal. Reinstallation gets a new installation identity unless an approved restore reactivates the tombstone.
 
 ## Runtime and Access
 
@@ -352,10 +299,6 @@ The authorization service is the system of record for organization policy. It st
 - Every invocation is centrally authorized before dispatch; package-specific resource checks may further restrict it.
 - Production does not start in a fail-open mode when identity or authorization is unavailable.
 
-Each authorization grant wraps one relationship tuple and records an immutable ID, organization, human issuer, creation and optional expiration, issuance-authority snapshot, and policy revision. Grant mutation creates a new record; revocation appends a revocation record rather than rewriting or deleting history. A later loss of the issuer's authority does not revoke an existing durable grant; revocation, expiration, or an explicit policy migration does. Delegated authority is evaluated against the delegating subject's current authority and narrows immediately with it. Platform controllers may apply a recorded human-authorized grant but cannot originate one.
-
-The first implementation does not cache authorization decisions. Caller tokens and internal caller contexts are short-lived, and every workflow step is authorized independently. Existing streams may continue until their configured lifetime expires. Security events go to an immutable audit sink outside package-controlled storage.
-
 ### Authorization Model and Evaluation
 
 Authorization uses a provider-independent check protocol built around:
@@ -364,57 +307,21 @@ Authorization uses a provider-independent check protocol built around:
 - An **action**, such as a package operation or administrative permission
 - A canonical **resource**, identified by a reserved platform type or a package-namespaced type
 
-The platform reserves resource types for registries, packages, releases, installations, revisions, workflows, identities, and authorization grants. Package-defined resource types are namespaced by canonical package identity and cannot use reserved names. Users and service accounts are subjects unless the requested action manages the identity itself.
-
-A decision returns allow or deny together with the immutable policy model ID and revision used to evaluate it. A batch form evaluates multiple checks against the same policy snapshot and has the same semantics as individual checks; catalogs and controllers use it to avoid per-item authorization calls.
-
-The authorization model defines resource types, relations, actions, and which relations satisfy each action. Relationship targets may be direct subjects, resources, or subject sets such as the members of a group. Subject-set traversal is cycle-safe. Package invocation uses the installation identity as the resource and the canonical operation ID as the action; package-specific checks may use a more specific package-owned resource.
-
-The authorization service stores the policy model and organization-managed grants in one authoritative runtime system. Platform bootstrap registers reserved resource types, while package admission registers namespaced resource types and operation requirements. Each model change produces an immutable, content-hashed generation. Grants may be revoked at any time. A policy-model change cannot remove or rename a resource type or relation referenced by active grants unless those grants are revoked or migrated in the same transaction. Grants are indexed by subject, relation, and resource so evaluation does not scan the complete relationship set.
-
-Credential scopes are an upper bound on authority: a relationship grant cannot restore access excluded by the authenticated credential. Missing subjects, actions, resources, or policy models—and authorization-provider outages—produce a denial.
+The platform reserves resource types for registries, packages, releases, installations, revisions, workflows, identities, and authorization grants. Packages register namespaced resource types at admission and cannot use reserved names.
 
 ### Package Access Policy
 
-Release manifests define only the authorization relationships or roles required to invoke each operation. They do not declare configuration, secrets, ingress, or egress capabilities.
-
-Package upgrades cannot directly change organization-managed grants. A subject with appropriately scoped `authorization.grant` may update those grants within their delegated authority. An upgrade succeeds admission only when all required bindings and delegation approvals are present; otherwise it fails before rollout and may be retried after they are supplied.
-
-MCP endpoints are mesh-internal by default. External invocation uses the deployment ingress and the same authorization service. Direct package egress defaults to deny and is managed by deployment policy rather than release metadata.
+Release manifests define only the authorization relationships or roles required to invoke each operation. MCP endpoints are mesh-internal by default. External invocation uses the deployment ingress and the same authorization service. Direct package egress defaults to deny and is managed by deployment policy rather than release metadata.
 
 ### Workflows
 
-Packages publish immutable workflow definitions, not workers. The revision controller registers promoted definitions with a workflow MCP service in the mesh. Each execution records its definition digest, actor, workflow identity, and compatible operation-contract digests.
-
-The workflow service runs each execution against its pinned definition until completion, migration, or documented retirement. New executions use the promoted workflow catalog generation. Removal and incompatible upgrades account for queued work, retries, timers, and long-running executions.
-
-Every workflow operation is authorized at execution. Selecting an organization-managed service account as a workflow identity requires `service_account.assign`. The triggering actor remains in the audit and delegation chain.
-
-Each workflow definition has a package-stable ID and immutable definition digest. Its release metadata declares input and output schemas, operation-contract references, retry and timeout policy, supported signals, timer behavior, and whether concurrent executions are allowed. Definition IDs cannot be reassigned to unrelated workflows.
-
-Running executions remain pinned to their definition and operation-contract digests. A replacement definition does not mutate them. Before an incompatible upgrade or removal, admission requires one explicit policy for every affected execution class: allow pinned executions to finish, stop starting new executions and retire after a deadline, or run a declared migration that produces a new execution record. Forced termination is a separately authorized and audited action. Signals, timers, retries, and queued steps follow the pinned definition until the selected policy completes.
-
-`runAs` means explicit delegation from the triggering actor to the selected workflow identity. It never substitutes an unverified subject. The authorization service validates the delegation at execution start, and every step separately checks the workflow identity, effective subject, target operation, and current credential upper bound.
+Packages publish immutable workflow definitions that the revision controller registers with a mesh workflow service; each execution is pinned to its definition and operation-contract digests until completion, migration, or retirement, while new executions use the promoted catalog generation.
 
 ### User Interfaces
 
-UI bundles are immutable content-addressed artifacts referenced by the release manifest. Each interface declares a package-stable interface ID, entry document, asset root, visibility, CSP profile, and an operation allowlist. Bundles are static and cannot contain server-side executable code.
-
-The platform assigns each installation interface a stable non-executable launch origin and a distinct executable origin for every promoted UI generation beneath a deployment-controlled wildcard application domain. The launch origin only redirects to the currently promoted generation and serves no package-controlled document or script. Package generations never share an executable origin, cookies, service workers, browser storage, or CSP authority with deployment administration, protected services, another interface, or an older generation.
-
-Private interfaces use an origin-scoped session established through the normal external identity flow. The interface service issues a short-lived browser capability only when the request originates from the currently promoted generation's verified entry document. The capability names the installation, interface ID, UI generation, allowed operations, and exact generation-specific origin. Ingress validates that capability and the `Origin` header, rejects stale generations, and carries its signed allowlist claims into the caller token. After decoding the MCP request, the destination waypoint rejects browser operations outside that allowlist in addition to performing normal subject authorization. A public interface must be explicitly allowed by organization policy, and public asset access does not make its operations public. Browser code never receives workload credentials, caller tokens, or internal caller contexts.
-
-The platform applies the declared CSP profile, strict CORS, MIME validation, integrity metadata, response-size limits, immutable caching for revision-qualified assets, and service-worker scope restrictions. Interfaces requiring embedding use opaque sandboxed frames and explicit `postMessage` schemas; embedding does not grant same-origin access.
+TODO
 
 ### Catalogs and Administration
-
-An organization deployment exposes package, operation, UI, and workflow catalogs; a dependency graph; revision, rollout, migration, identity, and authorization administration; API-grant management; and a development sandbox.
-
-Administrative catalogs may expose candidate metadata. User-facing package, operation, UI, and workflow catalogs expose only their atomically promoted generations. New operation contracts appear only after applicable routing, UI-serving, and workflow-registration prerequisites in [Revision Rollouts](#revision-rollouts) have converged.
-
-Clients treat catalogs as snapshots. Invocation remains authoritative and may reject stale or undeclared operations under the rules in [Dependencies and Contracts](#dependencies-and-contracts).
-
-Organization administrators can configure upstream pull sources, authorize imports, and install, upgrade, roll back, or remove packages. Package administrators can perform revision and administration actions within their delegated package and authorization scope. Package developers with registry write access can build, publish, test, and invoke packages. Package users see only catalogs and operations authorized for them.
 
 Representative endpoints:
 
@@ -438,28 +345,6 @@ Authentication comes from an interactive session, keychain, environment, or stan
 Invocation uses MCP Streamable HTTP: JSON-RPC over POST with JSON or SSE responses. The gateway enforces request size, timeout, rate, and stream lifetime.
 
 Ingress strips external identity and routing fields, authenticates the credential, and exchanges it for a short-lived signed caller token; it neither parses MCP nor authorizes operations. The token is bound to its issuer, waypoint audience, target installation, and raw envelope hash. It carries a unique ID; issuance, not-before, and expiry times; actor and effective subject; credential and delegation upper bounds; optional browser-capability claims; delegation chain; and trace ID.
-
-The deployment exposes package-scoped MCP endpoints rather than one endpoint that multiplexes package names from JSON-RPC bodies. A protected MCP extension shared by destination waypoints validates the caller token and request-envelope hash, parses the JSON-RPC envelope, resolves the request class and canonical operation ID, and writes trusted dynamic metadata for `ext_authz`, routing, canary selection, and telemetry. Callers cannot supply that metadata. Malformed JSON-RPC, unsupported methods, unknown operations, mismatched hashes, and expired tokens fail at the waypoint before reaching a package.
-
-MCP methods map to authorization and routing as follows:
-
-- `initialize`, `ping`, and session negotiation require the installation-level `package.connect` action and do not select an operation.
-- Catalog and discovery methods terminate at a protected catalog service behind the waypoint. They require their catalog-read action, use a batch authorization check against one policy snapshot, and return only entries authorized for the effective subject; untrusted package runtimes do not filter their own discoverability.
-- Operation calls such as `tools/call` resolve the package-stable operation ID from validated parameters and require that operation's action and resource checks.
-- Cancellation, progress, and other session notifications must reference an existing authorized session and inherit its installation, revision, actor, and effective subject. They cannot change authorization scope.
-- Unsupported methods fail closed. A JSON-RPC batch is accepted only when every item has the same target installation, request class, operation, authorization scope, session, and routing target and each item is authorized independently; otherwise the complete batch is rejected.
-
-The waypoint sends verified caller context and decoded request metadata to authorization. On allow, the adapter returns short-lived signed internal context carrying the actor, effective subject, applicable immediate workload, and delegation chain. It is bound to the target installation, request class, applicable operation, envelope hash, applied credential and delegation bounds, applicable browser claims, policy generation, and trace ID. The waypoint removes the external token and reserved fields. Catalog requests terminate at the protected catalog service; runtime requests select a revision Service and forward only the internal context.
-
-After `ext_authz`, a protected metadata-aware cluster-selector extension uses only decoder-generated metadata and the signed routing table for the committed or active fenced generation to select operation-specific canary backends for runtime request classes. Catalog and discovery classes bypass revision selection and terminate at the catalog service. No route trusts a caller-supplied operation header, and standard `HTTPRoute` header matching is not used for decoded operations.
-
-For a new session, the waypoint wraps the runtime-issued opaque session ID in a client-opaque signed routing token containing the installation, revision, `releaseDigest`, routing generation, issued and expiry times, and random nonce. On each successful continuation or response, the waypoint may rotate the wrapper without extending it beyond the configured maximum session lifetime or revision drain deadline. The waypoint verifies and unwraps continuations before routing to their named revision Service. Cancellation is forwarded to that revision, and reconnect succeeds only while the wrapper is valid and the revision remains inside its drain deadline. SSE streams have a configured maximum lifetime and remain pinned until completion, cancellation, or that deadline.
-
-Ingress authenticates external credentials, creates package caller tokens, and authorizes catalogs and management APIs; it does not authorize MCP operations. The destination waypoint decodes and authorizes every MCP request before revision routing. Both use one authorization service and relationship graph.
-
-Checks use the effective subject, target installation, and request-class action. Package-originated calls also require the immediate workload's authority; operation calls additionally require the canonical operation ID, approved package access policy, and any package-specific resource authorization. Credential scope and every applicable relationship check must allow the request. Decisions record the policy model and revision; missing or unknown identities, installations, request classes, operations, or policies—and provider outages—deny access.
-
-For package-to-package calls, the caller asks the identity service to mint a caller token over its authenticated workload channel and presents the signed parent internal caller context or a platform-issued workload-execution context. The request names one declared dependency and request-envelope hash; it cannot supply a replacement actor, effective subject, or delegation chain. The identity service verifies the parent context, preserves its actor and effective subject, appends the authenticated caller workload to the delegation chain, and cryptographically attenuates scope and expiry. The destination waypoint remains authoritative for target operation authorization. Tokens are single-target, short-lived, non-refreshable by the package, and cannot broaden delegated authority. Package SDKs perform this exchange and send the resulting token to the destination Service.
 
 ### Development Sandbox
 
@@ -492,20 +377,7 @@ The platform separates deployment into three trust and lifecycle tiers:
 2. **Protected system packages**: identity, authorization, secret management, registry verification, audit, and workflow execution. After the bootstrap substrate is healthy, revision controllers install and upgrade these services using signed releases and the normal immutable revision and rollout machinery.
 3. **Ordinary organization packages**: packages installed by authorized organization or package administrators and constrained by organization policy.
 
-Protected system packages have fixed canonical identities, trusted-signer allowlists, dedicated platform workload identities, protected names and routes, and platform-only revision permissions. They cannot grant themselves authority, be replaced by an ordinary package, or be removed through ordinary package APIs. Infrastructure configuration pins the initial system-package releases and bootstrap order; after identity and authorization are available, subsequent changes require normal platform authorization.
-
-Initial bootstrap uses a deliberately narrower trust path than ordinary admission:
-
-1. Terraform provisions the state store, revision controllers, an append-only audit spool, secret bootstrap backend, certificate authority, and an offline-pinned bundle containing the initial protected-package manifests, digests, signer keys, platform identities, and network policy.
-2. A bootstrap controller verifies that bundle without registry, identity, authorization, secret-service, or audit-service APIs. It creates the initial secret, audit, identity, and authorization workloads directly from digest-pinned images rather than through ordinary package admission.
-3. Initial workloads use prebound Kubernetes service accounts and static namespace, mTLS, and `NetworkPolicy` allowlists from the signed bundle. Bootstrap secrets are mounted from the substrate backend. Security events are synchronously appended to the substrate audit spool until the audit package durably imports them.
-4. Terraform supplies the initial human administrator identities and organization root grants as signed bootstrap records. The authorization service imports each record once and rejects replay. Identity, authorization, secrets, and audit then prove their typed APIs, policy attachments, secret access, and durable audit delivery through bootstrap conformance checks.
-5. Using those now-normal services, the bootstrap controller directly creates the digest-pinned registry-verification workload, which verifies its own pinned manifest and signer before adoption. The revision controller then installs workflow execution through ordinary protected-package admission. It adopts every directly created workload into immutable revision records only after its manifest, identity, policy, secrets, and audit history pass the same checks.
-6. The controller writes an irreversible bootstrap-complete marker and removes bootstrap-only API access, secret mounts, static allowlists, and controller permissions. From that point, bootstrap records and offline bundles cannot authorize upgrades; every protected-package change uses normal signed releases, revision control, and platform authorization.
-
-Loss of identity or authorization does not reopen bootstrap mode. Recovery uses separately documented state-store restore and break-glass procedures with offline quorum approval and immutable audit records.
-
-The bootstrap substrate and protected system packages are both inside the platform availability boundary. If a required component in either tier is unavailable, the affected capability is counted as platform downtime even when some existing package traffic continues. For example, a registry-verification outage is publishing and installation downtime, while an identity or authorization outage may prevent new requests without immediately terminating established connections. An ordinary package failure counts as downtime for that package, not for the platform, unless a platform defect caused or spread the failure.
+The bootstrap substrate and protected system packages are both inside the platform availability boundary. If a required component in either tier is unavailable, the affected capability is counted as platform downtime even when some existing package traffic continues. An ordinary package failure counts as downtime for that package, not for the platform, unless a platform defect caused or spread the failure.
 
 ### Trusted Platform Services
 
@@ -514,54 +386,30 @@ The bootstrap substrate and protected system packages provide these trusted serv
 - **Identity service**: authenticates sessions and API grants, resolves canonical principals, manages organization service accounts, issues caller tokens, and manages signing keys for internal caller contexts and session wrappers.
 - **Authorization service**: stores immutable policy models, grants, assignments, and revocations and evaluates provider-independent and Envoy `ext_authz` checks.
 - **Secret-management service**: stores and rotates platform and connection credentials and releases secret material only to explicitly authorized workload identities.
-- **Registry-verification service**: verifies the deployment registry and upstream source identities, controls pull-through imports, verifies manifests, digests, signatures, platform compatibility, trust policy, and local artifact completeness before catalog exposure and admission.
+- **Registry-verification service**: verifies the deployment registry, validates pull-through imports identified by canonical package ID, verifies manifests, digests, signatures, platform compatibility, trust policy, and local artifact completeness before catalog exposure and admission.
 - **Audit sink**: accepts append-only security, authorization, administration, and runtime events in storage that packages cannot control.
 - **Workflow service**: registers promoted package-defined workflows and runs pinned executions outside package runtimes.
-- **Control-plane state store**: a bootstrap-substrate service that durably stores deployment-registry state, upstream source configurations, import attempts, package slots, revision requests and operations, routing and catalog generations, migration outcomes, and recovery metadata.
-
-The Istio control plane provides the certificate authority and workload-certificate lifecycle. Backup and recovery tooling protects control-plane state and trusted-service configuration but does not sit on the request path.
-
-Each trusted service exposes a versioned typed API. Control-plane clients use shared libraries for workload authentication, canonical caller context, deadlines, bounded retries, idempotency keys, metrics, tracing, and audit metadata. Istio provides service discovery, mTLS, and network routing, so the first implementation does not add a generic control-plane proxy.
+- **Control-plane state store**: a bootstrap-substrate service that durably stores deployment-registry state, import attempts and provenance, package slots, revision requests and operations, routing and catalog generations, migration outcomes, and recovery metadata.
 
 ### Runtime Architecture
 
-Production uses Istio ambient mode. `ztunnel` provides L4 transport security and workload identity, while waypoint proxies provide L7 routing, authorization, and telemetry. Package Pods have no mesh or application proxy sidecar.
+Production uses Istio ambient mode. Package Pods have no mesh or application proxy sidecar; they expose MCP and health endpoints directly. The runtime combines `istiod`, mandatory node-level `ztunnel`, shared destination and ingress waypoints, gateways, unprivileged package containers, protected services, the state store, and revision controllers. Revision controllers reconcile durable state into Deployments, Services, waypoint enrollment, Gateway API routes, signed cluster-selection configuration, and `AuthorizationPolicy`; `istiod` distributes the resulting xDS configuration. `Istiod` owns endpoint, routing, certificate, and mesh-policy distribution—not revision state, grants, workflows, or catalogs.
 
-The runtime combines `istiod`, mandatory node-level `ztunnel`, shared destination waypoints, ingress and egress gateways, unprivileged package containers, the protected services above, the state store, and revision controllers. Package containers expose MCP and health endpoints directly; the interface service serves static UIs.
+**`ztunnel` configures (L4):**
 
-Revision controllers reconcile durable state through trusted-service and Kubernetes APIs into Deployments, stable and revision Services, waypoint enrollment, Gateway API routes, signed cluster-selection configuration, and `AuthorizationPolicy`. `istiod` distributes the resulting xDS configuration. Controllers advance catalog generations only after protected status reports and allow-path and bypass probes confirm route, selector, enrollment, and policy convergence.
+- mTLS and identity-based L4 `AuthorizationPolicy` on workload ports, including bypass prevention for direct Pod IP or revision Service access
+- Ambient workload enrollment, policy-generation binding, and readiness gating until the current generation is loaded
+- L4 telemetry and audit for connection, byte, policy-denial, and bypass events
 
-Istio owns endpoint, routing, certificate, and mesh-policy distribution—not revision state, grants, workflows, or catalogs. Ingress authenticates external callers; destination waypoints authorize MCP requests.
+`ztunnel` cannot enforce L7 policy, decode MCP, select revision backends, or run `ext_authz` authorization checks.
 
-Because `ztunnel` cannot enforce L7 policy, ingress handles management checks while the destination waypoint decodes and authorizes every MCP request before revision selection. Every stable package Service is waypoint-enrolled, and ingress traffic traverses that waypoint. `AuthorizationPolicy` permits application-port traffic only from its authenticated identity, including requests addressed directly to a Pod IP or revision Service. Health probes use a separate protected port with the minimum exception.
+**Waypoints configure (L7):**
 
-A readiness controller keeps new `ztunnel` instances and affected workloads out of service until the current policy generation is loaded. Admission requires accepted waypoint enrollment, ingress waypoint use, bypass prevention, MCP decoding and authorization extensions, routes, and policy attachments.
+- Gateway API `HTTPRoute` resources, waypoint enrollment, and protected extensions (MCP decoder, `ext_authz`, cluster selector, session wrapper, routing-status reporter, and audit adapter)
+- MCP decoding, authorization, and operation-specific revision routing via decoder metadata and signed generation-fenced routing tables—not caller headers or `HTTPRoute` matching
+- Signed session routing wrappers for SSE pinning, plus L7 request, MCP outcome, and trace telemetry
 
-The external authenticator, caller-token exchange, waypoint MCP decoder, authorization adapter, metadata-aware cluster selector, session wrapper, response observer, audit adapter, and routing-status reporter are protected extensions pinned by infrastructure configuration. The waypoint decoder executes before `ext_authz`, removes all external copies of reserved fields, and produces trusted dynamic metadata. After authorization, the cluster selector uses that metadata and signed generation-fenced configuration to choose a revision backend; standard `HTTPRoute` header matching is not used for decoded operations.
-
-Production uses `ztunnel` for transport security and L4 authorization, `NetworkPolicy` for reachability, ingress `ext_authz` for management authorization, and destination-waypoint `ext_authz` for MCP authorization. Authorization fails closed; health ports have no public ingress.
-
-Waypoints emit L7 request rate, transport and MCP outcome, duration, response-size, route, operation, source and destination identity, selected backend, access-log, and trace telemetry. The protected response observer distinguishes HTTP transport results from JSON-RPC errors and terminal SSE outcomes without exposing response bodies. `ztunnel` emits L4 connection, byte, policy-denial, and bypass telemetry. Kubernetes reports Pod health, restarts, resources, and rollout state, while package instrumentation reports application-internal metrics and trace spans. Application metrics are scraped separately rather than merged through a per-Pod proxy.
-
-The waypoint audit adapter durably records malformed requests, token and envelope-hash failures, authorization denials, routing-generation mismatches, and session-token failures before returning an error. `ztunnel` policy denials flow through the protected audit pipeline. If a required security event cannot be delivered or durably buffered, the affected request fails closed.
-
-If `istiod` is unavailable, established traffic uses its last configuration. New revision operations requiring routing or policy changes fail closed until dependencies recover.
-
-Terraform manages the bootstrap substrate, including clusters, networking, container infrastructure, state storage, revision controllers, certificate authority, and recovery tooling. Package installation does not mutate this substrate.
-
-### Production Operational Baseline
-
-Production uses a regional Kubernetes cluster dedicated to the platform rather than assuming an unrelated existing cluster. Infrastructure configuration pins supported Kubernetes, Gateway API, Istio, CNI, `ztunnel`, gateway, and waypoint versions. Upgrades use documented skew ranges, staged control-plane and data-plane rollout, conformance tests, and rollback criteria.
-
-Terraform defines regional node placement, autoscaling bounds, resource quotas, default requests and limits, Pod disruption budgets, topology-spread constraints, priority classes, and capacity reserved for protected services. Protected services and routing proxies remain available during one-zone loss and planned node disruption. Revision admission fails when required capacity cannot be reserved.
-
-Network infrastructure preserves deployment-owned ingress addresses, TLS certificate and DNS validation, outbound NAT addresses, private DNS, private-service routes, and OAuth callback origins. Default-deny `NetworkPolicy` and ambient enrollment apply to every package namespace. External destinations use an audited organization egress policy; an egress gateway is required when source-IP stability, protocol inspection, or centralized policy cannot be provided safely by direct egress.
-
-The state store and trusted-service state have encrypted regional replication, point-in-time recovery, versioned backup formats, restore verification, and declared RPO and RTO. Disaster-recovery tests cover state restoration, certificate and signing-key recovery, route reconstruction, protected-package bootstrap recovery without reopening bootstrap authorization, and reconciliation of Kubernetes resources from durable state.
-
-Security audit storage uses retention-locked, package-inaccessible storage with independently managed encryption and deletion authority. Delivery has bounded buffering, loss and lag alerts, schema versions, and trace correlation. An audit outage fails closed for security-sensitive mutations when the event cannot be durably buffered.
-
-Operational documentation defines DNS and gateway rollback, expired-certificate recovery, authorization and identity outages, stuck routing convergence, state-store restore, cluster loss, signer compromise, and quorum-controlled break-glass access. Break-glass credentials are offline, time-bounded, scope-limited, and always produce independently retained audit evidence.
+Ingress authenticates external credentials and mints caller tokens; the destination waypoint decodes and authorizes MCP requests. Health probes use a separate protected port with the minimum exception. `NetworkPolicy` provides reachability enforcement alongside ambient policy. Authorization fails closed; health ports have no public ingress. If a required security event cannot be delivered or durably buffered, the affected request fails closed. If `istiod` is unavailable, established traffic uses its last configuration; new revision operations requiring routing or policy changes fail closed until dependencies recover.
 
 ### Infrastructure and Service Rollouts
 
@@ -572,63 +420,32 @@ The mesh is redeployed only for changes to Istio or its trust and extension conf
 - Istio certificate-authority and trust-domain configuration
 - Mesh-wide extension-provider and ambient-enrollment configuration
 
-Protected system packages roll independently through the revision controller and do not require a mesh redeployment. Ordinary package revisions, upstream source and registry-policy changes, identity assignments, and authorization-binding updates likewise change runtime or control-plane state without redeploying the mesh.
+Protected system packages roll independently through the revision controller and do not require a mesh redeployment. Ordinary package revisions, registry trust-policy changes, identity assignments, and authorization-binding updates likewise change runtime or control-plane state without redeploying the mesh.
 
 Bootstrap-substrate changes, including control-plane state migrations and backup or recovery tooling, use infrastructure rollouts but do not redeploy the mesh unless they also change an Istio item listed above. Package releases declare supported MCP versions. Infrastructure pins Kubernetes, Istio, Envoy, the shared MCP extension, session-token format, authorization adapter, and routing-status extension versions and accounts for overlapping old and new versions before admitting releases that require new features. Registry trust-root changes remain separately authorized and audited.
 
 ## Representative Request Lifecycles
 
-These summaries add sequencing and externally observable behavior; preceding sections define the authoritative mechanics.
+- Provision the deployment registry
+- Pull a package release
+- Publish a package release
+- Upgrade a package
+- Invoke a package operation
+- Invoke a package operation (package-to-package)
+- Authentication
+- Connect external credentials
 
-### Provision the Deployment Registry
+# Minimum Dependencies
 
-Deployment provisioning creates one private registry with OCI 1.1 storage, a self-certifying `registryId`, publisher controls, and pull-through import. It publishes the signed descriptor and verifies storage, digest, authentication, authorization, and signature enforcement before serving traffic. Publisher private keys remain publisher-controlled.
 
-### Pull a Package Release
-
-An administrator selects an external release, read-only authorization, and trust policy. The deployment registry verifies the source identity and complete release, copies its content into local storage, and atomically exposes it. The API returns the import status and `releaseDigest`; failures retain diagnostics but expose no installable release.
-
-### Publish a Package Release
-
-A developer or CI job authenticates to the deployment registry and runs `vt build <dir> --push`. The registry validates and atomically publishes the signed release, then returns its immutable `releaseDigest`. Interrupted attempts remain non-installable, and publishing never installs the release.
-
-### Upgrade a Package
-
-An authorized administrator submits a durable request naming the target `releaseDigest` and approved identity or authorization changes. The control plane verifies permissions, appends the request, fences the operation, and returns its ID. Candidates remain absent from user catalogs and receive no primary traffic before promotion; operations with identical contracts may receive controlled canary traffic. Promotion uses the convergence-gated transaction above, and pre-promotion failure leaves the prior revision primary.
-
-### Invoke a Package Operation
-
-An external caller sends MCP Streamable HTTP to a package-scoped endpoint. Ingress authenticates, strips untrusted metadata, applies transport limits, and issues a caller token bound to the installation and envelope hash; it neither parses MCP nor authorizes an operation. The waypoint validates the token, decodes and authorizes the request, removes the caller token, adds signed internal context, selects the revision, and pins sessions through its signed wrapper. The runtime receives the request directly. Audit records include the decision and policy generation, actor, effective subject, immediate caller workload when applicable, target, `releaseDigest`, caller-token ID, trace ID, duration, and outcome.
-
-Package-to-package calls bypass ingress but still terminate at the destination waypoint. The identity service derives an attenuated, single-target token from authenticated workload context; raw caller credentials are never forwarded.
-
-## Assurance
-
-### Retention and Audit
-
-Retention follows active-revision, rollback, recovery, and garbage-collection rules above; shared OCI layers are deleted only after references are rechecked. Authentication, authorization, registry, lifecycle, migration, secret-access, and network-policy events go to the immutable audit sink with actor, target, decision, identifiers, trace ID, and outcome.
-
-### Required Verification
-
-Before production use, automated tests cover:
-
-- **Registry and release integrity**: one-registry-per-deployment enforcement, least-privilege push and upstream read authorization, atomic publication and pull-through import under retries and concurrency, preservation of source identity, complete local artifact closure, signature and compatibility rejection, upstream-source disablement, and safe garbage collection
-- **Runtime contract**: direct MCP and health endpoints, platform-manifest-pinned Pods, synthetic contract readiness, Kubernetes shutdown, waypoint request and response decoding, token upper bounds, protected catalog filtering, cancellation, session rotation and pinning, SSE draining, and malformed or ambiguous MCP requests
-- **Revision state machines**: validation failures, administrator, controller, and dependency races, restart at every phase, and migration idempotency and lease loss
-- **Rollout and recovery**: canary and promotion failures before and after routing intent, proxy-membership churn, route restoration, atomic rollout groups, catalog convergence, draining and SSE behavior, rollback approval, removal, tombstones, retained workflows, autoscaling, and mixed versions
-- **Platform lifecycle**: bootstrap ordering and outages, protected identities and signers, ordinary-package replacement prevention, and independent infrastructure and system-package rollouts
-- **Authorization models**: deterministic policy publication, active-grant preservation, subject-set cycles, and parity between batch and individual checks
-- **Identity and delegation**: spoofing, claim validation, token expiration and rotation, `runAs`, confused-deputy prevention, attenuation, and revocation
-- **Fail-closed enforcement**: authorization and audit outages, direct Pod-IP and revision-Service bypass attempts, `ztunnel` and waypoint churn, stale policy generations, and ingress or waypoint `ext_authz` failures
-- **Interfaces and workflows**: route collisions, CSP and asset validation, revision-qualified caching, pinned workflow executions, signals and timers during upgrades, retirement, migration, and forced termination
-- **Disaster recovery**: regional state restore, route reconstruction, signing-key and certificate recovery, protected-service recovery, audit continuity, and break-glass controls
 
 ## Glossary
 
 | Term | Meaning |
 | --- | --- |
-| Package identity | Permanent `(registryId, packageId)`; never reused |
-| Pull-through import | Verified, atomic copy of an external release and its complete artifact closure into the deployment registry using read-only upstream authorization |
+| Canonical package ID | Global package identifier: the concatenation of `registryId` and registry-local `packageId`, written as `registryId/packageId`; never reused |
+| Package identity | Equivalent to canonical package ID; also representable as `(registryId, packageId)` |
+| Pull-through import | Verified, atomic copy of an external release and its complete artifact closure into the deployment registry, identified by canonical package ID and release version, using upstream read credentials supplied at import time |
 | `releaseDigest` | Hash of canonical manifest bytes and authoritative install input |
 | Revision | Installed release or removal tombstone |
 | Revision operation | Fenced execution of durable revision intent |
@@ -640,39 +457,3 @@ Before production use, automated tests cover:
 | Protected system package | Signer-pinned platform package unavailable to ordinary package APIs |
 | Waypoint | Shared Envoy proxy for MCP authorization, revision routing, sessions, and telemetry |
 | `ztunnel` | Node-level ambient proxy for L4 security and workload identity |
-
-## Appendix: Design Invariants
-
-The following invariants apply to every implementation:
-
-1. Published releases are immutable and digest-addressed.
-2. Revision intent and outcomes are append-only.
-3. Each package slot permits one active fenced revision operation.
-4. Controllers reconcile durable intent idempotently and resume after failure.
-5. Lifecycle state, workload observations, routing convergence, and catalog convergence remain distinct.
-6. Only successful promotion changes the promoted head.
-7. Every traffic-eligible revision satisfies the compatibility and removal rules in [Dependencies and Contracts](#dependencies-and-contracts).
-8. Organization-managed identities are the sole source of runtime authority.
-9. Ordinary package APIs cannot replace the bootstrap substrate or protected platform capabilities.
-10. External artifacts remain untrusted until admission verifies their digests, signatures, schemas, and policy.
-11. Authorization uses canonical identities and one immutable policy generation; policy changes cannot silently delete or orphan grants.
-12. Package runtimes receive no raw credentials or caller-supplied identity, only short-lived, signed, audience-bound caller context.
-
-## Appendix: Foundations
-
-### Identity Model
-
-The system keeps these identities separate:
-
-- **Registry identity**: an immutable self-certifying `registryId` derived from the registry's offline root public key. The identifier is globally stable for that registry but does not imply endorsement by, or membership in, a central registry namespace. Signed registry descriptors authorize the current origin set and origin changes.
-- **Package identity**: permanent `(registryId, packageId)` assigned when the package is reserved. A slug is a mutable display and discovery alias, never a security identifier.
-- **Release identity**: `(registryId, packageId, releaseVersion, releaseDigest)`.
-- **Installation identity**: an organization-scoped UUID representing one installed package.
-- **Workload identity**: the installation principal used in authorization checks for one installation's runtime or migration job, bound at installation to an organization-managed Kubernetes service account.
-- **Workflow identity**: the principal assigned to a workflow definition or execution.
-- **Actor identity**: the user, API grant, platform service account, or workflow that initiated an action.
-- **Effective subject**: the principal whose delegated authority an invocation exercises.
-
-Authentication resolves credentials to canonical principals before authorization. Downstream services accept identity only from verified workload identity or signed context; delegation preserves actor and effective subject through authorization and audit.
-
-Package IDs are never reused; slug renames retain aliases and tombstones. A different registry yields a different package identity even for identical bytes. Release metadata cannot name workload identities or Kubernetes service accounts; installation selects them from organization-managed resources.

--- a/plans/service_mesh/plan.md
+++ b/plans/service_mesh/plan.md
@@ -138,9 +138,9 @@ Without `--push`, `vt build` writes the release bundle locally and needs no depl
 
 ### Stored Content and Backing Services
 
-Google Artifact Registry stores the immutable release bundle: runtime and migration Bun app artifacts, UI bundles, workflow definitions, schemas, the canonical release manifest, and detached signatures. Bun app artifacts may use OCI artifact storage, but they are not publisher-supplied container images. Each artifact is content-addressed by SHA-256 digest.
+Google Cloud Storage stores the immutable release bundle: runtime and migration Bun app artifacts, UI bundles, workflow definitions, schemas, the canonical release manifest, and detached signatures. Each artifact is stored under its SHA-256 digest. Uploads use generation-match preconditions so an existing digest cannot be overwritten; bucket retention and versioning provide an additional recovery and immutability boundary.
 
-The registry service also tracks metadata that Artifact Registry does not provide on its own:
+The registry service tracks catalog and control-plane metadata separately from Cloud Storage:
 
 - Canonical package IDs, slugs, version indexes, and tombstones
 - Publication and import attempts, including pending and failed state

--- a/plans/service_mesh/plan.md
+++ b/plans/service_mesh/plan.md
@@ -89,7 +89,8 @@ Publishers create releases from a source directory with `vt build <dir>`. For ex
 g-issues/
 ├── package.yaml
 ├── runtime/
-│   ├── Dockerfile
+│   ├── package.json
+│   ├── bun.lock
 │   └── src/
 ├── migrations/
 │   ├── v2.3.0/
@@ -98,7 +99,7 @@ g-issues/
     └── admin-console/
 ```
 
-`package.yaml` defines the package name, version, operations, dependencies, workflows, UIs, migration jobs, and authorization requirements. Workflow definitions and operation schemas live in the migration jobs rather than separate source directories. `vt build g-issues/` validates the package, builds digest-addressed artifacts locally, and writes a logical release bundle.
+`package.yaml` defines the package name, version, operations, dependencies, workflows, UIs, migration jobs, and authorization requirements. Runtime and migration code must be Bun applications; packages do not supply Dockerfiles or custom container images. Workflow definitions and operation schemas live in the migration jobs rather than separate source directories. `vt build g-issues/` validates the package, installs dependencies from the frozen Bun lockfile, builds digest-addressed Bun application artifacts locally, and writes a logical release bundle.
 
 ### Example Release Bundle
 
@@ -108,17 +109,15 @@ A typical bundle is not one container or folder. For example:
 g-issues@2.3.1
 ├── release_manifest.json
 ├── runtime
-│   └── image-index
-│       ├── linux-amd64 image
-│       └── linux-arm64 image
+│   └── bun-app.tar.gz
 ├── migrations
-│   ├── v2.3.0 image
-│   └── v2.3.1 image
+│   ├── v2.3.0-bun-app.tar.gz
+│   └── v2.3.1-bun-app.tar.gz
 └── ui
     └── admin-console.tar.gz
 ```
 
-A UI-only or workflow-only package omits the runtime image.
+A UI-only or workflow-only package omits the runtime Bun app.
 
 ```sh
 vt build <dir>
@@ -139,7 +138,7 @@ Without `--push`, `vt build` writes the release bundle locally and needs no depl
 
 ### Stored Content and Backing Services
 
-Google Artifact Registry stores the immutable release bundle: runtime and migration OCI images, UI bundles, workflow definitions, schemas, the canonical release manifest, and detached signatures. Each artifact is content-addressed by SHA-256 digest.
+Google Artifact Registry stores the immutable release bundle: runtime and migration Bun app artifacts, UI bundles, workflow definitions, schemas, the canonical release manifest, and detached signatures. Bun app artifacts may use OCI artifact storage, but they are not publisher-supplied container images. Each artifact is content-addressed by SHA-256 digest.
 
 The registry service also tracks metadata that Artifact Registry does not provide on its own:
 
@@ -173,7 +172,7 @@ An administrator specifies a canonical package ID, release version, and upstream
 - Ordered migration jobs
 - Required authorization relationships or roles for each operation
 - Supported MCP protocol versions
-- Runtime startup instructions and probe contract for releases that include a runtime
+- Bun version, entry point, startup instructions, and probe contract for releases that include a runtime
 - Optional source metadata (e.g. PR number)
 
 #### Publication
@@ -393,7 +392,7 @@ The bootstrap substrate and protected system packages provide these trusted serv
 
 ### Runtime Architecture
 
-Production uses Istio ambient mode. Package Pods have no mesh or application proxy sidecar; they expose MCP and health endpoints directly. The runtime combines `istiod`, mandatory node-level `ztunnel`, shared destination and ingress waypoints, gateways, unprivileged package containers, protected services, the state store, and revision controllers. Revision controllers reconcile durable state into Deployments, Services, waypoint enrollment, Gateway API routes, signed cluster-selection configuration, and `AuthorizationPolicy`; `istiod` distributes the resulting xDS configuration. `Istiod` owns endpoint, routing, certificate, and mesh-policy distribution—not revision state, grants, workflows, or catalogs.
+Production uses Istio ambient mode. Package Pods have no mesh or application proxy sidecar; they expose MCP and health endpoints directly. Every package runtime and migration executes as a Bun application in a platform-owned, unprivileged Bun container image; publishers cannot provide arbitrary images or Dockerfiles. The runtime combines `istiod`, mandatory node-level `ztunnel`, shared destination and ingress waypoints, gateways, these standardized Bun application containers, protected services, the state store, and revision controllers. Revision controllers reconcile durable state into Deployments, Services, waypoint enrollment, Gateway API routes, signed cluster-selection configuration, and `AuthorizationPolicy`; `istiod` distributes the resulting xDS configuration. `Istiod` owns endpoint, routing, certificate, and mesh-policy distribution—not revision state, grants, workflows, or catalogs.
 
 **`ztunnel` configures (L4):**
 
@@ -422,7 +421,7 @@ The mesh is redeployed only for changes to Istio or its trust and extension conf
 
 Protected system packages roll independently through the revision controller and do not require a mesh redeployment. Ordinary package revisions, registry trust-policy changes, identity assignments, and authorization-binding updates likewise change runtime or control-plane state without redeploying the mesh.
 
-Bootstrap-substrate changes, including control-plane state migrations and backup or recovery tooling, use infrastructure rollouts but do not redeploy the mesh unless they also change an Istio item listed above. Package releases declare supported MCP versions. Infrastructure pins Kubernetes, Istio, Envoy, the shared MCP extension, session-token format, authorization adapter, and routing-status extension versions and accounts for overlapping old and new versions before admitting releases that require new features. Registry trust-root changes remain separately authorized and audited.
+Bootstrap-substrate changes, including control-plane state migrations and backup or recovery tooling, use infrastructure rollouts but do not redeploy the mesh unless they also change an Istio item listed above. Package releases declare supported MCP and Bun versions. Infrastructure pins Kubernetes, Istio, Envoy, the platform Bun container image, the shared MCP extension, session-token format, authorization adapter, and routing-status extension versions and accounts for overlapping old and new versions before admitting releases that require new features. Registry trust-root changes remain separately authorized and audited.
 
 ## Representative Request Lifecycles
 

--- a/plans/service_mesh/plan.md
+++ b/plans/service_mesh/plan.md
@@ -21,7 +21,7 @@ The platform builds, distributes, installs, and runs packages in a shared servic
 - Dependency and migration metadata
 - Per-operation authorization relationship or role requirements
 
-The platform should enable the following user experiences.
+The platform supports the following roles and workflows.
 
 ### Organization Administrator
 
@@ -100,8 +100,6 @@ g-issues/
 
 ### Example Release Bundle
 
-A typical release bundle contains multiple artifacts rather than a single archive. For example:
-
 ```text
 g-issues@2.3.1
 ├── release_manifest.json
@@ -150,9 +148,7 @@ The registry service tracks catalog and control-plane metadata separately from C
 
 ### Identity and Trust
 
-Every registry controls who can pull from it and who can publish to it.
-
-The deployment registry controls read access for discovery and download, and write access for authorized publishers. Upstream registries do the same on their side; pull-through import uses read-only credentials supplied for that import operation.
+Each registry controls discovery, download, and publication access. The deployment registry authorizes its readers and publishers; upstream registries enforce their own policies. Pull-through import uses read-only credentials supplied for that import operation.
 
 Each registry has a stable `registryId` derived from its root public key.
 
@@ -193,7 +189,7 @@ Pull-through import has its own validation before copying an external release lo
 
 ### First Installation
 
-A release in the registry catalog is not yet running in the mesh. The first installation admits it. For example, installation of `g-issues@2.3.1` proceeds as follows:
+First installation admits a cataloged release into the mesh. Installation of `g-issues@2.3.1` proceeds as follows:
 
 1. **Select a release.** A package administrator chooses the app and an immutable `releaseDigest` from the registry catalog.
 2. **Review the contract.** The platform shows declared operations, dependencies, workflows, UIs, migrations, and required authorization relationships.
@@ -201,7 +197,7 @@ A release in the registry catalog is not yet running in the mesh. The first inst
 4. **Configure operation authority.** For each operation, the administrator decides whether it runs only as the workload identity or may exercise delegated caller authority, and binds permissions as durable grants or delegated authority.
 5. **Approve admission.** The administrator confirms the bindings. This requires `service_account.assign` for each identity and `authorization.grant` for each relationship or role being granted.
 6. **Verify and prepare.** The control plane re-verifies the `releaseDigest`, resolves dependencies, reserves the package slot, binds identities, provisions mesh routes and policies, and then runs prepare migrations.
-7. **Roll out.** The revision controller creates runtime workloads when needed, stages UI and workflow artifacts, and promotes the revision once readiness checks converge. The app then appears in user-facing catalogs and becomes invocable.
+7. **Roll out.** For releases with a runtime, the revision controller creates runtime workloads. It stages UI and workflow artifacts and promotes the revision once readiness checks converge. The app then appears in user-facing catalogs and becomes invocable.
 
 ## Package Revisions
 
@@ -217,7 +213,7 @@ The control plane persists:
 - **Routing and catalog generations**: independent operation-routing, package, operation, UI, and workflow generations committed for the promoted revision
 - **Terminal outcomes**: completion or failure phase, duration, and reason
 
-### Installation
+### Installation Reconciliation
 
 Publishing does not install a package. An authorized installer selects an immutable `releaseDigest` and supplies the following bindings and settings:
 
@@ -332,7 +328,7 @@ Representative endpoints:
 - Administration: `https://vt.valon.tools/admin`
 - Package administration: `https://vt.valon.tools/packages/<package>/admin`
 
-Management APIs require dedicated administrative permissions and should use a private listener or equivalent network controls where practical.
+Management APIs require dedicated administrative permissions and a private listener or equivalent network controls.
 
 ### External Connections
 

--- a/plans/service_mesh/plan.md
+++ b/plans/service_mesh/plan.md
@@ -334,6 +334,18 @@ Representative endpoints:
 
 Management APIs require dedicated administrative permissions and should use a private listener or equivalent network controls where practical.
 
+### External Connections
+
+Users connect a package to an external service through the CLI:
+
+```sh
+vt connect <package>
+```
+
+The CLI opens a browser-based login flow. After the user authenticates and grants access, the platform syncs the resulting external credentials into its secret-management service for the package connection.
+
+TODO: Define provider discovery, requested scopes and consent, callback handling, credential storage and rotation, revocation, and package access to connected credentials.
+
 ### Invocation
 
 Authorized operations are available over the deployment endpoint and through the CLI:

--- a/plans/service_mesh/plan.md
+++ b/plans/service_mesh/plan.md
@@ -4,15 +4,12 @@
 
 - [Overview](#overview)
 - [Registries](#registries)
-- [Foundations](#foundations)
 - [Publishing and Distribution](#publishing-and-distribution)
 - [Package Revisions](#package-revisions)
 - [Runtime and Access](#runtime-and-access)
 - [Platform Architecture](#platform-architecture)
 - [Representative Request Lifecycles](#representative-request-lifecycles)
-- [Assurance](#assurance)
 - [Glossary](#glossary)
-- [Appendix: Design Invariants](#appendix-design-invariants)
 
 ## Overview
 
@@ -30,7 +27,7 @@ The platform should enable the following user experiences.
 
 An organization administrator can:
 
-- Operate one deployment, private registry, and administration surface, such as `https://vt.valon.tools`, `/registry`, and `/admin`.
+- Operate one deployment with a private registry and administration surfaces, such as `https://vt.valon.tools`, `/registry`, and `/admin`.
 - Pull trusted releases into the private registry by canonical package ID and release version, supplying upstream read credentials at import time.
 - Browse installed apps as a graph, including operations, UIs, workflows, dependencies, versions, identities, and authorization.
 - Open an app administration page, change its version, or install and remove it.
@@ -39,8 +36,8 @@ An organization administrator can:
 
 A publisher can:
 
-- Define package metadata, operations, dependencies, workflows, UIs, and migration jobs in a source manifest.
-- Run `vt build <dir>` to validate the package and build a release bundle locally, or add `--push` to publish it to the deployment registry.
+- Define package metadata, operations, dependencies, workflows, UIs, and migration jobs in `package.yaml`.
+- Run `vt build <dir>` to validate the package and build a release bundle locally, or pass `--push` to publish it to the deployment registry.
 - Run `vt dev --deployment <url> <dir>` to test a package in an isolated, user-scoped mesh sandbox before publishing it.
 
 ### Package Administrator
@@ -48,14 +45,14 @@ A publisher can:
 A package administrator can:
 
 - Inspect an app and its deployment details.
-- Manage its desired version within their package-scoped authority.
+- Manage an app's desired release version within the administrator's package-scoped authority.
 - Promote releases from the private registry manually or through deployment rules.
 - Perform the first installation that admits a package into the mesh.
 - Select organization-managed identities for runtimes, migrations, and workflows.
 - Decide whether an operation runs only as its workload identity or may exercise explicitly delegated caller authority.
 - Bind each permission as either a durable grant or delegated authority.
 
-A durable grant cannot exceed the human issuer's authority when created and remains until explicitly revoked, expired, or invalidated by a policy migration. Delegated authority is bounded by the subject's current authority and narrows immediately when that authority is lost.
+A durable grant cannot exceed the human issuer's authority when created and remains until it is explicitly revoked, expires, or is invalidated by a policy migration. Delegated authority is bounded by the subject's current authority and narrows immediately when that authority is lost.
 
 Package administration and publishing are independent roles, although the same person may hold both. Publishing, installation, and promotion remain separate actions.
 
@@ -74,11 +71,11 @@ The registry protocol is open. Anyone may operate a compatible registry; there i
 
 ### Deployment Registry
 
-Each deployment has exactly one registry and uses it as the sole package catalog and artifact source. Installation, upgrade, rollback, and recovery never fetch directly from an external registry.
+Each deployment has exactly one deployment registry, also called its private registry, and uses it as the sole package catalog and artifact source. Installation, upgrade, rollback, and recovery never fetch directly from an external registry.
 
 Releases enter through:
 
-- **Push**: an authorized publisher uploads a release created for the deployment registry. Publication credentials grant only the permitted package and release actions.
+- **Push**: an authorized publisher uploads a release created for the deployment registry. Publication credentials authorize only the permitted package and release actions.
 - **Pull-through import**: an administrator specifies a canonical package ID, release version, and upstream read credentials at import time. The registry resolves the source registry from the package ID, verifies the release, and stores the complete release locally before exposing it.
 
 ### Build
@@ -99,11 +96,11 @@ g-issues/
     └── admin-console/
 ```
 
-`package.yaml` defines the package name, version, operations, dependencies, workflows, UIs, migration jobs, and authorization requirements. Runtime and migration code must be Bun applications; packages do not supply Dockerfiles or custom container images. Workflow definitions and operation schemas live in the migration jobs rather than separate source directories. `vt build g-issues/` validates the package, installs dependencies from the frozen Bun lockfile, builds digest-addressed Bun application artifacts locally, and writes a logical release bundle.
+`package.yaml` defines the package name, version, operations, dependencies, workflows, UIs, migration jobs, and authorization requirements. Runtime and migration code must be Bun applications; packages do not supply Dockerfiles or custom container images. Workflow definitions and operation schemas are referenced by `package.yaml` rather than requiring separate source directories. `vt build g-issues/` validates the package, installs dependencies from the frozen Bun lockfile, builds digest-addressed Bun application artifacts locally, and writes a logical release bundle.
 
 ### Example Release Bundle
 
-A typical bundle is not one container or folder. For example:
+A typical release bundle contains multiple artifacts rather than a single archive. For example:
 
 ```text
 g-issues@2.3.1
@@ -113,6 +110,10 @@ g-issues@2.3.1
 ├── migrations
 │   ├── v2.3.0-bun-app.tar.gz
 │   └── v2.3.1-bun-app.tar.gz
+├── workflows
+│   └── definitions.json
+├── schemas
+│   └── operations.json
 └── ui
     └── admin-console.tar.gz
 ```
@@ -124,9 +125,9 @@ vt build <dir>
 vt build <dir> --push
 ```
 
-Without `--push`, `vt build` writes the release bundle locally and needs no deployment credentials. With `--push`, it uploads to the deployment registry after building.
+Without `--push`, `vt build` writes the release bundle locally and needs no deployment credentials. With `--push`, it uploads the release bundle to the deployment registry after building.
 
-#### CLI authentication
+### CLI Authentication
 
 `vt build <dir> --push` authenticates to the deployment registry before upload. The CLI resolves credentials in this order:
 
@@ -134,11 +135,11 @@ Without `--push`, `vt build` writes the release bundle locally and needs no depl
 2. A session stored in the OS keychain from a prior `vt auth login`
 3. Interactive `vt auth login` if no credential is available
 
-`--push` is safe to run idempotently: retrying the same release after interruption resumes or completes the existing attempt instead of creating a duplicate catalog entry.
+`--push` is idempotent: retrying the same release after interruption resumes or completes the existing attempt instead of creating a duplicate catalog entry.
 
 ### Stored Content and Backing Services
 
-Google Cloud Storage stores the immutable release bundle: runtime and migration Bun app artifacts, UI bundles, workflow definitions, schemas, the canonical release manifest, and detached signatures. Each artifact is stored under its SHA-256 digest. Uploads use generation-match preconditions so an existing digest cannot be overwritten; bucket retention and versioning provide an additional recovery and immutability boundary.
+Google Cloud Storage stores the immutable release bundle: runtime and migration Bun app artifacts, UI bundles, workflow definitions, schemas, the canonical release manifest, and detached signatures. Each artifact is stored under its SHA-256 digest. Uploads use generation-match preconditions so an existing digest cannot be overwritten; bucket retention and versioning provide additional recovery and immutability safeguards.
 
 The registry service tracks catalog and control-plane metadata separately from Cloud Storage:
 
@@ -149,7 +150,7 @@ The registry service tracks catalog and control-plane metadata separately from C
 
 ### Identity and Trust
 
-Every registry is responsible for permissioning who can pull from it and who can publish to it.
+Every registry controls who can pull from it and who can publish to it.
 
 The deployment registry controls read access for discovery and download, and write access for authorized publishers. Upstream registries do the same on their side; pull-through import uses read-only credentials supplied for that import operation.
 
@@ -157,7 +158,7 @@ Each registry has a stable `registryId` derived from its root public key.
 
 ### Pull-through Imports
 
-An administrator specifies a canonical package ID, release version, and upstream read credentials at import time. The canonical package ID encodes the source registry; no standing upstream source configuration is required. The import grants read access only for that operation; installation still requires organization trust in the release signature. The registry verifies the complete release, then atomically adds it to the local catalog; failed imports remain invisible. Imported releases keep their source identity, signatures, and digest.
+An administrator specifies a canonical package ID, release version, and upstream read credentials at import time. The canonical package ID encodes the source registry; no standing upstream source configuration is required. The import grants read access only for that operation; installation still requires the organization's trust policy to accept the release signature. The registry verifies the complete release, then atomically adds it to the local catalog; failed imports remain invisible. Imported releases keep their source identity, signatures, and digest.
 
 ## Publishing and Distribution
 
@@ -168,11 +169,12 @@ An administrator specifies a canonical package ID, release version, and upstream
 - Canonical registry and package IDs, slug, and `releaseVersion`
 - Digest references for every artifact produced by `vt build`
 - MCP operations with input and output schema digests
+- Workflow definition digests
 - Required and optional package and operation dependencies
 - Ordered migration jobs
 - Required authorization relationships or roles for each operation
 - Supported MCP protocol versions
-- Bun version, entry point, startup instructions, and probe contract for releases that include a runtime
+- Required Bun version, entry point, and probe contract for releases that include a runtime
 - Optional source metadata (e.g. PR number)
 
 #### Publication
@@ -187,18 +189,18 @@ An administrator specifies a canonical package ID, release version, and upstream
 
 When the registry receives a push request, it authenticates the publisher, verifies signatures, digests, and contracts, and rejects conflicting republications of the same `releaseVersion`. A `releaseVersion` follows a documented grammar and binds permanently to one `releaseDigest`. Only after those checks succeed does the registry expose the release in the catalog.
 
-Pull-through import has its own validation before copying an external release locally; installation is a separate check that re-verifies the selected `releaseDigest` before admitting a package into the **mesh**.
+Pull-through import has its own validation before copying an external release locally; installation is a separate check that re-verifies the selected `releaseDigest` before admitting a package into the mesh.
 
 ### First Installation
 
-A release in the registry catalog is not yet running in the mesh. The first installation admits it. For example, installing `g-issues@2.3.1`:
+A release in the registry catalog is not yet running in the mesh. The first installation admits it. For example, installation of `g-issues@2.3.1` proceeds as follows:
 
 1. **Select a release.** A package administrator chooses the app and an immutable `releaseDigest` from the registry catalog.
 2. **Review the contract.** The platform shows declared operations, dependencies, workflows, UIs, migrations, and required authorization relationships.
 3. **Bind identities.** The administrator selects organization-managed service accounts for the runtime, migration jobs, and workflows when the release includes them.
 4. **Configure operation authority.** For each operation, the administrator decides whether it runs only as the workload identity or may exercise delegated caller authority, and binds permissions as durable grants or delegated authority.
 5. **Approve admission.** The administrator confirms the bindings. This requires `service_account.assign` for each identity and `authorization.grant` for each relationship or role being granted.
-6. **Verify and prepare.** The control plane re-verifies the `releaseDigest`, resolves dependencies, reserves the package slot, runs prepare migrations, and provisions identities, mesh routes, and policies.
+6. **Verify and prepare.** The control plane re-verifies the `releaseDigest`, resolves dependencies, reserves the package slot, binds identities, provisions mesh routes and policies, and then runs prepare migrations.
 7. **Roll out.** The revision controller creates runtime workloads when needed, stages UI and workflow artifacts, and promotes the revision once readiness checks converge. The app then appears in user-facing catalogs and becomes invocable.
 
 ## Package Revisions
@@ -208,7 +210,7 @@ A release in the registry catalog is not yet running in the mesh. The first inst
 The control plane persists:
 
 - **Package slots**: one organization-scoped slot keyed by canonical package identity, reserved before allocating an installation ID and used to fence concurrent first installs
-- **Revision requests**: append-only install, upgrade, rollback, and removal intent with actor, previous promoted revision, target release or tombstone, deployment-registry catalog generation and applicable trust-policy revision, approved authorization bindings, resolved dependencies, and timestamps
+- **Revision requests**: append-only records of install, upgrade, rollback, and removal intent, including the actor, previous promoted revision, target release or tombstone, deployment-registry catalog generation and applicable trust-policy revision, approved authorization bindings, resolved dependencies, and timestamps
 - **Installation head**: last successfully promoted revision and current admitted candidate
 - **Revision operation**: one generation-fenced state machine per installation, including phase, candidate Kubernetes resources, deadlines, stability timestamp, and routing generation
 - **Migration outcomes**: immutable status keyed by installation, `releaseDigest`, and migration ID
@@ -217,7 +219,7 @@ The control plane persists:
 
 ### Installation
 
-Publishing does not install a package. An authorized installer selects an immutable `releaseDigest` and binds:
+Publishing does not install a package. An authorized installer selects an immutable `releaseDigest` and supplies the following bindings and settings:
 
 - An organization-managed Kubernetes service account when the release has a runtime or migration
 - Organization-managed workflow identities
@@ -227,17 +229,17 @@ Publishing does not install a package. An authorized installer selects an immuta
 
 Installation is a reconciled saga:
 
-1. Verify that the release is complete in the deployment registry, then verify its source registry identity and applicable trust policy, release signature and referenced artifact digests, platform support, runtime compatibility, and schema versions.
+1. Verify that the release is complete in the deployment registry, then verify its source registry identity, applicable trust policy, release signature, referenced artifact digests, platform support, runtime compatibility, and schema versions.
 2. Resolve exact dependency revisions and operation-contract digests.
 3. Reserve the organization package slot and persist the revision request, approved authorization snapshot, and fenced revision operation.
-4. Provision the installation and any required runtime, migration, and workflow identities, authorization relationships, ambient data-plane enrollment, and `AuthorizationPolicy` attachments.
+4. Bind the installation to any required runtime, migration, and workflow identities, authorization relationships, ambient data-plane enrollment, and `AuthorizationPolicy` attachments.
 5. Hand the fenced operation to the revision controller, which follows the canonical phases in [Revision Rollouts](#revision-rollouts).
 
-Failures preserve phase and diagnostics. The revision controller retries within policy and cleans up resources created for an unpromoted revision when an administrator cancels. Promotion, catalog exposure, and canary behavior follow the rules in Revision Rollouts.
+Failures preserve phase and diagnostics. The revision controller retries within policy and cleans up resources created for an unpromoted revision when an administrator cancels the operation. Promotion, catalog exposure, and canary behavior follow the rules in Revision Rollouts.
 
 ### Dependencies and Contracts
 
-Dependencies specify canonical package identities, `releaseVersion` ranges, required or optional status, and operation-contract digests. Admission records the selected revisions and digests.
+Dependencies specify canonical package identities, `releaseVersion` ranges, whether they are required or optional, and operation-contract digests. Admission records the selected revisions and digests.
 
 The platform validates:
 
@@ -252,7 +254,7 @@ All schemas use the same JSON Schema version and are normalized before hashing. 
 
 ### Revision Rollouts
 
-Runtime upgrades use Kubernetes blue/green rollouts: each candidate revision runs in a distinct immutable Deployment behind a revision-specific Service, and the serving Deployment is never restarted or mutated in place. Promotion advances the promoted head and all catalog generations in one state-store transaction only after routing, UI, and workflow prerequisites converge for a stability window; failure before that commit restores prior routing without advancing any generation. Convergence is verified from Kubernetes workload health, per-proxy routing-status reports, and ambient enrollment gates.
+Runtime upgrades use Kubernetes blue/green rollouts. Each candidate revision runs in a distinct immutable Deployment behind a revision-specific Service, and the serving Deployment is never restarted or mutated in place. Promotion advances the promoted head and all catalog generations in one state-store transaction only after routing, UI, and workflow prerequisites converge for a stability window. Failure before that commit restores prior routing without advancing any generation. Convergence is verified from Kubernetes workload health, per-proxy routing-status reports, and ambient enrollment gates.
 
 The canonical revision-operation phases are:
 
@@ -267,21 +269,22 @@ The canonical revision-operation phases are:
 9. **Finalizing**: run separately approved irreversible migrations.
 10. **Complete**: record convergence and timing.
 
-The prior revision drains pinned sessions and MCP SSE streams until a hard deadline while new sessions route only to the promoted revision. Pre-promotion failure leaves the prior revision primary; post-promotion failure marks the new revision degraded without automatic rollback—the next revision operation waits for administrator retry, approved rollback, or forward fix.
+The prior revision drains pinned sessions and MCP SSE streams until a hard deadline while new sessions route only to the promoted revision. Pre-promotion failure leaves the prior revision primary; post-promotion failure marks the new revision degraded without automatic rollback—the next revision operation waits for an administrator retry, an approved rollback, or a forward fix.
 
 ### Migrations and Rollback
 
 Migrations are separately identified, digest-pinned jobs. Each declares:
 
 - Migration ID and `releaseDigest`
-- Phase: which revision lifecycle stage runs the job
-  - **Prepare** — runs before promotion while the prior revision may still serve traffic. Changes must be backward-compatible with the serving revision (expand/contract expand).
-  - **Finalize** — runs after promotion once the candidate is primary. May be irreversible; destructive jobs require separate administrator approval (expand/contract contract).
+- Phase—the revision lifecycle stage in which the job runs
+  - **Prepare** — runs before promotion while the prior revision may still serve traffic. Changes must be backward-compatible with the serving revision (the expand phase of an expand/contract migration).
+  - **Finalize** — runs after promotion once the candidate is primary. These migrations may be irreversible; destructive jobs require separate administrator approval (the contract phase of an expand/contract migration).
   - **Compensating** — runs on approved rollback to reverse or repair data changes from prior migrations when returning to an earlier revision.
-
 - Dedicated workload identity
 - Timeout, resource limits, retry policy, and idempotency key
 - Compatibility with the prior and candidate package revisions
+
+In the expand phase of an expand/contract migration, the schema changes remain compatible with the serving revision. The contract phase removes the obsolete schema only after the new revision is primary.
 
 ## Runtime and Access
 
@@ -290,11 +293,11 @@ Migrations are separately identified, digest-pinned jobs. Each declares:
 The authorization service is the system of record for organization policy. It stores Zanzibar-style tuples used by management, user-invocation, workflow, and package-to-package authorization checks. Enforcement topology and mesh policy attachment are defined in [Runtime Architecture](#runtime-architecture).
 
 - Users authenticate through an external identity provider with organization-level SSO, issuer and tenant allowlists, and session revocation.
-- API keys are named, expiring, scoped API grants that act on behalf of an owner. Only hashes are stored, plaintext is returned once, and empty scope does not mean unrestricted access.
+- API keys are credentials for named, expiring, scoped API grants that act on behalf of an owner. Only hashes are stored; plaintext is returned only once, and an empty scope does not mean unrestricted access.
 - `service_account.create` permits creating an organization-managed service account but grants it no authority.
 - `service_account.assign` permits binding a service account to a package runtime, workflow definition, or workflow execution but grants it no new authority.
 - `authorization.grant` permits granting a relationship or role and may be held only by a human subject. The grant cannot exceed the issuer's current authority, resource scope, conditions, or expiration.
-- Every installed package runtime uses an organization-owned workload identity; workflow definitions and executions use organization-owned workflow identities.
+- Every installed package runtime uses an organization-owned workload identity. Workflow definitions are bound to organization-owned workflow identities that the workflow service uses for execution.
 - Every invocation is centrally authorized before dispatch; package-specific resource checks may further restrict it.
 - Production does not start in a fail-open mode when identity or authorization is unavailable.
 
@@ -314,11 +317,11 @@ Release manifests define only the authorization relationships or roles required 
 
 ### Workflows
 
-Packages publish immutable workflow definitions that the revision controller registers with a mesh workflow service; each execution is pinned to its definition and operation-contract digests until completion, migration, or retirement, while new executions use the promoted catalog generation.
+Packages publish immutable workflow definitions that the revision controller registers with a mesh workflow service. Each execution is pinned to its definition and operation-contract digests until completion, migration, or retirement, while new executions use the promoted catalog generation.
 
 ### User Interfaces
 
-TODO
+UI staging, serving, authorization, version pinning, and rollback behavior remain to be specified.
 
 ### Catalogs and Administration
 
@@ -343,7 +346,7 @@ Authentication comes from an interactive session, keychain, environment, or stan
 
 Invocation uses MCP Streamable HTTP: JSON-RPC over POST with JSON or SSE responses. The gateway enforces request size, timeout, rate, and stream lifetime.
 
-Ingress strips external identity and routing fields, authenticates the credential, and exchanges it for a short-lived signed caller token; it neither parses MCP nor authorizes operations. The token is bound to its issuer, waypoint audience, target installation, and raw envelope hash. It carries a unique ID; issuance, not-before, and expiry times; actor and effective subject; credential and delegation upper bounds; optional browser-capability claims; delegation chain; and trace ID.
+Ingress strips external identity and routing fields, authenticates the credential, and exchanges it for a short-lived signed caller token; it neither parses MCP nor authorizes operations. The token is bound to its issuer, waypoint audience, target installation, and raw envelope hash. It carries a unique ID; issuance, not-before, and expiry times; actor and effective subject; credential and delegation upper bounds; optional browser-capability claims; a delegation chain; and a trace ID. After authorization, the destination waypoint replaces the caller token with a signed internal caller context containing only the claims the runtime needs.
 
 ### Development Sandbox
 
@@ -362,9 +365,9 @@ Development packages:
 - Cannot receive or forward raw caller credentials
 - Do not inherit the production workload's permissions
 - Use sandbox-scoped authorization
-- Expire automatically and are audited on connect and disconnect
+- Expire automatically and are audited upon connection and disconnection
 
-The first implementation has one production deployment profile: Kubernetes with Istio ambient mode and the protected platform services described below. `vt build` may run locally, but there is no standalone laptop, VM, no-auth, or non-mesh production runtime. The development sandbox is a capability of a connected deployment rather than a second local control plane.
+The first implementation has one production deployment profile: Kubernetes with Istio ambient mode and the protected platform services described below. `vt build` may run locally, but there is no production runtime for standalone laptops or VMs, unauthenticated operation, or operation outside the mesh. The development sandbox is a capability of a connected deployment rather than a second local control plane.
 
 ## Platform Architecture
 
@@ -372,11 +375,11 @@ The first implementation has one production deployment profile: Kubernetes with 
 
 The platform separates deployment into three trust and lifecycle tiers:
 
-1. **Bootstrap substrate**: Kubernetes and Istio, the control-plane state store, revision controllers, certificate authority, and backup and recovery tooling. Terraform deploys these components before package APIs are available.
+1. **Bootstrap substrate**: Kubernetes and Istio, the Google Cloud Storage artifact bucket, the control-plane state store, revision controllers, certificate authority, and backup and recovery tooling. Terraform provisions or deploys these components before package APIs are available.
 2. **Protected system packages**: identity, authorization, secret management, registry verification, audit, and workflow execution. After the bootstrap substrate is healthy, revision controllers install and upgrade these services using signed releases and the normal immutable revision and rollout machinery.
 3. **Ordinary organization packages**: packages installed by authorized organization or package administrators and constrained by organization policy.
 
-The bootstrap substrate and protected system packages are both inside the platform availability boundary. If a required component in either tier is unavailable, the affected capability is counted as platform downtime even when some existing package traffic continues. An ordinary package failure counts as downtime for that package, not for the platform, unless a platform defect caused or spread the failure.
+The bootstrap substrate and protected system packages are both inside the platform availability boundary. If a required component in either tier is unavailable, the affected capability is counted as platform downtime even when some existing package traffic continues. An ordinary package failure counts as downtime for that package, not for the platform, unless a platform defect caused or propagated the failure.
 
 ### Trusted Platform Services
 
@@ -385,14 +388,14 @@ The bootstrap substrate and protected system packages provide these trusted serv
 - **Identity service**: authenticates sessions and API grants, resolves canonical principals, manages organization service accounts, issues caller tokens, and manages signing keys for internal caller contexts and session wrappers.
 - **Authorization service**: stores immutable policy models, grants, assignments, and revocations and evaluates provider-independent and Envoy `ext_authz` checks.
 - **Secret-management service**: stores and rotates platform and connection credentials and releases secret material only to explicitly authorized workload identities.
-- **Registry-verification service**: verifies the deployment registry, validates pull-through imports identified by canonical package ID, verifies manifests, digests, signatures, platform compatibility, trust policy, and local artifact completeness before catalog exposure and admission.
-- **Audit sink**: accepts append-only security, authorization, administration, and runtime events in storage that packages cannot control.
+- **Registry-verification service**: validates the deployment registry and pull-through imports identified by canonical package ID. Before catalog exposure and admission, it verifies manifests, digests, signatures, platform compatibility, trust policy, and local artifact completeness.
+- **Audit sink**: writes append-only security, authorization, administration, and runtime events to storage that packages cannot control.
 - **Workflow service**: registers promoted package-defined workflows and runs pinned executions outside package runtimes.
 - **Control-plane state store**: a bootstrap-substrate service that durably stores deployment-registry state, import attempts and provenance, package slots, revision requests and operations, routing and catalog generations, migration outcomes, and recovery metadata.
 
 ### Runtime Architecture
 
-Production uses Istio ambient mode. Package Pods have no mesh or application proxy sidecar; they expose MCP and health endpoints directly. Every package runtime and migration executes as a Bun application in a platform-owned, unprivileged Bun container image; publishers cannot provide arbitrary images or Dockerfiles. The runtime combines `istiod`, mandatory node-level `ztunnel`, shared destination and ingress waypoints, gateways, these standardized Bun application containers, protected services, the state store, and revision controllers. Revision controllers reconcile durable state into Deployments, Services, waypoint enrollment, Gateway API routes, signed cluster-selection configuration, and `AuthorizationPolicy`; `istiod` distributes the resulting xDS configuration. `Istiod` owns endpoint, routing, certificate, and mesh-policy distribution—not revision state, grants, workflows, or catalogs.
+Production uses Istio ambient mode. Package Pods have no mesh or application proxy sidecar; they expose MCP and health endpoints directly. Every package runtime and migration executes as a Bun application in a platform-owned, unprivileged Bun container image; publishers cannot provide arbitrary images or Dockerfiles. The runtime combines `istiod`, mandatory node-level `ztunnel`, shared destination and ingress waypoints, gateways, these standardized Bun application containers, protected services, the state store, and revision controllers. Revision controllers reconcile durable state into Deployments, Services, waypoint enrollment, Gateway API routes, signed cluster-selection configuration, and `AuthorizationPolicy`; `istiod` distributes the resulting xDS configuration. `istiod` owns endpoint, routing, certificate, and mesh-policy distribution—not revision state, grants, workflows, or catalogs.
 
 **`ztunnel` configures (L4):**
 
@@ -408,14 +411,14 @@ Production uses Istio ambient mode. Package Pods have no mesh or application pro
 - MCP decoding, authorization, and operation-specific revision routing via decoder metadata and signed generation-fenced routing tables—not caller headers or `HTTPRoute` matching
 - Signed session routing wrappers for SSE pinning, plus L7 request, MCP outcome, and trace telemetry
 
-Ingress authenticates external credentials and mints caller tokens; the destination waypoint decodes and authorizes MCP requests. Health probes use a separate protected port with the minimum exception. `NetworkPolicy` provides reachability enforcement alongside ambient policy. Authorization fails closed; health ports have no public ingress. If a required security event cannot be delivered or durably buffered, the affected request fails closed. If `istiod` is unavailable, established traffic uses its last configuration; new revision operations requiring routing or policy changes fail closed until dependencies recover.
+Ingress authenticates external credentials and mints caller tokens; the destination waypoint decodes and authorizes MCP requests. Health probes use a separate protected port with only the minimum necessary policy exception. `NetworkPolicy` provides reachability enforcement alongside ambient policy. Authorization fails closed; health ports have no public ingress. If a required security event cannot be delivered or durably buffered, the affected request fails closed. If `istiod` is unavailable, established traffic uses its last configuration; new revision operations requiring routing or policy changes fail closed until dependencies recover.
 
 ### Infrastructure and Service Rollouts
 
 The mesh is redeployed only for changes to Istio or its trust and extension configuration, including:
 
 - `istiod`, `ztunnel`, and waypoint proxy versions
-- Ingress and egress gateway versions or deploy-pinned configuration
+- Ingress and egress gateway versions or deployment-pinned configuration
 - Istio certificate-authority and trust-domain configuration
 - Mesh-wide extension-provider and ambient-enrollment configuration
 
@@ -425,8 +428,10 @@ Bootstrap-substrate changes, including control-plane state migrations and backup
 
 ## Representative Request Lifecycles
 
+The following representative lifecycles remain to be specified:
+
 - Provision the deployment registry
-- Pull a package release
+- Import a package release through pull-through
 - Publish a package release
 - Upgrade a package
 - Invoke a package operation
@@ -434,23 +439,25 @@ Bootstrap-substrate changes, including control-plane state migrations and backup
 - Authentication
 - Connect external credentials
 
-# Minimum Dependencies
-
-
-
 ## Glossary
 
 | Term | Meaning |
 | --- | --- |
+| App | User-facing term for an installed package |
+| API grant | Named, expiring set of permissions; an API key is the credential used to exercise it |
 | Canonical package ID | Global package identifier: the concatenation of `registryId` and registry-local `packageId`, written as `registryId/packageId`; never reused |
+| Deployment registry | A deployment's private registry and sole package catalog and artifact source |
 | Package identity | Equivalent to canonical package ID; also representable as `(registryId, packageId)` |
 | Pull-through import | Verified, atomic copy of an external release and its complete artifact closure into the deployment registry, identified by canonical package ID and release version, using upstream read credentials supplied at import time |
-| `releaseDigest` | Hash of canonical manifest bytes and authoritative install input |
+| `releaseVersion` | Publisher-assigned version that permanently resolves to one immutable `releaseDigest` within a package |
+| `releaseDigest` | SHA-256 hash of the canonical manifest bytes; the authoritative installation input |
 | Revision | Installed release or removal tombstone |
 | Revision operation | Fenced execution of durable revision intent |
 | Promotion | Atomic commit advancing the promoted head and catalog generations |
 | Routing generation | Durable correlation of one routing decision, its resources, proxy set, and observations |
-| Atomic rollout group | One fenced promotion across mutually dependent packages |
+| Service account | Organization-managed non-human principal that may be assigned to runtimes, migrations, or workflows |
+| Workload identity | Runtime identity materialized from an assigned service account and enforced by Kubernetes and the mesh |
+| Workflow identity | Identity bound to a workflow definition and used by the workflow service for executions |
 | Caller token | Signed pre-authorization context presented only to a destination waypoint |
 | Internal caller context | Signed post-authorization context forwarded to a runtime |
 | Protected system package | Signer-pinned platform package unavailable to ordinary package APIs |

--- a/plans/service_mesh/plan.md
+++ b/plans/service_mesh/plan.md
@@ -1,16 +1,29 @@
 # Service Mesh Design
 
+## Contents
+
+- [Overview](#overview)
+- [Design Invariants](#design-invariants)
+- [Model](#identity-model)
+- [Publishing](#package-releases)
+- [Revisions](#durable-deployment-state)
+- [Runtime](#workflows)
+- [Authorization](#authentication-and-authorization)
+- [Implementation](#runtime-architecture)
+- [Assurance](#retention-and-audit)
+- [Glossary](#glossary)
+
 ## Overview
 
-The platform builds, distributes, installs, and runs services in a shared service mesh. A service release may include:
+The platform builds, distributes, installs, and runs packages in a shared service mesh. A package release may include:
 
 - An MCP server and its operations
 - One or more single-page user interfaces
 - Durable workflow definitions and workers
 - Dependency and migration metadata
-- Runtime, configuration, secret, network, and authorization requirements
+- Runtime, configuration, and authorization requirements
 
-An organization operates one deployment backed by a private registry and, optionally, additional trusted registries. The deployment exposes catalogs of installed services, callable operations, user interfaces, workflows, and dependencies.
+An organization operates one deployment backed by a private registry and, optionally, additional trusted registries. The deployment exposes catalogs of installed packages, callable operations, user interfaces, workflows, and dependencies.
 
 Publishing makes a release discoverable. Installation admits an immutable release into an organization. Canarying permits controlled, undiscoverable traffic, while promotion makes an installed revision primary and user-discoverable. These states are separate and must not be inferred from one another.
 
@@ -18,66 +31,48 @@ Publishing makes a release discoverable. Installation admits an immutable releas
 
 The following invariants apply to every implementation:
 
-1. A published release is immutable and identified by a digest.
+1. A published release is immutable and identified by its `releaseDigest`.
 2. A deployment records every accepted install, upgrade, rollback, and removal request in an append-only revision history.
-3. At most one lifecycle operation for an organization and canonical service identity is nonterminal at a time, including first installation.
-4. Request handlers record intent; reconcilers perform runtime work and resume safely after process failure.
+3. For each canonical package identity in an organization, only one revision operation — install, upgrade, rollback, or removal — may be in progress at a time.
+4. Durable revision requests record intent; revision controllers perform runtime work and resume safely after process failure.
 5. Published, admitted, materialized, running, ready, canary-callable, promoted, and converged are distinct states.
 6. A pre-promotion failure does not replace the last successfully promoted revision.
 7. Routing propagation is eventually consistent, so every revision that may receive traffic remains contract-compatible until propagation and draining finish. New contracts become visible only after routing convergence.
-8. Package metadata can request capabilities but cannot grant itself identity, authorization, secrets, ingress, or egress.
+8. Packages run only under organization-provisioned identities; requested capabilities require explicit grant or delegation and cannot be self-asserted by release metadata.
 9. Dynamic services cannot replace the identity, authorization, certificate, secret, registry-verification, audit, state-storage, or recovery components needed to administer the mesh.
 10. Every externally supplied manifest, image, schema, migration, and attestation is untrusted until its digest, signature, and policy are verified.
-
-## Runtime Architecture
-
-The runtime consists of:
-
-- **Istio control plane (`istiod`)**: distributes routing, policy, endpoint, and certificate configuration to the Istio data plane.
-- **Istio workload data plane**: Envoy sidecars mediate inbound and outbound workload traffic. Ambient mode, using mandatory node-level `ztunnel` proxies and optional L7 waypoint proxies, is a possible later deployment mode; a deployment uses one documented mode at a time.
-- **Ingress gateways**: separate Envoy data-plane proxies terminate external transport, remove untrusted identity headers, authenticate supported credentials, and route public and organization traffic.
-- **Egress gateways**: separate Envoy data-plane proxies enforce and audit declared external network access where direct egress cannot be safely allowed.
-- **Service supervisor (`gestaltd`)**: runs alongside one service installation, mediates application-level invocation and authorization, reports observed state, and manages the service process. It is not an Istio data-plane proxy and does not replace Envoy.
-- **Service runtime**: runs the service's MCP server, interfaces, and workflow workers.
-- **Lifecycle controllers**: reconcile durable install and rollout records into workloads, routing, catalogs, identities, and policy.
-
-Production uses Istio `PeerAuthentication` in `STRICT` mode for mesh mutual TLS, Istio `AuthorizationPolicy` for workload-to-workload policy, and Kubernetes `NetworkPolicy` for network reachability. The deployment installs explicit default-deny authorization and network policies; these mechanisms are not assumed to deny traffic merely because they are enabled. Service application ports are reachable only through the mesh data plane. Health and supervisor administration ports have explicit, minimal exceptions and are not exposed through public ingress.
-
-Established data-plane traffic continues using the last known configuration when `istiod` is unavailable. New lifecycle operations that require routing, certificates, policy, or registry verification fail closed until their control-plane dependencies recover.
-
-Terraform deploys the GCP infrastructure, including the Valon Tools cluster, GitHub Actions cluster, networking, container infrastructure, identity services, and deploy-pinned trusted components. Installing services does not mutate this trusted computing base.
 
 ## Identity Model
 
 The system keeps these identities separate:
 
 - **Registry identity**: immutable `registryId` plus its configured origin and trust-policy digest.
-- **Service identity**: permanent `(registryId, serviceId)` assigned when the service is reserved. A slug is a mutable display and discovery alias, never a security identifier.
-- **Release identity**: `(registryId, serviceId, version, releaseDigest)`.
-- **Installation identity**: an organization-scoped UUID representing one installed service.
+- **Package identity**: permanent `(registryId, packageId)` assigned when the package is reserved. A slug is a mutable display and discovery alias, never a security identifier.
+- **Release identity**: `(registryId, packageId, releaseVersion, releaseDigest)`.
+- **Installation identity**: an organization-scoped UUID representing one installed package.
 - **Workload identity**: an orchestrator-owned SPIFFE identity for one installation's runtime or migration job.
 - **Workflow identity**: the principal assigned to a workflow definition or execution.
 - **Actor identity**: the user, API grant, service account, or workflow that initiated an action.
 - **Effective subject**: the principal whose delegated authority an invocation exercises.
 
-Service IDs are never reused. Slug renames retain aliases and tombstones. Mirroring a service preserves its identity only through a signed mirror or transfer relationship; otherwise importing it creates a distinct service identity.
+Package IDs are never reused. Slug renames retain aliases and tombstones. Mirroring a package preserves its identity only through a signed mirror or transfer relationship; otherwise importing it creates a distinct package identity.
 
 Package authors cannot select workload identities. The orchestrator binds installations to Kubernetes service accounts and short-lived SPIFFE certificates. Trust domain, certificate lifetime, rotation, and compromise revocation are deployment policy.
 
-## Service Releases
+## Package Releases
 
-One service version has one platform-independent, signed release manifest. The release manifest is stored as an OCI artifact or another digest-addressed immutable object and references an OCI image index digest. The image index selects immutable image manifests for supported `os`, `architecture`, and optional `variant` tuples.
+Each `releaseVersion` has one platform-independent, signed release manifest. The release manifest is stored as an OCI artifact or another digest-addressed immutable object and references an OCI image index digest. The image index selects immutable image manifests for supported `os`, `architecture`, and optional `variant` tuples.
 
 Platform images may contain different binaries, but their operation contracts, dependencies, migrations, workflows, and requested capabilities must match the release manifest. A platform-specific release contract is not allowed.
 
 The release manifest contains:
 
-- Canonical registry and service IDs, slug, and version
+- Canonical registry and package IDs, slug, and `releaseVersion`
 - OCI image-index digest and supported platforms
 - Instructions for starting the MCP server, interfaces, and workflow workers
 - MCP endpoint, operations, and input/output schema digests
 - Included workflows and user interfaces
-- Required and optional service and operation dependencies
+- Required and optional package and operation dependencies
 - Ordered prepare, finalize, and compensating migration jobs
 - Rollback classification
 - Requested service-account, authorization, ingress, and egress capabilities
@@ -89,9 +84,9 @@ The release manifest contains:
 
 The manifest does not contain self-asserted signatures or provenance. Signatures and SLSA/in-toto provenance are detached attestations over the release and image digests, such as OCI referrers.
 
-The release digest is computed over the canonical manifest bytes and is carried by catalog entries, signatures, attestations, and installation records rather than by the hashed manifest itself.
+The `releaseDigest` is computed over the canonical manifest bytes and is carried by catalog entries, signatures, attestations, and installation records rather than by the hashed manifest itself.
 
-Versions follow a registry-defined, documented grammar and comparison order. A `(registryId, serviceId, version)` binds permanently to one release digest. A conflicting republish is rejected. An identical retry is idempotent and does not rewrite publication time or provenance. Mutable tags may aid discovery but are never installation inputs.
+`releaseVersion` values follow a registry-defined, documented grammar and comparison order. A `(registryId, packageId, releaseVersion)` binds permanently to one `releaseDigest`. A conflicting republish is rejected. An identical retry is idempotent and does not rewrite publication time or provenance. Mutable tags may aid discovery but are never installation inputs.
 
 ## Registries
 
@@ -101,7 +96,7 @@ Registries control who can publish, discover, or download releases. Each configu
 - Discovery, metadata, blob, and publication endpoints
 - Authentication and authorization scopes
 - Trusted signing identities and builders
-- Allowed service namespaces
+- Allowed package namespaces
 - Source repository and workflow constraints
 - Required provenance level
 - Whether direct developer publication is permitted
@@ -111,7 +106,7 @@ Connecting a registry does not trust every publisher in it. Catalogs and manifes
 
 The registry interface defines pagination, conditional reads, consistency guarantees, error codes, retries, rate limits, and authentication separately for catalog discovery, immutable metadata, blob pulls, and publication.
 
-A catalog contains paginated service and release summaries pointing to authoritative release-manifest digests. It does not duplicate the full release contract. Per-service indexes use monotonic revisions and compare-and-swap updates.
+A catalog contains paginated package and release summaries pointing to authoritative release-manifest digests. It does not duplicate the full release contract. Per-package indexes use monotonic revisions and compare-and-swap updates.
 
 Disconnecting a registry blocks new discovery and installation but preserves its identity and all historical records. Hard removal is rejected while any desired, running, redeployable, dependent, or in-progress revision references it. Rebinding to a mirror requires digest-equivalent content and signatures trusted by the deployment.
 
@@ -121,13 +116,13 @@ Disconnecting a registry blocks new discovery and installation but preserves its
 
 Publication is a recoverable transaction:
 
-1. Reserve `(serviceId, version)` and create a publish-attempt ID.
+1. Reserve `(packageId, releaseVersion)` and create a publish-attempt ID.
 2. Record a pending release with source and workflow provenance.
 3. Upload content-addressed image blobs and manifests.
 4. Validate all platform images and release contracts server-side.
 5. Create the immutable release manifest.
 6. Attach signatures and provenance attestations.
-7. Commit availability by compare-and-swap updating the service catalog last.
+7. Commit availability by compare-and-swap updating the package catalog last.
 8. Mark the attempt succeeded or failed.
 
 Pending and failed attempts are visible but never installable. Concurrent publishers cannot lose catalog updates. Stale attempts become failed, and orphaned content-addressed blobs are garbage-collected after a grace period.
@@ -136,16 +131,16 @@ Pending and failed attempts are visible but never installable. Concurrent publis
 
 The control plane persists:
 
-- **Service slots**: one organization-scoped slot keyed by canonical service identity, reserved before allocating an installation ID and used to fence concurrent first installs
-- **Revision requests**: append-only install, upgrade, rollback, and removal intent with actor, previous promoted revision, target release digest, approved capabilities, resolved dependencies, and timestamps
+- **Package slots**: one organization-scoped slot keyed by canonical package identity, reserved before allocating an installation ID and used to fence concurrent first installs
+- **Revision requests**: append-only install, upgrade, rollback, and removal intent with actor, previous promoted revision, target `releaseDigest`, approved capabilities, resolved dependencies, and timestamps
 - **Installation head**: last successfully promoted revision and current admitted candidate
-- **Lifecycle operation**: one generation-fenced state machine per installation
-- **Migration outcomes**: immutable status keyed by installation, release digest, and migration ID
+- **Revision operation**: one generation-fenced state machine per installation
+- **Migration outcomes**: immutable status keyed by installation, `releaseDigest`, and migration ID
 - **Workload observations**: materialized, started, ready, draining, stopped, and error state for each target replica
 - **Routing and catalog generation**: the promoted revision visible to callers
 - **Terminal outcomes**: completion or failure phase, duration, and reason
 
-Lifecycle records use optimistic concurrency and fencing tokens. A stale controller cannot mutate a newer generation after losing its lease. Retries are idempotent, and every external mutation has a stable idempotency key.
+Revision records use optimistic concurrency and fencing tokens. A stale controller cannot mutate a newer generation after losing its lease. Retries are idempotent, and every external mutation has a stable idempotency key.
 
 Each rollout targets one immutable runtime cohort identified by the infrastructure generation and `gestaltd` supervisor generation. Replicas enroll during a bounded epoch; the nonempty cohort is then frozen for promotion accounting. Scaling replicas that join later still converge but do not retroactively change the completed cohort. Observations include the rollout generation and enrollment epoch so stale or overlapping infrastructure cohorts cannot satisfy a newer rollout.
 
@@ -164,33 +159,33 @@ The runtime distinguishes:
 
 ## Installation
 
-Publishing does not install a service. An organization administrator selects an immutable release digest and binds:
+Publishing does not install a package. An organization administrator selects an immutable `releaseDigest` and binds:
 
-- Organization-owned service and workflow identities
+- Organization-owned package and workflow identities
 - Package-requested operations and capabilities to approved authorization relationships
 - Caller-delegation policy per operation
 - Typed configuration values and secret references
 - Ingress and egress requests to organization policy
 - Initial replica, resource, and availability settings
 
-The platform shows the requested-versus-approved capability diff before admission. An installer can use only identities for which they have `can_use` or `can_delegate`, and cannot convert temporary authority into an unrestricted persistent service grant. Sensitive capabilities may require a second approver.
+The platform shows the requested-versus-approved capability diff before admission. An installer can use only identities for which they have `can_use` or `can_delegate`, and cannot convert temporary authority into an unrestricted persistent package grant. Sensitive capabilities may require a second approver.
 
 Installation is a reconciled saga:
 
 1. Verify registry trust, release and image signatures, provenance, platform support, runtime compatibility, and schema versions.
 2. Resolve exact dependency revisions and operation-contract digests.
-3. Reserve the organization service slot and persist the revision request, approved capability snapshot, and fenced lifecycle operation.
+3. Reserve the organization package slot and persist the revision request, approved capability snapshot, and fenced revision operation.
 4. Provision the installation identity, workload identity, policy, configuration, and secret bindings.
 5. Materialize and start the initial workload without making it callable.
 6. Require readiness quorum and minimum healthy duration.
 7. Promote routing, wait for the frozen proxy cohort to acknowledge the routing generation, and drain any prior compatible route.
 8. Advance the callable catalog only after routing converges, then record convergence and the terminal outcome.
 
-Failures preserve the durable phase and diagnostics. The reconciler retries retryable phases within policy and compensates unpromoted resources when an administrator cancels the installation. A service is not callable until promotion succeeds.
+Failures preserve the durable phase and diagnostics. The revision controller retries retryable phases within policy and compensates unpromoted resources when an administrator cancels the installation. A package is not callable until promotion succeeds.
 
 ## Dependencies and Contracts
 
-Dependencies use canonical service identities, version ranges, and required operation contract digests. Dependencies may be required or optional. Admission records the exact revisions and contract digests selected.
+Dependencies use canonical package identities, `releaseVersion` ranges, and required operation contract digests. Dependencies may be required or optional. Admission records the exact revisions and contract digests selected.
 
 The platform validates:
 
@@ -198,12 +193,12 @@ The platform validates:
 - Required operations exist
 - Required input and output contracts match
 - The candidate remains compatible with existing reverse dependents
-- No conflicting lifecycle operation is active in the affected dependency subgraph
+- No conflicting revision operation is active in the affected dependency subgraph
 - Workflow calls reference compatible operation contracts
 
 JSON Schemas use one pinned dialect and canonical encoding before hashing. The first implementation requires exact schema digests. Semantic compatibility can be introduced only with documented contravariant input and covariant output rules.
 
-Validation reads a revisioned desired-state snapshot and commits with generation preconditions. For independent services, upgrades may proceed concurrently. Upgrades that affect the same dependency subgraph use deterministic locking or one atomic multi-service rollout plan. Dependency cycles are rejected until atomic rollout groups are implemented.
+Validation reads a revisioned desired-state snapshot and commits with generation preconditions. For independent packages, upgrades may proceed concurrently. Upgrades that affect the same dependency subgraph use deterministic locking or one atomic multi-package rollout plan. Dependency cycles are rejected until atomic rollout groups are implemented.
 
 ## Upgrades and Traffic Promotion
 
@@ -225,22 +220,22 @@ The rollout state machine is:
 
 Each phase has a timeout, retry policy, and terminal error taxonomy. Promotion requires nonempty frozen runtime and proxy cohorts and cannot be inferred from one ready instance. Routing changes define weight propagation, proxy acknowledgement, readiness quorum, connection draining, and behavior for MCP SSE streams. During partial routing propagation, both revisions support the promoted operation-contract digests.
 
-Failures before promotion produce a failed candidate and leave the prior promoted revision primary. Failures during soak after promotion mark the new revision degraded and trigger rollback when its rollback class permits; otherwise they require an audited forward fix. Finalization failure does not relabel the promoted revision as a failed candidate or route traffic implicitly: it records `promoted_with_finalization_error`, blocks the next lifecycle operation, and requires retry or an approved forward fix.
+Failures before promotion produce a failed candidate and leave the prior promoted revision primary. Failures during soak after promotion mark the new revision degraded and trigger rollback when its rollback class permits; otherwise they require an audited forward fix. Finalization failure does not relabel the promoted revision as a failed candidate or route traffic implicitly: it records `promoted_with_finalization_error`, blocks the next revision operation, and requires retry or an approved forward fix.
 
-The availability goal is zero planned downtime for services that satisfy the compatibility contract. Any supported operation that requires downtime declares and receives explicit administrator approval before admission; a vague downtime target is not sufficient.
+The availability goal is zero planned downtime for packages that satisfy the compatibility contract. Any supported operation that requires downtime declares and receives explicit administrator approval before admission; a vague downtime target is not sufficient.
 
 ## Migrations and Rollback
 
 Migrations are separately identified, digest-pinned jobs. Each declares:
 
-- Migration ID and release digest
+- Migration ID and `releaseDigest`
 - Prepare, finalize, or compensating phase
 - Dedicated workload identity and requested capabilities
 - Required secrets and network destinations
 - Timeout, resource limits, retry policy, and idempotency key
-- Compatibility with the prior and candidate service revisions
+- Compatibility with the prior and candidate package revisions
 
-Migration jobs run with least privilege and deny-by-default egress. They never run as the installer, lifecycle controller, or normal service identity. Attempt and completion records are durable.
+Migration jobs run with least privilege and deny-by-default egress. They never run as the installer, revision controller, or normal package identity. Attempt and completion records are durable.
 
 Each release declares one rollback class:
 
@@ -251,15 +246,7 @@ Each release declares one rollback class:
 
 Prepare migrations follow expand/contract rules and must remain compatible with the serving revision. Releases with a rollback-capable class defer destructive finalize migrations until the rollback window closes. A no-post-promotion-rollback release requires explicit approval before promotion and has no rollback window. A rollback command is not proof that data rollback is safe.
 
-Administrators initiate rollback through the same lifecycle controller. Manual shell execution cannot update lifecycle state. Automatic rollback may later invoke the same audited state machine when canary or soak gates fail.
-
-## Workflows
-
-Workflow definitions are immutable and versioned independently from service processes. Each execution records its workflow-definition digest, actor, workflow identity, and compatible service-operation contract revisions.
-
-Existing executions continue on workers that support their pinned definition until they complete, migrate, or reach a documented retirement policy. New executions use the promoted workflow catalog generation. Removal and incompatible upgrades must account for queued work, retries, timers, and long-running executions before workers are drained.
-
-Every workflow operation is authorized at execution time. `can_run_as` is required to select an organization-managed workflow identity. The original triggering actor remains in the audit and delegation chain.
+Administrators initiate rollback through the same revision controller. Manual shell execution cannot update revision state. Automatic rollback may later invoke the same audited state machine when canary or soak gates fail.
 
 ## Removal
 
@@ -270,35 +257,43 @@ Removal is a durable tombstoned revision, not deletion of a catalog row:
 3. Drain already-resolved requests, streams, workers, and queued work according to policy.
 4. Stop workloads and block ingress and egress.
 5. Revoke workload certificates, installation-owned assignments, delegated tokens, secret bindings, and runtime configuration.
-6. Apply service-data retention or destruction policy.
-7. Preserve the service tombstone and audit history.
+6. Apply package-data retention or destruction policy.
+7. Preserve the package tombstone and audit history.
 8. Garbage-collect runtime resources after the recovery window.
 
 Organization-owned persistent grants are not silently deleted; the removal UI distinguishes them from installation-owned grants. Reinstallation creates a new installation identity unless an explicit restore operation reactivates the tombstone within policy.
+
+## Workflows
+
+Workflow definitions are immutable and versioned independently from package processes. Each execution records its workflow-definition digest, actor, workflow identity, and compatible package-operation contract revisions.
+
+Existing executions continue on workers that support their pinned definition until they complete, migrate, or reach a documented retirement policy. New executions use the promoted workflow catalog generation. Removal and incompatible upgrades must account for queued work, retries, timers, and long-running executions before workers are drained.
+
+Every workflow operation is authorized at execution time. `can_run_as` is required to select an organization-managed workflow identity. The original triggering actor remains in the audit and delegation chain.
 
 ## Catalogs and Administration
 
 An organization deployment provides:
 
-- A service catalog
+- A package catalog
 - An operation catalog
 - A user-interface catalog
 - A workflow catalog
 - A dependency graph
-- Service revisions, rollout and migration status, identities, and authorization settings
+- Package revisions, rollout and migration status, identities, and authorization settings
 - API-grant management
 - A development sandbox
 
-Candidate metadata may be visible to administrators, but user-facing callable catalogs expose only contracts safe for the currently propagated routes. Routing is updated first because xDS propagation is asynchronous; newly added contracts become discoverable only after the frozen proxy cohort acknowledges the routing generation. Both revisions remain contract-compatible until old routes drain. Each invocation, including an SSE stream, resolves once and remains pinned to one service revision.
+Candidate metadata may be visible to administrators, but user-facing callable catalogs expose only contracts safe for the currently propagated routes. Routing is updated first because xDS propagation is asynchronous; newly added contracts become discoverable only after the frozen proxy cohort acknowledges the routing generation. Both revisions remain contract-compatible until old routes drain. Each invocation, including an SSE stream, resolves once and remains pinned to one package revision.
 
-Organization administrators can connect registries and install, upgrade, roll back, or remove services. Service developers can build, publish, test, and invoke services. Service users see only catalogs and operations authorized for them.
+Organization administrators can connect registries and install, upgrade, roll back, or remove packages. Package developers can build, publish, test, and invoke packages. Package users see only catalogs and operations authorized for them.
 
 Representative endpoints:
 
 - Deployment: `https://vt.valon.tools`
 - Private registry: `https://vt.valon.tools/registry`
 - Administration: `https://vt.valon.tools/admin`
-- Service administration: `https://vt.valon.tools/services/<service>/admin`
+- Package administration: `https://vt.valon.tools/packages/<package>/admin`
 
 Management APIs use a private listener or equivalent network restriction and require stronger authorization than user invocation endpoints.
 
@@ -307,23 +302,23 @@ Management APIs use a private listener or equivalent network restriction and req
 Authorized operations are available over the deployment endpoint and through the CLI:
 
 ```sh
-vt invoke --deployment <url> <service> <operation> --args <json>
+vt invoke --deployment <url> <package> <operation> --args <json>
 ```
 
 Authentication comes from an interactive session, keychain, environment, or standard input. Secrets and tokens are not positional command arguments.
 
-Operation invocation uses MCP Streamable HTTP. Clients and services support JSON-RPC over POST and the protocol's JSON and SSE response forms. The gateway enforces request size, timeout, rate, and stream-lifetime policy.
+Operation invocation uses MCP Streamable HTTP. Clients and packages support JSON-RPC over POST and the protocol's JSON and SSE response forms. The gateway enforces request size, timeout, rate, and stream-lifetime policy.
 
-Ingress strips externally supplied internal-identity headers. It exchanges user credentials for a short-lived, audience-bound internal invocation token containing the original actor, effective subject, immediate calling workload, delegation chain, target service and operation, issued/expiry times, nonce, and trace ID. Services never forward raw user bearer tokens or API keys.
+Ingress strips externally supplied internal-identity headers. It exchanges user credentials for a short-lived, audience-bound internal invocation token containing the original actor, effective subject, immediate calling workload, delegation chain, target package and operation, issued/expiry times, nonce, and trace ID. Packages never forward raw user bearer tokens or API keys.
 
 The authorization decision intersects:
 
 - The authenticated calling workload's permission to invoke the target
 - The effective subject's permission
-- The installed service's approved operation policy
+- The installed package's approved operation policy
 - Any operation-specific resource authorization
 
-Unknown identities, services, operations, policies, or authorization-provider outages deny access.
+Unknown identities, packages, operations, policies, or authorization-provider outages deny access.
 
 ## Authentication and Authorization
 
@@ -331,7 +326,7 @@ Unknown identities, services, operations, policies, or authorization-provider ou
 - API keys are named, expiring, scoped API grants that act on behalf of an owner. Only hashes are stored, plaintext is returned once, and empty scope does not mean unrestricted access.
 - Users create service accounts only with an attenuated subset of authority and explicit expiry or organization policy.
 - Every installation has organization-owned workload and workflow identities.
-- Every invocation is centrally authorized before dispatch; service-specific resource checks may further restrict it.
+- Every invocation is centrally authorized before dispatch; package-specific resource checks may further restrict it.
 - Production does not start in a fail-open mode when identity or authorization is unavailable.
 
 Authorization uses a Zanzibar-style graph. Relationship definitions declare whether they support delegated assignments, persistent grants, both, or neither. The default is neither.
@@ -341,7 +336,7 @@ Authorization uses a Zanzibar-style graph. Relationship definitions declare whet
 
 An assignment is a first-class record containing an immutable ID, organization, subject, relationship, resource, mode, issuer, creation and optional expiration, optional parent assignment, policy revision, and revocation state. Delegation has bounded depth, acyclic ancestry, transactional creation, and cascading invalidation. Independent valid paths preserve access after one path is revoked.
 
-Authorization caches and delegated invocation tokens have bounded lifetimes. Revocation has a documented maximum propagation time and applies to long-lived streams and each workflow step. Security events are written to an immutable audit sink outside service-controlled storage.
+Authorization caches and delegated invocation tokens have bounded lifetimes. Revocation has a documented maximum propagation time and applies to long-lived streams and each workflow step. Security events are written to an immutable audit sink outside package-controlled storage.
 
 ## Configuration, Secrets, Ingress, and Egress
 
@@ -353,15 +348,15 @@ Every endpoint is classified as public, organization-authenticated, mesh-interna
 
 ## Development Sandbox
 
-`vt dev` builds a local service and connects it only to an explicitly enabled per-user sandbox:
+`vt dev` builds a local package and connects it only to an explicitly enabled per-user sandbox:
 
 ```sh
 vt dev --deployment <url> <dir>
 ```
 
-Authentication uses the normal interactive or keychain flow. The platform issues a short-lived development workload identity distinct from the user's identity. Development routing is scoped to the developer or named test session and cannot take over a production service slug.
+Authentication uses the normal interactive or keychain flow. The platform issues a short-lived development workload identity distinct from the user's identity. Development routing is scoped to the developer or named test session and cannot take over a production package slug.
 
-Development services:
+Development packages:
 
 - Receive no production traffic by default
 - Cannot run migrations
@@ -369,6 +364,37 @@ Development services:
 - Cannot forward caller credentials
 - Use sandbox-scoped authorization and egress
 - Expire automatically and are audited on connect and disconnect
+
+## Runtime Architecture
+
+The runtime consists of:
+
+- **Istio control plane (`istiod`)**: distributes routing, policy, endpoint, and certificate configuration to the Istio data plane.
+- **Istio workload data plane**: Envoy sidecars mediate inbound and outbound workload traffic. Ambient mode, using mandatory node-level `ztunnel` proxies and optional L7 waypoint proxies, is a possible later deployment mode; a deployment uses one documented mode at a time.
+- **Ingress gateways**: separate Envoy data-plane proxies terminate external transport, remove untrusted identity headers, authenticate supported credentials, and route public and organization traffic.
+- **Egress gateways**: separate Envoy data-plane proxies enforce and audit declared external network access where direct egress cannot be safely allowed.
+- **Package supervisor (`gestaltd`)**: runs alongside one package installation, mediates application-level invocation and authorization, reports observed state, and manages the package process. It is not an Istio data-plane proxy and does not replace Envoy.
+- **Package runtime**: runs the package's MCP server, interfaces, and workflow workers.
+- **Revision controllers**: reconcile durable install and rollout records into workloads, routing, catalogs, identities, and policy.
+
+Production uses Istio `PeerAuthentication` in `STRICT` mode for mesh mutual TLS, Istio `AuthorizationPolicy` for workload-to-workload policy, and Kubernetes `NetworkPolicy` for network reachability. The deployment installs explicit default-deny authorization and network policies; these mechanisms are not assumed to deny traffic merely because they are enabled. Package application ports are reachable only through the mesh data plane. Health and supervisor administration ports have explicit, minimal exceptions and are not exposed through public ingress.
+
+Established data-plane traffic continues using the last known configuration when `istiod` is unavailable. New revision operations that require routing, certificates, policy, or registry verification fail closed until their control-plane dependencies recover.
+
+Terraform deploys the GCP infrastructure, including the Valon Tools cluster, GitHub Actions cluster, networking, container infrastructure, identity services, and deploy-pinned trusted components. Installing packages does not mutate this trusted computing base.
+
+## Mesh Deployment
+
+The mesh is redeployed only when changing deploy-pinned infrastructure, including:
+
+- `istiod` and Istio data-plane versions
+- `gestaltd` supervisor versions
+- Ingress and egress gateways
+- Identity, authorization, certificate, secret, audit, state-storage, registry-verification, or recovery services
+
+Package releases declare compatible `gestaltd` and mesh protocol ranges. Infrastructure rollouts account for old and new runtime cohorts before admitting a package release that requires new capabilities.
+
+Installing, upgrading, rolling back, or removing packages is a runtime change and does not require mesh redeployment. Connecting or disconnecting a registry is durable control-plane state and does not require redeployment, but changing registry trust roots remains a separately authorized and audited action.
 
 ## Retention and Audit
 
@@ -381,20 +407,7 @@ Immutable release metadata, attestations, and accepted revision history are reta
 
 OCI garbage collection is reference-aware because layers may be shared. Pruning is serialized with admission and rechecks eligibility immediately before deletion.
 
-Audit events include authentication, API-grant lifecycle, certificate issuance, authorization decisions, assignment mutation, delegated identity use, registry and trust-policy changes, publish/install/upgrade/rollback/removal, migration execution, secret access, ingress/egress denial, and development injection. Events include actor, effective subject, calling workload, target, policy revision, decision reason, trace ID, and release digest.
-
-## Mesh Deployment
-
-The mesh is redeployed only when changing deploy-pinned infrastructure, including:
-
-- `istiod` and Istio data-plane versions
-- `gestaltd` supervisor versions
-- Ingress and egress gateways
-- Identity, authorization, certificate, secret, audit, state-storage, registry-verification, or recovery services
-
-Service releases declare compatible `gestaltd` and mesh protocol ranges. Infrastructure rollouts account for old and new runtime cohorts before admitting a service release that requires new capabilities.
-
-Installing, upgrading, rolling back, or removing services is a runtime change and does not require mesh redeployment. Connecting or disconnecting a registry is durable control-plane state and does not require redeployment, but changing registry trust roots remains a separately authorized and audited action.
+Audit events include authentication, API-grant lifecycle, certificate issuance, authorization decisions, assignment mutation, delegated identity use, registry and trust-policy changes, publish/install/upgrade/rollback/removal, migration execution, secret access, ingress/egress denial, and development injection. Events include actor, effective subject, calling workload, target, policy revision, decision reason, trace ID, and `releaseDigest`.
 
 ## Required Verification
 
@@ -404,7 +417,7 @@ Before production use, automated tests cover:
 - Signature, provenance, trust-policy, platform, and runtime compatibility failures
 - Install and upgrade validation failures writing no admitted revision
 - Concurrent administrator and controller fencing
-- Controller failure and restart at every lifecycle phase
+- Controller failure and restart at every revision phase
 - Migration idempotency, lease loss, and incompatible rollback declarations
 - Dependency and reverse-dependent races
 - Canary failure, routing/catalog generation safety, draining, and SSE behavior
@@ -412,3 +425,35 @@ Before production use, automated tests cover:
 - Removal cleanup, tombstones, and retained workflow executions
 - Authorization outage, confused-deputy attempts, delegation attenuation, and revocation propagation
 - Multi-replica convergence and old/new infrastructure cohort overlap
+
+## Glossary
+
+**package identity**  
+Permanent `(registryId, packageId)` for a published package. Assigned when the package is reserved; never reused.
+
+**release**  
+Immutable, signed artifact for one `releaseVersion` of a package, identified by `releaseDigest`.
+
+**releaseVersion**  
+Registry-assigned label for one published release of a package. `(registryId, packageId, releaseVersion)` binds permanently to one `releaseDigest`.
+
+**releaseDigest**  
+Content hash of the canonical release manifest bytes. The authoritative install input; signatures and attestations bind to it.
+
+**revision**  
+One installed state of a package in an organization, backed by a specific `releaseDigest`.
+
+**revision request**  
+Durable intent to install, upgrade, rollback, or remove a package.
+
+**revision operation**  
+Generation-fenced state machine that executes one revision request.
+
+**revision controller**  
+Background worker that drives a revision operation to completion and resumes after failure.
+
+**rollout**  
+Staged path from admission through canarying and promotion for an install or upgrade candidate.
+
+**promotion**  
+Makes a revision primary for routing and user-facing catalogs.

--- a/plans/service_mesh/plan.md
+++ b/plans/service_mesh/plan.md
@@ -22,11 +22,13 @@ The platform builds, distributes, installs, and runs packages in a shared servic
 - Dependency and migration metadata
 - Runtime and operation-authorization requirements
 
-A platform package supervisor runs beside each installed package, starts its MCP server, and reports its observed runtime state.
+Each package runtime Pod includes a platform-owned supervisor sidecar that gates readiness and shutdown, exposes the mesh listener, and reports observed runtime state. Kubernetes starts and terminates the sibling runtime container. UI-only and workflow-only packages do not create runtime Pods.
 
 Each organization operates one deployment backed by a private registry and optional trusted registries. The deployment exposes catalogs of installed packages, callable operations, user interfaces, workflows, and dependencies.
 
-Publishing makes a release discoverable. Installation admits an immutable release into an organization. Canarying permits controlled, undiscoverable traffic. Promotion makes an installed revision primary, and convergence then makes its contracts user-discoverable. These milestones are separate and must not be inferred from one another.
+Publishing makes a release discoverable. Installation admits an immutable release into an organization. Canarying permits controlled, undiscoverable traffic. Routing and external registrations converge before promotion atomically makes an installed revision primary and exposes its catalog generations. These milestones are separate and must not be inferred from one another.
+
+This design is a full replacement for the existing Gestalt implementation. It does not preserve the existing provider runtime, package archive, registry, deployment, authorization, or workflow protocols, and it does not define an in-place migration. Feature names shared with the existing system do not imply wire-format or state compatibility.
 
 ## Foundations
 
@@ -40,7 +42,7 @@ The following invariants apply to every implementation:
 4. Durable revision requests record intent; revision controllers perform runtime work and resume safely after process failure.
 5. Registry publication, revision-operation phase, live workload health, routing promotion, and catalog convergence are tracked separately.
 6. A pre-promotion failure does not replace the last successfully promoted revision.
-7. Routing propagation is eventually consistent, so every revision that may receive traffic remains contract-compatible with operations referenced by installed reverse dependencies until propagation and draining finish. New contracts become visible only after routing convergence. A candidate may omit an operation when no installed package or retained workflow references it; stale or undeclared calls to that operation may fail after promotion.
+7. Routing propagation is eventually consistent, so every revision that may receive traffic remains contract-compatible with operations referenced by installed reverse dependencies until propagation and draining finish. New contracts become visible only after routing convergence. A candidate may omit an operation when no installed package or workflow definition or execution retained by policy references it; stale or undeclared calls to that operation may fail after promotion.
 8. Packages run only under organization-provisioned identities; release metadata may define access requirements but cannot grant authority.
 9. Ordinary packages cannot replace components needed to administer the platform. Identity, authorization, workflow execution, secret management, registry verification, and audit may be implemented only by protected system packages; certificates, state storage, revision control, and recovery remain part of the bootstrap substrate.
 10. Every externally supplied manifest, image, schema, and migration is untrusted until its digest, signature, and policy are verified.
@@ -51,7 +53,7 @@ The following invariants apply to every implementation:
 
 The system keeps these identities separate:
 
-- **Registry identity**: deployment-scoped immutable `registryId` plus its configured origin. The identifier distinguishes registries within one platform deployment; it is not a global registry namespace.
+- **Registry identity**: an immutable self-certifying `registryId` derived from the registry's offline root public key. The identifier is globally stable for that registry but does not imply endorsement by, or membership in, a central registry namespace. Signed registry descriptors authorize the current origin set and origin changes.
 - **Package identity**: permanent `(registryId, packageId)` assigned when the package is reserved. A slug is a mutable display and discovery alias, never a security identifier.
 - **Release identity**: `(registryId, packageId, releaseVersion, releaseDigest)`.
 - **Installation identity**: an organization-scoped UUID representing one installed package.
@@ -70,22 +72,22 @@ Release metadata cannot name workload identities or Kubernetes service accounts.
 
 ### Package Releases
 
-Each `(packageId, releaseVersion)` has one signed release manifest and may support one or more `os`, `architecture`, and optional `variant` tuples. Stored by digest, the manifest references an OCI image index covering those platforms.
+Each `(registryId, packageId, releaseVersion)` has one release manifest with detached signatures. A release with a runtime declares one or more OS, architecture, and optional variant tuples and references an OCI runtime image index covering them.
 
-Platform images may contain different binaries, but contracts, dependencies, migrations, workflow definitions, and operation access requirements are shared across all supported platforms.
+Runtime and migration images may contain platform-specific binaries, but contracts, dependencies, workflow definitions, user interfaces, and operation access requirements are shared across all supported platforms.
 
 The release manifest contains:
 
 - Canonical registry and package IDs, slug, and `releaseVersion`
-- OCI image-index digest and supported platforms
-- MCP server startup instructions and interface entry points
-- MCP endpoint, operations, and input/output schema digests
-- Included workflow definitions and user interfaces
+- Optional OCI runtime image-index digest, supported platforms, startup instructions, and probe contract
+- Zero or more digest-addressed migration image indexes with their supported platforms
+- Zero or more MCP operations with input and output schema digests
+- Zero or more digest-addressed workflow definitions and UI bundles
 - Required and optional package and operation dependencies
 - Ordered prepare, finalize, and compensating migration jobs
 - Required authorization relationships or roles for each operation
-- Startup, liveness, and readiness endpoints
-- Minimum and maximum supported package-supervisor and mesh protocol versions
+- Supported MCP protocol versions and private runtime control API versions
+- Minimum and maximum compatible package-supervisor versions
 - Optional source repository URL and source revision
 
 The registry stores signatures separately from the manifest. Each signature identifies the exact release or image digest it covers.
@@ -94,7 +96,25 @@ Source repository and revision are optional display metadata. Publication must s
 
 The `releaseDigest` is the hash of the canonical manifest bytes. Catalog entries, signatures, and installation records carry it; the manifest does not.
 
-`releaseVersion` follows a documented registry grammar and comparison order. `(registryId, packageId, releaseVersion)` binds permanently to one `releaseDigest`: conflicting republishes fail, while identical retries are idempotent and preserve publication time and metadata. Mutable tags may aid discovery but are never installation inputs.
+`releaseVersion` follows a documented registry grammar and comparison order. `(registryId, packageId, releaseVersion)` binds permanently to one `releaseDigest`: conflicting republications fail, while identical retries are idempotent and preserve publication time and metadata. Mutable tags may aid discovery but are never installation inputs.
+
+### Package Runtime Contract
+
+A release may contain an MCP runtime, static user interfaces, workflow definitions, or any combination of them. A release with no MCP runtime does not create a runtime Deployment. Protected system packages may additionally expose platform-owned typed APIs; those APIs are versioned platform protocols and are not part of the ordinary package operation catalog.
+
+Every MCP runtime image follows one platform runtime contract:
+
+- Kubernetes starts the runtime container through the manifest-declared executable and arguments. The image contains no embedded platform credential.
+- The supervisor and runtime mount one private in-memory volume. The runtime exposes MCP Streamable HTTP on `/run/gestalt/mcp.sock` and the typed runtime control API on `/run/gestalt/control.sock`; it never binds a mesh-reachable application port directly.
+- The supervisor owns the mesh-facing listener and relays MCP to the private MCP socket without changing JSON-RPC semantics. Configuration, readiness, cancellation, and graceful shutdown use the separate control socket.
+- Startup, liveness, and readiness probes are distinct. Readiness reports the loaded `releaseDigest`, operation-contract digest set, MCP version, and private runtime control API version.
+- The supervisor supplies configuration and secret references through the platform runtime API. Secret values are fetched under the installation workload identity and are never embedded in release metadata.
+- Graceful shutdown first rejects new sessions, then allows pinned requests and streams to drain until the revision deadline. The supervisor requests shutdown over the control API and fails its readiness gate; Kubernetes remains responsible for container termination.
+- The runtime accepts caller identity only through a verified supervisor context. Caller-supplied identity headers, credentials, and routing fields are discarded before dispatch.
+
+The private runtime control API is a versioned typed protocol covering configuration, readiness, stream cancellation, graceful shutdown, and observed runtime state. It does not carry MCP invocation payloads. Its compatibility range is recorded independently from the MCP protocol and package-supervisor version range. Ordinary packages cannot replace or extend this protocol.
+
+The OCI artifact specification defines canonical media types and paths for the release manifest, image indexes, UI bundles, workflow definitions, schemas, and migration images. Canonical manifest serialization, digest calculation, detached-signature envelopes, package reservation, and publication idempotency are normative parts of the registry protocol rather than implementation details.
 
 ### Registries
 
@@ -102,12 +122,14 @@ The registry protocol is open and has no central creation or approval authority.
 
 Registries control who can publish, discover, or download releases. Each configured registry has:
 
-- An immutable `registryId` that is unique within the platform deployment
+- The registry's immutable `registryId`, root public key, descriptor generation, and verified origin set
 - Discovery, metadata, blob, and publication endpoints
 - Optional read credentials for discovery and download from a private registry
 - A registry trust policy binding each trusted public-key fingerprint to a publisher identity and the package IDs that key may sign
 - Whether local clients may publish directly
 - A policy revision incremented when trust or local publication rules change
+
+The registry root key signs descriptors containing the `registryId`, protocol version, authorized origin set, operational signing keys, and descriptor generation. Deployments verify that the identifier matches the root key and accept origin additions, removals, mirrors, and disaster-recovery endpoints only through a newer valid descriptor. The offline root key does not sign package releases; publisher and operational keys rotate independently.
 
 The registry's publisher policy controls which releases it accepts. Each connected organization's registry trust policy independently controls which of those releases the organization will admit and may be more restrictive. Registry connection credentials, when present, are read-only and are stored by the secret-management service. Publishers authenticate to the registry with their own user or CI credentials, which the platform does not retain. Artifact verification uses the registry trust policy and public trust material, not registry credentials.
 
@@ -117,11 +139,11 @@ The registry provides distinct APIs for paginated discovery, reading immutable m
 
 A registry catalog contains paginated package and release summaries that reference authoritative manifest digests, without duplicating release contracts. Per-package indexes use monotonic revisions and compare-and-swap updates.
 
-Disconnecting a registry blocks discovery and installation but preserves its identity and history. Hard removal fails while any desired, running, redeployable, dependent, or in-progress revision references it. A replacement is a new registry; package identities do not carry over.
+Disconnecting a registry blocks discovery and installation but preserves its identity and history. Hard removal fails while any desired, running, dependent, or in-progress revision references it, or while its artifacts remain eligible for rollback or disaster recovery under retention policy. A replacement is a new registry; package identities do not carry over.
 
 ### Build and Publish
 
-`vt build <dir>` validates package metadata and builds an OCI image index and release manifest locally. Adding `--push` publishes the result to the selected registry:
+`vt build <dir>` validates package metadata and builds the applicable digest-addressed runtime, migration, UI, workflow, and schema artifacts, zero or more OCI image indexes, and one release manifest locally. Adding `--push` publishes the result to the selected registry:
 
 ```sh
 vt build <dir> --push
@@ -133,8 +155,8 @@ Publication is a recoverable transaction:
 
 1. Reserve `(packageId, releaseVersion)` and create a publish-attempt ID.
 2. Record a pending release with any optional source metadata.
-3. Upload content-addressed image blobs and manifests.
-4. Validate all platform images and release contracts server-side.
+3. Upload all applicable content-addressed blobs, image indexes, and manifests.
+4. Validate all referenced artifacts and release contracts server-side.
 5. Store the immutable release manifest.
 6. Attach signatures.
 7. After all artifacts are stored, atomically add the release to the package catalog. Retry if another publisher changed the catalog first.
@@ -153,7 +175,7 @@ The control plane persists:
 - **Installation head**: last successfully promoted revision and current admitted candidate
 - **Revision operation**: one generation-fenced state machine per installation, including phase, candidate Kubernetes resources, deadlines, stability timestamp, and routing generation
 - **Migration outcomes**: immutable status keyed by installation, `releaseDigest`, and migration ID
-- **Routing and catalog generation**: the promoted revision visible to callers
+- **Routing and catalog generations**: independent operation-routing, package, operation, UI, and workflow generations committed for the promoted revision
 - **Terminal outcomes**: completion or failure phase, duration, and reason
 
 The revision-operation phase is the canonical lifecycle state. Image availability, process status, replica health, routing synchronization, and catalog generation are observations attached to that operation, not additional lifecycle states.
@@ -162,11 +184,11 @@ The revision-operation phase is the canonical lifecycle state. Image availabilit
 
 Publishing does not install a package. An authorized installer selects an immutable `releaseDigest` and binds:
 
-- An organization-managed Kubernetes service account for the installation's workload identity
+- An organization-managed Kubernetes service account when the release has a runtime or migration
 - Organization-managed workflow identities
 - Package-declared authorization relationships or roles for each operation
 - Caller-delegation policy per operation
-- Initial replica, resource, and availability settings
+- Initial replica, resource, and availability settings when the release has a runtime
 
 Before admission, the platform shows package-declared operation access requirements and resulting authorization bindings. The installer — an organization administrator or package administrator with install authority — needs `service_account.assign` for each selected identity and `authorization.grant` for each relationship or role being granted.
 
@@ -175,7 +197,7 @@ Installation is a reconciled saga:
 1. Verify the registry identity and trust policy, release and image signatures, platform support, runtime compatibility, and schema versions.
 2. Resolve exact dependency revisions and operation-contract digests.
 3. Reserve the organization package slot and persist the revision request, approved authorization snapshot, and fenced revision operation.
-4. Provision the installation, workload, and migration identities, authorization relationships, ambient data-plane enrollment, and required `AuthorizationPolicy` attachments.
+4. Provision the installation and any required runtime, migration, and workflow identities, authorization relationships, ambient data-plane enrollment, and `AuthorizationPolicy` attachments.
 5. Hand the fenced operation to the revision controller, which follows the canonical phases in [Revision Rollouts](#revision-rollouts).
 
 Failures preserve phase and diagnostics. The revision controller retries within policy and cleans up resources created for an unpromoted revision when an administrator cancels. Promotion, catalog exposure, and canary behavior follow the rules in Revision Rollouts.
@@ -195,19 +217,31 @@ The platform validates:
 
 All schemas use the same JSON Schema version and are normalized before hashing. Initially, schemas are compatible only when their hashes match.
 
-Declared dependencies and workflow references are the authoritative compatibility boundary for operation removal. A candidate may remove an operation when no installed package or retained workflow references it, including after accounting for other revisions in the same atomic rollout plan. External callers do not create an implicit dependency: callers using stale catalogs, cached operation names, or otherwise undeclared contracts may receive an operation-unavailable error after promotion.
+Declared dependencies and workflow references are the authoritative compatibility boundary for operation removal. A candidate may remove an operation when no installed package or workflow definition or execution retained by policy references it, including after accounting for other revisions in the same atomic rollout group. External callers do not create an implicit dependency: callers using stale catalogs, cached operation names, or otherwise undeclared contracts may receive an operation-unavailable error after promotion.
 
-Validation reads a revisioned desired-state snapshot and commits with generation preconditions. Independent packages may upgrade concurrently. Upgrades affecting the same dependency subgraph use deterministic locking or one atomic multi-package rollout plan. Cyclic dependencies may be upgraded sequentially when every intermediate state is compatible. Mutually dependent changes require an atomic rollout group.
+Validation reads a revisioned desired-state snapshot and commits with generation preconditions. Independent packages may upgrade concurrently. Upgrades affecting the same dependency subgraph use deterministic locking or one atomic rollout group. Cyclic dependencies may be upgraded sequentially when every intermediate state is compatible. Mutually dependent changes require an atomic rollout group.
+
+An atomic rollout group is one durable request containing candidates for multiple package slots, one desired-state snapshot, and one lock order. Admission validates compatibility across the complete before-and-after graph. Controllers may prepare, start, and canary members independently. All members' routing intents and external registration prerequisites converge first; promoted heads and package, operation, UI, and workflow catalog generations then commit in one generation-fenced state-store transaction. A pre-commit failure restores routing for every member and advances none of their promoted heads.
 
 ### Revision Rollouts
 
-Upgrades use a Kubernetes-native blue/green rollout with optional Istio canary traffic. Each upgrade creates a candidate revision in a distinct immutable Kubernetes Deployment behind a revision-specific Service. The promoted and candidate Deployments may run together, so the serving Deployment is never restarted or mutated in place.
+Releases with an MCP runtime use a Kubernetes-native blue/green rollout with optional Istio canary traffic. Each runtime upgrade creates a candidate revision in a distinct immutable Kubernetes Deployment behind a revision-specific Service. The promoted and candidate Deployments may run together, so the serving Deployment is never restarted or mutated in place. Runtime-less releases use the same durable revision state machine without creating runtime Deployments or Services.
 
 Revision records use optimistic concurrency and fencing tokens, preventing a controller that loses its lease from mutating a newer generation. Retries are idempotent; every external mutation has a stable idempotency key. For example, controller A may start an upgrade at generation 4, create the candidate Deployment, and then lose its lease. Controller B takes over at generation 5. Any later update from controller A is rejected, while controller B can safely retry the Deployment request without creating a duplicate.
 
-Kubernetes and the package supervisor are the source of truth for live workload health. A candidate is ready only when Kubernetes has observed the Deployment generation, its required replicas are available, and package-supervisor readiness confirms the target `releaseDigest` for a stability window. Replacement pods and autoscaled replicas count by current readiness, not persistent identity.
+For runtime releases, Kubernetes and the package supervisor are the source of truth for live workload health. A runtime candidate is ready only when Kubernetes has observed the Deployment generation, its required replicas are available, and package-supervisor readiness confirms the target `releaseDigest` for a stability window. Replacement pods and autoscaled replicas count by current readiness, not persistent identity.
 
-Istio routes traffic between revision-specific Services. Promotion converges when every currently live relevant ingress gateway and destination waypoint reports the target xDS generation and their Kubernetes Deployments remain available for a stability window. If the set of live routing proxies changes, the stability window resets. Packages may call other packages only through declared dependencies and mesh-managed routes. Direct or undeclared package-to-package calls are blocked.
+Before any candidate becomes promotable, the interface service must verify and stage every UI bundle, and the workflow service must register every workflow definition as candidate-only and acknowledge its digest. These records remain unreachable from user catalogs. A release with no runtime reaches Ready from artifact verification and the required UI and workflow acknowledgements; Starting, Canarying, runtime routing, Draining, and runtime observation are skipped when they do not apply.
+
+Each installation with an MCP runtime has one stable frontend Service and revision-specific backend Services. Gateway API `HTTPRoute` resources select weighted revision backends; callers never address a revision Service directly. Packages may call other packages only through declared dependencies and these mesh-managed routes. Direct or undeclared package-to-package calls are blocked.
+
+The controller assigns each routing change a durable `routingGeneration` and records the exact Kubernetes resource UIDs, generations, and desired route hashes that implement it. Infrastructure installs a protected routing-status extension in every ingress gateway and waypoint; the extension exposes, over an mTLS-protected administration endpoint, the routing generations and route hashes currently loaded by that proxy. This extension and endpoint are versioned with the pinned Istio/Envoy build and covered by infrastructure conformance tests.
+
+The relevant proxy set is a persisted membership snapshot of available ingress-gateway and destination-waypoint replicas selected for those resources. Convergence requires accepted and resolved Gateway API status, ready route backends, every member's routing-status report matching the desired hashes, and authenticated synthetic probes observing the target generation through each proxy class. The controller does not infer application convergence from one global Istio xDS version. Proxy replacement, loss of availability, or membership change resets the stability window. A bounded timeout fails the phase and leaves enough recorded evidence for deterministic retry or restoration.
+
+Gateway and waypoint readiness is gated on the routing-status extension reporting either the current committed generation or an active generation-fenced rollout generation authorized for that proxy and route. During promotion, the proxy may remain ready on the fenced candidate generation while convergence is observed. Immediately after the promotion commit, only the newly committed generation satisfies readiness. A new or restarted proxy cannot enter Service endpoints or load-balancer membership until it has loaded and reported the then-current committed generation, so proxy churn after promotion cannot reintroduce stale routing.
+
+Promotion has one commit point. For runtime releases, the controller first writes primary routing intent while the previous revision remains the persisted promoted head. After routing converges and all UI-serving and workflow-registration acknowledgements remain valid for the stability window, one state-store transaction updates the promoted revision and the relevant routing, package, operation, UI, and workflow generations. Only that transaction constitutes successful promotion. If a prerequisite fails before the transaction, the controller restores previous routing and external registrations and confirms their convergence; it does not advance the promoted head or any catalog generation.
 
 The control plane persists rollout intent and decisions, then reconstructs progress from Kubernetes, the package supervisor, and Istio after restart. Historical rollout outcomes remain immutable; current workload health is a separate live view.
 
@@ -215,16 +249,16 @@ The canonical revision-operation phases are:
 
 1. **Admitted**: verify the release, policy, runtime compatibility, dependencies, and reverse dependents.
 2. **Preparing**: run backward-compatible prepare migrations as fenced one-shot jobs.
-3. **Starting**: create the revision-specific Deployment and Service with no production traffic.
-4. **Ready**: require Kubernetes availability and package-supervisor readiness for the configured stability window.
+3. **Starting**: create any revision-specific runtime resources and stage candidate-only UI bundles and workflow definitions.
+4. **Ready**: require all applicable runtime, UI-serving, and workflow-registration checks for the configured stability window.
 5. **Canarying**: route a configurable small traffic percentage for operations whose contracts exactly match the promoted revision; the candidate remains absent from user-facing catalogs.
-6. **Promoting**: route primary traffic to the candidate, wait for live relevant proxies to remain synced to the routing generation, and then expose newly added contracts in callable catalogs. Promotion makes the candidate the last successfully promoted revision.
+6. **Promoting**: converge applicable routing and external registrations, then atomically commit the promoted head and relevant package, operation, UI, workflow, and routing generations.
 7. **Draining**: keep the prior revision available for in-flight requests and streams until their drain deadline.
 8. **Observing**: monitor the promoted revision under production traffic for a configured period.
 9. **Finalizing**: run explicitly approved irreversible finalize migrations when required.
 10. **Complete**: record convergence and terminal timing.
 
-Canarying and Finalizing may be skipped when they do not apply. A failure or cancellation records a terminal outcome against the phase where the operation stopped rather than introducing another progression phase.
+Starting runtime resources, Canarying, runtime routing, Draining, runtime observation, and Finalizing are skipped when they do not apply. A failure or cancellation records a terminal outcome against the phase where the operation stopped rather than introducing another progression phase.
 
 Each phase has a timeout, retry policy, and terminal error taxonomy. Readiness requires the configured replica capacity, not a single ready pod. During routing propagation and draining, revisions follow the compatibility and operation-removal rules in [Dependencies and Contracts](#dependencies-and-contracts). Existing MCP SSE streams remain pinned to their original revision while the old revision drains, including streams for an operation omitted by the candidate.
 
@@ -250,9 +284,9 @@ The first version does not classify rollback safety in release metadata or initi
 
 Removal is a durable tombstoned revision, not deletion of a catalog row:
 
-1. Reject removal while required reverse dependents exist, unless they are removed in the same atomic plan.
-2. Promote a tombstone generation that removes callable catalog entries and prevents new invocation resolution.
-3. Drain resolved requests and streams, stop new workflow executions, and handle queued or running executions according to policy.
+1. Reject removal while required reverse dependents exist, unless they are removed in the same atomic rollout group.
+2. In one fenced transition, promote tombstones for the package, operation, UI, and workflow generations, disable interface launch routes, unregister promoted workflow definitions, stop new workflow executions, and prevent new invocation resolution.
+3. Drain resolved requests and streams and handle queued or running workflow executions according to their recorded retirement policy.
 4. Stop the removed package's runtime workloads, scale them to zero, and block any stale ingress or package-initiated egress.
 5. Revoke workload authorization bindings, installation-owned assignments, and delegated tokens.
 6. Apply package data retention or destruction policy.
@@ -314,6 +348,22 @@ The workflow service runs each execution against its pinned definition until com
 
 Every workflow operation is authorized at execution. Selecting an organization-managed service account as a workflow identity requires `service_account.assign`. The triggering actor remains in the audit and delegation chain.
 
+Each workflow definition has a package-stable ID and immutable definition digest. Its release metadata declares input and output schemas, operation-contract references, retry and timeout policy, supported signals, timer behavior, and whether concurrent executions are allowed. Definition IDs cannot be reassigned to unrelated workflows.
+
+Running executions remain pinned to their definition and operation-contract digests. A replacement definition does not mutate them. Before an incompatible upgrade or removal, admission requires one explicit policy for every affected execution class: allow pinned executions to finish, stop starting new executions and retire after a deadline, or run a declared migration that produces a new execution record. Forced termination is a separately authorized and audited action. Signals, timers, retries, and queued steps follow the pinned definition until the selected policy completes.
+
+`runAs` means explicit delegation from the triggering actor to the selected workflow identity. It never substitutes an unverified subject. The authorization service validates the delegation at execution start, and every step separately checks the workflow identity, effective subject, target operation, and current credential upper bound.
+
+### User Interfaces
+
+UI bundles are immutable content-addressed artifacts referenced by the release manifest. Each interface declares a package-stable interface ID, entry document, asset root, visibility, CSP profile, and an operation allowlist. Bundles are static and cannot contain server-side executable code.
+
+The platform assigns each installation interface a stable non-executable launch origin and a distinct executable origin for every promoted UI generation beneath a deployment-controlled wildcard application domain. The launch origin only redirects to the currently promoted generation and serves no package-controlled document or script. Package generations never share an executable origin, cookies, service workers, browser storage, or CSP authority with deployment administration, protected services, another interface, or an older generation.
+
+Private interfaces use an origin-scoped session established through the normal external identity flow. The interface service issues a short-lived browser capability only when the request originates from the currently promoted generation's verified entry document. The capability names the installation, interface ID, UI generation, allowed operations, and exact generation-specific origin. Ingress validates that capability and the `Origin` header in addition to normal subject authorization; it rejects stale generations and browser calls outside the declared allowlist. A public interface must be explicitly allowed by organization policy, and public asset access does not make its operations public. Browser code never receives workload credentials or raw internal invocation tokens.
+
+The platform applies the declared CSP profile, strict CORS, MIME validation, integrity metadata, response-size limits, immutable caching for revision-qualified assets, and service-worker scope restrictions. Interfaces requiring embedding use opaque sandboxed frames and explicit `postMessage` schemas; embedding does not grant same-origin access.
+
 ### Catalogs and Administration
 
 An organization deployment provides:
@@ -327,7 +377,7 @@ An organization deployment provides:
 - API grant management
 - A development sandbox
 
-Administrative catalogs may expose candidate metadata. Callable catalogs are keyed to the converged routing generation and expose new contracts only after the promotion and synchronization requirements in [Revision Rollouts](#revision-rollouts) are satisfied.
+Administrative catalogs may expose candidate metadata. User-facing package, operation, UI, and workflow catalogs expose only their atomically promoted generations. New operation contracts appear only after applicable routing, UI-serving, and workflow-registration prerequisites in [Revision Rollouts](#revision-rollouts) have converged.
 
 Clients treat catalogs as snapshots. Invocation remains authoritative and may reject stale or undeclared operations under the rules in [Dependencies and Contracts](#dependencies-and-contracts).
 
@@ -354,23 +404,41 @@ Authentication comes from an interactive session, keychain, environment, or stan
 
 Invocation uses MCP Streamable HTTP: JSON-RPC over POST with JSON or SSE responses. The gateway enforces request size, timeout, rate, and stream lifetime.
 
-Ingress strips externally supplied internal-identity headers and exchanges user credentials for a short-lived, signed internal invocation token. The token is bound to its issuer, audience, target package, and operation and carries a unique ID, issuance, not-before, and expiry times, the original actor, effective subject, immediate caller workload identity, delegation chain, and trace ID. Signing keys rotate with an overlap window for in-flight requests. Packages never receive or forward raw user bearer tokens or API keys.
+Ingress strips externally supplied internal-identity headers and exchanges user credentials for a short-lived, signed internal invocation token. The token is bound to its issuer, audience, target installation, request class, operation when applicable, and request-envelope hash and carries a unique ID, issuance, not-before, and expiry times, the original actor, effective subject, immediate caller workload identity, delegation chain, and trace ID. Signing keys rotate with an overlap window for in-flight requests. Packages never receive or forward raw user bearer tokens or API keys.
+
+The deployment exposes package-scoped MCP endpoints rather than one endpoint that multiplexes package names from JSON-RPC bodies. A trusted MCP request decoder at ingress validates the JSON-RPC envelope, resolves the canonical operation ID from the MCP method and parameters, rejects ambiguous or batch requests that target more than one authorization scope, and writes immutable dynamic metadata for authorization and routing. External clients cannot supply that metadata. The decoder binds a hash of the authorized request envelope into the internal invocation token so a downstream component cannot change the target operation after authorization.
+
+MCP methods map to authorization and routing as follows:
+
+- `initialize`, `ping`, and session negotiation require the installation-level `package.connect` action and do not select an operation.
+- Catalog and discovery methods require their catalog-read action and return only entries authorized for the effective subject.
+- Operation calls such as `tools/call` resolve the package-stable operation ID from validated parameters and require that operation's action and resource checks.
+- Cancellation, progress, and other session notifications must reference an existing authorized session and inherit its installation, revision, actor, and effective subject. They cannot change authorization scope.
+- Unsupported methods fail closed. A JSON-RPC batch is accepted only when every item has the same target installation, request class, operation, authorization scope, session, and routing target and each item is authorized independently; otherwise the complete batch is rejected.
+
+The destination waypoint uses the package endpoint and verified token claims for routing and `ext_authz`; it does not trust a caller-supplied operation header. The supervisor verifies the token, request-envelope hash, target installation, request class, operation when applicable, and selected revision before dispatch. Malformed JSON-RPC, unsupported MCP methods, unknown operations, mismatched hashes, and expired tokens fail before reaching the runtime.
+
+After weighted routing selects a revision Service, a protected waypoint extension creates a short-lived signed dispatch receipt bound to the invocation-token ID, installation ID, revision ID, `releaseDigest`, routing generation, and request-envelope hash. Waypoint receipt-signing certificates are issued and rotated by the identity service for the waypoint workload identity. The supervisor verifies this receipt and confirms that its loaded digest matches it; packages never receive the receipt. Session continuation receipts must name the revision already pinned by the session.
+
+MCP session IDs are client-opaque signed routing tokens issued by the supervisor under an identity-service-certified workload signing key. They contain the installation, revision, `releaseDigest`, routing generation, issued and expiry times, and random nonce. Before backend selection, the waypoint verifies the token and routes subsequent requests to its named revision Service. Cancellation is forwarded to that revision, and reconnect succeeds only while the token is valid and the revision remains inside its drain deadline. SSE streams send platform heartbeats, have a configured maximum lifetime, and remain pinned until completion, cancellation, or that deadline.
 
 Authorization is enforced at two surfaces:
 
 - **Ingress gateway**: user invocation, catalogs, package administration, and package revision APIs. The gateway's `ext_authz` filter calls the authorization service before forwarding to control-plane or package services.
-- **Destination waypoint**: package-to-package MCP calls are checked before forwarding to the MCP server. Waypoint enforcement is described in [Runtime Architecture](#runtime-architecture).
+- **Destination waypoint**: every MCP call is checked before revision routing. For external calls, the waypoint revalidates the ingress-issued token and authorized request metadata; for package calls, it performs the corresponding workload and effective-subject authorization check. Waypoint enforcement is described in [Runtime Architecture](#runtime-architecture).
 
-Both surfaces use one authorization service and relationship graph. Checks use the immediate caller workload identity, effective subject, target package, and operation for MCP traffic; management checks use the actor and requested revision or administration action.
+Both surfaces use one authorization service and relationship graph. MCP checks always use the effective subject, target installation, and request-class action. Package-originated calls additionally use the immediate caller workload identity. Operation calls additionally use the canonical operation ID; connection, catalog, session, and notification classes use the actions defined in the MCP method mapping and do not invent an operation. Management checks use the actor and requested revision or administration action.
 
-For MCP invocation, the authorization decision intersects:
+For an MCP operation call, the authorization decision intersects:
 
-- The authenticated caller workload identity's permission to invoke the target
+- The caller workload identity's permission to invoke the target when the call originated from a package
 - The effective subject's permission
 - The installed package's approved operation access policy
 - Any operation-specific resource authorization
 
-Credential scope and every applicable relationship check must allow the request. The decision records the policy model ID and revision. Unknown identities, packages, operations, policies, or authorization-provider outages deny access.
+Credential scope and every relationship check applicable to the request class must allow the request. The decision records the policy model ID and revision. Missing or unknown identities, installations, request classes, required operations, policies, or authorization-provider outages deny access.
+
+For package-to-package calls, the caller asks the identity service to mint an internal invocation token over its authenticated workload channel. The request names one declared dependency, operation, effective subject, and request-envelope hash. The identity service verifies the caller's workload identity and delegation chain, while the authorization service evaluates the call before a token is issued. Tokens are single-target, short-lived, non-refreshable by the package, and cannot broaden the caller's credential or delegated authority. Package SDKs perform this exchange and send the resulting token to the destination Service.
 
 ### Development Sandbox
 
@@ -391,6 +459,8 @@ Development packages:
 - Use sandbox-scoped authorization
 - Expire automatically and are audited on connect and disconnect
 
+The first implementation has one production deployment profile: Kubernetes with Istio ambient mode and the protected platform services described below. `vt build` may run locally, but there is no standalone laptop, VM, no-auth, or non-mesh production runtime. The development sandbox is a capability of a connected deployment rather than a second local control plane.
+
 ## Platform Architecture
 
 ### Deployment Tiers
@@ -402,6 +472,17 @@ The platform separates deployment into three trust and lifecycle tiers:
 3. **Ordinary organization packages**: packages installed by authorized organization or package administrators and constrained by organization policy.
 
 Protected system packages have fixed canonical identities, trusted-signer allowlists, dedicated platform workload identities, protected names and routes, and platform-only revision permissions. They cannot grant themselves authority, be replaced by an ordinary package, or be removed through ordinary package APIs. Infrastructure configuration pins the initial system-package releases and bootstrap order; after identity and authorization are available, subsequent changes require normal platform authorization.
+
+Initial bootstrap uses a deliberately narrower trust path than ordinary admission:
+
+1. Terraform provisions the state store, revision controllers, an append-only audit spool, secret bootstrap backend, certificate authority, and an offline-pinned bundle containing the initial protected-package manifests, digests, signer keys, platform identities, and network policy.
+2. A bootstrap controller verifies that bundle without registry, identity, authorization, secret-service, or audit-service APIs. It creates the initial secret, audit, identity, and authorization workloads directly from digest-pinned images rather than through ordinary package admission.
+3. Initial workloads use prebound Kubernetes service accounts and static namespace, mTLS, and `NetworkPolicy` allowlists from the signed bundle. Bootstrap secrets are mounted from the substrate backend. Security events are synchronously appended to the substrate audit spool until the audit package durably imports them.
+4. Terraform supplies the initial human administrator identities and organization root grants as signed bootstrap records. The authorization service imports each record once and rejects replay. Identity, authorization, secrets, and audit then prove their typed APIs, policy attachments, secret access, and durable audit delivery through bootstrap conformance checks.
+5. Using those now-normal services, the bootstrap controller directly creates the digest-pinned registry-verification workload, which verifies its own pinned manifest and signer before adoption. The revision controller then installs workflow execution through ordinary protected-package admission. It adopts every directly created workload into immutable revision records only after its manifest, identity, policy, secrets, and audit history pass the same checks.
+6. The controller writes an irreversible bootstrap-complete marker and removes bootstrap-only API access, secret mounts, static allowlists, and controller permissions. From that point, bootstrap records and offline bundles cannot authorize upgrades; every protected-package change uses normal signed releases, revision control, and platform authorization.
+
+Loss of identity or authorization does not reopen bootstrap mode. Recovery uses separately documented state-store restore and break-glass procedures with offline quorum approval and immutable audit records.
 
 The bootstrap substrate and protected system packages are both inside the platform availability boundary. If a required component in either tier is unavailable, the affected capability is counted as platform downtime even when some existing package traffic continues. For example, a registry-verification outage is publishing and installation downtime, while an identity or authorization outage may prevent new requests without immediately terminating established connections. An ordinary package failure counts as downtime for that package, not for the platform, unless a platform defect caused or spread the failure.
 
@@ -423,7 +504,7 @@ Each trusted service exposes a versioned typed API. Control-plane clients use sh
 
 ### Runtime Architecture
 
-Production uses Istio ambient mode. `ztunnel` provides L4 transport security and workload identity, while waypoint proxies provide L7 routing and authorization. Sidecars are not planned for the first implementation.
+Production uses Istio ambient mode. `ztunnel` provides L4 transport security and workload identity, while waypoint proxies provide L7 routing and authorization. Istio data-plane sidecars are not planned for the first implementation; the package supervisor remains an application sidecar.
 
 The runtime consists of:
 
@@ -432,23 +513,41 @@ The runtime consists of:
 - **Waypoint proxies**: shared Envoy proxies providing L7 routing, telemetry, and authorization for destination Kubernetes Services.
 - **Ingress gateways**: terminate external transport, remove untrusted identity headers, authenticate credentials, enforce `ext_authz`, and route public and organization traffic.
 - **Egress gateways**: enforce and audit organization-declared external access that cannot safely use direct egress.
-- **Package supervisor (`gestaltd`)**: runs beside an installation, manages its process lifecycle and local invocation, and reports observed state. It is not an Istio proxy.
-- **Package runtime**: runs the package's MCP server and serves its interfaces.
+- **Package supervisor (`gestaltd`)**: one platform-owned sidecar container in each runtime Pod that gates runtime readiness and shutdown through the control API, exposes the mesh-facing MCP listener, verifies invocation context, and reports observed state. It is not an Istio proxy.
+- **Package runtime**: an unprivileged container that implements the private side of the package runtime contract. Static interfaces are served by a protected platform service, not by this container.
 - **Protected system packages**: provide identity, authorization, secrets, registry verification, audit, and workflow execution as defined above.
 - **Control-plane state store**: provides durable state for trusted services and revision controllers as part of the bootstrap substrate.
 - **Revision controllers**: reconcile durable revision requests and rollout state into workloads, routing, catalogs, identities, and policy.
 
-Revision controllers use trusted-service APIs and the Kubernetes API to create or update Deployments, Services, waypoint enrollment, routes, traffic weights, and `AuthorizationPolicy` resources. `istiod` watches the Kubernetes and Istio resources, translates the desired state into xDS configuration, and distributes it to ingress gateways, waypoints, and `ztunnel`. Proxies acknowledge the configuration they receive; revision controllers observe synchronization for the target routing generation before advancing callable catalogs.
+Revision controllers use trusted-service APIs and the Kubernetes API to create or update Deployments, stable frontend and revision Services, waypoint enrollment, Gateway API routes, traffic weights, and `AuthorizationPolicy` resources. `istiod` watches the Kubernetes and Istio resources, translates the desired state into xDS configuration, and distributes it to ingress gateways, waypoints, and `ztunnel`. The protected routing-status extension reports loaded route hashes and routing generations; revision controllers require those reports and active probes before advancing promoted catalog generations.
 
 Istio keeps workload endpoints, routing, certificates, and mesh-policy configuration synchronized. It does not own or synchronize package revision state, authorization grants, workflow executions, or catalogs. Those remain the responsibility of revision controllers and trusted platform services. Package operation invocations remain on the mesh data plane and use ingress or destination-waypoint authorization.
 
-`ztunnel` cannot enforce L7 authorization. MCP, revision, and administration checks therefore run at ingress gateways or destination waypoints. Kubernetes Services exposing MCP servers enroll in a waypoint, where revision controllers attach `AuthorizationPolicy` `CUSTOM` rules.
+`ztunnel` cannot enforce L7 authorization. MCP, revision, and administration checks therefore run at ingress gateways or destination waypoints. Every stable package Service is explicitly enrolled in a destination waypoint. Ingress-to-Service traffic is configured to traverse that waypoint, and `AuthorizationPolicy` `CUSTOM` rules use `targetRefs` for the enrolled Service or Gateway. Admission fails if the required waypoint, enrollment, extension provider, route, or policy attachment is absent or not accepted.
+
+The ingress request decoder, external authenticator, internal-token exchange, and authorization adapter are protected extensions pinned by infrastructure configuration. The decoder executes before `ext_authz`. Ingress removes all external copies of their reserved headers and dynamic metadata before decoding. Only decoded metadata and signed token claims may select an operation or revision.
+
+After token verification, the waypoint derives a trusted operation routing key from the signed claim. Gateway API header matches may use only that platform-generated key to select operation-specific canary weights; no route matches a client-supplied operation header. Route configuration remains declarative and digest-correlated with the operation contracts admitted for both revisions.
 
 Production uses `ztunnel` for transport security and L4 workload authorization, Kubernetes `NetworkPolicy` for reachability, and ingress or waypoint `ext_authz` for application authorization. Authorization checks fail closed on denial or outage. Only the mesh data plane can reach package application ports; health and supervisor administration ports have minimal explicit exceptions and no public ingress.
 
 If `istiod` is unavailable, established traffic uses its last configuration. New revision operations requiring routing or policy changes fail closed until dependencies recover.
 
 Terraform manages the bootstrap substrate, including clusters, networking, container infrastructure, state storage, revision controllers, certificate authority, and recovery tooling. Package installation does not mutate this substrate.
+
+### Production Operational Baseline
+
+Production uses a regional Kubernetes cluster dedicated to the platform rather than assuming an unrelated existing cluster. Infrastructure configuration pins supported Kubernetes, Gateway API, Istio, CNI, `ztunnel`, gateway, and waypoint versions. Upgrades use documented skew ranges, staged control-plane and data-plane rollout, conformance tests, and rollback criteria.
+
+Terraform defines regional node placement, autoscaling bounds, resource quotas, default requests and limits, Pod disruption budgets, topology-spread constraints, priority classes, and capacity reserved for protected services. Protected services and routing proxies remain available during one-zone loss and planned node disruption. Revision admission fails when required capacity cannot be reserved.
+
+Network infrastructure preserves deployment-owned ingress addresses, TLS certificate and DNS validation, outbound NAT addresses, private DNS, private-service routes, and OAuth callback origins. Default-deny `NetworkPolicy` and ambient enrollment apply to every package namespace. External destinations use an audited organization egress policy; an egress gateway is required when source-IP stability, protocol inspection, or centralized policy cannot be provided safely by direct egress.
+
+The state store and trusted-service state have encrypted regional replication, point-in-time recovery, versioned backup formats, restore verification, and declared RPO and RTO. Disaster-recovery tests cover state restoration, certificate and signing-key recovery, route reconstruction, protected-package bootstrap recovery without reopening bootstrap authorization, and reconciliation of Kubernetes resources from durable state.
+
+Security audit storage uses retention-locked, package-inaccessible storage with independently managed encryption and deletion authority. Delivery has bounded buffering, loss and lag alerts, schema versions, and trace correlation. An audit outage fails closed for security-sensitive mutations when the event cannot be durably buffered.
+
+Operational documentation defines DNS and gateway rollback, expired-certificate recovery, authorization and identity outages, stuck routing convergence, state-store restore, cluster loss, signer compromise, and quorum-controlled break-glass access. Break-glass credentials are offline, time-bounded, scope-limited, and always produce independently retained audit evidence.
 
 ### Infrastructure and Service Rollouts
 
@@ -461,7 +560,7 @@ The mesh is redeployed only for changes to Istio or its trust and extension conf
 
 Protected system packages roll independently through the revision controller and do not require a mesh redeployment. Ordinary package revisions, registry connection changes, identity assignments, and authorization-binding updates likewise change runtime or control-plane state without redeploying the mesh. `gestaltd` supervisor updates roll with the workloads that use them.
 
-Bootstrap-substrate changes, including control-plane state migrations and backup or recovery tooling, use infrastructure rollouts but do not redeploy the mesh unless they also change an Istio item listed above. Package releases declare compatible `gestaltd` and mesh protocol ranges, and infrastructure rollouts account for overlapping old and new versions before admitting releases that require new features. Registry trust-root changes remain separately authorized and audited.
+Bootstrap-substrate changes, including control-plane state migrations and backup or recovery tooling, use infrastructure rollouts but do not redeploy the mesh unless they also change an Istio item listed above. Package releases independently declare supported MCP versions, private runtime control API versions, and compatible `gestaltd` supervisor versions. Infrastructure pins Kubernetes, Istio, Envoy, routing-status extension, and dispatch-receipt protocol versions and accounts for overlapping old and new versions before admitting releases that require new features. Registry trust-root changes remain separately authorized and audited.
 
 ## Representative Request Lifecycles
 
@@ -472,7 +571,7 @@ The following lifecycles show how representative registry, management, and data-
 Registry creation is a registry-side operation and is distinct from connecting that registry to an organization. The reference registry-creation service and CLI are convenience tools, not gatekeepers; operators may instead use the underlying libraries or build any compatible implementation.
 
 1. A registry operator uses the reference tooling or an independent implementation to provision a protocol-compatible registry and durable metadata store. The registry uses OCI 1.1 storage—Google Artifact Registry by default—for content-addressed images, manifests, and signature bundles.
-2. The registry generates one immutable `registryId`. The identifier scopes package and release identities and must be unique among registries connected to the same platform deployment.
+2. The registry generates an offline root key and derives its immutable `registryId` from that public key. The identifier remains stable wherever the registry is connected.
 3. The operator configures discovery and download visibility, publisher authentication, who may create packages, and who may publish versions to each package. The reference tooling may also configure optional GitHub listeners or other publication triggers.
 4. The operator configures the registry's publisher policy by registering publisher identities, their public keys, and the package IDs each key may sign. The reference tooling may provision KMS-backed signing keys, but private keys remain publisher-controlled and are never stored by the registry.
 5. The registry publishes a descriptor matching the required schema, including its protocol version, `registryId`, API endpoints, and supported signature formats, through its well-known metadata endpoint.
@@ -483,17 +582,17 @@ Registry creation is a registry-side operation and is distinct from connecting t
 1. An organization administrator submits the registry's HTTPS origin, optional read credentials for a private registry, and a registry trust policy binding trusted publisher identities and public keys to package IDs.
 2. The ingress gateway authenticates the actor, removes untrusted identity headers, and calls the authorization service through `ext_authz`. The request proceeds only when the actor has the required registry-management permission.
 3. The registry-verification service connects through the permitted egress path and reads the registry's protocol version, immutable `registryId`, API endpoints, catalog, and signature bundles. Remote content remains untrusted.
-4. The control plane rejects a `registryId` already bound to a different origin or an origin already bound to a different `registryId`. It stores any read credentials through the secret-management service and persists the verified registry identity and initial registry trust policy revision.
+4. The control plane verifies the self-certifying `registryId`, descriptor signature and generation, and that the submitted origin is in the signed origin set. It rejects an origin already associated with a different registry identity. It stores any read credentials through the secret-management service and persists the verified registry identity, descriptor generation, and initial registry trust policy revision.
 5. After verification succeeds, the control plane marks the registry connected and advances the registry catalog generation. Packages become discoverable, but each release must still pass admission checks before installation.
 6. The API returns the registry record and verification status. Failures preserve diagnostics without making the registry available for discovery or installation.
 
 ### Publish a Package Release
 
 1. A developer or CI job authenticates directly to the registry with its own publishing credential and runs `vt build <dir> --push`.
-2. `vt` validates the package metadata, builds the platform images and OCI image index, creates the canonical release manifest, and calculates its `releaseDigest`.
+2. `vt` validates the package metadata, builds every applicable digest-addressed artifact and OCI image index, creates the canonical release manifest, and calculates its `releaseDigest`.
 3. The registry authorizes the publisher to reserve `(packageId, releaseVersion)` and creates a recoverable publish-attempt ID. A version already bound to a different digest is rejected.
-4. `vt` uploads content-addressed image blobs, the image index, and the release manifest. The registry recalculates digests and validates platform images and release contracts before making anything discoverable.
-5. The publisher signs a statement containing the `registryId`, `packageId`, `releaseVersion`, `releaseDigest`, and image-index digest with an authorized KMS-backed key, then uploads the signature bundle.
+4. `vt` uploads the content-addressed blobs, image indexes, and release manifest. The registry recalculates every digest and validates all referenced artifacts and release contracts before making anything discoverable.
+5. The publisher signs a statement containing the `registryId`, `packageId`, `releaseVersion`, `releaseDigest`, and every referenced runtime, migration, UI, workflow, and schema artifact digest with an authorized KMS-backed key, then uploads the signature bundle.
 6. The registry verifies the signature and confirms under its publisher policy that the signing key may publish the package. It then atomically binds the version to the digest and adds the release to the package catalog.
 7. The registry returns the immutable `releaseDigest`. Failed or interrupted attempts remain non-installable and may be retried; publishing does not install or deploy the release.
 
@@ -503,20 +602,20 @@ Registry creation is a registry-side operation and is distinct from connecting t
 2. The ingress gateway authenticates and authorizes the actor. The control plane verifies any required `service_account.assign` and `authorization.grant` permissions.
 3. The control plane appends the revision request, verifies that no revision operation is active for the installation, and creates a generation-fenced revision operation. The API returns the operation ID so the client can observe progress asynchronously.
 4. The revision controller verifies the recorded registry trust policy revision, release and image signatures, platform and runtime compatibility, schemas, dependencies, reverse dependents, workflows, and migrations against the recorded desired-state snapshot.
-5. The controller runs declared prepare migrations, creates the immutable candidate Deployment and revision-specific Service, and applies ambient data-plane enrollment and the required `AuthorizationPolicy` attachments. The candidate initially receives no production traffic.
-6. After readiness remains stable, the controller may canary operations whose contracts exactly match the promoted revision. Promotion then updates primary routing and waits for every currently live relevant ingress gateway and destination waypoint to remain synchronized with the target xDS generation for the configured stability window.
-7. The callable catalogs advance only after routing converges. The previous revision drains pinned requests and streams while the controller observes the promoted revision and runs any separately approved finalization.
+5. The controller runs declared prepare migrations, creates any immutable candidate runtime resources, stages UI bundles and workflow definitions, and applies required ambient enrollment and `AuthorizationPolicy` attachments. Candidate artifacts remain absent from user-facing catalogs and receive no default production traffic.
+6. After applicable readiness remains stable, the controller may canary runtime operations whose contracts exactly match the promoted revision. Promotion writes any primary routing intent and waits for routing status, UI-serving, and workflow-registration prerequisites associated with the candidate generations.
+7. After applicable routing, UI-serving, and workflow-registration prerequisites remain converged for the stability window, one transaction advances the promoted head and relevant routing, package, operation, UI, and workflow generations. The previous runtime revision drains pinned requests and streams while the controller observes the promoted revision and runs any separately approved finalization.
 8. The controller records the terminal outcome. A pre-promotion failure leaves the previously promoted revision primary.
 
 ### Invoke a Package Operation
 
-1. An external caller sends an MCP Streamable HTTP request to the deployment endpoint with a session credential or API grant, the target package and operation, and JSON arguments.
-2. The ingress gateway authenticates the credential, removes untrusted internal-identity headers, applies request limits, and calls the authorization service through `ext_authz`.
-3. The authorization service evaluates the credential scope, immediate caller workload identity, effective subject, target installation, canonical operation ID, approved package access policy, and any operation-specific resource against one policy generation. An unknown target or denied check fails before dispatch.
-4. The gateway exchanges the external credential for a short-lived, signed internal invocation token bound to the target audience, package, and operation, then resolves the request to one callable revision. That resolution remains pinned for the lifetime of the invocation.
-5. The mesh routes the request to the selected revision-specific Service.
-6. The package supervisor dispatches the operation to the package runtime. The runtime returns one JSON-RPC response or opens an SSE stream; an open stream remains on the selected revision while that revision drains.
-7. The response returns through the mesh and ingress gateway. The platform records the authorization decision, policy model ID and revision, actor, effective subject, immediate caller workload identity, target, `releaseDigest`, internal token ID, trace ID, duration, and outcome.
+1. An external caller sends an MCP Streamable HTTP request to the package-scoped deployment endpoint with a session credential or API grant and a JSON-RPC envelope.
+2. The ingress gateway authenticates the credential, removes untrusted internal metadata, applies request limits, and decodes the MCP request class and canonical operation when applicable before calling the authorization service through `ext_authz`.
+3. The authorization service evaluates the credential scope, effective subject, target installation, request class, canonical operation ID when applicable, approved package access policy, and any operation-specific resource against one policy generation. An unknown target or denied check fails before dispatch.
+4. The gateway exchanges the external credential for a short-lived internal invocation token bound to the target installation, request class, applicable operation, and request-envelope hash.
+5. The destination waypoint revalidates the token, applies the trusted operation-specific route when applicable, selects a revision Service, and attaches a signed dispatch receipt. A new session becomes pinned to that revision.
+6. The package supervisor verifies the token and dispatch receipt and relays the MCP request to the private runtime socket. The runtime returns one JSON-RPC response or opens an SSE stream; an open stream remains on the selected revision while that revision drains.
+7. The response returns through the mesh and ingress gateway. The platform records the authorization decision, policy model ID and revision, actor, effective subject, immediate caller workload identity, target, `releaseDigest`, internal token and dispatch-receipt IDs, trace ID, duration, and outcome.
 
 Package-to-package invocation does not pass through ingress. The calling package presents a platform-issued internal invocation token to the destination waypoint, which performs the corresponding workload and effective-subject authorization checks before revision routing and dispatch. Raw caller credentials are never forwarded.
 
@@ -533,12 +632,15 @@ Authentication, authorization, registry, package-lifecycle, migration, secret-ac
 Before production use, automated tests cover:
 
 - **Registry and release integrity**: atomic publication under retries and concurrency, signature and compatibility rejection, and safe disconnection and garbage collection
+- **Runtime contract**: supervisor protocol negotiation, digest-aware readiness, request-envelope decoding, token binding, cancellation, session pinning, SSE draining, and malformed or ambiguous MCP requests
 - **Revision state machines**: validation failures, administrator, controller, and dependency races, restart at every phase, and migration idempotency and lease loss
-- **Rollout and recovery**: canary and promotion failures, routing and catalog convergence, draining and SSE behavior, rollback approval, removal, tombstones, retained workflows, autoscaling, and mixed versions
+- **Rollout and recovery**: canary and promotion failures before and after routing intent, proxy-membership churn, route restoration, atomic rollout groups, catalog convergence, draining and SSE behavior, rollback approval, removal, tombstones, retained workflows, autoscaling, and mixed versions
 - **Platform lifecycle**: bootstrap ordering and outages, protected identities and signers, ordinary-package replacement prevention, and independent infrastructure and system-package rollouts
 - **Authorization models**: deterministic policy publication, active-grant preservation, subject-set cycles, and parity between batch and individual checks
 - **Identity and delegation**: spoofing, claim validation, token expiration and rotation, `runAs`, confused-deputy prevention, attenuation, and revocation
 - **Fail-closed enforcement**: authorization outages, data-plane bypass attempts, and ingress or waypoint `ext_authz` failures
+- **Interfaces and workflows**: route collisions, CSP and asset validation, revision-qualified caching, pinned workflow executions, signals and timers during upgrades, retirement, migration, and forced termination
+- **Disaster recovery**: regional state restore, route reconstruction, signing-key and certificate recovery, protected-service recovery, audit continuity, and break-glass controls
 
 ## Glossary
 
@@ -546,7 +648,7 @@ Before production use, automated tests cover:
 Permanent `(registryId, packageId)` for a registry package. Assigned when the package is reserved; never reused.
 
 **release**<br>
-Immutable, signed artifact for one `releaseVersion` of a package, identified by `releaseDigest`.
+Immutable artifact with detached signatures for one `releaseVersion` of a package, identified by `releaseDigest`.
 
 **releaseVersion**<br>
 Registry-scoped version label for one published release of a package. `(registryId, packageId, releaseVersion)` binds permanently to one `releaseDigest`.
@@ -570,7 +672,13 @@ Background worker that drives a revision operation to completion and resumes aft
 Path from admission through readiness, optional canarying, and promotion for an install or upgrade candidate.
 
 **promotion**<br>
-Makes a revision primary for routing; callable catalogs advance only after routing convergence.
+Atomic state-store commit that advances the promoted revision and relevant routing, package, operation, UI, and workflow generations after all applicable prerequisites have converged.
+
+**routing generation**<br>
+Durable identifier that correlates one routing decision with its exact Kubernetes resources, desired route hashes, relevant proxy-membership snapshot, and convergence observations.
+
+**atomic rollout group**<br>
+One generation-fenced revision request that validates and promotes mutually dependent package revisions as a single desired-state and catalog change.
 
 **authorization model**<br>
 Immutable, content-hashed definition of resource types, relations, actions, and allowed relationship targets used for one generation of authorization decisions.
@@ -579,7 +687,10 @@ Immutable, content-hashed definition of resource types, relations, actions, and 
 An assignment of a subject, resource, or subject set to one relation on a resource.
 
 **internal invocation token**<br>
-Short-lived signed context that carries verified caller and delegation information and is bound to its intended audience, package, and operation.
+Short-lived signed context carrying verified caller and delegation information, bound to its issuer, audience, target installation, request class, optional operation, and request-envelope hash.
+
+**package supervisor**<br>
+Platform-owned `gestaltd` sidecar in each runtime Pod that implements the mesh-facing runtime contract, verifies invocation context, gates runtime readiness and shutdown, and reports observed state.
 
 **bootstrap substrate**<br>
 Infrastructure that must exist before package APIs are available, including Kubernetes, Istio, control-plane state, revision controllers, certificate authority, and recovery tooling.

--- a/plans/service_mesh/plan.md
+++ b/plans/service_mesh/plan.md
@@ -3,14 +3,13 @@
 ## Contents
 
 - [Overview](#overview)
-- [Design Invariants](#design-invariants)
-- [Model](#identity-model)
-- [Publishing](#package-releases)
-- [Revisions](#durable-deployment-state)
-- [Runtime](#workflows)
-- [Authorization](#authentication-and-authorization)
-- [Implementation](#runtime-architecture)
-- [Assurance](#retention-and-audit)
+- [Foundations](#foundations)
+- [Publishing and Distribution](#publishing-and-distribution)
+- [Package Revisions](#package-revisions)
+- [Runtime and Access](#runtime-and-access)
+- [Platform Architecture](#platform-architecture)
+- [Representative Request Lifecycles](#representative-request-lifecycles)
+- [Assurance](#assurance)
 - [Glossary](#glossary)
 
 ## Overview
@@ -19,15 +18,19 @@ The platform builds, distributes, installs, and runs packages in a shared servic
 
 - An MCP server and its operations
 - One or more single-page user interfaces
-- Durable workflow definitions and workers
+- Durable workflow definitions
 - Dependency and migration metadata
-- Runtime, configuration, and authorization requirements
+- Runtime and operation-authorization requirements
 
-An organization operates one deployment backed by a private registry and, optionally, additional trusted registries. The deployment exposes catalogs of installed packages, callable operations, user interfaces, workflows, and dependencies.
+A platform package supervisor runs beside each installed package, starts its MCP server, and reports its observed runtime state.
 
-Publishing makes a release discoverable. Installation admits an immutable release into an organization. Canarying permits controlled, undiscoverable traffic, while promotion makes an installed revision primary and user-discoverable. These states are separate and must not be inferred from one another.
+Each organization operates one deployment backed by a private registry and optional trusted registries. The deployment exposes catalogs of installed packages, callable operations, user interfaces, workflows, and dependencies.
 
-## Design Invariants
+Publishing makes a release discoverable. Installation admits an immutable release into an organization. Canarying permits controlled, undiscoverable traffic. Promotion makes an installed revision primary, and convergence then makes its contracts user-discoverable. These milestones are separate and must not be inferred from one another.
+
+## Foundations
+
+### Design Invariants
 
 The following invariants apply to every implementation:
 
@@ -35,157 +38,151 @@ The following invariants apply to every implementation:
 2. A deployment records every accepted install, upgrade, rollback, and removal request in an append-only revision history.
 3. For each canonical package identity in an organization, only one revision operation — install, upgrade, rollback, or removal — may be in progress at a time.
 4. Durable revision requests record intent; revision controllers perform runtime work and resume safely after process failure.
-5. Published, admitted, materialized, running, ready, canary-callable, promoted, and converged are distinct states.
+5. Registry publication, revision-operation phase, live workload health, routing promotion, and catalog convergence are tracked separately.
 6. A pre-promotion failure does not replace the last successfully promoted revision.
-7. Routing propagation is eventually consistent, so every revision that may receive traffic remains contract-compatible until propagation and draining finish. New contracts become visible only after routing convergence.
-8. Packages run only under organization-provisioned identities; requested capabilities require explicit grant or delegation and cannot be self-asserted by release metadata.
-9. Dynamic services cannot replace the identity, authorization, certificate, secret, registry-verification, audit, state-storage, or recovery components needed to administer the mesh.
-10. Every externally supplied manifest, image, schema, migration, and attestation is untrusted until its digest, signature, and policy are verified.
+7. Routing propagation is eventually consistent, so every revision that may receive traffic remains contract-compatible with operations referenced by installed reverse dependencies until propagation and draining finish. New contracts become visible only after routing convergence. A candidate may omit an operation when no installed package or retained workflow references it; stale or undeclared calls to that operation may fail after promotion.
+8. Packages run only under organization-provisioned identities; release metadata may define access requirements but cannot grant authority.
+9. Ordinary packages cannot replace components needed to administer the platform. Identity, authorization, workflow execution, secret management, registry verification, and audit may be implemented only by protected system packages; certificates, state storage, revision control, and recovery remain part of the bootstrap substrate.
+10. Every externally supplied manifest, image, schema, and migration is untrusted until its digest, signature, and policy are verified.
+11. Every authorization decision uses canonical identities and one immutable policy generation. Grants change only through explicit authorized actions; policy-model changes cannot silently delete or orphan them.
+12. Raw user credentials and caller-supplied identity fields never cross into package runtimes. Internal caller context is short-lived, signed, and bound to its intended audience and target.
 
-## Identity Model
+### Identity Model
 
 The system keeps these identities separate:
 
-- **Registry identity**: immutable `registryId` plus its configured origin and trust-policy digest.
+- **Registry identity**: deployment-scoped immutable `registryId` plus its configured origin. The identifier distinguishes registries within one platform deployment; it is not a global registry namespace.
 - **Package identity**: permanent `(registryId, packageId)` assigned when the package is reserved. A slug is a mutable display and discovery alias, never a security identifier.
 - **Release identity**: `(registryId, packageId, releaseVersion, releaseDigest)`.
 - **Installation identity**: an organization-scoped UUID representing one installed package.
-- **Workload identity**: an orchestrator-owned SPIFFE identity for one installation's runtime or migration job.
+- **Workload identity**: the installation principal used in authorization checks for one installation's runtime or migration job, bound at installation to an organization-managed Kubernetes service account.
 - **Workflow identity**: the principal assigned to a workflow definition or execution.
-- **Actor identity**: the user, API grant, service account, or workflow that initiated an action.
+- **Actor identity**: the user, API grant, platform service account, or workflow that initiated an action.
 - **Effective subject**: the principal whose delegated authority an invocation exercises.
 
-Package IDs are never reused. Slug renames retain aliases and tombstones. Mirroring a package preserves its identity only through a signed mirror or transfer relationship; otherwise importing it creates a distinct package identity.
+Authentication resolves a credential to one canonical principal before authorization. Gateways remove caller-supplied internal identity fields, and downstream services accept identity only from verified workload identity or signed internal context. Delegation keeps the actor and effective subject distinct throughout authorization and audit.
 
-Package authors cannot select workload identities. The orchestrator binds installations to Kubernetes service accounts and short-lived SPIFFE certificates. Trust domain, certificate lifetime, rotation, and compromise revocation are deployment policy.
+Package IDs are never reused. Slug renames retain aliases and tombstones. Content published under a different registry receives a distinct package identity, even when the release bytes are identical.
 
-## Package Releases
+Release metadata cannot name workload identities or Kubernetes service accounts. Runtime identities and authorization bindings are selected from organization-managed resources during installation.
 
-Each `releaseVersion` has one platform-independent, signed release manifest. The release manifest is stored as an OCI artifact or another digest-addressed immutable object and references an OCI image index digest. The image index selects immutable image manifests for supported `os`, `architecture`, and optional `variant` tuples.
+## Publishing and Distribution
 
-Platform images may contain different binaries, but their operation contracts, dependencies, migrations, workflows, and requested capabilities must match the release manifest. A platform-specific release contract is not allowed.
+### Package Releases
+
+Each `(packageId, releaseVersion)` has one signed release manifest and may support one or more `os`, `architecture`, and optional `variant` tuples. Stored by digest, the manifest references an OCI image index covering those platforms.
+
+Platform images may contain different binaries, but contracts, dependencies, migrations, workflow definitions, and operation access requirements are shared across all supported platforms.
 
 The release manifest contains:
 
 - Canonical registry and package IDs, slug, and `releaseVersion`
 - OCI image-index digest and supported platforms
-- Instructions for starting the MCP server, interfaces, and workflow workers
+- MCP server startup instructions and interface entry points
 - MCP endpoint, operations, and input/output schema digests
-- Included workflows and user interfaces
+- Included workflow definitions and user interfaces
 - Required and optional package and operation dependencies
 - Ordered prepare, finalize, and compensating migration jobs
-- Rollback classification
-- Requested service-account, authorization, ingress, and egress capabilities
-- Configuration and typed secret requirements
+- Required authorization relationships or roles for each operation
 - Startup, liveness, and readiness endpoints
-- Minimum and maximum supported `gestaltd` and mesh protocol versions
-- Source repository and revision
-- Subjects for detached signatures and build-provenance attestations
+- Minimum and maximum supported package-supervisor and mesh protocol versions
+- Optional source repository URL and source revision
 
-The manifest does not contain self-asserted signatures or provenance. Signatures and SLSA/in-toto provenance are detached attestations over the release and image digests, such as OCI referrers.
+The registry stores signatures separately from the manifest. Each signature identifies the exact release or image digest it covers.
 
-The `releaseDigest` is computed over the canonical manifest bytes and is carried by catalog entries, signatures, attestations, and installation records rather than by the hashed manifest itself.
+Source repository and revision are optional display metadata. Publication must support releases without either field; when present, catalogs and administration views may use them for links and context.
 
-`releaseVersion` values follow a registry-defined, documented grammar and comparison order. A `(registryId, packageId, releaseVersion)` binds permanently to one `releaseDigest`. A conflicting republish is rejected. An identical retry is idempotent and does not rewrite publication time or provenance. Mutable tags may aid discovery but are never installation inputs.
+The `releaseDigest` is the hash of the canonical manifest bytes. Catalog entries, signatures, and installation records carry it; the manifest does not.
 
-## Registries
+`releaseVersion` follows a documented registry grammar and comparison order. `(registryId, packageId, releaseVersion)` binds permanently to one `releaseDigest`: conflicting republishes fail, while identical retries are idempotent and preserve publication time and metadata. Mutable tags may aid discovery but are never installation inputs.
+
+### Registries
+
+The registry protocol is open and has no central creation or approval authority. Anyone may operate a registry using the reference creation tooling or an independent implementation that serves the required registry descriptor, APIs, and signature bundles. Each organization independently decides whether to connect to and trust that registry.
 
 Registries control who can publish, discover, or download releases. Each configured registry has:
 
-- An immutable `registryId`
+- An immutable `registryId` that is unique within the platform deployment
 - Discovery, metadata, blob, and publication endpoints
-- Authentication and authorization scopes
-- Trusted signing identities and builders
-- Allowed package namespaces
-- Source repository and workflow constraints
-- Required provenance level
-- Whether direct developer publication is permitted
-- A versioned trust-policy digest
+- Optional read credentials for discovery and download from a private registry
+- A registry trust policy binding each trusted public-key fingerprint to a publisher identity and the package IDs that key may sign
+- Whether local clients may publish directly
+- A policy revision incremented when trust or local publication rules change
 
-Connecting a registry does not trust every publisher in it. Catalogs and manifests remain untrusted until admission verifies their immutable digests, signatures, provenance, schema versions, and the deployment's registry policy.
+The registry's publisher policy controls which releases it accepts. Each connected organization's registry trust policy independently controls which of those releases the organization will admit and may be more restrictive. Registry connection credentials, when present, are read-only and are stored by the secret-management service. Publishers authenticate to the registry with their own user or CI credentials, which the platform does not retain. Artifact verification uses the registry trust policy and public trust material, not registry credentials.
 
-The registry interface defines pagination, conditional reads, consistency guarantees, error codes, retries, rate limits, and authentication separately for catalog discovery, immutable metadata, blob pulls, and publication.
+Connecting a registry does not trust its publishers. Catalogs and manifests remain untrusted until admission verifies digests, signatures, schema versions, and the registry trust policy.
 
-A catalog contains paginated package and release summaries pointing to authoritative release-manifest digests. It does not duplicate the full release contract. Per-package indexes use monotonic revisions and compare-and-swap updates.
+The registry provides distinct APIs for paginated discovery, reading immutable metadata and blobs, and authenticated publication.
 
-Disconnecting a registry blocks new discovery and installation but preserves its identity and all historical records. Hard removal is rejected while any desired, running, redeployable, dependent, or in-progress revision references it. Rebinding to a mirror requires digest-equivalent content and signatures trusted by the deployment.
+A registry catalog contains paginated package and release summaries that reference authoritative manifest digests, without duplicating release contracts. Per-package indexes use monotonic revisions and compare-and-swap updates.
 
-## Build and Publish
+Disconnecting a registry blocks discovery and installation but preserves its identity and history. Hard removal fails while any desired, running, redeployable, dependent, or in-progress revision references it. A replacement is a new registry; package identities do not carry over.
 
-`vt build <dir>` validates source metadata and builds an OCI image index and release manifest. The build records resolved source and material digests. Production publication requires attestations from a trusted builder; direct publication must satisfy the same policy.
+### Build and Publish
+
+`vt build <dir>` validates package metadata and builds an OCI image index and release manifest locally. Adding `--push` publishes the result to the selected registry:
+
+```sh
+vt build <dir> --push
+```
+
+Without `--push`, the command does not modify a registry.
 
 Publication is a recoverable transaction:
 
 1. Reserve `(packageId, releaseVersion)` and create a publish-attempt ID.
-2. Record a pending release with source and workflow provenance.
+2. Record a pending release with any optional source metadata.
 3. Upload content-addressed image blobs and manifests.
 4. Validate all platform images and release contracts server-side.
-5. Create the immutable release manifest.
-6. Attach signatures and provenance attestations.
-7. Commit availability by compare-and-swap updating the package catalog last.
+5. Store the immutable release manifest.
+6. Attach signatures.
+7. After all artifacts are stored, atomically add the release to the package catalog. Retry if another publisher changed the catalog first.
 8. Mark the attempt succeeded or failed.
 
 Pending and failed attempts are visible but never installable. Concurrent publishers cannot lose catalog updates. Stale attempts become failed, and orphaned content-addressed blobs are garbage-collected after a grace period.
 
-## Durable Deployment State
+## Package Revisions
+
+### Durable Deployment State
 
 The control plane persists:
 
 - **Package slots**: one organization-scoped slot keyed by canonical package identity, reserved before allocating an installation ID and used to fence concurrent first installs
-- **Revision requests**: append-only install, upgrade, rollback, and removal intent with actor, previous promoted revision, target `releaseDigest`, approved capabilities, resolved dependencies, and timestamps
+- **Revision requests**: append-only install, upgrade, rollback, and removal intent with actor, previous promoted revision, target `releaseDigest`, registry trust policy revision, approved authorization bindings, resolved dependencies, and timestamps
 - **Installation head**: last successfully promoted revision and current admitted candidate
-- **Revision operation**: one generation-fenced state machine per installation
+- **Revision operation**: one generation-fenced state machine per installation, including phase, candidate Kubernetes resources, deadlines, stability timestamp, and routing generation
 - **Migration outcomes**: immutable status keyed by installation, `releaseDigest`, and migration ID
-- **Workload observations**: materialized, started, ready, draining, stopped, and error state for each target replica
 - **Routing and catalog generation**: the promoted revision visible to callers
 - **Terminal outcomes**: completion or failure phase, duration, and reason
 
-Revision records use optimistic concurrency and fencing tokens. A stale controller cannot mutate a newer generation after losing its lease. Retries are idempotent, and every external mutation has a stable idempotency key.
+The revision-operation phase is the canonical lifecycle state. Image availability, process status, replica health, routing synchronization, and catalog generation are observations attached to that operation, not additional lifecycle states.
 
-Each rollout targets one immutable runtime cohort identified by the infrastructure generation and `gestaltd` supervisor generation. Replicas enroll during a bounded epoch; the nonempty cohort is then frozen for promotion accounting. Scaling replicas that join later still converge but do not retroactively change the completed cohort. Observations include the rollout generation and enrollment epoch so stale or overlapping infrastructure cohorts cannot satisfy a newer rollout.
+### Installation
 
-Routing convergence uses a separately frozen proxy cohort. In sidecar mode it contains every live ingress gateway plus the live sidecars of declared reverse-dependent caller workloads at the promotion epoch. `istiod` xDS status supplies proxy membership and acknowledgement of the target routing generation. A reverse-dependent replica that starts later cannot become ready until it receives at least that generation. Undeclared direct east-west invocation is denied, so it cannot bypass this cohort. Ambient mode must define the equivalent gateway, waypoint, and `ztunnel` cohort before it is supported.
+Publishing does not install a package. An authorized installer selects an immutable `releaseDigest` and binds:
 
-The runtime distinguishes:
-
-- **Published**: committed in a registry
-- **Admitted**: verified and accepted as a candidate by the organization
-- **Materialized**: image and immutable contract are available to a workload node
-- **Running**: the candidate process started
-- **Ready**: the candidate passes readiness and minimum healthy-duration checks
-- **Canary-callable**: an undiscoverable candidate receives a controlled subset of traffic for operations whose contracts exactly match the promoted revision
-- **Promoted**: routing selects the candidate as primary
-- **Converged**: the required workload cohort observes the promoted generation
-
-## Installation
-
-Publishing does not install a package. An organization administrator selects an immutable `releaseDigest` and binds:
-
-- Organization-owned package and workflow identities
-- Package-requested operations and capabilities to approved authorization relationships
+- An organization-managed Kubernetes service account for the installation's workload identity
+- Organization-managed workflow identities
+- Package-declared authorization relationships or roles for each operation
 - Caller-delegation policy per operation
-- Typed configuration values and secret references
-- Ingress and egress requests to organization policy
 - Initial replica, resource, and availability settings
 
-The platform shows the requested-versus-approved capability diff before admission. An installer can use only identities for which they have `can_use` or `can_delegate`, and cannot convert temporary authority into an unrestricted persistent package grant. Sensitive capabilities may require a second approver.
+Before admission, the platform shows package-declared operation access requirements and resulting authorization bindings. The installer — an organization administrator or package administrator with install authority — needs `service_account.assign` for each selected identity and `authorization.grant` for each relationship or role being granted.
 
 Installation is a reconciled saga:
 
-1. Verify registry trust, release and image signatures, provenance, platform support, runtime compatibility, and schema versions.
+1. Verify the registry identity and trust policy, release and image signatures, platform support, runtime compatibility, and schema versions.
 2. Resolve exact dependency revisions and operation-contract digests.
-3. Reserve the organization package slot and persist the revision request, approved capability snapshot, and fenced revision operation.
-4. Provision the installation identity, workload identity, policy, configuration, and secret bindings.
-5. Materialize and start the initial workload without making it callable.
-6. Require readiness quorum and minimum healthy duration.
-7. Promote routing, wait for the frozen proxy cohort to acknowledge the routing generation, and drain any prior compatible route.
-8. Advance the callable catalog only after routing converges, then record convergence and the terminal outcome.
+3. Reserve the organization package slot and persist the revision request, approved authorization snapshot, and fenced revision operation.
+4. Provision the installation, workload, and migration identities, authorization relationships, ambient data-plane enrollment, and required `AuthorizationPolicy` attachments.
+5. Hand the fenced operation to the revision controller, which follows the canonical phases in [Revision Rollouts](#revision-rollouts).
 
-Failures preserve the durable phase and diagnostics. The revision controller retries retryable phases within policy and compensates unpromoted resources when an administrator cancels the installation. A package is not callable until promotion succeeds.
+Failures preserve phase and diagnostics. The revision controller retries within policy and cleans up resources created for an unpromoted revision when an administrator cancels. Promotion, catalog exposure, and canary behavior follow the rules in Revision Rollouts.
 
-## Dependencies and Contracts
+### Dependencies and Contracts
 
-Dependencies use canonical package identities, `releaseVersion` ranges, and required operation contract digests. Dependencies may be required or optional. Admission records the exact revisions and contract digests selected.
+Dependencies specify canonical package identities, `releaseVersion` ranges, required or optional status, and operation-contract digests. Admission records the selected revisions and digests.
 
 The platform validates:
 
@@ -196,82 +193,128 @@ The platform validates:
 - No conflicting revision operation is active in the affected dependency subgraph
 - Workflow calls reference compatible operation contracts
 
-JSON Schemas use one pinned dialect and canonical encoding before hashing. The first implementation requires exact schema digests. Semantic compatibility can be introduced only with documented contravariant input and covariant output rules.
+All schemas use the same JSON Schema version and are normalized before hashing. Initially, schemas are compatible only when their hashes match.
 
-Validation reads a revisioned desired-state snapshot and commits with generation preconditions. For independent packages, upgrades may proceed concurrently. Upgrades that affect the same dependency subgraph use deterministic locking or one atomic multi-package rollout plan. Dependency cycles are rejected until atomic rollout groups are implemented.
+Declared dependencies and workflow references are the authoritative compatibility boundary for operation removal. A candidate may remove an operation when no installed package or retained workflow references it, including after accounting for other revisions in the same atomic rollout plan. External callers do not create an implicit dependency: callers using stale catalogs, cached operation names, or otherwise undeclared contracts may receive an operation-unavailable error after promotion.
 
-## Upgrades and Traffic Promotion
+Validation reads a revisioned desired-state snapshot and commits with generation preconditions. Independent packages may upgrade concurrently. Upgrades affecting the same dependency subgraph use deterministic locking or one atomic multi-package rollout plan. Cyclic dependencies may be upgraded sequentially when every intermediate state is compatible. Mutually dependent changes require an atomic rollout group.
 
-An upgrade never mutates the running revision in place. It creates a candidate generation while the last promoted revision continues serving.
+### Revision Rollouts
 
-The rollout state machine is:
+Upgrades use a Kubernetes-native blue/green rollout with optional Istio canary traffic. Each upgrade creates a candidate revision in a distinct immutable Kubernetes Deployment behind a revision-specific Service. The promoted and candidate Deployments may run together, so the serving Deployment is never restarted or mutated in place.
 
-1. **Admitted**: verify the release, policy, runtime compatibility, dependencies, reverse dependents, and rollback classification.
-2. **Staging**: pull and verify images for the target cohort.
-3. **Preparing**: run backward-compatible prepare migrations as fenced one-shot jobs.
-4. **Starting**: start candidate workloads with no production traffic.
-5. **Ready**: require a readiness quorum and minimum healthy duration.
-6. **Canarying**: route a configurable small traffic percentage for operations whose contracts exactly match the promoted revision; the candidate remains absent from user-facing catalogs.
-7. **Promoting**: make the candidate primary, wait for the frozen proxy cohort to acknowledge the routing generation, and only then expose newly added contracts in callable catalogs. Promotion is the boundary after which the candidate is the last successfully promoted revision.
-8. **Draining**: keep the prior revision available for in-flight requests and streams until their drain deadline.
-9. **Soaking**: observe the promoted revision for a configured period.
-10. **Finalizing**: run irreversible contract/finalize migrations only after the rollback window when required.
-11. **Complete**: record convergence and terminal timing.
+Revision records use optimistic concurrency and fencing tokens, preventing a controller that loses its lease from mutating a newer generation. Retries are idempotent; every external mutation has a stable idempotency key. For example, controller A may start an upgrade at generation 4, create the candidate Deployment, and then lose its lease. Controller B takes over at generation 5. Any later update from controller A is rejected, while controller B can safely retry the Deployment request without creating a duplicate.
 
-Each phase has a timeout, retry policy, and terminal error taxonomy. Promotion requires nonempty frozen runtime and proxy cohorts and cannot be inferred from one ready instance. Routing changes define weight propagation, proxy acknowledgement, readiness quorum, connection draining, and behavior for MCP SSE streams. During partial routing propagation, both revisions support the promoted operation-contract digests.
+Kubernetes and the package supervisor are the source of truth for live workload health. A candidate is ready only when Kubernetes has observed the Deployment generation, its required replicas are available, and package-supervisor readiness confirms the target `releaseDigest` for a stability window. Replacement pods and autoscaled replicas count by current readiness, not persistent identity.
 
-Failures before promotion produce a failed candidate and leave the prior promoted revision primary. Failures during soak after promotion mark the new revision degraded and trigger rollback when its rollback class permits; otherwise they require an audited forward fix. Finalization failure does not relabel the promoted revision as a failed candidate or route traffic implicitly: it records `promoted_with_finalization_error`, blocks the next revision operation, and requires retry or an approved forward fix.
+Istio routes traffic between revision-specific Services. Promotion converges when every currently live relevant ingress gateway and destination waypoint reports the target xDS generation and their Kubernetes Deployments remain available for a stability window. If the set of live routing proxies changes, the stability window resets. Packages may call other packages only through declared dependencies and mesh-managed routes. Direct or undeclared package-to-package calls are blocked.
 
-The availability goal is zero planned downtime for packages that satisfy the compatibility contract. Any supported operation that requires downtime declares and receives explicit administrator approval before admission; a vague downtime target is not sufficient.
+The control plane persists rollout intent and decisions, then reconstructs progress from Kubernetes, the package supervisor, and Istio after restart. Historical rollout outcomes remain immutable; current workload health is a separate live view.
 
-## Migrations and Rollback
+The canonical revision-operation phases are:
+
+1. **Admitted**: verify the release, policy, runtime compatibility, dependencies, and reverse dependents.
+2. **Preparing**: run backward-compatible prepare migrations as fenced one-shot jobs.
+3. **Starting**: create the revision-specific Deployment and Service with no production traffic.
+4. **Ready**: require Kubernetes availability and package-supervisor readiness for the configured stability window.
+5. **Canarying**: route a configurable small traffic percentage for operations whose contracts exactly match the promoted revision; the candidate remains absent from user-facing catalogs.
+6. **Promoting**: route primary traffic to the candidate, wait for live relevant proxies to remain synced to the routing generation, and then expose newly added contracts in callable catalogs. Promotion makes the candidate the last successfully promoted revision.
+7. **Draining**: keep the prior revision available for in-flight requests and streams until their drain deadline.
+8. **Observing**: monitor the promoted revision under production traffic for a configured period.
+9. **Finalizing**: run explicitly approved irreversible finalize migrations when required.
+10. **Complete**: record convergence and terminal timing.
+
+Canarying and Finalizing may be skipped when they do not apply. A failure or cancellation records a terminal outcome against the phase where the operation stopped rather than introducing another progression phase.
+
+Each phase has a timeout, retry policy, and terminal error taxonomy. Readiness requires the configured replica capacity, not a single ready pod. During routing propagation and draining, revisions follow the compatibility and operation-removal rules in [Dependencies and Contracts](#dependencies-and-contracts). Existing MCP SSE streams remain pinned to their original revision while the old revision drains, including streams for an operation omitted by the candidate.
+
+Pre-promotion failures mark the candidate failed and leave the prior revision primary. Failures during post-promotion observation mark the new revision degraded. Neither case triggers automatic rollback. Degraded or finalization-error states block the next revision operation until an administrator retries, initiates an approved rollback, or approves a forward fix. Finalization failure records `promoted_with_finalization_error`; it neither marks the promoted revision failed nor changes routing.
+
+Compatible packages target zero planned downtime. Any release requiring downtime must declare it and receive explicit administrator approval before admission.
+
+### Migrations and Rollback
 
 Migrations are separately identified, digest-pinned jobs. Each declares:
 
 - Migration ID and `releaseDigest`
 - Prepare, finalize, or compensating phase
-- Dedicated workload identity and requested capabilities
-- Required secrets and network destinations
+- Dedicated workload identity
 - Timeout, resource limits, retry policy, and idempotency key
 - Compatibility with the prior and candidate package revisions
 
-Migration jobs run with least privilege and deny-by-default egress. They never run as the installer, revision controller, or normal package identity. Attempt and completion records are durable.
+Migration jobs use least privilege and deny-by-default egress. They never run as the installer, revision controller, or installation's normal workload identity. Attempts and outcomes are durable.
 
-Each release declares one rollback class:
+The first version does not classify rollback safety in release metadata or initiate rollback automatically. Prepare migrations follow expand/contract rules and remain compatible with the serving revision. Destructive finalization requires separate administrator approval. Before manual rollback, an administrator must confirm data compatibility and select any required declared compensating migration; the platform does not infer rollback safety. Administrators may initiate an approved rollback through the revision controller; shell commands cannot update revision state.
 
-- **Traffic-only**: the previous revision can serve against the current data model
-- **Code and compatible data**: old code and schema remain mutually compatible
-- **Compensating migration required**: rollback requires a declared, verified job
-- **No post-promotion rollback**: an explicitly approved release cannot return traffic to the prior revision after promotion
-
-Prepare migrations follow expand/contract rules and must remain compatible with the serving revision. Releases with a rollback-capable class defer destructive finalize migrations until the rollback window closes. A no-post-promotion-rollback release requires explicit approval before promotion and has no rollback window. A rollback command is not proof that data rollback is safe.
-
-Administrators initiate rollback through the same revision controller. Manual shell execution cannot update revision state. Automatic rollback may later invoke the same audited state machine when canary or soak gates fail.
-
-## Removal
+### Removal
 
 Removal is a durable tombstoned revision, not deletion of a catalog row:
 
 1. Reject removal while required reverse dependents exist, unless they are removed in the same atomic plan.
 2. Promote a tombstone generation that removes callable catalog entries and prevents new invocation resolution.
-3. Drain already-resolved requests, streams, workers, and queued work according to policy.
-4. Stop workloads and block ingress and egress.
-5. Revoke workload certificates, installation-owned assignments, delegated tokens, secret bindings, and runtime configuration.
-6. Apply package-data retention or destruction policy.
+3. Drain resolved requests and streams, stop new workflow executions, and handle queued or running executions according to policy.
+4. Stop the removed package's runtime workloads, scale them to zero, and block any stale ingress or package-initiated egress.
+5. Revoke workload authorization bindings, installation-owned assignments, and delegated tokens.
+6. Apply package data retention or destruction policy.
 7. Preserve the package tombstone and audit history.
 8. Garbage-collect runtime resources after the recovery window.
 
-Organization-owned persistent grants are not silently deleted; the removal UI distinguishes them from installation-owned grants. Reinstallation creates a new installation identity unless an explicit restore operation reactivates the tombstone within policy.
+Removal preserves organization-owned grants and distinguishes them from installation-owned grants. Reinstallation creates a new installation identity unless an approved restore reactivates the tombstone.
 
-## Workflows
+## Runtime and Access
 
-Workflow definitions are immutable and versioned independently from package processes. Each execution records its workflow-definition digest, actor, workflow identity, and compatible package-operation contract revisions.
+### Authentication and Authorization
 
-Existing executions continue on workers that support their pinned definition until they complete, migrate, or reach a documented retirement policy. New executions use the promoted workflow catalog generation. Removal and incompatible upgrades must account for queued work, retries, timers, and long-running executions before workers are drained.
+The authorization service is the system of record for organization policy. It stores Zanzibar-style tuples used by management, user-invocation, workflow, and package-to-package authorization checks. Enforcement topology and mesh policy attachment are defined in [Runtime Architecture](#runtime-architecture).
 
-Every workflow operation is authorized at execution time. `can_run_as` is required to select an organization-managed workflow identity. The original triggering actor remains in the audit and delegation chain.
+- Users authenticate through an external identity provider with organization-level SSO, issuer and tenant allowlists, and session revocation.
+- API keys are named, expiring, scoped API grants that act on behalf of an owner. Only hashes are stored, plaintext is returned once, and empty scope does not mean unrestricted access.
+- `service_account.create` permits creating an organization-managed service account but grants it no authority.
+- `service_account.assign` permits binding a service account to a package runtime, workflow definition, or workflow execution but grants it no new authority.
+- `authorization.grant` permits granting a relationship or role and may be held only by a human subject. The grant cannot exceed the issuer's current authority, resource scope, conditions, or expiration.
+- Every installed package runtime uses an organization-owned workload identity; workflow definitions and executions use organization-owned workflow identities.
+- Every invocation is centrally authorized before dispatch; package-specific resource checks may further restrict it.
+- Production does not start in a fail-open mode when identity or authorization is unavailable.
 
-## Catalogs and Administration
+Each authorization grant wraps one relationship tuple and records an immutable ID, organization, human issuer, creation and optional expiration, source authority, and policy revision. Grant mutation creates a new record; revocation appends a revocation record rather than rewriting or deleting history. Revoking or narrowing the source authority invalidates dependent grants. Platform controllers may apply a recorded human-authorized grant but cannot originate one.
+
+The first implementation does not cache authorization decisions. Internal invocation tokens are short-lived, and every workflow step is authorized independently. Existing streams may continue until their configured lifetime expires. Security events go to an immutable audit sink outside package-controlled storage.
+
+### Authorization Model and Evaluation
+
+Authorization uses a provider-independent check protocol built around:
+
+- A canonical **subject** being evaluated, such as the effective subject, immediate caller workload, or management actor
+- An **action**, such as a package operation or administrative permission
+- A canonical **resource**, identified by a reserved platform type or a package-namespaced type
+
+The platform reserves resource types for registries, packages, releases, installations, revisions, workflows, identities, and authorization grants. Package-defined resource types are namespaced by canonical package identity and cannot use reserved names. Users and service accounts are subjects unless the requested action manages the identity itself.
+
+A decision returns allow or deny together with the immutable policy model ID and revision used to evaluate it. A batch form evaluates multiple checks against the same policy snapshot and has the same semantics as individual checks; catalogs and controllers use it to avoid per-item authorization calls.
+
+The authorization model defines resource types, relations, actions, and which relations satisfy each action. Relationship targets may be direct subjects, resources, or subject sets such as the members of a group. Subject-set traversal is cycle-safe. Package invocation uses the installation identity as the resource and the canonical operation ID as the action; package-specific checks may use a more specific package-owned resource.
+
+The authorization service stores the policy model and organization-managed grants in one authoritative runtime system. Platform bootstrap registers reserved resource types, while package admission registers namespaced resource types and operation requirements. Each model change produces an immutable, content-hashed generation. Grants may be revoked at any time. A policy-model change cannot remove or rename a resource type or relation referenced by active grants unless those grants are revoked or migrated in the same transaction. Grants are indexed by subject, relation, and resource so evaluation does not scan the complete relationship set.
+
+Credential scopes are an upper bound on authority: a relationship grant cannot restore access excluded by the authenticated credential. Missing subjects, actions, resources, policy models, or provider availability produce a denial.
+
+### Package Access Policy
+
+Release manifests define only the authorization relationships or roles required to invoke each operation. They do not declare configuration, secrets, ingress, or egress capabilities.
+
+Package upgrades cannot directly change organization-managed grants. A subject with appropriately scoped `authorization.grant` may update those grants within their delegated authority. An upgrade succeeds admission only when all required bindings and delegation approvals are present; otherwise it fails before rollout and may be retried after they are supplied.
+
+MCP endpoints are mesh-internal by default. External invocation uses the deployment ingress and the same authorization service. Direct package egress defaults to deny and is managed by deployment policy rather than release metadata.
+
+### Workflows
+
+Packages publish immutable workflow definitions, not workers. The revision controller registers promoted definitions with a workflow MCP service in the mesh. Each execution records its definition digest, actor, workflow identity, and compatible operation-contract digests.
+
+The workflow service runs each execution against its pinned definition until completion, migration, or documented retirement. New executions use the promoted workflow catalog generation. Removal and incompatible upgrades account for queued work, retries, timers, and long-running executions.
+
+Every workflow operation is authorized at execution. Selecting an organization-managed service account as a workflow identity requires `service_account.assign`. The triggering actor remains in the audit and delegation chain.
+
+### Catalogs and Administration
 
 An organization deployment provides:
 
@@ -281,12 +324,14 @@ An organization deployment provides:
 - A workflow catalog
 - A dependency graph
 - Package revisions, rollout and migration status, identities, and authorization settings
-- API-grant management
+- API grant management
 - A development sandbox
 
-Candidate metadata may be visible to administrators, but user-facing callable catalogs expose only contracts safe for the currently propagated routes. Routing is updated first because xDS propagation is asynchronous; newly added contracts become discoverable only after the frozen proxy cohort acknowledges the routing generation. Both revisions remain contract-compatible until old routes drain. Each invocation, including an SSE stream, resolves once and remains pinned to one package revision.
+Administrative catalogs may expose candidate metadata. Callable catalogs are keyed to the converged routing generation and expose new contracts only after the promotion and synchronization requirements in [Revision Rollouts](#revision-rollouts) are satisfied.
 
-Organization administrators can connect registries and install, upgrade, roll back, or remove packages. Package developers can build, publish, test, and invoke packages. Package users see only catalogs and operations authorized for them.
+Clients treat catalogs as snapshots. Invocation remains authoritative and may reject stale or undeclared operations under the rules in [Dependencies and Contracts](#dependencies-and-contracts).
+
+Organization administrators can connect registries and install, upgrade, roll back, or remove packages. Package administrators can perform revision and administration actions within their delegated package and authorization scope. Package developers can build, publish, test, and invoke packages. Package users see only catalogs and operations authorized for them.
 
 Representative endpoints:
 
@@ -295,9 +340,9 @@ Representative endpoints:
 - Administration: `https://vt.valon.tools/admin`
 - Package administration: `https://vt.valon.tools/packages/<package>/admin`
 
-Management APIs use a private listener or equivalent network restriction and require stronger authorization than user invocation endpoints.
+Management APIs require dedicated administrative permissions and should use a private listener or equivalent network controls where practical.
 
-## Invocation
+### Invocation
 
 Authorized operations are available over the deployment endpoint and through the CLI:
 
@@ -305,48 +350,29 @@ Authorized operations are available over the deployment endpoint and through the
 vt invoke --deployment <url> <package> <operation> --args <json>
 ```
 
-Authentication comes from an interactive session, keychain, environment, or standard input. Secrets and tokens are not positional command arguments.
+Authentication comes from an interactive session, keychain, environment, or standard input. Positional arguments never carry secrets or tokens.
 
-Operation invocation uses MCP Streamable HTTP. Clients and packages support JSON-RPC over POST and the protocol's JSON and SSE response forms. The gateway enforces request size, timeout, rate, and stream-lifetime policy.
+Invocation uses MCP Streamable HTTP: JSON-RPC over POST with JSON or SSE responses. The gateway enforces request size, timeout, rate, and stream lifetime.
 
-Ingress strips externally supplied internal-identity headers. It exchanges user credentials for a short-lived, audience-bound internal invocation token containing the original actor, effective subject, immediate calling workload, delegation chain, target package and operation, issued/expiry times, nonce, and trace ID. Packages never forward raw user bearer tokens or API keys.
+Ingress strips externally supplied internal-identity headers and exchanges user credentials for a short-lived, signed internal invocation token. The token is bound to its issuer, audience, target package, and operation and carries a unique ID, issuance, not-before, and expiry times, the original actor, effective subject, immediate caller workload identity, delegation chain, and trace ID. Signing keys rotate with an overlap window for in-flight requests. Packages never receive or forward raw user bearer tokens or API keys.
 
-The authorization decision intersects:
+Authorization is enforced at two surfaces:
 
-- The authenticated calling workload's permission to invoke the target
+- **Ingress gateway**: user invocation, catalogs, package administration, and package revision APIs. The gateway's `ext_authz` filter calls the authorization service before forwarding to control-plane or package services.
+- **Destination waypoint**: package-to-package MCP calls are checked before forwarding to the MCP server. Waypoint enforcement is described in [Runtime Architecture](#runtime-architecture).
+
+Both surfaces use one authorization service and relationship graph. Checks use the immediate caller workload identity, effective subject, target package, and operation for MCP traffic; management checks use the actor and requested revision or administration action.
+
+For MCP invocation, the authorization decision intersects:
+
+- The authenticated caller workload identity's permission to invoke the target
 - The effective subject's permission
-- The installed package's approved operation policy
+- The installed package's approved operation access policy
 - Any operation-specific resource authorization
 
-Unknown identities, packages, operations, policies, or authorization-provider outages deny access.
+Credential scope and every applicable relationship check must allow the request. The decision records the policy model ID and revision. Unknown identities, packages, operations, policies, or authorization-provider outages deny access.
 
-## Authentication and Authorization
-
-- Users authenticate through an external identity provider with organization-level SSO, issuer and tenant allowlists, and session revocation.
-- API keys are named, expiring, scoped API grants that act on behalf of an owner. Only hashes are stored, plaintext is returned once, and empty scope does not mean unrestricted access.
-- Users create service accounts only with an attenuated subset of authority and explicit expiry or organization policy.
-- Every installation has organization-owned workload and workflow identities.
-- Every invocation is centrally authorized before dispatch; package-specific resource checks may further restrict it.
-- Production does not start in a fail-open mode when identity or authorization is unavailable.
-
-Authorization uses a Zanzibar-style graph. Relationship definitions declare whether they support delegated assignments, persistent grants, both, or neither. The default is neither.
-
-- **Delegated assignment (`delegatable`)**: a holder with `can_delegate_<relationship>` may create a child assignment that cannot exceed or outlive its parent.
-- **Persistent grant (`grantable`)**: a principal with `can_grant_<relationship>` may create an independent assignment that remains until explicitly revoked.
-
-An assignment is a first-class record containing an immutable ID, organization, subject, relationship, resource, mode, issuer, creation and optional expiration, optional parent assignment, policy revision, and revocation state. Delegation has bounded depth, acyclic ancestry, transactional creation, and cascading invalidation. Independent valid paths preserve access after one path is revoked.
-
-Authorization caches and delegated invocation tokens have bounded lifetimes. Revocation has a documented maximum propagation time and applies to long-lived streams and each workflow step. Security events are written to an immutable audit sink outside package-controlled storage.
-
-## Configuration, Secrets, Ingress, and Egress
-
-Release manifests declare typed requirements, not concrete secret values or unrestricted secret names. Administrators bind them to organization-owned configuration and secret-manager objects. Secret access is granted only to the installation or migration workload identity and uses short-lived retrieval where possible.
-
-Capability expansion on upgrade requires renewed approval. Expansion includes new authorization relationships, identities, secrets, public routes, egress destinations, migration permissions, or caller delegation. Capability reduction may be automatically accepted under organization policy.
-
-Every endpoint is classified as public, organization-authenticated, mesh-internal, or management-only. Egress is deny-by-default and explicitly grants destination, port, protocol, TLS/SNI, DNS, and credential behavior.
-
-## Development Sandbox
+### Development Sandbox
 
 `vt dev` builds a local package and connects it only to an explicitly enabled per-user sandbox:
 
@@ -354,106 +380,218 @@ Every endpoint is classified as public, organization-authenticated, mesh-interna
 vt dev --deployment <url> <dir>
 ```
 
-Authentication uses the normal interactive or keychain flow. The platform issues a short-lived development workload identity distinct from the user's identity. Development routing is scoped to the developer or named test session and cannot take over a production package slug.
+Authentication uses the normal interactive or keychain flow. The platform assigns a short-lived development workload identity distinct from the user. Routes are scoped to the developer or named test session and cannot claim a production package slug.
 
 Development packages:
 
-- Receive no production traffic by default
+- Receive traffic only from their developer or explicitly named test sessions and never become the default production route
 - Cannot run migrations
-- Cannot access production secrets
-- Cannot forward caller credentials
-- Use sandbox-scoped authorization and egress
+- Cannot receive or forward raw caller credentials
+- Do not inherit the production workload's permissions
+- Use sandbox-scoped authorization
 - Expire automatically and are audited on connect and disconnect
 
-## Runtime Architecture
+## Platform Architecture
+
+### Deployment Tiers
+
+The platform separates deployment into three trust and lifecycle tiers:
+
+1. **Bootstrap substrate**: Kubernetes and Istio, the control-plane state store, revision controllers, certificate authority, and backup and recovery tooling. Terraform deploys these components before package APIs are available.
+2. **Protected system packages**: identity, authorization, secret management, registry verification, audit, and workflow execution. After the bootstrap substrate is healthy, revision controllers install and upgrade these services using signed releases and the normal immutable revision and rollout machinery.
+3. **Ordinary organization packages**: packages installed by authorized organization or package administrators and constrained by organization policy.
+
+Protected system packages have fixed canonical identities, trusted-signer allowlists, dedicated platform workload identities, protected names and routes, and platform-only revision permissions. They cannot grant themselves authority, be replaced by an ordinary package, or be removed through ordinary package APIs. Infrastructure configuration pins the initial system-package releases and bootstrap order; after identity and authorization are available, subsequent changes require normal platform authorization.
+
+The bootstrap substrate and protected system packages are both inside the platform availability boundary. If a required component in either tier is unavailable, the affected capability is counted as platform downtime even when some existing package traffic continues. For example, a registry-verification outage is publishing and installation downtime, while an identity or authorization outage may prevent new requests without immediately terminating established connections. An ordinary package failure counts as downtime for that package, not for the platform, unless a platform defect caused or spread the failure.
+
+### Trusted Platform Services
+
+The bootstrap substrate and protected system packages provide these trusted services:
+
+- **Identity service**: authenticates sessions and API grants, resolves canonical principals, manages organization service accounts, and issues short-lived internal invocation tokens.
+- **Authorization service**: stores immutable policy models, grants, assignments, and revocations and evaluates provider-independent and Envoy `ext_authz` checks.
+- **Secret-management service**: stores and rotates platform and connection credentials and releases secret material only to explicitly authorized workload identities.
+- **Registry-verification service**: retrieves registry metadata and verifies origins, manifests, digests, signatures, platform compatibility, and the registry trust policy before admission.
+- **Audit sink**: accepts append-only security, authorization, administration, and runtime events in storage that packages cannot control.
+- **Workflow service**: registers promoted package-defined workflows and runs pinned executions outside package runtimes.
+- **Control-plane state store**: a bootstrap-substrate service that durably stores registries, package slots, revision requests and operations, routing and catalog generations, migration outcomes, and recovery metadata.
+
+The Istio control plane provides the certificate authority and workload-certificate lifecycle. Backup and recovery tooling protects control-plane state and trusted-service configuration but does not sit on the request path.
+
+Each trusted service exposes a versioned typed API. Control-plane clients use shared libraries for workload authentication, canonical caller context, deadlines, bounded retries, idempotency keys, metrics, tracing, and audit metadata. Istio provides service discovery, mTLS, and network routing, so the first implementation does not add a generic control-plane proxy.
+
+### Runtime Architecture
+
+Production uses Istio ambient mode. `ztunnel` provides L4 transport security and workload identity, while waypoint proxies provide L7 routing and authorization. Sidecars are not planned for the first implementation.
 
 The runtime consists of:
 
-- **Istio control plane (`istiod`)**: distributes routing, policy, endpoint, and certificate configuration to the Istio data plane.
-- **Istio workload data plane**: Envoy sidecars mediate inbound and outbound workload traffic. Ambient mode, using mandatory node-level `ztunnel` proxies and optional L7 waypoint proxies, is a possible later deployment mode; a deployment uses one documented mode at a time.
-- **Ingress gateways**: separate Envoy data-plane proxies terminate external transport, remove untrusted identity headers, authenticate supported credentials, and route public and organization traffic.
-- **Egress gateways**: separate Envoy data-plane proxies enforce and audit declared external network access where direct egress cannot be safely allowed.
-- **Package supervisor (`gestaltd`)**: runs alongside one package installation, mediates application-level invocation and authorization, reports observed state, and manages the package process. It is not an Istio data-plane proxy and does not replace Envoy.
-- **Package runtime**: runs the package's MCP server, interfaces, and workflow workers.
-- **Revision controllers**: reconcile durable install and rollout records into workloads, routing, catalogs, identities, and policy.
+- **Istio control plane (`istiod`)**: distributes routing, policy, endpoint, and certificate configuration.
+- **`ztunnel`**: mandatory node proxies providing L4 transport security and workload identity.
+- **Waypoint proxies**: shared Envoy proxies providing L7 routing, telemetry, and authorization for destination Kubernetes Services.
+- **Ingress gateways**: terminate external transport, remove untrusted identity headers, authenticate credentials, enforce `ext_authz`, and route public and organization traffic.
+- **Egress gateways**: enforce and audit organization-declared external access that cannot safely use direct egress.
+- **Package supervisor (`gestaltd`)**: runs beside an installation, manages its process lifecycle and local invocation, and reports observed state. It is not an Istio proxy.
+- **Package runtime**: runs the package's MCP server and serves its interfaces.
+- **Protected system packages**: provide identity, authorization, secrets, registry verification, audit, and workflow execution as defined above.
+- **Control-plane state store**: provides durable state for trusted services and revision controllers as part of the bootstrap substrate.
+- **Revision controllers**: reconcile durable revision requests and rollout state into workloads, routing, catalogs, identities, and policy.
 
-Production uses Istio `PeerAuthentication` in `STRICT` mode for mesh mutual TLS, Istio `AuthorizationPolicy` for workload-to-workload policy, and Kubernetes `NetworkPolicy` for network reachability. The deployment installs explicit default-deny authorization and network policies; these mechanisms are not assumed to deny traffic merely because they are enabled. Package application ports are reachable only through the mesh data plane. Health and supervisor administration ports have explicit, minimal exceptions and are not exposed through public ingress.
+Revision controllers use trusted-service APIs and the Kubernetes API to create or update Deployments, Services, waypoint enrollment, routes, traffic weights, and `AuthorizationPolicy` resources. `istiod` watches the Kubernetes and Istio resources, translates the desired state into xDS configuration, and distributes it to ingress gateways, waypoints, and `ztunnel`. Proxies acknowledge the configuration they receive; revision controllers observe synchronization for the target routing generation before advancing callable catalogs.
 
-Established data-plane traffic continues using the last known configuration when `istiod` is unavailable. New revision operations that require routing, certificates, policy, or registry verification fail closed until their control-plane dependencies recover.
+Istio keeps workload endpoints, routing, certificates, and mesh-policy configuration synchronized. It does not own or synchronize package revision state, authorization grants, workflow executions, or catalogs. Those remain the responsibility of revision controllers and trusted platform services. Package operation invocations remain on the mesh data plane and use ingress or destination-waypoint authorization.
 
-Terraform deploys the GCP infrastructure, including the Valon Tools cluster, GitHub Actions cluster, networking, container infrastructure, identity services, and deploy-pinned trusted components. Installing packages does not mutate this trusted computing base.
+`ztunnel` cannot enforce L7 authorization. MCP, revision, and administration checks therefore run at ingress gateways or destination waypoints. Kubernetes Services exposing MCP servers enroll in a waypoint, where revision controllers attach `AuthorizationPolicy` `CUSTOM` rules.
 
-## Mesh Deployment
+Production uses `ztunnel` for transport security and L4 workload authorization, Kubernetes `NetworkPolicy` for reachability, and ingress or waypoint `ext_authz` for application authorization. Authorization checks fail closed on denial or outage. Only the mesh data plane can reach package application ports; health and supervisor administration ports have minimal explicit exceptions and no public ingress.
 
-The mesh is redeployed only when changing deploy-pinned infrastructure, including:
+If `istiod` is unavailable, established traffic uses its last configuration. New revision operations requiring routing or policy changes fail closed until dependencies recover.
 
-- `istiod` and Istio data-plane versions
-- `gestaltd` supervisor versions
-- Ingress and egress gateways
-- Identity, authorization, certificate, secret, audit, state-storage, registry-verification, or recovery services
+Terraform manages the bootstrap substrate, including clusters, networking, container infrastructure, state storage, revision controllers, certificate authority, and recovery tooling. Package installation does not mutate this substrate.
 
-Package releases declare compatible `gestaltd` and mesh protocol ranges. Infrastructure rollouts account for old and new runtime cohorts before admitting a package release that requires new capabilities.
+### Infrastructure and Service Rollouts
 
-Installing, upgrading, rolling back, or removing packages is a runtime change and does not require mesh redeployment. Connecting or disconnecting a registry is durable control-plane state and does not require redeployment, but changing registry trust roots remains a separately authorized and audited action.
+The mesh is redeployed only for changes to Istio or its trust and extension configuration, including:
 
-## Retention and Audit
+- `istiod`, `ztunnel`, and waypoint proxy versions
+- Ingress and egress gateway versions or deploy-pinned configuration
+- Istio certificate-authority and trust-domain configuration
+- Mesh-wide extension-provider and ambient-enrollment configuration
 
-Immutable release metadata, attestations, and accepted revision history are retained permanently or according to organization audit policy. Blob retention is separate:
+Protected system packages roll independently through the revision controller and do not require a mesh redeployment. Ordinary package revisions, registry connection changes, identity assignments, and authorization-binding updates likewise change runtime or control-plane state without redeploying the mesh. `gestaltd` supervisor updates roll with the workloads that use them.
 
-- Unused releases expire after a configurable window
-- Running, admitted, and rollback-eligible revisions retain all required blobs
-- Historical revisions retain blobs through a configurable recovery window
-- Expired historical blobs may be garbage-collected while metadata and audit history remain
+Bootstrap-substrate changes, including control-plane state migrations and backup or recovery tooling, use infrastructure rollouts but do not redeploy the mesh unless they also change an Istio item listed above. Package releases declare compatible `gestaltd` and mesh protocol ranges, and infrastructure rollouts account for overlapping old and new versions before admitting releases that require new features. Registry trust-root changes remain separately authorized and audited.
 
-OCI garbage collection is reference-aware because layers may be shared. Pruning is serialized with admission and rechecks eligibility immediately before deletion.
+## Representative Request Lifecycles
 
-Audit events include authentication, API-grant lifecycle, certificate issuance, authorization decisions, assignment mutation, delegated identity use, registry and trust-policy changes, publish/install/upgrade/rollback/removal, migration execution, secret access, ingress/egress denial, and development injection. Events include actor, effective subject, calling workload, target, policy revision, decision reason, trace ID, and `releaseDigest`.
+The following lifecycles show how representative registry, management, and data-plane requests move through the system.
 
-## Required Verification
+### Create a Registry
+
+Registry creation is a registry-side operation and is distinct from connecting that registry to an organization. The reference registry-creation service and CLI are convenience tools, not gatekeepers; operators may instead use the underlying libraries or build any compatible implementation.
+
+1. A registry operator uses the reference tooling or an independent implementation to provision a protocol-compatible registry and durable metadata store. The registry uses OCI 1.1 storage—Google Artifact Registry by default—for content-addressed images, manifests, and signature bundles.
+2. The registry generates one immutable `registryId`. The identifier scopes package and release identities and must be unique among registries connected to the same platform deployment.
+3. The operator configures discovery and download visibility, publisher authentication, who may create packages, and who may publish versions to each package. The reference tooling may also configure optional GitHub listeners or other publication triggers.
+4. The operator configures the registry's publisher policy by registering publisher identities, their public keys, and the package IDs each key may sign. The reference tooling may provision KMS-backed signing keys, but private keys remain publisher-controlled and are never stored by the registry.
+5. The registry publishes a descriptor matching the required schema, including its protocol version, `registryId`, API endpoints, and supported signature formats, through its well-known metadata endpoint.
+6. Readiness checks verify metadata and blob durability, digest validation, authentication, authorization, and signature enforcement before the registry accepts publication or discovery traffic.
+
+### Connect a Registry
+
+1. An organization administrator submits the registry's HTTPS origin, optional read credentials for a private registry, and a registry trust policy binding trusted publisher identities and public keys to package IDs.
+2. The ingress gateway authenticates the actor, removes untrusted identity headers, and calls the authorization service through `ext_authz`. The request proceeds only when the actor has the required registry-management permission.
+3. The registry-verification service connects through the permitted egress path and reads the registry's protocol version, immutable `registryId`, API endpoints, catalog, and signature bundles. Remote content remains untrusted.
+4. The control plane rejects a `registryId` already bound to a different origin or an origin already bound to a different `registryId`. It stores any read credentials through the secret-management service and persists the verified registry identity and initial registry trust policy revision.
+5. After verification succeeds, the control plane marks the registry connected and advances the registry catalog generation. Packages become discoverable, but each release must still pass admission checks before installation.
+6. The API returns the registry record and verification status. Failures preserve diagnostics without making the registry available for discovery or installation.
+
+### Publish a Package Release
+
+1. A developer or CI job authenticates directly to the registry with its own publishing credential and runs `vt build <dir> --push`.
+2. `vt` validates the package metadata, builds the platform images and OCI image index, creates the canonical release manifest, and calculates its `releaseDigest`.
+3. The registry authorizes the publisher to reserve `(packageId, releaseVersion)` and creates a recoverable publish-attempt ID. A version already bound to a different digest is rejected.
+4. `vt` uploads content-addressed image blobs, the image index, and the release manifest. The registry recalculates digests and validates platform images and release contracts before making anything discoverable.
+5. The publisher signs a statement containing the `registryId`, `packageId`, `releaseVersion`, `releaseDigest`, and image-index digest with an authorized KMS-backed key, then uploads the signature bundle.
+6. The registry verifies the signature and confirms under its publisher policy that the signing key may publish the package. It then atomically binds the version to the digest and adds the release to the package catalog.
+7. The registry returns the immutable `releaseDigest`. Failed or interrupted attempts remain non-installable and may be retried; publishing does not install or deploy the release.
+
+### Upgrade a Package
+
+1. An organization or package administrator selects a target `releaseDigest` for an installed package and submits a durable upgrade revision request with any approved identity or authorization changes.
+2. The ingress gateway authenticates and authorizes the actor. The control plane verifies any required `service_account.assign` and `authorization.grant` permissions.
+3. The control plane appends the revision request, verifies that no revision operation is active for the installation, and creates a generation-fenced revision operation. The API returns the operation ID so the client can observe progress asynchronously.
+4. The revision controller verifies the recorded registry trust policy revision, release and image signatures, platform and runtime compatibility, schemas, dependencies, reverse dependents, workflows, and migrations against the recorded desired-state snapshot.
+5. The controller runs declared prepare migrations, creates the immutable candidate Deployment and revision-specific Service, and applies ambient data-plane enrollment and the required `AuthorizationPolicy` attachments. The candidate initially receives no production traffic.
+6. After readiness remains stable, the controller may canary operations whose contracts exactly match the promoted revision. Promotion then updates primary routing and waits for every currently live relevant ingress gateway and destination waypoint to remain synchronized with the target xDS generation for the configured stability window.
+7. The callable catalogs advance only after routing converges. The previous revision drains pinned requests and streams while the controller observes the promoted revision and runs any separately approved finalization.
+8. The controller records the terminal outcome. A pre-promotion failure leaves the previously promoted revision primary.
+
+### Invoke a Package Operation
+
+1. An external caller sends an MCP Streamable HTTP request to the deployment endpoint with a session credential or API grant, the target package and operation, and JSON arguments.
+2. The ingress gateway authenticates the credential, removes untrusted internal-identity headers, applies request limits, and calls the authorization service through `ext_authz`.
+3. The authorization service evaluates the credential scope, immediate caller workload identity, effective subject, target installation, canonical operation ID, approved package access policy, and any operation-specific resource against one policy generation. An unknown target or denied check fails before dispatch.
+4. The gateway exchanges the external credential for a short-lived, signed internal invocation token bound to the target audience, package, and operation, then resolves the request to one callable revision. That resolution remains pinned for the lifetime of the invocation.
+5. The mesh routes the request to the selected revision-specific Service.
+6. The package supervisor dispatches the operation to the package runtime. The runtime returns one JSON-RPC response or opens an SSE stream; an open stream remains on the selected revision while that revision drains.
+7. The response returns through the mesh and ingress gateway. The platform records the authorization decision, policy model ID and revision, actor, effective subject, immediate caller workload identity, target, `releaseDigest`, internal token ID, trace ID, duration, and outcome.
+
+Package-to-package invocation does not pass through ingress. The calling package presents a platform-issued internal invocation token to the destination waypoint, which performs the corresponding workload and effective-subject authorization checks before revision routing and dispatch. Raw caller credentials are never forwarded.
+
+## Assurance
+
+### Retention and Audit
+
+Release metadata, accepted revision history, and audit events are retained according to applicable policy. Registries and platform-owned artifact storage retain blobs required by active revisions or the configured rollback window. Unreferenced blobs may be garbage-collected after a grace period; shared OCI layers are deleted only after references are rechecked.
+
+Authentication, authorization, registry, package-lifecycle, migration, secret-access, and network-policy events are written to the immutable audit sink with the actor, target, decision, relevant identifiers, trace ID, and outcome.
+
+### Required Verification
 
 Before production use, automated tests cover:
 
-- Create-only and atomic publication, concurrent publishers, and stale attempts
-- Signature, provenance, trust-policy, platform, and runtime compatibility failures
-- Install and upgrade validation failures writing no admitted revision
-- Concurrent administrator and controller fencing
-- Controller failure and restart at every revision phase
-- Migration idempotency, lease loss, and incompatible rollback declarations
-- Dependency and reverse-dependent races
-- Canary failure, routing/catalog generation safety, draining, and SSE behavior
-- Registry disconnection, mirror rebinding, and blob-prune concurrency
-- Removal cleanup, tombstones, and retained workflow executions
-- Authorization outage, confused-deputy attempts, delegation attenuation, and revocation propagation
-- Multi-replica convergence and old/new infrastructure cohort overlap
+- **Registry and release integrity**: atomic publication under retries and concurrency, signature and compatibility rejection, and safe disconnection and garbage collection
+- **Revision state machines**: validation failures, administrator, controller, and dependency races, restart at every phase, and migration idempotency and lease loss
+- **Rollout and recovery**: canary and promotion failures, routing and catalog convergence, draining and SSE behavior, rollback approval, removal, tombstones, retained workflows, autoscaling, and mixed versions
+- **Platform lifecycle**: bootstrap ordering and outages, protected identities and signers, ordinary-package replacement prevention, and independent infrastructure and system-package rollouts
+- **Authorization models**: deterministic policy publication, active-grant preservation, subject-set cycles, and parity between batch and individual checks
+- **Identity and delegation**: spoofing, claim validation, token expiration and rotation, `runAs`, confused-deputy prevention, attenuation, and revocation
+- **Fail-closed enforcement**: authorization outages, data-plane bypass attempts, and ingress or waypoint `ext_authz` failures
 
 ## Glossary
 
-**package identity**  
-Permanent `(registryId, packageId)` for a published package. Assigned when the package is reserved; never reused.
+**package identity**<br>
+Permanent `(registryId, packageId)` for a registry package. Assigned when the package is reserved; never reused.
 
-**release**  
+**release**<br>
 Immutable, signed artifact for one `releaseVersion` of a package, identified by `releaseDigest`.
 
-**releaseVersion**  
-Registry-assigned label for one published release of a package. `(registryId, packageId, releaseVersion)` binds permanently to one `releaseDigest`.
+**releaseVersion**<br>
+Registry-scoped version label for one published release of a package. `(registryId, packageId, releaseVersion)` binds permanently to one `releaseDigest`.
 
-**releaseDigest**  
-Content hash of the canonical release manifest bytes. The authoritative install input; signatures and attestations bind to it.
+**releaseDigest**<br>
+Content hash of the canonical release manifest bytes. The authoritative install input; signatures bind to it.
 
-**revision**  
+**revision**<br>
 One installed state of a package in an organization, backed by a specific `releaseDigest`.
 
-**revision request**  
+**revision request**<br>
 Durable intent to install, upgrade, rollback, or remove a package.
 
-**revision operation**  
+**revision operation**<br>
 Generation-fenced state machine that executes one revision request.
 
-**revision controller**  
+**revision controller**<br>
 Background worker that drives a revision operation to completion and resumes after failure.
 
-**rollout**  
-Staged path from admission through canarying and promotion for an install or upgrade candidate.
+**rollout**<br>
+Path from admission through readiness, optional canarying, and promotion for an install or upgrade candidate.
 
-**promotion**  
-Makes a revision primary for routing and user-facing catalogs.
+**promotion**<br>
+Makes a revision primary for routing; callable catalogs advance only after routing convergence.
+
+**authorization model**<br>
+Immutable, content-hashed definition of resource types, relations, actions, and allowed relationship targets used for one generation of authorization decisions.
+
+**relationship tuple**<br>
+An assignment of a subject, resource, or subject set to one relation on a resource.
+
+**internal invocation token**<br>
+Short-lived signed context that carries verified caller and delegation information and is bound to its intended audience, package, and operation.
+
+**bootstrap substrate**<br>
+Infrastructure that must exist before package APIs are available, including Kubernetes, Istio, control-plane state, revision controllers, certificate authority, and recovery tooling.
+
+**protected system package**<br>
+A trusted, signer-pinned package that uses normal revision rollouts but has a fixed platform identity and cannot be replaced or removed through ordinary package APIs.
+
+**waypoint**<br>
+Shared Envoy proxy that enforces L7 routing and authorization for Kubernetes Services exposing packages in ambient mode.
+
+**workflow service**<br>
+MCP service in the mesh that registers package-defined workflows and executes them outside package processes.
+
+**ztunnel**<br>
+Node-level ambient proxy that provides L4 transport security and workload identity for enrolled pods.

--- a/plans/service_mesh/plan.md
+++ b/plans/service_mesh/plan.md
@@ -3,6 +3,7 @@
 ## Contents
 
 - [Overview](#overview)
+- [Registries](#registries)
 - [Foundations](#foundations)
 - [Publishing and Distribution](#publishing-and-distribution)
 - [Package Revisions](#package-revisions)
@@ -11,6 +12,7 @@
 - [Representative Request Lifecycles](#representative-request-lifecycles)
 - [Assurance](#assurance)
 - [Glossary](#glossary)
+- [Appendix: Design Invariants](#appendix-design-invariants)
 
 ## Overview
 
@@ -20,149 +22,196 @@ The platform builds, distributes, installs, and runs packages in a shared servic
 - One or more single-page user interfaces
 - Durable workflow definitions
 - Dependency and migration metadata
-- Runtime and operation-authorization requirements
+- Per-operation authorization relationship or role requirements
 
-Each package runtime Pod includes a platform-owned supervisor sidecar that gates readiness and shutdown, exposes the mesh listener, and reports observed runtime state. Kubernetes starts and terminates the sibling runtime container. UI-only and workflow-only packages do not create runtime Pods.
+The platform should enable the following user experiences.
 
-Each organization operates one deployment backed by a private registry and optional trusted registries. The deployment exposes catalogs of installed packages, callable operations, user interfaces, workflows, and dependencies.
+### Organization Administrator
 
-Publishing makes a release discoverable. Installation admits an immutable release into an organization. Canarying permits controlled, undiscoverable traffic. Routing and external registrations converge before promotion atomically makes an installed revision primary and exposes its catalog generations. These milestones are separate and must not be inferred from one another.
+An organization administrator can:
 
-This design is a full replacement for the existing Gestalt implementation. It does not preserve the existing provider runtime, package archive, registry, deployment, authorization, or workflow protocols, and it does not define an in-place migration. Feature names shared with the existing system do not imply wire-format or state compatibility.
+- Operate one deployment, private registry, and administration surface, such as `https://vt.valon.tools`, `/registry`, and `/admin`.
+- Configure source automation to build and publish packages from GitHub branches, pull requests, or label-based rules.
+- Configure read-only upstream registry sources and pull trusted releases into the private registry.
+- Browse installed apps as a graph, including operations, UIs, workflows, dependencies, versions, identities, and authorization.
+- Open an app administration page, change its version, or install and remove it.
 
-## Foundations
+### Package Publisher
 
-### Design Invariants
+A publisher can:
 
-The following invariants apply to every implementation:
+- Define package metadata, operations, dependencies, workflows, UIs, and migration jobs in a source manifest.
+- Run `vt build <dir>` and optionally push the result directly to the deployment registry.
+- Use repository automation instead of pushing manually.
+- Run `vt dev --deployment <url> <dir>` to test a package in an isolated, user-scoped mesh sandbox before publishing it.
 
-1. A published release is immutable and identified by its `releaseDigest`.
-2. A deployment records every accepted install, upgrade, rollback, and removal request in an append-only revision history.
-3. For each canonical package identity in an organization, only one revision operation — install, upgrade, rollback, or removal — may be in progress at a time.
-4. Durable revision requests record intent; revision controllers perform runtime work and resume safely after process failure.
-5. Registry publication, revision-operation phase, live workload health, routing promotion, and catalog convergence are tracked separately.
-6. A pre-promotion failure does not replace the last successfully promoted revision.
-7. Routing propagation is eventually consistent, so every revision that may receive traffic remains contract-compatible with operations referenced by installed reverse dependencies until propagation and draining finish. New contracts become visible only after routing convergence. A candidate may omit an operation when no installed package or workflow definition or execution retained by policy references it; stale or undeclared calls to that operation may fail after promotion.
-8. Packages run only under organization-provisioned identities; release metadata may define access requirements but cannot grant authority.
-9. Ordinary packages cannot replace components needed to administer the platform. Identity, authorization, workflow execution, secret management, registry verification, and audit may be implemented only by protected system packages; certificates, state storage, revision control, and recovery remain part of the bootstrap substrate.
-10. Every externally supplied manifest, image, schema, and migration is untrusted until its digest, signature, and policy are verified.
-11. Every authorization decision uses canonical identities and one immutable policy generation. Grants change only through explicit authorized actions; policy-model changes cannot silently delete or orphan them.
-12. Raw user credentials and caller-supplied identity fields never cross into package runtimes. Internal caller context is short-lived, signed, and bound to its intended audience and target.
+Migration jobs should be retry-safe and reversible where practical. Explicitly approved one-time jobs are supported when idempotency is impossible; their durable outcome prevents accidental re-execution.
 
-### Identity Model
+### Package Administrator
 
-The system keeps these identities separate:
+A package administrator can:
 
-- **Registry identity**: an immutable self-certifying `registryId` derived from the registry's offline root public key. The identifier is globally stable for that registry but does not imply endorsement by, or membership in, a central registry namespace. Signed registry descriptors authorize the current origin set and origin changes.
-- **Package identity**: permanent `(registryId, packageId)` assigned when the package is reserved. A slug is a mutable display and discovery alias, never a security identifier.
-- **Release identity**: `(registryId, packageId, releaseVersion, releaseDigest)`.
-- **Installation identity**: an organization-scoped UUID representing one installed package.
-- **Workload identity**: the installation principal used in authorization checks for one installation's runtime or migration job, bound at installation to an organization-managed Kubernetes service account.
-- **Workflow identity**: the principal assigned to a workflow definition or execution.
-- **Actor identity**: the user, API grant, platform service account, or workflow that initiated an action.
-- **Effective subject**: the principal whose delegated authority an invocation exercises.
+- Inspect an app and its deployment details.
+- Manage its desired version within their package-scoped authority.
+- Invoke any app operation they are authorized to use.
+- Promote releases from the private registry manually or through deployment rules.
+- Perform the first installation that admits a package into the mesh.
+- Select organization-managed identities for runtimes, migrations, and workflows.
+- Decide whether an operation runs only as its workload identity or may exercise explicitly delegated caller authority.
+- Bind each permission as either a durable grant or delegated authority.
 
-Authentication resolves a credential to one canonical principal before authorization. Gateways remove caller-supplied internal identity fields, and downstream services accept identity only from verified workload identity or signed internal context. Delegation keeps the actor and effective subject distinct throughout authorization and audit.
+A durable grant cannot exceed the human issuer's authority when created and remains until explicitly revoked, expired, or invalidated by a policy migration. Delegated authority is bounded by the subject's current authority and narrows immediately when that authority is lost.
 
-Package IDs are never reused. Slug renames retain aliases and tombstones. Content published under a different registry receives a distinct package identity, even when the release bytes are identical.
+Package administration and publishing are independent roles, although the same person may hold both. Publishing, installation, and promotion remain separate actions.
 
-Release metadata cannot name workload identities or Kubernetes service accounts. Runtime identities and authorization bindings are selected from organization-managed resources during installation.
+### Package User
 
-## Publishing and Distribution
+A package user can:
 
-### Package Releases
+- Open a deployment and browse only the apps, operations, UIs, and workflows they are authorized to see.
+- Launch an app UI or invoke an operation through MCP Streamable HTTP or `vt invoke`.
+- Manage their API grants and use a development sandbox when authorized.
+- Use these capabilities without access to organization or app administration surfaces.
 
-Each `(registryId, packageId, releaseVersion)` has one release manifest with detached signatures. A release with a runtime declares one or more OS, architecture, and optional variant tuples and references an OCI runtime image index covering them.
+## Registries
 
-Runtime and migration images may contain platform-specific binaries, but contracts, dependencies, workflow definitions, user interfaces, and operation access requirements are shared across all supported platforms.
+The registry protocol is open. Anyone may operate a compatible registry; there is no central creation or approval authority.
 
-The release manifest contains:
+### Deployment Registry
 
-- Canonical registry and package IDs, slug, and `releaseVersion`
-- Optional OCI runtime image-index digest, supported platforms, startup instructions, and probe contract
-- Zero or more digest-addressed migration image indexes with their supported platforms
-- Zero or more MCP operations with input and output schema digests
-- Zero or more digest-addressed workflow definitions and UI bundles
-- Required and optional package and operation dependencies
-- Ordered prepare, finalize, and compensating migration jobs
-- Required authorization relationships or roles for each operation
-- Supported MCP protocol versions and private runtime control API versions
-- Minimum and maximum compatible package-supervisor versions
-- Optional source repository URL and source revision
+Each deployment has exactly one registry and uses it as the sole package catalog and artifact source. Installation, upgrade, rollback, and recovery never fetch directly from an external registry.
 
-The registry stores signatures separately from the manifest. Each signature identifies the exact release or image digest it covers.
+Releases enter through:
 
-Source repository and revision are optional display metadata. Publication must support releases without either field; when present, catalogs and administration views may use them for links and context.
+- **Push**: an authorized publisher uploads a release created for the deployment registry. Publication credentials grant only the permitted package and release actions.
+- **Pull-through import**: an administrator imports an external release using read-only upstream authorization. The registry verifies and stores the complete release locally before exposing it.
 
-The `releaseDigest` is the hash of the canonical manifest bytes. Catalog entries, signatures, and installation records carry it; the manifest does not.
+### Build
 
-`releaseVersion` follows a documented registry grammar and comparison order. `(registryId, packageId, releaseVersion)` binds permanently to one `releaseDigest`: conflicting republications fail, while identical retries are idempotent and preserve publication time and metadata. Mutable tags may aid discovery but are never installation inputs.
+Publishers create releases from a source directory with `vt build <dir>`. For example:
 
-### Package Runtime Contract
+```text
+g-issues/
+├── package.yaml
+├── runtime/
+│   ├── Dockerfile
+│   └── src/
+├── migrations/
+│   ├── v2.3.0/
+│   └── v2.3.1/
+└── ui/
+    └── admin-console/
+```
 
-A release may contain an MCP runtime, static user interfaces, workflow definitions, or any combination of them. A release with no MCP runtime does not create a runtime Deployment. Protected system packages may additionally expose platform-owned typed APIs; those APIs are versioned platform protocols and are not part of the ordinary package operation catalog.
+`package.yaml` defines the package name, version, operations, dependencies, workflows, UIs, migration jobs, and authorization requirements. Workflow definitions and operation schemas live in the migration jobs rather than separate source directories. `vt build g-issues/` validates the package, builds digest-addressed artifacts locally, and writes a logical release bundle.
 
-Every MCP runtime image follows one platform runtime contract:
+### Example Release Bundle
 
-- Kubernetes starts the runtime container through the manifest-declared executable and arguments. The image contains no embedded platform credential.
-- The supervisor and runtime mount one private in-memory volume. The runtime exposes MCP Streamable HTTP on `/run/gestalt/mcp.sock` and the typed runtime control API on `/run/gestalt/control.sock`; it never binds a mesh-reachable application port directly.
-- The supervisor owns the mesh-facing listener and relays MCP to the private MCP socket without changing JSON-RPC semantics. Configuration, readiness, cancellation, and graceful shutdown use the separate control socket.
-- Startup, liveness, and readiness probes are distinct. Readiness reports the loaded `releaseDigest`, operation-contract digest set, MCP version, and private runtime control API version.
-- The supervisor supplies configuration and secret references through the platform runtime API. Secret values are fetched under the installation workload identity and are never embedded in release metadata.
-- Graceful shutdown first rejects new sessions, then allows pinned requests and streams to drain until the revision deadline. The supervisor requests shutdown over the control API and fails its readiness gate; Kubernetes remains responsible for container termination.
-- The runtime accepts caller identity only through a verified supervisor context. Caller-supplied identity headers, credentials, and routing fields are discarded before dispatch.
+A typical bundle is not one container or folder. For example:
 
-The private runtime control API is a versioned typed protocol covering configuration, readiness, stream cancellation, graceful shutdown, and observed runtime state. It does not carry MCP invocation payloads. Its compatibility range is recorded independently from the MCP protocol and package-supervisor version range. Ordinary packages cannot replace or extend this protocol.
+```text
+g-issues@2.3.1
+├── release_manifest.json
+├── runtime
+│   └── image-index
+│       ├── linux-amd64 image
+│       └── linux-arm64 image
+├── migrations
+│   ├── v2.3.0 image
+│   └── v2.3.1 image
+└── ui
+    └── admin-console.tar.gz
+```
 
-The OCI artifact specification defines canonical media types and paths for the release manifest, image indexes, UI bundles, workflow definitions, schemas, and migration images. Canonical manifest serialization, digest calculation, detached-signature envelopes, package reservation, and publication idempotency are normative parts of the registry protocol rather than implementation details.
-
-### Registries
-
-The registry protocol is open and has no central creation or approval authority. Anyone may operate a registry using the reference creation tooling or an independent implementation that serves the required registry descriptor, APIs, and signature bundles. Each organization independently decides whether to connect to and trust that registry.
-
-Registries control who can publish, discover, or download releases. Each configured registry has:
-
-- The registry's immutable `registryId`, root public key, descriptor generation, and verified origin set
-- Discovery, metadata, blob, and publication endpoints
-- Optional read credentials for discovery and download from a private registry
-- A registry trust policy binding each trusted public-key fingerprint to a publisher identity and the package IDs that key may sign
-- Whether local clients may publish directly
-- A policy revision incremented when trust or local publication rules change
-
-The registry root key signs descriptors containing the `registryId`, protocol version, authorized origin set, operational signing keys, and descriptor generation. Deployments verify that the identifier matches the root key and accept origin additions, removals, mirrors, and disaster-recovery endpoints only through a newer valid descriptor. The offline root key does not sign package releases; publisher and operational keys rotate independently.
-
-The registry's publisher policy controls which releases it accepts. Each connected organization's registry trust policy independently controls which of those releases the organization will admit and may be more restrictive. Registry connection credentials, when present, are read-only and are stored by the secret-management service. Publishers authenticate to the registry with their own user or CI credentials, which the platform does not retain. Artifact verification uses the registry trust policy and public trust material, not registry credentials.
-
-Connecting a registry does not trust its publishers. Catalogs and manifests remain untrusted until admission verifies digests, signatures, schema versions, and the registry trust policy.
-
-The registry provides distinct APIs for paginated discovery, reading immutable metadata and blobs, and authenticated publication.
-
-A registry catalog contains paginated package and release summaries that reference authoritative manifest digests, without duplicating release contracts. Per-package indexes use monotonic revisions and compare-and-swap updates.
-
-Disconnecting a registry blocks discovery and installation but preserves its identity and history. Hard removal fails while any desired, running, dependent, or in-progress revision references it, or while its artifacts remain eligible for rollback or disaster recovery under retention policy. A replacement is a new registry; package identities do not carry over.
-
-### Build and Publish
-
-`vt build <dir>` validates package metadata and builds the applicable digest-addressed runtime, migration, UI, workflow, and schema artifacts, zero or more OCI image indexes, and one release manifest locally. Adding `--push` publishes the result to the selected registry:
+A UI-only or workflow-only package omits the runtime image.
 
 ```sh
 vt build <dir> --push
 ```
 
-Without `--push`, the command does not modify a registry.
+#### CLI authentication
 
-Publication is a recoverable transaction:
+`vt build <dir>` without `--push` needs no deployment credentials.
 
-1. Reserve `(packageId, releaseVersion)` and create a publish-attempt ID.
-2. Record a pending release with any optional source metadata.
-3. Upload all applicable content-addressed blobs, image indexes, and manifests.
-4. Validate all referenced artifacts and release contracts server-side.
-5. Store the immutable release manifest.
-6. Attach signatures.
-7. After all artifacts are stored, atomically add the release to the package catalog. Retry if another publisher changed the catalog first.
-8. Mark the attempt succeeded or failed.
+`vt build <dir> --push` authenticates to the deployment registry before upload. The CLI resolves credentials in this order:
 
-Pending and failed attempts are visible but never installable. Concurrent publishers cannot lose catalog updates. Stale attempts become failed, and orphaned content-addressed blobs are garbage-collected after a grace period.
+1. `VT_API_KEY` environment variable
+2. A session stored in the OS keychain from a prior `vt auth login`
+3. Interactive `vt auth login` if no credential is available
+
+`--push` is safe to run idempotently: retrying the same release after interruption resumes or completes the existing attempt instead of creating a duplicate catalog entry. Pending and failed attempts are visible but never installable. Concurrent publishers cannot lose catalog updates. Stale attempts become failed, and orphaned content-addressed blobs are garbage-collected after a grace period.
+
+### Stored Content and Backing Services
+
+Google Artifact Registry stores the immutable release bundle: runtime and migration OCI images, UI bundles, workflow definitions, schemas, the canonical release manifest, and detached signatures. Each artifact is content-addressed by SHA-256 digest.
+
+The registry service also tracks metadata that Artifact Registry does not provide on its own:
+
+- Package IDs, slugs, version indexes, and tombstones
+- Publication and import attempts, including pending and failed state
+- Catalog indexes that map `(package, version)` to `releaseDigest`
+- Trusted upstream registries and which publishers we accept from them
+- Import history, including where a release came from and whether the copy completed
+
+Upstream read credentials live in the secret-management service, and signing keys live in KMS; neither is stored with package artifacts.
+
+### Identity and Trust
+
+Every registry is responsible for permissioning who can pull from it and who can publish to it.
+
+The deployment registry controls read access for discovery and download, and write access for authorized publishers. Upstream registries do the same on their side; pull-through import uses read-only credentials supplied for that one-time operation.
+
+Each registry has a stable `registryId` derived from its root public key.
+
+### Pull-through Imports
+
+Upstream access is a one-time import that grants read access only; installation still requires organization trust in the release signature. An administrator import verifies the complete release, then atomically adds it to the local catalog; failed imports remain invisible. Imported releases keep their source identity, signatures, and digest.
+
+## Publishing and Distribution
+
+### Package Releases
+
+Each `(registryId, packageId, releaseVersion)` has one canonical release manifest with detached signatures. Runtime and migration binaries may vary by platform; manifest contracts do not.
+
+`release_manifest.json` must declare:
+
+- Canonical registry and package IDs, slug, and `releaseVersion`
+- Digest references for every artifact produced by `vt build`
+- MCP operations with input and output schema digests
+- Required and optional package and operation dependencies
+- Ordered prepare, finalize, and compensating migration jobs
+- Required authorization relationships or roles for each operation
+- Supported MCP protocol versions
+- Runtime startup instructions and probe contract for releases that include a runtime
+- Optional source metadata (e.g. PR number)
+
+#### Publication
+
+1. `vt build` produces the release artifacts; each artifact gets a SHA-256 digest.
+2. `vt build` writes `release_manifest.json` listing those digests and the release metadata above.
+3. `vt build` computes `releaseDigest` as the SHA-256 hash of the canonical manifest bytes. It is not embedded in the manifest.
+4. The publisher signs `registryId`, `packageId`, `releaseVersion`, `releaseDigest`, and every referenced artifact digest. The signature is stored separately from the manifest.
+5. `--push` uploads the artifacts, manifest, and signature to the deployment registry.
+
+#### Verification
+
+When the registry receives a push request, it authenticates the publisher, verifies signatures, digests, and contracts, and rejects conflicting republications of the same `releaseVersion`. A `releaseVersion` follows a documented grammar and binds permanently to one `releaseDigest`. Only after those checks succeed does the registry expose the release in the catalog.
+
+Pull-through import has its own validation before copying an external release locally; installation is a separate check that re-verifies the selected `releaseDigest` before admitting a package into the mesh.
+
+### First Installation
+
+A release in the registry catalog is not yet running in the mesh. The first installation admits it. For example, installing `g-issues@2.3.1`:
+
+1. **Select a release.** A package administrator chooses the app and an immutable `releaseDigest` from the registry catalog.
+2. **Review the contract.** The platform shows declared operations, dependencies, workflows, UIs, migrations, and required authorization relationships.
+3. **Bind identities.** The administrator selects organization-managed service accounts for the runtime, migration jobs, and workflows when the release includes them.
+4. **Configure operation authority.** For each operation, the administrator decides whether it runs only as the workload identity or may exercise delegated caller authority, and binds permissions as durable grants or delegated authority.
+5. **Approve admission.** The administrator confirms the bindings. This requires `service_account.assign` for each identity and `authorization.grant` for each relationship or role being granted.
+6. **Verify and prepare.** The control plane re-verifies the `releaseDigest`, resolves dependencies, reserves the package slot, runs prepare migrations, and provisions identities, mesh routes, and policies.
+7. **Roll out.** The revision controller creates runtime workloads when needed, stages UI and workflow artifacts, and promotes the revision once readiness checks converge. The app then appears in user-facing catalogs and becomes invocable.
+
+Releases without a runtime skip workload creation but still register workflows, UIs, and catalog entries through the same path. See [Installation](#installation) and [Revision Rollouts](#revision-rollouts) for the durable state machine and promotion rules.
 
 ## Package Revisions
 
@@ -171,7 +220,7 @@ Pending and failed attempts are visible but never installable. Concurrent publis
 The control plane persists:
 
 - **Package slots**: one organization-scoped slot keyed by canonical package identity, reserved before allocating an installation ID and used to fence concurrent first installs
-- **Revision requests**: append-only install, upgrade, rollback, and removal intent with actor, previous promoted revision, target `releaseDigest`, registry trust policy revision, approved authorization bindings, resolved dependencies, and timestamps
+- **Revision requests**: append-only install, upgrade, rollback, and removal intent with actor, previous promoted revision, target release or tombstone, deployment-registry catalog generation and applicable trust-policy revision, approved authorization bindings, resolved dependencies, and timestamps
 - **Installation head**: last successfully promoted revision and current admitted candidate
 - **Revision operation**: one generation-fenced state machine per installation, including phase, candidate Kubernetes resources, deadlines, stability timestamp, and routing generation
 - **Migration outcomes**: immutable status keyed by installation, `releaseDigest`, and migration ID
@@ -194,7 +243,7 @@ Before admission, the platform shows package-declared operation access requireme
 
 Installation is a reconciled saga:
 
-1. Verify the registry identity and trust policy, release and image signatures, platform support, runtime compatibility, and schema versions.
+1. Verify that the release is complete in the deployment registry, then verify its source registry identity and applicable trust policy, release signature and referenced artifact digests, platform support, runtime compatibility, and schema versions.
 2. Resolve exact dependency revisions and operation-contract digests.
 3. Reserve the organization package slot and persist the revision request, approved authorization snapshot, and fenced revision operation.
 4. Provision the installation and any required runtime, migration, and workflow identities, authorization relationships, ambient data-plane enrollment, and `AuthorizationPolicy` attachments.
@@ -227,40 +276,40 @@ An atomic rollout group is one durable request containing candidates for multipl
 
 Releases with an MCP runtime use a Kubernetes-native blue/green rollout with optional Istio canary traffic. Each runtime upgrade creates a candidate revision in a distinct immutable Kubernetes Deployment behind a revision-specific Service. The promoted and candidate Deployments may run together, so the serving Deployment is never restarted or mutated in place. Runtime-less releases use the same durable revision state machine without creating runtime Deployments or Services.
 
-Revision records use optimistic concurrency and fencing tokens, preventing a controller that loses its lease from mutating a newer generation. Retries are idempotent; every external mutation has a stable idempotency key. For example, controller A may start an upgrade at generation 4, create the candidate Deployment, and then lose its lease. Controller B takes over at generation 5. Any later update from controller A is rejected, while controller B can safely retry the Deployment request without creating a duplicate.
+Revision operations use optimistic concurrency and fencing tokens, so a controller that loses its lease cannot mutate a newer generation. Retries are idempotent, and every external mutation has a stable idempotency key.
 
-For runtime releases, Kubernetes and the package supervisor are the source of truth for live workload health. A runtime candidate is ready only when Kubernetes has observed the Deployment generation, its required replicas are available, and package-supervisor readiness confirms the target `releaseDigest` for a stability window. Replacement pods and autoscaled replicas count by current readiness, not persistent identity.
+For runtime releases, Kubernetes is the source of truth for live workload health and configured image identity. A runtime candidate is ready only when Kubernetes has observed the Deployment generation, its required replicas are available, each Pod specification is pinned to the expected platform-manifest digest resolved from the admitted image index, ambient enrollment and policy readiness gates are true, and runtime probes and synthetic MCP contract checks remain successful for a stability window. Replacement pods and autoscaled replicas count by current readiness, not persistent identity.
 
-Before any candidate becomes promotable, the interface service must verify and stage every UI bundle, and the workflow service must register every workflow definition as candidate-only and acknowledge its digest. These records remain unreachable from user catalogs. A release with no runtime reaches Ready from artifact verification and the required UI and workflow acknowledgements; Starting, Canarying, runtime routing, Draining, and runtime observation are skipped when they do not apply.
+Before promotion, the interface service verifies and stages every UI bundle, while the workflow service registers each definition as candidate-only and acknowledges its digest. These records remain absent from user catalogs. A release without a runtime reaches Ready after artifact verification and applicable UI and workflow acknowledgements; it skips runtime resource creation, Canarying, runtime routing, Draining, and runtime observation.
 
-Each installation with an MCP runtime has one stable frontend Service and revision-specific backend Services. Gateway API `HTTPRoute` resources select weighted revision backends; callers never address a revision Service directly. Packages may call other packages only through declared dependencies and these mesh-managed routes. Direct or undeclared package-to-package calls are blocked.
+Each installation with an MCP runtime has one stable frontend Service and revision-specific backend Services. Gateway API `HTTPRoute` resources establish the package route, while a protected waypoint cluster-selector extension applies the admitted operation-specific revision weights after MCP decoding and authorization. Callers never address a revision Service directly. Packages may call other packages only through declared dependencies and these mesh-managed routes. Direct or undeclared package-to-package calls are blocked.
 
-The controller assigns each routing change a durable `routingGeneration` and records the exact Kubernetes resource UIDs, generations, and desired route hashes that implement it. Infrastructure installs a protected routing-status extension in every ingress gateway and waypoint; the extension exposes, over an mTLS-protected administration endpoint, the routing generations and route hashes currently loaded by that proxy. This extension and endpoint are versioned with the pinned Istio/Envoy build and covered by infrastructure conformance tests.
+The controller assigns each routing change a durable `routingGeneration` and records the exact Kubernetes resource UIDs, generations, waypoint cluster-selection configuration, and desired route and policy hashes that implement it. Infrastructure installs a protected routing-status extension in every ingress gateway and waypoint; the extension exposes, over an mTLS-protected administration endpoint, the routing generations and configuration hashes currently loaded by that proxy. This extension and endpoint are versioned with the pinned Istio/Envoy build and covered by infrastructure conformance tests.
 
-The relevant proxy set is a persisted membership snapshot of available ingress-gateway and destination-waypoint replicas selected for those resources. Convergence requires accepted and resolved Gateway API status, ready route backends, every member's routing-status report matching the desired hashes, and authenticated synthetic probes observing the target generation through each proxy class. The controller does not infer application convergence from one global Istio xDS version. Proxy replacement, loss of availability, or membership change resets the stability window. A bounded timeout fails the phase and leaves enough recorded evidence for deterministic retry or restoration.
+The relevant data-plane set is a persisted membership snapshot of available ingress gateways, destination waypoints, and destination-node `ztunnel` instances selected for those resources. Convergence requires accepted and resolved Gateway API status, ready route backends, every gateway and waypoint report matching the desired hashes, ambient status confirming workload enrollment and policy generation on every relevant `ztunnel`, and authenticated allow-path and direct-bypass probes. The controller does not infer application convergence from one global Istio xDS version. Data-plane replacement, loss of availability, or membership change resets the stability window. A bounded timeout fails the phase and leaves enough recorded evidence for deterministic retry or restoration.
 
-Gateway and waypoint readiness is gated on the routing-status extension reporting either the current committed generation or an active generation-fenced rollout generation authorized for that proxy and route. During promotion, the proxy may remain ready on the fenced candidate generation while convergence is observed. Immediately after the promotion commit, only the newly committed generation satisfies readiness. A new or restarted proxy cannot enter Service endpoints or load-balancer membership until it has loaded and reported the then-current committed generation, so proxy churn after promotion cannot reintroduce stale routing.
+Gateway and waypoint readiness is gated on the routing-status extension reporting either the current committed generation or an active generation-fenced rollout generation authorized for that proxy and route. Destination workload readiness is separately gated on ambient enrollment and the current or fenced `ztunnel` policy generation. During promotion, the data plane may remain ready on the fenced candidate generation while convergence is observed. Immediately after the promotion commit, only the newly committed generation satisfies readiness. New or restarted gateways, waypoints, and `ztunnel` instances cannot enter traffic-serving membership until they report the then-current committed generation, so data-plane churn after promotion cannot reintroduce stale routing or bypass policy.
 
 Promotion has one commit point. For runtime releases, the controller first writes primary routing intent while the previous revision remains the persisted promoted head. After routing converges and all UI-serving and workflow-registration acknowledgements remain valid for the stability window, one state-store transaction updates the promoted revision and the relevant routing, package, operation, UI, and workflow generations. Only that transaction constitutes successful promotion. If a prerequisite fails before the transaction, the controller restores previous routing and external registrations and confirms their convergence; it does not advance the promoted head or any catalog generation.
 
-The control plane persists rollout intent and decisions, then reconstructs progress from Kubernetes, the package supervisor, and Istio after restart. Historical rollout outcomes remain immutable; current workload health is a separate live view.
+The control plane persists rollout intent and decisions, then reconstructs progress from Kubernetes, Istio, and protected platform services after restart. Historical rollout outcomes remain immutable; current workload health is a separate live view.
 
 The canonical revision-operation phases are:
 
-1. **Admitted**: verify the release, policy, runtime compatibility, dependencies, and reverse dependents.
-2. **Preparing**: run backward-compatible prepare migrations as fenced one-shot jobs.
-3. **Starting**: create any revision-specific runtime resources and stage candidate-only UI bundles and workflow definitions.
-4. **Ready**: require all applicable runtime, UI-serving, and workflow-registration checks for the configured stability window.
-5. **Canarying**: route a configurable small traffic percentage for operations whose contracts exactly match the promoted revision; the candidate remains absent from user-facing catalogs.
-6. **Promoting**: converge applicable routing and external registrations, then atomically commit the promoted head and relevant package, operation, UI, workflow, and routing generations.
-7. **Draining**: keep the prior revision available for in-flight requests and streams until their drain deadline.
-8. **Observing**: monitor the promoted revision under production traffic for a configured period.
-9. **Finalizing**: run explicitly approved irreversible finalize migrations when required.
-10. **Complete**: record convergence and terminal timing.
+1. **Admitted**: validate release, policy, compatibility, and dependencies.
+2. **Preparing**: run fenced, backward-compatible prepare migrations.
+3. **Starting**: create runtime resources and stage candidate UI and workflow artifacts.
+4. **Ready**: hold every applicable check for the stability window.
+5. **Canarying**: send limited traffic only for contracts identical to the promoted revision, without catalog exposure.
+6. **Promoting**: execute the convergence and atomic commit protocol above.
+7. **Draining**: enforce the pinned-session and hard-deadline protocol below.
+8. **Observing**: monitor production traffic for the configured period.
+9. **Finalizing**: run separately approved irreversible migrations.
+10. **Complete**: record convergence and timing.
 
-Starting runtime resources, Canarying, runtime routing, Draining, runtime observation, and Finalizing are skipped when they do not apply. A failure or cancellation records a terminal outcome against the phase where the operation stopped rather than introducing another progression phase.
+Inapplicable runtime, canary, drain, observation, and finalization work is skipped. Failure or cancellation is a terminal outcome attached to the stopping phase, not another progression phase.
 
-Each phase has a timeout, retry policy, and terminal error taxonomy. Readiness requires the configured replica capacity, not a single ready pod. During routing propagation and draining, revisions follow the compatibility and operation-removal rules in [Dependencies and Contracts](#dependencies-and-contracts). Existing MCP SSE streams remain pinned to their original revision while the old revision drains, including streams for an operation omitted by the candidate.
+Each phase has a timeout, retry policy, and terminal error taxonomy. Readiness requires the configured replica capacity, not a single ready pod. During routing propagation and draining, revisions follow the compatibility and operation-removal rules in [Dependencies and Contracts](#dependencies-and-contracts). The prior revision Service remains available for pinned sessions while new session routing targets only the promoted revision. One termination-grace interval before the hard drain deadline, the controller starts Pod deletion and publishes a protected draining cluster containing the terminating Pod endpoints. The waypoint cluster selector admits only valid pinned-session tokens to that cluster and does not depend on normal Service endpoint discovery retaining terminating endpoints. Kubernetes force-terminates any remaining process at the deadline, after which the controller removes the drain cluster and prior revision resources. Existing MCP SSE streams remain pinned to their original revision while the old revision drains, including streams for an operation omitted by the candidate.
 
 Pre-promotion failures mark the candidate failed and leave the prior revision primary. Failures during post-promotion observation mark the new revision degraded. Neither case triggers automatic rollback. Degraded or finalization-error states block the next revision operation until an administrator retries, initiates an approved rollback, or approves a forward fix. Finalization failure records `promoted_with_finalization_error`; it neither marks the promoted revision failed nor changes routing.
 
@@ -282,18 +331,11 @@ The first version does not classify rollback safety in release metadata or initi
 
 ### Removal
 
-Removal is a durable tombstoned revision, not deletion of a catalog row:
+Removal is a durable tombstoned revision, not catalog-row deletion. Admission rejects it while required reverse dependents exist unless the same atomic rollout group removes them. Preparing records workflow-retirement and data-retention decisions. Starting stages tombstone generations and candidate interface and workflow retirement changes; Ready confirms their acknowledgements. Promoting atomically commits package, operation, UI, and workflow tombstones, disables interface launches, unregisters workflows, stops new executions, and prevents new invocation resolution.
 
-1. Reject removal while required reverse dependents exist, unless they are removed in the same atomic rollout group.
-2. In one fenced transition, promote tombstones for the package, operation, UI, and workflow generations, disable interface launch routes, unregister promoted workflow definitions, stop new workflow executions, and prevent new invocation resolution.
-3. Drain resolved requests and streams and handle queued or running workflow executions according to their recorded retirement policy.
-4. Stop the removed package's runtime workloads, scale them to zero, and block any stale ingress or package-initiated egress.
-5. Revoke workload authorization bindings, installation-owned assignments, and delegated tokens.
-6. Apply package data retention or destruction policy.
-7. Preserve the package tombstone and audit history.
-8. Garbage-collect runtime resources after the recovery window.
+Draining applies the normal hard deadline to resolved runtime requests and streams; workflow executions follow their recorded finish, retire, or migrate policy. Finalizing removes runtime workloads, blocks stale ingress and package egress, revokes installation-owned bindings, assignments, and delegated tokens, and performs approved data retention or destruction. Complete preserves the tombstone and audit history; runtime-resource garbage collection follows the recovery window. Canarying and Observing are skipped.
 
-Removal preserves organization-owned grants and distinguishes them from installation-owned grants. Reinstallation creates a new installation identity unless an approved restore reactivates the tombstone.
+Organization-owned grants survive removal. Reinstallation gets a new installation identity unless an approved restore reactivates the tombstone.
 
 ## Runtime and Access
 
@@ -310,9 +352,9 @@ The authorization service is the system of record for organization policy. It st
 - Every invocation is centrally authorized before dispatch; package-specific resource checks may further restrict it.
 - Production does not start in a fail-open mode when identity or authorization is unavailable.
 
-Each authorization grant wraps one relationship tuple and records an immutable ID, organization, human issuer, creation and optional expiration, source authority, and policy revision. Grant mutation creates a new record; revocation appends a revocation record rather than rewriting or deleting history. Revoking or narrowing the source authority invalidates dependent grants. Platform controllers may apply a recorded human-authorized grant but cannot originate one.
+Each authorization grant wraps one relationship tuple and records an immutable ID, organization, human issuer, creation and optional expiration, issuance-authority snapshot, and policy revision. Grant mutation creates a new record; revocation appends a revocation record rather than rewriting or deleting history. A later loss of the issuer's authority does not revoke an existing durable grant; revocation, expiration, or an explicit policy migration does. Delegated authority is evaluated against the delegating subject's current authority and narrows immediately with it. Platform controllers may apply a recorded human-authorized grant but cannot originate one.
 
-The first implementation does not cache authorization decisions. Internal invocation tokens are short-lived, and every workflow step is authorized independently. Existing streams may continue until their configured lifetime expires. Security events go to an immutable audit sink outside package-controlled storage.
+The first implementation does not cache authorization decisions. Caller tokens and internal caller contexts are short-lived, and every workflow step is authorized independently. Existing streams may continue until their configured lifetime expires. Security events go to an immutable audit sink outside package-controlled storage.
 
 ### Authorization Model and Evaluation
 
@@ -330,7 +372,7 @@ The authorization model defines resource types, relations, actions, and which re
 
 The authorization service stores the policy model and organization-managed grants in one authoritative runtime system. Platform bootstrap registers reserved resource types, while package admission registers namespaced resource types and operation requirements. Each model change produces an immutable, content-hashed generation. Grants may be revoked at any time. A policy-model change cannot remove or rename a resource type or relation referenced by active grants unless those grants are revoked or migrated in the same transaction. Grants are indexed by subject, relation, and resource so evaluation does not scan the complete relationship set.
 
-Credential scopes are an upper bound on authority: a relationship grant cannot restore access excluded by the authenticated credential. Missing subjects, actions, resources, policy models, or provider availability produce a denial.
+Credential scopes are an upper bound on authority: a relationship grant cannot restore access excluded by the authenticated credential. Missing subjects, actions, resources, or policy models—and authorization-provider outages—produce a denial.
 
 ### Package Access Policy
 
@@ -360,28 +402,19 @@ UI bundles are immutable content-addressed artifacts referenced by the release m
 
 The platform assigns each installation interface a stable non-executable launch origin and a distinct executable origin for every promoted UI generation beneath a deployment-controlled wildcard application domain. The launch origin only redirects to the currently promoted generation and serves no package-controlled document or script. Package generations never share an executable origin, cookies, service workers, browser storage, or CSP authority with deployment administration, protected services, another interface, or an older generation.
 
-Private interfaces use an origin-scoped session established through the normal external identity flow. The interface service issues a short-lived browser capability only when the request originates from the currently promoted generation's verified entry document. The capability names the installation, interface ID, UI generation, allowed operations, and exact generation-specific origin. Ingress validates that capability and the `Origin` header in addition to normal subject authorization; it rejects stale generations and browser calls outside the declared allowlist. A public interface must be explicitly allowed by organization policy, and public asset access does not make its operations public. Browser code never receives workload credentials or raw internal invocation tokens.
+Private interfaces use an origin-scoped session established through the normal external identity flow. The interface service issues a short-lived browser capability only when the request originates from the currently promoted generation's verified entry document. The capability names the installation, interface ID, UI generation, allowed operations, and exact generation-specific origin. Ingress validates that capability and the `Origin` header, rejects stale generations, and carries its signed allowlist claims into the caller token. After decoding the MCP request, the destination waypoint rejects browser operations outside that allowlist in addition to performing normal subject authorization. A public interface must be explicitly allowed by organization policy, and public asset access does not make its operations public. Browser code never receives workload credentials, caller tokens, or internal caller contexts.
 
 The platform applies the declared CSP profile, strict CORS, MIME validation, integrity metadata, response-size limits, immutable caching for revision-qualified assets, and service-worker scope restrictions. Interfaces requiring embedding use opaque sandboxed frames and explicit `postMessage` schemas; embedding does not grant same-origin access.
 
 ### Catalogs and Administration
 
-An organization deployment provides:
-
-- A package catalog
-- An operation catalog
-- A user-interface catalog
-- A workflow catalog
-- A dependency graph
-- Package revisions, rollout and migration status, identities, and authorization settings
-- API grant management
-- A development sandbox
+An organization deployment exposes package, operation, UI, and workflow catalogs; a dependency graph; revision, rollout, migration, identity, and authorization administration; API-grant management; and a development sandbox.
 
 Administrative catalogs may expose candidate metadata. User-facing package, operation, UI, and workflow catalogs expose only their atomically promoted generations. New operation contracts appear only after applicable routing, UI-serving, and workflow-registration prerequisites in [Revision Rollouts](#revision-rollouts) have converged.
 
 Clients treat catalogs as snapshots. Invocation remains authoritative and may reject stale or undeclared operations under the rules in [Dependencies and Contracts](#dependencies-and-contracts).
 
-Organization administrators can connect registries and install, upgrade, roll back, or remove packages. Package administrators can perform revision and administration actions within their delegated package and authorization scope. Package developers can build, publish, test, and invoke packages. Package users see only catalogs and operations authorized for them.
+Organization administrators can configure upstream pull sources, authorize imports, and install, upgrade, roll back, or remove packages. Package administrators can perform revision and administration actions within their delegated package and authorization scope. Package developers with registry write access can build, publish, test, and invoke packages. Package users see only catalogs and operations authorized for them.
 
 Representative endpoints:
 
@@ -404,41 +437,29 @@ Authentication comes from an interactive session, keychain, environment, or stan
 
 Invocation uses MCP Streamable HTTP: JSON-RPC over POST with JSON or SSE responses. The gateway enforces request size, timeout, rate, and stream lifetime.
 
-Ingress strips externally supplied internal-identity headers and exchanges user credentials for a short-lived, signed internal invocation token. The token is bound to its issuer, audience, target installation, request class, operation when applicable, and request-envelope hash and carries a unique ID, issuance, not-before, and expiry times, the original actor, effective subject, immediate caller workload identity, delegation chain, and trace ID. Signing keys rotate with an overlap window for in-flight requests. Packages never receive or forward raw user bearer tokens or API keys.
+Ingress strips external identity and routing fields, authenticates the credential, and exchanges it for a short-lived signed caller token; it neither parses MCP nor authorizes operations. The token is bound to its issuer, waypoint audience, target installation, and raw envelope hash. It carries a unique ID; issuance, not-before, and expiry times; actor and effective subject; credential and delegation upper bounds; optional browser-capability claims; delegation chain; and trace ID.
 
-The deployment exposes package-scoped MCP endpoints rather than one endpoint that multiplexes package names from JSON-RPC bodies. A trusted MCP request decoder at ingress validates the JSON-RPC envelope, resolves the canonical operation ID from the MCP method and parameters, rejects ambiguous or batch requests that target more than one authorization scope, and writes immutable dynamic metadata for authorization and routing. External clients cannot supply that metadata. The decoder binds a hash of the authorized request envelope into the internal invocation token so a downstream component cannot change the target operation after authorization.
+The deployment exposes package-scoped MCP endpoints rather than one endpoint that multiplexes package names from JSON-RPC bodies. A protected MCP extension shared by destination waypoints validates the caller token and request-envelope hash, parses the JSON-RPC envelope, resolves the request class and canonical operation ID, and writes trusted dynamic metadata for `ext_authz`, routing, canary selection, and telemetry. Callers cannot supply that metadata. Malformed JSON-RPC, unsupported methods, unknown operations, mismatched hashes, and expired tokens fail at the waypoint before reaching a package.
 
 MCP methods map to authorization and routing as follows:
 
 - `initialize`, `ping`, and session negotiation require the installation-level `package.connect` action and do not select an operation.
-- Catalog and discovery methods require their catalog-read action and return only entries authorized for the effective subject.
+- Catalog and discovery methods terminate at a protected catalog service behind the waypoint. They require their catalog-read action, use a batch authorization check against one policy snapshot, and return only entries authorized for the effective subject; untrusted package runtimes do not filter their own discoverability.
 - Operation calls such as `tools/call` resolve the package-stable operation ID from validated parameters and require that operation's action and resource checks.
 - Cancellation, progress, and other session notifications must reference an existing authorized session and inherit its installation, revision, actor, and effective subject. They cannot change authorization scope.
 - Unsupported methods fail closed. A JSON-RPC batch is accepted only when every item has the same target installation, request class, operation, authorization scope, session, and routing target and each item is authorized independently; otherwise the complete batch is rejected.
 
-The destination waypoint uses the package endpoint and verified token claims for routing and `ext_authz`; it does not trust a caller-supplied operation header. The supervisor verifies the token, request-envelope hash, target installation, request class, operation when applicable, and selected revision before dispatch. Malformed JSON-RPC, unsupported MCP methods, unknown operations, mismatched hashes, and expired tokens fail before reaching the runtime.
+The waypoint sends verified caller context and decoded request metadata to authorization. On allow, the adapter returns short-lived signed internal context carrying the actor, effective subject, applicable immediate workload, and delegation chain. It is bound to the target installation, request class, applicable operation, envelope hash, applied credential and delegation bounds, applicable browser claims, policy generation, and trace ID. The waypoint removes the external token and reserved fields. Catalog requests terminate at the protected catalog service; runtime requests select a revision Service and forward only the internal context.
 
-After weighted routing selects a revision Service, a protected waypoint extension creates a short-lived signed dispatch receipt bound to the invocation-token ID, installation ID, revision ID, `releaseDigest`, routing generation, and request-envelope hash. Waypoint receipt-signing certificates are issued and rotated by the identity service for the waypoint workload identity. The supervisor verifies this receipt and confirms that its loaded digest matches it; packages never receive the receipt. Session continuation receipts must name the revision already pinned by the session.
+After `ext_authz`, a protected metadata-aware cluster-selector extension uses only decoder-generated metadata and the signed routing table for the committed or active fenced generation to select operation-specific canary backends for runtime request classes. Catalog and discovery classes bypass revision selection and terminate at the catalog service. No route trusts a caller-supplied operation header, and standard `HTTPRoute` header matching is not used for decoded operations.
 
-MCP session IDs are client-opaque signed routing tokens issued by the supervisor under an identity-service-certified workload signing key. They contain the installation, revision, `releaseDigest`, routing generation, issued and expiry times, and random nonce. Before backend selection, the waypoint verifies the token and routes subsequent requests to its named revision Service. Cancellation is forwarded to that revision, and reconnect succeeds only while the token is valid and the revision remains inside its drain deadline. SSE streams send platform heartbeats, have a configured maximum lifetime, and remain pinned until completion, cancellation, or that deadline.
+For a new session, the waypoint wraps the runtime-issued opaque session ID in a client-opaque signed routing token containing the installation, revision, `releaseDigest`, routing generation, issued and expiry times, and random nonce. On each successful continuation or response, the waypoint may rotate the wrapper without extending it beyond the configured maximum session lifetime or revision drain deadline. The waypoint verifies and unwraps continuations before routing to their named revision Service. Cancellation is forwarded to that revision, and reconnect succeeds only while the wrapper is valid and the revision remains inside its drain deadline. SSE streams have a configured maximum lifetime and remain pinned until completion, cancellation, or that deadline.
 
-Authorization is enforced at two surfaces:
+Ingress authenticates external credentials, creates package caller tokens, and authorizes catalogs and management APIs; it does not authorize MCP operations. The destination waypoint decodes and authorizes every MCP request before revision routing. Both use one authorization service and relationship graph.
 
-- **Ingress gateway**: user invocation, catalogs, package administration, and package revision APIs. The gateway's `ext_authz` filter calls the authorization service before forwarding to control-plane or package services.
-- **Destination waypoint**: every MCP call is checked before revision routing. For external calls, the waypoint revalidates the ingress-issued token and authorized request metadata; for package calls, it performs the corresponding workload and effective-subject authorization check. Waypoint enforcement is described in [Runtime Architecture](#runtime-architecture).
+Checks use the effective subject, target installation, and request-class action. Package-originated calls also require the immediate workload's authority; operation calls additionally require the canonical operation ID, approved package access policy, and any package-specific resource authorization. Credential scope and every applicable relationship check must allow the request. Decisions record the policy model and revision; missing or unknown identities, installations, request classes, operations, or policies—and provider outages—deny access.
 
-Both surfaces use one authorization service and relationship graph. MCP checks always use the effective subject, target installation, and request-class action. Package-originated calls additionally use the immediate caller workload identity. Operation calls additionally use the canonical operation ID; connection, catalog, session, and notification classes use the actions defined in the MCP method mapping and do not invent an operation. Management checks use the actor and requested revision or administration action.
-
-For an MCP operation call, the authorization decision intersects:
-
-- The caller workload identity's permission to invoke the target when the call originated from a package
-- The effective subject's permission
-- The installed package's approved operation access policy
-- Any operation-specific resource authorization
-
-Credential scope and every relationship check applicable to the request class must allow the request. The decision records the policy model ID and revision. Missing or unknown identities, installations, request classes, required operations, policies, or authorization-provider outages deny access.
-
-For package-to-package calls, the caller asks the identity service to mint an internal invocation token over its authenticated workload channel. The request names one declared dependency, operation, effective subject, and request-envelope hash. The identity service verifies the caller's workload identity and delegation chain, while the authorization service evaluates the call before a token is issued. Tokens are single-target, short-lived, non-refreshable by the package, and cannot broaden the caller's credential or delegated authority. Package SDKs perform this exchange and send the resulting token to the destination Service.
+For package-to-package calls, the caller asks the identity service to mint a caller token over its authenticated workload channel and presents the signed parent internal caller context or a platform-issued workload-execution context. The request names one declared dependency and request-envelope hash; it cannot supply a replacement actor, effective subject, or delegation chain. The identity service verifies the parent context, preserves its actor and effective subject, appends the authenticated caller workload to the delegation chain, and cryptographically attenuates scope and expiry. The destination waypoint remains authoritative for target operation authorization. Tokens are single-target, short-lived, non-refreshable by the package, and cannot broaden delegated authority. Package SDKs perform this exchange and send the resulting token to the destination Service.
 
 ### Development Sandbox
 
@@ -490,13 +511,13 @@ The bootstrap substrate and protected system packages are both inside the platfo
 
 The bootstrap substrate and protected system packages provide these trusted services:
 
-- **Identity service**: authenticates sessions and API grants, resolves canonical principals, manages organization service accounts, and issues short-lived internal invocation tokens.
+- **Identity service**: authenticates sessions and API grants, resolves canonical principals, manages organization service accounts, issues caller tokens, and manages signing keys for internal caller contexts and session wrappers.
 - **Authorization service**: stores immutable policy models, grants, assignments, and revocations and evaluates provider-independent and Envoy `ext_authz` checks.
 - **Secret-management service**: stores and rotates platform and connection credentials and releases secret material only to explicitly authorized workload identities.
-- **Registry-verification service**: retrieves registry metadata and verifies origins, manifests, digests, signatures, platform compatibility, and the registry trust policy before admission.
+- **Registry-verification service**: verifies the deployment registry and upstream source identities, controls pull-through imports, verifies manifests, digests, signatures, platform compatibility, trust policy, and local artifact completeness before catalog exposure and admission.
 - **Audit sink**: accepts append-only security, authorization, administration, and runtime events in storage that packages cannot control.
 - **Workflow service**: registers promoted package-defined workflows and runs pinned executions outside package runtimes.
-- **Control-plane state store**: a bootstrap-substrate service that durably stores registries, package slots, revision requests and operations, routing and catalog generations, migration outcomes, and recovery metadata.
+- **Control-plane state store**: a bootstrap-substrate service that durably stores deployment-registry state, upstream source configurations, import attempts, package slots, revision requests and operations, routing and catalog generations, migration outcomes, and recovery metadata.
 
 The Istio control plane provides the certificate authority and workload-certificate lifecycle. Backup and recovery tooling protects control-plane state and trusted-service configuration but does not sit on the request path.
 
@@ -504,32 +525,25 @@ Each trusted service exposes a versioned typed API. Control-plane clients use sh
 
 ### Runtime Architecture
 
-Production uses Istio ambient mode. `ztunnel` provides L4 transport security and workload identity, while waypoint proxies provide L7 routing and authorization. Istio data-plane sidecars are not planned for the first implementation; the package supervisor remains an application sidecar.
+Production uses Istio ambient mode. `ztunnel` provides L4 transport security and workload identity, while waypoint proxies provide L7 routing, authorization, and telemetry. Package Pods have no mesh or application proxy sidecar.
 
-The runtime consists of:
+The runtime combines `istiod`, mandatory node-level `ztunnel`, shared destination waypoints, ingress and egress gateways, unprivileged package containers, the protected services above, the state store, and revision controllers. Package containers expose MCP and health endpoints directly; the interface service serves static UIs.
 
-- **Istio control plane (`istiod`)**: distributes routing, policy, endpoint, and certificate configuration.
-- **`ztunnel`**: mandatory node proxies providing L4 transport security and workload identity.
-- **Waypoint proxies**: shared Envoy proxies providing L7 routing, telemetry, and authorization for destination Kubernetes Services.
-- **Ingress gateways**: terminate external transport, remove untrusted identity headers, authenticate credentials, enforce `ext_authz`, and route public and organization traffic.
-- **Egress gateways**: enforce and audit organization-declared external access that cannot safely use direct egress.
-- **Package supervisor (`gestaltd`)**: one platform-owned sidecar container in each runtime Pod that gates runtime readiness and shutdown through the control API, exposes the mesh-facing MCP listener, verifies invocation context, and reports observed state. It is not an Istio proxy.
-- **Package runtime**: an unprivileged container that implements the private side of the package runtime contract. Static interfaces are served by a protected platform service, not by this container.
-- **Protected system packages**: provide identity, authorization, secrets, registry verification, audit, and workflow execution as defined above.
-- **Control-plane state store**: provides durable state for trusted services and revision controllers as part of the bootstrap substrate.
-- **Revision controllers**: reconcile durable revision requests and rollout state into workloads, routing, catalogs, identities, and policy.
+Revision controllers reconcile durable state through trusted-service and Kubernetes APIs into Deployments, stable and revision Services, waypoint enrollment, Gateway API routes, signed cluster-selection configuration, and `AuthorizationPolicy`. `istiod` distributes the resulting xDS configuration. Controllers advance catalog generations only after protected status reports and allow-path and bypass probes confirm route, selector, enrollment, and policy convergence.
 
-Revision controllers use trusted-service APIs and the Kubernetes API to create or update Deployments, stable frontend and revision Services, waypoint enrollment, Gateway API routes, traffic weights, and `AuthorizationPolicy` resources. `istiod` watches the Kubernetes and Istio resources, translates the desired state into xDS configuration, and distributes it to ingress gateways, waypoints, and `ztunnel`. The protected routing-status extension reports loaded route hashes and routing generations; revision controllers require those reports and active probes before advancing promoted catalog generations.
+Istio owns endpoint, routing, certificate, and mesh-policy distribution—not revision state, grants, workflows, or catalogs. Ingress authenticates external callers; destination waypoints authorize MCP requests.
 
-Istio keeps workload endpoints, routing, certificates, and mesh-policy configuration synchronized. It does not own or synchronize package revision state, authorization grants, workflow executions, or catalogs. Those remain the responsibility of revision controllers and trusted platform services. Package operation invocations remain on the mesh data plane and use ingress or destination-waypoint authorization.
+Because `ztunnel` cannot enforce L7 policy, ingress handles management checks while the destination waypoint decodes and authorizes every MCP request before revision selection. Every stable package Service is waypoint-enrolled, and ingress traffic traverses that waypoint. `AuthorizationPolicy` permits application-port traffic only from its authenticated identity, including requests addressed directly to a Pod IP or revision Service. Health probes use a separate protected port with the minimum exception.
 
-`ztunnel` cannot enforce L7 authorization. MCP, revision, and administration checks therefore run at ingress gateways or destination waypoints. Every stable package Service is explicitly enrolled in a destination waypoint. Ingress-to-Service traffic is configured to traverse that waypoint, and `AuthorizationPolicy` `CUSTOM` rules use `targetRefs` for the enrolled Service or Gateway. Admission fails if the required waypoint, enrollment, extension provider, route, or policy attachment is absent or not accepted.
+A readiness controller keeps new `ztunnel` instances and affected workloads out of service until the current policy generation is loaded. Admission requires accepted waypoint enrollment, ingress waypoint use, bypass prevention, MCP decoding and authorization extensions, routes, and policy attachments.
 
-The ingress request decoder, external authenticator, internal-token exchange, and authorization adapter are protected extensions pinned by infrastructure configuration. The decoder executes before `ext_authz`. Ingress removes all external copies of their reserved headers and dynamic metadata before decoding. Only decoded metadata and signed token claims may select an operation or revision.
+The external authenticator, caller-token exchange, waypoint MCP decoder, authorization adapter, metadata-aware cluster selector, session wrapper, response observer, audit adapter, and routing-status reporter are protected extensions pinned by infrastructure configuration. The waypoint decoder executes before `ext_authz`, removes all external copies of reserved fields, and produces trusted dynamic metadata. After authorization, the cluster selector uses that metadata and signed generation-fenced configuration to choose a revision backend; standard `HTTPRoute` header matching is not used for decoded operations.
 
-After token verification, the waypoint derives a trusted operation routing key from the signed claim. Gateway API header matches may use only that platform-generated key to select operation-specific canary weights; no route matches a client-supplied operation header. Route configuration remains declarative and digest-correlated with the operation contracts admitted for both revisions.
+Production uses `ztunnel` for transport security and L4 authorization, `NetworkPolicy` for reachability, ingress `ext_authz` for management authorization, and destination-waypoint `ext_authz` for MCP authorization. Authorization fails closed; health ports have no public ingress.
 
-Production uses `ztunnel` for transport security and L4 workload authorization, Kubernetes `NetworkPolicy` for reachability, and ingress or waypoint `ext_authz` for application authorization. Authorization checks fail closed on denial or outage. Only the mesh data plane can reach package application ports; health and supervisor administration ports have minimal explicit exceptions and no public ingress.
+Waypoints emit L7 request rate, transport and MCP outcome, duration, response-size, route, operation, source and destination identity, selected backend, access-log, and trace telemetry. The protected response observer distinguishes HTTP transport results from JSON-RPC errors and terminal SSE outcomes without exposing response bodies. `ztunnel` emits L4 connection, byte, policy-denial, and bypass telemetry. Kubernetes reports Pod health, restarts, resources, and rollout state, while package instrumentation reports application-internal metrics and trace spans. Application metrics are scraped separately rather than merged through a per-Pod proxy.
+
+The waypoint audit adapter durably records malformed requests, token and envelope-hash failures, authorization denials, routing-generation mismatches, and session-token failures before returning an error. `ztunnel` policy denials flow through the protected audit pipeline. If a required security event cannot be delivered or durably buffered, the affected request fails closed.
 
 If `istiod` is unavailable, established traffic uses its last configuration. New revision operations requiring routing or policy changes fail closed until dependencies recover.
 
@@ -558,151 +572,107 @@ The mesh is redeployed only for changes to Istio or its trust and extension conf
 - Istio certificate-authority and trust-domain configuration
 - Mesh-wide extension-provider and ambient-enrollment configuration
 
-Protected system packages roll independently through the revision controller and do not require a mesh redeployment. Ordinary package revisions, registry connection changes, identity assignments, and authorization-binding updates likewise change runtime or control-plane state without redeploying the mesh. `gestaltd` supervisor updates roll with the workloads that use them.
+Protected system packages roll independently through the revision controller and do not require a mesh redeployment. Ordinary package revisions, upstream source and registry-policy changes, identity assignments, and authorization-binding updates likewise change runtime or control-plane state without redeploying the mesh.
 
-Bootstrap-substrate changes, including control-plane state migrations and backup or recovery tooling, use infrastructure rollouts but do not redeploy the mesh unless they also change an Istio item listed above. Package releases independently declare supported MCP versions, private runtime control API versions, and compatible `gestaltd` supervisor versions. Infrastructure pins Kubernetes, Istio, Envoy, routing-status extension, and dispatch-receipt protocol versions and accounts for overlapping old and new versions before admitting releases that require new features. Registry trust-root changes remain separately authorized and audited.
+Bootstrap-substrate changes, including control-plane state migrations and backup or recovery tooling, use infrastructure rollouts but do not redeploy the mesh unless they also change an Istio item listed above. Package releases declare supported MCP versions. Infrastructure pins Kubernetes, Istio, Envoy, the shared MCP extension, session-token format, authorization adapter, and routing-status extension versions and accounts for overlapping old and new versions before admitting releases that require new features. Registry trust-root changes remain separately authorized and audited.
 
 ## Representative Request Lifecycles
 
-The following lifecycles show how representative registry, management, and data-plane requests move through the system.
+These summaries add sequencing and externally observable behavior; preceding sections define the authoritative mechanics.
 
-### Create a Registry
+### Provision the Deployment Registry
 
-Registry creation is a registry-side operation and is distinct from connecting that registry to an organization. The reference registry-creation service and CLI are convenience tools, not gatekeepers; operators may instead use the underlying libraries or build any compatible implementation.
+Deployment provisioning creates one private registry with OCI 1.1 storage, a self-certifying `registryId`, publisher controls, and pull-through import. It publishes the signed descriptor and verifies storage, digest, authentication, authorization, and signature enforcement before serving traffic. Publisher private keys remain publisher-controlled.
 
-1. A registry operator uses the reference tooling or an independent implementation to provision a protocol-compatible registry and durable metadata store. The registry uses OCI 1.1 storage—Google Artifact Registry by default—for content-addressed images, manifests, and signature bundles.
-2. The registry generates an offline root key and derives its immutable `registryId` from that public key. The identifier remains stable wherever the registry is connected.
-3. The operator configures discovery and download visibility, publisher authentication, who may create packages, and who may publish versions to each package. The reference tooling may also configure optional GitHub listeners or other publication triggers.
-4. The operator configures the registry's publisher policy by registering publisher identities, their public keys, and the package IDs each key may sign. The reference tooling may provision KMS-backed signing keys, but private keys remain publisher-controlled and are never stored by the registry.
-5. The registry publishes a descriptor matching the required schema, including its protocol version, `registryId`, API endpoints, and supported signature formats, through its well-known metadata endpoint.
-6. Readiness checks verify metadata and blob durability, digest validation, authentication, authorization, and signature enforcement before the registry accepts publication or discovery traffic.
+### Pull a Package Release
 
-### Connect a Registry
-
-1. An organization administrator submits the registry's HTTPS origin, optional read credentials for a private registry, and a registry trust policy binding trusted publisher identities and public keys to package IDs.
-2. The ingress gateway authenticates the actor, removes untrusted identity headers, and calls the authorization service through `ext_authz`. The request proceeds only when the actor has the required registry-management permission.
-3. The registry-verification service connects through the permitted egress path and reads the registry's protocol version, immutable `registryId`, API endpoints, catalog, and signature bundles. Remote content remains untrusted.
-4. The control plane verifies the self-certifying `registryId`, descriptor signature and generation, and that the submitted origin is in the signed origin set. It rejects an origin already associated with a different registry identity. It stores any read credentials through the secret-management service and persists the verified registry identity, descriptor generation, and initial registry trust policy revision.
-5. After verification succeeds, the control plane marks the registry connected and advances the registry catalog generation. Packages become discoverable, but each release must still pass admission checks before installation.
-6. The API returns the registry record and verification status. Failures preserve diagnostics without making the registry available for discovery or installation.
+An administrator selects an external release, read-only authorization, and trust policy. The deployment registry verifies the source identity and complete release, copies its content into local storage, and atomically exposes it. The API returns the import status and `releaseDigest`; failures retain diagnostics but expose no installable release.
 
 ### Publish a Package Release
 
-1. A developer or CI job authenticates directly to the registry with its own publishing credential and runs `vt build <dir> --push`.
-2. `vt` validates the package metadata, builds every applicable digest-addressed artifact and OCI image index, creates the canonical release manifest, and calculates its `releaseDigest`.
-3. The registry authorizes the publisher to reserve `(packageId, releaseVersion)` and creates a recoverable publish-attempt ID. A version already bound to a different digest is rejected.
-4. `vt` uploads the content-addressed blobs, image indexes, and release manifest. The registry recalculates every digest and validates all referenced artifacts and release contracts before making anything discoverable.
-5. The publisher signs a statement containing the `registryId`, `packageId`, `releaseVersion`, `releaseDigest`, and every referenced runtime, migration, UI, workflow, and schema artifact digest with an authorized KMS-backed key, then uploads the signature bundle.
-6. The registry verifies the signature and confirms under its publisher policy that the signing key may publish the package. It then atomically binds the version to the digest and adds the release to the package catalog.
-7. The registry returns the immutable `releaseDigest`. Failed or interrupted attempts remain non-installable and may be retried; publishing does not install or deploy the release.
+A developer or CI job authenticates to the deployment registry and runs `vt build <dir> --push`. The registry validates and atomically publishes the signed release, then returns its immutable `releaseDigest`. Interrupted attempts remain non-installable, and publishing never installs the release.
 
 ### Upgrade a Package
 
-1. An organization or package administrator selects a target `releaseDigest` for an installed package and submits a durable upgrade revision request with any approved identity or authorization changes.
-2. The ingress gateway authenticates and authorizes the actor. The control plane verifies any required `service_account.assign` and `authorization.grant` permissions.
-3. The control plane appends the revision request, verifies that no revision operation is active for the installation, and creates a generation-fenced revision operation. The API returns the operation ID so the client can observe progress asynchronously.
-4. The revision controller verifies the recorded registry trust policy revision, release and image signatures, platform and runtime compatibility, schemas, dependencies, reverse dependents, workflows, and migrations against the recorded desired-state snapshot.
-5. The controller runs declared prepare migrations, creates any immutable candidate runtime resources, stages UI bundles and workflow definitions, and applies required ambient enrollment and `AuthorizationPolicy` attachments. Candidate artifacts remain absent from user-facing catalogs and receive no default production traffic.
-6. After applicable readiness remains stable, the controller may canary runtime operations whose contracts exactly match the promoted revision. Promotion writes any primary routing intent and waits for routing status, UI-serving, and workflow-registration prerequisites associated with the candidate generations.
-7. After applicable routing, UI-serving, and workflow-registration prerequisites remain converged for the stability window, one transaction advances the promoted head and relevant routing, package, operation, UI, and workflow generations. The previous runtime revision drains pinned requests and streams while the controller observes the promoted revision and runs any separately approved finalization.
-8. The controller records the terminal outcome. A pre-promotion failure leaves the previously promoted revision primary.
+An authorized administrator submits a durable request naming the target `releaseDigest` and approved identity or authorization changes. The control plane verifies permissions, appends the request, fences the operation, and returns its ID. Candidates remain absent from user catalogs and receive no primary traffic before promotion; operations with identical contracts may receive controlled canary traffic. Promotion uses the convergence-gated transaction above, and pre-promotion failure leaves the prior revision primary.
 
 ### Invoke a Package Operation
 
-1. An external caller sends an MCP Streamable HTTP request to the package-scoped deployment endpoint with a session credential or API grant and a JSON-RPC envelope.
-2. The ingress gateway authenticates the credential, removes untrusted internal metadata, applies request limits, and decodes the MCP request class and canonical operation when applicable before calling the authorization service through `ext_authz`.
-3. The authorization service evaluates the credential scope, effective subject, target installation, request class, canonical operation ID when applicable, approved package access policy, and any operation-specific resource against one policy generation. An unknown target or denied check fails before dispatch.
-4. The gateway exchanges the external credential for a short-lived internal invocation token bound to the target installation, request class, applicable operation, and request-envelope hash.
-5. The destination waypoint revalidates the token, applies the trusted operation-specific route when applicable, selects a revision Service, and attaches a signed dispatch receipt. A new session becomes pinned to that revision.
-6. The package supervisor verifies the token and dispatch receipt and relays the MCP request to the private runtime socket. The runtime returns one JSON-RPC response or opens an SSE stream; an open stream remains on the selected revision while that revision drains.
-7. The response returns through the mesh and ingress gateway. The platform records the authorization decision, policy model ID and revision, actor, effective subject, immediate caller workload identity, target, `releaseDigest`, internal token and dispatch-receipt IDs, trace ID, duration, and outcome.
+An external caller sends MCP Streamable HTTP to a package-scoped endpoint. Ingress authenticates, strips untrusted metadata, applies transport limits, and issues a caller token bound to the installation and envelope hash; it neither parses MCP nor authorizes an operation. The waypoint validates the token, decodes and authorizes the request, removes the caller token, adds signed internal context, selects the revision, and pins sessions through its signed wrapper. The runtime receives the request directly. Audit records include the decision and policy generation, actor, effective subject, immediate caller workload when applicable, target, `releaseDigest`, caller-token ID, trace ID, duration, and outcome.
 
-Package-to-package invocation does not pass through ingress. The calling package presents a platform-issued internal invocation token to the destination waypoint, which performs the corresponding workload and effective-subject authorization checks before revision routing and dispatch. Raw caller credentials are never forwarded.
+Package-to-package calls bypass ingress but still terminate at the destination waypoint. The identity service derives an attenuated, single-target token from authenticated workload context; raw caller credentials are never forwarded.
 
 ## Assurance
 
 ### Retention and Audit
 
-Release metadata, accepted revision history, and audit events are retained according to applicable policy. Registries and platform-owned artifact storage retain blobs required by active revisions or the configured rollback window. Unreferenced blobs may be garbage-collected after a grace period; shared OCI layers are deleted only after references are rechecked.
-
-Authentication, authorization, registry, package-lifecycle, migration, secret-access, and network-policy events are written to the immutable audit sink with the actor, target, decision, relevant identifiers, trace ID, and outcome.
+Retention follows active-revision, rollback, recovery, and garbage-collection rules above; shared OCI layers are deleted only after references are rechecked. Authentication, authorization, registry, lifecycle, migration, secret-access, and network-policy events go to the immutable audit sink with actor, target, decision, identifiers, trace ID, and outcome.
 
 ### Required Verification
 
 Before production use, automated tests cover:
 
-- **Registry and release integrity**: atomic publication under retries and concurrency, signature and compatibility rejection, and safe disconnection and garbage collection
-- **Runtime contract**: supervisor protocol negotiation, digest-aware readiness, request-envelope decoding, token binding, cancellation, session pinning, SSE draining, and malformed or ambiguous MCP requests
+- **Registry and release integrity**: one-registry-per-deployment enforcement, least-privilege push and upstream read authorization, atomic publication and pull-through import under retries and concurrency, preservation of source identity, complete local artifact closure, signature and compatibility rejection, upstream-source disablement, and safe garbage collection
+- **Runtime contract**: direct MCP and health endpoints, platform-manifest-pinned Pods, synthetic contract readiness, Kubernetes shutdown, waypoint request and response decoding, token upper bounds, protected catalog filtering, cancellation, session rotation and pinning, SSE draining, and malformed or ambiguous MCP requests
 - **Revision state machines**: validation failures, administrator, controller, and dependency races, restart at every phase, and migration idempotency and lease loss
 - **Rollout and recovery**: canary and promotion failures before and after routing intent, proxy-membership churn, route restoration, atomic rollout groups, catalog convergence, draining and SSE behavior, rollback approval, removal, tombstones, retained workflows, autoscaling, and mixed versions
 - **Platform lifecycle**: bootstrap ordering and outages, protected identities and signers, ordinary-package replacement prevention, and independent infrastructure and system-package rollouts
 - **Authorization models**: deterministic policy publication, active-grant preservation, subject-set cycles, and parity between batch and individual checks
 - **Identity and delegation**: spoofing, claim validation, token expiration and rotation, `runAs`, confused-deputy prevention, attenuation, and revocation
-- **Fail-closed enforcement**: authorization outages, data-plane bypass attempts, and ingress or waypoint `ext_authz` failures
+- **Fail-closed enforcement**: authorization and audit outages, direct Pod-IP and revision-Service bypass attempts, `ztunnel` and waypoint churn, stale policy generations, and ingress or waypoint `ext_authz` failures
 - **Interfaces and workflows**: route collisions, CSP and asset validation, revision-qualified caching, pinned workflow executions, signals and timers during upgrades, retirement, migration, and forced termination
 - **Disaster recovery**: regional state restore, route reconstruction, signing-key and certificate recovery, protected-service recovery, audit continuity, and break-glass controls
 
 ## Glossary
 
-**package identity**<br>
-Permanent `(registryId, packageId)` for a registry package. Assigned when the package is reserved; never reused.
+| Term | Meaning |
+| --- | --- |
+| Package identity | Permanent `(registryId, packageId)`; never reused |
+| Pull-through import | Verified, atomic copy of an external release and its complete artifact closure into the deployment registry using read-only upstream authorization |
+| `releaseDigest` | Hash of canonical manifest bytes and authoritative install input |
+| Revision | Installed release or removal tombstone |
+| Revision operation | Fenced execution of durable revision intent |
+| Promotion | Atomic commit advancing the promoted head and catalog generations |
+| Routing generation | Durable correlation of one routing decision, its resources, proxy set, and observations |
+| Atomic rollout group | One fenced promotion across mutually dependent packages |
+| Caller token | Signed pre-authorization context presented only to a destination waypoint |
+| Internal caller context | Signed post-authorization context forwarded to a runtime |
+| Protected system package | Signer-pinned platform package unavailable to ordinary package APIs |
+| Waypoint | Shared Envoy proxy for MCP authorization, revision routing, sessions, and telemetry |
+| `ztunnel` | Node-level ambient proxy for L4 security and workload identity |
 
-**release**<br>
-Immutable artifact with detached signatures for one `releaseVersion` of a package, identified by `releaseDigest`.
+## Appendix: Design Invariants
 
-**releaseVersion**<br>
-Registry-scoped version label for one published release of a package. `(registryId, packageId, releaseVersion)` binds permanently to one `releaseDigest`.
+The following invariants apply to every implementation:
 
-**releaseDigest**<br>
-Content hash of the canonical release manifest bytes. The authoritative install input; signatures bind to it.
+1. Published releases are immutable and digest-addressed.
+2. Revision intent and outcomes are append-only.
+3. Each package slot permits one active fenced revision operation.
+4. Controllers reconcile durable intent idempotently and resume after failure.
+5. Lifecycle state, workload observations, routing convergence, and catalog convergence remain distinct.
+6. Only successful promotion changes the promoted head.
+7. Every traffic-eligible revision satisfies the compatibility and removal rules in [Dependencies and Contracts](#dependencies-and-contracts).
+8. Organization-managed identities are the sole source of runtime authority.
+9. Ordinary package APIs cannot replace the bootstrap substrate or protected platform capabilities.
+10. External artifacts remain untrusted until admission verifies their digests, signatures, schemas, and policy.
+11. Authorization uses canonical identities and one immutable policy generation; policy changes cannot silently delete or orphan grants.
+12. Package runtimes receive no raw credentials or caller-supplied identity, only short-lived, signed, audience-bound caller context.
 
-**revision**<br>
-One installed state of a package in an organization, backed by a specific `releaseDigest`.
+## Appendix: Foundations
 
-**revision request**<br>
-Durable intent to install, upgrade, rollback, or remove a package.
+### Identity Model
 
-**revision operation**<br>
-Generation-fenced state machine that executes one revision request.
+The system keeps these identities separate:
 
-**revision controller**<br>
-Background worker that drives a revision operation to completion and resumes after failure.
+- **Registry identity**: an immutable self-certifying `registryId` derived from the registry's offline root public key. The identifier is globally stable for that registry but does not imply endorsement by, or membership in, a central registry namespace. Signed registry descriptors authorize the current origin set and origin changes.
+- **Package identity**: permanent `(registryId, packageId)` assigned when the package is reserved. A slug is a mutable display and discovery alias, never a security identifier.
+- **Release identity**: `(registryId, packageId, releaseVersion, releaseDigest)`.
+- **Installation identity**: an organization-scoped UUID representing one installed package.
+- **Workload identity**: the installation principal used in authorization checks for one installation's runtime or migration job, bound at installation to an organization-managed Kubernetes service account.
+- **Workflow identity**: the principal assigned to a workflow definition or execution.
+- **Actor identity**: the user, API grant, platform service account, or workflow that initiated an action.
+- **Effective subject**: the principal whose delegated authority an invocation exercises.
 
-**rollout**<br>
-Path from admission through readiness, optional canarying, and promotion for an install or upgrade candidate.
+Authentication resolves credentials to canonical principals before authorization. Downstream services accept identity only from verified workload identity or signed context; delegation preserves actor and effective subject through authorization and audit.
 
-**promotion**<br>
-Atomic state-store commit that advances the promoted revision and relevant routing, package, operation, UI, and workflow generations after all applicable prerequisites have converged.
-
-**routing generation**<br>
-Durable identifier that correlates one routing decision with its exact Kubernetes resources, desired route hashes, relevant proxy-membership snapshot, and convergence observations.
-
-**atomic rollout group**<br>
-One generation-fenced revision request that validates and promotes mutually dependent package revisions as a single desired-state and catalog change.
-
-**authorization model**<br>
-Immutable, content-hashed definition of resource types, relations, actions, and allowed relationship targets used for one generation of authorization decisions.
-
-**relationship tuple**<br>
-An assignment of a subject, resource, or subject set to one relation on a resource.
-
-**internal invocation token**<br>
-Short-lived signed context carrying verified caller and delegation information, bound to its issuer, audience, target installation, request class, optional operation, and request-envelope hash.
-
-**package supervisor**<br>
-Platform-owned `gestaltd` sidecar in each runtime Pod that implements the mesh-facing runtime contract, verifies invocation context, gates runtime readiness and shutdown, and reports observed state.
-
-**bootstrap substrate**<br>
-Infrastructure that must exist before package APIs are available, including Kubernetes, Istio, control-plane state, revision controllers, certificate authority, and recovery tooling.
-
-**protected system package**<br>
-A trusted, signer-pinned package that uses normal revision rollouts but has a fixed platform identity and cannot be replaced or removed through ordinary package APIs.
-
-**waypoint**<br>
-Shared Envoy proxy that enforces L7 routing and authorization for Kubernetes Services exposing packages in ambient mode.
-
-**workflow service**<br>
-MCP service in the mesh that registers package-defined workflows and executes them outside package processes.
-
-**ztunnel**<br>
-Node-level ambient proxy that provides L4 transport security and workload identity for enrolled pods.
+Package IDs are never reused; slug renames retain aliases and tombstones. A different registry yields a different package identity even for identical bytes. Release metadata cannot name workload identities or Kubernetes service accounts; installation selects them from organization-managed resources.

--- a/plans/service_mesh/plan.md
+++ b/plans/service_mesh/plan.md
@@ -2,105 +2,296 @@
 
 ## Overview
 
-The platform builds, distributes, installs, and runs services in a shared service mesh. A service package may include:
+The platform builds, distributes, installs, and runs services in a shared service mesh. A service release may include:
 
 - An MCP server and its operations
-- User interface (single-page app or SPA's)
-- Workflows
+- One or more single-page user interfaces
+- Durable workflow definitions and workers
 - Dependency and migration metadata
-- Runtime and authorization requirements
+- Runtime, configuration, secret, network, and authorization requirements
 
-Organizations operate a deployment backed by one private registry and, optionally, additional public registries. The deployment exposes a catalog of installed services, operations, interfaces, workflows, and dependencies.
+An organization operates one deployment backed by a private registry and, optionally, additional trusted registries. The deployment exposes catalogs of installed services, callable operations, user interfaces, workflows, and dependencies.
 
-## Architecture
+Publishing makes a release discoverable. Installation admits an immutable release into an organization. Canarying permits controlled, undiscoverable traffic, while promotion makes an installed revision primary and user-discoverable. These states are separate and must not be inferred from one another.
+
+## Design Invariants
+
+The following invariants apply to every implementation:
+
+1. A published release is immutable and identified by a digest.
+2. A deployment records every accepted install, upgrade, rollback, and removal request in an append-only revision history.
+3. At most one lifecycle operation for an organization and canonical service identity is nonterminal at a time, including first installation.
+4. Request handlers record intent; reconcilers perform runtime work and resume safely after process failure.
+5. Published, admitted, materialized, running, ready, canary-callable, promoted, and converged are distinct states.
+6. A pre-promotion failure does not replace the last successfully promoted revision.
+7. Routing propagation is eventually consistent, so every revision that may receive traffic remains contract-compatible until propagation and draining finish. New contracts become visible only after routing convergence.
+8. Package metadata can request capabilities but cannot grant itself identity, authorization, secrets, ingress, or egress.
+9. Dynamic services cannot replace the identity, authorization, certificate, secret, registry-verification, audit, state-storage, or recovery components needed to administer the mesh.
+10. Every externally supplied manifest, image, schema, migration, and attestation is untrusted until its digest, signature, and policy are verified.
+
+## Runtime Architecture
 
 The runtime consists of:
 
-- **Control plane (`istiod`)**: manages mesh configuration and service routing.
-- **Ingress data plane**: receives traffic from the load balancer.
-- **Service data plane (`gestaltd`)**: runs alongside each service and mediates mesh traffic.
-- **Service runtime**: runs the service's server, interfaces, and workflows.
+- **Istio control plane (`istiod`)**: distributes routing, policy, endpoint, and certificate configuration to the Istio data plane.
+- **Istio workload data plane**: Envoy sidecars mediate inbound and outbound workload traffic. Ambient mode, using mandatory node-level `ztunnel` proxies and optional L7 waypoint proxies, is a possible later deployment mode; a deployment uses one documented mode at a time.
+- **Ingress gateways**: separate Envoy data-plane proxies terminate external transport, remove untrusted identity headers, authenticate supported credentials, and route public and organization traffic.
+- **Egress gateways**: separate Envoy data-plane proxies enforce and audit declared external network access where direct egress cannot be safely allowed.
+- **Service supervisor (`gestaltd`)**: runs alongside one service installation, mediates application-level invocation and authorization, reports observed state, and manages the service process. It is not an Istio data-plane proxy and does not replace Envoy.
+- **Service runtime**: runs the service's MCP server, interfaces, and workflow workers.
+- **Lifecycle controllers**: reconcile durable install and rollout records into workloads, routing, catalogs, identities, and policy.
 
-Terraform deploys the GCP infrastructure, including the Valon Tools cluster, GitHub Actions cluster, networking, container infrastructure, and identity services.
+Production uses Istio `PeerAuthentication` in `STRICT` mode for mesh mutual TLS, Istio `AuthorizationPolicy` for workload-to-workload policy, and Kubernetes `NetworkPolicy` for network reachability. The deployment installs explicit default-deny authorization and network policies; these mechanisms are not assumed to deny traffic merely because they are enabled. Service application ports are reachable only through the mesh data plane. Health and supervisor administration ports have explicit, minimal exceptions and are not exposed through public ingress.
 
-## Service Packages
+Established data-plane traffic continues using the last known configuration when `istiod` is unavailable. New lifecycle operations that require routing, certificates, policy, or registry verification fail closed until their control-plane dependencies recover.
 
-When first published, a registry assigns the service a UUID unique within that registry and associates it with a human-readable slug. Service references include both the registry and UUID. Each package version consists of a built OCI image and a service manifest for a specific platform. The service manifest contains:
+Terraform deploys the GCP infrastructure, including the Valon Tools cluster, GitHub Actions cluster, networking, container infrastructure, identity services, and deploy-pinned trusted components. Installing services does not mutate this trusted computing base.
 
-- The immutable OCI image reference and digest
-- Instructions for starting the MCP server and user interfaces
-- The MCP endpoint, operations, and input/output schemas
-- Included workflows and interfaces
-- Service and operation dependencies
-- Ordered pre-upgrade and rollback commands
-- Service-account and authorization requirements
-- Health and readiness endpoints
-- Configuration and secret requirements
-- Image signature and build provenance
+## Identity Model
 
-Upgrade commands may perform schema migrations, workflow changes, or other dependency updates. They should be idempotent and reversible where possible.
+The system keeps these identities separate:
+
+- **Registry identity**: immutable `registryId` plus its configured origin and trust-policy digest.
+- **Service identity**: permanent `(registryId, serviceId)` assigned when the service is reserved. A slug is a mutable display and discovery alias, never a security identifier.
+- **Release identity**: `(registryId, serviceId, version, releaseDigest)`.
+- **Installation identity**: an organization-scoped UUID representing one installed service.
+- **Workload identity**: an orchestrator-owned SPIFFE identity for one installation's runtime or migration job.
+- **Workflow identity**: the principal assigned to a workflow definition or execution.
+- **Actor identity**: the user, API grant, service account, or workflow that initiated an action.
+- **Effective subject**: the principal whose delegated authority an invocation exercises.
+
+Service IDs are never reused. Slug renames retain aliases and tombstones. Mirroring a service preserves its identity only through a signed mirror or transfer relationship; otherwise importing it creates a distinct service identity.
+
+Package authors cannot select workload identities. The orchestrator binds installations to Kubernetes service accounts and short-lived SPIFFE certificates. Trust domain, certificate lifetime, rotation, and compromise revocation are deployment policy.
+
+## Service Releases
+
+One service version has one platform-independent, signed release manifest. The release manifest is stored as an OCI artifact or another digest-addressed immutable object and references an OCI image index digest. The image index selects immutable image manifests for supported `os`, `architecture`, and optional `variant` tuples.
+
+Platform images may contain different binaries, but their operation contracts, dependencies, migrations, workflows, and requested capabilities must match the release manifest. A platform-specific release contract is not allowed.
+
+The release manifest contains:
+
+- Canonical registry and service IDs, slug, and version
+- OCI image-index digest and supported platforms
+- Instructions for starting the MCP server, interfaces, and workflow workers
+- MCP endpoint, operations, and input/output schema digests
+- Included workflows and user interfaces
+- Required and optional service and operation dependencies
+- Ordered prepare, finalize, and compensating migration jobs
+- Rollback classification
+- Requested service-account, authorization, ingress, and egress capabilities
+- Configuration and typed secret requirements
+- Startup, liveness, and readiness endpoints
+- Minimum and maximum supported `gestaltd` and mesh protocol versions
+- Source repository and revision
+- Subjects for detached signatures and build-provenance attestations
+
+The manifest does not contain self-asserted signatures or provenance. Signatures and SLSA/in-toto provenance are detached attestations over the release and image digests, such as OCI referrers.
+
+The release digest is computed over the canonical manifest bytes and is carried by catalog entries, signatures, attestations, and installation records rather than by the hashed manifest itself.
+
+Versions follow a registry-defined, documented grammar and comparison order. A `(registryId, serviceId, version)` binds permanently to one release digest. A conflicting republish is rejected. An identical retry is idempotent and does not rewrite publication time or provenance. Mutable tags may aid discovery but are never installation inputs.
 
 ## Registries
 
-Registries store versioned service packages and control who can discover or download them. A deployment may use private, organization-specific, and public registries, provided each implements the registry interface.
+Registries control who can publish, discover, or download releases. Each configured registry has:
 
-Each registry exposes a catalog manifest listing its services. Each entry includes the registry-scoped service UUID, slug, available versions and platforms, service manifest location, and immutable OCI image reference and digest. The OCI image is the deployable artifact; a Dockerfile may be retained as optional source provenance but is not part of the runtime contract.
+- An immutable `registryId`
+- Discovery, metadata, blob, and publication endpoints
+- Authentication and authorization scopes
+- Trusted signing identities and builders
+- Allowed service namespaces
+- Source repository and workflow constraints
+- Required provenance level
+- Whether direct developer publication is permitted
+- A versioned trust-policy digest
 
-A registry can be connected to a GitHub repository and configured to build from `main`, pull requests, or label-based rules. Service developers can also build and push packages directly.
+Connecting a registry does not trust every publisher in it. Catalogs and manifests remain untrusted until admission verifies their immutable digests, signatures, provenance, schema versions, and the deployment's registry policy.
+
+The registry interface defines pagination, conditional reads, consistency guarantees, error codes, retries, rate limits, and authentication separately for catalog discovery, immutable metadata, blob pulls, and publication.
+
+A catalog contains paginated service and release summaries pointing to authoritative release-manifest digests. It does not duplicate the full release contract. Per-service indexes use monotonic revisions and compare-and-swap updates.
+
+Disconnecting a registry blocks new discovery and installation but preserves its identity and all historical records. Hard removal is rejected while any desired, running, redeployable, dependent, or in-progress revision references it. Rebinding to a mirror requires digest-equivalent content and signatures trusted by the deployment.
 
 ## Build and Publish
 
-1. `vt build <dir>` builds a service package from a source directory and its manifest.
-2. The build produces a platform-specific OCI image with an immutable digest.
-3. The package is published through the configured GitHub integration or with `--push <registry-url>`.
-4. The registry publishes the catalog and service manifests and points them to the built OCI image.
+`vt build <dir>` validates source metadata and builds an OCI image index and release manifest. The build records resolved source and material digests. Production publication requires attestations from a trusted builder; direct publication must satisfy the same policy.
 
-`vt dev <url> <dir> <token>` injects a local service into an existing mesh for development. A development service runs with the developer's identity.
+Publication is a recoverable transaction:
+
+1. Reserve `(serviceId, version)` and create a publish-attempt ID.
+2. Record a pending release with source and workflow provenance.
+3. Upload content-addressed image blobs and manifests.
+4. Validate all platform images and release contracts server-side.
+5. Create the immutable release manifest.
+6. Attach signatures and provenance attestations.
+7. Commit availability by compare-and-swap updating the service catalog last.
+8. Mark the attempt succeeded or failed.
+
+Pending and failed attempts are visible but never installable. Concurrent publishers cannot lose catalog updates. Stale attempts become failed, and orphaned content-addressed blobs are garbage-collected after a grace period.
+
+## Durable Deployment State
+
+The control plane persists:
+
+- **Service slots**: one organization-scoped slot keyed by canonical service identity, reserved before allocating an installation ID and used to fence concurrent first installs
+- **Revision requests**: append-only install, upgrade, rollback, and removal intent with actor, previous promoted revision, target release digest, approved capabilities, resolved dependencies, and timestamps
+- **Installation head**: last successfully promoted revision and current admitted candidate
+- **Lifecycle operation**: one generation-fenced state machine per installation
+- **Migration outcomes**: immutable status keyed by installation, release digest, and migration ID
+- **Workload observations**: materialized, started, ready, draining, stopped, and error state for each target replica
+- **Routing and catalog generation**: the promoted revision visible to callers
+- **Terminal outcomes**: completion or failure phase, duration, and reason
+
+Lifecycle records use optimistic concurrency and fencing tokens. A stale controller cannot mutate a newer generation after losing its lease. Retries are idempotent, and every external mutation has a stable idempotency key.
+
+Each rollout targets one immutable runtime cohort identified by the infrastructure generation and `gestaltd` supervisor generation. Replicas enroll during a bounded epoch; the nonempty cohort is then frozen for promotion accounting. Scaling replicas that join later still converge but do not retroactively change the completed cohort. Observations include the rollout generation and enrollment epoch so stale or overlapping infrastructure cohorts cannot satisfy a newer rollout.
+
+Routing convergence uses a separately frozen proxy cohort. In sidecar mode it contains every live ingress gateway plus the live sidecars of declared reverse-dependent caller workloads at the promotion epoch. `istiod` xDS status supplies proxy membership and acknowledgement of the target routing generation. A reverse-dependent replica that starts later cannot become ready until it receives at least that generation. Undeclared direct east-west invocation is denied, so it cannot bypass this cohort. Ambient mode must define the equivalent gateway, waypoint, and `ztunnel` cohort before it is supported.
+
+The runtime distinguishes:
+
+- **Published**: committed in a registry
+- **Admitted**: verified and accepted as a candidate by the organization
+- **Materialized**: image and immutable contract are available to a workload node
+- **Running**: the candidate process started
+- **Ready**: the candidate passes readiness and minimum healthy-duration checks
+- **Canary-callable**: an undiscoverable candidate receives a controlled subset of traffic for operations whose contracts exactly match the promoted revision
+- **Promoted**: routing selects the candidate as primary
+- **Converged**: the required workload cohort observes the promoted generation
 
 ## Installation
 
-Publishing a service does not install it. On first installation, an organization administrator selects a version and configures:
+Publishing does not install a service. An organization administrator selects an immutable release digest and binds:
 
-- The identity used by workflows
-- The identity used by service operations
-- Whether an operation forwards the caller's identity
-- The service's authorized operations
+- Organization-owned service and workflow identities
+- Package-requested operations and capabilities to approved authorization relationships
+- Caller-delegation policy per operation
+- Typed configuration values and secret references
+- Ingress and egress requests to organization policy
+- Initial replica, resource, and availability settings
 
-A service identity cannot initially exceed the installer’s authorization. Its relationships are assigned using the authorization model below.
+The platform shows the requested-versus-approved capability diff before admission. An installer can use only identities for which they have `can_use` or `can_delegate`, and cannot convert temporary authority into an unrestricted persistent service grant. Sensitive capabilities may require a second approver.
 
-Installing or removing a service updates the runtime catalog without redeploying the service mesh.
+Installation is a reconciled saga:
 
-## Upgrades
+1. Verify registry trust, release and image signatures, provenance, platform support, runtime compatibility, and schema versions.
+2. Resolve exact dependency revisions and operation-contract digests.
+3. Reserve the organization service slot and persist the revision request, approved capability snapshot, and fenced lifecycle operation.
+4. Provision the installation identity, workload identity, policy, configuration, and secret bindings.
+5. Materialize and start the initial workload without making it callable.
+6. Require readiness quorum and minimum healthy duration.
+7. Promote routing, wait for the frozen proxy cohort to acknowledge the routing generation, and drain any prior compatible route.
+8. Advance the callable catalog only after routing converges, then record convergence and the terminal outcome.
 
-Before an upgrade, the platform verifies that required operations exist, dependencies are ready and not being upgraded, and the package defines valid pre-upgrade and rollback commands.
+Failures preserve the durable phase and diagnostics. The reconciler retries retryable phases within policy and compensates unpromoted resources when an administrator cancels the installation. A service is not callable until promotion succeeds.
 
-The upgrade sequence is:
+## Dependencies and Contracts
 
-1. Pull the new OCI image.
-2. Run the service's pre-upgrade commands in order.
-3. Start the new service version.
-4. Validate startup and the `/ready` endpoint.
-5. Shift traffic to the new version.
+Dependencies use canonical service identities, version ranges, and required operation contract digests. Dependencies may be required or optional. Admission records the exact revisions and contract digests selected.
 
-The old version continues serving until the traffic shift. If an upgrade step fails, the platform stops the upgrade and records the failed command and error. An authorized administrator then resolves the failure and manually runs the declared rollback commands.
+The platform validates:
 
-After traffic shifts, traffic may return to the old version only when the package declares that rollback safe. Automatic rollback can be added later using the same commands and safety declaration.
+- Every required dependency has a promoted compatible revision
+- Required operations exist
+- Required input and output contracts match
+- The candidate remains compatible with existing reverse dependents
+- No conflicting lifecycle operation is active in the affected dependency subgraph
+- Workflow calls reference compatible operation contracts
 
-Workflows should continue running during an upgrade unless they call the service being upgraded. Service operations and interfaces may be unavailable during the traffic transition. The target is less than ten seconds of downtime.
+JSON Schemas use one pinned dialect and canonical encoding before hashing. The first implementation requires exact schema digests. Semantic compatibility can be introduced only with documented contravariant input and covariant output rules.
 
-## Administration and Discovery
+Validation reads a revisioned desired-state snapshot and commits with generation preconditions. For independent services, upgrades may proceed concurrently. Upgrades that affect the same dependency subgraph use deterministic locking or one atomic multi-service rollout plan. Dependency cycles are rejected until atomic rollout groups are implemented.
+
+## Upgrades and Traffic Promotion
+
+An upgrade never mutates the running revision in place. It creates a candidate generation while the last promoted revision continues serving.
+
+The rollout state machine is:
+
+1. **Admitted**: verify the release, policy, runtime compatibility, dependencies, reverse dependents, and rollback classification.
+2. **Staging**: pull and verify images for the target cohort.
+3. **Preparing**: run backward-compatible prepare migrations as fenced one-shot jobs.
+4. **Starting**: start candidate workloads with no production traffic.
+5. **Ready**: require a readiness quorum and minimum healthy duration.
+6. **Canarying**: route a configurable small traffic percentage for operations whose contracts exactly match the promoted revision; the candidate remains absent from user-facing catalogs.
+7. **Promoting**: make the candidate primary, wait for the frozen proxy cohort to acknowledge the routing generation, and only then expose newly added contracts in callable catalogs. Promotion is the boundary after which the candidate is the last successfully promoted revision.
+8. **Draining**: keep the prior revision available for in-flight requests and streams until their drain deadline.
+9. **Soaking**: observe the promoted revision for a configured period.
+10. **Finalizing**: run irreversible contract/finalize migrations only after the rollback window when required.
+11. **Complete**: record convergence and terminal timing.
+
+Each phase has a timeout, retry policy, and terminal error taxonomy. Promotion requires nonempty frozen runtime and proxy cohorts and cannot be inferred from one ready instance. Routing changes define weight propagation, proxy acknowledgement, readiness quorum, connection draining, and behavior for MCP SSE streams. During partial routing propagation, both revisions support the promoted operation-contract digests.
+
+Failures before promotion produce a failed candidate and leave the prior promoted revision primary. Failures during soak after promotion mark the new revision degraded and trigger rollback when its rollback class permits; otherwise they require an audited forward fix. Finalization failure does not relabel the promoted revision as a failed candidate or route traffic implicitly: it records `promoted_with_finalization_error`, blocks the next lifecycle operation, and requires retry or an approved forward fix.
+
+The availability goal is zero planned downtime for services that satisfy the compatibility contract. Any supported operation that requires downtime declares and receives explicit administrator approval before admission; a vague downtime target is not sufficient.
+
+## Migrations and Rollback
+
+Migrations are separately identified, digest-pinned jobs. Each declares:
+
+- Migration ID and release digest
+- Prepare, finalize, or compensating phase
+- Dedicated workload identity and requested capabilities
+- Required secrets and network destinations
+- Timeout, resource limits, retry policy, and idempotency key
+- Compatibility with the prior and candidate service revisions
+
+Migration jobs run with least privilege and deny-by-default egress. They never run as the installer, lifecycle controller, or normal service identity. Attempt and completion records are durable.
+
+Each release declares one rollback class:
+
+- **Traffic-only**: the previous revision can serve against the current data model
+- **Code and compatible data**: old code and schema remain mutually compatible
+- **Compensating migration required**: rollback requires a declared, verified job
+- **No post-promotion rollback**: an explicitly approved release cannot return traffic to the prior revision after promotion
+
+Prepare migrations follow expand/contract rules and must remain compatible with the serving revision. Releases with a rollback-capable class defer destructive finalize migrations until the rollback window closes. A no-post-promotion-rollback release requires explicit approval before promotion and has no rollback window. A rollback command is not proof that data rollback is safe.
+
+Administrators initiate rollback through the same lifecycle controller. Manual shell execution cannot update lifecycle state. Automatic rollback may later invoke the same audited state machine when canary or soak gates fail.
+
+## Workflows
+
+Workflow definitions are immutable and versioned independently from service processes. Each execution records its workflow-definition digest, actor, workflow identity, and compatible service-operation contract revisions.
+
+Existing executions continue on workers that support their pinned definition until they complete, migrate, or reach a documented retirement policy. New executions use the promoted workflow catalog generation. Removal and incompatible upgrades must account for queued work, retries, timers, and long-running executions before workers are drained.
+
+Every workflow operation is authorized at execution time. `can_run_as` is required to select an organization-managed workflow identity. The original triggering actor remains in the audit and delegation chain.
+
+## Removal
+
+Removal is a durable tombstoned revision, not deletion of a catalog row:
+
+1. Reject removal while required reverse dependents exist, unless they are removed in the same atomic plan.
+2. Promote a tombstone generation that removes callable catalog entries and prevents new invocation resolution.
+3. Drain already-resolved requests, streams, workers, and queued work according to policy.
+4. Stop workloads and block ingress and egress.
+5. Revoke workload certificates, installation-owned assignments, delegated tokens, secret bindings, and runtime configuration.
+6. Apply service-data retention or destruction policy.
+7. Preserve the service tombstone and audit history.
+8. Garbage-collect runtime resources after the recovery window.
+
+Organization-owned persistent grants are not silently deleted; the removal UI distinguishes them from installation-owned grants. Reinstallation creates a new installation identity unless an explicit restore operation reactivates the tombstone within policy.
+
+## Catalogs and Administration
 
 An organization deployment provides:
 
 - A service catalog
 - An operation catalog
 - A user-interface catalog
+- A workflow catalog
 - A dependency graph
-- Service details, versions, workflows, identities, and authorization settings
-- API-key management
+- Service revisions, rollout and migration status, identities, and authorization settings
+- API-grant management
 - A development sandbox
 
-Organization administrators can connect registries and install, upgrade, or remove services. Service developers can build, publish, test, and invoke services. Service users see only the catalogs and tools available to them.
+Candidate metadata may be visible to administrators, but user-facing callable catalogs expose only contracts safe for the currently propagated routes. Routing is updated first because xDS propagation is asynchronous; newly added contracts become discoverable only after the frozen proxy cohort acknowledges the routing generation. Both revisions remain contract-compatible until old routes drain. Each invocation, including an SSE stream, resolves once and remains pinned to one service revision.
+
+Organization administrators can connect registries and install, upgrade, roll back, or remove services. Service developers can build, publish, test, and invoke services. Service users see only catalogs and operations authorized for them.
 
 Representative endpoints:
 
@@ -109,38 +300,115 @@ Representative endpoints:
 - Administration: `https://vt.valon.tools/admin`
 - Service administration: `https://vt.valon.tools/services/<service>/admin`
 
+Management APIs use a private listener or equivalent network restriction and require stronger authorization than user invocation endpoints.
+
 ## Invocation
 
 Authorized operations are available over the deployment endpoint and through the CLI:
 
 ```sh
-vt invoke <url> <service> <operation> <args> <token>
+vt invoke --deployment <url> <service> <operation> --args <json>
 ```
 
-Operation invocation uses MCP Streamable HTTP. Clients and services must support JSON-RPC over POST and the protocol's JSON and SSE response forms.
+Authentication comes from an interactive session, keychain, environment, or standard input. Secrets and tokens are not positional command arguments.
+
+Operation invocation uses MCP Streamable HTTP. Clients and services support JSON-RPC over POST and the protocol's JSON and SSE response forms. The gateway enforces request size, timeout, rate, and stream-lifetime policy.
+
+Ingress strips externally supplied internal-identity headers. It exchanges user credentials for a short-lived, audience-bound internal invocation token containing the original actor, effective subject, immediate calling workload, delegation chain, target service and operation, issued/expiry times, nonce, and trace ID. Services never forward raw user bearer tokens or API keys.
+
+The authorization decision intersects:
+
+- The authenticated calling workload's permission to invoke the target
+- The effective subject's permission
+- The installed service's approved operation policy
+- Any operation-specific resource authorization
+
+Unknown identities, services, operations, policies, or authorization-provider outages deny access.
 
 ## Authentication and Authorization
 
-- Users authenticate through an external identity provider, with organization-level SSO support.
-- Users can create API keys that act as their identity.
-- Users can create service accounts with a subset of their permissions.
-- Every installed service has an assigned identity.
-- Every operation can enforce authorization.
+- Users authenticate through an external identity provider with organization-level SSO, issuer and tenant allowlists, and session revocation.
+- API keys are named, expiring, scoped API grants that act on behalf of an owner. Only hashes are stored, plaintext is returned once, and empty scope does not mean unrestricted access.
+- Users create service accounts only with an attenuated subset of authority and explicit expiry or organization policy.
+- Every installation has organization-owned workload and workflow identities.
+- Every invocation is centrally authorized before dispatch; service-specific resource checks may further restrict it.
+- Production does not start in a fail-open mode when identity or authorization is unavailable.
 
-Authorization uses a Zanzibar-style graph of relationship tuples. Each relationship definition declares whether it supports delegated assignments, persistent grants, both, or neither. The default is neither.
+Authorization uses a Zanzibar-style graph. Relationship definitions declare whether they support delegated assignments, persistent grants, both, or neither. The default is neither.
 
-- **Delegated assignment (`delegatable`)**: a relationship holder can create a derived assignment that cannot exceed or outlive its parent assignment.
-- **Persistent grant (`grantable`)**: a principal with the relationship-specific grant permission can create an independent assignment that remains until explicitly revoked.
+- **Delegated assignment (`delegatable`)**: a holder with `can_delegate_<relationship>` may create a child assignment that cannot exceed or outlive its parent.
+- **Persistent grant (`grantable`)**: a principal with `can_grant_<relationship>` may create an independent assignment that remains until explicitly revoked.
 
-Assignments record their issuer, assignment mode, creation time, optional expiration, and optional parent assignment. Revoking a parent invalidates its delegated descendants, while an independent assignment through another path preserves access. Persistent grants require an explicit Zanzibar permission such as `can_grant_<relationship>`.
+An assignment is a first-class record containing an immutable ID, organization, subject, relationship, resource, mode, issuer, creation and optional expiration, optional parent assignment, policy revision, and revocation state. Delegation has bounded depth, acyclic ancestry, transactional creation, and cascading invalidation. Independent valid paths preserve access after one path is revoked.
+
+Authorization caches and delegated invocation tokens have bounded lifetimes. Revocation has a documented maximum propagation time and applies to long-lived streams and each workflow step. Security events are written to an immutable audit sink outside service-controlled storage.
+
+## Configuration, Secrets, Ingress, and Egress
+
+Release manifests declare typed requirements, not concrete secret values or unrestricted secret names. Administrators bind them to organization-owned configuration and secret-manager objects. Secret access is granted only to the installation or migration workload identity and uses short-lived retrieval where possible.
+
+Capability expansion on upgrade requires renewed approval. Expansion includes new authorization relationships, identities, secrets, public routes, egress destinations, migration permissions, or caller delegation. Capability reduction may be automatically accepted under organization policy.
+
+Every endpoint is classified as public, organization-authenticated, mesh-internal, or management-only. Egress is deny-by-default and explicitly grants destination, port, protocol, TLS/SNI, DNS, and credential behavior.
+
+## Development Sandbox
+
+`vt dev` builds a local service and connects it only to an explicitly enabled per-user sandbox:
+
+```sh
+vt dev --deployment <url> <dir>
+```
+
+Authentication uses the normal interactive or keychain flow. The platform issues a short-lived development workload identity distinct from the user's identity. Development routing is scoped to the developer or named test session and cannot take over a production service slug.
+
+Development services:
+
+- Receive no production traffic by default
+- Cannot run migrations
+- Cannot access production secrets
+- Cannot forward caller credentials
+- Use sandbox-scoped authorization and egress
+- Expire automatically and are audited on connect and disconnect
+
+## Retention and Audit
+
+Immutable release metadata, attestations, and accepted revision history are retained permanently or according to organization audit policy. Blob retention is separate:
+
+- Unused releases expire after a configurable window
+- Running, admitted, and rollback-eligible revisions retain all required blobs
+- Historical revisions retain blobs through a configurable recovery window
+- Expired historical blobs may be garbage-collected while metadata and audit history remain
+
+OCI garbage collection is reference-aware because layers may be shared. Pruning is serialized with admission and rechecks eligibility immediately before deletion.
+
+Audit events include authentication, API-grant lifecycle, certificate issuance, authorization decisions, assignment mutation, delegated identity use, registry and trust-policy changes, publish/install/upgrade/rollback/removal, migration execution, secret access, ingress/egress denial, and development injection. Events include actor, effective subject, calling workload, target, policy revision, decision reason, trace ID, and release digest.
 
 ## Mesh Deployment
 
-The mesh is redeployed only when changing mesh infrastructure, including:
+The mesh is redeployed only when changing deploy-pinned infrastructure, including:
 
-- The `istiod` snapshot
-- The `gestaltd` snapshot
-- Ingress
-- Egress
+- `istiod` and Istio data-plane versions
+- `gestaltd` supervisor versions
+- Ingress and egress gateways
+- Identity, authorization, certificate, secret, audit, state-storage, registry-verification, or recovery services
 
-Installing, upgrading, or removing services and adding or removing registries are runtime changes and do not require a mesh redeployment.
+Service releases declare compatible `gestaltd` and mesh protocol ranges. Infrastructure rollouts account for old and new runtime cohorts before admitting a service release that requires new capabilities.
+
+Installing, upgrading, rolling back, or removing services is a runtime change and does not require mesh redeployment. Connecting or disconnecting a registry is durable control-plane state and does not require redeployment, but changing registry trust roots remains a separately authorized and audited action.
+
+## Required Verification
+
+Before production use, automated tests cover:
+
+- Create-only and atomic publication, concurrent publishers, and stale attempts
+- Signature, provenance, trust-policy, platform, and runtime compatibility failures
+- Install and upgrade validation failures writing no admitted revision
+- Concurrent administrator and controller fencing
+- Controller failure and restart at every lifecycle phase
+- Migration idempotency, lease loss, and incompatible rollback declarations
+- Dependency and reverse-dependent races
+- Canary failure, routing/catalog generation safety, draining, and SSE behavior
+- Registry disconnection, mirror rebinding, and blob-prune concurrency
+- Removal cleanup, tombstones, and retained workflow executions
+- Authorization outage, confused-deputy attempts, delegation attenuation, and revocation propagation
+- Multi-replica convergence and old/new infrastructure cohort overlap

--- a/plans/service_mesh/prototypes.md
+++ b/plans/service_mesh/prototypes.md
@@ -1,0 +1,51 @@
+# Service Mesh Prototypes
+
+These prototypes are disposable experiments used to validate infrastructure
+choices and the highest-risk request and rollout paths. They are not intended
+to become production deployment tooling.
+
+## Prototype 1: Managed Mesh and Ambient Waypoints
+
+Implementation: [valon-tools#366](https://github.com/valon-technologies/valon-tools/pull/366)
+
+This prototype created an isolated GKE Standard cluster, first exercised
+managed Google Cloud Service Mesh, and then converted the cluster to
+self-managed upstream Istio ambient mode to deploy a shared waypoint.
+
+What we learned:
+
+- Managed Google Cloud Service Mesh does not provide the ambient `ztunnel` and
+  waypoint data plane required by this architecture.
+- Self-managed upstream Istio ambient mode can run sidecarless workloads and a
+  shared destination waypoint on GKE Standard.
+- The production architecture should therefore use self-managed upstream
+  Istio rather than managed Google Cloud Service Mesh.
+
+## Prototype 2: Authorized Revision Promotion
+
+Implementation: [valon-tools#367](https://github.com/valon-technologies/valon-tools/pull/367)
+
+This prototype deployed two immutable package revisions behind a destination
+waypoint and exercised the request and promotion path proposed in the service
+mesh design.
+
+What we learned:
+
+- A waypoint-attached Gateway API `HTTPRoute` can select revision-specific
+  Services from a reserved revision header and independently change the
+  default revision.
+- A waypoint-attached `CUSTOM` `AuthorizationPolicy` can fail closed through
+  `ext_authz` for the front Service, revision-specific Services, and direct Pod
+  IP requests.
+- Default traffic can move from revision v1 to v2 while requests explicitly
+  pinned to v1 continue to reach v1.
+- The runtime can independently reject a request when its authorized operation
+  metadata does not match its JSON-RPC body.
+- Persisting promotion intent before changing the route, and committing the
+  promoted revision afterward, works as the basis of the proposed rollout
+  ordering. The prototype's SQLite PVC survived a state-store Pod restart, but
+  it did not test Cloud SQL transaction fencing or recovery.
+
+The prototype uses a mock bearer token, a small HTTP authorization service, and
+a SQLite state store. Signed caller and session tokens, the production
+authorization model, MCP streaming, and database fencing remain to be tested.

--- a/plans/service_mesh/prototypes.md
+++ b/plans/service_mesh/prototypes.md
@@ -1,27 +1,23 @@
 # Service Mesh Prototypes
 
-These prototypes are disposable experiments used to validate infrastructure
-choices and the highest-risk request and rollout paths. They are not intended
-to become production deployment tooling.
+Disposable experiments; not production tooling.
 
 ## Prototype 1: Managed Mesh and Ambient Waypoints
 
 Implementation: [valon-tools#366](https://github.com/valon-technologies/valon-tools/pull/366)
 
-This prototype created an isolated GKE Standard cluster, first exercised
-managed Google Cloud Service Mesh, and then converted the cluster to
-self-managed upstream Istio ambient mode to deploy a shared waypoint.
+Tested managed Google Cloud Service Mesh, then converted the GKE Standard
+cluster to self-managed Istio ambient mode with a shared waypoint.
 
-What we learned:
+Findings:
 
-- Managed Google Cloud Service Mesh does not provide the ambient `ztunnel` and
-  waypoint data plane required by this architecture.
-- Self-managed upstream Istio ambient mode can run sidecarless workloads and a
-  shared destination waypoint on GKE Standard.
-- The production architecture should therefore use self-managed upstream
-  Istio rather than managed Google Cloud Service Mesh.
+- Managed Google Cloud Service Mesh lacks the required ambient `ztunnel` and
+  waypoint data plane.
+- Self-managed Istio ambient supports sidecarless workloads and shared
+  destination waypoints on GKE Standard.
+- Use self-managed Istio, not managed Google Cloud Service Mesh.
 
-Reproduce from the `valon-tools` repository:
+Run from `valon-tools`:
 
 ```sh
 scripts/setup-mesh-prototype-cluster.sh dev
@@ -29,11 +25,10 @@ scripts/deploy-mesh-prototype-demo.sh dev
 AUTO_APPROVE=true scripts/deploy-mesh-prototype-waypoint-demo.sh dev
 ```
 
-The second deployment command exercises managed Cloud Service Mesh. The third
-irreversibly converts this disposable cluster to self-managed upstream Istio
-ambient mode and exercises its waypoint.
+The second command tests managed Cloud Service Mesh. The final command
+permanently converts the cluster to self-managed Istio ambient.
 
-Remove only the prototype workloads while retaining the cluster:
+Remove workloads:
 
 ```sh
 scripts/deploy-mesh-prototype-demo.sh dev --destroy
@@ -44,48 +39,34 @@ scripts/deploy-mesh-prototype-waypoint-demo.sh dev --destroy
 
 Implementation: [valon-tools#367](https://github.com/valon-technologies/valon-tools/pull/367)
 
-This prototype deployed two immutable package revisions behind a destination
-waypoint and exercised the request and promotion path proposed in the service
-mesh design.
+Tested two immutable package revisions behind a destination waypoint.
 
-What we learned:
+Findings:
 
-- A waypoint-attached Gateway API `HTTPRoute` can select revision-specific
-  Services from a reserved revision header and independently change the
-  default revision.
-- A waypoint-attached `CUSTOM` `AuthorizationPolicy` can fail closed through
-  `ext_authz` for the front Service, revision-specific Services, and direct Pod
-  IP requests.
-- Default traffic can move from revision v1 to v2 while requests explicitly
-  pinned to v1 continue to reach v1.
-- The runtime can independently reject a request when its authorized operation
-  metadata does not match its JSON-RPC body.
-- Persisting promotion intent before changing the route, and committing the
-  promoted revision afterward, works as the basis of the proposed rollout
-  ordering. The prototype's SQLite PVC survived a state-store Pod restart, but
-  it did not test Cloud SQL transaction fencing or recovery.
+- A waypoint `HTTPRoute` can route by revision header and change the default
+  revision independently.
+- A waypoint `CUSTOM` `AuthorizationPolicy` with `ext_authz` fails closed for
+  front Service, revision Service, and direct Pod IP requests.
+- Default traffic can move from v1 to v2 while pinned requests remain on v1.
+- The runtime can reject operation metadata that differs from the JSON-RPC body.
+- Persisting promotion intent before route changes and committing the promoted
+  revision afterward provides the required rollout ordering. SQLite state
+  survived a Pod restart; Cloud SQL transaction fencing and recovery remain
+  untested.
 
-The prototype uses a mock bearer token, a small HTTP authorization service, and
-a SQLite state store. Signed caller and session tokens, the production
-authorization model, MCP streaming, and database fencing remain to be tested.
-
-On a cluster already converted to upstream Istio ambient mode by Prototype 1,
-reproduce from the `valon-tools` repository:
+Run from `valon-tools` after Prototype 1 converts the cluster:
 
 ```sh
 scripts/deploy-mesh-vertical-slice-prototype.sh dev
 ```
 
-The script deploys the workloads, runs the assertions described above, and
-exits nonzero if an assertion fails. Remove its workloads and persistent volume
-claim while retaining the cluster:
+The script deploys and verifies the prototype. Remove its workloads and PVC:
 
 ```sh
 scripts/deploy-mesh-vertical-slice-prototype.sh dev --destroy
 ```
 
-After both prototypes are no longer needed, remove the shared disposable
-cluster and its network:
+Remove the shared cluster and network:
 
 ```sh
 AUTO_APPROVE=true scripts/setup-mesh-prototype-cluster.sh dev --destroy

--- a/plans/service_mesh/prototypes.md
+++ b/plans/service_mesh/prototypes.md
@@ -21,6 +21,25 @@ What we learned:
 - The production architecture should therefore use self-managed upstream
   Istio rather than managed Google Cloud Service Mesh.
 
+Reproduce from the `valon-tools` repository:
+
+```sh
+scripts/setup-mesh-prototype-cluster.sh dev
+scripts/deploy-mesh-prototype-demo.sh dev
+AUTO_APPROVE=true scripts/deploy-mesh-prototype-waypoint-demo.sh dev
+```
+
+The second deployment command exercises managed Cloud Service Mesh. The third
+irreversibly converts this disposable cluster to self-managed upstream Istio
+ambient mode and exercises its waypoint.
+
+Remove only the prototype workloads while retaining the cluster:
+
+```sh
+scripts/deploy-mesh-prototype-demo.sh dev --destroy
+scripts/deploy-mesh-prototype-waypoint-demo.sh dev --destroy
+```
+
 ## Prototype 2: Authorized Revision Promotion
 
 Implementation: [valon-tools#367](https://github.com/valon-technologies/valon-tools/pull/367)
@@ -49,3 +68,25 @@ What we learned:
 The prototype uses a mock bearer token, a small HTTP authorization service, and
 a SQLite state store. Signed caller and session tokens, the production
 authorization model, MCP streaming, and database fencing remain to be tested.
+
+On a cluster already converted to upstream Istio ambient mode by Prototype 1,
+reproduce from the `valon-tools` repository:
+
+```sh
+scripts/deploy-mesh-vertical-slice-prototype.sh dev
+```
+
+The script deploys the workloads, runs the assertions described above, and
+exits nonzero if an assertion fails. Remove its workloads and persistent volume
+claim while retaining the cluster:
+
+```sh
+scripts/deploy-mesh-vertical-slice-prototype.sh dev --destroy
+```
+
+After both prototypes are no longer needed, remove the shared disposable
+cluster and its network:
+
+```sh
+AUTO_APPROVE=true scripts/setup-mesh-prototype-cluster.sh dev --destroy
+```


### PR DESCRIPTION
## Summary
Combines #3000 and #3018 into a single PR.

- define the package, registry, revision, rollout, workflow, and invocation lifecycles for the service mesh
- establish deployment tiers, workload identity, authorization, routing, migration, recovery, and audit boundaries
- document representative registry, upgrade, and invocation request flows with consistent terminology
- define the greenfield package artifact, supervisor, MCP routing, session, and authorization contracts
- specify protected-service bootstrap, atomic promotion, runtime-less releases, workflows, and isolated UI generations
- establish self-certifying registries and the production Kubernetes, Istio, audit, and disaster-recovery baseline
- record the two disposable mesh prototypes and the infrastructure, authorization, routing, and rollout conclusions they validated

## Test plan
- [x] Run `git diff --check`
- [x] Review the specification for internal consistency and fail-closed behavior
- [x] Execute the linked ambient vertical-slice prototype end to end
- [x] Documentation-only change; no runtime tests required

Made with [Cursor](https://cursor.com)