### PR TITLE
gestaltd: expose read-only app admin agent identities

### DIFF
--- a/gestaltd/internal/server/handlers_app_admin_authorization_projections_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_authorization_projections_test.go
@@ -1,0 +1,44 @@
+package server
+
+import (
+	"testing"
+)
+
+func TestAppAdminGrantRosterPartition(t *testing.T) {
+	t.Parallel()
+
+	rows := []appAdminMemberRow{
+		{SubjectID: "user:alice", SelectorKind: "subject_id", SelectorValue: "user:alice", Role: "admin", Source: "static", Effective: true},
+		{SelectorKind: "subject_set", SelectorValue: "group:eng#member", Role: "viewer", Source: "static", Effective: true},
+		{SubjectID: "service_account:slack-bot", SelectorKind: "subject_id", SelectorValue: "service_account:slack-bot", Role: "viewer", Source: "static", Effective: true},
+		{SubjectID: "service_account:slack-bot", SelectorKind: "subject_id", SelectorValue: "service_account:slack-bot", Role: "viewer", Source: "dynamic", Effective: false, ShadowedBy: "static viewer grant"},
+		{SubjectID: "user:bob", SelectorKind: "subject_id", SelectorValue: "user:bob", Role: "viewer", Source: "dynamic", Effective: true},
+	}
+
+	s := &Server{}
+	humans := s.projectAppAdminHumanMemberRows(t.Context(), rows)
+	identities := s.projectAppAdminIdentityRows(t.Context(), rows)
+
+	if len(humans) != 3 {
+		t.Fatalf("humans = %#v, want 3 rows", humans)
+	}
+	if len(identities) != 2 {
+		t.Fatalf("identities = %#v, want 2 rows", identities)
+	}
+	for _, row := range humans {
+		if isAppAdminServiceAccountRow(row) {
+			t.Fatalf("service account leaked into humans: %#v", row)
+		}
+	}
+	for _, row := range identities {
+		if !isAppAdminServiceAccountRow(appAdminMemberRow{
+			SubjectID:    row.SubjectID,
+			SelectorKind: "subject_id",
+		}) {
+			t.Fatalf("non-service-account leaked into identities: %#v", row)
+		}
+	}
+	if got := len(humans) + len(identities); got != len(rows) {
+		t.Fatalf("partition lost or duplicated rows: humans=%d identities=%d input=%d", len(humans), len(identities), len(rows))
+	}
+}

--- a/gestaltd/internal/server/handlers_app_admin_identities.go
+++ b/gestaltd/internal/server/handlers_app_admin_identities.go
@@ -1,0 +1,79 @@
+package server
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/valon-technologies/gestalt/server/core"
+)
+
+// appAdminIdentityRow is the read model for GET /apps/{app}/admin/identities.
+// It is the agent-identity projection of app authorization relationships:
+// service_account subjects with a grant on this app.
+type appAdminIdentityRow struct {
+	SubjectID   string `json:"subjectId"`
+	DisplayName string `json:"displayName"`
+	Role        string `json:"role"`
+	Source      string `json:"source"`
+	Mutable     bool   `json:"mutable"`
+	Effective   bool   `json:"effective"`
+	ShadowedBy  string `json:"shadowedBy,omitempty"`
+}
+
+func (s *Server) mountAppAdminIdentitiesRoutes(r chi.Router) {
+	r.With(s.pluginRouteAuthMiddleware("app"), s.appAdminAuthorizationMiddleware).
+		Get("/apps/{app}/admin/identities", s.listAppAdminIdentities)
+}
+
+func (s *Server) listAppAdminIdentities(w http.ResponseWriter, r *http.Request) {
+	appName := strings.TrimSpace(chi.URLParam(r, "app"))
+	if appName == "" {
+		writeError(w, http.StatusBadRequest, "app is required")
+		return
+	}
+	if s.authorization == nil {
+		writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
+		return
+	}
+
+	memberRows, err := s.listAppAuthorizationMemberRows(r.Context(), appName)
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
+		return
+	}
+	writeJSON(w, http.StatusOK, projectAppAdminIdentityRows(memberRows))
+}
+
+func projectAppAdminIdentityRows(rows []appAdminMemberRow) []appAdminIdentityRow {
+	out := make([]appAdminIdentityRow, 0)
+	for _, row := range rows {
+		if !isAppAdminServiceAccountRow(row) {
+			continue
+		}
+		kind, localID, ok := core.ParseSubjectID(row.SubjectID)
+		displayName := row.SubjectID
+		if ok && kind == "service_account" && localID != "" {
+			displayName = localID
+		}
+		out = append(out, appAdminIdentityRow{
+			SubjectID:   row.SubjectID,
+			DisplayName: displayName,
+			Role:        row.Role,
+			Source:      row.Source,
+			Mutable:     row.Mutable,
+			Effective:   row.Effective,
+			ShadowedBy:  row.ShadowedBy,
+		})
+	}
+	return out
+}
+
+func isAppAdminServiceAccountRow(row appAdminMemberRow) bool {
+	if row.SelectorKind != "subject_id" || row.SubjectID == "" {
+		return false
+	}
+	kind, _, ok := core.ParseSubjectID(row.SubjectID)
+	return ok && kind == "service_account"
+}

