### PR TITLE
Allow app admins to look up users by email

### DIFF
--- a/docs/content/client/cli/index.mdx
+++ b/docs/content/client/cli/index.mdx
@@ -33,7 +33,7 @@ asIndexPage: true
 | `gestalt agent sessions ...` | Create, list, inspect, and update agent sessions. |
 | `gestalt agent turns ...` | Create, list, inspect, cancel, and stream agent turns. |
 | `gestalt tokens create\|list\|revoke` | Manage Gestalt API tokens. |
-| `gestalt users lookup EMAIL` | Look up a user's UUID and `user:<uuid>` subject ID by email (requires gestalt admin). |
+| `gestalt users lookup EMAIL` | Look up a user's UUID and `user:<uuid>` subject ID by email (requires gestalt admin or app admin). |
 
 ## URL resolution
 

--- a/gestaltd/internal/server/handlers_app_admin_registry.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry.go
@@ -252,34 +252,16 @@ func (s *Server) hasAnyExplicitAppAdmin(ctx context.Context, subjectID string) (
 	if s == nil || s.authorization == nil {
 		return false, errors.New("authorization is unavailable")
 	}
-	pageToken := ""
-	for {
-		resp, err := s.authorization.ListRelationships(ctx, &proto.ListRelationshipsRequest{
-			Filter: &proto.RelationshipFilter{
-				Target: &proto.RelationshipTarget{
-					Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{
-						Type: "subject",
-						Id:   strings.TrimSpace(subjectID),
-					}},
-				},
-				Relation: "admin",
-			},
-			PageSize:  500,
-			PageToken: pageToken,
-		})
+	for appName := range s.pluginDefs {
+		allowed, err := s.hasExplicitAppAdmin(ctx, subjectID, appName)
 		if err != nil {
 			return false, err
 		}
-		for _, relationship := range resp.GetRelationships() {
-			if relationship.GetTuple().GetResource().GetType() == "app" {
-				return true, nil
-			}
-		}
-		pageToken = strings.TrimSpace(resp.GetNextPageToken())
-		if pageToken == "" {
-			return false, nil
+		if allowed {
+			return true, nil
 		}
 	}
+	return false, nil
 }
 
 func (s *Server) getAppAdminRegistry(w http.ResponseWriter, r *http.Request) {

--- a/gestaltd/internal/server/handlers_app_admin_registry.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry.go
@@ -245,6 +245,43 @@ func (s *Server) hasExplicitAppAdmin(ctx context.Context, subjectID, appName str
 	}
 }
 
+// hasAnyExplicitAppAdmin reports whether subjectID has an explicit admin grant on
+// any app resource. This is a coarse gate for operator workflows like user
+// lookup until finer-grained authorization is wired in.
+func (s *Server) hasAnyExplicitAppAdmin(ctx context.Context, subjectID string) (bool, error) {
+	if s == nil || s.authorization == nil {
+		return false, errors.New("authorization is unavailable")
+	}
+	pageToken := ""
+	for {
+		resp, err := s.authorization.ListRelationships(ctx, &proto.ListRelationshipsRequest{
+			Filter: &proto.RelationshipFilter{
+				Target: &proto.RelationshipTarget{
+					Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{
+						Type: "subject",
+						Id:   strings.TrimSpace(subjectID),
+					}},
+				},
+				Relation: "admin",
+			},
+			PageSize:  500,
+			PageToken: pageToken,
+		})
+		if err != nil {
+			return false, err
+		}
+		for _, relationship := range resp.GetRelationships() {
+			if relationship.GetTuple().GetResource().GetType() == "app" {
+				return true, nil
+			}
+		}
+		pageToken = strings.TrimSpace(resp.GetNextPageToken())
+		if pageToken == "" {
+			return false, nil
+		}
+	}
+}
+
 func (s *Server) getAppAdminRegistry(w http.ResponseWriter, r *http.Request) {
 	app, registry, ok := s.appAdminRegistryConfig(w, r)
 	if !ok {

--- a/gestaltd/internal/server/handlers_users.go
+++ b/gestaltd/internal/server/handlers_users.go
@@ -17,7 +17,7 @@ type userLookupResponse struct {
 }
 
 func (s *Server) lookupUserByEmail(w http.ResponseWriter, r *http.Request) {
-	if _, ok := s.requireGestaltAdmin(w, r); !ok {
+	if _, ok := s.requireUserLookupAccess(w, r); !ok {
 		return
 	}
 	if s.users == nil {
@@ -50,6 +50,52 @@ func (s *Server) lookupUserByEmail(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) requireGestaltAdmin(w http.ResponseWriter, r *http.Request) (*principal.Principal, bool) {
+	p, ok := s.requireAuthenticatedUserCaller(w, r)
+	if !ok {
+		return nil, false
+	}
+
+	_, allowed, err := s.authorizeMountedAppAccess(r.Context(), p, s.adminMountedUI())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to authorize request")
+		return nil, false
+	}
+	if !allowed {
+		writeError(w, http.StatusForbidden, "gestalt admin access required")
+		return nil, false
+	}
+	return p, true
+}
+
+func (s *Server) requireUserLookupAccess(w http.ResponseWriter, r *http.Request) (*principal.Principal, bool) {
+	p, ok := s.requireAuthenticatedUserCaller(w, r)
+	if !ok {
+		return nil, false
+	}
+
+	_, gestaltAdmin, err := s.authorizeMountedAppAccess(r.Context(), p, s.adminMountedUI())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to authorize request")
+		return nil, false
+	}
+	if gestaltAdmin {
+		return p, true
+	}
+
+	subjectID := strings.TrimSpace(principal.Canonicalized(p).SubjectID)
+	appAdmin, err := s.hasAnyExplicitAppAdmin(r.Context(), subjectID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to authorize request")
+		return nil, false
+	}
+	if !appAdmin {
+		writeError(w, http.StatusForbidden, "gestalt admin or app admin access required")
+		return nil, false
+	}
+	return p, true
+}
+
+func (s *Server) requireAuthenticatedUserCaller(w http.ResponseWriter, r *http.Request) (*principal.Principal, bool) {
 	p, err := s.resolveRequestPrincipalWithUserID(r)
 	switch {
 	case errors.Is(err, errInvalidAuthorizationHeader):
@@ -66,16 +112,6 @@ func (s *Server) requireGestaltAdmin(w http.ResponseWriter, r *http.Request) (*p
 		return nil, false
 	}
 	if err := requireUserCaller(w, p); err != nil {
-		return nil, false
-	}
-
-	_, allowed, err := s.authorizeMountedAppAccess(r.Context(), p, s.adminMountedUI())
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to authorize request")
-		return nil, false
-	}
-	if !allowed {
-		writeError(w, http.StatusForbidden, "gestalt admin access required")
 		return nil, false
 	}
 	return p, true

--- a/gestaltd/internal/server/handlers_users.go
+++ b/gestaltd/internal/server/handlers_users.go
@@ -49,24 +49,6 @@ func (s *Server) lookupUserByEmail(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func (s *Server) requireGestaltAdmin(w http.ResponseWriter, r *http.Request) (*principal.Principal, bool) {
-	p, ok := s.requireAuthenticatedUserCaller(w, r)
-	if !ok {
-		return nil, false
-	}
-
-	_, allowed, err := s.authorizeMountedAppAccess(r.Context(), p, s.adminMountedUI())
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to authorize request")
-		return nil, false
-	}
-	if !allowed {
-		writeError(w, http.StatusForbidden, "gestalt admin access required")
-		return nil, false
-	}
-	return p, true
-}
-
 func (s *Server) requireUserLookupAccess(w http.ResponseWriter, r *http.Request) (*principal.Principal, bool) {
 	p, ok := s.requireAuthenticatedUserCaller(w, r)
 	if !ok {

--- a/gestaltd/internal/server/handlers_users_test.go
+++ b/gestaltd/internal/server/handlers_users_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/server"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
@@ -176,6 +177,11 @@ func newAuthorizedUserLookupTestServer(t *testing.T, grants userLookupTestGrants
 	}
 
 	return newTestServer(t, func(cfg *server.Config) {
+		if grants.appAdmin != "" {
+			cfg.AppDefs = map[string]*config.ProviderEntry{
+				grants.appAdmin: {},
+			}
+		}
 		cfg.Auth = coretesting.NamedIntrospectIdentityStub("test", func(_ context.Context, token string) (*core.UserIdentity, error) {
 			if token != "session-token" {
 				return nil, core.ErrNotFound

--- a/gestaltd/internal/server/handlers_users_test.go
+++ b/gestaltd/internal/server/handlers_users_test.go
@@ -20,7 +20,7 @@ import (
 func TestLookupUserByEmailRequiresAuthentication(t *testing.T) {
 	t.Parallel()
 
-	ts := newAuthorizedUserLookupTestServer(t, true)
+	ts := newAuthorizedUserLookupTestServer(t, userLookupTestGrants{gestaltAdmin: true})
 	testutil.CloseOnCleanup(t, ts)
 
 	resp, err := http.Get(ts.URL + "/api/v1/users/lookup?email=admin-api-user%40example.test")
@@ -34,10 +34,10 @@ func TestLookupUserByEmailRequiresAuthentication(t *testing.T) {
 	}
 }
 
-func TestLookupUserByEmailRequiresGestaltAdmin(t *testing.T) {
+func TestLookupUserByEmailRequiresAdminAccess(t *testing.T) {
 	t.Parallel()
 
-	ts := newAuthorizedUserLookupTestServer(t, false)
+	ts := newAuthorizedUserLookupTestServer(t, userLookupTestGrants{})
 	testutil.CloseOnCleanup(t, ts)
 
 	req, err := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/users/lookup?email=admin-api-user%40example.test", nil)
@@ -57,10 +57,33 @@ func TestLookupUserByEmailRequiresGestaltAdmin(t *testing.T) {
 	}
 }
 
+func TestLookupUserByEmailAllowsAppAdmin(t *testing.T) {
+	t.Parallel()
+
+	ts := newAuthorizedUserLookupTestServer(t, userLookupTestGrants{appAdmin: "traffic-cop"})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/users/lookup?email=admin-api-user%40example.test", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "session-token"})
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET user lookup: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
+	}
+}
+
 func TestLookupUserByEmailReturnsSubjectID(t *testing.T) {
 	t.Parallel()
 
-	ts := newAuthorizedUserLookupTestServer(t, true)
+	ts := newAuthorizedUserLookupTestServer(t, userLookupTestGrants{gestaltAdmin: true})
 	testutil.CloseOnCleanup(t, ts)
 
 	req, err := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/users/lookup?email=admin-api-user%40example.test", nil)
@@ -101,7 +124,7 @@ func TestLookupUserByEmailReturnsSubjectID(t *testing.T) {
 func TestLookupUserByEmailNotFound(t *testing.T) {
 	t.Parallel()
 
-	ts := newAuthorizedUserLookupTestServer(t, true)
+	ts := newAuthorizedUserLookupTestServer(t, userLookupTestGrants{gestaltAdmin: true})
 	testutil.CloseOnCleanup(t, ts)
 
 	req, err := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/users/lookup?email=missing%40example.test", nil)
@@ -121,19 +144,27 @@ func TestLookupUserByEmailNotFound(t *testing.T) {
 	}
 }
 
-func newAuthorizedUserLookupTestServer(t *testing.T, grantAdmin bool) *httptest.Server {
+func newAuthorizedUserLookupTestServer(t *testing.T, grants userLookupTestGrants) *httptest.Server {
 	t.Helper()
 
 	svc := testutil.NewStubServices(t)
 	user := seedUserRecord(t, svc, "admin-api-user", "admin-api-user@example.test", time.Now())
 
 	relationships := []*proto.Relationship(nil)
-	if grantAdmin {
+	if grants.gestaltAdmin {
 		relationships = append(relationships, testAuthorizationRelationship(
 			principal.UserSubjectID(user.ID),
 			"admin",
 			"gestaltAdmin",
 			"gestaltAdmin",
+		))
+	}
+	if grants.appAdmin != "" {
+		relationships = append(relationships, testAuthorizationRelationship(
+			principal.UserSubjectID(user.ID),
+			"admin",
+			"app",
+			grants.appAdmin,
 		))
 	}
 
@@ -157,4 +188,9 @@ func newAuthorizedUserLookupTestServer(t *testing.T, grantAdmin bool) *httptest.
 			_, _ = w.Write([]byte("admin-shell"))
 		})
 	})
+}
+
+type userLookupTestGrants struct {
+	gestaltAdmin bool
+	appAdmin     string
 }


### PR DESCRIPTION
## Summary
- Expands `GET /api/v1/users/lookup` (and `gestalt users lookup`) beyond gestalt admins to any user with an explicit `admin` relationship on an `app` resource.
- Adds `hasAnyExplicitAppAdmin` as a coarse, hardcoded gate for now — enough for Traffic Cop / app registry operators who grant access via deploy config but are not gestalt admins.

## Test plan
- [x] `go test ./gestaltd/internal/server -run LookupUserByEmail`
- [ ] Merge and bump gestaltd on toolshed so valon.tools picks up the change
- [ ] Verify a traffic-cop app admin (non-gestalt-admin) can run user lookup


Made with [Cursor](https://cursor.com)