### PR TITLE
Add plan for allowlisted external users on valon.tools

### DIFF
--- a/plans/external_users/implementation.md
+++ b/plans/external_users/implementation.md
@@ -1,0 +1,148 @@
+# External Users — Implementation Checklist
+
+Phased work to ship allowlisted external login on valon.tools. Complete phases in
+order; phase 0 is a prerequisite for any production login widening.
+
+## Phase 0 — Authorization hardening (toolshed)
+
+**Goal:** A authenticated subject with zero `authorization.relationships` cannot
+read or invoke Valon apps by inheriting `app.defaultRole: viewer`.
+
+### Tasks
+
+- [ ] **0.1 Baseline audit** — Deploy config to a dev gestaltd with `identity:
+      local` or staging; create a test user with no relationships. Record which
+      mounted UIs load and which MCP `invoke` calls succeed today.
+- [ ] **0.2 Patch `app` resource type** in `toolshed/valon-tools/deploy/config.yaml`:
+      - Set `defaultRole: noaccess` (or remove `defaultRole` and rely on deny-by-default
+        if all actions are explicit — prefer explicit `noaccess` for clarity).
+      - Change `"*"` action to `relations: [nobody]` (or equivalent deny relation).
+      - List every `app` action used in prod (grep deploy config and app manifests
+        for `get_me`, `stores.health`, deal-hub, ci-cd sync, etc.) and assign explicit
+        `relations` so Valon behavior is unchanged **for granted users**.
+- [ ] **0.3 Per-app spot check** — For each app with `authorizationPolicy`, confirm
+      ungranted users are denied at UI (`allowedRoles`) and API layers after 0.2.
+- [ ] **0.4 Regression** — Run CI/CD dev workflow, open 2–3 high-traffic apps as a
+      granted Valon user; confirm no permission regressions.
+- [ ] **0.5 Ship authz-only deploy** — Merge and deploy to prod **before** Auth0
+      cutover.
+
+### Verification
+
+```text
+Subject: user:<uuid> with no relationships
+Expect: 403 on mounted app UIs and MCP invokes (except explicitly public ops if any)
+```
+
+## Phase 1 — Auth0 tenant (dev)
+
+**Goal:** IdP ready for gestaltd OIDC integration testing.
+
+### Tasks
+
+- [ ] **1.1** Create dev Auth0 tenant.
+- [ ] **1.2** Create Regular Web Application; callback
+      `http://localhost:8080/api/v1/auth/login/callback` and staging URL.
+- [ ] **1.3** Enable **Google** connection; configure for `@valon.com` workforce.
+- [ ] **1.4** Enable **Username-Password-Authentication**; decide signup policy
+      (invite-only recommended for first partner).
+- [ ] **1.5** Require email verification on database connection.
+- [ ] **1.6** (Optional) Auth0 Action: domain allowlist `{valon.com, example.com}`;
+      block `@valon.com` on database connection.
+- [ ] **1.7** Store client id/secret in dev secret manager or local env for
+      `gestalt-dev.yaml` / staging overlay.
+
+### Verification
+
+- Manual login at Auth0 Universal Login with Google test account and database test
+  user `@example.com`.
+- `/.well-known/openid-configuration` returns `authorization_endpoint`,
+  `token_endpoint`, `userinfo_endpoint`.
+
+## Phase 2 — Gestalt / toolshed staging config
+
+**Goal:** End-to-end login on non-prod with `allowedDomains`.
+
+### Tasks
+
+- [ ] **2.1** Update `valon-tools/deploy/config.yaml` identity block:
+      - `issuerUrl: https://<dev-tenant>.auth0.com`
+      - `allowedDomains: [valon.com, example.com]`
+      - `displayName: Sign in`
+      - Rename provider key to `auth0` (optional) and set
+        `server.providers.identity: auth0`.
+- [ ] **2.2** Point staging `prod/config.yaml` overlay (or staging-specific overlay)
+      at Auth0 secrets.
+- [ ] **2.3** Regenerate `gestalt.lock.json` if provider git ref changes.
+- [ ] **2.4** Deploy staging valon.tools (or run local gestaltd with prod config
+      merge + dev secrets).
+
+### Verification
+
+| Case | Expected |
+| --- | --- |
+| `@valon.com` + Google | Login OK; grants work |
+| `@example.com` + database | Login OK; no app access |
+| `user@blocked.com` | Error at callback (domain) |
+| Unverified email | Error at callback |
+
+## Phase 3 — Production cutover
+
+**Goal:** valon.tools uses Auth0 with domain allowlist.
+
+### Tasks
+
+- [ ] **3.1** Create prod Auth0 tenant (or promote dev tenant settings).
+- [ ] **3.2** Add GSM secrets `auth0-client-id`, `auth0-client-secret`; update
+      `toolshed/valon-tools/terraform/main.tf`.
+- [ ] **3.3** Update `valon-tools/deploy/prod/config.yaml`:
+      - Identity issuer, secrets, `allowedDomains`.
+      - `redirectUrl: https://valon.tools/api/v1/auth/login/callback`.
+- [ ] **3.4** Confirm phase 0 authz deploy is live in prod.
+- [ ] **3.5** Deploy via toolshed CI; monitor auth audit logs during cutover.
+- [ ] **3.6** Communicate to Valon: login page now Auth0 Universal Login (Google
+      button should still work).
+
+### Rollback
+
+- Revert deploy config to Google `issuerUrl` and `google-oauth-*` secrets.
+- No gestaltd binary rollback required if only config changed.
+
+## Phase 4 — Operations
+
+**Goal:** Repeatable process for partners and support.
+
+### Tasks
+
+- [ ] **4.1 Runbook** — How to add a domain to `allowedDomains` (PR to toolshed,
+      deploy, no Auth0 change if only Gestalt enforces list; optional Auth0 Action
+      update for defense in depth).
+- [ ] **4.2 Runbook** — How to grant an external user access (find `user:<uuid>` via
+      session endpoint or admin tooling; add `authorization.relationships` row;
+      deploy).
+- [ ] **4.3 Runbook** — How to revoke external access (remove relationship; optional
+      Auth0 user block).
+- [ ] **4.4** Replace placeholder `example.com` with first real partner domain when
+      contracted.
+
+## Gestalt platform follow-ups (optional, post-v1)
+
+Not required for initial valon.tools ship, but tracked for product completeness:
+
+- [ ] **Multi-IdP login UI** — `GET /api/v1/auth/info` listing multiple providers
+      (only needed if Gestalt hosts more than one OIDC issuer simultaneously).
+- [ ] **Admin UI: external user grants** — Reduce reliance on config-file
+      relationship edits.
+- [ ] **Auth0 Actions as config** — Document standard Action templates in
+      gestalt-providers or toolshed docs.
+
+## File touch list
+
+| Repository | Paths |
+| --- | --- |
+| toolshed | `valon-tools/deploy/config.yaml` |
+| toolshed | `valon-tools/deploy/prod/config.yaml` |
+| toolshed | `valon-tools/terraform/main.tf` |
+| toolshed | `valon-tools/deploy/gestalt.lock.json` (regenerated) |
+| gestalt | `plans/external_users/*` (this plan) |
+| gestalt-providers | No code changes expected for v1 |

--- a/plans/external_users/implementation.md
+++ b/plans/external_users/implementation.md
@@ -21,35 +21,29 @@ Land [plan.md](./plan.md) and this file. No runtime changes.
 - Regression as a granted Valon user (CI/CD, 2–3 apps).
 - Deploy to prod. **No identity provider change.**
 
-**PR 3 — Auth0 staging identity config**
+**PR 3 — Auth0 cutover (`valon.tools`)**
 
 Stack on merged PR 2 (or land in parallel after PR 2 is approved; do not deploy
 widened login until PR 2 is live).
 
-- Update `valon-tools/deploy/config.yaml` identity block: Auth0 `issuerUrl`,
-  `allowedDomains: [valon.com, example.com]`, `displayName`.
-- Point staging overlay at `auth0-client-id` / `auth0-client-secret` (dev GSM or
-  staging secrets).
-- Regenerate `gestalt.lock.json` if provider git ref changes.
-- Deploy staging / run local gestaltd against staging Auth0 tenant.
-
-Requires Auth0 dev tenant (see Process step 1).
-
-**PR 4 — Auth0 production cutover**
-
-Stack on merged PR 2. Land after PR 3 staging verification.
-
 - Add `auth0-client-id` and `auth0-client-secret` to GSM and
   `valon-tools/terraform/main.tf`.
-- Update `valon-tools/deploy/prod/config.yaml`: issuer, secrets, `allowedDomains`,
-  `redirectUrl: https://valon.tools/api/v1/auth/login/callback`.
-- Deploy via toolshed CI; monitor `auth.login.*` audit events.
+- Update identity in `valon-tools/deploy/config.yaml` and
+  `valon-tools/deploy/prod/config.yaml`: Auth0 `issuerUrl`,
+  `allowedDomains: [valon.com, example.com]`, `displayName`,
+  `redirectUrl: https://valon.tools/api/v1/auth/login/callback`, secrets refs.
+- Regenerate `gestalt.lock.json` if provider git ref changes.
+- Deploy via toolshed CI; monitor `auth.login.*` audit events on valon.tools.
+
+Requires Auth0 application `valon-tools-toolshed` (see Process steps 2–3). Keep
+existing `google-oauth-*` GSM secrets for Calendar/Drive/IAP — they are not the
+Gestalt login issuer.
 
 Rollback: revert issuer to Google and `google-oauth-*` secrets.
 
-**PR 5 — External user ops runbooks**
+**PR 4 — External user ops runbooks**
 
-Land after PR 4 or in parallel once authz shape is stable.
+Land after PR 3 or in parallel once authz shape is stable.
 
 - Runbook: add partner domain → `allowedDomains` PR + deploy (+ optional Auth0
   Action).
@@ -69,42 +63,48 @@ and generic Auth0 issuer.
 main
  ├── gestalt PR 1 — design doc
  ├── toolshed PR 2 — app authorization hardening
