### PR TITLE
Document external users incident findings and rollout controls

### DIFF
--- a/plans/external_users/implementation_v2.md
+++ b/plans/external_users/implementation_v2.md
@@ -6,21 +6,20 @@ Allow verified users from approved external domains to log in without changing e
 
 ## What failed
 
-1. **Incomplete employee roster.** `valon-employees` contained 67 UUIDs and 6 emails found in existing authorization rows, not an authoritative employee list. Employees who relied only on `app.defaultRole` could be missing.
-2. **Inconsistent authorization.** Operation `CheckAccess` supported subject sets, but mounted UI, catalog, and admin paths used separate relationship scans. [#3061](https://github.com/valon-technologies/gestalt/pull/3061) broke group-only catalog access. [#3062](https://github.com/valon-technologies/gestalt/pull/3062) fixed only UI/catalog traversal.
-3. **Bad policy migration.** Setting the shared app wildcard to `[nobody]` denied hundreds of valid operations. The relationship-gated wildcard must remain `[viewer, user, editor, admin]`.
-4. **Untested Auth0 configuration.** The cutover exposed, in sequence, an issuer mismatch, HS256 tokens, and missing connection/HRD setup.
-5. **Unsafe deployment state.** No-traffic Cloud Run candidates could overwrite shared authorization state during startup. Traffic rollback did not restore that state.
-6. **Non-reproducible binaries.** `GESTALTD_PINNED_SHA` was mutable and outside the Toolshed commit.
-7. **Oversized hotfix.** [#4071](https://github.com/valon-technologies/toolshed/pull/4071) generated 5,762 direct grants and failed startup probes. [#4073](https://github.com/valon-technologies/toolshed/pull/4073) restored service.
+1. **Inconsistent authorization.** Operation `CheckAccess` supported subject sets, but mounted UI, catalog, and admin paths used separate relationship scans. [#3061](https://github.com/valon-technologies/gestalt/pull/3061) broke group-only catalog access. [#3062](https://github.com/valon-technologies/gestalt/pull/3062) fixed only UI/catalog traversal.
+2. **Bad policy migration.** Setting the shared app wildcard to `[nobody]` denied hundreds of valid operations. The relationship-gated wildcard must remain `[viewer, user, editor, admin]`.
+3. **Untested Auth0 configuration.** The cutover exposed, in sequence, an issuer mismatch, HS256 tokens, and missing connection/HRD setup.
+4. **Unsafe deployment state.** No-traffic Cloud Run candidates could overwrite shared authorization state during startup. Traffic rollback did not restore that state.
+5. **Non-reproducible binaries.** `GESTALTD_PINNED_SHA` was mutable and outside the Toolshed commit.
+6. **Oversized hotfix.** [#4071](https://github.com/valon-technologies/toolshed/pull/4071) generated 5,762 direct grants and failed startup probes. [#4073](https://github.com/valon-technologies/toolshed/pull/4073) restored service.
 
-The #3062 binary was deployed by #4072 at 12:04 UTC. Dave still reproduced UI, catalog, and CLI failures at 12:09 UTC. For Linear, Workplace Hub, and AI Spend, grants and wildcard policy existed; an absent or incorrect employee UUID is the leading remaining explanation. Confirm it from retained production data before assigning person-specific causality.
+The 67-user roster intentionally covered previously logged-in users and included Dave and Kevon. Roster completeness was not the cause. The #3062 binary was deployed by #4072 at 12:04 UTC, but Dave still reproduced UI, catalog, and CLI failures at 12:09 UTC. This confirms that authorization policy and evaluation remained incorrect across request surfaces.
 
 ## Non-negotiables
 
 - Keep Google login until explicit employee authorization passes and soaks.
-- Build employee membership from the approved active-employee authority, joined to persisted Gestalt UUIDs by normalized email.
-- Never use existing authorization rows as the employee roster.
+- Keep the reviewed roster of previously logged-in users as canonical Gestalt UUIDs.
+- Add future users through an explicit, validated manual process.
 - Never use `[nobody]` as the shared app wildcard.
 - Never generate per-user/per-app grants.
 - A no-traffic candidate must not mutate active authorization state.
@@ -88,13 +87,13 @@ Use the real authorization evaluator for at least one integration suite. Cover:
 
 ## Stack B — Employee authorization under Google
 
-### T1 — Inventory and roster
+### T1 — Inventory and roster validation
 
 - Resolve every app’s key, resource type/ID, policy alias, valid relations, mounted roles, management path, and registered operations.
 - Explicitly cover Talent Team, Rippling, Traffic Cop, agent-trace-viewer, and other dedicated policies.
-- Load active employees from the approved People/Identity authority.
-- Join normalized Valon emails to persisted Gestalt UUIDs.
-- Block on missing users, duplicates, inactive employees, external identities, or noncanonical subjects.
+- Verify every reviewed roster entry is a unique, canonical Gestalt UUID.
+- Document the manual lookup, validation, addition, and removal workflow.
+- Block on missing users, duplicates, or noncanonical subjects.
 
 ### T2 — Versioned authorization state
 

--- a/plans/external_users/implementation_v2.md
+++ b/plans/external_users/implementation_v2.md
@@ -22,9 +22,9 @@ The current users table maps Dave and Kevon to canonical UUIDs absent from the h
 
 - Keep Google login until explicit employee authorization passes and soaks.
 - Build employee eligibility from an approved People/Identity authority, joined to canonical Gestalt users; never infer employment from authorization rows or email domain alone.
-- Reconcile every users-table record to either an active employee UUID or an explicitly reviewed exclusion.
-- Store the restricted inventory outside source control; commit only its digest, counts, and reviewed exception identifiers.
-- Recheck inventory immediately before activation and provision future employee membership before first login.
+- Block only on active employees without one canonical user, ambiguous internal identities, and roster entries not backed by active employment.
+- Store the restricted employee-to-user join outside source control; commit only its digest and aggregate reconciliation results.
+- Recompute that join immediately before activation and provision future employee membership before first login.
 - Never use `[nobody]` as the shared app wildcard.
 - Do not replace group access with generated per-user/per-app grants.
 - A no-traffic candidate must not mutate active authorization state.
@@ -32,16 +32,21 @@ The current users table maps Dave and Kevon to canonical UUIDs absent from the h
 - Roll back on the first failed gate; do not stack hotfixes.
 - Keep federated logout out of this rollout.
 
-## Release controls
+## Rollout manifest
 
-- Allow one production deployment at a time with workflow concurrency and a protected-environment approval.
-- Resolve all high- and medium-severity review findings on the final SHA, then wait for the agreed review-settle period.
-- Define maximum relationship-count growth, authorization-state diff size, startup duration, and readiness duration before deployment.
-- A failed gate freezes merges and queued deployments. A named incident commander must approve resumption.
+Before each stack, commit one machine-readable manifest with:
+
+- final reviewed SHA, immutable input digests, secret version IDs, and previous-state references;
+- named owner, incident commander, approvers, and protected production environment;
+- literal plan/apply/verify/rollback commands and expected output artifacts;
+- numeric relationship-count, authorization-diff, startup, readiness, and denial thresholds;
+- verifier IDs, checks, settle-period end, and explicit success criteria.
+
+CI rejects missing values and unresolved high/medium findings. The deployment workflow consumes the manifest, allows one production run at a time, and cancels queued runs after failure. Resumption requires an incident-commander approval recorded in a new manifest revision.
 
 ## Verifiers
 
-- **Michael:** temporary group-only canary after the no-default snapshot is active.
+- **Dedicated employee canary:** canonical UUID with group-only access and no direct grants.
 - **Dave:** fresh browser and CLI session.
 - **Kevon:** fresh browser and MCP session.
 - **Named employee app admin:** management and user-lookup paths.
@@ -81,14 +86,15 @@ Required negative checks:
 - Reject or explicitly map opaque subjects such as `user:auth0|...`.
 - Prove Google and Auth0 tokens for the same verified email resolve to the same existing UUID across browser, CLI, API token, and MCP.
 
-### G3 — Shared effective-access contract
+### G3 — One authorization decision engine
 
-- Keep provider `CheckAccess` authoritative for operation actions.
-- Replace direct-only UI, catalog, and admin scans with one effective-role contract that supports subject sets.
+- Put direct grants, subject sets, default roles, policy aliases, and action precedence in one provider-owned evaluator.
+- Make `CheckAccess`, batch checks, and effective-role queries thin views over that evaluator; no server path may traverse relationships independently.
+- Implement catalog and MCP listing as batched decisions from the same evaluator used for invocation.
 - Centralize app key, resource type/ID, and `authorizationPolicy` mapping.
 - Cover mounted UI, catalog, management paths, app admin, lookup, operation invocation, and MCP tool listing/calls.
 - Restrict user lookup to an explicit employee operator role; app-scoped administration alone must not permit user enumeration.
-- Bound any relationship traversal by pages, depth, and query count; fail closed on malformed sets.
+- Bound evaluator traversal by depth and work count; fail closed on malformed sets.
 
 ### G4 — Conformance suite
 
@@ -104,11 +110,11 @@ Use the real authorization evaluator for at least one integration suite. Cover:
 ### Gate A
 
 1. Complete G1 before starting any candidate connected to production authorization storage.
-2. Pin the exact G4 image digest in source-controlled deployment input.
+2. Validate the Stack A rollout manifest and pin the exact G4 image digest.
 3. Deploy under Google with current default-role behavior unchanged.
 4. Run the current-access regression matrix for all employee verifiers.
-5. Run Michael group-only in a production-shaped isolated environment with `defaultRole` removed.
-6. Stop and restore the prior immutable bundle on any failure.
+5. Run the dedicated group-only canary in a production-shaped isolated environment with `defaultRole` removed.
+6. Execute the manifest rollback command on any failure.
 
 ## Stack B — Employee authorization under Google
 
@@ -116,22 +122,20 @@ Use the real authorization evaluator for at least one integration suite. Cover:
 
 - Resolve every app’s key, resource type/ID, policy alias, valid relations, mounted roles, management path, and registered operations.
 - Explicitly cover Talent Team, Rippling, Traffic Cop, agent-trace-viewer, and other dedicated policies.
-- Export a restricted, point-in-time users-table inventory containing canonical UUID and normalized email.
-- Join the approved People/Identity employee source to that inventory.
-- Classify every unmatched record as a reviewed exclusion. Require an owner and reason for non-Valon, test, duplicate, stale, and service accounts.
+- Export the approved active-employee authority and join normalized employee emails to canonical Gestalt users.
 - Verify every employee entry is a unique, canonical Gestalt UUID and every roster UUID resolves to exactly one users-table record.
-- Generate the employee membership file from the reviewed inventory, never from existing authorization relationships.
-- Produce a set-difference report and require zero unclassified users, zero missing employees, zero duplicate UUIDs, and zero orphaned roster UUIDs.
-- Commit the inventory digest and reconciliation summary, not raw email/UUID pairs.
+- Generate membership from that join, never from existing authorization relationships.
+- Require zero unmapped employees, zero ambiguous internal identities, zero duplicate UUIDs, and zero roster entries absent from the employee authority.
+- Commit the source and join digests plus aggregate results, not raw email/UUID pairs. Unrelated external and stale users require no classification.
 - Document lookup, classification, onboarding, removal, and emergency correction. Employee onboarding must add membership before first Gestalt login.
 
 ### T2 — Preseed, shadow, activate
 
 1. Add compact employee memberships and subject-set grants while `defaultRole` remains active.
 2. Capture the current effective-access matrix for every approved employee, resource, and registered action.
-3. Shadow-evaluate the proposed no-default model against that baseline across provider and server authorization paths.
+3. Shadow-evaluate the proposed no-default model against that baseline through the canonical evaluator and each server surface.
 4. Require zero unexplained employee denials and zero unexpected control-user allows.
-5. Re-export and reconcile the users table immediately before apply; stop on any digest or classification change.
+5. Recompute the active-employee-to-user join immediately before apply; stop on any employee-relevant change.
 6. Apply the no-default snapshot under Google.
 7. Keep:
 
@@ -143,21 +147,20 @@ Use the real authorization evaluator for at least one integration suite. Cover:
 
 ### Gate B
 
-1. Verify the users-table reconciliation, previous authorization snapshot, and rollback command.
+1. Validate the Stack B rollout manifest, employee join, previous authorization snapshot, and rollback command.
 2. Require every approved employee UUID to pass the shadow evaluation before removing `defaultRole`.
 3. Require the authorization plan to remain within the declared count, diff, startup, and readiness budgets.
 4. Apply T2.
-5. Temporarily remove Michael’s direct grants and run all verifier and negative checks.
-6. Restore Michael’s original direct grants and verify restoration.
-7. Repeat checks after 30 minutes and the next business morning.
-8. Soak for one business day.
-9. On failure, reactivate the previous authorization snapshot and runtime bundle.
+5. Run all verifier and negative checks, including the permanently group-only canary.
+6. Repeat checks after 30 minutes and the next business morning.
+7. Soak for one business day.
+8. On failure, execute the manifest rollback command to reactivate the previous authorization snapshot and runtime bundle atomically.
 
 ## Stack C — Employee-only Auth0
 
 ### T3 — Versioned Auth0 state and live preflight
 
-Create a reviewed desired-state manifest and rollback export for the exact Auth0 client, enabled connections, HRD domains, callback/logout URLs, signing algorithm, database signup setting, and GSM secret version IDs. Diff live state against it, then run a real authorization-code flow. Verify:
+Provision a dedicated Auth0 client and its connections additively before building the candidate. Record the exact client, enabled connections, HRD domains, callback/logout URLs, signing algorithm, database signup setting, and GSM secret version IDs in the Stack C rollout manifest. Diff live state against it, then run a real authorization-code flow. Verify:
 
 - configured issuer exactly matches discovery;
 - ID token uses RS256 and passes JWKS verification;
@@ -170,11 +173,11 @@ Create a reviewed desired-state manifest and rollback export for the exact Auth0
 - pinned GSM versions and IAM are correct;
 - `allowedDomains` is `[valon.com]`.
 
-Do not weaken issuer or algorithm validation. Add provider tests only for a concrete gap.
+Freeze this Auth0 client and its secret references after preflight. Later steps may only route traffic between the immutable Google and Auth0 revisions. Do not weaken issuer or algorithm validation.
 
 ### T4 — Isolated candidate
 
-- Deploy the exact production candidate on a separate hostname.
+- Build the production candidate already bound to the frozen Auth0 client, config, and secret versions; deploy it on a separate hostname.
 - Preserve a controlled copy of production user UUIDs.
 - Isolate authorization relationships, grants, and sessions.
 - Seed the exact production authorization snapshot.
@@ -182,48 +185,60 @@ Do not weaken issuer or algorithm validation. Add provider tests only for a conc
 
 This proves artifact compatibility, not production routing, cookies, or shared-state behavior.
 
-### T5 — Production cutover
+### T5 — Production candidate
 
-- Deploy the exact immutable T4 bundle as a tagged no-traffic candidate.
-- Verify its runtime digest, provider refs, config, Auth0 manifest, secret versions, readiness, and lack of authorization-state mutation.
-- Change identity configuration only.
+- Deploy the exact T4 image and frozen configuration as a tagged no-traffic production revision.
+- Verify its runtime digest, provider refs, config, Auth0 state, secret versions, readiness, and lack of authorization-state mutation.
 - Keep external/database login disabled.
+- Do not mutate Auth0, GSM references, authorization, or runtime configuration after verification.
 
 ### Gate C
 
-1. Rehearse the complete Google, Auth0 tenant, secret-reference, and authorization-state rollback bundle in a production-shaped environment.
-2. Reverify the tagged candidate and all desired/live-state digests.
+1. Validate the Stack C rollout manifest and rehearse its single-step traffic rollback to the immutable Google revision.
+2. Reverify the tagged candidate and all frozen-state digests.
 3. Record each verifier’s normalized email subject and canonical UUID without logging tokens.
-4. Shift atomically; never split traffic across issuers.
+4. Cut over with one traffic-routing update to the verified Auth0 revision; never split traffic across issuers.
 5. Run all employee checks within 15 minutes.
-6. Roll back immediately on login failure, UUID change, empty catalog, UI denial, or CLI/MCP denial.
+6. Reverse only that routing update on login failure, UUID change, empty catalog, UI denial, or CLI/MCP denial.
 7. Soak for one business day.
 
 ## Stack D — External pilot
 
-### T6 — Probe
+### T6 — Immutable probe candidate
 
-- Enable the database connection for one pre-created verified user with public signup disabled.
-- Add one temporary domain to `allowedDomains`.
-- Run no-grant, app-role grant, cross-app/admin isolation, revoke, and employee-regression checks.
-- Use runtime relationships for grant/revoke; do not redeploy production config per user.
-- Disable the probe user and remove the temporary domain after the test.
+- Provision a separate pilot Auth0 client additively with Google Workspace, a database connection, public signup disabled, one pre-created verified user, and one temporary allowed domain.
+- Freeze that client and its secret versions, then build and deploy a tagged no-traffic revision bound to them.
+- Verify employee login, probe login, no-grant behavior, and frozen-state digests on the candidate hostname.
+- Do not mutate the active employee-only Auth0 client or revision.
+
+### Gate D
+
+1. Validate the Stack D rollout manifest and rehearse one-step traffic rollback to the employee-only Auth0 revision.
+2. Route traffic to the verified probe revision.
+3. Run app-role grant, cross-app/admin isolation, revoke, and employee-regression checks. Use runtime relationships for grant/revoke.
+4. Route back to the employee-only revision after the probe, then disable the unused pilot client.
 
 ### T7 — First partner
 
-- Add one approved domain and a small named cohort.
-- Keep public signup disabled.
-- Repeat employee and external checks before expanding.
+- Build a new frozen client/configuration and runtime revision for one approved domain and a small pre-created cohort; keep public signup disabled.
+- Add later users from that domain by pre-creating identities and runtime grants; this does not require a new client.
+- Require a new frozen client and runtime revision only when domains or authentication policy change.
 
-## Evidence required at every gate
+### Gate E
 
-- Immutable runtime image digest, provider refs, Toolshed commit, config digest, authorization digests, and users-table inventory digest.
-- People/Identity-to-users-table-to-roster reconciliation counts, freshness timestamp, and reviewed exclusions.
-- Auth0 desired/live-state digest, rollback export digest, and pinned GSM secret version IDs.
-- Verifier UUIDs and pass/fail results.
-- Denials segmented by login, catalog, UI, HTTP, CLI, MCP discovery/call, and admin.
-- Authorization plan diff, apply/rollback duration, relationship count, startup duration, and budget results.
-- Final reviewed SHA, resolved high/medium findings, settle-period end, deployment run, and candidate revision.
-- Two approvals: Gestalt authorization owner and Toolshed/on-call owner.
+1. Validate the partner rollout manifest and rehearse traffic rollback to the employee-only or previous partner revision.
+2. Route traffic to the verified partner revision.
+3. Run employee, no-grant, grant, isolation, revoke, renewal, and account-switching checks.
+4. Roll back only on failure; retain the partner revision after the defined soak succeeds.
+
+## Gate outputs
+
+- **Gate A:** Gestalt image digest; conformance report; server-surface report; startup/readiness results; rollback rehearsal.
+- **Gate B:** employee-source and join digests; aggregate reconciliation; baseline/shadow diff; authorization plan and snapshot digests; canary/verifier results.
+- **Gate C:** frozen Auth0-state and GSM-version digests; Google/Auth0 revision IDs; identity-continuity results; traffic rollback rehearsal.
+- **Gate D:** frozen pilot Auth0/GSM/runtime digests; named cohort; domain and connection state; revision IDs; traffic rollback rehearsal; exact runtime grant diff; no-grant/grant/isolation/revoke results; employee regression.
+- **Gate E:** frozen partner Auth0/GSM/runtime digests; named cohort and domain; previous/partner revision IDs; rollback rehearsal; full verifier results; soak result.
+
+Every output is produced by a literal manifest command and checked against that stack's numeric thresholds. Gate A does not require later-stack inventory or Auth0 evidence.
 
 Rollback immediately for any verifier failure, UUID change, employee access loss, unexpected external access, candidate readiness failure, inventory/Auth0/authorization drift, or exceeded deployment budget.

--- a/plans/external_users/implementation_v2.md
+++ b/plans/external_users/implementation_v2.md
@@ -6,14 +6,16 @@ Allow verified users from approved external domains to log in without changing e
 
 ## What failed
 
-1. **Inconsistent authorization.** Operation `CheckAccess` supported subject sets, but mounted UI, catalog, and admin paths used separate relationship scans. [#3061](https://github.com/valon-technologies/gestalt/pull/3061) broke group-only catalog access. [#3062](https://github.com/valon-technologies/gestalt/pull/3062) fixed only UI/catalog traversal.
-2. **Bad policy migration.** Setting the shared app wildcard to `[nobody]` denied hundreds of valid operations. The relationship-gated wildcard must remain `[viewer, user, editor, admin]`.
+1. **Inconsistent authorization.** Operation `CheckAccess` supported subject sets, but mounted UI, catalog, and app-admin paths did not share that evaluator. [#3061](https://github.com/valon-technologies/gestalt/pull/3061) broke group-only catalog access. [#3062](https://github.com/valon-technologies/gestalt/pull/3062) added subject-set traversal for mounted UI and catalog, but app-admin checks remained direct-only.
+2. **Bad policy migration.** Setting the shared app wildcard to `[nobody]` denied 713 operations that previously relied on wildcard viewer access. [Toolshed #4062](https://github.com/valon-technologies/toolshed/pull/4062) restored `[viewer, user, editor, admin]`.
 3. **Untested Auth0 configuration.** The cutover exposed, in sequence, an issuer mismatch, HS256 tokens, and missing connection/HRD setup.
 4. **Unsafe deployment state.** No-traffic Cloud Run candidates could overwrite shared authorization state during startup. Traffic rollback did not restore that state.
 5. **Non-reproducible binaries.** `GESTALTD_PINNED_SHA` was mutable and outside the Toolshed commit.
 6. **Oversized hotfix.** [#4071](https://github.com/valon-technologies/toolshed/pull/4071) generated 5,762 direct grants and failed startup probes. [#4073](https://github.com/valon-technologies/toolshed/pull/4073) restored service.
 
-The 67-user roster intentionally covered previously logged-in users and included Dave and Kevon. Roster completeness was not the cause. The #3062 binary was deployed by #4072 at 12:04 UTC, but Dave still reproduced UI, catalog, and CLI failures at 12:09 UTC. This confirms that authorization policy and evaluation remained incorrect across request surfaces.
+The 67-user roster intentionally covered previously logged-in users and included Dave and Kevon. Roster completeness was not the cause.
+
+The `[nobody]` policy explains earlier operation denials, and a focused regression test confirms that #3062 resolves a canonical UUID’s group-derived mounted-UI access. Neither explains Dave’s UI, catalog, and CLI failures after [Toolshed #4072](https://github.com/valon-technologies/toolshed/pull/4072) deployed #3062 with the restored wildcard. The exact post-#4072 failure remains unproven; stale or unexpected authorization state, artifact mismatch, and an uncovered production path remain hypotheses.
 
 ## Non-negotiables
 
@@ -21,9 +23,9 @@ The 67-user roster intentionally covered previously logged-in users and included
 - Keep the reviewed roster of previously logged-in users as canonical Gestalt UUIDs.
 - Add future users through an explicit, validated manual process.
 - Never use `[nobody]` as the shared app wildcard.
-- Never generate per-user/per-app grants.
+- Do not replace group access with generated per-user/per-app grants.
 - A no-traffic candidate must not mutate active authorization state.
-- Pin runtime, providers, config, and authorization state immutably.
+- Pin runtime, providers, config, and the static authorization baseline immutably; audit runtime grant changes.
 - Roll back on the first failed gate; do not stack hotfixes.
 - Keep federated logout out of this rollout.
 
@@ -121,8 +123,8 @@ Use the real authorization evaluator for at least one integration suite. Cover:
 
 1. Verify the previous authorization snapshot and rollback command.
 2. Apply T3.
-3. Run all employee and negative checks immediately.
-4. Restore Michael’s original direct grants.
+3. Temporarily remove Michael’s direct grants and run all verifier and negative checks.
+4. Restore Michael’s original direct grants and verify restoration.
 5. Repeat checks after 30 minutes and the next business morning.
 6. Soak for one business day.
 7. On failure, reactivate the previous authorization snapshot and runtime bundle.
@@ -175,10 +177,11 @@ This proves artifact compatibility, not production routing, cookies, or shared-s
 
 ### T7 — Probe
 
-- Enable one temporary domain and one pre-created verified user.
+- Enable the database connection for one pre-created verified user with public signup disabled.
+- Add one temporary domain to `allowedDomains`.
 - Run no-grant, grant, revoke, and employee-regression checks.
 - Use runtime relationships for grant/revoke; do not redeploy production config per user.
-- Remove the temporary domain after the test.
+- Disable the probe user and remove the temporary domain after the test.
 
 ### T8 — First partner
 

--- a/plans/external_users/implementation_v2.md
+++ b/plans/external_users/implementation_v2.md
@@ -6,37 +6,45 @@ Allow verified users from approved external domains to log in without changing e
 
 ## What failed
 
-1. **Incomplete employee migration.** The roster generator harvested UUIDs from existing authorization relationships instead of the Gestalt `users` table. The deployed roster contained 67 UUIDs; only 64 match current user records, while 294 of 358 users are absent. Dave and Kevon are in the users table but their canonical UUIDs are absent from the roster.
-2. **Inconsistent authorization.** Operation `CheckAccess` supported subject sets, but mounted UI, catalog, and app-admin paths did not share that evaluator. [#3061](https://github.com/valon-technologies/gestalt/pull/3061) broke group-only catalog access. [#3062](https://github.com/valon-technologies/gestalt/pull/3062) added subject-set traversal for mounted UI and catalog, but app-admin checks remained direct-only.
+1. **Incomplete employee migration.** The roster was derived from subjects already present in production authorization relationships instead of reconciling an employee authority against the Gestalt `users` table. Its validator checked that same incomplete source. The deployed roster contained 67 UUIDs and six email-form subjects.
+2. **Inconsistent authorization.** Operation `CheckAccess` supported subject sets, but mounted UI, catalog, and app-admin paths did not share that evaluator. [#3061](https://github.com/valon-technologies/gestalt/pull/3061) introduced direct-only catalog checks. [#3062](https://github.com/valon-technologies/gestalt/pull/3062) added subject-set traversal to the mounted-role helper, which the catalog reused, but app-admin checks remained direct-only.
 3. **Bad policy migration.** Setting the shared app wildcard to `[nobody]` denied 713 operations that previously relied on wildcard viewer access. [Toolshed #4062](https://github.com/valon-technologies/toolshed/pull/4062) restored `[viewer, user, editor, admin]`.
-4. **Untested Auth0 configuration.** The cutover exposed, in sequence, an issuer mismatch, HS256 tokens, and missing connection/HRD setup.
+4. **Untested Auth0 configuration.** The cutover exposed an issuer mismatch and missing connection/HRD setup, followed by HS256 tokens. Tenant changes were mutable and partly out of band.
 5. **Unsafe deployment state.** No-traffic Cloud Run candidates could overwrite shared authorization state during startup. Traffic rollback did not restore that state.
 6. **Non-reproducible binaries.** `GESTALTD_PINNED_SHA` was mutable and outside the Toolshed commit.
-7. **Oversized hotfix.** [#4071](https://github.com/valon-technologies/toolshed/pull/4071) generated 5,762 direct grants and failed startup probes. [#4073](https://github.com/valon-technologies/toolshed/pull/4073) restored service.
+7. **Oversized hotfix.** [#4071](https://github.com/valon-technologies/toolshed/pull/4071) added 5,762 direct grants and failed startup probes. [#4073](https://github.com/valon-technologies/toolshed/pull/4073) restored the prior repository tree and deployed successfully; its employee UI/CLI verification was not recorded.
 
-The missing canonical memberships explain why Dave and Kevon still failed after [Toolshed #4072](https://github.com/valon-technologies/toolshed/pull/4072) deployed #3062 with the restored wildcard: subject-set traversal cannot grant access to a UUID that is not a member of the subject set. A focused regression test confirms both sides of this behavior—a roster UUID receives group-derived access and an absent UUID is denied.
+The current production users-table comparison finds 358 users, of whom 64 match the 67 roster UUIDs; 294 are absent and three roster UUIDs are orphaned. All six email-form entries duplicate UUID-backed users. These counts prove that the inventory process was incomplete, not that all 294 records were active employees.
 
-The users-table comparison uses current production state, so its aggregate counts are evidence of a broken inventory process rather than a historical snapshot of the incident minute. The historical deployed roster independently confirms that Dave and Kevon were absent.
+The current users table maps Dave and Kevon to canonical UUIDs absent from the historical roster. That is the leading explanation for their post-[#4072](https://github.com/valon-technologies/toolshed/pull/4072) authorization failures: subject-set traversal cannot grant access to a UUID outside the set, and a focused regression test reproduces that behavior. The incident did not preserve a versioned users-table snapshot and request-subject report, so the person-specific conclusion is not treated as proven.
 
 ## Non-negotiables
 
 - Keep Google login until explicit employee authorization passes and soaks.
-- Build the employee inventory from a versioned users-table snapshot, not existing authorization relationships.
-- Reconcile every users-table record to either a canonical employee UUID or an explicitly reviewed exclusion; do not grant employee access solely from email domain.
-- Add future users through an explicit, validated process that updates the reconciliation.
+- Build employee eligibility from an approved People/Identity authority, joined to canonical Gestalt users; never infer employment from authorization rows or email domain alone.
+- Reconcile every users-table record to either an active employee UUID or an explicitly reviewed exclusion.
+- Store the restricted inventory outside source control; commit only its digest, counts, and reviewed exception identifiers.
+- Recheck inventory immediately before activation and provision future employee membership before first login.
 - Never use `[nobody]` as the shared app wildcard.
 - Do not replace group access with generated per-user/per-app grants.
 - A no-traffic candidate must not mutate active authorization state.
-- Pin runtime, providers, config, and the static authorization baseline immutably; audit runtime grant changes.
+- Pin runtime, providers, config, static authorization, Auth0 tenant state, and GSM secret version IDs; audit runtime grant changes.
 - Roll back on the first failed gate; do not stack hotfixes.
 - Keep federated logout out of this rollout.
+
+## Release controls
+
+- Allow one production deployment at a time with workflow concurrency and a protected-environment approval.
+- Resolve all high- and medium-severity review findings on the final SHA, then wait for the agreed review-settle period.
+- Define maximum relationship-count growth, authorization-state diff size, startup duration, and readiness duration before deployment.
+- A failed gate freezes merges and queued deployments. A named incident commander must approve resumption.
 
 ## Verifiers
 
 - **Michael:** temporary group-only canary after the no-default snapshot is active.
 - **Dave:** fresh browser and CLI session.
 - **Kevon:** fresh browser and MCP session.
-- **App admin:** management and user-lookup paths.
+- **Named employee app admin:** management and user-lookup paths.
 - **External probe:** verified, pre-created database user; public signup disabled.
 
 Required employee checks:
@@ -45,33 +53,44 @@ Required employee checks:
 - Meal Swap, AI Spend, and Build load.
 - Fresh CLI session can run read-only Linear and Slack operations.
 - MCP lists and successfully calls read-only Linear and Slack operations.
-- App-admin management and lookup paths work.
+- Employee app-admin management and authorized lookup paths work.
 
 Required negative checks:
 
 - An ungranted identity cannot see or invoke internal apps.
 - An external probe sees home only before a grant.
-- Grant exposes only the selected app/action.
+- A grant exposes only the selected app role and the actions that role permits.
+- An external app admin cannot enumerate users or manage another app.
 - Revoke removes access promptly.
 
 ## Stack A — Gestalt correctness
 
-### G1 — Canonical identity
+### G1 — Deployment-safe authorization state
+
+- Remove implicit active-state writes from normal server startup before any production candidate is started.
+- Add explicit authorization `plan`, `apply`, and `rollback`.
+- Record model digest, relationship digest, previous snapshot, and exact rollback command.
+- Make activation atomic and prevent candidate, old-revision, and concurrent runtime-grant races.
+- Store the gestaltd SHA and resolved image digest in the deployment bundle, not a mutable repository variable.
+- Reject authorization plans that exceed the predeclared count, diff, startup, or readiness budgets.
+
+### G2 — Canonical identity
 
 - Resolve verified `user:<email>` to persisted `user:<uuid>` before every authorization boundary.
 - Fail closed when user-store resolution fails.
 - Reject or explicitly map opaque subjects such as `user:auth0|...`.
 - Prove Google and Auth0 tokens for the same verified email resolve to the same existing UUID across browser, CLI, API token, and MCP.
 
-### G2 — Shared effective-access contract
+### G3 — Shared effective-access contract
 
 - Keep provider `CheckAccess` authoritative for operation actions.
 - Replace direct-only UI, catalog, and admin scans with one effective-role contract that supports subject sets.
 - Centralize app key, resource type/ID, and `authorizationPolicy` mapping.
 - Cover mounted UI, catalog, management paths, app admin, lookup, operation invocation, and MCP tool listing/calls.
+- Restrict user lookup to an explicit employee operator role; app-scoped administration alone must not permit user enumeration.
 - Bound any relationship traversal by pages, depth, and query count; fail closed on malformed sets.
 
-### G3 — Conformance suite
+### G4 — Conformance suite
 
 Use the real authorization evaluator for at least one integration suite. Cover:
 
@@ -79,15 +98,17 @@ Use the real authorization evaluator for at least one integration suite. Cover:
 - group-derived admin;
 - custom policy aliases and dedicated resource types;
 - employee, elevated admin, ungranted external, granted external, and revoked external;
+- external app-admin isolation and user-lookup denial;
 - browser, CLI exchange, API token, MCP `tools/list`, and MCP calls.
 
 ### Gate A
 
-1. Pin the exact G3 image digest in source-controlled deployment input.
-2. Deploy under Google with current default-role behavior unchanged.
-3. Run the current-access regression matrix for all employee verifiers.
-4. Run Michael group-only in a production-shaped isolated environment with `defaultRole` removed.
-5. Stop and restore the prior immutable bundle on any failure.
+1. Complete G1 before starting any candidate connected to production authorization storage.
+2. Pin the exact G4 image digest in source-controlled deployment input.
+3. Deploy under Google with current default-role behavior unchanged.
+4. Run the current-access regression matrix for all employee verifiers.
+5. Run Michael group-only in a production-shaped isolated environment with `defaultRole` removed.
+6. Stop and restore the prior immutable bundle on any failure.
 
 ## Stack B — Employee authorization under Google
 
@@ -95,28 +116,24 @@ Use the real authorization evaluator for at least one integration suite. Cover:
 
 - Resolve every app’s key, resource type/ID, policy alias, valid relations, mounted roles, management path, and registered operations.
 - Explicitly cover Talent Team, Rippling, Traffic Cop, agent-trace-viewer, and other dedicated policies.
-- Export and version a point-in-time production users-table inventory containing canonical UUID and normalized email.
-- Classify every record as employee or reviewed exclusion. Require an owner and reason for non-Valon, test, duplicate, stale, and service accounts.
+- Export a restricted, point-in-time users-table inventory containing canonical UUID and normalized email.
+- Join the approved People/Identity employee source to that inventory.
+- Classify every unmatched record as a reviewed exclusion. Require an owner and reason for non-Valon, test, duplicate, stale, and service accounts.
 - Verify every employee entry is a unique, canonical Gestalt UUID and every roster UUID resolves to exactly one users-table record.
 - Generate the employee membership file from the reviewed inventory, never from existing authorization relationships.
 - Produce a set-difference report and require zero unclassified users, zero missing employees, zero duplicate UUIDs, and zero orphaned roster UUIDs.
-- Document the lookup, classification, validation, addition, and removal workflow.
+- Commit the inventory digest and reconciliation summary, not raw email/UUID pairs.
+- Document lookup, classification, onboarding, removal, and emergency correction. Employee onboarding must add membership before first Gestalt login.
 
-### T2 — Versioned authorization state
-
-- Remove implicit active-state writes from normal server startup.
-- Add explicit authorization `plan`, `apply`, and `rollback`.
-- Record model digest, relationship digest, previous snapshot, and exact rollback command.
-- Make activation atomic and prevent candidate/old-revision races.
-- Store the gestaltd SHA and resolved image digest in the deployment bundle, not a mutable repository variable.
-
-### T3 — Preseed, shadow, activate
+### T2 — Preseed, shadow, activate
 
 1. Add compact employee memberships and subject-set grants while `defaultRole` remains active.
-2. Shadow-evaluate the proposed no-default model for every employee and inventoried access path.
-3. Require zero unexpected employee denials and zero unexpected control-user allows.
-4. Apply the no-default snapshot under Google.
-5. Keep:
+2. Capture the current effective-access matrix for every approved employee, resource, and registered action.
+3. Shadow-evaluate the proposed no-default model against that baseline across provider and server authorization paths.
+4. Require zero unexplained employee denials and zero unexpected control-user allows.
+5. Re-export and reconcile the users table immediately before apply; stop on any digest or classification change.
+6. Apply the no-default snapshot under Google.
+7. Keep:
 
    ```yaml
    actions:
@@ -128,18 +145,19 @@ Use the real authorization evaluator for at least one integration suite. Cover:
 
 1. Verify the users-table reconciliation, previous authorization snapshot, and rollback command.
 2. Require every approved employee UUID to pass the shadow evaluation before removing `defaultRole`.
-3. Apply T3.
-4. Temporarily remove Michael’s direct grants and run all verifier and negative checks.
-5. Restore Michael’s original direct grants and verify restoration.
-6. Repeat checks after 30 minutes and the next business morning.
-7. Soak for one business day.
-8. On failure, reactivate the previous authorization snapshot and runtime bundle.
+3. Require the authorization plan to remain within the declared count, diff, startup, and readiness budgets.
+4. Apply T2.
+5. Temporarily remove Michael’s direct grants and run all verifier and negative checks.
+6. Restore Michael’s original direct grants and verify restoration.
+7. Repeat checks after 30 minutes and the next business morning.
+8. Soak for one business day.
+9. On failure, reactivate the previous authorization snapshot and runtime bundle.
 
 ## Stack C — Employee-only Auth0
 
-### T4 — Live preflight
+### T3 — Versioned Auth0 state and live preflight
 
-Run a real authorization-code flow against the exact candidate application and artifacts. Verify:
+Create a reviewed desired-state manifest and rollback export for the exact Auth0 client, enabled connections, HRD domains, callback/logout URLs, signing algorithm, database signup setting, and GSM secret version IDs. Diff live state against it, then run a real authorization-code flow. Verify:
 
 - configured issuer exactly matches discovery;
 - ID token uses RS256 and passes JWKS verification;
@@ -149,12 +167,12 @@ Run a real authorization-code flow against the exact candidate application and a
 - callbacks and logout URLs are allowlisted;
 - Google Workspace connection and HRD are enabled;
 - database login and public signup are disabled;
-- GSM values and IAM are correct;
+- pinned GSM versions and IAM are correct;
 - `allowedDomains` is `[valon.com]`.
 
 Do not weaken issuer or algorithm validation. Add provider tests only for a concrete gap.
 
-### T5 — Isolated candidate
+### T4 — Isolated candidate
 
 - Deploy the exact production candidate on a separate hostname.
 - Preserve a controlled copy of production user UUIDs.
@@ -164,32 +182,34 @@ Do not weaken issuer or algorithm validation. Add provider tests only for a conc
 
 This proves artifact compatibility, not production routing, cookies, or shared-state behavior.
 
-### T6 — Production cutover
+### T5 — Production cutover
 
-- Deploy the exact immutable T5 bundle.
+- Deploy the exact immutable T4 bundle as a tagged no-traffic candidate.
+- Verify its runtime digest, provider refs, config, Auth0 manifest, secret versions, readiness, and lack of authorization-state mutation.
 - Change identity configuration only.
 - Keep external/database login disabled.
-- Shift atomically; never split traffic across issuers.
 
 ### Gate C
 
-1. Retain verified Google and authorization-state rollback commands.
-2. Record each verifier’s normalized email subject and canonical UUID without logging tokens.
-3. Run all employee checks within 15 minutes.
-4. Roll back immediately on login failure, UUID change, empty catalog, UI denial, or CLI/MCP denial.
-5. Soak for one business day.
+1. Rehearse the complete Google, Auth0 tenant, secret-reference, and authorization-state rollback bundle in a production-shaped environment.
+2. Reverify the tagged candidate and all desired/live-state digests.
+3. Record each verifier’s normalized email subject and canonical UUID without logging tokens.
+4. Shift atomically; never split traffic across issuers.
+5. Run all employee checks within 15 minutes.
+6. Roll back immediately on login failure, UUID change, empty catalog, UI denial, or CLI/MCP denial.
+7. Soak for one business day.
 
 ## Stack D — External pilot
 
-### T7 — Probe
+### T6 — Probe
 
 - Enable the database connection for one pre-created verified user with public signup disabled.
 - Add one temporary domain to `allowedDomains`.
-- Run no-grant, grant, revoke, and employee-regression checks.
+- Run no-grant, app-role grant, cross-app/admin isolation, revoke, and employee-regression checks.
 - Use runtime relationships for grant/revoke; do not redeploy production config per user.
 - Disable the probe user and remove the temporary domain after the test.
 
-### T8 — First partner
+### T7 — First partner
 
 - Add one approved domain and a small named cohort.
 - Keep public signup disabled.
@@ -198,10 +218,12 @@ This proves artifact compatibility, not production routing, cookies, or shared-s
 ## Evidence required at every gate
 
 - Immutable runtime image digest, provider refs, Toolshed commit, config digest, authorization digests, and users-table inventory digest.
-- Users-table-to-roster reconciliation counts and reviewed exclusions.
+- People/Identity-to-users-table-to-roster reconciliation counts, freshness timestamp, and reviewed exclusions.
+- Auth0 desired/live-state digest, rollback export digest, and pinned GSM secret version IDs.
 - Verifier UUIDs and pass/fail results.
 - Denials segmented by login, catalog, UI, HTTP, CLI, MCP discovery/call, and admin.
-- Authorization apply/rollback duration and relationship count.
+- Authorization plan diff, apply/rollback duration, relationship count, startup duration, and budget results.
+- Final reviewed SHA, resolved high/medium findings, settle-period end, deployment run, and candidate revision.
 - Two approvals: Gestalt authorization owner and Toolshed/on-call owner.
 
-Rollback immediately for any verifier failure, UUID change, employee access loss, unexpected external access, candidate readiness failure, or authorization digest change outside explicit apply/rollback.
+Rollback immediately for any verifier failure, UUID change, employee access loss, unexpected external access, candidate readiness failure, inventory/Auth0/authorization drift, or exceeded deployment budget.

--- a/plans/external_users/implementation_v2.md
+++ b/plans/external_users/implementation_v2.md
@@ -6,22 +6,24 @@ Allow verified users from approved external domains to log in without changing e
 
 ## What failed
 
-1. **Inconsistent authorization.** Operation `CheckAccess` supported subject sets, but mounted UI, catalog, and app-admin paths did not share that evaluator. [#3061](https://github.com/valon-technologies/gestalt/pull/3061) broke group-only catalog access. [#3062](https://github.com/valon-technologies/gestalt/pull/3062) added subject-set traversal for mounted UI and catalog, but app-admin checks remained direct-only.
-2. **Bad policy migration.** Setting the shared app wildcard to `[nobody]` denied 713 operations that previously relied on wildcard viewer access. [Toolshed #4062](https://github.com/valon-technologies/toolshed/pull/4062) restored `[viewer, user, editor, admin]`.
-3. **Untested Auth0 configuration.** The cutover exposed, in sequence, an issuer mismatch, HS256 tokens, and missing connection/HRD setup.
-4. **Unsafe deployment state.** No-traffic Cloud Run candidates could overwrite shared authorization state during startup. Traffic rollback did not restore that state.
-5. **Non-reproducible binaries.** `GESTALTD_PINNED_SHA` was mutable and outside the Toolshed commit.
-6. **Oversized hotfix.** [#4071](https://github.com/valon-technologies/toolshed/pull/4071) generated 5,762 direct grants and failed startup probes. [#4073](https://github.com/valon-technologies/toolshed/pull/4073) restored service.
+1. **Incomplete employee migration.** The roster generator harvested UUIDs from existing authorization relationships instead of the Gestalt `users` table. The deployed roster contained 67 UUIDs; only 64 match current user records, while 294 of 358 users are absent. Dave and Kevon are in the users table but their canonical UUIDs are absent from the roster.
+2. **Inconsistent authorization.** Operation `CheckAccess` supported subject sets, but mounted UI, catalog, and app-admin paths did not share that evaluator. [#3061](https://github.com/valon-technologies/gestalt/pull/3061) broke group-only catalog access. [#3062](https://github.com/valon-technologies/gestalt/pull/3062) added subject-set traversal for mounted UI and catalog, but app-admin checks remained direct-only.
+3. **Bad policy migration.** Setting the shared app wildcard to `[nobody]` denied 713 operations that previously relied on wildcard viewer access. [Toolshed #4062](https://github.com/valon-technologies/toolshed/pull/4062) restored `[viewer, user, editor, admin]`.
+4. **Untested Auth0 configuration.** The cutover exposed, in sequence, an issuer mismatch, HS256 tokens, and missing connection/HRD setup.
+5. **Unsafe deployment state.** No-traffic Cloud Run candidates could overwrite shared authorization state during startup. Traffic rollback did not restore that state.
+6. **Non-reproducible binaries.** `GESTALTD_PINNED_SHA` was mutable and outside the Toolshed commit.
+7. **Oversized hotfix.** [#4071](https://github.com/valon-technologies/toolshed/pull/4071) generated 5,762 direct grants and failed startup probes. [#4073](https://github.com/valon-technologies/toolshed/pull/4073) restored service.
 
-The 67-user roster intentionally covered previously logged-in users and included Dave and Kevon. Roster completeness was not the cause.
+The missing canonical memberships explain why Dave and Kevon still failed after [Toolshed #4072](https://github.com/valon-technologies/toolshed/pull/4072) deployed #3062 with the restored wildcard: subject-set traversal cannot grant access to a UUID that is not a member of the subject set. A focused regression test confirms both sides of this behavior—a roster UUID receives group-derived access and an absent UUID is denied.
 
-The `[nobody]` policy explains earlier operation denials, and a focused regression test confirms that #3062 resolves a canonical UUID’s group-derived mounted-UI access. Neither explains Dave’s UI, catalog, and CLI failures after [Toolshed #4072](https://github.com/valon-technologies/toolshed/pull/4072) deployed #3062 with the restored wildcard. The exact post-#4072 failure remains unproven; stale or unexpected authorization state, artifact mismatch, and an uncovered production path remain hypotheses.
+The users-table comparison uses current production state, so its aggregate counts are evidence of a broken inventory process rather than a historical snapshot of the incident minute. The historical deployed roster independently confirms that Dave and Kevon were absent.
 
 ## Non-negotiables
 
 - Keep Google login until explicit employee authorization passes and soaks.
-- Keep the reviewed roster of previously logged-in users as canonical Gestalt UUIDs.
-- Add future users through an explicit, validated manual process.
+- Build the employee inventory from a versioned users-table snapshot, not existing authorization relationships.
+- Reconcile every users-table record to either a canonical employee UUID or an explicitly reviewed exclusion; do not grant employee access solely from email domain.
+- Add future users through an explicit, validated process that updates the reconciliation.
 - Never use `[nobody]` as the shared app wildcard.
 - Do not replace group access with generated per-user/per-app grants.
 - A no-traffic candidate must not mutate active authorization state.
@@ -93,9 +95,12 @@ Use the real authorization evaluator for at least one integration suite. Cover:
 
 - Resolve every app’s key, resource type/ID, policy alias, valid relations, mounted roles, management path, and registered operations.
 - Explicitly cover Talent Team, Rippling, Traffic Cop, agent-trace-viewer, and other dedicated policies.
-- Verify every reviewed roster entry is a unique, canonical Gestalt UUID.
-- Document the manual lookup, validation, addition, and removal workflow.
-- Block on missing users, duplicates, or noncanonical subjects.
+- Export and version a point-in-time production users-table inventory containing canonical UUID and normalized email.
+- Classify every record as employee or reviewed exclusion. Require an owner and reason for non-Valon, test, duplicate, stale, and service accounts.
+- Verify every employee entry is a unique, canonical Gestalt UUID and every roster UUID resolves to exactly one users-table record.
+- Generate the employee membership file from the reviewed inventory, never from existing authorization relationships.
+- Produce a set-difference report and require zero unclassified users, zero missing employees, zero duplicate UUIDs, and zero orphaned roster UUIDs.
+- Document the lookup, classification, validation, addition, and removal workflow.
 
 ### T2 — Versioned authorization state
 
@@ -121,13 +126,14 @@ Use the real authorization evaluator for at least one integration suite. Cover:
 
 ### Gate B
 
-1. Verify the previous authorization snapshot and rollback command.
-2. Apply T3.
-3. Temporarily remove Michael’s direct grants and run all verifier and negative checks.
-4. Restore Michael’s original direct grants and verify restoration.
-5. Repeat checks after 30 minutes and the next business morning.
-6. Soak for one business day.
-7. On failure, reactivate the previous authorization snapshot and runtime bundle.
+1. Verify the users-table reconciliation, previous authorization snapshot, and rollback command.
+2. Require every approved employee UUID to pass the shadow evaluation before removing `defaultRole`.
+3. Apply T3.
+4. Temporarily remove Michael’s direct grants and run all verifier and negative checks.
+5. Restore Michael’s original direct grants and verify restoration.
+6. Repeat checks after 30 minutes and the next business morning.
+7. Soak for one business day.
+8. On failure, reactivate the previous authorization snapshot and runtime bundle.
 
 ## Stack C — Employee-only Auth0
 
@@ -191,7 +197,8 @@ This proves artifact compatibility, not production routing, cookies, or shared-s
 
 ## Evidence required at every gate
 
-- Immutable runtime image digest, provider refs, Toolshed commit, config digest, and authorization digests.
+- Immutable runtime image digest, provider refs, Toolshed commit, config digest, authorization digests, and users-table inventory digest.
+- Users-table-to-roster reconciliation counts and reviewed exclusions.
 - Verifier UUIDs and pass/fail results.
 - Denials segmented by login, catalog, UI, HTTP, CLI, MCP discovery/call, and admin.
 - Authorization apply/rollback duration and relationship count.


### PR DESCRIPTION
## Summary
- distinguish proven incident failures from the leading but unproven person-specific membership explanation
- require one provider-owned authorization evaluator for UI, catalog, admin, invocation, and MCP
- derive employee membership from the People/Identity authority joined to canonical Gestalt users
- replace live canary mutations with a permanently group-only canary and atomic authorization snapshots
- drive each stack from a machine-readable rollout manifest with literal commands, thresholds, owners, outputs, and rollback
- use separate frozen Auth0 clients/revisions and single traffic-pointer cutovers for employee, probe, and partner releases

## Evidence reviewed
- Toolshed #4044, #4046, #4049, #4050, #4054, #4061–#4064, #4066–#4068, and #4071–#4073
- Gestalt #3052, #3054, #3056, and #3058–#3063
- current users-table versus historical roster reconciliation
- provider access, identity canonicalization, bootstrap-state, mounted UI, catalog, and app-admin behavior

## Validation
- [x] Run focused provider, identity, bootstrap, and server-surface tests
- [x] Validate users-table/roster edge cases
- [x] Run `git diff --check`
- [x] Pass thermo-nuclear structural review after three review/fix rounds