### PR TITLE
[docs] roster from @valon.com users rows; record Phase 1 as shipped

### DIFF
--- a/plans/external_users/implementation_prompt.md
+++ b/plans/external_users/implementation_prompt.md
@@ -73,8 +73,12 @@ and resource-type repairs.
 
 ## Non-negotiables
 
-- **Never** build the roster from authorization rows. Use Rippling (the People authority),
-  joined to canonical Gestalt user UUIDs by normalized email.
+- **Never** build the roster from authorization rows. Build it from the Gestalt `users`
+  table — every `@valon.com` row, by canonical UUID. Every employee is on the Valon domain,
+  so an excluded row with a non-Valon domain is a non-employee. **The exception is a row
+  with no usable email at all** — blank, or a provider-opaque subject like `auth0|abc`. Those
+  carry no domain to judge, they are the original root-cause shape, and each one must be
+  resolved to a person before the flip. See "Roster source" in the spec.
 - **Never** set the shared app wildcard to `[nobody]`. Keep
   `actions: "*": relations: [viewer, user, editor, admin]`.
 - **Never** generate per-user/per-app grants. One grant per resource type, to the group.
@@ -107,16 +111,35 @@ and resource-type repairs.
 
 ## Work already done
 
-Five gestalt PRs were implemented and passed CI, then closed pending a replan. The branches
-are pushed; reopen or re-file them rather than rewriting:
+**Phase 1 is merged and deployed** (2026-08-08). All five gestalt PRs are on `main`:
 
-| Branch | Content | Closed PR |
+| Content | PR | Merge commit |
 | --- | --- | --- |
