### PR TITLE
Filter /apps catalog by viewer/editor/admin grants

### DIFF
--- a/gestaltd/internal/server/handlers_auth_login_denied.go
+++ b/gestaltd/internal/server/handlers_auth_login_denied.go
@@ -55,6 +55,12 @@ func (s *Server) loginDeniedURL(r *http.Request, reason string) (string, error) 
 	return s.resolvePublicURL(r, deniedPath)
 }
 
+// loginDeniedReturnURL is the federated-logout return target. Auth0 Allowed Logout
+// URLs must include this path exactly; the failure reason is carried in a cookie.
+func (s *Server) loginDeniedReturnURL(r *http.Request) (string, error) {
+	return s.resolvePublicURL(r, loginDeniedPath)
+}
+
 func (s *Server) setLoginDeniedReasonCookie(w http.ResponseWriter, reason string) {
 	reason = strings.TrimSpace(reason)
 	if reason == "" {
@@ -106,16 +112,16 @@ func (s *Server) failBrowserLogin(w http.ResponseWriter, r *http.Request, auth a
 	}
 	s.setLoginDeniedReasonCookie(w, reason)
 
-	deniedURL, err := s.loginDeniedURL(r, reason)
+	deniedReturnURL, err := s.loginDeniedReturnURL(r)
 	if err != nil {
 		writeError(w, http.StatusUnauthorized, "login failed")
 		return
 	}
-	if logoutURL, err := s.federatedLogoutURL(auth, deniedURL); err == nil && strings.TrimSpace(logoutURL) != "" {
+	if logoutURL, err := s.federatedLogoutURL(auth, deniedReturnURL); err == nil && strings.TrimSpace(logoutURL) != "" {
 		http.Redirect(w, r, logoutURL, http.StatusFound)
 		return
 	}
-	http.Redirect(w, r, deniedURL, http.StatusFound)
+	http.Redirect(w, r, deniedReturnURL, http.StatusFound)
 }
 
 func loginDeniedCopy(reason string) (title, message string) {

--- a/gestaltd/internal/server/handlers_auth_login_denied.go
+++ b/gestaltd/internal/server/handlers_auth_login_denied.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"html"
 	"net/http"
-	"net/url"
 	"strings"
 )
 
@@ -44,15 +43,6 @@ func loginFailureFromOAuthError(oauthErr, description string) error {
 		return errors.New(oauthErr)
 	}
 	return errors.New("oauth authorization failed")
-}
-
-func (s *Server) loginDeniedURL(r *http.Request, reason string) (string, error) {
-	reason = strings.TrimSpace(reason)
-	if reason == "" {
-		reason = loginFailureReasonGeneric
-	}
-	deniedPath := loginDeniedPath + "?reason=" + url.QueryEscape(reason)
-	return s.resolvePublicURL(r, deniedPath)
 }
 
 // loginDeniedReturnURL is the federated-logout return target. Auth0 Allowed Logout

--- a/gestaltd/internal/server/integration_visibility.go
+++ b/gestaltd/internal/server/integration_visibility.go
@@ -9,7 +9,40 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 )
 
