### PR TITLE
Normalize authorization gateway resource type

### DIFF
--- a/gestaltd/services/providergateway/gateway_test.go
+++ b/gestaltd/services/providergateway/gateway_test.go
@@ -186,6 +186,29 @@ func TestPreparePublicRequest(t *testing.T) {
 			wantCode:   codes.InvalidArgument,
 		},
 		{
+			name:       "authorization check uses stable provider resource type",
+			fullMethod: proto.Authorization_CheckAccess_FullMethodName,
+			withOrigin: true,
+			introspect: activeAlice,
+			req: &proto.CheckAccessRequest{
+				Subject:  &proto.Subject{Type: "subject", Id: "service_account:test"},
+				Action:   &proto.Action{Name: "read"},
+				Resource: &proto.Resource{Type: "app", Id: "roadmap"},
+			},
+			checkAuth: func(t *testing.T, auth *stubAuthorizationProvider) {
+				t.Helper()
+				if got := auth.request.GetResource().GetType(); got != string(ProviderKindAuthorization) {
+					t.Fatalf("authorization resource type = %q, want %q", got, ProviderKindAuthorization)
+				}
+				if got := auth.request.GetResource().GetId(); got != "authorization" {
+					t.Fatalf("authorization resource id = %q, want authorization", got)
+				}
+				if got := auth.request.GetAction().GetName(); got != "authorization" {
+					t.Fatalf("authorization action = %q, want authorization", got)
+				}
+			},
+		},
+		{
 			name:       "requires authorization provider",
 			fullMethod: proto.Workflow_DeliverEvent_FullMethodName,
 			withOrigin: true,

--- a/gestaltd/services/providergateway/public_request.go
+++ b/gestaltd/services/providergateway/public_request.go
@@ -190,6 +190,8 @@ func publicIdentityLoginMethod(fullMethod string) bool {
 func providerKindFromFullMethod(fullMethod string) ProviderKind {
 	service, _ := splitFullMethod(fullMethod)
 	switch service {
+	case proto.Authorization_ServiceDesc.ServiceName:
+		return ProviderKindAuthorization
 	case proto.App_ServiceDesc.ServiceName:
 		return ProviderKindApp
 	case proto.Workflow_ServiceDesc.ServiceName:


### PR DESCRIPTION
## Summary
- map public Authorization RPCs to the stable `authorization` provider kind
- prevent authorization policies from depending on protobuf service names
- cover the gateway authorization request shape with a regression test

## Test plan
- [x] `go test ./gestaltd/services/providergateway`
- [x] `git diff --check`


Made with [Cursor](https://cursor.com)