### PR TITLE
[gestaltd] batch catalog, operation and MCP listing decisions

### DIFF
--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1938,6 +1938,17 @@ type AdminConfig struct {
 	AllowedRoles        []string `yaml:"allowedRoles,omitempty"`
 }
 
+// UserLookupConfig gates resolving other people's identities (turning a subject
+// ID into an email on an admin surface) on an explicit employee operator role.
+// It is deliberately separate from any app's admin policy: app-scoped
+// administration alone must not permit user enumeration. Leaving it unset uses
+// the built-in operator resource and relation whenever authorization is
+// configured.
+type UserLookupConfig struct {
+	AuthorizationPolicy string   `yaml:"authorizationPolicy,omitempty"`
+	AllowedRoles        []string `yaml:"allowedRoles,omitempty"`
+}
+
 type ServerConfig struct {
 	Public        ListenerConfig           `yaml:"public"`
 	Management    ManagementListenerConfig `yaml:"management"`
@@ -1952,6 +1963,7 @@ type ServerConfig struct {
 	Runtime       ServerRuntimeConfig      `yaml:"runtime,omitempty"`
 	Egress        EgressConfig             `yaml:"egress,omitempty"`
 	Admin         AdminConfig              `yaml:"admin,omitempty"`
+	UserLookup    UserLookupConfig         `yaml:"userLookup,omitempty"`
 	AppRegistry   ServerAppRegistryConfig  `yaml:"appRegistry,omitempty"`
 	AutoActivate  *bool                    `yaml:"autoActivate,omitempty"`
 	// AuthorizationStateApply gates whether server startup is allowed to
@@ -2481,6 +2493,9 @@ func normalizeConfigShapeForPartialLoad(cfg *Config) error {
 		return err
 	}
 	if err := normalizeAdminConfig(cfg); err != nil {
+		return err
+	}
+	if err := normalizeUserLookupConfig(cfg); err != nil {
 		return err
 	}
 	return nil
@@ -3752,6 +3767,26 @@ func normalizeAdminConfig(cfg *Config) error {
 	}
 	admin.AllowedRoles = roles
 	cfg.Server.Admin = admin
+	return nil
+}
+
+func normalizeUserLookupConfig(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	lookup := cfg.Server.UserLookup
+	lookup.AuthorizationPolicy = strings.TrimSpace(lookup.AuthorizationPolicy)
+	if len(lookup.AllowedRoles) == 0 {
+		lookup.AllowedRoles = nil
+		cfg.Server.UserLookup = lookup
+		return nil
+	}
+	roles, err := packageio.NormalizeUIAllowedRoles("server.userLookup.allowedRoles", lookup.AllowedRoles)
+	if err != nil {
+		return fmt.Errorf("normalize user lookup config: %w", err)
+	}
+	lookup.AllowedRoles = roles
+	cfg.Server.UserLookup = lookup
 	return nil
 }
 

--- a/gestaltd/internal/server/authorization_decision.go
+++ b/gestaltd/internal/server/authorization_decision.go
@@ -26,6 +26,11 @@ func (s *Server) authorizationResource(appKey string) *proto.Resource {
 // checkResourceAccess routes an HTTP-surface authorization question through the
 // provider-owned evaluator. Server code never traverses relationships to reach
 // a decision, so group and subject-set derived access is honored everywhere.
+//
+// When the request carries a listing decision cache, an answer a batched call
+// already produced for this exact question is reused. The cached answer comes
+// from the same projection this function applies to a single response, so a
+// batched listing and a single decision cannot disagree.
 func (s *Server) checkResourceAccess(
 	ctx context.Context,
 	req invocation.ResourceAccessRequest,
@@ -33,5 +38,15 @@ func (s *Server) checkResourceAccess(
 	if s == nil || s.authorization == nil {
 		return invocation.ResourceAccessDecision{}, invocation.ErrAuthorizationUnavailable
 	}
-	return invocation.CheckResourceAccess(ctx, s.authorization, req)
+	cache := listingDecisionCacheFromContext(ctx)
+	key := newListingDecisionKey(req)
+	if decision, ok := cache.decision(key); ok {
+		return decision, nil
+	}
+	decision, err := invocation.CheckResourceAccess(ctx, s.authorization, req)
+	if err != nil {
+		return invocation.ResourceAccessDecision{}, err
+	}
+	cache.putDecision(key, decision)
+	return decision, nil
 }

--- a/gestaltd/internal/server/authorization_listing.go
+++ b/gestaltd/internal/server/authorization_listing.go
@@ -1,0 +1,156 @@
+package server
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+
+	"github.com/valon-technologies/gestalt/server/services/invocation"
+)
+
+// listingDecisionKey identifies exactly one authorization question. Two
+// questions share a key only when they would produce the same evaluator
+// request, so a cache hit can never substitute one question's answer for
+// another's.
+type listingDecisionKey struct {
+	subjectID    string
+	action       string
+	resourceType string
+	resourceID   string
+	allowedRoles string
+}
+
+func newListingDecisionKey(req invocation.ResourceAccessRequest) listingDecisionKey {
+	return listingDecisionKey{
+		subjectID:    strings.TrimSpace(req.SubjectID),
+		action:       strings.TrimSpace(req.Action),
+		resourceType: strings.TrimSpace(req.Resource.GetType()),
+		resourceID:   strings.TrimSpace(req.Resource.GetId()),
+		allowedRoles: strings.Join(req.AllowedRoles, "\x00"),
+	}
+}
+
+// listingDecisionCache memoizes evaluator answers and active-model reads for
+// the lifetime of one listing request.
+//
+// It is a cache, never a decision maker. Every entry is produced by the same
+// helpers the single-decision path uses, and only successful answers are
+// stored, so reading from the cache cannot change an answer - it can only
+// remove a repeat of the same provider call. That is what makes it safe to
+// batch a listing: the per-app code path is untouched and still asks
+// checkResourceAccess, which now finds the answer already present.
+type listingDecisionCache struct {
+	mu        sync.Mutex
+	decisions map[listingDecisionKey]invocation.ResourceAccessDecision
+	models    map[string]mountedUIModelSnapshot
+}
+
+type listingDecisionCacheContextKey struct{}
+
+// withListingDecisionCache installs a per-request decision cache. Only listing
+// surfaces install one; every other surface keeps making its own calls.
+func withListingDecisionCache(ctx context.Context) (context.Context, *listingDecisionCache) {
+	cache := &listingDecisionCache{
+		decisions: make(map[listingDecisionKey]invocation.ResourceAccessDecision),
+		models:    make(map[string]mountedUIModelSnapshot),
+	}
+	return context.WithValue(ctx, listingDecisionCacheContextKey{}, cache), cache
+}
+
+func listingDecisionCacheFromContext(ctx context.Context) *listingDecisionCache {
+	if ctx == nil {
+		return nil
+	}
+	cache, _ := ctx.Value(listingDecisionCacheContextKey{}).(*listingDecisionCache)
+	return cache
+}
+
+func (c *listingDecisionCache) decision(key listingDecisionKey) (invocation.ResourceAccessDecision, bool) {
+	if c == nil {
+		return invocation.ResourceAccessDecision{}, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	decision, ok := c.decisions[key]
+	return decision, ok
+}
+
+func (c *listingDecisionCache) putDecision(key listingDecisionKey, decision invocation.ResourceAccessDecision) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.decisions[key] = decision
+}
+
+func (c *listingDecisionCache) model(typeName string) (mountedUIModelSnapshot, bool) {
+	if c == nil {
+		return mountedUIModelSnapshot{}, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	snapshot, ok := c.models[typeName]
+	return snapshot, ok
+}
+
+func (c *listingDecisionCache) putModel(typeName string, snapshot mountedUIModelSnapshot) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.models[typeName] = snapshot
+}
+
+// prefetchListingDecisions answers every question a listing is about to ask
+// with ONE batched provider call and stores the answers in the request's
+// decision cache.
+//
+// A batch the provider cannot serve is deliberately not an error here. The
+// cache simply stays empty and each entry falls back to the single-decision
+// path that already shipped, so listing degrades to more provider calls and
+// never to fewer visible apps. Whatever the evaluator does answer is enforced
+// identically either way, and invoke-time enforcement is unchanged.
+func (s *Server) prefetchListingDecisions(ctx context.Context, reqs []invocation.ResourceAccessRequest) {
+	cache := listingDecisionCacheFromContext(ctx)
+	if s == nil || s.authorization == nil || cache == nil || len(reqs) == 0 {
+		return
+	}
+
+	keys := make([]listingDecisionKey, 0, len(reqs))
+	unique := make([]invocation.ResourceAccessRequest, 0, len(reqs))
+	seen := make(map[listingDecisionKey]struct{}, len(reqs))
+	for _, req := range reqs {
+		key := newListingDecisionKey(req)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		keys = append(keys, key)
+		unique = append(unique, req)
+	}
+
+	decisions, err := invocation.CheckResourceAccessMany(ctx, s.authorization, unique)
+	if err != nil {
+		slog.WarnContext(ctx, "auth: batched listing decision unavailable; falling back to per-item decisions",
+			"error", err, "requests", len(unique))
+		return
+	}
+	for i, decision := range decisions {
+		cache.putDecision(keys[i], decision)
+	}
+}
+
+// operationAccessChecker exposes the broker's batched operation-access
+// decisions to listing surfaces. Only the broker owns invocation authorization,
+// so anything else means listing cannot be filtered and must stay unfiltered
+// rather than guess.
+func operationAccessChecker(invoker invocation.Invoker) invocation.OperationAccessChecker {
+	broker, ok := invoker.(*invocation.Broker)
+	if !ok {
+		return nil
+	}
+	return broker
+}

--- a/gestaltd/internal/server/authorization_listing_test.go
+++ b/gestaltd/internal/server/authorization_listing_test.go
@@ -1,0 +1,307 @@
+package server_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/server"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
+)
+
+type listedIntegration struct {
+	Name        string `json:"name"`
+	MountedPath string `json:"mountedPath"`
+}
+
+// listingTestServer mounts two static app UIs behind app-level authorization so
+// /apps has two mounted-UI decisions to make in one request.
+func listingTestServer(t *testing.T, authz *serverTestAuthorizationProvider, subjectID string) *httptest.Server {
+	t.Helper()
+
+	rootDir := t.TempDir()
+	writeTestUIAsset(t, filepath.Join(rootDir, "index.html"), "<html>app</html>")
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("listing-token", subjectID, "")
+		cfg.Authorization = authz
+		cfg.Services = testutil.NewStubServices(t)
+		cfg.Providers = testutil.NewProviderRegistry(t,
+			&coretesting.StubIntegration{N: "sampleApp", DN: "Sample"},
+			&coretesting.StubIntegration{N: "otherApp", DN: "Other"},
+		)
+		cfg.AppDefs = map[string]*config.ProviderEntry{
+			"sampleApp": {
+				Static:             &config.AppStaticConfig{Mount: "/sample"},
+				ResolvedStaticRoot: rootDir,
+			},
+			"otherApp": {
+				Static:             &config.AppStaticConfig{Mount: "/other"},
+				ResolvedStaticRoot: rootDir,
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+	return ts
+}
+
+func listIntegrationsForTest(t *testing.T, ts *httptest.Server) []listedIntegration {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer listing-token")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET apps: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("GET apps status = %d: %s", resp.StatusCode, body)
+	}
+	var integrations []listedIntegration
+	if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
+		t.Fatalf("decode apps: %v", err)
+	}
+	return integrations
+}
+
+func mountedPathFor(integrations []listedIntegration, name string) (string, bool) {
+	for _, integration := range integrations {
+		if integration.Name == name {
+			return integration.MountedPath, true
+		}
+	}
+	return "", false
+}
+
+// TestAppsListingBatchesGroupDerivedDecisions is the core listing guarantee: a
+// subject whose only grant comes from a group still sees its app, and the whole
+// listing costs one batched evaluator call instead of one per app.
+func TestAppsListingBatchesGroupDerivedDecisions(t *testing.T) {
+	t.Parallel()
+
+	subjectID := principal.UserSubjectID(testCanonicalViewerUserID)
+	authz := &serverTestAuthorizationProvider{
+		relationships: append(
+			subjectSetGrant(subjectID, "viewer", "app", "sampleApp"),
+			subjectSetGrant(subjectID, "viewer", "app", "otherApp")...,
+		),
+	}
+
+	integrations := listIntegrationsForTest(t, listingTestServer(t, authz, subjectID))
+	for _, name := range []string{"sampleApp", "otherApp"} {
+		mountedPath, ok := mountedPathFor(integrations, name)
+		if !ok {
+			t.Fatalf("app %q missing from listing: %#v", name, integrations)
+		}
+		if mountedPath == "" {
+			t.Fatalf("group-granted app %q lost its mounted path", name)
+		}
+	}
+	if len(authz.checkAccessManyRequests) != 1 {
+		t.Fatalf("CheckAccessMany calls = %d, want exactly 1 batched call", len(authz.checkAccessManyRequests))
+	}
+	if got := len(authz.checkAccessRequests); got != 0 {
+		t.Fatalf("per-item CheckAccess calls = %d, want 0 when the batch answers everything", got)
+	}
+}
+
+// TestAppsListingHidesUngrantedApp proves the filtering is real: a subject with
+// no grant does not get the mounted path.
+func TestAppsListingHidesUngrantedApp(t *testing.T) {
+	t.Parallel()
+
+	subjectID := principal.UserSubjectID(testCanonicalViewerUserID)
+	authz := &serverTestAuthorizationProvider{
+		relationships: subjectSetGrant(subjectID, "viewer", "app", "sampleApp"),
+	}
+
+	integrations := listIntegrationsForTest(t, listingTestServer(t, authz, subjectID))
+	if mountedPath, _ := mountedPathFor(integrations, "sampleApp"); mountedPath == "" {
+		t.Fatalf("granted app lost its mounted path: %#v", integrations)
+	}
+	if mountedPath, _ := mountedPathFor(integrations, "otherApp"); mountedPath != "" {
+		t.Fatalf("ungranted app exposed mounted path %q", mountedPath)
+	}
+}
+
+// TestAppsListingHonorsDefaultRole is the access-loss regression guard for
+// Gate A. The subject holds no relationship at all and is visible only through
+// the resource type's defaultRole. Batched listing must reach the same answer
+// the mounted-UI boundary reaches, or every employee silently loses their apps
+// the moment listing is filtered.
+func TestAppsListingHonorsDefaultRole(t *testing.T) {
+	t.Parallel()
+
+	subjectID := principal.UserSubjectID(testCanonicalViewerUserID)
+	authz := &serverTestAuthorizationProvider{
+		resourceTypes: []*proto.AuthorizationModelResourceType{{
+			Name:        "app",
+			DefaultRole: "viewer",
+			Actions:     []*proto.ModelAction{{Name: "*"}},
+		}},
+	}
+
+	integrations := listIntegrationsForTest(t, listingTestServer(t, authz, subjectID))
+	for _, name := range []string{"sampleApp", "otherApp"} {
+		mountedPath, ok := mountedPathFor(integrations, name)
+		if !ok {
+			t.Fatalf("defaultRole app %q missing from listing: %#v", name, integrations)
+		}
+		if mountedPath == "" {
+			t.Fatalf("defaultRole app %q lost its mounted path", name)
+		}
+	}
+	if len(authz.checkAccessManyRequests) != 1 {
+		t.Fatalf("CheckAccessMany calls = %d, want exactly 1 batched call", len(authz.checkAccessManyRequests))
+	}
+}
+
+// TestAppsListingFallsBackWhenBatchFails proves the batch is an optimization,
+// never a gate: a provider that cannot serve CheckAccessMany must not cost the
+// caller a single app.
+func TestAppsListingFallsBackWhenBatchFails(t *testing.T) {
+	t.Parallel()
+
+	subjectID := principal.UserSubjectID(testCanonicalViewerUserID)
+	authz := &serverTestAuthorizationProvider{
+		relationships:      subjectSetGrant(subjectID, "viewer", "app", "sampleApp"),
+		checkAccessManyErr: errors.New("batch rpc unimplemented"),
+	}
+
+	integrations := listIntegrationsForTest(t, listingTestServer(t, authz, subjectID))
+	if mountedPath, _ := mountedPathFor(integrations, "sampleApp"); mountedPath == "" {
+		t.Fatalf("granted app hidden after batch failure: %#v", integrations)
+	}
+	if len(authz.checkAccessRequests) == 0 {
+		t.Fatal("batch failure did not fall back to per-item decisions")
+	}
+}
+
+// erroringOperationAccess is an evaluator that cannot answer, used to prove a
+// listing surfaces the failure rather than returning an empty list.
+type erroringOperationAccess struct{}
+
+func (erroringOperationAccess) CheckOperationAccessMany(
+	context.Context, *principal.Principal, []invocation.OperationAccessQuery,
+) ([]error, error) {
+	return nil, errors.New("evaluator unavailable")
+}
+
+// allowOneOperationAccess allows exactly one operation and counts its calls, so
+// a test can prove operation listing asks once for the whole catalog.
+type allowOneOperationAccess struct {
+	allowed string
+	calls   int
+	queries int
+}
+
+func (a *allowOneOperationAccess) CheckOperationAccessMany(
+	_ context.Context, _ *principal.Principal, queries []invocation.OperationAccessQuery,
+) ([]error, error) {
+	a.calls++
+	a.queries += len(queries)
+	results := make([]error, len(queries))
+	for i, query := range queries {
+		if query.Operation != a.allowed {
+			results[i] = errors.New("denied")
+		}
+	}
+	return results, nil
+}
+
+func operationsListingServer(t *testing.T, checker invocation.OperationAccessChecker) *httptest.Server {
+	t.Helper()
+	stub := &coretesting.StubIntegration{
+		N:        "sampleApp",
+		DN:       "Sample",
+		ConnMode: core.ConnectionModeNone,
+		CatalogVal: &catalog.Catalog{
+			Name: "sampleApp",
+			Operations: []catalog.CatalogOperation{
+				{ID: "items.list", Method: "GET", Path: "/items"},
+				{ID: "items.create", Method: "POST", Path: "/items"},
+			},
+		},
+	}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Services = testutil.NewStubServices(t)
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.AppDefs = map[string]*config.ProviderEntry{"sampleApp": {}}
+		cfg.OperationAccessChecker = checker
+	})
+	testutil.CloseOnCleanup(t, ts)
+	return ts
+}
+
+func getOperations(t *testing.T, ts *httptest.Server) (int, []byte) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/sampleApp/operations", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET operations: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	return resp.StatusCode, body
+}
+
+// TestOperationListingFiltersWithOneBatchedCall pins both properties at once:
+// the catalog is filtered to what the caller may invoke, and the whole catalog
+// is decided in a single batched question.
+func TestOperationListingFiltersWithOneBatchedCall(t *testing.T) {
+	t.Parallel()
+
+	checker := &allowOneOperationAccess{allowed: "items.list"}
+	status, body := getOperations(t, operationsListingServer(t, checker))
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", status, body)
+	}
+	var ops []struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(body, &ops); err != nil {
+		t.Fatalf("decode operations: %v", err)
+	}
+	if len(ops) != 1 || ops[0].ID != "items.list" {
+		t.Fatalf("operations = %#v, want only items.list", ops)
+	}
+	if checker.calls != 1 {
+		t.Fatalf("batched calls = %d, want 1", checker.calls)
+	}
+	if checker.queries != 2 {
+		t.Fatalf("batched queries = %d, want 2 (one per operation)", checker.queries)
+	}
+}
+
+// TestOperationListingFailsLoudlyWhenEvaluatorUnavailable is the "never a
+// silently empty list" guard.
+func TestOperationListingFailsLoudlyWhenEvaluatorUnavailable(t *testing.T) {
+	t.Parallel()
+
+	status, body := getOperations(t, operationsListingServer(t, erroringOperationAccess{}))
+	if status == http.StatusOK {
+		t.Fatalf("evaluator failure returned 200 with body %s", body)
+	}
+	if status != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503: %s", status, body)
+	}
+}

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -227,6 +227,20 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 	}
 
 	names := s.providers.List()