--- a/gestaltd/internal/server/handlers_app_admin_identities.go
+++ b/gestaltd/internal/server/handlers_app_admin_identities.go
@@ -1,12 +1,11 @@
 package server
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
-
-	"github.com/valon-technologies/gestalt/server/core"
 )
 
 // appAdminIdentityRow is the read model for GET /apps/{app}/admin/identities.
@@ -43,19 +42,21 @@ func (s *Server) listAppAdminIdentities(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
 		return
 	}
-	writeJSON(w, http.StatusOK, projectAppAdminIdentityRows(memberRows))
+	writeJSON(w, http.StatusOK, s.projectAppAdminIdentityRows(r.Context(), memberRows))
 }
 
-func projectAppAdminIdentityRows(rows []appAdminMemberRow) []appAdminIdentityRow {
+// projectAppAdminIdentityRows is the service-account projection of the shared
+// app authorization grant roster. Display labels use the same subject resolver
+// as registry revision actors (ManagedSubject when present).
+func (s *Server) projectAppAdminIdentityRows(ctx context.Context, rows []appAdminMemberRow) []appAdminIdentityRow {
 	out := make([]appAdminIdentityRow, 0)
 	for _, row := range rows {
 		if !isAppAdminServiceAccountRow(row) {
 			continue
 		}
-		kind, localID, ok := core.ParseSubjectID(row.SubjectID)
-		displayName := row.SubjectID
-		if ok && kind == "service_account" && localID != "" {
-			displayName = localID
+		displayName := strings.TrimSpace(s.resolveRevisionActorLabel(ctx, row.SubjectID))
+		if displayName == "" {
+			displayName = row.SubjectID
 		}
 		out = append(out, appAdminIdentityRow{
 			SubjectID:   row.SubjectID,
@@ -68,12 +69,4 @@ func projectAppAdminIdentityRows(rows []appAdminMemberRow) []appAdminIdentityRow
 		})
 	}
 	return out
-}
-
-func isAppAdminServiceAccountRow(row appAdminMemberRow) bool {
-	if row.SelectorKind != "subject_id" || row.SubjectID == "" {
-		return false
-	}
-	kind, _, ok := core.ParseSubjectID(row.SubjectID)
-	return ok && kind == "service_account"
 }

--- a/gestaltd/internal/server/handlers_app_admin_identities.go
+++ b/gestaltd/internal/server/handlers_app_admin_identities.go
@@ -46,17 +46,22 @@ func (s *Server) listAppAdminIdentities(w http.ResponseWriter, r *http.Request) 
 }
 
 // projectAppAdminIdentityRows is the service-account projection of the shared
-// app authorization grant roster. Display labels use the same subject resolver
-// as registry revision actors (ManagedSubject when present).
+// app authorization grant roster. Display labels use the shared subject
+// presentation helper (ManagedSubject when present).
 func (s *Server) projectAppAdminIdentityRows(ctx context.Context, rows []appAdminMemberRow) []appAdminIdentityRow {
+	labels := make(map[string]string)
 	out := make([]appAdminIdentityRow, 0)
 	for _, row := range rows {
 		if !isAppAdminServiceAccountRow(row) {
 			continue
 		}
-		displayName := strings.TrimSpace(s.resolveRevisionActorLabel(ctx, row.SubjectID))
-		if displayName == "" {
-			displayName = row.SubjectID
+		displayName, ok := labels[row.SubjectID]
+		if !ok {
+			displayName = strings.TrimSpace(s.resolveSubjectDisplayLabel(ctx, row.SubjectID))
+			if displayName == "" {
+				displayName = row.SubjectID
+			}
+			labels[row.SubjectID] = displayName
 		}
 		out = append(out, appAdminIdentityRow{
 			SubjectID:   row.SubjectID,

--- a/gestaltd/internal/server/handlers_app_admin_identities_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_identities_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/internal/server"
@@ -120,6 +121,230 @@ func TestAppAdminIdentitiesList(t *testing.T) {
 	}
 	if _, ok := bySubject[adminID]; ok {
 		t.Fatalf("human subjects must not appear in identities: %#v", rows)
+	}
+}
+
+func TestAppAdminIdentitiesListShadowsRuntimeDuplicate(t *testing.T) {
+	t.Parallel()
+
+	adminID := principal.UserSubjectID("alice")
+	const saID = "service_account:slack-bot"
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(adminID, "admin", "app", "g-issues"),
+			{
+				Tuple: &proto.RelationshipTuple{
+					Target: &proto.RelationshipTarget{
+						Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{
+							Type: "subject",
+							Id:   saID,
+						}},
+					},
+					Relation: "viewer",
+					Resource: &proto.Resource{Type: "app", Id: "g-issues"},
+				},
+				SourceLayer: proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG,
+			},
+			{
+				Tuple: &proto.RelationshipTuple{
+					Target: &proto.RelationshipTarget{
+						Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{
+							Type: "subject",
+							Id:   saID,
+						}},
+					},
+					Relation: "viewer",
+					Resource: &proto.Resource{Type: "app", Id: "g-issues"},
+				},
+				SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME,
+			},
+		},
+	}
+	authz.relationships[0].SourceLayer = proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", adminID, "")
+		cfg.Authorization = authz
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	request, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/g-issues/admin/identities", nil)
+	request.Header.Set("Authorization", "Bearer alice-token")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET identities: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("GET status = %d: %s", response.StatusCode, body)
+	}
+
+	var rows []struct {
+		Role       string `json:"role"`
+		Source     string `json:"source"`
+		Effective  bool   `json:"effective"`
+		ShadowedBy string `json:"shadowedBy"`
+		SubjectID  string `json:"subjectId"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&rows); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	var staticViewer, dynamicViewer *struct {
+		Role       string `json:"role"`
+		Source     string `json:"source"`
+		Effective  bool   `json:"effective"`
+		ShadowedBy string `json:"shadowedBy"`
+		SubjectID  string `json:"subjectId"`
+	}
+	for i := range rows {
+		row := &rows[i]
+		if row.SubjectID != saID || row.Role != "viewer" {
+			continue
+		}
+		switch row.Source {
+		case "static":
+			staticViewer = row
+		case "dynamic":
+			dynamicViewer = row
+		}
+	}
+	if staticViewer == nil || !staticViewer.Effective || staticViewer.ShadowedBy != "" {
+		t.Fatalf("static viewer = %#v", staticViewer)
+	}
+	if dynamicViewer == nil || dynamicViewer.Effective || dynamicViewer.ShadowedBy != "static viewer grant" {
+		t.Fatalf("dynamic viewer = %#v", dynamicViewer)
+	}
+}
+
+func TestAppAdminIdentitiesListExcludesSubjectSet(t *testing.T) {
+	t.Parallel()
+
+	adminID := principal.UserSubjectID("alice")
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(adminID, "admin", "app", "g-issues"),
+			{
+				Tuple: &proto.RelationshipTuple{
+					Target: &proto.RelationshipTarget{
+						Kind: &proto.RelationshipTarget_SubjectSet{
+							SubjectSet: &proto.SubjectSet{
+								Resource: &proto.Resource{Type: "group", Id: "eng"},
+								Relation: "member",
+							},
+						},
+					},
+					Relation: "viewer",
+					Resource: &proto.Resource{Type: "app", Id: "g-issues"},
+				},
+				SourceLayer: proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG,
+			},
+			{
+				Tuple: &proto.RelationshipTuple{
+					Target: &proto.RelationshipTarget{
+						Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{
+							Type: "subject",
+							Id:   "service_account:slack-bot",
+						}},
+					},
+					Relation: "viewer",
+					Resource: &proto.Resource{Type: "app", Id: "g-issues"},
+				},
+				SourceLayer: proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG,
+			},
+		},
+	}
+	authz.relationships[0].SourceLayer = proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", adminID, "")
+		cfg.Authorization = authz
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	request, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/g-issues/admin/identities", nil)
+	request.Header.Set("Authorization", "Bearer alice-token")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET identities: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("GET status = %d: %s", response.StatusCode, body)
+	}
+
+	var rows []struct {
+		SubjectID string `json:"subjectId"`
+		Role      string `json:"role"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&rows); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(rows) != 1 || rows[0].SubjectID != "service_account:slack-bot" {
+		t.Fatalf("identities = %#v, want only service_account:slack-bot", rows)
+	}
+}
+
+func TestAppAdminIdentitiesListEmpty(t *testing.T) {
+	t.Parallel()
+
+	adminID := principal.UserSubjectID("alice")
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(adminID, "admin", "app", "g-issues"),
+		},
+	}
+	authz.relationships[0].SourceLayer = proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", adminID, "")
+		cfg.Authorization = authz
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	request, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/g-issues/admin/identities", nil)
+	request.Header.Set("Authorization", "Bearer alice-token")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET identities: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("GET status = %d: %s", response.StatusCode, body)
+	}
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if got := strings.TrimSpace(string(body)); got != "[]" {
+		t.Fatalf("empty identities body = %q, want []", got)
+	}
+}
+
+func TestAppAdminIdentitiesFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	adminID := principal.UserSubjectID("alice")
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", adminID, "")
+		cfg.Authorization = nil
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	request, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/g-issues/admin/identities", nil)
+	request.Header.Set("Authorization", "Bearer alice-token")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET identities: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	// Without authorization, app-admin middleware fails closed before the handler.
+	if response.StatusCode != http.StatusServiceUnavailable && response.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("GET status = %d, want 503 or 403: %s", response.StatusCode, body)
 	}
 }
 

