### PR TITLE
Improve login denied UX for rejected email domains

### DIFF
--- a/gestaltd/internal/server/handlers_auth.go
+++ b/gestaltd/internal/server/handlers_auth.go
@@ -468,6 +468,11 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 
 	code := r.URL.Query().Get("code")
 	if code == "" {
+		if oauthErr := strings.TrimSpace(r.URL.Query().Get("error")); oauthErr != "" {
+			auditErr = loginFailureFromOAuthError(oauthErr, r.URL.Query().Get("error_description"))
+			s.failBrowserLogin(w, r, auth, auditErr)
+			return
+		}
 		auditErr = errors.New("missing code parameter")
 		writeError(w, http.StatusBadRequest, "missing code parameter")
 		return
@@ -530,7 +535,11 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 	if err != nil || tokenResp == nil || strings.TrimSpace(tokenResp.AccessToken) == "" {
 		auditErr = errors.New("login failed")
 		slog.ErrorContext(r.Context(), "login callback failed", "error", err)
-		writeError(w, http.StatusUnauthorized, "login failed")
+		if mode == loginCallbackCLIGrant {
+			writeError(w, http.StatusUnauthorized, "login failed")
+			return
+		}
+		s.failBrowserLogin(w, r, auth, err)
 		return
 	}
 

--- a/gestaltd/internal/server/handlers_auth_login_denied.go
+++ b/gestaltd/internal/server/handlers_auth_login_denied.go
@@ -1,0 +1,174 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"html"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const (
+	loginDeniedPath           = browserLoginPath + "/denied"
+	loginDeniedReasonCookie   = "login_denied_reason"
+	loginDeniedCookieMaxAge   = 300
+	loginFailureReasonDomain  = "domain_not_allowed"
+	loginFailureReasonEmail   = "email_not_verified"
+	loginFailureReasonOAuth   = "oauth_error"
+	loginFailureReasonGeneric = "generic"
+)
+
+func classifyLoginFailure(err error) string {
+	if err == nil {
+		return loginFailureReasonGeneric
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "is not allowed"):
+		return loginFailureReasonDomain
+	case strings.Contains(msg, "is not verified"):
+		return loginFailureReasonEmail
+	default:
+		return loginFailureReasonGeneric
+	}
+}
+
+func loginFailureFromOAuthError(oauthErr, description string) error {
+	oauthErr = strings.TrimSpace(oauthErr)
+	description = strings.TrimSpace(description)
+	if description != "" {
+		return fmt.Errorf("%s: %s", oauthErr, description)
+	}
+	if oauthErr != "" {
+		return errors.New(oauthErr)
+	}
+	return errors.New("oauth authorization failed")
+}
+
+func (s *Server) loginDeniedURL(r *http.Request, reason string) (string, error) {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = loginFailureReasonGeneric
+	}
+	deniedPath := loginDeniedPath + "?reason=" + url.QueryEscape(reason)
+	return s.resolvePublicURL(r, deniedPath)
+}
+
+func (s *Server) setLoginDeniedReasonCookie(w http.ResponseWriter, reason string) {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		return
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     loginDeniedReasonCookie,
+		Value:    reason,
+		Path:     loginDeniedPath,
+		MaxAge:   loginDeniedCookieMaxAge,
+		HttpOnly: true,
+		Secure:   s.secureCookies,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+func (s *Server) loginDeniedReasonFromRequest(r *http.Request) string {
+	if reason := strings.TrimSpace(r.URL.Query().Get("reason")); reason != "" {
+		return reason
+	}
+	cookie, err := r.Cookie(loginDeniedReasonCookie)
+	if err != nil {
+		return loginFailureReasonGeneric
+	}
+	reason := strings.TrimSpace(cookie.Value)
+	if reason == "" {
+		return loginFailureReasonGeneric
+	}
+	return reason
+}
+
+func (s *Server) clearLoginDeniedReasonCookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     loginDeniedReasonCookie,
+		Value:    "",
+		Path:     loginDeniedPath,
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   s.secureCookies,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+func (s *Server) failBrowserLogin(w http.ResponseWriter, r *http.Request, auth authRuntime, cause error) {
+	s.clearLoginStateCookie(w)
+	reason := classifyLoginFailure(cause)
+	if strings.TrimSpace(r.URL.Query().Get("error")) != "" {
+		reason = loginFailureReasonOAuth
+	}
+	s.setLoginDeniedReasonCookie(w, reason)
+
+	deniedURL, err := s.loginDeniedURL(r, reason)
+	if err != nil {
+		writeError(w, http.StatusUnauthorized, "login failed")
+		return
+	}
+	if logoutURL, err := s.federatedLogoutURL(auth, deniedURL); err == nil && strings.TrimSpace(logoutURL) != "" {
+		http.Redirect(w, r, logoutURL, http.StatusFound)
+		return
+	}
+	http.Redirect(w, r, deniedURL, http.StatusFound)
+}
+
+func loginDeniedCopy(reason string) (title, message string) {
+	switch strings.TrimSpace(reason) {
+	case loginFailureReasonDomain:
+		return "Sign-in not allowed", "That email domain is not allowed for this site. Sign in with an approved work account, or contact your administrator."
+	case loginFailureReasonEmail:
+		return "Email not verified", "Your email address must be verified before you can sign in."
+	case loginFailureReasonOAuth:
+		return "Sign-in cancelled", "Sign-in did not complete. You can try again with a different account."
+	default:
+		return "Sign-in failed", "We could not complete sign-in. You can try again with a different account."
+	}
+}
+
+func (s *Server) loginDenied(w http.ResponseWriter, r *http.Request) {
+	reason := s.loginDeniedReasonFromRequest(r)
+	s.clearLoginDeniedReasonCookie(w)
+
+	title, message := loginDeniedCopy(reason)
+	retryURL, err := s.resolvePublicURL(r, browserLoginPath+"?next=/")
+	if err != nil {
+		retryURL = browserLoginPath + "?next=/"
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusUnauthorized)
+	_, _ = fmt.Fprintf(w, `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>%s</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 0; min-height: 100vh; display: grid; place-items: center; background: #f8fafc; color: #0f172a; }
+    main { max-width: 32rem; padding: 2rem; background: #fff; border: 1px solid #e2e8f0; border-radius: 12px; box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08); }
+    h1 { margin: 0 0 0.75rem; font-size: 1.5rem; }
+    p { margin: 0 0 1.5rem; line-height: 1.5; color: #334155; }
+    a { display: inline-block; padding: 0.625rem 1rem; border-radius: 8px; background: #0f172a; color: #fff; text-decoration: none; font-weight: 600; }
+    a:hover { background: #1e293b; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>%s</h1>
+    <p>%s</p>
+    <a href="%s">Try again</a>
+  </main>
+</body>
+</html>`,
+		html.EscapeString(title),
+		html.EscapeString(title),
+		html.EscapeString(message),
+		html.EscapeString(retryURL),
+	)
+}

--- a/gestaltd/internal/server/handlers_auth_login_denied.go
+++ b/gestaltd/internal/server/handlers_auth_login_denied.go
@@ -125,7 +125,7 @@ func loginDeniedCopy(reason string) (title, message string) {
 	case loginFailureReasonEmail:
 		return "Email not verified", "Your email address must be verified before you can sign in."
 	case loginFailureReasonOAuth:
-		return "Sign-in cancelled", "Sign-in did not complete. You can try again with a different account."
+		return "Sign-in canceled", "Sign-in did not complete. You can try again with a different account."
 	default:
 		return "Sign-in failed", "We could not complete sign-in. You can try again with a different account."
 	}

--- a/gestaltd/internal/server/handlers_auth_login_denied_test.go
+++ b/gestaltd/internal/server/handlers_auth_login_denied_test.go
@@ -1,0 +1,55 @@
+package server
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestClassifyLoginFailure(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "domain",
+			err:  errors.New(`oidc auth: email domain "gmail.com" is not allowed`),
+			want: loginFailureReasonDomain,
+		},
+		{
+			name: "email verified",
+			err:  errors.New("oidc auth: email user@gmail.com is not verified"),
+			want: loginFailureReasonEmail,
+		},
+		{
+			name: "generic",
+			err:  errors.New("token exchange failed"),
+			want: loginFailureReasonGeneric,
+		},
+		{
+			name: "nil",
+			err:  nil,
+			want: loginFailureReasonGeneric,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := classifyLoginFailure(tt.err); got != tt.want {
+				t.Fatalf("classifyLoginFailure() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoginDeniedCopy(t *testing.T) {
+	t.Parallel()
+
+	title, message := loginDeniedCopy(loginFailureReasonDomain)
+	if title == "" || message == "" {
+		t.Fatalf("loginDeniedCopy() returned empty copy: %q / %q", title, message)
+	}
+}

--- a/gestaltd/internal/server/routes_auth.go
+++ b/gestaltd/internal/server/routes_auth.go
@@ -7,6 +7,7 @@ func (s *Server) mountAuthRoutes(r chi.Router) {
 	r.Get("/auth/login", s.startBrowserLogin)
 	r.Post("/auth/login", s.startLogin)
 	r.Get("/auth/login/callback", s.loginCallback)
+	r.Get("/auth/login/denied", s.loginDenied)
 	r.Get("/auth/logout", s.logoutBrowser)
 	r.Post("/auth/logout", s.logout)
 	r.Get("/auth/callback", s.integrationOAuthCallback)

--- a/gestaltd/internal/server/test_auth_stubs_test.go
+++ b/gestaltd/internal/server/test_auth_stubs_test.go
@@ -1,9 +1,12 @@
 package server_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
+	"net/http/cookiejar"
 	"net/url"
 	"strings"
 	"sync"
@@ -430,4 +433,88 @@ func testAuthStubForScopedBearer() *coretesting.StubAuthProvider {
 		}
 		return testIntrospectActive(principal.UserSubjectID(userID), scope), nil
 	})
+}
+
+type federatedLogoutAuthStub struct {
+	coretesting.StubAuthProvider
+	logoutPrefix string
+}
+
+func (s *federatedLogoutAuthStub) FederatedLogoutURL(returnTo string) (string, error) {
+	prefix := strings.TrimSpace(s.logoutPrefix)
+	if prefix == "" {
+		prefix = "https://idp.example.test/v2/logout"
+	}
+	return prefix + "?returnTo=" + url.QueryEscape(returnTo), nil
+}
+
+func TestLoginCallbackRejectedDomainRedirectsThroughLogout(t *testing.T) {
+	t.Parallel()
+
+	stub := &federatedLogoutAuthStub{
+		StubAuthProvider: coretesting.StubAuthProvider{N: "auth0"},
+	}
+	stub.TokenFn = func(_ context.Context, _ *core.TokenRequest) (*core.TokenResponse, error) {
+		return nil, fmt.Errorf(`oidc auth: email domain "gmail.com" is not allowed`)
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = stub
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	jar, _ := cookiejar.New(nil)
+	client := &http.Client{
+		Jar: jar,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	loginResp, err := client.Post(ts.URL+"/api/v1/auth/login", "application/json", bytes.NewBufferString(`{"state":"test-state"}`))
+	if err != nil {
+		t.Fatalf("start login: %v", err)
+	}
+	_ = loginResp.Body.Close()
+
+	callbackResp, err := client.Get(ts.URL + "/api/v1/auth/login/callback?code=good-code&state=test-state")
+	if err != nil {
+		t.Fatalf("callback: %v", err)
+	}
+	defer func() { _ = callbackResp.Body.Close() }()
+
+	if callbackResp.StatusCode != http.StatusFound {
+		t.Fatalf("status = %d, want 302", callbackResp.StatusCode)
+	}
+	location := callbackResp.Header.Get("Location")
+	if !strings.HasPrefix(location, "https://idp.example.test/v2/logout") {
+		t.Fatalf("Location = %q, want federated logout redirect", location)
+	}
+	parsed, err := url.Parse(location)
+	if err != nil {
+		t.Fatalf("parse Location: %v", err)
+	}
+	returnTo := parsed.Query().Get("returnTo")
+	if !strings.Contains(returnTo, "/api/v1/auth/login/denied") {
+		t.Fatalf("returnTo = %q, want login denied page", returnTo)
+	}
+	if !strings.Contains(returnTo, "domain_not_allowed") {
+		t.Fatalf("returnTo = %q, want domain_not_allowed reason", returnTo)
+	}
+
+	deniedResp, err := client.Get(ts.URL + "/api/v1/auth/login/denied?reason=domain_not_allowed")
+	if err != nil {
+		t.Fatalf("denied page: %v", err)
+	}
+	defer func() { _ = deniedResp.Body.Close() }()
+	if deniedResp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("denied status = %d, want 401", deniedResp.StatusCode)
+	}
+	body, err := io.ReadAll(deniedResp.Body)
+	if err != nil {
+		t.Fatalf("read denied body: %v", err)
+	}
+	if !strings.Contains(string(body), "Try again") || !strings.Contains(string(body), "not allowed") {
+		t.Fatalf("denied body = %q, want user-facing denial copy", string(body))
+	}
 }


### PR DESCRIPTION
## Summary
- On browser login callback failure (e.g. non-allowlisted email domain like `@gmail.com`), clear the login state cookie and redirect through Auth0 federated logout when available.
- Add `GET /api/v1/auth/login/denied` with a simple HTML page explaining the rejection and a **Try again** link.
- Handle Auth0 OAuth `error` query params on the callback instead of only showing "missing code parameter".

Fixes the stuck loop where Auth0 SSO stayed active after Gestalt rejected the email, so refreshing valon.tools silently re-authenticated the same blocked account.

## Test plan
- [x] `go test ./internal/server/ -run 'TestClassifyLoginFailure|TestLoginCallbackRejectedDomain'`
- [ ] After deploy: sign in with `@gmail.com` → see denied page → **Try again** → Auth0 account picker / fresh login
- [ ] Confirm Auth0 **Allowed Logout URLs** includes `https://valon.tools/api/v1/auth/login/denied` (or a wildcard covering it)

## Related
- gestalt #3058, #3059 (federated logout)
- toolshed #4068 (deploy bump in flight)


Made with [Cursor](https://cursor.com)