+var integrationCatalogVisibleRoles = []string{"viewer", "editor", "admin"}
+
+func (s *Server) integrationAuthorizationResourceName(provider string) string {
+	if entry, ok := s.pluginDefs[provider]; ok && entry != nil {
+		if policy := strings.TrimSpace(entry.AuthorizationPolicy); policy != "" {
+			return policy
+		}
+	}
+	return strings.TrimSpace(provider)
+}
+
+// integrationCatalogVisibleContext reports whether an integration should appear in
+// GET /api/v1/apps. Callers need viewer/editor/admin on the app resource, unless
+// the resource type's defaultRole grants one of those catalog roles.
+func (s *Server) integrationCatalogVisibleContext(ctx context.Context, p *principal.Principal, provider string) bool {
+	if principal.IsNonUserPrincipal(p) {
+		return false
+	}
+	if s.authorization == nil {
+		return true
+	}
+	subjectID := strings.TrimSpace(principal.Canonicalized(p).SubjectID)
+	if subjectID == "" {
+		return false
+	}
+	resourceName := s.integrationAuthorizationResourceName(provider)
+	_, allowed, err := s.authorizeMountedResourceRoles(ctx, resourceName, subjectID, integrationCatalogVisibleRoles)
+	return err == nil && allowed
+}
+
 func (s *Server) integrationHasUsableSurfaceContext(ctx context.Context, p *principal.Principal, provider string, prov core.Provider, info integrationInfo) bool {
+	if !s.integrationCatalogVisibleContext(ctx, p, provider) {
+		return false
+	}
 	if info.MountedPath != "" {
 		return true
 	}

--- a/gestaltd/internal/server/integration_visibility_test.go
+++ b/gestaltd/internal/server/integration_visibility_test.go
@@ -1,0 +1,182 @@
+package server_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/server"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
+)
+
+func TestListIntegrationsRequiresCatalogRole(t *testing.T) {
+	t.Parallel()
+
+	const sessionToken = "session-token"
+	sessionAuth := coretesting.NamedIntrospectIdentityStub("test", func(_ context.Context, token string) (*core.UserIdentity, error) {
+		if token != sessionToken {
+			return nil, core.ErrNotFound
+		}
+		return &core.UserIdentity{Email: "user@example.test"}, nil
+	})
+
+	svc := testutil.NewStubServices(t)
+	user := seedUserRecord(t, svc, "catalog-user", "user@example.test", time.Now())
+	subjectID := principal.UserSubjectID(user.ID)
+
+	grantedProvider := &coretesting.StubIntegration{
+		N:          "granted-app",
+		ConnMode:   core.ConnectionModeNone,
+		CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{{ID: "ping", Method: http.MethodGet}}},
+	}
+	openProvider := &coretesting.StubIntegration{
+		N:          "open-app",
+		ConnMode:   core.ConnectionModeNone,
+		CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{{ID: "ping", Method: http.MethodGet}}},
+	}
+	lockedProvider := &coretesting.StubIntegration{
+		N:          "locked-app",
+		ConnMode:   core.ConnectionModeNone,
+		CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{{ID: "ping", Method: http.MethodGet}}},
+	}
+
+	authz := &serverTestAuthorizationProvider{
+		resourceTypes: []*proto.AuthorizationModelResourceType{
+			{Name: "app"},
+			{Name: "openPolicy", DefaultRole: "viewer"},
+		},
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(subjectID, "viewer", "app", "granted-app"),
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = sessionAuth
+		cfg.Services = svc
+		cfg.Authorization = authz
+		cfg.ProviderKinds = map[string]invocation.ProviderKind{
+			"granted-app": invocation.ProviderKindApp,
+			"open-app":    invocation.ProviderKindApp,
+			"locked-app":  invocation.ProviderKindApp,
+		}
+		cfg.Providers = testutil.NewProviderRegistry(t, grantedProvider, openProvider, lockedProvider)
+		cfg.AppDefs = map[string]*config.ProviderEntry{
+			"granted-app": {},
+			"open-app": {
+				AuthorizationPolicy: "openPolicy",
+			},
+			"locked-app": {},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: sessionToken})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /api/v1/apps: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
+	}
+
+	var listed []struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&listed); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	names := make(map[string]struct{}, len(listed))
+	for _, item := range listed {
+		names[item.Name] = struct{}{}
+	}
+	if _, ok := names["granted-app"]; !ok {
+		t.Fatalf("listed apps = %v, want granted-app visible with viewer grant", names)
+	}
+	if _, ok := names["open-app"]; !ok {
+		t.Fatalf("listed apps = %v, want open-app visible via defaultRole viewer", names)
+	}
+	if _, ok := names["locked-app"]; ok {
+		t.Fatalf("listed apps = %v, want locked-app hidden without grant", names)
+	}
+}
+
+func TestListIntegrationsHidesAppsWithOnlyConnectionDefinitions(t *testing.T) {
+	t.Parallel()
+
+	const sessionToken = "session-token"
+	sessionAuth := coretesting.NamedIntrospectIdentityStub("test", func(_ context.Context, token string) (*core.UserIdentity, error) {
+		if token != sessionToken {
+			return nil, core.ErrNotFound
+		}
+		return &core.UserIdentity{Email: "user@example.test"}, nil
+	})
+
+	svc := testutil.NewStubServices(t)
+	seedUserRecord(t, svc, "catalog-user", "user@example.test", time.Now())
+
+	provider := &coretesting.StubIntegration{
+		N:          "oauth-only",
+		ConnMode:   core.ConnectionModeSubject,
+		CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{{ID: "ping", Method: http.MethodGet}}},
+	}
+
+	authz := &serverTestAuthorizationProvider{
+		resourceTypes: []*proto.AuthorizationModelResourceType{{Name: "app"}},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = sessionAuth
+		cfg.Services = svc
+		cfg.Authorization = authz
+		cfg.ProviderKinds = map[string]invocation.ProviderKind{
+			"oauth-only": invocation.ProviderKindApp,
+		}
+		cfg.Providers = testutil.NewProviderRegistry(t, provider)
+		cfg.AppDefs = testPluginDefsForConnections("oauth-only", testDefaultConnection)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: sessionToken})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /api/v1/apps: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
+	}
+
+	var listed []struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&listed); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	for _, item := range listed {
+		if item.Name == "oauth-only" {
+			t.Fatalf("listed apps = %v, want oauth-only hidden without viewer/editor/admin grant", listed)
+		}
+	}
+}