--- a/gestaltd/internal/server/handlers_app_admin_identities_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_identities_test.go
@@ -1,12 +1,14 @@
 package server_test
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
 
+	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/server"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
@@ -345,6 +347,67 @@ func TestAppAdminIdentitiesFailsClosed(t *testing.T) {
 	if response.StatusCode != http.StatusServiceUnavailable && response.StatusCode != http.StatusForbidden {
 		body, _ := io.ReadAll(response.Body)
 		t.Fatalf("GET status = %d, want 503 or 403: %s", response.StatusCode, body)
+	}
+}
+
+func TestAppAdminIdentitiesListUsesManagedSubjectDisplayName(t *testing.T) {
+	t.Parallel()
+
+	adminID := principal.UserSubjectID("alice")
+	const saID = "service_account:slack-bot"
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(adminID, "admin", "app", "g-issues"),
+			{
+				Tuple: &proto.RelationshipTuple{
+					Target: &proto.RelationshipTarget{
+						Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{
+							Type: "subject",
+							Id:   saID,
+						}},
+					},
+					Relation: "viewer",
+					Resource: &proto.Resource{Type: "app", Id: "g-issues"},
+				},
+				SourceLayer: proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG,
+			},
+		},
+	}
+	authz.relationships[0].SourceLayer = proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", adminID, "")
+		cfg.Authorization = authz
+		if _, err := cfg.Services.ManagedSubjects.CreateManagedSubject(context.Background(), &core.ManagedSubject{
+			SubjectID:   saID,
+			DisplayName: "Slack Bot",
+		}); err != nil {
+			t.Fatalf("CreateManagedSubject: %v", err)
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	request, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/g-issues/admin/identities", nil)
+	request.Header.Set("Authorization", "Bearer alice-token")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET identities: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("GET status = %d: %s", response.StatusCode, body)
+	}
+
+	var rows []struct {
+		SubjectID   string `json:"subjectId"`
+		DisplayName string `json:"displayName"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&rows); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(rows) != 1 || rows[0].SubjectID != saID || rows[0].DisplayName != "Slack Bot" {
+		t.Fatalf("identities = %#v, want displayName Slack Bot", rows)
 	}
 }
 

--- a/gestaltd/internal/server/handlers_app_admin_identities_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_identities_test.go
@@ -1,0 +1,152 @@
+package server_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/server"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+)
+
+func TestAppAdminIdentitiesList(t *testing.T) {
+	t.Parallel()
+
+	adminID := principal.UserSubjectID("alice")
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(adminID, "admin", "app", "g-issues"),
+			{
+				Tuple: &proto.RelationshipTuple{
+					Target: &proto.RelationshipTarget{
+						Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{
+							Type: "subject",
+							Id:   "service_account:slack-bot",
+						}},
+					},
+					Relation: "viewer",
+					Resource: &proto.Resource{Type: "app", Id: "g-issues"},
+				},
+				SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME,
+			},
+			{
+				Tuple: &proto.RelationshipTuple{
+					Target: &proto.RelationshipTarget{
+						Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{
+							Type: "subject",
+							Id:   "service_account:ci-runner",
+						}},
+					},
+					Relation: "editor",
+					Resource: &proto.Resource{Type: "app", Id: "g-issues"},
+				},
+				SourceLayer: proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG,
+			},
+			{
+				Tuple: &proto.RelationshipTuple{
+					Target: &proto.RelationshipTarget{
+						Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{
+							Type: "subject",
+							Id:   "service_account:other-bot",
+						}},
+					},
+					Relation: "viewer",
+					Resource: &proto.Resource{Type: "app", Id: "other-app"},
+				},
+				SourceLayer: proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG,
+			},
+		},
+	}
+	authz.relationships[0].SourceLayer = proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", adminID, "")
+		cfg.Authorization = authz
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	request, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/g-issues/admin/identities", nil)
+	request.Header.Set("Authorization", "Bearer alice-token")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET identities: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("GET status = %d: %s", response.StatusCode, body)
+	}
+
+	var rows []struct {
+		SubjectID   string `json:"subjectId"`
+		DisplayName string `json:"displayName"`
+		Role        string `json:"role"`
+		Source      string `json:"source"`
+		Mutable     bool   `json:"mutable"`
+		Effective   bool   `json:"effective"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&rows); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("identities = %#v, want 2 service-account rows for g-issues", rows)
+	}
+
+	bySubject := map[string]struct {
+		DisplayName string
+		Role        string
+		Source      string
+		Mutable     bool
+	}{}
+	for _, row := range rows {
+		if !row.Effective {
+			t.Fatalf("unexpected row %#v", row)
+		}
+		bySubject[row.SubjectID] = struct {
+			DisplayName string
+			Role        string
+			Source      string
+			Mutable     bool
+		}{DisplayName: row.DisplayName, Role: row.Role, Source: row.Source, Mutable: row.Mutable}
+	}
+	if got := bySubject["service_account:slack-bot"]; got.DisplayName != "slack-bot" || got.Role != "viewer" || got.Source != "dynamic" || !got.Mutable {
+		t.Fatalf("slack-bot row = %#v", got)
+	}
+	if got := bySubject["service_account:ci-runner"]; got.DisplayName != "ci-runner" || got.Role != "editor" || got.Source != "static" || got.Mutable {
+		t.Fatalf("ci-runner row = %#v", got)
+	}
+	if _, ok := bySubject[adminID]; ok {
+		t.Fatalf("human subjects must not appear in identities: %#v", rows)
+	}
+}
+
+func TestAppAdminIdentitiesListForbiddenWithoutAdmin(t *testing.T) {
+	t.Parallel()
+
+	viewerID := principal.UserSubjectID("bob")
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(viewerID, "viewer", "app", "g-issues"),
+		},
+	}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("bob-token", viewerID, "")
+		cfg.Authorization = authz
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	request, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/g-issues/admin/identities", nil)
+	request.Header.Set("Authorization", "Bearer bob-token")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET identities: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("GET status = %d, want 403: %s", response.StatusCode, body)
+	}
+}

