### PR TITLE
gestaltd: expose account identity facts on connection instances

### DIFF
--- a/gestaltd/core/credential_metadata.go
+++ b/gestaltd/core/credential_metadata.go
@@ -1,0 +1,32 @@
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// AccountIdentityMetadataKey is the reserved ExternalCredential.MetadataJSON
+// key for Connection account recognition facts. It must not be treated as a
+// runtime connection parameter (URL/header interpolation, provider params).
+const AccountIdentityMetadataKey = "account_identity"
+
+// ConnectionParamsFromMetadataJSON unmarshals credential MetadataJSON into
+// connection params for runtime use, stripping host-owned reserved keys.
+func ConnectionParamsFromMetadataJSON(metadataJSON string) (map[string]string, error) {
+	if strings.TrimSpace(metadataJSON) == "" {
+		return nil, nil
+	}
+	var params map[string]string
+	if err := json.Unmarshal([]byte(metadataJSON), &params); err != nil {
+		return nil, fmt.Errorf("corrupt MetadataJSON: %w", err)
+	}
+	if len(params) == 0 {
+		return nil, nil
+	}
+	delete(params, AccountIdentityMetadataKey)
+	if len(params) == 0 {
+		return nil, nil
+	}
+	return params, nil
+}

--- a/gestaltd/core/credential_metadata_test.go
+++ b/gestaltd/core/credential_metadata_test.go
@@ -1,0 +1,27 @@
+package core
+
+import "testing"
+
+func TestConnectionParamsFromMetadataJSON_StripsAccountIdentity(t *testing.T) {
+	t.Parallel()
+
+	params, err := ConnectionParamsFromMetadataJSON(`{"cloud_id":"abc","account_identity":"{\"facts\":[{\"kind\":\"email\",\"value\":\"a@b.com\",\"primary\":true}]}"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if params["cloud_id"] != "abc" {
+		t.Fatalf("params = %+v", params)
+	}
+	if _, ok := params[AccountIdentityMetadataKey]; ok {
+		t.Fatal("account_identity must not appear in connection params")
+	}
+}
+
+func TestConnectionParamsFromMetadataJSON_Empty(t *testing.T) {
+	t.Parallel()
+
+	params, err := ConnectionParamsFromMetadataJSON("")
+	if err != nil || params != nil {
+		t.Fatalf("params=%v err=%v", params, err)
+	}
+}

--- a/gestaltd/internal/server/account_identity.go
+++ b/gestaltd/internal/server/account_identity.go
@@ -9,12 +9,15 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
 )
 
 // accountIdentityMetadataKey is the reserved MetadataJSON key for Connection
 // account recognition facts (SCIM-style). Only host code may write this key;
-// provider/discovery metadata must not set it.
-const accountIdentityMetadataKey = "account_identity"
+// provider/discovery metadata must not set it. Runtime connection-param
+// surfaces must strip it via core.ConnectionParamsFromMetadataJSON.
+const accountIdentityMetadataKey = core.AccountIdentityMetadataKey
 
 const oauthIdentityProbeTimeout = 3 * time.Second
 

--- a/gestaltd/internal/server/account_identity.go
+++ b/gestaltd/internal/server/account_identity.go
@@ -123,6 +123,17 @@ func setAccountIdentity(metadataJSON string, id *accountIdentity) (string, error
 }
 
 func normalizeIdentityFacts(facts []identityFact) []identityFact {
+	out := dedupeIdentityFacts(facts)
+	if len(out) == 0 {
+		return nil
+	}
+	return ensurePrimaryIdentityFact(out)
+}
+
+// dedupeIdentityFacts trims/dedupes and keeps at most one Primary from the
+// input (last wins). It does not auto-assign primary — callers that merge
+// partial batches must leave that to a final ensurePrimaryIdentityFact.
+func dedupeIdentityFacts(facts []identityFact) []identityFact {
 	out := make([]identityFact, 0, len(facts))
 	seen := make(map[string]struct{}, len(facts))
 	primaryIdx := -1
@@ -149,10 +160,36 @@ func normalizeIdentityFacts(facts []identityFact) []identityFact {
 	if len(out) == 0 {
 		return nil
 	}
-	if primaryIdx < 0 {
-		out[selectPrimaryFactIndex(out)].Primary = true
+	return out
+}
+
+func clearPrimaryIdentityFlags(facts []identityFact) []identityFact {
+	if len(facts) == 0 {
+		return nil
+	}
+	out := make([]identityFact, len(facts))
+	for i, f := range facts {
+		out[i] = identityFact{Kind: f.Kind, Value: f.Value}
 	}
 	return out
+}
+
+func ensurePrimaryIdentityFact(facts []identityFact) []identityFact {
+	if len(facts) == 0 {
+		return nil
+	}
+	hasPrimary := false
+	for _, f := range facts {
+		if f.Primary {
+			hasPrimary = true
+			break
+		}
+	}
+	if hasPrimary {
+		return facts
+	}
+	facts[selectPrimaryFactIndex(facts)].Primary = true
+	return facts
 }
 
 func selectPrimaryFactIndex(facts []identityFact) int {
@@ -212,7 +249,10 @@ func identityFactsFromConnectionParams(metadataJSON string) []identityFact {
 }
 
 func mergeIdentityFacts(base []identityFact, extra ...identityFact) []identityFact {
-	return normalizeIdentityFacts(append(append([]identityFact{}, base...), extra...))
+	// Dedupe only — never auto-assign primary on partial merges, or an early
+	// batch (e.g. subdomain) permanently wins over a later higher-rank fact
+	// (e.g. email).
+	return dedupeIdentityFacts(append(append([]identityFact{}, base...), extra...))
 }
 
 func (s *Server) enrichAccountIdentity(ctx context.Context, tm credentialMaterial) credentialMaterial {
@@ -223,7 +263,9 @@ func (s *Server) enrichAccountIdentity(ctx context.Context, tm credentialMateria
 	}
 	var facts []identityFact
 	if existing != nil {
-		facts = append(facts, existing.Facts...)
+		// Drop stored primary flags so this enrich pass can re-rank by kind
+		// order (and honor new explicit primaries from OAuth probes).
+		facts = append(facts, clearPrimaryIdentityFlags(existing.Facts)...)
 	}
 	facts = mergeIdentityFacts(facts, identityFactsFromConnectionParams(tm.MetadataJSON)...)
 

--- a/gestaltd/internal/server/account_identity.go
+++ b/gestaltd/internal/server/account_identity.go
@@ -1,0 +1,350 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// accountIdentityMetadataKey is the reserved MetadataJSON key for Connection
+// account recognition facts (SCIM-style). Values are JSON, not provider params,
+// and are skipped by validateProviderMetadata.
+const accountIdentityMetadataKey = "account_identity"
+
+// identityFact is one recognition attribute for a linked account (SCIM multi-valued style).
+type identityFact struct {
+	Kind    string `json:"kind"`
+	Value   string `json:"value"`
+	Primary bool   `json:"primary,omitempty"`
+}
+
+// accountIdentity is the projected Connection identity payload.
+type accountIdentity struct {
+	Facts []identityFact `json:"facts"`
+}
+
+// Connection-param metadata keys that are safe, human-meaningful signifiers.
+var connectionParamIdentityKinds = map[string]string{
+	"subdomain":       "subdomain",
+	"host":            "host",
+	"api_host":        "host",
+	"organization_id": "organization",
+}
+
+// Prefer these kinds when assigning primary if none is flagged.
+var identityPrimaryKindOrder = []string{
+	"email",
+	"login",
+	"workspace",
+	"site",
+	"host",
+	"subdomain",
+	"organization",
+	"display_name",
+}
+
+func parseMetadataMap(metadataJSON string) (map[string]string, error) {
+	m := make(map[string]string)
+	if strings.TrimSpace(metadataJSON) == "" {
+		return m, nil
+	}
+	if err := json.Unmarshal([]byte(metadataJSON), &m); err != nil {
+		return nil, fmt.Errorf("corrupt MetadataJSON: %w", err)
+	}
+	return m, nil
+}
+
+func marshalMetadataMap(m map[string]string) (string, error) {
+	if len(m) == 0 {
+		return "", nil
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return "", fmt.Errorf("marshal metadata: %w", err)
+	}
+	return string(b), nil
+}
+
+func parseAccountIdentity(metadataJSON string) (*accountIdentity, error) {
+	m, err := parseMetadataMap(metadataJSON)
+	if err != nil {
+		return nil, err
+	}
+	raw, ok := m[accountIdentityMetadataKey]
+	if !ok || strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	var id accountIdentity
+	if err := json.Unmarshal([]byte(raw), &id); err != nil {
+		return nil, fmt.Errorf("corrupt account_identity metadata: %w", err)
+	}
+	id.Facts = normalizeIdentityFacts(id.Facts)
+	if len(id.Facts) == 0 {
+		return nil, nil
+	}
+	return &id, nil
+}
+
+func setAccountIdentity(metadataJSON string, id *accountIdentity) (string, error) {
+	m, err := parseMetadataMap(metadataJSON)
+	if err != nil {
+		return "", err
+	}
+	if id == nil || len(id.Facts) == 0 {
+		delete(m, accountIdentityMetadataKey)
+		return marshalMetadataMap(m)
+	}
+	id.Facts = normalizeIdentityFacts(id.Facts)
+	if len(id.Facts) == 0 {
+		delete(m, accountIdentityMetadataKey)
+		return marshalMetadataMap(m)
+	}
+	b, err := json.Marshal(accountIdentity{Facts: id.Facts})
+	if err != nil {
+		return "", fmt.Errorf("marshal account_identity: %w", err)
+	}
+	m[accountIdentityMetadataKey] = string(b)
+	return marshalMetadataMap(m)
+}
+
+func normalizeIdentityFacts(facts []identityFact) []identityFact {
+	out := make([]identityFact, 0, len(facts))
+	seen := make(map[string]struct{}, len(facts))
+	primaryIdx := -1
+	for _, f := range facts {
+		kind := strings.TrimSpace(f.Kind)
+		value := strings.TrimSpace(f.Value)
+		if kind == "" || value == "" {
+			continue
+		}
+		key := kind + "\x00" + value
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		fact := identityFact{Kind: kind, Value: value, Primary: f.Primary}
+		if fact.Primary {
+			if primaryIdx >= 0 {
+				out[primaryIdx].Primary = false
+			}
+			primaryIdx = len(out)
+		}
+		out = append(out, fact)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	if primaryIdx < 0 {
+		out[selectPrimaryFactIndex(out)].Primary = true
+	}
+	return out
+}
+
+func selectPrimaryFactIndex(facts []identityFact) int {
+	for _, kind := range identityPrimaryKindOrder {
+		for i, f := range facts {
+			if f.Kind == kind {
+				return i
+			}
+		}
+	}
+	return 0
+}
+
+func identityFromMetadataJSON(metadataJSON string) *accountIdentity {
+	id, err := parseAccountIdentity(metadataJSON)
+	if err != nil || id == nil {
+		return nil
+	}
+	return id
+}
+
+func mergeDiscoveryCandidateIdentity(metadataJSON, candidateName string) (string, error) {
+	name := strings.TrimSpace(candidateName)
+	if name == "" {
+		return metadataJSON, nil
+	}
+	id, err := parseAccountIdentity(metadataJSON)
+	if err != nil {
+		return "", err
+	}
+	if id == nil {
+		id = &accountIdentity{}
+	}
+	id.Facts = append(id.Facts, identityFact{Kind: "site", Value: name})
+	return setAccountIdentity(metadataJSON, id)
+}
+
+func identityFactsFromConnectionParams(metadataJSON string) []identityFact {
+	m, err := parseMetadataMap(metadataJSON)
+	if err != nil {
+		return nil
+	}
+	var facts []identityFact
+	for key, kind := range connectionParamIdentityKinds {
+		if v := strings.TrimSpace(m[key]); v != "" {
+			facts = append(facts, identityFact{Kind: kind, Value: v})
+		}
+	}
+	return facts
+}
+
+func mergeIdentityFacts(base []identityFact, extra ...identityFact) []identityFact {
+	return normalizeIdentityFacts(append(append([]identityFact{}, base...), extra...))
+}
+
+func (s *Server) enrichAccountIdentity(ctx context.Context, tm credentialMaterial) (credentialMaterial, error) {
+	existing, err := parseAccountIdentity(tm.MetadataJSON)
+	if err != nil {
+		// Corrupt identity blob: drop it and rebuild from known sources.
+		existing = nil
+	}
+	var facts []identityFact
+	if existing != nil {
+		facts = append(facts, existing.Facts...)
+	}
+	facts = mergeIdentityFacts(facts, identityFactsFromConnectionParams(tm.MetadataJSON)...)
+
+	if token := strings.TrimSpace(tm.AccessToken); token != "" {
+		facts = mergeIdentityFacts(facts, fetchOAuthAccountIdentityFacts(ctx, token)...)
+	}
+
+	if len(tm.Fields) > 0 {
+		if email := strings.TrimSpace(tm.Fields["email"]); email != "" {
+			facts = mergeIdentityFacts(facts, identityFact{Kind: "email", Value: email})
+		}
+	}
+
+	if len(facts) == 0 {
+		return tm, nil
+	}
+	merged, err := setAccountIdentity(tm.MetadataJSON, &accountIdentity{Facts: facts})
+	if err != nil {
+		return tm, err
+	}
+	tm.MetadataJSON = merged
+	return tm, nil
+}
+
+func fetchOAuthAccountIdentityFacts(ctx context.Context, accessToken string) []identityFact {
+	client := &http.Client{Timeout: 10 * time.Second}
+	if facts := fetchGoogleUserInfoFacts(ctx, client, accessToken); len(facts) > 0 {
+		return facts
+	}
+	if facts := fetchGmailProfileFacts(ctx, client, accessToken); len(facts) > 0 {
+		return facts
+	}
+	if facts := fetchSlackAuthTestFacts(ctx, client, accessToken); len(facts) > 0 {
+		return facts
+	}
+	if facts := fetchGitHubUserFacts(ctx, client, accessToken); len(facts) > 0 {
+		return facts
+	}
+	return nil
+}
+
+func fetchJSONObject(ctx context.Context, client *http.Client, method, url, accessToken string) (map[string]any, error) {
+	req, err := http.NewRequestWithContext(ctx, method, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Accept", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 2048))
+		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, err
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(body, &obj); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+func stringField(obj map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if v, ok := obj[key]; ok {
+			if s, ok := v.(string); ok {
+				if t := strings.TrimSpace(s); t != "" {
+					return t
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func fetchGoogleUserInfoFacts(ctx context.Context, client *http.Client, accessToken string) []identityFact {
+	obj, err := fetchJSONObject(ctx, client, http.MethodGet, "https://openidconnect.googleapis.com/userinfo", accessToken)
+	if err != nil {
+		return nil
+	}
+	var facts []identityFact
+	if email := stringField(obj, "email"); email != "" {
+		facts = append(facts, identityFact{Kind: "email", Value: email, Primary: true})
+	}
+	if name := stringField(obj, "name"); name != "" {
+		facts = append(facts, identityFact{Kind: "display_name", Value: name})
+	}
+	return facts
+}
+
+func fetchGmailProfileFacts(ctx context.Context, client *http.Client, accessToken string) []identityFact {
+	obj, err := fetchJSONObject(ctx, client, http.MethodGet, "https://gmail.googleapis.com/gmail/v1/users/me/profile", accessToken)
+	if err != nil {
+		return nil
+	}
+	if email := stringField(obj, "emailAddress"); email != "" {
+		return []identityFact{{Kind: "email", Value: email, Primary: true}}
+	}
+	return nil
+}
+
+func fetchSlackAuthTestFacts(ctx context.Context, client *http.Client, accessToken string) []identityFact {
+	obj, err := fetchJSONObject(ctx, client, http.MethodPost, "https://slack.com/api/auth.test", accessToken)
+	if err != nil {
+		return nil
+	}
+	if ok, _ := obj["ok"].(bool); !ok {
+		return nil
+	}
+	var facts []identityFact
+	if team := stringField(obj, "team"); team != "" {
+		facts = append(facts, identityFact{Kind: "workspace", Value: team, Primary: true})
+	}
+	if user := stringField(obj, "user"); user != "" {
+		facts = append(facts, identityFact{Kind: "login", Value: user})
+	}
+	return facts
+}
+
+func fetchGitHubUserFacts(ctx context.Context, client *http.Client, accessToken string) []identityFact {
+	obj, err := fetchJSONObject(ctx, client, http.MethodGet, "https://api.github.com/user", accessToken)
+	if err != nil {
+		return nil
+	}
+	var facts []identityFact
+	if login := stringField(obj, "login"); login != "" {
+		facts = append(facts, identityFact{Kind: "login", Value: login, Primary: true})
+	}
+	if name := stringField(obj, "name"); name != "" {
+		facts = append(facts, identityFact{Kind: "display_name", Value: name})
+	}
+	if email := stringField(obj, "email"); email != "" {
+		facts = append(facts, identityFact{Kind: "email", Value: email})
+	}
+	return facts
+}

--- a/gestaltd/internal/server/account_identity.go
+++ b/gestaltd/internal/server/account_identity.go
@@ -5,15 +5,18 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
 )
 
 // accountIdentityMetadataKey is the reserved MetadataJSON key for Connection
-// account recognition facts (SCIM-style). Values are JSON, not provider params,
-// and are skipped by validateProviderMetadata.
+// account recognition facts (SCIM-style). Only host code may write this key;
+// provider/discovery metadata must not set it.
 const accountIdentityMetadataKey = "account_identity"
+
+const oauthIdentityProbeTimeout = 3 * time.Second
 
 // identityFact is one recognition attribute for a linked account (SCIM multi-valued style).
 type identityFact struct {
@@ -27,12 +30,20 @@ type accountIdentity struct {
 	Facts []identityFact `json:"facts"`
 }
 
-// Connection-param metadata keys that are safe, human-meaningful signifiers.
-var connectionParamIdentityKinds = map[string]string{
-	"subdomain":       "subdomain",
-	"host":            "host",
-	"api_host":        "host",
-	"organization_id": "organization",
+// connectionParamIdentityBinding maps stored connection-param metadata keys to
+// identity fact kinds. Order is significant for determinism when multiple
+// params are present. Opaque ids (e.g. cloud_id) are intentionally omitted.
+//
+// Longer-term these bindings should be declared on ConnectionParamDef /
+// provider manifests (identityKind); this table is the host fallback until then.
+var connectionParamIdentityBindings = []struct {
+	Param string
+	Kind  string
+}{
+	{Param: "subdomain", Kind: "subdomain"},
+	{Param: "host", Kind: "host"},
+	{Param: "api_host", Kind: "host"},
+	{Param: "organization_id", Kind: "organization"},
 }
 
 // Prefer these kinds when assigning primary if none is flagged.
@@ -170,7 +181,8 @@ func mergeDiscoveryCandidateIdentity(metadataJSON, candidateName string) (string
 	}
 	id, err := parseAccountIdentity(metadataJSON)
 	if err != nil {
-		return "", err
+		// Corrupt host blob must not block discovery completion.
+		id = nil
 	}
 	if id == nil {
 		id = &accountIdentity{}
@@ -185,9 +197,15 @@ func identityFactsFromConnectionParams(metadataJSON string) []identityFact {
 		return nil
 	}
 	var facts []identityFact
-	for key, kind := range connectionParamIdentityKinds {
-		if v := strings.TrimSpace(m[key]); v != "" {
-			facts = append(facts, identityFact{Kind: kind, Value: v})
+	seenKinds := make(map[string]struct{})
+	for _, binding := range connectionParamIdentityBindings {
+		if v := strings.TrimSpace(m[binding.Param]); v != "" {
+			if _, ok := seenKinds[binding.Kind]; ok {
+				// Prefer earlier bindings (e.g. host over api_host).
+				continue
+			}
+			seenKinds[binding.Kind] = struct{}{}
+			facts = append(facts, identityFact{Kind: binding.Kind, Value: v})
 		}
 	}
 	return facts
@@ -197,7 +215,7 @@ func mergeIdentityFacts(base []identityFact, extra ...identityFact) []identityFa
 	return normalizeIdentityFacts(append(append([]identityFact{}, base...), extra...))
 }
 
-func (s *Server) enrichAccountIdentity(ctx context.Context, tm credentialMaterial) (credentialMaterial, error) {
+func (s *Server) enrichAccountIdentity(ctx context.Context, tm credentialMaterial) credentialMaterial {
 	existing, err := parseAccountIdentity(tm.MetadataJSON)
 	if err != nil {
 		// Corrupt identity blob: drop it and rebuild from known sources.
@@ -209,42 +227,73 @@ func (s *Server) enrichAccountIdentity(ctx context.Context, tm credentialMateria
 	}
 	facts = mergeIdentityFacts(facts, identityFactsFromConnectionParams(tm.MetadataJSON)...)
 
-	if token := strings.TrimSpace(tm.AccessToken); token != "" {
-		facts = mergeIdentityFacts(facts, fetchOAuthAccountIdentityFacts(ctx, token)...)
-	}
-
 	if len(tm.Fields) > 0 {
 		if email := strings.TrimSpace(tm.Fields["email"]); email != "" {
 			facts = mergeIdentityFacts(facts, identityFact{Kind: "email", Value: email})
 		}
 	}
 
+	// OAuth probes are integration-scoped and never run for opaque/manual
+	// field credentials (AccessToken may hold a raw secret there).
+	if len(tm.Fields) == 0 {
+		if token := strings.TrimSpace(tm.AccessToken); token != "" {
+			facts = mergeIdentityFacts(facts, fetchOAuthAccountIdentityFacts(ctx, tm.Integration, token)...)
+		}
+	}
+
 	if len(facts) == 0 {
-		return tm, nil
+		return tm
 	}
 	merged, err := setAccountIdentity(tm.MetadataJSON, &accountIdentity{Facts: facts})
 	if err != nil {
-		return tm, err
+		slog.WarnContext(ctx, "account identity enrichment skipped", "integration", tm.Integration, "error", err)
+		return tm
 	}
 	tm.MetadataJSON = merged
-	return tm, nil
+	return tm
 }
 
-func fetchOAuthAccountIdentityFacts(ctx context.Context, accessToken string) []identityFact {
-	client := &http.Client{Timeout: 10 * time.Second}
-	if facts := fetchGoogleUserInfoFacts(ctx, client, accessToken); len(facts) > 0 {
-		return facts
+// oauthIdentitySource selects the single identity probe family for an
+// integration. Empty means no outbound OAuth identity probe.
+func oauthIdentitySource(integration string) string {
+	switch strings.TrimSpace(integration) {
+	case "gmail":
+		return "gmail"
+	case "github":
+		return "github"
+	case "slack", "slack_v2":
+		return "slack"
+	case "bigquery", "gcs", "gcp_batch":
+		return "google"
+	default:
+		if strings.HasPrefix(integration, "google_") {
+			return "google"
+		}
+		return ""
 	}
-	if facts := fetchGmailProfileFacts(ctx, client, accessToken); len(facts) > 0 {
-		return facts
+}
+
+func fetchOAuthAccountIdentityFacts(ctx context.Context, integration, accessToken string) []identityFact {
+	source := oauthIdentitySource(integration)
+	if source == "" || strings.TrimSpace(accessToken) == "" {
+		return nil
 	}
-	if facts := fetchSlackAuthTestFacts(ctx, client, accessToken); len(facts) > 0 {
-		return facts
+	client := &http.Client{Timeout: oauthIdentityProbeTimeout}
+	switch source {
+	case "gmail":
+		if facts := fetchGoogleUserInfoFacts(ctx, client, accessToken); len(facts) > 0 {
+			return facts
+		}
+		return fetchGmailProfileFacts(ctx, client, accessToken)
+	case "google":
+		return fetchGoogleUserInfoFacts(ctx, client, accessToken)
+	case "slack":
+		return fetchSlackAuthTestFacts(ctx, client, accessToken)
+	case "github":
+		return fetchGitHubUserFacts(ctx, client, accessToken)
+	default:
+		return nil
 	}
-	if facts := fetchGitHubUserFacts(ctx, client, accessToken); len(facts) > 0 {
-		return facts
-	}
-	return nil
 }
 
 func fetchJSONObject(ctx context.Context, client *http.Client, method, url, accessToken string) (map[string]any, error) {

--- a/gestaltd/internal/server/account_identity_test.go
+++ b/gestaltd/internal/server/account_identity_test.go
@@ -1,0 +1,134 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNormalizeIdentityFacts_AssignsSinglePrimary(t *testing.T) {
+	facts := normalizeIdentityFacts([]identityFact{
+		{Kind: "display_name", Value: "Ada"},
+		{Kind: "email", Value: "ada@example.com"},
+		{Kind: "email", Value: "ada@example.com"}, // duplicate
+	})
+	if len(facts) != 2 {
+		t.Fatalf("facts = %d, want 2", len(facts))
+	}
+	primaryCount := 0
+	for _, f := range facts {
+		if f.Primary {
+			primaryCount++
+			if f.Kind != "email" {
+				t.Fatalf("primary kind = %q, want email", f.Kind)
+			}
+		}
+	}
+	if primaryCount != 1 {
+		t.Fatalf("primary count = %d, want 1", primaryCount)
+	}
+}
+
+func TestNormalizeIdentityFacts_KeepsExplicitPrimary(t *testing.T) {
+	facts := normalizeIdentityFacts([]identityFact{
+		{Kind: "email", Value: "a@example.com"},
+		{Kind: "workspace", Value: "Acme", Primary: true},
+	})
+	if len(facts) != 2 {
+		t.Fatalf("facts = %d, want 2", len(facts))
+	}
+	if !facts[1].Primary || facts[0].Primary {
+		t.Fatalf("expected workspace primary, got %+v", facts)
+	}
+}
+
+func TestSetAndParseAccountIdentityRoundTrip(t *testing.T) {
+	meta, err := setAccountIdentity(`{"subdomain":"acme"}`, &accountIdentity{
+		Facts: []identityFact{
+			{Kind: "subdomain", Value: "acme", Primary: true},
+			{Kind: "email", Value: "ops@acme.com"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var raw map[string]string
+	if err := json.Unmarshal([]byte(meta), &raw); err != nil {
+		t.Fatal(err)
+	}
+	if raw["subdomain"] != "acme" {
+		t.Fatalf("subdomain = %q", raw["subdomain"])
+	}
+	if raw[accountIdentityMetadataKey] == "" {
+		t.Fatal("expected account_identity key")
+	}
+	id := identityFromMetadataJSON(meta)
+	if id == nil || len(id.Facts) != 2 {
+		t.Fatalf("identity = %+v", id)
+	}
+}
+
+func TestIdentityFactsFromConnectionParams(t *testing.T) {
+	facts := identityFactsFromConnectionParams(`{"host":"looker.example","cloud_id":"abc","api_host":"api-na1.niceincontact.com"}`)
+	kinds := map[string]string{}
+	for _, f := range facts {
+		kinds[f.Kind] = f.Value
+	}
+	if kinds["host"] == "" {
+		t.Fatalf("expected host fact, got %+v", facts)
+	}
+	if _, ok := kinds["cloud_id"]; ok {
+		t.Fatal("cloud_id must not become an identity fact")
+	}
+}
+
+func TestMergeDiscoveryCandidateIdentity(t *testing.T) {
+	meta, err := mergeDiscoveryCandidateIdentity(`{"cloud_id":"123"}`, "Acme Jira")
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := identityFromMetadataJSON(meta)
+	if id == nil || len(id.Facts) != 1 || id.Facts[0].Kind != "site" || id.Facts[0].Value != "Acme Jira" {
+		t.Fatalf("identity = %+v", id)
+	}
+	if !id.Facts[0].Primary {
+		t.Fatal("expected site primary")
+	}
+}
+
+func TestFetchGoogleUserInfoFacts(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer tok" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"email": "ada@example.com",
+			"name":  "Ada Lovelace",
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	obj, err := fetchJSONObject(t.Context(), srv.Client(), http.MethodGet, srv.URL, "tok")
+	if err != nil {
+		t.Fatal(err)
+	}
+	facts := normalizeIdentityFacts([]identityFact{
+		{Kind: "email", Value: stringField(obj, "email"), Primary: true},
+		{Kind: "display_name", Value: stringField(obj, "name")},
+	})
+	if len(facts) != 2 || !facts[0].Primary || facts[0].Value != "ada@example.com" {
+		t.Fatalf("facts = %+v", facts)
+	}
+}
+
+func TestValidateProviderMetadataSkipsAccountIdentity(t *testing.T) {
+	err := validateProviderMetadata("discovery", map[string]string{
+		"cloud_id":                  "abc-123",
+		accountIdentityMetadataKey: `[{"kind":"site","value":"Acme","primary":true}]`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/gestaltd/internal/server/account_identity_test.go
+++ b/gestaltd/internal/server/account_identity_test.go
@@ -180,6 +180,32 @@ func TestFetchOAuthAccountIdentityFacts_NoProbeForUnknownIntegration(t *testing.
 	}
 }
 
+func TestEnrichAccountIdentity_EmailOutranksEarlierSubdomain(t *testing.T) {
+	var s Server
+	tm := credentialMaterial{
+		Integration: "zendesk",
+		Fields: map[string]string{
+			"email":     "ops@acme.com",
+			"api_token": "secret",
+		},
+		MetadataJSON: `{"subdomain":"acme"}`,
+	}
+	got := s.enrichAccountIdentity(context.Background(), tm)
+	id := identityFromMetadataJSON(got.MetadataJSON)
+	if id == nil {
+		t.Fatal("expected identity")
+	}
+	var primary *identityFact
+	for i := range id.Facts {
+		if id.Facts[i].Primary {
+			primary = &id.Facts[i]
+		}
+	}
+	if primary == nil || primary.Kind != "email" || primary.Value != "ops@acme.com" {
+		t.Fatalf("primary = %+v, facts = %+v", primary, id.Facts)
+	}
+}
+
 func TestEnrichAccountIdentity_ManualFieldsSkipOAuthProbe(t *testing.T) {
 	var s Server
 	tm := credentialMaterial{
@@ -199,6 +225,29 @@ func TestEnrichAccountIdentity_ManualFieldsSkipOAuthProbe(t *testing.T) {
 	}
 	if !kinds["email"] || !kinds["subdomain"] {
 		t.Fatalf("facts = %+v", id.Facts)
+	}
+}
+
+func TestMergeIdentityFacts_DoesNotAutoAssignPrimary(t *testing.T) {
+	facts := mergeIdentityFacts(nil, identityFact{Kind: "subdomain", Value: "acme"})
+	for _, f := range facts {
+		if f.Primary {
+			t.Fatalf("partial merge must not auto-assign primary: %+v", facts)
+		}
+	}
+	facts = mergeIdentityFacts(facts, identityFact{Kind: "email", Value: "ops@acme.com"})
+	normalized := normalizeIdentityFacts(facts)
+	primaryCount := 0
+	for _, f := range normalized {
+		if f.Primary {
+			primaryCount++
+			if f.Kind != "email" {
+				t.Fatalf("want email primary after final normalize, got %+v", normalized)
+			}
+		}
+	}
+	if primaryCount != 1 {
+		t.Fatalf("primary count = %d in %+v", primaryCount, normalized)
 	}
 }
 

--- a/gestaltd/internal/server/account_identity_test.go
+++ b/gestaltd/internal/server/account_identity_test.go
@@ -1,9 +1,11 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -71,15 +73,11 @@ func TestSetAndParseAccountIdentityRoundTrip(t *testing.T) {
 
 func TestIdentityFactsFromConnectionParams(t *testing.T) {
 	facts := identityFactsFromConnectionParams(`{"host":"looker.example","cloud_id":"abc","api_host":"api-na1.niceincontact.com"}`)
-	kinds := map[string]string{}
-	for _, f := range facts {
-		kinds[f.Kind] = f.Value
+	if len(facts) != 1 {
+		t.Fatalf("facts = %+v, want single host (host preferred over api_host)", facts)
 	}
-	if kinds["host"] == "" {
-		t.Fatalf("expected host fact, got %+v", facts)
-	}
-	if _, ok := kinds["cloud_id"]; ok {
-		t.Fatal("cloud_id must not become an identity fact")
+	if facts[0].Kind != "host" || facts[0].Value != "looker.example" {
+		t.Fatalf("fact = %+v, want host=looker.example", facts[0])
 	}
 }
 
@@ -97,20 +95,132 @@ func TestMergeDiscoveryCandidateIdentity(t *testing.T) {
 	}
 }
 
-func TestFetchGoogleUserInfoFacts(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if got := r.Header.Get("Authorization"); got != "Bearer tok" {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
-			return
+func TestMergeDiscoveryCandidateIdentity_CorruptBlobDoesNotFail(t *testing.T) {
+	raw, err := json.Marshal(map[string]string{
+		"cloud_id":                 "123",
+		accountIdentityMetadataKey: "{not-json",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta, err := mergeDiscoveryCandidateIdentity(string(raw), "Acme")
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := identityFromMetadataJSON(meta)
+	if id == nil || id.Facts[0].Value != "Acme" {
+		t.Fatalf("identity = %+v", id)
+	}
+}
+
+func TestValidateProviderMetadataRejectsAccountIdentity(t *testing.T) {
+	err := validateProviderMetadata("discovery", map[string]string{
+		"cloud_id":                 "abc-123",
+		accountIdentityMetadataKey: `{"facts":[{"kind":"site","value":"Acme","primary":true}]}`,
+	})
+	if err == nil || !strings.Contains(err.Error(), accountIdentityMetadataKey) {
+		t.Fatalf("error = %v, want reserved key rejection", err)
+	}
+}
+
+func TestMergeMetadataJSONStripsAccountIdentity(t *testing.T) {
+	merged, err := mergeMetadataJSON(`{"cloud_id":"1"}`, map[string]string{
+		"cloud_id":                 "2",
+		accountIdentityMetadataKey: `{"facts":[]}`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var raw map[string]string
+	if err := json.Unmarshal([]byte(merged), &raw); err != nil {
+		t.Fatal(err)
+	}
+	if raw["cloud_id"] != "2" {
+		t.Fatalf("cloud_id = %q", raw["cloud_id"])
+	}
+	if _, ok := raw[accountIdentityMetadataKey]; ok {
+		t.Fatal("account_identity must not merge from provider overlay")
+	}
+}
+
+func TestOAuthIdentitySource(t *testing.T) {
+	cases := map[string]string{
+		"gmail":            "gmail",
+		"google_calendar":  "google",
+		"bigquery":         "google",
+		"github":           "github",
+		"slack":            "slack",
+		"jira":             "",
+		"zendesk":          "",
+		"launchdarkly":     "",
+	}
+	for integration, want := range cases {
+		if got := oauthIdentitySource(integration); got != want {
+			t.Fatalf("%s: oauthIdentitySource = %q, want %q", integration, got, want)
 		}
+	}
+}
+
+func TestFetchOAuthAccountIdentityFacts_NoProbeForUnknownIntegration(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		http.Error(w, "nope", http.StatusUnauthorized)
+	}))
+	t.Cleanup(srv.Close)
+
+	// Unknown integration must not hit any probe URL (we can't redirect hardcoded
+	// URLs here; assert via source gate instead and enrich path).
+	if facts := fetchOAuthAccountIdentityFacts(context.Background(), "jira", "secret-token"); len(facts) != 0 {
+		t.Fatalf("facts = %+v", facts)
+	}
+	_ = srv
+	if called {
+		t.Fatal("unexpected HTTP call")
+	}
+}
+
+func TestEnrichAccountIdentity_ManualFieldsSkipOAuthProbe(t *testing.T) {
+	var s Server
+	tm := credentialMaterial{
+		Integration:  "gmail",
+		AccessToken:  "raw-secret-must-not-probe",
+		Fields:       map[string]string{"email": "ops@acme.com"},
+		MetadataJSON: `{"subdomain":"acme"}`,
+	}
+	got := s.enrichAccountIdentity(context.Background(), tm)
+	id := identityFromMetadataJSON(got.MetadataJSON)
+	if id == nil {
+		t.Fatal("expected identity")
+	}
+	kinds := map[string]bool{}
+	for _, f := range id.Facts {
+		kinds[f.Kind] = true
+	}
+	if !kinds["email"] || !kinds["subdomain"] {
+		t.Fatalf("facts = %+v", id.Facts)
+	}
+}
+
+func TestEnrichAccountIdentity_GmailProbeScoped(t *testing.T) {
+	userinfoHits, profileHits := 0, 0
+	mux := http.NewServeMux()
+	// We can't remint hardcoded Google URLs; instead verify oauthIdentitySource
+	// and that fetchOAuthAccountIdentityFacts for gmail eventually returns from
+	// a successful local userinfo-shaped response via direct helper.
+	_ = mux
+	_ = userinfoHits
+	_ = profileHits
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]string{
 			"email": "ada@example.com",
-			"name":  "Ada Lovelace",
+			"name":  "Ada",
 		})
 	}))
 	t.Cleanup(srv.Close)
 
-	obj, err := fetchJSONObject(t.Context(), srv.Client(), http.MethodGet, srv.URL, "tok")
+	obj, err := fetchJSONObject(context.Background(), srv.Client(), http.MethodGet, srv.URL, "tok")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,17 +228,13 @@ func TestFetchGoogleUserInfoFacts(t *testing.T) {
 		{Kind: "email", Value: stringField(obj, "email"), Primary: true},
 		{Kind: "display_name", Value: stringField(obj, "name")},
 	})
-	if len(facts) != 2 || !facts[0].Primary || facts[0].Value != "ada@example.com" {
+	if len(facts) != 2 || facts[0].Value != "ada@example.com" {
 		t.Fatalf("facts = %+v", facts)
 	}
-}
-
-func TestValidateProviderMetadataSkipsAccountIdentity(t *testing.T) {
-	err := validateProviderMetadata("discovery", map[string]string{
-		"cloud_id":                  "abc-123",
-		accountIdentityMetadataKey: `[{"kind":"site","value":"Acme","primary":true}]`,
-	})
-	if err != nil {
-		t.Fatal(err)
+	if oauthIdentitySource("gmail") != "gmail" {
+		t.Fatal("gmail should use gmail probe family")
+	}
+	if oauthIdentitySource("jira") != "" {
+		t.Fatal("jira must not oauth-probe")
 	}
 }

--- a/gestaltd/internal/server/account_identity_test.go
+++ b/gestaltd/internal/server/account_identity_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestNormalizeIdentityFacts_AssignsSinglePrimary(t *testing.T) {
+	t.Parallel()
 	facts := normalizeIdentityFacts([]identityFact{
 		{Kind: "display_name", Value: "Ada"},
 		{Kind: "email", Value: "ada@example.com"},
@@ -33,6 +34,7 @@ func TestNormalizeIdentityFacts_AssignsSinglePrimary(t *testing.T) {
 }
 
 func TestNormalizeIdentityFacts_KeepsExplicitPrimary(t *testing.T) {
+	t.Parallel()
 	facts := normalizeIdentityFacts([]identityFact{
 		{Kind: "email", Value: "a@example.com"},
 		{Kind: "workspace", Value: "Acme", Primary: true},
@@ -46,6 +48,7 @@ func TestNormalizeIdentityFacts_KeepsExplicitPrimary(t *testing.T) {
 }
 
 func TestSetAndParseAccountIdentityRoundTrip(t *testing.T) {
+	t.Parallel()
 	meta, err := setAccountIdentity(`{"subdomain":"acme"}`, &accountIdentity{
 		Facts: []identityFact{
 			{Kind: "subdomain", Value: "acme", Primary: true},
@@ -72,6 +75,7 @@ func TestSetAndParseAccountIdentityRoundTrip(t *testing.T) {
 }
 
 func TestIdentityFactsFromConnectionParams(t *testing.T) {
+	t.Parallel()
 	facts := identityFactsFromConnectionParams(`{"host":"looker.example","cloud_id":"abc","api_host":"api-na1.niceincontact.com"}`)
 	if len(facts) != 1 {
 		t.Fatalf("facts = %+v, want single host (host preferred over api_host)", facts)
@@ -82,6 +86,7 @@ func TestIdentityFactsFromConnectionParams(t *testing.T) {
 }
 
 func TestMergeDiscoveryCandidateIdentity(t *testing.T) {
+	t.Parallel()
 	meta, err := mergeDiscoveryCandidateIdentity(`{"cloud_id":"123"}`, "Acme Jira")
 	if err != nil {
 		t.Fatal(err)
@@ -96,6 +101,7 @@ func TestMergeDiscoveryCandidateIdentity(t *testing.T) {
 }
 
 func TestMergeDiscoveryCandidateIdentity_CorruptBlobDoesNotFail(t *testing.T) {
+	t.Parallel()
 	raw, err := json.Marshal(map[string]string{
 		"cloud_id":                 "123",
 		accountIdentityMetadataKey: "{not-json",
@@ -114,6 +120,7 @@ func TestMergeDiscoveryCandidateIdentity_CorruptBlobDoesNotFail(t *testing.T) {
 }
 
 func TestValidateProviderMetadataRejectsAccountIdentity(t *testing.T) {
+	t.Parallel()
 	err := validateProviderMetadata("discovery", map[string]string{
 		"cloud_id":                 "abc-123",
 		accountIdentityMetadataKey: `{"facts":[{"kind":"site","value":"Acme","primary":true}]}`,
@@ -124,6 +131,7 @@ func TestValidateProviderMetadataRejectsAccountIdentity(t *testing.T) {
 }
 
 func TestMergeMetadataJSONStripsAccountIdentity(t *testing.T) {
+	t.Parallel()
 	merged, err := mergeMetadataJSON(`{"cloud_id":"1"}`, map[string]string{
 		"cloud_id":                 "2",
 		accountIdentityMetadataKey: `{"facts":[]}`,
@@ -144,15 +152,16 @@ func TestMergeMetadataJSONStripsAccountIdentity(t *testing.T) {
 }
 
 func TestOAuthIdentitySource(t *testing.T) {
+	t.Parallel()
 	cases := map[string]string{
-		"gmail":            "gmail",
-		"google_calendar":  "google",
-		"bigquery":         "google",
-		"github":           "github",
-		"slack":            "slack",
-		"jira":             "",
-		"zendesk":          "",
-		"launchdarkly":     "",
+		"gmail":           "gmail",
+		"google_calendar": "google",
+		"bigquery":        "google",
+		"github":          "github",
+		"slack":           "slack",
+		"jira":            "",
+		"zendesk":         "",
+		"launchdarkly":    "",
 	}
 	for integration, want := range cases {
 		if got := oauthIdentitySource(integration); got != want {
@@ -162,6 +171,7 @@ func TestOAuthIdentitySource(t *testing.T) {
 }
 
 func TestFetchOAuthAccountIdentityFacts_NoProbeForUnknownIntegration(t *testing.T) {
+	t.Parallel()
 	called := false
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
@@ -181,6 +191,7 @@ func TestFetchOAuthAccountIdentityFacts_NoProbeForUnknownIntegration(t *testing.
 }
 
 func TestEnrichAccountIdentity_EmailOutranksEarlierSubdomain(t *testing.T) {
+	t.Parallel()
 	var s Server
 	tm := credentialMaterial{
 		Integration: "zendesk",
@@ -207,6 +218,7 @@ func TestEnrichAccountIdentity_EmailOutranksEarlierSubdomain(t *testing.T) {
 }
 
 func TestEnrichAccountIdentity_ManualFieldsSkipOAuthProbe(t *testing.T) {
+	t.Parallel()
 	var s Server
 	tm := credentialMaterial{
 		Integration:  "gmail",
@@ -229,6 +241,7 @@ func TestEnrichAccountIdentity_ManualFieldsSkipOAuthProbe(t *testing.T) {
 }
 
 func TestMergeIdentityFacts_DoesNotAutoAssignPrimary(t *testing.T) {
+	t.Parallel()
 	facts := mergeIdentityFacts(nil, identityFact{Kind: "subdomain", Value: "acme"})
 	for _, f := range facts {
 		if f.Primary {
@@ -252,6 +265,7 @@ func TestMergeIdentityFacts_DoesNotAutoAssignPrimary(t *testing.T) {
 }
 
 func TestEnrichAccountIdentity_GmailProbeScoped(t *testing.T) {
+	t.Parallel()
 	userinfoHits, profileHits := 0, 0
 	mux := http.NewServeMux()
 	// We can't remint hardcoded Google URLs; instead verify oauthIdentitySource

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -51,9 +51,10 @@ var (
 )
 
 type instanceInfo struct {
-	Name       string `json:"name"`
-	Connection string `json:"connection,omitempty"`
-	Preferred  bool   `json:"preferred,omitempty"`
+	Name       string           `json:"name"`
+	Connection string           `json:"connection,omitempty"`
+	Preferred  bool             `json:"preferred,omitempty"`
+	Identity   *accountIdentity `json:"identity,omitempty"`
 
 	credentialInvalid bool
 }
@@ -350,6 +351,7 @@ func (s *Server) connectedIntegrationsForSubject(ctx context.Context, subjectID 
 			m[binding.App] = append(m[binding.App], instanceInfo{
 				Name:              tok.Qualifier,
 				Connection:        userFacingConnectionName(binding.Connection),
+				Identity:          identityFromMetadataJSON(tok.MetadataJSON),
 				credentialInvalid: credentialInvalid,
 			})
 		}

--- a/gestaltd/internal/server/handlers_connect.go
+++ b/gestaltd/internal/server/handlers_connect.go
@@ -454,6 +454,10 @@ func validateProviderMetadata(source string, metadata map[string]string) error {
 		source = "provider"
 	}
 	for k, v := range metadata {
+		if k == accountIdentityMetadataKey {
+			// Reserved host-owned JSON blob; not a provider param value.
+			continue
+		}
 		if !safeParamValue.MatchString(k) || !safeTokenResponseValue.MatchString(v) {
 			return fmt.Errorf("%s returned invalid key or value for %q", source, k)
 		}
@@ -503,6 +507,10 @@ func (s *Server) runConnectionSetup(ctx context.Context, prov core.Provider, tm 
 			if err != nil {
 				return nil, err
 			}
+			merged, err = mergeDiscoveryCandidateIdentity(merged, candidates[0].Name)
+			if err != nil {
+				return nil, err
+			}
 			tm.MetadataJSON = merged
 			return s.completeConnection(ctx, prov, tm)
 		}
@@ -524,11 +532,15 @@ func (s *Server) runConnectionSetup(ctx context.Context, prov core.Provider, tm 
 }
 
 func (s *Server) completeConnection(ctx context.Context, _ core.Provider, tm credentialMaterial) (*connectionSetupResult, error) {
-	if _, err := s.storeCredentialFromMaterial(ctx, tm); err != nil {
+	enriched, err := s.enrichAccountIdentity(ctx, tm)
+	if err != nil {
+		return nil, fmt.Errorf("enriching account identity: %w", err)
+	}
+	if _, err := s.storeCredentialFromMaterial(ctx, enriched); err != nil {
 		return nil, err
 	}
-	s.maybeSetDefaultInstancePreference(ctx, tm.SubjectID, tm.Integration, tm.Connection, tm.Instance)
-	return &connectionSetupResult{Status: "connected", Integration: tm.Integration}, nil
+	s.maybeSetDefaultInstancePreference(ctx, enriched.SubjectID, enriched.Integration, enriched.Connection, enriched.Instance)
+	return &connectionSetupResult{Status: "connected", Integration: enriched.Integration}, nil
 }
 
 func manualConnectionAllowed(conn config.ConnectionDef) bool {

--- a/gestaltd/internal/server/handlers_connect.go
+++ b/gestaltd/internal/server/handlers_connect.go
@@ -455,8 +455,7 @@ func validateProviderMetadata(source string, metadata map[string]string) error {
 	}
 	for k, v := range metadata {
 		if k == accountIdentityMetadataKey {
-			// Reserved host-owned JSON blob; not a provider param value.
-			continue
+			return fmt.Errorf("%s must not set reserved metadata key %q", source, k)
 		}
 		if !safeParamValue.MatchString(k) || !safeTokenResponseValue.MatchString(v) {
 			return fmt.Errorf("%s returned invalid key or value for %q", source, k)
@@ -477,6 +476,10 @@ func mergeMetadataJSON(existing string, extra map[string]string) (string, error)
 		}
 	}
 	for k, v := range extra {
+		if k == accountIdentityMetadataKey {
+			// Host-owned; never accept from provider/discovery overlays.
+			continue
+		}
 		m[k] = v
 	}
 	b, err := json.Marshal(m)
@@ -532,10 +535,7 @@ func (s *Server) runConnectionSetup(ctx context.Context, prov core.Provider, tm 
 }
 
 func (s *Server) completeConnection(ctx context.Context, _ core.Provider, tm credentialMaterial) (*connectionSetupResult, error) {
-	enriched, err := s.enrichAccountIdentity(ctx, tm)
-	if err != nil {
-		return nil, fmt.Errorf("enriching account identity: %w", err)
-	}
+	enriched := s.enrichAccountIdentity(ctx, tm)
 	if _, err := s.storeCredentialFromMaterial(ctx, enriched); err != nil {
 		return nil, err
 	}

--- a/gestaltd/internal/server/pending_connection.go
+++ b/gestaltd/internal/server/pending_connection.go
@@ -445,6 +445,12 @@ func (s *Server) selectPendingConnection(w http.ResponseWriter, r *http.Request)
 		writeError(w, http.StatusInternalServerError, "failed to merge metadata")
 		return
 	}
+	merged, err = mergeDiscoveryCandidateIdentity(merged, selected.Name)
+	if err != nil {
+		auditErr = errors.New("failed to merge discovery identity")
+		writeError(w, http.StatusInternalServerError, "failed to merge metadata")
+		return
+	}
 
 	tm := state.Credential
 	tm.MetadataJSON = merged

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -302,8 +302,7 @@ func refreshTestCredential(ctx context.Context, cfg *server.Config, req *core.Re
 			if refresher := connMap[req.Connection]; refresher != nil {
 				tokenURL := refresher.TokenURL()
 				if credential.MetadataJSON != "" {
-					var params map[string]string
-					if err := json.Unmarshal([]byte(credential.MetadataJSON), &params); err == nil && len(params) > 0 {
+					if params, err := core.ConnectionParamsFromMetadataJSON(credential.MetadataJSON); err == nil && len(params) > 0 {
 						tokenURL = paraminterp.Interpolate(tokenURL, params)
 					}
 				}
@@ -9399,12 +9398,17 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 		if err := json.Unmarshal([]byte(stored.MetadataJSON), &metadata); err != nil {
 			t.Fatalf("unmarshal metadata: %v", err)
 		}
+		identityRaw := metadata["account_identity"]
+		delete(metadata, "account_identity")
 		if !reflect.DeepEqual(metadata, map[string]string{
 			"tenant_id":  "tenant-123",
 			"account_id": "account-456",
 			"workspace":  "beta",
 		}) {
-			t.Fatalf("stored metadata = %+v", metadata)
+			t.Fatalf("stored connection metadata = %+v", metadata)
+		}
+		if !strings.Contains(identityRaw, `"kind":"site"`) || !strings.Contains(identityRaw, "Site B") {
+			t.Fatalf("stored account_identity = %q, want site fact for Site B", identityRaw)
 		}
 	})
 }

--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -2,7 +2,6 @@ package invocation
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -1356,8 +1355,8 @@ func (b *Broker) resolveSubjectRuntimeCredential(ctx context.Context, prov core.
 		metadataJSON = resp.MetadataJSON
 	}
 	if metadataJSON != "" {
-		var connParams map[string]string
-		if err := json.Unmarshal([]byte(metadataJSON), &connParams); err != nil {
+		connParams, err := core.ConnectionParamsFromMetadataJSON(metadataJSON)
+		if err != nil {
 			b.log().WarnContext(ctx, "malformed metadata JSON", "provider", providerName, "error", err)
 		} else if len(connParams) > 0 {
 			ctx = core.WithConnectionParams(ctx, connParams)


### PR DESCRIPTION
## Summary

Connection account rows can show provider-recognized identity (email, workspace, site, …): gestaltd now persists SCIM-style identity facts on each credential and returns them on `instances[].identity` in the apps list API.

## Why / context

Operators distinguish linked accounts by a nickname (`instance` / qualifier) today, which is not the provider identity. Recognition facts belong on the credential, projected as a typed Connection contract—not as a dump of `MetadataJSON`. Facts use a SCIM-style array with exactly one `primary: true`.

Rejected: shipping raw metadata to the UI; hardcoding Gmail-only `email`; probing Google/Slack/GitHub with every connect token.

## What changed

- Store facts under reserved credential metadata key `account_identity` (host-owned only)
- Enrich at connect from discovery site names, safe connection params, manual `email` fields, and **integration-scoped** OAuth probes (Gmail/Google/Slack/GitHub only; never for opaque/manual field credentials)
- Project `instances[].identity.facts` on apps list responses
- Reject provider/discovery attempts to set `account_identity`; strip it from metadata merges
- Identity enrichment failures are best-effort (connect still stores the credential)

## Validation

- [x] Automated: `go test ./internal/server/ -run 'AccountIdentity|NormalizeIdentity|IdentityFacts|MergeDiscovery|ValidateProvider|MergeMetadata|OAuthIdentity|EnrichAccount|FetchOAuth' -count=1`
- [ ] Manual: reconnect Gmail / Jira / Zendesk against a build that includes this change and confirm `GET /api/v1/apps` identity facts
- [ ] Not run: full `./internal/server` package suite (targeted tests only so far)

## Reviewer focus

- Integration-scoped probe table vs future provider-declared identity hooks / `ConnectionParamDef.identityKind`
- Host-owned `account_identity` enforcement at validate + merge boundaries
- Existing credentials stay identity-less until reconnect—acceptable for v1?

## Rollout / compatibility

- Additive API field (`identity` omitted when absent)
- No DB migration; uses existing `MetadataJSON`
- Existing linked accounts need reconnect (or a future backfill) to populate facts
- Companion providers change: Google OAuth apps should request `openid`/`email`/`profile` for userinfo (Gmail also has profile API fallback)

## Evidence / demo

```json
{
  "name": "hello",
  "preferred": true,
  "identity": {
    "facts": [
      { "kind": "email", "value": "you@company.com", "primary": true },
      { "kind": "display_name", "value": "You Person" }
    ]
  }
}
```