-| `g2-canonical-identity` | Canonical identity at every authorization boundary | [#3070](https://github.com/valon-technologies/gestalt/pull/3070) |
-| `g3a-unify-authorization-evaluator` | Mounted UI + app admin decide through the evaluator | [#3071](https://github.com/valon-technologies/gestalt/pull/3071) |
-| `g1-authorization-state-safety` | Startup authorization-state write gated behind explicit apply | [#3069](https://github.com/valon-technologies/gestalt/pull/3069) |
-| `g4-authorization-conformance-suite` | Conformance suite across every server surface | [#3073](https://github.com/valon-technologies/gestalt/pull/3073) |
-| `g3b-batched-listing-decisions` | Catalog + MCP listing authorization | [#3072](https://github.com/valon-technologies/gestalt/pull/3072) |
+| Startup authorization-state write gated behind explicit apply | [#3069](https://github.com/valon-technologies/gestalt/pull/3069) | `3b5157258` |
+| Canonical identity at every authorization boundary | [#3075](https://github.com/valon-technologies/gestalt/pull/3075) | `48a6624c4` |
+| Mounted UI + app admin decide through the evaluator | [#3071](https://github.com/valon-technologies/gestalt/pull/3071) | `1c53b04aa` |
+| Catalog + MCP listing authorization (PR 9, landed early) | [#3072](https://github.com/valon-technologies/gestalt/pull/3072) | `77cd8ef6f` |
+| Conformance suite across every server surface | [#3073](https://github.com/valon-technologies/gestalt/pull/3073) | `a3ff3a33d` |
+
+Toolshed [#4144](https://github.com/valon-technologies/toolshed/pull/4144) then set
+`server.authorizationStateApply: true` in `valon-tools/deploy/prod/config.yaml` and deployed,
+with `GESTALTD_PINNED_SHA` bumped to `a3ff3a33dd6c1fc3263ebb02ab2a47315fd75443`. Prod logs
+confirm `authorization state applied` on the serving revision, so exactly one deployment
+owns that write and every other gestaltd invocation is plan-only.
+
+Two deviations from the plan as written, both deliberate:
+
+- **PR 9 (catalog + MCP listing authorization) landed in Phase 1, not Phase 4.** The
+  conformance suite asserts listing behavior that only exists once it is in, and does not
+  compile without it. Landing it early is inert while `defaultRole` is active — every
+  employee resolves viewer, so the filter removes nothing — and it means the Phase 4
+  prerequisite is already deployed. It still needs verifying against an ungranted identity
+  before any external domain is enabled.
+- **#3070 was re-filed as #3075.** Merging #3069 deleted its base branch, and GitHub
+  auto-closed the dependent PR rather than retargeting it, then refused to reopen it. When
+  landing the remaining stacks, retarget each PR to `main` *before* merging the one below it.
+
+Phase 1's check — the current-access regression with real people — is outstanding.
 
 Caveat on the conformance suite: it runs against an in-repo reference evaluator, not the
 real provider (that provider is a separate module in another repository and needs a live
@@ -128,17 +151,22 @@ not prove the shipped provider implements those semantics.
 Phases 1 and 2 are additive with `defaultRole` still active, so **nobody's access changes**
 and mistakes are free. Only Phase 3 carries risk.
 
-**Phase 1 — make group membership work** (PRs 1–5). Land the five gestalt branches above,
-wire the state-apply flag to exactly one owning revision in Toolshed, deploy under Google.
-*Check:* current-access regression for real employees. Nothing should change for anyone.
+**Phase 1 — make group membership work** (PRs 1–5). **Merged and deployed**; see "Work
+already done". *Check, still outstanding:* current-access regression for real employees.
+Nothing should change for anyone.
 
 **Phase 2 — build the roster, additively** (PR 6). Enumerate every resource type declaring a
-`defaultRole`. Build `valon-employees` from Rippling. Add memberships and one grant per
-resource type to the group.
-*Gate:* every active employee resolves to exactly one Gestalt UUID and is in the group;
-every user who authenticated in the last 30 days is either in the group or an identified
-non-employee, **with the count reconciled explicitly** — this is the check that would have
-caught the original 67-vs-358 failure; every cleared resource type has a matching grant.
+`defaultRole`. Build `valon-employees` from the Gestalt `users` table — **every `@valon.com`
+row**, by canonical UUID. Last time only 67 UUIDs went in against 358 real users; there are
+many hundreds, so export them from the database rather than transcribing a list. The DSN is
+the Cloud SQL instance valon.tools mounts, `gitlab-peach-street:us-east4:terra-east4`, with
+credentials in that project's Secret Manager. Everything the domain filter excludes —
+other domains, blank emails, subjects with no email — goes on an exclusion list that gets
+read row by row and dispositioned. Add memberships and one grant per resource type.
+*Gate:* roster count plus exclusion count equals the `users` row count, **all three numbers
+recorded** — this is the check that would have caught the original 67-vs-358 failure; every
+exclusion carries a disposition; every user who authenticated in the last 30 days is in the
+group or dispositioned; every cleared resource type has a matching grant.
 
 **Phase 3 — the flip** (PRs 7–8). Clear `defaultRole` on the two narrow custom-policy types
 first as a live rehearsal including the rollback, then on `app` and the anchor trio.
@@ -158,6 +186,10 @@ subjects match, callbacks allowlisted, HRD enabled, public signup disabled,
 temporary probe domain, then the first partner domain.
 *External acceptance test:* an authenticated external sees an empty `/apps`, `tools/list`
 returns nothing, and invocation is denied.
+*Hard ordering:* the first external login puts an external into the `users` table the roster
+was built from. The `@valon.com` filter is what stops a later rebuild granting them employee
+access, so from here it is load-bearing: complete Phases 2 and 3 first, and treat any
+rebuild afterwards as a change needing its own pass over the exclusion list.
 
 ## How to work
 

--- a/plans/external_users/implementation_v2.md
+++ b/plans/external_users/implementation_v2.md
@@ -47,7 +47,7 @@ Root cause of 2, found while implementing this plan: `resolvePrincipalUserID` tr
 ## Non-negotiables
 
 - Keep Google login until employee authorization passes and soaks.
-- Build `valon-employees` from an approved People/Identity authority (Rippling), joined to canonical Gestalt users by normalized email. **Never** infer employment from authorization rows or email domain.
+- Build `valon-employees` from the Gestalt `users` table — every row whose email is `@valon.com`, by canonical UUID. **Never** from authorization rows: that is what produced the 67-of-358 roster. Every row the filter excludes must be named and dispositioned, never silently dropped. See [Roster source](#roster-source).
 - **Never** use `[nobody]` as the shared app wildcard. Keep `actions: "*": relations: [viewer, user, editor, admin]`.
 - **Never** generate per-user/per-app grants. One grant per app for the group.
 - A no-traffic candidate must not mutate active authorization state.
@@ -62,18 +62,18 @@ Cut from the earlier draft of this plan because the flip is reversible by constr
 | --- | --- |
 | Explicit authorization `plan`/`apply`/`rollback`, diff/count budgets, atomic activation | Rollback is one config field. A snapshot subsystem is insurance against an irreversible change this is not. |
 | Isolated-hostname candidate, shadow evaluation, per-stack rollout manifests | Same. Verification happens with `defaultRole` still active, where mistakes are free. |
-Catalog and MCP listing authorization is **not** cut. `FilterCatalogForPrincipal` is currently `return cat` — it ignores the principal — and MCP `tools/list` filters only on token scope. An authenticated external with zero grants would therefore see the entire internal app catalog and every tool, even though it could invoke none of them. "No apps visible" makes that a hard prerequisite for Phase 4, not a follow-up. It is still not required for the employee flip, so it lands between Phase 3 and externals.
+Catalog and MCP listing authorization is **not** cut. `FilterCatalogForPrincipal` used to be `return cat` — it ignored the principal — and MCP `tools/list` filtered only on token scope. An authenticated external with zero grants would therefore have seen the entire internal app catalog and every tool, even though it could invoke none of them. "No apps visible" makes that a hard prerequisite for Phase 4, not a follow-up. It shipped early, with Phase 1 (PR 9, [#3072](https://github.com/valon-technologies/gestalt/pull/3072)), because the conformance suite does not compile without it; it is inert while `defaultRole` is active and still needs verifying against an ungranted identity before Phase 4.
 
 ## Phase 1 — Make group membership work
 
-Correctness only. `defaultRole` stays on, so **no one's access changes**.
+**Merged and deployed 2026-08-08.** Correctness only. `defaultRole` stays on, so **no one's access changes**.
 
 - Route every authorization boundary through the canonical `user:<uuid>` subject; fail closed on unresolved or provider-opaque subjects.
 - Replace the direct-only relationship scans in mounted UI and app admin with the shared evaluator, so group and subject-set grants are honored.
 - Stop server startup from writing active authorization state unless explicitly told to, and wire exactly one revision to own that write.
 - Land the conformance suite covering direct, one-level, nested, cyclic, malformed and paginated grants across mounted UI, catalog, app admin, invocation and MCP.
 
-**Check:** current-access regression for Dave, Kevon, and an app admin. Nothing should change for anyone.
+**Check — outstanding:** current-access regression for Dave, Kevon, and an app admin. Nothing should change for anyone.
 
 **Note:** `CheckAccess` is action-shaped and there is no effective-roles RPC, so a policy-shaped resource type that declares relations but no actions makes the evaluator deny a question it cannot represent. A bounded transition shim keeps the legacy direct-grant path working in exactly that case and logs a warning. **If that warning never fires in production, the shim is safe to delete** — and its absence is the evidence Phase 2 needs.
 
@@ -82,17 +82,20 @@ Correctness only. `defaultRole` stays on, so **no one's access changes**.
 Still additive. `defaultRole` stays on, so **still no access change**.
 
 - **Enumerate every resource type that declares a `defaultRole`**, resolving YAML anchors and aliases rather than grepping — the six in the table above are the current answer, but re-derive it from the deployed config rather than trusting this doc. This list is exactly the set of grants the group needs, and exactly the set Phase 3 clears.
-- Export active employees from Rippling. Join normalized Valon emails to canonical Gestalt user UUIDs.
-- Create `valon-employees` and add memberships from that join.
+- Read every row of the Gestalt `users` table and take its canonical UUID. The database is the Cloud SQL instance the valon.tools service mounts, `gitlab-peach-street:us-east4:terra-east4`; credentials are in that project's Secret Manager. Do not hand-transcribe the UUIDs — export them.
+- Partition that export on email domain. `@valon.com` (case-insensitive, after normalization) is the roster. Everything else goes on an exclusion list. Every employee is on the Valon domain, so a non-Valon *domain* on that list is a non-employee and needs no adjudication.
+- **Read the exclusion list for rows with no usable email** — blank, null, or a provider-opaque subject like `auth0|abc` that never had an email backfilled. Those are not covered by "every employee is on the Valon domain", because they carry no domain to judge. Resolve each to a person before the flip and add them to the roster by name if they are one. This is the same subject shape as the original root cause, so expect it to exist rather than assuming it does not.
+- Create `valon-employees` and add a membership per UUID.
 - Add **one grant per resource type for the group** — matching the role each `defaultRole` currently confers, so employees keep exactly what they have today. Not per user.
-- Store the employee↔user join outside source control; commit only its digest and aggregate counts.
+- Store the exported roster outside source control; commit only its digest and aggregate counts.
 
-**Gate — this is the check that would have caught the original failure:**
+**Gate:**
 
-1. Every active Rippling employee resolves to exactly one Gestalt UUID and is in the group. Zero unmapped, zero ambiguous, zero duplicates.
-2. Every Gestalt user who authenticated in the last 30 days is either in the group or an identified non-employee. **Reconcile the count explicitly** — the original roster was 67 against 358 users and nothing flagged it.
-3. Every resource type carrying a `defaultRole` has a corresponding group grant. A resource type cleared in Phase 3 without one silently revokes whatever that `defaultRole` was providing.
-4. Recompute the join immediately before Phase 3 and stop on any employee-relevant change.
+1. Membership count plus exclusion-list count equals the `users` table row count. Zero unmapped, zero ambiguous, zero duplicates. **Record all three numbers** — the original roster was 67 against 358 users and nothing flagged it. Three numbers that add up is the check; a single roster count proves nothing.
+2. **Zero rows on the exclusion list lack a usable email.** Rows excluded for having a non-Valon domain need no further work. Rows excluded because they have no domain to judge are the gap the filter cannot reason about, and each one is resolved to a person or confirmed not to be one.
+3. Every Gestalt user who authenticated in the last 30 days is in the group. A recent authenticator on the exclusion list is the loudest possible signal that the predicate dropped a working user; treat it as a stop, not a note.
+4. Every resource type carrying a `defaultRole` has a corresponding group grant. A resource type cleared in Phase 3 without one silently revokes whatever that `defaultRole` was providing.
+5. Re-export immediately before Phase 3 and stop on any change in either count.
 
 ## Phase 3 — Flip
 
@@ -119,6 +122,8 @@ Repeat the checks at 30 minutes and the next business morning. Soak one business
 
 **Prerequisite.** Land catalog and MCP listing authorization first. Without it an authenticated external sees every internal app and tool. This must be deployed and verified against an ungranted identity *before* any external domain is enabled.
 
+**Prerequisite.** Phases 2 and 3 must be complete. The first external login puts an external into the `users` table the roster is built from. The `@valon.com` filter is what keeps a later rebuild from granting them employee access, so it is load-bearing from this point on: any rebuild after this must re-read its exclusion list rather than trusting the predicate alone. See [Roster source](#roster-source).
+
 **Auth0 employee-only cutover.** Verify issuer matches discovery, RS256 + JWKS, correct audience, ID-token and userinfo subjects match, callbacks/logout allowlisted, Google Workspace connection and HRD enabled, database login and public signup disabled, `allowedDomains: [valon.com]`. Run a real authorization-code flow against the exact candidate before deploying. Shift traffic atomically; never split across issuers. Soak one business day.
 
 **Probe.** One temporary domain, one pre-created verified user, no grants. Confirm:
@@ -138,25 +143,25 @@ Externals hold no grants, so grant/revoke workflows and per-app external access 
 
 ## PRs
 
-| # | Repo | Phase | Content |
-| --- | --- | --- | --- |
-| 1 | gestalt | 1 | Canonical identity at every authorization boundary |
-| 2 | gestalt | 1 | Mounted UI + app admin decide through the evaluator |
-| 3 | gestalt | 1 | Startup authorization-state write gated behind explicit apply |
-| 4 | gestalt | 1 | Conformance suite |
-| 5 | toolshed | 1 | Wire the state-apply flag to the one owning revision; deploy Phase 1 |
-| 6 | toolshed | 2 | `valon-employees` roster, memberships, per-resource-type group grants, reconciliation gate |
-| 7 | toolshed | 3 | Clear `defaultRole` on the custom-policy types (`pmiPayoffCancellations`, `itAccountOnboarding`) |
-| 8 | toolshed | 3 | Clear `defaultRole` on `app` and the anchor trio (`agent-trace-viewer`/`workflow`/`agent`) |
-| 9 | gestalt | 4 | Catalog + MCP listing authorization (**prerequisite for externals**) |
-| 10 | toolshed | 4 | Auth0 secrets — GSM + `terraform/main.tf` |
-| 11 | toolshed | 4 | Auth0 employee-only identity cutover |
-| 12 | toolshed | 4 | Enable temporary probe domain |
-| 13 | toolshed | 4 | Remove probe domain; enable first partner domain |
+| # | Repo | Phase | Content | Status |
+| --- | --- | --- | --- | --- |
+| 1 | gestalt | 1 | Canonical identity at every authorization boundary | merged [#3075](https://github.com/valon-technologies/gestalt/pull/3075) |
+| 2 | gestalt | 1 | Mounted UI + app admin decide through the evaluator | merged [#3071](https://github.com/valon-technologies/gestalt/pull/3071) |
+| 3 | gestalt | 1 | Startup authorization-state write gated behind explicit apply | merged [#3069](https://github.com/valon-technologies/gestalt/pull/3069) |
+| 4 | gestalt | 1 | Conformance suite | merged [#3073](https://github.com/valon-technologies/gestalt/pull/3073) |
+| 5 | toolshed | 1 | Wire the state-apply flag to the one owning revision; deploy Phase 1 | merged + deployed [#4144](https://github.com/valon-technologies/toolshed/pull/4144) |
+| 6 | toolshed | 2 | `valon-employees` roster, memberships, per-resource-type group grants, reconciliation gate | not started |
+| 7 | toolshed | 3 | Clear `defaultRole` on the custom-policy types (`pmiPayoffCancellations`, `itAccountOnboarding`) | not started |
+| 8 | toolshed | 3 | Clear `defaultRole` on `app` and the anchor trio (`agent-trace-viewer`/`workflow`/`agent`) | not started |
+| 9 | gestalt | 4 | Catalog + MCP listing authorization (**prerequisite for externals**) | merged early with Phase 1, [#3072](https://github.com/valon-technologies/gestalt/pull/3072) |
+| 10 | toolshed | 4 | Auth0 secrets — GSM + `terraform/main.tf` | not started |
+| 11 | toolshed | 4 | Auth0 employee-only identity cutover | not started |
+| 12 | toolshed | 4 | Enable temporary probe domain | not started |
+| 13 | toolshed | 4 | Remove probe domain; enable first partner domain | not started |
 
 Phase 3 is split so the two narrow custom-policy types go first as a live rehearsal of the procedure *including the rollback*, before touching `app` and the anchor trio.
 
-PRs 1–4 were implemented and passed CI on branches `g2-canonical-identity`, `g3a-unify-authorization-evaluator`, `g1-authorization-state-safety`, and `g4-authorization-conformance-suite`. PR 9 was implemented on `g3b-batched-listing-decisions`. Those branches are pushed; the PRs were closed pending this replan and can be reopened.
+PRs 1–5 are merged and deployed as of 2026-08-08, and PR 9 landed with them — see "Work already done" in [implementation_prompt.md](./implementation_prompt.md) for merge commits and the two deviations. Phase 1's current-access regression is still outstanding. PRs 6–8 and 10–13 are not started.
 
 Implementation handoff: [implementation_prompt.md](./implementation_prompt.md).
 
@@ -167,3 +172,24 @@ Implementation handoff: [implementation_prompt.md](./implementation_prompt.md).
 The consequence is that this migration is mandatory rather than optional, and the employee-access risk it carries is accepted deliberately: `defaultRole` cannot be scoped to exclude a subject, so the only way to stop an authenticated external inheriting viewer on everything is to remove it and grant employees explicitly. Phases 1–3 exist to make that removal safe.
 
 **Externals receive no grants.** Authentication only. This removes any need for external grant/revoke tooling in this rollout, and makes the external acceptance criterion simple and testable: an authenticated external sees an empty `/apps` and can invoke nothing.
+
+### Roster source
+
+**`valon-employees` is the `@valon.com` rows of the Gestalt `users` table, not a Rippling join.**
+
+The failure this migration exists to avoid is an *incomplete* roster: employees whose access came solely from `defaultRole` were absent from the group, so clearing `defaultRole` cut them off. The `users` table is the source least able to have that failure. Every subject that can authenticate today has a row in it, so the table is a superset of everyone the flip could hurt. A Rippling join reintroduces the failure mode directly: anyone Rippling omits, or whose email does not join cleanly, silently loses access at the flip. It is also simpler to check — counts that add up, rather than a three-way reconciliation across an HR export, an email normalization, and a UUID join.
+
+**Why the domain filter, given that.** Without it the roster is "every row", which is correct today and wrong the moment Phase 4 lands: externals enter the same table, and any later rebuild would hand them full employee access. The `@valon.com` predicate makes the rule survive its own success — it stays correct after externals exist, so the roster is not a thing that quietly expires.
+
+**The filter is also the one part of this that can subtract.** Every other rule here can only over-grant, which is safe during a migration whose whole risk is under-granting. A predicate that drops a real employee is the original failure wearing different clothes.
+
+Two things bound that risk, and they are not the same thing. Every Valon employee is on the Valon domain — established, and it means a non-Valon *domain* on the exclusion list is a non-employee needing no adjudication. What it does not cover is a row with no domain to judge at all: a blank email, or a provider-opaque subject like `auth0|abc` that never had one backfilled. That shape is exactly the original root cause, so it is the one case the filter genuinely cannot reason about.
+
+So the filter partitions rather than discards, and the reading is narrow: `@valon.com` rows are the roster, the rest are excluded, and the only rows anyone has to look at are the ones carrying no usable email. The gate is three numbers that add up — roster plus exclusions equals total — plus zero unresolved email-less rows. This keeps the property that made the users table the right source (nothing is omitted without someone noticing) while gaining the property that makes it durable (it does not silently absorb externals later).
+
+**What it still does not do:**
+
+- **It is not an employment authority.** Departed employees keep rows, so they keep membership. Today that is a no-op — they cannot authenticate, because Google login is domain-restricted and their account is gone. It becomes real only if a departed identity can authenticate again, which is a deprovisioning concern rather than a migration concern. Track it separately.
+- **It does not make Phase 4 ordering optional.** The filter means a rebuild after externals exist is no longer catastrophic, but "no longer catastrophic" is not "verified". Build the roster and complete the flip before enabling any external domain, and treat any post-Phase-4 rebuild as a change that needs its own review of the exclusion list.
+
+A durable employment authority — Rippling or otherwise — remains the right follow-up before this group is next rebuilt from scratch. It is the wrong tool for *this* step, where the cost of omission is an employee locked out and the cost of inclusion is an employee keeping access they already have.


### PR DESCRIPTION
## Description

Two docs-only changes to `plans/external_users/`. No code, no config.

1. **Phase 2 roster source** moves from a Rippling join to the Gestalt `users` table filtered to `@valon.com`.
2. **Staleness pass** now that Phase 1 is merged and deployed.

## Why the users table

The failure this migration exists to avoid is an *incomplete* roster. The `users` table is the source least able to have that failure: every subject that can authenticate has a row, so it is a superset of everyone the flip could hurt. A Rippling join reintroduces the failure mode directly — anyone Rippling omits, or whose email does not join cleanly, silently loses access at the flip. It is also easier to check: counts that add up, rather than a three-way reconciliation across an HR export, an email normalization, and a UUID join.

## Why the domain filter, and what it needed

Unfiltered, the roster is "every row" — correct today, wrong the moment Phase 4 lands, because externals enter the same table and any rebuild would grant them employee access. `@valon.com` makes the rule survive its own success.

The filter is the **only rule in this plan that can subtract**, so it needed a bound. Every Valon employee is on the Valon domain, which means an excluded row with a non-Valon domain is a non-employee and needs no adjudication. What that does not cover is a row with **no domain to judge at all** — a blank email, or a provider-opaque subject like `auth0|abc` that never had one backfilled. That is precisely the shape behind the original root cause (`resolvePrincipalUserID` treating `auth0|abc` as canonical), so it is the one case the predicate genuinely cannot reason about.

Phase 2's gate is therefore three numbers that add up (roster + exclusions = total) plus **zero unresolved email-less rows**, and a recent authenticator landing on the exclusion list is a stop rather than a note.

## Staleness pass

Phase 1 shipped on 2026-08-08, so the docs no longer claim the branches are closed and awaiting reopen:

- "Work already done" now lists merge commits: `3b5157258`, `48a6624c4`, `1c53b04aa`, `77cd8ef6f`, `a3ff3a33d`, plus toolshed [#4144](https://github.com/valon-technologies/toolshed/pull/4144) and the `GESTALTD_PINNED_SHA` bump.
- Records the two deviations: **PR 9 landed early with Phase 1** (the conformance suite does not compile without it; inert while `defaultRole` is active, still needs verifying against an ungranted identity before Phase 4), and **#3070 was re-filed as #3075** after GitHub auto-closed it on base-branch deletion — with the retarget-before-merge lesson for the remaining stacks.
- PR table carries a status column; Phase 1's current-access regression is marked outstanding in both docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)