--- a/gestaltd/internal/server/handlers_app_admin_members.go
+++ b/gestaltd/internal/server/handlers_app_admin_members.go
@@ -47,7 +47,20 @@ func (s *Server) listAppAdminMembers(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
 		return
 	}
-	writeJSON(w, http.StatusOK, rows)
+	// Members is the human/group access roster. Service-account grants are
+	// owned by GET /apps/{app}/admin/identities.
+	writeJSON(w, http.StatusOK, projectAppAdminHumanMemberRows(rows))
+}
+
+func projectAppAdminHumanMemberRows(rows []appAdminMemberRow) []appAdminMemberRow {
+	out := make([]appAdminMemberRow, 0, len(rows))
+	for _, row := range rows {
+		if isAppAdminServiceAccountRow(row) {
+			continue
+		}
+		out = append(out, row)
+	}
+	return out
 }
 
 func (s *Server) listAppAuthorizationMemberRows(ctx context.Context, appName string) ([]appAdminMemberRow, error) {

--- a/gestaltd/internal/server/handlers_app_admin_members.go
+++ b/gestaltd/internal/server/handlers_app_admin_members.go
@@ -13,8 +13,8 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 )
 
-// appAdminMemberRow is the read model for GET /apps/{app}/admin/members.
-// Field names match the app-default Members UI contract.
+// appAdminMemberRow is the shared authorization grant roster row used before
+// Members / Identities projections. Field names match the Members UI contract.
 type appAdminMemberRow struct {
 	Email         string `json:"email,omitempty"`
 	Role          string `json:"role"`
@@ -50,7 +50,7 @@ func (s *Server) listAppAdminMembers(w http.ResponseWriter, r *http.Request) {
 	}
 	// Members is the human/group access roster. Service-account grants are
 	// owned by GET /apps/{app}/admin/identities.
-	writeJSON(w, http.StatusOK, projectAppAdminHumanMemberRows(rows))
+	writeJSON(w, http.StatusOK, s.projectAppAdminHumanMemberRows(r.Context(), rows))
 }
 
 // isAppAdminServiceAccountRow partitions the shared app authorization grant
