### PR TITLE
gestaltd: expose read-only app admin members roster

### DIFF
--- a/gestaltd/internal/server/handlers_app_admin_members.go
+++ b/gestaltd/internal/server/handlers_app_admin_members.go
@@ -1,0 +1,150 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+)
+
+// appAdminMemberRow is the read model for GET /apps/{app}/admin/members.
+// Field names match the app-default Members UI contract.
+type appAdminMemberRow struct {
+	Email         string `json:"email,omitempty"`
+	Role          string `json:"role"`
+	Source        string `json:"source"`
+	Mutable       bool   `json:"mutable"`
+	Effective     bool   `json:"effective"`
+	SelectorKind  string `json:"selectorKind,omitempty"`
+	SelectorValue string `json:"selectorValue,omitempty"`
+	SubjectID     string `json:"subjectId,omitempty"`
+}
+
+func (s *Server) mountAppAdminMembersRoutes(r chi.Router) {
+	r.With(s.pluginRouteAuthMiddleware("app"), s.appAdminAuthorizationMiddleware).
+		Get("/apps/{app}/admin/members", s.listAppAdminMembers)
+}
+
+func (s *Server) listAppAdminMembers(w http.ResponseWriter, r *http.Request) {
+	appName := strings.TrimSpace(chi.URLParam(r, "app"))
+	if appName == "" {
+		writeError(w, http.StatusBadRequest, "app is required")
+		return
+	}
+	if s.authorization == nil {
+		writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
+		return
+	}
+
+	rows, err := s.listAppAuthorizationMemberRows(r.Context(), appName)
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
+		return
+	}
+	writeJSON(w, http.StatusOK, rows)
+}
+
+func (s *Server) listAppAuthorizationMemberRows(ctx context.Context, appName string) ([]appAdminMemberRow, error) {
+	appName = strings.TrimSpace(appName)
+	rows := make([]appAdminMemberRow, 0)
+	pageToken := ""
+	for {
+		resp, err := s.authorization.ListRelationships(ctx, &proto.ListRelationshipsRequest{
+			Filter: &proto.RelationshipFilter{
+				Resource: &proto.Resource{Type: "app", Id: appName},
+			},
+			PageSize:  500,
+			PageToken: pageToken,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, relationship := range resp.GetRelationships() {
+			if row, ok := s.appAdminMemberRowFromRelationship(ctx, relationship); ok {
+				rows = append(rows, row)
+			}
+		}
+		pageToken = strings.TrimSpace(resp.GetNextPageToken())
+		if pageToken == "" {
+			return rows, nil
+		}
+	}
+}
+
+func (s *Server) appAdminMemberRowFromRelationship(ctx context.Context, relationship *proto.Relationship) (appAdminMemberRow, bool) {
+	if relationship == nil || relationship.GetTuple() == nil {
+		return appAdminMemberRow{}, false
+	}
+	tuple := relationship.GetTuple()
+	role := strings.TrimSpace(tuple.GetRelation())
+	if role == "" {
+		return appAdminMemberRow{}, false
+	}
+
+	source, mutable := appAdminMemberSource(relationship.GetSourceLayer())
+	row := appAdminMemberRow{
+		Role:      role,
+		Source:    source,
+		Mutable:   mutable,
+		Effective: true,
+	}
+
+	switch target := tuple.GetTarget().GetKind().(type) {
+	case *proto.RelationshipTarget_Subject:
+		subjectID := strings.TrimSpace(target.Subject.GetId())
+		if subjectID == "" {
+			return appAdminMemberRow{}, false
+		}
+		row.SubjectID = subjectID
+		row.SelectorKind = "subject_id"
+		row.SelectorValue = subjectID
+		row.Email = s.resolveAppAdminMemberEmail(ctx, subjectID)
+		return row, true
+	case *proto.RelationshipTarget_SubjectSet:
+		resourceType := strings.TrimSpace(target.SubjectSet.GetResource().GetType())
+		resourceID := strings.TrimSpace(target.SubjectSet.GetResource().GetId())
+		relation := strings.TrimSpace(target.SubjectSet.GetRelation())
+		if resourceType == "" || resourceID == "" {
+			return appAdminMemberRow{}, false
+		}
+		selector := resourceType + ":" + resourceID
+		if relation != "" {
+			selector += "#" + relation
+		}
+		row.SelectorKind = "subject_set"
+		row.SelectorValue = selector
+		return row, true
+	default:
+		return appAdminMemberRow{}, false
+	}
+}
+
+func appAdminMemberSource(layer proto.SourceLayer) (source string, mutable bool) {
+	switch layer {
+	case proto.SourceLayer_SOURCE_LAYER_RUNTIME:
+		return "dynamic", true
+	default:
+		// Static config and unspecified (legacy) grants are treated as locked policy.
+		return "static", false
+	}
+}
+
+func (s *Server) resolveAppAdminMemberEmail(ctx context.Context, subjectID string) string {
+	kind, id, ok := core.ParseSubjectID(subjectID)
+	if !ok || kind != string(principal.KindUser) || s.users == nil {
+		return ""
+	}
+	if strings.Contains(id, "@") {
+		return id
+	}
+	user, err := s.users.GetUser(ctx, id)
+	if err != nil || user == nil {
+		return ""
+	}
+	return strings.TrimSpace(user.Email)
+}

--- a/gestaltd/internal/server/handlers_app_admin_members.go
+++ b/gestaltd/internal/server/handlers_app_admin_members.go
@@ -20,6 +20,7 @@ type appAdminMemberRow struct {
 	Source        string `json:"source"`
 	Mutable       bool   `json:"mutable"`
 	Effective     bool   `json:"effective"`
+	ShadowedBy    string `json:"shadowedBy,omitempty"`
 	SelectorKind  string `json:"selectorKind,omitempty"`
 	SelectorValue string `json:"selectorValue,omitempty"`
 	SubjectID     string `json:"subjectId,omitempty"`
@@ -71,9 +72,36 @@ func (s *Server) listAppAuthorizationMemberRows(ctx context.Context, appName str
 		}
 		pageToken = strings.TrimSpace(resp.GetNextPageToken())
 		if pageToken == "" {
-			return rows, nil
+			return projectAppAdminMemberRoster(rows), nil
 		}
 	}
+}
+
+// memberGrantKey identifies one logical grant for static-over-runtime shadowing.
+func memberGrantKey(row appAdminMemberRow) string {
+	return row.SelectorKind + "\x00" + row.SelectorValue + "\x00" + row.Role
+}
+
+// projectAppAdminMemberRoster owns roster layering: when the same selector+role
+// exists as both static and runtime, the runtime row is marked shadowed.
+func projectAppAdminMemberRoster(rows []appAdminMemberRow) []appAdminMemberRow {
+	staticKeys := make(map[string]struct{})
+	for _, row := range rows {
+		if row.Source == "static" {
+			staticKeys[memberGrantKey(row)] = struct{}{}
+		}
+	}
+	out := make([]appAdminMemberRow, 0, len(rows))
+	for _, row := range rows {
+		if row.Source == "dynamic" {
+			if _, ok := staticKeys[memberGrantKey(row)]; ok {
+				row.Effective = false
+				row.ShadowedBy = "static " + row.Role + " grant"
+			}
+		}
+		out = append(out, row)
+	}
+	return out
 }
 
 func (s *Server) appAdminMemberRowFromRelationship(ctx context.Context, relationship *proto.Relationship) (appAdminMemberRow, bool) {

--- a/gestaltd/internal/server/handlers_app_admin_members_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_members_test.go
@@ -1,0 +1,141 @@
+package server_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/server"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+)
+
+func TestAppAdminMembersList(t *testing.T) {
+	t.Parallel()
+
+	adminID := principal.UserSubjectID("alice")
+	viewerID := principal.UserSubjectID("bob")
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(adminID, "admin", "app", "g-issues"),
+			{
+				Tuple: &proto.RelationshipTuple{
+					Target: &proto.RelationshipTarget{
+						Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{
+							Type: "subject",
+							Id:   viewerID,
+						}},
+					},
+					Relation: "viewer",
+					Resource: &proto.Resource{Type: "app", Id: "g-issues"},
+				},
+				SourceLayer: proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG,
+			},
+			{
+				Tuple: &proto.RelationshipTuple{
+					Target: &proto.RelationshipTarget{
+						Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{
+							Type: "subject",
+							Id:   "service_account:slack-bot",
+						}},
+					},
+					Relation: "viewer",
+					Resource: &proto.Resource{Type: "app", Id: "g-issues"},
+				},
+				SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME,
+			},
+			testAuthorizationRelationship(adminID, "admin", "app", "other-app"),
+		},
+	}
+	// Stamp static layer on the helper-built admin row.
+	authz.relationships[0].SourceLayer = proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", adminID, "")
+		cfg.Authorization = authz
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	request, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/g-issues/admin/members", nil)
+	request.Header.Set("Authorization", "Bearer alice-token")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET members: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("GET status = %d: %s", response.StatusCode, body)
+	}
+
+	var rows []struct {
+		Role          string `json:"role"`
+		Source        string `json:"source"`
+		Mutable       bool   `json:"mutable"`
+		Effective     bool   `json:"effective"`
+		SelectorKind  string `json:"selectorKind"`
+		SelectorValue string `json:"selectorValue"`
+		SubjectID     string `json:"subjectId"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&rows); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("members = %#v, want 3 rows for g-issues only", rows)
+	}
+
+	bySubject := map[string]struct {
+		Role    string
+		Source  string
+		Mutable bool
+	}{}
+	for _, row := range rows {
+		if !row.Effective || row.SelectorKind != "subject_id" {
+			t.Fatalf("unexpected row %#v", row)
+		}
+		bySubject[row.SubjectID] = struct {
+			Role    string
+			Source  string
+			Mutable bool
+		}{Role: row.Role, Source: row.Source, Mutable: row.Mutable}
+	}
+	if got := bySubject[adminID]; got.Role != "admin" || got.Source != "static" || got.Mutable {
+		t.Fatalf("admin row = %#v", got)
+	}
+	if got := bySubject[viewerID]; got.Role != "viewer" || got.Source != "static" || got.Mutable {
+		t.Fatalf("viewer row = %#v", got)
+	}
+	if got := bySubject["service_account:slack-bot"]; got.Role != "viewer" || got.Source != "dynamic" || !got.Mutable {
+		t.Fatalf("service account row = %#v", got)
+	}
+}
+
+func TestAppAdminMembersListForbiddenWithoutAdmin(t *testing.T) {
+	t.Parallel()
+
+	viewerID := principal.UserSubjectID("bob")
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(viewerID, "viewer", "app", "g-issues"),
+		},
+	}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("bob-token", viewerID, "")
+		cfg.Authorization = authz
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	request, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/g-issues/admin/members", nil)
+	request.Header.Set("Authorization", "Bearer bob-token")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET members: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("GET status = %d, want 403: %s", response.StatusCode, body)
+	}
+}

--- a/gestaltd/internal/server/handlers_app_admin_members_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_members_test.go
@@ -112,6 +112,165 @@ func TestAppAdminMembersList(t *testing.T) {
 	}
 }
 
+func TestAppAdminMembersListShadowsRuntimeDuplicate(t *testing.T) {
+	t.Parallel()
+
+	adminID := principal.UserSubjectID("alice")
+	viewerID := principal.UserSubjectID("bob")
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(adminID, "admin", "app", "g-issues"),
+			{
+				Tuple: &proto.RelationshipTuple{
+					Target: &proto.RelationshipTarget{
+						Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{
+							Type: "subject",
+							Id:   viewerID,
+						}},
+					},
+					Relation: "viewer",
+					Resource: &proto.Resource{Type: "app", Id: "g-issues"},
+				},
+				SourceLayer: proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG,
+			},
+			{
+				Tuple: &proto.RelationshipTuple{
+					Target: &proto.RelationshipTarget{
+						Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{
+							Type: "subject",
+							Id:   viewerID,
+						}},
+					},
+					Relation: "viewer",
+					Resource: &proto.Resource{Type: "app", Id: "g-issues"},
+				},
+				SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME,
+			},
+		},
+	}
+	authz.relationships[0].SourceLayer = proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", adminID, "")
+		cfg.Authorization = authz
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	request, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/g-issues/admin/members", nil)
+	request.Header.Set("Authorization", "Bearer alice-token")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET members: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("GET status = %d: %s", response.StatusCode, body)
+	}
+
+	var rows []struct {
+		Role       string `json:"role"`
+		Source     string `json:"source"`
+		Effective  bool   `json:"effective"`
+		ShadowedBy string `json:"shadowedBy"`
+		SubjectID  string `json:"subjectId"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&rows); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	var staticViewer, dynamicViewer *struct {
+		Role       string `json:"role"`
+		Source     string `json:"source"`
+		Effective  bool   `json:"effective"`
+		ShadowedBy string `json:"shadowedBy"`
+		SubjectID  string `json:"subjectId"`
+	}
+	for i := range rows {
+		row := &rows[i]
+		if row.SubjectID != viewerID || row.Role != "viewer" {
+			continue
+		}
+		switch row.Source {
+		case "static":
+			staticViewer = row
+		case "dynamic":
+			dynamicViewer = row
+		}
+	}
+	if staticViewer == nil || !staticViewer.Effective || staticViewer.ShadowedBy != "" {
+		t.Fatalf("static viewer = %#v", staticViewer)
+	}
+	if dynamicViewer == nil || dynamicViewer.Effective || dynamicViewer.ShadowedBy != "static viewer grant" {
+		t.Fatalf("dynamic viewer = %#v", dynamicViewer)
+	}
+}
+
+func TestAppAdminMembersListSubjectSet(t *testing.T) {
+	t.Parallel()
+
+	adminID := principal.UserSubjectID("alice")
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(adminID, "admin", "app", "g-issues"),
+			{
+				Tuple: &proto.RelationshipTuple{
+					Target: &proto.RelationshipTarget{
+						Kind: &proto.RelationshipTarget_SubjectSet{
+							SubjectSet: &proto.SubjectSet{
+								Resource: &proto.Resource{Type: "group", Id: "eng"},
+								Relation: "member",
+							},
+						},
+					},
+					Relation: "viewer",
+					Resource: &proto.Resource{Type: "app", Id: "g-issues"},
+				},
+				SourceLayer: proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG,
+			},
+		},
+	}
+	authz.relationships[0].SourceLayer = proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", adminID, "")
+		cfg.Authorization = authz
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	request, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/g-issues/admin/members", nil)
+	request.Header.Set("Authorization", "Bearer alice-token")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET members: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("GET status = %d: %s", response.StatusCode, body)
+	}
+
+	var rows []struct {
+		Role          string `json:"role"`
+		SelectorKind  string `json:"selectorKind"`
+		SelectorValue string `json:"selectorValue"`
+		SubjectID     string `json:"subjectId"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&rows); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	found := false
+	for _, row := range rows {
+		if row.SelectorKind == "subject_set" && row.SelectorValue == "group:eng#member" && row.Role == "viewer" && row.SubjectID == "" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("subject_set row missing: %#v", rows)
+	}
+}
+
 func TestAppAdminMembersListForbiddenWithoutAdmin(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -6,6 +6,7 @@ import (
 
 func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 	s.mountAppAdminRegistryRoutes(r)
+	s.mountAppAdminMembersRoutes(r)
 
 	r.Group(func(r chi.Router) {
 		r.Use(s.authMiddleware)


### PR DESCRIPTION
## Summary

Adds `GET /api/v1/apps/{app}/admin/members` so app admins can read the per-app authorization roster (people and service accounts) for the gestalt-providers Members UI—without restoring the removed admin write APIs.

## Why / context

App workspace Members expects a per-app roster gated like other app-admin surfaces. Opening public authorization relationship APIs would widen the wrong boundary; this endpoint reuses the existing explicit `admin` on `app/{app}` middleware used by registry admin.

## What changed

- Mount read-only `GET /apps/{app}/admin/members` behind `pluginRouteAuthMiddleware("app")` + `appAdminAuthorizationMiddleware`
- List relationships for `app/{app}` (static + runtime), map to the Members UI row shape (`role`, `source`, `mutable`, `effective`, `shadowedBy`, selectors, optional email for `user:` subjects)
- Roster projection marks runtime grants that duplicate a static selector+role as `effective: false` with `shadowedBy: "static <role> grant"`
- Subject-set targets are returned as selector rows; non-user subjects skip email enrichment

## Validation

- [x] Automated: `go test ./internal/server/ -run TestAppAdminMembers` (list, static-over-runtime shadowing, subject_set, forbidden without admin)
- [ ] Manual after deploy: as app admin, `GET /api/v1/apps/g-issues/admin/members` returns admin/viewer/SA rows
- [ ] Manual after deploy: as viewer-only, same path returns 403
- [ ] Pair with gestalt-providers Members UI against this endpoint

## Reviewer focus

- Confirm the authz gate matches registry admin (`hasExplicitAppAdmin`) and is not gestaltAdmin-only
- Confirm static-over-runtime shadowing key (`selectorKind` + `selectorValue` + `role`) matches product expectations for locked policy grants

## Rollout / compatibility

- Additive HTTP route only; no config/schema migration
- Deploy gestaltd before relying on Members nav (UI probes this route and hides the tab on 404/403)
- No write surface restored

## Links

Pairs with gestalt-providers app-admin Members read UI.