### PR TITLE
[gestaltd] authorization conformance suite across every server surface

### DIFF
--- a/gestaltd/internal/server/conformance_evaluator_test.go
+++ b/gestaltd/internal/server/conformance_evaluator_test.go
@@ -1,0 +1,516 @@
+package server_test
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+)
+
+// This file holds the single authorization evaluator the conformance suite in
+// conformance_test.go runs every case against.
+//
+// HONEST PROVENANCE. The production relationship-graph evaluator lives outside
+// this repository, in the gestalt-providers module
+// github.com/valon-technologies/gestalt-providers/authorization/indexeddb. It
+// is a separate Go module that is not in this repository's go.work, depends on
+// the indexeddb host service at runtime, and would introduce a module cycle
+// (it `replace`s the gestalt sdk and rpc modules back onto this checkout). CI
+// runs `go test ./...` in the gestaltd module with no sibling checkout and no
+// network, so that package cannot be built or run here.
+//
+// conformanceEvaluator is therefore a reference implementation of the documented
+// evaluation semantics, transcribed from that provider's evaluateAccess:
+//
+//   - a resource type absent from the active model denies;
+//   - an action is looked up by name, then by the "*" wildcard action;
+//   - an action with no allowed relations denies;
+//   - a relationship counts only when its relation is in the action's allowed
+//     set and its target resolves to the subject;
+//   - subject sets expand recursively with a visited set, so cycles terminate;
+//   - matched relations are reported in the model's declared relation order;
+//   - when nothing matched, the resource type's defaultRole allows if the
+//     action permits it;
+//   - malformed tuples are skipped rather than trusted.
+//
+// It is deliberately the ONLY evaluator the suite uses, reached through the
+// single constructor newConformanceAuthorization. Swapping the real provider in
+// is a change to that constructor alone: the suite is written against
+// core.AuthorizationProvider and never against this type's internals.
+//
+// What this proves and does not prove is spelled out in the suite's header
+// comment in conformance_test.go.
+
+// conformanceWildcardAction is the model action name that matches every action.
+const conformanceWildcardAction = "*"
+
+// conformanceMaxTraversal bounds subject-set expansion work for one decision.
+// A cyclic or adversarially wide relationship graph exhausts the budget and
+// denies instead of running forever.
+const conformanceMaxTraversal = 4096
+
+// conformanceAction is one action a resource type answers about, with the
+// relations that authorize it.
+type conformanceAction struct {
+	Name      string
+	Relations []string
+}
+
+// conformanceResourceType is one resource type in the active model.
+type conformanceResourceType struct {
+	Name        string
+	DefaultRole string
+	Actions     []conformanceAction
+}
+
+// conformanceSpec is the authorization state one test case starts from.
+type conformanceSpec struct {
+	ResourceTypes []conformanceResourceType
+	Relationships []*proto.Relationship
+	// ListPageSize, when positive, makes ListRelationships page at that size so
+	// a surface that reads relationships must follow next_page_token.
+	ListPageSize int
+}
+
+// conformanceEvaluator is the shared reference evaluator. Every method is safe
+// for concurrent use because httptest servers answer requests on their own
+// goroutines.
+type conformanceEvaluator struct {
+	core.AuthorizationProvider
+
+	mu            sync.Mutex
+	resourceTypes []conformanceResourceType
+	relationships []*proto.Relationship
+	listPageSize  int
+
+	checkAccessCalls     int
+	checkAccessManyCalls int
+	listCalls            int
+	// budgetExhausted records that at least one decision hit the traversal
+	// budget, which is how a test proves a cyclic graph stayed bounded.
+	budgetExhausted bool
+}
+
+// newConformanceAuthorization is the suite's single evaluator constructor and
+// the one place to swap in the real provider.
+func newConformanceAuthorization(t *testing.T, spec conformanceSpec) *conformanceEvaluator {
+	t.Helper()
+	return &conformanceEvaluator{
+		resourceTypes: spec.ResourceTypes,
+		relationships: spec.Relationships,
+		listPageSize:  spec.ListPageSize,
+	}
+}
+
+func (e *conformanceEvaluator) CheckAccess(_ context.Context, req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.checkAccessCalls++
+	return e.evaluateLocked(req), nil
+}
+
+func (e *conformanceEvaluator) CheckAccessMany(_ context.Context, req *proto.CheckAccessManyRequest) (*proto.CheckAccessManyResponse, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.checkAccessManyCalls++
+	decisions := make([]*proto.CheckAccessResponse, 0, len(req.GetRequests()))
+	for _, entry := range req.GetRequests() {
+		decisions = append(decisions, e.evaluateLocked(entry))
+	}
+	return &proto.CheckAccessManyResponse{Decisions: decisions}, nil
+}
+
+// evaluateLocked is the evaluator itself. The single and batched RPCs both go
+// through it, so a listing decision and an invocation decision cannot disagree.
+func (e *conformanceEvaluator) evaluateLocked(req *proto.CheckAccessRequest) *proto.CheckAccessResponse {
+	subjectID := strings.TrimSpace(req.GetSubject().GetId())
+	actionName := strings.TrimSpace(req.GetAction().GetName())
+	resource := req.GetResource()
+	if subjectID == "" || actionName == "" || resource == nil {
+		return &proto.CheckAccessResponse{}
+	}
+
+	resourceType, ok := e.findResourceTypeLocked(resource.GetType())
+	if !ok {
+		return &proto.CheckAccessResponse{}
+	}
+	action, ok := findConformanceAction(resourceType, actionName)
+	if !ok {
+		return &proto.CheckAccessResponse{}
+	}
+	allowed := make(map[string]struct{}, len(action.Relations))
+	for _, relation := range action.Relations {
+		if relation = strings.TrimSpace(relation); relation != "" {
+			allowed[relation] = struct{}{}
+		}
+	}
+	if len(allowed) == 0 {
+		return &proto.CheckAccessResponse{}
+	}
+
+	budget := conformanceMaxTraversal
+	matched := make(map[string]struct{}, len(allowed))
+	for _, relationship := range e.relationships {
+		tuple := relationship.GetTuple()
+		if tuple == nil || !conformanceResourcesEqual(tuple.GetResource(), resource) {
+			continue
+		}
+		relation := strings.TrimSpace(tuple.GetRelation())
+		if _, ok := allowed[relation]; !ok {
+			continue
+		}
+		if e.targetMatchesLocked(tuple.GetTarget(), subjectID, map[string]struct{}{}, &budget) {
+			matched[relation] = struct{}{}
+		}
+	}
+	if budget <= 0 {
+		e.budgetExhausted = true
+	}
+	if len(matched) > 0 {
+		return &proto.CheckAccessResponse{
+			Allowed:          true,
+			MatchedRelations: orderedConformanceRelations(action, matched),
+		}
+	}
+	if defaultRole := strings.TrimSpace(resourceType.DefaultRole); defaultRole != "" {
+		if _, ok := allowed[defaultRole]; ok {
+			return &proto.CheckAccessResponse{Allowed: true, MatchedRelations: []string{defaultRole}}
+		}
+	}
+	return &proto.CheckAccessResponse{}
+}
+
+// targetMatchesLocked resolves one relationship target to the subject. It
+// terminates on cycles through visited and on runaway graphs through budget,
+// and treats every malformed shape as "does not match" rather than as a match.
+func (e *conformanceEvaluator) targetMatchesLocked(
+	target *proto.RelationshipTarget,
+	subjectID string,
+	visited map[string]struct{},
+	budget *int,
+) bool {
+	if target == nil || budget == nil {
+		return false
+	}
+	*budget--
+	if *budget <= 0 {
+		return false
+	}
+	if subject := target.GetSubject(); subject != nil {
+		return strings.TrimSpace(subject.GetId()) == subjectID
+	}
+	set := target.GetSubjectSet()
+	if set == nil || set.GetResource() == nil {
+		return false
+	}
+	setResource := set.GetResource()
+	setRelation := strings.TrimSpace(set.GetRelation())
+	if strings.TrimSpace(setResource.GetType()) == "" ||
+		strings.TrimSpace(setResource.GetId()) == "" ||
+		setRelation == "" {
+		return false
+	}
+	key := setResource.GetType() + "\x00" + setResource.GetId() + "\x00" + setRelation
+	if _, seen := visited[key]; seen {
+		return false
+	}
+	visited[key] = struct{}{}
+
+	for _, relationship := range e.relationships {
+		tuple := relationship.GetTuple()
+		if tuple == nil {
+			continue
+		}
+		if strings.TrimSpace(tuple.GetRelation()) != setRelation {
+			continue
+		}
+		if !conformanceResourcesEqual(tuple.GetResource(), setResource) {
+			continue
+		}
+		if e.targetMatchesLocked(tuple.GetTarget(), subjectID, visited, budget) {
+			return true
+		}
+	}
+	return false
+}
+
+func (e *conformanceEvaluator) findResourceTypeLocked(name string) (conformanceResourceType, bool) {
+	name = strings.TrimSpace(name)
+	for _, resourceType := range e.resourceTypes {
+		if strings.TrimSpace(resourceType.Name) == name {
+			return resourceType, true
+		}
+	}
+	return conformanceResourceType{}, false
+}
+
+func findConformanceAction(resourceType conformanceResourceType, name string) (conformanceAction, bool) {
+	for _, action := range resourceType.Actions {
+		if strings.TrimSpace(action.Name) == name {
+			return action, true
+		}
+	}
+	for _, action := range resourceType.Actions {
+		if strings.TrimSpace(action.Name) == conformanceWildcardAction {
+			return action, true
+		}
+	}
+	return conformanceAction{}, false
+}
+
+// orderedConformanceRelations reports matched relations in the model's declared
+// order, which is what makes the first reported relation deterministic.
+func orderedConformanceRelations(action conformanceAction, matched map[string]struct{}) []string {
+	out := make([]string, 0, len(matched))
+	for _, relation := range action.Relations {
+		relation = strings.TrimSpace(relation)
+		if _, ok := matched[relation]; !ok {
+			continue
+		}
+		out = append(out, relation)
+		delete(matched, relation)
+	}
+	return out
+}
+
+func conformanceResourcesEqual(a, b *proto.Resource) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	return strings.TrimSpace(a.GetType()) == strings.TrimSpace(b.GetType()) &&
+		strings.TrimSpace(a.GetId()) == strings.TrimSpace(b.GetId())
+}
+
+// ListRelationships answers the roster and transition-shim reads. When the spec
+// sets a page size it pages, so a caller that ignores next_page_token loses
+// rows and the test notices.
+func (e *conformanceEvaluator) ListRelationships(
+	_ context.Context, req *proto.ListRelationshipsRequest,
+) (*proto.ListRelationshipsResponse, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.listCalls++
+
+	filtered := make([]*proto.Relationship, 0, len(e.relationships))
+	for _, relationship := range e.relationships {
+		if conformanceMatchesFilter(relationship, req.GetFilter()) {
+			filtered = append(filtered, relationship)
+		}
+	}
+
+	pageSize := e.listPageSize
+	if pageSize <= 0 || pageSize >= len(filtered) {
+		return &proto.ListRelationshipsResponse{Relationships: filtered}, nil
+	}
+	offset := 0
+	if token := strings.TrimSpace(req.GetPageToken()); token != "" {
+		parsed, err := strconv.Atoi(token)
+		if err != nil || parsed < 0 {
+			return nil, fmt.Errorf("invalid page token %q", token)
+		}
+		offset = parsed
+	}
+	if offset > len(filtered) {
+		offset = len(filtered)
+	}
+	end := min(offset+pageSize, len(filtered))
+	resp := &proto.ListRelationshipsResponse{Relationships: filtered[offset:end]}
+	if end < len(filtered) {
+		resp.NextPageToken = strconv.Itoa(end)
+	}
+	return resp, nil
+}
+
+func conformanceMatchesFilter(relationship *proto.Relationship, filter *proto.RelationshipFilter) bool {
+	tuple := relationship.GetTuple()
+	if tuple == nil {
+		return false
+	}
+	if filter == nil {
+		return true
+	}
+	if resource := filter.GetResource(); resource != nil && !conformanceResourcesEqual(tuple.GetResource(), resource) {
+		return false
+	}
+	if relation := strings.TrimSpace(filter.GetRelation()); relation != "" &&
+		strings.TrimSpace(tuple.GetRelation()) != relation {
+		return false
+	}
+	if target := filter.GetTarget().GetSubject(); target != nil {
+		subject := tuple.GetTarget().GetSubject()
+		if subject == nil || strings.TrimSpace(subject.GetId()) != strings.TrimSpace(target.GetId()) {
+			return false
+		}
+	}
+	return true
+}
+
+// AddRelationship and DeleteRelationship let a test grant and then revoke access
+// against the same live evaluator the server is already talking to.
+func (e *conformanceEvaluator) AddRelationship(
+	_ context.Context, req *proto.AddRelationshipRequest,
+) (*proto.AddRelationshipResponse, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if req.GetRelationship().GetTuple() == nil {
+		return nil, fmt.Errorf("relationship tuple is required")
+	}
+	e.relationships = append(e.relationships, req.GetRelationship())
+	return &proto.AddRelationshipResponse{}, nil
+}
+
+func (e *conformanceEvaluator) DeleteRelationship(
+	_ context.Context, req *proto.DeleteRelationshipRequest,
+) (*proto.DeleteRelationshipResponse, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	want := req.GetRelationshipTuple()
+	if want == nil {
+		return nil, fmt.Errorf("relationship tuple is required")
+	}
+	kept := make([]*proto.Relationship, 0, len(e.relationships))
+	for _, relationship := range e.relationships {
+		if conformanceTupleEqual(relationship.GetTuple(), want) {
+			continue
+		}
+		kept = append(kept, relationship)
+	}
+	e.relationships = kept
+	return &proto.DeleteRelationshipResponse{}, nil
+}
+
+func conformanceTupleEqual(a, b *proto.RelationshipTuple) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	if strings.TrimSpace(a.GetRelation()) != strings.TrimSpace(b.GetRelation()) {
+		return false
+	}
+	if !conformanceResourcesEqual(a.GetResource(), b.GetResource()) {
+		return false
+	}
+	aSubject, bSubject := a.GetTarget().GetSubject(), b.GetTarget().GetSubject()
+	if aSubject != nil && bSubject != nil {
+		return strings.TrimSpace(aSubject.GetId()) == strings.TrimSpace(bSubject.GetId())
+	}
+	aSet, bSet := a.GetTarget().GetSubjectSet(), b.GetTarget().GetSubjectSet()
+	if aSet != nil && bSet != nil {
+		return conformanceResourcesEqual(aSet.GetResource(), bSet.GetResource()) &&
+			strings.TrimSpace(aSet.GetRelation()) == strings.TrimSpace(bSet.GetRelation())
+	}
+	return false
+}
+
+func (e *conformanceEvaluator) ListActiveModelResourceTypes(
+	_ context.Context, req *proto.ListActiveModelResourceTypesRequest,
+) (*proto.ListActiveModelResourceTypesResponse, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	name := strings.TrimSpace(req.GetFilter().GetName())
+	out := []*proto.AuthorizationModelResourceType{}
+	for _, resourceType := range e.resourceTypes {
+		if name != "" && strings.TrimSpace(resourceType.Name) != name {
+			continue
+		}
+		entry := &proto.AuthorizationModelResourceType{
+			Name:        resourceType.Name,
+			DefaultRole: resourceType.DefaultRole,
+		}
+		for _, action := range resourceType.Actions {
+			entry.Actions = append(entry.Actions, &proto.ModelAction{
+				Name:      action.Name,
+				Relations: action.Relations,
+			})
+		}
+		out = append(out, entry)
+	}
+	return &proto.ListActiveModelResourceTypesResponse{ResourceTypes: out}, nil
+}
+
+func (e *conformanceEvaluator) Ping(context.Context) error { return nil }
+
+func (e *conformanceEvaluator) Close() error { return nil }
+
+// counters snapshots the call counters without racing the server goroutines.
+func (e *conformanceEvaluator) counters() (checkAccess, checkAccessMany, list int, budgetExhausted bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.checkAccessCalls, e.checkAccessManyCalls, e.listCalls, e.budgetExhausted
+}
+
+// grant adds a runtime relationship the way a live grant would.
+func (e *conformanceEvaluator) grant(t *testing.T, relationship *proto.Relationship) {
+	t.Helper()
+	if _, err := e.AddRelationship(
+		context.Background(), &proto.AddRelationshipRequest{Relationship: relationship},
+	); err != nil {
+		t.Fatalf("AddRelationship: %v", err)
+	}
+}
+
+// revoke removes a runtime relationship the way a live revoke would.
+func (e *conformanceEvaluator) revoke(t *testing.T, relationship *proto.Relationship) {
+	t.Helper()
+	if _, err := e.DeleteRelationship(
+		context.Background(), &proto.DeleteRelationshipRequest{RelationshipTuple: relationship.GetTuple()},
+	); err != nil {
+		t.Fatalf("DeleteRelationship: %v", err)
+	}
+}
+
+// --- relationship builders -------------------------------------------------
+
+// conformanceDirectGrant is a plain subject -> resource grant.
+func conformanceDirectGrant(subjectID, relation, resourceType, resourceID string) *proto.Relationship {
+	return &proto.Relationship{
+		Tuple: &proto.RelationshipTuple{
+			Target: &proto.RelationshipTarget{
+				Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{Type: "subject", Id: subjectID}},
+			},
+			Relation: relation,
+			Resource: &proto.Resource{Type: resourceType, Id: resourceID},
+		},
+		SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME,
+	}
+}
+
+// conformanceGroupMember makes a subject a member of a group.
+func conformanceGroupMember(subjectID, groupID string) *proto.Relationship {
+	return conformanceDirectGrant(subjectID, "member", "group", groupID)
+}
+
+// conformanceNestedGroupMember makes every member of child a member of parent,
+// which is the one extra hop that turns a one-level grant into a nested one.
+func conformanceNestedGroupMember(childGroupID, parentGroupID string) *proto.Relationship {
+	return conformanceSubjectSetGrant("group", childGroupID, "member", "member", "group", parentGroupID)
+}
+
+// conformanceGroupGrant grants a role on a resource to a group's members.
+func conformanceGroupGrant(groupID, relation, resourceType, resourceID string) *proto.Relationship {
+	return conformanceSubjectSetGrant("group", groupID, "member", relation, resourceType, resourceID)
+}
+
+// conformanceSubjectSetGrant is the general subject-set tuple:
+// (setType:setID#setRelation) holds `relation` on resourceType:resourceID.
+func conformanceSubjectSetGrant(
+	setType, setID, setRelation, relation, resourceType, resourceID string,
+) *proto.Relationship {
+	return &proto.Relationship{
+		Tuple: &proto.RelationshipTuple{
+			Target: &proto.RelationshipTarget{
+				Kind: &proto.RelationshipTarget_SubjectSet{SubjectSet: &proto.SubjectSet{
+					Resource: &proto.Resource{Type: setType, Id: setID},
+					Relation: setRelation,
+				}},
+			},
+			Relation: relation,
+			Resource: &proto.Resource{Type: resourceType, Id: resourceID},
+		},
+		SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME,
+	}
+}