+	registryApps := s.configuredRegistryApps()
+
+	// Answer every app-visibility question this listing asks in one batched
+	// evaluator call. Each app below still reaches its decision through the
+	// same single-decision helper; the batch only pre-populates the answers.
+	ctx, _ := withListingDecisionCache(r.Context())
+	r = r.WithContext(ctx)
+	prefetchNames := make([]string, 0, len(names)+len(registryApps))
+	prefetchNames = append(prefetchNames, names...)
+	for _, app := range registryApps {
+		prefetchNames = append(prefetchNames, app.name)
+	}
+	s.prefetchIntegrationListingDecisions(ctx, p, prefetchNames)
+
 	seen := make(map[string]struct{}, len(names))
 	out := make([]integrationInfo, 0, len(names))
 	for _, name := range names {
@@ -257,12 +271,21 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 		s.applyIntegrationConnectionStatus(&info, prov, instances, authTypes, p)
 		info.MountedPath = s.integrationMountedPathForPrincipalContext(r.Context(), p, name, info.MountedPath)
 		info.ManagementPath = s.integrationManagementPath(r.Context(), p, name)
-		if !s.integrationHasUsableSurfaceContext(r.Context(), p, name, prov, info) {
+		usable, err := s.integrationHasUsableSurfaceContext(r.Context(), p, name, prov, info)
+		if err != nil {
+			// An unreachable evaluator must not be reported as "you have no
+			// apps": fail the request instead of returning a silently empty or
+			// silently truncated list.
+			slog.ErrorContext(r.Context(), "listing integrations", "app", name, "error", err)
+			writeError(w, http.StatusServiceUnavailable, "failed to authorize app access")
+			return
+		}
+		if !usable {
 			continue
 		}
 		out = append(out, info)
 	}
-	for _, app := range s.configuredRegistryApps() {
+	for _, app := range registryApps {
 		if _, ok := seen[app.name]; ok {
 			continue
 		}
@@ -706,7 +729,13 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 	if recordDiscoveryMetrics {
 		metricutil.RecordDiscoveryMetrics(r.Context(), discoveryStartedAt, name, "list_operations", discoveryConnectionMode, discoveryFailed)
 	}
-	cat = invocation.FilterCatalogForPrincipal(ctx, cat, name, p, nil)
+	cat, err = invocation.FilterCatalogForPrincipal(ctx, cat, name, p, s.operationAccess)
+	if err != nil {
+		// Never answer "no operations" because the evaluator was unreachable.
+		slog.ErrorContext(ctx, "listing operations", "app", name, "error", err)
+		writeError(w, http.StatusServiceUnavailable, "failed to authorize app access")
+		return
+	}
 	ops := s.publicHTTPOperations(name, prov, cat.Operations)
 	sort.Slice(ops, func(i, j int) bool {
 		return ops[i].ID < ops[j].ID

--- a/gestaltd/internal/server/handlers_app_admin_identities.go
+++ b/gestaltd/internal/server/handlers_app_admin_identities.go
@@ -49,6 +49,9 @@ func (s *Server) listAppAdminIdentities(w http.ResponseWriter, r *http.Request) 
 // app authorization grant roster. Display labels use the shared subject
 // presentation helper (ManagedSubject when present).
 func (s *Server) projectAppAdminIdentityRows(ctx context.Context, rows []appAdminMemberRow) []appAdminIdentityRow {
+	// Rows here are service accounts, so no user lookup is expected; resolve
+	// the gate once anyway so the shared labeler stays on one code path.
+	allowLookup := s.userLookupAllowed(ctx)
 	labels := make(map[string]string)
 	out := make([]appAdminIdentityRow, 0)
 	for _, row := range rows {
@@ -57,7 +60,7 @@ func (s *Server) projectAppAdminIdentityRows(ctx context.Context, rows []appAdmi
 		}
 		displayName, ok := labels[row.SubjectID]
 		if !ok {
-			displayName = strings.TrimSpace(s.resolveSubjectDisplayLabel(ctx, row.SubjectID))
+			displayName = strings.TrimSpace(s.resolveSubjectDisplayLabelForLookup(ctx, row.SubjectID, allowLookup))
 			if displayName == "" {
 				displayName = row.SubjectID
 			}

--- a/gestaltd/internal/server/handlers_app_admin_members.go
+++ b/gestaltd/internal/server/handlers_app_admin_members.go
@@ -67,13 +67,20 @@ func isAppAdminServiceAccountRow(row appAdminMemberRow) bool {
 // projectAppAdminHumanMemberRows is the human/group projection of the shared
 // grant roster. Email enrichment belongs here — not in the shared mapper —
 // so identities listing does not resolve user emails it will discard.
+//
+// Turning a subject ID into an email is user lookup, so it is gated on the
+// explicit employee operator role rather than on the app-scoped admin grant
+// that reached this handler. An app administrator without that role still sees
+// the full grant roster - which subjects and groups hold which roles on their
+// own app - but cannot use it to enumerate the directory.
 func (s *Server) projectAppAdminHumanMemberRows(ctx context.Context, rows []appAdminMemberRow) []appAdminMemberRow {
+	allowLookup := s.userLookupAllowed(ctx)
 	out := make([]appAdminMemberRow, 0, len(rows))
 	for _, row := range rows {
 		if isAppAdminServiceAccountRow(row) {
 			continue
 		}
-		if row.SelectorKind == "subject_id" && row.SubjectID != "" {
+		if allowLookup && row.SelectorKind == "subject_id" && row.SubjectID != "" {
 			row.Email = s.resolveAppAdminMemberEmail(ctx, row.SubjectID)
 		}
 		out = append(out, row)

--- a/gestaltd/internal/server/handlers_app_admin_registry.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry.go
@@ -961,6 +961,9 @@ func (s *Server) resolveRevisionActorLabels(ctx context.Context, requests []*cor
 	if s == nil {
 		return labels
 	}
+	// Resolve the user-lookup gate once for the whole page rather than per
+	// actor: labeling a user actor with their email is user lookup.
+	allowLookup := s.userLookupAllowed(ctx)
 	seen := make(map[string]struct{})
 	for _, request := range requests {
 		if request == nil {
@@ -974,7 +977,7 @@ func (s *Server) resolveRevisionActorLabels(ctx context.Context, requests []*cor
 			continue
 		}
 		seen[actor] = struct{}{}
-		labels[actor] = s.resolveSubjectDisplayLabel(ctx, actor)
+		labels[actor] = s.resolveSubjectDisplayLabelForLookup(ctx, actor, allowLookup)
 	}
 	return labels
 }
@@ -984,8 +987,18 @@ func (s *Server) resolveRevisionActorLabel(ctx context.Context, actor string) st
 }
 
 // resolveSubjectDisplayLabel owns subject presentation labels for admin
-// surfaces (registry revision actors, agent identities, etc.).
+// surfaces (registry revision actors, agent identities, etc.). It resolves the
+// user-lookup gate itself; callers labeling many subjects should resolve the
+// gate once and call resolveSubjectDisplayLabelForLookup instead.
 func (s *Server) resolveSubjectDisplayLabel(ctx context.Context, subjectID string) string {
+	return s.resolveSubjectDisplayLabelForLookup(ctx, subjectID, s.userLookupAllowed(ctx))
+}
+
+// resolveSubjectDisplayLabelForLookup labels a subject, resolving a user
+// subject to their email only when the caller holds the employee operator role
+// that permits user lookup. Without it the subject ID is shown as-is, so an
+// app-scoped administrator cannot turn an admin surface into a directory.
+func (s *Server) resolveSubjectDisplayLabelForLookup(ctx context.Context, subjectID string, allowLookup bool) string {
 	subjectID = strings.TrimSpace(subjectID)
 	if subjectID == "" {
 		return ""
@@ -1002,7 +1015,7 @@ func (s *Server) resolveSubjectDisplayLabel(ctx context.Context, subjectID strin
 		if strings.Contains(id, "@") {
 			return id
 		}
-		if s.users != nil {
+		if allowLookup && s.users != nil {
 			user, err := s.users.GetUser(ctx, id)
 			if err == nil && user != nil {
 				if email := strings.TrimSpace(user.Email); email != "" {

--- a/gestaltd/internal/server/handlers_app_admin_registry_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry_test.go
@@ -531,6 +531,10 @@ func TestAppAdminRegistryHistory(t *testing.T) {
 	authz := &serverTestAuthorizationProvider{
 		relationships: []*proto.Relationship{
 			testAuthorizationRelationship(subjectID, "admin", "app", "g-issues"),
+			// Resolving another person's subject ID to their email is user
+			// lookup, which requires the employee operator role in addition to
+			// app-scoped admin.
+			testAuthorizationRelationship(subjectID, testUserLookupRole, testUserLookupResource, testUserLookupResource),
 		},
 	}
 	ts := newTestServer(t, func(cfg *server.Config) {

--- a/gestaltd/internal/server/integration_visibility.go
+++ b/gestaltd/internal/server/integration_visibility.go
@@ -9,15 +9,15 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 )
 
-func (s *Server) integrationHasUsableSurfaceContext(ctx context.Context, p *principal.Principal, provider string, prov core.Provider, info integrationInfo) bool {
+func (s *Server) integrationHasUsableSurfaceContext(ctx context.Context, p *principal.Principal, provider string, prov core.Provider, info integrationInfo) (bool, error) {
 	if info.MountedPath != "" {
-		return true
+		return true, nil
 	}
 	if info.ManagementPath != "" {
-		return true
+		return true, nil
 	}
 	if s.integrationHasSettingsSurface(p, info) {
-		return true
+		return true, nil
 	}
 	return s.integrationHasVisibleHTTPOperationsContext(ctx, p, provider, prov)
 }
@@ -32,13 +32,97 @@ func (s *Server) integrationHasSettingsSurface(p *principal.Principal, info inte
 		len(info.Connections) > 0
 }
 
-func (s *Server) integrationHasVisibleHTTPOperationsContext(ctx context.Context, p *principal.Principal, provider string, prov core.Provider) bool {
+// integrationHasVisibleHTTPOperationsContext reports whether the principal can
+// invoke any of this app's public HTTP operations. The filter is a batched
+// evaluator decision, so an app whose every operation the caller would be
+// denied is not advertised. An evaluator failure is surfaced as an error, not
+// as "no operations": hiding an app on a transport error is exactly the silent
+// access loss this must not cause.
+func (s *Server) integrationHasVisibleHTTPOperationsContext(ctx context.Context, p *principal.Principal, provider string, prov core.Provider) (bool, error) {
 	cat := prov.Catalog()
 	if cat == nil {
-		return false
+		return false, nil
 	}
-	cat = invocation.FilterCatalogForPrincipal(ctx, cat, provider, p, nil)
-	return len(s.publicHTTPOperations(provider, prov, cat.Operations)) > 0
+	cat, err := invocation.FilterCatalogForPrincipal(ctx, cat, provider, p, s.operationAccess)
+	if err != nil {
+		return false, err
+	}
+	return len(s.publicHTTPOperations(provider, prov, cat.Operations)) > 0, nil
+}
+
+// prefetchIntegrationListingDecisions answers every authorization question the
+// /apps listing is about to ask - one mounted-UI question and one app-admin
+// question per app - with a single batched evaluator call. The per-app handlers
+// below are unchanged and still ask checkResourceAccess; they simply find the
+// answer already cached.
+func (s *Server) prefetchIntegrationListingDecisions(ctx context.Context, p *principal.Principal, appNames []string) {
+	if s == nil || s.authorization == nil || p == nil || principal.IsNonUserPrincipal(p) {
+		return
+	}
+	subjectID, err := principal.ResolveAuthorizationSubjectID(ctx, s.credentialUserResolver(), p)
+	if err != nil {
+		return
+	}
+	if subjectID = strings.TrimSpace(subjectID); subjectID == "" {
+		return
+	}
+
+	reqs := make([]invocation.ResourceAccessRequest, 0, 2*len(appNames))
+	for _, name := range appNames {
+		if req, ok := s.mountedUIListingAccessRequest(name, subjectID); ok {
+			reqs = append(reqs, req)
+		}
+		if _, ok := s.registryApp(name); ok {
+			reqs = append(reqs, invocation.ResourceAccessRequest{
+				SubjectID:    subjectID,
+				Action:       name,
+				Resource:     s.authorizationResource(name),
+				AllowedRoles: []string{appAdminRole},
+			})
+		}
+	}
+	s.prefetchListingDecisions(ctx, reqs)
+}
+
+// mountedUIListingAccessRequest is the exact question
+// mountedUIRootAccessibleContext will ask for this app's mounted UI, or ok
+// false when the mount asks none. It builds the request through the same
+// mountedResourceAccess type the mounted-UI boundary uses so the prefetched
+// question cannot drift from the question actually asked.
+func (s *Server) mountedUIListingAccessRequest(appName, subjectID string) (invocation.ResourceAccessRequest, bool) {
+	mountedPath := s.configuredMountedPath(appName)
+	if mountedPath == "" {
+		return invocation.ResourceAccessRequest{}, false
+	}
+	mounted, ok := s.mountedUIForProvider(appName, mountedPath)
+	if !ok || !mountedUIRequiresAuthorization(mounted) {
+		return invocation.ResourceAccessRequest{}, false
+	}
+	resourceName := mountedUIAuthorizationResourceName(mounted)
+	if resourceName == "" {
+		return invocation.ResourceAccessRequest{}, false
+	}
+	access := mountedResourceAccess{
+		appKey:       strings.TrimSpace(mounted.AppName),
+		resourceName: resourceName,
+		subjectID:    subjectID,
+		allowedRoles: mounted.AllowedRoles,
+	}
+	return invocation.ResourceAccessRequest{
+		SubjectID:    access.subjectID,
+		Action:       access.action(),
+		Resource:     s.authorizationResource(access.resourceName),
+		AllowedRoles: access.allowedRoles,
+	}, true
+}
+
+// configuredMountedPath returns the app's declared static mount path.
+func (s *Server) configuredMountedPath(appName string) string {
+	entry, ok := s.pluginDefs[appName]
+	if !ok || entry == nil || entry.Static == nil {
+		return ""
+	}
+	return strings.TrimSpace(entry.Static.Mount)
 }
 
 func (s *Server) integrationMountedPathForPrincipalContext(ctx context.Context, p *principal.Principal, provider, mountedPath string) string {

--- a/gestaltd/internal/server/mounted_ui.go
+++ b/gestaltd/internal/server/mounted_ui.go
@@ -451,11 +451,17 @@ func (m mountedUIModelSnapshot) answersAction(action string) bool {
 }
 
 // mountedUIResourceModel reads the mount's resource type from the active model.
+// Within a listing request the read is memoized per resource type, so filtering
+// many apps does not re-read the same model entry once per app.
 func (s *Server) mountedUIResourceModel(ctx context.Context, resourceName string) (mountedUIModelSnapshot, error) {
 	if s == nil || s.authorization == nil {
 		return mountedUIModelSnapshot{}, invocation.ErrAuthorizationUnavailable
 	}
 	typeName := strings.TrimSpace(s.authorizationResource(resourceName).GetType())
+	cache := listingDecisionCacheFromContext(ctx)
+	if cached, ok := cache.model(typeName); ok {
+		return cached, nil
+	}
 	resp, err := s.authorization.ListActiveModelResourceTypes(ctx, &proto.ListActiveModelResourceTypesRequest{
 		Filter:   &proto.AuthorizationModelResourceTypeFilter{Name: typeName},
 		PageSize: 1,
@@ -477,6 +483,7 @@ func (s *Server) mountedUIResourceModel(ctx context.Context, resourceName string
 		}
 		break
 	}
+	cache.putModel(typeName, snapshot)
 	return snapshot, nil
 }
 

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -153,6 +153,11 @@ func run(ctx context.Context, cfg *config.Config, result *bootstrap.Result, gest
 			AuthorizationPolicy: cfg.Server.Admin.AuthorizationPolicy,
 			AllowedRoles:        append([]string(nil), cfg.Server.Admin.AllowedRoles...),
 		},
+		UserLookup: UserLookupRouteConfig{
+			AuthorizationPolicy: cfg.Server.UserLookup.AuthorizationPolicy,
+			AllowedRoles:        append([]string(nil), cfg.Server.UserLookup.AllowedRoles...),
+		},
+		OperationAccessChecker:  operationAccessChecker(result.Invoker),
 		AppRegistries:           cfg.AppRegistries,
 		AppRegistryHeartbeatTTL: heartbeatTTL,
 		AppRegistryRolloutMode:  cfg.Server.AppRegistry.RolloutMode,
@@ -497,6 +502,7 @@ func newMCPHandler(cfg *config.Config, connMaps bootstrap.ConnectionMaps, result
 	return gestaltmcp.NewStatelessHTTPHandler(gestaltmcp.Config{
 		Invoker:           invoker,
 		TokenResolver:     broker,
+		OperationAccess:   broker,
 		AuditSink:         result.AuditSink,
 		Providers:         result.Providers,
 		AllowedProviders:  allowedProviders,

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -122,6 +122,8 @@ type Server struct {
 	authorization                 core.AuthorizationProvider
 	providerKinds                 map[string]invocation.ProviderKind
 	authorizationPolicies         map[string]string
+	operationAccess               invocation.OperationAccessChecker
+	userLookupRoute               UserLookupRouteConfig
 	auditSink                     core.AuditSink
 	users                         userStore
 	externalCredentials           core.ExternalCredentialProvider
@@ -206,12 +208,19 @@ func (s *Server) catalogSelectorConfig() invocation.CatalogSelectorConfig {
 }
 
 type Config struct {
-	Auth                    core.IdentityProvider
-	SelectedAuthProvider    string
-	AuthProviders           map[string]core.IdentityProvider
-	Authorization           core.AuthorizationProvider
-	ProviderKinds           map[string]invocation.ProviderKind
-	AuthorizationPolicies   map[string]string
+	Auth                  core.IdentityProvider
+	SelectedAuthProvider  string
+	AuthProviders         map[string]core.IdentityProvider
+	Authorization         core.AuthorizationProvider
+	ProviderKinds         map[string]invocation.ProviderKind
+	AuthorizationPolicies map[string]string
+	// OperationAccessChecker answers batched operation-access questions for
+	// catalog listing. Nil disables catalog filtering; invoke-time
+	// enforcement is unaffected either way.
+	OperationAccessChecker invocation.OperationAccessChecker
+	// UserLookup gates resolving other people's identities on an explicit
+	// employee operator role.
+	UserLookup              UserLookupRouteConfig
 	AuditSink               core.AuditSink
 	Services                *coredata.Services
 	Providers               *registry.ProviderMap[core.Provider]
@@ -327,6 +336,15 @@ func New(cfg Config) (*Server, error) {
 	if err != nil {
 		return nil, fmt.Errorf("normalize admin route: %w", err)
 	}
+	defaultUserLookupResource := ""
+	if !noAuth && cfg.Authorization != nil {
+		defaultUserLookupResource = defaultUserLookupAuthorizationResource
+	}
+	userLookupRoute, err := normalizeUserLookupRouteConfig(cfg.UserLookup, defaultUserLookupResource)
+	if err != nil {
+		return nil, fmt.Errorf("normalize user lookup route: %w", err)
+	}
+	operationAccess := cfg.OperationAccessChecker
 	if err := validateAdminRouteRuntime(adminRoute, noAuth, cfg.PublicBaseURL, cfg.ManagementBaseURL, cfg.RouteProfile); err != nil {
 		return nil, fmt.Errorf("validate admin route: %w", err)
 	}
@@ -440,6 +458,8 @@ func New(cfg Config) (*Server, error) {
 		authorization:                 cfg.Authorization,
 		providerKinds:                 cfg.ProviderKinds,
 		authorizationPolicies:         cfg.AuthorizationPolicies,
+		operationAccess:               operationAccess,
+		userLookupRoute:               userLookupRoute,
 		auditSink:                     cfg.AuditSink,
 		users:                         users,
 		externalCredentials:           externalCredentials,

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -2770,7 +2770,9 @@ type serverTestAuthorizationProvider struct {
 	relationships            []*proto.Relationship
 	listRelationshipRequests []*proto.ListRelationshipsRequest
 	checkAccessRequests      []*proto.CheckAccessRequest
+	checkAccessManyRequests  []*proto.CheckAccessManyRequest
 	checkAccessErr           error
+	checkAccessManyErr       error
 }
 
 // CheckAccess models the provider-owned evaluator: it expands subject sets so a
@@ -2778,6 +2780,13 @@ type serverTestAuthorizationProvider struct {
 // real relationship-graph provider does.
 func (p *serverTestAuthorizationProvider) CheckAccess(_ context.Context, req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
 	p.checkAccessRequests = append(p.checkAccessRequests, req)
+	return p.decide(req)
+}
+
+// decide is the evaluator itself, shared by the single and batched RPCs so the
+// stub cannot answer one question two ways. Only the public entry points record
+// calls, which lets tests count batched versus per-item round trips.
+func (p *serverTestAuthorizationProvider) decide(req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
 	if p.checkAccessErr != nil {
 		return nil, p.checkAccessErr
 	}
@@ -2789,10 +2798,14 @@ func (p *serverTestAuthorizationProvider) CheckAccess(_ context.Context, req *pr
 	return &proto.CheckAccessResponse{Allowed: len(relations) > 0, MatchedRelations: relations}, nil
 }
 
-func (p *serverTestAuthorizationProvider) CheckAccessMany(ctx context.Context, req *proto.CheckAccessManyRequest) (*proto.CheckAccessManyResponse, error) {
+func (p *serverTestAuthorizationProvider) CheckAccessMany(_ context.Context, req *proto.CheckAccessManyRequest) (*proto.CheckAccessManyResponse, error) {
+	p.checkAccessManyRequests = append(p.checkAccessManyRequests, req)
+	if p.checkAccessManyErr != nil {
+		return nil, p.checkAccessManyErr
+	}
 	decisions := make([]*proto.CheckAccessResponse, 0, len(req.GetRequests()))
 	for _, entry := range req.GetRequests() {
-		decision, err := p.CheckAccess(ctx, entry)
+		decision, err := p.decide(entry)
 		if err != nil {
 			return nil, err
 		}

--- a/gestaltd/internal/server/test_auth_stubs_test.go
+++ b/gestaltd/internal/server/test_auth_stubs_test.go
@@ -28,6 +28,12 @@ const (
 	// test subjects use realistic user-table UUIDs.
 	testCanonicalAdminUserID  = "9f2c1c2e-1a2b-4c3d-8e4f-5a6b7c8d9e01"
 	testCanonicalViewerUserID = "3b7d5e6f-2c3d-4e5f-9a0b-1c2d3e4f5a02"
+
+	// User lookup is gated on a dedicated employee operator resource and
+	// relation, not on any app's admin grant. These mirror the server's
+	// built-in defaults.
+	testUserLookupResource = "gestaltUserLookup"
+	testUserLookupRole     = "operator"
 )
 
 func grantTestProviders(t *testing.T) *registry.ProviderMap[core.Provider] {

--- a/gestaltd/internal/server/user_lookup.go
+++ b/gestaltd/internal/server/user_lookup.go
@@ -3,6 +3,8 @@ package server
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"slices"
 	"strings"
 
 	"github.com/valon-technologies/gestalt/server/services/apps/packageio"
@@ -15,6 +17,12 @@ import (
 // administering an app must not, on its own, let the administrator enumerate
 // the people in the directory.
 const defaultUserLookupAuthorizationResource = "gestaltUserLookup"
+
+// userLookupLegacyDecisionLogMessage marks a user-lookup decision that fell
+// back to the direct-grant path because the active model declares no matching
+// or wildcard action. Its absence in production is the evidence the shim can
+// be deleted.
+const userLookupLegacyDecisionLogMessage = "auth: user lookup resource type declares no matching action; using legacy direct-grant path"
 
 // defaultUserLookupOperatorRole is the explicit employee operator relation that
 // permits user lookup. It is a distinct relation from "admin" so an app-scoped
@@ -92,5 +100,51 @@ func (s *Server) userLookupAllowed(ctx context.Context) bool {
 		Resource:     s.authorizationResource(policy),
 		AllowedRoles: s.userLookupRoute.AllowedRoles,
 	})
-	return err == nil && decision.Allowed
+	if err != nil {
+		return false
+	}
+	if decision.Allowed {
+		return true
+	}
+	return s.userLookupAllowedByDirectGrant(ctx, subjectID, policy)
+}
+
+// userLookupAllowedByDirectGrant is the user-lookup half of the TRANSITION
+// SHIM documented on legacyDirectGrantMountedAccess. The user-lookup resource
+// type is policy-shaped like gestaltAdmin: it declares the operator relation
+// but typically no actions. CheckAccessRequest is action-shaped, so an
+// evaluator asked about an undeclared action answers "denied" to a question it
+// cannot represent, and an operator grant would never restore lookup. Delete
+// this with the mounted-UI shim once T1 confirms the user-lookup resource type
+// declares a matching or wildcard action.
+//
+// Only a successfully read model that proves the evaluator cannot answer
+// reaches the direct-grant scan; a model or provider error denies.
+func (s *Server) userLookupAllowedByDirectGrant(ctx context.Context, subjectID, policy string) bool {
+	model, err := s.mountedUIResourceModel(ctx, policy)
+	if err != nil || model.answersAction(policy) {
+		return false
+	}
+
+	slog.WarnContext(ctx, userLookupLegacyDecisionLogMessage,
+		"resourceType", model.typeName,
+		"resource", policy,
+		"action", policy,
+		"modelKnowsResourceType", model.found,
+	)
+
+	roles, err := s.legacyDirectGrantRoles(ctx, subjectID, policy)
+	if err != nil {
+		return false
+	}
+	allowed := s.userLookupRoute.AllowedRoles
+	if len(allowed) == 0 {
+		return len(roles) > 0
+	}
+	for _, allowedRole := range allowed {
+		if allowedRole = strings.TrimSpace(allowedRole); allowedRole != "" && slices.Contains(roles, allowedRole) {
+			return true
+		}
+	}
+	return false
 }

--- a/gestaltd/internal/server/user_lookup.go
+++ b/gestaltd/internal/server/user_lookup.go
@@ -1,0 +1,96 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/services/apps/packageio"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
+)
+
+// defaultUserLookupAuthorizationResource names the dedicated authorization
+// resource that gates user lookup. It is deliberately not any app's resource:
+// administering an app must not, on its own, let the administrator enumerate
+// the people in the directory.
+const defaultUserLookupAuthorizationResource = "gestaltUserLookup"
+
+// defaultUserLookupOperatorRole is the explicit employee operator relation that
+// permits user lookup. It is a distinct relation from "admin" so an app-scoped
+// admin grant can never satisfy it.
+const defaultUserLookupOperatorRole = "operator"
+
+// UserLookupRouteConfig gates user lookup - resolving another person's identity
+// (their email) from a subject ID - on an explicit employee operator role.
+//
+// AuthorizationPolicy empty means the gate is inactive, which is the case when
+// auth or the authorization provider is not configured; behavior then matches
+// what it was before the gate existed. Otherwise the caller must hold one of
+// AllowedRoles on the policy resource.
+type UserLookupRouteConfig struct {
+	AuthorizationPolicy string
+	AllowedRoles        []string
+}
+
+func normalizeUserLookupRouteConfig(cfg UserLookupRouteConfig, defaultAuthorizationResource string) (UserLookupRouteConfig, error) {
+	cfg.AuthorizationPolicy = strings.TrimSpace(cfg.AuthorizationPolicy)
+	if cfg.AuthorizationPolicy == "" {
+		cfg.AuthorizationPolicy = strings.TrimSpace(defaultAuthorizationResource)
+	}
+	if cfg.AuthorizationPolicy == "" {
+		if len(cfg.AllowedRoles) > 0 {
+			return UserLookupRouteConfig{}, fmt.Errorf("user lookup allowedRoles requires authorizationPolicy")
+		}
+		cfg.AllowedRoles = nil
+		return cfg, nil
+	}
+	if len(cfg.AllowedRoles) == 0 {
+		cfg.AllowedRoles = []string{defaultUserLookupOperatorRole}
+		return cfg, nil
+	}
+	roles, err := packageio.NormalizeUIAllowedRoles("user lookup allowedRoles", cfg.AllowedRoles)
+	if err != nil {
+		return UserLookupRouteConfig{}, err
+	}
+	cfg.AllowedRoles = roles
+	return cfg, nil
+}
+
+// userLookupAllowed reports whether the caller holds the employee operator role
+// that permits resolving other people's identities.
+//
+// The decision goes through the shared evaluator like every other server-side
+// decision, so the role may be held directly or through a group. Any evaluator
+// error denies: user enumeration fails closed. Callers resolve this once per
+// request and pass the answer down, so gating a roster costs one decision, not
+// one per row.
+func (s *Server) userLookupAllowed(ctx context.Context) bool {
+	if s == nil {
+		return false
+	}
+	policy := strings.TrimSpace(s.userLookupRoute.AuthorizationPolicy)
+	if policy == "" {
+		// The gate is not configured (no auth / no authorization provider), so
+		// lookup behaves as it did before the gate existed.
+		return true
+	}
+	p := PrincipalFromContext(ctx)
+	if p == nil || principal.IsNonUserPrincipal(p) {
+		return false
+	}
+	subjectID, err := principal.ResolveAuthorizationSubjectID(ctx, s.credentialUserResolver(), p)
+	if err != nil {
+		return false
+	}
+	if subjectID = strings.TrimSpace(subjectID); subjectID == "" {
+		return false
+	}
+	decision, err := s.checkResourceAccess(ctx, invocation.ResourceAccessRequest{
+		SubjectID:    subjectID,
+		Action:       policy,
+		Resource:     s.authorizationResource(policy),
+		AllowedRoles: s.userLookupRoute.AllowedRoles,
+	})
+	return err == nil && decision.Allowed
+}

--- a/gestaltd/internal/server/user_lookup_test.go
+++ b/gestaltd/internal/server/user_lookup_test.go
@@ -156,3 +156,64 @@ func TestUserLookupHonorsGroupDerivedOperatorRole(t *testing.T) {
 		t.Fatalf("group-derived operator role did not resolve email: %#v", rows)
 	}
 }
+
+// TestUserLookupWorksWhenModelDeclaresNoMatchingAction guards the transition
+// shim. The user-lookup resource is policy-shaped like gestaltAdmin: it carries
+// the operator relation but declares no actions. CheckAccessRequest is
+// action-shaped, so an evaluator asked about an undeclared action answers
+// "denied" to a question it cannot represent. Without the shim an operator
+// grant would never restore lookup and the gate would stay shut for everyone.
+func TestUserLookupWorksWhenModelDeclaresNoMatchingAction(t *testing.T) {
+	t.Parallel()
+
+	services := testutil.NewStubServices(t)
+	member := seedUser(t, services, "bob@valon.com")
+	memberSubject := principal.UserSubjectID(member.ID)
+	adminSubject := principal.UserSubjectID(testCanonicalAdminUserID)
+
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(adminSubject, "admin", "app", "g-issues"),
+			testAuthorizationRelationship(memberSubject, "viewer", "app", "g-issues"),
+			testAuthorizationRelationship(adminSubject, testUserLookupRole, testUserLookupResource, testUserLookupResource),
+		},
+		// The app type answers actions; the user-lookup type declares the
+		// operator relation but no actions at all, as a real policy type does.
+		resourceTypes: []*proto.AuthorizationModelResourceType{
+			{Name: "app", Actions: []*proto.ModelAction{{Name: "*"}}},
+			{Name: testUserLookupResource},
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("admin-token", adminSubject, "")
+		cfg.Authorization = authz
+		cfg.Services = services
+		cfg.AppDefs = appAdminTestAppDefs()
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	request, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/g-issues/admin/members", nil)
+	request.Header.Set("Authorization", "Bearer admin-token")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET members: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("GET members status = %d: %s", response.StatusCode, body)
+	}
+	var rows []memberEmailRow
+	if err := json.NewDecoder(response.Body).Decode(&rows); err != nil {
+		t.Fatalf("decode members: %v", err)
+	}
+
+	email, ok := memberEmailFor(rows, memberSubject)
+	if !ok {
+		t.Fatalf("member row missing: %#v", rows)
+	}
+	if email != "bob@valon.com" {
+		t.Fatalf("operator grant did not resolve email when the model declares no matching action: %#v", rows)
+	}
+}

--- a/gestaltd/internal/server/user_lookup_test.go
+++ b/gestaltd/internal/server/user_lookup_test.go
@@ -1,0 +1,158 @@
+package server_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/server"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+)
+
+type memberEmailRow struct {
+	Email     string `json:"email"`
+	Role      string `json:"role"`
+	SubjectID string `json:"subjectId"`
+}
+
+// userLookupMembersRows fetches the app-admin member roster for an admin that
+// holds app-scoped admin plus, optionally, the employee operator role.
+func userLookupMembersRows(t *testing.T, withOperatorRole bool) []memberEmailRow {
+	t.Helper()
+
+	services := testutil.NewStubServices(t)
+	member := seedUser(t, services, "bob@valon.com")
+	memberSubject := principal.UserSubjectID(member.ID)
+	adminSubject := principal.UserSubjectID(testCanonicalAdminUserID)
+
+	relationships := []*proto.Relationship{
+		testAuthorizationRelationship(adminSubject, "admin", "app", "g-issues"),
+		testAuthorizationRelationship(memberSubject, "viewer", "app", "g-issues"),
+	}
+	if withOperatorRole {
+		relationships = append(relationships,
+			testAuthorizationRelationship(adminSubject, testUserLookupRole, testUserLookupResource, testUserLookupResource))
+	}
+	authz := &serverTestAuthorizationProvider{relationships: relationships}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("admin-token", adminSubject, "")
+		cfg.Authorization = authz
+		cfg.Services = services
+		cfg.AppDefs = appAdminTestAppDefs()
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	request, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/g-issues/admin/members", nil)
+	request.Header.Set("Authorization", "Bearer admin-token")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET members: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("GET members status = %d: %s", response.StatusCode, body)
+	}
+	var rows []memberEmailRow
+	if err := json.NewDecoder(response.Body).Decode(&rows); err != nil {
+		t.Fatalf("decode members: %v", err)
+	}
+	return rows
+}
+
+func memberEmailFor(rows []memberEmailRow, subjectID string) (string, bool) {
+	for _, row := range rows {
+		if row.SubjectID == subjectID {
+			return row.Email, true
+		}
+	}
+	return "", false
+}
+
+// TestAppAdminAloneCannotEnumerateUsers is the restriction the plan asks for:
+// administering an app must not, on its own, turn the admin surface into a
+// directory. The roster still lists the grants; only the identity lookup is
+// withheld.
+func TestAppAdminAloneCannotEnumerateUsers(t *testing.T) {
+	t.Parallel()
+
+	rows := userLookupMembersRows(t, false)
+	if len(rows) != 2 {
+		t.Fatalf("members = %#v, want 2 rows", rows)
+	}
+	for _, row := range rows {
+		if row.Email != "" {
+			t.Fatalf("app-scoped admin resolved an email without the operator role: %#v", row)
+		}
+	}
+}
+
+// TestEmployeeOperatorRoleAllowsUserLookup is the positive half: the explicit
+// operator role, and only it, restores identity resolution.
+func TestEmployeeOperatorRoleAllowsUserLookup(t *testing.T) {
+	t.Parallel()
+
+	rows := userLookupMembersRows(t, true)
+	if len(rows) != 2 {
+		t.Fatalf("members = %#v, want 2 rows", rows)
+	}
+	found := false
+	for _, row := range rows {
+		if row.Email == "bob@valon.com" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("operator role did not resolve member email: %#v", rows)
+	}
+}
+
+// TestUserLookupHonorsGroupDerivedOperatorRole proves the gate goes through the
+// shared evaluator, so the operator role may be held through a group.
+func TestUserLookupHonorsGroupDerivedOperatorRole(t *testing.T) {
+	t.Parallel()
+
+	services := testutil.NewStubServices(t)
+	member := seedUser(t, services, "bob@valon.com")
+	memberSubject := principal.UserSubjectID(member.ID)
+	adminSubject := principal.UserSubjectID(testCanonicalAdminUserID)
+
+	relationships := []*proto.Relationship{
+		testAuthorizationRelationship(adminSubject, "admin", "app", "g-issues"),
+		testAuthorizationRelationship(memberSubject, "viewer", "app", "g-issues"),
+	}
+	relationships = append(relationships,
+		subjectSetGrant(adminSubject, testUserLookupRole, testUserLookupResource, testUserLookupResource)...)
+	authz := &serverTestAuthorizationProvider{relationships: relationships}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("admin-token", adminSubject, "")
+		cfg.Authorization = authz
+		cfg.Services = services
+		cfg.AppDefs = appAdminTestAppDefs()
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	request, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/g-issues/admin/members", nil)
+	request.Header.Set("Authorization", "Bearer admin-token")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET members: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	var rows []memberEmailRow
+	if err := json.NewDecoder(response.Body).Decode(&rows); err != nil {
+		t.Fatalf("decode members: %v", err)
+	}
+	email, ok := memberEmailFor(rows, memberSubject)
+	if !ok {
+		t.Fatalf("member row missing: %#v", rows)
+	}
+	if email != "bob@valon.com" {
+		t.Fatalf("group-derived operator role did not resolve email: %#v", rows)
+	}
+}

--- a/gestaltd/services/apps/mcp/binding.go
+++ b/gestaltd/services/apps/mcp/binding.go
@@ -16,14 +16,19 @@ const (
 )
 
 type Config struct {
-	Invoker             invocation.Invoker
-	TokenResolver       invocation.TokenResolver
-	AuditSink           core.AuditSink
-	Providers           *registry.ProviderMap[core.Provider]
-	AllowedProviders    []string
-	ToolPrefixes        map[string]string
-	IncludeREST         map[string]bool
-	MCPConnection       map[string]string
-	CatalogProjection   func(provName string, prov core.Provider, cat *catalog.Catalog) *catalog.Catalog
+	Invoker           invocation.Invoker
+	TokenResolver     invocation.TokenResolver
+	AuditSink         core.AuditSink
+	Providers         *registry.ProviderMap[core.Provider]
+	AllowedProviders  []string
+	ToolPrefixes      map[string]string
+	IncludeREST       map[string]bool
+	MCPConnection     map[string]string
+	CatalogProjection func(provName string, prov core.Provider, cat *catalog.Catalog) *catalog.Catalog
+	// OperationAccess answers tools/list authorization questions in one
+	// batched evaluator call, using the same decision path tools/call uses.
+	// Nil means tools/list is not authorization-filtered; tools/call
+	// enforcement is unaffected either way.
+	OperationAccess     invocation.OperationAccessChecker
 	InvocationValidator func(ctx context.Context, provName string, prov core.Provider, op catalog.CatalogOperation, params map[string]any, explicitConnection string) error
 }

--- a/gestaltd/services/apps/mcp/stateless_http.go
+++ b/gestaltd/services/apps/mcp/stateless_http.go
@@ -168,13 +168,33 @@ func (h *StatelessHTTPHandler) handleMessage(ctx context.Context, headers http.H
 	}
 }
 
+// listedTool is one tools/list candidate and the operation it maps to, so the
+// authorization question asked about it is the same question tools/call asks.
+type listedTool struct {
+	tool  mcpgo.Tool
+	query invocation.OperationAccessQuery
+}
+
+// listTools answers tools/list. A tool is listed only when the caller's token
+// scope permits the app AND the authorization evaluator allows the underlying
+// operation - scope and authorization, not scope or authorization.
+//
+// The authorization answers come from one batched call through the same
+// decision path tools/call uses, so a listed tool is a callable tool. When the
+// evaluator cannot be reached the request fails with an error rather than
+// returning a short or empty tool list, because an empty tools/list is
+// indistinguishable from "you have no tools". tools/call enforcement is
+// unchanged and remains the authority.
 func (h *StatelessHTTPHandler) listTools(ctx context.Context, req mcpgo.ListToolsRequest) (mcpgo.ListToolsResult, error) {
 	if strings.TrimSpace(string(req.Params.Cursor)) != "" {
 		return mcpgo.ListToolsResult{}, fmt.Errorf("tools/list cursor is not supported")
 	}
 	p := principal.FromContext(ctx)
-	tools := make([]mcpgo.Tool, 0)
+	candidates := make([]listedTool, 0)
 	for _, provName := range h.providerNames {
+		if p != nil && !principal.AllowsProviderPermission(p, provName) {
+			continue
+		}
 		prov, ok := h.provider(ctx, provName)
 		if !ok {
 			continue
@@ -187,17 +207,52 @@ func (h *StatelessHTTPHandler) listTools(ctx context.Context, req mcpgo.ListTool
 		if cat == nil {
 			continue
 		}
-		toolMap, _ := statelessToolMap(h.cfg, provName, cat)
+		toolMap, refs := statelessToolMap(h.cfg, provName, cat)
 		names := make([]string, 0, len(toolMap))
 		for name := range toolMap {
 			names = append(names, name)
 		}
 		sort.Strings(names)
 		for _, name := range names {
-			if p != nil && !principal.AllowsProviderPermission(p, provName) {
-				continue
+			operation := refs[name].operation
+			var allowedRoles []string
+			if op, found := invocation.CatalogOperation(cat, operation); found {
+				allowedRoles = op.AllowedRoles
 			}
-			tools = append(tools, toolMap[name])
+			candidates = append(candidates, listedTool{
+				tool: toolMap[name],
+				query: invocation.OperationAccessQuery{
+					Provider:     provName,
+					Operation:    operation,
+					AllowedRoles: allowedRoles,
+				},
+			})
+		}
+	}
+
+	if h.cfg.OperationAccess == nil || len(candidates) == 0 {
+		tools := make([]mcpgo.Tool, 0, len(candidates))
+		for i := range candidates {
+			tools = append(tools, candidates[i].tool)
+		}
+		return mcpgo.ListToolsResult{Tools: tools}, nil
+	}
+
+	queries := make([]invocation.OperationAccessQuery, len(candidates))
+	for i := range candidates {
+		queries[i] = candidates[i].query
+	}
+	results, err := h.cfg.OperationAccess.CheckOperationAccessMany(ctx, p, queries)
+	if err != nil {
+		return mcpgo.ListToolsResult{}, fmt.Errorf("tools/list authorization is unavailable: %w", err)
+	}
+	if len(results) != len(candidates) {
+		return mcpgo.ListToolsResult{}, fmt.Errorf("tools/list authorization returned %d decisions for %d tools", len(results), len(candidates))
+	}
+	tools := make([]mcpgo.Tool, 0, len(candidates))
+	for i := range candidates {
+		if results[i] == nil {
+			tools = append(tools, candidates[i].tool)
 		}
 	}
 	return mcpgo.ListToolsResult{Tools: tools}, nil

--- a/gestaltd/services/apps/mcp/stateless_http_listing_test.go
+++ b/gestaltd/services/apps/mcp/stateless_http_listing_test.go
@@ -1,0 +1,203 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
+)
+
+// recordingOperationAccess allows a named set of operations and counts the
+// batched calls, so a test can prove tools/list asks once for every tool rather
+// than once per tool.
+type recordingOperationAccess struct {
+	allowed map[string]bool
+	err     error
+	calls   int
+	queries []invocation.OperationAccessQuery
+}
+
+func (r *recordingOperationAccess) CheckOperationAccessMany(
+	_ context.Context, _ *principal.Principal, queries []invocation.OperationAccessQuery,
+) ([]error, error) {
+	r.calls++
+	r.queries = append(r.queries, queries...)
+	if r.err != nil {
+		return nil, r.err
+	}
+	results := make([]error, len(queries))
+	for i, query := range queries {
+		if !r.allowed[query.Operation] {
+			results[i] = errors.New("denied")
+		}
+	}
+	return results, nil
+}
+
+func listingTestConfig(t *testing.T, access invocation.OperationAccessChecker) Config {
+	t.Helper()
+	stub := &coretesting.StubIntegration{
+		N:        "sampleApp",
+		ConnMode: core.ConnectionModeNone,
+		CatalogVal: &catalog.Catalog{
+			Name: "sampleApp",
+			Operations: []catalog.CatalogOperation{
+				{ID: "items.list", Method: "GET", Path: "/items"},
+				{ID: "items.create", Method: "POST", Path: "/items"},
+			},
+		},
+	}
+	return Config{
+		Providers:        testutil.NewProviderRegistry(t, stub),
+		AllowedProviders: []string{"sampleApp"},
+		IncludeREST:      map[string]bool{"sampleApp": true},
+		OperationAccess:  access,
+	}
+}
+
+func listToolNames(t *testing.T, cfg Config, p *principal.Principal) ([]string, map[string]any) {
+	t.Helper()
+	handler := NewStatelessHTTPHandler(cfg)
+	body := `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`
+	req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader([]byte(body)))
+	req.Header.Set("Content-Type", "application/json")
+	if p != nil {
+		req = req.WithContext(principal.WithPrincipal(req.Context(), p))
+	}
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("tools/list status = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var envelope struct {
+		Result struct {
+			Tools []struct {
+				Name string `json:"name"`
+			} `json:"tools"`
+		} `json:"result"`
+		Error map[string]any `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode tools/list: %v", err)
+	}
+	names := make([]string, 0, len(envelope.Result.Tools))
+	for _, tool := range envelope.Result.Tools {
+		names = append(names, tool.Name)
+	}
+	return names, envelope.Error
+}
+
+func listingTestPrincipal() *principal.Principal {
+	return &principal.Principal{SubjectID: "user:u-1", UserID: "u-1", Kind: principal.KindUser}
+}
+
+// TestListToolsFiltersOnAuthorizationWithOneBatchedCall proves tools/list now
+// consults the evaluator - a tool the caller cannot call is not listed - and
+// that it does so in one batched question for the whole tool set.
+func TestListToolsFiltersOnAuthorizationWithOneBatchedCall(t *testing.T) {
+	t.Parallel()
+
+	access := &recordingOperationAccess{allowed: map[string]bool{"items.list": true}}
+	names, rpcErr := listToolNames(t, listingTestConfig(t, access), listingTestPrincipal())
+	if rpcErr != nil {
+		t.Fatalf("tools/list error: %v", rpcErr)
+	}
+	if len(names) != 1 {
+		t.Fatalf("tools = %v, want only the allowed tool", names)
+	}
+	if access.calls != 1 {
+		t.Fatalf("batched calls = %d, want 1", access.calls)
+	}
+	if len(access.queries) != 2 {
+		t.Fatalf("batched queries = %d, want 2 (one per tool)", len(access.queries))
+	}
+}
+
+// TestListToolsListsGrantedToolsForGrantedSubject is the positive half: a
+// subject the evaluator allows keeps every tool.
+func TestListToolsListsGrantedToolsForGrantedSubject(t *testing.T) {
+	t.Parallel()
+
+	access := &recordingOperationAccess{allowed: map[string]bool{"items.list": true, "items.create": true}}
+	names, rpcErr := listToolNames(t, listingTestConfig(t, access), listingTestPrincipal())
+	if rpcErr != nil {
+		t.Fatalf("tools/list error: %v", rpcErr)
+	}
+	if len(names) != 2 {
+		t.Fatalf("tools = %v, want both tools", names)
+	}
+}
+
+// TestListToolsHidesEverythingForUngrantedSubject covers the ungranted case.
+func TestListToolsHidesEverythingForUngrantedSubject(t *testing.T) {
+	t.Parallel()
+
+	access := &recordingOperationAccess{allowed: map[string]bool{}}
+	names, rpcErr := listToolNames(t, listingTestConfig(t, access), listingTestPrincipal())
+	if rpcErr != nil {
+		t.Fatalf("tools/list error: %v", rpcErr)
+	}
+	if len(names) != 0 {
+		t.Fatalf("ungranted subject sees tools %v", names)
+	}
+}
+
+// TestListToolsKeepsScopeAsAnAdditionalFilter proves scope AND authorization:
+// an authorization allow does not override a token scope that excludes the app.
+func TestListToolsKeepsScopeAsAnAdditionalFilter(t *testing.T) {
+	t.Parallel()
+
+	access := &recordingOperationAccess{allowed: map[string]bool{"items.list": true, "items.create": true}}
+	scoped := listingTestPrincipal()
+	scoped.Scopes = []string{"otherApp"}
+	names, rpcErr := listToolNames(t, listingTestConfig(t, access), scoped)
+	if rpcErr != nil {
+		t.Fatalf("tools/list error: %v", rpcErr)
+	}
+	if len(names) != 0 {
+		t.Fatalf("out-of-scope tools listed: %v", names)
+	}
+	if access.calls != 0 {
+		t.Fatalf("evaluator consulted for out-of-scope app: %d calls", access.calls)
+	}
+}
+
+// TestListToolsFailsLoudlyWhenEvaluatorUnavailable keeps an unreachable
+// evaluator from being reported to the client as "you have no tools".
+func TestListToolsFailsLoudlyWhenEvaluatorUnavailable(t *testing.T) {
+	t.Parallel()
+
+	access := &recordingOperationAccess{allowed: map[string]bool{}, err: errors.New("evaluator unavailable")}
+	names, rpcErr := listToolNames(t, listingTestConfig(t, access), listingTestPrincipal())
+	if rpcErr == nil {
+		t.Fatalf("evaluator failure returned tools %v instead of an error", names)
+	}
+	if len(names) != 0 {
+		t.Fatalf("tools returned alongside error: %v", names)
+	}
+}
+
+// TestListToolsWithoutCheckerKeepsCurrentBehavior keeps a deployment with no
+// authorization evaluator listing exactly what it listed before.
+func TestListToolsWithoutCheckerKeepsCurrentBehavior(t *testing.T) {
+	t.Parallel()
+
+	names, rpcErr := listToolNames(t, listingTestConfig(t, nil), listingTestPrincipal())
+	if rpcErr != nil {
+		t.Fatalf("tools/list error: %v", rpcErr)
+	}
+	if len(names) != 2 {
+		t.Fatalf("tools = %v, want both tools", names)
+	}
+}

--- a/gestaltd/services/invocation/authorization_batch.go
+++ b/gestaltd/services/invocation/authorization_batch.go
@@ -1,0 +1,185 @@
+package invocation
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+)
+
+// maxBatchedAccessChecks bounds one batched authorization call so a large
+// catalog or app roster cannot turn a single listing request into an unbounded
+// provider request.
+const maxBatchedAccessChecks = 1000
+
+// ErrBatchedAccessTooLarge reports that a caller asked for more decisions in
+// one batch than the server will send to the evaluator.
+var ErrBatchedAccessTooLarge = fmt.Errorf("batched authorization check exceeds %d requests", maxBatchedAccessChecks)
+
+// CheckResourceAccessMany answers many authorization questions with ONE
+// provider call. Listing surfaces use it so a catalog or app roster costs one
+// decision round trip instead of one per entry.
+//
+// Every answer is built by the same helpers CheckResourceAccess uses: the same
+// question builder and the same response projection. A batched decision and a
+// single decision for the same (subject, action, resource, allowed roles) are
+// therefore identical by construction, not by convention.
+//
+// It fails closed exactly like CheckResourceAccess: a nil provider, a transport
+// error, or a response the server cannot interpret returns an error and no
+// allow. Callers that must not hide entries on failure are expected to fall
+// back to CheckResourceAccess per entry rather than treat the error as a deny.
+func CheckResourceAccessMany(
+	ctx context.Context,
+	authorization core.AuthorizationProvider,
+	reqs []ResourceAccessRequest,
+) ([]ResourceAccessDecision, error) {
+	if authorization == nil {
+		return nil, ErrAuthorizationUnavailable
+	}
+	if len(reqs) > maxBatchedAccessChecks {
+		return nil, ErrBatchedAccessTooLarge
+	}
+
+	decisions := make([]ResourceAccessDecision, len(reqs))
+	batch := &proto.CheckAccessManyRequest{Requests: make([]*proto.CheckAccessRequest, 0, len(reqs))}
+	indexes := make([]int, 0, len(reqs))
+	for i, req := range reqs {
+		question := req.protoRequest()
+		if question.GetSubject().GetId() == "" || question.GetAction().GetName() == "" || question.GetResource() == nil {
+			// CheckResourceAccess answers a degenerate question with a deny and
+			// no provider call; the batch does the same and stays aligned.
+			continue
+		}
+		indexes = append(indexes, i)
+		batch.Requests = append(batch.Requests, question)
+	}
+	if len(batch.Requests) == 0 {
+		return decisions, nil
+	}
+
+	resp, err := authorization.CheckAccessMany(ctx, batch)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil || len(resp.GetDecisions()) != len(batch.Requests) {
+		return nil, ErrMalformedAuthorizationDecision
+	}
+	for n, decision := range resp.GetDecisions() {
+		if decision == nil {
+			return nil, ErrMalformedAuthorizationDecision
+		}
+		i := indexes[n]
+		decisions[i] = resourceAccessDecision(decision, reqs[i].AllowedRoles)
+	}
+	return decisions, nil
+}
+
+// OperationAccessQuery is one operation-listing question: may this principal
+// invoke this operation on this app.
+type OperationAccessQuery struct {
+	Provider     string
+	Operation    string
+	AllowedRoles []string
+}
+
+// OperationAccessChecker answers many operation-access questions with one
+// batched evaluator call. Catalog and MCP listing depend on this interface so
+// they can reach exactly the decisions invocation reaches.
+type OperationAccessChecker interface {
+	CheckOperationAccessMany(
+		ctx context.Context,
+		p *principal.Principal,
+		queries []OperationAccessQuery,
+	) ([]error, error)
+}
+
+// CheckOperationAccessMany answers many operation-access questions with one
+// batched evaluator call. Element i is nil when the operation is allowed and
+// otherwise carries the same ErrAuthorizationDenied error CheckOperationAccess
+// would return for that operation.
+//
+// Every answer runs through the same token-scope check, the same remote
+// delegation check, and the same evaluator projection the single-decision path
+// uses, so a listing answer and the invocation answer for the same operation
+// cannot disagree. Allowed roles are applied here as well, matching
+// authorizeOperation, so a tool the caller could not actually call is not
+// listed.
+//
+// When the provider cannot serve the batch - a transport failure, an
+// unimplemented batch RPC, or a response the server cannot interpret - each
+// unresolved question falls back to the single-decision path instead of being
+// reported as denied. Listing then costs more calls, never fewer results.
+func (b *Broker) CheckOperationAccessMany(
+	ctx context.Context,
+	p *principal.Principal,
+	queries []OperationAccessQuery,
+) ([]error, error) {
+	results := make([]error, len(queries))
+	pending := make([]int, 0, len(queries))
+	for i, query := range queries {
+		switch {
+		case !principal.AllowsOperationPermission(p, query.Provider, query.Operation):
+			results[i] = operationAccessDenied(query)
+		case b.providerDelegatesRemoteAuthorization(ctx, query.Provider):
+			// The remote app owns this decision, exactly as at invoke time.
+		default:
+			pending = append(pending, i)
+		}
+	}
+	if len(pending) == 0 || b == nil || b.authorization == nil {
+		// A server with no authorization provider allows every operation its
+		// token scope allows; that is what CheckOperationAccess does today.
+		return results, nil
+	}
+
+	subjectID, err := principal.ResolveCredentialSubjectID(ctx, b.users, p)
+	if err != nil {
+		for _, i := range pending {
+			results[i] = fmt.Errorf("%w: %s.%s: %v",
+				ErrAuthorizationDenied, queries[i].Provider, queries[i].Operation, err)
+		}
+		return results, nil
+	}
+
+	properties := subjectAccessProperties(p)
+	reqs := make([]ResourceAccessRequest, 0, len(pending))
+	for _, i := range pending {
+		reqs = append(reqs, ResourceAccessRequest{
+			SubjectID:         subjectID,
+			Action:            queries[i].Operation,
+			Resource:          b.authorizationResource(queries[i].Provider),
+			AllowedRoles:      queries[i].AllowedRoles,
+			SubjectProperties: properties,
+		})
+	}
+
+	decisions, batchErr := CheckResourceAccessMany(ctx, b.authorization, reqs)
+	if batchErr != nil {
+		for n, i := range pending {
+			decision, singleErr := CheckResourceAccess(ctx, b.authorization, reqs[n])
+			if singleErr != nil {
+				return nil, singleErr
+			}
+			results[i] = operationAccessResult(decision, queries[i])
+		}
+		return results, nil
+	}
+	for n, i := range pending {
+		results[i] = operationAccessResult(decisions[n], queries[i])
+	}
+	return results, nil
+}
+
+func operationAccessResult(decision ResourceAccessDecision, query OperationAccessQuery) error {
+	if !decision.Allowed {
+		return operationAccessDenied(query)
+	}
+	return nil
+}
+
+func operationAccessDenied(query OperationAccessQuery) error {
+	return fmt.Errorf("%w: %s.%s", ErrAuthorizationDenied, query.Provider, query.Operation)
+}

--- a/gestaltd/services/invocation/authorization_batch_test.go
+++ b/gestaltd/services/invocation/authorization_batch_test.go
@@ -1,0 +1,315 @@
+package invocation
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+)
+
+// batchAuthorizationProvider models a provider-owned evaluator that expands
+// subject sets, so a subject holding a role only through a group is allowed
+// exactly as the real relationship-graph provider allows it. It counts calls so
+// tests can prove a listing costs one batched round trip, not one per entry.
+type batchAuthorizationProvider struct {
+	core.AuthorizationProvider
+
+	// allow maps "<subject>|<action>" to the relations that authorize it.
+	allow map[string][]string
+
+	checkAccessCalls     int
+	checkAccessManyCalls int
+	checkAccessErr       error
+	checkAccessManyErr   error
+}
+
+func (p *batchAuthorizationProvider) CheckAccess(_ context.Context, req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
+	p.checkAccessCalls++
+	if p.checkAccessErr != nil {
+		return nil, p.checkAccessErr
+	}
+	relations := p.allow[req.GetSubject().GetId()+"|"+req.GetAction().GetName()]
+	return &proto.CheckAccessResponse{Allowed: len(relations) > 0, MatchedRelations: relations}, nil
+}
+
+func (p *batchAuthorizationProvider) CheckAccessMany(ctx context.Context, req *proto.CheckAccessManyRequest) (*proto.CheckAccessManyResponse, error) {
+	p.checkAccessManyCalls++
+	if p.checkAccessManyErr != nil {
+		return nil, p.checkAccessManyErr
+	}
+	decisions := make([]*proto.CheckAccessResponse, 0, len(req.GetRequests()))
+	for _, entry := range req.GetRequests() {
+		// Reuse the single-decision path so the stub cannot drift either.
+		p.checkAccessCalls--
+		decision, err := p.CheckAccess(ctx, entry)
+		if err != nil {
+			return nil, err
+		}
+		decisions = append(decisions, decision)
+	}
+	return &proto.CheckAccessManyResponse{Decisions: decisions}, nil
+}
+
+func (p *batchAuthorizationProvider) Ping(context.Context) error { return nil }
+
+func (p *batchAuthorizationProvider) Close() error { return nil }
+
+func batchTestCatalog() *catalog.Catalog {
+	return &catalog.Catalog{
+		Name: "slack",
+		Operations: []catalog.CatalogOperation{
+			{ID: "chat.postMessage", Method: "POST", Transport: catalog.TransportApp},
+			{ID: "chat.delete", Method: "POST", Transport: catalog.TransportApp},
+			{ID: "admin.purge", Method: "POST", Transport: catalog.TransportApp, AllowedRoles: []string{"admin"}},
+		},
+	}
+}
+
+func batchTestBroker(t *testing.T, authz core.AuthorizationProvider) *Broker {
+	t.Helper()
+	provider := &coretesting.StubIntegration{
+		N:          "slack",
+		ConnMode:   core.ConnectionModeNone,
+		CatalogVal: batchTestCatalog(),
+	}
+	return NewBroker(
+		testutil.NewProviderRegistry(t, provider),
+		nil,
+		nil,
+		WithAuthorizationProvider(authz),
+		WithProviderKinds(map[string]ProviderKind{"slack": ProviderKindApp}),
+	)
+}
+
+func batchTestPrincipal() *principal.Principal {
+	return &principal.Principal{SubjectID: "user:u-123", UserID: "u-123", Kind: principal.KindUser}
+}
+
+// TestFilterCatalogForPrincipalIssuesOneBatchedCall is the call-count guard:
+// filtering a three-operation catalog must cost one CheckAccessMany and zero
+// per-operation CheckAccess calls.
+func TestFilterCatalogForPrincipalIssuesOneBatchedCall(t *testing.T) {
+	t.Parallel()
+
+	authz := &batchAuthorizationProvider{allow: map[string][]string{
+		"user:u-123|chat.postMessage": {"user"},
+		"user:u-123|chat.delete":      {"user"},
+	}}
+	broker := batchTestBroker(t, authz)
+
+	filtered, err := FilterCatalogForPrincipal(
+		context.Background(), batchTestCatalog(), "slack", batchTestPrincipal(), broker)
+	if err != nil {
+		t.Fatalf("FilterCatalogForPrincipal: %v", err)
+	}
+	if len(filtered.Operations) != 2 {
+		t.Fatalf("filtered operations = %d, want 2: %#v", len(filtered.Operations), filtered.Operations)
+	}
+	if authz.checkAccessManyCalls != 1 {
+		t.Fatalf("CheckAccessMany calls = %d, want 1", authz.checkAccessManyCalls)
+	}
+	if authz.checkAccessCalls != 0 {
+		t.Fatalf("CheckAccess calls = %d, want 0 (listing must batch)", authz.checkAccessCalls)
+	}
+}
+
+// TestFilterCatalogForPrincipalHidesOnlyDeniedOperations proves an ungranted
+// subject sees nothing while a granted subject keeps its operations, and that
+// an operation's AllowedRoles are applied at listing exactly as at invoke.
+func TestFilterCatalogForPrincipalHidesOnlyDeniedOperations(t *testing.T) {
+	t.Parallel()
+
+	ungranted := &batchAuthorizationProvider{allow: map[string][]string{}}
+	filtered, err := FilterCatalogForPrincipal(
+		context.Background(), batchTestCatalog(), "slack", batchTestPrincipal(), batchTestBroker(t, ungranted))
+	if err != nil {
+		t.Fatalf("FilterCatalogForPrincipal: %v", err)
+	}
+	if len(filtered.Operations) != 0 {
+		t.Fatalf("ungranted subject sees %#v, want none", filtered.Operations)
+	}
+
+	// The subject is allowed the role-restricted operation but the evaluator
+	// names a relation the operation does not accept, which is a deny at invoke
+	// time; listing must agree.
+	wrongRole := &batchAuthorizationProvider{allow: map[string][]string{
+		"user:u-123|admin.purge": {"viewer"},
+	}}
+	filtered, err = FilterCatalogForPrincipal(
+		context.Background(), batchTestCatalog(), "slack", batchTestPrincipal(), batchTestBroker(t, wrongRole))
+	if err != nil {
+		t.Fatalf("FilterCatalogForPrincipal: %v", err)
+	}
+	if len(filtered.Operations) != 0 {
+		t.Fatalf("role-mismatched operation was listed: %#v", filtered.Operations)
+	}
+}
+
+// TestCheckOperationAccessManyMatchesSingleDecision is the semantic-identity
+// guard: for every operation, the batched answer equals the answer the
+// single-decision path gives for the same question.
+func TestCheckOperationAccessManyMatchesSingleDecision(t *testing.T) {
+	t.Parallel()
+
+	allow := map[string][]string{
+		"user:u-123|chat.postMessage": {"user"},
+		"user:u-123|admin.purge":      {"admin"},
+	}
+	p := batchTestPrincipal()
+	queries := []OperationAccessQuery{
+		{Provider: "slack", Operation: "chat.postMessage"},
+		{Provider: "slack", Operation: "chat.delete"},
+		{Provider: "slack", Operation: "admin.purge", AllowedRoles: []string{"admin"}},
+		{Provider: "slack", Operation: "admin.purge", AllowedRoles: []string{"viewer"}},
+	}
+
+	batchAuthz := &batchAuthorizationProvider{allow: allow}
+	batched, err := batchTestBroker(t, batchAuthz).CheckOperationAccessMany(context.Background(), p, queries)
+	if err != nil {
+		t.Fatalf("CheckOperationAccessMany: %v", err)
+	}
+	singleAuthz := &batchAuthorizationProvider{allow: allow}
+	singleBroker := batchTestBroker(t, singleAuthz)
+	for i, query := range queries {
+		single := singleBroker.CheckOperationAccess(context.Background(), p, query.Provider, query.Operation)
+		// CheckOperationAccess does not apply AllowedRoles, so compare only the
+		// questions where the query places no role restriction.
+		if len(query.AllowedRoles) > 0 {
+			continue
+		}
+		if (batched[i] == nil) != (single == nil) {
+			t.Fatalf("query %d: batched = %v, single = %v", i, batched[i], single)
+		}
+	}
+	if batched[2] != nil {
+		t.Fatalf("admin role query denied: %v", batched[2])
+	}
+	if batched[3] == nil {
+		t.Fatal("viewer role query allowed an admin-only operation")
+	}
+}
+
+// TestCheckOperationAccessManyFallsBackWhenBatchFails proves the safety
+// property that matters most: a provider that cannot serve the batch must not
+// turn every entry into a denial. Listing degrades to per-item calls instead.
+func TestCheckOperationAccessManyFallsBackWhenBatchFails(t *testing.T) {
+	t.Parallel()
+
+	authz := &batchAuthorizationProvider{
+		allow:              map[string][]string{"user:u-123|chat.postMessage": {"user"}},
+		checkAccessManyErr: errors.New("batch rpc unimplemented"),
+	}
+	broker := batchTestBroker(t, authz)
+
+	results, err := broker.CheckOperationAccessMany(context.Background(), batchTestPrincipal(), []OperationAccessQuery{
+		{Provider: "slack", Operation: "chat.postMessage"},
+		{Provider: "slack", Operation: "chat.delete"},
+	})
+	if err != nil {
+		t.Fatalf("CheckOperationAccessMany: %v", err)
+	}
+	if results[0] != nil {
+		t.Fatalf("granted operation denied after batch failure: %v", results[0])
+	}
+	if results[1] == nil {
+		t.Fatal("ungranted operation allowed after batch failure")
+	}
+	if authz.checkAccessCalls != 2 {
+		t.Fatalf("fallback CheckAccess calls = %d, want 2", authz.checkAccessCalls)
+	}
+}
+
+// TestFilterCatalogForPrincipalReturnsErrorInsteadOfEmptyCatalog is the
+// access-loss guard: an unreachable evaluator must surface an error, never a
+// silently empty operation list that reads as "you have no apps".
+func TestFilterCatalogForPrincipalReturnsErrorInsteadOfEmptyCatalog(t *testing.T) {
+	t.Parallel()
+
+	authz := &batchAuthorizationProvider{
+		allow:              map[string][]string{},
+		checkAccessManyErr: errors.New("evaluator unavailable"),
+		checkAccessErr:     errors.New("evaluator unavailable"),
+	}
+	filtered, err := FilterCatalogForPrincipal(
+		context.Background(), batchTestCatalog(), "slack", batchTestPrincipal(), batchTestBroker(t, authz))
+	if err == nil {
+		t.Fatalf("evaluator failure produced a catalog instead of an error: %#v", filtered)
+	}
+	if filtered != nil {
+		t.Fatalf("filtered catalog = %#v, want nil on error", filtered)
+	}
+}
+
+// TestFilterCatalogForPrincipalWithoutCheckerLeavesCatalogIntact keeps the
+// no-authorization deployment unchanged.
+func TestFilterCatalogForPrincipalWithoutCheckerLeavesCatalogIntact(t *testing.T) {
+	t.Parallel()
+
+	cat := batchTestCatalog()
+	filtered, err := FilterCatalogForPrincipal(context.Background(), cat, "slack", batchTestPrincipal(), nil)
+	if err != nil {
+		t.Fatalf("FilterCatalogForPrincipal: %v", err)
+	}
+	if len(filtered.Operations) != len(cat.Operations) {
+		t.Fatalf("filtered operations = %d, want %d", len(filtered.Operations), len(cat.Operations))
+	}
+}
+
+// TestCheckResourceAccessManyMatchesCheckResourceAccess pins the shared
+// projection: batched and single answers agree for the same question.
+func TestCheckResourceAccessManyMatchesCheckResourceAccess(t *testing.T) {
+	t.Parallel()
+
+	authz := &batchAuthorizationProvider{allow: map[string][]string{
+		"user:u-1|sampleApp": {"viewer"},
+	}}
+	reqs := []ResourceAccessRequest{
+		{SubjectID: "user:u-1", Action: "sampleApp", Resource: &proto.Resource{Type: "app", Id: "sampleApp"}},
+		{SubjectID: "user:u-1", Action: "sampleApp", Resource: &proto.Resource{Type: "app", Id: "sampleApp"}, AllowedRoles: []string{"admin"}},
+		{SubjectID: "user:u-2", Action: "sampleApp", Resource: &proto.Resource{Type: "app", Id: "sampleApp"}},
+		{SubjectID: "", Action: "sampleApp", Resource: &proto.Resource{Type: "app", Id: "sampleApp"}},
+	}
+
+	batched, err := CheckResourceAccessMany(context.Background(), authz, reqs)
+	if err != nil {
+		t.Fatalf("CheckResourceAccessMany: %v", err)
+	}
+	for i, req := range reqs {
+		single, singleErr := CheckResourceAccess(context.Background(), authz, req)
+		if singleErr != nil {
+			t.Fatalf("req %d: CheckResourceAccess: %v", i, singleErr)
+		}
+		if batched[i] != single {
+			t.Fatalf("req %d: batched = %+v, single = %+v", i, batched[i], single)
+		}
+	}
+}
+
+// TestCheckResourceAccessManyFailsClosedOnMalformedResponse keeps a truncated
+// batch from being read as a set of denials.
+func TestCheckResourceAccessManyFailsClosedOnMalformedResponse(t *testing.T) {
+	t.Parallel()
+
+	authz := &truncatingAuthorizationProvider{}
+	_, err := CheckResourceAccessMany(context.Background(), authz, []ResourceAccessRequest{
+		{SubjectID: "user:u-1", Action: "a", Resource: &proto.Resource{Type: "app", Id: "a"}},
+		{SubjectID: "user:u-1", Action: "b", Resource: &proto.Resource{Type: "app", Id: "b"}},
+	})
+	if !errors.Is(err, ErrMalformedAuthorizationDecision) {
+		t.Fatalf("error = %v, want ErrMalformedAuthorizationDecision", err)
+	}
+}
+
+type truncatingAuthorizationProvider struct {
+	core.AuthorizationProvider
+}
+
+func (p *truncatingAuthorizationProvider) CheckAccessMany(context.Context, *proto.CheckAccessManyRequest) (*proto.CheckAccessManyResponse, error) {
+	return &proto.CheckAccessManyResponse{Decisions: []*proto.CheckAccessResponse{{Allowed: true}}}, nil
+}

--- a/gestaltd/services/invocation/authorization_check.go
+++ b/gestaltd/services/invocation/authorization_check.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"strings"
 
+	"google.golang.org/protobuf/types/known/structpb"
+
 	"github.com/valon-technologies/gestalt/server/core"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 )
@@ -48,6 +50,10 @@ type ResourceAccessRequest struct {
 	// AllowedRoles, when non-empty, requires the evaluator to report one of
 	// these relations as the relation that authorized the action.
 	AllowedRoles []string
+	// SubjectProperties, when set, is the subject metadata the evaluator sees
+	// (token scope, client ID, audience). Surfaces that carry it on the
+	// single-decision path must carry the same value into a batched decision.
+	SubjectProperties *structpb.Struct
 }
 
 // ResourceAccessDecision is the evaluator's answer. Role is the relation that
@@ -79,30 +85,48 @@ func CheckResourceAccess(
 		return ResourceAccessDecision{}, nil
 	}
 
-	resp, err := authorization.CheckAccess(ctx, SubjectAccessRequest(subjectID, action, req.Resource))
+	resp, err := authorization.CheckAccess(ctx, req.protoRequest())
 	if err != nil {
 		return ResourceAccessDecision{}, err
 	}
 	if resp == nil {
 		return ResourceAccessDecision{}, ErrMalformedAuthorizationDecision
 	}
-	if !resp.GetAllowed() {
-		return ResourceAccessDecision{}, nil
-	}
+	return resourceAccessDecision(resp, req.AllowedRoles), nil
+}
 
+// protoRequest builds the evaluator question for one resource access request.
+// The batched and single-decision paths both go through it, so they can never
+// ask the evaluator two different questions about the same access request.
+func (req ResourceAccessRequest) protoRequest() *proto.CheckAccessRequest {
+	out := SubjectAccessRequest(req.SubjectID, req.Action, req.Resource)
+	if req.SubjectProperties != nil {
+		out.Subject.Properties = req.SubjectProperties
+	}
+	return out
+}
+
+// resourceAccessDecision projects one evaluator response onto the caller's
+// allowed-role restriction. It is the only place a CheckAccessResponse becomes
+// an allow/deny answer, so a decision read out of a batched response and a
+// decision read out of a single response are identical by construction.
+func resourceAccessDecision(resp *proto.CheckAccessResponse, allowedRoles []string) ResourceAccessDecision {
+	if !resp.GetAllowed() {
+		return ResourceAccessDecision{}
+	}
 	roles := boundedRelations(resp.GetMatchedRelations())
-	if len(req.AllowedRoles) == 0 {
+	if len(allowedRoles) == 0 {
 		role := ""
 		if len(roles) > 0 {
 			role = roles[0]
 		}
-		return ResourceAccessDecision{Allowed: true, Role: role}, nil
+		return ResourceAccessDecision{Allowed: true, Role: role}
 	}
-	role := matchedAllowedRole(roles, req.AllowedRoles)
+	role := matchedAllowedRole(roles, allowedRoles)
 	if role == "" {
-		return ResourceAccessDecision{}, nil
+		return ResourceAccessDecision{}
 	}
-	return ResourceAccessDecision{Allowed: true, Role: role}, nil
+	return ResourceAccessDecision{Allowed: true, Role: role}
 }
 
 // boundedRelations normalizes and caps the relations reported by a decision.

--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -1088,15 +1088,22 @@ func (b *Broker) CheckProviderAccess(ctx context.Context, p *principal.Principal
 }
 
 func accessRequest(p *principal.Principal, subjectID string, resource *proto.Resource, action string) *proto.CheckAccessRequest {
+	req := SubjectAccessRequest(subjectID, action, resource)
+	req.Subject.Properties = subjectAccessProperties(p)
+	return req
+}
+
+// subjectAccessProperties is the subject metadata the evaluator sees for an
+// invocation decision. Batched listing decisions reuse it so a listed operation
+// is judged with the same subject the invocation decision judges.
+func subjectAccessProperties(p *principal.Principal) *structpb.Struct {
 	p = principal.Canonicalized(p)
 	properties, _ := structpb.NewStruct(map[string]any{
 		"scope":     strings.Join(p.Scopes, " "),
 		"client_id": strings.TrimSpace(p.ClientID),
 		"audience":  append([]string(nil), p.Audience...),
 	})
-	req := SubjectAccessRequest(subjectID, action, resource)
-	req.Subject.Properties = properties
-	return req
+	return properties
 }
 
 func (b *Broker) resolveConnectionMode(ctx context.Context, prov core.Provider, providerName, connection string) core.ConnectionMode {

--- a/gestaltd/services/invocation/catalog.go
+++ b/gestaltd/services/invocation/catalog.go
@@ -320,6 +320,52 @@ func mergeCatalogs(provName string, staticCat, sessionCat *catalog.Catalog) (*ca
 	return merged, nil
 }
 
-func FilterCatalogForPrincipal(ctx context.Context, cat *catalog.Catalog, provName string, p *principal.Principal, _ any) *catalog.Catalog {
-	return cat
+// FilterCatalogForPrincipal removes the operations the principal may not
+// invoke. It reaches those answers with ONE batched evaluator call for the
+// whole catalog, through the same decision path invocation uses, so a listed
+// operation is an invocable operation and an operation hidden here would have
+// been denied at invoke time anyway.
+//
+// It never silently empties a catalog. When the evaluator cannot be reached the
+// error is returned to the caller so the surface can fail the request: an empty
+// operation list is indistinguishable from "you have no apps", and a listing
+// that quietly drops everything is the exact access-loss failure this filtering
+// exists to avoid. A nil checker means no filtering is configured and the
+// catalog is returned unchanged; invoke-time enforcement is unaffected.
+func FilterCatalogForPrincipal(
+	ctx context.Context,
+	cat *catalog.Catalog,
+	provName string,
+	p *principal.Principal,
+	checker OperationAccessChecker,
+) (*catalog.Catalog, error) {
+	if cat == nil || checker == nil || len(cat.Operations) == 0 {
+		return cat, nil
+	}
+
+	queries := make([]OperationAccessQuery, len(cat.Operations))
+	for i := range cat.Operations {
+		queries[i] = OperationAccessQuery{
+			Provider:     provName,
+			Operation:    cat.Operations[i].ID,
+			AllowedRoles: cat.Operations[i].AllowedRoles,
+		}
+	}
+	results, err := checker.CheckOperationAccessMany(ctx, p, queries)
+	if err != nil {
+		return nil, err
+	}
+	if len(results) != len(queries) {
+		return nil, ErrMalformedAuthorizationDecision
+	}
+
+	filtered := cat.Clone()
+	operations := make([]catalog.CatalogOperation, 0, len(filtered.Operations))
+	for i := range filtered.Operations {
+		if results[i] == nil {
+			operations = append(operations, filtered.Operations[i])
+		}
+	}
+	filtered.Operations = operations
+	return filtered, nil
 }


### PR DESCRIPTION
## Description

`FilterCatalogForPrincipal` ignored its principal and returned the catalog unfiltered, and MCP `tools/list` filtered only on token scope — so listings did not reflect authorization and enforcement happened only at invoke time. Both now decide through the same evaluator path used for invocation, batched via `CheckAccessMany`.

Stack A / second half of G3 in [plans/external_users/implementation_v2.md](https://github.com/valon-technologies/gestalt/blob/main/plans/external_users/implementation_v2.md). Stacked on #3071.

### Why this doesn't cause access loss

Listing filtering is a new restriction, so semantic identity with the single-decision path matters more than the batching itself. Batching is implemented as a request-scoped **prefetch into a cache keyed on the exact `(subject, action, resourceType, resourceID, allowedRoles)` question** — not as a second decision path. `/apps` decision code is unchanged; the `defaultRole` fallback and the G3a transition shim still run per item.

- A failed, truncated, or malformed batch logs and returns an empty cache, so every item falls back to the per-item decision. Listing degrades to more calls, never to fewer results.
- Transport errors surface as 503 (`/apps`, `/apps/{name}/operations`) or a JSON-RPC error (`tools/list`) rather than an empty list that reads as "you have no apps".
- Regression guard included: a subject visible only via `defaultRole` still sees its apps.

Call-count evidence in tests: `/apps` over two apps → 1 `CheckAccessMany`, 0 per-item `CheckAccess`; same for catalog, operation listing, and `tools/list`.

### Behavior changes worth reviewing
- **User lookup is now gated on an explicit operator role** (`server.userLookup`, defaulting to resource `gestaltUserLookup` / relation `operator` whenever auth and an authorization provider are configured). App admins still see the full grant roster for their own app — only subject-ID→email resolution is withheld, so admin surfaces can't be used as a directory. **This means app admins lose email visibility until granted the operator role.** Empty policy (no-auth deployments) leaves behavior unchanged.
- `/apps/{name}/operations` now also applies the token-scope filter. Browser sessions have empty scopes and are unaffected; narrow API tokens see a list matching what they can actually call.
- `tools/list` with a nil principal now lists nothing (previously everything). `tools/call` already refused nil principals, so this closes a listing/enforcement gap.
- Catalog/MCP operation filtering has **no** transition shim — it mirrors `authorizeOperation` exactly, so nothing invocable can be hidden, but an app resource type declaring neither the operation ID nor `"*"` will see those operations disappear from listings. They already fail at invoke, so this is truthful rather than new access loss. T1's inventory should still confirm every app resource type declares `"*"` before Gate A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)