### PR TITLE
[gestaltd] gate authorization state startup writes behind explicit apply

### DIFF
--- a/gestaltd/internal/bootstrap/authorization_bootstrap.go
+++ b/gestaltd/internal/bootstrap/authorization_bootstrap.go
@@ -5,7 +5,9 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"log/slog"
 	"maps"
+	"os"
 	"slices"
 	"strconv"
 	"strings"
@@ -20,6 +22,32 @@ import (
 	gproto "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 )
+
+// authorizationStateApplyEnv gates whether server startup is allowed to
+// overwrite active authorization provider state. Set to a truthy value
+// (see strconv.ParseBool) for the one deployment revision meant to own
+// authorization state; every other revision, including no-traffic
+// candidates, must start with this unset so it only plans/logs.
+const authorizationStateApplyEnv = "GESTALTD_AUTHORIZATION_STATE_APPLY"
+
+// resolveAuthorizationStateApply reports whether bootstrapAuthorizationProviderState
+// is allowed to call SetAuthorizationState. cfg.Server.AuthorizationStateApply
+// takes precedence over the environment variable; both default to false
+// (plan-only) when unset.
+func resolveAuthorizationStateApply(cfg *config.Config) bool {
+	if cfg != nil && cfg.Server.AuthorizationStateApply != nil {
+		return *cfg.Server.AuthorizationStateApply
+	}
+	raw := strings.TrimSpace(os.Getenv(authorizationStateApplyEnv))
+	if raw == "" {
+		return false
+	}
+	parsed, err := strconv.ParseBool(raw)
+	if err != nil {
+		return false
+	}
+	return parsed
+}
 
 func bootstrapAuthorizationProviderState(ctx context.Context, cfg *config.Config, providers map[string]core.AuthorizationProvider) error {
 	if len(providers) == 0 {
@@ -60,12 +88,30 @@ func bootstrapAuthorizationProviderState(ctx context.Context, cfg *config.Config
 		return fmt.Errorf("bootstrap: authorization provider %q: %w", name, err)
 	}
 	staticRelationships = append(staticRelationships, runtimeRelationships...)
+	digest := model.GetId()
+	apply := resolveAuthorizationStateApply(cfg)
+	if !apply {
+		slog.InfoContext(ctx, "authorization state plan (no-op): startup will not mutate authorization provider state",
+			"provider", name,
+			"model_digest", digest,
+			"resource_type_count", len(model.GetResourceTypes()),
+			"relationship_count", len(staticRelationships),
+			"enable_env", authorizationStateApplyEnv,
+		)
+		return nil
+	}
 	if _, err := provider.SetAuthorizationState(ctx, &proto.SetAuthorizationStateRequest{
 		Model:         model,
 		Relationships: staticRelationships,
 	}); err != nil {
 		return fmt.Errorf("bootstrap: authorization provider %q: set authorization state: %w", name, err)
 	}
+	slog.InfoContext(ctx, "authorization state applied: startup wrote authorization provider state",
+		"provider", name,
+		"model_digest", digest,
+		"resource_type_count", len(model.GetResourceTypes()),
+		"relationship_count", len(staticRelationships),
+	)
 	return nil
 }
 

--- a/gestaltd/internal/bootstrap/authorization_bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/authorization_bootstrap_test.go
@@ -60,7 +60,10 @@ func TestBootstrapAuthorizationProviderStatePreservesRuntimeRelationships(t *tes
 	}
 	before := time.Now().Unix()
 	cfg := &config.Config{
-		Server: config.ServerConfig{Providers: config.ServerProvidersConfig{Authorization: "authz"}},
+		Server: config.ServerConfig{
+			Providers:               config.ServerProvidersConfig{Authorization: "authz"},
+			AuthorizationStateApply: boolPtr(true),
+		},
 		Providers: config.ProvidersConfig{
 			Authorization: map[string]*config.ProviderEntry{"authz": {Default: true}},
 		},
@@ -297,7 +300,10 @@ func TestBootstrapAuthorizationProviderStateAuthorizesProviderGatewayRequests(t 
 	t.Parallel()
 
 	cfg := &config.Config{
-		Server: config.ServerConfig{Providers: config.ServerProvidersConfig{Authorization: "authz"}},
+		Server: config.ServerConfig{
+			Providers:               config.ServerProvidersConfig{Authorization: "authz"},
+			AuthorizationStateApply: boolPtr(true),
+		},
 		Providers: config.ProvidersConfig{
 			Authorization: map[string]*config.ProviderEntry{"authz": {Default: true}},
 		},
@@ -659,3 +665,169 @@ func (telemetrynoopProvider) PrometheusHandler() http.Handler      { return nil 
 func (telemetrynoopProvider) MeterProvider() metric.MeterProvider  { return nil }
 func (telemetrynoopProvider) TracerProvider() trace.TracerProvider { return nil }
 func (telemetrynoopProvider) Shutdown(context.Context) error       { return nil }
+
+func boolPtr(v bool) *bool { return &v }
+
+func authorizationBootstrapTestConfig(applyEnabled *bool) *config.Config {
+	return &config.Config{
+		Server: config.ServerConfig{
+			Providers:               config.ServerProvidersConfig{Authorization: "authz"},
+			AuthorizationStateApply: applyEnabled,
+		},
+		Providers: config.ProvidersConfig{
+			Authorization: map[string]*config.ProviderEntry{"authz": {Default: true}},
+		},
+		Authorization: config.AuthorizationConfig{
+			Models: map[string]config.AuthorizationModelDef{
+				"default": {
+					ResourceTypes: map[string]config.AuthorizationResourceTypeDef{
+						"github": {
+							Relations: map[string]config.AuthorizationRelationDef{
+								"viewer": {SubjectTypes: []string{"subject"}},
+							},
+							Actions: map[string]config.AuthorizationActionDef{
+								"repos/list-for-authenticated-user": {Relations: []string{"viewer"}},
+							},
+						},
+					},
+				},
+			},
+			Relationships: []config.AuthorizationRelationshipDef{{
+				Subject:  config.AuthorizationSubjectDef{Type: "subject", ID: "user:alice"},
+				Relation: "viewer",
+				Resource: config.AuthorizationResourceDef{Type: "github", ID: "repo-1"},
+			}},
+		},
+	}
+}
+
+func TestBootstrapAuthorizationProviderStateDefaultsToPlanOnly(t *testing.T) {
+	t.Parallel()
+
+	provider := &recordingAuthorizationProvider{}
+	cfg := authorizationBootstrapTestConfig(nil)
+
+	if err := bootstrapAuthorizationProviderState(context.Background(), cfg, map[string]core.AuthorizationProvider{"authz": provider}); err != nil {
+		t.Fatalf("bootstrapAuthorizationProviderState: %v", err)
+	}
+	if provider.setAuthorizationState != nil {
+		t.Fatal("SetAuthorizationState should not be called when authorization state apply is not enabled")
+	}
+}
+
+func TestBootstrapAuthorizationProviderStateExplicitFalseSkipsApply(t *testing.T) {
+	t.Parallel()
+
+	provider := &recordingAuthorizationProvider{}
+	cfg := authorizationBootstrapTestConfig(boolPtr(false))
+
+	if err := bootstrapAuthorizationProviderState(context.Background(), cfg, map[string]core.AuthorizationProvider{"authz": provider}); err != nil {
+		t.Fatalf("bootstrapAuthorizationProviderState: %v", err)
+	}
+	if provider.setAuthorizationState != nil {
+		t.Fatal("SetAuthorizationState should not be called when authorization state apply is explicitly disabled")
+	}
+}
+
+func TestBootstrapAuthorizationProviderStateEnvEnablesApply(t *testing.T) {
+	t.Setenv(authorizationStateApplyEnv, "true")
+
+	provider := &recordingAuthorizationProvider{}
+	cfg := authorizationBootstrapTestConfig(nil)
+
+	if err := bootstrapAuthorizationProviderState(context.Background(), cfg, map[string]core.AuthorizationProvider{"authz": provider}); err != nil {
+		t.Fatalf("bootstrapAuthorizationProviderState: %v", err)
+	}
+	if provider.setAuthorizationState == nil {
+		t.Fatal("SetAuthorizationState should be called when GESTALTD_AUTHORIZATION_STATE_APPLY=true")
+	}
+}
+
+func TestBootstrapAuthorizationProviderStateConfigOverridesEnv(t *testing.T) {
+	t.Setenv(authorizationStateApplyEnv, "true")
+
+	provider := &recordingAuthorizationProvider{}
+	cfg := authorizationBootstrapTestConfig(boolPtr(false))
+
+	if err := bootstrapAuthorizationProviderState(context.Background(), cfg, map[string]core.AuthorizationProvider{"authz": provider}); err != nil {
+		t.Fatalf("bootstrapAuthorizationProviderState: %v", err)
+	}
+	if provider.setAuthorizationState != nil {
+		t.Fatal("explicit config false should override a truthy env var")
+	}
+}
+
+func TestBootstrapAuthorizationProviderStatePlanAndApplyProduceSameDigest(t *testing.T) {
+	t.Parallel()
+
+	planProvider := &recordingAuthorizationProvider{}
+	planCfg := authorizationBootstrapTestConfig(boolPtr(false))
+	if err := bootstrapAuthorizationProviderState(context.Background(), planCfg, map[string]core.AuthorizationProvider{"authz": planProvider}); err != nil {
+		t.Fatalf("bootstrapAuthorizationProviderState (plan): %v", err)
+	}
+	planModel, err := staticAuthorizationModel(planCfg)
+	if err != nil {
+		t.Fatalf("staticAuthorizationModel: %v", err)
+	}
+	if err := stampAuthorizationModel(planModel, time.Now()); err != nil {
+		t.Fatalf("stampAuthorizationModel: %v", err)
+	}
+	planDigest := planModel.GetId()
+
+	applyProvider := &recordingAuthorizationProvider{}
+	applyCfg := authorizationBootstrapTestConfig(boolPtr(true))
+	if err := bootstrapAuthorizationProviderState(context.Background(), applyCfg, map[string]core.AuthorizationProvider{"authz": applyProvider}); err != nil {
+		t.Fatalf("bootstrapAuthorizationProviderState (apply): %v", err)
+	}
+	if applyProvider.setAuthorizationState == nil {
+		t.Fatal("SetAuthorizationState should be called when apply is enabled")
+	}
+	applyDigest := applyProvider.setAuthorizationState.GetModel().GetId()
+
+	if planDigest == "" || applyDigest == "" {
+		t.Fatalf("digests should be non-empty: plan=%q apply=%q", planDigest, applyDigest)
+	}
+	if planDigest != applyDigest {
+		t.Fatalf("plan digest %q should match apply digest %q for identical static models", planDigest, applyDigest)
+	}
+}
+
+func TestAuthorizationModelContentHashDeterministicAndSensitiveToChanges(t *testing.T) {
+	t.Parallel()
+
+	cfg := authorizationBootstrapTestConfig(nil)
+	modelA, err := staticAuthorizationModel(cfg)
+	if err != nil {
+		t.Fatalf("staticAuthorizationModel: %v", err)
+	}
+	modelB, err := staticAuthorizationModel(cfg)
+	if err != nil {
+		t.Fatalf("staticAuthorizationModel: %v", err)
+	}
+	digestA, err := authorizationModelContentHash(modelA)
+	if err != nil {
+		t.Fatalf("authorizationModelContentHash: %v", err)
+	}
+	digestB, err := authorizationModelContentHash(modelB)
+	if err != nil {
+		t.Fatalf("authorizationModelContentHash: %v", err)
+	}
+	if digestA != digestB {
+		t.Fatalf("digest should be deterministic for identical models: %q != %q", digestA, digestB)
+	}
+
+	cfg.Authorization.Models["default"].ResourceTypes["docs"] = config.AuthorizationResourceTypeDef{
+		Relations: map[string]config.AuthorizationRelationDef{"reader": {SubjectTypes: []string{"subject"}}},
+	}
+	modelC, err := staticAuthorizationModel(cfg)
+	if err != nil {
+		t.Fatalf("staticAuthorizationModel: %v", err)
+	}
+	digestC, err := authorizationModelContentHash(modelC)
+	if err != nil {
+		t.Fatalf("authorizationModelContentHash: %v", err)
+	}
+	if digestC == digestA {
+		t.Fatal("digest should change when the static model gains a resource type")
+	}
+}

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -327,6 +327,8 @@ func agentProviderTurnIdempotencyScope(req *proto.CreateAgentProviderTurnRequest
 	return strings.Join([]string{"turn", subjectID, strings.TrimSpace(req.GetSessionId()), idempotencyKey}, "\x00")
 }
 
+func authorizationStateApplyPtr(v bool) *bool { return &v }
+
 func turnStatusIsTerminalForTest(status coreagent.ExecutionStatus) bool {
 	switch status {
 	case coreagent.ExecutionStatusSucceeded, coreagent.ExecutionStatusFailed, coreagent.ExecutionStatusCanceled:
@@ -1888,6 +1890,7 @@ func TestBootstrapAuthorizationProviderStateUsesProviderGatewayTransport(t *test
 
 	cfg := validConfig()
 	cfg.Server.Providers.Authorization = "authz"
+	cfg.Server.AuthorizationStateApply = authorizationStateApplyPtr(true)
 	cfg.Providers.Authorization = map[string]*config.ProviderEntry{
 		"authz": {Config: yaml.Node{Kind: yaml.MappingNode}},
 	}

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1954,6 +1954,13 @@ type ServerConfig struct {
 	Admin         AdminConfig              `yaml:"admin,omitempty"`
 	AppRegistry   ServerAppRegistryConfig  `yaml:"appRegistry,omitempty"`
 	AutoActivate  *bool                    `yaml:"autoActivate,omitempty"`
+	// AuthorizationStateApply gates whether server startup is allowed to
+	// overwrite active authorization provider state. When unset, the
+	// GESTALTD_AUTHORIZATION_STATE_APPLY environment variable is consulted;
+	// when neither is set/true, startup only computes and logs the
+	// authorization state it would have applied. This keeps no-traffic
+	// candidates from mutating shared authorization state by default.
+	AuthorizationStateApply *bool `yaml:"authorizationStateApply,omitempty"`
 	// Dev is set programmatically when gestaltd is launched via the dev
 	// subcommand. It gates CLI config resolution and reverse-tunnel startup.
 	Dev bool `yaml:"-"`


### PR DESCRIPTION
## Description

Gates `bootstrapAuthorizationProviderState` behind an explicit apply switch (`Server.AuthorizationStateApply`, falling back to `GESTALTD_AUTHORIZATION_STATE_APPLY`) so a no-traffic candidate no longer overwrites shared authorization state just by starting up. Default is now plan-only: it computes the static model and logs its digest without calling `SetAuthorizationState`.

Stack A / G1 of [plans/external_users/implementation_v2.md](https://github.com/valon-technologies/gestalt/blob/main/plans/external_users/implementation_v2.md), addressing incident finding #5. Snapshot storage, rollback command generation, and a CLI plan/apply/rollback surface are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)