### PR TITLE
Add federated logout for OIDC identity providers

### DIFF
--- a/gestaltd/internal/server/handlers_auth.go
+++ b/gestaltd/internal/server/handlers_auth.go
@@ -672,6 +672,73 @@ func (s *Server) clearLoginStateCookie(w http.ResponseWriter) {
 	})
 }
 
+type federatedLogoutProvider interface {
+	FederatedLogoutURL(returnTo string) (string, error)
+}
+
+func (s *Server) federatedLogoutURL(returnTo string) (string, error) {
+	if s == nil || s.auth == nil {
+		return "", errors.New("auth is not configured")
+	}
+	provider, ok := s.auth.(federatedLogoutProvider)
+	if !ok {
+		return "", errors.New("federated logout is not supported")
+	}
+	return provider.FederatedLogoutURL(returnTo)
+}
+
+func (s *Server) logoutReturnURL(r *http.Request) (string, error) {
+	returnPath, err := resolveLoginRedirectPath(r.URL.Query().Get("returnTo"), s.allowedLoginRedirectBaseURLs())
+	if err != nil {
+		return "", err
+	}
+	if returnPath == "" {
+		returnPath = "/"
+	}
+	return s.resolvePublicURL(r, returnPath)
+}
+
+func (s *Server) logoutBrowser(w http.ResponseWriter, r *http.Request) {
+	auditAllowed := false
+	auditErr := errors.New("logout failed")
+	var auditPrincipal *principal.Principal
+	if !s.noAuth {
+		p, err := s.resolveRequestPrincipalWithUserID(r)
+		switch {
+		case err == nil:
+			auditPrincipal = p
+		case errors.Is(err, errInvalidAuthorizationHeader), errors.Is(err, principal.ErrInvalidToken):
+			slog.InfoContext(r.Context(), "logout: unable to resolve caller for audit", "error", err)
+		default:
+			slog.WarnContext(r.Context(), "logout: unable to resolve caller for audit", "error", err)
+		}
+	}
+	defer func() {
+		s.auditHTTPEvent(r.Context(), auditPrincipal, s.authProviderName(), "auth.logout", auditAllowed, auditErr)
+	}()
+
+	s.clearSessionCookie(w)
+	auditAllowed = true
+	auditErr = nil
+
+	returnTo, err := s.logoutReturnURL(r)
+	if err != nil {
+		slog.WarnContext(r.Context(), "logout return url resolution failed", "error", err)
+		http.Redirect(w, r, "/", http.StatusFound)
+		return
+	}
+	if logoutURL, err := s.federatedLogoutURL(returnTo); err == nil && strings.TrimSpace(logoutURL) != "" {
+		http.Redirect(w, r, logoutURL, http.StatusFound)
+		return
+	}
+	parsed, err := url.Parse(returnTo)
+	if err != nil || parsed.Path == "" {
+		http.Redirect(w, r, "/", http.StatusFound)
+		return
+	}
+	http.Redirect(w, r, parsed.RequestURI(), http.StatusFound)
+}
+
 func (s *Server) logout(w http.ResponseWriter, r *http.Request) {
 	auditAllowed := false
 	auditErr := errors.New("logout failed")
@@ -698,5 +765,11 @@ func (s *Server) logout(w http.ResponseWriter, r *http.Request) {
 	s.clearSessionCookie(w)
 	auditAllowed = true
 	auditErr = nil
-	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	resp := map[string]string{"status": "ok"}
+	if returnTo, err := s.logoutReturnURL(r); err == nil {
+		if logoutURL, err := s.federatedLogoutURL(returnTo); err == nil && strings.TrimSpace(logoutURL) != "" {
+			resp["redirect"] = logoutURL
+		}
+	}
+	writeJSON(w, http.StatusOK, resp)
 }

--- a/gestaltd/internal/server/routes_auth.go
+++ b/gestaltd/internal/server/routes_auth.go
@@ -7,6 +7,7 @@ func (s *Server) mountAuthRoutes(r chi.Router) {
 	r.Get("/auth/login", s.startBrowserLogin)
 	r.Post("/auth/login", s.startLogin)
 	r.Get("/auth/login/callback", s.loginCallback)
+	r.Get("/auth/logout", s.logoutBrowser)
 	r.Post("/auth/logout", s.logout)
 	r.Get("/auth/callback", s.integrationOAuthCallback)
 	r.Post("/auth/pending-connection", s.selectPendingConnection)


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/auth/logout` that clears the Gestalt `session_token` cookie and redirects to the upstream IdP federated logout URL (Auth0 `/v2/logout`).
- Extend `POST /api/v1/auth/logout` to return an optional `redirect` field when the identity provider supports federated logout.
- Fixes valon.tools logout where users stayed signed in via Auth0 SSO after clicking Log out.

## Test plan
- [x] `go test ./internal/server/ -run TestLogout`
- [ ] After deploy: click Log out on valon.tools → lands on home page, not auto-logged back in
- [ ] Verify `returnTo` is in Auth0 application Allowed Logout URLs

## Related
- gestalt-providers: https://github.com/valon-technologies/gestalt-providers/pull/1244
- toolshed bump + deploy required after both merge