### PR TITLE
Fix federated logout for remote OIDC identity providers

### DIFF
--- a/gestaltd/internal/server/handlers_auth.go
+++ b/gestaltd/internal/server/handlers_auth.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	identityservice "github.com/valon-technologies/gestalt/server/services/identity"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
 )
@@ -672,22 +673,27 @@ func (s *Server) clearLoginStateCookie(w http.ResponseWriter) {
 	})
 }
 
-type federatedLogoutProvider interface {
-	FederatedLogoutURL(returnTo string) (string, error)
+func (s *Server) logoutAuthRuntime(returnPath string) authRuntime {
+	auth := s.serverAuthRuntime()
+	returnPath = strings.TrimSpace(returnPath)
+	if returnPath == "" {
+		return auth
+	}
+	runtime, err := s.loginAuthRuntimeForNextPath(returnPath)
+	if err != nil {
+		return auth
+	}
+	return runtime
 }
 
-func (s *Server) federatedLogoutURL(returnTo string) (string, error) {
-	if s == nil || s.auth == nil {
+func (s *Server) federatedLogoutURL(auth authRuntime, returnTo string) (string, error) {
+	if auth.noAuth || auth.provider == nil {
 		return "", errors.New("auth is not configured")
 	}
-	provider, ok := s.auth.(federatedLogoutProvider)
-	if !ok {
-		return "", errors.New("federated logout is not supported")
-	}
-	return provider.FederatedLogoutURL(returnTo)
+	return identityservice.FederatedLogoutURL(auth.provider, returnTo)
 }
 
-func (s *Server) logoutReturnURL(r *http.Request) (string, error) {
+func (s *Server) logoutReturnPath(r *http.Request) (string, error) {
 	returnPath, err := resolveLoginRedirectPath(r.URL.Query().Get("returnTo"), s.allowedLoginRedirectBaseURLs())
 	if err != nil {
 		return "", err
@@ -695,6 +701,10 @@ func (s *Server) logoutReturnURL(r *http.Request) (string, error) {
 	if returnPath == "" {
 		returnPath = "/"
 	}
+	return returnPath, nil
+}
+
+func (s *Server) logoutReturnURL(r *http.Request, returnPath string) (string, error) {
 	return s.resolvePublicURL(r, returnPath)
 }
 
@@ -721,22 +731,24 @@ func (s *Server) logoutBrowser(w http.ResponseWriter, r *http.Request) {
 	auditAllowed = true
 	auditErr = nil
 
-	returnTo, err := s.logoutReturnURL(r)
+	returnPath, err := s.logoutReturnPath(r)
 	if err != nil {
 		slog.WarnContext(r.Context(), "logout return url resolution failed", "error", err)
 		http.Redirect(w, r, "/", http.StatusFound)
 		return
 	}
-	if logoutURL, err := s.federatedLogoutURL(returnTo); err == nil && strings.TrimSpace(logoutURL) != "" {
-		http.Redirect(w, r, logoutURL, http.StatusFound)
-		return
-	}
-	parsed, err := url.Parse(returnTo)
-	if err != nil || parsed.Path == "" {
+	auth := s.logoutAuthRuntime(returnPath)
+	returnTo, err := s.logoutReturnURL(r, returnPath)
+	if err != nil {
+		slog.WarnContext(r.Context(), "logout return url resolution failed", "error", err)
 		http.Redirect(w, r, "/", http.StatusFound)
 		return
 	}
-	http.Redirect(w, r, parsed.RequestURI(), http.StatusFound)
+	if logoutURL, err := s.federatedLogoutURL(auth, returnTo); err == nil && strings.TrimSpace(logoutURL) != "" {
+		http.Redirect(w, r, logoutURL, http.StatusFound)
+		return
+	}
+	http.Redirect(w, r, returnTo, http.StatusFound)
 }
 
 func (s *Server) logout(w http.ResponseWriter, r *http.Request) {
@@ -766,9 +778,12 @@ func (s *Server) logout(w http.ResponseWriter, r *http.Request) {
 	auditAllowed = true
 	auditErr = nil
 	resp := map[string]string{"status": "ok"}
-	if returnTo, err := s.logoutReturnURL(r); err == nil {
-		if logoutURL, err := s.federatedLogoutURL(returnTo); err == nil && strings.TrimSpace(logoutURL) != "" {
-			resp["redirect"] = logoutURL
+	if returnPath, err := s.logoutReturnPath(r); err == nil {
+		auth := s.logoutAuthRuntime(returnPath)
+		if returnTo, err := s.logoutReturnURL(r, returnPath); err == nil {
+			if logoutURL, err := s.federatedLogoutURL(auth, returnTo); err == nil && strings.TrimSpace(logoutURL) != "" {
+				resp["redirect"] = logoutURL
+			}
 		}
 	}
 	writeJSON(w, http.StatusOK, resp)

--- a/gestaltd/services/identity/client.go
+++ b/gestaltd/services/identity/client.go
@@ -42,13 +42,15 @@ type ExecConfig struct {
 }
 
 type remoteIdentityProvider struct {
-	runtime     proto.ProviderLifecycleClient
-	client      identityRPCClient
-	name        string
-	displayName string
-	description string
-	callbackURL string
-	closer      io.Closer
+	runtime       proto.ProviderLifecycleClient
+	client        identityRPCClient
+	name          string
+	displayName   string
+	description   string
+	callbackURL   string
+	oidcIssuerURL string
+	oidcClientID  string
+	closer        io.Closer
 }
 
 func NewExecutable(ctx context.Context, cfg ExecConfig) (core.IdentityProvider, error) {
@@ -129,7 +131,12 @@ func (p *remoteIdentityProvider) configure(ctx context.Context, name string, con
 		p.displayName = meta.DisplayName
 		p.description = meta.Description
 	}
+	p.oidcIssuerURL, p.oidcClientID = oidcLogoutConfigFromMap(config)
 	return nil
+}
+
+func (p *remoteIdentityProvider) FederatedLogoutURL(returnTo string) (string, error) {
+	return BuildOIDCFederatedLogoutURL(p.oidcIssuerURL, p.oidcClientID, returnTo)
 }
 
 func (p *remoteIdentityProvider) DisplayName() string {
@@ -382,7 +389,8 @@ func mapIdentityProviderRPCError(err error) error {
 }
 
 var (
-	_ core.IdentityProvider = (*remoteIdentityProvider)(nil)
+	_ core.IdentityProvider     = (*remoteIdentityProvider)(nil)
+	_ FederatedLogoutProvider   = (*remoteIdentityProvider)(nil)
 	_ interface {
 		DisplayName() string
 		Description() string

--- a/gestaltd/services/identity/client.go
+++ b/gestaltd/services/identity/client.go
@@ -389,8 +389,8 @@ func mapIdentityProviderRPCError(err error) error {
 }
 
 var (
-	_ core.IdentityProvider     = (*remoteIdentityProvider)(nil)
-	_ FederatedLogoutProvider   = (*remoteIdentityProvider)(nil)
+	_ core.IdentityProvider   = (*remoteIdentityProvider)(nil)
+	_ FederatedLogoutProvider = (*remoteIdentityProvider)(nil)
 	_ interface {
 		DisplayName() string
 		Description() string

--- a/gestaltd/services/identity/federated_logout.go
+++ b/gestaltd/services/identity/federated_logout.go
@@ -1,0 +1,66 @@
+package identity
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/core"
+)
+
+// FederatedLogoutProvider is implemented by identity providers that can build
+// an upstream SSO logout URL.
+type FederatedLogoutProvider interface {
+	FederatedLogoutURL(returnTo string) (string, error)
+}
+
+// FederatedLogoutURL returns the upstream federated logout URL when supported.
+func FederatedLogoutURL(provider core.IdentityProvider, returnTo string) (string, error) {
+	if provider == nil {
+		return "", errors.New("auth is not configured")
+	}
+	federated, ok := provider.(FederatedLogoutProvider)
+	if !ok {
+		return "", errors.New("federated logout is not supported")
+	}
+	return federated.FederatedLogoutURL(returnTo)
+}
+
+// BuildOIDCFederatedLogoutURL builds an OIDC/Auth0-style /v2/logout URL.
+func BuildOIDCFederatedLogoutURL(issuerURL, clientID, returnTo string) (string, error) {
+	returnTo = strings.TrimSpace(returnTo)
+	if returnTo == "" {
+		return "", fmt.Errorf("oidc auth: returnTo is required")
+	}
+	issuer := strings.TrimRight(strings.TrimSpace(issuerURL), "/")
+	clientID = strings.TrimSpace(clientID)
+	if issuer == "" || clientID == "" {
+		return "", fmt.Errorf("oidc auth: federated logout is not configured")
+	}
+	parsed, err := url.Parse(issuer + "/v2/logout")
+	if err != nil {
+		return "", fmt.Errorf("oidc auth: build logout url: %w", err)
+	}
+	query := parsed.Query()
+	query.Set("client_id", clientID)
+	query.Set("returnTo", returnTo)
+	parsed.RawQuery = query.Encode()
+	return parsed.String(), nil
+}
+
+func oidcLogoutConfigFromMap(config map[string]any) (issuerURL, clientID string) {
+	if len(config) == 0 {
+		return "", ""
+	}
+	return configString(config, "issuerUrl"), configString(config, "clientId")
+}
+
+func configString(config map[string]any, key string) string {
+	raw, ok := config[key]
+	if !ok || raw == nil {
+		return ""
+	}
+	value, _ := raw.(string)
+	return strings.TrimSpace(value)
+}

--- a/gestaltd/services/identity/federated_logout_test.go
+++ b/gestaltd/services/identity/federated_logout_test.go
@@ -1,0 +1,37 @@
+package identity
+
+import "testing"
+
+func TestBuildOIDCFederatedLogoutURL(t *testing.T) {
+	t.Parallel()
+
+	got, err := BuildOIDCFederatedLogoutURL(
+		"https://tenant.us.auth0.com/",
+		"client-id",
+		"https://valon.tools/apps",
+	)
+	if err != nil {
+		t.Fatalf("BuildOIDCFederatedLogoutURL() error = %v", err)
+	}
+	want := "https://tenant.us.auth0.com/v2/logout?client_id=client-id&returnTo=https%3A%2F%2Fvalon.tools%2Fapps"
+	if got != want {
+		t.Fatalf("BuildOIDCFederatedLogoutURL() = %q, want %q", got, want)
+	}
+}
+
+func TestRemoteIdentityProviderFederatedLogoutURL(t *testing.T) {
+	t.Parallel()
+
+	provider := &remoteIdentityProvider{
+		oidcIssuerURL: "https://tenant.us.auth0.com/",
+		oidcClientID:  "client-id",
+	}
+	got, err := provider.FederatedLogoutURL("https://valon.tools/")
+	if err != nil {
+		t.Fatalf("FederatedLogoutURL() error = %v", err)
+	}
+	want := "https://tenant.us.auth0.com/v2/logout?client_id=client-id&returnTo=https%3A%2F%2Fvalon.tools%2F"
+	if got != want {
+		t.Fatalf("FederatedLogoutURL() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
Addresses Bugbot findings on #3058:

- **High:** Federated logout never reached OIDC providers because production loads them as `remoteIdentityProvider` subprocesses. The type assert on `s.auth` always failed, so logout only cleared the local cookie and left Auth0 SSO active.
- **Medium:** Logout now resolves the route-specific identity provider (same as login) instead of always using the server-default auth.
- **Medium:** Local logout fallback redirects preserve absolute management `returnTo` URLs instead of stripping the origin via `RequestURI()`.

## Changes
- Store `issuerUrl` / `clientId` from provider configure config on `remoteIdentityProvider` and build Auth0 `/v2/logout` URLs locally.
- Add shared `identity.FederatedLogoutURL` / `BuildOIDCFederatedLogoutURL` helpers.
- Route logout through `logoutAuthRuntime(returnPath)` before calling federated logout.

## Test plan
- [x] `go test ./services/identity/ -run 'TestBuildOIDC|TestRemoteIdentity'`
- [x] `go test ./internal/server/ -run TestLogout`
- [ ] After deploy: single-click logout on valon.tools clears Auth0 SSO

## Related
- #3058 (original federated logout PR — merged with this bug)
- gestalt-providers #1244 (home UI logout flow)


Made with [Cursor](https://cursor.com)