### PR TITLE
Document controller-runtime prototype findings

### DIFF
--- a/plans/service_mesh/prototypes.md
+++ b/plans/service_mesh/prototypes.md
@@ -72,14 +72,7 @@ Findings:
 - `controller-runtime` fits the revision controllers. Keep SQL authoritative and use a minimal `RevisionOperation` as a rebuildable work projection.
 - The prototype used a ConfigMap in place of SQL. SQL transactions and Temporal integration remain untested.
 
-Responsibility split:
-
-- **Gestalt control plane** owns package admission, authoritative SQL state, authorization bindings, Temporal workflows, revision intent, promotion, and recovery. It projects fenced work into Kubernetes and consumes convergence status.
-- **`controller-runtime`** is a Go library used by Gestalt revision controllers, not a standalone control plane. Controllers elect a leader, watch `RevisionOperation` projections and child resources, and reconcile Deployments, Services, routes, enrollment, and policies. They do not own package state or workflow sequencing.
-- **Gestalt SDK** provides package-authoring APIs, runtime schemas, catalog metadata, typed handlers, host-service clients, and transport adapters. It does not deploy workloads or configure the mesh.
-- **`istiod`** is the Istio control plane, not the Gestalt control plane. It watches Kubernetes, Gateway API, and Istio resources, then distributes endpoints, routes, identities, certificates, and policies to the mesh data plane. It does not own Gestalt revisions, grants, workflows, or catalogs.
-- **Ingress** is the external trust boundary. It authenticates callers, removes caller-supplied internal headers, validates routing metadata, applies external limits, and mints short-lived caller tokens.
-- **Destination waypoints** are L7 data-plane proxies. They call `ext_authz`, enforce authorization policy, and route approved requests to revision Services. They do not decode MCP bodies or own deployment state.
+Architecture responsibilities: [responsibilities.md](responsibilities.md).
 
 Run from `valon-tools` against the shared prototype cluster:
 

--- a/plans/service_mesh/prototypes.md
+++ b/plans/service_mesh/prototypes.md
@@ -66,6 +66,39 @@ The script deploys and verifies the prototype. Remove its workloads and PVC:
 scripts/deploy-mesh-vertical-slice-prototype.sh dev --destroy
 ```
 
+## Prototype 3: Revision Reconciliation
+
+Implementation: [valon-tools#368](https://github.com/valon-technologies/valon-tools/pull/368)
+
+Tested a `controller-runtime` revision controller with two replicas.
+
+Findings:
+
+- Kubernetes lease election kept one active reconciler.
+- Child-resource watches repaired a deleted Service. Reconciliation also
+  converged after both controller Pods restarted with partial state.
+- An uncached authoritative-intent read fenced a stale `RevisionOperation`
+  generation without deleting the promoted or candidate revision.
+- Cancellation deleted the candidate Deployment and Service while retaining
+  the promoted revision.
+- `controller-runtime` fits the revision controllers. Keep SQL authoritative
+  and use a minimal `RevisionOperation` as a rebuildable work projection.
+- The prototype used a ConfigMap in place of SQL. SQL transactions and Temporal
+  integration remain untested.
+
+Run from `valon-tools` against the shared prototype cluster:
+
+```sh
+scripts/deploy-mesh-controller-runtime-prototype.sh dev
+```
+
+The script builds the controller image, deploys the resources, and verifies the
+failure cases. Remove the namespace, RBAC, and CRD:
+
+```sh
+scripts/deploy-mesh-controller-runtime-prototype.sh dev --destroy
+```
+
 Remove the shared cluster and network:
 
 ```sh