--- a/gestaltd/internal/server/test_auth_stubs_test.go
+++ b/gestaltd/internal/server/test_auth_stubs_test.go
@@ -498,8 +498,8 @@ func TestLoginCallbackRejectedDomainRedirectsThroughLogout(t *testing.T) {
 	if !strings.Contains(returnTo, "/api/v1/auth/login/denied") {
 		t.Fatalf("returnTo = %q, want login denied page", returnTo)
 	}
-	if !strings.Contains(returnTo, "domain_not_allowed") {
-		t.Fatalf("returnTo = %q, want domain_not_allowed reason", returnTo)
+	if strings.Contains(returnTo, "reason=") {
+		t.Fatalf("returnTo = %q, want path without query (reason is in cookie)", returnTo)
 	}
 
 	deniedResp, err := client.Get(ts.URL + "/api/v1/auth/login/denied?reason=domain_not_allowed")


### PR DESCRIPTION
## Summary
- Gate `GET /api/v1/apps` on authorization: integrations only appear when the caller has **viewer**, **editor**, or **admin** on the app resource, or the resource type has a **defaultRole** that grants catalog access (open policy).
- Fixes external probe users (e.g. `@example.com`) seeing the full internal toolshed catalog after login; they still get `/apps` via `home` defaultRole but not CI/CD, Traffic Cop, etc.
- Use a query-free `/api/v1/auth/login/denied` URL for Auth0 federated logout `returnTo` (failure reason stays in cookie); avoids Auth0 "returnTo not in Allowed Logout URLs" when the denied page includes query params.

## Context
`listIntegrations` previously treated any provider with connection definitions as visible, regardless of grants. Valon staff access comes from `valon-employees` subjectSet viewer grants; externals without relationships should not see internal apps in the launcher.

## Test plan
- [x] `go test ./gestaltd/internal/server/ -run TestListIntegrations`
- [ ] After deploy: log in as ungranted `@example.com` probe user → `/apps` loads but internal toolshed apps are absent
- [ ] Log in as `@valon.com` staff → full catalog unchanged
- [ ] Domain-denied login → federated logout lands on denied page (requires `https://valon.tools/api/v1/auth/login/denied` in Auth0 Allowed Logout URLs)


Made with [Cursor](https://cursor.com)