### PR TITLE
[gestaltd] canonicalize identity at every authorization boundary

### DIFF
--- a/gestaltd/internal/server/audit.go
+++ b/gestaltd/internal/server/audit.go
@@ -31,7 +31,11 @@ func (s *Server) resolvePrincipalUserID(ctx context.Context, p *principal.Princi
 	if principal.IsNonUserPrincipal(p) {
 		return p, nil
 	}
-	if p.UserID != "" && !strings.Contains(p.UserID, "@") {
+	// Only a persisted user UUID is already canonical. A provider-opaque
+	// subject such as "auth0|abc" or "google-oauth2|123" contains no "@" but
+	// is not canonical, so it must still be resolved through the user store
+	// rather than passed through to an authorization boundary.
+	if principal.ClassifyUserSubjectValue(p.UserID) == principal.UserSubjectFormCanonical {
 		return p, nil
 	}
 	if p.Identity == nil || p.Identity.Email == "" {

--- a/gestaltd/internal/server/authorization_subject_boundary_internal_test.go
+++ b/gestaltd/internal/server/authorization_subject_boundary_internal_test.go
@@ -1,0 +1,359 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+)
+
+const (
+	boundaryCanonicalUserID = "1f8f6b0a-5f52-4f4a-8a3e-3f6f4b2c9d10"
+	boundaryUserEmail       = "dave@valon.com"
+)
+
+// subjectScopedAuthzStub only grants the canonical subject, so any boundary
+// that authorizes the raw token subject is denied.
+type subjectScopedAuthzStub struct {
+	core.AuthorizationProvider
+	grantedSubjectID string
+	relation         string
+}
+
+func (s subjectScopedAuthzStub) ListRelationships(
+	_ context.Context,
+	req *proto.ListRelationshipsRequest,
+) (*proto.ListRelationshipsResponse, error) {
+	subjectID := req.GetFilter().GetTarget().GetSubject().GetId()
+	if subjectID != s.grantedSubjectID {
+		return &proto.ListRelationshipsResponse{}, nil
+	}
+	return &proto.ListRelationshipsResponse{
+		Relationships: []*proto.Relationship{
+			{Tuple: &proto.RelationshipTuple{
+				Resource: req.GetFilter().GetResource(),
+				Relation: s.relation,
+				Target: &proto.RelationshipTarget{
+					Kind: &proto.RelationshipTarget_Subject{
+						Subject: &proto.Subject{Type: "subject", Id: subjectID},
+					},
+				},
+			}},
+		},
+	}, nil
+}
+
+func (subjectScopedAuthzStub) ListActiveModelResourceTypes(
+	context.Context,
+	*proto.ListActiveModelResourceTypesRequest,
+) (*proto.ListActiveModelResourceTypesResponse, error) {
+	return &proto.ListActiveModelResourceTypesResponse{}, nil
+}
+
+type boundaryUserStore struct {
+	usersByEmail map[string]string
+	err          error
+}
+
+func (b boundaryUserStore) FindOrCreateUser(_ context.Context, email string) (*core.User, error) {
+	if b.err != nil {
+		return nil, b.err
+	}
+	id, ok := b.usersByEmail[email]
+	if !ok {
+		return nil, nil
+	}
+	return &core.User{ID: id, Email: email}, nil
+}
+
+func (b boundaryUserStore) GetUser(_ context.Context, id string) (*core.User, error) {
+	if b.err != nil {
+		return nil, b.err
+	}
+	for email, userID := range b.usersByEmail {
+		if userID == id {
+			return &core.User{ID: id, Email: email}, nil
+		}
+	}
+	return nil, core.ErrNotFound
+}
+
+func emailPrincipal() *principal.Principal {
+	return &principal.Principal{
+		SubjectID: principal.UserSubjectID(boundaryUserEmail),
+		Identity:  &core.UserIdentity{Email: boundaryUserEmail},
+		Kind:      principal.KindUser,
+		Source:    principal.SourceBearer,
+	}
+}
+
+func opaquePrincipal() *principal.Principal {
+	return &principal.Principal{
+		SubjectID: principal.UserSubjectID("auth0|abc123"),
+		Kind:      principal.KindUser,
+		Source:    principal.SourceBearer,
+	}
+}
+
+func mountedUIFixture() MountedUI {
+	return MountedUI{
+		Name:                "app:g-issues",
+		AppName:             "g-issues",
+		AppLevelAuth:        true,
+		AuthorizationPolicy: "g-issues",
+		AllowedRoles:        []string{"viewer"},
+	}
+}
+
+func TestMountedUIBoundaryResolvesEmailSubjectToCanonicalUser(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{
+		authorization: subjectScopedAuthzStub{
+			grantedSubjectID: principal.UserSubjectID(boundaryCanonicalUserID),
+			relation:         "viewer",
+		},
+		users: boundaryUserStore{usersByEmail: map[string]string{boundaryUserEmail: boundaryCanonicalUserID}},
+	}
+
+	access, allowed, err := s.authorizeMountedAppAccess(context.Background(), emailPrincipal(), mountedUIFixture())
+	if err != nil {
+		t.Fatalf("authorizeMountedAppAccess: %v", err)
+	}
+	if !allowed {
+		t.Fatal("email-form subject was denied; it must resolve to the canonical user")
+	}
+	if access.Role != "viewer" {
+		t.Fatalf("access.Role = %q, want viewer", access.Role)
+	}
+}
+
+func TestMountedUIBoundaryAllowsCanonicalSubject(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{
+		authorization: subjectScopedAuthzStub{
+			grantedSubjectID: principal.UserSubjectID(boundaryCanonicalUserID),
+			relation:         "viewer",
+		},
+	}
+	p := &principal.Principal{
+		SubjectID: principal.UserSubjectID(boundaryCanonicalUserID),
+		Kind:      principal.KindUser,
+		Source:    principal.SourceBearer,
+	}
+
+	_, allowed, err := s.authorizeMountedAppAccess(context.Background(), p, mountedUIFixture())
+	if err != nil {
+		t.Fatalf("authorizeMountedAppAccess: %v", err)
+	}
+	if !allowed {
+		t.Fatal("canonical subject was denied")
+	}
+}
+
+func TestMountedUIBoundaryDeniesOpaqueSubject(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{
+		authorization: subjectScopedAuthzStub{
+			grantedSubjectID: principal.UserSubjectID("auth0|abc123"),
+			relation:         "viewer",
+		},
+		users: boundaryUserStore{usersByEmail: map[string]string{boundaryUserEmail: boundaryCanonicalUserID}},
+	}
+
+	_, allowed, err := s.authorizeMountedAppAccess(context.Background(), opaquePrincipal(), mountedUIFixture())
+	if err != nil {
+		t.Fatalf("authorizeMountedAppAccess: %v", err)
+	}
+	if allowed {
+		t.Fatal("opaque subject was authorized")
+	}
+}
+
+func TestMountedUIBoundaryFailsClosedOnUserStoreError(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{
+		authorization: subjectScopedAuthzStub{
+			grantedSubjectID: principal.UserSubjectID(boundaryUserEmail),
+			relation:         "viewer",
+		},
+		users: boundaryUserStore{err: errors.New("user store unavailable")},
+	}
+
+	_, allowed, err := s.authorizeMountedAppAccess(context.Background(), emailPrincipal(), mountedUIFixture())
+	if err == nil {
+		t.Fatal("user store failure did not surface an error")
+	}
+	if allowed {
+		t.Fatal("user store failure fell back to the raw token subject")
+	}
+}
+
+func TestMountedUIBoundaryFailsClosedWithoutUserStore(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{
+		authorization: subjectScopedAuthzStub{
+			grantedSubjectID: principal.UserSubjectID(boundaryUserEmail),
+			relation:         "viewer",
+		},
+	}
+
+	_, allowed, err := s.authorizeMountedAppAccess(context.Background(), emailPrincipal(), mountedUIFixture())
+	if err != nil {
+		t.Fatalf("authorizeMountedAppAccess: %v", err)
+	}
+	if allowed {
+		t.Fatal("missing user store fell back to the raw token subject")
+	}
+}
+
+func appAdminRequest(t *testing.T, p *principal.Principal) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/apps/g-issues/admin/registry", nil)
+	req = req.WithContext(principal.WithPrincipal(req.Context(), p))
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("app", "g-issues")
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx))
+}
+
+func TestAppAdminBoundaryResolvesEmailSubjectToCanonicalUser(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{
+		authorization: subjectScopedAuthzStub{
+			grantedSubjectID: principal.UserSubjectID(boundaryCanonicalUserID),
+			relation:         "admin",
+		},
+		users: boundaryUserStore{usersByEmail: map[string]string{boundaryUserEmail: boundaryCanonicalUserID}},
+	}
+	called := false
+	handler := s.appAdminAuthorizationMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		called = true
+	}))
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, appAdminRequest(t, emailPrincipal()))
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+	if !called {
+		t.Fatal("canonical app admin was denied")
+	}
+}
+
+func TestAppAdminBoundaryDeniesOpaqueSubject(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{
+		authorization: subjectScopedAuthzStub{
+			grantedSubjectID: principal.UserSubjectID("auth0|abc123"),
+			relation:         "admin",
+		},
+		users: boundaryUserStore{usersByEmail: map[string]string{boundaryUserEmail: boundaryCanonicalUserID}},
+	}
+	called := false
+	handler := s.appAdminAuthorizationMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		called = true
+	}))
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, appAdminRequest(t, opaquePrincipal()))
+
+	if called {
+		t.Fatal("opaque subject reached the app admin handler")
+	}
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusForbidden)
+	}
+}
+
+func TestAppAdminBoundaryFailsClosedOnUserStoreError(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{
+		authorization: subjectScopedAuthzStub{
+			grantedSubjectID: principal.UserSubjectID(boundaryUserEmail),
+			relation:         "admin",
+		},
+		users: boundaryUserStore{err: errors.New("user store unavailable")},
+	}
+	called := false
+	handler := s.appAdminAuthorizationMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		called = true
+	}))
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, appAdminRequest(t, emailPrincipal()))
+
+	if called {
+		t.Fatal("user store failure fell back to the raw token subject")
+	}
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusServiceUnavailable)
+	}
+}
+
+// TestResolvePrincipalUserIDCanonicalizesOpaqueSubject covers the enrichment
+// path that feeds every authorization boundary. A provider-opaque subject
+// contains no "@", so it must not be mistaken for an already-canonical user
+// ID and passed through to authorization unresolved.
+func TestResolvePrincipalUserIDCanonicalizesOpaqueSubject(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{users: boundaryUserStore{
+		usersByEmail: map[string]string{boundaryUserEmail: boundaryCanonicalUserID},
+	}}
+
+	p := &principal.Principal{
+		SubjectID: principal.UserSubjectID("auth0|abc123"),
+		Identity:  &core.UserIdentity{Email: boundaryUserEmail},
+		Kind:      principal.KindUser,
+		Source:    principal.SourceBearer,
+	}
+
+	enriched, err := s.resolvePrincipalUserID(context.Background(), p)
+	if err != nil {
+		t.Fatalf("resolvePrincipalUserID: %v", err)
+	}
+	if got, want := enriched.SubjectID, principal.UserSubjectID(boundaryCanonicalUserID); got != want {
+		t.Fatalf("subject ID = %q, want canonical %q", got, want)
+	}
+	if got := enriched.UserID; got != boundaryCanonicalUserID {
+		t.Fatalf("user ID = %q, want %q", got, boundaryCanonicalUserID)
+	}
+}
+
+// TestResolvePrincipalUserIDLeavesCanonicalSubjectUnchanged keeps the common
+// path free of a user-store round trip.
+func TestResolvePrincipalUserIDLeavesCanonicalSubjectUnchanged(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{users: boundaryUserStore{err: errors.New("user store must not be called")}}
+
+	p := &principal.Principal{
+		SubjectID: principal.UserSubjectID(boundaryCanonicalUserID),
+		Identity:  &core.UserIdentity{Email: boundaryUserEmail},
+		Kind:      principal.KindUser,
+		Source:    principal.SourceBearer,
+	}
+
+	enriched, err := s.resolvePrincipalUserID(context.Background(), p)
+	if err != nil {
+		t.Fatalf("resolvePrincipalUserID: %v", err)
+	}
+	if got, want := enriched.SubjectID, principal.UserSubjectID(boundaryCanonicalUserID); got != want {
+		t.Fatalf("subject ID = %q, want %q", got, want)
+	}
+}

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -296,11 +296,11 @@ func (s *Server) integrationManagementPath(ctx context.Context, p *principal.Pri
 	if _, ok := s.registryApp(appName); !ok {
 		return ""
 	}
-	subjectID := strings.TrimSpace(principal.Canonicalized(p).SubjectID)
-	if subjectID == "" {
+	subjectID, err := principal.ResolveAuthorizationSubjectID(ctx, s.credentialUserResolver(), p)
+	if err != nil || strings.TrimSpace(subjectID) == "" {
 		return ""
 	}
-	allowed, err := s.hasExplicitAppAdmin(ctx, subjectID, appName)
+	allowed, err := s.hasExplicitAppAdmin(ctx, strings.TrimSpace(subjectID), appName)
 	if err != nil || !allowed {
 		return ""
 	}

--- a/gestaltd/internal/server/handlers_app_admin_identities_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_identities_test.go
@@ -18,7 +18,7 @@ import (
 func TestAppAdminIdentitiesList(t *testing.T) {
 	t.Parallel()
 
-	adminID := principal.UserSubjectID("alice")
+	adminID := principal.UserSubjectID(testCanonicalAdminUserID)
 	authz := &serverTestAuthorizationProvider{
 		relationships: []*proto.Relationship{
 			testAuthorizationRelationship(adminID, "admin", "app", "g-issues"),
@@ -129,7 +129,7 @@ func TestAppAdminIdentitiesList(t *testing.T) {
 func TestAppAdminIdentitiesListShadowsRuntimeDuplicate(t *testing.T) {
 	t.Parallel()
 
-	adminID := principal.UserSubjectID("alice")
+	adminID := principal.UserSubjectID(testCanonicalAdminUserID)
 	const saID = "service_account:slack-bot"
 	authz := &serverTestAuthorizationProvider{
 		relationships: []*proto.Relationship{
@@ -223,7 +223,7 @@ func TestAppAdminIdentitiesListShadowsRuntimeDuplicate(t *testing.T) {
 func TestAppAdminIdentitiesListExcludesSubjectSet(t *testing.T) {
 	t.Parallel()
 
-	adminID := principal.UserSubjectID("alice")
+	adminID := principal.UserSubjectID(testCanonicalAdminUserID)
 	authz := &serverTestAuthorizationProvider{
 		relationships: []*proto.Relationship{
 			testAuthorizationRelationship(adminID, "admin", "app", "g-issues"),
@@ -292,7 +292,7 @@ func TestAppAdminIdentitiesListExcludesSubjectSet(t *testing.T) {
 func TestAppAdminIdentitiesListEmpty(t *testing.T) {
 	t.Parallel()
 
-	adminID := principal.UserSubjectID("alice")
+	adminID := principal.UserSubjectID(testCanonicalAdminUserID)
 	authz := &serverTestAuthorizationProvider{
 		relationships: []*proto.Relationship{
 			testAuthorizationRelationship(adminID, "admin", "app", "g-issues"),
@@ -329,7 +329,7 @@ func TestAppAdminIdentitiesListEmpty(t *testing.T) {
 func TestAppAdminIdentitiesFailsClosed(t *testing.T) {
 	t.Parallel()
 
-	adminID := principal.UserSubjectID("alice")
+	adminID := principal.UserSubjectID(testCanonicalAdminUserID)
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", adminID, "")
 		cfg.Authorization = nil
@@ -353,7 +353,7 @@ func TestAppAdminIdentitiesFailsClosed(t *testing.T) {
 func TestAppAdminIdentitiesListUsesManagedSubjectDisplayName(t *testing.T) {
 	t.Parallel()
 
-	adminID := principal.UserSubjectID("alice")
+	adminID := principal.UserSubjectID(testCanonicalAdminUserID)
 	const saID = "service_account:slack-bot"
 	authz := &serverTestAuthorizationProvider{
 		relationships: []*proto.Relationship{
@@ -414,7 +414,7 @@ func TestAppAdminIdentitiesListUsesManagedSubjectDisplayName(t *testing.T) {
 func TestAppAdminIdentitiesListForbiddenWithoutAdmin(t *testing.T) {
 	t.Parallel()
 
-	viewerID := principal.UserSubjectID("bob")
+	viewerID := principal.UserSubjectID(testCanonicalViewerUserID)
 	authz := &serverTestAuthorizationProvider{
 		relationships: []*proto.Relationship{
 			testAuthorizationRelationship(viewerID, "viewer", "app", "g-issues"),

--- a/gestaltd/internal/server/handlers_app_admin_members_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_members_test.go
@@ -15,8 +15,8 @@ import (
 func TestAppAdminMembersList(t *testing.T) {
 	t.Parallel()
 
-	adminID := principal.UserSubjectID("alice")
-	viewerID := principal.UserSubjectID("bob")
+	adminID := principal.UserSubjectID(testCanonicalAdminUserID)
+	viewerID := principal.UserSubjectID(testCanonicalViewerUserID)
 	authz := &serverTestAuthorizationProvider{
 		relationships: []*proto.Relationship{
 			testAuthorizationRelationship(adminID, "admin", "app", "g-issues"),
@@ -115,8 +115,8 @@ func TestAppAdminMembersList(t *testing.T) {
 func TestAppAdminMembersListShadowsRuntimeDuplicate(t *testing.T) {
 	t.Parallel()
 
-	adminID := principal.UserSubjectID("alice")
-	viewerID := principal.UserSubjectID("bob")
+	adminID := principal.UserSubjectID(testCanonicalAdminUserID)
+	viewerID := principal.UserSubjectID(testCanonicalViewerUserID)
 	authz := &serverTestAuthorizationProvider{
 		relationships: []*proto.Relationship{
 			testAuthorizationRelationship(adminID, "admin", "app", "g-issues"),
@@ -209,7 +209,7 @@ func TestAppAdminMembersListShadowsRuntimeDuplicate(t *testing.T) {
 func TestAppAdminMembersListSubjectSet(t *testing.T) {
 	t.Parallel()
 
-	adminID := principal.UserSubjectID("alice")
+	adminID := principal.UserSubjectID(testCanonicalAdminUserID)
 	authz := &serverTestAuthorizationProvider{
 		relationships: []*proto.Relationship{
 			testAuthorizationRelationship(adminID, "admin", "app", "g-issues"),
@@ -274,7 +274,7 @@ func TestAppAdminMembersListSubjectSet(t *testing.T) {
 func TestAppAdminMembersListForbiddenWithoutAdmin(t *testing.T) {
 	t.Parallel()
 
-	viewerID := principal.UserSubjectID("bob")
+	viewerID := principal.UserSubjectID(testCanonicalViewerUserID)
 	authz := &serverTestAuthorizationProvider{
 		relationships: []*proto.Relationship{
 			testAuthorizationRelationship(viewerID, "viewer", "app", "g-issues"),

--- a/gestaltd/internal/server/handlers_app_admin_registry.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry.go
@@ -192,7 +192,19 @@ func (s *Server) appAdminAuthorizationMiddleware(next http.Handler) http.Handler
 		if err := requireUserCaller(w, p); err != nil {
 			return
 		}
-		subjectID := strings.TrimSpace(principal.Canonicalized(p).SubjectID)
+		subjectID, err := principal.ResolveAuthorizationSubjectID(r.Context(), s.credentialUserResolver(), p)
+		switch {
+		case errors.Is(err, principal.ErrCredentialSubjectRequired):
+			writeError(w, http.StatusUnauthorized, "missing authorization")
+			return
+		case errors.Is(err, principal.ErrOpaqueCredentialSubject):
+			writeError(w, http.StatusForbidden, "app access denied")
+			return
+		case err != nil:
+			writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
+			return
+		}
+		subjectID = strings.TrimSpace(subjectID)
 		if subjectID == "" {
 			writeError(w, http.StatusUnauthorized, "missing authorization")
 			return

--- a/gestaltd/internal/server/handlers_app_admin_registry_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry_test.go
@@ -25,7 +25,7 @@ func TestAppAdminRegistrySelectAndRead(t *testing.T) {
 	t.Parallel()
 
 	fixture := registrytest.NewInstallFixture(t)
-	subjectID := principal.UserSubjectID("alice")
+	subjectID := principal.UserSubjectID(testCanonicalAdminUserID)
 	authz := &serverTestAuthorizationProvider{
 		relationships: []*proto.Relationship{
 			testAuthorizationRelationship(subjectID, "admin", "app", "g-issues"),
@@ -122,7 +122,7 @@ func TestAppAdminRegistryAutoDeploy(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("seed auto-deploy settings: %v", err)
 	}
-	subjectID := principal.UserSubjectID("alice")
+	subjectID := principal.UserSubjectID(testCanonicalAdminUserID)
 	authz := &serverTestAuthorizationProvider{
 		relationships: []*proto.Relationship{
 			testAuthorizationRelationship(subjectID, "admin", "app", "g-issues"),
@@ -213,7 +213,7 @@ func TestAppAdminRegistryAutoDeployNotifies(t *testing.T) {
 
 	fixture := registrytest.NewInstallFixture(t)
 	services := testutil.NewStubServices(t)
-	subjectID := principal.UserSubjectID("alice")
+	subjectID := principal.UserSubjectID(testCanonicalAdminUserID)
 	authz := &serverTestAuthorizationProvider{
 		relationships: []*proto.Relationship{
 			testAuthorizationRelationship(subjectID, "admin", "app", "g-issues"),
@@ -278,7 +278,7 @@ func TestAppAdminRegistryAutoDeployRequiresAppAdmin(t *testing.T) {
 	t.Parallel()
 
 	fixture := registrytest.NewInstallFixture(t)
-	subjectID := principal.UserSubjectID("alice")
+	subjectID := principal.UserSubjectID(testCanonicalAdminUserID)
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", subjectID, "")
 		cfg.Authorization = &serverTestAuthorizationProvider{}
@@ -310,7 +310,7 @@ func TestAppAdminRegistryFailsClosed(t *testing.T) {
 	t.Parallel()
 
 	fixture := registrytest.NewInstallFixture(t)
-	subjectID := principal.UserSubjectID("alice")
+	subjectID := principal.UserSubjectID(testCanonicalAdminUserID)
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", subjectID, "")
 		cfg.AppDefs = map[string]*config.ProviderEntry{
@@ -337,7 +337,7 @@ func TestAppAdminRegistryFailsClosed(t *testing.T) {
 func TestListAppsIncludesManagementPathForUninstalledRegistryApp(t *testing.T) {
 	t.Parallel()
 
-	subjectID := principal.UserSubjectID("alice")
+	subjectID := principal.UserSubjectID(testCanonicalAdminUserID)
 	authz := &serverTestAuthorizationProvider{
 		relationships: []*proto.Relationship{
 			testAuthorizationRelationship(subjectID, "admin", "app", "g-issues"),
@@ -378,7 +378,7 @@ func TestListAppsIncludesManagementPathForUninstalledRegistryApp(t *testing.T) {
 func TestListAppsIncludesManagementPathForAppAdmin(t *testing.T) {
 	t.Parallel()
 
-	subjectID := principal.UserSubjectID("alice")
+	subjectID := principal.UserSubjectID(testCanonicalAdminUserID)
 	authz := &serverTestAuthorizationProvider{
 		relationships: []*proto.Relationship{
 			testAuthorizationRelationship(subjectID, "admin", "app", "g-issues"),
@@ -421,7 +421,7 @@ func TestAppAdminRegistryIncludesPendingAndFailedVersions(t *testing.T) {
 	t.Parallel()
 
 	fixture := registrytest.NewInstallFixture(t)
-	subjectID := principal.UserSubjectID("alice")
+	subjectID := principal.UserSubjectID(testCanonicalAdminUserID)
 	authz := &serverTestAuthorizationProvider{
 		relationships: []*proto.Relationship{
 			testAuthorizationRelationship(subjectID, "admin", "app", "g-issues"),
@@ -527,7 +527,7 @@ func TestAppAdminRegistryHistory(t *testing.T) {
 	services := testutil.NewStubServices(t)
 	alice := seedUser(t, services, "alice@valon.com")
 	aliceActor := principal.UserSubjectID(alice.ID)
-	subjectID := principal.UserSubjectID("alice")
+	subjectID := principal.UserSubjectID(testCanonicalAdminUserID)
 	authz := &serverTestAuthorizationProvider{
 		relationships: []*proto.Relationship{
 			testAuthorizationRelationship(subjectID, "admin", "app", "g-issues"),
@@ -673,7 +673,7 @@ func TestAppAdminRegistryHistoryActiveRolloutFields(t *testing.T) {
 	services := testutil.NewStubServices(t)
 	alice := seedUser(t, services, "alice@valon.com")
 	aliceActor := principal.UserSubjectID(alice.ID)
-	subjectID := principal.UserSubjectID("alice")
+	subjectID := principal.UserSubjectID(testCanonicalAdminUserID)
 	authz := &serverTestAuthorizationProvider{
 		relationships: []*proto.Relationship{
 			testAuthorizationRelationship(subjectID, "admin", "app", "g-issues"),
@@ -762,7 +762,7 @@ func TestAppAdminRegistryHistoryStoredRolloutOutcomeFields(t *testing.T) {
 	services := testutil.NewStubServices(t)
 	alice := seedUser(t, services, "alice@valon.com")
 	aliceActor := principal.UserSubjectID(alice.ID)
-	subjectID := principal.UserSubjectID("alice")
+	subjectID := principal.UserSubjectID(testCanonicalAdminUserID)
 	authz := &serverTestAuthorizationProvider{
 		relationships: []*proto.Relationship{
 			testAuthorizationRelationship(subjectID, "admin", "app", "g-issues"),
@@ -844,7 +844,7 @@ func TestAppAdminRegistryFleetStateAndRecoveryResponseShapes(t *testing.T) {
 
 	fixture := registrytest.NewInstallFixture(t)
 	services := testutil.NewStubServices(t)
-	subjectID := principal.UserSubjectID("alice")
+	subjectID := principal.UserSubjectID(testCanonicalAdminUserID)
 	authz := &serverTestAuthorizationProvider{
 		relationships: []*proto.Relationship{
 			testAuthorizationRelationship(subjectID, "admin", "app", "g-issues"),
@@ -1039,7 +1039,7 @@ func TestAppAdminRegistryHistoryIgnoresLiveRolloutForOlderSameVersion(t *testing
 	services := testutil.NewStubServices(t)
 	alice := seedUser(t, services, "alice@valon.com")
 	aliceActor := principal.UserSubjectID(alice.ID)
-	subjectID := principal.UserSubjectID("alice")
+	subjectID := principal.UserSubjectID(testCanonicalAdminUserID)
 	otherVersion := "0.0.0-snapshot.gother"
 	authz := &serverTestAuthorizationProvider{
 		relationships: []*proto.Relationship{
@@ -1146,7 +1146,7 @@ func TestAppAdminRegistryHistoryPrefersStoredOutcomeOverLiveRollout(t *testing.T
 	services := testutil.NewStubServices(t)
 	alice := seedUser(t, services, "alice@valon.com")
 	aliceActor := principal.UserSubjectID(alice.ID)
-	subjectID := principal.UserSubjectID("alice")
+	subjectID := principal.UserSubjectID(testCanonicalAdminUserID)
 	authz := &serverTestAuthorizationProvider{
 		relationships: []*proto.Relationship{
 			testAuthorizationRelationship(subjectID, "admin", "app", "g-issues"),

--- a/gestaltd/internal/server/mounted_ui.go
+++ b/gestaltd/internal/server/mounted_ui.go
@@ -280,23 +280,38 @@ func (s *Server) authorizeMountedAppAccess(ctx context.Context, p *principal.Pri
 	if s.authorization == nil {
 		return invocation.AccessContext{}, true, nil
 	}
-	resourceName, subjectID, ok := mountedUIAuthorizationSubject(p, mounted)
-	if !ok {
-		return invocation.AccessContext{}, false, nil
+	resourceName, subjectID, ok, err := s.mountedUIAuthorizationSubject(ctx, p, mounted)
+	if err != nil || !ok {
+		return invocation.AccessContext{}, false, err
 	}
 	return s.authorizeMountedResourceRoles(ctx, resourceName, subjectID, mounted.AllowedRoles)
 }
 
-func mountedUIAuthorizationSubject(p *principal.Principal, mounted MountedUI) (resourceName, subjectID string, ok bool) {
+// mountedUIAuthorizationSubject resolves the canonical subject the mounted UI
+// boundary authorizes as. Unresolvable or provider-opaque subjects are denied;
+// the raw token subject is never used.
+func (s *Server) mountedUIAuthorizationSubject(
+	ctx context.Context,
+	p *principal.Principal,
+	mounted MountedUI,
+) (resourceName, subjectID string, ok bool, err error) {
 	resourceName = mountedUIAuthorizationResourceName(mounted)
 	if resourceName == "" {
-		return "", "", false
+		return "", "", false, nil
 	}
-	subjectID = strings.TrimSpace(principal.Canonicalized(p).SubjectID)
+	subjectID, err = principal.ResolveAuthorizationSubjectID(ctx, s.credentialUserResolver(), p)
+	switch {
+	case errors.Is(err, principal.ErrCredentialSubjectRequired),
+		errors.Is(err, principal.ErrOpaqueCredentialSubject):
+		return "", "", false, nil
+	case err != nil:
+		return "", "", false, err
+	}
+	subjectID = strings.TrimSpace(subjectID)
 	if subjectID == "" {
-		return "", "", false
+		return "", "", false, nil
 	}
-	return resourceName, subjectID, true
+	return resourceName, subjectID, true, nil
 }
 
 func (s *Server) authorizeMountedResourceRoles(ctx context.Context, resourceName, subjectID string, allowedRoles []string) (invocation.AccessContext, bool, error) {

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -96,6 +96,23 @@ type AppRuntimeState interface {
 	WithRunningVersion(app string, fn func(version string) error) error
 }
 
+// userStore is the persisted user lookup the server needs to canonicalize
+// human identities before authorization.
+type userStore interface {
+	principal.CredentialUserResolver
+	GetUser(ctx context.Context, id string) (*core.User, error)
+}
+
+// credentialUserResolver returns the user store used to canonicalize human
+// subjects, or nil when no user store is configured so that resolution fails
+// closed instead of panicking on a nil store.
+func (s *Server) credentialUserResolver() principal.CredentialUserResolver {
+	if s == nil || s.users == nil {
+		return nil
+	}
+	return s.users
+}
+
 type Server struct {
 	router                        chi.Router
 	handler                       http.Handler
@@ -105,7 +122,7 @@ type Server struct {
 	authorization                 core.AuthorizationProvider
 	providerKinds                 map[string]invocation.ProviderKind
 	auditSink                     core.AuditSink
-	users                         *coredata.UserService
+	users                         userStore
 	externalCredentials           core.ExternalCredentialProvider
 	connectionInstancePreferences *coredata.ConnectionInstancePreferenceService
 	managedSubjects               *coredata.ManagedSubjectService
@@ -336,7 +353,10 @@ func New(cfg Config) (*Server, error) {
 	if cfg.Services == nil {
 		return nil, fmt.Errorf("services are required")
 	}
-	users := cfg.Services.Users
+	var users userStore
+	if cfg.Services.Users != nil {
+		users = cfg.Services.Users
+	}
 	externalCredentials := cfg.Services.ExternalCredentials
 	connectionInstancePreferences := cfg.Services.ConnectionInstancePreferences
 	if core.ExternalCredentialProviderMissing(externalCredentials) {

--- a/gestaltd/internal/server/test_auth_stubs_test.go
+++ b/gestaltd/internal/server/test_auth_stubs_test.go
@@ -23,6 +23,11 @@ const (
 	testSessionToken       = "session-token"
 	testGrantSessionCookie = "grant-session-token"
 	grantTestScope         = "testapp"
+
+	// Authorization boundaries only accept canonical persisted user IDs, so
+	// test subjects use realistic user-table UUIDs.
+	testCanonicalAdminUserID  = "9f2c1c2e-1a2b-4c3d-8e4f-5a6b7c8d9e01"
+	testCanonicalViewerUserID = "3b7d5e6f-2c3d-4e5f-9a0b-1c2d3e4f5a02"
 )
 
 func grantTestProviders(t *testing.T) *registry.ProviderMap[core.Provider] {

--- a/gestaltd/services/identity/principal/authorization_subject.go
+++ b/gestaltd/services/identity/principal/authorization_subject.go
@@ -1,0 +1,144 @@
+package principal
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// UserSubjectForm classifies the form of the user portion of a subject ID.
+type UserSubjectForm string
+
+const (
+	// UserSubjectFormEmpty is an absent or blank subject value.
+	UserSubjectFormEmpty UserSubjectForm = "empty"
+	// UserSubjectFormCanonical is a persisted Gestalt user UUID.
+	UserSubjectFormCanonical UserSubjectForm = "canonical"
+	// UserSubjectFormEmail is a verified email that must be resolved to a
+	// persisted user UUID before it may be authorized.
+	UserSubjectFormEmail UserSubjectForm = "email"
+	// UserSubjectFormOpaque is any other value, including provider-opaque
+	// subjects such as "auth0|abc" or "google-oauth2|123". Opaque values are
+	// never authorized directly.
+	UserSubjectFormOpaque UserSubjectForm = "opaque"
+)
+
+// ClassifyUserSubjectID classifies a full subject ID such as
+// "user:<uuid>", "user:person@example.com", or "user:auth0|abc".
+func ClassifyUserSubjectID(subjectID string) UserSubjectForm {
+	value := strings.TrimSpace(subjectID)
+	if value == "" {
+		return UserSubjectFormEmpty
+	}
+	if userID := UserIDFromSubjectID(value); userID != "" {
+		return ClassifyUserSubjectValue(userID)
+	}
+	if strings.Contains(value, ":") {
+		// A non-user subject namespace is not classifiable as a user subject.
+		return UserSubjectFormOpaque
+	}
+	return ClassifyUserSubjectValue(value)
+}
+
+// ClassifyUserSubjectValue classifies the value of a user subject, i.e. the
+// part after the "user:" prefix.
+func ClassifyUserSubjectValue(value string) UserSubjectForm {
+	value = strings.TrimSpace(value)
+	switch {
+	case value == "":
+		return UserSubjectFormEmpty
+	case isCanonicalUserID(value):
+		return UserSubjectFormCanonical
+	case isEmailForm(value):
+		return UserSubjectFormEmail
+	default:
+		return UserSubjectFormOpaque
+	}
+}
+
+func isCanonicalUserID(value string) bool {
+	if len(value) != 36 {
+		return false
+	}
+	parsed, err := uuid.Parse(value)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(parsed.String(), value)
+}
+
+func isEmailForm(value string) bool {
+	if strings.ContainsAny(value, " \t\r\n|:/\\,;<>\"") {
+		return false
+	}
+	at := strings.Index(value, "@")
+	if at <= 0 || at != strings.LastIndex(value, "@") {
+		return false
+	}
+	domain := value[at+1:]
+	if domain == "" || !strings.Contains(domain, ".") {
+		return false
+	}
+	return !strings.HasPrefix(domain, ".") && !strings.HasSuffix(domain, ".")
+}
+
+// ResolveAuthorizationSubjectID returns the subject ID an authorization
+// boundary must evaluate for p.
+//
+// Non-user principals keep their canonical token subject. User principals are
+// resolved to the persisted "user:<uuid>" subject: a canonical UUID passes
+// through, a verified email is resolved through the user store, and any other
+// (provider-opaque) subject is rejected. Every failure mode returns an error so
+// callers deny instead of falling back to the raw token subject.
+func ResolveAuthorizationSubjectID(ctx context.Context, users CredentialUserResolver, p *Principal) (string, error) {
+	p = Canonicalized(p)
+	if p == nil {
+		return "", ErrCredentialSubjectRequired
+	}
+	if IsNonUserPrincipal(p) {
+		subjectID := strings.TrimSpace(p.SubjectID)
+		if subjectID == "" {
+			return "", ErrCredentialSubjectRequired
+		}
+		return subjectID, nil
+	}
+
+	userID := strings.TrimSpace(p.UserID)
+	if ClassifyUserSubjectValue(userID) == UserSubjectFormCanonical {
+		return UserSubjectID(userID), nil
+	}
+
+	email := authorizationSubjectEmail(p, userID)
+	if email == "" {
+		return "", fmt.Errorf("%w: %q", ErrOpaqueCredentialSubject, strings.TrimSpace(p.SubjectID))
+	}
+	if users == nil {
+		return "", ErrCredentialSubjectRequired
+	}
+
+	dbUser, err := users.FindOrCreateUser(ctx, email)
+	if err != nil {
+		return "", fmt.Errorf("resolve canonical user: %w", err)
+	}
+	if dbUser == nil || strings.TrimSpace(dbUser.ID) == "" {
+		return "", ErrCredentialSubjectRequired
+	}
+	return UserSubjectID(strings.TrimSpace(dbUser.ID)), nil
+}
+
+func authorizationSubjectEmail(p *Principal, userID string) string {
+	if p.Identity != nil {
+		if email := strings.TrimSpace(p.Identity.Email); isEmailForm(email) {
+			return email
+		}
+	}
+	if isEmailForm(userID) {
+		return userID
+	}
+	if suffix := strings.TrimSpace(UserIDFromSubjectID(strings.TrimSpace(p.SubjectID))); isEmailForm(suffix) {
+		return suffix
+	}
+	return ""
+}

--- a/gestaltd/services/identity/principal/authorization_subject_test.go
+++ b/gestaltd/services/identity/principal/authorization_subject_test.go
@@ -1,0 +1,177 @@
+package principal
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+)
+
+const testCanonicalUserID = "28542db5-ae88-404f-a231-a0034cb9212c"
+
+func TestClassifyUserSubjectID(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		subjectID string
+		want      UserSubjectForm
+	}{
+		{"empty", "  ", UserSubjectFormEmpty},
+		{"canonical uuid", "user:" + testCanonicalUserID, UserSubjectFormCanonical},
+		{"bare canonical uuid", testCanonicalUserID, UserSubjectFormCanonical},
+		{"email", "user:person@valon.com", UserSubjectFormEmail},
+		{"auth0", "user:auth0|abc123", UserSubjectFormOpaque},
+		{"google oauth2", "user:google-oauth2|1234567890", UserSubjectFormOpaque},
+		{"samlp", "user:samlp|okta|person@valon.com", UserSubjectFormOpaque},
+		{"non user namespace", "service_account:workflow-bot", UserSubjectFormOpaque},
+		{"unrecognized", "user:alice", UserSubjectFormOpaque},
+		{"email without domain dot", "user:person@localhost", UserSubjectFormOpaque},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := ClassifyUserSubjectID(tc.subjectID); got != tc.want {
+				t.Fatalf("ClassifyUserSubjectID(%q) = %q, want %q", tc.subjectID, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveAuthorizationSubjectID_EmailResolvesToCanonicalUUID(t *testing.T) {
+	t.Parallel()
+
+	users := stubCredentialUserResolver{users: map[string]string{"dave@valon.com": testCanonicalUserID}}
+	subjectID, err := ResolveAuthorizationSubjectID(context.Background(), users, &Principal{
+		SubjectID: "user:dave@valon.com",
+		Identity:  &core.UserIdentity{Email: "dave@valon.com"},
+		Kind:      KindUser,
+		Source:    SourceBearer,
+	})
+	if err != nil {
+		t.Fatalf("ResolveAuthorizationSubjectID: %v", err)
+	}
+	if subjectID != UserSubjectID(testCanonicalUserID) {
+		t.Fatalf("subjectID = %q, want %q", subjectID, UserSubjectID(testCanonicalUserID))
+	}
+}
+
+func TestResolveAuthorizationSubjectID_CanonicalUUIDPassesThrough(t *testing.T) {
+	t.Parallel()
+
+	subjectID, err := ResolveAuthorizationSubjectID(context.Background(), nil, &Principal{
+		SubjectID: UserSubjectID(testCanonicalUserID),
+		Kind:      KindUser,
+		Source:    SourceBearer,
+	})
+	if err != nil {
+		t.Fatalf("ResolveAuthorizationSubjectID: %v", err)
+	}
+	if subjectID != UserSubjectID(testCanonicalUserID) {
+		t.Fatalf("subjectID = %q, want %q", subjectID, UserSubjectID(testCanonicalUserID))
+	}
+}
+
+func TestResolveAuthorizationSubjectID_OpaqueSubjectRejected(t *testing.T) {
+	t.Parallel()
+
+	users := stubCredentialUserResolver{users: map[string]string{"dave@valon.com": testCanonicalUserID}}
+	for _, subject := range []string{"user:auth0|abc123", "user:google-oauth2|1234567890", "user:alice"} {
+		t.Run(subject, func(t *testing.T) {
+			t.Parallel()
+			subjectID, err := ResolveAuthorizationSubjectID(context.Background(), users, &Principal{
+				SubjectID: subject,
+				Kind:      KindUser,
+				Source:    SourceBearer,
+			})
+			if !errors.Is(err, ErrOpaqueCredentialSubject) {
+				t.Fatalf("err = %v, want ErrOpaqueCredentialSubject", err)
+			}
+			if subjectID != "" {
+				t.Fatalf("subjectID = %q, want empty", subjectID)
+			}
+		})
+	}
+}
+
+func TestResolveAuthorizationSubjectID_OpaqueSubjectWithVerifiedEmailMapsToCanonicalUUID(t *testing.T) {
+	t.Parallel()
+
+	users := stubCredentialUserResolver{users: map[string]string{"kevon@valon.com": testCanonicalUserID}}
+	subjectID, err := ResolveAuthorizationSubjectID(context.Background(), users, &Principal{
+		SubjectID: "user:auth0|abc123",
+		Identity:  &core.UserIdentity{Email: "kevon@valon.com"},
+		Kind:      KindUser,
+		Source:    SourceBearer,
+	})
+	if err != nil {
+		t.Fatalf("ResolveAuthorizationSubjectID: %v", err)
+	}
+	if subjectID != UserSubjectID(testCanonicalUserID) {
+		t.Fatalf("subjectID = %q, want %q", subjectID, UserSubjectID(testCanonicalUserID))
+	}
+}
+
+func TestResolveAuthorizationSubjectID_UserStoreFailureFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	storeErr := errors.New("user store unavailable")
+	subjectID, err := ResolveAuthorizationSubjectID(
+		context.Background(),
+		stubCredentialUserResolver{err: storeErr},
+		&Principal{
+			SubjectID: "user:dave@valon.com",
+			Identity:  &core.UserIdentity{Email: "dave@valon.com"},
+			Kind:      KindUser,
+			Source:    SourceBearer,
+		},
+	)
+	if !errors.Is(err, storeErr) {
+		t.Fatalf("err = %v, want store error", err)
+	}
+	if subjectID != "" {
+		t.Fatalf("subjectID = %q, want empty (no fallback to raw subject)", subjectID)
+	}
+}
+
+func TestResolveAuthorizationSubjectID_MissingUserStoreFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	subjectID, err := ResolveAuthorizationSubjectID(context.Background(), nil, &Principal{
+		SubjectID: "user:dave@valon.com",
+		Identity:  &core.UserIdentity{Email: "dave@valon.com"},
+		Kind:      KindUser,
+		Source:    SourceBearer,
+	})
+	if !errors.Is(err, ErrCredentialSubjectRequired) {
+		t.Fatalf("err = %v, want ErrCredentialSubjectRequired", err)
+	}
+	if subjectID != "" {
+		t.Fatalf("subjectID = %q, want empty", subjectID)
+	}
+}
+
+func TestResolveAuthorizationSubjectID_NonUserPrincipalKeepsTokenSubject(t *testing.T) {
+	t.Parallel()
+
+	subjectID, err := ResolveAuthorizationSubjectID(context.Background(), nil, &Principal{
+		SubjectID: "service_account:workflow-bot",
+		Kind:      Kind("service_account"),
+		Source:    SourceBearer,
+	})
+	if err != nil {
+		t.Fatalf("ResolveAuthorizationSubjectID: %v", err)
+	}
+	if subjectID != "service_account:workflow-bot" {
+		t.Fatalf("subjectID = %q, want service account subject", subjectID)
+	}
+}
+
+func TestResolveAuthorizationSubjectID_NilPrincipalDenied(t *testing.T) {
+	t.Parallel()
+
+	if _, err := ResolveAuthorizationSubjectID(context.Background(), nil, nil); !errors.Is(err, ErrCredentialSubjectRequired) {
+		t.Fatalf("err = %v, want ErrCredentialSubjectRequired", err)
+	}
+}

--- a/gestaltd/services/identity/principal/errors.go
+++ b/gestaltd/services/identity/principal/errors.go
@@ -5,4 +5,8 @@ import "errors"
 var (
 	ErrInvalidToken              = errors.New("invalid token")
 	ErrCredentialSubjectRequired = errors.New("credential subject required")
+	// ErrOpaqueCredentialSubject reports a user subject that is neither a
+	// canonical persisted user ID nor a resolvable verified email, such as a
+	// provider-opaque subject like "user:auth0|abc".
+	ErrOpaqueCredentialSubject = errors.New("opaque credential subject")
 )


### PR DESCRIPTION
## Description

Resolves verified subjects to the persisted `user:<uuid>` before the mounted-UI and app-admin boundaries authorize, and fails closed instead of falling back to the raw token subject.

Root cause addressed: `resolvePrincipalUserID` treated any subject without an `@` as already canonical, so a provider-opaque subject such as `auth0|abc` reached authorization unresolved and matched no relationship — the mechanism behind the employee access loss. Subjects are now classified explicitly (canonical UUID short-circuits with no user-store round trip, verified email resolves, opaque is rejected).

Stack A / G2 of [plans/external_users/implementation_v2.md](https://github.com/valon-technologies/gestalt/blob/main/plans/external_users/implementation_v2.md). Stacked on #3069. Relationship traversal is unchanged here — unifying the UI/catalog/admin scans into one evaluator is G3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Re-filed from #3070, which GitHub auto-closed when its base branch `g1-authorization-state-safety` was deleted on merge of #3069. Same branch, same content, now based on `main`.