--- a/plans/service_mesh/prototypes.md
+++ b/plans/service_mesh/prototypes.md
@@ -6,15 +6,12 @@ Disposable experiments; not production tooling.
 
 Implementation: [valon-tools#366](https://github.com/valon-technologies/valon-tools/pull/366)
 
-Tested managed Google Cloud Service Mesh, then converted the GKE Standard
-cluster to self-managed Istio ambient mode with a shared waypoint.
+Tested managed Google Cloud Service Mesh, then converted the GKE Standard cluster to self-managed Istio ambient mode with a shared waypoint.
 
 Findings:
 
-- Managed Google Cloud Service Mesh lacks the required ambient `ztunnel` and
-  waypoint data plane.
-- Self-managed Istio ambient supports sidecarless workloads and shared
-  destination waypoints on GKE Standard.
+- Managed Google Cloud Service Mesh lacks the required ambient `ztunnel` and waypoint data plane.
+- Self-managed Istio ambient supports sidecarless workloads and shared destination waypoints on GKE Standard.
 - Use self-managed Istio, not managed Google Cloud Service Mesh.
 
 Run from `valon-tools`:
@@ -25,8 +22,7 @@ scripts/deploy-mesh-prototype-demo.sh dev
 AUTO_APPROVE=true scripts/deploy-mesh-prototype-waypoint-demo.sh dev
 ```
 
-The second command tests managed Cloud Service Mesh. The final command
-permanently converts the cluster to self-managed Istio ambient.
+The second command tests managed Cloud Service Mesh. The final command permanently converts the cluster to self-managed Istio ambient.
 
 Remove workloads:
 
@@ -43,16 +39,11 @@ Tested two immutable package revisions behind a destination waypoint.
 
 Findings:
 
-- A waypoint `HTTPRoute` can route by revision header and change the default
-  revision independently.
-- A waypoint `CUSTOM` `AuthorizationPolicy` with `ext_authz` fails closed for
-  front Service, revision Service, and direct Pod IP requests.
+- A waypoint `HTTPRoute` can route by revision header and change the default revision independently.
+- A waypoint `CUSTOM` `AuthorizationPolicy` with `ext_authz` fails closed for front Service, revision Service, and direct Pod IP requests.
 - Default traffic can move from v1 to v2 while pinned requests remain on v1.
 - The runtime can reject operation metadata that differs from the JSON-RPC body.
-- Persisting promotion intent before route changes and committing the promoted
-  revision afterward provides the required rollout ordering. SQLite state
-  survived a Pod restart; Cloud SQL transaction fencing and recovery remain
-  untested.
+- Persisting promotion intent before route changes and committing the promoted revision afterward provides the required rollout ordering. SQLite state survived a Pod restart; Cloud SQL transaction fencing and recovery remain untested.
 
 Run from `valon-tools` after Prototype 1 converts the cluster:
 
@@ -75,41 +66,20 @@ Tested a `controller-runtime` revision controller with two replicas.
 Findings:
 
 - Kubernetes lease election kept one active reconciler.
-- Child-resource watches repaired a deleted Service. Reconciliation also
-  converged after both controller Pods restarted with partial state.
-- An uncached authoritative-intent read fenced a stale `RevisionOperation`
-  generation without deleting the promoted or candidate revision.
-- Cancellation deleted the candidate Deployment and Service while retaining
-  the promoted revision.
-- `controller-runtime` fits the revision controllers. Keep SQL authoritative
-  and use a minimal `RevisionOperation` as a rebuildable work projection.
-- The prototype used a ConfigMap in place of SQL. SQL transactions and Temporal
-  integration remain untested.
+- Child-resource watches repaired a deleted Service. Reconciliation also converged after both controller Pods restarted with partial state.
+- An uncached authoritative-intent read fenced a stale `RevisionOperation` generation without deleting the promoted or candidate revision.
+- Cancellation deleted the candidate Deployment and Service while retaining the promoted revision.
+- `controller-runtime` fits the revision controllers. Keep SQL authoritative and use a minimal `RevisionOperation` as a rebuildable work projection.
+- The prototype used a ConfigMap in place of SQL. SQL transactions and Temporal integration remain untested.
 
 Responsibility split:
 
-- **Gestalt control plane** owns package admission, authoritative SQL state,
-  authorization bindings, Temporal workflows, revision intent, promotion, and
-  recovery. It projects fenced work into Kubernetes and consumes convergence
-  status.
-- **`controller-runtime`** is a Go library used by Gestalt revision controllers,
-  not a standalone control plane. Controllers elect a leader, watch
-  `RevisionOperation` projections and child resources, and reconcile
-  Deployments, Services, routes, enrollment, and policies. They do not own
-  package state or workflow sequencing.
-- **Gestalt SDK** provides package-authoring APIs, runtime schemas, catalog
-  metadata, typed handlers, host-service clients, and transport adapters. It
-  does not deploy workloads or configure the mesh.
-- **`istiod`** is the Istio control plane, not the Gestalt control plane. It
-  watches Kubernetes, Gateway API, and Istio resources, then distributes
-  endpoints, routes, identities, certificates, and policies to the mesh data
-  plane. It does not own Gestalt revisions, grants, workflows, or catalogs.
-- **Ingress** is the external trust boundary. It authenticates callers, removes
-  caller-supplied internal headers, validates routing metadata, applies external
-  limits, and mints short-lived caller tokens.
-- **Destination waypoints** are L7 data-plane proxies. They call `ext_authz`,
-  enforce authorization policy, and route approved requests to revision
-  Services. They do not decode MCP bodies or own deployment state.
+- **Gestalt control plane** owns package admission, authoritative SQL state, authorization bindings, Temporal workflows, revision intent, promotion, and recovery. It projects fenced work into Kubernetes and consumes convergence status.
+- **`controller-runtime`** is a Go library used by Gestalt revision controllers, not a standalone control plane. Controllers elect a leader, watch `RevisionOperation` projections and child resources, and reconcile Deployments, Services, routes, enrollment, and policies. They do not own package state or workflow sequencing.
+- **Gestalt SDK** provides package-authoring APIs, runtime schemas, catalog metadata, typed handlers, host-service clients, and transport adapters. It does not deploy workloads or configure the mesh.
+- **`istiod`** is the Istio control plane, not the Gestalt control plane. It watches Kubernetes, Gateway API, and Istio resources, then distributes endpoints, routes, identities, certificates, and policies to the mesh data plane. It does not own Gestalt revisions, grants, workflows, or catalogs.
+- **Ingress** is the external trust boundary. It authenticates callers, removes caller-supplied internal headers, validates routing metadata, applies external limits, and mints short-lived caller tokens.
+- **Destination waypoints** are L7 data-plane proxies. They call `ext_authz`, enforce authorization policy, and route approved requests to revision Services. They do not decode MCP bodies or own deployment state.
 
 Run from `valon-tools` against the shared prototype cluster:
 
@@ -117,8 +87,7 @@ Run from `valon-tools` against the shared prototype cluster:
 scripts/deploy-mesh-controller-runtime-prototype.sh dev
 ```
 
-The script builds the controller image, deploys the resources, and verifies the
-failure cases. Remove the namespace, RBAC, and CRD:
+The script builds the controller image, deploys the resources, and verifies the failure cases. Remove the namespace, RBAC, and CRD:
 
 ```sh
 scripts/deploy-mesh-controller-runtime-prototype.sh dev --destroy

--- a/plans/service_mesh/prototypes.md
+++ b/plans/service_mesh/prototypes.md
@@ -86,6 +86,31 @@ Findings:
 - The prototype used a ConfigMap in place of SQL. SQL transactions and Temporal
   integration remain untested.
 
+Responsibility split:
+
+- **Gestalt control plane** owns package admission, authoritative SQL state,
+  authorization bindings, Temporal workflows, revision intent, promotion, and
+  recovery. It projects fenced work into Kubernetes and consumes convergence
+  status.
+- **`controller-runtime`** is a Go library used by Gestalt revision controllers,
+  not a standalone control plane. Controllers elect a leader, watch
+  `RevisionOperation` projections and child resources, and reconcile
+  Deployments, Services, routes, enrollment, and policies. They do not own
+  package state or workflow sequencing.
+- **Gestalt SDK** provides package-authoring APIs, runtime schemas, catalog
+  metadata, typed handlers, host-service clients, and transport adapters. It
+  does not deploy workloads or configure the mesh.
+- **`istiod`** is the Istio control plane, not the Gestalt control plane. It
+  watches Kubernetes, Gateway API, and Istio resources, then distributes
+  endpoints, routes, identities, certificates, and policies to the mesh data
+  plane. It does not own Gestalt revisions, grants, workflows, or catalogs.
+- **Ingress** is the external trust boundary. It authenticates callers, removes
+  caller-supplied internal headers, validates routing metadata, applies external
+  limits, and mints short-lived caller tokens.
+- **Destination waypoints** are L7 data-plane proxies. They call `ext_authz`,
+  enforce authorization policy, and route approved requests to revision
+  Services. They do not decode MCP bodies or own deployment state.
+
 Run from `valon-tools` against the shared prototype cluster:
 
 ```sh

--- a/plans/service_mesh/responsibilities.md
+++ b/plans/service_mesh/responsibilities.md
@@ -6,3 +6,60 @@
 - **`istiod`** is the Istio control plane, not the Gestalt control plane. It watches Kubernetes, Gateway API, and Istio resources, then distributes endpoints, routes, identities, certificates, and policies to the mesh data plane. It does not own Gestalt revisions, grants, workflows, or catalogs.
 - **Ingress** is the external trust boundary. It authenticates callers, removes caller-supplied internal headers, validates routing metadata, applies external limits, and mints short-lived caller tokens.
 - **Destination waypoints** are L7 data-plane proxies. They call `ext_authz`, enforce authorization policy, and route approved requests to revision Services. They do not decode MCP bodies or own deployment state.
+
+## Interactions
+
+```text
+CONTROL
+
+Administrator
+    |
+    v
+Gestalt control plane ---> SQL (authoritative state)
+    |
+    v
+Temporal workflow
+    |
+    v
+RevisionOperation
+    |
+    v
+Revision controller (controller-runtime)
+    |
+    v
+Kubernetes and Istio resources
+    |
+    v
+istiod ---> ztunnel and waypoint configuration
+
+REQUEST
+
+External caller
+    |
+    v
+Ingress (authenticate and mint caller token)
+    |
+    v
+Destination waypoint A (authorize and route)
+    |
+    v
+Package A Bun wrapper (verify context)
+    |
+    v
+Package A SDK invokes package B
+    |
+    v
+Bun outbound adapter (add B headers and destination-bound token)
+    |
+    v
+ztunnel (mTLS)
+    |
+    v
+Destination waypoint B (ext_authz and revision routing)
+    |
+    v
+Package B Bun wrapper (verify context and body)
+    |
+    v
+Package B handler
+```

--- a/plans/service_mesh/responsibilities.md
+++ b/plans/service_mesh/responsibilities.md
@@ -1,0 +1,8 @@
+# Service Mesh Responsibilities
+
+- **Gestalt control plane** owns package admission, authoritative SQL state, authorization bindings, Temporal workflows, revision intent, promotion, and recovery. It projects fenced work into Kubernetes and consumes convergence status.
+- **`controller-runtime`** is a Go library used by Gestalt revision controllers, not a standalone control plane. Controllers elect a leader, watch `RevisionOperation` projections and child resources, and reconcile Deployments, Services, routes, enrollment, and policies. They do not own package state or workflow sequencing.
+- **Gestalt SDK** provides package-authoring APIs, runtime schemas, catalog metadata, typed handlers, host-service clients, and transport adapters. It does not deploy workloads or configure the mesh.
+- **`istiod`** is the Istio control plane, not the Gestalt control plane. It watches Kubernetes, Gateway API, and Istio resources, then distributes endpoints, routes, identities, certificates, and policies to the mesh data plane. It does not own Gestalt revisions, grants, workflows, or catalogs.
+- **Ingress** is the external trust boundary. It authenticates callers, removes caller-supplied internal headers, validates routing metadata, applies external limits, and mints short-lived caller tokens.
+- **Destination waypoints** are L7 data-plane proxies. They call `ext_authz`, enforce authorization policy, and route approved requests to revision Services. They do not decode MCP bodies or own deployment state.


### PR DESCRIPTION
## Summary
- link the controller-runtime reconciliation prototype
- record results for leader election, repair, restart recovery, generation fencing, and cancellation
- document the production fit and the remaining SQL and Temporal integration gaps

## Test plan
- [x] Review rendered Markdown
- [x] Verify reproduction and cleanup commands against valon-tools#368

Made with [Cursor](https://cursor.com)