### PR TITLE
Add user lookup by email for grant authoring

### DIFF
--- a/docs/content/client/cli/index.mdx
+++ b/docs/content/client/cli/index.mdx
@@ -33,6 +33,7 @@ asIndexPage: true
 | `gestalt agent sessions ...` | Create, list, inspect, and update agent sessions. |
 | `gestalt agent turns ...` | Create, list, inspect, cancel, and stream agent turns. |
 | `gestalt tokens create\|list\|revoke` | Manage Gestalt API tokens. |
+| `gestalt users lookup EMAIL` | Look up a user's UUID and `user:<uuid>` subject ID by email (requires gestalt admin). |
 
 ## URL resolution
 

--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -67,6 +67,12 @@ pub enum Commands {
         #[command(subcommand)]
         command: WorkflowCommands,
     },
+
+    /// Look up Gestalt users and subject identifiers
+    Users {
+        #[command(subcommand)]
+        command: UsersCommands,
+    },
 }
 
 #[derive(Subcommand)]
@@ -211,6 +217,15 @@ pub enum TokenCommands {
     Revoke {
         /// Token ID to revoke
         id: String,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum UsersCommands {
+    /// Look up a user's persisted UUID and subject ID by email
+    Lookup {
+        /// Email address to look up
+        email: String,
     },
 }
 

--- a/gestalt/cli/src/commands/mod.rs
+++ b/gestalt/cli/src/commands/mod.rs
@@ -8,5 +8,6 @@ pub mod describe;
 pub mod init;
 pub mod invoke;
 pub mod tokens;
+pub mod users;
 mod workflow_target;
 pub mod workflows;

--- a/gestalt/cli/src/commands/users.rs
+++ b/gestalt/cli/src/commands/users.rs
@@ -1,0 +1,52 @@
+use anyhow::{Context, Result};
+use serde_json::Value;
+
+use crate::api::ApiClient;
+use crate::cli::UsersCommands;
+use crate::output::{self, Format};
+
+pub fn dispatch(client: &ApiClient, command: UsersCommands, format: Format) -> Result<()> {
+    match command {
+        UsersCommands::Lookup { email } => lookup(client, &email, format),
+    }
+}
+
+fn lookup(client: &ApiClient, email: &str, format: Format) -> Result<()> {
+    let email = email.trim();
+    if email.is_empty() {
+        anyhow::bail!("email is required");
+    }
+
+    let path = format!(
+        "/api/v1/users/lookup?email={}",
+        crate::api::encode_path_segment(email)
+    );
+    let resp = client
+        .get(&path)
+        .context("failed to look up user by email")?;
+
+    match format {
+        Format::Json => output::print_json(&resp),
+        Format::Table => print_lookup_table(&resp),
+    }
+    Ok(())
+}
+
+fn print_lookup_table(value: &Value) {
+    output::print_json_table(value);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::lookup;
+    use crate::api::ApiClient;
+    use crate::output::Format;
+
+    #[test]
+    fn lookup_rejects_blank_email() {
+        let client = ApiClient::new("http://localhost:8080", "token").expect("client");
+        let err = lookup(&client, "  ", Format::Json)
+            .expect_err("blank email should fail before request");
+        assert!(err.to_string().contains("email is required"));
+    }
+}

--- a/gestalt/cli/src/main.rs
+++ b/gestalt/cli/src/main.rs
@@ -59,6 +59,10 @@ fn run() -> anyhow::Result<()> {
             commands::workflows::dispatch(&api, &workflow, command, format)
         }
         Commands::Agent(args) => dispatch_agent(args, url, url_was_explicit, format),
+        Commands::Users { command } => {
+            let api = ApiClient::from_env(url)?;
+            commands::users::dispatch(&api, command, format)
+        }
     }
 }
 

--- a/gestaltd/internal/server/handlers_users.go
+++ b/gestaltd/internal/server/handlers_users.go
@@ -1,0 +1,82 @@
+package server
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+)
+
+type userLookupResponse struct {
+	SubjectID   string `json:"subjectId"`
+	ID          string `json:"id"`
+	Email       string `json:"email"`
+	DisplayName string `json:"displayName,omitempty"`
+}
+
+func (s *Server) lookupUserByEmail(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requireGestaltAdmin(w, r); !ok {
+		return
+	}
+	if s.users == nil {
+		writeError(w, http.StatusServiceUnavailable, "user store is unavailable")
+		return
+	}
+
+	email := strings.TrimSpace(r.URL.Query().Get("email"))
+	if email == "" {
+		writeError(w, http.StatusBadRequest, "email query parameter is required")
+		return
+	}
+
+	user, err := s.users.FindUserByEmail(r.Context(), email)
+	if err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "user not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to look up user")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, userLookupResponse{
+		SubjectID:   principal.UserSubjectID(user.ID),
+		ID:          user.ID,
+		Email:       user.Email,
+		DisplayName: strings.TrimSpace(user.DisplayName),
+	})
+}
+
+func (s *Server) requireGestaltAdmin(w http.ResponseWriter, r *http.Request) (*principal.Principal, bool) {
+	p, err := s.resolveRequestPrincipalWithUserID(r)
+	switch {
+	case errors.Is(err, errInvalidAuthorizationHeader):
+		writeError(w, http.StatusUnauthorized, "invalid authorization header format")
+		return nil, false
+	case errors.Is(err, principal.ErrInvalidToken):
+		writeError(w, http.StatusUnauthorized, "missing authorization")
+		return nil, false
+	case err != nil:
+		writeError(w, http.StatusInternalServerError, "failed to resolve user")
+		return nil, false
+	case p == nil:
+		writeError(w, http.StatusUnauthorized, "missing authorization")
+		return nil, false
+	}
+	if err := requireUserCaller(w, p); err != nil {
+		return nil, false
+	}
+
+	_, allowed, err := s.authorizeMountedAppAccess(r.Context(), p, s.adminMountedUI())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to authorize request")
+		return nil, false
+	}
+	if !allowed {
+		writeError(w, http.StatusForbidden, "gestalt admin access required")
+		return nil, false
+	}
+	return p, true
+}

