### PR TITLE
Resolve mounted UI roles through subject sets

### DIFF
--- a/gestaltd/internal/server/mounted_ui.go
+++ b/gestaltd/internal/server/mounted_ui.go
@@ -351,33 +351,108 @@ func mountedUIRequiresAuthorization(mounted MountedUI) bool {
 
 func (s *Server) mountedUIAuthorizationRoles(ctx context.Context, subjectID, resourceName string) (map[string]struct{}, error) {
 	roles := map[string]struct{}{}
+	subject := &proto.Subject{
+		Type: "subject",
+		Id:   strings.TrimSpace(subjectID),
+	}
+	relationships, err := s.listAuthorizationRelationships(ctx, &proto.RelationshipFilter{
+		Resource: invocation.AuthorizationResource(resourceName, s.providerKinds),
+	})
+	if err != nil {
+		return nil, err
+	}
+	for _, relationship := range relationships {
+		matches, err := s.mountedUIRelationshipTargetMatchesSubject(
+			ctx,
+			subject,
+			relationship.GetTuple().GetTarget(),
+			map[string]struct{}{},
+		)
+		if err != nil {
+			return nil, err
+		}
+		if !matches {
+			continue
+		}
+		relation := strings.TrimSpace(relationship.GetTuple().GetRelation())
+		if relation != "" {
+			roles[relation] = struct{}{}
+		}
+	}
+	return roles, nil
+}
+
+func (s *Server) mountedUIRelationshipTargetMatchesSubject(
+	ctx context.Context,
+	subject *proto.Subject,
+	target *proto.RelationshipTarget,
+	visited map[string]struct{},
+) (bool, error) {
+	if target == nil {
+		return false, nil
+	}
+	if targetSubject := target.GetSubject(); targetSubject != nil {
+		return strings.TrimSpace(targetSubject.GetType()) == strings.TrimSpace(subject.GetType()) &&
+			strings.TrimSpace(targetSubject.GetId()) == strings.TrimSpace(subject.GetId()), nil
+	}
+	subjectSet := target.GetSubjectSet()
+	if subjectSet == nil || subjectSet.GetResource() == nil {
+		return false, nil
+	}
+	resource := subjectSet.GetResource()
+	relation := strings.TrimSpace(subjectSet.GetRelation())
+	key := strings.Join([]string{
+		strings.TrimSpace(subject.GetType()),
+		strings.TrimSpace(subject.GetId()),
+		strings.TrimSpace(resource.GetType()),
+		strings.TrimSpace(resource.GetId()),
+		relation,
+	}, "\x00")
+	if _, ok := visited[key]; ok {
+		return false, nil
+	}
+	visited[key] = struct{}{}
+
+	relationships, err := s.listAuthorizationRelationships(ctx, &proto.RelationshipFilter{
+		Relation: relation,
+		Resource: resource,
+	})
+	if err != nil {
+		return false, err
+	}
+	for _, relationship := range relationships {
+		matches, err := s.mountedUIRelationshipTargetMatchesSubject(
+			ctx,
+			subject,
+			relationship.GetTuple().GetTarget(),
+			visited,
+		)
+		if err != nil {
+			return false, err
+		}
+		if matches {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (s *Server) listAuthorizationRelationships(ctx context.Context, filter *proto.RelationshipFilter) ([]*proto.Relationship, error) {
+	var relationships []*proto.Relationship
 	pageToken := ""
 	for {
 		resp, err := s.authorization.ListRelationships(ctx, &proto.ListRelationshipsRequest{
-			Filter: &proto.RelationshipFilter{
-				Target: &proto.RelationshipTarget{
-					Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{
-						Type: "subject",
-						Id:   strings.TrimSpace(subjectID),
-					}},
-				},
-				Resource: invocation.AuthorizationResource(resourceName, s.providerKinds),
-			},
+			Filter:    filter,
 			PageSize:  500,
 			PageToken: pageToken,
 		})
 		if err != nil {
 			return nil, err
 		}
-		for _, relationship := range resp.GetRelationships() {
-			relation := strings.TrimSpace(relationship.GetTuple().GetRelation())
-			if relation != "" {
-				roles[relation] = struct{}{}
-			}
-		}
+		relationships = append(relationships, resp.GetRelationships()...)
 		pageToken = strings.TrimSpace(resp.GetNextPageToken())
 		if pageToken == "" {
-			return roles, nil
+			return relationships, nil
 		}
 	}
 }

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -2640,7 +2640,15 @@ func TestMountedUIAppLevelAuthorizationRelationships(t *testing.T) {
 		relationships: []*proto.Relationship{
 			testAuthorizationRelationship(
 				principal.UserSubjectID(user.ID),
-				"admin",
+				"member",
+				"group",
+				"valon-employees",
+			),
+			testAuthorizationSubjectSetRelationship(
+				"group",
+				"valon-employees",
+				"member",
+				"viewer",
 				"app",
 				"sampleApp",
 			),
@@ -2697,10 +2705,10 @@ func TestMountedUIAppLevelAuthorizationRelationships(t *testing.T) {
 	body, _ = io.ReadAll(resp.Body)
 	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("relationship-gated mounted UI status = %d, want 200: %s", resp.StatusCode, body)
+		t.Fatalf("employee-group-gated mounted UI status = %d, want 200: %s", resp.StatusCode, body)
 	}
 	if !bytes.Contains(body, []byte("sample-shell")) {
-		t.Fatalf("relationship-gated mounted UI body = %q, want sample-shell", body)
+		t.Fatalf("employee-group-gated mounted UI body = %q, want sample-shell", body)
 	}
 	if len(authz.listRelationshipRequests) == 0 {
 		t.Fatal("authorization ListRelationships was not called")
@@ -2838,6 +2846,35 @@ func testAuthorizationRelationship(subjectID, relation, resourceType, resourceID
 				Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{
 					Type: "subject",
 					Id:   subjectID,
+				}},
+			},
+			Relation: relation,
+			Resource: &proto.Resource{
+				Type: resourceType,
+				Id:   resourceID,
+			},
+		},
+		SourceLayer: proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG,
+	}
+}
+
+func testAuthorizationSubjectSetRelationship(
+	subjectSetResourceType,
+	subjectSetResourceID,
+	subjectSetRelation,
+	relation,
+	resourceType,
+	resourceID string,
+) *proto.Relationship {
+	return &proto.Relationship{
+		Tuple: &proto.RelationshipTuple{
+			Target: &proto.RelationshipTarget{
+				Kind: &proto.RelationshipTarget_SubjectSet{SubjectSet: &proto.SubjectSet{
+					Resource: &proto.Resource{
+						Type: subjectSetResourceType,
+						Id:   subjectSetResourceID,
+					},
+					Relation: subjectSetRelation,
 				}},
 			},
 			Relation: relation,


### PR DESCRIPTION
## Summary
- resolve mounted-app roles for direct subjects and subject-set membership
- recursively follow nested subject sets with cycle protection
- add regression coverage for a `valon-employees` group viewer grant

## Test plan
- [x] `go test ./internal/server -run TestMountedUIAppLevelAuthorizationRelationships -count=1`
- [x] `go test ./internal/server -count=1`

Made with [Cursor](https://cursor.com)