### PR TITLE
Hide unauthorized apps with settings surfaces

### DIFF
--- a/gestaltd/internal/server/authorization_listing_test.go
+++ b/gestaltd/internal/server/authorization_listing_test.go
@@ -39,8 +39,8 @@ func listingTestServer(t *testing.T, authz *serverTestAuthorizationProvider, sub
 		cfg.Authorization = authz
 		cfg.Services = testutil.NewStubServices(t)
 		cfg.Providers = testutil.NewProviderRegistry(t,
-			&coretesting.StubIntegration{N: "sampleApp", DN: "Sample"},
-			&coretesting.StubIntegration{N: "otherApp", DN: "Other"},
+			&coretesting.StubIntegration{N: "sampleApp", DN: "Sample", ConnMode: core.ConnectionModeNone},
+			&coretesting.StubIntegration{N: "otherApp", DN: "Other", ConnMode: core.ConnectionModeNone},
 		)
 		cfg.AppDefs = map[string]*config.ProviderEntry{
 			"sampleApp": {

--- a/gestaltd/internal/server/authorization_listing_test.go
+++ b/gestaltd/internal/server/authorization_listing_test.go
@@ -193,6 +193,41 @@ func TestAppsListingFallsBackWhenBatchFails(t *testing.T) {
 	}
 }
 
+func TestAppsListingFallsThroughDeniedSettingsToAuthorizedOperations(t *testing.T) {
+	t.Parallel()
+
+	subjectID := principal.UserSubjectID(testCanonicalViewerUserID)
+	checker := &allowOneOperationAccess{allowed: "items.list"}
+	stub := &coretesting.StubIntegration{
+		N:        "sampleApp",
+		DN:       "Sample",
+		ConnMode: core.ConnectionModeNone,
+		CatalogVal: &catalog.Catalog{
+			Name: "sampleApp",
+			Operations: []catalog.CatalogOperation{
+				{ID: "items.list", Method: http.MethodGet, Path: "/items"},
+			},
+		},
+	}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("listing-token", subjectID, "")
+		cfg.Authorization = &serverTestAuthorizationProvider{}
+		cfg.Services = testutil.NewStubServices(t)
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.AppDefs = map[string]*config.ProviderEntry{"sampleApp": {}}
+		cfg.OperationAccessChecker = checker
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	integrations := listIntegrationsForTest(t, ts)
+	if _, ok := mountedPathFor(integrations, "sampleApp"); !ok {
+		t.Fatalf("operation-authorized app missing from listing: %#v", integrations)
+	}
+	if checker.calls != 1 || checker.queries != 1 {
+		t.Fatalf("operation checks = {%d calls, %d queries}, want {1, 1}", checker.calls, checker.queries)
+	}
+}
+
 // erroringOperationAccess is an evaluator that cannot answer, used to prove a
 // listing surfaces the failure rather than returning an empty list.
 type erroringOperationAccess struct{}

--- a/gestaltd/internal/server/authorization_listing_test.go
+++ b/gestaltd/internal/server/authorization_listing_test.go
@@ -122,7 +122,7 @@ func TestAppsListingBatchesGroupDerivedDecisions(t *testing.T) {
 }
 
 // TestAppsListingHidesUngrantedApp proves the filtering is real: a subject with
-// no grant does not get the mounted path.
+// no grant does not see the app through an otherwise usable settings surface.
 func TestAppsListingHidesUngrantedApp(t *testing.T) {
 	t.Parallel()
 
@@ -135,8 +135,8 @@ func TestAppsListingHidesUngrantedApp(t *testing.T) {
 	if mountedPath, _ := mountedPathFor(integrations, "sampleApp"); mountedPath == "" {
 		t.Fatalf("granted app lost its mounted path: %#v", integrations)
 	}
-	if mountedPath, _ := mountedPathFor(integrations, "otherApp"); mountedPath != "" {
-		t.Fatalf("ungranted app exposed mounted path %q", mountedPath)
+	if _, ok := mountedPathFor(integrations, "otherApp"); ok {
+		t.Fatalf("ungranted app exposed in listing: %#v", integrations)
 	}
 }
 

--- a/gestaltd/internal/server/integration_visibility.go
+++ b/gestaltd/internal/server/integration_visibility.go
@@ -17,7 +17,13 @@ func (s *Server) integrationHasUsableSurfaceContext(ctx context.Context, p *prin
 		return true, nil
 	}
 	if s.integrationHasSettingsSurface(p, info) {
-		return s.integrationSettingsAccessibleContext(ctx, p, provider)
+		settingsAccessible, err := s.integrationSettingsAccessibleContext(ctx, p, provider)
+		if err != nil {
+			return false, err
+		}
+		if settingsAccessible {
+			return true, nil
+		}
 	}
 	return s.integrationHasVisibleHTTPOperationsContext(ctx, p, provider, prov)
 }

--- a/gestaltd/internal/server/integration_visibility.go
+++ b/gestaltd/internal/server/integration_visibility.go
@@ -46,7 +46,10 @@ func (s *Server) integrationSettingsAccessibleContext(ctx context.Context, p *pr
 		return false, nil
 	}
 	subjectID, err := principal.ResolveAuthorizationSubjectID(ctx, s.credentialUserResolver(), p)
-	if err != nil || strings.TrimSpace(subjectID) == "" {
+	if err != nil {
+		return false, err
+	}
+	if strings.TrimSpace(subjectID) == "" {
 		return false, nil
 	}
 	decision, err := s.checkResourceAccess(ctx, invocation.ResourceAccessRequest{

--- a/gestaltd/internal/server/integration_visibility.go
+++ b/gestaltd/internal/server/integration_visibility.go
@@ -17,7 +17,7 @@ func (s *Server) integrationHasUsableSurfaceContext(ctx context.Context, p *prin
 		return true, nil
 	}
 	if s.integrationHasSettingsSurface(p, info) {
-		return true, nil
+		return s.integrationSettingsAccessibleContext(ctx, p, provider)
 	}
 	return s.integrationHasVisibleHTTPOperationsContext(ctx, p, provider, prov)
 }
@@ -30,6 +30,28 @@ func (s *Server) integrationHasSettingsSurface(p *principal.Principal, info inte
 		info.CredentialState == credentialStateConfigured ||
 		info.CredentialState == credentialStateNotRequired ||
 		len(info.Connections) > 0
+}
+
+func (s *Server) integrationSettingsAccessibleContext(ctx context.Context, p *principal.Principal, provider string) (bool, error) {
+	if s == nil || s.authorization == nil {
+		return true, nil
+	}
+	if p == nil || principal.IsNonUserPrincipal(p) {
+		return false, nil
+	}
+	subjectID, err := principal.ResolveAuthorizationSubjectID(ctx, s.credentialUserResolver(), p)
+	if err != nil || strings.TrimSpace(subjectID) == "" {
+		return false, nil
+	}
+	decision, err := s.checkResourceAccess(ctx, invocation.ResourceAccessRequest{
+		SubjectID: subjectID,
+		Action:    provider,
+		Resource:  s.authorizationResource(provider),
+	})
+	if err != nil {
+		return false, err
+	}
+	return decision.Allowed, nil
 }
 
 // integrationHasVisibleHTTPOperationsContext reports whether the principal can
@@ -67,8 +89,13 @@ func (s *Server) prefetchIntegrationListingDecisions(ctx context.Context, p *pri
 		return
 	}
 
-	reqs := make([]invocation.ResourceAccessRequest, 0, 2*len(appNames))
+	reqs := make([]invocation.ResourceAccessRequest, 0, 3*len(appNames))
 	for _, name := range appNames {
+		reqs = append(reqs, invocation.ResourceAccessRequest{
+			SubjectID: subjectID,
+			Action:    name,
+			Resource:  s.authorizationResource(name),
+		})
 		if req, ok := s.mountedUIListingAccessRequest(name, subjectID); ok {
 			reqs = append(reqs, req)
 		}


### PR DESCRIPTION
## Summary
- require app authorization before a credential/settings surface can keep an app visible in the catalog
- preserve public mounted apps and authorized operation surfaces
- add regression coverage ensuring an ungranted app is omitted entirely

## Test plan
- [x] `go test ./gestaltd/internal/server -run 'TestAppsListing' -count=1`
- [x] `go test ./gestaltd/internal/server -count=1`

Made with [Cursor](https://cursor.com)