### PR TITLE
Release gestalt CLI v0.0.2-alpha.14

### DIFF
--- a/gestalt/Cargo.toml
+++ b/gestalt/Cargo.toml
@@ -3,5 +3,5 @@ resolver = "2"
 members = ["cli"]
 
 [workspace.package]
-version = "0.0.2-alpha.13"
+version = "0.0.2-alpha.14"
 edition = "2024"


### PR DESCRIPTION
## Summary
- Bump gestalt CLI workspace version to `0.0.2-alpha.14`
- Ships `gestalt users lookup` (added in #3054) to Homebrew and the install script

## Test plan
- [x] `cargo test` in `gestalt/` passes locally
- [ ] After merge: tag `gestalt/v0.0.2-alpha.14` to trigger release workflow
- [ ] `brew upgrade valon-technologies/gestalt/gestalt` installs new version
- [ ] `GESTALT_URL=https://valon.tools gestalt users lookup user@valon.com` works


Made with [Cursor](https://cursor.com)