--- a/gestaltd/internal/server/conformance_test.go
+++ b/gestaltd/internal/server/conformance_test.go
@@ -1,0 +1,1403 @@
+package server_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
+	"github.com/valon-technologies/gestalt/server/internal/publicrpc"
+	"github.com/valon-technologies/gestalt/server/internal/server"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	gestaltmcp "github.com/valon-technologies/gestalt/server/services/apps/mcp"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
+	"github.com/valon-technologies/gestalt/server/services/providergateway"
+)
+
+// AUTHORIZATION CONFORMANCE SUITE (plan step G4).
+//
+// Every case below drives a real server surface -- mounted UI, the /apps
+// catalog, app admin, the app-admin member roster, user lookup, operation
+// invocation, and MCP tools/list plus tools/call -- against one shared
+// authorization evaluator, so the surfaces are proven to agree with each other
+// rather than each with its own stub.
+//
+// WHAT THE EVALUATOR IS. The production relationship-graph evaluator ships in
+// the out-of-repo gestalt-providers module and cannot be built or run from this
+// module in CI (see the header of conformance_evaluator_test.go for the full
+// reasoning). The suite therefore runs against conformanceEvaluator, a single
+// in-repo reference implementation of the documented semantics, reached through
+// the single constructor newConformanceAuthorization.
+//
+// WHAT THIS PROVES: that every server surface asks the same question of the
+// same evaluator, projects the answer the same way, honors subject sets,
+// default roles, policy aliases, action-to-relation mapping and pagination
+// consistently, and fails closed on cyclic, malformed, and under-specified
+// provider responses.
+//
+// WHAT THIS DOES NOT PROVE: that the real provider implements those semantics.
+// That remains an assumption until the real evaluator is exercised, which the
+// plan's Gate A canary and the T2 shadow evaluation are responsible for.
+
+const (
+	conformanceEmployeeUserID = "6a1f0d4c-3e5b-4a7c-9d2e-8f0a1b2c3d04"
+	conformanceAdminUserID    = "7b2e1c5d-4f6a-4b8d-8e3f-9a0b1c2d3e05"
+	conformanceExternalUserID = "8c3d2e6f-5a7b-4c9e-9f4a-0b1c2d3e4f06"
+	conformanceOutsiderUserID = "9d4e3f70-6b8c-4dae-8a5b-1c2d3e4f5a07"
+
+	conformanceEmployeeToken = "conformance-employee-token"
+	conformanceAdminToken    = "conformance-admin-token"
+	conformanceExternalToken = "conformance-external-token"
+	conformanceOutsiderToken = "conformance-outsider-token"
+
+	// conformanceTalentPolicy is a custom authorizationPolicy alias. Apps bound
+	// to it are authorized against a dedicated resource type of the same name
+	// rather than against the shared "app" type.
+	conformanceTalentPolicy = "talentTeamPolicy"
+
+	conformanceMountedApp = "sampleApp"
+	conformanceOtherApp   = "otherApp"
+	conformanceTalentApp  = "talent-team"
+	conformanceAdminApp   = "g-issues"
+
+	// Role-gated mounts sit on their own paths, separate from the apps' static
+	// mounts, so both mount shapes can be exercised on one server.
+	conformanceGatedSamplePath = "/gated-sample"
+	conformanceGatedTalentPath = "/gated-talent"
+
+	conformanceGroup       = "engineering"
+	conformanceNestedGroup = "engineering-leads"
+
+	conformanceListOperation = "items.list"
+
+	conformancePublicBaseURL = "https://gestalt.test"
+)
+
+func conformanceSubject(userID string) string { return principal.UserSubjectID(userID) }
+
+// conformanceModel is the active authorization model every case shares. The
+// wildcard action mirrors the model the plan keeps in production:
+//
+//	actions:
+//	  "*":
+//	    relations: [viewer, user, editor, admin]
+//
+// appDefaultRole is the "app" resource type's defaultRole, which is what lets an
+// employee through with no relationship of their own. Passing "" models the
+// post-Stack-B world where defaultRole has been removed.
+func conformanceModel(appDefaultRole string) []conformanceResourceType {
+	return []conformanceResourceType{
+		{
+			Name:        "app",
+			DefaultRole: appDefaultRole,
+			Actions: []conformanceAction{
+				{Name: conformanceWildcardAction, Relations: []string{"viewer", "user", "editor", "admin"}},
+			},
+		},
+		{
+			// A dedicated resource type for the custom policy alias. It
+			// deliberately declares a different relation set than "app", so a
+			// grant on the wrong type cannot accidentally satisfy it.
+			Name: conformanceTalentPolicy,
+			Actions: []conformanceAction{
+				{Name: conformanceWildcardAction, Relations: []string{"viewer", "admin"}},
+			},
+		},
+		{
+			Name: testUserLookupResource,
+			Actions: []conformanceAction{
+				{Name: conformanceWildcardAction, Relations: []string{testUserLookupRole}},
+			},
+		},
+	}
+}
+
+// conformanceHarness is one running server plus the evaluator behind it.
+type conformanceHarness struct {
+	ts       *httptest.Server
+	authz    *conformanceEvaluator
+	services *coredata.Services
+}
+
+// conformanceConfig describes the server one case needs.
+type conformanceConfig struct {
+	spec conformanceSpec
+	// authorization overrides the evaluator entirely. Only the fail-closed
+	// provider-behavior cases set it.
+	authorization core.AuthorizationProvider
+	// withInvocation wires an authorization-aware broker plus the two surfaces
+	// that invoke through it: MCP and the public REST operation endpoint.
+	withInvocation bool
+}
+
+// newConformanceHarness starts a server whose every authorization boundary is
+// answered by one evaluator. The mounts, apps, policy aliases and MCP tools are
+// identical in every case so the surfaces are directly comparable.
+func newConformanceHarness(t *testing.T, cfg conformanceConfig) *conformanceHarness {
+	t.Helper()
+
+	authz := newConformanceAuthorization(t, cfg.spec)
+	var authorization core.AuthorizationProvider = authz
+	if cfg.authorization != nil {
+		authorization = cfg.authorization
+	}
+
+	services := testutil.NewStubServices(t)
+	providers := testutil.NewProviderRegistry(t,
+		conformanceStubApp(conformanceMountedApp),
+		conformanceStubApp(conformanceOtherApp),
+	)
+	policies := map[string]string{conformanceTalentApp: conformanceTalentPolicy}
+
+	// The catalog reports an app's mounted path from its declared static mount,
+	// so the listed apps are configured the way production configures them.
+	staticRoot := t.TempDir()
+	writeTestUIAsset(t, filepath.Join(staticRoot, "index.html"), "<html>conformance</html>")
+	staticApp := func(mount, policy string) *config.ProviderEntry {
+		return &config.ProviderEntry{
+			Static:              &config.AppStaticConfig{Mount: mount},
+			ResolvedStaticRoot:  staticRoot,
+			AuthorizationPolicy: policy,
+		}
+	}
+	appDefs := map[string]*config.ProviderEntry{
+		conformanceMountedApp: staticApp("/sample", ""),
+		conformanceOtherApp:   staticApp("/other", ""),
+		conformanceTalentApp:  staticApp("/talent", conformanceTalentPolicy),
+		conformanceAdminApp:   {},
+	}
+
+	ts := newTestServer(t, func(sc *server.Config) {
+		sc.Auth = conformanceAuthStub()
+		sc.Authorization = authorization
+		sc.Services = services
+		sc.Providers = providers
+		sc.AppDefs = appDefs
+		sc.AuthorizationPolicies = policies
+		// Role-gated mounts live on their own paths so the catalog keeps using
+		// the static mounts above. AllowedRoles is what forces the evaluator to
+		// name the relation that authorized the request.
+		sc.MountedUIs = []server.MountedUI{
+			conformanceMount(conformanceMountedApp, conformanceGatedSamplePath, ""),
+			conformanceMount(conformanceTalentApp, conformanceGatedTalentPath, conformanceTalentPolicy),
+		}
+		if cfg.withInvocation {
+			broker := invocation.NewBroker(providers, services.Users, services.ExternalCredentials,
+				invocation.WithAuthorizationProvider(authorization),
+				invocation.WithProviderKinds(testProviderKindsFromAppDefs(appDefs)),
+				invocation.WithAuthorizationPolicies(policies),
+			)
+			sc.Invoker = broker
+
+			// The public REST operation endpoint invokes through the same
+			// broker, so an HTTP operation call and an MCP tool call reach the
+			// same evaluator decision.
+			generated, err := publicrpc.NewGeneratedRegistry()
+			if err != nil {
+				t.Fatalf("NewGeneratedRegistry: %v", err)
+			}
+			transport := providergateway.NewProviderGatewayTransport()
+			transport.SetIdentityProvider(sc.Auth)
+			transport.SetPublicMethods(generated)
+			transport.SetAuthorizationProvider(authorization)
+			transport.SetPublicBaseURL(conformancePublicBaseURL)
+			sc.PublicBaseURL = conformancePublicBaseURL
+			sc.PublicGatewayTransport = transport
+
+			sc.MCPHandler = gestaltmcp.NewStatelessHTTPHandler(gestaltmcp.Config{
+				Invoker:          broker,
+				TokenResolver:    broker,
+				OperationAccess:  broker,
+				Providers:        providers,
+				AllowedProviders: []string{conformanceMountedApp},
+				IncludeREST:      map[string]bool{conformanceMountedApp: true},
+			})
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	return &conformanceHarness{ts: ts, authz: authz, services: services}
+}
+
+// conformanceMount is a role-gated mounted UI. AllowedRoles is what forces the
+// evaluator to name the relation that authorized the request instead of merely
+// answering "allowed".
+func conformanceMount(appName, path, policy string) server.MountedUI {
+	return server.MountedUI{
+		Name:                "conformance:" + appName,
+		Path:                path,
+		AppName:             appName,
+		AuthorizationPolicy: policy,
+		AppLevelAuth:        true,
+		AllowedRoles:        []string{"viewer", "admin"},
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(appName + "-shell"))
+		}),
+	}
+}
+
+func conformanceStubApp(name string) *coretesting.StubIntegration {
+	return &coretesting.StubIntegration{
+		N:        name,
+		DN:       name,
+		ConnMode: core.ConnectionModeNone,
+		CatalogVal: &catalog.Catalog{
+			Name: name,
+			Operations: []catalog.CatalogOperation{{
+				ID:          conformanceListOperation,
+				Description: "List items",
+				Method:      http.MethodGet,
+				Path:        "/items",
+				Transport:   catalog.TransportREST,
+			}},
+		},
+		ExecuteFn: func(_ context.Context, op string, _ map[string]any, _ string) (*core.OperationResult, error) {
+			return &core.OperationResult{
+				Status:  http.StatusOK,
+				Body:    []byte(`{"invoked":"` + op + `"}`),
+				Headers: map[string][]string{"Content-Type": {"application/json"}},
+			}, nil
+		},
+	}
+}
+
+// conformanceAuthStub maps every credential the suite uses -- browser session
+// cookies, API tokens, and CLI-exchanged tokens -- onto canonical user subjects.
+// A CLI exchange mints "cli:<token>", which introspects to the same subject as
+// the session it was exchanged from, so the three credential shapes are
+// distinguishable in the test yet identical to authorization.
+func conformanceAuthStub() *coretesting.StubAuthProvider {
+	subjects := map[string]string{
+		conformanceEmployeeToken: conformanceSubject(conformanceEmployeeUserID),
+		conformanceAdminToken:    conformanceSubject(conformanceAdminUserID),
+		conformanceExternalToken: conformanceSubject(conformanceExternalUserID),
+		conformanceOutsiderToken: conformanceSubject(conformanceOutsiderUserID),
+	}
+	resolve := func(token string) (string, bool) {
+		token = strings.TrimSpace(token)
+		if subject, ok := subjects[token]; ok {
+			return subject, true
+		}
+		if exchanged, ok := strings.CutPrefix(token, "cli:"); ok {
+			subject, ok := subjects[exchanged]
+			return subject, ok
+		}
+		return "", false
+	}
+
+	stub := testAuthStubWithIntrospect(func(_ context.Context, token string) (*core.IntrospectResponse, error) {
+		subject, ok := resolve(token)
+		if !ok {
+			return &core.IntrospectResponse{Active: false}, nil
+		}
+		return testIntrospectActive(subject, ""), nil
+	})
+	stub.TokenFn = func(_ context.Context, req *core.TokenRequest) (*core.TokenResponse, error) {
+		if req == nil || strings.TrimSpace(req.GrantType) != core.GrantTypeTokenExchange {
+			return nil, fmt.Errorf("unsupported grant_type")
+		}
+		subjectToken := strings.TrimSpace(req.SubjectToken)
+		if _, ok := resolve(subjectToken); !ok {
+			return nil, fmt.Errorf("inactive subject token")
+		}
+		return &core.TokenResponse{
+			AccessToken: "cli:" + subjectToken,
+			TokenType:   "Bearer",
+			ExpiresIn:   int(30 * 24 * time.Hour / time.Second),
+			GrantID:     "conformance-grant-" + subjectToken,
+			Scope:       strings.TrimSpace(req.Scope),
+		}, nil
+	}
+	return stub
+}
+
+// --- request helpers -------------------------------------------------------
+
+// conformanceCredential is how a request authenticates. Exactly one of cookie
+// or bearer is set, which is what makes the browser and token surfaces
+// comparable on identical requests.
+type conformanceCredential struct {
+	bearer string
+	cookie string
+}
+
+func conformanceBearer(token string) conformanceCredential {
+	return conformanceCredential{bearer: token}
+}
+func conformanceCookie(token string) conformanceCredential {
+	return conformanceCredential{cookie: token}
+}
+
+func (h *conformanceHarness) do(t *testing.T, method, path string, cred conformanceCredential, body io.Reader) (int, string) {
+	t.Helper()
+	req, err := http.NewRequest(method, h.ts.URL+path, body)
+	if err != nil {
+		t.Fatalf("new request %s %s: %v", method, path, err)
+	}
+	switch {
+	case cred.bearer != "":
+		req.Header.Set("Authorization", "Bearer "+cred.bearer)
+	case cred.cookie != "":
+		req.AddCookie(&http.Cookie{Name: "session_token", Value: cred.cookie})
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	return resp.StatusCode, string(raw)
+}
+
+func (h *conformanceHarness) get(t *testing.T, path string, cred conformanceCredential) (int, string) {
+	t.Helper()
+	return h.do(t, http.MethodGet, path, cred, nil)
+}
+
+// mountedUIWithin asserts the mounted UI answers at all within the deadline.
+// It is how the cyclic and malformed cases prove the evaluator stays bounded:
+// a traversal that never terminates shows up as a client timeout rather than as
+// a hung test binary.
+func (h *conformanceHarness) mountedUIWithin(
+	t *testing.T, path string, cred conformanceCredential, deadline time.Duration,
+) (int, string) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, h.ts.URL+path+"/", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+cred.bearer)
+	client := &http.Client{Timeout: deadline}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("mounted UI did not answer within %s: %v", deadline, err)
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	return resp.StatusCode, string(raw)
+}
+
+// mountedUI is the browser-facing mounted app shell for one app.
+func (h *conformanceHarness) mountedUI(t *testing.T, path string, cred conformanceCredential) (int, string) {
+	t.Helper()
+	return h.get(t, path+"/", cred)
+}
+
+// mountedPaths reads the /apps catalog and returns each app's mounted path.
+// An app the caller may not open is listed with an empty mounted path.
+func (h *conformanceHarness) mountedPaths(t *testing.T, cred conformanceCredential) map[string]string {
+	t.Helper()
+	status, body := h.get(t, "/api/v1/apps", cred)
+	if status != http.StatusOK {
+		t.Fatalf("GET /api/v1/apps status = %d: %s", status, body)
+	}
+	var listed []listedIntegration
+	if err := json.Unmarshal([]byte(body), &listed); err != nil {
+		t.Fatalf("decode /apps: %v (body=%s)", err, body)
+	}
+	out := make(map[string]string, len(listed))
+	for _, integration := range listed {
+		out[integration.Name] = integration.MountedPath
+	}
+	return out
+}
+
+// members reads an app's admin member roster, which is both the app-admin gate
+// and the paginated relationship read.
+func (h *conformanceHarness) members(t *testing.T, appName string, cred conformanceCredential) (int, []memberEmailRow) {
+	t.Helper()
+	status, body := h.get(t, "/api/v1/apps/"+appName+"/admin/members", cred)
+	if status != http.StatusOK {
+		return status, nil
+	}
+	var rows []memberEmailRow
+	if err := json.Unmarshal([]byte(body), &rows); err != nil {
+		t.Fatalf("decode members: %v (body=%s)", err, body)
+	}
+	return status, rows
+}
+
+// mcp issues one JSON-RPC call against the mounted MCP endpoint.
+func (h *conformanceHarness) mcp(t *testing.T, cred conformanceCredential, payload map[string]any) map[string]any {
+	t.Helper()
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal mcp payload: %v", err)
+	}
+	status, body := h.do(t, http.MethodPost, "/mcp", cred, bytes.NewReader(encoded))
+	if status != http.StatusOK {
+		t.Fatalf("POST /mcp status = %d: %s", status, body)
+	}
+	var envelope map[string]any
+	if err := json.Unmarshal([]byte(body), &envelope); err != nil {
+		t.Fatalf("decode mcp response: %v (body=%s)", err, body)
+	}
+	return envelope
+}
+
+// mcpToolNames lists the tools the caller may see.
+func (h *conformanceHarness) mcpToolNames(t *testing.T, cred conformanceCredential) []string {
+	t.Helper()
+	envelope := h.mcp(t, cred, map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": map[string]any{},
+	})
+	if rpcErr, ok := envelope["error"]; ok {
+		t.Fatalf("tools/list error: %v", rpcErr)
+	}
+	result, _ := envelope["result"].(map[string]any)
+	rawTools, _ := result["tools"].([]any)
+	names := make([]string, 0, len(rawTools))
+	for _, raw := range rawTools {
+		tool, _ := raw.(map[string]any)
+		if name, ok := tool["name"].(string); ok {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// mcpCallSucceeds reports whether tools/call for the list operation ran. A
+// denied call comes back as a JSON-RPC error or an isError result.
+func (h *conformanceHarness) mcpCallSucceeds(t *testing.T, cred conformanceCredential, toolName string) bool {
+	t.Helper()
+	envelope := h.mcp(t, cred, map[string]any{
+		"jsonrpc": "2.0", "id": 2, "method": "tools/call",
+		"params": map[string]any{"name": toolName, "arguments": map[string]any{}},
+	})
+	if _, ok := envelope["error"]; ok {
+		return false
+	}
+	result, ok := envelope["result"].(map[string]any)
+	if !ok {
+		return false
+	}
+	isError, _ := result["isError"].(bool)
+	return !isError
+}
+
+// invokeOperation calls one app operation over the public REST surface, which
+// is the non-MCP operation-invocation path. It reports whether the call was
+// authorized.
+func (h *conformanceHarness) invokeOperation(t *testing.T, appName string, cred conformanceCredential) bool {
+	t.Helper()
+	status, body := h.do(t, http.MethodPost,
+		"/api/v2/app/"+appName+"/operations/"+conformanceListOperation,
+		cred, strings.NewReader(`{"params":{}}`))
+	switch status {
+	case http.StatusOK:
+		return true
+	case http.StatusForbidden, http.StatusUnauthorized:
+		return false
+	default:
+		t.Fatalf("POST operation status = %d: %s", status, body)
+		return false
+	}
+}
+
+// conformanceListToolName finds the list tool's prefixed MCP name.
+func conformanceListToolName(t *testing.T, names []string) string {
+	t.Helper()
+	for _, name := range names {
+		if strings.Contains(name, "items") {
+			return name
+		}
+	}
+	t.Fatalf("list tool not found in %v", names)
+	return ""
+}
+
+// --- grant shapes ----------------------------------------------------------
+
+// TestConformanceGrantShapes covers the grant topologies the plan enumerates.
+// Every case asks the same role-gated mounted UI the same question, so the only
+// variable is the shape of the relationship graph behind the answer.
+func TestConformanceGrantShapes(t *testing.T) {
+	t.Parallel()
+
+	subject := conformanceSubject(conformanceExternalUserID)
+	cred := conformanceBearer(conformanceExternalToken)
+
+	cases := []struct {
+		name          string
+		relationships []*proto.Relationship
+		wantStatus    int
+	}{
+		{
+			name:          "direct grant",
+			relationships: []*proto.Relationship{conformanceDirectGrant(subject, "viewer", "app", conformanceMountedApp)},
+			wantStatus:    http.StatusOK,
+		},
+		{
+			name: "one level subject set",
+			relationships: []*proto.Relationship{
+				conformanceGroupMember(subject, conformanceGroup),
+				conformanceGroupGrant(conformanceGroup, "viewer", "app", conformanceMountedApp),
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "nested subject set",
+			relationships: []*proto.Relationship{
+				conformanceGroupMember(subject, conformanceNestedGroup),
+				conformanceNestedGroupMember(conformanceNestedGroup, conformanceGroup),
+				conformanceGroupGrant(conformanceGroup, "viewer", "app", conformanceMountedApp),
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "grant outside the mount's allowed roles",
+			relationships: []*proto.Relationship{
+				conformanceGroupMember(subject, conformanceGroup),
+				conformanceGroupGrant(conformanceGroup, "editor", "app", conformanceMountedApp),
+			},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:          "no grant at all",
+			relationships: nil,
+			wantStatus:    http.StatusForbidden,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			harness := newConformanceHarness(t, conformanceConfig{spec: conformanceSpec{
+				ResourceTypes: conformanceModel(""),
+				Relationships: testCase.relationships,
+			}})
+			status, body := harness.mountedUI(t, conformanceGatedSamplePath, cred)
+			if status != testCase.wantStatus {
+				t.Fatalf("mounted UI status = %d, want %d: %s", status, testCase.wantStatus, body)
+			}
+		})
+	}
+}
+
+// TestConformanceCyclicGrantsFailClosedAndStayBounded asserts the property that
+// matters for a cyclic graph: the request terminates and denies. It does not
+// assert a particular traversal strategy.
+func TestConformanceCyclicGrantsFailClosedAndStayBounded(t *testing.T) {
+	t.Parallel()
+
+	// Two groups whose membership is defined entirely in terms of each other,
+	// plus a self-referential third. No subject is a member of any of them.
+	harness := newConformanceHarness(t, conformanceConfig{spec: conformanceSpec{
+		ResourceTypes: conformanceModel(""),
+		Relationships: []*proto.Relationship{
+			conformanceNestedGroupMember(conformanceGroup, conformanceNestedGroup),
+			conformanceNestedGroupMember(conformanceNestedGroup, conformanceGroup),
+			conformanceNestedGroupMember("self-loop", "self-loop"),
+			conformanceGroupGrant(conformanceGroup, "viewer", "app", conformanceMountedApp),
+			conformanceGroupGrant("self-loop", "viewer", "app", conformanceMountedApp),
+			// A direct grant to a different subject, so the resource is not
+			// trivially empty.
+			conformanceDirectGrant(conformanceSubject(conformanceAdminUserID), "viewer", "app", conformanceMountedApp),
+		},
+	}})
+
+	status, body := harness.mountedUIWithin(
+		t, conformanceGatedSamplePath, conformanceBearer(conformanceExternalToken), 30*time.Second,
+	)
+	if status != http.StatusForbidden {
+		t.Fatalf("cyclic graph status = %d, want 403: %s", status, body)
+	}
+
+	// The granted subject still gets in, proving the cycle did not poison the
+	// whole resource.
+	if status, body := harness.mountedUI(t, conformanceGatedSamplePath, conformanceBearer(conformanceAdminToken)); status != http.StatusOK {
+		t.Fatalf("direct grant holder status = %d, want 200: %s", status, body)
+	}
+
+	// Termination came from cycle detection, not from the traversal budget's
+	// emergency brake. If this ever flips, the cycle handling regressed even
+	// though the denial above still looks correct.
+	if _, _, _, budgetExhausted := harness.authz.counters(); budgetExhausted {
+		t.Fatal("cycle terminated only by exhausting the traversal budget")
+	}
+}
+
+// TestConformanceCatalogAsksOneBatchedQuestionPerListing proves the catalog
+// reaches its per-app decisions through one batched evaluator call rather than
+// one call per app, which is what keeps listing and invocation on the same
+// decision path without an N-round-trip cost.
+func TestConformanceCatalogAsksOneBatchedQuestionPerListing(t *testing.T) {
+	t.Parallel()
+
+	external := conformanceSubject(conformanceExternalUserID)
+	harness := newConformanceHarness(t, conformanceConfig{spec: conformanceSpec{
+		ResourceTypes: conformanceModel(""),
+		Relationships: []*proto.Relationship{
+			conformanceGroupMember(external, conformanceGroup),
+			conformanceGroupGrant(conformanceGroup, "viewer", "app", conformanceMountedApp),
+			conformanceGroupGrant(conformanceGroup, "viewer", "app", conformanceOtherApp),
+		},
+	}})
+	cred := conformanceBearer(conformanceExternalToken)
+
+	paths := harness.mountedPaths(t, cred)
+	for _, app := range []string{conformanceMountedApp, conformanceOtherApp} {
+		if paths[app] == "" {
+			t.Fatalf("group-granted app %q lost its mounted path", app)
+		}
+	}
+	single, batched, _, _ := harness.authz.counters()
+	if batched == 0 {
+		t.Fatal("catalog listing made no batched evaluator call")
+	}
+	if single > batched {
+		t.Fatalf("catalog listing made %d per-item calls against %d batched calls", single, batched)
+	}
+}
+
+// TestConformanceMalformedGrantsFailClosed feeds the evaluator tuples a real
+// provider could persist but cannot interpret. Every one must be ignored rather
+// than trusted, and none may crash the request.
+func TestConformanceMalformedGrantsFailClosed(t *testing.T) {
+	t.Parallel()
+
+	subject := conformanceSubject(conformanceExternalUserID)
+	resource := &proto.Resource{Type: "app", Id: conformanceMountedApp}
+
+	malformed := []*proto.Relationship{
+		// No tuple at all.
+		{},
+		// Tuple with no target.
+		{Tuple: &proto.RelationshipTuple{Relation: "viewer", Resource: resource}},
+		// Target with neither a subject nor a subject set.
+		{Tuple: &proto.RelationshipTuple{Target: &proto.RelationshipTarget{}, Relation: "viewer", Resource: resource}},
+		// Subject set with no resource.
+		{Tuple: &proto.RelationshipTuple{
+			Target: &proto.RelationshipTarget{Kind: &proto.RelationshipTarget_SubjectSet{
+				SubjectSet: &proto.SubjectSet{Relation: "member"},
+			}},
+			Relation: "viewer",
+			Resource: resource,
+		}},
+		// Subject set with a blank relation.
+		{Tuple: &proto.RelationshipTuple{
+			Target: &proto.RelationshipTarget{Kind: &proto.RelationshipTarget_SubjectSet{
+				SubjectSet: &proto.SubjectSet{Resource: &proto.Resource{Type: "group", Id: conformanceGroup}},
+			}},
+			Relation: "viewer",
+			Resource: resource,
+		}},
+		// Blank relation on the grant itself.
+		{Tuple: &proto.RelationshipTuple{
+			Target: &proto.RelationshipTarget{Kind: &proto.RelationshipTarget_Subject{
+				Subject: &proto.Subject{Type: "subject", Id: subject},
+			}},
+			Resource: resource,
+		}},
+		// Grant with no resource.
+		{Tuple: &proto.RelationshipTuple{
+			Target: &proto.RelationshipTarget{Kind: &proto.RelationshipTarget_Subject{
+				Subject: &proto.Subject{Type: "subject", Id: subject},
+			}},
+			Relation: "viewer",
+		}},
+		// A grant naming a relation the model's action does not allow.
+		conformanceDirectGrant(subject, "not-a-modeled-relation", "app", conformanceMountedApp),
+		// A grant on a resource type the model does not declare.
+		conformanceDirectGrant(subject, "viewer", "undeclaredType", conformanceMountedApp),
+	}
+
+	harness := newConformanceHarness(t, conformanceConfig{spec: conformanceSpec{
+		ResourceTypes: conformanceModel(""),
+		Relationships: malformed,
+	}})
+
+	status, body := harness.mountedUIWithin(
+		t, conformanceGatedSamplePath, conformanceBearer(conformanceExternalToken), 30*time.Second,
+	)
+	if status != http.StatusForbidden {
+		t.Fatalf("malformed grants status = %d, want 403: %s", status, body)
+	}
+}
+
+// TestConformancePaginatedGrantsAreReadWhole proves the app-admin roster follows
+// next_page_token: the evaluator hands back one grant per page, so a surface
+// that stopped after the first page would report one member instead of all.
+func TestConformancePaginatedGrantsAreReadWhole(t *testing.T) {
+	t.Parallel()
+
+	admin := conformanceSubject(conformanceAdminUserID)
+	relationships := []*proto.Relationship{
+		conformanceDirectGrant(admin, "admin", "app", conformanceAdminApp),
+	}
+	const extraMembers = 6
+	for i := range extraMembers {
+		relationships = append(relationships, conformanceDirectGrant(
+			fmt.Sprintf("user:conformance-page-%d", i), "viewer", "app", conformanceAdminApp,
+		))
+	}
+
+	harness := newConformanceHarness(t, conformanceConfig{spec: conformanceSpec{
+		ResourceTypes: conformanceModel(""),
+		Relationships: relationships,
+		ListPageSize:  1,
+	}})
+
+	status, rows := harness.members(t, conformanceAdminApp, conformanceBearer(conformanceAdminToken))
+	if status != http.StatusOK {
+		t.Fatalf("members status = %d, want 200", status)
+	}
+	if len(rows) != len(relationships) {
+		t.Fatalf("members = %d rows, want %d; pagination was not followed", len(rows), len(relationships))
+	}
+	_, _, listCalls, _ := harness.authz.counters()
+	if listCalls < len(relationships) {
+		t.Fatalf("ListRelationships calls = %d, want at least %d pages", listCalls, len(relationships))
+	}
+}
+
+// --- roles, policies, and resource types -----------------------------------
+
+// TestConformanceGroupDerivedAdmin proves app administration is reachable purely
+// through group membership, on both the app-admin gate and the role-gated mount.
+func TestConformanceGroupDerivedAdmin(t *testing.T) {
+	t.Parallel()
+
+	admin := conformanceSubject(conformanceAdminUserID)
+	harness := newConformanceHarness(t, conformanceConfig{spec: conformanceSpec{
+		ResourceTypes: conformanceModel(""),
+		Relationships: []*proto.Relationship{
+			conformanceGroupMember(admin, conformanceNestedGroup),
+			conformanceNestedGroupMember(conformanceNestedGroup, conformanceGroup),
+			conformanceGroupGrant(conformanceGroup, "admin", "app", conformanceAdminApp),
+			conformanceGroupGrant(conformanceGroup, "admin", "app", conformanceMountedApp),
+		},
+	}})
+
+	cred := conformanceBearer(conformanceAdminToken)
+	if status, _ := harness.members(t, conformanceAdminApp, cred); status != http.StatusOK {
+		t.Fatalf("app admin status = %d, want 200", status)
+	}
+	if status, body := harness.mountedUI(t, conformanceGatedSamplePath, cred); status != http.StatusOK {
+		t.Fatalf("mounted UI status = %d, want 200: %s", status, body)
+	}
+}
+
+// TestConformancePolicyAliasUsesDedicatedResourceType proves a custom
+// authorizationPolicy redirects the question to its own resource type: a grant
+// on the alias opens the app, and the same grant on the shared "app" type does
+// not.
+func TestConformancePolicyAliasUsesDedicatedResourceType(t *testing.T) {
+	t.Parallel()
+
+	subject := conformanceSubject(conformanceExternalUserID)
+	cred := conformanceBearer(conformanceExternalToken)
+
+	t.Run("grant on the alias resource type allows", func(t *testing.T) {
+		t.Parallel()
+
+		harness := newConformanceHarness(t, conformanceConfig{spec: conformanceSpec{
+			ResourceTypes: conformanceModel(""),
+			Relationships: []*proto.Relationship{
+				conformanceGroupMember(subject, conformanceGroup),
+				conformanceGroupGrant(conformanceGroup, "viewer", conformanceTalentPolicy, conformanceTalentPolicy),
+			},
+		}})
+		if status, body := harness.mountedUI(t, conformanceGatedTalentPath, cred); status != http.StatusOK {
+			t.Fatalf("policy-aliased mount status = %d, want 200: %s", status, body)
+		}
+	})
+
+	t.Run("grant on the shared app type does not leak into the alias", func(t *testing.T) {
+		t.Parallel()
+
+		harness := newConformanceHarness(t, conformanceConfig{spec: conformanceSpec{
+			ResourceTypes: conformanceModel(""),
+			Relationships: []*proto.Relationship{
+				conformanceDirectGrant(subject, "viewer", "app", conformanceTalentApp),
+				conformanceDirectGrant(subject, "viewer", "app", conformanceMountedApp),
+			},
+		}})
+		if status, body := harness.mountedUI(t, conformanceGatedTalentPath, cred); status != http.StatusForbidden {
+			t.Fatalf("policy-aliased mount status = %d, want 403: %s", status, body)
+		}
+		// The same grant shape on a non-aliased app still works, so the denial
+		// above is the alias mapping and not a broken grant.
+		if status, body := harness.mountedUI(t, conformanceGatedSamplePath, cred); status != http.StatusOK {
+			t.Fatalf("non-aliased mount status = %d, want 200: %s", status, body)
+		}
+	})
+
+	t.Run("app admin resolves the app key through the policy map", func(t *testing.T) {
+		t.Parallel()
+
+		// App admin looks the resource up from the app key, so this case
+		// exercises the shared app key -> policy alias -> resource mapping
+		// rather than the mount's own configured policy.
+		aliased := newConformanceHarness(t, conformanceConfig{spec: conformanceSpec{
+			ResourceTypes: conformanceModel(""),
+			Relationships: []*proto.Relationship{
+				conformanceDirectGrant(subject, "admin", conformanceTalentPolicy, conformanceTalentPolicy),
+			},
+		}})
+		if status, _ := aliased.members(t, conformanceTalentApp, cred); status != http.StatusOK {
+			t.Fatalf("policy-aliased app admin status = %d, want 200", status)
+		}
+
+		unaliased := newConformanceHarness(t, conformanceConfig{spec: conformanceSpec{
+			ResourceTypes: conformanceModel(""),
+			Relationships: []*proto.Relationship{
+				conformanceDirectGrant(subject, "admin", "app", conformanceTalentApp),
+			},
+		}})
+		if status, _ := unaliased.members(t, conformanceTalentApp, cred); status != http.StatusForbidden {
+			t.Fatalf("admin on the unaliased app resource status = %d, want 403", status)
+		}
+	})
+
+	t.Run("alias resource type enforces its own relation set", func(t *testing.T) {
+		t.Parallel()
+
+		// "editor" authorizes the shared "app" type but is not a relation the
+		// talent policy's action accepts.
+		harness := newConformanceHarness(t, conformanceConfig{spec: conformanceSpec{
+			ResourceTypes: conformanceModel(""),
+			Relationships: []*proto.Relationship{
+				conformanceDirectGrant(subject, "editor", conformanceTalentPolicy, conformanceTalentPolicy),
+			},
+		}})
+		if status, body := harness.mountedUI(t, conformanceGatedTalentPath, cred); status != http.StatusForbidden {
+			t.Fatalf("policy-aliased mount status = %d, want 403: %s", status, body)
+		}
+	})
+}
+
+// --- population matrix ------------------------------------------------------
+
+// TestConformanceEmployeeUsesDefaultRole is the current production behavior:
+// under a model whose "app" type carries a defaultRole, an employee with no
+// relationship of their own reaches the app, on every surface.
+func TestConformanceEmployeeUsesDefaultRole(t *testing.T) {
+	t.Parallel()
+
+	harness := newConformanceHarness(t, conformanceConfig{
+		withInvocation: true,
+		spec: conformanceSpec{
+			ResourceTypes: conformanceModel("viewer"),
+		},
+	})
+	cred := conformanceBearer(conformanceEmployeeToken)
+
+	if status, body := harness.mountedUI(t, conformanceGatedSamplePath, cred); status != http.StatusOK {
+		t.Fatalf("mounted UI status = %d, want 200: %s", status, body)
+	}
+	if got := harness.mountedPaths(t, cred)[conformanceMountedApp]; got == "" {
+		t.Fatal("defaultRole employee lost the mounted path in /apps")
+	}
+	names := harness.mcpToolNames(t, cred)
+	if len(names) == 0 {
+		t.Fatal("defaultRole employee saw no MCP tools")
+	}
+	if !harness.mcpCallSucceeds(t, cred, conformanceListToolName(t, names)) {
+		t.Fatal("defaultRole employee could not call an MCP tool")
+	}
+	if !harness.invokeOperation(t, conformanceMountedApp, cred) {
+		t.Fatal("defaultRole employee could not invoke an operation")
+	}
+}
+
+// TestConformanceEmployeeWithoutDefaultRoleNeedsAGrant is the post-Stack-B
+// world: with defaultRole removed, the same employee is denied unless a
+// membership grant carries them.
+func TestConformanceEmployeeWithoutDefaultRoleNeedsAGrant(t *testing.T) {
+	t.Parallel()
+
+	employee := conformanceSubject(conformanceEmployeeUserID)
+	cred := conformanceBearer(conformanceEmployeeToken)
+
+	denied := newConformanceHarness(t, conformanceConfig{spec: conformanceSpec{
+		ResourceTypes: conformanceModel(""),
+	}})
+	if status, body := denied.mountedUI(t, conformanceGatedSamplePath, cred); status != http.StatusForbidden {
+		t.Fatalf("no-default employee status = %d, want 403: %s", status, body)
+	}
+
+	granted := newConformanceHarness(t, conformanceConfig{spec: conformanceSpec{
+		ResourceTypes: conformanceModel(""),
+		Relationships: []*proto.Relationship{
+			conformanceGroupMember(employee, conformanceGroup),
+			conformanceGroupGrant(conformanceGroup, "viewer", "app", conformanceMountedApp),
+		},
+	}})
+	if status, body := granted.mountedUI(t, conformanceGatedSamplePath, cred); status != http.StatusOK {
+		t.Fatalf("membership-granted employee status = %d, want 200: %s", status, body)
+	}
+}
+
+// TestConformanceElevatedAdminPassesEveryGate proves an admin relation satisfies
+// both the viewer-or-admin mount and the admin-only app-admin gate through one
+// evaluator, with no surface inventing its own role ordering.
+func TestConformanceElevatedAdminPassesEveryGate(t *testing.T) {
+	t.Parallel()
+
+	admin := conformanceSubject(conformanceAdminUserID)
+	harness := newConformanceHarness(t, conformanceConfig{
+		withInvocation: true,
+		spec: conformanceSpec{
+			ResourceTypes: conformanceModel(""),
+			Relationships: []*proto.Relationship{
+				conformanceDirectGrant(admin, "admin", "app", conformanceMountedApp),
+				conformanceDirectGrant(admin, "admin", "app", conformanceAdminApp),
+			},
+		},
+	})
+	cred := conformanceBearer(conformanceAdminToken)
+
+	if status, body := harness.mountedUI(t, conformanceGatedSamplePath, cred); status != http.StatusOK {
+		t.Fatalf("mounted UI status = %d, want 200: %s", status, body)
+	}
+	if status, _ := harness.members(t, conformanceAdminApp, cred); status != http.StatusOK {
+		t.Fatalf("app admin status = %d, want 200", status)
+	}
+	names := harness.mcpToolNames(t, cred)
+	if len(names) == 0 {
+		t.Fatal("admin saw no MCP tools")
+	}
+}
+
+// TestConformanceUngrantedExternalIsDeniedEverywhere is the baseline external
+// case: no relationship, no defaultRole, denied on every surface.
+func TestConformanceUngrantedExternalIsDeniedEverywhere(t *testing.T) {
+	t.Parallel()
+
+	harness := newConformanceHarness(t, conformanceConfig{
+		withInvocation: true,
+		spec:           conformanceSpec{ResourceTypes: conformanceModel("")},
+	})
+	cred := conformanceBearer(conformanceOutsiderToken)
+
+	if status, body := harness.mountedUI(t, conformanceGatedSamplePath, cred); status != http.StatusForbidden {
+		t.Fatalf("mounted UI status = %d, want 403: %s", status, body)
+	}
+	if got := harness.mountedPaths(t, cred)[conformanceMountedApp]; got != "" {
+		t.Fatalf("/apps exposed mounted path %q to an ungranted external user", got)
+	}
+	if status, _ := harness.members(t, conformanceAdminApp, cred); status != http.StatusForbidden {
+		t.Fatalf("app admin status = %d, want 403", status)
+	}
+	if names := harness.mcpToolNames(t, cred); len(names) != 0 {
+		t.Fatalf("tools/list exposed %v to an ungranted external user", names)
+	}
+	if harness.mcpCallSucceeds(t, cred, conformanceMountedApp+"_items_list") {
+		t.Fatal("tools/call succeeded for an ungranted external user")
+	}
+	if harness.invokeOperation(t, conformanceMountedApp, cred) {
+		t.Fatal("operation invocation succeeded for an ungranted external user")
+	}
+}
+
+// TestConformanceGrantedExternalIsAllowedOnEverySurface is the mirror image, and
+// the case that proves the surfaces agree: one runtime grant opens the mount,
+// the catalog, invocation, and MCP together.
+func TestConformanceGrantedExternalIsAllowedOnEverySurface(t *testing.T) {
+	t.Parallel()
+
+	external := conformanceSubject(conformanceExternalUserID)
+	harness := newConformanceHarness(t, conformanceConfig{
+		withInvocation: true,
+		spec: conformanceSpec{
+			ResourceTypes: conformanceModel(""),
+			Relationships: []*proto.Relationship{
+				conformanceGroupMember(external, conformanceGroup),
+				conformanceGroupGrant(conformanceGroup, "viewer", "app", conformanceMountedApp),
+			},
+		},
+	})
+	cred := conformanceBearer(conformanceExternalToken)
+
+	if status, body := harness.mountedUI(t, conformanceGatedSamplePath, cred); status != http.StatusOK {
+		t.Fatalf("mounted UI status = %d, want 200: %s", status, body)
+	}
+	paths := harness.mountedPaths(t, cred)
+	if paths[conformanceMountedApp] == "" {
+		t.Fatal("/apps hid the mounted path from a granted external user")
+	}
+	if paths[conformanceOtherApp] != "" {
+		t.Fatalf("/apps exposed ungranted app %q", conformanceOtherApp)
+	}
+	names := harness.mcpToolNames(t, cred)
+	if len(names) == 0 {
+		t.Fatal("tools/list hid every tool from a granted external user")
+	}
+	if !harness.mcpCallSucceeds(t, cred, conformanceListToolName(t, names)) {
+		t.Fatal("tools/call denied a granted external user")
+	}
+	if !harness.invokeOperation(t, conformanceMountedApp, cred) {
+		t.Fatal("operation invocation denied a granted external user")
+	}
+	if harness.invokeOperation(t, conformanceOtherApp, cred) {
+		t.Fatal("operation invocation succeeded on an ungranted app")
+	}
+}
+
+// TestConformanceRevokedExternalIsDeniedPromptly removes a live grant and
+// reasserts every surface. No surface may keep serving from a cached decision.
+func TestConformanceRevokedExternalIsDeniedPromptly(t *testing.T) {
+	t.Parallel()
+
+	external := conformanceSubject(conformanceExternalUserID)
+	membership := conformanceGroupMember(external, conformanceGroup)
+	harness := newConformanceHarness(t, conformanceConfig{
+		withInvocation: true,
+		spec: conformanceSpec{
+			ResourceTypes: conformanceModel(""),
+			Relationships: []*proto.Relationship{
+				membership,
+				conformanceGroupGrant(conformanceGroup, "viewer", "app", conformanceMountedApp),
+			},
+		},
+	})
+	cred := conformanceBearer(conformanceExternalToken)
+
+	if status, body := harness.mountedUI(t, conformanceGatedSamplePath, cred); status != http.StatusOK {
+		t.Fatalf("pre-revoke mounted UI status = %d, want 200: %s", status, body)
+	}
+	toolName := conformanceListToolName(t, harness.mcpToolNames(t, cred))
+
+	harness.authz.revoke(t, membership)
+
+	if status, body := harness.mountedUI(t, conformanceGatedSamplePath, cred); status != http.StatusForbidden {
+		t.Fatalf("post-revoke mounted UI status = %d, want 403: %s", status, body)
+	}
+	if got := harness.mountedPaths(t, cred)[conformanceMountedApp]; got != "" {
+		t.Fatalf("post-revoke /apps still exposed mounted path %q", got)
+	}
+	if names := harness.mcpToolNames(t, cred); len(names) != 0 {
+		t.Fatalf("post-revoke tools/list still exposed %v", names)
+	}
+	if harness.mcpCallSucceeds(t, cred, toolName) {
+		t.Fatal("post-revoke tools/call still succeeded")
+	}
+	if harness.invokeOperation(t, conformanceMountedApp, cred) {
+		t.Fatal("post-revoke operation invocation still succeeded")
+	}
+
+	// Re-granting restores access, proving the denial tracked the grant rather
+	// than a one-way latch.
+	harness.authz.grant(t, membership)
+	if status, body := harness.mountedUI(t, conformanceGatedSamplePath, cred); status != http.StatusOK {
+		t.Fatalf("re-granted mounted UI status = %d, want 200: %s", status, body)
+	}
+}
+
+// TestConformanceExternalAppAdminIsIsolated proves administering one app confers
+// nothing on another app, and does not turn into a general viewer role.
+func TestConformanceExternalAppAdminIsIsolated(t *testing.T) {
+	t.Parallel()
+
+	external := conformanceSubject(conformanceExternalUserID)
+	harness := newConformanceHarness(t, conformanceConfig{
+		withInvocation: true,
+		spec: conformanceSpec{
+			ResourceTypes: conformanceModel(""),
+			Relationships: []*proto.Relationship{
+				conformanceDirectGrant(external, "admin", "app", conformanceAdminApp),
+			},
+		},
+	})
+	cred := conformanceBearer(conformanceExternalToken)
+
+	if status, _ := harness.members(t, conformanceAdminApp, cred); status != http.StatusOK {
+		t.Fatalf("own app admin status = %d, want 200", status)
+	}
+	if status, _ := harness.members(t, conformanceMountedApp, cred); status != http.StatusForbidden {
+		t.Fatalf("other app admin status = %d, want 403", status)
+	}
+	if status, _ := harness.members(t, conformanceOtherApp, cred); status != http.StatusForbidden {
+		t.Fatalf("third app admin status = %d, want 403", status)
+	}
+	if status, body := harness.mountedUI(t, conformanceGatedSamplePath, cred); status != http.StatusForbidden {
+		t.Fatalf("mounted UI of an unadministered app status = %d, want 403: %s", status, body)
+	}
+	if got := harness.mountedPaths(t, cred)[conformanceMountedApp]; got != "" {
+		t.Fatalf("/apps exposed an unadministered app's mounted path %q", got)
+	}
+	if names := harness.mcpToolNames(t, cred); len(names) != 0 {
+		t.Fatalf("tools/list exposed %v to an admin of a different app", names)
+	}
+}
+
+// TestConformanceUserLookupNeedsTheEmployeeOperatorRole proves app-scoped
+// administration does not become a user directory: the roster still lists the
+// grants, but identities resolve only for the explicit operator role, which may
+// itself be held through a group.
+func TestConformanceUserLookupNeedsTheEmployeeOperatorRole(t *testing.T) {
+	t.Parallel()
+
+	admin := conformanceSubject(conformanceAdminUserID)
+
+	rosterEmails := func(t *testing.T, extra ...*proto.Relationship) []memberEmailRow {
+		t.Helper()
+		harness := newConformanceHarness(t, conformanceConfig{spec: conformanceSpec{
+			ResourceTypes: conformanceModel(""),
+		}})
+		member := seedUser(t, harness.services, "member@valon.com")
+		harness.authz.grant(t, conformanceDirectGrant(admin, "admin", "app", conformanceAdminApp))
+		harness.authz.grant(t, conformanceDirectGrant(
+			conformanceSubject(member.ID), "viewer", "app", conformanceAdminApp,
+		))
+		for _, relationship := range extra {
+			harness.authz.grant(t, relationship)
+		}
+		status, rows := harness.members(t, conformanceAdminApp, conformanceBearer(conformanceAdminToken))
+		if status != http.StatusOK {
+			t.Fatalf("members status = %d, want 200", status)
+		}
+		if len(rows) != 2 {
+			t.Fatalf("members = %#v, want 2 rows", rows)
+		}
+		return rows
+	}
+
+	t.Run("app admin alone cannot enumerate users", func(t *testing.T) {
+		t.Parallel()
+
+		for _, row := range rosterEmails(t) {
+			if row.Email != "" {
+				t.Fatalf("app-scoped admin resolved an email without the operator role: %#v", row)
+			}
+		}
+	})
+
+	t.Run("group derived operator role restores lookup", func(t *testing.T) {
+		t.Parallel()
+
+		rows := rosterEmails(t,
+			conformanceGroupMember(admin, conformanceGroup),
+			conformanceGroupGrant(conformanceGroup, testUserLookupRole, testUserLookupResource, testUserLookupResource),
+		)
+		found := false
+		for _, row := range rows {
+			if row.Email == "member@valon.com" {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("operator role did not resolve member email: %#v", rows)
+		}
+	})
+}
+
+// --- credential surfaces ----------------------------------------------------
+
+// TestConformanceCredentialSurfacesAgree walks one user through the browser
+// session, the CLI token exchange, and the resulting API token, then through
+// MCP, and requires the same authorization answer from all of them -- first
+// while granted, then after the grant is revoked.
+func TestConformanceCredentialSurfacesAgree(t *testing.T) {
+	t.Parallel()
+
+	external := conformanceSubject(conformanceExternalUserID)
+	membership := conformanceGroupMember(external, conformanceGroup)
+	harness := newConformanceHarness(t, conformanceConfig{
+		withInvocation: true,
+		spec: conformanceSpec{
+			ResourceTypes: conformanceModel(""),
+			Relationships: []*proto.Relationship{
+				membership,
+				conformanceGroupGrant(conformanceGroup, "viewer", "app", conformanceMountedApp),
+			},
+		},
+	})
+
+	browser := conformanceCookie(conformanceExternalToken)
+	apiToken := conformanceBearer(conformanceExternalToken)
+
+	// The CLI exchanges the browser session for a long-lived API token through
+	// the real /api/v1/tokens surface.
+	status, body := harness.do(t, http.MethodPost, "/api/v1/tokens", browser,
+		strings.NewReader(`{"name":"conformance-cli","scopes":"`+conformanceMountedApp+`"}`))
+	if status != http.StatusCreated {
+		t.Fatalf("CLI token exchange status = %d, want 201: %s", status, body)
+	}
+	var created struct {
+		Token string `json:"token"`
+	}
+	if err := json.Unmarshal([]byte(body), &created); err != nil {
+		t.Fatalf("decode created token: %v (body=%s)", err, body)
+	}
+	if created.Token == "" {
+		t.Fatalf("CLI token exchange returned no token: %s", body)
+	}
+	cliToken := conformanceBearer(created.Token)
+
+	surfaces := map[string]conformanceCredential{
+		"browser session": browser,
+		"CLI exchanged":   cliToken,
+		"API token":       apiToken,
+	}
+	for name, cred := range surfaces {
+		if status, body := harness.mountedUI(t, conformanceGatedSamplePath, cred); status != http.StatusOK {
+			t.Fatalf("%s: granted mounted UI status = %d, want 200: %s", name, status, body)
+		}
+		if got := harness.mountedPaths(t, cred)[conformanceMountedApp]; got == "" {
+			t.Fatalf("%s: /apps hid the mounted path from a granted user", name)
+		}
+	}
+	toolName := conformanceListToolName(t, harness.mcpToolNames(t, cliToken))
+	if !harness.mcpCallSucceeds(t, cliToken, toolName) {
+		t.Fatal("CLI exchanged token: tools/call denied a granted user")
+	}
+	for _, name := range []string{"CLI exchanged", "API token"} {
+		if !harness.invokeOperation(t, conformanceMountedApp, surfaces[name]) {
+			t.Fatalf("%s: operation invocation denied a granted user", name)
+		}
+	}
+
+	harness.authz.revoke(t, membership)
+
+	for name, cred := range surfaces {
+		if status, body := harness.mountedUI(t, conformanceGatedSamplePath, cred); status != http.StatusForbidden {
+			t.Fatalf("%s: revoked mounted UI status = %d, want 403: %s", name, status, body)
+		}
+		if got := harness.mountedPaths(t, cred)[conformanceMountedApp]; got != "" {
+			t.Fatalf("%s: /apps still exposed mounted path %q after revoke", name, got)
+		}
+	}
+	if names := harness.mcpToolNames(t, cliToken); len(names) != 0 {
+		t.Fatalf("CLI exchanged token: tools/list still exposed %v after revoke", names)
+	}
+	if harness.mcpCallSucceeds(t, cliToken, toolName) {
+		t.Fatal("CLI exchanged token: tools/call still succeeded after revoke")
+	}
+	for _, name := range []string{"CLI exchanged", "API token"} {
+		if harness.invokeOperation(t, conformanceMountedApp, surfaces[name]) {
+			t.Fatalf("%s: operation invocation still succeeded after revoke", name)
+		}
+	}
+}
+
+// TestConformanceMCPListingAndCallAgree closes the listing/invocation gap: a
+// tool the caller cannot invoke must not appear in tools/list, and a tool that
+// does appear must be callable. Both answers come from the same evaluator.
+func TestConformanceMCPListingAndCallAgree(t *testing.T) {
+	t.Parallel()
+
+	external := conformanceSubject(conformanceExternalUserID)
+	harness := newConformanceHarness(t, conformanceConfig{
+		withInvocation: true,
+		spec: conformanceSpec{
+			ResourceTypes: conformanceModel(""),
+			Relationships: []*proto.Relationship{
+				conformanceGroupMember(external, conformanceGroup),
+				conformanceGroupGrant(conformanceGroup, "user", "app", conformanceMountedApp),
+			},
+		},
+	})
+
+	granted := conformanceBearer(conformanceExternalToken)
+	ungranted := conformanceBearer(conformanceOutsiderToken)
+
+	names := harness.mcpToolNames(t, granted)
+	if len(names) == 0 {
+		t.Fatal("tools/list hid every tool from a granted caller")
+	}
+	toolName := conformanceListToolName(t, names)
+	if !harness.mcpCallSucceeds(t, granted, toolName) {
+		t.Fatalf("tools/list offered %q but tools/call denied it", toolName)
+	}
+
+	if listed := harness.mcpToolNames(t, ungranted); len(listed) != 0 {
+		t.Fatalf("tools/list offered %v to an ungranted caller", listed)
+	}
+	if harness.mcpCallSucceeds(t, ungranted, toolName) {
+		t.Fatalf("tools/call ran %q for an ungranted caller", toolName)
+	}
+}
+
+// --- provider-response conformance -----------------------------------------
+
+// allowWithoutRelationsProvider is the failure mode G3a flagged: a provider that
+// answers "allowed" without naming the relation that authorized it. A role-gated
+// surface has nothing to check the answer against and must deny.
+type allowWithoutRelationsProvider struct {
+	core.AuthorizationProvider
+
+	resourceTypes []conformanceResourceType
+}
+
+func (p *allowWithoutRelationsProvider) CheckAccess(
+	_ context.Context, _ *proto.CheckAccessRequest,
+) (*proto.CheckAccessResponse, error) {
+	return &proto.CheckAccessResponse{Allowed: true}, nil
+}
+
+func (p *allowWithoutRelationsProvider) CheckAccessMany(
+	_ context.Context, req *proto.CheckAccessManyRequest,
+) (*proto.CheckAccessManyResponse, error) {
+	decisions := make([]*proto.CheckAccessResponse, 0, len(req.GetRequests()))
+	for range req.GetRequests() {
+		decisions = append(decisions, &proto.CheckAccessResponse{Allowed: true})
+	}
+	return &proto.CheckAccessManyResponse{Decisions: decisions}, nil
+}
+
+func (p *allowWithoutRelationsProvider) ListRelationships(
+	_ context.Context, _ *proto.ListRelationshipsRequest,
+) (*proto.ListRelationshipsResponse, error) {
+	return &proto.ListRelationshipsResponse{}, nil
+}
+
+func (p *allowWithoutRelationsProvider) ListActiveModelResourceTypes(
+	_ context.Context, req *proto.ListActiveModelResourceTypesRequest,
+) (*proto.ListActiveModelResourceTypesResponse, error) {
+	name := strings.TrimSpace(req.GetFilter().GetName())
+	out := []*proto.AuthorizationModelResourceType{}
+	for _, resourceType := range p.resourceTypes {
+		if name != "" && resourceType.Name != name {
+			continue
+		}
+		entry := &proto.AuthorizationModelResourceType{Name: resourceType.Name, DefaultRole: resourceType.DefaultRole}
+		for _, action := range resourceType.Actions {
+			entry.Actions = append(entry.Actions, &proto.ModelAction{Name: action.Name, Relations: action.Relations})
+		}
+		out = append(out, entry)
+	}
+	return &proto.ListActiveModelResourceTypesResponse{ResourceTypes: out}, nil
+}
+
+// TestConformanceAllowWithoutMatchedRelationsIsNotARole is the explicit guard
+// for the risk G3a flagged. `allowed: true` with an empty matched_relations list
+// carries no role, so it must not satisfy a role-gated mount or app admin.
+func TestConformanceAllowWithoutMatchedRelationsIsNotARole(t *testing.T) {
+	t.Parallel()
+
+	harness := newConformanceHarness(t, conformanceConfig{
+		authorization: &allowWithoutRelationsProvider{resourceTypes: conformanceModel("")},
+		spec:          conformanceSpec{ResourceTypes: conformanceModel("")},
+	})
+	cred := conformanceBearer(conformanceOutsiderToken)
+
+	if status, body := harness.mountedUI(t, conformanceGatedSamplePath, cred); status != http.StatusForbidden {
+		t.Fatalf("role-gated mount status = %d, want 403 on a relation-less allow: %s", status, body)
+	}
+	if status, _ := harness.members(t, conformanceAdminApp, cred); status != http.StatusForbidden {
+		t.Fatalf("app admin status = %d, want 403 on a relation-less allow", status)
+	}
+	if status, body := harness.mountedUI(t, conformanceGatedTalentPath, cred); status != http.StatusForbidden {
+		t.Fatalf("policy-aliased mount status = %d, want 403 on a relation-less allow: %s", status, body)
+	}
+}


### PR DESCRIPTION
## Description

Adds a conformance suite driving mounted UI, catalog/`/apps`, app admin, user lookup, operation invocation, and MCP `tools/list`/`tools/call` against one shared evaluator — proving every surface asks the same question and projects the answer the same way. This is the check that would have caught the incident: #3061 broke group-only catalog access precisely because each surface traversed relationships independently.

Stack A / G4 in [plans/external_users/implementation_v2.md](https://github.com/valon-technologies/gestalt/blob/main/plans/external_users/implementation_v2.md). Stacked on #3072.

### ⚠️ Read this before approving: it is NOT the real evaluator

G4 asks for "the real authorization evaluator". **That is not achievable from this module, so this suite uses an in-repo reference implementation instead.** Being explicit because the plan's whole point is not trusting untested assumptions.

Why (a) is impossible: the real evaluator (`gestalt-providers/authorization/indexeddb/access.go`) is a **separate Go module in another repository**, its own `go.mod` `replace`s back into this checkout via relative paths, and it requires a live indexeddb host service. CI runs `go test` inside the `gestaltd` module with no sibling checkout and no network. There is no in-repo authorization provider — `buildNamedAuthorizationProvider` only builds a remote gRPC client or calls a factory nothing in-repo registers.

`conformanceEvaluator` was transcribed line-by-line from the real `evaluateAccess` (resource type absent → deny; action lookup then `"*"` fallback; empty relation set → deny; relation must be in the action's allowed set; recursive subject-set expansion with a visited set; matched relations in declared order; `defaultRole` only when the action permits it). It is the **single** evaluator every case uses, reached through one constructor, and the suite is written against `core.AuthorizationProvider` without touching internals — so swapping in the real provider is a one-function change.

**Proven:** every server surface agrees with every other. **Not proven:** that the shipped provider implements these semantics. That remains Gate A's canary and T2's shadow evaluation.

### Coverage
All G4 bullets are covered: direct / one-level / nested / cyclic / malformed / paginated grants; group-derived admin; policy aliases and dedicated resource types; employee, elevated admin, ungranted external, granted external, revoked external; external app-admin isolation and user-lookup denial; browser, CLI token exchange, API token, and MCP list + call. Cyclic and malformed assert fail-closed *and bounded* (cycle detection, not a budget brake, terminates the walk).

Includes the explicit assertion for the risk flagged in #3071: a provider returning `allowed: true` with empty `matched_relations` must not silently grant a role-gated mount or app admin.

The assertions were mutation-tested — removing the broker's `OperationAccess`, the authorization provider, or the `AuthorizationPolicies` map each makes specific tests fail rather than silently pass.

Suite cost is ~0.1s inside a 0.76s package run, and it is `-race` clean.

### Note on an unrelated flaky test
`TestAgentRuntimeConfigSelectedProviderStartsSessionWithRuntimeFields` (`internal/bootstrap`) intermittently times out at ~5s under full-suite parallel load. I confirmed it fails identically on unmodified `origin/main`, so it is pre-existing and unrelated to this stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)