--- a/gestaltd/internal/server/handlers_users_test.go
+++ b/gestaltd/internal/server/handlers_users_test.go
@@ -1,0 +1,160 @@
+package server_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/server"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+)
+
+func TestLookupUserByEmailRequiresAuthentication(t *testing.T) {
+	t.Parallel()
+
+	ts := newAuthorizedUserLookupTestServer(t, true)
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/api/v1/users/lookup?email=admin-api-user%40example.test")
+	if err != nil {
+		t.Fatalf("GET user lookup: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 401: %s", resp.StatusCode, body)
+	}
+}
+
+func TestLookupUserByEmailRequiresGestaltAdmin(t *testing.T) {
+	t.Parallel()
+
+	ts := newAuthorizedUserLookupTestServer(t, false)
+	testutil.CloseOnCleanup(t, ts)
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/users/lookup?email=admin-api-user%40example.test", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "session-token"})
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET user lookup: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 403: %s", resp.StatusCode, body)
+	}
+}
+
+func TestLookupUserByEmailReturnsSubjectID(t *testing.T) {
+	t.Parallel()
+
+	ts := newAuthorizedUserLookupTestServer(t, true)
+	testutil.CloseOnCleanup(t, ts)
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/users/lookup?email=admin-api-user%40example.test", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "session-token"})
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET user lookup: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
+	}
+
+	var payload struct {
+		SubjectID string `json:"subjectId"`
+		ID        string `json:"id"`
+		Email     string `json:"email"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if payload.SubjectID != principal.UserSubjectID("admin-api-user") {
+		t.Fatalf("subjectId = %q, want %q", payload.SubjectID, principal.UserSubjectID("admin-api-user"))
+	}
+	if payload.ID != "admin-api-user" {
+		t.Fatalf("id = %q, want admin-api-user", payload.ID)
+	}
+	if payload.Email != "admin-api-user@example.test" {
+		t.Fatalf("email = %q, want admin-api-user@example.test", payload.Email)
+	}
+}
+
+func TestLookupUserByEmailNotFound(t *testing.T) {
+	t.Parallel()
+
+	ts := newAuthorizedUserLookupTestServer(t, true)
+	testutil.CloseOnCleanup(t, ts)
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/users/lookup?email=missing%40example.test", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "session-token"})
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET user lookup: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNotFound {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 404: %s", resp.StatusCode, body)
+	}
+}
+
+func newAuthorizedUserLookupTestServer(t *testing.T, grantAdmin bool) *httptest.Server {
+	t.Helper()
+
+	svc := testutil.NewStubServices(t)
+	user := seedUserRecord(t, svc, "admin-api-user", "admin-api-user@example.test", time.Now())
+
+	relationships := []*proto.Relationship(nil)
+	if grantAdmin {
+		relationships = append(relationships, testAuthorizationRelationship(
+			principal.UserSubjectID(user.ID),
+			"admin",
+			"gestaltAdmin",
+			"gestaltAdmin",
+		))
+	}
+
+	authz := &serverTestAuthorizationProvider{
+		resourceTypes: []*proto.AuthorizationModelResourceType{{
+			Name: "gestaltAdmin",
+		}},
+		relationships: relationships,
+	}
+
+	return newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = coretesting.NamedIntrospectIdentityStub("test", func(_ context.Context, token string) (*core.UserIdentity, error) {
+			if token != "session-token" {
+				return nil, core.ErrNotFound
+			}
+			return &core.UserIdentity{Email: user.Email}, nil
+		})
+		cfg.Services = svc
+		cfg.Authorization = authz
+		cfg.AdminUI = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("admin-shell"))
+		})
+	})
+}

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -23,6 +23,8 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 		r.Post("/tokens", s.createAPIToken)
 		r.Delete("/tokens/{id}", s.revokeAPIToken)
 
+		r.Get("/users/lookup", s.lookupUserByEmail)
+
 	})
 
 	r.With(s.pluginRouteAuthMiddleware("name")).Get("/apps/{name}/operations", s.listOperations)


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/users/lookup?email=...` for gestalt admins to resolve a user's persisted UUID and `user:<uuid>` subject ID
- Add `gestalt users lookup EMAIL` CLI command that calls the same endpoint
- Reuse existing `UserService.FindUserByEmail`; gate access with the same gestaltAdmin authorization used by the admin API

## Motivation
Grant entries in deploy config require stable `user:<uuid>` subject IDs. Operators currently have to query the users store manually; this exposes the existing lookup path through gestalt itself.

## Test plan
- [x] `go test ./internal/server -run TestLookupUserByEmail`
- [x] `cargo test users::tests` in `gestalt/cli`
- [ ] `GESTALT_URL=https://valon.tools gestalt users lookup tyler.campbell@valon.com` as a gestalt admin
- [ ] Confirm non-admin callers receive 403


Made with [Cursor](https://cursor.com)