### PR TITLE
Scope legacy logout URLs to Auth0 issuers

### DIFF
--- a/gestaltd/services/identity/federated_logout.go
+++ b/gestaltd/services/identity/federated_logout.go
@@ -27,7 +27,7 @@ func FederatedLogoutURL(provider core.IdentityProvider, returnTo string) (string
 	return federated.FederatedLogoutURL(returnTo)
 }
 
-// BuildOIDCFederatedLogoutURL builds an OIDC/Auth0-style /v2/logout URL.
+// BuildOIDCFederatedLogoutURL builds an Auth0 /v2/logout URL.
 func BuildOIDCFederatedLogoutURL(issuerURL, clientID, returnTo string) (string, error) {
 	returnTo = strings.TrimSpace(returnTo)
 	if returnTo == "" {
@@ -37,6 +37,13 @@ func BuildOIDCFederatedLogoutURL(issuerURL, clientID, returnTo string) (string, 
 	clientID = strings.TrimSpace(clientID)
 	if issuer == "" || clientID == "" {
 		return "", fmt.Errorf("oidc auth: federated logout is not configured")
+	}
+	issuerParsed, err := url.Parse(issuer)
+	if err != nil || issuerParsed.Scheme == "" || issuerParsed.Host == "" {
+		return "", fmt.Errorf("oidc auth: invalid issuer url")
+	}
+	if !strings.HasSuffix(strings.ToLower(issuerParsed.Hostname()), ".auth0.com") {
+		return "", fmt.Errorf("oidc auth: federated logout is not supported for issuer")
 	}
 	parsed, err := url.Parse(issuer + "/v2/logout")
 	if err != nil {

--- a/gestaltd/services/identity/federated_logout_test.go
+++ b/gestaltd/services/identity/federated_logout_test.go
@@ -19,6 +19,20 @@ func TestBuildOIDCFederatedLogoutURL(t *testing.T) {
 	}
 }
 
+func TestBuildOIDCFederatedLogoutURLRejectsNonAuth0Issuer(t *testing.T) {
+	t.Parallel()
+
+	for _, issuer := range []string{
+		"https://login.example.com/",
+		"https://tenant.auth0.com.example.com/",
+		"not-a-url",
+	} {
+		if _, err := BuildOIDCFederatedLogoutURL(issuer, "client-id", "https://valon.tools/"); err == nil {
+			t.Errorf("BuildOIDCFederatedLogoutURL(%q) error = nil, want unsupported issuer error", issuer)
+		}
+	}
+}
+
 func TestRemoteIdentityProviderFederatedLogoutURL(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- prevent generic OIDC deployments from receiving Auth0-specific `/v2/logout` redirects
- validate issuer URLs and require an actual `*.auth0.com` hostname
- cover generic, deceptive-suffix, and malformed issuer rejection

## Test plan
- [x] `go test ./gestaltd/services/identity ./gestaltd/internal/server`
- [x] `git diff --check`

Follow-up to #3078 addressing the unresolved Bugbot finding.

Made with [Cursor](https://cursor.com)