### PR TITLE
[gestalt] replan external users rollout around one reversible flip

### DIFF
--- a/plans/external_users/implementation_prompt.md
+++ b/plans/external_users/implementation_prompt.md
@@ -1,0 +1,173 @@
+# Implement the external-users migration on valon.tools
+
+Read [implementation_v2.md](./implementation_v2.md) first. It is the spec; this document is
+the framing and the guardrails.
+
+## Goal
+
+Make valon.tools reachable by users from an approved external email domain, without
+internal users losing access.
+
+- **External users get authentication only.** They sign in, land on the valon.tools home
+  page, and get nothing else: no apps visible in `/apps`, no MCP tools listed, nothing
+  invocable, zero authorization grants.
+- **Internal users move into a `valon-employees` group** and receive **at least reader
+  (`viewer`) on every app**, granted to the group — never per user.
+
+The migration is one substitution: `defaultRole` (an implicit blanket allow that grants
+every authenticated subject) is removed, and employees are granted explicitly via
+`valon-employees` instead. `defaultRole` must go, because the moment an external can
+authenticate they inherit it.
+
+## This migration was attempted on 2026-08-06 and broke employee access. Read what happened.
+
+Do not start until you have looked at these. The failure modes are specific and repeatable.
+
+**The two things that actually caused access loss:**
+
+1. **The employee roster was built from existing authorization rows instead of an employee
+   authority.** It contained 67 UUIDs against 358 real users — only 64 matched. Employees
+   whose access came solely from `defaultRole` were simply absent from the group, so
+   clearing `defaultRole` cut them off. The validator checked the same incomplete source,
+   so nothing flagged it.
+
+2. **Group membership was not honored on every authorization path.** `CheckAccess`
+   understood subject sets, but mounted UI, catalog, and app-admin each ran their own
+   direct-grant-only relationship scan. An employee *in* the group was still denied.
+   - [gestalt#3061](https://github.com/valon-technologies/gestalt/pull/3061) — "Filter
+     /apps catalog by viewer/editor/admin grants". Introduced direct-only catalog checks;
+     broke group-only catalog access.
+   - [gestalt#3062](https://github.com/valon-technologies/gestalt/pull/3062) — "Resolve
+     mounted UI roles through subject sets". Fixed the mounted-role helper and catalog, but
+     **app-admin checks stayed direct-only**, so the incident continued after this shipped.
+   - Root cause found later: `resolvePrincipalUserID` treated any subject without an `@` as
+     already canonical, so a provider-opaque subject like `auth0|abc` reached authorization
+     unresolved and matched no relationship.
+
+**What made recovery worse:**
+
+3. **The shared app wildcard was set to `[nobody]`**, denying 713 operations that relied on
+   wildcard viewer access.
+   [toolshed#4062](https://github.com/valon-technologies/toolshed/pull/4062) — "Restore
+   staff access for registry app operations" restored `[viewer, user, editor, admin]`.
+
+4. **The hotfix was oversized.**
+   [toolshed#4071](https://github.com/valon-technologies/toolshed/pull/4071) — "Hotfix
+   direct Valon employee app grants" generated 5,762 direct per-user grants and failed
+   startup probes. Reverted by
+   [toolshed#4072](https://github.com/valon-technologies/toolshed/pull/4072) and
+   [toolshed#4073](https://github.com/valon-technologies/toolshed/pull/4073).
+
+5. **Auth0 was configured untested** — issuer mismatch, missing connection/HRD setup, then
+   HS256 tokens, discovered in sequence during the cutover.
+
+6. **No-traffic Cloud Run candidates could overwrite shared authorization state at
+   startup**, and traffic rollback did not restore it.
+
+Fallout continued for days: [toolshed#4124](https://github.com/valon-technologies/toolshed/pull/4124),
+[#4134](https://github.com/valon-technologies/toolshed/pull/4134),
+[#4139](https://github.com/valon-technologies/toolshed/pull/4139),
+[#4140](https://github.com/valon-technologies/toolshed/pull/4140), and
+[#4141](https://github.com/valon-technologies/toolshed/pull/4141) are all follow-on grant
+and resource-type repairs.
+
+## Non-negotiables
+
+- **Never** build the roster from authorization rows. Use Rippling (the People authority),
+  joined to canonical Gestalt user UUIDs by normalized email.
+- **Never** set the shared app wildcard to `[nobody]`. Keep
+  `actions: "*": relations: [viewer, user, editor, admin]`.
+- **Never** generate per-user/per-app grants. One grant per resource type, to the group.
+- Keep Google login until employee authorization has passed and soaked one business day.
+- Roll back on the first failed check. Do not diagnose live and do not stack hotfixes.
+
+## Traps that are easy to miss
+
+- **`defaultRole` is on six resource types, not just `app`.** In
+  `toolshed/valon-tools/deploy/config.yaml`: `agent-trace-viewer` (`viewer`), `workflow`
+  and `agent` (aliases of it), `app` (`viewer`), `pmiPayoffCancellations` (**`admin`**),
+  `itAccountOnboarding` (`noaccess`). Clearing only `app` leaves an external with viewer on
+  three types and **admin on one**. Re-derive this list from the deployed config; do not
+  trust this document.
+- **`agent-trace-viewer` is a YAML anchor** (`&defaultAuthzResource`). Grepping
+  `defaultRole` finds four sites; there are six. Editing it silently changes `workflow` and
+  `agent` too.
+- **`noaccess` is not a deny.** `authorizeMountedResourceRoles` allows whenever
+  `defaultRole != "" && len(allowedRoles) == 0`. Omit the field entirely; never set a
+  sentinel.
+- **Grants must match or exceed what each `defaultRole` confers today.** "At least reader"
+  is the floor, not the target — `pmiPayoffCancellations` currently confers `admin`, so
+  granting the group `viewer` there is a downgrade that breaks that app for employees.
+  Every resource type you clear needs a corresponding group grant, or you have revoked
+  access rather than migrated it.
+- **`CheckAccess` is action-shaped and there is no effective-roles RPC.** A policy-shaped
+  resource type that declares relations but no actions makes the evaluator deny a question
+  it cannot represent. A bounded transition shim handles this; if its warning never fires
+  in production, the shim can be deleted.
+
+## Work already done
+
+Five gestalt PRs were implemented and passed CI, then closed pending a replan. The branches
+are pushed; reopen or re-file them rather than rewriting:
+
+| Branch | Content | Closed PR |
+| --- | --- | --- |
+| `g2-canonical-identity` | Canonical identity at every authorization boundary | [#3070](https://github.com/valon-technologies/gestalt/pull/3070) |
+| `g3a-unify-authorization-evaluator` | Mounted UI + app admin decide through the evaluator | [#3071](https://github.com/valon-technologies/gestalt/pull/3071) |
+| `g1-authorization-state-safety` | Startup authorization-state write gated behind explicit apply | [#3069](https://github.com/valon-technologies/gestalt/pull/3069) |
+| `g4-authorization-conformance-suite` | Conformance suite across every server surface | [#3073](https://github.com/valon-technologies/gestalt/pull/3073) |
+| `g3b-batched-listing-decisions` | Catalog + MCP listing authorization | [#3072](https://github.com/valon-technologies/gestalt/pull/3072) |
+
+Caveat on the conformance suite: it runs against an in-repo reference evaluator, not the
+real provider (that provider is a separate module in another repository and needs a live
+indexeddb host service). It proves every server surface agrees with every other; it does
+not prove the shipped provider implements those semantics.
+
+## Sequence — 13 PRs, four phases
+
+Phases 1 and 2 are additive with `defaultRole` still active, so **nobody's access changes**
+and mistakes are free. Only Phase 3 carries risk.
+
+**Phase 1 — make group membership work** (PRs 1–5). Land the five gestalt branches above,
+wire the state-apply flag to exactly one owning revision in Toolshed, deploy under Google.
+*Check:* current-access regression for real employees. Nothing should change for anyone.
+
+**Phase 2 — build the roster, additively** (PR 6). Enumerate every resource type declaring a
+`defaultRole`. Build `valon-employees` from Rippling. Add memberships and one grant per
+resource type to the group.
+*Gate:* every active employee resolves to exactly one Gestalt UUID and is in the group;
+every user who authenticated in the last 30 days is either in the group or an identified
+non-employee, **with the count reconciled explicitly** — this is the check that would have
+caught the original 67-vs-358 failure; every cleared resource type has a matching grant.
+
+**Phase 3 — the flip** (PRs 7–8). Clear `defaultRole` on the two narrow custom-policy types
+first as a live rehearsal including the rollback, then on `app` and the anchor trio.
+*Verify within 15 minutes with real people*, not synthetic subjects: fresh browser, CLI, and
+MCP sessions; `/apps` lists expected integrations; the apps behind the non-`app` resource
+types still work.
+*Rollback:* re-add `defaultRole` and redeploy. Group memberships stay, so reverting costs
+nothing. Do this on the first failure.
+Soak one business day.
+
+**Phase 4 — externals** (PRs 9–13). Catalog/MCP listing authorization must be deployed and
+verified against an ungranted identity **before** any external domain is enabled — without
+it an authenticated external sees the entire internal app catalog. Then Auth0 secrets,
+employee-only Auth0 cutover (verify issuer matches discovery, RS256 + JWKS, audience,
+subjects match, callbacks allowlisted, HRD enabled, public signup disabled,
+`allowedDomains: [valon.com]`, via a real authorization-code flow before deploying), then a
+temporary probe domain, then the first partner domain.
+*External acceptance test:* an authenticated external sees an empty `/apps`, `tools/list`
+returns nothing, and invocation is denied.
+
+## How to work
+
+- Open PRs; do not merge without review. Two approvals per gate: Gestalt authorization owner
+  and Toolshed/on-call owner.
+- Push with `git push origin <branch>:<branch>` and open PRs with `gh pr create`. Do **not**
+  use `gs branch submit` — it reads `branch.<name>.merge` as the remote name and can push
+  straight to `main`, and the credentials in use bypass branch protection.
+- Run `go build ./...`, `go test -count=1 ./...`, and `golangci-lint run <touched packages>`
+  (v2.12.1, config at `gestaltd/.golangci.yml`; `paralleltest` requires `t.Parallel()`
+  except where `t.Setenv` is used) before pushing.
+- `TestAgentRuntimeConfigSelectedProviderStartsSessionWithRuntimeFields` in
+  `internal/bootstrap` flakes under full-suite load on `main`. It is pre-existing.

--- a/plans/external_users/implementation_v2.md
+++ b/plans/external_users/implementation_v2.md
@@ -145,12 +145,20 @@ Externals hold no grants, so grant/revoke workflows and per-app external access 
 | 3 | gestalt | 1 | Startup authorization-state write gated behind explicit apply |
 | 4 | gestalt | 1 | Conformance suite |
 | 5 | toolshed | 1 | Wire the state-apply flag to the one owning revision; deploy Phase 1 |
-| 6 | toolshed | 2 | `valon-employees` roster, memberships, per-app group grants, reconciliation gate |
-| 7 | toolshed | 3 | Remove `defaultRole` |
-| 8 | gestalt | 4 | Catalog + MCP listing authorization (**prerequisite for externals**) |
-| 9+ | toolshed | 4 | Auth0 cutover, probe, first partner |
+| 6 | toolshed | 2 | `valon-employees` roster, memberships, per-resource-type group grants, reconciliation gate |
+| 7 | toolshed | 3 | Clear `defaultRole` on the custom-policy types (`pmiPayoffCancellations`, `itAccountOnboarding`) |
+| 8 | toolshed | 3 | Clear `defaultRole` on `app` and the anchor trio (`agent-trace-viewer`/`workflow`/`agent`) |
+| 9 | gestalt | 4 | Catalog + MCP listing authorization (**prerequisite for externals**) |
+| 10 | toolshed | 4 | Auth0 secrets — GSM + `terraform/main.tf` |
+| 11 | toolshed | 4 | Auth0 employee-only identity cutover |
+| 12 | toolshed | 4 | Enable temporary probe domain |
+| 13 | toolshed | 4 | Remove probe domain; enable first partner domain |
 
-PRs 1–4 were implemented and passed CI on branches `g2-canonical-identity`, `g3a-unify-authorization-evaluator`, `g1-authorization-state-safety`, and `g4-authorization-conformance-suite`. PR 8 was implemented on `g3b-batched-listing-decisions`. Those branches are pushed; the PRs were closed pending this replan and can be reopened.
+Phase 3 is split so the two narrow custom-policy types go first as a live rehearsal of the procedure *including the rollback*, before touching `app` and the anchor trio.
+
+PRs 1–4 were implemented and passed CI on branches `g2-canonical-identity`, `g3a-unify-authorization-evaluator`, `g1-authorization-state-safety`, and `g4-authorization-conformance-suite`. PR 9 was implemented on `g3b-batched-listing-decisions`. Those branches are pushed; the PRs were closed pending this replan and can be reopened.
+
+Implementation handoff: [implementation_prompt.md](./implementation_prompt.md).
 
 ## Decisions
 

--- a/plans/external_users/implementation_v2.md
+++ b/plans/external_users/implementation_v2.md
@@ -2,294 +2,121 @@
 
 ## Goal
 
-Allow verified users from approved external domains to log in without changing employee access. Ship authorization, employee-only Auth0, and external access as separate releases.
+Let approved external users log in to valon.tools without internal users losing access, by moving employees from an implicit `defaultRole` grant to explicit `valon-employees` group membership.
 
-## What failed
+## The migration is one substitution
 
-1. **Incomplete employee migration.** The roster was derived from subjects already present in production authorization relationships instead of reconciling an employee authority against the Gestalt `users` table. Its validator checked that same incomplete source. The deployed roster contained 67 UUIDs and six email-form subjects.
-2. **Inconsistent authorization.** Operation `CheckAccess` supported subject sets, but mounted UI, catalog, and app-admin paths did not share that evaluator. [#3061](https://github.com/valon-technologies/gestalt/pull/3061) introduced direct-only catalog checks. [#3062](https://github.com/valon-technologies/gestalt/pull/3062) added subject-set traversal to the mounted-role helper, which the catalog reused, but app-admin checks remained direct-only.
+Everything here serves a single change:
+
+> **`app.defaultRole: viewer` (implicit, grants everyone) → `valon-employees` group membership (explicit, grants employees).**
+
+`defaultRole` is a blanket allow. Once an external can authenticate, `defaultRole` hands them viewer on everything, so it must be gone before the first external logs in. That one flip is the only risky step; the rest of this plan exists to make it safe and to make it reversible.
+
+**Rollback is re-adding `defaultRole` and redeploying.** Group memberships are additive, so they stay in place through a revert and cost nothing. This is why this plan needs no snapshot/rollback subsystem: the risky delta is a single config field.
+
+## What failed last time
+
+1. **Incomplete employee migration.** The roster was derived from subjects already present in production authorization relationships instead of reconciling an employee authority against the Gestalt `users` table. Its validator checked that same incomplete source. The deployed roster contained 67 UUIDs and six email-form subjects; production had 358 users, of whom only 64 matched.
+2. **Inconsistent authorization.** Operation `CheckAccess` supported subject sets, but mounted UI, catalog, and app-admin paths did not share that evaluator. [#3061](https://github.com/valon-technologies/gestalt/pull/3061) introduced direct-only catalog checks. [#3062](https://github.com/valon-technologies/gestalt/pull/3062) added subject-set traversal to the mounted-role helper, but app-admin checks remained direct-only. An employee *in* the group was still denied.
 3. **Bad policy migration.** Setting the shared app wildcard to `[nobody]` denied 713 operations that previously relied on wildcard viewer access. [Toolshed #4062](https://github.com/valon-technologies/toolshed/pull/4062) restored `[viewer, user, editor, admin]`.
-4. **Untested Auth0 configuration.** The cutover exposed an issuer mismatch and missing connection/HRD setup, followed by HS256 tokens. Tenant changes were mutable and partly out of band.
+4. **Untested Auth0 configuration.** The cutover exposed an issuer mismatch and missing connection/HRD setup, followed by HS256 tokens.
 5. **Unsafe deployment state.** No-traffic Cloud Run candidates could overwrite shared authorization state during startup. Traffic rollback did not restore that state.
-6. **Non-reproducible binaries.** `GESTALTD_PINNED_SHA` was mutable and outside the Toolshed commit.
-7. **Oversized hotfix.** [#4071](https://github.com/valon-technologies/toolshed/pull/4071) added 5,762 direct grants and failed startup probes. [#4073](https://github.com/valon-technologies/toolshed/pull/4073) restored the prior repository tree and deployed successfully; its employee UI/CLI verification was not recorded.
+6. **Oversized hotfix.** [#4071](https://github.com/valon-technologies/toolshed/pull/4071) added 5,762 direct grants and failed startup probes. [#4073](https://github.com/valon-technologies/toolshed/pull/4073) restored the prior tree.
 
-The current production users-table comparison finds 358 users, of whom 64 match the 67 roster UUIDs; 294 are absent and three roster UUIDs are orphaned. All six email-form entries duplicate UUID-backed users. These counts prove that the inventory process was incomplete, not that all 294 records were active employees.
+Findings 1 and 2 are the causes of employee access loss. Everything else made recovery harder.
 
-The current users table maps Dave and Kevon to canonical UUIDs absent from the historical roster. That is the leading explanation for their post-[#4072](https://github.com/valon-technologies/toolshed/pull/4072) authorization failures: subject-set traversal cannot grant access to a UUID outside the set, and a focused regression test reproduces that behavior. The incident did not preserve a versioned users-table snapshot and request-subject report, so the person-specific conclusion is not treated as proven.
+Root cause of 2, found while implementing this plan: `resolvePrincipalUserID` treated any subject without an `@` as already canonical, so a provider-opaque subject such as `auth0|abc` reached authorization unresolved and matched no relationship.
 
 ## Non-negotiables
 
-- Keep Google login until explicit employee authorization passes and soaks.
-- Build employee eligibility from an approved People/Identity authority, joined to canonical Gestalt users; never infer employment from authorization rows or email domain alone.
-- Block only on active employees without one canonical user, ambiguous internal identities, and roster entries not backed by active employment.
-- Store the restricted employee-to-user join outside source control; commit only its digest and aggregate reconciliation results.
-- Recompute that join immediately before activation and provision future employee membership before first login.
-- Never use `[nobody]` as the shared app wildcard.
-- Do not replace group access with generated per-user/per-app grants.
+- Keep Google login until employee authorization passes and soaks.
+- Build `valon-employees` from an approved People/Identity authority (Rippling), joined to canonical Gestalt users by normalized email. **Never** infer employment from authorization rows or email domain.
+- **Never** use `[nobody]` as the shared app wildcard. Keep `actions: "*": relations: [viewer, user, editor, admin]`.
+- **Never** generate per-user/per-app grants. One grant per app for the group.
 - A no-traffic candidate must not mutate active authorization state.
-- Pin runtime, providers, config, static authorization, Auth0 tenant state, and GSM secret version IDs; audit runtime grant changes.
-- Roll back on the first failed gate; do not stack hotfixes.
+- Roll back on the first failed check; do not stack hotfixes.
 - Keep federated logout out of this rollout.
 
-## Rollout manifest
+## Deliberately out of scope
 
-Before each stack, commit one machine-readable manifest with:
+Cut from the earlier draft of this plan because the flip is reversible by construction:
 
-- final reviewed SHA, immutable input digests, secret version IDs, and previous-state references;
-- named owner, incident commander, approvers, and protected production environment;
-- literal plan/apply/verify/rollback commands and expected output artifacts;
-- numeric relationship-count, authorization-diff, startup, readiness, and denial thresholds;
-- verifier IDs, checks, settle-period end, and explicit success criteria.
+| Cut | Why |
+| --- | --- |
+| Explicit authorization `plan`/`apply`/`rollback`, diff/count budgets, atomic activation | Rollback is one config field. A snapshot subsystem is insurance against an irreversible change this is not. |
+| Isolated-hostname candidate, shadow evaluation, per-stack rollout manifests | Same. Verification happens with `defaultRole` still active, where mistakes are free. |
+| Catalog/MCP listing authorization | Leaks app *names* to externals, not access. Required before externals log in (Phase 4), not before the employee flip. |
 
-CI rejects missing values and unresolved high/medium findings. The deployment workflow consumes the manifest, allows one production run at a time, and cancels queued runs after failure. Resumption requires an incident-commander approval recorded in a new manifest revision.
+## Phase 1 — Make group membership work
 
-## Verifiers
+Correctness only. `defaultRole` stays on, so **no one's access changes**.
 
-- **Dedicated employee canary:** canonical UUID with group-only access and no direct grants.
-- **Dave:** fresh browser and CLI session.
-- **Kevon:** fresh browser and MCP session.
-- **Named employee app admin:** management and user-lookup paths.
-- **External probe:** verified, pre-created database user; public signup disabled.
+- Route every authorization boundary through the canonical `user:<uuid>` subject; fail closed on unresolved or provider-opaque subjects.
+- Replace the direct-only relationship scans in mounted UI and app admin with the shared evaluator, so group and subject-set grants are honored.
+- Stop server startup from writing active authorization state unless explicitly told to, and wire exactly one revision to own that write.
+- Land the conformance suite covering direct, one-level, nested, cyclic, malformed and paginated grants across mounted UI, catalog, app admin, invocation and MCP.
 
-Required employee checks:
+**Check:** current-access regression for Dave, Kevon, and an app admin. Nothing should change for anyone.
 
-- `/apps` includes expected integrations.
-- Meal Swap, AI Spend, and Build load.
-- Fresh CLI session can run read-only Linear and Slack operations.
-- MCP lists and successfully calls read-only Linear and Slack operations.
-- Employee app-admin management and authorized lookup paths work.
+**Note:** `CheckAccess` is action-shaped and there is no effective-roles RPC, so a policy-shaped resource type that declares relations but no actions makes the evaluator deny a question it cannot represent. A bounded transition shim keeps the legacy direct-grant path working in exactly that case and logs a warning. **If that warning never fires in production, the shim is safe to delete** — and its absence is the evidence Phase 2 needs.
 
-Required negative checks:
+## Phase 2 — Build the roster, additively
 
-- An ungranted identity cannot see or invoke internal apps.
-- An external probe sees home only before a grant.
-- A grant exposes only the selected app role and the actions that role permits.
-- An external app admin cannot enumerate users or manage another app.
-- Revoke removes access promptly.
+Still additive. `defaultRole` stays on, so **still no access change**.
 
-## Stack A — Gestalt correctness
+- Export active employees from Rippling. Join normalized Valon emails to canonical Gestalt user UUIDs.
+- Create `valon-employees` and add memberships from that join.
+- Add **one grant per app for the group**. Not per user.
+- Store the employee↔user join outside source control; commit only its digest and aggregate counts.
 
-### G1 — Deployment-safe authorization state
+**Gate — this is the check that would have caught the original failure:**
 
-- Remove implicit active-state writes from normal server startup before any production candidate is started.
-- Add explicit authorization `plan`, `apply`, and `rollback`.
-- Record model digest, relationship digest, previous snapshot, and exact rollback command.
-- Make activation atomic and prevent candidate, old-revision, and concurrent runtime-grant races.
-- Store the gestaltd SHA and resolved image digest in the deployment bundle, not a mutable repository variable.
-- Reject authorization plans that exceed the predeclared count, diff, startup, or readiness budgets.
+1. Every active Rippling employee resolves to exactly one Gestalt UUID and is in the group. Zero unmapped, zero ambiguous, zero duplicates.
+2. Every Gestalt user who authenticated in the last 30 days is either in the group or an identified non-employee. **Reconcile the count explicitly** — the original roster was 67 against 358 users and nothing flagged it.
+3. Recompute the join immediately before Phase 3 and stop on any employee-relevant change.
 
-### G2 — Canonical identity
+## Phase 3 — Flip
 
-- Resolve verified `user:<email>` to persisted `user:<uuid>` before every authorization boundary.
-- Fail closed when user-store resolution fails.
-- Reject or explicitly map opaque subjects such as `user:auth0|...`.
-- Prove Google and Auth0 tokens for the same verified email resolve to the same existing UUID across browser, CLI, API token, and MCP.
+The one risky step.
 
-### G3 — One authorization decision engine
+- Remove `defaultRole` from the `app` resource type. Change nothing else.
+- Keep the wildcard at `[viewer, user, editor, admin]`.
 
-- Put direct grants, subject sets, default roles, policy aliases, and action precedence in one provider-owned evaluator.
-- Make `CheckAccess`, batch checks, and effective-role queries thin views over that evaluator; no server path may traverse relationships independently.
-- Implement catalog and MCP listing as batched decisions from the same evaluator used for invocation.
-- Centralize app key, resource type/ID, and `authorizationPolicy` mapping.
-- Cover mounted UI, catalog, management paths, app admin, lookup, operation invocation, and MCP tool listing/calls.
-- Restrict user lookup to an explicit employee operator role; app-scoped administration alone must not permit user enumeration.
-- Bound evaluator traversal by depth and work count; fail closed on malformed sets.
+**Verify immediately** (within 15 minutes), with real people, not synthetic subjects:
 
-### G4 — Conformance suite
+- Dave: fresh browser and CLI session.
+- Kevon: fresh browser and MCP session.
+- An app admin: management and user-lookup paths.
+- `/apps` lists the expected integrations; Meal Swap, AI Spend and Build load.
+- A fresh CLI session runs read-only Linear and Slack operations; MCP lists and calls them.
 
-Use the real authorization evaluator for at least one integration suite. Cover:
+**Rollback:** re-add `defaultRole`, redeploy. Memberships stay. Do this on the first failure rather than diagnosing live.
 
-- direct, one-level, nested, cyclic, malformed, and paginated grants;
-- group-derived admin;
-- custom policy aliases and dedicated resource types;
-- employee, elevated admin, ungranted external, granted external, and revoked external;
-- external app-admin isolation and user-lookup denial;
-- browser, CLI exchange, API token, MCP `tools/list`, and MCP calls.
+Repeat the checks at 30 minutes and the next business morning. Soak one business day before Phase 4.
 
-### Gate A
+## Phase 4 — Externals
 
-1. Complete G1 before starting any candidate connected to production authorization storage.
-2. Validate the Stack A rollout manifest and pin the exact G4 image digest.
-3. Deploy under Google with current default-role behavior unchanged.
-4. Run the current-access regression matrix for all employee verifiers.
-5. Run the dedicated group-only canary in a production-shaped isolated environment with `defaultRole` removed.
-6. Execute the manifest rollback command on any failure.
+- Land catalog and MCP listing authorization so an ungranted identity cannot enumerate internal apps or tools.
+- Auth0 employee-only cutover: verify issuer matches discovery, RS256 + JWKS, correct audience, ID-token and userinfo subjects match, callbacks/logout allowlisted, Google Workspace connection and HRD enabled, database login and public signup disabled, `allowedDomains: [valon.com]`. Run a real authorization-code flow against the exact candidate before deploying. Shift traffic atomically; never split across issuers.
+- Probe: one temporary domain, one pre-created verified user. Confirm no-grant sees home only, a grant exposes only the selected app, revoke removes access promptly, and employees are unaffected. Remove the temporary domain.
+- First partner: one approved domain, a small named cohort, public signup stays disabled.
 
-## Stack B — Employee authorization under Google
+## PRs
 
-### T1 — Inventory and roster validation
+| # | Repo | Phase | Content |
+| --- | --- | --- | --- |
+| 1 | gestalt | 1 | Canonical identity at every authorization boundary |
+| 2 | gestalt | 1 | Mounted UI + app admin decide through the evaluator |
+| 3 | gestalt | 1 | Startup authorization-state write gated behind explicit apply |
+| 4 | gestalt | 1 | Conformance suite |
+| 5 | toolshed | 1 | Wire the state-apply flag to the one owning revision; deploy Phase 1 |
+| 6 | toolshed | 2 | `valon-employees` roster, memberships, per-app group grants, reconciliation gate |
+| 7 | toolshed | 3 | Remove `defaultRole` |
+| 8 | gestalt | 4 | Catalog + MCP listing authorization |
+| 9+ | toolshed | 4 | Auth0 cutover, probe, first partner |
 
-- Resolve every app’s key, resource type/ID, policy alias, valid relations, mounted roles, management path, and registered operations.
-- Explicitly cover Talent Team, Rippling, Traffic Cop, agent-trace-viewer, and other dedicated policies.
-- Export the approved active-employee authority and join normalized employee emails to canonical Gestalt users.
-- Verify every employee entry is a unique, canonical Gestalt UUID and every roster UUID resolves to exactly one users-table record.
-- Generate membership from that join, never from existing authorization relationships.
-- Require zero unmapped employees, zero ambiguous internal identities, zero duplicate UUIDs, and zero roster entries absent from the employee authority.
-- Commit the source and join digests plus aggregate results, not raw email/UUID pairs. Unrelated external and stale users require no classification.
-- Document lookup, classification, onboarding, removal, and emergency correction. Employee onboarding must add membership before first Gestalt login.
+PRs 1–4 were implemented and passed CI on branches `g2-canonical-identity`, `g3a-unify-authorization-evaluator`, `g1-authorization-state-safety`, and `g4-authorization-conformance-suite`. Those branches are pushed; the PRs were closed pending this replan and can be reopened.
 
-### T2 — Preseed, shadow, activate
+## Open question
 
-1. Add compact employee memberships and subject-set grants while `defaultRole` remains active.
-2. Capture the current effective-access matrix for every approved employee, resource, and registered action.
-3. Shadow-evaluate the proposed no-default model against that baseline through the canonical evaluator and each server surface.
-4. Require zero unexplained employee denials and zero unexpected control-user allows.
-5. Recompute the active-employee-to-user join immediately before apply; stop on any employee-relevant change.
-6. Apply the no-default snapshot under Google.
-7. Keep:
-
-   ```yaml
-   actions:
-     "*":
-       relations: [viewer, user, editor, admin]
-   ```
-
-### Gate B
-
-1. Validate the Stack B rollout manifest, employee join, previous authorization snapshot, and rollback command.
-2. Require every approved employee UUID to pass the shadow evaluation before removing `defaultRole`.
-3. Require the authorization plan to remain within the declared count, diff, startup, and readiness budgets.
-4. Apply T2.
-5. Run all verifier and negative checks, including the permanently group-only canary.
-6. Repeat checks after 30 minutes and the next business morning.
-7. Soak for one business day.
-8. On failure, execute the manifest rollback command to reactivate the previous authorization snapshot and runtime bundle atomically.
-
-## Stack C — Employee-only Auth0
-
-### T3 — Versioned Auth0 state and live preflight
-
-Provision a dedicated Auth0 client and its connections additively before building the candidate. Record the exact client, enabled connections, HRD domains, callback/logout URLs, signing algorithm, database signup setting, and GSM secret version IDs in the Stack C rollout manifest. Diff live state against it, then run a real authorization-code flow. Verify:
-
-- configured issuer exactly matches discovery;
-- ID token uses RS256 and passes JWKS verification;
-- audience is correct;
-- ID-token and userinfo subjects match;
-- email is verified and normalizes correctly;
-- callbacks and logout URLs are allowlisted;
-- Google Workspace connection and HRD are enabled;
-- database login and public signup are disabled;
-- pinned GSM versions and IAM are correct;
-- `allowedDomains` is `[valon.com]`.
-
-Freeze this Auth0 client and its secret references after preflight. Later steps may only route traffic between the immutable Google and Auth0 revisions. Do not weaken issuer or algorithm validation.
-
-### T4 — Isolated candidate
-
-- Build the production candidate already bound to the frozen Auth0 client, config, and secret versions; deploy it on a separate hostname.
-- Preserve a controlled copy of production user UUIDs.
-- Isolate authorization relationships, grants, and sessions.
-- Seed the exact production authorization snapshot.
-- Run all employee, identity-continuity, renewal, account-switching, and domain-rejection checks.
-
-This proves artifact compatibility, not production routing, cookies, or shared-state behavior.
-
-### T5 — Production candidate
-
-- Deploy the exact T4 image and frozen configuration as a tagged no-traffic production revision.
-- Verify its runtime digest, provider refs, config, Auth0 state, secret versions, readiness, and lack of authorization-state mutation.
-- Keep external/database login disabled.
-- Do not mutate Auth0, GSM references, authorization, or runtime configuration after verification.
-
-### Gate C
-
-1. Validate the Stack C rollout manifest and rehearse its single-step traffic rollback to the immutable Google revision.
-2. Reverify the tagged candidate and all frozen-state digests.
-3. Record each verifier’s normalized email subject and canonical UUID without logging tokens.
-4. Cut over with one traffic-routing update to the verified Auth0 revision; never split traffic across issuers.
-5. Run all employee checks within 15 minutes.
-6. Reverse only that routing update on login failure, UUID change, empty catalog, UI denial, or CLI/MCP denial.
-7. Soak for one business day.
-
-## Stack D — External pilot
-
-### T6 — Immutable probe candidate
-
-- Provision a separate pilot Auth0 client additively with Google Workspace, a database connection, public signup disabled, one pre-created verified user, and one temporary allowed domain.
-- Freeze that client and its secret versions, then build and deploy a tagged no-traffic revision bound to them.
-- Verify employee login, probe login, no-grant behavior, and frozen-state digests on the candidate hostname.
-- Do not mutate the active employee-only Auth0 client or revision.
-
-### Gate D
-
-1. Validate the Stack D rollout manifest and rehearse one-step traffic rollback to the employee-only Auth0 revision.
-2. Route traffic to the verified probe revision.
-3. Run app-role grant, cross-app/admin isolation, revoke, and employee-regression checks. Use runtime relationships for grant/revoke.
-4. Route back to the employee-only revision after the probe, then disable the unused pilot client.
-
-### T7 — First partner
-
-- Build a new frozen client/configuration and runtime revision for one approved domain and a small pre-created cohort; keep public signup disabled.
-- Add later users from that domain by pre-creating identities and runtime grants; this does not require a new client.
-- Require a new frozen client and runtime revision only when domains or authentication policy change.
-
-### Gate E
-
-1. Validate the partner rollout manifest and rehearse traffic rollback to the employee-only or previous partner revision.
-2. Route traffic to the verified partner revision.
-3. Run employee, no-grant, grant, isolation, revoke, renewal, and account-switching checks.
-4. Roll back only on failure; retain the partner revision after the defined soak succeeds.
-
-## Gate outputs
-
-- **Gate A:** Gestalt image digest; conformance report; server-surface report; startup/readiness results; rollback rehearsal.
-- **Gate B:** employee-source and join digests; aggregate reconciliation; baseline/shadow diff; authorization plan and snapshot digests; canary/verifier results.
-- **Gate C:** frozen Auth0-state and GSM-version digests; Google/Auth0 revision IDs; identity-continuity results; traffic rollback rehearsal.
-- **Gate D:** frozen pilot Auth0/GSM/runtime digests; named cohort; domain and connection state; revision IDs; traffic rollback rehearsal; exact runtime grant diff; no-grant/grant/isolation/revoke results; employee regression.
-- **Gate E:** frozen partner Auth0/GSM/runtime digests; named cohort and domain; previous/partner revision IDs; rollback rehearsal; full verifier results; soak result.
-
-Every output is produced by a literal manifest command and checked against that stack's numeric thresholds. Gate A does not require later-stack inventory or Auth0 evidence.
-
-Rollback immediately for any verifier failure, UUID change, employee access loss, unexpected external access, candidate readiness failure, inventory/Auth0/authorization drift, or exceeded deployment budget.
-
-## Stacking
-
-Each stack's items land as its own PR, git-stacked within the stack. A stack does not merge into the next stack's branch — it gates it: the next stack's PRs may be authored in parallel, but the candidate they build does not deploy or take traffic until the prior stack's Gate passes. Gate C, D, and E cutovers are traffic-routing actions driven by that stack's rollout manifest, not separate PRs.
-
-```text
-main
- ├── gestalt PR A1 — G1 deployment-safe authorization state
- │    └── gestalt PR A2 — G2 canonical identity
- │         └── gestalt PR A3 — G3 one authorization decision engine
- │              └── gestalt PR A4 — G4 conformance suite
- │                                                       ⇣ Gate A
- ├── toolshed PR B1 — T1 inventory and roster validation
- │    └── toolshed PR B2 — T2 preseed, shadow, activate
- │                                                       ⇣ Gate B
- ├── toolshed PR C1 — T3 versioned Auth0 state + live preflight
- │    └── toolshed PR C2 — T4 isolated candidate
- │         └── toolshed PR C3 — T5 production candidate (no-traffic)
- │                                                       ⇣ Gate C (traffic cutover, no PR)
- └── toolshed PR D1 — T6 immutable probe candidate
-                                                         ⇣ Gate D (probe traffic, no PR)
-      └── toolshed PR D2 — T7 first partner
-                                                         ⇣ Gate E (partner cutover, no PR)
-```
-
-| PR | Repo | Base branch | Depends on | Gates activation |
-| --- | --- | --- | --- | --- |
-| A1 | gestalt | `main` | — | — |
-| A2 | gestalt | A1 | A1 merged | — |
-| A3 | gestalt | A2 | A2 merged | — |
-| A4 | gestalt | A3 | A3 merged | Gate A |
-| B1 | toolshed | `main` | Gate A passed | — |
-| B2 | toolshed | B1 | B1 merged | Gate B |
-| C1 | toolshed | `main` | Gate B passed | — |
-| C2 | toolshed | C1 | C1 merged | — |
-| C3 | toolshed | C2 | C2 merged | Gate C |
-| D1 | toolshed | `main` | Gate C passed | Gate D |
-| D2 | toolshed | D1 | D1 merged; Gate D clean | Gate E |
-
-`gestalt-providers` has no PR in this plan unless T3's live preflight surfaces a concrete provider gap (issuer/algorithm/subject handling) — land that as an unstacked, independently reviewed provider PR before C1 resumes, per "Do not weaken issuer or algorithm validation."
-
-Each stack's rollout manifest (see "Rollout manifest") is committed as part of that stack's first PR (A1, B1, C1, D1) and amended by later PRs in the same stack, not filed as a separate change.
-
-## Process
-
-1. **Stack A (gestalt correctness)** — Land A1–A4. G1 must be complete and merged before any candidate connects to production authorization storage. Validate the manifest, pin the G4 image digest, deploy under Google with `defaultRole` unchanged, run the current-access regression matrix, then run the dedicated group-only canary with `defaultRole` removed in an isolated environment. Execute the manifest rollback on any failure; do not proceed to Stack B until Gate A passes.
-2. **Stack B (employee authorization under Google)** — Land B1–B2. B1 builds and validates the employee-to-user join with zero unmapped/ambiguous/duplicate entries. B2 preseeds compact memberships under `defaultRole`, shadow-evaluates the no-default model against the captured baseline, recomputes the join immediately before apply, then activates the no-default snapshot while keeping the wildcard at `[viewer, user, editor, admin]`. Run Gate B: apply, run all verifier and negative checks including the permanent group-only canary, repeat at 30 minutes and next business morning, soak one business day. On failure, execute the manifest rollback to reactivate the previous snapshot and runtime bundle atomically.
-3. **Stack C (employee-only Auth0)** — Land C1–C3. C1 provisions the Auth0 client and connections additively, freezes them, and runs live preflight against the frozen client — no deploy. C2 deploys the frozen bundle to an isolated hostname with a controlled copy of production UUIDs and the production authorization snapshot. C3 deploys the same immutable bundle as a tagged no-traffic production revision with external/database login still disabled. Run Gate C: reverify frozen-state digests, record verifier UUIDs, cut over with one traffic-routing update (never split traffic across issuers), run all employee checks within 15 minutes, reverse only that routing update on failure, then soak one business day before Stack D.
-4. **Stack D (external pilot)** — Land D1: provision a separate pilot Auth0 client additively, freeze it, deploy a tagged no-traffic revision. Run Gate D: route traffic to the probe revision, run grant/isolation/revoke/employee-regression checks via runtime relationships only, route back and disable the unused pilot client. Land D2 once Gate D is clean: build a new frozen client/revision for one approved partner domain and named cohort, public signup still disabled. Run Gate E: route traffic to the partner revision, run the full verifier set plus renewal and account-switching checks, roll back only on failure, retain the revision after soak succeeds.
-
-Every PR requires the manifest for its stack to validate in CI (no missing values, no unresolved high/medium findings) before merge. Every Gate requires that stack's rollback command to be rehearsed and confirmed valid before the cutover it gates.
+**What do external users actually need access to?** If it is one or two specific apps rather than broad access, running them against a separate Gestalt instance avoids the employee migration entirely — no `defaultRole` removal, no roster, no flip. The whole risk here comes from externals sharing an authorization surface with employees.

--- a/plans/external_users/implementation_v2.md
+++ b/plans/external_users/implementation_v2.md
@@ -4,11 +4,28 @@
 
 Let approved external users log in to valon.tools without internal users losing access, by moving employees from an implicit `defaultRole` grant to explicit `valon-employees` group membership.
 
+**External users get authentication only.** They sign in, reach the valon.tools home page, and get nothing else: no apps visible, no operations invocable, zero authorization grants. Per-partner access, if it is ever wanted, is a later decision driven by a real requirement.
+
+Externals share the valon.tools instance with employees (decided; see [Decisions](#decisions)). That is what makes this migration necessary rather than optional: `defaultRole` is a blanket allow, so the moment an external can authenticate they inherit viewer on everything unless it is gone.
+
 ## The migration is one substitution
 
 Everything here serves a single change:
 
-> **`app.defaultRole: viewer` (implicit, grants everyone) → `valon-employees` group membership (explicit, grants employees).**
+> **`defaultRole` on every resource type that declares one (implicit, grants everyone) → `valon-employees` group membership (explicit, grants employees).**
+
+It is **not** just `app`. As of `toolshed/valon-tools/deploy/config.yaml` six resource types carry a `defaultRole`:
+
+| Resource type | `defaultRole` | Note |
+| --- | --- | --- |
+| `agent-trace-viewer` | `viewer` | YAML anchor `&defaultAuthzResource` |
+| `workflow` | `viewer` | alias of that anchor |
+| `agent` | `viewer` | alias of that anchor |
+| `app` | `viewer` | |
+| `pmiPayoffCancellations` | `admin` | an authenticated external would inherit **admin** |
+| `itAccountOnboarding` | `noaccess` | non-empty, so still an allow — see below |
+
+Two traps here. The anchor/alias means editing `agent-trace-viewer` silently changes `workflow` and `agent` too, and grepping for `defaultRole` finds only four of the six sites. And `noaccess` is not a deny: `authorizeMountedResourceRoles` allows whenever `defaultRole != "" && len(allowedRoles) == 0`, so any non-empty value authorizes a mount that restricts no roles. Clear the field; do not set it to a sentinel.
 
 `defaultRole` is a blanket allow. Once an external can authenticate, `defaultRole` hands them viewer on everything, so it must be gone before the first external logs in. That one flip is the only risky step; the rest of this plan exists to make it safe and to make it reversible.
 
@@ -45,7 +62,7 @@ Cut from the earlier draft of this plan because the flip is reversible by constr
 | --- | --- |
 | Explicit authorization `plan`/`apply`/`rollback`, diff/count budgets, atomic activation | Rollback is one config field. A snapshot subsystem is insurance against an irreversible change this is not. |
 | Isolated-hostname candidate, shadow evaluation, per-stack rollout manifests | Same. Verification happens with `defaultRole` still active, where mistakes are free. |
-| Catalog/MCP listing authorization | Leaks app *names* to externals, not access. Required before externals log in (Phase 4), not before the employee flip. |
+Catalog and MCP listing authorization is **not** cut. `FilterCatalogForPrincipal` is currently `return cat` — it ignores the principal — and MCP `tools/list` filters only on token scope. An authenticated external with zero grants would therefore see the entire internal app catalog and every tool, even though it could invoke none of them. "No apps visible" makes that a hard prerequisite for Phase 4, not a follow-up. It is still not required for the employee flip, so it lands between Phase 3 and externals.
 
 ## Phase 1 — Make group membership work
 
@@ -64,23 +81,26 @@ Correctness only. `defaultRole` stays on, so **no one's access changes**.
 
 Still additive. `defaultRole` stays on, so **still no access change**.
 
+- **Enumerate every resource type that declares a `defaultRole`**, resolving YAML anchors and aliases rather than grepping — the six in the table above are the current answer, but re-derive it from the deployed config rather than trusting this doc. This list is exactly the set of grants the group needs, and exactly the set Phase 3 clears.
 - Export active employees from Rippling. Join normalized Valon emails to canonical Gestalt user UUIDs.
 - Create `valon-employees` and add memberships from that join.
-- Add **one grant per app for the group**. Not per user.
+- Add **one grant per resource type for the group** — matching the role each `defaultRole` currently confers, so employees keep exactly what they have today. Not per user.
 - Store the employee↔user join outside source control; commit only its digest and aggregate counts.
 
 **Gate — this is the check that would have caught the original failure:**
 
 1. Every active Rippling employee resolves to exactly one Gestalt UUID and is in the group. Zero unmapped, zero ambiguous, zero duplicates.
 2. Every Gestalt user who authenticated in the last 30 days is either in the group or an identified non-employee. **Reconcile the count explicitly** — the original roster was 67 against 358 users and nothing flagged it.
-3. Recompute the join immediately before Phase 3 and stop on any employee-relevant change.
+3. Every resource type carrying a `defaultRole` has a corresponding group grant. A resource type cleared in Phase 3 without one silently revokes whatever that `defaultRole` was providing.
+4. Recompute the join immediately before Phase 3 and stop on any employee-relevant change.
 
 ## Phase 3 — Flip
 
 The one risky step.
 
-- Remove `defaultRole` from the `app` resource type. Change nothing else.
-- Keep the wildcard at `[viewer, user, editor, admin]`.
+- **Clear `defaultRole` from every resource type enumerated in Phase 2** — omit the field entirely; do not set `noaccess` or any other sentinel, which still reads as an allow. Remember the anchor: clearing `agent-trace-viewer` also clears `workflow` and `agent`, and that is intended, but confirm the rendered config rather than the source YAML.
+- Change nothing else. Keep the wildcard at `[viewer, user, editor, admin]`.
+- Highest-risk item to confirm cleared: `pmiPayoffCancellations`, whose `defaultRole: admin` would otherwise hand an authenticated external admin.
 
 **Verify immediately** (within 15 minutes), with real people, not synthetic subjects:
 
@@ -88,6 +108,7 @@ The one risky step.
 - Kevon: fresh browser and MCP session.
 - An app admin: management and user-lookup paths.
 - `/apps` lists the expected integrations; Meal Swap, AI Spend and Build load.
+- The apps behind the non-`app` resource types still work: agent trace viewer, workflows, agents, `pmiPayoffCancellations`, and `itAccountOnboarding`. These are the ones a roster built only around `app` would silently break.
 - A fresh CLI session runs read-only Linear and Slack operations; MCP lists and calls them.
 
 **Rollback:** re-add `defaultRole`, redeploy. Memberships stay. Do this on the first failure rather than diagnosing live.
@@ -96,10 +117,24 @@ Repeat the checks at 30 minutes and the next business morning. Soak one business
 
 ## Phase 4 — Externals
 
-- Land catalog and MCP listing authorization so an ungranted identity cannot enumerate internal apps or tools.
-- Auth0 employee-only cutover: verify issuer matches discovery, RS256 + JWKS, correct audience, ID-token and userinfo subjects match, callbacks/logout allowlisted, Google Workspace connection and HRD enabled, database login and public signup disabled, `allowedDomains: [valon.com]`. Run a real authorization-code flow against the exact candidate before deploying. Shift traffic atomically; never split across issuers.
-- Probe: one temporary domain, one pre-created verified user. Confirm no-grant sees home only, a grant exposes only the selected app, revoke removes access promptly, and employees are unaffected. Remove the temporary domain.
-- First partner: one approved domain, a small named cohort, public signup stays disabled.
+**Prerequisite.** Land catalog and MCP listing authorization first. Without it an authenticated external sees every internal app and tool. This must be deployed and verified against an ungranted identity *before* any external domain is enabled.
+
+**Auth0 employee-only cutover.** Verify issuer matches discovery, RS256 + JWKS, correct audience, ID-token and userinfo subjects match, callbacks/logout allowlisted, Google Workspace connection and HRD enabled, database login and public signup disabled, `allowedDomains: [valon.com]`. Run a real authorization-code flow against the exact candidate before deploying. Shift traffic atomically; never split across issuers. Soak one business day.
+
+**Probe.** One temporary domain, one pre-created verified user, no grants. Confirm:
+
+- login succeeds and `GET /api/v1/auth/session` returns a `user:<uuid>`;
+- home renders and **`/apps` is empty**;
+- MCP `tools/list` returns nothing and `tools/call` refuses;
+- direct operation invocation is denied;
+- a non-allowlisted domain is rejected at the Gestalt callback;
+- employees are unaffected throughout.
+
+Remove the temporary domain afterwards.
+
+**First partner.** One approved domain, a small named cohort, public signup stays disabled. Repeat the checks above.
+
+Externals hold no grants, so grant/revoke workflows and per-app external access are deliberately not built here. Add them when a partner actually needs a specific app.
 
 ## PRs
 
@@ -112,11 +147,15 @@ Repeat the checks at 30 minutes and the next business morning. Soak one business
 | 5 | toolshed | 1 | Wire the state-apply flag to the one owning revision; deploy Phase 1 |
 | 6 | toolshed | 2 | `valon-employees` roster, memberships, per-app group grants, reconciliation gate |
 | 7 | toolshed | 3 | Remove `defaultRole` |
-| 8 | gestalt | 4 | Catalog + MCP listing authorization |
+| 8 | gestalt | 4 | Catalog + MCP listing authorization (**prerequisite for externals**) |
 | 9+ | toolshed | 4 | Auth0 cutover, probe, first partner |
 
-PRs 1–4 were implemented and passed CI on branches `g2-canonical-identity`, `g3a-unify-authorization-evaluator`, `g1-authorization-state-safety`, and `g4-authorization-conformance-suite`. Those branches are pushed; the PRs were closed pending this replan and can be reopened.
+PRs 1–4 were implemented and passed CI on branches `g2-canonical-identity`, `g3a-unify-authorization-evaluator`, `g1-authorization-state-safety`, and `g4-authorization-conformance-suite`. PR 8 was implemented on `g3b-batched-listing-decisions`. Those branches are pushed; the PRs were closed pending this replan and can be reopened.
 
-## Open question
+## Decisions
 
-**What do external users actually need access to?** If it is one or two specific apps rather than broad access, running them against a separate Gestalt instance avoids the employee migration entirely — no `defaultRole` removal, no roster, no flip. The whole risk here comes from externals sharing an authorization surface with employees.
+**Externals share the valon.tools instance with employees.** A separate instance (e.g. `partners.valon.tools`) with no internal apps mounted would have delivered the same external experience — sign in, see nothing — with zero changes to valon.tools and therefore zero employee-access risk. It was rejected because externals must be on the valon.tools hostname itself.
+
+The consequence is that this migration is mandatory rather than optional, and the employee-access risk it carries is accepted deliberately: `defaultRole` cannot be scoped to exclude a subject, so the only way to stop an authenticated external inheriting viewer on everything is to remove it and grant employees explicitly. Phases 1–3 exist to make that removal safe.
+
+**Externals receive no grants.** Authentication only. This removes any need for external grant/revoke tooling in this rollout, and makes the external acceptance criterion simple and testable: an authenticated external sees an empty `/apps` and can invoke nothing.


### PR DESCRIPTION
## Description

Rewrites `plans/external_users/implementation_v2.md` around the single substitution the migration actually requires — `app.defaultRole` (implicit, grants everyone) → `valon-employees` group membership (explicit, grants employees) — and drops the machinery that existed to make an irreversible change survivable.

The key change in framing: **rollback is re-adding `defaultRole` and redeploying.** Group memberships are additive and survive a revert, so the risky delta is one config field. That removes the need for an authorization plan/apply/rollback subsystem, diff/count budgets, atomic activation, shadow evaluation, isolated-hostname candidates, and per-stack rollout manifests.

Restructured into four phases where only Phase 3 carries risk. Phases 1 and 2 are additive with `defaultRole` still active, so verification happens where mistakes are free.

### Kept
The `What failed` forensics (real PR numbers, the 67-roster-vs-358-users reconciliation, the `[nobody]` wildcard that denied 713 operations), the load-bearing non-negotiables, and the root cause found while implementing the earlier version: `resolvePrincipalUserID` treated any subject without an `@` as already canonical, so `auth0|abc` reached authorization unresolved and matched no relationship.

The two findings that actually caused employee access loss are unchanged and still gated:
1. Group membership must be honored at **every** authorization boundary (Phase 1).
2. The roster must come from an employee authority, never from existing authorization rows — with an explicit count reconciliation against recently-authenticated users (Phase 2).

### Scope
11 PRs / 5 gates → 9 PRs, four of which are already implemented and passed CI on preserved branches (`g2-canonical-identity`, `g3a-unify-authorization-evaluator`, `g1-authorization-state-safety`, `g4-authorization-conformance-suite`). Those PRs were closed pending this replan and can be reopened.

### Open question in the doc
If external users only need one or two specific apps, running them against a separate Gestalt instance avoids the employee migration entirely. Worth answering before Phase 1 starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)