@@ -64,11 +64,17 @@ func isAppAdminServiceAccountRow(row appAdminMemberRow) bool {
 	return ok && kind == coredata.ManagedSubjectKindServiceAccount
 }
 
-func projectAppAdminHumanMemberRows(rows []appAdminMemberRow) []appAdminMemberRow {
+// projectAppAdminHumanMemberRows is the human/group projection of the shared
+// grant roster. Email enrichment belongs here — not in the shared mapper —
+// so identities listing does not resolve user emails it will discard.
+func (s *Server) projectAppAdminHumanMemberRows(ctx context.Context, rows []appAdminMemberRow) []appAdminMemberRow {
 	out := make([]appAdminMemberRow, 0, len(rows))
 	for _, row := range rows {
 		if isAppAdminServiceAccountRow(row) {
 			continue
+		}
+		if row.SelectorKind == "subject_id" && row.SubjectID != "" {
+			row.Email = s.resolveAppAdminMemberEmail(ctx, row.SubjectID)
 		}
 		out = append(out, row)
 	}
@@ -129,7 +135,7 @@ func projectAppAdminMemberRoster(rows []appAdminMemberRow) []appAdminMemberRow {
 	return out
 }
 
-func (s *Server) appAdminMemberRowFromRelationship(ctx context.Context, relationship *proto.Relationship) (appAdminMemberRow, bool) {
+func (s *Server) appAdminMemberRowFromRelationship(_ context.Context, relationship *proto.Relationship) (appAdminMemberRow, bool) {
 	if relationship == nil || relationship.GetTuple() == nil {
 		return appAdminMemberRow{}, false
 	}
@@ -156,7 +162,6 @@ func (s *Server) appAdminMemberRowFromRelationship(ctx context.Context, relation
 		row.SubjectID = subjectID
 		row.SelectorKind = "subject_id"
 		row.SelectorValue = subjectID
-		row.Email = s.resolveAppAdminMemberEmail(ctx, subjectID)
 		return row, true
 	case *proto.RelationshipTarget_SubjectSet:
 		resourceType := strings.TrimSpace(target.SubjectSet.GetResource().GetType())

--- a/gestaltd/internal/server/handlers_app_admin_members.go
+++ b/gestaltd/internal/server/handlers_app_admin_members.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 )
@@ -50,6 +51,17 @@ func (s *Server) listAppAdminMembers(w http.ResponseWriter, r *http.Request) {
 	// Members is the human/group access roster. Service-account grants are
 	// owned by GET /apps/{app}/admin/identities.
 	writeJSON(w, http.StatusOK, projectAppAdminHumanMemberRows(rows))
+}
+
+// isAppAdminServiceAccountRow partitions the shared app authorization grant
+// roster: direct service_account subject_id grants belong on identities;
+// humans, other subjects, and subject_set selectors belong on members.
+func isAppAdminServiceAccountRow(row appAdminMemberRow) bool {
+	if row.SelectorKind != "subject_id" || row.SubjectID == "" {
+		return false
+	}
+	kind, _, ok := core.ParseSubjectID(row.SubjectID)
+	return ok && kind == coredata.ManagedSubjectKindServiceAccount
 }
 
 func projectAppAdminHumanMemberRows(rows []appAdminMemberRow) []appAdminMemberRow {

--- a/gestaltd/internal/server/handlers_app_admin_members_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_members_test.go
@@ -82,8 +82,8 @@ func TestAppAdminMembersList(t *testing.T) {
 	if err := json.NewDecoder(response.Body).Decode(&rows); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if len(rows) != 3 {
-		t.Fatalf("members = %#v, want 3 rows for g-issues only", rows)
+	if len(rows) != 2 {
+		t.Fatalf("members = %#v, want 2 human rows for g-issues (service accounts excluded)", rows)
 	}
 
 	bySubject := map[string]struct {
@@ -107,8 +107,8 @@ func TestAppAdminMembersList(t *testing.T) {
 	if got := bySubject[viewerID]; got.Role != "viewer" || got.Source != "static" || got.Mutable {
 		t.Fatalf("viewer row = %#v", got)
 	}
-	if got := bySubject["service_account:slack-bot"]; got.Role != "viewer" || got.Source != "dynamic" || !got.Mutable {
-		t.Fatalf("service account row = %#v", got)
+	if _, ok := bySubject["service_account:slack-bot"]; ok {
+		t.Fatalf("service account must not appear in members: %#v", rows)
 	}
 }
 

--- a/gestaltd/internal/server/handlers_app_admin_registry.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry.go
@@ -972,22 +972,28 @@ func (s *Server) resolveRevisionActorLabels(ctx context.Context, requests []*cor
 			continue
 		}
 		seen[actor] = struct{}{}
-		labels[actor] = s.resolveRevisionActorLabel(ctx, actor)
+		labels[actor] = s.resolveSubjectDisplayLabel(ctx, actor)
 	}
 	return labels
 }
 
 func (s *Server) resolveRevisionActorLabel(ctx context.Context, actor string) string {
-	actor = strings.TrimSpace(actor)
-	if actor == "" {
+	return s.resolveSubjectDisplayLabel(ctx, actor)
+}
+
+// resolveSubjectDisplayLabel owns subject presentation labels for admin
+// surfaces (registry revision actors, agent identities, etc.).
+func (s *Server) resolveSubjectDisplayLabel(ctx context.Context, subjectID string) string {
+	subjectID = strings.TrimSpace(subjectID)
+	if subjectID == "" {
 		return ""
 	}
-	if strings.HasPrefix(actor, "system:") {
-		return actor
+	if strings.HasPrefix(subjectID, "system:") {
+		return subjectID
 	}
-	kind, id, ok := core.ParseSubjectID(actor)
+	kind, id, ok := core.ParseSubjectID(subjectID)
 	if !ok {
-		return actor
+		return subjectID
 	}
 	switch kind {
 	case string(principal.KindUser):
@@ -1005,7 +1011,7 @@ func (s *Server) resolveRevisionActorLabel(ctx context.Context, actor string) st
 		return id
 	case coredata.ManagedSubjectKindServiceAccount:
 		if s.managedSubjects != nil {
-			subject, err := s.managedSubjects.GetManagedSubject(ctx, actor)
+			subject, err := s.managedSubjects.GetManagedSubject(ctx, subjectID)
 			if err == nil && subject != nil {
 				if displayName := strings.TrimSpace(subject.DisplayName); displayName != "" {
 					return displayName

--- a/gestaltd/internal/server/handlers_app_admin_registry_internal_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry_internal_test.go
@@ -9,7 +9,10 @@ func TestResolveRevisionActorLabelPreservesSystemActor(t *testing.T) {
 	t.Parallel()
 
 	server := &Server{}
-	if got := server.resolveRevisionActorLabel(context.Background(), "system:auto-deploy"); got != "system:auto-deploy" {
+	if got := server.resolveSubjectDisplayLabel(context.Background(), "system:auto-deploy"); got != "system:auto-deploy" {
 		t.Fatalf("system actor label = %q, want system:auto-deploy", got)
+	}
+	if got := server.resolveRevisionActorLabel(context.Background(), "system:auto-deploy"); got != "system:auto-deploy" {
+		t.Fatalf("revision wrapper label = %q, want system:auto-deploy", got)
 	}
 }

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -7,6 +7,7 @@ import (
 func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 	s.mountAppAdminRegistryRoutes(r)
 	s.mountAppAdminMembersRoutes(r)
+	s.mountAppAdminIdentitiesRoutes(r)
 
 	r.Group(func(r chi.Router) {
 		r.Use(s.authMiddleware)


### PR DESCRIPTION
## Summary

App admins can list the service-account grants on an app via `GET /api/v1/apps/{app}/admin/identities`, while members stays the human/group roster.

## Why / context

Agent identities are an app-scoped authorization projection (`service_account:*` subjects with a grant on that app). Members and identities share one relationship listing source and split at the read-model boundary.

Rejected alternative: return service accounts from members and filter in the UI — that conflates two product concepts and leaves the wrong contract for the Members page.

## What changed

- Add app-admin-gated `GET /apps/{app}/admin/identities` returning service-account grant rows
- Project members to exclude `service_account:` subjects
- Keep email enrichment on the human projection only; resolve display names through a shared subject label helper (ManagedSubject when present)
- Cover shadowing, subject-set exclusion, empty `[]`, ManagedSubject display names, and grant-roster partition

## Validation

- [x] Automated: `go test ./gestaltd/internal/server/ -run 'TestAppAdmin(Members|Identities|GrantRoster)|TestResolveRevision' -count=1`
- [ ] Manual after deploy: as app admin, identities returns only `service_account:*` for that app; members omits them
- [ ] Manual after deploy: viewer-only subject gets 403 on identities
- [ ] Pair with gestalt-providers App Admin → Agent identities UI

## Reviewer focus

- Confirm the members/identities split and projection ownership (email vs display label)
- Confirm authz gate matches registry/members

## Rollout / compatibility

- Additive identities route; members response shape is a narrowing (service accounts move to identities)
- Deploy gestaltd before the UI pair
- No schema/config migration; no write surface

## Links

- UI pair: https://github.com/valon-technologies/gestalt-providers/pull/1249