### PR TITLE
gestaltd: fix ListRuns targetApp filter when list targets are empty

### DIFF
--- a/gestaltd/core/workflow/ownership.go
+++ b/gestaltd/core/workflow/ownership.go
@@ -1,8 +1,6 @@
 package workflow
 
 import (
-	"encoding/base64"
-	"encoding/json"
 	"strings"
 )
 
@@ -14,6 +12,12 @@ func AppDefinitionIDPrefix(appName string) string {
 		return ""
 	}
 	return "app_" + appName + "_"
+}
+
+// AppDefinitionID builds the canonical app-owned definition id
+// app_<appName>_<localId>.
+func AppDefinitionID(appName, localID string) string {
+	return AppDefinitionIDPrefix(appName) + strings.TrimSpace(localID)
 }
 
 // DefinitionBelongsToApp reports whether definitionID is owned by appName
@@ -40,26 +44,9 @@ func TargetReferencesApp(target Target, appName string) bool {
 	return false
 }
 
-// OwnerKeyFromRunID extracts a provider-encoded owner_key from a run ID when
-// the ID is a base64url JSON handle (temporal list summaries). Returns "" when
-// the ID is not that shape.
-func OwnerKeyFromRunID(runID string) string {
-	raw := decodeRunIDPayload(runID)
-	if len(raw) == 0 || raw[0] != '{' {
-		return ""
-	}
-	var handle struct {
-		OwnerKey string `json:"owner_key"`
-	}
-	if err := json.Unmarshal(raw, &handle); err != nil {
-		return ""
-	}
-	return strings.TrimSpace(handle.OwnerKey)
-}
-
 // RunMatchesTargetApp reports whether a run belongs to targetApp for list
-// filtering. Prefer hydrated step targets; fall back to definition-id ownership
-// and provider run-handle owner_key when list summaries omit Target.steps.
+// filtering. Prefer hydrated step targets; when list summaries omit
+// Target.steps, fall back to app-owned definition IDs (app_<app>_…).
 func RunMatchesTargetApp(run *Run, targetApp string) bool {
 	if run == nil {
 		return false
@@ -71,29 +58,5 @@ func RunMatchesTargetApp(run *Run, targetApp string) bool {
 	if TargetReferencesApp(run.Target, app) {
 		return true
 	}
-	if DefinitionBelongsToApp(run.DefinitionID, app) {
-		return true
-	}
-	if OwnerKeyFromRunID(run.ID) == app {
-		return true
-	}
-	return false
-}
-
-func decodeRunIDPayload(runID string) []byte {
-	runID = strings.TrimSpace(runID)
-	if runID == "" {
-		return nil
-	}
-	if raw, err := base64.RawURLEncoding.DecodeString(runID); err == nil {
-		return raw
-	}
-	padded := runID
-	if m := len(padded) % 4; m != 0 {
-		padded += strings.Repeat("=", 4-m)
-	}
-	if raw, err := base64.URLEncoding.DecodeString(padded); err == nil {
-		return raw
-	}
-	return nil
+	return DefinitionBelongsToApp(run.DefinitionID, app)
 }

--- a/gestaltd/core/workflow/ownership.go
+++ b/gestaltd/core/workflow/ownership.go
@@ -1,0 +1,99 @@
+package workflow
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+)
+
+// AppDefinitionIDPrefix is the stable ownership prefix for app-owned
+// workflow definitions: app_<appName>_<localId>.
+func AppDefinitionIDPrefix(appName string) string {
+	appName = strings.TrimSpace(appName)
+	if appName == "" {
+		return ""
+	}
+	return "app_" + appName + "_"
+}
+
+// DefinitionBelongsToApp reports whether definitionID is owned by appName
+// via the app_<appName>_… convention.
+func DefinitionBelongsToApp(definitionID, appName string) bool {
+	prefix := AppDefinitionIDPrefix(appName)
+	if prefix == "" {
+		return false
+	}
+	return strings.HasPrefix(strings.TrimSpace(definitionID), prefix)
+}
+
+// TargetReferencesApp reports whether any step on target invokes appName.
+func TargetReferencesApp(target Target, appName string) bool {
+	appName = strings.TrimSpace(appName)
+	if appName == "" {
+		return false
+	}
+	for i := range target.Steps {
+		if target.Steps[i].App != nil && strings.TrimSpace(target.Steps[i].App.Name) == appName {
+			return true
+		}
+	}
+	return false
+}
+
+// OwnerKeyFromRunID extracts a provider-encoded owner_key from a run ID when
+// the ID is a base64url JSON handle (temporal list summaries). Returns "" when
+// the ID is not that shape.
+func OwnerKeyFromRunID(runID string) string {
+	raw := decodeRunIDPayload(runID)
+	if len(raw) == 0 || raw[0] != '{' {
+		return ""
+	}
+	var handle struct {
+		OwnerKey string `json:"owner_key"`
+	}
+	if err := json.Unmarshal(raw, &handle); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(handle.OwnerKey)
+}
+
+// RunMatchesTargetApp reports whether a run belongs to targetApp for list
+// filtering. Prefer hydrated step targets; fall back to definition-id ownership
+// and provider run-handle owner_key when list summaries omit Target.steps.
+func RunMatchesTargetApp(run *Run, targetApp string) bool {
+	if run == nil {
+		return false
+	}
+	app := strings.TrimSpace(targetApp)
+	if app == "" {
+		return true
+	}
+	if TargetReferencesApp(run.Target, app) {
+		return true
+	}
+	if DefinitionBelongsToApp(run.DefinitionID, app) {
+		return true
+	}
+	if OwnerKeyFromRunID(run.ID) == app {
+		return true
+	}
+	return false
+}
+
+func decodeRunIDPayload(runID string) []byte {
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return nil
+	}
+	if raw, err := base64.RawURLEncoding.DecodeString(runID); err == nil {
+		return raw
+	}
+	padded := runID
+	if m := len(padded) % 4; m != 0 {
+		padded += strings.Repeat("=", 4-m)
+	}
+	if raw, err := base64.URLEncoding.DecodeString(padded); err == nil {
+		return raw
+	}
+	return nil
+}

--- a/gestaltd/core/workflow/ownership.go
+++ b/gestaltd/core/workflow/ownership.go
@@ -20,14 +20,41 @@ func AppDefinitionID(appName, localID string) string {
 	return AppDefinitionIDPrefix(appName) + strings.TrimSpace(localID)
 }
 
+// DefinitionOwnerApp returns the longest candidate app name that owns
+// definitionID under the app_<app>_… convention. Prefer the full installed
+// app set so shorter names cannot claim definitions owned by underscore
+// supersets (foo vs foo_bar). With a single candidate this matches a plain
+// prefix check.
+func DefinitionOwnerApp(definitionID string, candidates []string) string {
+	rest, ok := strings.CutPrefix(strings.TrimSpace(definitionID), "app_")
+	if !ok || rest == "" {
+		return ""
+	}
+	best := ""
+	for _, app := range candidates {
+		app = strings.TrimSpace(app)
+		if app == "" {
+			continue
+		}
+		if rest == app || strings.HasPrefix(rest, app+"_") {
+			if len(app) >= len(best) {
+				best = app
+			}
+		}
+	}
+	return best
+}
+
 // DefinitionBelongsToApp reports whether definitionID is owned by appName
