### PR TITLE
Add explicit catalog-hidden static apps

### DIFF
--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -563,9 +563,10 @@ type ProviderEntry struct {
 // AppStaticConfig configures a packaged app's static bundle mount.
 // TODO(hughhan1): static.theme is a deployer workaround and should not be supported long-term.
 type AppStaticConfig struct {
-	Mount  string         `yaml:"mount,omitempty"`
-	Theme  *UIThemeConfig `yaml:"theme,omitempty"`
-	Public bool           `yaml:"public,omitempty"`
+	Mount         string         `yaml:"mount,omitempty"`
+	Theme         *UIThemeConfig `yaml:"theme,omitempty"`
+	Public        bool           `yaml:"public,omitempty"`
+	CatalogHidden bool           `yaml:"catalogHidden,omitempty"`
 }
 
 type providerEntryFields ProviderEntry

--- a/gestaltd/internal/server/authorization_listing_test.go
+++ b/gestaltd/internal/server/authorization_listing_test.go
@@ -41,6 +41,7 @@ func listingTestServer(t *testing.T, authz *serverTestAuthorizationProvider, sub
 		cfg.Providers = testutil.NewProviderRegistry(t,
 			&coretesting.StubIntegration{N: "sampleApp", DN: "Sample", ConnMode: core.ConnectionModeNone},
 			&coretesting.StubIntegration{N: "otherApp", DN: "Other", ConnMode: core.ConnectionModeNone},
+			&coretesting.StubIntegration{N: "publicHidden", DN: "Hidden", ConnMode: core.ConnectionModeNone},
 		)
 		cfg.AppDefs = map[string]*config.ProviderEntry{
 			"sampleApp": {
@@ -49,6 +50,10 @@ func listingTestServer(t *testing.T, authz *serverTestAuthorizationProvider, sub
 			},
 			"otherApp": {
 				Static:             &config.AppStaticConfig{Mount: "/other"},
+				ResolvedStaticRoot: rootDir,
+			},
+			"publicHidden": {
+				Static:             &config.AppStaticConfig{Mount: "/hidden", Public: true, CatalogHidden: true},
 				ResolvedStaticRoot: rootDir,
 			},
 		}
@@ -137,6 +142,20 @@ func TestAppsListingHidesUngrantedApp(t *testing.T) {
 	}
 	if _, ok := mountedPathFor(integrations, "otherApp"); ok {
 		t.Fatalf("ungranted app exposed in listing: %#v", integrations)
+	}
+}
+
+func TestAppsListingOmitsCatalogHiddenPublicApp(t *testing.T) {
+	t.Parallel()
+
+	subjectID := principal.UserSubjectID(testCanonicalViewerUserID)
+	authz := &serverTestAuthorizationProvider{
+		relationships: subjectSetGrant(subjectID, "viewer", "app", "publicHidden"),
+	}
+
+	integrations := listIntegrationsForTest(t, listingTestServer(t, authz, subjectID))
+	if _, ok := mountedPathFor(integrations, "publicHidden"); ok {
+		t.Fatalf("catalog-hidden public app exposed in listing: %#v", integrations)
 	}
 }
 

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -244,6 +244,9 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 	seen := make(map[string]struct{}, len(names))
 	out := make([]integrationInfo, 0, len(names))
 	for _, name := range names {
+		if s.integrationHiddenFromCatalog(name) {
+			continue
+		}
 		prov, err := s.providers.GetWithContext(r.Context(), name)
 		if err != nil {
 			continue
@@ -286,6 +289,9 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 		out = append(out, info)
 	}
 	for _, app := range registryApps {
+		if s.integrationHiddenFromCatalog(app.name) {
+			continue
+		}
 		if _, ok := seen[app.name]; ok {
 			continue
 		}

--- a/gestaltd/internal/server/integration_visibility.go
+++ b/gestaltd/internal/server/integration_visibility.go
@@ -9,6 +9,11 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 )
 
+func (s *Server) integrationHiddenFromCatalog(provider string) bool {
+	entry, ok := s.pluginDefs[strings.TrimSpace(provider)]
+	return ok && entry != nil && entry.Static != nil && entry.Static.CatalogHidden
+}
+
 func (s *Server) integrationHasUsableSurfaceContext(ctx context.Context, p *principal.Principal, provider string, prov core.Provider, info integrationInfo) (bool, error) {
 	if info.MountedPath != "" {
 		return true, nil


### PR DESCRIPTION
## Summary
- add `static.catalogHidden` to separate route accessibility from catalog visibility
- omit catalog-hidden apps from both running-provider and registry-placeholder listings
- cover a public, authorized static app that must still remain absent from the catalog

## Test plan
- [x] `go test ./gestaltd/internal/config ./gestaltd/internal/server -count=1`

Made with [Cursor](https://cursor.com)