- │    └── toolshed PR 3 — Auth0 staging identity config
- │         └── toolshed PR 4 — Auth0 production cutover
- └── toolshed PR 5 — external user ops runbooks
+ │    └── toolshed PR 3 — Auth0 cutover (valon.tools)
+ └── toolshed PR 4 — external user ops runbooks
 ```
 
 | PR | Repo | Base branch | Depends on |
 | --- | --- | --- | --- |
 | 1 | gestalt | `main` | — |
 | 2 | toolshed | `main` | — |
-| 3 | toolshed | `main` | PR 2 approved; Auth0 dev tenant |
-| 4 | toolshed | `main` | PR 2 merged; PR 3 verified on staging |
-| 5 | toolshed | `main` | PR 2 merged (PR 4 for prod-specific steps) |
+| 3 | toolshed | `main` | PR 2 approved; `valon-tools-toolshed` + GSM secrets |
+| 4 | toolshed | `main` | PR 2 merged (PR 3 for prod-specific steps) |
 
-Auth0 tenant setup (dashboard) is not a git PR; complete before PR 3 deploy.
+Auth0 application setup (dashboard) is not a git PR; complete before PR 3 deploy.
 
 ### Process
 
-1. **Auth0 dev tenant** — Regular Web Application; callbacks for localhost and
-   staging; Google + `Username-Password-Authentication` connections; Universal Login
-   with both enabled; email verification on database. Optional Action: domain
-   allowlist; block `@valon.com` on database. Docs:
+1. **gestalt design (PR 1)** — Merge plan docs; get explicit approval on authz +
+   Auth0 approach.
+2. **Auth0 application `valon-tools-toolshed`** — In your existing Auth0 tenant,
+   create a **new Regular Web Application** for valon.tools Gestalt login (do not
+   repurpose unrelated apps):
+   - **Name:** `valon-tools-toolshed`
+   - **Callbacks:** `https://valon.tools/api/v1/auth/login/callback`
+   - **Connections:** Google (for `@valon.com`) + `Username-Password-Authentication`
+     (externals / probe users)
+   - **Universal Login:** both connections enabled; email verification on database
+   - Optional Action: block `@valon.com` on database; duplicate domain allowlist
+   - Copy **Client ID** and **Client Secret** for step 3
+   Docs:
    [Database connections](https://auth0.com/docs/authenticate/database-connections),
    [Universal Login](https://auth0.com/docs/authenticate/login/auth0-universal-login).
-2. **gestalt design (PR 1)** — Merge plan docs; get explicit approval on authz +
-   Auth0 approach.
-3. **Authz hardening (toolshed PR 2)** — Implement, babysit CI/Bugbot, deploy to
-   prod before any login widening. Verify ungranted test subject gets 403 on UI/MCP.
-4. **Staging Auth0 (toolshed PR 3)** — Point staging config at dev tenant; run
-   verification matrix below on staging.
-5. **Auth0 prod tenant** — Mirror dev settings; prod callback
-   `https://valon.tools/api/v1/auth/login/callback`; GSM secrets.
-6. **Production cutover (toolshed PR 4)** — Merge after staging sign-off; monitor
-   auth audit logs; confirm Valon Google login still works.
-7. **Ops runbooks (toolshed PR 5)** — Document domain onboarding and grant/revoke
+3. **GSM secrets** — Store app credentials in `gitlab-peach-street` as
+   `auth0-client-id` / `auth0-client-secret`. Do not overwrite
+   `google-oauth-client-id` / `google-oauth-client-secret` (Google API / IAP).
+4. **Authz hardening (toolshed PR 2)** — Implement, babysit CI/Bugbot, deploy to
+   valon.tools before any login widening. Verify ungranted test subject gets 403 on
+   UI/MCP. Can run in parallel with steps 2–3.
+5. **Auth0 cutover (toolshed PR 3)** — Wire valon.tools identity config to
+   `valon-tools-toolshed`; deploy; create verified external probe user (see
+   **External domain probe** below); run verification matrix on valon.tools.
+6. **Ops runbooks (toolshed PR 4)** — Document domain onboarding and grant/revoke
    workflow for support.
-8. **First partner** — Add real domain to `allowedDomains`; configure Auth0 signup
+7. **First partner** — Add real domain to `allowedDomains`; configure Auth0 signup
    policy (open vs invite-only); grant relationships for pilot users.
 
 ## Tests
@@ -115,12 +115,43 @@ Auth0 tenant setup (dashboard) is not a git PR; complete before PR 3 deploy.
   invokes after patch (except explicitly public ops).
 - Granted Valon user: no regression on CI/CD and 2–3 high-traffic apps.
 
-### Login and domain allowlist (PR 3–4)
+### Login and domain allowlist (PR 3)
+
+#### External domain probe (`valon.tools`)
+
+Test allowlisted external login **without** owning an inbox for the probe address
+(e.g. `probe@example.com`). Use Auth0 admin create with **email verified** set.
+
+**Prerequisites:** PR 2 deployed on valon.tools; PR 3 live with Auth0 identity and
+`allowedDomains: [valon.com, example.com]` (or your probe domain).
+
+1. **Auth0 `valon-tools-toolshed`** (Process step 2) — User Management → Create user:
+   - Connection: `Username-Password-Authentication`
+   - Email: `probe@example.com` (any `@example.com` address)
+   - Password: test-only password
+   - Enable **email verified** (or equivalent) — no confirmation email required
+2. **Gestalt** — Do **not** add `authorization.relationships` for this user.
+3. **Login** — https://valon.tools → Universal Login → database → `probe@example.com`.
+4. **Record UUID** — `GET /api/v1/auth/session` → `user:<uuid>` for later grant tests.
+5. **Negative controls** — Auth0 user on a non-allowlisted domain (e.g.
+   `other@gmail.com`) should fail at Gestalt callback (`allowedDomains`).
+
+| Step | Expected |
+| --- | --- |
+| `probe@example.com` login | OK |
+| `GET /api/v1/auth/session` | Returns `user:<uuid>` |
+| Mounted app UI / MCP / admin | 403 (no grants) |
+| `user@notallowed.com` | Rejected at Gestalt callback |
+
+Remove `example.com` from `allowedDomains` when probe testing is complete unless
+contracted for a partner.
+
+#### Verification matrix
 
 | Case | Expected |
 | --- | --- |
 | `@valon.com` + Google | Login OK; existing grants work |
-| `@example.com` + database | Login OK; no app/MCP/admin access without grants |
+| `@example.com` + database (verified probe user) | Login OK; no app/MCP/admin access without grants |
 | `user@notallowed.com` | Rejected at Gestalt callback (`allowedDomains`) |
 | Unverified email | Rejected by OIDC provider |
 | CLI login (`cli=1`) | Still works through Auth0 |

--- a/plans/external_users/implementation.md
+++ b/plans/external_users/implementation.md
@@ -1,148 +1,51 @@
-# External Users — Implementation Checklist
+# External Users — Checklist
 
-Phased work to ship allowlisted external login on valon.tools. Complete phases in
-order; phase 0 is a prerequisite for any production login widening.
+Phase 0 before any login widening. Details: [plan.md](./plan.md).
 
-## Phase 0 — Authorization hardening (toolshed)
+## Phase 0 — Authz (toolshed)
 
-**Goal:** A authenticated subject with zero `authorization.relationships` cannot
-read or invoke Valon apps by inheriting `app.defaultRole: viewer`.
+- [ ] Test user with zero relationships: record which UIs/MCP invokes work today.
+- [ ] Patch `app` in `deploy/config.yaml`: `defaultRole: noaccess`, `"*"` → `nobody`,
+      explicit relations on all prod `app` actions.
+- [ ] Spot-check apps with `authorizationPolicy` + `allowedRoles`.
+- [ ] Regression as granted Valon user (CI/CD, 2–3 apps).
+- [ ] Deploy to prod before Auth0.
 
-### Tasks
+## Phase 1 — Auth0 (dev)
 
-- [ ] **0.1 Baseline audit** — Deploy config to a dev gestaltd with `identity:
-      local` or staging; create a test user with no relationships. Record which
-      mounted UIs load and which MCP `invoke` calls succeed today.
-- [ ] **0.2 Patch `app` resource type** in `toolshed/valon-tools/deploy/config.yaml`:
-      - Set `defaultRole: noaccess` (or remove `defaultRole` and rely on deny-by-default
-        if all actions are explicit — prefer explicit `noaccess` for clarity).
-      - Change `"*"` action to `relations: [nobody]` (or equivalent deny relation).
-      - List every `app` action used in prod (grep deploy config and app manifests
-        for `get_me`, `stores.health`, deal-hub, ci-cd sync, etc.) and assign explicit
-        `relations` so Valon behavior is unchanged **for granted users**.
-- [ ] **0.3 Per-app spot check** — For each app with `authorizationPolicy`, confirm
-      ungranted users are denied at UI (`allowedRoles`) and API layers after 0.2.
-- [ ] **0.4 Regression** — Run CI/CD dev workflow, open 2–3 high-traffic apps as a
-      granted Valon user; confirm no permission regressions.
-- [ ] **0.5 Ship authz-only deploy** — Merge and deploy to prod **before** Auth0
-      cutover.
+- [ ] Tenant + Regular Web App (localhost + staging callbacks).
+- [ ] Google + Username-Password connections; email verification on database.
+- [ ] Optional Action: domain allowlist; block `@valon.com` on database.
+- [ ] Dev secrets for staging overlay.
 
-### Verification
+## Phase 2 — Staging
 
-```text
-Subject: user:<uuid> with no relationships
-Expect: 403 on mounted app UIs and MCP invokes (except explicitly public ops if any)
-```
+- [ ] `deploy/config.yaml`: Auth0 `issuerUrl`, `allowedDomains`.
+- [ ] Staging overlay secrets; regen lockfile if needed.
+- [ ] Deploy staging / local gestaltd.
 
-## Phase 1 — Auth0 tenant (dev)
+## Phase 3 — Prod
 
-**Goal:** IdP ready for gestaltd OIDC integration testing.
+- [ ] Prod tenant; GSM secrets; `terraform/main.tf`.
+- [ ] `deploy/prod/config.yaml`: issuer, secrets, `allowedDomains`, `redirectUrl`.
+- [ ] Confirm phase 0 live; deploy; monitor auth audit events.
 
-### Tasks
+Rollback: Google `issuerUrl` + `google-oauth-*`.
 
-- [ ] **1.1** Create dev Auth0 tenant.
-- [ ] **1.2** Create Regular Web Application; callback
-      `http://localhost:8080/api/v1/auth/login/callback` and staging URL.
-- [ ] **1.3** Enable **Google** connection; configure for `@valon.com` workforce.
-- [ ] **1.4** Enable **Username-Password-Authentication**; decide signup policy
-      (invite-only recommended for first partner).
-- [ ] **1.5** Require email verification on database connection.
-- [ ] **1.6** (Optional) Auth0 Action: domain allowlist `{valon.com, example.com}`;
-      block `@valon.com` on database connection.
-- [ ] **1.7** Store client id/secret in dev secret manager or local env for
-      `gestalt-dev.yaml` / staging overlay.
+## Phase 4 — Ops
 
-### Verification
+- [ ] Runbook: add domain → `allowedDomains` PR + deploy.
+- [ ] Runbook: grant user → session API for UUID → relationship row → deploy.
+- [ ] Runbook: revoke → remove relationship (+ optional Auth0 block).
+- [ ] Replace `example.com` with first partner domain.
 
-- Manual login at Auth0 Universal Login with Google test account and database test
-  user `@example.com`.
-- `/.well-known/openid-configuration` returns `authorization_endpoint`,
-  `token_endpoint`, `userinfo_endpoint`.
-
-## Phase 2 — Gestalt / toolshed staging config
-
-**Goal:** End-to-end login on non-prod with `allowedDomains`.
-
-### Tasks
-
-- [ ] **2.1** Update `valon-tools/deploy/config.yaml` identity block:
-      - `issuerUrl: https://<dev-tenant>.auth0.com`
-      - `allowedDomains: [valon.com, example.com]`
-      - `displayName: Sign in`
-      - Rename provider key to `auth0` (optional) and set
-        `server.providers.identity: auth0`.
-- [ ] **2.2** Point staging `prod/config.yaml` overlay (or staging-specific overlay)
-      at Auth0 secrets.
-- [ ] **2.3** Regenerate `gestalt.lock.json` if provider git ref changes.
-- [ ] **2.4** Deploy staging valon.tools (or run local gestaltd with prod config
-      merge + dev secrets).
-
-### Verification
+## Verify
 
 | Case | Expected |
 | --- | --- |
+| No relationships, post-authz patch | 403 UI/MCP |
 | `@valon.com` + Google | Login OK; grants work |
-| `@example.com` + database | Login OK; no app access |
-| `user@blocked.com` | Error at callback (domain) |
-| Unverified email | Error at callback |
-
-## Phase 3 — Production cutover
-
-**Goal:** valon.tools uses Auth0 with domain allowlist.
-
-### Tasks
-
-- [ ] **3.1** Create prod Auth0 tenant (or promote dev tenant settings).
-- [ ] **3.2** Add GSM secrets `auth0-client-id`, `auth0-client-secret`; update
-      `toolshed/valon-tools/terraform/main.tf`.
-- [ ] **3.3** Update `valon-tools/deploy/prod/config.yaml`:
-      - Identity issuer, secrets, `allowedDomains`.
-      - `redirectUrl: https://valon.tools/api/v1/auth/login/callback`.
-- [ ] **3.4** Confirm phase 0 authz deploy is live in prod.
-- [ ] **3.5** Deploy via toolshed CI; monitor auth audit logs during cutover.
-- [ ] **3.6** Communicate to Valon: login page now Auth0 Universal Login (Google
-      button should still work).
-
-### Rollback
-
-- Revert deploy config to Google `issuerUrl` and `google-oauth-*` secrets.
-- No gestaltd binary rollback required if only config changed.
-
-## Phase 4 — Operations
-
-**Goal:** Repeatable process for partners and support.
-
-### Tasks
-
-- [ ] **4.1 Runbook** — How to add a domain to `allowedDomains` (PR to toolshed,
-      deploy, no Auth0 change if only Gestalt enforces list; optional Auth0 Action
-      update for defense in depth).
-- [ ] **4.2 Runbook** — How to grant an external user access (find `user:<uuid>` via
-      session endpoint or admin tooling; add `authorization.relationships` row;
-      deploy).
-- [ ] **4.3 Runbook** — How to revoke external access (remove relationship; optional
-      Auth0 user block).
-- [ ] **4.4** Replace placeholder `example.com` with first real partner domain when
-      contracted.
-
-## Gestalt platform follow-ups (optional, post-v1)
-
-Not required for initial valon.tools ship, but tracked for product completeness:
-
-- [ ] **Multi-IdP login UI** — `GET /api/v1/auth/info` listing multiple providers
-      (only needed if Gestalt hosts more than one OIDC issuer simultaneously).
-- [ ] **Admin UI: external user grants** — Reduce reliance on config-file
-      relationship edits.
-- [ ] **Auth0 Actions as config** — Document standard Action templates in
-      gestalt-providers or toolshed docs.
-
-## File touch list
-
-| Repository | Paths |
-| --- | --- |
-| toolshed | `valon-tools/deploy/config.yaml` |
-| toolshed | `valon-tools/deploy/prod/config.yaml` |
-| toolshed | `valon-tools/terraform/main.tf` |
-| toolshed | `valon-tools/deploy/gestalt.lock.json` (regenerated) |
-| gestalt | `plans/external_users/*` (this plan) |
-| gestalt-providers | No code changes expected for v1 |
+| `@example.com` + database | Login OK; no access |
+| `user@blocked.com` | Rejected at callback |
+| Unverified email | Rejected at callback |
+| CLI login (`cli=1`) | Still works |

--- a/plans/external_users/implementation.md
+++ b/plans/external_users/implementation.md
@@ -14,10 +14,15 @@ Land [plan.md](./plan.md) and this file. No runtime changes.
 
 **PR 2 — `app` authorization hardening**
 
-- Patch `app` in `valon-tools/deploy/config.yaml`: `defaultRole: noaccess`, `"*"` →
+- Patch `app` in `valon-tools/deploy/config.yaml`: **omit `defaultRole`**, `"*"` →
   `nobody`, explicit `relations` on every prod `app` action (`get_me`,
   `stores.health`, deal-hub, ci-cd sync, …).
-- Spot-check apps with `authorizationPolicy` and `allowedRoles`.
+- **Do not** set `defaultRole: noaccess` — gestaltd treats any non-empty
+  `defaultRole` as an allow fallback for mounted UIs when `allowedRoles` is empty,
+  and `CheckAccess` can allow when `defaultRole` appears in the action relation
+  list (`mounted_ui.go`, `authorization/indexeddb/access.go`).
+- Spot-check apps with `authorizationPolicy` and `allowedRoles`; clear
+  `defaultRole` on custom policy resource types where needed.
 - Regression as a granted Valon user (CI/CD, 2–3 apps).
 - Deploy to prod. **No identity provider change.**
 
@@ -112,7 +117,9 @@ Auth0 application setup (dashboard) is not a git PR; complete before PR 3 deploy
 ### Authorization (PR 2)
 
 - Subject with zero `authorization.relationships`: 403 on mounted app UIs and MCP
-  invokes after patch (except explicitly public ops).
+  invokes after patch (except explicitly public ops). Requires **cleared
+  `defaultRole`** on the relevant resource type — `"*": relations: [nobody]` alone
+  does not block static UI serving.
 - Granted Valon user: no regression on CI/CD and 2–3 high-traffic apps.
 
 ### Login and domain allowlist (PR 3)

--- a/plans/external_users/implementation.md
+++ b/plans/external_users/implementation.md
@@ -1,51 +1,142 @@
-# External Users — Checklist
+# External Users — Implementation
 
-Phase 0 before any login widening. Details: [plan.md](./plan.md).
+Allowlisted external login on valon.tools. Design: [plan.md](./plan.md).
 
-## Phase 0 — Authz (toolshed)
+## Implementation
 
-- [ ] Test user with zero relationships: record which UIs/MCP invokes work today.
-- [ ] Patch `app` in `deploy/config.yaml`: `defaultRole: noaccess`, `"*"` → `nobody`,
-      explicit relations on all prod `app` actions.
-- [ ] Spot-check apps with `authorizationPolicy` + `allowedRoles`.
-- [ ] Regression as granted Valon user (CI/CD, 2–3 apps).
-- [ ] Deploy to prod before Auth0.
+### gestalt
 
-## Phase 1 — Auth0 (dev)
+**PR 1 — Design doc**
 
-- [ ] Tenant + Regular Web App (localhost + staging callbacks).
-- [ ] Google + Username-Password connections; email verification on database.
-- [ ] Optional Action: domain allowlist; block `@valon.com` on database.
-- [ ] Dev secrets for staging overlay.
+Land [plan.md](./plan.md) and this file. No runtime changes.
 
-## Phase 2 — Staging
+### toolshed
 
-- [ ] `deploy/config.yaml`: Auth0 `issuerUrl`, `allowedDomains`.
-- [ ] Staging overlay secrets; regen lockfile if needed.
-- [ ] Deploy staging / local gestaltd.
+**PR 2 — `app` authorization hardening**
 
-## Phase 3 — Prod
+- Patch `app` in `valon-tools/deploy/config.yaml`: `defaultRole: noaccess`, `"*"` →
+  `nobody`, explicit `relations` on every prod `app` action (`get_me`,
+  `stores.health`, deal-hub, ci-cd sync, …).
+- Spot-check apps with `authorizationPolicy` and `allowedRoles`.
+- Regression as a granted Valon user (CI/CD, 2–3 apps).
+- Deploy to prod. **No identity provider change.**
 
-- [ ] Prod tenant; GSM secrets; `terraform/main.tf`.
-- [ ] `deploy/prod/config.yaml`: issuer, secrets, `allowedDomains`, `redirectUrl`.
-- [ ] Confirm phase 0 live; deploy; monitor auth audit events.
+**PR 3 — Auth0 staging identity config**
 
-Rollback: Google `issuerUrl` + `google-oauth-*`.
+Stack on merged PR 2 (or land in parallel after PR 2 is approved; do not deploy
+widened login until PR 2 is live).
 
-## Phase 4 — Ops
+- Update `valon-tools/deploy/config.yaml` identity block: Auth0 `issuerUrl`,
+  `allowedDomains: [valon.com, example.com]`, `displayName`.
+- Point staging overlay at `auth0-client-id` / `auth0-client-secret` (dev GSM or
+  staging secrets).
+- Regenerate `gestalt.lock.json` if provider git ref changes.
+- Deploy staging / run local gestaltd against staging Auth0 tenant.
 
-- [ ] Runbook: add domain → `allowedDomains` PR + deploy.
-- [ ] Runbook: grant user → session API for UUID → relationship row → deploy.
-- [ ] Runbook: revoke → remove relationship (+ optional Auth0 block).
-- [ ] Replace `example.com` with first partner domain.
+Requires Auth0 dev tenant (see Process step 1).
 
-## Verify
+**PR 4 — Auth0 production cutover**
+
+Stack on merged PR 2. Land after PR 3 staging verification.
+
+- Add `auth0-client-id` and `auth0-client-secret` to GSM and
+  `valon-tools/terraform/main.tf`.
+- Update `valon-tools/deploy/prod/config.yaml`: issuer, secrets, `allowedDomains`,
+  `redirectUrl: https://valon.tools/api/v1/auth/login/callback`.
+- Deploy via toolshed CI; monitor `auth.login.*` audit events.
+
+Rollback: revert issuer to Google and `google-oauth-*` secrets.
+
+**PR 5 — External user ops runbooks**
+
+Land after PR 4 or in parallel once authz shape is stable.
+
+- Runbook: add partner domain → `allowedDomains` PR + deploy (+ optional Auth0
+  Action).
+- Runbook: grant external user → `GET /api/v1/auth/session` for `user:<uuid>` →
+  `authorization.relationships` row → deploy.
+- Runbook: revoke → remove relationship; optional Auth0 user block.
+- Replace placeholder `example.com` with first partner domain when contracted.
+
+### gestalt-providers
+
+No code changes expected for v1. OIDC provider already supports `allowedDomains`
+and generic Auth0 issuer.
+
+### Stacking
+
+```text
+main
+ ├── gestalt PR 1 — design doc
+ ├── toolshed PR 2 — app authorization hardening
+ │    └── toolshed PR 3 — Auth0 staging identity config
+ │         └── toolshed PR 4 — Auth0 production cutover
+ └── toolshed PR 5 — external user ops runbooks
+```
+
+| PR | Repo | Base branch | Depends on |
+| --- | --- | --- | --- |
+| 1 | gestalt | `main` | — |
+| 2 | toolshed | `main` | — |
+| 3 | toolshed | `main` | PR 2 approved; Auth0 dev tenant |
+| 4 | toolshed | `main` | PR 2 merged; PR 3 verified on staging |
+| 5 | toolshed | `main` | PR 2 merged (PR 4 for prod-specific steps) |
+
+Auth0 tenant setup (dashboard) is not a git PR; complete before PR 3 deploy.
+
+### Process
+
+1. **Auth0 dev tenant** — Regular Web Application; callbacks for localhost and
+   staging; Google + `Username-Password-Authentication` connections; Universal Login
+   with both enabled; email verification on database. Optional Action: domain
+   allowlist; block `@valon.com` on database. Docs:
+   [Database connections](https://auth0.com/docs/authenticate/database-connections),
+   [Universal Login](https://auth0.com/docs/authenticate/login/auth0-universal-login).
+2. **gestalt design (PR 1)** — Merge plan docs; get explicit approval on authz +
+   Auth0 approach.
+3. **Authz hardening (toolshed PR 2)** — Implement, babysit CI/Bugbot, deploy to
+   prod before any login widening. Verify ungranted test subject gets 403 on UI/MCP.
+4. **Staging Auth0 (toolshed PR 3)** — Point staging config at dev tenant; run
+   verification matrix below on staging.
+5. **Auth0 prod tenant** — Mirror dev settings; prod callback
+   `https://valon.tools/api/v1/auth/login/callback`; GSM secrets.
+6. **Production cutover (toolshed PR 4)** — Merge after staging sign-off; monitor
+   auth audit logs; confirm Valon Google login still works.
+7. **Ops runbooks (toolshed PR 5)** — Document domain onboarding and grant/revoke
+   workflow for support.
+8. **First partner** — Add real domain to `allowedDomains`; configure Auth0 signup
+   policy (open vs invite-only); grant relationships for pilot users.
+
+## Tests
+
+### Authorization (PR 2)
+
+- Subject with zero `authorization.relationships`: 403 on mounted app UIs and MCP
+  invokes after patch (except explicitly public ops).
+- Granted Valon user: no regression on CI/CD and 2–3 high-traffic apps.
+
+### Login and domain allowlist (PR 3–4)
 
 | Case | Expected |
 | --- | --- |
-| No relationships, post-authz patch | 403 UI/MCP |
-| `@valon.com` + Google | Login OK; grants work |
-| `@example.com` + database | Login OK; no access |
-| `user@blocked.com` | Rejected at callback |
-| Unverified email | Rejected at callback |
-| CLI login (`cli=1`) | Still works |
+| `@valon.com` + Google | Login OK; existing grants work |
+| `@example.com` + database | Login OK; no app/MCP/admin access without grants |
+| `user@notallowed.com` | Rejected at Gestalt callback (`allowedDomains`) |
+| Unverified email | Rejected by OIDC provider |
+| CLI login (`cli=1`) | Still works through Auth0 |
+
+### Rollback
+
+- Revert to Google `issuerUrl` + `google-oauth-*`: Valon users can log in; external
+  database users cannot.
+
+## Related Docs
+
+<pre>
+├── <a href="./plan.md">plan.md</a> — design, config, Auth0 summary
+├── <a href="https://auth0.com/docs/authenticate/database-connections">Auth0 — Database connections</a>
+├── <a href="https://auth0.com/docs/authenticate/login/auth0-universal-login">Auth0 — Universal Login</a>
+├── <a href="https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow">Auth0 — Authorization Code Flow</a>
+├── <a href="https://github.com/valon-technologies/gestalt-providers/tree/main/auth/oidc">gestalt-providers/auth/oidc</a>
+└── <a href="../../docs/content/providers/identity.mdx">gestaltd — Identity providers</a>
+</pre>

--- a/plans/external_users/implementation.md
+++ b/plans/external_users/implementation.md
@@ -14,35 +14,22 @@ Land [plan.md](./plan.md) and this file. No runtime changes.
 
 **PR 2 — `app` authorization hardening**
 
-- Patch `app` in `valon-tools/deploy/config.yaml`: **omit `defaultRole`**, `"*"` →
-  `nobody`, explicit `relations` on every prod `app` action (`get_me`,
-  `stores.health`, deal-hub, ci-cd sync, …).
-- **Do not** set `defaultRole: noaccess` — gestaltd treats any non-empty
-  `defaultRole` as an allow fallback for mounted UIs when `allowedRoles` is empty,
-  and `CheckAccess` can allow when `defaultRole` appears in the action relation
-  list (`mounted_ui.go`, `authorization/indexeddb/access.go`).
-- Spot-check apps with `authorizationPolicy` and `allowedRoles`; clear
-  `defaultRole` on custom policy resource types where needed.
+- Patch `app` in `valon-tools/deploy/config.yaml`: **omit `defaultRole`**, `"*"` → `nobody`, explicit `relations` on every prod `app` action (`get_me`, `stores.health`, deal-hub, ci-cd sync, …).
+- **Do not** set `defaultRole: noaccess` — gestaltd treats any non-empty `defaultRole` as an allow fallback for mounted UIs when `allowedRoles` is empty, and `CheckAccess` can allow when `defaultRole` appears in the action relation list (`mounted_ui.go`, `authorization/indexeddb/access.go`).
+- Spot-check apps with `authorizationPolicy` and `allowedRoles`; clear `defaultRole` on custom policy resource types where needed.
 - Regression as a granted Valon user (CI/CD, 2–3 apps).
 - Deploy to prod. **No identity provider change.**
 
 **PR 3 — Auth0 cutover (`valon.tools`)**
 
-Stack on merged PR 2 (or land in parallel after PR 2 is approved; do not deploy
-widened login until PR 2 is live).
+Stack on merged PR 2 (or land in parallel after PR 2 is approved; do not deploy widened login until PR 2 is live).
 
-- Add `auth0-client-id` and `auth0-client-secret` to GSM and
-  `valon-tools/terraform/main.tf`.
-- Update identity in `valon-tools/deploy/config.yaml` and
-  `valon-tools/deploy/prod/config.yaml`: Auth0 `issuerUrl`,
-  `allowedDomains: [valon.com, example.com]`, `displayName`,
-  `redirectUrl: https://valon.tools/api/v1/auth/login/callback`, secrets refs.
+- Add `auth0-client-id` and `auth0-client-secret` to GSM and `valon-tools/terraform/main.tf`.
+- Update identity in `valon-tools/deploy/config.yaml` and `valon-tools/deploy/prod/config.yaml`: Auth0 `issuerUrl`, `allowedDomains: [valon.com, example.com]`, `displayName`, `redirectUrl: https://valon.tools/api/v1/auth/login/callback`, secrets refs.
 - Regenerate `gestalt.lock.json` if provider git ref changes.
 - Deploy via toolshed CI; monitor `auth.login.*` audit events on valon.tools.
 
-Requires Auth0 application `valon-tools-toolshed` (see Process steps 2–3). Keep
-existing `google-oauth-*` GSM secrets for Calendar/Drive/IAP — they are not the
-Gestalt login issuer.
+Requires Auth0 application `valon-tools-toolshed` (see Process steps 2–3). Keep existing `google-oauth-*` GSM secrets for Calendar/Drive/IAP — they are not the Gestalt login issuer.
 
 Rollback: revert issuer to Google and `google-oauth-*` secrets.
 
@@ -50,17 +37,14 @@ Rollback: revert issuer to Google and `google-oauth-*` secrets.
 
 Land after PR 3 or in parallel once authz shape is stable.
 
-- Runbook: add partner domain → `allowedDomains` PR + deploy (+ optional Auth0
-  Action).
-- Runbook: grant external user → `GET /api/v1/auth/session` for `user:<uuid>` →
-  `authorization.relationships` row → deploy.
+- Runbook: add partner domain → `allowedDomains` PR + deploy (+ optional Auth0 Action).
+- Runbook: grant external user → `GET /api/v1/auth/session` for `user:<uuid>` → `authorization.relationships` row → deploy.
 - Runbook: revoke → remove relationship; optional Auth0 user block.
 - Replace placeholder `example.com` with first partner domain when contracted.
 
 ### gestalt-providers
 
-No code changes expected for v1. OIDC provider already supports `allowedDomains`
-and generic Auth0 issuer.
+No code changes expected for v1. OIDC provider already supports `allowedDomains` and generic Auth0 issuer.
 
 ### Stacking
 
@@ -83,54 +67,35 @@ Auth0 application setup (dashboard) is not a git PR; complete before PR 3 deploy
 
 ### Process
 
-1. **gestalt design (PR 1)** — Merge plan docs; get explicit approval on authz +
-   Auth0 approach.
-2. **Auth0 application `valon-tools-toolshed`** — In your existing Auth0 tenant,
-   create a **new Regular Web Application** for valon.tools Gestalt login (do not
-   repurpose unrelated apps):
+1. **gestalt design (PR 1)** — Merge plan docs; get explicit approval on authz + Auth0 approach.
+2. **Auth0 application `valon-tools-toolshed`** — In your existing Auth0 tenant, create a **new Regular Web Application** for valon.tools Gestalt login (do not repurpose unrelated apps):
    - **Name:** `valon-tools-toolshed`
    - **Callbacks:** `https://valon.tools/api/v1/auth/login/callback`
-   - **Connections:** Google (for `@valon.com`) + `Username-Password-Authentication`
-     (externals / probe users)
+   - **Connections:** Google (for `@valon.com`) + `Username-Password-Authentication` (externals / probe users)
    - **Universal Login:** both connections enabled; email verification on database
    - Optional Action: block `@valon.com` on database; duplicate domain allowlist
    - Copy **Client ID** and **Client Secret** for step 3
-   Docs:
-   [Database connections](https://auth0.com/docs/authenticate/database-connections),
-   [Universal Login](https://auth0.com/docs/authenticate/login/auth0-universal-login).
-3. **GSM secrets** — Store app credentials in `gitlab-peach-street` as
-   `auth0-client-id` / `auth0-client-secret`. Do not overwrite
-   `google-oauth-client-id` / `google-oauth-client-secret` (Google API / IAP).
-4. **Authz hardening (toolshed PR 2)** — Implement, babysit CI/Bugbot, deploy to
-   valon.tools before any login widening. Verify ungranted test subject gets 403 on
-   UI/MCP. Can run in parallel with steps 2–3.
-5. **Auth0 cutover (toolshed PR 3)** — Wire valon.tools identity config to
-   `valon-tools-toolshed`; deploy; create verified external probe user (see
-   **External domain probe** below); run verification matrix on valon.tools.
-6. **Ops runbooks (toolshed PR 4)** — Document domain onboarding and grant/revoke
-   workflow for support.
-7. **First partner** — Add real domain to `allowedDomains`; configure Auth0 signup
-   policy (open vs invite-only); grant relationships for pilot users.
+   Docs: [Database connections](https://auth0.com/docs/authenticate/database-connections), [Universal Login](https://auth0.com/docs/authenticate/login/auth0-universal-login).
+3. **GSM secrets** — Store app credentials in `gitlab-peach-street` as `auth0-client-id` / `auth0-client-secret`. Do not overwrite `google-oauth-client-id` / `google-oauth-client-secret` (Google API / IAP).
+4. **Authz hardening (toolshed PR 2)** — Implement, babysit CI/Bugbot, deploy to valon.tools before any login widening. Verify ungranted test subject gets 403 on UI/MCP. Can run in parallel with steps 2–3.
+5. **Auth0 cutover (toolshed PR 3)** — Wire valon.tools identity config to `valon-tools-toolshed`; deploy; create verified external probe user (see **External domain probe** below); run verification matrix on valon.tools.
+6. **Ops runbooks (toolshed PR 4)** — Document domain onboarding and grant/revoke workflow for support.
+7. **First partner** — Add real domain to `allowedDomains`; configure Auth0 signup policy (open vs invite-only); grant relationships for pilot users.
 
 ## Tests
 
 ### Authorization (PR 2)
 
-- Subject with zero `authorization.relationships`: 403 on mounted app UIs and MCP
-  invokes after patch (except explicitly public ops). Requires **cleared
-  `defaultRole`** on the relevant resource type — `"*": relations: [nobody]` alone
-  does not block static UI serving.
+- Subject with zero `authorization.relationships`: 403 on mounted app UIs and MCP invokes after patch (except explicitly public ops). Requires **cleared `defaultRole`** on the relevant resource type — `"*": relations: [nobody]` alone does not block static UI serving.
 - Granted Valon user: no regression on CI/CD and 2–3 high-traffic apps.
 
 ### Login and domain allowlist (PR 3)
 
 #### External domain probe (`valon.tools`)
 
-Test allowlisted external login **without** owning an inbox for the probe address
-(e.g. `probe@example.com`). Use Auth0 admin create with **email verified** set.
+Test allowlisted external login **without** owning an inbox for the probe address (e.g. `probe@example.com`). Use Auth0 admin create with **email verified** set.
 
-**Prerequisites:** PR 2 deployed on valon.tools; PR 3 live with Auth0 identity and
-`allowedDomains: [valon.com, example.com]` (or your probe domain).
+**Prerequisites:** PR 2 deployed on valon.tools; PR 3 live with Auth0 identity and `allowedDomains: [valon.com, example.com]` (or your probe domain).
 
 1. **Auth0 `valon-tools-toolshed`** (Process step 2) — User Management → Create user:
    - Connection: `Username-Password-Authentication`
@@ -140,8 +105,7 @@ Test allowlisted external login **without** owning an inbox for the probe addres
 2. **Gestalt** — Do **not** add `authorization.relationships` for this user.
 3. **Login** — https://valon.tools → Universal Login → database → `probe@example.com`.
 4. **Record UUID** — `GET /api/v1/auth/session` → `user:<uuid>` for later grant tests.
-5. **Negative controls** — Auth0 user on a non-allowlisted domain (e.g.
-   `other@gmail.com`) should fail at Gestalt callback (`allowedDomains`).
+5. **Negative controls** — Auth0 user on a non-allowlisted domain (e.g. `other@gmail.com`) should fail at Gestalt callback (`allowedDomains`).
 
 | Step | Expected |
 | --- | --- |
@@ -150,8 +114,7 @@ Test allowlisted external login **without** owning an inbox for the probe addres
 | Mounted app UI / MCP / admin | 403 (no grants) |
 | `user@notallowed.com` | Rejected at Gestalt callback |
 
-Remove `example.com` from `allowedDomains` when probe testing is complete unless
-contracted for a partner.
+Remove `example.com` from `allowedDomains` when probe testing is complete unless contracted for a partner.
 
 #### Verification matrix
 
@@ -165,8 +128,7 @@ contracted for a partner.
 
 ### Rollback
 
-- Revert to Google `issuerUrl` + `google-oauth-*`: Valon users can log in; external
-  database users cannot.
+- Revert to Google `issuerUrl` + `google-oauth-*`: Valon users can log in; external database users cannot.
 
 ## Related Docs
 

--- a/plans/external_users/plan.md
+++ b/plans/external_users/plan.md
@@ -10,8 +10,11 @@ Auth0 Google connection; externals via Auth0 database. No app/MCP/admin access w
 - Identity: `gestalt-providers/auth/oidc` with `issuerUrl: https://accounts.google.com`
   (`toolshed/valon-tools/deploy`; config key `google`).
 - No `allowedDomains` — Gestalt accepts any verified email after OAuth.
-- **Blocker:** `app` resource type has `defaultRole: viewer` and `"*"` includes
-  `viewer`. Ungranted users get viewer on `app`-kind checks. Fix before widening login.
+- **Blocker:** `app` has `defaultRole: viewer` and `"*"` includes `viewer`. A
+  non-empty `defaultRole` is an **allow fallback** in gestaltd: mounted UIs with
+  empty `allowedRoles` still serve static assets, and `CheckAccess` can allow
+  actions when `defaultRole` matches the action’s relation list — even for
+  ungranted subjects. Fix before widening login.
 - Users: `FindOrCreateUser(email)` → stable `user:<uuid>`; grants use UUIDs in prod.
 
 ## Flow
@@ -20,7 +23,7 @@ Auth0 Google connection; externals via Auth0 database. No app/MCP/admin access w
 Browser → GET /api/v1/auth/login → Auth0 Universal Login
   (Google | Database) → /api/v1/auth/login/callback
   → oidc provider (email_verified, allowedDomains) → session cookie
-  → FindOrCreateUser → CheckAccess (relationships + defaultRole)
+  → FindOrCreateUser → CheckAccess (relationships; optional defaultRole bypass)
 ```
 
 One Gestalt OIDC issuer (`https://<tenant>.auth0.com`). Login UI stays on Auth0.
@@ -45,13 +48,21 @@ Optional Auth0 Action: force `@valon.com` to Google; duplicate domain check.
 | Login | Yes | Yes if allowlisted |
 | Default access | Existing grants | Denied |
 
-Before external login, patch `app` in `toolshed/valon-tools/deploy/config.yaml`
-(mirror `itAccountOnboarding`):
+Before external login, patch `app` in `toolshed/valon-tools/deploy/config.yaml`:
 
-- `defaultRole: noaccess`
-- `"*": relations: [nobody]`
+- **Clear `defaultRole`** on `app` (omit the field). Do not set `defaultRole:
+  noaccess` — any non-empty `defaultRole` still authorizes mounted UIs when
+  `allowedRoles` is empty (`gestaltd/internal/server/mounted_ui.go`).
+- `"*": relations: [nobody]` — closes the `CheckAccess` wildcard; ungranted
+  subjects have no `nobody` relationship, so RPC/MCP/actions deny. Does **not** gate
+  static UI by itself.
 - Explicit `relations` on every `app` action Valon uses (`get_me`, `stores.health`,
-  deal-hub, ci-cd sync, …)
+  deal-hub, ci-cd sync, …).
+- Spot-check apps with a custom `authorizationPolicy` — clear `defaultRole` on
+  those resource types too when they use an empty `allowedRoles` UI mount.
+
+`itAccountOnboarding` is a useful reference for `"*"` → `nobody` and per-action
+relations, not for `defaultRole: noaccess` as a UI deny lever.
 
 Grant externals: login → `GET /api/v1/auth/session` for `user:<uuid>` → add
 relationship → deploy.
@@ -100,4 +111,5 @@ Rollback: revert issuer to Google + `google-oauth-*` secrets.
 - Database signup: open vs invite-only?
 - MFA on database connection?
 - Custom Auth0 domain?
-- Per-app `defaultRole: noaccess` resource types vs global `app` patch only?
+- Per-app `authorizationPolicy` resource types: clear `defaultRole` where mounts
+  rely on relationship grants only?

--- a/plans/external_users/plan.md
+++ b/plans/external_users/plan.md
@@ -2,7 +2,8 @@
 
 Allowlisted domains (e.g. `valon.com`, `example.com`) can log in. `@valon.com` via
 Auth0 Google connection; externals via Auth0 database. No app/MCP/admin access without
-`authorization.relationships`. Checklist: [implementation.md](./implementation.md).
+`authorization.relationships`. Implementation PRs and process:
+[implementation.md](./implementation.md).
 
 ## Current state
 

--- a/plans/external_users/plan.md
+++ b/plans/external_users/plan.md
@@ -1,109 +1,30 @@
 # External Users on valon.tools
 
-Support authenticated users whose email domain is not `@valon.com`, while keeping
-default access closed. Valon employees retain Google sign-in; allowlisted external
-domains (e.g. `@example.com`) can authenticate via Auth0 database login.
-
-## Contents
-
-- [Goals and non-goals](#goals-and-non-goals)
-- [Current state](#current-state)
-- [Target architecture](#target-architecture)
-- [Domain allowlist](#domain-allowlist)
-- [Authorization model](#authorization-model)
-- [Implementation phases](#implementation-phases)
-- [Configuration reference](#configuration-reference)
-- [Auth0 setup](#auth0-setup)
-- [Toolshed / valon-tools deploy](#toolshed--valon-tools-deploy)
-- [Testing and rollout](#testing-and-rollout)
-- [Open questions](#open-questions)
-
-## Goals and non-goals
-
-### Goals
-
-- Allowlisted email domains can complete platform login on `https://valon.tools/`.
-- `@valon.com` remains allowed and continues to sign in with Google (via Auth0
-  Google social connection, not a separate Gestalt identity provider).
-- External users receive **no app, MCP, or admin access** until explicitly granted
-  in `authorization.relationships`.
-- Domain enforcement happens at login (`allowedDomains` on the OIDC identity
-  provider), not only at the IdP.
-- Single OIDC issuer in Gestalt config (Auth0 tenant); no multi-button login UX
-  work in gestaltd for v1.
-
-### Non-goals (v1)
-
-- Per-partner SAML/OIDC enterprise connections (can add Auth0 connections later
-  without Gestalt code changes).
-- Self-service signup policy beyond what Auth0 configures (invite-only vs open
-  registration is an Auth0 dashboard decision).
-- Native username/password forms hosted by gestaltd (Auth0 Universal Login only).
-- Automatic provisioning of external users into specific apps (manual or scripted
-  grant assignment only).
-- Changing how Valon employees are named in `authorization.relationships` (stable
-  `user:<uuid>` subjects keyed by email remain the source of truth).
+Allowlisted domains (e.g. `valon.com`, `example.com`) can log in. `@valon.com` via
+Auth0 Google connection; externals via Auth0 database. No app/MCP/admin access without
+`authorization.relationships`. Checklist: [implementation.md](./implementation.md).
 
 ## Current state
 
-**Identity.** Production valon.tools uses the generic OIDC identity provider from
-`gestalt-providers/auth/oidc`, configured with `issuerUrl: https://accounts.google.com`
-and secrets `google-oauth-client-id` / `google-oauth-client-secret`. The config key
-is named `google` but the implementation is OIDC, not a bespoke Google plugin.
+- Identity: `gestalt-providers/auth/oidc` with `issuerUrl: https://accounts.google.com`
+  (`toolshed/valon-tools/deploy`; config key `google`).
+- No `allowedDomains` — Gestalt accepts any verified email after OAuth.
+- **Blocker:** `app` resource type has `defaultRole: viewer` and `"*"` includes
+  `viewer`. Ungranted users get viewer on `app`-kind checks. Fix before widening login.
+- Users: `FindOrCreateUser(email)` → stable `user:<uuid>`; grants use UUIDs in prod.
 
-**Domain filter.** `allowedDomains` is not set today, so Gestalt does not restrict
-email domains after a successful OAuth exchange. Any restriction is implicit in who
-can use the Google OAuth client / Workspace.
-
-**Authorization gap.** The shared `app` resource type in
-`toolshed/valon-tools/deploy/config.yaml` sets `defaultRole: viewer` with a
-wildcard action that includes `viewer`. Apps without a dedicated authorization
-resource type name map to type `app` for `CheckAccess`. Users with **no**
-`authorization.relationships` rows can still receive **viewer** on those resources
-via `defaultRole`. Opening login to external domains without tightening this policy
-would grant unintended baseline access.
-
-**User records.** On first login, gestaltd calls `FindOrCreateUser(email)` and
-issues stable `user:<uuid>` subject IDs. Existing relationship rows in prod
-reference those UUIDs (comments note the email). Same email across IdP changes
-preserves the internal user id.
-
-## Target architecture
+## Flow
 
 ```text
-Browser → valon.tools (gestaltd)
-              │
-              │  GET /api/v1/auth/login
-              ▼
-         Auth0 Universal Login
-              │
-              ├── Google connection  → @valon.com (and other Google accounts on allowlist)
-              └── Database connection → allowlisted external domains (e.g. @example.com)
-              │
-              │  redirect + code
-              ▼
-         GET /api/v1/auth/login/callback
-              │
-              ▼
-    gestalt-providers/auth/oidc
-      · exchange code, verify email_verified
-      · CheckAllowedDomains(allowedDomains, email)
-      · issue session cookie
-              │
-              ▼
-    FindOrCreateUser(email) → user:<uuid>
-              │
-              ▼
-    authorization CheckAccess (relationships + defaultRole)
+Browser → GET /api/v1/auth/login → Auth0 Universal Login
+  (Google | Database) → /api/v1/auth/login/callback
+  → oidc provider (email_verified, allowedDomains) → session cookie
+  → FindOrCreateUser → CheckAccess (relationships + defaultRole)
 ```
 
-Gestalt continues to expose one login entry point (`/api/v1/auth/login`). Auth0
-chooses Google vs database on its hosted page. Gestalt config points at one
-`issuerUrl` (`https://<tenant>.auth0.com`).
+One Gestalt OIDC issuer (`https://<tenant>.auth0.com`). Login UI stays on Auth0.
 
 ## Domain allowlist
-
-Enforce domains in **Gestalt OIDC config** using `allowedDomains`:
 
 ```yaml
 allowedDomains:
@@ -111,229 +32,71 @@ allowedDomains:
   - example.com
 ```
 
-Behavior (implemented in `gestalt-providers/auth/internal/userinfo`):
+Empty list = allow all. Non-empty = reject at callback if domain not listed
+(`gestalt-providers/auth/internal/userinfo`). Not a substitute for authz.
 
-- Empty list → all domains allowed (current prod behavior).
-- Non-empty list → login rejected if the verified email domain is not listed
-  (case-insensitive match on the part after `@`).
+Optional Auth0 Action: force `@valon.com` to Google; duplicate domain check.
 
-**Allowlist is not authorization.** It only decides who may authenticate. Pair
-with closed default authorization for externals.
+## Authorization
 
-Optional Auth0-side rules (recommended):
-
-- Auth0 Action: users with `@valon.com` must use the Google connection (block
-  database signup/login for internal domain).
-- Rate limits and MFA on the database connection.
-
-Add new partner domains by updating `allowedDomains` and redeploying config (no
-gestaltd code change).
-
-## Authorization model
-
-### Principle
-
-| Stage | Valon employee (`@valon.com`) | External (`@example.com`) |
+| | `@valon.com` | External |
 | --- | --- | --- |
-| Login | Allowed (Google via Auth0) | Allowed (database via Auth0) |
-| Default app access | Existing `authorization.relationships` | **Denied** |
-| MCP / API invoke | As granted today | Denied until granted |
-| Admin UI | As granted today | Denied until granted |
+| Login | Yes | Yes if allowlisted |
+| Default access | Existing grants | Denied |
 
-### Required policy change (gestalt / toolshed config)
+Before external login, patch `app` in `toolshed/valon-tools/deploy/config.yaml`
+(mirror `itAccountOnboarding`):
 
-Tighten the default posture for the `app` resource type before enabling external
-login. Recommended approach (mirror `itAccountOnboarding`):
+- `defaultRole: noaccess`
+- `"*": relations: [nobody]`
+- Explicit `relations` on every `app` action Valon uses (`get_me`, `stores.health`,
+  deal-hub, ci-cd sync, …)
 
-```yaml
-app:
-  defaultRole: noaccess
-  relations:
-    noaccess:
-      subjectTypes: [subject]
-    nobody:
-      subjectTypes: [subject]
-    viewer: ...
-    # ... existing relations preserved
-  actions:
-    "*":
-      relations: [nobody]
-    get_me:
-      relations: [viewer, operator, admin]   # if needed for session/bootstrap
-    # ... preserve explicit actions Valon apps rely on
-```
+Grant externals: login → `GET /api/v1/auth/session` for `user:<uuid>` → add
+relationship → deploy.
 
-Audit every action on `app` that Valon workflows and apps use today (`get_me`,
-`stores.health`, deal-hub actions, CI/CD sync actions, etc.) and ensure each has
-explicit `relations` — wildcard `*` should not grant `viewer` by default.
-
-Apps with `authorizationPolicy: <name>` and UI `allowedRoles: [admin]` already deny
-ungranted users at the mounted UI layer. The `app` `defaultRole` fix closes the
-MCP/API path for provider kind `app`.
-
-### Granting access to an external user
-
-1. User completes Auth0 signup/login; gestaltd creates `user:<uuid>`.
-2. Operator adds `authorization.relationships` in deploy config (or future admin UI),
-   e.g. viewer on a specific app resource.
-3. Redeploy or apply relationship update through the authorization provider.
-
-Document the subject id via admin tooling or `GET /api/v1/auth/session` after a
-test login.
-
-## Implementation phases
-
-See [implementation.md](./implementation.md) for a checklist with owners and
-verification steps per phase.
-
-| Phase | Summary |
-| --- | --- |
-| **0 — Authz audit** | Inventory effective access for a user with zero relationships; patch `app.defaultRole`. |
-| **1 — Auth0 dev tenant** | Tenant, OIDC app, Google + Database connections, Universal Login. |
-| **2 — Gestalt staging** | Point staging/local overlay at Auth0; set `allowedDomains`. |
-| **3 — Toolshed prod config** | Secrets, issuer swap, allowlist, deploy. |
-| **4 — Operational runbook** | Grant workflow, domain onboarding, incident rollback. |
-
-## Configuration reference
-
-### Identity provider (prod overlay)
-
-Replace Google issuer with Auth0; keep the same OIDC provider package:
+## Gestalt / toolshed config
 
 ```yaml
-server:
-  providers:
-    identity: auth0   # or keep key name `google` — cosmetic only
-
 providers:
   identity:
     auth0:
-      source:
-        git:
-          repo: https://github.com/valon-technologies/gestalt-providers.git
-          ref: <pinned ref>
-          path: auth/oidc/manifest.yaml
-          artifactRepository: valon
-          materialization: snapshot
+      source: { git: ... path: auth/oidc/manifest.yaml }
       config:
         issuerUrl: https://<tenant>.auth0.com
-        displayName: Sign in
         redirectUrl: https://valon.tools/api/v1/auth/login/callback
-        clientId:
-          secret:
-            provider: secrets
-            name: auth0-client-id
-        clientSecret:
-          secret:
-            provider: secrets
-            name: auth0-client-secret
+        clientId: { secret: auth0-client-id }
+        clientSecret: { secret: auth0-client-secret }
         indexeddb: main-db
-        scopes:
-          - openid
-          - email
-          - profile
-        allowedDomains:
-          - valon.com
-          - example.com
+        scopes: [openid, email, profile]
+        allowedDomains: [valon.com, example.com]
 ```
 
-Callback path remains `config.AuthCallbackPath` =
-`/api/v1/auth/login/callback`.
+GSM + `toolshed/valon-tools/terraform/main.tf`: `auth0-client-id`,
+`auth0-client-secret`. Keep `google-oauth-*` for Calendar/Drive/IAP connections.
 
-### Secrets and Terraform
+Files: `deploy/config.yaml` (authz + dev identity), `deploy/prod/config.yaml`,
+`gestalt.lock.json` if ref changes.
 
-Add to GSM and `toolshed/valon-tools/terraform/main.tf` secret list:
+## Auth0
 
-- `auth0-client-id`
-- `auth0-client-secret`
+1. Regular Web App; callback `https://valon.tools/api/v1/auth/login/callback`.
+2. Connections: Google (`@valon.com`), Username-Password (externals).
+3. Universal Login: both enabled; email verification required on database.
+4. Issuer: `https://<tenant>.auth0.com`
 
-Retain `google-oauth-*` until Google connection credentials live in Auth0 only;
-other valon.tools connections (Calendar, Drive, Front Porch IAP, etc.) may still
-reference the Google OAuth client independently.
+Rollback: revert issuer to Google + `google-oauth-*` secrets.
 
-## Auth0 setup
+## Rollout
 
-1. **Create tenant** (dev + prod; custom domain optional for prod).
-2. **Application** — OIDC, type Regular Web Application:
-   - Allowed Callback URLs: `https://valon.tools/api/v1/auth/login/callback`
-   - Allowed Logout URLs: `https://valon.tools/`
-   - Token Endpoint Authentication: Post (confidential client).
-3. **Connections:**
-   - **Google** — for workforce; restrict to `@valon.com` in connection or Action.
-   - **Username-Password-Authentication** — for external allowlisted domains;
-     enable/disable signup per product policy.
-4. **Universal Login** — enable both connections on the application.
-5. **Email verification** — required (Gestalt OIDC rejects unverified emails).
-6. **Optional Action** (login / pre-user-registration):
-   - Reject email domains not in `{valon.com, example.com}` (defense in depth
-     beside Gestalt `allowedDomains`).
-   - Force `@valon.com` through Google connection only.
-7. **Issuer URL** for Gestalt: `https://<tenant>.auth0.com` (verify via
-   `/.well-known/openid-configuration`).
-
-## Toolshed / valon-tools deploy
-
-Files to change:
-
-| File | Change |
-| --- | --- |
-| `valon-tools/deploy/config.yaml` | `allowedDomains`, Auth0 issuer in base identity block (dev); **authz `app` hardening** |
-| `valon-tools/deploy/prod/config.yaml` | Prod secrets refs, `redirectUrl`, `allowedDomains` overlay |
-| `valon-tools/terraform/main.tf` | New secret names |
-| `gestalt.lock.json` | Regenerate if provider ref bumps |
-
-Deploy path unchanged: merge to toolshed → CI validates lockfile → deploy
-workflow pins gestaltd image.
-
-**Rollback:** revert config to Google `issuerUrl` and previous secrets; Auth0
-sessions expire via cookie TTL (`sessionTtl`, default 24h).
-
-## Testing and rollout
-
-### Pre-prod checks
-
-- [ ] User with zero relationships cannot invoke MCP operations on a sample `app`-kind
-      provider after authz patch.
-- [ ] `@valon.com` via Google: login succeeds; existing grants still work.
-- [ ] `@example.com` via database: login succeeds; all mounted apps return 403 or
-      empty capability surface without grants.
-- [ ] `user@notallowed.com`: rejected at Gestalt callback (`allowedDomains`).
-- [ ] `email_verified: false` in Auth0: rejected by OIDC provider.
-- [ ] CLI login (`gestalt auth login` / callback with `cli=1`) still works through
-      Auth0.
-
-### Staged rollout
-
-1. Authz patch deploy **before** widening login (safe for current Google-only users
-   if `get_me` / explicit actions are preserved).
-2. Auth0 dev tenant + staging gestaltd config.
-3. Prod Auth0 + config swap in a low-traffic window.
-4. Add first real external domain to `allowedDomains` when a partner is ready
-   (replace `example.com` placeholder).
-
-### Monitoring
-
-- gestaltd auth metrics (`auth.login.start`, `auth.login.complete` audit events).
-- Auth0 dashboard: failed logins, signup rate, blocked domains.
-- Alert on spike in `403`/`401` from new external subject IDs (expected until
-  grants are assigned).
+1. Ship authz patch (phase 0).
+2. Auth0 dev + staging config.
+3. Prod cutover.
+4. Swap `example.com` for real partner domains in `allowedDomains`.
 
 ## Open questions
 
-1. **Signup policy** — Open registration on database connection vs invite-only
-   (Auth0 creates user, operator sends password reset link).
-2. **MFA** — Required for database users at Auth0; optional for Google workforce.
-3. **Custom Auth0 domain** — `login.valon.com` vs default `*.auth0.com` issuer.
-4. **Per-app external access** — Will some apps use a dedicated authorization
-   resource type with `defaultRole: noaccess` instead of relying solely on the
-   global `app` tightening?
-5. **Subject discovery** — Admin UI or runbook step to map email → `user:<uuid>`
-   for relationship edits.
-
-## Related documentation
-
-- [Identity providers](https://gestaltd.ai/providers/identity) — OIDC config shape.
-- `gestalt-providers/auth/oidc/README.md` — `allowedDomains`, `displayName`, PKCE.
-- `gestalt/docs/content/reference/config-file.mdx` — `providers.identity.oidc`.
-- Prior toolshed exploration: Auth0 database login vs SSO (conversation context);
-  old standalone toolshed `docs/auth.md` documented OIDC issuers including Auth0.
+- Database signup: open vs invite-only?
+- MFA on database connection?
+- Custom Auth0 domain?
+- Per-app `defaultRole: noaccess` resource types vs global `app` patch only?

--- a/plans/external_users/plan.md
+++ b/plans/external_users/plan.md
@@ -91,8 +91,8 @@ Rollback: revert issuer to Google + `google-oauth-*` secrets.
 ## Rollout
 
 1. Ship authz patch (phase 0).
-2. Auth0 dev + staging config.
-3. Prod cutover.
+2. Auth0 `valon-tools-toolshed` application + GSM secrets.
+3. `valon.tools` cutover.
 4. Swap `example.com` for real partner domains in `allowedDomains`.
 
 ## Open questions

--- a/plans/external_users/plan.md
+++ b/plans/external_users/plan.md
@@ -1,20 +1,12 @@
 # External Users on valon.tools
 
-Allowlisted domains (e.g. `valon.com`, `example.com`) can log in. `@valon.com` via
-Auth0 Google connection; externals via Auth0 database. No app/MCP/admin access without
-`authorization.relationships`. Implementation PRs and process:
-[implementation.md](./implementation.md).
+Allowlisted domains (e.g. `valon.com`, `example.com`) can log in. `@valon.com` via Auth0 Google connection; externals via Auth0 database. No app/MCP/admin access without `authorization.relationships`. Implementation PRs and process: [implementation.md](./implementation.md).
 
 ## Current state
 
-- Identity: `gestalt-providers/auth/oidc` with `issuerUrl: https://accounts.google.com`
-  (`toolshed/valon-tools/deploy`; config key `google`).
+- Identity: `gestalt-providers/auth/oidc` with `issuerUrl: https://accounts.google.com` (`toolshed/valon-tools/deploy`; config key `google`).
 - No `allowedDomains` — Gestalt accepts any verified email after OAuth.
-- **Blocker:** `app` has `defaultRole: viewer` and `"*"` includes `viewer`. A
-  non-empty `defaultRole` is an **allow fallback** in gestaltd: mounted UIs with
-  empty `allowedRoles` still serve static assets, and `CheckAccess` can allow
-  actions when `defaultRole` matches the action’s relation list — even for
-  ungranted subjects. Fix before widening login.
+- **Blocker:** `app` has `defaultRole: viewer` and `"*"` includes `viewer`. A non-empty `defaultRole` is an **allow fallback** in gestaltd: mounted UIs with empty `allowedRoles` still serve static assets, and `CheckAccess` can allow actions when `defaultRole` matches the action’s relation list — even for ungranted subjects. Fix before widening login.
 - Users: `FindOrCreateUser(email)` → stable `user:<uuid>`; grants use UUIDs in prod.
 
 ## Flow
@@ -36,8 +28,7 @@ allowedDomains:
   - example.com
 ```
 
-Empty list = allow all. Non-empty = reject at callback if domain not listed
-(`gestalt-providers/auth/internal/userinfo`). Not a substitute for authz.
+Empty list = allow all. Non-empty = reject at callback if domain not listed (`gestalt-providers/auth/internal/userinfo`). Not a substitute for authz.
 
 Optional Auth0 Action: force `@valon.com` to Google; duplicate domain check.
 
@@ -50,22 +41,14 @@ Optional Auth0 Action: force `@valon.com` to Google; duplicate domain check.
 
 Before external login, patch `app` in `toolshed/valon-tools/deploy/config.yaml`:
 
-- **Clear `defaultRole`** on `app` (omit the field). Do not set `defaultRole:
-  noaccess` — any non-empty `defaultRole` still authorizes mounted UIs when
-  `allowedRoles` is empty (`gestaltd/internal/server/mounted_ui.go`).
-- `"*": relations: [nobody]` — closes the `CheckAccess` wildcard; ungranted
-  subjects have no `nobody` relationship, so RPC/MCP/actions deny. Does **not** gate
-  static UI by itself.
-- Explicit `relations` on every `app` action Valon uses (`get_me`, `stores.health`,
-  deal-hub, ci-cd sync, …).
-- Spot-check apps with a custom `authorizationPolicy` — clear `defaultRole` on
-  those resource types too when they use an empty `allowedRoles` UI mount.
+- **Clear `defaultRole`** on `app` (omit the field). Do not set `defaultRole: noaccess` — any non-empty `defaultRole` still authorizes mounted UIs when `allowedRoles` is empty (`gestaltd/internal/server/mounted_ui.go`).
+- `"*": relations: [nobody]` — closes the `CheckAccess` wildcard; ungranted subjects have no `nobody` relationship, so RPC/MCP/actions deny. Does **not** gate static UI by itself.
+- Explicit `relations` on every `app` action Valon uses (`get_me`, `stores.health`, deal-hub, ci-cd sync, …).
+- Spot-check apps with a custom `authorizationPolicy` — clear `defaultRole` on those resource types too when they use an empty `allowedRoles` UI mount.
 
-`itAccountOnboarding` is a useful reference for `"*"` → `nobody` and per-action
-relations, not for `defaultRole: noaccess` as a UI deny lever.
+`itAccountOnboarding` is a useful reference for `"*"` → `nobody` and per-action relations, not for `defaultRole: noaccess` as a UI deny lever.
 
-Grant externals: login → `GET /api/v1/auth/session` for `user:<uuid>` → add
-relationship → deploy.
+Grant externals: login → `GET /api/v1/auth/session` for `user:<uuid>` → add relationship → deploy.
 
 ## Gestalt / toolshed config
 
@@ -84,11 +67,9 @@ providers:
         allowedDomains: [valon.com, example.com]
 ```
 
-GSM + `toolshed/valon-tools/terraform/main.tf`: `auth0-client-id`,
-`auth0-client-secret`. Keep `google-oauth-*` for Calendar/Drive/IAP connections.
+GSM + `toolshed/valon-tools/terraform/main.tf`: `auth0-client-id`, `auth0-client-secret`. Keep `google-oauth-*` for Calendar/Drive/IAP connections.
 
-Files: `deploy/config.yaml` (authz + dev identity), `deploy/prod/config.yaml`,
-`gestalt.lock.json` if ref changes.
+Files: `deploy/config.yaml` (authz + dev identity), `deploy/prod/config.yaml`, `gestalt.lock.json` if ref changes.
 
 ## Auth0
 
@@ -111,5 +92,4 @@ Rollback: revert issuer to Google + `google-oauth-*` secrets.
 - Database signup: open vs invite-only?
 - MFA on database connection?
 - Custom Auth0 domain?
-- Per-app `authorizationPolicy` resource types: clear `defaultRole` where mounts
-  rely on relationship grants only?
+- Per-app `authorizationPolicy` resource types: clear `defaultRole` where mounts rely on relationship grants only?

--- a/plans/external_users/plan.md
+++ b/plans/external_users/plan.md
@@ -1,0 +1,339 @@
+# External Users on valon.tools
+
+Support authenticated users whose email domain is not `@valon.com`, while keeping
+default access closed. Valon employees retain Google sign-in; allowlisted external
+domains (e.g. `@example.com`) can authenticate via Auth0 database login.
+
+## Contents
+
+- [Goals and non-goals](#goals-and-non-goals)
+- [Current state](#current-state)
+- [Target architecture](#target-architecture)
+- [Domain allowlist](#domain-allowlist)
+- [Authorization model](#authorization-model)
+- [Implementation phases](#implementation-phases)
+- [Configuration reference](#configuration-reference)
+- [Auth0 setup](#auth0-setup)
+- [Toolshed / valon-tools deploy](#toolshed--valon-tools-deploy)
+- [Testing and rollout](#testing-and-rollout)
+- [Open questions](#open-questions)
+
+## Goals and non-goals
+
+### Goals
+
+- Allowlisted email domains can complete platform login on `https://valon.tools/`.
+- `@valon.com` remains allowed and continues to sign in with Google (via Auth0
+  Google social connection, not a separate Gestalt identity provider).
+- External users receive **no app, MCP, or admin access** until explicitly granted
+  in `authorization.relationships`.
+- Domain enforcement happens at login (`allowedDomains` on the OIDC identity
+  provider), not only at the IdP.
+- Single OIDC issuer in Gestalt config (Auth0 tenant); no multi-button login UX
+  work in gestaltd for v1.
+
+### Non-goals (v1)
+
+- Per-partner SAML/OIDC enterprise connections (can add Auth0 connections later
+  without Gestalt code changes).
+- Self-service signup policy beyond what Auth0 configures (invite-only vs open
+  registration is an Auth0 dashboard decision).
+- Native username/password forms hosted by gestaltd (Auth0 Universal Login only).
+- Automatic provisioning of external users into specific apps (manual or scripted
+  grant assignment only).
+- Changing how Valon employees are named in `authorization.relationships` (stable
+  `user:<uuid>` subjects keyed by email remain the source of truth).
+
+## Current state
+
+**Identity.** Production valon.tools uses the generic OIDC identity provider from
+`gestalt-providers/auth/oidc`, configured with `issuerUrl: https://accounts.google.com`
+and secrets `google-oauth-client-id` / `google-oauth-client-secret`. The config key
+is named `google` but the implementation is OIDC, not a bespoke Google plugin.
+
+**Domain filter.** `allowedDomains` is not set today, so Gestalt does not restrict
+email domains after a successful OAuth exchange. Any restriction is implicit in who
+can use the Google OAuth client / Workspace.
+
+**Authorization gap.** The shared `app` resource type in
+`toolshed/valon-tools/deploy/config.yaml` sets `defaultRole: viewer` with a
+wildcard action that includes `viewer`. Apps without a dedicated authorization
+resource type name map to type `app` for `CheckAccess`. Users with **no**
+`authorization.relationships` rows can still receive **viewer** on those resources
+via `defaultRole`. Opening login to external domains without tightening this policy
+would grant unintended baseline access.
+
+**User records.** On first login, gestaltd calls `FindOrCreateUser(email)` and
+issues stable `user:<uuid>` subject IDs. Existing relationship rows in prod
+reference those UUIDs (comments note the email). Same email across IdP changes
+preserves the internal user id.
+
+## Target architecture
+
+```text
+Browser → valon.tools (gestaltd)
+              │
+              │  GET /api/v1/auth/login
+              ▼
+         Auth0 Universal Login
+              │
+              ├── Google connection  → @valon.com (and other Google accounts on allowlist)
+              └── Database connection → allowlisted external domains (e.g. @example.com)
+              │
+              │  redirect + code
+              ▼
+         GET /api/v1/auth/login/callback
+              │
+              ▼
+    gestalt-providers/auth/oidc
+      · exchange code, verify email_verified
+      · CheckAllowedDomains(allowedDomains, email)
+      · issue session cookie
+              │
+              ▼
+    FindOrCreateUser(email) → user:<uuid>
+              │
+              ▼
+    authorization CheckAccess (relationships + defaultRole)
+```
+
+Gestalt continues to expose one login entry point (`/api/v1/auth/login`). Auth0
+chooses Google vs database on its hosted page. Gestalt config points at one
+`issuerUrl` (`https://<tenant>.auth0.com`).
+
+## Domain allowlist
+
+Enforce domains in **Gestalt OIDC config** using `allowedDomains`:
+
+```yaml
+allowedDomains:
+  - valon.com
+  - example.com
+```
+
+Behavior (implemented in `gestalt-providers/auth/internal/userinfo`):
+
+- Empty list → all domains allowed (current prod behavior).
+- Non-empty list → login rejected if the verified email domain is not listed
+  (case-insensitive match on the part after `@`).
+
+**Allowlist is not authorization.** It only decides who may authenticate. Pair
+with closed default authorization for externals.
+
+Optional Auth0-side rules (recommended):
+
+- Auth0 Action: users with `@valon.com` must use the Google connection (block
+  database signup/login for internal domain).
+- Rate limits and MFA on the database connection.
+
+Add new partner domains by updating `allowedDomains` and redeploying config (no
+gestaltd code change).
+
+## Authorization model
+
+### Principle
+
+| Stage | Valon employee (`@valon.com`) | External (`@example.com`) |
+| --- | --- | --- |
+| Login | Allowed (Google via Auth0) | Allowed (database via Auth0) |
+| Default app access | Existing `authorization.relationships` | **Denied** |
+| MCP / API invoke | As granted today | Denied until granted |
+| Admin UI | As granted today | Denied until granted |
+
+### Required policy change (gestalt / toolshed config)
+
+Tighten the default posture for the `app` resource type before enabling external
+login. Recommended approach (mirror `itAccountOnboarding`):
+
+```yaml
+app:
+  defaultRole: noaccess
+  relations:
+    noaccess:
+      subjectTypes: [subject]
+    nobody:
+      subjectTypes: [subject]
+    viewer: ...
+    # ... existing relations preserved
+  actions:
+    "*":
+      relations: [nobody]
+    get_me:
+      relations: [viewer, operator, admin]   # if needed for session/bootstrap
+    # ... preserve explicit actions Valon apps rely on
+```
+
+Audit every action on `app` that Valon workflows and apps use today (`get_me`,
+`stores.health`, deal-hub actions, CI/CD sync actions, etc.) and ensure each has
+explicit `relations` — wildcard `*` should not grant `viewer` by default.
+
+Apps with `authorizationPolicy: <name>` and UI `allowedRoles: [admin]` already deny
+ungranted users at the mounted UI layer. The `app` `defaultRole` fix closes the
+MCP/API path for provider kind `app`.
+
+### Granting access to an external user
+
+1. User completes Auth0 signup/login; gestaltd creates `user:<uuid>`.
+2. Operator adds `authorization.relationships` in deploy config (or future admin UI),
+   e.g. viewer on a specific app resource.
+3. Redeploy or apply relationship update through the authorization provider.
+
+Document the subject id via admin tooling or `GET /api/v1/auth/session` after a
+test login.
+
+## Implementation phases
+
+See [implementation.md](./implementation.md) for a checklist with owners and
+verification steps per phase.
+
+| Phase | Summary |
+| --- | --- |
+| **0 — Authz audit** | Inventory effective access for a user with zero relationships; patch `app.defaultRole`. |
+| **1 — Auth0 dev tenant** | Tenant, OIDC app, Google + Database connections, Universal Login. |
+| **2 — Gestalt staging** | Point staging/local overlay at Auth0; set `allowedDomains`. |
+| **3 — Toolshed prod config** | Secrets, issuer swap, allowlist, deploy. |
+| **4 — Operational runbook** | Grant workflow, domain onboarding, incident rollback. |
+
+## Configuration reference
+
+### Identity provider (prod overlay)
+
+Replace Google issuer with Auth0; keep the same OIDC provider package:
+
+```yaml
+server:
+  providers:
+    identity: auth0   # or keep key name `google` — cosmetic only
+
+providers:
+  identity:
+    auth0:
+      source:
+        git:
+          repo: https://github.com/valon-technologies/gestalt-providers.git
+          ref: <pinned ref>
+          path: auth/oidc/manifest.yaml
+          artifactRepository: valon
+          materialization: snapshot
+      config:
+        issuerUrl: https://<tenant>.auth0.com
+        displayName: Sign in
+        redirectUrl: https://valon.tools/api/v1/auth/login/callback
+        clientId:
+          secret:
+            provider: secrets
+            name: auth0-client-id
+        clientSecret:
+          secret:
+            provider: secrets
+            name: auth0-client-secret
+        indexeddb: main-db
+        scopes:
+          - openid
+          - email
+          - profile
+        allowedDomains:
+          - valon.com
+          - example.com
+```
+
+Callback path remains `config.AuthCallbackPath` =
+`/api/v1/auth/login/callback`.
+
+### Secrets and Terraform
+
+Add to GSM and `toolshed/valon-tools/terraform/main.tf` secret list:
+
+- `auth0-client-id`
+- `auth0-client-secret`
+
+Retain `google-oauth-*` until Google connection credentials live in Auth0 only;
+other valon.tools connections (Calendar, Drive, Front Porch IAP, etc.) may still
+reference the Google OAuth client independently.
+
+## Auth0 setup
+
+1. **Create tenant** (dev + prod; custom domain optional for prod).
+2. **Application** — OIDC, type Regular Web Application:
+   - Allowed Callback URLs: `https://valon.tools/api/v1/auth/login/callback`
+   - Allowed Logout URLs: `https://valon.tools/`
+   - Token Endpoint Authentication: Post (confidential client).
+3. **Connections:**
+   - **Google** — for workforce; restrict to `@valon.com` in connection or Action.
+   - **Username-Password-Authentication** — for external allowlisted domains;
+     enable/disable signup per product policy.
+4. **Universal Login** — enable both connections on the application.
+5. **Email verification** — required (Gestalt OIDC rejects unverified emails).
+6. **Optional Action** (login / pre-user-registration):
+   - Reject email domains not in `{valon.com, example.com}` (defense in depth
+     beside Gestalt `allowedDomains`).
+   - Force `@valon.com` through Google connection only.
+7. **Issuer URL** for Gestalt: `https://<tenant>.auth0.com` (verify via
+   `/.well-known/openid-configuration`).
+
+## Toolshed / valon-tools deploy
+
+Files to change:
+
+| File | Change |
+| --- | --- |
+| `valon-tools/deploy/config.yaml` | `allowedDomains`, Auth0 issuer in base identity block (dev); **authz `app` hardening** |
+| `valon-tools/deploy/prod/config.yaml` | Prod secrets refs, `redirectUrl`, `allowedDomains` overlay |
+| `valon-tools/terraform/main.tf` | New secret names |
+| `gestalt.lock.json` | Regenerate if provider ref bumps |
+
+Deploy path unchanged: merge to toolshed → CI validates lockfile → deploy
+workflow pins gestaltd image.
+
+**Rollback:** revert config to Google `issuerUrl` and previous secrets; Auth0
+sessions expire via cookie TTL (`sessionTtl`, default 24h).
+
+## Testing and rollout
+
+### Pre-prod checks
+
+- [ ] User with zero relationships cannot invoke MCP operations on a sample `app`-kind
+      provider after authz patch.
+- [ ] `@valon.com` via Google: login succeeds; existing grants still work.
+- [ ] `@example.com` via database: login succeeds; all mounted apps return 403 or
+      empty capability surface without grants.
+- [ ] `user@notallowed.com`: rejected at Gestalt callback (`allowedDomains`).
+- [ ] `email_verified: false` in Auth0: rejected by OIDC provider.
+- [ ] CLI login (`gestalt auth login` / callback with `cli=1`) still works through
+      Auth0.
+
+### Staged rollout
+
+1. Authz patch deploy **before** widening login (safe for current Google-only users
+   if `get_me` / explicit actions are preserved).
+2. Auth0 dev tenant + staging gestaltd config.
+3. Prod Auth0 + config swap in a low-traffic window.
+4. Add first real external domain to `allowedDomains` when a partner is ready
+   (replace `example.com` placeholder).
+
+### Monitoring
+
+- gestaltd auth metrics (`auth.login.start`, `auth.login.complete` audit events).
+- Auth0 dashboard: failed logins, signup rate, blocked domains.
+- Alert on spike in `403`/`401` from new external subject IDs (expected until
+  grants are assigned).
+
+## Open questions
+
+1. **Signup policy** — Open registration on database connection vs invite-only
+   (Auth0 creates user, operator sends password reset link).
+2. **MFA** — Required for database users at Auth0; optional for Google workforce.
+3. **Custom Auth0 domain** — `login.valon.com` vs default `*.auth0.com` issuer.
+4. **Per-app external access** — Will some apps use a dedicated authorization
+   resource type with `defaultRole: noaccess` instead of relying solely on the
+   global `app` tightening?
+5. **Subject discovery** — Admin UI or runbook step to map email → `user:<uuid>`
+   for relationship edits.
+
+## Related documentation
+
+- [Identity providers](https://gestaltd.ai/providers/identity) — OIDC config shape.
+- `gestalt-providers/auth/oidc/README.md` — `allowedDomains`, `displayName`, PKCE.
+- `gestalt/docs/content/reference/config-file.mdx` — `providers.identity.oidc`.
+- Prior toolshed exploration: Auth0 database login vs SSO (conversation context);
+  old standalone toolshed `docs/auth.md` documented OIDC issuers including Auth0.


### PR DESCRIPTION
## Summary

- Adds `plans/external_users/plan.md` describing how to support allowlisted external email domains on valon.tools via Auth0 OIDC (Google for `@valon.com`, database login for partners).
- Adds `plans/external_users/implementation.md` with phased checklist: authz hardening, Auth0 tenant setup, staging/prod config, and operational runbooks.
- Documents required `allowedDomains` config (`valon.com`, `example.com`) and the need to close the `app.defaultRole: viewer` gap before widening login.

## Test plan

- [ ] Review plan for accuracy against current toolshed deploy config and OIDC provider behavior
- [ ] Confirm phase ordering (authz before Auth0 cutover) with platform owners


Made with [Cursor](https://cursor.com)