-// via the app_<appName>_… convention.
+// via the app_<appName>_… convention when appName is the only candidate.
+// Prefer DefinitionOwnerApp with the full app set when disambiguating
+// underscore-containing names.
 func DefinitionBelongsToApp(definitionID, appName string) bool {
-	prefix := AppDefinitionIDPrefix(appName)
-	if prefix == "" {
+	appName = strings.TrimSpace(appName)
+	if appName == "" {
 		return false
 	}
-	return strings.HasPrefix(strings.TrimSpace(definitionID), prefix)
+	return DefinitionOwnerApp(definitionID, []string{appName}) == appName
 }
 
 // TargetReferencesApp reports whether any step on target invokes appName.
@@ -47,7 +74,9 @@ func TargetReferencesApp(target Target, appName string) bool {
 // RunMatchesTargetApp reports whether a run belongs to targetApp for list
 // filtering. Prefer hydrated step targets; when list summaries omit
 // Target.steps, fall back to app-owned definition IDs (app_<app>_…).
-func RunMatchesTargetApp(run *Run, targetApp string) bool {
+// knownApps should be the installed app names so underscore supersets win
+// longest-match ownership; when empty, only targetApp is considered.
+func RunMatchesTargetApp(run *Run, targetApp string, knownApps ...string) bool {
 	if run == nil {
 		return false
 	}
@@ -58,5 +87,14 @@ func RunMatchesTargetApp(run *Run, targetApp string) bool {
 	if TargetReferencesApp(run.Target, app) {
 		return true
 	}
-	return DefinitionBelongsToApp(run.DefinitionID, app)
+	candidates := make([]string, 0, len(knownApps)+1)
+	candidates = append(candidates, app)
+	for _, name := range knownApps {
+		name = strings.TrimSpace(name)
+		if name == "" || name == app {
+			continue
+		}
+		candidates = append(candidates, name)
+	}
+	return DefinitionOwnerApp(run.DefinitionID, candidates) == app
 }

--- a/gestaltd/core/workflow/ownership_test.go
+++ b/gestaltd/core/workflow/ownership_test.go
@@ -1,0 +1,98 @@
+package workflow
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+)
+
+func TestDefinitionBelongsToApp(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		id, app string
+		want    bool
+	}{
+		{"app_ai-spend-tracker_ai_spend_tracker_sync", "ai-spend-tracker", true},
+		{"app_ci-cd_ci_cd_pr_sync", "ci-cd", true},
+		{"app_ci-cd_ci_cd_pr_sync", "ai-spend-tracker", false},
+		{"app_ai-spend-tracker_x", "ai-spend", false}, // must not prefix-match shorter names
+		{"cfg_slack_agent_default", "slack", false},
+		{"", "ci-cd", false},
+		{"app_ci-cd_x", "", false},
+	}
+	for _, tc := range cases {
+		if got := DefinitionBelongsToApp(tc.id, tc.app); got != tc.want {
+			t.Fatalf("DefinitionBelongsToApp(%q, %q) = %v, want %v", tc.id, tc.app, got, tc.want)
+		}
+	}
+}
+
+func TestOwnerKeyFromRunID(t *testing.T) {
+	t.Parallel()
+	payload, err := json.Marshal(map[string]any{
+		"kind":      "temporal-run",
+		"owner_key": "ai-spend-tracker",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded := base64.RawURLEncoding.EncodeToString(payload)
+	if got := OwnerKeyFromRunID(encoded); got != "ai-spend-tracker" {
+		t.Fatalf("OwnerKeyFromRunID = %q, want ai-spend-tracker", got)
+	}
+	if got := OwnerKeyFromRunID("not-a-handle"); got != "" {
+		t.Fatalf("OwnerKeyFromRunID(opaque) = %q, want empty", got)
+	}
+}
+
+func TestRunMatchesTargetApp(t *testing.T) {
+	t.Parallel()
+
+	hydrated := &Run{
+		ID:           "opaque",
+		DefinitionID: "app_other_wf",
+		Target: Target{Steps: []Step{{
+			ID:  "sync",
+			App: &AppCall{Name: "ai-spend-tracker", Operation: "runs.sync"},
+		}}},
+	}
+	if !RunMatchesTargetApp(hydrated, "ai-spend-tracker") {
+		t.Fatal("expected hydrated step app to match")
+	}
+	if RunMatchesTargetApp(hydrated, "ci-cd") {
+		t.Fatal("expected non-matching step app to miss")
+	}
+
+	listSummary := &Run{
+		ID: encodeOwnerHandle(t, "ai-spend-tracker"),
+		DefinitionID: "app_ai-spend-tracker_ai_spend_tracker_sync_every_four_hours",
+		Target:       Target{}, // list summaries omit steps
+	}
+	if !RunMatchesTargetApp(listSummary, "ai-spend-tracker") {
+		t.Fatal("expected empty-target list summary to match via definition/owner")
+	}
+	if RunMatchesTargetApp(listSummary, "ci-cd") {
+		t.Fatal("expected empty-target list summary not to match other apps")
+	}
+
+	ownerOnly := &Run{
+		ID:           encodeOwnerHandle(t, "ci-cd"),
+		DefinitionID: "cfg_not_app_owned",
+		Target:       Target{},
+	}
+	if !RunMatchesTargetApp(ownerOnly, "ci-cd") {
+		t.Fatal("expected owner_key handle to match when definition is not app-owned")
+	}
+}
+
+func encodeOwnerHandle(t *testing.T, owner string) string {
+	t.Helper()
+	payload, err := json.Marshal(map[string]any{
+		"kind":      "temporal-run",
+		"owner_key": owner,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return base64.RawURLEncoding.EncodeToString(payload)
+}

--- a/gestaltd/core/workflow/ownership_test.go
+++ b/gestaltd/core/workflow/ownership_test.go
@@ -1,10 +1,6 @@
 package workflow
 
-import (
-	"encoding/base64"
-	"encoding/json"
-	"testing"
-)
+import "testing"
 
 func TestDefinitionBelongsToApp(t *testing.T) {
 	t.Parallel()
@@ -27,21 +23,12 @@ func TestDefinitionBelongsToApp(t *testing.T) {
 	}
 }
 
-func TestOwnerKeyFromRunID(t *testing.T) {
+func TestAppDefinitionID(t *testing.T) {
 	t.Parallel()
-	payload, err := json.Marshal(map[string]any{
-		"kind":      "temporal-run",
-		"owner_key": "ai-spend-tracker",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	encoded := base64.RawURLEncoding.EncodeToString(payload)
-	if got := OwnerKeyFromRunID(encoded); got != "ai-spend-tracker" {
-		t.Fatalf("OwnerKeyFromRunID = %q, want ai-spend-tracker", got)
-	}
-	if got := OwnerKeyFromRunID("not-a-handle"); got != "" {
-		t.Fatalf("OwnerKeyFromRunID(opaque) = %q, want empty", got)
+	got := AppDefinitionID("ai-spend-tracker", "ai_spend_tracker_sync")
+	want := "app_ai-spend-tracker_ai_spend_tracker_sync"
+	if got != want {
+		t.Fatalf("AppDefinitionID = %q, want %q", got, want)
 	}
 }
 
@@ -64,35 +51,23 @@ func TestRunMatchesTargetApp(t *testing.T) {
 	}
 
 	listSummary := &Run{
-		ID: encodeOwnerHandle(t, "ai-spend-tracker"),
+		ID:           "opaque-list-id",
 		DefinitionID: "app_ai-spend-tracker_ai_spend_tracker_sync_every_four_hours",
 		Target:       Target{}, // list summaries omit steps
 	}
 	if !RunMatchesTargetApp(listSummary, "ai-spend-tracker") {
-		t.Fatal("expected empty-target list summary to match via definition/owner")
+		t.Fatal("expected empty-target list summary to match via definition ownership")
 	}
 	if RunMatchesTargetApp(listSummary, "ci-cd") {
 		t.Fatal("expected empty-target list summary not to match other apps")
 	}
 
-	ownerOnly := &Run{
-		ID:           encodeOwnerHandle(t, "ci-cd"),
-		DefinitionID: "cfg_not_app_owned",
+	cfgOwned := &Run{
+		ID:           "opaque",
+		DefinitionID: "cfg_slack_agent_default",
 		Target:       Target{},
 	}
-	if !RunMatchesTargetApp(ownerOnly, "ci-cd") {
-		t.Fatal("expected owner_key handle to match when definition is not app-owned")
+	if RunMatchesTargetApp(cfgOwned, "slack") {
+		t.Fatal("cfg_* definitions are not app-owned; empty targets must not match by name alone")
 	}
-}
-
-func encodeOwnerHandle(t *testing.T, owner string) string {
-	t.Helper()
-	payload, err := json.Marshal(map[string]any{
-		"kind":      "temporal-run",
-		"owner_key": owner,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	return base64.RawURLEncoding.EncodeToString(payload)
 }

--- a/gestaltd/core/workflow/ownership_test.go
+++ b/gestaltd/core/workflow/ownership_test.go
@@ -23,6 +23,23 @@ func TestDefinitionBelongsToApp(t *testing.T) {
 	}
 }
 
+func TestDefinitionOwnerAppLongestMatch(t *testing.T) {
+	t.Parallel()
+	id := "app_foo_bar_sync"
+	if got := DefinitionOwnerApp(id, []string{"foo", "foo_bar"}); got != "foo_bar" {
+		t.Fatalf("DefinitionOwnerApp = %q, want foo_bar", got)
+	}
+	if !DefinitionBelongsToApp(id, "foo") {
+		t.Fatal("single-candidate DefinitionBelongsToApp still uses prefix match")
+	}
+	if RunMatchesTargetApp(&Run{DefinitionID: id}, "foo", "foo", "foo_bar") {
+		t.Fatal("foo must not own foo_bar's definition when both apps are known")
+	}
+	if !RunMatchesTargetApp(&Run{DefinitionID: id}, "foo_bar", "foo", "foo_bar") {
+		t.Fatal("foo_bar should own its definition with longest-match candidates")
+	}
+}
+
 func TestAppDefinitionID(t *testing.T) {
 	t.Parallel()
 	got := AppDefinitionID("ai-spend-tracker", "ai_spend_tracker_sync")

--- a/gestaltd/core/workflow/workflow.go
+++ b/gestaltd/core/workflow/workflow.go
@@ -302,6 +302,9 @@ type ListRunsRequest struct {
 	PageSize  int
 	PageToken string
 	TargetApp string
+	// KnownApps is the installed app name set used to disambiguate
+	// app_<app>_… definition ownership when Target.steps is empty.
+	KnownApps []string
 	Status    RunStatus
 }
 

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1337,6 +1337,7 @@ func BootstrapWithOptions(ctx context.Context, cfg *config.Config, factories *Fa
 		DefaultConnection: connMaps.DefaultConnection,
 		CatalogConnection: connMaps.APIConnection,
 		MCPConnection:     connMaps.MCPConnection,
+		AppNames:          slices.Collect(maps.Keys(cfg.Apps)),
 	}))
 	agentManager.SetTarget(agentmanager.New(agentmanager.Config{
 		Providers:         providers,

--- a/gestaltd/internal/bootstrap/validate.go
+++ b/gestaltd/internal/bootstrap/validate.go
@@ -83,6 +83,7 @@ func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistr
 		DefaultConnection: connMaps.DefaultConnection,
 		CatalogConnection: connMaps.APIConnection,
 		MCPConnection:     connMaps.MCPConnection,
+		AppNames:          slices.Collect(maps.Keys(cfg.Apps)),
 	}))
 	prepared.AgentManager.SetTarget(agentmanager.New(agentmanager.Config{
 		Providers:         providers,

--- a/gestaltd/internal/bootstrap/workflow_app_definitions.go
+++ b/gestaltd/internal/bootstrap/workflow_app_definitions.go
@@ -71,7 +71,7 @@ func (r *appWorkflowDeclarations) Snapshot() map[string][]*proto.WorkflowDefinit
 }
 
 func appWorkflowDefinitionID(appName, localID string) string {
-	return "app_" + strings.TrimSpace(appName) + "_" + strings.TrimSpace(localID)
+	return coreworkflow.AppDefinitionID(appName, localID)
 }
 
 func validateAppWorkflowLocalID(localID string) error {

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -3,7 +3,9 @@ package server
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -489,6 +491,7 @@ func New(cfg Config) (*Server, error) {
 		DefaultConnection: cfg.DefaultConnection,
 		CatalogConnection: cfg.CatalogConnection,
 		MCPConnection:     cfg.MCPConnection,
+		AppNames:          slices.Collect(maps.Keys(cfg.AppDefs)),
 		Now:               now,
 	})
 	if cfg.RouteProfile != RouteProfileManagement {

--- a/gestaltd/rpc/protov1/v1/workflow.pb.go
+++ b/gestaltd/rpc/protov1/v1/workflow.pb.go
@@ -2910,13 +2910,15 @@ func (x *GetWorkflowProviderRunRequest) GetProvider() string {
 }
 
 type ListWorkflowProviderRunsRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	PageSize      int32                  `protobuf:"varint,1,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
-	PageToken     string                 `protobuf:"bytes,2,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
-	Status        WorkflowRunStatus      `protobuf:"varint,3,opt,name=status,proto3,enum=gestalt.provider.v1.WorkflowRunStatus" json:"status,omitempty"`
-	TargetApp     string                 `protobuf:"bytes,5,opt,name=target_app,json=targetApp,proto3" json:"target_app,omitempty"`
-	Context       *RequestContext        `protobuf:"bytes,6,opt,name=context,proto3" json:"context,omitempty"`
-	Provider      string                 `protobuf:"bytes,7,opt,name=provider,proto3" json:"provider,omitempty"`
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	PageSize  int32                  `protobuf:"varint,1,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
+	PageToken string                 `protobuf:"bytes,2,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
+	Status    WorkflowRunStatus      `protobuf:"varint,3,opt,name=status,proto3,enum=gestalt.provider.v1.WorkflowRunStatus" json:"status,omitempty"`
+	// Optional filter for runs owned by or invoking this app. Matching uses
+	// hydrated target steps when present, otherwise app-owned definition IDs.
+	TargetApp     string          `protobuf:"bytes,5,opt,name=target_app,json=targetApp,proto3" json:"target_app,omitempty"`
+	Context       *RequestContext `protobuf:"bytes,6,opt,name=context,proto3" json:"context,omitempty"`
+	Provider      string          `protobuf:"bytes,7,opt,name=provider,proto3" json:"provider,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }

--- a/gestaltd/services/workflows/workflowmanager/manager.go
+++ b/gestaltd/services/workflows/workflowmanager/manager.go
@@ -825,7 +825,7 @@ func runMatchesListFilters(run *coreworkflow.Run, req coreworkflow.ListRunsReque
 	}
 	if app := strings.TrimSpace(req.TargetApp); app != "" {
 		// List summaries often omit Target.steps. Match hydrated steps, then
-		// fall back to app-owned definition IDs and provider run-handle owner_key.
+		// fall back to app-owned definition IDs (app_<app>_…).
 		if !coreworkflow.RunMatchesTargetApp(run, app) {
 			return false
 		}

--- a/gestaltd/services/workflows/workflowmanager/manager.go
+++ b/gestaltd/services/workflows/workflowmanager/manager.go
@@ -121,8 +121,11 @@ type Config struct {
 	DefaultConnection map[string]string
 	CatalogConnection map[string]string
 	MCPConnection     map[string]string
-	Now               func() time.Time
-	Logger            *slog.Logger
+	// AppNames is the installed app catalog used to disambiguate
+	// app_<app>_… ownership when ListRuns target summaries omit steps.
+	AppNames []string
+	Now      func() time.Time
+	Logger   *slog.Logger
 }
 
 type Manager struct {
@@ -135,6 +138,7 @@ type Manager struct {
 	defaultConnection map[string]string
 	catalogConnection map[string]string
 	mcpConnection     map[string]string
+	appNames          []string
 	now               func() time.Time
 	logger            *slog.Logger
 }
@@ -240,6 +244,7 @@ func New(cfg Config) *Manager {
 		defaultConnection: maps.Clone(cfg.DefaultConnection),
 		catalogConnection: maps.Clone(cfg.CatalogConnection),
 		mcpConnection:     maps.Clone(cfg.MCPConnection),
+		appNames:          append([]string(nil), cfg.AppNames...),
 		now:               now,
 		logger:            cfg.Logger,
 	}
@@ -366,6 +371,9 @@ func (m *Manager) ListRuns(ctx context.Context, p *principal.Principal, provider
 	}
 	if m == nil || m.workflow == nil {
 		return nil, ErrWorkflowNotConfigured
+	}
+	if len(req.KnownApps) == 0 && m != nil {
+		req.KnownApps = append([]string(nil), m.appNames...)
 	}
 	p = principal.Canonicalized(p)
 	subjectID := strings.TrimSpace(principalSubjectID(p))
@@ -825,8 +833,9 @@ func runMatchesListFilters(run *coreworkflow.Run, req coreworkflow.ListRunsReque
 	}
 	if app := strings.TrimSpace(req.TargetApp); app != "" {
 		// List summaries often omit Target.steps. Match hydrated steps, then
-		// fall back to app-owned definition IDs (app_<app>_…).
-		if !coreworkflow.RunMatchesTargetApp(run, app) {
+		// fall back to app-owned definition IDs (app_<app>_…), disambiguated
+		// with the installed app set when provided.
+		if !coreworkflow.RunMatchesTargetApp(run, app, req.KnownApps...) {
 			return false
 		}
 	}

--- a/gestaltd/services/workflows/workflowmanager/manager.go
+++ b/gestaltd/services/workflows/workflowmanager/manager.go
@@ -824,7 +824,9 @@ func runMatchesListFilters(run *coreworkflow.Run, req coreworkflow.ListRunsReque
 		return false
 	}
 	if app := strings.TrimSpace(req.TargetApp); app != "" {
-		if !workflowTargetHasApp(run.Target, app) {
+		// List summaries often omit Target.steps. Match hydrated steps, then
+		// fall back to app-owned definition IDs and provider run-handle owner_key.
+		if !coreworkflow.RunMatchesTargetApp(run, app) {
 			return false
 		}
 	}
@@ -832,19 +834,6 @@ func runMatchesListFilters(run *coreworkflow.Run, req coreworkflow.ListRunsReque
 		return false
 	}
 	return true
-}
-
-func workflowTargetHasApp(target coreworkflow.Target, appName string) bool {
-	appName = strings.TrimSpace(appName)
-	if appName == "" {
-		return false
-	}
-	for i := range target.Steps {
-		if target.Steps[i].App != nil && strings.TrimSpace(target.Steps[i].App.Name) == appName {
-			return true
-		}
-	}
-	return false
 }
 
 func (m *Manager) DeliverEvent(ctx context.Context, p *principal.Principal, req EventDeliver) (out coreworkflow.Event, err error) {

--- a/gestaltd/services/workflows/workflowmanager/manager_test.go
+++ b/gestaltd/services/workflows/workflowmanager/manager_test.go
@@ -716,3 +716,19 @@ func (p *testWorkflowProvider) DeliverEvent(_ context.Context, req *proto.Delive
 func (p *testWorkflowProvider) Ping(context.Context) error { return nil }
 
 func (p *testWorkflowProvider) Close() error { return nil }
+
+func TestRunMatchesListFiltersEmptyTargetUsesDefinitionOwnership(t *testing.T) {
+	t.Parallel()
+	run := &coreworkflow.Run{
+		ID:           "list-summary",
+		DefinitionID: "app_ai-spend-tracker_ai_spend_tracker_sync_every_four_hours",
+		Target:       coreworkflow.Target{},
+		Status:       coreworkflow.RunStatusSucceeded,
+	}
+	if !runMatchesListFilters(run, coreworkflow.ListRunsRequest{TargetApp: "ai-spend-tracker"}) {
+		t.Fatal("empty-target list summary should match via app-owned definition id")
+	}
+	if runMatchesListFilters(run, coreworkflow.ListRunsRequest{TargetApp: "ci-cd"}) {
+		t.Fatal("empty-target list summary should not match a different app")
+	}
+}

--- a/gestaltd/services/workflows/workflowmanager/manager_test.go
+++ b/gestaltd/services/workflows/workflowmanager/manager_test.go
@@ -732,3 +732,20 @@ func TestRunMatchesListFiltersEmptyTargetUsesDefinitionOwnership(t *testing.T) {
 		t.Fatal("empty-target list summary should not match a different app")
 	}
 }
+
+func TestRunMatchesListFiltersKnownAppsDisambiguatesPrefixCollision(t *testing.T) {
+	t.Parallel()
+	run := &coreworkflow.Run{
+		ID:           "list-summary",
+		DefinitionID: "app_foo_bar_daily_sync",
+		Target:       coreworkflow.Target{},
+		Status:       coreworkflow.RunStatusSucceeded,
+	}
+	known := []string{"foo", "foo_bar"}
+	if runMatchesListFilters(run, coreworkflow.ListRunsRequest{TargetApp: "foo", KnownApps: known}) {
+		t.Fatal("prefix collision should not match shorter app when longer owner is known")
+	}
+	if !runMatchesListFilters(run, coreworkflow.ListRunsRequest{TargetApp: "foo_bar", KnownApps: known}) {
+		t.Fatal("prefix collision should match longest known app owner")
+	}
+}

--- a/sdk/go/client/workflow.go
+++ b/sdk/go/client/workflow.go
@@ -140,6 +140,8 @@ type ListWorkflowProviderRunsRequest struct {
 	PageSize  int32
 	PageToken string
 	Status    WorkflowRunStatus
+	// Optional filter for runs owned by or invoking this app. Matching uses
+	// hydrated target steps when present, otherwise app-owned definition IDs.
 	TargetApp string
 	Context   *RequestContext
 	Provider  string

--- a/sdk/go/publicclient/generated/workflow.go
+++ b/sdk/go/publicclient/generated/workflow.go
@@ -60,6 +60,8 @@ type ListWorkflowProviderRunsRequest struct {
 	PageSize  int32
 	PageToken string
 	Status    gestaltclient.WorkflowRunStatus
+	// Optional filter for runs owned by or invoking this app. Matching uses
+	// hydrated target steps when present, otherwise app-owned definition IDs.
 	TargetApp string
 	Provider  string
 }

--- a/sdk/proto/v1/workflow.proto
+++ b/sdk/proto/v1/workflow.proto
@@ -344,6 +344,10 @@ message ListWorkflowProviderRunsRequest {
   int32 page_size = 1;
   string page_token = 2;
   WorkflowRunStatus status = 3;
+  // Optional ownership / participation filter. Matches runs that invoke this
+  // app in their target steps, or (when list summaries omit steps) app-owned
+  // definitions (`app_<target_app>_…`) and provider run handles whose
+  // owner_key equals target_app.
   string target_app = 5;
   RequestContext context = 6;
   string provider = 7;

--- a/sdk/proto/v1/workflow.proto
+++ b/sdk/proto/v1/workflow.proto
@@ -344,10 +344,8 @@ message ListWorkflowProviderRunsRequest {
   int32 page_size = 1;
   string page_token = 2;
   WorkflowRunStatus status = 3;
-  // Optional ownership / participation filter. Matches runs that invoke this
-  // app in their target steps, or (when list summaries omit steps) app-owned
-  // definitions (`app_<target_app>_…`) and provider run handles whose
-  // owner_key equals target_app.
+  // Optional filter for runs owned by or invoking this app. Matching uses
+  // hydrated target steps when present, otherwise app-owned definition IDs.
   string target_app = 5;
   RequestContext context = 6;
   string provider = 7;

--- a/sdk/python/gestalt/_api.py
+++ b/sdk/python/gestalt/_api.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import builtins
 import dataclasses
 import json
+import os
 import threading
 from dataclasses import MISSING
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, Final, Generic, TypeVar, cast
 
 from ._protocol import JsonObject, JsonValue
+from ._grpc_transport import ENV_HOST_SERVICE_TOKEN
 
 if TYPE_CHECKING:
     from typing_extensions import dataclass_transform
@@ -136,11 +138,19 @@ class Request:
 
         from .app import App
 
-        return App.connect(
-            context=self._native_context(),
-            timeout=timeout,
-            relay_token=self.relay_token,
-        )
+        previous = os.environ.get(ENV_HOST_SERVICE_TOKEN)
+        if self.relay_token.strip():
+            os.environ[ENV_HOST_SERVICE_TOKEN] = self.relay_token.strip()
+        try:
+            return App.connect(
+                context=self._native_context(),
+                timeout=timeout,
+            )
+        finally:
+            if previous is None:
+                os.environ.pop(ENV_HOST_SERVICE_TOKEN, None)
+            else:
+                os.environ[ENV_HOST_SERVICE_TOKEN] = previous
 
     def gestalt(self) -> "BoundGestaltClient":
         """Return the public Gestalt client bound to this request's relay context."""
@@ -155,11 +165,20 @@ class Request:
 
         from .agent import Agent
 
-        return Agent.connect(
-            context=self._native_context(),
-            timeout=timeout,
-            relay_token=self.relay_token,
-        )
+        previous = os.environ.get(ENV_HOST_SERVICE_TOKEN)
+        if self.relay_token.strip():
+            os.environ[ENV_HOST_SERVICE_TOKEN] = self.relay_token.strip()
+        try:
+            return Agent.connect(
+                context=self._native_context(),
+                timeout=timeout,
+            )
+        finally:
+            if previous is None:
+                os.environ.pop(ENV_HOST_SERVICE_TOKEN, None)
+            else:
+                os.environ[ENV_HOST_SERVICE_TOKEN] = previous
+
 
     def workflows(self, *, timeout: float | None = None) -> "Workflow":
         from ._workflow import Workflow

--- a/sdk/python/gestalt/_api.py
+++ b/sdk/python/gestalt/_api.py
@@ -11,8 +11,8 @@ from dataclasses import MISSING
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, Final, Generic, TypeVar, cast
 
-from ._protocol import JsonObject, JsonValue
 from ._grpc_transport import ENV_HOST_SERVICE_TOKEN
+from ._protocol import JsonObject, JsonValue
 
 if TYPE_CHECKING:
     from typing_extensions import dataclass_transform

--- a/sdk/python/gestalt/_api.py
+++ b/sdk/python/gestalt/_api.py
@@ -11,7 +11,6 @@ from dataclasses import MISSING
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, Final, Generic, TypeVar, cast
 
-from ._grpc_transport import ENV_HOST_SERVICE_TOKEN
 from ._protocol import JsonObject, JsonValue
 
 if TYPE_CHECKING:
@@ -138,19 +137,11 @@ class Request:
 
         from .app import App
 
-        previous = os.environ.get(ENV_HOST_SERVICE_TOKEN)
-        if self.relay_token.strip():
-            os.environ[ENV_HOST_SERVICE_TOKEN] = self.relay_token.strip()
-        try:
-            return App.connect(
-                context=self._native_context(),
-                timeout=timeout,
-            )
-        finally:
-            if previous is None:
-                os.environ.pop(ENV_HOST_SERVICE_TOKEN, None)
-            else:
-                os.environ[ENV_HOST_SERVICE_TOKEN] = previous
+        return App.connect(
+            context=self._native_context(),
+            timeout=timeout,
+            relay_token=self.relay_token,
+        )
 
     def gestalt(self) -> "BoundGestaltClient":
         """Return the public Gestalt client bound to this request's relay context."""
@@ -165,20 +156,11 @@ class Request:
 
         from .agent import Agent
 
-        previous = os.environ.get(ENV_HOST_SERVICE_TOKEN)
-        if self.relay_token.strip():
-            os.environ[ENV_HOST_SERVICE_TOKEN] = self.relay_token.strip()
-        try:
-            return Agent.connect(
-                context=self._native_context(),
-                timeout=timeout,
-            )
-        finally:
-            if previous is None:
-                os.environ.pop(ENV_HOST_SERVICE_TOKEN, None)
-            else:
-                os.environ[ENV_HOST_SERVICE_TOKEN] = previous
-
+        return Agent.connect(
+            context=self._native_context(),
+            timeout=timeout,
+            relay_token=self.relay_token,
+        )
 
     def workflows(self, *, timeout: float | None = None) -> "Workflow":
         from ._workflow import Workflow

--- a/sdk/python/gestalt/_api.py
+++ b/sdk/python/gestalt/_api.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import builtins
 import dataclasses
 import json
-import os
 import threading
 from dataclasses import MISSING
 from http import HTTPStatus

--- a/sdk/python/gestalt/agent.py
+++ b/sdk/python/gestalt/agent.py
@@ -557,13 +557,14 @@ class Agent:
         *,
         context: RequestContext | None = None,
         timeout: float | None = None,
+        relay_token: str = "",
     ) -> Agent:
         target = os.environ.get(ENV_HOST_SERVICE_SOCKET, "")
         if not target:
             raise RuntimeError(f"{ENV_HOST_SERVICE_SOCKET} is not set")
-        token = os.environ.get(ENV_HOST_SERVICE_TOKEN, "")
+        token = (relay_token or os.environ.get(ENV_HOST_SERVICE_TOKEN, "")).strip()
         channel = host_service_channel(
-            "agent", target, token=token.strip(), binding=(name or "").strip()
+            "agent", target, token=token, binding=(name or "").strip()
         )
         client = cls(channel, context=context, timeout=timeout)
         client._owns_channel = True

--- a/sdk/python/gestalt/agent.py
+++ b/sdk/python/gestalt/agent.py
@@ -16,6 +16,7 @@ from ._codec import support as _support
 from ._gen.v1 import agent_pb2_grpc as _agent_pb2_grpc
 from ._grpc_transport import (
     ENV_HOST_SERVICE_SOCKET,
+    ENV_HOST_SERVICE_TOKEN,
     host_service_channel,
 )
 from .app import AgentToolRef, OperationAnnotations, RequestContext
@@ -556,13 +557,13 @@ class Agent:
         *,
         context: RequestContext | None = None,
         timeout: float | None = None,
-        relay_token: str = "",
     ) -> Agent:
         target = os.environ.get(ENV_HOST_SERVICE_SOCKET, "")
         if not target:
             raise RuntimeError(f"{ENV_HOST_SERVICE_SOCKET} is not set")
+        token = os.environ.get(ENV_HOST_SERVICE_TOKEN, "")
         channel = host_service_channel(
-            "agent", target, token=relay_token.strip(), binding=(name or "").strip()
+            "agent", target, token=token.strip(), binding=(name or "").strip()
         )
         client = cls(channel, context=context, timeout=timeout)
         client._owns_channel = True

--- a/sdk/python/gestalt/app.py
+++ b/sdk/python/gestalt/app.py
@@ -497,13 +497,14 @@ class App:
         *,
         context: RequestContext | None = None,
         timeout: float | None = None,
+        relay_token: str = "",
     ) -> App:
         target = os.environ.get(ENV_HOST_SERVICE_SOCKET, "")
         if not target:
             raise RuntimeError(f"{ENV_HOST_SERVICE_SOCKET} is not set")
-        token = os.environ.get(ENV_HOST_SERVICE_TOKEN, "")
+        token = (relay_token or os.environ.get(ENV_HOST_SERVICE_TOKEN, "")).strip()
         channel = host_service_channel(
-            "app", target, token=token.strip(), binding=(name or "").strip()
+            "app", target, token=token, binding=(name or "").strip()
         )
         client = cls(channel, context=context, timeout=timeout)
         client._owns_channel = True

--- a/sdk/python/gestalt/app.py
+++ b/sdk/python/gestalt/app.py
@@ -16,6 +16,7 @@ from ._codec import support as _support
 from ._gen.v1 import app_pb2_grpc as _app_pb2_grpc
 from ._grpc_transport import (
     ENV_HOST_SERVICE_SOCKET,
+    ENV_HOST_SERVICE_TOKEN,
     host_service_channel,
 )
 from .invoke_support import decode_app_result
@@ -496,13 +497,13 @@ class App:
         *,
         context: RequestContext | None = None,
         timeout: float | None = None,
-        relay_token: str = "",
     ) -> App:
         target = os.environ.get(ENV_HOST_SERVICE_SOCKET, "")
         if not target:
             raise RuntimeError(f"{ENV_HOST_SERVICE_SOCKET} is not set")
+        token = os.environ.get(ENV_HOST_SERVICE_TOKEN, "")
         channel = host_service_channel(
-            "app", target, token=relay_token.strip(), binding=(name or "").strip()
+            "app", target, token=token.strip(), binding=(name or "").strip()
         )
         client = cls(channel, context=context, timeout=timeout)
         client._owns_channel = True

--- a/sdk/python/gestalt/authorization.py
+++ b/sdk/python/gestalt/authorization.py
@@ -311,14 +311,18 @@ class Authorization:
 
     @classmethod
     def connect(
-        cls, name: str | None = None, *, timeout: float | None = None
+        cls,
+        name: str | None = None,
+        *,
+        timeout: float | None = None,
+        relay_token: str = "",
     ) -> Authorization:
         target = os.environ.get(ENV_HOST_SERVICE_SOCKET, "")
         if not target:
             raise RuntimeError(f"{ENV_HOST_SERVICE_SOCKET} is not set")
-        token = os.environ.get(ENV_HOST_SERVICE_TOKEN, "")
+        token = (relay_token or os.environ.get(ENV_HOST_SERVICE_TOKEN, "")).strip()
         channel = host_service_channel(
-            "authorization", target, token=token.strip(), binding=(name or "").strip()
+            "authorization", target, token=token, binding=(name or "").strip()
         )
         client = cls(channel, timeout=timeout)
         client._owns_channel = True

--- a/sdk/python/gestalt/cache.py
+++ b/sdk/python/gestalt/cache.py
@@ -141,13 +141,19 @@ class Cache:
         self._owns_channel = False
 
     @classmethod
-    def connect(cls, name: str | None = None, *, timeout: float | None = None) -> Cache:
+    def connect(
+        cls,
+        name: str | None = None,
+        *,
+        timeout: float | None = None,
+        relay_token: str = "",
+    ) -> Cache:
         target = os.environ.get(ENV_HOST_SERVICE_SOCKET, "")
         if not target:
             raise RuntimeError(f"{ENV_HOST_SERVICE_SOCKET} is not set")
-        token = os.environ.get(ENV_HOST_SERVICE_TOKEN, "")
+        token = (relay_token or os.environ.get(ENV_HOST_SERVICE_TOKEN, "")).strip()
         channel = host_service_channel(
-            "cache", target, token=token.strip(), binding=(name or "").strip()
+            "cache", target, token=token, binding=(name or "").strip()
         )
         client = cls(channel, timeout=timeout)
         client._owns_channel = True

--- a/sdk/python/gestalt/external_credential.py
+++ b/sdk/python/gestalt/external_credential.py
@@ -216,17 +216,18 @@ class ExternalCredentials:
 
     @classmethod
     def connect(
-        cls, name: str | None = None, *, timeout: float | None = None
+        cls,
+        name: str | None = None,
+        *,
+        timeout: float | None = None,
+        relay_token: str = "",
     ) -> ExternalCredentials:
         target = os.environ.get(ENV_HOST_SERVICE_SOCKET, "")
         if not target:
             raise RuntimeError(f"{ENV_HOST_SERVICE_SOCKET} is not set")
-        token = os.environ.get(ENV_HOST_SERVICE_TOKEN, "")
+        token = (relay_token or os.environ.get(ENV_HOST_SERVICE_TOKEN, "")).strip()
         channel = host_service_channel(
-            "external_credentials",
-            target,
-            token=token.strip(),
-            binding=(name or "").strip(),
+            "external_credentials", target, token=token, binding=(name or "").strip()
         )
         client = cls(channel, timeout=timeout)
         client._owns_channel = True

--- a/sdk/python/gestalt/identity.py
+++ b/sdk/python/gestalt/identity.py
@@ -186,14 +186,18 @@ class Identity:
 
     @classmethod
     def connect(
-        cls, name: str | None = None, *, timeout: float | None = None
+        cls,
+        name: str | None = None,
+        *,
+        timeout: float | None = None,
+        relay_token: str = "",
     ) -> Identity:
         target = os.environ.get(ENV_HOST_SERVICE_SOCKET, "")
         if not target:
             raise RuntimeError(f"{ENV_HOST_SERVICE_SOCKET} is not set")
-        token = os.environ.get(ENV_HOST_SERVICE_TOKEN, "")
+        token = (relay_token or os.environ.get(ENV_HOST_SERVICE_TOKEN, "")).strip()
         channel = host_service_channel(
-            "identity", target, token=token.strip(), binding=(name or "").strip()
+            "identity", target, token=token, binding=(name or "").strip()
         )
         client = cls(channel, timeout=timeout)
         client._owns_channel = True

--- a/sdk/python/gestalt/indexeddb.py
+++ b/sdk/python/gestalt/indexeddb.py
@@ -760,14 +760,18 @@ class IndexedDB:
 
     @classmethod
     def connect(
-        cls, name: str | None = None, *, timeout: float | None = None
+        cls,
+        name: str | None = None,
+        *,
+        timeout: float | None = None,
+        relay_token: str = "",
     ) -> IndexedDB:
         target = os.environ.get(ENV_HOST_SERVICE_SOCKET, "")
         if not target:
             raise RuntimeError(f"{ENV_HOST_SERVICE_SOCKET} is not set")
-        token = os.environ.get(ENV_HOST_SERVICE_TOKEN, "")
+        token = (relay_token or os.environ.get(ENV_HOST_SERVICE_TOKEN, "")).strip()
         channel = host_service_channel(
-            "indexeddb", target, token=token.strip(), binding=(name or "").strip()
+            "indexeddb", target, token=token, binding=(name or "").strip()
         )
         client = cls(channel, timeout=timeout)
         client._owns_channel = True

--- a/sdk/python/gestalt/public/generated/workflow.py
+++ b/sdk/python/gestalt/public/generated/workflow.py
@@ -64,6 +64,8 @@ class ListWorkflowProviderRunsRequest:
     page_size: int = 0
     page_token: str = ""
     status: WorkflowRunStatus = 0
+    #: Optional filter for runs owned by or invoking this app. Matching uses
+    #: hydrated target steps when present, otherwise app-owned definition IDs.
     target_app: str = ""
     provider: str = ""
 

--- a/sdk/python/gestalt/s3.py
+++ b/sdk/python/gestalt/s3.py
@@ -264,13 +264,19 @@ class S3:
         self._owns_channel = False
 
     @classmethod
-    def connect(cls, name: str | None = None, *, timeout: float | None = None) -> S3:
+    def connect(
+        cls,
+        name: str | None = None,
+        *,
+        timeout: float | None = None,
+        relay_token: str = "",
+    ) -> S3:
         target = os.environ.get(ENV_HOST_SERVICE_SOCKET, "")
         if not target:
             raise RuntimeError(f"{ENV_HOST_SERVICE_SOCKET} is not set")
-        token = os.environ.get(ENV_HOST_SERVICE_TOKEN, "")
+        token = (relay_token or os.environ.get(ENV_HOST_SERVICE_TOKEN, "")).strip()
         channel = host_service_channel(
-            "s3", target, token=token.strip(), binding=(name or "").strip()
+            "s3", target, token=token, binding=(name or "").strip()
         )
         client = cls(channel, timeout=timeout)
         client._owns_channel = True

--- a/sdk/python/gestalt/workflow.py
+++ b/sdk/python/gestalt/workflow.py
@@ -143,6 +143,8 @@ class ListWorkflowProviderRunsRequest:
     page_size: int = 0
     page_token: str = ""
     status: WorkflowRunStatus = 0
+    #: Optional filter for runs owned by or invoking this app. Matching uses
+    #: hydrated target steps when present, otherwise app-owned definition IDs.
     target_app: str = ""
     context: RequestContext | None = None
     provider: str = ""

--- a/sdk/python/gestalt/workflow.py
+++ b/sdk/python/gestalt/workflow.py
@@ -569,13 +569,14 @@ class Workflow:
         *,
         context: RequestContext | None = None,
         timeout: float | None = None,
+        relay_token: str = "",
     ) -> Workflow:
         target = os.environ.get(ENV_HOST_SERVICE_SOCKET, "")
         if not target:
             raise RuntimeError(f"{ENV_HOST_SERVICE_SOCKET} is not set")
-        token = os.environ.get(ENV_HOST_SERVICE_TOKEN, "")
+        token = (relay_token or os.environ.get(ENV_HOST_SERVICE_TOKEN, "")).strip()
         channel = host_service_channel(
-            "workflow", target, token=token.strip(), binding=(name or "").strip()
+            "workflow", target, token=token, binding=(name or "").strip()
         )
         client = cls(channel, context=context, timeout=timeout)
         client._owns_channel = True

--- a/sdk/python/tests/test_agent_transport.py
+++ b/sdk/python/tests/test_agent_transport.py
@@ -24,7 +24,6 @@ from gestalt import (
     AGENT_SESSION_STATE_ACTIVE,
     AGENT_SESSION_STATE_ARCHIVED,
     ENV_HOST_SERVICE_SOCKET,
-    ENV_HOST_SERVICE_TOKEN,
     AgentInteraction,
     AgentMessage,
     AgentMessagePart,
@@ -872,15 +871,7 @@ class AgentTransportTests(unittest.TestCase):
         )
 
     def test_agent_accepts_native_message_metadata(self) -> None:
-        previous_token = os.environ.get(ENV_HOST_SERVICE_TOKEN)
-        os.environ[ENV_HOST_SERVICE_TOKEN] = "relay-token-py"
-        try:
-            manager = genagent.Agent.connect()
-        finally:
-            if previous_token is None:
-                os.environ.pop(ENV_HOST_SERVICE_TOKEN, None)
-            else:
-                os.environ[ENV_HOST_SERVICE_TOKEN] = previous_token
+        manager = genagent.Agent.connect(relay_token="relay-token-py")
         created_turn = manager.create_turn(
             session_id="session-managed-1",
             model="gpt-5.1",

--- a/sdk/python/tests/test_agent_transport.py
+++ b/sdk/python/tests/test_agent_transport.py
@@ -24,6 +24,7 @@ from gestalt import (
     AGENT_SESSION_STATE_ACTIVE,
     AGENT_SESSION_STATE_ARCHIVED,
     ENV_HOST_SERVICE_SOCKET,
+    ENV_HOST_SERVICE_TOKEN,
     AgentInteraction,
     AgentMessage,
     AgentMessagePart,
@@ -871,7 +872,15 @@ class AgentTransportTests(unittest.TestCase):
         )
 
     def test_agent_accepts_native_message_metadata(self) -> None:
-        manager = genagent.Agent.connect(relay_token="relay-token-py")
+        previous_token = os.environ.get(ENV_HOST_SERVICE_TOKEN)
+        os.environ[ENV_HOST_SERVICE_TOKEN] = "relay-token-py"
+        try:
+            manager = genagent.Agent.connect()
+        finally:
+            if previous_token is None:
+                os.environ.pop(ENV_HOST_SERVICE_TOKEN, None)
+            else:
+                os.environ[ENV_HOST_SERVICE_TOKEN] = previous_token
         created_turn = manager.create_turn(
             session_id="session-managed-1",
             model="gpt-5.1",

--- a/sdk/python/tests/test_app_transport.py
+++ b/sdk/python/tests/test_app_transport.py
@@ -14,6 +14,7 @@ from google.protobuf import json_format
 
 from gestalt import (
     ENV_HOST_SERVICE_SOCKET,
+    ENV_HOST_SERVICE_TOKEN,
     InvokeError,
     Request,
 )
@@ -377,9 +378,11 @@ class AppTransportTests(unittest.TestCase):
         port = tcp_server.add_insecure_port("127.0.0.1:0")
         tcp_server.start()
         previous_socket = os.environ.get(ENV_HOST_SERVICE_SOCKET)
+        previous_token = os.environ.get(ENV_HOST_SERVICE_TOKEN)
         os.environ[ENV_HOST_SERVICE_SOCKET] = f"tcp://127.0.0.1:{port}"
+        os.environ[ENV_HOST_SERVICE_TOKEN] = "relay-token-python"
         try:
-            client = App.connect(relay_token="relay-token-python")
+            client = App.connect()
             response = client.invoke_raw(
                 AppInvokeRequest(app="github", operation="plain_text")
             )
@@ -392,6 +395,10 @@ class AppTransportTests(unittest.TestCase):
                 os.environ.pop(ENV_HOST_SERVICE_SOCKET, None)
             else:
                 os.environ[ENV_HOST_SERVICE_SOCKET] = previous_socket
+            if previous_token is None:
+                os.environ.pop(ENV_HOST_SERVICE_TOKEN, None)
+            else:
+                os.environ[ENV_HOST_SERVICE_TOKEN] = previous_token
             tcp_server.stop(grace=0).wait()
 
     def test_tcp_target_ignores_proxy_env(self) -> None:
@@ -403,13 +410,15 @@ class AppTransportTests(unittest.TestCase):
         port = tcp_server.add_insecure_port("127.0.0.1:0")
         tcp_server.start()
         previous_socket = os.environ.get(ENV_HOST_SERVICE_SOCKET)
+        previous_token = os.environ.get(ENV_HOST_SERVICE_TOKEN)
         previous_http_proxy = os.environ.get("http_proxy")
         previous_https_proxy = os.environ.get("https_proxy")
         os.environ[ENV_HOST_SERVICE_SOCKET] = f"tcp://127.0.0.1:{port}"
+        os.environ[ENV_HOST_SERVICE_TOKEN] = "relay-token-python"
         os.environ["http_proxy"] = "http://127.0.0.1:1"
         os.environ["https_proxy"] = "http://127.0.0.1:1"
         try:
-            client = App.connect(relay_token="relay-token-python")
+            client = App.connect()
             response = client.invoke_raw(
                 AppInvokeRequest(app="github", operation="plain_text")
             )
@@ -422,6 +431,10 @@ class AppTransportTests(unittest.TestCase):
                 os.environ.pop(ENV_HOST_SERVICE_SOCKET, None)
             else:
                 os.environ[ENV_HOST_SERVICE_SOCKET] = previous_socket
+            if previous_token is None:
+                os.environ.pop(ENV_HOST_SERVICE_TOKEN, None)
+            else:
+                os.environ[ENV_HOST_SERVICE_TOKEN] = previous_token
             if previous_http_proxy is None:
                 os.environ.pop("http_proxy", None)
             else:

--- a/sdk/python/tests/test_app_transport.py
+++ b/sdk/python/tests/test_app_transport.py
@@ -14,7 +14,6 @@ from google.protobuf import json_format
 
 from gestalt import (
     ENV_HOST_SERVICE_SOCKET,
-    ENV_HOST_SERVICE_TOKEN,
     InvokeError,
     Request,
 )
@@ -378,11 +377,9 @@ class AppTransportTests(unittest.TestCase):
         port = tcp_server.add_insecure_port("127.0.0.1:0")
         tcp_server.start()
         previous_socket = os.environ.get(ENV_HOST_SERVICE_SOCKET)
-        previous_token = os.environ.get(ENV_HOST_SERVICE_TOKEN)
         os.environ[ENV_HOST_SERVICE_SOCKET] = f"tcp://127.0.0.1:{port}"
-        os.environ[ENV_HOST_SERVICE_TOKEN] = "relay-token-python"
         try:
-            client = App.connect()
+            client = App.connect(relay_token="relay-token-python")
             response = client.invoke_raw(
                 AppInvokeRequest(app="github", operation="plain_text")
             )
@@ -395,10 +392,6 @@ class AppTransportTests(unittest.TestCase):
                 os.environ.pop(ENV_HOST_SERVICE_SOCKET, None)
             else:
                 os.environ[ENV_HOST_SERVICE_SOCKET] = previous_socket
-            if previous_token is None:
-                os.environ.pop(ENV_HOST_SERVICE_TOKEN, None)
-            else:
-                os.environ[ENV_HOST_SERVICE_TOKEN] = previous_token
             tcp_server.stop(grace=0).wait()
 
     def test_tcp_target_ignores_proxy_env(self) -> None:
@@ -410,15 +403,13 @@ class AppTransportTests(unittest.TestCase):
         port = tcp_server.add_insecure_port("127.0.0.1:0")
         tcp_server.start()
         previous_socket = os.environ.get(ENV_HOST_SERVICE_SOCKET)
-        previous_token = os.environ.get(ENV_HOST_SERVICE_TOKEN)
         previous_http_proxy = os.environ.get("http_proxy")
         previous_https_proxy = os.environ.get("https_proxy")
         os.environ[ENV_HOST_SERVICE_SOCKET] = f"tcp://127.0.0.1:{port}"
-        os.environ[ENV_HOST_SERVICE_TOKEN] = "relay-token-python"
         os.environ["http_proxy"] = "http://127.0.0.1:1"
         os.environ["https_proxy"] = "http://127.0.0.1:1"
         try:
-            client = App.connect()
+            client = App.connect(relay_token="relay-token-python")
             response = client.invoke_raw(
                 AppInvokeRequest(app="github", operation="plain_text")
             )
@@ -431,10 +422,6 @@ class AppTransportTests(unittest.TestCase):
                 os.environ.pop(ENV_HOST_SERVICE_SOCKET, None)
             else:
                 os.environ[ENV_HOST_SERVICE_SOCKET] = previous_socket
-            if previous_token is None:
-                os.environ.pop(ENV_HOST_SERVICE_TOKEN, None)
-            else:
-                os.environ[ENV_HOST_SERVICE_TOKEN] = previous_token
             if previous_http_proxy is None:
                 os.environ.pop("http_proxy", None)
             else:

--- a/sdk/rust/src/generated/gestalt/provider/v1/gestalt.provider.v1.rs
+++ b/sdk/rust/src/generated/gestalt/provider/v1/gestalt.provider.v1.rs
@@ -3995,6 +3995,8 @@ pub struct ListWorkflowProviderRunsRequest {
     pub page_token: ::prost::alloc::string::String,
     #[prost(enumeration = "WorkflowRunStatus", tag = "3")]
     pub status: i32,
+    /// Optional filter for runs owned by or invoking this app. Matching uses
+    /// hydrated target steps when present, otherwise app-owned definition IDs.
     #[prost(string, tag = "5")]
     pub target_app: ::prost::alloc::string::String,
     #[prost(message, optional, tag = "6")]

--- a/sdk/rust/src/public/generated/workflow.rs
+++ b/sdk/rust/src/public/generated/workflow.rs
@@ -96,6 +96,9 @@ pub struct ListWorkflowProviderRunsRequest {
     pub page_token: String,
     /// The `status` field.
     pub status: WorkflowRunStatus,
+    /// Optional filter for runs owned by or invoking this app. Matching uses
+    /// hydrated target steps when present, otherwise app-owned definition IDs.
+    ///
     /// The `target_app` field.
     pub target_app: String,
     /// The `provider` field.

--- a/sdk/rust/src/workflow.rs
+++ b/sdk/rust/src/workflow.rs
@@ -220,6 +220,9 @@ pub struct ListWorkflowProviderRunsRequest {
     pub page_token: String,
     /// The `status` field.
     pub status: WorkflowRunStatus,
+    /// Optional filter for runs owned by or invoking this app. Matching uses
+    /// hydrated target steps when present, otherwise app-owned definition IDs.
+    ///
     /// The `target_app` field.
     pub target_app: String,
     /// The `context` field; None when unset.

--- a/sdk/tools/sdkgen/internal/emit/python/render.go
+++ b/sdk/tools/sdkgen/internal/emit/python/render.go
@@ -655,16 +655,16 @@ func (r *renderer) renderClient(svc *model.Service) {
 			params += ", context: " + r.fieldType(ctxField) + " | None = None"
 			forward = "channel, context=context"
 		}
-		params += ", timeout: float | None = None"
+		params += ", timeout: float | None = None, relay_token: str = \"\""
 		forward += ", timeout=timeout"
 		r.body.WriteString("    @classmethod\n")
 		fmt.Fprintf(&r.body, "    def connect(%s) -> %s:\n", params, name)
 		r.body.WriteString("        target = os.environ.get(ENV_HOST_SERVICE_SOCKET, \"\")\n")
 		r.body.WriteString("        if not target:\n")
 		r.body.WriteString("            raise RuntimeError(f\"{ENV_HOST_SERVICE_SOCKET} is not set\")\n")
-		r.body.WriteString("        token = os.environ.get(ENV_HOST_SERVICE_TOKEN, \"\")\n")
+		r.body.WriteString("        token = (relay_token or os.environ.get(ENV_HOST_SERVICE_TOKEN, \"\")).strip()\n")
 		r.body.WriteString("        channel = host_service_channel(\n")
-		fmt.Fprintf(&r.body, "            %q, target, token=token.strip(), binding=(name or \"\").strip()\n", svc.HostBinding)
+		fmt.Fprintf(&r.body, "            %q, target, token=token, binding=(name or \"\").strip()\n", svc.HostBinding)
 		r.body.WriteString("        )\n")
 		fmt.Fprintf(&r.body, "        client = cls(%s)\n", forward)
 		r.body.WriteString("        client._owns_channel = True\n")

--- a/sdk/typescript-web/src/client/runtime/internal/gen/v1/workflow_pb.ts
+++ b/sdk/typescript-web/src/client/runtime/internal/gen/v1/workflow_pb.ts
@@ -1306,6 +1306,9 @@ export type ListWorkflowProviderRunsRequest = Message<"gestalt.provider.v1.ListW
   status: WorkflowRunStatus;
 
   /**
+   * Optional filter for runs owned by or invoking this app. Matching uses
+   * hydrated target steps when present, otherwise app-owned definition IDs.
+   *
    * @generated from field: string target_app = 5;
    */
   targetApp: string;

--- a/sdk/typescript-web/src/client/runtime/native-types.ts
+++ b/sdk/typescript-web/src/client/runtime/native-types.ts
@@ -1013,6 +1013,10 @@ export interface ListWorkflowProviderRunsRequest {
   pageSize: number;
   pageToken: string;
   status: WorkflowRunStatus;
+  /**
+   * Optional filter for runs owned by or invoking this app. Matching uses
+   * hydrated target steps when present, otherwise app-owned definition IDs.
+   */
   targetApp: string;
   provider: string;
 }

--- a/sdk/typescript/src/internal/gen/v1/workflow_pb.ts
+++ b/sdk/typescript/src/internal/gen/v1/workflow_pb.ts
@@ -1306,6 +1306,9 @@ export type ListWorkflowProviderRunsRequest = Message<"gestalt.provider.v1.ListW
   status: WorkflowRunStatus;
 
   /**
+   * Optional filter for runs owned by or invoking this app. Matching uses
+   * hydrated target steps when present, otherwise app-owned definition IDs.
+   *
    * @generated from field: string target_app = 5;
    */
   targetApp: string;

--- a/sdk/typescript/src/workflow.ts
+++ b/sdk/typescript/src/workflow.ts
@@ -145,6 +145,10 @@ export interface ListWorkflowProviderRunsRequest {
   pageSize: number;
   pageToken: string;
   status: WorkflowRunStatus;
+  /**
+   * Optional filter for runs owned by or invoking this app. Matching uses
+   * hydrated target steps when present, otherwise app-owned definition IDs.
+   */
   targetApp: string;
   context?: RequestContext;
   provider: string;


### PR DESCRIPTION
## Summary

App Admin Workflows can list runs for an app again: `ListRuns` `targetApp` no longer drops every run when providers return list summaries with empty `Target.steps`.

## Why / context

App Admin calls `GET /api/v2/workflow/runs?provider=…&targetApp=<app>`. gestaltd post-filtered those results by scanning hydrated step apps on `run.Target`. Temporal list summaries omit steps (`"target":{"steps":[]}`), so the filter discarded every run even when definition IDs were clearly app-owned (`app_<app>_…`). That made `/apps/<app>/admin/workflows` look empty for apps that were actively producing runs.

Hardcoding a frontend workaround (client-side re-scan of unfiltered pages) would encode provider list-shape quirks in the console. Ownership of app workflows already has a canonical definition-id convention in gestaltd; list filtering should use that when steps are absent.

## What changed

- `core/workflow.RunMatchesTargetApp` matches hydrated step apps, then falls back to app-owned definition IDs (`app_<app>_…`).
- `workflowmanager.runMatchesListFilters` uses that helper.
- `AppDefinitionID` / `AppDefinitionIDPrefix` are the shared builders; bootstrap app workflow IDs call into them.
- Proto documents `target_app` in product terms (owned by or invoking the app).
- Regenerated checked-in bindings for the proto comment.

**Follow-up (not in this PR):** first-class `owner_app` on `WorkflowRun` list summaries so config-managed (`cfg_*`) runs can be filtered without decoding provider run-handle internals. Decoding Temporal `owner_key` from run IDs was considered and rejected as a domain-boundary leak.

## Validation

- [x] Automated: `go test ./core/workflow/ ./internal/bootstrap/ ./services/workflows/workflowmanager/`
- [x] Automated: regenerated server/SDK bindings with `buf@v1.66.1` + `sdkgen`
- [ ] Manual: after gestaltd pin/deploy to valon.tools, `/apps/ai-spend-tracker/admin/workflows` shows recent runs
- [ ] Manual: `targetApp=ci-cd` still returns ci-cd runs; unfiltered list and run detail unchanged

## Reviewer focus

Confirm definition-id ownership is the right durable fallback (vs parsing provider run IDs in `core/workflow`), and that empty `targetApp` / non-`app_*` definitions stay correctly unmatched.

## Rollout / compatibility

Server-side filter behavior only. Additive proto comment; no wire field changes. Requires gestaltd deploy (and Valon pin) before App Admin Workflows recovers.

## Evidence / demo

Backend API contract fix — no UI surface in this PR to record. Prod repro before fix: `GET /api/v2/workflow/runs?provider=local&targetApp=ai-spend-tracker` returned `{"runs":[]}` while unfiltered pages contained `app_ai-spend-tracker_*` runs.

## Links

Related: empty App Admin Workflows for ai-spend-tracker on valon.tools after admin grant.